### PR TITLE
adding converter for Basic to PF Jets

### DIFF
--- a/RecoJets/JetProducers/plugins/BasicToPFJet.cc
+++ b/RecoJets/JetProducers/plugins/BasicToPFJet.cc
@@ -14,10 +14,20 @@
 //
 // Original Author:  clint richardson
 //         Created:  Thu, 6 Mar 2014 12:00:00 GMT
-// $Id$
 //
 //
+// system include files
+#include <memory>
+#include <vector>
+#include <sstream>
 
+// user include files
+#include "FWCore/PluginManager/interface/ModuleDef.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "DataFormats/JetReco/interface/CATopJetTagInfo.h"
+#include "DataFormats/JetReco/interface/PFJetCollection.h"
+
+//include header file
 #include "RecoJets/JetProducers/plugins/BasicToPFJet.h"
 
 BasicToPFJet::BasicToPFJet(const edm::ParameterSet& PSet) :

--- a/RecoJets/JetProducers/plugins/BasicToPFJet.cc
+++ b/RecoJets/JetProducers/plugins/BasicToPFJet.cc
@@ -1,0 +1,65 @@
+// -*- C++ -*-
+//
+// Package:    BasicToPFJet
+// Class:      BasicToPFJet
+// 
+/**\class BasicToPFJet BasicToPFJet.cc UserCode/BasicToPFJet/plugins/BasicToPFJet.cc
+
+ Description: converts reco::BasicJets to reco::PFJets and adds the new PFJetCollection to the event. Originally designed
+              to be a work around for a way to store reco::BasicJets at HLT level
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author:  clint richardson
+//         Created:  Thu, 6 Mar 2014 12:00:00 GMT
+// $Id$
+//
+//
+
+#include "../interface/BasicToPFJet.h"
+
+BasicToPFJet::BasicToPFJet(const edm::ParameterSet& PSet) :
+  src_ (PSet.getParameter<edm::InputTag>("src")),
+  inputToken_ (consumes<reco::BasicJetCollection>(src_))
+{
+  produces<reco::PFJetCollection>();
+}
+
+BasicToPFJet::~BasicToPFJet(){}
+
+
+void BasicToPFJet::fillDescriptions(edm::ConfigurationDescriptions& descriptions){
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("src",edm::InputTag(""));
+  descriptions.add("BasicToPFJet",desc);
+}
+
+void BasicToPFJet::produce( edm::Event& Event, const edm::EventSetup& EventSetup){
+
+  //first get the basic jet collection
+  edm::Handle<reco::BasicJetCollection> BasicJetColl;
+  Event.getByToken(inputToken_, BasicJetColl);
+
+  //now make the new pf jet collection
+  reco::PFJetCollection* PFJetColl = new reco::PFJetCollection;
+  //make the 'specific'
+  reco::PFJet::Specific specific;
+
+  //now get iterator
+  reco::BasicJetCollection::const_iterator i = BasicJetColl->begin();
+
+  //loop over basic jets and convert them to pfjets
+  for(; i!=BasicJetColl->end(); i++){
+    reco::PFJet pfjet(i->p4(),i->vertex(),specific);
+    PFJetColl->push_back(pfjet);
+  }
+
+  std::auto_ptr<reco::PFJetCollection> selectedPFJets(PFJetColl);
+  Event.put(selectedPFJets);
+}
+
+ 
+//define as plug-in for the framework
+DEFINE_FWK_MODULE(BasicToPFJet);

--- a/RecoJets/JetProducers/plugins/BasicToPFJet.cc
+++ b/RecoJets/JetProducers/plugins/BasicToPFJet.cc
@@ -53,7 +53,8 @@ void BasicToPFJet::produce( edm::Event& Event, const edm::EventSetup& EventSetup
   Event.getByToken(inputToken_, BasicJetColl);
 
   //now make the new pf jet collection
-  reco::PFJetCollection* PFJetColl = new reco::PFJetCollection;
+  std::auto_ptr<reco::PFJetCollection> PFJetColl(new reco::PFJetCollection);
+  //reco::PFJetCollection* PFJetColl = new reco::PFJetCollection;
   //make the 'specific'
   reco::PFJet::Specific specific;
 
@@ -66,8 +67,8 @@ void BasicToPFJet::produce( edm::Event& Event, const edm::EventSetup& EventSetup
     PFJetColl->push_back(pfjet);
   }
 
-  std::auto_ptr<reco::PFJetCollection> selectedPFJets(PFJetColl);
-  Event.put(selectedPFJets);
+  //std::auto_ptr<reco::PFJetCollection> selectedPFJets(PFJetColl);
+  Event.put(PFJetColl);
 }
 
  

--- a/RecoJets/JetProducers/plugins/BasicToPFJet.cc
+++ b/RecoJets/JetProducers/plugins/BasicToPFJet.cc
@@ -18,7 +18,7 @@
 //
 //
 
-#include "../interface/BasicToPFJet.h"
+#include "RecoJets/JetProducers/plugins/BasicToPFJet.h"
 
 BasicToPFJet::BasicToPFJet(const edm::ParameterSet& PSet) :
   src_ (PSet.getParameter<edm::InputTag>("src")),

--- a/RecoJets/JetProducers/plugins/BasicToPFJet.h
+++ b/RecoJets/JetProducers/plugins/BasicToPFJet.h
@@ -1,29 +1,13 @@
-#ifndef BasicToPFJet_h
-#define BasicToPFJet_h
+#ifndef RecoJets_JetProducers_BasicToPFJet_h
+#define RecoJets_JetProducers_BasicToPFJet_h
 
-// system include files
-#include <memory>
-#include <vector>
-#include <sstream>
-
-// user include files
-#include "FWCore/PluginManager/interface/ModuleDef.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "DataFormats/JetReco/interface/CATopJetTagInfo.h"
-#include "DataFormats/JetReco/interface/BasicJet.h"
-#include "DataFormats/JetReco/interface/CaloJet.h"
-#include "DataFormats/Candidate/interface/CompositeCandidate.h"
-#include "PhysicsTools/CandUtils/interface/AddFourMomenta.h"
-#include "DataFormats/Candidate/interface/CandMatchMap.h"
-#include "DataFormats/HLTReco/interface/TriggerTypeDefs.h"
-#include "HLTrigger/HLTcore/interface/HLTFilter.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
-using std::cout;
-using std::endl;
+#include "DataFormats/JetReco/interface/BasicJet.h"
+
 
 class BasicToPFJet : public edm::EDProducer {
 

--- a/RecoJets/JetProducers/plugins/BasicToPFJet.h
+++ b/RecoJets/JetProducers/plugins/BasicToPFJet.h
@@ -1,0 +1,43 @@
+#ifndef UserCode_BasicToPFJet_h
+#define UserCode_BasicToPFJet_h
+
+// system include files
+#include <memory>
+#include <vector>
+#include <sstream>
+
+// user include files
+#include "FWCore/PluginManager/interface/ModuleDef.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/JetReco/interface/CATopJetTagInfo.h"
+#include "DataFormats/JetReco/interface/BasicJet.h"
+#include "DataFormats/JetReco/interface/CaloJet.h"
+#include "DataFormats/Candidate/interface/CompositeCandidate.h"
+#include "PhysicsTools/CandUtils/interface/AddFourMomenta.h"
+#include "DataFormats/Candidate/interface/CandMatchMap.h"
+#include "DataFormats/HLTReco/interface/TriggerTypeDefs.h"
+#include "HLTrigger/HLTcore/interface/HLTFilter.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+using std::cout;
+using std::endl;
+
+class BasicToPFJet : public edm::EDProducer {
+
+ public:
+
+  explicit BasicToPFJet(const edm::ParameterSet& PSet);
+  virtual ~BasicToPFJet();
+  virtual void produce(edm::Event & event, const edm::EventSetup & EventSetup) override;
+  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+
+ private:
+  edm::InputTag src_;
+  const edm::EDGetTokenT<reco::BasicJetCollection> inputToken_;
+};
+
+
+#endif

--- a/RecoJets/JetProducers/plugins/BasicToPFJet.h
+++ b/RecoJets/JetProducers/plugins/BasicToPFJet.h
@@ -1,5 +1,5 @@
-#ifndef UserCode_BasicToPFJet_h
-#define UserCode_BasicToPFJet_h
+#ifndef BasicToPFJet_h
+#define BasicToPFJet_h
 
 // system include files
 #include <memory>


### PR DESCRIPTION
As the title suggests this is to add a plugin that will convert reco::BasicJets to reco::PFJets. Such a converter is needed in order to work with Basic Jets using HLTFilters. 
