### PR TITLE
Add consumes interface to METProducers

### DIFF
--- a/RecoMET/METProducers/interface/BeamHaloSummaryProducer.h
+++ b/RecoMET/METProducers/interface/BeamHaloSummaryProducer.h
@@ -24,6 +24,7 @@
 #include <cstdlib>
 
 // user include files
+#include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -68,6 +69,11 @@ namespace reco
     edm::InputTag IT_EcalHaloData;
     edm::InputTag IT_HcalHaloData;
     edm::InputTag IT_GlobalHaloData;
+
+    edm::EDGetTokenT<CSCHaloData> cschalodata_token_;
+    edm::EDGetTokenT<EcalHaloData> ecalhalodata_token_;
+    edm::EDGetTokenT<HcalHaloData> hcalhalodata_token_;
+    edm::EDGetTokenT<GlobalHaloData> globalhalodata_token_;
 
     float L_EcalPhiWedgeEnergy;
     int L_EcalPhiWedgeConstituents;

--- a/RecoMET/METProducers/interface/CSCHaloDataProducer.h
+++ b/RecoMET/METProducers/interface/CSCHaloDataProducer.h
@@ -24,6 +24,7 @@
 #include <cstdlib>
 
 // user include files
+#include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -163,7 +164,15 @@ class CSCHaloDataProducer : public edm::EDProducer {
     edm::InputTag IT_Muon;
     edm::InputTag IT_SA;
 
-
+    // TOKENS
+    edm::EDGetTokenT<reco::MuonCollection> cosmicmuon_token_;
+    edm::EDGetTokenT<reco::MuonTimeExtraMap> csctimemap_token_;
+    edm::EDGetTokenT<reco::MuonCollection> muon_token_;
+    edm::EDGetTokenT<CSCSegmentCollection> cscsegment_token_;
+    edm::EDGetTokenT<CSCRecHit2DCollection> cscrechit_token_;
+    edm::EDGetTokenT<CSCALCTDigiCollection> cscalct_token_;
+    edm::EDGetTokenT<L1MuGMTReadoutCollection> l1mugmtro_token_;
+    edm::EDGetTokenT<edm::TriggerResults> hltresult_token_;
   };
 }
 

--- a/RecoMET/METProducers/interface/EcalHaloDataProducer.h
+++ b/RecoMET/METProducers/interface/EcalHaloDataProducer.h
@@ -24,6 +24,7 @@
 #include <cstdlib>
 
 // user include files
+#include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -108,6 +109,12 @@ namespace reco
     //Higher Level Reco
     edm::InputTag IT_SuperCluster;
     edm::InputTag IT_Photon;
+
+    edm::EDGetTokenT<EBRecHitCollection> ebrechit_token_;
+    edm::EDGetTokenT<EERecHitCollection> eerechit_token_;
+    edm::EDGetTokenT<ESRecHitCollection> esrechit_token_;
+    edm::EDGetTokenT<reco::SuperClusterCollection> supercluster_token_;
+    edm::EDGetTokenT<reco::PhotonCollection> photon_token_;
     
     float  EBRecHitEnergyThreshold;
     float  EERecHitEnergyThreshold;

--- a/RecoMET/METProducers/interface/GlobalHaloDataProducer.h
+++ b/RecoMET/METProducers/interface/GlobalHaloDataProducer.h
@@ -24,6 +24,7 @@
 #include <cstdlib>
 
 // user include files
+#include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -196,6 +197,14 @@ namespace reco
     edm::InputTag IT_CSCHaloData;
     edm::InputTag IT_EcalHaloData;
     edm::InputTag IT_HcalHaloData;
+
+    edm::EDGetTokenT<edm::View<reco::Candidate> > calotower_token_;
+    edm::EDGetTokenT<reco::CaloMETCollection> calomet_token_;
+    edm::EDGetTokenT<CSCSegmentCollection> cscsegment_token_;
+    edm::EDGetTokenT<CSCRecHit2DCollection> cscrechit_token_;
+    edm::EDGetTokenT<CSCHaloData> cschalo_token_;
+    edm::EDGetTokenT<EcalHaloData> ecalhalo_token_;
+    edm::EDGetTokenT<HcalHaloData> hcalhalo_token_;
 
     float EcalMinMatchingRadius;
     float  EcalMaxMatchingRadius;

