### PR TITLE
    Fixed thread-safety problems with JetCorrectors

### DIFF
--- a/CondFormats/JetMETObjects/interface/FactorizedJetCorrector.h
+++ b/CondFormats/JetMETObjects/interface/FactorizedJetCorrector.h
@@ -9,6 +9,7 @@
 #include <vector>
 #include <string>
 #include "TLorentzVector.h"
+#include "CondFormats/JetMETObjects/interface/FactorizedJetCorrectorCalculator.h"
 
 class SimpleJetCorrector;
 class JetCorrectorParameters;
@@ -21,7 +22,7 @@ class FactorizedJetCorrector
     FactorizedJetCorrector();
     FactorizedJetCorrector(const std::string& fLevels, const std::string& fTags, const std::string& fOptions="");
     FactorizedJetCorrector(const std::vector<JetCorrectorParameters>& fParameters);
-    ~FactorizedJetCorrector();
+
     void setNPV		(int   fNPV);
     void setJetEta      (float fEta);
     void setJetPt       (float fPt); 
@@ -44,50 +45,8 @@ class FactorizedJetCorrector
   //---- Member Functions ----  
     FactorizedJetCorrector(const FactorizedJetCorrector&);
     FactorizedJetCorrector& operator= (const FactorizedJetCorrector&);
-    float getLepPt()    const;
-    float getRelLepPt() const;
-    float getPtRel()    const;
-    std::string parseOption(const std::string& ss, const std::string& type);
-    std::string removeSpaces(const std::string& ss);
-    std::vector<std::string> parseLevels(const std::string& ss);
-    void initCorrectors(const std::string& fLevels, const std::string& fFiles, const std::string& fOptions);
-    void checkConsistency(const std::vector<std::string>& fLevels, const std::vector<std::string>& fTags);
-    std::vector<float> fillVector(const std::vector<VarTypes>& fVarTypes);
-    std::vector<VarTypes> mapping(const std::vector<std::string>& fNames);
     //---- Member Data ---------
-    int   mNPV;
-    float mJetE;
-    float mJetEta;
-    float mJetPt;
-    float mJetPhi;
-    float mJetEMF; 
-    float mJetA;
-    float mRho;
-    float mJPTrawE;
-    float mJPTrawEt;
-    float mJPTrawPt;
-    float mJPTrawEta; 
-    float mJPTrawOff;
-    float mLepPx;
-    float mLepPy;
-    float mLepPz;
-    bool  mAddLepToJet;
-    bool  mIsNPVset;
-    bool  mIsJetEset;
-    bool  mIsJetPtset;
-    bool  mIsJetPhiset;
-    bool  mIsJetEtaset;
-    bool  mIsJetEMFset; 
-    bool  mIsJetAset;
-    bool  mIsRhoset;
-    bool  mIsJPTrawP4set;
-    bool  mIsJPTrawOFFset;
-    bool  mIsLepPxset;
-    bool  mIsLepPyset;
-    bool  mIsLepPzset;
-    bool  mIsAddLepToJetset;
-    std::vector<LevelTypes> mLevels;
-    std::vector<std::vector<VarTypes> > mParTypes,mBinTypes; 
-    std::vector<SimpleJetCorrector*> mCorrectors;
+    FactorizedJetCorrectorCalculator::VariableValues mValues;
+    FactorizedJetCorrectorCalculator mCalc;
 };
 #endif

--- a/CondFormats/JetMETObjects/interface/FactorizedJetCorrectorCalculator.h
+++ b/CondFormats/JetMETObjects/interface/FactorizedJetCorrectorCalculator.h
@@ -1,0 +1,107 @@
+// This is the header file "FactorizedJetCorrectorCalculator.h". This is the interface for the 
+// class FactorizedJetCorrectorCalculator.
+// Author: Konstantinos Kousouris, Philipp Schieferdecker
+// Email:  kkousour@fnal.gov, philipp.schieferdecker@cern.ch
+
+#ifndef CondFormats_JetMETObjects_FactorizedJetCorrectorCalculator_h
+#define CondFormats_JetMETObjects_FactorizedJetCorrectorCalculator_h
+
+
+#include <vector>
+#include <string>
+#include "TLorentzVector.h"
+
+class SimpleJetCorrector;
+class JetCorrectorParameters;
+
+class FactorizedJetCorrectorCalculator
+{
+  public:
+
+    class VariableValues
+    {
+    public:
+      friend class FactorizedJetCorrector;
+      friend class FactorizedJetCorrectorCalculator;
+      VariableValues();
+      void setNPV		(int   fNPV);
+      void setJetEta      (float fEta);
+      void setJetPt       (float fPt); 
+      void setJetE        (float fE);
+      void setJetPhi      (float fE);
+      void setJetEMF      (float fEMF); 
+      void setJetA        (float fA);
+      void setRho         (float fRho);
+      void setJPTrawP4    (const TLorentzVector& fJPTrawP4);
+      void setJPTrawOff   (float fJPTrawOff);
+      void setLepPx       (float fLepPx);
+      void setLepPy       (float fLepPy);
+      void setLepPz       (float fLepPz);
+      void setAddLepToJet (bool fAddLepToJet);
+
+      void reset();
+    private:
+      //---- Member Data ---------
+      int   mNPV;
+      float mJetE;
+      float mJetEta;
+      float mJetPt;
+      float mJetPhi;
+      float mJetEMF; 
+      float mJetA;
+      float mRho;
+      float mJPTrawE;
+      float mJPTrawEt;
+      float mJPTrawPt;
+      float mJPTrawEta; 
+      float mJPTrawOff;
+      float mLepPx;
+      float mLepPy;
+      float mLepPz;
+      bool  mAddLepToJet;
+      bool  mIsNPVset;
+      bool  mIsJetEset;
+      bool  mIsJetPtset;
+      bool  mIsJetPhiset;
+      bool  mIsJetEtaset;
+      bool  mIsJetEMFset; 
+      bool  mIsJetAset;
+      bool  mIsRhoset;
+      bool  mIsJPTrawP4set;
+      bool  mIsJPTrawOFFset;
+      bool  mIsLepPxset;
+      bool  mIsLepPyset;
+      bool  mIsLepPzset;
+      bool  mIsAddLepToJetset;
+    };
+
+    enum VarTypes   {kJetPt,kJetEta,kJetPhi,kJetE,kJetEMF,kRelLepPt,kPtRel,kNPV,kJetA,kRho,kJPTrawE,kJPTrawEt,kJPTrawPt,kJPTrawEta,kJPTrawOff};
+    enum LevelTypes {kL1,kL2,kL3,kL4,kL5,kL6,kL7,kL1fj,kL1JPT};
+    FactorizedJetCorrectorCalculator();
+    FactorizedJetCorrectorCalculator(const std::string& fLevels, const std::string& fTags, const std::string& fOptions="");
+    FactorizedJetCorrectorCalculator(const std::vector<JetCorrectorParameters>& fParameters);
+    ~FactorizedJetCorrectorCalculator();
+    float getCorrection(VariableValues&) const;
+    std::vector<float> getSubCorrections(VariableValues&) const;
+    
+       
+  private:
+  //---- Member Functions ----  
+    FactorizedJetCorrectorCalculator(const FactorizedJetCorrectorCalculator&);
+    FactorizedJetCorrectorCalculator& operator= (const FactorizedJetCorrectorCalculator&);
+    float getLepPt(const VariableValues&)    const;
+    float getRelLepPt(const VariableValues&) const;
+    float getPtRel(const VariableValues&)    const;
+    std::string parseOption(const std::string& ss, const std::string& type) const;
+    std::string removeSpaces(const std::string& ss) const;
+    std::vector<std::string> parseLevels(const std::string& ss) const;
+    void initCorrectors(const std::string& fLevels, const std::string& fFiles, const std::string& fOptions);
+    void checkConsistency(const std::vector<std::string>& fLevels, const std::vector<std::string>& fTags);
+    std::vector<float> fillVector(const std::vector<VarTypes>& fVarTypes, const VariableValues&) const;
+    std::vector<VarTypes> mapping(const std::vector<std::string>& fNames) const;
+    //---- Member Data ---------
+    std::vector<LevelTypes> mLevels;
+    std::vector<std::vector<VarTypes> > mParTypes,mBinTypes; 
+    std::vector<SimpleJetCorrector const*> mCorrectors;
+};
+#endif

--- a/CondFormats/JetMETObjects/interface/SimpleJetCorrector.h
+++ b/CondFormats/JetMETObjects/interface/SimpleJetCorrector.h
@@ -5,7 +5,7 @@
 #include <vector>
 
 #include <TFormula.h>
-
+#include "CondFormats/JetMETObjects/interface/JetCorrectorParameters.h"
 
 class JetCorrectorParameters;
 
@@ -21,20 +21,21 @@ class SimpleJetCorrector
   //-------- Member functions -----------
   void   setInterpolation(bool fInterpolation) {mDoInterpolation = fInterpolation;}
   float  correction(const std::vector<float>& fX,const std::vector<float>& fY) const;  
-  const  JetCorrectorParameters& parameters() const {return *mParameters;} 
+  const  JetCorrectorParameters& parameters() const {return mParameters;} 
 
  private:
   //-------- Member functions -----------
   SimpleJetCorrector(const SimpleJetCorrector&);
   SimpleJetCorrector& operator= (const SimpleJetCorrector&);
-  float    invert(const std::vector<float>& fX) const;
+  float    invert(const std::vector<float>& fX, TFormula&) const;
   float    correctionBin(unsigned fBin,const std::vector<float>& fY) const;
   unsigned findInvertVar();
+  void     setFuncParameters();
   //-------- Member variables -----------
-  bool                    mDoInterpolation;
+  JetCorrectorParameters  mParameters;
+  TFormula                mFunc;
   unsigned                mInvertVar; 
-  TFormula*               mFunc;
-  JetCorrectorParameters* mParameters;
+  bool                    mDoInterpolation;
 };
 
 #endif

--- a/CondFormats/JetMETObjects/src/FactorizedJetCorrector.cc
+++ b/CondFormats/JetMETObjects/src/FactorizedJetCorrector.cc
@@ -19,622 +19,105 @@
 //------------------------------------------------------------------------
 FactorizedJetCorrector::FactorizedJetCorrector()
 {
-  mJetEta  = -9999;
-  mJetPt   = -9999;
-  mJetPhi  = -9999;
-  mJetE    = -9999;
-  mJetEMF  = -9999;
-  mJetA    = -9999;
-  mRho     = -9999;
-  mLepPx   = -9999;
-  mLepPy   = -9999;
-  mLepPz   = -9999;
-  mNPV     = -9999;
-  mJPTrawE = -9999;
-  mJPTrawEt = -9999;
-  mJPTrawPt = -9999;
-  mJPTrawEta = -9999;
-  mJPTrawOff = -9999;
-  mAddLepToJet      = false;
-  mIsNPVset         = false;
-  mIsJetEset        = false;
-  mIsJetPtset       = false;
-  mIsJetPhiset      = false;
-  mIsJetEtaset      = false;
-  mIsJetEMFset      = false;
-  mIsJetAset        = false;
-  mIsRhoset         = false;
-  mIsJPTrawP4set    = false;
-  mIsJPTrawOFFset   = false;
-  mIsLepPxset       = false;
-  mIsLepPyset       = false;
-  mIsLepPzset       = false;
-  mIsAddLepToJetset = false;
 }
 //------------------------------------------------------------------------ 
 //--- FactorizedJetCorrector constructor ---------------------------------
 //------------------------------------------------------------------------
