### PR TITLE
preparing HBHERecHit class for introducing out-of-time pileup correction...

### DIFF
--- a/DataFormats/HcalRecHit/interface/HBHERecHit.h
+++ b/DataFormats/HcalRecHit/interface/HBHERecHit.h
@@ -15,18 +15,19 @@ public:
 
   HBHERecHit();
   //HBHERecHit(const HcalDetId& id, float energy, float time);
-  /// get the id
   HBHERecHit(const HcalDetId& id, float amplitude, float timeRising, float timeFalling=0);
-  /// get the amplitude (generally fC, but can vary)
-  /// get the hit time
+
+  /// get the hit falling time
   float timeFalling() const { return timeFalling_; }
+  /// get the id
   HcalDetId id() const { return HcalDetId(detid()); }
 
-
+  inline void setRawEnergy(const float en) {rawEnergy_ = en;}
+  inline float eraw() const {return rawEnergy_;}
 
 private:
-
   float timeFalling_;
+  float rawEnergy_;
 };
 
 std::ostream& operator<<(std::ostream& s, const HBHERecHit& hit);

--- a/DataFormats/HcalRecHit/interface/rawEnergy.h
+++ b/DataFormats/HcalRecHit/interface/rawEnergy.h
@@ -1,0 +1,104 @@
+#ifndef DATAFORMATS_HCALRECHIT_RAWENERGY_H
+#define DATAFORMATS_HCALRECHIT_RAWENERGY_H
+
+#include "Alignment/Geners/interface/IOIsClassType.hh"
+
+namespace HcalRecHitPrivate {
+    template <typename T>
+    class HasRawEnergySetterHelper
+    {
+    private:
+        template<void (T::*)(float)> struct tester;
+        typedef char One;
+        typedef struct {char a[2];} Two;
+        template<typename C> static One test(tester<&C::setRawEnergy>*);
+        template<typename C> static Two test(...);
+
+    public:
+        enum {value = sizeof(HasRawEnergySetterHelper<T>::template test<T>(0)) == 1};
+    };
+
+    template<typename T, bool is_class_type=gs::IOIsClassType<T>::value>
+    struct HasRawEnergySetter
+    {
+        enum {value = false};
+    };    
+
+    template<typename T>
+    struct HasRawEnergySetter<T, true>
+    {
+        enum {value = HasRawEnergySetterHelper<T>::value};
+    };
+
+    template<typename T, bool>
+    struct RawEnergySetter
+    {
+        inline static void setRawEnergy(T&, float) {}
+    };
+
+    template<typename T>
+    struct RawEnergySetter<T, true>
+    {
+        inline static void setRawEnergy(T& h, float e) {h.setRawEnergy(e);}
+    };
+
+    template <typename T>
+    class HasRawEnergyGetterHelper
+    {
+    private:
+        template<float (T::*)() const> struct tester;
+        typedef char One;
+        typedef struct {char a[2];} Two;
+        template<typename C> static One test(tester<&C::eraw>*);
+        template<typename C> static Two test(...);
+
+    public:
+        enum {value = sizeof(HasRawEnergyGetterHelper<T>::template test<T>(0)) == 1};
+    };
+
+    template<typename T, bool is_class_type=gs::IOIsClassType<T>::value>
+    struct HasRawEnergyGetter
+    {
+        enum {value = false};
+    };    
+
+    template<typename T>
+    struct HasRawEnergyGetter<T, true>
+    {
+        enum {value = HasRawEnergyGetterHelper<T>::value};
+    };
+
+    template<typename T, bool>
+    struct RawEnergyGetter
+    {
+        inline static float getRawEnergy(const T&, float v) {return v;}
+    };
+
+    template<typename T>
+    struct RawEnergyGetter<T, true>
+    {
+        inline static float getRawEnergy(const T& h, float) {return h.eraw();}
+    };
+}
+
+// Function for setting the raw energy in a code templated
+// upon the rechit type. The function call will be ignored
+// in case the HcalRecHit type does not have a member function
+// "void setRawEnergy(float)".
+template <typename HcalRecHit>
+inline void setRawEnergy(HcalRecHit& h, float e)
+{
+    HcalRecHitPrivate::RawEnergySetter<HcalRecHit,HcalRecHitPrivate::HasRawEnergySetter<HcalRecHit>::value>::setRawEnergy(h, e);
+}
+
+// Function for getting the raw energy in a code templated
+// upon the rechit type. This function will return "valueIfNoSuchMember"
+// in case the HcalRecHit type does not have a member function
+// "float eraw() const".
+template <typename HcalRecHit>
+inline float getRawEnergy(const HcalRecHit& h, float valueIfNoSuchMember=-1.0e20)
+{
+    return HcalRecHitPrivate::RawEnergyGetter<HcalRecHit,HcalRecHitPrivate::HasRawEnergyGetter<HcalRecHit>::value>::getRawEnergy(h, valueIfNoSuchMember);
+}
+
+#endif // DATAFORMATS_HCALRECHIT_RAWENERGY_H

--- a/DataFormats/HcalRecHit/src/HBHERecHit.cc
+++ b/DataFormats/HcalRecHit/src/HBHERecHit.cc
@@ -1,17 +1,21 @@
 #include "DataFormats/HcalRecHit/interface/HBHERecHit.h"
 
 
