### PR TITLE
Shashlik improved fiber radius v2

### DIFF
--- a/Geometry/HGCalCommonData/data/NoTaper/shashlikmodule.xml
+++ b/Geometry/HGCalCommonData/data/NoTaper/shashlikmodule.xml
@@ -52,7 +52,7 @@
   <Numeric name="WidthBack"         value="[widthBack]"/>
   <Numeric name="ModuleThickness"   value="[moduleThickness]"/>
   <Numeric name="ModuleTaperAngle"  value="[moduleTaperAngle]"/>
-  <Numeric name="HoleRadius"        value="0.8*mm"/>
+  <Numeric name="HoleRadius"        value="0.6*mm"/>
   <String name="FibreMaterial"      value="materials:Quartz"/>
   <String name="FibreName"          value="shashlikmodule:ShashlikFibre"/>
   <Vector name="HoleX" type="numeric" nEntries="4">

--- a/Geometry/HGCalCommonData/data/shashlikmodule.xml
+++ b/Geometry/HGCalCommonData/data/shashlikmodule.xml
@@ -52,7 +52,7 @@
   <Numeric name="WidthBack"         value="[widthBack]"/>
   <Numeric name="ModuleThickness"   value="[moduleThickness]"/>
   <Numeric name="ModuleTaperAngle"  value="[moduleTaperAngle]"/>
-  <Numeric name="HoleRadius"        value="0.8*mm"/>
+  <Numeric name="HoleRadius"        value="0.6*mm"/>
   <String name="FibreMaterial"      value="materials:Quartz"/>
   <String name="FibreName"          value="shashlikmodule:ShashlikFibre"/>
   <Vector name="HoleX" type="numeric" nEntries="4">


### PR DESCRIPTION
Changed base to 620_SLHC10. This change affects only the radius definition of the readout fibers in the shashlik modules. Nothing else downstream changes in terms of module counting/DetID/etc.
