### PR TITLE
cmsDriver handles pre-mixed input to datamixer

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1384,6 +1384,7 @@ class ConfigBuilder(object):
 	    return
 
     def prepare_DATAMIX(self, sequence = None):
+	    """ Enrich the schedule with the digitisation step"""
 	    self.loadAndRemember(self.DATAMIXDefaultCFF)
 	    self.scheduleSequence('pdatamix','datamixing_step')
 	    if self._options.pileup_input:

--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1382,9 +1382,21 @@ class ConfigBuilder(object):
 	    return
 
     def prepare_DATAMIX(self, sequence = None):
-	    """ Enrich the schedule with the digitisation step"""
 	    self.loadAndRemember(self.DATAMIXDefaultCFF)
 	    self.scheduleSequence('pdatamix','datamixing_step')
+	    if self._options.premixed_input:
+		    theFiles=''
+		    if not "DATAMIX" in self.stepMap.keys():
+			    print '** --premixed_input only makes sense in the presence of the DATAMIX step, which is not in your sequence; ignoring the value of --premixed_input'
+		    elif self._options.premixed_input.startswith('dbs:') or self._options.premixed_input.startswith('das:'):
+			    theFiles=filesFromDASQuery('file dataset = %s'%(self._options.premixed_input[4:],))[0]
+		    elif self._options.premixed_input.startswith("filelist:"):
+			    theFiles= (filesFromList(self._options.premixed_input[9:]))[0]
+		    else:
+			    theFiles=self._options.premixed_input.split(',')
+		    #print theFiles
+		    self.executeAndRemember( "process.mixData.input.fileNames = cms.untracked.vstring(%s)"%(  theFiles ) )
+
 	    return
 
     def prepare_DIGI2RAW(self, sequence = None):

--- a/Configuration/Applications/python/Options.py
+++ b/Configuration/Applications/python/Options.py
@@ -194,11 +194,6 @@ expertSettings.add_option("--datamix",
                   default=defaultOptions.datamix,
                   dest="datamix")
 
-expertSettings.add_option("--premixed_input",
-                          help="define the pre-mixed files to mix with",
-                          default=None,
-                          dest="premixed_input")
-
 expertSettings.add_option("--gflash",
                   help="Run the FULL SIM using the GFlash parameterization.",
                   action="store_true",

--- a/Configuration/Applications/python/Options.py
+++ b/Configuration/Applications/python/Options.py
@@ -194,6 +194,11 @@ expertSettings.add_option("--datamix",
                   default=defaultOptions.datamix,
                   dest="datamix")
 
+expertSettings.add_option("--premixed_input",
+                          help="define the pre-mixed files to mix with",
+                          default=None,
+                          dest="premixed_input")
+
 expertSettings.add_option("--gflash",
                   help="Run the FULL SIM using the GFlash parameterization.",
                   action="store_true",


### PR DESCRIPTION
- the cmsDriver.py pileup_input is made aware of the presence of the DATAMIX and sets its input
- needed to handle PRE-mixing and DATAMIX in production (CSA14)
