### PR TITLE
remove from EcalClusterTools flags-aware versions of functions

### DIFF
--- a/RecoEcal/EgammaCoreTools/interface/EcalClusterLazyTools.h
+++ b/RecoEcal/EgammaCoreTools/interface/EcalClusterLazyTools.h
@@ -44,87 +44,68 @@ class EcalClusterLazyTools {
   //note e3x2 does not have a definate eta/phi geometry, it takes the maximum 3x2 block containing the 
   //seed regardless of whether that 3 in eta or phi
   float e1x3( const reco::BasicCluster &cluster );
-  float e1x3( const reco::BasicCluster &cluster, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv );
   
   float e3x1( const reco::BasicCluster &cluster );
-  float e3x1( const reco::BasicCluster &cluster, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv );
        
   float e1x5( const reco::BasicCluster &cluster );
-  float e1x5( const reco::BasicCluster &cluster, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv );
   
   float e5x1( const reco::BasicCluster &cluster );
-  float e5x1( const reco::BasicCluster &cluster, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv );
   
   float e2x2( const reco::BasicCluster &cluster );
-  float e2x2( const reco::BasicCluster &cluster, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv );
   
   float e3x2( const reco::BasicCluster &cluster );
-  float e3x2( const reco::BasicCluster &cluster, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv );
   
   float e3x3( const reco::BasicCluster &cluster );
-  float e3x3( const reco::BasicCluster &cluster, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv );
   
   float e4x4( const reco::BasicCluster &cluster );
-  float e4x4( const reco::BasicCluster &cluster, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv );
   
   float e5x5( const reco::BasicCluster &cluster );
-  float e5x5( const reco::BasicCluster &cluster, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv );
   // energy in the 2x5 strip right of the max crystal (does not contain max crystal)
   // 2 crystals wide in eta, 5 wide in phi.
   float e2x5Right( const reco::BasicCluster &cluster );
-  float e2x5Right( const reco::BasicCluster &cluster, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv );
+
   // energy in the 2x5 strip left of the max crystal (does not contain max crystal)
   float e2x5Left( const reco::BasicCluster &cluster );
-  float e2x5Left( const reco::BasicCluster &cluster, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv );
+
   // energy in the 5x2 strip above the max crystal (does not contain max crystal)
   // 5 crystals wide in eta, 2 wide in phi.
   float e2x5Top( const reco::BasicCluster &cluster );
-  float e2x5Top( const reco::BasicCluster &cluster, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv );
   
   // energy in the 5x2 strip below the max crystal (does not contain max crystal)
   float e2x5Bottom( const reco::BasicCluster &cluster );
-  float e2x5Bottom( const reco::BasicCluster &cluster, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv );
+
   // energy in a 2x5 strip containing the seed (max) crystal.
   // 2 crystals wide in eta, 5 wide in phi.
   // it is the maximum of either (1x5left + 1x5center) or (1x5right + 1x5center)
   float e2x5Max( const reco::BasicCluster &cluster );
-  float e2x5Max( const reco::BasicCluster &cluster, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv );
+
   // energies in the crystal left, right, top, bottom w.r.t. to the most energetic crystal
   float eLeft( const reco::BasicCluster &cluster );
-  float eLeft( const reco::BasicCluster &cluster, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv );
-  
+
   float eRight( const reco::BasicCluster &cluster );
-  float eRight( const reco::BasicCluster &cluster, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv );
   
   float eTop( const reco::BasicCluster &cluster );
-  float eTop( const reco::BasicCluster &cluster, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv );
   
   float eBottom( const reco::BasicCluster &cluster );
-  float eBottom( const reco::BasicCluster &cluster, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv );
+
   // the energy of the most energetic crystal in the cluster
   float eMax( const reco::BasicCluster &cluster );
-  float eMax( const reco::BasicCluster &cluster, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv );
+
   // the energy of the second most energetic crystal in the cluster
   float e2nd( const reco::BasicCluster &cluster );
-  float e2nd( const reco::BasicCluster &cluster, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv );
   
   // get the DetId and the energy of the maximum energy crystal of the input cluster
   std::pair<DetId, float> getMaximum( const reco::BasicCluster &cluster );
-  std::pair<DetId, float> getMaximum( const reco::BasicCluster &cluster, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv );
-  
+
   std::vector<float> energyBasketFractionEta( const reco::BasicCluster &cluster );
-  std::vector<float> energyBasketFractionEta( const reco::BasicCluster &cluster,const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv  );
   
   std::vector<float> energyBasketFractionPhi( const reco::BasicCluster &cluster );
-  std::vector<float> energyBasketFractionPhi( const reco::BasicCluster &cluster, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv );
   
   // return a vector v with v[0] = etaLat, v[1] = phiLat, v[2] = lat
   std::vector<float> lat( const reco::BasicCluster &cluster, bool logW = true, float w0 = 4.7 );
-  std::vector<float> lat( const reco::BasicCluster &cluster, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv, bool logW = true, float w0 = 4.7 );
   
   // return a vector v with v[0] = covEtaEta, v[1] = covEtaPhi, v[2] = covPhiPhi
   std::vector<float> covariances(const reco::BasicCluster &cluster, float w0 = 4.7 );
-  std::vector<float> covariances(const reco::BasicCluster &cluster, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv, float w0 = 4.7 );
   
   // return a vector v with v[0] = covIEtaIEta, v[1] = covIEtaIPhi, v[2] = covIPhiIPhi
   //this function calculates differences in eta/phi in units of crystals not global eta/phi
@@ -133,10 +114,8 @@ class EcalClusterLazyTools {
   //Warning: covIEtaIEta has been studied by egamma, but so far covIPhiIPhi hasnt been studied extensively so there could be a bug in 
   //         the covIPhiIEta or covIPhiIPhi calculations. I dont think there is but as it hasnt been heavily used, there might be one
   std::vector<float> localCovariances(const reco::BasicCluster &cluster, float w0 = 4.7);
-  std::vector<float> localCovariances(const reco::BasicCluster &cluster, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv, float w0 = 4.7);
   
   std::vector<float> scLocalCovariances(const reco::SuperCluster &cluster, float w0 = 4.7);
-  std::vector<float> scLocalCovariances(const reco::SuperCluster &cluster, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv, float w0 = 4.7);
   
   double zernike20( const reco::BasicCluster &cluster, double R0 = 6.6, bool logW = true, float w0 = 4.7 );
   double zernike42( const reco::BasicCluster &cluster, double R0 = 6.6, bool logW = true, float w0 = 4.7 );
@@ -147,7 +126,6 @@ class EcalClusterLazyTools {
   // get the energy deposited in a matrix centered in the maximum energy crystal = (0,0)
   // the size is specified by ixMin, ixMax, iyMin, iyMax in unit of crystals
   float matrixEnergy( const reco::BasicCluster &cluster, DetId id, int ixMin, int ixMax, int iyMin, int iyMax );
-  float matrixEnergy( const reco::BasicCluster &cluster, DetId id, int ixMin, int ixMax, int iyMin, int iyMax, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv );
   
   // get time of basic cluster seed crystal 
   float BasicClusterSeedTime(const reco::BasicCluster &cluster);

--- a/RecoEcal/EgammaCoreTools/interface/EcalClusterTools.h
+++ b/RecoEcal/EgammaCoreTools/interface/EcalClusterTools.h
@@ -53,97 +53,73 @@ class EcalClusterTools {
                 //seed regardless of whether that 3 in eta or phi
                 static float e1x3( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology );
 
-static float e1x3( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv);
 
                 static float e3x1( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology );
 
-static float e3x1( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv);
 
                 static float e1x5( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology );
-		//AA
-		//Take into account severities
-                static float e1x5( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv);
 
                 static float e5x1( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology );
-static float e5x1( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv);
 
                 static float e2x2( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology );
-static float e2x2( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv );
 
                 static float e3x2( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology );
-static float e3x2( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv);
 
                 static float e3x3( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology );
-static float e3x3( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv );
 
                 static float e4x4( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology);
-static float e4x4( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv);
 
                 static float e5x5( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology );
-static float e5x5( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv);
 
                 // energy in the 2x5 strip right of the max crystal (does not contain max crystal)
 		// 2 crystals wide in eta, 5 wide in phi.
                 static float e2x5Right( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology );
-static float e2x5Right( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv );
                 // energy in the 2x5 strip left of the max crystal (does not contain max crystal)
 
                 static float e2x5Left( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology );
-static float e2x5Left( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv );
                 // energy in the 5x2 strip above the max crystal (does not contain max crystal)
 		// 5 crystals wide in eta, 2 wide in phi.
 
                 static float e2x5Top( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology );
-static float e2x5Top( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv );
                 // energy in the 5x2 strip below the max crystal (does not contain max crystal)                
 
                 static float e2x5Bottom( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology );
-static float e2x5Bottom( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv );
+
                 // energy in a 2x5 strip containing the seed (max) crystal.
                 // 2 crystals wide in eta, 5 wide in phi.
                 // it is the maximum of either (1x5left + 1x5center) or (1x5right + 1x5center)
-		static float e2x5Max( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology );
-static float e2x5Max( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv );
+                static float e2x5Max( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology );
+
 
                 // energies in the crystal left, right, top, bottom w.r.t. to the most energetic crystal
                 static float eLeft( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology );
-static float eLeft( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv );
 
                 static float eRight( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology );
-static float eRight( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv );
 
                 static float eTop( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology );
-static float eTop( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv );
 
                 static float eBottom( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology );
-static float eBottom( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv );
                 // the energy of the most energetic crystal in the cluster
 
                 static float eMax( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits );
-static float eMax( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv );
 
                 // the energy of the second most energetic crystal in the cluster
                 static float e2nd( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits );
-static float e2nd( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv );
 
                 // get the DetId and the energy of the maximum energy crystal of the input cluster
                 static std::pair<DetId, float> getMaximum( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits);
-static std::pair<DetId, float> getMaximum( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv);
 
                 static std::vector<float> energyBasketFractionEta( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits );
-static std::vector<float> energyBasketFractionEta( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv );
 
                 static std::vector<float> energyBasketFractionPhi( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits);
-static std::vector<float> energyBasketFractionPhi( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv);
 
                 // return a vector v with v[0] = etaLat, v[1] = phiLat, v[2] = lat
                 static std::vector<float> lat( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloGeometry *geometry, bool logW = true, float w0 = 4.7 );
-static std::vector<float> lat( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloGeometry *geometry, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv, bool logW = true,float w0 = 4.7);
 
                 // return a vector v with v[0] = covEtaEta, v[1] = covEtaPhi, v[2] = covPhiPhi
 
                 static std::vector<float> covariances(const reco::BasicCluster &cluster, const EcalRecHitCollection* recHits, const CaloTopology *topology, const CaloGeometry* geometry, float w0 = 4.7);
-static std::vector<float> covariances(const reco::BasicCluster &cluster, const EcalRecHitCollection* recHits, const CaloTopology *topology, const CaloGeometry* geometry,const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv,float w0 = 4.7);
+
                 // return a vector v with v[0] = covIEtaIEta, v[1] = covIEtaIPhi, v[2] = covIPhiIPhi
                 //this function calculates differences in eta/phi in units of crystals not global eta/phi
                 //this is gives better performance in the crack regions of the calorimeter but gives otherwise identical results to covariances function
@@ -153,10 +129,8 @@ static std::vector<float> covariances(const reco::BasicCluster &cluster, const E
                 //Warning: covIEtaIEta has been studied by egamma, but so far covIPhiIPhi hasnt been studied extensively so there could be a bug in 
                 //         the covIPhiIEta or covIPhiIPhi calculations. I dont think there is but as it hasnt been heavily used, there might be one
                 static std::vector<float> localCovariances(const reco::BasicCluster &cluster, const EcalRecHitCollection* recHits, const CaloTopology *topology, float w0 = 4.7);
-static std::vector<float> localCovariances(const reco::BasicCluster &cluster, const EcalRecHitCollection* recHits, const CaloTopology *topology, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv,float w0 = 4.7);
                 
                 static std::vector<float> scLocalCovariances(const reco::SuperCluster &cluster, const EcalRecHitCollection* recHits,const CaloTopology *topology, float w0 = 4.7);
-static std::vector<float> scLocalCovariances(const reco::SuperCluster &cluster, const EcalRecHitCollection* recHits,const CaloTopology *topology, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv, float w0 = 4.7);
 
                 // cluster second moments with respect to principal axes:
                 static Cluster2ndMoments cluster2ndMoments( const reco::BasicCluster &basicCluster, const EcalRecHitCollection &recHits, double phiCorrectionFactor=0.8, double w0=4.7, bool useLogWeights=true);
@@ -170,29 +144,23 @@ static std::vector<float> scLocalCovariances(const reco::SuperCluster &cluster, 
                 // get the detId's of a matrix centered in the maximum energy crystal = (0,0)
                 // the size is specified by ixMin, ixMax, iyMin, iyMax in unit of crystals
                 static std::vector<DetId> matrixDetId( const CaloTopology* topology, DetId id, int ixMin, int ixMax, int iyMin, int iyMax );
-static std::vector<DetId> matrixDetId( const CaloTopology* topology, DetId id, int ixMin, int ixMax, int iyMin, int iyMax, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv  );
+
                 // get the energy deposited in a matrix centered in the maximum energy crystal = (0,0)
                 // the size is specified by ixMin, ixMax, iyMin, iyMax in unit of crystals
                 static float matrixEnergy( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology, DetId id, int ixMin, int ixMax, int iyMin, int iyMax );
 
-		//AA
-		//Take into account the severities and flags
-                static float matrixEnergy( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology, DetId id, int ixMin, int ixMax, int iyMin, int iyMax, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv );
-		static float getFraction( const std::vector< std::pair<DetId, float> > &v_id, DetId id);
+
+                static float getFraction( const std::vector< std::pair<DetId, float> > &v_id, DetId id);
                 // get the DetId and the energy of the maximum energy crystal in a vector of DetId
                 static std::pair<DetId, float> getMaximum( const std::vector< std::pair<DetId, float> > &v_id, const EcalRecHitCollection *recHits);
-static std::pair<DetId, float> getMaximum( const std::vector< std::pair<DetId, float> > &v_id, const EcalRecHitCollection *recHits, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv);
+
                 // get the energy of a DetId, return 0 if the DetId is not in the collection
                 static float recHitEnergy(DetId id, const EcalRecHitCollection *recHits);
 
-		//AA
-		//Take into account severities and flags
-                static float recHitEnergy(DetId id, const EcalRecHitCollection *recHits, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv);
-
-		//Shower shape variables return vector <Roundness, Angle> of a photon
-		static std::vector<float> roundnessBarrelSuperClusters( const reco::SuperCluster &superCluster ,const EcalRecHitCollection &recHits, int weightedPositionMethod = 0, float energyThreshold = 0.0);
-		static std::vector<float> roundnessBarrelSuperClustersUserExtended( const reco::SuperCluster &superCluster ,const EcalRecHitCollection &recHits, int ieta_delta=0, int iphi_delta=0, float energyRHThresh=0.00000, int weightedPositionMethod=0);
-		static std::vector<float> roundnessSelectedBarrelRecHits(const std::vector<std::pair<const EcalRecHit*,float> >&rhVector, int weightedPositionMethod = 0);
+                //Shower shape variables return vector <Roundness, Angle> of a photon
+                static std::vector<float> roundnessBarrelSuperClusters( const reco::SuperCluster &superCluster ,const EcalRecHitCollection &recHits, int weightedPositionMethod = 0, float energyThreshold = 0.0);
+                static std::vector<float> roundnessBarrelSuperClustersUserExtended( const reco::SuperCluster &superCluster ,const EcalRecHitCollection &recHits, int ieta_delta=0, int iphi_delta=0, float energyRHThresh=0.00000, int weightedPositionMethod=0);
+                static std::vector<float> roundnessSelectedBarrelRecHits(const std::vector<std::pair<const EcalRecHit*,float> >&rhVector, int weightedPositionMethod = 0);
         private:
                 struct EcalClusterEnergyDeposition
                 { 
@@ -204,14 +172,12 @@ static std::pair<DetId, float> getMaximum( const std::vector< std::pair<DetId, f
                 static std::vector<EcalClusterEnergyDeposition> getEnergyDepTopology( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloGeometry *geometry, bool logW, float w0 );
 
                 static math::XYZVector meanClusterPosition( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology *topology, const CaloGeometry *geometry );
-static math::XYZVector meanClusterPosition( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology *topology, const CaloGeometry *geometry, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv );
+
                 //return energy weighted mean distance from the seed crystal in number of crystals
                 //<iEta,iPhi>, iPhi is not defined for endcap and is returned as zero 
                 static std::pair<float,float>  mean5x5PositionInLocalCrysCoord(const reco::BasicCluster &cluster, const EcalRecHitCollection* recHits,const CaloTopology *topology);
-static std::pair<float,float>  mean5x5PositionInLocalCrysCoord(const reco::BasicCluster &cluster, const EcalRecHitCollection* recHits,const CaloTopology *topology, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv);
 
-		static std::pair<float,float> mean5x5PositionInXY(const reco::BasicCluster &cluster, const EcalRecHitCollection* recHits,const CaloTopology *topology);
-static std::pair<float,float> mean5x5PositionInXY(const reco::BasicCluster &cluster, const EcalRecHitCollection* recHits,const CaloTopology *topology, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv);
+                static std::pair<float,float> mean5x5PositionInXY(const reco::BasicCluster &cluster, const EcalRecHitCollection* recHits,const CaloTopology *topology);
 
                 static double f00(double r) { return 1; }
                 static double f11(double r) { return r; }
@@ -239,18 +205,18 @@ static std::pair<float,float> mean5x5PositionInXY(const reco::BasicCluster &clus
                 //useful functions for the localCovariances function
                 static float getIEta(const DetId& id);
                 static float getIPhi(const DetId& id);
-		static float getNormedIX(const DetId& id);
+                static float getNormedIX(const DetId& id);
                 static float getNormedIY(const DetId& id);
                 static float getDPhiEndcap(const DetId& crysId,float meanX,float meanY);
                 static float getNrCrysDiffInEta(const DetId& crysId,const DetId& orginId);
                 static float getNrCrysDiffInPhi(const DetId& crysId,const DetId& orginId);
 		
-		//useful functions for showerRoundnessBarrel function
-		static int deltaIEta(int seed_ieta, int rh_ieta);
-		static int deltaIPhi(int seed_iphi, int rh_iphi);
-		static std::vector<int> getSeedPosition(const std::vector<std::pair<const EcalRecHit*,float> >&RH_ptrs);
-		static float getSumEnergy(const std::vector<std::pair<const EcalRecHit*,float> >&RH_ptrs_fracs);
-		static float computeWeight(float eRH, float energyTotal, int weightedPositionMethod);
+                //useful functions for showerRoundnessBarrel function
+                static int deltaIEta(int seed_ieta, int rh_ieta);
+                static int deltaIPhi(int seed_iphi, int rh_iphi);
+                static std::vector<int> getSeedPosition(const std::vector<std::pair<const EcalRecHit*,float> >&RH_ptrs);
+                static float getSumEnergy(const std::vector<std::pair<const EcalRecHit*,float> >&RH_ptrs_fracs);
+                static float computeWeight(float eRH, float energyTotal, int weightedPositionMethod);
 		
 };
 

--- a/RecoEcal/EgammaCoreTools/src/EcalClusterLazyTools.cc
+++ b/RecoEcal/EgammaCoreTools/src/EcalClusterLazyTools.cc
@@ -143,21 +143,9 @@ float EcalClusterLazyTools::e1x3( const reco::BasicCluster &cluster )
 }
 
 
-float EcalClusterLazyTools::e1x3( const reco::BasicCluster &cluster, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv )
-{
-        return EcalClusterTools::e1x3( cluster, getEcalRecHitCollection(cluster), topology_, flagsexcl, severitiesexcl, sevLv );
-}
-
-
-
 float EcalClusterLazyTools::e3x1( const reco::BasicCluster &cluster )
 {
         return EcalClusterTools::e3x1( cluster, getEcalRecHitCollection(cluster), topology_ );
-}
-
-float EcalClusterLazyTools::e3x1( const reco::BasicCluster &cluster, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv )
-{
-        return EcalClusterTools::e3x1( cluster, getEcalRecHitCollection(cluster), topology_, flagsexcl, severitiesexcl, sevLv );
 }
 
 
@@ -166,21 +154,10 @@ float EcalClusterLazyTools::e1x5( const reco::BasicCluster &cluster )
         return EcalClusterTools::e1x5( cluster, getEcalRecHitCollection(cluster), topology_ );
 }
 
-float EcalClusterLazyTools::e1x5( const reco::BasicCluster &cluster, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv )
-{
-        return EcalClusterTools::e1x5( cluster, getEcalRecHitCollection(cluster), topology_, flagsexcl, severitiesexcl, sevLv );
-}
-
-
 
 float EcalClusterLazyTools::e5x1( const reco::BasicCluster &cluster )
 {
   return EcalClusterTools::e5x1( cluster, getEcalRecHitCollection(cluster), topology_ );
-	}
-
-float EcalClusterLazyTools::e5x1( const reco::BasicCluster &cluster, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv )
-{
-  return EcalClusterTools::e5x1( cluster, getEcalRecHitCollection(cluster), topology_, flagsexcl, severitiesexcl, sevLv );
 	}
 
 
@@ -189,20 +166,10 @@ float EcalClusterLazyTools::e2x2( const reco::BasicCluster &cluster )
         return EcalClusterTools::e2x2( cluster, getEcalRecHitCollection(cluster), topology_ );
 }
 
-float EcalClusterLazyTools::e2x2( const reco::BasicCluster &cluster, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv )
-{
-        return EcalClusterTools::e2x2( cluster, getEcalRecHitCollection(cluster), topology_, flagsexcl, severitiesexcl, sevLv );
-}
-
 
 float EcalClusterLazyTools::e3x2( const reco::BasicCluster &cluster )
 {
         return EcalClusterTools::e3x2( cluster, getEcalRecHitCollection(cluster), topology_ );
-}
-
-float EcalClusterLazyTools::e3x2( const reco::BasicCluster &cluster, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv )
-{
-        return EcalClusterTools::e3x2( cluster, getEcalRecHitCollection(cluster), topology_, flagsexcl, severitiesexcl, sevLv );
 }
 
 
@@ -211,31 +178,17 @@ float EcalClusterLazyTools::e3x3( const reco::BasicCluster &cluster )
         return EcalClusterTools::e3x3( cluster, getEcalRecHitCollection(cluster), topology_ );
 }
 
-float EcalClusterLazyTools::e3x3( const reco::BasicCluster &cluster, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv )
-{
-        return EcalClusterTools::e3x3( cluster, getEcalRecHitCollection(cluster), topology_, flagsexcl, severitiesexcl, sevLv );
-}
-
 
 float EcalClusterLazyTools::e4x4( const reco::BasicCluster &cluster )
 {
         return EcalClusterTools::e4x4( cluster, getEcalRecHitCollection(cluster), topology_ );
 }
 
-float EcalClusterLazyTools::e4x4( const reco::BasicCluster &cluster, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv )
-{
-        return EcalClusterTools::e4x4( cluster, getEcalRecHitCollection(cluster), topology_, flagsexcl, severitiesexcl, sevLv );
-}
 
 
 float EcalClusterLazyTools::e5x5( const reco::BasicCluster &cluster )
 {
         return EcalClusterTools::e5x5( cluster, getEcalRecHitCollection(cluster), topology_ );
-}
-
-float EcalClusterLazyTools::e5x5( const reco::BasicCluster &cluster, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv )
-{
-        return EcalClusterTools::e5x5( cluster, getEcalRecHitCollection(cluster), topology_, flagsexcl, severitiesexcl, sevLv );
 }
 
 
@@ -244,10 +197,6 @@ float EcalClusterLazyTools::e2x5Right( const reco::BasicCluster &cluster )
         return EcalClusterTools::e2x5Right( cluster, getEcalRecHitCollection(cluster), topology_ );
 }
 
-float EcalClusterLazyTools::e2x5Right( const reco::BasicCluster &cluster, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv )
-{
-        return EcalClusterTools::e2x5Right( cluster, getEcalRecHitCollection(cluster), topology_, flagsexcl, severitiesexcl, sevLv );
-}
 
 
 float EcalClusterLazyTools::e2x5Left( const reco::BasicCluster &cluster )
@@ -255,10 +204,6 @@ float EcalClusterLazyTools::e2x5Left( const reco::BasicCluster &cluster )
         return EcalClusterTools::e2x5Left( cluster, getEcalRecHitCollection(cluster), topology_ );
 }
 
-float EcalClusterLazyTools::e2x5Left( const reco::BasicCluster &cluster, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv )
-{
-        return EcalClusterTools::e2x5Left( cluster, getEcalRecHitCollection(cluster), topology_, flagsexcl, severitiesexcl, sevLv );
-}
 
 
 float EcalClusterLazyTools::e2x5Top( const reco::BasicCluster &cluster )
@@ -266,10 +211,6 @@ float EcalClusterLazyTools::e2x5Top( const reco::BasicCluster &cluster )
         return EcalClusterTools::e2x5Top( cluster, getEcalRecHitCollection(cluster), topology_ );
 }
 
-float EcalClusterLazyTools::e2x5Top( const reco::BasicCluster &cluster, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv )
-{
-        return EcalClusterTools::e2x5Top( cluster, getEcalRecHitCollection(cluster), topology_, flagsexcl, severitiesexcl, sevLv );
-}
 
 
 float EcalClusterLazyTools::e2x5Bottom( const reco::BasicCluster &cluster )
@@ -277,20 +218,11 @@ float EcalClusterLazyTools::e2x5Bottom( const reco::BasicCluster &cluster )
         return EcalClusterTools::e2x5Bottom( cluster, getEcalRecHitCollection(cluster), topology_ );
 }
 
