### PR TITLE
adding new scenarios in runTheMatrix for SLHC10

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1106,8 +1106,14 @@ upgradeKeys=['2017',
              'Extended2023TTI',
              'Extended2023Muon',
              'Extended2023CFCal',
-             'Extended2023CFCal4Eta'
-             ]
+             'Extended2023CFCal4Eta',
+	     'Extended2023Pixel',            
+	     'Extended2023SHCalNoTaper',
+	     'Extended2023SHCalNoTaper4Eta',
+	     'Extended2023HGCal',
+	     'Extended2023HGCalMuon4Eta'
+	     	     
+	     ]
 upgradeGeoms={ '2017' : 'Extended2017',
                '2019' : 'Extended2019',
                '2019WithGEM' : 'Extended2019',
@@ -1125,7 +1131,12 @@ upgradeGeoms={ '2017' : 'Extended2017',
                'Extended2023TTI' : 'Extended2023TTI,Extended2023TTIReco',
                'Extended2023Muon' : 'Extended2023Muon,Extended2023MuonReco',
                'Extended2023CFCal' : 'Extended2023CFCal,Extended2023CFCalReco',
-               'Extended2023CFCal4Eta' : 'Extended2023CFCal4Eta,Extended2023CFCal4EtaReco'
+               'Extended2023CFCal4Eta' : 'Extended2023CFCal4Eta,Extended2023CFCal4EtaReco',
+               'Extended2023Pixel' : 'Extended2023Pixel,Extended2023PixelReco',
+               'Extended2023SHCalNoTaper' : 'Extended2023SHCalNoTaper,Extended2023SHCalNoTaperReco',
+               'Extended2023SHCalNoTaper4Eta' : 'Extended2023SHCalNoTaper4Eta,Extended2023SHCalNoTaper4EtaReco',
+               'Extended2023HGCal' : 'Extended2023HGCal,Extended2023HGCalReco',
+               'Extended2023HGCalMuon4Eta' : 'Extended2023HGCalMuon4Eta,Extended2023HGCalMuon4EtaReco'
                }
 upgradeGTs={ '2017' : 'auto:upgrade2017',
              '2019' : 'auto:upgrade2019',
@@ -1144,7 +1155,12 @@ upgradeGTs={ '2017' : 'auto:upgrade2017',
              'Extended2023TTI' : 'auto:upgradePLS3',
              'Extended2023Muon' : 'auto:upgradePLS3',
              'Extended2023CFCal' : 'auto:upgradePLS3',
-             'Extended2023CFCal4Eta' : 'auto:upgradePLS3'
+             'Extended2023CFCal4Eta' : 'auto:upgradePLS3',
+             'Extended2023Pixel' : 'auto:upgradePLS3',
+             'Extended2023SHCalNoTaper' : 'auto:upgradePLS3',
+             'Extended2023SHCalNoTaper4Eta' : 'auto:upgradePLS3',
+             'Extended2023HGCal' : 'auto:upgradePLS3',
+             'Extended2023HGCalMuon4Eta' : 'auto:upgradePLS3'
              }
 upgradeCustoms={ '2017' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2017',
                  '2019' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2019',
@@ -1163,7 +1179,12 @@ upgradeCustoms={ '2017' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.
                  'Extended2023TTI' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023TTI',
                  'Extended2023Muon' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023Muon',
                  'Extended2023CFCal' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023',
-                 'Extended2023CFCal4Eta' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023'
+                 'Extended2023CFCal4Eta' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023',
+                 'Extended2023Pixel' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023Pixel',
+                 'Extended2023SHCalNoTaper' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023',
+                 'Extended2023SHCalNoTaper4Eta' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023',
+                 'Extended2023HGCal' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023',
+                 'Extended2023HGCalMuon4Eta' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023'
                  }
 ### remember that you need to add a new step for phase 2 to include the track trigger
 ### remember that you need to add fastsim
@@ -1195,7 +1216,12 @@ upgradeScenToRun={ '2017':['GenSimFull','DigiFull','RecoFull','HARVESTFull'],
                    'Extended2023TTI':['GenSimHLBeamSpotFull','DigiTrkTrigFull'], ##no need to go beyond local reco
                    'Extended2023Muon':['GenSimFull','DigiFull','RecoFull','HARVESTFull'],
                    'Extended2023CFCal':['GenSimFull','DigiFull','RecoFull','HARVESTFull'],
-                   'Extended2023CFCal4Eta':['GenSimFull','DigiFull','RecoFull','HARVESTFull']
+                   'Extended2023CFCal4Eta':['GenSimFull','DigiFull','RecoFull','HARVESTFull'],
+	           'Extended2023Pixel':['GenSimFull','DigiFull','RecoFull','HARVESTFull'],          
+	           'Extended2023SHCalNoTaper':['GenSimFull','DigiFull','RecoFull','HARVESTFull'],
+	           'Extended2023SHCalNoTaper4Eta':['GenSimFull','DigiFull','RecoFull','HARVESTFull'],
+	           'Extended2023HGCal':['GenSimFull','DigiFull','RecoFull','HARVESTFull'],
+	           'Extended2023HGCalMuon4Eta':['GenSimFull','DigiFull','RecoFull','HARVESTFull']
                    }
 
 upgradeStepDict={}

--- a/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
@@ -15,6 +15,7 @@ from SLHCUpgradeSimulations.Configuration.phase2TkCustoms_LB_4LPS_2L2S import l1
 from SLHCUpgradeSimulations.Configuration.phase1TkCustomsPixel10D import customise as customisePhase1TkPixel10D
 from SLHCUpgradeSimulations.Configuration.combinedCustoms_TTI import customise as customiseTTI
 from SLHCUpgradeSimulations.Configuration.combinedCustoms_TTI import l1EventContent_TTI as customise_ev_l1tracker
+from SLHCUpgradeSimulations.Configuration.combinedCustoms_TTI import l1EventContent_TTI_forHLT
 
 from SLHCUpgradeSimulations.Configuration.customise_mixing import customise_NoCrossing
 from SLHCUpgradeSimulations.Configuration.phase1TkCustoms import customise as customisePhase1Tk
@@ -98,6 +99,14 @@ def cust_2023(process):
     process=customise_gem(process)
     return process
 
+def cust_2023Pixel(process):
+    process=customisePostLS1(process)
+    process=customiseBE5DPixel10D(process)
+    process=customise_HcalPhase2(process)
+    process=customise_ev_BE5DPixel10D(process)
+    process=customise_gem(process)
+    return process
+
 def cust_2023Muon(process):
     process=customisePostLS1(process)
     process=customiseBE5DPixel10D(process)
@@ -113,8 +122,16 @@ def cust_2023TTI(process):
     process=customiseBE5DPixel10D(process)
     process=customise_HcalPhase0(process)
     process=customise_ev_l1tracker(process)
-
     return process
+
+def cust_2023TTI_forHLT(process):
+    process=customisePostLS1(process)
+    process=customiseTTI(process)
+    process=customiseBE5DPixel10D(process)
+    process=customise_HcalPhase0(process)
+    process=l1EventContent_TTI_forHLT(process)
+    return process
+
 
 def noCrossing(process):
     process=customise_NoCrossing(process)


### PR DESCRIPTION
hi so I have added 5 scenarios in runthematrix
         'Extended2023Pixel',  
         'Extended2023SHCalNoTaper',
         'Extended2023SHCalNoTaper4Eta',
         'Extended2023HGCal',
         'Extended2023HGCalMuon4Eta'
they can be tested with 13600,13800,14000,14200,14400 resp.
--> at this stage (14/03/31) we should make Extened2023Pixel fully run, the other ones should pass the gem-sim step 
