### PR TITLE
Removed unused code from IOPool/Streamer

### DIFF
--- a/IOPool/Streamer/src/StreamSerializer.cc
+++ b/IOPool/Streamer/src/StreamSerializer.cc
@@ -46,8 +46,6 @@ namespace edm {
     FDEBUG(6) << "StreamSerializer::serializeRegistry" << std::endl;
     SendJobHeader sd;
 
-    SelectedProducts::const_iterator i(selections_->begin()), e(selections_->end());
-
     FDEBUG(9) << "Product List: " << std::endl;
 
 
@@ -135,7 +133,6 @@ namespace edm {
     selectionIDs.push_back(selectorConfig);
     SendEvent se(eventPrincipal.aux(), eventPrincipal.processHistory(), selectionIDs, eventPrincipal.branchListIndexes());
 
-    SelectedProducts::const_iterator i(selections_->begin()),ie(selections_->end());
     // Loop over EDProducts, fill the provenance, and write.
 
     for(SelectedProducts::const_iterator i = selections_->begin(), iEnd = selections_->end(); i != iEnd; ++i) {

--- a/IOPool/Streamer/src/StreamerOutputModuleBase.cc
+++ b/IOPool/Streamer/src/StreamerOutputModuleBase.cc
@@ -23,12 +23,12 @@
 namespace {
   //A utility function that packs bits from source into bytes, with
   // packInOneByte as the numeber of bytes that are packed from source to dest.
-  inline void printBits(unsigned char c) {
+/*  inline void printBits(unsigned char c) {
     for (int i = 7; i >= 0; --i) {
       int bit = ((c >> i) & 1);
       std::cout << " " << bit;
     }
-  }
+  } */
 
   void packIntoString(std::vector<unsigned char> const& source,
                       std::vector<unsigned char>& package) {


### PR DESCRIPTION
The clang compiler complains about unused variables and functions.
