### PR TITLE
Remove Cintex

### DIFF
--- a/CondCore/CondDB/test/testRootStreaming.cpp
+++ b/CondCore/CondDB/test/testRootStreaming.cpp
@@ -1,7 +1,6 @@
 #include "FWCore/PluginManager/interface/PluginManager.h"
 #include "FWCore/PluginManager/interface/standard.h"
 #include "FWCore/PluginManager/interface/PluginCapabilities.h"
-#include "Cintex/Cintex.h"
 #include "MyTestData.h"
 //
 #include <iostream>
@@ -16,7 +15,6 @@ int main (int argc, char** argv)
   edmplugin::PluginManager::Config config;
   edmplugin::PluginManager::configure(edmplugin::standard::config());
   
-  ROOT::Cintex::Cintex::Enable();
   static std::string const prefix("LCGReflex/");
   edmplugin::PluginCapabilities::get()->load(prefix + "MyTestData");
 

--- a/CondCore/Utilities/bin/conddb_validate.cpp
+++ b/CondCore/Utilities/bin/conddb_validate.cpp
@@ -20,7 +20,6 @@
 
 // for the xml dump
 #include "TFile.h"
-#include "Cintex/Cintex.h"
 #include <sstream>
 #include <stdio.h>
 
@@ -115,7 +114,6 @@ cond::ValidateUtilities::ValidateUtilities():Utilities("conddb_validate"){
   addAuthenticationOptions();
   addOption<std::string>("tag","t","migrate only the tag (optional)");
   addOption<std::string>("dir","d","tmp folder to dump the temporary files for the comparison (optional)");
-  ROOT::Cintex::Cintex::Enable();
 }
 
 cond::ValidateUtilities::~ValidateUtilities(){


### PR DESCRIPTION
Totally trivial.  Remove use of Cintex that was carried forward from 7_1_X branch so that unit tests will compile.
Fixes compilation errors in ROOT6 IB.
Please merge promptly.