-FactorizedJetCorrector::FactorizedJetCorrector(const std::string& fLevels, const std::string& fFiles, const std::string& fOptions)
+FactorizedJetCorrector::FactorizedJetCorrector(const std::string& fLevels, const std::string& fFiles, const std::string& fOptions):
+mCalc(fLevels,fFiles,fOptions)
 {
-  mJetEta = -9999;
-  mJetPt  = -9999;
-  mJetPhi = -9999;
-  mJetE   = -9999;
-  mJetEMF = -9999;
-  mJetA   = -9999;
-  mRho    = -9999;
-  mLepPx  = -9999;
-  mLepPy  = -9999;
-  mLepPz  = -9999;
-  mNPV    = -9999;
-  mJPTrawE = -9999;
-  mJPTrawEt = -9999;
-  mJPTrawPt = -9999;
-  mJPTrawEta = -9999;
-  mJPTrawOff = -9999;
-  mAddLepToJet      = false;
-  mIsNPVset         = false;
-  mIsJetEset        = false;
-  mIsJetPtset       = false;
-  mIsJetPhiset      = false;
-  mIsJetEtaset      = false;
-  mIsJetEMFset      = false;
-  mIsJetAset        = false;
-  mIsRhoset         = false;
-  mIsJPTrawP4set    = false;
-  mIsJPTrawOFFset   = false;
-  mIsLepPxset       = false;
-  mIsLepPyset       = false;
-  mIsLepPzset       = false;
-  mIsAddLepToJetset = false;
-  initCorrectors(fLevels, fFiles, fOptions);       
 }
 //------------------------------------------------------------------------
 //--- FactorizedJetCorrector constructor ---------------------------------
 //------------------------------------------------------------------------
-FactorizedJetCorrector::FactorizedJetCorrector(const std::vector<JetCorrectorParameters>& fParameters)
+FactorizedJetCorrector::FactorizedJetCorrector(const std::vector<JetCorrectorParameters>& fParameters):
+  mCalc(fParameters)
 {
-  mJetEta = -9999;
-  mJetPt  = -9999;
-  mJetPhi = -9999;
-  mJetE   = -9999;
-  mJetEMF = -9999;
-  mJetA   = -9999;
-  mRho    = -9999;
-  mLepPx  = -9999;
-  mLepPy  = -9999;
-  mLepPz  = -9999;
-  mNPV    = -9999;
-  mJPTrawE = -9999;
-  mJPTrawEt = -9999;
-  mJPTrawPt = -9999;
-  mJPTrawEta = -9999;
-  mJPTrawOff = -9999;
-  mAddLepToJet      = false;
-  mIsNPVset         = false;
-  mIsJetEset        = false;
-  mIsJetPtset       = false;
-  mIsJetPhiset      = false;
-  mIsJetEtaset      = false;
-  mIsJetEMFset      = false;
-  mIsJetAset        = false;
-  mIsRhoset         = false;
-  mIsJPTrawP4set    = false;
-  mIsJPTrawOFFset   = false;
-  mIsLepPxset       = false;
-  mIsLepPyset       = false;
-  mIsLepPzset       = false;
-  mIsAddLepToJetset = false;
-  for(unsigned i=0;i<fParameters.size();i++) {
-    std::string ss = fParameters[i].definitions().level();
-    if (ss == "L1Offset")
-      mLevels.push_back(kL1);
-    else if (ss == "L1JPTOffset")
-      mLevels.push_back(kL1JPT);
-    else if (ss == "L2Relative")
-      mLevels.push_back(kL2);
-    else if (ss == "L3Absolute")
-      mLevels.push_back(kL3);
-    else if (ss == "L4EMF")
-      mLevels.push_back(kL4);
-    else if (ss == "L5Flavor")
-      mLevels.push_back(kL5);
-    else if (ss == "L6SLB")
-      mLevels.push_back(kL6);
-    else if (ss == "L7Parton")
-      mLevels.push_back(kL7);
-    else if (ss == "L1FastJet")
-      mLevels.push_back(kL1fj);
-    mCorrectors.push_back(new SimpleJetCorrector(fParameters[i]));
-    mBinTypes.push_back(mapping(mCorrectors[i]->parameters().definitions().binVar()));
-    mParTypes.push_back(mapping(mCorrectors[i]->parameters().definitions().parVar()));
-  }  
 }
 
