### PR TITLE
code-cleaning in RecoMET

### DIFF
--- a/DataFormats/METReco/interface/MET.h
+++ b/DataFormats/METReco/interface/MET.h
@@ -1,25 +1,31 @@
+// -*- C++ -*-
+
+// Package:    METReco
+// Class:      MET
+//
+/**\class MET
+
+ Description: This is the fundemental class for missing transverse
+ momentum (a.k.a MET). The class inherits from RecoCandidate, and so
+ is stored in the event as a candidate. The actual MET information is
+ contained in the RecoCandidate LorentzVector while supplimentary
+ information is stored as varibles in the MET class itself (such as
+ SumET). As there may have been more than one correction applied to
+ the missing transverse momentum, a vector of corrections to the
+ missing px and the missing py is maintained so that one can always
+ recover the uncorrected MET by applying the negative of each
+ correction.
+
+*/
+// Original authors: Michael Schmitt, Richard Cavanaugh The University of Florida
+// changes by: Freya Blekman, Cornell University
+//
+
+//____________________________________________________________________________||
 #ifndef METRECO_MET_H
 #define METRECO_MET_H
 
-/** \class MET
- *
- * This is the fundemental class for missing transverse momentum (a.k.a MET).
- * The class inherits from RecoCandidate, and so is stored in the event as 
- * a candidate.  The actual MET information is contained in the RecoCandidate 
- * LorentzVector while supplimentary information is stored as varibles in 
- * the MET class itself (such as SumET). As there may have been more than 
- * one correction applied to the missing transverse momentum, a vector of 
- * corrections to the missing px and the missing py is maintained
- * so that one can always recover the uncorrected MET by applying the 
- * negative of each correction.  
- *
- * \authors Michael Schmitt, Richard Cavanaugh The University of Florida
- * changes by Freya Blekman, Cornell University: Added significance interface
- * 
- * \version   1st Version May 31st, 2005.
- *
- ************************************************************/
-
+//____________________________________________________________________________||
 #include "DataFormats/RecoCandidate/interface/RecoCandidate.h"
 #include "DataFormats/METReco/interface/CorrMETData.h"
 #include <cmath>
@@ -27,54 +33,56 @@
 #include <cstring>
 #include "TMatrixD.h"
 
+//____________________________________________________________________________||
 namespace reco
 {
   class MET : public RecoCandidate
-    {
-    public:
-      //-----------------------------------------------------------------
-      //Define Constructors
-      MET();
-      MET( const LorentzVector& p4_, const Point& vtx_ );
-      MET( double sumet_, const LorentzVector& p4_, const Point& vtx_ );
-      MET( double sumet_, const std::vector<CorrMETData>& corr_, 
-	   const LorentzVector& p4_, const Point& vtx_ );
-      //----------------------------------------------------------------- 
-      //explicit clone function
-      MET * clone() const;
-      //-----------------------------------------------------------------
-      //Define methods to extract elements related to MET
-      //scalar sum of transverse energy over all objects
-      double sumEt() const { return sumet; }       
-      //MET Significance = MET / std::sqrt(SumET)
-      double mEtSig() const { return ( sumet ? (this->et() / std::sqrt(sumet)) : (0.0) ); }
-      //real MET significance
-      double significance() const;
-      //longitudinal component of the vector sum of energy over all object
-      //(useful for data quality monitoring)
-      double e_longitudinal() const {return elongit; }  
-      //-----------------------------------------------------------------
-      //Define different methods for the corrections to individual MET elements
-      std::vector<double> dmEx() const ;
-      std::vector<double> dmEy() const ;
-      std::vector<double> dsumEt() const ;
-      std::vector<double> dSignificance() const ;
-      //Define method to extract the entire "block" of MET corrections
-      std::vector<CorrMETData> mEtCorr() const { return corr; }
-      //-----------------------------------------------------------------
-      void setSignificanceMatrix(const TMatrixD& matrix);
-      TMatrixD getSignificanceMatrix(void) const;
-    private:
-      virtual bool overlap( const Candidate & ) const;
-      double sumet;
-      double elongit;
-      // bookkeeping for the significance
-      double signif_dxx;
-      double signif_dyy;
-      double signif_dyx;
-      double signif_dxy;
-      std::vector<CorrMETData> corr;
-    };
+  {
+  public:
+
+    MET();
+    MET( const LorentzVector& p4_, const Point& vtx_ );
+    MET( double sumet_, const LorentzVector& p4_, const Point& vtx_ );
+    MET( double sumet_, const std::vector<CorrMETData>& corr_,
+	 const LorentzVector& p4_, const Point& vtx_ );
+
+    MET * clone() const;
+
+    //________________________________________________________________________||
+    //scalar sum of transverse energy over all objects
+    double sumEt() const { return sumet; }
+    //MET Significance = MET / std::sqrt(SumET)
+    double mEtSig() const { return ( sumet ? (this->et() / std::sqrt(sumet)) : (0.0) ); }
+    //real MET significance
+    double significance() const;
+    //longitudinal component of the vector sum of energy over all object
+    //(useful for data quality monitoring)
+    double e_longitudinal() const {return elongit; }
+
+    //________________________________________________________________________||
+    //Define different methods for the corrections to individual MET elements
+    std::vector<double> dmEx() const ;
+    std::vector<double> dmEy() const ;
+    std::vector<double> dsumEt() const ;
+    std::vector<double> dSignificance() const ;
+    std::vector<CorrMETData> mEtCorr() const { return corr; }
+
+    //________________________________________________________________________||
+    void setSignificanceMatrix(const TMatrixD& matrix);
+    TMatrixD getSignificanceMatrix(void) const;
+
+  private:
+    virtual bool overlap( const Candidate & ) const;
+    double sumet;
+    double elongit;
+    // bookkeeping for the significance
+    double signif_dxx;
+    double signif_dyy;
+    double signif_dyx;
+    double signif_dxy;
+    std::vector<CorrMETData> corr;
+  };
 }
 
