### PR TITLE
first pass through consumes for MuonAssociatorEDProducer

### DIFF
--- a/SimMuon/MCTruth/interface/DTHitAssociator.h
+++ b/SimMuon/MCTruth/interface/DTHitAssociator.h
@@ -14,6 +14,7 @@
 #include "DataFormats/DTDigi/interface/DTDigiCollection.h"
 #include "SimDataFormats/DigiSimLinks/interface/DTDigiSimLinkCollection.h"
 #include "Geometry/DTGeometry/interface/DTGeometry.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include <vector>
 #include <map>
@@ -29,6 +30,10 @@ class DTHitAssociator {
   typedef std::map<DTWireId, std::vector<DTDigiSimLink> > LinksMap;
 
   DTHitAssociator(const edm::Event&, const edm::EventSetup&, const edm::ParameterSet&, bool printRtS); 
+  DTHitAssociator(const edm::ParameterSet&, edm::ConsumesCollector && iC); 
+
+  void initEvent(const edm::Event&, const edm::EventSetup& );
+
   virtual ~DTHitAssociator(){}
 
   std::vector<SimHitIdpr> associateHitId(const TrackingRecHit & hit);

--- a/SimMuon/MCTruth/interface/MuonAssociatorByHits.h
+++ b/SimMuon/MCTruth/interface/MuonAssociatorByHits.h
@@ -19,7 +19,9 @@
 #include "SimMuon/MCTruth/interface/RPCHitAssociator.h"
 #include "SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h"
 #include "SimTracker/TrackAssociation/interface/TrackAssociatorBase.h"
-
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "SimDataFormats/Track/interface/SimTrackContainer.h"
+#include "SimDataFormats/Vertex/interface/SimVertexContainer.h"
 
 #include <boost/ptr_container/ptr_vector.hpp>
 
@@ -33,7 +35,8 @@ class MuonAssociatorByHits : public TrackAssociatorBase {
   typedef std::pair<unsigned int,std::vector<SimHitIdpr> > uint_SimHitIdpr_pair;
   typedef boost::ptr_vector<uint_SimHitIdpr_pair> MapOfMatchedIds;
   
-  MuonAssociatorByHits( const edm::ParameterSet& );  
+  MuonAssociatorByHits (const edm::ParameterSet& conf, edm::ConsumesCollector && iC);   
+  MuonAssociatorByHits (const edm::ParameterSet& conf);   
   ~MuonAssociatorByHits();
   
   // Get base methods from base class
@@ -49,7 +52,7 @@ class MuonAssociatorByHits : public TrackAssociatorBase {
   /// Association Sim To Reco with Collections
   reco::SimToRecoCollection associateSimToReco(const edm::RefToBaseVector<reco::Track>&,
 					       const edm::RefVector<TrackingParticleCollection>&,
-					       const edm::Event * event = 0, const edm::EventSetup * setup = 0) const ;
+					       const edm::Event * event = 0, const edm::EventSetup * setup = 0) const;
 
  
   void getMatchedIds
@@ -60,7 +63,7 @@ class MuonAssociatorByHits : public TrackAssociatorBase {
      int& n_tracker_INVALID, int& n_dt_INVALID, int& n_csc_INVALID, int& n_rpc_INVALID,
      int& n_tracker_matched_INVALID, int& n_dt_matched_INVALID, int& n_csc_matched_INVALID, int& n_rpc_matched_INVALID,
      trackingRecHit_iterator begin, trackingRecHit_iterator end,
-     TrackerHitAssociator* trackertruth, DTHitAssociator& dttruth, MuonTruth& csctruth, RPCHitAssociator& rpctruth, 
+     TrackerHitAssociator* trackertruth, DTHitAssociator& dttruth, MuonTruth& csctruth, RPCHitAssociator& rpctruth,
      bool printRts, const TrackerTopology *) const;
   
   int getShared(MapOfMatchedIds & matchedIds, TrackingParticleCollection::const_iterator trpart) const;
@@ -110,6 +113,11 @@ class MuonAssociatorByHits : public TrackAssociatorBase {
   edm::InputTag simtracksXFTag;
   const edm::ParameterSet& conf_;
 
+  edm::EDGetTokenT<CrossingFrame<SimTrack> > simtracksXFToken_;
+  edm::EDGetTokenT<CrossingFrame<SimVertex> > simvertsXFToken_;
+  edm::EDGetTokenT<edm::SimTrackContainer> simtracksToken_;
+  edm::EDGetTokenT<edm::SimVertexContainer> simvertsToken_;
+
   int LayerFromDetid(const DetId&) const;
   const TrackingRecHit* getHitPtr(edm::OwnVector<TrackingRecHit>::const_iterator iter) const {return &*iter;}
   const TrackingRecHit* getHitPtr(const trackingRecHit_iterator& iter) const {return &**iter;}
@@ -127,10 +135,10 @@ class MuonAssociatorByHits : public TrackAssociatorBase {
  
   IndexAssociation associateSimToRecoIndices(const TrackHitsCollection &, 
                                              const edm::RefVector<TrackingParticleCollection>&,
-					     const edm::Event * event = 0, const edm::EventSetup * setup = 0) const ; 
+					     const edm::Event * event = 0, const edm::EventSetup * setup = 0)  const; 
   IndexAssociation associateRecoToSimIndices(const TrackHitsCollection &, 
                                              const edm::RefVector<TrackingParticleCollection>&,
-					     const edm::Event * event = 0, const edm::EventSetup * setup = 0) const ;
+					     const edm::Event * event = 0, const edm::EventSetup * setup = 0) const;
   
 
 

--- a/SimMuon/MCTruth/interface/MuonTruth.h
+++ b/SimMuon/MCTruth/interface/MuonTruth.h
@@ -19,6 +19,7 @@
 #include "Geometry/CSCGeometry/interface/CSCLayerGeometry.h"
 #include "CondFormats/CSCObjects/interface/CSCBadChambers.h"
 #include "CondFormats/DataRecord/interface/CSCBadChambersRcd.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 class MuonTruth
 {
@@ -29,6 +30,10 @@ public:
   typedef std::pair <uint32_t, EncodedEventId> SimHitIdpr;
 
   MuonTruth(const edm::Event&, const edm::EventSetup&, const edm::ParameterSet&); 
+  MuonTruth(const edm::ParameterSet&, edm::ConsumesCollector && iC);
+ 
+  void initEvent(const edm::Event &, const edm::EventSetup& );
+
   std::vector<SimHitIdpr> associateHitId(const TrackingRecHit &);
   std::vector<SimHitIdpr> associateCSCHitId(const CSCRecHit2D *);
 

--- a/SimMuon/MCTruth/interface/RPCHitAssociator.h
+++ b/SimMuon/MCTruth/interface/RPCHitAssociator.h
@@ -11,6 +11,7 @@
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
 #include "DataFormats/MuonDetId/interface/RPCDetId.h"
 #include "SimDataFormats/RPCDigiSimLink/interface/RPCDigiSimLink.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include <vector>
 #include <map>
@@ -35,8 +36,11 @@ class RPCHitAssociator {
    typedef std::pair<uint32_t, EncodedEventId> SimHitIdpr;
 
   // Constructor with configurable parameters
-  RPCHitAssociator(const edm::Event&, const edm::EventSetup&, const edm::ParameterSet&); 
+   RPCHitAssociator(const edm::ParameterSet&, edm::ConsumesCollector && ic); 
+   RPCHitAssociator(const edm::Event& e, const edm::EventSetup& eventSetup, const edm::ParameterSet& conf );
 
+   void initEvent(const edm::Event&, const edm::EventSetup&);
+  
   // Destructor
   ~RPCHitAssociator(){}
 
@@ -52,6 +56,10 @@ class RPCHitAssociator {
    bool crossingframe;
    edm::InputTag RPCsimhitsTag;
    edm::InputTag RPCsimhitsXFTag;
+
+   edm::EDGetTokenT<CrossingFrame<PSimHit> > RPCsimhitsXFToken_;
+   edm::EDGetTokenT<edm::PSimHitContainer> RPCsimhitsToken_;
+   edm::EDGetTokenT<edm::DetSetVector<RPCDigiSimLink> > RPCdigisimlinkToken_; 
 
    std::map<unsigned int, edm::PSimHitContainer> _SimHitMap;
 

--- a/SimMuon/MCTruth/interface/TrackerMuonHitExtractor.h
+++ b/SimMuon/MCTruth/interface/TrackerMuonHitExtractor.h
@@ -12,10 +12,12 @@
 #include "DataFormats/MuonReco/interface/Muon.h"
 #include "DataFormats/CSCRecHit/interface/CSCSegmentCollection.h"
 #include "DataFormats/DTRecHit/interface/DTRecSegment4DCollection.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 class TrackerMuonHitExtractor {
   public:
-    explicit TrackerMuonHitExtractor(const edm::ParameterSet&);
+    explicit TrackerMuonHitExtractor(const edm::ParameterSet&, edm::ConsumesCollector && ic);
+    explicit TrackerMuonHitExtractor(const edm::ParameterSet& );
     ~TrackerMuonHitExtractor();
 
     void init(const edm::Event&, const edm::EventSetup&);
@@ -24,8 +26,11 @@ class TrackerMuonHitExtractor {
     edm::Handle<DTRecSegment4DCollection> dtSegmentCollectionH_;
     edm::Handle<CSCSegmentCollection> cscSegmentCollectionH_;
 
+    edm::EDGetTokenT<DTRecSegment4DCollection> inputDTRecSegment4DToken_;
+    edm::EDGetTokenT<CSCSegmentCollection> inputCSCSegmentToken_;
     edm::InputTag inputDTRecSegment4DCollection_;
     edm::InputTag inputCSCSegmentCollection_;
+
 };
 
 #endif

--- a/SimMuon/MCTruth/plugins/MuonAssociatorEDProducer.cc
+++ b/SimMuon/MCTruth/plugins/MuonAssociatorEDProducer.cc
@@ -14,6 +14,8 @@ MuonAssociatorEDProducer::MuonAssociatorEDProducer(const edm::ParameterSet& pars
   LogTrace("MuonAssociatorEDProducer") << "constructing  MuonAssociatorEDProducer" << parset_.dump();
   produces<reco::RecoToSimCollection>();
   produces<reco::SimToRecoCollection>();
+  tpToken_=consumes<TrackingParticleCollection>(tpTag);
+  tracksToken_=consumes<edm::View<reco::Track> >(tracksTag);
 
   /// Perform some sanity checks of the configuration
   edm::LogVerbatim("MuonAssociatorByHits") << "constructing  MuonAssociatorByHits" << parset_.dump();
@@ -57,13 +59,15 @@ MuonAssociatorEDProducer::MuonAssociatorEDProducer(const edm::ParameterSet& pars
     }
   }
 
+  LogTrace("MuonAssociatorEDProducer") << "MuonAssociatorEDProducer::beginJob : constructing MuonAssociatorByHits";
+  associatorByHits = new MuonAssociatorByHits(parset_,consumesCollector());
+
+
 }
 
 MuonAssociatorEDProducer::~MuonAssociatorEDProducer() {}
 
 void MuonAssociatorEDProducer::beginJob() {
-  LogTrace("MuonAssociatorEDProducer") << "MuonAssociatorEDProducer::beginJob : constructing MuonAssociatorByHits";
-  associatorByHits = new MuonAssociatorByHits(parset_);
 }
 
 void MuonAssociatorEDProducer::endJob() {}
@@ -73,12 +77,12 @@ void MuonAssociatorEDProducer::produce(edm::Event& event, const edm::EventSetup&
 
    Handle<TrackingParticleCollection>  TPCollection ;
    LogTrace("MuonAssociatorEDProducer") <<"getting TrackingParticle collection - "<<tpTag;
-   event.getByLabel(tpTag, TPCollection);
+   event.getByToken(tpToken_, TPCollection);
    LogTrace("MuonAssociatorEDProducer") <<"\t... size = "<<TPCollection->size();
 
    Handle<edm::View<reco::Track> > trackCollection;
    LogTrace("MuonAssociatorEDProducer") <<"getting reco::Track collection - "<<tracksTag;
-   bool trackAvailable = event.getByLabel (tracksTag, trackCollection);
+   bool trackAvailable = event.getByToken (tracksToken_, trackCollection);
    if (trackAvailable) LogTrace("MuonAssociatorEDProducer") <<"\t... size = "<<trackCollection->size();
    else LogTrace("MuonAssociatorEDProducer") <<"\t... NOT FOUND.";
 

--- a/SimMuon/MCTruth/plugins/MuonAssociatorEDProducer.h
+++ b/SimMuon/MCTruth/plugins/MuonAssociatorEDProducer.h
@@ -8,6 +8,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "SimMuon/MCTruth/interface/MuonAssociatorByHits.h"
+#include "DataFormats/RecoCandidate/interface/TrackAssociation.h"
 
 class MuonAssociatorEDProducer : public edm::EDProducer {
 public:
@@ -21,6 +22,9 @@ private:
 
   edm::InputTag tracksTag;
   edm::InputTag tpTag;
+  edm::EDGetTokenT<TrackingParticleCollection> tpToken_;
+  edm::EDGetTokenT<edm::View<reco::Track> > tracksToken_;
+
   bool ignoreMissingTrackCollection;
   edm::ParameterSet parset_;
   MuonAssociatorByHits * associatorByHits;

--- a/SimMuon/MCTruth/plugins/MuonTrackProducer.cc
+++ b/SimMuon/MCTruth/plugins/MuonTrackProducer.cc
@@ -13,9 +13,9 @@
 #include <sstream>
 
 MuonTrackProducer::MuonTrackProducer(const edm::ParameterSet& parset) :
-  muonsTag(parset.getParameter< edm::InputTag >("muonsTag")),
-  inputDTRecSegment4DCollection_(parset.getParameter<edm::InputTag>("inputDTRecSegment4DCollection")),
-  inputCSCSegmentCollection_(parset.getParameter<edm::InputTag>("inputCSCSegmentCollection")),
+  muonsToken(consumes<reco::MuonCollection>(parset.getParameter< edm::InputTag >("muonsTag"))),
+  inputDTRecSegment4DToken_(consumes<DTRecSegment4DCollection>(parset.getParameter<edm::InputTag>("inputDTRecSegment4DCollection"))),
+  inputCSCSegmentToken_(consumes<CSCSegmentCollection>(parset.getParameter<edm::InputTag>("inputCSCSegmentCollection"))),
   selectionTags(parset.getParameter< std::vector<std::string> >("selectionTags")),
   trackType(parset.getParameter< std::string >("trackType")),
   parset_(parset)
@@ -31,9 +31,9 @@ MuonTrackProducer::~MuonTrackProducer() {
 
 void MuonTrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) 
 {
-  iEvent.getByLabel(muonsTag,muonCollectionH);
-  iEvent.getByLabel(inputDTRecSegment4DCollection_, dtSegmentCollectionH_);
-  iEvent.getByLabel(inputCSCSegmentCollection_, cscSegmentCollectionH_);
+  iEvent.getByToken(muonsToken,muonCollectionH);
+  iEvent.getByToken(inputDTRecSegment4DToken_, dtSegmentCollectionH_);
+  iEvent.getByToken(inputCSCSegmentToken_, cscSegmentCollectionH_);
   
   std::auto_ptr<reco::TrackCollection> selectedTracks(new reco::TrackCollection);
   std::auto_ptr<reco::TrackExtraCollection> selectedTrackExtras( new reco::TrackExtraCollection() );

--- a/SimMuon/MCTruth/plugins/MuonTrackProducer.h
+++ b/SimMuon/MCTruth/plugins/MuonTrackProducer.h
@@ -26,9 +26,9 @@ class MuonTrackProducer : public edm::EDProducer {
     edm::Handle<DTRecSegment4DCollection> dtSegmentCollectionH_;
     edm::Handle<CSCSegmentCollection> cscSegmentCollectionH_;
 
-    edm::InputTag muonsTag;
-    edm::InputTag inputDTRecSegment4DCollection_;
-    edm::InputTag inputCSCSegmentCollection_;
+    edm::EDGetTokenT<reco::MuonCollection> muonsToken;
+    edm::EDGetTokenT<DTRecSegment4DCollection> inputDTRecSegment4DToken_;
+    edm::EDGetTokenT<CSCSegmentCollection> inputCSCSegmentToken_;
     std::vector<std::string> selectionTags;
     std::string trackType;
     const edm::ParameterSet parset_;

--- a/SimMuon/MCTruth/src/MuonTruth.cc
+++ b/SimMuon/MCTruth/src/MuonTruth.cc
@@ -16,6 +16,32 @@ MuonTruth::MuonTruth(const edm::Event& event, const edm::EventSetup& setup, cons
   CSCsimHitsXFTag(conf.getParameter<edm::InputTag>("CSCsimHitsXFTag"))
 
 {
+  initEvent(event,setup);
+}
+
+MuonTruth::MuonTruth( const edm::ParameterSet& conf, edm::ConsumesCollector && iC ): 
+  theDigiSimLinks(0),
+  theWireDigiSimLinks(0),
+  linksTag(conf.getParameter<edm::InputTag>("CSClinksTag")),
+  wireLinksTag(conf.getParameter<edm::InputTag>("CSCwireLinksTag")),
+  // CrossingFrame used or not ?
+  crossingframe(conf.getParameter<bool>("crossingframe")),
+  CSCsimHitsTag(conf.getParameter<edm::InputTag>("CSCsimHitsTag")),
+  CSCsimHitsXFTag(conf.getParameter<edm::InputTag>("CSCsimHitsXFTag"))
+
+{
+  iC.consumes<DigiSimLinks>(linksTag);
+  iC.consumes<DigiSimLinks>(wireLinksTag);
+  if ( crossingframe ) {
+    iC.consumes<CrossingFrame<PSimHit> >(CSCsimHitsXFTag);
+  } else if (!CSCsimHitsTag.label().empty()){
+    iC.consumes<edm::PSimHitContainer>(CSCsimHitsTag);
+  }
+
+}
+
+void MuonTruth::initEvent(const edm::Event& event, const edm::EventSetup& setup) {
+
   edm::Handle<DigiSimLinks> digiSimLinks;
   LogTrace("MuonTruth") <<"getting CSC Strip DigiSimLink collection - "<<linksTag;
   event.getByLabel(linksTag, digiSimLinks);

--- a/SimMuon/MCTruth/src/RPCHitAssociator.cc
+++ b/SimMuon/MCTruth/src/RPCHitAssociator.cc
@@ -2,14 +2,39 @@
 
 using namespace std;
 
-// Constructor
-RPCHitAssociator::RPCHitAssociator(const edm::Event& e, const edm::EventSetup& eventSetup, const edm::ParameterSet& conf):
 
+
+// Constructor
+RPCHitAssociator::RPCHitAssociator( const edm::ParameterSet& conf, 
+				    edm::ConsumesCollector && iC):
   RPCdigisimlinkTag(conf.getParameter<edm::InputTag>("RPCdigisimlinkTag")),
   // CrossingFrame used or not ?
   crossingframe(conf.getParameter<bool>("crossingframe")),
   RPCsimhitsTag(conf.getParameter<edm::InputTag>("RPCsimhitsTag")),
   RPCsimhitsXFTag(conf.getParameter<edm::InputTag>("RPCsimhitsXFTag"))
+{
+  if (crossingframe){
+    RPCsimhitsXFToken_=iC.consumes<CrossingFrame<PSimHit> >(RPCsimhitsXFTag);
+  } else if (!RPCsimhitsTag.label().empty()) {
+    RPCsimhitsToken_=iC.consumes<edm::PSimHitContainer>(RPCsimhitsTag);
+  }
+
+  RPCdigisimlinkToken_=iC.consumes< edm::DetSetVector<RPCDigiSimLink> >(RPCdigisimlinkTag); 
+}
+
+RPCHitAssociator::RPCHitAssociator(const edm::Event& e, const edm::EventSetup& eventSetup, const edm::ParameterSet& conf ):
+  RPCdigisimlinkTag(conf.getParameter<edm::InputTag>("RPCdigisimlinkTag")),
+  // CrossingFrame used or not ?
+  crossingframe(conf.getParameter<bool>("crossingframe")),
+  RPCsimhitsTag(conf.getParameter<edm::InputTag>("RPCsimhitsTag")),
+  RPCsimhitsXFTag(conf.getParameter<edm::InputTag>("RPCsimhitsXFTag"))
+{
+  initEvent(e,eventSetup);
+}
+
+
+void RPCHitAssociator::initEvent(const edm::Event& e, const edm::EventSetup& eventSetup)
+
 
 {
   if (crossingframe) {

--- a/SimMuon/MCTruth/src/TrackerMuonHitExtractor.cc
+++ b/SimMuon/MCTruth/src/TrackerMuonHitExtractor.cc
@@ -12,7 +12,16 @@
 #include "DataFormats/MuonReco/interface/MuonSelectors.h"
 #include <sstream>
 
-TrackerMuonHitExtractor::TrackerMuonHitExtractor(const edm::ParameterSet& parset) :
+TrackerMuonHitExtractor::TrackerMuonHitExtractor(const edm::ParameterSet& parset,
+						 edm::ConsumesCollector && ic) :
+  inputDTRecSegment4DToken_(ic.consumes<DTRecSegment4DCollection>(parset.getParameter<edm::InputTag>("inputDTRecSegment4DCollection"))),
+  inputCSCSegmentToken_(ic.consumes<CSCSegmentCollection>(parset.getParameter<edm::InputTag>("inputCSCSegmentCollection"))),
+  inputDTRecSegment4DCollection_(parset.getParameter<edm::InputTag>("inputDTRecSegment4DCollection")),
+  inputCSCSegmentCollection_(parset.getParameter<edm::InputTag>("inputCSCSegmentCollection"))
+{
+}
+
+TrackerMuonHitExtractor::TrackerMuonHitExtractor(const edm::ParameterSet& parset ) :
   inputDTRecSegment4DCollection_(parset.getParameter<edm::InputTag>("inputDTRecSegment4DCollection")),
   inputCSCSegmentCollection_(parset.getParameter<edm::InputTag>("inputCSCSegmentCollection"))
 {


### PR DESCRIPTION
Do most of the consumes migration for MuonAssociatorEDProducer

However - big issues remain (imho) here given the const-ness of the associate\* methods in MuonAssociatorByHits class that prevent getByToken to be used (and the helper classes to simply be member data which could then be created once instead of reparsing the pset each time

The remaining consumes are in TrackerHitAssociator which I believe is high on Mike's list to look at
