### PR TITLE
Add customisation without EE

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1175,19 +1175,19 @@ upgradeCustoms={ '2017' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.
                  'BE5DFast' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.fastsimPhase2',
                  'BE5DForwardFast' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.fastsimPhase2',
                  'Extended2023' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023',
-                 'Extended2023HGCalMuon' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023',
-                 'Extended2023SHCal' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023',
-                 'Extended2023SHCal4Eta' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023',
+                 'Extended2023HGCalMuon' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023NoEE',
+                 'Extended2023SHCal' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023NoEE',
+                 'Extended2023SHCal4Eta' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023NoEE',
                  'Extended2023TTI' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023TTI',
                  'Extended2023Muon' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023Muon',
                  'Extended2023Muon4Eta' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023Muon',
                  'Extended2023CFCal' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023',
                  'Extended2023CFCal4Eta' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023',
                  'Extended2023Pixel' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023Pixel',
-                 'Extended2023SHCalNoTaper' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023',
-                 'Extended2023SHCalNoTaper4Eta' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023',
-                 'Extended2023HGCal' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023',
-                 'Extended2023HGCalMuon4Eta' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023'
+                 'Extended2023SHCalNoTaper' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023NoEE',
+                 'Extended2023SHCalNoTaper4Eta' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023NoEE',
+                 'Extended2023HGCal' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023NoEE',
+                 'Extended2023HGCalMuon4Eta' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023NoEE'
                  }
 ### remember that you need to add a new step for phase 2 to include the track trigger
 ### remember that you need to add fastsim

--- a/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
@@ -101,6 +101,12 @@ def cust_2023(process):
     process=customise_rpc(process)
     return process
 
+def cust_2023NoEE(process):
+    process=cust_2023(process)
+    if hasattr(process,'L1simulation_step'):
+        process.simEcalTriggerPrimitiveDigis.BarrelOnly = cms.bool(True)
+    return process
+
 def cust_2023Pixel(process):
     process=customisePostLS1(process)
     process=customiseBE5DPixel10D(process)

--- a/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
@@ -105,6 +105,8 @@ def cust_2023NoEE(process):
     process=cust_2023(process)
     if hasattr(process,'L1simulation_step'):
         process.simEcalTriggerPrimitiveDigis.BarrelOnly = cms.bool(True)
+    if hasattr(process,'digitisation_step'):
+    	process.mix.digitizers.ecal.accumulatorType = cms.string('EcalPhaseIIDigiProducer')
     return process
 
 def cust_2023Pixel(process):


### PR DESCRIPTION
Stops the ECal trigger primitive producer from using the endcaps in scenarios without EE (Shashlik and HGCal).  This was discussed with @kpedro88 and @ianna in the comments for #3229, I've only just gotten around to adding it.  Previously the Shashlik (EDIT - I meant HGCal) scenarios failed in step 2 with:

```
----- Begin Fatal Exception 22-Apr-2014 11:20:00 CEST-----------------------
An exception of category 'NoRecord' occurred while
   [0] Processing run: 1
   [1] Running path 'digitisation_step'
   [2] Calling beginRun for module EcalTrigPrimProducer/'simEcalTriggerPrimitiveDigis'
Exception Message:
No "EcalEndcapGeometryRecord" record found in the EventSetup.
 Please add an ESSource or ESProducer that delivers such a record.
----- End Fatal Exception -------------------------------------------------
```

This fixes that error, although step 2 still fails with:

```
cmsRun: <build path>/src/SimCalorimetry/EcalSimAlgos/src/ESDigitizer.cc:70: void ESDigitizer::setGain(int): Assertion `0 != m_detIds && 0 != m_detIds->size()' failed.
```
