### PR TITLE
Revert NavigationSchool using modules back to legacy

### DIFF
--- a/RecoEgamma/EgammaPhotonProducers/interface/ConversionTrackCandidateProducer.h
+++ b/RecoEgamma/EgammaPhotonProducers/interface/ConversionTrackCandidateProducer.h
@@ -7,7 +7,7 @@
  **
  ***/
 
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -36,7 +36,7 @@ class OutInConversionTrackFinder;
 class InOutConversionTrackFinder;
 
 // ConversionTrackCandidateProducer inherits from EDProducer, so it can be a module:
-class ConversionTrackCandidateProducer : public edm::stream::EDProducer<> {
+class ConversionTrackCandidateProducer : public edm::EDProducer {
 
  public:
 
@@ -44,7 +44,7 @@ class ConversionTrackCandidateProducer : public edm::stream::EDProducer<> {
   ~ConversionTrackCandidateProducer();
   
   virtual void beginRun (edm::Run const&, edm::EventSetup const & es) override final;
-  virtual void produce(edm::Event& evt, const edm::EventSetup& es);
+  virtual void produce(edm::Event& evt, const edm::EventSetup& es) override;
 
  private:
 

--- a/RecoEgamma/EgammaPhotonProducers/interface/TrackProducerWithSCAssociation.h
+++ b/RecoEgamma/EgammaPhotonProducers/interface/TrackProducerWithSCAssociation.h
@@ -9,20 +9,20 @@
  ** 
  ***/
 
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/EDProducer.h"
 #include "RecoTracker/TrackProducer/interface/TrackProducerBase.h"
 #include "RecoTracker/TrackProducer/interface/TrackProducerAlgorithm.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
 #include "DataFormats/EgammaTrackReco/interface/TrackCandidateCaloClusterAssociation.h"
 
-class TrackProducerWithSCAssociation : public TrackProducerBase<reco::Track>, public edm::stream::EDProducer<> {
+class TrackProducerWithSCAssociation : public TrackProducerBase<reco::Track>, public edm::EDProducer {
 public:
 
   explicit TrackProducerWithSCAssociation(const edm::ParameterSet& iConfig);
 
 
-  virtual void produce(edm::Event&, const edm::EventSetup&);
+  virtual void produce(edm::Event&, const edm::EventSetup&) override;
 
   std::vector<reco::TransientTrack> getTransient(edm::Event&, const edm::EventSetup&);
 

--- a/RecoTracker/TrackProducer/plugins/TrackProducer.h
+++ b/RecoTracker/TrackProducer/plugins/TrackProducer.h
@@ -7,13 +7,13 @@
  *  \author cerati
  */
 
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/EDProducer.h"
 #include "RecoTracker/TrackProducer/interface/KfTrackProducerBase.h"
 #include "RecoTracker/TrackProducer/interface/TrackProducerAlgorithm.h"
 
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
 
-class TrackProducer : public KfTrackProducerBase, public edm::stream::EDProducer<> {
+class TrackProducer : public KfTrackProducerBase, public edm::EDProducer {
 public:
 
   /// Constructor


### PR DESCRIPTION
Valgrind found that NavigationSchool obtained from the EventSetup
is not thread safe. Therefore we reverted all modules using that
instance back to legacy types until the issue can be solved.
