### PR TITLE
Fullsim csa14 pu in time only

### DIFF
--- a/Configuration/StandardSequences/python/Mixing.py
+++ b/Configuration/StandardSequences/python/Mixing.py
@@ -108,7 +108,7 @@ addMixingScenario("FS_2012_Startup_inTimeOnly",{'file': 'FastSimulation.PileUpPr
 addMixingScenario("FS_2012_Summer_inTimeOnly",{'file': 'FastSimulation.PileUpProducer.PileUpSimulator_2012_Summer_inTimeOnly_cff'})
 addMixingScenario("FS_mix_2012_Startup_inTimeOnly",{'file': 'FastSimulation.PileUpProducer.mix_2012_Startup_inTimeOnly_cff'})
 addMixingScenario("FS_mix_2012_Summer_inTimeOnly",{'file': 'FastSimulation.PileUpProducer.mix_2012_Summer_inTimeOnly_cff'})
-
+addMixingScenario("FS_CSA14_inTimeOnly",{'file': 'FastSimulation.PileUpProducer.PileUpSimulator_CSA14_inTimeOnly_cff'})
 
 #scenarios for L1 tdr work
 addMixingScenario("AVE_10_BX_25ns",{'file': 'SimGeneral.MixingModule.mix_POISSON_average_cfi','BX':25, 'B': (-12,3), 'N': 10})

--- a/Configuration/StandardSequences/python/Mixing.py
+++ b/Configuration/StandardSequences/python/Mixing.py
@@ -96,6 +96,7 @@ addMixingScenario("E8TeV_2012_25nsRunning_TrainFrontOOTPU",{'file': 'SimGeneral.
 addMixingScenario("2012_Summer_50ns_PoissonOOTPU_FixedInTime0",{'file': 'SimGeneral.MixingModule.mix_2012_Summer_50ns_PoissonOOTPU_FixedInTime0_cfi'})
 addMixingScenario("2012_Summer_50ns_PoissonOOTPU_FixedInTime30",{'file': 'SimGeneral.MixingModule.mix_2012_Summer_50ns_PoissonOOTPU_FixedInTime30_cfi'})
 addMixingScenario("CSA14_50ns_PoissonOOT",{'file': 'SimGeneral.MixingModule.mix_CSA14_50ns_PoissonOOTPU_cfi'})
+addMixingScenario("CSA14_inTimeOnly",{'file': 'SimGeneral.MixingModule.mix_CSA14_inTimeOnly_cfi'})
 addMixingScenario("ProdStep2",{'file': 'SimGeneral.MixingModule.mixProdStep2_cfi'})
 addMixingScenario("fromDB",{'file': 'SimGeneral.MixingModule.mix_fromDB_cfi'})
 ##fastsim section

--- a/FastSimulation/PileUpProducer/python/PileUpSimulator_CSA14_inTimeOnly_cff.py
+++ b/FastSimulation/PileUpProducer/python/PileUpSimulator_CSA14_inTimeOnly_cff.py
@@ -1,0 +1,61 @@
+from FastSimulation.PileUpProducer.PileUpSimulator13TeV_cfi import PileUpSimulatorBlock as _block13TeV
+from FastSimulation.Configuration.MixingFamos_cff import *
+
+#define the PU scenario itself
+famosPileUp.PileUpSimulator = _block13TeV.PileUpSimulator
+famosPileUp.PileUpSimulator.usePoisson = False
+
+famosPileUp.PileUpSimulator.probFunctionVariable = (0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50)
+famosPileUp.PileUpSimulator.probValue = (0.,
+                                         0.,
+                                         0.,
+                                         0.,
+                                         0.,
+                                         0.,
+                                         0.,
+                                         0.,
+                                         0.,
+                                         0.,
+                                         0.,
+                                         0.,
+                                         0.,
+                                         0.,
+                                         0.,
+                                         0.,
+                                         0.,
+                                         0.,
+                                         0.,
+                                         0.,
+                                         0.016666667,
+                                         0.016666667,
+                                         0.016666667,
+                                         0.016666667,
+                                         0.016666667,
+                                         0.016666667,
+                                         0.016666667,
+                                         0.016666667,
+                                         0.016666667,
+                                         0.016666667,
+                                         0.016666667,
+                                         0.016666667,
+                                         0.016666667,
+                                         0.016666667,
+                                         0.016666667,
+                                         0.016666667,
+                                         0.016666667,
+                                         0.016666667,
+                                         0.016666667,
+                                         0.016666667,
+                                         0.5,
+                                         0.016666667,
+                                         0.016666667,
+                                         0.016666667,
+                                         0.016666667,
+                                         0.016666667,
+                                         0.016666667,
+                                         0.016666667,
+                                         0.016666667,
+                                         0.016666667,
+                                         0.016666667)
+#also import the "no PU" option with the MixingModule:
+from FastSimulation.PileUpProducer.mix_NoPileUp_cfi import *

--- a/SimGeneral/MixingModule/python/mix_CSA14_inTimeOnly_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_CSA14_inTimeOnly_cfi.py
@@ -1,3 +1,4 @@
 import FWCore.ParameterSet.Config as cms
 from SimGeneral.MixingModule.mix_CSA14_50ns_PoissonOOTPU_cfi import *
-mix.input.manage_OOT = False
+mix.maxBunch = 0
+mix.minBunch = 0

--- a/SimGeneral/MixingModule/python/mix_CSA14_inTimeOnly_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_CSA14_inTimeOnly_cfi.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+from SimGeneral.MixingModule.mix_CSA14_50ns_PoissonOOTPU_cfi import *
+mix.input.manage_OOT = False


### PR DESCRIPTION
added a CSA14 pu scenario for fullsim w/o OOT PU.
Purpose: FastSim validation.
