### PR TITLE
Fixed double delete and memory leak in RawEventFileWriterForBU

### DIFF
--- a/EventFilter/Utilities/plugins/RawEventFileWriterForBU.cc
+++ b/EventFilter/Utilities/plugins/RawEventFileWriterForBU.cc
@@ -90,15 +90,9 @@ RawEventFileWriterForBU::RawEventFileWriterForBU(std::string const& fileName)
 
 RawEventFileWriterForBU::~RawEventFileWriterForBU()
 {
-
-  if (fileMon_ != 0)
-    delete fileMon_;
-
-  if (lumiMon_ != 0)
-    delete lumiMon_;
-
-  if (runMon_ != 0)
-    delete lumiMon_;
+  delete fileMon_;
+  delete lumiMon_;
+  delete runMon_;
 }
 
 void RawEventFileWriterForBU::doOutputEvent(FRDEventMsgView const& msg)


### PR DESCRIPTION
There was an obvious cut and paste error where the same variable was
used to do a delete and another variable was missed. This was fix.
In addition, there is no need to check for null before deleting a
pointer since delete does that itself.
NOTE: It would be better if these variables were converted to
std::unique_ptr<> so memory management would be automatic.
