### PR TITLE
Consumes migration for the Muon HLT DQM

### DIFF
--- a/DQMOffline/Trigger/interface/HLTMuonMatchAndPlot.h
+++ b/DQMOffline/Trigger/interface/HLTMuonMatchAndPlot.h
@@ -4,9 +4,7 @@
 /** \class HLTMuonMatchAndPlot
  *  Match reconstructed muons to HLT objects and plot efficiencies.
  *
- *  Note that this is not a true EDAnalyzer; rather, the intent is that one
- *  EDAnalyzer would call a separate instantiation of HLTMuonMatchAndPlot
- *  for each HLT path under consideration.
+ *  Note that this is not a true EDAnalyzer;
  *
  *  Documentation available on the CMS TWiki:
  *  https://twiki.cern.ch/twiki/bin/view/CMS/MuonHLTOfflinePerformance
@@ -17,25 +15,24 @@
 
 // Base Class Headers
 
-//#include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
-//#include "DataFormats/Common/interface/RefToBase.h"
-//#include "DataFormats/TrackReco/interface/Track.h"
-//#include "DataFormats/Candidate/interface/Candidate.h"
+#include "DataFormats/Common/interface/Handle.h"
 
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
 
 #include "DataFormats/HLTReco/interface/TriggerEvent.h"
+#include "DataFormats/HLTReco/interface/TriggerEventWithRefs.h"
 #include "DataFormats/Common/interface/TriggerResults.h"
 #include "DataFormats/MuonReco/interface/Muon.h"
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "DataFormats/Math/interface/LorentzVector.h"
 #include "DataFormats/HLTReco/interface/TriggerObject.h"
-#include "DataFormats/MuonReco/interface/Muon.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 #include "DataFormats/Math/interface/deltaR.h"
 
@@ -48,7 +45,6 @@
 #include "TPRegexp.h"
 
 
-
 //////////////////////////////////////////////////////////////////////////////
 //////// Typedefs and Constants //////////////////////////////////////////////
 
@@ -59,9 +55,10 @@ const std::string EFFICIENCY_SUFFIXES[2] = {"denom", "numer"};
 
 
 //////////////////////////////////////////////////////////////////////////////
-//////// Class Definition ////////////////////////////////////////////////////
+//////// HLTMuonMatchAndPlot Class Definition ////////////////////////////////
 
-class HLTMuonMatchAndPlot {
+class HLTMuonMatchAndPlot 
+{
 
  public:
 
@@ -71,7 +68,9 @@ class HLTMuonMatchAndPlot {
 
   // Analyzer Methods
   void beginRun(const edm::Run &, const edm::EventSetup &);
-  void analyze(const edm::Event &, const edm::EventSetup &);
+  void analyze(edm::Handle<reco::MuonCollection> &, edm::Handle<reco::BeamSpot> &, 
+	       edm::Handle<reco::VertexCollection> &, edm::Handle<trigger::TriggerEvent> &, 
+	       edm::Handle<edm::TriggerResults> &);
   void endRun(const edm::Run &, const edm::EventSetup &);
 
   // Helper Methods
@@ -81,7 +80,7 @@ class HLTMuonMatchAndPlot {
   template <class T1, class T2> std::vector<size_t> 
     matchByDeltaR(const std::vector<T1> &, const std::vector<T2> &, 
                   const double maxDeltaR = NOMATCH);
-
+  
  private:
 
   // Internal Methods
@@ -102,7 +101,6 @@ class HLTMuonMatchAndPlot {
   std::string hltProcessName_;
   std::string destination_;
   std::vector<std::string> requiredTriggers_;
-  std::map<std::string, edm::InputTag> inputTags_;
   std::map<std::string, std::vector<double> > binParams_;
   std::map<std::string, double> plotCuts_;
   edm::ParameterSet targetParams_;
@@ -126,6 +124,7 @@ class HLTMuonMatchAndPlot {
   StringCutObjectSelector<reco::Muon> probeMuonSelector_;
   double probeZ0Cut_; 
   double probeD0Cut_;
+
 };
 
 #endif

--- a/DQMOffline/Trigger/interface/HLTMuonMatchAndPlotContainer.h
+++ b/DQMOffline/Trigger/interface/HLTMuonMatchAndPlotContainer.h
@@ -1,0 +1,79 @@
+#ifndef DQMOffline_Trigger_HLTMuonMatchAndPlotContainer_H
+#define DQMOffline_Trigger_HLTMuonMatchAndPlotContainer_H
+
+/** \class HLTMuonMatchAndPlot
+ *  Contanier class to handle vector of reconstructed muons matched to 
+ *  HLT objects used to plot efficiencies.
+ *
+ *  Note that this is not a true EDAnalyzer; rather, the intent is that one
+ *  EDAnalyzer would call an instance  of HLTMuonMatchAndPlotContainer
+ *
+ *  Documentation available on the CMS TWiki:
+ *  https://twiki.cern.ch/twiki/bin/view/CMS/MuonHLTOfflinePerformance
+ *
+ *  
+ *  \author  C. Battilana
+ */
+
+// Base Class Headers
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+
+#include "DQMOffline/Trigger/interface/HLTMuonMatchAndPlot.h"
+
+#include "DataFormats/HLTReco/interface/TriggerEvent.h"
+#include "DataFormats/HLTReco/interface/TriggerEventWithRefs.h"
+#include "DataFormats/Common/interface/TriggerResults.h"
+#include "DataFormats/MuonReco/interface/Muon.h"
+#include "DataFormats/MuonReco/interface/MuonFwd.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "DataFormats/Math/interface/deltaR.h"
+
+#include<vector>
+#include<string>
+
+
+//////////////////////////////////////////////////////////////////////////////
+///Container Class Definition (this is what is used by the DQM module) ///////
+
+class HLTMuonMatchAndPlotContainer 
+{
+
+ public:
+
+  /// Constructor
+  HLTMuonMatchAndPlotContainer(edm::ConsumesCollector &&, const edm::ParameterSet &);
+
+  /// Destructor
+  ~HLTMuonMatchAndPlotContainer() { plotters_.clear(); };
+
+  /// Add a HLTMuonMatchAndPlot for a given path
+  void addPlotter(const edm::ParameterSet &, std::string,
+		  const std::vector<std::string>&);
+
+  // Analyzer Methods
+  void beginRun(const edm::Run &, const edm::EventSetup &);
+  void analyze(const edm::Event &, const edm::EventSetup &);
+  void endRun(const edm::Run &, const edm::EventSetup &);
+
+ private:
+
+  std::vector<HLTMuonMatchAndPlot> plotters_;
+
+  edm::EDGetTokenT<reco::BeamSpot> bsToken_;
+  edm::EDGetTokenT<reco::MuonCollection> muonToken_;
+  edm::EDGetTokenT<reco::VertexCollection> pvToken_;
+
+  edm::EDGetTokenT<trigger::TriggerEvent> trigSummaryToken_;
+  edm::EDGetTokenT<edm::TriggerResults>   trigResultsToken_;
+  
+};
+
+#endif
+ 
+