-float EcalClusterLazyTools::e2x5Bottom( const reco::BasicCluster &cluster, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv )
-{
-        return EcalClusterTools::e2x5Bottom( cluster, getEcalRecHitCollection(cluster), topology_, flagsexcl, severitiesexcl, sevLv );
-}
 
 // Energy in 2x5 strip containing the max crystal.
 float EcalClusterLazyTools::e2x5Max( const reco::BasicCluster &cluster )
 {
         return EcalClusterTools::e2x5Max( cluster, getEcalRecHitCollection(cluster), topology_ );
-}
-
-float EcalClusterLazyTools::e2x5Max( const reco::BasicCluster &cluster, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv )
-{
-        return EcalClusterTools::e2x5Max( cluster, getEcalRecHitCollection(cluster), topology_, flagsexcl, severitiesexcl, sevLv );
 }
 
 
@@ -299,20 +231,10 @@ float EcalClusterLazyTools::eLeft( const reco::BasicCluster &cluster )
         return EcalClusterTools::eLeft( cluster, getEcalRecHitCollection(cluster), topology_ );
 }
 
-float EcalClusterLazyTools::eLeft( const reco::BasicCluster &cluster, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv )
-{
-        return EcalClusterTools::eLeft( cluster, getEcalRecHitCollection(cluster), topology_, flagsexcl, severitiesexcl, sevLv );
-}
-
 
 float EcalClusterLazyTools::eRight( const reco::BasicCluster &cluster )
 {
         return EcalClusterTools::eRight( cluster, getEcalRecHitCollection(cluster), topology_ );
-}
-
-float EcalClusterLazyTools::eRight( const reco::BasicCluster &cluster, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv )
-{
-        return EcalClusterTools::eRight( cluster, getEcalRecHitCollection(cluster), topology_, flagsexcl, severitiesexcl, sevLv );
 }
 
 
