### PR TITLE
Add TrackingParticle selector (fix for #4132)

### DIFF
--- a/SimGeneral/MixingModule/python/digitizers_cfi.py
+++ b/SimGeneral/MixingModule/python/digitizers_cfi.py
@@ -7,7 +7,7 @@ from SimGeneral.MixingModule.stripDigitizer_cfi import *
 from SimGeneral.MixingModule.ecalDigitizer_cfi import *
 from SimGeneral.MixingModule.hcalDigitizer_cfi import *
 from SimGeneral.MixingModule.castorDigitizer_cfi import *
-from SimGeneral.MixingModule.trackingTruthProducer_cfi import *
+from SimGeneral.MixingModule.trackingTruthProducerSelection_cfi import *
 
 theDigitizers = cms.PSet(
   pixel = cms.PSet(

--- a/SimGeneral/MixingModule/python/trackingTruthProducerSelection_cfi.py
+++ b/SimGeneral/MixingModule/python/trackingTruthProducerSelection_cfi.py
@@ -6,9 +6,9 @@ trackingParticles.select = cms.PSet(
     chargedOnlyTP = cms.bool(True),
     pdgIdTP = cms.vint32(),
     signalOnlyTP = cms.bool(True),
-    minRapidityTP = cms.double(-2.6),
+    minRapidityTP = cms.double(-5.0),
     minHitTP = cms.int32(3),
-    ptMinTP = cms.double(0.2),
-    maxRapidityTP = cms.double(2.6),
+    ptMinTP = cms.double(0.1),
+    maxRapidityTP = cms.double(5.0),
     tipTP = cms.double(1000)
 )

--- a/SimGeneral/MixingModule/python/trackingTruthProducerSelection_cfi.py
+++ b/SimGeneral/MixingModule/python/trackingTruthProducerSelection_cfi.py
@@ -10,5 +10,6 @@ trackingParticles.select = cms.PSet(
     minHitTP = cms.int32(3),
     ptMinTP = cms.double(0.1),
     maxRapidityTP = cms.double(5.0),
-    tipTP = cms.double(1000)
+    tipTP = cms.double(1000),
+    stableOnlyTP = cms.bool(False)
 )


### PR DESCRIPTION
This is a fix for ~~#4132~~ (EDIT - I meant #3142) which adds an extra parameter.  stableOnlyTP should be true for FastSim and false for FullSim, so I set it to false.  I don't actually know how FastSim is configured though.
