### PR TITLE
make nominalValue() inlined

### DIFF
--- a/MagneticField/Engine/interface/MagneticField.h
+++ b/MagneticField/Engine/interface/MagneticField.h
@@ -53,7 +53,10 @@ class MagneticField
   }
   
   /// The nominal field value for this map in kGauss
-  int nominalValue() const;
+  int nominalValue() const {  
+     if(kSet==nominalValueCompiuted.load()) return theNominalValue;
+     return computeNominalValue();
+  }     
 
 private:
   //nominal field value 

--- a/MagneticField/Engine/src/MagneticField.cc
+++ b/MagneticField/Engine/src/MagneticField.cc
@@ -20,14 +20,7 @@ MagneticField::MagneticField(const MagneticField& orig) : nominalValueCompiuted(
 MagneticField::~MagneticField(){}
 
 int MagneticField::computeNominalValue() const {
-  return int((inTesla(GlobalPoint(0.f,0.f,0.f))).z() * 10.f + 0.5f);
-}
-
-int MagneticField::nominalValue() const {
-  if(kSet==nominalValueCompiuted.load()) return theNominalValue;
-
-  //need to make one
-  int tmp = computeNominalValue();
+  int tmp = int((inTesla(GlobalPoint(0.f,0.f,0.f))).z() * 10.f + 0.5f);
 
   //Try to cache
   char expected = kUnset;


### PR DESCRIPTION
restore performance critical method as inlined (the optimization barrier remains)
