### PR TITLE
track cluster splitting ported from 5X to 71X and SLC6 (recommit #2961)

### DIFF
--- a/RecoLocalTracker/SubCollectionProducers/python/splitter_tracking_RunI_setup_cff.py
+++ b/RecoLocalTracker/SubCollectionProducers/python/splitter_tracking_RunI_setup_cff.py
@@ -1,0 +1,142 @@
+import FWCore.ParameterSet.Config as cms
+from RecoLocalTracker.SubCollectionProducers.SeedClusterRemover_cfi import *
+from RecoTracker.IterativeTracking.ElectronSeeds_cff  import *
+from RecoTracker.MeasurementDet.MeasurementTrackerESProducer_cfi import *
+from RecoTracker.MeasurementDet.MeasurementTrackerEventProducer_cfi import *#new in 700pre8
+from RecoTracker.IterativeTracking.RunI_InitialStep_cff import *
+from RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi import *
+from RecoTracker.IterativeTracking.RunI_MixedTripletStep_cff import *
+from RecoTracker.IterativeTracking.RunI_LowPtTripletStep_cff import *
+from RecoTracker.IterativeTracking.RunI_PixelPairStep_cff import *
+from RecoTracker.IterativeTracking.RunI_DetachedTripletStep_cff import *
+from RecoTracker.IterativeTracking.RunI_PixelLessStep_cff import *
+from RecoTracker.IterativeTracking.RunI_TobTecStep_cff import *
+from RecoTracker.ConversionSeedGenerators.ConversionStep_cff import *
+
+def customizeTracking(newpixclusters, newstripclusters, newpixrechits, newstriprechits):
+
+    seedClusterRemover.stripClusters = newstripclusters
+    seedClusterRemover.pixelClusters = newpixelclusters
+
+
+    initialStepSeedClusterMask.stripClusters = newstripclusters
+    initialStepSeedClusterMask.pixelClusters = newpixelclusters
+
+    pixelPairStepSeedClusterMask.stripClusters  = newstripclusters
+    pixelPairStepSeedClusterMask.pixelClusters = newpixelclusters
+    
+    mixedTripletStepSeedClusterMask.stripClusters  = newstripclusters
+    mixedTripletStepSeedClusterMask.pixelClusters  = newpixelclusters
+    
+    pixelLessStepSeedClusterMask.stripClusters  = newstripclusters
+    pixelLessStepSeedClusterMask.pixelClusters  = newpixelclusters
+
+    tripletElectronClusterMask.stripClusters  =newstripclusters
+    tripletElectronClusterMask.pixelClusters = newpixelclusters
+    
+    tripletElectronSeedLayers.BPix.HitProducer = newpixrechits
+    tripletElectronSeedLayers.FPix.HitProducer = newpixrechits
+
+    pixelPairElectronSeedLayers.BPix.HitProducer = newpixrechits
+    pixelPairElectronSeedLayers.FPix.HitProducer = newpixrechits
+    
+    stripPairElectronSeedLayers.TIB.matchedRecHits = cms.InputTag(newstriprechits,"matchedRecHit")
+    stripPairElectronSeedLayers.TID.matchedRecHits = cms.InputTag(newstriprechits,"matchedRecHit")
+    stripPairElectronSeedLayers.TEC.matchedRecHits = cms.InputTag(newstriprechits,"matchedRecHit")
+
+    
+    MeasurementTracker.pixelClusterProducer = newpixelclusters
+    MeasurementTracker.stripClusterProducer = newstripclusters
+
+    MeasurementTrackerEvent.pixelClusterProducer =newpixelclusters
+    MeasurementTrackerEvent.stripClusterProducer =newstripclusters
+    
+
+    initialStepSeedLayers.BPix.HitProducer = newpixrechits
+    initialStepSeedLayers.FPix.HitProducer = newpixrechits
+    
+    initialStepSeeds.ClusterCheckPSet.PixelClusterCollectionLabel = newpixelclusters
+    initialStepSeeds.ClusterCheckPSet.ClusterCollectionLabel      = newstripclusters
+    
+
+    lowPtTripletStepClusters.pixelClusters = newpixelclusters
+    lowPtTripletStepClusters.stripClusters = newstripclusters
+    lowPtTripletStepSeedLayers.BPix.HitProducer = newpixrechits
+    lowPtTripletStepSeedLayers.FPix.HitProducer = newpixrechits
+    lowPtTripletStepSeeds.ClusterCheckPSet.PixelClusterCollectionLabel = newpixelclusters
+    lowPtTripletStepSeeds.ClusterCheckPSet.ClusterCollectionLabel      = newstripclusters
+
+    pixelPairStepClusters.pixelClusters = newpixclusters
+    pixelPairStepClusters.stripClusters = newstripclusters
+    pixelPairStepSeedLayers.BPix.HitProducer =newpixrechits
+    pixelPairStepSeedLayers.FPix.HitProducer =newpixrechits
+    pixelPairStepSeeds.ClusterCheckPSet.PixelClusterCollectionLabel = newpixclusters
+    pixelPairStepSeeds.ClusterCheckPSet.ClusterCollectionLabel      = newstripclusters
+
+    detachedTripletStepClusters.pixelClusters = newpixclusters
+    detachedTripletStepClusters.stripClusters = newstripclusters
+    detachedTripletStepSeedLayers.BPix.HitProducer =newpixrechits
+    detachedTripletStepSeedLayers.FPix.HitProducer =newpixrechits
+    detachedTripletStepSeeds.ClusterCheckPSet.PixelClusterCollectionLabel = newpixclusters
+    detachedTripletStepSeeds.ClusterCheckPSet.ClusterCollectionLabel      = newstripclusters
+    detachedTripletStepClusters.stripRecHits =newstriprechits
+
+    mixedTripletStepClusters.pixelClusters = newpixclusters
+    mixedTripletStepClusters.stripClusters = newstripclusters
+    mixedTripletStepSeedLayersA.BPix.HitProducer =newpixrechits
+    mixedTripletStepSeedLayersA.FPix.HitProducer =newpixrechits
+    mixedTripletStepSeedLayersB.BPix.HitProducer =newpixrechits
+    mixedTripletStepSeedsA.ClusterCheckPSet.PixelClusterCollectionLabel = newpixclusters
+    mixedTripletStepSeedsA.ClusterCheckPSet.ClusterCollectionLabel      = newstripclusters
+    mixedTripletStepSeedsB.ClusterCheckPSet.PixelClusterCollectionLabel = newpixclusters
+    mixedTripletStepSeedsB.ClusterCheckPSet.ClusterCollectionLabel      = newstripclusters
+ 
+
+    pixelLessStepClusters.pixelClusters = newpixclusters
+    pixelLessStepClusters.stripClusters = newstripclusters
+
+    pixelLessStepSeeds.ClusterCheckPSet.PixelClusterCollectionLabel = newpixclusters
+    pixelLessStepSeeds.ClusterCheckPSet.ClusterCollectionLabel      = newstripclusters
+
+    tobTecStepClusters.pixelClusters = newpixclusters
+    tobTecStepClusters.stripClusters = newstripclusters
+    tobTecStepSeeds.ClusterCheckPSet.PixelClusterCollectionLabel = newpixclusters
+    tobTecStepSeeds.ClusterCheckPSet.ClusterCollectionLabel      = newstripclusters
+    mixedTripletStepSeedLayersA.TEC.matchedRecHits = cms.InputTag(newstriprechits,"matchedRecHit")
+    mixedTripletStepSeedLayersB.TIB.matchedRecHits = cms.InputTag(newstriprechits,"matchedRecHit")
+
+    pixelLessStepSeedLayers.TIB.matchedRecHits = cms.InputTag(newstriprechits,"matchedRecHit")
+    pixelLessStepSeedLayers.TID.matchedRecHits = cms.InputTag(newstriprechits,"matchedRecHit")
+    pixelLessStepSeedLayers.TEC.matchedRecHits = cms.InputTag(newstriprechits,"matchedRecHit")
+    tobTecStepSeedLayers.TOB.matchedRecHits = cms.InputTag(newstriprechits,"matchedRecHit")
+    tobTecStepSeedLayers.TEC.matchedRecHits = cms.InputTag(newstriprechits,"matchedRecHit")
+
+
+    photonConvTrajSeedFromSingleLeg.ClusterCheckPSet.PixelClusterCollectionLabel = newpixclusters
+    photonConvTrajSeedFromSingleLeg.ClusterCheckPSet.ClusterCollectionLabel      = newstripclusters
+    convClusters.pixelClusters =newpixclusters 
+    convClusters.stripClusters =newstripclusters
+    convLayerPairs.BPix.HitProducer = newpixelrechits
+    convLayerPairs.FPix.HitProducer = newpixelrechits
+    convLayerPairs.TIB1.matchedRecHits = cms.InputTag(newstriprechits,"matchedRecHit")
+    convLayerPairs.TIB2.matchedRecHits = cms.InputTag(newstriprechits,"matchedRecHit")
+    convLayerPairs.TIB3.rphiRecHits = cms.InputTag(newstriprechits,"rphiRecHit")
+    convLayerPairs.TIB4.rphiRecHits = cms.InputTag(newstriprechits,"rphiRecHit")
+    convLayerPairs.TID1.matchedRecHits = cms.InputTag(newstriprechits,"matchedRecHit")
+    convLayerPairs.TID1.stereoRecHits = cms.InputTag(newstriprechits,"stereoRecHitUnmatched")
+    convLayerPairs.TID1.rphiRecHits = cms.InputTag(newstriprechits,"rphiRecHitUnmatched")
+    convLayerPairs.TID2.matchedRecHits = cms.InputTag(newstriprechits,"matchedRecHit")
+    convLayerPairs.TID2.stereoRecHits = cms.InputTag(newstriprechits,"stereoRecHitUnmatched")
+    convLayerPairs.TID2.rphiRecHits = cms.InputTag(newstriprechits,"rphiRecHitUnmatched")
+    convLayerPairs.TID3.matchedRecHits = cms.InputTag(newstriprechits,"matchedRecHit")
+    convLayerPairs.TID3.stereoRecHits = cms.InputTag(newstriprechits,"stereoRecHitUnmatched")
+    convLayerPairs.TID3.rphiRecHits = cms.InputTag(newstriprechits,"rphiRecHitUnmatched")
+    convLayerPairs.TEC.matchedRecHits = cms.InputTag(newstriprechits,"matchedRecHit")
+    convLayerPairs.TEC.stereoRecHits = cms.InputTag(newstriprechits,"stereoRecHitUnmatched")
+    convLayerPairs.TEC.rphiRecHits = cms.InputTag(newstriprechits,"rphiRecHitUnmatched")
+    convLayerPairs.TOB1.matchedRecHits = cms.InputTag(newstriprechits,"matchedRecHit")
+    convLayerPairs.TOB2.matchedRecHits = cms.InputTag(newstriprechits,"matchedRecHit")
+    convLayerPairs.TOB3.rphiRecHits = cms.InputTag(newstriprechits,"rphiRecHit")
+    convLayerPairs.TOB4.rphiRecHits = cms.InputTag(newstriprechits,"rphiRecHit")
+    convLayerPairs.TOB5.rphiRecHits = cms.InputTag(newstriprechits,"rphiRecHit")
+    convLayerPairs.TOB6.rphiRecHits = cms.InputTag(newstriprechits,"rphiRecHit")

--- a/RecoLocalTracker/SubCollectionProducers/python/splitter_tracking_setup_cff.py
+++ b/RecoLocalTracker/SubCollectionProducers/python/splitter_tracking_setup_cff.py
@@ -1,144 +1,163 @@
+import FWCore.ParameterSet.Config as cms
 from RecoLocalTracker.SubCollectionProducers.SeedClusterRemover_cfi import *
-
-seedClusterRemover.stripClusters = 'splitClusters'
-seedClusterRemover.pixelClusters = 'splitClusters'
-
-from RecoTracker.IterativeTracking.ElectronSeeds_cff  import *
-initialStepSeedClusterMask.stripClusters = 'splitClusters'
-initialStepSeedClusterMask.pixelClusters = 'splitClusters'
-
-pixelPairStepSeedClusterMask.stripClusters  = 'splitClusters'
-pixelPairStepSeedClusterMask.pixelClusters = 'splitClusters'
-
-mixedTripletStepSeedClusterMask.stripClusters  = 'splitClusters'
-mixedTripletStepSeedClusterMask.pixelClusters = 'splitClusters'
-
-pixelLessStepSeedClusterMask.stripClusters  = 'splitClusters'
-pixelLessStepSeedClusterMask.pixelClusters = 'splitClusters'
-
-tripletElectronClusterMask.stripClusters  = 'splitClusters'
-tripletElectronClusterMask.pixelClusters = 'splitClusters'
-
-tripletElectronSeedLayers.BPix.HitProducer = 'mySiPixelRecHits'
-tripletElectronSeedLayers.FPix.HitProducer = 'mySiPixelRecHits'
-
-pixelPairElectronSeedLayers.BPix.HitProducer = 'mySiPixelRecHits'
-pixelPairElectronSeedLayers.FPix.HitProducer = 'mySiPixelRecHits'
-
-stripPairElectronSeedLayers.TIB.matchedRecHits = cms.InputTag("mySiStripRecHits","matchedRecHit")
-stripPairElectronSeedLayers.TID.matchedRecHits = cms.InputTag("mySiStripRecHits","matchedRecHit")
-stripPairElectronSeedLayers.TEC.matchedRecHits = cms.InputTag("mySiStripRecHits","matchedRecHit")
-
-from RecoTracker.MeasurementDet.MeasurementTrackerESProducer_cfi import *
-MeasurementTracker.pixelClusterProducer = cms.string('splitClusters')
-MeasurementTracker.stripClusterProducer = cms.string('splitClusters')
-from RecoTracker.MeasurementDet.MeasurementTrackerEventProducer_cfi import *#new in 700pre8
-MeasurementTrackerEvent.pixelClusterProducer = cms.string('splitClusters')
-MeasurementTrackerEvent.stripClusterProducer = cms.string('splitClusters')
-
-
 from RecoTracker.IterativeTracking.InitialStep_cff import *
-import RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi
-initialStepSeedLayers = RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi.PixelLayerTriplets.clone()
-
-initialStepSeedLayers.BPix.HitProducer = 'mySiPixelRecHits'
-initialStepSeedLayers.FPix.HitProducer = 'mySiPixelRecHits'
-
-initialStepSeeds.ClusterCheckPSet.PixelClusterCollectionLabel = 'splitClusters'
-initialStepSeeds.ClusterCheckPSet.ClusterCollectionLabel      = 'splitClusters'
-
-initialStepSeeds.OrderedHitsFactoryPSet.SeedingLayers = 'initialStepSeedLayers'
+from RecoTracker.IterativeTracking.ElectronSeeds_cff  import *
 from RecoTracker.IterativeTracking.LowPtTripletStep_cff import *
-lowPtTripletStepClusters.pixelClusters = 'splitClusters'
-lowPtTripletStepClusters.stripClusters = 'splitClusters'
-lowPtTripletStepSeedLayers.BPix.HitProducer = 'mySiPixelRecHits'
-lowPtTripletStepSeedLayers.FPix.HitProducer = 'mySiPixelRecHits'
-lowPtTripletStepSeeds.ClusterCheckPSet.PixelClusterCollectionLabel = 'splitClusters'
-lowPtTripletStepSeeds.ClusterCheckPSet.ClusterCollectionLabel      = 'splitClusters'
-
 from RecoTracker.IterativeTracking.PixelPairStep_cff import *
-pixelPairStepClusters.pixelClusters = 'splitClusters'
-pixelPairStepClusters.stripClusters = 'splitClusters'
-pixelPairStepSeedLayers.BPix.HitProducer = 'mySiPixelRecHits'
-pixelPairStepSeedLayers.FPix.HitProducer = 'mySiPixelRecHits'
-
-pixelPairStepSeeds.ClusterCheckPSet.PixelClusterCollectionLabel = 'splitClusters'
-pixelPairStepSeeds.ClusterCheckPSet.ClusterCollectionLabel      = 'splitClusters'
 from RecoTracker.IterativeTracking.DetachedTripletStep_cff import *
-detachedTripletStepClusters.pixelClusters = 'splitClusters'
-detachedTripletStepClusters.stripClusters = 'splitClusters'
-detachedTripletStepSeedLayers.BPix.HitProducer = 'mySiPixelRecHits'
-detachedTripletStepSeedLayers.FPix.HitProducer = 'mySiPixelRecHits'
-detachedTripletStepSeeds.ClusterCheckPSet.PixelClusterCollectionLabel = 'splitClusters'
-detachedTripletStepSeeds.ClusterCheckPSet.ClusterCollectionLabel      = 'splitClusters'
-
-from RecoTracker.IterativeTracking.MixedTripletStep_cff import *
-
-mixedTripletStepClusters.pixelClusters = 'splitClusters'
-mixedTripletStepClusters.stripClusters = 'splitClusters'
-
-mixedTripletStepSeedLayersA.BPix.HitProducer = 'mySiPixelRecHits'
-mixedTripletStepSeedLayersA.FPix.HitProducer = 'mySiPixelRecHits'
-mixedTripletStepSeedLayersB.BPix.HitProducer = 'mySiPixelRecHits'
-
-mixedTripletStepSeedsA.ClusterCheckPSet.PixelClusterCollectionLabel = 'splitClusters'
-mixedTripletStepSeedsA.ClusterCheckPSet.ClusterCollectionLabel      = 'splitClusters'
-mixedTripletStepSeedsB.ClusterCheckPSet.PixelClusterCollectionLabel = 'splitClusters'
-mixedTripletStepSeedsB.ClusterCheckPSet.ClusterCollectionLabel      = 'splitClusters'
-
-
-
-from RecoTracker.IterativeTracking.PixelLessStep_cff import *
-pixelLessStepClusters.pixelClusters = 'splitClusters'
-pixelLessStepClusters.stripClusters = 'splitClusters'
-
-pixelLessStepSeeds.ClusterCheckPSet.PixelClusterCollectionLabel = 'splitClusters'
-pixelLessStepSeeds.ClusterCheckPSet.ClusterCollectionLabel      = 'splitClusters'
-
 from RecoTracker.IterativeTracking.TobTecStep_cff import *
-tobTecStepClusters.pixelClusters = 'splitClusters'
-tobTecStepClusters.stripClusters = 'splitClusters'
-tobTecStepSeeds.ClusterCheckPSet.PixelClusterCollectionLabel = 'splitClusters'
-tobTecStepSeeds.ClusterCheckPSet.ClusterCollectionLabel      = 'splitClusters'
-mixedTripletStepSeedLayersA.TEC.matchedRecHits = cms.InputTag("mySiStripRecHits","matchedRecHit")
-mixedTripletStepSeedLayersB.TIB.matchedRecHits = cms.InputTag("mySiStripRecHits","matchedRecHit")
-
-pixelLessStepSeedLayers.TIB.matchedRecHits = cms.InputTag("mySiStripRecHits","matchedRecHit")
-pixelLessStepSeedLayers.TID.matchedRecHits = cms.InputTag("mySiStripRecHits","matchedRecHit")
-pixelLessStepSeedLayers.TEC.matchedRecHits = cms.InputTag("mySiStripRecHits","matchedRecHit")
-tobTecStepSeedLayers.TOB.matchedRecHits = cms.InputTag("mySiStripRecHits","matchedRecHit")
-tobTecStepSeedLayers.TEC.matchedRecHits = cms.InputTag("mySiStripRecHits","matchedRecHit")
-
+from RecoTracker.IterativeTracking.MixedTripletStep_cff import *
+from RecoTracker.MeasurementDet.MeasurementTrackerEventProducer_cfi import *#new in 700pre8
+from RecoTracker.IterativeTracking.PixelLessStep_cff import *
+from  RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff import *
 from RecoTracker.ConversionSeedGenerators.ConversionStep_cff import *
-photonConvTrajSeedFromSingleLeg.ClusterCheckPSet.PixelClusterCollectionLabel = 'splitClusters'
-photonConvTrajSeedFromSingleLeg.ClusterCheckPSet.ClusterCollectionLabel      = 'splitClusters'
-convClusters.pixelClusters = 'splitClusters'
-convClusters.stripClusters = 'splitClusters'
-convLayerPairs.BPix.HitProducer = 'mySiPixelRecHits'
-convLayerPairs.FPix.HitProducer = 'mySiPixelRecHits'
-convLayerPairs.TIB1.matchedRecHits = cms.InputTag("mySiStripRecHits","matchedRecHit")
-convLayerPairs.TIB2.matchedRecHits = cms.InputTag("mySiStripRecHits","matchedRecHit")
-convLayerPairs.TIB3.rphiRecHits = cms.InputTag("mySiStripRecHits","rphiRecHit")
-convLayerPairs.TIB4.rphiRecHits = cms.InputTag("mySiStripRecHits","rphiRecHit")
-convLayerPairs.TID1.matchedRecHits = cms.InputTag("mySiStripRecHits","matchedRecHit")
-convLayerPairs.TID1.stereoRecHits = cms.InputTag("mySiStripRecHits","stereoRecHitUnmatched")
-convLayerPairs.TID1.rphiRecHits = cms.InputTag("mySiStripRecHits","rphiRecHitUnmatched")
-convLayerPairs.TID2.matchedRecHits = cms.InputTag("mySiStripRecHits","matchedRecHit")
-convLayerPairs.TID2.stereoRecHits = cms.InputTag("mySiStripRecHits","stereoRecHitUnmatched")
-convLayerPairs.TID2.rphiRecHits = cms.InputTag("mySiStripRecHits","rphiRecHitUnmatched")
-convLayerPairs.TID3.matchedRecHits = cms.InputTag("mySiStripRecHits","matchedRecHit")
-convLayerPairs.TID3.stereoRecHits = cms.InputTag("mySiStripRecHits","stereoRecHitUnmatched")
-convLayerPairs.TID3.rphiRecHits = cms.InputTag("mySiStripRecHits","rphiRecHitUnmatched")
-convLayerPairs.TEC.matchedRecHits = cms.InputTag("mySiStripRecHits","matchedRecHit")
-convLayerPairs.TEC.stereoRecHits = cms.InputTag("mySiStripRecHits","stereoRecHitUnmatched")
-convLayerPairs.TEC.rphiRecHits = cms.InputTag("mySiStripRecHits","rphiRecHitUnmatched")
-convLayerPairs.TOB1.matchedRecHits = cms.InputTag("mySiStripRecHits","matchedRecHit")
-convLayerPairs.TOB2.matchedRecHits = cms.InputTag("mySiStripRecHits","matchedRecHit")
-convLayerPairs.TOB3.rphiRecHits = cms.InputTag("mySiStripRecHits","rphiRecHit")
-convLayerPairs.TOB4.rphiRecHits = cms.InputTag("mySiStripRecHits","rphiRecHit")
-convLayerPairs.TOB5.rphiRecHits = cms.InputTag("mySiStripRecHits","rphiRecHit")
-convLayerPairs.TOB6.rphiRecHits = cms.InputTag("mySiStripRecHits","rphiRecHit")
 
-from RecoLocalCalo.HcalRecProducers.HBHEIsolatedNoiseReflagger_cfi import *
-hbhereco.hbheInput= cms.InputTag("hbheprereco::SPLIT")
 
+def customizeTracking(newpixclusters, newstripclusters, newpixrechits, newstriprechits):
+
+    matchedsplitSiStripRecHits = cms.InputTag(newstriprechits,"matchedRecHit"), 
+    matchedsplitSiPixelRecHits = cms.InputTag(newpixrechits,"matchedRecHit"), 
+    rphisplitSiStripRecHits = cms.InputTag(newstriprechits,"rphiRecHit"), 
+    stereosplitSiStripRecHits = cms.InputTag(newpixrechits,"stereoRecHit"), 
+    
+    seedClusterRemover.stripClusters = newstripclusters
+    seedClusterRemover.pixelClusters = newpixclusters
+
+
+
+    initialStepSeedLayers.BPix.HitProducer =newpixrechits
+    initialStepSeedLayers.FPix.HitProducer =newpixrechits
+    initialStepClusters.pixelClusters = newpixclusters
+    initialStepClusters.stripClusters = newstripclusters
+    initialStepClusters.stripRecHits  =newstriprechits
+    initialStepSeeds.ClusterCheckPSet.PixelClusterCollectionLabel = newpixclusters
+    initialStepSeeds.ClusterCheckPSet.ClusterCollectionLabel      = newstripclusters
+    #initialStepSeeds.OrderedHitsFactoryPSet.SeedingLayers = 'initialStepSeedLayers'
+
+    initialStepSeedClusterMask.stripClusters = newstripclusters
+    initialStepSeedClusterMask.pixelClusters = newpixclusters
+    
+    pixelPairStepSeedClusterMask.stripClusters  = newstripclusters
+    pixelPairStepSeedClusterMask.pixelClusters = newpixclusters
+    
+    mixedTripletStepSeedClusterMask.stripClusters  = newstripclusters
+    mixedTripletStepSeedClusterMask.pixelClusters = newpixclusters
+
+    
+    tripletElectronClusterMask.stripClusters  = newstripclusters
+    tripletElectronClusterMask.pixelClusters = newpixclusters
+
+    tripletElectronSeedLayers.BPix.HitProducer =newpixrechits
+    tripletElectronSeedLayers.FPix.HitProducer =newpixrechits
+    
+    pixelPairElectronSeedLayers.BPix.HitProducer =newpixrechits
+    pixelPairElectronSeedLayers.FPix.HitProducer =newpixrechits
+    
+    stripPairElectronSeedLayers.TIB.matchedRecHits = cms.InputTag(newstriprechits,"matchedRecHit")
+    stripPairElectronSeedLayers.TID.matchedRecHits = cms.InputTag(newstriprechits,"matchedRecHit")	
+    stripPairElectronSeedLayers.TEC.matchedRecHits = cms.InputTag(newstriprechits,"matchedRecHit")
+
+
+
+    lowPtTripletStepClusters.pixelClusters = newpixclusters
+    lowPtTripletStepClusters.stripClusters = newstripclusters
+    lowPtTripletStepSeedLayers.BPix.HitProducer =newpixrechits
+    lowPtTripletStepSeedLayers.FPix.HitProducer =newpixrechits
+    lowPtTripletStepSeeds.ClusterCheckPSet.PixelClusterCollectionLabel = newpixclusters
+    lowPtTripletStepSeeds.ClusterCheckPSet.ClusterCollectionLabel      = newstripclusters
+    
+
+    pixelPairStepClusters.pixelClusters = newpixclusters
+    pixelPairStepClusters.stripClusters = newstripclusters
+    pixelPairStepSeedLayers.BPix.HitProducer =newpixrechits
+    pixelPairStepSeedLayers.FPix.HitProducer =newpixrechits
+    pixelPairStepSeeds.ClusterCheckPSet.PixelClusterCollectionLabel = newpixclusters
+    pixelPairStepSeeds.ClusterCheckPSet.ClusterCollectionLabel      = newstripclusters
+
+    detachedTripletStepClusters.pixelClusters = newpixclusters
+    detachedTripletStepClusters.stripClusters = newstripclusters
+    detachedTripletStepSeedLayers.BPix.HitProducer =newpixrechits
+    detachedTripletStepSeedLayers.FPix.HitProducer =newpixrechits
+    detachedTripletStepSeeds.ClusterCheckPSet.PixelClusterCollectionLabel = newpixclusters
+    detachedTripletStepSeeds.ClusterCheckPSet.ClusterCollectionLabel      = newstripclusters
+    detachedTripletStepClusters.stripRecHits =newstriprechits
+
+    mixedTripletStepClusters.pixelClusters = newpixclusters
+    mixedTripletStepClusters.stripClusters = newstripclusters
+    mixedTripletStepSeedLayersA.BPix.HitProducer =newpixrechits
+    mixedTripletStepSeedLayersA.FPix.HitProducer =newpixrechits
+    mixedTripletStepSeedLayersB.BPix.HitProducer =newpixrechits
+    mixedTripletStepSeedsA.ClusterCheckPSet.PixelClusterCollectionLabel = newpixclusters
+    mixedTripletStepSeedsA.ClusterCheckPSet.ClusterCollectionLabel      = newstripclusters
+    mixedTripletStepSeedsB.ClusterCheckPSet.PixelClusterCollectionLabel = newpixclusters
+    mixedTripletStepSeedsB.ClusterCheckPSet.ClusterCollectionLabel      = newstripclusters
+    mixedTripletStepSeedLayersA.TEC.matchedRecHits = cms.InputTag(newstriprechits,"matchedRecHit")
+    mixedTripletStepSeedLayersB.TIB.matchedRecHits = cms.InputTag(newstriprechits,"matchedRecHit")
+
+
+
+    pixelLessStepSeedClusterMask.stripClusters  = newstripclusters
+    pixelLessStepSeedClusterMask.pixelClusters = newpixclusters
+    pixelLessStepClusters.pixelClusters = newpixclusters
+    pixelLessStepClusters.stripClusters = newstripclusters
+    pixelLessStepSeeds.ClusterCheckPSet.PixelClusterCollectionLabel = newpixclusters
+    pixelLessStepSeeds.ClusterCheckPSet.ClusterCollectionLabel      = newstripclusters
+    pixelLessStepSeedClusters.stripRecHits = newstriprechits
+    pixelLessStepSeedClusters.pixelClusters = newpixclusters
+    pixelLessStepSeedClusters.stripClusters = newstripclusters
+    pixelLessStepSeedLayers.MTIB.rphiRecHits = cms.InputTag(newstriprechits,"rphiRecHit")
+    pixelLessStepSeedLayers.MTID.rphiRecHits = cms.InputTag(newstriprechits,"rphiRecHit")
+    pixelLessStepSeedLayers.MTEC.rphiRecHits = cms.InputTag(newstriprechits,"rphiRecHit")
+    
+    pixelLessStepSeedLayers.TIB.matchedRecHits = cms.InputTag(newstriprechits,"matchedRecHit")
+    pixelLessStepSeedLayers.TID.matchedRecHits = cms.InputTag(newstriprechits,"matchedRecHit")
+    pixelLessStepSeedLayers.TEC.matchedRecHits = cms.InputTag(newstriprechits,"matchedRecHit")
+    
+    tobTecStepClusters.pixelClusters = newpixclusters
+    tobTecStepClusters.stripClusters = newstripclusters
+    tobTecStepSeedClusters.pixelClusters = newpixclusters
+    tobTecStepSeedClusters.stripClusters = newstripclusters
+    tobTecStepSeedClusters.stripRecHits =newstriprechits
+    tobTecStepSeedLayersPair.TOB.matchedRecHits  = cms.InputTag(newstriprechits,"matchedRecHit")
+    tobTecStepSeedLayersPair.TEC.matchedRecHits  = cms.InputTag(newstriprechits,"matchedRecHit")
+    tobTecStepSeedLayersTripl.TOB.matchedRecHits = cms.InputTag(newstriprechits,"matchedRecHit")
+    tobTecStepSeedLayersTripl.MTOB.rphiRecHits   = cms.InputTag(newstriprechits,"rphiRecHit")
+    tobTecStepSeedLayersTripl.MTEC.rphiRecHits   = cms.InputTag(newstriprechits,"rphiRecHit")
+
+
+    MeasurementTrackerEvent.pixelClusterProducer = newpixclusters
+    MeasurementTrackerEvent.stripClusterProducer = newstripclusters
+
+    globalSeedsFromTriplets.ClusterCheckPSet.ClusterCollectionLabel=newstripclusters
+    globalSeedsFromTriplets.ClusterCheckPSet.PixelClusterCollectionLabel=newpixclusters
+
+
+
+    photonConvTrajSeedFromSingleLeg.ClusterCheckPSet.PixelClusterCollectionLabel = newpixclusters
+    photonConvTrajSeedFromSingleLeg.ClusterCheckPSet.ClusterCollectionLabel      = newstripclusters
+    convClusters.pixelClusters = newpixclusters
+    convClusters.stripClusters = newstripclusters
+    convLayerPairs.BPix.HitProducer =newpixrechits
+    convLayerPairs.FPix.HitProducer =newpixrechits
+    convLayerPairs.TIB1.matchedRecHits = cms.InputTag(newstriprechits,"matchedRecHit")
+    convLayerPairs.TIB2.matchedRecHits = cms.InputTag(newstriprechits,"matchedRecHit")
+    convLayerPairs.TID1.matchedRecHits = cms.InputTag(newstriprechits,"matchedRecHit")
+    convLayerPairs.TID2.matchedRecHits = cms.InputTag(newstriprechits,"matchedRecHit")
+    convLayerPairs.TID3.matchedRecHits = cms.InputTag(newstriprechits,"matchedRecHit")
+    convLayerPairs.TEC.matchedRecHits  = cms.InputTag(newstriprechits,"matchedRecHit")
+    convLayerPairs.TOB1.matchedRecHits = cms.InputTag(newstriprechits,"matchedRecHit")
+    convLayerPairs.TOB2.matchedRecHits = cms.InputTag(newstriprechits,"matchedRecHit")
+    convLayerPairs.TIB3.rphiRecHits = cms.InputTag(newstriprechits,"rphiRecHit")
+    convLayerPairs.TIB4.rphiRecHits = cms.InputTag(newstriprechits,"rphiRecHit")
+    convLayerPairs.TID1.rphiRecHits = cms.InputTag(newstriprechits,"rphiRecHit")
+    convLayerPairs.TID2.rphiRecHits = cms.InputTag(newstriprechits,"rphiRecHit")
+    convLayerPairs.TID3.rphiRecHits = cms.InputTag(newstriprechits,"rphiRecHit")
+    convLayerPairs.TEC.rphiRecHits  = cms.InputTag(newstriprechits,"rphiRecHit")
+    convLayerPairs.TOB3.rphiRecHits = cms.InputTag(newstriprechits,"rphiRecHit")
+    convLayerPairs.TOB4.rphiRecHits = cms.InputTag(newstriprechits,"rphiRecHit")
+    convLayerPairs.TOB5.rphiRecHits = cms.InputTag(newstriprechits,"rphiRecHit")
+    convLayerPairs.TOB6.rphiRecHits = cms.InputTag(newstriprechits,"rstrophiRecHit")
+    convLayerPairs.TID1.stereoRecHits = cms.InputTag(newstriprechits,"stereoRecHit")
+    convLayerPairs.TID2.stereoRecHits = cms.InputTag(newstriprechits,"stereoRecHit")
+    convLayerPairs.TID3.stereoRecHits = cms.InputTag(newstriprechits,"stereoRecHit")
+    convLayerPairs.TEC.stereoRecHits  = cms.InputTag(newstriprechits,"stereoRecHit")

--- a/RecoLocalTracker/SubCollectionProducers/test/run_simsplit_runI.py
+++ b/RecoLocalTracker/SubCollectionProducers/test/run_simsplit_runI.py
@@ -20,14 +20,24 @@ process.load('Configuration/StandardSequences/DigiToRaw_cff')
 process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
 
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(100)
+    input = cms.untracked.int32(10)
 )
