### PR TITLE
Fix HGCal build file

### DIFF
--- a/Geometry/HGCalCommonData/plugins/BuildFile.xml
+++ b/Geometry/HGCalCommonData/plugins/BuildFile.xml
@@ -8,5 +8,5 @@
 <use   name="DetectorDescription/Core"/>
 
 <flags   EDM_PLUGIN="1"/>
-<library file="DD*.cc" name="GeometryHGCalCommonDataPlugin"> </library>
+<library file="DD*.cc,module.cc" name="GeometryHGCalCommonDataPlugin"> </library>
 <library file="ShashlikNumberingInitialization.cc" name="GeometryShashlikNumberingInitialization"> </library>


### PR DESCRIPTION
module.cc is not currently included in GeometryHGCalCommonDataPlugin, so a lot of plugins are compiled but not declared as EDM plugins.  In the current Integration Builds tests 122xx, 124xx and 126xx fail with:

```
----- Begin Fatal Exception 27-Mar-2014 15:20:02 CET-----------------------
An exception of category 'PluginNotFound' occurred while
   [0] Processing run: 1
   [1] Running path 'simulation_step'
   [2] Calling beginRun for module OscarProducer/'g4SimHits'
   [3] Using EventSetup component XMLIdealGeometryESSource/'' to make data DDCompactView/'' in record IdealGeometryRecord
Exception Message:
Unable to find plugin 'hgcal:DDHGCalEEAlgo' in category 'DDAlgorithm'. Please check spelling of name.
----- End Fatal Exception -------------------------------------------------
```

This pull request should fix them.  They still fail in step 2 though.
