### PR TITLE
Cache invalid types also

### DIFF
--- a/FWCore/Utilities/src/TypeWithDict.cc
+++ b/FWCore/Utilities/src/TypeWithDict.cc
@@ -48,6 +48,7 @@ namespace edm {
     }
     TType* type = gInterpreter->Type_Factory(name);
     if (!gInterpreter->Type_IsValid(type)) {
+      typeMap.insert(std::make_pair(name, TypeWithDict()));
       return TypeWithDict();
     }
     typeMap.insert(std::make_pair(name, TypeWithDict(type, 0L)));


### PR DESCRIPTION
This is a small correction/enhancement to the major performance improvement of caching TypeWithDict for non-class types.  In the prior pull request, caching was done only for valid types.  However, the conditions database also looks up types that are invaild. There is nothing wrong with this, but a default constructed TypeWithDict for an invalid type also needs to be cached.
Please merge this promptly unless there are issues.
