### PR TITLE
Multisource bugfixes

### DIFF
--- a/Utilities/XrdAdaptor/plugins/XrdStorageMaker.cc
+++ b/Utilities/XrdAdaptor/plugins/XrdStorageMaker.cc
@@ -111,6 +111,7 @@ public:
     XrdCl::Env *env = XrdCl::DefaultEnv::GetEnv();
     if (env)
     {
+      env->PutInt("StreamTimeout", timeout);
       env->PutInt("RequestTimeout", timeout);
       env->PutInt("ConnectionWindow", timeout);
     }

--- a/Utilities/XrdAdaptor/src/XrdRequestManager.cc
+++ b/Utilities/XrdAdaptor/src/XrdRequestManager.cc
@@ -568,6 +568,7 @@ RequestManager::requestFailure(std::shared_ptr<XrdAdaptor::ClientRequest> c_ptr,
             addConnections(ex);
             throw ex;
         }
+        m_activeSources.push_back(new_source);
     }
     else
     {

--- a/Utilities/XrdAdaptor/src/XrdRequestManager.h
+++ b/Utilities/XrdAdaptor/src/XrdRequestManager.h
@@ -170,6 +170,11 @@ private:
          */
         std::shared_future<std::shared_ptr<Source> > open();
 
+        /**
+         * Returns the current source server name.  Useful primarily for debugging.
+         */
+        std::string current_source();
+
     private:
         RequestManager & m_manager;
         std::shared_future<std::shared_ptr<Source> > m_shared_future;


### PR DESCRIPTION
From the latest round of testing:
1) Make sure the problematic server is logged if we fail during recovery.
2) Align all timeouts to the same default; make sure all Xrootd client timeouts are set.
3) Add recovered source to list of active sources; this prevents us from triggering an assert on having no active sources.

These are the last issues that large-scale CRAB3 testing has revealed.  I think we are ready to try a relval run on this branch.
