### PR TITLE
Removed unnecessary static variable declaration from CaloTauSelectorDefinition

### DIFF
--- a/RecoTauTag/TauTagTools/plugins/CaloTauSelectorDefinition.h
+++ b/RecoTauTag/TauTagTools/plugins/CaloTauSelectorDefinition.h
@@ -64,7 +64,7 @@ struct CaloTauSelectorDefinition {
     }
 
     unsigned key=0;
-    static bool passedAllCuts;
+    bool passedAllCuts;
     for( collection::const_iterator calotau = hc->begin();
           calotau != hc->end();
           ++calotau, ++key)


### PR DESCRIPTION
The static analyzer flagged the static as a thread safety issue. Turns out
a local variable is actually what should have been intended.
