### PR TITLE
Cleanup PluginManager to avoid StaticAnalyzer warnings

### DIFF
--- a/FWCore/PluginManager/src/PluginCapabilities.cc
+++ b/FWCore/PluginManager/src/PluginCapabilities.cc
@@ -163,7 +163,7 @@ PluginCapabilities::category() const
 //
 PluginCapabilities*
 PluginCapabilities::get() {
-  static PluginCapabilities s_instance;
+  [[cms::thread_safe]] static PluginCapabilities s_instance;
   return &s_instance;
 }
 

--- a/FWCore/PluginManager/src/PluginManager.cc
+++ b/FWCore/PluginManager/src/PluginManager.cc
@@ -160,7 +160,7 @@ PluginManager::loadableFor_(const std::string& iCategory,
       "' because the category '"<<iCategory<<"' has no known plugins";
     } else {
       ioThrowIfFailElseSucceedStatus = false;
-      static boost::filesystem::path s_path;
+      static const boost::filesystem::path s_path;
       return s_path;
     }
   }
@@ -179,7 +179,7 @@ PluginManager::loadableFor_(const std::string& iCategory,
       <<"' in category '"<<iCategory<<"'. Please check spelling of name.";
     } else {
       ioThrowIfFailElseSucceedStatus = false;
-      static boost::filesystem::path s_path;
+      static const boost::filesystem::path s_path;
       return s_path;
     }
   }
@@ -326,7 +326,7 @@ PluginManager::loadingLibraryNamed_()
 {
   //NOTE: pluginLoadMutex() indirectly guards this since this value
   // is only accessible via the Sentry call which us guarded by the mutex
-  static std::string s_name(staticallyLinkedLoadingFileName());
+  [[cms::thread_safe]] static std::string s_name(staticallyLinkedLoadingFileName());
   return s_name;
 }
 

--- a/FWCore/PluginManager/src/PresenceFactory.cc
+++ b/FWCore/PluginManager/src/PresenceFactory.cc
@@ -16,7 +16,7 @@ namespace edm {
 
 
   PresenceFactory* PresenceFactory::get() {
-    static PresenceFactory singleInstance_;
+    [[cms::thread_safe]] static PresenceFactory singleInstance_;
     return &singleInstance_;
   }
 


### PR DESCRIPTION
The remaining statics in the PluginManager are protected by various mutex so are thread safe. Added the appropriate C++11 attribute to let the StaticAnalyzer know the code is fine.
