### PR TITLE
Make python scripts use less memory by only calculating needed paths

### DIFF
--- a/Utilities/StaticAnalyzers/scripts/create_calls_db.sh
+++ b/Utilities/StaticAnalyzers/scripts/create_calls_db.sh
@@ -1,36 +1,19 @@
 #!/usr/bin/env bash
 export LC_ALL=C
-if [ $# -eq 0 ]
-        then
-        echo "Passing -j1 to make."
-        echo "Supply a number argument to override."
-        J=1
-else
-        J=$1
-fi
 
 eval `scram runtime -sh`
-ulimit -m 8000000
-ulimit -v 8000000
-ulimit -t 1200
-export USER_LLVM_CHECKERS="-disable-checker cplusplus -disable-checker unix -disable-checker threadsafety -disable-checker core -disable-checker security -disable-checker deadcode -disable-checker cms -enable-checker cms.FunctionDumper -enable-checker optional.EDMPluginDumper -enable-checker cms.FunctionChecker -enable-checker optional.ClassDumper -enable-checker optional.ClassChecker"
-export USER_CXXFLAGS="-DEDM_ML_DEBUG"
-cd ${LOCALRT}/src/Utilities/StaticAnalyzers
-scram b clean; scram b -k -j $J 2>&1 | tee ${LOCALRT}/tmp/clangSAbuild.log
+
 cd ${LOCALRT}/tmp
-if [ ! -f ./classes.txt ] 
+
+if [ ! -f ./function-calls-db.txt ]
         then 
-        cp  -p ${CMSSW_BASE}/src/Utilities/StaticAnalyzers/scripts/classes.txt* . 
+	echo "run ${CMSSW_BASE}/src/Utilities/StaticAnalyzers/scripts/run_class_dumper.sh first"
+	exit 1
 fi
-touch function-dumper.txt.unsorted function-checker.txt.unsorted plugins.txt.unsorted class-checker.txt.unsorted
-cd ${LOCALRT}
-scram b -k -j $J checker  SCRAM_IGNORE_PACKAGES=Fireworks/% SCRAM_IGNORE_SUBDIRS=test 2>&1 > tmp/function+class-dumper.log
-cd ${LOCALRT}/tmp
 
-sort -u < function-dumper.txt.unsorted >function-calls-db.txt
-sort -u < function-checker.txt.unsorted >function-statics-db.txt
-sort -u < plugins.txt.unsorted > plugins.txt
-cat  function-calls-db.txt function-statics-db.txt >db.txt
-sort -u < classes.txt.dumperall.unsorted >classes.txt.dumperall
-sort -u < class-checker.txt.unsorted | grep -e"^data class">class-checker.txt
-
+if [ ! -f ./function-statics-db.txt ]
+        then
+	echo "run ${CMSSW_BASE}/src/Utilities/StaticAnalyzers/scripts/run_class_checker.sh first"
+	exit 2
+fi
+${CMSSW_BASE}/src/Utilities/StaticAnalyzers/scripts/create_statics_esd_reports.sh

--- a/Utilities/StaticAnalyzers/scripts/create_statics_esd_reports.sh
+++ b/Utilities/StaticAnalyzers/scripts/create_statics_esd_reports.sh
@@ -2,26 +2,26 @@
 export LC_ALL=C
 eval `scram runtime -sh`
 cd ${LOCALRT}/tmp
-if [ ! -f ./classes.txt ] 
-        then 
-        cp  -p ${CMSSW_BASE}/src/Utilities/StaticAnalyzers/scripts/*.txt* .
-fi
 
 if [ ! -f ./db.txt ]
 	then
-	echo "run ${CMSSW_BASE}/src/Utilities/StaticAnalyzers/scripts/create_calls_db.sh first"
+	echo "run ${CMSSW_BASE}/src/Utilities/StaticAnalyzers/scripts/run_class_checker.sh first"
+	exit 1
+fi
+
+
+if [ ! -f ./classes.txt.dumperft ]
+        then
+	echo "run ${CMSSW_BASE}/src/Utilities/StaticAnalyzers/scripts/run_class_dumper.sh first"
 	exit 2
 fi
-sort -u < class-checker.txt.unsorted | grep -e"^data class">class-checker.txt
-
- 
 
 ${CMSSW_BASE}/src/Utilities/StaticAnalyzers/scripts/statics.py 2>&1 > statics-report.txt.unsorted
 sort -u < statics-report.txt.unsorted > statics-report.txt
 awk -F\' 'NR==FNR{a[" "$0"::"]=1;next} {n=0;for(i in a){if(index($2,i) && $1 == "In call stack "){n=1}}} n' plugins.txt statics-report.txt | sort -u  | awk '{print $0"\n"}' > module2statics.txt
 awk -F\' 'NR==FNR{a[" "$0"::"]=1;next} {n=0;for(i in a){if(index($4,i) && $1 == "Non-const static variable "){n=1}}} n' plugins.txt statics-report.txt | sort -u  | awk '{print $0"\n"}' > static2modules.txt
-sort -u < class-checker.txt.unsorted | grep -e"^data class">class-checker.txt
+
 ${CMSSW_BASE}/src/Utilities/StaticAnalyzers/scripts/data-class-funcs.py 2>&1 > data-class-funcs-report.txt
-cat data-class-funcs-report.txt | grep -v -e "^In call stack " | grep -v -e"Flagged event setup data class" | sort -u  >override-flagged-classes.txt
-cat data-class-funcs-report.txt | grep -e "^Flagged event setup data class" | sort -u | awk '{print $0"\n\n"}' >esd2tlf.txt
-cat data-class-funcs-report.txt | grep -e "^In call stack" | sort -u | awk '{print $0"\n\n"}' >tlf2esd.txt
+grep -v -e "^In call stack " data-class-funcs-report.txt | grep -v -e"Flagged event setup data class"| sort -u  >override-flagged-classes.txt
+grep -e "^Flagged event setup data class" data-class-funcs-report.txt | sort -u | awk '{print $0"\n\n"}' >esd2tlf.txt
+grep -e "^In call stack" data-class-funcs-report.txt | sort -u | awk '{print $0"\n\n"}' >tlf2esd.txt

--- a/Utilities/StaticAnalyzers/scripts/run_class_checker.sh
+++ b/Utilities/StaticAnalyzers/scripts/run_class_checker.sh
@@ -2,24 +2,33 @@
 export LC_ALL=C 
 if [ $# -eq 0 ] 
  	then
-	echo "Passing -j1 to make."
-	echo "Supply a number argument to override."
-	J=1
+	echo "Supply a number argument to pass to scram b -j#"
+	exit 10
 else
 	J=$1
 fi
 
-export SCRAM_ARCH=slc5_amd64_gcc481
 eval `scram runtime -sh`
 ulimit -m 2000000
 ulimit -v 2000000
 ulimit -t 1200
-export USER_LLVM_CHECKERS="-disable-checker cplusplus -disable-checker unix -disable-checker threadsafety -disable-checker core -disable-checker security -disable-checker deadcode -disable-checker cms -enable-checker optional.ClassChecker"
-if [ ! -f ${CMSSW_BASE}/tmp/classes.txt ] 
+if [ ! -f ${LOCALRT}/tmp/classes.txt ] 
 	then 
-	cp  -p ${CMSSW_BASE}/src/Utilities/StaticAnalyzers/scripts/classes.txt ${CMSSW_BASE}/tmp/classes.txt
+	echo "run ${CMSSW_BASE}/src/Utilities/StaticAnalyzers/scripts/run_class_dumper.sh first"
+	exit 1
 fi
-mv ${CMSSW_BASE}/tmp/class-checker.txt.sorted ${CMSSW_BASE}/tmp/class-checker.txt.sorted.old
-rm ${CMSSW_BASE}/tmp/class-checker.txt.unsorted
-scram b -k -j $J checker 2>&1 | tee ${CMSSW_BASE}/tmp/classchecker.log
-sort -u < ${CMSSW_BASE}/tmp/class-checker.txt.unsorted | grep -e"^data class">${CMSSW_BASE}/tmp/class-checker.txt.sorted 
+cd ${LOCALRT}/tmp/
+touch function-checker.txt.unsorted class-checker.txt.unsorted
+cd $LOCALRT/src/Utilities/StaticAnalyzers
+scram b -j $J
+cd ${LOCALRT}/
+export USER_CXXFLAGS="-DEDM_ML_DEBUG -w -fsyntax-only"
+export USER_LLVM_CHECKERS="-disable-checker cms -enable-checker optional.ClassChecker -enable-checker cms.FunctionChecker"
+scram b -k -j $J checker  SCRAM_IGNORE_PACKAGES=Fireworks/% SCRAM_IGNORE_SUBDIRS=test 2>&1 | tee ${LOCALRT}/tmp/class+function-checker.log
+cd ${LOCALRT}/tmp/
+sort -u < class-checker.txt.unsorted | grep -e"^data class">class-checker.txt
+sort -u < function-checker.txt.unsorted >function-statics-db.txt
+sort -u < function-checker.txt.unsorted >function-statics-db.txt
+sort -u < plugins.txt.unsorted > plugins.txt
+cat  function-calls-db.txt function-statics-db.txt >db.txt
+

--- a/Utilities/StaticAnalyzers/scripts/run_class_dumper.sh
+++ b/Utilities/StaticAnalyzers/scripts/run_class_dumper.sh
@@ -2,30 +2,34 @@
 export LC_ALL=C
 if [ $# -eq 0 ]
         then
-        echo "Passing -j1 to make."
-        echo "Supply a number argument to override."
-        J=1
+	echo "Supply a number argument to pass to scram b -j#"
+        exit 10
 else
         J=$1
 fi
 
-export SCRAM_ARCH=slc5_amd64_gcc481
 eval `scram runtime -sh`
 ulimit -m 2000000
 ulimit -v 2000000
 ulimit -t 1200
-for file in `cmsglimpse -l -F src/classes.*.h$ include`;do dir=`dirname $file`;echo \#include \<$file\> >${CMSSW_BASE}/src/$dir/`basename $file`.cc ; done
-export USER_LLVM_CHECKERS="-disable-checker cplusplus -disable-checker unix -disable-checker threadsafety -disable-checker core -disable-checker security -disable-checker deadcode -disable-checker cms -enable-checker optional.ClassDumperCT"
-scram b -k -j $J checker 
-sort -u < ${CMSSW_BASE}/tmp/classes.txt.dumperct.unsorted | grep -e"^class" >${CMSSW_BASE}/tmp/classes.txt.dumperct
-find ${CMSSW_BASE}/src/ -name classes\*.h.cc | xargs rm -f
-export USER_LLVM_CHECKERS="-disable-checker cplusplus -disable-checker unix -disable-checker threadsafety -disable-checker core -disable-checker security -disable-checker deadcode -disable-checker cms -enable-checker optional.ClassDumperFT"
-scram b -k -j $J checker 
-sort -u < ${CMSSW_BASE}/tmp/classes.txt.dumperft.unsorted | grep -e"^class" >${CMSSW_BASE}/tmp/classes.txt.dumperft
-export USER_LLVM_CHECKERS="-disable-checker cplusplus -disable-checker unix -disable-checker threadsafety -disable-checker core -disable-checker security -disable-checker deadcode -disable-checker cms -enable-checker optional.ClassDumperInherit"
-scram b -k -j $J checker 
-sort -u < ${CMSSW_BASE}/tmp/classes.txt.inherits.unsorted | grep -e"^class" >${CMSSW_BASE}/tmp/classes.txt.inherits
-cat ${CMSSW_BASE}/tmp/classes.txt.dumperct ${CMSSW_BASE}/tmp/classes.txt.dumperft ${CMSSW_BASE}/tmp/classes.txt.inherits | sort -u | grep -e"^class" >${CMSSW_BASE}/tmp/classes.txt
-export USER_LLVM_CHECKERS="-disable-checker cplusplus -disable-checker unix -disable-checker threadsafety -disable-checker core -disable-checker security -disable-checker deadcode -disable-checker cms -enable-checker optional.ClassDumper"
-scram b -k -j $J checker 
-sort -u < ${CMSSW_BASE}/tmp/classes.txt.dumperall.unsorted | grep -e"^class" >${CMSSW_BASE}/tmp/classes.txt.dumperall.sorted
+for file in `cmsglimpse -l -F src/classes.*.h$ include`;do 
+	dir=`dirname $file`;
+	echo \#include \<$file\> >${LOCALRT}/src/$dir/`basename $file`.cc ; 
+done
+cd ${LOCALRT}/tmp/
+touch function-dumper.txt.unsorted plugins.txt.unsorted classes.txt.dumperct.unsorted classes.txt.dumperft.unsorted classes.txt.dumperall.unsorted
+cd ${LOCALRT}/src/Utilities/StaticAnalyzers
+scram b -j $J
+cd ${LOCALRT}/
+export USER_CXXFLAGS="-DEDM_ML_DEBUG -w -fsyntax-only"
+export USER_LLVM_CHECKERS="-disable-checker cms -enable-checker cms.FunctionDumper -enable-checker optional.ClassDumper -enable-checker optional.ClassDumperCT -enable-checker optional.ClassDumperFT -enable-checker optional.EDMPluginDumper"
+scram b -k -j $J checker SCRAM_IGNORE_PACKAGES=Fireworks/% SCRAM_IGNORE_SUBDIRS=test 2>&1 | tee $CMSSW_BASE/tmp/class+function-dumper.log
+find ${LOCALRT}/src/ -name classes\*.h.cc | xargs rm -fv
+cd ${LOCALRT}/tmp
+sort -u < classes.txt.dumperct.unsorted | grep -e"^class" >classes.txt.dumperct
+sort -u < classes.txt.dumperft.unsorted | grep -e"^class" >classes.txt.dumperft
+sort -u < classes.txt.dumperall.unsorted | grep -e"^class" >classes.txt.dumperall
+sort -u < function-dumper.txt.unsorted >function-calls-db.txt
+for cl in `awk -F\' '{print $2}' classes.txt.dumperft  | sort -u`;do echo grep -e\"base class \'$cl\'\$\"  classes.txt.dumperall ; done >tmp.sh
+source tmp.sh | sort -u >classes.txt.inherits
+cat classes.txt.dumperct classes.txt.dumperft classes.txt.inherits | sort -u |grep -e"^class" >classes.txt

--- a/Utilities/StaticAnalyzers/scripts/statics.py
+++ b/Utilities/StaticAnalyzers/scripts/statics.py
@@ -1,11 +1,10 @@
 #! /usr/bin/env python
 import re
-topfunc = re.compile("::produce\(|::analyze\(|::filter\(::beginLuminosityBlock\(|::beginRun\(")
-onefunc = re.compile("edm::one::ED(Producer|Filter|Analyzer)Base::(produce|filter|analyze|beginLuminosityBlock|beginRun)")
+topfunc = re.compile("::(produce|analyze|filter|beginLuminosityBlock|beginRun)\(")
+baseclass = re.compile("edm::(one::|stream::|global::)?ED(Producer|Filter|Analyzer)(Base)?")
 farg = re.compile("\(.*\)")
 statics = set()
 toplevelfuncs = set()
-onefuncs = set()
 
 import networkx as nx
 G=nx.DiGraph()
@@ -16,35 +15,39 @@ for line in f :
 	fields = line.split("'")
 	if fields[2] == ' calls function ' :
 		G.add_edge(fields[1],fields[3],kind=fields[2])
-		if topfunc.search(fields[1]):
-			toplevelfuncs.add(fields[1])
 	if fields[2] == ' overrides function ' :
-		G.add_edge(fields[1],fields[3],kind=fields[2])
+		if baseclass.search(fields[3]) :
+			if topfunc.search(fields[3]) : toplevelfuncs.add(fields[1])
+			G.add_edge(fields[1],fields[3],kind=' overrides function ')
+		else :
+			G.add_edge(fields[3],fields[1],kind=' calls function ')
 	if fields[2] == ' static variable ' :
-		G.add_edge(fields[1],fields[3],kind=fields[2])
+		G.add_edge(fields[1],fields[3],kind=' static variable ')
 		statics.add(fields[3])
 f.close()
 
 
-paths = nx.shortest_path(G)
-
 for static in statics:
 	for tfunc in toplevelfuncs:
 		if nx.has_path(G,tfunc,static): 
-			print "Non-const static variable \'"+re.sub(farg,"()",static)+"\' is accessed in call stack \'",
-			for path in paths[tfunc][static]:
-				if not path == static : print re.sub(farg,"()",path)+"; ",
-			print "\'. ",
+			path = nx.shortest_path(G,tfunc,static)
+			print "Non-const static variable \'"+re.sub(farg,"()",static)+"\' is accessed in call stack ",
+			print " \'",
+			for p in path :			
+				print re.sub(farg,"()",p)+"; ",
+			print " \'. ",
 			for key in  G[tfunc].keys() :
 				if 'kind' in G[tfunc][key] and G[tfunc][key]['kind'] == ' overrides function '  :
-					print "'"+tfunc+"'"+G[tfunc][key]['kind']+"'"+key+"'"
+					print "'"+re.sub(farg,"()",tfunc)+"'"+G[tfunc][key]['kind']+"'"+re.sub(farg,"()",key)+"'",
 			print ""
-			print "In call stack '",
-			for path in paths[tfunc][static]:
-				if not path == static : print re.sub(farg,"()",path)+"; ",
-				else : print "\' non-const static variable \'"+re.sub(farg,"()",static)+"\' is accessed. ",
+			path = nx.shortest_path(G,tfunc,static)
+			print "In call stack ' ",
+			for p in path:
+				print re.sub(farg,"()",p)+"; ",
+			print "\'",
+			print " non-const static variable \'"+re.sub(farg,"()",static)+"\' is accessed. ",
 			for key in  G[tfunc].keys() :
 				if 'kind' in G[tfunc][key] and G[tfunc][key]['kind'] == ' overrides function '  :
-					print "'"+tfunc+"'"+G[tfunc][key]['kind']+"'"+key+"'"
-			print ""
+					print "'"+re.sub(farg,"()",tfunc)+"'"+G[tfunc][key]['kind']+"'"+re.sub(farg,"()",key)+"'",
+			print
 

--- a/Utilities/StaticAnalyzers/src/ClassChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/ClassChecker.cpp
@@ -599,6 +599,8 @@ void ClassChecker::checkASTDecl(const clang::CXXRecordDecl *RD, clang::ento::Ana
                     clang::ento::BugReporter &BR) const {
 
 	const clang::SourceManager &SM = BR.getSourceManager();
+ 	const char *sfile=SM.getPresumedLoc(RD->getLocation()).getFilename();
+ 	if (!support::isCmsLocalFile(sfile)) return;
 	
   	std::string buf;
   	llvm::raw_string_ostream os(buf);


### PR DESCRIPTION
... no all of them. This drops the memory usage from 10G to 1G when running the python scripts using networkX.

Print out template type if class is a template specialization.
