### PR TITLE
Workaround for multithreading.

### DIFF
--- a/DQMOffline/JetMET/interface/JetAnalyzer.h
+++ b/DQMOffline/JetMET/interface/JetAnalyzer.h
@@ -62,7 +62,7 @@ namespace jetAnalysis {
   //class StripSignalOverNoiseCalculator;
 }
 
-class JetAnalyzer : public DQMEDAnalyzer {
+class JetAnalyzer : public edm::EDAnalyzer {
  public:
 
   /// Constructor
@@ -70,10 +70,14 @@ class JetAnalyzer : public DQMEDAnalyzer {
   
   /// Destructor
   virtual ~JetAnalyzer();
+
+  // This is a temporary fix to make sure we do not have a non thread safe
+  // analyzer using the thread aware DQM Analyzer base class.
+  void beginRun(edm::Run const &run, edm::EventSetup const &es) override;
   
 /// Inizialize parameters for histo binning
 //  void beginJob(void);
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &);
   /// Get the analysis
  void analyze(const edm::Event&, const edm::EventSetup&);
 

--- a/DQMOffline/JetMET/interface/METAnalyzer.h
+++ b/DQMOffline/JetMET/interface/METAnalyzer.h
@@ -75,7 +75,7 @@
 
 
 
-class METAnalyzer : public DQMEDAnalyzer{
+class METAnalyzer : public edm::EDAnalyzer{
  public:
 
   /// Constructor
@@ -87,9 +87,12 @@ class METAnalyzer : public DQMEDAnalyzer{
   /// Finish up a job
   void endJob();
 
+  // This is a temporary fix to make sure we do not have a non thread safe
+  // analyzer using the thread aware DQM Analyzer base class.
+  void beginRun(edm::Run const &run, edm::EventSetup const &es) override;
 /// Inizialize parameters for histo binning
 //  void beginJob(void);
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &);
 
   // Book MonitorElements
   //void bookMESet(std::string);

--- a/DQMOffline/JetMET/src/JetAnalyzer.cc
+++ b/DQMOffline/JetMET/src/JetAnalyzer.cc
@@ -265,6 +265,18 @@ JetAnalyzer::~JetAnalyzer() {
   }
 }
 
+void JetAnalyzer::beginRun(edm::Run const &run, edm::EventSetup const &es)
+{
+  dqmBeginRun(run, es);
+
+  dbe_->bookTransaction([this, &run, &es](DQMStore::IBooker &b){
+        this->bookHistograms(b, run, es);                
+      }, 
+      run.run(),
+      0,
+      run.moduleCallingContext()->moduleDescription()->id()); 
+}
+
 // ***********************************************************
 void JetAnalyzer::bookHistograms(DQMStore::IBooker & ibooker,
 				     edm::Run const & iRun,

--- a/DQMOffline/JetMET/src/METAnalyzer.cc
+++ b/DQMOffline/JetMET/src/METAnalyzer.cc
@@ -167,6 +167,16 @@ METAnalyzer::~METAnalyzer() {
 //  delete muonEventFlag_;
 }
 
+void METAnalyzer::beginRun(edm::Run const &run, edm::EventSetup const &es)
+{
+  dqmBeginRun(run, es);
+  dbe_->bookTransaction([this, &run, &es](DQMStore::IBooker &b){
+        this->bookHistograms(b, run, es);                
+      }, 
+      run.run(),
+      0,
+      run.moduleCallingContext()->moduleDescription()->id()); 
+}
 
 void METAnalyzer::bookHistograms(DQMStore::IBooker & ibooker,
 				     edm::Run const & iRun,


### PR DESCRIPTION
- Revert back to `edm::EDAnalyzer` JetAnalyzer and METAnalyzer since
  they are calling thread unsafe methods of the DQM, which is not
  allowed for DQMEDAnalyzer derived classes.
