### PR TITLE
fix thread safety in steppingHelixPropagator (supersede #3160)

### DIFF
--- a/Calibration/HcalAlCaRecoProducers/src/AlCaHOCalibProducer.cc
+++ b/Calibration/HcalAlCaRecoProducers/src/AlCaHOCalibProducer.cc
@@ -776,7 +776,8 @@ AlCaHOCalibProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
 	  auto aPlane2 = new Plane(pos,rot);
 
-	  SteppingHelixStateInfo steppingHelixstateinfo_ = myHelix.propagate(SteppingHelixStateInfo(freetrajectorystate_), (*aPlane2));
+	  SteppingHelixStateInfo steppingHelixstateinfo_;
+	  myHelix.propagate(SteppingHelixStateInfo(freetrajectorystate_), (*aPlane2), steppingHelixstateinfo_);
 
 	  if (steppingHelixstateinfo_.isValid()) {
 

--- a/FastSimulation/MuonSimHitProducer/src/MuonSimHitProducer.cc
+++ b/FastSimulation/MuonSimHitProducer/src/MuonSimHitProducer.cc
@@ -281,8 +281,8 @@ MuonSimHitProducer::produce(edm::Event& iEvent,const edm::EventSetup& iSetup) {
 
       // Propagate with material effects (dE/dx average only)
       SteppingHelixStateInfo shsStart(*(propagatedState.freeTrajectoryState()));
-      const SteppingHelixStateInfo& shsDest = 
-	((const SteppingHelixPropagator*)propagatorWithMaterial)->propagate(shsStart,navLayers[ilayer]->surface());
+      SteppingHelixStateInfo shsDest;
+      ((const SteppingHelixPropagator*)propagatorWithMaterial)->propagate(shsStart,navLayers[ilayer]->surface(),shsDest);
       std::pair<TrajectoryStateOnSurface,double> next(shsDest.getStateOnSurface(navLayers[ilayer]->surface()),
 						      shsDest.path());
       // No need to continue if there is no valid propagation available.

--- a/TrackPropagation/SteppingHelixPropagator/interface/SteppingHelixPropagator.h
+++ b/TrackPropagation/SteppingHelixPropagator/interface/SteppingHelixPropagator.h
@@ -91,10 +91,10 @@ class SteppingHelixPropagator GCC11_FINAL : public Propagator {
   
   //! Propagate to Plane given a starting point
   virtual TrajectoryStateOnSurface 
-    propagate(const FreeTrajectoryState& ftsStart, const Plane& pDest) const;
+    propagate(const FreeTrajectoryState& ftsStart, const Plane& pDest) const override;
   //! Propagate to Cylinder given a starting point (a Cylinder is assumed to be positioned at 0,0,0)
   virtual TrajectoryStateOnSurface 
-    propagate(const FreeTrajectoryState& ftsStart, const Cylinder& cDest) const;
+    propagate(const FreeTrajectoryState& ftsStart, const Cylinder& cDest) const override;
   //! Propagate to PCA to point given a starting point 
   virtual FreeTrajectoryState 
     propagate(const FreeTrajectoryState& ftsStart, const GlobalPoint& pDest) const;
@@ -105,23 +105,23 @@ class SteppingHelixPropagator GCC11_FINAL : public Propagator {
   //! Propagate to PCA to a line determined by BeamSpot position and slope given a starting point 
   virtual FreeTrajectoryState 
     propagate(const FreeTrajectoryState& ftsStart, 
-	      const reco::BeamSpot& beamSpot) const;
+	      const reco::BeamSpot& beamSpot) const override;
 
   //! Propagate to Plane given a starting point: return final 
   //! TrajectoryState and path length from start to this point
   virtual std::pair<TrajectoryStateOnSurface, double> 
-    propagateWithPath(const FreeTrajectoryState& ftsStart, const Plane& pDest) const;
+    propagateWithPath(const FreeTrajectoryState& ftsStart, const Plane& pDest) const override;
   //! Propagate to Cylinder given a starting point: return final TrajectoryState 
   //!and path length from start to this point
   virtual std::pair<TrajectoryStateOnSurface, double> 
-    propagateWithPath(const FreeTrajectoryState& ftsStart, const Cylinder& cDest) const;
+    propagateWithPath(const FreeTrajectoryState& ftsStart, const Cylinder& cDest) const override;
   //! Propagate to PCA to point given a starting point 
   virtual std::pair<FreeTrajectoryState, double> 
     propagateWithPath(const FreeTrajectoryState& ftsStart, const GlobalPoint& pDest) const;
   //! Propagate to PCA to a line (given by 2 points) given a starting point 
   virtual std::pair<FreeTrajectoryState, double> 
     propagateWithPath(const FreeTrajectoryState& ftsStart, 
-		      const GlobalPoint& pDest1, const GlobalPoint& pDest2) const;
+		      const GlobalPoint& pDest1, const GlobalPoint& pDest2) const override;
   //! Propagate to PCA to a line (given by beamSpot position and slope) given a starting point 
   virtual std::pair<FreeTrajectoryState, double> 
     propagateWithPath(const FreeTrajectoryState& ftsStart, 
@@ -129,18 +129,18 @@ class SteppingHelixPropagator GCC11_FINAL : public Propagator {
     
     
   //! Propagate to Plane given a starting point
-  const SteppingHelixStateInfo& 
+  const SteppingHelixStateInfo 
     propagate(const SteppingHelixStateInfo& ftsStart, const Surface& sDest) const;
-  const SteppingHelixStateInfo& 
+  const SteppingHelixStateInfo 
     propagate(const SteppingHelixStateInfo& ftsStart, const Plane& pDest) const;
   //! Propagate to Cylinder given a starting point (a Cylinder is assumed to be positioned at 0,0,0)
-  const SteppingHelixStateInfo& 
+  const SteppingHelixStateInfo 
     propagate(const SteppingHelixStateInfo& ftsStart, const Cylinder& cDest) const;
   //! Propagate to PCA to point given a starting point 
-  const SteppingHelixStateInfo& 
+  const SteppingHelixStateInfo 
     propagate(const SteppingHelixStateInfo& ftsStart, const GlobalPoint& pDest) const;
   //! Propagate to PCA to a line (given by 2 points) given a starting point 
-  const SteppingHelixStateInfo& 
+  const SteppingHelixStateInfo 
     propagate(const SteppingHelixStateInfo& ftsStart, 
 	      const GlobalPoint& pDest1, const GlobalPoint& pDest2) const;
 
@@ -195,13 +195,16 @@ class SteppingHelixPropagator GCC11_FINAL : public Propagator {
 
  protected:
   typedef SteppingHelixStateInfo::VolumeBounds MatBounds;
+  static const int MAX_POINTS = 7;
+  typedef StateInfo StateArray[MAX_POINTS+1];
   //! (Internals) Init starting point
-  void setIState(const SteppingHelixStateInfo& sStart) const;
+  void setIState(const SteppingHelixStateInfo& sStart,
+		 StateArray& svBuff, int& nPoints) const;
 
   //! propagate: chose stop point by type argument
   //! propagate to fixed radius [ r = sqrt(x**2+y**2) ] with precision epsilon
   //! propagate to plane by [x0,y0,z0, n_x, n_y, n_z] parameters
-  Result propagate(SteppingHelixPropagator::DestType type, 
+  Result propagate(StateArray& svBuff, int& nPoints, SteppingHelixPropagator::DestType type, 
 		   const double pars[6], double epsilon = 1e-3) const;
 
   //! (Internals) compute transient values for initial point (resets step counter).
@@ -264,9 +267,8 @@ class SteppingHelixPropagator GCC11_FINAL : public Propagator {
   typedef std::pair<TrajectoryStateOnSurface, double> TsosPP;
   typedef std::pair<FreeTrajectoryState, double> FtsPP;
   static const int MAX_STEPS = 10000;
-  static const int MAX_POINTS = 7;
-  mutable int nPoints_;
-  mutable StateInfo svBuf_[MAX_POINTS+1];
+  //mutable int nPoints_;
+  //mutable StateInfo svBuf_[MAX_POINTS+1];
 
   StateInfo invalidState_;
 

--- a/TrackPropagation/SteppingHelixPropagator/interface/SteppingHelixPropagator.h
+++ b/TrackPropagation/SteppingHelixPropagator/interface/SteppingHelixPropagator.h
@@ -197,6 +197,10 @@ class SteppingHelixPropagator GCC11_FINAL : public Propagator {
   typedef SteppingHelixStateInfo::VolumeBounds MatBounds;
   static const int MAX_POINTS = 7;
   typedef StateInfo StateArray[MAX_POINTS+1];
+
+  //! (Internals) set defaults needed for states used inside propagate methods
+  void initStateArraySHPSpecific(StateArray& svBuf, bool flagsOnly) const;
+
   //! (Internals) Init starting point
   void setIState(const SteppingHelixStateInfo& sStart,
 		 StateArray& svBuff, int& nPoints) const;

--- a/TrackPropagation/SteppingHelixPropagator/interface/SteppingHelixPropagator.h
+++ b/TrackPropagation/SteppingHelixPropagator/interface/SteppingHelixPropagator.h
@@ -129,20 +129,20 @@ class SteppingHelixPropagator GCC11_FINAL : public Propagator {
     
     
   //! Propagate to Plane given a starting point
-  const SteppingHelixStateInfo 
-    propagate(const SteppingHelixStateInfo& ftsStart, const Surface& sDest) const;
-  const SteppingHelixStateInfo 
-    propagate(const SteppingHelixStateInfo& ftsStart, const Plane& pDest) const;
+  void
+    propagate(const SteppingHelixStateInfo& ftsStart, const Surface& sDest, SteppingHelixStateInfo& out) const;
+  void
+    propagate(const SteppingHelixStateInfo& ftsStart, const Plane& pDest, SteppingHelixStateInfo& out) const;
   //! Propagate to Cylinder given a starting point (a Cylinder is assumed to be positioned at 0,0,0)
-  const SteppingHelixStateInfo 
-    propagate(const SteppingHelixStateInfo& ftsStart, const Cylinder& cDest) const;
+  void
+    propagate(const SteppingHelixStateInfo& ftsStart, const Cylinder& cDest, SteppingHelixStateInfo& out) const;
   //! Propagate to PCA to point given a starting point 
-  const SteppingHelixStateInfo 
-    propagate(const SteppingHelixStateInfo& ftsStart, const GlobalPoint& pDest) const;
+  void
+    propagate(const SteppingHelixStateInfo& ftsStart, const GlobalPoint& pDest, SteppingHelixStateInfo& out) const;
   //! Propagate to PCA to a line (given by 2 points) given a starting point 
-  const SteppingHelixStateInfo 
+  void
     propagate(const SteppingHelixStateInfo& ftsStart, 
-	      const GlobalPoint& pDest1, const GlobalPoint& pDest2) const;
+	      const GlobalPoint& pDest1, const GlobalPoint& pDest2, SteppingHelixStateInfo& out) const;
 
   
   //! Switch debug printouts (to cout) .. very verbose

--- a/TrackPropagation/SteppingHelixPropagator/src/SteppingHelixPropagator.cc
+++ b/TrackPropagation/SteppingHelixPropagator/src/SteppingHelixPropagator.cc
@@ -36,6 +36,22 @@
 #include <sstream>
 #include <typeinfo>
 
+void SteppingHelixPropagator::initStateArraySHPSpecific(StateArray& svBuf, bool flagsOnly) const{
+  for (int i = 0; i <= MAX_POINTS; i++){
+    svBuf[i].isComplete = true;
+    svBuf[i].isValid_ = true;
+    svBuf[i].hasErrorPropagated_ = !noErrorPropagation_;
+    if (!flagsOnly){
+      svBuf[i].p3 = Vector(0,0,0);
+      svBuf[i].r3 = Point(0,0,0);
+      svBuf[i].bf = Vector(0,0,0);
+      svBuf[i].bfGradLoc =  Vector(0,0,0);
+      svBuf[i].covCurv = AlgebraicSymMatrix55();
+      svBuf[i].matDCovCurv = AlgebraicSymMatrix55();
+    }
+  }
+}
+
 SteppingHelixPropagator::SteppingHelixPropagator() :
   Propagator(anyDirection)
 {
@@ -103,7 +119,7 @@ std::pair<TrajectoryStateOnSurface, double>
 SteppingHelixPropagator::propagateWithPath(const FreeTrajectoryState& ftsStart, 
 					   const Plane& pDest) const {
 
-  StateArray svBuf;
+  StateArray svBuf; initStateArraySHPSpecific(svBuf, true);
   int nPoints = 0;
   setIState(SteppingHelixStateInfo(ftsStart),svBuf,nPoints);
 
@@ -117,7 +133,7 @@ std::pair<TrajectoryStateOnSurface, double>
 SteppingHelixPropagator::propagateWithPath(const FreeTrajectoryState& ftsStart, 
 					   const Cylinder& cDest) const {
 
-  StateArray svBuf;
+  StateArray svBuf; initStateArraySHPSpecific(svBuf, true);
   int nPoints = 0;
   setIState(SteppingHelixStateInfo(ftsStart),svBuf,nPoints);
 
@@ -131,7 +147,7 @@ SteppingHelixPropagator::propagateWithPath(const FreeTrajectoryState& ftsStart,
 std::pair<FreeTrajectoryState, double> 
 SteppingHelixPropagator::propagateWithPath(const FreeTrajectoryState& ftsStart, 
 					   const GlobalPoint& pDest) const {
-  StateArray svBuf;
+  StateArray svBuf; initStateArraySHPSpecific(svBuf, true);
   int nPoints = 0;
   setIState(SteppingHelixStateInfo(ftsStart),svBuf,nPoints);
 
@@ -155,7 +171,7 @@ SteppingHelixPropagator::propagateWithPath(const FreeTrajectoryState& ftsStart,
     }
     return FtsPP();
   }
-  StateArray svBuf;
+  StateArray svBuf; initStateArraySHPSpecific(svBuf, true);
   int nPoints = 0;
   setIState(SteppingHelixStateInfo(ftsStart),svBuf,nPoints);
   
@@ -222,7 +238,7 @@ SteppingHelixPropagator::propagate(const SteppingHelixStateInfo& sStart,
     out = invalidState_; 
     return ;
   }
-  StateArray svBuf;
+  StateArray svBuf; initStateArraySHPSpecific(svBuf, true);
   int nPoints = 0;
   setIState(sStart,svBuf,nPoints);
   
@@ -258,7 +274,7 @@ SteppingHelixPropagator::propagate(const SteppingHelixStateInfo& sStart,
     out = invalidState_;
     return;
   }
-  StateArray svBuf;
+  StateArray svBuf; initStateArraySHPSpecific(svBuf, true);
   int nPoints = 0;
   setIState(sStart,svBuf,nPoints);
   
@@ -291,7 +307,7 @@ SteppingHelixPropagator::propagate(const SteppingHelixStateInfo& sStart,
     out = invalidState_;
     return;
   }
-  StateArray svBuf;
+  StateArray svBuf; initStateArraySHPSpecific(svBuf, true);
   int nPoints = 0;
   setIState(sStart,svBuf,nPoints);
   
@@ -321,7 +337,7 @@ SteppingHelixPropagator::propagate(const SteppingHelixStateInfo& sStart,
     out = invalidState_;
     return;
   }
-  StateArray svBuf;
+  StateArray svBuf; initStateArraySHPSpecific(svBuf, true);
   int nPoints = 0;
   setIState(sStart,svBuf,nPoints);
   

--- a/TrackPropagation/SteppingHelixPropagator/src/SteppingHelixPropagator.cc
+++ b/TrackPropagation/SteppingHelixPropagator/src/SteppingHelixPropagator.cc
@@ -1005,6 +1005,7 @@ bool SteppingHelixPropagator::makeAtomStep(SteppingHelixPropagator::StateInfo& s
       svNext.bf = bf;
       svNext.p3 = svCurrent.p3;
       svNext.isYokeVol = svCurrent.isYokeVol;
+      svNext.magVol = svCurrent.magVol;
       MatBounds rzTmp;
       dEdx = getDeDx(svNext, dEdXPrime, radX0, rzTmp);
       dP = dEdx*dS;      

--- a/TrackPropagation/SteppingHelixPropagator/test/SteppingHelixPropagatorAnalyzer.cc
+++ b/TrackPropagation/SteppingHelixPropagator/test/SteppingHelixPropagatorAnalyzer.cc
@@ -416,7 +416,7 @@ SteppingHelixPropagatorAnalyzer::analyze(const edm::Event& iEvent, const edm::Ev
 	if (radX0CorrectionMode_ ){
 	  const SteppingHelixPropagator* shPropCPtr = 
 	    dynamic_cast<const SteppingHelixPropagator*>(&*shProp);
-	  siDest = shPropCPtr->propagate(siStart, *igHit->surf);
+	  shPropCPtr->propagate(siStart, *igHit->surf,siDest);
 	  if (siDest.isValid()){
 	    siStart = siDest;
 	    siStart.getFreeState(ftsStart);

--- a/TrackingTools/TrackAssociator/src/CachedTrajectory.cc
+++ b/TrackingTools/TrackAssociator/src/CachedTrajectory.cc
@@ -80,7 +80,7 @@ void CachedTrajectory::propagate(SteppingHelixStateInfo& state, const Plane& pla
    if( const SteppingHelixPropagator* shp = dynamic_cast<const SteppingHelixPropagator*>(propagator_) )
      {
 	try {
-	   state = shp->propagate(state, plane);
+	   shp->propagate(state, plane, state);
 	}
 	catch(cms::Exception &ex){
            edm::LogWarning("TrackAssociator") << 
@@ -104,7 +104,7 @@ void CachedTrajectory::propagate(SteppingHelixStateInfo& state, const Cylinder& 
    if( const SteppingHelixPropagator* shp = dynamic_cast<const SteppingHelixPropagator*>(propagator_) )
      {
 	try {
-	   state = shp->propagate(state, cylinder);
+	   shp->propagate(state, cylinder,state);
 	}
 	catch(cms::Exception &ex){
            edm::LogWarning("TrackAssociator") << 
@@ -259,7 +259,7 @@ TrajectoryStateOnSurface CachedTrajectory::propagate(const Plane* plane)
      {
 	SteppingHelixStateInfo state;
 	try { 
-	   state = shp->propagate(fullTrajectory_[closestPointOnLeft], *plane);
+	   shp->propagate(fullTrajectory_[closestPointOnLeft], *plane, state);
 	}
 	catch(cms::Exception &ex){
            edm::LogWarning("TrackAssociator") << 


### PR DESCRIPTION
(by Chris) Removed mutables in SteppingHelixPropagator and instead put those data items on the stack when doing the operations.
