### PR TITLE
Made statics const

### DIFF
--- a/PhysicsTools/PatUtils/interface/ShiftedJetProducerT.h
+++ b/PhysicsTools/PatUtils/interface/ShiftedJetProducerT.h
@@ -134,7 +134,7 @@ class ShiftedJetProducerT : public edm::EDProducer
       }
 
       if ( addResidualJES_ ) {
-	static SmearedJetProducer_namespace::RawJetExtractorT<T> rawJetExtractor;
+	const static SmearedJetProducer_namespace::RawJetExtractorT<T> rawJetExtractor;
 	reco::Candidate::LorentzVector rawJetP4 = rawJetExtractor(*originalJet);
 	if ( rawJetP4.E() > 1.e-1 ) {
 	  reco::Candidate::LorentzVector corrJetP4upToL3 =

--- a/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
+++ b/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
@@ -224,7 +224,7 @@ class SmearedJetProducerT : public edm::EDProducer
     for ( int jetIndex = 0; jetIndex < numJets; ++jetIndex ) {
       const T& jet = jets->at(jetIndex);
 
-      static SmearedJetProducer_namespace::RawJetExtractorT<T> rawJetExtractor;
+      static const SmearedJetProducer_namespace::RawJetExtractorT<T> rawJetExtractor;
       reco::Candidate::LorentzVector rawJetP4 = rawJetExtractor(jet);
       if ( verbosity_ ) {
 	std::cout << "rawJet: Pt = " << rawJetP4.pt() << ", eta = " << rawJetP4.eta() << ", phi = " << rawJetP4.phi() << std::endl;


### PR DESCRIPTION
The static analyzer flagged these as not being thread-unsafe because
of the use of a non-const statc. In this particular case the static
could be made const without a problem.
