### PR TITLE
Interface for the HCAL out-of-time pileup corrections

### DIFF
--- a/CondFormats/DataRecord/interface/HcalOOTPileupCorrectionRcd.h
+++ b/CondFormats/DataRecord/interface/HcalOOTPileupCorrectionRcd.h
@@ -1,0 +1,26 @@
+#ifndef CondFormats_HcalOOTPileupCorrectionRcd_h
+#define CondFormats_HcalOOTPileupCorrectionRcd_h
+// -*- C++ -*-
+//
+// Package:     CondFormats/DataRecord
+// Class  :     HcalOOTPileupCorrectionRcd
+// 
+/**\class HcalOOTPileupCorrectionRcd HcalOOTPileupCorrectionRcd.h CondFormats/DataRecord/interface/HcalOOTPileupCorrectionRcd.h
+
+ Description: record for storing OOT pileup mitigation parameters
+
+ Usage:
+    <usage>
+
+*/
+//
+// Author:      Igor Volobouev
+// Created:     Fri Apr  4 04:57:59 CEST 2014
+//
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+
+class HcalOOTPileupCorrectionRcd : public edm::eventsetup::EventSetupRecordImplementation<HcalOOTPileupCorrectionRcd> {};
+
+#endif // CondFormats_HcalOOTPileupCorrectionRcd_h
+

--- a/CondFormats/DataRecord/src/HcalOOTPileupCorrectionRcd.cc
+++ b/CondFormats/DataRecord/src/HcalOOTPileupCorrectionRcd.cc
@@ -1,0 +1,15 @@
+// -*- C++ -*-
+//
+// Package:     CondFormats/DataRecord
+// Class  :     HcalOOTPileupCorrectionRcd
+// 
+// Implementation:
+//     [Notes on implementation]
+//
+// Author:      Igor Volobouev
+// Created:     Fri Apr  4 04:57:59 CEST 2014
+
+#include "CondFormats/DataRecord/interface/HcalOOTPileupCorrectionRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+
+EVENTSETUP_RECORD_REG(HcalOOTPileupCorrectionRcd);

--- a/CondFormats/HcalObjects/interface/HcalOOTPileupCorrectionData.h
+++ b/CondFormats/HcalObjects/interface/HcalOOTPileupCorrectionData.h
@@ -1,0 +1,40 @@
+#ifndef CondFormats_HcalObjects_HcalOOTPileupCorrectionData_h
+#define CondFormats_HcalObjects_HcalOOTPileupCorrectionData_h
+
+//
+// A storage buffer for HCAL OOT pileup corrections
+//
+// I. Volobouev, 04/03/2014
+//
+
+#include <string>
+
+class HcalOOTPileupCorrectionData
+{
+public:
+    // Constructors
+    inline HcalOOTPileupCorrectionData() {}
+    inline explicit HcalOOTPileupCorrectionData(const std::string& s) 
+        : m_buffer(s) {}
+    inline HcalOOTPileupCorrectionData(const char* c, std::size_t len)
+        : m_buffer(c, len) {}
+    inline explicit HcalOOTPileupCorrectionData(std::size_t len) 
+        : m_buffer(len, '\0') {}
+
+    // Inspectors
+    inline const std::string& str() const {return m_buffer;}
+    inline std::size_t length() const {return m_buffer.size();}
+    inline bool empty() const {return m_buffer.empty();}
+    inline const char* getBuffer() const
+        {return m_buffer.empty() ? static_cast<const char*>(0) : &m_buffer[0];}
+
+    // Modifiers
+    inline char* getBuffer() 
+        {return m_buffer.empty() ? static_cast<char*>(0) : &m_buffer[0];}
+    inline void setStr(const std::string& s) {m_buffer = s;}
+
+private:
+    std::string m_buffer;
+};
+
+#endif // CondFormats_HcalObjects_HcalOOTPileupCorrectionData_h

--- a/CondFormats/HcalObjects/src/T_EventSetup_HcalOOTPileupCorrectionData.cc
+++ b/CondFormats/HcalObjects/src/T_EventSetup_HcalOOTPileupCorrectionData.cc
@@ -1,0 +1,4 @@
+#include "CondFormats/HcalObjects/interface/HcalOOTPileupCorrectionData.h"
+#include "FWCore/Utilities/interface/typelookup.h"
+
+TYPELOOKUP_DATA_REG(HcalOOTPileupCorrectionData);

--- a/CondFormats/HcalObjects/src/classes.h
+++ b/CondFormats/HcalObjects/src/classes.h
@@ -2,6 +2,8 @@
 
 #include "CondFormats/HcalObjects/interface/AllObjects.h"
 
+#include "CondFormats/HcalObjects/interface/HcalOOTPileupCorrectionData.h"
+
 namespace CondFormats_HcalObjects {
   struct dictionary {
 
@@ -83,6 +85,8 @@ namespace CondFormats_HcalObjects {
 
     HcalTimingParams myTimingParams;
     std::vector<HcalTimingParam> myTimingParamVec;
+
+    HcalOOTPileupCorrectionData myOOTPileupCorrectionData;
   };
 }
 

--- a/CondFormats/HcalObjects/src/classes_def.xml
+++ b/CondFormats/HcalObjects/src/classes_def.xml
@@ -376,4 +376,8 @@
  </class> 
  <class name="HcalFlagHFDigiTimeParams" class_version="0"/>
 
+ <class name="HcalOOTPileupCorrectionData" class_version="0">
+  <field name="m_buffer" mapping="blob" />
+ </class>
+
 </lcgdict>   

--- a/RecoLocalCalo/HcalRecAlgos/BuildFile.xml
+++ b/RecoLocalCalo/HcalRecAlgos/BuildFile.xml
@@ -1,4 +1,5 @@
 <use   name="boost"/>
+<use   name="Alignment/Geners"/>
 <use   name="DataFormats/HcalDigi"/>
 <use   name="DataFormats/HcalRecHit"/>
 <use   name="CalibFormats/HcalObjects"/>

--- a/RecoLocalCalo/HcalRecAlgos/doc/OOTPileupCorrection_note.txt
+++ b/RecoLocalCalo/HcalRecAlgos/doc/OOTPileupCorrection_note.txt
@@ -1,0 +1,50 @@
+To develop a new OOT pileup correction class, you can proceed as follows:
+
+1) Inherit your class from AbsOOTPileupCorrection, overriding all methods
+   of the base class except "operator==" and "operator!=". Develop your
+   correction implementation.
+
+2) Insert appropriate #include and "add_reader" statements inside
+   "OOTPileupCorrectionReader.cc".
+
+3) Optionally, update "parseOOTPileupCorrection" function defined inside
+   "OOTPileupCorrectionSerializer.cc". This will allow you to create your
+   correction objects using an edm::ParameterSet.
+
+4) Serialize your correction into a "Geners" string archive and write
+   that archive into a .gssa file (no compression). If you updated
+   "parseOOTPileupCorrection" function in the previous step, this can be
+   done using the "OOTPileupCorrectionSerializer" module. See config files
+   OOTPileupCorrectionSerializer_cfi.py (in the "python" directory of the
+   RecoLocalCalo/HcalRecAlgos package) and OOTPileupCorrectionSerializer_cfg.py
+   (in the "test" directory). Alternatively, serialization can be performed
+   in combination with any other method of constructing your class, inside
+   or outside of the CMSSW framework. You can employ objects which belong
+   to different correction classes for HBHE, HO, and HF.
+
+5) Make sure that you can write your corrections into the database and
+   read them back. See files OOTPileupCorrectionDBWriter_cfg.py and
+   OOTPileupCorrectionDBReader_cfg.py in the "test" directory of the
+   RecoLocalCalo/HcalRecAlgos package. Verify that the file created by
+   the "OOTPileupCorrectionDBReader" module is identical to the file that
+   contains the original serialized archive.
+
+6) Update the configuration files for the "HcalHitReconstructor" module.
+   Parameters that might need updating are "dataOOTCorrectionName",
+   "dataOOTCorrectionCategory", "mcOOTCorrectionName", and
+   "mcOOTCorrectionCategory". You might also need to update the settings
+   of the OOTPileupCorrectionESProducer event setup module.
+
+This is it! Your corrections, stored for now in your private database, are
+ready to be applied to the CMS HCAL data. If you need to make "official"
+corrections, follow the instructions at
+https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideCondObjectsTutorial#How_to_read_write_the_data_to_th
+The steps described in the twiki page prior to this tag are already
+accomplished for you.
+
+A simple example class which has little useful functionality but plays
+nicely with the system is called "DummyOOTPileupCorrection". You can find
+it in the package RecoLocalCalo/HcalRecAlgos.
+
+Igor Volobouev
+April 2014

