### PR TITLE
FastTimerService: fix DQM directory structure

### DIFF
--- a/HLTrigger/Timer/plugins/BuildFile.xml
+++ b/HLTrigger/Timer/plugins/BuildFile.xml
@@ -1,4 +1,5 @@
 <library file="*.cc" name="HLTriggerTimerPlugins">
+  <use   name="boost_regex"/>
   <use   name="HLTrigger/Timer"/>
   <use   name="FWCore/Framework"/>
   <use   name="FWCore/ParameterSet"/>

--- a/HLTrigger/Timer/plugins/FastTimerServiceClient.cc
+++ b/HLTrigger/Timer/plugins/FastTimerServiceClient.cc
@@ -2,6 +2,9 @@
 #include <string>
 #include <cstring>
 
+// boost headers
+#include <boost/regex.hpp>
+
 // Root headers
 #include <TH1F.h>
 
@@ -31,16 +34,15 @@ private:
   std::string m_dqm_path;
 
   void analyze(const edm::Event & event, const edm::EventSetup & setup) override;
-  void beginJob() override;
-  void endJob() override;
-  void beginRun(edm::Run const & run, edm::EventSetup const & setup) override;
-  void endRun  (edm::Run const & run, edm::EventSetup const & setup) override;
-  void beginLuminosityBlock(edm::LuminosityBlock const & lumi, edm::EventSetup const & setup) override;
-  void endLuminosityBlock  (edm::LuminosityBlock const & lumi, edm::EventSetup const & setup) override;
+  void endRun(edm::Run const & run, edm::EventSetup const & setup) override;
+  void endLuminosityBlock(edm::LuminosityBlock const & lumi, edm::EventSetup const & setup) override;
 
 private:
   void fillSummaryPlots();
+  void fillProcessSummaryPlots(std::string const & path);
+  void fillPathSummaryPlots(double events, std::string const & path);
 };
+
 
 FastTimerServiceClient::FastTimerServiceClient(edm::ParameterSet const & config) :
   m_dqm_path( config.getUntrackedParameter<std::string>( "dqmPath" ) )
@@ -52,22 +54,7 @@ FastTimerServiceClient::~FastTimerServiceClient()
 }
 
 void
-FastTimerServiceClient::analyze(edm::Event const & event, edm::EventSetup const & setup) 
-{
-}
-
-void
-FastTimerServiceClient::beginJob(void)
-{
-}
-
-void
-FastTimerServiceClient::endJob(void)
-{
-}
-
-void
-FastTimerServiceClient::beginRun(edm::Run const & run, edm::EventSetup const & setup)
+FastTimerServiceClient::analyze(edm::Event const & event, edm::EventSetup const & setup)
 {
 }
 
@@ -75,11 +62,6 @@ void
 FastTimerServiceClient::endRun(edm::Run const & run, edm::EventSetup const & setup)
 {
   fillSummaryPlots();
-}
-
-void
-FastTimerServiceClient::beginLuminosityBlock(edm::LuminosityBlock const & lumi, edm::EventSetup const & setup)
-{
 }
 
 void
@@ -95,30 +77,74 @@ FastTimerServiceClient::fillSummaryPlots(void)
   if (dqm == 0)
     // cannot access the DQM store
     return;