+//____________________________________________________________________________||
 #endif // METRECO_MET_H

--- a/DataFormats/METReco/interface/MET.h
+++ b/DataFormats/METReco/interface/MET.h
@@ -64,7 +64,6 @@ namespace reco
     std::vector<double> dmEx() const ;
     std::vector<double> dmEy() const ;
     std::vector<double> dsumEt() const ;
-    std::vector<double> dSignificance() const ;
     std::vector<CorrMETData> mEtCorr() const { return corr; }
 
     //________________________________________________________________________||

--- a/DataFormats/METReco/src/MET.cc
+++ b/DataFormats/METReco/src/MET.cc
@@ -1,30 +1,32 @@
-// File: MET.cc
-// Description: see MET.h
-// Author: Michael Schmitt, R. Cavanaugh University of Florida
-// Creation Date:  MHS MAY 30, 2005 initial version
+// -*- C++ -*-
 
+// Package:    METReco
+// Class:      MET
+//
+// Original authors: Michael Schmitt, Richard Cavanaugh The University of Florida
+// changes by: Freya Blekman, Cornell University
+//
+
+//____________________________________________________________________________||
 #include "DataFormats/METReco/interface/MET.h"
 #include "TVector.h"
 
+//____________________________________________________________________________||
 using namespace std;
 using namespace reco;
 
-//---------------------------------------------------------------------------
-// Default Constructor;
-//-----------------------------------
+//____________________________________________________________________________||
 MET::MET()
 {
   sumet = 0.0;
   elongit = 0.0;
   signif_dxx=signif_dyy=signif_dyx=signif_dxy=0.;
 }
-//---------------------------------------------------------------------------
 
-//---------------------------------------------------------------------------
 // Constructer for the case when only p4_ =  (mEx, mEy, 0, mEt) is known.
 // The vertex information is currently not used (but may be in the future)
 // and is required by the RecoCandidate constructer.
-//-----------------------------------
+//____________________________________________________________________________||
 MET::MET( const LorentzVector& p4_, const Point& vtx_ ) : 
   RecoCandidate( 0, p4_, vtx_ )
 {
@@ -32,13 +34,11 @@ MET::MET( const LorentzVector& p4_, const Point& vtx_ ) :
   elongit = 0.0;
   signif_dxx=signif_dyy=signif_dyx=signif_dxy=0.;
 }
-//---------------------------------------------------------------------------
 
-//---------------------------------------------------------------------------
 // Constructer for the case when the SumET is known in addition to 
 // p4_ = (mEx, mEy, 0, mEt).  The vertex information is currently not used
 // (but see above).
-//-----------------------------------
+//____________________________________________________________________________||
 MET::MET( double sumet_, const LorentzVector& p4_, const Point& vtx_ ) : 
   RecoCandidate( 0, p4_, vtx_ ) 
 {
@@ -46,13 +46,11 @@ MET::MET( double sumet_, const LorentzVector& p4_, const Point& vtx_ ) :
   elongit = 0.0;
   signif_dxx=signif_dyy=signif_dyx=signif_dxy=0.;
 }
-//---------------------------------------------------------------------------
 
-//---------------------------------------------------------------------------
 // Constructor for the case when the SumET, the corrections which
 // were applied to the MET, as well the MET itself p4_ = (mEx, mEy, 0, mEt)
 // are all known.  See above concerning the vertex information. 
-//-----------------------------------
+//____________________________________________________________________________||
 MET::MET( double sumet_, const std::vector<CorrMETData>& corr_, 
 	  const LorentzVector& p4_, const Point& vtx_ ) : 
   RecoCandidate( 0, p4_, vtx_ )
@@ -69,17 +67,14 @@ MET::MET( double sumet_, const std::vector<CorrMETData>& corr_,
       corr.push_back( *i );
     }
 }
-//---------------------------------------------------------------------------
 
