### PR TITLE
Trigger photon fix

### DIFF
--- a/HLTrigger/Egamma/src/HLTDisplacedEgammaFilter.cc
+++ b/HLTrigger/Egamma/src/HLTDisplacedEgammaFilter.cc
@@ -110,7 +110,8 @@ HLTDisplacedEgammaFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& i
 
   std::vector<edm::Ref<reco::RecoEcalCandidateCollection> > recoecalcands;
   PrevFilterOutput->getObjects(TriggerCluster, recoecalcands);
-
+  if(recoecalcands.empty()) PrevFilterOutput->getObjects(TriggerPhoton, recoecalcands);
+  
   // look at all candidates,  check cuts and add to filter object
   int n(0);
 

--- a/HLTrigger/Egamma/src/HLTEgammaCaloIsolFilterPairs.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaCaloIsolFilterPairs.cc
@@ -81,6 +81,7 @@ HLTEgammaCaloIsolFilterPairs::hltFilter(edm::Event& iEvent, const edm::EventSetu
 
   std::vector<edm::Ref<reco::RecoEcalCandidateCollection> > recoecalcands;
   PrevFilterOutput->getObjects(TriggerCluster, recoecalcands);
+  if(recoecalcands.empty()) PrevFilterOutput->getObjects(TriggerPhoton, recoecalcands);
 
   //get hold of ecal isolation association map
   edm::Handle<reco::RecoEcalCandidateIsolationMap> depMap;

--- a/HLTrigger/Egamma/src/HLTEgammaDoubleEtPhiFilter.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaDoubleEtPhiFilter.cc
@@ -69,7 +69,7 @@ HLTEgammaDoubleEtPhiFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup&
 
   std::vector<edm::Ref<reco::RecoEcalCandidateCollection> >  mysortedrecoecalcands;
   PrevFilterOutput->getObjects(TriggerCluster,  mysortedrecoecalcands);
-  if(mysortedrecoecalcands.empty()) PrevFilterOutput->getObjects(TriggerCluster,mysortedrecoecalcands);  //we dont know if its type trigger cluster or trigger photon
+  if(mysortedrecoecalcands.empty()) PrevFilterOutput->getObjects(TriggerPhoton,mysortedrecoecalcands);  //we dont know if its type trigger cluster or trigger photon
   // Sort the list
   std::sort(mysortedrecoecalcands.begin(), mysortedrecoecalcands.end(), EgammaHLTEtSortCriterium());
   edm::Ref<reco::RecoEcalCandidateCollection> ref1, ref2;

--- a/HLTrigger/Egamma/src/HLTEgammaEtFilterPairs.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaEtFilterPairs.cc
@@ -65,6 +65,7 @@ HLTEgammaEtFilterPairs::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSe
 
   std::vector<edm::Ref<reco::RecoEcalCandidateCollection> > recoecalcands;                // vref with your specific C++ collection type
   PrevFilterOutput->getObjects(TriggerCluster, recoecalcands);
+  if(recoecalcands.empty()) PrevFilterOutput->getObjects(TriggerPhoton, recoecalcands);
   // they list should be interpreted as pairs:
   // <recoecalcands[0],recoecalcands[1]>
   // <recoecalcands[2],recoecalcands[3]>

--- a/HLTrigger/Egamma/src/HLTElectronEoverpFilterRegional.cc
+++ b/HLTrigger/Egamma/src/HLTElectronEoverpFilterRegional.cc
@@ -68,7 +68,7 @@ HLTElectronEoverpFilterRegional::hltFilter(edm::Event& iEvent, const edm::EventS
 
   std::vector<edm::Ref<reco::RecoEcalCandidateCollection> > recoecalcands;
   PrevFilterOutput->getObjects(TriggerCluster, recoecalcands);
-
+  if(recoecalcands.empty()) PrevFilterOutput->getObjects(TriggerPhoton, recoecalcands);
    // Get the HLT electrons from EgammaHLTPixelMatchElectronProducers
   edm::Handle<reco::ElectronCollection> electronIsolatedHandle;
   iEvent.getByToken(electronIsolatedToken_,electronIsolatedHandle);

--- a/HLTrigger/Egamma/src/HLTPMMassFilter.cc
+++ b/HLTrigger/Egamma/src/HLTPMMassFilter.cc
@@ -137,6 +137,7 @@ HLTPMMassFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, tr
 
     vector< Ref< RecoEcalCandidateCollection > > scs;
     PrevFilterOutput->getObjects(TriggerCluster, scs);
+    if(scs.empty()) PrevFilterOutput->getObjects(TriggerPhoton, scs);  //we dont know if its type trigger cluster or trigger photon
 
     for (unsigned int i=0; i<scs.size(); i++) {
 


### PR DESCRIPTION
The HLTPMMassFilter needs protection against objects being of type TriggerPhoton rather than type TriggerCluster for upcoming HLT menus and needs to go in. I also took the opportunity to protect the remaining E/gamma filters which were unprotected against this.  

Explanation of the issue:
Due to a rather poor design decision made before my time (yes its really that old), E/gamma trigger objects use TriggerClusters for non-saved RecoEcalCandidates and TriggerPhotons for saved RecoEcalCandidates. You need to look for both as there is no way to know for sure which the previous filter will output as it depends on whether saveTags=true for the previous filter. We probably should have fixed this at the source (and say this every time the issue comes up) but I'm concerned a core change in the framework will need a lot of testing for edge cases as it is not obvious everywhere this is used.  Just checking for both is an accepted solution that has been running fine for all of data taking. It is very clear when this bug comes in as the filter will accept zero events.
