### PR TITLE
No longer share global objects from RecoVertex/ConfigurableVertexReco

### DIFF
--- a/RecoVertex/ConfigurableVertexReco/interface/ConfFitterBuilder.h
+++ b/RecoVertex/ConfigurableVertexReco/interface/ConfFitterBuilder.h
@@ -11,7 +11,7 @@ template < class O > class ConfFitterBuilder {
 public:
   ConfFitterBuilder < O > ( const std::string & name, const std::string & description  )
   {
-    VertexFitterManager::Instance().registerFitter ( name, new O(), description );
+    VertexFitterManager::Instance().registerFitter ( name, []()->AbstractConfFitter*{return new O();}, description );
   }
 };
 

--- a/RecoVertex/ConfigurableVertexReco/interface/ConfRecoBuilder.h
+++ b/RecoVertex/ConfigurableVertexReco/interface/ConfRecoBuilder.h
@@ -11,7 +11,7 @@ template < class O > class ConfRecoBuilder {
 public:
   ConfRecoBuilder < O > ( const std::string & name, const std::string & description  )
   {
-    VertexRecoManager::Instance().registerReconstructor ( name, new O(), description );
+    VertexRecoManager::Instance().registerReconstructor ( name,[]()->AbstractConfReconstructor*{ return new O(); } , description );
   }
 };
 

--- a/RecoVertex/ConfigurableVertexReco/interface/ReconstructorFromFitter.h
+++ b/RecoVertex/ConfigurableVertexReco/interface/ReconstructorFromFitter.h
@@ -1,6 +1,7 @@
 #ifndef _ReconstructorFromFitter_H_
 #define _ReconstructorFromFitter_H_
 
+#include <memory>
 #include "RecoVertex/ConfigurableVertexReco/interface/AbstractConfReconstructor.h"
 #include "RecoVertex/ConfigurableVertexReco/interface/AbstractConfFitter.h"
 
