### PR TITLE
Fixed the contents of RecoBTag/PerformanceDB/python/measure/Pool_btagMistagWinter13.py

### DIFF
--- a/RecoBTag/PerformanceDB/python/measure/Pool_btagMistagWinter13.py
+++ b/RecoBTag/PerformanceDB/python/measure/Pool_btagMistagWinter13.py
@@ -1,105 +1,142 @@
 import FWCore.ParameterSet.Config as cms
 
-BtagPerformanceESProducer_MISTAGCSVL = cms.ESProducer("BtagPerformanceESProducer",
-# this is what it makes available
-    ComponentName = cms.string('MISTAGCSVL'),
-# this is where it gets the payload from                                                
-    PayloadName = cms.string('MISTAGCSVL_T'),
-    WorkingPointName = cms.string('MISTAGCSVL_WP')
-)
+from CondCore.DBCommon.CondDBCommon_cfi import *
 
-BtagPerformanceESProducer_MISTAGCSVM = cms.ESProducer("BtagPerformanceESProducer",
-# this is what it makes available
-    ComponentName = cms.string('MISTAGCSVM'),
-# this is where it gets the payload from                                                
-    PayloadName = cms.string('MISTAGCSVM_T'),
-    WorkingPointName = cms.string('MISTAGCSVM_WP')
-)
-
-BtagPerformanceESProducer_MISTAGCSVT = cms.ESProducer("BtagPerformanceESProducer",
-# this is what it makes available
-    ComponentName = cms.string('MISTAGCSVT'),
-# this is where it gets the payload from                                                
-    PayloadName = cms.string('MISTAGCSVT_T'),
-    WorkingPointName = cms.string('MISTAGCSVT_WP')
-)
-
-BtagPerformanceESProducer_MISTAGCSVSLV1L = cms.ESProducer("BtagPerformanceESProducer",
-# this is what it makes available
-    ComponentName = cms.string('MISTAGCSVSLV1L'),
-# this is where it gets the payload from                                                
-    PayloadName = cms.string('MISTAGCSVSLV1L_T'),
-    WorkingPointName = cms.string('MISTAGCSVSLV1L_WP')
-)
-
-BtagPerformanceESProducer_MISTAGCSVSLV1M = cms.ESProducer("BtagPerformanceESProducer",
-# this is what it makes available
-    ComponentName = cms.string('MISTAGCSVSLV1M'),
-# this is where it gets the payload from                                                
-    PayloadName = cms.string('MISTAGCSVSLV1M_T'),
-    WorkingPointName = cms.string('MISTAGCSVSLV1M_WP')
-)
-
-BtagPerformanceESProducer_MISTAGCSVSLV1T = cms.ESProducer("BtagPerformanceESProducer",
-# this is what it makes available
-    ComponentName = cms.string('MISTAGCSVSLV1T'),
-# this is where it gets the payload from                                                
-    PayloadName = cms.string('MISTAGCSVSLV1T_T'),
-    WorkingPointName = cms.string('MISTAGCSVSLV1T_WP')
-)
-
-BtagPerformanceESProducer_MISTAGCSVV1L = cms.ESProducer("BtagPerformanceESProducer",
-# this is what it makes available
-    ComponentName = cms.string('MISTAGCSVV1L'),
-# this is where it gets the payload from                                                
-    PayloadName = cms.string('MISTAGCSVV1L_T'),
-    WorkingPointName = cms.string('MISTAGCSVV1L_WP')
-)
-
-BtagPerformanceESProducer_MISTAGCSVV1M = cms.ESProducer("BtagPerformanceESProducer",
-# this is what it makes available
-    ComponentName = cms.string('MISTAGCSVV1M'),
-# this is where it gets the payload from                                                
-    PayloadName = cms.string('MISTAGCSVV1M_T'),
-    WorkingPointName = cms.string('MISTAGCSVV1M_WP')
-)
-
-BtagPerformanceESProducer_MISTAGCSVV1T = cms.ESProducer("BtagPerformanceESProducer",
-# this is what it makes available
-    ComponentName = cms.string('MISTAGCSVV1T'),
-# this is where it gets the payload from                                                
-    PayloadName = cms.string('MISTAGCSVV1T_T'),
-    WorkingPointName = cms.string('MISTAGCSVV1T_WP')
-)
-
-BtagPerformanceESProducer_MISTAGJPL = cms.ESProducer("BtagPerformanceESProducer",
-# this is what it makes available
-    ComponentName = cms.string('MISTAGJPL'),
-# this is where it gets the payload from                                                
-    PayloadName = cms.string('MISTAGJPL_T'),
-    WorkingPointName = cms.string('MISTAGJPL_WP')
-)
-
-BtagPerformanceESProducer_MISTAGJPM = cms.ESProducer("BtagPerformanceESProducer",
-# this is what it makes available
-    ComponentName = cms.string('MISTAGJPM'),
-# this is where it gets the payload from                                                
-    PayloadName = cms.string('MISTAGJPM_T'),
-    WorkingPointName = cms.string('MISTAGJPM_WP')
-)
-
-BtagPerformanceESProducer_MISTAGJPT = cms.ESProducer("BtagPerformanceESProducer",
-# this is what it makes available
-    ComponentName = cms.string('MISTAGJPT'),
-# this is where it gets the payload from                                                
-    PayloadName = cms.string('MISTAGJPT_T'),
-    WorkingPointName = cms.string('MISTAGJPT_WP')
-)
-
-BtagPerformanceESProducer_MISTAGTCHPT = cms.ESProducer("BtagPerformanceESProducer",
-# this is what it makes available
-    ComponentName = cms.string('MISTAGTCHPT'),
-# this is where it gets the payload from                                                
-    PayloadName = cms.string('MISTAGTCHPT_T'),
-    WorkingPointName = cms.string('MISTAGTCHPT_WP')
-)
+PoolDBESSourcebtagMistagWinter13 = cms.ESSource("PoolDBESSource",
+                              CondDBCommon,
+                              toGet = cms.VPSet(
+    #
+    # working points
+    #
+    cms.PSet(
+    record = cms.string('PerformancePayloadRecord'),
+    tag = cms.string('PerformancePayloadFromBinnedTFormula_MISTAGCSVL_v10_offline'),
+    label = cms.untracked.string('MISTAGCSVL_T')
+    ),
+    cms.PSet(
+    record = cms.string('PerformanceWPRecord'),
+    tag = cms.string('PerformanceWorkingPoint_MISTAGCSVL_v10_offline'),
+    label = cms.untracked.string('MISTAGCSVL_WP')
+    ),
+    cms.PSet(
+    record = cms.string('PerformancePayloadRecord'),
+    tag = cms.string('PerformancePayloadFromBinnedTFormula_MISTAGCSVM_v10_offline'),
+    label = cms.untracked.string('MISTAGCSVM_T')
+    ),
+    cms.PSet(
+    record = cms.string('PerformanceWPRecord'),
+    tag = cms.string('PerformanceWorkingPoint_MISTAGCSVM_v10_offline'),
+    label = cms.untracked.string('MISTAGCSVM_WP')
+    ),
+    cms.PSet(
+    record = cms.string('PerformancePayloadRecord'),
+    tag = cms.string('PerformancePayloadFromBinnedTFormula_MISTAGCSVT_v10_offline'),
+    label = cms.untracked.string('MISTAGCSVT_T')
+    ),
+    cms.PSet(
+    record = cms.string('PerformanceWPRecord'),
+    tag = cms.string('PerformanceWorkingPoint_MISTAGCSVT_v10_offline'),
+    label = cms.untracked.string('MISTAGCSVT_WP')
+    ),
+    cms.PSet(
+    record = cms.string('PerformancePayloadRecord'),
+    tag = cms.string('PerformancePayloadFromBinnedTFormula_MISTAGCSVSLV1L_v10_offline'),
+    label = cms.untracked.string('MISTAGCSVSLV1L_T')
+    ),
+    cms.PSet(
+    record = cms.string('PerformanceWPRecord'),
+    tag = cms.string('PerformanceWorkingPoint_MISTAGCSVSLV1L_v10_offline'),
+    label = cms.untracked.string('MISTAGCSVSLV1L_WP')
+    ),
+    cms.PSet(
+    record = cms.string('PerformancePayloadRecord'),
+    tag = cms.string('PerformancePayloadFromBinnedTFormula_MISTAGCSVSLV1M_v10_offline'),
+    label = cms.untracked.string('MISTAGCSVSLV1M_T')
+    ),
+    cms.PSet(
+    record = cms.string('PerformanceWPRecord'),
+    tag = cms.string('PerformanceWorkingPoint_MISTAGCSVSLV1M_v10_offline'),
+    label = cms.untracked.string('MISTAGCSVSLV1M_WP')
+    ),
+    cms.PSet(
+    record = cms.string('PerformancePayloadRecord'),
+    tag = cms.string('PerformancePayloadFromBinnedTFormula_MISTAGCSVSLV1T_v10_offline'),
+    label = cms.untracked.string('MISTAGCSVSLV1T_T')
+    ),
+    cms.PSet(
+    record = cms.string('PerformanceWPRecord'),
+    tag = cms.string('PerformanceWorkingPoint_MISTAGCSVSLV1T_v10_offline'),
+    label = cms.untracked.string('MISTAGCSVSLV1T_WP')
+    ),
+    cms.PSet(
+    record = cms.string('PerformancePayloadRecord'),
+    tag = cms.string('PerformancePayloadFromBinnedTFormula_MISTAGCSVV1L_v10_offline'),
+    label = cms.untracked.string('MISTAGCSVV1L_T')
+    ),
+    cms.PSet(
+    record = cms.string('PerformanceWPRecord'),
+    tag = cms.string('PerformanceWorkingPoint_MISTAGCSVV1L_v10_offline'),
+    label = cms.untracked.string('MISTAGCSVV1L_WP')
+    ),
+    cms.PSet(
+    record = cms.string('PerformancePayloadRecord'),
+    tag = cms.string('PerformancePayloadFromBinnedTFormula_MISTAGCSVV1M_v10_offline'),
+    label = cms.untracked.string('MISTAGCSVV1M_T')
+    ),
+    cms.PSet(
+    record = cms.string('PerformanceWPRecord'),
+    tag = cms.string('PerformanceWorkingPoint_MISTAGCSVV1M_v10_offline'),
+    label = cms.untracked.string('MISTAGCSVV1M_WP')
+    ),
+    cms.PSet(
+    record = cms.string('PerformancePayloadRecord'),
+    tag = cms.string('PerformancePayloadFromBinnedTFormula_MISTAGCSVV1T_v10_offline'),
+    label = cms.untracked.string('MISTAGCSVV1T_T')
+    ),
+    cms.PSet(
+    record = cms.string('PerformanceWPRecord'),
+    tag = cms.string('PerformanceWorkingPoint_MISTAGCSVV1T_v10_offline'),
+    label = cms.untracked.string('MISTAGCSVV1T_WP')
+    ),
+    cms.PSet(
+    record = cms.string('PerformancePayloadRecord'),
+    tag = cms.string('PerformancePayloadFromBinnedTFormula_MISTAGJPL_v10_offline'),
+    label = cms.untracked.string('MISTAGJPL_T')
+    ),
+    cms.PSet(
+    record = cms.string('PerformanceWPRecord'),
+    tag = cms.string('PerformanceWorkingPoint_MISTAGJPL_v10_offline'),
+    label = cms.untracked.string('MISTAGJPL_WP')
+    ),
+    cms.PSet(
+    record = cms.string('PerformancePayloadRecord'),
+    tag = cms.string('PerformancePayloadFromBinnedTFormula_MISTAGJPM_v10_offline'),
+    label = cms.untracked.string('MISTAGJPM_T')
+    ),
+    cms.PSet(
+    record = cms.string('PerformanceWPRecord'),
+    tag = cms.string('PerformanceWorkingPoint_MISTAGJPM_v10_offline'),
+    label = cms.untracked.string('MISTAGJPM_WP')
+    ),
+    cms.PSet(
+    record = cms.string('PerformancePayloadRecord'),
+    tag = cms.string('PerformancePayloadFromBinnedTFormula_MISTAGJPT_v10_offline'),
+    label = cms.untracked.string('MISTAGJPT_T')
+    ),
+    cms.PSet(
+    record = cms.string('PerformanceWPRecord'),
+    tag = cms.string('PerformanceWorkingPoint_MISTAGJPT_v10_offline'),
+    label = cms.untracked.string('MISTAGJPT_WP')
+    ),
+    cms.PSet(
+    record = cms.string('PerformancePayloadRecord'),
+    tag = cms.string('PerformancePayloadFromBinnedTFormula_MISTAGTCHPT_v10_offline'),
+    label = cms.untracked.string('MISTAGTCHPT_T')
+    ),
+    cms.PSet(
+    record = cms.string('PerformanceWPRecord'),
+    tag = cms.string('PerformanceWorkingPoint_MISTAGTCHPT_v10_offline'),
+    label = cms.untracked.string('MISTAGTCHPT_WP')
+    ),
+))
+PoolDBESSourcebtagMistagWinter13.connect = 'frontier://FrontierProd/CMS_COND_PAT_000'


### PR DESCRIPTION
Same as #3164. Bugfix for the problem reported in https://hypernews.cern.ch/HyperNews/CMS/get/btag/1070.html. The bug originally sneaked in with #1365.

In addition, could #2504 be reopened and merged? Also note that this PR and #2504 have zero impact on the standard reconstruction.
