### PR TITLE
Remove DTDataIntegrityTask service from configuration

### DIFF
--- a/DQM/DTMonitorModule/python/dtDQMOfflineSources_Cosmics_cff.py
+++ b/DQM/DTMonitorModule/python/dtDQMOfflineSources_Cosmics_cff.py
@@ -36,7 +36,7 @@ dtDataIntegrityUnpacker = cms.EDProducer("DTUnpackingModule",
 )
 
 from DQM.DTMonitorModule.dtDataIntegrityTask_cfi import *
-DTDataIntegrityTask.processingMode = "Offline"
+#DTDataIntegrityTask.processingMode = "Offline"
 
 from DQM.DTMonitorModule.dtTriggerEfficiencyTask_cfi import *
 

--- a/DQM/DTMonitorModule/python/dtDQMOfflineSources_cff.py
+++ b/DQM/DTMonitorModule/python/dtDQMOfflineSources_cff.py
@@ -37,7 +37,7 @@ dtDataIntegrityUnpacker = cms.EDProducer("DTUnpackingModule",
 )
 
 from DQM.DTMonitorModule.dtDataIntegrityTask_cfi import *
-DTDataIntegrityTask.processingMode = "Offline"
+#DTDataIntegrityTask.processingMode = "Offline"
 
 from DQM.DTMonitorModule.dtTriggerEfficiencyTask_cfi import *
 

--- a/DQM/DTMonitorModule/python/dtDataIntegrityTask_EvF_cff.py
+++ b/DQM/DTMonitorModule/python/dtDataIntegrityTask_EvF_cff.py
@@ -22,7 +22,7 @@ dtunpacker = cms.EDProducer("DTUnpackingModule",
 )
 
 from DQM.DTMonitorModule.dtDataIntegrityTask_cfi import *
-DTDataIntegrityTask.processingMode = "HLT"
+#DTDataIntegrityTask.processingMode = "HLT"
 
 dtDQMEvF = cms.Sequence(dtunpacker)
 

--- a/DQM/DTMonitorModule/python/dtDataIntegrityTask_EvF_cfi.py
+++ b/DQM/DTMonitorModule/python/dtDataIntegrityTask_EvF_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
 from DQM.DTMonitorModule.dtDataIntegrityTask_cfi import *
-DTDataIntegrityTask.processingMode = "HLT"
-DTDataIntegrityTask.fedIntegrityFolder = "DT/FEDIntegrity_EvF"
+#DTDataIntegrityTask.processingMode = "HLT"
+#DTDataIntegrityTask.fedIntegrityFolder = "DT/FEDIntegrity_EvF"
 

--- a/DQM/DTMonitorModule/python/dtDataIntegrityTask_cfi.py
+++ b/DQM/DTMonitorModule/python/dtDataIntegrityTask_cfi.py
@@ -1,9 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 
-DTDataIntegrityTask = cms.Service("DTDataIntegrityTask",
-                                  getSCInfo = cms.untracked.bool(True),
-                                  fedIntegrityFolder = cms.untracked.string("DT/FEDIntegrity"),
-                                  processingMode     = cms.untracked.string("Online")
-)
+#DTDataIntegrityTask = cms.Service("DTDataIntegrityTask",
+#                                  getSCInfo = cms.untracked.bool(True),
+#                                  fedIntegrityFolder = cms.untracked.string("DT/FEDIntegrity"),
+#                                  processingMode     = cms.untracked.string("Online")
+#)
 
 

--- a/HLTrigger/Configuration/python/HLT_2013_Famos_cff.py
+++ b/HLTrigger/Configuration/python/HLT_2013_Famos_cff.py
@@ -1747,11 +1747,11 @@ trackerTopologyConstants = cms.ESProducer( "TrackerTopologyEP",
   pxf_moduleMask = cms.uint32( 63 )
 )
 