-process.MessageLogger.cerr.FwkReport.reportEvery = 10
+#process.MessageLogger.cerr.FwkReport.reportEvery = 100
 # Input source
 process.source = cms.Source("PoolSource",
     secondaryFileNames = cms.untracked.vstring(),
     fileNames = cms.untracked.vstring(
-        'root://eoscms//eos/cms/store/user/taroni/ClusterSplitting/ZpTauTau8TeV/GEN-SIM-RAW/ZpTT_1500_8TeV_Tauola_cfi_py_GEN_SIM_DIGI_L1_DIGI2RAW_HLT.root'
+     'root://eoscms//eos/cms/store/user/taroni/ClusterSplitting/ZpTauTau8TeV/GEN-SIM-RAW/ZpTauTau_GEN-SIM-RAW_0.root',
+     'root://eoscms//eos/cms/store/user/taroni/ClusterSplitting/ZpTauTau8TeV/GEN-SIM-RAW/ZpTauTau_GEN-SIM-RAW_1.root',
+     'root://eoscms//eos/cms/store/user/taroni/ClusterSplitting/ZpTauTau8TeV/GEN-SIM-RAW/ZpTauTau_GEN-SIM-RAW_2.root',
+     'root://eoscms//eos/cms/store/user/taroni/ClusterSplitting/ZpTauTau8TeV/GEN-SIM-RAW/ZpTauTau_GEN-SIM-RAW_3.root',
+     'root://eoscms//eos/cms/store/user/taroni/ClusterSplitting/ZpTauTau8TeV/GEN-SIM-RAW/ZpTauTau_GEN-SIM-RAW_4.root',
+     'root://eoscms//eos/cms/store/user/taroni/ClusterSplitting/ZpTauTau8TeV/GEN-SIM-RAW/ZpTauTau_GEN-SIM-RAW_5.root',
+     'root://eoscms//eos/cms/store/user/taroni/ClusterSplitting/ZpTauTau8TeV/GEN-SIM-RAW/ZpTauTau_GEN-SIM-RAW_6.root',
+     'root://eoscms//eos/cms/store/user/taroni/ClusterSplitting/ZpTauTau8TeV/GEN-SIM-RAW/ZpTauTau_GEN-SIM-RAW_7.root',
+     'root://eoscms//eos/cms/store/user/taroni/ClusterSplitting/ZpTauTau8TeV/GEN-SIM-RAW/ZpTauTau_GEN-SIM-RAW_8.root',
+     'root://eoscms//eos/cms/store/user/taroni/ClusterSplitting/ZpTauTau8TeV/GEN-SIM-RAW/ZpTauTau_GEN-SIM-RAW_9.root'
+
 ),
 )
                             
