### PR TITLE
bugfix from followup of #3385 for fastsim.

### DIFF
--- a/DataFormats/ParticleFlowReco/interface/PFBlockElement.h
+++ b/DataFormats/ParticleFlowReco/interface/PFBlockElement.h
@@ -102,7 +102,7 @@ namespace reco {
     virtual const PFRecTrackRef& trackRefPF()  const {return nullPFRecTrack_; }
     virtual const PFClusterRef& clusterRef() const {return nullPFCluster_; }
     virtual const PFDisplacedTrackerVertexRef& displacedVertexRef(TrackType trType) const { return nullPFDispVertex_; }
-    virtual const ConversionRef&    convRef() const { return nullConv_;}
+    virtual const ConversionRefVector&    convRefs() const { return nullConv_;}
     virtual const MuonRef& muonRef() const { return nullMuon_; }
     virtual const VertexCompositeCandidateRef& V0Ref()  const { return nullVertex_; }
     virtual void setDisplacedVertexRef(const PFDisplacedTrackerVertexRef& niref, TrackType trType) { 
@@ -155,7 +155,7 @@ namespace reco {
     const static PFRecTrackRef nullPFRecTrack_;
     const static PFClusterRef nullPFCluster_;
     const static PFDisplacedTrackerVertexRef nullPFDispVertex_;
-    const static ConversionRef nullConv_;
+    const static ConversionRefVector nullConv_;
     const static MuonRef nullMuon_;
     const static VertexCompositeCandidateRef nullVertex_;
   

--- a/DataFormats/ParticleFlowReco/interface/PFBlockElementTrack.h
+++ b/DataFormats/ParticleFlowReco/interface/PFBlockElementTrack.h
@@ -100,11 +100,11 @@ namespace reco {
     }
 
     /// \return ref to original recoConversion
-    const ConversionRef& convRef() const {return convRef_;} 
+    const ConversionRefVector& convRefs() const {return convRefs_;} 
 
     /// \set the ref to  gamma conversion
     void setConversionRef(const ConversionRef& convRef, TrackType trType) { 
-      convRef_ = convRef; setTrackType(trType,true); 
+      convRefs_.push_back(convRef); setTrackType(trType,true); 
     } 
 
     /// \return ref to original V0
@@ -140,7 +140,7 @@ namespace reco {
     reco::MuonRef muonRef_;
 
     /// reference to reco conversion
-    ConversionRef convRef_;      
+    ConversionRefVector convRefs_;      
 
     /// reference to V0
     VertexCompositeCandidateRef v0Ref_;

--- a/DataFormats/ParticleFlowReco/src/PFBlockElement.cc
+++ b/DataFormats/ParticleFlowReco/src/PFBlockElement.cc
@@ -10,7 +10,7 @@ const reco::PFRecTrackRef reco::PFBlockElement::nullPFRecTrack_ = reco::PFRecTra
 const reco::PFClusterRef reco::PFBlockElement::nullPFCluster_ = reco::PFClusterRef();
 const reco::PFDisplacedTrackerVertexRef reco::PFBlockElement::nullPFDispVertex_ = 
   reco::PFDisplacedTrackerVertexRef();
-const reco::ConversionRef reco::PFBlockElement::nullConv_ = reco::ConversionRef();
+const reco::ConversionRefVector reco::PFBlockElement::nullConv_ = reco::ConversionRefVector();
 const reco::MuonRef  reco::PFBlockElement::nullMuon_ = reco::MuonRef();
 const reco::VertexCompositeCandidateRef reco::PFBlockElement::nullVertex_ = reco::VertexCompositeCandidateRef();
 

--- a/DataFormats/ParticleFlowReco/src/classes_def_2.xml
+++ b/DataFormats/ParticleFlowReco/src/classes_def_2.xml
@@ -128,8 +128,9 @@
   <class name="edm::OwnVector<reco::PFBlockElement, edm::ClonePolicy<reco::PFBlockElement> >"/>
   <class name="edm::Wrapper<edm::OwnVector<reco::PFBlockElement, edm::ClonePolicy<reco::PFBlockElement> > >" />
 
-  <class name="reco::PFBlockElementTrack" ClassVersion="10">
+  <class name="reco::PFBlockElementTrack" ClassVersion="11">
    <version ClassVersion="10" checksum="2342660248"/>
+   <version ClassVersion="11" checksum="1450496342"/>
 <!-- removed by Florian. It useful to have this Ref (especially for a reprocessing)   
     <field name="trackRefPF_" transient="true"/>
 -->

--- a/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporter.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporter.cc
@@ -58,7 +58,7 @@ importToBlock( const edm::Event& e,
       if( (*itr)->type() == reco::PFBlockElement::TRACK ) {
 	const reco::PFBlockElementTrack* trkel =
 	  static_cast<reco::PFBlockElementTrack*>(itr->get());
-	const reco::ConversionRef& cRef = trkel->convRef();
+	const reco::ConversionRefVector& cRef = trkel->convRefs();
 	const reco::PFDisplacedTrackerVertexRef& dvRef = 
 	  trkel->displacedVertexRef(reco::PFBlockElement::T_FROM_DISP);
 	const reco::VertexCompositeCandidateRef& v0Ref =
@@ -66,7 +66,7 @@ importToBlock( const edm::Event& e,
 	// if there is no displaced vertex reference  and it is marked
 	// as a conversion it's gotta be a converted brem
 	if( trkel->trackType(reco::PFBlockElement::T_FROM_GAMMACONV) &&
-	    cRef.isNull() && dvRef.isNull() && v0Ref.isNull() ) {
+	    cRef.size() == 0 && dvRef.isNull() && v0Ref.isNull() ) {
 	  // if the Pt resolution is bad we kill this element
 	  if( !goodPtResolution( trkel->trackRef() ) ) {
 	    itr = elems.erase(itr);

--- a/RecoParticleFlow/PFProducer/plugins/linkers/TrackAndTrackLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/linkers/TrackAndTrackLinker.cc
@@ -60,12 +60,16 @@ testLink( const reco::PFBlockElement* elem1,
     if( ni1_FROM_DISP == ni2_FROM_DISP ) { dist = 1.0; }
 
   if (  elem1->trackType(reco::PFBlockElement::T_FROM_GAMMACONV)  &&
-	elem2->trackType(reco::PFBlockElement::T_FROM_GAMMACONV)  ) {    
-    if ( elem1->convRef().isNonnull() && elem2->convRef().isNonnull() ) {
-      if ( elem1->convRef() ==  elem2->convRef() ) {
-	dist=1.0;
+	elem2->trackType(reco::PFBlockElement::T_FROM_GAMMACONV)  ) {
+    for( const auto& conv1 : elem1->convRefs() ) {
+      for( const auto& conv2 : elem2->convRefs() ) {
+	if( conv1.isNonnull() && conv2.isNonnull() &&
+	    conv1 == conv2 ) {
+	  dist=1.0;
+	  break;
+	}
       }
-    }     
+    }
   }
   
   if (  elem1->trackType(reco::PFBlockElement::T_FROM_V0)  &&

--- a/RecoParticleFlow/PFProducer/src/PFAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFAlgo.cc
@@ -802,7 +802,7 @@ void PFAlgo::processBlock( const reco::PFBlockRef& blockref,
 	    if(elements[iEle].trackRef()->quality(reco::TrackBase::highPurity))continue;
 	    const reco::PFBlockElementTrack * trackRef = dynamic_cast<const reco::PFBlockElementTrack*>((&elements[iEle]));
 	    if(!(trackRef->trackType(reco::PFBlockElement::T_FROM_GAMMACONV)))continue;
-	    if(elements[iEle].convRef().isNonnull())active[iEle]=false;
+	    if(elements[iEle].convRefs().size())active[iEle]=false;
 	  }
       }
     }

--- a/RecoParticleFlow/PFProducer/src/PFBlockAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFBlockAlgo.cc
@@ -285,6 +285,7 @@ PFBlockAlgo::link( const reco::PFBlockElement* el1,
 void PFBlockAlgo::buildElements(const edm::Event& evt) {
   // import block elements as defined in python configuration
   for( const auto& importer : _importers ) {
+
     importer->importToBlock(evt,elements_);
   }
   
@@ -304,7 +305,7 @@ void PFBlockAlgo::buildElements(const edm::Event& evt) {
       }
     }    
   }
-  //std::cout << "(new) imported: " << elements_.size() << std::endl;
+  //std::cout << "(new) imported: " << elements_.size() << " elements!" << std::endl;
 }
 
 std::ostream& operator<<(std::ostream& out, const PFBlockAlgo& a) {

--- a/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
@@ -1959,11 +1959,15 @@ fillPFCandidates(const std::list<PFEGammaAlgo::ProtoEGObject>& ROs,
     for( const auto& secdkf : RO.secondaryKFs ) {
       const PFKFElement* kf = secdkf.first;
       cand.addElementInBlock(_currentblock,kf->index());
-      reco::ConversionRef convref = kf->convRef();
-      if( convref.isNonnull() && convref.isAvailable() ) {
-	xtra.addConversionRef(convref);
+      const reco::ConversionRefVector& convrefs = kf->convRefs();
+      bool no_conv_ref = true;
+      for( const auto& convref : convrefs ) {
+	if( convref.isNonnull() && convref.isAvailable() ) {
+	  xtra.addConversionRef(convref);
+	  no_conv_ref = false;
+	}
       }
-      else {
+      if( no_conv_ref ) {
         //single leg conversions
         
         //look for stored mva value in map or else recompute

--- a/RecoParticleFlow/PFProducer/src/PFPhotonAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFPhotonAlgo.cc
@@ -831,16 +831,18 @@ void PFPhotonAlgo::RunPFPhoton(const reco::PFBlockRef&  blockRef,
 	    photonCand.addElementInBlock(blockRef,*it);
 	    if( elements[*it].type() == reco::PFBlockElement::TRACK  )
 	      {
-		if(elements[*it].convRef().isNonnull())
-		  {
-		    //make sure it is not stored already as the partner track
-		    bool matched=false;
-		    for(unsigned int ic = 0; ic < ConversionsRef_.size(); ic++)
-		      {
-			if(ConversionsRef_[ic]==elements[*it].convRef())matched=true;
-		      }
-		    if(!matched)ConversionsRef_.push_back(elements[*it].convRef());
-		  }
+		for( const auto& convref : elements[*it].convRefs() ) {
+		  if(convref.isNonnull())
+		    {
+		      //make sure it is not stored already as the partner track
+		      bool matched=false;
+		      for(unsigned int ic = 0; ic < ConversionsRef_.size(); ic++)
+			{
+			  if(ConversionsRef_[ic]==convref)matched=true;
+			}
+		      if(!matched)ConversionsRef_.push_back(convref);
+		    }
+		}
 	      }
 	  }
 	active[*it] = false;	

--- a/RecoParticleFlow/PFProducer/test/PFBlockComparator.cc
+++ b/RecoParticleFlow/PFProducer/test/PFBlockComparator.cc
@@ -83,7 +83,8 @@ namespace {
 	case reco::PFBlockElement::TRACK:
 	  result = ( cmpElem.trackRef().isNonnull() &&
 		     chkElem.trackRef().isNonnull() &&
-		     cmpElem.trackRef()->momentum() == chkElem.trackRef()->momentum() );	    
+		     cmpElem.trackRef()->momentum() == 
+		     chkElem.trackRef()->momentum() );	    
 	  break;
 	case reco::PFBlockElement::PS1:
 	case reco::PFBlockElement::PS2:
@@ -116,7 +117,8 @@ namespace {
 	      static_cast<const reco::PFBlockElementGsfTrack&>(chkElem);	      
 	    result = ( cmpGSF.GsftrackRef().isNonnull() &&
 		       chkGSF.GsftrackRef().isNonnull() &&
-		       cmpGSF.GsftrackRef()->momentum() == chkGSF.GsftrackRef()->momentum() );	      
+		       cmpGSF.GsftrackRef()->momentum() == 
+		       chkGSF.GsftrackRef()->momentum() );	      
 	  }
 	  break;
 	case reco::PFBlockElement::BREM:
@@ -127,7 +129,8 @@ namespace {
 	      static_cast<const reco::PFBlockElementBrem&>(chkElem);	      
 	    result = ( cmpBREM.GsftrackRef().isNonnull() &&
 		       chkBREM.GsftrackRef().isNonnull() &&
-		       cmpBREM.GsftrackRef()->momentum() == chkBREM.GsftrackRef()->momentum() &&
+		       cmpBREM.GsftrackRef()->momentum() == 
+		       chkBREM.GsftrackRef()->momentum() &&
 		       cmpBREM.indTrajPoint() == chkBREM.indTrajPoint() );	      
 	  }
 	  break;
@@ -282,12 +285,14 @@ void PFBlockComparator::analyze(const edm::Event& e,
 	    std::cout << "new: ";
 	    for(auto newassc : new_elems ) { 
 	      std::cout << "( " << newassc.first << " , " 
+			<< newassc.second << " , " 
 			<< block.elements()[newassc.second].type() << " ), "; 
 	    }
 	    std::cout << std::endl;
 	    std::cout << "old: ";
 	    for(auto oldassc : old_elems ) { 
 	      std::cout << "( " << oldassc.first << " , " 
+			<< oldassc.second << " , "
 			<< matched_block->elements()[oldassc.second].type() << " ), "; 
 	    }
 	    std::cout << std::endl;	      
@@ -296,7 +301,8 @@ void PFBlockComparator::analyze(const edm::Event& e,
 	  std::cout << "+++WARNING+++ : couldn't find match for element: " << elem << std::endl;
 	}
       }     
-      if( found_elements != block.elements().size() ) {
+      if( found_elements != block.elements().size() ||
+	  found_elements != matched_block->elements().size() ) {
 	std::cout << "+++WARNING+++ : couldn't find all elements in block with " 
 		  << block.elements().size() << " elements matched to block with " 
 		  << matched_block->elements().size() << "!" << std::endl;


### PR DESCRIPTION
This PR addresses the follow up at the end of the PFBlockAlgo overhaul to see what was going on in the fast sim workflow since there was an event with changed block content.

Further study showed that there was some strange behavior in the old version of PFBlockAlgo where tracks that were included in multiple conversion vertices would be imported multiple times (bad behavior for linking, PFEGammaAlgo). In the new version of PFBlockAlgo only the ref from the last-encountered conversion was being saved (bad behavior for linking). Furthermore, in the old PFBlockAlgo only the last found element was updated if it overlapped with a muon or nuclear interaction vertex.

Note that this may be an issue rather specific to fastsim.

Now the PFBlockElementTrack can store multiple conversion refs, and the tracks are only imported once. This ensures optimal behavior of the linker as well as content of the blocks. 

Compared to CMSSW_7_1_X_2014-04-24-1400 without 3385. The one discrepant event for block.element.size() is still there, but now blocks.size() agrees for all events in wf5.1. There could be possible knock on effects in terms of conversion multiplicity (judging from 3385 validation probably not so much), but this new behavior is known to be more correct.

I saw no effect on the block content in 1k events of wf38 compared to #3385.
