### PR TITLE
MuonAnalysis/MomentumScaleCalibration: add missing `std::`

### DIFF
--- a/MuonAnalysis/MomentumScaleCalibration/plugins/MuScleFitUtils.cc
+++ b/MuonAnalysis/MomentumScaleCalibration/plugins/MuScleFitUtils.cc
@@ -1131,7 +1131,7 @@ void MuScleFitUtils::minimizeLikelihood()
 {
   // Output file with fit parameters resulting from minimization
   // -----------------------------------------------------------
-  ofstream FitParametersFile;
+  std::ofstream FitParametersFile;
   FitParametersFile.open ("FitParameters.txt", std::ios::app);
   FitParametersFile << "Fitting with resolution, scale, bgr function # "
 		    << ResolFitType << " " << ScaleFitType << " " << BgrFitType

--- a/MuonAnalysis/MomentumScaleCalibration/src/BackgroundFunction.cc
+++ b/MuonAnalysis/MomentumScaleCalibration/src/BackgroundFunction.cc
@@ -7,7 +7,7 @@ void BackgroundFunction::readParameters( TString fileName )
   // std::vector<double> parameterErrors;
 
   // Read the parameters file
-  ifstream parametersFile(fileName.Data());
+  std::ifstream parametersFile(fileName.Data());
   std::string line;
 
   std::string iteration("Iteration ");


### PR DESCRIPTION
Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
