### PR TITLE
Emdqm update

### DIFF
--- a/HLTriggerOffline/Egamma/interface/EmDQM.h
+++ b/HLTriggerOffline/Egamma/interface/EmDQM.h
@@ -132,6 +132,7 @@ private:
   HLTConfigProvider hltConfig_;
 
   // routines to build validation configuration from HLTConfiguration
+  int countSubstring(const std::string&, const std::string&);
   std::vector<std::vector<std::string> > findEgammaPaths();
   std::vector<std::string> getFilterModules(const std::string&);
   double getPrimaryEtCut(const std::string&);
@@ -219,6 +220,7 @@ private:
   edm::EDGetTokenT<edm::TriggerResults> hltResults_token;
   edm::EDGetTokenT<edm::View<reco::Candidate> > gencutColl_fidWenu_token;
   edm::EDGetTokenT<edm::View<reco::Candidate> > gencutColl_fidZee_token;
+  edm::EDGetTokenT<edm::View<reco::Candidate> > gencutColl_fidTripleEle_token;
   edm::EDGetTokenT<edm::View<reco::Candidate> > gencutColl_fidGammaJet_token;
   edm::EDGetTokenT<edm::View<reco::Candidate> > gencutColl_fidDiGamma_token;
   edm::EDGetTokenT<edm::View<reco::Candidate> > gencutColl_manualConf_token;

--- a/HLTriggerOffline/Egamma/python/EgammaValidationAutoConf_cff.py
+++ b/HLTriggerOffline/Egamma/python/EgammaValidationAutoConf_cff.py
@@ -11,17 +11,17 @@ samples=dummy()
 
 samples.names = ['Wenu',
                  'Zee',
-                 #'TripleEle',
+                 'TripleEle',
                  'GammaJet',
                  'DiGamma']
 samples.pdgid = [ 11,
                   11,
-                  #11,
+                  11,
                   22,
                   22]
 samples.num   = [1,
                  2,
-                 #3,
+                 3,
                  1,
                  2]
 

--- a/HLTriggerOffline/Egamma/src/EmDQM.cc
+++ b/HLTriggerOffline/Egamma/src/EmDQM.cc
@@ -51,6 +51,7 @@ EmDQM::EmDQM(const edm::ParameterSet& pset_) : pset(pset_)
   if (autoConfMode_) {
     gencutColl_fidWenu_token = mayConsume<edm::View<reco::Candidate> >(edm::InputTag("fiducialWenu"));
     gencutColl_fidZee_token = mayConsume<edm::View<reco::Candidate> >(edm::InputTag("fiducialZee"));
+    gencutColl_fidTripleEle_token = mayConsume<edm::View<reco::Candidate> >(edm::InputTag("fiducialTripleEle"));
     gencutColl_fidGammaJet_token = mayConsume<edm::View<reco::Candidate> >(edm::InputTag("fiducialGammaJet"));
     gencutColl_fidDiGamma_token = mayConsume<edm::View<reco::Candidate> >(edm::InputTag("fiducialDiGamma"));
   } else {
@@ -83,7 +84,42 @@ EmDQM::dqmBeginRun(edm::Run const &iRun, edm::EventSetup const &iSetup)
            edm::LogPrint("EmDQM") << "processName=" << hltConfig_.processName();
            edm::LogPrint("EmDQM") << "tableName=" << hltConfig_.tableName();
            edm::LogPrint("EmDQM") << "size=" << hltConfig_.size();
+           edm::LogInfo("EmDQM") << "The following filter types are not analyzed: \n" 
+                                  << "\tHLTGlobalSumsMET\n"
+                                  << "\tHLTHtMhtFilter\n"
+                                  << "\tHLTMhtFilter\n"
+                                  << "\tHLTJetTag\n"
+                                  << "\tHLT1CaloJet\n"
+                                  << "\tHLT1CaloMET\n"
+                                  << "\tHLT1CaloBJet\n"
+                                  << "\tHLT1Tau\n"
+                                  << "\tHLT1PFTau\n"
+                                  << "\tPFTauSelector\n"
+                                  << "\tHLT1PFJet\n"
+                                  << "\tHLTPFJetCollectionsFilter\n"
+                                  << "\tHLTPFJetCollectionsVBFFilter\n"
+                                  << "\tHLTPFJetTag\n"
+                                  << "\tEtMinCaloJetSelector\n"
+                                  << "\tEtMinPFJetSelector\n"
+                                  << "\tLargestEtCaloJetSelector\n"
+                                  << "\tLargestEtPFJetSelector\n"
+                                  << "\tHLTEgammaTriggerFilterObjectWrapper\n"
+                                  << "\tHLTEgammaDoubleLegCombFilter\n"
+                                  << "\tHLT2ElectronTau\n"
+                                  << "\tHLT2ElectronMET\n"
+                                  << "\tHLT2ElectronPFTau\n"
+                                  << "\tHLTPMMassFilter\n"
+                                  << "\tHLTHcalTowerFilter\n"
+                                  << "\tHLT1Photon\n"
+                                  << "\tHLTRFilter\n"
+                                  << "\tHLTRHemisphere\n"
+                                  << "\tHLTElectronPFMTFilter\n"
+                                  << "\tPrimaryVertexObjectFilter\n"
+                                  << "\tHLTEgammaAllCombMassFilter\n"
+                                  << "\tHLTMuon*\n"
+                                  ;
         }