-  
-  MonitorElement * me;
-  me = dqm->get(m_dqm_path + "/event");
+
+  if (dqm->get(m_dqm_path + "/event")) {
+    // the plots are directly in the configured folder
+    fillProcessSummaryPlots(m_dqm_path);
+  } else {
+    static const boost::regex running_n_processes(".*/Running [0-9]+ processes");
+    dqm->setCurrentFolder(m_dqm_path);
+    std::vector<std::string> subdirs = dqm->getSubdirs();
+    for (auto const & subdir: subdirs) {
+      if (boost::regex_match(subdir, running_n_processes)) {
+        // the plots are in a per-number-of-processes folder
+        if (dqm->get(subdir + "/event"))
+          fillProcessSummaryPlots(subdir);
+      }
+    }
+  }
+}
+
+
+
+void
+FastTimerServiceClient::fillProcessSummaryPlots(std::string const & current_path) {
+  DQMStore * dqm = edm::Service<DQMStore>().operator->();
+
+  MonitorElement * me = dqm->get(current_path + "/event");
   if (me == 0)
     // no FastTimerService DQM information
     return;
+
   double events = me->getTH1F()->GetEntries();
 
-  // note: the following (identical) loops need to be kept separate, as any of these group of histograms might be missing
+  // look for per-process directories
+  static const boost::regex process_name(".*/process .*");
+  dqm->setCurrentFolder(current_path);
+  std::vector<std::string> subdirs = dqm->getSubdirs();
+  for (auto const & subdir: subdirs) {
+    if (boost::regex_match(subdir, process_name)) {
+      // look for per-path plots inside each per-process directory
+      if (dqm->dirExists(subdir + "/Paths"))
+        fillPathSummaryPlots(events, subdir);
+    }
+  }
+
+  // look for per-path plots inside the current directory
+  if (dqm->dirExists(current_path + "/Paths"))
+    fillPathSummaryPlots(events, current_path);
+}
+
+void
+FastTimerServiceClient::fillPathSummaryPlots(double events, std::string const & current_path) {
+  DQMStore * dqm = edm::Service<DQMStore>().operator->();
+
+  // note: the following checks need to be kept separate, as any of these histograms might be missing
   // if any of them is filled, size will have the total number of paths, and "paths" can be used to extract the list of labels
-  dqm->setCurrentFolder(m_dqm_path);
+  MonitorElement * me;
   TProfile const * paths = nullptr;
   uint32_t         size  = 0;
 
   // extract the list of Paths and EndPaths from the summary plots
-  if (( me = dqm->get(m_dqm_path + "/paths_active_time") )) {
-    paths = me->getTProfile();
-    size  = paths->GetXaxis()->GetNbins();
-  } else 
-  if (( me = dqm->get(m_dqm_path + "/paths_total_time") )) {
+  if (( me = dqm->get(current_path + "/paths_active_time") )) {
     paths = me->getTProfile();
     size  = paths->GetXaxis()->GetNbins();
   } else
-  if (( me = dqm->get(m_dqm_path + "/paths_exclusive_time") )) {
+  if (( me = dqm->get(current_path + "/paths_total_time") )) {
+    paths = me->getTProfile();
+    size  = paths->GetXaxis()->GetNbins();
+  } else
+  if (( me = dqm->get(current_path + "/paths_exclusive_time") )) {
     paths = me->getTProfile();
     size  = paths->GetXaxis()->GetNbins();
   }
@@ -130,12 +156,12 @@ FastTimerServiceClient::fillSummaryPlots(void)
   //  - the average time spent in each module (total time spent in that module, averaged over all events)
   //  - the running time spent in each module (total time spent in that module, averaged over the events where that module actually ran)
   //  - the "efficiency" of each module (number of time a module succeded divided by the number of times the has run)
-  dqm->setCurrentFolder(m_dqm_path + "/Paths");
+  dqm->setCurrentFolder(current_path + "/Paths");
   for (uint32_t p = 1; p <= size; ++p) {
     // extract the list of Paths and EndPaths from the bin labels of one of the summary plots
     std::string label = paths->GetXaxis()->GetBinLabel(p);
-    MonitorElement * me_counter = dqm->get( m_dqm_path + "/Paths/" + label + "_module_counter" );
-    MonitorElement * me_total   = dqm->get( m_dqm_path + "/Paths/" + label + "_module_total" );
+    MonitorElement * me_counter = dqm->get( current_path + "/Paths/" + label + "_module_counter" );
+    MonitorElement * me_total   = dqm->get( current_path + "/Paths/" + label + "_module_total" );
     if (me_counter == 0 or me_total == 0)
       continue;
     TH1F * counter = me_counter->getTH1F();
@@ -144,8 +170,12 @@ FastTimerServiceClient::fillSummaryPlots(void)
     double   min  = counter->GetXaxis()->GetXmin();
     double   max  = counter->GetXaxis()->GetXmax();
     TH1F * average    = dqm->book1D(label + "_module_average",    label + " module average",    bins, min, max)->getTH1F();
+    average   ->SetYTitle("processing time [ms]");
     TH1F * running    = dqm->book1D(label + "_module_running",    label + " module running",    bins, min, max)->getTH1F();
+    running   ->SetYTitle("processing time [ms]");
     TH1F * efficiency = dqm->book1D(label + "_module_efficiency", label + " module efficiency", bins, min, max)->getTH1F();
+    efficiency->SetYTitle("filter efficiency");
+    efficiency->SetMaximum(1.05);
     for (uint32_t i = 1; i <= bins; ++i) {
       const char * module = counter->GetXaxis()->GetBinLabel(i);
       average   ->GetXaxis()->SetBinLabel(i, module);
@@ -160,8 +190,6 @@ FastTimerServiceClient::fillSummaryPlots(void)
         efficiency->SetBinContent(i, p / n);
       }
     }
-    average->SetYTitle("processing time [ms]");
-    running->SetYTitle("processing time [ms]");
   }
 
 }

--- a/HLTrigger/Timer/src/FastTimerService.cc
+++ b/HLTrigger/Timer/src/FastTimerService.cc
@@ -422,7 +422,7 @@ void FastTimerService::preStreamBeginRun(edm::StreamContext const & sc)
 
     // per-path and per-module accounting
     if (m_enable_timing_paths) {
-      booker.setCurrentFolder(m_dqm_path + "/Paths");
+      booker.setCurrentFolder(m_dqm_path + "/process " + process_name + "/Paths");
       for (auto & keyval: stream.paths[pid]) {
         std::string const & pathname = keyval.first;
         PathInfo          & pathinfo = keyval.second;


### PR DESCRIPTION
FastTimerService:
- move per-path plots under the per-process directories

FastTimerServiceClient:
- adapt the harvesting step to the new plot directory structure
- cleanup

This is the 7.0.x backport of #3089 .