--- a/RecoLocalCalo/HcalRecAlgos/interface/AbsOOTPileupCorrection.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/AbsOOTPileupCorrection.h
@@ -1,0 +1,112 @@
+#ifndef RecoLocalCalo_HcalRecAlgos_AbsOOTPileupCorrection_h
+#define RecoLocalCalo_HcalRecAlgos_AbsOOTPileupCorrection_h
+
+#include <iostream>
+#include <typeinfo>
+
+#include "DataFormats/HcalDetId/interface/HcalDetId.h"
+#include "Alignment/Geners/interface/ClassId.hh"
+
+// The contents of the "BunchXParameter" class are not well
+// defined yet. Potentially, they could be as simple as 0/1 flag
+// for beam gap/normal bunch crossing or they can include bunch
+// crossing lumi data. We need to figure out how to get this
+// information.
+class BunchXParameter;
+
+class AbsOOTPileupCorrection
+{
+public:
+    inline virtual ~AbsOOTPileupCorrection() {}
+
+    // Main correction application method to be implemented by
+    // derived classes. Arguments are as follows:
+    //
+    //  id              -- HCAL detector id.
+    //
+    //  inputCharge     -- This array contains pedestal-subtracted input
+    //                     charge. Gain factors converting charge into
+    //                     energy might already be applied by the caller.
+    //                     The caler should collaborate with this class
+    //                     providing the right arguments here, depending on
+    //                     what "inputIsEnergy" method returns.
+    //
+    //  lenInputCharge  -- Length of the "inputCharge" array.
+    //
+    //  bcParams        -- Information about bunch crossings, in the order
+    //                     corresponding to "inputCharge".
+    //
+    //  lenBcParams     -- Length of the "bunchParams" array. Must not be
+    //                     less than lenInputCharge.
+    //
+    //  firstTimeSlice  -- The first time slice that will be used for energy
+    //                     reconstruction.
+    //
+    //  nTimeSlices     -- Number of time slices that will be used for energy
+    //                     reconstruction. The sum firstTimeSlice + nTimeSlices
+    //                     must not exceed lenInputCharge.
+    //
+    //  correctedCharge -- Array of corrected charges (or energies), to be
+    //                     filled on output.
+    //
+    //  lenCorrectedCharge -- Length of the "correctedCharge" array. Must not
+    //                     be less than lenInputCharge.
+    //
+    //  pulseShapeCorrApplied -- *pulseShapeCorrApplied should be set "true"
+    //                     if the algorithm effectively performs the phase-based
+    //                     amplitude correction, so that additional correction
+    //                     of this type is not needed. If additional correction
+    //                     has to be applied, this flag should be set "false".
+    //
+    //  leakCorrApplied -- *leakCorrApplied should be set "true" if the
+    //                     algorithm effectively performs a correction for
+    //                     charge leakage into the time slice before the
+    //                     first one used for energy reconstruction. If not,
+    //                     this flag should be set "false".
+    //
+    //  readjustTiming  -- *readjustTiming should be set "true" if one should
+    //                     use OOT pileup corrected energies to derive hit time.
+    //                     To use the original, uncorrected energies set this
+    //                     to "false".
+    //
+    // Some of the input arguments may be ignored by derived classes.
+    //
+    virtual void apply(const HcalDetId& id,
+                       const double* inputCharge, unsigned lenInputCharge,
+                       const BunchXParameter* bcParams, unsigned lenBcParams,
+                       unsigned firstTimeSlice, unsigned nTimeSlices,
+                       double* correctedCharge, unsigned lenCorrectedCharge,
+                       bool* pulseShapeCorrApplied, bool* leakCorrApplied,
+                       bool* readjustTiming) const = 0;
+
+    // Another method to be overriden by derived classes. This method
+    // tells whether fC -> GeV conversion should be performed before
+    // calling the "apply" method or after. If "true" is returned,
+    // it is assumed that the input is in GeV (this also takes into
+    // account potentially different gains per cap id).
+    virtual bool inputIsEnergy() const = 0;
+
+    // Comparison operators. Note that they are not virtual and should
+    // not be overriden by derived classes. These operators are very
+    // useful for I/O testing.
+    inline bool operator==(const AbsOOTPileupCorrection& r) const
+        {return (typeid(*this) == typeid(r)) && this->isEqual(r);}
+    inline bool operator!=(const AbsOOTPileupCorrection& r) const
+        {return !(*this == r);}
+
+    // I/O methods needed for writing. Must be implemented by derived classes.
+    virtual gs::ClassId classId() const = 0;
+    virtual bool write(std::ostream& of) const = 0;
+
+    // I/O methods needed for reading
+    static inline const char* classname() {return "AbsOOTPileupCorrection";}
+    static inline unsigned version() {return 1;}
+    static AbsOOTPileupCorrection* read(const gs::ClassId& id, std::istream& in);
+
+protected:
+    // Method needed to compare objects for equality.
+    // Must be implemented by derived classes.
+    virtual bool isEqual(const AbsOOTPileupCorrection&) const = 0;
+};
+
+#endif // RecoLocalCalo_HcalRecAlgos_AbsOOTPileupCorrection_h

--- a/RecoLocalCalo/HcalRecAlgos/interface/DummyOOTPileupCorrection.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/DummyOOTPileupCorrection.h
@@ -1,0 +1,57 @@
+#ifndef RecoLocalCalo_HcalRecAlgos_DummyOOTPileupCorrection_h
+#define RecoLocalCalo_HcalRecAlgos_DummyOOTPileupCorrection_h
+
+// This is a "final" class. No other classes should be derived from it.
+
+#include <string>
+
+#include "RecoLocalCalo/HcalRecAlgos/interface/AbsOOTPileupCorrection.h"
+
+class DummyOOTPileupCorrection final : public AbsOOTPileupCorrection
+{
+public:
+    // Constructor
+    inline DummyOOTPileupCorrection(const std::string& itemDescription,
+                                    const double scale)
+        : descr_(itemDescription), scale_(scale) {}
+
+    // Destructor
+    inline ~DummyOOTPileupCorrection() {}
+
+    // Inspectors
+    inline const std::string& description() const {return descr_;}
+    inline double getScale() const {return scale_;}
+
+    // Main correction function
+    void apply(const HcalDetId& id,
+               const double* inputCharge, unsigned lenInputCharge,
+               const BunchXParameter* bcParams, unsigned lenBcParams,
+               unsigned firstTimeSlice, unsigned nTimeSlices,
+               double* correctedCharge, unsigned lenCorrectedCharge,
+               bool* pulseShapeCorrApplied, bool* leakCorrApplied,
+               bool* readjustTiming) const;
+
+    // Are we using charge or energy?
+    inline bool inputIsEnergy() const {return false;}
+
+    // Methods related to I/O
+    inline gs::ClassId classId() const {return gs::ClassId(*this);}
+    bool write(std::ostream& of) const;
+
+    static inline const char* classname() {return "DummyOOTPileupCorrection";}
+    static inline unsigned version() {return 1;}
+    static DummyOOTPileupCorrection* read(const gs::ClassId& id,
+                                          std::istream& in);
+protected:
+    // Comparison function must be implemented
+    bool isEqual(const AbsOOTPileupCorrection& otherBase) const;
+
+private:
+    // Disable default constructor
+    DummyOOTPileupCorrection();
+
+    std::string descr_;
+    double scale_;
+};
+
+#endif // RecoLocalCalo_HcalRecAlgos_DummyOOTPileupCorrection_h

