### PR TITLE
Shashlik improved fiber radius

### DIFF
--- a/DataFormats/EcalDetId/interface/EcalDetIdCollections.h
+++ b/DataFormats/EcalDetId/interface/EcalDetIdCollections.h
@@ -5,6 +5,7 @@
 
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
 #include "DataFormats/EcalDetId/interface/EEDetId.h"
+#include "DataFormats/EcalDetId/interface/EKDetId.h"
 #include "DataFormats/EcalDetId/interface/EcalElectronicsId.h"
 #include "DataFormats/EcalDetId/interface/EcalTrigTowerDetId.h"
 #include "DataFormats/EcalDetId/interface/EcalScDetId.h"
@@ -13,6 +14,7 @@
 
 typedef edm::EDCollection<EBDetId> EBDetIdCollection;
 typedef edm::EDCollection<EEDetId> EEDetIdCollection;
+typedef edm::EDCollection<EKDetId> EKDetIdCollection;
 typedef edm::EDCollection<EcalElectronicsId> EcalElectronicsIdCollection;
 typedef edm::EDCollection<EcalTriggerElectronicsId> EcalTriggerElectronicsIdCollection;
 typedef edm::EDCollection<EcalTrigTowerDetId> EcalTrigTowerDetIdCollection;

--- a/DataFormats/EcalDetId/src/EKDetId.cc
+++ b/DataFormats/EcalDetId/src/EKDetId.cc
@@ -3,11 +3,205 @@
     
 #include <iostream>
 #include <algorithm>
+
+namespace {
+  /** Maximum possibility of Fiber number (0:FIB_MAX-1)
+   */
+  static const int FIB_MAX=6;
+  
+  /** Maximum possibility of Read-Out type (0:RO_MAX-1)
+   */
+  static const int RO_MAX=3;
+
+  const int MAX_SM_SIZE = 21;
+
+  const int MAX_MODULES_ROW = 2*MAX_SM_SIZE*5;
+
+  const int MAX_MODULES = MAX_MODULES_ROW * MAX_MODULES_ROW;
+
+  const int MAX_HASH_INDEX = RO_MAX*FIB_MAX*MAX_MODULES*2;
+
+  const int MODULE_OFFSET = MAX_SM_SIZE * 5;
+
+  const int blackBox[MAX_SM_SIZE] = {
+    //109876543210987654321
+    0b111111111111111111111,
+    0b111111111111111111111,
+    0b111111111111111111111,
+    0b111111111111111111111,
+    0b111111111111111111111,
+    0b111111111111111111111,
+    0b111111111111111111111,
+    0b111111111111111111111,
+    0b111111111111111111111,
+    0b111111111111111111111,
+    0b111111111111111111111,
+    0b111111111111111111111,
+    0b111111111111111111111,
+    0b111111111111111111111,
+    0b111111111111111111111,
+    0b111111111111111111111,
+    0b111111111111111111111,
+    0b111111111111111111111,
+    0b111111111111111111111,
+    0b111111111111111111111,
+    0b111111111111111111111
+  };
+
+
+  const int noTaperEcalEta4[MAX_SM_SIZE] = {
+    //109876543210987654321
+    0b111111111111111111100, // 1
+    0b111111111111111111100, // 2
+    0b111111111111111111111, // 3
+    0b111111111111111111111, // 4
+    0b111111111111111111111, // 5
+    0b111111111111111111111, // 6
+    0b011111111111111111111, // 7
+    0b011111111111111111111, // 8
+    0b011111111111111111111, // 9
+    0b001111111111111111111, // 10
+    0b001111111111111111111, // 11
+    0b000111111111111111111, // 12
+    0b000011111111111111111, // 13
+    0b000011111111111111111, // 14
+    0b000001111111111111111, // 15
+    0b000000111111111111111, // 16
+    0b000000011111111111111, // 17
+    0b000000000111111111111, // 18
+    0b000000000011111111111, // 19
+    0b000000000000111111111, // 20
+    0b000000000000000111111  // 21
+  };
    
-const int EKDetId::QuadColLimits[EKDetId::nCols+1] = { 0,13,27,40,54,70,87,104,120,136,151,166,180,193,205,215,225,232,234 };
+  const int taperEcalEta3[MAX_SM_SIZE] = {
+    //109876543210987654321
+    0b011111111111111100000, // 1
+    0b011111111111111100000, // 2
+    0b011111111111111100000, // 3
+    0b011111111111111110000, // 4
+    0b011111111111111111000, // 5
+    0b001111111111111111111, // 6
+    0b001111111111111111111, // 7
+    0b001111111111111111111, // 8
+    0b000111111111111111111, // 9
+    0b000011111111111111111, // 10
+    0b000011111111111111111, // 11
+    0b000011111111111111111, // 12
+    0b000001111111111111111, // 13
+    0b000000111111111111111, // 14
+    0b000000011111111111111, // 15
+    0b000000001111111111111, // 16
+    0b000000000111111111111, // 17
+    0b000000000001111111111, // 18
+    0b000000000000011111111, // 19
+    0b000000000000000011111, // 20
+    0b000000000000000000000  // 21
+  };
+   
+  const int taperEcalEta4[MAX_SM_SIZE] = {
+    //109876543210987654321
+    0b011111111111111111000, // 1
+    0b011111111111111111100, // 2
+    0b011111111111111111110, // 3
+    0b011111111111111111111, // 4
+    0b011111111111111111111, // 5
+    0b001111111111111111111, // 6
+    0b001111111111111111111, // 7
+    0b001111111111111111111, // 8
+    0b000111111111111111111, // 9
+    0b000011111111111111111, // 10
+    0b000011111111111111111, // 11
+    0b000011111111111111111, // 12
+    0b000001111111111111111, // 13
+    0b000000111111111111111, // 14
+    0b000000011111111111111, // 15
+    0b000000001111111111111, // 16
+    0b000000000111111111111, // 17
+    0b000000000001111111111, // 18
+    0b000000000000011111111, // 19
+    0b000000000000000011111, // 20
+    0b000000000000000000000  // 21
+  };
+   
+  const int noTaperEcalEta3[MAX_SM_SIZE] = {
+    //109876543210987654321
+    0b111111111111111100000, // 1
+    0b111111111111111100000, // 2
+    0b111111111111111110000, // 3
+    0b111111111111111110000, // 4
+    0b111111111111111111100, // 5
+    0b111111111111111111111, // 6
+    0b011111111111111111111, // 7
+    0b011111111111111111111, // 8
+    0b011111111111111111111, // 9
+    0b001111111111111111111, // 10
+    0b001111111111111111111, // 11
+    0b000111111111111111111, // 12
+    0b000011111111111111111, // 13
+    0b000011111111111111111, // 14
+    0b000001111111111111111, // 15
+    0b000000111111111111111, // 16
+    0b000000011111111111111, // 17
+    0b000000000111111111111, // 18
+    0b000000000011111111111, // 19
+    0b000000000000111111111, // 20
+    0b000000000000000111111  // 21
+  };
 
-const int EKDetId::iYoffset[EKDetId::nCols+1]      = { 0, 5, 4, 4, 3, 1, 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0 };
+  const int* EK_CONFIG [] = {blackBox, noTaperEcalEta4, noTaperEcalEta3, taperEcalEta4, taperEcalEta3, 0};
+}
 
