### PR TITLE
7_1_X Remove false dependency in  DataFormats/TauReco to RecoVertex/VertexTools

### DIFF
--- a/DataFormats/TauReco/BuildFile.xml
+++ b/DataFormats/TauReco/BuildFile.xml
@@ -5,7 +5,6 @@
 <use   name="DataFormats/TrackReco"/>
 <use   name="DataFormats/JetReco"/>
 <use   name="DataFormats/ParticleFlowCandidate"/>
-<use   name="RecoVertex/VertexTools"/>
 <use   name="rootrflx"/>
 <use   name="rootcore"/>
 <flags LCG_DICT_HEADER="classes_hlt.h classes_1.h classes_2.h classes_3.h"/>

--- a/DataFormats/TauReco/src/PFTau3ProngSummary.cc
+++ b/DataFormats/TauReco/src/PFTau3ProngSummary.cc
@@ -1,7 +1,6 @@
 #include "DataFormats/TauReco/interface/PFTau3ProngSummary.h"
 #include "TMatrixT.h"
 #include "TMatrixTSym.h"
-#include "RecoVertex/VertexTools/interface/VertexDistance3D.h"
 #include "TVectorT.h"
 using namespace reco;
 

--- a/DataFormats/TauReco/src/PFTauTransverseImpactParameter.cc
+++ b/DataFormats/TauReco/src/PFTauTransverseImpactParameter.cc
@@ -1,7 +1,6 @@
 #include "DataFormats/TauReco/interface/PFTauTransverseImpactParameter.h"
 #include "TMatrixT.h"
 #include "TMatrixTSym.h"
-#include "RecoVertex/VertexTools/interface/VertexDistance3D.h"
 #include "TVectorT.h"
 using namespace reco;
 


### PR DESCRIPTION
The change avoid pulling new 30 dependent libraries in FWLite.
