### PR TITLE
Customise forward ParticleFlow linking

### DIFF
--- a/RecoParticleFlow/PFProducer/python/particleFlowBlock_cff.py
+++ b/RecoParticleFlow/PFProducer/python/particleFlowBlock_cff.py
@@ -5,5 +5,4 @@ import FWCore.ParameterSet.Config as cms
 # note that tracking is redone since we need updated hits and they 
 # are not stored in the event!
 # include "RecoTracker/TrackProducer/data/CTFFinalFitWithMaterial.cff"
-#from RecoParticleFlow.PFProducer.particleFlowBlock_cfi import *
-from RecoParticleFlow.PFProducer.particleFlowBlock2024_cfi import *
+from RecoParticleFlow.PFProducer.particleFlowBlock_cfi import *

--- a/SLHCUpgradeSimulations/Configuration/python/phase2TkCustomsBE5D.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase2TkCustomsBE5D.py
@@ -198,6 +198,11 @@ def customise_Reco(process,pileup):
     process.pixelTracks.FilterPSet.tipMax = cms.double(0.05)
     process.pixelTracks.RegionFactoryPSet.RegionPSet.originRadius =  cms.double(0.02)
 
+    # Particle flow needs to know that the eta range has increased, for
+    # when linking tracks to HF clusters
+    for link in process.particleFlowBlock.linkDefinitions:
+        if hasattr(link,'trackerEtaBoundary') : link.trackerEtaBoundary = cms.double(3.8)
+
     return process
 
 def customise_condOverRides(process):

--- a/SLHCUpgradeSimulations/Configuration/python/phase2TkCustomsBE5DPixel10D.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase2TkCustomsBE5DPixel10D.py
@@ -203,6 +203,11 @@ def customise_Reco(process,pileup):
     process.pixelTracks.FilterPSet.tipMax = cms.double(0.05)
     process.pixelTracks.RegionFactoryPSet.RegionPSet.originRadius =  cms.double(0.02)
 
+    # Particle flow needs to know that the eta range has increased, for
+    # when linking tracks to HF clusters
+    for link in process.particleFlowBlock.linkDefinitions:
+        if hasattr(link,'trackerEtaBoundary') : link.trackerEtaBoundary = cms.double(3.8)
+
     return process
 
 def customise_condOverRides(process):


### PR DESCRIPTION
This customises the particle flow linking between the extended tracker and the HF.  It is to activate the work done in #3482.  See @bachtis' talk in the 24/Apr/2014 TP studies meeting.  That pull request also brings in a configuration error in step3 by referring to a file that is missing from the pull request.  To fix that I changed the default back to the original file.

This pull request might need some changes depending on the response from @bachtis.  Since this also fixes some tests I'll merge this and add any changes required in a subsequent pull request.
