### PR TITLE
Made ParametersDefinerForTP thread-safe

### DIFF
--- a/SimTracker/TrackAssociation/interface/CosmicParametersDefinerForTP.h
+++ b/SimTracker/TrackAssociation/interface/CosmicParametersDefinerForTP.h
@@ -20,21 +20,22 @@ class CosmicParametersDefinerForTP : public ParametersDefinerForTP {
   virtual TrackingParticle::Point vertex(const edm::Event& iEvent, const edm::EventSetup& iSetup, const TrackingParticleRef& tpr) const override;
 
   virtual TrackingParticle::Vector momentum(const edm::Event& iEvent, const edm::EventSetup& iSetup, 
-	const Charge ch, const Point & vertex, const LorentzVector& lv) const {
+	const Charge ch, const Point & vertex, const LorentzVector& lv) const override {
     return TrackingParticle::Vector();
   }
 
   virtual TrackingParticle::Point vertex(const edm::Event& iEvent, const edm::EventSetup& iSetup,
-	const Charge ch, const Point & vertex, const LorentzVector& lv) const {
+	const Charge ch, const Point & vertex, const LorentzVector& lv) const override {
     return TrackingParticle::Point();
   }
 
-  void initEvent(edm::Handle<SimHitTPAssociationProducer::SimHitTPAssociationList> simHitsTPAssocToSet) const {
+  void initEvent(edm::Handle<SimHitTPAssociationProducer::SimHitTPAssociationList> simHitsTPAssocToSet)  override {
     simHitsTPAssoc = simHitsTPAssocToSet;
   }
 
+  std::unique_ptr<ParametersDefinerForTP> clone() const override { return std::unique_ptr<CosmicParametersDefinerForTP>( new CosmicParametersDefinerForTP(*this)); }
  private:
-  mutable edm::Handle<SimHitTPAssociationProducer::SimHitTPAssociationList> simHitsTPAssoc;
+  edm::Handle<SimHitTPAssociationProducer::SimHitTPAssociationList> simHitsTPAssoc;
 };
 
 

--- a/SimTracker/TrackAssociation/interface/ParametersDefinerForTP.h
+++ b/SimTracker/TrackAssociation/interface/ParametersDefinerForTP.h
@@ -7,6 +7,8 @@
  * \author Boris Mangano (UCSD)  5/7/2009
  */
 
+#include <memory>
+
 #include <SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h>
 #include "SimGeneral/TrackingAnalysis/interface/SimHitTPAssociationProducer.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
@@ -47,7 +49,9 @@ class ParametersDefinerForTP {
     return vertex(iEvent, iSetup, tp.charge(),tp.vertex(),tp.p4());
   }
 
-  virtual void initEvent(edm::Handle<SimHitTPAssociationProducer::SimHitTPAssociationList> simHitsTPAssocToSet) const { }
+  virtual void initEvent(edm::Handle<SimHitTPAssociationProducer::SimHitTPAssociationList> simHitsTPAssocToSet) { }
+
+  virtual std::unique_ptr<ParametersDefinerForTP> clone() const { return std::unique_ptr<ParametersDefinerForTP>(new ParametersDefinerForTP(*this)); }
 
   edm::InputTag beamSpotInputTag_;
 

--- a/Validation/RecoTrack/plugins/MultiTrackValidator.cc
+++ b/Validation/RecoTrack/plugins/MultiTrackValidator.cc
@@ -152,8 +152,10 @@ void MultiTrackValidator::analyze(const edm::Event& event, const edm::EventSetup
   edm::LogInfo("TrackValidator") << "\n====================================================" << "\n"
 				 << "Analyzing new event" << "\n"
 				 << "====================================================\n" << "\n";
-  edm::ESHandle<ParametersDefinerForTP> parametersDefinerTP;
-  setup.get<TrackAssociatorRecord>().get(parametersDefiner,parametersDefinerTP);
+  edm::ESHandle<ParametersDefinerForTP> parametersDefinerTPHandle;
+  setup.get<TrackAssociatorRecord>().get(parametersDefiner,parametersDefinerTPHandle);
+  //Since we modify the object, we must clone it
+  auto parametersDefinerTP = parametersDefinerTPHandle->clone();
 
   edm::Handle<TrackingParticleCollection>  TPCollectionHeff ;
   event.getByToken(label_tp_effic,TPCollectionHeff);


### PR DESCRIPTION
The virtual initEvent method of ParametersDefinerForTP was const and
allowed inheriting classes to modify the state of the object. This function
has been changed to non-const and a const clone method was added. Now any
code which called initEvent must first clone the object and use their own
copy.
