### PR TITLE
No Cintex in ROOT 6

### DIFF
--- a/Validation/RecoVertex/bin/BuildFile.xml
+++ b/Validation/RecoVertex/bin/BuildFile.xml
@@ -1,6 +1,5 @@
 <library   name="ValidationRecoVertexMacros" file="*.cc">
 <use   name="DPGAnalysis/SiStripTools"/>
 <use   name="root"/>
-<use   name="rootcintex"/>
 <use   name="rootgraphics"/>
 </library>


### PR DESCRIPTION
Totally trivial.  There is no rootcintex product in ROOT6, so this request removes the attempted usage of it in a BuildFile.  Please merge as soon as convenient.