+
 
         // All electron and photon paths
         std::vector<std::vector<std::string> > egammaPaths = findEgammaPaths();
@@ -96,6 +132,25 @@ EmDQM::dqmBeginRun(edm::Run const &iRun, edm::EventSetup const &iSetup)
         std::vector<std::string> filterModules;
 
         for (unsigned int j=0; j < egammaPaths.size() ; j++) {
+           if (verbosity_ >= OUTPUT_ALL) {
+              switch(j) {
+                 case TYPE_SINGLE_ELE:
+                    edm::LogPrint("EmDQM") << "/////////////////////////////////////////\nSingle electron paths: ";
+                    break;
+                 case TYPE_DOUBLE_ELE:
+                    edm::LogPrint("EmDQM") << "/////////////////////////////////////////\nDouble electron paths: ";
+                    break;
+                 case TYPE_TRIPLE_ELE:
+                    edm::LogPrint("EmDQM") << "/////////////////////////////////////////\nTriple electron paths: ";
+                    break;
+                 case TYPE_SINGLE_PHOTON:
+                    edm::LogPrint("EmDQM") << "/////////////////////////////////////////\nSingle photon paths: ";
+                    break;
+                 case TYPE_DOUBLE_PHOTON:
+                    edm::LogPrint("EmDQM") << "/////////////////////////////////////////\nDouble photon paths: ";
+                    break;
+              }
+           }
 
            for (unsigned int i=0; i < egammaPaths.at(j).size() ; i++) {
               // get pathname of this trigger 
@@ -153,7 +208,7 @@ EmDQM::dqmBeginRun(edm::Run const &iRun, edm::EventSetup const &iSetup)
                  case TYPE_TRIPLE_ELE:
                     paramSet.addParameter<unsigned>("reqNum", 3);
                     paramSet.addParameter<int>("pdgGen", 11);
-                    paramSet.addParameter<edm::InputTag>("cutcollection", edm::InputTag("fiducialZee"));
+                    paramSet.addParameter<edm::InputTag>("cutcollection", edm::InputTag("fiducialTripleEle"));
                     paramSet.addParameter<int>("cutnum", 3);
                     break;
                  case TYPE_SINGLE_PHOTON:
@@ -219,20 +274,37 @@ EmDQM::dqmBeginRun(edm::Run const &iRun, edm::EventSetup const &iSetup)
                     filterPSet = makePSetForEgammaDoubleEtDeltaPhiFilter(moduleLabel);
                  }
                  else if (moduleType == "HLTGlobalSumsMET"
-                          || moduleType == "HLTMhtHtFilter"
+                          || moduleType == "HLTHtMhtFilter"
+                          || moduleType == "HLTMhtFilter"
                           || moduleType == "HLTJetTag"
                           || moduleType == "HLT1CaloJet"
+                          || moduleType == "HLT1CaloMET"
                           || moduleType == "HLT1CaloBJet"
                           || moduleType == "HLT1Tau"
+                          || moduleType == "HLT1PFTau"
                           || moduleType == "PFTauSelector"
+                          || moduleType == "HLT1PFJet"
+                          || moduleType == "HLTPFJetCollectionsFilter"
+                          || moduleType == "HLTPFJetCollectionsVBFFilter"
+                          || moduleType == "HLTPFJetTag"
                           || moduleType == "EtMinCaloJetSelector"
+                          || moduleType == "EtMinPFJetSelector"
                           || moduleType == "LargestEtCaloJetSelector"
+                          || moduleType == "LargestEtPFJetSelector"
                           || moduleType == "HLTEgammaTriggerFilterObjectWrapper"  // 'fake' filter
                           || moduleType == "HLTEgammaDoubleLegCombFilter" // filter does not put anything in TriggerEventWithRefs
-                          //|| moduleType == "HLT2ElectronTau"
+                          || moduleType == "HLT2ElectronMET"
+                          || moduleType == "HLT2ElectronTau"
+                          || moduleType == "HLT2ElectronPFTau"
                           || moduleType == "HLTPMMassFilter"
                           || moduleType == "HLTHcalTowerFilter"
-                          //|| moduleType == "HLT1Photon"
+                          || moduleType == "HLT1Photon"
+                          || moduleType == "HLTRFilter"
+                          || moduleType == "HLTRHemisphere"
+                          || moduleType == "HLTElectronPFMTFilter"
+                          || moduleType == "PrimaryVertexObjectFilter"
+                          || moduleType == "HLTEgammaAllCombMassFilter"
+                          || moduleType.find("HLTMuon") != std::string::npos
                          )
                     continue;
                  else {
@@ -588,7 +660,7 @@ bool EmDQM::checkRecoParticlesRequirement(const edm::Event & event)
           else event.getByToken(gencutColl_fidDiGamma_token, referenceParticles);
           break;
        case 3:
-          event.getByToken(gencutColl_fidZee_token, referenceParticles);
+          event.getByToken(gencutColl_fidTripleEle_token, referenceParticles);
           break;
     }
   } else {
@@ -658,7 +730,7 @@ EmDQM::analyze(const edm::Event & event , const edm::EventSetup& setup)
             else event.getByToken(gencutColl_fidDiGamma_token, cutCounter);
             break;
          case 3:
-            event.getByToken(gencutColl_fidZee_token, cutCounter);
+            event.getByToken(gencutColl_fidTripleEle_token, cutCounter);
             break;
       }
     } else {
@@ -989,6 +1061,20 @@ void EmDQM::endJob()
 
 }
 
