### PR TITLE
removed use of TkDetMap from configurations

### DIFF
--- a/DQM/SiStripCommon/python/TkHistoMap_cfi.py
+++ b/DQM/SiStripCommon/python/TkHistoMap_cfi.py
@@ -1,4 +1,4 @@
 import FWCore.ParameterSet.Config as cms
 
-TkDetMap = cms.Service("TkDetMap");
+#TkDetMap = cms.Service("TkDetMap");
 SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader");

--- a/DQM/SiStripMonitorClient/python/SiStripClientConfigP5_Cosmic_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripClientConfigP5_Cosmic_cff.py
@@ -63,5 +63,5 @@ TrackEffClient.FolderName = 'Tracking/TrackParameters/TrackEfficiency'
 TrackEffClient.AlgoName   = 'CKFTk'
 
 # Services needed for TkHistoMap
-TkDetMap = cms.Service("TkDetMap")
+#TkDetMap = cms.Service("TkDetMap")
 

--- a/DQM/SiStripMonitorClient/python/SiStripClientConfigP5_HeavyIons_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripClientConfigP5_HeavyIons_cff.py
@@ -63,5 +63,5 @@ TrackEffClient.FolderName = 'Tracking/TrackParameters/TrackEfficiency'
 TrackEffClient.AlgoName   = 'CKFTk'
 
 # Services needed for TkHistoMap
-TkDetMap = cms.Service("TkDetMap")
+#TkDetMap = cms.Service("TkDetMap")
 

--- a/DQM/SiStripMonitorClient/python/SiStripClientConfigP5_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripClientConfigP5_cff.py
@@ -63,5 +63,5 @@ TrackEffClient.FolderName = 'Tracking/TrackParameters/TrackEfficiency'
 TrackEffClient.AlgoName   = 'CKFTk'
 
 # Services needed for TkHistoMap
-TkDetMap = cms.Service("TkDetMap")
+#TkDetMap = cms.Service("TkDetMap")
 

--- a/DQM/SiStripMonitorClient/python/SiStripClientConfig_Tier0_Cosmic_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripClientConfig_Tier0_Cosmic_cff.py
@@ -41,9 +41,11 @@ TrackEffClient.FolderName = 'Tracking/TrackParameters/TrackEfficiency'
 TrackEffClient.AlgoName   = 'CKFTk'
 
 # Sequence
-SiStripCosmicDQMClient = cms.Sequence(siStripQTester*siStripOfflineAnalyser*TrackEffClient)
+#removed modules using TkDetMap
+#SiStripCosmicDQMClient = cms.Sequence(siStripQTester*siStripOfflineAnalyser*TrackEffClient)
+SiStripCosmicDQMClient = cms.Sequence(siStripQTester*TrackEffClient)
 
 
 # Services needed for TkHistoMap
-TkDetMap = cms.Service("TkDetMap")
+#TkDetMap = cms.Service("TkDetMap")
 SiStripDetInfoFileReade = cms.Service("SiStripDetInfoFileReader")

--- a/DQM/SiStripMonitorClient/python/SiStripClientConfig_Tier0_HeavyIons_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripClientConfig_Tier0_HeavyIons_cff.py
@@ -33,8 +33,10 @@ siStripQTesterHI = cms.EDAnalyzer("QualityTester",
 )
 
 # define new HI sequence
-SiStripOfflineDQMClientHI = cms.Sequence(siStripQTesterHI*siStripOfflineAnalyser)
+#removed modules using TkDetMap
+#SiStripOfflineDQMClientHI = cms.Sequence(siStripQTesterHI*siStripOfflineAnalyser)
+SiStripOfflineDQMClientHI = cms.Sequence(siStripQTesterHI)
 
 # Services needed for TkHistoMap
-TkDetMap = cms.Service("TkDetMap")
+#TkDetMap = cms.Service("TkDetMap")
 SiStripDetInfoFileReade = cms.Service("SiStripDetInfoFileReader")

