### PR TITLE
make TkMSParametrization thread safe

### DIFF
--- a/RecoTracker/TkMSParametrization/src/MultipleScatteringParametrisation.cc
+++ b/RecoTracker/TkMSParametrization/src/MultipleScatteringParametrisation.cc
@@ -38,7 +38,7 @@ namespace {
     Keepers() : keepers{&x0DetLayer,&x0AtEta,&x0Averaged}, isInitialised(false) {}
   };
 
-  const Keepers keepers;
+  thread_local const Keepers keepers;
 
 }
 


### PR DESCRIPTION
A proper solution would require two/three days of solid work.
Given that a full reimplementation of TkMSParametrization is planned since ages, I estimate that this mitigation is enough.
If no reimplementation will be available in the timescale of Run2, TRK POG will consider a more sane solution 
