### PR TITLE
Recover lost hits-on-track at |eta|>1

### DIFF
--- a/RecoTracker/MeasurementDet/plugins/TkPixelMeasurementDet.cc
+++ b/RecoTracker/MeasurementDet/plugins/TkPixelMeasurementDet.cc
@@ -15,7 +15,7 @@ namespace {
 }
 
 TkPixelMeasurementDet::TkPixelMeasurementDet( const GeomDet* gdet,
-					      const PixelClusterParameterEstimator* cpe) : 
+					      const PixelClusterParameterEstimator* cpe) :
     MeasurementDet (gdet),
     theCPE(cpe),
     skipClusters_(0),
@@ -35,7 +35,7 @@ bool TkPixelMeasurementDet::measurements( const TrajectoryStateOnSurface& stateO
     result.add(InvalidTransientRecHit::build(&geomDet(), TrackingRecHit::inactive), 0.F);
     return true;
   }
-  
+
   auto oldSize = result.size();
   MeasurementDet::RecHitContainer && allHits = recHits(stateOnThisDet);
   for (auto && hit : allHits) {
@@ -64,7 +64,7 @@ TkPixelMeasurementDet::buildRecHit( const SiPixelClusterRef & cluster,
   return TSiPixelRecHit::build( lv.first, lv.second, &fastGeomDet(), cluster, theCPE);
 }
 
-TkPixelMeasurementDet::RecHitContainer 
+TkPixelMeasurementDet::RecHitContainer
 TkPixelMeasurementDet::recHits( const TrajectoryStateOnSurface& ts ) const
 {
   RecHitContainer result;
@@ -76,7 +76,7 @@ TkPixelMeasurementDet::recHits( const TrajectoryStateOnSurface& ts ) const
   }
   result.reserve(detSet_.size());
   for ( const_iterator ci = detSet_.begin(); ci != detSet_.end(); ++ ci ) {
-    
+
     if (ci < begin){
       edm::LogError("IndexMisMatch")<<"TkPixelMeasurementDet cannot create hit because of index mismatch.";
       return result;
@@ -89,7 +89,7 @@ TkPixelMeasurementDet::recHits( const TrajectoryStateOnSurface& ts ) const
      if(0==skipClusters_ or skipClusters_->empty() or (not (*skipClusters_)[index]) ) {
        SiPixelClusterRef cluster = edmNew::makeRefTo( handle_, ci );
        result.push_back( buildRecHit( cluster, ts.localParameters() ) );
-     }else{   
+     }else{
        LogDebug("TkPixelMeasurementDet")<<"skipping this cluster from last iteration on "<<fastGeomDet().geographicalId().rawId()<<" key: "<<index;
      }
   }
@@ -105,6 +105,6 @@ TkPixelMeasurementDet::hasBadComponents( const TrajectoryStateOnSurface &tsos ) 
     for (std::vector<LocalPoint>::const_iterator it = badRocPositions_.begin(), ed = badRocPositions_.end(); it != ed; ++it) {
         if ( (std::abs(it->x() - lp.x()) < dx) &&
              (std::abs(it->y() - lp.y()) < dy) ) return true;
-    } 
+    }
     return false;
 }

--- a/RecoTracker/TkDetLayers/src/BladeShapeBuilderFromDet.cc
+++ b/RecoTracker/TkDetLayers/src/BladeShapeBuilderFromDet.cc
@@ -9,7 +9,7 @@
 
 using namespace std;
 
-BoundDiskSector* 
+BoundDiskSector*
 BladeShapeBuilderFromDet::operator()( const vector<const GeomDet*>& dets) const
 {
   // find mean position
@@ -25,7 +25,7 @@ BladeShapeBuilderFromDet::operator()( const vector<const GeomDet*>& dets) const
   Plane tmpPlane( meanPos, rotation);
 
 
-  auto bo = 
+  auto bo =
     computeBounds( dets,tmpPlane );
   GlobalPoint pos = meanPos+bo.second;
   //edm::LogInfo(TkDetLayers) << "global pos in operator: " << pos ;
@@ -62,20 +62,20 @@ BladeShapeBuilderFromDet::computeBounds( const vector<const GeomDet*>& dets,
       if ( PhiLess()( phi, phimin)) phimin = phi;
       if ( PhiLess()( phimax, phi)) phimax = phi;
     }
-    // in addition to the corners we have to check the middle of the 
+    // in addition to the corners we have to check the middle of the
     // det +/- length/2, since the min (max) radius for typical fw
     // dets is reached there
-        
+
     float rdet = (*it)->position().perp();
     float height  = (*it)->surface().bounds().width();
     rmin = min( rmin, rdet-height/2.F);
-    rmax = max( rmax, rdet+height/2.F);  
-    
+    rmax = max( rmax, rdet+height/2.F);
+
 
   }
 
-  if (!PhiLess()(phimin, phimax)) 
-    edm::LogError("TkDetLayers") << " BladeShapeBuilderFromDet : " 
+  if (!PhiLess()(phimin, phimax))
+    edm::LogError("TkDetLayers") << " BladeShapeBuilderFromDet : "
 				 << "Something went wrong with Phi Sorting !" ;
   float zPos = (zmax+zmin)/2.;
   float phiWin = phimax - phimin;
@@ -85,12 +85,12 @@ BladeShapeBuilderFromDet::computeBounds( const vector<const GeomDet*>& dets,
     if ( (phimin < Geom::pi() / 2.) || (phimax > -Geom::pi()/2.) ){
       edm::LogError("TkDetLayers") << " something strange going on, please check " ;
     }
-    //edm::LogInfo(TkDetLayers) << " Wedge at pi: phi " << phimin << " " << phimax << " " << phiWin 
+    //edm::LogInfo(TkDetLayers) << " Wedge at pi: phi " << phimin << " " << phimax << " " << phiWin
     //	 << " " << 2.*Geom::pi()+phiWin << " " ;
     phiWin += 2.*Geom::pi();
-    phiPos += Geom::pi(); 
+    phiPos += Geom::pi();
   }
-  
+
   LocalVector localPos( rmed*cos(phiPos), rmed*sin(phiPos), zPos);
 
   LogDebug("TkDetLayers") << "localPos in computeBounds: " << localPos << "\n"
@@ -106,16 +106,16 @@ BladeShapeBuilderFromDet::computeBounds( const vector<const GeomDet*>& dets,
 }
 
 
-Surface::RotationType 
+Surface::RotationType
 BladeShapeBuilderFromDet::computeRotation( const vector<const GeomDet*>& dets,
 					   const Surface::PositionType& meanPos) const
 {
   const Plane& plane = dets.front()->surface();
-  
+
   GlobalVector xAxis;
   GlobalVector yAxis;
   GlobalVector zAxis;
-  
+
   GlobalVector planeXAxis    = plane.toGlobal( LocalVector( 1, 0, 0));
   GlobalPoint  planePosition = plane.position();
 
@@ -133,7 +133,7 @@ BladeShapeBuilderFromDet::computeRotation( const vector<const GeomDet*>& dets,
   }
 
   xAxis = yAxis.cross( zAxis);
-  
+
   return Surface::RotationType( xAxis, yAxis);
 }
 

