### PR TITLE
change "double" to "float" in DataFormats/METReco

### DIFF
--- a/DataFormats/METReco/interface/SpecificCaloMETData.h
+++ b/DataFormats/METReco/interface/SpecificCaloMETData.h
@@ -21,6 +21,14 @@
 //____________________________________________________________________________||
 struct SpecificCaloMETData
 {
+  SpecificCaloMETData()
+    : MaxEtInEmTowers(0.0), MaxEtInHadTowers(0.0)
+    , HadEtInHO(0.0), HadEtInHB(0.0),  HadEtInHF(0.0), HadEtInHE(0.0)
+    , EmEtInEB(0.0), EmEtInEE(0.0), EmEtInHF(0.0), EtFractionHadronic(0.0)
+    , EtFractionEm(0.0), METSignificance(0.0), CaloMETInpHF(0.0)
+    , CaloMETInmHF(0.0), CaloSETInpHF(0.0), CaloSETInmHF(0.0)
+    , CaloMETPhiInpHF(0.0), CaloMETPhiInmHF(0.0) { }
+
   double MaxEtInEmTowers;    // Maximum ET in EM towers
   double MaxEtInHadTowers;   // Maximum ET in HCAL towers
   double HadEtInHO;          // Hadronic ET fraction in HO

--- a/DataFormats/METReco/interface/SpecificCaloMETData.h
+++ b/DataFormats/METReco/interface/SpecificCaloMETData.h
@@ -29,24 +29,24 @@ struct SpecificCaloMETData
     , CaloMETInmHF(0.0), CaloSETInpHF(0.0), CaloSETInmHF(0.0)
     , CaloMETPhiInpHF(0.0), CaloMETPhiInmHF(0.0) { }
 
-  double MaxEtInEmTowers;    // Maximum ET in EM towers
-  double MaxEtInHadTowers;   // Maximum ET in HCAL towers
-  double HadEtInHO;          // Hadronic ET fraction in HO
-  double HadEtInHB;          // Hadronic ET in HB
-  double HadEtInHF;          // Hadronic ET in HF
-  double HadEtInHE;          // Hadronic ET in HE
-  double EmEtInEB;           // Em ET in EB
-  double EmEtInEE;           // Em ET in EE
-  double EmEtInHF;           // Em ET in HF
-  double EtFractionHadronic; // Hadronic ET fraction
-  double EtFractionEm;       // Em ET fraction
-  double METSignificance;    // Em ET fraction
-  double CaloMETInpHF;       // CaloMET in HF+
-  double CaloMETInmHF;       // CaloMET in HF-
-  double CaloSETInpHF;       // CaloSET in HF+
-  double CaloSETInmHF;       // CaloSET in HF-
-  double CaloMETPhiInpHF;    // CaloMET-phi in HF+
-  double CaloMETPhiInmHF;    // CaloMET-phi in HF-
+  float MaxEtInEmTowers;    // Maximum ET in EM towers
+  float MaxEtInHadTowers;   // Maximum ET in HCAL towers
+  float HadEtInHO;          // Hadronic ET fraction in HO
+  float HadEtInHB;          // Hadronic ET in HB
+  float HadEtInHF;          // Hadronic ET in HF
+  float HadEtInHE;          // Hadronic ET in HE
+  float EmEtInEB;           // Em ET in EB
+  float EmEtInEE;           // Em ET in EE
+  float EmEtInHF;           // Em ET in HF
+  float EtFractionHadronic; // Hadronic ET fraction
+  float EtFractionEm;       // Em ET fraction
+  float METSignificance;    // Em ET fraction
+  float CaloMETInpHF;       // CaloMET in HF+
+  float CaloMETInmHF;       // CaloMET in HF-
+  float CaloSETInpHF;       // CaloSET in HF+
+  float CaloSETInmHF;       // CaloSET in HF-
+  float CaloMETPhiInpHF;    // CaloMET-phi in HF+
+  float CaloMETPhiInmHF;    // CaloMET-phi in HF-
 
 };
 

