### PR TITLE
make CPE thread safe,

### DIFF
--- a/FastSimulation/TrackingRecHitProducer/src/FastPixelCPE.cc
+++ b/FastSimulation/TrackingRecHitProducer/src/FastPixelCPE.cc
@@ -7,30 +7,3 @@
 // Services
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#include "boost/multi_array.hpp"
-
-#include <iostream>
-#include <map>
-#include <memory>
-using namespace std;
-
-//-----------------------------------------------------------------------------
-//!  The constructor.
-//-----------------------------------------------------------------------------
-
-
-PixelClusterParameterEstimator::ReturnType FastPixelCPE::getParameters(const SiPixelCluster & cluster, const GeomDetUnit &det) const
-{
-  
-  std::map<std::pair<unsigned int, std::pair<int,int> >, std::pair<LocalPoint,LocalError> >::const_iterator pixel_link = 
-    pos_err_map.find(std::make_pair(det.geographicalId().rawId(),std::make_pair(cluster.minPixelRow(),cluster.minPixelCol())));
-  if (pixel_link != pos_err_map.end()) {
-    std::pair<LocalPoint,LocalError> pos_err_info = pixel_link->second;
-    return std::make_tuple(pos_err_info.first, pos_err_info.second, SiPixelRecHitQuality::QualWordType());
-  }
-  throw cms::Exception("FastPixelCPE") << "Cluster not filled.";
-}
-
-void FastPixelCPE::enterLocalParameters(unsigned int id, std::pair<int,int> &row_col, const std::pair<LocalPoint,LocalError>& pos_err_info) {
-  pos_err_map.insert(std::make_pair(std::make_pair(id,row_col), pos_err_info));
-}

--- a/FastSimulation/TrackingRecHitProducer/src/FastPixelCPE.h
+++ b/FastSimulation/TrackingRecHitProducer/src/FastPixelCPE.h
@@ -3,33 +3,25 @@
 
 //Header files
 #include "RecoLocalTracker/ClusterParameterEstimator/interface/PixelClusterParameterEstimator.h"
-#include "FastSimDataFormats/External/interface/FastTrackerCluster.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include <map>
-#include <memory>
 
