### PR TITLE
Migrate remaining SpecialSeedGenerators to SeedingLayerSetsHits

### DIFF
--- a/RecoTracker/Configuration/python/RecoTrackerBHM_cff.py
+++ b/RecoTracker/Configuration/python/RecoTrackerBHM_cff.py
@@ -6,5 +6,5 @@ from RecoTracker.SpecialSeedGenerators.CombinatorialSeedGeneratorForBeamHalo_cff
 from RecoTracker.CkfPattern.CkfTrackCandidatesBHM_cff import *
 #Final fit
 from RecoTracker.TrackProducer.CTFFinalFitWithMaterialBHM_cff import *
-beamhaloTracksSeq = cms.Sequence(beamhaloTrackerSeeds * beamhaloTrackCandidates * beamhaloTracks)
+beamhaloTracksSeq = cms.Sequence(beamhaloTrackerSeedingLayers * beamhaloTrackerSeeds * beamhaloTrackCandidates * beamhaloTracks)
 

--- a/RecoTracker/Configuration/python/RecoTrackerNotStandard_cff.py
+++ b/RecoTracker/Configuration/python/RecoTrackerNotStandard_cff.py
@@ -40,4 +40,4 @@ regionalCosmicTracks = RecoTracker.TrackProducer.CTFFinalFitWithMaterialP5_cff.c
     src = cms.InputTag( "regionalCosmicCkfTrackCandidates" ),
 )
 # Final Sequence
-regionalCosmicTracksSeq = cms.Sequence( regionalCosmicTrackerSeeds * regionalCosmicCkfTrackCandidates * regionalCosmicTracks )
+regionalCosmicTracksSeq = cms.Sequence( regionalCosmicTrackerSeedingLayers * regionalCosmicTrackerSeeds * regionalCosmicCkfTrackCandidates * regionalCosmicTracks )

--- a/RecoTracker/Configuration/python/RecoTrackerP5_cff.py
+++ b/RecoTracker/Configuration/python/RecoTrackerP5_cff.py
@@ -15,7 +15,7 @@ from RecoTracker.FinalTrackSelectors.CosmicTFFinalTrackSelectorP5_cff import *
 #chi2 set to 40!!
 # CTF
 from RecoTracker.SpecialSeedGenerators.CombinatorialSeedGeneratorForCosmicsP5_cff import *
