### PR TITLE
Tracer: optionally add timestamps to each message

### DIFF
--- a/FWCore/Services/src/Tracer.h
+++ b/FWCore/Services/src/Tracer.h
@@ -145,6 +145,7 @@ namespace edm {
          std::string indention_;
          std::set<std::string> dumpContextForLabels_;
          bool dumpNonModuleContext_;
+         bool printTimestamps_;
       };
    }
 }


### PR DESCRIPTION
Add an option to the Tracer Service to print a timestamp along with each message.

This is th 7.0.x version of #3035 .
