### PR TITLE
Make static into member data of PixelFitterByHelixProjections

### DIFF
--- a/RecoPixelVertexing/PixelTrackFitting/interface/PixelFitterByHelixProjections.h
+++ b/RecoPixelVertexing/PixelTrackFitting/interface/PixelFitterByHelixProjections.h
@@ -7,6 +7,7 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/ESWatcher.h"
 
 #include <vector>
 
@@ -14,6 +15,9 @@
 class TransientTrackingRecHitBuilder;
 class TrackerGeometry;
 class MagneticField;
+class TrackerDigiGeometryRecord;
+class IdealMagneticFieldRecord;
+class TransientRecHitRecord;
 
 
 class PixelFitterByHelixProjections : public PixelFitter {
@@ -43,5 +47,8 @@ private:
   mutable const MagneticField * theField;
   mutable const TransientTrackingRecHitBuilder * theTTRecHitBuilder;
 
+  mutable edm::ESWatcher<TrackerDigiGeometryRecord> theTrackerWatcher;
+  mutable edm::ESWatcher<IdealMagneticFieldRecord> theFieldWatcher;
+  mutable edm::ESWatcher<TransientRecHitRecord> theTTRecHitBuilderWatcher;
 };
 #endif

--- a/RecoPixelVertexing/PixelTrackFitting/src/PixelFitterByHelixProjections.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/src/PixelFitterByHelixProjections.cc
@@ -26,7 +26,6 @@
 
 #include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
-#include "FWCore/Framework/interface/ESWatcher.h"
 
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -109,22 +108,19 @@ reco::Track* PixelFitterByHelixProjections::run(
   vector<GlobalError> errors(nhits);
   vector<bool> isBarrel(nhits);
   
-  static edm::ESWatcher<TrackerDigiGeometryRecord> watcherTrackerDigiGeometryRecord;
-  if (!theTracker || watcherTrackerDigiGeometryRecord.check(es)) {
+  if (theTrackerWatcher.check(es)) {
     edm::ESHandle<TrackerGeometry> trackerESH;
     es.get<TrackerDigiGeometryRecord>().get(trackerESH);
     theTracker = trackerESH.product();
   }
 
-  static edm::ESWatcher<IdealMagneticFieldRecord>  watcherIdealMagneticFieldRecord;
-  if (!theField || watcherIdealMagneticFieldRecord.check(es)) {
+  if (theFieldWatcher.check(es)) {
     edm::ESHandle<MagneticField> fieldESH;
     es.get<IdealMagneticFieldRecord>().get(fieldESH);
     theField = fieldESH.product();
   }
 
-  static edm::ESWatcher<TransientRecHitRecord> watcherTransientRecHitRecord;
-  if (!theTTRecHitBuilder || watcherTransientRecHitRecord.check(es)) {
+  if (theTTRecHitBuilderWatcher.check(es)) {
     edm::ESHandle<TransientTrackingRecHitBuilder> ttrhbESH;
     std::string builderName = theConfig.getParameter<std::string>("TTRHBuilder");
     es.get<TransientRecHitRecord>().get(builderName,ttrhbESH);


### PR DESCRIPTION
Valgind found this statics being modified from multiple threads.
Moving them to be member data solves several problems including the
thread safety issues. The other problem was if multiple
PixelFitterByHelixProjections were being used in a job and the job
crossed an IOV boundary, only one of them would get updated EventSetup
data.
