### PR TITLE
updated TTI customization: keep only the signal TrackingParticles; add c...

### DIFF
--- a/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
@@ -15,6 +15,7 @@ from SLHCUpgradeSimulations.Configuration.phase2TkCustoms_LB_4LPS_2L2S import l1
 from SLHCUpgradeSimulations.Configuration.phase1TkCustomsPixel10D import customise as customisePhase1TkPixel10D
 from SLHCUpgradeSimulations.Configuration.combinedCustoms_TTI import customise as customiseTTI
 from SLHCUpgradeSimulations.Configuration.combinedCustoms_TTI import l1EventContent_TTI as customise_ev_l1tracker
+from SLHCUpgradeSimulations.Configuration.combinedCustoms_TTI import l1EventContent_TTI_forHLT
 
 from SLHCUpgradeSimulations.Configuration.customise_mixing import customise_NoCrossing
 from SLHCUpgradeSimulations.Configuration.phase1TkCustoms import customise as customisePhase1Tk
@@ -113,8 +114,16 @@ def cust_2023TTI(process):
     process=customiseBE5DPixel10D(process)
     process=customise_HcalPhase0(process)
     process=customise_ev_l1tracker(process)
-
     return process
+
+def cust_2023TTI_forHLT(process):
+    process=customisePostLS1(process)
+    process=customiseTTI(process)
+    process=customiseBE5DPixel10D(process)
+    process=customise_HcalPhase0(process)
+    process=l1EventContent_TTI_forHLT(process)
+    return process
+
 
 def noCrossing(process):
     process=customise_NoCrossing(process)

--- a/SLHCUpgradeSimulations/Configuration/python/combinedCustoms_TTI.py
+++ b/SLHCUpgradeSimulations/Configuration/python/combinedCustoms_TTI.py
@@ -6,9 +6,24 @@ def customise(process):
     return process	
 
 def customise_Digi_TTI(process):
-    # needed in addition to customise_Digi (only bx=0 for TrackingParticles)
+
+    # keep bx=0 only for TrackingParticles  (still includes all the in-time PU)
     process.mix.digitizers.mergedtruth.maximumPreviousBunchCrossing = cms.uint32(0)
     process.mix.digitizers.mergedtruth.maximumSubsequentBunchCrossing = cms.uint32(0)
+
+    # remove all PU from TrackingParticles
+    process.mix.digitizers.mergedtruth.select = cms.PSet(
+        lipTP = cms.double(1000),
+        chargedOnlyTP = cms.bool(False),
+        pdgIdTP = cms.vint32(),
+        signalOnlyTP = cms.bool(True),
+        minRapidityTP = cms.double(-5.0),
+        minHitTP = cms.int32(0),
+        ptMinTP = cms.double(0.),
+        maxRapidityTP = cms.double(5.0),
+        tipTP = cms.double(1000),
+        stableOnlyTP = cms.bool( False )
+     )
     return process
 
 
@@ -40,11 +55,51 @@ def l1EventContent_TTI(process):
 	    getattr(process,b).outputCommands.append('drop *_TTClusterAssociatorFromPixelDigis_ClusterInclusive_*')
 
 	    # other savings. The following collections can be obtained from RAW2DIGI
-	    getattr(process,b).outputCommands.append('drop EcalTriggerPrimitiveDigisSorted_simEcalTriggerPrimitiveDigis_*_*')
-            getattr(process,b).outputCommands.append('drop HcalTriggerPrimitiveDigisSorted_simHcalTriggerPrimitiveDigis_*_*')
+	    #getattr(process,b).outputCommands.append('drop EcalTriggerPrimitiveDigisSorted_simEcalTriggerPrimitiveDigis_*_*')
+            #getattr(process,b).outputCommands.append('drop HcalTriggerPrimitiveDigisSorted_simHcalTriggerPrimitiveDigis_*_*')
 	    getattr(process,b).outputCommands.append('drop *_simEcalDigis_*_*')
 	    getattr(process,b).outputCommands.append('drop *_simEcalPreshowerDigis_*_*')
 	    getattr(process,b).outputCommands.append('drop *_simHcalDigis_*_*')
-	    getattr(process,b).outputCommands.append('drop *_simSiStripDigis_*_*')
+	    #getattr(process,b).outputCommands.append('drop *_simSiStripDigis_*_*')
 
     return process
+
+
+def l1EventContent_TTI_forHLT(process):
+
+    # as above, but keep the tracker digis. In case we want to produce some
+    # samples that the HLT could use for CPU studies...
+
+    alist=['RAWSIM','FEVTDEBUG','FEVTDEBUGHLT','GENRAW','RAWSIMHLT','FEVT']
+    for a in alist:
+        b=a+'output'
+        if hasattr(process,b):
+
+            getattr(process,b).outputCommands.append('keep *_TTClustersFromPixelDigis_*_*')
+            getattr(process,b).outputCommands.append('keep *_TTStubsFromPixelDigis_*_*')
+            getattr(process,b).outputCommands.append('keep *_TTTracksFromPixelDigis_*_*')
+
+            getattr(process,b).outputCommands.append('keep *_TTClusterAssociatorFromPixelDigis_*_*')
+            getattr(process,b).outputCommands.append('keep *_TTStubAssociatorFromPixelDigis_*_*')
+            getattr(process,b).outputCommands.append('keep *_TTTrackAssociatorFromPixelDigis_*_*')
+
+            getattr(process,b).outputCommands.append('drop PixelDigiSimLinkedmDetSetVector_mix_*_*')
+            getattr(process,b).outputCommands.append('drop PixelDigiedmDetSetVector_mix_*_*')
+
+	    # that's the only difference w.r.t. l1EventContent_TTI :
+            getattr(process,b).outputCommands.append('keep *_simSiPixelDigis_*_*')
+
+            # drop what is not used in the stubs
+            getattr(process,b).outputCommands.append('drop *_TTStubAssociatorFromPixelDigis_StubRejected_*')
+            getattr(process,b).outputCommands.append('drop *_TTStubsFromPixelDigis_StubRejected_*')
+            getattr(process,b).outputCommands.append('drop *_TTClustersFromPixelDigis_ClusterInclusive_*')
+            getattr(process,b).outputCommands.append('drop *_TTClusterAssociatorFromPixelDigis_ClusterInclusive_*')
+
+            # other savings. The following collections can be obtained from RAW2DIGI
+            getattr(process,b).outputCommands.append('drop *_simEcalDigis_*_*')
+            getattr(process,b).outputCommands.append('drop *_simEcalPreshowerDigis_*_*')
+            getattr(process,b).outputCommands.append('drop *_simHcalDigis_*_*')
+
+    return process
+
+


### PR DESCRIPTION
- updated customise_Digi_TTI in SLHCUpgradeSimulations/Configuration/python/combinedCustoms_TTI.py: keep only TrackingParticles from the main interaction
- minor update of l1EventContent_TTI and addition of a l1EventContent_TTI_forHLT, the latter may be used if we need to produce samples that may be used for HLT CPU studies
- added a cust_2023TTI_forHLT in combinedCustoms.py, which is the same as the default cust_2023TTI except that we call the "forHLT" event content