+bool EKDetId::validHashIndex( int i ) { return ( i < MAX_HASH_INDEX) ; }
+
+int EKDetId::smIndex (int ismCol, int ismRow) {
+  if (ismCol == 0 || ismCol > MAX_SM_SIZE || ismCol < -MAX_SM_SIZE || ismRow == 0 || ismRow > MAX_SM_SIZE || ismRow < -MAX_SM_SIZE) {
+    throw cms::Exception("InvalidDetId") << "EKDetId::smIndex() called with wrong arguments ismCol:ismRow " << ismCol << ':' << ismRow;
+  }
+  if (ismCol > 0) --ismCol;
+  if (ismRow > 0) --ismRow;
+  int result = (ismCol+MAX_SM_SIZE)*2*MAX_SM_SIZE + (ismRow+MAX_SM_SIZE);
+  return result;
+}
+
+int EKDetId::smXLocation (int iSM) {
+  if (iSM >= MAX_MODULES || iSM < 0) {
+    throw cms::Exception("InvalidDetId") << "EKDetId::smXLocation() called with wrong arguments SM " << iSM;
+  }
+  return iSM / (2*MAX_SM_SIZE)-MAX_SM_SIZE;
+}
+
+int EKDetId::smYLocation (int iSM) {
+  if (iSM >= MAX_MODULES || iSM < 0) {
+    throw cms::Exception("InvalidDetId") << "EKDetId::smYLocation() called with wrong arguments SM " << iSM;
+  }
+  return iSM % (2*MAX_SM_SIZE)-MAX_SM_SIZE;
+}
+
+int EKDetId::ix(int iSM, int iMod) const {
+  /*
+   *  ix() return individual module x-coordinate
+   *
+   *  Input     : iSM, iMod - SuperModule and module ids
+   */
+  int smCol = smXLocation (iSM);
+  int modCol = (iMod-1) / 5;
+  return smCol*5+modCol+MODULE_OFFSET;
+}
+
+int EKDetId::iy(int iSM, int iMod) const {
+  /*
+   *  iy() return individual module y-coordinate
+   *
+   *  Input     : iSM, iMod - SuperModule and module ids
+   */
+  int smRow = smYLocation (iSM);
+  int modRow = (iMod-1) % 5;
+  return smRow*5+modRow+MODULE_OFFSET;
+}
+
+
+   
 EKDetId::EKDetId(int module_ix, int module_iy, int fiber, int ro, 
 		 int iz) : DetId( Ecal, EcalShashlik) {
   id_ |= (module_iy&0xff) | ((module_ix&0xff)<<8) |
@@ -24,7 +218,6 @@ EKDetId::EKDetId(int index1, int index2, int fiber, int ro, int iz,
    } else if (mode == SCMODULEMODE) {
     int supermodule = index1;
     int module      = index2;
-    //      std::cout << "iz " << iz << " SM " << index1 << " module " << index2  << std::endl;
     module_ix = ix(supermodule, module);
     module_iy = iy(supermodule, module);
   } else {
@@ -46,76 +239,90 @@ void EKDetId::setFiber(int fib, int ro) {
   id_ = (idc) | ((fib&0x7)<<16) | ((ro&0x3)<<19);
 }
 
-int EKDetId::ism() const { 
-  return ism((1 + (ix() - 1)/nMods), (1 + (iy() - 1)/nMods)); 
-}
+ int EKDetId::ism() const {
+   int ismCol = (ix() - MODULE_OFFSET) / 5;
+   int ismRow = (iy() - MODULE_OFFSET) / 5;
+   return smIndex (ismCol, ismRow);
+ }
+
+int EKDetId::ism(int ix, int iy) {
+   int ismCol = (ix - MODULE_OFFSET) / 5;
+   int ismRow = (iy - MODULE_OFFSET) / 5;
+   return smIndex (ismCol, ismRow);
+ }
 
 int EKDetId::imod() const {
   return imod(ix(), iy());
 }
 
 int EKDetId::iquadrant() const {
-  if (ix()>nRows) {
-    if (iy()>nRows) return 1;
+  if (ix() >= MODULE_OFFSET) {
+    if (iy() >= MODULE_OFFSET) return 1;
     else            return 4;
   } else {
-    if (iy()>nRows) return 2;
+    if (iy()>=MODULE_OFFSET) return 2;
     else            return 3;
   }
 }
 
 int EKDetId::hashedIndex() const {
-  int iSM  = ism();
-  int iMod = imod();
-  int iFib = fiber();
-  int iRO  = readout();
-  return ((positiveZ() ? kEKhalf : 0) +
-	  ((((iSM-1)*IMOD_MAX+iMod-1)*FIB_MAX+iFib)*RO_MAX+iRO));
+  return (((((positiveZ() ? 1 : 0)*MAX_MODULES_ROW + ix())*MAX_MODULES_ROW + iy())*FIB_MAX + fiber())*RO_MAX + readout());
 }
   
 EKDetId EKDetId::unhashIndex(int hi) {
 
-  if (validHashIndex(hi)) {
-    const int iz (hi<kEKhalf ? -1 : 1);
-    const uint32_t di (hi%kEKhalf);
-    const uint32_t ro (di%RO_MAX);
-    const uint32_t fib (((di-ro)/RO_MAX)%FIB_MAX);
-    const uint32_t iMD (((((di-ro)/RO_MAX)-fib)/FIB_MAX)%IMOD_MAX+1);
-    const uint32_t iSM (((((di-ro)/RO_MAX)-fib)/FIB_MAX-iMD+1)/IMOD_MAX+1);
-    return EKDetId(iSM, iMD, fib, ro, iz, SCMODULEMODE);
-  } else {
-    return EKDetId() ;
-  }
-}
-  
-bool EKDetId::validDetId(int iSM, int iMD, int fib, int ro, int iz) {
-
-  return (iSM >= ISM_MIN && iSM <= ISM_MAX && iMD >= IMOD_MIN &&
-	  iMD <= IMOD_MAX && fib >= 0 && fib < FIB_MAX &&
-	  ro >= 0 && ro < RO_MAX && abs(iz) == 1);
-}
-  
-bool EKDetId::slowValidDetId(int jx, int jy, int fib, int ro, int iz) const {
-  int iSM = ism((1 + (jx - 1)/nMods), (1 + (jy - 1)/nMods));
-  int iMD = imod(jx,jy);
-  return validDetId(iSM, iMD, fib, ro, iz);
+  if (!validHashIndex(hi)) return EKDetId();
+  int iRo = hi % RO_MAX;
+  hi = (hi-iRo)/RO_MAX;
+  int iFib = hi % FIB_MAX;
+  hi = (hi-iFib) / FIB_MAX;
+  int iy = hi % MAX_MODULES_ROW;
+  hi = (hi-iy) / MAX_MODULES_ROW;
+  int ix = hi % MAX_MODULES_ROW;
+  hi = (hi-ix) / MAX_MODULES_ROW;
+  int iz = hi ? 1 : -1;
+  return EKDetId(ix, iy, iFib, iRo, iz);
 }
 
-bool EKDetId::isNextToBoundary(EKDetId id) {
-  return isNextToDBoundary(id)  || isNextToRingBoundary(id) ;
+bool EKDetId::validSM (int ix, int iy, Configuration conf) {
+  if (int (conf) >= int (Configuration::LAST)) return false; 
+  int smCol = ix / 5 - MAX_SM_SIZE;
+  int smRow = iy / 5 - MAX_SM_SIZE;
+  if (smCol < 0) smCol = -smCol-1; //reverse negative
+  if (smRow < 0) smRow = -smRow-1;
+  if (smCol >= MAX_SM_SIZE || smRow >= MAX_SM_SIZE) return false;
+  return (EK_CONFIG [conf] [smRow] & (1<<smCol));
+}
+  
+bool EKDetId::validDetId(int iSM, int iMD, int fib, int ro, int iz, Configuration conf) {
+  int smCol = iSM % (2*MAX_SM_SIZE) - MAX_SM_SIZE;
+  int smRow = iSM / (2*MAX_SM_SIZE) - MAX_SM_SIZE;
+  if (smCol < 0) smCol = -smCol-1; //reverse negative
+  if (smRow < 0) smRow = -smRow-1;
+  if (smCol >= MAX_SM_SIZE || smRow >= MAX_SM_SIZE) return false;
+  if (!EK_CONFIG [conf] [smRow] & (1<<smCol)) return false;
+  return (iMD > 0) && (iMD <= 25) && (fib >= 0) && (fib < FIB_MAX) && (ro >= 0) && (ro < RO_MAX) && (abs(iz) == 1);
+}
+  
+bool EKDetId::slowValidDetId(int ix, int iy, int fib, int ro, int iz, Configuration conf) {
+  if (!validSM (ix, iy, conf)) return false; 
+  return (fib >= 0) && (fib < FIB_MAX) && (ro >= 0) && (ro < RO_MAX) && (abs(iz) == 1);
+}
+
+bool EKDetId::isNextToBoundary(EKDetId id, Configuration conf) {
+  return isNextToDBoundary(id)  || isNextToRingBoundary(id, conf) ;
 }
 
 bool EKDetId::isNextToDBoundary(EKDetId id) {
   // hardcoded values for D boundary
-  return id.ix() == nRows || id.ix() == nRows+1 ;
+  return id.ix() == MODULE_OFFSET || id.ix() == MODULE_OFFSET-1;
 }
 
-bool EKDetId::isNextToRingBoundary(EKDetId id) {
+bool EKDetId::isNextToRingBoundary(EKDetId id, Configuration conf) {
   for (int i = -1; i <= 1; ++i) {
     for (int j = -1; j <= 1; ++j) {
-      const int iSM(ism(id.ix()+i, id.iy()+j));
-      const int iMD(imod(id.ix()+i, id.iy()+j));
-      if ( !validDetId(iSM, iMD, id.fiber(), id.readout(), id.zside())) {
+      if (i == 0 && j == 0) continue;
+      if (!slowValidDetId(id.ix()+i, id.iy()+j, id.fiber(), id.readout(), id.zside(), conf)) {
 	return true;
       }
     }
@@ -123,11 +330,11 @@ bool EKDetId::isNextToRingBoundary(EKDetId id) {
   return false;
 }
 
-EKDetId EKDetId::offsetBy(int nrStepsX, int nrStepsY ) const {
+EKDetId EKDetId::offsetBy(int nrStepsX, int nrStepsY, Configuration conf ) const {
   int newX = ix() + nrStepsX;
   int newY = iy() + nrStepsY;
 
-  if (slowValidDetId(newX, newY, fiber(), readout(), zside())) {
+  if (slowValidDetId(newX, newY, fiber(), readout(), zside(), conf)) {
     return EKDetId(newX, newY, fiber(), readout(), zside());
   } else {
     return EKDetId(0);
@@ -135,18 +342,14 @@ EKDetId EKDetId::offsetBy(int nrStepsX, int nrStepsY ) const {
 }
 
 EKDetId EKDetId::switchZSide() const {
-  int newZSide = -1 * zside();
-  if(slowValidDetId(ix(), iy(), fiber(), readout(), newZSide)) {
-    return EKDetId( ix(), iy(), fiber(), readout(), newZSide);
-  } else {
-    return EKDetId(0);
-  }
+  // assume symmetric detector
+  return EKDetId( ix(), iy(), fiber(), readout(), -1 * zside());
 }
 
-DetId EKDetId::offsetBy(const DetId startId, int nrStepsX, int nrStepsY ) {
+DetId EKDetId::offsetBy(const DetId startId, int nrStepsX, int nrStepsY, Configuration conf) {
   if (startId.det() == DetId::Ecal && startId.subdetId() == EcalShashlik) {
     EKDetId eeStartId(startId);
-    return eeStartId.offsetBy(nrStepsX, nrStepsY).rawId();
+    return eeStartId.offsetBy(nrStepsX, nrStepsY, conf).rawId();
   } else {
     return DetId(0);
   }
@@ -169,136 +372,15 @@ int EKDetId::distanceY(const EKDetId& a,const EKDetId& b) {
   return abs(a.iy() - b.iy()); 
 }
 
-int EKDetId::ism(int ismCol, int ismRow) {
-
-  if (0  < ismCol && 2*nCols >= ismCol &&  0  < ismRow && 2*nCols >= ismRow) {
-    const int iquad ((nCols<ismCol && nCols<ismRow ? 1 :
-		      (nCols>=ismCol && nCols<ismRow ? 2 :
-		       (nCols>=ismCol && nCols>=ismRow ? 3 : 4))));
-    
-    const int iCol = (1 == iquad || 4 == iquad ? ismCol - nCols : nCols+1 - ismCol);
-    const int iRow = (1 == iquad || 2 == iquad ? ismRow - nCols : nCols+1 - ismRow ) ;
-
-    static int nSMinQuadrant = ISM_MAX/4;
-    const int yOff (iYoffset[iCol]);
-    const int qOff (nSMinQuadrant*(iquad - 1));
-
-    const int ismOne (QuadColLimits[iCol-1] + iRow - yOff);
-    return (yOff                >= iRow   ? -1 : 
-	    (QuadColLimits[iCol] <  ismOne ? -2 : ismOne + qOff)) ;
-  } else {
-    return -3 ; // bad inputs
-  }
-}  
-
 int EKDetId::imod(int jx, int jy) {
   /*
    *  Return module number from (x,y) coordinates.
    *
    *  Input     : ix, iy - (x,y) position of module
    */
-  const int iquad ((jx>nRows) ? ((jy>nRows) ? 1 : 4) : ((jy>nRows) ? 2 : 3));
-  const int imodCol(((iquad == 1 || iquad == 4)) ? (jx-nRows-1)%nMods : 
-		    (jx-1)%nMods);
-  const int imodRow(((iquad == 1 || iquad == 2)) ? (jy-nRows-1)%nMods :
-		    (jy-1)%nMods);
-  return (5*imodCol + imodRow + 1);
+  return (5*(jx%5) + (jy%5) + 1);
 }  
 
-int EKDetId::ix(int iSM, int iMod) const {
-  /*
-   *  ix() return individual module x-coordinate
-   *
-   *  Input     : iSM, iMod - SuperModule and module ids
-   */
-  
-   int nSMinQuadrant = QuadColLimits[nCols];
-   if (iSM > 4*nSMinQuadrant || iSM < 1) {
-     throw cms::Exception("InvalidDetId") << "EKDetId::ix() called with wrong arguments SM/Module " << iSM << ":" << iMod;
-   }
-  
-   //  Map SC number into (x>0,y>0) quadrant.
-   int iSMmap, iqx,iq;
-   if (iSM > 3*nSMinQuadrant) {
-     iSMmap = iSM - 3*nSMinQuadrant;
-     iqx    = 1;
-     iq     = 4;
-   } else if (iSM > 2*nSMinQuadrant) {
-     iSMmap = iSM - 2*nSMinQuadrant;
-     iqx    =-1;
-     iq     = 3;
-   } else if (iSM > nSMinQuadrant) {
-     iSMmap = iSM - nSMinQuadrant;
-     iqx    =-1;
-      iq    = 2;
-   } else {
-     iSMmap = iSM;
-     iqx    = 1;
-     iq     = 1;
-   }
-
-   // Decide which column the SC is in
-   int iCol = 0 ;
-   while (iSMmap > QuadColLimits[iCol++]) ;
-   iCol-- ;
-
-   int ixMod = IX_MAX/2;
-   if (iq == 1 || iq == 4) { 
-     ixMod += iqx*(5*(iCol-1)) + (int)(iMod+4)/5;
-   } else {
-     ixMod += iqx*(5*iCol) + (int)(iMod+4)/5;
-   } 
-   // returning a value from 1 to 180  
-   return ixMod;
-}
-
-int EKDetId::iy(int iSM, int iMod) const {
-  /*
-   *  iy() return individual module y-coordinate
-   *
-   *  Input     : iSM, iMod - Supermodule and module ids
-   */
-
-   int nSMinQuadrant = QuadColLimits[nCols];
-   if (iSM > 4*nSMinQuadrant || iSM < 1) {
-     throw cms::Exception("InvalidDetId") << "EKDetId::iy() called with wrong arguments SM/Module " << iSM << ":" << iMod;
-   }
-
-   //  Map SC number into (x>0,y>0) quadrant
-   int iSMmap, iqy, iq;
-   if (iSM > 3*nSMinQuadrant) {
-     iSMmap = iSM - 3*nSMinQuadrant;
-     iqy    =-1;
-     iq     = 4;
-   } else if (iSM > 2*nSMinQuadrant) {
-     iSMmap = iSM - 2*nSMinQuadrant;
-     iqy    =-1;
-     iq     = 3;
-   } else if (iSM > nSMinQuadrant) {
-     iSMmap = iSM - nSMinQuadrant;
-     iqy    = 1;
-     iq     = 2;
-   } else {
-     iSMmap = iSM;
-     iqy    = 1;
-     iq     = 1;
-   }
-
-   // Decide which column the SM is in
-   int iCol = 0;
-   while (iSMmap > QuadColLimits[iCol++]) ;
-   iCol--;
-
-   int iSMy  = iSMmap - QuadColLimits[iCol-1] + iYoffset[iCol];
-  
-   int iyMod = IY_MAX/2;
-   if (iq == 3 || iq == 4) {
-     iyMod += iqy*(5*iSMy) + (iMod-1)%5 + 1;
-   } else {
-     iyMod += iqy*(5*(iSMy-1)) + (iMod-1)%5 + 1;
-   }
-   return iyMod;
-}
 
 #include <ostream>
 std::ostream& operator<<(std::ostream& s,const EKDetId& id) {

--- a/DataFormats/EcalDetId/src/classes.h
+++ b/DataFormats/EcalDetId/src/classes.h
@@ -1,6 +1,7 @@
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
 #include <boost/cstdint.hpp> 
 #include "DataFormats/EcalDetId/interface/EEDetId.h"
+#include "DataFormats/EcalDetId/interface/EKDetId.h"
 #include "DataFormats/EcalDetId/interface/ESDetId.h"
 #include "DataFormats/EcalDetId/interface/EcalElectronicsId.h"
 #include "DataFormats/EcalDetId/interface/EcalTriggerElectronicsId.h"
@@ -14,12 +15,14 @@ namespace {
   struct dictionary {
     edm::EDCollection<EBDetId> vEBDI_;
     edm::EDCollection<EEDetId> vEEDI_;
+    edm::EDCollection<EKDetId> vEKDI_;
     edm::EDCollection<EcalTrigTowerDetId> vETTDI_;
     edm::EDCollection<EcalElectronicsId> vEELI_;
     edm::EDCollection<EcalTriggerElectronicsId> vETELI_;
 
     EBDetIdCollection theEBDI_;
     EEDetIdCollection theEEDI_;
+    EKDetIdCollection theEKDI_;
     EcalTrigTowerDetIdCollection theETTDI_;
     EcalScDetIdCollection theESCDI_;
     EcalElectronicsIdCollection theEELI_;
@@ -27,6 +30,7 @@ namespace {
 
     edm::Wrapper<EBDetIdCollection> anotherEBDIw_;
     edm::Wrapper<EEDetIdCollection> anotherEEDIw_;
+    edm::Wrapper<EKDetIdCollection> anotherEKDIw_;
     edm::Wrapper<EcalTrigTowerDetIdCollection> anothertheETTDIw_;
     edm::Wrapper<EcalScDetIdCollection> anothertheESCDIw_;
     edm::Wrapper<EcalElectronicsIdCollection> anothertheEELIw_;
@@ -34,6 +38,7 @@ namespace {
 
     edm::Wrapper< edm::EDCollection<EBDetId> > theEBDIw_;
     edm::Wrapper< edm::EDCollection<EEDetId> > theEEDIw_;
+    edm::Wrapper< edm::EDCollection<EKDetId> > theEKDIw_;
     edm::Wrapper< edm::EDCollection<EcalTrigTowerDetId> > theETTDIw_;
     edm::Wrapper< edm::EDCollection<EcalScDetIdCollection> > theESCDIw_;
     edm::Wrapper< edm::EDCollection<EcalElectronicsId> > theEELIw_;
@@ -42,10 +47,12 @@ namespace {
     // needed for channel recovery
     std::set<EBDetId> _ebDetId;
     std::set<EEDetId> _eeDetId;
+    std::set<EKDetId> _ekDetId;
     std::set<EcalTrigTowerDetId> _TTId;
     std::set<EcalScDetId> _SCId;
     edm::Wrapper< std::set<EBDetId> > _ebDetIdw;
     edm::Wrapper< std::set<EEDetId> > _eeDetIdw;
+    edm::Wrapper< std::set<EKDetId> > _ekDetIdw;
     edm::Wrapper< std::set<EcalTrigTowerDetId> > _TTIdw;
     edm::Wrapper< std::set<EcalScDetId> > _SCIdw;
  };

--- a/DataFormats/EcalDetId/src/classes_def.xml
+++ b/DataFormats/EcalDetId/src/classes_def.xml
@@ -5,6 +5,9 @@
   <class name="EEDetId" ClassVersion="10">
    <version ClassVersion="10" checksum="18639436"/>
   </class>
+  <class name="EKDetId" ClassVersion="9">
+   <version ClassVersion="9" checksum="18993730"/>
+  </class>
   <class name="ESDetId" ClassVersion="10">
    <version ClassVersion="10" checksum="19466122"/>
   </class>
@@ -25,25 +28,30 @@
   </class>
   <class name="std::vector<EBDetId>"/>
   <class name="std::vector<EEDetId>"/>
+  <class name="std::vector<EKDetId>"/>
   <class name="std::vector<EcalTrigTowerDetId>"/>
   <class name="std::vector<EcalElectronicsId>"/>
   <class name="std::vector<EcalTriggerElectronicsId>"/>
   <class name="std::set<EBDetId>"/>
   <class name="std::set<EEDetId>"/>
+  <class name="std::set<EKDetId>"/>
   <class name="std::set<EcalTrigTowerDetId>"/>
   <class name="std::set<EcalScDetId>"/>
   <class name="edm::Wrapper<std::set<EBDetId> > "/>
   <class name="edm::Wrapper<std::set<EEDetId> > "/>
+  <class name="edm::Wrapper<std::set<EKDetId> > "/>
   <class name="edm::Wrapper<std::set<EcalTrigTowerDetId> > "/>
   <class name="edm::Wrapper<std::set<EcalScDetId> > "/>
   <class name="edm::EDCollection<EBDetId> "/>
   <class name="edm::EDCollection<EEDetId> "/>
+  <class name="edm::EDCollection<EKDetId> "/>
   <class name="edm::EDCollection<EcalTrigTowerDetId> "/>
   <class name="edm::EDCollection<EcalScDetId> "/>
   <class name="edm::EDCollection<EcalElectronicsId> " />
   <class name="edm::EDCollection<EcalTriggerElectronicsId> " />
   <class name="edm::Wrapper<edm::EDCollection<EBDetId> > " id="EF1C41A8-6FCA-DDC6-7463-3208C2AEE68F"/>
   <class name="edm::Wrapper<edm::EDCollection<EEDetId> > " id="182A27B1-7C9F-3114-027F-BF26932C6CD0"/>
+  <class name="edm::Wrapper<edm::EDCollection<EKDetId> > " id="182A27B1-7C9F-3114-027F-BF26932C6CD1"/>
   <class name="edm::Wrapper<edm::EDCollection<EcalTrigTowerDetId> > " id="3177FB3F-B69D-07EC-D5BE-A0AFF6A4D78F"/>
   <class name="edm::Wrapper<edm::EDCollection<EcalScDetId> > " id="364d0ca9-8daa-4baf-8203-9d86881b51ff"/>
   <class name="edm::Wrapper<edm::EDCollection<EcalElectronicsId> > " id="1CCDC3B0-D381-60A8-E3B1-B75C4D0F6802"/>

--- a/Geometry/HGCalCommonData/data/NoTaper/shashlikmodule.xml
+++ b/Geometry/HGCalCommonData/data/NoTaper/shashlikmodule.xml
@@ -50,7 +50,7 @@
   <Numeric name="WidthFront"        value="[widthFront]"/>
   <Numeric name="WidthBack"         value="[widthBack]"/>
   <Numeric name="ModuleThickness"   value="[moduleThickness]"/>
-  <Numeric name="HoleRadius"        value="0.8*mm"/>
+  <Numeric name="HoleRadius"        value="0.6*mm"/>
   <String name="FibreMaterial"      value="materials:Quartz"/>
   <String name="FibreName"          value="shashlikmodule:ShashlikFibre"/>
   <Vector name="HoleX" type="numeric" nEntries="4">

--- a/Geometry/HGCalCommonData/data/shashlikmodule.xml
+++ b/Geometry/HGCalCommonData/data/shashlikmodule.xml
@@ -52,7 +52,8 @@
   <Numeric name="WidthBack"         value="[widthBack]"/>
   <Numeric name="ModuleThickness"   value="[moduleThickness]"/>
   <Numeric name="ModuleTaperAngle"  value="[moduleTaperAngle]"/>
-  <Numeric name="HoleRadius"        value="0.8*mm"/>
+  <!-- ccn: changed from 0.8mm -->
+  <Numeric name="HoleRadius"        value="0.6*mm"/>
   <String name="FibreMaterial"      value="materials:Quartz"/>
   <String name="FibreName"          value="shashlikmodule:ShashlikFibre"/>
   <Vector name="HoleX" type="numeric" nEntries="4">

--- a/Geometry/HGCalCommonData/plugins/BuildFile.xml
+++ b/Geometry/HGCalCommonData/plugins/BuildFile.xml
@@ -1,5 +1,6 @@
 <library   file="*.cc" name="GeometryHGCalCommonDataPlugin">
  <use   name="DetectorDescription/Parser"/>
  <use   name="FWCore/PluginManager"/>
+ <use   name="DataFormats/EcalDetId"/>
  <flags   EDM_PLUGIN="1"/>
 </library>

--- a/Geometry/HGCalCommonData/plugins/DDShashlikModule.cc
+++ b/Geometry/HGCalCommonData/plugins/DDShashlikModule.cc
@@ -38,7 +38,7 @@ void DDShashlikModule::initialize(const DDNumericArguments & nArgs,
   widthFront     = nArgs["WidthFront"];
   widthBack      = nArgs["WidthBack"];
   moduleThick    = nArgs["ModuleThickness"];
-  moduleTaperAngle = nArgs["ModuleTaperAngle"];
+  //  moduleTaperAngle = nArgs["ModuleTaperAngle"];
   holeR          = nArgs["HoleRadius"];
   fibreMat       = sArgs["FibreMaterial"];
   fibreName      = sArgs["FibreName"];
@@ -51,7 +51,7 @@ void DDShashlikModule::initialize(const DDNumericArguments & nArgs,
 			    << " thickness " << activeThick <<"|"<< absorbThick
 			    << " width " << widthFront << "|" << widthBack 
 			    << " module size " << moduleThick 
-			    << " module taper angle " << moduleTaperAngle/CLHEP::deg << "deg  "
+    //<< " module taper angle " << moduleTaperAngle/CLHEP::deg << "deg  "
 			    << holeX.size() << " holes of radius " << holeR 
 			    << " for fibres "<<fibreName <<" with "<< fibreMat
 			    << " Calibration fibre " << calibFibreName 

--- a/Geometry/HGCalCommonData/plugins/DDShashlikModule.h
+++ b/Geometry/HGCalCommonData/plugins/DDShashlikModule.h
@@ -31,7 +31,7 @@ private:
   double              widthFront;     //Width of the module in the front
   double              widthBack;      //Width of the module in the back
   double              moduleThick;    //Offset in z
-  double              moduleTaperAngle; //Taper angle of individual module
+  //  double              moduleTaperAngle; //Taper angle of individual module
   double              holeR;          //Radius of the hole
   std::string         fibreMat;       //Fibre Material
   std::string         fibreName;      //Fibre Name

--- a/Geometry/HGCalCommonData/plugins/DDShashlikNoTaperEndcap.cc
+++ b/Geometry/HGCalCommonData/plugins/DDShashlikNoTaperEndcap.cc
@@ -10,6 +10,7 @@
 #include "DetectorDescription/Core/interface/DDSplit.h"
 #include "DetectorDescription/Core/interface/DDLogicalPart.h"
 #include "Geometry/HGCalCommonData/plugins/DDShashlikNoTaperEndcap.h"
+#include "DataFormats/EcalDetId/interface/EKDetId.h"
 #include "CLHEP/Units/GlobalPhysicalConstants.h"
 #include "CLHEP/Units/GlobalSystemOfUnits.h"
 
@@ -64,17 +65,20 @@ DDShashlikNoTaperEndcap::createQuarter( DDCompactView& cpv, int xQuadrant, int y
   double phiZ = 3*theta; 
   double offsetZ = m_zoffset;
   double offsetXY = m_xyoffset;
-  int row(0), column(0);
 
   // ccn: these need to change for no-taper option
   //double offsetX = offsetZ * tan( xphi );
   //double offsetY = offsetZ * tan( yphi );
-  double offsetX = xQuadrant*0.5*offsetXY;
-  double offsetY = yQuadrant*0.5*offsetXY;
+  double offsetX0 = xQuadrant*0.5*offsetXY;
+  double offsetY0 = yQuadrant*0.5*offsetXY;
   
+  int column = 0;
+  double offsetX = offsetX0;
   while( abs(offsetX) < m_rMax)
   {
     column++;
+    int row = 0;
+    double offsetY = offsetY0;
     while( abs(offsetY) < m_rMax)
     {
       row++;
@@ -105,7 +109,15 @@ DDShashlikNoTaperEndcap::createQuarter( DDCompactView& cpv, int xQuadrant, int y
 	DDTranslation tran( offsetX, offsetY, offsetZ );
 	
 	DDName parentName = parent().name(); 
-	cpv.position( DDName( m_childName ), parentName, copyNo, tran, rotation );
+       int absCopyNo = EKDetId::smIndex (xQuadrant>0?column:-column, yQuadrant>0?row:-row);
+       cpv.position( DDName( m_childName ), parentName, absCopyNo, tran, rotation );
+//      EKDetId id (absCopyNo, 13, 0, 0, 1, EKDetId::SCMODULEMODE);
+//      std::cout << "quadrant " << xQuadrant<<':'<<yQuadrant<<" offset: "<<offsetX<<':'<<offsetY
+//                <<" copy# " << absCopyNo
+//                << " column:row " << column<<':'<<row
+//                << " X:Y location "<<EKDetId::smXLocation(absCopyNo)<<':'<<EKDetId::smYLocation(absCopyNo)
+//                << " ix:iy " << id.ix() << ':' << id.iy()
+//                <<std::endl;
 
 	copyNo += m_incrCopyNo;
       }
@@ -128,7 +140,6 @@ DDShashlikNoTaperEndcap::createQuarter( DDCompactView& cpv, int xQuadrant, int y
 
   }
   
-  // std::cout << row << " rows and " << column << " columns in quadrant " << xQuadrant << ":" << yQuadrant << std::endl;
   return copyNo;
 }
 

--- a/Geometry/HGCalCommonData/plugins/DDShashlikNoTaperSupermodule.cc
+++ b/Geometry/HGCalCommonData/plugins/DDShashlikNoTaperSupermodule.cc
@@ -160,31 +160,76 @@ DDShashlikNoTaperSupermodule::execute( DDCompactView& cpv )
 // 				  << offsetY << ","
 // 				  << offsetZ1+offsetZ2 << ")" << " (copyNo & 5)=" << (copyNo & 5);
 
+        // these are hard-coded for now
+        //
+        //
+        if (ix == 0) {
+          offsetX  = -1.0 * offsetXc2secondc;
+          offsetZ1 = -1.0 * offsetZc2secondc;
+        }
+        else if (ix == 1){
+          offsetZ1 = -1.0*offsetZc2c;
+          offsetX  = -1.0*offsetXc2c; 
+        }else if (ix == 2){
+          offsetZ1 = 0.0;
+          offsetX  = 0.0; 
+        }else if (ix == 3){
+          offsetZ1 = -1.0*offsetZc2c;
+          offsetX  = offsetXc2c; 
+        }else if (ix == 4){
+          offsetZ1 = -1.0*offsetZc2secondc;
+          offsetX  = offsetXc2secondc; 
+        }
+        
+        if (iy == 0) {
+          offsetY  = -1.0 * offsetYc2secondc;
+          offsetZ2 = -1.0 * offsetZc2secondc;
+        }
+        else if (iy == 1){
+          offsetZ2 = -1.0*offsetZc2c;
+          offsetY = -1.0*offsetYc2c;
+        }
+        else if (iy == 2){
+          offsetZ2 = 0.0;
+          offsetY = 0.0;
+        }
+        else if (iy == 3){
+          offsetZ2 = -1.0*offsetZc2c;
+          offsetY = offsetYc2c;
+        }
+        else if (iy == 4){
+          offsetZ2 = -1.0*offsetZc2secondc;
+          offsetY = offsetYc2secondc;
+        }
+                          
+        DDTranslation tran1( offsetX, 0.0, offsetZ1 );
+        DDTranslation tran2( 0.0, offsetY, offsetZ2 );
 			  
-	DDTranslation tran1( offsetX, 0.0, offsetZ1 );
- 	DDTranslation tran2( 0.0, offsetY, offsetZ2 );
-    
 	DDName parentName = parent().name(); 
-	cpv.position( DDName( m_childName ), parentName, copyNo, (tran1+tran2), rotation );
+       int absCopyNo = ix*5+iy+1;
+       cpv.position( DDName( m_childName ), parentName, absCopyNo, (tran1+tran2), rotation );
+//     std::cout << "DDShashlikSupermodule::execute-> "
+//               << offsetX<<':'<<offsetY<<"->"<<absCopyNo
+//               <<std::endl;
 
 
 
-	// these are hard-coded for now
-	//
-	//
-	if((copyNo % 5) == 1){
-	  offsetZ1 = -1.0*offsetZc2c;
-	  offsetX  = -1.0*offsetXc2c; 
-	}else if((copyNo % 5) == 2){
-	  offsetZ1 = 0.0;
-	  offsetX  = 0.0; 
-	}else if((copyNo % 5) == 3){
-	  offsetZ1 = -1.0*offsetZc2c;
-	  offsetX  = offsetXc2c; 
-	}else if((copyNo % 5) == 4){
-	  offsetZ1 = -1.0*offsetZc2secondc;
-	  offsetX  = offsetXc2secondc; 
-	}
+// 	// these are hard-coded for now
+// 	//
+// 	//
+// 	if((copyNo % 5) == 1){
+// 	  offsetZ1 = -1.0*offsetZc2c;
+// 	  offsetX  = -1.0*offsetXc2c; 
+// 	}else if((copyNo % 5) == 2){
+// 	  offsetZ1 = 0.0;
+// 	  offsetX  = 0.0; 
+// 	}else if((copyNo % 5) == 3){
+// 	  offsetZ1 = -1.0*offsetZc2c;
+// 	  offsetX  = offsetXc2c; 
+// 	}else if((copyNo % 5) == 4){
+// 	  offsetZ1 = -1.0*offsetZc2secondc;
+// 	  offsetX  = offsetXc2secondc; 
+// 	}
 
 	xphi += m_stepAngle;
 	copyNo += m_incrCopyNo;
@@ -194,28 +239,28 @@ DDShashlikNoTaperSupermodule::execute( DDCompactView& cpv )
       xphi    = - 2* m_stepAngle;
       phi    += m_stepAngle;
  
-      offsetZ1 = -1.0*offsetZc2secondc;
-      offsetX  = -1.0*offsetXc2secondc; 
+//       offsetZ1 = -1.0*offsetZc2secondc;
+//       offsetX  = -1.0*offsetXc2secondc; 
 
-      // these are hard-coded for now
-      //
-      //
-      if(copyNo == 6){
-	offsetZ2 = -1.0*offsetZc2c;
-	offsetY = -1.0*offsetYc2c;
-      }
-      if(copyNo == 11){
-	offsetZ2 = 0.0;
-	offsetY = 0.0;
-      }
-      if(copyNo == 16){
-	offsetZ2 = -1.0*offsetZc2c;
- 	offsetY = offsetYc2c;
-      }
-      if(copyNo == 21){
-	offsetZ2 = -1.0*offsetZc2secondc;
- 	offsetY = offsetYc2secondc;
-      }
+//       // these are hard-coded for now
+//       //
+//       //
+//       if(copyNo == 6){
+// 	offsetZ2 = -1.0*offsetZc2c;
+// 	offsetY = -1.0*offsetYc2c;
+//       }
+//       if(copyNo == 11){
+// 	offsetZ2 = 0.0;
+// 	offsetY = 0.0;
+//       }
+//       if(copyNo == 16){
+// 	offsetZ2 = -1.0*offsetZc2c;
+//  	offsetY = offsetYc2c;
+//       }
+//       if(copyNo == 21){
+// 	offsetZ2 = -1.0*offsetZc2secondc;
+//  	offsetY = offsetYc2secondc;
+//       }
 
     }
 

--- a/Geometry/HGCalCommonData/plugins/DDShashlikSupermodule.cc
+++ b/Geometry/HGCalCommonData/plugins/DDShashlikSupermodule.cc
@@ -169,31 +169,62 @@ DDShashlikSupermodule::execute( DDCompactView& cpv )
 	//			  << offsetY << ","
 	//			  << offsetZ1+offsetZ2 << ")" << " (copyNo & 5)=" << (copyNo & 5);
 
+
 			  
+        // these are hard-coded for now
+        //
+        //
+        if (ix == 0) {
+          offsetX  = -1.0 * offsetXc2secondc;
+          offsetZ1 = -1.0 * offsetZc2secondc;
+        }
+        else if (ix == 1){
+          offsetZ1 = -1.0*offsetZc2c;
+          offsetX  = -1.0*offsetXc2c; 
+        }else if (ix == 2){
+          offsetZ1 = 0.0;
+          offsetX  = 0.0; 
+        }else if (ix == 3){
+          offsetZ1 = -1.0*offsetZc2c;
+          offsetX  = offsetXc2c; 
+        }else if (ix == 4){
+          offsetZ1 = -1.0*offsetZc2secondc;
+          offsetX  = offsetXc2secondc; 
+        }
+        
+        if (iy == 0) {
+          offsetY  = -1.0 * offsetYc2secondc;
+          offsetZ2 = -1.0 * offsetZc2secondc;
+        }
+        else if (iy == 1){
+          offsetZ2 = -1.0*offsetZc2c;
+          offsetY = -1.0*offsetYc2c;
+        }
+        else if (iy == 2){
+          offsetZ2 = 0.0;
+          offsetY = 0.0;
+        }
+        else if (iy == 3){
+          offsetZ2 = -1.0*offsetZc2c;
+          offsetY = offsetYc2c;
+        }
+        else if (iy == 4){
+          offsetZ2 = -1.0*offsetZc2secondc;
+          offsetY = offsetYc2secondc;
+        }
+                          
 	DDTranslation tran1( offsetX, 0.0, offsetZ1 );
  	DDTranslation tran2( 0.0, offsetY, offsetZ2 );
     
 	DDName parentName = parent().name(); 
-	cpv.position( DDName( m_childName ), parentName, copyNo, (tran1+tran2), rotation );
+	int absCopyNo = ix*5+iy+1;
+	cpv.position( DDName( m_childName ), parentName, absCopyNo, (tran1+tran2), rotation );
+//     std::cout << "DDShashlikSupermodule::execute-> "
+//               << offsetX<<':'<<offsetY<<"->"<<absCopyNo
+//               <<std::endl;
 
 
 
-	// these are hard-coded for now
-	//
-	//
-	if((copyNo % 5) == 1){
-	  offsetZ1 = -1.0*offsetZc2c;
-	  offsetX  = -1.0*offsetXc2c; 
-	}else if((copyNo % 5) == 2){
-	  offsetZ1 = 0.0;
-	  offsetX  = 0.0; 
-	}else if((copyNo % 5) == 3){
-	  offsetZ1 = -1.0*offsetZc2c;
-	  offsetX  = offsetXc2c; 
-	}else if((copyNo % 5) == 4){
-	  offsetZ1 = -1.0*offsetZc2secondc;
-	  offsetX  = offsetXc2secondc; 
-	}
 
 	xphi += m_stepAngle;
 	copyNo += m_incrCopyNo;
@@ -205,26 +236,6 @@ DDShashlikSupermodule::execute( DDCompactView& cpv )
  
       offsetZ1 = -1.0*offsetZc2secondc;
       offsetX  = -1.0*offsetXc2secondc; 
-
-      // these are hard-coded for now
-      //
-      //
-      if(copyNo == 6){
-	offsetZ2 = -1.0*offsetZc2c;
-	offsetY = -1.0*offsetYc2c;
-      }
-      if(copyNo == 11){
-	offsetZ2 = 0.0;
-	offsetY = 0.0;
-      }
-      if(copyNo == 16){
-	offsetZ2 = -1.0*offsetZc2c;
- 	offsetY = offsetYc2c;
-      }
-      if(copyNo == 21){
-	offsetZ2 = -1.0*offsetZc2secondc;
- 	offsetY = offsetYc2secondc;
-      }
 
     }
 


### PR DESCRIPTION
Small change: Reduced radius of shashlik readout fibers from 0.8mm to 0.6mm. Only files changing:
- Geometry/HGCalCommonData/data/shashlikmodule.xml 
- Geometry/HGCalCommonData/data/NoTaper/shashlikmodule.xml
  ...with no impact on module numbering/DetID/channel counting.

This change is important for shashlik TP studies as it provides a more realistic fiber scenario.