@@ -321,20 +243,11 @@ float EcalClusterLazyTools::eTop( const reco::BasicCluster &cluster )
         return EcalClusterTools::eTop( cluster, getEcalRecHitCollection(cluster), topology_ );
 }
 
-float EcalClusterLazyTools::eTop( const reco::BasicCluster &cluster, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv )
-{
-        return EcalClusterTools::eTop( cluster, getEcalRecHitCollection(cluster), topology_, flagsexcl, severitiesexcl, sevLv );
-}
 
 
 float EcalClusterLazyTools::eBottom( const reco::BasicCluster &cluster )
 {
         return EcalClusterTools::eBottom( cluster, getEcalRecHitCollection(cluster), topology_ );
-}
-
-float EcalClusterLazyTools::eBottom( const reco::BasicCluster &cluster, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv )
-{
-        return EcalClusterTools::eBottom( cluster, getEcalRecHitCollection(cluster), topology_, flagsexcl, severitiesexcl, sevLv );
 }
 
 
@@ -343,30 +256,16 @@ float EcalClusterLazyTools::eMax( const reco::BasicCluster &cluster )
         return EcalClusterTools::eMax( cluster, getEcalRecHitCollection(cluster) );
 }
 
-float EcalClusterLazyTools::eMax( const reco::BasicCluster &cluster, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv )
-{
-        return EcalClusterTools::eMax( cluster, getEcalRecHitCollection(cluster), flagsexcl, severitiesexcl, sevLv );
-}
-
 
 float EcalClusterLazyTools::e2nd( const reco::BasicCluster &cluster )
 {
         return EcalClusterTools::e2nd( cluster, getEcalRecHitCollection(cluster) );
 }
 
