### PR TITLE
Automatically switch DQMStore to threaded mode

### DIFF
--- a/DQMServices/Core/interface/Standalone.h
+++ b/DQMServices/Core/interface/Standalone.h
@@ -53,10 +53,21 @@ namespace edm
     T &operator*(void) { return * operator->(); }
   };
 
+  struct SystemBounds {
+    unsigned int maxNumberOfStreams() const { return 0; }
+  };
+
+  struct PreallocationSignal {
+    template <typename T>
+    void connect( T&& ) {};
+  };
+
   struct ActivityRegistry
   {
     template <typename T>
     void watchPostSourceRun(void*, T) {}
+
+    PreallocationSignal preallocateSignal_;
   };
   
   

--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -1,3 +1,4 @@
+#include "FWCore/ServiceRegistry/interface/SystemBounds.h"
 #include "DQMServices/Core/interface/Standalone.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/QReport.h"
@@ -398,6 +399,12 @@ DQMStore::DQMStore(const edm::ParameterSet &pset, edm::ActivityRegistry& ar)
   if(pset.getUntrackedParameter<bool>("forceResetOnBeginRun",false)) {
     ar.watchPostSourceRun(this,&DQMStore::forceReset);
   }
+  ar.preallocateSignal_.connect([this](edm::service::SystemBounds const& iBounds) {
+      if(iBounds.maxNumberOfStreams() > 1 ) {
+	enableMultiThread_ = true;
+      }
+    });
+
 }
 
 DQMStore::DQMStore(const edm::ParameterSet &pset)


### PR DESCRIPTION
Have the DQMStore automatically switch to threaded mode when the
configuration for the job has more than one stream.