--- a/RecoLocalCalo/HcalRecAlgos/interface/GenersHomogeneousESProducer.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/GenersHomogeneousESProducer.h
@@ -1,0 +1,129 @@
+#ifndef RecoLocalCalo_HcalRecAlgos_GenersHomogeneousESProducer_h
+#define RecoLocalCalo_HcalRecAlgos_GenersHomogeneousESProducer_h
+
+// -*- C++ -*-
+//
+// Package:    RecoLocalCalo/HcalRecAlgos
+// Class:      GenersHomogeneousESProducer
+// 
+/**\class GenersHomogeneousESProducer GenersHomogeneousESProducer.h RecoLocalCalo/HcalRecAlgos/interface/GenersHomogeneousESProducer.h
+
+ Description: producer for homogeneous Geners archives
+
+ Implementation:
+     A collection of homogeneous objects in a Geners archive
+     (presumably retrieved from a database) is deserialized and
+     placed into a double map with const index access (i.e., an
+     exception will be thrown if a non-existent index is used
+     with operator[]).
+
+     When the objects are retrieved from the archive, they are
+     filtered on their name and category with the usual Geners
+     search facilities.
+*/
+//
+// Original Author:  Igor Volobouev
+//         Created:  Fri Apr  4 05:24:31 CEST 2014
+//
+//
+
+
+// system include files
+#include <memory>
+#include <sstream>
+#include <utility>
+
+#include "boost/shared_ptr.hpp"
+
+// user include files
+#include "FWCore/Framework/interface/ModuleFactory.h"
+#include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/Framework/interface/ESTransientHandle.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "CondFormats/HcalObjects/interface/HcalOOTPileupCorrectionData.h"
+#include "JetMETCorrections/FFTJetObjects/interface/FFTJetDict.h"
+#include "Alignment/Geners/interface/Reference.hh"
+#include "Alignment/Geners/interface/StringArchive.hh"
+
+//
+// class declaration
+//
+template<typename DataType, class RecordType>
+class GenersHomogeneousESProducer : public edm::ESProducer
+{
+public:
+    GenersHomogeneousESProducer(const edm::ParameterSet&);
+    inline virtual ~GenersHomogeneousESProducer() {}
+
+    typedef DataType data_type;
+    typedef RecordType record_type;
+    typedef boost::shared_ptr<DataType> DataPtr;
+    typedef FFTJetDict<std::string,FFTJetDict<std::string,DataPtr> > DataMap;
+    typedef boost::shared_ptr<DataMap> ReturnType;
+
+    ReturnType produce(const RecordType&);
+
+private:
+    // ----------member data ---------------------------
+    gs::SearchSpecifier nameSearch_;
+    gs::SearchSpecifier categorySearch_;
+
+    static void insertDictItem(DataMap& seq, DataPtr fptr,
+                               const std::string& name,
+                               const std::string& category);
+};
+
+//
+// constructor
+//
+template<typename DataType, class RecordType>
+GenersHomogeneousESProducer<DataType,RecordType>::GenersHomogeneousESProducer(
+    const edm::ParameterSet& ps)
+    : nameSearch_(ps.getParameter<std::string>("name"),
+                  ps.getParameter<bool>("nameIsRegex")),
+      categorySearch_(ps.getParameter<std::string>("category"),
+                      ps.getParameter<bool>("categoryIsRegex"))
+{
+   //the following line is needed to tell the framework what
+   // data is being produced
+   setWhatProduced(this);
+}
+
+
+// ------------ method called to produce the data  ------------
+template<typename DataType, class RecordType>
+typename GenersHomogeneousESProducer<DataType,RecordType>::ReturnType
+GenersHomogeneousESProducer<DataType,RecordType>::produce(const RecordType& iRecord)
+{
+    edm::ESTransientHandle<HcalOOTPileupCorrectionData> parHandle;
+    iRecord.get(parHandle);
+
+    std::istringstream is(parHandle->str());
+    CPP11_auto_ptr<gs::StringArchive> ar(gs::read_item<gs::StringArchive>(is));
+    gs::Reference<DataType> ref(*ar, nameSearch_, categorySearch_);
+    ReturnType result(new DataMap());
+    const unsigned long nFound = ref.size();
+    for (unsigned long i=0; i<nFound; ++i)
+    {
+        CPP11_shared_ptr<const gs::CatalogEntry> e(ref.indexedCatalogEntry(i));
+        CPP11_auto_ptr<DataType> pdata = ref.get(i);
+        DataPtr shared(pdata.release());
+        insertDictItem(*result, shared, e->name(), e->category());
+    }
+    return result;
+}
+
+
+template<typename DataType, class RecordType>
+void GenersHomogeneousESProducer<DataType,RecordType>::insertDictItem(
+    DataMap& seq, DataPtr fptr,
+    const std::string& name, const std::string& category)
+{
+    typename DataMap::iterator it = seq.find(category);
+    if (it == seq.end())
+        it = seq.insert(std::make_pair(
+             category, FFTJetDict<std::string,DataPtr>())).first;
+    it->second.insert(std::make_pair(name, fptr));
+}
+
+#endif // RecoLocalCalo_HcalRecAlgos_GenersHomogeneousESProducer_h

--- a/RecoLocalCalo/HcalRecAlgos/interface/HcalSimpleRecAlgo.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HcalSimpleRecAlgo.h
@@ -1,6 +1,9 @@
 #ifndef HCALSIMPLERECALGO_H
 #define HCALSIMPLERECALGO_H 1
 
+#include <memory>
+#include "boost/shared_ptr.hpp"
+
 #include "DataFormats/HcalDigi/interface/HcalUpgradeDataFrame.h"
 #include "DataFormats/HcalDigi/interface/HBHEDataFrame.h"
 #include "DataFormats/HcalDigi/interface/HFDataFrame.h"
@@ -15,7 +18,7 @@
 #include "CalibFormats/HcalObjects/interface/HcalCoder.h"
 #include "CalibFormats/HcalObjects/interface/HcalCalibrations.h"
 #include "CalibCalorimetry/HcalAlgos/interface/HcalPulseContainmentManager.h"
-#include <memory>
+#include "RecoLocalCalo/HcalRecAlgos/interface/AbsOOTPileupCorrection.h"
 
 /** \class HcalSimpleRecAlgo
 
@@ -33,8 +36,10 @@ public:
   /** Full featured constructor for HB/HE and HO (HPD-based detectors) */
   HcalSimpleRecAlgo(bool correctForTimeslew, 
 		    bool correctForContainment, float fixedPhaseNs);
+
   /** Simple constructor for PMT-based detectors */
   HcalSimpleRecAlgo();
+
   void beginRun(edm::EventSetup const & es);
   void endRun();
 
@@ -45,8 +50,19 @@ public:
 
   // ugly hack related to HB- e-dependent corrections
   void setForData(int runnum);
+
   // usage of leak correction 
   void setLeakCorrection();
+
+  // set OOT pileup corrections
+  void setHBHEPileupCorrection(boost::shared_ptr<AbsOOTPileupCorrection> corr);
+  void setHFPileupCorrection(boost::shared_ptr<AbsOOTPileupCorrection> corr);
+  void setHOPileupCorrection(boost::shared_ptr<AbsOOTPileupCorrection> corr);
+
+  // Set bunch crossing information.
+  // This object will not manage the pointer.
+  void setBXInfo(const BunchXParameter* info, unsigned lenInfo);
+
 
   HBHERecHit reconstruct(const HBHEDataFrame& digi, int first, int toadd, const HcalCoder& coder, const HcalCalibrations& calibs) const;
   HBHERecHit reconstructHBHEUpgrade(const HcalUpgradeDataFrame& digi,  int first, int toadd, const HcalCoder& coder, const HcalCalibrations& calibs) const;
@@ -58,7 +74,6 @@ public:
   HcalCalibRecHit reconstruct(const HcalCalibDataFrame& digi,  int first, int toadd, const HcalCoder& coder, const HcalCalibrations& calibs) const;
 
 
-
 private:
   bool correctForTimeslew_;
   bool correctForPulse_;
@@ -67,6 +82,11 @@ private:
   int runnum_;  // data run numer
   bool setLeakCorrection_;
   int pileupCleaningID_;
+  const BunchXParameter* bunchCrossingInfo_;
+  unsigned lenBunchCrossingInfo_;
+  boost::shared_ptr<AbsOOTPileupCorrection> hbhePileupCorr_;
+  boost::shared_ptr<AbsOOTPileupCorrection> hfPileupCorr_;
+  boost::shared_ptr<AbsOOTPileupCorrection> hoPileupCorr_;
 };
 
 #endif

--- a/RecoLocalCalo/HcalRecAlgos/interface/OOTPileupCorrectionReader.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/OOTPileupCorrectionReader.h
@@ -1,0 +1,19 @@
+#ifndef RecoLocalCalo_HcalRecAlgos_OOTPileupCorrectionReader_h
+#define RecoLocalCalo_HcalRecAlgos_OOTPileupCorrectionReader_h
+
+#include "Alignment/Geners/interface/AbsReader.hh"
+#include "RecoLocalCalo/HcalRecAlgos/interface/AbsOOTPileupCorrection.h"
+
+// Note that the folowing class does not have any public constructors.
+// All application usage is through the gs::StaticReader wrapper.
+//
+class OOTPileupCorrectionReader : public gs::DefaultReader<AbsOOTPileupCorrection>
+{
+    typedef gs::DefaultReader<AbsOOTPileupCorrection> Base;
+    friend class gs::StaticReader<OOTPileupCorrectionReader>;
+    OOTPileupCorrectionReader();
+};
+
+typedef gs::StaticReader<OOTPileupCorrectionReader> StaticOOTPileupCorrectionReader;
+
+#endif // RecoLocalCalo_HcalRecAlgos_OOTPileupCorrectionReader_h

--- a/RecoLocalCalo/HcalRecAlgos/interface/OOTPileupCorrectionTypedefs.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/OOTPileupCorrectionTypedefs.h
@@ -1,0 +1,12 @@
+#ifndef RecoLocalCalo_HcalRecAlgos_OOTPileupCorrectionTypedefs_h
+#define RecoLocalCalo_HcalRecAlgos_OOTPileupCorrectionTypedefs_h
+
+#include "CondFormats/DataRecord/interface/HcalOOTPileupCorrectionRcd.h"
+#include "RecoLocalCalo/HcalRecAlgos/interface/AbsOOTPileupCorrection.h"
+#include "RecoLocalCalo/HcalRecAlgos/interface/GenersHomogeneousESProducer.h"
+
+typedef GenersHomogeneousESProducer<AbsOOTPileupCorrection,HcalOOTPileupCorrectionRcd> OOTPileupCorrectionESProducer;
+
+typedef typename OOTPileupCorrectionESProducer::ReturnType::element_type OOTPileupCorrectionTable;
+
+#endif // RecoLocalCalo_HcalRecAlgos_OOTPileupCorrectionTypedefs_h

