### PR TITLE
CLANG warning cleanup

### DIFF
--- a/DataFormats/FWLite/test/test.cppunit.cpp
+++ b/DataFormats/FWLite/test/test.cppunit.cpp
@@ -238,7 +238,8 @@ void testRefInROOT::testRefFirst()
     for(edmtest::OtherThingCollection::const_iterator itOther=pOthers->begin(), itEnd=pOthers->end() ;
         itOther != itEnd; ++itOther) {
       //std::cout <<"getting ref"<<std::endl;
-      std:: cout << itOther->ref.get()->a << "\n";
+      int arbitraryBigNumber = 1000000; 
+      CPPUNIT_ASSERT(itOther->ref.get()->a < arbitraryBigNumber);
     }
     //std::cout <<"get all Refs"<<std::endl;
     

--- a/DataFormats/FWLite/test/test.cppunit.cpp
+++ b/DataFormats/FWLite/test/test.cppunit.cpp
@@ -238,7 +238,7 @@ void testRefInROOT::testRefFirst()
     for(edmtest::OtherThingCollection::const_iterator itOther=pOthers->begin(), itEnd=pOthers->end() ;
         itOther != itEnd; ++itOther) {
       //std::cout <<"getting ref"<<std::endl;
-      itOther->ref.get()->a;
+      std:: cout << itOther->ref.get()->a << "\n";
     }
     //std::cout <<"get all Refs"<<std::endl;
     

--- a/FWCore/FWLite/bin/storageSize.cc
+++ b/FWCore/FWLite/bin/storageSize.cc
@@ -27,7 +27,6 @@
 static char const* const kClassNameOpt = "className";
 static char const* const kHelpOpt = "help";
 static char const* const kHelpCommandOpt="help,h";
-static char const* const kProgramName = "edmClassStorageSize";
 
 
 int main(int argc, char* argv[]) try

--- a/FWCore/FWLite/bin/storageSizeForBranch.cc
+++ b/FWCore/FWLite/bin/storageSizeForBranch.cc
@@ -31,7 +31,6 @@ static char const* const kBranchNameOpt = "branchName";
 static char const* const kFileNameOpt = "fileName";
 static char const* const kHelpOpt = "help";
 static char const* const kHelpCommandOpt="help,h";
-static char const* const kProgramName = "edmBranchStorageSize";
 static char const* const kEntryNumberCommandOpt = "entryNumber,e";
 static char const* const kEntryNumberOpt = "entryNumber";
 

--- a/IOPool/Common/bin/EdmProvDump.cc
+++ b/IOPool/Common/bin/EdmProvDump.cc
@@ -1068,7 +1068,6 @@ static char const* const kShowTopLevelPSetsCommandOpt ="showTopLevelPSets,t";
 static char const* const kHelpOpt = "help";
 static char const* const kHelpCommandOpt = "help,h";
 static char const* const kFileNameOpt = "input-file";
-static char const* const kFileNameCommandOpt = "input-file";
 
 int main(int argc, char* argv[]) {
   using namespace boost::program_options;


### PR DESCRIPTION
Cleanup some CLANG compiler warning in Core
packages related to unused variables and expressions.
