### PR TITLE
Made Statics const in ConversionTrackEcalImpactPoint

### DIFF
--- a/RecoEgamma/EgammaPhotonAlgos/interface/ConversionTrackEcalImpactPoint.h
+++ b/RecoEgamma/EgammaPhotonAlgos/interface/ConversionTrackEcalImpactPoint.h
@@ -65,29 +65,13 @@ private:
   PropagationDirection       dir_;
   std::vector<reco::CaloClusterPtr> matchingBC_;
 
+  static const ReferenceCountingPointer<BoundCylinder>  theBarrel_;
+  static const ReferenceCountingPointer<BoundDisk>      theNegativeEtaEndcap_;
+  static const ReferenceCountingPointer<BoundDisk>      thePositiveEtaEndcap_;
 
-
-/** Hard-wired numbers defining the surfaces on which the crystal front faces lie. */
-  static float barrelRadius() {return 129.f;} //p81, p50, ECAL TDR
-  static float barrelHalfLength() {return 270.9f;} //p81, p50, ECAL TDR
-  static float endcapRadius() {return 171.1f;} // fig 3.26, p81, ECAL TDR
-  static float endcapZ() {return 320.5f;} // fig 3.26, p81, ECAL TDR
-
-  static void initialize();
-  static void check() {if (!theInit_) initialize();}
-
-
-
-
-  static ReferenceCountingPointer<BoundCylinder>  theBarrel_;
-  static ReferenceCountingPointer<BoundDisk>      theNegativeEtaEndcap_;
-  static ReferenceCountingPointer<BoundDisk>      thePositiveEtaEndcap_;
-
-  static const BoundCylinder& barrel()        { check(); return *theBarrel_;}
-  static const BoundDisk& negativeEtaEndcap() { check(); return *theNegativeEtaEndcap_;}
-  static const BoundDisk& positiveEtaEndcap() { check(); return *thePositiveEtaEndcap_;}
-  static bool theInit_;
-
+  static const BoundCylinder& barrel()        { return *theBarrel_;}
+  static const BoundDisk& negativeEtaEndcap() { return *theNegativeEtaEndcap_;}
+  static const BoundDisk& positiveEtaEndcap() { return *thePositiveEtaEndcap_;}
 
 };
 

--- a/RecoEgamma/EgammaPhotonAlgos/src/ConversionTrackEcalImpactPoint.cc
+++ b/RecoEgamma/EgammaPhotonAlgos/src/ConversionTrackEcalImpactPoint.cc
@@ -10,10 +10,44 @@
 #include <vector>
 #include <map>
 
-ReferenceCountingPointer<BoundCylinder>  ConversionTrackEcalImpactPoint::theBarrel_ = 0;
-ReferenceCountingPointer<BoundDisk>      ConversionTrackEcalImpactPoint::theNegativeEtaEndcap_ = 0;
-ReferenceCountingPointer<BoundDisk>      ConversionTrackEcalImpactPoint::thePositiveEtaEndcap_ = 0;
-bool                                     ConversionTrackEcalImpactPoint::theInit_ = false;
+static const float epsilon = 0.001;
+
+/** Hard-wired numbers defining the surfaces on which the crystal front faces lie. */
+static float barrelRadius() {return 129.f;} //p81, p50, ECAL TDR
+static float barrelHalfLength() {return 270.9f;} //p81, p50, ECAL TDR
+static float endcapRadius() {return 171.1f;} // fig 3.26, p81, ECAL TDR
+static float endcapZ() {return 320.5f;} // fig 3.26, p81, ECAL TDR
+
+
+
+static BoundCylinder* initBarrel() {
+  Surface::RotationType rot; // unit rotation matrix
+
+
+  return new Cylinder(barrelRadius(), Surface::PositionType(0,0,0), rot, 
+				 new SimpleCylinderBounds( barrelRadius()-epsilon, 
+				       		       barrelRadius()+epsilon, 
+						       -barrelHalfLength(), 
+						       barrelHalfLength()));
+}
+
+static BoundDisk* initNegative() {
+  Surface::RotationType rot; // unit rotation matrix
+  return new BoundDisk( Surface::PositionType( 0, 0, -endcapZ()), rot, 
+		   new SimpleDiskBounds( 0, endcapRadius(), -epsilon, epsilon));
+}
+
+static BoundDisk* initPositive() {
+  Surface::RotationType rot; // unit rotation matrix
+
+  return new BoundDisk( Surface::PositionType( 0, 0, endcapZ()), rot, 
+		   new SimpleDiskBounds( 0, endcapRadius(), -epsilon, epsilon));
+  
+}
+
+const ReferenceCountingPointer<BoundCylinder>  ConversionTrackEcalImpactPoint::theBarrel_ = initBarrel();
+const ReferenceCountingPointer<BoundDisk>      ConversionTrackEcalImpactPoint::theNegativeEtaEndcap_ = initNegative();
+const ReferenceCountingPointer<BoundDisk>      ConversionTrackEcalImpactPoint::thePositiveEtaEndcap_ = initPositive();
 
 
 ConversionTrackEcalImpactPoint::ConversionTrackEcalImpactPoint(const MagneticField* field ): 
@@ -109,26 +143,3 @@ std::vector<math::XYZPointF> ConversionTrackEcalImpactPoint::find( const std::ve
 
 
 
-void ConversionTrackEcalImpactPoint::initialize() {
-
-  const float epsilon = 0.001;
-  Surface::RotationType rot; // unit rotation matrix
-
-
-  theBarrel_ = new Cylinder(barrelRadius(), Surface::PositionType(0,0,0), rot, 
-				 new SimpleCylinderBounds( barrelRadius()-epsilon, 
-				       		       barrelRadius()+epsilon, 
-						       -barrelHalfLength(), 
-						       barrelHalfLength()));
-  theNegativeEtaEndcap_ = 
-    new BoundDisk( Surface::PositionType( 0, 0, -endcapZ()), rot, 
-		   new SimpleDiskBounds( 0, endcapRadius(), -epsilon, epsilon));
-  
-  thePositiveEtaEndcap_ = 
-    new BoundDisk( Surface::PositionType( 0, 0, endcapZ()), rot, 
-		   new SimpleDiskBounds( 0, endcapRadius(), -epsilon, epsilon));
-  
-  theInit_ = true;
-
-
-}


### PR DESCRIPTION
By moving initialization of statics to library load time, the statics
could be made const. This avoids thread-safety issues.