--- a/DQM/SiStripMonitorClient/python/SiStripClientConfig_Tier0_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripClientConfig_Tier0_cff.py
@@ -39,9 +39,11 @@ siStripQTester = cms.EDAnalyzer("QualityTester",
 
 
 # Sequence
-SiStripOfflineDQMClient = cms.Sequence(siStripQTester*siStripOfflineAnalyser)
+#removed modules using TkDetMap
+#SiStripOfflineDQMClient = cms.Sequence(siStripQTester*siStripOfflineAnalyser)
+SiStripOfflineDQMClient = cms.Sequence(siStripQTester)
 
 
 # Services needed for TkHistoMap
-TkDetMap = cms.Service("TkDetMap")
+#TkDetMap = cms.Service("TkDetMap")
 SiStripDetInfoFileReade = cms.Service("SiStripDetInfoFileReader")

--- a/DQM/SiStripMonitorClient/python/SiStripClientConfig_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripClientConfig_cff.py
@@ -82,5 +82,5 @@ SiStripOnlineDQMClient = cms.Sequence(onlineAnalyser)
 SiStripOfflineDQMClient = cms.Sequence(offlineAnalyser)
 
 # Services needed for TkHistoMap
-TkDetMap = cms.Service("TkDetMap")
+#TkDetMap = cms.Service("TkDetMap")
 

--- a/DQM/SiStripMonitorClient/python/SiStripSourceConfigP5_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripSourceConfigP5_cff.py
@@ -205,5 +205,5 @@ TrackEffMon_hi.AlgoName                            = 'HeavyIonTk'
 TrackEffMon_hi.FolderName                          = 'Tracking/TrackParameters/TrackEfficiency'
 
 # Services needed for TkHistoMap
-TkDetMap = cms.Service("TkDetMap")
+#TkDetMap = cms.Service("TkDetMap")
 SiStripDetInfoFileReade = cms.Service("SiStripDetInfoFileReader")

--- a/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_Cosmic_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_Cosmic_cff.py
@@ -170,7 +170,7 @@ dqmInfoSiStrip = cms.EDAnalyzer("DQMEventInfo",
 )
 
 # Services needed for TkHistoMap
-TkDetMap = cms.Service("TkDetMap")
+#TkDetMap = cms.Service("TkDetMap")
 SiStripDetInfoFileReade = cms.Service("SiStripDetInfoFileReader")
 
 # Event History Producer
@@ -182,8 +182,12 @@ from DPGAnalysis.SiStripTools.apvcyclephaseproducerfroml1tsDB_cfi import *
 # Sequences 
 SiStripDQMTier0_cosmicTk = cms.Sequence(APVPhases*consecutiveHEs*SiStripMonitorTrack_cosmicTk*MonitorTrackResiduals_cosmicTk*TrackMon_cosmicTk*TrackEffMon_cosmicTk)
 
-SiStripDQMTier0_ckf = cms.Sequence(APVPhases*consecutiveHEs*SiStripMonitorTrack_ckf*MonitorTrackResiduals_ckf*TrackMon_ckf*TrackEffMon_ckf)
+#removed modules using TkDetMap
+#SiStripDQMTier0_ckf = cms.Sequence(APVPhases*consecutiveHEs*SiStripMonitorTrack_ckf*MonitorTrackResiduals_ckf*TrackMon_ckf*TrackEffMon_ckf)
+SiStripDQMTier0_ckf = cms.Sequence(APVPhases*consecutiveHEs*MonitorTrackResiduals_ckf*TrackMon_ckf*TrackEffMon_ckf)
 
 #SiStripDQMTier0_rs = cms.Sequence(APVPhases*consecutiveHEs*SiStripMonitorTrack_rs*MonitorTrackResiduals_rs*TrackMon_rs*TrackEffMon_rs)
 
-SiStripDQMTier0 = cms.Sequence(APVPhases*consecutiveHEs*siStripFEDCheck*siStripFEDMonitor*SiStripMonitorDigi*SiStripMonitorCluster*SiStripMonitorTrack_ckf*MonitorTrackResiduals_ckf*TrackMon_cosmicTk*TrackMon_ckf*TrackEffMon_ckf*TrackSplitMonitor*dqmInfoSiStrip)
+#removed modules using TkDetMap
+#SiStripDQMTier0 = cms.Sequence(APVPhases*consecutiveHEs*siStripFEDCheck*siStripFEDMonitor*SiStripMonitorDigi*SiStripMonitorCluster*SiStripMonitorTrack_ckf*MonitorTrackResiduals_ckf*TrackMon_cosmicTk*TrackMon_ckf*TrackEffMon_ckf*TrackSplitMonitor*dqmInfoSiStrip)
+SiStripDQMTier0 = cms.Sequence(APVPhases*consecutiveHEs*siStripFEDCheck*MonitorTrackResiduals_ckf*TrackMon_cosmicTk*TrackMon_ckf*TrackEffMon_ckf*TrackSplitMonitor*dqmInfoSiStrip)

--- a/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_HeavyIons_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_HeavyIons_cff.py
@@ -23,9 +23,14 @@ TrackMon_hi = DQM.TrackingMonitor.TrackerHeavyIonTrackingMonitor_cfi.TrackerHeav
 TrackMon_hi.FolderName          = 'Tracking/TrackParameters'
 TrackMon_hi.BSFolderName        = 'Tracking/TrackParameters/BeamSpotParameters'
 
+#removed all modules using TkDetMap service
+#SiStripDQMTier0_hi = cms.Sequence(APVPhases * consecutiveHEs *
+#                                  siStripFEDCheck * siStripFEDMonitor *
+#                                  SiStripMonitorDigi * SiStripMonitorCluster *
+#                                  SiStripMonitorTrack_hi *
+#                                  MonitorTrackResiduals_hi *
+#                                  TrackMon_hi)
 SiStripDQMTier0_hi = cms.Sequence(APVPhases * consecutiveHEs *
-                                  siStripFEDCheck * siStripFEDMonitor *
-                                  SiStripMonitorDigi * SiStripMonitorCluster *
-                                  SiStripMonitorTrack_hi *
+                                  siStripFEDCheck * 
                                   MonitorTrackResiduals_hi *
                                   TrackMon_hi)

--- a/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_cff.py
@@ -109,7 +109,7 @@ dqmInfoSiStrip = cms.EDAnalyzer("DQMEventInfo",
 )
 
 # Services needed for TkHistoMap
-TkDetMap = cms.Service("TkDetMap")
+#TkDetMap = cms.Service("TkDetMap")
 SiStripDetInfoFileReade = cms.Service("SiStripDetInfoFileReader")
 
 # Event History Producer
@@ -122,18 +122,33 @@ from DPGAnalysis.SiStripTools.apvcyclephaseproducerfroml1tsDB_cfi import *
 from RecoLuminosity.LumiProducer.lumiProducer_cff import *
 
 # Sequence
+#removed modules using TkDetMap service
+#SiStripDQMTier0 = cms.Sequence(
+#    APVPhases*consecutiveHEs*siStripFEDCheck*siStripFEDMonitor*SiStripMonitorDigi*SiStripMonitorClusterBPTX
+#    *SiStripMonitorTrackCommon*MonitorTrackResiduals
+#    *dqmInfoSiStrip)
+
+#SiStripDQMTier0Common = cms.Sequence(
+#    APVPhases*consecutiveHEs*siStripFEDCheck*siStripFEDMonitor*SiStripMonitorDigi*SiStripMonitorClusterBPTX        
+#    *SiStripMonitorTrackCommon
+#    *dqmInfoSiStrip)
+
+#SiStripDQMTier0MinBias = cms.Sequence(
+#    APVPhases*consecutiveHEs*siStripFEDCheck*siStripFEDMonitor*SiStripMonitorDigi*SiStripMonitorClusterBPTX
+#    *SiStripMonitorTrackMB*MonitorTrackResiduals
+#    *dqmInfoSiStrip)
+
 SiStripDQMTier0 = cms.Sequence(
-    APVPhases*consecutiveHEs*siStripFEDCheck*siStripFEDMonitor*SiStripMonitorDigi*SiStripMonitorClusterBPTX
-    *SiStripMonitorTrackCommon*MonitorTrackResiduals
+    APVPhases*consecutiveHEs*siStripFEDCheck
+    *MonitorTrackResiduals
     *dqmInfoSiStrip)
 
 SiStripDQMTier0Common = cms.Sequence(
-    APVPhases*consecutiveHEs*siStripFEDCheck*siStripFEDMonitor*SiStripMonitorDigi*SiStripMonitorClusterBPTX        
-    *SiStripMonitorTrackCommon
+    APVPhases*consecutiveHEs*siStripFEDCheck
     *dqmInfoSiStrip)
 
 SiStripDQMTier0MinBias = cms.Sequence(
-    APVPhases*consecutiveHEs*siStripFEDCheck*siStripFEDMonitor*SiStripMonitorDigi*SiStripMonitorClusterBPTX
+    APVPhases*consecutiveHEs*siStripFEDCheck
     *SiStripMonitorTrackMB*MonitorTrackResiduals
     *dqmInfoSiStrip)
 

--- a/DQM/SiStripMonitorClient/python/SiStripSourceConfig_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripSourceConfig_cff.py
@@ -84,9 +84,13 @@ TrackMonColl.FolderName = 'Tracking/TrackParameters'
 TrackMonColl.AlgoName = 'CKFTk'
 TrackMonColl.doSeedParameterHistos = True
 # Sequences
-SiStripSourcesSimData = cms.Sequence(SiStripMonitorDigi*SiStripMonitorCluster*SiStripMonitorTrackSim*MonitorTrackResidualsSim*TrackMonSim)
-SiStripSourcesRealData = cms.Sequence(SiStripMonitorDigi*SiStripMonitorCluster*SiStripMonitorTrackReal*MonitorTrackResidualsReal*TrackMonReal)
-SiStripSourcesRealDataCollision = cms.Sequence(SiStripMonitorDigi*SiStripMonitorCluster*SiStripMonitorTrackColl*MonitorTrackResidualsColl*TrackMonColl)
+#removed modules using TkDetMap service
+#SiStripSourcesSimData = cms.Sequence(SiStripMonitorDigi*SiStripMonitorCluster*SiStripMonitorTrackSim*MonitorTrackResidualsSim*TrackMonSim)
+#SiStripSourcesRealData = cms.Sequence(SiStripMonitorDigi*SiStripMonitorCluster*SiStripMonitorTrackReal*MonitorTrackResidualsReal*TrackMonReal)
+#SiStripSourcesRealDataCollision = cms.Sequence(SiStripMonitorDigi*SiStripMonitorCluster*SiStripMonitorTrackColl*MonitorTrackResidualsColl*TrackMonColl)
+SiStripSourcesSimData = cms.Sequence(SiStripMonitorTrackSim*MonitorTrackResidualsSim*TrackMonSim)
+SiStripSourcesRealData = cms.Sequence(SiStripMonitorTrackReal*MonitorTrackResidualsReal*TrackMonReal)
+SiStripSourcesRealDataCollision = cms.Sequence(SiStripMonitorTrackColl*MonitorTrackResidualsColl*TrackMonColl)
 
 
 


### PR DESCRIPTION
The TkDetMap service is not thread-safe and violates CMSSW coding
rules and must be removed from configurations until it is changed.
Modules dependent upon TkDetMap have also been removed from configurations.
