### PR TITLE
Pcl for cosmics: specialize PromptCalibProd streams for running only cosmic friendly workflows

### DIFF
--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdSiStrip_Output_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdSiStrip_Output_cff.py
@@ -1,0 +1,17 @@
+import FWCore.ParameterSet.Config as cms
+
+
+
+
+OutALCARECOPromptCalibProdSiStrip_noDrop = cms.PSet(
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('pathALCARECOPromptCalibProdSiStrip')
+    ),
+    outputCommands = cms.untracked.vstring(
+        'keep *_MEtoEDMConvertSiStrip_*_*')
+)
+
+import copy
+
+OutALCARECOPromptCalibProdSiStrip=copy.deepcopy(OutALCARECOPromptCalibProdSiStrip_noDrop)
+OutALCARECOPromptCalibProdSiStrip.outputCommands.insert(0, "drop *")

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdSiStrip_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdSiStrip_cff.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+
+                     
+seqALCARECOPromptCalibProdSiStrip = cms.Sequence()
+
+

--- a/Calibration/TkAlCaRecoProducers/test/BuildFile.xml
+++ b/Calibration/TkAlCaRecoProducers/test/BuildFile.xml
@@ -1,0 +1,6 @@
+<use   name="DQMServices/Core"/>
+<use   name="FWCore/Framework"/>
+<use   name="boost"/>
+<library   file="DQMRootFileReader.cc" name="CalibrationTkAlCaRecoProducersDQMRootFileReader">
+  <flags   EDM_PLUGIN="1"/>
+</library>

--- a/Calibration/TkAlCaRecoProducers/test/DQMRootFileReader.cc
+++ b/Calibration/TkAlCaRecoProducers/test/DQMRootFileReader.cc
@@ -1,0 +1,99 @@
+// -*- C++ -*-
+//
+// Class:      DQMRootFileReader
+// 
+/**\class DQMRootFileReader
+
+Description: Simple example showing how to read MonitorElements from a DQM plain ROOT file
+
+Implementation:
+<Notes on implementation>
+*/
+//
+//
+//
+
+
+// system include files
+#include <string>
+#include <vector>
+#include <iostream>
+
+// user include files
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+
+
+using std::cout;
+using std::endl;
+
+//
+// class declaration
+//
+class DQMRootFileReader : public edm::EDAnalyzer {
+public:
+  explicit DQMRootFileReader( const edm::ParameterSet& );
+  ~DQMRootFileReader();
+  
+  virtual void analyze( const edm::Event&, const edm::EventSetup& );
+  
+  virtual void endJob(void);
+
+private:
+  // ----------member data ---------------------------
+  
+  // back-end interface
+  DQMStore * dbe;
+  std::string filename;
+};
+
+//
+// constructors and destructor
+//
+DQMRootFileReader::DQMRootFileReader(const edm::ParameterSet& iConfig ) {
+  // get hold of back-end interface
+  dbe = edm::Service<DQMStore>().operator->();
+
+  filename = iConfig.getUntrackedParameter<std::string>("RootFileName", "test_playback.root");
+}
+
+
+
+DQMRootFileReader::~DQMRootFileReader() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
+  
+}
+
+
+void DQMRootFileReader::endJob(void)
+{
+  cout << "Dumping DQMStore dir structure:" << endl;
+  dbe->showDirStructure();
+  // dbe->save("test.root");  
+}
+
+
+//
+// member functions
+//
+
+// ------------ method called to produce the data  ------------
+void DQMRootFileReader::analyze(const edm::Event& iEvent, 
+					 const edm::EventSetup& iSetup )
+{
+  // NOTE: this is here just because we need it after the beginRun of MEtoEDMCoverter which calls a Reset on all MEs.
+  dbe->open(filename, false, "","",DQMStore::OpenRunDirs::StripRunDirs);
+  dbe->showDirStructure();
+
+}
+
+// define this as a plug-in
+DEFINE_FWK_MODULE(DQMRootFileReader);
+

