### PR TITLE
Multisource xrootd v4

### DIFF
--- a/Utilities/XrdAdaptor/plugins/XrdStorageMaker.cc
+++ b/Utilities/XrdAdaptor/plugins/XrdStorageMaker.cc
@@ -22,6 +22,13 @@ public:
 class XrdStorageMaker : public StorageMaker
 {
 public:
+  static const unsigned int XRD_DEFAULT_TIMEOUT = 3*60;
+
+  XrdStorageMaker()
+  {
+    setTimeout(XRD_DEFAULT_TIMEOUT);
+  }
+
   /** Open a storage object for the given URL (protocol + path), using the
       @a mode bits.  No temporary files are downloaded.  */
   virtual Storage *open (const std::string &proto,
@@ -95,6 +102,17 @@ public:
         ex << "Invalid log level specified " << level;
         ex.addContext("Calling XrdStorageMaker::setDebugLevel()");
         throw ex;
+    }
+  }
+
+  virtual void setTimeout(unsigned int timeout) override
+  {
+    timeout = timeout ? timeout : XRD_DEFAULT_TIMEOUT;
+    XrdCl::Env *env = XrdCl::DefaultEnv::GetEnv();
+    if (env)
+    {
+      env->PutInt("RequestTimeout", timeout);
+      env->PutInt("ConnectionWindow", timeout);
     }
   }
 

--- a/Utilities/XrdAdaptor/src/XrdFile.cc
+++ b/Utilities/XrdAdaptor/src/XrdFile.cc
@@ -337,21 +337,25 @@ XrdFile::readv (IOPosBuffer *into, IOSize n)
     IOSize result;
     try
     {
+      const int retry_count = 5;
+      for (int retries=0; retries<retry_count; retries++)
+      {
       try
       {
         result = m_requestmanager->handle(cl).get();
       }
       catch (XrootdException& ex)
       {
-        if (ex.getCode() == XrdCl::errInvalidResponse)
+        if ((retries != retry_count-1) && (ex.getCode() == XrdCl::errInvalidResponse))
         {
-          edm::LogWarning("XrdAdaptorInternal") << "Got an invalid response from Xrootd server; retrying once" << std::endl;
+          edm::LogWarning("XrdAdaptorInternal") << "Got an invalid response from Xrootd server; retrying" << std::endl;
           result = m_requestmanager->handle(cl).get();
         }
         else
         {
           throw;
         }
+      }
       }
     }
     catch (edm::Exception& ex)

--- a/Utilities/XrdAdaptor/src/XrdRequest.cc
+++ b/Utilities/XrdAdaptor/src/XrdRequest.cc
@@ -75,7 +75,7 @@ XrdAdaptor::ClientRequest::HandleResponse(XrdCl::XRootDStatus *stat, XrdCl::AnyO
             ex.addContext("XrdAdaptor::ClientRequest::HandleResponse() failure while running connection recovery");
             std::stringstream ss;
             ss << "Original error: '" << status->ToStr() << "' (errno="
-              << status->errNo << ", code=" << status->code << ").";
+              << status->errNo << ", code=" << status->code << ", source=" << (source ? source->ID() : "(unknown source)") << ").";
             ex.addAdditionalInfo(ss.str());
             m_promise.set_exception(std::current_exception());
             {std::unique_lock<std::mutex> sentry(g_ml_mutex);
@@ -92,6 +92,7 @@ XrdAdaptor::ClientRequest::HandleResponse(XrdCl::XRootDStatus *stat, XrdCl::AnyO
                << " connection recovery.";
             ex.addContext("Calling XrdRequestManager::handle()");
             m_manager.addConnections(ex);
+            ex.addAdditionalInfo("Original source of error is " + (source ? source->ID() : "(unknown source)"));
             m_promise.set_exception(std::make_exception_ptr(ex));
             {std::unique_lock<std::mutex> sentry(g_ml_mutex);
             edm::LogWarning("XrdAdaptorInternal") << "Caught a new exception when running connection recovery.";

--- a/Utilities/XrdAdaptor/src/XrdRequestManager.h
+++ b/Utilities/XrdAdaptor/src/XrdRequestManager.h
@@ -156,6 +156,7 @@ private:
 
     public:
         OpenHandler(RequestManager & manager);
+        ~OpenHandler();
 
         /**
          * Handle the file-open response
@@ -177,6 +178,7 @@ private:
         // Can only be touched when m_mutex is held.
         std::unique_ptr<XrdCl::File> m_file;
         std::recursive_mutex m_mutex;
+        std::atomic_flag m_ignore_response;
     };
 
     OpenHandler m_open_handler;

--- a/Utilities/XrdAdaptor/src/XrdSource.cc
+++ b/Utilities/XrdAdaptor/src/XrdSource.cc
@@ -30,7 +30,7 @@ using namespace XrdAdaptor;
 
 Source::Source(timespec now, std::unique_ptr<XrdCl::File> fh)
     : m_lastDowngrade({0, 0}),
-      m_id(fh.get() ? fh->GetDataServer() : "(unknown)"),
+      m_id("(unknown)"),
       m_fh(std::move(fh)),
       m_qm(QualityMetricFactory::get(now, m_id))
 #ifdef XRD_FAKE_SLOW
@@ -39,6 +39,14 @@ Source::Source(timespec now, std::unique_ptr<XrdCl::File> fh)
     //, m_slow(true)
 #endif
 {
+    if (m_fh.get())
+    {
+      if (!m_fh->GetProperty("DataServer", m_id))
+      {
+        edm::LogWarning("XrdFileWarning")
+          << "Source::Source() failed to determine data server name.'";
+      }
+    }
     assert(m_qm.get());
     assert(m_fh.get());
 }


### PR DESCRIPTION
This set of patches adds a few fixes and features over the previous multisource xrootd release.  See the commit notes.

The most important fix prevents a use-after-free for sites that are slow to respond to an open request.
