### PR TITLE
cleanup of SIM core

### DIFF
--- a/SimG4Core/Application/interface/OscarMTProducer.h
+++ b/SimG4Core/Application/interface/OscarMTProducer.h
@@ -23,7 +23,7 @@ public:
   explicit OscarMTProducer(edm::ParameterSet const & p);
   virtual ~OscarMTProducer();
   virtual void beginRun(const edm::Run & r,const edm::EventSetup& c) override;
-  virtual void endRun(const edm::Run & r,const edm::EventSetup& c) override { }
+  virtual void endRun(const edm::Run & r,const edm::EventSetup& c) override;
   virtual void produce(edm::Event & e, const edm::EventSetup& c) override;
 
 private:

--- a/SimG4Core/Application/interface/OscarProducer.h
+++ b/SimG4Core/Application/interface/OscarProducer.h
@@ -23,7 +23,7 @@ public:
   explicit OscarProducer(edm::ParameterSet const & p);
   virtual ~OscarProducer();
   virtual void beginRun(const edm::Run & r,const edm::EventSetup& c) override;
-  virtual void endRun(const edm::Run & r,const edm::EventSetup& c) override { }
+  virtual void endRun(const edm::Run & r,const edm::EventSetup& c) override;
   virtual void produce(edm::Event & e, const edm::EventSetup& c) override;
 
 private:

--- a/SimG4Core/Application/interface/RunManager.h
+++ b/SimG4Core/Application/interface/RunManager.h
@@ -67,8 +67,11 @@ public:
   void initG4(const edm::EventSetup & es);
   void initializeUserActions();
   void initializeRun();
+
+  void stopG4();
   void terminateRun();
   void abortRun(bool softAbort=false);
+
   const G4Run * currentRun() const { return m_currentRun; }
   void produce(edm::Event& inpevt, const edm::EventSetup& es);
   void abortEvent();

--- a/SimG4Core/Application/interface/RunManagerMT.h
+++ b/SimG4Core/Application/interface/RunManagerMT.h
@@ -69,6 +69,8 @@ public:
   void initG4(const edm::EventSetup & es);
   void initializeUserActions();
   void initializeRun();
+
+  void stopG4();
   void terminateRun();
   void abortRun(bool softAbort=false);
   const G4Run * currentRun() const { return m_currentRun; }

--- a/SimG4Core/Application/interface/StackingAction.h
+++ b/SimG4Core/Application/interface/StackingAction.h
@@ -29,12 +29,17 @@ private:
   void initPointer();
 
   int  isItPrimaryDecayProductOrConversion(const G4Track*, const G4Track &) const;
+
   int  isItFromPrimary(const G4Track &, int) const;
+
   bool rrApplicable(const G4Track*, const G4Track&) const;
+
   bool isItLongLived(const G4Track*) const;
 
   bool isThisRegion(const G4Region*, std::vector<const G4Region*>&) const;
-  void printRegions(const std::vector<const G4Region*>& reg) const;
+
+  void printRegions(const std::vector<const G4Region*>& reg, 
+		    const std::string& word) const;
 
 private:
 

--- a/SimG4Core/Application/interface/SteppingAction.h
+++ b/SimG4Core/Application/interface/SteppingAction.h
@@ -8,13 +8,14 @@
 #include "G4Region.hh"
 #include "G4UserSteppingAction.hh"
 #include "G4VPhysicalVolume.hh"
+#include "G4Track.hh"
 
 #include <string>
 #include <vector>
 
 class EventAction;
 class G4VTouchable;
