### PR TITLE
Mark PluginManager statics as thread safe

### DIFF
--- a/FWCore/PluginManager/src/PluginFactoryManager.cc
+++ b/FWCore/PluginManager/src/PluginFactoryManager.cc
@@ -83,7 +83,7 @@ PluginFactoryManager::end() const
 PluginFactoryManager*
 PluginFactoryManager::get()
 {
-   static PluginFactoryManager s_instance;
+   [[cms::thread_safe]] static PluginFactoryManager s_instance;
    return &s_instance;
 }
 }

--- a/FWCore/PluginManager/src/PluginManager.cc
+++ b/FWCore/PluginManager/src/PluginManager.cc
@@ -332,7 +332,7 @@ PluginManager::loadingLibraryNamed_()
 
 PluginManager*& PluginManager::singleton()
 {
-  static PluginManager* s_singleton=0;
+  [[cms::thread_safe]] static PluginManager* s_singleton=0;
   return s_singleton;
 }
 


### PR DESCRIPTION
The singletons for the plugin system are required to be initialized before any threads are started, therefore the statics which hold those singletons are thread safe. This commit used the cms attribute to mark these as safe so we do not get a false positive from the static analyzer.
