### PR TITLE
remove static in PixelFitterByHelixProjections

### DIFF
--- a/RecoPixelVertexing/PixelTrackFitting/interface/PixelFitterByHelixProjections.h
+++ b/RecoPixelVertexing/PixelTrackFitting/interface/PixelFitterByHelixProjections.h
@@ -7,6 +7,10 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/ESWatcher.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "TrackingTools/Records/interface/TransientRecHitRecord.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 
 #include <vector>
 
@@ -42,6 +46,12 @@ private:
   mutable const TrackerGeometry * theTracker;
   mutable const MagneticField * theField;
   mutable const TransientTrackingRecHitBuilder * theTTRecHitBuilder;
+
+  mutable edm::ESWatcher<TrackerDigiGeometryRecord> watcherTrackerDigiGeometryRecord;
+  mutable edm::ESWatcher<IdealMagneticFieldRecord>  watcherIdealMagneticFieldRecord;
+  mutable edm::ESWatcher<TransientRecHitRecord> watcherTransientRecHitRecord;
+
+
 
 };
 #endif

--- a/RecoPixelVertexing/PixelTrackFitting/src/PixelFitterByHelixProjections.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/src/PixelFitterByHelixProjections.cc
@@ -108,22 +108,20 @@ reco::Track* PixelFitterByHelixProjections::run(
   vector<GlobalPoint> points(nhits);
   vector<GlobalError> errors(nhits);
   vector<bool> isBarrel(nhits);
+
   
-  static edm::ESWatcher<TrackerDigiGeometryRecord> watcherTrackerDigiGeometryRecord;
   if (!theTracker || watcherTrackerDigiGeometryRecord.check(es)) {
     edm::ESHandle<TrackerGeometry> trackerESH;
     es.get<TrackerDigiGeometryRecord>().get(trackerESH);
     theTracker = trackerESH.product();
   }
 
-  static edm::ESWatcher<IdealMagneticFieldRecord>  watcherIdealMagneticFieldRecord;
   if (!theField || watcherIdealMagneticFieldRecord.check(es)) {
     edm::ESHandle<MagneticField> fieldESH;
     es.get<IdealMagneticFieldRecord>().get(fieldESH);
     theField = fieldESH.product();
   }
 
-  static edm::ESWatcher<TransientRecHitRecord> watcherTransientRecHitRecord;
   if (!theTTRecHitBuilder || watcherTransientRecHitRecord.check(es)) {
     edm::ESHandle<TransientTrackingRecHitBuilder> ttrhbESH;
     std::string builderName = theConfig.getParameter<std::string>("TTRHBuilder");


### PR DESCRIPTION
This is NOT a solution.
Just a place holder.
The real "solution" (sort of) is to move 
theField 
theTracker 
theTTRecHitBuilder

in the base case (PixelFitter)
initialize them in a initSetup non const method.

to do to this PixelFitters need to be cloned and owned by the callers 
(actually the PixelFitter is always owed by its client. so no need to clone, just proper use of (non)-const)
such as
PixelTrackReconstruction  that already has a non const initSetup method
alternative is to initialize the three above in the caller and percolate through the calling sequence of the run method...
other clients (TSGFromL1Muon.cc, more??) should take similar action...

apparently there are more PixelFitters children than clients...