-float EcalClusterLazyTools::e2nd( const reco::BasicCluster &cluster, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv )
-{
-        return EcalClusterTools::e2nd( cluster, getEcalRecHitCollection(cluster), flagsexcl, severitiesexcl, sevLv );
-}
 
 std::pair<DetId, float> EcalClusterLazyTools::getMaximum( const reco::BasicCluster &cluster )
 {
         return EcalClusterTools::getMaximum( cluster, getEcalRecHitCollection(cluster) );
-}
-
-std::pair<DetId, float> EcalClusterLazyTools::getMaximum( const reco::BasicCluster &cluster, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv )
-{
-        return EcalClusterTools::getMaximum( cluster, getEcalRecHitCollection(cluster), flagsexcl, severitiesexcl, sevLv );
 }
 
 
@@ -375,20 +274,11 @@ std::vector<float> EcalClusterLazyTools::energyBasketFractionEta( const reco::Ba
         return EcalClusterTools::energyBasketFractionEta( cluster, getEcalRecHitCollection(cluster) );
 }
 
-std::vector<float> EcalClusterLazyTools::energyBasketFractionEta( const reco::BasicCluster &cluster, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv )
-{
-        return EcalClusterTools::energyBasketFractionEta( cluster, getEcalRecHitCollection(cluster), flagsexcl, severitiesexcl, sevLv );
-}
 
 
 std::vector<float> EcalClusterLazyTools::energyBasketFractionPhi( const reco::BasicCluster &cluster )
 {
         return EcalClusterTools::energyBasketFractionPhi( cluster, getEcalRecHitCollection(cluster) );
-}
-
-std::vector<float> EcalClusterLazyTools::energyBasketFractionPhi( const reco::BasicCluster &cluster, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv )
-{
-        return EcalClusterTools::energyBasketFractionPhi( cluster, getEcalRecHitCollection(cluster), flagsexcl, severitiesexcl, sevLv );
 }
 
 
