### PR TITLE
Btv hit pattern fix for SLHC

### DIFF
--- a/DQMOffline/RecoB/interface/TrackIPTagPlotter.h
+++ b/DQMOffline/RecoB/interface/TrackIPTagPlotter.h
@@ -38,6 +38,7 @@ class TrackIPTagPlotter : public BaseTagInfoPlotter {
   double endEffPur_ ; 
   unsigned int mcPlots_;
   bool willFinalize_;
+  uint32_t m_maxPixelBarrelLayer, m_maxPixelEndcapLayer;
   bool makeQualityPlots_;
 
   TrackIPHistograms<double> * tkcntHistosSig3D[5];

--- a/DQMOffline/RecoB/python/bTagTrackIPAnalysis_cff.py
+++ b/DQMOffline/RecoB/python/bTagTrackIPAnalysis_cff.py
@@ -1,8 +1,10 @@
 import FWCore.ParameterSet.Config as cms
+from RecoBTag.Configuration.SLHCPixelBarrelLayerDef_cfi import *
 
 # TrackIP tag info configuration
 bTagTrackIPAnalysisBlock = cms.PSet(
     parameters = cms.PSet(
+        PixelBarrelLayerDefBlock,
         QualityPlots = cms.bool(False),
         endEffPur = cms.double(1.005),
         nBinEffPur = cms.int32(200),

--- a/DQMOffline/RecoB/src/TrackIPTagPlotter.cc
+++ b/DQMOffline/RecoB/src/TrackIPTagPlotter.cc
@@ -12,6 +12,8 @@ TrackIPTagPlotter::TrackIPTagPlotter(const std::string & tagName,
   startEffPur_(pSet.getParameter<double>("startEffPur")),
   endEffPur_(pSet.getParameter<double>("endEffPur")),
   mcPlots_(mc), willFinalize_(wf),
+  m_maxPixelBarrelLayer(pSet.getParameter<uint32_t>("maxPixelBarrelLayer")),
+  m_maxPixelEndcapLayer(pSet.getParameter<uint32_t>("maxPixelEndcapLayer")),
   makeQualityPlots_(pSet.getParameter<bool>("QualityPlots")),
   lowerIPSBound(pSet.getParameter<double>("LowerIPSBound")),
   upperIPSBound(pSet.getParameter<double>("UpperIPSBound")),
@@ -644,7 +646,7 @@ void TrackIPTagPlotter::analyzeTag (const reco::BaseTagInfo * baseTagInfo,
     tkcntHistosTkNChiSqr2D[4]->fill(jetFlavour, trackQual, track->normalizedChi2(), true,w);
     tkcntHistosTkPt2D[4]->fill(jetFlavour, trackQual, track->pt(), true,w);
     tkcntHistosTkNHits2D[4]->fill(jetFlavour, trackQual, track->found(), true,w);
-    tkcntHistosTkNPixelHits2D[4]->fill(jetFlavour, trackQual, track->hitPattern().numberOfValidPixelHits(), true,w);
+    tkcntHistosTkNPixelHits2D[4]->fill(jetFlavour, trackQual, track->hitPattern().numberOfValidPixelHits(m_maxPixelBarrelLayer, m_maxPixelEndcapLayer), true,w);
     if(n >= 4) continue;
     tkcntHistosSig2D[n]->fill(jetFlavour, trackQual, ip[selectedIndices[n]].ip2d.significance(), true,w);
     tkcntHistosVal2D[n]->fill(jetFlavour, trackQual, ip[selectedIndices[n]].ip2d.value(), true,w);
@@ -655,7 +657,7 @@ void TrackIPTagPlotter::analyzeTag (const reco::BaseTagInfo * baseTagInfo,
     tkcntHistosTkNChiSqr2D[n]->fill(jetFlavour, trackQual, track->normalizedChi2(), true,w);
     tkcntHistosTkPt2D[n]->fill(jetFlavour, trackQual, track->pt(), true,w);
     tkcntHistosTkNHits2D[n]->fill(jetFlavour, trackQual, track->found(), true,w);
-    tkcntHistosTkNPixelHits2D[n]->fill(jetFlavour, trackQual, track->hitPattern().numberOfValidPixelHits(), true,w);
+    tkcntHistosTkNPixelHits2D[n]->fill(jetFlavour, trackQual, track->hitPattern().numberOfValidPixelHits(m_maxPixelBarrelLayer, m_maxPixelEndcapLayer), true,w);
   }
   sortedIndices = tagInfo->sortedIndexes(reco::TrackIPTagInfo::Prob2D);
   selectedIndices.clear();
@@ -715,7 +717,7 @@ void TrackIPTagPlotter::analyzeTag (const reco::BaseTagInfo * baseTagInfo,
     tkcntHistosTkNChiSqr3D[4]->fill(jetFlavour, trackQual, track->normalizedChi2(), true,w);
     tkcntHistosTkPt3D[4]->fill(jetFlavour, trackQual, track->pt(), true,w);
     tkcntHistosTkNHits3D[4]->fill(jetFlavour, trackQual, track->found(), true,w);
-    tkcntHistosTkNPixelHits3D[4]->fill(jetFlavour, trackQual, track->hitPattern().numberOfValidPixelHits(), true,w);
+    tkcntHistosTkNPixelHits3D[4]->fill(jetFlavour, trackQual, track->hitPattern().numberOfValidPixelHits(m_maxPixelBarrelLayer, m_maxPixelEndcapLayer), true,w);
     //ghostTrack infos  
     ghostTrackDistanceValuHisto->fill(jetFlavour, trackQual, ip[selectedIndices[n]].distanceToGhostTrack.value(), true,w);
     ghostTrackDistanceSignHisto->fill(jetFlavour, trackQual, ip[selectedIndices[n]].distanceToGhostTrack.significance(), true,w);
@@ -731,7 +733,7 @@ void TrackIPTagPlotter::analyzeTag (const reco::BaseTagInfo * baseTagInfo,
     tkcntHistosTkNChiSqr3D[n]->fill(jetFlavour, trackQual, track->normalizedChi2(), true,w);
     tkcntHistosTkPt3D[n]->fill(jetFlavour, trackQual, track->pt(), true,w);
     tkcntHistosTkNHits3D[n]->fill(jetFlavour, trackQual, track->found(), true,w);
-    tkcntHistosTkNPixelHits3D[n]->fill(jetFlavour, trackQual, track->hitPattern().numberOfValidPixelHits(), true,w);
+    tkcntHistosTkNPixelHits3D[n]->fill(jetFlavour, trackQual, track->hitPattern().numberOfValidPixelHits(m_maxPixelBarrelLayer, m_maxPixelEndcapLayer), true,w);
   }
   sortedIndices = tagInfo->sortedIndexes(reco::TrackIPTagInfo::Prob3D);
   selectedIndices.clear();

--- a/RecoBTag/Configuration/python/SLHCPixelBarrelLayerDef_cfi.py
+++ b/RecoBTag/Configuration/python/SLHCPixelBarrelLayerDef_cfi.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+
+PixelBarrelLayerDefBlock = cms.PSet(
+  maxPixelBarrelLayer = cms.uint32(4),
+  maxPixelEndcapLayer = cms.uint32(3)
+)

--- a/RecoBTag/ImpactParameter/plugins/TrackIPProducer.cc
+++ b/RecoBTag/ImpactParameter/plugins/TrackIPProducer.cc
@@ -73,6 +73,8 @@ TrackIPProducer::TrackIPProducer(const edm::ParameterSet& iConfig) :
   m_computeGhostTrack       = m_config.getParameter<bool>("computeGhostTrack");
   m_ghostTrackPriorDeltaR   = m_config.getParameter<double>("ghostTrackPriorDeltaR");
   m_cutPixelHits            = m_config.getParameter<int>("minimumNumberOfPixelHits");
+  m_maxPixelBarrelLayer     = m_config.getParameter<uint32_t>("maxPixelBarrelLayer");
+  m_maxPixelEndcapLayer     = m_config.getParameter<uint32_t>("maxPixelEndcapLayer");
   m_cutTotalHits            = m_config.getParameter<int>("minimumNumberOfHits");
   m_cutMaxTIP               = m_config.getParameter<double>("maximumTransverseImpactParameter");
   m_cutMinPt                = m_config.getParameter<double>("minimumTransverseMomentum");
@@ -170,9 +172,11 @@ TrackIPProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
                " chi2 " <<  track.normalizedChi2()<<
                " #pixel " <<    track.hitPattern().numberOfValidPixelHits()<< endl;
 */
+
+
        if (track.pt() > m_cutMinPt &&
            track.hitPattern().numberOfValidHits() >= m_cutTotalHits &&         // min num tracker hits
-           track.hitPattern().numberOfValidPixelHits() >= m_cutPixelHits &&
+           track.hitPattern().numberOfValidPixelHits(m_maxPixelBarrelLayer, m_maxPixelEndcapLayer) >= m_cutPixelHits &&
            track.normalizedChi2() < m_cutMaxChiSquared &&
            std::abs(track.dxy(pv->position())) < m_cutMaxTIP &&
            std::abs(track.dz(pv->position())) < m_cutMaxLIP) {
@@ -325,7 +329,7 @@ void TrackIPProducer::checkEventSetup(const EventSetup & iSetup)
      const TrackProbabilityCalibration *  ca2D= calib2DHandle.product();
      const TrackProbabilityCalibration *  ca3D= calib3DHandle.product();
 
-     m_probabilityEstimator.reset(new HistogramProbabilityEstimator(ca3D,ca2D));
+     m_probabilityEstimator.reset(new HistogramProbabilityEstimator(ca3D,ca2D, m_maxPixelBarrelLayer, m_maxPixelEndcapLayer));
 
    }
    m_calibrationCacheId3D=cacheId3D;

--- a/RecoBTag/ImpactParameter/plugins/TrackIPProducer.h
+++ b/RecoBTag/ImpactParameter/plugins/TrackIPProducer.h
@@ -33,6 +33,8 @@ class TrackIPProducer : public edm::EDProducer {
     bool m_useDB;
 
     int  m_cutPixelHits;
+    uint32_t  m_maxPixelBarrelLayer;
+    uint32_t  m_maxPixelEndcapLayer;
     int  m_cutTotalHits;
     double  m_cutMaxTIP;
     double  m_cutMinPt;

--- a/RecoBTag/ImpactParameter/python/impactParameter_cfi.py
+++ b/RecoBTag/ImpactParameter/python/impactParameter_cfi.py
@@ -1,6 +1,8 @@
 import FWCore.ParameterSet.Config as cms
+from RecoBTag.Configuration.SLHCPixelBarrelLayerDef_cfi import *
 
 impactParameterTagInfos = cms.EDProducer("TrackIPProducer",
+    PixelBarrelLayerDefBlock,
     jetTracks = cms.InputTag("ak5JetTracksAssociatorAtVertexPF"),
     primaryVertex = cms.InputTag("offlinePrimaryVertices"),
     computeProbabilities = cms.bool(True),

--- a/RecoBTag/SecondaryVertex/interface/TrackSelector.h
+++ b/RecoBTag/SecondaryVertex/interface/TrackSelector.h
@@ -24,6 +24,8 @@ class TrackSelector {
 	bool				selectQuality;
 	reco::TrackBase::TrackQuality	quality;
 	unsigned int			minPixelHits;
+        unsigned int                    maxBpixLayer;
+        unsigned int                    maxEpixLayer;
 	unsigned int			minTotalHits;
 	double				minPt;
 	double				maxNormChi2;

--- a/RecoBTag/SecondaryVertex/python/trackPseudoSelection_cfi.py
+++ b/RecoBTag/SecondaryVertex/python/trackPseudoSelection_cfi.py
@@ -1,10 +1,12 @@
 import FWCore.ParameterSet.Config as cms
 
 from RecoBTag.ImpactParameter.variableJTA_cfi import *
+from RecoBTag.Configuration.SLHCPixelBarrelLayerDef_cfi import *
 
 trackPseudoSelectionBlock = cms.PSet(
     trackPseudoSelection = cms.PSet(
                 variableJTAPars,
+                PixelBarrelLayerDefBlock,
                 totalHitsMin = cms.uint32(0),
                 jetDeltaRMax = cms.double(0.3),
                 qualityClass = cms.string('highPurity'),

--- a/RecoBTag/SecondaryVertex/python/trackSelection_cfi.py
+++ b/RecoBTag/SecondaryVertex/python/trackSelection_cfi.py
@@ -1,10 +1,12 @@
 import FWCore.ParameterSet.Config as cms
 
 from RecoBTag.ImpactParameter.variableJTA_cfi import *
+from RecoBTag.Configuration.SLHCPixelBarrelLayerDef_cfi import *
 
 trackSelectionBlock = cms.PSet(
 	trackSelection = cms.PSet(
                 variableJTAPars,
+                PixelBarrelLayerDefBlock,
 		totalHitsMin = cms.uint32(0),
 		jetDeltaRMax = cms.double(0.3),
 		qualityClass = cms.string('highPurity'),

--- a/RecoBTag/SecondaryVertex/python/vertexTrackSelection_cfi.py
+++ b/RecoBTag/SecondaryVertex/python/vertexTrackSelection_cfi.py
@@ -1,10 +1,12 @@
 import FWCore.ParameterSet.Config as cms
 
 from RecoBTag.ImpactParameter.variableJTA_cfi import *
+from RecoBTag.Configuration.SLHCPixelBarrelLayerDef_cfi import *
 
 vertexTrackSelectionBlock = cms.PSet(
 	trackSelection = cms.PSet(
                 variableJTAPars,
+                PixelBarrelLayerDefBlock,
 		totalHitsMin = cms.uint32(8),
 		jetDeltaRMax = cms.double(0.3),
 		qualityClass = cms.string('highPurity'),

--- a/RecoBTag/SecondaryVertex/src/TrackSelector.cc
+++ b/RecoBTag/SecondaryVertex/src/TrackSelector.cc
@@ -15,6 +15,8 @@ using namespace ROOT::Math;
 
 TrackSelector::TrackSelector(const edm::ParameterSet &params) :
 	minPixelHits(params.getParameter<unsigned int>("pixelHitsMin")),
+        maxBpixLayer(params.getParameter<unsigned int>("maxPixelBarrelLayer")),
+        maxEpixLayer(params.getParameter<unsigned int>("maxPixelEndcapLayer")),
 	minTotalHits(params.getParameter<unsigned int>("totalHitsMin")),
 	minPt(params.getParameter<double>("ptMin")),
 	maxNormChi2(params.getParameter<double>("normChi2Max")),
@@ -73,7 +75,7 @@ TrackSelector::operator () (const Track &track,
 
   return (!selectQuality || track.quality(quality)) &&
     (minPixelHits <= 0 ||
-     track.hitPattern().numberOfValidPixelHits() >= (int)minPixelHits) &&
+     track.hitPattern().numberOfValidPixelHits(maxBpixLayer, maxEpixLayer) >= (int)minPixelHits) &&
     (minTotalHits <= 0 ||
      track.hitPattern().numberOfValidHits() >= (int)minTotalHits) &&
     track.pt() >= minPt &&

--- a/RecoBTag/TrackProbability/interface/HistogramProbabilityEstimator.h
+++ b/RecoBTag/TrackProbability/interface/HistogramProbabilityEstimator.h
@@ -21,8 +21,8 @@ class HistogramProbabilityEstimator {
 
 
   HistogramProbabilityEstimator( const  TrackProbabilityCalibration  * calib3D,
-                                const TrackProbabilityCalibration * calib2D) 
-   :   m_calibration3D(calib3D),m_calibration2D(calib2D)
+				 const TrackProbabilityCalibration * calib2D, uint32_t maxBpix, uint32_t maxEpix) 
+    :   m_calibration3D(calib3D),m_calibration2D(calib2D), m_maxBpix(maxBpix), m_maxEpix(maxEpix)
     {}
 
 /*   HistogramProbabilityEstimator( AlgorithmCalibration<TrackClassFilterCategory,CalibratedHistogramXML>  * calib3D,
@@ -44,7 +44,7 @@ class HistogramProbabilityEstimator {
  private:
   const TrackProbabilityCalibration * m_calibration3D;
  const TrackProbabilityCalibration * m_calibration2D;
-   
+ uint32_t m_maxBpix, m_maxEpix;
 };
 
 #endif

--- a/RecoBTag/TrackProbability/interface/TrackClassFilter.h
+++ b/RecoBTag/TrackProbability/interface/TrackClassFilter.h
@@ -13,7 +13,7 @@ class TrackClassFilter
 {
  public:
 
- TrackClassFilter() {}
+  TrackClassFilter(uint32_t maxBpix, uint32_t maxEpix): m_maxBpix(maxBpix), m_maxEpix(maxEpix) {}
 
  class Input
  {
@@ -33,7 +33,7 @@ class TrackClassFilter
  bool operator()(const first_argument_type & , const second_argument_type &) const;
 
 //  void dump() const;
-
+ uint32_t m_maxBpix, m_maxEpix;
 };
 
 

--- a/RecoBTag/TrackProbability/src/HistogramProbabilityEstimator.cc
+++ b/RecoBTag/TrackProbability/src/HistogramProbabilityEstimator.cc
@@ -26,7 +26,7 @@ pair<bool,double> HistogramProbabilityEstimator::probability(bool quality, int i
       else if(ipType==1) {it=m_calibration2D->data.begin(); it_end=m_calibration2D->data.end(); }
       else return pair<bool,double>(probabilityHistogram ,trackProbability);
 
-      found = std::find_if(it,it_end,bind1st(TrackClassFilter(),input));
+      found = std::find_if(it,it_end,bind1st(TrackClassFilter(m_maxBpix, m_maxEpix),input));
       if(found!=it_end) probabilityHistogram = &found->histogram;
      if(!probabilityHistogram)
        {

--- a/RecoBTag/TrackProbability/src/TrackClassFilter.cc
+++ b/RecoBTag/TrackProbability/src/TrackClassFilter.cc
@@ -16,7 +16,7 @@ const TrackProbabilityCategoryData & d = category.category;
   double p=track.p();
   double eta=track.eta();
   double nhit=track.numberOfValidHits();
-  double npix=track.hitPattern().numberOfValidPixelHits();
+  double npix=track.hitPattern().numberOfValidPixelHits(m_maxBpix, m_maxEpix);
   bool   firstPixel=track.hitPattern().hasValidHitInFirstPixelBarrel();
   double chi=track.normalizedChi2();
   


### PR DESCRIPTION
This fix bypasses the wrong counting of pixel hits in the phase II geometry. It is based on the new version of HitPattern in SLHC10. Please include it into SLHC12 !