--- a/RecoMET/METProducers/interface/HcalHaloDataProducer.h
+++ b/RecoMET/METProducers/interface/HcalHaloDataProducer.h
@@ -24,6 +24,7 @@
 #include <cstdlib>
 
 // user include files
+#include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -96,6 +97,9 @@ namespace reco
     edm::InputTag IT_HBHERecHit;
     edm::InputTag IT_HORecHit;
     edm::InputTag IT_HFRecHit;
+
+    edm::EDGetTokenT<HBHERecHitCollection> hbherechit_token_;
+    edm::EDGetTokenT<HFRecHitCollection> hfrechit_token_;
 
     float HBRecHitEnergyThreshold;
     float HERecHitEnergyThreshold;

--- a/RecoMET/METProducers/interface/HcalNoiseInfoProducer.h
+++ b/RecoMET/METProducers/interface/HcalNoiseInfoProducer.h
@@ -18,6 +18,7 @@
 #include <memory>
 
 // user include files
+#include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -28,6 +29,12 @@
 #include "RecoMET/METAlgorithms/interface/HcalNoiseRBXArray.h"
 #include "DataFormats/METReco/interface/HcalNoiseSummary.h"
 
+#include "RecoMET/METProducers/interface/HcalNoiseInfoProducer.h"
+#include "DataFormats/HcalDigi/interface/HcalDigiCollections.h"
+#include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
+#include "DataFormats/CaloTowers/interface/CaloTowerCollection.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/TrackReco/interface/Track.h"
 
 namespace reco {
 
@@ -85,6 +92,12 @@ namespace reco {
     std::string recHitCollName_;       // name of the rechit collection
     std::string caloTowerCollName_;    // name of the caloTower collection
     std::string trackCollName_;        // name of the track collection
+
+    edm::EDGetTokenT<HBHEDigiCollection> hbhedigi_token_;
+    edm::EDGetTokenT<HcalCalibDigiCollection> hcalcalibdigi_token_;
+    edm::EDGetTokenT<HBHERecHitCollection> hbherechit_token_;
+    edm::EDGetTokenT<CaloTowerCollection> calotower_token_;
+    edm::EDGetTokenT<reco::TrackCollection> track_token_;
 
     double TotalCalibCharge;    // placeholder to calculate total charge in calibration channels
 

--- a/RecoMET/METProducers/src/BeamHaloSummaryProducer.cc
+++ b/RecoMET/METProducers/src/BeamHaloSummaryProducer.cc
@@ -1,4 +1,5 @@
 #include "RecoMET/METProducers/interface/BeamHaloSummaryProducer.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 /*
   [class]:  BeamHaloSummaryProducer
@@ -46,6 +47,11 @@ BeamHaloSummaryProducer::BeamHaloSummaryProducer(const edm::ParameterSet& iConfi
   T_HcalPhiWedgeToF = (float)iConfig.getParameter<double>("t_HcalPhiWedgeToF");
   T_HcalPhiWedgeConfidence = (float)iConfig.getParameter<double>("t_HcalPhiWedgeConfidence");
 
+  cschalodata_token_ = consumes<CSCHaloData>(IT_CSCHaloData);
+  ecalhalodata_token_ = consumes<EcalHaloData>(IT_EcalHaloData);
+  hcalhalodata_token_ = consumes<HcalHaloData>(IT_HcalHaloData);
+  globalhalodata_token_ = consumes<GlobalHaloData>(IT_GlobalHaloData);
+
   produces<BeamHaloSummary>();
 }
 
@@ -56,7 +62,8 @@ void BeamHaloSummaryProducer::produce(Event& iEvent, const EventSetup& iSetup)
 
   // CSC Specific Halo Data
   Handle<CSCHaloData> TheCSCHaloData;
-  iEvent.getByLabel(IT_CSCHaloData, TheCSCHaloData);
+  //  iEvent.getByLabel(IT_CSCHaloData, TheCSCHaloData);
+  iEvent.getByToken(cschalodata_token_, TheCSCHaloData);
 
   const CSCHaloData CSCData = (*TheCSCHaloData.product() );
 
@@ -90,8 +97,9 @@ void BeamHaloSummaryProducer::produce(Event& iEvent, const EventSetup& iSetup)
 
   //Ecal Specific Halo Data
   Handle<EcalHaloData> TheEcalHaloData;
-  iEvent.getByLabel(IT_EcalHaloData, TheEcalHaloData);
-  
+  //  iEvent.getByLabel(IT_EcalHaloData, TheEcalHaloData);
+  iEvent.getByToken(ecalhalodata_token_, TheEcalHaloData);
+
   const EcalHaloData EcalData = (*TheEcalHaloData.product() );
   
   bool EcalLooseId = false, EcalTightId = false;
@@ -162,7 +170,9 @@ void BeamHaloSummaryProducer::produce(Event& iEvent, const EventSetup& iSetup)
 
   // Hcal Specific Halo Data
   Handle<HcalHaloData> TheHcalHaloData;
-  iEvent.getByLabel(IT_HcalHaloData, TheHcalHaloData);
+  //  iEvent.getByLabel(IT_HcalHaloData, TheHcalHaloData);
+  iEvent.getByToken(hcalhalodata_token_, TheHcalHaloData);
+
   const HcalHaloData HcalData = (*TheHcalHaloData.product() );
   const std::vector<PhiWedge> HcalWedges = HcalData.GetPhiWedges();
   bool HcalLooseId = false, HcalTightId = false;
@@ -202,7 +212,9 @@ void BeamHaloSummaryProducer::produce(Event& iEvent, const EventSetup& iSetup)
 
   // Global Halo Data
   Handle<GlobalHaloData> TheGlobalHaloData;
-  iEvent.getByLabel(IT_GlobalHaloData, TheGlobalHaloData);
+  //  iEvent.getByLabel(IT_GlobalHaloData, TheGlobalHaloData);
+  iEvent.getByToken(globalhalodata_token_, TheGlobalHaloData);
+
   bool GlobalLooseId = false;
   bool GlobalTightId = false;
   const GlobalHaloData GlobalData = (*TheGlobalHaloData.product() );

--- a/RecoMET/METProducers/src/CSCHaloDataProducer.cc
+++ b/RecoMET/METProducers/src/CSCHaloDataProducer.cc
@@ -1,5 +1,6 @@
 #include "RecoMET/METProducers/interface/CSCHaloDataProducer.h"
 #include "FWCore/Common/interface/TriggerNames.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 /*
   [class]:  CSCHaloDataProducer
@@ -61,6 +62,15 @@ CSCHaloDataProducer::CSCHaloDataProducer(const edm::ParameterSet& iConfig)
   CSCAlgo.SetMatchingDEtaThreshold( (float)iConfig.getParameter<double>("MatchingDEtaThreshold") );
   CSCAlgo.SetMatchingDWireThreshold(iConfig.getParameter<int>("MatchingDWireThreshold") );
 
+  cosmicmuon_token_ = consumes<reco::MuonCollection>(IT_CosmicMuon);
+  csctimemap_token_ = consumes<reco::MuonTimeExtraMap>(edm::InputTag(IT_CosmicMuon.label(), "csc"));
+  muon_token_       = consumes<reco::MuonCollection>(IT_Muon);
+  cscsegment_token_ = consumes<CSCSegmentCollection>(IT_CSCSegment);
+  cscrechit_token_  = consumes<CSCRecHit2DCollection>(IT_CSCRecHit);
+  cscalct_token_    = consumes<CSCALCTDigiCollection>(IT_ALCT);
+  l1mugmtro_token_  = consumes<L1MuGMTReadoutCollection>(IT_L1MuGMTReadout);
+  hltresult_token_  = consumes<edm::TriggerResults>(IT_HLTResult);
+
   produces<CSCHaloData>();
 }
 
@@ -72,35 +82,43 @@ void CSCHaloDataProducer::produce(Event& iEvent, const EventSetup& iSetup)
 
   //Get Muons Collection from Cosmic Reconstruction 
   edm::Handle< reco::MuonCollection > TheCosmics;
-  iEvent.getByLabel(IT_CosmicMuon, TheCosmics);
-  
+  //  iEvent.getByLabel(IT_CosmicMuon, TheCosmics);
+  iEvent.getByToken(cosmicmuon_token_, TheCosmics);
+
   //Get Muon Time Information from Cosmic Reconstruction
   edm::Handle<reco::MuonTimeExtraMap> TheCSCTimeMap;
-  iEvent.getByLabel(IT_CosmicMuon.label(),"csc",TheCSCTimeMap);
+  //  iEvent.getByLabel(IT_CosmicMuon.label(),"csc",TheCSCTimeMap);
+  iEvent.getByToken(csctimemap_token_, TheCSCTimeMap);
 
  //Collision Muon Collection
   edm::Handle< reco::MuonCollection> TheMuons;
-  iEvent.getByLabel(IT_Muon, TheMuons);
+  //  iEvent.getByLabel(IT_Muon, TheMuons);
+  iEvent.getByToken(muon_token_, TheMuons);
 
   //Get CSC Segments
   edm::Handle<CSCSegmentCollection> TheCSCSegments;
-  iEvent.getByLabel(IT_CSCSegment, TheCSCSegments);
+  //  iEvent.getByLabel(IT_CSCSegment, TheCSCSegments);
+  iEvent.getByToken(cscsegment_token_, TheCSCSegments);
 
   //Get CSC RecHits
   Handle<CSCRecHit2DCollection> TheCSCRecHits;
-  iEvent.getByLabel(IT_CSCRecHit, TheCSCRecHits);
+  //  iEvent.getByLabel(IT_CSCRecHit, TheCSCRecHits);
+  iEvent.getByToken(cscrechit_token_, TheCSCRecHits);
 
   //Get L1MuGMT 
   edm::Handle < L1MuGMTReadoutCollection > TheL1GMTReadout ;
-  iEvent.getByLabel (IT_L1MuGMTReadout, TheL1GMTReadout);
+  //  iEvent.getByLabel (IT_L1MuGMTReadout, TheL1GMTReadout);
+  iEvent.getByToken(l1mugmtro_token_, TheL1GMTReadout);
 
   //Get Chamber Anode Trigger Information
   edm::Handle<CSCALCTDigiCollection> TheALCTs;
-  iEvent.getByLabel (IT_ALCT, TheALCTs);
+  //  iEvent.getByLabel (IT_ALCT, TheALCTs);
+  iEvent.getByToken(cscalct_token_, TheALCTs);
 
   //Get HLT Results                                                                                                                                                       
   edm::Handle<edm::TriggerResults> TheHLTResults;
-  iEvent.getByLabel( IT_HLTResult , TheHLTResults);
+  //  iEvent.getByLabel( IT_HLTResult , TheHLTResults);
+  iEvent.getByToken(hltresult_token_, TheHLTResults);
 
   const edm::TriggerNames * triggerNames = 0;
   if (TheHLTResults.isValid()) {

--- a/RecoMET/METProducers/src/EcalHaloDataProducer.cc
+++ b/RecoMET/METProducers/src/EcalHaloDataProducer.cc
@@ -1,4 +1,5 @@
 #include "RecoMET/METProducers/interface/EcalHaloDataProducer.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 /*
   [class]:  EcalHaloDataProducer
@@ -36,6 +37,12 @@ EcalHaloDataProducer::EcalHaloDataProducer(const edm::ParameterSet& iConfig)
   RoundnessCut = iConfig.getParameter<double>("RoundnessCutParam");
   AngleCut = iConfig.getParameter<double>("AngleCutParam");
 
+  ebrechit_token_ = consumes<EBRecHitCollection>(IT_EBRecHit);
+  eerechit_token_ = consumes<EERecHitCollection>(IT_EERecHit);
+  esrechit_token_ = consumes<ESRecHitCollection>(IT_ESRecHit);
+  supercluster_token_ = consumes<reco::SuperClusterCollection>(IT_SuperCluster);
+  photon_token_ = consumes<reco::PhotonCollection>(IT_Photon);
+
   produces<EcalHaloData>();
 }
 
@@ -47,23 +54,28 @@ void EcalHaloDataProducer::produce(Event& iEvent, const EventSetup& iSetup)
 
   //Get  EB RecHits
   edm::Handle<EBRecHitCollection> TheEBRecHits;
-  iEvent.getByLabel(IT_EBRecHit, TheEBRecHits);
+  //  iEvent.getByLabel(IT_EBRecHit, TheEBRecHits);
+  iEvent.getByToken(ebrechit_token_, TheEBRecHits);
 
   //Get EE RecHits
   edm::Handle<EERecHitCollection> TheEERecHits;
-  iEvent.getByLabel(IT_EERecHit, TheEERecHits);
+  //  iEvent.getByLabel(IT_EERecHit, TheEERecHits);
+  iEvent.getByToken(eerechit_token_, TheEERecHits);
 
   //Get ES RecHits
   edm::Handle<ESRecHitCollection> TheESRecHits;
-  iEvent.getByLabel(IT_ESRecHit, TheESRecHits);
+  //  iEvent.getByLabel(IT_ESRecHit, TheESRecHits);
+  iEvent.getByToken(esrechit_token_, TheESRecHits);
 
   //Get ECAL Barrel SuperClusters                  
   edm::Handle<reco::SuperClusterCollection> TheSuperClusters;
-  iEvent.getByLabel(IT_SuperCluster, TheSuperClusters);
+  //  iEvent.getByLabel(IT_SuperCluster, TheSuperClusters);
+  iEvent.getByToken(supercluster_token_, TheSuperClusters);
 
   //Get Photons
   edm::Handle<reco::PhotonCollection> ThePhotons;
-  iEvent.getByLabel(IT_Photon, ThePhotons);
+  //  iEvent.getByLabel(IT_Photon, ThePhotons);
+  iEvent.getByToken(photon_token_, ThePhotons);
 
   //Run the EcalHaloAlgo to reconstruct the EcalHaloData object 
   EcalHaloAlgo EcalAlgo;

--- a/RecoMET/METProducers/src/GlobalHaloDataProducer.cc
+++ b/RecoMET/METProducers/src/GlobalHaloDataProducer.cc
@@ -1,4 +1,5 @@
 #include "RecoMET/METProducers/interface/GlobalHaloDataProducer.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 /*
   [class]:  GlobalHaloDataProducer
@@ -29,7 +30,15 @@ GlobalHaloDataProducer::GlobalHaloDataProducer(const edm::ParameterSet& iConfig)
   HcalMinMatchingRadius = (float)iConfig.getParameter<double>("HcalMinMatchingRadiusParam");
   HcalMaxMatchingRadius = (float)iConfig.getParameter<double>("HcalMaxMatchingRadiusParam");
   CaloTowerEtThreshold  = (float)iConfig.getParameter<double>("CaloTowerEtThresholdParam");
-  
+
+  calotower_token_  = consumes<edm::View<Candidate> >(IT_CaloTower);
+  calomet_token_    = consumes<reco::CaloMETCollection>(IT_met);
+  cscsegment_token_ = consumes<CSCSegmentCollection>(IT_CSCSegment);
+  cscrechit_token_  = consumes<CSCRecHit2DCollection>(IT_CSCRecHit);
+  cschalo_token_    = consumes<CSCHaloData>(IT_CSCHaloData);
+  ecalhalo_token_   = consumes<EcalHaloData>(IT_EcalHaloData);
+  hcalhalo_token_   = consumes<HcalHaloData>(IT_HcalHaloData);
+
   produces<GlobalHaloData>();
 }
 