@@ -99,6 +109,29 @@ process.templates.LoadTemplatesFromDB = False
 
 # This is the default speed. Recommended.
 process.StripCPEfromTrackAngleESProducer.TemplateRecoSpeed = 0;
+tgrIndex = process.globalreco.index(process.trackingGlobalReco)
+tgrIndexFromReco = process.reconstruction_fromRECO.index(process.trackingGlobalReco)
+process.globalreco.remove(process.trackingGlobalReco)
+process.reconstruction_fromRECO.remove(process.trackingGlobalReco)
+del process.trackingGlobalReco
+del process.ckftracks
+del process.ckftracks_wodEdX
+del process.ckftracks_plus_pixelless
+del process.ckftracks_woBH
+del process.iterTracking
+del process.InitialStep
+del process.LowPtTripletStep
+del process.PixelPairStep
+del process.DetachedTripletStep
+del process.MixedTripletStep
+del process.PixelLessStep
+del process.TobTecStep
+
+# Load the new Iterative Tracking configuration
+process.load("RecoTracker.Configuration.RecoTrackerRunI_cff")
+
+process.globalreco.insert(tgrIndex, process.trackingGlobalReco)
+process.reconstruction_fromRECO.insert(tgrIndexFromReco, process.trackingGlobalReco)
 
 ############################## inserted new stuff
 
