### PR TITLE
removed unnecessary mutables from PixelDigiCollection

### DIFF
--- a/DataFormats/SiPixelDigi/interface/PixelDigiCollection.h
+++ b/DataFormats/SiPixelDigi/interface/PixelDigiCollection.h
@@ -23,8 +23,8 @@ class PixelDigiCollection {
   const std::vector<unsigned int> detIDs() const;
   
  private:
-  mutable std::vector<PixelDigi> container_;
-  mutable Registry map_;
+  std::vector<PixelDigi> container_;
+  Registry map_;
 
 };
 

--- a/DataFormats/SiPixelDigi/src/PixelDigiCollection.cc
+++ b/DataFormats/SiPixelDigi/src/PixelDigiCollection.cc
@@ -40,7 +40,11 @@ void PixelDigiCollection::put(Range input, unsigned int detID) {
 const PixelDigiCollection::Range PixelDigiCollection::get(unsigned int detID) const {
   // get Digis of detID
 
-  PixelDigiCollection::IndexRange returnIndexRange = map_[detID];
+  auto found = map_.find(detID);
+  PixelDigiCollection::IndexRange returnIndexRange{};
+  if(found != map_.end()) {
+    returnIndexRange = found->second;
+  }
 
   PixelDigiCollection::Range returnRange;
   returnRange.first  = container_.begin()+returnIndexRange.first;


### PR DESCRIPTION
The previous code was using std::map::operator[] in places where
it could use std::map::find to get the same results. Switching
to find allowed the removal of the mutables. These mutables were
causing warnings from the static analyzer and would have lead to
crashes in the threaded framework.
