### PR TITLE
Workaround TestRunnerFWCoreTFWLiteSelector tests

### DIFF
--- a/FWCore/TFWLiteSelector/test/proof_thing2_sel.C
+++ b/FWCore/TFWLiteSelector/test/proof_thing2_sel.C
@@ -22,6 +22,8 @@ void proof_thing2_sel()
 {
   if (gSystem->Getenv("TMPDIR")) {
     std::string t(gSystem->Getenv("TMPDIR"));
+    if (t.size() > 80)
+      t = "/tmp";
     t += "/proof";
     gEnv->SetValue("Proof.Sandbox", t.c_str());
     gEnv->SetValue("ProofLite.SockPathDir", t.c_str());

--- a/FWCore/TFWLiteSelector/test/proof_thing_sel.C
+++ b/FWCore/TFWLiteSelector/test/proof_thing_sel.C
@@ -22,6 +22,8 @@ void proof_thing_sel()
 {
   if (gSystem->Getenv("TMPDIR")) {
     std::string t = gSystem->Getenv("TMPDIR");
+    if (t.size() > 80)
+      t = "/tmp";
     t += "/proof";
     gEnv->SetValue("Proof.Sandbox", t.c_str());
     gEnv->SetValue("ProofLite.SockPathDir", t.c_str());


### PR DESCRIPTION
Not particularly elegant and leaks a directory, we should probably
simply remove the test.
