### PR TITLE
Open and close conditions file after TFileAdaptor is enabled

### DIFF
--- a/FWCore/Framework/bin/cmsRun.cpp
+++ b/FWCore/Framework/bin/cmsRun.cpp
@@ -23,7 +23,6 @@ PSet script.   See notes in EventProcessor.cpp for details about it.
 #include "FWCore/Utilities/interface/Presence.h"
 
 #include "TError.h"
-#include "TFile.h"
 
 #include "boost/program_options.hpp"
 #include "boost/shared_ptr.hpp"
@@ -330,11 +329,6 @@ int main(int argc, char* argv[]) {
         edm::MessageDrop::instance()->jobMode = jobMode;
       }
 
-      // FIXME: BEGIN temporary workaround for checksum problems in conditions
-      edm::FileInPath condfile("FWCore/Framework/data/cond_dump.root");
-      TFile* fptr = TFile::Open(condfile.fullPath().c_str());
-      fptr->Close();
-      // END temporary workaround for checksum problems in conditions
       context = "Constructing the EventProcessor";
       std::auto_ptr<edm::EventProcessor>
           procP(new

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -84,6 +84,9 @@
 #include <sched.h>
 #endif
 
+//FIXME: Needed for temporary workaround for checksum problem in conditions
+#include "TFile.h"
+
 namespace edm {
 
   // ---------------------------------------------------------------
@@ -456,6 +459,12 @@ namespace edm {
 
     // intialize miscellaneous items
     boost::shared_ptr<CommonParams> common(items.initMisc(*parameterSet));
+
+    // FIXME: BEGIN temporary workaround for checksum problems in conditions
+    edm::FileInPath condfile("FWCore/Framework/data/cond_dump.root");
+    TFile* fptr = TFile::Open(condfile.fullPath().c_str());
+    fptr->Close();
+    // END temporary workaround for checksum problems in conditions
 
     // intialize the event setup provider
     esp_ = espController_->makeProvider(*parameterSet);


### PR DESCRIPTION
There is a workaround already in place that opens and closes a ROOT/EDM file of conditions data at the beginning of a cmsRun job, before TFileAdaptor has been enabled.  This causes a fatal error with new ROOT6 code (not yet in the IB) that unloads plugins when TFileAdaptor is later enabled.
This fix moves the opening and closing of the conditions data file to after TFileAdaptor is enabled, thereby avioding the problem.
Please merge this promptly unless there are issues.
