### PR TITLE
Optimization of PixelHitMatcher

### DIFF
--- a/RecoEgamma/EgammaElectronAlgos/interface/BarrelMeasurementEstimator.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/BarrelMeasurementEstimator.h
@@ -45,8 +45,8 @@ class BarrelMeasurementEstimator : public MeasurementEstimator
 
     // zero value indicates incompatible ts - hit pair
     virtual std::pair<bool,double> estimate( const TrajectoryStateOnSurface & ts, const TrackingRecHit & hit ) const ;
-    virtual std::pair<bool,double> estimate( const TrajectoryStateOnSurface & ts, GlobalPoint & gp ) const ;
-    virtual std::pair<bool,double> estimate( const GlobalPoint & vprim, const TrajectoryStateOnSurface & ts, GlobalPoint & gp ) const ;
+    virtual std::pair<bool,double> estimate( const TrajectoryStateOnSurface & ts, const GlobalPoint & gp ) const ;
+    virtual std::pair<bool,double> estimate( const GlobalPoint & vprim, const TrajectoryStateOnSurface & ts, const GlobalPoint & gp ) const ;
     virtual bool estimate( const TrajectoryStateOnSurface & ts, const BoundPlane & plane) const ;
 
     virtual BarrelMeasurementEstimator* clone() const

--- a/RecoEgamma/EgammaElectronAlgos/interface/ForwardMeasurementEstimator.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/ForwardMeasurementEstimator.h
@@ -43,8 +43,8 @@ class ForwardMeasurementEstimator
 
     // zero value indicates incompatible ts - hit pair
     virtual std::pair<bool,double> estimate( const TrajectoryStateOnSurface & ts, const TrackingRecHit & hit ) const ;
-    virtual std::pair<bool,double> estimate( const TrajectoryStateOnSurface & ts, GlobalPoint & gp ) const ;
-    virtual std::pair<bool,double> estimate( const GlobalPoint & vprim, const TrajectoryStateOnSurface & ts, GlobalPoint & gp ) const ;
+    virtual std::pair<bool,double> estimate( const TrajectoryStateOnSurface & ts, const GlobalPoint & gp ) const ;
+    virtual std::pair<bool,double> estimate( const GlobalPoint & vprim, const TrajectoryStateOnSurface & ts, const GlobalPoint & gp ) const ;
     virtual bool estimate( const TrajectoryStateOnSurface & ts, const BoundPlane & plane ) const ;
 
     virtual ForwardMeasurementEstimator* clone() const

