### PR TITLE
added AVE_10 and AVE_20 13 TeV pu scenarios

### DIFF
--- a/Configuration/StandardSequences/python/Mixing.py
+++ b/Configuration/StandardSequences/python/Mixing.py
@@ -110,6 +110,8 @@ addMixingScenario("FS_2012_Summer_inTimeOnly",{'file': 'FastSimulation.PileUpPro
 addMixingScenario("FS_mix_2012_Startup_inTimeOnly",{'file': 'FastSimulation.PileUpProducer.mix_2012_Startup_inTimeOnly_cff'})
 addMixingScenario("FS_mix_2012_Summer_inTimeOnly",{'file': 'FastSimulation.PileUpProducer.mix_2012_Summer_inTimeOnly_cff'})
 addMixingScenario("FS_CSA14_inTimeOnly",{'file': 'FastSimulation.PileUpProducer.PileUpSimulator_CSA14_inTimeOnly_cff'})
+addMixingScenario("FS_E13TeV_AVE_10_inTimeOnly",{'file': 'FastSimulation.PileUpProducer.PileUpSimulator_E13TeV_AVE_10_inTimeOnly_cff'})
+addMixingScenario("FS_E13TeV_AVE_20_inTimeOnly",{'file': 'FastSimulation.PileUpProducer.PileUpSimulator_E13TeV_AVE_20_inTimeOnly_cff'})
 
 #scenarios for L1 tdr work
 addMixingScenario("AVE_10_BX_25ns",{'file': 'SimGeneral.MixingModule.mix_POISSON_average_cfi','BX':25, 'B': (-12,3), 'N': 10})

--- a/FastSimulation/PileUpProducer/python/PileUpSimulator_E13TeV_AVE_10_inTimeOnly_cff.py
+++ b/FastSimulation/PileUpProducer/python/PileUpSimulator_E13TeV_AVE_10_inTimeOnly_cff.py
@@ -1,0 +1,8 @@
+from FastSimulation.PileUpProducer.PileUpSimulator13TeV_cfi import PileUpSimulatorBlock as _block13TeV
+from FastSimulation.Configuration.MixingFamos_cff import *
+
+#define the PU scenario itself
+famosPileUp.PileUpSimulator = _block13TeV.PileUpSimulator
+famosPileUp.PileUpSimulator.usePoisson = True
+famosPileUp.PileUpSimulator.averageNumber = 10
+

--- a/FastSimulation/PileUpProducer/python/PileUpSimulator_E13TeV_AVE_20_inTimeOnly_cff.py
+++ b/FastSimulation/PileUpProducer/python/PileUpSimulator_E13TeV_AVE_20_inTimeOnly_cff.py
@@ -1,0 +1,8 @@
+from FastSimulation.PileUpProducer.PileUpSimulator13TeV_cfi import PileUpSimulatorBlock as _block13TeV
+from FastSimulation.Configuration.MixingFamos_cff import *
+
+#define the PU scenario itself
+famosPileUp.PileUpSimulator = _block13TeV.PileUpSimulator
+famosPileUp.PileUpSimulator.usePoisson = True
+famosPileUp.PileUpSimulator.averageNumber = 20
+


### PR DESCRIPTION
added AVE_10 and AVE_20 13 TeV pu scenarios for FastSim
both scenarios tested with 100 events, checked true and observed number of pu interactions.
