### PR TITLE
Fullsim csa14 pu in time only

### DIFF
--- a/Configuration/StandardSequences/python/Mixing.py
+++ b/Configuration/StandardSequences/python/Mixing.py
@@ -96,6 +96,7 @@ addMixingScenario("E8TeV_2012_25nsRunning_TrainFrontOOTPU",{'file': 'SimGeneral.
 addMixingScenario("2012_Summer_50ns_PoissonOOTPU_FixedInTime0",{'file': 'SimGeneral.MixingModule.mix_2012_Summer_50ns_PoissonOOTPU_FixedInTime0_cfi'})
 addMixingScenario("2012_Summer_50ns_PoissonOOTPU_FixedInTime30",{'file': 'SimGeneral.MixingModule.mix_2012_Summer_50ns_PoissonOOTPU_FixedInTime30_cfi'})
 addMixingScenario("CSA14_50ns_PoissonOOT",{'file': 'SimGeneral.MixingModule.mix_CSA14_50ns_PoissonOOTPU_cfi'})
+addMixingScenario("CSA14_inTimeOnly",{'file': 'SimGeneral.MixingModule.mix_CSA14_inTimeOnly_cfi'})
 addMixingScenario("ProdStep2",{'file': 'SimGeneral.MixingModule.mixProdStep2_cfi'})
 addMixingScenario("fromDB",{'file': 'SimGeneral.MixingModule.mix_fromDB_cfi'})
 ##fastsim section

--- a/SimGeneral/MixingModule/python/mix_CSA14_inTimeOnly_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_CSA14_inTimeOnly_cfi.py
@@ -1,3 +1,4 @@
 import FWCore.ParameterSet.Config as cms
 from SimGeneral.MixingModule.mix_CSA14_50ns_PoissonOOTPU_cfi import *
-mix.input.manage_OOT = False
+mix.maxBunch = 0
+mix.minBunch = 0

--- a/SimGeneral/MixingModule/python/mix_CSA14_inTimeOnly_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_CSA14_inTimeOnly_cfi.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+from SimGeneral.MixingModule.mix_CSA14_50ns_PoissonOOTPU_cfi import *
+mix.input.manage_OOT = False


### PR DESCRIPTION
added a CSA14 pu scenario for fullsim w/o OOT PU.
Purpose: FastSim validation.
