### PR TITLE
Adding pre-selection to input jets for tau RECO

### DIFF
--- a/RecoTauTag/Configuration/python/HPSPFTaus_cff.py
+++ b/RecoTauTag/Configuration/python/HPSPFTaus_cff.py
@@ -22,6 +22,12 @@ from RecoTauTag.RecoTau.RecoTauDiscriminantCutMultiplexer_cfi import *
 # Load helper functions to change the source of the discriminants
 from RecoTauTag.RecoTau.TauDiscriminatorTools import *
 
+# Load PFjet input parameters
+from RecoTauTag.RecoTau.PFRecoTauPFJetInputs_cfi import PFRecoTauPFJetInputs
+
+# deltaBeta correction factor calculated for taus from ak5PFJets (Run I)
+ak5dBetaCorrection=0.0772/0.1687 
+
 # Select those taus that pass the HPS selections
 #  - pt > 15, mass cuts, tauCone cut
 from RecoTauTag.RecoTau.PFRecoTauDiscriminationByHPSSelection_cfi import hpsSelectionDiscriminator, decayMode_1Prong0Pi0, decayMode_1Prong1Pi0, decayMode_1Prong2Pi0, decayMode_3Prong0Pi0
@@ -153,7 +159,7 @@ hpsPFTauDiscriminationByVLooseCombinedIsolationDBSumPtCorr.qualityCuts.isolation
 hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr = hpsPFTauDiscriminationByLooseIsolationDBSumPtCorr.clone(
     ApplyDiscriminationByTrackerIsolation = True,
     ApplyDiscriminationByECALIsolation = True,
-    deltaBetaFactor = "%0.4f"%(0.0772/0.1687),
+    deltaBetaFactor = "%0.4f"%(ak5dBetaCorrection),
     applyOccupancyCut = False,
     applySumPtCut = True,
     maximumSumPtCut = 2.0,
@@ -182,7 +188,7 @@ hpsPFTauDiscriminationByRawGammaIsolationDBSumPtCorr = hpsPFTauDiscriminationByL
 hpsPFTauDiscriminationByMediumCombinedIsolationDBSumPtCorr = hpsPFTauDiscriminationByMediumIsolationDBSumPtCorr.clone(
     ApplyDiscriminationByTrackerIsolation = True,
     ApplyDiscriminationByECALIsolation = True,
-    deltaBetaFactor = "%0.4f"%(0.0772/0.1687),
+    deltaBetaFactor = "%0.4f"%(ak5dBetaCorrection),
     applyOccupancyCut = False,
     applySumPtCut = True,
     maximumSumPtCut = 1.0,
@@ -194,7 +200,7 @@ hpsPFTauDiscriminationByMediumCombinedIsolationDBSumPtCorr.qualityCuts.isolation
 hpsPFTauDiscriminationByTightCombinedIsolationDBSumPtCorr = hpsPFTauDiscriminationByTightIsolationDBSumPtCorr.clone(
     ApplyDiscriminationByTrackerIsolation = True,
     ApplyDiscriminationByECALIsolation = True,
-    deltaBetaFactor = "%0.4f"%(0.0772/0.1687),
+    deltaBetaFactor = "%0.4f"%(ak5dBetaCorrection),
     applyOccupancyCut = False,
     applySumPtCut = True,
     maximumSumPtCut = 0.8,
@@ -587,7 +593,7 @@ hpsPFTauMVA3IsolationChargedIsoPtSum = hpsPFTauDiscriminationByLooseCombinedIsol
     applyDeltaBetaCorrection = cms.bool(False),
     storeRawSumPt = cms.bool(True),
     storeRawPUsumPt = cms.bool(False),
-    customOuterCone = cms.double(0.5),
+    customOuterCone = PFRecoTauPFJetInputs.isolationConeSize,
     isoConeSizeForDeltaBeta = cms.double(0.8),
     verbosity = cms.int32(0)
 )

--- a/RecoTauTag/Configuration/python/RecoPFTauTag_cff.py
+++ b/RecoTauTag/Configuration/python/RecoPFTauTag_cff.py
@@ -1,5 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
+from RecoTauTag.RecoTau.PFRecoTauPFJetInputs_cfi import PFRecoTauPFJetInputs
+
 #-------------------------------------------------------------------------------
 #------------------ Jet Production and Preselection-----------------------------
 #-------------------------------------------------------------------------------
@@ -19,7 +21,7 @@ import FWCore.ParameterSet.Config as cms
 from RecoTauTag.RecoTau.RecoTauJetRegionProducer_cfi import \
       RecoTauJetRegionProducer
 recoTauAK5PFJets08Region=RecoTauJetRegionProducer.clone(
-    src = cms.InputTag("ak5PFJets")
+    src = PFRecoTauPFJetInputs.inputJetCollection
 )
 
 
@@ -27,7 +29,7 @@ recoTauAK5PFJets08Region=RecoTauJetRegionProducer.clone(
 # Reconstruct the pi zeros in our pre-selected jets.
 from RecoTauTag.RecoTau.RecoTauPiZeroProducer_cfi import \
          ak5PFJetsLegacyHPSPiZeros
-ak5PFJetsLegacyHPSPiZeros.jetSrc = cms.InputTag("ak5PFJets")
+ak5PFJetsLegacyHPSPiZeros.jetSrc = PFRecoTauPFJetInputs.inputJetCollection
 # import charged hadrons
 from RecoTauTag.RecoTau.PFRecoTauChargedHadronProducer_cfi import \
           ak5PFJetsRecoTauChargedHadrons
@@ -42,7 +44,7 @@ from RecoTauTag.RecoTau.PFRecoTauChargedHadronProducer_cfi import \
 from RecoTauTag.RecoTau.RecoTauCombinatoricProducer_cfi import \
         combinatoricRecoTaus
 
-combinatoricRecoTaus.jetSrc = cms.InputTag("ak5PFJets")
+combinatoricRecoTaus.jetSrc = PFRecoTauPFJetInputs.inputJetCollection
 
 
 #-------------------------------------------------------------------------------
@@ -59,10 +61,11 @@ combinatoricRecoTaus.piZeroSrc = cms.InputTag("ak5PFJetsLegacyHPSPiZeros")
 # Build the PFTauTagInfos separately, then relink them into the taus.
 from RecoTauTag.RecoTau.PFRecoTauTagInfoProducer_cfi import \
         pfRecoTauTagInfoProducer
-from RecoJets.JetAssociationProducers.ic5PFJetTracksAssociatorAtVertex_cfi \
-        import ic5PFJetTracksAssociatorAtVertex
-ak5PFJetTracksAssociatorAtVertex = ic5PFJetTracksAssociatorAtVertex.clone()
-ak5PFJetTracksAssociatorAtVertex.jets = cms.InputTag("ak5PFJets")
+from RecoJets.JetAssociationProducers.ak5JTA_cff \
+        import ak5JetTracksAssociatorAtVertexPF
+ak5PFJetTracksAssociatorAtVertex = ak5JetTracksAssociatorAtVertexPF.clone()
+ak5PFJetTracksAssociatorAtVertex.jets = PFRecoTauPFJetInputs.inputJetCollection
+ak5PFJetTracksAssociatorAtVertex.coneSize = PFRecoTauPFJetInputs.jetConeSize
 tautagInfoModifer = cms.PSet(
     name = cms.string("TTIworkaround"),
     plugin = cms.string("RecoTauTagInfoWorkaroundModifer"),

--- a/RecoTauTag/RecoTau/plugins/RecoTauProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauProducer.cc
@@ -58,6 +58,9 @@ class RecoTauProducer : public edm::EDProducer
   edm::InputTag jetRegionSrc_;
   edm::InputTag chargedHadronSrc_;
   edm::InputTag piZeroSrc_;
+
+  double minJetPt_;
+  double maxJetAbsEta_;
  //token definition
   edm::EDGetTokenT<reco::CandidateView> jet_token;
   edm::EDGetTokenT<edm::Association<reco::PFJetCollection> > jetRegion_token;
@@ -81,6 +84,8 @@ RecoTauProducer::RecoTauProducer(const edm::ParameterSet& pset)
   chargedHadronSrc_ = pset.getParameter<edm::InputTag>("chargedHadronSrc");
   piZeroSrc_ = pset.getParameter<edm::InputTag>("piZeroSrc");
   
+  minJetPt_ = ( pset.exists("minJetPt") ) ? pset.getParameter<double>("minJetPt") : -1.0;
+  maxJetAbsEta_ = ( pset.exists("maxJetAbsEta") ) ? pset.getParameter<double>("maxJetAbsEta") : 99.0;
   //consumes definition
   jet_token=consumes<reco::CandidateView>(jetSrc_);
   jetRegion_token = consumes<edm::Association<reco::PFJetCollection> >(jetRegionSrc_);
@@ -160,6 +165,8 @@ void RecoTauProducer::produce(edm::Event& evt, const edm::EventSetup& es)
   // Loop over the jets and build the taus for each jet
   BOOST_FOREACH( reco::PFJetRef jetRef, jets ) {
     // Get the jet with extra constituents from an area around the jet
+    if(jetRef->pt() - minJetPt_ < 1e-5) continue;
+    if(fabs(jetRef->eta()) - maxJetAbsEta_ > -1e-5) continue;
     reco::PFJetRef jetRegionRef = (*jetRegionHandle)[jetRef];
     if ( jetRegionRef.isNull() ) {
       throw cms::Exception("BadJetRegionRef") 
@@ -190,7 +197,6 @@ void RecoTauProducer::produce(edm::Event& evt, const edm::EventSetup& es)
 
     // Get the pizeros associated with this jet
     const std::vector<reco::RecoTauPiZero>& piZeros = (*piZeroAssoc)[jetRef];
-
     // Loop over our builders and create the set of taus for this jet
     unsigned int nTausBuilt = 0;
     for ( BuilderList::const_iterator builder = builders_.begin();

--- a/RecoTauTag/RecoTau/python/PFRecoTauChargedHadronProducer_cfi.py
+++ b/RecoTauTag/RecoTau/python/PFRecoTauChargedHadronProducer_cfi.py
@@ -4,9 +4,10 @@ import RecoTauTag.RecoTau.PFRecoTauChargedHadronBuilderPlugins_cfi as builders
 import RecoTauTag.RecoTau.PFRecoTauChargedHadronQualityPlugins_cfi as ranking
 
 from RecoTauTag.RecoTau.PFRecoTauQualityCuts_cfi import PFTauQualityCuts
+from RecoTauTag.RecoTau.PFRecoTauPFJetInputs_cfi import PFRecoTauPFJetInputs
 
 ak5PFJetsRecoTauChargedHadrons = cms.EDProducer("PFRecoTauChargedHadronProducer",
-    jetSrc = cms.InputTag("ak5PFJets"),
+    jetSrc = PFRecoTauPFJetInputs.inputJetCollection,
     jetRegionSrc = cms.InputTag("recoTauAK5PFJets08Region"),
     outputSelection = cms.string('pt > %1.1f' % PFTauQualityCuts.signalQualityCuts.minTrackPt.value()), # CV: apply minimum Pt cut as sanity check
     builders = cms.VPSet(

--- a/RecoTauTag/RecoTau/python/PFRecoTauDiscriminationByHPSSelection_cfi.py
+++ b/RecoTauTag/RecoTau/python/PFRecoTauDiscriminationByHPSSelection_cfi.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 from RecoTauTag.RecoTau.TauDiscriminatorTools import noPrediscriminants
+from RecoTauTag.RecoTau.PFRecoTauPFJetInputs_cfi import PFRecoTauPFJetInputs
 
 decayMode_1Prong0Pi0 = cms.PSet(
     nCharged = cms.uint32(1),
@@ -63,7 +64,7 @@ hpsSelectionDiscriminator = cms.EDProducer(
     "PFRecoTauDiscriminationByHPSSelection",
     PFTauProducer = cms.InputTag('combinatoricRecoTaus'),
     Prediscriminants = noPrediscriminants,
-    matchingCone = cms.double(0.5),
+    matchingCone = PFRecoTauPFJetInputs.jetConeSize,
     minTauPt = cms.double(0.0),
     coneSizeFormula = cms.string("max(min(0.1, 3.0/pt()), 0.05)"),
     decayModes = cms.VPSet(

--- a/RecoTauTag/RecoTau/python/PFRecoTauPFJetInputs_cfi.py
+++ b/RecoTauTag/RecoTau/python/PFRecoTauPFJetInputs_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+PFRecoTauPFJetInputs = cms.PSet (
+    inputJetCollection = cms.InputTag("ak5PFJets"),
+    jetConeSize = cms.double(0.5), # for matching between tau and jet
+    isolationConeSize = cms.double(0.5) # for the size of the tau isolation
+)

--- a/RecoTauTag/RecoTau/python/PFRecoTauPFJetInputs_cfi.py
+++ b/RecoTauTag/RecoTau/python/PFRecoTauPFJetInputs_cfi.py
@@ -3,5 +3,7 @@ import FWCore.ParameterSet.Config as cms
 PFRecoTauPFJetInputs = cms.PSet (
     inputJetCollection = cms.InputTag("ak5PFJets"),
     jetConeSize = cms.double(0.5), # for matching between tau and jet
-    isolationConeSize = cms.double(0.5) # for the size of the tau isolation
+    isolationConeSize = cms.double(0.5), # for the size of the tau isolation
+    minJetPt = cms.double(14.0), # do not make taus from jet with pt below that value
+    maxJetAbsEta = cms.double(2.5) # do not make taus from jet more forward/backward than this
 )

--- a/RecoTauTag/RecoTau/python/RecoTauCombinatoricProducer_cfi.py
+++ b/RecoTauTag/RecoTau/python/RecoTauCombinatoricProducer_cfi.py
@@ -2,7 +2,7 @@
 import FWCore.ParameterSet.Config as cms
 from RecoTauTag.RecoTau.PFRecoTauQualityCuts_cfi import PFTauQualityCuts
 from RecoTauTag.RecoTau.PFRecoTauEnergyAlgorithmPlugin_cfi import pfTauEnergyAlgorithmPlugin
-
+from RecoTauTag.RecoTau.PFRecoTauPFJetInputs_cfi import PFRecoTauPFJetInputs
 '''
 
 Configuration for combinatoric PFTau producer plugins.
@@ -74,7 +74,7 @@ _combinatoricTauConfig = cms.PSet(
     name = cms.string("combinatoric"),
     plugin = cms.string("RecoTauBuilderCombinatoricPlugin"),
     pfCandSrc = cms.InputTag("particleFlow"),
-    isolationConeSize = cms.double(0.5),
+    isolationConeSize = PFRecoTauPFJetInputs.isolationConeSize,
     qualityCuts = PFTauQualityCuts,
     decayModes = cms.VPSet(
         combinatoricDecayModeConfigs.config1prong0pi0,
@@ -87,7 +87,7 @@ _combinatoricTauConfig = cms.PSet(
 )
 
 combinatoricRecoTaus = cms.EDProducer("RecoTauProducer",
-    jetSrc = cms.InputTag("ak5PFJets"),
+    jetSrc = PFRecoTauPFJetInputs.inputJetCollection,
     jetRegionSrc = cms.InputTag("recoTauAK5PFJets08Region"),
     chargedHadronSrc = cms.InputTag('ak5PFJetsRecoTauChargedHadrons'),                                
     piZeroSrc = cms.InputTag("ak5PFJetsRecoTauPiZeros"),

--- a/RecoTauTag/RecoTau/python/RecoTauCombinatoricProducer_cfi.py
+++ b/RecoTauTag/RecoTau/python/RecoTauCombinatoricProducer_cfi.py
@@ -88,6 +88,8 @@ _combinatoricTauConfig = cms.PSet(
 
 combinatoricRecoTaus = cms.EDProducer("RecoTauProducer",
     jetSrc = PFRecoTauPFJetInputs.inputJetCollection,
+    minJetPt = PFRecoTauPFJetInputs.minJetPt,
+    maxJetAbsEta = PFRecoTauPFJetInputs.maxJetAbsEta,
     jetRegionSrc = cms.InputTag("recoTauAK5PFJets08Region"),
     chargedHadronSrc = cms.InputTag('ak5PFJetsRecoTauChargedHadrons'),                                
     piZeroSrc = cms.InputTag("ak5PFJetsRecoTauPiZeros"),

--- a/RecoTauTag/RecoTau/python/RecoTauJetRegionProducer_cfi.py
+++ b/RecoTauTag/RecoTau/python/RecoTauJetRegionProducer_cfi.py
@@ -1,9 +1,11 @@
 import FWCore.ParameterSet.Config as cms
 
+from RecoTauTag.RecoTau.PFRecoTauPFJetInputs_cfi import PFRecoTauPFJetInputs
+
 RecoTauJetRegionProducer = cms.EDProducer(
         "RecoTauJetRegionProducer",
             deltaR = cms.double(0.8),
-            src = cms.InputTag("ak5PFJets"),
+            src = PFRecoTauPFJetInputs.inputJetCollection,
             pfCandSrc = cms.InputTag("particleFlow"),
             pfCandAssocMapSrc = cms.InputTag("")
         )

--- a/RecoTauTag/RecoTau/python/RecoTauPiZeroProducer_cfi.py
+++ b/RecoTauTag/RecoTau/python/RecoTauPiZeroProducer_cfi.py
@@ -2,10 +2,12 @@ import FWCore.ParameterSet.Config as cms
 
 import RecoTauTag.RecoTau.RecoTauPiZeroBuilderPlugins_cfi as builders
 import RecoTauTag.RecoTau.RecoTauPiZeroQualityPlugins_cfi as ranking
+from RecoTauTag.RecoTau.PFRecoTauPFJetInputs_cfi import PFRecoTauPFJetInputs
+
 
 ak5PFJetsRecoTauGreedyPiZeros = cms.EDProducer(
     "RecoTauPiZeroProducer",
-    jetSrc = cms.InputTag("ak5PFJets"),
+    jetSrc = PFRecoTauPFJetInputs.inputJetCollection,
     massHypothesis = cms.double(0.136),
     outputSelection = cms.string('pt > 1.5'),
     builders = cms.VPSet(
@@ -18,7 +20,7 @@ ak5PFJetsRecoTauGreedyPiZeros = cms.EDProducer(
 
 ak5PFJetsRecoTauPiZeros = cms.EDProducer(
     "RecoTauPiZeroProducer",
-    jetSrc = cms.InputTag("ak5PFJets"),
+    jetSrc = PFRecoTauPFJetInputs.inputJetCollection,
     massHypothesis = cms.double(0.136),
     outputSelection = cms.string('pt > 1.5'),
     builders = cms.VPSet(
@@ -35,7 +37,7 @@ ak5PFJetsRecoTauPiZeros = cms.EDProducer(
 
 ak5PFJetsLegacyTaNCPiZeros = cms.EDProducer(
     "RecoTauPiZeroProducer",
-    jetSrc = cms.InputTag("ak5PFJets"),
+    jetSrc = PFRecoTauPFJetInputs.inputJetCollection,
     massHypothesis = cms.double(0.136),
     outputSelection = cms.string('pt > 1.5'),
     builders = cms.VPSet(
@@ -49,7 +51,7 @@ ak5PFJetsLegacyTaNCPiZeros = cms.EDProducer(
 
 ak5PFJetsLegacyHPSPiZeros = cms.EDProducer(
     "RecoTauPiZeroProducer",
-    jetSrc = cms.InputTag("ak5PFJets"),
+    jetSrc = PFRecoTauPFJetInputs.inputJetCollection,
     massHypothesis = cms.double(0.136),
     outputSelection = cms.string('pt > 0'),
     builders = cms.VPSet(

--- a/RecoTauTag/RecoTau/python/RecoTauShrinkingConeProducer_cfi.py
+++ b/RecoTauTag/RecoTau/python/RecoTauShrinkingConeProducer_cfi.py
@@ -32,6 +32,9 @@ shrinkingConeRecoTaus = cms.EDProducer(
     jetSrc = PFRecoTauPFJetInputs.inputJetCollection,
     piZeroSrc = cms.InputTag("ak5PFJetsRecoTauPiZeros"),
     jetRegionSrc = cms.InputTag("recoTauAK5PFJets08Region"),
+    chargedHadronSrc = cms.InputTag('ak5PFJetsRecoTauChargedHadrons'),
+    minJetPt = cms.double(-1.0),
+    maxJetAbsEta = cms.double(99.0),
     builders = cms.VPSet(
         _shrinkingConeRecoTausConfig
     ),

--- a/RecoTauTag/RecoTau/python/RecoTauShrinkingConeProducer_cfi.py
+++ b/RecoTauTag/RecoTau/python/RecoTauShrinkingConeProducer_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from RecoTauTag.RecoTau.PFRecoTauQualityCuts_cfi import PFTauQualityCuts
-
+from RecoTauTag.RecoTau.PFRecoTauPFJetInputs_cfi import PFRecoTauPFJetInputs
 '''
 
 Configuration for 'shrinkingCone' PFTau Producer
@@ -29,7 +29,7 @@ _shrinkingConeRecoTausConfig = cms.PSet(
 
 shrinkingConeRecoTaus = cms.EDProducer(
     "RecoTauProducer",
-    jetSrc = cms.InputTag("ak5PFJets"),
+    jetSrc = PFRecoTauPFJetInputs.inputJetCollection,
     piZeroSrc = cms.InputTag("ak5PFJetsRecoTauPiZeros"),
     jetRegionSrc = cms.InputTag("recoTauAK5PFJets08Region"),
     builders = cms.VPSet(


### PR DESCRIPTION
This PR is extension of #3558 by commits 8bf124d and 2105513.
It adds the possibility to reject some jets as an input seeds for tau reconstruction based on their pt and eta. It is turned on by default and the requirements for running the tau RECO sequence are
1) pt > 14 GeV
2) |eta| < 2.5

The performance change is expected - loss of efficiency for very low pt true taus, and also decreased fake rate for very low pt jets.

However, no change is expected for the taus passing recommended kinematical cuts (pt > 20 GeV + |eta| < 2.3).

This is shown on slides: https://indico.cern.ch/event/316898/material/0/0.pdf

Additionally, one can expect improvement of overall timing needed for tauRECO (as the algorithm is executed fewer times) and also size reduction in the RECO PFTauCollection, as it will contain fewer candidates.

The 8bf124d and 2105513 were not added to the existing PR #3558, as they do change the performance, while the original PR is just python re-structuring. 

@veelken and @monicava, this is something you wanted to watch as well