+// returns count of non-overlapping occurrences of 'sub' in 'str'
+int 
+EmDQM::countSubstring(const std::string& str, const std::string& sub)
+{
+    if (sub.length() == 0) return 0;
+    int count = 0;
+    for (size_t offset = str.find(sub); offset != std::string::npos;
+	 offset = str.find(sub, offset + sub.length()))
+    {
+        ++count;
+    }
+    return count;
+}
+
 //----------------------------------------------------------------------
 // find egamma trigger paths from trigger name
 std::vector<std::vector<std::string> >
@@ -1000,51 +1086,44 @@ EmDQM::findEgammaPaths()
 
       std::string path = hltConfig_.triggerName(i);
 
-      // Find electron and photon paths
+      // Find electron and photon paths and classify them
       if (int(path.find("HLT_")) == 0) {    // Path should start with 'HLT_'
-         if (path.find("HLT_Ele") != std::string::npos && path.rfind("Ele") == 4 && path.find("SC") == std::string::npos) {
-            Paths[TYPE_SINGLE_ELE].push_back(path);
-            //std::cout << "Electron " << path << std::endl;
+
+         int scCount = countSubstring(path, "_SC");
+         int eleCount = countSubstring(path, "Ele");
+         int doubleEleCount = countSubstring(path, "DoubleEle");
+         int tripleEleCount = countSubstring(path, "TripleEle");
+         int photonCount = countSubstring(path, "Photon");
+         int doublePhotonCount = countSubstring(path, "DoublePhoton");
+
+         int totEleCount = 2*tripleEleCount + doubleEleCount + eleCount + scCount;
+         int totPhotonCount = doublePhotonCount + photonCount;
+
+         if (totEleCount + totPhotonCount < 1) continue;
+         switch (totEleCount) {
+            case 1:
+               Paths[TYPE_SINGLE_ELE].push_back(path);
+               //std::cout << "Electron \t" << path << std::endl;
+               break;
+            case 2:
+               Paths[TYPE_DOUBLE_ELE].push_back(path);
+               //std::cout << "DoubleElectron \t" << path << std::endl;
+               break;
+            case 3:
+               Paths[TYPE_TRIPLE_ELE].push_back(path);
+               //std::cout << "TripleElectron \t" << path << std::endl;
+               break;
          }
-         if (path.find("HLT_Ele") != std::string::npos && path.find("EleId") != std::string::npos && path.rfind("Ele") == path.find("EleId")) {
-            Paths[TYPE_SINGLE_ELE].push_back(path);
-            //std::cout << "Electron " << path << std::endl;
-         }
-         else if (path.find("HLT_Ele") != std::string::npos && path.rfind("Ele") > 4) {
-            Paths[TYPE_DOUBLE_ELE].push_back(path);
-            //std::cout << "DoubleElectron " << path << std::endl;
-         }
-         else if (path.find("HLT_DoubleEle") != std::string::npos && path.find("Ele") == path.rfind("Ele")) {
-            Paths[TYPE_DOUBLE_ELE].push_back(path);
-            //std::cout << "DoubleElectron " << path << std::endl;
-         }
-         else if (path.find("HLT_Ele") != std::string::npos && path.find("SC") != std::string::npos) {
-            Paths[TYPE_DOUBLE_ELE].push_back(path);
-            //std::cout << "DoubleElectron " << path << std::endl;
-         }
-         else if (path.find("HLT_DoubleEle") != std::string::npos && path.find("Ele") != path.rfind("Ele")) {
-            Paths[TYPE_TRIPLE_ELE].push_back(path);
-            //std::cout << "TripleElectron " << path << std::endl;
-         }
-         else if (path.find("HLT_TripleEle") != std::string::npos && path.find("Ele") == path.rfind("Ele")) {
-            Paths[TYPE_TRIPLE_ELE].push_back(path);
-            //std::cout << "TripleElectron " << path << std::endl;
-         }
-         else if (path.find("HLT_Photon") != std::string::npos && path.find("Ele") != std::string::npos) {
-            Paths[TYPE_DOUBLE_PHOTON].push_back(path);
-            //std::cout << "DoublePhoton " << path << std::endl;
-         }
-         else if (path.find("HLT_Photon") != std::string::npos && path.rfind("Photon") == 4) {
-            Paths[TYPE_SINGLE_PHOTON].push_back(path);
-            //std::cout << "Photon " << path << std::endl;
-         }
-         else if (path.find("HLT_Photon") != std::string::npos && path.rfind("Photon") > 4) {
-            Paths[TYPE_DOUBLE_PHOTON].push_back(path);
-            //std::cout << "DoublePhoton " << path << std::endl;
-         }
-         else if (path.find("HLT_DoublePhoton") != std::string::npos) {
-            Paths[TYPE_DOUBLE_PHOTON].push_back(path);
-            //std::cout << "DoublePhoton " << path << std::endl;
+
+         switch (totPhotonCount) {
+            case 1:
+               Paths[TYPE_SINGLE_PHOTON].push_back(path);
+               //std::cout << "Photon \t\t" << path << std::endl;
+               break;
+            case 2:
+               Paths[TYPE_DOUBLE_PHOTON].push_back(path);
+               //std::cout << "DoublePhoton \t" << path << std::endl;
+               break;
          }
       }
       //std::cout << i << " triggerName: " << path << " containing " << hltConfig_.size(i) << " modules."<< std::endl;
@@ -1084,12 +1163,12 @@ EmDQM::getPrimaryEtCut(const std::string& path)
 {
    double minEt = -1;
 
-   boost::regex reg("^HLT_.*?([[:digit:]]+).*");
+   boost::regex reg("^HLT_.*?(Ele|Photon|EG|SC)([[:digit:]]+).*");
 
    boost::smatch what;
    if (boost::regex_match(path, what, reg, boost::match_extra))
    {
-     minEt = boost::lexical_cast<double>(what[1]); 
+     minEt = boost::lexical_cast<double>(what[2]); 
    }
 
    return minEt;
@@ -1113,14 +1192,35 @@ EmDQM::makePSetForL1SeedFilter(const std::string& moduleName)
   retPSet.addParameter<int>("theHLTOutputTypes", trigger::TriggerL1NoIsoEG);
   
   // as HLTLevel1GTSeed has no parameter ncandcut we determine the value from the name of the filter
-  if (moduleName.find("Single") != std::string::npos)
-     retPSet.addParameter<int>("ncandcut", 1);
-  else if (moduleName.find("Double") != std::string::npos)
-     retPSet.addParameter<int>("ncandcut", 2);
-  else if (moduleName.find("Triple") != std::string::npos)
-     retPSet.addParameter<int>("ncandcut", 3);
-  else
-     retPSet.addParameter<int>("ncandcut", -1);
+
+  int orCount = countSubstring(moduleName, "OR");
+  int egCount = countSubstring(moduleName, "EG");
+  int dEgCount = countSubstring(moduleName, "DoubleEG");
+  int tEgCount = countSubstring(moduleName, "TripleEG");
+
+  int candCount = 2*tEgCount + dEgCount + egCount;
+  // if L1 is and OR of triggers try the assumption that all of them are similar first and, if not successful, let the path name decide
+  if (orCount > 0 && candCount > 0) {
+     if (egCount % (orCount+1) == 0 && dEgCount % (orCount+1) == 0 && tEgCount % (orCount+1) == 0) candCount /= (orCount+1);
+     else candCount = -1;
+  }
+
+  switch (candCount) {
+     case 0:
+        retPSet.addParameter<int>("ncandcut", 0);
+        break;
+     case 1:
+        retPSet.addParameter<int>("ncandcut", 1);
+        break;
+     case 2:
+        retPSet.addParameter<int>("ncandcut", 2);
+        break;
+     case 3:
+        retPSet.addParameter<int>("ncandcut", 3);
+        break;
+     default:
+        retPSet.addParameter<int>("ncandcut", -1);
+  }
 
   return retPSet;
 }

--- a/HLTriggerOffline/Egamma/src/EmDQMPostProcessor.cc
+++ b/HLTriggerOffline/Egamma/src/EmDQMPostProcessor.cc
@@ -267,9 +267,13 @@ void EmDQMPostProcessor::endRun(edm::Run const& run, edm::EventSetup const& es)
 
       dqm->goUp();
 
-      // fill overall efficiency histograms
+      // have a per-step histogram of the path on the front page
       std::string trigName = dir->substr(dir->rfind("/") + 1);
       trigName = trigName.replace(trigName.rfind("_DQM"),4,"");
+      TProfile* pathEffPerStep = dqm->bookProfile(trigName + "__" + histoName, total)->getTProfile();
+      pathEffPerStep->SetTitle((trigName + "__" + histoName).c_str());
+
+      // fill overall efficiency histograms
       double totCont = total->GetBinContent(total->GetNbinsX());
       double totErr = total->GetBinError(total->GetNbinsX());
       if (trigName.find("HLT_Ele") != std::string::npos || trigName.find("HLT_DoubleEle") != std::string::npos || trigName.find("HLT_TripleEle") != std::string::npos) {
@@ -295,8 +299,8 @@ void EmDQMPostProcessor::endRun(edm::Run const& run, edm::EventSetup const& es)
     else {
       allElePaths.back()->GetXaxis()->SetLabelSize(0.03);
       allPhotonPaths.back()->GetXaxis()->SetLabelSize(0.03);
-      dqm->bookProfile(allEleHistoName, allElePaths.back())->getTProfile();
-      dqm->bookProfile(allPhotonHistoName, allPhotonPaths.back())->getTProfile();
+      dqm->bookProfile(allEleHistoName, allElePaths.back());
+      dqm->bookProfile(allPhotonHistoName, allPhotonPaths.back());
     }
   } // loop over postfixes
   


### PR DESCRIPTION
Changes in EmDQM to validate all egamma paths in a given menu. Now all paths containing either 'Ele' or 'Photon' in the name are considered. This includes now also mu-ele cross triggers, where the electron is in the second leg. For those, the electron relevant filters are checked.
Per-filter efficieny plots are now also on the top page of the egamma validation for a quicker overview for the validator. The plots in the subfolders will be kept in parallel for one or two relval cycles to make sure the transition is smooth, and then dropped if the validators are happy with the new setup.
