### PR TITLE
If a type is a struct forward declare it as a struct

### DIFF
--- a/FWCore/Framework/interface/Frameworkfwd.h
+++ b/FWCore/Framework/interface/Frameworkfwd.h
@@ -26,7 +26,7 @@ namespace edm {
   class LuminosityBlock;
   class LuminosityBlockPrincipal;
   class OutputModule;
-  class OutputModuleDescription;
+  struct OutputModuleDescription;
   class ParameterSet;
   class Principal;
   class PrincipalCache;

--- a/FWCore/Framework/interface/Schedule.h
+++ b/FWCore/Framework/interface/Schedule.h
@@ -102,7 +102,7 @@ namespace edm {
   class PreallocationConfiguration;
   class StreamSchedule;
   class GlobalSchedule;
-  class TriggerTimingReport;
+  struct TriggerTimingReport;
   class ModuleRegistry;
   class TriggerResultInserter;
   

--- a/FWCore/Framework/interface/ScheduleItems.h
+++ b/FWCore/Framework/interface/ScheduleItems.h
@@ -13,7 +13,7 @@ namespace edm {
   class ExceptionToActionTable;
   class ActivityRegistry;
   class BranchIDListHelper;
-  class CommonParams;
+  struct CommonParams;
   class SubProcess;
   class ParameterSet;
   class ProcessConfiguration;

--- a/FWCore/Framework/src/ModuleRegistry.h
+++ b/FWCore/Framework/src/ModuleRegistry.h
@@ -29,7 +29,7 @@
 // forward declarations
 namespace edm {
   class ParameterSet;
-  class MakeModuleParams;
+  struct MakeModuleParams;
   class ModuleDescription;
   class PreallocationConfiguration;
   namespace maker {

--- a/FWCore/Framework/src/StreamSchedule.h
+++ b/FWCore/Framework/src/StreamSchedule.h
@@ -103,7 +103,7 @@ namespace edm {
   class RunStopwatch;
   class UnscheduledCallProducer;
   class WorkerInPath;
-  class TriggerTimingReport;
+  struct TriggerTimingReport;
   class ModuleRegistry;
   class TriggerResultInserter;
   class PreallocationConfiguration;


### PR DESCRIPTION
clang gives a warning if a forward declaration is ‘class’ but the actual type is ‘struct’.
