### PR TITLE
Fix refToPSet_ within VPSet

### DIFF
--- a/FWCore/ParameterSet/python/Config.py
+++ b/FWCore/ParameterSet/python/Config.py
@@ -1710,12 +1710,16 @@ process.subProcess = cms.SubProcess( process = childProcess, SelectEvents = cms.
             proc.ref = PSet(refToPSet_ = string("top"))
             proc.ref2 = PSet( a = int32(1), b = PSet( refToPSet_ = string("top")))
             proc.ref3 = PSet(refToPSet_ = string("ref"))
+            proc.ref4 = VPSet(PSet(refToPSet_ = string("top")),
+                              PSet(refToPSet_ = string("ref2")))
             p = TestMakePSet()
             proc.fillProcessDesc(p)
             self.assertEqual((True,1),p.values["ref"][1].values["a"])
             self.assertEqual((True,1),p.values["ref3"][1].values["a"])
             self.assertEqual((True,1),p.values["ref2"][1].values["a"])
             self.assertEqual((True,1),p.values["ref2"][1].values["b"][1].values["a"])
+            self.assertEqual((True,1),p.values["ref4"][1][0].values["a"])
+            self.assertEqual((True,1),p.values["ref4"][1][1].values["a"])
         def testPrune(self):
             p = Process("test")
             p.a = EDAnalyzer("MyAnalyzer")

--- a/FWCore/ParameterSet/python/Types.py
+++ b/FWCore/ParameterSet/python/Types.py
@@ -667,12 +667,14 @@ class PSet(_ParameterTypeBase,_Parameterizable,_ConfigureComponent,_Labelable):
         return object.__str__(self)
     def insertInto(self, parameterSet, myname):
         newpset = parameterSet.newPSet()
-        if self.isRef_():
-            ref = parameterSet.getTopPSet_(self.refToPSet_.value())
-            ref.insertInto(parameterSet,myname)
-            return
         self.insertContentsInto(newpset)
         parameterSet.addPSet(self.isTracked(), myname, newpset)
+    def insertContentsInto(self, parameterSet):
+        if self.isRef_():
+            ref = parameterSet.getTopPSet_(self.refToPSet_.value())
+            ref.insertContentsInto(parameterSet)
+        else:
+            super(PSet, self).insertContentsInto(parameterSet)
 
 
 class vint32(_ValidatingParameterListBase):


### PR DESCRIPTION
Fix (and add test for) `refToPSet_` expansion inside VPSet, e.g. in the following situation

```
process.a = cms.PSet(...)
process.b = cms.PSet(...)
process.c = cms.VPSet(
    cms.PSet(refToPSet_ = cms.string("a")),
    cms.PSet(refToPSet_ = cms.string("b"))
)
```
