### PR TITLE
Revert MuonDetLayerGeometry using modules back to legacy type

### DIFF
--- a/RecoMuon/CosmicMuonProducer/src/CosmicMuonProducer.h
+++ b/RecoMuon/CosmicMuonProducer/src/CosmicMuonProducer.h
@@ -6,19 +6,19 @@
  *  \author Chang Liu
  */
 
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/EDProducer.h"
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
 
 class MuonTrackFinder;
 class MuonServiceProxy;
 
-class CosmicMuonProducer : public edm::stream::EDProducer<> {
+class CosmicMuonProducer : public edm::EDProducer {
 public:
   explicit CosmicMuonProducer(const edm::ParameterSet&);
 
    ~CosmicMuonProducer();
   
-  virtual void produce(edm::Event&, const edm::EventSetup&);
+  virtual void produce(edm::Event&, const edm::EventSetup&) override;
 
 private:
   MuonTrackFinder* theTrackFinder;

--- a/RecoMuon/CosmicMuonProducer/src/GlobalCosmicMuonProducer.h
+++ b/RecoMuon/CosmicMuonProducer/src/GlobalCosmicMuonProducer.h
@@ -9,7 +9,7 @@
  *  \author Chang Liu  -  Purdue University <Chang.Liu@cern.ch>
  */
 
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
@@ -17,13 +17,13 @@
 class MuonTrackFinder;
 class MuonServiceProxy;
 
-class GlobalCosmicMuonProducer : public edm::stream::EDProducer<> {
+class GlobalCosmicMuonProducer : public edm::EDProducer {
 public:
   explicit GlobalCosmicMuonProducer(const edm::ParameterSet&);
 
    ~GlobalCosmicMuonProducer();
   
-  virtual void produce(edm::Event&, const edm::EventSetup&);
+  virtual void produce(edm::Event&, const edm::EventSetup&) override;
 
 private:
   edm::EDGetTokenT<reco::TrackCollection> theTrackCollectionToken;

--- a/RecoMuon/GlobalMuonProducer/src/GlobalMuonProducer.h
+++ b/RecoMuon/GlobalMuonProducer/src/GlobalMuonProducer.h
@@ -13,7 +13,7 @@
  *   \author  R.Bellan - INFN TO
  */
 
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/EDProducer.h"
 
 // Input and output collection
 #include "DataFormats/TrackReco/interface/Track.h"
@@ -29,7 +29,7 @@ namespace edm {class ParameterSet; class Event; class EventSetup;}
 class MuonTrackFinder;
 class MuonServiceProxy;
 
-class GlobalMuonProducer : public edm::stream::EDProducer<> {
+class GlobalMuonProducer : public edm::EDProducer {
 
  public:
 
@@ -40,7 +40,7 @@ class GlobalMuonProducer : public edm::stream::EDProducer<> {
   virtual ~GlobalMuonProducer(); 
   
   /// reconstruct muons
-  virtual void produce(edm::Event&, const edm::EventSetup&);
+  virtual void produce(edm::Event&, const edm::EventSetup&) override;
   
  private:
 

--- a/RecoMuon/GlobalMuonProducer/src/TevMuonProducer.h
+++ b/RecoMuon/GlobalMuonProducer/src/TevMuonProducer.h
@@ -13,7 +13,7 @@
  *   \author  R.Bellan - INFN TO
  */
 
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/EDProducer.h"
 #include "RecoMuon/GlobalTrackingTools/interface/GlobalMuonRefitter.h"
 #include "RecoMuon/TrackingTools/interface/MuonTrackLoader.h"
 
@@ -36,7 +36,7 @@ namespace edm {class ParameterSet; class Event; class EventSetup;}
 class MuonTrackFinder;
 class MuonServiceProxy;
 
-class TevMuonProducer : public edm::stream::EDProducer<> {
+class TevMuonProducer : public edm::EDProducer {
 
  public:
 
@@ -47,7 +47,7 @@ class TevMuonProducer : public edm::stream::EDProducer<> {
   virtual ~TevMuonProducer(); 
   
   /// reconstruct muons
-  virtual void produce(edm::Event&, const edm::EventSetup&);
+  virtual void produce(edm::Event&, const edm::EventSetup&) override;
   
  private:
     

--- a/RecoMuon/GlobalTrackingTools/plugins/GlobalTrackQualityProducer.h
+++ b/RecoMuon/GlobalTrackingTools/plugins/GlobalTrackQualityProducer.h
@@ -9,7 +9,7 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -24,14 +24,14 @@
 
 class GlobalMuonRefitter;
 
-class GlobalTrackQualityProducer : public edm::stream::EDProducer<> {
+class GlobalTrackQualityProducer : public edm::EDProducer {
  public:
   explicit GlobalTrackQualityProducer(const edm::ParameterSet& iConfig);
 
   virtual ~GlobalTrackQualityProducer(); // {}
   
  private:
-  virtual void produce(edm::Event&, const edm::EventSetup&);
+  virtual void produce(edm::Event&, const edm::EventSetup&) override;
   virtual std::pair<double,double> kink(Trajectory& muon) const ;
   virtual std::pair<double,double> newChi2(Trajectory& muon) const;
   virtual double trackProbability(Trajectory& track) const;

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.h
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.h
@@ -26,7 +26,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -64,7 +64,7 @@
 class MuonMesh;
 class MuonKinkFinder;
 
-class MuonIdProducer : public edm::stream::EDProducer<> {
+class MuonIdProducer : public edm::EDProducer {
  public:
    typedef reco::Muon::MuonTrackType TrackType;
   

--- a/RecoMuon/MuonIdentification/plugins/MuonTimingProducer.h
+++ b/RecoMuon/MuonIdentification/plugins/MuonTimingProducer.h
@@ -25,7 +25,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -40,7 +40,7 @@
 // class decleration
 //
 
-class MuonTimingProducer : public edm::stream::EDProducer<> {
+class MuonTimingProducer : public edm::EDProducer {
    public:
       explicit MuonTimingProducer(const edm::ParameterSet&);
       ~MuonTimingProducer();

--- a/RecoMuon/MuonSeedGenerator/plugins/CosmicMuonSeedGenerator.h
+++ b/RecoMuon/MuonSeedGenerator/plugins/CosmicMuonSeedGenerator.h
@@ -7,7 +7,7 @@
  *  \author Chang Liu - Purdue University 
  */
 
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
@@ -23,7 +23,7 @@ class TrajectoryStateTransform;
 
 namespace edm {class ParameterSet; class Event; class EventSetup;}
 
-class CosmicMuonSeedGenerator: public edm::stream::EDProducer<> {
+class CosmicMuonSeedGenerator: public edm::EDProducer {
  public:
 
   /// Constructor
@@ -35,7 +35,7 @@ class CosmicMuonSeedGenerator: public edm::stream::EDProducer<> {
   // Operations
 
   /// reconstruct muon's seeds
-  virtual void produce(edm::Event&, const edm::EventSetup&);
+  virtual void produce(edm::Event&, const edm::EventSetup&) override;
 
  private:
 

--- a/RecoMuon/MuonSeedGenerator/plugins/MuonSeedGenerator.h
+++ b/RecoMuon/MuonSeedGenerator/plugins/MuonSeedGenerator.h
@@ -7,7 +7,7 @@
  *  \author R. Bellan - INFN Torino
  */
 
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
 #include <vector>
@@ -17,7 +17,7 @@ class MuonSeedVFinder;
 class MuonSeedVPatternRecognition;
 class MuonSeedVCleaner;
 
-class MuonSeedGenerator: public edm::stream::EDProducer<> {
+class MuonSeedGenerator: public edm::EDProducer {
  public:
 
   /// Constructor
@@ -29,7 +29,7 @@ class MuonSeedGenerator: public edm::stream::EDProducer<> {
   // Operations
 
   /// reconstruct muon's seeds
-  virtual void produce(edm::Event&, const edm::EventSetup&);
+  virtual void produce(edm::Event&, const edm::EventSetup&) override;
 
  protected:
 

--- a/RecoMuon/MuonSeedGenerator/plugins/MuonSeedProducer.h
+++ b/RecoMuon/MuonSeedGenerator/plugins/MuonSeedProducer.h
@@ -13,7 +13,7 @@
  *
  */
 
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/EDProducer.h"
 #include <FWCore/Framework/interface/Frameworkfwd.h>
 #include <FWCore/Framework/interface/Event.h>
 #include <FWCore/ParameterSet/interface/ParameterSet.h>
@@ -22,7 +22,7 @@
 
 class MuonSeedBuilder;
 
-class MuonSeedProducer: public edm::stream::EDProducer<> {
+class MuonSeedProducer: public edm::EDProducer {
  public:
 
   /// Constructor
@@ -34,7 +34,7 @@ class MuonSeedProducer: public edm::stream::EDProducer<> {
   // Operations
 
   /// Get event properties to send to builder to fill seed collection
-  virtual void produce(edm::Event&, const edm::EventSetup&);
+  virtual void produce(edm::Event&, const edm::EventSetup&) override;
 
  private:
 

--- a/RecoMuon/MuonSeedGenerator/plugins/SETMuonSeedProducer.h
+++ b/RecoMuon/MuonSeedGenerator/plugins/SETMuonSeedProducer.h
@@ -10,7 +10,7 @@
 //---- provided need to be fitted properly (starting from the initial estimates also provided).
 //---- Technically all this information is stored as a TrajectorySeed. SS 
 
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "RecoMuon/TrackingTools/interface/RecoMuonEnumerators.h"
 
@@ -27,7 +27,7 @@ class STAFilter;
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 
-class SETMuonSeedProducer : public edm::stream::EDProducer<> {
+class SETMuonSeedProducer : public edm::EDProducer {
   
  public:
   typedef MuonTransientTrackingRecHit::MuonRecHitContainer MuonRecHitContainer;
@@ -40,7 +40,7 @@ class SETMuonSeedProducer : public edm::stream::EDProducer<> {
   virtual ~SETMuonSeedProducer();
   
   // Operations
-  virtual void produce(edm::Event&, const edm::EventSetup&);
+  virtual void produce(edm::Event&, const edm::EventSetup&) override;
 
  protected:
 

--- a/RecoMuon/StandAloneMuonProducer/src/StandAloneMuonProducer.h
+++ b/RecoMuon/StandAloneMuonProducer/src/StandAloneMuonProducer.h
@@ -13,7 +13,7 @@
  *   \author  R.Bellan - INFN TO
  */
 
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
 
@@ -22,7 +22,7 @@ namespace edm {class ParameterSet; class Event; class EventSetup;}
 class MuonTrackFinder;
 class MuonServiceProxy;
 
-class StandAloneMuonProducer : public edm::stream::EDProducer<> {
+class StandAloneMuonProducer : public edm::EDProducer {
 
  public:
 
@@ -33,7 +33,7 @@ class StandAloneMuonProducer : public edm::stream::EDProducer<> {
   virtual ~StandAloneMuonProducer(); 
   
   /// reconstruct muons
-  virtual void produce(edm::Event&, const edm::EventSetup&);
+  virtual void produce(edm::Event&, const edm::EventSetup&) override;
     
  private:
   


### PR DESCRIPTION
We missed the fact that MuonDetLayerGeometry is not thread safe and
therefore all modules which use that class which were converted to
edm::stream::EDProducer<> must be reverted back to edm::EDProducer
so that the framework will treat them as thread unsafe.
