### PR TITLE
Multithreading improvements in JetTagComputer

### DIFF
--- a/CondFormats/PhysicsToolsObjects/interface/MVAComputer.h
+++ b/CondFormats/PhysicsToolsObjects/interface/MVAComputer.h
@@ -194,6 +194,7 @@ class MVAComputerContainer {
 
 	MVAComputer &add(const std::string &label);
 	virtual const MVAComputer &find(const std::string &label) const;
+	virtual bool contains(const std::string &label) const;
 
 	// cacheId stuff to detect changes
 	typedef unsigned int CacheId;

--- a/CondFormats/PhysicsToolsObjects/src/MVAComputer.cc
+++ b/CondFormats/PhysicsToolsObjects/src/MVAComputer.cc
@@ -203,5 +203,14 @@ const MVAComputer &MVAComputerContainer::find(const std::string &label) const
 	return pos->second;
 }
 
+bool MVAComputerContainer::contains(const std::string &label) const
+{
+	std::vector<Entry>::const_iterator pos =
+				std::find_if(entries.begin(), entries.end(),
+				             Comparator(label));
+	if (pos == entries.end()) return false;
+	return true;
+}
+
 } // namespace Calibration
 } // namespace PhysicsTools

--- a/PhysicsTools/MVATrainer/interface/MVATrainerContainer.h
+++ b/PhysicsTools/MVATrainer/interface/MVATrainerContainer.h
@@ -27,6 +27,14 @@ class MVATrainerContainer : public Calibration::MVAComputerContainer {
 		return Calibration::MVAComputerContainer::find(label);
 	}
 
+	virtual bool
+	contains(const std::string &label) const
+	{
+		Map_t::const_iterator pos = trainCalibs.find(label);
+		if (pos != trainCalibs.end()) return true;
+		return Calibration::MVAComputerContainer::contains(label);
+	}
+
 	void addTrainer(const std::string &label, const Value_t &calibration)
 	{ trainCalibs[label] = calibration; }
 

--- a/RecoBTau/JetTagComputer/interface/CombinedMVAJetTagComputer.h
+++ b/RecoBTau/JetTagComputer/interface/CombinedMVAJetTagComputer.h
@@ -17,16 +17,7 @@ class CombinedMVAJetTagComputer : public GenericMVAJetTagComputer {
 	CombinedMVAJetTagComputer(const edm::ParameterSet &parameters);
 	virtual ~CombinedMVAJetTagComputer();
 
-	virtual void setEventSetup(const edm::EventSetup &es) const
-	{
-		setEventSetup(es, false);
-		GenericMVAJetTagComputer::setEventSetup(es);
-	}
-
-	virtual void passEventSetup(const edm::EventSetup &es) const
-	{
-		setEventSetup(es, true);
-	}
+	virtual void initialize(const JetTagComputerRecord & record);
 
 	virtual reco::TaggingVariableList
 	taggingVariables(const TagInfoHelper &info) const;
@@ -41,9 +32,7 @@ class CombinedMVAJetTagComputer : public GenericMVAJetTagComputer {
 		std::vector<int>	indices;
 	};
 
-	void setEventSetup(const edm::EventSetup &es, bool pass) const;
-
-	mutable std::vector<Computer>	computers;
+	std::vector<Computer> computers;
 };
 
 #endif // RecoBTau_JetTagComputer_CombinedMVAJetTagComputer_h

