### PR TITLE
Remove unnecessary call that causes unloading in ROOT6

### DIFF
--- a/IOPool/TFileAdaptor/src/TFileAdaptor.cc
+++ b/IOPool/TFileAdaptor/src/TFileAdaptor.cc
@@ -175,7 +175,6 @@
 
     // set our own root plugins
     TPluginManager* mgr = gROOT->GetPluginManager();
-    mgr->LoadHandlersFromPluginDirs();
 
     if (!native("file"))      addType(mgr, "^file:");
     if (!native("http"))      addType(mgr, "^http:");


### PR DESCRIPTION
The constructor of our TFileAdaptor service made an unnecessary call to the ROOT function TPluginManager::LoadHandlersFromPluginDirs(). In ROOT 5, this call was unnecessary, but caused no observed problems. In ROOT 6, this causes unnecessary unloading and reloading of ROOT plugins. CMS has no need for unloading, ever.
This pull request will remove the same call in the 7_1_X branch (ROOT5).  This maintains code commonality, and removes an unnecessary call that may adversely affect performance.
