### PR TITLE
Fixed uninitialized variable in PFTau3ProngSummary

### DIFF
--- a/DataFormats/TauReco/src/PFTau3ProngSummary.cc
+++ b/DataFormats/TauReco/src/PFTau3ProngSummary.cc
@@ -142,7 +142,7 @@ double PFTau3ProngSummary::M_23()const{
 int PFTau3ProngSummary::Tau_Charge()const{
   for(unsigned int i=0;i<has3ProngSolution_.size();i++){
     if(has3ProngSolution_[i]==true){
-      int charge;
+      int charge = 0;
       for(unsigned int j=0;j<daughter_p4_[i].size();j++)charge+=daughter_charge_[i][j];
       return charge;
     }


### PR DESCRIPTION
PFTau3ProngSummary::Tau_Charge was returning an undefined value
since it was using a uninitialized stack variable as its charge
summing variable. The problem was found by the static analyzer.