-//------------------------------------------------------------------------ 
-//--- FactorizedJetCorrector destructor ----------------------------------
-//------------------------------------------------------------------------
-FactorizedJetCorrector::~FactorizedJetCorrector()
-{
-  for(unsigned i=0;i<mCorrectors.size();i++)
-    delete mCorrectors[i];
-}
-//------------------------------------------------------------------------ 
-//--- initialises the correctors -----------------------------------------
-//------------------------------------------------------------------------
-void FactorizedJetCorrector::initCorrectors(const std::string& fLevels, const std::string& fFiles, const std::string& fOptions)
-{
-  //---- Read the CorrectionLevels string and parse the requested sub-correction levels.
-  std::vector<std::string> tmp = parseLevels(removeSpaces(fLevels));
-  for(unsigned i=0;i<tmp.size();i++) {
-    if (tmp[i] == "L1Offset")
-      mLevels.push_back(kL1);
-    else if (tmp[i] == "L1JPTOffset")
-      mLevels.push_back(kL1JPT);
-    else if (tmp[i] == "L2Relative")
-      mLevels.push_back(kL2);
-    else if (tmp[i] == "L3Absolute")
-      mLevels.push_back(kL3);
-    else if (tmp[i] == "L4EMF")
-      mLevels.push_back(kL4);
-    else if (tmp[i] == "L5Flavor")
-      mLevels.push_back(kL5);
-    else if (tmp[i] == "L6SLB")
-      mLevels.push_back(kL6);
-    else if (tmp[i] == "L7Parton")
-      mLevels.push_back(kL7);
-    else if (tmp[i] == "L1FastJet")
-      mLevels.push_back(kL1fj);
-    else {
-      std::stringstream sserr; 
-      sserr<<"unknown correction level "<<tmp[i];
-      handleError("FactorizedJetCorrector",sserr.str());
-    }							
-  }   	 
-  //---- Read the parameter filenames string and parse the requested sub-correction tags.
-  std::vector<std::string> Files = parseLevels(removeSpaces(fFiles));
-  //---- Read the Options string and define the FlavorOption and PartonOption.
-  std::string FlavorOption = parseOption(removeSpaces(fOptions),"L5Flavor");
-  std::string PartonOption = parseOption(removeSpaces(fOptions),"L7Parton");
-  //---- Check the consistency between tags and requested sub-corrections. 
-  checkConsistency(tmp,Files);  
-  //---- Create instances of the requested sub-correctors.
-  for(unsigned i=0;i<mLevels.size();i++) {     	    
-    if (mLevels[i]==kL1||mLevels[i]==kL1JPT||mLevels[i]==kL2||mLevels[i]==kL3||mLevels[i]==kL4||mLevels[i]==kL6||mLevels[i]==kL1fj)
-      mCorrectors.push_back(new SimpleJetCorrector(Files[i])); 
-    else if (mLevels[i]==kL5 && FlavorOption.length()==0) 
-      handleError("FactorizedJetCorrector","must specify flavor option when requesting L5Flavor correction!");
-    else if (mLevels[i]==kL5 && FlavorOption.length()>0)
-      mCorrectors.push_back(new SimpleJetCorrector(Files[i],FlavorOption));
-    else if (mLevels[i]==kL7 && PartonOption.length()==0) 
-      handleError("FactorizedJetCorrector","must specify parton option when requesting L7Parton correction!");
-    else if (mLevels[i]==kL7 && PartonOption.length()>0)
-      mCorrectors.push_back(new SimpleJetCorrector(Files[i],PartonOption));
-    else {
-      std::stringstream sserr; 
-      sserr<<"unknown correction level "<<tmp[i];
-      handleError("FactorizedJetCorrector",sserr.str());
-    }
-    mBinTypes.push_back(mapping(mCorrectors[i]->parameters().definitions().binVar())); 
-    mParTypes.push_back(mapping(mCorrectors[i]->parameters().definitions().parVar()));	
-  } 
-}
-//------------------------------------------------------------------------ 
-//--- Mapping between variable names and variable types ------------------
-//------------------------------------------------------------------------
-std::vector<FactorizedJetCorrector::VarTypes> FactorizedJetCorrector::mapping(const std::vector<std::string>& fNames)
-{
-  std::vector<VarTypes> result;
-  for(unsigned i=0;i<fNames.size();i++) {
-    std::string ss = fNames[i]; 
-    if (ss=="JetPt")
-      result.push_back(kJetPt);
-    else if (ss=="JetEta")
-      result.push_back(kJetEta); 
-    else if (ss=="JetPhi")
-      result.push_back(kJetPhi);
-    else if (ss=="JetE")
-      result.push_back(kJetE);
-    else if (ss=="JetEMF")
-      result.push_back(kJetEMF);
-    else if (ss=="RelLepPt")
-      result.push_back(kRelLepPt);
-    else if (ss=="PtRel")
-      result.push_back(kPtRel);
-    else if (ss=="NPV")
-      result.push_back(kNPV);
-    else if (ss=="JetA")
-      result.push_back(kJetA);
-    else if (ss=="Rho")
-      result.push_back(kRho);
-    else if (ss=="JPTrawE")
-      result.push_back(kJPTrawE);
-    else if (ss=="JPTrawEt")
-      result.push_back(kJPTrawEt);
-    else if (ss=="JPTrawPt")
-      result.push_back(kJPTrawPt);
-    else if (ss=="JPTrawEta")
-      result.push_back(kJPTrawEta);
-    else if (ss=="JPTrawOff")
-      result.push_back(kJPTrawOff);
-    else {
-      std::stringstream sserr; 
-      sserr<<"unknown parameter name: "<<ss;
-      handleError("FactorizedJetCorrector",sserr.str());
-    }
-  }
-  return result;  
-}
-//------------------------------------------------------------------------ 
-//--- Consistency checker ------------------------------------------------
-//------------------------------------------------------------------------
-void FactorizedJetCorrector::checkConsistency(const std::vector<std::string>& fLevels, const std::vector<std::string>& fTags)
-{
-  //---- First check: the number of tags must be equal to the number of sub-corrections.
-  if (fLevels.size() != fTags.size()) {
-    std::stringstream sserr; 
-    sserr<<"number of correction levels: "<<fLevels.size()<<" doesn't match # of tags: "<<fTags.size();
-    handleError("FactorizedJetCorrector",sserr.str());
-  }
-  //---- Second check: each tag must contain the corresponding sub-correction level.
-  for(unsigned int i=0;i<fTags.size();i++) {
-    if ((int)fTags[i].find(fLevels[i])<0) {
-      std::stringstream sserr; 
-      sserr<<"inconsistent tag: "<<fTags[i]<<" for "<<"the requested correction: "<<fLevels[i];
-      handleError("FactorizedJetCorrector",sserr.str());
-    }
-  }
-}
-//------------------------------------------------------------------------ 
-//--- String parser ------------------------------------------------------
-//------------------------------------------------------------------------
-std::vector<std::string> FactorizedJetCorrector::parseLevels(const std::string& ss)
-{
-  std::vector<std::string> result;
-  unsigned int pos(0),j,newPos;
-  int i;
-  std::string tmp;
-  //---- The ss string must be of the form: "LX:LY:...:LZ"
-  while (pos<ss.length()) {
-    tmp = "";
-    i = ss.find(":" , pos);
-    if (i<0 && pos==0) {
-      result.push_back(ss);
-      pos = ss.length();
-    }
-    else if (i<0 && pos>0) {
-      for(j=pos;j<ss.length();j++)
-        tmp+=ss[j];
-      result.push_back(tmp);
-      pos = ss.length();
-    }  
-    else {
-      newPos = i;
-      for(j=pos;j<newPos;j++)
-        tmp+=ss[j];
-      result.push_back(tmp);
-      pos = newPos+1;     
-    }
-  }
-  return result;
-}
-//------------------------------------------------------------------------ 
-//--- String parser ------------------------------------------------------
-//------------------------------------------------------------------------
-std::string FactorizedJetCorrector::parseOption(const std::string& ss, const std::string& type)
-{
-  std::string result;
-  int pos1(-1),pos2(-1);
-  //---- The ss string must be of the form: "type1:option1&type2:option2&..."
-  pos1 = ss.find(type+":");
-  if (pos1<0)
-    result = "";
-  else {
-    pos2 = ss.find("&",pos1+type.length()+1); 
-    if (pos2<0)
-      result = ss.substr(pos1+type.length()+1,ss.length()-pos1-type.length()-1);
-    else
-      result = ss.substr(pos1+type.length()+1,pos2-pos1-type.length()-1);
-  }
-  return result;
-}
-//------------------------------------------------------------------------ 
-//--- String manipulator -------------------------------------------------
-//------------------------------------------------------------------------
-std::string FactorizedJetCorrector::removeSpaces(const std::string& ss)
-{
-  std::string result("");
-  std::string aChar;
-  for(unsigned int i=0;i<ss.length();i++) {
-    aChar = ss.substr(i,1);
-    if (aChar != " ")
-      result+=aChar;
-  }
-  return result; 
-}
 //------------------------------------------------------------------------ 
 //--- Returns the correction ---------------------------------------------
 //------------------------------------------------------------------------
 float FactorizedJetCorrector::getCorrection()
 {
-  std::vector<float> vv = getSubCorrections();
-  return vv[vv.size()-1];
+  return mCalc.getCorrection(mValues);
 }
 //------------------------------------------------------------------------ 
 //--- Returns the vector of subcorrections, up to a given level ----------
 //------------------------------------------------------------------------
 std::vector<float> FactorizedJetCorrector::getSubCorrections()
 {
-  float scale,factor;
-  std::vector<float> factors;
-  std::vector<float> vx,vy;
-  factor = 1;
-  for(unsigned int i=0;i<mLevels.size();i++) { 
-    vx = fillVector(mBinTypes[i]);
-    vy = fillVector(mParTypes[i]);
-    //if (mLevels[i]==kL2 || mLevels[i]==kL6)
-      //mCorrectors[i]->setInterpolation(true); 
-    scale = mCorrectors[i]->correction(vx,vy); 
-    //----- For JPT jets, the offset is stored in order to be used later by the the L1JPTOffset
-    if ((mLevels[i]==kL1 || mLevels[i]==kL1fj) && mIsJPTrawP4set && !mIsJPTrawOFFset) { 
-      mJPTrawOff = scale;
-      mIsJPTrawOFFset = true;
-    }	
-    else if (mLevels[i]==kL6 && mAddLepToJet) { 
-      scale  *= 1.0 + getLepPt() / mJetPt;
-      mJetE  *= scale;
-      mJetPt *= scale;
-      factor *= scale;
-    }
-    else {
-      mJetE  *= scale;
-      mJetPt *= scale;
-      factor *= scale;  
-    }
-    factors.push_back(factor);	
-  }
-  mIsNPVset       = false;
-  mIsJetEset      = false;
-  mIsJetPtset     = false;
-  mIsJetPhiset    = false;
-  mIsJetEtaset    = false;
-  mIsJetEMFset    = false;
-  mIsJetAset      = false;
-  mIsRhoset       = false;
-  mIsJPTrawP4set  = false;
-  mIsJPTrawOFFset = false;
-  mIsLepPxset     = false;
-  mIsLepPyset     = false;
-  mIsLepPzset     = false;
-  mAddLepToJet    = false;
-  return factors; 
-}
-//------------------------------------------------------------------------ 
-//--- Reads the parameter names and fills a vector of floats -------------
-//------------------------------------------------------------------------
-std::vector<float> FactorizedJetCorrector::fillVector(const std::vector<VarTypes>& fVarTypes)
-{
-//  std::vector<VarTypes> fVarTypes = _fVarTypes;
-  std::vector<float> result;
-  for(unsigned i=0;i<fVarTypes.size();i++) {
-    if (fVarTypes[i] == kJetEta) {
-      if (!mIsJetEtaset) 
-        handleError("FactorizedJetCorrector","jet eta is not set");
-      result.push_back(mJetEta);
-    }
-    else if (fVarTypes[i] == kNPV) {
-      if (!mIsNPVset)
-        handleError("FactorizedJetCorrector","number of primary vertices is not set");
-      result.push_back(mNPV);
-    }
-    else if (fVarTypes[i] == kJetPt) {
-      if (!mIsJetPtset)
-        handleError("FactorizedJetCorrector","jet pt is not set");
-      result.push_back(mJetPt);
-    }
-    else if (fVarTypes[i] == kJetPhi) {
-      if (!mIsJetPhiset) 
-        handleError("FactorizedJetCorrector","jet phi is not set");
-      result.push_back(mJetPhi);
-    }
-    else if (fVarTypes[i] == kJetE) {
-      if (!mIsJetEset) 
-        handleError("FactorizedJetCorrector","jet E is not set");
-      result.push_back(mJetE);
-    }
-    else if (fVarTypes[i] == kJetEMF) {
-      if (!mIsJetEMFset) 
-        handleError("FactorizedJetCorrector","jet EMF is not set");
-      result.push_back(mJetEMF);
-    } 
-    else if (fVarTypes[i] == kJetA) {
-      if (!mIsJetAset) 
-        handleError("FactorizedJetCorrector","jet area is not set");
-      result.push_back(mJetA);
-    }
-    else if (fVarTypes[i] == kRho) {
-      if (!mIsRhoset) 
-        handleError("FactorizedJetCorrector","fastjet density Rho is not set");
-      result.push_back(mRho);
-    }
-    else if (fVarTypes[i] == kJPTrawE) {
-      if (!mIsJPTrawP4set) 
-        handleError("FactorizedJetCorrector","raw CaloJet P4 for JPT is not set");
-      result.push_back(mJPTrawE);
-    }
-    else if (fVarTypes[i] == kJPTrawEt) {
-      if (!mIsJPTrawP4set) 
-        handleError("FactorizedJetCorrector","raw CaloJet P4 for JPT is not set");
-      result.push_back(mJPTrawEt);
-    }
-    else if (fVarTypes[i] == kJPTrawPt) {
-      if (!mIsJPTrawP4set)
-        handleError("FactorizedJetCorrector","raw CaloJet P4 for JPT is not set");
-      result.push_back(mJPTrawPt);
-    }
-    else if (fVarTypes[i] == kJPTrawEta) {
-      if (!mIsJPTrawP4set) 
-        handleError("FactorizedJetCorrector","raw CaloJet P4 for JPT is not set");
-      result.push_back(mJPTrawEta);
-    }
-    else if (fVarTypes[i] == kJPTrawOff) {
-      if (!mIsJPTrawOFFset) 
-        handleError("FactorizedJetCorrector","Offset correction for JPT is not set");
-      result.push_back(mJPTrawOff);
-    }
-    else if (fVarTypes[i] == kRelLepPt) {
-      if (!mIsJetPtset||!mIsAddLepToJetset||!mIsLepPxset||!mIsLepPyset) 
-        handleError("FactorizedJetCorrector","can't calculate rel lepton pt");
-      result.push_back(getRelLepPt());
-    }
-    else if (fVarTypes[i] == kPtRel) {
-      if (!mIsJetPtset||!mIsJetEtaset||!mIsJetPhiset||!mIsJetEset||!mIsAddLepToJetset||!mIsLepPxset||!mIsLepPyset||!mIsLepPzset) 
-        handleError("FactorizedJetCorrector","can't calculate ptrel");
-      result.push_back(getPtRel());
-    }
-    else {
-      std::stringstream sserr; 
-      sserr<<"unknown parameter "<<fVarTypes[i];
-      handleError("FactorizedJetCorrector",sserr.str());
-    }
-  }
-  return result;      
-}
-//------------------------------------------------------------------------ 
-//--- Calculate the lepPt (needed for the SLB) ---------------------------
-//------------------------------------------------------------------------
-float FactorizedJetCorrector::getLepPt() const
-{
-  return std::sqrt(mLepPx*mLepPx + mLepPy*mLepPy);
-}
-//------------------------------------------------------------------------ 
-//--- Calculate the relLepPt (needed for the SLB) ---------------------------
-//------------------------------------------------------------------------
-float FactorizedJetCorrector::getRelLepPt() const
-{
-  float lepPt = getLepPt();
-  return (mAddLepToJet) ? lepPt/(mJetPt + lepPt) : lepPt/mJetPt;
-}
-//------------------------------------------------------------------------ 
-//--- Calculate the PtRel (needed for the SLB) ---------------------------
-//------------------------------------------------------------------------
-float FactorizedJetCorrector::getPtRel() const
-{
-  typedef ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiE4D<float> >
-    PtEtaPhiELorentzVector;
-  typedef ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<float> >
-    XYZVector;
-  PtEtaPhiELorentzVector jet;
-  XYZVector lep;
-  jet.SetPt(mJetPt);
-  jet.SetEta(mJetEta);
-  jet.SetPhi(mJetPhi);
-  jet.SetE(mJetE);
-  lep.SetXYZ(mLepPx,mLepPy,mLepPz);
-  float lj_x = (mAddLepToJet) ? lep.X()+jet.Px() : jet.Px();
-  float lj_y = (mAddLepToJet) ? lep.Y()+jet.Py() : jet.Py();
-  float lj_z = (mAddLepToJet) ? lep.Z()+jet.Pz() : jet.Pz();
-  // absolute values squared
-  float lj2  = lj_x*lj_x+lj_y*lj_y+lj_z*lj_z;
-  if (lj2<=0) {
-    std::stringstream sserr; 
-    sserr<<"lepton+jet momentum sq is not positive: "<<lj2;
-    handleError("FactorizedJetCorrector",sserr.str());
-  }
-  float lep2 = lep.X()*lep.X()+lep.Y()*lep.Y()+lep.Z()*lep.Z();
-  // projection vec(mu) to lepjet axis
-  float lepXlj = lep.X()*lj_x+lep.Y()*lj_y+lep.Z()*lj_z;
-  // absolute value squared and normalized
-  float pLrel2 = lepXlj*lepXlj/lj2;
-  // lep2 = pTrel2 + pLrel2
-  float pTrel2 = lep2-pLrel2;
-  return (pTrel2 > 0) ? std::sqrt(pTrel2) : 0.0;
+  return mCalc.getSubCorrections(mValues);
 }
 //------------------------------------------------------------------------ 
 //--- Setters ------------------------------------------------------------
 //------------------------------------------------------------------------
 void FactorizedJetCorrector::setNPV(int fNPV)
 {
-  mNPV = fNPV;
-  mIsNPVset = true;
+
+  mValues.setNPV (fNPV);
 }
 void FactorizedJetCorrector::setJetEta(float fEta)
 {
-  mJetEta = fEta;
-  mIsJetEtaset = true;
+  mValues.setJetEta( fEta );
 }
 //------------------------------------------------------------------------
 void FactorizedJetCorrector::setJetPt(float fPt)
 {
-  mJetPt = fPt;
-  mIsJetPtset  = true;
+  mValues.setJetPt(fPt);
 }
 //------------------------------------------------------------------------
 void FactorizedJetCorrector::setJetPhi(float fPhi)
 {
-  mJetPhi = fPhi;
-  mIsJetPhiset  = true;
+  mValues.setJetPhi( fPhi );
 }
 //------------------------------------------------------------------------
 void FactorizedJetCorrector::setJetE(float fE)
 {
-  mJetE = fE;
-  mIsJetEset   = true;
+  mValues.setJetE(fE);
 }
 //------------------------------------------------------------------------
 void FactorizedJetCorrector::setJetEMF(float fEMF)
 {
-  mJetEMF = fEMF;
-  mIsJetEMFset = true;
+  mValues.setJetEMF( fEMF );
 }
 //------------------------------------------------------------------------
 void FactorizedJetCorrector::setJetA(float fA)
 {
-  mJetA = fA;
-  mIsJetAset = true;
+  mValues.setJetA( fA );
 }
 //------------------------------------------------------------------------
 void FactorizedJetCorrector::setRho(float fRho)
 {
-  mRho = fRho;
-  mIsRhoset = true;
+  mValues.setRho(fRho);
 }
 //------------------------------------------------------------------------
 void FactorizedJetCorrector::setJPTrawP4(const TLorentzVector& fJPTrawP4)
 {
-  mJPTrawE   = fJPTrawP4.Energy();
-  mJPTrawEt  = fJPTrawP4.Et();
-  mJPTrawPt  = fJPTrawP4.Pt();
-  mJPTrawEta = fJPTrawP4.Eta();
-  mIsJPTrawP4set = true;
+  mValues.setJPTrawP4(fJPTrawP4);
 }
 //------------------------------------------------------------------------
 void FactorizedJetCorrector::setJPTrawOff(float fJPTrawOff)
 {
-  mJPTrawOff = fJPTrawOff;
-  mIsJPTrawOFFset = true;
+  mValues.setJPTrawOff(fJPTrawOff);
 }
 //------------------------------------------------------------------------
 void FactorizedJetCorrector::setLepPx(float fPx)
 {
-  mLepPx = fPx;
-  mIsLepPxset  = true;
+  mValues.setLepPx( fPx );
 }
 //------------------------------------------------------------------------
 void FactorizedJetCorrector::setLepPy(float fPy)
 {
-  mLepPy = fPy;
-  mIsLepPyset  = true;
+  mValues.setLepPy( fPy );
 }
 //------------------------------------------------------------------------
 void FactorizedJetCorrector::setLepPz(float fPz)
 {
-  mLepPz = fPz;
-  mIsLepPzset  = true;
+  mValues.setLepPz(fPz);
 }
 //------------------------------------------------------------------------
 void FactorizedJetCorrector::setAddLepToJet(bool fAddLepToJet)
 {
-  mAddLepToJet = fAddLepToJet;
-  mIsAddLepToJetset = true;
+  mValues.setAddLepToJet(fAddLepToJet);
 }

