### PR TITLE
Navigation

### DIFF
--- a/RecoEgamma/EgammaPhotonProducers/src/ConversionTrackCandidateProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/ConversionTrackCandidateProducer.cc
@@ -153,6 +153,7 @@ void  ConversionTrackCandidateProducer::beginRun (edm::Run const& r , edm::Event
   edm::ESHandle<NavigationSchool> nav;
   theEventSetup.get<NavigationSchoolRecord>().get("SimpleNavigationSchool", nav);
   theNavigationSchool_ = nav.product();
+  theTrajectoryBuilder_->setNavigationSchool(nav.product());
 }
 
 
@@ -178,7 +179,7 @@ void ConversionTrackCandidateProducer::produce(edm::Event& theEvent, const edm::
   theOutInSeedFinder_->setEvent(theEvent);
   theInOutSeedFinder_->setEvent(theEvent);
 
-// Set the navigation school  
+  // Set the navigation school  
   NavigationSetter setter(*theNavigationSchool_);  
 
   //

--- a/RecoEgamma/EgammaPhotonProducers/src/TrackProducerWithSCAssociation.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/TrackProducerWithSCAssociation.cc
@@ -332,7 +332,7 @@ TrackingRecHitRefProd rHits = evt.getRefBeforePut<TrackingRecHitCollection>();
       {
         edm::Handle<MeasurementTrackerEvent> mte;
         evt.getByLabel(edm::InputTag("MeasurementTrackerEvent"), mte);
-	NavigationSetter setter( *theSchool );
+	// NavigationSetter setter( *theSchool );
 	setSecondHitPattern(theTraj,track,thePropagator,&*mte);
       }
     //==============================================================

--- a/RecoMuon/DetLayers/src/MuonDetLayerGeometry.cc
+++ b/RecoMuon/DetLayers/src/MuonDetLayerGeometry.cc
@@ -309,5 +309,10 @@ void MuonDetLayerGeometry::sortLayers() {
   std::copy(allBarrel.begin(),allBarrel.end(),back_inserter(allDetLayers));
   std::copy(allForward.begin(),allForward.end(),back_inserter(allDetLayers));
 
+  // number layers
+  int sq=0;
+  for (auto l : allDetLayers) 
+    (*l).setSeqNum(sq++);
+
 
 }

--- a/RecoMuon/Navigation/interface/MuonNavigationPrinter.h
+++ b/RecoMuon/Navigation/interface/MuonNavigationPrinter.h
@@ -19,14 +19,15 @@
 class DetLayer;
 class MuonDetLayerGeometry;
 class GeometricSearchTracker;
+class MuonNavigationSchool;
 
 #include <vector>
 #include <string>
 
 class MuonNavigationPrinter {
   public:
-    MuonNavigationPrinter(const MuonDetLayerGeometry *, bool enableRPC = true );
-    MuonNavigationPrinter(const MuonDetLayerGeometry *,const GeometricSearchTracker *);
+  MuonNavigationPrinter(const MuonDetLayerGeometry *, MuonNavigationSchool const &, bool enableRPC = true );
+  MuonNavigationPrinter(const MuonDetLayerGeometry *,MuonNavigationSchool const &, const GeometricSearchTracker *);
 
   private:
     void printLayer(DetLayer*) const;
@@ -35,6 +36,9 @@ class MuonNavigationPrinter {
 //    std::string layerPart(const DetLayer*) const;
     /// return detector module (pixel, silicon, msgc, dt, csc, rpc)
 //    std::string layerModule(const DetLayer*) const;
+
+
+  MuonNavigationSchool const * school=nullptr;
 
 };
 #endif

--- a/RecoMuon/Navigation/interface/MuonNavigationSchool.h
+++ b/RecoMuon/Navigation/interface/MuonNavigationSchool.h
@@ -50,7 +50,7 @@ class MuonNavigationSchool : public NavigationSchool {
     /// link endcap layers
     void linkEndcapLayers(const MapE&,std::vector<MuonForwardNavigableLayer*>&);
     /// establish inward links
-    void createInverseLinks() const;
+    void createInverseLinks();
     float calculateEta(const float&, const float& ) const;
 
   private: 

--- a/RecoMuon/Navigation/src/MuonNavigationPrinter.cc
+++ b/RecoMuon/Navigation/src/MuonNavigationPrinter.cc
@@ -28,68 +28,76 @@
 #include <iomanip>
 using namespace std;
 
+#define VI_DEBUG
+
+#ifdef VI_DEBUG
+#define PRINT(x) std::cout << x << ' '
+#else
+#define PRINT(x) edm::LogInfo(x)
+#endif
+
 MuonNavigationPrinter::MuonNavigationPrinter(const MuonDetLayerGeometry * muonLayout, bool enableRPC) {
 
-  edm::LogInfo ("MuonNavigationPrinter")<< "MuonNavigationPrinter::MuonNavigationPrinter" ;
+  PRINT("MuonNavigationPrinter")<< "MuonNavigationPrinter::MuonNavigationPrinter" << std::endl;
   vector<DetLayer*>::const_iterator iter;
-  edm::LogInfo ("MuonNavigationPrinter")<<"================================";
-  edm::LogInfo ("MuonNavigationPrinter")<< "BARREL:";
+  PRINT("MuonNavigationPrinter")<<"================================" << std::endl;
+  PRINT("MuonNavigationPrinter")<< "BARREL:" << std::endl;
   vector<DetLayer*> barrel;
   if ( enableRPC ) barrel = muonLayout->allBarrelLayers();
   else barrel = muonLayout->allDTLayers();
 
-  edm::LogInfo ("MuonNavigationPrinter")<<"There are "<<barrel.size()<<" Barrel DetLayers";
+  PRINT("MuonNavigationPrinter")<<"There are "<<barrel.size()<<" Barrel DetLayers";
   for ( iter = barrel.begin(); iter != barrel.end(); iter++ ) printLayer(*iter);
-  edm::LogInfo ("MuonNavigationPrinter")<<"================================";
-  edm::LogInfo ("MuonNavigationPrinter")  << "BACKWARD:";
+  PRINT("MuonNavigationPrinter")<<"================================" << std::endl;
+  PRINT("MuonNavigationPrinter")  << "BACKWARD:" << std::endl;
 
   vector<DetLayer*> backward;
   if ( enableRPC ) backward = muonLayout->allBackwardLayers();
   else backward = muonLayout->backwardCSCLayers();
 
-  edm::LogInfo ("MuonNavigationPrinter")<<"There are "<<backward.size()<<" Backward DetLayers";
+  PRINT("MuonNavigationPrinter")<<"There are "<<backward.size()<<" Backward DetLayers";
   for ( iter = backward.begin(); iter != backward.end(); iter++ ) printLayer(*iter);
-  edm::LogInfo ("MuonNavigationPrinter") << "==============================";
-  edm::LogInfo ("MuonNavigationPrinter") << "FORWARD:";
+  PRINT("MuonNavigationPrinter") << "==============================" << std::endl;
+  PRINT("MuonNavigationPrinter") << "FORWARD:" << std::endl;
   vector<DetLayer*> forward;
   if ( enableRPC ) forward = muonLayout->allForwardLayers();
   else forward = muonLayout->forwardCSCLayers();
 
-  edm::LogInfo ("MuonNavigationPrinter")<<"There are "<<forward.size()<<" Forward DetLayers";
+  PRINT("MuonNavigationPrinter")<<"There are "<<forward.size()<<" Forward DetLayers" << std::endl;
   for ( iter = forward.begin(); iter != forward.end(); iter++ ) printLayer(*iter);
 
 }
 
 MuonNavigationPrinter::MuonNavigationPrinter(const MuonDetLayerGeometry * muonLayout, const GeometricSearchTracker * tracker) {
 
-  edm::LogInfo ("MuonNavigationPrinter")<< "MuonNavigationPrinter::MuonNavigationPrinter" ;
+  PRINT("MuonNavigationPrinter")<< "MuonNavigationPrinter::MuonNavigationPrinter" << std::endl ;
   vector<DetLayer*>::const_iterator iter;
 //  vector<BarrelDetLayer*>::const_iterator tkiter;
 //  vector<ForwardDetLayer*>::const_iterator tkfiter;
-  edm::LogInfo ("MuonNavigationPrinter")<<"================================";
-  edm::LogInfo ("MuonNavigationPrinter")<< "BARREL:";
+  PRINT("MuonNavigationPrinter")<<"================================" << std::endl;
+  PRINT("MuonNavigationPrinter")<< "BARREL:" << std::endl;
   vector<BarrelDetLayer*> tkbarrel = tracker->barrelLayers();
-  edm::LogInfo ("MuonNavigationPrinter")<<"There are "<<tkbarrel.size()<<" Tk Barrel DetLayers";
+  PRINT("MuonNavigationPrinter")<<"There are "<<tkbarrel.size()<<" Tk Barrel DetLayers" << std::endl;
 //  for ( tkiter = tkbarrel.begin(); tkiter != tkbarrel.end(); tkiter++ ) printLayer(*tkiter);
   vector<DetLayer*> barrel = muonLayout->allBarrelLayers();
-  edm::LogInfo ("MuonNavigationPrinter")<<"There are "<<barrel.size()<<" Mu Barrel DetLayers";
+  PRINT("MuonNavigationPrinter")<<"There are "<<barrel.size()<<" Mu Barrel DetLayers";
   for ( iter = barrel.begin(); iter != barrel.end(); iter++ ) printLayer(*iter);
-  edm::LogInfo ("MuonNavigationPrinter")<<"================================";
-  edm::LogInfo ("MuonNavigationPrinter")  << "BACKWARD:";
+  PRINT("MuonNavigationPrinter")<<"================================" << std::endl;
+  PRINT("MuonNavigationPrinter")  << "BACKWARD:" << std::endl;
   vector<ForwardDetLayer*> tkbackward = tracker->negForwardLayers();
-  edm::LogInfo ("MuonNavigationPrinter")<<"There are "<<tkbackward.size()<<" Tk Backward DetLayers";
+  PRINT("MuonNavigationPrinter")<<"There are "<<tkbackward.size()<<" Tk Backward DetLayers" << std::endl;
 ///  for ( tkfiter = tkbackward.begin(); tkfiter != tkbackward.end(); tkfiter++ ) printLayer(*tkfiter);
   vector<DetLayer*> backward = muonLayout->allBackwardLayers();
-  edm::LogInfo ("MuonNavigationPrinter")<<"There are "<<backward.size()<<" Mu Backward DetLayers";
+  PRINT("MuonNavigationPrinter")<<"There are "<<backward.size()<<" Mu Backward DetLayers << std::endl";
   for ( iter = backward.begin(); iter != backward.end(); iter++ ) printLayer(*iter);
-  edm::LogInfo ("MuonNavigationPrinter") << "==============================";
-  edm::LogInfo ("MuonNavigationPrinter") << "FORWARD:";
+  PRINT("MuonNavigationPrinter") << "==============================" << std::endl;
+  PRINT("MuonNavigationPrinter") << "FORWARD:" << std::endl;
   vector<ForwardDetLayer*> tkforward =  tracker->posForwardLayers();
-  edm::LogInfo ("MuonNavigationPrinter")<<"There are "<<tkforward.size()<<" Tk Forward DetLayers";
+  PRINT("MuonNavigationPrinter")<<"There are "<<tkforward.size()<<" Tk Forward DetLayers" << std::endl;
 //  for ( tkfiter = tkforward.begin(); tkfiter != tkforward.end(); tkfiter++ ) printLayer(*tkfiter);
 
   vector<DetLayer*> forward = muonLayout->allForwardLayers();
-  edm::LogInfo ("MuonNavigationPrinter")<<"There are "<<forward.size()<<" Mu Forward DetLayers";
+  PRINT("MuonNavigationPrinter")<<"There are "<<forward.size()<<" Mu Forward DetLayers";
   for ( iter = forward.begin(); iter != forward.end(); iter++ ) printLayer(*iter);
 
 }
@@ -99,17 +107,17 @@ void MuonNavigationPrinter::printLayer(DetLayer* layer) const {
   vector<const DetLayer*> nextLayers = layer->nextLayers(insideOut);
   vector<const DetLayer*> compatibleLayers = layer->compatibleLayers(insideOut);
   if (BarrelDetLayer* bdl = dynamic_cast<BarrelDetLayer*>(layer)) {
-    edm::LogInfo ("MuonNavigationPrinter") 
+    PRINT("MuonNavigationPrinter") 
          << layer->location() << " " << layer->subDetector() << " layer at R: "
          << setiosflags(ios::showpoint | ios::fixed)
          << setw(8) << setprecision(2)
          << bdl->specificSurface().radius() << "  length: "
          << setw(6) << setprecision(2)
-         << layer->surface().bounds().length();
+         << layer->surface().bounds().length() << std::endl;
           
   }
   else if (ForwardDetLayer* fdl = dynamic_cast<ForwardDetLayer*>(layer)) {
-    edm::LogInfo ("MuonNavigationPrinter") << endl
+    PRINT("MuonNavigationPrinter") << endl
          << layer->location() << " " << layer->subDetector() << "layer at z: "
          << setiosflags(ios::showpoint | ios::fixed)
          << setw(8) << setprecision(2)
@@ -117,23 +125,23 @@ void MuonNavigationPrinter::printLayer(DetLayer* layer) const {
          << setw(6) << setprecision(2)
          << fdl->specificSurface().innerRadius() << "  outer r: "
          << setw(6) << setprecision(2)
-         << fdl->specificSurface().outerRadius();
+         << fdl->specificSurface().outerRadius() << std::endl;
   }
-  edm::LogInfo ("MuonNavigationPrinter") << " has " << nextLayers.size() << " next layers in the direction inside-out: ";
+  PRINT("MuonNavigationPrinter") << " has " << nextLayers.size() << " next layers in the direction inside-out: " << std::endl;
   printLayers(nextLayers);
 
   nextLayers.clear();
   nextLayers = layer->nextLayers(outsideIn);
 
-   edm::LogInfo ("MuonNavigationPrinter") << " has " << nextLayers.size() << " next layers in the direction outside-in: ";
+   PRINT("MuonNavigationPrinter") << " has " << nextLayers.size() << " next layers in the direction outside-in: " << std::endl;
   printLayers(nextLayers);
 
-  edm::LogInfo ("MuonNavigationPrinter") << " has " << compatibleLayers.size() << " compatible layers in the direction inside-out:: ";
+  PRINT("MuonNavigationPrinter") << " has " << compatibleLayers.size() << " compatible layers in the direction inside-out:: " << std::endl;
   printLayers(compatibleLayers);
   compatibleLayers.clear();
   compatibleLayers = layer->compatibleLayers(outsideIn);
   
-  edm::LogInfo ("MuonNavigationPrinter") << " has " << compatibleLayers.size() << " compatible layers in the direction outside-in: ";
+  PRINT("MuonNavigationPrinter") << " has " << compatibleLayers.size() << " compatible layers in the direction outside-in: " << std::endl;
   printLayers(compatibleLayers);
 
 }
@@ -144,31 +152,31 @@ void MuonNavigationPrinter::printLayers(const vector<const DetLayer*>& nextLayer
   for ( vector<const DetLayer*>::const_iterator inext = nextLayers.begin();
       inext != nextLayers.end(); inext++ ) {
 
-     edm::LogInfo ("MuonNavigationPrinter") << " --> "; 
+     PRINT("MuonNavigationPrinter") << " --> " << std::endl; 
      if ( (*inext)->location() == GeomDetEnumerators::barrel ) {
       const BarrelDetLayer* l = dynamic_cast<const BarrelDetLayer*>(&(**inext));
-      edm::LogInfo ("MuonNavigationPrinter") << (*inext)->location() << " "
+      PRINT("MuonNavigationPrinter") << (*inext)->location() << " "
            << (*inext)->subDetector()
            << " layer at R: "
            << setiosflags(ios::showpoint | ios::fixed)
            << setw(8) << setprecision(2)
-           << l->specificSurface().radius() << "   ";
+           << l->specificSurface().radius() << "   " << std::endl;
     }
     else {
       const ForwardDetLayer* l = dynamic_cast<const ForwardDetLayer*>(&(**inext));
-       edm::LogInfo ("MuonNavigationPrinter") << (*inext)->location() << " "
+       PRINT("MuonNavigationPrinter") << (*inext)->location() << " "
            << (*inext)->subDetector()
            << " layer at z: "
            << setiosflags(ios::showpoint | ios::fixed)
            << setw(8) << setprecision(2)
-           << l->surface().position().z() << "   ";
+           << l->surface().position().z() << "   " << std::endl;
     }
-    edm::LogInfo ("MuonNavigationPrinter") << setiosflags(ios::showpoint | ios::fixed)
+    PRINT("MuonNavigationPrinter") << setiosflags(ios::showpoint | ios::fixed)
          << setprecision(1)
          << setw(6) << (*inext)->surface().bounds().length() << ", "
          << setw(6) << (*inext)->surface().bounds().width() << ", "
          << setw(4) <<(*inext)->surface().bounds().thickness() << " : " 
-         << (*inext)->surface().position();
+         << (*inext)->surface().position() << std::endl;
   }
 
 }

--- a/RecoMuon/Navigation/src/MuonNavigationPrinter.cc
+++ b/RecoMuon/Navigation/src/MuonNavigationPrinter.cc
@@ -28,7 +28,7 @@
 #include <iomanip>
 using namespace std;
 
-#define VI_DEBUG
+// #define VI_DEBUG
 
 #ifdef VI_DEBUG
 #define PRINT(x) std::cout << x << ' '

--- a/RecoMuon/Navigation/src/MuonNavigationPrinter.cc
+++ b/RecoMuon/Navigation/src/MuonNavigationPrinter.cc
@@ -21,7 +21,7 @@
 #include "DataFormats/GeometrySurface/interface/BoundDisk.h"
 #include "RecoMuon/DetLayers/interface/MuonDetLayerGeometry.h"
 #include "RecoTracker/TkDetLayers/interface/GeometricSearchTracker.h"
-
+#include "RecoMuon/Navigation/interface/MuonNavigationSchool.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include <iostream>
@@ -36,7 +36,8 @@ using namespace std;
 #define PRINT(x) edm::LogInfo(x)
 #endif
 
-MuonNavigationPrinter::MuonNavigationPrinter(const MuonDetLayerGeometry * muonLayout, bool enableRPC) {
+MuonNavigationPrinter::MuonNavigationPrinter(const MuonDetLayerGeometry * muonLayout,  MuonNavigationSchool const & sh,  bool enableRPC) :
+  school(&sh) {
 
   PRINT("MuonNavigationPrinter")<< "MuonNavigationPrinter::MuonNavigationPrinter" << std::endl;
   vector<DetLayer*>::const_iterator iter;
@@ -68,7 +69,8 @@ MuonNavigationPrinter::MuonNavigationPrinter(const MuonDetLayerGeometry * muonLa
 
 }
 
-MuonNavigationPrinter::MuonNavigationPrinter(const MuonDetLayerGeometry * muonLayout, const GeometricSearchTracker * tracker) {
+MuonNavigationPrinter::MuonNavigationPrinter(const MuonDetLayerGeometry * muonLayout,  MuonNavigationSchool const & sh, const GeometricSearchTracker * tracker)  :
+  school(&sh){
 
   PRINT("MuonNavigationPrinter")<< "MuonNavigationPrinter::MuonNavigationPrinter" << std::endl ;
   vector<DetLayer*>::const_iterator iter;
@@ -104,8 +106,8 @@ MuonNavigationPrinter::MuonNavigationPrinter(const MuonDetLayerGeometry * muonLa
 
 /// print layer
 void MuonNavigationPrinter::printLayer(DetLayer* layer) const {
-  vector<const DetLayer*> nextLayers = layer->nextLayers(insideOut);
-  vector<const DetLayer*> compatibleLayers = layer->compatibleLayers(insideOut);
+  vector<const DetLayer*> nextLayers = school->nextLayers(*layer,insideOut);
+  vector<const DetLayer*> compatibleLayers = school->compatibleLayers(*layer,insideOut);
   if (BarrelDetLayer* bdl = dynamic_cast<BarrelDetLayer*>(layer)) {
     PRINT("MuonNavigationPrinter") 
          << layer->location() << " " << layer->subDetector() << " layer at R: "
@@ -131,7 +133,7 @@ void MuonNavigationPrinter::printLayer(DetLayer* layer) const {
   printLayers(nextLayers);
 
   nextLayers.clear();
-  nextLayers = layer->nextLayers(outsideIn);
+  nextLayers = school->nextLayers(*layer,outsideIn);
 
    PRINT("MuonNavigationPrinter") << " has " << nextLayers.size() << " next layers in the direction outside-in: " << std::endl;
   printLayers(nextLayers);
@@ -139,7 +141,7 @@ void MuonNavigationPrinter::printLayer(DetLayer* layer) const {
   PRINT("MuonNavigationPrinter") << " has " << compatibleLayers.size() << " compatible layers in the direction inside-out:: " << std::endl;
   printLayers(compatibleLayers);
   compatibleLayers.clear();
-  compatibleLayers = layer->compatibleLayers(outsideIn);
+  compatibleLayers = school->compatibleLayers(*layer,outsideIn);
   
   PRINT("MuonNavigationPrinter") << " has " << compatibleLayers.size() << " compatible layers in the direction outside-in: " << std::endl;
   printLayers(compatibleLayers);

--- a/RecoMuon/Navigation/src/MuonNavigationSchool.cc
+++ b/RecoMuon/Navigation/src/MuonNavigationSchool.cc
@@ -38,6 +38,9 @@ using namespace std;
 MuonNavigationSchool::MuonNavigationSchool(const MuonDetLayerGeometry * muonLayout, bool enableRPC ) : theMuonDetLayerGeometry(muonLayout) {
 
   theAllDetLayersInSystem=&muonLayout->allLayers(); 
+  theAllNavigableLayer.resize(muonLayout->allLayers().size(),nullptr);
+
+
 
   // get all barrel DetLayers (DT + optional RPC) 
   vector<DetLayer*> barrel;
@@ -257,10 +260,13 @@ void MuonNavigationSchool::linkEndcapLayers(const MapE& layers,
 
 
 /// create inverse links (i.e. inwards)
-void MuonNavigationSchool::createInverseLinks() const {
+void MuonNavigationSchool::createInverseLinks()  {
 
   // set outward link
   NavigationSetter setter(*this);
+
+  setState(navigableLayers());
+
 
   // find for each layer which are the layers pointing to it
   typedef map<const DetLayer*, MapB, less<const DetLayer*> > BarrelMapType;

--- a/RecoMuon/Navigation/src/MuonNavigationSchool.cc
+++ b/RecoMuon/Navigation/src/MuonNavigationSchool.cc
@@ -20,7 +20,7 @@
 /* Collaborating Class Header */
 #include "TrackingTools/DetLayers/interface/BarrelDetLayer.h"
 #include "TrackingTools/DetLayers/interface/ForwardDetLayer.h"
-#include "TrackingTools/DetLayers/interface/NavigationSetter.h"
+// #include "TrackingTools/DetLayers/interface/NavigationSetter.h"
 #include "DataFormats/GeometrySurface/interface/BoundCylinder.h"
 #include "DataFormats/GeometrySurface/interface/BoundDisk.h"
 #include "RecoMuon/DetLayers/interface/MuonDetLayerGeometry.h"
@@ -263,7 +263,7 @@ void MuonNavigationSchool::linkEndcapLayers(const MapE& layers,
 void MuonNavigationSchool::createInverseLinks()  {
 
   // set outward link
-  NavigationSetter setter(*this);
+  // NavigationSetter setter(*this);
 
   setState(navigableLayers());
 
@@ -285,7 +285,7 @@ void MuonNavigationSchool::createInverseLinks()  {
               bli != theBarrelLayers.end(); bli++ ) {
     // barrel
     MuonBarrelNavigableLayer* mbnl =
-      dynamic_cast<MuonBarrelNavigableLayer*>(((*bli).first)->navigableLayer());
+      dynamic_cast<MuonBarrelNavigableLayer*>(theAllNavigableLayer[((*bli).first)->seqNum()]);
     MapB reacheableB = mbnl->getOuterBarrelLayers();
     for (MapBI i = reacheableB.begin(); i != reacheableB.end(); i++ ) {
       reachedBarrelLayersMap[(*i).first].insert(*bli);
@@ -317,13 +317,13 @@ void MuonNavigationSchool::createInverseLinks()  {
   for ( MapEI eli  = theBackwardLayers.begin(); 
               eli != theBackwardLayers.end(); eli++ ) {
     MapE reacheableE =
-      dynamic_cast<MuonForwardNavigableLayer*>(((*eli).first)->navigableLayer())->getOuterEndcapLayers();
+      dynamic_cast<MuonForwardNavigableLayer*>(theAllNavigableLayer[((*eli).first)->seqNum()])->getOuterEndcapLayers();
     for (MapEI i = reacheableE.begin(); i != reacheableE.end(); i++ ) {
       reachedForwardLayersMap[(*i).first].insert(*eli);
     }
   // collect all compatible layer starting from a backward layer
     MapE compatibleE =
-      dynamic_cast<MuonForwardNavigableLayer*>(((*eli).first)->navigableLayer())->getAllOuterEndcapLayers();
+      dynamic_cast<MuonForwardNavigableLayer*>(theAllNavigableLayer[((*eli).first)->seqNum()])->getAllOuterEndcapLayers();
     for (MapEI i = compatibleE.begin(); i != compatibleE.end(); i++ ) {
       compatibleForwardLayersMap[(*i).first].insert(*eli);
     }
@@ -333,13 +333,13 @@ void MuonNavigationSchool::createInverseLinks()  {
               eli != theForwardLayers.end(); eli++ ) {
   // collect all reacheable layer starting from a forward layer
     MapE reacheableE =
-      dynamic_cast<MuonForwardNavigableLayer*>(((*eli).first)->navigableLayer())->getOuterEndcapLayers();
+      dynamic_cast<MuonForwardNavigableLayer*>(theAllNavigableLayer[((*eli).first)->seqNum()])->getOuterEndcapLayers();
     for (MapEI i = reacheableE.begin(); i != reacheableE.end(); i++ ) {
       reachedForwardLayersMap[(*i).first].insert(*eli);
     }
   // collect all compatible layer starting from a forward layer
     MapE compatibleE =
-      dynamic_cast<MuonForwardNavigableLayer*>(((*eli).first)->navigableLayer())->getAllOuterEndcapLayers();
+      dynamic_cast<MuonForwardNavigableLayer*>(theAllNavigableLayer[((*eli).first)->seqNum()])->getAllOuterEndcapLayers();
     for (MapEI i = compatibleE.begin(); i != compatibleE.end(); i++ ) {
       compatibleForwardLayersMap[(*i).first].insert(*eli);
     }
@@ -349,7 +349,7 @@ void MuonNavigationSchool::createInverseLinks()  {
   for ( MapBI bli  = theBarrelLayers.begin(); 
               bli != theBarrelLayers.end(); bli++ ) {
     MuonBarrelNavigableLayer* mbnl =
-      dynamic_cast<MuonBarrelNavigableLayer*>(((*bli).first)->navigableLayer());
+      dynamic_cast<MuonBarrelNavigableLayer*>(theAllNavigableLayer[((*bli).first)->seqNum()]);
     mbnl->setInwardLinks(reachedBarrelLayersMap[(*bli).first]);
     mbnl->setInwardCompatibleLinks(compatibleBarrelLayersMap[(*bli).first]);
 
@@ -358,7 +358,7 @@ void MuonNavigationSchool::createInverseLinks()  {
   for ( MapEI eli  = theBackwardLayers.begin(); 
               eli != theBackwardLayers.end(); eli++ ) {
     MuonForwardNavigableLayer* mfnl =      
-      dynamic_cast<MuonForwardNavigableLayer*>(((*eli).first)->navigableLayer());
+      dynamic_cast<MuonForwardNavigableLayer*>(theAllNavigableLayer[((*eli).first)->seqNum()]);
     // for backward next layers
     mfnl->setInwardLinks(reachedBarrelLayersMap[(*eli).first],
                          reachedForwardLayersMap[(*eli).first]);
@@ -370,8 +370,8 @@ void MuonNavigationSchool::createInverseLinks()  {
   for ( MapEI eli  = theForwardLayers.begin(); 
               eli != theForwardLayers.end(); eli++ ) {
     MuonForwardNavigableLayer* mfnl = 
-      dynamic_cast<MuonForwardNavigableLayer*>(((*eli).first)->navigableLayer());
-  // and for forward next layers
+      dynamic_cast<MuonForwardNavigableLayer*>(theAllNavigableLayer[((*eli).first)->seqNum()]);
+    // and for forward next layers
     mfnl->setInwardLinks(reachedBarrelLayersMap[(*eli).first],
                          reachedForwardLayersMap[(*eli).first]);
   // and for forward compatible layers

--- a/RecoMuon/Navigation/test/MuonNavigationTest.cc
+++ b/RecoMuon/Navigation/test/MuonNavigationTest.cc
@@ -19,7 +19,7 @@
 #include "RecoMuon/Navigation/interface/MuonNavigationSchool.h"
 //#include "RecoMuon/Navigation/interface/MuonTkNavigationSchool.h"
 #include "RecoMuon/Records/interface/MuonRecoGeometryRecord.h"
-#include "TrackingTools/DetLayers/interface/NavigationSetter.h"
+// #include "TrackingTools/DetLayers/interface/NavigationSetter.h"
 #include "RecoMuon/Navigation/interface/MuonNavigationPrinter.h"
 #include "RecoMuon/DetLayers/interface/MuonDetLayerGeometry.h"
 //#include "RecoTracker/TkDetLayers/interface/GeometricSearchTracker.h"
@@ -66,8 +66,8 @@ MuonNavigationTest::analyze( const edm::Event& iEvent, const edm::EventSetup& iS
 
    if ( testMuon ) {
       MuonNavigationSchool school(mm);
-      NavigationSetter setter(school);
-      MuonNavigationPrinter* printer = new MuonNavigationPrinter(mm);
+      // NavigationSetter setter(school);
+      MuonNavigationPrinter* printer = new MuonNavigationPrinter(mm, school );
       delete printer;
    }
 /*

--- a/RecoTracker/CkfPattern/interface/BaseCkfTrajectoryBuilder.h
+++ b/RecoTracker/CkfPattern/interface/BaseCkfTrajectoryBuilder.h
@@ -82,6 +82,8 @@ public:
 				    TrajectoryContainer& result) const { assert(0==1);}
 
 
+  void setNavigationSchool(NavigationSchool const * nv) { theNavigationSchool=nv;}
+
   virtual void setEvent(const edm::Event& event) const ;
   virtual void unset() const;
 
@@ -158,6 +160,8 @@ public:
   const Chi2MeasurementEstimatorBase*   theEstimator;
   const TransientTrackingRecHitBuilder* theTTRHBuilder;
   const MeasurementTrackerEvent*        theMeasurementTracker;
+  const NavigationSchool *              theNavigationSchool = nullptr;
+
 
  private:
   //  int theMaxLostHit;            /**< Maximum number of lost hits per trajectory candidate.*/

--- a/RecoTracker/CkfPattern/src/BaseCkfTrajectoryBuilder.cc
+++ b/RecoTracker/CkfPattern/src/BaseCkfTrajectoryBuilder.cc
@@ -7,6 +7,7 @@
 #include "TrackingTools/TrajectoryFiltering/interface/TrajectoryFilter.h"
 
   
+#include "TrackingTools/DetLayers/interface/NavigationSchool.h"
 #include "TrackingTools/MeasurementDet/interface/LayerMeasurements.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
 #include "TrackingTools/GeomPropagators/interface/Propagator.h"
@@ -210,12 +211,12 @@ BaseCkfTrajectoryBuilder::findStateAndLayers(const TrajectorySeed& seed, const T
       
       TSOS currentState(trajectoryStateTransform::transientState(ptod,surface,forwardPropagator(seed)->magneticField()));      
       const DetLayer* lastLayer = theMeasurementTracker->geometricSearchTracker()->detLayer(id);      
-      return StateAndLayers(currentState,lastLayer->nextLayers( *currentState.freeState(), traj.direction()) );
+      return StateAndLayers(currentState,theNavigationSchool->nextLayers(*lastLayer,*currentState.freeState(), traj.direction()) );
     }
   else
     {  
       TSOS const & currentState = traj.lastMeasurement().updatedState();
-      return StateAndLayers(currentState,traj.lastLayer()->nextLayers( *currentState.freeState(), traj.direction()) );
+      return StateAndLayers(currentState,theNavigationSchool->nextLayers(*traj.lastLayer(), *currentState.freeState(), traj.direction()) );
     }
 }
 
@@ -224,7 +225,7 @@ BaseCkfTrajectoryBuilder::findStateAndLayers(const TempTrajectory& traj) const{
   assert(!traj.empty());
  
   TSOS const & currentState = traj.lastMeasurement().updatedState();
-  return StateAndLayers(currentState,traj.lastLayer()->nextLayers( *currentState.freeState(), traj.direction()) );
+  return StateAndLayers(currentState,theNavigationSchool->nextLayers(*traj.lastLayer(), *currentState.freeState(), traj.direction()) );
 }
 
 

--- a/RecoTracker/CkfPattern/src/CkfTrackCandidateMakerBase.cc
+++ b/RecoTracker/CkfPattern/src/CkfTrackCandidateMakerBase.cc
@@ -136,6 +136,7 @@ namespace cms{
     edm::ESHandle<NavigationSchool> navigationSchoolH;
     es.get<NavigationSchoolRecord>().get(theNavigationSchoolName, navigationSchoolH);
     theNavigationSchool = navigationSchoolH.product();
+    theTrajectoryBuilder->setNavigationSchool(theNavigationSchool);
   }
 
   // Functions that gets called by framework every event
@@ -145,7 +146,7 @@ namespace cms{
     setEventSetup( es ); 
 
     // set the correct navigation
-    NavigationSetter setter( *theNavigationSchool);
+    // NavigationSetter setter( *theNavigationSchool);
     
     // propagator
     edm::ESHandle<Propagator> thePropagator;

--- a/RecoTracker/TkNavigation/src/BeamHaloNavigationSchool.cc
+++ b/RecoTracker/TkNavigation/src/BeamHaloNavigationSchool.cc
@@ -22,6 +22,11 @@ BeamHaloNavigationSchool::BeamHaloNavigationSchool(const GeometricSearchTracker*
   edm::LogInfo("BeamHaloNavigationSchool")<<"*********Running BeamHaloNavigationSchool *********";
   theBarrelLength = 0;theField = field; theTracker = theInputTracker;
   theAllDetLayersInSystem=&theInputTracker->allLayers();
+  theAllNavigableLayer.resize(theInputTracker->allLayers().size(),nullptr);
+
+
+
+
   // Get barrel layers
   /*sideways does not need barrels*/
   /*  vector<BarrelDetLayer*> blc = theTracker->barrelLayers(); 
@@ -47,12 +52,16 @@ BeamHaloNavigationSchool::BeamHaloNavigationSchool(const GeometricSearchTracker*
   //  linkBarrelLayers( symFinder);
 
   linkForwardLayers( symFinder);
+ 
+  setState(navigableLayers());
+
   LogDebug("BeamHaloNavigationSchool")<<"inverse relation";
   establishInverseRelations();
 
 
   //add the necessary inward links to end caps
   LogDebug("BeamHaloNavigationSchool")<<"linkOtherEndLayer";
+
   linkOtherEndLayers( symFinder);
 
   //set checkCrossing = false to all layers
@@ -73,6 +82,9 @@ BeamHaloNavigationSchool::BeamHaloNavigationSchool(const GeometricSearchTracker*
 
 void BeamHaloNavigationSchool::establishInverseRelations() {
   NavigationSetter setter(*this);
+
+
+
 
   // find for each layer which are the barrel and forward
   // layers that point to it

--- a/RecoTracker/TkNavigation/src/CosmicNavigationSchool.cc
+++ b/RecoTracker/TkNavigation/src/CosmicNavigationSchool.cc
@@ -12,7 +12,7 @@
 #include "TrackingTools/DetLayers/interface/ForwardDetLayer.h"
 #include "TrackingTools/DetLayers/src/DetBelowZ.h"
 #include "TrackingTools/DetLayers/src/DetLessZ.h"
-#include "TrackingTools/DetLayers/interface/NavigationSetter.h"
+// #include "TrackingTools/DetLayers/interface/NavigationSetter.h"
 
 #include <functional>
 #include <algorithm>

--- a/RecoTracker/TkNavigation/src/SimpleNavigableLayer.cc
+++ b/RecoTracker/TkNavigation/src/SimpleNavigableLayer.cc
@@ -1,10 +1,12 @@
 #include "RecoTracker/TkNavigation/interface/SimpleNavigableLayer.h"
+#include "TrackingTools/DetLayers/interface/NavigationSchool.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "DataFormats/GeometrySurface/interface/BoundCylinder.h"
 #include "DataFormats/GeometrySurface/interface/BoundDisk.h"
 #include "TrackingTools/PatternTools/interface/TransverseImpactPointExtrapolator.h"
+
 #include <set>
 
 using namespace std;
@@ -244,7 +246,7 @@ std::vector< const DetLayer * > SimpleNavigableLayer::compatibleLayers (const Fr
       if (!collect.insert(toTry).second) continue;
       
       //find the next layers from it
-      Lvect && nextLayers = (toTry)->nextLayers(fts,timeDirection);
+      Lvect && nextLayers = school->nextLayers(*toTry,fts,timeDirection);
       LogDebug("SimpleNavigableLayer")
 	<<counter<<"] this layer has : "<<nextLayers.size()<<" next layers.";
       nextLayerToTry.insert(nextLayers.begin(),nextLayers.end());

--- a/RecoTracker/TkNavigation/src/SimpleNavigationSchool.cc
+++ b/RecoTracker/TkNavigation/src/SimpleNavigationSchool.cc
@@ -32,6 +32,7 @@ SimpleNavigationSchool::SimpleNavigationSchool(const GeometricSearchTracker* the
 {
 
   theAllDetLayersInSystem=&theInputTracker->allLayers();
+  theAllNavigableLayer.resize(theInputTracker->allLayers().size(),nullptr);
 
   // Get barrel layers
   vector<BarrelDetLayer*> blc = theTracker->barrelLayers(); 
@@ -361,7 +362,9 @@ float SimpleNavigationSchool::barrelLength()
 
 void SimpleNavigationSchool::establishInverseRelations() {
 
-  NavigationSetter setter(*this);
+  // NavigationSetter setter(*this);
+
+  setState(navigableLayers());
 
     // find for each layer which are the barrel and forward
     // layers that point to it
@@ -389,12 +392,20 @@ void SimpleNavigationSchool::establishInverseRelations() {
       }
     }
 
-
+    /*
     vector<DetLayer*> lc = theTracker->allLayers();
     for ( vector<DetLayer*>::iterator i = lc.begin(); i != lc.end(); i++) {
       SimpleNavigableLayer* navigableLayer =
 	dynamic_cast<SimpleNavigableLayer*>((**i).navigableLayer());
       navigableLayer->setInwardLinks( reachedBarrelLayersMap[*i],reachedForwardLayersMap[*i] );
+    }
+    */
+    
+    for(auto nl : theAllNavigableLayer) {
+      if (!nl) continue;
+      SimpleNavigableLayer* navigableLayer = static_cast<SimpleNavigableLayer*>(nl);
+      auto dl = nl->detLayer();
+      navigableLayer->setInwardLinks( reachedBarrelLayersMap[dl],reachedForwardLayersMap[dl] );
     }
     
 }

--- a/RecoTracker/TkNavigation/src/SimpleNavigationSchool.cc
+++ b/RecoTracker/TkNavigation/src/SimpleNavigationSchool.cc
@@ -34,6 +34,7 @@ SimpleNavigationSchool::SimpleNavigationSchool(const GeometricSearchTracker* the
   theAllDetLayersInSystem=&theInputTracker->allLayers();
   theAllNavigableLayer.resize(theInputTracker->allLayers().size(),nullptr);
 
+
   // Get barrel layers
   vector<BarrelDetLayer*> blc = theTracker->barrelLayers(); 
   for ( vector<BarrelDetLayer*>::iterator i = blc.begin(); i != blc.end(); i++) {
@@ -376,19 +377,17 @@ void SimpleNavigationSchool::establishInverseRelations() {
     ForwardMapType reachedForwardLayersMap;
 
 
-    for ( BDLI bli = theBarrelLayers.begin();
-        bli!=theBarrelLayers.end(); bli++) {
-      DLC reachedLC = (**bli).nextLayers( insideOut);
-      for ( DLI i = reachedLC.begin(); i != reachedLC.end(); i++) {
-        reachedBarrelLayersMap[*i].push_back( *bli);
+    for ( auto bli :  theBarrelLayers) {
+      auto reachedLC = nextLayers(*bli, insideOut);
+      for ( auto i : reachedLC) {
+        reachedBarrelLayersMap[i].push_back(bli);
       }
     }
 
-    for ( FDLI fli = theForwardLayers.begin();
-        fli!=theForwardLayers.end(); fli++) {
-      DLC reachedLC = (**fli).nextLayers( insideOut);
-      for ( DLI i = reachedLC.begin(); i != reachedLC.end(); i++) {
-        reachedForwardLayersMap[*i].push_back( *fli);
+    for ( auto fli : theForwardLayers) {
+      auto reachedLC = nextLayers(*fli, insideOut);
+      for ( auto i : reachedLC) {
+        reachedForwardLayersMap[i].push_back(fli);
       }
     }
 
@@ -401,12 +400,14 @@ void SimpleNavigationSchool::establishInverseRelations() {
     }
     */
     
+    
     for(auto nl : theAllNavigableLayer) {
       if (!nl) continue;
-      SimpleNavigableLayer* navigableLayer = static_cast<SimpleNavigableLayer*>(nl);
+      auto navigableLayer = static_cast<SimpleNavigableLayer*>(nl);
       auto dl = nl->detLayer();
       navigableLayer->setInwardLinks( reachedBarrelLayersMap[dl],reachedForwardLayersMap[dl] );
     }
+    
     
 }
 

--- a/RecoTracker/TkNavigation/src/SimpleNavigationSchool.cc
+++ b/RecoTracker/TkNavigation/src/SimpleNavigationSchool.cc
@@ -12,7 +12,7 @@
 #include "TrackingTools/DetLayers/interface/ForwardDetLayer.h"
 #include "TrackingTools/DetLayers/src/DetBelowZ.h"
 #include "TrackingTools/DetLayers/src/DetLessZ.h"
-#include "TrackingTools/DetLayers/interface/NavigationSetter.h"
+// #include "TrackingTools/DetLayers/interface/NavigationSetter.h"
 
 #include "DataFormats/GeometrySurface/interface/BoundCylinder.h"
 #include "DataFormats/GeometrySurface/interface/BoundDisk.h"

--- a/RecoTracker/TkNavigation/test/NavigationSchoolAnalyzer_cfg.py
+++ b/RecoTracker/TkNavigation/test/NavigationSchoolAnalyzer_cfg.py
@@ -26,7 +26,8 @@ process.source = cms.Source("EmptySource")
 
 process.navigationSchoolAnalyzer = cms.EDAnalyzer("NavigationSchoolAnalyzer",
 #    navigationSchoolName = cms.string('BeamHaloNavigationSchool')
-    navigationSchoolName = cms.string('SimpleNavigationSchool')
+    navigationSchoolName = cms.string('CosmicNavigationSchool')
+#    navigationSchoolName = cms.string('SimpleNavigationSchool')
 )
 
 process.p = cms.Path(process.navigationSchoolAnalyzer)

--- a/RecoTracker/TkNavigation/test/NavigationSchoolAnalyzer_cfg.py
+++ b/RecoTracker/TkNavigation/test/NavigationSchoolAnalyzer_cfg.py
@@ -30,6 +30,9 @@ process.navigationSchoolAnalyzer = cms.EDAnalyzer("NavigationSchoolAnalyzer",
 #    navigationSchoolName = cms.string('SimpleNavigationSchool')
 )
 
-process.p = cms.Path(process.navigationSchoolAnalyzer)
+process.muonNavigationTest = cms.EDAnalyzer("MuonNavigationTest")
+
+
+process.p = cms.Path(process.navigationSchoolAnalyzer+process.muonNavigationTest)
 
 

--- a/RecoTracker/TkNavigation/test/NavigationSchoolAnalyzer_cfg.py
+++ b/RecoTracker/TkNavigation/test/NavigationSchoolAnalyzer_cfg.py
@@ -2,19 +2,22 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("NavigationSchoolAnalyze")
 
-process.load("Configuration.StandardSequences.Geometry_cff")
-process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-process.GlobalTag.globaltag = 'STARTUP_V4::All'
-process.load("Configuration.StandardSequences.MagneticField_cff")
+# process.load("Configuration.StandardSequences.Geometry_cff")
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:com10_8E33v2', '')
+# process.load("Configuration.StandardSequences.MagneticField_cff")
 process.load("RecoTracker.TkNavigation.NavigationSchoolESProducer_cff")
 
-process.MessageLogger = cms.Service("MessageLogger",
-    destinations = cms.untracked.vstring('detailedInfo')
-)
+#process.MessageLogger = cms.Service("MessageLogger",
+#    destinations = cms.untracked.vstring('detailedInfo')
+#)
 
-process.Tracer = cms.Service("Tracer",
-    indentation = cms.untracked.string('$$')
-)
+#process.Tracer = cms.Service("Tracer",
+#    indentation = cms.untracked.string('$$')
+#)
 
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1)
@@ -22,8 +25,8 @@ process.maxEvents = cms.untracked.PSet(
 process.source = cms.Source("EmptySource")
 
 process.navigationSchoolAnalyzer = cms.EDAnalyzer("NavigationSchoolAnalyzer",
-    navigationSchoolName = cms.string('BeamHaloNavigationSchool')
-#    navigationSchoolName = cms.string('SimpleNavigationSchool')
+#    navigationSchoolName = cms.string('BeamHaloNavigationSchool')
+    navigationSchoolName = cms.string('SimpleNavigationSchool')
 )
 
 process.p = cms.Path(process.navigationSchoolAnalyzer)

--- a/RecoTracker/TrackProducer/interface/TrackProducerBase.icc
+++ b/RecoTracker/TrackProducer/interface/TrackProducerBase.icc
@@ -21,7 +21,7 @@
 
 #include "TrackingTools/DetLayers/interface/NavigationSchool.h"
 #include "RecoTracker/Record/interface/NavigationSchoolRecord.h"
-#include "TrackingTools/DetLayers/interface/NavigationSetter.h"
+// #include "TrackingTools/DetLayers/interface/NavigationSetter.h"
 
 #include <TrackingTools/KalmanUpdators/interface/Chi2MeasurementEstimator.h>
 #include <TrackingTools/DetLayers/interface/GeometricSearchDet.h> 
@@ -188,10 +188,11 @@ TrackProducerBase<T>::setSecondHitPattern(Trajectory* traj, T& track,
     // ----------- this previous block of code is not very safe. It should rely less on the sorting of the trajectory measurements -----
 
    
+    
     LogDebug("TrackProducer") << "calling inner compLayers()...";
-    std::vector< const DetLayer * > innerCompLayers = innerLayer->compatibleLayers(*innerState,dirForInnerLayers);
+    auto innerCompLayers = (*theSchool).compatibleLayers(*innerLayer,*innerState,dirForInnerLayers);
     LogDebug("TrackProducer") << "calling outer compLayers()...";
-    std::vector< const DetLayer * > outerCompLayers = outerLayer->compatibleLayers(*outerState,dirForOuterLayers);
+    auto outerCompLayers = (*theSchool).compatibleLayers(*outerLayer,*outerState,dirForOuterLayers);
 
     LogDebug("TrackProducer")
       << "inner DetLayer  sub: " 

--- a/RecoTracker/TrackProducer/src/GsfTrackProducerBase.cc
+++ b/RecoTracker/TrackProducer/src/GsfTrackProducerBase.cc
@@ -108,7 +108,7 @@ GsfTrackProducerBase::putInEvt(edm::Event& evt,
       {
         edm::Handle<MeasurementTrackerEvent> mte;
         evt.getByToken(mteSrc_, mte);
-	NavigationSetter setter( *theSchool );
+	// NavigationSetter setter( *theSchool );
 	setSecondHitPattern(theTraj,track,prop,&*mte);
       }
     //==============================================================

--- a/RecoTracker/TrackProducer/src/KfTrackProducerBase.cc
+++ b/RecoTracker/TrackProducer/src/KfTrackProducerBase.cc
@@ -102,7 +102,7 @@ void KfTrackProducerBase::putInEvt(edm::Event& evt,
       {
         edm::Handle<MeasurementTrackerEvent> mte;
         evt.getByToken(mteSrc_, mte);
-	NavigationSetter setter( *theSchool );
+	// NavigationSetter setter( *theSchool );
 	setSecondHitPattern(theTraj,track,prop,&*mte);
       }
     //==============================================================

--- a/TrackingTools/DetLayers/interface/DetLayer.h
+++ b/TrackingTools/DetLayers/interface/DetLayer.h
@@ -46,6 +46,9 @@ class DetLayer : public GeometricSearchDet {
   /// Which part of the detector (barrel, endcap)
   virtual Location location() const = 0;
 
+
+  // obsoleted my new interface
+
   /// Return the NavigableLayer associated with this DetLayer
   NavigableLayer* navigableLayer() const { return theNavigableLayer;}
 

--- a/TrackingTools/DetLayers/interface/NavigableLayer.h
+++ b/TrackingTools/DetLayers/interface/NavigableLayer.h
@@ -12,6 +12,7 @@
 
 class DetLayer;
 class FreeTrajectoryState;
+class NavigationSchool;
 
 /** The navigation component of the DetLayer.
  *  If navigation is not setup the DetLayer has a zero pointer to
@@ -51,6 +52,12 @@ public:
   virtual DetLayer* detLayer() const = 0;
   virtual void   setDetLayer( DetLayer* dl) = 0;
 
+  void setSchool(NavigationSchool const * sh) {school = sh;}
+
+protected :
+
+  NavigationSchool const * school=nullptr;
+  
 };
 
 #endif 

--- a/TrackingTools/DetLayers/interface/NavigationSchool.h
+++ b/TrackingTools/DetLayers/interface/NavigationSchool.h
@@ -3,9 +3,8 @@
 
 #include <vector>
 
-class NavigableLayer;
-class NavigationSchool;
-class DetLayer;
+#include "NavigableLayer.h"
+#include "DetLayer.h"
 
 /** A base class for NavigationSchools.
  *  The links between layers are computed or loaded from 
@@ -25,8 +24,43 @@ public:
 
   virtual StateType navigableLayers() const = 0;
 
-  const std::vector<DetLayer*> & allLayersInSystem() const {return *theAllDetLayersInSystem;}
 
+ /// Return the next (closest) layer(s) that can be reached in the specified
+  /// NavigationDirection
+  template<typename... Args>
+  std::vector<const DetLayer*> 
+  nextLayers(const DetLayer & detLayer, Args && ...args) const {
+   assert( detLayer.seqNum()>=0);
+   auto nl = theAllNavigableLayer[detLayer.seqNum()];
+    return nl
+      ? nl->nextLayers(std::forward<Args>(args)...)
+      : std::vector<const DetLayer*>();
+  }
+  
+  /// Returns all layers compatible 
+  template<typename... Args>
+  std::vector<const DetLayer*> 
+  compatibleLayers(const DetLayer & detLayer, Args && ...args) const {
+    auto nl = theAllNavigableLayer[detLayer.seqNum()];
+    return nl
+      ? nl->compatibleLayers(std::forward<Args>(args)...)
+      : std::vector<const DetLayer*>();
+  }
+
+protected:
+
+  void setState( const StateType& state) {
+    for (auto nl : state)
+      if (nl) theAllNavigableLayer[nl->detLayer()->seqNum()]=nl;
+  }
+
+  // index correspond to seqNum of DetLayers
+  StateType theAllNavigableLayer;
+
+
+  // will be obsoleted together with NAvigationSetter
+public:
+  const std::vector<DetLayer*> & allLayersInSystem() const {return *theAllDetLayersInSystem;}
  protected:
   const std::vector<DetLayer*> * theAllDetLayersInSystem;
 };

--- a/TrackingTools/DetLayers/interface/NavigationSchool.h
+++ b/TrackingTools/DetLayers/interface/NavigationSchool.h
@@ -6,8 +6,8 @@
 #include "NavigableLayer.h"
 #include "DetLayer.h"
 
-#include <iostream>
-#include <typeinfo>
+// #include <iostream>
+// #include <typeinfo>
 
 /** A base class for NavigationSchools.
  *  The links between layers are computed or loaded from 
@@ -20,7 +20,7 @@ class NavigationSchool {
 public:
 
   NavigationSchool() : theAllDetLayersInSystem(0){
-    std::cout << "NVSH: C "<< this << std::endl;
+//    std::cout << "NVSH: C "<< this << std::endl;
   }
 
   virtual ~NavigationSchool() {}
@@ -55,8 +55,8 @@ public:
 protected:
 
   void setState( const StateType& state) {
-    std::cout << "NVSH: set "<< this << ' ' << typeid(*this).name() 
-	      << ' ' << state.size() << ' ' << theAllNavigableLayer.size() << std::endl;
+  //  std::cout << "NVSH: set "<< this << ' ' << typeid(*this).name() 
+  //	      << ' ' << state.size() << ' ' << theAllNavigableLayer.size() << std::endl;
 
     for (auto nl : state)
       if (nl) theAllNavigableLayer[nl->detLayer()->seqNum()]=nl;

--- a/TrackingTools/DetLayers/interface/NavigationSchool.h
+++ b/TrackingTools/DetLayers/interface/NavigationSchool.h
@@ -58,8 +58,11 @@ protected:
   //  std::cout << "NVSH: set "<< this << ' ' << typeid(*this).name() 
   //	      << ' ' << state.size() << ' ' << theAllNavigableLayer.size() << std::endl;
 
-    for (auto nl : state)
-      if (nl) theAllNavigableLayer[nl->detLayer()->seqNum()]=nl;
+    for (auto nl : state) {
+      if (!nl) continue;
+      theAllNavigableLayer[nl->detLayer()->seqNum()]=nl;
+      nl->setSchool(this);
+    }
   }
 
   // index correspond to seqNum of DetLayers

--- a/TrackingTools/DetLayers/interface/NavigationSchool.h
+++ b/TrackingTools/DetLayers/interface/NavigationSchool.h
@@ -6,6 +6,9 @@
 #include "NavigableLayer.h"
 #include "DetLayer.h"
 
+#include <iostream>
+#include <typeinfo>
+
 /** A base class for NavigationSchools.
  *  The links between layers are computed or loaded from 
  *  persistent store by a NavigationSchool.
@@ -16,7 +19,9 @@
 class NavigationSchool {
 public:
 
-  NavigationSchool() : theAllDetLayersInSystem(0){}
+  NavigationSchool() : theAllDetLayersInSystem(0){
+    std::cout << "NVSH: C "<< this << std::endl;
+  }
 
   virtual ~NavigationSchool() {}
 
@@ -50,6 +55,9 @@ public:
 protected:
 
   void setState( const StateType& state) {
+    std::cout << "NVSH: set "<< this << ' ' << typeid(*this).name() 
+	      << ' ' << state.size() << ' ' << theAllNavigableLayer.size() << std::endl;
+
     for (auto nl : state)
       if (nl) theAllNavigableLayer[nl->detLayer()->seqNum()]=nl;
   }

--- a/TrackingTools/DetLayers/interface/NavigationSchool.h
+++ b/TrackingTools/DetLayers/interface/NavigationSchool.h
@@ -20,7 +20,7 @@ class NavigationSchool {
 public:
 
   NavigationSchool() : theAllDetLayersInSystem(0){
-    std::cout << "NVSH: C "<< this << std::endl;
+//    std::cout << "NVSH: C "<< this << std::endl;
   }
 
   virtual ~NavigationSchool() {}
@@ -55,8 +55,8 @@ public:
 protected:
 
   void setState( const StateType& state) {
-    std::cout << "NVSH: set "<< this << ' ' << typeid(*this).name() 
-	      << ' ' << state.size() << ' ' << theAllNavigableLayer.size() << std::endl;
+  //  std::cout << "NVSH: set "<< this << ' ' << typeid(*this).name() 
+  //	      << ' ' << state.size() << ' ' << theAllNavigableLayer.size() << std::endl;
 
     for (auto nl : state)
       if (nl) theAllNavigableLayer[nl->detLayer()->seqNum()]=nl;

--- a/TrackingTools/DetLayers/interface/NavigationSchool.h
+++ b/TrackingTools/DetLayers/interface/NavigationSchool.h
@@ -6,8 +6,8 @@
 #include "NavigableLayer.h"
 #include "DetLayer.h"
 
-// #include <iostream>
-// #include <typeinfo>
+#include <iostream>
+#include <typeinfo>
 
 /** A base class for NavigationSchools.
  *  The links between layers are computed or loaded from 
@@ -20,7 +20,7 @@ class NavigationSchool {
 public:
 
   NavigationSchool() : theAllDetLayersInSystem(0){
-//    std::cout << "NVSH: C "<< this << std::endl;
+    std::cout << "NVSH: C "<< this << std::endl;
   }
 
   virtual ~NavigationSchool() {}
@@ -55,8 +55,8 @@ public:
 protected:
 
   void setState( const StateType& state) {
-  //  std::cout << "NVSH: set "<< this << ' ' << typeid(*this).name() 
-  //	      << ' ' << state.size() << ' ' << theAllNavigableLayer.size() << std::endl;
+    std::cout << "NVSH: set "<< this << ' ' << typeid(*this).name() 
+	      << ' ' << state.size() << ' ' << theAllNavigableLayer.size() << std::endl;
 
     for (auto nl : state)
       if (nl) theAllNavigableLayer[nl->detLayer()->seqNum()]=nl;


### PR DESCRIPTION
On Friday Chris reported that
Trackings use of DetLayer is inherently thread unsafe. The NavigationSchool is in the EventSetup but it gives non-const access to its internal DetLayers:
https://cmssdt.cern.ch/SDT/lxr/source/TrackingTools/DetLayers/interface/NavigationSchool.h?v=CMSSW_7_1_X_2014-04-25-0200#028
and those DetLayers are constantly being modified by other code:
       https://cmssdt.cern.ch/SDT/lxr/source/TrackingTools/DetLayers/src/NavigationSetter.cc?v=CMSSW_7_1_X_2014-04-25-0200#059
In addition, the DetLayers have internally a NavigableLayer\* which they give non-const access to and call non-const methods on in its own const functions:
       https://cmssdt.cern.ch/SDT/lxr/source/TrackingTools/DetLayers/interface/DetLayer.h?v=CMSSW_7_1_X_2014-04-25-0200#050
and to top it off, some types inheriting from NavigableLayer use mutables
       https://cmssdt.cern.ch/SDT/lxr/source/RecoTracker/TkNavigation/interface/SimpleNavigableLayer.h?v=CMSSW_7_1_X_2014-04-25-0200#042
The only way to deal with this now is to mark all modules which interact with DetLayers as thread-unsafe.

After a week-end long of code analysis I come to the conclusion that the best solution will be:
to create a vector of NavigableLayer const \*  in the NavigationSchool (or equivalent)
using DetLayer::seqNum as index.
One should them to manage to get the NavigationSchool  everywhere 
nextLayers and compatibleLayers are invoked a trivial indirection will do the trick…

This is 
a) easy to find all calls to nextLayers and compatibleLayers.
Labour intensive to percolate the navigation school. NOT error-prone
b) quite logical,  it will reassign the responsibility of navigation to the Navigation!
c) No changes to configation (unless percolation fails)

Plan there're is
1) The infrastructure for both tracker and muon is trivial to build.
I wil do it togehter with a couple of use case.

2) at that point the Labour intensive part can be split in many pieces: it it just to find the way to percolate navigation scool and modify the calling sequence to 
nextLayers and compatibleLayers by few characters (litterally!)

3) remove all “mutable” including the Navigation Setter.
add const here and there (maybe a couple of cost_cast in the NavigationSchool itself)

DONE…

---

status : this PR

1)
done for Base class, Simple, Cosmic and Muon
all three tested with properly modified already existing unit tests

2)
done in CkfTrajectoryBuilder and Maker (+ partial in Conversion f/w/c TrBuilder)
one NavigationSetter gone!

at this point we ca go in Parallel.
This PR is therefore requested to be integrated to allow other developers to modify various bits of code
that require NavigationSchool to be percolated

No regression expected
No regression observed
