### PR TITLE
add back tracking particle selector, modify cuts to new defaults

### DIFF
--- a/SimGeneral/MixingModule/python/digitizers_cfi.py
+++ b/SimGeneral/MixingModule/python/digitizers_cfi.py
@@ -7,7 +7,7 @@ from SimGeneral.MixingModule.stripDigitizer_cfi import *
 from SimGeneral.MixingModule.ecalDigitizer_cfi import *
 from SimGeneral.MixingModule.hcalDigitizer_cfi import *
 from SimGeneral.MixingModule.castorDigitizer_cfi import *
-from SimGeneral.MixingModule.trackingTruthProducer_cfi import *
+from SimGeneral.MixingModule.trackingTruthProducerSelection_cfi import *
 
 theDigitizers = cms.PSet(
   pixel = cms.PSet(

--- a/SimGeneral/MixingModule/python/trackingTruthProducerSelection_cfi.py
+++ b/SimGeneral/MixingModule/python/trackingTruthProducerSelection_cfi.py
@@ -6,9 +6,9 @@ trackingParticles.select = cms.PSet(
     chargedOnlyTP = cms.bool(True),
     pdgIdTP = cms.vint32(),
     signalOnlyTP = cms.bool(True),
-    minRapidityTP = cms.double(-2.6),
+    minRapidityTP = cms.double(-5.0),
     minHitTP = cms.int32(3),
-    ptMinTP = cms.double(0.2),
-    maxRapidityTP = cms.double(2.6),
+    ptMinTP = cms.double(0.1),
+    maxRapidityTP = cms.double(5.0),
     tipTP = cms.double(1000)
 )


### PR DESCRIPTION
Added selector to TrackingParticles by default, change cut values to those recommended by tracking DPG.
