### PR TITLE
Added refToPSet_ ability in python PSet

### DIFF
--- a/FWCore/ParameterSet/python/Config.py
+++ b/FWCore/ParameterSet/python/Config.py
@@ -856,28 +856,51 @@ class Process(object):
                 self.__thelist.append(pset)
             def newPSet(self):
                 return self.__processPSet.newPSet()
+        #This adaptor is used to 'add' the method 'getTopPSet_'
+        # to the ProcessDesc and PythonParameterSet C++ classes.
+        # This method is needed for the PSet refToPSet_ functionality.
+        class TopLevelPSetAcessorAdaptor(object):
+            def __init__(self,ppset,process):
+                self.__ppset = ppset
+                self.__process = process
+            def __getattr__(self,attr):
+                return getattr(self.__ppset,attr)
+            def getTopPSet_(self,label):
+                return getattr(self.__process,label)
+            def newPSet(self):
+                return TopLevelPSetAcessorAdaptor(self.__ppset.newPSet(),self.__process)
+            def addPSet(self,tracked,name,ppset):
+                return self.__ppset.addPSet(tracked,name,self.__extractPSet(ppset))
+            def addVPSet(self,tracked,name,vpset):
+                return self.__ppset.addVPSet(tracked,name,[self.__extractPSet(x) for x in vpset])
+            def __extractPSet(self,pset):
+                if isinstance(pset,TopLevelPSetAcessorAdaptor):
+                    return pset.__ppset
+                return pset
+                
         self.validate()
         processPSet.addString(True, "@process_name", self.name_())
         all_modules = self.producers_().copy()
         all_modules.update(self.filters_())
         all_modules.update(self.analyzers_())
         all_modules.update(self.outputModules_())
-        self._insertInto(processPSet, self.psets_())
-        self._insertInto(processPSet, self.vpsets_())
-        self._insertManyInto(processPSet, "@all_modules", all_modules, True)
-        self._insertOneInto(processPSet,  "@all_sources", self.source_(), True)
-        self._insertOneInto(processPSet,  "@all_loopers", self.looper_(), True)
-        self._insertOneInto(processPSet,  "@all_subprocesses", self.subProcess_(), False)
-        self._insertManyInto(processPSet, "@all_esmodules", self.es_producers_(), True)
-        self._insertManyInto(processPSet, "@all_essources", self.es_sources_(), True)
-        self._insertManyInto(processPSet, "@all_esprefers", self.es_prefers_(), True)
-        self._insertManyInto(processPSet, "@all_aliases", self.aliases_(), True)
-        self._insertPaths(processPSet)
+        adaptor = TopLevelPSetAcessorAdaptor(processPSet,self)
+        self._insertInto(adaptor, self.psets_())
+        self._insertInto(adaptor, self.vpsets_())
+        self._insertManyInto(adaptor, "@all_modules", all_modules, True)
+        self._insertOneInto(adaptor,  "@all_sources", self.source_(), True)
+        self._insertOneInto(adaptor,  "@all_loopers", self.looper_(), True)
+        self._insertOneInto(adaptor,  "@all_subprocesses", self.subProcess_(), False)
+        self._insertManyInto(adaptor, "@all_esmodules", self.es_producers_(), True)
+        self._insertManyInto(adaptor, "@all_essources", self.es_sources_(), True)
+        self._insertManyInto(adaptor, "@all_esprefers", self.es_prefers_(), True)
+        self._insertManyInto(adaptor, "@all_aliases", self.aliases_(), True)
+        self._insertPaths(adaptor)
         #handle services differently
         services = []
         for n in self.services_():
-             getattr(self,n).insertInto(ServiceInjectorAdaptor(processPSet,services))
-        processPSet.addVPSet(False,"services",services)
+             getattr(self,n).insertInto(ServiceInjectorAdaptor(adaptor,services))
+        adaptor.addVPSet(False,"services",services)
         return processPSet
 
     def validate(self):
@@ -1128,7 +1151,7 @@ if __name__=="__main__":
             self.__insertValue(tracked,label,value)
         def newPSet(self):
             return TestMakePSet()
-        
+    
     class TestModuleCommand(unittest.TestCase):
         def setUp(self):
             """Nothing to do """
@@ -1681,6 +1704,18 @@ process.subProcess = cms.SubProcess( process = childProcess, SelectEvents = cms.
             self.assertEqual((True,['a']),p.values["@sub_process"][1].values["process"][1].values['@all_modules'])
             self.assertEqual((True,['p']),p.values["@sub_process"][1].values["process"][1].values['@paths'])
             self.assertEqual({'@service_type':(True,'Foo')}, p.values["@sub_process"][1].values["process"][1].values["services"][1][0].values)
+        def testRefToPSet(self):
+            proc = Process("test")
+            proc.top = PSet(a = int32(1))
+            proc.ref = PSet(refToPSet_ = string("top"))
+            proc.ref2 = PSet( a = int32(1), b = PSet( refToPSet_ = string("top")))
+            proc.ref3 = PSet(refToPSet_ = string("ref"))
+            p = TestMakePSet()
+            proc.fillProcessDesc(p)
+            self.assertEqual((True,1),p.values["ref"][1].values["a"])
+            self.assertEqual((True,1),p.values["ref3"][1].values["a"])
+            self.assertEqual((True,1),p.values["ref2"][1].values["a"])
+            self.assertEqual((True,1),p.values["ref2"][1].values["b"][1].values["a"])
         def testPrune(self):
             p = Process("test")
             p.a = EDAnalyzer("MyAnalyzer")

--- a/FWCore/ParameterSet/python/Types.py
+++ b/FWCore/ParameterSet/python/Types.py
@@ -620,6 +620,10 @@ class PSet(_ParameterTypeBase,_Parameterizable,_ConfigureComponent,_Labelable):
         _Parameterizable.__init__(self,*arg,**args)
     def value(self):
         return self
+    def isRef_(self):
+        """Returns true if this PSet is actually a reference to a different PSet
+            """
+        return hasattr(self,"refToPSet_")
     @staticmethod
     def _isValid(value):
         return True
@@ -663,6 +667,10 @@ class PSet(_ParameterTypeBase,_Parameterizable,_ConfigureComponent,_Labelable):
         return object.__str__(self)
     def insertInto(self, parameterSet, myname):
         newpset = parameterSet.newPSet()
+        if self.isRef_():
+            ref = parameterSet.getTopPSet_(self.refToPSet_.value())
+            ref.insertInto(parameterSet,myname)
+            return
         self.insertContentsInto(newpset)
         parameterSet.addPSet(self.isTracked(), myname, newpset)
 


### PR DESCRIPTION
The python PSet class is now capable of containing a lazy evaluated reference to a PSet at the highest level of the Process. This is done by using a parameter named refToPSet_ which takes a cms.string with the label of the top level PSet to which one wants to reference. The reference does not happen until we convert the python PSet into the C++ ParameterSet. At that time a copy to the reference is used to create the C++ ParameterSet.
