### PR TITLE
Eg consumes migration

### DIFF
--- a/RecoEgamma/EgammaElectronAlgos/interface/ElectronSeedGenerator.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/ElectronSeedGenerator.h
@@ -54,6 +54,7 @@ class ElectronSeedGenerator
   struct Tokens {
     edm::EDGetTokenT<std::vector<reco::Vertex> > token_vtx;
     edm::EDGetTokenT<reco::BeamSpot> token_bs;
+    edm::EDGetTokenT<std::vector<reco::Vertex> > token_measTrkEvt;
   };
 
   typedef edm::OwnVector<TrackingRecHit> PRecHitContainer;
@@ -120,7 +121,7 @@ class ElectronSeedGenerator
 
   std::string theMeasurementTrackerName;
   const MeasurementTracker*     theMeasurementTracker;
-  edm::InputTag theMeasurementTrackerEventTag;
+  edm::EDGetTokenT<std::vector<reco::Vertex> > theMeasurementTrackerEventTag;
 
   const NavigationSchool*       theNavigationSchool;
 

--- a/RecoEgamma/EgammaElectronAlgos/interface/ElectronSeedGenerator.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/ElectronSeedGenerator.h
@@ -54,7 +54,7 @@ class ElectronSeedGenerator
   struct Tokens {
     edm::EDGetTokenT<std::vector<reco::Vertex> > token_vtx;
     edm::EDGetTokenT<reco::BeamSpot> token_bs;
-    edm::EDGetTokenT<std::vector<reco::Vertex> > token_measTrkEvt;
+    edm::EDGetTokenT<MeasurementTrackerEvent> token_measTrkEvt;
   };
 
   typedef edm::OwnVector<TrackingRecHit> PRecHitContainer;
@@ -121,7 +121,7 @@ class ElectronSeedGenerator
 
   std::string theMeasurementTrackerName;
   const MeasurementTracker*     theMeasurementTracker;
-  edm::EDGetTokenT<std::vector<reco::Vertex> > theMeasurementTrackerEventTag;
+  edm::EDGetTokenT<MeasurementTrackerEvent> theMeasurementTrackerEventTag;
 
   const NavigationSchool*       theNavigationSchool;
 

--- a/RecoEgamma/EgammaElectronAlgos/src/ElectronSeedGenerator.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/ElectronSeedGenerator.cc
@@ -42,6 +42,7 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
+
 #include <vector>
 #include <utility>
 
