### PR TITLE
The L2MuonIsolatorProducer was migrated to consumes.

### DIFF
--- a/HLTrigger/Muon/src/HLTMuonIsoFilter.cc
+++ b/HLTrigger/Muon/src/HLTMuonIsoFilter.cc
@@ -24,6 +24,8 @@
 
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+
 #include <iostream>
 //
 // constructors and destructor
@@ -54,7 +56,7 @@ HLTMuonIsoFilter::HLTMuonIsoFilter(const edm::ParameterSet& iConfig) : HLTFilter
      theDepositIsolator=0;
        }else{
      std::string type = isolatorPSet.getParameter<std::string>("ComponentName");
-     theDepositIsolator = MuonIsolatorFactory::get()->create(type, isolatorPSet);
+     theDepositIsolator = MuonIsolatorFactory::get()->create(type, isolatorPSet, consumesCollector());
    }
 
    if (theDepositIsolator) produces<edm::ValueMap<bool> >();

--- a/RecoMuon/L2MuonIsolationProducer/src/L2MuonIsolationProducer.cc
+++ b/RecoMuon/L2MuonIsolationProducer/src/L2MuonIsolationProducer.cc
@@ -56,7 +56,7 @@ L2MuonIsolationProducer::L2MuonIsolationProducer(const ParameterSet& par) :
   optOutputDecision = haveIsolator;
   if (optOutputDecision){
     std::string type = isolatorPSet.getParameter<std::string>("ComponentName");
-    theDepositIsolator = MuonIsolatorFactory::get()->create(type,isolatorPSet);
+    theDepositIsolator = MuonIsolatorFactory::get()->create(type, isolatorPSet, consumesCollector());
   }
   if (optOutputDecision) produces<edm::ValueMap<bool> >();
   produces<reco::IsoDepositMap>();

--- a/RecoMuon/MuonIsolation/interface/MuonIsolatorFactory.h
+++ b/RecoMuon/MuonIsolation/interface/MuonIsolatorFactory.h
@@ -4,7 +4,8 @@
 #include "FWCore/PluginManager/interface/PluginFactory.h"
 #include "RecoMuon/MuonIsolation/interface/MuIsoBaseIsolator.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
-typedef edmplugin::PluginFactory<muonisolation::MuIsoBaseIsolator* (const edm::ParameterSet&) >  MuonIsolatorFactory;
+typedef edmplugin::PluginFactory<muonisolation::MuIsoBaseIsolator* (const edm::ParameterSet&, edm::ConsumesCollector && iC) >  MuonIsolatorFactory;
 
 #endif

--- a/RecoMuon/MuonIsolation/interface/SimpleCutsIsolator.h
+++ b/RecoMuon/MuonIsolation/interface/SimpleCutsIsolator.h
@@ -4,10 +4,12 @@
 #include "RecoMuon/MuonIsolation/interface/MuIsoBaseIsolator.h"
 #include "RecoMuon/MuonIsolation/interface/Cuts.h"
 
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+
 
 class SimpleCutsIsolator : public muonisolation::MuIsoBaseIsolator {
  public:
-  SimpleCutsIsolator(const edm::ParameterSet & par):
+ SimpleCutsIsolator(const edm::ParameterSet & par, edm::ConsumesCollector && iC):
     theCuts(par.getParameter<std::vector<double> > ("EtaBounds"),
 	    par.getParameter<std::vector<double> > ("ConeSizes"),
 	    par.getParameter<std::vector<double> > ("Thresholds"))

--- a/RecoMuon/MuonIsolation/plugins/CutsIsolatorWithCorrection.cc
+++ b/RecoMuon/MuonIsolation/plugins/CutsIsolatorWithCorrection.cc
@@ -5,7 +5,8 @@
 
 using namespace muonisolation;
 
-CutsIsolatorWithCorrection::CutsIsolatorWithCorrection(const edm::ParameterSet & par):
+CutsIsolatorWithCorrection::CutsIsolatorWithCorrection(const edm::ParameterSet & par,
+						       edm::ConsumesCollector && iC ):
   theCuts(par.getParameter<std::vector<double> > ("EtaBounds"),
 	  par.getParameter<std::vector<double> > ("ConeSizes"),
 	  par.getParameter<std::vector<double> > ("Thresholds")),
@@ -15,7 +16,7 @@ CutsIsolatorWithCorrection::CutsIsolatorWithCorrection(const edm::ParameterSet &
   theCutAbsIso(par.getParameter<bool>("CutAbsoluteIso")),
   theCutRelativeIso(par.getParameter<bool>("CutRelativeIso")),
   theUseRhoCorrection(par.getParameter<bool>("UseRhoCorrection")),
-  theRhoSrc(par.getParameter<edm::InputTag>("RhoSrc")),
+  theRhoToken(iC.consumes<double>(par.getParameter<edm::InputTag>("RhoSrc"))),
   theRhoMax(par.getParameter<double>("RhoMax")),
   theRhoScaleBarrel(par.getParameter<double>("RhoScaleBarrel")),
   theRhoScaleEndcap(par.getParameter<double>("RhoScaleEndcap")),
@@ -62,7 +63,7 @@ MuIsoBaseIsolator::Result CutsIsolatorWithCorrection::result(const DepositContai
 
   if (theUseRhoCorrection){
     edm::Handle<double> rhoHandle; 
-    ev->getByLabel(theRhoSrc, rhoHandle); 
+    ev->getByToken(theRhoToken, rhoHandle); 
     rho = *(rhoHandle.product());
     if (rho < 0.0) rho = 0.0;
     double rhoScale = fabs(tk.eta()) > 1.442 ? theRhoScaleEndcap : theRhoScaleBarrel;

--- a/RecoMuon/MuonIsolation/plugins/CutsIsolatorWithCorrection.h
+++ b/RecoMuon/MuonIsolation/plugins/CutsIsolatorWithCorrection.h
@@ -4,10 +4,12 @@
 #include "RecoMuon/MuonIsolation/interface/MuIsoBaseIsolator.h"
 #include "RecoMuon/MuonIsolation/interface/Cuts.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 class CutsIsolatorWithCorrection : public muonisolation::MuIsoBaseIsolator {
  public:
-  CutsIsolatorWithCorrection(const edm::ParameterSet & par);
+  CutsIsolatorWithCorrection(const edm::ParameterSet & par, 
+			     edm::ConsumesCollector && iC);
 
   virtual ResultType resultType() const {return ISOL_BOOL_TYPE;}
 
@@ -30,7 +32,7 @@ class CutsIsolatorWithCorrection : public muonisolation::MuIsoBaseIsolator {
   bool theCutAbsIso;
   bool theCutRelativeIso;
   bool theUseRhoCorrection;
-  edm::InputTag theRhoSrc;
+  edm::EDGetTokenT<double> theRhoToken;
   double theRhoMax;
   double theRhoScaleBarrel;
   double theRhoScaleEndcap;


### PR DESCRIPTION
In order to do so the MuonIsolatorFactory (from RecoMuon/MuonIsolation) as well as the MuIsoBaseIsolator base class were updated to deal with ConsumesCollector.
