### PR TITLE
Thread safety cleanup in SiStripRecHitMatcher

### DIFF
--- a/RecoLocalTracker/SiStripRecHitConverter/interface/SiStripRecHitMatcher.h
+++ b/RecoLocalTracker/SiStripRecHitConverter/interface/SiStripRecHitMatcher.h
@@ -19,7 +19,7 @@
 class GluedGeomDet;
 
 #include <cfloat>
-
+#include <memory>
 
 #include <boost/function.hpp>
 
@@ -62,7 +62,7 @@ public:
   
   
  //match a single hit
-  SiStripMatchedRecHit2D * match(const SiStripRecHit2D *monoRH, 
+  std::unique_ptr<SiStripMatchedRecHit2D> match(const SiStripRecHit2D *monoRH,
 				 const SiStripRecHit2D *stereoRH,
 				 const GluedGeomDet* gluedDet,
 				 LocalVector trackdirection, bool force=false) const;

--- a/RecoLocalTracker/SiStripRecHitConverter/src/SiStripRecHitMatcher.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/src/SiStripRecHitMatcher.cc
@@ -265,7 +265,7 @@ SiStripRecHitMatcher::project(const GeomDetUnit *det,const GluedGeomDet* gluedde
 
 
 //match a single hit
-SiStripMatchedRecHit2D * 
+std::unique_ptr<SiStripMatchedRecHit2D>
 SiStripRecHitMatcher::match(const SiStripRecHit2D *monoRH, 
 			    const SiStripRecHit2D *stereoRH,
 			    const GluedGeomDet* gluedDet,
@@ -347,8 +347,7 @@ SiStripRecHitMatcher::match(const SiStripRecHit2D *monoRH,
   Local2DPoint position(solution(0),solution(1));
   
 
-  if ((!force) &&  (!((gluedDet->surface()).bounds().inside(position,10.f*scale_))) ) return nullptr;                                                       
-  
+  if ((!force) &&  (!((gluedDet->surface()).bounds().inside(position,10.f*scale_))) ) return std::unique_ptr<SiStripMatchedRecHit2D>(nullptr);
 
   double c2 = -m10;
   double s2 = -m11;
@@ -370,7 +369,7 @@ SiStripRecHitMatcher::match(const SiStripRecHit2D *monoRH,
   //if it is inside the gluedet bonds
   //Change NSigmaInside in the configuration file to accept more hits
   if(force || (gluedDet->surface()).bounds().inside(position,error,scale_)) 
-    return new SiStripMatchedRecHit2D(LocalPoint(position), error, *gluedDet, monoRH,stereoRH);
-  return nullptr;
+    return std::unique_ptr<SiStripMatchedRecHit2D> (new SiStripMatchedRecHit2D(LocalPoint(position), error, *gluedDet, monoRH,stereoRH));
+  return std::unique_ptr<SiStripMatchedRecHit2D>(nullptr);
 }
 

--- a/RecoTracker/TransientTrackingRecHit/src/TSiStripMatchedRecHit.cc
+++ b/RecoTracker/TransientTrackingRecHit/src/TSiStripMatchedRecHit.cc
@@ -62,7 +62,8 @@ TSiStripMatchedRecHit::clone( const TrajectoryStateOnSurface& ts) const
     SiStripRecHit2D stereoHit = SiStripRecHit2D( lvStereo.first, lvStereo.second,
 						 *gdet->stereoDet(),
 						 orig->stereoClusterRef());
-    const SiStripMatchedRecHit2D* better =  theMatcher->match(&monoHit,&stereoHit,gdet,tkDir);
+    std::unique_ptr<SiStripMatchedRecHit2D> temp = theMatcher->match(&monoHit,&stereoHit,gdet,tkDir);
+    const SiStripMatchedRecHit2D* better =  temp.release();
     
     if (better == nullptr) {
       //dm::LogWarning("TSiStripMatchedRecHit") << "Refitting of a matched rechit returns NULL";
@@ -109,7 +110,7 @@ TSiStripMatchedRecHit::transientHits () const {
   return result;
 }
 
-  void TSiStripMatchedRecHit::ComputeCoarseLocalPosition(){
+void TSiStripMatchedRecHit::ComputeCoarseLocalPosition(){
   if (!theCPE || !theMatcher) return;
   const SiStripMatchedRecHit2D *orig = static_cast<const SiStripMatchedRecHit2D *> (trackingRecHit_);
   if ( (!orig)  ||  orig->hasPositionAndError()) return;
@@ -133,7 +134,8 @@ TSiStripMatchedRecHit::transientHits () const {
   SiStripRecHit2D stereoHit = SiStripRecHit2D( lvStereo.first, lvStereo.second, 
 					       *gdet->stereoDet(),
 						 orig->stereoClusterRef());
-  SiStripMatchedRecHit2D* better =  theMatcher->match(&monoHit,&stereoHit,gdet,tkDir);
+  std::unique_ptr<SiStripMatchedRecHit2D> temp = theMatcher->match(&monoHit,&stereoHit,gdet,tkDir);
+  SiStripMatchedRecHit2D* better = temp.release();
   
   if (!better) {
     edm::LogWarning("TSiStripMatchedRecHit")<<"could not get a matching rechit.";

--- a/RecoTracker/TransientTrackingRecHit/src/TkClonerImpl.cc
+++ b/RecoTracker/TransientTrackingRecHit/src/TkClonerImpl.cc
@@ -18,7 +18,7 @@
 #include "RecoLocalTracker/ClusterParameterEstimator/interface/StripClusterParameterEstimator.h"
 #include "RecoLocalTracker/SiStripRecHitConverter/interface/SiStripRecHitMatcher.h"
 
-
+#include <memory>
 
 SiPixelRecHit * TkClonerImpl::operator()(SiPixelRecHit const & hit, TrajectoryStateOnSurface const& tsos) const {
   const SiPixelCluster& clust = *hit.cluster();  
@@ -98,9 +98,9 @@ SiStripMatchedRecHit2D * TkClonerImpl::operator()(SiStripMatchedRecHit2D const &
 						 hit.stereoClusterRef());
     
     // return theMatcher->match(&monoHit,&stereoHit,gdet,tkDir,true);
-    auto better =  theMatcher->match(&monoHit,&stereoHit,gdet,tkDir,false);
+    std::unique_ptr<SiStripMatchedRecHit2D> temp = theMatcher->match(&monoHit,&stereoHit,gdet,tkDir,false);
+    SiStripMatchedRecHit2D * better =  temp.release();
     return better ? better : hit.clone();
-
 }
 
 


### PR DESCRIPTION
Modify return type of SiStripRecHitMatcher::match
from a bare pointer to a unique_ptr. This eliminates
a report from the thread safety static code checker
of a potential thread safety problem. Also modify the
two files where this function is called to use
the new interface.