--- a/Calibration/TkAlCaRecoProducers/test/convertSiStripRootDQMFileToEDM_cfg.py
+++ b/Calibration/TkAlCaRecoProducers/test/convertSiStripRootDQMFileToEDM_cfg.py
@@ -1,0 +1,62 @@
+import FWCore.ParameterSet.Config as cms
+
+""" This python cfg converts a plain DQM root file in a EDM file that can be used to run the SiStrip bad channel calibration as done @ Tier0"""
+
+
+
+process = cms.Process("CONV")
+
+#process.load("DQMServices.Core.test.MessageLogger_cfi")
+process.load('Configuration.EventContent.EventContent_cff')
+process.load("DQMServices.Core.DQM_cfg")
+#process.DQMStore.collateHistograms = cms.untracked.bool(True)
+
+
+
+process.fileReader = cms.EDAnalyzer("DQMRootFileReader",
+                                    RootFileName = cms.untracked.string
+                                    ('/build/cerminar/debugpcl/CMSSW_5_3_16/src/Calibration/TkAlCaRecoProducers/test/DQM_V0001_R000160819__StreamExpress__Run2011A-Express-v1__DQM.root')
+                                    )
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+    )
+
+
+runNumber = int(process.fileReader.RootFileName.value().split('/')[-1].split('_')[2].lstrip("R"))
+print "Run number extracted from file name:",runNumber
+
+process.source = cms.Source("EmptySource",
+                            firstRun = cms.untracked.uint32(runNumber),
+                            )
+
+
+
+
+process.ALCARECOStreamSiStripPCLHistos = cms.OutputModule("PoolOutputModule",
+                                                          outputCommands = cms.untracked.vstring('drop *', 
+                                                                                                 'keep *_MEtoEDMConvertSiStrip_*_*'),
+                                                          fileName = cms.untracked.string('SiStripPCLHistos.root'),
+                                                          dataset = cms.untracked.PSet(
+                                                              filterName = cms.untracked.string(''),
+                                                              dataTier = cms.untracked.string('ALCARECO')
+                                                              ),
+                                                          eventAutoFlushCompressedSize = cms.untracked.int32(5242880)
+                                                          )
+
+process.MEtoEDMConvertSiStrip = cms.EDProducer("MEtoEDMConverter",
+                                               deleteAfterCopy = cms.untracked.bool(False),
+                                               Verbosity = cms.untracked.int32(0),
+                                               Frequency = cms.untracked.int32(50),
+                                               Name = cms.untracked.string('MEtoEDMConverter'),
+                                               MEPathToSave = cms.untracked.string('AlCaReco/SiStrip')
+                                               )
+
+
+
+process.path = cms.Path(process.fileReader)
+process.ALCARECOStreamSiStripPCLHistosOutPath = cms.EndPath(process.ALCARECOStreamSiStripPCLHistos)
+process.endjob_step = cms.EndPath(process.MEtoEDMConvertSiStrip)
+
+
+process.schedule = cms.Schedule(process.path, process.endjob_step, process.ALCARECOStreamSiStripPCLHistosOutPath)

--- a/Configuration/DataProcessing/python/Reco.py
+++ b/Configuration/DataProcessing/python/Reco.py
@@ -63,7 +63,13 @@ class Reco(Scenario):
         Proton collision data taking express processing
 
         """
-        step = stepALCAPRODUCER(args['skims'])
+        skims = args['skims']
+        # the AlCaReco skims for PCL should only run during AlCaSkimming step which uses the same configuration on the Tier0 side, for this reason we drop them here
+        pclWkflws = [x for x in skims if "PromptCalibProd" in x]
+        for wfl in pclWkflws:
+            skims.remove(wfl)
+        
+        step = stepALCAPRODUCER(skims)
         dqmStep= dqmSeq(args,'')
         options = Options()
         options.__dict__.update(defaultOptions.__dict__)

--- a/Configuration/DataProcessing/python/Reco.py
+++ b/Configuration/DataProcessing/python/Reco.py
@@ -93,15 +93,18 @@ class Reco(Scenario):
         """
 
         step = ""
-        if 'PromptCalibProd' in skims:
-            step = "ALCA:PromptCalibProd" 
-            skims.remove('PromptCalibProd')
+        pclWflws = [x for x in skims if "PromptCalibProd" in x]
+        if len(pclWflws):
+            step = 'ALCA:'
+        for wfl in pclWflws:
+            step += wfl
+            skims.remove(wfl)
         
         if len( skims ) > 0:
             if step != "":
                 step += ","
             step += "ALCAOUTPUT:"+('+'.join(skims))
-                
+
         options = Options()
         options.__dict__.update(defaultOptions.__dict__)
         options.scenario = self.cbSc

--- a/Configuration/DataProcessing/python/Reco.py
+++ b/Configuration/DataProcessing/python/Reco.py
@@ -125,8 +125,9 @@ class Reco(Scenario):
 
         # FIXME: dirty hack..any way around this?
         # Tier0 needs the dataset used for ALCAHARVEST step to be a different data-tier
-        if 'PromptCalibProd' in step:
-            process.ALCARECOStreamPromptCalibProd.dataset.dataTier = cms.untracked.string('ALCAPROMPT')
+        for wfl in pclWflws:
+            methodToCall = getattr(process, 'ALCARECOStream'+wfl)
+            methodToCall.dataset.dataTier = cms.untracked.string('ALCAPROMPT')
 
         return process
 

--- a/Configuration/DataProcessing/test/run_CfgTest.sh
+++ b/Configuration/DataProcessing/test/run_CfgTest.sh
@@ -36,9 +36,9 @@ runTest "${INPUT} --scenario=hcalnzs --reco --aod --alcareco --dqm --global-tag 
 
 INPUT=${LOCAL_TEST_DIR}/RunAlcaSkimming.py
 
