### PR TITLE
Improved cluster charge cut for tracking

### DIFF
--- a/RecoLocalTracker/SubCollectionProducers/src/TrackClusterRemover.cc
+++ b/RecoLocalTracker/SubCollectionProducers/src/TrackClusterRemover.cc
@@ -16,6 +16,7 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
+#include "DataFormats/SiStripDetId/interface/SiStripDetId.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/Common/interface/ValueMap.h"
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
@@ -82,7 +83,7 @@ class TrackClusterRemover : public edm::stream::EDProducer<> {
         edm::ProductID pixelSourceProdID, stripSourceProdID; // ProdIDs refs must point to (for consistency tests)
 
         inline void process(const TrackingRecHit *hit, float chi2);
-        inline void process(const OmniClusterRef & cluRef, uint32_t subdet, bool fromTrack);
+        inline void process(const OmniClusterRef & cluRef, SiStripDetId & detid, bool fromTrack);
 
 
         template<typename T> 
@@ -101,7 +102,7 @@ class TrackClusterRemover : public edm::stream::EDProducer<> {
   std::vector<bool> collectedStrips_;
   std::vector<bool> collectedPixels_;
 
-
+  float sensorThickness (const SiStripDetId& detid) const;
 
 };
 
@@ -221,7 +222,7 @@ void TrackClusterRemover::mergeOld(ClusterRemovalInfo::Indices &refs,
        }
 }
 
