### PR TITLE
fix vertex loop in PFPhotonIsolationCalculator

### DIFF
--- a/CommonTools/ParticleFlow/src/PFPileUpAlgo.cc
+++ b/CommonTools/ParticleFlow/src/PFPileUpAlgo.cc
@@ -42,37 +42,20 @@ void PFPileUpAlgo::process(const PFCollection & pfCandidates,
 int 
 PFPileUpAlgo::chargedHadronVertex( const reco::VertexCollection& vertices, const reco::PFCandidate& pfcand ) const {
 
-  
-  reco::TrackBaseRef trackBaseRef( pfcand.trackRef() );
-  
+  auto const & track = pfcand.trackRef();  
   size_t  iVertex = 0;
-  unsigned index=0;
-  unsigned nFoundVertex = 0;
-  typedef reco::VertexCollection::const_iterator IV;
-  typedef reco::Vertex::trackRef_iterator IT;
+  unsigned int index=0;
+  unsigned int nFoundVertex = 0;
   float bestweight=0;
-  for(IV iv=vertices.begin(); iv!=vertices.end(); ++iv, ++index) {
-
-    const reco::Vertex& vtx = *iv;
-    
-    // loop on tracks in vertices
-    for(IT iTrack=vtx.tracks_begin(); 
-	iTrack!=vtx.tracks_end(); ++iTrack) {
-	 
-      const reco::TrackBaseRef& baseRef = *iTrack;
-
-      // one of the tracks in the vertex is the same as 
-      // the track considered in the function
-      if(baseRef == trackBaseRef ) {
-	float w = vtx.trackWeight(baseRef);
-	//select the vertex for which the track has the highest weight
-	if (w > bestweight){
+  for( auto const & vtx : vertices) {
+      float w = vtx.trackWeight(track);
+     //select the vertex for which the track has the highest weight
+ 	if (w > bestweight){
 	  bestweight=w;
 	  iVertex=index;
 	  nFoundVertex++;
-	}	 	
-      }
-    }
+	}
+     ++index;
   }
 
   if (nFoundVertex>0){
@@ -89,7 +72,7 @@ PFPileUpAlgo::chargedHadronVertex( const reco::VertexCollection& vertices, const
     double ztrack = pfcand.vertex().z();
     bool foundVertex = false;
     index = 0;
-    for(IV iv=vertices.begin(); iv!=vertices.end(); ++iv, ++index) {
+    for(auto iv=vertices.begin(); iv!=vertices.end(); ++iv, ++index) {
 
       double dz = fabs(ztrack - iv->z());
       if(dz<dzmin) {

--- a/RecoEgamma/PhotonIdentification/src/PFPhotonIsolationCalculator.cc
+++ b/RecoEgamma/PhotonIdentification/src/PFPhotonIsolationCalculator.cc
@@ -684,7 +684,7 @@ if(fabs(dxy) > 0.2)
 //--------------------------------------------------------------------------------------------------
 reco::VertexRef PFPhotonIsolationCalculator::chargedHadronVertex( edm::Handle< reco::VertexCollection > verticesColl, const reco::PFCandidate& pfcand ){
 
-  //code copied from Florian's PFNoPU class (who clearly did not understand the use of vtx.trackWeight....)
+  //code copied from Florian's PFNoPU class (corrected removing the double loop....)
     
   auto const & track = pfcand.trackRef();
 

--- a/RecoEgamma/PhotonIdentification/src/PFPhotonIsolationCalculator.cc
+++ b/RecoEgamma/PhotonIdentification/src/PFPhotonIsolationCalculator.cc
@@ -684,39 +684,27 @@ if(fabs(dxy) > 0.2)
 //--------------------------------------------------------------------------------------------------
 reco::VertexRef PFPhotonIsolationCalculator::chargedHadronVertex( edm::Handle< reco::VertexCollection > verticesColl, const reco::PFCandidate& pfcand ){
 
-  //code copied from Florian's PFNoPU class
+  //code copied from Florian's PFNoPU class (who clearly did not understand the use of vtx.trackWeight....)
     
-  reco::TrackBaseRef trackBaseRef( pfcand.trackRef() );
+  auto const & track = pfcand.trackRef();
 
   size_t iVertex = 0;
-  unsigned index=0;
-  unsigned nFoundVertex = 0;
+  unsigned int index=0;
+  unsigned int nFoundVertex = 0;
 
   float bestweight=0;
   
   const reco::VertexCollection& vertices = *(verticesColl.product());
 
-  for( reco::VertexCollection::const_iterator iv=vertices.begin(); iv!=vertices.end(); ++iv, ++index) {
-    
-    const reco::Vertex& vtx = *iv;
-    
-    // loop on tracks in vertices
-    for(reco::Vertex::trackRef_iterator iTrack=vtx.tracks_begin();iTrack!=vtx.tracks_end(); ++iTrack) {
-      const reco::TrackBaseRef& baseRef = *iTrack;
-
-      // one of the tracks in the vertex is the same as
-      // the track considered in the function
-      if(baseRef == trackBaseRef ) {
-	float w = vtx.trackWeight(baseRef);
-	//select the vertex for which the track has the highest weight
-	if (w > bestweight){
-	  bestweight=w;
-	  iVertex=index;
-	  nFoundVertex++;
-	}
-      }
+  for( auto const & vtx :  vertices) {
+    float w = vtx.trackWeight(track); // 0 if does not belong here
+    //select the vertex for which the track has the highest weight
+    if (w > bestweight){ // should we break here?
+        bestweight=w;
+	iVertex=index;
+	nFoundVertex++;
     }
- 
+    ++index; 
   }
  
  


### PR DESCRIPTION
Removed an "obfuscated" nested loop.
also profit of the new template interface to remove RefBase churn...
(still, it is looping on all the tracks in all the vertices for each charged particle...)

accounting for more than 1% of the time in Reco 40PU25ns TTBAR
http://innocent.web.cern.ch/innocent/perfResults/igprof-navigator/TTBAR_step3_ori_CMSSW_7_1_X_2014-04-05-1400_slc6_amd64_gcc490/190

No regression expected. No regression observed
