### PR TITLE
PF clustering with time information: additions and fixes

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/interface/ECALRecHitResolutionProvider.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/ECALRecHitResolutionProvider.h
@@ -1,0 +1,64 @@
+#ifndef RecoParticleFlow_PFClusterProducer_ECALRecHitResolutionProvider_h
+#define RecoParticleFlow_PFClusterProducer_ECALRecHitResolutionProvider_h
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+
+class ECALRecHitResolutionProvider{
+ public:
+  ECALRecHitResolutionProvider(const edm::ParameterSet& iConfig) {
+    noiseTerm_ = iConfig.getParameter<double>("noiseTerm"); 
+    constantTerm_ = iConfig.getParameter<double>("constantTerm"); 
+    noiseTermLowE_ = iConfig.getParameter<double>("noiseTermLowE"); 
+    corrTermLowE_ = iConfig.getParameter<double>("corrTermLowE"); 
+    constantTermLowE_ = iConfig.getParameter<double>("constantTermLowE"); 
+    threshLowE_ = iConfig.getParameter<double>("threshLowE"); 
+    threshHighE_ = iConfig.getParameter<double>("threshHighE"); 
+
+    resHighE_ = sqrt(std::pow((noiseTerm_/threshHighE_), 2) + constantTerm_*constantTerm_);
+  }
+
+
+double timeResolution(double energy)
+{
+  double res = 100.;
+
+  if (energy <= 0.)
+    return res;
+  else if (energy < threshLowE_)
+  {
+    if (corrTermLowE_ > 0.) // different parametrisation
+      res = noiseTermLowE_/energy + corrTermLowE_/energy/energy;
+    else
+      res = sqrt(std::pow(noiseTermLowE_/energy, 2) + constantTermLowE_*constantTermLowE_);
+  }
+  else if (energy < threshHighE_)
+    res = sqrt(std::pow((noiseTerm_/energy), 2) + constantTerm_*constantTerm_);
+  else // if (energy >=threshHighE_)
+    res = resHighE_;
+
+  if (res > 100.)
+    return 100.;
+  return res;
+  
+}
+
+private:
+
+  double noiseTerm_; // Noise term
+  double constantTerm_; // Constant term
+
+  double noiseTermLowE_; // Noise term for low E
+  double constantTermLowE_; // Constant term for low E
+  double corrTermLowE_; // 2nd term for low E, different parametrisation
+
+  double threshLowE_; // different parametrisation below
+  double threshHighE_; // resolution constant above
+
+  double resHighE_; // precompute res at high E
+
+};
+
+#endif
+
+

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitCaloNavigatorWithTime.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitCaloNavigatorWithTime.h
@@ -26,10 +26,10 @@ template <typename D,typename T>
 class PFRecHitCaloNavigatorWithTime : public PFRecHitNavigatorBase {
  public:
   PFRecHitCaloNavigatorWithTime(const edm::ParameterSet& iConfig) {
-    noiseLevel_ = iConfig.getParameter<double>("noiseLevel");
-    noiseTerm_ = iConfig.getParameter<double>("noiseTerm");
-    constantTerm_ = iConfig.getParameter<double>("constantTerm");
-    sigmaCut_ = iConfig.getParameter<double>("sigmaCut");
+    noiseLevel2_ = pow(iConfig.getParameter<double>("noiseLevel"), 2);
+    noiseTerm2_ = pow(iConfig.getParameter<double>("noiseTerm"), 2);
+    constantTerm2_ = pow(iConfig.getParameter<double>("constantTerm"), 2);
+    sigmaCut2_ = pow(iConfig.getParameter<double>("sigmaCut"), 2);
 
     _timeResolutionCalc.reset(NULL);
     if( iConfig.exists("timeResolutionCalc") ) {
@@ -116,8 +116,7 @@ class PFRecHitCaloNavigatorWithTime : public PFRecHitNavigatorBase {
 
 
   void associateNeighbour(const DetId& id, reco::PFRecHit& hit,std::auto_ptr<reco::PFRecHitCollection>& hits,edm::RefProd<reco::PFRecHitCollection>& refProd,short eta, short phi) {
-    double sigma=0.0;
-    double aeff=0.0;
+    double sigma2=10000.0;
     
     const reco::PFRecHit temp(id,PFLayer::NONE,0.0,math::XYZPoint(0,0,0),math::XYZVector(0,0,0),std::vector<math::XYZPoint>());
     auto found_hit = std::lower_bound(hits->begin(),hits->end(),
@@ -127,18 +126,20 @@ class PFRecHitCaloNavigatorWithTime : public PFRecHitNavigatorBase {
 					return a.detId() < b.detId();
 				      });
     if( found_hit != hits->end() && found_hit->detId() == id.rawId() ) {
-      sigma = 100.;
       if (_timeResolutionCalc) {
-        double res1 = _timeResolutionCalc->timeResolution(hit.energy());
-        double res2 = _timeResolutionCalc->timeResolution(found_hit->energy());
-        sigma = sqrt(res1*res1 + res2*res2);
+        sigma2 = _timeResolutionCalc->timeResolution2(hit.energy()) + _timeResolutionCalc->timeResolution2(found_hit->energy());
       }
       else {
-        aeff = hit.energy()*found_hit->energy()/sqrt(hit.energy()*hit.energy()+found_hit->energy()*found_hit->energy());
-        sigma = sqrt((noiseTerm_*noiseLevel_/aeff)*(noiseTerm_*noiseLevel_/aeff)+2*constantTerm_*constantTerm_);
+        const double hitEnergy = hit.energy();
+        const double hitEnergy2 = hitEnergy*hitEnergy;
+        const double fhEnergy = found_hit->energy();
+        const double fhEnergy2 = fhEnergy*fhEnergy;
+        const double aeff2 = hitEnergy2*fhEnergy2/(hitEnergy2+fhEnergy2);
+        sigma2 = noiseTerm2_*noiseLevel2_/aeff2 + 2*constantTerm2_;
       }
-      if(std::abs(hit.time()-found_hit->time())/sigma<sigmaCut_) {
-	hit.addNeighbour(eta,phi,0,reco::PFRecHitRef(refProd,std::distance(hits->begin(),found_hit)));
+      const double deltaTime = hit.time()-found_hit->time();
+      if(deltaTime*deltaTime/sigma2<sigmaCut2_) {
+        hit.addNeighbour(eta,phi,0,reco::PFRecHitRef(refProd,std::distance(hits->begin(),found_hit)));
       }
     }
   }
@@ -146,10 +147,10 @@ class PFRecHitCaloNavigatorWithTime : public PFRecHitNavigatorBase {
 
 
   const T *topology_;
-  double noiseLevel_;
-  double noiseTerm_;
-  double constantTerm_;
-  double sigmaCut_;
+  double noiseLevel2_;
+  double noiseTerm2_;
+  double constantTerm2_;
+  double sigmaCut2_;
 
   std::unique_ptr<ECALRecHitResolutionProvider> _timeResolutionCalc;
 

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitCaloNavigatorWithTime.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitCaloNavigatorWithTime.h
@@ -134,8 +134,7 @@ class PFRecHitCaloNavigatorWithTime : public PFRecHitNavigatorBase {
         const double hitEnergy2 = hitEnergy*hitEnergy;
         const double fhEnergy = found_hit->energy();
         const double fhEnergy2 = fhEnergy*fhEnergy;
-        const double aeff2 = hitEnergy2*fhEnergy2/(hitEnergy2+fhEnergy2);
-        sigma2 = noiseTerm2_*noiseLevel2_/aeff2 + 2*constantTerm2_;
+        sigma2 = noiseTerm2_*noiseLevel2_*(hitEnergy2+fhEnergy2)/(hitEnergy2*fhEnergy2) + 2*constantTerm2_;
       }
       const double deltaTime = hit.time()-found_hit->time();
       if(deltaTime*deltaTime/sigma2<sigmaCut2_) {
@@ -143,8 +142,6 @@ class PFRecHitCaloNavigatorWithTime : public PFRecHitNavigatorBase {
       }
     }
   }
-
-
 
   const T *topology_;
   double noiseLevel2_;

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFClusterSelector.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFClusterSelector.cc
@@ -46,6 +46,7 @@ void PFClusterSelector::produce(edm::Event& iEvent,
     case PFLayer::HCAL_ENDCAP:
       timingCutsLow = &timingCutsLowEndcap_;
       timingCutsHigh = &timingCutsHighEndcap_;
+      break;
     default:      
       continue;
     }    

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterECALTimeResolutionParameters_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterECALTimeResolutionParameters_cfi.py
@@ -1,0 +1,22 @@
+import FWCore.ParameterSet.Config as cms
+
+# time resolution
+_timeResolutionECALBarrel = cms.PSet(
+    noiseTerm = cms.double(26.4021428571 * 0.042),
+    constantTerm = cms.double(0.428192),
+    noiseTermLowE = cms.double(31.4007142857 * 0.042),
+    corrTermLowE = cms.double(0.0510871),
+    constantTermLowE = cms.double(0.),
+    threshLowE = cms.double(0.5),
+    threshHighE = cms.double(5.)
+  )
+
+_timeResolutionECALEndcap = cms.PSet(
+    noiseTerm = cms.double(40.8921428571 * 0.14),
+    constantTerm = cms.double(0.),
+    noiseTermLowE = cms.double(49.4773571429 * 0.14),
+    corrTermLowE = cms.double(0.),
+    constantTermLowE = cms.double(0.),
+    threshLowE = cms.double(1.),
+    threshHighE = cms.double(10.)
+  )

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterECALUncorrected_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterECALUncorrected_cfi.py
@@ -1,5 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
+from particleFlowClusterECALTimeResolutionParameters_cfi import _timeResolutionECALBarrel, _timeResolutionECALEndcap
+
 #### PF CLUSTER ECAL ####
 
 #cleaning
@@ -70,7 +72,9 @@ _positionCalcECAL_all_nodepth = cms.PSet(
     minFractionInCalc = cms.double(1e-9),
     posCalcNCrystals = cms.int32(-1),
     logWeightDenominator = cms.double(0.08), # same as gathering threshold
-    minAllowedNormalization = cms.double(1e-9)
+    minAllowedNormalization = cms.double(1e-9),
+    timeResolutionCalcBarrel = _timeResolutionECALBarrel,
+    timeResolutionCalcEndcap = _timeResolutionECALEndcap,
 )
 _positionCalcECAL_3x3_nodepth = _positionCalcECAL_all_nodepth.clone(
     posCalcNCrystals = cms.int32(9)

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterECALWithTimeSelected_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterECALWithTimeSelected_cfi.py
@@ -3,10 +3,11 @@ import FWCore.ParameterSet.Config as cms
 particleFlowClusterECALWithTimeSelected = cms.EDProducer(
     "PFClusterSelector",
     src = cms.InputTag('particleFlowClusterECALWithTimeUncorrected'),
-    energyRanges = cms.vdouble(0.0,0.5,1.0,2.0,5.0),
-    ## pad the timing cuts on the high side (with repeats) to aboid overflows
-    timingCutsLowBarrel = cms.vdouble(-16.,-16.,-16.,-12.,-10.,-10.),
-    timingCutsHighBarrel = cms.vdouble(16.,16.,16.,12.,10.,10.),
-    timingCutsLowEndcap = cms.vdouble(-18.,-18.,-18.,-18.,-14.,-14.),
-    timingCutsHighEndcap = cms.vdouble(18.,18.,18.,18.,14.,14.)
+    energyRanges = cms.vdouble(1., 2., 5., 20.),
+    ## pad the timing cuts on the high side (with repeats) to avoid overflows
+    timingCutsLowBarrel = cms.vdouble(-12., -6., -4., -4., -4., -4.),
+    timingCutsHighBarrel = cms.vdouble(12., 6., 4., 4., 4., 4.),
+    timingCutsLowEndcap = cms.vdouble(-31.5, -20.5, -12., -5., -5., -5.),
+    timingCutsHighEndcap = cms.vdouble(31.5, 20.5, 12., 5., 5., 5.)
     )
+    

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterECALWithTimeUncorrected_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterECALWithTimeUncorrected_cfi.py
@@ -2,6 +2,8 @@ import FWCore.ParameterSet.Config as cms
 
 #### PF CLUSTER ECAL ####
 
+from particleFlowClusterECALTimeResolutionParameters_cfi import _timeResolutionECALBarrel, _timeResolutionECALEndcap
+
 #cleaning
 _spikeAndDoubleSpikeCleaner_ECAL = cms.PSet(
     algoName = cms.string("SpikeAndDoubleSpikeCleaner"),    
@@ -70,7 +72,9 @@ _positionCalcECAL_all_nodepth = cms.PSet(
     minFractionInCalc = cms.double(1e-9),
     posCalcNCrystals = cms.int32(-1),
     logWeightDenominator = cms.double(0.08), # same as gathering threshold
-    minAllowedNormalization = cms.double(1e-9)
+    minAllowedNormalization = cms.double(1e-9),
+    timeResolutionCalcBarrel = _timeResolutionECALBarrel,
+    timeResolutionCalcEndcap = _timeResolutionECALEndcap,
 )
 _positionCalcECAL_3x3_nodepth = _positionCalcECAL_all_nodepth.clone(
     posCalcNCrystals = cms.int32(9)
@@ -102,6 +106,8 @@ _pfClusterizerWithTime_ECAL = cms.PSet(
     maxIterations = cms.uint32(50),
     excludeOtherSeeds = cms.bool(True),
     minFracTot = cms.double(1e-20), ## numerical stabilization
+    maxNSigmaTime = cms.double(10.), # Maximum number of sigmas in time 
+    minChi2Prob = cms.double(0.01), # Minimum chi2 probability (ignored if 0)
     recHitEnergyNorms = cms.VPSet(
     cms.PSet( detector = cms.string("ECAL_BARREL"),
               recHitEnergyNorm = cms.double(0.08)
@@ -109,7 +115,9 @@ _pfClusterizerWithTime_ECAL = cms.PSet(
     cms.PSet( detector = cms.string("ECAL_ENDCAP"),
               recHitEnergyNorm = cms.double(0.3)
               )
-    )
+    ),
+    timeResolutionCalcBarrel = _timeResolutionECALBarrel,
+    timeResolutionCalcEndcap = _timeResolutionECALEndcap,
 )
 
 #energy corrector for corrected cluster producer

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterECALWithTimeUncorrected_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterECALWithTimeUncorrected_cfi.py
@@ -108,6 +108,7 @@ _pfClusterizerWithTime_ECAL = cms.PSet(
     minFracTot = cms.double(1e-20), ## numerical stabilization
     maxNSigmaTime = cms.double(10.), # Maximum number of sigmas in time 
     minChi2Prob = cms.double(0.01), # Minimum chi2 probability (ignored if 0)
+    clusterTimeResFromSeed = cms.bool(False),
     recHitEnergyNorms = cms.VPSet(
     cms.PSet( detector = cms.string("ECAL_BARREL"),
               recHitEnergyNorm = cms.double(0.08)

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterECALWithTimeUncorrected_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterECALWithTimeUncorrected_cfi.py
@@ -100,6 +100,8 @@ _pfClusterizerWithTime_ECAL = cms.PSet(
     allCellsPositionCalc = _positionCalcECAL_all_nodepth,
     positionCalcForConvergence = _positionCalcECAL_all_withdepth,
     showerSigma = cms.double(1.5),
+    # The following 2 parameters are only considerd if no
+    # time resolution is provided
     timeSigmaEB = cms.double(10),
     timeSigmaEE = cms.double(10), 
     stoppingTolerance = cms.double(1e-8),
@@ -107,7 +109,7 @@ _pfClusterizerWithTime_ECAL = cms.PSet(
     excludeOtherSeeds = cms.bool(True),
     minFracTot = cms.double(1e-20), ## numerical stabilization
     maxNSigmaTime = cms.double(10.), # Maximum number of sigmas in time 
-    minChi2Prob = cms.double(0.01), # Minimum chi2 probability (ignored if 0)
+    minChi2Prob = cms.double(0.), # Minimum chi2 probability (ignored if 0)
     clusterTimeResFromSeed = cms.bool(False),
     recHitEnergyNorms = cms.VPSet(
     cms.PSet( detector = cms.string("ECAL_BARREL"),

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterECALWithTime_cff.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterECALWithTime_cff.py
@@ -5,13 +5,13 @@ from RecoParticleFlow.PFClusterProducer.particleFlowClusterECALWithTimeSelected_
 
 from RecoParticleFlow.PFClusterProducer.particleFlowClusterECAL_cfi import *
 
-particleFlowClusterECALWithTime = particleFlowClusterECAL.clone(
-    inputECAL = cms.InputTag('particleFlowClusterECALWithTimeSelected')
-    )
+# particleFlowClusterECALWithTime = particleFlowClusterECAL.clone(
+#     inputECAL = cms.InputTag('particleFlowClusterECALWithTimeSelected')
+#     )
 
 particleFlowClusterECALWithTimeSequence = cms.Sequence(    
     particleFlowClusterECALWithTimeUncorrected +
     particleFlowClusterECALWithTimeSelected +
-    particleFlowClusterECALWithTime
+    particleFlowClusterECAL
     )
                                                    

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterECALWithTime_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterECALWithTime_cfi.py
@@ -100,6 +100,8 @@ _pfClusterizerWithTime_ECAL = cms.PSet(
     allCellsPositionCalc = _positionCalcECAL_all_nodepth,
     positionCalcForConvergence = _positionCalcECAL_all_withdepth,
     showerSigma = cms.double(1.5),
+    # The following 2 parameters are only considerd if no
+    # time resolution is provided
     timeSigmaEB = cms.double(10),
     timeSigmaEE = cms.double(10), 
     stoppingTolerance = cms.double(1e-8),
@@ -108,6 +110,7 @@ _pfClusterizerWithTime_ECAL = cms.PSet(
     minFracTot = cms.double(1e-20), ## numerical stabilization
     maxNSigmaTime = cms.double(10.), # Maximum number of sigmas in time 
     minChi2Prob = cms.double(0.), # Minimum chi2 probability (ignored if 0)
+    clusterTimeResFromSeed = cms.bool(False),
     recHitEnergyNorms = cms.VPSet(
     cms.PSet( detector = cms.string("ECAL_BARREL"),
               recHitEnergyNorm = cms.double(0.08)

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterECALWithTime_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterECALWithTime_cfi.py
@@ -1,5 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
+from particleFlowClusterECALTimeResolutionParameters_cfi import _timeResolutionECALBarrel, _timeResolutionECALEndcap
+
 #### PF CLUSTER ECAL ####
 
 #cleaning
@@ -70,7 +72,9 @@ _positionCalcECAL_all_nodepth = cms.PSet(
     minFractionInCalc = cms.double(1e-9),
     posCalcNCrystals = cms.int32(-1),
     logWeightDenominator = cms.double(0.08), # same as gathering threshold
-    minAllowedNormalization = cms.double(1e-9)
+    minAllowedNormalization = cms.double(1e-9),
+    timeResolutionCalcBarrel = _timeResolutionECALBarrel,
+    timeResolutionCalcEndcap = _timeResolutionECALEndcap,
 )
 _positionCalcECAL_3x3_nodepth = _positionCalcECAL_all_nodepth.clone(
     posCalcNCrystals = cms.int32(9)
@@ -102,6 +106,8 @@ _pfClusterizerWithTime_ECAL = cms.PSet(
     maxIterations = cms.uint32(50),
     excludeOtherSeeds = cms.bool(True),
     minFracTot = cms.double(1e-20), ## numerical stabilization
+    maxNSigmaTime = cms.double(10.), # Maximum number of sigmas in time 
+    minChi2Prob = cms.double(0.), # Minimum chi2 probability (ignored if 0)
     recHitEnergyNorms = cms.VPSet(
     cms.PSet( detector = cms.string("ECAL_BARREL"),
               recHitEnergyNorm = cms.double(0.08)
@@ -109,7 +115,9 @@ _pfClusterizerWithTime_ECAL = cms.PSet(
     cms.PSet( detector = cms.string("ECAL_ENDCAP"),
               recHitEnergyNorm = cms.double(0.3)
               )
-    )
+    ),
+    timeResolutionCalcBarrel = _timeResolutionECALBarrel,
+    timeResolutionCalcEndcap = _timeResolutionECALEndcap,
 )
 
 #energy corrector for corrected cluster producer

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterECAL_cff.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterECAL_cff.py
@@ -2,7 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoParticleFlow.PFClusterProducer.particleFlowClusterECALUncorrected_cfi import *
 from RecoParticleFlow.PFClusterProducer.particleFlowClusterECAL_cfi import *
-from RecoParticleFlow.PFClusterProducer.particleFlowRecHitECAL_cfi import *
 
 particleFlowClusterECALSequence = cms.Sequence(    
     particleFlowClusterECALUncorrected +

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowCluster_cff.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowCluster_cff.py
@@ -4,7 +4,8 @@ import Geometry.HcalEventSetup.hcalTopologyIdeal_cfi
 
 from RecoLocalCalo.CaloTowersCreator.calotowermaker_cfi import *
 from RecoJets.Configuration.CaloTowersRec_cff import *
-from RecoParticleFlow.PFClusterProducer.particleFlowRecHitECAL_cfi import *
+# from RecoParticleFlow.PFClusterProducer.particleFlowRecHitECAL_cfi import *
+from RecoParticleFlow.PFClusterProducer.particleFlowRecHitECALWithTime_cfi import *
 from RecoParticleFlow.PFClusterProducer.particleFlowRecHitHCAL_cfi import *
 from RecoParticleFlow.PFClusterProducer.particleFlowRecHitHO_cfi import *
 from RecoParticleFlow.PFClusterProducer.particleFlowRecHitPS_cfi import *
@@ -16,11 +17,20 @@ from RecoParticleFlow.PFClusterProducer.particleFlowClusterHFEM_cfi import *
 from RecoParticleFlow.PFClusterProducer.particleFlowClusterHFHAD_cfi import *
 
 
-from RecoParticleFlow.PFClusterProducer.particleFlowClusterECAL_cff import *
-#from RecoParticleFlow.PFClusterProducer.particleFlowClusterECALWithTime_cff import *
 
-pfClusteringECAL = cms.Sequence(particleFlowRecHitECAL*
-                                particleFlowClusterECALSequence)
+withTime = False
+if withTime:
+    from RecoParticleFlow.PFClusterProducer.particleFlowClusterECALWithTime_cff import *
+    pfClusteringECAL = cms.Sequence(particleFlowRecHitECALWithTime*
+                                     particleFlowClusterECALWithTimeSequence)
+    particleFlowClusterECAL.inputECAL = cms.InputTag('particleFlowClusterECALWithTimeSelected')
+else:
+    from RecoParticleFlow.PFClusterProducer.particleFlowClusterECAL_cff import *
+
+    pfClusteringECAL = cms.Sequence(particleFlowRecHitECAL*
+                                    particleFlowClusterECALSequence)
+    # particleFlowClusterECAL.inputECAL = cms.InputTag('particleFlowClusterECALWithTimeSelected')
+
 pfClusteringHCAL = cms.Sequence(particleFlowRecHitHCAL*particleFlowClusterHCAL)
 pfClusteringHCALall = cms.Sequence(particleFlowClusterHCAL+particleFlowClusterHFHAD+particleFlowClusterHFEM)
 pfClusteringHCAL = cms.Sequence(particleFlowRecHitHCAL*pfClusteringHCALall)

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowCluster_cff.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowCluster_cff.py
@@ -4,28 +4,27 @@ import Geometry.HcalEventSetup.hcalTopologyIdeal_cfi
 
 from RecoLocalCalo.CaloTowersCreator.calotowermaker_cfi import *
 from RecoJets.Configuration.CaloTowersRec_cff import *
-# from RecoParticleFlow.PFClusterProducer.particleFlowRecHitECAL_cfi import *
-from RecoParticleFlow.PFClusterProducer.particleFlowRecHitECALWithTime_cfi import *
+from RecoParticleFlow.PFClusterProducer.particleFlowRecHitECAL_cfi import *
 from RecoParticleFlow.PFClusterProducer.particleFlowRecHitHCAL_cfi import *
 from RecoParticleFlow.PFClusterProducer.particleFlowRecHitHO_cfi import *
 from RecoParticleFlow.PFClusterProducer.particleFlowRecHitPS_cfi import *
 
+from RecoParticleFlow.PFClusterProducer.particleFlowClusterECAL_cff import *
 from RecoParticleFlow.PFClusterProducer.particleFlowClusterHCAL_cfi import *
 from RecoParticleFlow.PFClusterProducer.particleFlowClusterHO_cfi import *
 from RecoParticleFlow.PFClusterProducer.particleFlowClusterPS_cfi import *
 from RecoParticleFlow.PFClusterProducer.particleFlowClusterHFEM_cfi import *
 from RecoParticleFlow.PFClusterProducer.particleFlowClusterHFHAD_cfi import *
 
-
+from RecoParticleFlow.PFClusterProducer.particleFlowRecHitECALWithTime_cfi import *
+from RecoParticleFlow.PFClusterProducer.particleFlowClusterECALWithTime_cff import *
 
 withTime = False
 if withTime:
-    from RecoParticleFlow.PFClusterProducer.particleFlowClusterECALWithTime_cff import *
     pfClusteringECAL = cms.Sequence(particleFlowRecHitECALWithTime*
                                      particleFlowClusterECALWithTimeSequence)
     particleFlowClusterECAL.inputECAL = cms.InputTag('particleFlowClusterECALWithTimeSelected')
 else:
-    from RecoParticleFlow.PFClusterProducer.particleFlowClusterECAL_cff import *
     pfClusteringECAL = cms.Sequence(particleFlowRecHitECAL*
                                     particleFlowClusterECALSequence)
 

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowCluster_cff.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowCluster_cff.py
@@ -26,10 +26,8 @@ if withTime:
     particleFlowClusterECAL.inputECAL = cms.InputTag('particleFlowClusterECALWithTimeSelected')
 else:
     from RecoParticleFlow.PFClusterProducer.particleFlowClusterECAL_cff import *
-
     pfClusteringECAL = cms.Sequence(particleFlowRecHitECAL*
                                     particleFlowClusterECALSequence)
-    # particleFlowClusterECAL.inputECAL = cms.InputTag('particleFlowClusterECALWithTimeSelected')
 
 pfClusteringHCAL = cms.Sequence(particleFlowRecHitHCAL*particleFlowClusterHCAL)
 pfClusteringHCALall = cms.Sequence(particleFlowClusterHCAL+particleFlowClusterHFHAD+particleFlowClusterHFEM)

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitECALWithTime_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitECALWithTime_cfi.py
@@ -1,6 +1,9 @@
 
 import FWCore.ParameterSet.Config as cms
 
+from particleFlowClusterECALTimeResolutionParameters_cfi import _timeResolutionECALBarrel, _timeResolutionECALEndcap
+
+
 #until we are actually clustering across the EB/EE boundary
 #it is faster to cluster EB and EE as separate
 particleFlowRecHitECALWithTime = cms.EDProducer("PFRecHitProducer",
@@ -11,13 +14,15 @@ particleFlowRecHitECALWithTime = cms.EDProducer("PFRecHitProducer",
              noiseLevel = cms.double(0.042),   
              noiseTerm  = cms.double(27.5),
              constantTerm = cms.double(10),
-             sigmaCut = cms.double(1.0)
+             sigmaCut = cms.double(5.0),
+             timeResolutionCalc = _timeResolutionECALBarrel
         ),
         endcap = cms.PSet(
              noiseLevel = cms.double(0.14),   
              noiseTerm  = cms.double(36.1),
              constantTerm = cms.double(10),
-             sigmaCut = cms.double(1.0)
+             sigmaCut = cms.double(5.0),
+             timeResolutionCalc = _timeResolutionECALEndcap
         )
     ),
     producers = cms.VPSet(

--- a/RecoParticleFlow/PFClusterProducer/src/Basic2DGenericPFlowPositionCalc.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/Basic2DGenericPFlowPositionCalc.cc
@@ -49,16 +49,16 @@ calculateAndSetPositionActual(reco::PFCluster& cluster) const {
 
     // If time resolution is given, calculated weighted average
     if (_timeResolutionCalcBarrel && _timeResolutionCalcEndcap) {
-      double res = 100.;
+      double res2 = 10000.;
       int cell_layer = (int)refhit->layer();
       if (cell_layer == PFLayer::HCAL_BARREL1 ||
           cell_layer == PFLayer::HCAL_BARREL2 ||
           cell_layer == PFLayer::ECAL_BARREL)
-        res = _timeResolutionCalcBarrel->timeResolution(refhit->energy());
+        res2 = _timeResolutionCalcBarrel->timeResolution2(refhit->energy());
       else
-        res = _timeResolutionCalcEndcap->timeResolution(refhit->energy());
-      cl_time += rhf.fraction()*refhit->time()/res/res;
-      cl_timeweight += rhf.fraction()/res/res;
+        res2 = _timeResolutionCalcEndcap->timeResolution2(refhit->energy());
+      cl_time += rhf.fraction()*refhit->time()/res2;
+      cl_timeweight += rhf.fraction()/res2;
     }
     else { // assume resolution = 1/E**2
       cl_timeweight+=refhit->energy()*refhit->energy()*rhf.fraction();

--- a/RecoParticleFlow/PFClusterProducer/src/Basic2DGenericPFlowPositionCalc.h
+++ b/RecoParticleFlow/PFClusterProducer/src/Basic2DGenericPFlowPositionCalc.h
@@ -5,6 +5,7 @@
 #include "DataFormats/ParticleFlowReco/interface/PFRecHitFwd.h"
 #include "DataFormats/ParticleFlowReco/interface/PFRecHit.h"
 
+#include "RecoParticleFlow/PFClusterProducer/interface/ECALRecHitResolutionProvider.h"
 
 class Basic2DGenericPFlowPositionCalc : public PFCPositionCalculatorBase {
  public:
@@ -14,7 +15,20 @@ class Basic2DGenericPFlowPositionCalc : public PFCPositionCalculatorBase {
     _logWeightDenom(conf.getParameter<double>("logWeightDenominator")),
     _minAllowedNorm(conf.getParameter<double>("minAllowedNormalization"))
 
-{ }
+  {  
+    _timeResolutionCalcBarrel.reset(NULL);
+    if( conf.exists("timeResolutionCalcBarrel") ) {
+      const edm::ParameterSet& timeResConf = 
+        conf.getParameterSet("timeResolutionCalcBarrel");
+        _timeResolutionCalcBarrel.reset(new ECALRecHitResolutionProvider(timeResConf));
+    }
+    _timeResolutionCalcEndcap.reset(NULL);
+    if( conf.exists("timeResolutionCalcEndcap") ) {
+      const edm::ParameterSet& timeResConf = 
+        conf.getParameterSet("timeResolutionCalcEndcap");
+        _timeResolutionCalcEndcap.reset(new ECALRecHitResolutionProvider(timeResConf));
+    }
+  }
   Basic2DGenericPFlowPositionCalc(const Basic2DGenericPFlowPositionCalc&) = delete;
   Basic2DGenericPFlowPositionCalc& operator=(const Basic2DGenericPFlowPositionCalc&) = delete;
 
@@ -25,6 +39,10 @@ class Basic2DGenericPFlowPositionCalc : public PFCPositionCalculatorBase {
   const int _posCalcNCrystals;
   const double _logWeightDenom;
   const double _minAllowedNorm;
+  
+  std::unique_ptr<ECALRecHitResolutionProvider> _timeResolutionCalcBarrel;
+  std::unique_ptr<ECALRecHitResolutionProvider> _timeResolutionCalcEndcap;
+
   void calculateAndSetPositionActual(reco::PFCluster&) const;
 };
 

--- a/RecoParticleFlow/PFClusterProducer/src/ECAL2DPositionCalcWithDepthCorr.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/ECAL2DPositionCalcWithDepthCorr.cc
@@ -78,9 +78,9 @@ calculateAndSetPositionActual(reco::PFCluster& cluster) const {
     cl_energy_float += rh_energyf;
     // If time resolution is given, calculated weighted average
     if (_timeResolutionCalc) {
-      double res = _timeResolutionCalc->timeResolution(refhit->energy());
-      cl_time += rhf.fraction()*refhit->time()/res/res;
-      cl_timeweight += rhf.fraction()/res/res;
+      const double res2 = _timeResolutionCalc->timeResolution2(refhit->energy());
+      cl_time += rhf.fraction()*refhit->time()/res2;
+      cl_timeweight += rhf.fraction()/res2;
     }
     else { // assume resolution = 1/E**2
       cl_timeweight+=refhit->energy()*refhit->energy()*rhf.fraction();

--- a/RecoParticleFlow/PFClusterProducer/src/ECAL2DPositionCalcWithDepthCorr.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/ECAL2DPositionCalcWithDepthCorr.cc
@@ -1,6 +1,7 @@
 #include "ECAL2DPositionCalcWithDepthCorr.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/isFinite.h"
 
 #include <cmath>
 #include <unordered_map>
@@ -71,9 +72,9 @@ calculateAndSetPositionActual(reco::PFCluster& cluster) const {
     const double rh_rawenergy = refhit->energy();
     const double rh_energy = rh_rawenergy * rh_fraction;    
     const double rh_energyf = ((float)rh_rawenergy) * ((float) rh_fraction);
-    if( std::isnan(rh_energy) ) {
+    if( !edm::isFinite(rh_energy) ) {
       throw cms::Exception("PFClusterAlgo")
-	<<"rechit " << refhit->detId() << " has a NaN energy... " 
+	<<"rechit " << refhit->detId() << " has non-finite energy... " 
 	<< "The input of the particle flow clustering seems to be corrupted.";
     }
     cl_energy += rh_energy;

--- a/RecoParticleFlow/PFClusterProducer/src/ECAL2DPositionCalcWithDepthCorr.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/ECAL2DPositionCalcWithDepthCorr.cc
@@ -76,13 +76,13 @@ calculateAndSetPositionActual(reco::PFCluster& cluster) const {
     }
     cl_energy += rh_energy;
     cl_energy_float += rh_energyf;
-    // If time resolution is given, calculated weighted average
+    // If time resolution is given, calculate weighted average
     if (_timeResolutionCalc) {
       const double res2 = _timeResolutionCalc->timeResolution2(refhit->energy());
       cl_time += rhf.fraction()*refhit->time()/res2;
       cl_timeweight += rhf.fraction()/res2;
     }
-    else { // assume resolution = 1/E**2
+    else { // assume resolution ~ 1/E**2
       cl_timeweight+=refhit->energy()*refhit->energy()*rhf.fraction();
       cl_time += refhit->energy()*refhit->energy()*rhf.fraction()*refhit->time();
     }

--- a/RecoParticleFlow/PFClusterProducer/src/ECAL2DPositionCalcWithDepthCorr.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/ECAL2DPositionCalcWithDepthCorr.cc
@@ -76,8 +76,16 @@ calculateAndSetPositionActual(reco::PFCluster& cluster) const {
     }
     cl_energy += rh_energy;
     cl_energy_float += rh_energyf;
-    cl_timeweight+=refhit->energy()*refhit->energy()*rhf.fraction();
-    cl_time += refhit->energy()*refhit->energy()*rhf.fraction()*refhit->time();   
+    // If time resolution is given, calculated weighted average
+    if (_timeResolutionCalc) {
+      double res = _timeResolutionCalc->timeResolution(refhit->energy());
+      cl_time += rhf.fraction()*refhit->time()/res/res;
+      cl_timeweight += rhf.fraction()/res/res;
+    }
+    else { // assume resolution = 1/E**2
+      cl_timeweight+=refhit->energy()*refhit->energy()*rhf.fraction();
+      cl_time += refhit->energy()*refhit->energy()*rhf.fraction()*refhit->time();
+    }
     if( rh_energy > max_e ) {
       max_e = rh_energy;
       max_e_layer = rhf.recHitRef()->layer();

--- a/RecoParticleFlow/PFClusterProducer/src/ECAL2DPositionCalcWithDepthCorr.h
+++ b/RecoParticleFlow/PFClusterProducer/src/ECAL2DPositionCalcWithDepthCorr.h
@@ -11,6 +11,8 @@
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
 
+#include "RecoParticleFlow/PFClusterProducer/interface/ECALRecHitResolutionProvider.h"
+
 /// This is EGM version of the ECAL position + depth correction calculation
 class ECAL2DPositionCalcWithDepthCorr : public PFCPositionCalculatorBase {
  public:
@@ -27,7 +29,14 @@ class ECAL2DPositionCalcWithDepthCorr : public PFCPositionCalculatorBase {
     _eeGeom(NULL),
     _esGeom(NULL),
     _esPlus(false),
-    _esMinus(false) { }
+    _esMinus(false) {
+        _timeResolutionCalc.reset(NULL);
+    if( conf.exists("timeResolutionCalc") ) {
+      const edm::ParameterSet& timeResConf = 
+        conf.getParameterSet("timeResolutionCalc");
+        _timeResolutionCalc.reset(new ECALRecHitResolutionProvider(timeResConf)); 
+      }
+    }
   ECAL2DPositionCalcWithDepthCorr(const ECAL2DPositionCalcWithDepthCorr&) = delete;
   ECAL2DPositionCalcWithDepthCorr& operator=(const ECAL2DPositionCalcWithDepthCorr&) = delete;
 
@@ -50,6 +59,8 @@ class ECAL2DPositionCalcWithDepthCorr : public PFCPositionCalculatorBase {
   const CaloSubdetectorGeometry* _eeGeom;
   const CaloSubdetectorGeometry* _esGeom;
   bool _esPlus, _esMinus;
+
+  std::unique_ptr<ECALRecHitResolutionProvider> _timeResolutionCalc;
   
   void calculateAndSetPositionActual(reco::PFCluster&) const;
 };

--- a/RecoParticleFlow/PFClusterProducer/src/PFlow2DClusterizerWithTime.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/PFlow2DClusterizerWithTime.cc
@@ -208,7 +208,6 @@ growPFClusters(const reco::PFCluster& topo,
     dist2.clear(); frac.clear(); fractot = 0;
 
     // add rechits to clusters, calculating fraction based on distance
-    // for( auto& cluster : clusters ) {   
     // need position in vector to get cluster time resolution   
     for (size_t iCluster = 0; iCluster < clusters.size(); ++iCluster) {
       reco::PFCluster& cluster = clusters[iCluster];
@@ -328,6 +327,9 @@ void PFlow2DClusterizerWithTime::clusterTimeResolution(reco::PFCluster& cluster,
     const reco::PFRecHit& rh = *(rhf.recHitRef());
     const double rhf_f = rhf.fraction();
 
+    if (rhf_f == 0.)
+      continue;
+
     bool isBarrel = (rh.layer() == PFLayer::HCAL_BARREL1 ||
       rh.layer() == PFLayer::HCAL_BARREL2 ||
       rh.layer() == PFLayer::ECAL_BARREL);
@@ -353,14 +355,13 @@ double PFlow2DClusterizerWithTime::dist2Time(const reco::PFCluster& cluster, con
 {
   const double deltaT = cluster.time()-refhit->time();
   const double t2 = deltaT*deltaT;
-  double res2 = 0.;
+  double res2 = 100.;
 
   if (cell_layer == PFLayer::HCAL_BARREL1 ||
   cell_layer == PFLayer::HCAL_BARREL2 ||
   cell_layer == PFLayer::ECAL_BARREL) {
     if (_timeResolutionCalcBarrel) {
       const double resCluster2 = prev_timeres2;
-      // Could move the hit res calculation to outer loop
       res2 = resCluster2 + _timeResolutionCalcBarrel->timeResolution2(refhit->energy());
     }
     else {
@@ -373,7 +374,6 @@ double PFlow2DClusterizerWithTime::dist2Time(const reco::PFCluster& cluster, con
      cell_layer == PFLayer::ECAL_ENDCAP) {
     if (_timeResolutionCalcEndcap) {
       const double resCluster2 = prev_timeres2;
-      // Could move the hit res calculation to outer loop
       res2 = resCluster2 + _timeResolutionCalcEndcap->timeResolution2(refhit->energy());
     }
      else {

--- a/RecoParticleFlow/PFClusterProducer/src/PFlow2DClusterizerWithTime.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/PFlow2DClusterizerWithTime.cc
@@ -89,13 +89,15 @@ PFlow2DClusterizerWithTime(const edm::ParameterSet& conf) :
   if( conf.exists("timeResolutionCalcBarrel") ) {
     const edm::ParameterSet& timeResConf = 
       conf.getParameterSet("timeResolutionCalcBarrel");
-      _timeResolutionCalcBarrel.reset(new ECALRecHitResolutionProvider(timeResConf));
+      _timeResolutionCalcBarrel.reset(new ECALRecHitResolutionProvider(
+        timeResConf));
   }
   _timeResolutionCalcEndcap.reset(NULL);
   if( conf.exists("timeResolutionCalcEndcap") ) {
     const edm::ParameterSet& timeResConf = 
       conf.getParameterSet("timeResolutionCalcEndcap");
-      _timeResolutionCalcEndcap.reset(new ECALRecHitResolutionProvider(timeResConf));
+      _timeResolutionCalcEndcap.reset(new ECALRecHitResolutionProvider(
+        timeResConf));
   }
 }
 
@@ -220,7 +222,8 @@ growPFClusters(const reco::PFCluster& topo,
         clus_prev_timeres2[iCluster]);
       d2 += d2time;
 
-      if (_minChi2Prob > 0. && !passChi2Prob(iCluster, d2time, clus_chi2, clus_chi2_nhits))
+      if (_minChi2Prob > 0. && !passChi2Prob(iCluster, d2time, clus_chi2, 
+        clus_chi2_nhits))
         d2 = 999.;
 
       dist2.emplace_back( d2);
@@ -295,8 +298,8 @@ prunePFClusters(reco::PFClusterCollection& clusters) const {
   }
 }
 
-void PFlow2DClusterizerWithTime::clusterTimeResolutionFromSeed(reco::PFCluster& cluster, 
-    double& clusterRes2) const
+void PFlow2DClusterizerWithTime::clusterTimeResolutionFromSeed(reco::PFCluster& 
+  cluster, double& clusterRes2) const
 {
   clusterRes2 = 10000.;
   for (auto& rhf : cluster.recHitFractions())
@@ -350,8 +353,8 @@ void PFlow2DClusterizerWithTime::clusterTimeResolution(reco::PFCluster& cluster,
   }
 }
 
-double PFlow2DClusterizerWithTime::dist2Time(const reco::PFCluster& cluster, const reco::PFRecHitRef& refhit, int cell_layer,
-  double prev_timeres2) const 
+double PFlow2DClusterizerWithTime::dist2Time(const reco::PFCluster& cluster, 
+  const reco::PFRecHitRef& refhit, int cell_layer, double prev_timeres2) const 
 {
   const double deltaT = cluster.time()-refhit->time();
   const double t2 = deltaT*deltaT;
@@ -362,7 +365,8 @@ double PFlow2DClusterizerWithTime::dist2Time(const reco::PFCluster& cluster, con
   cell_layer == PFLayer::ECAL_BARREL) {
     if (_timeResolutionCalcBarrel) {
       const double resCluster2 = prev_timeres2;
-      res2 = resCluster2 + _timeResolutionCalcBarrel->timeResolution2(refhit->energy());
+      res2 = resCluster2 + _timeResolutionCalcBarrel->timeResolution2(
+        refhit->energy());
     }
     else {
       return t2/_timeSigma_eb;
@@ -374,7 +378,8 @@ double PFlow2DClusterizerWithTime::dist2Time(const reco::PFCluster& cluster, con
      cell_layer == PFLayer::ECAL_ENDCAP) {
     if (_timeResolutionCalcEndcap) {
       const double resCluster2 = prev_timeres2;
-      res2 = resCluster2 + _timeResolutionCalcEndcap->timeResolution2(refhit->energy());
+      res2 = resCluster2 + _timeResolutionCalcEndcap->timeResolution2(
+        refhit->energy());
     }
      else {
       return t2/_timeSigma_ee;
@@ -388,8 +393,8 @@ double PFlow2DClusterizerWithTime::dist2Time(const reco::PFCluster& cluster, con
   return distTime2;
 }
 
-bool PFlow2DClusterizerWithTime::passChi2Prob(size_t iCluster, double dist2, std::vector<double>& clus_chi2, 
-  std::vector<size_t>& clus_chi2_nhits) const
+bool PFlow2DClusterizerWithTime::passChi2Prob(size_t iCluster, double dist2, 
+  std::vector<double>& clus_chi2, std::vector<size_t>& clus_chi2_nhits) const
 {
   if (iCluster >= clus_chi2.size()) { // first hit
     clus_chi2.push_back(dist2);

--- a/RecoParticleFlow/PFClusterProducer/src/PFlow2DClusterizerWithTime.h
+++ b/RecoParticleFlow/PFClusterProducer/src/PFlow2DClusterizerWithTime.h
@@ -59,6 +59,10 @@ class PFlow2DClusterizerWithTime : public PFClusterBuilderBase {
 		      reco::PFClusterCollection&) const;
   void clusterTimeResolution(reco::PFCluster& cluster, double& res) const;
   void clusterTimeResolutionFromSeed(reco::PFCluster& cluster, double& res) const;
+  double dist2Time(const reco::PFCluster&, const reco::PFRecHitRef&, int cell_layer,
+    double prev_timeres2) const;
+  bool passChi2Prob(size_t iCluster, double dist2, std::vector<double>& clus_chi2, 
+    std::vector<size_t>& clus_chi2_nhits) const;
   void prunePFClusters(reco::PFClusterCollection&) const;
 };
 

--- a/RecoParticleFlow/PFClusterProducer/src/PFlow2DClusterizerWithTime.h
+++ b/RecoParticleFlow/PFClusterProducer/src/PFlow2DClusterizerWithTime.h
@@ -37,6 +37,7 @@ class PFlow2DClusterizerWithTime : public PFClusterBuilderBase {
   const double _minFracTot;
   const double _maxNSigmaTime;
   const double _minChi2Prob;
+  const bool _clusterTimeResFromSeed;
   
   const std::unordered_map<std::string,int> _layerMap;
   std::unordered_map<int,double> _recHitEnergyNorms;
@@ -57,6 +58,7 @@ class PFlow2DClusterizerWithTime : public PFClusterBuilderBase {
 		      double dist,
 		      reco::PFClusterCollection&) const;
   void clusterTimeResolution(reco::PFCluster& cluster, double& res) const;
+  void clusterTimeResolutionFromSeed(reco::PFCluster& cluster, double& res) const;
   void prunePFClusters(reco::PFClusterCollection&) const;
 };
 

--- a/RecoParticleFlow/PFClusterProducer/src/PFlow2DClusterizerWithTime.h
+++ b/RecoParticleFlow/PFClusterProducer/src/PFlow2DClusterizerWithTime.h
@@ -58,11 +58,12 @@ class PFlow2DClusterizerWithTime : public PFClusterBuilderBase {
 		      double dist,
 		      reco::PFClusterCollection&) const;
   void clusterTimeResolution(reco::PFCluster& cluster, double& res) const;
-  void clusterTimeResolutionFromSeed(reco::PFCluster& cluster, double& res) const;
-  double dist2Time(const reco::PFCluster&, const reco::PFRecHitRef&, int cell_layer,
-    double prev_timeres2) const;
-  bool passChi2Prob(size_t iCluster, double dist2, std::vector<double>& clus_chi2, 
-    std::vector<size_t>& clus_chi2_nhits) const;
+  void clusterTimeResolutionFromSeed(reco::PFCluster& cluster, double& res) 
+    const;
+  double dist2Time(const reco::PFCluster&, const reco::PFRecHitRef&, 
+    int cell_layer, double prev_timeres2) const;
+  bool passChi2Prob(size_t iCluster, double dist2, 
+    std::vector<double>& clus_chi2, std::vector<size_t>& clus_chi2_nhits) const;
   void prunePFClusters(reco::PFClusterCollection&) const;
 };
 

--- a/RecoParticleFlow/PFClusterProducer/src/PFlow2DClusterizerWithTime.h
+++ b/RecoParticleFlow/PFClusterProducer/src/PFlow2DClusterizerWithTime.h
@@ -4,6 +4,8 @@
 #include "RecoParticleFlow/PFClusterProducer/interface/PFClusterBuilderBase.h"
 #include "DataFormats/ParticleFlowReco/interface/PFRecHitFraction.h"
 
+#include "RecoParticleFlow/PFClusterProducer/interface/ECALRecHitResolutionProvider.h"
+
 #include <unordered_map>
 
 class PFlow2DClusterizerWithTime : public PFClusterBuilderBase {
@@ -33,11 +35,16 @@ class PFlow2DClusterizerWithTime : public PFClusterBuilderBase {
   const double _timeSigma_ee;
   const bool _excludeOtherSeeds;
   const double _minFracTot;
+  const double _maxNSigmaTime;
+  const double _minChi2Prob;
   
   const std::unordered_map<std::string,int> _layerMap;
   std::unordered_map<int,double> _recHitEnergyNorms;
   std::unique_ptr<PFCPositionCalculatorBase> _allCellsPosCalc;
   std::unique_ptr<PFCPositionCalculatorBase> _convergencePosCalc;
+
+  std::unique_ptr<ECALRecHitResolutionProvider> _timeResolutionCalcBarrel;
+  std::unique_ptr<ECALRecHitResolutionProvider> _timeResolutionCalcEndcap;
   
   void seedPFClustersFromTopo(const reco::PFCluster&,
 			      const std::vector<bool>&,
@@ -49,7 +56,7 @@ class PFlow2DClusterizerWithTime : public PFClusterBuilderBase {
 		      const unsigned iter,
 		      double dist,
 		      reco::PFClusterCollection&) const;
-  
+  void clusterTimeResolution(reco::PFCluster& cluster, double& res) const;
   void prunePFClusters(reco::PFClusterCollection&) const;
 };
 


### PR DESCRIPTION
- Adds the possibility to use a parametric resolution for the ECAL rec-hit time in the different clustering steps; updates parameters in the cluster selection
- Additional options for using the time information in the PF clustering
- Fixes an issue that prevented PFClusters in the EE from passing the time selection

Note: The clustering that makes use of the rec-hit time information is still disabled by default.