- 
+
 template<typename T> 
 auto_ptr<edmNew::DetSetVector<T> >
 TrackClusterRemover::cleanup(const edmNew::DetSetVector<T> &oldClusters, const std::vector<uint8_t> &isGood, 
@@ -263,13 +264,25 @@ TrackClusterRemover::cleanup(const edmNew::DetSetVector<T> &oldClusters, const s
     return output;
 }
 
+float TrackClusterRemover::sensorThickness (const SiStripDetId& detid) const
+{
+  if (detid.subdetId()>2) {
+    if (detid.subdetId()==SiStripDetId::TOB) return 0.047;
+    if (detid.moduleGeometry()==SiStripDetId::W5 || detid.moduleGeometry()==SiStripDetId::W6 ||
+        detid.moduleGeometry()==SiStripDetId::W7)
+	return 0.047;
+    return 0.029; // so it is TEC ring 1-4 or TIB or TOB;
+  } else if (detid.subdetId()==1) return 0.0285;
+  else return 0.027;
+}
 
-void TrackClusterRemover::process(OmniClusterRef const & ocluster, uint32_t subdet, bool fromTrack) {
+void TrackClusterRemover::process(OmniClusterRef const & ocluster, SiStripDetId & detid, bool fromTrack) {
     SiStripRecHit2D::ClusterRef cluster = ocluster.cluster_strip();
   if (cluster.id() != stripSourceProdID) throw cms::Exception("Inconsistent Data") <<
     "TrackClusterRemover: strip cluster ref from Product ID = " << cluster.id() <<
     " does not match with source cluster collection (ID = " << stripSourceProdID << ")\n.";
   
+  uint32_t subdet = detid.subdetId();
   assert(cluster.id() == stripSourceProdID);
   if (pblocks_[subdet-1].usesSize_ && (cluster->amplitudes().size() > pblocks_[subdet-1].maxSize_)) return;
   if (!fromTrack) {
@@ -277,7 +290,7 @@ void TrackClusterRemover::process(OmniClusterRef const & ocluster, uint32_t subd
     for( std::vector<uint8_t>::const_iterator iAmp = cluster->amplitudes().begin(); iAmp != cluster->amplitudes().end(); ++iAmp){
       clusCharge += *iAmp;
     }
-    if (pblocks_[subdet-1].cutOnStripCharge_ && clusCharge > pblocks_[subdet-1].minGoodStripCharge_) return;
+    if (pblocks_[subdet-1].cutOnStripCharge_ && (clusCharge > (pblocks_[subdet-1].minGoodStripCharge_*sensorThickness(detid)))) return;
   }
   strips[cluster.key()] = false;  
   //if (!clusterWasteSolution_) collectedStrip[hit->geographicalId()].insert(cluster);
@@ -288,7 +301,7 @@ void TrackClusterRemover::process(OmniClusterRef const & ocluster, uint32_t subd
 
 
 void TrackClusterRemover::process(const TrackingRecHit *hit, float chi2) {
-    DetId detid = hit->geographicalId(); 
+    SiStripDetId detid = hit->geographicalId(); 
     uint32_t subdet = detid.subdetId();
 
     assert ((subdet > 0) && (subdet <= NumberOfParamBlocks));
@@ -327,19 +340,19 @@ void TrackClusterRemover::process(const TrackingRecHit *hit, float chi2) {
         if (hitType == typeid(SiStripRecHit2D)) {
             const SiStripRecHit2D *stripHit = static_cast<const SiStripRecHit2D *>(hit);
 //DBG//     cout << "Plain RecHit 2D: " << endl;
-            process(stripHit->omniClusterRef(),subdet, true);}
+            process(stripHit->omniClusterRef(),detid, true);}
 	else if (hitType == typeid(SiStripRecHit1D)) {
 	  const SiStripRecHit1D *hit1D = static_cast<const SiStripRecHit1D *>(hit);
-	  process(hit1D->omniClusterRef(),subdet, true);
+	  process(hit1D->omniClusterRef(),detid, true);
         } else if (hitType == typeid(SiStripMatchedRecHit2D)) {
             const SiStripMatchedRecHit2D *matchHit = static_cast<const SiStripMatchedRecHit2D *>(hit);
 //DBG//     cout << "Matched RecHit 2D: " << endl;
-            process(matchHit->monoClusterRef(),subdet, true);
-            process(matchHit->stereoClusterRef(),subdet, true);
+            process(matchHit->monoClusterRef(),detid, true);
+            process(matchHit->stereoClusterRef(),detid, true);
         } else if (hitType == typeid(ProjectedSiStripRecHit2D)) {
             const ProjectedSiStripRecHit2D *projHit = static_cast<const ProjectedSiStripRecHit2D *>(hit);
 //DBG//     cout << "Projected RecHit 2D: " << endl;
-            process(projHit->originalHit().omniClusterRef(),subdet, true);
+            process(projHit->originalHit().omniClusterRef(),detid, true);
         } else throw cms::Exception("NOT IMPLEMENTED") << "Don't know how to handle " << hitType.name() << " on detid " << detid.rawId() << "\n";
     }
 }
@@ -473,18 +486,16 @@ TrackClusterRemover::produce(Event& iEvent, const EventSetup& iSetup)
       const SiStripRecHit2DCollection::DataContainer * rphiRecHits = & (rechitsrphi).product()->data();
       for(  SiStripRecHit2DCollection::DataContainer::const_iterator
 	      recHit = rphiRecHits->begin(); recHit!= rphiRecHits->end(); recHit++){
-	DetId detid = recHit->geographicalId(); 
-	uint32_t subdet = detid.subdetId();
-	process(recHit->omniClusterRef(),subdet,false);
+	SiStripDetId detid = recHit->geographicalId(); 
+	process(recHit->omniClusterRef(),detid,false);
       }
       edm::Handle<SiStripRecHit2DCollection> rechitsstereo;
       iEvent.getByToken(stereoRecHitToken_, rechitsstereo);
       const SiStripRecHit2DCollection::DataContainer * stereoRecHits = & (rechitsstereo).product()->data();
       for(  SiStripRecHit2DCollection::DataContainer::const_iterator
 	      recHit = stereoRecHits->begin(); recHit!= stereoRecHits->end(); recHit++){
-	DetId detid = recHit->geographicalId(); 
-	uint32_t subdet = detid.subdetId();
-	process(recHit->omniClusterRef(),subdet,false);
+	SiStripDetId detid = recHit->geographicalId(); 
+	process(recHit->omniClusterRef(),detid,false);
       }
 
     }

--- a/RecoLocalTracker/SubCollectionProducers/src/TrackClusterRemover.cc
+++ b/RecoLocalTracker/SubCollectionProducers/src/TrackClusterRemover.cc
@@ -266,13 +266,13 @@ TrackClusterRemover::cleanup(const edmNew::DetSetVector<T> &oldClusters, const s
 
 float TrackClusterRemover::sensorThickness (const SiStripDetId& detid) const
 {
-  if (detid.subdetId()>2) {
+  if (detid.subdetId()>=SiStripDetId::TIB) {
     if (detid.subdetId()==SiStripDetId::TOB) return 0.047;
     if (detid.moduleGeometry()==SiStripDetId::W5 || detid.moduleGeometry()==SiStripDetId::W6 ||
         detid.moduleGeometry()==SiStripDetId::W7)
 	return 0.047;
     return 0.029; // so it is TEC ring 1-4 or TIB or TOB;
-  } else if (detid.subdetId()==1) return 0.0285;
+  } else if (detid.subdetId()==PixelSubdetector::PixelBarrel) return 0.0285;
   else return 0.027;
 }
 

--- a/RecoPixelVertexing/PixelLowPtUtilities/interface/ClusterShapeHitFilter.h
+++ b/RecoPixelVertexing/PixelLowPtUtilities/interface/ClusterShapeHitFilter.h
@@ -164,6 +164,11 @@ class ClusterShapeHitFilter
  
   ~ClusterShapeHitFilter();
 
+  void setChargeCuts(bool cutOnPixelCharge, float minGoodPixelCharge,
+	bool cutOnStripCharge, float minGoodStripCharge) {
+    cutOnPixelCharge_ = cutOnPixelCharge; minGoodPixelCharge_= minGoodPixelCharge;
+    cutOnStripCharge_ = cutOnStripCharge; minGoodStripCharge_= minGoodStripCharge; } 
+
   bool getSizes
   (const SiPixelRecHit & recHit, const LocalVector & ldir,
    const SiPixelClusterShapeCache& clusterShapeCache,
@@ -241,6 +246,10 @@ class ClusterShapeHitFilter
   StripLimits stripLimits[StripKeys::N+1]; // [2][2]
 
   float theAngle[6];
+  bool cutOnPixelCharge_, cutOnStripCharge_;
+  float minGoodPixelCharge_, minGoodStripCharge_;
+  bool checkClusterCharge(DetId detId, const SiStripCluster& cluster, const LocalVector & ldir) const;
+  bool checkClusterCharge(DetId detId, const SiPixelCluster& cluster, const LocalVector & ldir) const;
 };
 
 #endif

--- a/RecoPixelVertexing/PixelLowPtUtilities/interface/ClusterShapeHitFilterESProducer.h
+++ b/RecoPixelVertexing/PixelLowPtUtilities/interface/ClusterShapeHitFilterESProducer.h
@@ -49,6 +49,8 @@ class ClusterShapeHitFilterESProducer : public edm::ESProducer
 
  private:
   const std::string use_PixelShapeFile;
+  bool cutOnPixelCharge_, cutOnStripCharge_;
+  float minGoodPixelCharge_, minGoodStripCharge_;
 };
 
 #endif

--- a/RecoPixelVertexing/PixelLowPtUtilities/src/ClusterShapeHitFilter.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/src/ClusterShapeHitFilter.cc
@@ -413,20 +413,16 @@ bool ClusterShapeHitFilter::checkClusterCharge(DetId detId, const SiStripCluster
 {
   int clusCharge=accumulate( cluster.amplitudes().begin(), cluster.amplitudes().end(), uint16_t(0));
 
-  const StripGeomDetUnit* stripDet =
-    dynamic_cast<const StripGeomDetUnit*> (theTracker->idToDet(detId));
   float chargeCut = minGoodStripCharge_*
-    stripDet->surface().bounds().thickness()/abs(cos(ldir.theta()));
+    theTracker->idToDet(detId)->surface().bounds().thickness()/abs(ldir.z()/ldir.mag());
 
   return (clusCharge>chargeCut);
 }
 
 bool ClusterShapeHitFilter::checkClusterCharge(DetId detId, const SiPixelCluster& cluster, const LocalVector & ldir) const
 {
-  const PixelGeomDetUnit* stripDet =
-    dynamic_cast<const PixelGeomDetUnit*> (theTracker->idToDet(detId));
   float chargeCut = minGoodPixelCharge_*
-    stripDet->surface().bounds().thickness()/abs(cos(ldir.theta()));
+    theTracker->idToDet(detId)->surface().bounds().thickness()/abs(ldir.z()/ldir.mag());
 
   return (cluster.charge()>chargeCut);
 }

--- a/RecoPixelVertexing/PixelLowPtUtilities/src/ClusterShapeHitFilter.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/src/ClusterShapeHitFilter.cc
@@ -54,6 +54,7 @@ ClusterShapeHitFilter::ClusterShapeHitFilter
 
   // Load strip limits
   loadStripLimits();
+  cutOnPixelCharge_ = cutOnStripCharge_ = false;
 }
 
 /*****************************************************************************/
@@ -304,6 +305,8 @@ bool ClusterShapeHitFilter::isCompatible
 		    PixelData const * ipd) const
 {
  // Get detector
+  if (cutOnPixelCharge_ && (!checkClusterCharge(recHit.geographicalId(), *(recHit.cluster()), ldir))) return false;
+
   const PixelData & pd = getpd(recHit,ipd);
 
   int part;
@@ -383,6 +386,8 @@ bool ClusterShapeHitFilter::isCompatible
   int meas;
   float pred;
 
+  if (cutOnStripCharge_ && (!checkClusterCharge(detId, cluster, ldir))) return false;
+
   if(getSizes(detId, cluster, ldir, meas, pred))
   {
     StripKeys key(meas);
@@ -403,6 +408,28 @@ bool ClusterShapeHitFilter::isCompatible
   return isCompatible(detId, cluster, ldir);
 }
 
+
+bool ClusterShapeHitFilter::checkClusterCharge(DetId detId, const SiStripCluster& cluster, const LocalVector & ldir) const
+{
+  int clusCharge=accumulate( cluster.amplitudes().begin(), cluster.amplitudes().end(), uint16_t(0));
+
+  const StripGeomDetUnit* stripDet =
+    dynamic_cast<const StripGeomDetUnit*> (theTracker->idToDet(detId));
+  float chargeCut = minGoodStripCharge_*
+    stripDet->surface().bounds().thickness()/abs(cos(ldir.theta()));
+
+  return (clusCharge>chargeCut);
+}
+
+bool ClusterShapeHitFilter::checkClusterCharge(DetId detId, const SiPixelCluster& cluster, const LocalVector & ldir) const
+{
+  const PixelGeomDetUnit* stripDet =
+    dynamic_cast<const PixelGeomDetUnit*> (theTracker->idToDet(detId));
+  float chargeCut = minGoodPixelCharge_*
+    stripDet->surface().bounds().thickness()/abs(cos(ldir.theta()));
+
+  return (cluster.charge()>chargeCut);
+}
 
 #include "FWCore/PluginManager/interface/ModuleDef.h"
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/RecoPixelVertexing/PixelLowPtUtilities/src/ClusterShapeHitFilterESProducer.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/src/ClusterShapeHitFilterESProducer.cc
@@ -15,7 +15,11 @@ ClusterShapeHitFilterESProducer::ClusterShapeHitFilterESProducer
 {
   
   std::string componentName = iConfig.getParameter<std::string>("ComponentName");
-  
+  cutOnPixelCharge_ = iConfig.exists("minGoodPixelCharge");
+  cutOnStripCharge_ = iConfig.exists("minGoodStripCharge");
+  minGoodPixelCharge_= (cutOnPixelCharge_ ? iConfig.getParameter<double>("minGoodPixelCharge") : 0); 
+  minGoodStripCharge_= (cutOnStripCharge_ ? iConfig.getParameter<double>("minGoodStripCharge") : 0);
+
   edm::LogInfo("ClusterShapeHitFilterESProducer")
     << " with name: "            << componentName;
       
@@ -63,6 +67,7 @@ ClusterShapeHitFilterESProducer::produce
                                       pixel.product(),
                                       strip.product(),
                                       &use_PixelShapeFile));
-
+  aFilter->setChargeCuts(cutOnPixelCharge_, minGoodPixelCharge_, cutOnStripCharge_,
+    minGoodStripCharge_);
   return aFilter;
 }

--- a/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
@@ -8,18 +8,14 @@ import FWCore.ParameterSet.Config as cms
 
 detachedTripletStepClusters = cms.EDProducer("TrackClusterRemover",
     clusterLessSolution = cms.bool(True),
-    oldClusterRemovalInfo = cms.InputTag("initialStepClusters"),
     trajectories = cms.InputTag("initialStepTracks"),
     overrideTrkQuals = cms.InputTag('initialStep'),
     TrackQuality = cms.string('highPurity'),
     minNumberOfLayersWithMeasBeforeFiltering = cms.int32(0),
     pixelClusters = cms.InputTag("siPixelClusters"),
     stripClusters = cms.InputTag("siStripClusters"),
-    doStripChargeCheck = cms.bool(True),
-    stripRecHits = cms.string('siStripMatchedRecHits'),
     Common = cms.PSet(
         maxChi2 = cms.double(9.0),
-        minGoodStripCharge = cms.double(60.0)
     )
 )
 
@@ -60,11 +56,12 @@ detachedTripletStepTrajectoryFilter = TrackingTools.TrajectoryFiltering.Trajecto
     minPt = 0.075
     )
 
