### PR TITLE
DataFormats/PatCandidates: add missing dep on FWCore/Common

### DIFF
--- a/DataFormats/PatCandidates/BuildFile.xml
+++ b/DataFormats/PatCandidates/BuildFile.xml
@@ -1,4 +1,5 @@
 <use   name="FWCore/Utilities"/>
+<use   name="FWCore/Common"/>
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/StdDictionaries"/>
 <use   name="DataFormats/Candidate"/>


### PR DESCRIPTION
Fixes linking errors in ROOT6 IB.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
