### PR TITLE
Backporting PFJet-only explicit jet-track association for b-tagging studies

### DIFF
--- a/RecoJets/JetAssociationAlgorithms/interface/JetTracksAssociationExplicit.h
+++ b/RecoJets/JetAssociationAlgorithms/interface/JetTracksAssociationExplicit.h
@@ -1,0 +1,20 @@
+// \class JetTracksAssociationExplicit
+// Associate jets with tracks of PFJet type explicitly by those
+// in the PFCandidate constituents. 
+
+#ifndef JetTracksAssociationExplicit_h
+#define JetTracksAssociationExplicit_h
+
+#include "DataFormats/JetReco/interface/JetTracksAssociation.h"
+
+class JetTracksAssociationExplicit {
+ public:
+  JetTracksAssociationExplicit ();
+  ~JetTracksAssociationExplicit () {}
+
+  void produce (reco::JetTracksAssociation::Container* fAssociation, 
+		const std::vector <edm::RefToBase<reco::Jet> >& fJets,
+		const std::vector <reco::TrackRef>& fTracks) const;
+};
+
+#endif

--- a/RecoJets/JetAssociationAlgorithms/src/JetTracksAssociationExplicit.cc
+++ b/RecoJets/JetAssociationAlgorithms/src/JetTracksAssociationExplicit.cc
@@ -1,0 +1,27 @@
+// Associate jets with tracks by simple "dR" criteria
+// Fedor Ratnikov (UMd), Aug. 28, 2007
+// $Id: JetTracksAssociationExplicit.cc,v 1.1 2012/01/13 21:11:03 srappocc Exp $
+
+#include "RecoJets/JetAssociationAlgorithms/interface/JetTracksAssociationExplicit.h"
+
+#include "DataFormats/JetReco/interface/PFJet.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+
+JetTracksAssociationExplicit::JetTracksAssociationExplicit () 
+{}
+
+void JetTracksAssociationExplicit::produce (reco::JetTracksAssociation::Container* fAssociation, 
+					    const std::vector <edm::RefToBase<reco::Jet> >& fJets,
+					    const std::vector <reco::TrackRef>& fTracks) const 
+{
+  for (unsigned j = 0; j < fJets.size(); ++j) { 
+    reco::PFJet const * pfJet = dynamic_cast<reco::PFJet const *>( &* (fJets[j]) ) ;
+    if ( pfJet != 0 ) {
+      reco::TrackRefVector assoTracks = pfJet->getTrackRefs();
+      reco::JetTracksAssociation::setValue (fAssociation, fJets[j], assoTracks);
+    } else {
+      throw cms::Exception("InvalidConfiguration") 
+	<< "From JetTracksAssociationExplicit::produce: Only PFJets are currently supported for this module" << std::endl;
+    }
+  }
+}

--- a/RecoJets/JetAssociationProducers/BuildFile.xml
+++ b/RecoJets/JetAssociationProducers/BuildFile.xml
@@ -10,6 +10,3 @@
 <use   name="TrackingTools/TransientTrack"/>
 <use   name="TrackingTools/Records"/>
 <use   name="TrackingTools/TrackAssociator"/>
-<export>
-  <lib   name="1"/>
-</export>

--- a/RecoJets/JetAssociationProducers/python/ak5JTA_cff.py
+++ b/RecoJets/JetAssociationProducers/python/ak5JTA_cff.py
@@ -10,6 +10,11 @@ ak5JetTracksAssociatorAtVertex = cms.EDProducer("JetTracksAssociatorAtVertex",
     jets = cms.InputTag("ak5CaloJets")
 )
 
