### PR TITLE
Convert modules used in production to stream modules

### DIFF
--- a/CommonTools/ParticleFlow/plugins/PFCandIsolatorFromDeposit.h
+++ b/CommonTools/ParticleFlow/plugins/PFCandIsolatorFromDeposit.h
@@ -1,7 +1,7 @@
 #ifndef PFCandIsolatorFromDeposits_H
 #define PFCandIsolatorFromDeposits_H
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
@@ -20,7 +20,7 @@
 namespace edm { class Event; }
 namespace edm { class EventSetup; }
 
-class PFCandIsolatorFromDeposits : public edm::EDProducer {
+class PFCandIsolatorFromDeposits : public edm::stream::EDProducer<> {
 
 public:
   typedef edm::ValueMap<double> CandDoubleMap;

--- a/CommonTools/ParticleFlow/plugins/PFPileUp.h
+++ b/CommonTools/ParticleFlow/plugins/PFPileUp.h
@@ -7,7 +7,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "FWCore/Framework/interface/Event.h"
@@ -31,7 +31,7 @@ produces the corresponding collection of PileUpCandidates.
 
 
 
-class PFPileUp : public edm::EDProducer {
+class PFPileUp : public edm::stream::EDProducer<> {
  public:
 
   typedef std::vector< edm::FwdPtr<reco::PFCandidate> >  PFCollection;

--- a/EventFilter/CSCRawToDigi/interface/CSCDCCUnpacker.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCDCCUnpacker.h
@@ -8,14 +8,14 @@
  */
 
 #include <FWCore/Framework/interface/ConsumesCollector.h>
-#include <FWCore/Framework/interface/EDProducer.h>
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include <FWCore/ParameterSet/interface/ParameterSet.h>
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 
 class CSCMonitorInterface;
 
-class CSCDCCUnpacker: public edm::EDProducer {
+class CSCDCCUnpacker: public edm::stream::EDProducer<> {
  public:
   /// Constructor
   CSCDCCUnpacker(const edm::ParameterSet & pset);

--- a/EventFilter/CSCTFRawToDigi/interface/CSCTFUnpacker.h
+++ b/EventFilter/CSCTFRawToDigi/interface/CSCTFUnpacker.h
@@ -1,7 +1,7 @@
 #ifndef CSCTFUnpacker_h
 #define CSCTFUnpacker_h
 
-#include <FWCore/Framework/interface/EDProducer.h>
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include <FWCore/ParameterSet/interface/ParameterSet.h>
 #include <FWCore/Utilities/interface/InputTag.h>
 
@@ -13,7 +13,7 @@
 
 class CSCTriggerMapping;
 
-class CSCTFUnpacker: public edm::EDProducer {
+class CSCTFUnpacker: public edm::stream::EDProducer<> {
 private:
 	int  m_minBX, m_maxBX;
 	bool swapME1strips;

--- a/EventFilter/CSCTFRawToDigi/plugins/CSCTFUnpacker.cc
+++ b/EventFilter/CSCTFRawToDigi/plugins/CSCTFUnpacker.cc
@@ -36,7 +36,7 @@
 //#include <iostream>
 #include <sstream>
 
-CSCTFUnpacker::CSCTFUnpacker(const edm::ParameterSet& pset):edm::EDProducer(),mapping(0){
+CSCTFUnpacker::CSCTFUnpacker(const edm::ParameterSet& pset):edm::stream::EDProducer<>(),mapping(0){
 	LogDebug("CSCTFUnpacker|ctor")<<"Started ...";
 
 	// Edges of the time window, which LCTs are put into (unlike tracks, which are always centred around 0):

--- a/EventFilter/CastorRawToDigi/plugins/CastorRawToDigi.h
+++ b/EventFilter/CastorRawToDigi/plugins/CastorRawToDigi.h
@@ -14,7 +14,7 @@
  *
  ************************************************************/
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
@@ -26,7 +26,7 @@
 #include "EventFilter/CastorRawToDigi/interface/CastorCtdcUnpacker.h"
 #include "EventFilter/CastorRawToDigi/interface/CastorDataFrameFilter.h"
 
-class CastorRawToDigi : public edm::EDProducer
+class CastorRawToDigi : public edm::stream::EDProducer<>
 {
 public:
   explicit CastorRawToDigi(const edm::ParameterSet& ps);

--- a/EventFilter/DTTFRawToDigi/interface/DTTFFEDReader.h
+++ b/EventFilter/DTTFRawToDigi/interface/DTTFFEDReader.h
@@ -18,13 +18,13 @@
 #include "DataFormats/L1DTTrackFinder/interface/L1MuDTChambThContainer.h"
 #include "DataFormats/L1DTTrackFinder/interface/L1MuDTTrackContainer.h"
 
-#include <FWCore/Framework/interface/EDProducer.h>
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include <FWCore/ParameterSet/interface/ParameterSet.h>
 #include <FWCore/Utilities/interface/InputTag.h>
 
 #include <string>
 
-class DTTFFEDReader : public edm::EDProducer {
+class DTTFFEDReader : public edm::stream::EDProducer<> {
 
  public:
 

--- a/EventFilter/ESRawToDigi/interface/ESRawToDigi.h
+++ b/EventFilter/ESRawToDigi/interface/ESRawToDigi.h
@@ -3,7 +3,7 @@
 
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "EventFilter/ESRawToDigi/interface/ESUnpacker.h"
@@ -11,7 +11,7 @@
 #include "DataFormats/EcalRawData/interface/ESListOfFEDS.h"
 
 
-class ESRawToDigi : public edm::EDProducer {
+class ESRawToDigi : public edm::stream::EDProducer<> {
   
  public:
   

--- a/EventFilter/EcalRawToDigi/plugins/EcalRawToDigi.h
+++ b/EventFilter/EcalRawToDigi/plugins/EcalRawToDigi.h
@@ -27,7 +27,7 @@
 
 #include <DataFormats/Common/interface/Handle.h>
 #include <FWCore/Framework/interface/Event.h>
-#include <FWCore/Framework/interface/EDProducer.h>
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include <FWCore/MessageLogger/interface/MessageLogger.h>
 #include <FWCore/ParameterSet/interface/ParameterSet.h>
 #include <FWCore/Framework/interface/ESWatcher.h>
@@ -38,7 +38,7 @@ class EcalElectronicsMapper;
 class EcalElectronicsMapping;
 class DCCDataUnpacker;
 
-class EcalRawToDigi : public edm::EDProducer{
+class EcalRawToDigi : public edm::stream::EDProducer<>{
 
  public:
   /**

--- a/EventFilter/L1GlobalTriggerRawToDigi/interface/L1GlobalTriggerEvmRawToDigi.h
+++ b/EventFilter/L1GlobalTriggerRawToDigi/interface/L1GlobalTriggerEvmRawToDigi.h
@@ -21,7 +21,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -41,7 +41,7 @@ class FEDTrailer;
 
 
 // class declaration
-class L1GlobalTriggerEvmRawToDigi : public edm::EDProducer
+class L1GlobalTriggerEvmRawToDigi : public edm::stream::EDProducer<>
 {
 
 public:

--- a/EventFilter/L1GlobalTriggerRawToDigi/interface/L1GlobalTriggerRawToDigi.h
+++ b/EventFilter/L1GlobalTriggerRawToDigi/interface/L1GlobalTriggerRawToDigi.h
@@ -22,7 +22,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -46,7 +46,7 @@ class L1MuTriggerPtScale;
 
 
 // class declaration
-class L1GlobalTriggerRawToDigi : public edm::EDProducer
+class L1GlobalTriggerRawToDigi : public edm::stream::EDProducer<>
 {
 
 public:

--- a/EventFilter/L1GlobalTriggerRawToDigi/interface/L1GlobalTriggerRecordProducer.h
+++ b/EventFilter/L1GlobalTriggerRawToDigi/interface/L1GlobalTriggerRecordProducer.h
@@ -20,7 +20,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -32,7 +32,7 @@
 class L1GtTriggerMask;
 
 // class declaration
-class L1GlobalTriggerRecordProducer : public edm::EDProducer
+class L1GlobalTriggerRecordProducer : public edm::stream::EDProducer<>
 {
 
 public:
@@ -45,12 +45,7 @@ public:
 
 private:
 
-    virtual void beginJob();
-
-    virtual void produce(edm::Event&, const edm::EventSetup&);
-
-    ///
-    virtual void endJob();
+    virtual void produce(edm::Event&, const edm::EventSetup&) override;
 
 private:
     

--- a/EventFilter/L1GlobalTriggerRawToDigi/src/L1GlobaTriggerRecordProducer.cc
+++ b/EventFilter/L1GlobalTriggerRawToDigi/src/L1GlobaTriggerRecordProducer.cc
@@ -69,11 +69,6 @@ L1GlobalTriggerRecordProducer::~L1GlobalTriggerRecordProducer()
 
 // member functions
 
-void L1GlobalTriggerRecordProducer::beginJob()
-{
-    // empty
-}
-
 // method called to produce the data
 void L1GlobalTriggerRecordProducer::produce(edm::Event& iEvent, const edm::EventSetup& evSetup)
 {
@@ -229,14 +224,6 @@ void L1GlobalTriggerRecordProducer::produce(edm::Event& iEvent, const edm::Event
     iEvent.put( gtRecord );
 
 }
-
-//
-void L1GlobalTriggerRecordProducer::endJob()
-{
-
-    // empty now
-}
-
 
 // static class members
 

--- a/EventFilter/RPCRawToDigi/plugins/RPCUnpackingModule.h
+++ b/EventFilter/RPCRawToDigi/plugins/RPCUnpackingModule.h
@@ -6,7 +6,7 @@
  ** unpacking RPC raw data
  **/
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Framework/interface/ESWatcher.h"
 #include "CondFormats/DataRecord/interface/RPCEMapRcd.h"
@@ -17,7 +17,7 @@
 class RPCReadOutMapping;
 namespace edm { class Event; class EventSetup; class Run; }
 
-class RPCUnpackingModule: public edm::EDProducer {
+class RPCUnpackingModule: public edm::stream::EDProducer<> {
 public:
     
     ///Constructor

--- a/EventFilter/ScalersRawToDigi/src/ScalersRawToDigi.cc
+++ b/EventFilter/ScalersRawToDigi/src/ScalersRawToDigi.cc
@@ -16,7 +16,7 @@
 
 #include <memory>
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -35,7 +35,7 @@
 #include "DataFormats/Scalers/interface/DcsStatus.h"
 #include "DataFormats/Scalers/interface/ScalersRaw.h"
 
-class ScalersRawToDigi : public edm::EDProducer 
+class ScalersRawToDigi : public edm::stream::EDProducer<> 
 {
   public:
     explicit ScalersRawToDigi(const edm::ParameterSet&);

--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigi.h
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigi.h
@@ -7,7 +7,7 @@
  */
 
 #include "FWCore/Framework/interface/ESWatcher.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -23,7 +23,7 @@ class TH1D;
 class R2DTimerObserver;
 class PixelUnpackingRegions;
 
-class SiPixelRawToDigi : public edm::EDProducer {
+class SiPixelRawToDigi : public edm::stream::EDProducer<> {
 public:
 
   /// ctor

--- a/FWCore/Utilities/bin/edmConvertToStreamModule.py
+++ b/FWCore/Utilities/bin/edmConvertToStreamModule.py
@@ -82,8 +82,8 @@ def edit_file(fileName,moduleType,moduleName):
   fNew = open(fileName+"_NEW","w")
   
   lookingForChanges = True
+  addedInclude = False
   for l in fOld.readlines():
-    addedInclude = False
     if lookingForChanges:
       if -1 != l.find("#include"):
         if moduleType == kProducer:

--- a/FWCore/Utilities/bin/edmConvertToStreamModule.py
+++ b/FWCore/Utilities/bin/edmConvertToStreamModule.py
@@ -1,0 +1,84 @@
+#! /usr/bin/env python
+
+import subprocess
+import shutil
+import sys
+
+kProducer = 0
+kFilter = 1
+
+def find_file_for_module(name):
+  try:
+    found = subprocess.check_output(["git","grep", "class *"+name+" *: *public .*edm::EDProducer"])
+    type = kProducer
+  except:
+    try:
+      found = subprocess.check_output(["git","grep", "class *"+name+" *: *public .*edm::EDFilter"])
+      type = kFilter
+    except:
+      print "ERROR: Unable to find class declaration for "+name
+      exit(1)
+  lfound = found.split("\n")
+  if len(lfound) > 2:
+    print "ERROR: found more than one declaration of "+name
+    print lfound
+    exit(1)
+  s = lfound[0]
+  return (s[:s.find(":")],type)
+  
+def checkout_package(fileName):
+  c = fileName.split("/")
+  print "checking out "+c[0]+"/"+c[1]
+  sparce_checkout = ".git/info/sparse-checkout"
+  f = open(sparce_checkout,"r")
+  linesInSparse = set(f.readlines())
+  f.close()
+  linesInSparse.add(c[0]+"/"+c[1]+"\n")
+  
+  f = open(sparce_checkout+"_new","w")
+  for l in linesInSparse:
+    if l:
+      f.write(l)
+  f.close()
+  shutil.move(sparce_checkout,sparce_checkout+"_old")
+  shutil.move(sparce_checkout+"_new",sparce_checkout)
+  subprocess.call(["git","read-tree","-mu","HEAD"])
+
+def edit_file(fileName,moduleType,moduleName):
+  print " editting "+fileName
+  fOld = open(fileName)
+  fNew = open(fileName+"_NEW","w")
+  
+  lookingForChanges = True
+  for l in fOld.readlines():
+    if lookingForChanges:
+      if -1 != l.find("#include"):
+        if moduleType == kProducer:
+          if -1 != l.find("FWCore/Framework/interface/EDProducer.h"):
+            l='#include "FWCore/Framework/interface/stream/EDProducer.h"\n'
+        elif moduleType == kFilter:
+          if -1 != l.find("FWCore/Framework/interface/EDFilter.h"):
+            l = '#include "FWCore/Framework/interface/stream/EDFilter.h"\n'
+      elif -1 != l.find("class"):
+        if -1 != l.find(moduleName):
+          if moduleType == kProducer:
+            if -1 != l.find("edm::EDProducer"):
+              l = l.replace("edm::EDProducer","edm::stream::EDProducer<>")
+              lookingForChanges = False
+          elif moduleType == kFilter:
+            if -1 != l.find("edm::EDFilter"):
+              l=l.replace("edm::EDFilter","edm::stream::EDFilter<>")
+    fNew.write(l)
+  fNew.close()
+  fOld.close()
+  shutil.move(fileName,fileName+"_OLD")
+  shutil.move(fileName+"_NEW",fileName)
+
+modules = sys.argv[1:]
+
+for m in modules:
+  f,t = find_file_for_module(m)
+  if f:
+    checkout_package(f)
+    edit_file(f,t,m)
+

--- a/FWCore/Utilities/bin/edmConvertToStreamModule.py
+++ b/FWCore/Utilities/bin/edmConvertToStreamModule.py
@@ -3,28 +3,60 @@
 import subprocess
 import shutil
 import sys
+import re
 
 kProducer = 0
 kFilter = 1
 
-def find_file_for_module(name):
+def find_all_module_classes():
+  s = set()
+  found = subprocess.check_output(["git","grep", "class *[A-Za-z0-9_<>]* *: *public "])
+  s.update(found.split("\n"))
+
+  ret = dict()
+  for l in s:
+    parts = l.split(":")
+    if len(parts)>2:
+      file = parts[0]
+      name = parts[1]
+      name = name[name.find("class")+5:].strip()
+      ret.setdefault(name,[]).append((":".join(parts[2:]), file))
+  
+  return ret
+
+def print_lines(lines):
+  for l in lines:
+    if len(l)>0:
+      print "  ",l
+
+def find_file_for_module(name,all_modules):
+  if name in all_modules:
+    info = all_modules[name]
+    if len(info) != 1:
+      print "ERROR: more than one declaration for '"+name+"'\n"
+      for inherits,file in info:
+        print "  ",file, inherits
+      return (None,None)
+    inherits,file = info[0]
+    if -1 != inherits.find("edm::EDProducer"):
+      type = kProducer
+    elif -1 != inherits.find("edm::EDFilter"):
+      type = kFilter
+    else:
+      print "ERROR: class '"+name+"' does not directly inherit from EDProducer or EDFilter\n  "+inherits
+      return (None,None)
+    return (file,type)
+  print "ERROR: did not find a standard class declaration for '"+name+"'"
   try:
-    found = subprocess.check_output(["git","grep", "class *"+name+" *: *public .*edm::EDProducer"])
-    type = kProducer
+    found = subprocess.check_output(["git","grep", "class *"+name+" *:"])
+    print_lines( found.split("\n") )
   except:
     try:
-      found = subprocess.check_output(["git","grep", "class *"+name+" *: *public .*edm::EDFilter"])
-      type = kFilter
+      found = subprocess.check_output(["git","grep", "typedef *.* "+name])
+      print_lines( found.split("\n") )
     except:
-      print "ERROR: Unable to find class declaration for "+name
-      exit(1)
-  lfound = found.split("\n")
-  if len(lfound) > 2:
-    print "ERROR: found more than one declaration of "+name
-    print lfound
-    exit(1)
-  s = lfound[0]
-  return (s[:s.find(":")],type)
+      pass
+  return (None,None)
   
 def checkout_package(fileName):
   c = fileName.split("/")
@@ -51,14 +83,17 @@ def edit_file(fileName,moduleType,moduleName):
   
   lookingForChanges = True
   for l in fOld.readlines():
+    addedInclude = False
     if lookingForChanges:
       if -1 != l.find("#include"):
         if moduleType == kProducer:
           if -1 != l.find("FWCore/Framework/interface/EDProducer.h"):
             l='#include "FWCore/Framework/interface/stream/EDProducer.h"\n'
+            addedInclude = True
         elif moduleType == kFilter:
           if -1 != l.find("FWCore/Framework/interface/EDFilter.h"):
             l = '#include "FWCore/Framework/interface/stream/EDFilter.h"\n'
+            addedInclude = True
       elif -1 != l.find("class"):
         if -1 != l.find(moduleName):
           if moduleType == kProducer:
@@ -69,6 +104,14 @@ def edit_file(fileName,moduleType,moduleName):
             if -1 != l.find("edm::EDFilter"):
               l=l.replace("edm::EDFilter","edm::stream::EDFilter<>")
     fNew.write(l)
+    if -1 != l.find(" beginJob("):
+      print " WARNING: beginJob found but not supported by stream"
+      print "  ",l
+    if -1 != l.find(" endJob("):
+      print " WARNING: endJob found but not supported by stream"
+      print "  ",l
+  if not addedInclude:
+    print " WARNING: did not write include into "+fileName
   fNew.close()
   fOld.close()
   shutil.move(fileName,fileName+"_OLD")
@@ -76,8 +119,12 @@ def edit_file(fileName,moduleType,moduleName):
 
 modules = sys.argv[1:]
 
+print "getting info"
+all_mods_info= find_all_module_classes()
+
+
 for m in modules:
-  f,t = find_file_for_module(m)
+  f,t = find_file_for_module(m,all_mods_info)
   if f:
     checkout_package(f)
     edit_file(f,t,m)

--- a/L1Trigger/GlobalTrigger/interface/ConvertObjectMapRecord.h
+++ b/L1Trigger/GlobalTrigger/interface/ConvertObjectMapRecord.h
@@ -20,11 +20,11 @@
  *
  */
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
-class ConvertObjectMapRecord : public edm::EDProducer {
+class ConvertObjectMapRecord : public edm::stream::EDProducer<> {
 
 public:
     explicit ConvertObjectMapRecord(const edm::ParameterSet& pset);

--- a/L1Trigger/L1ExtraFromDigis/interface/L1ExtraParticlesProd.h
+++ b/L1Trigger/L1ExtraFromDigis/interface/L1ExtraParticlesProd.h
@@ -18,7 +18,7 @@
 // system include files
 
 // user include files
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -38,7 +38,7 @@
 // forward declarations
 class L1CaloGeometry ;
 
-class L1ExtraParticlesProd : public edm::EDProducer {
+class L1ExtraParticlesProd : public edm::stream::EDProducer<> {
    public:
       explicit L1ExtraParticlesProd(const edm::ParameterSet&);
       ~L1ExtraParticlesProd();

--- a/PhysicsTools/IsolationAlgos/plugins/CandIsoDepositProducer.h
+++ b/PhysicsTools/IsolationAlgos/plugins/CandIsoDepositProducer.h
@@ -1,7 +1,7 @@
 #ifndef MuonIsolationProducers_CandIsoDepositProducer_H
 #define MuonIsolationProducers_CandIsoDepositProducer_H
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "DataFormats/Common/interface/AssociationVector.h"
@@ -17,7 +17,7 @@
 namespace edm { class Event; }
 namespace edm { class EventSetup; }
 
-class CandIsoDepositProducer : public edm::EDProducer {
+class CandIsoDepositProducer : public edm::stream::EDProducer<> {
 
 public:
   CandIsoDepositProducer(const edm::ParameterSet&);

--- a/PhysicsTools/IsolationAlgos/plugins/CandIsolatorFromDeposits.h
+++ b/PhysicsTools/IsolationAlgos/plugins/CandIsolatorFromDeposits.h
@@ -1,7 +1,7 @@
 #ifndef MuonIsolationProducers_CandIsolatorFromDeposits_H
 #define MuonIsolationProducers_CandIsolatorFromDeposits_H
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
@@ -20,7 +20,7 @@
 namespace edm { class Event; }
 namespace edm { class EventSetup; }
 
-class CandIsolatorFromDeposits : public edm::EDProducer {
+class CandIsolatorFromDeposits : public edm::stream::EDProducer<> {
 
 public:
   typedef edm::ValueMap<double> CandDoubleMap;

--- a/RecoBTag/ImpactParameter/plugins/TrackIPProducer.h
+++ b/RecoBTag/ImpactParameter/plugins/TrackIPProducer.h
@@ -6,12 +6,12 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
 class HistogramProbabilityEstimator;
 
-class TrackIPProducer : public edm::EDProducer {
+class TrackIPProducer : public edm::stream::EDProducer<> {
    public:
       explicit TrackIPProducer(const edm::ParameterSet&);
       ~TrackIPProducer();

--- a/RecoBTag/SecondaryVertex/plugins/BVertexFilter.cc
+++ b/RecoBTag/SecondaryVertex/plugins/BVertexFilter.cc
@@ -22,7 +22,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -37,7 +37,7 @@
 // class declaration
 //
 #include "RecoBTag/SecondaryVertex/interface/VertexFilter.h"
-class BVertexFilter : public edm::EDFilter {
+class BVertexFilter : public edm::stream::EDFilter<> {
    public:
       explicit BVertexFilter(const edm::ParameterSet&);
       ~BVertexFilter();

--- a/RecoBTag/SecondaryVertex/plugins/BtoCharmDecayVertexMerger.cc
+++ b/RecoBTag/SecondaryVertex/plugins/BtoCharmDecayVertexMerger.cc
@@ -2,7 +2,7 @@
 
 // first revised prototype version for CMSSW 29.Aug.2012
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -20,7 +20,7 @@
 
 #include <algorithm>
 
-class BtoCharmDecayVertexMerger : public edm::EDProducer {
+class BtoCharmDecayVertexMerger : public edm::stream::EDProducer<> {
     public:
        BtoCharmDecayVertexMerger(const edm::ParameterSet &params);
 

--- a/RecoBTag/SecondaryVertex/plugins/SecondaryVertexProducer.cc
+++ b/RecoBTag/SecondaryVertex/plugins/SecondaryVertexProducer.cc
@@ -9,7 +9,7 @@
 
 #include <boost/iterator/transform_iterator.hpp>
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -62,7 +62,7 @@ namespace {
 	};
 }
 
-class SecondaryVertexProducer : public edm::EDProducer {
+class SecondaryVertexProducer : public edm::stream::EDProducer<> {
     public:
 	explicit SecondaryVertexProducer(const edm::ParameterSet &params);
 	~SecondaryVertexProducer();

--- a/RecoBTag/SoftLepton/plugins/SoftLepton.h
+++ b/RecoBTag/SoftLepton/plugins/SoftLepton.h
@@ -25,7 +25,7 @@
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/Common/interface/RefToBase.h"
 #include "DataFormats/Math/interface/Vector3D.h"
@@ -47,7 +47,7 @@
 
 class TransientTrackBuilder;
 
-class SoftLepton : public edm::EDProducer {
+class SoftLepton : public edm::stream::EDProducer<> {
 public:
   explicit SoftLepton(const edm::ParameterSet& iConfig);
   ~SoftLepton();

--- a/RecoBTag/SoftLepton/plugins/SoftPFElectronTagInfoProducer.h
+++ b/RecoBTag/SoftLepton/plugins/SoftPFElectronTagInfoProducer.h
@@ -4,7 +4,7 @@
 
 #include <vector>
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -26,7 +26,7 @@
 // a PFCandidateCollection as input and produces a RefVector
 // to the likely soft electrons in this collection.
 
-class SoftPFElectronTagInfoProducer : public edm::EDProducer
+class SoftPFElectronTagInfoProducer : public edm::stream::EDProducer<>
 {
 
   public:

--- a/RecoBTag/SoftLepton/plugins/SoftPFMuonTagInfoProducer.h
+++ b/RecoBTag/SoftLepton/plugins/SoftPFMuonTagInfoProducer.h
@@ -4,7 +4,7 @@
 
 #include <vector>
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -31,7 +31,7 @@
 // a PFCandidateCollection as input and produces a RefVector
 // to the likely soft muons in this collection.
 
-class SoftPFMuonTagInfoProducer : public edm::EDProducer
+class SoftPFMuonTagInfoProducer : public edm::stream::EDProducer<>
 {
 
   public:

--- a/RecoEcal/EgammaClusterProducers/interface/EcalDigiSelector.h
+++ b/RecoEcal/EgammaClusterProducers/interface/EcalDigiSelector.h
@@ -6,7 +6,7 @@
 #include <map>
 #include <string>
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -17,7 +17,7 @@
 //
 
 
-class EcalDigiSelector : public edm::EDProducer 
+class EcalDigiSelector : public edm::stream::EDProducer<> 
 {
   
  public:

--- a/RecoEcal/EgammaClusterProducers/interface/EgammaSCCorrectionMaker.h
+++ b/RecoEcal/EgammaClusterProducers/interface/EgammaSCCorrectionMaker.h
@@ -20,7 +20,7 @@
 #include <memory>
 #include <string>
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -35,7 +35,7 @@
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 
 
-class EgammaSCCorrectionMaker : public edm::EDProducer {
+class EgammaSCCorrectionMaker : public edm::stream::EDProducer<> {
 	
    public:
      explicit EgammaSCCorrectionMaker(const edm::ParameterSet&);

--- a/RecoEcal/EgammaClusterProducers/interface/InterestingDetIdCollectionProducer.h
+++ b/RecoEcal/EgammaClusterProducers/interface/InterestingDetIdCollectionProducer.h
@@ -31,7 +31,7 @@ The following classes of "interesting id" are considered
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -44,7 +44,7 @@ The following classes of "interesting id" are considered
 class CaloTopology;
 class EcalSeverityLevelAlgo;
 
-class InterestingDetIdCollectionProducer : public edm::EDProducer {
+class InterestingDetIdCollectionProducer : public edm::stream::EDProducer<> {
    public:
       //! ctor
       explicit InterestingDetIdCollectionProducer(const edm::ParameterSet&);

--- a/RecoEcal/EgammaClusterProducers/interface/PreshowerClusterShapeProducer.h
+++ b/RecoEcal/EgammaClusterProducers/interface/PreshowerClusterShapeProducer.h
@@ -4,7 +4,7 @@
 
 #include <memory>
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "DataFormats/EcalDetId/interface/ESDetId.h"
@@ -18,7 +18,7 @@
 
 // authors A. Kyriakis, D. Maletic
 
-class PreshowerClusterShapeProducer : public edm::EDProducer {
+class PreshowerClusterShapeProducer : public edm::stream::EDProducer<> {
 
  public:
 

--- a/RecoEcal/EgammaClusterProducers/interface/PreshowerPhiClusterProducer.h
+++ b/RecoEcal/EgammaClusterProducers/interface/PreshowerPhiClusterProducer.h
@@ -3,7 +3,7 @@
 
 #include <memory>
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -18,7 +18,7 @@
 #include "CondFormats/ESObjects/interface/ESMissingEnergyCalibration.h"
 #include "CondFormats/ESObjects/interface/ESChannelStatus.h"
 
-class PreshowerPhiClusterProducer : public edm::EDProducer {
+class PreshowerPhiClusterProducer : public edm::stream::EDProducer<> {
 
  public:
 

--- a/RecoEcal/EgammaClusterProducers/interface/ReducedESRecHitCollectionProducer.h
+++ b/RecoEcal/EgammaClusterProducers/interface/ReducedESRecHitCollectionProducer.h
@@ -2,9 +2,9 @@
 #define _ReducedESRecHitCollectionProducer_H
 
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/Common/interface/Handle.h"
@@ -21,7 +21,7 @@
 
 class EcalPreshowerGeometry;
 class CaloSubdetectorTopology;
-class ReducedESRecHitCollectionProducer : public edm::EDProducer {
+class ReducedESRecHitCollectionProducer : public edm::stream::EDProducer<> {
 
  public :
 

--- a/RecoEcal/EgammaClusterProducers/interface/ReducedRecHitCollectionProducer.h
+++ b/RecoEcal/EgammaClusterProducers/interface/ReducedRecHitCollectionProducer.h
@@ -21,7 +21,7 @@ Implementation:
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -32,7 +32,7 @@ Implementation:
 
 class CaloTopology;
 
-class ReducedRecHitCollectionProducer : public edm::EDProducer {
+class ReducedRecHitCollectionProducer : public edm::stream::EDProducer<> {
    public:
       //! ctor
       explicit ReducedRecHitCollectionProducer(const edm::ParameterSet&);

--- a/RecoEcal/EgammaClusterProducers/interface/UnifiedSCCollectionProducer.h
+++ b/RecoEcal/EgammaClusterProducers/interface/UnifiedSCCollectionProducer.h
@@ -4,7 +4,7 @@
 #include <memory>
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 
@@ -12,7 +12,7 @@
 
 #include "FWCore/Utilities/interface/InputTag.h"
 
-class UnifiedSCCollectionProducer : public edm::EDProducer 
+class UnifiedSCCollectionProducer : public edm::stream::EDProducer<> 
 {
   
   public:

--- a/RecoEcal/EgammaClusterProducers/src/InterestingTrackEcalDetIdProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/InterestingTrackEcalDetIdProducer.cc
@@ -22,7 +22,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -46,7 +46,7 @@
 // class declaration
 //
 
-class InterestingTrackEcalDetIdProducer : public edm::EDProducer {
+class InterestingTrackEcalDetIdProducer : public edm::stream::EDProducer<> {
    public:
       explicit InterestingTrackEcalDetIdProducer(const edm::ParameterSet&);
       ~InterestingTrackEcalDetIdProducer();

--- a/RecoEgamma/EgammaElectronProducers/plugins/GEDGsfElectronFinalizer.h
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GEDGsfElectronFinalizer.h
@@ -2,7 +2,7 @@
 #ifndef GEDGsfElectronFinalizer_h
 #define GEDGsfElectronFinalizer_h
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 
@@ -13,7 +13,7 @@
 #include <string>
 #include <vector>
 
-class GEDGsfElectronFinalizer : public edm::EDProducer
+class GEDGsfElectronFinalizer : public edm::stream::EDProducer<>
 {
  public:
   explicit GEDGsfElectronFinalizer (const edm::ParameterSet &);

--- a/RecoEgamma/EgammaElectronProducers/plugins/SiStripElectronAssociator.h
+++ b/RecoEgamma/EgammaElectronProducers/plugins/SiStripElectronAssociator.h
@@ -24,7 +24,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -39,7 +39,7 @@
 // class decleration
 //
 
-class SiStripElectronAssociator : public edm::EDProducer {
+class SiStripElectronAssociator : public edm::stream::EDProducer<> {
  public:
   explicit SiStripElectronAssociator(const edm::ParameterSet&);
   ~SiStripElectronAssociator();

--- a/RecoEgamma/EgammaElectronProducers/plugins/SiStripElectronProducer.h
+++ b/RecoEgamma/EgammaElectronProducers/plugins/SiStripElectronProducer.h
@@ -23,7 +23,7 @@
 // user include files
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "DataFormats/EgammaCandidates/interface/SiStripElectron.h"
 #include "RecoEgamma/EgammaElectronAlgos/interface/SiStripElectronAlgo.h"
@@ -32,7 +32,7 @@
 
 // forward declarations
 
-class SiStripElectronProducer : public edm::EDProducer {
+class SiStripElectronProducer : public edm::stream::EDProducer<> {
    public:
       explicit SiStripElectronProducer(const edm::ParameterSet&);
       ~SiStripElectronProducer();

--- a/RecoEgamma/EgammaHFProducers/plugins/HFEMClusterProducer.h
+++ b/RecoEgamma/EgammaHFProducers/plugins/HFEMClusterProducer.h
@@ -7,12 +7,12 @@
 // $Id: HFClusterProducer.h,v 1.2 2007/09/19 Kevin Klapoetke
 //
 #include "HFClusterAlgo.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Event.h"
 
-class HFEMClusterProducer : public edm::EDProducer {
+class HFEMClusterProducer : public edm::stream::EDProducer<> {
 public:
   explicit HFEMClusterProducer(edm::ParameterSet const& conf);
   virtual void produce(edm::Event& e, edm::EventSetup const& iSetup);

--- a/RecoEgamma/EgammaHFProducers/plugins/HFRecoEcalCandidateProducer.h
+++ b/RecoEgamma/EgammaHFProducers/plugins/HFRecoEcalCandidateProducer.h
@@ -13,7 +13,7 @@
 //
 //
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -21,7 +21,7 @@
 #include "HFRecoEcalCandidateAlgo.h"
 #include "HFValueStruct.h"
 
-class HFRecoEcalCandidateProducer : public edm::EDProducer {
+class HFRecoEcalCandidateProducer : public edm::stream::EDProducer<> {
  public:
   explicit HFRecoEcalCandidateProducer(edm::ParameterSet const& conf);
   virtual void produce(edm::Event& e, edm::EventSetup const& iSetup);

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaEcalRecHitIsolationProducer.h
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaEcalRecHitIsolationProducer.h
@@ -18,7 +18,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -31,7 +31,7 @@
 // class declaration
 //
 
-class EgammaEcalRecHitIsolationProducer : public edm::EDProducer {
+class EgammaEcalRecHitIsolationProducer : public edm::stream::EDProducer<> {
    public:
       explicit EgammaEcalRecHitIsolationProducer(const edm::ParameterSet&);
       ~EgammaEcalRecHitIsolationProducer();

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaElectronTkIsolationProducer.h
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaElectronTkIsolationProducer.h
@@ -10,14 +10,14 @@
 //*****************************************************************************
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-class EgammaElectronTkIsolationProducer : public edm::EDProducer {
+class EgammaElectronTkIsolationProducer : public edm::stream::EDProducer<> {
  public:
   explicit EgammaElectronTkIsolationProducer(const edm::ParameterSet&);
   ~EgammaElectronTkIsolationProducer();

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaTowerIsolationProducer.h
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaTowerIsolationProducer.h
@@ -18,7 +18,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -31,7 +31,7 @@
 // class declaration
 //
 
-class EgammaTowerIsolationProducer : public edm::EDProducer {
+class EgammaTowerIsolationProducer : public edm::stream::EDProducer<> {
    public:
       explicit EgammaTowerIsolationProducer(const edm::ParameterSet&);
       ~EgammaTowerIsolationProducer();

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EleIsoDetIdCollectionProducer.h
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EleIsoDetIdCollectionProducer.h
@@ -23,7 +23,7 @@ Implementation:
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -32,7 +32,7 @@ Implementation:
 
 class CaloTopology;
 
-class EleIsoDetIdCollectionProducer : public edm::EDProducer {
+class EleIsoDetIdCollectionProducer : public edm::stream::EDProducer<> {
    public:
       //! ctor
       explicit EleIsoDetIdCollectionProducer(const edm::ParameterSet&);

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/GamIsoDetIdCollectionProducer.h
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/GamIsoDetIdCollectionProducer.h
@@ -23,7 +23,7 @@ Implementation:
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -36,7 +36,7 @@ Implementation:
 
 class CaloTopology;
 
-class GamIsoDetIdCollectionProducer : public edm::EDProducer {
+class GamIsoDetIdCollectionProducer : public edm::stream::EDProducer<> {
    public:
       //! ctor
       explicit GamIsoDetIdCollectionProducer(const edm::ParameterSet&);

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/ParticleBasedIsoProducer.h
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/ParticleBasedIsoProducer.h
@@ -1,7 +1,7 @@
 #ifndef ParticleBasedIsoProducer_h
 #define ParticleBasedIsoProducer_h
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -15,7 +15,7 @@
 #include "DataFormats/Common/interface/ValueMap.h"
 
 
-class ParticleBasedIsoProducer : public edm::EDProducer
+class ParticleBasedIsoProducer : public edm::stream::EDProducer<>
 {
  public:
 

--- a/RecoEgamma/EgammaPhotonProducers/interface/ConversionProducer.h
+++ b/RecoEgamma/EgammaPhotonProducers/interface/ConversionProducer.h
@@ -9,7 +9,7 @@
  ***/
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -63,7 +63,7 @@
 class TransientTrackBuilder;
 class ConversionVertexFinder;
 
-class ConversionProducer : public edm::EDProducer {
+class ConversionProducer : public edm::stream::EDProducer<> {
     public:
       explicit ConversionProducer(const edm::ParameterSet&);
       ~ConversionProducer();

--- a/RecoEgamma/EgammaPhotonProducers/interface/ConversionTrackCandidateProducer.h
+++ b/RecoEgamma/EgammaPhotonProducers/interface/ConversionTrackCandidateProducer.h
@@ -7,7 +7,7 @@
  **
  ***/
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -36,7 +36,7 @@ class OutInConversionTrackFinder;
 class InOutConversionTrackFinder;
 
 // ConversionTrackCandidateProducer inherits from EDProducer, so it can be a module:
-class ConversionTrackCandidateProducer : public edm::EDProducer {
+class ConversionTrackCandidateProducer : public edm::stream::EDProducer<> {
 
  public:
 

--- a/RecoEgamma/EgammaPhotonProducers/interface/ConversionTrackMerger.h
+++ b/RecoEgamma/EgammaPhotonProducers/interface/ConversionTrackMerger.h
@@ -12,7 +12,7 @@
 //
 //
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -27,7 +27,7 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-  class ConversionTrackMerger : public edm::EDProducer
+  class ConversionTrackMerger : public edm::stream::EDProducer<>
   {
   public:
 

--- a/RecoEgamma/EgammaPhotonProducers/interface/ConversionTrackProducer.h
+++ b/RecoEgamma/EgammaPhotonProducers/interface/ConversionTrackProducer.h
@@ -12,7 +12,7 @@
 //
 //
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -40,7 +40,7 @@ namespace reco {
 #include "RecoTracker/ConversionSeedGenerators/interface/IdealHelixParameters.h"
 //--------------------------------------------------
 
-  class ConversionTrackProducer : public edm::EDProducer
+  class ConversionTrackProducer : public edm::stream::EDProducer<>
   {
 
     typedef edm::AssociationMap<edm::OneToOne<std::vector<Trajectory>,

--- a/RecoEgamma/EgammaPhotonProducers/interface/ConvertedPhotonProducer.h
+++ b/RecoEgamma/EgammaPhotonProducers/interface/ConvertedPhotonProducer.h
@@ -7,7 +7,7 @@
  **
  ***/
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -33,7 +33,7 @@
 class ConversionTrackEcalImpactPoint;
 class ConversionTrackPairFinder;
 class ConversionVertexFinder;
-class ConvertedPhotonProducer : public edm::EDProducer {
+class ConvertedPhotonProducer : public edm::stream::EDProducer<> {
 
  public:
 

--- a/RecoEgamma/EgammaPhotonProducers/interface/GEDPhotonCoreProducer.h
+++ b/RecoEgamma/EgammaPhotonProducers/interface/GEDPhotonCoreProducer.h
@@ -7,7 +7,7 @@
  **
  ***/
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -20,7 +20,7 @@
 //#include "RecoEgamma/PhotonIdentification/interface/PhotonIsolationCalculator.h"
 
 // GEDPhotonCoreProducer inherits from EDProducer, so it can be a module:
-class GEDPhotonCoreProducer : public edm::EDProducer {
+class GEDPhotonCoreProducer : public edm::stream::EDProducer<> {
 
  public:
 

--- a/RecoEgamma/EgammaPhotonProducers/interface/GEDPhotonProducer.h
+++ b/RecoEgamma/EgammaPhotonProducers/interface/GEDPhotonProducer.h
@@ -7,7 +7,7 @@
  **
  ***/
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -39,7 +39,7 @@
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
 
 // GEDPhotonProducer inherits from EDProducer, so it can be a module:
-class GEDPhotonProducer : public edm::EDProducer {
+class GEDPhotonProducer : public edm::stream::EDProducer<> {
 
  public:
 

--- a/RecoEgamma/EgammaPhotonProducers/interface/PhotonCoreProducer.h
+++ b/RecoEgamma/EgammaPhotonProducers/interface/PhotonCoreProducer.h
@@ -7,7 +7,7 @@
  **
  ***/
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -27,7 +27,7 @@
 #include "RecoEgamma/PhotonIdentification/interface/PhotonIsolationCalculator.h"
 
 // PhotonCoreProducer inherits from EDProducer, so it can be a module:
-class PhotonCoreProducer : public edm::EDProducer {
+class PhotonCoreProducer : public edm::stream::EDProducer<> {
 
  public:
 

--- a/RecoEgamma/EgammaPhotonProducers/interface/PhotonProducer.h
+++ b/RecoEgamma/EgammaPhotonProducers/interface/PhotonProducer.h
@@ -7,7 +7,7 @@
  **
  ***/
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -34,7 +34,7 @@
 #include "RecoEgamma/EgammaPhotonAlgos/interface/PhotonEnergyCorrector.h"
 
 // PhotonProducer inherits from EDProducer, so it can be a module:
-class PhotonProducer : public edm::EDProducer {
+class PhotonProducer : public edm::stream::EDProducer<> {
 
  public:
 

--- a/RecoEgamma/EgammaPhotonProducers/interface/TrackProducerWithSCAssociation.h
+++ b/RecoEgamma/EgammaPhotonProducers/interface/TrackProducerWithSCAssociation.h
@@ -9,13 +9,14 @@
  ** 
  ***/
 
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "RecoTracker/TrackProducer/interface/TrackProducerBase.h"
 #include "RecoTracker/TrackProducer/interface/TrackProducerAlgorithm.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
 #include "DataFormats/EgammaTrackReco/interface/TrackCandidateCaloClusterAssociation.h"
 
-class TrackProducerWithSCAssociation : public TrackProducerBase<reco::Track>, public edm::EDProducer {
+class TrackProducerWithSCAssociation : public TrackProducerBase<reco::Track>, public edm::stream::EDProducer<> {
 public:
 
   explicit TrackProducerWithSCAssociation(const edm::ParameterSet& iConfig);

--- a/RecoEgamma/ElectronIdentification/plugins/ElectronIdMVABased.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/ElectronIdMVABased.cc
@@ -22,7 +22,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -39,7 +39,7 @@
 
 using namespace std;
 using namespace reco;
-class ElectronIdMVABased : public edm::EDFilter {
+class ElectronIdMVABased : public edm::stream::EDFilter<> {
 	public:
 		explicit ElectronIdMVABased(const edm::ParameterSet&);
 		~ElectronIdMVABased();

--- a/RecoEgamma/PhotonIdentification/plugins/PhotonIDProducer.h
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonIDProducer.h
@@ -1,7 +1,7 @@
 #ifndef PhotonIDProducer_h
 #define PhotonIDProducer_h
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "DataFormats/Common/interface/Handle.h"
@@ -13,7 +13,7 @@
 #include "DataFormats/EgammaCandidates/interface/PhotonFwd.h"
 
 
-class PhotonIDProducer : public edm::EDProducer
+class PhotonIDProducer : public edm::stream::EDProducer<>
 {
  public:
 

--- a/RecoJets/JetAssociationProducers/interface/TrackExtrapolator.h
+++ b/RecoJets/JetAssociationProducers/interface/TrackExtrapolator.h
@@ -30,7 +30,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -55,7 +55,7 @@
 // class declaration
 //
 
-class TrackExtrapolator : public edm::EDProducer {
+class TrackExtrapolator : public edm::stream::EDProducer<> {
    public:
       explicit TrackExtrapolator(const edm::ParameterSet&);
       ~TrackExtrapolator();

--- a/RecoJets/JetAssociationProducers/src/JetExtender.h
+++ b/RecoJets/JetAssociationProducers/src/JetExtender.h
@@ -8,7 +8,7 @@
 #ifndef JetExtender_h
 #define JetExtender_h
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "DataFormats/Common/interface/EDProductfwd.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -16,7 +16,7 @@
 #include "DataFormats/JetReco/interface/Jet.h"
 #include "DataFormats/JetReco/interface/JetTracksAssociation.h"
 
-class JetExtender : public edm::EDProducer {
+class JetExtender : public edm::stream::EDProducer<> {
    public:
       JetExtender(const edm::ParameterSet&);
       virtual ~JetExtender();

--- a/RecoJets/JetAssociationProducers/src/JetTracksAssociatorAtCaloFace.h
+++ b/RecoJets/JetAssociationProducers/src/JetTracksAssociatorAtCaloFace.h
@@ -6,7 +6,7 @@
 #ifndef JetTracksAssociatorAtCaloFace_h
 #define JetTracksAssociatorAtCaloFace_h
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "DataFormats/Common/interface/EDProductfwd.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -18,7 +18,7 @@
 #include "DataFormats/Common/interface/View.h"
 #include "DataFormats/JetReco/interface/JetTracksAssociation.h"
 
-class JetTracksAssociatorAtCaloFace : public edm::EDProducer {
+class JetTracksAssociatorAtCaloFace : public edm::stream::EDProducer<> {
    public:
       JetTracksAssociatorAtCaloFace(const edm::ParameterSet&);
       virtual ~JetTracksAssociatorAtCaloFace() {}

--- a/RecoJets/JetAssociationProducers/src/JetTracksAssociatorAtVertex.h
+++ b/RecoJets/JetAssociationProducers/src/JetTracksAssociatorAtVertex.h
@@ -8,7 +8,7 @@
 #ifndef JetTracksAssociatorAtVertex_h
 #define JetTracksAssociatorAtVertex_h
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "DataFormats/Common/interface/EDProductfwd.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -16,7 +16,7 @@
 #include "RecoJets/JetAssociationAlgorithms/interface/JetTracksAssociationDRVertex.h"
 #include "RecoJets/JetAssociationAlgorithms/interface/JetTracksAssociationDRVertexAssigned.h"
 
-class JetTracksAssociatorAtVertex : public edm::EDProducer {
+class JetTracksAssociatorAtVertex : public edm::stream::EDProducer<> {
    public:
       JetTracksAssociatorAtVertex(const edm::ParameterSet&);
       virtual ~JetTracksAssociatorAtVertex();

--- a/RecoJets/JetAssociationProducers/src/JetTracksAssociatorExplicit.h
+++ b/RecoJets/JetAssociationProducers/src/JetTracksAssociatorExplicit.h
@@ -8,7 +8,7 @@
 #ifndef JetTracksAssociatorExplicit_h
 #define JetTracksAssociatorExplicit_h
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "DataFormats/Common/interface/EDProductfwd.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -16,7 +16,7 @@
 #include "RecoJets/JetAssociationAlgorithms/interface/JetTracksAssociationExplicit.h"
 #include "RecoJets/JetAssociationAlgorithms/interface/JetTracksAssociationExplicit.h"
 
-class JetTracksAssociatorExplicit : public edm::EDProducer {
+class JetTracksAssociatorExplicit : public edm::stream::EDProducer<> {
    public:
       JetTracksAssociatorExplicit(const edm::ParameterSet&);
       virtual ~JetTracksAssociatorExplicit();

--- a/RecoJets/JetPlusTracks/plugins/JetPlusTrackProducer.h
+++ b/RecoJets/JetPlusTracks/plugins/JetPlusTrackProducer.h
@@ -22,7 +22,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -40,7 +40,7 @@
 // class declaration
 //
 
-class JetPlusTrackProducer : public edm::EDProducer {
+class JetPlusTrackProducer : public edm::stream::EDProducer<> {
    public:
       explicit JetPlusTrackProducer(const edm::ParameterSet&);
       ~JetPlusTrackProducer();

--- a/RecoJets/JetProducers/plugins/CastorJetIDProducer.h
+++ b/RecoJets/JetProducers/plugins/CastorJetIDProducer.h
@@ -24,7 +24,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -38,7 +38,7 @@
 // class decleration
 //
 
-class CastorJetIDProducer : public edm::EDProducer {
+class CastorJetIDProducer : public edm::stream::EDProducer<> {
    public:
 
       explicit CastorJetIDProducer(const edm::ParameterSet&);

--- a/RecoJets/JetProducers/plugins/FixedGridRhoProducer.h
+++ b/RecoJets/JetProducers/plugins/FixedGridRhoProducer.h
@@ -1,12 +1,12 @@
 #ifndef RecoJets_JetProducers_plugins_FixedGridRhoProducer_h
 #define RecoJets_JetProducers_plugins_FixedGridRhoProducer_h
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "RecoJets/JetAlgorithms/interface/FixedGridEnergyDensity.h"
 
-class FixedGridRhoProducer : public edm::EDProducer {
+class FixedGridRhoProducer : public edm::stream::EDProducer<> {
 
  public:
   explicit FixedGridRhoProducer(const edm::ParameterSet& iConfig);

--- a/RecoJets/JetProducers/plugins/FixedGridRhoProducerFastjet.h
+++ b/RecoJets/JetProducers/plugins/FixedGridRhoProducerFastjet.h
@@ -1,7 +1,7 @@
 #ifndef RecoJets_JetProducers_plugins_FixedGridRhoProducerFastjet_h
 #define RecoJets_JetProducers_plugins_FixedGridRhoProducerFastjet_h
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
@@ -9,7 +9,7 @@
 #include "fastjet/tools/GridMedianBackgroundEstimator.hh"
 
 
-class FixedGridRhoProducerFastjet : public edm::EDProducer {
+class FixedGridRhoProducerFastjet : public edm::stream::EDProducer<> {
 
  public:
   explicit FixedGridRhoProducerFastjet(const edm::ParameterSet& iConfig);

--- a/RecoJets/JetProducers/plugins/JetIDProducer.h
+++ b/RecoJets/JetProducers/plugins/JetIDProducer.h
@@ -27,7 +27,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -42,7 +42,7 @@
 // class decleration
 //
 
-class JetIDProducer : public edm::EDProducer {
+class JetIDProducer : public edm::stream::EDProducer<> {
    public:
 
       explicit JetIDProducer(const edm::ParameterSet&);

--- a/RecoLocalCalo/Castor/src/CastorTowerProducer.cc
+++ b/RecoLocalCalo/Castor/src/CastorTowerProducer.cc
@@ -26,7 +26,7 @@
 
 // user include 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -48,7 +48,7 @@
 // class declaration
 //
 
-class CastorTowerProducer : public edm::EDProducer {
+class CastorTowerProducer : public edm::stream::EDProducer<> {
    public:
       explicit CastorTowerProducer(const edm::ParameterSet&);
       ~CastorTowerProducer();

--- a/RecoLocalCalo/CastorReco/plugins/CastorSimpleReconstructor.h
+++ b/RecoLocalCalo/CastorReco/plugins/CastorSimpleReconstructor.h
@@ -1,7 +1,7 @@
 #ifndef CASTORSIMPLERECONSTRUCTOR_H
 #define CASTORSIMPLERECONSTRUCTOR_H 1
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/HcalDigi/interface/HcalDigiCollections.h"
@@ -11,7 +11,7 @@
 
 #include "RecoLocalCalo/CastorReco/interface/CastorSimpleRecAlgo.h"
 
-class CastorSimpleReconstructor : public edm::EDProducer {
+class CastorSimpleReconstructor : public edm::stream::EDProducer<> {
     public:
       explicit CastorSimpleReconstructor(const edm::ParameterSet& ps);
       virtual ~CastorSimpleReconstructor();

--- a/RecoLocalCalo/EcalRecProducers/plugins/ESRecHitProducer.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/ESRecHitProducer.h
@@ -1,7 +1,7 @@
 #ifndef RecoLocalCalo_EcalRecProducers_ESRecHitProducer_HH
 #define RecoLocalCalo_EcalRecProducers_ESRecHitProducer_HH
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -14,7 +14,7 @@
 
 class ESDigiCollection;
 
-class ESRecHitProducer : public edm::EDProducer {
+class ESRecHitProducer : public edm::stream::EDProducer<> {
 
  public:
 

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalCompactTrigPrimProducer.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalCompactTrigPrimProducer.h
@@ -7,14 +7,14 @@
  *
  **/
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
 
-class EcalCompactTrigPrimProducer: public edm::EDProducer {
+class EcalCompactTrigPrimProducer: public edm::stream::EDProducer<> {
 
 public:
   EcalCompactTrigPrimProducer(const edm::ParameterSet& ps);

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalDetIdToBeRecoveredProducer.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalDetIdToBeRecoveredProducer.h
@@ -11,7 +11,7 @@
  *
  **/
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -27,7 +27,7 @@
 #include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
 
 
-class EcalDetIdToBeRecoveredProducer : public edm::EDProducer {
+class EcalDetIdToBeRecoveredProducer : public edm::stream::EDProducer<> {
 
         public:
                 explicit EcalDetIdToBeRecoveredProducer(const edm::ParameterSet& ps);

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitProducer.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitProducer.h
@@ -8,7 +8,7 @@
  *
  **/
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -23,7 +23,7 @@ class EEDetId;
 class EcalTrigTowerDetId;
 class EcalScDetId;
 
-class EcalRecHitProducer : public edm::EDProducer {
+class EcalRecHitProducer : public edm::stream::EDProducer<> {
 
         public:
                 explicit EcalRecHitProducer(const edm::ParameterSet& ps);

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalTPSkimmer.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalTPSkimmer.h
@@ -8,7 +8,7 @@
  *
  **/
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -19,7 +19,7 @@
 
 #include "Geometry/CaloTopology/interface/EcalTrigTowerConstituentsMap.h"
 
-class EcalTPSkimmer : public edm::EDProducer {
+class EcalTPSkimmer : public edm::stream::EDProducer<> {
 
         public:
                 explicit EcalTPSkimmer(const edm::ParameterSet& ps);

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitProducer.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitProducer.h
@@ -1,7 +1,7 @@
 #ifndef RecoLocalCalo_EcalRecProducers_EcalUncalibRecHitProducer_hh
 #define RecoLocalCalo_EcalRecProducers_EcalUncalibRecHitProducer_hh
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -15,7 +15,7 @@
 class EBDigiCollection;
 class EEDigiCollection;
 
-class EcalUncalibRecHitProducer : public edm::EDProducer {
+class EcalUncalibRecHitProducer : public edm::stream::EDProducer<> {
 
         public:
                 explicit EcalUncalibRecHitProducer(const edm::ParameterSet& ps);

--- a/RecoLocalMuon/CSCRecHitD/src/CSCRecHitDProducer.h
+++ b/RecoLocalMuon/CSCRecHitD/src/CSCRecHitDProducer.h
@@ -16,7 +16,7 @@
 
 #include <FWCore/Framework/interface/ConsumesCollector.h>
 #include <FWCore/Framework/interface/Frameworkfwd.h>
-#include <FWCore/Framework/interface/EDProducer.h>
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include <FWCore/Framework/interface/Event.h>
 #include <FWCore/ParameterSet/interface/ParameterSet.h>
 #include <FWCore/Utilities/interface/InputTag.h>
@@ -27,7 +27,7 @@
 class CSCRecHitDBuilder; 
 class CSCRecoConditions;
 
-class CSCRecHitDProducer : public edm::EDProducer {
+class CSCRecHitDProducer : public edm::stream::EDProducer<> {
 
 public:
   explicit CSCRecHitDProducer( const edm::ParameterSet& ps );

--- a/RecoLocalMuon/CSCSegment/src/CSCSegmentProducer.h
+++ b/RecoLocalMuon/CSCSegment/src/CSCSegmentProducer.h
@@ -9,7 +9,7 @@
 
 #include <FWCore/Framework/interface/ConsumesCollector.h>
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
@@ -17,7 +17,7 @@
 
 class CSCSegmentBuilder; 
 
-class CSCSegmentProducer : public edm::EDProducer {
+class CSCSegmentProducer : public edm::stream::EDProducer<> {
 public:
     /// Constructor
     explicit CSCSegmentProducer(const edm::ParameterSet&);

--- a/RecoLocalMuon/DTRecHit/plugins/DTRecHitProducer.h
+++ b/RecoLocalMuon/DTRecHit/plugins/DTRecHitProducer.h
@@ -9,7 +9,7 @@
  *  \author G. Cerminara
  */
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
 namespace edm {
@@ -20,7 +20,7 @@ namespace edm {
 
 class DTRecHitBaseAlgo;
 
-class DTRecHitProducer : public edm::EDProducer {
+class DTRecHitProducer : public edm::stream::EDProducer<> {
 public:
   /// Constructor
   DTRecHitProducer(const edm::ParameterSet&);

--- a/RecoLocalMuon/DTSegment/src/DTRecSegment2DProducer.h
+++ b/RecoLocalMuon/DTSegment/src/DTRecSegment2DProducer.h
@@ -11,7 +11,7 @@
  */
 
 /* Base Class Headers */
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
 namespace edm {
@@ -28,7 +28,7 @@ class DTRecSegment2DBaseAlgo;
 
 /* Class DTRecSegment2DProducer Interface */
 
-class DTRecSegment2DProducer : public edm::EDProducer {
+class DTRecSegment2DProducer : public edm::stream::EDProducer<> {
 
  public:
 

--- a/RecoLocalMuon/DTSegment/src/DTRecSegment4DProducer.h
+++ b/RecoLocalMuon/DTSegment/src/DTRecSegment4DProducer.h
@@ -7,7 +7,7 @@
  * \author Riccardo Bellan - INFN Torino <riccardo.bellan@cern.ch>
  */
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
 namespace edm {
@@ -17,7 +17,7 @@ namespace edm {
 }
 class DTRecSegment4DBaseAlgo;
 
-class DTRecSegment4DProducer: public edm::EDProducer {
+class DTRecSegment4DProducer: public edm::stream::EDProducer<> {
 public:
   /// Constructor
   DTRecSegment4DProducer(const edm::ParameterSet&) ;

--- a/RecoLocalMuon/DTSegment/src/DTSegment4DT0Corrector.h
+++ b/RecoLocalMuon/DTSegment/src/DTSegment4DT0Corrector.h
@@ -7,7 +7,7 @@
  * \author Mario Pelliccioni - INFN Torino <pellicci@cern.ch>
  */
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "RecoLocalMuon/DTSegment/src/DTSegmentUpdator.h"
 
@@ -17,7 +17,7 @@ namespace edm {
   class EventSetup;
 }
 
-class DTSegment4DT0Corrector: public edm::EDProducer {
+class DTSegment4DT0Corrector: public edm::stream::EDProducer<> {
 
  public:
   /// Constructor

--- a/RecoLocalMuon/RPCRecHit/src/RPCRecHitProducer.h
+++ b/RecoLocalMuon/RPCRecHit/src/RPCRecHitProducer.h
@@ -16,7 +16,7 @@
 #include <bitset>
 #include <map>
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "DataFormats/MuonDetId/interface/RPCDetId.h"
 
@@ -38,7 +38,7 @@ namespace edm {
 
 class RPCRecHitBaseAlgo;
 
-class RPCRecHitProducer : public edm::EDProducer {
+class RPCRecHitProducer : public edm::stream::EDProducer<> {
 
 public:
   /// Constructor

--- a/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusterizer.h
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusterizer.h
@@ -2,7 +2,7 @@
 #define RecoLocalTracker_SiStripClusterizer_h
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "RecoLocalTracker/SiStripClusterizer/interface/StripClusterizerAlgorithm.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -10,7 +10,7 @@
 #include <vector>
 #include <memory>
 
-class SiStripClusterizer : public edm::EDProducer  {
+class SiStripClusterizer : public edm::stream::EDProducer<>  {
 
 public:
 

--- a/RecoLocalTracker/SiStripZeroSuppression/plugins/SiStripZeroSuppression.h
+++ b/RecoLocalTracker/SiStripZeroSuppression/plugins/SiStripZeroSuppression.h
@@ -1,6 +1,6 @@
 #ifndef SiStripZeroSuppression_h
 #define SiStripZeroSuppression_h
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
@@ -13,7 +13,7 @@
 class SiStripDigi;
 class SiStripRawDigi;
 
-class SiStripZeroSuppression : public edm::EDProducer
+class SiStripZeroSuppression : public edm::stream::EDProducer<>
 {
   
  public:

--- a/RecoLocalTracker/SubCollectionProducers/interface/ClusterSummaryProducer.h
+++ b/RecoLocalTracker/SubCollectionProducers/interface/ClusterSummaryProducer.h
@@ -30,7 +30,7 @@
 // user include files
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
 #include "FWCore/Framework/interface/Event.h"
@@ -64,13 +64,13 @@ class ClusterVariables;
 class ClusterSummary;
 
 
-class ClusterSummaryProducer : public edm::EDProducer {
+class ClusterSummaryProducer : public edm::stream::EDProducer<> {
    public:
       explicit ClusterSummaryProducer(const edm::ParameterSet&);
       ~ClusterSummaryProducer(){};
 
    private:
-      virtual void beginJob() override;
+      virtual void beginStream(edm::StreamID) override;
       virtual void produce(edm::Event&, const edm::EventSetup&) override;
 
       void decodeInput(std::vector<std::string> &, std::string );

--- a/RecoLocalTracker/SubCollectionProducers/src/ClusterSummaryProducer.cc
+++ b/RecoLocalTracker/SubCollectionProducers/src/ClusterSummaryProducer.cc
@@ -189,7 +189,7 @@ ClusterSummaryProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
 
 
 void 
-ClusterSummaryProducer::beginJob()
+ClusterSummaryProducer::beginStream(edm::StreamID)
 {
    
   if (doStrips) decodeInput(v_stripModuleTypes,stripModules.c_str());

--- a/RecoLocalTracker/SubCollectionProducers/src/SeedClusterRemover.cc
+++ b/RecoLocalTracker/SubCollectionProducers/src/SeedClusterRemover.cc
@@ -1,5 +1,5 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -35,7 +35,7 @@
 // class decleration
 //
 
-class SeedClusterRemover : public edm::EDProducer {
+class SeedClusterRemover : public edm::stream::EDProducer<> {
     public:
         SeedClusterRemover(const edm::ParameterSet& iConfig) ;
         ~SeedClusterRemover() ;

--- a/RecoLocalTracker/SubCollectionProducers/src/TrackClusterRemover.cc
+++ b/RecoLocalTracker/SubCollectionProducers/src/TrackClusterRemover.cc
@@ -1,5 +1,5 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -34,7 +34,7 @@
 // class decleration
 //
 
-class TrackClusterRemover : public edm::EDProducer {
+class TrackClusterRemover : public edm::stream::EDProducer<> {
     public:
         TrackClusterRemover(const edm::ParameterSet& iConfig) ;
         ~TrackClusterRemover() ;

--- a/RecoMET/METProducers/interface/BeamHaloSummaryProducer.h
+++ b/RecoMET/METProducers/interface/BeamHaloSummaryProducer.h
@@ -26,7 +26,7 @@
 // user include files
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -47,7 +47,7 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -55,7 +55,7 @@
 
 namespace reco
 {
-  class BeamHaloSummaryProducer : public edm::EDProducer {
+  class BeamHaloSummaryProducer : public edm::stream::EDProducer<> {
     
   public:
     explicit BeamHaloSummaryProducer(const edm::ParameterSet&);

--- a/RecoMET/METProducers/interface/CSCHaloDataProducer.h
+++ b/RecoMET/METProducers/interface/CSCHaloDataProducer.h
@@ -26,7 +26,7 @@
 // user include files
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -92,7 +92,7 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -130,7 +130,7 @@ class MuonServiceProxy;
 
 namespace reco
 {
-class CSCHaloDataProducer : public edm::EDProducer {
+class CSCHaloDataProducer : public edm::stream::EDProducer<> {
     
   public:
     explicit CSCHaloDataProducer(const edm::ParameterSet&);

--- a/RecoMET/METProducers/interface/CaloMETProducer.h
+++ b/RecoMET/METProducers/interface/CaloMETProducer.h
@@ -20,7 +20,7 @@
 
 //____________________________________________________________________________||
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -39,7 +39,7 @@ namespace metsig
 //____________________________________________________________________________||
 namespace cms
 {
-  class CaloMETProducer: public edm::EDProducer
+  class CaloMETProducer: public edm::stream::EDProducer<>
     {
     public:
       explicit CaloMETProducer(const edm::ParameterSet&);

--- a/RecoMET/METProducers/interface/EcalHaloDataProducer.h
+++ b/RecoMET/METProducers/interface/EcalHaloDataProducer.h
@@ -26,7 +26,7 @@
 // user include files
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -71,7 +71,7 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -91,7 +91,7 @@
 
 namespace reco
 {
-  class EcalHaloDataProducer : public edm::EDProducer {
+  class EcalHaloDataProducer : public edm::stream::EDProducer<> {
     
   public:
     explicit EcalHaloDataProducer(const edm::ParameterSet&);

--- a/RecoMET/METProducers/interface/GlobalHaloDataProducer.h
+++ b/RecoMET/METProducers/interface/GlobalHaloDataProducer.h
@@ -26,7 +26,7 @@
 // user include files
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -126,7 +126,7 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -179,7 +179,7 @@
 
 namespace reco
 {
-  class GlobalHaloDataProducer : public edm::EDProducer {
+  class GlobalHaloDataProducer : public edm::stream::EDProducer<> {
     
   public:
     explicit GlobalHaloDataProducer(const edm::ParameterSet&);

--- a/RecoMET/METProducers/interface/HcalHaloDataProducer.h
+++ b/RecoMET/METProducers/interface/HcalHaloDataProducer.h
@@ -26,7 +26,7 @@
 // user include files
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -63,7 +63,7 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -83,7 +83,7 @@
 
 namespace reco
 {
-  class HcalHaloDataProducer : public edm::EDProducer {
+  class HcalHaloDataProducer : public edm::stream::EDProducer<> {
     
   public:
     explicit HcalHaloDataProducer(const edm::ParameterSet&);

--- a/RecoMET/METProducers/interface/MuonMET.h
+++ b/RecoMET/METProducers/interface/MuonMET.h
@@ -10,8 +10,7 @@
 
 //____________________________________________________________________________||
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
-
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
@@ -25,7 +24,7 @@
 //____________________________________________________________________________||
 namespace cms 
 {
-  class MuonMET : public edm::EDProducer 
+  class MuonMET : public edm::stream::EDProducer<> 
   {
   public:
     explicit MuonMET( const edm::ParameterSet& );

--- a/RecoMET/METProducers/interface/MuonMETValueMapProducer.h
+++ b/RecoMET/METProducers/interface/MuonMETValueMapProducer.h
@@ -20,7 +20,7 @@
 
 //____________________________________________________________________________||
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/Common/interface/Handle.h"
@@ -36,7 +36,7 @@
 namespace cms
 {
 
-class MuonMETValueMapProducer : public edm::EDProducer
+class MuonMETValueMapProducer : public edm::stream::EDProducer<>
 {
 public:
   explicit MuonMETValueMapProducer(const edm::ParameterSet&);

--- a/RecoMET/METProducers/interface/MuonTCMETValueMapProducer.h
+++ b/RecoMET/METProducers/interface/MuonTCMETValueMapProducer.h
@@ -19,7 +19,7 @@
 
 //____________________________________________________________________________||
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/Common/interface/Handle.h"
@@ -38,7 +38,7 @@ class TCMETAlgo;
 namespace cms
 {
 
-class MuonTCMETValueMapProducer : public edm::EDProducer
+class MuonTCMETValueMapProducer : public edm::stream::EDProducer<>
 {
 
 public:
@@ -47,7 +47,6 @@ public:
 
 
 private:
-  virtual void beginJob() override;
   virtual void produce(edm::Event&, const edm::EventSetup&) override;
       
   edm::Handle<reco::MuonCollection>    muons_;

--- a/RecoMET/METProducers/interface/PFMETProducer.h
+++ b/RecoMET/METProducers/interface/PFMETProducer.h
@@ -20,7 +20,7 @@
 
 //____________________________________________________________________________||
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -39,7 +39,7 @@ namespace metsig
 //____________________________________________________________________________||
 namespace cms
 {
-  class PFMETProducer: public edm::EDProducer
+  class PFMETProducer: public edm::stream::EDProducer<>
     {
     public:
       explicit PFMETProducer(const edm::ParameterSet&);

--- a/RecoMET/METProducers/interface/TCMETProducer.h
+++ b/RecoMET/METProducers/interface/TCMETProducer.h
@@ -20,7 +20,7 @@
 
 //____________________________________________________________________________||
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -32,7 +32,7 @@
 //____________________________________________________________________________||
 namespace cms
 {
-  class TCMETProducer: public edm::EDProducer
+  class TCMETProducer: public edm::stream::EDProducer<>
     {
     public:
       explicit TCMETProducer(const edm::ParameterSet&);

--- a/RecoMET/METProducers/src/MuonTCMETValueMapProducer.cc
+++ b/RecoMET/METProducers/src/MuonTCMETValueMapProducer.cc
@@ -94,6 +94,11 @@ MuonTCMETValueMapProducer::MuonTCMETValueMapProducer(const edm::ParameterSet& iC
   response_function = 0;
   tcmetAlgo_=new TCMETAlgo();
 
+  if( rfType_ == 1 )
+    response_function = tcmetAlgo_->getResponseFunction_fit();
+  else if( rfType_ == 2 )
+    response_function = tcmetAlgo_->getResponseFunction_mode();
+
   muonToken_ = consumes<reco::MuonCollection>(iConfig.getParameter<edm::InputTag>("muonInputTag"));
   beamSpotToken_ = consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>("beamSpotInputTag"));
   vertexToken_ = consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("vertexInputTag"));
@@ -185,16 +190,6 @@ void MuonTCMETValueMapProducer::produce(edm::Event& iEvent, const edm::EventSetu
   iEvent.put(vm_muCorrData, "muCorrData");
 }
   
-//____________________________________________________________________________||
-void MuonTCMETValueMapProducer::beginJob()
-{
-
-  if( rfType_ == 1 )
-    response_function = tcmetAlgo_->getResponseFunction_fit();
-  else if( rfType_ == 2 )
-    response_function = tcmetAlgo_->getResponseFunction_mode();
-}
-
 //____________________________________________________________________________||
 bool MuonTCMETValueMapProducer::isGoodMuon( const reco::Muon* muon )
 {

--- a/RecoMuon/CosmicMuonProducer/src/CosmicMuonProducer.h
+++ b/RecoMuon/CosmicMuonProducer/src/CosmicMuonProducer.h
@@ -6,13 +6,13 @@
  *  \author Chang Liu
  */
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
 
 class MuonTrackFinder;
 class MuonServiceProxy;
 
-class CosmicMuonProducer : public edm::EDProducer {
+class CosmicMuonProducer : public edm::stream::EDProducer<> {
 public:
   explicit CosmicMuonProducer(const edm::ParameterSet&);
 

--- a/RecoMuon/CosmicMuonProducer/src/GlobalCosmicMuonProducer.h
+++ b/RecoMuon/CosmicMuonProducer/src/GlobalCosmicMuonProducer.h
@@ -9,7 +9,7 @@
  *  \author Chang Liu  -  Purdue University <Chang.Liu@cern.ch>
  */
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
@@ -17,7 +17,7 @@
 class MuonTrackFinder;
 class MuonServiceProxy;
 
-class GlobalCosmicMuonProducer : public edm::EDProducer {
+class GlobalCosmicMuonProducer : public edm::stream::EDProducer<> {
 public:
   explicit GlobalCosmicMuonProducer(const edm::ParameterSet&);
 

--- a/RecoMuon/GlobalMuonProducer/src/GlobalMuonProducer.h
+++ b/RecoMuon/GlobalMuonProducer/src/GlobalMuonProducer.h
@@ -13,7 +13,7 @@
  *   \author  R.Bellan - INFN TO
  */
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 // Input and output collection
 #include "DataFormats/TrackReco/interface/Track.h"
@@ -29,7 +29,7 @@ namespace edm {class ParameterSet; class Event; class EventSetup;}
 class MuonTrackFinder;
 class MuonServiceProxy;
 
-class GlobalMuonProducer : public edm::EDProducer {
+class GlobalMuonProducer : public edm::stream::EDProducer<> {
 
  public:
 

--- a/RecoMuon/GlobalMuonProducer/src/TevMuonProducer.h
+++ b/RecoMuon/GlobalMuonProducer/src/TevMuonProducer.h
@@ -13,7 +13,7 @@
  *   \author  R.Bellan - INFN TO
  */
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "RecoMuon/GlobalTrackingTools/interface/GlobalMuonRefitter.h"
 #include "RecoMuon/TrackingTools/interface/MuonTrackLoader.h"
 
@@ -36,7 +36,7 @@ namespace edm {class ParameterSet; class Event; class EventSetup;}
 class MuonTrackFinder;
 class MuonServiceProxy;
 
-class TevMuonProducer : public edm::EDProducer {
+class TevMuonProducer : public edm::stream::EDProducer<> {
 
  public:
 

--- a/RecoMuon/GlobalTrackingTools/plugins/GlobalTrackQualityProducer.h
+++ b/RecoMuon/GlobalTrackingTools/plugins/GlobalTrackQualityProducer.h
@@ -9,7 +9,7 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -24,7 +24,7 @@
 
 class GlobalMuonRefitter;
 
-class GlobalTrackQualityProducer : public edm::EDProducer {
+class GlobalTrackQualityProducer : public edm::stream::EDProducer<> {
  public:
   explicit GlobalTrackQualityProducer(const edm::ParameterSet& iConfig);
 

--- a/RecoMuon/MuonIdentification/plugins/CaloMuonProducer.h
+++ b/RecoMuon/MuonIdentification/plugins/CaloMuonProducer.h
@@ -14,13 +14,13 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
 #include "DataFormats/MuonReco/interface/CaloMuon.h"
 
 
-class CaloMuonProducer : public edm::EDProducer {
+class CaloMuonProducer : public edm::stream::EDProducer<> {
  public:
    explicit CaloMuonProducer(const edm::ParameterSet&);
    ~CaloMuonProducer();

--- a/RecoMuon/MuonIdentification/plugins/CosmicsMuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/CosmicsMuonIdProducer.cc
@@ -7,7 +7,7 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "RecoMuon/MuonIdentification/interface/MuonCosmicsId.h"
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
@@ -16,7 +16,7 @@
 
 #include "RecoMuon/MuonIdentification/interface/MuonCosmicCompatibilityFiller.h"
 
-class CosmicsMuonIdProducer : public edm::EDProducer {
+class CosmicsMuonIdProducer : public edm::stream::EDProducer<> {
 public:
   CosmicsMuonIdProducer(const edm::ParameterSet& iConfig) :
     inputMuonCollection_(iConfig.getParameter<edm::InputTag>("muonCollection")),

--- a/RecoMuon/MuonIdentification/plugins/InterestingEcalDetIdProducer.h
+++ b/RecoMuon/MuonIdentification/plugins/InterestingEcalDetIdProducer.h
@@ -3,14 +3,14 @@
 // -*- C++ -*-
 #include <memory>
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
 #include "DataFormats/MuonReco/interface/Muon.h"
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
 
 class CaloTopology;
-class InterestingEcalDetIdProducer : public edm::EDProducer {
+class InterestingEcalDetIdProducer : public edm::stream::EDProducer<> {
  public:
   explicit InterestingEcalDetIdProducer(const edm::ParameterSet&);
   ~InterestingEcalDetIdProducer();

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.h
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.h
@@ -26,7 +26,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -64,7 +64,7 @@
 class MuonMesh;
 class MuonKinkFinder;
 
-class MuonIdProducer : public edm::EDProducer {
+class MuonIdProducer : public edm::stream::EDProducer<> {
  public:
    typedef reco::Muon::MuonTrackType TrackType;
   

--- a/RecoMuon/MuonIdentification/plugins/MuonProducer.h
+++ b/RecoMuon/MuonIdentification/plugins/MuonProducer.h
@@ -11,7 +11,7 @@
  *  \author R. Bellan - UCSB <riccardo.bellan@cern.ch>
  */
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
@@ -44,7 +44,7 @@ namespace reco {class Track;}
 class MuPFIsoHelper;
 
 
-class MuonProducer : public edm::EDProducer {
+class MuonProducer : public edm::stream::EDProducer<> {
 public:
 
   /// Constructor

--- a/RecoMuon/MuonIdentification/plugins/MuonSelectionTypeValueMapProducer.h
+++ b/RecoMuon/MuonIdentification/plugins/MuonSelectionTypeValueMapProducer.h
@@ -8,14 +8,14 @@
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
 #include "DataFormats/MuonReco/interface/MuonSelectors.h"
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-class MuonSelectionTypeValueMapProducer : public edm::EDProducer {
+class MuonSelectionTypeValueMapProducer : public edm::stream::EDProducer<> {
     public:
         explicit MuonSelectionTypeValueMapProducer(const edm::ParameterSet& iConfig) :
             inputMuonCollection_(iConfig.getParameter<edm::InputTag>("inputMuonCollection")),

--- a/RecoMuon/MuonIdentification/plugins/MuonShowerInformationProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonShowerInformationProducer.cc
@@ -7,7 +7,7 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
@@ -16,7 +16,7 @@
 
 #include "RecoMuon/MuonIdentification/interface/MuonShowerInformationFiller.h"
 
-class MuonShowerInformationProducer : public edm::EDProducer {
+class MuonShowerInformationProducer : public edm::stream::EDProducer<> {
 public:
   MuonShowerInformationProducer(const edm::ParameterSet& iConfig) :
     inputMuonCollection_(iConfig.getParameter<edm::InputTag>("muonCollection")),

--- a/RecoMuon/MuonIdentification/plugins/MuonTimingProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonTimingProducer.cc
@@ -64,17 +64,6 @@ MuonTimingProducer::~MuonTimingProducer()
 // member functions
 //
 
-// ------------ method called once each job just before starting event loop  ------------
-void 
-MuonTimingProducer::beginJob()
-{
-}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void 
-MuonTimingProducer::endJob() {
-}
-
 // ------------ method called to produce the data  ------------
 void
 MuonTimingProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {

--- a/RecoMuon/MuonIdentification/plugins/MuonTimingProducer.h
+++ b/RecoMuon/MuonIdentification/plugins/MuonTimingProducer.h
@@ -25,7 +25,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -40,15 +40,13 @@
 // class decleration
 //
 
-class MuonTimingProducer : public edm::EDProducer {
+class MuonTimingProducer : public edm::stream::EDProducer<> {
    public:
       explicit MuonTimingProducer(const edm::ParameterSet&);
       ~MuonTimingProducer();
 
    private:
-      virtual void beginJob() ;
-      virtual void produce(edm::Event&, const edm::EventSetup&);
-      virtual void endJob() ;
+      virtual void produce(edm::Event&, const edm::EventSetup&) override;
       
       // ----------member data ---------------------------
       edm::InputTag m_muonCollection;

--- a/RecoMuon/MuonIdentification/plugins/TrajectorySeedFromMuonProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/TrajectorySeedFromMuonProducer.cc
@@ -7,7 +7,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -44,7 +44,7 @@
 
 #include "RecoMuon/MuonIdentification/interface/MuonCosmicsId.h"
 
-class TrajectorySeedFromMuonProducer : public edm::EDProducer
+class TrajectorySeedFromMuonProducer : public edm::stream::EDProducer<>
 {
 
 public:

--- a/RecoMuon/MuonIsolationProducers/plugins/MuIsoDepositCopyProducer.h
+++ b/RecoMuon/MuonIsolationProducers/plugins/MuIsoDepositCopyProducer.h
@@ -1,7 +1,7 @@
 #ifndef MuonIsolationProducers_MuIsoDepositCopyProducer_H
 #define MuonIsolationProducers_MuIsoDepositCopyProducer_H
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/RecoCandidate/interface/IsoDeposit.h"
 #include "DataFormats/RecoCandidate/interface/IsoDepositFwd.h"
@@ -13,7 +13,7 @@
 namespace edm { class Event; }
 namespace edm { class EventSetup; }
 
-class MuIsoDepositCopyProducer : public edm::EDProducer {
+class MuIsoDepositCopyProducer : public edm::stream::EDProducer<> {
 
 public:
 

--- a/RecoMuon/MuonIsolationProducers/plugins/MuIsoDepositProducer.h
+++ b/RecoMuon/MuonIsolationProducers/plugins/MuIsoDepositProducer.h
@@ -1,7 +1,7 @@
 #ifndef MuonIsolationProducers_MuIsoDepositProducer_H
 #define MuonIsolationProducers_MuIsoDepositProducer_H
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "PhysicsTools/IsolationAlgos/interface/IsoDepositExtractor.h"
@@ -10,7 +10,7 @@
 namespace edm { class Event; }
 namespace edm { class EventSetup; }
 
-class MuIsoDepositProducer : public edm::EDProducer {
+class MuIsoDepositProducer : public edm::stream::EDProducer<> {
 
 public:
 

--- a/RecoMuon/MuonSeedGenerator/plugins/CosmicMuonSeedGenerator.h
+++ b/RecoMuon/MuonSeedGenerator/plugins/CosmicMuonSeedGenerator.h
@@ -7,7 +7,7 @@
  *  \author Chang Liu - Purdue University 
  */
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
@@ -23,7 +23,7 @@ class TrajectoryStateTransform;
 
 namespace edm {class ParameterSet; class Event; class EventSetup;}
 
-class CosmicMuonSeedGenerator: public edm::EDProducer {
+class CosmicMuonSeedGenerator: public edm::stream::EDProducer<> {
  public:
 
   /// Constructor

--- a/RecoMuon/MuonSeedGenerator/plugins/MuonSeedGenerator.h
+++ b/RecoMuon/MuonSeedGenerator/plugins/MuonSeedGenerator.h
@@ -7,7 +7,7 @@
  *  \author R. Bellan - INFN Torino
  */
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
 #include <vector>
@@ -17,7 +17,7 @@ class MuonSeedVFinder;
 class MuonSeedVPatternRecognition;
 class MuonSeedVCleaner;
 
-class MuonSeedGenerator: public edm::EDProducer {
+class MuonSeedGenerator: public edm::stream::EDProducer<> {
  public:
 
   /// Constructor

--- a/RecoMuon/MuonSeedGenerator/plugins/MuonSeedMerger.h
+++ b/RecoMuon/MuonSeedGenerator/plugins/MuonSeedMerger.h
@@ -10,7 +10,7 @@
  *  \author R. Bellan - CERN <riccardo.bellan@cern.ch>
  */
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 // Data Formats 
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeed.h"
@@ -19,7 +19,7 @@
 
 namespace edm {class ParameterSet; class Event; class EventSetup;}
 
-class MuonSeedMerger : public edm::EDProducer {
+class MuonSeedMerger : public edm::stream::EDProducer<> {
 public:
   /// Constructor
   MuonSeedMerger(const edm::ParameterSet&);

--- a/RecoMuon/MuonSeedGenerator/plugins/MuonSeedProducer.h
+++ b/RecoMuon/MuonSeedGenerator/plugins/MuonSeedProducer.h
@@ -13,7 +13,7 @@
  *
  */
 
-#include <FWCore/Framework/interface/EDProducer.h>
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include <FWCore/Framework/interface/Frameworkfwd.h>
 #include <FWCore/Framework/interface/Event.h>
 #include <FWCore/ParameterSet/interface/ParameterSet.h>
@@ -22,7 +22,7 @@
 
 class MuonSeedBuilder;
 
-class MuonSeedProducer: public edm::EDProducer {
+class MuonSeedProducer: public edm::stream::EDProducer<> {
  public:
 
   /// Constructor

--- a/RecoMuon/MuonSeedGenerator/plugins/SETMuonSeedProducer.h
+++ b/RecoMuon/MuonSeedGenerator/plugins/SETMuonSeedProducer.h
@@ -10,7 +10,7 @@
 //---- provided need to be fitted properly (starting from the initial estimates also provided).
 //---- Technically all this information is stored as a TrajectorySeed. SS 
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "RecoMuon/TrackingTools/interface/RecoMuonEnumerators.h"
 
@@ -27,7 +27,7 @@ class STAFilter;
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 
-class SETMuonSeedProducer : public edm::EDProducer {
+class SETMuonSeedProducer : public edm::stream::EDProducer<> {
   
  public:
   typedef MuonTransientTrackingRecHit::MuonRecHitContainer MuonRecHitContainer;

--- a/RecoMuon/StandAloneMuonProducer/src/StandAloneMuonProducer.h
+++ b/RecoMuon/StandAloneMuonProducer/src/StandAloneMuonProducer.h
@@ -13,7 +13,7 @@
  *   \author  R.Bellan - INFN TO
  */
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
 
@@ -22,7 +22,7 @@ namespace edm {class ParameterSet; class Event; class EventSetup;}
 class MuonTrackFinder;
 class MuonServiceProxy;
 
-class StandAloneMuonProducer : public edm::EDProducer {
+class StandAloneMuonProducer : public edm::stream::EDProducer<> {
 
  public:
 

--- a/RecoParticleFlow/PFProducer/plugins/PFElectronTranslator.h
+++ b/RecoParticleFlow/PFProducer/plugins/PFElectronTranslator.h
@@ -1,6 +1,6 @@
 #ifndef RecoParticleFlow_PFProducer_PFElectronTranslator_H
 #define RecoParticleFlow_PFProducer_PFElectronTranslator_H
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -20,7 +20,7 @@
 
 
 
-class PFElectronTranslator : public edm::EDProducer
+class PFElectronTranslator : public edm::stream::EDProducer<>
 {
  public:
   explicit PFElectronTranslator(const edm::ParameterSet&);

--- a/RecoParticleFlow/PFProducer/plugins/PFPhotonTranslator.h
+++ b/RecoParticleFlow/PFProducer/plugins/PFPhotonTranslator.h
@@ -1,6 +1,6 @@
 #ifndef RecoParticleFlow_PFProducer_PFPhotonTranslator_H
 #define RecoParticleFlow_PFProducer_PFPhotonTranslator_H
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -57,7 +57,7 @@
 #include "TLorentzVector.h"
 #include "TMath.h"
 
-class PFPhotonTranslator : public edm::EDProducer
+class PFPhotonTranslator : public edm::stream::EDProducer<>
 {
  public:
   explicit PFPhotonTranslator(const edm::ParameterSet&);

--- a/RecoParticleFlow/PFTracking/interface/ElectronSeedMerger.h
+++ b/RecoParticleFlow/PFTracking/interface/ElectronSeedMerger.h
@@ -6,12 +6,12 @@
 // user include files
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "DataFormats/EgammaReco/interface/ElectronSeedFwd.h"
 
-class ElectronSeedMerger : public edm::EDProducer {
+class ElectronSeedMerger : public edm::stream::EDProducer<> {
    public:
       explicit ElectronSeedMerger(const edm::ParameterSet&);
       ~ElectronSeedMerger();

--- a/RecoParticleFlow/PFTracking/interface/GoodSeedProducer.h
+++ b/RecoParticleFlow/PFTracking/interface/GoodSeedProducer.h
@@ -6,7 +6,7 @@
 // user include files
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -47,7 +47,7 @@ class TrackerGeometry;
 class TrajectoryStateOnSurface;
 
 
-class GoodSeedProducer : public edm::EDProducer {
+class GoodSeedProducer : public edm::stream::EDProducer<> {
   typedef TrajectoryStateOnSurface TSOS;
    public:
       explicit GoodSeedProducer(const edm::ParameterSet&);

--- a/RecoParticleFlow/PFTracking/interface/PFElecTkProducer.h
+++ b/RecoParticleFlow/PFTracking/interface/PFElecTkProducer.h
@@ -4,7 +4,7 @@
 #include "DataFormats/ParticleFlowReco/interface/PFConversion.h"
 #include "DataFormats/ParticleFlowReco/interface/PFV0.h"
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -41,7 +41,7 @@ class ConvBremPFTrackFinder;
  and transform them in PFGsfRecTracks.
 */
 
-class PFElecTkProducer : public edm::EDProducer {
+class PFElecTkProducer : public edm::stream::EDProducer<> {
  public:
   
      ///Constructor

--- a/RecoParticleFlow/PFTracking/interface/PFNuclearProducer.h
+++ b/RecoParticleFlow/PFTracking/interface/PFNuclearProducer.h
@@ -1,7 +1,7 @@
 #ifndef PFNuclearProducer_H
 #define PFNuclearProducer_H
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -9,7 +9,7 @@
 #include "DataFormats/ParticleFlowReco/interface/PFNuclearInteraction.h"
 
 class PFTrackTransformer;
-class PFNuclearProducer : public edm::EDProducer {
+class PFNuclearProducer : public edm::stream::EDProducer<> {
 public:
   
   ///Constructor

--- a/RecoParticleFlow/PFTracking/interface/PFTrackProducer.h
+++ b/RecoParticleFlow/PFTracking/interface/PFTrackProducer.h
@@ -1,7 +1,7 @@
 #ifndef PFTrackProducer_H
 #define PFTrackProducer_H
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -23,7 +23,7 @@
 
 
 class PFTrackTransformer;
-class PFTrackProducer : public edm::EDProducer {
+class PFTrackProducer : public edm::stream::EDProducer<> {
 public:
   
   ///Constructor

--- a/RecoParticleFlow/PFTracking/plugins/PFConversionProducer.h
+++ b/RecoParticleFlow/PFTracking/plugins/PFConversionProducer.h
@@ -1,7 +1,7 @@
 #ifndef PFConversionProducer_H
 #define PFConversionProducer_H
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -11,7 +11,7 @@
 #include "DataFormats/ParticleFlowReco/interface/PFConversionFwd.h"
 
 class PFTrackTransformer;
-class PFConversionProducer : public edm::EDProducer {
+class PFConversionProducer : public edm::stream::EDProducer<> {
 public:
   
   ///Constructor

--- a/RecoParticleFlow/PFTracking/plugins/PFDisplacedTrackerVertexProducer.h
+++ b/RecoParticleFlow/PFTracking/plugins/PFDisplacedTrackerVertexProducer.h
@@ -1,7 +1,7 @@
 #ifndef PFDisplacedTrackerVertexProducer_H
 #define PFDisplacedTrackerVertexProducer_H
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -9,7 +9,7 @@
 #include "DataFormats/ParticleFlowReco/interface/PFDisplacedTrackerVertex.h"
 
 class PFTrackTransformer;
-class PFDisplacedTrackerVertexProducer : public edm::EDProducer {
+class PFDisplacedTrackerVertexProducer : public edm::stream::EDProducer<> {
 public:
   
   ///Constructor

--- a/RecoParticleFlow/PFTracking/plugins/PFDisplacedVertexCandidateProducer.h
+++ b/RecoParticleFlow/PFTracking/plugins/PFDisplacedVertexCandidateProducer.h
@@ -3,7 +3,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "FWCore/Framework/interface/Event.h"
@@ -24,7 +24,7 @@ together by the criterion which is by default the minimal approach distance.
 \date   November 2009
 */
 
-class PFDisplacedVertexCandidateProducer : public edm::EDProducer {
+class PFDisplacedVertexCandidateProducer : public edm::stream::EDProducer<> {
  public:
 
   explicit PFDisplacedVertexCandidateProducer(const edm::ParameterSet&);

--- a/RecoParticleFlow/PFTracking/plugins/PFDisplacedVertexProducer.h
+++ b/RecoParticleFlow/PFTracking/plugins/PFDisplacedVertexProducer.h
@@ -3,7 +3,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "FWCore/Framework/interface/Event.h"
@@ -22,7 +22,7 @@ together by the criterion which is by default the minimal approach distance.
 \date   November 2009
 */
 
-class PFDisplacedVertexProducer : public edm::EDProducer {
+class PFDisplacedVertexProducer : public edm::stream::EDProducer<> {
  public:
 
   explicit PFDisplacedVertexProducer(const edm::ParameterSet&);

--- a/RecoParticleFlow/PFTracking/plugins/PFV0Producer.h
+++ b/RecoParticleFlow/PFTracking/plugins/PFV0Producer.h
@@ -1,7 +1,7 @@
 #ifndef PFV0Producer_H
 #define PFV0Producer_H
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -11,7 +11,7 @@
 
 
 class PFTrackTransformer;
-class PFV0Producer : public edm::EDProducer {
+class PFV0Producer : public edm::stream::EDProducer<> {
 public:
   
   ///Constructor

--- a/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackProducer.h
+++ b/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackProducer.h
@@ -1,13 +1,13 @@
 #ifndef PixelTrackProducer_H
 #define PixelTrackProducer_H
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "RecoPixelVertexing/PixelTrackFitting/interface/TracksWithHits.h"
 #include "RecoPixelVertexing/PixelTrackFitting/interface/PixelTrackReconstruction.h"
 
 namespace edm { class Event; class EventSetup; class ParameterSet; }
 
-class PixelTrackProducer :  public edm::EDProducer {
+class PixelTrackProducer :  public edm::stream::EDProducer<> {
 
 public:
   explicit PixelTrackProducer(const edm::ParameterSet& conf);

--- a/RecoTauTag/RecoTau/interface/RecoTauBuilderPlugins.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauBuilderPlugins.h
@@ -106,7 +106,6 @@ class RecoTauModifierPlugin : public RecoTauEventHolderPlugin
   virtual ~RecoTauModifierPlugin() {}
   // Modify an existing PFTau (i.e. add electron rejection, etc)
   virtual void operator()(PFTau&) const = 0;
-  virtual void beginJob(edm::EDProducer*) {}
   virtual void beginEvent() {}
   virtual void endEvent() {}
 };

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronProducer.cc
@@ -11,7 +11,7 @@
  *
  */
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -49,7 +49,7 @@
 #include <functional>
 #include <math.h>
 
-class PFRecoTauChargedHadronProducer : public edm::EDProducer 
+class PFRecoTauChargedHadronProducer : public edm::stream::EDProducer<> 
 {
 public:
   typedef reco::tau::PFRecoTauChargedHadronBuilderPlugin Builder;

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauEnergyAlgorithmPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauEnergyAlgorithmPlugin.cc
@@ -40,7 +40,6 @@ class PFRecoTauEnergyAlgorithmPlugin : public RecoTauModifierPlugin
   explicit PFRecoTauEnergyAlgorithmPlugin(const edm::ParameterSet&, edm::ConsumesCollector &&iC);
   virtual ~PFRecoTauEnergyAlgorithmPlugin();
   void operator()(PFTau&) const;
-  virtual void beginJob(edm::EDProducer*);
   virtual void beginEvent();
   virtual void endEvent();
 
@@ -66,9 +65,6 @@ class PFRecoTauEnergyAlgorithmPlugin : public RecoTauModifierPlugin
 }
 
 PFRecoTauEnergyAlgorithmPlugin::~PFRecoTauEnergyAlgorithmPlugin()
-{}
-
-void PFRecoTauEnergyAlgorithmPlugin::beginJob(edm::EDProducer* producer)
 {}
 
 void PFRecoTauEnergyAlgorithmPlugin::beginEvent()

--- a/RecoTauTag/RecoTau/plugins/RecoTauJetRegionProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauJetRegionProducer.cc
@@ -19,7 +19,7 @@
 #include "RecoTauTag/RecoTau/interface/ConeTools.h"
 #include "RecoTauTag/RecoTau/interface/RecoTauCommonUtilities.h"
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -29,7 +29,7 @@
 #include <string>
 #include <iostream>
 
-class RecoTauJetRegionProducer : public edm::EDProducer 
+class RecoTauJetRegionProducer : public edm::stream::EDProducer<> 
 {
  public:
   typedef edm::Association<reco::PFJetCollection> PFJetMatchMap;

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroProducer.cc
@@ -17,7 +17,7 @@
 #include <algorithm>
 #include <functional>
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -37,7 +37,7 @@
 #include "CommonTools/CandUtils/interface/AddFourMomenta.h"
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
 
-class RecoTauPiZeroProducer : public edm::EDProducer {
+class RecoTauPiZeroProducer : public edm::stream::EDProducer<> {
   public:
     typedef reco::tau::RecoTauPiZeroBuilderPlugin Builder;
     typedef reco::tau::RecoTauPiZeroQualityPlugin Ranker;

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroUnembedder.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroUnembedder.cc
@@ -14,7 +14,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "RecoTauTag/RecoTau/interface/RecoTauCommonUtilities.h"
 
@@ -23,7 +23,7 @@
 #include "DataFormats/TauReco/interface/RecoTauPiZero.h"
 #include "DataFormats/TauReco/interface/RecoTauPiZeroFwd.h"
 
-class RecoTauPiZeroUnembedder : public edm::EDProducer {
+class RecoTauPiZeroUnembedder : public edm::stream::EDProducer<> {
   public:
     RecoTauPiZeroUnembedder(const edm::ParameterSet& pset);
     virtual ~RecoTauPiZeroUnembedder(){}

--- a/RecoTauTag/RecoTau/plugins/RecoTauPileUpVertexSelector.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPileUpVertexSelector.cc
@@ -6,7 +6,7 @@
  */
 
 
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -38,7 +38,7 @@ class VertexTrackPtSumFilter : public std::unary_function<reco::Vertex, bool> {
 
 }
 
-class RecoTauPileUpVertexSelector : public edm::EDFilter {
+class RecoTauPileUpVertexSelector : public edm::stream::EDFilter<> {
   public:
     explicit RecoTauPileUpVertexSelector(const edm::ParameterSet &pset);
     ~RecoTauPileUpVertexSelector() {}

--- a/RecoTauTag/RecoTau/plugins/RecoTauProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauProducer.cc
@@ -22,7 +22,7 @@
 #include <algorithm>
 #include <functional>
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -41,7 +41,7 @@
 
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
 
-class RecoTauProducer : public edm::EDProducer 
+class RecoTauProducer : public edm::stream::EDProducer<> 
 {
  public:
   typedef reco::tau::RecoTauBuilderPlugin Builder;
@@ -106,7 +106,6 @@ RecoTauProducer::RecoTauProducer(const edm::ParameterSet& pset)
     // Build the plugin
     reco::tau::RecoTauModifierPlugin* plugin = 0;
     plugin = RecoTauModifierPluginFactory::get()->create(pluginType, *modfierPSet, consumesCollector());
-    plugin->beginJob(this);
     modifiers_.push_back(plugin);
   }
 

--- a/RecoTracker/DeDx/plugins/DeDxDiscriminatorProducer.cc
+++ b/RecoTracker/DeDx/plugins/DeDxDiscriminatorProducer.cc
@@ -217,7 +217,7 @@ void  DeDxDiscriminatorProducer::beginRun(edm::Run const& run, const edm::EventS
 
 }
 
-void  DeDxDiscriminatorProducer::endJob()
+void  DeDxDiscriminatorProducer::endStream()
 {
    MODsColl.clear();
 }

--- a/RecoTracker/DeDx/plugins/DeDxDiscriminatorProducer.h
+++ b/RecoTracker/DeDx/plugins/DeDxDiscriminatorProducer.h
@@ -2,7 +2,7 @@
 #define TrackRecoDeDx_DeDxDiscriminatorProducer_H
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -45,7 +45,7 @@
 
 
 
-class DeDxDiscriminatorProducer : public edm::EDProducer {
+class DeDxDiscriminatorProducer : public edm::stream::EDProducer<> {
 
 public:
 
@@ -55,7 +55,7 @@ public:
 private:
   virtual void beginRun(edm::Run const& run, const edm::EventSetup&) override;
   virtual void produce(edm::Event&, const edm::EventSetup&) override;
-  virtual void endJob() ;
+  virtual void endStream() override;
 
   double GetProbability(const SiStripCluster*   cluster, TrajectoryStateOnSurface trajState,const uint32_t &);
   double ComputeDiscriminator (std::vector<double>& vect_probs);

--- a/RecoTracker/DeDx/plugins/DeDxEstimatorProducer.h
+++ b/RecoTracker/DeDx/plugins/DeDxEstimatorProducer.h
@@ -2,7 +2,7 @@
 #define TrackRecoDeDx_DeDxEstimatorProducer_H
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -31,7 +31,7 @@
 // class declaration
 //
 
-class DeDxEstimatorProducer : public edm::EDProducer {
+class DeDxEstimatorProducer : public edm::stream::EDProducer<> {
 
 public:
 

--- a/RecoTracker/FinalTrackSelectors/interface/CosmicTrackSelector.h
+++ b/RecoTracker/FinalTrackSelectors/interface/CosmicTrackSelector.h
@@ -15,7 +15,7 @@
 #include <memory>
 #include <algorithm>
 #include <map>
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/EventPrincipal.h" 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -32,7 +32,7 @@
 
 namespace reco { namespace modules {
     
-    class CosmicTrackSelector : public edm::EDProducer {
+    class CosmicTrackSelector : public edm::stream::EDProducer<> {
 		   private:
 		   public:
 		     // constructor 

--- a/RecoTracker/FinalTrackSelectors/interface/DuplicateListMerger.h
+++ b/RecoTracker/FinalTrackSelectors/interface/DuplicateListMerger.h
@@ -7,7 +7,7 @@
  * \author Matthew Walker
  */
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "DataFormats/Provenance/interface/ParameterSetID.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -35,7 +35,7 @@
 #include "TMVA/Reader.h"
 
 namespace reco { namespace modules {
-    class DuplicateListMerger : public edm::EDProducer {
+    class DuplicateListMerger : public edm::stream::EDProducer<> {
        public:
          /// constructor
          explicit DuplicateListMerger(const edm::ParameterSet& iPara);

--- a/RecoTracker/FinalTrackSelectors/interface/DuplicateTrackMerger.h
+++ b/RecoTracker/FinalTrackSelectors/interface/DuplicateTrackMerger.h
@@ -7,7 +7,7 @@
  * \author Matthew Walker
  */
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "DataFormats/Provenance/interface/ParameterSetID.h"
 #include "DataFormats/Candidate/interface/LeafCandidate.h"
@@ -31,7 +31,7 @@
 #include "CondFormats/EgammaObjects/interface/GBRForest.h"
 
 namespace reco { namespace modules {
-    class DuplicateTrackMerger : public edm::EDProducer {
+    class DuplicateTrackMerger : public edm::stream::EDProducer<> {
        public:
          /// constructor
          explicit DuplicateTrackMerger(const edm::ParameterSet& iPara);

--- a/RecoTracker/FinalTrackSelectors/src/MultiTrackSelector.h
+++ b/RecoTracker/FinalTrackSelectors/src/MultiTrackSelector.h
@@ -15,7 +15,7 @@
 #include <memory>
 #include <algorithm>
 #include <map>
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -34,7 +34,7 @@
 
 namespace reco { namespace modules {
 
-    class MultiTrackSelector : public edm::EDProducer {
+    class MultiTrackSelector : public edm::stream::EDProducer<> {
         private:
         public:
             /// constructor 

--- a/RecoTracker/FinalTrackSelectors/src/TrackListMerger.h
+++ b/RecoTracker/FinalTrackSelectors/src/TrackListMerger.h
@@ -12,7 +12,7 @@
 //
 //
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -31,7 +31,7 @@
 
 namespace cms
 {
-  class TrackListMerger : public edm::EDProducer
+  class TrackListMerger : public edm::stream::EDProducer<>
   {
   public:
 

--- a/RecoTracker/MeasurementDet/plugins/MeasurementTrackerEventProducer.h
+++ b/RecoTracker/MeasurementDet/plugins/MeasurementTrackerEventProducer.h
@@ -2,7 +2,7 @@
 #define MeasurementTrackerEventProducer_h
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 
@@ -11,7 +11,7 @@
 #include "DataFormats/Common/interface/ContainerMask.h"
 #include "DataFormats/DetId/interface/DetIdCollection.h"
 
-class MeasurementTrackerEventProducer : public edm::EDProducer {
+class MeasurementTrackerEventProducer : public edm::stream::EDProducer<> {
 public:
       explicit MeasurementTrackerEventProducer(const edm::ParameterSet &iConfig) ;
       ~MeasurementTrackerEventProducer() {}

--- a/RecoTracker/SpecialSeedGenerators/interface/CtfSpecialSeedGenerator.h
+++ b/RecoTracker/SpecialSeedGenerators/interface/CtfSpecialSeedGenerator.h
@@ -6,7 +6,7 @@
  *  from combinations of hits in pairs of strip layers 
  */
 //FWK
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -37,7 +37,7 @@
 
 #include <map>
 
-class CtfSpecialSeedGenerator : public edm::EDProducer
+class CtfSpecialSeedGenerator : public edm::stream::EDProducer<>
 {
  public:
   typedef TrajectoryStateOnSurface TSOS;

--- a/RecoTracker/SpecialSeedGenerators/src/MuonReSeeder.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/MuonReSeeder.cc
@@ -10,7 +10,7 @@
 */
 
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -28,7 +28,7 @@
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 
 
-class MuonReSeeder : public edm::EDProducer {
+class MuonReSeeder : public edm::stream::EDProducer<> {
     public:
       explicit MuonReSeeder(const edm::ParameterSet & iConfig);
       virtual ~MuonReSeeder() { }

--- a/RecoTracker/SpecialSeedGenerators/src/OutsideInMuonSeeder.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/OutsideInMuonSeeder.cc
@@ -10,7 +10,7 @@
 */
 
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -41,7 +41,7 @@
 #include "TrackingTools/PatternTools/interface/TrajectoryMeasurement.h"
 #include "TrackingTools/PatternTools/interface/TrajMeasLessEstim.h"
 
-class OutsideInMuonSeeder : public edm::EDProducer {
+class OutsideInMuonSeeder : public edm::stream::EDProducer<> {
     public:
       explicit OutsideInMuonSeeder(const edm::ParameterSet & iConfig);
       virtual ~OutsideInMuonSeeder() { }

--- a/RecoTracker/TkSeedGenerator/plugins/SeedCombiner.h
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedCombiner.h
@@ -2,7 +2,7 @@
 #define RecoTracker_TkSeedGenerator_SeedCombiner_H
 
 #include <vector>
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
 #include "DataFormats/TrackerRecHit2D/interface/ClusterRemovalInfo.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -10,7 +10,7 @@
 namespace edm { class Event; class EventSetup; class ParameterSet; }
 
 
-class SeedCombiner : public edm::EDProducer {
+class SeedCombiner : public edm::stream::EDProducer<> {
 public:
 
   SeedCombiner(const edm::ParameterSet& cfg);

--- a/RecoTracker/TkSeedingLayers/plugins/SeedingLayersEDProducer.cc
+++ b/RecoTracker/TkSeedingLayers/plugins/SeedingLayersEDProducer.cc
@@ -1,6 +1,6 @@
 #include "TrackingTools/TransientTrackingRecHit/interface/SeedingLayerSetsHits.h"
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
@@ -10,7 +10,7 @@
 #include "RecoTracker/TkSeedingLayers/interface/SeedingLayerSetsBuilder.h"
 #include "RecoTracker/TkSeedingLayers/interface/SeedingLayerSets.h"
 
-class SeedingLayersEDProducer: public edm::EDProducer {
+class SeedingLayersEDProducer: public edm::stream::EDProducer<> {
 public:
   SeedingLayersEDProducer(const edm::ParameterSet& iConfig);
   ~SeedingLayersEDProducer();

--- a/RecoTracker/TrackProducer/plugins/TrackProducer.h
+++ b/RecoTracker/TrackProducer/plugins/TrackProducer.h
@@ -7,12 +7,13 @@
  *  \author cerati
  */
 
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "RecoTracker/TrackProducer/interface/KfTrackProducerBase.h"
 #include "RecoTracker/TrackProducer/interface/TrackProducerAlgorithm.h"
 
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
 
-class TrackProducer : public KfTrackProducerBase, public edm::EDProducer {
+class TrackProducer : public KfTrackProducerBase, public edm::stream::EDProducer<> {
 public:
 
   /// Constructor

--- a/RecoVertex/AdaptiveVertexFinder/plugins/InclusiveVertexFinder.cc
+++ b/RecoVertex/AdaptiveVertexFinder/plugins/InclusiveVertexFinder.cc
@@ -1,6 +1,6 @@
 #include <memory>
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -30,7 +30,7 @@
 
 //#define VTXDEBUG 1
 
-class InclusiveVertexFinder : public edm::EDProducer {
+class InclusiveVertexFinder : public edm::stream::EDProducer<> {
     public:
 	InclusiveVertexFinder(const edm::ParameterSet &params);
 

--- a/RecoVertex/AdaptiveVertexFinder/plugins/TrackVertexArbitrator.cc
+++ b/RecoVertex/AdaptiveVertexFinder/plugins/TrackVertexArbitrator.cc
@@ -8,7 +8,7 @@
 #include "TrackingTools/IPTools/interface/IPTools.h"
 
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -42,7 +42,7 @@
 
 //#define VTXDEBUG
 
-class TrackVertexArbitrator : public edm::EDProducer {
+class TrackVertexArbitrator : public edm::stream::EDProducer<> {
     public:
 	TrackVertexArbitrator(const edm::ParameterSet &params);
 

--- a/RecoVertex/AdaptiveVertexFinder/plugins/VertexMerger.cc
+++ b/RecoVertex/AdaptiveVertexFinder/plugins/VertexMerger.cc
@@ -1,7 +1,7 @@
 #include <memory>
 #include <set>
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -14,7 +14,7 @@
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "RecoVertex/VertexTools/interface/VertexDistance3D.h"
 
-class VertexMerger : public edm::EDProducer {
+class VertexMerger : public edm::stream::EDProducer<> {
     public:
 	VertexMerger(const edm::ParameterSet &params);
 

--- a/RecoVertex/BeamSpotProducer/interface/BeamSpotProducer.h
+++ b/RecoVertex/BeamSpotProducer/interface/BeamSpotProducer.h
@@ -12,14 +12,14 @@
 
 ________________________________________________________________**/
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 
 
-class BeamSpotProducer: public edm::EDProducer {
+class BeamSpotProducer: public edm::stream::EDProducer<> {
 
   public:
 	typedef std::vector<edm::ParameterSet> Parameters;

--- a/RecoVertex/PrimaryVertexProducer/interface/PrimaryVertexProducer.h
+++ b/RecoVertex/PrimaryVertexProducer/interface/PrimaryVertexProducer.h
@@ -22,7 +22,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -51,7 +51,7 @@
 // class declaration
 //
 
-class PrimaryVertexProducer : public edm::EDProducer {
+class PrimaryVertexProducer : public edm::stream::EDProducer<> {
 public:
   explicit PrimaryVertexProducer(const edm::ParameterSet&);
   ~PrimaryVertexProducer();

--- a/RecoVertex/V0Producer/interface/V0Producer.h
+++ b/RecoVertex/V0Producer/interface/V0Producer.h
@@ -24,7 +24,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -39,7 +39,7 @@
 
 #include "RecoVertex/V0Producer/interface/V0Fitter.h"
 
-class V0Producer : public edm::EDProducer {
+class V0Producer : public edm::stream::EDProducer<> {
 public:
   explicit V0Producer(const edm::ParameterSet&);
   ~V0Producer();

--- a/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTrigPrimProducer.h
+++ b/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTrigPrimProducer.h
@@ -19,7 +19,7 @@
 
 #include <memory>
  
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
  
@@ -29,7 +29,7 @@
   
 class EcalTrigPrimFunctionalAlgo;
  
-class EcalTrigPrimProducer : public edm::EDProducer
+class EcalTrigPrimProducer : public edm::stream::EDProducer<>
 {
  public:
   


### PR DESCRIPTION
Based on results from the static analyzer, we determined which modules would be safe to convert to stream type and therefore work properly when used in the threaded framework.

Created a script which automatically converts a list of modules to stream modules.
