### PR TITLE
Remove DQM service from configurations

### DIFF
--- a/DQMServices/Core/python/DQM_cfg.py
+++ b/DQMServices/Core/python/DQM_cfg.py
@@ -3,10 +3,11 @@ import FWCore.ParameterSet.Config as cms
 # needed backend
 from DQMServices.Core.DQMStore_cfi import *
 
-DQM = cms.Service("DQM",
-    debug = cms.untracked.bool(False),
-    publishFrequency = cms.untracked.double(5.0),
-    collectorPort = cms.untracked.int32(9090),
-    collectorHost = cms.untracked.string('localhost'),
-    filter = cms.untracked.string('')
-)
+#Temporarily remove for thread safety reasons
+#DQM = cms.Service("DQM",
+#    debug = cms.untracked.bool(False),
+#    publishFrequency = cms.untracked.double(5.0),
+#    collectorPort = cms.untracked.int32(9090),
+#    collectorHost = cms.untracked.string('localhost'),
+#    filter = cms.untracked.string('')
+#)


### PR DESCRIPTION
The DQM service is not thread-safe and must be removed from
configurations until it is changed.
