### PR TITLE
Fix memory hoarding bug

### DIFF
--- a/FWCore/Utilities/interface/TypeWithDict.h
+++ b/FWCore/Utilities/interface/TypeWithDict.h
@@ -119,6 +119,9 @@ public:
   void deallocate(void* address) const;
   ObjectWithDict construct() const;
   void destruct(void* address, bool dealloc = true) const;
+  void* ttype() const {
+    return type_;
+  }
 };
 
 // A related free function

--- a/FWCore/Utilities/src/ObjectWithDict.cc
+++ b/FWCore/Utilities/src/ObjectWithDict.cc
@@ -18,12 +18,12 @@ namespace edm {
   }
 
   ObjectWithDict::ObjectWithDict(TypeWithDict const& type, void* address) :
-    type_(gInterpreter->Type_Factory(type.typeInfo())),
+    type_(static_cast<TType*>(type.ttype())),
     address_(address) {
   }
 
   ObjectWithDict::ObjectWithDict(std::type_info const& ti, void* address) :
-    type_(gInterpreter->Type_Factory(ti)),
+    type_(static_cast<TType*>(TypeWithDict(ti).ttype())),
     address_(address) {
   }
 


### PR DESCRIPTION
This request is a fix for a bug causing hoarding of memory in the ROOT6 IB.  Without this fix, in step 1 of Relval 5.1, the memory footprint increases by 26MB per event.  With this fix, the memory footprint increases by only 5MB per event.
Please merge this request as soon as convenient unless there are issues.
