### PR TITLE
Fixed run time error due to interface change for Geant4 10.0 

### DIFF
--- a/SimG4Core/MagneticField/interface/G4MonopoleEquation.hh
+++ b/SimG4Core/MagneticField/interface/G4MonopoleEquation.hh
@@ -23,7 +23,10 @@
 // * acceptance of all terms of the Geant4 Software license.          *
 // ********************************************************************
 //
-// GEANT4 tag $Name:  $
+/// \file exoticphysics/monopole/include/G4MonopoleEquation.hh
+/// \brief Definition of the G4MonopoleEquation class
+//
+// $Id: G4MonopoleEquation.hh 69705 2013-05-13 09:09:52Z gcosmo $
 //
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
@@ -39,7 +42,7 @@
 // History:
 // - Created. V.Grichine, 10.11.98
 // - Modified. S.Burdin, 30.04.10
-// 	       B.Bozsogi, 15.06.10
+//                B.Bozsogi, 15.06.10
 // -------------------------------------------------------------------
 
 #ifndef G4MONOPOLEEQUATION_hh
@@ -47,31 +50,31 @@
 
 #include "G4EquationOfMotion.hh"
 #include "G4ElectroMagneticField.hh"
-#include "globals.hh"
 
 class G4MonopoleEquation : public G4EquationOfMotion
 {
-public:  
+public:  // with description
 
   G4MonopoleEquation(G4ElectroMagneticField *emField );
 
-  virtual ~G4MonopoleEquation(); 
+  ~G4MonopoleEquation();
 
-  virtual void SetChargeMomentumMass(G4ChargeState particleCharges,
-				     G4double particleElectricCharge,
-				     G4double mass);
+  virtual void  SetChargeMomentumMass( G4ChargeState particleChargeState,
+                                       G4double      momentum, 
+                                       G4double      mass);
+  // magnetic charge in e+ units
                                  
   virtual void EvaluateRhsGivenB(const G4double y[],
-				 const G4double Field[],
-				 G4double dydx[] ) const;
+                         const G4double Field[],
+                         G4double dydx[] ) const;
   // Given the value of the electromagnetic field, this function 
   // calculates the value of the derivative dydx.
 
 private:
 
-  G4double        fMagCharge ;
-  G4double        fElCharge;
-  G4double        fMassCof;
+  G4double  fMagCharge ;
+  G4double  fElCharge;
+  G4double  fMassCof;
 };
 
 #endif

--- a/SimG4Core/MagneticField/src/G4MonopoleEquation.cc
+++ b/SimG4Core/MagneticField/src/G4MonopoleEquation.cc
@@ -23,7 +23,10 @@
 // * acceptance of all terms of the Geant4 Software license.          *
 // ********************************************************************
 //
-// GEANT4 tag $Name:  $
+/// \file exoticphysics/monopole/src/G4MonopoleEquation.cc
+/// \brief Implementation of the G4MonopoleEquation class
+//
+// $Id: G4MonopoleEquation.cc 69705 2013-05-13 09:09:52Z gcosmo $
 //
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
@@ -52,96 +55,101 @@
 // -------------------------------------------------------------------
 
 #include "SimG4Core/MagneticField/interface/G4MonopoleEquation.hh"
+#include "globals.hh"
 #include "G4PhysicalConstants.hh"
 #include "G4SystemOfUnits.hh"
-
 #include <iomanip>
 
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
 G4MonopoleEquation::G4MonopoleEquation(G4ElectroMagneticField *emField )
-      : G4EquationOfMotion( emField ) {
-}
+      : G4EquationOfMotion( emField ) 
+{}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
 G4MonopoleEquation::~G4MonopoleEquation()
 {}
 
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
 void  
