### PR TITLE
Added Pythia8 status code for intermediate resonances to the GenJets particle selector

### DIFF
--- a/RecoJets/JetProducers/plugins/InputGenJetsParticleSelector.cc
+++ b/RecoJets/JetProducers/plugins/InputGenJetsParticleSelector.cc
@@ -78,7 +78,7 @@ void InputGenJetsParticleSelector::setExcludeFromResonancePids(const std::vector
 
 bool InputGenJetsParticleSelector::isParton(int pdgId) const{
   pdgId = (pdgId > 0 ? pdgId : -pdgId) % 10000;
-  return (pdgId > 0 && pdgId < 6) || pdgId == 7 ||
+  return (pdgId > 0 && pdgId < 6) ||
     pdgId == 9 || (tausAsJets && pdgId == 15) || pdgId == 21;
   // tops are not considered "regular" partons
   // but taus eventually are (since they may hadronize later)
@@ -95,7 +95,7 @@ bool InputGenJetsParticleSelector::isResonance(int pdgId)
 {
   // gauge bosons and tops
   pdgId = (pdgId > 0 ? pdgId : -pdgId) % 10000;
-  return (pdgId > 21 && pdgId <= 42) || pdgId == 6 || pdgId == 8 ;  //BUG! war 21. 22=gamma..
+  return (pdgId > 21 && pdgId <= 42) || pdgId == 6 || pdgId == 7 || pdgId == 8 ;  //BUG! was 21. 22=gamma..
 }
 
 bool InputGenJetsParticleSelector::isIgnored(int pdgId) const

--- a/RecoJets/JetProducers/plugins/InputGenJetsParticleSelector.cc
+++ b/RecoJets/JetProducers/plugins/InputGenJetsParticleSelector.cc
@@ -233,10 +233,11 @@ void InputGenJetsParticleSelector::produce (edm::Event &evt, const edm::EventSet
   edm::Handle<reco::GenParticleCollection> genParticles;
   evt.getByToken(input_genpartcoll_token_, genParticles );
     
-    
+  std::map<const reco::GenParticle*,size_t> particlePtrIdxMap;
   ParticleVector particles;
   for (reco::GenParticleCollection::const_iterator iter=genParticles->begin();iter!=genParticles->end();++iter){
-    particles.push_back(&*iter); 
+    particles.push_back(&*iter);
+    particlePtrIdxMap[&*iter] = (iter - genParticles->begin());
   }
   
   std::sort(particles.begin(), particles.end());
@@ -266,8 +267,8 @@ void InputGenJetsParticleSelector::produce (edm::Event &evt, const edm::EventSet
     }
 	
   }
- unsigned int count=0;
-  for(size_t idx=0;idx<genParticles->size();++idx){ 
+
+  for(size_t idx = 0; idx < size; ++idx){ 
     const reco::GenParticle *particle = particles[idx];
     if (!selected[idx] || invalid[idx]){
       continue;
@@ -286,10 +287,9 @@ void InputGenJetsParticleSelector::produce (edm::Event &evt, const edm::EventSet
 
    
     if (particle->pt() >= ptMin){
-      edm::Ref<reco::GenParticleCollection> particleRef(genParticles,idx);
+      edm::Ref<reco::GenParticleCollection> particleRef(genParticles,particlePtrIdxMap[particle]);
       selected_->push_back(particleRef);
       //cout<<"Finally we have: ["<<setw(4)<<idx<<"] "<<setw(4)<<particle->pdgId()<<" "<<particle->pt()<<endl;
-      count++;
     }
   }
   evt.put(selected_);

--- a/RecoJets/JetProducers/plugins/InputGenJetsParticleSelector.cc
+++ b/RecoJets/JetProducers/plugins/InputGenJetsParticleSelector.cc
@@ -27,6 +27,11 @@
 *
 *
 * \author: Christophe Saout, Andreas Oehler
+* 
+* Modifications:
+* 
+*    04.08.2014: Dinko Ferencek
+*                Added support for Pythia8 (status=22 for intermediate resonances)
 *
 */
 
@@ -115,8 +120,7 @@ bool InputGenJetsParticleSelector::isExcludedFromResonance(int pdgId) const
 }
 
 static unsigned int partIdx(const InputGenJetsParticleSelector::ParticleVector &p,
-			    //const reco::GenParticle *particle)
-			    const reco::GenParticle *particle)
+			       const reco::GenParticle *particle)
 {
   InputGenJetsParticleSelector::ParticleVector::const_iterator pos =
     std::lower_bound(p.begin(), p.end(), particle);
@@ -180,7 +184,7 @@ InputGenJetsParticleSelector::fromResonance(ParticleBitmap &invalid,
 
   if (invalid[idx]) return kIndirect;
       
-  if (isResonance(id) && particle->status() == 3){
+  if (isResonance(id) && (particle->status() == 3 || particle->status() == 22) ){
     return kDirect;
   }
 


### PR DESCRIPTION
Fix for the issue originally reported in https://hypernews.cern.ch/HyperNews/CMS/get/jet-algorithms/307.html The following changes were implemented:
- added Pythia8 status code for intermediate resonances so that GenJets 
  in Pythia6 and Pythia8 samples behave the same way 
- moved b' (pdgId=7) from partons to resonances (I don't really know why 
  b' was considered as parton in the first place)
- there is a pointer sorting step in the code which makes sense from the 
  point of view of efficient searching through the linked list of 
  GenParticles (and this is done quite frequently in the code) but there is no
  protection against changing the particle 
  order wrt the original GenParticle collection after pointer sorting is 
  performed in a separate vector. The increase in timing that results from the added 
  protection is not very significant (~3%).
