### PR TITLE
Fix hit pattern tk layers slhc

### DIFF
--- a/DataFormats/TrackReco/interface/HitPattern.h
+++ b/DataFormats/TrackReco/interface/HitPattern.h
@@ -345,6 +345,10 @@ namespace reco {
     int stripTOBLayersNull() const;                  // case 999999: strip TOB
     int stripTECLayersNull() const;                  // case 999999: strip TEC
 
+    int trackerLayersWithMeasurement(uint32_t MaxPixBarrel,uint32_t MaxPixForward) const;// case 0: tracker
+    int pixelLayersWithMeasurement(uint32_t MaxPixBarrel,uint32_t MaxPixForward) const;// case 0: pixel
+    int pixelBarrelLayersWithMeasurement(uint32_t MaxPixBarrel) const;// case 0: pixel PXB
+    int pixelEndcapLayersWithMeasurement(uint32_t MaxPixForward) const;// case 0: pixel PXF
 
 
     /// subdet = 0(all), 1(DT), 2(CSC), 3(RPC); hitType=-1(all), 0=valid, 3=bad
@@ -773,7 +777,6 @@ inline int HitPattern::numberOfInactiveTrackerHits() const {
 
 
 
-
   
   inline int HitPattern::trackerLayersWithMeasurement() const {
     return pixelLayersWithMeasurement() + 
@@ -783,6 +786,24 @@ inline int HitPattern::numberOfInactiveTrackerHits() const {
   inline int HitPattern::pixelLayersWithMeasurement() const {
     return pixelBarrelLayersWithMeasurement() +
       pixelEndcapLayersWithMeasurement();
+  }
+
+  inline int HitPattern::trackerLayersWithMeasurement(uint32_t MaxPixBarrel,uint32_t MaxPixForward) const {
+    return pixelLayersWithMeasurement(MaxPixBarrel,MaxPixForward) + 
+      stripLayersWithMeasurement();
+  }
+  
+  inline int HitPattern::pixelLayersWithMeasurement(uint32_t MaxPixBarrel,uint32_t MaxPixForward) const {
+    return pixelBarrelLayersWithMeasurement(MaxPixBarrel) +
+      pixelEndcapLayersWithMeasurement(MaxPixForward);
+  }
+
+  inline int HitPattern::pixelBarrelLayersWithMeasurement() const {
+    return pixelBarrelLayersWithMeasurement(10);
+  }
+
+  inline int HitPattern::pixelEndcapLayersWithMeasurement() const {
+    return pixelEndcapLayersWithMeasurement(15);
   }
   
   inline int HitPattern::stripLayersWithMeasurement() const {

--- a/DataFormats/TrackReco/interface/HitPattern.h
+++ b/DataFormats/TrackReco/interface/HitPattern.h
@@ -345,10 +345,10 @@ namespace reco {
     int stripTOBLayersNull() const;                  // case 999999: strip TOB
     int stripTECLayersNull() const;                  // case 999999: strip TEC
 
-    int trackerLayersWithMeasurement(uint32_t MaxPixBarrel,uint32_t MaxPixForward) const;// case 0: tracker
-    int pixelLayersWithMeasurement(uint32_t MaxPixBarrel,uint32_t MaxPixForward) const;// case 0: pixel
-    int pixelBarrelLayersWithMeasurement(uint32_t MaxPixBarrel) const;// case 0: pixel PXB
-    int pixelEndcapLayersWithMeasurement(uint32_t MaxPixForward) const;// case 0: pixel PXF
+    int trackerLayersWithMeasurement(uint32_t MaxPixBarrelLayer,uint32_t MaxPixForwardDisk) const;// case 0: tracker
+    int pixelLayersWithMeasurement(uint32_t MaxPixBarrelLayer,uint32_t MaxPixForwardDisk) const;// case 0: pixel
+    int pixelBarrelLayersWithMeasurement(uint32_t MaxPixBarrelLayer) const;// case 0: pixel PXB
+    int pixelEndcapLayersWithMeasurement(uint32_t MaxPixForwardDisk) const;// case 0: pixel PXF
 
 
     /// subdet = 0(all), 1(DT), 2(CSC), 3(RPC); hitType=-1(all), 0=valid, 3=bad
@@ -788,22 +788,22 @@ inline int HitPattern::numberOfInactiveTrackerHits() const {
       pixelEndcapLayersWithMeasurement();
   }
 
-  inline int HitPattern::trackerLayersWithMeasurement(uint32_t MaxPixBarrel,uint32_t MaxPixForward) const {
-    return pixelLayersWithMeasurement(MaxPixBarrel,MaxPixForward) + 
+  inline int HitPattern::trackerLayersWithMeasurement(uint32_t MaxPixBarrelLayer,uint32_t MaxPixForwardDisk) const {
+    return pixelLayersWithMeasurement(MaxPixBarrelLayer,MaxPixForwardDisk) + 
       stripLayersWithMeasurement();
   }
   
-  inline int HitPattern::pixelLayersWithMeasurement(uint32_t MaxPixBarrel,uint32_t MaxPixForward) const {
-    return pixelBarrelLayersWithMeasurement(MaxPixBarrel) +
-      pixelEndcapLayersWithMeasurement(MaxPixForward);
+  inline int HitPattern::pixelLayersWithMeasurement(uint32_t MaxPixBarrelLayer,uint32_t MaxPixForwardDisk) const {
+    return pixelBarrelLayersWithMeasurement(MaxPixBarrelLayer) +
+      pixelEndcapLayersWithMeasurement(MaxPixForwardDisk);
   }
 
   inline int HitPattern::pixelBarrelLayersWithMeasurement() const {
-    return pixelBarrelLayersWithMeasurement(10);
+    return pixelBarrelLayersWithMeasurement(10);//all layers are "pixel" is SLHC geometry - fixme hardcoded
   }
 
   inline int HitPattern::pixelEndcapLayersWithMeasurement() const {
-    return pixelEndcapLayersWithMeasurement(15);
+    return pixelEndcapLayersWithMeasurement(15);//all layers are "pixel" is SLHC geometry - fixme hardcoded
   }
   
   inline int HitPattern::stripLayersWithMeasurement() const {

--- a/DataFormats/TrackReco/src/HitPattern.cc
+++ b/DataFormats/TrackReco/src/HitPattern.cc
@@ -345,19 +345,19 @@ uint32_t HitPattern::getTrackerMonoStereo (uint32_t substr, uint32_t layer) cons
 
 
 
-int HitPattern::pixelBarrelLayersWithMeasurement(uint32_t MaxPixBarrel) const {
+int HitPattern::pixelBarrelLayersWithMeasurement(uint32_t MaxPixBarrelLayer) const {
   int count = 0;
   uint32_t substr = PixelSubdetector::PixelBarrel;
-  for (uint32_t layer=1; layer<=MaxPixBarrel; layer++) {
+  for (uint32_t layer=1; layer<=MaxPixBarrelLayer; layer++) {
     if (getTrackerLayerCase(substr, layer) == 0) count++;
   }
   return count;
 }
 
-int HitPattern::pixelEndcapLayersWithMeasurement(uint32_t MaxPixForward) const {
+int HitPattern::pixelEndcapLayersWithMeasurement(uint32_t MaxPixForwardDisk) const {
   int count = 0;
   uint32_t substr = PixelSubdetector::PixelEndcap;
-  for (uint32_t layer=1; layer<=MaxPixForward; layer++) {
+  for (uint32_t layer=1; layer<=MaxPixForwardDisk; layer++) {
     if (getTrackerLayerCase(substr, layer) == 0) count++;
   }
   return count;

--- a/DataFormats/TrackReco/src/HitPattern.cc
+++ b/DataFormats/TrackReco/src/HitPattern.cc
@@ -345,21 +345,19 @@ uint32_t HitPattern::getTrackerMonoStereo (uint32_t substr, uint32_t layer) cons
 
 
 
-int HitPattern::pixelBarrelLayersWithMeasurement() const {
+int HitPattern::pixelBarrelLayersWithMeasurement(uint32_t MaxPixBarrel) const {
   int count = 0;
   uint32_t substr = PixelSubdetector::PixelBarrel;
-  uint32_t NPixBarrel = 10;
-  for (uint32_t layer=1; layer<=NPixBarrel; layer++) {
+  for (uint32_t layer=1; layer<=MaxPixBarrel; layer++) {
     if (getTrackerLayerCase(substr, layer) == 0) count++;
   }
   return count;
 }
 
-int HitPattern::pixelEndcapLayersWithMeasurement() const {
+int HitPattern::pixelEndcapLayersWithMeasurement(uint32_t MaxPixForward) const {
   int count = 0;
   uint32_t substr = PixelSubdetector::PixelEndcap;
-  uint32_t NPixForward = 10;
-  for (uint32_t layer=1; layer<=NPixForward; layer++) {
+  for (uint32_t layer=1; layer<=MaxPixForward; layer++) {
     if (getTrackerLayerCase(substr, layer) == 0) count++;
   }
   return count;


### PR DESCRIPTION
HitPattern::trackerLayersWithMeasurement() was broken in SLHC due to hardcoded number of pixel layers in pixelEndcapLayersWithMeasurement.

Fixing the problem and taking the opportunity to add methods to get number of layers/disks with a maximum layer/disk value (so that one can restrict to inner pixels).

If possible put in SLHC12 already.