--- a/RecoBTau/JetTagComputer/interface/GenericMVAComputer.h
+++ b/RecoBTau/JetTagComputer/interface/GenericMVAComputer.h
@@ -73,13 +73,13 @@ class GenericMVAComputer : public PhysicsTools::MVAComputer {
 		    protected:
 			friend class TaggingVariableIterator;
 
-			inline Value(TaggingVariableMapping *mapping,
+			inline Value(TaggingVariableMapping const* mapping,
 			             const Iter_t &iter) :
 				mapping(mapping), iter(iter) {}
 
 		    private:
 			// pointer to the current mapping
-			TaggingVariableMapping	*mapping;
+			TaggingVariableMapping	const* mapping;
 			// iterator to reco::TaggingVariable in orig. container
 			Iter_t			iter;
 		};
@@ -115,7 +115,7 @@ class GenericMVAComputer : public PhysicsTools::MVAComputer {
 
 	    protected:
 		friend class GenericMVAComputer;
-		inline TaggingVariableIterator(TaggingVariableMapping *mapping,
+		inline TaggingVariableIterator(TaggingVariableMapping const* mapping,
 		                               const Iter_t &iter) :
 			value(mapping, iter) {}
 
@@ -143,7 +143,7 @@ class GenericMVAComputer : public PhysicsTools::MVAComputer {
 	};
 
     private:
-	static TaggingVariableMapping	mapping;
+	static const TaggingVariableMapping	mapping;
 };
 
 #endif // RecoBTau_BTauComputer_GenericMVAComputer_h

--- a/RecoBTau/JetTagComputer/interface/GenericMVAComputerCache.h
+++ b/RecoBTau/JetTagComputer/interface/GenericMVAComputerCache.h
@@ -17,10 +17,9 @@ class GenericMVAComputerCache {
 	bool
 	update(const PhysicsTools::Calibration::MVAComputerContainer *calib);
 
-	inline GenericMVAComputer const* getComputer(int index) const
-	{ return index >= 0 ? computers[index].computer.get() : 0; }
+	GenericMVAComputer const* getComputer(int index) const;
 
-	inline bool isEmpty() const { return empty; }
+	inline bool isEmpty() const;
 
     private:
 	struct IndividualComputer {
@@ -37,6 +36,7 @@ class GenericMVAComputerCache {
 	PhysicsTools::Calibration::MVAComputerContainer::CacheId	cacheId;
 	bool								initialized;
 	bool								empty;
+        std::string errorUpdatingLabel;
 };
 
 #endif // RecoBTau_JetTagComputer_GenericMVAComputerCache_h

--- a/RecoBTau/JetTagComputer/interface/GenericMVAJetTagComputer.h
+++ b/RecoBTau/JetTagComputer/interface/GenericMVAJetTagComputer.h
@@ -11,12 +11,14 @@
 #include "RecoBTau/JetTagComputer/interface/GenericMVAComputerCache.h"
 #include "RecoBTau/JetTagComputer/interface/TagInfoMVACategorySelector.h"
 
+class JetTagComputerRecord;
+
 class GenericMVAJetTagComputer : public JetTagComputer {
     public:
 	GenericMVAJetTagComputer(const edm::ParameterSet &parameters);
 	virtual ~GenericMVAJetTagComputer();
 
-	virtual void setEventSetup(const edm::EventSetup &es) const;
+	virtual void initialize(const JetTagComputerRecord &);
 
 	virtual float discriminator(const TagInfoHelper &info) const;
 
@@ -25,12 +27,9 @@ class GenericMVAJetTagComputer : public JetTagComputer {
 	virtual reco::TaggingVariableList
 	taggingVariables(const TagInfoHelper &info) const;
 
-	// for passing through an EventSetup when training
-	virtual void passEventSetup(const edm::EventSetup &es) const {}
-
     private:
-	std::auto_ptr<TagInfoMVACategorySelector>	categorySelector;
-	mutable GenericMVAComputerCache			computerCache;
+	std::auto_ptr<TagInfoMVACategorySelector> categorySelector;
+	GenericMVAComputerCache computerCache;
 };
 
 #endif // RecoBTau_JetTagComputer_GenericMVAJetTagComputer_h

--- a/RecoBTau/JetTagComputer/interface/JetTagComputer.h
+++ b/RecoBTau/JetTagComputer/interface/JetTagComputer.h
@@ -9,6 +9,8 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #include "DataFormats/BTauReco/interface/BaseTagInfo.h"
 
+class JetTagComputerRecord;
+
 class JetTagComputer {
     public:
 	class TagInfoHelper {
@@ -61,14 +63,16 @@ class JetTagComputer {
 	explicit JetTagComputer(const edm::ParameterSet& configuration) :
 		m_setupDone(false) {}
 
-	virtual void setEventSetup(const edm::EventSetup&) const {}
+	virtual void initialize(const JetTagComputerRecord &) {}
 
 	float operator () (const reco::BaseTagInfo& info) const;
 	inline float operator () (const TagInfoHelper &helper) const
 	{ return discriminator(helper); }
 
 	inline const std::vector<std::string> &getInputLabels() const
-	{ m_setupDone = true; return m_inputLabels; }
+	{ return m_inputLabels; }
+
+        void setupDone() { m_setupDone = true; }
 
     protected:
 	void uses(unsigned int id, const std::string &label);
@@ -79,7 +83,7 @@ class JetTagComputer {
 
     private:
 	std::vector<std::string>	m_inputLabels;
-	mutable bool			m_setupDone;
+	bool m_setupDone;
 };
 
 #endif // RecoBTau_JetTagComputer_h

--- a/RecoBTau/JetTagComputer/interface/JetTagComputerESProducer.h
+++ b/RecoBTau/JetTagComputer/interface/JetTagComputerESProducer.h
@@ -5,6 +5,7 @@
 #include <boost/static_assert.hpp>
 #include <boost/type_traits.hpp>
 #include <boost/shared_ptr.hpp>
+#include <boost/make_shared.hpp>
 
 #include "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -21,13 +22,15 @@ public:
   JetTagComputerESProducer(const edm::ParameterSet & pset) : m_pset(pset) {
     setWhatProduced(this, m_pset.getParameter<std::string>("@module_label") );
 
-    m_jetTagComputer = boost::shared_ptr<JetTagComputer>( new ConcreteJetTagComputer( m_pset ) );
+    m_jetTagComputer = boost::make_shared<ConcreteJetTagComputer>(m_pset);
   }
   
   virtual ~JetTagComputerESProducer() {
   }
 
   boost::shared_ptr<JetTagComputer> produce(const JetTagComputerRecord & record) {
+    m_jetTagComputer->initialize(record);
+    m_jetTagComputer->setupDone();
     return m_jetTagComputer;
   }
 

--- a/RecoBTau/JetTagComputer/interface/JetTagComputerRecord.h
+++ b/RecoBTau/JetTagComputer/interface/JetTagComputerRecord.h
@@ -1,8 +1,14 @@
 #ifndef RecoBTau_JetTagComputerRecord_h
 #define RecoBTau_JetTagComputerRecord_h
 
-#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+#include "FWCore/Framework/interface/DependentRecordImplementation.h"
+#include <boost/mpl/vector.hpp>
 
-class JetTagComputerRecord : public edm::eventsetup::EventSetupRecordImplementation<JetTagComputerRecord> {};
+class BTauGenericMVAJetTagComputerRcd;
 
-#endif 
+class JetTagComputerRecord :
+  public edm::eventsetup::DependentRecordImplementation<
+    JetTagComputerRecord,
+    boost::mpl::vector<BTauGenericMVAJetTagComputerRcd> > {};
+
+#endif

--- a/RecoBTau/JetTagComputer/plugins/JetTagProducer.h
+++ b/RecoBTau/JetTagComputer/plugins/JetTagProducer.h
@@ -9,9 +9,12 @@
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/ESWatcher.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "RecoBTau/JetTagComputer/interface/JetTagComputer.h"
+#include "RecoBTau/JetTagComputer/interface/JetTagComputerRecord.h"
+
 #include "DataFormats/Common/interface/View.h"
 #include "DataFormats/BTauReco/interface/BaseTagInfo.h"
 
@@ -23,12 +26,10 @@ class JetTagProducer : public edm::EDProducer {
     private:
 	virtual void produce(edm::Event&, const edm::EventSetup&);
 
-	void setup(const edm::EventSetup&);
-
-	const JetTagComputer			*m_computer;
 	std::string				m_jetTagComputer;
 	std::vector<edm::EDGetTokenT<edm::View<reco::BaseTagInfo> > > token_tagInfos;
 	unsigned int nTagInfos;
+        edm::ESWatcher<JetTagComputerRecord> recordWatcher_;
 };
 
 #endif // RecoBTag_JetTagComputer_JetTagProducer_h

--- a/RecoBTau/JetTagComputer/src/GenericMVAComputer.cc
+++ b/RecoBTau/JetTagComputer/src/GenericMVAComputer.cc
@@ -9,7 +9,7 @@ using namespace reco;
 using namespace PhysicsTools;
 
 // static cache
-GenericMVAComputer::TaggingVariableMapping GenericMVAComputer::mapping;
+const GenericMVAComputer::TaggingVariableMapping GenericMVAComputer::mapping;
 
 GenericMVAComputer::TaggingVariableMapping::TaggingVariableMapping()
 {

--- a/RecoBTau/JetTagComputer/src/GenericMVAJetTagComputer.cc
+++ b/RecoBTau/JetTagComputer/src/GenericMVAJetTagComputer.cc
@@ -13,6 +13,7 @@
 #include "DataFormats/BTauReco/interface/TaggingVariable.h"
 #include "RecoBTau/JetTagComputer/interface/GenericMVAComputer.h"
 #include "RecoBTau/JetTagComputer/interface/GenericMVAJetTagComputer.h"
+#include "RecoBTau/JetTagComputer/interface/JetTagComputerRecord.h"
 
 using namespace reco;
 using namespace PhysicsTools;
@@ -46,11 +47,13 @@ GenericMVAJetTagComputer::~GenericMVAJetTagComputer()
 {
 }
 
-void GenericMVAJetTagComputer::setEventSetup(const edm::EventSetup &es) const
-{
+void GenericMVAJetTagComputer::initialize(const JetTagComputerRecord & record) {
+
+        const BTauGenericMVAJetTagComputerRcd& dependentRecord = record.getRecord<BTauGenericMVAJetTagComputerRcd>();
+
 	// retrieve MVAComputer calibration container
 	edm::ESHandle<Calibration::MVAComputerContainer> calibHandle;
-	es.get<BTauGenericMVAJetTagComputerRcd>().get(calibHandle);
+	dependentRecord.get(calibHandle);
 	const Calibration::MVAComputerContainer *calib = calibHandle.product();
 
 	// check for updates

--- a/RecoBTau/JetTagComputer/src/JetTagComputer.cc
+++ b/RecoBTau/JetTagComputer/src/JetTagComputer.cc
@@ -17,7 +17,7 @@ float JetTagComputer::operator () (const reco::BaseTagInfo& info) const
 
 void JetTagComputer::uses(unsigned int id, const std::string &label)
 {
-	if (m_setupDone)
+        if (m_setupDone)
 		throw cms::Exception("InvalidState")
 			<< "JetTagComputer::uses called outside of "
 			   "constructor" << std::endl;


### PR DESCRIPTION
Replace the const JetTagComputer::setEventSetup function
with a non-const initialize function, because setEventSetup
actually modified the data of the EventSetup product.
Previously the function had to be explicitly called
by the JetTagProducer using a const reference and now
the new function is called by the ESProducer.

JetTagComputerRecord is now dependent on
BTauGenericMVAJetTagComputerRcd and the calibrations
are obtained through this dependence. This manages
the IOVs properly also.

Remove the passEventSetup function which could not
have ever been called by anything in the release.
GenericMVAJetTagComputer::computers is no longer mutable.
GenericMVAComputer::mapping is now a const static member.
GenericMVAJetTagComputer::computerCache
is no longer mutable. JetTagComputer::m_setupDone is
no longer mutable.  JetTagProducer no longer has m_computer
as a data member as that was an EventSetup product.
The const_cast in CombinedMVAJetTagComputer::setEventSetup
is removed.

GenericMVAComputerCache now delays throwing an exception
when a calibration is missing until its getComputer function
is called. This is necessary because some ESProducers
are called by the hltConditions module even though they
are never actually used and it is OK that their calibrations
are missing. The function initialize is now
always called during the EventSetup get function call
whereas previously setEventSetup had to be explicitly
called by the module using the EventSetup product.
