### PR TITLE
Temporary workaround for ROOT6 bug

### DIFF
--- a/DataFormats/Common/interface/DetSetVectorNew.h
+++ b/DataFormats/Common/interface/DetSetVectorNew.h
@@ -396,7 +396,10 @@ namespace edmNew {
     int m_subdetId;
     
     
-    IdContainer m_ids;
+    // Workaround for ROOT 6 bug.
+    // ROOT6 has a problem with this IdContainer typedef
+    //IdContainer m_ids;
+    std::vector<Trans::Item> m_ids;
     DataContainer m_data;
     
   };


### PR DESCRIPTION
There is a subtle bug in ROOT6 where in rare cases it causes the wrong typedef name to be used in checksum calculations.  What is worse, is that sometimes ROOT6 uses the correct typedef name for the same typedef, causing inconsistent checksums within ROOT6.  This problem causes 145 of the relval tests to fail. These failures may hide other errors.
The typedef causing the problem is a typedef of a typedef of a typedef.
This workaround pull request peals off two layers of typedef to use a single typedef for the field that is causing a problem.  With this pull request, most of the 145 failing relvals now pass, although at least 22 of them fail later for a different reason.
Please merge this request promptly unless there are issues.
