### PR TITLE
Thread safety cleanup in Geometry

### DIFF
--- a/Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h
+++ b/Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h
@@ -39,7 +39,7 @@ public:
   /// the proxy topology (through topology() and specificTopology()) which includes
   /// corrections for the surface deformations, and once via the GeomDetType
   /// (through type().topology() and the like).
-  virtual PixelGeomDetType& specificType() const;
+  virtual const PixelGeomDetType& specificType() const;
 
   /// Returns a reference to the pixel proxy topology
   virtual const PixelTopology& specificTopology() const;

--- a/Geometry/TrackerGeometryBuilder/src/PixelGeomDetUnit.cc
+++ b/Geometry/TrackerGeometryBuilder/src/PixelGeomDetUnit.cc
@@ -12,7 +12,7 @@ PixelGeomDetUnit::PixelGeomDetUnit( BoundPlane* sp, PixelGeomDetType* type,const
 
 const GeomDetType& PixelGeomDetUnit::type() const { return theTopology->type(); }
 
-PixelGeomDetType& PixelGeomDetUnit::specificType() const { return theTopology->specificType(); }
+const PixelGeomDetType& PixelGeomDetUnit::specificType() const { return theTopology->specificType(); }
 
 const Topology& PixelGeomDetUnit::topology() const { return *theTopology; }
 


### PR DESCRIPTION
Make the return value of a function be
a const ref instead of just a ref.
Eliminates a potential thread safety problem
reported by the clang static code analyzer.
