### PR TITLE
rebase l1t consumes migration

### DIFF
--- a/EventFilter/CSCTFRawToDigi/plugins/CSCTFUnpacker.cc
+++ b/EventFilter/CSCTFRawToDigi/plugins/CSCTFUnpacker.cc
@@ -82,6 +82,7 @@ CSCTFUnpacker::CSCTFUnpacker(const edm::ParameterSet& pset):edm::stream::EDProdu
 	produces<L1CSCTrackCollection>();
 	produces<L1CSCStatusDigiCollection>();
 	produces<CSCTriggerContainer<csctf::TrackStub> >("DT");
+	consumes<FEDRawDataCollection>(producer);
 }
 
 CSCTFUnpacker::~CSCTFUnpacker(){

--- a/EventFilter/DTTFRawToDigi/src/DTTFFEDReader.cc
+++ b/EventFilter/DTTFRawToDigi/src/DTTFFEDReader.cc
@@ -34,7 +34,7 @@ DTTFFEDReader::DTTFFEDReader(const edm::ParameterSet& pset) {
   DTTFInputTag = pset.getParameter<edm::InputTag>("DTTF_FED_Source");
 
   verbose_ =  pset.getUntrackedParameter<bool>("verbose",false);
-
+  consumes<FEDRawDataCollection>(getDTTFInputTag());
 }
 
 DTTFFEDReader::~DTTFFEDReader(){}

--- a/EventFilter/GctRawToDigi/plugins/GctRawToDigi.cc
+++ b/EventFilter/GctRawToDigi/plugins/GctRawToDigi.cc
@@ -107,6 +107,7 @@ GctRawToDigi::GctRawToDigi(const edm::ParameterSet& iConfig) :
   // Error collection
   produces<L1TriggerErrorCollection>();
   usesResource("GctRawToDigi");
+  consumes<FEDRawDataCollection>(inputLabel_);
 }
 
 

--- a/EventFilter/L1GlobalTriggerRawToDigi/src/L1GlobaTriggerEvmRawToDigi.cc
+++ b/EventFilter/L1GlobalTriggerRawToDigi/src/L1GlobaTriggerEvmRawToDigi.cc
@@ -118,6 +118,7 @@ L1GlobalTriggerEvmRawToDigi::L1GlobalTriggerEvmRawToDigi(const edm::ParameterSet
     m_gtfeWord = new L1GtfeExtWord();
     m_tcsWord = new L1TcsWord();
     m_gtFdlWord = new L1GtFdlWord();
+    consumes<FEDRawDataCollection>(m_evmGtInputTag);
 
 }
 

--- a/EventFilter/L1GlobalTriggerRawToDigi/src/L1GlobaTriggerRawToDigi.cc
+++ b/EventFilter/L1GlobalTriggerRawToDigi/src/L1GlobaTriggerRawToDigi.cc
@@ -97,6 +97,7 @@ L1GlobalTriggerRawToDigi::L1GlobalTriggerRawToDigi(const edm::ParameterSet& pSet
     produces<std::vector<L1MuRegionalCand> > ("RPCb");
     produces<std::vector<L1MuRegionalCand> > ("RPCf");
     produces<std::vector<L1MuGMTCand> > ();
+    consumes<FEDRawDataCollection>(m_daqGtInputTag);
 
     // create GTFE, FDL, PSB cards once per producer
     // content will be reset whenever needed

--- a/L1Trigger/CSCTrackFinder/plugins/CSCTFCandidateProducer.cc
+++ b/L1Trigger/CSCTrackFinder/plugins/CSCTFCandidateProducer.cc
@@ -14,6 +14,7 @@ CSCTFCandidateProducer::CSCTFCandidateProducer(const edm::ParameterSet& pset)
   my_builder = new CSCTFCandidateBuilder(mu_sorter_pset);
   input_module = pset.getUntrackedParameter<edm::InputTag>("CSCTrackProducer");
   produces<std::vector<L1MuRegionalCand> >("CSC");
+  consumes<L1CSCTrackCollection>(input_module);
 }
 
 CSCTFCandidateProducer::~CSCTFCandidateProducer()