--- a/DataFormats/METReco/interface/SpecificCaloMETData.h
+++ b/DataFormats/METReco/interface/SpecificCaloMETData.h
@@ -1,22 +1,28 @@
+// -*- C++ -*-
+
+// Package:    METReco
+// Class:      SpecificCaloMETData
+//
+/** \class SpecificCaloMETData
+
+    SpecificCaloMETData represents MET made from CaloTowers Provide
+    energy contributions from different subdetectors in addition to
+    generic MET parameters
+
+*/
+//
+// Authors:    R. Cavanaugh, UFL
+//
+
+//____________________________________________________________________________||
 #ifndef METReco_SpecificCaloMETData_h
 #define METReco_SpecificCaloMETData_h
 
-/** \class SpecificCaloMETData
- *
- * \short MET made from CaloTowers
- *
- * SpecificCaloMETData represents MET made from CaloTowers
- * Provide energy contributions from different subdetectors
- * in addition to generic MET parameters
- *
- * \author    R. Cavanaugh, UFL
- *
- ************************************************************/
-
+//____________________________________________________________________________||
 struct SpecificCaloMETData
 {
-  double MaxEtInEmTowers;         // Maximum ET in EM towers
-  double MaxEtInHadTowers;        // Maximum ET in HCAL towers
+  double MaxEtInEmTowers;    // Maximum ET in EM towers
+  double MaxEtInHadTowers;   // Maximum ET in HCAL towers
   double HadEtInHO;          // Hadronic ET fraction in HO
   double HadEtInHB;          // Hadronic ET in HB
   double HadEtInHF;          // Hadronic ET in HF
@@ -26,13 +32,15 @@ struct SpecificCaloMETData
   double EmEtInHF;           // Em ET in HF
   double EtFractionHadronic; // Hadronic ET fraction
   double EtFractionEm;       // Em ET fraction
-  double METSignificance;       // Em ET fraction
-  double CaloMETInpHF;         // CaloMET in HF+ 
-  double CaloMETInmHF;         // CaloMET in HF- 
-  double CaloSETInpHF;         // CaloSET in HF+ 
-  double CaloSETInmHF;         // CaloSET in HF- 
-  double CaloMETPhiInpHF;         // CaloMET-phi in HF+ 
-  double CaloMETPhiInmHF;         // CaloMET-phi in HF- 
+  double METSignificance;    // Em ET fraction
+  double CaloMETInpHF;       // CaloMET in HF+
+  double CaloMETInmHF;       // CaloMET in HF-
+  double CaloSETInpHF;       // CaloSET in HF+
+  double CaloSETInmHF;       // CaloSET in HF-
+  double CaloMETPhiInpHF;    // CaloMET-phi in HF+
+  double CaloMETPhiInmHF;    // CaloMET-phi in HF-
 
-}; //public : struct SpecificCaloMETData
-#endif
+};
+
+//____________________________________________________________________________||
+#endif // METReco_SpecificCaloMETData_h

