### PR TITLE
Add missing dictionaries

### DIFF
--- a/SimDataFormats/TrackingAnalysis/src/classes_def.xml
+++ b/SimDataFormats/TrackingAnalysis/src/classes_def.xml
@@ -21,6 +21,8 @@
   <class pattern="edm::Ref<std::vector<TrackingParticle>,*>" />
   <class pattern="edm::RefVector<std::vector<TrackingParticle>,*>" />
   <class name="edm::RefProd<std::vector<TrackingParticle> >" />
+  <class name="TrackingParticleRef" />
+  <class name="TrackingParticleRefVector" />
 
   <class pattern="edm::Ref< std::vector<HepMC::GenVertex>,*>" />
   <class pattern="edm::RefVector< std::vector<HepMC::GenVertex>,*>" />


### PR DESCRIPTION
Many relval tests in the ROOT6 IB are failing due to missing dictionaries for typedefs TrackingParticleRef and TrackingParticleRefVector.
This pull request adds specifications to generate the missing dictionaries.
Pleas merge promptly unless there are issues.