--- a/RecoEgamma/EgammaElectronAlgos/src/BarrelMeasurementEstimator.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/BarrelMeasurementEstimator.cc
@@ -34,32 +34,31 @@ std::pair<bool,double> BarrelMeasurementEstimator::estimate( const TrajectorySta
 
 //usable in case we have no TransientTrackingRecHit
 std::pair<bool,double> BarrelMeasurementEstimator::estimate( const TrajectoryStateOnSurface& ts,
-					   GlobalPoint &gp) const {
-  float tsPhi = ts.globalParameters().position().phi();
-  float myR = gp.perp();
+					   const GlobalPoint &gp) const {
+  
   float myZ = gp.z();
+  float myR = gp.perp();
+  float zDiff = ts.globalParameters().position().z() - myZ;
 
   float myZmax =  theZMax;
   float myZmin =  theZMin;
 
-  if(std::abs(myZ)<30. && myR>8.)
-    {
-      myZmax = 0.09;
-      myZmin = -0.09;
-    }
+  if(std::abs(myZ)<30. && myR>8.) {
+    myZmax = 0.09;
+    myZmin = -0.09;
+  }
+
+  if( zDiff >= myZmax || zDiff <= myZmin ) return std::pair<bool,double>(false,0.);
+
+  float tsPhi = ts.globalParameters().position().phi();  
 
   float rhPhi = gp.phi();
-
-  float zDiff = ts.globalParameters().position().z() - gp.z();
+  
   float phiDiff = tsPhi - rhPhi;
   if (phiDiff > pi) phiDiff -= twopi;
   if (phiDiff < -pi) phiDiff += twopi;
 
-
-
-
-  if ( phiDiff < thePhiMax && phiDiff > thePhiMin &&
-       zDiff < myZmax && zDiff > myZmin) {
+  if ( phiDiff < thePhiMax && phiDiff > thePhiMin ) {
 
     return std::pair<bool,double>(true,1.);
      } else {
@@ -72,29 +71,30 @@ std::pair<bool,double> BarrelMeasurementEstimator::estimate( const TrajectorySta
 std::pair<bool,double> BarrelMeasurementEstimator::estimate
  ( const GlobalPoint & vprim,
    const TrajectoryStateOnSurface & absolute_ts,
-   GlobalPoint& absolute_gp ) const
+   const GlobalPoint& absolute_gp ) const
  {
   GlobalVector ts = absolute_ts.globalParameters().position() - vprim ;
   GlobalVector gp = absolute_gp - vprim ;
-
-  float tsPhi = ts.phi();
+  
   float myR = gp.perp();
   float myZ = gp.z();
-
+  float zDiff = myZ -ts.z() ;  
   float myZmax =  theZMax;
   float myZmin =  theZMin;
-
   if(std::abs(myZ)<30. && myR>8.)
     {
       myZmax = 0.09;
       myZmin = -0.09;
     }
+  
+
+  if( zDiff >= myZmax || zDiff <= myZmin ) return std::pair<bool,double>(false,0.);
 
   float rhPhi = gp.phi() ;
-  float zDiff = gp.z()-ts.z() ;
+  float tsPhi = ts.phi();  
   float phiDiff = normalized_phi(rhPhi-tsPhi) ;
 
-  if ( phiDiff < thePhiMax && phiDiff > thePhiMin && zDiff < myZmax && zDiff > myZmin)
+  if ( phiDiff < thePhiMax && phiDiff > thePhiMin )
    { return std::pair<bool,double>(true,1.) ; }
   else
    { return std::pair<bool,double>(false,0.) ; }

--- a/RecoEgamma/EgammaElectronAlgos/src/ForwardMeasurementEstimator.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/ForwardMeasurementEstimator.cc
@@ -30,35 +30,31 @@ std::pair<bool,double> ForwardMeasurementEstimator::estimate( const TrajectorySt
   return estimate(ts,gp);
 }
 
-std::pair<bool,double> ForwardMeasurementEstimator::estimate( const TrajectoryStateOnSurface& ts, GlobalPoint &gp) const {
+std::pair<bool,double> ForwardMeasurementEstimator::estimate( const TrajectoryStateOnSurface& ts, const GlobalPoint &gp) const {
 
   float tsR = ts.globalParameters().position().perp();
-  float tsPhi = ts.globalParameters().position().phi();
-
-  float rhPhi = gp.phi();
   float rhR = gp.perp();
-
-  float myZ = gp.z();
-
+  float rDiff = tsR - rhR;
   float rMin = theRMin;
   float rMax = theRMax;
+  float myZ = gp.z();
+  if(std::abs(myZ)> 70. &&  std::abs(myZ)<170.) {
+    rMin = theRMinI;
+    rMax = theRMaxI;
+  }
+  if( rDiff >= rMax || rDiff <= rMin ) return std::pair<bool,double>(false,0.);
+  
+  float tsPhi = ts.globalParameters().position().phi();
+  float rhPhi = gp.phi();
+  
   float myPhimin = thePhiMin;
   float myPhimax = thePhiMax;
-
-  if(std::abs(myZ)> 70. &&  std::abs(myZ)<170.)
-    {
-      rMin = theRMinI;
-      rMax = theRMaxI;
-    }
 
   float phiDiff = tsPhi - rhPhi;
   if (phiDiff > pi) phiDiff -= twopi;
   if (phiDiff < -pi) phiDiff += twopi;
 
-  float rDiff = tsR - rhR;
-
-  if ( phiDiff < myPhimax && phiDiff > myPhimin &&
-       rDiff < rMax && rDiff > rMin) {
+  if ( phiDiff < myPhimax && phiDiff > myPhimin ) {
     return std::pair<bool,double>(true,1.);
   } else {
     return std::pair<bool,double>(false,0.);
@@ -68,34 +64,33 @@ std::pair<bool,double> ForwardMeasurementEstimator::estimate( const TrajectorySt
 std::pair<bool,double> ForwardMeasurementEstimator::estimate
  ( const GlobalPoint& vprim,
    const TrajectoryStateOnSurface& absolute_ts,
-   GlobalPoint & absolute_gp ) const
+   const GlobalPoint & absolute_gp ) const
  {
   GlobalVector ts = absolute_ts.globalParameters().position() - vprim ;
   GlobalVector gp = absolute_gp - vprim ;
 
-  float tsR = ts.perp();
-  float tsPhi = ts.phi();
-
-  float rhPhi = gp.phi();
   float rhR = gp.perp();
-
-  float myZ = gp.z();
-
+  float tsR = ts.perp();
+  float rDiff = rhR - tsR;
   float rMin = theRMin;
   float rMax = theRMax;
+  float myZ = gp.z();
+  if(std::abs(myZ)> 70. &&  std::abs(myZ)<170.) {
+    rMin = theRMinI;
+    rMax = theRMaxI;
+  }
+  
+  if( rDiff >= rMax || rDiff <= rMin ) return std::pair<bool,double>(false,0.);
+  
+  float tsPhi = ts.phi();
+  float rhPhi = gp.phi();  
+  
   float myPhimin = thePhiMin;
-  float myPhimax = thePhiMax;
+  float myPhimax = thePhiMax;  
 
-  if(std::abs(myZ)> 70. &&  std::abs(myZ)<170.)
-    {
-      rMin = theRMinI;
-      rMax = theRMaxI;
-    }
+  float phiDiff = normalized_phi(rhPhi - tsPhi) ;  
 
-  float phiDiff = normalized_phi(rhPhi - tsPhi) ;
-  float rDiff = rhR - tsR;
-
-  if ( phiDiff < myPhimax && phiDiff > myPhimin && rDiff < rMax && rDiff > rMin)
+  if ( phiDiff < myPhimax && phiDiff > myPhimin )
    { return std::pair<bool,double>(true,1.) ; }
   else
    { return std::pair<bool,double>(false,0.) ; }


### PR DESCRIPTION
Factor of 3.5 speed up in ecalDrivenElectronSeeds producer.
4x speed up in compatibleSeeds() function in PixelHitMatcher class.
Mostly this comes from using hash tables, some speedup from not using GlobalPoint::phi() all the time and lazy returns.
Timing measurements are from TTBar 25ns@40PU.

No regressions expected.
In local testing of single electron gun and ttbar 25ns, no regressions observed.

@VinInn