-import TrackingTools.KalmanUpdators.Chi2MeasurementEstimatorESProducer_cfi
-detachedTripletStepChi2Est = TrackingTools.KalmanUpdators.Chi2MeasurementEstimatorESProducer_cfi.Chi2MeasurementEstimator.clone(
+import TrackingTools.KalmanUpdators.Chi2ChargeMeasurementEstimatorESProducer_cfi
+detachedTripletStepChi2Est = TrackingTools.KalmanUpdators.Chi2ChargeMeasurementEstimatorESProducer_cfi.Chi2ChargeMeasurementEstimator.clone(
     ComponentName = cms.string('detachedTripletStepChi2Est'),
     nSigma = cms.double(3.0),
-    MaxChi2 = cms.double(9.0)
+    MaxChi2 = cms.double(9.0),
+    minGoodStripCharge = cms.double(2069),
 )
 
 # TRACK BUILDING

--- a/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
@@ -55,11 +55,12 @@ lowPtTripletStepTrajectoryFilter = TrackingTools.TrajectoryFiltering.TrajectoryF
                  cms.PSet(refToPSet_ = cms.string('ClusterShapeTrajectoryFilter'))]
     )
 
-import TrackingTools.KalmanUpdators.Chi2MeasurementEstimatorESProducer_cfi
-lowPtTripletStepChi2Est = TrackingTools.KalmanUpdators.Chi2MeasurementEstimatorESProducer_cfi.Chi2MeasurementEstimator.clone(
+import TrackingTools.KalmanUpdators.Chi2ChargeMeasurementEstimatorESProducer_cfi
+lowPtTripletStepChi2Est = TrackingTools.KalmanUpdators.Chi2ChargeMeasurementEstimatorESProducer_cfi.Chi2ChargeMeasurementEstimator.clone(
     ComponentName = cms.string('lowPtTripletStepChi2Est'),
     nSigma = cms.double(3.0),
-    MaxChi2 = cms.double(9.0)
+    MaxChi2 = cms.double(9.0),
+    minGoodStripCharge = cms.double(2069),
 )
 
 # TRACK BUILDING

--- a/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
@@ -13,8 +13,11 @@ mixedTripletStepClusters = cms.EDProducer("TrackClusterRemover",
     minNumberOfLayersWithMeasBeforeFiltering = cms.int32(0),
     pixelClusters = cms.InputTag("siPixelClusters"),
     stripClusters = cms.InputTag("siStripClusters"),
+    doStripChargeCheck = cms.bool(True),
+    stripRecHits = cms.string('siStripMatchedRecHits'),
     Common = cms.PSet(
-        maxChi2 = cms.double(9.0)
+        maxChi2 = cms.double(9.0),
+        minGoodStripCharge = cms.double(2069)
     )
 )
 
@@ -57,12 +60,19 @@ mixedTripletStepSeedsA.RegionFactoryPSet.RegionPSet.ptMin = 0.4
 mixedTripletStepSeedsA.RegionFactoryPSet.RegionPSet.originHalfLength = 15.0
 mixedTripletStepSeedsA.RegionFactoryPSet.RegionPSet.originRadius = 1.5
 
+import RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi
+mixedTripletStepClusterShapeHitFilter  = RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi.ClusterShapeHitFilterESProducer.clone(
+	ComponentName = cms.string('mixedTripletStepClusterShapeHitFilter'),
+        PixelShapeFile= cms.string('RecoPixelVertexing/PixelLowPtUtilities/data/pixelShape.par'),
+	minGoodStripCharge = cms.double(2069)
+	)
+	
 mixedTripletStepSeedsA.SeedComparitorPSet = cms.PSet(
         ComponentName = cms.string('PixelClusterShapeSeedComparitor'),
         FilterAtHelixStage = cms.bool(False),
         FilterPixelHits = cms.bool(True),
         FilterStripHits = cms.bool(True),
-        ClusterShapeHitFilterName = cms.string('ClusterShapeHitFilter'),
+        ClusterShapeHitFilterName = cms.string('mixedTripletStepClusterShapeHitFilter'),
         ClusterShapeCacheSrc = cms.InputTag('siPixelClusterShapeCache')
     )
 
@@ -99,7 +109,7 @@ mixedTripletStepSeedsB.SeedComparitorPSet = cms.PSet(
         FilterAtHelixStage = cms.bool(False),
         FilterPixelHits = cms.bool(True),
         FilterStripHits = cms.bool(True),
-        ClusterShapeHitFilterName = cms.string('ClusterShapeHitFilter'),
+        ClusterShapeHitFilterName = cms.string('mixedTripletStepClusterShapeHitFilter'),
         ClusterShapeCacheSrc = cms.InputTag('siPixelClusterShapeCache')
     )
 
@@ -134,11 +144,12 @@ mixedTripletStepPropagatorOpposite = TrackingTools.MaterialEffects.OppositeMater
     ptMin = 0.1
     )
 
