### PR TITLE
Fix append bug in DQMEventMessage

### DIFF
--- a/IOPool/Streamer/src/DQMEventMessage.cc
+++ b/IOPool/Streamer/src/DQMEventMessage.cc
@@ -69,7 +69,10 @@ DQMEventMsgView::DQMEventMsgView(void* buf):
       meCountList_.push_back(meCount);
 
       // subfolder name
-      std::string subFolderName = "Subfolder " + idx;
+      std::stringstream s;
+      s.str("Subfolder ");
+      s<<idx;
+      std::string subFolderName = s.str();
       uint32 nameLen = convert32(bufPtr);
       bufPtr += sizeof(uint32);
       if (nameLen <= MAX_STRING_SIZE) // prevent something totally crazy // nameLen >= 0, since nameLen is unsigned.


### PR DESCRIPTION
The previous code obviously thought ‘std::string subFolderName = “Subfolder “ + idx;’ was appending ‘idx’ to the string. That is not what was happening. Instead, pointer math was happening. So if ‘idx’ was 1 the resulting string was “ubfolder “. If ‘idx’ was 2 we got ‘bfolder ‘. If ‘idx’ was larger than the string length we would get random garbage.
This problem was found by clang.
