### PR TITLE
Pat in cms driver

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -296,6 +296,10 @@ class ConfigBuilder(object):
                     self.process.options = cms.untracked.PSet( Rethrow = cms.untracked.vstring('ProductNotFound'),fileMode = cms.untracked.string('FULLMERGE'))
             else:
                     self.process.options = cms.untracked.PSet( )
+
+	    if self._options.runUnscheduled:
+		    self.process.options.allowUnscheduled=cms.untracked.bool(True)
+		    
             self.addedObjects.append(("","options"))
 
             if self._options.lazy_download:
@@ -844,6 +848,7 @@ class ConfigBuilder(object):
         self.L1RecoDefaultCFF="Configuration/StandardSequences/L1Reco_cff"
         self.L1TrackTriggerDefaultCFF="Configuration/StandardSequences/L1TrackTrigger_cff"
         self.RECODefaultCFF="Configuration/StandardSequences/Reconstruction_Data_cff"
+        self.PATDefaultCFF="Configuration/StandardSequences/PAT_cff"
 	self.EIDefaultCFF=None
         self.SKIMDefaultCFF="Configuration/StandardSequences/Skims_cff"
         self.POSTRECODefaultCFF="Configuration/StandardSequences/PostRecoGenerator_cff"
@@ -897,6 +902,7 @@ class ConfigBuilder(object):
         self.PATLayer0DefaultSeq='all'
         self.ENDJOBDefaultSeq='endOfProcess'
         self.REPACKDefaultSeq='DigiToRawRepack'
+	self.PATDefaultSeq='miniAOD'
 
         self.EVTCONTDefaultCFF="Configuration/EventContent/EventContent_cff"
 
@@ -907,6 +913,7 @@ class ConfigBuilder(object):
         if self._options.isMC==True:
                 self.RAW2DIGIDefaultCFF="Configuration/StandardSequences/RawToDigi_cff"
 		self.RECODefaultCFF="Configuration/StandardSequences/Reconstruction_cff"
+		self.PATDefaultCFF="Configuration/StandardSequences/PATMC_cff"
                 self.DQMOFFLINEDefaultCFF="DQMOffline/Configuration/DQMOfflineMC_cff"
                 self.ALCADefaultCFF="Configuration/StandardSequences/AlCaRecoStreamsMC_cff"
 	else:
@@ -1572,6 +1579,12 @@ class ConfigBuilder(object):
 	self.scheduleSequence(sequence.split('.')[-1],'reconstruction_step')
         return
 
+    def prepare_PAT(self, sequence = "miniAOD"):
+        ''' Enrich the schedule with PAT '''
+        self.loadDefaultOrSpecifiedCFF(sequence,self.PATDefaultCFF)
+	self.scheduleSequence(sequence.split('.')[-1],'pat_step')
+        return
+
     def prepare_EI(self, sequence = None):
         ''' Enrich the schedule with event interpretation '''
 	from Configuration.StandardSequences.EventInterpretation import EventInterpretation
@@ -2077,30 +2090,31 @@ class ConfigBuilder(object):
                 self.pythonCfgCode += dumpPython(self.process,endpath)
 
         # dump the schedule
-        self.pythonCfgCode += "\n# Schedule definition\n"
-        result = "process.schedule = cms.Schedule("
+	if not self._options.runUnscheduled:	
+		self.pythonCfgCode += "\n# Schedule definition\n"
+		result = "process.schedule = cms.Schedule("
 
-        # handling of the schedule
-        self.process.schedule = cms.Schedule()
-        for item in self.schedule:
-                if not isinstance(item, cms.Schedule):
-                        self.process.schedule.append(item)
-                else:
-                        self.process.schedule.extend(item)
+                # handling of the schedule
+		self.process.schedule = cms.Schedule()
+		for item in self.schedule:
+			if not isinstance(item, cms.Schedule):
+				self.process.schedule.append(item)
+			else:
+				self.process.schedule.extend(item)
 
