### PR TITLE
New design, Run1 and Run2 simulation, Run1 data, and HLT GTs in autoCond.

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -8,7 +8,7 @@ autoCond = {
     # GlobalTag for MC production of p-Pb events with realistic alignment and calibrations
     'startpa'           :   'STARTHI70_V10::All',
     # GlobalTag for data reprocessing: this should always be the GR_R tag
-    'com10'             :   'GR_R_70_V1::All',
+    'com10'             :   'GR_R_70_V2::All',
     # GlobalTag for running HLT on recent data: this should be the GR_P (prompt reco) global tag until a compatible GR_H tag is available, 
     # then it should point to the GR_H tag and override the connection string and pfnPrefix for use offline
     'hltonline'         :   'GR_H_V35::All,frontier://FrontierProd/CMS_COND_31X_GLOBALTAG,frontier://FrontierProd/',

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -1,17 +1,17 @@
 autoCond = { 
     # GlobalTag for MC production with perfectly aligned and calibrated detector
-    'mc'                :   'MC_70_V4::All',
+    'mc'                :   'MC_70_V6::All',
     # GlobalTag for MC production with realistic alignment and calibrations
-    'startup'           :   'START70_V6::All',
+    'startup'           :   'START70_V7::All',
     # GlobalTag for MC production of Heavy Ions events with realistic alignment and calibrations
-    'starthi'           :   'STARTHI70_V7::All',
+    'starthi'           :   'STARTHI70_V9::All',
     # GlobalTag for MC production of p-Pb events with realistic alignment and calibrations
-    'startpa'           :   'STARTHI70_V8::All',
+    'startpa'           :   'STARTHI70_V10::All',
     # GlobalTag for data reprocessing: this should always be the GR_R tag
     'com10'             :   'GR_R_70_V1::All',
     # GlobalTag for running HLT on recent data: this should be the GR_P (prompt reco) global tag until a compatible GR_H tag is available, 
     # then it should point to the GR_H tag and override the connection string and pfnPrefix for use offline
-    'hltonline'         :   'GR_H_V33::All,frontier://FrontierProd/CMS_COND_31X_GLOBALTAG,frontier://FrontierProd/',
+    'hltonline'         :   'GR_H_V35::All,frontier://FrontierProd/CMS_COND_31X_GLOBALTAG,frontier://FrontierProd/',
     # GlobalTag for POSTLS1 upgrade studies:
     'upgradePLS1'       :   'POSTLS170_V7::All',
     'upgradePLS150ns'   :   'POSTLS170_V6::All',


### PR DESCRIPTION
New Run1 simulation GT including SiStrip offsets for APV cycle phase producers (and a fix for simulated geometry in HI workflows); new design GT including SiStrip offsets for APV cycle phase producers, technical improvements, and a fix for simulated Geometry; new HLT GT including SiStrip offsets for APV cycle phase producers.
- MC_70_V6 GT
  - technical improvements (a.k.a. migrations to newer accounts)
  - fix of the `ExtendedZeroMaterial` simulated geometry
  - enabling Ecal full readout for pre-mixing
  - adding SiStrip offsets for APV cycle phase producers.
- START70_V7 GT
  - adding SiStrip offsets for APV cycle phase producers.
- STARTHI70_V9 GT
  - fix of the `ExtendedZeroMaterial` simulated geometry
  - adding SiStrip offsets for APV cycle phase producers.
- STARTHI70_V10 GT
  - fix of the `ExtendedZeroMaterial` simulated geometry
  - adding SiStrip offsets for APV cycle phase producers.
- GR_R_70_V1 GT
  - adding SiStrip offsets for APV cycle phase producers.
- GR_H_V35 GT
  - adding SiStrip offsets for APV cycle phase producers.
