### PR TITLE
define dead regions

### DIFF
--- a/SimG4Core/Application/interface/StackingAction.h
+++ b/SimG4Core/Application/interface/StackingAction.h
@@ -43,18 +43,19 @@ private:
   bool                          savePDandCinAll;
   bool                          killInCalo, killInCaloEfH;
   bool                          killHeavy, trackNeutrino, killDeltaRay;
-  bool                          killBeamPipe;
   double                        limitEnergyForVacuum;
   double                        kmaxIon, kmaxNeutron, kmaxProton;
   double                        maxTrackTime;
   unsigned int                  numberTimes;
   std::vector<double>           maxTrackTimes;
   std::vector<std::string>      maxTimeNames;
-  std::vector<const G4Region*>  maxTimeRegions;
+  std::vector<std::string>      deadRegionNames;
 
+  std::vector<const G4Region*>  maxTimeRegions;
   std::vector<const G4Region*>  trackerRegions;
   std::vector<const G4Region*>  muonRegions;
   std::vector<const G4Region*>  caloRegions;
+  std::vector<const G4Region*>  lowdensRegions;
   std::vector<const G4Region*>  deadRegions;
 
   NewTrackAction*               newTA;

--- a/SimG4Core/Application/interface/SteppingAction.h
+++ b/SimG4Core/Application/interface/SteppingAction.h
@@ -31,6 +31,7 @@ private:
   bool initPointer();
 
   bool catchLowEnergyInVacuum(G4Track * theTrack) const; 
+  bool killInsideDeadRegion(G4Track * theTrack) const;
   bool catchLongLived(const G4Step * aStep) const;
   bool killLowEnergy(const G4Step * aStep) const;
   bool isThisVolume(const G4VTouchable* touch, G4VPhysicalVolume* pv) const;
@@ -46,12 +47,15 @@ private:
   double                        maxTrackTime;
   std::vector<double>           maxTrackTimes, ekinMins;
   std::vector<std::string>      maxTimeNames, ekinNames, ekinParticles;
+  std::vector<std::string>      deadRegionNames;
   std::vector<const G4Region*>  maxTimeRegions;
+  std::vector<const G4Region*>  deadRegions;
   std::vector<G4LogicalVolume*> ekinVolumes;
   std::vector<int>              ekinPDG;
   unsigned int                  numberTimes;
   unsigned int                  numberEkins;
   unsigned int                  numberPart;
+  unsigned int                  ndeadRegions;
 
   bool                          initialized;
   bool                          killBeamPipe;

--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -10,9 +10,9 @@ common_heavy_suppression = cms.PSet(
 
 common_maximum_time = cms.PSet(
     MaxTrackTime  = cms.double(500.0),
-    MaxTimeNames  = cms.vstring('ZDCRegion','QuadRegion','InterimRegion'),
-    MaxTrackTimes = cms.vdouble(2000.0,0.,0.),
-    KillBeamPipe            = cms.bool(True),
+    MaxTimeNames  = cms.vstring('ZDCRegion'),
+    MaxTrackTimes = cms.vdouble(2000.0),
+    DeadRegions   = cms.vstring('QuadRegion','CastorRegion','InterimRegion'),
     CriticalEnergyForVacuum = cms.double(2.0),
     CriticalDensity         = cms.double(1e-15)
 )

--- a/SimG4Core/Application/src/SteppingAction.cc
+++ b/SimG4Core/Application/src/SteppingAction.cc
@@ -40,8 +40,6 @@ SteppingAction::SteppingAction(EventAction* e, const edm::ParameterSet & p)
 				       << maxTrackTime/CLHEP::ns 
 				       << " ns";
 
-  initialized = initPointer(); 
-
   numberTimes = maxTrackTimes.size();
   if(numberTimes > 0) {
     for (unsigned int i=0; i<numberTimes; i++) {
@@ -52,6 +50,7 @@ SteppingAction::SteppingAction(EventAction* e, const edm::ParameterSet & p)
     }
   }
 
+  ndeadRegions =  deadRegionNames.size();
   if(ndeadRegions > 0) {
     G4ExceptionDescription ed;   
     ed << "SteppingAction: Number of DeadRegions where all trackes are killed: "
@@ -89,7 +88,7 @@ SteppingAction::~SteppingAction() {}
 
 void SteppingAction::UserSteppingAction(const G4Step * aStep) 
 {
-  //  if (!initialized) { initialized = initPointer(); }
+  if (!initialized) { initialized = initPointer(); }
   m_g4StepSignal(aStep);
 
   G4Track * theTrack = aStep->GetTrack();
@@ -297,7 +296,6 @@ bool SteppingAction::initPointer()
       }
     }
   }
-  ndeadRegions =  deadRegionNames.size();
   if (ndeadRegions > 0) {
     deadRegions.resize(ndeadRegions, 0);
     std::vector<G4Region*>::const_iterator rcite;


### PR DESCRIPTION
Fix warning messages in DIGI step due to wrong DetId of Castor by killing all particles entering CastorRegion at SIM step. The fix is working because no Castor hits are produced.

This fix is coherent with the same approach already used in QuadRegion and InterimRegion.

In order to make this fact clear a new configuration option is added: list of "dead" regions.

For HI runs this options should be overwritten.  
