### PR TITLE
Emulated me0 segment producer bugfix

### DIFF
--- a/FastSimulation/Muons/plugins/EmulatedME0SegmentProducer.cc
+++ b/FastSimulation/Muons/plugins/EmulatedME0SegmentProducer.cc
@@ -67,7 +67,7 @@ void EmulatedME0SegmentProducer::produce(edm::Event& ev, const edm::EventSetup& 
       if ( (CurrentParticle.status()==1) && ( (CurrentParticle.pdgId()==13)  || (CurrentParticle.pdgId()==-13) ) ){  
 
 	//Setup
-	if (CurrentParticle.pz()==0) continue;
+	if (fabs(CurrentParticle.pz()<0.00001)) continue;
 
 	float zSign  = CurrentParticle.pz()/fabs(CurrentParticle.pz());
 


### PR DESCRIPTION
Made a slight change to the bug fix from before, safer to not use ==0