--- a/DataFormats/METReco/interface/SpecificGenMETData.h
+++ b/DataFormats/METReco/interface/SpecificGenMETData.h
@@ -21,6 +21,12 @@
 //____________________________________________________________________________||
 struct SpecificGenMETData
 {
+
+  SpecificGenMETData()
+    : NeutralEMEtFraction(0.0), NeutralHadEtFraction(0.0)
+    , ChargedEMEtFraction(0.0), ChargedHadEtFraction(0.0)
+    , MuonEtFraction(0.0), InvisibleEtFraction(0.0) { }
+
   double NeutralEMEtFraction;
   double NeutralHadEtFraction;
   double ChargedEMEtFraction;

--- a/DataFormats/METReco/interface/SpecificGenMETData.h
+++ b/DataFormats/METReco/interface/SpecificGenMETData.h
@@ -1,41 +1,39 @@
+// -*- C++ -*-
+
+// Package:    METReco
+// Class:      SpecificGenMETData
+//
+/** \class SpecificGenMETData
+
+    SpecificGenMETData represents MET made from HEPMC particles
+    Provide energy contributions from different particles in addition
+    to generic MET parameters
+
+*/
+//  Authors:    Richard Cavanaugh, Ronald Remington
+//
+
+
+//____________________________________________________________________________||
 #ifndef METReco_SpecificGenMETData_h
 #define METReco_SpecificGenMETData_h
 
-/** \class SpecificGenMETData
- *
- * \short MET made from CaloTowers
- *
- * SpecificGenMETData represents MET made from HEPMC particles
- * Provide energy contributions from different particles
- * in addition to generic MET parameters
- *
- * \author    R. Cavanaugh, UFL
- *
- * 
- ************************************************************/
-
-/*
-Revision: Sept. 29, 2009
-Author : Ronald Remington
-Notes:  Changed names of data members to align with those in PFMET.  Should be integrated in CMSSW_3_4_X.
-*/
-
+//____________________________________________________________________________||
 struct SpecificGenMETData
 {
-  double NeutralEMEtFraction ;
-  double NeutralHadEtFraction ;
-  double ChargedEMEtFraction ;
-  double ChargedHadEtFraction ;
-  double MuonEtFraction ;
-  double InvisibleEtFraction ;
+  double NeutralEMEtFraction;
+  double NeutralHadEtFraction;
+  double ChargedEMEtFraction;
+  double ChargedHadEtFraction;
+  double MuonEtFraction;
+  double InvisibleEtFraction;
 
   //Old, obsolete datamembers (to be removed as soon as possible e.g 4_X_Y)
   double m_EmEnergy;         // Event energy from EM particles
   double m_HadEnergy;        // Event energy from Hadronic particles
   double m_InvisibleEnergy;  // Event energy from neutrinos, etc
   double m_AuxiliaryEnergy;  // Event energy from undecayed particles
+};
 
-
-
-}; //public : struct SpecificGenMETData
-#endif
+//____________________________________________________________________________||
+#endif // METReco_SpecificGenMETData_h

--- a/DataFormats/METReco/interface/SpecificGenMETData.h
+++ b/DataFormats/METReco/interface/SpecificGenMETData.h
@@ -27,18 +27,18 @@ struct SpecificGenMETData
     , ChargedEMEtFraction(0.0), ChargedHadEtFraction(0.0)
     , MuonEtFraction(0.0), InvisibleEtFraction(0.0) { }
 
-  double NeutralEMEtFraction;
-  double NeutralHadEtFraction;
-  double ChargedEMEtFraction;
-  double ChargedHadEtFraction;
-  double MuonEtFraction;
-  double InvisibleEtFraction;
+  float NeutralEMEtFraction;
+  float NeutralHadEtFraction;
+  float ChargedEMEtFraction;
+  float ChargedHadEtFraction;
+  float MuonEtFraction;
+  float InvisibleEtFraction;
 
   //Old, obsolete datamembers (to be removed as soon as possible e.g 4_X_Y)
-  double m_EmEnergy;         // Event energy from EM particles
-  double m_HadEnergy;        // Event energy from Hadronic particles
-  double m_InvisibleEnergy;  // Event energy from neutrinos, etc
-  double m_AuxiliaryEnergy;  // Event energy from undecayed particles
+  float m_EmEnergy;         // Event energy from EM particles
+  float m_HadEnergy;        // Event energy from Hadronic particles
+  float m_InvisibleEnergy;  // Event energy from neutrinos, etc
+  float m_AuxiliaryEnergy;  // Event energy from undecayed particles
 };
 
 //____________________________________________________________________________||

--- a/DataFormats/METReco/interface/SpecificPFMETData.h
+++ b/DataFormats/METReco/interface/SpecificPFMETData.h
@@ -17,21 +17,21 @@ struct SpecificPFMETData
 		      , Type6Fraction(0.0), Type7Fraction(0.0) { }
 
   // Data Members (should be renamed with "Et" in them to avoid ambiguities, see below)
-  double NeutralEMFraction;
-  double NeutralHadFraction;
-  double ChargedEMFraction;
-  double ChargedHadFraction;
-  double MuonFraction;
-  double Type6Fraction;
-  double Type7Fraction;
+  float NeutralEMFraction;
+  float NeutralHadFraction;
+  float ChargedEMFraction;
+  float ChargedHadFraction;
+  float MuonFraction;
+  float Type6Fraction;
+  float Type7Fraction;
 
