### PR TITLE
code-cleaning in DataFormats/METReco

### DIFF
--- a/DataFormats/METReco/interface/CorrMETData.h
+++ b/DataFormats/METReco/interface/CorrMETData.h
@@ -18,18 +18,16 @@ struct CorrMETData
   double mey;
 
   double sumet; // to be deleted
-  double significance; // to be deleted
 
-  CorrMETData() : mex(0.0), mey(0.0), sumet(0.0), significance(0.0) { }
+  CorrMETData() : mex(0.0), mey(0.0), sumet(0.0) { }
 
-  CorrMETData(const CorrMETData& corr) : mex(corr.mex), mey(corr.mey), sumet(corr.sumet), significance(corr.significance) { }
+  CorrMETData(const CorrMETData& corr) : mex(corr.mex), mey(corr.mey), sumet(corr.sumet) { }
 
   CorrMETData& operator+=(const CorrMETData& rhs)
   {
     mex += rhs.mex;	 
     mey += rhs.mey;	 
     sumet += rhs.sumet;	 
-    significance += rhs.significance;
     return *this;
   }
 
@@ -38,7 +36,6 @@ struct CorrMETData
     mex *= rhs;
     mey *= rhs;	 
     sumet *= rhs;	 
-    significance *= rhs;
     return *this;
   }
 

--- a/DataFormats/METReco/src/classes_def.xml
+++ b/DataFormats/METReco/src/classes_def.xml
@@ -8,8 +8,9 @@
   <class name="std::vector<CommonMETData>"/> 
   <class name="edm::Wrapper<std::vector<CommonMETData> >"/> 
 
-  <class name="CorrMETData" ClassVersion="10">
+  <class name="CorrMETData" ClassVersion="11">
    <version ClassVersion="10" checksum="1727583300"/>
+   <version ClassVersion="11" checksum="1460799916"/>
   </class>
   <class name="edm::Wrapper<CorrMETData>"/> 
   <class name="std::vector<CorrMETData>"/> 


### PR DESCRIPTION
Following https://github.com/cms-sw/cmssw/pull/3314, this PR removes "significance" from "CorrMETData."
