### PR TITLE
Made CaloCellGeometry interface const thread-safe

### DIFF
--- a/Geometry/CaloGeometry/interface/CaloCellGeometry.h
+++ b/Geometry/CaloGeometry/interface/CaloCellGeometry.h
@@ -8,6 +8,7 @@
 #include <CLHEP/Geometry/Transform3D.h>
 #include <vector>
 #include <string>
+#include <cassert>
 
 #include "FWCore/Utilities/interface/GCC11Compatibility.h"
 
@@ -70,7 +71,7 @@ public:
   virtual ~CaloCellGeometry() ;
       
   /// Returns the corner points of this cell's volume.
-  virtual const CornersVec& getCorners() const = 0 ;
+  const CornersVec& getCorners() const { assert(not m_corners.uninitialized()); return m_corners; }
 
   /// Returns the position of reference for this cell 
   const GlobalPoint& getPosition() const {return m_refPoint;}
@@ -109,27 +110,27 @@ public:
 protected:
 
   CaloCellGeometry( CornersVec::const_reference gp ,
-		    const CornersMgr*           mgr,
+		    CornersMgr*                 mgr,
 		    const CCGFloat*             par ) ;
 
   CaloCellGeometry( const CornersVec& cv,
 		    const CCGFloat*   par ) ;
 
-  CornersVec& setCorners() const ;
-
   CaloCellGeometry( void );
 
   // MUST be called by children constructors
