### PR TITLE
Thread safety cleanup in KalmanAlignmentAlgorithm

### DIFF
--- a/Alignment/KalmanAlignmentAlgorithm/interface/CurrentAlignmentKFUpdator.h
+++ b/Alignment/KalmanAlignmentAlgorithm/interface/CurrentAlignmentKFUpdator.h
@@ -35,8 +35,8 @@ private:
 					typename AlgebraicROOTObject<D>::Vector & vecR,
 					typename AlgebraicROOTObject<D>::SymMatrix & matV ) const;
 
-  AlignmentParameters* getAlignmentParameters( const AlignableDetOrUnitPtr& alignableDet ) const;
-  AlignmentParameters* getHigherLevelParameters( const Alignable* aAlignable ) const;
+  AlignmentParameters const* getAlignmentParameters( const AlignableDetOrUnitPtr& alignableDet ) const;
+  AlignmentParameters const* getHigherLevelParameters( const Alignable* aAlignable ) const;
 
   AlignableNavigator* theAlignableNavigator;
 

--- a/Alignment/KalmanAlignmentAlgorithm/src/CurrentAlignmentKFUpdator.cc
+++ b/Alignment/KalmanAlignmentAlgorithm/src/CurrentAlignmentKFUpdator.cc
@@ -92,7 +92,7 @@ void CurrentAlignmentKFUpdator::includeCurrentAlignmentEstimate( const TrackingR
     return;
   }
 
-  AlignmentParameters* alignmentParameters = getAlignmentParameters( alignableDet );
+  AlignmentParameters const* alignmentParameters = getAlignmentParameters( alignableDet );
 
   if ( alignmentParameters )
   {
@@ -119,17 +119,17 @@ void CurrentAlignmentKFUpdator::includeCurrentAlignmentEstimate( const TrackingR
 }
 
 
-AlignmentParameters* CurrentAlignmentKFUpdator::getAlignmentParameters( const AlignableDetOrUnitPtr& alignableDet ) const
+AlignmentParameters const* CurrentAlignmentKFUpdator::getAlignmentParameters( const AlignableDetOrUnitPtr& alignableDet ) const
 {
   // Get alignment parameters from AlignableDet ...
-  AlignmentParameters* alignmentParameters = alignableDet->alignmentParameters();
+  AlignmentParameters const* alignmentParameters = alignableDet->alignmentParameters();
   // ... or any higher level alignable.
   if ( !alignmentParameters ) alignmentParameters = getHigherLevelParameters( alignableDet );
   return alignmentParameters;
 }
 
 
-AlignmentParameters* CurrentAlignmentKFUpdator::getHigherLevelParameters( const Alignable* aAlignable ) const
+AlignmentParameters const* CurrentAlignmentKFUpdator::getHigherLevelParameters( const Alignable* aAlignable ) const
 {
   Alignable* higherLevelAlignable = aAlignable->mother();
   // Alignable has no mother ... most probably the alignable is already the full tracker.


### PR DESCRIPTION
Make the return value of two const functions be
a const pointer instead of just a pointer.
Eliminates a potential thread safety problem
reported by the clang static code analyzer.
