### PR TITLE
add CaloTowerTopology cfi to HGCal geom configs

### DIFF
--- a/Configuration/Geometry/python/GeometryExtended2023HGCalMuon4EtaReco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2023HGCalMuon4EtaReco_cff.py
@@ -39,6 +39,7 @@ CaloGeometryBuilder = cms.ESProducer("CaloGeometryBuilder",
 from Geometry.EcalAlgo.EcalBarrelGeometry_cfi import *
 from Geometry.HcalEventSetup.HcalGeometry_cfi import *
 from Geometry.HcalEventSetup.CaloTowerGeometry_cfi import *
+from Geometry.HcalEventSetup.CaloTowerTopology_cfi import *
 from Geometry.HcalEventSetup.HcalTopology_cfi import *
 from Geometry.ForwardGeometry.ForwardGeometry_cfi import *
 

--- a/Configuration/Geometry/python/GeometryExtended2023HGCalMuonReco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2023HGCalMuonReco_cff.py
@@ -39,6 +39,7 @@ CaloGeometryBuilder = cms.ESProducer("CaloGeometryBuilder",
 from Geometry.EcalAlgo.EcalBarrelGeometry_cfi import *
 from Geometry.HcalEventSetup.HcalGeometry_cfi import *
 from Geometry.HcalEventSetup.CaloTowerGeometry_cfi import *
+from Geometry.HcalEventSetup.CaloTowerTopology_cfi import *
 from Geometry.HcalEventSetup.HcalTopology_cfi import *
 from Geometry.ForwardGeometry.ForwardGeometry_cfi import *
 

--- a/Configuration/Geometry/python/GeometryExtended2023HGCalReco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2023HGCalReco_cff.py
@@ -39,6 +39,7 @@ CaloGeometryBuilder = cms.ESProducer("CaloGeometryBuilder",
 from Geometry.EcalAlgo.EcalBarrelGeometry_cfi import *
 from Geometry.HcalEventSetup.HcalGeometry_cfi import *
 from Geometry.HcalEventSetup.CaloTowerGeometry_cfi import *
+from Geometry.HcalEventSetup.CaloTowerTopology_cfi import *
 from Geometry.HcalEventSetup.HcalTopology_cfi import *
 from Geometry.ForwardGeometry.ForwardGeometry_cfi import *
 


### PR DESCRIPTION
This fixes the CaloTowerTopology-related error in the HGCal tests as noted in [pull request 3187](https://github.com/cms-sw/cmssw/pull/3187).
