### PR TITLE
Make hidden declaration explicit.

### DIFF
--- a/FWCore/ParameterSet/interface/ParameterDescriptionBase.h
+++ b/FWCore/ParameterSet/interface/ParameterDescriptionBase.h
@@ -96,6 +96,7 @@ namespace edm {
                                      bool optional,
                                      DocFormatHelper & dfh);
 
+    using ParameterDescriptionNode::exists_;
     virtual bool exists_(ParameterSet const& pset, bool isTracked) const = 0;
 
     virtual void insertDefault_(ParameterSet & pset) const = 0;


### PR DESCRIPTION
Required to avoid shadowing warning by clang.

```
.../src/FWCore/ParameterSet/interface/ParameterDescriptionBase.h:99:18:
warning: 'edm::ParameterDescriptionBase::exists_' hides overloaded
virtual function [-Woverloaded-virtual]
     virtual bool exists_(ParameterSet const& pset, bool isTracked)
const = 0;
                 ^
.../src/FWCore/ParameterSet/interface/ParameterDescriptionNode.h:246:18:
note: hidden overloaded virtual function
'edm::ParameterDescriptionNode::exists_' declared here: different number
of parameters (1 vs 2)
    virtual bool exists_(ParameterSet const& pset) const = 0;
```
