### PR TITLE
Removed unnecessary mutables from FP420 cluster classes

### DIFF
--- a/DataFormats/FP420Cluster/interface/ClusterCollectionFP420.h
+++ b/DataFormats/FP420Cluster/interface/ClusterCollectionFP420.h
@@ -35,10 +35,10 @@ class ClusterCollectionFP420 {
   void clear();
   
  private:
-  mutable std::vector<ClusterFP420> container_;
-  mutable Registry map_;
+  std::vector<ClusterFP420> container_;
+  Registry map_;
 
-  mutable ClusterFP420Container clusterMap_; 
+  ClusterFP420Container clusterMap_; 
 };
 
 #endif // 

--- a/DataFormats/FP420Cluster/interface/RecoCollectionFP420.h
+++ b/DataFormats/FP420Cluster/interface/RecoCollectionFP420.h
@@ -35,10 +35,10 @@ class RecoCollectionFP420 {
     void clear();
     
  private:
-    mutable std::vector<RecoFP420> container_;
-    mutable Registry map_;
+    std::vector<RecoFP420> container_;
+    Registry map_;
     
-    mutable RecoFP420Container trackMap_; 
+    RecoFP420Container trackMap_; 
 };
 
 #endif // 

--- a/DataFormats/FP420Cluster/interface/TrackCollectionFP420.h
+++ b/DataFormats/FP420Cluster/interface/TrackCollectionFP420.h
@@ -35,10 +35,10 @@ class TrackCollectionFP420 {
     void clear();
     
  private:
-    mutable std::vector<TrackFP420> container_;
-    mutable Registry map_;
+    std::vector<TrackFP420> container_;
+    Registry map_;
     
-    mutable TrackFP420Container trackMap_; 
+    TrackFP420Container trackMap_; 
 };
 
 #endif // 


### PR DESCRIPTION
These unneeded mutables were causing the static analyzer to complain.
Removing them caused no other changes to the code.