--- a/RecoLocalCalo/HcalRecAlgos/interface/rawEnergy.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/rawEnergy.h
@@ -1,0 +1,104 @@
+#ifndef RecoLocalCalo_HcalRecAlgos_rawEnergy_h
+#define RecoLocalCalo_HcalRecAlgos_rawEnergy_h
+
+#include "Alignment/Geners/interface/IOIsClassType.hh"
+
+namespace HcalRecAlgosPrivate {
+    template <typename T>
+    class HasRawEnergySetterHelper
+    {
+    private:
+        template<void (T::*)(float)> struct tester;
+        typedef char One;
+        typedef struct {char a[2];} Two;
+        template<typename C> static One test(tester<&C::setRawEnergy>*);
+        template<typename C> static Two test(...);
+
+    public:
+        enum {value = sizeof(HasRawEnergySetterHelper<T>::template test<T>(0)) == 1};
+    };
+
+    template<typename T, bool is_class_type=gs::IOIsClassType<T>::value>
+    struct HasRawEnergySetter
+    {
+        enum {value = false};
+    };    
+
+    template<typename T>
+    struct HasRawEnergySetter<T, true>
+    {
+        enum {value = HasRawEnergySetterHelper<T>::value};
+    };
+
+    template<typename T, bool>
+    struct RawEnergySetter
+    {
+        inline static void setRawEnergy(T&, float) {}
+    };
+
+    template<typename T>
+    struct RawEnergySetter<T, true>
+    {
+        inline static void setRawEnergy(T& h, float e) {h.setRawEnergy(e);}
+    };
+
+    template <typename T>
+    class HasRawEnergyGetterHelper
+    {
+    private:
+        template<float (T::*)() const> struct tester;
+        typedef char One;
+        typedef struct {char a[2];} Two;
+        template<typename C> static One test(tester<&C::eraw>*);
+        template<typename C> static Two test(...);
+
+    public:
+        enum {value = sizeof(HasRawEnergyGetterHelper<T>::template test<T>(0)) == 1};
+    };
+
+    template<typename T, bool is_class_type=gs::IOIsClassType<T>::value>
+    struct HasRawEnergyGetter
+    {
+        enum {value = false};
+    };    
+
+    template<typename T>
+    struct HasRawEnergyGetter<T, true>
+    {
+        enum {value = HasRawEnergyGetterHelper<T>::value};
+    };
+
+    template<typename T, bool>
+    struct RawEnergyGetter
+    {
+        inline static float getRawEnergy(const T&, float v) {return v;}
+    };
+
+    template<typename T>
+    struct RawEnergyGetter<T, true>
+    {
+        inline static float getRawEnergy(const T& h, float) {return h.eraw();}
+    };
+}
+
+// Function for setting the raw energy in a code templated
+// upon the rechit type. The function call will be ignored
+// in case the HcalRecHit type does not have a member function
+// "void setRawEnergy(float)".
+template <typename HcalRecHit>
+inline void setRawEnergy(HcalRecHit& h, float e)
+{
+    HcalRecAlgosPrivate::RawEnergySetter<HcalRecHit,HcalRecAlgosPrivate::HasRawEnergySetter<HcalRecHit>::value>::setRawEnergy(h, e);
+}
+
+// Function for getting the raw energy in a code templated
+// upon the rechit type. This function will return "valueIfNoSuchMember"
+// in case the HcalRecHit type does not have a member function
+// "float eraw() const".
+template <typename HcalRecHit>
+inline float getRawEnergy(const HcalRecHit& h, float valueIfNoSuchMember=-1.0e20)
+{
+    return HcalRecAlgosPrivate::RawEnergyGetter<HcalRecHit,HcalRecAlgosPrivate::HasRawEnergyGetter<HcalRecHit>::value>::getRawEnergy(h, valueIfNoSuchMember);
+}
+
+#endif // RecoLocalCalo_HcalRecAlgos_rawEnergy_h

--- a/RecoLocalCalo/HcalRecAlgos/plugins/BuildFile.xml
+++ b/RecoLocalCalo/HcalRecAlgos/plugins/BuildFile.xml
@@ -1,7 +1,11 @@
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/PluginManager"/>
 <use   name="FWCore/ParameterSet"/>
+<use   name="CondCore/PluginSystem"/>
+<use   name="CondCore/ESSources"/>
 <use   name="RecoLocalCalo/HcalRecAlgos"/>
+<use   name="CondFormats/DataRecord"/>
+<use   name="CondFormats/HcalObjects"/>
 <library   file="*.cc" name="RecoLocalCaloHcalRecAlgosPlugin">
   <flags   EDM_PLUGIN="1"/>
 </library>

