### PR TITLE
APVPhases params read from DB

### DIFF
--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalZeroBiasHI_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalZeroBiasHI_cff.py
@@ -62,7 +62,7 @@ calZeroBiasClusters.Clusterizer = ZeroBiasClusterizer
 
 # Not persistent collections needed by the filters in the AlCaReco DQM
 from DPGAnalysis.SiStripTools.eventwithhistoryproducerfroml1abc_cfi import *
-from DPGAnalysis.SiStripTools.apvcyclephaseproducerfroml1ts2011_cfi import *
+from DPGAnalysis.SiStripTools.apvcyclephaseproducerfroml1tsDB_cfi import *
 
 # SiStripQuality (only to test the different data labels)#
 qualityStatistics = cms.EDAnalyzer("SiStripQualityStatistics",

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalZeroBias_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalZeroBias_cff.py
@@ -56,7 +56,7 @@ calZeroBiasClusters.Clusterizer = ZeroBiasClusterizer
 
 # Not persistent collections needed by the filters in the AlCaReco DQM
 from DPGAnalysis.SiStripTools.eventwithhistoryproducerfroml1abc_cfi import *
-from DPGAnalysis.SiStripTools.apvcyclephaseproducerfroml1ts2011_cfi import *
+from DPGAnalysis.SiStripTools.apvcyclephaseproducerfroml1tsDB_cfi import *
 
 # SiStripQuality (only to test the different data labels)#
 qualityStatistics = cms.EDAnalyzer("SiStripQualityStatistics",

--- a/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_Cosmic_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_Cosmic_cff.py
@@ -177,7 +177,7 @@ SiStripDetInfoFileReade = cms.Service("SiStripDetInfoFileReader")
 from DPGAnalysis.SiStripTools.eventwithhistoryproducerfroml1abc_cfi import *
 
 # APV Phase Producer
-from DPGAnalysis.SiStripTools.apvcyclephaseproducerfroml1ts2011_cfi import *
+from DPGAnalysis.SiStripTools.apvcyclephaseproducerfroml1tsDB_cfi import *
 
 # Sequences 
 SiStripDQMTier0_cosmicTk = cms.Sequence(APVPhases*consecutiveHEs*SiStripMonitorTrack_cosmicTk*MonitorTrackResiduals_cosmicTk*TrackMon_cosmicTk*TrackEffMon_cosmicTk)

--- a/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_cff.py
@@ -116,7 +116,7 @@ SiStripDetInfoFileReade = cms.Service("SiStripDetInfoFileReader")
 from  DPGAnalysis.SiStripTools.eventwithhistoryproducerfroml1abc_cfi import *
 
 # APV Phase Producer
-from DPGAnalysis.SiStripTools.apvcyclephaseproducerfroml1ts2011_cfi import *
+from DPGAnalysis.SiStripTools.apvcyclephaseproducerfroml1tsDB_cfi import *
 
 # temporary patch in order to have BXlumi 
 from RecoLuminosity.LumiProducer.lumiProducer_cff import *

--- a/DQM/SiStripMonitorCluster/test/MonitorCluster_RealData_cfg.py
+++ b/DQM/SiStripMonitorCluster/test/MonitorCluster_RealData_cfg.py
@@ -74,16 +74,17 @@ process.load("DPGAnalysis.SiStripTools.eventwithhistoryproducerfroml1abc_cfi")
 # APV Phase Producer
 #nwe one
 process.load("DPGAnalysis.SiStripTools.apvcyclephaseproducerfroml1ts_cfi")
-APVPhases = cms.EDProducer("APVCyclePhaseProducerFromL1TS",
-                            defaultPartitionNames = cms.vstring("TI",
-                            "TO",
-                            "TP",
-                            "TM"
-                            ),
-                            defaultPhases = cms.vint32(60,60,60,60),
-                            magicOffset = cms.untracked.int32(258),
-                            l1TSCollection = cms.InputTag("scalersRawToDigi"),
-                            )
+from DPGAnalysis.SiStripTools.apvcyclephaseproducerfroml1tsDB_cfi import *
+#APVPhases = cms.EDProducer("APVCyclePhaseProducerFromL1TS",
+#                            defaultPartitionNames = cms.vstring("TI",
+#                            "TO",
+#                            "TP",
+#                            "TM"
+#                            ),
+#                            defaultPhases = cms.vint32(60,60,60,60),
+#                            magicOffset = cms.untracked.int32(258),
+#                            l1TSCollection = cms.InputTag("scalersRawToDigi"),
+#                            )
 
 #--------------------------
 # SiStrip MonitorCluster


### PR DESCRIPTION
Update of the config file for APV cycle phases to read parameters directly from DB. Making use of the development by @venturia in #2910.