-DTDataIntegrityTask = cms.Service( "DTDataIntegrityTask",
-  processingMode = cms.untracked.string( "HLT" ),
-  fedIntegrityFolder = cms.untracked.string( "DT/FEDIntegrity_EvF" ),
-  getSCInfo = cms.untracked.bool( True )
-)
+#DTDataIntegrityTask = cms.Service( "DTDataIntegrityTask",
+#  processingMode = cms.untracked.string( "HLT" ),
+#  fedIntegrityFolder = cms.untracked.string( "DT/FEDIntegrity_EvF" ),
+#  getSCInfo = cms.untracked.bool( True )
+#)
 
 hltGetConditions = cms.EDAnalyzer( "EventSetupRecordDataGetter",
     toGet = cms.VPSet( 

--- a/HLTrigger/Configuration/python/HLT_2013_cff.py
+++ b/HLTrigger/Configuration/python/HLT_2013_cff.py
@@ -3286,11 +3286,11 @@ trackerTopologyConstants = cms.ESProducer( "TrackerTopologyEP",
   pxf_moduleMask = cms.uint32( 63 )
 )
 
-DTDataIntegrityTask = cms.Service( "DTDataIntegrityTask",
-  processingMode = cms.untracked.string( "HLT" ),
-  fedIntegrityFolder = cms.untracked.string( "DT/FEDIntegrity_EvF" ),
-  getSCInfo = cms.untracked.bool( True )
-)
+#DTDataIntegrityTask = cms.Service( "DTDataIntegrityTask",
+#  processingMode = cms.untracked.string( "HLT" ),
+#  fedIntegrityFolder = cms.untracked.string( "DT/FEDIntegrity_EvF" ),
+#  getSCInfo = cms.untracked.bool( True )
+#)
 
 hltGetConditions = cms.EDAnalyzer( "EventSetupRecordDataGetter",
     toGet = cms.VPSet( 

--- a/HLTrigger/Configuration/python/HLT_FULL_cff.py
+++ b/HLTrigger/Configuration/python/HLT_FULL_cff.py
@@ -4523,11 +4523,11 @@ trackerTopologyConstants = cms.ESProducer( "TrackerTopologyEP",
   pxf_moduleMask = cms.uint32( 63 )
 )
 
-DTDataIntegrityTask = cms.Service( "DTDataIntegrityTask",
-  processingMode = cms.untracked.string( "HLT" ),
-  fedIntegrityFolder = cms.untracked.string( "DT/FEDIntegrity_EvF" ),
-  getSCInfo = cms.untracked.bool( True )
-)
+#DTDataIntegrityTask = cms.Service( "DTDataIntegrityTask",
+#  processingMode = cms.untracked.string( "HLT" ),
+#  fedIntegrityFolder = cms.untracked.string( "DT/FEDIntegrity_EvF" ),
+#  getSCInfo = cms.untracked.bool( True )
+#)
 
 hltGetConditions = cms.EDAnalyzer( "EventSetupRecordDataGetter",
     toGet = cms.VPSet( 

--- a/HLTrigger/Configuration/python/HLT_GRun_Famos_cff.py
+++ b/HLTrigger/Configuration/python/HLT_GRun_Famos_cff.py
@@ -1747,11 +1747,11 @@ trackerTopologyConstants = cms.ESProducer( "TrackerTopologyEP",
   pxf_moduleMask = cms.uint32( 63 )
 )
 
-DTDataIntegrityTask = cms.Service( "DTDataIntegrityTask",
-  processingMode = cms.untracked.string( "HLT" ),
-  fedIntegrityFolder = cms.untracked.string( "DT/FEDIntegrity_EvF" ),
-  getSCInfo = cms.untracked.bool( True )
-)
+#DTDataIntegrityTask = cms.Service( "DTDataIntegrityTask",
+#  processingMode = cms.untracked.string( "HLT" ),
+#  fedIntegrityFolder = cms.untracked.string( "DT/FEDIntegrity_EvF" ),
+#  getSCInfo = cms.untracked.bool( True )
+#)
 
 hltGetConditions = cms.EDAnalyzer( "EventSetupRecordDataGetter",
     toGet = cms.VPSet( 

--- a/HLTrigger/Configuration/python/HLT_GRun_cff.py
+++ b/HLTrigger/Configuration/python/HLT_GRun_cff.py
@@ -3484,11 +3484,11 @@ trackerTopologyConstants = cms.ESProducer( "TrackerTopologyEP",
   pxf_moduleMask = cms.uint32( 63 )
 )
 
-DTDataIntegrityTask = cms.Service( "DTDataIntegrityTask",
-  processingMode = cms.untracked.string( "HLT" ),
-  fedIntegrityFolder = cms.untracked.string( "DT/FEDIntegrity_EvF" ),
-  getSCInfo = cms.untracked.bool( True )
-)
+#DTDataIntegrityTask = cms.Service( "DTDataIntegrityTask",
+#  processingMode = cms.untracked.string( "HLT" ),
+#  fedIntegrityFolder = cms.untracked.string( "DT/FEDIntegrity_EvF" ),
+#  getSCInfo = cms.untracked.bool( True )
+#)
 
 hltGetConditions = cms.EDAnalyzer( "EventSetupRecordDataGetter",
     toGet = cms.VPSet( 

--- a/HLTrigger/Configuration/python/HLT_HIon_cff.py
+++ b/HLTrigger/Configuration/python/HLT_HIon_cff.py
@@ -2071,11 +2071,11 @@ trackerTopologyConstants = cms.ESProducer( "TrackerTopologyEP",
   pxf_moduleMask = cms.uint32( 63 )
 )
 
-DTDataIntegrityTask = cms.Service( "DTDataIntegrityTask",
-  processingMode = cms.untracked.string( "HLT" ),
-  fedIntegrityFolder = cms.untracked.string( "DT/FEDIntegrity_EvF" ),
-  getSCInfo = cms.untracked.bool( True )
-)
+#DTDataIntegrityTask = cms.Service( "DTDataIntegrityTask",
+#  processingMode = cms.untracked.string( "HLT" ),
+#  fedIntegrityFolder = cms.untracked.string( "DT/FEDIntegrity_EvF" ),
+#  getSCInfo = cms.untracked.bool( True )
+#)
 
 hltGetConditions = cms.EDAnalyzer( "EventSetupRecordDataGetter",
     toGet = cms.VPSet( 

--- a/HLTrigger/Configuration/python/HLT_PIon_cff.py
+++ b/HLTrigger/Configuration/python/HLT_PIon_cff.py
@@ -2511,11 +2511,11 @@ trackerTopologyConstants = cms.ESProducer( "TrackerTopologyEP",
   pxf_moduleMask = cms.uint32( 63 )
 )
 
-DTDataIntegrityTask = cms.Service( "DTDataIntegrityTask",
-  processingMode = cms.untracked.string( "HLT" ),
-  fedIntegrityFolder = cms.untracked.string( "DT/FEDIntegrity_EvF" ),
-  getSCInfo = cms.untracked.bool( True )
-)
+#DTDataIntegrityTask = cms.Service( "DTDataIntegrityTask",
+#  processingMode = cms.untracked.string( "HLT" ),
+#  fedIntegrityFolder = cms.untracked.string( "DT/FEDIntegrity_EvF" ),
+#  getSCInfo = cms.untracked.bool( True )
+#)
 
 hltGetConditions = cms.EDAnalyzer( "EventSetupRecordDataGetter",
     toGet = cms.VPSet( 

--- a/HLTrigger/HLTanalyzers/python/HLT_FULL_cff.py
+++ b/HLTrigger/HLTanalyzers/python/HLT_FULL_cff.py
@@ -4240,11 +4240,11 @@ siStripLorentzAngleDepESProducer = cms.ESProducer( "SiStripLorentzAngleDepESProd
   )
 )
 
-DTDataIntegrityTask = cms.Service( "DTDataIntegrityTask",
-  processingMode = cms.untracked.string( "HLT" ),
-  fedIntegrityFolder = cms.untracked.string( "DT/FEDIntegrity_EvF" ),
-  getSCInfo = cms.untracked.bool( True )
-)
+#DTDataIntegrityTask = cms.Service( "DTDataIntegrityTask",
+#  processingMode = cms.untracked.string( "HLT" ),
+#  fedIntegrityFolder = cms.untracked.string( "DT/FEDIntegrity_EvF" ),
+#  getSCInfo = cms.untracked.bool( True )
+#)
 
 hltGetConditions = cms.EDAnalyzer( "EventSetupRecordDataGetter",
     toGet = cms.VPSet( 


### PR DESCRIPTION
The DTDataIntegrityTask service is not thread-safe and must be removed
from configurations until it is changed.