--- a/CondFormats/JetMETObjects/src/FactorizedJetCorrectorCalculator.cc
+++ b/CondFormats/JetMETObjects/src/FactorizedJetCorrectorCalculator.cc
@@ -1,0 +1,592 @@
+// This is the file "FactorizedJetCorrectorCalculator.cc". 
+// This is the implementation of the class FactorizedJetCorrectorCalculator.
+// Author: Konstantinos Kousouris, Philipp Schieferdecker
+// Email:  kkousour@fnal.gov, philipp.schieferdecker@cern.ch
+
+#include "CondFormats/JetMETObjects/interface/FactorizedJetCorrectorCalculator.h"
+#include "CondFormats/JetMETObjects/interface/SimpleJetCorrector.h"
+#include "CondFormats/JetMETObjects/interface/JetCorrectorParameters.h"
+#include "CondFormats/JetMETObjects/src/Utilities.cc"
+#include "Math/PtEtaPhiE4D.h"
+#include "Math/Vector3D.h"
+#include "Math/LorentzVector.h"
+#include <vector>
+#include <string>
+#include <sstream>
+
+//------------------------------------------------------------------------ 
+//--- Default FactorizedJetCorrectorCalculator constructor -------------------------
+//------------------------------------------------------------------------
+FactorizedJetCorrectorCalculator::FactorizedJetCorrectorCalculator()
+{
+}
+//------------------------------------------------------------------------ 
+//--- FactorizedJetCorrectorCalculator constructor ---------------------------------
+//------------------------------------------------------------------------
+FactorizedJetCorrectorCalculator::FactorizedJetCorrectorCalculator(const std::string& fLevels, const std::string& fFiles, const std::string& fOptions)
+{
+  initCorrectors(fLevels, fFiles, fOptions);
+}
+//------------------------------------------------------------------------
+//--- FactorizedJetCorrectorCalculator constructor ---------------------------------
+//------------------------------------------------------------------------
+FactorizedJetCorrectorCalculator::FactorizedJetCorrectorCalculator(const std::vector<JetCorrectorParameters>& fParameters)
+{
+  for(unsigned i=0;i<fParameters.size();i++) {
+    std::string ss = fParameters[i].definitions().level();
+    if (ss == "L1Offset")
+      mLevels.push_back(kL1);
+    else if (ss == "L1JPTOffset")
+      mLevels.push_back(kL1JPT);
+    else if (ss == "L2Relative")
+      mLevels.push_back(kL2);
+    else if (ss == "L3Absolute")
+      mLevels.push_back(kL3);
+    else if (ss == "L4EMF")
+      mLevels.push_back(kL4);
+    else if (ss == "L5Flavor")
+      mLevels.push_back(kL5);
+    else if (ss == "L6SLB")
+      mLevels.push_back(kL6);
+    else if (ss == "L7Parton")
+      mLevels.push_back(kL7);
+    else if (ss == "L1FastJet")
+      mLevels.push_back(kL1fj);
+    mCorrectors.push_back(new SimpleJetCorrector(fParameters[i]));
+    mBinTypes.push_back(mapping(mCorrectors[i]->parameters().definitions().binVar()));
+    mParTypes.push_back(mapping(mCorrectors[i]->parameters().definitions().parVar()));
+  }  
+}
+
+//------------------------------------------------------------------------ 
+//--- FactorizedJetCorrectorCalculator destructor ----------------------------------
+//------------------------------------------------------------------------
+FactorizedJetCorrectorCalculator::~FactorizedJetCorrectorCalculator()
+{
+  for(unsigned i=0;i<mCorrectors.size();i++)
+    delete mCorrectors[i];
+}
+//------------------------------------------------------------------------ 
+//--- initialises the correctors -----------------------------------------
+//------------------------------------------------------------------------
+void FactorizedJetCorrectorCalculator::initCorrectors(const std::string& fLevels, const std::string& fFiles, const std::string& fOptions)
+{
+  //---- Read the CorrectionLevels string and parse the requested sub-correction levels.
+  std::vector<std::string> tmp = parseLevels(removeSpaces(fLevels));
+  for(unsigned i=0;i<tmp.size();i++) {
+    if (tmp[i] == "L1Offset")
+      mLevels.push_back(kL1);
+    else if (tmp[i] == "L1JPTOffset")
+      mLevels.push_back(kL1JPT);
+    else if (tmp[i] == "L2Relative")
+      mLevels.push_back(kL2);
+    else if (tmp[i] == "L3Absolute")
+      mLevels.push_back(kL3);
+    else if (tmp[i] == "L4EMF")
+      mLevels.push_back(kL4);
+    else if (tmp[i] == "L5Flavor")
+      mLevels.push_back(kL5);
+    else if (tmp[i] == "L6SLB")
+      mLevels.push_back(kL6);
+    else if (tmp[i] == "L7Parton")
+      mLevels.push_back(kL7);
+    else if (tmp[i] == "L1FastJet")
+      mLevels.push_back(kL1fj);
+    else {
+      std::stringstream sserr; 
+      sserr<<"unknown correction level "<<tmp[i];
+      handleError("FactorizedJetCorrectorCalculator",sserr.str());
+    }							
+  }   	 
+  //---- Read the parameter filenames string and parse the requested sub-correction tags.
+  std::vector<std::string> Files = parseLevels(removeSpaces(fFiles));
+  //---- Read the Options string and define the FlavorOption and PartonOption.
+  std::string FlavorOption = parseOption(removeSpaces(fOptions),"L5Flavor");
+  std::string PartonOption = parseOption(removeSpaces(fOptions),"L7Parton");
+  //---- Check the consistency between tags and requested sub-corrections. 
+  checkConsistency(tmp,Files);  
+  //---- Create instances of the requested sub-correctors.
+  for(unsigned i=0;i<mLevels.size();i++) {     	    
+    if (mLevels[i]==kL1||mLevels[i]==kL1JPT||mLevels[i]==kL2||mLevels[i]==kL3||mLevels[i]==kL4||mLevels[i]==kL6||mLevels[i]==kL1fj)
+      mCorrectors.push_back(new SimpleJetCorrector(Files[i])); 
+    else if (mLevels[i]==kL5 && FlavorOption.length()==0) 
+      handleError("FactorizedJetCorrectorCalculator","must specify flavor option when requesting L5Flavor correction!");
+    else if (mLevels[i]==kL5 && FlavorOption.length()>0)
+      mCorrectors.push_back(new SimpleJetCorrector(Files[i],FlavorOption));
+    else if (mLevels[i]==kL7 && PartonOption.length()==0) 
+      handleError("FactorizedJetCorrectorCalculator","must specify parton option when requesting L7Parton correction!");
+    else if (mLevels[i]==kL7 && PartonOption.length()>0)
+      mCorrectors.push_back(new SimpleJetCorrector(Files[i],PartonOption));
+    else {
+      std::stringstream sserr; 
+      sserr<<"unknown correction level "<<tmp[i];
+      handleError("FactorizedJetCorrectorCalculator",sserr.str());
+    }
+    mBinTypes.push_back(mapping(mCorrectors[i]->parameters().definitions().binVar())); 
+    mParTypes.push_back(mapping(mCorrectors[i]->parameters().definitions().parVar()));	
+  } 
+}
+//------------------------------------------------------------------------ 
+//--- Mapping between variable names and variable types ------------------
+//------------------------------------------------------------------------
+std::vector<FactorizedJetCorrectorCalculator::VarTypes> FactorizedJetCorrectorCalculator::mapping(const std::vector<std::string>& fNames) const
+{
+  std::vector<VarTypes> result;
+  for(unsigned i=0;i<fNames.size();i++) {
+    std::string ss = fNames[i]; 
+    if (ss=="JetPt")
+      result.push_back(kJetPt);
+    else if (ss=="JetEta")
+      result.push_back(kJetEta); 
+    else if (ss=="JetPhi")
+      result.push_back(kJetPhi);
+    else if (ss=="JetE")
+      result.push_back(kJetE);
+    else if (ss=="JetEMF")
+      result.push_back(kJetEMF);
+    else if (ss=="RelLepPt")
+      result.push_back(kRelLepPt);
+    else if (ss=="PtRel")
+      result.push_back(kPtRel);
+    else if (ss=="NPV")
+      result.push_back(kNPV);
+    else if (ss=="JetA")
+      result.push_back(kJetA);
+    else if (ss=="Rho")
+      result.push_back(kRho);
+    else if (ss=="JPTrawE")
+      result.push_back(kJPTrawE);
+    else if (ss=="JPTrawEt")
+      result.push_back(kJPTrawEt);
+    else if (ss=="JPTrawPt")
+      result.push_back(kJPTrawPt);
+    else if (ss=="JPTrawEta")
+      result.push_back(kJPTrawEta);
+    else if (ss=="JPTrawOff")
+      result.push_back(kJPTrawOff);
+    else {
+      std::stringstream sserr; 
+      sserr<<"unknown parameter name: "<<ss;
+      handleError("FactorizedJetCorrectorCalculator",sserr.str());
+    }
+  }
+  return result;  
+}
+//------------------------------------------------------------------------ 
+//--- Consistency checker ------------------------------------------------
+//------------------------------------------------------------------------
+void FactorizedJetCorrectorCalculator::checkConsistency(const std::vector<std::string>& fLevels, const std::vector<std::string>& fTags)
+{
+  //---- First check: the number of tags must be equal to the number of sub-corrections.
+  if (fLevels.size() != fTags.size()) {
+    std::stringstream sserr; 
+    sserr<<"number of correction levels: "<<fLevels.size()<<" doesn't match # of tags: "<<fTags.size();
+    handleError("FactorizedJetCorrectorCalculator",sserr.str());
+  }
+  //---- Second check: each tag must contain the corresponding sub-correction level.
+  for(unsigned int i=0;i<fTags.size();i++) {
+    if ((int)fTags[i].find(fLevels[i])<0) {
+      std::stringstream sserr; 
+      sserr<<"inconsistent tag: "<<fTags[i]<<" for "<<"the requested correction: "<<fLevels[i];
+      handleError("FactorizedJetCorrectorCalculator",sserr.str());
+    }
+  }
+}
+//------------------------------------------------------------------------ 
+//--- String parser ------------------------------------------------------
+//------------------------------------------------------------------------
+std::vector<std::string> FactorizedJetCorrectorCalculator::parseLevels(const std::string& ss) const
+{
+  std::vector<std::string> result;
+  unsigned int pos(0),j,newPos;
+  int i;
+  std::string tmp;
+  //---- The ss string must be of the form: "LX:LY:...:LZ"
+  while (pos<ss.length()) {
+    tmp = "";
+    i = ss.find(":" , pos);
+    if (i<0 && pos==0) {
+      result.push_back(ss);
+      pos = ss.length();
+    }
+    else if (i<0 && pos>0) {
+      for(j=pos;j<ss.length();j++)
+        tmp+=ss[j];
+      result.push_back(tmp);
+      pos = ss.length();
+    }  
+    else {
+      newPos = i;
+      for(j=pos;j<newPos;j++)
+        tmp+=ss[j];
+      result.push_back(tmp);
+      pos = newPos+1;     
+    }
+  }
+  return result;
+}
+//------------------------------------------------------------------------ 
+//--- String parser ------------------------------------------------------
+//------------------------------------------------------------------------
+std::string FactorizedJetCorrectorCalculator::parseOption(const std::string& ss, const std::string& type) const
+{
+  std::string result;
+  int pos1(-1),pos2(-1);
+  //---- The ss string must be of the form: "type1:option1&type2:option2&..."
+  pos1 = ss.find(type+":");
+  if (pos1<0)
+    result = "";
+  else {
+    pos2 = ss.find("&",pos1+type.length()+1); 
+    if (pos2<0)
+      result = ss.substr(pos1+type.length()+1,ss.length()-pos1-type.length()-1);
+    else
+      result = ss.substr(pos1+type.length()+1,pos2-pos1-type.length()-1);
+  }
+  return result;
+}
+//------------------------------------------------------------------------ 
+//--- String manipulator -------------------------------------------------
+//------------------------------------------------------------------------
+std::string FactorizedJetCorrectorCalculator::removeSpaces(const std::string& ss) const
+{
+  std::string result("");
+  std::string aChar;
+  for(unsigned int i=0;i<ss.length();i++) {
+    aChar = ss.substr(i,1);
+    if (aChar != " ")
+      result+=aChar;
+  }
+  return result; 
+}
+//------------------------------------------------------------------------ 
+//--- Returns the correction ---------------------------------------------
+//------------------------------------------------------------------------
+float FactorizedJetCorrectorCalculator::getCorrection(FactorizedJetCorrectorCalculator::VariableValues& iValues) const
+{
+  std::vector<float> vv = getSubCorrections(iValues);
+  return vv[vv.size()-1];
+}
+//------------------------------------------------------------------------ 
+//--- Returns the vector of subcorrections, up to a given level ----------
+//------------------------------------------------------------------------
+std::vector<float> FactorizedJetCorrectorCalculator::getSubCorrections( FactorizedJetCorrectorCalculator::VariableValues& iValues) const
+{
+  float scale,factor;
+  std::vector<float> factors;
+  std::vector<float> vx,vy;
+  factor = 1;
+  for(unsigned int i=0;i<mLevels.size();i++) { 
+    vx = fillVector(mBinTypes[i],iValues);
+    vy = fillVector(mParTypes[i],iValues);
+    //if (mLevels[i]==kL2 || mLevels[i]==kL6)
+      //mCorrectors[i]->setInterpolation(true); 
+    scale = mCorrectors[i]->correction(vx,vy); 
+    //----- For JPT jets, the offset is stored in order to be used later by the the L1JPTOffset
+    if ((mLevels[i]==kL1 || mLevels[i]==kL1fj) && iValues.mIsJPTrawP4set && !iValues.mIsJPTrawOFFset) { 
+      iValues.setJPTrawOff(scale);
+    }	
+    else if (mLevels[i]==kL6 && iValues.mAddLepToJet) { 
+      scale  *= 1.0 + getLepPt(iValues) / iValues.mJetPt;
+      iValues.mJetE  *= scale;
+      iValues.mJetPt *= scale;
+      factor *= scale;
+    }
+    else {
+      iValues.mJetE  *= scale;
+      iValues.mJetPt *= scale;
+      factor *= scale;  
+    }
+    factors.push_back(factor);	
+  }
+  iValues.reset();
+  return factors; 
+}
+//------------------------------------------------------------------------ 
+//--- Reads the parameter names and fills a vector of floats -------------
+//------------------------------------------------------------------------
+std::vector<float> FactorizedJetCorrectorCalculator::fillVector(const std::vector<VarTypes>& fVarTypes, 
+								const FactorizedJetCorrectorCalculator::VariableValues& iValues) const
+{
+//  std::vector<VarTypes> fVarTypes = _fVarTypes;
+  std::vector<float> result;
+  for(unsigned i=0;i<fVarTypes.size();i++) {
+    if (fVarTypes[i] == kJetEta) {
+      if (!iValues.mIsJetEtaset) 
+        handleError("FactorizedJetCorrectorCalculator","jet eta is not set");
+      result.push_back(iValues.mJetEta);
+    }
+    else if (fVarTypes[i] == kNPV) {
+      if (!iValues.mIsNPVset)
+        handleError("FactorizedJetCorrectorCalculator","number of primary vertices is not set");
+      result.push_back(iValues.mNPV);
+    }
+    else if (fVarTypes[i] == kJetPt) {
+      if (!iValues.mIsJetPtset)
+        handleError("FactorizedJetCorrectorCalculator","jet pt is not set");
+      result.push_back(iValues.mJetPt);
+    }
+    else if (fVarTypes[i] == kJetPhi) {
+      if (!iValues.mIsJetPhiset) 
+        handleError("FactorizedJetCorrectorCalculator","jet phi is not set");
+      result.push_back(iValues.mJetPhi);
+    }
+    else if (fVarTypes[i] == kJetE) {
+      if (!iValues.mIsJetEset) 
+        handleError("FactorizedJetCorrectorCalculator","jet E is not set");
+      result.push_back(iValues.mJetE);
+    }
+    else if (fVarTypes[i] == kJetEMF) {
+      if (!iValues.mIsJetEMFset) 
+        handleError("FactorizedJetCorrectorCalculator","jet EMF is not set");
+      result.push_back(iValues.mJetEMF);
+    } 
+    else if (fVarTypes[i] == kJetA) {
+      if (!iValues.mIsJetAset) 
+        handleError("FactorizedJetCorrectorCalculator","jet area is not set");
+      result.push_back(iValues.mJetA);
+    }
+    else if (fVarTypes[i] == kRho) {
+      if (!iValues.mIsRhoset) 
+        handleError("FactorizedJetCorrectorCalculator","fastjet density Rho is not set");
+      result.push_back(iValues.mRho);
+    }
+    else if (fVarTypes[i] == kJPTrawE) {
+      if (!iValues.mIsJPTrawP4set) 
+        handleError("FactorizedJetCorrectorCalculator","raw CaloJet P4 for JPT is not set");
+      result.push_back(iValues.mJPTrawE);
+    }
+    else if (fVarTypes[i] == kJPTrawEt) {
+      if (!iValues.mIsJPTrawP4set) 
+        handleError("FactorizedJetCorrectorCalculator","raw CaloJet P4 for JPT is not set");
+      result.push_back(iValues.mJPTrawEt);
+    }
+    else if (fVarTypes[i] == kJPTrawPt) {
+      if (!iValues.mIsJPTrawP4set)
+        handleError("FactorizedJetCorrectorCalculator","raw CaloJet P4 for JPT is not set");
+      result.push_back(iValues.mJPTrawPt);
+    }
+    else if (fVarTypes[i] == kJPTrawEta) {
+      if (!iValues.mIsJPTrawP4set) 
+        handleError("FactorizedJetCorrectorCalculator","raw CaloJet P4 for JPT is not set");
+      result.push_back(iValues.mJPTrawEta);
+    }
+    else if (fVarTypes[i] == kJPTrawOff) {
+      if (!iValues.mIsJPTrawOFFset) 
+        handleError("FactorizedJetCorrectorCalculator","Offset correction for JPT is not set");
+      result.push_back(iValues.mJPTrawOff);
+    }
+    else if (fVarTypes[i] == kRelLepPt) {
+      if (!iValues.mIsJetPtset||!iValues.mIsAddLepToJetset||!iValues.mIsLepPxset||!iValues.mIsLepPyset) 
+        handleError("FactorizedJetCorrectorCalculator","can't calculate rel lepton pt");
+      result.push_back(getRelLepPt(iValues));
+    }
+    else if (fVarTypes[i] == kPtRel) {
+      if (!iValues.mIsJetPtset||!iValues.mIsJetEtaset||!iValues.mIsJetPhiset||!iValues.mIsJetEset||!iValues.mIsAddLepToJetset||!iValues.mIsLepPxset||!iValues.mIsLepPyset||!iValues.mIsLepPzset) 
+        handleError("FactorizedJetCorrectorCalculator","can't calculate ptrel");
+      result.push_back(getPtRel(iValues));
+    }
+    else {
+      std::stringstream sserr; 
+      sserr<<"unknown parameter "<<fVarTypes[i];
+      handleError("FactorizedJetCorrectorCalculator",sserr.str());
+    }
+  }
+  return result;      
+}
+//------------------------------------------------------------------------ 
+//--- Calculate the lepPt (needed for the SLB) ---------------------------
+//------------------------------------------------------------------------
+float FactorizedJetCorrectorCalculator::getLepPt(const FactorizedJetCorrectorCalculator::VariableValues& iValues) const
+{
+  return std::sqrt(iValues.mLepPx*iValues.mLepPx + iValues.mLepPy*iValues.mLepPy);
+}
+//------------------------------------------------------------------------ 
+//--- Calculate the relLepPt (needed for the SLB) ---------------------------
+//------------------------------------------------------------------------
+float FactorizedJetCorrectorCalculator::getRelLepPt(const FactorizedJetCorrectorCalculator::VariableValues& iValues) const
+{
+  float lepPt = getLepPt(iValues);
+  return (iValues.mAddLepToJet) ? lepPt/(iValues.mJetPt + lepPt) : lepPt/iValues.mJetPt;
+}
+//------------------------------------------------------------------------ 
+//--- Calculate the PtRel (needed for the SLB) ---------------------------
+//------------------------------------------------------------------------
+float FactorizedJetCorrectorCalculator::getPtRel(const FactorizedJetCorrectorCalculator::VariableValues& iValues) const
+{
+  typedef ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiE4D<float> >
+    PtEtaPhiELorentzVector;
+  typedef ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<float> >
+    XYZVector;
+  PtEtaPhiELorentzVector jet;
+  XYZVector lep;
+  jet.SetPt(iValues.mJetPt);
+  jet.SetEta(iValues.mJetEta);
+  jet.SetPhi(iValues.mJetPhi);
+  jet.SetE(iValues.mJetE);
+  lep.SetXYZ(iValues.mLepPx,iValues.mLepPy,iValues.mLepPz);
+  float lj_x = (iValues.mAddLepToJet) ? lep.X()+jet.Px() : jet.Px();
+  float lj_y = (iValues.mAddLepToJet) ? lep.Y()+jet.Py() : jet.Py();
+  float lj_z = (iValues.mAddLepToJet) ? lep.Z()+jet.Pz() : jet.Pz();
+  // absolute values squared
+  float lj2  = lj_x*lj_x+lj_y*lj_y+lj_z*lj_z;
+  if (lj2<=0) {
+    std::stringstream sserr; 
+    sserr<<"lepton+jet momentum sq is not positive: "<<lj2;
+    handleError("FactorizedJetCorrectorCalculator",sserr.str());
+  }
+  float lep2 = lep.X()*lep.X()+lep.Y()*lep.Y()+lep.Z()*lep.Z();
+  // projection vec(mu) to lepjet axis
+  float lepXlj = lep.X()*lj_x+lep.Y()*lj_y+lep.Z()*lj_z;
+  // absolute value squared and normalized
+  float pLrel2 = lepXlj*lepXlj/lj2;
+  // lep2 = pTrel2 + pLrel2
+  float pTrel2 = lep2-pLrel2;
+  return (pTrel2 > 0) ? std::sqrt(pTrel2) : 0.0;
+}
+
+
+//------------------------------------------------------------------------ 
+//--- Default FactorizedJetCorrectorCalculator::VariableValues constructor -------------------------
+//------------------------------------------------------------------------
+FactorizedJetCorrectorCalculator::VariableValues::VariableValues()
+{
+  mJetEta  = -9999;
+  mJetPt   = -9999;
+  mJetPhi  = -9999;
+  mJetE    = -9999;
+  mJetEMF  = -9999;
+  mJetA    = -9999;
+  mRho     = -9999;
+  mLepPx   = -9999;
+  mLepPy   = -9999;
+  mLepPz   = -9999;
+  mNPV     = -9999;
+  mJPTrawE = -9999;
+  mJPTrawEt = -9999;
+  mJPTrawPt = -9999;
+  mJPTrawEta = -9999;
+  mJPTrawOff = -9999;
+  mAddLepToJet      = false;
+  mIsNPVset         = false;
+  mIsJetEset        = false;
+  mIsJetPtset       = false;
+  mIsJetPhiset      = false;
+  mIsJetEtaset      = false;
+  mIsJetEMFset      = false;
+  mIsJetAset        = false;
+  mIsRhoset         = false;
+  mIsJPTrawP4set    = false;
+  mIsJPTrawOFFset   = false;
+  mIsLepPxset       = false;
+  mIsLepPyset       = false;
+  mIsLepPzset       = false;
+  mIsAddLepToJetset = false;
+}
+
+//------------------------------------------------------------------------ 
+//--- Setters ------------------------------------------------------------
+//------------------------------------------------------------------------
+void FactorizedJetCorrectorCalculator::VariableValues::setNPV(int fNPV)
+{
+  mNPV = fNPV;
+  mIsNPVset = true;
+}
+void FactorizedJetCorrectorCalculator::VariableValues::setJetEta(float fEta)
+{
+  mJetEta = fEta;
+  mIsJetEtaset = true;
+}
+//------------------------------------------------------------------------
+void FactorizedJetCorrectorCalculator::VariableValues::setJetPt(float fPt)
+{
+  mJetPt = fPt;
+  mIsJetPtset  = true;
+}
+//------------------------------------------------------------------------
+void FactorizedJetCorrectorCalculator::VariableValues::setJetPhi(float fPhi)
+{
+  mJetPhi = fPhi;
+  mIsJetPhiset  = true;
+}
+//------------------------------------------------------------------------
+void FactorizedJetCorrectorCalculator::VariableValues::setJetE(float fE)
+{
+  mJetE = fE;
+  mIsJetEset   = true;
+}
+//------------------------------------------------------------------------
+void FactorizedJetCorrectorCalculator::VariableValues::setJetEMF(float fEMF)
+{
+  mJetEMF = fEMF;
+  mIsJetEMFset = true;
+}
+//------------------------------------------------------------------------
+void FactorizedJetCorrectorCalculator::VariableValues::setJetA(float fA)
+{
+  mJetA = fA;
+  mIsJetAset = true;
+}
+//------------------------------------------------------------------------
+void FactorizedJetCorrectorCalculator::VariableValues::setRho(float fRho)
+{
+  mRho = fRho;
+  mIsRhoset = true;
+}
+//------------------------------------------------------------------------
+void FactorizedJetCorrectorCalculator::VariableValues::setJPTrawP4(const TLorentzVector& fJPTrawP4)
+{
+  mJPTrawE   = fJPTrawP4.Energy();
+  mJPTrawEt  = fJPTrawP4.Et();
+  mJPTrawPt  = fJPTrawP4.Pt();
+  mJPTrawEta = fJPTrawP4.Eta();
+  mIsJPTrawP4set = true;
+}
+//------------------------------------------------------------------------
+void FactorizedJetCorrectorCalculator::VariableValues::setJPTrawOff(float fJPTrawOff)
+{
+  mJPTrawOff = fJPTrawOff;
+  mIsJPTrawOFFset = true;
+}
+//------------------------------------------------------------------------
+void FactorizedJetCorrectorCalculator::VariableValues::setLepPx(float fPx)
+{
+  mLepPx = fPx;
+  mIsLepPxset  = true;
+}
+//------------------------------------------------------------------------
+void FactorizedJetCorrectorCalculator::VariableValues::setLepPy(float fPy)
+{
+  mLepPy = fPy;
+  mIsLepPyset  = true;
+}
+//------------------------------------------------------------------------
+void FactorizedJetCorrectorCalculator::VariableValues::setLepPz(float fPz)
+{
+  mLepPz = fPz;
+  mIsLepPzset  = true;
+}
+//------------------------------------------------------------------------
+void FactorizedJetCorrectorCalculator::VariableValues::setAddLepToJet(bool fAddLepToJet)
+{
+  mAddLepToJet = fAddLepToJet;
+  mIsAddLepToJetset = true;
+}
+
+void FactorizedJetCorrectorCalculator::VariableValues::reset()
+{
+  mIsNPVset       = false;
+  mIsJetEset      = false;
+  mIsJetPtset     = false;
+  mIsJetPhiset    = false;
+  mIsJetEtaset    = false;
+  mIsJetEMFset    = false;
+  mIsJetAset      = false;
+  mIsRhoset       = false;
+  mIsJPTrawP4set  = false;
+  mIsJPTrawOFFset = false;
+  mIsLepPxset     = false;
+  mIsLepPyset     = false;
+  mIsLepPzset     = false;
+  mAddLepToJet    = false;
+}

