### PR TITLE
Properly reset DQMStore after bookTransaction call

### DIFF
--- a/DQMServices/Core/interface/DQMStore.h
+++ b/DQMServices/Core/interface/DQMStore.h
@@ -236,12 +236,21 @@ class DQMStore
     /* If enableMultiThread is not enabled we do not set run_,
        streamId_ and moduleId_ to 0, since we rely on their default
        initialization in DQMSTore constructor. */
+    uint32_t oldRun,oldStreamId,oldModuleId;
     if (enableMultiThread_) {
+      oldRun = run_;
       run_ = run;
+      oldStreamId = streamId_;
       streamId_ = streamId;
+      oldModuleId = moduleId_;
       moduleId_ = moduleId;
     }
     f(*ibooker_);
+    if (enableMultiThread_) {
+      run_ = oldRun;
+      streamId_ = oldStreamId;
+      moduleId_ = oldModuleId;
+    }
   }
   // Signature needed in the harvesting where the booking is done
   // in the endJob. No handles to the run there. Two arguments ensure


### PR DESCRIPTION
When enableMultiThreading was turned on, the Harvesting step was
crashing. The problem was traced down to one DQMEDAnalyzer in the
job which was setting the value for run_, streamId_ and moduleId_
and then those values were being applied to legacy modules who called
DQMStore. By resetting the values of those variables back to what
they were before the call to bookTransaction the jobs now run correctly.
