### PR TITLE
Fixed const correctness for CosmicMuonSmoother

### DIFF
--- a/RecoMuon/CosmicMuonProducer/interface/CosmicMuonSmoother.h
+++ b/RecoMuon/CosmicMuonProducer/interface/CosmicMuonSmoother.h
@@ -59,11 +59,11 @@ public:
 
   const Propagator* propagatorOpposite() const {return &*theService->propagator(thePropagatorOppositeName);}
 
-  KFUpdator* updator() const {return theUpdator;}
+  const KFUpdator* updator() const {return theUpdator;}
 
-  CosmicMuonUtilities* utilities() const {return theUtilities; } 
+  const CosmicMuonUtilities* utilities() const {return theUtilities; } 
 
-  Chi2MeasurementEstimator* estimator() const {return theEstimator;}
+  const Chi2MeasurementEstimator* estimator() const {return theEstimator;}
 
   std::vector<Trajectory> fit(const Trajectory&) const;
   std::vector<Trajectory> fit(const TrajectorySeed& seed,

--- a/RecoMuon/CosmicMuonProducer/interface/CosmicMuonTrajectoryBuilder.h
+++ b/RecoMuon/CosmicMuonProducer/interface/CosmicMuonTrajectoryBuilder.h
@@ -68,7 +68,7 @@ public:
 
   CosmicMuonSmoother* smoother() const {return theSmoother;}
 
-  CosmicMuonUtilities* utilities() const {return smoother()->utilities();}
+  const CosmicMuonUtilities* utilities() const {return smoother()->utilities();}
 
   DirectMuonNavigation* navigation() const {return theNavigation;}
 

--- a/RecoMuon/CosmicMuonProducer/interface/GlobalCosmicMuonTrajectoryBuilder.h
+++ b/RecoMuon/CosmicMuonProducer/interface/GlobalCosmicMuonTrajectoryBuilder.h
@@ -70,7 +70,7 @@ private:
 
   CosmicMuonSmoother* smoother() const {return theSmoother;}
 
-  CosmicMuonUtilities* utilities() const {return smoother()->utilities();}
+  const CosmicMuonUtilities* utilities() const {return smoother()->utilities();}
 
   bool isTraversing(const reco::Track& tk) const;
 


### PR DESCRIPTION
The static analyzer identified that CosmicMuonSmoother was returning
a non const pointer to internal member data from a const function. This
is a thread-safety issue since a routine that has a 'const' CosmicMuonSmoother
can still change the memory owned by the smoother. The fix was trivial since
no other code cared that those pointers were non-const.
The two TrajectoryBuilder classes were passing on one of the non-const
pointers so they also had to be changed to return a const pointer.
