### PR TITLE
Removed use of static for temporary variable in TauA1NuConstrainedFitter

### DIFF
--- a/RecoTauTag/ImpactParameter/interface/ErrorMatrixPropagator.h
+++ b/RecoTauTag/ImpactParameter/interface/ErrorMatrixPropagator.h
@@ -6,6 +6,7 @@
  * author: Ian M. Nugent
  * Humboldt Foundations
  */
+#include <functional>
 
 #include "TMatrixT.h"
 #include "TMatrixTSym.h"
@@ -17,7 +18,7 @@ class  ErrorMatrixPropagator {
  public:
   ErrorMatrixPropagator(){};
   virtual ~ErrorMatrixPropagator(){};
-  static TMatrixTSym<double> propagateError(TVectorT<double> (*f)(const TVectorT<double> &par), const TVectorT<double>& inPar, TMatrixTSym<double>& inCov, double epsilon=0.001, double errorEpsilonRatio=1000);
+  static TMatrixTSym<double> propagateError(std::function<TVectorT<double>(const TVectorT<double>&)> f, const TVectorT<double>& inPar, TMatrixTSym<double>& inCov, double epsilon=0.001, double errorEpsilonRatio=1000);
 };
 
 }

--- a/RecoTauTag/ImpactParameter/interface/TauA1NuConstrainedFitter.h
+++ b/RecoTauTag/ImpactParameter/interface/TauA1NuConstrainedFitter.h
@@ -39,8 +39,8 @@ class TauA1NuConstrainedFitter : public MultiProngTauSolver{
   static TVectorT<double> ComputeNuLorentzVectorPar(const TVectorT<double> &inpar);
   static TVectorT<double> ComputeA1LorentzVectorPar(const TVectorT<double> &inpar);
   static TVectorT<double> ComputeMotherLorentzVectorPar(const TVectorT<double> &inpar);
-  static TVectorT<double> SolveAmbiguityAnalytically(const TVectorT<double> &inpar);
-  static TVectorT<double> SolveAmbiguityAnalyticallywithRot(const TVectorT<double> &inpar);
+  static TVectorT<double> SolveAmbiguityAnalytically(const TVectorT<double> &inpar, unsigned int ambiguity);
+  static TVectorT<double> SolveAmbiguityAnalyticallywithRot(const TVectorT<double> &inpar, unsigned int ambiguity);
   static TVectorT<double> TauRot(const TVectorT<double> &inpar);
 
   void UpdateExpandedPar();

--- a/RecoTauTag/ImpactParameter/src/ErrorMatrixPropagator.cc
+++ b/RecoTauTag/ImpactParameter/src/ErrorMatrixPropagator.cc
@@ -9,7 +9,7 @@
 
 using namespace tauImpactParameter;
 
-TMatrixTSym<double> ErrorMatrixPropagator::propagateError(TVectorT<double> (*f)(const TVectorT<double>& par), 
+TMatrixTSym<double> ErrorMatrixPropagator::propagateError( std::function<TVectorT<double>(const TVectorT<double>&)> f, 
 							  const TVectorT<double>& inPar, TMatrixTSym<double>& inCov, double epsilon, double errorEpsilonRatio){
   TVectorT<double> v=f(inPar);
   TMatrixT<double> Jacobian(inPar.GetNrows(),v.GetNrows());


### PR DESCRIPTION
The threaded framework was failing becuase multiple DQM modules were calling
TauA1NuConstrainedFitter at the same time and the class was using a static
to hold temporary data. I changed the code so now one passes the value as an
argument of the function which uses the value. This also required changed
ErrorMatrixPropagator which was formerly taking a pointer to a function but
now sometimes the function being called needed an additional argument. Changing
ErrorMatrixPropagator to use a std::function<> instead of a pointer to a function
as the argument fixed that problem.