@@ -49,31 +58,38 @@ void GlobalHaloDataProducer::produce(Event& iEvent, const EventSetup& iSetup)
 
   //Get CaloTowers
   edm::Handle<edm::View<Candidate> > TheCaloTowers;
-  iEvent.getByLabel(IT_CaloTower,TheCaloTowers);
+  //  iEvent.getByLabel(IT_CaloTower,TheCaloTowers);
+  iEvent.getByToken(calotower_token_, TheCaloTowers);
 
   //Get MET
   edm::Handle< reco::CaloMETCollection > TheCaloMET;
-  iEvent.getByLabel(IT_met, TheCaloMET);
+  //  iEvent.getByLabel(IT_met, TheCaloMET);
+  iEvent.getByToken(calomet_token_, TheCaloMET);
 
   //Get CSCSegments
   edm::Handle<CSCSegmentCollection> TheCSCSegments;
-  iEvent.getByLabel(IT_CSCSegment, TheCSCSegments);
+  //  iEvent.getByLabel(IT_CSCSegment, TheCSCSegments);
+  iEvent.getByToken(cscsegment_token_, TheCSCSegments);
 
   //Get CSCRecHits
   edm::Handle<CSCRecHit2DCollection> TheCSCRecHits;
-  iEvent.getByLabel(IT_CSCRecHit, TheCSCRecHits );
+  //  iEvent.getByLabel(IT_CSCRecHit, TheCSCRecHits );
+  iEvent.getByToken(cscrechit_token_, TheCSCRecHits);
 
   //Get CSCHaloData
   edm::Handle<reco::CSCHaloData> TheCSCHaloData;