--- a/CondFormats/JetMETObjects/src/SimpleJetCorrector.cc
+++ b/CondFormats/JetMETObjects/src/SimpleJetCorrector.cc
@@ -10,8 +10,6 @@
 //------------------------------------------------------------------------
 SimpleJetCorrector::SimpleJetCorrector()
 {
-  mFunc            = new TFormula();
-  mParameters      = new JetCorrectorParameters();
   mDoInterpolation = false;
   mInvertVar       = 9999;
 }
@@ -19,24 +17,24 @@ SimpleJetCorrector::SimpleJetCorrector()
 //--- SimpleJetCorrector constructor -------------------------------------
 //--- reads arguments from a file ----------------------------------------
 //------------------------------------------------------------------------
-SimpleJetCorrector::SimpleJetCorrector(const std::string& fDataFile, const std::string& fOption)
+SimpleJetCorrector::SimpleJetCorrector(const std::string& fDataFile, const std::string& fOption):
+  mParameters(fDataFile,fOption),
+  mFunc("function",((mParameters.definitions()).formula()).c_str())
 {
-  mParameters      = new JetCorrectorParameters(fDataFile,fOption);
-  mFunc            = new TFormula("function",((mParameters->definitions()).formula()).c_str());
   mDoInterpolation = false;
-  if (mParameters->definitions().isResponse())
+  if (mParameters.definitions().isResponse())
     mInvertVar = findInvertVar();
 }
 //------------------------------------------------------------------------
 //--- SimpleJetCorrector constructor -------------------------------------
 //--- reads arguments from a file ----------------------------------------
 //------------------------------------------------------------------------