-  void initSpan() const {
+  void initSpan() {
+     initCorners(m_corners);
      m_dEta = std::abs(getCorners()[0].eta()-
                       getCorners()[2].eta());
      m_dPhi = std::abs(getCorners()[0].phi() -
                       getCorners()[2].phi());
      initBack();
-
   }
 
- void initBack() const {
+  virtual void initCorners(CornersVec&) = 0;
+private:
+ void initBack() {
     // from CaloTower code
     CornersVec const & cv = getCorners();
     m_backPoint = GlobalPoint(0.25 * (cv[4].x() + cv[5].x() + cv[6].x() + cv[7].x()),
@@ -137,14 +138,14 @@ protected:
                               0.25 * (cv[4].z() + cv[5].z() + cv[6].z() + cv[7].z()));   
   }
 
-private:
+
   GlobalPoint         m_refPoint ;
-  mutable GlobalPoint         m_backPoint ;
-  mutable CornersVec  m_corners  ;
+  GlobalPoint         m_backPoint ;
+  CornersVec  m_corners  ;
   const CCGFloat*     m_parms    ;
   float m_eta, m_phi;
-  mutable float m_dEta;
-  mutable float m_dPhi;
+  float m_dEta;
+  float m_dPhi;
 
 };
 

--- a/Geometry/CaloGeometry/interface/EZArrayFL.h
+++ b/Geometry/CaloGeometry/interface/EZArrayFL.h
@@ -33,10 +33,10 @@ class EZArrayFL
       EZArrayFL< T >() : m_begin ( 0 ) ,
 			 m_mgr   (   ) {}
 
-      EZArrayFL< T >( const MgrType* mgr  ) : m_begin ( 0 ) ,
+      EZArrayFL< T >( MgrType* mgr  ) : m_begin ( 0 ) ,
 					      m_mgr   ( mgr )   {}
 
-      EZArrayFL< T >( const MgrType* mgr   , 
+      EZArrayFL< T >( MgrType* mgr   , 
 		      const_iterator start ,
 		      const_iterator finis       ) :
 	 m_begin ( 0==finis-start ? (iterator)0 : mgr->assign() ) ,
@@ -52,9 +52,9 @@ class EZArrayFL
 
       virtual ~EZArrayFL< T >() {}
 
-      void resize() const { assign() ; }
+      void resize() { assign() ; }
 
-      void assign( const T& t = T() ) const 
+      void assign( const T& t = T() ) 
       {
 	 assert( (iterator)0 == m_begin ) ;
 	 m_begin = m_mgr->assign( t ) ;
@@ -88,8 +88,8 @@ class EZArrayFL
 
       //EZArrayFL( const EZArrayFL& ) ; //stop
       //EZArrayFL& operator=( const EZArrayFL& ) ; //stop
-      mutable iterator m_begin   ;
-      const MgrType*   m_mgr   ;
+      iterator m_begin   ;
+      MgrType*   m_mgr   ;
 };
 
 #endif

--- a/Geometry/CaloGeometry/interface/EZMgrFL.h
+++ b/Geometry/CaloGeometry/interface/EZMgrFL.h
@@ -29,10 +29,10 @@ class EZMgrFL
 
       virtual ~EZMgrFL< T >() {}
 
-      iterator reserve() const { return assign() ; }
-      iterator resize()  const { return assign() ; }
+      iterator reserve() { return assign() ; }
+      iterator resize()  { return assign() ; }
 
-      iterator assign( const T& t = T() ) const
+      iterator assign( const T& t = T() )
       {
 	 assert( ( m_vec.size() + m_subSize ) <= m_vecSize ) ;
 	 if( 0 == m_vec.capacity() )
@@ -60,7 +60,7 @@ class EZMgrFL
 
       const size_type m_vecSize ;
       const size_type m_subSize ;
-      mutable VecType m_vec     ;
+      VecType m_vec     ;
 };
 
 #endif

--- a/Geometry/CaloGeometry/interface/IdealObliquePrism.h
+++ b/Geometry/CaloGeometry/interface/IdealObliquePrism.h
@@ -40,12 +40,10 @@ public:
   IdealObliquePrism& operator=( const IdealObliquePrism& idop ) ;
 	 
   IdealObliquePrism( const GlobalPoint& faceCenter, 
-		     const CornersMgr*  mgr       ,
+		     CornersMgr*        mgr       ,
 		     const CCGFloat*    parm       ) ;
 
   virtual ~IdealObliquePrism() ;
-
-  virtual const CornersVec& getCorners() const ;
 
   CCGFloat dEta() const ;
   CCGFloat dPhi() const ;
@@ -62,6 +60,7 @@ public:
 			     Pt3D&           ref  ) const ;
 
 private:
+  virtual void initCorners(CornersVec&)  override;
 
   static GlobalPoint etaPhiPerp( float eta, float phi, float perp ) ;
   static GlobalPoint etaPhiZ(float eta, float phi, float z) ;

--- a/Geometry/CaloGeometry/interface/IdealZPrism.h
+++ b/Geometry/CaloGeometry/interface/IdealZPrism.h
@@ -38,12 +38,10 @@ class IdealZPrism : public CaloCellGeometry
       IdealZPrism& operator=( const IdealZPrism& idzp ) ;
       
       IdealZPrism( const GlobalPoint& faceCenter , 
-		   const CornersMgr*  mgr        ,
+		   CornersMgr*        mgr        ,
 		   const CCGFloat*    parm         ) ;
       
       virtual ~IdealZPrism() ;
-      
-      virtual const CornersVec& getCorners() const ;
       
       CCGFloat dEta() const ;
       CCGFloat dPhi() const ;
@@ -61,6 +59,8 @@ class IdealZPrism : public CaloCellGeometry
       
    private:
 
+      virtual void initCorners(CornersVec& ) override;
+      
       static GlobalPoint etaPhiR( float eta ,
 				  float phi ,
 				  float rad   ) ;

--- a/Geometry/CaloGeometry/interface/PreshowerStrip.h
+++ b/Geometry/CaloGeometry/interface/PreshowerStrip.h
@@ -37,13 +37,11 @@ public:
   PreshowerStrip& operator=( const PreshowerStrip& tr ) ;
 
   PreshowerStrip( const GlobalPoint& po   ,
-		  const CornersMgr*  mgr  ,
+		        CornersMgr*  mgr  ,
 		  const CCGFloat*    parm  ) :
     CaloCellGeometry ( po , mgr, parm ) {initSpan();}
 
   virtual ~PreshowerStrip();
-
-  virtual const CornersVec& getCorners() const ;
 
   CCGFloat dx() const { return param()[0] ; }
   CCGFloat dy() const { return param()[1] ; }
@@ -61,6 +59,8 @@ public:
 
   virtual Tr3D getTransform( Pt3DVec* /*lptr*/ ) const
     { return Tr3D() ; }
+ private:
+  virtual void initCorners(CaloCellGeometry::CornersVec&) override;
 };
 
 std::ostream& operator<<( std::ostream& s , const PreshowerStrip& cell) ;