--- a/RecoLocalCalo/HcalRecAlgos/plugins/OOTPileupCorrectionDBReader.cc
+++ b/RecoLocalCalo/HcalRecAlgos/plugins/OOTPileupCorrectionDBReader.cc
@@ -1,0 +1,114 @@
+// -*- C++ -*-
+//
+// Package:    RecoLocalCalo/HcalRecAlgos
+// Class:      OOTPileupCorrectionDBReader
+// 
+/**\class OOTPileupCorrectionDBReader OOTPileupCorrectionDBReader.cc RecoLocalCalo/HcalRecAlgos/plugins/OOTPileupCorrectionDBReader.cc
+
+ Description: gets a blob from a database and writes it into a file
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author:  Igor Volobouev
+//         Created:  Fri Apr  4 05:40:18 CEST 2014
+//
+//
+
+#include <iostream>
+#include <sstream>
+#include <fstream>
+
+#include "Alignment/Geners/interface/StringArchive.hh"
+#include "Alignment/Geners/interface/CompressedIO.hh"
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "CondFormats/HcalObjects/interface/HcalOOTPileupCorrectionData.h"
+#include "CondFormats/DataRecord/interface/HcalOOTPileupCorrectionRcd.h"
+
+//
+// class declaration
+//
+class OOTPileupCorrectionDBReader : public edm::EDAnalyzer
+{
+public:
+    explicit OOTPileupCorrectionDBReader(const edm::ParameterSet&);
+    virtual ~OOTPileupCorrectionDBReader() {}
+
+private:
+    OOTPileupCorrectionDBReader();
+    OOTPileupCorrectionDBReader(const OOTPileupCorrectionDBReader&);
+    OOTPileupCorrectionDBReader& operator=(const OOTPileupCorrectionDBReader&);
+
+    virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+
+    std::string outputFile_;
+    bool dumpMetadata_;
+};
+
+OOTPileupCorrectionDBReader::OOTPileupCorrectionDBReader(const edm::ParameterSet& ps)
+    : outputFile_(ps.getParameter<std::string>("outputFile")),
+      dumpMetadata_(ps.getUntrackedParameter<bool>("dumpMetadata", true))
+{
+}
+
+void OOTPileupCorrectionDBReader::analyze(const edm::Event& iEvent,
+                                          const edm::EventSetup& iSetup)
+{
+    edm::ESHandle<HcalOOTPileupCorrectionData> p;
+    iSetup.get<HcalOOTPileupCorrectionRcd>().get(p);
+
+    if (dumpMetadata_)
+    {
+        // Dump info about archive contents
+        std::istringstream is(p->str());
+        CPP11_auto_ptr<gs::StringArchive> par = gs::read_item<gs::StringArchive>(is);
+        const unsigned long long idSmall = par->smallestId();
+        if (!idSmall)
+            std::cout << "++++ No valid records in the archive" << std::endl;
+        else
+        {
+            std::cout << "++++ Archive metadata begins" << std::endl;
+            const unsigned long long idLarge = par->largestId();
+            unsigned long long count = 0;
+            for (unsigned long long id = idSmall; id <= idLarge; ++id)
+                if (par->itemExists(id))
+                {
+                    CPP11_shared_ptr<const gs::CatalogEntry> e = 
+                        par->catalogEntry(id);
+                    std::cout << '\n';
+                    e->humanReadable(std::cout);
+                    ++count;
+                }
+            std::cout << "\n++++ Archive metadata ends, "
+                      << count << " items total" << std::endl;
+        }
+    }
+
+    if (!outputFile_.empty())
+    {
+        std::ofstream of(outputFile_.c_str(), std::ios_base::binary);
+        if (!of.is_open())
+            throw cms::Exception("InvalidArgument")
+                << "Failed to open file \"" << outputFile_ << '"' << std::endl;
+        if (!p->empty())
+        {
+            of.write(p->getBuffer(), p->length());
+            if (of.fail())
+                throw cms::Exception("SystemError")
+                    << "Output stream failure while writing file \""
+                    << outputFile_ << '"' << std::endl;
+        }
+    }
+}
+
+DEFINE_FWK_MODULE(OOTPileupCorrectionDBReader);

--- a/RecoLocalCalo/HcalRecAlgos/plugins/OOTPileupCorrectionDBWriter.cc
+++ b/RecoLocalCalo/HcalRecAlgos/plugins/OOTPileupCorrectionDBWriter.cc
@@ -1,0 +1,104 @@
+// -*- C++ -*-
+//
+// Package:    JetMETCorrections/FFTJetModules
+// Class:      OOTPileupCorrectionDBWriter
+// 
+/**\class OOTPileupCorrectionDBWriter OOTPileupCorrectionDBWriter.cc JetMETCorrections/FFTJetModules/plugins/OOTPileupCorrectionDBWriter.cc
+
+ Description: writes a blob from a file into a database
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author:  Igor Volobouev
+//         Created:  Wed Aug  1 20:59:12 CDT 2012
+//
+//
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <cassert>
+#include <fstream>
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "CondFormats/HcalObjects/interface/HcalOOTPileupCorrectionData.h"
+#include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
+
+#define init_param(type, varname) varname (ps.getParameter< type >( #varname ))
+
+//
+// class declaration
+//
+class OOTPileupCorrectionDBWriter : public edm::EDAnalyzer
+{
+public:
+    explicit OOTPileupCorrectionDBWriter(const edm::ParameterSet&);
+    virtual ~OOTPileupCorrectionDBWriter() {}
+
+private:
+    OOTPileupCorrectionDBWriter();
+    OOTPileupCorrectionDBWriter(const OOTPileupCorrectionDBWriter&);
+    OOTPileupCorrectionDBWriter& operator=(const OOTPileupCorrectionDBWriter&);
+
+    virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+
+    std::string inputFile;
+    std::string record;
+};
+
+OOTPileupCorrectionDBWriter::OOTPileupCorrectionDBWriter(const edm::ParameterSet& ps)
+    : init_param(std::string, inputFile),
+      init_param(std::string, record)
+{
+}
+
+void OOTPileupCorrectionDBWriter::analyze(const edm::Event& iEvent,
+                                      const edm::EventSetup& iSetup)
+{
+    std::auto_ptr<HcalOOTPileupCorrectionData> fcp;
+
+    {
+        std::ifstream input(inputFile.c_str(), std::ios_base::binary);
+        if (!input.is_open())
+            throw cms::Exception("InvalidArgument")
+                << "Failed to open file \"" << inputFile << '"' << std::endl;
+
+        struct stat st;
+        if (stat(inputFile.c_str(), &st))
+            throw cms::Exception("SystemError")
+                << "Failed to stat file \"" << inputFile << '"' << std::endl;
+
+        const std::size_t len = st.st_size;
+        fcp = std::auto_ptr<HcalOOTPileupCorrectionData>(
+            new HcalOOTPileupCorrectionData(len));
+        assert(fcp->length() == len);
+        if (len)
+            input.read(fcp->getBuffer(), len);
+        if (input.fail())
+            throw cms::Exception("SystemError")
+                << "Input stream failure while reading file \""
+                << inputFile << '"' << std::endl;
+    }
+
+    edm::Service<cond::service::PoolDBOutputService> poolDbService;
+    if (poolDbService.isAvailable())
+        poolDbService->writeOne(fcp.release(),
+                                poolDbService->currentTime(),
+                                record);
+    else
+        throw cms::Exception("ConfigurationError")
+            << "PoolDBOutputService is not available, "
+            << "please configure it properly" << std::endl;
+}
+
+DEFINE_FWK_MODULE(OOTPileupCorrectionDBWriter);

--- a/RecoLocalCalo/HcalRecAlgos/plugins/OOTPileupCorrectionESProducer.cc
+++ b/RecoLocalCalo/HcalRecAlgos/plugins/OOTPileupCorrectionESProducer.cc
@@ -1,0 +1,21 @@
+// -*- C++ -*-
+//
+// Package:    RecoLocalCalo/HcalRecAlgos
+// Class:      OOTPileupCorrectionESProducer
+// 
+/**\class OOTPileupCorrectionESProducer OOTPileupCorrectionESProducer.cc RecoLocalCalo/HcalRecAlgos/plugins/OOTPileupCorrectionESProducer.cc
+
+ Description: producer for classes derived from AbsOOTPileupCorrection
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author:  Igor Volobouev
+//         Created:  Fri Apr  4 05:42:28 CEST 2014
+//
+//
+
+#include "RecoLocalCalo/HcalRecAlgos/interface/OOTPileupCorrectionTypedefs.h"
+
+DEFINE_FWK_EVENTSETUP_MODULE(OOTPileupCorrectionESProducer);

--- a/RecoLocalCalo/HcalRecAlgos/plugins/OOTPileupCorrectionSerializer.cc
+++ b/RecoLocalCalo/HcalRecAlgos/plugins/OOTPileupCorrectionSerializer.cc
@@ -1,0 +1,207 @@
+// -*- C++ -*-
+//
+// Package:    RecoLocalCalo/HcalRecAlgos
+// Class:      OOTPileupCorrectionSerializer
+// 
+/**\class OOTPileupCorrectionSerializer OOTPileupCorrectionSerializer.cc RecoLocalCalo/HcalRecAlgos/plugins/OOTPileupCorrectionSerializer.cc
+
+ Description: [one line class summary]
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author:  Igor Volobouev
+//         Created:  Fri Apr  4 05:42:57 CEST 2014
+//
+//
+
+
+// system include files
+#include <memory>
+#include <fstream>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include "Alignment/Geners/interface/Record.hh"
+#include "Alignment/Geners/interface/Reference.hh"
+#include "Alignment/Geners/interface/StringArchive.hh"
+#include "Alignment/Geners/interface/IOException.hh"
+
+// Include headers for all subclasses of AbsOOTPileupCorrection
+#include "RecoLocalCalo/HcalRecAlgos/interface/DummyOOTPileupCorrection.h"
+
+
+//
+// Parser for the AbsOOTPileupCorrection subclasses.
+//
+// Do not use parameters called "name" and "category" -- these
+// are reserved for the archive catalog.
+//
+static std::unique_ptr<AbsOOTPileupCorrection> parseOOTPileupCorrection(
+    const edm::ParameterSet& ps)
+{
+    typedef std::unique_ptr<AbsOOTPileupCorrection> Result;
+
+    const std::string& correctionType = ps.getParameter<std::string>("Class");
+
+    if (!correctionType.compare("DummyOOTPileupCorrection"))
+        return Result(new DummyOOTPileupCorrection(
+                          ps.getParameter<std::string>("description"),
+                          ps.getParameter<double>("scale")));
+
+    else
+        throw cms::Exception("BadConfig")
+            << "In parseOOTPileupCorrection: unknown correction type \""
+            << correctionType << "\"\n";
+}
+
+
+//
+// class declaration
+//
+class OOTPileupCorrectionSerializer : public edm::EDAnalyzer 
+{
+public:
+    explicit OOTPileupCorrectionSerializer(const edm::ParameterSet&);
+    ~OOTPileupCorrectionSerializer();
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+    virtual void beginJob() override;
+    virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+    virtual void endJob() override;
+};
+
+//
+// constructors and destructor
+//
+OOTPileupCorrectionSerializer::OOTPileupCorrectionSerializer(const edm::ParameterSet& ps)
+{
+    const std::vector<edm::ParameterSet>& corrs = ps.getParameter<
+        std::vector<edm::ParameterSet> >("corrections");
+    const unsigned nCors = corrs.size();
+    if (nCors)
+    {
+        const bool verify = ps.getUntrackedParameter<bool>("verify", true);
+
+        const std::string& outputFile = ps.getParameter<std::string>("outputFile");
+        std::ofstream of(outputFile.c_str(), std::ios_base::binary);
+        if (!of.is_open())
+            throw gs::IOOpeningFailure("OOTPileupCorrectionSerializer", outputFile);
+
+        // Iterate over corrections
+        gs::StringArchive ar;
+        for (unsigned i=0; i<nCors; ++i)
+        {
+            const std::string& name = corrs[i].getParameter<std::string>("name");
+            const std::string& cat = corrs[i].getParameter<std::string>("category");
+            std::unique_ptr<AbsOOTPileupCorrection> p(parseOOTPileupCorrection(corrs[i]));
+            ar << gs::Record(*p, name.c_str(), cat.c_str());
+
+            if (verify)                
+            {
+                const unsigned long long itemId = ar.lastItemId();
+                gs::Reference<AbsOOTPileupCorrection> ref(ar, itemId);
+                assert(ref.unique());
+                CPP11_auto_ptr<AbsOOTPileupCorrection> readback(ref.get(0));
+                if (*readback != *p)
+                    throw gs::IOInvalidData("In OOTPileupCorrectionSerializer: "
+                                            "readback verification failure");
+            }
+        }
+        ar.flush();
+        if (!gs::write_item(of, ar))
+            throw cms::Exception("SystemError")
+                << "In OOTPileupCorrectionSerializer: failed to write into file \""
+                << outputFile << "\"\n";
+    }
+}
+
+
+OOTPileupCorrectionSerializer::~OOTPileupCorrectionSerializer()
+{
+ 
+   // do anything here that needs to be done at desctruction time
+   // (e.g. close files, deallocate resources etc.)
+
+}
+
+
+//
+// member functions
+//
+
+// ------------ method called for each event  ------------
+void
+OOTPileupCorrectionSerializer::analyze(const edm::Event& /* iEvent */,
+                                       const edm::EventSetup& /* iSetup */)
+{
+}
+
+
+// ------------ method called once each job just before starting event loop  ------------
+void 
+OOTPileupCorrectionSerializer::beginJob()
+{
+}
+
+// ------------ method called once each job just after ending the event loop  ------------
+void 
+OOTPileupCorrectionSerializer::endJob() 
+{
+}
+
+// ------------ method called when starting to processes a run  ------------
+/*
+void 
+OOTPileupCorrectionSerializer::beginRun(edm::Run const&, edm::EventSetup const&)
+{
+}
+*/
+
+// ------------ method called when ending the processing of a run  ------------
+/*
+void 
+OOTPileupCorrectionSerializer::endRun(edm::Run const&, edm::EventSetup const&)
+{
+}
+*/
+
+// ------------ method called when starting to processes a luminosity block  ------------
+/*
+void 
+OOTPileupCorrectionSerializer::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
+{
+}
+*/
+
+// ------------ method called when ending the processing of a luminosity block  ------------
+/*
+void 
+OOTPileupCorrectionSerializer::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
+{
+}
+*/
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void
+OOTPileupCorrectionSerializer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(OOTPileupCorrectionSerializer);

