### PR TITLE
Remove cout from MSLayersKeeperX0DetLayer

### DIFF
--- a/RecoTracker/TkMSParametrization/src/MSLayersKeeperX0DetLayer.cc
+++ b/RecoTracker/TkMSParametrization/src/MSLayersKeeperX0DetLayer.cc
@@ -49,8 +49,8 @@ void MSLayersKeeperX0DetLayer::init(const edm::EventSetup &iSetup)
     setDataX0(*it, dataX0);
     theLayersData.update(*it);
   }
-  cout << "MSLayersKeeperX0DetLayer LAYERS: "<<endl;
-  theLayersData.print();
+  //cout << "MSLayersKeeperX0DetLayer LAYERS: "<<endl;
+  //theLayersData.print();
 }
 
 // vector<MSLayer>


### PR DESCRIPTION
In addition to being against CMS policy, the cout was being flagged
as a thread safety issue by valgrind. Also, the printout was happening
once per stream not once per job.
If this functionality is actually needed then the MessageLogger should
be used.
