### PR TITLE
Use new return value from FPE

### DIFF
--- a/FWCore/Services/test/fpe_test_2.sh
+++ b/FWCore/Services/test/fpe_test_2.sh
@@ -5,12 +5,12 @@ ulimit -c 0
 CONFIG=${LOCAL_TEST_DIR}/fpe_test_2_cfg.py
 
 echo "***"
-echo "If the test is successful, cmsRun will fail (abort) with error status 139 or 11."
+echo "If the test is successful, cmsRun will fail (abort) with error status 136 or 11."
 echo "The purpose is to test that floating point exceptions cause failures."
 echo "If the floating point exception does not cause the cmsRun job to"
 echo "abort, an explicit exception will thrown from CMS code that also causes"
 echo "an abort, but this time with error status 65."
-echo "The values 139 and 11 depend on things underneath that CMS does not"
+echo "The values 136 and 11 depend on things underneath that CMS does not"
 echo "control.  These values have changed before and may change again. If"
 echo "they do, someone will need to investigate and change the criteria in"
 echo "this shell script (fpe_test_2.sh)."
@@ -51,8 +51,8 @@ unset OVERFLOW
 
 echo "Completed cmsRun with DIVIDEBYZERO exception enabled"
 echo "cmsRun status: " $status
-if [ $status -ne 139 -a $status -ne 11 ] ; then
- echo "Test FAILED, status neither 139 nor 11"
+if [ $status -ne 136 -a $status -ne 11 ] ; then
+ echo "Test FAILED, status neither 136 nor 11"
  exit 1
 fi
 
@@ -70,8 +70,8 @@ unset OVERFLOW
 
 echo "Completed cmsRun with INVALID exception enabled"
 echo "cmsRun status: " $status
-if [ $status -ne 139 -a $status -ne 11 ] ; then
- echo "Test FAILED, status neither 139 nor 11"
+if [ $status -ne 136 -a $status -ne 11 ] ; then
+ echo "Test FAILED, status neither 136 nor 11"
  exit 1
 fi
 
@@ -89,8 +89,8 @@ unset OVERFLOW
 
 echo "Completed cmsRun with OVERFLOW exception enabled"
 echo "cmsRun status: " $status
-if [ $status -ne 139 -a $status -ne 11 ] ; then
- echo "Test FAILED, status neither 139 nor 11"
+if [ $status -ne 136 -a $status -ne 11 ] ; then
+ echo "Test FAILED, status neither 136 nor 11"
  exit 1
 fi
 
@@ -108,8 +108,8 @@ unset OVERFLOW
 
 echo "Completed cmsRun with UNDERFLOW exception enabled"
 echo "cmsRun status: " $status
-if [ $status -ne 139 -a $status -ne 11 ] ; then
- echo "Test FAILED, status neither 139 nor 11"
+if [ $status -ne 136 -a $status -ne 11 ] ; then
+ echo "Test FAILED, status neither 136 nor 11"
  exit 1
 fi
 


### PR DESCRIPTION
This is a fix for the unit test for floating point exceptions in the ROOT 6 IB.  The return code from cmsRun when a floating point exception is thrown has changed between ROOT 5 and ROOT 6.  This is not fully understood, but is likely due tot eh ROOT signal handler, which cmsRun uses.  Since the previous return code in the test was empirically determined, we simply empirically determine the new return code and change it in the test script.

Please merge this promptly unless there are issues.
