### PR TITLE
Hack to make MultipleScatteringParametrisation thread safe

### DIFF
--- a/RecoTracker/TkMSParametrization/src/MultipleScatteringParametrisation.cc
+++ b/RecoTracker/TkMSParametrization/src/MultipleScatteringParametrisation.cc
@@ -38,12 +38,16 @@ namespace {
     Keepers() : keepers{&x0DetLayer,&x0AtEta,&x0Averaged}, isInitialised(false) {}
   };
 
-  const Keepers keepers;
+  thread_local Keepers keepers;
+  //NOTE: This is being used to globally cache information from the EventSetup
+  // this should not be done so we need this code changed.
+  //NOTE; the thread_local only works in this case because MultipleScateringParametrisation
+  // instances are only ever created on the stack and not the heap.
 
 }
 
 void MultipleScatteringParametrisation::initKeepers(const edm::EventSetup &iSetup){
-  const_cast<Keepers&>(keepers).init(iSetup);
+  keepers.init(iSetup);
 }
 
 //using namespace PixelRecoUtilities;


### PR DESCRIPTION
Converted the static being modified to be thread_local. However, this
is really just a hack since the static is being used as a 'global'
cache of EventSetup data which is not allowed. This change allows
us to move forward until an actual acceptable change can be made.