@@ -114,36 +147,40 @@ process.newrechits = cms.Sequence(process.mySiPixelRecHits*process.mySiStripRecH
 # The commands included in splitter_tracking_setup_cff.py instruct 
 # the tracking machinery to use the clusters and rechits generated after 
 # cluster splitting (instead of the default clusters and rechits)
-#process.load('RecoLocalTracker.SubCollectionProducers.splitter_tracking_setup2_cff')
+
+from RecoLocalTracker.SubCollectionProducers.splitter_RunI_tracking_setup_cff import customizeTracking
+customizeTracking('splitClusters', 'splitClusters', 'mySiPixelRecHits', 'mySiStripRecHits')
 
 process.fullreco = cms.Sequence(process.globalreco*process.highlevelreco)
 process.options = cms.untracked.PSet(
 
 )
-from RecoLocalTracker.SubCollectionProducers.splitter_tracking_setup_cff import customizeTracking
-customizeTracking('splitClusters', 'splitClusters', 'mySiPixelRecHits', 'mySiStripRecHits')
 
-process.load("RecoTracker.TrackProducer.TrackRefitters_cff")
+#process.load("RecoTracker.TrackProducer.TrackRefitters_cff")
 
 # Output definition
 
 
 process.RECOoutput = cms.OutputModule("PoolOutputModule",
     outputCommands = process.FEVTDEBUGEventContent.outputCommands,
-    fileName = cms.untracked.string('ZpTauTau8TeV_simsplit_71X.root'),
+    fileName = cms.untracked.string('ZpTauTau8TeV_simsplit_runI.root'),
     dataset = cms.untracked.PSet(
         #filterName = cms.untracked.string(''),
         dataTier = cms.untracked.string('RECO')
     )
 )
-## process.RECOoutput.outputCommands.append( 'keep TrackingParticles_mergedtruth_MergedTrackTruth_*')
-## process.RECOoutput.outputCommands.append( 'keep TrackingVertexs_mergedtruth_MergedTrackTruth_*')
+process.RECOoutput.outputCommands.append( 'keep TrackingParticles_mergedtruth_MergedTrackTruth_*')
+process.RECOoutput.outputCommands.append( 'keep TrackingVertexs_mergedtruth_MergedTrackTruth_*')
 
 # Additional output definition
 process.dump = cms.EDAnalyzer("EventContentAnalyzer")
-# Other statements
+# Other statement
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'START70_V5::All', '')
 
