### PR TITLE
depth segmentation from HCAL topology for HE recalib

### DIFF
--- a/CalibCalorimetry/HcalPlugins/python/Hcal_Conditions_forGlobalTag_cff.py
+++ b/CalibCalorimetry/HcalPlugins/python/Hcal_Conditions_forGlobalTag_cff.py
@@ -12,7 +12,6 @@ es_hardcode = cms.ESSource("HcalHardcodeCalibrations",
 toGet = cms.untracked.vstring('GainWidths'),
 #--- the following 5 parameters can be omitted in case of regular Geometry 
     iLumi = cms.double(-1.),                 # for Upgrade: fb-1
-    HcalReLabel =  HcalReLabel,              # for Upgrade
     HERecalibration = cms.bool(False),       # True for Upgrade   
     HEreCalibCutoff = cms.double(20.),       # if above is True  
     HFRecalibration = cms.bool(False),       # True for Upgrade

--- a/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.h
+++ b/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.h
@@ -91,5 +91,6 @@ private:
   HERecalibration* he_recalibration;  
   HFRecalibration* hf_recalibration;  
   bool switchGainWidthsForTrigPrims; 
+  bool setHEdsegm;
 };
 

--- a/SLHCUpgradeSimulations/Configuration/python/HCalCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/HCalCustoms.py
@@ -5,8 +5,7 @@ def customise_HcalPhase0(process):
 
     if hasattr(process,'mix') and hasattr(process.mix,'digitizers') and hasattr(process.mix.digitizers,'hcal'):    
         process.mix.digitizers.hcal.HcalReLabel.RelabelHits=cms.untracked.bool(True)
-	
-    process.es_hardcode.HcalReLabel.RelabelHits = cms.untracked.bool(True)
+
     process.es_hardcode.HEreCalibCutoff = cms.double(20.) #for aging
 
     process.es_hardcode.toGet = cms.untracked.vstring(
@@ -44,8 +43,7 @@ def customise_HcalPhase1(process):
                 'CholeskyMatrices',
                 'CovarianceMatrices'
                 )
-    
-    process.es_hardcode.HcalReLabel.RelabelHits=cms.untracked.bool(True)
+
     # Special Upgrade trick (if absent - regular case assumed)
     process.es_hardcode.GainWidthsForTrigPrims = cms.bool(True)
     process.es_hardcode.HEreCalibCutoff = cms.double(100.) #for aging


### PR DESCRIPTION
HcalReLabel is no longer used. HE recalibration (for aging simulations) is now given the depth segmentation scheme via HcalTopology. This restores the correct Phase 0 and Phase 1 behavior.