-  iEvent.getByLabel(IT_CSCHaloData, TheCSCHaloData );
+  //  iEvent.getByLabel(IT_CSCHaloData, TheCSCHaloData );
+  iEvent.getByToken(cschalo_token_, TheCSCHaloData);
 
   // Get EcalHaloData
   edm::Handle<reco::EcalHaloData> TheEcalHaloData;
-  iEvent.getByLabel(IT_EcalHaloData, TheEcalHaloData );
-  
+  //  iEvent.getByLabel(IT_EcalHaloData, TheEcalHaloData );
+  iEvent.getByToken(ecalhalo_token_, TheEcalHaloData);
+
   // Get HcalHaloData
   edm::Handle<reco::HcalHaloData> TheHcalHaloData;
-  iEvent.getByLabel(IT_HcalHaloData, TheHcalHaloData );
+  //  iEvent.getByLabel(IT_HcalHaloData, TheHcalHaloData );
+  iEvent.getByToken(hcalhalo_token_, TheHcalHaloData);
 
   // Run the GlobalHaloAlgo to reconstruct the GlobalHaloData object 
   GlobalHaloAlgo GlobalAlgo;

--- a/RecoMET/METProducers/src/HcalHaloDataProducer.cc
+++ b/RecoMET/METProducers/src/HcalHaloDataProducer.cc
@@ -1,4 +1,5 @@
 #include "RecoMET/METProducers/interface/HcalHaloDataProducer.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 /*
   [class]:  HcalHaloDataProducer