--- a/RecoLocalCalo/HcalRecAlgos/plugins/plugin.cc
+++ b/RecoLocalCalo/HcalRecAlgos/plugins/plugin.cc
@@ -1,0 +1,6 @@
+#include "CondCore/ESSources/interface/registration_macros.h"
+
+#include "CondFormats/HcalObjects/interface/HcalOOTPileupCorrectionData.h"
+#include "CondFormats/DataRecord/interface/HcalOOTPileupCorrectionRcd.h"
+
+REGISTER_PLUGIN(HcalOOTPileupCorrectionRcd, HcalOOTPileupCorrectionData);

--- a/RecoLocalCalo/HcalRecAlgos/python/OOTPileupCorrectionESProducer_cfi.py
+++ b/RecoLocalCalo/HcalRecAlgos/python/OOTPileupCorrectionESProducer_cfi.py
@@ -1,0 +1,13 @@
+import FWCore.ParameterSet.Config as cms
+
+#
+# The following settings load all correction classes
+# stored in the database
+#
+OOTPileupCorrectionESProducer = cms.ESProducer(
+    'OOTPileupCorrectionESProducer',
+    name = cms.string(".*"),
+    nameIsRegex = cms.bool(True),
+    category = cms.string(".*"),
+    categoryIsRegex = cms.bool(True)
+)

--- a/RecoLocalCalo/HcalRecAlgos/python/OOTPileupCorrectionSerializer_cfi.py
+++ b/RecoLocalCalo/HcalRecAlgos/python/OOTPileupCorrectionSerializer_cfi.py
@@ -1,0 +1,52 @@
+import FWCore.ParameterSet.Config as cms
+
+ootPileupCorrectionSerializer = cms.EDAnalyzer(
+    "OOTPileupCorrectionSerializer",
+    #
+    # The output file will contain a generic serialization string
+    # archive (GSSA). The contents will be subsequently compressed
+    # by the database anyway, so we do not compress the archive here.
+    outputFile = cms.string("ootPileupCorrection.gssa"),
+    #
+    # Correction specs. Each correction is specified by
+    # a PSet. Each of these PSets must define string parameters
+    # "Class", "name", and "category". Depending on the class,
+    # other parameters may be necessary. The corrections are built
+    # out of the parameter sets by the "parseOOTPileupCorrection"
+    # finction defined inside "OOTPileupCorrectionSerializer.cc".
+    #
+    # Note that default category names in the HcalHitReconstructor
+    # config files are "DataOOTPileupCorrections" for data corrections
+    # and "MCOOTPileupCorrections" for MC corrections.
+    #
+    corrections = cms.VPSet(
+        cms.PSet(
+            Class = cms.string("DummyOOTPileupCorrection"),
+            name = cms.string("Dummy"),
+            category = cms.string("Example"),
+            description = cms.string("This correction does not change anything"),
+            scale = cms.double(1.0)
+        ),
+        cms.PSet(
+            Class = cms.string("DummyOOTPileupCorrection"),
+            name = cms.string("HF"),
+            category = cms.string("OOTPileupCorrections"),
+            description = cms.string("Multiplies all charge by a factor of 3"),
+            scale = cms.double(3.0)
+        ),
+        cms.PSet(
+            Class = cms.string("DummyOOTPileupCorrection"),
+            name = cms.string("HO"),
+            category = cms.string("OOTPileupCorrections"),
+            description = cms.string("Multiplies all charge by a factor of 1/2"),
+            scale = cms.double(0.5)
+        ),
+        cms.PSet(
+            Class = cms.string("DummyOOTPileupCorrection"),
+            name = cms.string("HBHE"),
+            category = cms.string("OOTPileupCorrections"),
+            description = cms.string("Multiplies all charge by a factor of 5"),
+            scale = cms.double(5.0)
+        )
+    )
+)

--- a/RecoLocalCalo/HcalRecAlgos/src/AbsOOTPileupCorrection.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/AbsOOTPileupCorrection.cc
@@ -1,0 +1,7 @@
+#include "RecoLocalCalo/HcalRecAlgos/interface/OOTPileupCorrectionReader.h"
+
+AbsOOTPileupCorrection* AbsOOTPileupCorrection::read(const gs::ClassId& id,
+                                                     std::istream& in)
+{
+    return StaticOOTPileupCorrectionReader::instance().read(id, in);
+}

--- a/RecoLocalCalo/HcalRecAlgos/src/DummyOOTPileupCorrection.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/DummyOOTPileupCorrection.cc
@@ -1,0 +1,77 @@
+#include "RecoLocalCalo/HcalRecAlgos/interface/DummyOOTPileupCorrection.h"
+
+#include "Alignment/Geners/interface/binaryIO.hh"
+#include "Alignment/Geners/interface/IOException.hh"
+
+void DummyOOTPileupCorrection::apply(
+    const HcalDetId& /* id */,
+    const double* inputCharge, const unsigned lenInputCharge,
+    const BunchXParameter* /* bcParams */, unsigned /* lenBcParams */,
+    unsigned /* firstTimeSlice */, unsigned /* nTimeSlices */,
+    double* correctedCharge, const unsigned lenCorrectedCharge,
+    bool* pulseShapeCorrApplied, bool* leakCorrApplied,
+    bool* readjustTiming) const
+{
+    // Check the arguments
+    if (inputCharge == 0 || correctedCharge == 0 ||
+        lenCorrectedCharge < lenInputCharge ||
+        pulseShapeCorrApplied == 0 || leakCorrApplied == 0 ||
+        readjustTiming == 0)
+        throw cms::Exception("InvalidArgument")
+            << "Invalid arguments in DummyOOTPileupCorrection::apply\n";
+
+    // Perform the correction
+    for (unsigned i=0; i<lenInputCharge; ++i)
+        correctedCharge[i] = scale_ * inputCharge[i];
+
+    // Tell the code that runs after this which additional
+    // corrections should be discarded
+    *pulseShapeCorrApplied = false;
+    *leakCorrApplied = false;
+
+    // Tell the code that runs after this whether corrected
+    // amplitudes should be used for timing calculations
+    *readjustTiming = false;
+}
+
+bool DummyOOTPileupCorrection::write(std::ostream& of) const
+{
+    gs::write_string(of, descr_);
+    gs::write_pod(of, scale_);
+    return !of.fail();
+}
+
+DummyOOTPileupCorrection* DummyOOTPileupCorrection::read(const gs::ClassId& id,
+                                                         std::istream& in)
+{
+    // Class id for the current version of this class
+    static const gs::ClassId myId(gs::ClassId::makeId<DummyOOTPileupCorrection>());
+
+    // As this class is final, it is sufficient to just check that
+    // the class id is correct. For more complicated situations
+    // (i.e., if class could be an intermediate base), see example
+    // code coming with the "Geners" package.
+    myId.ensureSameId(id);
+
+    // Read back the object info
+    std::string s;
+    gs::read_string(in, &s);
+
+    double scale;
+    gs::read_pod(in, &scale);
+
+    // Check the status of the stream
+    if (in.fail()) throw gs::IOReadFailure("In DummyOOTPileupCorrection::read: "
+                                           "input stream failure");
+    // Return a new object on the heap
+    return new DummyOOTPileupCorrection(s, scale);
+}
+
+bool DummyOOTPileupCorrection::isEqual(const AbsOOTPileupCorrection& otherBase) const
+{
+    // Note the use of static_cast rather than dynamic_cast below.
+    // static_cast works faster and it is guaranteed to succeed here.
+    const DummyOOTPileupCorrection& r = 
+        static_cast<const DummyOOTPileupCorrection&>(otherBase);
+    return descr_ == r.descr_ && scale_ == r.scale_;
+}

