### PR TITLE
update matrix: fixed and DQMIO

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1334,7 +1334,7 @@ steps['SKIMCOSD']={'-s':'SKIM:all',
                    '--scenario':'cosmics',
                    '--filein':'file:step2.root',
                    '--secondfilein':'filelist:step1_dasquery.log'}
-                 
+
 steps['RECOFROMRECO']=merge([{'-s':'RECO,EI',
                               '--filtername':'RECOfromRECO',
                               '--process':'reRECO',


### PR DESCRIPTION
rebase of #3377 :  
. DQMROOT => DQMIO needs be extended to teh cmsDriver
. when using dqmio, set NEW! datatier name to DQMIO (in place of old DQMROOT)
. two new workflows GEN-SIM only, to prepare input of pileup workflows which don't have a no-pileup correspondent ; thanks to @fabozzi (ZmumuJets_Pt_20_300 and ZmumuJ
. gen2015 for ZmumuJets_Pt_20_300_13 => get correct GT (thanks to @fabozzi and @ferro)

NOTE: in the meantime (#3377) the usage of SIM geometry has been updated, i.e. for 8TeV and postLs1 relvals no options are set for geometry, leaving it up to the GT to determined it