-class FastPixelCPE : public PixelClusterParameterEstimator
+class FastPixelCPE final : public PixelClusterParameterEstimator
 {
  public:
   FastPixelCPE(){;}
-  
-  //Standard method used
-  //LocalValues is typedef for std::pair<LocalPoint,LocalError> 
-  PixelClusterParameterEstimator::ReturnType getParameters( const SiPixelCluster & cl,
-							       const GeomDetUnit    & det) const;
-	
-  //Put information into the map.
-  void enterLocalParameters(unsigned int id, std::pair<int,int> &row_col, const std::pair<LocalPoint,LocalError>& pos_err_info); 
-  
-  //Clear the map.
-  void clearParameters() const { 
-    pos_err_map.clear(); 
+
+  // these methods should retrieve the information from the SiPixelCluster itself
+  virtual ReturnType getParameters(const SiPixelCluster & cl,
+                                   const GeomDetUnit    & det ) const override {
+    return std::make_tuple(LocalPoint(),LocalError(),SiPixelRecHitQuality::QualWordType());
+  }
+  virtual ReturnType getParameters(const SiPixelCluster & cl,
+                                   const GeomDetUnit    & det,
+                                   const LocalTrajectoryParameters & ltp ) const override {
+    return std::make_tuple(LocalPoint(),LocalError(),SiPixelRecHitQuality::QualWordType());
   }
 
- private:
-  //Map used to store clusters distinctly.
-  mutable std::map<std::pair<unsigned int, std::pair<int,int> >, std::pair<LocalPoint, LocalError> > pos_err_map;
+  
 };
 
 #endif

--- a/FastSimulation/TrackingRecHitProducer/src/FastStripCPE.cc
+++ b/FastSimulation/TrackingRecHitProducer/src/FastStripCPE.cc
@@ -2,25 +2,12 @@
 #include "Geometry/CommonTopologies/interface/StripTopology.h"
 #include <algorithm>
 #include<cmath>
-#include<map>
 #include <memory>
-
-void FastStripCPE::enterLocalParameters(uint32_t id, uint16_t firstStrip, const std::pair<LocalPoint, LocalError>& pos_err_info ) {
-  //Filling the map.
-  pos_err_map.insert(std::make_pair(std::make_pair(id, firstStrip), pos_err_info));
-}
 
 
 StripClusterParameterEstimator::LocalValues FastStripCPE::localParameters( const SiStripCluster & cl,const GeomDetUnit& det) const {
-  // strip cluster never supported detID
-  std::map<std::pair<uint32_t,uint16_t>,std::pair<LocalPoint,LocalError> >::const_iterator strip_link = pos_err_map.find(std::make_pair(det.geographicalId(),cl.firstStrip()));
-  if (strip_link != pos_err_map.end()) {
-    std::pair<LocalPoint,LocalError> pos_err_info = strip_link->second;
-    LocalPoint result = pos_err_info.first;
-    LocalError eresult = pos_err_info.second;
-    return std::make_pair(result,eresult);
-  }
-  throw cms::Exception("FastStripCPE") << "Cluster not filled.";
+   //the information should be retrieved from the cluster itself.
+   return StripClusterParameterEstimator::LocalValues();
 }
 
 LocalVector FastStripCPE::driftDirection(const StripGeomDetUnit* det) const {

--- a/FastSimulation/TrackingRecHitProducer/src/FastStripCPE.h
+++ b/FastSimulation/TrackingRecHitProducer/src/FastStripCPE.h
@@ -17,20 +17,10 @@ class FastStripCPE : public StripClusterParameterEstimator
   
   //Standard method used
   //LocalValues is typedef for std::pair<LocalPoint,LocalError> 
-  StripClusterParameterEstimator::LocalValues localParameters( const SiStripCluster & cl,const GeomDetUnit& det) const;
-  
-  //Put information into the map.
-  void enterLocalParameters(uint32_t id, uint16_t firstStrip, const std::pair<LocalPoint,LocalError>& pos_err_info);
-  
-  //Clear the map.
-  void clearParameters() const {
-    pos_err_map.clear();
-  }
+  StripClusterParameterEstimator::LocalValues localParameters( const SiStripCluster & cl,const GeomDetUnit& det) const override;  
 
-  LocalVector driftDirection(const StripGeomDetUnit* det)const;
-  
- private:
-  mutable std::map<std::pair<uint32_t, uint16_t>,std::pair<LocalPoint, LocalError> >  pos_err_map;
+
+  LocalVector driftDirection(const StripGeomDetUnit* ) const override;
   
 };
 

--- a/FastSimulation/TrackingRecHitProducer/src/SiClusterTranslator.cc
+++ b/FastSimulation/TrackingRecHitProducer/src/SiClusterTranslator.cc
@@ -87,12 +87,11 @@ SiClusterTranslator::produce(edm::Event& e, const edm::EventSetup& es)
   
   edm::ESHandle<PixelClusterParameterEstimator> pixelCPE;
   es.get<TkPixelCPERecord>().get("FastPixelCPE",pixelCPE);
-  auto pixelcpe = pixelCPE->clone();
-  pixelcpe->clearParameters();
+  //  auto pixelcpe = pixelCPE->clone();
   
   edm::ESHandle<StripClusterParameterEstimator> stripCPE;
   es.get<TkStripCPERecord>().get("FastStripCPE", stripCPE); 
-  auto stripcpe = stripCPE->clone();
+  // auto stripcpe = stripCPE->clone();
     
   edm::Handle<CrossingFrame<PSimHit> > cf_simhit;
   std::vector<const CrossingFrame<PSimHit> *> cf_simhitvec;
@@ -118,9 +117,6 @@ SiClusterTranslator::produce(edm::Event& e, const edm::EventSetup& es)
   std::map< DetId, std::vector<SiPixelCluster> > temporaryPixelClusters;
   std::map< DetId, std::vector<SiStripCluster> > temporaryStripClusters;
   
-  //Clearing CPE maps from previous event.
-  stripcpe->clearParameters();
-  pixelcpe->clearParameters();
   
   int ClusterNum = 0;
   
@@ -145,7 +141,7 @@ SiClusterTranslator::produce(edm::Event& e, const edm::EventSetup& es)
     if (subdet < 3) {
       //Here is the hard part. From the position of the FastSim Cluster I need to figure out the Pixel location for the Cluster.
       LocalPoint position = aCluster->localPosition();
-      LocalError error = aCluster->localPositionError();
+      // LocalError error = aCluster->localPositionError();
       //std::cout << "The pixel charge is " << aCluster->charge() << std::endl;
       int charge = (int)(aCluster->charge() + 0.5);
       //std::cout << "The pixel charge after integer conversion is " << charge << std::endl;
@@ -166,8 +162,11 @@ SiClusterTranslator::produce(edm::Event& e, const edm::EventSetup& es)
       SiPixelCluster::PixelPos pixelPos((int)pixelPos_out.first, (int)pixelPos_out.second);
       
       //Filling Pixel CPE with information.
-      std::pair<int,int> row_col((int)pixelPos_out.first,(int)pixelPos_out.second);
-      pixelcpe->enterLocalParameters((unsigned int) det.rawId() , row_col, std::make_pair(position,error));
+      // FIXME this cannot be done. CPE is global and cannot be modified.
+      // this information has to be encoded in the Pixel cluster itself w/o changing it!
+      // CPE has just to retrieve it and return.
+      //std::pair<int,int> row_col((int)pixelPos_out.first,(int)pixelPos_out.second);
+      // pixelcpe->enterLocalParameters((unsigned int) det.rawId() , row_col, std::make_pair(position,error));
       
       unsigned int ch = PixelChannelIdentifier::pixelToChannel((int)pixelPos_out.first, (int)pixelPos_out.second);
       
@@ -189,13 +188,15 @@ SiClusterTranslator::produce(edm::Event& e, const edm::EventSetup& es)
     else if ((subdet > 2) && (subdet < 7)) {
       //Getting pos/err info from the cluster
       LocalPoint position = aCluster->localPosition();
-      LocalError error = aCluster->localPositionError();
+      // LocalError error = aCluster->localPositionError();
       
       //Will have to make charge into ADC eventually...
       uint16_t charge = (uint16_t)(aCluster->charge() + 0.5);
       
       //std::cout << "The charge is " << charge << std::endl;
       
+      // FIXME VI there is something wrong here
+      // each "digi" is a new strip that this algorithm will add at the right of "strip_num"
       uint16_t strip_num = 0;
       std::vector<uint16_t> digi_vec;
       while (charge > 255) { 
@@ -221,7 +222,10 @@ SiClusterTranslator::produce(edm::Event& e, const edm::EventSetup& es)
       }
       
       //Filling Strip CPE with info.
-      stripcpe->enterLocalParameters(det.rawId(), strip_num, std::make_pair(position,error));
+      // FIXME this cannot be done. CPE	is global and cannot be	modified.
+      // this information has to be encoded in the Strip cluster itself	w/o modifing it!
+      // CPE has just to retrieve it and return.
+      // stripcpe->enterLocalParameters(det.rawId(), strip_num, std::make_pair(position,error));
       
       //Creating a new strip cluster
       SiStripCluster temporaryStripCluster(strip_num, digi_vec.begin(), digi_vec.end());

--- a/RecoLocalTracker/ClusterParameterEstimator/interface/PixelClusterParameterEstimator.h
+++ b/RecoLocalTracker/ClusterParameterEstimator/interface/PixelClusterParameterEstimator.h
@@ -20,26 +20,19 @@ class PixelClusterParameterEstimator
   
   typedef std::pair<LocalPoint,LocalError>  LocalValues;
   typedef std::vector<LocalValues> VLocalValues;
-  //methods needed by FastSim
-  virtual void enterLocalParameters(unsigned int id, std::pair<int,int>
-				    &row_col, LocalValues pos_err_info) {}
-  virtual void enterLocalParameters(uint32_t id, uint16_t firstStrip,
-				    LocalValues pos_err_info) {}
-  virtual void clearParameters() {}
-  
+
   using ReturnType = std::tuple<LocalPoint,LocalError,SiPixelRecHitQuality::QualWordType>;
 
   // here just to implement it in the clients;
   // to be properly implemented in the sub-classes in order to make them thread-safe
+
   virtual ReturnType getParameters(const SiPixelCluster & cl, 
-				   const GeomDetUnit    & det ) const {
-    return std::make_tuple(LocalPoint(),LocalError(),SiPixelRecHitQuality::QualWordType());
-  }
+                                   const GeomDetUnit    & det) const =0;
+
   virtual ReturnType getParameters(const SiPixelCluster & cl, 
 				   const GeomDetUnit    & det, 
-				   const LocalTrajectoryParameters & ltp ) const {
-    return std::make_tuple(LocalPoint(),LocalError(),SiPixelRecHitQuality::QualWordType());
-  }
+				   const LocalTrajectoryParameters & ltp ) const =0;
+
   virtual ReturnType getParameters(const SiPixelCluster & cl, 
 				   const GeomDetUnit    & det, 
 				   const TrajectoryStateOnSurface& tsos ) const {
@@ -59,9 +52,6 @@ class PixelClusterParameterEstimator
     return vlp;
   }
 
-  virtual std::unique_ptr<PixelClusterParameterEstimator> clone() const {
-    return std::unique_ptr<PixelClusterParameterEstimator>(new PixelClusterParameterEstimator(*this));
-  }
 
   PixelClusterParameterEstimator() : clusterProbComputationFlag_(0){}
 

--- a/RecoLocalTracker/ClusterParameterEstimator/interface/StripClusterParameterEstimator.h
+++ b/RecoLocalTracker/ClusterParameterEstimator/interface/StripClusterParameterEstimator.h
@@ -27,6 +27,7 @@ class StripClusterParameterEstimator
  public:
   typedef std::pair<LocalPoint,LocalError>  LocalValues;
   typedef std::vector<LocalValues> VLocalValues;
+
   virtual LocalValues localParameters( const SiStripCluster&,const GeomDetUnit&) const {
       return std::make_pair(LocalPoint(), LocalError());
   }
@@ -47,65 +48,13 @@ class StripClusterParameterEstimator
     return vlp;
   }
 
