### PR TITLE
Thread safety cleanup in PhysicsToolsObjects

### DIFF
--- a/CondFormats/PhysicsToolsObjects/src/PerformancePayloadFromBinnedTFormula.cc
+++ b/CondFormats/PhysicsToolsObjects/src/PerformancePayloadFromBinnedTFormula.cc
@@ -58,6 +58,10 @@ float PerformancePayloadFromBinnedTFormula::getResult(PerformanceResult::ResultT
   }
   //
   // i need a non const version 
+  // Note, in current implementation of TFormula EvalPar should be
+  // thread safe as it does nothing more than call a function
+  // through a function pointer which is stateless. In spite of the
+  // fact that it is not const.
   return formula->EvalPar(values);
 }
 

--- a/CondFormats/PhysicsToolsObjects/src/PerformancePayloadFromTFormula.cc
+++ b/CondFormats/PhysicsToolsObjects/src/PerformancePayloadFromTFormula.cc
@@ -37,6 +37,10 @@ float PerformancePayloadFromTFormula::getResult(PerformanceResult::ResultType r 
   }
   //
   // i need a non const version #$%^
+  // Note, in current implementation of TFormula EvalPar should be
+  // thread safe as it does nothing more than call a function
+  // through a function pointer which is stateless. In spite of the
+  // fact that it is not const.
   return formula->EvalPar(values);
 }
 
@@ -68,6 +72,7 @@ void PerformancePayloadFromTFormula::printFormula(PerformanceResult::ResultType 
   //
   if (resultPos(res) == PerformancePayloadFromTFormula::InvalidPos)  {
     cout << "Warning: result not available!" << endl;
+    return;
   }
   
   // nice, what to do here???


### PR DESCRIPTION
I first looked at this because reports of potential
thread safety problems from the static analyzer,
but a recent commit fixed those already. I added
a comment before the call to EvalPar as I spent
some time looking at it.

Also added a return statement in
PerformancePayloadFromTFormula::printFormula
when the index fails the range check instead
of trying to use it anyway.