-import TrackingTools.KalmanUpdators.Chi2MeasurementEstimatorESProducer_cfi
-mixedTripletStepChi2Est = TrackingTools.KalmanUpdators.Chi2MeasurementEstimatorESProducer_cfi.Chi2MeasurementEstimator.clone(
+import TrackingTools.KalmanUpdators.Chi2ChargeMeasurementEstimatorESProducer_cfi
+mixedTripletStepChi2Est = TrackingTools.KalmanUpdators.Chi2ChargeMeasurementEstimatorESProducer_cfi.Chi2ChargeMeasurementEstimator.clone(
     ComponentName = cms.string('mixedTripletStepChi2Est'),
     nSigma = cms.double(3.0),
-    MaxChi2 = cms.double(16.0)
+    MaxChi2 = cms.double(16.0),
+    minGoodStripCharge = cms.double(2069)
 )
 
 # TRACK BUILDING

--- a/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
@@ -58,11 +58,13 @@ pixelPairStepTrajectoryFilter = TrackingTools.TrajectoryFiltering.TrajectoryFilt
     minPt = 0.1
     )
 
-import TrackingTools.KalmanUpdators.Chi2MeasurementEstimatorESProducer_cfi
-pixelPairStepChi2Est = TrackingTools.KalmanUpdators.Chi2MeasurementEstimatorESProducer_cfi.Chi2MeasurementEstimator.clone(
+import TrackingTools.KalmanUpdators.Chi2ChargeMeasurementEstimatorESProducer_cfi
+pixelPairStepChi2Est = TrackingTools.KalmanUpdators.Chi2ChargeMeasurementEstimatorESProducer_cfi.Chi2ChargeMeasurementEstimator.clone(
     ComponentName = cms.string('pixelPairStepChi2Est'),
     nSigma = cms.double(3.0),
-    MaxChi2 = cms.double(9.0)
+    MaxChi2 = cms.double(9.0),
+    minGoodStripCharge = cms.double(2069),
+    pTChargeCutThreshold = cms.double(15.)
 )
 
 # TRACK BUILDING

--- a/TrackingTools/KalmanUpdators/interface/Chi2ChargeMeasurementEstimator.h
+++ b/TrackingTools/KalmanUpdators/interface/Chi2ChargeMeasurementEstimator.h
@@ -1,0 +1,55 @@
+#ifndef CommonDet_Chi2ChargeMeasurementEstimator_H
+#define CommonDet_Chi2ChargeMeasurementEstimator_H
+
+/** \class Chi2ChargeMeasurementEstimator
+ *  A Chi2 Measurement Estimator. 
+ *  Computhes the Chi^2 of a TrajectoryState with a RecHit or a 
+ *  Plane. The TrajectoryState must have errors.
+ *  Works for any RecHit dimension. Ported from ORCA.
+ *
+ *  \author todorov, cerati
+ */
+
+#include "TrackingTools/KalmanUpdators/interface/Chi2MeasurementEstimator.h"
+#include "DataFormats/SiStripDetId/interface/SiStripDetId.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h"
+class SiStripCluster;
+class TrackingRecHit;
+class Chi2ChargeMeasurementEstimator GCC11_FINAL : public Chi2MeasurementEstimator {
+public:
+
+  /** Construct with cuts on chi2 and nSigma.
+   *  The cut on Chi2 is used to define the acceptance of RecHits.
+   *  The errors of the trajectory state are multiplied by nSigma 
+   *  to define acceptance of Plane and maximalLocalDisplacement.
+   */
+  explicit Chi2ChargeMeasurementEstimator(double maxChi2, double nSigma,
+	bool cutOnPixelCharge, bool cutOnStripCharge, double minGoodPixelCharge, double minGoodStripCharge) : 
+    Chi2MeasurementEstimator( maxChi2, nSigma), cutOnPixelCharge_(cutOnPixelCharge),
+    cutOnStripCharge_(cutOnStripCharge), minGoodPixelCharge_(minGoodPixelCharge),
+    minGoodStripCharge_(minGoodStripCharge) {}
+
+  using Chi2MeasurementEstimator::estimate;
+  virtual std::pair<bool,double> estimate(const TrajectoryStateOnSurface&,
+				     const TrackingRecHit&) const;
+
+
+  virtual Chi2ChargeMeasurementEstimator* clone() const {
+    return new Chi2ChargeMeasurementEstimator(*this);
+  }
+private:
+  bool cutOnPixelCharge_;
+  bool cutOnStripCharge_;
+  double minGoodPixelCharge_; 
+  double minGoodStripCharge_;
+  inline double minGoodCharge(int subdet) const {return (subdet>2?minGoodStripCharge_:minGoodPixelCharge_);}
+
+  bool thickSensors (const SiStripDetId& detid) const;
+  
+  float sensorThickness (const DetId& detid) const;
+  bool checkClusterCharge(const OmniClusterRef::ClusterStripRef cluster, float chargeCut) const;
+  bool checkCharge(const TrackingRecHit& aRecHit, int subdet, float chargeCut) const;
+
+};
+
+#endif

--- a/TrackingTools/KalmanUpdators/interface/Chi2ChargeMeasurementEstimator.h
+++ b/TrackingTools/KalmanUpdators/interface/Chi2ChargeMeasurementEstimator.h
@@ -2,12 +2,14 @@
 #define CommonDet_Chi2ChargeMeasurementEstimator_H
 
 /** \class Chi2ChargeMeasurementEstimator
- *  A Chi2 Measurement Estimator. 
+ *  A Chi2 Measurement Estimator, checking also the charge of the cluster.
  *  Computhes the Chi^2 of a TrajectoryState with a RecHit or a 
  *  Plane. The TrajectoryState must have errors.
- *  Works for any RecHit dimension. Ported from ORCA.
+ *  If the cluster passes the chi2 cut, the charge is checked. This cut can 
+ *  be bypassed for high-pt cut.
+ *  Works for any RecHit dimension.
  *
- *  \author todorov, cerati
+ *  \author todorov, cerati, speer
  */
 
 #include "TrackingTools/KalmanUpdators/interface/Chi2MeasurementEstimator.h"
@@ -24,10 +26,14 @@ public:
    *  to define acceptance of Plane and maximalLocalDisplacement.
    */
   explicit Chi2ChargeMeasurementEstimator(double maxChi2, double nSigma,
-	bool cutOnPixelCharge, bool cutOnStripCharge, double minGoodPixelCharge, double minGoodStripCharge) : 
+	bool cutOnPixelCharge, bool cutOnStripCharge, double minGoodPixelCharge, double minGoodStripCharge,
+	float pTChargeCutThreshold = 100000.) : 
     Chi2MeasurementEstimator( maxChi2, nSigma), cutOnPixelCharge_(cutOnPixelCharge),
     cutOnStripCharge_(cutOnStripCharge), minGoodPixelCharge_(minGoodPixelCharge),