@@ -11,7 +12,7 @@
 class ReconstructorFromFitter : public AbstractConfReconstructor 
 {
   public:
-    ReconstructorFromFitter ( const AbstractConfFitter & );
+  explicit ReconstructorFromFitter ( std::unique_ptr<AbstractConfFitter>&&  );
     ReconstructorFromFitter ( const ReconstructorFromFitter & o );
     ~ReconstructorFromFitter();
     void configure(const edm::ParameterSet&);

--- a/RecoVertex/ConfigurableVertexReco/interface/VertexFitterManager.h
+++ b/RecoVertex/ConfigurableVertexReco/interface/VertexFitterManager.h
@@ -4,6 +4,9 @@
 #include "RecoVertex/ConfigurableVertexReco/interface/AbstractConfFitter.h"
 #include <map>
 #include <string>
+#include <vector>
+#include <functional>
+#include <memory>
 
 /*! \class VertexFitterManager
  *  Class that manages the vertex reconstruction strategies
@@ -13,12 +16,12 @@ class VertexFitterManager {
 
 public:
   static VertexFitterManager & Instance();
-  void registerFitter ( const std::string & name, AbstractConfFitter * o,
+  void registerFitter ( const std::string & name, std::function<AbstractConfFitter* ()> o,
                           const std::string & description );
-  std::string describe ( const std::string & );
+  std::string describe ( const std::string & ) const;
 
-  AbstractConfFitter * get ( const std::string & );
-  std::map < std::string, AbstractConfFitter * > get ();
+  std::unique_ptr<AbstractConfFitter> get ( const std::string & ) const;
+  std::vector<std::string> getNames() const;
 
   ~VertexFitterManager();
   VertexFitterManager * clone() const;
@@ -26,7 +29,7 @@ public:
 private:
   VertexFitterManager ( const VertexFitterManager & );
   VertexFitterManager ();
-  std::map < std::string, AbstractConfFitter * > theAbstractConfFitters;
+  std::map < std::string, std::function<AbstractConfFitter*()> > theAbstractConfFitters;
   std::map < std::string, std::string > theDescription;
 };
 

--- a/RecoVertex/ConfigurableVertexReco/interface/VertexRecoManager.h
+++ b/RecoVertex/ConfigurableVertexReco/interface/VertexRecoManager.h
@@ -4,6 +4,8 @@
 #include "RecoVertex/ConfigurableVertexReco/interface/AbstractConfReconstructor.h"
 #include <map>
 #include <string>
+#include <functional>
+#include <memory>
 
 /*! \class VertexRecoManager
  *  Class that manages the vertex reconstruction strategies
@@ -13,12 +15,12 @@ class VertexRecoManager {
 
 public:
   static VertexRecoManager & Instance();
-  void registerReconstructor ( const std::string & name, AbstractConfReconstructor * o,
+  void registerReconstructor ( const std::string & name, std::function<AbstractConfReconstructor *()> o,
                   const std::string & description );
-  std::string describe ( const std::string & );
+  std::string describe ( const std::string & ) const;
 
-  AbstractConfReconstructor * get ( const std::string & );
-  std::map < std::string, AbstractConfReconstructor * > get ();
+  std::unique_ptr<AbstractConfReconstructor>  get ( const std::string & ) const;
+  std::vector<std::string> getNames() const;
 
   ~VertexRecoManager();
   VertexRecoManager * clone() const;
@@ -26,7 +28,7 @@ public:
 private:
   VertexRecoManager ( const VertexRecoManager & );
   VertexRecoManager ();
-  std::map < std::string, AbstractConfReconstructor * > theAbstractConfReconstructors;
+  std::map < std::string, std::function<AbstractConfReconstructor*()> > theAbstractConfReconstructors;
   std::map < std::string, std::string > theDescription;
 };
 

--- a/RecoVertex/ConfigurableVertexReco/src/ConfigurableVertexFitter.cc
+++ b/RecoVertex/ConfigurableVertexReco/src/ConfigurableVertexFitter.cc
@@ -8,13 +8,12 @@ namespace {
   {
     cout << "[ConfigurableVertexFitter] got no fitter for \""
          << finder << "\"" << endl;
-    map < string, AbstractConfFitter * > valid = 
-      VertexFitterManager::Instance().get();
+    std::vector<std::string> valid =
+      VertexFitterManager::Instance().getNames();
     cout << "  Valid fitters are:";
-    for ( map < string, AbstractConfFitter * >::const_iterator i=valid.begin(); 
-          i!=valid.end() ; ++i )
+    for (const auto& i: valid)
     {
-      if ( i->second ) cout << "  " << i->first;
+      cout << "  " << i;
     }
     cout << endl;
     throw std::string ( finder + " not available!" );
@@ -25,7 +24,7 @@ ConfigurableVertexFitter::ConfigurableVertexFitter (
     const edm::ParameterSet & p ) : theFitter ( 0 )
 {
   string fitter=p.getParameter<string>("fitter");
-  theFitter = VertexFitterManager::Instance().get ( fitter );
+  theFitter = VertexFitterManager::Instance().get ( fitter ).release();
   if (!theFitter)
   {
     errorNoFitter ( fitter );
@@ -35,6 +34,7 @@ ConfigurableVertexFitter::ConfigurableVertexFitter (
 
 ConfigurableVertexFitter::~ConfigurableVertexFitter()
 {
+  delete theFitter;
 }
 
 ConfigurableVertexFitter::ConfigurableVertexFitter 

--- a/RecoVertex/ConfigurableVertexReco/src/ConfigurableVertexReconstructor.cc
+++ b/RecoVertex/ConfigurableVertexReco/src/ConfigurableVertexReconstructor.cc
@@ -9,13 +9,12 @@ namespace {
   {
     edm::LogError ( "ConfigurableVertexReconstructor") << "got no reconstructor for \""
          << finder << "\"";
-    map < string, AbstractConfReconstructor * > valid = 
-      VertexRecoManager::Instance().get();
+    vector <string> valid = 
+      VertexRecoManager::Instance().getNames();
     cout << "  Valid reconstructors are:";
-    for ( map < string, AbstractConfReconstructor * >::const_iterator i=valid.begin(); 
-          i!=valid.end() ; ++i )
+    for (const auto& i : valid)
     {
-      if ( i->second ) cout << "  " << i->first;
+      cout <<" "<<i;
     }
     cout << endl;
     throw std::string ( finder + " not available!" );
@@ -26,7 +25,7 @@ ConfigurableVertexReconstructor::ConfigurableVertexReconstructor (
     const edm::ParameterSet & p ) : theRector ( 0 )
 {
   string finder=p.getParameter<string>("finder");
-  theRector = VertexRecoManager::Instance().get ( finder );
+  theRector = VertexRecoManager::Instance().get ( finder ).release();
   if (!theRector)
   {
     errorNoReconstructor ( finder );
@@ -38,7 +37,7 @@ ConfigurableVertexReconstructor::ConfigurableVertexReconstructor (
 
 ConfigurableVertexReconstructor::~ConfigurableVertexReconstructor()
 {
-//  delete theRector;
+  delete theRector;
 }
 
 ConfigurableVertexReconstructor::ConfigurableVertexReconstructor 

--- a/RecoVertex/ConfigurableVertexReco/src/ReconstructorFromFitter.cc
+++ b/RecoVertex/ConfigurableVertexReco/src/ReconstructorFromFitter.cc
@@ -3,8 +3,8 @@
 
 using namespace std;
 
-ReconstructorFromFitter::ReconstructorFromFitter ( const AbstractConfFitter & f ) :
-  theFitter ( f.clone() )
+ReconstructorFromFitter::ReconstructorFromFitter ( std::unique_ptr<AbstractConfFitter>&& f ) :
+  theFitter ( f.release() )
 {}
 
 vector < TransientVertex > ReconstructorFromFitter::vertices

--- a/RecoVertex/ConfigurableVertexReco/src/VertexFitterManager.cc
+++ b/RecoVertex/ConfigurableVertexReco/src/VertexFitterManager.cc
@@ -11,7 +11,11 @@ void VertexFitterManager::registerFitter (
   theDescription[name]=d;
 
   // every fitter registers as a reconstructor, also
-  VertexRecoManager::Instance().registerReconstructor ( name, [o]()->AbstractConfReconstructor* { return new ReconstructorFromFitter ( *(o()) );}, d);
+  VertexRecoManager::Instance().registerReconstructor ( name, [o]()->AbstractConfReconstructor* {
+      //ReconstructorFromFitter clones the object passed
+      std::unique_ptr<AbstractConfFitter> t{o()};
+      return new ReconstructorFromFitter ( std::move(t) );},
+    d);
 }
 
 VertexFitterManager::~VertexFitterManager()

--- a/RecoVertex/ConfigurableVertexReco/src/VertexFitterManager.cc
+++ b/RecoVertex/ConfigurableVertexReco/src/VertexFitterManager.cc
@@ -5,29 +5,26 @@
 using namespace std;
 
 void VertexFitterManager::registerFitter (
-    const string & name, AbstractConfFitter * o, const string & d )
+      const string & name, std::function<AbstractConfFitter*()> o, const string & d )
 {
   theAbstractConfFitters[name]=o;
   theDescription[name]=d;
 
   // every fitter registers as a reconstructor, also
-  VertexRecoManager::Instance().registerReconstructor ( name, new ReconstructorFromFitter ( *o ), d);
+  VertexRecoManager::Instance().registerReconstructor ( name, [o]()->AbstractConfReconstructor* { return new ReconstructorFromFitter ( *(o()) );}, d);
 }
 
 VertexFitterManager::~VertexFitterManager()
 {
-  /*
-   * Let the VertexRecoManager delete them (they all register there, as well!)
-  for ( map < string, AbstractConfFitter * >::iterator i=theAbstractConfFitters.begin(); 
-        i!=theAbstractConfFitters.end() ; ++i )
-  {
-    delete i->second;
-  }*/
 }
 
