### PR TITLE
Added missing CLHEP header - fixed compillation

### DIFF
--- a/SimG4CMS/Forward/src/Bcm1fSD.cc
+++ b/SimG4CMS/Forward/src/Bcm1fSD.cc
@@ -23,6 +23,7 @@
 #include "G4EventManager.hh"
 #include "G4Event.hh"
 #include "G4VProcess.hh"
+#include "G4SystemOfUnits.hh"
 
 #include <string>
 #include <vector>


### PR DESCRIPTION
Trivial fix of compilation for the new lumi-monitor class.
