### PR TITLE
Tau trigger DQM monitors all PFTau paths

### DIFF
--- a/DQMOffline/Trigger/interface/HLTTauDQMOfflineSource.h
+++ b/DQMOffline/Trigger/interface/HLTTauDQMOfflineSource.h
@@ -17,6 +17,8 @@
 #include "DQMOffline/Trigger/interface/HLTTauDQMPathPlotter.h"
 #include "DQMOffline/Trigger/interface/HLTTauDQMPathSummaryPlotter.h"
 
+#include <boost/regex.hpp>
+
 //
 // class declaration
 //
@@ -37,7 +39,12 @@ private:
     edm::EDGetTokenT<edm::TriggerResults> triggerResultsToken_;
     edm::InputTag triggerEventSrc_;
     edm::EDGetTokenT<trigger::TriggerEvent> triggerEventToken_;
-    bool hltMenuChanged_;
+
+    // For path plotters
+    const boost::regex pathRegex_;
+    const int nPtBins_, nEtaBins_, nPhiBins_;
+    const double ptMax_, highPtMax_, l1MatchDr_, hltMatchDr_;
+    const std::string dqmBaseFolder_;
     
     HLTConfigProvider HLTCP_;
 
@@ -54,9 +61,9 @@ private:
     const int prescaleEvt_;     //every n events 
     
     // Plotters
-    std::vector<HLTTauDQML1Plotter> l1Plotters_;
-    std::vector<HLTTauDQMPathPlotter> pathPlotters2_;
-    std::vector<HLTTauDQMPathSummaryPlotter> pathSummaryPlotters_;
+    std::unique_ptr<HLTTauDQML1Plotter> l1Plotter_;
+    std::vector<HLTTauDQMPathPlotter> pathPlotters_;
+    std::unique_ptr<HLTTauDQMPathSummaryPlotter> pathSummaryPlotter_;
 };
 
 #endif

--- a/DQMOffline/Trigger/interface/HLTTauDQMPath.h
+++ b/DQMOffline/Trigger/interface/HLTTauDQMPath.h
@@ -4,8 +4,6 @@
 
 #include "DataFormats/Math/interface/LorentzVector.h"
 
-#include <boost/regex.hpp>
-
 #include<tuple>
 #include<vector>
 #include<string>
@@ -31,12 +29,10 @@ public:
     const int id; // from TriggerTypeDefs.h
   };
 
-  HLTTauDQMPath(const std::string& hltProcess, const std::string& dqmFolder, bool doRefAnalysis);
+  HLTTauDQMPath(const std::string& pathName, const std::string& hltProcess, bool doRefAnalysis, const HLTConfigProvider& HLTCP);
   ~HLTTauDQMPath();
 
-  void initialize(const edm::ParameterSet& pset);
-
-  bool beginRun(const HLTConfigProvider& HLTCP);
+  bool isValid() const { return isValid_; }
 
   bool fired(const edm::TriggerResults& triggerResults) const;
 
@@ -77,24 +73,20 @@ public:
   typedef std::tuple<std::string, size_t> FilterIndex;
 private:
   const std::string hltProcess_;
-  const std::string dqmFolder_;
   const bool doRefAnalysis_;
-
-  std::vector<boost::regex> pathRegexs_;
-  std::vector<boost::regex> ignoreFilterTypes_;
-  std::vector<boost::regex> ignoreFilterNames_;
 
   std::vector<FilterIndex> filterIndices_;
   std::vector<int> filterTauN_;
   std::vector<int> filterElectronN_;
   std::vector<int> filterMuonN_;
-  std::string pathName_;
-  unsigned int pathIndex_;
+  const std::string pathName_;
+  const unsigned int pathIndex_;
   size_t lastFilterBeforeL2TauIndex_;
   size_t lastL2TauFilterIndex_;
   size_t lastFilterBeforeL3TauIndex_;
   size_t lastL3TauFilterIndex_;
   bool isFirstL1Seed_;
+  bool isValid_;
 };
 
 