@@ -23,6 +24,9 @@ HcalHaloDataProducer::HcalHaloDataProducer(const edm::ParameterSet& iConfig)
   SumHcalEnergyThreshold = (float) iConfig.getParameter<double>("SumHcalEnergyThresholdParam");
   NHitsHcalThreshold =  iConfig.getParameter<int>("NHitsHcalThresholdParam");
 
+  hbherechit_token_ = consumes<HBHERecHitCollection>(IT_HBHERecHit);
+  hfrechit_token_ = consumes<HFRecHitCollection>(IT_HFRecHit);
+
   produces<HcalHaloData>();
 }
 
@@ -34,11 +38,13 @@ void HcalHaloDataProducer::produce(Event& iEvent, const EventSetup& iSetup)
   
   //Get HB/HE RecHits
   edm::Handle<HBHERecHitCollection> TheHBHERecHits;
-  iEvent.getByLabel(IT_HBHERecHit, TheHBHERecHits);
+  //  iEvent.getByLabel(IT_HBHERecHit, TheHBHERecHits);
+  iEvent.getByToken(hbherechit_token_, TheHBHERecHits);
 
   //Get HF RecHits
   edm::Handle<HFRecHitCollection> TheHFRecHits;
-  iEvent.getByLabel(IT_HFRecHit, TheHFRecHits);
+  //  iEvent.getByLabel(IT_HFRecHit, TheHFRecHits);
+  iEvent.getByToken(hfrechit_token_, TheHFRecHits);
 
   // Run the HcalHaloAlgo to reconstruct the HcalHaloData object
   HcalHaloAlgo HcalAlgo;