--- a/RecoTracker/TkDetLayers/src/CompatibleDetToGroupAdder.cc
+++ b/RecoTracker/TkDetLayers/src/CompatibleDetToGroupAdder.cc
@@ -7,7 +7,7 @@ using namespace std;
 
 
 bool CompatibleDetToGroupAdder::add( const GeometricSearchDet& det,
-				     const TrajectoryStateOnSurface& tsos, 
+				     const TrajectoryStateOnSurface& tsos,
 				     const Propagator& prop,
 				     const MeasurementEstimator& est,
 				     vector<DetGroup>& result) {
@@ -15,7 +15,7 @@ bool CompatibleDetToGroupAdder::add( const GeometricSearchDet& det,
     vector<DetGroup> tmp;
     det.groupedCompatibleDetsV(tsos, prop, est,tmp);
     if (tmp.empty()) return false;
-    
+
     if (result.empty()) result.swap(tmp);
     else                DetGroupMerger::addSameLevel(std::move(tmp), result);
   }
@@ -23,25 +23,25 @@ bool CompatibleDetToGroupAdder::add( const GeometricSearchDet& det,
     vector<GeometricSearchDet::DetWithState> compatDets;
     det.compatibleDetsV( tsos, prop, est, compatDets);
     if (compatDets.empty()) return false;
-    
+
     if (result.empty())
       result.push_back( DetGroup( 0, 1)); // empty group for insertion
-    
+
     if (result.size() != 1)
       edm::LogError("TkDetLayers") << "CompatibleDetToGroupAdder: det is not grouped but result has more than one group!" ;
     result.front().reserve(result.front().size()+compatDets.size());
     for (vector<GeometricSearchDet::DetWithState>::const_iterator i=compatDets.begin();
 	 i!=compatDets.end(); i++)
       result.front().push_back(std::move( *i));
-  } 
-    return true;
+  }
+  return true;
 }
 
 #include "TrackingTools/DetLayers/interface/GeomDetCompatibilityChecker.h"
 #include "TkGeomDetCompatibilityChecker.h"
 
 bool CompatibleDetToGroupAdder::add( const GeomDet& det,
-				     const TrajectoryStateOnSurface& tsos, 
+				     const TrajectoryStateOnSurface& tsos,
 				     const Propagator& prop,
 				     const MeasurementEstimator& est,
 				     vector<DetGroup>& result) {
@@ -56,12 +56,12 @@ bool CompatibleDetToGroupAdder::add( const GeomDet& det,
   if (result.empty())
     result.push_back( DetGroup( 0, 1)); // empty group for ge insertion
 
-  if (result.size() != 1) 
+  if (result.size() != 1)
       edm::LogError("TkDetLayers") << "CompatibleDetToGroupAdder: det is not grouped but result has more than one group!" ;
-    
 
-  result.front().push_back(ge); 
-  return true;  
+
+  result.front().push_back(ge);
+  return true;
 }
 
 

--- a/RecoTracker/TkDetLayers/src/GeometricSearchTrackerBuilder.cc
+++ b/RecoTracker/TkDetLayers/src/GeometricSearchTrackerBuilder.cc
@@ -39,7 +39,7 @@ GeometricSearchTrackerBuilder::build(const GeometricDet* theGeometricTracker,
   vector<ForwardDetLayer*> thePosTIDLayers;
   vector<ForwardDetLayer*> theNegTECLayers;
   vector<ForwardDetLayer*> thePosTECLayers;
-  
+
   using namespace trackerTrie;
 
   //-- future code
@@ -48,7 +48,7 @@ GeometricSearchTrackerBuilder::build(const GeometricDet* theGeometricTracker,
 
   // to be moved elsewhere
   {
-    const TrackingGeometry::DetUnitContainer&  modules = theGeomDetGeometry->detUnits(); 
+    const TrackingGeometry::DetUnitContainer&  modules = theGeomDetGeometry->detUnits();
     typedef TrackingGeometry::DetUnitContainer::const_iterator Iter;
     Iter b=modules.begin();
     Iter e=modules.end();
@@ -57,7 +57,7 @@ GeometricSearchTrackerBuilder::build(const GeometricDet* theGeometricTracker,
       for(;b!=e; ++b) {
 	last = b;
 	unsigned int rawid = (*b)->geographicalId().rawId();
-	trie.insert(trackerHierarchy(rawid), *b); 
+	trie.insert(trackerHierarchy(rawid), *b);
       }
     }
     catch(edm::Exception const & e) {
@@ -65,12 +65,12 @@ GeometricSearchTrackerBuilder::build(const GeometricDet* theGeometricTracker,
       unsigned int rawid = (*last)->geographicalId().rawId();
       int subdetid = (*last)->geographicalId().subdetId();
       std::cout << rawid << " " << subdetid << std::endl;
-    }  
+    }
   }
 
   // layers "ids"
   unsigned int layerId[] = {1,3,5,21,22,41,42,61,62};
-  //  boost::function<void(trackerTrie::Node const &)> fun[9]; 
+  //  boost::function<void(trackerTrie::Node const &)> fun[9];
   /*
 	thePxlBarLayers.push_back( aPixelBarrelLayerBuilder.build(*p) );
 	theTIBLayers.push_back( aTIBLayerBuilder.build(*p) );
@@ -82,18 +82,18 @@ GeometricSearchTrackerBuilder::build(const GeometricDet* theGeometricTracker,
 	theNegTECLayers.push_back( aTECLayerBuilder.build(*p) );
 	thePosTECLayers.push_back( aTECLayerBuilder.build(*p) );
   */
-   
+
 
   for (int i=0;i<9;i++) {
     std::string s;
-    if (layerId[i]>9) s+=char(layerId[i]/10); 
+    if (layerId[i]>9) s+=char(layerId[i]/10);
     s+=char(layerId[i]%10);
-    node_iterator e;	
+    node_iterator e;
     node_iterator p(trie.node(s));
     for (;p!=e;++p) {
       //    fun[i](*p);
     }
-  }    
+  }
 
 
   // current code
@@ -108,7 +108,7 @@ GeometricSearchTrackerBuilder::build(const GeometricDet* theGeometricTracker,
 	thePxlBarLayers.push_back( aPixelBarrelLayerBuilder.build(*it2,theGeomDetGeometry) );
       }
     }
-    
+
     if( (*it)->type() == GeometricDet::TIB) {
       vector<const GeometricDet*> theTIBGeometricDetLayers = (*it)->components();
       for(vector<const GeometricDet*>::const_iterator it2=theTIBGeometricDetLayers.begin();
@@ -119,13 +119,13 @@ GeometricSearchTrackerBuilder::build(const GeometricDet* theGeometricTracker,
 
     if( (*it)->type() == GeometricDet::TOB) {
       vector<const GeometricDet*> theTOBGeometricDetLayers = (*it)->components();
-      for(vector<const GeometricDet*>::const_iterator it2=theTOBGeometricDetLayers.begin();	  
+      for(vector<const GeometricDet*>::const_iterator it2=theTOBGeometricDetLayers.begin();
       it2!=theTOBGeometricDetLayers.end(); it2++){
 	theTOBLayers.push_back( aTOBLayerBuilder.build(*it2,theGeomDetGeometry) );
       }
     }
 
-    
+
     if( (*it)->type() == GeometricDet::PixelEndCap || (*it)->type() == GeometricDet::PixelEndCapPhase1 ){
       vector<const GeometricDet*> thePxlFwdGeometricDetLayers = (*it)->components();
       for(vector<const GeometricDet*>::const_iterator it2=thePxlFwdGeometricDetLayers.begin();
@@ -136,7 +136,7 @@ GeometricSearchTrackerBuilder::build(const GeometricDet* theGeometricTracker,
 	  thePosPxlFwdLayers.push_back( aPixelForwardLayerBuilder.build(*it2,theGeomDetGeometry) );
       }
     }
-    
+
 
 
     if( (*it)->type() == GeometricDet::TID){
@@ -163,7 +163,7 @@ GeometricSearchTrackerBuilder::build(const GeometricDet* theGeometricTracker,
 
 
   }
-  
+
 
   return new GeometricSearchTracker(thePxlBarLayers,theTIBLayers,theTOBLayers,
 				    theNegPxlFwdLayers,theNegTIDLayers,theNegTECLayers,

--- a/RecoTracker/TkDetLayers/src/PixelBlade.cc
+++ b/RecoTracker/TkDetLayers/src/PixelBlade.cc
@@ -6,6 +6,7 @@
 #include "LayerCrossingSide.h"
 #include "DetGroupMerger.h"
 #include "CompatibleDetToGroupAdder.h"
+#include "DataFormats/GeometrySurface/interface/BoundingBox.h"
 
 #include "TrackingTools/DetLayers/interface/DetLayerException.h"
 #include "TrackingTools/DetLayers/interface/MeasurementEstimator.h"
@@ -18,52 +19,68 @@ typedef GeometricSearchDet::DetWithState DetWithState;
 PixelBlade::~PixelBlade(){}
 
 PixelBlade::PixelBlade(vector<const GeomDet*>& frontDets,
-		       vector<const GeomDet*>& backDets):		       
-  theFrontDets(frontDets), theBackDets(backDets) 
+		       vector<const GeomDet*>& backDets):
+    theFrontDets(frontDets),
+    theBackDets(backDets),
+    front_radius_range_(std::make_pair(0,0)),
+    back_radius_range_(std::make_pair(0,0))
 {
   theDets.assign(theFrontDets.begin(),theFrontDets.end());
   theDets.insert(theDets.end(),theBackDets.begin(),theBackDets.end());
 
-  theDiskSector      = BladeShapeBuilderFromDet()(theDets);  
+  theDiskSector      = BladeShapeBuilderFromDet()(theDets);
   theFrontDiskSector = BladeShapeBuilderFromDet()(theFrontDets);
-  theBackDiskSector  = BladeShapeBuilderFromDet()(theBackDets);   
-
+  theBackDiskSector  = BladeShapeBuilderFromDet()(theBackDets);
+  // Hack to properly treat "pixel-blade" like geometry of the outer
+  // tracker of Phase II. For further explanations, see comments in
+  // PixelForwardLayer.cc.
+  front_radius_range_ = computeRadiusRanges(theFrontDets);
+  back_radius_range_  = computeRadiusRanges(theBackDets);
 
   //--------- DEBUG INFO --------------
   LogDebug("TkDetLayers") << "DEBUG INFO for PixelBlade" ;
-  LogDebug("TkDetLayers") << "Blade z, perp, innerRadius, outerR: " 
+  LogDebug("TkDetLayers") << "Blade z, perp, innerRadius, outerR[disk, front, back]: "
 			  << this->position().z() << " , "
-			  << this->position().perp() << " , "
+			  << this->position().perp() << " , ("
 			  << theDiskSector->innerRadius() << " , "
-			  << theDiskSector->outerRadius();
+			  << theDiskSector->outerRadius() << "), ("
+			  << theFrontDiskSector->innerRadius() << " , "
+			  << theFrontDiskSector->outerRadius() << "), ("
+			  << theBackDiskSector->innerRadius() << " , "
+			  << theBackDiskSector->outerRadius() << ")" << std::endl;
 
-  for(vector<const GeomDet*>::const_iterator it=theFrontDets.begin(); 
+  for(vector<const GeomDet*>::const_iterator it=theFrontDets.begin();
       it!=theFrontDets.end(); it++){
-    LogDebug("TkDetLayers") << "frontDet phi,z,r: " 
+    LogDebug("TkDetLayers") << "frontDet phi,z,r: "
 			    << (*it)->position().phi() << " , "
 			    << (*it)->position().z()   << " , "
-			    << (*it)->position().perp() ;
+			    << (*it)->position().perp() << " , "
+                            << " rmin: " << (*it)->surface().rSpan().first
+                            << " rmax: " << (*it)->surface().rSpan().second
+                            << std::endl;
   }
 
-  for(vector<const GeomDet*>::const_iterator it=theBackDets.begin(); 
+  for(vector<const GeomDet*>::const_iterator it=theBackDets.begin();
       it!=theBackDets.end(); it++){
-    LogDebug("TkDetLayers") << "backDet phi,z,r: " 
+    LogDebug("TkDetLayers") << "backDet phi,z,r: "
 			    << (*it)->position().phi() << " , "
 			    << (*it)->position().z()   << " , "
-			    << (*it)->position().perp();
+			    << (*it)->position().perp() << " , "
+                            << " rmin: " << (*it)->surface().rSpan().first
+                            << " rmax: " << (*it)->surface().rSpan().second
+                            << std::endl;
   }
-  //-----------------------------------
 
 }
 
 
-const vector<const GeometricSearchDet*>& 
+const vector<const GeometricSearchDet*>&
 PixelBlade::components() const{
-  throw DetLayerException("TOBRod doesn't have GeometricSearchDet components"); 
+  throw DetLayerException("TOBRod doesn't have GeometricSearchDet components");
 }
 
 pair<bool, TrajectoryStateOnSurface>
-PixelBlade::compatible( const TrajectoryStateOnSurface& ts, const Propagator&, 
+PixelBlade::compatible( const TrajectoryStateOnSurface& ts, const Propagator&,
 			const MeasurementEstimator&) const{
   edm::LogError("TkDetLayers") << "temporary dummy implementation of PixelBlade::compatible()!!" ;
   return pair<bool,TrajectoryStateOnSurface>();
@@ -73,50 +90,50 @@ PixelBlade::compatible( const TrajectoryStateOnSurface& ts, const Propagator&,
 
 void
 PixelBlade::groupedCompatibleDetsV( const TrajectoryStateOnSurface& tsos,
-					  const Propagator& prop,
-					   const MeasurementEstimator& est,
-					   std::vector<DetGroup> & result) const{
+                                    const Propagator& prop,
+                                    const MeasurementEstimator& est,
+                                    std::vector<DetGroup> & result) const{
 
 
+  SubLayerCrossings  crossings;
 
- SubLayerCrossings  crossings; 
   crossings = computeCrossings( tsos, prop.propagationDirection());
   if(! crossings.isValid()) return;
 
   vector<DetGroup> closestResult;
   addClosest( tsos, prop, est, crossings.closest(), closestResult);
 
-  if (closestResult.empty()){
+  if (closestResult.empty()) {
     vector<DetGroup> nextResult;
     addClosest( tsos, prop, est, crossings.other(), nextResult);
     if(nextResult.empty())    return;
-    
-    //DetGroupElement nextGel( nextResult.front().front());  
+
+    //DetGroupElement nextGel( nextResult.front().front());
     //int crossingSide = LayerCrossingSide().endcapSide( nextGel.trajectoryState(), prop);
 
     DetGroupMerger::orderAndMergeTwoLevels( std::move(closestResult), std::move(nextResult), result,
 					    0,0);//fixme gc patched for SLHC - already correctly sorted for SLHC
-                                            //crossings.closestIndex(), crossingSide);   
+    //crossings.closestIndex(), crossingSide);
   }
   else {
     DetGroupElement closestGel( closestResult.front().front());
     float window = computeWindowSize( closestGel.det(), closestGel.trajectoryState(), est);
-    
+
     searchNeighbors( tsos, prop, est, crossings.closest(), window,
 		     closestResult, false);
-    
+
     vector<DetGroup> nextResult;
     searchNeighbors( tsos, prop, est, crossings.other(), window,
 		     nextResult, true);
-    
+
     //int crossingSide = LayerCrossingSide().endcapSide( closestGel.trajectoryState(), prop);
     DetGroupMerger::orderAndMergeTwoLevels( std::move(closestResult), std::move(nextResult), result,
 					    0,0);//fixme gc patched for SLHC - already correctly sorted for SLHC
-                                            //crossings.closestIndex(), crossingSide);
+    //crossings.closestIndex(), crossingSide);
   }
 }
 
-SubLayerCrossings 
+SubLayerCrossings
 PixelBlade::computeCrossings( const TrajectoryStateOnSurface& startingState,
 			      PropagationDirection propDir) const
 {
@@ -130,7 +147,7 @@ PixelBlade::computeCrossings( const TrajectoryStateOnSurface& startingState,
 
   GlobalPoint gInnerPoint( crossing.position(innerPath.second));
   //Code for use of binfinder
-  //int innerIndex = theInnerBinFinder.binIndex(gInnerPoint.perp());  
+  //int innerIndex = theInnerBinFinder.binIndex(gInnerPoint.perp());
   //float innerDist = fabs( theInnerBinFinder.binPosition(innerIndex) - gInnerPoint.z());
 
   //  int innerIndex = findBin(gInnerPoint.perp(),0);
@@ -140,7 +157,6 @@ PixelBlade::computeCrossings( const TrajectoryStateOnSurface& startingState,
   //float innerDist = fabs( findPosition(innerIndex,0).perp() - gInnerPoint.perp());
   float innerDist = ( startingState.globalPosition() - gInnerPoint).mag();
   SubLayerCrossing innerSLC( 0, innerIndex, gInnerPoint);
-
 
   pair<bool,double> outerPath = crossing.pathLength( *theBackDiskSector);
   if (!outerPath.first) return SubLayerCrossings();
@@ -153,7 +169,7 @@ PixelBlade::computeCrossings( const TrajectoryStateOnSurface& startingState,
   int outerIndex  = findBin2(gOuterPoint,1);
 
   //fixme gc patched for SLHC - force order here to be in z
-   //float outerDist = fabs( findPosition(outerIndex,1).perp() - gOuterPoint.perp());
+  //float outerDist = fabs( findPosition(outerIndex,1).perp() - gOuterPoint.perp());
   float outerDist = ( startingState.globalPosition() - gOuterPoint).mag();
   SubLayerCrossing outerSLC( 1, outerIndex, gOuterPoint);
 
@@ -162,12 +178,12 @@ PixelBlade::computeCrossings( const TrajectoryStateOnSurface& startingState,
   }
   else {
     return SubLayerCrossings( outerSLC, innerSLC, 1);
-  } 
+  }
 }
 
 
 
-bool 
+bool
 PixelBlade::addClosest( const TrajectoryStateOnSurface& tsos,
 			const Propagator& prop,
 			const MeasurementEstimator& est,
@@ -177,17 +193,17 @@ PixelBlade::addClosest( const TrajectoryStateOnSurface& tsos,
 
   const vector<const GeomDet*>& sBlade( subBlade( crossing.subLayerIndex()));
 
-  return CompatibleDetToGroupAdder().add( *sBlade[crossing.closestDetIndex()], 
+  return CompatibleDetToGroupAdder().add( *sBlade[crossing.closestDetIndex()],
 					  tsos, prop, est, result);
 }
 
 
-float PixelBlade::computeWindowSize( const GeomDet* det, 
-				     const TrajectoryStateOnSurface& tsos, 
+float PixelBlade::computeWindowSize( const GeomDet* det,
+				     const TrajectoryStateOnSurface& tsos,
 				     const MeasurementEstimator& est) const
 {
   return
-    est.maximalLocalDisplacement(tsos, det->surface()).x();
+      est.maximalLocalDisplacement(tsos, det->surface()).x();
 }
 
 
@@ -197,14 +213,13 @@ void PixelBlade::searchNeighbors( const TrajectoryStateOnSurface& tsos,
 				  const Propagator& prop,
 				  const MeasurementEstimator& est,
 				  const SubLayerCrossing& crossing,
-				  float window, 
+				  float window,
 				  vector<DetGroup>& result,
 				  bool checkClosest) const
 {
   GlobalPoint gCrossingPos = crossing.position();
-
   const vector<const GeomDet*>& sBlade( subBlade( crossing.subLayerIndex()));
- 
+
   int closestIndex = crossing.closestDetIndex();
   int negStartIndex = closestIndex-1;
   int posStartIndex = closestIndex+1;
@@ -234,7 +249,7 @@ void PixelBlade::searchNeighbors( const TrajectoryStateOnSurface& tsos,
 bool PixelBlade::overlap( const GlobalPoint& crossPoint, const GeomDet& det, float window) const
 {
   // check if the z window around TSOS overlaps with the detector theDet (with a 1% margin added)
-  
+
   //   const float tolerance = 0.1;
   const float relativeMargin = 1.01;
 
@@ -247,9 +262,9 @@ bool PixelBlade::overlap( const GlobalPoint& crossPoint, const GeomDet& det, flo
   float localX = localCrossPoint.x();
   float detHalfLength = det.surface().bounds().length()/2.;
 
-  //   edm::LogInfo(TkDetLayers) << "PixelBlade::overlap: Det at " << det.position() << " hit at " << localY 
+  //   edm::LogInfo(TkDetLayers) << "PixelBlade::overlap: Det at " << det.position() << " hit at " << localY
   //        << " Window " << window << " halflength "  << detHalfLength ;
-  
+
   if ( ( fabs(localX)-window) < relativeMargin*detHalfLength ) { // FIXME: margin hard-wired!
     return true;
   } else {
@@ -257,14 +272,14 @@ bool PixelBlade::overlap( const GlobalPoint& crossPoint, const GeomDet& det, flo
   }
 }
 
-int 
-PixelBlade::findBin( float R,int diskSectorIndex) const 
+int
+PixelBlade::findBin( float R,int diskSectorIndex) const
 {
   vector<const GeomDet*> localDets = diskSectorIndex==0 ? theFrontDets : theBackDets;
-  
+
 
   int theBin = 0;
-  float rDiff = fabs( R - localDets.front()->surface().position().perp());;
+  float rDiff = fabs( R - localDets.front()->surface().position().perp());
   for (vector<const GeomDet*>::const_iterator i=localDets.begin(); i !=localDets.end(); i++){
     float testDiff = fabs( R - (**i).surface().position().perp());
     if ( testDiff < rDiff) {
@@ -275,35 +290,87 @@ PixelBlade::findBin( float R,int diskSectorIndex) const
   return theBin;
 }
 
-int 
-PixelBlade::findBin2( GlobalPoint thispoint,int diskSectorIndex) const 
+int
+PixelBlade::findBin2( GlobalPoint thispoint,int diskSectorIndex) const
 {
-  vector<const GeomDet*> localDets = diskSectorIndex==0 ? theFrontDets : theBackDets;
-  
+  const vector<const GeomDet*> & localDets = diskSectorIndex==0 ? theFrontDets : theBackDets;
+
 
 
   int theBin = 0;
-  int i_index=0;
   float sDiff = (thispoint - localDets.front()->surface().position()).mag();
 
   for (vector<const GeomDet*>::const_iterator i=localDets.begin(); i !=localDets.end(); i++){
     float testDiff = ( thispoint - (**i).surface().position()).mag();
-    
     if ( testDiff < sDiff) {
       sDiff = testDiff;
       theBin = i - localDets.begin();
     }
-    i_index++;
   }
   return theBin;
 }
 
 
 
-GlobalPoint 
-PixelBlade::findPosition(int index,int diskSectorType) const 
+GlobalPoint
+PixelBlade::findPosition(int index,int diskSectorType) const
 {
-  vector<const GeomDet*> diskSector = diskSectorType == 0 ? theFrontDets : theBackDets; 
+  vector<const GeomDet*> diskSector = diskSectorType == 0 ? theFrontDets : theBackDets;
   return (diskSector[index])->surface().position();
 }
 
+std::pair<float, float>
+PixelBlade::computeRadiusRanges(const std::vector<const GeomDet*> &current_dets) {
+
+  typedef Surface::PositionType::BasicVectorType Vector;
+  Vector posSum(0,0,0);
+  for (auto i : current_dets)
+    posSum += (*i).surface().position().basicVector();
+
+  Surface::PositionType meanPos( 0.,0.,posSum.z()/float(current_dets.size()));
+
+  // temporary plane - for the computation of bounds
+  const Plane& tmpplane = current_dets.front()->surface();
+
+  GlobalVector xAxis;
+  GlobalVector yAxis;
+  GlobalVector zAxis;
+
+  GlobalVector planeXAxis    = tmpplane.toGlobal(LocalVector(1, 0, 0));
+  GlobalPoint  planePosition = tmpplane.position();
+
+  if (planePosition.x() * planeXAxis.x()
+     + planePosition.y() * planeXAxis.y() > 0.){
+    yAxis = planeXAxis;
+  } else {
+    yAxis = -planeXAxis;
+  }
+
+  GlobalVector planeZAxis = tmpplane.toGlobal(LocalVector( 0, 0, 1));
+  if (planeZAxis.z() * planePosition.z() > 0.) {
+    zAxis = planeZAxis;
+  } else {
+    zAxis = -planeZAxis;
+  }
+
+  xAxis = yAxis.cross(zAxis);
+
+  Surface::RotationType rotation = Surface::RotationType(xAxis, yAxis);
+  Plane plane(meanPos, rotation);
+
+  Surface::PositionType tmpPos = current_dets.front()->surface().position();
+
+  float rmin(plane.toLocal(tmpPos).perp());
+  float rmax(plane.toLocal(tmpPos).perp());
+
+  for (auto it : current_dets) {
+    vector<GlobalPoint> corners = BoundingBox().corners(it->specificSurface());
+    for (auto i : corners) {
+      float r   = plane.toLocal(i).perp();
+      rmin = min(rmin, r);
+      rmax = max(rmax, r);
+    }
+  }
+
+  return std::make_pair(rmin, rmax);
+}

--- a/RecoTracker/TkDetLayers/src/PixelBlade.h
+++ b/RecoTracker/TkDetLayers/src/PixelBlade.h
@@ -7,6 +7,7 @@
 #include "TrackingTools/DetLayers/interface/PeriodicBinFinderInZ.h"
 #include "SubLayerCrossings.h"
 
+#include <utility>
 
 /** A concrete implementation for PixelBlade
  */
@@ -19,7 +20,7 @@ class PixelBlade GCC11_FINAL : public GeometricSearchDetWithGroups {
 	     std::vector<const GeomDet*>& backDets  );
 
   ~PixelBlade();
-  
+
   // GeometricSearchDet interface
   virtual const BoundSurface& surface() const {return *theDiskSector;}
 
@@ -28,32 +29,39 @@ class PixelBlade GCC11_FINAL : public GeometricSearchDetWithGroups {
   virtual const std::vector<const GeometricSearchDet*>& components() const;
 
   std::pair<bool, TrajectoryStateOnSurface>
-  compatible( const TrajectoryStateOnSurface& ts, const Propagator&, 
+  compatible( const TrajectoryStateOnSurface& ts, const Propagator&,
 	      const MeasurementEstimator&) const;
-  
-  virtual void 
+
+  virtual void
   groupedCompatibleDetsV( const TrajectoryStateOnSurface& tsos,
 			  const Propagator& prop,
 			  const MeasurementEstimator& est,
 			  std::vector<DetGroup> & result) const;
-  
+
   //Extension of the interface
   virtual const BoundDiskSector& specificSurface() const {return *theDiskSector;}
+
+  bool inRange(float radius, bool inner) const {
+    if (inner)
+      return (radius >= front_radius_range_.first && radius <= front_radius_range_.second);
+    else
+      return (radius >= back_radius_range_.first && radius <= back_radius_range_.second);
+  }
 
  private:
   // private methods for the implementation of groupedCompatibleDets()
 
   SubLayerCrossings computeCrossings( const TrajectoryStateOnSurface& tsos,
 				      PropagationDirection propDir) const;
-  
+
   bool addClosest( const TrajectoryStateOnSurface& tsos,
 		   const Propagator& prop,
 		   const MeasurementEstimator& est,
 		   const SubLayerCrossing& crossing,
 		   std::vector<DetGroup>& result) const;
-  
-  float computeWindowSize( const GeomDet* det, 
-			   const TrajectoryStateOnSurface& tsos, 
+
+  float computeWindowSize( const GeomDet* det,
+			   const TrajectoryStateOnSurface& tsos,
 			   const MeasurementEstimator& est) const;
 
 
@@ -61,31 +69,33 @@ class PixelBlade GCC11_FINAL : public GeometricSearchDetWithGroups {
 			const Propagator& prop,
 			const MeasurementEstimator& est,
 			const SubLayerCrossing& crossing,
-			float window, 
+			float window,
 			std::vector<DetGroup>& result,
 			bool checkClosest) const;
 
   bool overlap( const GlobalPoint& gpos, const GeomDet& det, float phiWin) const;
 
-  // This 2 find methods should be substituted with the use 
+  // This 2 find methods should be substituted with the use
   // of a GeneralBinFinderInR
-  
+
   int findBin( float R,int layer) const;
   int findBin2( GlobalPoint thispoint,int layer) const;
-  
+
   GlobalPoint findPosition(int index,int diskSectorIndex) const ;
 
   const std::vector<const GeomDet*>& subBlade( int ind) const {
     return (ind==0 ? theFrontDets : theBackDets);
   }
 
+  std::pair<float, float> computeRadiusRanges(const std::vector<const GeomDet*>&);
 
-
- private:
+private:
   std::vector<const GeomDet*> theDets;
   std::vector<const GeomDet*> theFrontDets;
   std::vector<const GeomDet*> theBackDets;
-  
+  std::pair<float, float> front_radius_range_;
+  std::pair<float, float> back_radius_range_;
+
   ReferenceCountingPointer<BoundDiskSector> theDiskSector;
   ReferenceCountingPointer<BoundDiskSector> theFrontDiskSector;
   ReferenceCountingPointer<BoundDiskSector> theBackDiskSector;
@@ -93,4 +103,4 @@ class PixelBlade GCC11_FINAL : public GeometricSearchDetWithGroups {
 
 
 #pragma GCC visibility pop
-#endif 
+#endif

--- a/RecoTracker/TkDetLayers/src/PixelBladeBuilder.cc
+++ b/RecoTracker/TkDetLayers/src/PixelBladeBuilder.cc
@@ -6,13 +6,13 @@
 
 using namespace edm;
 using namespace std;
-                                     
+
 PixelBlade* PixelBladeBuilder:: build(const GeometricDet* geometricDetFrontPanel,
 				      const GeometricDet* geometricDetBackPanel,
 				      const TrackerGeometry* theGeomDetGeometry)
 {
-  vector<const GeometricDet*> frontGeometricDets = geometricDetFrontPanel->components();  
-  vector<const GeometricDet*> backGeometricDets  = geometricDetBackPanel->components();  
+  vector<const GeometricDet*> frontGeometricDets = geometricDetFrontPanel->components();
+  vector<const GeometricDet*> backGeometricDets  = geometricDetBackPanel->components();
 
   vector<const GeomDet*> theFrontGeomDets;
   vector<const GeomDet*> theBackGeomDets;
@@ -34,7 +34,7 @@ PixelBlade* PixelBladeBuilder:: build(const GeometricDet* geometricDetFrontPanel
 
   return new PixelBlade(theFrontGeomDets,theBackGeomDets);
 }
- 
+
 
 
 

--- a/RecoTracker/TkDetLayers/src/PixelBladeBuilder.h
+++ b/RecoTracker/TkDetLayers/src/PixelBladeBuilder.h
@@ -8,19 +8,19 @@
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/TrackerNumberingBuilder/interface/GeometricDet.h"
 
-/** A concrete builder for PixelBlade 
+/** A concrete builder for PixelBlade
  */
 
 #pragma GCC visibility push(hidden)
-class PixelBladeBuilder {  
+class PixelBladeBuilder {
  public:
   PixelBladeBuilder(){};
   PixelBlade* build(const GeometricDet* geometricDetFrontPanel,
 		    const GeometricDet* geometricDetBackPanel,
 		    const TrackerGeometry* theGeomDetGeometry);
-  
+
 };
 
 
 #pragma GCC visibility pop
-#endif 
+#endif

--- a/RecoTracker/TkDetLayers/src/PixelForwardLayer.cc
+++ b/RecoTracker/TkDetLayers/src/PixelForwardLayer.cc
@@ -16,13 +16,14 @@
 #include "CompatibleDetToGroupAdder.h"
 
 #include <algorithm>
+#include <climits>
 
 using namespace std;
 
 typedef GeometricSearchDet::DetWithState DetWithState;
 
 PixelForwardLayer::PixelForwardLayer(vector<const PixelBlade*>& blades):
-  theComps(blades.begin(),blades.end())
+    theComps(blades.begin(),blades.end())
 {
   // Assumes blades are ordered inner first then outer; and within each by phi
   // where we go 0 -> pi, and then -pi -> 0
@@ -33,25 +34,27 @@ PixelForwardLayer::PixelForwardLayer(vector<const PixelBlade*>& blades):
   // or probably need to change the way this is done, e.g. a smarter binFinder
   float theRmin = (*(theComps.begin()))->surface().position().perp();
   float theRmax = theRmin;
-  for(vector<const GeometricSearchDet*>::const_iterator it=theComps.begin(); 
+  for(vector<const GeometricSearchDet*>::const_iterator it=theComps.begin();
       it!=theComps.end(); it++){
-      theRmin = std::min( theRmin, (*it)->surface().position().perp());
-      theRmax = std::max( theRmax, (*it)->surface().position().perp());
+    theRmin = std::min( theRmin, (*it)->surface().position().perp());
+    theRmax = std::max( theRmax, (*it)->surface().position().perp());
   }
   float split_inner_outer_radius = 0.5 * (theRmin + theRmax);
   _num_innerpanels = 0;
   for(vector<const GeometricSearchDet*>::const_iterator it=theComps.begin();
-      it!=theComps.end();it++){  
+      it!=theComps.end();it++){
     if((**it).surface().position().perp() <= split_inner_outer_radius) ++_num_innerpanels;
   }
   _num_outerpanels = theComps.size() - _num_innerpanels;
-  //std::cout << " Rmin, Rmax, R_average = " << theRmin << ", " << theRmax << ", "
-  //          << split_inner_outer_radius << std::endl;
-  //std::cout << " num inner, outer disks = " << _num_innerpanels << ", " << _num_outerpanels << std::endl;
+  edm::LogInfo("TkDetLayers") << " Rmin, Rmax, R_average = " << theRmin << ", " << theRmax << ", "
+                              << split_inner_outer_radius << std::endl
+                              << " num inner, outer disks = "
+                              << _num_innerpanels << ", " << _num_outerpanels
+                              << std::endl;
 
   for(vector<const GeometricSearchDet*>::const_iterator it=theComps.begin();
-      it!=theComps.end();it++){  
-    theBasicComps.insert(theBasicComps.end(),	
+      it!=theComps.end();it++){
+    theBasicComps.insert(theBasicComps.end(),
 			 (**it).basicComponents().begin(),
 			 (**it).basicComponents().end());
   }
@@ -59,7 +62,7 @@ PixelForwardLayer::PixelForwardLayer(vector<const PixelBlade*>& blades):
   //They should be already phi-ordered. TO BE CHECKED!!
   //sort( theBlades.begin(), theBlades.end(), PhiLess());
   setSurface( computeSurface() );
-  
+
   theBinFinder_inner = BinFinderType( theComps.front()->surface().position().phi(),
                                       _num_innerpanels);
   theBinFinder_outer = BinFinderType( theComps[_num_innerpanels]->surface().position().phi(),
@@ -68,29 +71,31 @@ PixelForwardLayer::PixelForwardLayer(vector<const PixelBlade*>& blades):
   //--------- DEBUG INFO --------------
   LogDebug("TkDetLayers") << "DEBUG INFO for PixelForwardLayer" << "\n"
                           << "Num of inner and outer panels = " << _num_innerpanels << ", " << _num_outerpanels << "\n"
-			  << "PixelForwardLayer.surfcace.phi(): " 
+                          << "Based on phi separation for inner: " << theComps.front()->surface().position().phi()
+                          << " and on phi separation for outer: "  << theComps[_num_innerpanels]->surface().position().phi()
+			  << "PixelForwardLayer.surfcace.phi(): "  << std::endl
 			  << this->surface().position().phi() << "\n"
-			  << "PixelForwardLayer.surfcace.z(): " 
+			  << "PixelForwardLayer.surfcace.z(): "
 			  << this->surface().position().z() << "\n"
-			  << "PixelForwardLayer.surfcace.innerR(): " 
+			  << "PixelForwardLayer.surfcace.innerR(): "
 			  << this->specificSurface().innerRadius() << "\n"
-			  << "PixelForwardLayer.surfcace.outerR(): " 
+			  << "PixelForwardLayer.surfcace.outerR(): "
 			  << this->specificSurface().outerRadius() ;
 
-  for(vector<const GeometricSearchDet*>::const_iterator it=theComps.begin(); 
+  for(vector<const GeometricSearchDet*>::const_iterator it=theComps.begin();
       it!=theComps.end(); it++){
     LogDebug("TkDetLayers") << "blades phi,z,r: "
                             << (*it)->surface().position().phi() << " , "
                             << (*it)->surface().position().z() <<   " , "
                             << (*it)->surface().position().perp();
     //for(vector<const GeomDet*>::const_iterator iu=(**it).basicComponents().begin();
-    //    iu!=(**it).basicComponents().end();iu++){  
+    //    iu!=(**it).basicComponents().end();iu++){
     //  std::cout << "   basic component rawId = " << hex << (**iu).geographicalId().rawId() << dec <<std::endl;
     //}
   }
   //-----------------------------------
 
-    
+
 }
 
 PixelForwardLayer::~PixelForwardLayer(){
@@ -98,17 +103,17 @@ PixelForwardLayer::~PixelForwardLayer(){
   for (i=theComps.begin(); i!=theComps.end(); i++) {
     delete *i;
   }
-} 
+}
 
 namespace {
 
-  bool groupSortByZ(DetGroupElement i,DetGroupElement j) { return (fabs(i.det()->position().z())<fabs(j.det()->position().z())); }
+bool groupSortByZ(DetGroupElement i,DetGroupElement j) { return (fabs(i.det()->position().z())<fabs(j.det()->position().z())); }
 
 }
 
 void
 PixelForwardLayer::groupedCompatibleDetsV( const TrajectoryStateOnSurface& tsos,
-					  const Propagator& prop,
+                                           const Propagator& prop,
 					   const MeasurementEstimator& est,
 					   std::vector<DetGroup> & result) const {
   vector<DetGroup> closestResult_inner;
@@ -119,37 +124,37 @@ PixelForwardLayer::groupedCompatibleDetsV( const TrajectoryStateOnSurface& tsos,
   vector<DetGroup> result_outer;
   int frontindex_inner = 0;
   int frontindex_outer = 0;
-  SubTurbineCrossings  crossings_inner; 
-  SubTurbineCrossings  crossings_outer; 
+  SubTurbineCrossings  crossings_inner;
+  SubTurbineCrossings  crossings_outer;
 
   crossings_inner = computeCrossings( tsos, prop.propagationDirection(), true);
   crossings_outer = computeCrossings( tsos, prop.propagationDirection(), false);
   if (!crossings_inner.isValid){
-    //edm::LogInfo("TkDetLayers") << "inner computeCrossings returns invalid in PixelForwardLayer::groupedCompatibleDets:";
+    edm::LogInfo("TkDetLayers") << "inner computeCrossings returns invalid in PixelForwardLayer::groupedCompatibleDets:";
     return;
   }
   if (!crossings_outer.isValid){
-    //edm::LogInfo("TkDetLayers") << "outer computeCrossings returns invalid in PixelForwardLayer::groupedCompatibleDets:";
+    edm::LogInfo("TkDetLayers") << "outer computeCrossings returns invalid in PixelForwardLayer::groupedCompatibleDets:";
     return;
   }
 
   typedef CompatibleDetToGroupAdder Adder;
-  Adder::add( *theComps[theBinFinder_inner.binIndex(crossings_inner.closestIndex)], 
-	     tsos, prop, est, closestResult_inner);
+  Adder::add( *theComps[theBinFinder_inner.binIndex(crossings_inner.closestIndex)],
+              tsos, prop, est, closestResult_inner);
 
   if(closestResult_inner.empty()){
-    Adder::add( *theComps[theBinFinder_inner.binIndex(crossings_inner.nextIndex)], 
-	       tsos, prop, est, result_inner);
+    Adder::add( *theComps[theBinFinder_inner.binIndex(crossings_inner.nextIndex)],
+                tsos, prop, est, result_inner);
     frontindex_inner = crossings_inner.nextIndex;
   } else {
-    if (Adder::add( *theComps[theBinFinder_inner.binIndex(crossings_inner.nextIndex)], 
-  		  tsos, prop, est, nextResult_inner)) {
+    if (Adder::add( *theComps[theBinFinder_inner.binIndex(crossings_inner.nextIndex)],
+                    tsos, prop, est, nextResult_inner)) {
       int crossingSide = LayerCrossingSide().endcapSide( tsos, prop);
       int theHelicity = computeHelicity(theComps[theBinFinder_inner.binIndex(crossings_inner.closestIndex)],
   					theComps[theBinFinder_inner.binIndex(crossings_inner.nextIndex)] );
       vector<DetGroup> tmp99 = closestResult_inner;
       DetGroupMerger::orderAndMergeTwoLevels( std::move(tmp99), std::move(nextResult_inner), result_inner,
-  					    theHelicity, crossingSide);
+                                              theHelicity, crossingSide);
       if (theHelicity == crossingSide) frontindex_inner = crossings_inner.closestIndex;
       else                             frontindex_inner = crossings_inner.nextIndex;
     } else {
@@ -168,22 +173,22 @@ PixelForwardLayer::groupedCompatibleDetsV( const TrajectoryStateOnSurface& tsos,
   //float detWidth = closestGel.det()->surface().bounds().width();
   //if (crossings.nextDistance < detWidth + window) {
 
-  Adder::add( *theComps[(theBinFinder_outer.binIndex(crossings_outer.closestIndex)) + _num_innerpanels], 
-	     tsos, prop, est, closestResult_outer);
+  Adder::add( *theComps[(theBinFinder_outer.binIndex(crossings_outer.closestIndex)) + _num_innerpanels],
+              tsos, prop, est, closestResult_outer);
 
   if(closestResult_outer.empty()){
-    Adder::add( *theComps[theBinFinder_outer.binIndex(crossings_outer.nextIndex) + _num_innerpanels], 
-	       tsos, prop, est, result_outer);
+    Adder::add( *theComps[theBinFinder_outer.binIndex(crossings_outer.nextIndex) + _num_innerpanels],
+                tsos, prop, est, result_outer);
     frontindex_outer = crossings_outer.nextIndex;
   } else {
-    if (Adder::add( *theComps[theBinFinder_outer.binIndex(crossings_outer.nextIndex) + _num_innerpanels], 
-  		  tsos, prop, est, nextResult_outer)) {
+    if (Adder::add( *theComps[theBinFinder_outer.binIndex(crossings_outer.nextIndex) + _num_innerpanels],
+                    tsos, prop, est, nextResult_outer)) {
       int crossingSide = LayerCrossingSide().endcapSide( tsos, prop);
       int theHelicity = computeHelicity(theComps[theBinFinder_outer.binIndex(crossings_outer.closestIndex) + _num_innerpanels],
   					theComps[theBinFinder_outer.binIndex(crossings_outer.nextIndex) + _num_innerpanels] );
       vector<DetGroup> tmp99 = closestResult_outer;
-      DetGroupMerger::orderAndMergeTwoLevels( std::move(tmp99), std::move(nextResult_outer), result_outer, 
-  					    theHelicity, crossingSide);
+      DetGroupMerger::orderAndMergeTwoLevels( std::move(tmp99), std::move(nextResult_outer), result_outer,
+                                              theHelicity, crossingSide);
       if (theHelicity == crossingSide) frontindex_outer = crossings_outer.closestIndex;
       else                             frontindex_outer = crossings_outer.nextIndex;
     } else {
@@ -203,19 +208,19 @@ PixelForwardLayer::groupedCompatibleDetsV( const TrajectoryStateOnSurface& tsos,
   else {
     int crossingSide = LayerCrossingSide().endcapSide( tsos, prop);
     int theHelicity = computeHelicity(theComps[theBinFinder_inner.binIndex(frontindex_inner)],
-  					theComps[theBinFinder_outer.binIndex(frontindex_outer) + _num_innerpanels] );
-    DetGroupMerger::orderAndMergeTwoLevels( std::move(result_inner), std::move(result_outer), result, 
+                                      theComps[theBinFinder_outer.binIndex(frontindex_outer) + _num_innerpanels] );
+    DetGroupMerger::orderAndMergeTwoLevels( std::move(result_inner), std::move(result_outer), result,
   					    theHelicity, crossingSide);
   }
 
   /*
-  for (auto gr : result) {
+    for (auto gr : result) {
     std::cout << "new group" << std::endl;
     for (auto dge : gr) {
-      PixelBarrelNameUpgrade name(dge.det()->geographicalId());
-      std::cout << "new det with geom det at r:"<<dge.det()->position().perp()<<" id:"<<dge.det()->geographicalId().rawId()<<" name:"<<name.name()<<" isHalf:"<<name.isHalfModule()<<" tsos at:" <<dge.trajectoryState().globalPosition()<< std::endl;
+    PixelBarrelNameUpgrade name(dge.det()->geographicalId());
+    std::cout << "new det with geom det at r:"<<dge.det()->position().perp()<<" id:"<<dge.det()->geographicalId().rawId()<<" name:"<<name.name()<<" isHalf:"<<name.isHalfModule()<<" tsos at:" <<dge.trajectoryState().globalPosition()<< std::endl;
     }
-  }
+    }
   */
 
   if (this->specificSurface().innerRadius()>17.0) {
@@ -254,14 +259,14 @@ PixelForwardLayer::groupedCompatibleDetsV( const TrajectoryStateOnSurface& tsos,
     splitResult.swap(result);
 
     /*
-    std::cout << "AFTER SPLITTING" <<std::endl;
-    for (auto gr : result) {
+      std::cout << "AFTER SPLITTING" <<std::endl;
+      for (auto gr : result) {
       std::cout << "new group" << std::endl;
       for (auto dge : gr) {
-	PixelBarrelNameUpgrade name(dge.det()->geographicalId());
-	std::cout << "new det with geom det at r:"<<dge.det()->position().perp()<<" id:"<<dge.det()->geographicalId().rawId()<<" name:"<<name.name()<<" isHalf:"<<name.isHalfModule()<<" tsos at:" <<dge.trajectoryState().globalPosition()<< std::endl;
+      PixelBarrelNameUpgrade name(dge.det()->geographicalId());
+      std::cout << "new det with geom det at r:"<<dge.det()->position().perp()<<" id:"<<dge.det()->geographicalId().rawId()<<" name:"<<name.name()<<" isHalf:"<<name.isHalfModule()<<" tsos at:" <<dge.trajectoryState().globalPosition()<< std::endl;
       }
-    }
+      }
     */
 
   }//end of hack for phase 2 stacked layers
@@ -271,12 +276,12 @@ PixelForwardLayer::groupedCompatibleDetsV( const TrajectoryStateOnSurface& tsos,
 
 
 
-void 
+void
 PixelForwardLayer::searchNeighbors( const TrajectoryStateOnSurface& tsos,
 				    const Propagator& prop,
 				    const MeasurementEstimator& est,
 				    const SubTurbineCrossings& crossings,
-				    float window, 
+				    float window,
 				    vector<DetGroup>& result,
                                     bool innerDisk) const
 {
@@ -290,7 +295,7 @@ PixelForwardLayer::searchNeighbors( const TrajectoryStateOnSurface& tsos,
   int quarter = theComps.size()/4;
   if(innerDisk) quarter = _num_innerpanels/4;
   else quarter = _num_outerpanels/4;
- 
+
   for (int idet=negStart; idet >= negStart - quarter+1; idet--) {
     vector<DetGroup> tmp1;
     vector<DetGroup> newResult;
@@ -300,7 +305,7 @@ PixelForwardLayer::searchNeighbors( const TrajectoryStateOnSurface& tsos,
       // maybe also add shallow crossing angle test here???
       if (!Adder::add( *neighbor, tsos, prop, est, tmp1)) break;
       int theHelicity = computeHelicity(theComps[theBinFinder_inner.binIndex(idet)],
-  				      theComps[theBinFinder_inner.binIndex(idet+1)] );
+                                        theComps[theBinFinder_inner.binIndex(idet+1)] );
       vector<DetGroup> tmp2; tmp2.swap(result);
       Merger::orderAndMergeTwoLevels( std::move(tmp1), std::move(tmp2), newResult, theHelicity, crossingSide);
     } else {
@@ -309,7 +314,7 @@ PixelForwardLayer::searchNeighbors( const TrajectoryStateOnSurface& tsos,
       // maybe also add shallow crossing angle test here???
       if (!Adder::add( *neighbor, tsos, prop, est, tmp1)) break;
       int theHelicity = computeHelicity(theComps[(theBinFinder_outer.binIndex(idet)) + _num_innerpanels],
-  				      theComps[(theBinFinder_outer.binIndex(idet+1)) + _num_innerpanels] );
+                                        theComps[(theBinFinder_outer.binIndex(idet+1)) + _num_innerpanels] );
       vector<DetGroup> tmp2; tmp2.swap(result);
       Merger::orderAndMergeTwoLevels( std::move(tmp1), std::move(tmp2), newResult, theHelicity, crossingSide);
     }
@@ -324,7 +329,7 @@ PixelForwardLayer::searchNeighbors( const TrajectoryStateOnSurface& tsos,
       // maybe also add shallow crossing angle test here???
       if (!Adder::add( *neighbor, tsos, prop, est, tmp1)) break;
       int theHelicity = computeHelicity(theComps[theBinFinder_inner.binIndex(idet-1)],
-  				      theComps[theBinFinder_inner.binIndex(idet)] );
+                                        theComps[theBinFinder_inner.binIndex(idet)] );
       vector<DetGroup> tmp2; tmp2.swap(result);
       Merger::orderAndMergeTwoLevels(std::move(tmp2), std::move(tmp1), newResult, theHelicity, crossingSide);
     } else {
@@ -333,7 +338,7 @@ PixelForwardLayer::searchNeighbors( const TrajectoryStateOnSurface& tsos,
       // maybe also add shallow crossing angle test here???
       if (!Adder::add( *neighbor, tsos, prop, est, tmp1)) break;
       int theHelicity = computeHelicity(theComps[(theBinFinder_outer.binIndex(idet-1)) + _num_innerpanels],
-  				      theComps[(theBinFinder_outer.binIndex(idet)) + _num_innerpanels] );
+                                        theComps[(theBinFinder_outer.binIndex(idet)) + _num_innerpanels] );
       vector<DetGroup> tmp2; tmp2.swap(result);
       Merger::orderAndMergeTwoLevels(std::move(tmp2), std::move(tmp1), newResult, theHelicity, crossingSide);
     }
@@ -341,17 +346,17 @@ PixelForwardLayer::searchNeighbors( const TrajectoryStateOnSurface& tsos,
   }
 }
 
-int 
+int
 PixelForwardLayer::computeHelicity(const GeometricSearchDet* firstBlade,const GeometricSearchDet* secondBlade) const
-{  
+{
   if( fabs(firstBlade->position().z()) < fabs(secondBlade->position().z()) ) return 0;
   return 1;
 }
 
-PixelForwardLayer::SubTurbineCrossings 
+PixelForwardLayer::SubTurbineCrossings
 PixelForwardLayer::computeCrossings( const TrajectoryStateOnSurface& startingState,
 				     PropagationDirection propDir, bool innerDisk) const
-{  
+{
   typedef MeasurementEstimator::Local2DVector Local2DVector;
 
   HelixPlaneCrossing::PositionType startPos( startingState.globalPosition());
@@ -362,74 +367,161 @@ PixelForwardLayer::computeCrossings( const TrajectoryStateOnSurface& startingSta
 					       propDir);
 
   pair<bool,double> thePath = turbineCrossing.pathLength( specificSurface() );
-  
+
   if (!thePath.first) {
-    //edm::LogInfo("TkDetLayers") << "ERROR in PixelForwardLayer: disk not crossed by track" ;
     return SubTurbineCrossings();
   }
 
   HelixPlaneCrossing::PositionType  turbinePoint( turbineCrossing.position(thePath.second));
   HelixPlaneCrossing::DirectionType turbineDir( turbineCrossing.direction(thePath.second));
   int closestIndex = 0;
-  if(innerDisk)
-    closestIndex = theBinFinder_inner.binIndex(turbinePoint.phi());
-  else
-    closestIndex = theBinFinder_outer.binIndex(turbinePoint.phi());
-
-  HelixArbitraryPlaneCrossing2Order theBladeCrossing(turbinePoint, turbineDir, rho);
-
-  float closestDist = 0;
   int nextIndex = 0;
-  if(innerDisk) {
-    const BoundPlane& closestPlane( static_cast<const BoundPlane&>( 
-      theComps[closestIndex]->surface()));
+  // The next if is needed in order to properly treat the PhaseII
+  // geometry in the forward region using a blade-like geometry on a
+  // real ring-based one. As ugly as it could be. 20 [cm] is the
+  // separation in R between true forward pixel blades (inner
+  // w.r.t. 20) and the outer tracker rings (outer w.r.t. 20).
+  if (turbinePoint.perp() < 20) {
+    if(innerDisk)
+      closestIndex = theBinFinder_inner.binIndex(turbinePoint.phi());
+    else
+      closestIndex = theBinFinder_outer.binIndex(turbinePoint.phi());
 
-    pair<bool,double> theClosestBladePath = theBladeCrossing.pathLength( closestPlane );
-    LocalPoint closestPos = closestPlane.toLocal(GlobalPoint(theBladeCrossing.position(theClosestBladePath.second)) );
-    
-    closestDist = closestPos.x(); // use fact that local X perp to global Y
+    HelixArbitraryPlaneCrossing2Order theBladeCrossing(turbinePoint, turbineDir, rho);
 
-    nextIndex = PhiLess()( closestPlane.position().phi(), turbinePoint.phi()) ? 
-      closestIndex+1 : closestIndex-1;
+    float closestDist = 0;
+    if(innerDisk) {
+      const BoundPlane& closestPlane( static_cast<const BoundPlane&>(
+          theComps[closestIndex]->surface()));
+
+      pair<bool,double> theClosestBladePath = theBladeCrossing.pathLength( closestPlane );
+      LocalPoint closestPos = closestPlane.toLocal(GlobalPoint(theBladeCrossing.position(theClosestBladePath.second)) );
+      closestDist = closestPos.x();
+      // use fact that local X perp to global Y
+      nextIndex = PhiLess()( closestPlane.position().phi(), turbinePoint.phi()) ?
+          closestIndex+1 : closestIndex-1;
+    } else {
+      const BoundPlane& closestPlane( static_cast<const BoundPlane&>(
+          theComps[closestIndex + _num_innerpanels]->surface()));
+
+      pair<bool,double> theClosestBladePath = theBladeCrossing.pathLength( closestPlane );
+      LocalPoint closestPos = closestPlane.toLocal(GlobalPoint(theBladeCrossing.position(theClosestBladePath.second)) );
+      closestDist = closestPos.x();
+      // use fact that local X perp to global Y
+      nextIndex = PhiLess()( closestPlane.position().phi(), turbinePoint.phi()) ?
+          closestIndex+1 : closestIndex-1;
+    }
+
+    float nextDist = 0;
+    if(innerDisk) {
+      const BoundPlane& nextPlane( static_cast<const BoundPlane&>(
+          theComps[ theBinFinder_inner.binIndex(nextIndex)]->surface()));
+      pair<bool,double> theNextBladePath    = theBladeCrossing.pathLength( nextPlane );
+      LocalPoint nextPos = nextPlane.toLocal(GlobalPoint(theBladeCrossing.position(theNextBladePath.second)) );
+      nextDist = nextPos.x();
+    } else {
+      const BoundPlane& nextPlane( static_cast<const BoundPlane&>(
+          theComps[ theBinFinder_outer.binIndex(nextIndex) + _num_innerpanels]->surface()));
+      pair<bool,double> theNextBladePath    = theBladeCrossing.pathLength( nextPlane );
+      LocalPoint nextPos = nextPlane.toLocal(GlobalPoint(theBladeCrossing.position(theNextBladePath.second)) );
+      nextDist = nextPos.x();
+    }
+    if (fabs(closestDist) < fabs(nextDist)) {
+      return SubTurbineCrossings( closestIndex, nextIndex, nextDist);
+    }
+    else {
+      return SubTurbineCrossings( nextIndex, closestIndex, closestDist);
+    }
   } else {
-    const BoundPlane& closestPlane( static_cast<const BoundPlane&>( 
-      theComps[closestIndex + _num_innerpanels]->surface()));
-
-    pair<bool,double> theClosestBladePath = theBladeCrossing.pathLength( closestPlane );
-    LocalPoint closestPos = closestPlane.toLocal(GlobalPoint(theBladeCrossing.position(theClosestBladePath.second)) );
-    
-    closestDist = closestPos.x(); // use fact that local X perp to global Y
-
-    nextIndex = PhiLess()( closestPlane.position().phi(), turbinePoint.phi()) ? 
-      closestIndex+1 : closestIndex-1;
-  }
-
-  float nextDist = 0;
-  if(innerDisk) {
-    const BoundPlane& nextPlane( static_cast<const BoundPlane&>( 
-      theComps[ theBinFinder_inner.binIndex(nextIndex)]->surface()));
-    pair<bool,double> theNextBladePath    = theBladeCrossing.pathLength( nextPlane );
-    LocalPoint nextPos = nextPlane.toLocal(GlobalPoint(theBladeCrossing.position(theNextBladePath.second)) );
-    nextDist = nextPos.x();
-  } else {
-    const BoundPlane& nextPlane( static_cast<const BoundPlane&>( 
-      theComps[ theBinFinder_outer.binIndex(nextIndex) + _num_innerpanels]->surface()));
-    pair<bool,double> theNextBladePath    = theBladeCrossing.pathLength( nextPlane );
-    LocalPoint nextPos = nextPlane.toLocal(GlobalPoint(theBladeCrossing.position(theNextBladePath.second)) );
-    nextDist = nextPos.x();
-  }
-
-  if (fabs(closestDist) < fabs(nextDist)) {
-    return SubTurbineCrossings( closestIndex, nextIndex, nextDist);
-  }
-  else {
-    return SubTurbineCrossings( nextIndex, closestIndex, closestDist);
+    // Special treatment is needed in the PhaseII geometry to properly
+    // handle the forward region of the outer tracker pretending to
+    // use a blade-like geometry on a ring-based one. The main
+    // difference here is that the check it not done on phi first, and
+    // then on R, but it is done directly on R, phi being derived
+    // later on in cascade. In order to do that, the PixelBlade has
+    // been extended to include 2 pair<float, float>, each
+    // representing the range of its front and back component. To be
+    // noted also that the front and back component of a "pixel blade"
+    // in the case of the outer Tracker has no concept of front and
+    // back, but are simply rings at different radii, hence the need
+    // to have 2 pairs into PixelBlade. In particular rings are joint
+    // into a single blade following the counter-intuitive logic 0-7,
+    // 1-8, 2-9, etc..., i.e. using the innermost ring together w/ the
+    // middle one, and so on (see PixelForwardLayerBuilder for further
+    // insight). To get things even more complex, we have to manually
+    // take care of assignign the indices 'closestIndex' and
+    // 'nextIndex' in such a way that the logic behind them did not
+    // change for the rest of the code. The search is now done
+    // everywhere everytime, guessing a-posteriori if the index
+    // belongs to the inner or outer part, and hence adjusting the
+    // indices accordingly (offsetting them of _num_innerpanels).
+    closestIndex = 0;
+    nextIndex = 0;
+    float target_radius = turbinePoint.perp();
+    bool found = false;
+    bool foundNext = false;
+    // The check is done every time on both sides of the blade, front
+    // and back, assigning a posteriori the correct index to the
+    // respective category, either innerDisk or outerDisk. Both checks
+    // have to be performed at the same time since not all indices are
+    // accessible from the different regions (innerdisk has access to
+    // 0-_num_innerpanels, while outer to the remainings).
+    for (auto blade : theComps) {
+      ++closestIndex;
+      if (dynamic_cast<const PixelBlade*>(blade)->inRange(target_radius, innerDisk) ||
+          dynamic_cast<const PixelBlade*>(blade)->inRange(target_radius, !innerDisk)) {
+        found = true;
+        break;
+      }
+    }
+    int counter = 0;
+    nextIndex = closestIndex;
+    // Do not comment this second loop since potentially it could find
+    // overlapping regions on different rings. In principle, to be
+    // verified in practice.
+    if (found) {
+      for (auto blade : theComps) {
+        // do not test what has been already checked.
+        if (counter < closestIndex) {
+          ++counter;
+          continue ;
+        }
+        ++nextIndex;
+      if (dynamic_cast<const PixelBlade*>(blade)->inRange(target_radius, innerDisk) ||
+          dynamic_cast<const PixelBlade*>(blade)->inRange(target_radius, !innerDisk)) {
+          foundNext = true;
+          break;
+        }
+      }
+    }
+    --closestIndex;
+    --nextIndex;
+    if (!found && !foundNext) {
+      closestIndex = nextIndex = 0;
+    }
+    if (found && !foundNext) {
+      if (closestIndex >= (int)_num_innerpanels) {
+        closestIndex = innerDisk ? 0 : closestIndex - _num_innerpanels;
+      }
+      // Carefully avoid having closestIndex == nextIndex, since this
+      // will trigger a likely double counting of hits.
+      nextIndex = closestIndex - 1;
+    }
+    if (found && foundNext) {
+      if (closestIndex >= (int)_num_innerpanels) {
+        closestIndex = innerDisk ? 0 : closestIndex - _num_innerpanels;
+      }
+      if (nextIndex >= (int)_num_innerpanels) {
+        nextIndex = innerDisk ? 0 : nextIndex - _num_innerpanels;
+      }
+    }
+    return SubTurbineCrossings( closestIndex, nextIndex, 1.);
   }
 }
 
-float 
-PixelForwardLayer::computeWindowSize( const GeomDet* det, 
-				      const TrajectoryStateOnSurface& tsos, 
+float
+PixelForwardLayer::computeWindowSize( const GeomDet* det,
+				      const TrajectoryStateOnSurface& tsos,
 				      const MeasurementEstimator& est) const
 {
   return est.maximalLocalDisplacement(tsos, det->surface()).x();

--- a/RecoTracker/TkDetLayers/src/PixelForwardLayer.h
+++ b/RecoTracker/TkDetLayers/src/PixelForwardLayer.h
@@ -7,7 +7,7 @@
 #include "Utilities/BinningTools/interface/PeriodicBinFinderInPhi.h"
 
 
-/** A concrete implementation for PixelForward layer 
+/** A concrete implementation for PixelForward layer
  *  built out of ForwardPixelBlade
  */
 
@@ -16,13 +16,13 @@ class PixelForwardLayer GCC11_FINAL : public ForwardDetLayer, public GeometricSe
  public:
   PixelForwardLayer(std::vector<const PixelBlade*>& blades);
   ~PixelForwardLayer();
-  
+
   // GeometricSearchDet interface
-  
+
   virtual const std::vector<const GeomDet*>& basicComponents() const {return theBasicComps;}
 
   virtual const std::vector<const GeometricSearchDet*>& components() const {return theComps;}
-  
+
   void groupedCompatibleDetsV( const TrajectoryStateOnSurface& tsos,
 			       const Propagator& prop,
 			       const MeasurementEstimator& est,
@@ -30,39 +30,39 @@ class PixelForwardLayer GCC11_FINAL : public ForwardDetLayer, public GeometricSe
 
   // DetLayer interface
   virtual SubDetector subDetector() const {return GeomDetEnumerators::PixelEndcap;}
-  
 
- private:  
+
+ private:
   // methods for groupedCompatibleDets implementation
   int computeHelicity(const GeometricSearchDet* firstBlade,const GeometricSearchDet* secondBlade) const;
 
   struct SubTurbineCrossings {
     SubTurbineCrossings(): isValid(false){};
-    SubTurbineCrossings( int ci, int ni, float nd) : 
+    SubTurbineCrossings( int ci, int ni, float nd) :
       isValid(true),closestIndex(ci), nextIndex(ni), nextDistance(nd) {}
-    
+
     bool  isValid;
     int   closestIndex;
     int   nextIndex;
     float nextDistance;
   };
-  
+
   void searchNeighbors( const TrajectoryStateOnSurface& tsos,
 			const Propagator& prop,
 			const MeasurementEstimator& est,
 			const SubTurbineCrossings& crossings,
-			float window, 
+			float window,
 			std::vector<DetGroup>& result,
-			bool innerDisk) const;  
+			bool innerDisk) const;
 
-  SubTurbineCrossings 
+  SubTurbineCrossings
     computeCrossings( const TrajectoryStateOnSurface& startingState,
 		      PropagationDirection propDir,bool innerDisk) const;
 
-  float computeWindowSize( const GeomDet* det, 
-			   const TrajectoryStateOnSurface& tsos, 
+  float computeWindowSize( const GeomDet* det,
+			   const TrajectoryStateOnSurface& tsos,
 			   const MeasurementEstimator& est) const;
-  
+
  private:
   typedef PeriodicBinFinderInPhi<double>   BinFinderType;
   // need separate objects for inner and outer disk
@@ -82,4 +82,4 @@ class PixelForwardLayer GCC11_FINAL : public ForwardDetLayer, public GeometricSe
 
 
 #pragma GCC visibility pop
-#endif 
+#endif

--- a/RecoTracker/TkDetLayers/src/PixelForwardLayerBuilder.cc
+++ b/RecoTracker/TkDetLayers/src/PixelForwardLayerBuilder.cc
@@ -6,32 +6,50 @@ using namespace edm;
 using namespace std;
 
 ForwardDetLayer* PixelForwardLayerBuilder::build(const GeometricDet* aPixelForwardLayer,
-						   const TrackerGeometry* theGeomDetGeometry){
+                                                 const TrackerGeometry* theGeomDetGeometry) {
   vector<const GeometricDet*>  theGeometricPanels = aPixelForwardLayer->components();
   int panelsSize = theGeometricPanels.size();
 
   /*
-  for(vector<const GeometricDet*>::const_iterator it= theGeometricPanels.begin(); 
-      it!=theGeometricPanels.end();it++){
-    
-    edm::LogInfo(TkDetLayers) << "panel.phi(): " << (*it)->positionBounds().phi() << " , " 
-	 << "panel.z():   " << (*it)->positionBounds().z()   << " , "
-	 << "comp.size(): " << (*it)->components().size()    ;    
+  int num = 0;
+  for(vector<const GeometricDet*>::const_iterator it= theGeometricPanels.begin();
+      it!=theGeometricPanels.end(); it++, ++num) {
+    edm::LogInfo("TkDetLayers") << "PanelsSize: " << panelsSize << " , "
+                                << "PanelNum: " << num  << " , "
+                                << "panel.phi(): " << (*it)->positionBounds().phi()  << " , "
+                                << "panel.z():   " << (*it)->positionBounds().z()    << " , "
+                                << "panel.y():   " << (*it)->positionBounds().y() << " , "
+                                << "panel.x():   " << (*it)->positionBounds().x() << " , "
+                                << "panel.r():   " << (*it)->positionBounds().perp() << " , "
+                                << "panel.rmax():   " << (*it)->bounds()->rSpan().second << " , "
+                                << "comp.size(): " << (*it)->components().size();
   }
   */
 
-  //edm::LogInfo(TkDetLayers) << "pixelFwdLayer.panels().size(): " << panelsSize ;  
+  //edm::LogInfo(TkDetLayers) << "pixelFwdLayer.panels().size(): " << panelsSize ;
 
   vector<const PixelBlade*> theBlades;
   PixelBladeBuilder myBladeBuilder;
 
-  for(int i=0; i< (panelsSize/2); i++){
+  for(int i=0; i< (panelsSize/2); i++) {
     theBlades.push_back( myBladeBuilder.build( theGeometricPanels[i],
 					       theGeometricPanels[i+(panelsSize/2)],
 					       theGeomDetGeometry ) );
   }
-  
-  if ( aPixelForwardLayer->type()==GeometricDet::PixelEndCapPhase1 ) 
+  // Hack to recover the outermost ring (15) of the PhaseII outer
+  // tracker. Since panelsSize is odd, the last one is cut of by the
+  // previous integer division by 2. It is somewhat *arbitrarily*
+  // coupled with the innermost panel, mainly to be sure that it will
+  // fall into the opposite side of the division that is internally
+  // done in the PixelForwardLayer class: if they are opposite, there
+  // will be no hits duplication while doing TSB propagation.
+  if (panelsSize & 0x1) {
+    theBlades.push_back( myBladeBuilder.build( theGeometricPanels[0],
+					       theGeometricPanels[panelsSize-1],
+					       theGeomDetGeometry ) );
+  }
+
+  if ( aPixelForwardLayer->type()==GeometricDet::PixelEndCapPhase1 )
     return new PixelForwardLayerPhase1(theBlades);
-  return new PixelForwardLayer(theBlades);  
+  return new PixelForwardLayer(theBlades);
 }


### PR DESCRIPTION
Recover lost hits-on-track in the forward region.

See https://indico.cern.ch/event/314557/contribution/6/material/slides/0.pdf for further details.
