### PR TITLE
use unique_ptr for cablingtree, remove option to use cablingmap

### DIFF
--- a/CondCore/Utilities/BuildFile.xml
+++ b/CondCore/Utilities/BuildFile.xml
@@ -1,4 +1,4 @@
-<flags CXXFLAGS="-Wno-sign-compare -Wno-unused-variable "/>
+<flags CXXFLAGS="-Wno-sign-compare -Wno-unused-variable -Os"/>
 <use   name="FWCore/Utilities"/>
 <use   name="FWCore/PluginManager"/>
 <use   name="FWCore/MessageLogger"/>

--- a/CondFormats/SiPixelObjects/interface/SiPixelFedCablingMap.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelFedCablingMap.h
@@ -6,6 +6,14 @@
 
 #include <string>
 #include <map>
+#include<memory>
+
+#include "FWCore/Utilities/interface/GCC11Compatibility.h"
+#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
+#define NO_DICT
+#endif
+
+
 class SiPixelFedCablingTree;
 
 
@@ -21,7 +29,9 @@ public:
 
   virtual ~SiPixelFedCablingMap() {}
 
-  SiPixelFedCablingTree * cablingTree() const; 
+#ifdef NO_DICT
+  std::unique_ptr<SiPixelFedCablingTree> cablingTree() const; 
+#endif
 
   virtual std::string version() const { return theVersion; }
 

--- a/CondFormats/SiPixelObjects/src/SiPixelFedCablingMap.cc
+++ b/CondFormats/SiPixelObjects/src/SiPixelFedCablingMap.cc
@@ -60,9 +60,9 @@ SiPixelFedCablingMap::SiPixelFedCablingMap(const SiPixelFedCablingTree *cab)
   }  
 }
 