-  virtual std::unique_ptr<StripClusterParameterEstimator> clone() const {
-    return std::unique_ptr<StripClusterParameterEstimator>(new StripClusterParameterEstimator(*this));
-  }
+  
+  // used by Validation....
+  virtual LocalVector driftDirection(const StripGeomDetUnit* ) const =0;
 
   virtual ~StripClusterParameterEstimator(){}
   
-  //methods needed by FastSim
-  virtual void enterLocalParameters(unsigned int id, std::pair<int,int>
-				    &row_col, LocalValues pos_err_info) {}
-  virtual void enterLocalParameters(uint32_t id, uint16_t firstStrip,
-				    LocalValues pos_err_info) {}
-  virtual void clearParameters() {}
 
-  typedef std::pair<MeasurementPoint,MeasurementError>  MeasurementValues;
-  virtual LocalVector driftDirection(const StripGeomDetUnit* det)const {
-    return LocalVector();
-  }
-
-  //
-  // methods to get directly the measurements
-  //
-
-  virtual MeasurementValues measurementParameters( const SiStripCluster&,const GeomDetUnit&) const
-  {
-    throw cms::Exception("Not implemented")
-      << "StripClusterParameterEstimator::measurementParameters not yet implemented"<< std::endl;
-  }
-
-  virtual MeasurementValues measurementParameters( const SiStripCluster& cluster,
-                                                   const GeomDetUnit& gd,
-                                                   const LocalTrajectoryParameters & ltp) const
-  {
-    throw cms::Exception("Not implemented") << "StripClusterParameterEstimator::measurementParameters not yet implemented"<<
- std::endl;
-  }
-
-
-  float templateProbability() const
-  {
-    return stripCPEtemplateProbability_;
-  }
-
-  int templateQbin() const
-  {
-    return stripCPEtemplateQbin_;
-  }
-
-  void templateProbability( float stp )
-  {
-    stripCPEtemplateProbability_ = stp;
-  }
-
-  void templateQbin( int stqb )
-  {
-    stripCPEtemplateQbin_ = stqb;
-  }
-
-  mutable float stripCPEtemplateProbability_;
-  mutable int stripCPEtemplateQbin_;
 
 };
 


### PR DESCRIPTION
remove unused attributes and methods, 
made FastCPE dummy as non implementable in the way it was used to be (if ever it worked that way)