-  // double NeutralEMEtFraction;
-  // double NeutralHadEtFraction;
-  // double ChargedEMEtFraction;
-  // double ChargedHadEtFraction;
-  // double MuonEtFraction;
-  // double Type6EtFraction;
-  // double Type7EtFraction;
+  // float NeutralEMEtFraction;
+  // float NeutralHadEtFraction;
+  // float ChargedEMEtFraction;
+  // float ChargedHadEtFraction;
+  // float MuonEtFraction;
+  // float Type6EtFraction;
+  // float Type7EtFraction;
 
 };
 

--- a/DataFormats/METReco/src/classes_def.xml
+++ b/DataFormats/METReco/src/classes_def.xml
@@ -49,8 +49,9 @@
    <version ClassVersion="11" checksum="1851051058"/>
   </class>
   <class name="std::vector<SpecificPFMETData> "/>
-  <class name="SpecificGenMETData" ClassVersion="10">
+  <class name="SpecificGenMETData" ClassVersion="11">
    <version ClassVersion="10" checksum="2173201550"/>
+   <version ClassVersion="11" checksum="2260055190"/>
   </class>
 
   <class name="reco::MET" ClassVersion="10">

--- a/DataFormats/METReco/src/classes_def.xml
+++ b/DataFormats/METReco/src/classes_def.xml
@@ -43,8 +43,9 @@
   </class>
   <class name="std::vector<SpecificCaloMETData> "/>
 
-  <class name="SpecificPFMETData" ClassVersion="10">
+  <class name="SpecificPFMETData" ClassVersion="11">
    <version ClassVersion="10" checksum="219431109"/>
+   <version ClassVersion="11" checksum="1851051058"/>
   </class>
   <class name="std::vector<SpecificPFMETData> "/>
   <class name="SpecificGenMETData" ClassVersion="10">

--- a/DataFormats/METReco/src/classes_def.xml
+++ b/DataFormats/METReco/src/classes_def.xml
@@ -38,8 +38,9 @@
   <class name="reco::MVAMEtPFCandInfoCollection" />
   <class name="edm::Wrapper<reco::MVAMEtPFCandInfoCollection>" />
 
-  <class name="SpecificCaloMETData" ClassVersion="10">
+  <class name="SpecificCaloMETData" ClassVersion="11">
    <version ClassVersion="10" checksum="3022746385"/>
+   <version ClassVersion="11" checksum="747083523"/>
   </class>
   <class name="std::vector<SpecificCaloMETData> "/>
 

--- a/RecoMET/METAlgorithms/interface/CaloSpecificAlgo.h
+++ b/RecoMET/METAlgorithms/interface/CaloSpecificAlgo.h
@@ -44,9 +44,9 @@ class CaloSpecificAlgo
   typedef math::XYZTLorentzVector LorentzVector;
   typedef math::XYZPoint Point;
   void update_totalEt_totalEm(double &totalEt, double& totalEm, const CaloTower* calotower, bool noHF);
-  void update_MaxTowerEm_MaxTowerHad(double &MaxTowerEm, double &MaxTowerHad, const CaloTower* calotower, bool noHF);
-  void update_EmEtInEB_EmEtInEE(double &EmEtInEB, double &EmEtInEE, const CaloTower* calotower);
-  void update_HadEtInHB_HadEtInHE_HadEtInHO_HadEtInHF_EmEtInHF(double &HadEtInHB, double &HadEtInHE, double &HadEtInHO, double &HadEtInHF, double &EmEtInHF, const CaloTower* calotower, bool noHF);
+  void update_MaxTowerEm_MaxTowerHad(float &MaxTowerEm, float &MaxTowerHad, const CaloTower* calotower, bool noHF);
+  void update_EmEtInEB_EmEtInEE(float &EmEtInEB, float &EmEtInEE, const CaloTower* calotower);
+  void update_HadEtInHB_HadEtInHE_HadEtInHO_HadEtInHF_EmEtInHF(float &HadEtInHB, float &HadEtInHE, float &HadEtInHO, float &HadEtInHF, float &EmEtInHF, const CaloTower* calotower, bool noHF);
   void update_sumEtInpHF_MExInpHF_MEyInpHF_sumEtInmHF_MExInmHF_MEyInmHF(double &sumEtInpHF, double &MExInpHF, double &MEyInpHF, double &sumEtInmHF, double &MExInmHF, double &MEyInmHF, const CaloTower* calotower);
   void remove_HF_from_MET(CommonMETData &met, double sumEtInpHF, double MExInpHF, double MEyInpHF, double sumEtInmHF, double MExInmHF, double MEyInmHF);
   void add_MET_in_HF(SpecificCaloMETData &specific, double sumEtInpHF, double MExInpHF, double MEyInpHF, double sumEtInmHF, double MExInmHF, double MEyInmHF);