-
-//----------------------------------------------------------------- 
-//explicit clone function
+//____________________________________________________________________________||
 MET * MET::clone() const {
      return new MET( * this );
 }
-//----------------------------------------------------------------- 
 
 // function that calculates the MET significance from the vector information.
+//____________________________________________________________________________||
 double MET::significance() const {
   if(signif_dxx==0 && signif_dyy==0 && signif_dxy==0 && signif_dyx==0)
     return -1;
@@ -95,10 +90,9 @@ double MET::significance() const {
   return signif;
 }
 
-//---------------------------------------------------------------------------
 // Returns the vector of all corrections applied to the x component of the
 // missing transverse momentum, mEx
-//-----------------------------------
+//____________________________________________________________________________||
 std::vector<double> MET::dmEx() const 
 {
   std::vector<double> deltas;
@@ -109,12 +103,10 @@ std::vector<double> MET::dmEx() const
     }
   return deltas;
 }
-//---------------------------------------------------------------------------
 
-//---------------------------------------------------------------------------
 // Returns the vector of all corrections applied to the y component of the
 // missing transverse momentum, mEy
-//-----------------------------------
+//____________________________________________________________________________||
 std::vector<double> MET::dmEy() const 
 {
   std::vector<double> deltas;
@@ -125,12 +117,10 @@ std::vector<double> MET::dmEy() const
     }
   return deltas;
 }
-//---------------------------------------------------------------------------
 
-//---------------------------------------------------------------------------
 // Returns the vector of all corrections applied to the scalar sum of the 
 // transverse energy (over all objects)
-//-----------------------------------
+//____________________________________________________________________________||
 std::vector<double> MET::dsumEt() const 
 {
   std::vector<double> deltas;
@@ -142,10 +132,8 @@ std::vector<double> MET::dsumEt() const
   return deltas;
 }
 
-//---------------------------------------------------------------------------
 // returns the significance matrix
-//---------------------------------------------------------------------------
-
+//____________________________________________________________________________||
 TMatrixD MET::getSignificanceMatrix(void) const
 {
   TMatrixD result(2,2);
@@ -156,10 +144,9 @@ TMatrixD MET::getSignificanceMatrix(void) const
   return result;
 }
 
-//---------------------------------------------------------------------------
 // Returns the vector of all corrections applied to the significance of the 
 // transverse energy (over all objects)
-//-----------------------------------
+//____________________________________________________________________________||
 std::vector<double> MET::dSignificance() const
 {
   std::vector<double> deltas;
@@ -170,22 +157,22 @@ std::vector<double> MET::dSignificance() const
     }
   return deltas;
 }
-//---------------------------------------------------------------------------
 
-//---------------------------------------------------------------------------
 // Required RecoCandidate polymorphism
-//-----------------------------------
+//____________________________________________________________________________||
 bool MET::overlap( const Candidate & ) const 
 {
   return false;
 }
-//---------------------------------------------------------------------------
 
-void
-MET::setSignificanceMatrix(const TMatrixD &inmatrix){
+//____________________________________________________________________________||
+void MET::setSignificanceMatrix(const TMatrixD &inmatrix)
+{
   signif_dxx=inmatrix(0,0);
   signif_dxy=inmatrix(0,1);
   signif_dyx=inmatrix(1,0);
   signif_dyy=inmatrix(1,1);
   return;
 }
+
+//____________________________________________________________________________||

--- a/DataFormats/METReco/src/MET.cc
+++ b/DataFormats/METReco/src/MET.cc
@@ -144,20 +144,6 @@ TMatrixD MET::getSignificanceMatrix(void) const
   return result;
 }
 
-// Returns the vector of all corrections applied to the significance of the 
-// transverse energy (over all objects)
-//____________________________________________________________________________||
-std::vector<double> MET::dSignificance() const
-{
-  std::vector<double> deltas;
-  std::vector<CorrMETData>::const_iterator i;
-  for( i = corr.begin(); i != corr.end(); i++ )
-    {
-      deltas.push_back( i->significance );
-    }
-  return deltas;
-}
-
 // Required RecoCandidate polymorphism
 //____________________________________________________________________________||
 bool MET::overlap( const Candidate & ) const 


### PR DESCRIPTION
Eventually, we will delete "significance" from "CorrMETData" as we will make "CorrMETData" a 2D vector on the px-py plane as it was discussed in cms-metdevelopers@cern.ch a long time ago.
https://github.com/cms-sw/cmssw/blob/CMSSW_7_1_0_pre6/DataFormats/METReco/interface/CorrMETData.h#L21

Also we will eventually delete "corr" from "MET" as this is not used by most MET corrections (I think that this is used only in the correction of CaloMET for muons. This is not used by Type-I/II/0 corrections)
https://github.com/cms-sw/cmssw/blob/CMSSW_7_1_0_pre6/DataFormats/METReco/interface/MET.h#L76

This PR request will prepare for these deletion. 
