### PR TITLE
Major performance improvement

### DIFF
--- a/CondCore/ORA/src/STLContainerStreamer.cc
+++ b/CondCore/ORA/src/STLContainerStreamer.cc
@@ -98,7 +98,7 @@ bool ora::STLContainerWriter::build( DataElement& offset,
                     "STLContainerWriter::build" );
   }
 
-  std::string valueName("value_type");
+  std::string valueName(m_associative ? "mapped_type" : "value_type");
   // Retrieve the relevant mapping element
   MappingElement::iterator iMe = m_mappingElement.find( valueName );
   if ( iMe == m_mappingElement.end() ) {
@@ -311,7 +311,7 @@ bool ora::STLContainerReader::build( DataElement& offset, IRelationalData& ){
                     "STLContainerReader::build" );
   }
 
-  std::string valueName("value_type");
+  std::string valueName(m_associative ? "mapped_type" : "value_type");
   // Retrieve the relevant mapping element
   MappingElement::iterator iMe = m_mappingElement.find( valueName );
   if ( iMe == m_mappingElement.end() ) {


### PR DESCRIPTION
This pull request, together with the new CMS patch to ROOT 6,
~wmtan/public/root6_patch_for_v5-99-05-lhcb-237-gb0e136f.patch
are a major performace improvement (a factor of 40 per event) for ROOT 6.  Among other things,
these changes prevent unnecessary runtime use of the llvm/clang compiler to get the std::type_info
from the typename when constructing a TypeWithDict from a type name.  For type names that are classes,
the use of the compiler is avoided entirely.  For type names that are not classes (e.g. typedefs, built ins, C-style arrays, enums, pointers, references), the compiler is used once per type, and the result  cached.

This pull request is functionally independent of the ROOT6 patch above, so they do not need to be picked up
in the same IB.  However, the performance improvement depends on both this pull request and the new patch.
Please merge promptly unless there are issues.