-process.GlobalTag.globaltag = 'MC_71_V1::All'
+process.GlobalTag.globaltag = 'START70_V5::All'
+from RecoLocalCalo.HcalRecProducers.HBHEIsolatedNoiseReflagger_cfi import *
+process.hbhereco.hbheInput= cms.InputTag("hbheprereco::SPLIT")
 
 process.mix.mixObjects.mixSH.crossingFrames.append('TrackerHitsPixelBarrelHighTof')
 process.mix.mixObjects.mixSH.crossingFrames.append('TrackerHitsPixelBarrelLowTof')
@@ -158,9 +195,7 @@ process.mix.mixObjects.mixSH.crossingFrames.append('TrackerHitsTIDLowTof')
 process.mix.mixObjects.mixSH.crossingFrames.append('TrackerHitsTOBHighTof') 
 process.mix.mixObjects.mixSH.crossingFrames.append('TrackerHitsTOBLowTof')
 
-
-from RecoLocalCalo.HcalRecProducers.HBHEIsolatedNoiseReflagger_cfi import *
-process.hbhereco.hbheInput= cms.InputTag("hbheprereco::SPLIT")
+process.mix.mixObjects.mixHepMC.makeCrossingFrame = True
 
 # Path and EndPath definitions
 process.pre_init  = cms.Path(cms.Sequence(process.pdigi*process.SimL1Emulator*process.DigiToRaw))
