### PR TITLE
Make test items public to avoid clang compilation errors

### DIFF
--- a/FWCore/Framework/test/global_module_t.cppunit.cc
+++ b/FWCore/Framework/test/global_module_t.cppunit.cc
@@ -65,8 +65,6 @@ public:
   void endRunSummaryProdTest();
   void endLumiSummaryProdTest();
 
-private:
-
   enum class Trans {
     kBeginJob,
     kBeginStream,
@@ -83,9 +81,12 @@ private:
     kEndStream,
     kEndJob
   };
+  typedef std::vector<Trans> Expectations;
+
+private:
+
   
   std::map<Trans,std::function<void(edm::Worker*)>> m_transToFunc;
-  typedef std::vector<Trans> Expectations;
   
   edm::ProcessConfiguration m_procConfig;
   boost::shared_ptr<edm::ProductRegistry> m_prodReg;


### PR DESCRIPTION
The enum class and typedef need to be declared public in the test class to avoid compilation problems with clang. Given this is local to the test there is no concern.