+ak5JetTracksAssociatorExplicit = cms.EDProducer("JetTracksAssociatorExplicit",
+    j2tParametersVX,
+    jets = cms.InputTag("ak5PFJets")
+)
+
 ak5JetTracksAssociatorAtCaloFace = cms.EDProducer("JetTracksAssociatorAtCaloFace",
     j2tParametersCALO,
     jets = cms.InputTag("ak5CaloJets")
@@ -24,3 +29,4 @@ ak5JetExtender = cms.EDProducer("JetExtender",
 
 ak5JTA = cms.Sequence(ak5JetTracksAssociatorAtVertex*ak5JetTracksAssociatorAtCaloFace*ak5JetExtender)
 
+ak5JTAExplicit = cms.Sequence(ak5JetTracksAssociatorExplicit)

--- a/RecoJets/JetAssociationProducers/src/JetTracksAssociatorExplicit.cc
+++ b/RecoJets/JetAssociationProducers/src/JetTracksAssociatorExplicit.cc
@@ -1,0 +1,55 @@
+// \class JetTracksAssociatorExplicit JetTracksAssociatorExplicit.cc 
+//
+// Original Author:  Andrea Rizzi
+//         Created:  Wed Apr 12 11:12:49 CEST 2006
+// Accommodated for Jet Package by: Fedor Ratnikov Jul. 30, 2007
+// $Id: JetTracksAssociatorExplicit.cc,v 1.1 2012/01/13 21:11:04 srappocc Exp $
+//
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+// user include files
+#include "FWCore/Framework/interface/Event.h"
+#include "DataFormats/Common/interface/View.h"
+#include "DataFormats/JetReco/interface/Jet.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/JetReco/interface/JetTracksAssociation.h"
+
+#include "JetTracksAssociatorExplicit.h"
+
+JetTracksAssociatorExplicit::JetTracksAssociatorExplicit(const edm::ParameterSet& fConfig)
+  : mJets (fConfig.getParameter<edm::InputTag> ("jets")),
+    mTracks (fConfig.getParameter<edm::InputTag> ("tracks")),
+    mAssociatorExplicit ()
+{
+
+  produces<reco::JetTracksAssociation::Container> ();
+}
+
+JetTracksAssociatorExplicit::~JetTracksAssociatorExplicit() {}
+
+void JetTracksAssociatorExplicit::produce(edm::Event& fEvent, const edm::EventSetup& fSetup) {
+  edm::Handle <edm::View <reco::Jet> > jets_h;
+  fEvent.getByLabel (mJets, jets_h);
+  edm::Handle <reco::TrackCollection> tracks_h;
+  fEvent.getByLabel (mTracks, tracks_h);
+  
+  std::auto_ptr<reco::JetTracksAssociation::Container> jetTracks (new reco::JetTracksAssociation::Container (reco::JetRefBaseProd(jets_h)));
+
+  // format inputs
+  std::vector <edm::RefToBase<reco::Jet> > allJets;
+  allJets.reserve (jets_h->size());
+  for (unsigned i = 0; i < jets_h->size(); ++i) allJets.push_back (jets_h->refAt(i));
+  std::vector <reco::TrackRef> allTracks;
+  allTracks.reserve (tracks_h->size());
+  // run algo
+  for (unsigned i = 0; i < tracks_h->size(); ++i) {
+    allTracks.push_back (reco::TrackRef (tracks_h, i));
+  }
+
+
+  mAssociatorExplicit.produce (&*jetTracks, allJets, allTracks);
+
+
+  // store output
+  fEvent.put (jetTracks);
+}

--- a/RecoJets/JetAssociationProducers/src/JetTracksAssociatorExplicit.h
+++ b/RecoJets/JetAssociationProducers/src/JetTracksAssociatorExplicit.h
@@ -1,0 +1,33 @@
+// \class JetTracksAssociatorExplicit JetTracksAssociatorExplicit.cc 
+//
+// Original Author:  Andrea Rizzi
+//         Created:  Wed Apr 12 11:12:49 CEST 2006
+// Accommodated for Jet Package by: Fedor Ratnikov Jul. 30, 2007
+// $Id: JetTracksAssociatorExplicit.h,v 1.1 2012/01/13 21:11:04 srappocc Exp $
+//
+//
+#ifndef JetTracksAssociatorExplicit_h
+#define JetTracksAssociatorExplicit_h
+
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "DataFormats/Common/interface/EDProductfwd.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "RecoJets/JetAssociationAlgorithms/interface/JetTracksAssociationExplicit.h"
+#include "RecoJets/JetAssociationAlgorithms/interface/JetTracksAssociationExplicit.h"
+
+class JetTracksAssociatorExplicit : public edm::EDProducer {
+   public:
+      JetTracksAssociatorExplicit(const edm::ParameterSet&);
+      virtual ~JetTracksAssociatorExplicit();
+
+      virtual void produce(edm::Event&, const edm::EventSetup&);
+
+   private:
+     edm::InputTag mJets;
+     edm::InputTag mTracks;
+     JetTracksAssociationExplicit mAssociatorExplicit;
+};
+
+#endif

--- a/RecoJets/JetAssociationProducers/src/SealModule.cc
+++ b/RecoJets/JetAssociationProducers/src/SealModule.cc
@@ -1,11 +1,13 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "JetTracksAssociatorAtVertex.h"
+#include "JetTracksAssociatorExplicit.h"
 #include "JetTracksAssociatorAtCaloFace.h"
 #include "JetExtender.h"
 #include "JetSignalVertexCompatibility.h"
 
 DEFINE_FWK_MODULE(JetTracksAssociatorAtVertex);
+DEFINE_FWK_MODULE(JetTracksAssociatorExplicit);
 DEFINE_FWK_MODULE(JetTracksAssociatorAtCaloFace);
 DEFINE_FWK_MODULE(JetExtender);
 DEFINE_FWK_MODULE(JetSignalVertexCompatibility);


### PR DESCRIPTION
This is a backport of PFJet-only explicit jet-track association available in CMSSW>=6_0_X. This feature has no impact on the standard reconstruction and does not introduce any DataFormat changes.