@@ -175,6 +210,5 @@ process.RECOoutput_step = cms.EndPath(process.RECOoutput)
 #process.pixeltree_tempsplit =cms.Path(process.PixelTreeSplit)
 #process.vertex_assoc = cms.Path(process.Vertex2TracksDefault)
 
-
-# Schedule definition
-process.schedule = cms.Schedule(process.init_step,process.splitClusters_step,process.newrechits_step, process.fullreco_step, process.RECOoutput_step)
+#Schedule definition
+process.schedule = cms.Schedule(process.init_step,process.splitClusters_step,process.newrechits_step,process.fullreco_step, process.RECOoutput_step)

--- a/RecoLocalTracker/SubCollectionProducers/test/run_split.py
+++ b/RecoLocalTracker/SubCollectionProducers/test/run_split.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process('SPLIT')
+
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')
 process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
@@ -17,18 +18,24 @@ process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(10)
 )
-#process.MessageLogger.cerr.FwkReport.reportEvery = 100
+process.MessageLogger.cerr.FwkReport.reportEvery = 10
 # Input source
 process.source = cms.Source("PoolSource",
     secondaryFileNames = cms.untracked.vstring(),
     fileNames = cms.untracked.vstring(
-    'root://eoscms///eos/cms/store/relval/CMSSW_7_0_0_pre8/RelValTTbar/GEN-SIM-DIGI-RAW-HLTDEBUG/PU_START70_V1-v1/00000/02ED271A-DB4A-E311-A756-002618FDA279.root',
-    'root://eoscms///eos/cms/store/relval/CMSSW_7_0_0_pre8/RelValTTbar/GEN-SIM-DIGI-RAW-HLTDEBUG/PU_START70_V1-v1/00000/04FF79F5-DA4A-E311-B585-003048678FDE.root',
-    'root://eoscms///eos/cms/store/relval/CMSSW_7_0_0_pre8/RelValTTbar/GEN-SIM-DIGI-RAW-HLTDEBUG/PU_START70_V1-v1/00000/0EEC6BF3-DA4A-E311-BAAA-0030486792B4.root',
-    'root://eoscms///eos/cms/store/relval/CMSSW_7_0_0_pre8/RelValTTbar/GEN-SIM-DIGI-RAW-HLTDEBUG/PU_START70_V1-v1/00000/18463930-DB4A-E311-83B5-0025905A612A.root',
-    'root://eoscms///eos/cms/store/relval/CMSSW_7_0_0_pre8/RelValTTbar/GEN-SIM-DIGI-RAW-HLTDEBUG/PU_START70_V1-v1/00000/1CDB1236-DB4A-E311-B5DA-002618FDA28E.root',
-    'root://eoscms///eos/cms/store/relval/CMSSW_7_0_0_pre8/RelValTTbar/GEN-SIM-DIGI-RAW-HLTDEBUG/PU_START70_V1-v1/00000/20F548F6-DA4A-E311-8B37-00261894397E.root',
-),
+        'root://eoscms//eos/cms/store/user/taroni/ClusterSplitting/ZpTauTau8TeV/GEN-SIM-RAW/ZpTT_1500_8TeV_Tauola_cfi_py_GEN_SIM_DIGI_L1_DIGI2RAW_HLT.root'
+#    'root://eoscms//eos/cms/store/user/taroni/ClusterSplitting/ZpTauTau8TeV/GEN-SIM-RAW/ZpTauTau_GEN-SIM-RAW_0.root',
+#    'root://eoscms//eos/cms/store/user/taroni/ClusterSplitting/ZpTauTau8TeV/GEN-SIM-RAW/ZpTauTau_GEN-SIM-RAW_1.root',
+#    'root://eoscms//eos/cms/store/user/taroni/ClusterSplitting/ZpTauTau8TeV/GEN-SIM-RAW/ZpTauTau_GEN-SIM-RAW_2.root',
+#    'root://eoscms//eos/cms/store/user/taroni/ClusterSplitting/ZpTauTau8TeV/GEN-SIM-RAW/ZpTauTau_GEN-SIM-RAW_3.root',
+#    'root://eoscms//eos/cms/store/user/taroni/ClusterSplitting/ZpTauTau8TeV/GEN-SIM-RAW/ZpTauTau_GEN-SIM-RAW_4.root',
+#    'root://eoscms//eos/cms/store/user/taroni/ClusterSplitting/ZpTauTau8TeV/GEN-SIM-RAW/ZpTauTau_GEN-SIM-RAW_5.root',
+#    'root://eoscms//eos/cms/store/user/taroni/ClusterSplitting/ZpTauTau8TeV/GEN-SIM-RAW/ZpTauTau_GEN-SIM-RAW_6.root',
+#    'root://eoscms//eos/cms/store/user/taroni/ClusterSplitting/ZpTauTau8TeV/GEN-SIM-RAW/ZpTauTau_GEN-SIM-RAW_7.root',
+#    'root://eoscms//eos/cms/store/user/taroni/ClusterSplitting/ZpTauTau8TeV/GEN-SIM-RAW/ZpTauTau_GEN-SIM-RAW_8.root',
+#    'root://eoscms//eos/cms/store/user/taroni/ClusterSplitting/ZpTauTau8TeV/GEN-SIM-RAW/ZpTauTau_GEN-SIM-RAW_9.root'
+#        'file:/afs/cern.ch/work/t/taroni/private/ClusterSplitting/CMSSW_7_1_X_2014-03-18-0200/src/ZpTT_1500_8TeV_Tauola_cfi_py_GEN_SIM_DIGI_L1_DIGI2RAW_HLT.root'
+    ),
 
 )
                             