-G4MonopoleEquation::SetChargeMomentumMass(G4ChargeState particleCharges,
-                                          G4double,
-                                          G4double particleMass)
+G4MonopoleEquation::SetChargeMomentumMass( G4ChargeState particleChargeState, 
+                                           G4double      ,           // momentum, 
+                                           G4double particleMass)
 {
-  G4double particleMagneticCharge= particleCharges.MagneticCharge(); 
-  G4double particleElectricCharge= particleCharges.GetCharge(); 
+   G4double particleMagneticCharge= particleChargeState.MagneticCharge(); 
+   G4double particleElectricCharge= particleChargeState.GetCharge(); 
 
-  fElCharge  = eplus* particleElectricCharge*c_light;
+  //   fElCharge = particleElectricCharge;
+  fElCharge =eplus* particleElectricCharge*c_light;
    
-  fMagCharge = eplus*particleMagneticCharge*c_light ;
+  fMagCharge =  eplus*particleMagneticCharge*c_light ;
 
-//    G4cout << " G4MonopoleEquation: ElectricCharge=" << particleElectricCharge
-// 	  << "; MagneticCharge=" << particleMagneticCharge
-// 	  << G4endl;
-
-   
+  // G4cout << " G4MonopoleEquation: ElectricCharge=" << particleElectricCharge
+  //           << "; MagneticCharge=" << particleMagneticCharge
+  //           << G4endl;
+ 
   fMassCof = particleMass*particleMass ; 
 }
 
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
 void
 G4MonopoleEquation::EvaluateRhsGivenB(const G4double y[],
-				      const G4double Field[],
-				      G4double dydx[] ) const
+                                      const G4double Field[],
+                                      G4double dydx[] ) const
 {
-  
-   // Components of y:
-   //    0-2 dr/ds, 
-   //    3-5 dp/ds - momentum derivatives 
+  // Components of y:
+  //    0-2 dr/ds, 
+  //    3-5 dp/ds - momentum derivatives 
 
-   G4double pSquared = y[3]*y[3] + y[4]*y[4] + y[5]*y[5] ;
+  G4double pSquared = y[3]*y[3] + y[4]*y[4] + y[5]*y[5] ;
 
-   G4double Energy   = std::sqrt( pSquared + fMassCof );
+  G4double Energy   = std::sqrt( pSquared + fMassCof );
    
-   //   G4double pModuleInverse  = (pSquared <= 0.0) ? 0.0 : 1.0/std::sqrt(pSquared);
-   G4double pModuleInverse  = 1.0/std::sqrt(pSquared);
+  G4double pModuleInverse  = 1.0/std::sqrt(pSquared);
 
-   G4double inverse_velocity = Energy * pModuleInverse / c_light;
+  G4double inverse_velocity = Energy * pModuleInverse / c_light;
 
-   G4double cofEl     = fElCharge * pModuleInverse ;
-   G4double cofMag = fMagCharge * Energy * pModuleInverse; 
+  G4double cofEl     = fElCharge * pModuleInverse ;
+  G4double cofMag = fMagCharge * Energy * pModuleInverse; 
 
 
-   dydx[0] = y[3]*pModuleInverse ;                         
-   dydx[1] = y[4]*pModuleInverse ;                         
-   dydx[2] = y[5]*pModuleInverse ;                    
+  dydx[0] = y[3]*pModuleInverse ;                         
+  dydx[1] = y[4]*pModuleInverse ;                         
+  dydx[2] = y[5]*pModuleInverse ;                    
      
-   // G4double magCharge = twopi * hbar_Planck / (eplus * mu0);    
-   // magnetic charge in SI units A*m convention
-   //  see http://en.wikipedia.org/wiki/Magnetic_monopole   
-   //   G4cout  << "Magnetic charge:  " << magCharge << G4endl;
+  // G4double magCharge = twopi * hbar_Planck / (eplus * mu0);    
+  // magnetic charge in SI units A*m convention
+  //  see http://en.wikipedia.org/wiki/Magnetic_monopole   
+  //   G4cout  << "Magnetic charge:  " << magCharge << G4endl;   
+  // dp/ds = dp/dt * dt/ds = dp/dt / v = Force / velocity
+  // dydx[3] = fMagCharge * Field[0]  * inverse_velocity  * c_light;    
+  // multiplied by c_light to convert to MeV/mm
+  //     dydx[4] = fMagCharge * Field[1]  * inverse_velocity  * c_light; 
+  //     dydx[5] = fMagCharge * Field[2]  * inverse_velocity  * c_light; 
+      
+  dydx[3] = cofMag * Field[0] + cofEl * (y[4]*Field[2] - y[5]*Field[1]);   
+  dydx[4] = cofMag * Field[1] + cofEl * (y[5]*Field[0] - y[3]*Field[2]); 
+  dydx[5] = cofMag * Field[2] + cofEl * (y[3]*Field[1] - y[4]*Field[0]); 
    
-   // dp/ds = dp/dt * dt/ds = dp/dt / v = Force / velocity
-   
-   //     dydx[3] = fMagCharge * Field[0]  * inverse_velocity  * c_light;    // multiplied by c_light to convert to MeV/mm
-   //     dydx[4] = fMagCharge * Field[1]  * inverse_velocity  * c_light; 
-   //     dydx[5] = fMagCharge * Field[2]  * inverse_velocity  * c_light; 
-   
-   dydx[3] = cofMag * Field[0] + cofEl * (y[4]*Field[2] - y[5]*Field[1]);   
-   dydx[4] = cofMag * Field[1] + cofEl * (y[5]*Field[0] - y[3]*Field[2]); 
-   dydx[5] = cofMag * Field[2] + cofEl * (y[3]*Field[1] - y[4]*Field[0]); 
-   
-//        G4cout << std::setprecision(5)<< "E=" << Energy
-// 	      << "; p="<< 1/pModuleInverse
-// 	      << "; mC="<< magCharge
-// 	      <<"; x=" << y[0]
-// 	      <<"; y=" << y[1]
-// 	      <<"; z=" << y[2]
-// 	      <<"; dydx[3]=" << dydx[3]
-// 	      <<"; dydx[4]=" << dydx[4]
-// 	      <<"; dydx[5]=" << dydx[5]
-// 	      << G4endl;
+  //        G4cout << std::setprecision(5)<< "E=" << Energy
+  //               << "; p="<< 1/pModuleInverse
+  //               << "; mC="<< magCharge
+  //               <<"; x=" << y[0]
+  //               <<"; y=" << y[1]
+  //               <<"; z=" << y[2]
+  //               <<"; dydx[3]=" << dydx[3]
+  //               <<"; dydx[4]=" << dydx[4]
+  //               <<"; dydx[5]=" << dydx[5]
+  //               << G4endl;
 
-   dydx[6] = 0.;//not used
-
-   ////////
+  dydx[6] = 0.;//not used
    
-   // Lab Time of flight
-   dydx[7] = inverse_velocity;
-   return ;
+  // Lab Time of flight
+  dydx[7] = inverse_velocity;
+  return;
 }
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......


### PR DESCRIPTION
In Geant4 10.0 interface to the monopole equation on motion has been changed. Class G4MonopoleEquation is copied from Geant4 10.0 example code (it is not part of source). 
