### PR TITLE
Preparation for new mixing part 9

### DIFF
--- a/FastSimulation/Configuration/python/mixHitsAndTracksWithPU_cfi.py
+++ b/FastSimulation/Configuration/python/mixHitsAndTracksWithPU_cfi.py
@@ -76,9 +76,11 @@ mix = cms.EDProducer("MixingModule",
                      
                      input = cms.SecSource("PoolSource",
                          nbPileupEvents = cms.PSet(
-                         averageNumber = cms.double(0.) 
+                           probFunctionVariable = cms.vint32(0,1), # dummy value, it is replaced by the cfi that imports this file
+                           probValue = cms.vdouble(1,0), # dummy value, it is replaced by the cfi that imports this file
+                           histoFileName = cms.untracked.string('histProbFunction.root'),
                          ),
-                         type = cms.string('poisson'),
+                         type = cms.string('probFunction'),
                          sequential = cms.untracked.bool(False),
                          manage_OOT = cms.untracked.bool(False),  ## manage out-of-time pileup
                                            ## setting this to True means that the out-of-time pileup

--- a/FastSimulation/PileUpProducer/python/mix_2012_Summer_inTimeOnly_cff.py
+++ b/FastSimulation/PileUpProducer/python/mix_2012_Summer_inTimeOnly_cff.py
@@ -1,4 +1,5 @@
-from FastSimulation.PileUpProducer.PileUpSimulator13TeV_cfi import *
+import FWCore.ParameterSet.Config as cms
+#from FastSimulation.PileUpProducer.PileUpSimulator13TeV_cfi import *
 
 npu = cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59)
 prob = cms.vdouble(

--- a/FastSimulation/PileUpProducer/python/mix_E8TeV_AVE_10_BX_inTimeOnly.py
+++ b/FastSimulation/PileUpProducer/python/mix_E8TeV_AVE_10_BX_inTimeOnly.py
@@ -1,4 +1,5 @@
-from FastSimulation.PileUpProducer.PileUpSimulator8TeV_cfi import *
+import FWCore.ParameterSet.Config as cms
+#from FastSimulation.PileUpProducer.PileUpSimulator8TeV_cfi import *
 
 from FastSimulation.Configuration.CommonInputs_cff import *
 

--- a/FastSimulation/PileUpProducer/python/mix_E8TeV_AVE_140_BX_inTimeOnly.py
+++ b/FastSimulation/PileUpProducer/python/mix_E8TeV_AVE_140_BX_inTimeOnly.py
@@ -1,4 +1,5 @@
-from FastSimulation.PileUpProducer.PileUpSimulator8TeV_cfi import *
+import FWCore.ParameterSet.Config as cms
+#from FastSimulation.PileUpProducer.PileUpSimulator8TeV_cfi import *
 
 from FastSimulation.Configuration.CommonInputs_cff import *
 

--- a/FastSimulation/PileUpProducer/python/mix_E8TeV_AVE_200_BX_inTimeOnly.py
+++ b/FastSimulation/PileUpProducer/python/mix_E8TeV_AVE_200_BX_inTimeOnly.py
@@ -1,4 +1,5 @@
-from FastSimulation.PileUpProducer.PileUpSimulator8TeV_cfi import *
+import FWCore.ParameterSet.Config as cms
+#from FastSimulation.PileUpProducer.PileUpSimulator8TeV_cfi import *
 
 from FastSimulation.Configuration.CommonInputs_cff import *
 

--- a/FastSimulation/PileUpProducer/python/mix_E8TeV_AVE_70_BX_inTimeOnly.py
+++ b/FastSimulation/PileUpProducer/python/mix_E8TeV_AVE_70_BX_inTimeOnly.py
@@ -1,4 +1,5 @@
-from FastSimulation.PileUpProducer.PileUpSimulator8TeV_cfi import *
+import FWCore.ParameterSet.Config as cms
+#from FastSimulation.PileUpProducer.PileUpSimulator8TeV_cfi import *
 
 from FastSimulation.Configuration.CommonInputs_cff import *
 

--- a/FastSimulation/Tracking/plugins/RecoTrackAccumulator.cc
+++ b/FastSimulation/Tracking/plugins/RecoTrackAccumulator.cc
@@ -79,7 +79,7 @@ template<class T> void RecoTrackAccumulator::accumulateEvent(const T& e, edm::Ev
 
   if (tracks.isValid()) {
     short track_counter = 0;
-    //    short hit_counter = 0;
+    short hit_counter = 0;
     for (auto const& track : *tracks) {
       NewTrackList_->push_back(track);
       // track extras:
@@ -89,9 +89,11 @@ template<class T> void RecoTrackAccumulator::accumulateEvent(const T& e, edm::Ev
       //tx.setResiduals(track.residuals());
       // rechits:
       for( trackingRecHit_iterator hit = track.recHitsBegin(); hit != track.recHitsEnd(); ++ hit ) {
-	NewHitList_->push_back( (*hit)->clone() ); // is this safe?
+	//NewHitList_->push_back( (*hit)->clone() ); // is this safe?
+	NewHitList_->push_back( (*hits)[hit_counter] );
 	//	tx.add( TrackingRecHitRef( rHits, NewHitList_->size() - 1) );
-	//	hit_counter++;
+	NewTrackExtraList_->at(track_counter).add( TrackingRecHitRef( rHits, NewHitList_->size() - 1) );
+	hit_counter++;
       }
 
       track_counter++;


### PR DESCRIPTION
This PR contains an important fix to a bug that had sneaked inside 710pre3, related to the "DigiRecoMixing" option (non-default yet).
However, that bug was masking another problem. We had been discussing exactly that problem with Chris Jones in the comments of PR 2016 ( https://github.com/cms-sw/cmssw/pull/2016 ), but we didn't converge on a solution.
What you find in FastSimulation/Tracking/plugins/RecoTrackAccumulator.cc now is what I understood that Chris was suggesting to do. However, if you test it you will get:

<blockquote>
----- Begin Fatal Exception 27-Mar-2014 16:24:26 CET-----------------------
An exception of category 'InvalidReference' occurred while
   [0] Processing run: 1 lumi: 1 event: 1
   [1] Running path 'simulation_step'
   [2] Calling event method for module MixingModule/'mix'
Exception Message:
Inconsistency RefCore::pushBackItem: Ref or Ptr is inconsistent with RefVector (PtrVector)id = (1:184) should be (1:165)
----- End Fatal Exception -------------------------------------------------
</blockquote>


To do a test, you need to edit the last line in FastSimulation/Configuration/python/CommonInputs_cff.py from GenMixing to DigiRecoMixing, and then execute /afs/cern.ch/user/g/giamman/public/test.py (which includes a PU scenario that makes use of the new mixing).