@@ -408,30 +298,18 @@ std::vector<float> EcalClusterLazyTools::covariances(const reco::BasicCluster &c
         return EcalClusterTools::covariances( cluster, getEcalRecHitCollection(cluster), topology_, geometry_, w0 );
 }
 
-std::vector<float> EcalClusterLazyTools::covariances(const reco::BasicCluster &cluster,const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv, float w0 )
-{
-        return EcalClusterTools::covariances( cluster, getEcalRecHitCollection(cluster), topology_, geometry_, flagsexcl, severitiesexcl, sevLv, w0 );
-}
 
 std::vector<float> EcalClusterLazyTools::localCovariances(const reco::BasicCluster &cluster, float w0 )
 {
         return EcalClusterTools::localCovariances( cluster, getEcalRecHitCollection(cluster), topology_, w0 );
 }
 
-std::vector<float> EcalClusterLazyTools::localCovariances(const reco::BasicCluster &cluster, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv, float w0 )
-{
-        return EcalClusterTools::localCovariances( cluster, getEcalRecHitCollection(cluster), topology_, flagsexcl, severitiesexcl, sevLv, w0 );
-}
 
 std::vector<float> EcalClusterLazyTools::scLocalCovariances(const reco::SuperCluster &cluster, float w0 )
 {
         return EcalClusterTools::scLocalCovariances( cluster, getEcalRecHitCollection(cluster), topology_, w0 );
 }
 
