### PR TITLE
Thread safety cleanup

### DIFF
--- a/FastSimulation/ParticlePropagator/src/ParticlePropagator.cc
+++ b/FastSimulation/ParticlePropagator/src/ParticlePropagator.cc
@@ -153,7 +153,7 @@ ParticlePropagator::propagateToBoundSurface(const TrackerLayer& layer) {
 
 
   fiducial = true;
-  BoundDisk* disk = layer.disk();
+  BoundDisk const* disk = layer.disk();
   //  bool disk = layer.forward();
   //  double innerradius=-999;
   double innerradius = disk ? layer.diskInnerRadius() : -999. ;

--- a/FastSimulation/TrackerSetup/interface/TrackerLayer.h
+++ b/FastSimulation/TrackerSetup/interface/TrackerLayer.h
@@ -73,10 +73,10 @@ public:
   inline const BoundSurface& surface() const { return *theSurface; }
 
   /// Returns the cylinder
-  inline BoundCylinder* cylinder() const { return theCylinder; }
+  inline BoundCylinder const* cylinder() const { return theCylinder; }
 
   /// Returns the surface
-  inline BoundDisk* disk() const { return theDisk; }
+  inline BoundDisk const* disk() const { return theDisk; }
 
   /// Returns the layer number  
   inline unsigned int layerNumber() const { return theLayerNumber; }


### PR DESCRIPTION
Make return values of a couple functions be
pointers to const instead of just pointers.
Eliminates some potential thread safety problems
reported by the clang static code analyzer.
