### PR TITLE
Migrate RectangularEtaPhiTrackingRegion to consumes

### DIFF
--- a/RecoEgamma/EgammaElectronAlgos/interface/SeedFilter.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/SeedFilter.h
@@ -17,6 +17,8 @@
 #include "RecoEgamma/EgammaElectronAlgos/interface/FTSFromVertexToPointFactory.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 
+#include "RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h"
+
 #include <TMath.h>
 
 #include <Math/VectorUtil.h>
@@ -24,6 +26,7 @@
 
 class SeedGeneratorFromRegionHits;
 class MagneticField;
+class MeasurementTrackerEvent;
 namespace edm { class ConsumesCollector; }
 
 class SeedFilter {
@@ -54,11 +57,11 @@ class SeedFilter {
 
   edm::ESHandle<MagneticField> theMagField;
 
-  int hitsfactoryMode_;
+  RectangularEtaPhiTrackingRegion::UseMeasurementTracker hitsfactoryMode_;
 
   edm::EDGetTokenT<reco::BeamSpot> beamSpotTag_;
 
-  std::string measurementTrackerName_;
+  edm::EDGetTokenT<MeasurementTrackerEvent> measurementTrackerToken_;
 };
 
 #endif // SeedFilter_H

--- a/RecoHI/HiTracking/plugins/HITrackingRegionForPrimaryVtxProducer.h
+++ b/RecoHI/HiTracking/plugins/HITrackingRegionForPrimaryVtxProducer.h
@@ -132,7 +132,7 @@ class HITrackingRegionForPrimaryVtxProducer : public TrackingRegionProducer {
 
       if(estTracks>regTracking) {  // regional tracking
         result.push_back( 
-	  new RectangularEtaPhiTrackingRegion(theDirection, origin, thePtMin, theOriginRadius, halflength, etaB, phiB, RectangularEtaPhiTrackingRegion::UseMeasurementTracker::kForSiStrips, thePrecise) );
+	  new RectangularEtaPhiTrackingRegion(theDirection, origin, thePtMin, theOriginRadius, halflength, etaB, phiB, RectangularEtaPhiTrackingRegion::UseMeasurementTracker::kNever, thePrecise) );
       }
       else {                       // global tracking
         LogTrace("heavyIonHLTVertexing")<<" [HIVertexing: Global Tracking]";

--- a/RecoHI/HiTracking/plugins/HITrackingRegionForPrimaryVtxProducer.h
+++ b/RecoHI/HiTracking/plugins/HITrackingRegionForPrimaryVtxProducer.h
@@ -132,7 +132,7 @@ class HITrackingRegionForPrimaryVtxProducer : public TrackingRegionProducer {
 
       if(estTracks>regTracking) {  // regional tracking
         result.push_back( 
-	  new RectangularEtaPhiTrackingRegion(theDirection, origin, thePtMin, theOriginRadius, halflength, etaB, phiB, 0, thePrecise) );
+	  new RectangularEtaPhiTrackingRegion(theDirection, origin, thePtMin, theOriginRadius, halflength, etaB, phiB, RectangularEtaPhiTrackingRegion::UseMeasurementTracker::kForSiStrips, thePrecise) );
       }
       else {                       // global tracking
         LogTrace("heavyIonHLTVertexing")<<" [HIVertexing: Global Tracking]";

--- a/RecoHI/HiTracking/plugins/HITrackingRegionProducer.h
+++ b/RecoHI/HiTracking/plugins/HITrackingRegionProducer.h
@@ -104,7 +104,7 @@ class HITrackingRegionProducer : public TrackingRegionProducer {
     // tracking region selection
     std::vector<TrackingRegion* > result;
     if(estTracks>regTracking) {  // regional tracking
-      result.push_back( new RectangularEtaPhiTrackingRegion(theDirection, theOrigin, thePtMin, theOriginRadius, theOriginHalfLength, etaB, phiB, RectangularEtaPhiTrackingRegion::UseMeasurementTracker::kForSiStrips, thePrecise) );
+      result.push_back( new RectangularEtaPhiTrackingRegion(theDirection, theOrigin, thePtMin, theOriginRadius, theOriginHalfLength, etaB, phiB, RectangularEtaPhiTrackingRegion::UseMeasurementTracker::kNever, thePrecise) );
     }
     else {                       // global tracking
       LogTrace("heavyIonHLTVertexing")<<" [HIVertexing: Global Tracking]";

--- a/RecoHI/HiTracking/plugins/HITrackingRegionProducer.h
+++ b/RecoHI/HiTracking/plugins/HITrackingRegionProducer.h
@@ -104,7 +104,7 @@ class HITrackingRegionProducer : public TrackingRegionProducer {
     // tracking region selection
     std::vector<TrackingRegion* > result;
     if(estTracks>regTracking) {  // regional tracking
-      result.push_back( new RectangularEtaPhiTrackingRegion(theDirection, theOrigin, thePtMin, theOriginRadius, theOriginHalfLength, etaB, phiB, 0, thePrecise) );
+      result.push_back( new RectangularEtaPhiTrackingRegion(theDirection, theOrigin, thePtMin, theOriginRadius, theOriginHalfLength, etaB, phiB, RectangularEtaPhiTrackingRegion::UseMeasurementTracker::kForSiStrips, thePrecise) );
     }
     else {                       // global tracking
       LogTrace("heavyIonHLTVertexing")<<" [HIVertexing: Global Tracking]";

--- a/RecoMuon/GlobalTrackingTools/interface/MuonTrackingRegionBuilder.h
+++ b/RecoMuon/GlobalTrackingTools/interface/MuonTrackingRegionBuilder.h
@@ -18,9 +18,10 @@
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h"
 
 class MuonServiceProxy;
-class RectangularEtaPhiTrackingRegion;
+class MeasurementTrackerEvent;
 
 namespace edm {class ParameterSet; class Event;}
 
@@ -78,8 +79,8 @@ class MuonTrackingRegionBuilder {
 
     GlobalPoint theVertexPos;
 
-    double theOnDemand;
-    std::string theMeasurementTrackerName;
+    RectangularEtaPhiTrackingRegion::UseMeasurementTracker theOnDemand;
+    edm::EDGetTokenT<MeasurementTrackerEvent> theMeasurementTrackerToken;
     edm::EDGetTokenT<reco::BeamSpot> bsHandleToken;
     edm::EDGetTokenT<reco::VertexCollection> vertexCollectionToken;
 };

--- a/RecoTauTag/HLTProducers/src/TauRegionalPixelSeedGenerator.h
+++ b/RecoTauTag/HLTProducers/src/TauRegionalPixelSeedGenerator.h
@@ -19,6 +19,7 @@
 #include "RecoTracker/TkTrackingRegions/interface/TrackingRegionProducer.h"
 #include "RecoTracker/TkTrackingRegions/interface/GlobalTrackingRegion.h"
 #include "RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h"
+#include "RecoTracker/MeasurementDet/interface/MeasurementTrackerEvent.h"
 // Math
 #include "Math/GenVector/VectorUtil.h"
 #include "Math/GenVector/PxPyPzE4D.h"
@@ -51,13 +52,19 @@ class TauRegionalPixelSeedGenerator : public TrackingRegionProducer {
       else{
 	m_searchOpt = false;
       }
-      m_measurementTracker ="";
-      m_howToUseMeasurementTracker=0;
+      m_howToUseMeasurementTracker = RectangularEtaPhiTrackingRegion::UseMeasurementTracker::kForSiStrips;
       if (regionPSet.exists("measurementTrackerName")){
-	m_measurementTracker = regionPSet.getParameter<std::string>("measurementTrackerName");
+        // FIXME: when next time altering the configuration of this
+        // class, please change the types of the following parameters:
+        // - howToUseMeasurementTracker to at least int32 or to a string
+        //   corresponding to the UseMeasurementTracker enumeration
+        // - measurementTrackerName to InputTag
 	if (regionPSet.exists("howToUseMeasurementTracker")){
-	  m_howToUseMeasurementTracker = regionPSet.getParameter<double>("howToUseMeasurementTracker");
+	  m_howToUseMeasurementTracker = RectangularEtaPhiTrackingRegion::doubleToUseMeasurementTracker(regionPSet.getParameter<double>("howToUseMeasurementTracker"));
 	}
+        if(m_howToUseMeasurementTracker != RectangularEtaPhiTrackingRegion::UseMeasurementTracker::kNever) {
+          token_measurementTracker = iC.consumes<MeasurementTrackerEvent>(regionPSet.getParameter<std::string>("measurementTrackerName"));
+        }
       }
     }
   
@@ -92,9 +99,15 @@ class TauRegionalPixelSeedGenerator : public TrackingRegionProducer {
       edm::Handle<edm::View<reco::Candidate> > h_jets;
       e.getByToken(token_jet, h_jets);
       
-      for (unsigned int iJet =0; iJet < h_jets->size(); ++iJet)
+      const MeasurementTrackerEvent *measurementTracker = nullptr;
+      if(!token_measurementTracker.isUninitialized()) {
+        edm::Handle<MeasurementTrackerEvent> hmte;
+        e.getByToken(token_measurementTracker, hmte);
+        measurementTracker = hmte.product();
+      }
+
+      for(const reco::Candidate& myJet: *h_jets)
 	{
-	  const reco::Candidate & myJet = (*h_jets)[iJet];
           GlobalVector jetVector(myJet.momentum().x(),myJet.momentum().y(),myJet.momentum().z());
 //          GlobalPoint  vertex(0, 0, originZ);
           RectangularEtaPhiTrackingRegion* etaphiRegion = new RectangularEtaPhiTrackingRegion( jetVector,
@@ -106,7 +119,7 @@ class TauRegionalPixelSeedGenerator : public TrackingRegionProducer {
                                                                                                m_deltaPhi,
 											       m_howToUseMeasurementTracker,
 											       true,
-											       m_measurementTracker,
+											       measurementTracker,
 											       m_searchOpt);
           result.push_back(etaphiRegion);
       }
@@ -124,8 +137,8 @@ class TauRegionalPixelSeedGenerator : public TrackingRegionProducer {
   float m_deltaPhi;
   edm::EDGetTokenT<reco::VertexCollection> token_vertex; 
   edm::EDGetTokenT<reco::CandidateView> token_jet; 
-  std::string m_measurementTracker;
-  double m_howToUseMeasurementTracker;
+  edm::EDGetTokenT<MeasurementTrackerEvent> token_measurementTracker;
+  RectangularEtaPhiTrackingRegion::UseMeasurementTracker m_howToUseMeasurementTracker;
   bool m_searchOpt;
 };
 

--- a/RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h
+++ b/RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h
@@ -92,7 +92,7 @@ public:
 				   const GlobalPoint & vertexPos,
                                    float ptMin, float rVertex, float zVertex,
                                    float deltaEta, float deltaPhi,
-                                   UseMeasurementTracker whereToUseMeasurementTracker = UseMeasurementTracker::kForSiStrips,
+                                   UseMeasurementTracker whereToUseMeasurementTracker = UseMeasurementTracker::kNever,
                                    bool precise = true,
                                    const MeasurementTrackerEvent *measurementTracker = nullptr,
 				   bool etaPhiRegion=false) 
@@ -114,7 +114,7 @@ public:
                                    float ptMin, float rVertex, float zVertex,
                                    Margin etaMargin,
                                    Margin phiMargin,
-                                   UseMeasurementTracker whereToUseMeasurementTracker = UseMeasurementTracker::kForSiStrips,
+                                   UseMeasurementTracker whereToUseMeasurementTracker = UseMeasurementTracker::kNever,
 				   bool precise = true, 
                                    const MeasurementTrackerEvent *measurementTracker = nullptr,
 				   bool etaPhiRegion=false) 
@@ -134,7 +134,7 @@ public:
                                    float rVertex, float zVertex,
                                    Margin etaMargin,
                                    Margin phiMargin,
-                                   UseMeasurementTracker whereToUseMeasurementTracker = UseMeasurementTracker::kForSiStrips,
+                                   UseMeasurementTracker whereToUseMeasurementTracker = UseMeasurementTracker::kNever,
                                    bool precise = true,
                                    const MeasurementTrackerEvent *measurementTracker = nullptr,
 				   bool etaPhiRegion=false) 

--- a/RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h
+++ b/RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h
@@ -78,11 +78,12 @@ public:
                                    bool precise = true,
                                    const std::string & measurementTrackerName = "",
 				   bool etaPhiRegion=false) 
-    : TrackingRegionBase( dir, vertexPos, Range( -1/ptMin, 1/ptMin), rVertex, zVertex),
-    thePhiMargin(std::abs(deltaPhi),std::abs(deltaPhi)),
-    theMeasurementTrackerUsage(whereToUseMeasurementTracker), thePrecise(precise),
-    theUseEtaPhi(etaPhiRegion), theMeasurementTrackerName(measurementTrackerName)
-  { initEtaRange(dir, Margin( std::abs(deltaEta),std::abs(deltaEta))); }
+    : RectangularEtaPhiTrackingRegion(dir, vertexPos, Range( -1/ptMin, 1/ptMin), rVertex, zVertex,
+                                      Margin(std::abs(deltaEta), std::abs(deltaEta)),
+                                      Margin(std::abs(deltaPhi), std::abs(deltaPhi)),
+                                      whereToUseMeasurementTracker, precise,
+                                      measurementTrackerName, etaPhiRegion)
+    {}
  
  /** constructor (asymmetrinc eta and phi margins). <BR>
   * non equal left-right eta and phi bounds around direction are
@@ -99,11 +100,11 @@ public:
 				   bool precise = true, 
                                    const std::string & measurementTrackerName = "",
 				   bool etaPhiRegion=false) 
-    : TrackingRegionBase( dir, vertexPos, Range( -1/ptMin, 1/ptMin), rVertex, zVertex), 
-    thePhiMargin( phiMargin), theMeasurementTrackerUsage(whereToUseMeasurementTracker), 
-    thePrecise(precise),theUseEtaPhi(etaPhiRegion),
-    theMeasurementTrackerName(measurementTrackerName)
-    { initEtaRange(dir, etaMargin); }
+    : RectangularEtaPhiTrackingRegion(dir, vertexPos, Range( -1/ptMin, 1/ptMin), rVertex, zVertex,
+                                      etaMargin, phiMargin,
+                                      whereToUseMeasurementTracker, precise,
+                                      measurementTrackerName, etaPhiRegion)
+    {}
 
  /** constructor (explicit pt range, asymmetrinc eta and phi margins). <BR>
   * the meaning of other arguments is the same as in the case of 

--- a/RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h
+++ b/RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h
@@ -24,9 +24,27 @@ class OuterHitPhiPrediction;
 class OuterEstimator;
 class BarrelDetLayer;
 class ForwardDetLayer;
+class MeasurementTrackerEvent;
 
 class RectangularEtaPhiTrackingRegion GCC11_FINAL : public TrackingRegion {
 public:
+  enum class UseMeasurementTracker {
+    kNever = -1,
+    kForSiStrips = 0,
+    kAlways = 1
+  };
+
+  static UseMeasurementTracker intToUseMeasurementTracker(int value) {
+    assert(value >= -1 && value <= 1);
+    return static_cast<UseMeasurementTracker>(value);
+  }
+
+  static UseMeasurementTracker doubleToUseMeasurementTracker(double value) {
+    // mimic the old behaviour
+    if(value >  0.5) return UseMeasurementTracker::kAlways;
+    if(value > -0.5) return UseMeasurementTracker::kForSiStrips;
+    return UseMeasurementTracker::kNever;
+  }
 
   RectangularEtaPhiTrackingRegion(RectangularEtaPhiTrackingRegion const & rh) :
     TrackingRegion(rh),
@@ -37,7 +55,7 @@ public:
     theMeasurementTrackerUsage(rh.theMeasurementTrackerUsage),
     thePrecise(rh.thePrecise),
     theUseEtaPhi(rh.theUseEtaPhi),
-    theMeasurementTrackerName(rh.theMeasurementTrackerName) {}
+    theMeasurementTracker(rh.theMeasurementTracker) {}
   
   RectangularEtaPhiTrackingRegion& operator=(RectangularEtaPhiTrackingRegion const &)=delete;
   RectangularEtaPhiTrackingRegion(RectangularEtaPhiTrackingRegion &&)=default;
@@ -74,15 +92,15 @@ public:
 				   const GlobalPoint & vertexPos,
                                    float ptMin, float rVertex, float zVertex,
                                    float deltaEta, float deltaPhi,
-                                   float whereToUseMeasurementTracker = 0.,
+                                   UseMeasurementTracker whereToUseMeasurementTracker = UseMeasurementTracker::kForSiStrips,
                                    bool precise = true,
-                                   const std::string & measurementTrackerName = "",
+                                   const MeasurementTrackerEvent *measurementTracker = nullptr,
 				   bool etaPhiRegion=false) 
     : RectangularEtaPhiTrackingRegion(dir, vertexPos, Range( -1/ptMin, 1/ptMin), rVertex, zVertex,
                                       Margin(std::abs(deltaEta), std::abs(deltaEta)),
                                       Margin(std::abs(deltaPhi), std::abs(deltaPhi)),
                                       whereToUseMeasurementTracker, precise,
-                                      measurementTrackerName, etaPhiRegion)
+                                      measurementTracker, etaPhiRegion)
     {}
  
  /** constructor (asymmetrinc eta and phi margins). <BR>
@@ -96,14 +114,14 @@ public:
                                    float ptMin, float rVertex, float zVertex,
                                    Margin etaMargin,
                                    Margin phiMargin,
-                                   float whereToUseMeasurementTracker = 0.,
+                                   UseMeasurementTracker whereToUseMeasurementTracker = UseMeasurementTracker::kForSiStrips,
 				   bool precise = true, 
-                                   const std::string & measurementTrackerName = "",
+                                   const MeasurementTrackerEvent *measurementTracker = nullptr,
 				   bool etaPhiRegion=false) 
     : RectangularEtaPhiTrackingRegion(dir, vertexPos, Range( -1/ptMin, 1/ptMin), rVertex, zVertex,
                                       etaMargin, phiMargin,
                                       whereToUseMeasurementTracker, precise,
-                                      measurementTrackerName, etaPhiRegion)
+                                      measurementTracker, etaPhiRegion)
     {}
 
  /** constructor (explicit pt range, asymmetrinc eta and phi margins). <BR>
@@ -116,13 +134,13 @@ public:
                                    float rVertex, float zVertex,
                                    Margin etaMargin,
                                    Margin phiMargin,
-                                   float whereToUseMeasurementTracker = 0.,
+                                   UseMeasurementTracker whereToUseMeasurementTracker = UseMeasurementTracker::kForSiStrips,
                                    bool precise = true,
-                                   const std::string & measurementTrackerName = "",
+                                   const MeasurementTrackerEvent *measurementTracker = nullptr,
 				   bool etaPhiRegion=false) 
     : TrackingRegionBase( dir, vertexPos, invPtRange, rVertex, zVertex),
     thePhiMargin( phiMargin), theMeasurementTrackerUsage(whereToUseMeasurementTracker), thePrecise(precise),theUseEtaPhi(etaPhiRegion),
-    theMeasurementTrackerName(measurementTrackerName)
+    theMeasurementTracker(measurementTracker)
     { initEtaRange(dir, etaMargin); }
 
 
@@ -187,10 +205,10 @@ private:
   Range theLambdaRange;
   Margin thePhiMargin;
   float theMeanLambda;
-  float theMeasurementTrackerUsage;
+  const UseMeasurementTracker theMeasurementTrackerUsage;
   bool thePrecise;
   bool theUseEtaPhi;
-  std::string theMeasurementTrackerName;
+  const MeasurementTrackerEvent *theMeasurementTracker;
 
 
 

--- a/RecoTracker/TkTrackingRegions/src/RectangularEtaPhiTrackingRegion.cc
+++ b/RecoTracker/TkTrackingRegions/src/RectangularEtaPhiTrackingRegion.cc
@@ -318,8 +318,8 @@ void RectangularEtaPhiTrackingRegion::hits_(
   OuterEstimator * est = 0;
 
   bool measurementMethod = false;
-  if ( theMeasurementTrackerUsage > 0.5) measurementMethod = true;
-  if ( theMeasurementTrackerUsage > -0.5 &&
+  if(theMeasurementTrackerUsage == UseMeasurementTracker::kAlways) measurementMethod = true;
+  else if(theMeasurementTrackerUsage == UseMeasurementTracker::kForSiStrips &&
        !(detLayer->subDetector() == GeomDetEnumerators::PixelBarrel ||
          detLayer->subDetector() == GeomDetEnumerators::PixelEndcap) ) measurementMethod = true;
 
@@ -366,9 +366,7 @@ void RectangularEtaPhiTrackingRegion::hits_(
     // propagator
     StraightLinePropagator prop( magField, alongMomentum);
     
-    edm::Handle<MeasurementTrackerEvent> mte;
-    ev.getByLabel(edm::InputTag(theMeasurementTrackerName), mte);
-    LayerMeasurements lm(mte->measurementTracker(), *mte);
+    LayerMeasurements lm(theMeasurementTracker->measurementTracker(), *theMeasurementTracker);
     
     vector<TrajectoryMeasurement> meas = lm.measurements(*detLayer, tsos, prop, *findDetAndHits);
     result.reserve(meas.size());


### PR DESCRIPTION
The RectangularEtaPhiTrackingRegion needs MeasurementTrackerEvent if it is configured to use MTE always or for strips only (and if any seeding layer is in strips). RectangularEtaPhiTrackingRegion is constructed per event by various factory-like classes (+ a couple of others). Therefore the responsibility to call consumes+getByToken is moved to these constructing classes, and they call getByToken only if MTE usage is not disabled (`!= kNever`).

I also changed the default value of `whereToUseMeasurementTracker` from `kForSiStrips` to `kNever` in the constructor of RectangularEtaPhiTrackingRegion. I think this is the only sensible default value given the (also old)  default value of `measurementTracker` parameter.

Based on top of CMSSW_7_1_X_2014-03-27-0200, should not affect physics.

FYI @VinInn @fwyzard @gennai @mtosi @cerati @rovere