--- a/RecoLocalCalo/HcalRecAlgos/src/ES_OOTPileupCorrectionTable.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/ES_OOTPileupCorrectionTable.cc
@@ -1,0 +1,4 @@
+#include "FWCore/Utilities/interface/typelookup.h"
+#include "RecoLocalCalo/HcalRecAlgos/interface/OOTPileupCorrectionTypedefs.h"
+
+TYPELOOKUP_DATA_REG(OOTPileupCorrectionTable);

--- a/RecoLocalCalo/HcalRecAlgos/src/OOTPileupCorrectionReader.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/OOTPileupCorrectionReader.cc
@@ -1,0 +1,16 @@
+#include "RecoLocalCalo/HcalRecAlgos/interface/OOTPileupCorrectionReader.h"
+
+// Include headers for all classes derived from AbsOOTPileupCorrection
+// which are known at this point in code development
+#include "RecoLocalCalo/HcalRecAlgos/interface/DummyOOTPileupCorrection.h"
+
+// Simple macro for adding a reader for a class derived from AbsOOTPileupCorrection
+#define add_reader(Derived) do {                                                   \
+    const gs::ClassId& id(gs::ClassId::makeId<Derived >());                        \
+    (*this)[id.name()] = new gs::ConcreteReader<AbsOOTPileupCorrection,Derived >();\
+} while(0);
+
+OOTPileupCorrectionReader::OOTPileupCorrectionReader()
+{
+    add_reader(DummyOOTPileupCorrection);
+}

--- a/RecoLocalCalo/HcalRecAlgos/test/OOTPileupCorrectionDBReader_cfg.py
+++ b/RecoLocalCalo/HcalRecAlgos/test/OOTPileupCorrectionDBReader_cfg.py
@@ -1,0 +1,29 @@
+database = "sqlite_file:testOOTPileupCorrection.db"
+tag = "test"
+outputfile = "testOOTPileupCorrection_dbread.gssa"
+
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('OOTPileupCorrectionDBRead')
+
+process.source = cms.Source('EmptySource') 
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(1)) 
+
+process.load("CondCore.DBCommon.CondDBCommon_cfi")
+process.CondDBCommon.connect = database
+
+process.PoolDBESSource = cms.ESSource("PoolDBESSource",
+    process.CondDBCommon,
+    toGet = cms.VPSet(cms.PSet(
+        record = cms.string("HcalOOTPileupCorrectionRcd"),
+        tag = cms.string(tag)
+    ))
+)
+
+process.dumper = cms.EDAnalyzer(
+    'OOTPileupCorrectionDBReader',
+    outputFile = cms.string(outputfile),
+    dumpMetadata = cms.untracked.bool(True)
+)
+
+process.p = cms.Path(process.dumper)

--- a/RecoLocalCalo/HcalRecAlgos/test/OOTPileupCorrectionDBWriter_cfg.py
+++ b/RecoLocalCalo/HcalRecAlgos/test/OOTPileupCorrectionDBWriter_cfg.py
@@ -1,0 +1,45 @@
+database = "sqlite_file:testOOTPileupCorrection.db"
+tag = "test"
+inputfile = "testOOTPileupCorrection.gssa"
+
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('OOTPileupCorrectionDBWrite') 
+
+process.source = cms.Source('EmptySource') 
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(1)) 
+
+process.load("CondCore.DBCommon.CondDBCommon_cfi")
+process.CondDBCommon.connect = database
+
+# Data is tagged in the database by the "tag" parameter specified in the
+# PoolDBOutputService configuration. We then check if the tag already exists.
+#
+# -- If the tag does not exist, a new interval of validity (IOV) for this tag
+#    is created, valid till "end of time".
+#
+# -- If the tag already exists: the IOV of the previous data is stopped at
+#    "current time" and we register new data valid from now on (currentTime
+#    is the time of the current event!). 
+#
+# The "record" parameter should be the same in the PoolDBOutputService
+# configuration and in the module which writes the object. It is basically
+# used in order to just associate the record with the tag.
+#
+process.PoolDBOutputService = cms.Service(
+    "PoolDBOutputService",
+    process.CondDBCommon,
+    timetype = cms.untracked.string('runnumber'),
+    toPut = cms.VPSet(cms.PSet(
+        record = cms.string("HcalOOTPileupCorrectionRcd"),
+        tag = cms.string(tag)
+    ))
+)
+
+process.filereader = cms.EDAnalyzer(
+    'OOTPileupCorrectionDBWriter',
+    inputFile = cms.string(inputfile),
+    record = cms.string("HcalOOTPileupCorrectionRcd")
+)
+
+process.p = cms.Path(process.filereader)

--- a/RecoLocalCalo/HcalRecAlgos/test/OOTPileupCorrectionSerializer_cfg.py
+++ b/RecoLocalCalo/HcalRecAlgos/test/OOTPileupCorrectionSerializer_cfg.py
@@ -1,0 +1,12 @@
+import FWCore.ParameterSet.Config as cms
+from RecoLocalCalo.HcalRecAlgos.OOTPileupCorrectionSerializer_cfi import *
+
+process = cms.Process('OOTPileupCorrectionSerializer')
+
+process.source = cms.Source('EmptySource')
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(0))
+
+process.filewriter = ootPileupCorrectionSerializer
+process.filewriter.outputFile = cms.string("testOOTPileupCorrection.gssa")
+
+process.p = cms.Path(process.filewriter)