--- a/Geometry/CaloGeometry/interface/TruncatedPyramid.h
+++ b/Geometry/CaloGeometry/interface/TruncatedPyramid.h
@@ -30,7 +30,7 @@ public:
   
   TruncatedPyramid& operator=( const TruncatedPyramid& tr ) ;
   
-  TruncatedPyramid( const CornersMgr*  cMgr ,
+  TruncatedPyramid(       CornersMgr*  cMgr ,
 		    const GlobalPoint& fCtr ,
 		    const GlobalPoint& bCtr ,
 		    const GlobalPoint& cor1 ,
@@ -42,8 +42,6 @@ public:
   virtual ~TruncatedPyramid() ;
   
   const GlobalPoint getPosition( CCGFloat depth ) const ;
-  
-  virtual const CornersVec& getCorners() const ;
   
   // Return thetaAxis polar angle of axis of the crystal
   CCGFloat getThetaAxis() const ;
@@ -77,6 +75,8 @@ public:
   virtual void getTransform( Tr3D& tr, Pt3DVec* lptr ) const ;
   
 private:
+  virtual void initCorners(CornersVec&) override;
+  
   GlobalVector makeAxis( void );
   
   const GlobalPoint backCtr( void ) const;    

--- a/Geometry/CaloGeometry/src/CaloCellGeometry.cc
+++ b/Geometry/CaloGeometry/src/CaloCellGeometry.cc
@@ -29,7 +29,7 @@ CaloCellGeometry::~CaloCellGeometry()
 
 
 CaloCellGeometry::CaloCellGeometry( CornersVec::const_reference gp ,
-				    const CornersMgr*           mgr,
+				    CornersMgr*                 mgr,
 				    const CCGFloat*             par ) :
    m_refPoint ( gp  ),
    m_corners  ( mgr ),
@@ -46,18 +46,6 @@ CaloCellGeometry::CaloCellGeometry( const CornersVec& cv,
    m_parms    ( par ),
    m_eta( m_refPoint.eta()), m_phi(m_refPoint.phi())
 {}
-
-CaloCellGeometry::CornersVec& 
-CaloCellGeometry::setCorners() const 
-{
-   return m_corners ; 
-}
-
-const CaloCellGeometry::CornersVec&
-CaloCellGeometry::getCorners() const
-{
-   return m_corners ;
-}
 
 std::ostream& operator<<( std::ostream& s, const CaloCellGeometry& cell ) 
 {

--- a/Geometry/CaloGeometry/src/IdealObliquePrism.cc
+++ b/Geometry/CaloGeometry/src/IdealObliquePrism.cc
@@ -23,7 +23,7 @@ IdealObliquePrism::operator=( const IdealObliquePrism& idop )
 }
 
 IdealObliquePrism::IdealObliquePrism( const GlobalPoint& faceCenter, 
-				      const CornersMgr*  mgr       ,
+				      CornersMgr*        mgr       ,
 				      const CCGFloat*    parm       )
   : CaloCellGeometry ( faceCenter, mgr, parm )
 {initSpan();}
@@ -145,13 +145,11 @@ void IdealObliquePrism::localCorners( Pt3DVec&        lc  ,
    ref   = 0.25*( lc[0] + lc[1] + lc[2] + lc[3] ) ;
 }
 
-const CaloCellGeometry::CornersVec& 
-IdealObliquePrism::getCorners() const
+void IdealObliquePrism::initCorners(CaloCellGeometry::CornersVec& co)
 {
-   const CornersVec& co ( CaloCellGeometry::getCorners() ) ;
    if( co.uninitialized() )
    {
-      CornersVec& corners ( setCorners() ) ;
+      CornersVec& corners ( co ) ;
       if( dz()>0 ) 
       { 
 	 /* In this case, the faces are parallel to the zaxis.  
@@ -196,7 +194,6 @@ IdealObliquePrism::getCorners() const
 	 
       }
    }
-   return co ;
 }
 
 std::ostream& operator<<( std::ostream& s, const IdealObliquePrism& cell ) 

--- a/Geometry/CaloGeometry/src/IdealZPrism.cc
+++ b/Geometry/CaloGeometry/src/IdealZPrism.cc
@@ -23,7 +23,7 @@ IdealZPrism::operator=( const IdealZPrism& idzp )
 }
 
 IdealZPrism::IdealZPrism( const GlobalPoint& faceCenter , 
-			  const CornersMgr*  mgr        ,
+			  CornersMgr*  mgr              ,
 			  const CCGFloat*    parm         )
   : CaloCellGeometry ( faceCenter, mgr, parm )   
 {initSpan();}
@@ -141,13 +141,12 @@ IdealZPrism::localCorners( Pt3DVec&        lc  ,
    ref   = 0.25*( lc[0] + lc[1] + lc[2] + lc[3] ) ;
 }
 
-const CaloCellGeometry::CornersVec& 
-IdealZPrism::getCorners() const 
+void
+IdealZPrism::initCorners(CaloCellGeometry::CornersVec& co)
 {
-   const CornersVec& co ( CaloCellGeometry::getCorners() ) ;
    if( co.uninitialized() ) 
    {
-      CornersVec& corners ( setCorners() ) ;
+      CornersVec& corners ( co ) ;
       
       const GlobalPoint p      ( getPosition() ) ;
       const CCGFloat    z_near ( p.z() ) ;
@@ -164,7 +163,6 @@ IdealZPrism::getCorners() const
       corners[ 6 ] = GlobalPoint( corners[2].x(), corners[2].y(), z_far ); // (-,-,far)
       corners[ 7 ] = GlobalPoint( corners[3].x(), corners[3].y(), z_far ); // (-,+,far)	
    }
-   return co ;
 }
 
 std::ostream& operator<<( std::ostream& s, const IdealZPrism& cell ) 

--- a/Geometry/CaloGeometry/src/PreshowerStrip.cc
+++ b/Geometry/CaloGeometry/src/PreshowerStrip.cc
@@ -30,14 +30,11 @@ PreshowerStrip::operator=( const PreshowerStrip& tr )
   return *this ; 
 }
 
-const CaloCellGeometry::CornersVec& 
-PreshowerStrip::getCorners() const 
+void
+PreshowerStrip::initCorners(CaloCellGeometry::CornersVec& corners) 
 {
-  const CornersVec& co ( CaloCellGeometry::getCorners() ) ;
-  if( co.uninitialized() ) 
+  if( corners.uninitialized() ) 
   {
-    CornersVec& corners ( setCorners() ) ;
-
     const GlobalPoint& ctr ( getPosition() ) ;
     const CCGFloat x ( ctr.x() ) ;
     const CCGFloat y ( ctr.y() ) ;
@@ -72,7 +69,6 @@ PreshowerStrip::getCorners() const
       }
     }
   }
-  return co ;
 }
 
 std::ostream& operator<<( std::ostream& s, const PreshowerStrip& cell ) 

--- a/Geometry/CaloGeometry/src/TruncatedPyramid.cc
+++ b/Geometry/CaloGeometry/src/TruncatedPyramid.cc
@@ -41,7 +41,7 @@ TruncatedPyramid::operator=( const TruncatedPyramid& tr )
    return *this ; 
 }
 
-TruncatedPyramid::TruncatedPyramid( const CornersMgr*  cMgr ,
+TruncatedPyramid::TruncatedPyramid(       CornersMgr*  cMgr ,
 				    const GlobalPoint& fCtr ,
 				    const GlobalPoint& bCtr ,
 				    const GlobalPoint& cor1 ,
@@ -182,14 +182,11 @@ TruncatedPyramid::getTransform( Tr3D& tr, Pt3DVec* lptr ) const
    if( 0 != lptr ) (*lptr) = lc ;
 }
 
-const CaloCellGeometry::CornersVec& 
-TruncatedPyramid::getCorners() const 
+void
+TruncatedPyramid::initCorners(CaloCellGeometry::CornersVec& corners) 
 {
-   const CornersVec& co ( CaloCellGeometry::getCorners() ) ;
-   if( co.uninitialized() ) 
+   if( corners.uninitialized() ) 
    {
-      CornersVec& corners ( setCorners() ) ;
-
       Pt3DVec lc ;
 
       Tr3D tr ;
@@ -201,7 +198,6 @@ TruncatedPyramid::getCorners() const
 	 corners[i] = GlobalPoint( corn.x(), corn.y(), corn.z() ) ;
       }
    }
-   return co ;
 }
 
 namespace truncPyr

--- a/Geometry/ForwardGeometry/interface/IdealCastorTrapezoid.h
+++ b/Geometry/ForwardGeometry/interface/IdealCastorTrapezoid.h
@@ -45,13 +45,11 @@ class IdealCastorTrapezoid: public CaloCellGeometry
       IdealCastorTrapezoid& operator=( const IdealCastorTrapezoid& idct ) ;
       
       IdealCastorTrapezoid( const GlobalPoint& faceCenter,
-			    const CornersMgr*  mgr       ,
+			    CornersMgr*          mgr     ,
 			    const CCGFloat*      parm        ) ;
 	 
       virtual ~IdealCastorTrapezoid() ;
 	 
-      virtual const CornersVec& getCorners() const;
-
       CCGFloat dxl() const ; 
       CCGFloat dxh() const ; 
       CCGFloat dx()  const ; 
@@ -72,6 +70,9 @@ class IdealCastorTrapezoid: public CaloCellGeometry
 				const CCGFloat* pv  , 
 				Pt3D&           ref   ) ;
    private:
+      virtual void initCorners(CornersVec& ) override;
+
+
 };
 
 std::ostream& operator<<( std::ostream& s , const IdealCastorTrapezoid& cell ) ;

--- a/Geometry/ForwardGeometry/interface/IdealZDCTrapezoid.h
+++ b/Geometry/ForwardGeometry/interface/IdealZDCTrapezoid.h
@@ -35,12 +35,10 @@ class IdealZDCTrapezoid: public CaloCellGeometry
       IdealZDCTrapezoid& operator=( const IdealZDCTrapezoid& idzt ) ;
 
       IdealZDCTrapezoid( const GlobalPoint& faceCenter,
-			 const CornersMgr*  mgr       ,
+			       CornersMgr*  mgr       ,
 			 const CCGFloat*    parm        ) ;
 	 
       virtual ~IdealZDCTrapezoid() ;
-
-      virtual const CornersVec& getCorners() const ;
 
       CCGFloat an() const ;
       CCGFloat dx() const ;
@@ -58,6 +56,9 @@ class IdealZDCTrapezoid: public CaloCellGeometry
 				Pt3D&           ref  ) ;
     
    private:
+      void initCorners(CaloCellGeometry::CornersVec& );
+
+
 };
 
 std::ostream& operator<<( std::ostream& s , const IdealZDCTrapezoid& cell ) ;

--- a/Geometry/ForwardGeometry/src/IdealCastorTrapezoid.cc
+++ b/Geometry/ForwardGeometry/src/IdealCastorTrapezoid.cc
@@ -27,7 +27,7 @@ IdealCastorTrapezoid::operator=( const IdealCastorTrapezoid& idct )
 }
 
 IdealCastorTrapezoid::IdealCastorTrapezoid( const GlobalPoint& faceCenter,
-					    const CornersMgr*  mgr       ,
+					          CornersMgr*  mgr       ,
 					    const CCGFloat*    parm       )
   : CaloCellGeometry ( faceCenter, mgr, parm )  
 {initSpan();}
@@ -143,13 +143,11 @@ IdealCastorTrapezoid::localCorners( Pt3DVec&        lc  ,
    ref   = 0.25*( lc[0] + lc[1] + lc[2] + lc[3] ) ;
 }
 
-const CaloCellGeometry::CornersVec& 
-IdealCastorTrapezoid::getCorners() const 
+void
+IdealCastorTrapezoid::initCorners(CaloCellGeometry::CornersVec& corners)
 {
-   const CornersVec& co ( CaloCellGeometry::getCorners() ) ;
-   if( co.uninitialized() ) 
+   if( corners.uninitialized() ) 
    {
-      CaloCellGeometry::CornersVec& corners ( setCorners() ) ;
       const GlobalPoint& p ( getPosition() ) ;
       const CCGFloat zsign ( 0 < p.z() ? 1. : -1. ) ;
       const Pt3D  gf ( p.x(), p.y(), p.z() ) ;
@@ -179,7 +177,6 @@ IdealCastorTrapezoid::getCorners() const
 	 corners[i] = GlobalPoint( gl.x(), gl.y(), gl.z() ) ;
       }
    }
-   return co ;
 }
 
 std::ostream& operator<<( std::ostream& s, const IdealCastorTrapezoid& cell ) 

--- a/Geometry/ForwardGeometry/src/IdealZDCTrapezoid.cc
+++ b/Geometry/ForwardGeometry/src/IdealZDCTrapezoid.cc
@@ -24,7 +24,7 @@ IdealZDCTrapezoid::operator=( const IdealZDCTrapezoid& idzt )
 }
 
 IdealZDCTrapezoid::IdealZDCTrapezoid( const GlobalPoint& faceCenter,
-				      const CornersMgr*  mgr       ,
+				            CornersMgr*  mgr       ,
 				      const CCGFloat*    parm        ) :  
    CaloCellGeometry ( faceCenter, mgr, parm )  
 {initSpan();}
@@ -99,13 +99,11 @@ IdealZDCTrapezoid::localCorners( Pt3DVec&        lc  ,
    ref   = 0.25*( lc[0] + lc[1] + lc[2] + lc[3] ) ;
 }
 
-const CaloCellGeometry::CornersVec& 
-IdealZDCTrapezoid::getCorners() const 
+void
+IdealZDCTrapezoid::initCorners(CaloCellGeometry::CornersVec& corners)
 {
-   const CornersVec& co ( CaloCellGeometry::getCorners() ) ;
-   if( co.uninitialized() ) 
+   if( corners.uninitialized() ) 
    {
-      CaloCellGeometry::CornersVec& corners ( setCorners() ) ;
       const GlobalPoint& p ( getPosition() ) ;
       const CCGFloat zsign ( 0 < p.z() ? 1. : -1. ) ;
       const Pt3D  gf ( p.x(), p.y(), p.z() ) ;
@@ -131,7 +129,6 @@ IdealZDCTrapezoid::getCorners() const
 	 corners[i] = GlobalPoint( gl.x(), gl.y(), gl.z() ) ;
       }
    }
-   return co ;
 }
 
 std::ostream& operator<<( std::ostream& s, const IdealZDCTrapezoid& cell ) 


### PR DESCRIPTION
The previous implementation of CaloCellGeometry appears to have been
thread-safe, however the interface it used did not guarantee that.
This commit removes the mutables and makes any modifying member
methods non-const. No client code was disturbed by this change.