-std::string VertexFitterManager::describe ( const std::string & d )
+std::string VertexFitterManager::describe ( const std::string & d ) const
 {
-  return theDescription[d];
+  auto found = theDescription.find(d);
+  if(found == theDescription.end()) {
+    return std::string{};
+  }
+  return found->first;
 }
 
 VertexFitterManager * VertexFitterManager::clone() const
@@ -56,14 +53,24 @@ VertexFitterManager & VertexFitterManager::Instance()
   return singleton;
 }
 
-AbstractConfFitter * VertexFitterManager::get ( const string & s )
+std::unique_ptr<AbstractConfFitter> VertexFitterManager::get ( const string & s ) const
 {
-  return theAbstractConfFitters[s];
+  auto found = theAbstractConfFitters.find(s);
+  if(found == theAbstractConfFitters.end()) {
+    return std::unique_ptr<AbstractConfFitter>{};
+  }
+  return std::unique_ptr<AbstractConfFitter>{found->second()};
 }
 
-map < string, AbstractConfFitter * > VertexFitterManager::get()
+std::vector<std::string> VertexFitterManager::getNames() const 
 {
-  return theAbstractConfFitters;
+  std::vector<std::string> ret;
+  ret.reserve(theAbstractConfFitters.size());
+
+  for(const auto& i : theAbstractConfFitters) {
+    ret.push_back(i.first);
+  }
+  return ret;
 }
 
 VertexFitterManager::VertexFitterManager()

