### PR TITLE
Removed mutable from L1GtTriggerMenu

### DIFF
--- a/CondFormats/L1TObjects/interface/L1GtTriggerMenu.h
+++ b/CondFormats/L1TObjects/interface/L1GtTriggerMenu.h
@@ -270,7 +270,7 @@ public:
 private:
 
     /// map containing the conditions (per condition chip) - transient
-    mutable std::vector<ConditionMap> m_conditionMap;
+    std::vector<ConditionMap> m_conditionMap;
 
 private:
 


### PR DESCRIPTION
The declaration of mutable on a member data was unnecessary since
that member data was never modified in a const function. Removing
the mutable avoids warnings from the static analyzer.