-HBHERecHit::HBHERecHit() : CaloRecHit() {
+HBHERecHit::HBHERecHit() : CaloRecHit(), rawEnergy_(-1.0e21) {
 }
 
 HBHERecHit::HBHERecHit(const HcalDetId& id, float energy, float timeRising, float timeFalling) :
   CaloRecHit(id,energy,timeRising),
-  timeFalling_(timeFalling)	
+  timeFalling_(timeFalling),
+  rawEnergy_(-1.0e21)
 {
 }
 
 std::ostream& operator<<(std::ostream& s, const HBHERecHit& hit) {
   s << hit.id() << ": " << hit.energy() << " GeV";
+  if (hit.eraw() > -0.9e21) {
+    s << ", eraw=" << hit.eraw() << " GeV";
+  }
   if(hit.time() > -998) {
     s << ", t= " << hit.time() << " to " << hit.timeFalling() << " ns";
   }

--- a/DataFormats/HcalRecHit/src/classes_def.xml
+++ b/DataFormats/HcalRecHit/src/classes_def.xml
@@ -1,5 +1,6 @@
 <lcgdict>
-   <class name="HBHERecHit" ClassVersion="12">
+   <class name="HBHERecHit" ClassVersion="13">
+    <version ClassVersion="13" checksum="1684878064"/>
     <version ClassVersion="12" checksum="3812633329"/>
     <version ClassVersion="10" checksum="3145355338"/>
    </class>

--- a/DataFormats/HcalRecHit/test/HcalRecHitDump.cc
+++ b/DataFormats/HcalRecHit/test/HcalRecHitDump.cc
@@ -2,9 +2,14 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/GetterOfProducts.h"
 #include "FWCore/Framework/interface/ProcessMatch.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
 #include "DataFormats/HcalRecHit/interface/HcalSourcePositionData.h"
+
+#include <string>
 #include <iostream>
 
 using namespace std;
@@ -15,27 +20,40 @@ namespace cms {
       
   \author J. Mans - Minnesota
   */
-  class HcalRecHitDump : public edm::EDAnalyzer {
+  class HcalRecHitDump : public edm::EDAnalyzer
+  {
   public:
     explicit HcalRecHitDump(edm::ParameterSet const& conf);
     virtual void analyze(edm::Event const& e, edm::EventSetup const& c);
+
   private:
     edm::GetterOfProducts<HcalSourcePositionData> getHcalSourcePositionData_;
+
+    string hbhePrefix_;
+    string hoPrefix_;
+    string hfPrefix_;
   };
 
   HcalRecHitDump::HcalRecHitDump(edm::ParameterSet const& conf) :
-    getHcalSourcePositionData_(edm::ProcessMatch("*"), this) {
+    getHcalSourcePositionData_(edm::ProcessMatch("*"), this),
+    hbhePrefix_(conf.getUntrackedParameter<string>("hbhePrefix", "")),
+    hoPrefix_(conf.getUntrackedParameter<string>("hoPrefix", "")),
+    hfPrefix_(conf.getUntrackedParameter<string>("hfPrefix", ""))
+  {
     callWhenNewProductsRegistered(getHcalSourcePositionData_);
   }
-  
-  template<typename COLL> void analyzeT(edm::Event const& e, const char * name=0) {
+
+  template<typename COLL>
+  static void analyzeT(edm::Event const& e, const char* name=0, const char* prefix=0)
+  {
+    const string marker(prefix ? prefix : "");
     try {
-      std::vector<edm::Handle<COLL> > colls;
+      vector<edm::Handle<COLL> > colls;
       e.getManyByType(colls);
       typename std::vector<edm::Handle<COLL> >::iterator i;
       for (i=colls.begin(); i!=colls.end(); i++) {
         for (typename COLL::const_iterator j=(*i)->begin(); j!=(*i)->end(); j++)
-          cout << *j << std::endl;
+          cout << marker << *j << endl;
       }
     } catch (...) {
       if(name) cout << "No " << name << " RecHits." << endl;
@@ -43,9 +61,9 @@ namespace cms {
   }
 
   void HcalRecHitDump::analyze(edm::Event const& e, edm::EventSetup const& c) {
-    analyzeT<HBHERecHitCollection>(e, "HB/HE"); 
-    analyzeT<HFRecHitCollection>(e, "HF");
-    analyzeT<HORecHitCollection>(e, "HO");
+    analyzeT<HBHERecHitCollection>(e, "HB/HE", hbhePrefix_.c_str()); 
+    analyzeT<HFRecHitCollection>(e, "HF", hfPrefix_.c_str());
+    analyzeT<HORecHitCollection>(e, "HO", hoPrefix_.c_str());
     analyzeT<HcalCalibRecHitCollection>(e);
     analyzeT<ZDCRecHitCollection>(e);
     analyzeT<CastorRecHitCollection>(e);
@@ -53,7 +71,7 @@ namespace cms {
     std::vector<edm::Handle<HcalSourcePositionData> > handles;
     getHcalSourcePositionData_.fillHandles(e, handles);
     for (auto const& spd : handles){
-      cout << *spd << std::endl;
+      cout << *spd << endl;
     }
     cout << endl;    
   }


### PR DESCRIPTION
Added a member to the HBHERecHit to store uncorrected energy

Added a setter/getter function for the uncorrected energy that can
be used with classes that do not have relevant members

Modified HcalRecHitDump for grepping convenience