-SiPixelFedCablingTree * SiPixelFedCablingMap::cablingTree() const
+std::unique_ptr<SiPixelFedCablingTree>  SiPixelFedCablingMap::cablingTree() const
 {
-  SiPixelFedCablingTree * tree = new SiPixelFedCablingTree(theVersion); 
+  std::unique_ptr<SiPixelFedCablingTree>  tree(new SiPixelFedCablingTree(theVersion)); 
   for (Map::const_iterator im = theMap.begin(); im != theMap.end(); im++) {
     const sipixelobjects::PixelROC & roc = im->second;
     unsigned int fedId = im->first.fed;

--- a/CondFormats/SiPixelObjects/test/SiPixelFedCablingMapAnalyzer.cc
+++ b/CondFormats/SiPixelObjects/test/SiPixelFedCablingMapAnalyzer.cc
@@ -37,10 +37,9 @@ void SiPixelFedCablingMapAnalyzer::analyze( const edm::Event& iEvent, const edm:
    iSetup.get<SiPixelFedCablingMapRcd>().get(map);
 
    LogInfo(" got map, version: ") << map->version();
-   SiPixelFedCablingTree * tree = map->cablingTree();
+   auto tree = map->cablingTree();
    LogInfo("PRINT MAP:")<<tree->print(100);
    LogInfo("PRINT MAP, end:");
-   delete tree;
 
 }
 

--- a/EventFilter/SiPixelRawToDigi/interface/PixelDataFormatter.h
+++ b/EventFilter/SiPixelRawToDigi/interface/PixelDataFormatter.h
@@ -48,6 +48,7 @@ class SiPixelFedCabling;
 class SiPixelQuality;
 class SiPixelFrameConverter;
 class SiPixelFrameReverter;
+class SiPixelFedCablingTree;
 
 class PixelDataFormatter {
 
@@ -83,7 +84,8 @@ private:
   mutable int theDigiCounter;
   mutable int theWordCounter;
 
-  const SiPixelFedCabling* theCablingTree;
+
+  SiPixelFedCabling const * theCablingTree;
   const SiPixelFrameReverter* theFrameReverter;
   const SiPixelQuality* badPixelInfo;
   const std::set<unsigned int> * modulesToUnpack;

--- a/EventFilter/SiPixelRawToDigi/interface/PixelUnpackingRegions.h
+++ b/EventFilter/SiPixelRawToDigi/interface/PixelUnpackingRegions.h
@@ -11,12 +11,12 @@
 
 #include "CondFormats/DataRecord/interface/SiPixelFedCablingMapRcd.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingMap.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingTree.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include <cmath>
 #include <vector>
 #include <set>
-#include <boost/scoped_ptr.hpp>
 
 
 /** \class PixelUnpackingRegions
@@ -125,7 +125,7 @@ private:
   std::vector<Module> phiFPIXp_;
   std::vector<Module> phiFPIXm_;
 
-  boost::scoped_ptr<SiPixelFedCabling> cabling_;
+  std::unique_ptr<SiPixelFedCablingTree> cabling_;
   math::XYZPoint beamSpot_;
 
   edm::ESWatcher<SiPixelFedCablingMapRcd> watcherSiPixelFedCablingMap_;

--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelDigiToRaw.cc
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelDigiToRaw.cc
@@ -24,8 +24,7 @@
 using namespace std;
 
 SiPixelDigiToRaw::SiPixelDigiToRaw( const edm::ParameterSet& pset ) :
-  cablingTree_(0),
-  frameReverter_(0),
+  frameReverter_(nullptr),
   config_(pset),
   hCPU(0), hDigi(0), theTimer(0)
 {
@@ -50,7 +49,6 @@ SiPixelDigiToRaw::SiPixelDigiToRaw( const edm::ParameterSet& pset ) :
 
 // -----------------------------------------------------------------------------
 SiPixelDigiToRaw::~SiPixelDigiToRaw() {
-  delete cablingTree_;
   delete frameReverter_;
 
   if (theTimer) {
@@ -91,14 +89,14 @@ void SiPixelDigiToRaw::produce( edm::Event& ev,
     edm::ESHandle<SiPixelFedCablingMap> cablingMap;
     es.get<SiPixelFedCablingMapRcd>().get( cablingMap );
     fedIds = cablingMap->fedIds();
-    if (cablingTree_) delete cablingTree_; cablingTree_= cablingMap->cablingTree();
+    cablingTree_= cablingMap->cablingTree();
     if (frameReverter_) delete frameReverter_; frameReverter_ = new SiPixelFrameReverter( es, cablingMap.product() );
   }
 
   debug = edm::MessageDrop::instance()->debugEnabled;
   if (debug) LogDebug("SiPixelDigiToRaw") << cablingTree_->version();
 
-  PixelDataFormatter formatter(cablingTree_);
+  PixelDataFormatter formatter(cablingTree_.get());
   formatter.passFrameReverter(frameReverter_);
   if (theTimer) theTimer->start();
 

--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelDigiToRaw.h
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelDigiToRaw.h
@@ -20,7 +20,7 @@ class SiPixelFrameReverter;
 class TH1D;
 class R2DTimerObserver;
 
-class SiPixelDigiToRaw : public edm::EDProducer {
+class SiPixelDigiToRaw final : public edm::EDProducer {
 public:
 
   /// ctor
@@ -34,11 +34,11 @@ public:
   virtual void endJob() {}
 
   /// get data, convert to raw event, attach again to Event
-  virtual void produce( edm::Event&, const edm::EventSetup& );
+  virtual void produce( edm::Event&, const edm::EventSetup& ) override;
 
 private:
 
-  SiPixelFedCablingTree * cablingTree_;
+  std::unique_ptr<SiPixelFedCablingTree> cablingTree_;
   SiPixelFrameReverter* frameReverter_;
   edm::ParameterSet config_;
   TH1D *hCPU, *hDigi;

--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigi.h
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigi.h
@@ -40,7 +40,6 @@ private:
   edm::ParameterSet config_;
   std::unique_ptr<SiPixelFedCablingTree> cabling_;
   const SiPixelQuality* badPixelInfo_;
-  bool  useCablingTree_;
   PixelUnpackingRegions* regions_;
   edm::EDGetTokenT<FEDRawDataCollection> tFEDRawDataCollection; 
 

--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigi.h
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigi.h
@@ -16,6 +16,7 @@
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
+class SiPixelFedCablingTree;
 class SiPixelFedCabling;
 class SiPixelQuality;
 class TH1D;
@@ -37,7 +38,7 @@ public:
 private:
 
   edm::ParameterSet config_;
-  const SiPixelFedCabling* cabling_;
+  std::unique_ptr<SiPixelFedCablingTree> cabling_;
   const SiPixelQuality* badPixelInfo_;
   bool  useCablingTree_;
   PixelUnpackingRegions* regions_;

--- a/EventFilter/SiPixelRawToDigi/python/SiPixelRawToDigi_cfi.py
+++ b/EventFilter/SiPixelRawToDigi/python/SiPixelRawToDigi_cfi.py
@@ -6,7 +6,6 @@ siPixelDigis = cms.EDProducer("SiPixelRawToDigi",
     InputLabel = cms.InputTag("siPixelRawData"),
     CheckPixelOrder = cms.bool(False),
     UseQualityInfo = cms.bool(False),
-    UseCablingTree = cms.untracked.bool(True),
 ## ErrorList: list of error codes used by tracking to invalidate modules
     ErrorList = cms.vint32(29),
 ## UserErrorList: list of error codes used by Pixel experts for investigation

--- a/EventFilter/SiPixelRawToDigi/src/PixelUnpackingRegions.cc
+++ b/EventFilter/SiPixelRawToDigi/src/PixelUnpackingRegions.cc
@@ -97,7 +97,7 @@ void PixelUnpackingRegions::initialize(const edm::EventSetup& es)
   {
     edm::ESTransientHandle<SiPixelFedCablingMap> cablingMap;
     es.get<SiPixelFedCablingMapRcd>().get( cablingMap );
-    cabling_.reset((SiPixelFedCabling*)cablingMap->cablingTree());
+    cabling_ = cablingMap->cablingTree();
 
     edm::ESHandle<TrackerGeometry> geom;
     // get the TrackerGeom


### PR DESCRIPTION
required to be fully thread safe conformant. 
Took the opportunity to clean the code a bit following Danek advice.
