### PR TITLE
fixes for boostio branch

### DIFF
--- a/CondCore/CondDB/src/IOVSchema.cc
+++ b/CondCore/CondDB/src/IOVSchema.cc
@@ -313,9 +313,17 @@ namespace cond {
 				 const cond::Binary& streamerInfoData,				      
     				 const boost::posix_time::ptime& insertionTime ){
       std::string version("dummy");
-      RowBuffer< HASH, OBJECT_TYPE, DATA, STREAMER_INFO, VERSION, INSERTION_TIME > dataToInsert( std::tie( payloadHash, objectType, payloadData, streamerInfoData, version, insertionTime ) ); 
-      bool failOnDuplicate = false;
-      return insertInTable( m_schema, tname, dataToInsert.get(), failOnDuplicate );
+      if (streamerInfoData.size() == 0) { // we can't insert NULLs here
+	void * foo = new int(0);
+	cond::Binary fooB(foo, sizeof(foo));
+	RowBuffer< HASH, OBJECT_TYPE, DATA, STREAMER_INFO, VERSION, INSERTION_TIME > dataToInsert( std::tie( payloadHash, objectType, payloadData, fooB, version, insertionTime ) ); 
+	bool failOnDuplicate = false;
+	return insertInTable( m_schema, tname, dataToInsert.get(), failOnDuplicate );
+      } else {
+	RowBuffer< HASH, OBJECT_TYPE, DATA, STREAMER_INFO, VERSION, INSERTION_TIME > dataToInsert( std::tie( payloadHash, objectType, payloadData, streamerInfoData, version, insertionTime ) ); 
+	bool failOnDuplicate = false;
+	return insertInTable( m_schema, tname, dataToInsert.get(), failOnDuplicate );
+      }
     }
 
     cond::Hash PAYLOAD::Table::insertIfNew( const std::string& payloadObjectType, 

--- a/CondFormats/PhysicsToolsObjects/src/SerializationManual.h
+++ b/CondFormats/PhysicsToolsObjects/src/SerializationManual.h
@@ -1,3 +1,6 @@
+
+#include "boost/serialization/assume_abstract.hpp"
+
 COND_SERIALIZATION_INSTANTIATE(PhysicsTools::Calibration::Histogram<double, double>);
 COND_SERIALIZATION_INSTANTIATE(PhysicsTools::Calibration::Histogram<float, float>);
 
@@ -10,18 +13,21 @@ COND_SERIALIZATION_INSTANTIATE(PhysicsTools::Calibration::Histogram3D<float, flo
 COND_SERIALIZATION_INSTANTIATE(PhysicsTools::Calibration::Range<double>);
 COND_SERIALIZATION_INSTANTIATE(PhysicsTools::Calibration::Range<float>);
 
+//-ap not really sure that one is needed:
+BOOST_SERIALIZATION_ASSUME_ABSTRACT(PhysicsTools::Calibration::VarProcessor); 
 
-COND_SERIALIZATION_REGISTER_POLYMORPHIC(PhysicsTools::Calibration::ProcOptional)
-COND_SERIALIZATION_REGISTER_POLYMORPHIC(PhysicsTools::Calibration::ProcCount)
-COND_SERIALIZATION_REGISTER_POLYMORPHIC(PhysicsTools::Calibration::ProcClassed)
-COND_SERIALIZATION_REGISTER_POLYMORPHIC(PhysicsTools::Calibration::ProcSplitter)
-COND_SERIALIZATION_REGISTER_POLYMORPHIC(PhysicsTools::Calibration::ProcForeach)
-COND_SERIALIZATION_REGISTER_POLYMORPHIC(PhysicsTools::Calibration::ProcSort)
-COND_SERIALIZATION_REGISTER_POLYMORPHIC(PhysicsTools::Calibration::ProcCategory)
-COND_SERIALIZATION_REGISTER_POLYMORPHIC(PhysicsTools::Calibration::ProcNormalize)
-COND_SERIALIZATION_REGISTER_POLYMORPHIC(PhysicsTools::Calibration::ProcLikelihood)
-COND_SERIALIZATION_REGISTER_POLYMORPHIC(PhysicsTools::Calibration::ProcLinear)
-COND_SERIALIZATION_REGISTER_POLYMORPHIC(PhysicsTools::Calibration::ProcMultiply)
-COND_SERIALIZATION_REGISTER_POLYMORPHIC(PhysicsTools::Calibration::ProcMatrix)
-COND_SERIALIZATION_REGISTER_POLYMORPHIC(PhysicsTools::Calibration::ProcExternal)
-COND_SERIALIZATION_REGISTER_POLYMORPHIC(PhysicsTools::Calibration::ProcMLP)
+COND_SERIALIZABLE_POLYMORPHIC(PhysicsTools::Calibration::VarProcessor)
+COND_SERIALIZABLE_POLYMORPHIC(PhysicsTools::Calibration::ProcOptional)
+COND_SERIALIZABLE_POLYMORPHIC(PhysicsTools::Calibration::ProcCount)
+COND_SERIALIZABLE_POLYMORPHIC(PhysicsTools::Calibration::ProcClassed)
+COND_SERIALIZABLE_POLYMORPHIC(PhysicsTools::Calibration::ProcSplitter)
+COND_SERIALIZABLE_POLYMORPHIC(PhysicsTools::Calibration::ProcForeach)
+COND_SERIALIZABLE_POLYMORPHIC(PhysicsTools::Calibration::ProcSort)
+COND_SERIALIZABLE_POLYMORPHIC(PhysicsTools::Calibration::ProcCategory)
+COND_SERIALIZABLE_POLYMORPHIC(PhysicsTools::Calibration::ProcNormalize)
+COND_SERIALIZABLE_POLYMORPHIC(PhysicsTools::Calibration::ProcLikelihood)
+COND_SERIALIZABLE_POLYMORPHIC(PhysicsTools::Calibration::ProcLinear)
+COND_SERIALIZABLE_POLYMORPHIC(PhysicsTools::Calibration::ProcMultiply)
+COND_SERIALIZABLE_POLYMORPHIC(PhysicsTools::Calibration::ProcMatrix)
+COND_SERIALIZABLE_POLYMORPHIC(PhysicsTools::Calibration::ProcExternal)
+COND_SERIALIZABLE_POLYMORPHIC(PhysicsTools::Calibration::ProcMLP)


### PR DESCRIPTION
+1
- use the correct macro for the boost export declaration 
- temporary workaround to store a non-NULL streamerInfo, DB has non-null constraint :(