-class G4Track;
+//class G4Track;
 
 class SteppingAction: public G4UserSteppingAction {
 
@@ -30,13 +31,12 @@ private:
 
   bool initPointer();
 
-  bool catchLowEnergyInVacuum(G4Track * theTrack) const; 
-  bool killInsideDeadRegion(G4Track * theTrack) const;
-  bool catchLongLived(const G4Step * aStep) const;
+  bool killInsideDeadRegion(G4Track * theTrack, const G4Region* reg) const;
+  bool catchLongLived(G4Track* theTrack, const G4Region* reg) const;
   bool killLowEnergy(const G4Step * aStep) const;
-  bool isThisVolume(const G4VTouchable* touch, G4VPhysicalVolume* pv) const;
 
-  void PrintKilledTrack(const G4Track*, int type) const;
+  bool isThisVolume(const G4VTouchable* touch, G4VPhysicalVolume* pv) const;
+  void PrintKilledTrack(const G4Track*, const std::string&) const;
 
 private:
 

--- a/SimG4Core/Application/plugins/OscarMTProducer.cc
+++ b/SimG4Core/Application/plugins/OscarMTProducer.cc
@@ -137,6 +137,12 @@ OscarMTProducer::beginRun(const edm::Run & r, const edm::EventSetup & es)
   m_runManager->initG4(es);
 }
 