-std::vector<float> EcalClusterLazyTools::scLocalCovariances(const reco::SuperCluster &cluster, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv, float w0 )
-{
-        return EcalClusterTools::scLocalCovariances( cluster, getEcalRecHitCollection(cluster), topology_, flagsexcl, severitiesexcl, sevLv, w0 );
-}
 
 double EcalClusterLazyTools::zernike20( const reco::BasicCluster &cluster, double R0, bool logW, float w0 )
 {
@@ -452,11 +330,6 @@ std::vector<DetId> EcalClusterLazyTools::matrixDetId( DetId id, int ixMin, int i
 float EcalClusterLazyTools::matrixEnergy( const reco::BasicCluster &cluster, DetId id, int ixMin, int ixMax, int iyMin, int iyMax )
 {
   return EcalClusterTools::matrixEnergy( cluster, getEcalRecHitCollection(cluster), topology_, id, ixMin, ixMax, iyMin, iyMax );
-}
-
-float EcalClusterLazyTools::matrixEnergy( const reco::BasicCluster &cluster, DetId id, int ixMin, int ixMax, int iyMin, int iyMax,const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv )
-{
-  return EcalClusterTools::matrixEnergy( cluster, getEcalRecHitCollection(cluster), topology_, id, ixMin, ixMax, iyMin, iyMax, flagsexcl, severitiesexcl, sevLv );
 }
 
 


### PR DESCRIPTION
A while ago, we added to clustertools the option to pass, in calculation of cluster shapes, a list of flags and severities for the exclusion of certain classes of channels.
This interface is not necessary anymore, as only the hits effectively used in the clustering are now used in the calculation of shapes. Therefore it has been removed.
