### PR TITLE
Tracer: optionally add timestamps to each message

### DIFF
--- a/FWCore/Services/src/Tracer.cc
+++ b/FWCore/Services/src/Tracer.cc
@@ -15,6 +15,7 @@
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ServiceRegistry/interface/SystemBounds.h"
+#include "FWCore/Utilities/interface/TimeOfDay.h"
 
 #include "DataFormats/Provenance/interface/EventID.h"
 #include "DataFormats/Provenance/interface/LuminosityBlockID.h"
@@ -34,10 +35,32 @@
 
 using namespace edm::service;
 
+namespace {
+
+  class TimeStamper {
+  public:
+    TimeStamper(bool enable) :
+      enabled_(enable)
+    { }
+
+    friend
+    std::ostream & operator<<(std::ostream & out, TimeStamper const & timestamp) {
+      if (timestamp.enabled_)
+        out << std::setprecision(2) << edm::TimeOfDay() << "  ";
+      return out;
+    }
+
+  private:
+    bool enabled_;
+  };
+
+}
+
 Tracer::Tracer(ParameterSet const& iPS, ActivityRegistry&iRegistry) :
   indention_(iPS.getUntrackedParameter<std::string>("indention")),
   dumpContextForLabels_(),
-  dumpNonModuleContext_(iPS.getUntrackedParameter<bool>("dumpNonModuleContext"))
+  dumpNonModuleContext_(iPS.getUntrackedParameter<bool>("dumpNonModuleContext")),
+  printTimestamps_(iPS.getUntrackedParameter<bool>("printTimestamps"))
 {
   for (std::string & label: iPS.getUntrackedParameter<std::vector<std::string>>("dumpContextForLabels"))
     dumpContextForLabels_.insert(std::move(label));
@@ -142,60 +165,62 @@ Tracer::fillDescriptions(edm::ConfigurationDescriptions & descriptions) {
   desc.addUntracked<std::string>("indention", "++")->setComment("Prefix characters for output. The characters are repeated to form the indentation.");
   desc.addUntracked<std::vector<std::string>>("dumpContextForLabels", std::vector<std::string>{})->setComment("Prints context information to cout for the module transitions associated with these modules' labels");
   desc.addUntracked<bool>("dumpNonModuleContext", false)->setComment("Prints context information to cout for the transitions not associated with any module label");
+  desc.addUntracked<bool>("printTimestamps", false)->setComment("Prints a time stamp for every transition");
   descriptions.add("Tracer", desc);
   descriptions.setComment("This service prints each phase the framework is processing, e.g. constructing a module,running a module, etc.");
 }
 
 void
 Tracer::preallocate(service::SystemBounds const& bounds) {
-  LogAbsolute("Tracer") << indention_ << " preallocate: " << bounds.maxNumberOfConcurrentRuns() << " concurrent runs, " 
+  LogAbsolute("Tracer") << TimeStamper(printTimestamps_) << indention_ << " preallocate: " << bounds.maxNumberOfConcurrentRuns() << " concurrent runs, "
                                                           << bounds.maxNumberOfConcurrentLuminosityBlocks() << " concurrent luminosity sections, " 
                                                           << bounds.maxNumberOfStreams() << " streams";
 }
 
 void 
 Tracer::postBeginJob() {
-  LogAbsolute("Tracer") << indention_ << " finished: begin job";
+  LogAbsolute("Tracer") << TimeStamper(printTimestamps_) << indention_ << " finished: begin job";
 }
 
 void 
 Tracer::postEndJob() {
-  LogAbsolute("Tracer") << indention_ << " finished: end job";
+  LogAbsolute("Tracer") << TimeStamper(printTimestamps_) << indention_ << " finished: end job";
 }
 
 void
 Tracer::preSourceEvent(StreamID sid) {
-  LogAbsolute("Tracer") << indention_ << indention_ << " starting: source event";
+  LogAbsolute("Tracer") << TimeStamper(printTimestamps_) << indention_ << indention_ << " starting: source event";
 }
 
 void
 Tracer::postSourceEvent(StreamID sid) {
-  LogAbsolute("Tracer") << indention_ << indention_ << " finished: source event";
+  LogAbsolute("Tracer") << TimeStamper(printTimestamps_) << indention_ << indention_ << " finished: source event";
 }
 
 void
 Tracer::preSourceLumi() {
-  LogAbsolute("Tracer") << indention_ << indention_ << " starting: source lumi";
+  LogAbsolute("Tracer") << TimeStamper(printTimestamps_) << indention_ << indention_ << " starting: source lumi";
 }
 
 void
 Tracer::postSourceLumi() {
-  LogAbsolute("Tracer") << indention_ << indention_ << " finished: source lumi";
+  LogAbsolute("Tracer") << TimeStamper(printTimestamps_) << indention_ << indention_ << " finished: source lumi";
 }
 
 void
 Tracer::preSourceRun() {
-  LogAbsolute("Tracer") << indention_ << indention_ << " starting: source run";
+  LogAbsolute("Tracer") << TimeStamper(printTimestamps_) << indention_ << indention_ << " starting: source run";
 }
 
 void
 Tracer::postSourceRun() {
-  LogAbsolute("Tracer") << indention_ << indention_ << " finished: source run";
+  LogAbsolute("Tracer") << TimeStamper(printTimestamps_) << indention_ << indention_ << " finished: source run";
 }
 
 void
 Tracer::preOpenFile(std::string const& lfn, bool b) {
   LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
   out << indention_ << indention_ << " starting: open input file: lfn = " << lfn;
   if(dumpNonModuleContext_) out << " usedFallBack = " << b;
 }
@@ -203,6 +228,7 @@ Tracer::preOpenFile(std::string const& lfn, bool b) {
 void
 Tracer::postOpenFile (std::string const& lfn, bool b) {
   LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
   out << indention_ << indention_ << " finished: open input file: lfn = " << lfn;
   if(dumpNonModuleContext_) out << " usedFallBack = " << b;
 }
@@ -210,12 +236,14 @@ Tracer::postOpenFile (std::string const& lfn, bool b) {
 void
 Tracer::preCloseFile(std::string const & lfn, bool b) {
   LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
   out << indention_ << indention_ << " starting: close input file: lfn = " << lfn;
   if(dumpNonModuleContext_) out << " usedFallBack = " << b;
 }
 void
 Tracer::postCloseFile (std::string const& lfn, bool b) {
   LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
   out << indention_ << indention_ << " finished: close input file: lfn = " << lfn;
   if(dumpNonModuleContext_) out << " usedFallBack = " << b;
 }
@@ -224,6 +252,7 @@ void
 Tracer::preModuleBeginStream(StreamContext const& sc, ModuleCallingContext const& mcc) {
   ModuleDescription const& desc = *mcc.moduleDescription();
   LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
   out << indention_ << indention_ << " starting: begin stream for module: stream = " << sc.streamID() << " label = '" << desc.moduleLabel() << "' id = " << desc.id();
   if(dumpContextForLabels_.find(desc.moduleLabel()) != dumpContextForLabels_.end()) {
     out << "\n" << sc;
@@ -235,6 +264,7 @@ void
 Tracer::postModuleBeginStream(StreamContext const& sc, ModuleCallingContext const& mcc) {
   ModuleDescription const& desc = *mcc.moduleDescription();
   LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
   out << indention_ << indention_ << " finished: begin stream for module: stream = " << sc.streamID() << " label = '" << desc.moduleLabel() << "' id = " << desc.id();
   if(dumpContextForLabels_.find(desc.moduleLabel()) != dumpContextForLabels_.end()) {
     out << "\n" << sc;
@@ -246,6 +276,7 @@ void
 Tracer::preModuleEndStream(StreamContext const& sc, ModuleCallingContext const& mcc) {
   ModuleDescription const& desc = *mcc.moduleDescription();
   LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
   out << indention_ << indention_ << " starting: end stream for module: stream = " << sc.streamID() << " label = '" << desc.moduleLabel() << "' id = " << desc.id();
   if(dumpContextForLabels_.find(desc.moduleLabel()) != dumpContextForLabels_.end()) {
     out << "\n" << sc;
@@ -257,6 +288,7 @@ void
 Tracer::postModuleEndStream(StreamContext const& sc, ModuleCallingContext const& mcc) {
   ModuleDescription const& desc = *mcc.moduleDescription();
   LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
   out << indention_ << indention_ << " finished: end stream for module: stream = " << sc.streamID() << " label = '" << desc.moduleLabel() << "' id = " << desc.id();
   if(dumpContextForLabels_.find(desc.moduleLabel()) != dumpContextForLabels_.end()) {
     out << "\n" << sc;
@@ -267,6 +299,7 @@ Tracer::postModuleEndStream(StreamContext const& sc, ModuleCallingContext const&
 void
 Tracer::preGlobalBeginRun(GlobalContext const& gc) {
   LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
   out << indention_ << indention_ << " starting: global begin run " << gc.luminosityBlockID().run()
       << " : time = " << gc.timestamp().value();
   if(dumpNonModuleContext_) {
@@ -277,6 +310,7 @@ Tracer::preGlobalBeginRun(GlobalContext const& gc) {
 void
 Tracer::postGlobalBeginRun(GlobalContext const& gc) {
   LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
   out << indention_ << indention_ << " finished: global begin run " << gc.luminosityBlockID().run()
       << " : time = " << gc.timestamp().value();
   if(dumpNonModuleContext_) {
@@ -287,6 +321,7 @@ Tracer::postGlobalBeginRun(GlobalContext const& gc) {
 void
 Tracer::preGlobalEndRun(GlobalContext const& gc) {
   LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
   out << indention_ << indention_ << " starting: global end run " << gc.luminosityBlockID().run()
       << " : time = " << gc.timestamp().value();
   if(dumpNonModuleContext_) {
@@ -297,6 +332,7 @@ Tracer::preGlobalEndRun(GlobalContext const& gc) {
 void
 Tracer::postGlobalEndRun(GlobalContext const& gc) {
   LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
   out << indention_ << indention_ << " finished: global end run " << gc.luminosityBlockID().run()
       << " : time = " << gc.timestamp().value();
   if(dumpNonModuleContext_) {
@@ -307,6 +343,7 @@ Tracer::postGlobalEndRun(GlobalContext const& gc) {
 void
 Tracer::preStreamBeginRun(StreamContext const& sc) {
   LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
   out << indention_ << indention_ << " starting: begin run: stream = " << sc.streamID() << " run = " << sc.eventID().run()
       << " time = " << sc.timestamp().value();
   if(dumpNonModuleContext_) {
@@ -317,6 +354,7 @@ Tracer::preStreamBeginRun(StreamContext const& sc) {
 void
 Tracer::postStreamBeginRun(StreamContext const& sc) {
   LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
   out << indention_ << indention_ << " finished: begin run: stream = " << sc.streamID() << " run = " << sc.eventID().run()
       << " time = " << sc.timestamp().value();
   if(dumpNonModuleContext_) {
@@ -327,6 +365,7 @@ Tracer::postStreamBeginRun(StreamContext const& sc) {
 void
 Tracer::preStreamEndRun(StreamContext const& sc) {
   LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
   out << indention_ << indention_ << " starting: end run: stream = " << sc.streamID() << " run = " << sc.eventID().run()
       << " time = " << sc.timestamp().value();
   if(dumpNonModuleContext_) {
@@ -337,6 +376,7 @@ Tracer::preStreamEndRun(StreamContext const& sc) {
 void
 Tracer::postStreamEndRun(StreamContext const& sc) {
   LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
   out << indention_ << indention_ << " finished: end run: stream = " << sc.streamID() << " run = " << sc.eventID().run()
       << " time = " << sc.timestamp().value();
   if(dumpNonModuleContext_) {
@@ -347,6 +387,7 @@ Tracer::postStreamEndRun(StreamContext const& sc) {
 void
 Tracer::preGlobalBeginLumi(GlobalContext const& gc) {
   LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
   out << indention_ << indention_ << " starting: global begin lumi: run = " << gc.luminosityBlockID().run()
       << " lumi = " << gc.luminosityBlockID().luminosityBlock() << " time = " << gc.timestamp().value();
   if(dumpNonModuleContext_) {
@@ -357,6 +398,7 @@ Tracer::preGlobalBeginLumi(GlobalContext const& gc) {
 void
 Tracer::postGlobalBeginLumi(GlobalContext const& gc) {
   LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
   out << indention_ << indention_ << " finished: global begin lumi: run = " << gc.luminosityBlockID().run()
       << " lumi = " << gc.luminosityBlockID().luminosityBlock() << " time = " << gc.timestamp().value();
   if(dumpNonModuleContext_) {
@@ -367,6 +409,7 @@ Tracer::postGlobalBeginLumi(GlobalContext const& gc) {
 void
 Tracer::preGlobalEndLumi(GlobalContext const& gc) {
   LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
   out << indention_ << indention_ << " starting: global end lumi: run = " << gc.luminosityBlockID().run()
       << " lumi = " << gc.luminosityBlockID().luminosityBlock() << " time = " << gc.timestamp().value();
   if(dumpNonModuleContext_) {
@@ -377,6 +420,7 @@ Tracer::preGlobalEndLumi(GlobalContext const& gc) {
 void
 Tracer::postGlobalEndLumi(GlobalContext const& gc) {
   LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
   out << indention_ << indention_ << " finished: global end lumi: run = " << gc.luminosityBlockID().run()
       << " lumi = " << gc.luminosityBlockID().luminosityBlock() << " time = " << gc.timestamp().value();
   if(dumpNonModuleContext_) {
@@ -387,6 +431,7 @@ Tracer::postGlobalEndLumi(GlobalContext const& gc) {
 void
 Tracer::preStreamBeginLumi(StreamContext const& sc) {
   LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
   out << indention_ << indention_ << " starting: begin lumi: stream = " << sc.streamID() << " run = " << sc.eventID().run()
       << " lumi = " << sc.eventID().luminosityBlock() << " time = " << sc.timestamp().value();
   if(dumpNonModuleContext_) {
@@ -397,6 +442,7 @@ Tracer::preStreamBeginLumi(StreamContext const& sc) {
 void
 Tracer::postStreamBeginLumi(StreamContext const& sc) {
   LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
   out << indention_ << indention_ << " finished: begin lumi: stream = " << sc.streamID() << " run = " << sc.eventID().run()
       << " lumi = " << sc.eventID().luminosityBlock() << " time = " << sc.timestamp().value();
   if(dumpNonModuleContext_) {
@@ -407,6 +453,7 @@ Tracer::postStreamBeginLumi(StreamContext const& sc) {
 void
 Tracer::preStreamEndLumi(StreamContext const& sc) {
   LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
   out << indention_ << indention_ << " starting: end lumi: stream = " << sc.streamID() << " run = " << sc.eventID().run()
       << " lumi = " << sc.eventID().luminosityBlock() << " time = " << sc.timestamp().value();
   if(dumpNonModuleContext_) {
@@ -417,6 +464,7 @@ Tracer::preStreamEndLumi(StreamContext const& sc) {
 void
 Tracer::postStreamEndLumi(StreamContext const& sc) {
   LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
   out << indention_ << indention_ << " finished: end lumi: stream = " << sc.streamID() << " run = " << sc.eventID().run()
       << " lumi = " << sc.eventID().luminosityBlock() << " time = " << sc.timestamp().value();
   if(dumpNonModuleContext_) {
@@ -427,6 +475,7 @@ Tracer::postStreamEndLumi(StreamContext const& sc) {
 void
 Tracer::preEvent(StreamContext const& sc) {
   LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
   out << indention_ << indention_ << " starting: processing event : stream = " << sc.streamID() << " run = " << sc.eventID().run()
       << " lumi = " << sc.eventID().luminosityBlock() << " event = " << sc.eventID().event() << " time = " << sc.timestamp().value();
   if(dumpNonModuleContext_) {
@@ -437,6 +486,7 @@ Tracer::preEvent(StreamContext const& sc) {
 void
 Tracer::postEvent(StreamContext const& sc) {
   LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
   out << indention_ << indention_ << " finished: processing event : stream = " << sc.streamID() << " run = " << sc.eventID().run()
       << " lumi = " << sc.eventID().luminosityBlock() << " event = " << sc.eventID().event() << " time = " << sc.timestamp().value();
   if(dumpNonModuleContext_) {
@@ -447,6 +497,7 @@ Tracer::postEvent(StreamContext const& sc) {
 void
 Tracer::prePathEvent(StreamContext const& sc, PathContext const& pc) {
   LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
   out << indention_ << indention_ << indention_ << " starting: processing path '" << pc.pathName() << "' : stream = " << sc.streamID();
   if(dumpNonModuleContext_) {
     out << "\n" << sc;
@@ -457,6 +508,7 @@ Tracer::prePathEvent(StreamContext const& sc, PathContext const& pc) {
 void
 Tracer::postPathEvent(StreamContext const& sc, PathContext const& pc, HLTPathStatus const& hlts) {
   LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
   out << indention_ << indention_ << indention_ << " finished: processing path '" << pc.pathName() << "' : stream = " << sc.streamID();
   if(dumpNonModuleContext_) {
     out << "\n" << sc;
@@ -467,6 +519,7 @@ Tracer::postPathEvent(StreamContext const& sc, PathContext const& pc, HLTPathSta
 void 
 Tracer::preModuleConstruction(ModuleDescription const& desc) {
   LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
   out << indention_ << indention_ << " starting: constructing module with label '" << desc.moduleLabel() << "' id = " << desc.id();
   if(dumpContextForLabels_.find(desc.moduleLabel()) != dumpContextForLabels_.end()) {
     out << "\n" << desc;
@@ -476,6 +529,7 @@ Tracer::preModuleConstruction(ModuleDescription const& desc) {
 void 
 Tracer::postModuleConstruction(ModuleDescription const& desc) {
   LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
   out << indention_ << indention_ << " finished: constructing module with label '" << desc.moduleLabel() << "' id = " << desc.id();
   if(dumpContextForLabels_.find(desc.moduleLabel()) != dumpContextForLabels_.end()) {
     out << "\n" << desc;
@@ -485,6 +539,7 @@ Tracer::postModuleConstruction(ModuleDescription const& desc) {
 void 
 Tracer::preModuleBeginJob(ModuleDescription const& desc) {
   LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
   out << indention_ << indention_;
   out << " starting: begin job for module with label '" << desc.moduleLabel() << "' id = " << desc.id();
   if(dumpContextForLabels_.find(desc.moduleLabel()) != dumpContextForLabels_.end()) {
@@ -495,6 +550,7 @@ Tracer::preModuleBeginJob(ModuleDescription const& desc) {
 void 
 Tracer::postModuleBeginJob(ModuleDescription const& desc) {
   LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
   out << indention_ << indention_;
   out << " finished: begin job for module with label '" << desc.moduleLabel() << "' id = " << desc.id();
   if(dumpContextForLabels_.find(desc.moduleLabel()) != dumpContextForLabels_.end()) {
@@ -505,6 +561,7 @@ Tracer::postModuleBeginJob(ModuleDescription const& desc) {
 void 
 Tracer::preModuleEndJob(ModuleDescription const& desc) {
   LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
   out << indention_ << indention_;
   out << " starting: end job for module with label '" << desc.moduleLabel() << "' id = " << desc.id();
   if(dumpContextForLabels_.find(desc.moduleLabel()) != dumpContextForLabels_.end()) {
@@ -515,6 +572,7 @@ Tracer::preModuleEndJob(ModuleDescription const& desc) {
 void 
 Tracer::postModuleEndJob(ModuleDescription const& desc) {
   LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
   out << indention_ << indention_;
   out << " finished: end job for module with label '" << desc.moduleLabel() << "' id = " << desc.id();
   if(dumpContextForLabels_.find(desc.moduleLabel()) != dumpContextForLabels_.end()) {
@@ -525,6 +583,7 @@ Tracer::postModuleEndJob(ModuleDescription const& desc) {
 void 
 Tracer::preModuleEvent(StreamContext const& sc, ModuleCallingContext const& mcc) {
   LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
   unsigned int nIndents = mcc.depth() + 4;
   for(unsigned int i = 0; i < nIndents; ++i) {
     out << indention_;
@@ -539,6 +598,7 @@ Tracer::preModuleEvent(StreamContext const& sc, ModuleCallingContext const& mcc)
 void 
 Tracer::postModuleEvent(StreamContext const& sc, ModuleCallingContext const& mcc) {
   LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
   unsigned int nIndents = mcc.depth() + 4;
   for(unsigned int i = 0; i < nIndents; ++i) {
     out << indention_;
@@ -554,6 +614,7 @@ Tracer::postModuleEvent(StreamContext const& sc, ModuleCallingContext const& mcc
 void
 Tracer::preModuleEventDelayedGet(StreamContext const& sc, ModuleCallingContext const& mcc) {
   LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
   unsigned int nIndents = mcc.depth() + 4;
   for(unsigned int i = 0; i < nIndents; ++i) {
     out << indention_;
@@ -568,6 +629,7 @@ Tracer::preModuleEventDelayedGet(StreamContext const& sc, ModuleCallingContext c
 void
 Tracer::postModuleEventDelayedGet(StreamContext const& sc, ModuleCallingContext const& mcc) {
   LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
   unsigned int nIndents = mcc.depth() + 4;
   for(unsigned int i = 0; i < nIndents; ++i) {
     out << indention_;
@@ -583,6 +645,7 @@ Tracer::postModuleEventDelayedGet(StreamContext const& sc, ModuleCallingContext 
 void
 Tracer::preModuleStreamBeginRun(StreamContext const& sc, ModuleCallingContext const& mcc) {
   LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
   unsigned int nIndents = mcc.depth() + 3;
   for(unsigned int i = 0; i < nIndents; ++i) {
     out << indention_;
@@ -597,6 +660,7 @@ Tracer::preModuleStreamBeginRun(StreamContext const& sc, ModuleCallingContext co
 void
 Tracer::postModuleStreamBeginRun(StreamContext const& sc, ModuleCallingContext const& mcc) {
   LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
   unsigned int nIndents = mcc.depth() + 3;
   for(unsigned int i = 0; i < nIndents; ++i) {
     out << indention_;
@@ -611,6 +675,7 @@ Tracer::postModuleStreamBeginRun(StreamContext const& sc, ModuleCallingContext c
 void
 Tracer::preModuleStreamEndRun(StreamContext const& sc, ModuleCallingContext const& mcc) {
   LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
   unsigned int nIndents = mcc.depth() + 3;
   for(unsigned int i = 0; i < nIndents; ++i) {
     out << indention_;
@@ -625,6 +690,7 @@ Tracer::preModuleStreamEndRun(StreamContext const& sc, ModuleCallingContext cons
 void
 Tracer::postModuleStreamEndRun(StreamContext const& sc, ModuleCallingContext const& mcc) {
   LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
   unsigned int nIndents = mcc.depth() + 3;
   for(unsigned int i = 0; i < nIndents; ++i) {
     out << indention_;
@@ -639,6 +705,7 @@ Tracer::postModuleStreamEndRun(StreamContext const& sc, ModuleCallingContext con
 void
 Tracer::preModuleStreamBeginLumi(StreamContext const& sc, ModuleCallingContext const& mcc) {
   LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
   unsigned int nIndents = mcc.depth() + 3;
   for(unsigned int i = 0; i < nIndents; ++i) {
     out << indention_;
@@ -653,6 +720,7 @@ Tracer::preModuleStreamBeginLumi(StreamContext const& sc, ModuleCallingContext c
 void
 Tracer::postModuleStreamBeginLumi(StreamContext const& sc, ModuleCallingContext const& mcc) {
   LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
   unsigned int nIndents = mcc.depth() + 3;
   for(unsigned int i = 0; i < nIndents; ++i) {
     out << indention_;
@@ -667,6 +735,7 @@ Tracer::postModuleStreamBeginLumi(StreamContext const& sc, ModuleCallingContext 
 void
 Tracer::preModuleStreamEndLumi(StreamContext const& sc, ModuleCallingContext const& mcc) {
   LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
   unsigned int nIndents = mcc.depth() + 3;
   for(unsigned int i = 0; i < nIndents; ++i) {
     out << indention_;
@@ -681,6 +750,7 @@ Tracer::preModuleStreamEndLumi(StreamContext const& sc, ModuleCallingContext con
 void
 Tracer::postModuleStreamEndLumi(StreamContext const& sc, ModuleCallingContext const& mcc) {
   LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
   unsigned int nIndents = mcc.depth() + 3;
   for(unsigned int i = 0; i < nIndents; ++i) {
     out << indention_;
@@ -695,6 +765,7 @@ Tracer::postModuleStreamEndLumi(StreamContext const& sc, ModuleCallingContext co
 void
 Tracer::preModuleGlobalBeginRun(GlobalContext const& gc, ModuleCallingContext const& mcc) {
   LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
   unsigned int nIndents = mcc.depth() + 3;
   for(unsigned int i = 0; i < nIndents; ++i) {
     out << indention_;
@@ -709,6 +780,7 @@ Tracer::preModuleGlobalBeginRun(GlobalContext const& gc, ModuleCallingContext co
 void
 Tracer::postModuleGlobalBeginRun(GlobalContext const& gc, ModuleCallingContext const& mcc) {
   LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
   unsigned int nIndents = mcc.depth() + 3;
   for(unsigned int i = 0; i < nIndents; ++i) {
     out << indention_;
@@ -723,6 +795,7 @@ Tracer::postModuleGlobalBeginRun(GlobalContext const& gc, ModuleCallingContext c
 void
 Tracer::preModuleGlobalEndRun(GlobalContext const& gc, ModuleCallingContext const& mcc) {
   LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
   unsigned int nIndents = mcc.depth() + 3;
   for(unsigned int i = 0; i < nIndents; ++i) {
     out << indention_;
@@ -737,6 +810,7 @@ Tracer::preModuleGlobalEndRun(GlobalContext const& gc, ModuleCallingContext cons
 void
 Tracer::postModuleGlobalEndRun(GlobalContext const& gc, ModuleCallingContext const& mcc) {
   LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
   unsigned int nIndents = mcc.depth() + 3;
   for(unsigned int i = 0; i < nIndents; ++i) {
     out << indention_;
@@ -751,6 +825,7 @@ Tracer::postModuleGlobalEndRun(GlobalContext const& gc, ModuleCallingContext con
 void
 Tracer::preModuleGlobalBeginLumi(GlobalContext const& gc, ModuleCallingContext const& mcc) {
   LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
   unsigned int nIndents = mcc.depth() + 3;
   for(unsigned int i = 0; i < nIndents; ++i) {
     out << indention_;
@@ -765,6 +840,7 @@ Tracer::preModuleGlobalBeginLumi(GlobalContext const& gc, ModuleCallingContext c
 void
 Tracer::postModuleGlobalBeginLumi(GlobalContext const& gc, ModuleCallingContext const& mcc) {
   LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
   unsigned int nIndents = mcc.depth() + 3;
   for(unsigned int i = 0; i < nIndents; ++i) {
     out << indention_;
@@ -779,6 +855,7 @@ Tracer::postModuleGlobalBeginLumi(GlobalContext const& gc, ModuleCallingContext 
 void
 Tracer::preModuleGlobalEndLumi(GlobalContext const& gc, ModuleCallingContext const& mcc) {
   LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
   unsigned int nIndents = mcc.depth() + 3;
   for(unsigned int i = 0; i < nIndents; ++i) {
     out << indention_;
@@ -793,6 +870,7 @@ Tracer::preModuleGlobalEndLumi(GlobalContext const& gc, ModuleCallingContext con
 void
 Tracer::postModuleGlobalEndLumi(GlobalContext const& gc, ModuleCallingContext const& mcc) {
   LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
   unsigned int nIndents = mcc.depth() + 3;
   for(unsigned int i = 0; i < nIndents; ++i) {
     out << indention_;
@@ -807,6 +885,7 @@ Tracer::postModuleGlobalEndLumi(GlobalContext const& gc, ModuleCallingContext co
 void
 Tracer::preSourceConstruction(ModuleDescription const& desc) {
   LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
   out << indention_;
   out << " starting: constructing source: " << desc.moduleName();
   if(dumpNonModuleContext_) {
@@ -817,6 +896,7 @@ Tracer::preSourceConstruction(ModuleDescription const& desc) {
 void
 Tracer::postSourceConstruction(ModuleDescription const& desc) {
   LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
   out << indention_;
   out << " finished: constructing source: " << desc.moduleName();
   if(dumpNonModuleContext_) {

--- a/FWCore/Services/src/Tracer.h
+++ b/FWCore/Services/src/Tracer.h
@@ -145,6 +145,7 @@ namespace edm {
          std::string indention_;
          std::set<std::string> dumpContextForLabels_;
          bool dumpNonModuleContext_;
+         bool printTimestamps_;
       };
    }
 }


### PR DESCRIPTION
Add an option to the Tracer Service to print a timestamp along with each message.
