### PR TITLE
fix the time reconstruction with weights

### DIFF
--- a/RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitRecWeightsAlgo.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitRecWeightsAlgo.h
@@ -70,8 +70,8 @@ template<class C> class EcalUncalibRecHitRecWeightsAlgo
     ROOT::Math::SVector <double,3> param = (*(weights[iGainSwitch])) * frame;
     amplitude_ = param(EcalUncalibRecHitRecAbsAlgo<C>::iAmplitude);
     pedestal_ = param(EcalUncalibRecHitRecAbsAlgo<C>::iPedestal);
-    if (amplitude_) jitter_ = param(EcalUncalibRecHitRecAbsAlgo<C>::iTime);
-
+    if (amplitude_) jitter_ = -param(EcalUncalibRecHitRecAbsAlgo<C>::iTime) / amplitude_;
+    else jitter_ = 0.;
 
     //When saturated gain flag i
     if (isSaturated)


### PR DESCRIPTION
Bug fix for the weight-based time reconstruction algorithm. This algorithm is not used in standard RECO, but studies are ongoing for its possible use at HLT level