--- a/RecoMET/METAlgorithms/interface/CaloSpecificAlgo.h
+++ b/RecoMET/METAlgorithms/interface/CaloSpecificAlgo.h
@@ -43,7 +43,6 @@ class CaloSpecificAlgo
  private:
   typedef math::XYZTLorentzVector LorentzVector;
   typedef math::XYZPoint Point;
-  void initializeSpecificCaloMETData(SpecificCaloMETData &specific);
   void update_totalEt_totalEm(double &totalEt, double& totalEm, const CaloTower* calotower, bool noHF);
   void update_MaxTowerEm_MaxTowerHad(double &MaxTowerEm, double &MaxTowerHad, const CaloTower* calotower, bool noHF);
   void update_EmEtInEB_EmEtInEE(double &EmEtInEB, double &EmEtInEE, const CaloTower* calotower);

--- a/RecoMET/METAlgorithms/src/CaloSpecificAlgo.cc
+++ b/RecoMET/METAlgorithms/src/CaloSpecificAlgo.cc
@@ -82,7 +82,7 @@ void CaloSpecificAlgo::update_totalEt_totalEm(double &totalEt, double& totalEm, 
 }
 
 //____________________________________________________________________________||
-void CaloSpecificAlgo::update_MaxTowerEm_MaxTowerHad(double &MaxTowerEm, double &MaxTowerHad, const CaloTower* calotower, bool noHF)
+void CaloSpecificAlgo::update_MaxTowerEm_MaxTowerHad(float &MaxTowerEm, float &MaxTowerHad, const CaloTower* calotower, bool noHF)
 {
   DetId detIdHcal = find_DetId_of_HCAL_cell_in_constituent_of(calotower);
   DetId detIdEcal = find_DetId_of_ECAL_cell_in_constituent_of(calotower);
@@ -105,7 +105,7 @@ void CaloSpecificAlgo::update_MaxTowerEm_MaxTowerHad(double &MaxTowerEm, double 
 }
 
 //____________________________________________________________________________||
-void CaloSpecificAlgo::update_EmEtInEB_EmEtInEE(double &EmEtInEB, double &EmEtInEE, const CaloTower* calotower)
+void CaloSpecificAlgo::update_EmEtInEB_EmEtInEE(float &EmEtInEB, float &EmEtInEE, const CaloTower* calotower)
 {
   DetId detIdEcal = find_DetId_of_ECAL_cell_in_constituent_of(calotower);
   if(detIdEcal.null()) return;
@@ -122,7 +122,7 @@ void CaloSpecificAlgo::update_EmEtInEB_EmEtInEE(double &EmEtInEB, double &EmEtIn
 }
 
 //____________________________________________________________________________||
-void CaloSpecificAlgo::update_HadEtInHB_HadEtInHE_HadEtInHO_HadEtInHF_EmEtInHF(double &HadEtInHB, double &HadEtInHE, double &HadEtInHO, double &HadEtInHF, double &EmEtInHF, const CaloTower* calotower, bool noHF)
+void CaloSpecificAlgo::update_HadEtInHB_HadEtInHE_HadEtInHO_HadEtInHF_EmEtInHF(float &HadEtInHB, float &HadEtInHE, float &HadEtInHO, float &HadEtInHF, float &EmEtInHF, const CaloTower* calotower, bool noHF)
 {
   DetId detIdHcal = find_DetId_of_HCAL_cell_in_constituent_of(calotower);
   if(detIdHcal.null()) return;

--- a/RecoMET/METAlgorithms/src/CaloSpecificAlgo.cc
+++ b/RecoMET/METAlgorithms/src/CaloSpecificAlgo.cc
@@ -26,7 +26,6 @@ using namespace reco;
 reco::CaloMET CaloSpecificAlgo::addInfo(edm::Handle<edm::View<Candidate> > towers, const CommonMETData& umet, bool noHF, double globalThreshold)
 { 
   SpecificCaloMETData specific;
-  initializeSpecificCaloMETData(specific);
   CommonMETData met = umet;
   double totalEt = 0.0; 
   double totalEm = 0.0;
@@ -63,29 +62,6 @@ reco::CaloMET CaloSpecificAlgo::addInfo(edm::Handle<edm::View<Candidate> > tower
   const Point vtx(0.0, 0.0, 0.0);
   CaloMET caloMET(specific, met.sumet, p4, vtx);
   return caloMET;
-}
-
-//____________________________________________________________________________||
-void CaloSpecificAlgo::initializeSpecificCaloMETData(SpecificCaloMETData &specific)
-{
-  specific.MaxEtInEmTowers = 0.0;    // Maximum energy in EM towers
-  specific.MaxEtInHadTowers = 0.0;   // Maximum energy in HCAL towers
-  specific.HadEtInHO = 0.0;          // Hadronic energy fraction in HO
-  specific.HadEtInHB = 0.0;          // Hadronic energy in HB
-  specific.HadEtInHF = 0.0;          // Hadronic energy in HF
-  specific.HadEtInHE = 0.0;          // Hadronic energy in HE
-  specific.EmEtInEB = 0.0;           // Em energy in EB
-  specific.EmEtInEE = 0.0;           // Em energy in EE
-  specific.EmEtInHF = 0.0;           // Em energy in HF
-  specific.EtFractionHadronic = 0.0; // Hadronic energy fraction
-  specific.EtFractionEm = 0.0;       // Em energy fraction
-  specific.METSignificance = 0.0;
-  specific.CaloMETInpHF = 0.0;        // CaloMET in HF+ 
-  specific.CaloMETInmHF = 0.0;        // CaloMET in HF- 
-  specific.CaloSETInpHF = 0.0;        // CaloSET in HF+ 
-  specific.CaloSETInmHF = 0.0;        // CaloSET in HF- 
-  specific.CaloMETPhiInpHF = 0.0;     // CaloMET-phi in HF+ 
-  specific.CaloMETPhiInmHF = 0.0;     // CaloMET-phi in HF- 
 }
 
 //____________________________________________________________________________||

--- a/RecoMET/METAlgorithms/src/GenSpecificAlgo.cc
+++ b/RecoMET/METAlgorithms/src/GenSpecificAlgo.cc
@@ -125,13 +125,7 @@ SpecificGenMETData GenSpecificAlgo::mkSpecificGenMETData(edm::Handle<edm::View<r
   };
   const static std::set<int> invisiblepdgIdSet(invisiblepdgId, invisiblepdgId + sizeof(invisiblepdgId)/sizeof(int));
   
-  SpecificGenMETData specific = SpecificGenMETData();
-  specific.NeutralEMEtFraction     = 0.0;
-  specific.NeutralHadEtFraction    = 0.0;
-  specific.ChargedEMEtFraction     = 0.0;
-  specific.ChargedHadEtFraction    = 0.0;
-  specific.MuonEtFraction          = 0.0;
-  specific.InvisibleEtFraction     = 0.0;
+  SpecificGenMETData specific;
   double Et_unclassified = 0.0;
   
   for(edm::View<reco::Candidate>::const_iterator iParticle = (particles.product())->begin(); iParticle != (particles.product())->end(); ++iParticle)


### PR DESCRIPTION
continuing from https://github.com/cms-sw/cmssw/pull/3439, this PR changes "double" to "float" in SpecificGenMETData

I made this PR separate from https://github.com/cms-sw/cmssw/pull/3439 so https://github.com/cms-sw/cmssw/pull/3439 can be still merged even if this PR causes an error