--- a/L1Trigger/CSCTrackFinder/plugins/CSCTFTrackProducer.cc
+++ b/L1Trigger/CSCTrackFinder/plugins/CSCTFTrackProducer.cc
@@ -38,6 +38,9 @@ CSCTFTrackProducer::CSCTFTrackProducer(const edm::ParameterSet& pset)
   produces<L1CSCTrackCollection>();
   produces<CSCTriggerContainer<csctf::TrackStub> >();
   usesResource("CSCTFTrackProducer");
+  consumes<CSCCorrelatedLCTDigiCollection>(input_module);
+  consumes<L1MuDTChambPhContainer>(dt_producer);
+  consumes<CSCTriggerContainer<csctf::TrackStub> >(directProd);
 }
 
 CSCTFTrackProducer::~CSCTFTrackProducer()

--- a/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.cc
+++ b/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.cc
@@ -56,6 +56,8 @@ CSCTriggerPrimitivesProducer::CSCTriggerPrimitivesProducer(const edm::ParameterS
   produces<CSCCorrelatedLCTDigiCollection>();
   produces<CSCCorrelatedLCTDigiCollection>("MPCSORTED");
   usesResource("CSCTriggerGeometry");
+  consumes<CSCComparatorDigiCollection>(compDigiProducer_);
+  consumes<CSCWireDigiCollection>(wireDigiProducer_);
 }
 
 CSCTriggerPrimitivesProducer::~CSCTriggerPrimitivesProducer() {

--- a/L1Trigger/DTTrackFinder/interface/L1MuDTTFSetup.h
+++ b/L1Trigger/DTTrackFinder/interface/L1MuDTTFSetup.h
@@ -27,6 +27,7 @@
 //------------------------------------
 
 #include <FWCore/ParameterSet/interface/ParameterSet.h>
+#include <FWCore/Framework/interface/ConsumesCollector.h>
 class L1MuDTTrackFinder;
 
 //              ---------------------
@@ -38,7 +39,7 @@ class L1MuDTTFSetup {
   public:
 
     /// constructor
-    L1MuDTTFSetup(const edm::ParameterSet & ps);
+    L1MuDTTFSetup(const edm::ParameterSet & ps,edm::ConsumesCollector && ix);
 
     /// destructor
     virtual ~L1MuDTTFSetup();

--- a/L1Trigger/DTTrackFinder/interface/L1MuDTTrackFinder.h
+++ b/L1Trigger/DTTrackFinder/interface/L1MuDTTrackFinder.h
@@ -37,6 +37,7 @@
 
 #include <FWCore/Framework/interface/Event.h>
 #include <FWCore/ParameterSet/interface/ParameterSet.h>
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 class L1MuDTTFConfig;
 class L1MuDTSecProcMap;
 class L1MuDTSecProcId;
@@ -61,7 +62,7 @@ class L1MuDTTrackFinder {
     typedef std::vector<L1MuRegionalCand>::iterator       TFtracks_iter;
 
     /// constructor
-    L1MuDTTrackFinder(const edm::ParameterSet & ps);
+    L1MuDTTrackFinder(const edm::ParameterSet & ps, edm::ConsumesCollector && iC);
 
     /// destructor
     virtual ~L1MuDTTrackFinder();

--- a/L1Trigger/DTTrackFinder/plugins/DTTrackFinder.cc
+++ b/L1Trigger/DTTrackFinder/plugins/DTTrackFinder.cc
@@ -35,7 +35,7 @@ DTTrackFinder::DTTrackFinder(const edm::ParameterSet & pset) {
   produces<L1MuDTTrackContainer>("DTTF");
   produces<vector<L1MuRegionalCand> >("DT");
 
-  setup1 = new L1MuDTTFSetup(pset);
+  setup1 = new L1MuDTTFSetup(pset,consumesCollector());
   usesResource("DTTrackFinder");
 }
 

--- a/L1Trigger/DTTrackFinder/src/L1MuDTTFSetup.cc
+++ b/L1Trigger/DTTrackFinder/src/L1MuDTTFSetup.cc
@@ -42,8 +42,7 @@ using namespace std;
 // Constructors --
 //----------------
 
-L1MuDTTFSetup::L1MuDTTFSetup(const edm::ParameterSet & ps) : m_tf(new L1MuDTTrackFinder(ps)) {
-
+L1MuDTTFSetup::L1MuDTTFSetup(const edm::ParameterSet & ps, edm::ConsumesCollector && iC) : m_tf(new L1MuDTTrackFinder(ps,std::move(iC))) {
   // setup  the barrel Muon Trigger Track Finder
   m_tf->setup(); 
 

--- a/L1Trigger/DTTrackFinder/src/L1MuDTTrackFinder.cc
+++ b/L1Trigger/DTTrackFinder/src/L1MuDTTrackFinder.cc
@@ -52,7 +52,7 @@ using namespace std;
 // Constructors --
 //----------------
 
-L1MuDTTrackFinder::L1MuDTTrackFinder(const edm::ParameterSet & ps) {
+L1MuDTTrackFinder::L1MuDTTrackFinder(const edm::ParameterSet & ps,edm::ConsumesCollector && iC) {
 
   // set configuration parameters
   if ( m_config == 0 ) m_config = new L1MuDTTFConfig(ps);
@@ -69,6 +69,7 @@ L1MuDTTrackFinder::L1MuDTTrackFinder(const edm::ParameterSet & ps) {
   _cache.reserve(4*17);
   _cache0.reserve(144*17);
 
+  iC.consumes<L1MuDTChambPhContainer>(L1MuDTTFConfig::getDTDigiInputTag());
 }
 
 

--- a/L1Trigger/DTTrigger/interface/DTTrig.h
+++ b/L1Trigger/DTTrigger/interface/DTTrig.h
@@ -32,6 +32,7 @@
 #include "DataFormats/GeometryVector/interface/LocalPoint.h"
 #include "DataFormats/GeometryVector/interface/LocalVector.h"
 #include "L1Trigger/DTSectorCollector/interface/DTSCTrigUnit.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "L1Trigger/DTUtilities/interface/DTTrigData.h"
 #include "L1Trigger/DTBti/interface/DTBtiTrigData.h"
 #include "L1Trigger/DTTraco/interface/DTTracoTrigData.h"
@@ -68,7 +69,7 @@ class DTTrig {
   public:
   
     //! Constructors
-    DTTrig(const edm::ParameterSet &params);
+    DTTrig(const edm::ParameterSet &params, edm::ConsumesCollector && ix);
 
     //! Destructor
     ~DTTrig();

--- a/L1Trigger/DTTrigger/src/DTTrig.cc
+++ b/L1Trigger/DTTrigger/src/DTTrig.cc
@@ -47,7 +47,7 @@
 // Constructors --
 //----------------
 
-DTTrig::DTTrig(const  edm::ParameterSet &params) :
+DTTrig::DTTrig(const  edm::ParameterSet &params,edm::ConsumesCollector && iC) :
  _inputexist(1) ,  _configid(0) , _geomid(0) {
 
   // Set configuration parameters
@@ -59,7 +59,7 @@ DTTrig::DTTrig(const  edm::ParameterSet &params) :
   }
 
   _digitag   = params.getParameter<edm::InputTag>("digiTag");
-
+  iC.consumes<DTDigiCollection>(_digitag);
 }
 
 

--- a/L1Trigger/DTTrigger/src/DTTrigProd.cc
+++ b/L1Trigger/DTTrigger/src/DTTrigProd.cc
@@ -53,7 +53,7 @@ DTTrigProd::DTTrigProd(const ParameterSet& pset) : my_trig(0) {
 
   my_lut_dump_flag = pset.getUntrackedParameter<bool>("lutDumpFlag");
   my_lut_btic = pset.getUntrackedParameter<int>("lutBtic");
-
+  if(!(my_trig)) my_trig = new DTTrig(my_params,consumesCollector());
 }
 
 DTTrigProd::~DTTrigProd(){
@@ -72,20 +72,15 @@ void DTTrigProd::beginRun(edm::Run const& iRun, const edm::EventSetup& iEventSet
 
   my_CCBValid = dtConfig->CCBConfigValidity();
 
-  if (!my_trig) {
-    my_trig = new DTTrig(my_params);
-    my_trig->createTUs(iEventSetup);
-    if (my_debug)
+  my_trig->createTUs(iEventSetup);
+  if (my_debug)
       cout << "[DTTrigProd] TU's Created" << endl;
     
-    if(my_lut_dump_flag) {
+  if(my_lut_dump_flag) {
       cout << "Dumping luts...." << endl;
       my_trig->dumpLuts(my_lut_btic, dtConfig.product());
-    }	
-  }
+  }	
 
-
-  
 }
 
 

--- a/L1Trigger/DTTrigger/src/DTTrigTest.cc
+++ b/L1Trigger/DTTrigger/src/DTTrigTest.cc
@@ -59,7 +59,6 @@ DTTrigTest::DTTrigTest(const ParameterSet& pset): my_trig(0) {
   my_params = pset;
   if (my_debug) cout << "[DTTrigTest] Constructor executed!!!" << endl;
 
-
 }
 
 DTTrigTest::~DTTrigTest(){ 
@@ -201,7 +200,7 @@ void DTTrigTest::beginJob(){
 void DTTrigTest::beginRun(const edm::Run& iRun, const edm::EventSetup& iEventSetup) {
 
   if (!my_trig) {
-    my_trig = new DTTrig(my_params);
+    my_trig = new DTTrig(my_params, consumesCollector());
     my_trig->createTUs(iEventSetup);
     if (my_debug)
       cout << "[DTTrigTest] TU's Created" << endl;

--- a/L1Trigger/GlobalCaloTrigger/plugins/L1GctEmulator.cc
+++ b/L1Trigger/GlobalCaloTrigger/plugins/L1GctEmulator.cc
@@ -106,6 +106,8 @@ L1GctEmulator::L1GctEmulator(const edm::ParameterSet& ps) :
   if (m_verbose) {
     m_gct->print();
   }
+  consumes<L1CaloEmCollection>(m_inputLabel);
+  consumes<L1CaloRegionCollection>(m_inputLabel);
 }
 
 L1GctEmulator::~L1GctEmulator() {

--- a/L1Trigger/GlobalMuonTrigger/src/L1MuGMTPSB.cc
+++ b/L1Trigger/GlobalMuonTrigger/src/L1MuGMTPSB.cc
@@ -49,7 +49,7 @@
 //----------------
 // Constructors --
 //----------------
-L1MuGMTPSB::L1MuGMTPSB(const L1MuGlobalMuonTrigger& gmt) : 
+L1MuGMTPSB::L1MuGMTPSB(const L1MuGlobalMuonTrigger& gmt,edm::ConsumesCollector && iC) : 
                m_gmt(gmt), 
 	       m_RpcMuons(L1MuGMTConfig::MAXRPC),
                m_DtbxMuons(L1MuGMTConfig::MAXDTBX), 
@@ -61,7 +61,11 @@ L1MuGMTPSB::L1MuGMTPSB(const L1MuGlobalMuonTrigger& gmt) :
   m_CscMuons.reserve(L1MuGMTConfig::MAXCSC);
   m_Isol.init(false);
   m_Mip.init(false);
-
+  iC.consumes<std::vector<L1MuRegionalCand> >(L1MuGMTConfig::getDTInputTag());
+  iC.consumes<std::vector<L1MuRegionalCand> >(L1MuGMTConfig::getCSCInputTag());
+  iC.consumes<std::vector<L1MuRegionalCand> >(L1MuGMTConfig::getRPCbInputTag());
+  iC.consumes<std::vector<L1MuRegionalCand> >(L1MuGMTConfig::getRPCfInputTag());
+  iC.consumes<L1CaloRegionCollection>(L1MuGMTConfig::getMipIsoInputTag());
 }
 
 //--------------

--- a/L1Trigger/GlobalMuonTrigger/src/L1MuGMTPSB.h
+++ b/L1Trigger/GlobalMuonTrigger/src/L1MuGMTPSB.h
@@ -34,6 +34,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/L1GlobalMuonTrigger/interface/L1MuRegionalCand.h"
 #include "L1Trigger/GlobalMuonTrigger/src/L1MuGMTMatrix.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 //------------------------------------
 // Collaborating Class Declarations --
@@ -50,7 +51,7 @@ class L1MuGMTPSB {
   public:
 
     /// constructor
-    L1MuGMTPSB(const L1MuGlobalMuonTrigger& gmt);
+    L1MuGMTPSB(const L1MuGlobalMuonTrigger& gmt,edm::ConsumesCollector && iC);
 
     /// destructor
     virtual ~L1MuGMTPSB();

--- a/L1Trigger/GlobalMuonTrigger/src/L1MuGlobalMuonTrigger.cc
+++ b/L1Trigger/GlobalMuonTrigger/src/L1MuGlobalMuonTrigger.cc
@@ -94,7 +94,7 @@ L1MuGlobalMuonTrigger::L1MuGlobalMuonTrigger(const edm::ParameterSet& ps) {
 
   // create new PSB
   if ( L1MuGMTConfig::Debug(2) ) edm::LogVerbatim("GMT_info") << "creating GMT PSB";
-  m_PSB = new L1MuGMTPSB(*this);
+  m_PSB = new L1MuGMTPSB(*this,consumesCollector());
 
   // create new matcher
   if ( L1MuGMTConfig::Debug(2) ) edm::LogVerbatim("GMT_info") << "creating GMT Matcher (0,1)";

--- a/L1Trigger/GlobalTrigger/interface/L1GlobalTriggerGTL.h
+++ b/L1Trigger/GlobalTrigger/interface/L1GlobalTriggerGTL.h
@@ -33,6 +33,7 @@
 #include "FWCore/Utilities/interface/InputTag.h"
 
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 // forward declarations
 class L1GlobalTriggerPSB;
@@ -48,7 +49,7 @@ class L1GlobalTriggerGTL
 public:
 
     // constructors
-    L1GlobalTriggerGTL();
+    L1GlobalTriggerGTL(const edm::InputTag& mutag,edm::ConsumesCollector && iC);
 
     // destructor
     virtual ~L1GlobalTriggerGTL();

--- a/L1Trigger/GlobalTrigger/interface/L1GlobalTriggerPSB.h
+++ b/L1Trigger/GlobalTrigger/interface/L1GlobalTriggerPSB.h
@@ -35,7 +35,7 @@
 #include "CondFormats/L1TObjects/interface/L1GtFwd.h"
 #include "CondFormats/L1TObjects/interface/L1GtBoard.h"
 #include "CondFormats/L1TObjects/interface/L1GtBoardMaps.h"
-
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 // forward declarations
 class L1GctCand;
@@ -61,7 +61,7 @@ class L1GlobalTriggerPSB
 public:
 
     // constructor
-    L1GlobalTriggerPSB();
+    L1GlobalTriggerPSB(const edm::InputTag & caloTag, const std::vector<edm::InputTag>& vecTag, edm::ConsumesCollector && iC);
 
     // destructor
     virtual ~L1GlobalTriggerPSB();

--- a/L1Trigger/GlobalTrigger/src/L1GlobalTrigger.cc
+++ b/L1Trigger/GlobalTrigger/src/L1GlobalTrigger.cc
@@ -204,11 +204,11 @@ L1GlobalTrigger::L1GlobalTrigger(const edm::ParameterSet& parSet) :
     }
 
     // create new PSBs
-    m_gtPSB = new L1GlobalTriggerPSB();
+    m_gtPSB = new L1GlobalTriggerPSB(m_caloGctInputTag,m_technicalTriggersInputTags,consumesCollector());
     m_gtPSB->setVerbosity(m_verbosity);
 
     // create new GTL
-    m_gtGTL = new L1GlobalTriggerGTL();
+    m_gtGTL = new L1GlobalTriggerGTL(m_muGmtInputTag,consumesCollector());
     m_gtGTL->setVerbosity(m_verbosity);
 
     // create new FDL
@@ -260,6 +260,7 @@ L1GlobalTrigger::L1GlobalTrigger(const edm::ParameterSet& parSet) :
     m_l1GtTmVetoAlgoCacheID = 0ULL;
     m_l1GtTmVetoTechCacheID = 0ULL;
 
+    consumes<L1MuGMTReadoutCollection>(m_muGmtInputTag);
 }
 
 // destructor

--- a/L1Trigger/GlobalTrigger/src/L1GlobalTriggerGTL.cc
+++ b/L1Trigger/GlobalTrigger/src/L1GlobalTriggerGTL.cc
@@ -74,7 +74,7 @@
 // forward declarations
 
 // constructor
-L1GlobalTriggerGTL::L1GlobalTriggerGTL() :
+L1GlobalTriggerGTL::L1GlobalTriggerGTL(const edm::InputTag & m_muGmtInputTag,edm::ConsumesCollector && iC) :
     m_candL1Mu( new std::vector<const L1MuGMTCand*>),
     m_isDebugEnabled(edm::isDebugEnabled())
 {
@@ -90,6 +90,8 @@ L1GlobalTriggerGTL::L1GlobalTriggerGTL() :
     // pointer to conversion - actually done in the event loop (cached)
     m_gtEtaPhiConversions = new L1GtEtaPhiConversions();
     m_gtEtaPhiConversions->setVerbosity(m_verbosity);
+
+    iC.consumes<std::vector<L1MuGMTCand> >(m_muGmtInputTag);
 
 }
 

--- a/L1Trigger/GlobalTrigger/src/L1GlobalTriggerPSB.cc
+++ b/L1Trigger/GlobalTrigger/src/L1GlobalTriggerPSB.cc
@@ -46,7 +46,7 @@
 // forward declarations
 
 // constructor
-L1GlobalTriggerPSB::L1GlobalTriggerPSB()
+L1GlobalTriggerPSB::L1GlobalTriggerPSB(const edm::InputTag & m_caloGctInputTag, const std::vector<edm::InputTag>& m_technicalTriggersInputTags, edm::ConsumesCollector && iC)
         :
         m_candL1NoIsoEG ( new std::vector<const L1GctCand*>),
         m_candL1IsoEG   ( new std::vector<const L1GctCand*>),
@@ -63,7 +63,23 @@ L1GlobalTriggerPSB::L1GlobalTriggerPSB()
         m_isDebugEnabled(edm::isDebugEnabled())
 
 {
+    iC.consumes<L1GctEmCandCollection>(edm::InputTag(m_caloGctInputTag.label(),"nonIsoEm",""));
+    iC.consumes<L1GctEmCandCollection>(edm::InputTag(m_caloGctInputTag.label(),"isoEm",""));
+    iC.consumes<L1GctJetCandCollection>(edm::InputTag(m_caloGctInputTag.label(),"cenJets",""));
+    iC.consumes<L1GctJetCandCollection>(edm::InputTag(m_caloGctInputTag.label(),"forJets",""));
+    iC.consumes<L1GctJetCandCollection>(edm::InputTag(m_caloGctInputTag.label(),"tauJets",""));
+    iC.consumes<L1GctEtMissCollection>(m_caloGctInputTag);
+    iC.consumes<L1GctEtTotalCollection>(m_caloGctInputTag);
+    iC.consumes<L1GctEtHadCollection>(m_caloGctInputTag);
+    iC.consumes<L1GctHtMissCollection>(m_caloGctInputTag);
+    iC.consumes<L1GctJetCountsCollection>(m_caloGctInputTag);
+    iC.consumes<L1GctHFBitCountsCollection>(m_caloGctInputTag);
+    iC.consumes<L1GctHFRingEtSumsCollection>(m_caloGctInputTag);
 
+    for (std::vector<edm::InputTag>::const_iterator it = m_technicalTriggersInputTags.begin(); it
+	                != m_technicalTriggersInputTags.end(); it++) {
+	iC.consumes<L1GtTechnicalTriggerRecord>((*it));
+    }
     // empty
 
 }

--- a/L1Trigger/L1ExtraFromDigis/src/L1ExtraParticlesProd.cc
+++ b/L1Trigger/L1ExtraFromDigis/src/L1ExtraParticlesProd.cc
@@ -110,6 +110,18 @@ L1ExtraParticlesProd::L1ExtraParticlesProd(const edm::ParameterSet& iConfig)
    produces< L1HFRingsCollection >() ;
 
    //now do what ever other initialization is needed
+   consumes<L1MuGMTReadoutCollection>(muonSource_);
+   consumes<L1GctEmCandCollection>(isoEmSource_);
+   consumes<L1GctEmCandCollection>(nonIsoEmSource_);
+   consumes<L1GctJetCandCollection>(cenJetSource_);
+   consumes<L1GctJetCandCollection>(forJetSource_);
+   consumes<L1GctJetCandCollection>(tauJetSource_);
+   consumes<L1GctEtTotalCollection>(etTotSource_);
+   consumes<L1GctEtMissCollection>(etMissSource_);
+   consumes<L1GctEtHadCollection>(etHadSource_);
+   consumes<L1GctHtMissCollection>(htMissSource_);
+   consumes<L1GctHFRingEtSumsCollection>(hfRingEtSumsSource_);
+   consumes<L1GctHFBitCountsCollection>(hfRingBitCountsSource_);
 }
 
 

--- a/L1Trigger/RPCTechnicalTrigger/src/RPCTechnicalTrigger.cc
+++ b/L1Trigger/RPCTechnicalTrigger/src/RPCTechnicalTrigger.cc
@@ -101,7 +101,8 @@ RPCTechnicalTrigger::RPCTechnicalTrigger(const edm::ParameterSet& iConfig) {
   m_hasConfig = false;
   m_readConfig = NULL;
   produces<L1GtTechnicalTriggerRecord>();
-  
+  consumes<RPCDigiCollection>(m_rpcDigiLabel);
+  consumes<edm::DetSetVector<RPCDigiSimLink> >(edm::InputTag("simMuonRPCDigis", "RPCDigiSimLink",""));
 }
 
 
@@ -144,7 +145,6 @@ void RPCTechnicalTrigger::produce(edm::Event& iEvent, const edm::EventSetup& iSe
   std::auto_ptr<L1GtTechnicalTriggerRecord> output(new L1GtTechnicalTriggerRecord());
   
   if ( m_useRPCSimLink == 0 ) {
-
     iEvent.getByLabel(m_rpcDigiLabel, pIn);
     if ( ! pIn.isValid() ) {
       edm::LogError("RPCTechnicalTrigger") << "can't find RPCDigiCollection with label: " 

--- a/L1Trigger/RPCTrigger/plugins/RPCTrigger.cc
+++ b/L1Trigger/RPCTrigger/plugins/RPCTrigger.cc
@@ -45,6 +45,7 @@ RPCTrigger::RPCTrigger(const edm::ParameterSet& iConfig):
      
    
   m_label = iConfig.getParameter<std::string>("label");
+  consumes<RPCDigiCollection>(m_label);
 }
 
 

--- a/L1Trigger/RegionalCaloTrigger/plugins/L1RCTProducer.cc
+++ b/L1Trigger/RegionalCaloTrigger/plugins/L1RCTProducer.cc
@@ -51,6 +51,13 @@ L1RCTProducer::L1RCTProducer(const edm::ParameterSet& conf) :
   produces<L1CaloEmCollection>();
   produces<L1CaloRegionCollection>();
 
+  for(unsigned int ihc=0;ihc<hcalDigis.size();ihc++){
+	consumes<edm::SortedCollection<HcalTriggerPrimitiveDigi,edm::StrictWeakOrdering<HcalTriggerPrimitiveDigi> > >(hcalDigis[ihc]);
+  }
+
+  for(unsigned int iec=0;iec<ecalDigis.size();iec++){
+	consumes<edm::SortedCollection<EcalTriggerPrimitiveDigi,edm::StrictWeakOrdering<EcalTriggerPrimitiveDigi> > >(ecalDigis[iec]);
+  }
 }
 
 L1RCTProducer::~L1RCTProducer()


### PR DESCRIPTION
This is a rebase of pull #3395.  This is the first pass L1T consumes migration, from modules identified when running the standard L1T emulation sequence.  These changes have been tested (before the rebase) to bitwise reproduce L1 trigger emulation.
