### PR TITLE
 extended eta rangle for single Pions (relvals)

### DIFF
--- a/Configuration/Generator/python/SinglePiPt100Extended_cfi.py
+++ b/Configuration/Generator/python/SinglePiPt100Extended_cfi.py
@@ -1,0 +1,19 @@
+import FWCore.ParameterSet.Config as cms
+
+generator = cms.EDProducer("FlatRandomPtGunProducer",
+    PGunParameters = cms.PSet(
+        MaxPt = cms.double(100.01),
+        MinPt = cms.double(99.99),
+        PartID = cms.vint32(211),
+        MaxEta = cms.double(4.0),
+        MaxPhi = cms.double(3.14159265359),
+        MinEta = cms.double(-4.0),
+        MinPhi = cms.double(-3.14159265359) ## in radians
+
+    ),
+    Verbosity = cms.untracked.int32(0), ## set to 1 (or greater)  for printouts
+
+    psethack = cms.string('single pi pt 100'),
+    AddAntiParticle = cms.bool(True),
+    firstRun = cms.untracked.uint32(1)
+)

--- a/Configuration/Generator/python/SinglePiPt10Extended_cfi.py
+++ b/Configuration/Generator/python/SinglePiPt10Extended_cfi.py
@@ -1,0 +1,19 @@
+import FWCore.ParameterSet.Config as cms
+
+generator = cms.EDProducer("FlatRandomPtGunProducer",
+    PGunParameters = cms.PSet(
+        MaxPt = cms.double(10.01),
+        MinPt = cms.double(9.99),
+        PartID = cms.vint32(211),
+        MaxEta = cms.double(4.0),
+        MaxPhi = cms.double(3.14159265359),
+        MinEta = cms.double(-4.0),
+        MinPhi = cms.double(-3.14159265359) ## in radians
+
+    ),
+    Verbosity = cms.untracked.int32(0), ## set to 1 (or greater)  for printouts
+
+    psethack = cms.string('single pi pt 10'),
+    AddAntiParticle = cms.bool(True),
+    firstRun = cms.untracked.uint32(1)
+)

--- a/Configuration/Generator/python/SinglePiPt1Extended_cfi.py
+++ b/Configuration/Generator/python/SinglePiPt1Extended_cfi.py
@@ -1,0 +1,19 @@
+import FWCore.ParameterSet.Config as cms
+
+generator = cms.EDProducer("FlatRandomPtGunProducer",
+    PGunParameters = cms.PSet(
+        MaxPt = cms.double(1.01),
+        MinPt = cms.double(0.99),
+        PartID = cms.vint32(211),
+        MaxEta = cms.double(4.0),
+        MaxPhi = cms.double(3.14159265359),
+        MinEta = cms.double(-4.0),
+        MinPhi = cms.double(-3.14159265359) ## in radians
+
+    ),
+    Verbosity = cms.untracked.int32(0), ## set to 1 (or greater)  for printouts
+
+    psethack = cms.string('single pi pt 1'),
+    AddAntiParticle = cms.bool(True),
+    firstRun = cms.untracked.uint32(1)
+)


### PR DESCRIPTION
For slhc10_patch1 , no need to update runthematrix at this point, it can be used for any emergency studies  (relvals or special requests) 