-runTest "${INPUT} --scenario pp --lfn=/store/whatever --global-tag GLOBALTAG::ALL --skims SiStripCalZeroBias+SiStripCalMinBias+TkAlMinBias+PromptCalibProd"
-runTest "${INPUT} --scenario cosmics --lfn /store/whatever --global-tag GLOBALTAG::ALL --skims SiStripCalZeroBias+SiStripPCLHistos"
-runTest "${INPUT} --scenario HeavyIons --lfn=/store/whatever --global-tag GLOBALTAG::ALL --skims SiStripCalZeroBias+SiStripCalMinBias+TkAlMinBiasHI+PromptCalibProd"
+runTest "${INPUT} --scenario pp --lfn=/store/whatever --global-tag GLOBALTAG::ALL --skims SiStripCalZeroBias,SiStripCalMinBias,TkAlMinBias,PromptCalibProd"
+runTest "${INPUT} --scenario cosmics --lfn /store/whatever --global-tag GLOBALTAG::ALL --skims SiStripCalZeroBias,SiStripPCLHistos"
+runTest "${INPUT} --scenario HeavyIons --lfn=/store/whatever --global-tag GLOBALTAG::ALL --skims SiStripCalZeroBias,SiStripCalMinBias,TkAlMinBiasHI,PromptCalibProd"
 runTest "${INPUT} --scenario AlCaLumiPixels --lfn /store/whatever --global-tag GLOBALTAG::ALL --skims LumiPixels"
 #runTest "${INPUT} --scenario AlCaP0 --lfn /store/whatever --global-tag GLOBALTAG::ALL --skims EcalCalPi0Calib"
 #runTest "${INPUT} --scenario AlCaPhiSymEcal --lfn /store/whatever --global-tag GLOBALTAG::ALL --skims EcalCalPhiSym"

--- a/Configuration/EventContent/python/AlCaRecoOutput_cff.py
+++ b/Configuration/EventContent/python/AlCaRecoOutput_cff.py
@@ -99,6 +99,7 @@ from CalibMuon.DTCalibration.ALCARECODtCalibCosmics_Output_cff import *
 # stream for prompt-calibration @ Tier0
 ###############################################################
 from Calibration.TkAlCaRecoProducers.ALCARECOPromptCalibProd_Output_cff import *
+from Calibration.TkAlCaRecoProducers.ALCARECOPromptCalibProdSiStrip_Output_cff import *
 from Calibration.TkAlCaRecoProducers.ALCARECOSiStripPCLHistos_Output_cff import *
 
 # stream for the LumiPixels workflow

--- a/Configuration/StandardSequences/python/AlCaRecoStreams_cff.py
+++ b/Configuration/StandardSequences/python/AlCaRecoStreams_cff.py
@@ -92,6 +92,7 @@ from Alignment.CommonAlignmentProducer.ALCARECOMuAlBeamHaloOverlaps_cff import *
 # stream for prompt-calibration @ Tier0
 ###############################################################
 from Calibration.TkAlCaRecoProducers.ALCARECOPromptCalibProd_cff import *
+from Calibration.TkAlCaRecoProducers.ALCARECOPromptCalibProdSiStrip_cff import *
 from Calibration.TkAlCaRecoProducers.ALCARECOSiStripPCLHistos_cff import *
 
 
@@ -150,6 +151,7 @@ pathALCARECOTkAlCosmicsRegional0THLT = cms.Path(seqALCARECOTkAlCosmicsRegional0T
 pathALCARECOMuAlGlobalCosmicsInCollisions = cms.Path(seqALCARECOMuAlGlobalCosmicsInCollisions*ALCARECOMuAlGlobalCosmicsInCollisionsDQM)
 pathALCARECOMuAlGlobalCosmics = cms.Path(seqALCARECOMuAlGlobalCosmics*ALCARECOMuAlGlobalCosmicsDQM)
 pathALCARECOPromptCalibProd = cms.Path(seqALCARECOPromptCalibProd)
+pathALCARECOPromptCalibProdSiStrip = cms.Path(seqALCARECOPromptCalibProdSiStrip)
 pathALCARECOSiStripPCLHistos = cms.Path(seqALCARECOSiStripPCLHistos)
 
 # AlCaReco event content definitions:
@@ -463,6 +465,16 @@ ALCARECOStreamPromptCalibProd = cms.FilteredStream(
 	paths  = (pathALCARECOPromptCalibProd),
 	content = OutALCARECOPromptCalibProd.outputCommands,
 	selectEvents = OutALCARECOPromptCalibProd.SelectEvents,
+	dataTier = cms.untracked.string('ALCARECO')
+	)
+
+
+ALCARECOStreamPromptCalibProdSiStrip = cms.FilteredStream(
+	responsible = 'Gianluca Cerminara',
+	name = 'PromptCalibProdSiStrip',
+	paths  = (pathALCARECOPromptCalibProdSiStrip),
+	content = OutALCARECOPromptCalibProdSiStrip.outputCommands,
+	selectEvents = OutALCARECOPromptCalibProdSiStrip.SelectEvents,
 	dataTier = cms.untracked.string('ALCARECO')
 	)
 


### PR DESCRIPTION
Add the missing pieces to be able to assemble a working configuration for PCL @ Tier0 when running the "cosmics" scenario. A new PromptCalibProsSiStrip stream has been added to decouple the BeamSpot workflow from the SiStrip bad-channel one. This is needed to test the infrastructure during cosmics data taking (e.g. April GR)