-from RecoTracker.SpecialSeedGenerators.SimpleCosmicBONSeeder_cfi import *
+from RecoTracker.SpecialSeedGenerators.SimpleCosmicBONSeeder_cff import *
 from RecoTracker.TkSeedGenerator.GlobalCombinedSeeds_cff import *
 combinedP5SeedsForCTF = RecoTracker.TkSeedGenerator.GlobalCombinedSeeds_cfi.globalCombinedSeeds.clone()
 combinedP5SeedsForCTF.seedCollections = cms.VInputTag(
@@ -46,7 +46,8 @@ from RecoTracker.FinalTrackSelectors.CTFFinalTrackSelectorP5_cff import *
 ckfTrackCandidatesP5LHCNavigation    = ckfTrackCandidatesP5.clone(NavigationSchool = cms.string('SimpleNavigationSchool'))
 ctfWithMaterialTracksP5LHCNavigation = ctfWithMaterialTracksCosmics.clone(src = cms.InputTag("ckfTrackCandidatesP5LHCNavigation"))
 
-ctftracksP5 = cms.Sequence(combinatorialcosmicseedinglayersP5+combinatorialcosmicseedfinderP5*simpleCosmicBONSeeds*combinedP5SeedsForCTF*
+ctftracksP5 = cms.Sequence(combinatorialcosmicseedinglayersP5+combinatorialcosmicseedfinderP5*
+                           simpleCosmicBONSeedingLayers*simpleCosmicBONSeeds*combinedP5SeedsForCTF*
                            ckfTrackCandidatesP5*ctfWithMaterialTracksCosmics*ctfWithMaterialTracksP5+
                            ckfTrackCandidatesP5LHCNavigation*ctfWithMaterialTracksP5LHCNavigation)
 

--- a/RecoTracker/Configuration/python/RecoTrackerP5_cff.py
+++ b/RecoTracker/Configuration/python/RecoTrackerP5_cff.py
@@ -46,7 +46,7 @@ from RecoTracker.FinalTrackSelectors.CTFFinalTrackSelectorP5_cff import *
 ckfTrackCandidatesP5LHCNavigation    = ckfTrackCandidatesP5.clone(NavigationSchool = cms.string('SimpleNavigationSchool'))
 ctfWithMaterialTracksP5LHCNavigation = ctfWithMaterialTracksCosmics.clone(src = cms.InputTag("ckfTrackCandidatesP5LHCNavigation"))
 
-ctftracksP5 = cms.Sequence(combinatorialcosmicseedfinderP5*simpleCosmicBONSeeds*combinedP5SeedsForCTF*
+ctftracksP5 = cms.Sequence(combinatorialcosmicseedinglayersP5+combinatorialcosmicseedfinderP5*simpleCosmicBONSeeds*combinedP5SeedsForCTF*
                            ckfTrackCandidatesP5*ctfWithMaterialTracksCosmics*ctfWithMaterialTracksP5+
                            ckfTrackCandidatesP5LHCNavigation*ctfWithMaterialTracksP5LHCNavigation)
 

--- a/RecoTracker/Configuration/python/RecoTrackerTopBottom_cff.py
+++ b/RecoTracker/Configuration/python/RecoTrackerTopBottom_cff.py
@@ -3,7 +3,7 @@ import copy
 
 from RecoLocalTracker.SubCollectionProducers.ClusterSelectorTopBottom_cfi import *
 from RecoLocalTracker.Configuration.RecoLocalTracker_Cosmics_cff import *
-from RecoTracker.SpecialSeedGenerators.CombinatorialSeedGeneratorForCosmicsP5_cff import combinatorialcosmicseedfinderP5
+from RecoTracker.SpecialSeedGenerators.CombinatorialSeedGeneratorForCosmicsP5_cff import combinatorialcosmicseedfinderP5, combinatorialcosmicseedingtripletsP5, combinatorialcosmicseedingpairsTOBP5, combinatorialcosmicseedingpairsTECposP5, combinatorialcosmicseedingpairsTECnegP5
 from RecoTracker.SpecialSeedGenerators.SimpleCosmicBONSeeder_cfi import simpleCosmicBONSeeds
 from RecoTracker.TkSeedGenerator.GlobalCombinedSeeds_cff import globalCombinedSeeds
 from RecoTracker.MeasurementDet.MeasurementTrackerESProducer_cff import MeasurementTracker
@@ -34,40 +34,46 @@ trackerlocalrecoTop = cms.Sequence(((siPixelClustersTop*siPixelRecHitsTop)+(siSt
 trackerlocalrecoBottom = cms.Sequence(((siPixelClustersBottom*siPixelRecHitsBottom)+(siStripClustersBottom*siStripMatchedRecHitsBottom))*topBottomClusterInfoProducerBottom)
 
 ###CKF TOP
+combinatorialcosmicseedingtripletsP5Top = copy.deepcopy(combinatorialcosmicseedingtripletsP5)
+combinatorialcosmicseedingtripletsP5Top.TIB1.matchedRecHits = cms.InputTag("siStripMatchedRecHitsTop","matchedRecHit")
+combinatorialcosmicseedingtripletsP5Top.TIB2.matchedRecHits = cms.InputTag("siStripMatchedRecHitsTop","matchedRecHit")
+combinatorialcosmicseedingtripletsP5Top.TIB3.rphiRecHits = cms.InputTag("siStripMatchedRecHitsTop","rphiRecHit")
+combinatorialcosmicseedingtripletsP5Top.TOB1.matchedRecHits = cms.InputTag("siStripMatchedRecHitsTop","matchedRecHit")
+combinatorialcosmicseedingtripletsP5Top.TOB2.matchedRecHits = cms.InputTag("siStripMatchedRecHitsTop","matchedRecHit")
+combinatorialcosmicseedingtripletsP5Top.TOB3.rphiRecHits = cms.InputTag("siStripMatchedRecHitsTop","rphiRecHit")
+combinatorialcosmicseedingtripletsP5Top.TOB4.rphiRecHits = cms.InputTag("siStripMatchedRecHitsTop","rphiRecHit")
+combinatorialcosmicseedingtripletsP5Top.TOB5.rphiRecHits = cms.InputTag("siStripMatchedRecHitsTop","rphiRecHit")
+combinatorialcosmicseedingtripletsP5Top.TOB6.rphiRecHits = cms.InputTag("siStripMatchedRecHitsTop","rphiRecHit")
+combinatorialcosmicseedingtripletsP5Top.TEC.matchedRecHits = cms.InputTag("siStripMatchedRecHitsTop","matchedRecHit")
+combinatorialcosmicseedingtripletsP5Top.TEC.rphiRecHits = cms.InputTag("siStripMatchedRecHitsTop","rphiRecHit")
+combinatorialcosmicseedingpairsTOBP5Top = copy.deepcopy(combinatorialcosmicseedingpairsTOBP5)
+combinatorialcosmicseedingpairsTOBP5Top.TIB1.matchedRecHits = cms.InputTag("siStripMatchedRecHitsTop","matchedRecHit")
+combinatorialcosmicseedingpairsTOBP5Top.TIB2.matchedRecHits = cms.InputTag("siStripMatchedRecHitsTop","matchedRecHit")
+combinatorialcosmicseedingpairsTOBP5Top.TIB3.rphiRecHits = cms.InputTag("siStripMatchedRecHitsTop","rphiRecHit")
+combinatorialcosmicseedingpairsTOBP5Top.TOB1.matchedRecHits = cms.InputTag("siStripMatchedRecHitsTop","matchedRecHit")
+combinatorialcosmicseedingpairsTOBP5Top.TOB2.matchedRecHits = cms.InputTag("siStripMatchedRecHitsTop","matchedRecHit")
+combinatorialcosmicseedingpairsTOBP5Top.TOB3.rphiRecHits = cms.InputTag("siStripMatchedRecHitsTop","rphiRecHit")
+combinatorialcosmicseedingpairsTOBP5Top.TOB4.rphiRecHits = cms.InputTag("siStripMatchedRecHitsTop","rphiRecHit")
+combinatorialcosmicseedingpairsTOBP5Top.TOB5.rphiRecHits = cms.InputTag("siStripMatchedRecHitsTop","rphiRecHit")
+combinatorialcosmicseedingpairsTOBP5Top.TOB6.rphiRecHits = cms.InputTag("siStripMatchedRecHitsTop","rphiRecHit")
+combinatorialcosmicseedingpairsTOBP5Top.TEC.matchedRecHits = cms.InputTag("siStripMatchedRecHitsTop","matchedRecHit")
+combinatorialcosmicseedingpairsTOBP5Top.TEC.rphiRecHits = cms.InputTag("siStripMatchedRecHitsTop","rphiRecHit")
+combinatorialcosmicseedingpairsTECposP5Top = copy.deepcopy(combinatorialcosmicseedingpairsTECposP5)
+combinatorialcosmicseedingpairsTECposP5Top.TEC.matchedRecHits = cms.InputTag("siStripMatchedRecHitsTop","matchedRecHit")
+combinatorialcosmicseedingpairsTECposP5Top.TEC.rphiRecHits = cms.InputTag("siStripMatchedRecHitsTop","rphiRecHit")
+combinatorialcosmicseedingpairsTECnegP5Top = copy.deepcopy(combinatorialcosmicseedingpairsTECnegP5)
+combinatorialcosmicseedingpairsTECnegP5Top.TEC.matchedRecHits = cms.InputTag("siStripMatchedRecHitsTop","matchedRecHit")
+combinatorialcosmicseedingpairsTECnegP5Top.TEC.rphiRecHits = cms.InputTag("siStripMatchedRecHitsTop","rphiRecHit")
 combinatorialcosmicseedfinderP5Top = copy.deepcopy(combinatorialcosmicseedfinderP5)
 combinatorialcosmicseedfinderP5Top.SeedsFromPositiveY = True
 combinatorialcosmicseedfinderP5Top.SeedsFromNegativeY = False
 combinatorialcosmicseedfinderP5Top.ClusterCollectionLabel = cms.InputTag("siStripClustersTop")
-combinatorialcosmicseedfinderP5Top.OrderedHitsFactoryPSets[0].LayerPSet.TIB1.matchedRecHits = cms.InputTag("siStripMatchedRecHitsTop","matchedRecHit")
-combinatorialcosmicseedfinderP5Top.OrderedHitsFactoryPSets[0].LayerPSet.TIB2.matchedRecHits = cms.InputTag("siStripMatchedRecHitsTop","matchedRecHit")
-combinatorialcosmicseedfinderP5Top.OrderedHitsFactoryPSets[0].LayerPSet.TIB3.rphiRecHits = cms.InputTag("siStripMatchedRecHitsTop","rphiRecHit")
-combinatorialcosmicseedfinderP5Top.OrderedHitsFactoryPSets[0].LayerPSet.TOB1.matchedRecHits = cms.InputTag("siStripMatchedRecHitsTop","matchedRecHit")
-combinatorialcosmicseedfinderP5Top.OrderedHitsFactoryPSets[0].LayerPSet.TOB2.matchedRecHits = cms.InputTag("siStripMatchedRecHitsTop","matchedRecHit")
-combinatorialcosmicseedfinderP5Top.OrderedHitsFactoryPSets[0].LayerPSet.TOB3.rphiRecHits = cms.InputTag("siStripMatchedRecHitsTop","rphiRecHit")
-combinatorialcosmicseedfinderP5Top.OrderedHitsFactoryPSets[0].LayerPSet.TOB4.rphiRecHits = cms.InputTag("siStripMatchedRecHitsTop","rphiRecHit")
-combinatorialcosmicseedfinderP5Top.OrderedHitsFactoryPSets[0].LayerPSet.TOB5.rphiRecHits = cms.InputTag("siStripMatchedRecHitsTop","rphiRecHit")
-combinatorialcosmicseedfinderP5Top.OrderedHitsFactoryPSets[0].LayerPSet.TOB6.rphiRecHits = cms.InputTag("siStripMatchedRecHitsTop","rphiRecHit")
-combinatorialcosmicseedfinderP5Top.OrderedHitsFactoryPSets[0].LayerPSet.TEC.matchedRecHits = cms.InputTag("siStripMatchedRecHitsTop","matchedRecHit")
-combinatorialcosmicseedfinderP5Top.OrderedHitsFactoryPSets[0].LayerPSet.TEC.rphiRecHits = cms.InputTag("siStripMatchedRecHitsTop","rphiRecHit")
-combinatorialcosmicseedfinderP5Top.OrderedHitsFactoryPSets[1].LayerPSet.TIB1.matchedRecHits = cms.InputTag("siStripMatchedRecHitsTop","matchedRecHit")
-combinatorialcosmicseedfinderP5Top.OrderedHitsFactoryPSets[1].LayerPSet.TIB2.matchedRecHits = cms.InputTag("siStripMatchedRecHitsTop","matchedRecHit")
-combinatorialcosmicseedfinderP5Top.OrderedHitsFactoryPSets[1].LayerPSet.TIB3.rphiRecHits = cms.InputTag("siStripMatchedRecHitsTop","rphiRecHit")
-combinatorialcosmicseedfinderP5Top.OrderedHitsFactoryPSets[1].LayerPSet.TOB1.matchedRecHits = cms.InputTag("siStripMatchedRecHitsTop","matchedRecHit")
-combinatorialcosmicseedfinderP5Top.OrderedHitsFactoryPSets[1].LayerPSet.TOB2.matchedRecHits = cms.InputTag("siStripMatchedRecHitsTop","matchedRecHit")
-combinatorialcosmicseedfinderP5Top.OrderedHitsFactoryPSets[1].LayerPSet.TOB3.rphiRecHits = cms.InputTag("siStripMatchedRecHitsTop","rphiRecHit")
-combinatorialcosmicseedfinderP5Top.OrderedHitsFactoryPSets[1].LayerPSet.TOB4.rphiRecHits = cms.InputTag("siStripMatchedRecHitsTop","rphiRecHit")
-combinatorialcosmicseedfinderP5Top.OrderedHitsFactoryPSets[1].LayerPSet.TOB5.rphiRecHits = cms.InputTag("siStripMatchedRecHitsTop","rphiRecHit")
-combinatorialcosmicseedfinderP5Top.OrderedHitsFactoryPSets[1].LayerPSet.TOB6.rphiRecHits = cms.InputTag("siStripMatchedRecHitsTop","rphiRecHit")
-combinatorialcosmicseedfinderP5Top.OrderedHitsFactoryPSets[1].LayerPSet.TEC.matchedRecHits = cms.InputTag("siStripMatchedRecHitsTop","matchedRecHit")
-combinatorialcosmicseedfinderP5Top.OrderedHitsFactoryPSets[1].LayerPSet.TEC.rphiRecHits = cms.InputTag("siStripMatchedRecHitsTop","rphiRecHit")
-combinatorialcosmicseedfinderP5Top.OrderedHitsFactoryPSets[2].LayerPSet.TEC.matchedRecHits = cms.InputTag("siStripMatchedRecHitsTop","matchedRecHit")
-combinatorialcosmicseedfinderP5Top.OrderedHitsFactoryPSets[2].LayerPSet.TEC.rphiRecHits = cms.InputTag("siStripMatchedRecHitsTop","rphiRecHit")
-combinatorialcosmicseedfinderP5Top.OrderedHitsFactoryPSets[3].LayerPSet.TEC.matchedRecHits = cms.InputTag("siStripMatchedRecHitsTop","matchedRecHit")
-combinatorialcosmicseedfinderP5Top.OrderedHitsFactoryPSets[3].LayerPSet.TEC.rphiRecHits = cms.InputTag("siStripMatchedRecHitsTop","rphiRecHit")
-combinatorialcosmicseedfinderP5Top.OrderedHitsFactoryPSets[4].LayerPSet.TEC.matchedRecHits = cms.InputTag("siStripMatchedRecHitsTop","matchedRecHit")
-combinatorialcosmicseedfinderP5Top.OrderedHitsFactoryPSets[4].LayerPSet.TEC.rphiRecHits = cms.InputTag("siStripMatchedRecHitsTop","rphiRecHit")
-combinatorialcosmicseedfinderP5Top.OrderedHitsFactoryPSets[5].LayerPSet.TEC.matchedRecHits = cms.InputTag("siStripMatchedRecHitsTop","matchedRecHit")
-combinatorialcosmicseedfinderP5Top.OrderedHitsFactoryPSets[5].LayerPSet.TEC.rphiRecHits = cms.InputTag("siStripMatchedRecHitsTop","rphiRecHit")
+combinatorialcosmicseedfinderP5Top.OrderedHitsFactoryPSets[0].LayerSrc = "combinatorialcosmicseedingtripletsP5Top"
+combinatorialcosmicseedfinderP5Top.OrderedHitsFactoryPSets[1].LayerSrc = "combinatorialcosmicseedingpairsTOBP5Top"
+combinatorialcosmicseedfinderP5Top.OrderedHitsFactoryPSets[2].LayerSrc = "combinatorialcosmicseedingpairsTECposP5Top"
+combinatorialcosmicseedfinderP5Top.OrderedHitsFactoryPSets[3].LayerSrc = "combinatorialcosmicseedingpairsTECposP5Top"
+combinatorialcosmicseedfinderP5Top.OrderedHitsFactoryPSets[4].LayerSrc = "combinatorialcosmicseedingpairsTECnegP5Top"
+combinatorialcosmicseedfinderP5Top.OrderedHitsFactoryPSets[5].LayerSrc = "combinatorialcosmicseedingpairsTECnegP5Top"
 combinatorialcosmicseedfinderP5Top.MaxNumberOfCosmicClusters = 150
 simpleCosmicBONSeedsTop = copy.deepcopy(simpleCosmicBONSeeds)
 simpleCosmicBONSeedsTop.PositiveYOnly = True
@@ -106,12 +112,44 @@ ctfWithMaterialTracksP5Top = copy.deepcopy(ctfWithMaterialTracksCosmics)
 ctfWithMaterialTracksP5Top.src    = 'ckfTrackCandidatesP5Top'
 ctfWithMaterialTracksP5Top.Fitter = 'FittingSmootherRKP5'
 ctfWithMaterialTracksP5Top.clusterRemovalInfo = "topBottomClusterInfoProducerTop"
-ctftracksP5Top = cms.Sequence(combinatorialcosmicseedfinderP5Top*simpleCosmicBONSeedsTop*
+ctftracksP5Top = cms.Sequence(combinatorialcosmicseedingtripletsP5Top*combinatorialcosmicseedingpairsTOBP5Top*
+                              combinatorialcosmicseedingpairsTECposP5Top*combinatorialcosmicseedingpairsTECnegP5Top*
+                              combinatorialcosmicseedfinderP5Top*simpleCosmicBONSeedsTop*
                                        combinedP5SeedsForCTFTop*ckfTrackCandidatesP5Top*
                                        ctfWithMaterialTracksP5Top)
 
 
 ###CKF BOTTOM
+combinatorialcosmicseedingtripletsP5Bottom = copy.deepcopy(combinatorialcosmicseedingtripletsP5)
+combinatorialcosmicseedingtripletsP5Bottom.TIB1.matchedRecHits = cms.InputTag("siStripMatchedRecHitsBottom","matchedRecHit")
+combinatorialcosmicseedingtripletsP5Bottom.TIB2.matchedRecHits = cms.InputTag("siStripMatchedRecHitsBottom","matchedRecHit")
+combinatorialcosmicseedingtripletsP5Bottom.TIB3.rphiRecHits = cms.InputTag("siStripMatchedRecHitsBottom","rphiRecHit")
+combinatorialcosmicseedingtripletsP5Bottom.TOB1.matchedRecHits = cms.InputTag("siStripMatchedRecHitsBottom","matchedRecHit")
+combinatorialcosmicseedingtripletsP5Bottom.TOB2.matchedRecHits = cms.InputTag("siStripMatchedRecHitsBottom","matchedRecHit")
+combinatorialcosmicseedingtripletsP5Bottom.TOB3.rphiRecHits = cms.InputTag("siStripMatchedRecHitsBottom","rphiRecHit")
+combinatorialcosmicseedingtripletsP5Bottom.TOB4.rphiRecHits = cms.InputTag("siStripMatchedRecHitsBottom","rphiRecHit")
+combinatorialcosmicseedingtripletsP5Bottom.TOB5.rphiRecHits = cms.InputTag("siStripMatchedRecHitsBottom","rphiRecHit")
+combinatorialcosmicseedingtripletsP5Bottom.TOB6.rphiRecHits = cms.InputTag("siStripMatchedRecHitsBottom","rphiRecHit")
+combinatorialcosmicseedingtripletsP5Bottom.TEC.matchedRecHits = cms.InputTag("siStripMatchedRecHitsBottom","matchedRecHit")
+combinatorialcosmicseedingtripletsP5Bottom.TEC.rphiRecHits = cms.InputTag("siStripMatchedRecHitsBottom","rphiRecHit")
+combinatorialcosmicseedingpairsTOBP5Bottom = copy.deepcopy(combinatorialcosmicseedingpairsTOBP5)
+combinatorialcosmicseedingpairsTOBP5Bottom.TIB1.matchedRecHits = cms.InputTag("siStripMatchedRecHitsBottom","matchedRecHit")
+combinatorialcosmicseedingpairsTOBP5Bottom.TIB2.matchedRecHits = cms.InputTag("siStripMatchedRecHitsBottom","matchedRecHit")
+combinatorialcosmicseedingpairsTOBP5Bottom.TIB3.rphiRecHits = cms.InputTag("siStripMatchedRecHitsBottom","rphiRecHit")
+combinatorialcosmicseedingpairsTOBP5Bottom.TOB1.matchedRecHits = cms.InputTag("siStripMatchedRecHitsBottom","matchedRecHit")
+combinatorialcosmicseedingpairsTOBP5Bottom.TOB2.matchedRecHits = cms.InputTag("siStripMatchedRecHitsBottom","matchedRecHit")
+combinatorialcosmicseedingpairsTOBP5Bottom.TOB3.rphiRecHits = cms.InputTag("siStripMatchedRecHitsBottom","rphiRecHit")
+combinatorialcosmicseedingpairsTOBP5Bottom.TOB4.rphiRecHits = cms.InputTag("siStripMatchedRecHitsBottom","rphiRecHit")
+combinatorialcosmicseedingpairsTOBP5Bottom.TOB5.rphiRecHits = cms.InputTag("siStripMatchedRecHitsBottom","rphiRecHit")
+combinatorialcosmicseedingpairsTOBP5Bottom.TOB6.rphiRecHits = cms.InputTag("siStripMatchedRecHitsBottom","rphiRecHit")
+combinatorialcosmicseedingpairsTOBP5Bottom.TEC.matchedRecHits = cms.InputTag("siStripMatchedRecHitsBottom","matchedRecHit")
+combinatorialcosmicseedingpairsTOBP5Bottom.TEC.rphiRecHits = cms.InputTag("siStripMatchedRecHitsBottom","rphiRecHit")
+combinatorialcosmicseedingpairsTECposP5Bottom = copy.deepcopy(combinatorialcosmicseedingpairsTECposP5)
+combinatorialcosmicseedingpairsTECposP5Bottom.TEC.matchedRecHits = cms.InputTag("siStripMatchedRecHitsBottom","matchedRecHit")
+combinatorialcosmicseedingpairsTECposP5Bottom.TEC.rphiRecHits = cms.InputTag("siStripMatchedRecHitsBottom","rphiRecHit")
+combinatorialcosmicseedingpairsTECnegP5Bottom = copy.deepcopy(combinatorialcosmicseedingpairsTECnegP5)
+combinatorialcosmicseedingpairsTECnegP5Bottom.TEC.matchedRecHits = cms.InputTag("siStripMatchedRecHitsBottom","matchedRecHit")
+combinatorialcosmicseedingpairsTECnegP5Bottom.TEC.rphiRecHits = cms.InputTag("siStripMatchedRecHitsBottom","rphiRecHit")
 combinatorialcosmicseedfinderP5Bottom = copy.deepcopy(combinatorialcosmicseedfinderP5)
 combinatorialcosmicseedfinderP5Bottom.SeedsFromPositiveY = False
 combinatorialcosmicseedfinderP5Bottom.SeedsFromNegativeY = True
@@ -122,36 +160,12 @@ combinatorialcosmicseedfinderP5Bottom.OrderedHitsFactoryPSets[3].PropagationDire
 combinatorialcosmicseedfinderP5Bottom.OrderedHitsFactoryPSets[4].PropagationDirection = cms.string('oppositeToMomentum')
 combinatorialcosmicseedfinderP5Bottom.OrderedHitsFactoryPSets[5].PropagationDirection = cms.string('oppositeToMomentum')
 combinatorialcosmicseedfinderP5Bottom.ClusterCollectionLabel = cms.InputTag("siStripClustersBottom")
-combinatorialcosmicseedfinderP5Bottom.OrderedHitsFactoryPSets[0].LayerPSet.TIB1.matchedRecHits = cms.InputTag("siStripMatchedRecHitsBottom","matchedRecHit")
-combinatorialcosmicseedfinderP5Bottom.OrderedHitsFactoryPSets[0].LayerPSet.TIB2.matchedRecHits = cms.InputTag("siStripMatchedRecHitsBottom","matchedRecHit")
-combinatorialcosmicseedfinderP5Bottom.OrderedHitsFactoryPSets[0].LayerPSet.TIB3.rphiRecHits = cms.InputTag("siStripMatchedRecHitsBottom","rphiRecHit")
-combinatorialcosmicseedfinderP5Bottom.OrderedHitsFactoryPSets[0].LayerPSet.TOB1.matchedRecHits = cms.InputTag("siStripMatchedRecHitsBottom","matchedRecHit")
-combinatorialcosmicseedfinderP5Bottom.OrderedHitsFactoryPSets[0].LayerPSet.TOB2.matchedRecHits = cms.InputTag("siStripMatchedRecHitsBottom","matchedRecHit")
-combinatorialcosmicseedfinderP5Bottom.OrderedHitsFactoryPSets[0].LayerPSet.TOB3.rphiRecHits = cms.InputTag("siStripMatchedRecHitsBottom","rphiRecHit")
-combinatorialcosmicseedfinderP5Bottom.OrderedHitsFactoryPSets[0].LayerPSet.TOB4.rphiRecHits = cms.InputTag("siStripMatchedRecHitsBottom","rphiRecHit")
-combinatorialcosmicseedfinderP5Bottom.OrderedHitsFactoryPSets[0].LayerPSet.TOB5.rphiRecHits = cms.InputTag("siStripMatchedRecHitsBottom","rphiRecHit")
-combinatorialcosmicseedfinderP5Bottom.OrderedHitsFactoryPSets[0].LayerPSet.TOB6.rphiRecHits = cms.InputTag("siStripMatchedRecHitsBottom","rphiRecHit")
-combinatorialcosmicseedfinderP5Bottom.OrderedHitsFactoryPSets[0].LayerPSet.TEC.matchedRecHits = cms.InputTag("siStripMatchedRecHitsBottom","matchedRecHit")
-combinatorialcosmicseedfinderP5Bottom.OrderedHitsFactoryPSets[0].LayerPSet.TEC.rphiRecHits = cms.InputTag("siStripMatchedRecHitsBottom","rphiRecHit")
-combinatorialcosmicseedfinderP5Bottom.OrderedHitsFactoryPSets[1].LayerPSet.TIB1.matchedRecHits = cms.InputTag("siStripMatchedRecHitsBottom","matchedRecHit")
-combinatorialcosmicseedfinderP5Bottom.OrderedHitsFactoryPSets[1].LayerPSet.TIB2.matchedRecHits = cms.InputTag("siStripMatchedRecHitsBottom","matchedRecHit")
-combinatorialcosmicseedfinderP5Bottom.OrderedHitsFactoryPSets[1].LayerPSet.TIB3.rphiRecHits = cms.InputTag("siStripMatchedRecHitsBottom","rphiRecHit")
-combinatorialcosmicseedfinderP5Bottom.OrderedHitsFactoryPSets[1].LayerPSet.TOB1.matchedRecHits = cms.InputTag("siStripMatchedRecHitsBottom","matchedRecHit")
-combinatorialcosmicseedfinderP5Bottom.OrderedHitsFactoryPSets[1].LayerPSet.TOB2.matchedRecHits = cms.InputTag("siStripMatchedRecHitsBottom","matchedRecHit")
-combinatorialcosmicseedfinderP5Bottom.OrderedHitsFactoryPSets[1].LayerPSet.TOB3.rphiRecHits = cms.InputTag("siStripMatchedRecHitsBottom","rphiRecHit")
-combinatorialcosmicseedfinderP5Bottom.OrderedHitsFactoryPSets[1].LayerPSet.TOB4.rphiRecHits = cms.InputTag("siStripMatchedRecHitsBottom","rphiRecHit")
-combinatorialcosmicseedfinderP5Bottom.OrderedHitsFactoryPSets[1].LayerPSet.TOB5.rphiRecHits = cms.InputTag("siStripMatchedRecHitsBottom","rphiRecHit")
-combinatorialcosmicseedfinderP5Bottom.OrderedHitsFactoryPSets[1].LayerPSet.TOB6.rphiRecHits = cms.InputTag("siStripMatchedRecHitsBottom","rphiRecHit")
-combinatorialcosmicseedfinderP5Bottom.OrderedHitsFactoryPSets[1].LayerPSet.TEC.matchedRecHits = cms.InputTag("siStripMatchedRecHitsBottom","matchedRecHit")
-combinatorialcosmicseedfinderP5Bottom.OrderedHitsFactoryPSets[1].LayerPSet.TEC.rphiRecHits = cms.InputTag("siStripMatchedRecHitsBottom","rphiRecHit")
-combinatorialcosmicseedfinderP5Bottom.OrderedHitsFactoryPSets[2].LayerPSet.TEC.matchedRecHits = cms.InputTag("siStripMatchedRecHitsBottom","matchedRecHit")
-combinatorialcosmicseedfinderP5Bottom.OrderedHitsFactoryPSets[2].LayerPSet.TEC.rphiRecHits = cms.InputTag("siStripMatchedRecHitsBottom","rphiRecHit")
-combinatorialcosmicseedfinderP5Bottom.OrderedHitsFactoryPSets[3].LayerPSet.TEC.matchedRecHits = cms.InputTag("siStripMatchedRecHitsBottom","matchedRecHit")
-combinatorialcosmicseedfinderP5Bottom.OrderedHitsFactoryPSets[3].LayerPSet.TEC.rphiRecHits = cms.InputTag("siStripMatchedRecHitsBottom","rphiRecHit")
-combinatorialcosmicseedfinderP5Bottom.OrderedHitsFactoryPSets[4].LayerPSet.TEC.matchedRecHits = cms.InputTag("siStripMatchedRecHitsBottom","matchedRecHit")
-combinatorialcosmicseedfinderP5Bottom.OrderedHitsFactoryPSets[4].LayerPSet.TEC.rphiRecHits = cms.InputTag("siStripMatchedRecHitsBottom","rphiRecHit")
-combinatorialcosmicseedfinderP5Bottom.OrderedHitsFactoryPSets[5].LayerPSet.TEC.matchedRecHits = cms.InputTag("siStripMatchedRecHitsBottom","matchedRecHit")
-combinatorialcosmicseedfinderP5Bottom.OrderedHitsFactoryPSets[5].LayerPSet.TEC.rphiRecHits = cms.InputTag("siStripMatchedRecHitsBottom","rphiRecHit")
+combinatorialcosmicseedfinderP5Bottom.OrderedHitsFactoryPSets[0].LayerSrc = "combinatorialcosmicseedingtripletsP5Bottom"
+combinatorialcosmicseedfinderP5Bottom.OrderedHitsFactoryPSets[1].LayerSrc = "combinatorialcosmicseedingpairsTOBP5Bottom"
+combinatorialcosmicseedfinderP5Bottom.OrderedHitsFactoryPSets[2].LayerSrc = "combinatorialcosmicseedingpairsTECposP5Bottom"
+combinatorialcosmicseedfinderP5Bottom.OrderedHitsFactoryPSets[3].LayerSrc = "combinatorialcosmicseedingpairsTECposP5Bottom"
+combinatorialcosmicseedfinderP5Bottom.OrderedHitsFactoryPSets[4].LayerSrc = "combinatorialcosmicseedingpairsTECnegP5Bottom"
+combinatorialcosmicseedfinderP5Bottom.OrderedHitsFactoryPSets[5].LayerSrc = "combinatorialcosmicseedingpairsTECnegP5Bottom"
 combinatorialcosmicseedfinderP5Bottom.MaxNumberOfCosmicClusters = 150
 simpleCosmicBONSeedsBottom = copy.deepcopy(simpleCosmicBONSeeds)
 simpleCosmicBONSeedsBottom.PositiveYOnly = False
@@ -190,7 +204,9 @@ ctfWithMaterialTracksP5Bottom = copy.deepcopy(ctfWithMaterialTracksCosmics)
 ctfWithMaterialTracksP5Bottom.src    = 'ckfTrackCandidatesP5Bottom'
 ctfWithMaterialTracksP5Bottom.Fitter = 'FittingSmootherRKP5'
 ctfWithMaterialTracksP5Bottom.clusterRemovalInfo = "topBottomClusterInfoProducerBottom"
-ctftracksP5Bottom = cms.Sequence(combinatorialcosmicseedfinderP5Bottom*simpleCosmicBONSeedsBottom*
+ctftracksP5Bottom = cms.Sequence(combinatorialcosmicseedingtripletsP5Bottom*combinatorialcosmicseedingpairsTOBP5Bottom*
+                                 combinatorialcosmicseedingpairsTECposP5Bottom*combinatorialcosmicseedingpairsTECnegP5Bottom*
+                                 combinatorialcosmicseedfinderP5Bottom*simpleCosmicBONSeedsBottom*
                                        combinedP5SeedsForCTFBottom*ckfTrackCandidatesP5Bottom*
                                        ctfWithMaterialTracksP5Bottom)
 

--- a/RecoTracker/Configuration/python/RecoTrackerTopBottom_cff.py
+++ b/RecoTracker/Configuration/python/RecoTrackerTopBottom_cff.py
@@ -4,7 +4,7 @@ import copy
 from RecoLocalTracker.SubCollectionProducers.ClusterSelectorTopBottom_cfi import *
 from RecoLocalTracker.Configuration.RecoLocalTracker_Cosmics_cff import *
 from RecoTracker.SpecialSeedGenerators.CombinatorialSeedGeneratorForCosmicsP5_cff import combinatorialcosmicseedfinderP5, combinatorialcosmicseedingtripletsP5, combinatorialcosmicseedingpairsTOBP5, combinatorialcosmicseedingpairsTECposP5, combinatorialcosmicseedingpairsTECnegP5
-from RecoTracker.SpecialSeedGenerators.SimpleCosmicBONSeeder_cfi import simpleCosmicBONSeeds
+from RecoTracker.SpecialSeedGenerators.SimpleCosmicBONSeeder_cff import simpleCosmicBONSeeds, simpleCosmicBONSeedingLayers
 from RecoTracker.TkSeedGenerator.GlobalCombinedSeeds_cff import globalCombinedSeeds
 from RecoTracker.MeasurementDet.MeasurementTrackerESProducer_cff import MeasurementTracker
 from RecoTracker.CkfPattern.CkfTrackCandidatesP5_cff import GroupedCkfTrajectoryBuilderP5
@@ -75,21 +75,23 @@ combinatorialcosmicseedfinderP5Top.OrderedHitsFactoryPSets[3].LayerSrc = "combin
 combinatorialcosmicseedfinderP5Top.OrderedHitsFactoryPSets[4].LayerSrc = "combinatorialcosmicseedingpairsTECnegP5Top"
 combinatorialcosmicseedfinderP5Top.OrderedHitsFactoryPSets[5].LayerSrc = "combinatorialcosmicseedingpairsTECnegP5Top"
 combinatorialcosmicseedfinderP5Top.MaxNumberOfCosmicClusters = 150
+simpleCosmicBONSeedingLayersTop = copy.deepcopy(simpleCosmicBONSeedingLayers)
+simpleCosmicBONSeedingLayersTop.TIB1.matchedRecHits = cms.InputTag("siStripMatchedRecHitsTop","matchedRecHit")
+simpleCosmicBONSeedingLayersTop.TIB2.matchedRecHits = cms.InputTag("siStripMatchedRecHitsTop","matchedRecHit")
+simpleCosmicBONSeedingLayersTop.TIB3.rphiRecHits = cms.InputTag("siStripMatchedRecHitsTop","rphiRecHit")
+simpleCosmicBONSeedingLayersTop.TOB1.matchedRecHits = cms.InputTag("siStripMatchedRecHitsTop","matchedRecHit")
+simpleCosmicBONSeedingLayersTop.TOB2.matchedRecHits = cms.InputTag("siStripMatchedRecHitsTop","matchedRecHit")
+simpleCosmicBONSeedingLayersTop.TOB3.rphiRecHits = cms.InputTag("siStripMatchedRecHitsTop","rphiRecHit")
+simpleCosmicBONSeedingLayersTop.TOB4.rphiRecHits = cms.InputTag("siStripMatchedRecHitsTop","rphiRecHit")
+simpleCosmicBONSeedingLayersTop.TOB5.rphiRecHits = cms.InputTag("siStripMatchedRecHitsTop","rphiRecHit")
+simpleCosmicBONSeedingLayersTop.TOB6.rphiRecHits = cms.InputTag("siStripMatchedRecHitsTop","rphiRecHit")
+simpleCosmicBONSeedingLayersTop.TEC.matchedRecHits = cms.InputTag("siStripMatchedRecHitsTop","matchedRecHit")
+simpleCosmicBONSeedingLayersTop.TEC.rphiRecHits = cms.InputTag("siStripMatchedRecHitsTop","rphiRecHit")
 simpleCosmicBONSeedsTop = copy.deepcopy(simpleCosmicBONSeeds)
 simpleCosmicBONSeedsTop.PositiveYOnly = True
 simpleCosmicBONSeedsTop.NegativeYOnly = False
 simpleCosmicBONSeedsTop.ClusterCheckPSet.ClusterCollectionLabel = cms.InputTag("siStripClustersTop")
-simpleCosmicBONSeedsTop.TripletsPSet.TIB1.matchedRecHits = cms.InputTag("siStripMatchedRecHitsTop","matchedRecHit")
-simpleCosmicBONSeedsTop.TripletsPSet.TIB2.matchedRecHits = cms.InputTag("siStripMatchedRecHitsTop","matchedRecHit")
-simpleCosmicBONSeedsTop.TripletsPSet.TIB3.rphiRecHits = cms.InputTag("siStripMatchedRecHitsTop","rphiRecHit")
-simpleCosmicBONSeedsTop.TripletsPSet.TOB1.matchedRecHits = cms.InputTag("siStripMatchedRecHitsTop","matchedRecHit")
-simpleCosmicBONSeedsTop.TripletsPSet.TOB2.matchedRecHits = cms.InputTag("siStripMatchedRecHitsTop","matchedRecHit")
-simpleCosmicBONSeedsTop.TripletsPSet.TOB3.rphiRecHits = cms.InputTag("siStripMatchedRecHitsTop","rphiRecHit")
-simpleCosmicBONSeedsTop.TripletsPSet.TOB4.rphiRecHits = cms.InputTag("siStripMatchedRecHitsTop","rphiRecHit")
-simpleCosmicBONSeedsTop.TripletsPSet.TOB5.rphiRecHits = cms.InputTag("siStripMatchedRecHitsTop","rphiRecHit")
-simpleCosmicBONSeedsTop.TripletsPSet.TOB6.rphiRecHits = cms.InputTag("siStripMatchedRecHitsTop","rphiRecHit")
-simpleCosmicBONSeedsTop.TripletsPSet.TEC.matchedRecHits = cms.InputTag("siStripMatchedRecHitsTop","matchedRecHit")
-simpleCosmicBONSeedsTop.TripletsPSet.TEC.rphiRecHits = cms.InputTag("siStripMatchedRecHitsTop","rphiRecHit")
+simpleCosmicBONSeedsTop.TripletsSrc = "simpleCosmicBONSeedingLayersTop"
 simpleCosmicBONSeedsTop.ClusterCheckPSet.MaxNumberOfCosmicClusters = 150
 combinedP5SeedsForCTFTop = globalCombinedSeeds.clone(
 seedCollections = cms.VInputTag(cms.InputTag('combinatorialcosmicseedfinderP5Top'),cms.InputTag('simpleCosmicBONSeedsTop'))
@@ -114,7 +116,7 @@ ctfWithMaterialTracksP5Top.Fitter = 'FittingSmootherRKP5'
 ctfWithMaterialTracksP5Top.clusterRemovalInfo = "topBottomClusterInfoProducerTop"
 ctftracksP5Top = cms.Sequence(combinatorialcosmicseedingtripletsP5Top*combinatorialcosmicseedingpairsTOBP5Top*
                               combinatorialcosmicseedingpairsTECposP5Top*combinatorialcosmicseedingpairsTECnegP5Top*
-                              combinatorialcosmicseedfinderP5Top*simpleCosmicBONSeedsTop*
+                              combinatorialcosmicseedfinderP5Top*simpleCosmicBONSeedingLayersTop*simpleCosmicBONSeedsTop*
                                        combinedP5SeedsForCTFTop*ckfTrackCandidatesP5Top*
                                        ctfWithMaterialTracksP5Top)
 
@@ -167,21 +169,23 @@ combinatorialcosmicseedfinderP5Bottom.OrderedHitsFactoryPSets[3].LayerSrc = "com
 combinatorialcosmicseedfinderP5Bottom.OrderedHitsFactoryPSets[4].LayerSrc = "combinatorialcosmicseedingpairsTECnegP5Bottom"
 combinatorialcosmicseedfinderP5Bottom.OrderedHitsFactoryPSets[5].LayerSrc = "combinatorialcosmicseedingpairsTECnegP5Bottom"
 combinatorialcosmicseedfinderP5Bottom.MaxNumberOfCosmicClusters = 150
+simpleCosmicBONSeedingLayersBottom = copy.deepcopy(simpleCosmicBONSeedingLayers)
+simpleCosmicBONSeedingLayersBottom.TIB1.matchedRecHits = cms.InputTag("siStripMatchedRecHitsBottom","matchedRecHit")
+simpleCosmicBONSeedingLayersBottom.TIB2.matchedRecHits = cms.InputTag("siStripMatchedRecHitsBottom","matchedRecHit")
+simpleCosmicBONSeedingLayersBottom.TIB3.rphiRecHits = cms.InputTag("siStripMatchedRecHitsBottom","rphiRecHit")
+simpleCosmicBONSeedingLayersBottom.TOB1.matchedRecHits = cms.InputTag("siStripMatchedRecHitsBottom","matchedRecHit")
+simpleCosmicBONSeedingLayersBottom.TOB2.matchedRecHits = cms.InputTag("siStripMatchedRecHitsBottom","matchedRecHit")
+simpleCosmicBONSeedingLayersBottom.TOB3.rphiRecHits = cms.InputTag("siStripMatchedRecHitsBottom","rphiRecHit")
+simpleCosmicBONSeedingLayersBottom.TOB4.rphiRecHits = cms.InputTag("siStripMatchedRecHitsBottom","rphiRecHit")
+simpleCosmicBONSeedingLayersBottom.TOB5.rphiRecHits = cms.InputTag("siStripMatchedRecHitsBottom","rphiRecHit")
+simpleCosmicBONSeedingLayersBottom.TOB6.rphiRecHits = cms.InputTag("siStripMatchedRecHitsBottom","rphiRecHit")
+simpleCosmicBONSeedingLayersBottom.TEC.matchedRecHits = cms.InputTag("siStripMatchedRecHitsBottom","matchedRecHit")
+simpleCosmicBONSeedingLayersBottom.TEC.rphiRecHits = cms.InputTag("siStripMatchedRecHitsBottom","rphiRecHit")
 simpleCosmicBONSeedsBottom = copy.deepcopy(simpleCosmicBONSeeds)
 simpleCosmicBONSeedsBottom.PositiveYOnly = False
 simpleCosmicBONSeedsBottom.NegativeYOnly = True
 simpleCosmicBONSeedsBottom.ClusterCheckPSet.ClusterCollectionLabel = cms.InputTag("siStripClustersBottom")
-simpleCosmicBONSeedsBottom.TripletsPSet.TIB1.matchedRecHits = cms.InputTag("siStripMatchedRecHitsBottom","matchedRecHit")
-simpleCosmicBONSeedsBottom.TripletsPSet.TIB2.matchedRecHits = cms.InputTag("siStripMatchedRecHitsBottom","matchedRecHit")
-simpleCosmicBONSeedsBottom.TripletsPSet.TIB3.rphiRecHits = cms.InputTag("siStripMatchedRecHitsBottom","rphiRecHit")
-simpleCosmicBONSeedsBottom.TripletsPSet.TOB1.matchedRecHits = cms.InputTag("siStripMatchedRecHitsBottom","matchedRecHit")
-simpleCosmicBONSeedsBottom.TripletsPSet.TOB2.matchedRecHits = cms.InputTag("siStripMatchedRecHitsBottom","matchedRecHit")
-simpleCosmicBONSeedsBottom.TripletsPSet.TOB3.rphiRecHits = cms.InputTag("siStripMatchedRecHitsBottom","rphiRecHit")
-simpleCosmicBONSeedsBottom.TripletsPSet.TOB4.rphiRecHits = cms.InputTag("siStripMatchedRecHitsBottom","rphiRecHit")
-simpleCosmicBONSeedsBottom.TripletsPSet.TOB5.rphiRecHits = cms.InputTag("siStripMatchedRecHitsBottom","rphiRecHit")
-simpleCosmicBONSeedsBottom.TripletsPSet.TOB6.rphiRecHits = cms.InputTag("siStripMatchedRecHitsBottom","rphiRecHit")
-simpleCosmicBONSeedsBottom.TripletsPSet.TEC.matchedRecHits = cms.InputTag("siStripMatchedRecHitsBottom","matchedRecHit")
-simpleCosmicBONSeedsBottom.TripletsPSet.TEC.rphiRecHits = cms.InputTag("siStripMatchedRecHitsBottom","rphiRecHit")
+simpleCosmicBONSeedsBottom.TripletsSrc = "simpleCosmicBONSeedingLayersBottom"
 simpleCosmicBONSeedsBottom.ClusterCheckPSet.MaxNumberOfCosmicClusters = 150
 combinedP5SeedsForCTFBottom = globalCombinedSeeds.clone(
 seedCollections = cms.VInputTag(cms.InputTag('combinatorialcosmicseedfinderP5Bottom'),cms.InputTag('simpleCosmicBONSeedsBottom'))
@@ -206,7 +210,7 @@ ctfWithMaterialTracksP5Bottom.Fitter = 'FittingSmootherRKP5'
 ctfWithMaterialTracksP5Bottom.clusterRemovalInfo = "topBottomClusterInfoProducerBottom"
 ctftracksP5Bottom = cms.Sequence(combinatorialcosmicseedingtripletsP5Bottom*combinatorialcosmicseedingpairsTOBP5Bottom*
                                  combinatorialcosmicseedingpairsTECposP5Bottom*combinatorialcosmicseedingpairsTECnegP5Bottom*
-                                 combinatorialcosmicseedfinderP5Bottom*simpleCosmicBONSeedsBottom*
+                                 combinatorialcosmicseedfinderP5Bottom*simpleCosmicBONSeedingLayersBottom*simpleCosmicBONSeedsBottom*
                                        combinedP5SeedsForCTFBottom*ckfTrackCandidatesP5Bottom*
                                        ctfWithMaterialTracksP5Bottom)
 

--- a/RecoTracker/SpecialSeedGenerators/interface/BeamHaloPairGenerator.h
+++ b/RecoTracker/SpecialSeedGenerators/interface/BeamHaloPairGenerator.h
@@ -4,13 +4,14 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
 
 #include "RecoTracker/TkTrackingRegions/interface/OrderedHitsGenerator.h"
 #include "RecoTracker/TkTrackingRegions/interface/TrackingRegion.h"
 #include "RecoTracker/TkHitPairs/interface/OrderedHitPairs.h"
-#include "RecoTracker/TkSeedingLayers/interface/SeedingLayerSets.h"
 #include "RecoTracker/TkSeedingLayers/interface/OrderedSeedingHits.h"
-#include "RecoTracker/TkSeedingLayers/interface/SeedingLayerSetsBuilder.h"
+
+class SeedingLayerSetsHits;
 
 class BeamHaloPairGenerator : public OrderedHitsGenerator {
 	public:
@@ -20,8 +21,7 @@ class BeamHaloPairGenerator : public OrderedHitsGenerator {
 					      const edm::Event & ev, 
 					      const edm::EventSetup& es);
 	private:
-	SeedingLayerSetsBuilder theLayerBuilder;
-	ctfseeding::SeedingLayerSets theLss;
+	edm::EDGetTokenT<SeedingLayerSetsHits> theSeedingLayerToken;
 	OrderedHitPairs hitPairs;
 	double theMaxTheta;
 };

--- a/RecoTracker/SpecialSeedGenerators/interface/GenericPairGenerator.h
+++ b/RecoTracker/SpecialSeedGenerators/interface/GenericPairGenerator.h
@@ -4,12 +4,14 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
 
 #include "RecoTracker/TkTrackingRegions/interface/OrderedHitsGenerator.h"
 #include "RecoTracker/TkTrackingRegions/interface/TrackingRegion.h"
 #include "RecoTracker/TkHitPairs/interface/OrderedHitPairs.h"
-#include "RecoTracker/TkSeedingLayers/interface/SeedingLayerSetsBuilder.h"
 #include "RecoTracker/TkSeedingLayers/interface/OrderedSeedingHits.h"
+
+class SeedingLayerSetsHits;
 
 class GenericPairGenerator : public OrderedHitsGenerator {
 	public:
@@ -20,8 +22,7 @@ class GenericPairGenerator : public OrderedHitsGenerator {
 					      const edm::EventSetup& es);
         void clear() { hitPairs.clear();}
 	private:
-	SeedingLayerSetsBuilder theLsb;
-	ctfseeding::SeedingLayerSets theLss;
+	edm::EDGetTokenT<SeedingLayerSetsHits> theSeedingLayerToken;
 	OrderedHitPairs hitPairs;
 };
 

--- a/RecoTracker/SpecialSeedGenerators/interface/GenericTripletGenerator.h
+++ b/RecoTracker/SpecialSeedGenerators/interface/GenericTripletGenerator.h
@@ -4,14 +4,13 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
 
 #include "RecoTracker/TkTrackingRegions/interface/OrderedHitsGenerator.h"
 #include "RecoTracker/TkTrackingRegions/interface/TrackingRegion.h"
 #include "RecoPixelVertexing/PixelTriplets/interface/OrderedHitTriplets.h"
-#include "RecoTracker/TkSeedingLayers/interface/SeedingLayerSetsBuilder.h"
 #include "RecoTracker/TkSeedingLayers/interface/OrderedSeedingHits.h"
-
-//class ctfseeding::SeedingLayers;
+#include "TrackingTools/TransientTrackingRecHit/interface/SeedingLayerSetsHits.h"
 
 class GenericTripletGenerator : public OrderedHitsGenerator {
 	public:
@@ -24,9 +23,8 @@ class GenericTripletGenerator : public OrderedHitsGenerator {
 	private:
 	std::pair<bool,float> qualityFilter(const OrderedHitTriplet& oht, 
 					    const std::map<float, OrderedHitTriplet>& map,
-					    const ctfseeding::SeedingLayers& ls) const;
-	SeedingLayerSetsBuilder theLsb;	
-	ctfseeding::SeedingLayerSets theLss;
+					    const SeedingLayerSetsHits::SeedingLayerSet& ls) const;
+	edm::EDGetTokenT<SeedingLayerSetsHits> theSeedingLayerToken;
 	OrderedHitTriplets hitTriplets;
 };
 

--- a/RecoTracker/SpecialSeedGenerators/interface/SimpleCosmicBONSeeder.h
+++ b/RecoTracker/SpecialSeedGenerators/interface/SimpleCosmicBONSeeder.h
@@ -9,6 +9,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
 
 #include "DataFormats/GeometryCommonDetAlgo/interface/GlobalError.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2DCollection.h"
@@ -26,7 +27,6 @@
 #include "RecoTracker/TkSeedGenerator/interface/FastCircle.h"
 #include "RecoTracker/TkSeedGenerator/interface/FastHelix.h"
 #include "RecoTracker/SpecialSeedGenerators/interface/ClusterChecker.h"
-#include "RecoTracker/TkSeedingLayers/interface/SeedingLayerSetsBuilder.h"
 
 #include "TrackingTools/KalmanUpdators/interface/KFUpdator.h"
 #include "TrackingTools/MaterialEffects/interface/PropagatorWithMaterial.h"
@@ -36,6 +36,7 @@
 #include "TrackingTools/Records/interface/TransientRecHitRecord.h"
 #include "RecoTracker/TransientTrackingRecHit/interface/TkTransientTrackingRecHitBuilder.h"
 
+class SeedingLayerSetsHits;
 
 class SimpleCosmicBONSeeder : public edm::EDProducer
 {
@@ -61,8 +62,7 @@ class SimpleCosmicBONSeeder : public edm::EDProducer
   edm::ParameterSet conf_;
   std::string builderName;
 
-  SeedingLayerSetsBuilder theLsb;
-  ctfseeding::SeedingLayerSets theLss;
+  edm::EDGetTokenT<SeedingLayerSetsHits> seedingLayerToken_;
   GlobalTrackingRegion region_;
   double pMin_;
   bool writeTriplets_;
@@ -71,7 +71,6 @@ class SimpleCosmicBONSeeder : public edm::EDProducer
   double rescaleError_;
 
   uint32_t tripletsVerbosity_,seedVerbosity_, helixVerbosity_;
-  std::vector<std::string> layerTripletNames_;
  
   edm::ESHandle<MagneticField>                  magfield;
   edm::ESHandle<TrackerGeometry>                tracker;

--- a/RecoTracker/SpecialSeedGenerators/python/CombinatorialSeedGeneratorForBeamHalo_cff.py
+++ b/RecoTracker/SpecialSeedGenerators/python/CombinatorialSeedGeneratorForBeamHalo_cff.py
@@ -5,3 +5,7 @@ from RecoTracker.TkSeedingLayers.PixelLayerPairs_cfi import *
 #get the module combinatorialbeamhaloseedfinder
 from RecoTracker.SpecialSeedGenerators.CombinatorialSeedGeneratorForBeamHalo_cfi import *
 
+beamhaloTrackerSeedingLayers = cms.EDProducer("SeedingLayersEDProducer",
+    layerInfo,
+    layerList = layerList
+)

--- a/RecoTracker/SpecialSeedGenerators/python/CombinatorialSeedGeneratorForBeamHalo_cfi.py
+++ b/RecoTracker/SpecialSeedGenerators/python/CombinatorialSeedGeneratorForBeamHalo_cfi.py
@@ -79,20 +79,14 @@ beamhaloTrackerSeeds = cms.EDProducer("CtfSpecialSeedGenerator",
             maxTheta = cms.double(0.1),
             PropagationDirection = cms.string('alongMomentum'),
             NavigationDirection = cms.string('outsideIn'),
-            LayerPSet = cms.PSet(
-                layerInfo,
-                layerList = layerList
-            )
+            LayerSrc = cms.InputTag("beamhaloTrackerSeedingLayers")
         ), 
         cms.PSet(
             ComponentName = cms.string('BeamHaloPairGenerator'),
             maxTheta = cms.double(0.1),
             PropagationDirection = cms.string('oppositeToMomentum'),
             NavigationDirection = cms.string('outsideIn'),
-            LayerPSet = cms.PSet(
-                layerInfo,
-                layerList = layerList
-            )
+            LayerSrc = cms.InputTag("beamhaloTrackerSeedingLayers")
         )),
     UseScintillatorsConstraint = cms.bool(False),
     TTRHBuilder = cms.string('WithTrackAngle'),

--- a/RecoTracker/SpecialSeedGenerators/python/CombinatorialSeedGeneratorForCosmicsP5_cff.py
+++ b/RecoTracker/SpecialSeedGenerators/python/CombinatorialSeedGeneratorForCosmicsP5_cff.py
@@ -23,6 +23,63 @@ from RecoTracker.TransientTrackingRecHit.TransientTrackingRecHitBuilder_cfi impo
 from RecoTracker.TransientTrackingRecHit.TransientTrackingRecHitBuilderWithoutRefit_cfi import *
 import copy
 from RecoTracker.SpecialSeedGenerators.CombinatorialSeedGeneratorForCosmics_cfi import *
+# seeding layers
+combinatorialcosmicseedingtripletsP5 = cms.EDProducer("SeedingLayersEDProducer",
+    layerInfo,
+    layerList = cms.vstring('TOB4+TOB5+TOB6', 
+        'TOB3+TOB5+TOB6', 
+        'TOB3+TOB4+TOB5', 
+        'TOB2+TOB4+TOB5', 
+        'TOB3+TOB4+TOB6', 
+        'TOB2+TOB4+TOB6')
+)
+combinatorialcosmicseedingpairsTOBP5 = cms.EDProducer("SeedingLayersEDProducer",
+    layerInfo,
+    layerList = cms.vstring('TOB5+TOB6', 
+        'TOB4+TOB5')
+)
+combinatorialcosmicseedingpairsTECposP5 = cms.EDProducer("SeedingLayersEDProducer",
+    layerList = cms.vstring('TEC1_pos+TEC2_pos', 
+        'TEC2_pos+TEC3_pos', 
+        'TEC3_pos+TEC4_pos', 
+        'TEC4_pos+TEC5_pos', 
+        'TEC5_pos+TEC6_pos', 
+        'TEC6_pos+TEC7_pos', 
+        'TEC7_pos+TEC8_pos', 
+        'TEC8_pos+TEC9_pos'),
+    TEC = cms.PSet(
+        minRing = cms.int32(5),
+        matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+        useRingSlector = cms.bool(True),
+        TTRHBuilder = cms.string('WithTrackAngle'),
+        rphiRecHits = cms.InputTag("siStripMatchedRecHits","rphiRecHit"),
+        maxRing = cms.int32(7)
+    )
+)
+combinatorialcosmicseedingpairsTECnegP5 = cms.EDProducer("SeedingLayersEDProducer",
+    layerList = cms.vstring('TEC1_neg+TEC2_neg', 
+        'TEC2_neg+TEC3_neg', 
+        'TEC3_neg+TEC4_neg', 
+        'TEC4_neg+TEC5_neg', 
+        'TEC5_neg+TEC6_neg', 
+        'TEC6_neg+TEC7_neg', 
+        'TEC7_neg+TEC8_neg', 
+        'TEC8_neg+TEC9_neg'),
+    TEC = cms.PSet(
+        minRing = cms.int32(5),
+        matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+        useRingSlector = cms.bool(True),
+        TTRHBuilder = cms.string('WithTrackAngle'),
+        rphiRecHits = cms.InputTag("siStripMatchedRecHits","rphiRecHit"),
+        maxRing = cms.int32(7)
+    )
+)
+combinatorialcosmicseedinglayersP5 = cms.Sequence(
+    combinatorialcosmicseedingtripletsP5 +
+    combinatorialcosmicseedingpairsTOBP5 +
+    combinatorialcosmicseedingpairsTECposP5 +
+    combinatorialcosmicseedingpairsTECnegP5
+)
 #recHitMatcher
 #include "RecoLocalTracker/SiStripRecHitConverter/data/SiStripRecHitMatcher.cfi"
 #seeding module
@@ -32,117 +89,37 @@ combinatorialcosmicseedfinderP5.requireBOFF = True
 combinatorialcosmicseedfinderP5.UseScintillatorsConstraint = False
 combinatorialcosmicseedfinderP5.OrderedHitsFactoryPSets = cms.VPSet(cms.PSet(
     ComponentName = cms.string('GenericTripletGenerator'),
-    LayerPSet = cms.PSet(
-        layerInfo,
-        layerList = cms.vstring('TOB4+TOB5+TOB6', 
-            'TOB3+TOB5+TOB6', 
-            'TOB3+TOB4+TOB5', 
-            'TOB2+TOB4+TOB5', 
-            'TOB3+TOB4+TOB6', 
-            'TOB2+TOB4+TOB6')
-    ),
+    LayerSrc = cms.InputTag("combinatorialcosmicseedingtripletsP5"),
     PropagationDirection = cms.string('alongMomentum'),
     NavigationDirection = cms.string('outsideIn')
 ), 
     cms.PSet(
         ComponentName = cms.string('GenericPairGenerator'),
-        LayerPSet = cms.PSet(
-            layerInfo,
-            layerList = cms.vstring('TOB5+TOB6', 
-                'TOB4+TOB5')
-        ),
+        LayerSrc = cms.InputTag("combinatorialcosmicseedingpairsTOBP5"),
         PropagationDirection = cms.string('alongMomentum'),
         NavigationDirection = cms.string('outsideIn')
     ), 
     cms.PSet(
         ComponentName = cms.string('GenericPairGenerator'),
-        LayerPSet = cms.PSet(
-            layerList = cms.vstring('TEC1_pos+TEC2_pos', 
-                'TEC2_pos+TEC3_pos', 
-                'TEC3_pos+TEC4_pos', 
-                'TEC4_pos+TEC5_pos', 
-                'TEC5_pos+TEC6_pos', 
-                'TEC6_pos+TEC7_pos', 
-                'TEC7_pos+TEC8_pos', 
-                'TEC8_pos+TEC9_pos'),
-            TEC = cms.PSet(
-                minRing = cms.int32(5),
-                matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
-                useRingSlector = cms.bool(True),
-                TTRHBuilder = cms.string('WithTrackAngle'),
-                rphiRecHits = cms.InputTag("siStripMatchedRecHits","rphiRecHit"),
-                maxRing = cms.int32(7)
-            )
-        ),
+        LayerSrc = cms.InputTag("combinatorialcosmicseedingpairsTECposP5"),
         PropagationDirection = cms.string('alongMomentum'),
         NavigationDirection = cms.string('outsideIn')
     ), 
     cms.PSet(
         ComponentName = cms.string('GenericPairGenerator'),
-        LayerPSet = cms.PSet(
-            layerList = cms.vstring('TEC1_pos+TEC2_pos', 
-                'TEC2_pos+TEC3_pos', 
-                'TEC3_pos+TEC4_pos', 
-                'TEC4_pos+TEC5_pos', 
-                'TEC5_pos+TEC6_pos', 
-                'TEC6_pos+TEC7_pos', 
-                'TEC7_pos+TEC8_pos', 
-                'TEC8_pos+TEC9_pos'),
-            TEC = cms.PSet(
-                minRing = cms.int32(5),
-                matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
-                useRingSlector = cms.bool(True),
-                TTRHBuilder = cms.string('WithTrackAngle'),
-                rphiRecHits = cms.InputTag("siStripMatchedRecHits","rphiRecHit"),
-                maxRing = cms.int32(7)
-            )
-        ),
+        LayerSrc = cms.InputTag("combinatorialcosmicseedingpairsTECposP5"),
         PropagationDirection = cms.string('alongMomentum'),
         NavigationDirection = cms.string('insideOut')
     ), 
     cms.PSet(
         ComponentName = cms.string('GenericPairGenerator'),
-        LayerPSet = cms.PSet(
-            layerList = cms.vstring('TEC1_neg+TEC2_neg', 
-                'TEC2_neg+TEC3_neg', 
-                'TEC3_neg+TEC4_neg', 
-                'TEC4_neg+TEC5_neg', 
-                'TEC5_neg+TEC6_neg', 
-                'TEC6_neg+TEC7_neg', 
-                'TEC7_neg+TEC8_neg', 
-                'TEC8_neg+TEC9_neg'),
-            TEC = cms.PSet(
-                minRing = cms.int32(5),
-                matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
-                useRingSlector = cms.bool(True),
-                TTRHBuilder = cms.string('WithTrackAngle'),
-                rphiRecHits = cms.InputTag("siStripMatchedRecHits","rphiRecHit"),
-                maxRing = cms.int32(7)
-            )
-        ),
+        LayerSrc = cms.InputTag("combinatorialcosmicseedingpairsTECnegP5"),
         PropagationDirection = cms.string('alongMomentum'),
         NavigationDirection = cms.string('outsideIn')
     ), 
     cms.PSet(
         ComponentName = cms.string('GenericPairGenerator'),
-        LayerPSet = cms.PSet(
-            layerList = cms.vstring('TEC1_neg+TEC2_neg', 
-                'TEC2_neg+TEC3_neg', 
-                'TEC3_neg+TEC4_neg', 
-                'TEC4_neg+TEC5_neg', 
-                'TEC5_neg+TEC6_neg', 
-                'TEC6_neg+TEC7_neg', 
-                'TEC7_neg+TEC8_neg', 
-                'TEC8_neg+TEC9_neg'),
-            TEC = cms.PSet(
-                minRing = cms.int32(5),
-                matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
-                useRingSlector = cms.bool(True),
-                TTRHBuilder = cms.string('WithTrackAngle'),
-                rphiRecHits = cms.InputTag("siStripMatchedRecHits","rphiRecHit"),
-                maxRing = cms.int32(7)
-            )
-        ),
+        LayerSrc = cms.InputTag("combinatorialcosmicseedingpairsTECnegP5"),
         PropagationDirection = cms.string('alongMomentum'),
         NavigationDirection = cms.string('insideOut')
     ))

--- a/RecoTracker/SpecialSeedGenerators/python/CombinatorialSeedGeneratorForCosmicsRegionalReconstruction_cff.py
+++ b/RecoTracker/SpecialSeedGenerators/python/CombinatorialSeedGeneratorForCosmicsRegionalReconstruction_cff.py
@@ -1,3 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
 from RecoTracker.SpecialSeedGenerators.CombinatorialSeedGeneratorForCosmicsRegionalReconstruction_cfi import *
+
+regionalCosmicTrackerSeedingLayers = cms.EDProducer("SeedingLayersEDProducer",
+    layerInfo,
+    layerList = layerList
+)

--- a/RecoTracker/SpecialSeedGenerators/python/CombinatorialSeedGeneratorForCosmicsRegionalReconstruction_cfi.py
+++ b/RecoTracker/SpecialSeedGenerators/python/CombinatorialSeedGeneratorForCosmicsRegionalReconstruction_cfi.py
@@ -11,6 +11,19 @@ layerInfo = cms.PSet(
       maxRing = cms.int32(7)
       )
 )
+layerList = cms.vstring('TOB6+TOB5',
+                        'TOB6+TOB4', 
+                        'TOB6+TOB3',
+                        'TOB5+TOB4',
+                        'TOB5+TOB3',
+                        'TOB4+TOB3',
+                        'TEC1_neg+TOB6',
+                        'TEC1_neg+TOB5',
+                        'TEC1_neg+TOB4',
+                        'TEC1_pos+TOB6',
+                        'TEC1_pos+TOB5',
+                        'TEC1_pos+TOB4'                                   
+                        )
 
 regionalCosmicTrackerSeeds = cms.EDProducer( "SeedGeneratorFromRegionHitsEDProducer",
    RegionFactoryPSet = cms.PSet(                                 
@@ -43,22 +56,7 @@ regionalCosmicTrackerSeeds = cms.EDProducer( "SeedGeneratorFromRegionHitsEDProdu
     ),
     OrderedHitsFactoryPSet = cms.PSet(
         ComponentName = cms.string( "GenericPairGenerator"),
-        LayerPSet = cms.PSet(
-           layerInfo,
-           layerList = cms.vstring('TOB6+TOB5',
-                                   'TOB6+TOB4', 
-                                   'TOB6+TOB3',
-                                   'TOB5+TOB4',
-                                   'TOB5+TOB3',
-                                   'TOB4+TOB3',
-                                   'TEC1_neg+TOB6',
-                                   'TEC1_neg+TOB5',
-                                   'TEC1_neg+TOB4',
-                                   'TEC1_pos+TOB6',
-                                   'TEC1_pos+TOB5',
-                                   'TEC1_pos+TOB4'                                   
-                                   )
-           ),
+        LayerSrc = cms.InputTag("regionalCosmicTrackerSeedingLayers")
     ), 
 
     ClusterCheckPSet = cms.PSet (

--- a/RecoTracker/SpecialSeedGenerators/python/CombinatorialSeedGeneratorForCosmics_cfi.py
+++ b/RecoTracker/SpecialSeedGenerators/python/CombinatorialSeedGeneratorForCosmics_cfi.py
@@ -51,6 +51,21 @@ layerInfo = cms.PSet(
         rphiRecHits = cms.InputTag("siStripMatchedRecHits","rphiRecHit")
     )
 )
+combinatorialcosmicseedingtripletsTOB_layerList = cms.vstring('TOB4+TOB5+TOB6',
+    'TOB3+TOB5+TOB6',
+    'TOB3+TOB4+TOB5',
+    'TOB2+TOB4+TOB5',
+    'TOB3+TOB4+TOB6',
+    'TOB2+TOB4+TOB6')
+combinatorialcosmicseedingpairsTECpos_layerList = cms.vstring('TEC1_pos+TEC2_pos',
+    'TEC2_pos+TEC3_pos',
+    'TEC3_pos+TEC4_pos',
+    'TEC4_pos+TEC5_pos',
+    'TEC5_pos+TEC6_pos',
+    'TEC6_pos+TEC7_pos',
+    'TEC7_pos+TEC8_pos',
+    'TEC8_pos+TEC9_pos')
+combinatorialcosmicseedingtripletsTIB_layerList = cms.vstring('TIB1+TIB2+TIB3')
 combinatorialcosmicseedfinder = cms.EDProducer("CtfSpecialSeedGenerator",
     SeedMomentum = cms.double(5.0), ##initial momentum in GeV !!!set to a lower value for slice test data
 
@@ -69,40 +84,19 @@ combinatorialcosmicseedfinder = cms.EDProducer("CtfSpecialSeedGenerator",
     Charges = cms.vint32(-1),
     OrderedHitsFactoryPSets = cms.VPSet(cms.PSet(
         ComponentName = cms.string('GenericTripletGenerator'),
-        LayerPSet = cms.PSet(
-            layerInfo,
-            layerList = cms.vstring('TOB4+TOB5+TOB6', 
-                'TOB3+TOB5+TOB6', 
-                'TOB3+TOB4+TOB5', 
-                'TOB2+TOB4+TOB5', 
-                'TOB3+TOB4+TOB6', 
-                'TOB2+TOB4+TOB6')
-        ),
+        LayerSrc = cms.InputTag("combinatorialcosmicseedingtripletsTOB"),
         PropagationDirection = cms.string('alongMomentum'),
         NavigationDirection = cms.string('outsideIn')
     ), 
         cms.PSet(
             ComponentName = cms.string('GenericPairGenerator'),
-            LayerPSet = cms.PSet(
-                layerInfo,
-                layerList = cms.vstring('TEC1_pos+TEC2_pos', 
-                    'TEC2_pos+TEC3_pos', 
-                    'TEC3_pos+TEC4_pos', 
-                    'TEC4_pos+TEC5_pos', 
-                    'TEC5_pos+TEC6_pos', 
-                    'TEC6_pos+TEC7_pos', 
-                    'TEC7_pos+TEC8_pos', 
-                    'TEC8_pos+TEC9_pos')
-            ),
+            LayerSrc = cms.InputTag("combinatorialcosmicseedingpairsTECpos"),
             PropagationDirection = cms.string('alongMomentum'),
             NavigationDirection = cms.string('outsideIn')
         ), 
         cms.PSet(
             ComponentName = cms.string('GenericTripletGenerator'),
-            LayerPSet = cms.PSet(
-                layerInfo,
-                layerList = cms.vstring('TIB1+TIB2+TIB3')
-            ),
+            LayerSrc = cms.InputTag("combinatorialcosmicseedingtripletsTIB"),
             PropagationDirection = cms.string('oppositeToMomentum'),
             NavigationDirection = cms.string('insideOut')
         )),

--- a/RecoTracker/SpecialSeedGenerators/python/SimpleCosmicBONSeeder_cff.py
+++ b/RecoTracker/SpecialSeedGenerators/python/SimpleCosmicBONSeeder_cff.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+
+from RecoTracker.SpecialSeedGenerators.SimpleCosmicBONSeeder_cfi import *
+
+simpleCosmicBONSeedingLayers = cms.EDProducer("SeedingLayersEDProducer",
+    layerInfo,
+    layerList = cms.vstring(*layerList)
+)

--- a/RecoTracker/SpecialSeedGenerators/python/SimpleCosmicBONSeeder_cfi.py
+++ b/RecoTracker/SpecialSeedGenerators/python/SimpleCosmicBONSeeder_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-from RecoTracker.SpecialSeedGenerators.CombinatorialSeedGeneratorForCosmics_cfi import layerInfo
+import RecoTracker.SpecialSeedGenerators.CombinatorialSeedGeneratorForCosmics_cfi
 
 def makeSimpleCosmicSeedLayers(*layers):
     layerList = cms.vstring()
@@ -28,7 +28,10 @@ def makeSimpleCosmicSeedLayers(*layers):
                        'TOB6+TOB5+TEC1_neg' ]
     #print "SEEDING LAYER LIST = ", layerList
     return layerList
-    
+
+layerInfo = RecoTracker.SpecialSeedGenerators.CombinatorialSeedGeneratorForCosmics_cfi.layerInfo.clone()
+layerInfo.TEC.useSimpleRphiHitsCleaner = False
+layerList = makeSimpleCosmicSeedLayers('ALL'),
 
 simpleCosmicBONSeeds = cms.EDProducer("SimpleCosmicBONSeeder",
     TTRHBuilder = cms.string('WithTrackAngle'),
@@ -49,11 +52,8 @@ simpleCosmicBONSeeds = cms.EDProducer("SimpleCosmicBONSeeder",
         ptMin = cms.double(0.5),               # pt cut, applied both at the triplet finding and at the seeding level
         pMin  = cms.double(1.0),               # p  cut, applied only at the seeding level
     ),
-    TripletsPSet = cms.PSet(
-        layerInfo,
-        layerList = makeSimpleCosmicSeedLayers('ALL'),
-        debugLevel = cms.untracked.uint32(0),  # debug triplet finding (0 to 3)
-    ),
+    TripletsSrc = cms.InputTag("simpleCosmicBONSeedingLayers"),
+    TripletsDebugLevel = cms.untracked.uint32(0),  # debug triplet finding (0 to 3)
     seedOnMiddle    = cms.bool(False), # after finding the triplet, add only two hits to the seed
     rescaleError    = cms.double(1.0), # we don't need it anymore. At least for runs with BON
 
@@ -86,4 +86,4 @@ simpleCosmicBONSeeds = cms.EDProducer("SimpleCosmicBONSeeder",
     NegativeYOnly = cms.bool(False)
     #***
 )
-simpleCosmicBONSeeds.TripletsPSet.TEC.useSimpleRphiHitsCleaner = False
+

--- a/RecoTracker/SpecialSeedGenerators/src/GenericPairGenerator.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/GenericPairGenerator.cc
@@ -2,12 +2,14 @@
 //#include "RecoTracker/TkSeedingLayers/interface/SeedingLayerSetsBuilder.h"
 typedef SeedingHitSet::ConstRecHitPointer SeedingHit;
 
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "TrackingTools/TransientTrackingRecHit/interface/SeedingLayerSetsHits.h"
 using namespace ctfseeding;
 
 
 GenericPairGenerator::GenericPairGenerator(const edm::ParameterSet& conf, edm::ConsumesCollector& iC):
-  theLsb(conf.getParameter<edm::ParameterSet>("LayerPSet"), iC){
+  theSeedingLayerToken(iC.consumes<SeedingLayerSetsHits>(conf.getParameter<edm::InputTag>("LayerSrc"))) {
 	edm::LogInfo("CtfSpecialSeedGenerator|GenericPairGenerator") << "Constructing GenericPairGenerator";
 } 
 
@@ -17,17 +19,15 @@ const OrderedSeedingHits& GenericPairGenerator::run(const TrackingRegion& region
                               			    const edm::EventSetup& es){
 	hitPairs.clear();
 	hitPairs.reserve(0);
-        if(theLsb.check(es)) {
-          theLss = theLsb.layers(es);
-        }
-	SeedingLayerSets::const_iterator iLss;
-	for (iLss = theLss.begin(); iLss != theLss.end(); iLss++){
-		SeedingLayers ls = *iLss;
-		if (ls.size() != 2){
-                	throw cms::Exception("CtfSpecialSeedGenerator") << "You are using " << ls.size() <<" layers in set instead of 2 ";
-        	}	
-		auto innerHits  = region.hits(e, es, &ls[0]);
-		auto outerHits  = region.hits(e, es, &ls[1]);
+        edm::Handle<SeedingLayerSetsHits> hlayers;
+        e.getByToken(theSeedingLayerToken, hlayers);
+        const SeedingLayerSetsHits& layers = *hlayers;
+        if(layers.numberOfLayersInSet() != 2)
+          throw cms::Exception("CtfSpecialSeedGenerator") << "You are using " << layers.numberOfLayersInSet() <<" layers in set instead of 2 ";
+
+        for(SeedingLayerSetsHits::SeedingLayerSet ls: layers) {
+		auto innerHits  = region.hits(e, es, ls[0]);
+		auto outerHits  = region.hits(e, es, ls[1]);
 		for (auto iOuterHit = outerHits.begin(); iOuterHit != outerHits.end(); iOuterHit++){
 		  for (auto iInnerHit = innerHits.begin(); iInnerHit != innerHits.end(); iInnerHit++){
 		    hitPairs.push_back(OrderedHitPair(&(**iInnerHit),

--- a/RecoTracker/SpecialSeedGenerators/src/SimpleCosmicBONSeeder.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/SimpleCosmicBONSeeder.cc
@@ -10,18 +10,25 @@
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h"
 #include "FWCore/Utilities/interface/isFinite.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "TrackingTools/TransientTrackingRecHit/interface/SeedingLayerSetsHits.h"
 typedef SeedingHitSet::ConstRecHitPointer SeedingHit;
 
 #include <numeric>
 
+namespace {
+  std::string seedingLayersToString(const SeedingLayerSetsHits::SeedingLayerSet& layer) {
+    return layer[0].name() + "+" + layer[1].name() + "+" + layer[2].name();
+  }
+}
+
 using namespace std;
 SimpleCosmicBONSeeder::SimpleCosmicBONSeeder(edm::ParameterSet const& conf) : 
   conf_(conf),
-  theLsb(conf.getParameter<edm::ParameterSet>("TripletsPSet"), consumesCollector()),
+  seedingLayerToken_(consumes<SeedingLayerSetsHits>(conf.getParameter<edm::InputTag>("TripletsSrc"))),
   writeTriplets_(conf.getParameter<bool>("writeTriplets")),
   seedOnMiddle_(conf.existsAs<bool>("seedOnMiddle") ? conf.getParameter<bool>("seedOnMiddle") : false),
   rescaleError_(conf.existsAs<double>("rescaleError") ? conf.getParameter<double>("rescaleError") : 1.0),
-  tripletsVerbosity_(conf.getParameter<edm::ParameterSet>("TripletsPSet").getUntrackedParameter<uint32_t>("debugLevel",0)),
+  tripletsVerbosity_(conf.getUntrackedParameter<uint32_t>("TripletsDebugLevel",0)),
   seedVerbosity_(conf.getUntrackedParameter<uint32_t>("seedDebugLevel",0)),
   helixVerbosity_(conf.getUntrackedParameter<uint32_t>("helixDebugLevel",0)),
   check_(conf.getParameter<edm::ParameterSet>("ClusterCheckPSet"), consumesCollector()),
@@ -45,8 +52,6 @@ SimpleCosmicBONSeeder::SimpleCosmicBONSeeder(edm::ParameterSet const& conf) :
 
   produces<TrajectorySeedCollection>();
   if (writeTriplets_) produces<edm::OwnVector<TrackingRecHit> >("cosmicTriplets");
-
-  layerTripletNames_ = conf_.getParameter<edm::ParameterSet>("TripletsPSet").getParameter<std::vector<std::string> >("layerList");
 
   if (conf.existsAs<edm::ParameterSet>("ClusterChargeCheck")) {
       edm::ParameterSet cccc = conf.getParameter<edm::ParameterSet>("ClusterChargeCheck");
@@ -172,27 +177,24 @@ bool SimpleCosmicBONSeeder::triplets(const edm::Event& e, const edm::EventSetup&
 
     hitTriplets.clear();
     hitTriplets.reserve(0);
-    if(theLsb.check(es)) {
-      theLss = theLsb.layers(es);
-    }
-    SeedingLayerSets::const_iterator iLss;
+    edm::Handle<SeedingLayerSetsHits> hlayers;
+    e.getByToken(seedingLayerToken_, hlayers);
+    const SeedingLayerSetsHits& layers = *hlayers;
+    if(layers.numberOfLayersInSet() != 3)
+      throw cms::Exception("CtfSpecialSeedGenerator") << "You are using " << layers.numberOfLayersInSet() <<" layers in set instead of 3 ";
 
     double minRho = region_.ptMin() / ( 0.003 * magfield->inTesla(GlobalPoint(0,0,0)).z() );
 
-    for (iLss = theLss.begin(); iLss != theLss.end(); iLss++){
-        SeedingLayers ls = *iLss;
-        if (ls.size() != 3){
-            throw cms::Exception("CtfSpecialSeedGenerator") << "You are using " << ls.size() <<" layers in set instead of 3 ";
-        }
-
+    for(SeedingLayerSetsHits::LayerSetIndex layerIndex=0; layerIndex < layers.size(); ++layerIndex) {
+        SeedingLayerSetsHits::SeedingLayerSet ls = layers[layerIndex];
         /// ctfseeding SeedinHits and their iterators
-        auto innerHits  = region_.hits(e, es, &ls[0]);
-        auto middleHits = region_.hits(e, es, &ls[1]);
-        auto outerHits  = region_.hits(e, es, &ls[2]);
+        auto innerHits  = region_.hits(e, es, ls[0]);
+        auto middleHits = region_.hits(e, es, ls[1]);
+        auto outerHits  = region_.hits(e, es, ls[2]);
 
         if (tripletsVerbosity_ > 0) {
-            std::cout << "GenericTripletGenerator iLss = " << layerTripletNames_[iLss - theLss.begin()]
-                    << " (" << (iLss - theLss.begin()) << "): # = " 
+            std::cout << "GenericTripletGenerator iLss = " << seedingLayersToString(ls)
+                    << " (" << layerIndex << "): # = " 
                     << innerHits.size() << "/" << middleHits.size() << "/" << outerHits.size() << std::endl;
         }
 
@@ -296,8 +298,8 @@ bool SimpleCosmicBONSeeder::triplets(const edm::Event& e, const edm::EventSetup&
             }
         }
         if ((tripletsVerbosity_ > 0) && (hitTriplets.size() > sizBefore)) {
-            std::cout << "                        iLss = " << layerTripletNames_[iLss - theLss.begin()]
-                << " (" << (iLss - theLss.begin()) << "): # = " 
+            std::cout << "                        iLss = " << seedingLayersToString(ls)
+                << " (" << layerIndex << "): # = " 
                 << innerHits.size() << "/" << middleHits.size() << "/" << outerHits.size() 
                 << ": Found " << (hitTriplets.size() - sizBefore) << " seeds [running total: " << hitTriplets.size() << "]"
                 << std::endl ;

--- a/RecoTracker/TkTrackingRegions/interface/GlobalTrackingRegion.h
+++ b/RecoTracker/TkTrackingRegions/interface/GlobalTrackingRegion.h
@@ -33,11 +33,6 @@ public:
       Range( -1/ptMin, 1/ptMin), originRadius, originHalfLength),
       thePrecise(precise) { }
 
-  virtual TrackingRegion::ctfHits hits(
-      const edm::Event& ev,  
-      const edm::EventSetup& es, 
-      const ctfseeding::SeedingLayer* layer) const;
-
   TrackingRegion::Hits hits(
       const edm::Event& ev,
       const edm::EventSetup& es,

--- a/RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h
+++ b/RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h
@@ -135,11 +135,6 @@ public:
   /// is precise error calculation switched on 
   bool  isPrecise() const { return thePrecise; }
 
-  virtual TrackingRegion::ctfHits hits(
-      const edm::Event& ev,  
-      const edm::EventSetup& es, 
-      const ctfseeding::SeedingLayer* layer) const;
-
   virtual TrackingRegion::Hits hits(
       const edm::Event& ev,
       const edm::EventSetup& es,
@@ -160,13 +155,6 @@ public:
   virtual std::string print() const;
 
 private:
-  template <typename T, typename H, typename F>
-  void hits_(
-      const edm::Event& ev,
-      const edm::EventSetup& es,
-      const T& layer, H  & result,
-      F hitGetter, bool oldStyle) const;
-
   HitRZCompatibility* checkRZOld(
       const DetLayer* layer, 
       const TrackingRecHit*  outerHit,

--- a/RecoTracker/TkTrackingRegions/interface/TrackingRegion.h
+++ b/RecoTracker/TkTrackingRegions/interface/TrackingRegion.h
@@ -96,11 +96,6 @@ public:
 
 
 /// get hits from layer compatible with region constraints 
-  virtual ctfHits hits(
-		       const edm::Event& ev, 
-		       const edm::EventSetup& es, 
-		       const ctfseeding::SeedingLayer* layer) const = 0; 
-
   virtual Hits hits(
 		    const edm::Event& ev,
 		    const edm::EventSetup& es,

--- a/RecoTracker/TkTrackingRegions/src/GlobalTrackingRegion.cc
+++ b/RecoTracker/TkTrackingRegions/src/GlobalTrackingRegion.cc
@@ -24,14 +24,6 @@ std::string GlobalTrackingRegion::print() const {
   return str.str(); 
 }
 
-TrackingRegion::ctfHits GlobalTrackingRegion::hits(
-      const edm::Event& ev,
-      const edm::EventSetup& es,
-      const ctfseeding::SeedingLayer* layer) const
-{
- return layer->hits(ev,es);
-}
-
 TrackingRegion::Hits GlobalTrackingRegion::hits(
       const edm::Event& ev,
       const edm::EventSetup& es,

--- a/RecoTracker/TkTrackingRegions/src/RectangularEtaPhiTrackingRegion.cc
+++ b/RecoTracker/TkTrackingRegions/src/RectangularEtaPhiTrackingRegion.cc
@@ -283,34 +283,11 @@ HitRZConstraint
 			 );
 }
 
-TrackingRegion::ctfHits RectangularEtaPhiTrackingRegion::hits(
-      const edm::Event& ev,
-      const edm::EventSetup& es,
-      const  SeedingLayer* layer) const
-{
-  std::cout << "RectangularEtaPhiTrackingRegion old style hits" << std::endl;
-  TrackingRegion::ctfHits result;
-  hits_(ev, es, *layer, result, [&](const SeedingLayer& l) -> TrackingRegion::ctfHits { return l.hits(ev, es);}, true );
-  return result;
-}
-
 TrackingRegion::Hits RectangularEtaPhiTrackingRegion::hits(
       const edm::Event& ev,
       const edm::EventSetup& es,
       const SeedingLayerSetsHits::SeedingLayer& layer) const {
   TrackingRegion::Hits result;
-  hits_(ev, es, layer, result, [](const SeedingLayerSetsHits::SeedingLayer& l) -> TrackingRegion::Hits { return l.hits();},false);
-  return result;
-}
-
-template <typename T, typename H, typename F>
-void RectangularEtaPhiTrackingRegion::hits_(
-      const edm::Event& ev,
-      const edm::EventSetup& es,
-      const T& layer, H & result,
-      F hitGetter, bool oldStyle) const
-{
-
 
   //ESTIMATOR
 
@@ -377,7 +354,7 @@ void RectangularEtaPhiTrackingRegion::hits_(
     for (auto const & im : meas) {
       if(!im.recHit()->isValid()) continue;
       auto ptrHit = (BaseTrackerRecHit *)(im.recHit()->hit()->clone());
-      if (!oldStyle) cache.emplace_back(ptrHit);
+      cache.emplace_back(ptrHit);
       result.emplace_back(ptrHit);
     }
   
@@ -395,9 +372,9 @@ void RectangularEtaPhiTrackingRegion::hits_(
       const ForwardDetLayer& fl = dynamic_cast<const ForwardDetLayer&>(*detLayer);
       est = estimator(&fl,es);
     }
-    if (!est) return;
+    if (!est) return result;
     
-    auto layerHits = hitGetter(layer);
+    auto layerHits = layer.hits();
     result.reserve(layerHits.size());
     for (auto && ih : layerHits) {
       if ( est->hitCompatibility()(*ih) ) {
@@ -408,7 +385,8 @@ void RectangularEtaPhiTrackingRegion::hits_(
   
   // std::cout << "RectangularEtaPhiTrackingRegion hits "  << result.size() << std::endl;
   delete est;
-  
+
+  return result;
 }
 
 std::string RectangularEtaPhiTrackingRegion::print() const {

--- a/SLHCUpgradeSimulations/Configuration/python/phase2TkCustomsBE.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase2TkCustomsBE.py
@@ -168,8 +168,8 @@ def customise_Reco(process,pileup):
         TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelPairs'),
         skipClusters = cms.InputTag("pixelPairStepClusters"),
     )
-    process.regionalCosmicTrackerSeeds.OrderedHitsFactoryPSet.LayerPSet.layerList  = cms.vstring('BPix10+BPix9')  # Optimize later
-    process.regionalCosmicTrackerSeeds.OrderedHitsFactoryPSet.LayerPSet.BPix = cms.PSet(
+    process.regionalCosmicTrackerSeedingLayers.layerList  = cms.vstring('BPix10+BPix9')  # Optimize later
+    process.regionalCosmicTrackerSeedingLayers.BPix = cms.PSet(
         HitProducer = cms.string('siPixelRecHits'),
         TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelPairs'),
         skipClusters = cms.InputTag("pixelPairStepClusters"),

--- a/SLHCUpgradeSimulations/Configuration/python/phase2TkCustomsBE5D.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase2TkCustomsBE5D.py
@@ -135,8 +135,8 @@ def customise_Reco(process):
         TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelPairs'),
         skipClusters = cms.InputTag("pixelPairStepClusters"),
     )
-    process.regionalCosmicTrackerSeeds.OrderedHitsFactoryPSet.LayerPSet.layerList  = cms.vstring('BPix10+BPix9')  # Optimize later
-    process.regionalCosmicTrackerSeeds.OrderedHitsFactoryPSet.LayerPSet.BPix = cms.PSet(
+    process.regionalCosmicTrackerSeedingLayers.layerList  = cms.vstring('BPix10+BPix9')  # Optimize later
+    process.regionalCosmicTrackerSeedingLayers.BPix = cms.PSet(
         HitProducer = cms.string('siPixelRecHits'),
         TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelPairs'),
         skipClusters = cms.InputTag("pixelPairStepClusters"),

--- a/SLHCUpgradeSimulations/Configuration/python/phase2TkCustoms_LB_4LPS_2L2S.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase2TkCustoms_LB_4LPS_2L2S.py
@@ -133,8 +133,8 @@ def customise_Reco(process):
         TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelPairs'),
         skipClusters = cms.InputTag("pixelPairStepClusters"),
     )
-    process.regionalCosmicTrackerSeeds.OrderedHitsFactoryPSet.LayerPSet.layerList  = cms.vstring('BPix10+BPix9')  # Optimize later
-    process.regionalCosmicTrackerSeeds.OrderedHitsFactoryPSet.LayerPSet.BPix = cms.PSet(
+    process.regionalCosmicTrackerSeedingLayers.layerList  = cms.vstring('BPix10+BPix9')  # Optimize later
+    process.regionalCosmicTrackerSeedingLayers.BPix = cms.PSet(
         HitProducer = cms.string('siPixelRecHits'),
         TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelPairs'),
         skipClusters = cms.InputTag("pixelPairStepClusters"),

--- a/SLHCUpgradeSimulations/Configuration/python/phase2TkCustoms_LB_6PS.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase2TkCustoms_LB_6PS.py
@@ -133,8 +133,8 @@ def customise_Reco(process):
         TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelPairs'),
         skipClusters = cms.InputTag("pixelPairStepClusters"),
     )
-    process.regionalCosmicTrackerSeeds.OrderedHitsFactoryPSet.LayerPSet.layerList  = cms.vstring('BPix12+BPix11')  # Optimize later
-    process.regionalCosmicTrackerSeeds.OrderedHitsFactoryPSet.LayerPSet.BPix = cms.PSet(
+    process.regionalCosmicTrackerSeedingLayers.layerList  = cms.vstring('BPix12+BPix11')  # Optimize later
+    process.regionalCosmicTrackerSeedingLayers.BPix = cms.PSet(
         HitProducer = cms.string('siPixelRecHits'),
         TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelPairs'),
         skipClusters = cms.InputTag("pixelPairStepClusters"),

--- a/SLHCUpgradeSimulations/Geometry/test/RecoFull_Fullsim_Longbarrel_cfg.py
+++ b/SLHCUpgradeSimulations/Geometry/test/RecoFull_Fullsim_Longbarrel_cfg.py
@@ -169,12 +169,12 @@ process.regionalCosmicTrackerSeeds.SeedMergerPSet = cms.PSet(
 	)
 process.regionalCosmicTracks.TTRHBuilder = cms.string('WithTrackAngle')
 
-process.regionalCosmicTrackerSeeds.OrderedHitsFactoryPSet.LayerPSet.layerList = cms.vstring(
+process.regionalCosmicTrackerSeedingLayers.layerList = cms.vstring(
 	'BPix16+BPix15','BPix16+BPix14','BPix16+BPix13',
 	'BPix15+BPix14','BPix15+BPix13',
 	'BPix14+BPix13'
 	)
-process.regionalCosmicTrackerSeeds.OrderedHitsFactoryPSet.LayerPSet.BPix = cms.PSet(
+process.regionalCosmicTrackerSeedingLayers.BPix = cms.PSet(
 	TTRHBuilder = cms.string("PixelTTRHBuilderWithoutAngle" )
 	)
 

--- a/SLHCUpgradeSimulations/Geometry/test/RecoFull_Fullsim_Longbarrel_cfg.py
+++ b/SLHCUpgradeSimulations/Geometry/test/RecoFull_Fullsim_Longbarrel_cfg.py
@@ -160,7 +160,8 @@ process.muons.TrackerKinkFinderParameters.TrackerRecHitBuilder = cms.string('Wit
 # The SeedMergerPSet should be added to the following file for Phase 1
 # RecoTracker/SpecialSeedGenerators/python/CombinatorialSeedGeneratorForCosmicsRegionalReconstruction_cfi.py
 # but pixel layers are not used here for cosmic TODO: need Maria and Jan to do appropriate thing here
-from RecoPixelVertexing.PixelTriplets.quadrupletseedmerging_cff import PixelSeedMergerQuadrupletsprocess.regionalCosmicTrackerSeeds.SeedMergerPSet = cms.PSet(
+from RecoPixelVertexing.PixelTriplets.quadrupletseedmerging_cff import PixelSeedMergerQuadruplets
+process.regionalCosmicTrackerSeeds.SeedMergerPSet = cms.PSet(
 	mergeTriplets = cms.bool(False),
 	ttrhBuilderLabel = cms.string( "PixelTTRHBuilderWithoutAngle" ),
 	addRemainingTriplets = cms.bool(False),


### PR DESCRIPTION
Migrate SpecialSeedGenerators still using SeedingLayerSetsBuilder to use SeedingLayerSetsHits. These generators are
- BeamHaloPairGenerator
- GenericPairGenerator
- GenericTripletGenerator
- SimpleCosmicBONSeeder

The migration allows removal of `TrackingRegion::hits(..., const ctfseeding::SeedingLayer*)` method since nobody calls it anymore, simplifying the TrackingRecHit rework.

There should be no effect on physics.
