### PR TITLE
Thread safety cleanup in CondFormats/Common

### DIFF
--- a/CondFormats/Common/interface/FileBlob.h
+++ b/CondFormats/Common/interface/FileBlob.h
@@ -1,6 +1,9 @@
 #ifndef CondFormats_FileBlob_h
 #define CondFormats_FileBlob_h
 
+#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
+#include <memory>
+#endif
 #include <vector>
 #include <string>
 #include <iostream>
@@ -30,7 +33,9 @@ class FileBlob{
 
   int size() const {return isize;};
   /// i didn't want to do two copies ... hope this works.
-  std::vector<unsigned char>* getUncompressedBlob() const;
+#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
+  std::unique_ptr<std::vector<unsigned char> > getUncompressedBlob() const;
+#endif
   void getUncompressedBlob( std::vector<unsigned char>& myblobcopy ) const;
                                  
  private:

--- a/CondFormats/Common/src/FileBlob.cc
+++ b/CondFormats/Common/src/FileBlob.cc
@@ -71,11 +71,11 @@ void FileBlob::write(std::ostream & os) const {
   }
 }
 
-std::vector<unsigned char>* FileBlob::getUncompressedBlob() const { 
-  std::vector<unsigned char>*  newblob;
+std::unique_ptr<std::vector<unsigned char> > FileBlob::getUncompressedBlob() const {
+  std::unique_ptr<std::vector<unsigned char> >  newblob;
   if(compressed)
   {
-    newblob = new std::vector<unsigned char>(isize);
+    newblob.reset(new std::vector<unsigned char>(isize));
     uLongf destLen = newblob->size();
     //    std::cout<<"Store isize = "<<isize<<"; newblob->size() = "<<newblob->size()<<"; destLen = "<<destLen<<std::endl;
     int zerr =  uncompress(&*(newblob->begin()),  &destLen,
@@ -85,7 +85,7 @@ std::vector<unsigned char>* FileBlob::getUncompressedBlob() const {
                                    << " original size was " << isize
                                    << " new size is " << destLen;
   }else{
-    newblob = new std::vector<unsigned char>(blob);
+    newblob.reset(new std::vector<unsigned char>(blob));
   }
   return newblob;
  }

--- a/CondTools/DQM/plugins/DQMReferenceHistogramRootFileEventSetupAnalyzer.cc
+++ b/CondTools/DQM/plugins/DQMReferenceHistogramRootFileEventSetupAnalyzer.cc
@@ -1,10 +1,8 @@
 // C++ common header
 #include <iostream>
+#include <memory>
 #include <vector>
 #include <fstream>
-
-// Boost headers
-#include "boost/scoped_ptr.hpp"
 
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Run.h"
@@ -67,7 +65,7 @@ namespace edmtest {
 	edm::ESHandle<FileBlob> rootgeo;
 	iSetup.get<DQMReferenceHistogramRootFileRcd>().get(rootgeo);
 	//std::cout<<"ROOT FILE IN MEMORY"<<std::endl;
-	boost::scoped_ptr<std::vector<unsigned char> > tb( (*rootgeo).getUncompressedBlob() );
+        std::unique_ptr<std::vector<unsigned char> > tb( (*rootgeo).getUncompressedBlob() );
 	// char filename[128];
 	// sprintf(filename, "mem:%p,%ul", &(*tb)[0], (unsigned long) tb->size());
 	// edm::Service<DQMStore>()->open(filename, false, "", "Reference");

--- a/CondTools/DQM/plugins/DQMXMLFileEventSetupAnalyzer.cc
+++ b/CondTools/DQM/plugins/DQMXMLFileEventSetupAnalyzer.cc
@@ -1,10 +1,8 @@
 // C++ common header
 #include <iostream>
+#include <memory>
 #include <vector>
 #include <fstream>
-
-// Boost headers
-#include "boost/scoped_ptr.hpp"
 
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Run.h"
@@ -68,7 +66,7 @@ namespace edmtest {
 	edm::ESHandle<FileBlob> rootgeo;
 	iSetup.get<DQMXMLFileRcd>().get(labelToGet_,rootgeo);
 	//std::cout<<"XML FILE IN MEMORY 1 with label " << labelToGet_ <<std::endl;
-	boost::scoped_ptr<std::vector<unsigned char> > tb1( (*rootgeo).getUncompressedBlob() );
+	std::unique_ptr<std::vector<unsigned char> > tb1( (*rootgeo).getUncompressedBlob() );
 	//here you can implement the stream for putting the TFile on disk...
 	std::string outfile1("XML1_retrieved.xml") ;
 	std::ofstream output1(outfile1.c_str()) ;
@@ -77,13 +75,13 @@ namespace edmtest {
 	
 // 	iSetup.get<DQMXMLFileRcd>().get("XML2_mio",rootgeo);
 // 	std::cout<<"ROOT FILE IN MEMORY 2"<<std::endl;
-// 	boost::scoped_ptr<std::vector<unsigned char> > tb2( (*rootgeo).getUncompressedBlob() );
+// 	std::unique_ptr<std::vector<unsigned char> > tb2( (*rootgeo).getUncompressedBlob() );
 // 	//here you can implement the stream for putting the TFile on disk...
 // 	std::string outfile2("XML2_retrieved.xml") ;
 // 	std::ofstream output2(outfile2.c_str()) ;
 // 	output2.write((const char *)&(*tb2)[0], tb2->size());
 // 	output2.close() ;
-	//	boost::scoped_ptr<std::vector<unsigned char> > tb( (*rootgeo).getUncompressedBlob() );
+	//	std::unique_ptr<std::vector<unsigned char> > tb( (*rootgeo).getUncompressedBlob() );
       }
   }
   

--- a/CondTools/Geometry/test/GeometryTester.cc
+++ b/CondTools/Geometry/test/GeometryTester.cc
@@ -34,6 +34,7 @@
 #include "Geometry/Records/interface/PZdcRcd.h"
 
 #include <iostream>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -63,7 +64,7 @@ GeometryTester::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup
     edm::ESHandle<FileBlob> xmlgeo;
     iSetup.get<GeometryFileRcd>().get(geomLabel_, xmlgeo);
     std::cout<<"XML FILE"<<std::endl;
-    std::vector<unsigned char>* tb = (*xmlgeo).getUncompressedBlob();
+    std::unique_ptr<std::vector<unsigned char> > tb = (*xmlgeo).getUncompressedBlob();
     std::cout<<"SIZE FILE = "<<tb->size()<<std::endl;
     for(uint32_t i=0; i<tb->size();i++){
       std::cout<<(*tb)[i];

--- a/DQMServices/Components/src/QualityTester.cc
+++ b/DQMServices/Components/src/QualityTester.cc
@@ -12,6 +12,8 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/ParameterSet/interface/FileInPath.h"
+
+#include <memory>
 #include <stdio.h>
 #include <sstream>
 #include <math.h>
@@ -58,7 +60,7 @@ void QualityTester::beginRun(const edm::Run& run , const edm::EventSetup& iSetup
 //     std::cout << "Reading XML from Database" << std::endl ;
     edm::ESHandle<FileBlob> xmlfile;
     iSetup.get<DQMXMLFileRcd>().get(Label,xmlfile);
-    boost::scoped_ptr<std::vector<unsigned char> > vc( (*xmlfile).getUncompressedBlob() );
+    std::unique_ptr<std::vector<unsigned char> > vc( (*xmlfile).getUncompressedBlob() );
     std::string xmlstr="";
     for(std::vector<unsigned char>::iterator it=vc->begin();it!=vc->end();it++){
       xmlstr += *it;

--- a/GeometryReaders/XMLIdealGeometryESSource/src/XMLIdealGeometryESProducer.cc
+++ b/GeometryReaders/XMLIdealGeometryESSource/src/XMLIdealGeometryESProducer.cc
@@ -129,13 +129,11 @@ XMLIdealGeometryESProducer::produce(const IdealGeometryRecord& iRecord)
    DDLParser parser(*returnValue);
    parser.getDDLSAX2FileHandler()->setUserNS(true);
    parser.clearFiles();
-   
-   std::vector<unsigned char>* tb = (*gdd).getUncompressedBlob();
-   
-   parser.parse(*tb, tb->size()); 
-   
-   delete tb;
-   
+
+   std::unique_ptr<std::vector<unsigned char> > tb = (*gdd).getUncompressedBlob();
+
+   parser.parse(*tb, tb->size());
+
    //std::cout << "In XMLIdealGeometryESProducer::produce" << std::endl;
    returnValue->lockdown();
 

--- a/GeometryReaders/XMLIdealGeometryESSource/src/XMLIdealMagneticFieldGeometryESProducer.cc
+++ b/GeometryReaders/XMLIdealGeometryESSource/src/XMLIdealMagneticFieldGeometryESProducer.cc
@@ -23,6 +23,8 @@
 #include "DetectorDescription/Core/src/LogicalPart.h"
 #include "DetectorDescription/Core/src/Specific.h"
 
+#include <memory>
+
 class XMLIdealMagneticFieldGeometryESProducer : public edm::ESProducer
 {
 public:
@@ -70,13 +72,11 @@ XMLIdealMagneticFieldGeometryESProducer::produce( const IdealMagneticFieldRecord
   DDLParser parser(*returnValue);
   parser.getDDLSAX2FileHandler()->setUserNS(true);
   parser.clearFiles();
-   
-  std::vector<unsigned char>* tb = (*gdd).getUncompressedBlob();
-   
-  parser.parse(*tb, tb->size()); 
-   
-  delete tb;
-   
+
+  std::unique_ptr<std::vector<unsigned char> > tb = (*gdd).getUncompressedBlob();
+
+  parser.parse(*tb, tb->size());
+
   returnValue->lockdown();
 
   return returnValue ;

--- a/GeometryReaders/XMLIdealGeometryESSource/test/ExtractXMLFile.cc
+++ b/GeometryReaders/XMLIdealGeometryESSource/test/ExtractXMLFile.cc
@@ -100,7 +100,7 @@ ExtractXMLFile::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup
    std::cout << "Here I am " << std::endl;
    edm::ESHandle<FileBlob> gdd;
    iSetup.get<GeometryFileRcd>().get(label_, gdd);
-   //std::vector<unsigned char>* tb = (*gdd).getUncompressedBlob();
+   //std::unique_ptr<std::vector<unsigned char> > tb = (*gdd).getUncompressedBlob();
    std::ofstream f(fname_.c_str());
    (*gdd).write(f);
    //f.close();


### PR DESCRIPTION
Modify return type of FileBlob::getUncompressedBlob
from a bare pointer to a unique_ptr. This eliminates
a report from the thread safety static code checker
of a potential thread safety problem. Also changes
code that calls this function to use the new interface
and in one case fixes a memory leak.