-    minGoodStripCharge_(minGoodStripCharge) {}
+    minGoodStripCharge_(minGoodStripCharge) {
+      if (pTChargeCutThreshold>=0.) pTChargeCutThreshold_=pTChargeCutThreshold;
+      else pTChargeCutThreshold_=100000;
+    }
 
   using Chi2MeasurementEstimator::estimate;
   virtual std::pair<bool,double> estimate(const TrajectoryStateOnSurface&,
@@ -42,6 +48,7 @@ private:
   bool cutOnStripCharge_;
   double minGoodPixelCharge_; 
   double minGoodStripCharge_;
+  float pTChargeCutThreshold_;
   inline double minGoodCharge(int subdet) const {return (subdet>2?minGoodStripCharge_:minGoodPixelCharge_);}
 
   bool thickSensors (const SiStripDetId& detid) const;

--- a/TrackingTools/KalmanUpdators/interface/Chi2ChargeMeasurementEstimatorESProducer.h
+++ b/TrackingTools/KalmanUpdators/interface/Chi2ChargeMeasurementEstimatorESProducer.h
@@ -1,0 +1,31 @@
+#ifndef TrackingTools_ESProducers_Chi2ChargeMeasurementEstimatorESProducer_h
+#define TrackingTools_ESProducers_Chi2ChargeMeasurementEstimatorESProducer_h
+
+/** \class Chi2ChargeMeasurementEstimatorESProducer
+ *  ESProducer for Chi2ChargeMeasurementEstimator.
+ *
+ *  \author speer
+ */
+
+#include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
+#include "TrackingTools/KalmanUpdators/interface/Chi2ChargeMeasurementEstimator.h"
+#include <boost/shared_ptr.hpp>
+
+class  Chi2ChargeMeasurementEstimatorESProducer: public edm::ESProducer{
+ public:
+  Chi2ChargeMeasurementEstimatorESProducer(const edm::ParameterSet & p);
+  virtual ~Chi2ChargeMeasurementEstimatorESProducer(); 
+  boost::shared_ptr<Chi2MeasurementEstimatorBase> produce(const TrackingComponentsRecord &);
+ private:
+  boost::shared_ptr<Chi2MeasurementEstimatorBase> _estimator;
+  edm::ParameterSet pset_;
+};
+
+
+#endif
+
+
+
+

--- a/TrackingTools/KalmanUpdators/interface/Chi2MeasurementEstimator.h
+++ b/TrackingTools/KalmanUpdators/interface/Chi2MeasurementEstimator.h
@@ -12,7 +12,7 @@
 
 #include "TrackingTools/KalmanUpdators/interface/Chi2MeasurementEstimatorBase.h"
 
-class Chi2MeasurementEstimator GCC11_FINAL : public Chi2MeasurementEstimatorBase {
+class Chi2MeasurementEstimator : public Chi2MeasurementEstimatorBase {
 public:
 
   /** Construct with cuts on chi2 and nSigma.

--- a/TrackingTools/KalmanUpdators/plugins/Chi2ChargeMeasurementEstimatorESProducer.cc
+++ b/TrackingTools/KalmanUpdators/plugins/Chi2ChargeMeasurementEstimatorESProducer.cc
@@ -1,0 +1,39 @@
+#include "TrackingTools/KalmanUpdators/interface/Chi2ChargeMeasurementEstimatorESProducer.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ModuleFactory.h"
+#include "FWCore/Framework/interface/ESProducer.h"
+
+#include <string>
+#include <memory>
+
+using namespace edm;
+
+Chi2ChargeMeasurementEstimatorESProducer::Chi2ChargeMeasurementEstimatorESProducer(const edm::ParameterSet & p) 
+{
+  std::string myname = p.getParameter<std::string>("ComponentName");
+  pset_ = p;
+  setWhatProduced(this,myname);
+}
+
+Chi2ChargeMeasurementEstimatorESProducer::~Chi2ChargeMeasurementEstimatorESProducer() {}
+
+boost::shared_ptr<Chi2MeasurementEstimatorBase> 
+Chi2ChargeMeasurementEstimatorESProducer::produce(const TrackingComponentsRecord & iRecord){ 
+
+  double maxChi2 = pset_.getParameter<double>("MaxChi2");
+  double nSigma = pset_.getParameter<double>("nSigma");
+  bool cutOnPixelCharge_ = pset_.exists("minGoodPixelCharge");
+  bool cutOnStripCharge_ = pset_.exists("minGoodStripCharge");
+  double minGoodPixelCharge_= (cutOnPixelCharge_ ? pset_.getParameter<double>("minGoodPixelCharge") : 0); 
+  double minGoodStripCharge_= (cutOnStripCharge_ ? pset_.getParameter<double>("minGoodStripCharge") : 0);
+
+  _estimator = boost::shared_ptr<Chi2MeasurementEstimatorBase>(
+	new Chi2ChargeMeasurementEstimator(maxChi2,nSigma, cutOnPixelCharge_, cutOnStripCharge_, minGoodPixelCharge_, minGoodStripCharge_));
+  return _estimator;
+}
+
+

--- a/TrackingTools/KalmanUpdators/plugins/Chi2ChargeMeasurementEstimatorESProducer.cc
+++ b/TrackingTools/KalmanUpdators/plugins/Chi2ChargeMeasurementEstimatorESProducer.cc
@@ -30,9 +30,11 @@ Chi2ChargeMeasurementEstimatorESProducer::produce(const TrackingComponentsRecord
   bool cutOnStripCharge_ = pset_.exists("minGoodStripCharge");
   double minGoodPixelCharge_= (cutOnPixelCharge_ ? pset_.getParameter<double>("minGoodPixelCharge") : 0); 
   double minGoodStripCharge_= (cutOnStripCharge_ ? pset_.getParameter<double>("minGoodStripCharge") : 0);
-
+  double pTChargeCutThreshold_= (pset_.exists("pTChargeCutThreshold") ? pset_.getParameter<double>("pTChargeCutThreshold") : -1.);
+  
   _estimator = boost::shared_ptr<Chi2MeasurementEstimatorBase>(
-	new Chi2ChargeMeasurementEstimator(maxChi2,nSigma, cutOnPixelCharge_, cutOnStripCharge_, minGoodPixelCharge_, minGoodStripCharge_));
+	new Chi2ChargeMeasurementEstimator(maxChi2,nSigma, cutOnPixelCharge_, cutOnStripCharge_, 
+		minGoodPixelCharge_, minGoodStripCharge_, pTChargeCutThreshold_));
   return _estimator;
 }
 

--- a/TrackingTools/KalmanUpdators/plugins/module.cc
+++ b/TrackingTools/KalmanUpdators/plugins/module.cc
@@ -7,10 +7,12 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/ModuleFactory.h"
 #include "FWCore/Framework/interface/ESProducer.h"
+#include "TrackingTools/KalmanUpdators/interface/Chi2ChargeMeasurementEstimatorESProducer.h"
 
 DEFINE_FWK_EVENTSETUP_MODULE(KFUpdatorESProducer);
 DEFINE_FWK_EVENTSETUP_MODULE(KFSwitching1DUpdatorESProducer);
 DEFINE_FWK_EVENTSETUP_MODULE(Chi2MeasurementEstimatorESProducer);
 DEFINE_FWK_EVENTSETUP_MODULE(MRHChi2MeasurementEstimatorESProducer);
 DEFINE_FWK_EVENTSETUP_MODULE(TrackingRecHitPropagatorESProducer);
+DEFINE_FWK_EVENTSETUP_MODULE(Chi2ChargeMeasurementEstimatorESProducer);
 

--- a/TrackingTools/KalmanUpdators/python/Chi2ChargeMeasurementEstimatorESProducer_cfi.py
+++ b/TrackingTools/KalmanUpdators/python/Chi2ChargeMeasurementEstimatorESProducer_cfi.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+
+Chi2ChargeMeasurementEstimator = cms.ESProducer("Chi2ChargeMeasurementEstimatorESProducer",
+    ComponentName = cms.string('Chi2Charge'),
+    nSigma = cms.double(3.0),
+    MaxChi2 = cms.double(30.0),
+    minGoodStripCharge = cms.double(2069)
+)
+
+

--- a/TrackingTools/KalmanUpdators/src/Chi2ChargeMeasurementEstimator.cc
+++ b/TrackingTools/KalmanUpdators/src/Chi2ChargeMeasurementEstimator.cc
@@ -1,0 +1,123 @@
+#include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
+#include "TrackingTools/KalmanUpdators/interface/Chi2ChargeMeasurementEstimator.h"
+#include "TrackingTools/PatternTools/interface/MeasurementExtractor.h"
+
+#include "DataFormats/TrackerRecHit2D/interface/BaseTrackerRecHit.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2D.h"
+#include "AnalysisDataFormats/SiStripClusterInfo/interface/SiStripClusterInfo.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h"
+#include "RecoTracker/TransientTrackingRecHit/interface/ProjectedRecHit2D.h"
+#include "RecoTracker/TransientTrackingRecHit/interface/TSiStripMatchedRecHit.h"
+
+bool Chi2ChargeMeasurementEstimator::checkClusterCharge(const OmniClusterRef::ClusterStripRef cluster, float chargeCut) const
+{
+  int clusCharge=accumulate( cluster->amplitudes().begin(), cluster->amplitudes().end(), uint16_t(0));
+//   std::cout << clusCharge<<std::endl;
+  return (clusCharge>chargeCut);
+}
+
+bool Chi2ChargeMeasurementEstimator::checkCharge(const TrackingRecHit& aRecHit,
+	int subdet, float chargeCut) const
+{
+    
+  if (subdet<3) {
+    const SiPixelRecHit *hit = dynamic_cast<const SiPixelRecHit *>(&aRecHit);
+    if (likely(hit!=0)) return (hit->cluster()->charge()>chargeCut);
+    else{
+      const std::type_info &type = typeid(aRecHit);
+      throw cms::Exception("Unknown RecHit Type") << "checkCharge: Wrong recHit type: " << type.name()
+	<< " (SiPixelRecHit) expected";
+    }
+  } else {
+//           printf("Questo e' un %s, che ci fo? %i %lu %u\n", tid.name(), aRecHit.dimension(),aRecHit.recHits().size() ,aRecHit.getRTTI() );
+//  return true;	  
+
+
+///////////////////////////
+
+    if (aRecHit.getRTTI() == 3) { //  This is a matched RecHit
+          const std::type_info &tid = typeid(aRecHit);
+      if (tid == typeid(SiStripMatchedRecHit2D)) {
+        const SiStripMatchedRecHit2D *matchHit = static_cast<const SiStripMatchedRecHit2D *>(&aRecHit);
+        
+	if likely(matchHit!=0) return (checkClusterCharge(matchHit->monoClusterRef().cluster_strip(), chargeCut)
+          &&checkClusterCharge(matchHit->stereoClusterRef().cluster_strip(), chargeCut));
+	else{
+	  const std::type_info &type = typeid(aRecHit);
+	  throw cms::Exception("Unknown RecHit Type") << "checkCharge/SiStripMatchedRecHit2D: Wrong recHit type: " << type.name();
+	}
+      } else if (tid == typeid(TSiStripMatchedRecHit)) {
+        const TransientTrackingRecHit *tHit = static_cast<const TransientTrackingRecHit *>(&aRecHit);
+        const SiStripMatchedRecHit2D *matchHit = static_cast<const SiStripMatchedRecHit2D *>(tHit->hit());
+        
+	if likely(matchHit!=0) return (checkClusterCharge(matchHit->monoClusterRef().cluster_strip(), chargeCut)
+          &&checkClusterCharge(matchHit->stereoClusterRef().cluster_strip(), chargeCut));
+	else{
+	  const std::type_info &type = typeid(aRecHit);
+	  throw cms::Exception("Unknown RecHit Type") << "checkCharge/TSiStripMatchedRecHit: Wrong recHit type: " << type.name();
+	}
+      } else assert(false);
+    } else     {//if (aRecHit.getRTTI() == 2) { //  This is a matched RecHit
+        const TransientTrackingRecHit *projHit = static_cast<const TransientTrackingRecHit *>(&aRecHit);
+       const BaseTrackerRecHit* hit = dynamic_cast<const BaseTrackerRecHit*>(projHit->hit());
+        if likely(hit!=0) return checkClusterCharge(hit->firstClusterRef().cluster_strip(), chargeCut);//    cluster = &*(hit->cluster());
+	else{
+	  const std::type_info &type = typeid(projHit->hit());
+	  throw cms::Exception("Unknown RecHit Type") << "checkCharge/BaseTrackerRecHit: Wrong recHit type: " << type.name();
+	}
+    }
+    
+//     else {
+//         const BaseTrackerRecHit* hit = dynamic_cast<const BaseTrackerRecHit*>(&aRecHit);
+//         if likely(hit!=0) return checkClusterCharge(hit->firstClusterRef().cluster_strip(), chargeCut);//    cluster = &*(hit->cluster());
+// 	else{
+// 	  const std::type_info &type = typeid(aRecHit);
+// 	  throw cms::Exception("Unknown RecHit Type") << "checkCharge/BaseTrackerRecHit: Wrong recHit type: " << type.name();
+// 	}
+//     }
+  }
+
+  throw cms::Exception("Unknown RecHit Type") << "checkCharge: Unknown hit";
+
+}
+
+
+
+float Chi2ChargeMeasurementEstimator::sensorThickness (const DetId& detid) const
+{
+  if (detid.subdetId()>2) {
+    SiStripDetId siStripDetId = detid(); 
+    if (siStripDetId.subdetId()==SiStripDetId::TOB) return 0.047;
+    if (siStripDetId.moduleGeometry()==SiStripDetId::W5 || siStripDetId.moduleGeometry()==SiStripDetId::W6 ||
+        siStripDetId.moduleGeometry()==SiStripDetId::W7)
+	return 0.047;
+    return 0.029; // so it is TEC ring 1-4 or TIB or TOB;
+  } else if (detid.subdetId()==1) return 0.0285;
+  else return 0.027;
+}
+
+
+std::pair<bool,double> 
+Chi2ChargeMeasurementEstimator::estimate(const TrajectoryStateOnSurface& tsos,
+				   const TrackingRecHit& aRecHit) const {
+
+
+
+  std::pair<bool,double> estimateResult = Chi2MeasurementEstimator::estimate(tsos, aRecHit);
+  if ( !estimateResult.first || (!(cutOnStripCharge_||cutOnPixelCharge_))) return estimateResult;
+
+  SiStripDetId detid = aRecHit.geographicalId(); 
+  uint32_t subdet = detid.subdetId();
+  if((detid.det()==1) && (((subdet>2)&&cutOnStripCharge_) || ((subdet<3)&&cutOnPixelCharge_)))   {
+
+    float theDxdz = tsos.localParameters().dxdz();
+    float theDydz = tsos.localParameters().dydz();
+    float chargeCut = (float) minGoodCharge(subdet) * sensorThickness(detid)*(sqrt(1. + theDxdz*theDxdz + theDydz*theDydz));
+
+    if (!checkCharge(aRecHit, subdet, chargeCut)) return HitReturnType(false,0.);
+    else return estimateResult;
+  }
+
+  return estimateResult;
+}
+

--- a/TrackingTools/KalmanUpdators/src/Chi2ChargeMeasurementEstimator.cc
+++ b/TrackingTools/KalmanUpdators/src/Chi2ChargeMeasurementEstimator.cc
@@ -104,7 +104,8 @@ Chi2ChargeMeasurementEstimator::estimate(const TrajectoryStateOnSurface& tsos,
 
 
   std::pair<bool,double> estimateResult = Chi2MeasurementEstimator::estimate(tsos, aRecHit);
-  if ( !estimateResult.first || (!(cutOnStripCharge_||cutOnPixelCharge_))) return estimateResult;
+  if ( !estimateResult.first || (!(cutOnStripCharge_||cutOnPixelCharge_)) || 
+	(tsos.globalMomentum ().perp()>pTChargeCutThreshold_)) return estimateResult;
 
   SiStripDetId detid = aRecHit.geographicalId(); 
   uint32_t subdet = detid.subdetId();

--- a/TrackingTools/KalmanUpdators/src/Chi2ChargeMeasurementEstimator.cc
+++ b/TrackingTools/KalmanUpdators/src/Chi2ChargeMeasurementEstimator.cc
@@ -29,14 +29,9 @@ bool Chi2ChargeMeasurementEstimator::checkCharge(const TrackingRecHit& aRecHit,
 	<< " (SiPixelRecHit) expected";
     }
   } else {
-//           printf("Questo e' un %s, che ci fo? %i %lu %u\n", tid.name(), aRecHit.dimension(),aRecHit.recHits().size() ,aRecHit.getRTTI() );
-//  return true;	  
 
-
-///////////////////////////
-
-    if (aRecHit.getRTTI() == 3) { //  This is a matched RecHit
-          const std::type_info &tid = typeid(aRecHit);
+    if (aRecHit.getRTTI() == 4) { //  This is a matched RecHit
+      const std::type_info &tid = typeid(aRecHit);
       if (tid == typeid(SiStripMatchedRecHit2D)) {
         const SiStripMatchedRecHit2D *matchHit = static_cast<const SiStripMatchedRecHit2D *>(&aRecHit);
         
@@ -57,7 +52,7 @@ bool Chi2ChargeMeasurementEstimator::checkCharge(const TrackingRecHit& aRecHit,
 	  throw cms::Exception("Unknown RecHit Type") << "checkCharge/TSiStripMatchedRecHit: Wrong recHit type: " << type.name();
 	}
       } else assert(false);
-    } else     {//if (aRecHit.getRTTI() == 2) { //  This is a matched RecHit
+    } else {
         const TransientTrackingRecHit *projHit = static_cast<const TransientTrackingRecHit *>(&aRecHit);
        const BaseTrackerRecHit* hit = dynamic_cast<const BaseTrackerRecHit*>(projHit->hit());
         if likely(hit!=0) return checkClusterCharge(hit->firstClusterRef().cluster_strip(), chargeCut);//    cluster = &*(hit->cluster());
@@ -67,14 +62,6 @@ bool Chi2ChargeMeasurementEstimator::checkCharge(const TrackingRecHit& aRecHit,
 	}
     }
     
-//     else {
-//         const BaseTrackerRecHit* hit = dynamic_cast<const BaseTrackerRecHit*>(&aRecHit);
-//         if likely(hit!=0) return checkClusterCharge(hit->firstClusterRef().cluster_strip(), chargeCut);//    cluster = &*(hit->cluster());
-// 	else{
-// 	  const std::type_info &type = typeid(aRecHit);
-// 	  throw cms::Exception("Unknown RecHit Type") << "checkCharge/BaseTrackerRecHit: Wrong recHit type: " << type.name();
-// 	}
-//     }
   }
 
   throw cms::Exception("Unknown RecHit Type") << "checkCharge: Unknown hit";

--- a/TrackingTools/KalmanUpdators/src/Chi2ChargeMeasurementEstimator.cc
+++ b/TrackingTools/KalmanUpdators/src/Chi2ChargeMeasurementEstimator.cc
@@ -40,7 +40,7 @@ bool Chi2ChargeMeasurementEstimator::checkCharge(const TrackingRecHit& aRecHit,
 
 float Chi2ChargeMeasurementEstimator::sensorThickness (const DetId& detid) const
 {
-  if (detid.subdetId()>2) {
+  if (detid.subdetId()>=SiStripDetId::TIB) {
     SiStripDetId siStripDetId = detid(); 
     if (siStripDetId.subdetId()==SiStripDetId::TOB) return 0.047;
     if (siStripDetId.moduleGeometry()==SiStripDetId::W5 || siStripDetId.moduleGeometry()==SiStripDetId::W6 ||


### PR DESCRIPTION
This is an update of #3326. Only changes w.r.t to this is a rebase.
Improvements to the cluster charge for the default tracking sequence:
a) Use thickness of sensors
b) Path-dependent cut in seeding and building
c) pT-cut to switch off CCC for high-pT tracks during building (15 GeV, in iteratio n0 and 3).