--- a/RecoVertex/ConfigurableVertexReco/src/VertexRecoManager.cc
+++ b/RecoVertex/ConfigurableVertexReco/src/VertexRecoManager.cc
@@ -3,7 +3,7 @@
 using namespace std;
 
 void VertexRecoManager::registerReconstructor (
-    const string & name, AbstractConfReconstructor * o, const string & d )
+					       const string & name, std::function<AbstractConfReconstructor*()> o, const string & d )
 {
   theAbstractConfReconstructors[name]=o;
   theDescription[name]=d;
@@ -11,18 +11,15 @@ void VertexRecoManager::registerReconstructor (
 
 VertexRecoManager::~VertexRecoManager()
 {
-  // why should we delete?
-  /*
-  for ( map < string, AbstractConfReconstructor * >::iterator i=theAbstractConfReconstructors.begin(); 
-        i!=theAbstractConfReconstructors.end() ; ++i )
-  {
-    delete i->second;
-  }*/
 }
 
-std::string VertexRecoManager::describe ( const std::string & d )
+std::string VertexRecoManager::describe ( const std::string & d ) const
 {
-  return theDescription[d];
+  auto found = theDescription.find(d);
+  if(found == theDescription.end()) {
+    return std::string();
+  }
+  return found->second;
 }
 
 VertexRecoManager * VertexRecoManager::clone() const
@@ -51,14 +48,23 @@ VertexRecoManager & VertexRecoManager::Instance()
   return singleton;
 }
 
-AbstractConfReconstructor * VertexRecoManager::get ( const string & s )
+std::unique_ptr<AbstractConfReconstructor> VertexRecoManager::get ( const string & s ) const
 {
-  return theAbstractConfReconstructors[s];
+  auto found = theAbstractConfReconstructors.find(s);
+  if( found == theAbstractConfReconstructors.end()) {
+    return std::unique_ptr<AbstractConfReconstructor>{};
+  }
+  return std::unique_ptr<AbstractConfReconstructor>{found->second()};
 }
 
-map < string, AbstractConfReconstructor * > VertexRecoManager::get()
+std::vector<std::string> VertexRecoManager::getNames() const 
 {
-  return theAbstractConfReconstructors;
+  std::vector<std::string> ret;
+  ret.reserve(theAbstractConfReconstructors.size());
+  for(const auto& i : theAbstractConfReconstructors ) {
+    ret.push_back(i.first);
+  }
+  return ret;
 }
 
 VertexRecoManager::VertexRecoManager()


### PR DESCRIPTION
The classes VertexFitterManager and VertexRecoManager were allowing
code to get access to single instances of  AbstractConfReconstructor and
AbstractConfFitter. This causes thread safety issues. This change
converts the Managers to use factories instead so each caller gets
their own copy. This also solved a memory leak problem in the client
code where sometimes the shared code got the object from a Manager
and sometimes it got it from calling clone(). In the clone() case
the object was never deleted. Now the object is always deleted.
