### PR TITLE
Read DT uncertainties map from DB

### DIFF
--- a/RecoLocalMuon/DTRecHit/plugins/DTLinearDriftFromDBAlgo.cc
+++ b/RecoLocalMuon/DTRecHit/plugins/DTLinearDriftFromDBAlgo.cc
@@ -28,14 +28,19 @@ DTLinearDriftFromDBAlgo::DTLinearDriftFromDBAlgo(const ParameterSet& config) :
   doVdriftCorr(config.getParameter<bool>("doVdriftCorr")),
   // Option to force going back to digi time at Step 2 
   stepTwoFromDigi(config.getParameter<bool>("stepTwoFromDigi")),
-  // Assign hit uncertainties based on new uncertainties DB
-  useUncertDB(config.getParameter<bool>("useUncertDB")),
+  useUncertDB(false),
   // Set verbose output
   debug(config.getUntrackedParameter<bool>("debug"))
 {
-    if(debug)
-      cout<<"[DTLinearDriftFromDBAlgo] Constructor called"<<endl;
+  if(debug)
+    cout<<"[DTLinearDriftFromDBAlgo] Constructor called"<<endl;
+
+  // Check for compatibility with older configurations
+  if (config.existsAs<bool>("useUncertDB")) {
+    // Assign hit uncertainties based on new uncertainties DB
+    useUncertDB= config.getParameter<bool>("useUncertDB");
   }
+}
 
 
 

--- a/RecoLocalMuon/DTRecHit/plugins/DTLinearDriftFromDBAlgo.cc
+++ b/RecoLocalMuon/DTRecHit/plugins/DTLinearDriftFromDBAlgo.cc
@@ -28,6 +28,8 @@ DTLinearDriftFromDBAlgo::DTLinearDriftFromDBAlgo(const ParameterSet& config) :
   doVdriftCorr(config.getParameter<bool>("doVdriftCorr")),
   // Option to force going back to digi time at Step 2 
   stepTwoFromDigi(config.getParameter<bool>("stepTwoFromDigi")),
+  // Assign hit uncertainties based on new uncertainties DB
+  useUncertDB(config.getParameter<bool>("useUncertDB")),
   // Set verbose output
   debug(config.getUntrackedParameter<bool>("debug"))
 {
@@ -49,17 +51,19 @@ void DTLinearDriftFromDBAlgo::setES(const EventSetup& setup) {
   ESHandle<DTMtime> mTimeHandle;
   setup.get<DTMtimeRcd>().get(mTimeHandle);
   mTimeMap = &*mTimeHandle;
+
+  if (useUncertDB) {
+    ESHandle<DTRecoUncertainties> uncerts;
+    setup.get<DTRecoUncertaintiesRcd>().get(uncerts);
+    uncertMap = &*uncerts;
   
-//   ESHandle<DTRecoUncertainties> uncerts;
-//   setup.get<DTRecoUncertaintiesRcd>().get(uncerts);
-//   uncertMap = &*uncerts;
-
-  // check uncertainty map type
-//  if (uncerts->version()>1) edm::LogError("NotImplemented") << "DT Uncertainty DB version unknown: " << uncerts->version();
-
+    // check uncertainty map type
+    if (uncertMap->version()>1) edm::LogError("NotImplemented") << "DT Uncertainty DB version unknown: " << uncertMap->version();
+  }
+  
   if(debug) {
     cout << "[DTLinearDriftFromDBAlgo] meanTimer version: " << mTimeMap->version()<<endl;
-//    cout << "                          uncertDB  version: " << uncerts->version()<<endl;
+    if (useUncertDB) cout << "                          uncertDB  version: " << uncertMap->version()<<endl;
   }
   
 }
@@ -154,12 +158,14 @@ bool DTLinearDriftFromDBAlgo::compute(const DTLayer* layer,
   // vdrift is cm/ns , resolution is cm
   mTimeMap->get(wireId.superlayerId(),
 	        vDrift,
-	        hitResolution,  // Value from vdrift DB; obsolete.
+	        hitResolution,  // Value from vdrift DB; replaced below if useUncertDB card is set
 	        DTVelocityUnits::cm_per_ns);
 
-  // Read the uncertainty from the DB for the given channel and step
-  //  float hitResolution = uncertMap->get(wireId, step-1);
-
+  if (useUncertDB) {
+    // Read the uncertainty from the DB for the given channel and step
+    hitResolution = uncertMap->get(wireId, step-1);
+  }
+  
   //only in step 3
   if(doVdriftCorr && step == 3){
     if (abs(wireId.wheel()) == 2 && 

--- a/RecoLocalMuon/DTRecHit/plugins/DTLinearDriftFromDBAlgo.h
+++ b/RecoLocalMuon/DTRecHit/plugins/DTLinearDriftFromDBAlgo.h
@@ -99,6 +99,10 @@ class DTLinearDriftFromDBAlgo : public DTRecHitBaseAlgo {
   // (when off, Step 2 does nothing)
   const bool stepTwoFromDigi;
 
+  // Assign hit uncertainties based on new uncertainties DB 
+  // If false, the value taken from vdrift DB is used instead.
+  const bool useUncertDB;
+
   // Switch on/off the verbosity
   const bool debug;
 };

--- a/RecoLocalMuon/DTRecHit/plugins/DTLinearDriftFromDBAlgo.h
+++ b/RecoLocalMuon/DTRecHit/plugins/DTLinearDriftFromDBAlgo.h
@@ -101,7 +101,7 @@ class DTLinearDriftFromDBAlgo : public DTRecHitBaseAlgo {
 
   // Assign hit uncertainties based on new uncertainties DB 
   // If false, the value taken from vdrift DB is used instead.
-  const bool useUncertDB;
+  bool useUncertDB;
 
   // Switch on/off the verbosity
   const bool debug;

--- a/RecoLocalMuon/DTRecHit/python/DTLinearDriftFromDBAlgo_CosmicData_cfi.py
+++ b/RecoLocalMuon/DTRecHit/python/DTLinearDriftFromDBAlgo_CosmicData_cfi.py
@@ -26,7 +26,8 @@ DTLinearDriftFromDBAlgo_CosmicData = cms.PSet(
         stepTwoFromDigi = cms.bool(False),
         # The module to be used for ttrig synchronization and its set parameter
         tTrigMode = cms.string('DTTTrigSyncFromDB'),
-        doVdriftCorr = cms.bool(False)
+        doVdriftCorr = cms.bool(False),
+        useUncertDB = cms.bool(False)
     ),
     recAlgo = cms.string('DTLinearDriftFromDBAlgo')
 )

--- a/RecoLocalMuon/DTRecHit/python/DTLinearDriftFromDBAlgo_cfi.py
+++ b/RecoLocalMuon/DTRecHit/python/DTLinearDriftFromDBAlgo_cfi.py
@@ -27,7 +27,8 @@ DTLinearDriftFromDBAlgo = cms.PSet(
         # The module to be used for ttrig synchronization and its set parameter
         tTrigMode = cms.string('DTTTrigSyncFromDB'),
         # perform a correction to vdrift in MB1s of external wheels
-        doVdriftCorr = cms.bool(True)
+        doVdriftCorr = cms.bool(True),
+        useUncertDB = cms.bool(True)
     ),
     recAlgo = cms.string('DTLinearDriftFromDBAlgo')
 )


### PR DESCRIPTION
Reading of a new object for DT uncertainties is activated. Depends on PR #2992, which includes in the GT an object which corresponds to the same values used previously; no change of results is thus expected.

A card "useUncertDB" has been included; reverts to the old behaviour if set to False. HLT experts agreed to update ConfDB accordingly.