--- a/RecoMET/METProducers/src/HcalNoiseInfoProducer.cc
+++ b/RecoMET/METProducers/src/HcalNoiseInfoProducer.cc
@@ -1,3 +1,5 @@
+#include "RecoMET/METProducers/interface/HcalNoiseInfoProducer.h"
+
 //
 // HcalNoiseInfoProducer.cc
 //
@@ -7,13 +9,8 @@
 //
 //
 
-#include "RecoMET/METProducers/interface/HcalNoiseInfoProducer.h"
-#include "DataFormats/HcalDigi/interface/HcalDigiCollections.h"
-#include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
-#include "DataFormats/CaloTowers/interface/CaloTowerCollection.h"
-#include "DataFormats/TrackReco/interface/TrackFwd.h"
-#include "DataFormats/TrackReco/interface/Track.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "CalibFormats/HcalObjects/interface/HcalCoderDb.h"
 #include "CalibFormats/HcalObjects/interface/HcalCalibrations.h"
 #include "CalibFormats/HcalObjects/interface/HcalDbService.h"
@@ -116,6 +113,12 @@ HcalNoiseInfoProducer::HcalNoiseInfoProducer(const edm::ParameterSet& iConfig) :
      5297.,5609.5,5984.5,6359.5,6734.5,7172.,7672.,8172.,8734.5,9359.5,9984.5};
   for(int i = 0; i < 128; i++)
      adc2fC[i] = adc2fCTemp[i];
