### PR TITLE
Made static const for BeamSpotTransientTrackingRecHit

### DIFF
--- a/Alignment/ReferenceTrajectories/interface/BeamSpotTransientTrackingRecHit.h
+++ b/Alignment/ReferenceTrajectories/interface/BeamSpotTransientTrackingRecHit.h
@@ -61,7 +61,6 @@ class BeamSpotTransientTrackingRecHit GCC11_FINAL : public TValidTrackingRecHit 
   }
 
   virtual AlgebraicMatrix projectionMatrix() const {
-    if (!isInitialized) initialize();
     return theProjectionMatrix;
   }
 
@@ -83,9 +82,7 @@ class BeamSpotTransientTrackingRecHit GCC11_FINAL : public TValidTrackingRecHit 
      return new BeamSpotTransientTrackingRecHit(*this);
    }
    
-   static bool isInitialized;
-   static AlgebraicMatrix theProjectionMatrix;
-   void initialize() const;
+   static const AlgebraicMatrix theProjectionMatrix;
 };
 
 #endif

--- a/Alignment/ReferenceTrajectories/src/BeamSpotTransientTrackingRecHit.cc
+++ b/Alignment/ReferenceTrajectories/src/BeamSpotTransientTrackingRecHit.cc
@@ -23,13 +23,12 @@ AlgebraicSymMatrix BeamSpotTransientTrackingRecHit::parametersError() const
   return m;
 }
 
-void BeamSpotTransientTrackingRecHit::initialize() const
+
+static AlgebraicMatrix initialize()
 {
-  theProjectionMatrix = AlgebraicMatrix( 1, 5, 0);
-  theProjectionMatrix[0][3] = 1;
-  
-  isInitialized = true;
+  AlgebraicMatrix ret( 1, 5, 0);
+  ret[0][3] = 1;
+  return ret;
 }
 
-bool BeamSpotTransientTrackingRecHit::isInitialized(false);
-AlgebraicMatrix BeamSpotTransientTrackingRecHit::theProjectionMatrix;
+const AlgebraicMatrix BeamSpotTransientTrackingRecHit::theProjectionMatrix=initialize();


### PR DESCRIPTION
By moving the initialization to library load time, the static used
by BeamSpotTransientTrackingRecHit can be made const. This avoids
thread-safety issues.
