### PR TITLE
remove uses of hardcoded HCAL geometry

### DIFF
--- a/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc
+++ b/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc
@@ -3,7 +3,6 @@
 #include <cmath>
 #include <string>
 #include "CalibCalorimetry/HcalTPGAlgos/interface/HcaluLUTTPGCoder.h"
-#include "Geometry/HcalTowerAlgo/src/HcalHardcodeGeometryData.h"
 #include "CalibFormats/HcalObjects/interface/HcalCoderDb.h"
 #include "CalibFormats/HcalObjects/interface/HcalCalibrations.h"
 #include "CalibFormats/HcalObjects/interface/HcalDbService.h"
@@ -192,8 +191,12 @@ void HcaluLUTTPGCoder::update(const HcalDbService& conditions) {
    float nominalgain_ = metadata->getNominalGain();
 
    std::map<int, float> cosh_ieta;
-   for (int i = 0; i < 13; ++i)
-      cosh_ieta[i+29] = cosh((theHFEtaBounds[i+1] + theHFEtaBounds[i])/2.);
+   for (int i = metadata->topo()->firstHFRing(); i <= metadata->topo()->lastHFRing(); ++i){
+      std::pair<double,double> etas = metadata->topo()->etaRange(HcalForward,i);
+      double eta1 = etas.first;
+      double eta2 = etas.second;
+      cosh_ieta[i] = cosh((eta1 + eta2)/2.);
+   }
 
    HcalSubdetector subdets[] = {HcalBarrel, HcalEndcap, HcalForward};
    for (int isub = 0; isub < 3; ++isub){

--- a/FastSimulation/CalorimeterProperties/src/Calorimeter.cc
+++ b/FastSimulation/CalorimeterProperties/src/Calorimeter.cc
@@ -1,6 +1,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
+#include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
 #include "Geometry/EcalAlgo/interface/EcalBarrelGeometry.h"
@@ -16,7 +17,6 @@
 #include "FastSimulation/CalorimeterProperties/interface/HCALBarrelProperties.h"
 #include "FastSimulation/CalorimeterProperties/interface/HCALEndcapProperties.h"
 #include "FastSimulation/CalorimeterProperties/interface/HCALForwardProperties.h"
-#include "Geometry/HcalTowerAlgo/interface/HcalHardcodeGeometryLoader.h"
 
 Calorimeter::Calorimeter():
   myPreshowerLayer1Properties_(NULL),

--- a/RecoLocalCalo/HcalRecAlgos/src/HcalHFStatusBitFromRecHits.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HcalHFStatusBitFromRecHits.cc
@@ -1,6 +1,6 @@
 #include "RecoLocalCalo/HcalRecAlgos/interface/HcalHFStatusBitFromRecHits.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "Geometry/HcalTowerAlgo/src/HcalHardcodeGeometryData.h" // for eta bounds
+#include "Geometry/CaloTopology/interface/HcalTopology.h"
 
 #include <algorithm> // for "max"
 #include <cmath>
@@ -49,7 +49,10 @@ void HcalHFStatusBitFromRecHits::hfSetFlagFromRecHits(HFRecHitCollection& rec,
 
       ieta =iHF->id().ieta();  // int between 29-41
       // eta = average value between cell eta bounds
-      coshEta=fabs(cosh(0.5*(theHFEtaBounds[abs(ieta)-29]+theHFEtaBounds[abs(ieta)-28])));
+      std::pair<double,double> etas = myqual->topo()->etaRange(HcalForward,ieta);
+      double eta1 = etas.first;
+      double eta2 = etas.second;
+      coshEta=fabs(cosh(0.5*(eta1+eta2)));
 
       status=0; // status bit for rechit
 

--- a/RecoLocalCalo/HcalRecAlgos/src/HcalHF_PETalgorithm.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HcalHF_PETalgorithm.cc
@@ -1,10 +1,10 @@
 #include "RecoLocalCalo/HcalRecAlgos/interface/HcalHF_PETalgorithm.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "Geometry/HcalTowerAlgo/src/HcalHardcodeGeometryData.h" // for eta bounds
 #include "RecoLocalCalo/HcalRecAlgos/interface/HcalCaloFlagLabels.h"
 #include "CondFormats/HcalObjects/interface/HcalChannelQuality.h"
 #include "RecoLocalCalo/HcalRecAlgos/interface/HcalSeverityLevelComputer.h"
 #include "RecoLocalCalo/HcalRecAlgos/interface/HcalSeverityLevelComputerRcd.h"
+#include "Geometry/CaloTopology/interface/HcalTopology.h"
 
 #include <algorithm> // for "max"
 #include <cmath>
@@ -78,7 +78,10 @@ void HcalHF_PETalgorithm::HFSetFlagFromPET(HFRecHit& hf,
   int ieta=hf.id().ieta(); // get coordinates of rechit being checked
   int depth=hf.id().depth();
   int iphi=hf.id().iphi();
-  double fEta = 0.5*(theHFEtaBounds[abs(ieta)-29] + theHFEtaBounds[abs(ieta)-28]); // calculate eta as average of eta values at ieta boundaries
+  std::pair<double,double> etas = myqual->topo()->etaRange(HcalForward,ieta);
+  double eta1 = etas.first;
+  double eta2 = etas.second;
+  double fEta = 0.5*(eta1 + eta2); // calculate eta as average of eta values at ieta boundaries
   double energy=hf.energy();
   double ET = energy/fabs(cosh(fEta));
 

--- a/RecoLocalCalo/HcalRecAlgos/src/HcalHF_S9S1algorithm.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HcalHF_S9S1algorithm.cc
@@ -1,10 +1,10 @@
 #include "RecoLocalCalo/HcalRecAlgos/interface/HcalHF_S9S1algorithm.h"
 #include "RecoLocalCalo/HcalRecAlgos/interface/HcalCaloFlagLabels.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "Geometry/HcalTowerAlgo/src/HcalHardcodeGeometryData.h" // for eta bounds
 #include "RecoLocalCalo/HcalRecAlgos/interface/HcalSeverityLevelComputer.h"
 #include "RecoLocalCalo/HcalRecAlgos/interface/HcalSeverityLevelComputerRcd.h"
 #include "CondFormats/HcalObjects/interface/HcalChannelQuality.h"
+#include "Geometry/CaloTopology/interface/HcalTopology.h"
 
 #include <algorithm> // for "max"
 #include <cmath>
@@ -92,7 +92,10 @@ void HcalHF_S9S1algorithm::HFSetFlagFromS9S1(HFRecHit& hf,
   int ieta=hf.id().ieta(); // get coordinates of rechit being checked
   int depth=hf.id().depth();
   int iphi=hf.id().iphi();
-  double fEta = 0.5*(theHFEtaBounds[abs(ieta)-29] + theHFEtaBounds[abs(ieta)-28]); // calculate eta as average of eta values at ieta boundaries
+  std::pair<double,double> etas = myqual->topo()->etaRange(HcalForward,ieta);
+  double eta1 = etas.first;
+  double eta2 = etas.second;
+  double fEta = 0.5*(eta1 + eta2); // calculate eta as average of eta values at ieta boundaries
   double energy=hf.energy();
   double ET = energy/fabs(cosh(fEta));
 

--- a/RecoLocalCalo/HcalRecAlgos/test/HcalRecHitReflagger.cc
+++ b/RecoLocalCalo/HcalRecAlgos/test/HcalRecHitReflagger.cc
@@ -30,12 +30,13 @@
 
 #include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
 #include "RecoLocalCalo/HcalRecAlgos/interface/HcalCaloFlagLabels.h"
-#include "Geometry/HcalTowerAlgo/src/HcalHardcodeGeometryData.h" // for eta bounds
 
+#include "Geometry/CaloTopology/interface/HcalTopology.h"
 #include "CondFormats/HcalObjects/interface/HcalChannelStatus.h"
 #include "CondFormats/HcalObjects/interface/HcalChannelQuality.h"
 #include "CondFormats/HcalObjects/interface/HcalCondObjectContainer.h"
 #include "CondFormats/DataRecord/interface/HcalChannelQualityRcd.h"
+#include "Geometry/Records/interface/HcalRecNumberingRecord.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 
 
@@ -73,6 +74,7 @@ private:
   double GetSlope(const int ieta, const std::vector<double>& params); 
 
   // ----------member data ---------------------------
+  const HcalTopology* topo;
   edm::InputTag hfInputLabel_;
   int  hfFlagBit_;
 
@@ -194,6 +196,11 @@ HcalRecHitReflagger::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
    // prepare the output HF RecHit collection
    std::auto_ptr<HFRecHitCollection> pOut(new HFRecHitCollection());
+
+  //get the hcal topology
+  edm::ESHandle<HcalTopology> topo_;
+  iSetup.get<HcalRecNumberingRecord>().get(topo_);
+  topo = &*topo_;
    
    // loop over rechits, and set the new bit you wish to use
    for (HFRecHitCollection::const_iterator recHit=hfRecHits->begin(); recHit!=hfRecHits->end(); ++recHit) {
@@ -279,7 +286,10 @@ bool HcalRecHitReflagger::CheckPET(const HFRecHit& hf)
   int ieta = id.ieta();
   double energy=hf.energy();
   int depth = id.depth();
-  double fEta=fabs(0.5*(theHFEtaBounds[abs(ieta)-29]+theHFEtaBounds[abs(ieta)-28]));
+  std::pair<double,double> etas = topo->etaRange(HcalForward,ieta);
+  double eta1 = etas.first;
+  double eta2 = etas.second;
+  double fEta = 0.5*(eta1 + eta2); // calculate eta as average of eta values at ieta boundaries
   double ET = energy/cosh(fEta);
   double threshold=0;
   
@@ -346,7 +356,10 @@ bool HcalRecHitReflagger::CheckS9S1(const HFRecHit& hf)
   int ieta = id.ieta();
   double energy=hf.energy();
   int depth = id.depth();
-  double fEta=fabs(0.5*(theHFEtaBounds[abs(ieta)-29]+theHFEtaBounds[abs(ieta)-28]));
+  std::pair<double,double> etas = topo->etaRange(HcalForward,ieta);
+  double eta1 = etas.first;
+  double eta2 = etas.second;
+  double fEta = 0.5*(eta1 + eta2); // calculate eta as average of eta values at ieta boundaries
   double ET = energy/cosh(fEta);
   double threshold=0;
 


### PR DESCRIPTION
This removes uses of hardcoded HCAL geometry files which have been deleted, related to [pull request 3278](https://github.com/cms-sw/cmssw/pull/3278).