+
+  hbhedigi_token_      = consumes<HBHEDigiCollection>(edm::InputTag(digiCollName_));
+  hcalcalibdigi_token_ = consumes<HcalCalibDigiCollection>(edm::InputTag("hcalDigis"));
+  hbherechit_token_    = consumes<HBHERecHitCollection>(edm::InputTag(recHitCollName_));
+  calotower_token_     = consumes<CaloTowerCollection>(edm::InputTag(caloTowerCollName_));
+  track_token_         = consumes<reco::TrackCollection>(edm::InputTag(trackCollName_));
 
   // we produce a vector of HcalNoiseRBXs
   produces<HcalNoiseRBXCollection>();
@@ -322,7 +325,9 @@ HcalNoiseInfoProducer::filldigis(edm::Event& iEvent, const edm::EventSetup& iSet
 
   // get the digis
   edm::Handle<HBHEDigiCollection> handle;
-  iEvent.getByLabel(digiCollName_, handle);
+  //  iEvent.getByLabel(digiCollName_, handle);
+  iEvent.getByToken(hbhedigi_token_, handle);
+
   if(!handle.isValid()) {
     throw edm::Exception(edm::errors::ProductNotFound) << " could not find HBHEDigiCollection named " << digiCollName_ << "\n.";
     return;
@@ -393,7 +398,8 @@ HcalNoiseInfoProducer::filldigis(edm::Event& iEvent, const edm::EventSetup& iSet
 
   // get the calibration digis
   edm::Handle<HcalCalibDigiCollection> hCalib;
-  iEvent.getByLabel("hcalDigis", hCalib);
+  //  iEvent.getByLabel("hcalDigis", hCalib);
+  iEvent.getByToken(hcalcalibdigi_token_, hCalib);
 
   // get total charge in calibration channels
   if(hCalib.isValid() == true)
@@ -503,7 +509,9 @@ HcalNoiseInfoProducer::fillrechits(edm::Event& iEvent, const edm::EventSetup& iS
 
   // get the rechits
   edm::Handle<HBHERecHitCollection> handle;
-  iEvent.getByLabel(recHitCollName_, handle);
+  //  iEvent.getByLabel(recHitCollName_, handle);
+  iEvent.getByToken(hbherechit_token_, handle);
+
   if(!handle.isValid()) {
     throw edm::Exception(edm::errors::ProductNotFound)
       << " could not find HBHERecHitCollection named " << recHitCollName_ << "\n.";
@@ -644,7 +652,9 @@ HcalNoiseInfoProducer::fillcalotwrs(edm::Event& iEvent, const edm::EventSetup& i
 {
   // get the calotowers
   edm::Handle<CaloTowerCollection> handle;
-  iEvent.getByLabel(caloTowerCollName_, handle);
+  //  iEvent.getByLabel(caloTowerCollName_, handle);
+  iEvent.getByToken(calotower_token_, handle);
+
   if(!handle.isValid()) {
     throw edm::Exception(edm::errors::ProductNotFound)
       << " could not find CaloTowerCollection named " << caloTowerCollName_ << "\n.";
@@ -684,7 +694,8 @@ void
 HcalNoiseInfoProducer::filltracks(edm::Event& iEvent, const edm::EventSetup& iSetup, HcalNoiseSummary& summary) const
 {
   edm::Handle<reco::TrackCollection> handle;
-  iEvent.getByLabel(trackCollName_, handle);
+  //  iEvent.getByLabel(trackCollName_, handle);
+  iEvent.getByToken(track_token_, handle);
 
   // don't throw exception, just return quietly
   if(!handle.isValid()) {


### PR DESCRIPTION
Since I got pointed at CSCHaloDataProducer I discovered RecoMET/METProducers had several other classes also missing 'consumes', although some classes already had been updated. No idea why only some were done. This branch formally adds the consumes interface where it was missing. But BEWARE! I am no expert on this code, and there is what I consider to be a rather complicated templated class MinMETProducerT that you probably normally wouldn't want me messing with, and now I've given it a vector<EDGetTokenT<METCollection> >. The whole package compiles and builds in 710pre4. But it is in no way tested. I wouldn't have a clue how to do that.