-SimpleJetCorrector::SimpleJetCorrector(const JetCorrectorParameters& fParameters)
+SimpleJetCorrector::SimpleJetCorrector(const JetCorrectorParameters& fParameters):
+  mParameters(fParameters),
+  mFunc("function",((mParameters.definitions()).formula()).c_str())
 {
-  mParameters      = new JetCorrectorParameters(fParameters);
-  mFunc            = new TFormula("function",((mParameters->definitions()).formula()).c_str());
   mDoInterpolation = false;
-  if (mParameters->definitions().isResponse())
+  if (mParameters.definitions().isResponse())
     mInvertVar = findInvertVar();
 }
 //------------------------------------------------------------------------
@@ -44,9 +42,8 @@ SimpleJetCorrector::SimpleJetCorrector(const JetCorrectorParameters& fParameters
 //------------------------------------------------------------------------
 SimpleJetCorrector::~SimpleJetCorrector()
 {
-  delete mFunc;
-  delete mParameters;
 }
+
 //------------------------------------------------------------------------
 //--- calculates the correction ------------------------------------------
 //------------------------------------------------------------------------
@@ -55,24 +52,24 @@ float SimpleJetCorrector::correction(const std::vector<float>& fX,const std::vec
   float result = 1.;
   float tmp    = 0.0;
   float cor    = 0.0;
-  int bin = mParameters->binIndex(fX);
+  int bin = mParameters.binIndex(fX);
   if (bin<0)
     return result;
   if (!mDoInterpolation)
     result = correctionBin(bin,fY);
   else
     {
-      for(unsigned i=0;i<mParameters->definitions().nBinVar();i++)
+      for(unsigned i=0;i<mParameters.definitions().nBinVar();i++)
         {
           float xMiddle[3];
           float xValue[3];
-          int prevBin = mParameters->neighbourBin((unsigned)bin,i,false);
-          int nextBin = mParameters->neighbourBin((unsigned)bin,i,true);
+          int prevBin = mParameters.neighbourBin((unsigned)bin,i,false);
+          int nextBin = mParameters.neighbourBin((unsigned)bin,i,true);
           if (prevBin>=0 && nextBin>=0)
             {
-              xMiddle[0] = mParameters->record(prevBin).xMiddle(i);
-              xMiddle[1] = mParameters->record(bin).xMiddle(i);
-              xMiddle[2] = mParameters->record(nextBin).xMiddle(i);
+              xMiddle[0] = mParameters.record(prevBin).xMiddle(i);
+              xMiddle[1] = mParameters.record(bin).xMiddle(i);
+              xMiddle[2] = mParameters.record(nextBin).xMiddle(i);
               xValue[0]  = correctionBin(prevBin,fY);
               xValue[1]  = correctionBin(bin,fY);
               xValue[2]  = correctionBin(nextBin,fY);
@@ -85,7 +82,7 @@ float SimpleJetCorrector::correction(const std::vector<float>& fX,const std::vec
               tmp+=cor;
             }
         }
-      result = tmp/mParameters->definitions().nBinVar();
+      result = tmp/mParameters.definitions().nBinVar();
     }
   return result;
 }
@@ -94,10 +91,10 @@ float SimpleJetCorrector::correction(const std::vector<float>& fX,const std::vec
 //------------------------------------------------------------------------
 float SimpleJetCorrector::correctionBin(unsigned fBin,const std::vector<float>& fY) const
 {
-  if (fBin >= mParameters->size())
+  if (fBin >= mParameters.size())
     {
       std::stringstream sserr;
-      sserr<<"wrong bin: "<<fBin<<": only "<<mParameters->size()<<" available!";
+      sserr<<"wrong bin: "<<fBin<<": only "<<mParameters.size()<<" available!";
       handleError("SimpleJetCorrector",sserr.str());
     }
   unsigned N = fY.size();
@@ -108,9 +105,13 @@ float SimpleJetCorrector::correctionBin(unsigned fBin,const std::vector<float>& 
       handleError("SimpleJetCorrector",sserr.str());
     }
   float result = -1;
-  const std::vector<float>& par = mParameters->record(fBin).parameters();
+  //Have to do calculation using a temporary TFormula to avoid
+  // thread safety issues
+  TFormula tFunc(mFunc);
+
+  const std::vector<float>& par = mParameters.record(fBin).parameters();
   for(unsigned int i=2*N;i<par.size();i++)
-    mFunc->SetParameter(i-2*N,par[i]);
+    tFunc.SetParameter(i-2*N,par[i]);
   float x[4] = {};
   std::vector<float> tmp;
   for(unsigned i=0;i<N;i++)
@@ -118,10 +119,10 @@ float SimpleJetCorrector::correctionBin(unsigned fBin,const std::vector<float>& 
       x[i] = (fY[i] < par[2*i]) ? par[2*i] : (fY[i] > par[2*i+1]) ? par[2*i+1] : fY[i];
       tmp.push_back(x[i]);
     }
-  if (mParameters->definitions().isResponse())
-    result = invert(tmp);
+  if (mParameters.definitions().isResponse())
+    result = invert(tmp,tFunc);
   else
-    result = mFunc->Eval(x[0],x[1],x[2],x[3]);
+    result = tFunc.Eval(x[0],x[1],x[2],x[3]);
   return result;
 }
 //------------------------------------------------------------------------
@@ -130,7 +131,7 @@ float SimpleJetCorrector::correctionBin(unsigned fBin,const std::vector<float>& 
 unsigned SimpleJetCorrector::findInvertVar()
 {
   unsigned result = 9999;
-  std::vector<std::string> vv = mParameters->definitions().parVar();
+  std::vector<std::string> vv = mParameters.definitions().parVar();
   for(unsigned i=0;i<vv.size();i++)
     if (vv[i]=="JetPt")
       {
@@ -144,7 +145,7 @@ unsigned SimpleJetCorrector::findInvertVar()
 //------------------------------------------------------------------------
 //--- inversion ----------------------------------------------------------
 //------------------------------------------------------------------------
-float SimpleJetCorrector::invert(const std::vector<float>& fX) const
+float SimpleJetCorrector::invert(const std::vector<float>& fX, TFormula& tFunc) const
 {
   unsigned nMax = 50;
   unsigned N = fX.size();
@@ -157,7 +158,7 @@ float SimpleJetCorrector::invert(const std::vector<float>& fX) const
   unsigned nLoop=0;
   while(e > precision && nLoop < nMax)
     {
-      rsp = mFunc->Eval(x[0],x[1],x[2],x[3]);
+      rsp = tFunc.Eval(x[0],x[1],x[2],x[3]);
       float tmp = x[mInvertVar] * rsp;
       e = fabs(tmp - fX[mInvertVar])/fX[mInvertVar];
       x[mInvertVar] = fX[mInvertVar]/rsp;

--- a/JetMETCorrections/Algorithms/interface/L1FastjetCorrector.h
+++ b/JetMETCorrections/Algorithms/interface/L1FastjetCorrector.h
@@ -12,7 +12,7 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "CondFormats/JetMETObjects/interface/JetCorrectorParameters.h"
-#include "CondFormats/JetMETObjects/interface/FactorizedJetCorrector.h"
+#include "CondFormats/JetMETObjects/interface/FactorizedJetCorrectorCalculator.h"
 
 class L1FastjetCorrector : public JetCorrector
 {
@@ -41,7 +41,7 @@ public:
 private:
   // member data
   edm::InputTag srcRho_;
-  FactorizedJetCorrector* mCorrector;
+  FactorizedJetCorrectorCalculator const* mCorrector;
 };
 
 #endif

--- a/JetMETCorrections/Algorithms/interface/L1JPTOffsetCorrector.h
+++ b/JetMETCorrections/Algorithms/interface/L1JPTOffsetCorrector.h
@@ -4,7 +4,7 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "JetMETCorrections/Objects/interface/JetCorrector.h"
-#include "CondFormats/JetMETObjects/interface/FactorizedJetCorrector.h"
+#include "CondFormats/JetMETObjects/interface/FactorizedJetCorrectorCalculator.h"
 #include "CondFormats/JetMETObjects/interface/JetCorrectorParameters.h"
 
 //----- classes declaration -----------------------------------
@@ -12,7 +12,7 @@ namespace edm
 {
   class ParameterSet;
 }
-class FactorizedJetCorrector;
+class FactorizedJetCorrectorCalculator;
 //----- LXXXCorrector interface -------------------------------
 class L1JPTOffsetCorrector : public JetCorrector 
 {
@@ -41,7 +41,7 @@ class L1JPTOffsetCorrector : public JetCorrector
     //----- member data ---------------------------------------
     std::string mOffsetService;
     bool mIsOffsetSet;
-    FactorizedJetCorrector* mCorrector;
+    FactorizedJetCorrectorCalculator* mCorrector;
 };
 
 #endif

--- a/JetMETCorrections/Algorithms/interface/L1OffsetCorrector.h
+++ b/JetMETCorrections/Algorithms/interface/L1OffsetCorrector.h
@@ -4,7 +4,7 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "JetMETCorrections/Objects/interface/JetCorrector.h"
-#include "CondFormats/JetMETObjects/interface/FactorizedJetCorrector.h"
+#include "CondFormats/JetMETObjects/interface/FactorizedJetCorrectorCalculator.h"
 #include "CondFormats/JetMETObjects/interface/JetCorrectorParameters.h"
 
 //----- classes declaration -----------------------------------
@@ -12,7 +12,7 @@ namespace edm
 {
   class ParameterSet;
 }
-class FactorizedJetCorrector;
+class FactorizedJetCorrectorCalculator;
 //----- LXXXCorrector interface -------------------------------
 class L1OffsetCorrector : public JetCorrector 
 {
@@ -43,7 +43,7 @@ class L1OffsetCorrector : public JetCorrector
     //----- member data ---------------------------------------
     std::string mVertexCollName;
     int mMinVtxNdof;
-    FactorizedJetCorrector* mCorrector;
+    FactorizedJetCorrectorCalculator* mCorrector;
 
 };
 

--- a/JetMETCorrections/Algorithms/interface/L6SLBCorrector.h
+++ b/JetMETCorrections/Algorithms/interface/L6SLBCorrector.h
@@ -11,7 +11,7 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "JetMETCorrections/Objects/interface/JetCorrector.h"
-#include "CondFormats/JetMETObjects/interface/FactorizedJetCorrector.h"
+#include "CondFormats/JetMETObjects/interface/FactorizedJetCorrectorCalculator.h"
 #include "CondFormats/JetMETObjects/interface/JetCorrectorParameters.h"
 #include "DataFormats/BTauReco/interface/SoftLeptonTagInfo.h"
 
@@ -62,7 +62,7 @@ private:
   bool                    addMuonToJet_;
   edm::InputTag           srcBTagInfoElec_;
   edm::InputTag           srcBTagInfoMuon_;
-  FactorizedJetCorrector* corrector_;
+  FactorizedJetCorrectorCalculator* corrector_;
   
 };
 

--- a/JetMETCorrections/Algorithms/interface/LXXXCorrector.h
+++ b/JetMETCorrections/Algorithms/interface/LXXXCorrector.h
@@ -3,7 +3,7 @@
 #define LXXXCorrector_h
 
 #include "JetMETCorrections/Objects/interface/JetCorrector.h"
-#include "CondFormats/JetMETObjects/interface/FactorizedJetCorrector.h"
+#include "CondFormats/JetMETObjects/interface/FactorizedJetCorrectorCalculator.h"
 #include "CondFormats/JetMETObjects/interface/JetCorrectorParameters.h"
 
 //----- classes declaration -----------------------------------
@@ -37,7 +37,7 @@ class LXXXCorrector : public JetCorrector
   private:
     //----- member data ---------------------------------------
     unsigned mLevel;
-    FactorizedJetCorrector* mCorrector;
+    FactorizedJetCorrectorCalculator* mCorrector;
 };
 
 #endif

--- a/JetMETCorrections/Algorithms/src/L1FastjetCorrector.cc
+++ b/JetMETCorrections/Algorithms/src/L1FastjetCorrector.cc
@@ -27,7 +27,7 @@ L1FastjetCorrector::L1FastjetCorrector (const JetCorrectorParameters& fParam, co
     throw cms::Exception("L1FastjetCorrector")<<" correction level: "<<fParam.definitions().level()<<" is not L1FastJet"; 
   vector<JetCorrectorParameters> vParam;
   vParam.push_back(fParam);
-  mCorrector = new FactorizedJetCorrector(vParam);
+  mCorrector = new FactorizedJetCorrectorCalculator(vParam);
 }
 
 //______________________________________________________________________________
@@ -67,12 +67,13 @@ double L1FastjetCorrector::correction(const reco::Jet& fJet,
   edm::Handle<double> rho;
   fEvent.getByLabel(srcRho_,rho);
   double result(1.0);
-  mCorrector->setJetEta(fJet.eta());
-  mCorrector->setJetPt(fJet.pt());
-  mCorrector->setJetE(fJet.energy());
-  mCorrector->setJetA(fJet.jetArea());
-  mCorrector->setRho(*rho);
-  result = mCorrector->getCorrection();  
+  FactorizedJetCorrectorCalculator::VariableValues values;
+  values.setJetEta(fJet.eta());
+  values.setJetPt(fJet.pt());
+  values.setJetE(fJet.energy());
+  values.setJetA(fJet.jetArea());
+  values.setRho(*rho);
+  result = mCorrector->getCorrection(values);  
   return result;
 }
 

--- a/JetMETCorrections/Algorithms/src/L1JPTOffsetCorrector.cc
+++ b/JetMETCorrections/Algorithms/src/L1JPTOffsetCorrector.cc
@@ -31,7 +31,7 @@ L1JPTOffsetCorrector::L1JPTOffsetCorrector(const JetCorrectorParameters& fParam,
     throw cms::Exception("L1OffsetCorrector")<<" correction level: "<<fParam.definitions().level()<<" is not L1JPTOffset"; 
   vector<JetCorrectorParameters> vParam;
   vParam.push_back(fParam);
-  mCorrector = new FactorizedJetCorrector(vParam);
+  mCorrector = new FactorizedJetCorrectorCalculator(vParam);
 }
 //------------------------------------------------------------------------ 
 //--- L1OffsetCorrector destructor -------------------------------------------
@@ -77,10 +77,11 @@ double L1JPTOffsetCorrector::correction(const reco::Jet& fJet,
   }
   //------ calculate the correction for the JPT jet ------------
   TLorentzVector JPTrawP4(rawcalojet->px(),rawcalojet->py(),rawcalojet->pz(),rawcalojet->energy());
-  mCorrector->setJPTrawP4(JPTrawP4);
-  mCorrector->setJPTrawOff(offset);
-  mCorrector->setJetE(fJet.energy());
-  result = mCorrector->getCorrection();
+  FactorizedJetCorrectorCalculator::VariableValues values;
+  values.setJPTrawP4(JPTrawP4);
+  values.setJPTrawOff(offset);
+  values.setJetE(fJet.energy());
+  result = mCorrector->getCorrection(values);
   return result;
 }
 

--- a/JetMETCorrections/Algorithms/src/L1OffsetCorrector.cc
+++ b/JetMETCorrections/Algorithms/src/L1OffsetCorrector.cc
@@ -27,7 +27,7 @@ L1OffsetCorrector::L1OffsetCorrector(const JetCorrectorParameters& fParam, const
     throw cms::Exception("L1OffsetCorrector")<<" correction level: "<<fParam.definitions().level()<<" is not L1Offset"; 
   vector<JetCorrectorParameters> vParam;
   vParam.push_back(fParam);
-  mCorrector = new FactorizedJetCorrector(vParam);
+  mCorrector = new FactorizedJetCorrectorCalculator(vParam);
 }
 //------------------------------------------------------------------------ 
 //--- L1OffsetCorrector destructor -------------------------------------------
@@ -71,11 +71,12 @@ double L1OffsetCorrector::correction(const reco::Jet& fJet,
     }
   } 
   if (NPV > 0) {
-    mCorrector->setJetEta(fJet.eta());
-    mCorrector->setJetPt(fJet.pt());
-    mCorrector->setJetE(fJet.energy());
-    mCorrector->setNPV(NPV);
-    result = mCorrector->getCorrection();
+    FactorizedJetCorrectorCalculator::VariableValues values;
+    values.setJetEta(fJet.eta());
+    values.setJetPt(fJet.pt());
+    values.setJetE(fJet.energy());
+    values.setNPV(NPV);
+    result = mCorrector->getCorrection(values);
   }
   return result;
 }

--- a/JetMETCorrections/Algorithms/src/L6SLBCorrector.cc
+++ b/JetMETCorrections/Algorithms/src/L6SLBCorrector.cc
@@ -36,7 +36,7 @@ L6SLBCorrector::L6SLBCorrector(const JetCorrectorParameters& fParam, const edm::
 {
   vector<JetCorrectorParameters> vParam;
   vParam.push_back(fParam);
-  corrector_ = new FactorizedJetCorrector(vParam);
+  corrector_ = new FactorizedJetCorrectorCalculator(vParam);
 }
 
 //______________________________________________________________________________
@@ -74,10 +74,11 @@ double L6SLBCorrector::correction(const reco::Jet& fJet,
 				  const edm::Event& fEvent, 
 				  const edm::EventSetup& fSetup) const
 {
-  corrector_->setJetPt(fJet.pt());
-  corrector_->setJetEta(fJet.eta());
-  corrector_->setJetPhi(fJet.phi());
-  corrector_->setJetE(fJet.energy());
+  FactorizedJetCorrectorCalculator::VariableValues values;
+  values.setJetPt(fJet.pt());
+  values.setJetEta(fJet.eta());
+  values.setJetPhi(fJet.phi());
+  values.setJetE(fJet.energy());
   
   edm::Handle< vector<reco::SoftLeptonTagInfo> > muoninfos;
   fEvent.getByLabel(srcBTagInfoMuon_,muoninfos);
@@ -86,11 +87,11 @@ double L6SLBCorrector::correction(const reco::Jet& fJet,
     (*muoninfos)[getBTagInfoIndex(refToRawJet,*muoninfos)];
   if (sltMuon.leptons()>0) {
     edm::RefToBase<reco::Track> trackRef = sltMuon.lepton(0);
-    corrector_->setLepPx(trackRef->px());
-    corrector_->setLepPy(trackRef->py());
-    corrector_->setLepPz(trackRef->pz());
-    corrector_->setAddLepToJet(addMuonToJet_);
-    return corrector_->getCorrection();
+    values.setLepPx(trackRef->px());
+    values.setLepPy(trackRef->py());
+    values.setLepPz(trackRef->pz());
+    values.setAddLepToJet(addMuonToJet_);
+    return corrector_->getCorrection(values);
   }
   else {
     edm::Handle< vector<reco::SoftLeptonTagInfo> > elecinfos;
@@ -99,11 +100,11 @@ double L6SLBCorrector::correction(const reco::Jet& fJet,
       (*elecinfos)[getBTagInfoIndex(refToRawJet,*elecinfos)];
     if (sltElec.leptons()>0) {
       edm::RefToBase<reco::Track> trackRef = sltElec.lepton(0);
-      corrector_->setLepPx(trackRef->px());
-      corrector_->setLepPy(trackRef->py());
-      corrector_->setLepPz(trackRef->pz());
-      corrector_->setAddLepToJet(false);
-      return corrector_->getCorrection();
+      values.setLepPx(trackRef->px());
+      values.setLepPy(trackRef->py());
+      values.setLepPz(trackRef->pz());
+      values.setAddLepToJet(false);
+      return corrector_->getCorrection(values);
     }
   }
   return 1.0;

--- a/JetMETCorrections/Algorithms/src/LXXXCorrector.cc
+++ b/JetMETCorrections/Algorithms/src/LXXXCorrector.cc
@@ -2,7 +2,7 @@
 // Generic LX jet corrector class.
 
 #include "JetMETCorrections/Algorithms/interface/LXXXCorrector.h"
-#include "CondFormats/JetMETObjects/interface/FactorizedJetCorrector.h"
+#include "CondFormats/JetMETObjects/interface/FactorizedJetCorrectorCalculator.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -34,7 +34,7 @@ LXXXCorrector::LXXXCorrector(const JetCorrectorParameters& fParam, const edm::Pa
     throw cms::Exception("LXXXCorrector")<<" unknown correction level "<<level; 
   vector<JetCorrectorParameters> vParam;
   vParam.push_back(fParam);
-  mCorrector = new FactorizedJetCorrector(vParam);
+  mCorrector = new FactorizedJetCorrectorCalculator(vParam);
 }
 //------------------------------------------------------------------------ 
 //--- LXXXCorrector destructor -------------------------------------------
@@ -53,13 +53,14 @@ double LXXXCorrector::correction(const LorentzVector& fJet) const
     throw cms::Exception("Invalid jet type") << "L4EMFCorrection is applicable to CaloJets only";
     return 1;
   }
-  else {
-      mCorrector->setJetEta(fJet.eta()); 
-      mCorrector->setJetE(fJet.energy());
-      mCorrector->setJetPt(fJet.pt());
-      mCorrector->setJetPhi(fJet.phi());
-  } 
-  return mCorrector->getCorrection();
+
+  FactorizedJetCorrectorCalculator::VariableValues values;
+  values.setJetEta(fJet.eta()); 
+  values.setJetE(fJet.energy());
+  values.setJetPt(fJet.pt());
+  values.setJetPhi(fJet.phi());
+
+  return mCorrector->getCorrection(values);
 }
 //------------------------------------------------------------------------ 
 //--- Returns correction for a given jet ---------------------------------
@@ -70,10 +71,11 @@ double LXXXCorrector::correction(const reco::Jet& fJet) const
   // L4 correction applies to Calojets only
   if (mLevel == 4) {
       const reco::CaloJet& caloJet = dynamic_cast <const reco::CaloJet&> (fJet);
-      mCorrector->setJetEta(fJet.eta()); 
-      mCorrector->setJetPt(fJet.pt());
-      mCorrector->setJetEMF(caloJet.emEnergyFraction());
-      result = mCorrector->getCorrection();
+      FactorizedJetCorrectorCalculator::VariableValues values;
+      values.setJetEta(fJet.eta()); 
+      values.setJetPt(fJet.pt());
+      values.setJetEMF(caloJet.emEnergyFraction());
+      result = mCorrector->getCorrection(values);
   }
   else
     result = correction(fJet.p4());


### PR DESCRIPTION
```
Previously the JetCorrectors used the thread-unsafe class
FactorizedJetCorrector to do the work. After refactoring the JetCorrectors
now use the thread-safe class FactorizedJetCorrectorCalculator and its
helper VariableValues class. The functionality is identical but the
temporary variables now only exist on the stack.
```
