### PR TITLE
Always forward declare BranchKey as class

### DIFF
--- a/FWCore/Framework/interface/DelayedReader.h
+++ b/FWCore/Framework/interface/DelayedReader.h
@@ -13,7 +13,7 @@ uses input sources to retrieve EDProducts from external storage.
 #include <memory>
 
 namespace edm {
-  struct BranchKey;
+  class BranchKey;
   class EDProductGetter;
   class WrapperInterfaceBase;
   class SharedResourcesAcquirer;


### PR DESCRIPTION
The clang compiler complained that BranchKey was forward declared as a struct but in its actual declaration it was a class.
