### PR TITLE
fix top dqm regarding the way to get hlt process name

### DIFF
--- a/DQMOffline/Trigger/interface/TopDiLeptonHLTOfflineDQM.h
+++ b/DQMOffline/Trigger/interface/TopDiLeptonHLTOfflineDQM.h
@@ -149,6 +149,7 @@ namespace HLTOfflineDQMTopDiLepton {
       std::map<std::string,MonitorElement*> hists_;
 
       /// hlt objects
+      std::string          processName_;
       trigger::Vids        electronIds_;
       trigger::VRelectron  electronRefs_;
       trigger::Vids        muonIds_;

--- a/DQMOffline/Trigger/interface/TopSingleLeptonHLTOfflineDQM.h
+++ b/DQMOffline/Trigger/interface/TopSingleLeptonHLTOfflineDQM.h
@@ -151,6 +151,7 @@ namespace HLTOfflineDQMTopSingleLepton {
       std::map<std::string,MonitorElement*> hists_;
 
       /// hlt objects
+      std::string          processName_;
       trigger::Vids        electronIds_;
       trigger::VRelectron  electronRefs_;
       trigger::Vids        muonIds_;

--- a/DQMOffline/Trigger/src/TopDiLeptonHLTOfflineDQM.cc
+++ b/DQMOffline/Trigger/src/TopDiLeptonHLTOfflineDQM.cc
@@ -97,12 +97,14 @@ namespace HLTOfflineDQMTopDiLepton {
       }
     }
     // triggerExtras are optional; they may be omitted or empty
+    processName_ = "HLT";
     if( cfg.existsAs<edm::ParameterSet>("triggerExtras") ){
       edm::ParameterSet triggerExtras=cfg.getParameter<edm::ParameterSet>("triggerExtras");
       triggerTable_= iC.consumes< edm::TriggerResults >(triggerExtras.getParameter<edm::InputTag>("src"));
-      elecMuPaths_ =triggerExtras.getParameter<std::vector<std::string> >("pathsELECMU");
-      diMuonPaths_ =triggerExtras.getParameter<std::vector<std::string> >("pathsDIMUON");
-      diElecPaths_ =triggerExtras.getParameter<std::vector<std::string> >("pathsDIELEC");
+      processName_ = triggerExtras.getParameter<edm::InputTag>("src").process();
+      elecMuPaths_ = triggerExtras.getParameter<std::vector<std::string> >("pathsELECMU");
+      diMuonPaths_ = triggerExtras.getParameter<std::vector<std::string> >("pathsDIMUON");
+      diElecPaths_ = triggerExtras.getParameter<std::vector<std::string> >("pathsDIELEC");
     }
     // massExtras is optional; in case it's not found no mass
     // window cuts are applied for the same flavor monitor
@@ -116,7 +118,7 @@ namespace HLTOfflineDQMTopDiLepton {
     // and don't forget to do the histogram booking
     folder_=cfg.getParameter<std::string>("directory");
 
-    triggerEventWithRefsTag_ = iC.consumes< trigger::TriggerEventWithRefs >(edm::InputTag("hltTriggerSummaryRAW","","HLT"));
+    triggerEventWithRefsTag_ = iC.consumes< trigger::TriggerEventWithRefs >(edm::InputTag("hltTriggerSummaryRAW","",processName_));
 
   }
 
@@ -389,12 +391,12 @@ namespace HLTOfflineDQMTopDiLepton {
         bool dielec = false;
         bool dimuon = false;
         // consider only path from triggerPaths
-        TString name = triggerNames.triggerNames()[i].c_str();
+        string name = triggerNames.triggerNames()[i];
         for (unsigned int j=0; j<triggerPaths.size(); j++) {
-          if (name.Contains(TString(triggerPaths[j]), TString::kIgnoreCase) && name.Contains(TString("ele"), TString::kIgnoreCase) && name.Contains(TString("mu"), TString::kIgnoreCase)) elecmu = true;
+          if (TString(name.c_str()).Contains(TString(triggerPaths[j]), TString::kIgnoreCase) && TString(name.c_str()).Contains(TString("ele"), TString::kIgnoreCase) && TString(name.c_str()).Contains(TString("mu"), TString::kIgnoreCase)) elecmu = true;
           else {
-            if (name.Contains(TString(triggerPaths[j]), TString::kIgnoreCase) && name.Contains(TString("ele"), TString::kIgnoreCase)) dielec = true;
-            if (name.Contains(TString(triggerPaths[j]), TString::kIgnoreCase) && name.Contains(TString("mu"), TString::kIgnoreCase)) dimuon = true;
+            if (TString(name.c_str()).Contains(TString(triggerPaths[j]), TString::kIgnoreCase) && TString(name.c_str()).Contains(TString("ele"), TString::kIgnoreCase)) dielec = true;
+            if (TString(name.c_str()).Contains(TString(triggerPaths[j]), TString::kIgnoreCase) && TString(name.c_str()).Contains(TString("mu"), TString::kIgnoreCase)) dimuon = true;
           }
         }
 
@@ -489,14 +491,14 @@ namespace HLTOfflineDQMTopDiLepton {
       // loop over trigger paths 
       for(unsigned int i=0; i<triggerNames.triggerNames().size(); ++i){
         // consider only path from triggerPaths
-        TString name = triggerNames.triggerNames()[i].c_str();
+        string name = triggerNames.triggerNames()[i].c_str();
         bool isInteresting = false;
         for (unsigned int j=0; j<triggerPaths.size(); j++) {
-          if (name.Contains(TString(triggerPaths[j]), TString::kIgnoreCase)) isInteresting = true; 
+          if (TString(name.c_str()).Contains(TString(triggerPaths[j]), TString::kIgnoreCase)) isInteresting = true; 
         }
         if (!isInteresting) continue;
         // dump infos on the considered trigger path 
-        const unsigned int triggerIndex = event.triggerNames(*triggerTable).triggerIndex(triggerNames.triggerNames()[i]);
+        const unsigned int triggerIndex = triggerNames.triggerIndex(name);
         // get modules for the considered trigger path
         const vector<string>& moduleLabels(hltConfig.moduleLabels(triggerIndex));
         const unsigned int moduleIndex(triggerTable->index(triggerIndex));
@@ -510,7 +512,7 @@ namespace HLTOfflineDQMTopDiLepton {
           const string& moduleLabel(moduleLabels[k]);
           const string  moduleType(hltConfig.moduleType(moduleLabel));
           // check whether the module is packed up in TriggerEventWithRef product
-          const unsigned int filterIndex(triggerEventWithRefsHandle->filterIndex(edm::InputTag(moduleLabel,"","HLT")));
+          const unsigned int filterIndex(triggerEventWithRefsHandle->filterIndex(edm::InputTag(moduleLabel,"",processName_)));
           if (filterIndex<triggerEventWithRefsHandle->size()) {
             triggerEventWithRefsHandle->getObjects(filterIndex,electronIds_,electronRefs_);
             const unsigned int nElectrons(electronIds_.size());
@@ -533,7 +535,7 @@ namespace HLTOfflineDQMTopDiLepton {
         if (kElec > 0 && kMuon < 1 && isoElecs.size()>0) {
           const string& moduleLabelElec(moduleLabels[kElec]);
           const string  moduleTypeElec(hltConfig.moduleType(moduleLabelElec));
-          const unsigned int filterIndexElec(triggerEventWithRefsHandle->filterIndex(edm::InputTag(moduleLabelElec,"","HLT")));
+          const unsigned int filterIndexElec(triggerEventWithRefsHandle->filterIndex(edm::InputTag(moduleLabelElec,"",processName_)));
           triggerEventWithRefsHandle->getObjects(filterIndexElec,electronIds_,electronRefs_);
           const unsigned int nElectrons(electronIds_.size());
           double deltar1 = 600.;
@@ -570,7 +572,7 @@ namespace HLTOfflineDQMTopDiLepton {
         if (kMuon > 0 && kElec < 1 && isoMuons.size()>0) {
           const string& moduleLabelMuon(moduleLabels[kMuon]);
           const string  moduleTypeMuon(hltConfig.moduleType(moduleLabelMuon));
-          const unsigned int filterIndexMuon(triggerEventWithRefsHandle->filterIndex(edm::InputTag(moduleLabelMuon,"","HLT")));
+          const unsigned int filterIndexMuon(triggerEventWithRefsHandle->filterIndex(edm::InputTag(moduleLabelMuon,"",processName_)));
           triggerEventWithRefsHandle->getObjects(filterIndexMuon,muonIds_,muonRefs_);
           trigger::VRmuon myMuonRefs;
           const unsigned int nMuons(muonIds_.size());
@@ -644,7 +646,7 @@ namespace HLTOfflineDQMTopDiLepton {
         if (kElec > 0 && kMuon > 0 && isoElecs.size()>0) {
           const string& moduleLabelElec(moduleLabels[kElec]);
           const string  moduleTypeElec(hltConfig.moduleType(moduleLabelElec));
-          const unsigned int filterIndexElec(triggerEventWithRefsHandle->filterIndex(edm::InputTag(moduleLabelElec,"","HLT")));
+          const unsigned int filterIndexElec(triggerEventWithRefsHandle->filterIndex(edm::InputTag(moduleLabelElec,"",processName_)));
           triggerEventWithRefsHandle->getObjects(filterIndexElec,electronIds_,electronRefs_);
           const unsigned int nElectrons(electronIds_.size());
           double deltar = 600.;
@@ -665,7 +667,7 @@ namespace HLTOfflineDQMTopDiLepton {
         if (kElec > 0 && kMuon > 0 && isoMuons.size()>0) {
           const string& moduleLabelMuon(moduleLabels[kMuon]);
           const string  moduleTypeMuon(hltConfig.moduleType(moduleLabelMuon));
-          const unsigned int filterIndexMuon(triggerEventWithRefsHandle->filterIndex(edm::InputTag(moduleLabelMuon,"","HLT")));
+          const unsigned int filterIndexMuon(triggerEventWithRefsHandle->filterIndex(edm::InputTag(moduleLabelMuon,"",processName_)));
           triggerEventWithRefsHandle->getObjects(filterIndexMuon,muonIds_,muonRefs_);
           const unsigned int nMuons(muonIds_.size());
           if (isoMuons.size()<1) continue;
@@ -751,13 +753,11 @@ TopDiLeptonHLTOfflineDQM::dqmBeginRun(const edm::Run& iRun, const edm::EventSetu
   using namespace std;
   using namespace edm;
 
-  std::string processName = "HLT"; 
-
   bool changed(true);
-  if (!hltConfig_.init(iRun,iSetup,processName,changed)) {
+  if (!hltConfig_.init(iRun,iSetup,"*",changed)) {
         edm::LogWarning( "TopSingleLeptonHLTOfflineDQM" ) 
             << "Config extraction failure with process name "
-            << processName
+            << hltConfig_.processName()
             << "\n";
         return;
   }

--- a/DQMOffline/Trigger/src/TopSingleLeptonHLTOfflineDQM.cc
+++ b/DQMOffline/Trigger/src/TopSingleLeptonHLTOfflineDQM.cc
@@ -133,9 +133,11 @@ namespace HLTOfflineDQMTopSingleLepton {
     }
 
     // triggerExtras are optional; they may be omitted or empty
+    processName_ = "HLT";
     if( cfg.existsAs<edm::ParameterSet>("triggerExtras") ){
       edm::ParameterSet triggerExtras=cfg.getParameter<edm::ParameterSet>("triggerExtras");
       triggerTable_= iC.consumes< edm::TriggerResults >(triggerExtras.getParameter<edm::InputTag>("src"));
+      processName_ = triggerExtras.getParameter<edm::InputTag>("src").process();
       triggerPaths_=triggerExtras.getParameter<std::vector<std::string> >("paths");
     }
 
@@ -151,7 +153,7 @@ namespace HLTOfflineDQMTopSingleLepton {
     // and don't forget to do the histogram booking
     folder_=cfg.getParameter<std::string>("directory");
 
-    triggerEventWithRefsTag_ = iC.consumes< trigger::TriggerEventWithRefs >(edm::InputTag("hltTriggerSummaryRAW","","HLT"));
+    triggerEventWithRefsTag_ = iC.consumes< trigger::TriggerEventWithRefs >(edm::InputTag("hltTriggerSummaryRAW","",processName_));
 
   }
 
@@ -497,14 +499,14 @@ namespace HLTOfflineDQMTopSingleLepton {
       // loop over trigger paths 
       for(unsigned int i=0; i<triggerNames.triggerNames().size(); ++i){
         // consider only path from triggerPaths
-        TString name = triggerNames.triggerNames()[i].c_str();
+        string name = triggerNames.triggerNames()[i];
         bool isInteresting = false;
         for (unsigned int j=0; j<triggerPaths.size(); j++) {
-          if (name.Contains(TString(triggerPaths[j]), TString::kIgnoreCase)) isInteresting = true; 
+          if (TString(name.c_str()).Contains(TString(triggerPaths[j]), TString::kIgnoreCase)) isInteresting = true; 
         }
         if (!isInteresting) continue;
         // dump infos on the considered trigger path 
-        const unsigned int triggerIndex = event.triggerNames(*triggerTable).triggerIndex(triggerNames.triggerNames()[i]);
+        const unsigned int triggerIndex = triggerNames.triggerIndex(name);
         // get modules for the considered trigger path
         const vector<string>& moduleLabels(hltConfig.moduleLabels(triggerIndex));
         const unsigned int moduleIndex(triggerTable->index(triggerIndex));
@@ -524,7 +526,7 @@ namespace HLTOfflineDQMTopSingleLepton {
           const string& moduleLabel(moduleLabels[k]);
           const string  moduleType(hltConfig.moduleType(moduleLabel));
           // check whether the module is packed up in TriggerEventWithRef product
-          const unsigned int filterIndex(triggerEventWithRefsHandle->filterIndex(edm::InputTag(moduleLabel,"","HLT")));
+          const unsigned int filterIndex(triggerEventWithRefsHandle->filterIndex(edm::InputTag(moduleLabel,"",processName_)));
           if (filterIndex<triggerEventWithRefsHandle->size()) {
             triggerEventWithRefsHandle->getObjects(filterIndex,electronIds_,electronRefs_);
             const unsigned int nElectrons(electronIds_.size());
@@ -551,7 +553,7 @@ namespace HLTOfflineDQMTopSingleLepton {
         if (kElec > 0) {
           const string& moduleLabelElec(moduleLabels[kElec]);
           const string  moduleTypeElec(hltConfig.moduleType(moduleLabelElec));
-          const unsigned int filterIndexElec(triggerEventWithRefsHandle->filterIndex(edm::InputTag(moduleLabelElec,"","HLT")));
+          const unsigned int filterIndexElec(triggerEventWithRefsHandle->filterIndex(edm::InputTag(moduleLabelElec,"",processName_)));
           triggerEventWithRefsHandle->getObjects(filterIndexElec,electronIds_,electronRefs_);
           for (unsigned int inde = 0; inde < isoElecs.size(); inde++) {
             double deltar = deltaR(*electronRefs_[0],*isoElecs[inde]); 
@@ -569,7 +571,7 @@ namespace HLTOfflineDQMTopSingleLepton {
         if (kMuon > 0) {
           const string& moduleLabelMuon(moduleLabels[kMuon]);
           const string  moduleTypeMuon(hltConfig.moduleType(moduleLabelMuon));
-          const unsigned int filterIndexMuon(triggerEventWithRefsHandle->filterIndex(edm::InputTag(moduleLabelMuon,"","HLT")));
+          const unsigned int filterIndexMuon(triggerEventWithRefsHandle->filterIndex(edm::InputTag(moduleLabelMuon,"",processName_)));
           triggerEventWithRefsHandle->getObjects(filterIndexMuon,muonIds_,muonRefs_);
           for (unsigned int indm = 0; indm < isoMuons.size(); indm++) {
             double deltar = deltaR(*muonRefs_[0],*isoMuons[indm]); 
@@ -592,7 +594,7 @@ namespace HLTOfflineDQMTopSingleLepton {
         if (kJet > 0) {
           const string& moduleLabelJet(moduleLabels[kJet]);
           const string  moduleTypeJet(hltConfig.moduleType(moduleLabelJet));
-          const unsigned int filterIndexJet(triggerEventWithRefsHandle->filterIndex(edm::InputTag(moduleLabelJet,"","HLT")));
+          const unsigned int filterIndexJet(triggerEventWithRefsHandle->filterIndex(edm::InputTag(moduleLabelJet,"",processName_)));
           triggerEventWithRefsHandle->getObjects(filterIndexJet,pfjetIds_,pfjetRefs_);
           for (unsigned int indj = 0; indj < correctedJets.size(); indj++) {
             double deltar1 = deltaR(*pfjetRefs_[0],correctedJets[indj]); 
@@ -714,13 +716,11 @@ TopSingleLeptonHLTOfflineDQM::dqmBeginRun(const edm::Run& iRun, const edm::Event
   using namespace std;
   using namespace edm;
 
-  std::string processName = "HLT"; 
-
   bool changed(true);
-  if (!hltConfig_.init(iRun,iSetup,processName,changed)) {
+  if (!hltConfig_.init(iRun,iSetup,"*",changed)) {
         edm::LogWarning( "TopSingleLeptonHLTOfflineDQM" ) 
             << "Config extraction failure with process name "
-            << processName
+            << hltConfig_.processName()
             << "\n";
         return;
   }

--- a/DQMOffline/Trigger/src/TopSingleLeptonHLTOfflineDQM.cc
+++ b/DQMOffline/Trigger/src/TopSingleLeptonHLTOfflineDQM.cc
@@ -518,10 +518,6 @@ namespace HLTOfflineDQMTopSingleLepton {
         unsigned int kElec=0;
         unsigned int kMuon=0;
         unsigned int kJet=0;
-        // FIXME: This assert is needed to avoid a segfault when moduleIndex is >= the size of moduleLabels.
-        // This does happen in relval 50102 for gcc4.9.0, and the problem needs to be fixed.
-        // The assert does not fire for gcc4.8.1. The difference is not understood.
-        assert(moduleIndex < moduleLabels.size());
         for (unsigned int k=0; k<=moduleIndex; ++k) {
           const string& moduleLabel(moduleLabels[k]);
           const string  moduleType(hltConfig.moduleType(moduleLabel));


### PR DESCRIPTION
Crashes used to happen when relval FastSim was run (with process name HLT2) on top of some old 62X input files (with process name HLT). Andrea Perrotta has found a way to fix that and I've checked that the code runs properly on ttbar relval.
