### PR TITLE
Cleanup that helps static analyzer

### DIFF
--- a/TrackingTools/TrackAssociator/interface/DetIdAssociator.h
+++ b/TrackingTools/TrackAssociator/interface/DetIdAssociator.h
@@ -101,8 +101,6 @@ class DetIdAssociator{
    virtual int iEta (const GlobalPoint&) const;
    /// look-up map phi index
    virtual int iPhi (const GlobalPoint&) const;
-   /// set a specific track propagator to be used
-   virtual void setPropagator(Propagator* ptr){	ivProp_ = ptr; };
    /// number of bins of the look-up map in phi dimension
    int nPhiBins() const { return nPhi_;}
    /// number of bins of the look-up map in eta dimension
@@ -159,8 +157,6 @@ class DetIdAssociator{
    const double etaBinSize_;
    double maxEta_;
    double minTheta_;
-   
-   Propagator *ivProp_;
    
    // Detector fiducial volume 
    // approximated as a closed cylinder with non-zero width.

--- a/TrackingTools/TrackAssociator/src/DetIdAssociator.cc
+++ b/TrackingTools/TrackAssociator/src/DetIdAssociator.cc
@@ -25,7 +25,7 @@
 DetIdAssociator::DetIdAssociator(const int nPhi, const int nEta, const double etaBinSize)
   :nPhi_(nPhi),nEta_(nEta),
    lookupMap_(nPhi_*nEta_,std::pair<unsigned int, unsigned int>(0,0)),
-  theMapIsValid_(false),etaBinSize_(etaBinSize),ivProp_(0)
+  theMapIsValid_(false),etaBinSize_(etaBinSize)
 {
    if (nEta_ <= 0 || nPhi_ <= 0) throw cms::Exception("FatalError") << "incorrect look-up map size. Cannot initialize such a map.";
    maxEta_ = etaBinSize_*nEta_/2;


### PR DESCRIPTION
Remove unused members of DetIdAssociator. Removing
these eliminates some of the spurious problems reported
by the static analyzer used to look for threading
issues.
