### PR TITLE
Helix

### DIFF
--- a/TrackingTools/GeomPropagators/src/HelixArbitraryPlaneCrossing.cc
+++ b/TrackingTools/GeomPropagators/src/HelixArbitraryPlaneCrossing.cc
@@ -7,6 +7,18 @@
 #include <iostream>
 #include "FWCore/Utilities/interface/Likely.h"
 
+#ifdef VI_DEBUG
+struct MaxIter {
+   ~MaxIter() { std::cout << "maxiter " << v << std::endl; }
+    void operator()(int i) { v= std::min(v,i);}    
+  int v=100;
+};
+#else
+struct MaxIter { void operator()(int)const{}};
+#endif
+static MaxIter maxiter;
+
+
 HelixArbitraryPlaneCrossing::HelixArbitraryPlaneCrossing(const PositionType& point,
 							 const DirectionType& direction,
 							 const float curvature,
@@ -45,7 +57,7 @@ HelixArbitraryPlaneCrossing::pathLength(const Plane& plane) {
   //
   // Constants used for control of convergence
   //
-  const int maxIterations(100);
+  constexpr int maxIterations = 20;
   //
   // maximum distance to plane (taking into account numerical precision)
   //
@@ -54,50 +66,54 @@ HelixArbitraryPlaneCrossing::pathLength(const Plane& plane) {
   //
   // Prepare internal value of the propagation direction and position / direction vectors for iteration 
   //
-  PropagationDirection propDir = thePropDir;
-  PositionTypeDouble xnew(theX0,theY0,theZ0);
-  DirectionTypeDouble pnew(theCosPhi0,theSinPhi0,theCosTheta/theSinTheta);
+  
+  bool notFail;
+  double dSTotal;
+  // Use existing 2nd order object at first pass
+  std::tie(notFail,dSTotal) = theQuadraticCrossingFromStart.pathLength(plane);
+  if unlikely(!notFail) return std::make_pair(notFail,dSTotal);
+  auto  xnew = positionInDouble(dSTotal);
+
+  auto propDir = thePropDir;
+  auto newDir = dSTotal>=0 ? alongMomentum : oppositeToMomentum;
+  if ( propDir == anyDirection ) {
+      propDir = newDir;
+  }  else {
+     if unlikely( newDir!=propDir )  return std::pair<bool,double>(false,0);
+  }
+ 
+
   //
   // Prepare iterations: count and total pathlength
   //
-  unsigned int iteration(maxIterations+1);
-  double dSTotal(0.);
-  //
-  bool first = true;
+  auto iteration = maxIterations;
   while ( notAtSurface(plane,xnew,safeMaxDist) ) {
     //
     // return empty solution vector if no convergence after maxIterations iterations
     //
     if unlikely( --iteration == 0 ) {
-      edm::LogInfo("HelixArbitraryPlaneCrossing") << "pathLength : no convergence";
+      LogDebug("HelixArbitraryPlaneCrossing") << "pathLength : no convergence";
       return std::pair<bool,double>(false,0);
     }
 
     //
-    // Use existing 2nd order object at first pass, create temporary object
-    // for subsequent passes.
-    //
-    std::pair<bool,double> deltaS2;
-    if unlikely( first ) {
-      first = false;
-      deltaS2 = theQuadraticCrossingFromStart.pathLength(plane);
-    }
-    else {
-      HelixArbitraryPlaneCrossing2Order quadraticCrossing(xnew.x(),xnew.y(),xnew.z(),
+    // create temporary object for subsequent passes.
+    auto  pnew = directionInDouble(dSTotal);
+    HelixArbitraryPlaneCrossing2Order quadraticCrossing(xnew.x(),xnew.y(),xnew.z(),
 							  pnew.x(),pnew.y(),
 							  theCosTheta,theSinTheta,
 							  theRho,
 							  anyDirection);
       
-      deltaS2 = quadraticCrossing.pathLength(plane);
-    }
+    auto  deltaS2 = quadraticCrossing.pathLength(plane);
+   
      
     if unlikely( !deltaS2.first )  return deltaS2;
     //
     // Calculate and sort total pathlength (max. 2 solutions)
     //
     dSTotal += deltaS2.second;
-    PropagationDirection newDir = dSTotal>=0 ? alongMomentum : oppositeToMomentum;
+    auto newDir = dSTotal>=0 ? alongMomentum : oppositeToMomentum;
     if ( propDir == anyDirection ) {
       propDir = newDir;
     }
@@ -108,12 +124,12 @@ HelixArbitraryPlaneCrossing::pathLength(const Plane& plane) {
     // Step forward by dSTotal.
     //
     xnew = positionInDouble(dSTotal);
-    pnew = directionInDouble(dSTotal);
   }
   //
   // Return result
   //
-  return std::pair<bool,double>(true,dSTotal);
+  maxiter(iteration);
+  return std::make_pair(true,dSTotal);
 }
 //
 // Position on helix after a step of path length s.
@@ -179,11 +195,10 @@ HelixArbitraryPlaneCrossing::directionInDouble (double s) const {
   //
   // Calculate delta phi (if not already available)
   //
-  if unlikely( s!=theCachedS ) {
+  if unlikely( s!=theCachedS ) {  // very very unlikely!
     theCachedS = s;
     theCachedDPhi = theCachedS*theRho*theSinTheta;
-    theCachedSDPhi = sin(theCachedDPhi);
-    theCachedCDPhi = cos(theCachedDPhi);
+    vdt::fast_sincos(theCachedDPhi,theCachedSDPhi,theCachedCDPhi);
   }
 
   if ( std::abs(theCachedDPhi)>1.e-4 ) {

--- a/TrackingTools/GeomPropagators/src/HelixArbitraryPlaneCrossing.cc
+++ b/TrackingTools/GeomPropagators/src/HelixArbitraryPlaneCrossing.cc
@@ -67,6 +67,9 @@ HelixArbitraryPlaneCrossing::pathLength(const Plane& plane) {
   // Prepare internal value of the propagation direction and position / direction vectors for iteration 
   //
   
+  float dz = plane.localZ(Surface::GlobalPoint(theX0,theY0,theZ0));
+  if (std::abs(dz)<safeMaxDist) return std::make_pair(true,0.);
+
   bool notFail;
   double dSTotal;
   // Use existing 2nd order object at first pass
@@ -129,6 +132,7 @@ HelixArbitraryPlaneCrossing::pathLength(const Plane& plane) {
   // Return result
   //
   maxiter(iteration);
+
   return std::make_pair(true,dSTotal);
 }
 //

--- a/TrackingTools/GeomPropagators/src/HelixArbitraryPlaneCrossing2Order.cc
+++ b/TrackingTools/GeomPropagators/src/HelixArbitraryPlaneCrossing2Order.cc
@@ -59,18 +59,18 @@ HelixArbitraryPlaneCrossing2Order::pathLength(const Plane& plane) {
   //   curvature, forward plane or direction perp. to plane)
   //
   double dS1,dS2;
-  if likely( fabs(ceq1)>FLT_MIN ) {
+  if likely( std::abs(ceq1)>FLT_MIN ) {
     double deq1 = ceq2*ceq2;
     double deq2 = ceq1*ceq3;
-    if ( fabs(deq1)<FLT_MIN || fabs(deq2/deq1)>1.e-6 ) {
+    if ( std::abs(deq1)<FLT_MIN || std::abs(deq2/deq1)>1.e-6 ) {
       //
       // Standard solution for quadratic equations
       //
       double deq = deq1+2*deq2;
-      if likely( deq<0. )  return std::pair<bool,double>(false,0);
-      double ceq = -0.5*(ceq2+(ceq2>0?1:-1)*sqrt(deq));
-      dS1 = -2*(ceq/ceq1)*theSinThetaI;
-      dS2 = (ceq3/ceq)*theSinThetaI;
+      if unlikely( deq<0. )  return std::pair<bool,double>(false,0);
+      double ceq =  ceq2+std::copysign(std::sqrt(deq),ceq2);
+      dS1 = (ceq/ceq1)*theSinThetaI;
+      dS2 = -2.*(ceq3/ceq)*theSinThetaI;
     }
     else {
       //
@@ -153,13 +153,9 @@ HelixArbitraryPlaneCrossing2Order::solutionByDirection(const double dS1,
     double s1(propSign*dS1);
     double s2(propSign*dS2);
     // sort
-    if ( s1 > s2 ) {
-      double aux = s1;
-      s1 = s2;
-      s2 = aux;
-    }
+    if ( s1 > s2 ) std::swap(s1,s2);
     // choose solution (if any with positive sign)
-    if ( s1<0 && s2>=0 ) {
+    if ( (s1<0) & (s2>=0) ) {
       // First solution in backward direction: choose second one.
       valid = true;
       path = propSign*s2;

--- a/TrackingTools/GeomPropagators/src/HelixBarrelCylinderCrossing.cc
+++ b/TrackingTools/GeomPropagators/src/HelixBarrelCylinderCrossing.cc
@@ -123,7 +123,7 @@ HelixBarrelCylinderCrossing( const GlobalPoint& startingPos,
 
   auto dMag1 = d1.mag();
   auto tmp1 = 0.5f * dMag1 * float(rho);
-  if (std::abs(tmp1)>1.f) tmp1 = ::copysign(1.f,tmp1);
+  if (std::abs(tmp1)>1.f) tmp1 = std::copysign(1.f,tmp1);
   auto theS1 = theActualDir1 * 2.f* std::asin( tmp1 ) / (rho*sinTheta);
   thePos1 =  GlobalPoint( startingPos.x() + d1.x(),
 			  startingPos.y() + d1.y(),
@@ -132,7 +132,7 @@ HelixBarrelCylinderCrossing( const GlobalPoint& startingPos,
 
   auto dMag2 = d2.mag();
   auto tmp2 = 0.5f * dMag2 * float(rho);
-  if (std::abs(tmp2)>1.f) tmp2 = ::copysign(1.,tmp2);
+  if (std::abs(tmp2)>1.f) tmp2 = std::copysign(1.f,tmp2);
   auto theS2 = theActualDir2 * 2.f* std::asin( tmp2 ) / (float(rho)*sinTheta);
   thePos2 =  GlobalPoint( startingPos.x() + d2.x(),
 			  startingPos.y() + d2.y(),

--- a/TrackingTools/GeomPropagators/src/HelixBarrelPlaneCrossingByCircle.cc
+++ b/TrackingTools/GeomPropagators/src/HelixBarrelPlaneCrossingByCircle.cc
@@ -107,10 +107,9 @@ HelixBarrelPlaneCrossingByCircle::pathLength( const Plane& plane)
   bool solved = chooseSolution( Vector2D(dx1, dy1), Vector2D(dx2, dy2));
   if (solved) {
     theDmag = theD.mag();
-    // protect asin (taking some safety margin)
+    // protect asin 
     double sinAlpha = 0.5*theDmag*theRho;
-    if ( sinAlpha>(1.-10*DBL_EPSILON) )  sinAlpha = 1.-10*DBL_EPSILON;
-    else if ( sinAlpha<-(1.-10*DBL_EPSILON) )  sinAlpha = -(1.-10*DBL_EPSILON);
+    if ( std::abs(sinAlpha)>1.)  sinAlpha = std::copysign(1.,sinAlpha);
     theS = theActualDir*2./(theRho*theSinTheta) * asin( sinAlpha);
     return ResultType( true, theS);
   }


### PR DESCRIPTION
Speed ups and cleanup in Helix computation
In particular the iteration code in for ArbitraryPlaneCrossing has been "linearized"
The maximum number of iterations reduced to 20 (for good solution never seen exceeding 7)
log info degraded to log debug

15% speedup of Analytical propagator 

Regression:
As usual, when touching arithmetic code regression are observed.
Conversions are, as usual, affected more than others...
Fully consistent with what already observed when changes occur in optimization by the compiler