--- a/DQMOffline/Trigger/python/HLTMuonOfflineAnalyzer_cfi.py
+++ b/DQMOffline/Trigger/python/HLTMuonOfflineAnalyzer_cfi.py
@@ -48,8 +48,9 @@ hltMuonOfflineAnalyzer = cms.EDAnalyzer("HLTMuonOfflineAnalyzer",
     inputTags = cms.PSet(
         recoMuon       = cms.InputTag("muons"),
         beamSpot       = cms.InputTag("offlineBeamSpot"),
+        offlinePVs     = cms.InputTag("offlinePrimaryVertices"),
         triggerSummary = cms.InputTag("hltTriggerSummaryAOD"),
-        triggerResults = cms.InputTag("TriggerResults"),
+        triggerResults = cms.InputTag("TriggerResults")
     ),
 
     ## Both 1D and 2D plots use the binnings defined here

--- a/DQMOffline/Trigger/src/HLTMuonMatchAndPlotContainer.cc
+++ b/DQMOffline/Trigger/src/HLTMuonMatchAndPlotContainer.cc
@@ -1,0 +1,143 @@
+ /** \file DQMOffline/Trigger/HLTMuonMatchAndPlotContainer.cc
+ *
+ */
+
+#include "DQMOffline/Trigger/interface/HLTMuonMatchAndPlotContainer.h"
+
+//////////////////////////////////////////////////////////////////////////////
+//////// Namespaces and Typedefs /////////////////////////////////////////////
+
+using namespace std;
+using namespace edm;
+using namespace reco;
+using namespace trigger;
+
+//////////////////////////////////////////////////////////////////////////////
+///Container Class Members (this is what is used by the DQM module) //////////
+
+/// Constructor
+HLTMuonMatchAndPlotContainer::HLTMuonMatchAndPlotContainer(ConsumesCollector && iC, const ParameterSet & pset) 
+{
+
+  plotters_.clear();
+
+  string hltProcessName  = pset.getParameter<string>("hltProcessName");
+
+  ParameterSet inputTags = pset.getParameter<ParameterSet>("inputTags");
+
+  InputTag resTag = inputTags.getParameter<InputTag>("triggerResults");
+  InputTag sumTag = inputTags.getParameter<InputTag>("triggerSummary");
+  resTag = InputTag(resTag.label(), resTag.instance(), hltProcessName);
+  sumTag = InputTag(sumTag.label(), sumTag.instance(), hltProcessName);
+  
+  trigSummaryToken_ = iC.consumes<TriggerEvent>(sumTag);
+  trigResultsToken_ = iC.consumes<TriggerResults>(resTag);
+  
+  bsToken_   = iC.consumes<BeamSpot>(inputTags.getParameter<InputTag>("beamSpot"));
+  muonToken_ = iC.consumes<MuonCollection>(inputTags.getParameter<InputTag>("recoMuon"));
+  pvToken_   = iC.consumes<VertexCollection>(inputTags.getParameter<InputTag>("offlinePVs"));
+
+}
+
+
+/// Add a HLTMuonMatchAndPlot for a given path
+void HLTMuonMatchAndPlotContainer::addPlotter(const edm::ParameterSet &pset , std::string path,
+					      const std::vector<std::string>& labels)
+{
+
+  plotters_.push_back(HLTMuonMatchAndPlot(pset,path,labels));
+
+}
+
+
+void HLTMuonMatchAndPlotContainer::beginRun(const edm::Run & iRun, 
+					    const edm::EventSetup & iSetup)
+{
+
+  vector<HLTMuonMatchAndPlot>::iterator iter = plotters_.begin();
+  vector<HLTMuonMatchAndPlot>::iterator end  = plotters_.end();
+
+  for (; iter != end; ++iter) 
+    {
+      iter->beginRun(iRun, iSetup);
+    }
+
+}
+
+
+void HLTMuonMatchAndPlotContainer::endRun(const edm::Run & iRun, 
+					  const edm::EventSetup & iSetup)
+{
+
+  vector<HLTMuonMatchAndPlot>::iterator iter = plotters_.begin();
+  vector<HLTMuonMatchAndPlot>::iterator end  = plotters_.end();
+
+  for (; iter != end; ++iter) 
+    {
+      iter->endRun(iRun, iSetup);
+    }
+  
+}
+
+
+void HLTMuonMatchAndPlotContainer::analyze(const edm::Event & iEvent, 
+					   const edm::EventSetup & iSetup)
+{  
+
+  // Get objects from the event.  
+  Handle<TriggerEvent> triggerSummary;
+  iEvent.getByToken(trigSummaryToken_, triggerSummary);
+
+  if(!triggerSummary.isValid()) 
+  {
+    LogError("HLTMuonMatchAndPlot")<<"Missing triggerSummary collection" << endl;
+    return;
+  }
+
+  Handle<TriggerResults> triggerResults;
+  iEvent.getByToken(trigResultsToken_, triggerResults);
+
+  if(!triggerResults.isValid()) 
+  {
+    LogError("HLTMuonMatchAndPlot")<<"Missing triggerResults collection" << endl;
+    return;
+  }
+
+  Handle<MuonCollection> allMuons;
+  iEvent.getByToken(muonToken_, allMuons);
+
+  if(!allMuons.isValid()) 
+  {
+    LogError("HLTMuonMatchAndPlot")<<"Missing muon collection " << endl;
+    return;
+  }
+
+  Handle<BeamSpot> beamSpot;
+  iEvent.getByToken(bsToken_, beamSpot);
+
+  if(!beamSpot.isValid()) 
+  {
+    LogError("HLTMuonMatchAndPlot")<<"Missing beam spot collection " << endl;
+    return;
+  }
+
+  Handle<VertexCollection> vertices;
+  iEvent.getByToken(pvToken_, vertices);
+
+  if(!vertices.isValid()) 
+  {
+    LogError("HLTMuonMatchAndPlot")<<"Missing vertices collection " << endl;
+    return;
+  }
+  
+
+  vector<HLTMuonMatchAndPlot>::iterator iter = plotters_.begin();
+  vector<HLTMuonMatchAndPlot>::iterator end  = plotters_.end();
+
+  for (; iter != end; ++iter) 
+    {
+      iter->analyze(allMuons, beamSpot, vertices, triggerSummary, triggerResults);
+    }
+  
+}
+


### PR DESCRIPTION
The Muon HLT DQM module was migrated to use consumes.

Previously "getByLabel" was called by a vector of helper class instances (HLTMuonMatchAndPlot) that could only be created at BeginRun as access to the HLT menu was needed to populate the vector. 

To cope with this a container helper class (HLTMuonMatchAndPlotContainer) was added to handle "consumes" calls within the HLTMuonOfflineAnalyzer constructor as well as for handling population of the vector of HLTMuonMatchAndPlot and calls to getByToken within analyze. 