--- a/DQMOffline/Trigger/interface/HLTTauDQMPathPlotter.h
+++ b/DQMOffline/Trigger/interface/HLTTauDQMPathPlotter.h
@@ -20,7 +20,8 @@ class HLTConfigProvider;
 
 class HLTTauDQMPathPlotter: private HLTTauDQMPlotter {
 public:
-  HLTTauDQMPathPlotter(const edm::ParameterSet& pset, bool doRefAnalysis, const std::string& dqmBaseFolder,
+  HLTTauDQMPathPlotter(const std::string& pathName, const HLTConfigProvider& HLTCP,
+                       bool doRefAnalysis, const std::string& dqmBaseFolder,
                        const std::string& hltProcess, int ptbins, int etabins, int phibins,
                        double ptmax, double highptmax,
                        double l1MatchDr, double hltMatchDr);
@@ -28,7 +29,6 @@ public:
 
   using HLTTauDQMPlotter::isValid;
 
-  void updateHLTMenu(const HLTConfigProvider& HLTCP);
   void bookHistograms(DQMStore::IBooker &iBooker);
 
   void analyze(const edm::TriggerResults& triggerResults, const trigger::TriggerEvent& triggerEvent, const HLTTauDQMOfflineObjects& refCollection);

--- a/DQMOffline/Trigger/interface/HLTTauDQMPathSummaryPlotter.h
+++ b/DQMOffline/Trigger/interface/HLTTauDQMPathSummaryPlotter.h
@@ -24,7 +24,6 @@ public:
 
   void setPathObjects(const std::vector<const HLTTauDQMPath *>& pathObjects) {
     pathObjects_ = pathObjects;
-    runValid_ = !pathObjects_.empty();
   }
   void bookHistograms(DQMStore::IBooker &iBooker);
 

--- a/DQMOffline/Trigger/interface/HLTTauDQMPlotter.h
+++ b/DQMOffline/Trigger/interface/HLTTauDQMPlotter.h
@@ -33,7 +33,7 @@ public:
     HLTTauDQMPlotter(const edm::ParameterSet& pset, const std::string& dqmBaseFolder);
     HLTTauDQMPlotter(const std::string& dqmFolder, const std::string& dqmBaseFolder);
     ~HLTTauDQMPlotter();
-    bool isValid() const { return configValid_ && runValid_; }
+    bool isValid() const { return configValid_; }
 
 protected:
     //Helper functions
@@ -46,6 +46,5 @@ protected:
     
     //Validity check
     bool configValid_;
-    bool runValid_;
 };
 #endif

--- a/DQMOffline/Trigger/interface/HLTTauDQMPlotter.h
+++ b/DQMOffline/Trigger/interface/HLTTauDQMPlotter.h
@@ -31,6 +31,7 @@ struct HLTTauDQMOfflineObjects {
 class HLTTauDQMPlotter {
 public:
     HLTTauDQMPlotter(const edm::ParameterSet& pset, const std::string& dqmBaseFolder);
+    HLTTauDQMPlotter(const std::string& dqmFolder, const std::string& dqmBaseFolder);
     ~HLTTauDQMPlotter();
     bool isValid() const { return configValid_ && runValid_; }
 

--- a/DQMOffline/Trigger/interface/HLTTauDQMSummaryPlotter.h
+++ b/DQMOffline/Trigger/interface/HLTTauDQMSummaryPlotter.h
@@ -6,7 +6,8 @@
 
 class HLTTauDQMSummaryPlotter: private HLTTauDQMPlotter {
 public:
-    HLTTauDQMSummaryPlotter(const edm::ParameterSet& ps, const std::string& dqmBaseFolder);
+    HLTTauDQMSummaryPlotter(const edm::ParameterSet& ps, const std::string& dqmBaseFolder, const std::string& type);
+    HLTTauDQMSummaryPlotter(const std::string& dqmBaseFolder, const std::string& type);
     ~HLTTauDQMSummaryPlotter();
 
     using HLTTauDQMPlotter::isValid;
@@ -15,15 +16,9 @@ public:
     void plot();
 
 private:
-    void bookEfficiencyHisto(const std::string& folder, const std::string& name, const std::string& hist1, bool copyLabels=false);
-    void plotEfficiencyHisto( std::string folder, std::string name, std::string hist1, std::string hist2 );
-    void plotIntegratedEffHisto( std::string folder, std::string name, std::string refHisto, std::string evCount, int bin );
-    void bookTriggerBitEfficiencyHistos( std::string folder, std::string histo );
-    void plotTriggerBitEfficiencyHistos( std::string folder, std::string histo );
-    void bookFractionHisto(const std::string& folder, const std::string& name);
-    void plotFractionHisto(const std::string& folder, const std::string& name);
+  const std::string type_;
 
-    std::string type_;
-    DQMStore *store_;
+  class SummaryPlotter;
+  std::vector<std::unique_ptr<SummaryPlotter> > plotters_;
 };
 #endif

--- a/DQMOffline/Trigger/python/HLTTauDQMOffline_cfi.py
+++ b/DQMOffline/Trigger/python/HLTTauDQMOffline_cfi.py
@@ -62,46 +62,15 @@ hltTauOfflineMonitor_PFTaus = cms.EDAnalyzer("HLTTauDQMOfflineSource",
     DQMBaseFolder = cms.untracked.string("HLT/TauOffline/PFTaus/"),
     TriggerResultsSrc = cms.untracked.InputTag("TriggerResults", "", hltTauDQMofflineProcess),
     TriggerEventSrc = cms.untracked.InputTag("hltTriggerSummaryAOD", "", hltTauDQMofflineProcess),
-    MonitorSetup = cms.VPSet(
-        cms.PSet(
-            ConfigType            = cms.untracked.string("Path"),
-            DQMFolder             = cms.untracked.string('TauMET'),
-            Path                  = cms.untracked.vstring('HLT_LooseIsoPFTau35_Trk20_Prong1_MET(?<tr0>[[:digit:]]+)_v.*'),
-            IgnoreFilterNames     = cms.untracked.vstring(),
-            IgnoreFilterTypes     = cms.untracked.vstring(),
-        ),
-        cms.PSet(
-            ConfigType            = cms.untracked.string("Path"),
-            DQMFolder             = cms.untracked.string('MuTau'),
-            Path                  = cms.untracked.vstring('HLT_IsoMu(?<tr1>1[[:digit:]]+)_eta2p1_LooseIsoPFTau(?<tr0>[[:digit:]]+)_v.*'),
-            IgnoreFilterNames     = cms.untracked.vstring(),
-            IgnoreFilterTypes     = cms.untracked.vstring(),
-        ),
-        cms.PSet(
-            ConfigType            = cms.untracked.string("Path"),
-            DQMFolder             = cms.untracked.string('EleTau'),
-            Path                  = cms.untracked.vstring('HLT_Ele(?<tr1>[[:digit:]]+)_eta2p1_WP90Rho_LooseIsoPFTau(?<tr0>[[:digit:]]+)_v.*'),
-            IgnoreFilterNames     = cms.untracked.vstring(),
-            IgnoreFilterTypes     = cms.untracked.vstring(),
-        ),
-        cms.PSet(
-            ConfigType            = cms.untracked.string("Path"),
-            DQMFolder             = cms.untracked.string('DoubleTau'),
-            Path                  = cms.untracked.vstring('HLT_DoubleMediumIsoPFTau(?<tr0>[[:digit:]]+)_Trk(?<tr1>[[:digit:]])_eta2p1_Jet(?<tr2>[[:digit:]]+)_v.*'),
-            IgnoreFilterNames     = cms.untracked.vstring(),
-            IgnoreFilterTypes     = cms.untracked.vstring(),
-        ),
-        cms.PSet(
-            ConfigType            = cms.untracked.string("PathSummary"),
-            DQMFolder             = cms.untracked.string('Summary'),
-        ),
-        cms.PSet(
-            ConfigType            = cms.untracked.string("L1"),
-            DQMFolder             = cms.untracked.string('L1'),
-            L1Taus                = cms.untracked.InputTag("l1extraParticles", "Tau"),
-            L1Jets                = cms.untracked.InputTag("l1extraParticles", "Central"),
-            L1JetMinEt            = cms.untracked.double(40), # FIXME: this value is arbitrary at the moment
-        ),
+    L1Plotter = cms.untracked.PSet(
+        DQMFolder             = cms.untracked.string('L1'),
+        L1Taus                = cms.untracked.InputTag("l1extraParticles", "Tau"),
+        L1Jets                = cms.untracked.InputTag("l1extraParticles", "Central"),
+        L1JetMinEt            = cms.untracked.double(40), # FIXME: this value is arbitrary at the moment
+    ),
+    Paths = cms.untracked.string("PFTau"),
+    PathSummaryPlotter = cms.untracked.PSet(
+        DQMFolder             = cms.untracked.string('Summary'),
     ),
     Matching = cms.PSet(
         doMatching            = cms.untracked.bool(True),

--- a/DQMOffline/Trigger/python/HLTTauPostProcessor_cfi.py
+++ b/DQMOffline/Trigger/python/HLTTauPostProcessor_cfi.py
@@ -4,12 +4,14 @@ from DQMOffline.Trigger.HLTTauDQMOffline_cfi import *
 
 HLTTauPostAnalysis_PFTaus = cms.EDAnalyzer("HLTTauPostProcessor",
     DQMBaseFolder   = hltTauOfflineMonitor_PFTaus.DQMBaseFolder,
-    Setup           = hltTauOfflineMonitor_PFTaus.MonitorSetup,
+    L1Plotter       = hltTauOfflineMonitor_PFTaus.L1Plotter,
+    PathSummaryPlotter = hltTauOfflineMonitor_PFTaus.PathSummaryPlotter,
 )
 
 HLTTauPostAnalysis_Inclusive = cms.EDAnalyzer("HLTTauPostProcessor",
     DQMBaseFolder   = hltTauOfflineMonitor_Inclusive.DQMBaseFolder,
-    Setup           = hltTauOfflineMonitor_Inclusive.MonitorSetup,
+    L1Plotter       = hltTauOfflineMonitor_Inclusive.L1Plotter,
+    PathSummaryPlotter = hltTauOfflineMonitor_Inclusive.PathSummaryPlotter,
 )
 
 HLTTauPostSeq = cms.Sequence(HLTTauPostAnalysis_PFTaus*HLTTauPostAnalysis_Inclusive)

--- a/DQMOffline/Trigger/src/HLTTauDQML1Plotter.cc
+++ b/DQMOffline/Trigger/src/HLTTauDQML1Plotter.cc
@@ -120,7 +120,6 @@ void HLTTauDQML1Plotter::bookHistograms(DQMStore::IBooker &iBooker) {
     snprintf(buffer, BUFMAX, "L1 central jet #phi Efficiency (E_{T} > %.1f);Ref #tau #eta;entries", l1JetMinEt_);
     l1jetPhiEffDenom_ = iBooker.book1D("L1JetPhiEffDenom", buffer, binsPhi_, minPhi, maxPhi);
   }
-  runValid_ = true;
 }
 
 

--- a/DQMOffline/Trigger/src/HLTTauDQML1Plotter.cc
+++ b/DQMOffline/Trigger/src/HLTTauDQML1Plotter.cc
@@ -29,17 +29,11 @@ HLTTauDQML1Plotter::HLTTauDQML1Plotter(const edm::ParameterSet& ps, edm::Consume
     return;
 
   //Process PSet
-  try {
-    l1ExtraTaus_      = ps.getUntrackedParameter<edm::InputTag>("L1Taus");
-    l1ExtraTausToken_ = cc.consumes<l1extra::L1JetParticleCollection>(l1ExtraTaus_);
-    l1ExtraJets_      = ps.getUntrackedParameter<edm::InputTag>("L1Jets");
-    l1ExtraJetsToken_ = cc.consumes<l1extra::L1JetParticleCollection>(l1ExtraJets_);
-    l1JetMinEt_       = ps.getUntrackedParameter<double>("L1JetMinEt");
-  } catch ( cms::Exception &e ) {
-    edm::LogWarning("HLTTauDQMOffline") << "HLTTauDQML1Plotter::HLTTauDQML1Plotter: " << e.what();
-    configValid_ = false;
-    return;
-  }
+  l1ExtraTaus_      = ps.getUntrackedParameter<edm::InputTag>("L1Taus");
+  l1ExtraTausToken_ = cc.consumes<l1extra::L1JetParticleCollection>(l1ExtraTaus_);
+  l1ExtraJets_      = ps.getUntrackedParameter<edm::InputTag>("L1Jets");
+  l1ExtraJetsToken_ = cc.consumes<l1extra::L1JetParticleCollection>(l1ExtraJets_);
+  l1JetMinEt_       = ps.getUntrackedParameter<double>("L1JetMinEt");
   configValid_ = true;
 }
 

--- a/DQMOffline/Trigger/src/HLTTauDQMOfflineSource.cc
+++ b/DQMOffline/Trigger/src/HLTTauDQMOfflineSource.cc
@@ -19,62 +19,40 @@ HLTTauDQMOfflineSource::HLTTauDQMOfflineSource( const edm::ParameterSet& ps ):
   triggerResultsToken_(consumes<edm::TriggerResults>(triggerResultsSrc_)),
   triggerEventSrc_(ps.getUntrackedParameter<edm::InputTag>("TriggerEventSrc")),
   triggerEventToken_(consumes<trigger::TriggerEvent>(triggerEventSrc_)),
+  pathRegex_(ps.getUntrackedParameter<std::string>("Paths")),
+  nPtBins_(ps.getUntrackedParameter<int>("PtHistoBins", 20)),
+  nEtaBins_(ps.getUntrackedParameter<int>("EtaHistoBins",12)),
+  nPhiBins_(ps.getUntrackedParameter<int>("PhiHistoBins",18)),
+  ptMax_(ps.getUntrackedParameter<double>("PtHistoMax",200)),
+  highPtMax_(ps.getUntrackedParameter<double>("HighPtHistoMax",1000)),
+  l1MatchDr_(ps.getUntrackedParameter<double>("L1MatchDeltaR", 0.5)),
+  hltMatchDr_(ps.getUntrackedParameter<double>("HLTMatchDeltaR", 0.2)),
+  dqmBaseFolder_(ps.getUntrackedParameter<std::string>("DQMBaseFolder")),
   counterEvt_(0),
   prescaleEvt_(ps.getUntrackedParameter<int>("prescaleEvt", -1))
 {
-  int nPtBins  = ps.getUntrackedParameter<int>("PtHistoBins", 20);
-  int nEtaBins = ps.getUntrackedParameter<int>("EtaHistoBins",12);
-  int nPhiBins = ps.getUntrackedParameter<int>("PhiHistoBins",18);
-  double ptMax = ps.getUntrackedParameter<double>("PtHistoMax",200);
-  double highPtMax = ps.getUntrackedParameter<double>("HighPtHistoMax",1000);
-  double l1MatchDr = ps.getUntrackedParameter<double>("L1MatchDeltaR", 0.5);
-  double hltMatchDr = ps.getUntrackedParameter<double>("HLTMatchDeltaR", 0.2);
-  std::string dqmBaseFolder = ps.getUntrackedParameter<std::string>("DQMBaseFolder");
-
   edm::ParameterSet matching = ps.getParameter<edm::ParameterSet>("Matching");
   doRefAnalysis_ = matching.getUntrackedParameter<bool>("doMatching");
 
-  using VPSet = std::vector<edm::ParameterSet>;
-  VPSet monitorSetup = ps.getParameter<VPSet>("MonitorSetup");
-
-  /*
-  l1Plotters_.reserve(monitorSetup.size());
-  pathPlotters_.reserve(monitorSetup.size());
-  pathSummaryPlotters_.reserve(monitorSetup.size());
-  */
-  for(const edm::ParameterSet& pset: monitorSetup) {
-    std::string configtype;
+  if(ps.exists("L1Plotter")) {
     try {
-      configtype = pset.getUntrackedParameter<std::string>("ConfigType");
+      l1Plotter_.reset(new HLTTauDQML1Plotter(ps.getUntrackedParameter<edm::ParameterSet>("L1Plotter"), consumesCollector(),
+                                              nPhiBins_, ptMax_, highPtMax_, doRefAnalysis_, l1MatchDr_, dqmBaseFolder_));
     } catch(cms::Exception& e) {
       edm::LogWarning("HLTTauDQMOffline") << e.what() << std::endl;
-      continue;
     }
-    if(configtype == "L1") {
-      try {
-        l1Plotters_.emplace_back(pset, consumesCollector(), nPhiBins, ptMax, highPtMax, doRefAnalysis_, l1MatchDr, dqmBaseFolder);
-      } catch(cms::Exception& e) {
-        edm::LogWarning("HLTTauDQMOffline") << e.what() << std::endl;
-        continue;
-      }
-    } else if (configtype == "Path") {
-      try {
-        pathPlotters2_.emplace_back(pset, doRefAnalysis_, dqmBaseFolder, hltProcessName_, nPtBins, nEtaBins, nPhiBins, ptMax, highPtMax, l1MatchDr, hltMatchDr);
-      } catch ( cms::Exception &e ) {
-        edm::LogWarning("HLTTauDQMOffline") << e.what() << std::endl;
-        continue;
-      }
-    } else if (configtype == "PathSummary") {
-      try {
-        pathSummaryPlotters_.emplace_back(pset, doRefAnalysis_, dqmBaseFolder, hltMatchDr);
-      } catch ( cms::Exception &e ) {
-        edm::LogWarning("HLTTauDQMOffline") << e.what() << std::endl;
-        continue;
-      }
+  }
+  if(ps.exists("PathSummaryPlotter")) {
+    try {
+      pathSummaryPlotter_.reset(new HLTTauDQMPathSummaryPlotter(ps.getUntrackedParameter<edm::ParameterSet>("PathSummaryPlotter"),
+                                                                doRefAnalysis_, dqmBaseFolder_, hltMatchDr_));
+    } catch(cms::Exception& e) {
+      edm::LogWarning("HLTTauDQMOffline") << e.what() << std::endl;
     }
   }
 
   if(doRefAnalysis_) {
+    using VPSet = std::vector<edm::ParameterSet>;
     VPSet matchObjects = matching.getUntrackedParameter<VPSet>("matchFilters");
     for(const edm::ParameterSet& pset: matchObjects) {
       refObjects_.push_back(RefObject{pset.getUntrackedParameter<int>("matchObjectID"),
@@ -91,16 +69,34 @@ void HLTTauDQMOfflineSource::dqmBeginRun(const edm::Run& iRun, const edm::EventS
   //Evaluate configuration for every new trigger menu
   bool hltMenuChanged = false;
   if(HLTCP_.init(iRun, iSetup, hltProcessName_, hltMenuChanged)) {
+    LogDebug("HLTTauDQMOffline") << "dqmBeginRun(), hltMenuChanged " << hltMenuChanged;
     if(hltMenuChanged) {
-      std::vector<const HLTTauDQMPath *> pathObjects;
-      pathObjects.reserve(pathPlotters2_.size());
-      for(auto& pathPlotter: pathPlotters2_) {
-        pathPlotter.updateHLTMenu(HLTCP_);
-        if(pathPlotter.isValid())
-          pathObjects.push_back(pathPlotter.getPathObject());
+      // Find all paths to monitor
+      std::vector<std::string> foundPaths;
+      boost::smatch what;
+      LogDebug("HLTTauDQMOffline") << "Looking for paths with regex " << pathRegex_;
+      for(const std::string& pathName: HLTCP_.triggerNames()) {
+        if(boost::regex_search(pathName, what, pathRegex_)) {
+          LogDebug("HLTTauDQMOffline") << "Found path " << pathName;
+          foundPaths.emplace_back(pathName);
+        }
       }
-      for(auto& pathSummaryPlotter: pathSummaryPlotters_) {
-        pathSummaryPlotter.setPathObjects(pathObjects);
+      std::sort(foundPaths.begin(), foundPaths.end());
+
+      // Construct path plotters
+      std::vector<const HLTTauDQMPath *> pathObjects;
+      pathPlotters_.reserve(foundPaths.size());
+      pathObjects.reserve(foundPaths.size());
+      for(const std::string& pathName: foundPaths) {
+        pathPlotters_.emplace_back(pathName, HLTCP_, doRefAnalysis_, dqmBaseFolder_, hltProcessName_, nPtBins_, nEtaBins_, nPhiBins_, ptMax_, highPtMax_, l1MatchDr_, hltMatchDr_);
+        if(pathPlotters_.back().isValid()) {
+          pathObjects.push_back(pathPlotters_.back().getPathObject());
+        }
+      }
+
+      // Update paths to the summary plotter
+      if(pathSummaryPlotter_) {
+        pathSummaryPlotter_->setPathObjects(pathObjects);
       }
     }
   } else {
@@ -110,14 +106,14 @@ void HLTTauDQMOfflineSource::dqmBeginRun(const edm::Run& iRun, const edm::EventS
 
 //--------------------------------------------------------
 void HLTTauDQMOfflineSource::bookHistograms(DQMStore::IBooker &iBooker, const edm::Run& iRun, const EventSetup& iSetup ) {
-  for(auto& l1Plotter: l1Plotters_) {
-    l1Plotter.bookHistograms(iBooker);
+  if(l1Plotter_) {
+    l1Plotter_->bookHistograms(iBooker);
   }
-  for(auto& pathPlotter: pathPlotters2_) {
+  for(auto& pathPlotter: pathPlotters_) {
     pathPlotter.bookHistograms(iBooker);
   }
-  for(auto& pathSummaryPlotter: pathSummaryPlotters_) {
-    pathSummaryPlotter.bookHistograms(iBooker);
+  if(pathSummaryPlotter_) {
+    pathSummaryPlotter_->bookHistograms(iBooker);
   }
 }
 
@@ -164,20 +160,18 @@ void HLTTauDQMOfflineSource::analyze(const Event& iEvent, const EventSetup& iSet
         }
         
         //Path Plotters
-        for(auto& pathPlotter: pathPlotters2_) {
+        for(auto& pathPlotter: pathPlotters_) {
           if(pathPlotter.isValid())
             pathPlotter.analyze(*triggerResultsHandle, *triggerEventHandle, refC);
         }
         
-        for(auto& pathSummaryPlotter: pathSummaryPlotters_) {
-          if(pathSummaryPlotter.isValid())
-            pathSummaryPlotter.analyze(*triggerResultsHandle, *triggerEventHandle, refC);
+        if(pathSummaryPlotter_ && pathSummaryPlotter_->isValid()) {
+          pathSummaryPlotter_->analyze(*triggerResultsHandle, *triggerEventHandle, refC);
         }
         
-        //L1 Plotters
-        for(auto& l1Plotter: l1Plotters_) {
-          if(l1Plotter.isValid())
-            l1Plotter.analyze(iEvent, iSetup, refC);
+        //L1 Plotter
+        if(l1Plotter_ && l1Plotter_->isValid()) {
+          l1Plotter_->analyze(iEvent, iSetup, refC);
         }
     } else {
         counterEvt_++;

--- a/DQMOffline/Trigger/src/HLTTauDQMOfflineSource.cc
+++ b/DQMOffline/Trigger/src/HLTTauDQMOfflineSource.cc
@@ -35,20 +35,12 @@ HLTTauDQMOfflineSource::HLTTauDQMOfflineSource( const edm::ParameterSet& ps ):
   doRefAnalysis_ = matching.getUntrackedParameter<bool>("doMatching");
 
   if(ps.exists("L1Plotter")) {
-    try {
-      l1Plotter_.reset(new HLTTauDQML1Plotter(ps.getUntrackedParameter<edm::ParameterSet>("L1Plotter"), consumesCollector(),
-                                              nPhiBins_, ptMax_, highPtMax_, doRefAnalysis_, l1MatchDr_, dqmBaseFolder_));
-    } catch(cms::Exception& e) {
-      edm::LogWarning("HLTTauDQMOffline") << e.what() << std::endl;
-    }
+    l1Plotter_.reset(new HLTTauDQML1Plotter(ps.getUntrackedParameter<edm::ParameterSet>("L1Plotter"), consumesCollector(),
+                                            nPhiBins_, ptMax_, highPtMax_, doRefAnalysis_, l1MatchDr_, dqmBaseFolder_));
   }
   if(ps.exists("PathSummaryPlotter")) {
-    try {
-      pathSummaryPlotter_.reset(new HLTTauDQMPathSummaryPlotter(ps.getUntrackedParameter<edm::ParameterSet>("PathSummaryPlotter"),
-                                                                doRefAnalysis_, dqmBaseFolder_, hltMatchDr_));
-    } catch(cms::Exception& e) {
-      edm::LogWarning("HLTTauDQMOffline") << e.what() << std::endl;
-    }
+    pathSummaryPlotter_.reset(new HLTTauDQMPathSummaryPlotter(ps.getUntrackedParameter<edm::ParameterSet>("PathSummaryPlotter"),
+                                                              doRefAnalysis_, dqmBaseFolder_, hltMatchDr_));
   }
 
   if(doRefAnalysis_) {

--- a/DQMOffline/Trigger/src/HLTTauDQMPath.cc
+++ b/DQMOffline/Trigger/src/HLTTauDQMPath.cc
@@ -193,7 +193,7 @@ namespace {
         n.tau = 2;
       }
     }
-    else if(moduleType == "HLT1CaloJet") {
+    else if(moduleType == "HLT1CaloJet" || moduleType == "HLT1PFJet") {
       //const edm::ParameterSet& pset = HLTCP.modulePSet(filterName);
       //pset.getParameter<int>("triggerType") == trigger::TriggerTau) {
       if(getParameterSafe(HLTCP, filterName, "triggerType") == trigger::TriggerTau) {
@@ -220,7 +220,7 @@ namespace {
       //n.electron = HLTCP.modulePSet(filterName).getParameter<int>("ncandcut");
       n.electron = getParameterSafe(HLTCP, filterName, "ncandcut");
     }
-    else if(moduleType == "HLTMuonIsoFilter") {
+    else if(moduleType == "HLTMuonIsoFilter" || moduleType == "HLTMuonL3PreFilter") {
       n.muon = HLTCP.modulePSet(filterName).getParameter<int>("MinN");
     }
     else if(moduleType == "HLT2ElectronTau" || moduleType == "HLT2ElectronPFTau") {

--- a/DQMOffline/Trigger/src/HLTTauDQMPath.cc
+++ b/DQMOffline/Trigger/src/HLTTauDQMPath.cc
@@ -209,14 +209,18 @@ HLTTauDQMPath::HLTTauDQMPath(const std::string& pathName, const std::string& hlt
   isFirstL1Seed_(false),
   isValid_(false)
 {
+#ifdef EDM_ML_LOGDEBUG
   std::stringstream ss;
   ss << "HLTTauDQMPath: " << pathName_ << "\n";
+#endif
 
   // Get the filters
   HLTPath thePath(pathName_);
   filterIndices_ = thePath.interestingFilters(HLTCP, doRefAnalysis_);
   isFirstL1Seed_ = HLTCP.moduleType(std::get<0>(filterIndices_[0])) == "HLTLevel1GTSeed";
+#ifdef EDM_ML_LOGDEBUG
   ss << "  Filters";
+#endif
   // Set the filter multiplicity counts
   filterTauN_.clear();
   filterElectronN_.clear();
@@ -233,15 +237,19 @@ HLTTauDQMPath::HLTTauDQMPath(const std::string& pathName, const std::string& hlt
     filterElectronN_.push_back(n.electron);
     filterMuonN_.push_back(n.muon);
 
+#ifdef EDM_ML_LOGDEBUG
     ss << "\n    " << std::get<1>(filterIndices_[i])
        << " " << filterName
        << " " << moduleType
        << " ntau " << n.tau
        << " nele " << n.electron
        << " nmu " << n.muon;
+#endif
 
   }
-  edm::LogInfo("HLTTauDQMOffline") << ss.str();
+#ifdef EDM_ML_LOGDEBUG
+  LogDebug("HLTTauDQMOffline") << ss.str();
+#endif
 
 
   // Find the position of PFRecoTauProducer, use filters with taus

--- a/DQMOffline/Trigger/src/HLTTauDQMPath.cc
+++ b/DQMOffline/Trigger/src/HLTTauDQMPath.cc
@@ -75,8 +75,8 @@ namespace {
         // FIXME: this will not work in unscheduled mode, where
         // producers are not in paths. Try looking first filter using
         // the PFRecoTauProducer output instead.
-        if(type == "PFRecoTauProducer") {
-          //edm::LogInfo("HLTTauDQMOffline") << "Found PFTauProducer " << *iLabel << " index " << (iLabel-moduleLabels.begin());
+        if(type == "PFRecoTauProducer" || type == "RecoTauPiZeroUnembedder") {
+          LogDebug("HLTTauDQMOffline") << "Found tau producer " << type << " " << *iLabel << " index " << (iLabel-moduleLabels.begin());
           return iLabel-moduleLabels.begin();
         }
       }
@@ -252,12 +252,12 @@ HLTTauDQMPath::HLTTauDQMPath(const std::string& pathName, const std::string& hlt
 #endif
 
 
-  // Find the position of PFRecoTauProducer, use filters with taus
+  // Find the position of tau producer, use filters with taus
   // before it for L2 tau efficiency, and filters with taus after it
   // for L3 tau efficiency
   const size_t tauProducerIndex = thePath.tauProducerIndex(HLTCP);
   if(tauProducerIndex == std::numeric_limits<size_t>::max()) {
-    edm::LogWarning("HLTTauDQMOffline") << "HLTTauDQMPath::beginRun(): Did not find PFRecoTauProducer from HLT path " << pathName_;
+    edm::LogWarning("HLTTauDQMOffline") << "HLTTauDQMPath::beginRun(): Did not find tau producer from HLT path " << pathName_;
   }
   //lastFilterBeforeL2TauIndex_ = std::numeric_limits<size_t>::max();
   lastL2TauFilterIndex_ = std::numeric_limits<size_t>::max();

--- a/DQMOffline/Trigger/src/HLTTauDQMPath.cc
+++ b/DQMOffline/Trigger/src/HLTTauDQMPath.cc
@@ -217,6 +217,10 @@ HLTTauDQMPath::HLTTauDQMPath(const std::string& pathName, const std::string& hlt
   // Get the filters
   HLTPath thePath(pathName_);
   filterIndices_ = thePath.interestingFilters(HLTCP, doRefAnalysis_);
+  if(filterIndices_.empty()) {
+    edm::LogInfo("HLTTauDQMOffline") << "HLTTauDQMPath: " << pathName_ << " no interesting filters found";
+    return;
+  }
   isFirstL1Seed_ = HLTCP.moduleType(std::get<0>(filterIndices_[0])) == "HLTLevel1GTSeed";
 #ifdef EDM_ML_LOGDEBUG
   ss << "  Filters";

--- a/DQMOffline/Trigger/src/HLTTauDQMPathPlotter.cc
+++ b/DQMOffline/Trigger/src/HLTTauDQMPathPlotter.cc
@@ -3,11 +3,12 @@
 #include "DataFormats/HLTReco/interface/TriggerEvent.h"
 #include "DataFormats/HLTReco/interface/TriggerTypeDefs.h"
 
-HLTTauDQMPathPlotter::HLTTauDQMPathPlotter(const edm::ParameterSet& pset, bool doRefAnalysis, const std::string& dqmBaseFolder,
+HLTTauDQMPathPlotter::HLTTauDQMPathPlotter(const std::string& pathName, const HLTConfigProvider& HLTCP,
+                                           bool doRefAnalysis, const std::string& dqmBaseFolder,
                                            const std::string& hltProcess, int ptbins, int etabins, int phibins,
                                            double ptmax, double highptmax,
                                            double l1MatchDr, double hltMatchDr):
-  HLTTauDQMPlotter(pset, dqmBaseFolder),
+  HLTTauDQMPlotter(pathName, dqmBaseFolder),
   ptbins_(ptbins),
   etabins_(etabins),
   phibins_(phibins),
@@ -16,35 +17,12 @@ HLTTauDQMPathPlotter::HLTTauDQMPathPlotter(const edm::ParameterSet& pset, bool d
   l1MatchDr_(l1MatchDr),
   hltMatchDr_(hltMatchDr),
   doRefAnalysis_(doRefAnalysis),
-  hltPath_(hltProcess, dqmFolder_, doRefAnalysis_)
+  hltPath_(pathName, hltProcess, doRefAnalysis_, HLTCP)
 {
   if(!configValid_)
     return;
 
-  // Parse configuration
-  try {
-    hltPath_.initialize(pset);
-  } catch(cms::Exception& e) {
-    edm::LogWarning("HLTTauDQMOffline") << "HLTTauDQMPathPlotter::HLTTauDQMPathPlotter(): " << e.what();
-    configValid_ = false;
-    return;
-  }
-  configValid_ = true;
-}
-
-void HLTTauDQMPathPlotter::updateHLTMenu(const HLTConfigProvider& HLTCP) {
-  if(!configValid_)
-    return;
-
-  // Identify the correct HLT path
-  if(!HLTCP.inited()) {
-    edm::LogWarning("HLTTauDQMOffline") << "HLTTauDQMPathPlotter::beginRun(): HLTConfigProvider is not initialized!";
-    runValid_ = false;
-    return;
-  }
-
-  // Search path candidates
-  runValid_ = hltPath_.beginRun(HLTCP);
+  runValid_ = hltPath_.isValid();
 }
 
 void HLTTauDQMPathPlotter::bookHistograms(DQMStore::IBooker &iBooker) {
@@ -97,8 +75,19 @@ void HLTTauDQMPathPlotter::bookHistograms(DQMStore::IBooker &iBooker) {
     const int ntaus = hltPath_.getFilterNTaus(lastFilter);
     const int neles = hltPath_.getFilterNElectrons(lastFilter);
     const int nmus = hltPath_.getFilterNMuons(lastFilter);
-    if(ntaus+neles+nmus == 2) {
-      hMass_ = iBooker.book1D("ReferenceMass", "Invariant mass of reference "+dqmFolder_+";Reference invariant mass;entries", 100, 0, 500);
+    auto create = [&](const std::string& name) {
+      this->hMass_ = iBooker.book1D("ReferenceMass", "Invariant mass of reference "+name+";Reference invariant mass;entries", 100, 0, 500);
+    };
+
+    LogDebug("HLTTauDQMOffline") << "Path " << hltPath_.getPathName() << " number of taus " << ntaus << " electrons " << neles << " muons " << nmus;
+
+    if(ntaus == 2)
+      create("di-tau");
+    else if(ntaus == 1) {
+      if(neles == 1)
+        create("electron-tau");
+      else if(nmus == 1)
+        create("muon-tau");
     }
   }
 }

--- a/DQMOffline/Trigger/src/HLTTauDQMPathPlotter.cc
+++ b/DQMOffline/Trigger/src/HLTTauDQMPathPlotter.cc
@@ -19,10 +19,7 @@ HLTTauDQMPathPlotter::HLTTauDQMPathPlotter(const std::string& pathName, const HL
   doRefAnalysis_(doRefAnalysis),
   hltPath_(pathName, hltProcess, doRefAnalysis_, HLTCP)
 {
-  if(!configValid_)
-    return;
-
-  runValid_ = hltPath_.isValid();
+  configValid_ = configValid_ && hltPath_.isValid();
 }
 
 void HLTTauDQMPathPlotter::bookHistograms(DQMStore::IBooker &iBooker) {

--- a/DQMOffline/Trigger/src/HLTTauDQMPathPlotter.cc
+++ b/DQMOffline/Trigger/src/HLTTauDQMPathPlotter.cc
@@ -3,12 +3,21 @@
 #include "DataFormats/HLTReco/interface/TriggerEvent.h"
 #include "DataFormats/HLTReco/interface/TriggerTypeDefs.h"
 
+namespace {
+  std::string stripVersion(const std::string& pathName) {
+    size_t versionStart = pathName.rfind("_v");
+    if(versionStart == std::string::npos)
+      return pathName;
+    return pathName.substr(0, versionStart);
+  }
+}
+
 HLTTauDQMPathPlotter::HLTTauDQMPathPlotter(const std::string& pathName, const HLTConfigProvider& HLTCP,
                                            bool doRefAnalysis, const std::string& dqmBaseFolder,
                                            const std::string& hltProcess, int ptbins, int etabins, int phibins,
                                            double ptmax, double highptmax,
                                            double l1MatchDr, double hltMatchDr):
-  HLTTauDQMPlotter(pathName, dqmBaseFolder),
+  HLTTauDQMPlotter(stripVersion(pathName), dqmBaseFolder),
   ptbins_(ptbins),
   etabins_(etabins),
   phibins_(phibins),

--- a/DQMOffline/Trigger/src/HLTTauDQMPathSummaryPlotter.cc
+++ b/DQMOffline/Trigger/src/HLTTauDQMPathSummaryPlotter.cc
@@ -11,7 +11,7 @@ HLTTauDQMPathSummaryPlotter::~HLTTauDQMPathSummaryPlotter() {
 }
 
 void HLTTauDQMPathSummaryPlotter::bookHistograms(DQMStore::IBooker &iBooker) {
-  if(!isValid())
+  if(!isValid() || pathObjects_.empty())
     return;
 
   //Create the histograms

--- a/DQMOffline/Trigger/src/HLTTauDQMPlotter.cc
+++ b/DQMOffline/Trigger/src/HLTTauDQMPlotter.cc
@@ -17,6 +17,13 @@ HLTTauDQMPlotter::HLTTauDQMPlotter(const edm::ParameterSet& pset, const std::str
   }
 }
 
+HLTTauDQMPlotter::HLTTauDQMPlotter(const std::string& dqmFolder, const std::string& dqmBaseFolder):
+  dqmFullFolder_(dqmBaseFolder+dqmFolder),
+  dqmFolder_(dqmFolder),
+  configValid_(true),
+  runValid_(false)
+{}
+
 HLTTauDQMPlotter::~HLTTauDQMPlotter() {
 }
 

--- a/DQMOffline/Trigger/src/HLTTauDQMPlotter.cc
+++ b/DQMOffline/Trigger/src/HLTTauDQMPlotter.cc
@@ -4,8 +4,7 @@
 
 HLTTauDQMPlotter::HLTTauDQMPlotter(const edm::ParameterSet& pset, const std::string& dqmBaseFolder):
   dqmFullFolder_(dqmBaseFolder),
-  configValid_(false),
-  runValid_(false)
+  configValid_(false)
 {
   try {
     dqmFolder_ = pset.getUntrackedParameter<std::string>("DQMFolder");
@@ -20,8 +19,7 @@ HLTTauDQMPlotter::HLTTauDQMPlotter(const edm::ParameterSet& pset, const std::str
 HLTTauDQMPlotter::HLTTauDQMPlotter(const std::string& dqmFolder, const std::string& dqmBaseFolder):
   dqmFullFolder_(dqmBaseFolder+dqmFolder),
   dqmFolder_(dqmFolder),
-  configValid_(true),
-  runValid_(false)
+  configValid_(true)
 {}
 
 HLTTauDQMPlotter::~HLTTauDQMPlotter() {

--- a/DQMOffline/Trigger/src/HLTTauDQMPlotter.cc
+++ b/DQMOffline/Trigger/src/HLTTauDQMPlotter.cc
@@ -6,14 +6,9 @@ HLTTauDQMPlotter::HLTTauDQMPlotter(const edm::ParameterSet& pset, const std::str
   dqmFullFolder_(dqmBaseFolder),
   configValid_(false)
 {
-  try {
-    dqmFolder_ = pset.getUntrackedParameter<std::string>("DQMFolder");
-    dqmFullFolder_ += dqmFolder_;
-    configValid_  = true;
-  } catch ( cms::Exception &e ) {
-    edm::LogWarning("HLTTauDQMOfflineSource") << "HLTTauDQMPlotter::HLTTauDQMPlotter(): " << e.what();
-    configValid_ = false;
-  }
+  dqmFolder_ = pset.getUntrackedParameter<std::string>("DQMFolder");
+  dqmFullFolder_ += dqmFolder_;
+  configValid_  = true;
 }
 
 HLTTauDQMPlotter::HLTTauDQMPlotter(const std::string& dqmFolder, const std::string& dqmBaseFolder):

--- a/DQMOffline/Trigger/src/HLTTauDQMSummaryPlotter.cc
+++ b/DQMOffline/Trigger/src/HLTTauDQMSummaryPlotter.cc
@@ -50,17 +50,11 @@ private:
 HLTTauDQMSummaryPlotter::HLTTauDQMSummaryPlotter(const edm::ParameterSet& ps, const std::string& dqmBaseFolder, const std::string& type):
   HLTTauDQMPlotter(ps, dqmBaseFolder),
   type_(type)
-{
-  // no run concept in summary plotter
-  runValid_ = configValid_;
-}
+{}
 HLTTauDQMSummaryPlotter::HLTTauDQMSummaryPlotter(const std::string& dqmBaseFolder, const std::string& type):
   HLTTauDQMPlotter("", dqmBaseFolder),
   type_(type)
-{
-  // no run concept in summary plotter
-  runValid_ = configValid_;
-}
+{}
 
 HLTTauDQMSummaryPlotter::~HLTTauDQMSummaryPlotter() {}
 
@@ -96,7 +90,6 @@ void HLTTauDQMSummaryPlotter::bookPlots() {
   else if(type_ == "PathSummary") {
     plotters_.emplace_back(new SummaryPlotter(type_, triggerTag(), store));
   }
-  runValid_ = true;
 }
 
 void HLTTauDQMSummaryPlotter::plot() {

--- a/DQMOffline/Trigger/src/HLTTauDQMSummaryPlotter.cc
+++ b/DQMOffline/Trigger/src/HLTTauDQMSummaryPlotter.cc
@@ -20,25 +20,46 @@ namespace {
   }
 }
 
-HLTTauDQMSummaryPlotter::HLTTauDQMSummaryPlotter(const edm::ParameterSet& ps, const std::string& dqmBaseFolder):
-  HLTTauDQMPlotter(ps, dqmBaseFolder),
-  store_(nullptr)
-{
-  if(!configValid_)
-    return;
+class HLTTauDQMSummaryPlotter::SummaryPlotter {
+public:
+  enum class Type {
+    kL1,
+    kPath,
+    kPathSummary,
+    kUnknown
+  };
 
+  SummaryPlotter(const std::string& type, const std::string& folder, DQMStore& store);
+
+  void plot(DQMStore& store);
+
+private:
+  void bookEfficiencyHisto(const std::string& name, const std::string& hist1, bool copyLabels=false);
+  void plotEfficiencyHisto(std::string name, std::string hist1, std::string hist2 );
+  void plotIntegratedEffHisto(std::string name, std::string refHisto, std::string evCount, int bin );
+  void bookTriggerBitEfficiencyHistos(std::string histo );
+  void plotTriggerBitEfficiencyHistos(std::string histo );
+  void bookFractionHisto(const std::string& name);
+  void plotFractionHisto(const std::string& name);
+
+  const std::string folder_;
+  DQMStore *store_;
+  Type type_;
+};
+
+HLTTauDQMSummaryPlotter::HLTTauDQMSummaryPlotter(const edm::ParameterSet& ps, const std::string& dqmBaseFolder, const std::string& type):
+  HLTTauDQMPlotter(ps, dqmBaseFolder),
+  type_(type)
+{
   // no run concept in summary plotter
-  runValid_ = true;
-    
-  //Process PSet
-  try {
-    type_ = ps.getUntrackedParameter<std::string>("ConfigType");
-  } catch ( cms::Exception &e ) {
-    edm::LogWarning("HLTTauDQMOfflineSource") << "HLTTauDQMSummaryPlotter::HLTTauDQMSummaryPlotter(): " << e.what();
-    configValid_ = false;
-    return;
-  }
-  configValid_ = true;
+  runValid_ = configValid_;
+}
+HLTTauDQMSummaryPlotter::HLTTauDQMSummaryPlotter(const std::string& dqmBaseFolder, const std::string& type):
+  HLTTauDQMPlotter("", dqmBaseFolder),
+  type_(type)
+{
+  // no run concept in summary plotter
+  runValid_ = configValid_;
 }
 
 HLTTauDQMSummaryPlotter::~HLTTauDQMSummaryPlotter() {}
@@ -47,96 +68,144 @@ void HLTTauDQMSummaryPlotter::bookPlots() {
   if(!configValid_)
     return;
 
+  edm::Service<DQMStore> hstore;
+  if(!hstore.isAvailable())
+    return;
+
+  DQMStore& store = *hstore;
+  if(type_ == "L1") {
+    plotters_.emplace_back(new SummaryPlotter(type_, triggerTag(), store));
+  }
+  else if(type_ == "Path") {
+    std::string path = triggerTag();
+    path.pop_back(); // strip of trailing /
+    if(store.dirExists(path)) {
+      store.setCurrentFolder(path);
+      for(const std::string& subfolder: store.getSubdirs()) {
+        std::size_t pos = subfolder.rfind("/");
+        if(pos == std::string::npos)
+          continue;
+        ++pos; // position of first letter after /
+        if(subfolder.compare(pos, 4, "HLT_") == 0) { // start with HLT_
+          LogDebug("HLTTauDQMOffline") << "SummaryPlotter: processing path " << subfolder.substr(pos);
+          plotters_.emplace_back(new SummaryPlotter(type_, subfolder, store));
+        }
+      }
+    }
+  }
+  else if(type_ == "PathSummary") {
+    plotters_.emplace_back(new SummaryPlotter(type_, triggerTag(), store));
+  }
+  runValid_ = true;
+}
+
+void HLTTauDQMSummaryPlotter::plot() {
+  if(!isValid())
+    return;
+
   edm::Service<DQMStore> store;
   if(store.isAvailable()) {
-    store_ = store.operator->();
-        //Path Summary 
-        if ( type_ == "Path" ) {
-            bookTriggerBitEfficiencyHistos(triggerTag(), "EventsPerFilter");
+    for(auto& plotter: plotters_) {
+      plotter->plot(*store);
+    }
+  }
+}
+ 
+HLTTauDQMSummaryPlotter::SummaryPlotter::SummaryPlotter(const std::string& type, const std::string& folder, DQMStore& store):
+  folder_(folder),
+  store_(nullptr),
+  type_(Type::kUnknown)
+{
+  if(type == "L1") type_ = Type::kL1;
+  else if(type == "Path") type_ = Type::kPath;
+  else if(type == "PathSummary") type_ = Type::kPathSummary;
 
-            bookEfficiencyHisto(triggerTag(), "L2TrigTauEtEff",  "helpers/L2TrigTauEtEffNum"); 
-            bookEfficiencyHisto(triggerTag(), "L2TrigTauHighEtEff",  "helpers/L2TrigTauHighEtEffNum");
-            bookEfficiencyHisto(triggerTag(), "L2TrigTauEtaEff", "helpers/L2TrigTauEtaEffNum");
-            bookEfficiencyHisto(triggerTag(), "L2TrigTauPhiEff", "helpers/L2TrigTauPhiEffNum");
+  store_ = &store;
 
-            bookEfficiencyHisto(triggerTag(), "L3TrigTauEtEff",  "helpers/L3TrigTauEtEffNum");
-            bookEfficiencyHisto(triggerTag(), "L3TrigTauHighEtEff",  "helpers/L3TrigTauHighEtEffNum");
-            bookEfficiencyHisto(triggerTag(), "L3TrigTauEtaEff", "helpers/L3TrigTauEtaEffNum");
-            bookEfficiencyHisto(triggerTag(), "L3TrigTauPhiEff", "helpers/L3TrigTauPhiEffNum");
-        }
-        
-        //L1 Summary
-        else if ( type_ == "L1" ) {
-            bookEfficiencyHisto(triggerTag(),"L1TauEtEff","EfficiencyHelpers/L1TauEtEffNum");
-            bookEfficiencyHisto(triggerTag(),"L1TauHighEtEff","EfficiencyHelpers/L1TauHighEtEffNum");
-            bookEfficiencyHisto(triggerTag(),"L1TauEtaEff","EfficiencyHelpers/L1TauEtaEffNum");
-            bookEfficiencyHisto(triggerTag(),"L1TauPhiEff","EfficiencyHelpers/L1TauPhiEffNum");
-            
-            bookEfficiencyHisto(triggerTag(),"L1JetEtEff","EfficiencyHelpers/L1JetEtEffNum");
-            bookEfficiencyHisto(triggerTag(),"L1JetHighEtEff","EfficiencyHelpers/L1JetHighEtEffNum");
-            bookEfficiencyHisto(triggerTag(),"L1JetEtaEff","EfficiencyHelpers/L1JetEtaEffNum");
-            bookEfficiencyHisto(triggerTag(),"L1JetPhiEff","EfficiencyHelpers/L1JetPhiEffNum");
-        }
+  //Path Summary 
+  if ( type_ == Type::kPath ) {
+    bookTriggerBitEfficiencyHistos("EventsPerFilter");
 
-        else if(type_ == "PathSummary") {
-          bookEfficiencyHisto(triggerTag(), "PathEfficiency", "helpers/PathTriggerBits", true);
-        }
+    bookEfficiencyHisto("L2TrigTauEtEff",  "helpers/L2TrigTauEtEffNum"); 
+    bookEfficiencyHisto("L2TrigTauHighEtEff",  "helpers/L2TrigTauHighEtEffNum");
+    bookEfficiencyHisto("L2TrigTauEtaEff", "helpers/L2TrigTauEtaEffNum");
+    bookEfficiencyHisto("L2TrigTauPhiEff", "helpers/L2TrigTauPhiEffNum");
+
+    bookEfficiencyHisto("L3TrigTauEtEff",  "helpers/L3TrigTauEtEffNum");
+    bookEfficiencyHisto("L3TrigTauHighEtEff",  "helpers/L3TrigTauHighEtEffNum");
+    bookEfficiencyHisto("L3TrigTauEtaEff", "helpers/L3TrigTauEtaEffNum");
+    bookEfficiencyHisto("L3TrigTauPhiEff", "helpers/L3TrigTauPhiEffNum");
+  }
+
+  //L1 Summary
+  else if ( type_ == Type::kL1 ) {
+    bookEfficiencyHisto("L1TauEtEff","EfficiencyHelpers/L1TauEtEffNum");
+    bookEfficiencyHisto("L1TauHighEtEff","EfficiencyHelpers/L1TauHighEtEffNum");
+    bookEfficiencyHisto("L1TauEtaEff","EfficiencyHelpers/L1TauEtaEffNum");
+    bookEfficiencyHisto("L1TauPhiEff","EfficiencyHelpers/L1TauPhiEffNum");
+
+    bookEfficiencyHisto("L1JetEtEff","EfficiencyHelpers/L1JetEtEffNum");
+    bookEfficiencyHisto("L1JetHighEtEff","EfficiencyHelpers/L1JetHighEtEffNum");
+    bookEfficiencyHisto("L1JetEtaEff","EfficiencyHelpers/L1JetEtaEffNum");
+    bookEfficiencyHisto("L1JetPhiEff","EfficiencyHelpers/L1JetPhiEffNum");
+  }
+
+  else if(type_ == Type::kPathSummary) {
+    bookEfficiencyHisto("PathEfficiency", "helpers/PathTriggerBits", true);
   }
   store_ = nullptr;
 }
 
-void HLTTauDQMSummaryPlotter::plot() {
-  edm::Service<DQMStore> store;
-  if(store.isAvailable()) {
-    store_ = store.operator->();
-        //Path Summary 
-        if ( type_ == "Path" ) {
-            plotTriggerBitEfficiencyHistos(triggerTag(), "EventsPerFilter");
+void HLTTauDQMSummaryPlotter::SummaryPlotter::plot(DQMStore& store) {
+  store_ = &store;
 
-            plotEfficiencyHisto(triggerTag(), "L2TrigTauEtEff",  "helpers/L2TrigTauEtEffNum",  "helpers/L2TrigTauEtEffDenom");
-            plotEfficiencyHisto(triggerTag(), "L2TrigTauHighEtEff",  "helpers/L2TrigTauHighEtEffNum",  "helpers/L2TrigTauHighEtEffDenom");
-            plotEfficiencyHisto(triggerTag(), "L2TrigTauEtaEff", "helpers/L2TrigTauEtaEffNum", "helpers/L2TrigTauEtaEffDenom");
-            plotEfficiencyHisto(triggerTag(), "L2TrigTauPhiEff", "helpers/L2TrigTauPhiEffNum", "helpers/L2TrigTauPhiEffDenom");
+  //Path Summary 
+  if ( type_ == Type::kPath ) {
+    plotTriggerBitEfficiencyHistos("EventsPerFilter");
 
-            plotEfficiencyHisto(triggerTag(), "L3TrigTauEtEff",  "helpers/L3TrigTauEtEffNum",  "helpers/L3TrigTauEtEffDenom");
-            plotEfficiencyHisto(triggerTag(), "L3TrigTauHighEtEff",  "helpers/L3TrigTauHighEtEffNum",  "helpers/L3TrigTauHighEtEffDenom");
-            plotEfficiencyHisto(triggerTag(), "L3TrigTauEtaEff", "helpers/L3TrigTauEtaEffNum", "helpers/L3TrigTauEtaEffDenom");
-            plotEfficiencyHisto(triggerTag(), "L3TrigTauPhiEff", "helpers/L3TrigTauPhiEffNum", "helpers/L3TrigTauPhiEffDenom");
-        }
+    plotEfficiencyHisto("L2TrigTauEtEff",  "helpers/L2TrigTauEtEffNum",  "helpers/L2TrigTauEtEffDenom");
+    plotEfficiencyHisto("L2TrigTauHighEtEff",  "helpers/L2TrigTauHighEtEffNum",  "helpers/L2TrigTauHighEtEffDenom");
+    plotEfficiencyHisto("L2TrigTauEtaEff", "helpers/L2TrigTauEtaEffNum", "helpers/L2TrigTauEtaEffDenom");
+    plotEfficiencyHisto("L2TrigTauPhiEff", "helpers/L2TrigTauPhiEffNum", "helpers/L2TrigTauPhiEffDenom");
+
+    plotEfficiencyHisto("L3TrigTauEtEff",  "helpers/L3TrigTauEtEffNum",  "helpers/L3TrigTauEtEffDenom");
+    plotEfficiencyHisto("L3TrigTauHighEtEff",  "helpers/L3TrigTauHighEtEffNum",  "helpers/L3TrigTauHighEtEffDenom");
+    plotEfficiencyHisto("L3TrigTauEtaEff", "helpers/L3TrigTauEtaEffNum", "helpers/L3TrigTauEtaEffDenom");
+    plotEfficiencyHisto("L3TrigTauPhiEff", "helpers/L3TrigTauPhiEffNum", "helpers/L3TrigTauPhiEffDenom");
+  }
         
-        //L1 Summary
-        else if ( type_ == "L1" ) {
-            plotEfficiencyHisto(triggerTag(),"L1TauEtEff","EfficiencyHelpers/L1TauEtEffNum","EfficiencyHelpers/L1TauEtEffDenom");
-            plotEfficiencyHisto(triggerTag(),"L1TauHighEtEff","EfficiencyHelpers/L1TauHighEtEffNum","EfficiencyHelpers/L1TauHighEtEffDenom");
-            plotEfficiencyHisto(triggerTag(),"L1TauEtaEff","EfficiencyHelpers/L1TauEtaEffNum","EfficiencyHelpers/L1TauEtaEffDenom");
-            plotEfficiencyHisto(triggerTag(),"L1TauPhiEff","EfficiencyHelpers/L1TauPhiEffNum","EfficiencyHelpers/L1TauPhiEffDenom");
+  //L1 Summary
+  else if ( type_ == Type::kL1 ) {
+    plotEfficiencyHisto("L1TauEtEff","EfficiencyHelpers/L1TauEtEffNum","EfficiencyHelpers/L1TauEtEffDenom");
+    plotEfficiencyHisto("L1TauHighEtEff","EfficiencyHelpers/L1TauHighEtEffNum","EfficiencyHelpers/L1TauHighEtEffDenom");
+    plotEfficiencyHisto("L1TauEtaEff","EfficiencyHelpers/L1TauEtaEffNum","EfficiencyHelpers/L1TauEtaEffDenom");
+    plotEfficiencyHisto("L1TauPhiEff","EfficiencyHelpers/L1TauPhiEffNum","EfficiencyHelpers/L1TauPhiEffDenom");
             
-            plotEfficiencyHisto(triggerTag(),"L1JetEtEff","EfficiencyHelpers/L1JetEtEffNum","EfficiencyHelpers/L1JetEtEffDenom");
-            plotEfficiencyHisto(triggerTag(),"L1JetHighEtEff","EfficiencyHelpers/L1JetHighEtEffNum","EfficiencyHelpers/L1JetHighEtEffDenom");
-            plotEfficiencyHisto(triggerTag(),"L1JetEtaEff","EfficiencyHelpers/L1JetEtaEffNum","EfficiencyHelpers/L1JetEtaEffDenom");
-            plotEfficiencyHisto(triggerTag(),"L1JetPhiEff","EfficiencyHelpers/L1JetPhiEffNum","EfficiencyHelpers/L1JetPhiEffDenom");
+    plotEfficiencyHisto("L1JetEtEff","EfficiencyHelpers/L1JetEtEffNum","EfficiencyHelpers/L1JetEtEffDenom");
+    plotEfficiencyHisto("L1JetHighEtEff","EfficiencyHelpers/L1JetHighEtEffNum","EfficiencyHelpers/L1JetHighEtEffDenom");
+    plotEfficiencyHisto("L1JetEtaEff","EfficiencyHelpers/L1JetEtaEffNum","EfficiencyHelpers/L1JetEtaEffDenom");
+    plotEfficiencyHisto("L1JetPhiEff","EfficiencyHelpers/L1JetPhiEffNum","EfficiencyHelpers/L1JetPhiEffDenom");
             
-            plotEfficiencyHisto(triggerTag(),"L1ElectronEtEff","EfficiencyHelpers/L1ElectronEtEffNum","EfficiencyHelpers/L1ElectronEtEffDenom");
-            plotEfficiencyHisto(triggerTag(),"L1ElectronEtaEff","EfficiencyHelpers/L1ElectronEtaEffNum","EfficiencyHelpers/L1ElectronEtaEffDenom");
-            plotEfficiencyHisto(triggerTag(),"L1ElectronPhiEff","EfficiencyHelpers/L1ElectronPhiEffNum","EfficiencyHelpers/L1ElectronPhiEffDenom");
+    plotEfficiencyHisto("L1ElectronEtEff","EfficiencyHelpers/L1ElectronEtEffNum","EfficiencyHelpers/L1ElectronEtEffDenom");
+    plotEfficiencyHisto("L1ElectronEtaEff","EfficiencyHelpers/L1ElectronEtaEffNum","EfficiencyHelpers/L1ElectronEtaEffDenom");
+    plotEfficiencyHisto("L1ElectronPhiEff","EfficiencyHelpers/L1ElectronPhiEffNum","EfficiencyHelpers/L1ElectronPhiEffDenom");
             
-            plotEfficiencyHisto(triggerTag(),"L1MuonEtEff","EfficiencyHelpers/L1MuonEtEffNum","EfficiencyHelpers/L1MuonEtEffDenom");
-            plotEfficiencyHisto(triggerTag(),"L1MuonEtaEff","EfficiencyHelpers/L1MuonEtaEffNum","EfficiencyHelpers/L1MuonEtaEffDenom");
-            plotEfficiencyHisto(triggerTag(),"L1MuonPhiEff","EfficiencyHelpers/L1MuonPhiEffNum","EfficiencyHelpers/L1MuonPhiEffDenom");
-        }
+    plotEfficiencyHisto("L1MuonEtEff","EfficiencyHelpers/L1MuonEtEffNum","EfficiencyHelpers/L1MuonEtEffDenom");
+    plotEfficiencyHisto("L1MuonEtaEff","EfficiencyHelpers/L1MuonEtaEffNum","EfficiencyHelpers/L1MuonEtaEffDenom");
+    plotEfficiencyHisto("L1MuonPhiEff","EfficiencyHelpers/L1MuonPhiEffNum","EfficiencyHelpers/L1MuonPhiEffDenom");
+  }
 
-        else if(type_ == "PathSummary") {
-          plotEfficiencyHisto(triggerTag(), "PathEfficiency", "helpers/PathTriggerBits", "helpers/RefEvents");
-        }
+  else if(type_ == Type::kPathSummary) {
+    plotEfficiencyHisto("PathEfficiency", "helpers/PathTriggerBits", "helpers/RefEvents");
   }
   store_ = nullptr;
 }      
 
-void HLTTauDQMSummaryPlotter::bookEfficiencyHisto(const std::string& folder, const std::string& name, const std::string& hist1, bool copyLabels) {
-    if ( store_->dirExists(folder) ) {
-        store_->setCurrentFolder(folder);
+void HLTTauDQMSummaryPlotter::SummaryPlotter::bookEfficiencyHisto(const std::string& name, const std::string& hist1, bool copyLabels) {
+    if ( store_->dirExists(folder_) ) {
+        store_->setCurrentFolder(folder_);
         
-        MonitorElement * effnum = store_->get(folder+"/"+hist1);
+        MonitorElement * effnum = store_->get(folder_+"/"+hist1);
         
         if ( effnum ) {            
             MonitorElement *tmp = store_->bookProfile(name,name,effnum->getTH1F()->GetNbinsX(),effnum->getTH1F()->GetXaxis()->GetXmin(),effnum->getTH1F()->GetXaxis()->GetXmax(),105,0,1.05);
@@ -154,13 +223,13 @@ void HLTTauDQMSummaryPlotter::bookEfficiencyHisto(const std::string& folder, con
     }
 }
 
-void HLTTauDQMSummaryPlotter::plotEfficiencyHisto( std::string folder, std::string name, std::string hist1, std::string hist2 ) {
-    if ( store_->dirExists(folder) ) {
-        store_->setCurrentFolder(folder);
+void HLTTauDQMSummaryPlotter::SummaryPlotter::plotEfficiencyHisto(std::string name, std::string hist1, std::string hist2 ) {
+    if ( store_->dirExists(folder_) ) {
+        store_->setCurrentFolder(folder_);
         
-        MonitorElement * effnum = store_->get(folder+"/"+hist1);
-        MonitorElement * effdenom = store_->get(folder+"/"+hist2);
-        MonitorElement * eff = store_->get(folder+"/"+name);
+        MonitorElement * effnum = store_->get(folder_+"/"+hist1);
+        MonitorElement * effdenom = store_->get(folder_+"/"+hist2);
+        MonitorElement * eff = store_->get(folder_+"/"+name);
         
         if(effnum && effdenom && eff) {
           const TH1F *num = effnum->getTH1F();
@@ -168,7 +237,7 @@ void HLTTauDQMSummaryPlotter::plotEfficiencyHisto( std::string folder, std::stri
           TProfile *prof = eff->getTProfile();
           for (int i = 1; i <= num->GetNbinsX(); ++i) {
             if(denom->GetBinContent(i) < num->GetBinContent(i)) {
-              edm::LogError("HLTTauDQMOffline") << "Encountered denominator < numerator with efficiency plot " << name << " in folder " << folder << ", bin " << i << " numerator " << num->GetBinContent(i) << " denominator " << denom->GetBinContent(i);
+              edm::LogError("HLTTauDQMOffline") << "Encountered denominator < numerator with efficiency plot " << name << " in folder " << folder_ << ", bin " << i << " numerator " << num->GetBinContent(i) << " denominator " << denom->GetBinContent(i);
               continue;
             }
             std::tuple<float, float> effErr = calcEfficiency(num->GetBinContent(i), denom->GetBinContent(i));
@@ -182,13 +251,13 @@ void HLTTauDQMSummaryPlotter::plotEfficiencyHisto( std::string folder, std::stri
     }
 }
 
-void HLTTauDQMSummaryPlotter::plotIntegratedEffHisto( std::string folder, std::string name, std::string refHisto, std::string evCount, int bin ) {
-    if ( store_->dirExists(folder) ) {
-        store_->setCurrentFolder(folder);
+void HLTTauDQMSummaryPlotter::SummaryPlotter::plotIntegratedEffHisto(std::string name, std::string refHisto, std::string evCount, int bin ) {
+    if ( store_->dirExists(folder_) ) {
+        store_->setCurrentFolder(folder_);
         
-        MonitorElement * refH = store_->get(folder+"/"+refHisto);
-        MonitorElement * evC = store_->get(folder+"/"+evCount);
-        MonitorElement * eff = store_->get(folder+"/"+name);
+        MonitorElement * refH = store_->get(folder_+"/"+refHisto);
+        MonitorElement * evC = store_->get(folder_+"/"+evCount);
+        MonitorElement * eff = store_->get(folder_+"/"+name);
         
         if ( refH && evC && eff ) {
             TH1F *histo = refH->getTH1F();
@@ -216,11 +285,11 @@ void HLTTauDQMSummaryPlotter::plotIntegratedEffHisto( std::string folder, std::s
     }
 }
 
-void HLTTauDQMSummaryPlotter::bookTriggerBitEfficiencyHistos( std::string folder, std::string histo ) {
-    if ( store_->dirExists(folder) ) {
-        store_->setCurrentFolder(folder);
+void HLTTauDQMSummaryPlotter::SummaryPlotter::bookTriggerBitEfficiencyHistos(std::string histo ) {
+    if ( store_->dirExists(folder_) ) {
+        store_->setCurrentFolder(folder_);
         
-        MonitorElement * eff = store_->get(folder+"/"+histo);
+        MonitorElement * eff = store_->get(folder_+"/"+histo);
         
         if ( eff ) {
           //store_->bookProfile("EfficiencyRefInput","Efficiency with Matching",eff->getNbinsX()-1,0,eff->getNbinsX()-1,100,0,1);
@@ -235,13 +304,13 @@ void HLTTauDQMSummaryPlotter::bookTriggerBitEfficiencyHistos( std::string folder
     }
 }
 
-void HLTTauDQMSummaryPlotter::plotTriggerBitEfficiencyHistos( std::string folder, std::string histo ) {
-    if ( store_->dirExists(folder) ) {
-        store_->setCurrentFolder(folder);
-        MonitorElement * eff = store_->get(folder+"/"+histo);
-        //MonitorElement * effRefTruth = store_->get(folder+"/EfficiencyRefInput");
-        //MonitorElement * effRefL1 = store_->get(folder+"/EfficiencyRefL1");
-        MonitorElement * effRefPrevious = store_->get(folder+"/EfficiencyRefPrevious");
+void HLTTauDQMSummaryPlotter::SummaryPlotter::plotTriggerBitEfficiencyHistos(std::string histo ) {
+    if ( store_->dirExists(folder_) ) {
+        store_->setCurrentFolder(folder_);
+        MonitorElement * eff = store_->get(folder_+"/"+histo);
+        //MonitorElement * effRefTruth = store_->get(folder_+"/EfficiencyRefInput");
+        //MonitorElement * effRefL1 = store_->get(folder_+"/EfficiencyRefL1");
+        MonitorElement * effRefPrevious = store_->get(folder_+"/EfficiencyRefPrevious");
         
         //if ( eff && effRefTruth && effRefL1 && effRefPrevious ) {
         if (eff && effRefPrevious) {
@@ -273,7 +342,7 @@ void HLTTauDQMSummaryPlotter::plotTriggerBitEfficiencyHistos( std::string folder
             //Calculate efficiencies with ref to previous
             for ( int i = 2; i <= eff->getNbinsX(); ++i ) {
               if(eff->getBinContent(i-1) < eff->getBinContent(i)) {
-                edm::LogError("HLTTauDQMOffline") << "Encountered denominator < numerator with efficiency plot EfficiencyRefPrevious in folder " << folder << ", bin " << i << " numerator " << eff->getBinContent(i) << " denominator " << eff->getBinContent(i-1);
+                edm::LogError("HLTTauDQMOffline") << "Encountered denominator < numerator with efficiency plot EfficiencyRefPrevious in folder " << folder_ << ", bin " << i << " numerator " << eff->getBinContent(i) << " denominator " << eff->getBinContent(i-1);
                 continue;
               }
               const std::tuple<float, float> effErr = calcEfficiency(eff->getBinContent(i), eff->getBinContent(i-1));

--- a/DQMOffline/Trigger/src/HLTTauPostProcessor.cc
+++ b/DQMOffline/Trigger/src/HLTTauPostProcessor.cc
@@ -8,9 +8,15 @@ HLTTauPostProcessor::HLTTauPostProcessor(const edm::ParameterSet& ps):
   runAtEndRun_(ps.getUntrackedParameter<bool>("runAtEndRun",true))
 {
   std::string dqmBaseFolder = ps.getUntrackedParameter<std::string>("DQMBaseFolder");
-  for(const edm::ParameterSet& pset: ps.getParameter<std::vector<edm::ParameterSet> >("Setup")) {
-    summaryPlotters_.emplace_back(new HLTTauDQMSummaryPlotter(pset, dqmBaseFolder));
+  if(ps.exists("L1Plotter")) {
+    summaryPlotters_.emplace_back(new HLTTauDQMSummaryPlotter(ps.getUntrackedParameter<edm::ParameterSet>("L1Plotter"),
+                                                              dqmBaseFolder, "L1"));
   }
+  if(ps.exists("PathSummaryPlotter")) {
+    summaryPlotters_.emplace_back(new HLTTauDQMSummaryPlotter(ps.getUntrackedParameter<edm::ParameterSet>("PathSummaryPlotter"),
+                                                              dqmBaseFolder, "PathSummary"));
+  }
+  summaryPlotters_.emplace_back(new HLTTauDQMSummaryPlotter(dqmBaseFolder, "Path"));
 }
 
 HLTTauPostProcessor::~HLTTauPostProcessor()

--- a/DQMOffline/Trigger/test/HLTTauOfflineDQMTest_cfg.py
+++ b/DQMOffline/Trigger/test/HLTTauOfflineDQMTest_cfg.py
@@ -23,6 +23,15 @@ process.MessageLogger.categories.append("HLTTauDQMOffline")
 process.load("Configuration.StandardSequences.Geometry_cff")
 process.load("Geometry.CaloEventSetup.CaloTopology_cfi")
 
+# # remember to compile with USER_CXXFLAGS="-DEDM_ML_DEBUG"
+# process.MessageLogger.cerr.threshold = cms.untracked.string("DEBUG")
+# process.MessageLogger.debugModules.extend([
+#         "hltTauOfflineMonitor_PFTaus",
+#         "hltTauOfflineMonitor_Inclusive",
+#         "HLTTauPostAnalysis_PFTaus",
+#         "HLTTauPostAnalysis_Inclusive",
+#         ])
+
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:com10', '') # for data

--- a/HLTriggerOffline/Tau/python/Validation/HLTTauPostValidation_cfi.py
+++ b/HLTriggerOffline/Tau/python/Validation/HLTTauPostValidation_cfi.py
@@ -4,12 +4,14 @@ from HLTriggerOffline.Tau.Validation.HLTTauValidation_cfi import *
 
 HLTTauValPostAnalysis_MC = cms.EDAnalyzer("HLTTauPostProcessor",
     DQMBaseFolder   = hltTauValIdealMonitorMC.DQMBaseFolder,
-    Setup           = hltTauValIdealMonitorMC.MonitorSetup,
+    L1Plotter       = hltTauValIdealMonitorMC.L1Plotter,
+    PathSummaryPlotter = hltTauValIdealMonitorMC.L1Plotter,
 )
 
 HLTTauValPostAnalysis_PF = cms.EDAnalyzer("HLTTauPostProcessor",
     DQMBaseFolder   = hltTauValIdealMonitorPF.DQMBaseFolder,
-    Setup           = hltTauValIdealMonitorPF.MonitorSetup,
+    L1Plotter       = hltTauValIdealMonitorPF.L1Plotter,
+    PathSummaryPlotter = hltTauValIdealMonitorPF.PathSummaryPlotter,
 )
 
 HLTTauPostVal = cms.Sequence(HLTTauValPostAnalysis_MC+HLTTauValPostAnalysis_PF)

--- a/HLTriggerOffline/Tau/python/Validation/HLTTauValidation_cfi.py
+++ b/HLTriggerOffline/Tau/python/Validation/HLTTauValidation_cfi.py
@@ -7,53 +7,15 @@ hltTauValIdealMonitorMC = cms.EDAnalyzer("HLTTauDQMOfflineSource",
     DQMBaseFolder = cms.untracked.string("HLT/TauRelVal/MC/"),
     TriggerResultsSrc = cms.untracked.InputTag("TriggerResults", "", hltTauValidationProcess_IDEAL),
     TriggerEventSrc = cms.untracked.InputTag("hltTriggerSummaryAOD", "", hltTauValidationProcess_IDEAL),
-    MonitorSetup = cms.VPSet(
-        cms.PSet(
-            ConfigType            = cms.untracked.string("Path"),
-            DQMFolder             = cms.untracked.string('TauMET'),
-            Path                  = cms.untracked.vstring('HLT_LooseIsoPFTau35_Trk20_Prong1_MET(?<tr0>[[:digit:]]+)_v.*'),
-            IgnoreFilterNames     = cms.untracked.vstring(),
-            IgnoreFilterTypes     = cms.untracked.vstring(),
-        ),
-        cms.PSet(
-            ConfigType            = cms.untracked.string("Path"),
-            DQMFolder             = cms.untracked.string('MuLooseTau'),
-            Path                  = cms.untracked.vstring('HLT_IsoMu(?<tr1>1[[:digit:]]+)_eta2p1_LooseIsoPFTau(?<tr0>[[:digit:]]+)_v.*'),
-            IgnoreFilterNames     = cms.untracked.vstring(),
-            IgnoreFilterTypes     = cms.untracked.vstring(),
-        ),
-        cms.PSet(
-            ConfigType            = cms.untracked.string("Path"),
-            DQMFolder             = cms.untracked.string('MuMediumTau'),
-            Path                  = cms.untracked.vstring('HLT_IsoMu(?<tr1>[[:digit:]]+)_eta2p1_MediumIsoPFTau(?<tr0>[[:digit:]]+)_Trk1_eta2p1_v.*'),
-            IgnoreFilterNames     = cms.untracked.vstring(),
-            IgnoreFilterTypes     = cms.untracked.vstring(),
-        ),
-        cms.PSet(
-            ConfigType            = cms.untracked.string("Path"),
-            DQMFolder             = cms.untracked.string('EleTau'),
-            Path                  = cms.untracked.vstring('HLT_Ele(?<tr1>[[:digit:]]+)_eta2p1_WP90Rho_LooseIsoPFTau(?<tr0>[[:digit:]]+)_v.*'),
-            IgnoreFilterNames     = cms.untracked.vstring(),
-            IgnoreFilterTypes     = cms.untracked.vstring(),
-        ),
-        cms.PSet(
-            ConfigType            = cms.untracked.string("Path"),
-            DQMFolder             = cms.untracked.string('DoubleTau'),
-            Path                  = cms.untracked.vstring('HLT_DoubleMediumIsoPFTau(?<tr0>[[:digit:]]+)_Trk(?<tr1>[[:digit:]])_eta2p1_Jet(?<tr2>[[:digit:]]+)_v.*'),
-            IgnoreFilterNames     = cms.untracked.vstring(),
-            IgnoreFilterTypes     = cms.untracked.vstring(),
-        ),
-        cms.PSet(
-            ConfigType            = cms.untracked.string("PathSummary"),
-            DQMFolder             = cms.untracked.string('Summary'),
-        ),
-        cms.PSet(
-            ConfigType            = cms.untracked.string("L1"),
-            DQMFolder             = cms.untracked.string('L1'),
-            L1Taus                = cms.untracked.InputTag("l1extraParticles", "Tau"),
-            L1Jets                = cms.untracked.InputTag("l1extraParticles", "Central"),
-            L1JetMinEt            = cms.untracked.double(40), # this value is arbitrary at the moment
-        ),
+    L1Plotter = cms.untracked.PSet(
+        DQMFolder             = cms.untracked.string('L1'),
+        L1Taus                = cms.untracked.InputTag("l1extraParticles", "Tau"),
+        L1Jets                = cms.untracked.InputTag("l1extraParticles", "Central"),
+        L1JetMinEt            = cms.untracked.double(40), # this value is arbitrary at the moment
+    ),
+    Paths = cms.untracked.string("PFTau"),
+    PathSummaryPlotter = cms.untracked.PSet(
+        DQMFolder             = cms.untracked.string('Summary'),
     ),
     Matching = cms.PSet(
         doMatching            = cms.untracked.bool(True),


### PR DESCRIPTION
Extend tau trigger DQM to automatically monitor all tau paths (i.e. paths containing the substring "PFTau"). The set of plots per path (depending on the path type) stays the same. The subfolder names change from

```
DoubleTau
EleTau
TauMET
...
```

to (e.g.)

```
HLT_DoubleMediumIsoPFTau30_Trk1_eta2p1
HLT_Ele22_eta2p1_WP90NoIso_LooseIsoPFTau20
HLT_LooseIsoPFTau35_Trk20_Prong1_MET70
...
```

(i.e. all PFTau paths with their full name excluding the version)

Rebased on top of CMSSW_7_1_X_2014-04-08-0200

FYI @mbluj