--- a/RecoLocalCalo/HcalRecProducers/python/HcalHitReconstructor_hbhe_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HcalHitReconstructor_hbhe_cfi.py
@@ -13,6 +13,10 @@ hbheprereco = cms.EDProducer(
     tsFromDB = cms.bool(True),
     recoParamsFromDB = cms.bool(True),
     useLeakCorrection = cms.bool(False),
+    dataOOTCorrectionName = cms.string(""),
+    dataOOTCorrectionCategory = cms.string("DataOOTPileupCorrections"),
+    mcOOTCorrectionName = cms.string(""),
+    mcOOTCorrectionCategory = cms.string("MCOOTPileupCorrections"),
 
     # Set time slice for first digi to be stored in aux word
     # (HBHE uses time slices 4-7 for reco)

--- a/RecoLocalCalo/HcalRecProducers/python/HcalHitReconstructor_hf_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HcalHitReconstructor_hf_cfi.py
@@ -13,7 +13,11 @@ hfreco = cms.EDProducer("HcalHitReconstructor",
                         tsFromDB = cms.bool(True),
                         recoParamsFromDB = cms.bool(True),
                         useLeakCorrection = cms.bool(False),
-	
+                        dataOOTCorrectionName = cms.string(""),
+                        dataOOTCorrectionCategory = cms.string("DataOOTPileupCorrections"),
+                        mcOOTCorrectionName = cms.string(""),
+                        mcOOTCorrectionCategory = cms.string("MCOOTPileupCorrections"),
+
                         correctTiming = cms.bool(True),
                         # Set time slice for first digi to be stored in aux word 
                         firstAuxTS = cms.int32(1),

--- a/RecoLocalCalo/HcalRecProducers/python/HcalHitReconstructor_ho_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HcalHitReconstructor_ho_cfi.py
@@ -13,6 +13,10 @@ horeco = cms.EDProducer(
     tsFromDB = cms.bool(True),
     recoParamsFromDB = cms.bool(True),
     useLeakCorrection = cms.bool(False),
+    dataOOTCorrectionName = cms.string(""),
+    dataOOTCorrectionCategory = cms.string("DataOOTPileupCorrections"),
+    mcOOTCorrectionName = cms.string(""),
+    mcOOTCorrectionCategory = cms.string("MCOOTPileupCorrections"),
 
     # Set time slice for first digi to be stored in aux word
     # (HO uses time slices 4-7)

--- a/RecoLocalCalo/HcalRecProducers/src/HcalHitReconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HcalHitReconstructor.cc
@@ -36,11 +36,11 @@ HcalHitReconstructor::HcalHitReconstructor(edm::ParameterSet const& conf):
   firstSample_(conf.getParameter<int>("firstSample")),
   samplesToAdd_(conf.getParameter<int>("samplesToAdd")),
   tsFromDB_(conf.getParameter<bool>("tsFromDB")),
-  useLeakCorrection_( conf.getParameter<bool>("useLeakCorrection")),
-  dataOOTCorrectionName_(conf.getParameter<std::string>("dataOOTCorrectionName")),
-  dataOOTCorrectionCategory_(conf.getParameter<std::string>("dataOOTCorrectionCategory")),
-  mcOOTCorrectionName_(conf.getParameter<std::string>("mcOOTCorrectionName")),
-  mcOOTCorrectionCategory_(conf.getParameter<std::string>("mcOOTCorrectionCategory")),
+  useLeakCorrection_(conf.getParameter<bool>("useLeakCorrection")),
+  dataOOTCorrectionName_(""),
+  dataOOTCorrectionCategory_("DataOOTPileupCorrections"),
+  mcOOTCorrectionName_(""),
+  mcOOTCorrectionCategory_("MCOOTPileupCorrections"),
   setPileupCorrection_(0),
   paramTS(0),
   theTopology(0)
@@ -216,6 +216,14 @@ HcalHitReconstructor::HcalHitReconstructor(edm::ParameterSet const& conf):
 
   // If no valid OOT pileup correction name specified,
   // disable the correction
+  if (conf.existsAs<std::string>("dataOOTCorrectionName"))
+      dataOOTCorrectionName_ = conf.getParameter<std::string>("dataOOTCorrectionName");
+  if (conf.existsAs<std::string>("dataOOTCorrectionCategory"))
+      dataOOTCorrectionCategory_ = conf.getParameter<std::string>("dataOOTCorrectionCategory");
+  if (conf.existsAs<std::string>("mcOOTCorrectionName"))
+      mcOOTCorrectionName_ = conf.getParameter<std::string>("mcOOTCorrectionName");
+  if (conf.existsAs<std::string>("mcOOTCorrectionCategory"))
+      mcOOTCorrectionCategory_ = conf.getParameter<std::string>("mcOOTCorrectionCategory");
   if (dataOOTCorrectionName_.empty() && mcOOTCorrectionName_.empty())
       setPileupCorrection_ = 0;
 }

--- a/RecoLocalCalo/HcalRecProducers/src/HcalHitReconstructor.h
+++ b/RecoLocalCalo/HcalRecProducers/src/HcalHitReconstructor.h
@@ -39,60 +39,72 @@
 
 class HcalTopology;
 
-    class HcalHitReconstructor : public edm::EDProducer {
-    public:
-      explicit HcalHitReconstructor(const edm::ParameterSet& ps);
-      virtual ~HcalHitReconstructor();
-      virtual void beginRun(edm::Run const&r, edm::EventSetup const & es) override final;
-      virtual void endRun(edm::Run const&r, edm::EventSetup const & es) override final;
-      virtual void produce(edm::Event& e, const edm::EventSetup& c);
-    private:      
-      HcalSimpleRecAlgo reco_;
-      HcalADCSaturationFlag* saturationFlagSetter_;
-      HFTimingTrustFlag* HFTimingTrustFlagSetter_;
-      HBHEStatusBitSetter* hbheFlagSetter_;
-      HBHETimeProfileStatusBitSetter* hbheHSCPFlagSetter_;
-      HBHETimingShapedFlagSetter* hbheTimingShapedFlagSetter_;
-      HBHEPulseShapeFlagSetter *hbhePulseShapeFlagSetter_;
-      HcalHFStatusBitFromDigis*   hfdigibit_;
-      HcalHF_S9S1algorithm*       hfS9S1_;
-      HcalHF_S9S1algorithm*       hfS8S1_;
-      HcalHF_PETalgorithm*        hfPET_;
- 
-      DetId::Detector det_;
-      int subdet_;
-      HcalOtherSubdetector subdetOther_;
-      edm::InputTag inputLabel_;
-      edm::EDGetTokenT<HBHEDigiCollection> tok_hbhe_;
-      edm::EDGetTokenT<HODigiCollection> tok_ho_;
-      edm::EDGetTokenT<HFDigiCollection> tok_hf_;
-      edm::EDGetTokenT<HcalCalibDigiCollection> tok_calib_;
-      //std::vector<std::string> channelStatusToDrop_;
-      bool correctTiming_; // turn on/off Ken Rossato's algorithm to fix timing
-      bool setNoiseFlags_; // turn on/off basic noise flags
-      bool setHSCPFlags_;  // turn on/off HSCP noise flags
-      bool setSaturationFlags_; // turn on/off flag indicating ADC saturation
-      bool setTimingTrustFlags_; // turn on/off HF timing uncertainty flag 
-      bool setPulseShapeFlags_; //  turn on/off HBHE fit-based noise flags
-      bool dropZSmarkedPassed_; // turn on/off dropping of zero suppression marked and passed digis
+class HcalHitReconstructor : public edm::EDProducer
+{
+public:
+  explicit HcalHitReconstructor(const edm::ParameterSet& ps);
+  virtual ~HcalHitReconstructor();
 
-      int firstAuxTS_;
- 
-      // legacy parameters for config-set values compatibility 
-      int firstSample_;
-      int samplesToAdd_;
-      bool tsFromDB_;
-      bool recoParamsFromDB_;
-      bool digiTimeFromDB_;
+  virtual void beginRun(edm::Run const&r, edm::EventSetup const & es) override final;
+  virtual void endRun(edm::Run const&r, edm::EventSetup const & es) override final;
+  virtual void produce(edm::Event& e, const edm::EventSetup& c);
+private:
+  typedef void (HcalSimpleRecAlgo::*SetCorrectionFcn)(boost::shared_ptr<AbsOOTPileupCorrection> corr);
 
+  HcalSimpleRecAlgo reco_;
+  HcalADCSaturationFlag* saturationFlagSetter_;
+  HFTimingTrustFlag* HFTimingTrustFlagSetter_;
+  HBHEStatusBitSetter* hbheFlagSetter_;
+  HBHETimeProfileStatusBitSetter* hbheHSCPFlagSetter_;
+  HBHETimingShapedFlagSetter* hbheTimingShapedFlagSetter_;
+  HBHEPulseShapeFlagSetter *hbhePulseShapeFlagSetter_;
+  HcalHFStatusBitFromDigis*   hfdigibit_;
+  HcalHF_S9S1algorithm*       hfS9S1_;
+  HcalHF_S9S1algorithm*       hfS8S1_;
+  HcalHF_PETalgorithm*        hfPET_;
 
-      // switch on/off leakage (to pre-sample) correction
-      bool useLeakCorrection_;
-      
-      HcalRecoParams* paramTS;  // firstSample & sampleToAdd from DB  
-      const HcalFlagHFDigiTimeParams* HFDigiTimeParams; // HF DigiTime parameters
+  DetId::Detector det_;
+  int subdet_;
+  HcalOtherSubdetector subdetOther_;
+  edm::InputTag inputLabel_;
 
-      HcalTopology *theTopology;
-    };
+  edm::EDGetTokenT<HBHEDigiCollection> tok_hbhe_;
+  edm::EDGetTokenT<HODigiCollection> tok_ho_;
+  edm::EDGetTokenT<HFDigiCollection> tok_hf_;
+  edm::EDGetTokenT<HcalCalibDigiCollection> tok_calib_;
+
+  //std::vector<std::string> channelStatusToDrop_;
+  bool correctTiming_; // turn on/off Ken Rossato's algorithm to fix timing
+  bool setNoiseFlags_; // turn on/off basic noise flags
+  bool setHSCPFlags_;  // turn on/off HSCP noise flags
+  bool setSaturationFlags_; // turn on/off flag indicating ADC saturation
+  bool setTimingTrustFlags_; // turn on/off HF timing uncertainty flag 
+  bool setPulseShapeFlags_; //  turn on/off HBHE fit-based noise flags
+  bool dropZSmarkedPassed_; // turn on/off dropping of zero suppression marked and passed digis
+
+  int firstAuxTS_;
+
+  // legacy parameters for config-set values compatibility 
+  int firstSample_;
+  int samplesToAdd_;
+  bool tsFromDB_;
+  bool recoParamsFromDB_;
+  bool digiTimeFromDB_;
+
+  // switch on/off leakage (to pre-sample) correction
+  bool useLeakCorrection_;
+
+  // Labels related to OOT pileup corrections
+  std::string dataOOTCorrectionName_;
+  std::string dataOOTCorrectionCategory_;
+  std::string mcOOTCorrectionName_;
+  std::string mcOOTCorrectionCategory_;
+  SetCorrectionFcn setPileupCorrection_;
+
+  HcalRecoParams* paramTS;  // firstSample & sampleToAdd from DB  
+  const HcalFlagHFDigiTimeParams* HFDigiTimeParams; // HF DigiTime parameters
+
+  HcalTopology *theTopology;
+};
 
 #endif


### PR DESCRIPTION
Initial implementation of the interface for the HCAL out-of-time pileup corrections.

Note that the HcalHitReconstructor module gets four new parameters:
dataOOTCorrectionName, dataOOTCorrectionCategory, mcOOTCorrectionName,
and mcOOTCorrectionCategory. These parameters are set in the cfi files in the
RecoLocalCalo/HcalRecProducers package, but the configs for the
HLTrigger/Configuration and DQM/DataScouting packages will be broken
because they do not include these fragments. Instead, these packages define
their own configurations for HcalHitReconstructor. In all cases, one should be
able to set for now

dataOOTCorrectionName = cms.string(""),
dataOOTCorrectionCategory = cms.string("DataOOTPileupCorrections"),
mcOOTCorrectionName = cms.string(""),
mcOOTCorrectionCategory = cms.string("MCOOTPileupCorrections"),

With these settings, the OOT pileup corrections will be disabled.
