### PR TITLE
Fixed division by zero possibility

### DIFF
--- a/FastSimulation/Muons/plugins/EmulatedME0SegmentProducer.cc
+++ b/FastSimulation/Muons/plugins/EmulatedME0SegmentProducer.cc
@@ -67,6 +67,8 @@ void EmulatedME0SegmentProducer::produce(edm::Event& ev, const edm::EventSetup& 
       if ( (CurrentParticle.status()==1) && ( (CurrentParticle.pdgId()==13)  || (CurrentParticle.pdgId()==-13) ) ){  
 
 	//Setup
+	if (CurrentParticle.pz()==0) continue;
+
 	float zSign  = CurrentParticle.pz()/fabs(CurrentParticle.pz());
 
 	float zValue = 560. * zSign;


### PR DESCRIPTION
Did not account for possibility of precisely 0 pz momentum muons.  Division by 0 is now protected against and Emulated ME0Segments are not produced in the case that the gen particle has pz == 0.  
