### PR TITLE
add serialisation for new QGLikelihoodObject

### DIFF
--- a/CondCore/CondDB/src/GTSchema.cc
+++ b/CondCore/CondDB/src/GTSchema.cc
@@ -90,6 +90,9 @@ namespace cond {
       q.addOrderClause<RECORD>();
       q.addOrderClause<LABEL>();
       for ( auto row : q ) {
+	if ( std::get<1>(row) == "-" ) {
+	  std::get<1>(row) = "";
+	}
 	tags.push_back( row );
       }
       return q.retrievedRows();

--- a/CondFormats/JetMETObjects/interface/QGLikelihoodObject.h
+++ b/CondFormats/JetMETObjects/interface/QGLikelihoodObject.h
@@ -4,7 +4,7 @@
 #include "CondFormats/BTauObjects/interface/CombinedSVCategoryData.h"
 #include "CondFormats/PhysicsToolsObjects/interface/Histogram.h"
 
-
+#include "CondFormats/Serialization/interface/Serializable.h"
 
 #include <vector>
 
@@ -14,6 +14,8 @@ struct QGLikelihoodCategory {
   int EtaBin;  
   int QGIndex;
   int VarIndex;
+
+  COND_SERIALIZABLE;  
 };
 
 
@@ -26,10 +28,13 @@ struct QGLikelihoodObject
   {
     QGLikelihoodCategory category;
     Histogram histogram;
+
+    COND_SERIALIZABLE;  
   };
 
- std::vector<Entry> data;
-  
+  std::vector<Entry> data;
+
+  COND_SERIALIZABLE;  
 };
 
 #endif //QGLikelihoodObject_h

--- a/CondFormats/JetMETObjects/src/Serialization.cc
+++ b/CondFormats/JetMETObjects/src/Serialization.cc
@@ -54,4 +54,31 @@ void JetCorrectorParametersCollection::serialize(Archive & ar, const unsigned in
 }
 COND_SERIALIZATION_INSTANTIATE(JetCorrectorParametersCollection);
 
+template <class Archive>
+void QGLikelihoodCategory::serialize(Archive & ar, const unsigned int)
+{
+    ar & BOOST_SERIALIZATION_NVP(RhoVal);
+    ar & BOOST_SERIALIZATION_NVP(PtMin);
+    ar & BOOST_SERIALIZATION_NVP(PtMax);
+    ar & BOOST_SERIALIZATION_NVP(EtaBin);
+    ar & BOOST_SERIALIZATION_NVP(QGIndex);
+    ar & BOOST_SERIALIZATION_NVP(VarIndex);
+}
+COND_SERIALIZATION_INSTANTIATE(QGLikelihoodCategory);
+
+template <class Archive>
+void QGLikelihoodObject::serialize(Archive & ar, const unsigned int)
+{
+    ar & BOOST_SERIALIZATION_NVP(data);
+}
+COND_SERIALIZATION_INSTANTIATE(QGLikelihoodObject);
+
+template <class Archive>
+void QGLikelihoodObject::Entry::serialize(Archive & ar, const unsigned int)
+{
+    ar & BOOST_SERIALIZATION_NVP(category);
+    ar & BOOST_SERIALIZATION_NVP(histogram);
+}
+COND_SERIALIZATION_INSTANTIATE(QGLikelihoodObject::Entry);
+
 #include "CondFormats/JetMETObjects/src/SerializationManual.h"

--- a/CondFormats/JetMETObjects/src/headers.h
+++ b/CondFormats/JetMETObjects/src/headers.h
@@ -5,5 +5,6 @@
 #include "CondFormats/JetMETObjects/interface/SimpleJetCorrector.h"
 #include "CondFormats/JetMETObjects/interface/JetCorrectorParameters.h"
 #include "CondFormats/JetMETObjects/interface/FFTJetCorrectorParameters.h"
+#include "CondFormats/JetMETObjects/interface/QGLikelihoodObject.h"
 
 #include <vector>

--- a/CondFormats/JetMETObjects/test/testSerializationJetMETObjects.cpp
+++ b/CondFormats/JetMETObjects/test/testSerializationJetMETObjects.cpp
@@ -18,6 +18,8 @@ int main()
     testSerialization<std::vector<JetCorrectorParameters::Record>>();
     testSerialization<std::vector<JetCorrectorParameters>>();
     testSerialization<std::vector<JetCorrectorParametersCollection>>();
+    testSerialization<QGLikelihoodCategory>();
+    testSerialization<QGLikelihoodObject>();
 
     return 0;
 }


### PR DESCRIPTION
Update for BOOSTIO branch - please merge soon.
- add serialisation for new QGLikelihoodObject in JetMetObjects
- replace dash with empty string in label name before returning to the user
  Oracle interprets empty string as NULL so this can't be used as labelName
  in the DB, so internally we use a '-'. This commit makes sure that the user 
  still sees an emtpy string.
