### PR TITLE
Split the GEM customs for the 2019 and 2023 scenario

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
@@ -97,7 +97,9 @@ CSCMotherboard::CSCMotherboard(unsigned endcap, unsigned station,
     alctParams = conf.getParameter<edm::ParameterSet>("alctSLHC");
     clctParams = conf.getParameter<edm::ParameterSet>("clctSLHC");
     tmbParams  =  conf.getParameter<edm::ParameterSet>("tmbSLHC");
-    if (theStation==2){
+    const edm::ParameterSet me21mbParams(tmbParams.getUntrackedParameter<edm::ParameterSet>("me21ILT",edm::ParameterSet()));
+    const bool runME21ILT(me21mbParams.getUntrackedParameter<bool>("runME21ILT",false));
+    if (theStation==2 and runME21ILT){
       alctParams = conf.getParameter<edm::ParameterSet>("alctSLHCME21");
       clctParams = conf.getParameter<edm::ParameterSet>("clctSLHCME21");
     }

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
@@ -97,6 +97,10 @@ CSCMotherboard::CSCMotherboard(unsigned endcap, unsigned station,
     alctParams = conf.getParameter<edm::ParameterSet>("alctSLHC");
     clctParams = conf.getParameter<edm::ParameterSet>("clctSLHC");
     tmbParams  =  conf.getParameter<edm::ParameterSet>("tmbSLHC");
+    if (theStation==2){
+      alctParams = conf.getParameter<edm::ParameterSet>("alctSLHCME21");
+      clctParams = conf.getParameter<edm::ParameterSet>("clctSLHCME21");
+    }
   }
 
   mpc_block_me1a    = tmbParams.getParameter<unsigned int>("mpcBlockMe1a");
@@ -118,7 +122,7 @@ CSCMotherboard::CSCMotherboard(unsigned endcap, unsigned station,
   readout_earliest_2 = tmbParams.getUntrackedParameter<bool>("tmbReadoutEarliest2",false);
 
   infoV = tmbParams.getUntrackedParameter<int>("verbosity", 0);
-
+  
   alct = new CSCAnodeLCTProcessor(endcap, station, sector, subsector, chamber, alctParams, commonParams);
   clct = new CSCCathodeLCTProcessor(endcap, station, sector, subsector, chamber, clctParams, commonParams, tmbParams);
 

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11.cc
@@ -256,7 +256,7 @@ CSCMotherboardME11::CSCMotherboardME11(unsigned endcap, unsigned station,
   lct_central_bx = me11tmbParams.getUntrackedParameter<int>("lctCentralBX", 6);
 
   // debug gem matching
-  debug_gem_matching = me11tmbParams.getUntrackedParameter<bool>("debugGemMatching", false);
+  debug_gem_matching = me11tmbParams.getUntrackedParameter<bool>("debugMatching", false);
   debug_luts = me11tmbParams.getUntrackedParameter<bool>("debugLUTs", false);
 
   //  deltas used to construct GEM coincidence pads

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME21.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME21.cc
@@ -356,7 +356,7 @@ CSCMotherboardME21::run(const CSCWireDigiCollection* wiredc,
           // clct quality
           const int quality(clct->bestCLCT[bx_clct].getQuality());
           // low quality ALCT
-          const bool lowQualityALCT(alct->bestALCT[bx_alct].getQuality() == 0);
+          const bool lowQualityALCT(alct->bestALCT[bx_alct].getQuality() == 4);
           // low quality ALCT or CLCT
           const bool lowQuality(quality<4 or lowQualityALCT);
           if (debug_gem_matching) std::cout << "++Valid ME21 CLCT: " << clct->bestCLCT[bx_clct] << std::endl;

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME21.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME21.cc
@@ -67,7 +67,7 @@ CSCMotherboardME21::CSCMotherboardME21(unsigned endcap, unsigned station,
   
   const edm::ParameterSet alctParams(conf.getParameter<edm::ParameterSet>("alctSLHCME21"));
   const edm::ParameterSet clctParams(conf.getParameter<edm::ParameterSet>("clctSLHCME21"));
-  const edm::ParameterSet tmbParams(conf.getParameter<edm::ParameterSet>("tmbSLHCME21"));
+  const edm::ParameterSet tmbParams(conf.getParameter<edm::ParameterSet>("tmbSLHC"));
   const edm::ParameterSet me21tmbParams(tmbParams.getUntrackedParameter<edm::ParameterSet>("me21ILT"));
 
   // central bx for LCT is 6 for simulation

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME21.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME21.cc
@@ -65,9 +65,9 @@ CSCMotherboardME21::CSCMotherboardME21(unsigned endcap, unsigned station,
   if (!isSLHC) edm::LogError("L1CSCTPEmulatorConfigError")
     << "+++ Upgrade CSCMotherboardME21 constructed while isSLHC is not set! +++\n";
   
-  const edm::ParameterSet alctParams(conf.getParameter<edm::ParameterSet>("alctSLHC"));
-  const edm::ParameterSet clctParams(conf.getParameter<edm::ParameterSet>("clctSLHC"));
-  const edm::ParameterSet tmbParams(conf.getParameter<edm::ParameterSet>("tmbSLHC"));
+  const edm::ParameterSet alctParams(conf.getParameter<edm::ParameterSet>("alctSLHCME21"));
+  const edm::ParameterSet clctParams(conf.getParameter<edm::ParameterSet>("clctSLHCME21"));
+  const edm::ParameterSet tmbParams(conf.getParameter<edm::ParameterSet>("tmbSLHCME21"));
   const edm::ParameterSet me21tmbParams(tmbParams.getUntrackedParameter<edm::ParameterSet>("me21ILT"));
 
   // central bx for LCT is 6 for simulation

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME21.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME21.cc
@@ -356,7 +356,7 @@ CSCMotherboardME21::run(const CSCWireDigiCollection* wiredc,
           // clct quality
           const int quality(clct->bestCLCT[bx_clct].getQuality());
           // low quality ALCT
-          const bool lowQualityALCT(alct->bestALCT[bx_alct].getQuality() == 4);
+          const bool lowQualityALCT(alct->bestALCT[bx_alct].getQuality() == 0);
           // low quality ALCT or CLCT
           const bool lowQuality(quality<4 or lowQualityALCT);
           if (debug_gem_matching) std::cout << "++Valid ME21 CLCT: " << clct->bestCLCT[bx_clct] << std::endl;
@@ -889,8 +889,8 @@ unsigned int CSCMotherboardME21::findQualityGEM(const CSCALCTDigi& aLCT, const C
 	int n_gem = 0;  
 	if (hasPad) n_gem = 1;
 	if (hasCoPad) n_gem = 2;
-	const bool a4((aLCT.getQuality() >= 1 and aLCT.getQuality() != 4) or
-		      (aLCT.getQuality() == 4 and n_gem >=1));
+	const bool a4((aLCT.getQuality() >= 1) or
+		      (aLCT.getQuality() == 0 and n_gem >=1));
 	const bool c4((cLCT.getQuality() >= 4) or (cLCT.getQuality() >= 3 and n_gem>=1));
         //              quality = 4; "reserved for low-quality muons in future"
         if      (!a4 && !c4) quality = 5; // marginal anode and cathode

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME21.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME21.cc
@@ -889,8 +889,7 @@ unsigned int CSCMotherboardME21::findQualityGEM(const CSCALCTDigi& aLCT, const C
 	int n_gem = 0;  
 	if (hasPad) n_gem = 1;
 	if (hasCoPad) n_gem = 2;
-	const bool a4((aLCT.getQuality() >= 1) or
-		      (aLCT.getQuality() == 0 and n_gem >=1));
+	const bool a4((aLCT.getQuality() >= 1) or (aLCT.getQuality() >= 0 and n_gem >=1));
 	const bool c4((cLCT.getQuality() >= 4) or (cLCT.getQuality() >= 3 and n_gem>=1));
         //              quality = 4; "reserved for low-quality muons in future"
         if      (!a4 && !c4) quality = 5; // marginal anode and cathode

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME21.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME21.cc
@@ -116,7 +116,7 @@ CSCMotherboardME21::CSCMotherboardME21(unsigned endcap, unsigned station,
   gem_clear_nomatch_lcts = me21tmbParams.getUntrackedParameter<bool>("gemClearNomatchLCTs", false);
 
   // debug gem matching
-  debug_gem_matching = me21tmbParams.getUntrackedParameter<bool>("debugGemMatching", false);
+  debug_gem_matching = me21tmbParams.getUntrackedParameter<bool>("debugMatching", false);
   debug_luts = me21tmbParams.getUntrackedParameter<bool>("debugLUTs", false);
 
   //  deltas used to construct GEM coincidence pads

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME21.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME21.cc
@@ -65,8 +65,6 @@ CSCMotherboardME21::CSCMotherboardME21(unsigned endcap, unsigned station,
   if (!isSLHC) edm::LogError("L1CSCTPEmulatorConfigError")
     << "+++ Upgrade CSCMotherboardME21 constructed while isSLHC is not set! +++\n";
   
-  const edm::ParameterSet alctParams(conf.getParameter<edm::ParameterSet>("alctSLHCME21"));
-  const edm::ParameterSet clctParams(conf.getParameter<edm::ParameterSet>("clctSLHCME21"));
   const edm::ParameterSet tmbParams(conf.getParameter<edm::ParameterSet>("tmbSLHC"));
   const edm::ParameterSet me21tmbParams(tmbParams.getUntrackedParameter<edm::ParameterSet>("me21ILT"));
 
@@ -358,7 +356,7 @@ CSCMotherboardME21::run(const CSCWireDigiCollection* wiredc,
           // clct quality
           const int quality(clct->bestCLCT[bx_clct].getQuality());
           // low quality ALCT
-          const bool lowQualityALCT(alct->bestALCT[bx_alct].getQuality() == 4);
+          const bool lowQualityALCT(alct->bestALCT[bx_alct].getQuality() == 0);
           // low quality ALCT or CLCT
           const bool lowQuality(quality<4 or lowQualityALCT);
           if (debug_gem_matching) std::cout << "++Valid ME21 CLCT: " << clct->bestCLCT[bx_clct] << std::endl;

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME3141.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME3141.cc
@@ -76,10 +76,8 @@ CSCMotherboardME3141::CSCMotherboardME3141(unsigned endcap, unsigned station,
   if (!isSLHC) edm::LogError("L1CSCTPEmulatorConfigError")
     << "+++ Upgrade CSCMotherboardME3141 constructed while isSLHC is not set! +++\n";
   
-  edm::ParameterSet alctParams = conf.getParameter<edm::ParameterSet>("alctSLHC");
-  edm::ParameterSet clctParams = conf.getParameter<edm::ParameterSet>("clctSLHC");
-  edm::ParameterSet tmbParams = conf.getParameter<edm::ParameterSet>("tmbSLHC");
-  edm::ParameterSet me3141tmbParams = tmbParams.getUntrackedParameter<edm::ParameterSet>("me3141ILT");
+  const edm::ParameterSet tmbParams(conf.getParameter<edm::ParameterSet>("tmbSLHC"));
+  const edm::ParameterSet me3141tmbParams(tmbParams.getUntrackedParameter<edm::ParameterSet>("me3141ILT"));
 
   // central bx for LCT is 6 for simulation
   lct_central_bx = tmbParams.getUntrackedParameter<int>("lctCentralBX", 6);

--- a/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
@@ -20,7 +20,8 @@ from SLHCUpgradeSimulations.Configuration.combinedCustoms_TTI import l1EventCont
 from SLHCUpgradeSimulations.Configuration.customise_mixing import customise_NoCrossing
 from SLHCUpgradeSimulations.Configuration.phase1TkCustoms import customise as customisePhase1Tk
 from SLHCUpgradeSimulations.Configuration.HCalCustoms import customise_HcalPhase1, customise_HcalPhase0, customise_HcalPhase2
-from SLHCUpgradeSimulations.Configuration.gemCustoms import customise as customise_gem
+from SLHCUpgradeSimulations.Configuration.gemCustoms import customise2019 as customise_gem2019
+from SLHCUpgradeSimulations.Configuration.gemCustoms import customise2023 as customise_gem2023
 from SLHCUpgradeSimulations.Configuration.me0Customs import customise as customise_me0
 from SLHCUpgradeSimulations.Configuration.rpcCustoms import customise as customise_rpc
 from SLHCUpgradeSimulations.Configuration.fastsimCustoms import customiseDefault as fastCustomiseDefault
@@ -89,7 +90,7 @@ def cust_2019(process):
 
 def cust_2019WithGem(process):
     process=cust_2019(process)
-    process=customise_gem(process)
+    process=customise_gem2019(process)
     return process
 
 def cust_2023(process):
@@ -97,7 +98,7 @@ def cust_2023(process):
     process=customiseBE5D(process)
     process=customise_HcalPhase2(process)
     process=customise_ev_BE5D(process)
-    process=customise_gem(process)
+    process=customise_gem2023(process)
     process=customise_rpc(process)
     return process
 
@@ -114,7 +115,7 @@ def cust_2023Pixel(process):
     process=customiseBE5DPixel10D(process)
     process=customise_HcalPhase2(process)
     process=customise_ev_BE5DPixel10D(process)
-    process=customise_gem(process)
+    process=customise_gem2023(process)
     return process
 
 def cust_2023Muon(process):
@@ -122,7 +123,7 @@ def cust_2023Muon(process):
     process=customiseBE5DPixel10D(process)
     process=customise_HcalPhase2(process)
     process=customise_ev_BE5DPixel10D(process)
-    process=customise_gem(process)
+    process=customise_gem2023(process)
     process=customise_rpc(process)
     process=customise_me0(process)
     return process

--- a/SLHCUpgradeSimulations/Configuration/python/gemCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/gemCustoms.py
@@ -1,10 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
-def customise(process):
+def customise2019(process):
     if hasattr(process,'digitisation_step'):
         process=customise_Digi(process)
     if hasattr(process,'L1simulation_step'):
-        process=customise_L1Emulator(process,'pt0')
+        process=customise_L1Emulator2019(process,'pt0')
     if hasattr(process,'DigiToRaw'):
         process=customise_DigiToRaw(process)
     if hasattr(process,'RawToDigi'):
@@ -17,7 +17,12 @@ def customise(process):
         process=customise_harvesting(process)
     if hasattr(process,'validation_step'):
         process=customise_Validation(process)
+    return process
 
+def customise2023(process):
+    process = customise2019(process)
+    if hasattr(process,'L1simulation_step'):
+        process=customise_L1Emulator2023(process,'pt0')
     return process
 
 def customise_Digi(process):
@@ -35,8 +40,11 @@ def customise_Digi(process):
     process=outputCustoms(process)
     return process
 
-def customise_L1Emulator(process, ptdphi):
+def customise_L1Emulator2019(process, ptdphi):
     process.simCscTriggerPrimitiveDigis.gemPadProducer =  cms.untracked.InputTag("simMuonGEMCSCPadDigis","")
+    process.simCscTriggerPrimitiveDigis.clctSLHC.clctNplanesHitPattern = 3
+    process.simCscTriggerPrimitiveDigis.clctSLHC.clctPidThreshPretrig = 2
+    process.simCscTriggerPrimitiveDigis.clctParam07.clctPidThreshPretrig = 2
     ## GE1/1-ME1/1
     dphi_lct_pad98 = {
         'pt0'  : { 'odd' :  2.00000000 , 'even' :  2.00000000 },
@@ -82,7 +90,7 @@ def customise_L1Emulator(process, ptdphi):
         buildLCTfromALCTandGEM_ME1a = cms.untracked.bool(True),
         buildLCTfromALCTandGEM_ME1b = cms.untracked.bool(True),
         doLCTGhostBustingWithGEMs = cms.untracked.bool(False),
-        correctLCTtimingWithGEM = cms.untracked.bool(True),
+        correctLCTtimingWithGEM = cms.untracked.bool(False),
         promoteALCTGEMpattern = cms.untracked.bool(True),
         promoteALCTGEMquality = cms.untracked.bool(True),
         
@@ -98,14 +106,29 @@ def customise_L1Emulator(process, ptdphi):
         tmbCrossBxAlgorithm = cms.untracked.uint32(2),
         firstTwoLCTsInChamber = cms.untracked.bool(True),
     )
-    if tmb.me11ILT.runME11ILT:
-        process.simCscTriggerPrimitiveDigis.clctSLHC.clctNplanesHitPattern = 3
-        process.simCscTriggerPrimitiveDigis.clctSLHC.clctPidThreshPretrig = 2
-        process.simCscTriggerPrimitiveDigis.clctParam07.clctPidThreshPretrig = 2
-    if ptdphi != 'pt0' :
-        tmb.me11ILT.gemClearNomatchLCTs = True 
-        
+    return process
+
+def customise_L1Emulator2023(process, ptdphi):
+    ## ME21 has its own SLHC processors
+    process.simCscTriggerPrimitiveDigis.alctSLHCME21 = process.simCscTriggerPrimitiveDigis.alctSLHC.clone()
+    process.simCscTriggerPrimitiveDigis.clctSLHCME21 = process.simCscTriggerPrimitiveDigis.clctSLHC.clone()
+    process.simCscTriggerPrimitiveDigis.alctSLHCME21.alctNplanesHitPattern = 3
+    process.simCscTriggerPrimitiveDigis.alctSLHCME21.runME21ILT = cms.untracked.bool(True)
+    process.simCscTriggerPrimitiveDigis.clctSLHCME21.clctNplanesHitPattern = 3
+    process.simCscTriggerPrimitiveDigis.clctSLHCME21.clctPidThreshPretrig = 2
+    process.simCscTriggerPrimitiveDigis.clctParam07.clctPidThreshPretrig = 2
+    tmb = process.simCscTriggerPrimitiveDigis.tmbSLHC
     ## GE2/1-ME2/1
+    dphi_lct_pad98 = {
+        'pt0'  : { 'odd' :  2.00000000 , 'even' :  2.00000000 },
+        'pt05' : { 'odd' :  0.02203510 , 'even' :  0.00930056 },
+        'pt06' : { 'odd' :  0.01825790 , 'even' :  0.00790009 },
+        'pt10' : { 'odd' :  0.01066000 , 'even' :  0.00483286 },
+        'pt15' : { 'odd' :  0.00722795 , 'even' :  0.00363230 },
+        'pt20' : { 'odd' :  0.00562598 , 'even' :  0.00304879 },
+        'pt30' : { 'odd' :  0.00416544 , 'even' :  0.00253782 },
+        'pt40' : { 'odd' :  0.00342827 , 'even' :  0.00230833 }
+    }
     tmb.me21ILT = cms.untracked.PSet(
         ## run the upgrade algorithm
         runME21ILT = cms.untracked.bool(True),
@@ -137,7 +160,7 @@ def customise_L1Emulator(process, ptdphi):
         dropLowQualityCLCTsNoGEMs = cms.untracked.bool(True),
         buildLCTfromALCTandGEM = cms.untracked.bool(True),
         doLCTGhostBustingWithGEMs = cms.untracked.bool(False),
-        correctLCTtimingWithGEM = cms.untracked.bool(True),
+        correctLCTtimingWithGEM = cms.untracked.bool(False),
         promoteALCTGEMpattern = cms.untracked.bool(True),
         promoteALCTGEMquality = cms.untracked.bool(True),
 
@@ -147,19 +170,12 @@ def customise_L1Emulator(process, ptdphi):
         gemMatchDeltaBX = cms.untracked.int32(1),
         gemMatchDeltaPhiOdd = cms.untracked.double(dphi_lct_pad98[ptdphi]['odd']),
         gemMatchDeltaPhiEven = cms.untracked.double(dphi_lct_pad98[ptdphi]['even']),
-        gemClearNomatchLCTs = cms.untracked.bool(ptdphi == 'pt0' and False),
+        gemClearNomatchLCTs = cms.untracked.bool(False),
 
         ## cross BX algorithm
         tmbCrossBxAlgorithm = cms.untracked.uint32(2),
         firstTwoLCTsInChamber = cms.untracked.bool(True),
     )
-    
-    if tmb.me21ILT.runME21ILT:
-        process.simCscTriggerPrimitiveDigis.clctSLHC.clctNplanesHitPattern = 3
-        process.simCscTriggerPrimitiveDigis.clctSLHC.clctPidThreshPretrig = 2
-        process.simCscTriggerPrimitiveDigis.clctParam07.clctPidThreshPretrig = 2
-        process.simCscTriggerPrimitiveDigis.alctSLHC.runME21ILT = cms.untracked.bool(True)
-    
     return process
 
 def customise_DigiToRaw(process):
@@ -191,7 +207,6 @@ def customise_Validation(process):
     process.muonTrackValidator.useGEMs = cms.bool(True)
     return process
 
-
 def customise_harvesting(process):
     process.load('Validation.Configuration.gemPostValidation_cff')
     process.genHarvesting += process.gemPostValidation
@@ -205,5 +220,6 @@ def outputCustoms(process):
             getattr(process,b).outputCommands.append('keep *_simMuonGEMDigis_*_*')
             getattr(process,b).outputCommands.append('keep *_simMuonGEMCSCPadDigis_*_*')
             getattr(process,b).outputCommands.append('keep *_gemRecHits_*_*')
-
     return process
+
+    

--- a/SLHCUpgradeSimulations/Configuration/python/gemCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/gemCustoms.py
@@ -111,6 +111,7 @@ def customise_L1Emulator2019(process, ptdphi):
 
 ## TODO at migration to CMSSW 7X: make all params tracked!    
 def customise_L1Emulator2023(process, ptdphi):
+    process.simCscTriggerPrimitiveDigis.gemPadProducer =  cms.untracked.InputTag("simMuonGEMCSCPadDigis","")
     ## ME21 has its own SLHC processors
     process.simCscTriggerPrimitiveDigis.alctSLHCME21 = process.simCscTriggerPrimitiveDigis.alctSLHC.clone()
     process.simCscTriggerPrimitiveDigis.clctSLHCME21 = process.simCscTriggerPrimitiveDigis.clctSLHC.clone()

--- a/SLHCUpgradeSimulations/Configuration/python/gemCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/gemCustoms.py
@@ -40,6 +40,7 @@ def customise_Digi(process):
     process=outputCustoms(process)
     return process
 
+## TODO at migration to CMSSW 7X: make all params tracked!    
 def customise_L1Emulator2019(process, ptdphi):
     process.simCscTriggerPrimitiveDigis.gemPadProducer =  cms.untracked.InputTag("simMuonGEMCSCPadDigis","")
     process.simCscTriggerPrimitiveDigis.clctSLHC.clctNplanesHitPattern = 3
@@ -108,6 +109,7 @@ def customise_L1Emulator2019(process, ptdphi):
     )
     return process
 
+## TODO at migration to CMSSW 7X: make all params tracked!    
 def customise_L1Emulator2023(process, ptdphi):
     ## ME21 has its own SLHC processors
     process.simCscTriggerPrimitiveDigis.alctSLHCME21 = process.simCscTriggerPrimitiveDigis.alctSLHC.clone()

--- a/SimMuon/GEMDigitizer/test/runGEMCSCPadDigiReader_cfg.py
+++ b/SimMuon/GEMDigitizer/test/runGEMCSCPadDigiReader_cfg.py
@@ -25,6 +25,6 @@ process.source = cms.Source("PoolSource",
     )
 )
 
-process.dumper = cms.EDAnalyzer("GEMDigiReader")
+process.dumper = cms.EDAnalyzer("GEMCSCPadDigiReader")
 
 process.p = cms.Path(process.dumper)


### PR DESCRIPTION
This ensures that the ME21 ILT is not run in the 2019 upgrade scenario. 