@@ -115,7 +122,9 @@ process.Vertex2TracksDefault = AssociationMaps.clone(
 # The commands included in splitter_tracking_setup_cff.py instruct 
 # the tracking machinery to use the clusters and rechits generated after 
 # cluster splitting (instead of the default clusters and rechits)
-process.load('RecoLocalTracker.SubCollectionProducers.splitter_tracking_setup_cff')
+#process.load('RecoLocalTracker.SubCollectionProducers.splitter_tracking_setup2_cff')
+from RecoLocalTracker.SubCollectionProducers.splitter_tracking_setup_cff import customizeTracking
+customizeTracking('splitClusters', 'splitClusters', 'mySiPixelRecHits', 'mySiStripRecHits')
 
 process.fullreco = cms.Sequence(process.globalreco*process.highlevelreco)
 process.Globalreco = cms.Sequence(process.globalreco)
@@ -150,10 +159,10 @@ process.PixelTreeSplit = cms.EDAnalyzer(
 
 
 process.RECOoutput = cms.OutputModule("PoolOutputModule",
-    outputCommands = process.RECOSIMEventContent.outputCommands,
-    fileName = cms.untracked.string('TTbar700_split.root'),
+    outputCommands = process.FEVTDEBUGEventContent.outputCommands,
+    fileName = cms.untracked.string('ZpTauTau8TeV_split_71X_10.root'),
     dataset = cms.untracked.PSet(
-        dataTier = cms.untracked.string('RECO')
+        dataTier = cms.untracked.string('GEN-SIM-RECO')
     )
 )
 ## process.RECOoutput.outputCommands.append( 'keep TrackingParticles_mergedtruth_MergedTrackTruth_*')
@@ -163,8 +172,8 @@ process.RECOoutput = cms.OutputModule("PoolOutputModule",
 process.dump = cms.EDAnalyzer("EventContentAnalyzer")
 # Other statements
 
-process.GlobalTag.globaltag = 'START70_V1::All'
-#process.GlobalTag.globaltag = 'GR_R_52_V7::All'
+process.GlobalTag.globaltag = 'MC_71_V1::All'
+
 
 
 # Path and EndPath definitions

--- a/RecoLocalTracker/SubCollectionProducers/test/run_split_runI.py
+++ b/RecoLocalTracker/SubCollectionProducers/test/run_split_runI.py
@@ -7,28 +7,37 @@ process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
 process.load('FWCore.MessageService.MessageLogger_cfi')
 process.load('Configuration.StandardSequences.Services_cff')
 process.load('Configuration.EventContent.EventContent_cff')
-process.load('Configuration.StandardSequences.GeometryDB_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.StandardSequences.Geometry_cff')
 process.load('Configuration.StandardSequences.MagneticField_38T_cff')
 process.load('Configuration.StandardSequences.RawToDigi_cff')
 process.load('Configuration.StandardSequences.Reconstruction_cff')
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
-process.load("SimGeneral.MixingModule.mixNoPU_cfi")
-process.load('Configuration/StandardSequences/Simulation_cff')
-process.load('Configuration/StandardSequences/SimL1Emulator_cff')
-process.load('Configuration/StandardSequences/DigiToRaw_cff')
-process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+
+
 
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(100)
+    input = cms.untracked.int32(10)
 )
-process.MessageLogger.cerr.FwkReport.reportEvery = 10
+#process.MessageLogger.cerr.FwkReport.reportEvery = 100
 # Input source
 process.source = cms.Source("PoolSource",
     secondaryFileNames = cms.untracked.vstring(),
     fileNames = cms.untracked.vstring(
-        'root://eoscms//eos/cms/store/user/taroni/ClusterSplitting/ZpTauTau8TeV/GEN-SIM-RAW/ZpTT_1500_8TeV_Tauola_cfi_py_GEN_SIM_DIGI_L1_DIGI2RAW_HLT.root'
+#    'file:ZpTT_1500_8TeV_Tauola_cfi_py_GEN_SIM_DIGI_L1_DIGI2RAW_HLT.root',
+    'root://eoscms//eos/cms/store/user/taroni/ClusterSplitting/ZpTauTau8TeV/GEN-SIM-RAW/ZpTauTau_GEN-SIM-RAW_0.root',
+    'root://eoscms//eos/cms/store/user/taroni/ClusterSplitting/ZpTauTau8TeV/GEN-SIM-RAW/ZpTauTau_GEN-SIM-RAW_1.root',
+    'root://eoscms//eos/cms/store/user/taroni/ClusterSplitting/ZpTauTau8TeV/GEN-SIM-RAW/ZpTauTau_GEN-SIM-RAW_2.root',
+    'root://eoscms//eos/cms/store/user/taroni/ClusterSplitting/ZpTauTau8TeV/GEN-SIM-RAW/ZpTauTau_GEN-SIM-RAW_3.root',
+    'root://eoscms//eos/cms/store/user/taroni/ClusterSplitting/ZpTauTau8TeV/GEN-SIM-RAW/ZpTauTau_GEN-SIM-RAW_4.root',
+    'root://eoscms//eos/cms/store/user/taroni/ClusterSplitting/ZpTauTau8TeV/GEN-SIM-RAW/ZpTauTau_GEN-SIM-RAW_5.root',
+    'root://eoscms//eos/cms/store/user/taroni/ClusterSplitting/ZpTauTau8TeV/GEN-SIM-RAW/ZpTauTau_GEN-SIM-RAW_6.root',
+    'root://eoscms//eos/cms/store/user/taroni/ClusterSplitting/ZpTauTau8TeV/GEN-SIM-RAW/ZpTauTau_GEN-SIM-RAW_7.root',
+    'root://eoscms//eos/cms/store/user/taroni/ClusterSplitting/ZpTauTau8TeV/GEN-SIM-RAW/ZpTauTau_GEN-SIM-RAW_8.root',
+    'root://eoscms//eos/cms/store/user/taroni/ClusterSplitting/ZpTauTau8TeV/GEN-SIM-RAW/ZpTauTau_GEN-SIM-RAW_9.root'
 ),
+
 )
                             
 # from Jean-Roch
@@ -46,7 +55,7 @@ process.templates.LoadTemplatesFromDB = False
 # This is the default speed. Recommended.
 process.StripCPEfromTrackAngleESProducer.TemplateRecoSpeed = 0;
 
-# Split clusters have larger errors. Appropriate errors can be 
+# Split clusters have larger errors. Appropriate errors can be
 # assigned by turning UseStripSplitClusterErrors = True. The strip hit pull  
 # distributons improve considerably, but it does not help with b-tagging, 
 # so leave it False by default 
@@ -70,10 +79,10 @@ process.splitClusters = cms.EDProducer(
     tracks                = cms.InputTag('pixelTracks::SPLIT'),
     propagator            = cms.string('AnalyticalPropagator'),
     vertices              = cms.InputTag('pixelVertices::SPLIT'),
-    simSplitPixel         = cms.bool(True), # ideal pixel splitting turned OFF
-    simSplitStrip         = cms.bool(True), # ideal strip splitting turned OFF
-    tmpSplitPixel         = cms.bool(False), # template pixel spliting
-    tmpSplitStrip         = cms.bool(False), # template strip splitting
+    simSplitPixel         = cms.bool(False), # ideal pixel splitting turned OFF
+    simSplitStrip         = cms.bool(False), # ideal strip splitting turned OFF
+    tmpSplitPixel         = cms.bool(True), # template pixel spliting
+    tmpSplitStrip         = cms.bool(True), # template strip splitting
     useStraightTracks     = cms.bool(True),
     test     = cms.bool(True)
     )
@@ -105,34 +114,80 @@ process.StripCPEfromTrackAngleESProducer.TemplateRecoSpeed = 0;
 process.newrechits = cms.Sequence(process.mySiPixelRecHits*process.mySiStripRecHits)
 
 ######## track to vertex assoc ##################3
-## from CommonTools.RecoUtils.pf_pu_assomap_cfi import AssociationMaps
-## process.Vertex2TracksDefault = AssociationMaps.clone(
-##     AssociationType = cms.InputTag("VertexToTracks"),
-##     MaxNumberOfAssociations = cms.int32(1)
-## )
+from CommonTools.RecoUtils.pf_pu_assomap_cfi import AssociationMaps
+process.Vertex2TracksDefault = AssociationMaps.clone(
+    AssociationType = cms.InputTag("VertexToTracks"),
+    MaxNumberOfAssociations = cms.int32(1)
+)
+
+
+tgrIndex = process.globalreco.index(process.trackingGlobalReco)
+tgrIndexFromReco = process.reconstruction_fromRECO.index(process.trackingGlobalReco)
+process.globalreco.remove(process.trackingGlobalReco)
+process.reconstruction_fromRECO.remove(process.trackingGlobalReco)
+del process.trackingGlobalReco
+del process.ckftracks
+del process.ckftracks_wodEdX
+del process.ckftracks_plus_pixelless
+del process.ckftracks_woBH
+del process.iterTracking
+del process.InitialStep
+del process.LowPtTripletStep
+del process.PixelPairStep
+del process.DetachedTripletStep
+del process.MixedTripletStep
+del process.PixelLessStep
+del process.TobTecStep
+
+# Load the new Iterative Tracking configuration
+process.load("RecoTracker.Configuration.RecoTrackerRunI_cff")
+
+process.globalreco.insert(tgrIndex, process.trackingGlobalReco)
+process.reconstruction_fromRECO.insert(tgrIndexFromReco, process.trackingGlobalReco)
 
 # The commands included in splitter_tracking_setup_cff.py instruct 
 # the tracking machinery to use the clusters and rechits generated after 
 # cluster splitting (instead of the default clusters and rechits)
-#process.load('RecoLocalTracker.SubCollectionProducers.splitter_tracking_setup2_cff')
+from RecoLocalTracker.SubCollectionProducers.splitter_tracking_RunI_setup_cff import customizeTracking
+customizeTracking('splitClusters', 'splitClusters', 'mySiPixelRecHits', 'mySiStripRecHits')
+
 
 process.fullreco = cms.Sequence(process.globalreco*process.highlevelreco)
+## process.Globalreco = cms.Sequence(process.globalreco)
+## process.Highlevelreco = cms.Sequence(process.highlevelreco)
+
 process.options = cms.untracked.PSet(
 
 )
-from RecoLocalTracker.SubCollectionProducers.splitter_tracking_setup_cff import customizeTracking
-customizeTracking('splitClusters', 'splitClusters', 'mySiPixelRecHits', 'mySiStripRecHits')
 
-process.load("RecoTracker.TrackProducer.TrackRefitters_cff")
+#process.load("RecoTracker.TrackProducer.TrackRefitters_cff")
 
 # Output definition
+process.PixelTreeSplit = cms.EDAnalyzer(
+    "PixelAnalysisTree",
+    verbose                = cms.untracked.int32(0),
+    rootFileName           = cms.untracked.string('pixelTrees_TS_DATA.root'),
+    treeName               = cms.untracked.string('treeTmpSplit'),
+    dumpAllEvents          = cms.untracked.int32(1),
+    globalTag              = cms.string("GR_R_53::All"),
+    muonCollectionLabel    = cms.untracked.InputTag('muons'),
+#    trajectoryInputLabel   = cms.untracked.InputTag('TrackRefitter'),
+    trajectoryInputLabel   = cms.untracked.InputTag('generalTracks::SPLIT'),          
+    trackCollectionLabel   = cms.untracked.InputTag('generalTracks::SPLIT'),
+    pixelClusterLabel      = cms.untracked.InputTag('splitClusters'),
+    pixelRecHitLabel       = cms.untracked.InputTag('mySiPixelRecHits'),
+    L1GTReadoutRecordLabel = cms.untracked.InputTag("gtDigis"),
+    hltL1GtObjectMap       = cms.untracked.InputTag("hltL1GtObjectMap"),          
+    HLTResultsLabel        = cms.untracked.InputTag("TriggerResults::HLT"),
+    HLTProcessName         = cms.untracked.string("HLT"),
+    mapTrack2Vertex        = cms.untracked.bool(True)
+    )
 
 
 process.RECOoutput = cms.OutputModule("PoolOutputModule",
-    outputCommands = process.FEVTDEBUGEventContent.outputCommands,
-    fileName = cms.untracked.string('ZpTauTau8TeV_simsplit_71X.root'),
+    outputCommands = process.RECOSIMEventContent.outputCommands,
+    fileName = cms.untracked.string('ZpTauTau8TeV_split.root'),
     dataset = cms.untracked.PSet(
-        #filterName = cms.untracked.string(''),
         dataTier = cms.untracked.string('RECO')
     )
 )
@@ -142,39 +197,25 @@ process.RECOoutput = cms.OutputModule("PoolOutputModule",
 # Additional output definition
 process.dump = cms.EDAnalyzer("EventContentAnalyzer")
 # Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'START70_V5::All', '')
 
-process.GlobalTag.globaltag = 'MC_71_V1::All'
-
-process.mix.mixObjects.mixSH.crossingFrames.append('TrackerHitsPixelBarrelHighTof')
-process.mix.mixObjects.mixSH.crossingFrames.append('TrackerHitsPixelBarrelLowTof')
-process.mix.mixObjects.mixSH.crossingFrames.append('TrackerHitsPixelEndcapHighTof') 
-process.mix.mixObjects.mixSH.crossingFrames.append('TrackerHitsPixelEndcapLowTof')
-process.mix.mixObjects.mixSH.crossingFrames.append('TrackerHitsTECHighTof')
-process.mix.mixObjects.mixSH.crossingFrames.append('TrackerHitsTECLowTof')
-process.mix.mixObjects.mixSH.crossingFrames.append('TrackerHitsTIBHighTof') 
-process.mix.mixObjects.mixSH.crossingFrames.append('TrackerHitsTIBLowTof')
-process.mix.mixObjects.mixSH.crossingFrames.append('TrackerHitsTIDHighTof') 
-process.mix.mixObjects.mixSH.crossingFrames.append('TrackerHitsTIDLowTof')
-process.mix.mixObjects.mixSH.crossingFrames.append('TrackerHitsTOBHighTof') 
-process.mix.mixObjects.mixSH.crossingFrames.append('TrackerHitsTOBLowTof')
-
-
+process.GlobalTag.globaltag = 'START70_V5::All'
+#process.GlobalTag.globaltag = 'GR_R_52_V7::All'
 from RecoLocalCalo.HcalRecProducers.HBHEIsolatedNoiseReflagger_cfi import *
 process.hbhereco.hbheInput= cms.InputTag("hbheprereco::SPLIT")
-
 # Path and EndPath definitions
-process.pre_init  = cms.Path(cms.Sequence(process.pdigi*process.SimL1Emulator*process.DigiToRaw))
 process.init_step = cms.Path(cms.Sequence(process.RawToDigi*process.localreco*process.offlineBeamSpot+process.recopixelvertexing))
-process.rechits_step=cms.Path(process.siPixelRecHits)
 process.dump_step = cms.Path(process.dump)
-process.splitClusters_step=cms.Path(process.mix+process.splitClusters)
+process.splitClusters_step=cms.Path(process.splitClusters)
 process.newrechits_step=cms.Path(process.newrechits)
 process.fullreco_step=cms.Path(process.fullreco)
+
 process.endjob_step = cms.EndPath(process.endOfProcess)
 process.RECOoutput_step = cms.EndPath(process.RECOoutput)
 #process.pixeltree_tempsplit =cms.Path(process.PixelTreeSplit)
 #process.vertex_assoc = cms.Path(process.Vertex2TracksDefault)
 
-
 # Schedule definition
-process.schedule = cms.Schedule(process.init_step,process.splitClusters_step,process.newrechits_step, process.fullreco_step, process.RECOoutput_step)
+
+process.schedule = cms.Schedule(process.init_step,process.splitClusters_step,process.newrechits_step,process.fullreco_step,process.RECOoutput_step)


### PR DESCRIPTION
replacing #2961
Porting of cluster splitting in 71X release. Modified for the new tracking. Merge problems solved.

I tried to rebase what's showing up in 2961, but there were too many intermediate commits, ended up just committing the code after the merge
