### PR TITLE
PV@HLT

### DIFF
--- a/RecoPixelVertexing/PixelVertexFinding/interface/DivisiveVertexFinder.h
+++ b/RecoPixelVertexing/PixelVertexFinding/interface/DivisiveVertexFinder.h
@@ -33,7 +33,7 @@
 
 class DivisiveVertexFinder {
  public:
-  DivisiveVertexFinder(double track_pt_min, double track_pt_max, double track_chi2_max, double track_prob_max,
+  DivisiveVertexFinder(double track_pt_min, double track_pt_max, double track_chi2_max, double track_prob_min,
 		       double zOffset=5.0, int ntrkMin=5, bool useError=true, 
 		       double zSeparation=0.05, bool wtAverage=true, int verbosity=0);
   ~DivisiveVertexFinder();

--- a/RecoPixelVertexing/PixelVertexFinding/interface/DivisiveVertexFinder.h
+++ b/RecoPixelVertexing/PixelVertexFinding/interface/DivisiveVertexFinder.h
@@ -29,9 +29,12 @@
 //#include "CommonTools/Clustering1D/interface/DivisiveClusterizer1D.h"
 #include "RecoPixelVertexing/PixelVertexFinding/interface/DivisiveClusterizer1D.h"
 
+#include "RecoPixelVertexing/PixelVertexFinding/interface/PVClusterComparer.h"
+
 class DivisiveVertexFinder {
  public:
-  DivisiveVertexFinder(double zOffset=5.0, int ntrkMin=5, bool useError=true, 
+  DivisiveVertexFinder(double track_pt_min, double track_pt_max, double track_chi2_max, double track_prob_max,
+		       double zOffset=5.0, int ntrkMin=5, bool useError=true, 
 		       double zSeparation=0.05, bool wtAverage=true, int verbosity=0);
   ~DivisiveVertexFinder();
   
@@ -52,6 +55,9 @@ class DivisiveVertexFinder {
 
   // How loud should I be?
   int verbose_;
+
+  
+  PVClusterComparer* pvComparer_;
     
 };
 #endif

--- a/RecoPixelVertexing/PixelVertexFinding/interface/PVClusterComparer.h
+++ b/RecoPixelVertexing/PixelVertexFinding/interface/PVClusterComparer.h
@@ -17,7 +17,7 @@ class PVClusterComparer {
  public:
   /// Constructor does nothing, no data members
   PVClusterComparer();
-  PVClusterComparer(double track_pt_min, double track_pt_max, double track_chi2_max, double track_prob_max);
+  PVClusterComparer(double track_pt_min, double track_pt_max, double track_chi2_max, double track_prob_min);
    
   /// Calculate sum of square of the pT's of the tracks in the vertex
   double pTSquaredSum(const PVCluster &v) const;
@@ -30,7 +30,7 @@ class PVClusterComparer {
   const double track_pT_min_;
   const double track_pT_max_;
   const double track_chi2_max_;
-  const double track_prob_max_;
+  const double track_prob_min_;
 
 };
 #endif

--- a/RecoPixelVertexing/PixelVertexFinding/interface/PVClusterComparer.h
+++ b/RecoPixelVertexing/PixelVertexFinding/interface/PVClusterComparer.h
@@ -17,6 +17,7 @@ class PVClusterComparer {
  public:
   /// Constructor does nothing, no data members
   PVClusterComparer();
+  PVClusterComparer(double track_pt_min, double track_pt_max, double track_chi2_max, double track_prob_max);
    
   /// Calculate sum of square of the pT's of the tracks in the vertex
   double pTSquaredSum(const PVCluster &v) const;
@@ -25,5 +26,11 @@ class PVClusterComparer {
   /// Use this operator in a std::sort to sort them in decreasing sumPt
   bool operator() (const PVCluster &v1, const PVCluster &v2) const;
   bool operator() (const reco::Vertex &v1, const reco::Vertex &v2) const;
+
+  const double track_pT_min_;
+  const double track_pT_max_;
+  const double track_chi2_max_;
+  const double track_prob_max_;
+
 };
 #endif

--- a/RecoPixelVertexing/PixelVertexFinding/interface/PVClusterComparer.h
+++ b/RecoPixelVertexing/PixelVertexFinding/interface/PVClusterComparer.h
@@ -20,12 +20,16 @@ class PVClusterComparer {
   PVClusterComparer(double track_pt_min, double track_pt_max, double track_chi2_max, double track_prob_min);
    
   /// Calculate sum of square of the pT's of the tracks in the vertex
-  double pTSquaredSum(const PVCluster &v) const;
-  double pTSquaredSum(const reco::Vertex &v) const;
+  double pTSquaredSum(const PVCluster &v);
+  double pTSquaredSum(const reco::Vertex &v);
+  void setChisquareQuantile();
+  void updateChisquareQuantile(size_t ndof);
 
   /// Use this operator in a std::sort to sort them in decreasing sumPt
-  bool operator() (const PVCluster &v1, const PVCluster &v2) const;
-  bool operator() (const reco::Vertex &v1, const reco::Vertex &v2) const;
+  bool operator() (const PVCluster &v1, const PVCluster &v2);
+  bool operator() (const reco::Vertex &v1, const reco::Vertex &v2);
+
+  std::vector<double> maxChi2_;
 
   const double track_pT_min_;
   const double track_pT_max_;

--- a/RecoPixelVertexing/PixelVertexFinding/python/PixelVertexes_cfi.py
+++ b/RecoPixelVertexing/PixelVertexFinding/python/PixelVertexes_cfi.py
@@ -15,7 +15,7 @@ pixelVertices = cms.EDProducer("PixelVertexProducer",
     PVcomparer = cms.PSet(
         track_pt_max   = cms.double(    10.0), # SD: 20.
         track_chi2_max = cms.double(999999. ), # SD: 20
-        track_prob_max = cms.double(999999. ), # RM: 0.001
+        track_prob_min = cms.double(    -1. ), # RM: 0.001
     )
 )
 

--- a/RecoPixelVertexing/PixelVertexFinding/python/PixelVertexes_cfi.py
+++ b/RecoPixelVertexing/PixelVertexFinding/python/PixelVertexes_cfi.py
@@ -11,7 +11,12 @@ pixelVertices = cms.EDProducer("PixelVertexProducer",
     NTrkMin = cms.int32(2),
     Method2 = cms.bool(True),
     Finder = cms.string('DivisiveVertexFinder'),
-    PtMin = cms.double(1.0)
+    PtMin = cms.double(1.0),
+    PVcomparer = cms.PSet(
+        track_pt_max   = cms.double(    10.0), # SD: 20.
+        track_chi2_max = cms.double(999999. ), # SD: 20
+        track_prob_max = cms.double(999999. ), # RM: 0.001
+    )
 )
 
 

--- a/RecoPixelVertexing/PixelVertexFinding/src/DivisiveVertexFinder.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/src/DivisiveVertexFinder.cc
@@ -10,7 +10,7 @@
 #include <algorithm>
 #include <cmath>
 
-DivisiveVertexFinder::DivisiveVertexFinder(double track_pt_min, double track_pt_max, double track_chi2_max, double track_prob_max,
+DivisiveVertexFinder::DivisiveVertexFinder(double track_pt_min, double track_pt_max, double track_chi2_max, double track_prob_min,
 					   double zOffset, int ntrkMin, 
 					   bool useError, double zSeparation, bool wtAverage,
 					   int verbosity)
@@ -20,7 +20,7 @@ DivisiveVertexFinder::DivisiveVertexFinder(double track_pt_min, double track_pt_
     verbose_(verbosity)
 {
 
-  pvComparer_ = new PVClusterComparer(track_pt_min, track_pt_max, track_chi2_max, track_prob_max);
+  pvComparer_ = new PVClusterComparer(track_pt_min, track_pt_max, track_chi2_max, track_prob_min);
 
 }
 

--- a/RecoPixelVertexing/PixelVertexFinding/src/DivisiveVertexFinder.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/src/DivisiveVertexFinder.cc
@@ -3,7 +3,6 @@
 #include "RecoPixelVertexing/PixelVertexFinding/interface/PVCluster.h"
 #include "DataFormats/GeometryCommonDetAlgo/interface/Measurement1D.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "RecoPixelVertexing/PixelVertexFinding/interface/PVClusterComparer.h"
 #include "FWCore/Utilities/interface/isFinite.h"
 #include <utility>
 #include <vector>
@@ -11,7 +10,8 @@
 #include <algorithm>
 #include <cmath>
 
-DivisiveVertexFinder::DivisiveVertexFinder(double zOffset, int ntrkMin, 
+DivisiveVertexFinder::DivisiveVertexFinder(double track_pt_min, double track_pt_max, double track_chi2_max, double track_prob_max,
+					   double zOffset, int ntrkMin, 
 					   bool useError, double zSeparation, bool wtAverage,
 					   int verbosity)
   : zOffset_(zOffset), zSeparation_(zSeparation), ntrkMin_(ntrkMin), useError_(useError),
@@ -19,6 +19,8 @@ DivisiveVertexFinder::DivisiveVertexFinder(double zOffset, int ntrkMin,
     divmeth_(zOffset, ntrkMin, useError, zSeparation, wtAverage),
     verbose_(verbosity)
 {
+
+  pvComparer_ = new PVClusterComparer(track_pt_min, track_pt_max, track_chi2_max, track_prob_max);
 
 }
 
@@ -105,7 +107,8 @@ bool DivisiveVertexFinder::findVertexesAlt(const reco::TrackRefVector &trks,  //
   }
 
   // Finally, sort the vertexes in decreasing sumPtSquared
-  std::sort(vertexes.begin(), vertexes.end(), PVClusterComparer());
+  //  std::sort(vertexes.begin(), vertexes.end(), PVClusterComparer());
+  std::sort(vertexes.begin(), vertexes.end(), *pvComparer_);
 
   return true;
 }

--- a/RecoPixelVertexing/PixelVertexFinding/src/PVClusterComparer.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/src/PVClusterComparer.cc
@@ -10,6 +10,7 @@ PVClusterComparer::PVClusterComparer()
   , track_chi2_max_(9999999.)
   , track_prob_min_(-1.)
 {
+  setChisquareQuantile();
 }
 
 PVClusterComparer::PVClusterComparer(double track_pt_min, double track_pt_max, double track_chi2_max, double track_prob_min)
@@ -18,9 +19,10 @@ PVClusterComparer::PVClusterComparer(double track_pt_min, double track_pt_max, d
   , track_chi2_max_(track_chi2_max)
   , track_prob_min_(track_prob_min)
 {
+  setChisquareQuantile();
 }
 
-double PVClusterComparer::pTSquaredSum(const PVCluster &v) const {
+double PVClusterComparer::pTSquaredSum(const PVCluster &v) {
   double sum=0;
   for (size_t i=0; i<v.tracks().size(); ++i) {
 
@@ -28,26 +30,45 @@ double PVClusterComparer::pTSquaredSum(const PVCluster &v) const {
     if (pt < track_pT_min_) continue; // Don't count tracks below track_pT_min_ (2.5 GeV)
 
     // RM : exclude badly reconstructed tracks from the sum
-    if (track_prob_min_ >= 0. && track_prob_min_ <= 1.)
-      if (TMath::Prob(v.tracks()[i]->chi2(),v.tracks()[i]->ndof()) < track_prob_min_) continue ; 
+    //    if (track_prob_min_ >= 0. && track_prob_min_ <= 1.) 
+    //      if (TMath::Prob(v.tracks()[i]->chi2(),v.tracks()[i]->ndof()) < track_prob_min_) continue ; 
+    if (track_prob_min_ >= 0. && track_prob_min_ <= 1.) {      
+      size_t ndof = v.tracks()[i]->ndof();
+      if (ndof >= maxChi2_.size()) 
+	updateChisquareQuantile(ndof);
+      if (v.tracks()[i]->chi2() > maxChi2_[ndof] ) continue ;   
+    }
     if (v.tracks()[i]->normalizedChi2() > track_chi2_max_) continue;
-
     if (pt > track_pT_max_) pt = track_pT_max_;
     sum += pt*pt;
   }
   return sum;
 }
-double PVClusterComparer::pTSquaredSum(const reco::Vertex &v) const {
+
+double PVClusterComparer::pTSquaredSum(const reco::Vertex &v) {
   double sum=0;
   for (reco::Vertex::trackRef_iterator i=v.tracks_begin(), ie =v.tracks_end();
        i!=ie; ++i) {
-
+    
     double pt = (*i)->pt();
     if (pt < track_pT_min_) continue; // Don't count tracks below track_pT_min_ (2.5 GeV)
 
     // RM : exclude badly reconstructed tracks from the sum
-    if (track_prob_min_ >= 0. && track_prob_min_ <= 1.)
-      if (TMath::Prob((*i)->chi2(),(*i)->ndof()) < track_prob_min_) continue ; 
+    //    if (track_prob_min_ >= 0. && track_prob_min_ <= 1.)
+    //      if (TMath::Prob((*i)->chi2(),(*i)->ndof()) < track_prob_min_) continue ; 
+    if (track_prob_min_ >= 0. && track_prob_min_ <= 1.) {      
+      unsigned int ndof = (*i)->ndof();
+      if (ndof >= maxChi2_.size()) {
+	size_t oldsize = maxChi2_.size();
+	//	maxChi2_.resize(ndof+1);
+	for (size_t i = oldsize; i <= ndof; ++i) {
+	  double chi2 = TMath::ChisquareQuantile(1- track_prob_min_, i);
+	  maxChi2_.push_back(chi2);
+	}
+      }
+      // cut on chi2 which corresponds to the configured probability
+      if ((*i)->chi2() > maxChi2_[ndof] ) continue ;
+    }
     if ((*i)->normalizedChi2() > track_chi2_max_) continue;
     
     if (pt > track_pT_max_) pt = track_pT_max_;
@@ -56,9 +77,31 @@ double PVClusterComparer::pTSquaredSum(const reco::Vertex &v) const {
   return sum;
 }
 
-bool PVClusterComparer::operator() (const PVCluster &v1, const PVCluster &v2) const {
+void PVClusterComparer::setChisquareQuantile() {
+  std::vector<double> maxChi2(20, 0.);
+  if (track_prob_min_ >= 0. && track_prob_min_ <= 1.)
+    for (size_t ndof = 0; ndof < maxChi2_.size(); ++ndof)
+      // http://root.cern.ch/root/html/TMath.html#TMath:ChisquareQuantile  
+      maxChi2[ndof] = TMath::ChisquareQuantile(1- track_prob_min_, ndof);
+  
+  maxChi2_ = maxChi2;
+
+}
+
+void PVClusterComparer::updateChisquareQuantile(size_t ndof) {
+  
+  size_t oldsize = maxChi2_.size();
+  //	maxChi2_.resize(ndof+1);
+  for (size_t i = oldsize; i <= ndof; ++i) {
+    double chi2 = TMath::ChisquareQuantile(1- track_prob_min_, i);
+    maxChi2_.push_back(chi2);
+  }
+}
+
+
+bool PVClusterComparer::operator() (const PVCluster &v1, const PVCluster &v2) {
   return ( pTSquaredSum(v1) > pTSquaredSum(v2) );
 }
-bool PVClusterComparer::operator() (const reco::Vertex &v1, const reco::Vertex &v2) const {
+bool PVClusterComparer::operator() (const reco::Vertex &v1, const reco::Vertex &v2) {
   return ( pTSquaredSum(v1) > pTSquaredSum(v2) );
 }

--- a/RecoPixelVertexing/PixelVertexFinding/src/PVClusterComparer.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/src/PVClusterComparer.cc
@@ -36,6 +36,7 @@ double PVClusterComparer::pTSquaredSum(const PVCluster &v) {
       size_t ndof = v.tracks()[i]->ndof();
       if (ndof >= maxChi2_.size()) 
 	updateChisquareQuantile(ndof);
+      // cut on chi2 which corresponds to the configured probability
       if (v.tracks()[i]->chi2() > maxChi2_[ndof] ) continue ;   
     }
     if (v.tracks()[i]->normalizedChi2() > track_chi2_max_) continue;
@@ -58,14 +59,8 @@ double PVClusterComparer::pTSquaredSum(const reco::Vertex &v) {
     //      if (TMath::Prob((*i)->chi2(),(*i)->ndof()) < track_prob_min_) continue ; 
     if (track_prob_min_ >= 0. && track_prob_min_ <= 1.) {      
       unsigned int ndof = (*i)->ndof();
-      if (ndof >= maxChi2_.size()) {
-	size_t oldsize = maxChi2_.size();
-	//	maxChi2_.resize(ndof+1);
-	for (size_t i = oldsize; i <= ndof; ++i) {
-	  double chi2 = TMath::ChisquareQuantile(1- track_prob_min_, i);
-	  maxChi2_.push_back(chi2);
-	}
-      }
+      if (ndof >= maxChi2_.size()) 
+	updateChisquareQuantile(ndof);
       // cut on chi2 which corresponds to the configured probability
       if ((*i)->chi2() > maxChi2_[ndof] ) continue ;
     }

--- a/RecoPixelVertexing/PixelVertexFinding/src/PVClusterComparer.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/src/PVClusterComparer.cc
@@ -2,14 +2,33 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 
-PVClusterComparer::PVClusterComparer(){}
+#include "TMath.h"
+
+PVClusterComparer::PVClusterComparer()
+  : track_pT_min_  ( 2.5)
+  , track_pT_max_  (10.)
+  , track_chi2_max_(9999999.)
+  , track_prob_max_(9999999.)
+{
+}
+
+PVClusterComparer::PVClusterComparer(double track_pt_min, double track_pt_max, double track_chi2_max, double track_prob_max)
+  : track_pT_min_  (track_pt_min)
+  , track_pT_max_  (track_pt_max)
+  , track_chi2_max_(track_chi2_max)
+  , track_prob_max_(track_prob_max)
+{
+}
 
 double PVClusterComparer::pTSquaredSum(const PVCluster &v) const {
   double sum=0;
   for (unsigned int i=0; i<v.tracks().size(); ++i) {
+    // RM : exclude badly reconstructed tracks from the sum
+    if (TMath::Prob(v.tracks()[i]->chi2(),v.tracks()[i]->ndof())<track_prob_max_) continue ; 
+    if (v.tracks()[i]->normalizedChi2()<track_chi2_max_) continue;
     double pt = v.tracks()[i]->pt();
     if (pt > 2.5) { // Don't count tracks below 2.5 GeV
-      if (pt > 10.0) pt = 10.0;
+      if (pt > track_pT_max_) pt = track_pT_max_;
       sum += pt*pt;
     }
   }
@@ -18,9 +37,12 @@ double PVClusterComparer::pTSquaredSum(const PVCluster &v) const {
 double PVClusterComparer::pTSquaredSum(const reco::Vertex &v) const {
   double sum=0;
   for (reco::Vertex::trackRef_iterator i=v.tracks_begin(); i!=v.tracks_end(); ++i) {
+    // RM : exclude badly reconstructed tracks from the sum
+    if (TMath::Prob((*i)->chi2(),(*i)->ndof())<track_prob_max_) continue ; 
+    if ((*i)->normalizedChi2()<track_chi2_max_) continue;
     double pt = (*i)->pt();
     if (pt > 2.5) { // Don't count tracks below 2.5 GeV
-      if (pt > 10.0) pt = 10.0;
+      if (pt > track_pT_max_) pt = track_pT_max_;
       sum += pt*pt;
     }
   }

--- a/RecoPixelVertexing/PixelVertexFinding/src/PVClusterComparer.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/src/PVClusterComparer.cc
@@ -8,43 +8,50 @@ PVClusterComparer::PVClusterComparer()
   : track_pT_min_  ( 2.5)
   , track_pT_max_  (10.)
   , track_chi2_max_(9999999.)
-  , track_prob_max_(9999999.)
+  , track_prob_min_(-1.)
 {
 }
 
-PVClusterComparer::PVClusterComparer(double track_pt_min, double track_pt_max, double track_chi2_max, double track_prob_max)
+PVClusterComparer::PVClusterComparer(double track_pt_min, double track_pt_max, double track_chi2_max, double track_prob_min)
   : track_pT_min_  (track_pt_min)
   , track_pT_max_  (track_pt_max)
   , track_chi2_max_(track_chi2_max)
-  , track_prob_max_(track_prob_max)
+  , track_prob_min_(track_prob_min)
 {
 }
 
 double PVClusterComparer::pTSquaredSum(const PVCluster &v) const {
   double sum=0;
-  for (unsigned int i=0; i<v.tracks().size(); ++i) {
-    // RM : exclude badly reconstructed tracks from the sum
-    if (TMath::Prob(v.tracks()[i]->chi2(),v.tracks()[i]->ndof())<track_prob_max_) continue ; 
-    if (v.tracks()[i]->normalizedChi2()<track_chi2_max_) continue;
+  for (size_t i=0; i<v.tracks().size(); ++i) {
+
     double pt = v.tracks()[i]->pt();
-    if (pt > 2.5) { // Don't count tracks below 2.5 GeV
-      if (pt > track_pT_max_) pt = track_pT_max_;
-      sum += pt*pt;
-    }
+    if (pt < track_pT_min_) continue; // Don't count tracks below track_pT_min_ (2.5 GeV)
+
+    // RM : exclude badly reconstructed tracks from the sum
+    if (track_prob_min_ >= 0. && track_prob_min_ <= 1.)
+      if (TMath::Prob(v.tracks()[i]->chi2(),v.tracks()[i]->ndof()) < track_prob_min_) continue ; 
+    if (v.tracks()[i]->normalizedChi2() > track_chi2_max_) continue;
+
+    if (pt > track_pT_max_) pt = track_pT_max_;
+    sum += pt*pt;
   }
   return sum;
 }
 double PVClusterComparer::pTSquaredSum(const reco::Vertex &v) const {
   double sum=0;
-  for (reco::Vertex::trackRef_iterator i=v.tracks_begin(); i!=v.tracks_end(); ++i) {
-    // RM : exclude badly reconstructed tracks from the sum
-    if (TMath::Prob((*i)->chi2(),(*i)->ndof())<track_prob_max_) continue ; 
-    if ((*i)->normalizedChi2()<track_chi2_max_) continue;
+  for (reco::Vertex::trackRef_iterator i=v.tracks_begin(), ie =v.tracks_end();
+       i!=ie; ++i) {
+
     double pt = (*i)->pt();
-    if (pt > 2.5) { // Don't count tracks below 2.5 GeV
-      if (pt > track_pT_max_) pt = track_pT_max_;
-      sum += pt*pt;
-    }
+    if (pt < track_pT_min_) continue; // Don't count tracks below track_pT_min_ (2.5 GeV)
+
+    // RM : exclude badly reconstructed tracks from the sum
+    if (track_prob_min_ >= 0. && track_prob_min_ <= 1.)
+      if (TMath::Prob((*i)->chi2(),(*i)->ndof()) < track_prob_min_) continue ; 
+    if ((*i)->normalizedChi2() > track_chi2_max_) continue;
+    
+    if (pt > track_pT_max_) pt = track_pT_max_;
+    sum += pt*pt;
   }
   return sum;
 }

--- a/RecoPixelVertexing/PixelVertexFinding/src/PixelVertexProducer.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/src/PixelVertexProducer.cc
@@ -31,10 +31,14 @@ PixelVertexProducer::PixelVertexProducer(const edm::ParameterSet& conf)
   token_BeamSpot = consumes<reco::BeamSpot>(conf.getParameter<edm::InputTag>("beamSpot"));
   method2 = conf.getParameter<bool>("Method2");
 
+  edm::ParameterSet PVcomparerPSet = conf.getParameter<edm::ParameterSet>("PVcomparer");
+  double track_pt_max   = PVcomparerPSet.getParameter<double>("track_pt_max");
+  double track_chi2_max = PVcomparerPSet.getParameter<double>("track_chi2_max");
+  double track_prob_max = PVcomparerPSet.getParameter<double>("track_prob_max");
 
   if (finder == "DivisiveVertexFinder") {
     if (verbose_ > 0) edm::LogInfo("PixelVertexProducer") << ": Using the DivisiveVertexFinder\n";
-    dvf_ = new DivisiveVertexFinder(zOffset, ntrkMin, useError, zSeparation, wtAverage, verbose_);
+    dvf_ = new DivisiveVertexFinder(ptMin_,track_pt_max,track_chi2_max,track_prob_max,zOffset, ntrkMin, useError, zSeparation, wtAverage, verbose_);
   }
   else { // Finder not supported, or you made a mistake in your request
     // throw an exception once I figure out how CMSSW does this

--- a/RecoPixelVertexing/PixelVertexFinding/src/PixelVertexProducer.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/src/PixelVertexProducer.cc
@@ -31,10 +31,16 @@ PixelVertexProducer::PixelVertexProducer(const edm::ParameterSet& conf)
   token_BeamSpot = consumes<reco::BeamSpot>(conf.getParameter<edm::InputTag>("beamSpot"));
   method2 = conf.getParameter<bool>("Method2");
 
-  edm::ParameterSet PVcomparerPSet = conf.getParameter<edm::ParameterSet>("PVcomparer");
-  double track_pt_max   = PVcomparerPSet.getParameter<double>("track_pt_max");
-  double track_chi2_max = PVcomparerPSet.getParameter<double>("track_chi2_max");
-  double track_prob_min = PVcomparerPSet.getParameter<double>("track_prob_min");
+  double track_pt_max   = 10.;
+  double track_chi2_max = 9999999.;
+  double track_prob_min = -1.;
+
+  if ( conf.exists("PVcomparer") ) {
+    edm::ParameterSet PVcomparerPSet = conf.getParameter<edm::ParameterSet>("PVcomparer");
+    track_pt_max   = PVcomparerPSet.getParameter<double>("track_pt_max");
+    track_chi2_max = PVcomparerPSet.getParameter<double>("track_chi2_max");
+    track_prob_min = PVcomparerPSet.getParameter<double>("track_prob_min");
+  }
 
   if (finder == "DivisiveVertexFinder") {
     if (verbose_ > 0) edm::LogInfo("PixelVertexProducer") << ": Using the DivisiveVertexFinder\n";

--- a/RecoPixelVertexing/PixelVertexFinding/src/PixelVertexProducer.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/src/PixelVertexProducer.cc
@@ -34,11 +34,11 @@ PixelVertexProducer::PixelVertexProducer(const edm::ParameterSet& conf)
   edm::ParameterSet PVcomparerPSet = conf.getParameter<edm::ParameterSet>("PVcomparer");
   double track_pt_max   = PVcomparerPSet.getParameter<double>("track_pt_max");
   double track_chi2_max = PVcomparerPSet.getParameter<double>("track_chi2_max");
-  double track_prob_max = PVcomparerPSet.getParameter<double>("track_prob_max");
+  double track_prob_min = PVcomparerPSet.getParameter<double>("track_prob_min");
 
   if (finder == "DivisiveVertexFinder") {
     if (verbose_ > 0) edm::LogInfo("PixelVertexProducer") << ": Using the DivisiveVertexFinder\n";
-    dvf_ = new DivisiveVertexFinder(ptMin_,track_pt_max,track_chi2_max,track_prob_max,zOffset, ntrkMin, useError, zSeparation, wtAverage, verbose_);
+    dvf_ = new DivisiveVertexFinder(ptMin_,track_pt_max,track_chi2_max,track_prob_min,zOffset, ntrkMin, useError, zSeparation, wtAverage, verbose_);
   }
   else { // Finder not supported, or you made a mistake in your request
     // throw an exception once I figure out how CMSSW does this

--- a/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromProtoTracksEDProducer.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromProtoTracksEDProducer.cc
@@ -83,7 +83,7 @@ void SeedGeneratorFromProtoTracksEDProducer::produce(edm::Event& ev, const edm::
 
     // check the compatibility with a primary vertex
     bool keepTrack = false;
-    if ( (!foundVertices) | vertices->empty() ) { 
+    if ( (!foundVertices) || vertices->empty() ) { 
       if (useEventsWithNoVertex) keepTrack = true;
     } 
     else if (usePV_){

--- a/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromProtoTracksEDProducer.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromProtoTracksEDProducer.cc
@@ -72,6 +72,7 @@ void SeedGeneratorFromProtoTracksEDProducer::produce(edm::Event& ev, const edm::
   
   edm::Handle<reco::VertexCollection> vertices;
   bool foundVertices = ev.getByToken(theInputVertexCollectionTag, vertices);
+  bool noVertices = vertices->empty();
   //const reco::VertexCollection & vertices = *(h_vertices.product());
 
   ///
@@ -83,8 +84,8 @@ void SeedGeneratorFromProtoTracksEDProducer::produce(edm::Event& ev, const edm::
 
     // check the compatibility with a primary vertex
     bool keepTrack = false;
-    if ( !foundVertices ) { 
-	  if (useEventsWithNoVertex) keepTrack = true;
+    if ( (!foundVertices) | noVertices ) { 
+      if (useEventsWithNoVertex) keepTrack = true;
     } 
     else if (usePV_){
  
@@ -95,7 +96,6 @@ void SeedGeneratorFromProtoTracksEDProducer::produce(edm::Event& ev, const edm::
         keepTrack = true;
       }
     }
-
     else { 
       for (reco::VertexCollection::const_iterator iv=vertices->begin(); iv!= vertices->end(); ++iv) {
         GlobalPoint aPV(iv->position().x(),iv->position().y(),iv->position().z());

--- a/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromProtoTracksEDProducer.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromProtoTracksEDProducer.cc
@@ -72,7 +72,6 @@ void SeedGeneratorFromProtoTracksEDProducer::produce(edm::Event& ev, const edm::
   
   edm::Handle<reco::VertexCollection> vertices;
   bool foundVertices = ev.getByToken(theInputVertexCollectionTag, vertices);
-  bool noVertices = vertices->empty();
   //const reco::VertexCollection & vertices = *(h_vertices.product());
 
   ///
@@ -84,7 +83,7 @@ void SeedGeneratorFromProtoTracksEDProducer::produce(edm::Event& ev, const edm::
 
     // check the compatibility with a primary vertex
     bool keepTrack = false;
-    if ( (!foundVertices) | noVertices ) { 
+    if ( (!foundVertices) | vertices->empty() ) { 
       if (useEventsWithNoVertex) keepTrack = true;
     } 
     else if (usePV_){


### PR DESCRIPTION
changes in PVClusterComparer make no difference in performance (default parameters are equivalent to old setting)
but they allow to define track selections (for defining the vertex ranking) via configuration 

the change in the SeedGeneratorFromProtoTracksEDProducer
should prevent segmentation violation error when the vertex collection exists but it is empty ...