@@ -63,6 +64,7 @@ ElectronSeedGenerator::ElectronSeedGenerator(const edm::ParameterSet &pset,
    myMatchEle(0), myMatchPos(0),
    thePropagator(0),
    theMeasurementTracker(0),
+   theMeasurementTrackerEventTag(ts.token_measTrkEvt),
    theSetup(0), 
    cacheIDMagField_(0),/*cacheIDGeom_(0),*/cacheIDNavSchool_(0),cacheIDCkfComp_(0),cacheIDTrkGeom_(0)
  {
@@ -76,9 +78,6 @@ ElectronSeedGenerator::ElectronSeedGenerator(const edm::ParameterSet &pset,
   // use of a theMeasurementTrackerName
   if (pset.exists("measurementTrackerName"))
    { theMeasurementTrackerName = pset.getParameter<std::string>("measurementTrackerName") ; }
-  if (pset.existsAs<edm::InputTag>("measurementTrackerEvent")) {
-    theMeasurementTrackerEventTag = pset.getParameter<edm::InputTag>("measurementTrackerEvent");
-  }
 
   // use of reco vertex
   if (pset.exists("useRecoVertex"))
@@ -269,7 +268,7 @@ void  ElectronSeedGenerator::run
 
   // Step A: set Event for the TrajectoryBuilder
   edm::Handle<MeasurementTrackerEvent> data;
-  e.getByLabel(theMeasurementTrackerEventTag, data);
+  e.getByToken(theMeasurementTrackerEventTag, data);
   myMatchEle->setEvent(*data);
   myMatchPos->setEvent(*data);
 

--- a/RecoEgamma/EgammaElectronProducers/plugins/ElectronSeedProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/ElectronSeedProducer.cc
@@ -25,6 +25,7 @@
 #include "RecoEgamma/EgammaElectronAlgos/interface/ElectronHcalHelper.h"
 #include "RecoEgamma/EgammaElectronAlgos/interface/SeedFilter.h"
 #include "RecoEgamma/EgammaElectronAlgos/interface/ElectronUtilities.h"
+#include "RecoTracker/MeasurementDet/interface/MeasurementTrackerEvent.h"
 
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "Geometry/Records/interface/CaloTopologyRecord.h"
@@ -109,7 +110,7 @@ ElectronSeedProducer::ElectronSeedProducer( const edm::ParameterSet& iConfig )
       mayConsume<reco::VertexCollection>(edm::InputTag("offlinePrimaryVerticesWithBS"));
   }
   if(conf_.existsAs<edm::InputTag>("measurementTrackerEvent")) {
-    esg_tokens.token_measTrkEvt= consumes<std::vector<reco::Vertex> >(conf_.getParameter<edm::InputTag>("measurementTrackerEvent"));
+    esg_tokens.token_measTrkEvt= consumes<MeasurementTrackerEvent>(conf_.getParameter<edm::InputTag>("measurementTrackerEvent"));
   }
 
   matcher_ = new ElectronSeedGenerator(conf_,esg_tokens) ;

--- a/RecoEgamma/EgammaElectronProducers/plugins/ElectronSeedProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/ElectronSeedProducer.cc
@@ -108,6 +108,10 @@ ElectronSeedProducer::ElectronSeedProducer( const edm::ParameterSet& iConfig )
     esg_tokens.token_vtx = 
       mayConsume<reco::VertexCollection>(edm::InputTag("offlinePrimaryVerticesWithBS"));
   }
+  if(conf_.existsAs<edm::InputTag>("measurementTrackerEvent")) {
+    esg_tokens.token_measTrkEvt= consumes<std::vector<reco::Vertex> >(conf_.getParameter<edm::InputTag>("measurementTrackerEvent"));
+  }
+
   matcher_ = new ElectronSeedGenerator(conf_,esg_tokens) ;
 
   //  get collections from config'

--- a/RecoEgamma/EgammaHFProducers/plugins/HFEMClusterProducer.cc
+++ b/RecoEgamma/EgammaHFProducers/plugins/HFEMClusterProducer.cc
@@ -11,7 +11,7 @@
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "RecoEgamma/EgammaHFProducers/plugins/HFEMClusterProducer.h"
 using namespace reco;
-HFEMClusterProducer::HFEMClusterProducer(edm::ParameterSet const& conf): hfreco_(conf.getParameter<edm::InputTag>("hits")) {
+HFEMClusterProducer::HFEMClusterProducer(edm::ParameterSet const& conf): hfreco_(consumes<HFRecHitCollection>(conf.getParameter<edm::InputTag>("hits"))) {
   produces<reco::HFEMClusterShapeCollection>();
   produces<reco::BasicClusterCollection>();
   produces<reco::SuperClusterCollection>();
@@ -30,7 +30,7 @@ void HFEMClusterProducer::produce(edm::Event & e, edm::EventSetup const& iSetup)
   
   edm::Handle<HFRecHitCollection> hf_hits;
   
-  e.getByLabel(hfreco_,hf_hits);
+  e.getByToken(hfreco_,hf_hits);
   
   edm::ESHandle<CaloGeometry> geometry;
   iSetup.get<CaloGeometryRecord>().get(geometry);

--- a/RecoEgamma/EgammaHFProducers/plugins/HFEMClusterProducer.h
+++ b/RecoEgamma/EgammaHFProducers/plugins/HFEMClusterProducer.h
@@ -18,7 +18,7 @@ public:
   virtual void produce(edm::Event& e, edm::EventSetup const& iSetup);
   virtual void beginRun(edm::Run const &, edm::EventSetup const&) override final { algo_.resetForRun(); }
 private:
-  edm::InputTag hfreco_;
+  edm::EDGetToken hfreco_;
   HFClusterAlgo algo_;
 };
 #endif

--- a/RecoEgamma/EgammaHFProducers/plugins/HFRecoEcalCandidateProducer.cc
+++ b/RecoEgamma/EgammaHFProducers/plugins/HFRecoEcalCandidateProducer.cc
@@ -30,8 +30,9 @@
 
 HFRecoEcalCandidateProducer::HFRecoEcalCandidateProducer(edm::ParameterSet const& conf):
   defaultDB_(std::vector<double>()),
-  hfclusters_(conf.getParameter<edm::InputTag>("hfclusters")),
-  vertices_(conf.existsAs<edm::InputTag>("VertexCollection") ? conf.getParameter<edm::InputTag>("VertexCollection"):(edm::InputTag)"offlinePrimaryVertices"),
+  hfclustersSC_(consumes<reco::SuperClusterCollection>(conf.getParameter<edm::InputTag>("hfclusters"))),
+  hfclustersHFEM_(consumes<reco::HFEMClusterShapeAssociationCollection>(conf.getParameter<edm::InputTag>("hfclusters"))),
+  
   HFDBversion_(conf.existsAs<int>("HFDBversion") ? conf.getParameter<int>("HFDBversion"):99),//do nothing
   HFDBvector_(conf.existsAs<std::vector<double> >("HFDBvector") ? conf.getParameter<std::vector<double> >("HFDBvector"):defaultDB_),
   doPU_(false),
@@ -47,6 +48,9 @@ HFRecoEcalCandidateProducer::HFRecoEcalCandidateProducer(edm::ParameterSet const
 	conf.getParameter<std::vector<double> >("eSeLCut"),
 	hfvars_) 
 {
+  if(conf.existsAs<edm::InputTag>("VertexCollection")){
+    vertices_ = consumes<reco::VertexCollection>(conf.getParameter<edm::InputTag>("VertexCollection"));
+  }else vertices_ = consumes<reco::VertexCollection>(edm::InputTag("offlinePrimaryVertices"));
 
   produces<reco::RecoEcalCandidateCollection>();
 
@@ -58,13 +62,13 @@ void HFRecoEcalCandidateProducer::produce(edm::Event & e, edm::EventSetup const&
   edm::Handle<reco::SuperClusterCollection> super_clus;
   edm::Handle<reco::HFEMClusterShapeAssociationCollection> hf_assoc;
  
-  e.getByLabel(hfclusters_,super_clus);
-  e.getByLabel(hfclusters_,hf_assoc);
+  e.getByToken(hfclustersSC_,super_clus);
+  e.getByToken(hfclustersHFEM_,hf_assoc);
  
   int nvertex = 0;
   if(HFDBversion_!=99){
     edm:: Handle<reco::VertexCollection> pvHandle;
-    e.getByLabel(vertices_, pvHandle);
+    e.getByToken(vertices_, pvHandle);
     const reco::VertexCollection & vertices = *pvHandle.product();
     static const int minNDOF = 4;
     static const double maxAbsZ = 15.0;

--- a/RecoEgamma/EgammaHFProducers/plugins/HFRecoEcalCandidateProducer.h
+++ b/RecoEgamma/EgammaHFProducers/plugins/HFRecoEcalCandidateProducer.h
@@ -27,7 +27,7 @@ class HFRecoEcalCandidateProducer : public edm::EDProducer {
   virtual void produce(edm::Event& e, edm::EventSetup const& iSetup);
  private:
   std::vector<double> defaultDB_; 
-  edm::InputTag hfclusters_,vertices_;
+  edm::EDGetToken hfclustersSC_,hfclustersHFEM_,vertices_;
   int HFDBversion_;
   std::vector<double> HFDBvector_;
   bool doPU_; 

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EleIsoDetIdCollectionProducer.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EleIsoDetIdCollectionProducer.cc
@@ -29,8 +29,10 @@
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgoRcd.h"
 
 EleIsoDetIdCollectionProducer::EleIsoDetIdCollectionProducer(const edm::ParameterSet& iConfig) :
-            recHitsLabel_(iConfig.getParameter< edm::InputTag > ("recHitsLabel")),
-            emObjectLabel_(iConfig.getParameter< edm::InputTag > ("emObjectLabel")),
+            recHitsToken_(consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag > ("recHitsLabel"))),
+	    emObjectToken_(consumes<reco::GsfElectronCollection>(iConfig.getParameter< edm::InputTag > ("emObjectLabel"))),
+	    recHitsLabel_(iConfig.getParameter< edm::InputTag > ("recHitsLabel")),
+	    emObjectLabel_(iConfig.getParameter< edm::InputTag > ("emObjectLabel")),
             energyCut_(iConfig.getParameter<double>("energyCut")),
             etCut_(iConfig.getParameter<double>("etCut")),
             etCandCut_(iConfig.getParameter<double> ("etCandCut")),
@@ -81,11 +83,11 @@ EleIsoDetIdCollectionProducer::produce (edm::Event& iEvent, const edm::EventSetu
 
     //Get EM Object
     Handle<reco::GsfElectronCollection> emObjectH;
-    iEvent.getByLabel(emObjectLabel_,emObjectH);
+    iEvent.getByToken(emObjectToken_,emObjectH);
 
     // take EcalRecHits
     Handle<EcalRecHitCollection> recHitsH;
-    iEvent.getByLabel(recHitsLabel_,recHitsH);
+    iEvent.getByToken(recHitsToken_,recHitsH);
 
     edm::ESHandle<CaloGeometry> pG;
     iSetup.get<CaloGeometryRecord>().get(pG);    

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EleIsoDetIdCollectionProducer.h
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EleIsoDetIdCollectionProducer.h
@@ -24,7 +24,7 @@ Implementation:
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDProducer.h"
-
+#include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -43,6 +43,8 @@ class EleIsoDetIdCollectionProducer : public edm::EDProducer {
 
    private:
       // ----------member data ---------------------------
+      edm::EDGetToken recHitsToken_;
+      edm::EDGetToken emObjectToken_; 
       edm::InputTag recHitsLabel_;
       edm::InputTag emObjectLabel_;
       double energyCut_;

--- a/RecoEgamma/EgammaPhotonProducers/src/PhotonProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/PhotonProducer.cc
@@ -133,7 +133,15 @@ PhotonProducer::PhotonProducer(const edm::ParameterSet& config) :
   //
 
   thePhotonEnergyCorrector_ = new PhotonEnergyCorrector(conf_, consumesCollector());
+  thePhotonIsolationCalculator_ = new PhotonIsolationCalculator();
+  edm::ParameterSet isolationSumsCalculatorSet = conf_.getParameter<edm::ParameterSet>("isolationSumsCalculatorSet"); 
+  thePhotonIsolationCalculator_->setup(isolationSumsCalculatorSet, flagsexclEB_, flagsexclEE_, severitiesexclEB_, severitiesexclEE_,consumesCollector());
 
+
+  thePhotonMIPHaloTagger_ = new PhotonMIPHaloTagger();
+  edm::ParameterSet mipVariableSet = conf_.getParameter<edm::ParameterSet>("mipVariableSet"); 
+  thePhotonMIPHaloTagger_->setup(mipVariableSet,consumesCollector());
+  
   // Register the product
   produces< reco::PhotonCollection >(PhotonCollection_);
 
@@ -142,6 +150,8 @@ PhotonProducer::PhotonProducer(const edm::ParameterSet& config) :
 PhotonProducer::~PhotonProducer() 
 {
   delete thePhotonEnergyCorrector_;
+  delete thePhotonIsolationCalculator_;
+  delete thePhotonMIPHaloTagger_;
   //delete energyCorrectionF;
 }
 
@@ -149,19 +159,12 @@ PhotonProducer::~PhotonProducer()
 
 void  PhotonProducer::beginRun (edm::Run const& r, edm::EventSetup const & theEventSetup) {
 
-    thePhotonIsolationCalculator_ = new PhotonIsolationCalculator();
-    edm::ParameterSet isolationSumsCalculatorSet = conf_.getParameter<edm::ParameterSet>("isolationSumsCalculatorSet"); 
-    thePhotonIsolationCalculator_->setup(isolationSumsCalculatorSet, flagsexclEB_, flagsexclEE_, severitiesexclEB_, severitiesexclEE_);
-    thePhotonMIPHaloTagger_ = new PhotonMIPHaloTagger();
-    edm::ParameterSet mipVariableSet = conf_.getParameter<edm::ParameterSet>("mipVariableSet"); 
-    thePhotonMIPHaloTagger_->setup(mipVariableSet);
+   
+
     thePhotonEnergyCorrector_ -> init(theEventSetup); 
 }
 
 void  PhotonProducer::endRun (edm::Run const& r, edm::EventSetup const & theEventSetup) {
-
-  delete thePhotonIsolationCalculator_;
-  delete thePhotonMIPHaloTagger_;
 }
 
 

--- a/RecoEgamma/ElectronIdentification/interface/CutBasedElectronID.h
+++ b/RecoEgamma/ElectronIdentification/interface/CutBasedElectronID.h
@@ -2,12 +2,16 @@
 #define CutBasedElectronID_H
 
 #include "RecoEgamma/ElectronIdentification/interface/ElectronIDAlgo.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
 
 class CutBasedElectronID : public ElectronIDAlgo {
 
 public:
-
-  CutBasedElectronID(){};
+  
+  CutBasedElectronID(const edm::ParameterSet& conf,edm::ConsumesCollector & iC);
 
   virtual ~CutBasedElectronID() {};
 
@@ -24,7 +28,7 @@ public:
   std::string type_;
   std::string quality_;
   std::string version_;
-  edm::InputTag verticesCollection_;
+  edm::EDGetTokenT<std::vector<reco::Vertex> > verticesCollection_;
   edm::ParameterSet cuts_;
 
 };

--- a/RecoEgamma/ElectronIdentification/plugins/ElectronIDSelectorCutBased.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/ElectronIDSelectorCutBased.cc
@@ -9,7 +9,7 @@ ElectronIDSelectorCutBased::ElectronIDSelectorCutBased (const edm::ParameterSet&
   else if ( algorithm_ == "eIDCBClasses" )
      electronIDAlgo_ = new PTDRElectronID ();
   else if ( algorithm_ == "eIDCB" )
-     electronIDAlgo_ = new CutBasedElectronID ();
+    electronIDAlgo_ = new CutBasedElectronID (conf,iC);
   else {
     throw cms::Exception("Configuration")
       << "Invalid algorithm parameter in ElectronIDSelectorCutBased: must be eIDCBClasses or eIDCB." ;

--- a/RecoEgamma/ElectronIdentification/src/CutBasedElectronID.cc
+++ b/RecoEgamma/ElectronIdentification/src/CutBasedElectronID.cc
@@ -1,12 +1,16 @@
 #include "RecoEgamma/ElectronIdentification/interface/CutBasedElectronID.h"
 #include "DataFormats/EgammaReco/interface/BasicCluster.h"
-#include "DataFormats/VertexReco/interface/Vertex.h"
-#include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
 //#include "RecoEgamma/EgammaTools/interface/ConversionFinder.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 
 #include <algorithm>
+
+CutBasedElectronID::CutBasedElectronID(const edm::ParameterSet& conf,edm::ConsumesCollector & iC)
+{
+  verticesCollection_ = iC.consumes<std::vector<reco::Vertex> >(conf.getParameter<edm::InputTag>("verticesCollection"));
+
+}
 
 void CutBasedElectronID::setup(const edm::ParameterSet& conf) {
 
@@ -16,7 +20,7 @@ void CutBasedElectronID::setup(const edm::ParameterSet& conf) {
   type_ = conf.getParameter<std::string>("electronIDType");
   quality_ = conf.getParameter<std::string>("electronQuality");
   version_ = conf.getParameter<std::string>("electronVersion");
-  verticesCollection_ = conf.getParameter<edm::InputTag>("verticesCollection");
+  //verticesCollection_ = conf.getParameter<edm::InputTag>("verticesCollection");
   
   if (type_ == "classbased" and (version_ == "V06")) {
     newCategories_ = conf.getParameter<bool>("additionalCategories");
@@ -151,7 +155,7 @@ double CutBasedElectronID::cicSelection(const reco::GsfElectron* electron,
 
   if (version_ != "V01" or version_ != "V00") {
     edm::Handle<reco::VertexCollection> vtxH;
-    e.getByLabel(verticesCollection_, vtxH);
+    e.getByToken(verticesCollection_, vtxH);
     if (vtxH->size() != 0) {
       reco::VertexRef vtx(vtxH, 0);
       ip = fabs(electron->gsfTrack()->dxy(math::XYZPoint(vtx->x(),vtx->y(),vtx->z())));
@@ -485,7 +489,7 @@ double CutBasedElectronID::robustSelection(const reco::GsfElectron* electron ,
   if (version_ == "V03" or version_ == "V04") {
     edm::Handle<reco::BeamSpot> pBeamSpot;
     // uses the same name for the vertex collection to avoid adding more new names
-    e.getByLabel(verticesCollection_, pBeamSpot);
+    e.getByToken(verticesCollection_, pBeamSpot);
     if (pBeamSpot.isValid()) {
       const reco::BeamSpot *bspot = pBeamSpot.product();
       const math::XYZPoint bspotPosition = bspot->position();
@@ -504,7 +508,7 @@ double CutBasedElectronID::robustSelection(const reco::GsfElectron* electron ,
 
   if (version_ == "V05") {
     edm::Handle<reco::VertexCollection> vtxH;
-    e.getByLabel(verticesCollection_, vtxH);
+    e.getByToken(verticesCollection_, vtxH);
     if (vtxH->size() != 0) {
       reco::VertexRef vtx(vtxH, 0);
       ip = fabs(electron->gsfTrack()->dxy(math::XYZPoint(vtx->x(),vtx->y(),vtx->z())));

--- a/RecoEgamma/PhotonIdentification/interface/PhotonIsolationCalculator.h
+++ b/RecoEgamma/PhotonIdentification/interface/PhotonIsolationCalculator.h
@@ -12,7 +12,7 @@
 #include <string>
 
 #include "FWCore/Utilities/interface/GCC11Compatibility.h"
-
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 class PhotonIsolationCalculator {
 
@@ -26,7 +26,8 @@ public:
 	     std::vector<int> const & flagsEB_,
 	     std::vector<int> const & flagsEE_,
 	     std::vector<int> const & severitiesEB_,
-	     std::vector<int> const & severitiesEE_);
+	     std::vector<int> const & severitiesEE_,
+	     edm::ConsumesCollector && iC);
 
   void calculate(const reco::Photon*, 
 		 const edm::Event&, const edm::EventSetup& es,
@@ -94,12 +95,12 @@ private:
   
  private:
 
-  edm::InputTag barrelecalCollection_;
-  edm::InputTag endcapecalCollection_;
-  edm::InputTag hcalCollection_;
+  edm::EDGetToken barrelecalCollection_;
+  edm::EDGetToken endcapecalCollection_;
+  edm::EDGetToken hcalCollection_;
 
-  edm::InputTag trackInputTag_;
-  edm::InputTag beamSpotProducerTag_;
+  edm::EDGetToken trackInputTag_;
+  edm::EDGetToken beamSpotProducerTag_;
   double modulePhiBoundary_;
   std::vector<double> moduleEtaBoundary_;
   bool vetoClusteredEcalHits_;

--- a/RecoEgamma/PhotonIdentification/interface/PhotonMIPHaloTagger.h
+++ b/RecoEgamma/PhotonIdentification/interface/PhotonMIPHaloTagger.h
@@ -10,6 +10,7 @@
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgo.h"
 
 #include "RecoEcal/EgammaCoreTools/interface/EcalClusterTools.h" 
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include <string>
 
@@ -21,7 +22,7 @@ public:
 
   virtual ~PhotonMIPHaloTagger(){};
 
-  void setup(const edm::ParameterSet& conf);
+  void setup(const edm::ParameterSet& conf,edm::ConsumesCollector&& iC);
 
   void MIPcalculate(const reco::Photon*, 
 		    const edm::Event&, 
@@ -58,8 +59,8 @@ public:
  
  protected:
 
-  edm::InputTag EBecalCollection_;
-  edm::InputTag EEecalCollection_;
+  edm::EDGetToken EBecalCollection_;
+  edm::EDGetToken EEecalCollection_;
 
 
 

--- a/RecoEgamma/PhotonIdentification/src/PhotonIsolationCalculator.cc
+++ b/RecoEgamma/PhotonIdentification/src/PhotonIsolationCalculator.cc
@@ -44,14 +44,15 @@
 
 void PhotonIsolationCalculator::setup(const edm::ParameterSet& conf, 
 				      std::vector<int> const & flagsEB, std::vector<int> const & flagsEE, 
-				      std::vector<int> const & severitiesEB, std::vector<int> const & severitiesEE) {
+				      std::vector<int> const & severitiesEB, std::vector<int> const & severitiesEE,
+				      edm::ConsumesCollector && iC) {
 
 
-  trackInputTag_ = conf.getParameter<edm::InputTag>("trackProducer");
-  beamSpotProducerTag_ = conf.getParameter<edm::InputTag>("beamSpotProducer");
-  barrelecalCollection_ = conf.getParameter<edm::InputTag>("barrelEcalRecHitCollection");
-  endcapecalCollection_ = conf.getParameter<edm::InputTag>("endcapEcalRecHitCollection");
-  hcalCollection_ = conf.getParameter<edm::InputTag>("HcalRecHitCollection");
+  trackInputTag_ = iC.consumes<reco::TrackCollection>(conf.getParameter<edm::InputTag>("trackProducer"));
+  beamSpotProducerTag_ = iC.consumes<reco::BeamSpot>(conf.getParameter<edm::InputTag>("beamSpotProducer"));
+  barrelecalCollection_ = iC.consumes<EcalRecHitCollection>(conf.getParameter<edm::InputTag>("barrelEcalRecHitCollection"));
+  endcapecalCollection_ = iC.consumes<EcalRecHitCollection>(conf.getParameter<edm::InputTag>("endcapEcalRecHitCollection"));
+  hcalCollection_ = iC.consumes<CaloTowerCollection>(conf.getParameter<edm::InputTag>("HcalRecHitCollection"));
 
   //  gsfRecoInputTag_ = conf.getParameter<edm::InputTag>("GsfRecoCollection");
   modulePhiBoundary_ = conf.getParameter<double>("modulePhiBoundary");
@@ -557,7 +558,7 @@ void PhotonIsolationCalculator::calculateTrackIso(const reco::Photon* photon,
   ntrkCone =0;trkCone=0;
   //get the tracks
   edm::Handle<reco::TrackCollection> tracks;
-  e.getByLabel(trackInputTag_,tracks);
+  e.getByToken(trackInputTag_,tracks);
   if(!tracks.isValid()) {
     return;
   }
@@ -565,7 +566,7 @@ void PhotonIsolationCalculator::calculateTrackIso(const reco::Photon* photon,
   //Photon Eta and Phi.  Hope these are correct.
   reco::BeamSpot vertexBeamSpot;
   edm::Handle<reco::BeamSpot> recoBeamSpotHandle;
-  e.getByLabel(beamSpotProducerTag_,recoBeamSpotHandle);
+  e.getByToken(beamSpotProducerTag_,recoBeamSpotHandle);
   vertexBeamSpot = *recoBeamSpotHandle;
   
   PhotonTkIsolation phoIso(RCone, 
@@ -598,9 +599,9 @@ double PhotonIsolationCalculator::calculateEcalRecHitIso(const reco::Photon* pho
   
   edm::Handle<EcalRecHitCollection> ecalhitsCollEB;
   edm::Handle<EcalRecHitCollection> ecalhitsCollEE;
-  iEvent.getByLabel(endcapecalCollection_, ecalhitsCollEE);
+  iEvent.getByToken(endcapecalCollection_, ecalhitsCollEE);
  
-  iEvent.getByLabel(barrelecalCollection_, ecalhitsCollEB);
+  iEvent.getByToken(barrelecalCollection_, ecalhitsCollEB);
  
   const EcalRecHitCollection* rechitsCollectionEE_ = ecalhitsCollEE.product();
   const EcalRecHitCollection* rechitsCollectionEB_ = ecalhitsCollEB.product();
@@ -661,7 +662,7 @@ double PhotonIsolationCalculator::calculateHcalTowerIso(const reco::Photon* phot
 
   edm::Handle<CaloTowerCollection> hcalhitsCollH;
  
-  iEvent.getByLabel(hcalCollection_, hcalhitsCollH);
+  iEvent.getByToken(hcalCollection_, hcalhitsCollH);
   
   const CaloTowerCollection *toww = hcalhitsCollH.product();
 
@@ -692,7 +693,7 @@ double PhotonIsolationCalculator::calculateHcalTowerIso(const reco::Photon* phot
 
   edm::Handle<CaloTowerCollection> hcalhitsCollH;
  
-  iEvent.getByLabel(hcalCollection_, hcalhitsCollH);
+  iEvent.getByToken(hcalCollection_, hcalhitsCollH);
   
   const CaloTowerCollection *toww = hcalhitsCollH.product();
 

--- a/RecoEgamma/PhotonIdentification/src/PhotonMIPHaloTagger.cc
+++ b/RecoEgamma/PhotonIdentification/src/PhotonMIPHaloTagger.cc
@@ -45,11 +45,11 @@
 #include <TMath.h>
 
 
-void PhotonMIPHaloTagger::setup(const edm::ParameterSet& conf) {
+void PhotonMIPHaloTagger::setup(const edm::ParameterSet& conf,edm::ConsumesCollector && iC) {
 
 
-  EBecalCollection_ = conf.getParameter<edm::InputTag>("barrelEcalRecHitCollection");
-  EEecalCollection_ = conf.getParameter<edm::InputTag>("endcapEcalRecHitCollection");
+  EBecalCollection_ = iC.consumes<EcalRecHitCollection>(conf.getParameter<edm::InputTag>("barrelEcalRecHitCollection"));
+  EEecalCollection_ = iC.consumes<EcalRecHitCollection>(conf.getParameter<edm::InputTag>("endcapEcalRecHitCollection"));
 
 
   yRangeFit_             = conf.getParameter<double>("YRangeFit");
@@ -89,10 +89,10 @@ void PhotonMIPHaloTagger::MIPcalculate(const reco::Photon* pho,
   bool validEcalRecHits=true;
 
   edm::Handle<EcalRecHitCollection> barrelHitHandle;
-  e.getByLabel(EBecalCollection_, barrelHitHandle);
+  e.getByToken(EBecalCollection_, barrelHitHandle);
 
   if (!barrelHitHandle.isValid()) {
-    edm::LogError("MIPcalculate") << "Error! Can't get the product "<<EBecalCollection_.label();
+    edm::LogError("MIPcalculate") << "Error! Can't get the barrel hits product ";//<<EBecalCollection_.label(); (cant be bothered tracking the input tag just for this error message)
     validEcalRecHits=false;
   }
 


### PR DESCRIPTION
This is consumes migration of the remaining E/gamma modules from https://twiki.cern.ch/twiki/bin/view/CMSPublic/FWMultithreadedConsumesMigration. The modules fixed are:

EleIdCutBasedExtProducer
EleIsoDetIdCollectionProducer
ElectronSeedProducer
GEDPhotonProducer
PhotonProducer
HFRecoEcalCandidateProducer
HFEMClusterProducer

The last EGM module I saw was PhotonValidator in the Validation/RecoEgamma package. I decided not to fix that because the issue is in SimTracker/TrackerHitAssociation/src/TrackerHitAssociator.cc so didnt want to trample over others code.

In the 24/04 IB, runTheMatix.py -s failed due to missing services but it fails on a clean release too so I do not think this is my issue. They all pass in 22/04 IB which is the release I developed the code on.
