### PR TITLE
Workaround for ROOT6 checksum changes in conditions database

### DIFF
--- a/FWCore/Framework/bin/cmsRun.cpp
+++ b/FWCore/Framework/bin/cmsRun.cpp
@@ -23,6 +23,7 @@ PSet script.   See notes in EventProcessor.cpp for details about it.
 #include "FWCore/Utilities/interface/Presence.h"
 
 #include "TError.h"
+#include "TFile.h"
 
 #include "boost/program_options.hpp"
 #include "boost/shared_ptr.hpp"
@@ -329,6 +330,11 @@ int main(int argc, char* argv[]) {
         edm::MessageDrop::instance()->jobMode = jobMode;
       }
 
+      // FIXME: BEGIN temporary workaround for checksum problems in conditions
+      edm::FileInPath condfile("FWCore/Framework/data/cond_dump.root");
+      TFile* fptr = TFile::Open(condfile.fullPath().c_str());
+      fptr->Close();
+      // END temporary workaround for checksum problems in conditions
       context = "Constructing the EventProcessor";
       std::auto_ptr<edm::EventProcessor>
           procP(new


### PR DESCRIPTION
This is a temporary workaround for a problem causing almost all relval tests in the ROOT6 IB to fail.
The conditions database currently in use does not have streamer information.  So, there is no schema evolution capability.  Any checksum difference between ROOT 5 and ROOT 6 in a class read from the conditions database causes a fatal checksum error.
This workaround opens and closes a file containing conditions classes with streamer information at the beginning of the job.  This allows the normal schema evolution to work.
Please merge this pull request promptly unless there are issues.
