### PR TITLE
DataFormats/Candidate: make CMS_CLASS_VERSION(11) public, not protected

### DIFF
--- a/DataFormats/Candidate/interface/LeafRefCandidateT.h
+++ b/DataFormats/Candidate/interface/LeafRefCandidateT.h
@@ -224,6 +224,8 @@ namespace reco {
     virtual bool isConvertedPhoton() const GCC11_FINAL  { return false; }
     virtual bool isJet() const GCC11_FINAL  { return false; }
 
+    CMS_CLASS_VERSION(11)
+
   protected:
     /// T internally.
     /// NOTE! T must satisfy ref_->pt(), ref_->phi(), etc, like a TrackRef
@@ -261,8 +263,6 @@ namespace reco {
     friend class ::OverlapChecker;
     friend class ShallowCloneCandidate;
     friend class ShallowClonePtrCandidate;
-
-    CMS_CLASS_VERSION(11)
 
   private:
     // const iterator implementation


### PR DESCRIPTION
Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
