### PR TITLE
Thread safety cleanup in RecoBTau

### DIFF
--- a/RecoBTau/JetTagComputer/interface/GenericMVAComputerCache.h
+++ b/RecoBTau/JetTagComputer/interface/GenericMVAComputerCache.h
@@ -17,7 +17,7 @@ class GenericMVAComputerCache {
 	bool
 	update(const PhysicsTools::Calibration::MVAComputerContainer *calib);
 
-	inline GenericMVAComputer *getComputer(int index) const
+	inline GenericMVAComputer const* getComputer(int index) const
 	{ return index >= 0 ? computers[index].computer.get() : 0; }
 
 	inline bool isEmpty() const { return empty; }

--- a/RecoBTau/JetTagComputer/src/GenericMVAJetTagComputer.cc
+++ b/RecoBTau/JetTagComputer/src/GenericMVAJetTagComputer.cc
@@ -69,7 +69,7 @@ float GenericMVAJetTagComputer::discriminator(const TagInfoHelper &info) const
 			return -10.0;
 	}
 
-	GenericMVAComputer *computer = computerCache.getComputer(index);
+	GenericMVAComputer const* computer = computerCache.getComputer(index);
 
 	if (!computer)
 		return -10.0;


### PR DESCRIPTION
Make the return value of a const function be
a const pointer instead of just a pointer.
Eliminates a potential thread safety problem
reported by the clang static code analyzer.
