### PR TITLE
FWCore/PluginManager: gCINTMutex -> gInterpreterMutex

### DIFF
--- a/FWCore/PluginManager/BuildFile.xml
+++ b/FWCore/PluginManager/BuildFile.xml
@@ -1,6 +1,5 @@
 <use   name="boost"/>
 <use   name="tbb"/>
-<use   name="rootcint"/>
 <use   name="boost_filesystem"/>
 <use   name="FWCore/Utilities"/>
 <export>

--- a/FWCore/PluginManager/src/PluginManager.cc
+++ b/FWCore/PluginManager/src/PluginManager.cc
@@ -249,7 +249,7 @@ PluginManager::load(const std::string& iCategory,
       {
 	//TEMPORARY: to avoid possible deadlocks from ROOT, we must
 	// take the lock ourselves
-	R__LOCKGUARD2(gCINTMutex);
+	R__LOCKGUARD2(gInterpreterMutex);
 	ptr.reset( new SharedLibrary(p) );
       }
       loadables_[p]=ptr;
@@ -289,7 +289,7 @@ PluginManager::tryToLoad(const std::string& iCategory,
       {
 	//TEMPORARY: to avoid possible deadlocks from ROOT, we must
 	// take the lock ourselves
-	R__LOCKGUARD(gCINTMutex);
+	R__LOCKGUARD(gInterpreterMutex);
 	ptr.reset( new SharedLibrary(p) );
       }
       loadables_[p]=ptr;


### PR DESCRIPTION
gCINTMutex was renamed to gInterpreterMutex in ROOT6.
Also remove rootcint from BuildFile.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
