### PR TITLE
Fix in detecting cmssw environment in cmsShow script for patch releases

### DIFF
--- a/Fireworks/Core/scripts/cmsShow
+++ b/Fireworks/Core/scripts/cmsShow
@@ -96,20 +96,7 @@ setupEnv()
    fi
    
    # see if we are running in standalone mode
-   FROM_RELEASE=""
-   if [ -n "$CMSSW_BASE" ] && [ `expr "$SHELLDIR" : "$CMSSW_BASE"` -gt 0 ]; then
-     FROM_RELEASE='true'
-   elif [ -n "$CMSSW_RELEASE_BASE" ]; then
-     if [ `expr "$SHELLDIR" : "$CMSSW_RELEASE_BASE"` -gt 0 ]; then
-       FROM_RELEASE='true'
-     else
-       NO_PATCH_CMSSWRB=`echo $CMSSW_RELEASE_BASE | sed 's/cmssw-patch/cmssw/; s/\(CMSSW_[0-9_]*\)_patch[0-9]\+/\1/;'`
-       if [ `expr "$SHELLDIR" : "$NO_PATCH_CMSSWRB"` -gt 0 ]; then
-         FROM_RELEASE='true'
-       fi
-     fi
-   fi
-   if [ -z "$FROM_RELEASE" ]; then 
+   if [ ! -d $SHELLDIR/../../.SCRAM ] ; then
      export CMSSW_BASE=$SHELLDIR
      export CMSSW_SEARCH_PATH="."
      export CMSSW_DATA_PATH="."
@@ -215,7 +202,7 @@ creport=`mktemp /tmp/cmsshow-crash-report-XXXXXXXX`.txt
 exitStatus=$?
 if [ $exitStatus -gt 0 ] && [ $exitStatus -ne 137 ] && [ "$rootflag" != "on" ] ; then 
    writeSystemInfoToFile $creport
-   cmsShowSendReport  ${creport}
+   "$SHELLDIR/cmsShowSendReport"  ${creport}
    echo ""
    msgLen=75;
    awk -v msgLen=$msgLen 'BEGIN {printf("  %c",  35);  i=0;  while ( i <= msgLen) { printf( "%c", 35 ); ++i}; print ""; }'


### PR DESCRIPTION
cmsShow script presumed that the path of the script itself matches $CMSSW_RELEASE_BASE, 
In some cases  this is not true. This change simplifies check for cmssw environment and works for main and patch releases.
