### PR TITLE
New jet flavour definition: Pruned GenParticles update

### DIFF
--- a/PhysicsTools/JetExamples/test/printJetFlavourInfo.cc
+++ b/PhysicsTools/JetExamples/test/printJetFlavourInfo.cc
@@ -129,7 +129,7 @@ void printJetFlavourInfo::analyze(const edm::Event& iEvent, const edm::EventSetu
     {
       float dist = reco::deltaR( aJet->eta(), aJet->phi(), (*it)->eta(), (*it)->phi() );
       float dist2 = reco::deltaR( aJet->rapidity(), aJet->phi(), (*it)->rapidity(), (*it)->phi() );
-      std::cout << "                       c hadron " << (it-cHadrons.begin())
+      std::cout << "                        c hadron " << (it-cHadrons.begin())
                 << " PdgID, status, (pt,eta,rapidity,phi), dR(eta-phi), dR(rap-phi) = " << (*it)->pdgId()
                                                                                         << ", " << (*it)->status()
                                                                                         << ", (" << (*it)->pt()
@@ -233,7 +233,7 @@ void printJetFlavourInfo::analyze(const edm::Event& iEvent, const edm::EventSetu
           {
             float dist = reco::deltaR( aSubjet->eta(), aSubjet->phi(), (*it)->eta(), (*it)->phi() );
             float dist2 = reco::deltaR( aSubjet->rapidity(), aSubjet->phi(), (*it)->rapidity(), (*it)->phi() );
-            std::cout << "                            c hadron " << (it-cHadrons.begin())
+            std::cout << "                             c hadron " << (it-cHadrons.begin())
                       << " PdgID, status, (pt,eta,rapidity,phi), dR(eta-phi), dR(rap-phi) = " << (*it)->pdgId()
                                                                                               << ", " << (*it)->status()
                                                                                               << ", (" << (*it)->pt()

--- a/PhysicsTools/JetMCAlgos/src/Herwig6PartonSelector.cc
+++ b/PhysicsTools/JetMCAlgos/src/Herwig6PartonSelector.cc
@@ -24,7 +24,6 @@ Herwig6PartonSelector::run(const edm::Handle<reco::GenParticleCollection> & part
    for(reco::GenParticleCollection::const_iterator it = particles->begin(); it != particles->end(); ++it)
    {
      if( it->status()!=2 ) continue;                   // only accept status==2 particles
-     if( it->numberOfDaughters()==0 ) continue;        // skip particle if it has no daughters (likely a documentation line)
      if( !CandMCTagUtils::isParton( *it ) ) continue;  // skip particle if not a parton
 
      partons->push_back( reco::GenParticleRef( particles, it - particles->begin() ) );

--- a/PhysicsTools/JetMCAlgos/src/HerwigppPartonSelector.cc
+++ b/PhysicsTools/JetMCAlgos/src/HerwigppPartonSelector.cc
@@ -25,7 +25,6 @@ HerwigppPartonSelector::run(const edm::Handle<reco::GenParticleCollection> & par
    for(reco::GenParticleCollection::const_iterator it = particles->begin(); it != particles->end(); ++it)
    {
      if( it->status()!=2 ) continue;                   // only accept status==2 particles
-     if( it->numberOfDaughters()==0 ) continue;        // skip particle if it has no daughters (likely a documentation line)
      if( !CandMCTagUtils::isParton( *it ) ) continue;  // skip particle if not a parton
 
      partons->push_back( reco::GenParticleRef( particles, it - particles->begin() ) );

--- a/PhysicsTools/JetMCAlgos/src/Pythia6PartonSelector.cc
+++ b/PhysicsTools/JetMCAlgos/src/Pythia6PartonSelector.cc
@@ -24,7 +24,6 @@ Pythia6PartonSelector::run(const edm::Handle<reco::GenParticleCollection> & part
    for(reco::GenParticleCollection::const_iterator it = particles->begin(); it != particles->end(); ++it)
    {
      if( it->status()!=2 ) continue;                   // only accept status==2 particles
-     if( it->numberOfDaughters()==0 ) continue;        // skip particle if it has no daughters (likely a documentation line)
      if( !CandMCTagUtils::isParton( *it ) ) continue;  // skip particle if not a parton
 
      partons->push_back( reco::GenParticleRef( particles, it - particles->begin() ) );

--- a/PhysicsTools/JetMCAlgos/src/Pythia8PartonSelector.cc
+++ b/PhysicsTools/JetMCAlgos/src/Pythia8PartonSelector.cc
@@ -1,6 +1,6 @@
 
 /**
- * This is a Pythia8-specific parton selector that selects all status==71 partons. An explanation of
+ * This is a Pythia8-specific parton selector that selects all status==71 or 72 partons. An explanation of
  * the particle status codes returned by Pythia8 can be found in Pythia8 online manual
  * (http://home.thep.lu.se/~torbjorn/pythia81html/ParticleProperties.html).
  */
@@ -25,8 +25,7 @@ Pythia8PartonSelector::run(const edm::Handle<reco::GenParticleCollection> & part
    for(reco::GenParticleCollection::const_iterator it = particles->begin(); it != particles->end(); ++it)
    {
      int status = it->status();
-     if( !(status==71) ) continue;                     // only accept status==71 particles
-     if( it->numberOfDaughters()==0 ) continue;        // skip particle if it has no daughters (likely a documentation line)
+     if( !(status==71 || status==72) ) continue;       // only accept status==71 or 72 particles
      if( !CandMCTagUtils::isParton( *it ) ) continue;  // skip particle if not a parton
 
      partons->push_back( reco::GenParticleRef( particles, it - particles->begin() ) );

--- a/PhysicsTools/JetMCAlgos/src/SherpaPartonSelector.cc
+++ b/PhysicsTools/JetMCAlgos/src/SherpaPartonSelector.cc
@@ -23,7 +23,6 @@ SherpaPartonSelector::run(const edm::Handle<reco::GenParticleCollection> & parti
    for(reco::GenParticleCollection::const_iterator it = particles->begin(); it != particles->end(); ++it)
    {
      if( it->status()!=11 ) continue;                  // only accept status==11 particles
-     if( it->numberOfDaughters()==0 ) continue;        // skip particle if it has no daughters (likely a documentation line)
      if( !CandMCTagUtils::isParton( *it ) ) continue;  // skip particle if not a parton
 
      partons->push_back( reco::GenParticleRef( particles, it - particles->begin() ) );


### PR DESCRIPTION
Minor update to the new jet flavour code that fixes the parton selection routines when pruned GenParticles are used instead of the full GenParticle collection. Does not change DataFormats and has no impact on the standard reconstruction.
