### PR TITLE
Change handling of AlCaReco skims dedicated to PCL in ConfigDP

### DIFF
--- a/Configuration/DataProcessing/python/Reco.py
+++ b/Configuration/DataProcessing/python/Reco.py
@@ -63,7 +63,13 @@ class Reco(Scenario):
         Proton collision data taking express processing
 
         """
-        step = stepALCAPRODUCER(args['skims'])
+        skims = args['skims']
+        # the AlCaReco skims for PCL should only run during AlCaSkimming step which uses the same configuration on the Tier0 side, for this reason we drop them here
+        pclWkflws = [x for x in skims if "PromptCalibProd" in x]
+        for wfl in pclWkflws:
+            skims.remove(wfl)
+        
+        step = stepALCAPRODUCER(skims)
         dqmStep= dqmSeq(args,'')
         options = Options()
         options.__dict__.update(defaultOptions.__dict__)


### PR DESCRIPTION
The PromptCalibProd\* AlCaReco skims used to run PCL are now dropped from express configuration so that they are only run in the AlCaSkimming step @ Tier0.