-        if hasattr(self.process,"HLTSchedule"):
-            beforeHLT = self.schedule[:self.schedule.index(self.process.HLTSchedule)]
-            afterHLT = self.schedule[self.schedule.index(self.process.HLTSchedule)+1:]
-            pathNames = ['process.'+p.label_() for p in beforeHLT]
-            result += ','.join(pathNames)+')\n'
-            result += 'process.schedule.extend(process.HLTSchedule)\n'
-            pathNames = ['process.'+p.label_() for p in afterHLT]
-            result += 'process.schedule.extend(['+','.join(pathNames)+'])\n'
-        else:
-            pathNames = ['process.'+p.label_() for p in self.schedule]
-            result ='process.schedule = cms.Schedule('+','.join(pathNames)+')\n'
+		if hasattr(self.process,"HLTSchedule"):
+			beforeHLT = self.schedule[:self.schedule.index(self.process.HLTSchedule)]
+			afterHLT = self.schedule[self.schedule.index(self.process.HLTSchedule)+1:]
+			pathNames = ['process.'+p.label_() for p in beforeHLT]
+			result += ','.join(pathNames)+')\n'
+			result += 'process.schedule.extend(process.HLTSchedule)\n'
+			pathNames = ['process.'+p.label_() for p in afterHLT]
+			result += 'process.schedule.extend(['+','.join(pathNames)+'])\n'
+		else:
+			pathNames = ['process.'+p.label_() for p in self.schedule]
+			result ='process.schedule = cms.Schedule('+','.join(pathNames)+')\n'
 
-        self.pythonCfgCode += result
+	        self.pythonCfgCode += result
 
 	#repacked version
 	if self._options.isRepacked:

--- a/Configuration/Applications/python/Options.py
+++ b/Configuration/Applications/python/Options.py
@@ -98,6 +98,12 @@ parser.add_option("--runsScenarioForMC",
                   default=None,
                   dest="runsScenarioForMC")
 
+parser.add_option("--runUnscheduled",
+                  help="Enable unscheduled mode",
+                  action="store_true",
+                  default=False,
+                  dest="runUnscheduled")
+
 # expert settings
 expertSettings.add_option("--beamspot",
                           help="What beam spot to use (from Configuration/StandardSequences). Default depends on scenario",

--- a/Configuration/Applications/python/cmsDriverOptions.py
+++ b/Configuration/Applications/python/cmsDriverOptions.py
@@ -97,7 +97,8 @@ def OptionsFromItems(items):
                  "DATAMIX":"DIGI",
                  "DIGI2RAW":"DATAMIX",
                  "HARVESTING":"RECO",
-                 "ALCAHARVEST":"RECO"}
+                 "ALCAHARVEST":"RECO",
+                 "PAT":"RECO"}
 
     trimmedEvtType=options.evt_type.split('/')[-1]
 

--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -772,3 +772,24 @@ REDIGIEventContent.inputCommands.extend(IOMCRAW.outputCommands)
 REDIGIEventContent.inputCommands.extend(GeneratorInterfaceRAW.outputCommands)
 REDIGIEventContent.inputCommands.append('drop *_randomEngineStateProducer_*_*')
 
+
+########### and mini AOD
+
+MINIAODEventContent= cms.PSet(    
+    outputCommands = cms.untracked.vstring('drop *'),
+    eventAutoFlushCompressedSize=cms.untracked.int32(15*1024*1024),
+    compressionAlgorithm=cms.untracked.string("LZMA"),
+    compressionLevel=cms.untracked.int32(4)
+)
+
+MINIAODSIMEventContent= cms.PSet(    
+    outputCommands = cms.untracked.vstring('drop *'),
+    eventAutoFlushCompressedSize=cms.untracked.int32(15*1024*1024),
+    compressionAlgorithm=cms.untracked.string("LZMA"),
+    compressionLevel=cms.untracked.int32(4)
+)
+
+from PhysicsTools.PatAlgos.slimming.slimming_cff import MicroEventContent,MicroEventContentMC
+
+MINIAODEventContent.outputCommands.extend(MicroEventContent.outputCommands)
+MINIAODSIMEventContent.outputCommands.extend(MicroEventContentMC.outputCommands)

--- a/Configuration/StandardSequences/python/PATMC_cff.py
+++ b/Configuration/StandardSequences/python/PATMC_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+miniAOD=cms.Sequence()

--- a/Configuration/StandardSequences/python/PAT_cff.py
+++ b/Configuration/StandardSequences/python/PAT_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+miniAOD=cms.Sequence()


### PR DESCRIPTION
MiniAOD integration work: Add "PAT" step to cmsDriver which for the moment is a placeholder where the miniAOD will run - can also be used for analysis trains. Added event content definitions in standard location for MINIAOD and MINIAODSIM. Added unscheduled mode (needed for PAT) as an option to cmsDriver (off by default).
