### PR TITLE
Bug fix: TrackerTopologyEP added and Warning log file added

### DIFF
--- a/DQM/SiStripMonitorSummary/test/DBReader_Quality_cfg.py
+++ b/DQM/SiStripMonitorSummary/test/DBReader_Quality_cfg.py
@@ -20,13 +20,16 @@ process.load("CalibTracker.Configuration.Tracker_DependentRecords_forGlobalTag_n
 )
 
 process.source = cms.Source("EmptyIOVSource",
-                            lastValue = cms.uint64(1000000),
+                            lastValue = cms.uint64(216000),
                             timetype = cms.string('runnumber'),
-                            firstValue = cms.uint64(1000000),
+                            firstValue = cms.uint64(216000),
                             interval = cms.uint64(1)
                             )
 
 
+# the DB Geometry is NOT used because in this cfg only one tag is taken from the DB and no GT is used. To be fixed if this is a problem
+process.load('Configuration.Geometry.GeometryExtended_cff')
+process.TrackerTopologyEP = cms.ESProducer("TrackerTopologyEP")
 
 process.a = cms.ESSource("PoolDBESSource",
    BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
@@ -67,6 +70,8 @@ process.siStripQualityESProducer = cms.ESProducer("SiStripQualityESProducer",
     ThresholdForReducedGranularity = cms.double(0.2),
     appendToDataLabel = cms.string(''),
     ReduceGranularity = cms.bool(False),
+    PrintDebugOutput = cms.bool(False),
+    UseEmptyRunInfo = cms.bool(False),
     ListOfRecordToMerge = cms.VPSet(cms.PSet(
 ##    record = cms.string('SiStripDetVOffRcd'),
 ##    record = cms.string('SiStripDetCablingRcd'),
@@ -81,9 +86,6 @@ process.maxEvents = cms.untracked.PSet(
     )
 process.MessageLogger = cms.Service("MessageLogger",
                                     debugModules = cms.untracked.vstring(''),
-    Reader = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO')
-    ),                                    
                                     cout = cms.untracked.PSet(
     threshold = cms.untracked.string('INFO')
     ),

--- a/DQM/SiStripMonitorSummary/test/DBReader_cfg.py
+++ b/DQM/SiStripMonitorSummary/test/DBReader_cfg.py
@@ -15,7 +15,7 @@ process.MessageLogger = cms.Service("MessageLogger",
     cout = cms.untracked.PSet(
         threshold = cms.untracked.string('INFO')
     ),
-    destinations = cms.untracked.vstring('cout') #Reader.log
+    destinations = cms.untracked.vstring('cout','Reader') #Reader.log
 )
 
 process.maxEvents = cms.untracked.PSet(
@@ -29,7 +29,9 @@ process.source = cms.Source("EmptyIOVSource",
     interval = cms.uint64(1)
 )
 
-
+# the DB Geometry is NOT used because in this cfg only one tag is taken from the DB and no GT is used. To be fixed if this is a problem
+process.load('Configuration.Geometry.GeometryExtended_cff')
+process.TrackerTopologyEP = cms.ESProducer("TrackerTopologyEP")
 
 process.poolDBESSource = cms.ESSource("PoolDBESSource",
    BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
@@ -124,7 +126,7 @@ process.CondDataMonitoring.MonitorSiStripQuality       = False
 process.CondDataMonitoring.MonitorSiStripCabling       = False
 process.CondDataMonitoring.MonitorSiStripApvGain       = False
 process.CondDataMonitoring.MonitorSiStripLorentzAngle  = True
-process.CondDataMonitoring.MonitorSiStripBackPlaneCorrection  = True
+process.CondDataMonitoring.MonitorSiStripBackPlaneCorrection  = False
 process.CondDataMonitoring.MonitorSiStripLowThreshold  = False
 process.CondDataMonitoring.MonitorSiStripHighThreshold = False
 

--- a/DQM/SiStripMonitorSummary/test/DBReader_conddbmonitoring_generic_cfg.py
+++ b/DQM/SiStripMonitorSummary/test/DBReader_conddbmonitoring_generic_cfg.py
@@ -132,18 +132,18 @@ options.parseArguments()
 
 process.MessageLogger = cms.Service("MessageLogger",
                                     debugModules = cms.untracked.vstring(''),
-#    cout = cms.untracked.PSet(
-#        threshold = cms.untracked.string('INFO')
                                     destinations = cms.untracked.vstring(options.logDestination,
                                                                          options.qualityLogDestination,
                                                                          options.cablingLogDestination,
-                                                                         options.condLogDestination
+                                                                         options.condLogDestination,
+                                                                         'cout'
                                                                          ), #Reader, cout
                                     categories = cms.untracked.vstring('SiStripQualityStatistics',
                                                                        'SiStripQualityDQM',
                                                                        'SiStripFedCablingReader',
                                                                        'DummyCondObjContentPrinter',
-                                                                       )
+                                                                       ),
+                                    cout = cms.untracked.PSet(threshold = cms.untracked.string('WARNING'))
 )
 setattr(process.MessageLogger,options.logDestination,cms.untracked.PSet(threshold = cms.untracked.string('INFO')))
 setattr(process.MessageLogger,options.qualityLogDestination,cms.untracked.PSet(

--- a/DQM/SiStripMonitorSummary/test/DBReader_specifc_cfg.py
+++ b/DQM/SiStripMonitorSummary/test/DBReader_specifc_cfg.py
@@ -15,7 +15,7 @@ process.MessageLogger = cms.Service("MessageLogger",
     cout = cms.untracked.PSet(
         threshold = cms.untracked.string('INFO')
     ),
-    destinations = cms.untracked.vstring('cout') #Reader.log
+    destinations = cms.untracked.vstring('cout','Reader') #Reader.log
 )
 
 process.maxEvents = cms.untracked.PSet(
@@ -29,7 +29,9 @@ process.source = cms.Source("EmptyIOVSource",
     interval = cms.uint64(1)
 )
 
-
+# the DB Geometry is NOT used because in this cfg only one tag is taken from the DB and no GT is used. To be fixed if this is a problem
+process.load('Configuration.Geometry.GeometryExtended_cff')
+process.TrackerTopologyEP = cms.ESProducer("TrackerTopologyEP")
 
 process.poolDBESSource = cms.ESSource("PoolDBESSource",
     BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),

--- a/DQM/SiStripMonitorSummary/test/RunInfo_conddbmonitoring_cfg.py
+++ b/DQM/SiStripMonitorSummary/test/RunInfo_conddbmonitoring_cfg.py
@@ -90,6 +90,10 @@ process.source = cms.Source("EmptyIOVSource",
     interval = cms.uint64(1)
 )
 
+# the DB Geometry is NOT used because in this cfg only one tag is taken from the DB and no GT is used. To be fixed if this is a problem
+process.load('Configuration.Geometry.GeometryExtended_cff')
+process.TrackerTopologyEP = cms.ESProducer("TrackerTopologyEP")
+
 process.poolDBESSourceRunInfo = cms.ESSource("PoolDBESSource",
    BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
    DBParameters = cms.PSet(

--- a/DQM/SiStripMonitorSummary/test/SiStripCorrelateBadStripAndNoise_cfg.py
+++ b/DQM/SiStripMonitorSummary/test/SiStripCorrelateBadStripAndNoise_cfg.py
@@ -14,6 +14,10 @@ process.source = cms.Source("EmptyIOVSource",
                             interval = cms.uint64(1)
                             )
 
+# the DB Geometry is NOT used because in this cfg only one tag is taken from the DB and no GT is used. To be fixed if this is a problem
+process.load('Configuration.Geometry.GeometryExtended_cff')
+process.TrackerTopologyEP = cms.ESProducer("TrackerTopologyEP")
+
 process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(-1))
 
 process.poolDBESSource = cms.ESSource(

--- a/DQM/SiStripMonitorSummary/test/SiStripCorrelateNoise_cfg.py
+++ b/DQM/SiStripMonitorSummary/test/SiStripCorrelateNoise_cfg.py
@@ -13,6 +13,10 @@ process.source = cms.Source("EmptyIOVSource",
                             interval = cms.uint64(1)
                             )
 
+# the DB Geometry is NOT used because in this cfg only one tag is taken from the DB and no GT is used. To be fixed if this is a problem
+process.load('Configuration.Geometry.GeometryExtended_cff')
+process.TrackerTopologyEP = cms.ESProducer("TrackerTopologyEP")
+
 process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(-1))
 
 process.poolDBESSource = cms.ESSource(

--- a/DQM/SiStripMonitorSummary/test/SiStripCorrelateNoise_conddbmonitoring_cfg.py
+++ b/DQM/SiStripMonitorSummary/test/SiStripCorrelateNoise_conddbmonitoring_cfg.py
@@ -37,7 +37,8 @@ options.parseArguments()
 
 process.MessageLogger = cms.Service("MessageLogger",
                                     out = cms.untracked.PSet(threshold = cms.untracked.string('INFO')),
-                                    destinations = cms.untracked.vstring('out')
+                                    cout = cms.untracked.PSet(threshold = cms.untracked.string('WARNING')),
+                                    destinations = cms.untracked.vstring('out','cout')
                                     )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/DQM/SiStripMonitorSummary/test/SiStripCorrelateNoise_conddbmonitoring_cfg.py
+++ b/DQM/SiStripMonitorSummary/test/SiStripCorrelateNoise_conddbmonitoring_cfg.py
@@ -47,6 +47,10 @@ process.source = cms.Source("EmptyIOVSource",
                             interval = cms.uint64(1)
                             )
 
+# the DB Geometry is NOT used because in this cfg only one tag is taken from the DB and no GT is used. To be fixed if this is a problem
+process.load('Configuration.Geometry.GeometryExtended_cff')
+process.TrackerTopologyEP = cms.ESProducer("TrackerTopologyEP")
+
 process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(-1))
 
 process.poolDBESSource = cms.ESSource(

--- a/DQM/SiStripMonitorSummary/test/SiStripPlotGain_cfg.py
+++ b/DQM/SiStripMonitorSummary/test/SiStripPlotGain_cfg.py
@@ -13,6 +13,10 @@ process.source = cms.Source("EmptyIOVSource",
                             interval = cms.uint64(1)
                             )
 
+# the DB Geometry is NOT used because in this cfg only one tag is taken from the DB and no GT is used. To be fixed if this is a problem
+process.load('Configuration.Geometry.GeometryExtended_cff')
+process.TrackerTopologyEP = cms.ESProducer("TrackerTopologyEP")
+
 process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(-1))
 
 process.poolDBESSource = cms.ESSource(


### PR DESCRIPTION
Due to the absence of TrackerTopologyEP configuration in some workflows, the monitoring of the noise ratio failed silently. Warning messages added to the cronjob log file to avoid similar problems in future
