### PR TITLE
hlttracking parabolic mf: fix default configuration

### DIFF
--- a/RecoTracker/TrackProducer/python/TrackProducer_cfi.py
+++ b/RecoTracker/TrackProducer/python/TrackProducer_cfi.py
@@ -1,6 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
 TrackProducer = cms.EDProducer("TrackProducer",
+    useSimpleMF = cms.bool(False),
+    SimpleMagneticField = cms.string(""),
     src = cms.InputTag("ckfTrackCandidates"),
     clusterRemovalInfo = cms.InputTag(""),
     beamSpot = cms.InputTag("offlineBeamSpot"),

--- a/TrackingTools/MaterialEffects/python/MaterialPropagator_cfi.py
+++ b/TrackingTools/MaterialEffects/python/MaterialPropagator_cfi.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 MaterialPropagator = cms.ESProducer("PropagatorWithMaterialESProducer",
+    SimpleMagneticField = cms.string(""),
     MaxDPhi = cms.double(1.6),
     ComponentName = cms.string('PropagatorWithMaterial'),
     Mass = cms.double(0.105),

--- a/TrackingTools/MaterialEffects/python/OppositeMaterialPropagator_cfi.py
+++ b/TrackingTools/MaterialEffects/python/OppositeMaterialPropagator_cfi.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 OppositeMaterialPropagator = cms.ESProducer("PropagatorWithMaterialESProducer",
+    SimpleMagneticField = cms.string(""),
     MaxDPhi = cms.double(1.6),
     ComponentName = cms.string('PropagatorWithMaterialOpposite'),
     Mass = cms.double(0.105),


### PR DESCRIPTION
add missing parameters in the default configurations
for TrackProducer and PropagatorWithMaterialESProducer
