### PR TITLE
Switch to vdt_headers toolfile

### DIFF
--- a/FWCore/Framework/bin/BuildFile.xml
+++ b/FWCore/Framework/bin/BuildFile.xml
@@ -40,3 +40,18 @@
   <use   name="FWCore/ParameterSet"/>
   <use   name="FWCore/PythonParameterSet"/>
 </bin>
+<bin   name="cmsRunVDT" file="cmsRun.cpp">
+  <use   name="vdt"/>
+  <use   name="tbb"/>
+  <use   name="boost"/>
+  <use   name="boost_program_options"/>
+  <use   name="boost_python"/>
+  <use   name="jemalloc"/>
+  <use   name="FWCore/Framework"/>
+  <use   name="FWCore/MessageLogger"/>
+  <use   name="FWCore/PluginManager"/>
+  <use   name="FWCore/ServiceRegistry"/>
+  <use   name="FWCore/Utilities"/>
+  <use   name="FWCore/ParameterSet"/>
+  <use   name="FWCore/PythonParameterSet"/>
+</bin>

--- a/Geometry/CommonTopologies/BuildFile.xml
+++ b/Geometry/CommonTopologies/BuildFile.xml
@@ -1,6 +1,6 @@
 <use   name="FWCore/MessageLogger"/>
 <use   name="Utilities/General"/>
-<use   name="vdt"/>
+<use   name="vdt_headers"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/RecoJets/JetProducers/BuildFile.xml
+++ b/RecoJets/JetProducers/BuildFile.xml
@@ -11,7 +11,7 @@
 <use   name="CommonTools/Utils"/>
 <use   name="fastjet"/>
 <use   name="roottmva"/>
-<use   name="vdt"/>
+<use   name="vdt_headers"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/RecoLocalCalo/EcalRecAlgos/BuildFile.xml
+++ b/RecoLocalCalo/EcalRecAlgos/BuildFile.xml
@@ -6,7 +6,7 @@
 <use   name="CondFormats/ESObjects"/>
 <use   name="CondFormats/EcalObjects"/>
 <use   name="CondFormats/DataRecord"/>
-<use   name="vdt"/>
+<use   name="vdt_headers"/>
 
 <use   name="root"/>
 <use   name="rootminuit"/>

--- a/RecoLocalTracker/SiPixelRecHits/BuildFile.xml
+++ b/RecoLocalTracker/SiPixelRecHits/BuildFile.xml
@@ -8,7 +8,7 @@
 <use   name="DataFormats/TrackerRecHit2D"/>
 <use   name="TrackingTools/TrajectoryState"/>
 <use   name="boost"/>
-<use   name="vdt"/>
+<use   name="vdt_headers"/>
 
 <export>
   <lib   name="1"/>

--- a/RecoLocalTracker/SiStripRecHitConverter/BuildFile.xml
+++ b/RecoLocalTracker/SiStripRecHitConverter/BuildFile.xml
@@ -15,7 +15,7 @@
 <use   name="CalibFormats/SiStripObjects"/>
 <use   name="CalibTracker/Records"/>
 <use   name="TrackingTools/TransientTrackingRecHit"/>
-<use   name="vdt"/>
+<use   name="vdt_headers"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/RecoParticleFlow/PFClusterProducer/BuildFile.xml
+++ b/RecoParticleFlow/PFClusterProducer/BuildFile.xml
@@ -7,7 +7,7 @@
 <use   name="DataFormats/HcalDetId"/>
 <use   name="RecoEcal/EgammaCoreTools"/>
 <use   name="RecoParticleFlow/PFClusterTools"/>
-<use   name="vdt"/>
+<use   name="vdt_headers"/>
 <use   name="rootmath"/>
 <use   name="root"/>
 <export>

--- a/RecoVertex/PrimaryVertexProducer/BuildFile.xml
+++ b/RecoVertex/PrimaryVertexProducer/BuildFile.xml
@@ -9,7 +9,7 @@
 <use   name="RecoVertex/VertexPrimitives"/>
 <use   name="RecoVertex/VertexTools"/>
 <use   name="TrackingTools/TransientTrack"/>
-<use   name="vdt"/>
+<use   name="vdt_headers"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/SimTracker/Common/BuildFile.xml
+++ b/SimTracker/Common/BuildFile.xml
@@ -1,5 +1,5 @@
 <use   name="CLHEP"/>
-<use   name="vdt"/>
+<use   name="vdt_headers"/>
 <use   name="DataFormats/HepMCCandidate"/>
 <use   name="SimDataFormats/TrackingAnalysis"/>
 <use   name="SimDataFormats/TrackingHit"/>

--- a/TrackingTools/AnalyticalJacobians/BuildFile.xml
+++ b/TrackingTools/AnalyticalJacobians/BuildFile.xml
@@ -4,5 +4,5 @@
 <use   name="TrackingTools/TrajectoryParametrization"/>
 <use   name="DataFormats/GeometrySurface"/>
 <use   name="DataFormats/Math"/>
-<use   name="vdt"/>
+<use   name="vdt_headers"/>
 <use   name="rootmath"/>

--- a/TrackingTools/GeomPropagators/BuildFile.xml
+++ b/TrackingTools/GeomPropagators/BuildFile.xml
@@ -3,7 +3,7 @@
 <use   name="DataFormats/GeometrySurface"/>
 <use   name="TrackingTools/AnalyticalJacobians"/>
 <use   name="TrackingTools/TrajectoryState"/>
-<use   name="vdt"/>
+<use   name="vdt_headers"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/TrackingTools/TrajectoryState/BuildFile.xml
+++ b/TrackingTools/TrajectoryState/BuildFile.xml
@@ -8,7 +8,7 @@
 <use   name="TrackingTools/TrajectoryParametrization"/>
 <use   name="MagneticField/Engine"/>
 <use   name="rootrflx"/>
-<use   name="vdt"/>
+<use   name="vdt_headers"/>
 <export>
   <lib   name="1"/>
 </export>


### PR DESCRIPTION
In cms-sw/cmsdist#524 we split vdt toolfile in `vdt_headers` and `vdt` (i.e. the compatibility library). This moves all the build file to use `vdt_headers` and introduces a cmsRunVDT which binds libvdt as early as possible (to demonstrate this is actually enough).