+void 
+OscarProducer::endRun(const edm::Run&, const edm::EventSetup&)
+{
+  m_runManager->stopG4();
+}
+
 void OscarMTProducer::produce(edm::Event & e, const edm::EventSetup & es)
 {
   StaticRandomEngineSetUnset random(e.streamID());
@@ -148,7 +154,7 @@ void OscarMTProducer::produce(edm::Event & e, const edm::EventSetup & es)
 
   try {
 
-    m_runManager->produce(e,es);
+    m_runManager->produce(e, es);
 
     std::auto_ptr<edm::SimTrackContainer> 
       p1(new edm::SimTrackContainer);

--- a/SimG4Core/Application/plugins/OscarProducer.cc
+++ b/SimG4Core/Application/plugins/OscarProducer.cc
@@ -130,11 +130,17 @@ OscarProducer::~OscarProducer()
 { }
 
 void 
-OscarProducer::beginRun(const edm::Run & r, const edm::EventSetup & es)
+OscarProducer::beginRun(const edm::Run&, const edm::EventSetup & es)
 {
   // Random number generation not allowed here
   StaticRandomEngineSetUnset random(nullptr);
   m_runManager->initG4(es);
+}
+
+void 
+OscarProducer::endRun(const edm::Run&, const edm::EventSetup&)
+{
+  m_runManager->stopG4();
 }
 
 void OscarProducer::produce(edm::Event & e, const edm::EventSetup & es)
@@ -148,7 +154,7 @@ void OscarProducer::produce(edm::Event & e, const edm::EventSetup & es)
 
   try {
 
-    m_runManager->produce(e,es);
+    m_runManager->produce(e, es);
 
     std::auto_ptr<edm::SimTrackContainer> 
       p1(new edm::SimTrackContainer);

--- a/SimG4Core/Application/python/NeutronBGforMuonsHP_cff.py
+++ b/SimG4Core/Application/python/NeutronBGforMuonsHP_cff.py
@@ -4,14 +4,25 @@ def customise(process):
 
     # fragment allowing to simulate neutron background in muon system
 
-    # time window 1 millisecond
-    process.common_maximum_time.MaxTrackTime = cms.double(1000000.0)
-
-    # Physics List HP
+  if hasattr(process,'g4SimHits'):
+    # time window 10 millisecond
+    process.common_maximum_time.MaxTrackTime = cms.double(100000000.0)
+    process.common_maximum_time.DeadRegions = cms.vstring()
+    # Physics List XS
     process.g4SimHits.Physics.type = cms.string('SimG4Core/Physics/FTFP_BERT_HP_EML')
-
+    # Eta cut
+    process.g4SimHits.Generator.MinEtaCut = cms.double(-7.0)
+    process.g4SimHits.Generator.MaxEtaCut = cms.double(7.0)
+    # stacking action
+    process.g4SimHits.StackingAction.MaxTrackTime = cms.double(100000000.0)
+    process.g4SimHits.StackingAction.DeadRegions = cms.vstring()
+    # stepping action
+    process.g4SimHits.SteppingAction.MaxTrackTime = cms.double(100000000.0)
+    process.g4SimHits.SteppingAction.DeadRegions = cms.vstring()
     # Russian roulette disabled
     process.g4SimHits.StackingAction.RusRoGammaEnergyLimit = cms.double(0.0)
     process.g4SimHits.StackingAction.RusRoNeutronEnergyLimit = cms.double(0.0)
+    # full simulation of HF 
+    process.g4SimHits.HFShower.UseHFGflash = cms.bool(False)
 
     return(process)

--- a/SimG4Core/Application/python/NeutronBGforMuonsXS_cff.py
+++ b/SimG4Core/Application/python/NeutronBGforMuonsXS_cff.py
@@ -4,15 +4,25 @@ def customise(process):
 
     # fragment allowing to simulate neutron background in muon system
 
-    # time window 1 millisecond
-    process.common_maximum_time.MaxTrackTime = cms.double(1000000.0)
-
+  if hasattr(process,'g4SimHits'):
+    # time window 10 millisecond
+    process.common_maximum_time.MaxTrackTime = cms.double(100000000.0)
+    process.common_maximum_time.DeadRegions = cms.vstring()
     # Physics List XS
     process.g4SimHits.Physics.type = cms.string('SimG4Core/Physics/FTFP_BERT_XS_EML')
-
+    # Eta cut
+    process.g4SimHits.Generator.MinEtaCut = cms.double(-7.0)
+    process.g4SimHits.Generator.MaxEtaCut = cms.double(7.0)
+    # stacking action
+    process.g4SimHits.StackingAction.MaxTrackTime = cms.double(100000000.0)
+    process.g4SimHits.StackingAction.DeadRegions = cms.vstring()
+    # stepping action
+    process.g4SimHits.SteppingAction.MaxTrackTime = cms.double(100000000.0)
+    process.g4SimHits.SteppingAction.DeadRegions = cms.vstring()
     # Russian roulette disabled
-
     process.g4SimHits.StackingAction.RusRoGammaEnergyLimit = cms.double(0.0)
     process.g4SimHits.StackingAction.RusRoNeutronEnergyLimit = cms.double(0.0)
+    # full simulation of HF 
+    process.g4SimHits.HFShower.UseHFGflash = cms.bool(False)
 
     return(process)

--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -344,7 +344,7 @@ g4SimHits = cms.EDProducer("OscarProducer",
         FillHisto       = cms.untracked.bool(True)
     ),
     CastorSD = cms.PSet(
-        useShowerLibrary               = cms.bool(True),
+        useShowerLibrary               = cms.bool(False),
         minEnergyInGeVforUsingSLibrary = cms.double(1.0),
         nonCompensationFactor          = cms.double(0.85),
         Verbosity                      = cms.untracked.int32(0)

--- a/SimG4Core/Application/src/RunAction.cc
+++ b/SimG4Core/Application/src/RunAction.cc
@@ -19,7 +19,6 @@ void RunAction::BeginOfRunAction(const G4Run * aRun)
     {
       edm::LogWarning("SimG4CoreApplication")
         << "BeginOfRunAction: termination signal received";
-      //std::cout << "BeginOfRunAction: termination signal received" << std::endl;
       m_runInterface->abortRun(true);
     }
     BeginOfRun r(aRun);
@@ -32,7 +31,6 @@ void RunAction::EndOfRunAction(const G4Run * aRun)
     {
       edm::LogWarning("SimG4CoreApplication")
         << "EndOfRunAction: termination signal received";
-      //std::cout << "EndOfRunAction: termination signal received" << std::endl;
       m_runInterface->abortRun(true);
     }
   EndOfRun r(aRun);

--- a/SimG4Core/Application/src/StackingAction.cc
+++ b/SimG4Core/Application/src/StackingAction.cc
@@ -117,13 +117,13 @@ StackingAction::StackingAction(const edm::ParameterSet & p)
                                        << " in Calo: " << savePDandCinCalo
                                        << " in Muon: " << savePDandCinMuon
                                        << " everywhere: " << savePDandCinAll
-				       << "\n               saveFirstSecondary"
+				       << "\n  saveFirstSecondary"
 				       << ": " << saveFirstSecondary
-				       << " Flag for tracking neutrino: "
+				       << " Tracking neutrino flag: "
 				       << trackNeutrino 
 				       << " Kill Delta Ray flag: "
 				       << killDeltaRay
-				       << " Killing Flag for hadrons/ions: "
+				       << " Kill hadrons/ions flag: "
 				       << killHeavy;
 
   if(killHeavy) {
@@ -144,6 +144,17 @@ StackingAction::StackingAction(const edm::ParameterSet & p)
 					   << maxTrackTimes[i] << " ns ";
       maxTrackTimes[i] *= ns;
     }
+  }
+  if(limitEnergyForVacuum > 0.0) {
+    edm::LogInfo("SimG4CoreApplication") 
+      << "StackingAction LowDensity regions - kill if E < " 
+      << limitEnergyForVacuum/MeV << " MeV";
+    printRegions(lowdensRegions,"LowDensity"); 
+  }
+  if(deadRegions.size() > 0.0) {
+    edm::LogInfo("SimG4CoreApplication") 
+      << "StackingAction Dead regions - kill all secondaries ";
+    printRegions(deadRegions, "Dead"); 
   }
   if(gRRactive) {
     edm::LogInfo("SimG4CoreApplication") 
@@ -183,27 +194,16 @@ StackingAction::StackingAction(const edm::ParameterSet & p)
   }
 
   if(savePDandCinTracker) {
-    edm::LogInfo("SimG4CoreApplication") << "StackingAction Tracker regions ";
-    printRegions(trackerRegions); 
+    edm::LogInfo("SimG4CoreApplication") << "StackingAction Tracker regions: ";
+    printRegions(trackerRegions,"Tracker"); 
   }
   if(savePDandCinCalo) {
-    edm::LogInfo("SimG4CoreApplication") << "StackingAction Calo regions ";
-    printRegions(caloRegions); 
+    edm::LogInfo("SimG4CoreApplication") << "StackingAction Calo regions: ";
+    printRegions(caloRegions, "Calo"); 
   }
   if(savePDandCinMuon) {
-    edm::LogInfo("SimG4CoreApplication") << "StackingAction Muon regions ";
-    printRegions(trackerRegions); 
-  }
-  if(limitEnergyForVacuum > 0.0) {
-    edm::LogInfo("SimG4CoreApplication") 
-      << "StackingAction Low-density regions - kill if E(MeV) < " 
-      << limitEnergyForVacuum/MeV;
-    printRegions(lowdensRegions); 
-  }
-  if(deadRegions.size() > 0.0) {
-    edm::LogInfo("SimG4CoreApplication") 
-      << "StackingAction Dead regions - kill all secondaries ";
-    printRegions(deadRegions); 
+    edm::LogInfo("SimG4CoreApplication") << "StackingAction Muon regions: ";
+    printRegions(muonRegions,"Muon"); 
   }
 }
 
@@ -563,12 +563,12 @@ bool StackingAction::isItLongLived(const G4Track * aTrack) const
   return flag;
 }
 
-void StackingAction::printRegions(const std::vector<const G4Region*>& reg) const 
+void StackingAction::printRegions(const std::vector<const G4Region*>& reg, 
+				  const std::string& word) const 
 {
-  G4ExceptionDescription ed;
-   
   for (unsigned int i=0; i<reg.size(); ++i) {
-    ed << "           " << i << ". " << reg[i]->GetName() << "\n";
+    edm::LogInfo("SimG4CoreApplication") << " StackingAction: " << word 
+					 << "Region " << i 
+					 << ". " << reg[i]->GetName();
   }
-  edm::LogInfo("SimG4CoreApplication") << ed;
 }

--- a/SimG4Core/Application/src/SteppingAction.cc
+++ b/SimG4Core/Application/src/SteppingAction.cc
@@ -1,3 +1,4 @@
+
 #include "SimG4Core/Application/interface/SteppingAction.h"
 #include "SimG4Core/Application/interface/EventAction.h"
 
@@ -5,7 +6,6 @@
 #include "G4ParticleTable.hh"
 #include "G4PhysicalVolumeStore.hh"
 #include "G4RegionStore.hh"
-#include "G4Track.hh"
 #include "G4UnitsTable.hh"
 #include "G4SystemOfUnits.hh"
 
@@ -52,13 +52,13 @@ SteppingAction::SteppingAction(EventAction* e, const edm::ParameterSet & p)
 
   ndeadRegions =  deadRegionNames.size();
   if(ndeadRegions > 0) {
-    G4ExceptionDescription ed;   
-    ed << "SteppingAction: Number of DeadRegions where all trackes are killed: "
-       << ndeadRegions << " \n" << "     ";
+    edm::LogInfo("SimG4CoreApplication") 
+      << "SteppingAction: Number of DeadRegions where all trackes are killed "
+      << ndeadRegions;
     for(unsigned int i=0; i<ndeadRegions; ++i) {
-      ed << deadRegionNames[i] << "   ";
+      edm::LogInfo("SimG4CoreApplication") 
+	<< "SteppingAction: DeadRegion " << i << ".  " << deadRegionNames[i];
     }
-    edm::LogInfo("SimG4CoreApplication") << ed;
   }
   numberEkins = ekinNames.size();
   numberPart  = ekinParticles.size();
@@ -93,24 +93,40 @@ void SteppingAction::UserSteppingAction(const G4Step * aStep)
 
   G4Track * theTrack = aStep->GetTrack();
   bool ok = (theTrack->GetTrackStatus() == fAlive);
-  if(ok && aStep->GetPostStepPoint()->GetPhysicalVolume() != 0) {
+  G4StepPoint* postStep = aStep->GetPostStepPoint();
+  if(ok && postStep->GetPhysicalVolume() != 0) {
 
-    G4double kinEnergy = theTrack->GetKineticEnergy();
+    G4StepPoint* preStep = aStep->GetPreStepPoint();
+    const G4Region* theRegion = 
+      preStep->GetPhysicalVolume()->GetLogicalVolume()->GetRegion();
 
-    if(ok && killBeamPipe && kinEnergy < theCriticalEnergyForVacuum
-	&& theTrack->GetDefinition()->GetPDGCharge() != 0.0 && kinEnergy > 0.0) {
-      ok = catchLowEnergyInVacuum(theTrack);
-    }
-    if(ok && 0 < ndeadRegions) { ok = killInsideDeadRegion(theTrack); }
-    if(ok) { ok = catchLongLived(aStep); }
+    // kill in dead regions
+    if(ok && 0 < ndeadRegions) { ok = killInsideDeadRegion(theTrack, theRegion); }
 
+    // kill out of time
+    if(ok) { ok = catchLongLived(theTrack, theRegion); }
+
+    // kill low-energy in volumes on demand
     if(ok && numberEkins > 0) { ok = killLowEnergy(aStep); }
 
+    // kill low-energy in vacuum
+    G4double kinEnergy = theTrack->GetKineticEnergy();
+    if(ok && killBeamPipe && kinEnergy < theCriticalEnergyForVacuum
+	&& theTrack->GetDefinition()->GetPDGCharge() != 0.0 && kinEnergy > 0.0
+        && theTrack->GetNextVolume()->GetLogicalVolume()->GetMaterial()->GetDensity() 
+       <= theCriticalDensity) {
+      theTrack->SetTrackStatus(fStopAndKill);
+#ifdef DebugLog
+      PrintKilledTrack(theTrack, "LE in vacuum"); 
+#endif
+      ok = false;
+    }
+
+    // check transition tracker/calo
     if(ok) {
 
-      G4StepPoint* preStep = aStep->GetPreStepPoint();
       if(isThisVolume(preStep->GetTouchable(),tracker) &&
-	 isThisVolume(aStep->GetPostStepPoint()->GetTouchable(),calo)) {
+	 isThisVolume(postStep->GetTouchable(),calo)) {
 
 	math::XYZVectorD pos((preStep->GetPosition()).x(),
 			     (preStep->GetPosition()).y(),
@@ -121,7 +137,7 @@ void SteppingAction::UserSteppingAction(const G4Step * aStep)
 				     (preStep->GetMomentum()).z(),
 				     preStep->GetTotalEnergy());
       
-	uint32_t id = aStep->GetTrack()->GetTrackID();
+	uint32_t id = theTrack->GetTrackID();
       
 	std::pair<math::XYZVectorD,math::XYZTLorentzVectorD> p(pos,mom);
 	eventAction_->addTkCaloStateInfo(id,p);
@@ -130,30 +146,16 @@ void SteppingAction::UserSteppingAction(const G4Step * aStep)
   }
 }
 
-bool SteppingAction::catchLowEnergyInVacuum(G4Track * theTrack) const
+bool SteppingAction::killInsideDeadRegion(G4Track * theTrack, 
+					  const G4Region* reg) const
 {
   bool alive = true;
-  if (theTrack->GetNextVolume()->GetLogicalVolume()->GetMaterial()->GetDensity() 
-      <= theCriticalDensity) {
-    theTrack->SetTrackStatus(fStopAndKill);
-#ifdef DebugLog
-    PrintKilledTrack(theTrack, 0); 
-#endif
-    alive = false;
-  }
-  return alive;
-}
-
-bool SteppingAction::killInsideDeadRegion(G4Track * theTrack) const
-{
-  bool alive = true;
-  const G4Region* reg = theTrack->GetNextVolume()->GetLogicalVolume()->GetRegion();
   for(unsigned int i=0; i<ndeadRegions; ++i) {
     if(reg == deadRegions[i]) {
       alive = false;    
       theTrack->SetTrackStatus(fStopAndKill);
 #ifdef DebugLog
-      PrintKilledTrack(theTrack, 0); 
+      PrintKilledTrack(theTrack, "dead region"); 
 #endif
       break;
     }
@@ -161,14 +163,12 @@ bool SteppingAction::killInsideDeadRegion(G4Track * theTrack) const
   return alive;
 }
 
-bool SteppingAction::catchLongLived(const G4Step * aStep) const
+bool SteppingAction::catchLongLived(G4Track* theTrack, const G4Region* reg) const
 {
   bool flag   = true;
   double tofM = maxTrackTime;
 
   if(numberTimes > 0) {
-    G4Region* reg = 
-      aStep->GetPreStepPoint()->GetPhysicalVolume()->GetLogicalVolume()->GetRegion();
     for (unsigned int i=0; i<numberTimes; ++i) {
       if (reg == maxTimeRegions[i]) {
 	tofM = maxTrackTimes[i];
@@ -176,10 +176,10 @@ bool SteppingAction::catchLongLived(const G4Step * aStep) const
       }
     }
   }
-  if (aStep->GetPostStepPoint()->GetGlobalTime() > tofM) {
-    aStep->GetTrack()->SetTrackStatus(fStopAndKill);
+  if (theTrack->GetGlobalTime() > tofM) {
+    theTrack->SetTrackStatus(fStopAndKill);
 #ifdef DebugLog
-    PrintKilledTrack(aStep->GetTrack(), 1); 
+    PrintKilledTrack(theTrack, "out of time"); 
 #endif
     flag = false;
   }
@@ -212,7 +212,7 @@ bool SteppingAction::killLowEnergy(const G4Step * aStep) const
     if (ekin <= ekinM) {
       track->SetTrackStatus(fStopAndKill);
 #ifdef DebugLog
-      PrintKilledTrack(track, 2);
+      PrintKilledTrack(track, "low-energy");
 #endif
       ok = false;
     }
@@ -223,14 +223,12 @@ bool SteppingAction::killLowEnergy(const G4Step * aStep) const
 bool SteppingAction::isThisVolume(const G4VTouchable* touch, 
 				  G4VPhysicalVolume* pv) const
 {
-  int level = ((touch->GetHistoryDepth())+1);
-  if (level > 0 && level >= 3) {
-    unsigned int ii = (unsigned int)(level - 3);
-    return (touch->GetVolume(ii) == pv);
-  }
-  return false;
+  bool res = false;
+  int level = (touch->GetHistoryDepth())+1;
+  if (level >= 3) { res = (touch->GetVolume(level - 3) == pv); }
+  return res;
 }
-  
+
 bool SteppingAction::initPointer() 
 {
   const G4PhysicalVolumeStore * pvs = G4PhysicalVolumeStore::GetInstance();
@@ -241,12 +239,14 @@ bool SteppingAction::initPointer()
       if ((*pvcite)->GetName() == "CALO")    calo    = (*pvcite);
       if (tracker && calo) break;
     }
-    edm::LogInfo("SimG4CoreApplication") << "Pointer for Tracker " << tracker
-					 << " and for Calo " << calo;
-    if (tracker) LogDebug("SimG4CoreApplication") << "Tracker vol name "
-						  << tracker->GetName();
-    if (calo)    LogDebug("SimG4CoreApplication") << "Calorimeter vol name "
-						  << calo->GetName();
+    if (tracker || calo) {
+      edm::LogInfo("SimG4CoreApplication") << "Pointer for Tracker " << tracker
+					   << " and for Calo " << calo;
+      if (tracker) LogDebug("SimG4CoreApplication") << "Tracker vol name "
+						    << tracker->GetName();
+      if (calo)    LogDebug("SimG4CoreApplication") << "Calorimeter vol name "
+						    << calo->GetName();
+    }
   }
 
   const G4LogicalVolumeStore * lvs = G4LogicalVolumeStore::GetInstance();
@@ -265,7 +265,7 @@ bool SteppingAction::initPointer()
     }
     for (unsigned int i=0; i<numberEkins; ++i) {
       edm::LogInfo("SimG4CoreApplication") << ekinVolumes[i]->GetName()
-					   <<" with pointer " <<ekinVolumes[i];
+					   <<" with pointer " << ekinVolumes[i];
     }
   }
 
@@ -277,9 +277,9 @@ bool SteppingAction::initPointer()
       ekinPDG[i] = 
 	theParticleTable->FindParticle(partName=ekinParticles[i])->GetPDGEncoding();
       edm::LogInfo("SimG4CoreApplication") << "Particle " << ekinParticles[i]
-					 << " with PDG code " << ekinPDG[i]
-					 << " and KE cut off " 
-					 << ekinMins[i]/MeV << " MeV";
+					   << " with PDG code " << ekinPDG[i]
+					   << " and KE cut off " 
+					   << ekinMins[i]/MeV << " MeV";
     }
   }
 
@@ -311,12 +311,9 @@ bool SteppingAction::initPointer()
   return true;
 }
 
