### PR TITLE
modifing EgammaHLTGsfTrackVarProducer to produce 1/E-1/p as well

### DIFF
--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTGsfTrackVarProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTGsfTrackVarProducer.cc
@@ -41,7 +41,10 @@ EgammaHLTGsfTrackVarProducer::EgammaHLTGsfTrackVarProducer(const edm::ParameterS
  
   //register your products
   produces < reco::RecoEcalCandidateIsolationMap >( "Deta" ).setBranchAlias( "deta" );
-  produces < reco::RecoEcalCandidateIsolationMap >( "Dphi" ).setBranchAlias( "dphi" ); 
+  produces < reco::RecoEcalCandidateIsolationMap >( "Dphi" ).setBranchAlias( "dphi" );
+  produces < reco::RecoEcalCandidateIsolationMap >( "OneOESuperMinusOneOP" );
+  produces < reco::RecoEcalCandidateIsolationMap >( "OneOESeedMinusOneOP" );
+  
 }
 
 EgammaHLTGsfTrackVarProducer::~EgammaHLTGsfTrackVarProducer()
@@ -81,7 +84,9 @@ void EgammaHLTGsfTrackVarProducer::produce(edm::Event& iEvent, const edm::EventS
 
   reco::RecoEcalCandidateIsolationMap dEtaMap;
   reco::RecoEcalCandidateIsolationMap dPhiMap;
-  
+  reco::RecoEcalCandidateIsolationMap oneOverESuperMinusOneOverPMap;
+  reco::RecoEcalCandidateIsolationMap oneOverESeedMinusOneOverPMap;
+
   for(reco::RecoEcalCandidateCollection::const_iterator iRecoEcalCand = recoEcalCandHandle->begin(); iRecoEcalCand != recoEcalCandHandle->end(); iRecoEcalCand++){
     reco::RecoEcalCandidateRef recoEcalCandRef(recoEcalCandHandle,iRecoEcalCand-recoEcalCandHandle->begin());
    
@@ -109,6 +114,8 @@ void EgammaHLTGsfTrackVarProducer::produce(edm::Event& iEvent, const edm::EventS
     }
     float dEtaInValue=999999;
     float dPhiInValue=999999;
+    float oneOverESuperMinusOneOverPValue=999999;
+    float oneOverESeedMinusOneOverPValue=999999;
     
     if(static_cast<int>(gsfTracks.size())>=upperTrackNrToRemoveCut_){
       dEtaInValue=0;
@@ -122,20 +129,35 @@ void EgammaHLTGsfTrackVarProducer::produce(edm::Event& iEvent, const edm::EventS
 	GlobalPoint scPos(scRef->x(),scRef->y(),scRef->z());
 	GlobalPoint trackExtrapToSC = trackExtrapolator_.extrapolateTrackPosToPoint(*gsfTracks[trkNr],scPos);
 	EleRelPointPair scAtVtx(scRef->position(),trackExtrapToSC,beamSpot.position());
+
+	
+	float trkP = gsfTracks[trkNr]->p();
+	if(scRef->energy()!=0 && trkP!=0){
+	  if(fabs(1/scRef->energy() - 1/trkP)<oneOverESuperMinusOneOverPValue) oneOverESuperMinusOneOverPValue =fabs(1/scRef->energy() - 1/trkP);
+	}
+	if(scRef->seed().isNonnull() && scRef->seed()->energy()!=0 && trkP!=0){
+	  if(fabs(1/scRef->seed()->energy() - 1/trkP)<oneOverESeedMinusOneOverPValue) oneOverESeedMinusOneOverPValue =fabs(1/scRef->seed()->energy() - 1/trkP);
+	}
 	
 	if(fabs(scAtVtx.dEta())<dEtaInValue) dEtaInValue=fabs(scAtVtx.dEta()); //we are allowing them to come from different tracks
 	if(fabs(scAtVtx.dPhi())<dPhiInValue) dPhiInValue=fabs(scAtVtx.dPhi());//we are allowing them to come from different tracks
       }	
     }
-    
+   
     dEtaMap.insert(recoEcalCandRef, dEtaInValue);
     dPhiMap.insert(recoEcalCandRef, dPhiInValue);
+    oneOverESuperMinusOneOverPMap.insert(recoEcalCandRef,oneOverESuperMinusOneOverPValue);   
+    oneOverESeedMinusOneOverPMap.insert(recoEcalCandRef,oneOverESeedMinusOneOverPValue);
   }
 
   std::auto_ptr<reco::RecoEcalCandidateIsolationMap> dEtaMapForEvent(new reco::RecoEcalCandidateIsolationMap(dEtaMap));
   std::auto_ptr<reco::RecoEcalCandidateIsolationMap> dPhiMapForEvent(new reco::RecoEcalCandidateIsolationMap(dPhiMap));
+  std::auto_ptr<reco::RecoEcalCandidateIsolationMap> oneOverESuperMinusOneOverPMapForEvent(new reco::RecoEcalCandidateIsolationMap(oneOverESuperMinusOneOverPMap));
+  std::auto_ptr<reco::RecoEcalCandidateIsolationMap> oneOverESeedMinusOneOverPMapForEvent(new reco::RecoEcalCandidateIsolationMap(oneOverESeedMinusOneOverPMap));
   iEvent.put(dEtaMapForEvent, "Deta" );
   iEvent.put(dPhiMapForEvent, "Dphi" );
+  iEvent.put(oneOverESuperMinusOneOverPMapForEvent,"OneOESuperMinusOneOP");
+  iEvent.put(oneOverESeedMinusOneOverPMapForEvent,"OneOESeedMinusOneOP");
 }
 
 


### PR DESCRIPTION
This is a modification to the producer that makes the HLT Gsf track related variables to also make 1/E - 1/p. The timing should be negligible and it has run on ~100K Z'->ee events without crashing. This is a necessary addition for the E/g HLT. Speaking as E/g Reco & HLT subconvenor, I would like this change to go in the next available open pre-release. Many Thanks!
