### PR TITLE
Updated storage of flavor information in pat::Jet: Backport from 7_1_X to 6_2_X_SLHC

### DIFF
--- a/DataFormats/PatCandidates/interface/Jet.h
+++ b/DataFormats/PatCandidates/interface/Jet.h
@@ -519,8 +519,6 @@ namespace pat {
       std::vector<reco::GenJet> genJet_;
       reco::GenJetRefVector genJetRef_;
       edm::FwdRef<reco::GenJetCollection>  genJetFwdRef_;
-      int partonFlavour_;
-      int hadronFlavour_;
       reco::JetFlavourInfo jetFlavourInfo_;
 
       // ---- energy scale correction factors ----

--- a/DataFormats/PatCandidates/src/Jet.cc
+++ b/DataFormats/PatCandidates/src/Jet.cc
@@ -14,8 +14,6 @@ Jet::Jet() :
   PATObject<reco::Jet>(reco::Jet()),
   embeddedCaloTowers_(false),
   embeddedPFCandidates_(false),
-  partonFlavour_(0),
-  hadronFlavour_(0),
   jetCharge_(0.),
   isCaloTowerCached_(false),
   isPFCandidateCached_(false)
@@ -27,8 +25,6 @@ Jet::Jet(const reco::Jet & aJet) :
   PATObject<reco::Jet>(aJet),
   embeddedCaloTowers_(false),
   embeddedPFCandidates_(false),
-  partonFlavour_(0),
-  hadronFlavour_(0),
   jetCharge_(0.0),
   isCaloTowerCached_(false),
   isPFCandidateCached_(false)
@@ -41,8 +37,6 @@ Jet::Jet(const edm::Ptr<reco::Jet> & aJetRef) :
   PATObject<reco::Jet>(aJetRef),
   embeddedCaloTowers_(false),
   embeddedPFCandidates_(false),
-  partonFlavour_(0),
-  hadronFlavour_(0),
   jetCharge_(0.0),
   isCaloTowerCached_(false),
   isPFCandidateCached_(false)
@@ -55,8 +49,6 @@ Jet::Jet(const edm::RefToBase<reco::Jet> & aJetRef) :
   PATObject<reco::Jet>(aJetRef),
   embeddedCaloTowers_(false),
   embeddedPFCandidates_(false),
-  partonFlavour_(0),
-  hadronFlavour_(0),
   jetCharge_(0.0),
   isCaloTowerCached_(false),
   isPFCandidateCached_(false)
@@ -202,12 +194,12 @@ const reco::GenJet * Jet::genJet() const {
 
 /// return the parton-based flavour of the jet
 int Jet::partonFlavour() const {
-  return partonFlavour_;
+  return jetFlavourInfo_.getPartonFlavour();
 }
 
 /// return the hadron-based flavour of the jet
 int Jet::hadronFlavour() const {
-  return hadronFlavour_;
+  return jetFlavourInfo_.getHadronFlavour();
 }
 
 /// return the JetFlavourInfo of the jet
@@ -441,12 +433,12 @@ void Jet::setGenJetRef(const edm::FwdRef<reco::GenJetCollection> & gj)
 
 /// method to set the parton-based flavour of the jet
 void Jet::setPartonFlavour(int partonFl) {
-  partonFlavour_ = partonFl;
+  jetFlavourInfo_.setPartonFlavour(partonFl);
 }
 
 /// method to set the hadron-based flavour of the jet
 void Jet::setHadronFlavour(int hadronFl) {
-  hadronFlavour_ = hadronFl;
+  jetFlavourInfo_.setHadronFlavour(hadronFl);
 }
 
 /// method to set the JetFlavourInfo of the jet

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -106,10 +106,13 @@
    <field name="isCaloTowerCached_" transient="true"/>
    <field name="pfCandidatesTemp_" transient="true"/>
    <field name="isPFCandidateCached_" transient="true"/>
-   <version ClassVersion="12" checksum="398641970"/>
+   <version ClassVersion="12" checksum="862613450"/>
    <version ClassVersion="11" checksum="4153489469"/>
    <version ClassVersion="10" checksum="3393361159"/>
   </class>
+  <ioread sourceClass = "pat::Jet" version="[1-11]" targetClass="pat::Jet" source="int partonFlavour_" target="jetFlavourInfo_">
+    <![CDATA[jetFlavourInfo_ = reco::JetFlavourInfo(0,onfile.partonFlavour_);]]>
+  </ioread>
   <class name="pat::MET"  ClassVersion="10">
    <version ClassVersion="10" checksum="1136648776"/>
     <field name="uncorInfo_" transient="true"/>

--- a/PhysicsTools/PatAlgos/plugins/PATJetProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATJetProducer.cc
@@ -302,9 +302,12 @@ void PATJetProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
         ajet.setPartonFlavour( (*jetFlavMatch)[edm::RefToBase<reco::Jet>(jetRef)].getFlavour() );
     }
     else if (getJetMCFlavour_ && !useLegacyJetMCFlavour_) {
-        ajet.setPartonFlavour( (*jetFlavInfoMatch)[edm::RefToBase<reco::Jet>(jetRef)].getPartonFlavour() );
-        ajet.setHadronFlavour( (*jetFlavInfoMatch)[edm::RefToBase<reco::Jet>(jetRef)].getHadronFlavour() );
         if ( addJetFlavourInfo_ ) ajet.setJetFlavourInfo( (*jetFlavInfoMatch)[edm::RefToBase<reco::Jet>(jetRef)] );
+        else
+        {
+          ajet.setPartonFlavour( (*jetFlavInfoMatch)[edm::RefToBase<reco::Jet>(jetRef)].getPartonFlavour() );
+          ajet.setHadronFlavour( (*jetFlavInfoMatch)[edm::RefToBase<reco::Jet>(jetRef)].getHadronFlavour() );
+        }
     }
     // store the match to the generated partons
     if (addGenPartonMatch_) {

--- a/SimDataFormats/JetMatching/interface/JetFlavourInfo.h
+++ b/SimDataFormats/JetMatching/interface/JetFlavourInfo.h
@@ -53,6 +53,11 @@ class JetFlavourInfo
     /// Return the parton-based flavour
     const int getPartonFlavour() const { return m_partonFlavour; }
 
+    /// Set the hadron-based flavour
+    void setHadronFlavour(const int hadronFlavour) { m_hadronFlavour = hadronFlavour; }
+    /// Set the parton-based flavour
+    void setPartonFlavour(const int partonFlavour) { m_partonFlavour = partonFlavour; }
+
   private:
     GenParticleRefVector m_bHadrons;
     GenParticleRefVector m_cHadrons;


### PR DESCRIPTION
Backport of #3601