-void SteppingAction::PrintKilledTrack(const G4Track* aTrack, int type) const
+void SteppingAction::PrintKilledTrack(const G4Track* aTrack, 
+				      const std::string& typ) const
 {
-  const std::string ktypes[4] = {" LE in vacuum "," ToF "," LE in region "," ? "};
-  int idx = type;
-  if(type > 3) { idx = 3; }
-
   std::string vname = "";
   std::string rname = "";
   G4VPhysicalVolume* pv = aTrack->GetNextVolume();
@@ -329,7 +326,7 @@ void SteppingAction::PrintKilledTrack(const G4Track* aTrack, int type) const
     << "Track #" << aTrack->GetTrackID()
     << " " << aTrack->GetDefinition()->GetParticleName()
     << " E(MeV)= " << aTrack->GetKineticEnergy()/MeV 
-    << " is killed due to " << ktypes[idx] 
+    << " is killed due to " << typ
     << " inside LV: " << vname << " (" << rname
     << ") at " << aTrack->GetPosition();
 }


### PR DESCRIPTION
Clean-up of SIM core : improved info messages, removed unused variables/methods.

SteppingAction and StackingAction classes were optimized which bring few % speed-up.

The default g4SimHits configuration disable Castor and CastorShowerLibrary. Custom fragments for background study enable full simulation inside HF and Castor, disable RR, extends eta cuts, and the time cut. 
