### PR TITLE
Add back TrackingParticle Selector to digitization.  Change pT threshold...

### DIFF
--- a/SimGeneral/MixingModule/python/digitizers_cfi.py
+++ b/SimGeneral/MixingModule/python/digitizers_cfi.py
@@ -7,7 +7,7 @@ from SimGeneral.MixingModule.stripDigitizer_cfi import *
 from SimGeneral.MixingModule.ecalDigitizer_cfi import *
 from SimGeneral.MixingModule.hcalDigitizer_cfi import *
 from SimGeneral.MixingModule.castorDigitizer_cfi import *
-from SimGeneral.MixingModule.trackingTruthProducer_cfi import *
+from SimGeneral.MixingModule.trackingTruthProducerSelection_cfi import *
 
 theDigitizers = cms.PSet(
   pixel = cms.PSet(

--- a/SimGeneral/MixingModule/python/trackingTruthProducerSelection_cfi.py
+++ b/SimGeneral/MixingModule/python/trackingTruthProducerSelection_cfi.py
@@ -4,11 +4,12 @@ from SimGeneral.MixingModule.trackingTruthProducer_cfi import trackingParticles
 trackingParticles.select = cms.PSet(
     lipTP = cms.double(1000),
     chargedOnlyTP = cms.bool(True),
+    stableOnlyTP = cms.bool(True),
     pdgIdTP = cms.vint32(),
     signalOnlyTP = cms.bool(True),
-    minRapidityTP = cms.double(-2.6),
+    minRapidityTP = cms.double(-5.0),
     minHitTP = cms.int32(3),
-    ptMinTP = cms.double(0.2),
-    maxRapidityTP = cms.double(2.6),
+    ptMinTP = cms.double(0.1),
+    maxRapidityTP = cms.double(5.0),
     tipTP = cms.double(1000)
 )

--- a/SimGeneral/MixingModule/python/trackingTruthProducerSelection_cfi.py
+++ b/SimGeneral/MixingModule/python/trackingTruthProducerSelection_cfi.py
@@ -4,7 +4,7 @@ from SimGeneral.MixingModule.trackingTruthProducer_cfi import trackingParticles
 trackingParticles.select = cms.PSet(
     lipTP = cms.double(1000),
     chargedOnlyTP = cms.bool(True),
-    stableOnlyTP = cms.bool(True),
+    stableOnlyTP = cms.bool(False),
     pdgIdTP = cms.vint32(),
     signalOnlyTP = cms.bool(True),
     minRapidityTP = cms.double(-5.0),


### PR DESCRIPTION
... to 100 MeV, widen eta acceptance to +/-5

No significant increase in TrackingParticle size is seen with these changes over a pT cut of 200 MeV and an eta acceptance of +/- 2.6
