### PR TITLE
Validation/RecoEgamma Add profile of r9 vs eta in PhotonValidator

### DIFF
--- a/Validation/RecoEgamma/plugins/PhotonValidator.cc
+++ b/Validation/RecoEgamma/plugins/PhotonValidator.cc
@@ -724,9 +724,9 @@ void PhotonValidator::bookHistograms( DQMStore::IBooker & iBooker, edm::Run cons
 
     /////    //
     histname="pR9VsEta";
-    p_r9VsEta_[0] = dbe_->bookProfile(histname+"All"," All photons r9 vs #eta: all Ecal ",etaBin2,etaMin, etaMax,100, 0.,1.1);
-    p_r9VsEta_[1] = dbe_->bookProfile(histname+"Unconv"," Unconv photons r9 vs #eta: all Ecal ",etaBin2,etaMin, etaMax,100, 0.,1.1);
-    p_r9VsEta_[2] = dbe_->bookProfile(histname+"Conv"," Conv photons r9 vs #eta: all Ecal ",etaBin2,etaMin, etaMax,100, 0.,1.1);
+    p_r9VsEta_[0] = iBooker.bookProfile(histname+"All"," All photons r9 vs #eta: all Ecal ",etaBin2,etaMin, etaMax,100, 0.,1.1);
+    p_r9VsEta_[1] = iBooker.bookProfile(histname+"Unconv"," Unconv photons r9 vs #eta: all Ecal ",etaBin2,etaMin, etaMax,100, 0.,1.1);
+    p_r9VsEta_[2] = iBooker.bookProfile(histname+"Conv"," Conv photons r9 vs #eta: all Ecal ",etaBin2,etaMin, etaMax,100, 0.,1.1);
     //
     histname="R9VsEt";
     if ( ! isRunCentrally_ ) h2_r9VsEt_[0] = dbe_->book2D(histname+"All"," All photons r9 vs Et: all Ecal ",etBin,etMin, etMax,100, 0.,1.1);

--- a/Validation/RecoEgamma/plugins/PhotonValidator.cc
+++ b/Validation/RecoEgamma/plugins/PhotonValidator.cc
@@ -729,8 +729,8 @@ void PhotonValidator::bookHistograms( DQMStore::IBooker & iBooker, edm::Run cons
     p_r9VsEta_[2] = iBooker.bookProfile(histname+"Conv"," Conv photons r9 vs #eta: all Ecal ",etaBin2,etaMin, etaMax,100, 0.,1.1);
     //
     histname="R9VsEt";
-    if ( ! isRunCentrally_ ) h2_r9VsEt_[0] = dbe_->book2D(histname+"All"," All photons r9 vs Et: all Ecal ",etBin,etMin, etMax,100, 0.,1.1);
-    if ( ! isRunCentrally_ ) h2_r9VsEt_[1] = dbe_->book2D(histname+"Unconv"," All photons r9 vs Et: all Ecal ",etBin,etMin, etMax,100, 0.,1.1);
+    if ( ! isRunCentrally_ ) h2_r9VsEt_[0] = iBooker.book2D(histname+"All"," All photons r9 vs Et: all Ecal ",etBin,etMin, etMax,100, 0.,1.1);
+    if ( ! isRunCentrally_ ) h2_r9VsEt_[1] = iBooker.book2D(histname+"Unconv"," All photons r9 vs Et: all Ecal ",etBin,etMin, etMax,100, 0.,1.1);
     //
     histname = "r1";
     h_r1_[0][0] = iBooker.book1D(histname+"All",   " e1x5/e5x5: All Ecal",r9Bin,r9Min, r9Max) ;

--- a/Validation/RecoEgamma/plugins/PhotonValidator.cc
+++ b/Validation/RecoEgamma/plugins/PhotonValidator.cc
@@ -723,13 +723,14 @@ void PhotonValidator::bookHistograms( DQMStore::IBooker & iBooker, edm::Run cons
     }
 
     /////    //
-    histname="R9VsEta";
-    if ( ! isRunCentrally_ ) h2_r9VsEta_[0] = iBooker.book2D(histname+"All"," All photons r9 vs #eta: all Ecal ",etaBin2,etaMin, etaMax,100, 0.,1.1);
-    if ( ! isRunCentrally_ ) h2_r9VsEta_[1] = iBooker.book2D(histname+"Unconv"," All photons r9 vs #eta: all Ecal ",etaBin2,etaMin, etaMax,100, 0.,1.1);
+    histname="pR9VsEta";
+    p_r9VsEta_[0] = dbe_->bookProfile(histname+"All"," All photons r9 vs #eta: all Ecal ",etaBin2,etaMin, etaMax,100, 0.,1.1);
+    p_r9VsEta_[1] = dbe_->bookProfile(histname+"Unconv"," Unconv photons r9 vs #eta: all Ecal ",etaBin2,etaMin, etaMax,100, 0.,1.1);
+    p_r9VsEta_[2] = dbe_->bookProfile(histname+"Conv"," Conv photons r9 vs #eta: all Ecal ",etaBin2,etaMin, etaMax,100, 0.,1.1);
     //
     histname="R9VsEt";
-    if ( ! isRunCentrally_ ) h2_r9VsEt_[0] = iBooker.book2D(histname+"All"," All photons r9 vs Et: all Ecal ",etBin,etMin, etMax,100, 0.,1.1);
-    if ( ! isRunCentrally_ ) h2_r9VsEt_[1] = iBooker.book2D(histname+"Unconv"," All photons r9 vs Et: all Ecal ",etBin,etMin, etMax,100, 0.,1.1);
+    if ( ! isRunCentrally_ ) h2_r9VsEt_[0] = dbe_->book2D(histname+"All"," All photons r9 vs Et: all Ecal ",etBin,etMin, etMax,100, 0.,1.1);
+    if ( ! isRunCentrally_ ) h2_r9VsEt_[1] = dbe_->book2D(histname+"Unconv"," All photons r9 vs Et: all Ecal ",etBin,etMin, etMax,100, 0.,1.1);
     //
     histname = "r1";
     h_r1_[0][0] = iBooker.book1D(histname+"All",   " e1x5/e5x5: All Ecal",r9Bin,r9Min, r9Max) ;
@@ -2392,8 +2393,9 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
       h_sigmaIetaIeta_[type][0]->Fill( sigmaIetaIeta );
       //
       h_hOverE_[type][0]->Fill( hOverE );
+      p_r9VsEta_[0] -> Fill (mcEta_, r9);
+
       if ( ! isRunCentrally_ ) {
-	h2_r9VsEta_[0] -> Fill (mcEta_, r9);
 	h2_r9VsEt_[0] -> Fill ((*mcPho).fourMomentum().et(), r9);
 	h2_r1VsEta_[0] -> Fill (mcEta_, r1);
 	h2_r1VsEt_[0] -> Fill ((*mcPho).fourMomentum().et(), r1);
@@ -2485,7 +2487,6 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
       if (  (*mcPho).isAConversion() == 0 ) {
 	if ( ! isRunCentrally_ ) {
 	  h2_eResVsEta_[1]->Fill (mcEta_, photonE/ (*mcPho).fourMomentum().e()  ) ;
-	  h2_r9VsEta_[1] -> Fill (mcEta_, r9);
 	  h2_r9VsEt_[1] -> Fill ((*mcPho).fourMomentum().et(), r9);
 	  //
 	  h2_r1VsEta_[1] -> Fill (mcEta_, r1);
@@ -2536,6 +2537,7 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
 	if ( ! isRunCentrally_ ) h2_eResVsEt_[0][1]->Fill ((*mcPho).fourMomentum().et(), photonE/(*mcPho).fourMomentum().e()  ) ;
 	p_eResVsEt_[0][1]->Fill ((*mcPho).fourMomentum().et(), photonE/(*mcPho).fourMomentum().e()  ) ;
 	p_eResVsEta_[1]->Fill (mcEta_,photonE/ (*mcPho).fourMomentum().e()  ) ;
+	p_r9VsEta_[1] -> Fill (mcEta_, r9);
 	p_sigmaEoEVsEta_[1] ->Fill(mcEta_,sigmaEoE);
 
 
@@ -2546,6 +2548,7 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
 	h_phoEResRegr2_[2][0]->Fill( photonERegr2 / (*mcPho).fourMomentum().e() );
 	p_eResVsEt_[0][2]->Fill ((*mcPho).fourMomentum().et(), photonE/(*mcPho).fourMomentum().e()  ) ;
 	p_eResVsEta_[2]->Fill (mcEta_,photonE/ (*mcPho).fourMomentum().e()  ) ;
+	p_r9VsEta_[2] -> Fill (mcEta_, r9);
 	p_sigmaEoEVsEta_[2] ->Fill(mcEta_, sigmaEoE);
 
 	if ( ! isRunCentrally_ ) {

--- a/Validation/RecoEgamma/plugins/PhotonValidator.h
+++ b/Validation/RecoEgamma/plugins/PhotonValidator.h
@@ -250,7 +250,6 @@ class PhotonValidator : public DQMEDAnalyzer
 
   MonitorElement* h_EtR9Less093_[3][3];
   MonitorElement* h_r9_[3][3];
-  MonitorElement* h2_r9VsEta_[3];
   MonitorElement* p_r9VsEta_[3];
   MonitorElement* h2_r9VsEt_[3];
   MonitorElement* p_r9VsEt_[3];


### PR DESCRIPTION
this PR  replaces PR #3286 which was needing to be rebased. The present PR is made on top of CMSSW_7_1_X_2014-04-27-1400
