### PR TITLE
Made mutable in EventSetupRecord atomic

### DIFF
--- a/FWCore/Framework/interface/EventSetupRecord.h
+++ b/FWCore/Framework/interface/EventSetupRecord.h
@@ -57,6 +57,7 @@ using the 'setEventSetup' and 'clearEventSetup' functions.
 // system include files
 #include <map>
 #include <vector>
+#include <atomic>
 
 // forward declarations
 namespace cms {
@@ -212,7 +213,7 @@ namespace edm {
          std::map<DataKey, DataProxy const*> proxies_ ;
          EventSetup const* eventSetup_;
          unsigned long long cacheIdentifier_;
-         mutable bool transientAccessRequested_;
+         mutable std::atomic<bool> transientAccessRequested_;
       };
    }
 }


### PR DESCRIPTION
The mutable bool in EventSetupRecord is used to keep track if there are any ‘transient’ data requests. To be thread safe this needs to be changed to an std::atomic.
