### PR TITLE
Do not overwrite an existing process.options in TimeMemorySummary customise

### DIFF
--- a/Validation/Performance/python/TimeMemorySummary.py
+++ b/Validation/Performance/python/TimeMemorySummary.py
@@ -11,9 +11,12 @@ def customise(process):
     
     #Add these 3 lines to put back the summary for timing information at the end of the logfile
     #(needed for TimeReport report)
-    process.options = cms.untracked.PSet(
-        wantSummary = cms.untracked.bool(True)
-        )
+    if hasattr(process,"options"):
+        process.options.wantSummary = cms.untracked.bool(True)
+    else:
+        process.options = cms.untracked.PSet(
+            wantSummary = cms.untracked.bool(True)
+            )
 
     return(process)
 


### PR DESCRIPTION
The customise function in TimeMemorySummary.py was overwriting a
process.options if one was already defined. When this customise was
used in conjunction with the customise which turned on threading,
this one turned off the threading.
