### PR TITLE
Relval fixes for boost io branch

### DIFF
--- a/RecoMuon/L2MuonSeedGenerator/src/L2MuonSeedGenerator.cc
+++ b/RecoMuon/L2MuonSeedGenerator/src/L2MuonSeedGenerator.cc
@@ -51,17 +51,14 @@ L2MuonSeedGenerator::L2MuonSeedGenerator(const edm::ParameterSet& iConfig) :
   useOfflineSeed(iConfig.getUntrackedParameter<bool>("UseOfflineSeed", false)),
   useUnassociatedL1(iConfig.existsAs<bool>("UseUnassociatedL1") ? 
 		    iConfig.getParameter<bool>("UseUnassociatedL1") : true){
-//-ap ??? <<<<<<< HEAD
-//-ap ??? 
-//-ap ???   gmtToken_ = consumes<L1MuGMTReadoutCollection>(theL1GMTReadoutCollection);
-//-ap ???   muCollToken_ = consumes<L1MuonParticleCollection>(theSource);
-//-ap ??? 
-//-ap ???   if(useOfflineSeed) {
-//-ap ???     theOfflineSeedLabel = iConfig.getUntrackedParameter<InputTag>("OfflineSeedLabel");
-//-ap ???     offlineSeedToken_ = consumes<edm::View<TrajectorySeed> >(theOfflineSeedLabel);
-//-ap ???   }
-//-ap ??? =======
-//-ap ??? >>>>>>> apfeiffer1/merge-test
+
+  gmtToken_ = consumes<L1MuGMTReadoutCollection>(theL1GMTReadoutCollection);
+  muCollToken_ = consumes<L1MuonParticleCollection>(theSource);
+
+  if(useOfflineSeed) {
+    theOfflineSeedLabel = iConfig.getUntrackedParameter<InputTag>("OfflineSeedLabel");
+    offlineSeedToken_ = consumes<edm::View<TrajectorySeed> >(theOfflineSeedLabel);
+  }
   
   // service parameters
   ParameterSet serviceParameters = iConfig.getParameter<ParameterSet>("ServiceParameters");


### PR DESCRIPTION
+1
Commented out code from a conflict resolution caused some part of the consumes migration to be missing in the BOOSTIO branch. This PR fixes that (and should fix a (large?) number of presently "broken" relvals).
Please merge into the BOOSTIO branch.
