### PR TITLE
First implementation of SiStrip Gain computation @ PCL at Tier0

### DIFF
--- a/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromCalibTree.cc
+++ b/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromCalibTree.cc
@@ -703,16 +703,25 @@ void SiStripGainFromCalibTree::storeOnTree()
 
 bool SiStripGainFromCalibTree::produceTagFilter(){
    // The goal of this function is to check wether or not there is enough statistics to produce a meaningful tag for the DB or not 
-   if(Charge_Vs_Index->getTH2F()->Integral() < 2E8);return false;
-   if((1.0 * GOOD) / (GOOD+BAD) < 0.95); return false;
+  if(Charge_Vs_Index->getTH2F()->Integral() < 2E8) {
+    cout << "[SiStripGainFromCalibTree]produceTagFilter -> will not produce a paylaod because integral of statistics is: " << Charge_Vs_Index->getTH2F()->Integral() << endl;
+    setDoStore(false);
+    return false;
+  }
+  if((1.0 * GOOD) / (GOOD+BAD) < 0.95) {
+    setDoStore(false);
+    cout << "[SiStripGainFromCalibTree]produceTagFilter -> will not produce a paylaod because ration of GOOD/TOTAL: " << (1.0 * GOOD) / (GOOD+BAD) << endl;
+    return false;
+  }
    return true; 
 }
 
 SiStripApvGain* SiStripGainFromCalibTree::getNewObject() 
 {
-   if(!produceTagFilter())return NULL;
-
    SiStripApvGain* obj = new SiStripApvGain();
+   if(!produceTagFilter()) return obj;
+
+
    std::vector<float>* theSiStripVector = NULL;
    unsigned int PreviousDetId = 0; 
    for(unsigned int a=0;a<APVsCollOrdered.size();a++)

--- a/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromCalibTree.cc
+++ b/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromCalibTree.cc
@@ -137,7 +137,7 @@ class SiStripGainFromCalibTree : public ConditionDBWriter<SiStripApvGain> {
       edm::Service<TFileService> tfs;
 
   DQMStore* dbe;
-  
+  bool harvestingMode;
 
       double       MinNrEntries;
       double       MaxMPVError;
@@ -182,6 +182,8 @@ class SiStripGainFromCalibTree : public ConditionDBWriter<SiStripApvGain> {
       unsigned int GOOD;
       unsigned int BAD;
 
+  
+
    private :
       class isEqual{
          public:
@@ -219,7 +221,7 @@ SiStripGainFromCalibTree::SiStripGainFromCalibTree(const edm::ParameterSet& iCon
 
    useCalibration      = iConfig.getUntrackedParameter<bool>("UseCalibration", false);
    m_calibrationPath   = iConfig.getUntrackedParameter<string>("calibrationPath");
-
+   harvestingMode      = iConfig.getUntrackedParameter<bool>("harvestingMode", false);
 
    dbe = edm::Service<DQMStore>().operator->();
 
@@ -229,21 +231,35 @@ void SiStripGainFromCalibTree::algoBeginRun(const edm::Run& run, const edm::Even
 //void SiStripGainFromCalibTree::algoBeginJob(const edm::EventSetup& iSetup)
 {
   
-  // FIXME: add a swithc: if the histos are not booked should be just retrieved from DQMStore so that tehy can be used in the fit
+  if(!harvestingMode) {
+    // FIXME: decide what should be the folder name following the convention already there for ALCARECOS
+    dbe->setCurrentFolder("AlCaReco/SiStripGains/");
 
-  // FIXME: decide what should be the folder name following the convention already there for ALCARECOS
-  dbe->setCurrentFolder("AlCaReco/SiStripGains/");
+    Charge_Vs_Index           = dbe->book2D("Charge_Vs_Index"          , "Charge_Vs_Index"          , 72785, 0   , 72784,1000,0,2000);
+    Charge_Vs_Index_Absolute  = dbe->book2D("Charge_Vs_Index_Absolute" , "Charge_Vs_Index_Absolute" , 72785, 0   , 72784, 500,0,2000);
+    Charge_Vs_PathlengthTIB   = dbe->book2D("Charge_Vs_PathlengthTIB"  , "Charge_Vs_PathlengthTIB"  , 20   , 0.3 , 1.3  , 250,0,2000);
+    Charge_Vs_PathlengthTOB   = dbe->book2D("Charge_Vs_PathlengthTOB"  , "Charge_Vs_PathlengthTOB"  , 20   , 0.3 , 1.3  , 250,0,2000);
+    Charge_Vs_PathlengthTIDP  = dbe->book2D("Charge_Vs_PathlengthTIDP" , "Charge_Vs_PathlengthTIDP" , 20   , 0.3 , 1.3  , 250,0,2000);
+    Charge_Vs_PathlengthTIDM  = dbe->book2D("Charge_Vs_PathlengthTIDM" , "Charge_Vs_PathlengthTIDM" , 20   , 0.3 , 1.3  , 250,0,2000);
+    Charge_Vs_PathlengthTECP1 = dbe->book2D("Charge_Vs_PathlengthTECP1", "Charge_Vs_PathlengthTECP1", 20   , 0.3 , 1.3  , 250,0,2000);
+    Charge_Vs_PathlengthTECP2 = dbe->book2D("Charge_Vs_PathlengthTECP2", "Charge_Vs_PathlengthTECP2", 20   , 0.3 , 1.3  , 250,0,2000);
+    Charge_Vs_PathlengthTECM1 = dbe->book2D("Charge_Vs_PathlengthTECM1", "Charge_Vs_PathlengthTECM1", 20   , 0.3 , 1.3  , 250,0,2000);
+    Charge_Vs_PathlengthTECM2 = dbe->book2D("Charge_Vs_PathlengthTECM2", "Charge_Vs_PathlengthTECM2", 20   , 0.3 , 1.3  , 250,0,2000);
+  } else {
+    // When running in AlCaHarvesting mode the histos are already booked and should be just retrieved from
+    // DQMStore so that they can be used in the fit
+    Charge_Vs_Index           = dbe->get("AlCaReco/SiStripGains/Charge_Vs_Index");
+    Charge_Vs_Index_Absolute  = dbe->get("AlCaReco/SiStripGains/Charge_Vs_Index_Absolute");
+    Charge_Vs_PathlengthTIB   = dbe->get("AlCaReco/SiStripGains/Charge_Vs_PathlengthTIB");
+    Charge_Vs_PathlengthTOB   = dbe->get("AlCaReco/SiStripGains/Charge_Vs_PathlengthTOB");
+    Charge_Vs_PathlengthTIDP  = dbe->get("AlCaReco/SiStripGains/Charge_Vs_PathlengthTIDP");
+    Charge_Vs_PathlengthTIDM  = dbe->get("AlCaReco/SiStripGains/Charge_Vs_PathlengthTIDM");
+    Charge_Vs_PathlengthTECP1 = dbe->get("AlCaReco/SiStripGains/Charge_Vs_PathlengthTECP1");
+    Charge_Vs_PathlengthTECP2 = dbe->get("AlCaReco/SiStripGains/Charge_Vs_PathlengthTECP2");
+    Charge_Vs_PathlengthTECM1 = dbe->get("AlCaReco/SiStripGains/Charge_Vs_PathlengthTECM1");
+    Charge_Vs_PathlengthTECM2 = dbe->get("AlCaReco/SiStripGains/Charge_Vs_PathlengthTECM2");
 
-   Charge_Vs_Index           = dbe->book2D("Charge_Vs_Index"          , "Charge_Vs_Index"          , 72785, 0   , 72784,1000,0,2000);
-   Charge_Vs_Index_Absolute  = dbe->book2D("Charge_Vs_Index_Absolute" , "Charge_Vs_Index_Absolute" , 72785, 0   , 72784, 500,0,2000);
-   Charge_Vs_PathlengthTIB   = dbe->book2D("Charge_Vs_PathlengthTIB"  , "Charge_Vs_PathlengthTIB"  , 20   , 0.3 , 1.3  , 250,0,2000);
-   Charge_Vs_PathlengthTOB   = dbe->book2D("Charge_Vs_PathlengthTOB"  , "Charge_Vs_PathlengthTOB"  , 20   , 0.3 , 1.3  , 250,0,2000);
-   Charge_Vs_PathlengthTIDP  = dbe->book2D("Charge_Vs_PathlengthTIDP" , "Charge_Vs_PathlengthTIDP" , 20   , 0.3 , 1.3  , 250,0,2000);
-   Charge_Vs_PathlengthTIDM  = dbe->book2D("Charge_Vs_PathlengthTIDM" , "Charge_Vs_PathlengthTIDM" , 20   , 0.3 , 1.3  , 250,0,2000);
-   Charge_Vs_PathlengthTECP1 = dbe->book2D("Charge_Vs_PathlengthTECP1", "Charge_Vs_PathlengthTECP1", 20   , 0.3 , 1.3  , 250,0,2000);
-   Charge_Vs_PathlengthTECP2 = dbe->book2D("Charge_Vs_PathlengthTECP2", "Charge_Vs_PathlengthTECP2", 20   , 0.3 , 1.3  , 250,0,2000);
-   Charge_Vs_PathlengthTECM1 = dbe->book2D("Charge_Vs_PathlengthTECM1", "Charge_Vs_PathlengthTECM1", 20   , 0.3 , 1.3  , 250,0,2000);
-   Charge_Vs_PathlengthTECM2 = dbe->book2D("Charge_Vs_PathlengthTECM2", "Charge_Vs_PathlengthTECM2", 20   , 0.3 , 1.3  , 250,0,2000);
+  }
 
    edm::ESHandle<TrackerGeometry> tkGeom;
    iSetup.get<TrackerDigiGeometryRecord>().get( tkGeom );
@@ -335,9 +351,14 @@ void
 SiStripGainFromCalibTree::algoEndJob() {
    printf("EndJob\n");
    if(AlgoMode=="CalibTree")algoAnalyzeTheTree();
-   algoComputeMPVandGain();
-   storeOnTree();
-
+   // FIXME: here put the switch to run the harvesting mode
+   
+   if(harvestingMode) {
+     // these methods are run only in "AlCaHarvesting" mode once the full statistics out of the parallel jobs is
+     // harvested and available in the MEs
+     algoComputeMPVandGain();
+     storeOnTree();
+   }
 }
 
 
@@ -750,6 +771,9 @@ void SiStripGainFromCalibTree::MakeCalibrationMap(){
 void
 SiStripGainFromCalibTree::algoAnalyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
+  // in AlCaHarvesting mode we just need to run the logic in the endJob step
+  if(harvestingMode) return;
+  
    if(AlgoMode=="CalibTree")return;
 
    if(NEvent==0){

--- a/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromCalibTree.cc
+++ b/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromCalibTree.cc
@@ -59,8 +59,6 @@
 #include "CalibFormats/SiStripObjects/interface/SiStripQuality.h"
 #include "CalibTracker/Records/interface/SiStripQualityRcd.h"
 
-#include "DQMServices/Core/interface/DQMStore.h"
-#include "DQMServices/Core/interface/MonitorElement.h"
 
 #include "TFile.h"
 #include "TObjString.h"
@@ -230,8 +228,9 @@ SiStripGainFromCalibTree::SiStripGainFromCalibTree(const edm::ParameterSet& iCon
 void SiStripGainFromCalibTree::algoBeginRun(const edm::Run& run, const edm::EventSetup& iSetup)
 //void SiStripGainFromCalibTree::algoBeginJob(const edm::EventSetup& iSetup)
 {
-  
+  cout << "algoBeginRun start" << endl;
   if(!harvestingMode) {
+    cout << "   booking start" << endl;
     // FIXME: decide what should be the folder name following the convention already there for ALCARECOS
     dbe->setCurrentFolder("AlCaReco/SiStripGains/");
 
@@ -246,6 +245,7 @@ void SiStripGainFromCalibTree::algoBeginRun(const edm::Run& run, const edm::Even
     Charge_Vs_PathlengthTECM1 = dbe->book2D("Charge_Vs_PathlengthTECM1", "Charge_Vs_PathlengthTECM1", 20   , 0.3 , 1.3  , 250,0,2000);
     Charge_Vs_PathlengthTECM2 = dbe->book2D("Charge_Vs_PathlengthTECM2", "Charge_Vs_PathlengthTECM2", 20   , 0.3 , 1.3  , 250,0,2000);
   } else {
+    cout << "   retrieving from DQMStore" << endl;
     // When running in AlCaHarvesting mode the histos are already booked and should be just retrieved from
     // DQMStore so that they can be used in the fit
     Charge_Vs_Index           = dbe->get("AlCaReco/SiStripGains/Charge_Vs_Index");
@@ -295,7 +295,7 @@ void SiStripGainFromCalibTree::algoBeginRun(const edm::Run& run, const edm::Even
           for(unsigned int j=0;j<NAPV;j++){
                 stAPVGain* APV = new stAPVGain;
                 APV->Index         = Index;
-                APV->Bin           = Charge_Vs_Index->getRefTH2D()->GetXaxis()->FindBin(APV->Index);
+                APV->Bin           = Charge_Vs_Index->getTH2F()->GetXaxis()->FindBin(APV->Index);
                 APV->DetId         = Detid.rawId();
                 APV->APVId         = j;
                 APV->SubDet        = SubDet;
@@ -339,6 +339,8 @@ void SiStripGainFromCalibTree::algoBeginRun(const edm::Run& run, const edm::Even
    ERun       = 0;
    GOOD       = 0;
    BAD        = 0;
+   
+   cout << "algoBeginJob end" << endl;
 }
 
 
@@ -546,7 +548,7 @@ void SiStripGainFromCalibTree::algoAnalyzeTheTree()
 
 void SiStripGainFromCalibTree::algoComputeMPVandGain() {
    unsigned int I=0;
-   TH1D* Proj = NULL;
+   TH1F* Proj = NULL;
    double FitResults[5];
    double MPVmean = 300;
 
@@ -558,7 +560,7 @@ void SiStripGainFromCalibTree::algoComputeMPVandGain() {
    //if(I>1000)break;
       stAPVGain* APV = it->second;
 
-      Proj = (TH1D*)(Charge_Vs_Index->getRefTH2D()->ProjectionY("",APV->Bin,APV->Bin,"e"));
+      Proj = (TH1F*)(Charge_Vs_Index->getTH2F()->ProjectionY("",APV->Bin,APV->Bin,"e"));
       if(!Proj)continue;
 
       if(CalibrationLevel==0){
@@ -566,7 +568,7 @@ void SiStripGainFromCalibTree::algoComputeMPVandGain() {
          int SecondAPVId = APV->APVId;
          if(SecondAPVId%2==0){    SecondAPVId = SecondAPVId+1; }else{ SecondAPVId = SecondAPVId-1; }
 	 stAPVGain* APV2 = APVsColl[(APV->DetId<<3) | SecondAPVId];
-         TH1D* Proj2 = (TH1D*)(Charge_Vs_Index->getRefTH2D()->ProjectionY("",APV2->Bin,APV2->Bin,"e"));
+         TH1F* Proj2 = (TH1F*)(Charge_Vs_Index->getTH2F()->ProjectionY("",APV2->Bin,APV2->Bin,"e"));
          if(Proj2){Proj->Add(Proj2,1);delete Proj2;}
       }else if(CalibrationLevel==2){
           for(unsigned int i=0;i<6;i++){
@@ -575,7 +577,7 @@ void SiStripGainFromCalibTree::algoComputeMPVandGain() {
             if(tmpit==APVsColl.end())continue;
             stAPVGain* APV2 = tmpit->second;
 	    if(APV2->DetId != APV->DetId || APV2->APVId == APV->APVId)continue;            
-            TH1D* Proj2 = (TH1D*)(Charge_Vs_Index->getRefTH2D()->ProjectionY("",APV2->Bin,APV2->Bin,"e"));
+            TH1F* Proj2 = (TH1F*)(Charge_Vs_Index->getTH2F()->ProjectionY("",APV2->Bin,APV2->Bin,"e"));
 //            if(Proj2 && APV->DetId==369171124)printf("B) DetId %6i APVId %1i --> NEntries = %f\n",APV2->DetId, APV2->APVId, Proj2->GetEntries());
             if(Proj2){Proj->Add(Proj2,1);delete Proj2;}
           }          
@@ -772,6 +774,7 @@ void
 SiStripGainFromCalibTree::algoAnalyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
   // in AlCaHarvesting mode we just need to run the logic in the endJob step
+  cout << "ANALYZE" << endl;
   if(harvestingMode) return;
   
    if(AlgoMode=="CalibTree")return;

--- a/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromCalibTree.cc
+++ b/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromCalibTree.cc
@@ -59,6 +59,8 @@
 #include "CalibFormats/SiStripObjects/interface/SiStripQuality.h"
 #include "CalibTracker/Records/interface/SiStripQualityRcd.h"
 
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
 
 #include "TFile.h"
 #include "TObjString.h"
@@ -133,6 +135,9 @@ class SiStripGainFromCalibTree : public ConditionDBWriter<SiStripApvGain> {
 
       SiStripApvGain* getNewObject() override;
       edm::Service<TFileService> tfs;
+
+  DQMStore* dbe;
+  
 
       double       MinNrEntries;
       double       MaxMPVError;
@@ -216,11 +221,19 @@ SiStripGainFromCalibTree::SiStripGainFromCalibTree(const edm::ParameterSet& iCon
    m_calibrationPath   = iConfig.getUntrackedParameter<string>("calibrationPath");
 
 
+   dbe = edm::Service<DQMStore>().operator->();
+
 }
 
 void SiStripGainFromCalibTree::algoBeginRun(const edm::Run& run, const edm::EventSetup& iSetup)
 //void SiStripGainFromCalibTree::algoBeginJob(const edm::EventSetup& iSetup)
 {
+  
+  // FIXME: add a swithc: if the histos are not booked should be just retrieved from DQMStore so that tehy can be used in the fit
+
+  // FIXME: decide what should be the folder name following the convention already there for ALCARECOS
+  dbe->setCurrentFolder("AlCaReco/SiStripGains/");
+  //dbe->book1D(histoName,histoTitle, maxTDCCounts/timeBoxGranularity, 0, maxTDCCounts);
    Charge_Vs_Index           = tfs->make<TH2F>("Charge_Vs_Index"          , "Charge_Vs_Index"          , 72785, 0   , 72784,1000,0,2000);
    Charge_Vs_Index_Absolute  = tfs->make<TH2F>("Charge_Vs_Index_Absolute" , "Charge_Vs_Index_Absolute" , 72785, 0   , 72784, 500,0,2000);
    Charge_Vs_PathlengthTIB   = tfs->make<TH2F>("Charge_Vs_PathlengthTIB"  , "Charge_Vs_PathlengthTIB"  , 20   , 0.3 , 1.3  , 250,0,2000);

--- a/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromCalibTree.cc
+++ b/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromCalibTree.cc
@@ -33,6 +33,7 @@
 #include "DataFormats/FEDRawData/interface/FEDNumbering.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit1D.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2D.h"
 #include "DataFormats/SiStripDetId/interface/SiStripSubStructure.h"
@@ -115,6 +116,7 @@ class SiStripGainFromCalibTree : public ConditionDBWriter<SiStripApvGain> {
 
 
    private:
+
       virtual void algoBeginJob      (const edm::EventSetup&) override;
       virtual void algoEndJob        () override;
       virtual void algoAnalyze       (const edm::Event &, const edm::EventSetup &) override;
@@ -122,10 +124,10 @@ class SiStripGainFromCalibTree : public ConditionDBWriter<SiStripApvGain> {
               void algoAnalyzeTheTree();
               void algoComputeMPVandGain();
 
+              bool IsFarFromBorder(TrajectoryStateOnSurface* trajState, const uint32_t detid, const edm::EventSetup* iSetup);
               void getPeakOfLandau(TH1* InputHisto, double* FitResults, double LowRange=50, double HighRange=5400);
               bool IsGoodLandauFit(double* FitResults); 
               void storeOnTree();
-
               void MakeCalibrationMap();
 
 
@@ -151,6 +153,8 @@ class SiStripGainFromCalibTree : public ConditionDBWriter<SiStripApvGain> {
       bool         useCalibration;
       string       m_calibrationPath;
 
+      edm::InputTag theTracksLabel;
+      std::string  AlgoMode;
       std::string  OutputGains;
       vector<string> VInputFiles;
 
@@ -186,7 +190,9 @@ class SiStripGainFromCalibTree : public ConditionDBWriter<SiStripApvGain> {
 SiStripGainFromCalibTree::SiStripGainFromCalibTree(const edm::ParameterSet& iConfig) : ConditionDBWriter<SiStripApvGain>(iConfig)
 {
    OutputGains         = iConfig.getParameter<std::string>("OutputGains");
+   theTracksLabel      = iConfig.getUntrackedParameter<edm::InputTag>("Tracks");
 
+   AlgoMode            = iConfig.getUntrackedParameter<std::string>("AlgoMode", "CalibTree");
    MinNrEntries        = iConfig.getUntrackedParameter<double>  ("minNrEntries"       ,  20);
    MaxMPVError         = iConfig.getUntrackedParameter<double>  ("maxMPVError"        ,  500.0);
    MaxChi2OverNDF      = iConfig.getUntrackedParameter<double>  ("maxChi2OverNDF"     ,  5.0);
@@ -212,11 +218,8 @@ SiStripGainFromCalibTree::SiStripGainFromCalibTree(const edm::ParameterSet& iCon
 
 }
 
-
-
-
-void
-SiStripGainFromCalibTree::algoBeginJob(const edm::EventSetup& iSetup)
+void SiStripGainFromCalibTree::algoBeginRun(const edm::Run& run, const edm::EventSetup& iSetup)
+//void SiStripGainFromCalibTree::algoBeginJob(const edm::EventSetup& iSetup)
 {
    Charge_Vs_Index           = tfs->make<TH2F>("Charge_Vs_Index"          , "Charge_Vs_Index"          , 72785, 0   , 72784,1000,0,2000);
    Charge_Vs_Index_Absolute  = tfs->make<TH2F>("Charge_Vs_Index_Absolute" , "Charge_Vs_Index_Absolute" , 72785, 0   , 72784, 500,0,2000);
@@ -287,7 +290,7 @@ SiStripGainFromCalibTree::algoBeginJob(const edm::EventSetup& iSetup)
 		if(!FirstSetOfConstants){
 		   if(gainHandle->getNumberOfTags()!=2){printf("ERROR: NUMBER OF GAIN TAG IS EXPECTED TO BE 2\n");fflush(stdout);exit(0);};		   
 		   APV->PreviousGain  = gainHandle->getApvGain(APV->APVId,gainHandle->getRange(APV->DetId, 1),1);
-                   printf("DETID = %7i APVID=%1i Previous Gain=%8.4f\n",APV->DetId,APV->APVId,APV->PreviousGain);
+                   //printf("DETID = %7i APVID=%1i Previous Gain=%8.4f\n",APV->DetId,APV->APVId,APV->PreviousGain);
 		}
 
                 APVsCollOrdered.push_back(APV);
@@ -307,19 +310,21 @@ SiStripGainFromCalibTree::algoBeginJob(const edm::EventSetup& iSetup)
    ERun       = 0;
    GOOD       = 0;
    BAD        = 0;
-
-   algoAnalyzeTheTree();
-   algoComputeMPVandGain();
 }
 
 
-void
-SiStripGainFromCalibTree::algoAnalyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-}
+//void
+//SiStripGainFromCalibTree::algoAnalyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
+//{   
+//}
 
 void 
 SiStripGainFromCalibTree::algoEndJob() {
+   printf("EndJob\n");
+   if(AlgoMode=="CalibTree")algoAnalyzeTheTree();
+   algoComputeMPVandGain();
+   storeOnTree();
+
 }
 
 
@@ -349,9 +354,9 @@ void SiStripGainFromCalibTree::getPeakOfLandau(TH1* InputHisto, double* FitResul
 }
 
 bool SiStripGainFromCalibTree::IsGoodLandauFit(double* FitResults){
-   if(FitResults[0] < 2             )return false;
-   if(FitResults[1] > MaxMPVError   )return false;
-   if(FitResults[4] > MaxChi2OverNDF)return false;
+   if(FitResults[0] <= 0             )return false;
+//   if(FitResults[1] > MaxMPVError   )return false;
+//   if(FitResults[4] > MaxChi2OverNDF)return false;
    return true;   
 }
 
@@ -360,7 +365,8 @@ void SiStripGainFromCalibTree::algoAnalyzeTheTree()
 {
    for(unsigned int i=0;i<VInputFiles.size();i++){
       printf("Openning file %3i/%3i --> %s\n",i+1, (int)VInputFiles.size(), (char*)(VInputFiles[i].c_str())); fflush(stdout);
-      TChain* tree = new TChain("gainCalibrationTree/tree");
+//      TChain* tree = new TChain("gainCalibrationTree/tree");
+      TChain* tree = new TChain("commonCalibrationTree/tree");
       tree->Add(VInputFiles[i].c_str());
 
       TString EventPrefix("");
@@ -552,22 +558,20 @@ void SiStripGainFromCalibTree::algoComputeMPVandGain() {
       APV->FitChi2     = FitResults[4];
       APV->NEntries    = Proj->GetEntries();
 
-      if(APV->FitMPV>0){
+//      if(APV->FitMPV>0){
+      if(IsGoodLandauFit(FitResults)){
           APV->Gain = APV->FitMPV / MPVmean;
           GOOD++;
       }else{
-          APV->Gain = 1;
+          APV->Gain = APV->PreviousGain;
           BAD++;
       }
       if(APV->Gain<=0)           APV->Gain  = 1;
-//      if(!FirstSetOfConstants)   APV->Gain *= APV->PreviousGain;
-
+//      if(!FirstSetOfConstants)   APV->Gain *= APV->PreviousGain; //commented because already done at the level of the cluster computation
 
       //printf("%5i/%5i:  %6i - %1i  %5E Entries --> MPV = %f +- %f\n",I,APVsColl.size(),APV->DetId, APV->APVId, Proj->GetEntries(), FitResults[0], FitResults[1]);fflush(stdout);
       delete Proj;
    }printf("\n");
-
-   storeOnTree();
 }
 
 
@@ -620,7 +624,15 @@ void SiStripGainFromCalibTree::storeOnTree()
    MyTree->Branch("isMasked"          ,&tree_isMasked   ,"isMasked/O");
 
 
-   FILE* Gains = fopen(OutputGains.c_str(),"w");
+   FILE* Gains = stdout;
+   if(AlgoMode!="PCL"){
+   fprintf(Gains,"NEvents   = %i\n",NEvent);
+   fprintf(Gains,"NTracks   = %i\n",NTrack);
+   fprintf(Gains,"NClusters = %i\n",NCluster);
+   fprintf(Gains,"Number of APVs = %lu\n",static_cast<unsigned long>(APVsColl.size()));
+   fprintf(Gains,"GoodFits = %i BadFits = %i ratio = %f\n",GOOD,BAD,(100.0*GOOD)/(GOOD+BAD));
+   Gains=fopen(OutputGains.c_str(),"w");
+   }
    fprintf(Gains,"NEvents   = %i\n",NEvent);
    fprintf(Gains,"NTracks   = %i\n",NTrack);
    fprintf(Gains,"NClusters = %i\n",NCluster);
@@ -630,8 +642,8 @@ void SiStripGainFromCalibTree::storeOnTree()
    for(unsigned int a=0;a<APVsCollOrdered.size();a++){
       stAPVGain* APV = APVsCollOrdered[a];
       if(APV==NULL)continue;
-//     printf(      "%i | %i | PreviousGain = %7.5f NewGain = %7.5f\n", APV->DetId,APV->APVId,APV->PreviousGain,APV->Gain);
-      fprintf(Gains,"%i | %i | PreviousGain = %7.5f NewGain = %7.5f\n", APV->DetId,APV->APVId,APV->PreviousGain,APV->Gain);
+//     printf(      "%i | %i | PreviousGain = %7.5f NewGain = %7.5f (#clusters=%8.0f)\n", APV->DetId,APV->APVId,APV->PreviousGain,APV->Gain, APV->NEntries);
+      fprintf(Gains,"%i | %i | PreviousGain = %7.5f NewGain = %7.5f (#clusters=%8.0f)\n", APV->DetId,APV->APVId,APV->PreviousGain,APV->Gain, APV->NEntries);
 
       tree_Index      = APV->Index;
       tree_Bin        = APV->Bin;
@@ -657,7 +669,7 @@ void SiStripGainFromCalibTree::storeOnTree()
 
       MyTree->Fill();
    }
-   fclose(Gains);
+   if(AlgoMode!="PCL")fclose(Gains);
 
 
 }
@@ -719,6 +731,212 @@ void SiStripGainFromCalibTree::MakeCalibrationMap(){
 
 }
 
+
+
+
+void
+SiStripGainFromCalibTree::algoAnalyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+   if(AlgoMode=="CalibTree")return;
+
+   if(NEvent==0){
+      SRun          = iEvent.id().run();
+   }
+   ERun             = iEvent.id().run();
+   NEvent++;
+
+  //FROM SHALLOW GAIN
+  edm::ESHandle<TrackerGeometry> theTrackerGeometry;         iSetup.get<TrackerDigiGeometryRecord>().get( theTrackerGeometry );  
+  edm::ESHandle<SiStripGain> gainHandle;                     iSetup.get<SiStripGainRcd>().get(gainHandle);
+  edm::Handle<edm::View<reco::Track> > tracks;               iEvent.getByLabel(theTracksLabel, tracks);    
+  edm::Handle<TrajTrackAssociationCollection> associations;  iEvent.getByLabel(theTracksLabel, associations);
+
+  for( TrajTrackAssociationCollection::const_iterator association = associations->begin(); association != associations->end(); association++) {
+       const Trajectory*  traj  = association->key.get();
+       const reco::Track* track = association->val.get();
+
+       //clean on the tracks
+       if(fabs(track->eta())          < MinTrackEta        )continue;
+       if(fabs(track->eta())          > MaxTrackEta        )continue;
+       if(track->p()                  < MinTrackMomentum   )continue;
+       if(track->p()                  > MaxTrackMomentum   )continue;
+       if(track->numberOfValidHits()  < MinTrackHits       )continue;
+       if(track->chi2()/track->ndof() > MaxTrackChiOverNdf )continue;
+       NTrack++;
+
+       vector<TrajectoryMeasurement> measurements = traj->measurements();
+       for(vector<TrajectoryMeasurement>::const_iterator measurement_it = measurements.begin(); measurement_it!=measurements.end(); measurement_it++){
+          TrajectoryStateOnSurface trajState = measurement_it->updatedState();
+          if( !trajState.isValid() ) continue;     
+
+          const TrackingRecHit*         hit                 = (*measurement_it->recHit()).hit();
+          const SiStripRecHit1D*        sistripsimple1dhit  = dynamic_cast<const SiStripRecHit1D*>(hit);
+          const SiStripRecHit2D*        sistripsimplehit    = dynamic_cast<const SiStripRecHit2D*>(hit);
+          const SiStripMatchedRecHit2D* sistripmatchedhit   = dynamic_cast<const SiStripMatchedRecHit2D*>(hit);
+
+          const SiStripCluster*   Cluster = NULL;
+          uint32_t                DetId = 0;
+
+          for(unsigned int h=0;h<2;h++){
+            if(!sistripmatchedhit && h==1){
+               continue;
+            }else if(sistripmatchedhit  && h==0){
+               Cluster = &sistripmatchedhit->monoCluster();
+               DetId = sistripmatchedhit->monoId();
+            }else if(sistripmatchedhit  && h==1){
+               Cluster = &sistripmatchedhit->stereoCluster();;
+               DetId = sistripmatchedhit->stereoId();
+            }else if(sistripsimplehit){
+               Cluster = (sistripsimplehit->cluster()).get();
+               DetId = sistripsimplehit->geographicalId().rawId();
+            }else if(sistripsimple1dhit){
+               Cluster = (sistripsimple1dhit->cluster()).get();
+               DetId = sistripsimple1dhit->geographicalId().rawId();
+            }else{
+               continue;
+            }
+
+            LocalVector             trackDirection = trajState.localDirection();
+            double                  cosine         = trackDirection.z()/trackDirection.mag();
+            const vector<uint8_t>&  Ampls          = Cluster->amplitudes();
+            int                     FirstStrip     = Cluster->firstStrip();
+            int                     APVId          = FirstStrip/128;
+            bool                    Saturation     = false;
+            bool                    Overlapping    = false;
+            unsigned int            charge         = 0;
+            double                  PrevGain       = -1;
+            stAPVGain* APV = APVsColl[(DetId<<3) | (FirstStrip/128)];
+            double                  Path           = (10.0*APV->Thickness)/fabs(cosine);
+
+
+            if(gainHandle.isValid()){ 
+               SiStripApvGain::Range detGainRange = gainHandle->getRange(DetId);
+               PrevGain = *(detGainRange.first + APVId);
+            }
+
+            for(unsigned int a=0;a<Ampls.size();a++){               
+               charge+=Ampls[a];
+               if(Ampls[a] >=254)Saturation =true;
+            }
+            double                   ChargeOverPath = (double)charge / Path ;
+
+            if(FirstStrip==0                                  )Overlapping=true;
+            if(FirstStrip==128                                )Overlapping=true;
+            if(FirstStrip==256                                )Overlapping=true;
+            if(FirstStrip==384                                )Overlapping=true;
+            if(FirstStrip==512                                )Overlapping=true;
+            if(FirstStrip==640                                )Overlapping=true;
+
+            if(FirstStrip<=127 && FirstStrip+Ampls.size()>127)Overlapping=true;
+            if(FirstStrip<=255 && FirstStrip+Ampls.size()>255)Overlapping=true;
+            if(FirstStrip<=383 && FirstStrip+Ampls.size()>383)Overlapping=true;
+            if(FirstStrip<=511 && FirstStrip+Ampls.size()>511)Overlapping=true;
+            if(FirstStrip<=639 && FirstStrip+Ampls.size()>639)Overlapping=true;
+
+            if(FirstStrip+Ampls.size()==127                   )Overlapping=true;
+            if(FirstStrip+Ampls.size()==255                   )Overlapping=true;
+            if(FirstStrip+Ampls.size()==383                   )Overlapping=true;
+            if(FirstStrip+Ampls.size()==511                   )Overlapping=true;
+            if(FirstStrip+Ampls.size()==639                   )Overlapping=true;
+            if(FirstStrip+Ampls.size()==767                   )Overlapping=true;
+
+            //cleaning on the cluster
+            if(IsFarFromBorder(&trajState,DetId, &iSetup)  == false           )continue;
+            if(Overlapping                                 == true            )continue;
+            if(Saturation  && !AllowSaturation                                )continue;
+            if(Ampls.size()                              > MaxNrStrips        )continue;
+            NCluster++;
+
+
+            int Charge = 0;
+            if(useCalibration || !FirstSetOfConstants){
+               bool Saturation = false;
+               for(unsigned int s=0;s<Ampls.size();s++){
+                  int StripCharge =  Ampls[s];
+                  if(useCalibration && !FirstSetOfConstants){ StripCharge=(int)(StripCharge*(APV->PreviousGain/APV->CalibGain));
+                  }else if(useCalibration){                   StripCharge=(int)(StripCharge/APV->CalibGain);
+                  }else if(!FirstSetOfConstants){             StripCharge=(int)(StripCharge*APV->PreviousGain);}
+                  if(StripCharge>1024){
+                     StripCharge = 255;
+                     Saturation = true;
+                  }else if(StripCharge>254){
+                     StripCharge = 254;
+                     Saturation = true;
+                  }
+                  Charge += StripCharge;
+               }
+               if(Saturation && !AllowSaturation)continue;
+            }else{
+               Charge = charge;
+            }
+
+            //printf("ChargeDifference = %i Vs %i with Gain = %f\n",(*charge)[i],Charge,APV->CalibGain);
+
+            double ClusterChargeOverPath   =  ( (double) Charge )/Path ;
+            if(Validation)     {ClusterChargeOverPath/=PrevGain;}
+            if(OldGainRemoving){ClusterChargeOverPath*=PrevGain;}
+            Charge_Vs_Index_Absolute->Fill(APV->Index,Charge);   
+            Charge_Vs_Index         ->Fill(APV->Index,ClusterChargeOverPath);
+
+
+                  if(APV->SubDet==StripSubdetector::TIB){ Charge_Vs_PathlengthTIB  ->Fill(Path,Charge);
+            }else if(APV->SubDet==StripSubdetector::TOB){ Charge_Vs_PathlengthTOB  ->Fill(Path,Charge);
+            }else if(APV->SubDet==StripSubdetector::TID){ 
+                     if(APV->Eta<0){                      Charge_Vs_PathlengthTIDM ->Fill(Path,Charge);
+               }else if(APV->Eta>0){                      Charge_Vs_PathlengthTIDP ->Fill(Path,Charge);
+               }
+            }else if(APV->SubDet==StripSubdetector::TEC){
+                     if(APV->Eta<0){
+                        if(APV->Thickness<0.04){          Charge_Vs_PathlengthTECM1->Fill(Path,Charge);
+                  }else if(APV->Thickness>0.04){          Charge_Vs_PathlengthTECM2->Fill(Path,Charge);
+                  }
+               }else if(APV->Eta>0){
+                        if(APV->Thickness<0.04){          Charge_Vs_PathlengthTECP1->Fill(Path,Charge);
+                  }else if(APV->Thickness>0.04){          Charge_Vs_PathlengthTECP2->Fill(Path,Charge);
+                  }
+               }
+            }
+
+          }//loop on  clusters
+       }//loop on measurements
+  }//loop on tracks
+
+}
+
+
+bool SiStripGainFromCalibTree::IsFarFromBorder(TrajectoryStateOnSurface* trajState, const uint32_t detid, const edm::EventSetup* iSetup)
+{ 
+  edm::ESHandle<TrackerGeometry> tkGeom; iSetup->get<TrackerDigiGeometryRecord>().get( tkGeom );
+
+  LocalPoint  HitLocalPos   = trajState->localPosition();
+  LocalError  HitLocalError = trajState->localError().positionError() ;
+
+  const GeomDetUnit* it = tkGeom->idToDetUnit(DetId(detid));
+  if (dynamic_cast<const StripGeomDetUnit*>(it)==0 && dynamic_cast<const PixelGeomDetUnit*>(it)==0) {
+     std::cout << "this detID doesn't seem to belong to the Tracker" << std::endl;
+     return false;
+  }
+
+  const BoundPlane plane = it->surface();
+  const TrapezoidalPlaneBounds* trapezoidalBounds( dynamic_cast<const TrapezoidalPlaneBounds*>(&(plane.bounds())));
+  const RectangularPlaneBounds* rectangularBounds( dynamic_cast<const RectangularPlaneBounds*>(&(plane.bounds())));
+
+  double DistFromBorder = 1.0;    
+  double HalfLength     = it->surface().bounds().length() /2.0;
+
+  if(trapezoidalBounds)
+  {
+      //std::array<const float, 4> const & parameters = (*trapezoidalBounds).parameters();
+     std::vector<float> const & parameters = (*trapezoidalBounds).parameters();
+     HalfLength     = parameters[3];
+  }else if(rectangularBounds){
+     HalfLength     = it->surface().bounds().length() /2.0;
+  }else{return false;}
+
+  if (fabs(HitLocalPos.y())+HitLocalError.yy() >= (HalfLength - DistFromBorder) ) return false;
+
+  return true;
+}
 
 
 

--- a/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromCalibTree.cc
+++ b/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromCalibTree.cc
@@ -975,8 +975,8 @@ bool SiStripGainFromCalibTree::IsFarFromBorder(TrajectoryStateOnSurface* trajSta
 
   if(trapezoidalBounds)
   {
-      //std::array<const float, 4> const & parameters = (*trapezoidalBounds).parameters();
-     std::vector<float> const & parameters = (*trapezoidalBounds).parameters();
+     std::array<const float, 4> const & parameters = (*trapezoidalBounds).parameters();
+     //std::vector<float> const & parameters = (*trapezoidalBounds).parameters();
      HalfLength     = parameters[3];
   }else if(rectangularBounds){
      HalfLength     = it->surface().bounds().length() /2.0;

--- a/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromCalibTree.cc
+++ b/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromCalibTree.cc
@@ -163,16 +163,16 @@ class SiStripGainFromCalibTree : public ConditionDBWriter<SiStripApvGain> {
       std::string  OutputGains;
       vector<string> VInputFiles;
 
-      TH2F*        Charge_Vs_Index;
-      TH2F*        Charge_Vs_Index_Absolute;
-      TH2F*        Charge_Vs_PathlengthTIB;
-      TH2F*        Charge_Vs_PathlengthTOB;
-      TH2F*        Charge_Vs_PathlengthTIDP;
-      TH2F*        Charge_Vs_PathlengthTIDM;
-      TH2F*        Charge_Vs_PathlengthTECP1;
-      TH2F*        Charge_Vs_PathlengthTECP2;
-      TH2F*        Charge_Vs_PathlengthTECM1;
-      TH2F*        Charge_Vs_PathlengthTECM2;
+      MonitorElement*        Charge_Vs_Index;
+      MonitorElement*        Charge_Vs_Index_Absolute;
+      MonitorElement*        Charge_Vs_PathlengthTIB;
+      MonitorElement*        Charge_Vs_PathlengthTOB;
+      MonitorElement*        Charge_Vs_PathlengthTIDP;
+      MonitorElement*        Charge_Vs_PathlengthTIDM;
+      MonitorElement*        Charge_Vs_PathlengthTECP1;
+      MonitorElement*        Charge_Vs_PathlengthTECP2;
+      MonitorElement*        Charge_Vs_PathlengthTECM1;
+      MonitorElement*        Charge_Vs_PathlengthTECM2;
 
       unsigned int NEvent;    
       unsigned int NTrack;
@@ -233,17 +233,17 @@ void SiStripGainFromCalibTree::algoBeginRun(const edm::Run& run, const edm::Even
 
   // FIXME: decide what should be the folder name following the convention already there for ALCARECOS
   dbe->setCurrentFolder("AlCaReco/SiStripGains/");
-  //dbe->book1D(histoName,histoTitle, maxTDCCounts/timeBoxGranularity, 0, maxTDCCounts);
-   Charge_Vs_Index           = tfs->make<TH2F>("Charge_Vs_Index"          , "Charge_Vs_Index"          , 72785, 0   , 72784,1000,0,2000);
-   Charge_Vs_Index_Absolute  = tfs->make<TH2F>("Charge_Vs_Index_Absolute" , "Charge_Vs_Index_Absolute" , 72785, 0   , 72784, 500,0,2000);
-   Charge_Vs_PathlengthTIB   = tfs->make<TH2F>("Charge_Vs_PathlengthTIB"  , "Charge_Vs_PathlengthTIB"  , 20   , 0.3 , 1.3  , 250,0,2000);
-   Charge_Vs_PathlengthTOB   = tfs->make<TH2F>("Charge_Vs_PathlengthTOB"  , "Charge_Vs_PathlengthTOB"  , 20   , 0.3 , 1.3  , 250,0,2000);
-   Charge_Vs_PathlengthTIDP  = tfs->make<TH2F>("Charge_Vs_PathlengthTIDP" , "Charge_Vs_PathlengthTIDP" , 20   , 0.3 , 1.3  , 250,0,2000);
-   Charge_Vs_PathlengthTIDM  = tfs->make<TH2F>("Charge_Vs_PathlengthTIDM" , "Charge_Vs_PathlengthTIDM" , 20   , 0.3 , 1.3  , 250,0,2000);
-   Charge_Vs_PathlengthTECP1 = tfs->make<TH2F>("Charge_Vs_PathlengthTECP1", "Charge_Vs_PathlengthTECP1", 20   , 0.3 , 1.3  , 250,0,2000);
-   Charge_Vs_PathlengthTECP2 = tfs->make<TH2F>("Charge_Vs_PathlengthTECP2", "Charge_Vs_PathlengthTECP2", 20   , 0.3 , 1.3  , 250,0,2000);
-   Charge_Vs_PathlengthTECM1 = tfs->make<TH2F>("Charge_Vs_PathlengthTECM1", "Charge_Vs_PathlengthTECM1", 20   , 0.3 , 1.3  , 250,0,2000);
-   Charge_Vs_PathlengthTECM2 = tfs->make<TH2F>("Charge_Vs_PathlengthTECM2", "Charge_Vs_PathlengthTECM2", 20   , 0.3 , 1.3  , 250,0,2000);
+
+   Charge_Vs_Index           = dbe->book2D("Charge_Vs_Index"          , "Charge_Vs_Index"          , 72785, 0   , 72784,1000,0,2000);
+   Charge_Vs_Index_Absolute  = dbe->book2D("Charge_Vs_Index_Absolute" , "Charge_Vs_Index_Absolute" , 72785, 0   , 72784, 500,0,2000);
+   Charge_Vs_PathlengthTIB   = dbe->book2D("Charge_Vs_PathlengthTIB"  , "Charge_Vs_PathlengthTIB"  , 20   , 0.3 , 1.3  , 250,0,2000);
+   Charge_Vs_PathlengthTOB   = dbe->book2D("Charge_Vs_PathlengthTOB"  , "Charge_Vs_PathlengthTOB"  , 20   , 0.3 , 1.3  , 250,0,2000);
+   Charge_Vs_PathlengthTIDP  = dbe->book2D("Charge_Vs_PathlengthTIDP" , "Charge_Vs_PathlengthTIDP" , 20   , 0.3 , 1.3  , 250,0,2000);
+   Charge_Vs_PathlengthTIDM  = dbe->book2D("Charge_Vs_PathlengthTIDM" , "Charge_Vs_PathlengthTIDM" , 20   , 0.3 , 1.3  , 250,0,2000);
+   Charge_Vs_PathlengthTECP1 = dbe->book2D("Charge_Vs_PathlengthTECP1", "Charge_Vs_PathlengthTECP1", 20   , 0.3 , 1.3  , 250,0,2000);
+   Charge_Vs_PathlengthTECP2 = dbe->book2D("Charge_Vs_PathlengthTECP2", "Charge_Vs_PathlengthTECP2", 20   , 0.3 , 1.3  , 250,0,2000);
+   Charge_Vs_PathlengthTECM1 = dbe->book2D("Charge_Vs_PathlengthTECM1", "Charge_Vs_PathlengthTECM1", 20   , 0.3 , 1.3  , 250,0,2000);
+   Charge_Vs_PathlengthTECM2 = dbe->book2D("Charge_Vs_PathlengthTECM2", "Charge_Vs_PathlengthTECM2", 20   , 0.3 , 1.3  , 250,0,2000);
 
    edm::ESHandle<TrackerGeometry> tkGeom;
    iSetup.get<TrackerDigiGeometryRecord>().get( tkGeom );
@@ -279,7 +279,7 @@ void SiStripGainFromCalibTree::algoBeginRun(const edm::Run& run, const edm::Even
           for(unsigned int j=0;j<NAPV;j++){
                 stAPVGain* APV = new stAPVGain;
                 APV->Index         = Index;
-                APV->Bin           = Charge_Vs_Index->GetXaxis()->FindBin(APV->Index);
+                APV->Bin           = Charge_Vs_Index->getRefTH2D()->GetXaxis()->FindBin(APV->Index);
                 APV->DetId         = Detid.rawId();
                 APV->APVId         = j;
                 APV->SubDet        = SubDet;
@@ -537,7 +537,7 @@ void SiStripGainFromCalibTree::algoComputeMPVandGain() {
    //if(I>1000)break;
       stAPVGain* APV = it->second;
 
-      Proj = (TH1D*)(Charge_Vs_Index->ProjectionY("",APV->Bin,APV->Bin,"e"));
+      Proj = (TH1D*)(Charge_Vs_Index->getRefTH2D()->ProjectionY("",APV->Bin,APV->Bin,"e"));
       if(!Proj)continue;
 
       if(CalibrationLevel==0){
@@ -545,7 +545,7 @@ void SiStripGainFromCalibTree::algoComputeMPVandGain() {
          int SecondAPVId = APV->APVId;
          if(SecondAPVId%2==0){    SecondAPVId = SecondAPVId+1; }else{ SecondAPVId = SecondAPVId-1; }
 	 stAPVGain* APV2 = APVsColl[(APV->DetId<<3) | SecondAPVId];
-         TH1D* Proj2 = (TH1D*)(Charge_Vs_Index->ProjectionY("",APV2->Bin,APV2->Bin,"e"));
+         TH1D* Proj2 = (TH1D*)(Charge_Vs_Index->getRefTH2D()->ProjectionY("",APV2->Bin,APV2->Bin,"e"));
          if(Proj2){Proj->Add(Proj2,1);delete Proj2;}
       }else if(CalibrationLevel==2){
           for(unsigned int i=0;i<6;i++){
@@ -554,7 +554,7 @@ void SiStripGainFromCalibTree::algoComputeMPVandGain() {
             if(tmpit==APVsColl.end())continue;
             stAPVGain* APV2 = tmpit->second;
 	    if(APV2->DetId != APV->DetId || APV2->APVId == APV->APVId)continue;            
-            TH1D* Proj2 = (TH1D*)(Charge_Vs_Index->ProjectionY("",APV2->Bin,APV2->Bin,"e"));
+            TH1D* Proj2 = (TH1D*)(Charge_Vs_Index->getRefTH2D()->ProjectionY("",APV2->Bin,APV2->Bin,"e"));
 //            if(Proj2 && APV->DetId==369171124)printf("B) DetId %6i APVId %1i --> NEntries = %f\n",APV2->DetId, APV2->APVId, Proj2->GetEntries());
             if(Proj2){Proj->Add(Proj2,1);delete Proj2;}
           }          

--- a/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromCalibTree.cc
+++ b/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromCalibTree.cc
@@ -117,7 +117,8 @@ class SiStripGainFromCalibTree : public ConditionDBWriter<SiStripApvGain> {
 
    private:
 
-      virtual void algoBeginJob      (const edm::EventSetup&) override;
+  
+      virtual void algoBeginRun(const edm::Run& run, const edm::EventSetup& iSetup) override;
       virtual void algoEndJob        () override;
       virtual void algoAnalyze       (const edm::Event &, const edm::EventSetup &) override;
 
@@ -235,7 +236,6 @@ SiStripGainFromCalibTree::SiStripGainFromCalibTree(const edm::ParameterSet& iCon
 }
 
 void SiStripGainFromCalibTree::algoBeginRun(const edm::Run& run, const edm::EventSetup& iSetup)
-//void SiStripGainFromCalibTree::algoBeginJob(const edm::EventSetup& iSetup)
 {
   cout << "algoBeginRun start" << endl;
   if(!harvestingMode){
@@ -328,7 +328,7 @@ void SiStripGainFromCalibTree::algoBeginRun(const edm::Run& run, const edm::Even
    BAD        = 0;
    MASKED     = 0;
    
-   cout << "algoBeginJob end" << endl;
+   cout << "algoBeginRun end" << endl;
 }
 
 void 

--- a/CalibTracker/SiStripChannelGain/python/computeGain_cff.py
+++ b/CalibTracker/SiStripChannelGain/python/computeGain_cff.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-SiStripCalib = cms.EDFilter("SiStripGainFromCalibTree",
+SiStripCalib = cms.EDAnalyzer("SiStripGainFromCalibTree",
     OutputGains         = cms.string('Gains_ASCII.txt'),
 
     minTrackMomentum    = cms.untracked.double(2),

--- a/CalibTracker/SiStripChannelGain/python/computeGain_cff.py
+++ b/CalibTracker/SiStripChannelGain/python/computeGain_cff.py
@@ -32,6 +32,10 @@ SiStripCalib = cms.EDAnalyzer("SiStripGainFromCalibTree",
     UseCalibration     = cms.untracked.bool(False),
     calibrationPath    = cms.untracked.string(""),
 
+    GoodFracForTagProd  = cms.untracked.double(0.95),
+    NClustersForTagProd = cms.untracked.double(2E8),
+    
+
     SinceAppendMode     = cms.bool(True),
     IOVMode             = cms.string('Job'),
     Record              = cms.string('SiStripApvGainRcd'),

--- a/CalibTracker/SiStripChannelGain/test/7TeVData/Gains_Compute_cfg.py
+++ b/CalibTracker/SiStripChannelGain/test/7TeVData/Gains_Compute_cfg.py
@@ -7,6 +7,12 @@ process.load("Geometry.TrackerGeometryBuilder.trackerGeometry_cfi")
 process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 
+#this block is there to solve issue related to SiStripQualityRcd
+process.load("CalibTracker.SiStripESProducers.SiStripQualityESProducer_cfi")
+process.load("CalibTracker.SiStripESProducers.fake.SiStripDetVOffFakeESSource_cfi")
+process.es_prefer_fakeSiStripDetVOff = cms.ESPrefer("SiStripDetVOffFakeESSource","siStripDetVOffFakeESSource")
+
+
 process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
 
 process.MessageLogger = cms.Service("MessageLogger",
@@ -17,93 +23,22 @@ process.MessageLogger = cms.Service("MessageLogger",
 process.source = cms.Source("EmptyIOVSource",
     timetype   = cms.string('runnumber'),
     interval   = cms.uint64(1),
-    firstValue = cms.uint64(140058),
-    lastValue  = cms.uint64(140058)
+    firstValue = cms.uint64(XXX_FIRSTRUN_XXX),
+    lastValue  = cms.uint64(XXX_LASTRUN_XXX)
 )
 
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1)
 )
 
-process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-process.GlobalTag.globaltag = 'GR10_P_V7::All'
-process.prefer("GlobalTag")
+process.GlobalTag.globaltag = 'XXX_GT_XXX::All'
 
 process.load("CalibTracker.SiStripChannelGain.computeGain_cff")
 process.SiStripCalib.InputFiles          = cms.vstring(
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_16_140058_1.root',   #Size=859Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_17_140059_1.root',   #Size=2047Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_43_140124_1.root',   #Size=2047Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_45_140126_1.root',   #Size=1781Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_59_140158_1.root',   #Size=2047Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_60_140159_1.root',   #Size=2047Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_1_140160_1.root',   #Size=1064Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_24_140331_1.root',   #Size=2047Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_30_140352_1.root',   #Size=1691Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_32_140361_1.root',   #Size=808Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_33_140362_1.root',   #Size=1392Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_42_140379_1.root',   #Size=1115Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_52_140382_1.root',   #Size=1786Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_46_140383_1.root',   #Size=2047Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_47_140385_1.root',   #Size=1172Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_49_140387_1.root',   #Size=828Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_50_140388_1.root',   #Size=680Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_56_140399_1.root',   #Size=2047Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_57_140401_1.root',   #Size=1596Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_118_140401_1.root',   #Size=1596Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_20_141874_1.root',   #Size=615Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_21_141876_1.root',   #Size=542Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_24_141880_1.root',   #Size=1149Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_25_141881_1.root',   #Size=2047Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_26_141882_1.root',   #Size=1332Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_42_142187_1.root',   #Size=1616Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_44_142189_1.root',   #Size=650Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_45_142191_1.root',   #Size=586Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_67_142265_1.root',   #Size=604Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_75_142305_1.root',   #Size=873Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_78_142311_1.root',   #Size=1687Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_79_142312_1.root',   #Size=781Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_5_142414_1.root',   #Size=591Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_9_142419_1.root',   #Size=611Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_10_142420_1.root',   #Size=587Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_11_142422_1.root',   #Size=2047Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_25_142524_1.root',   #Size=1140Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_26_142525_1.root',   #Size=519Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_27_142528_1.root',   #Size=2047Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_33_142558_1.root',   #Size=882Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_47_142662_1.root',   #Size=756Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_48_142663_1.root',   #Size=640Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_6_142928_1.root',   #Size=2047Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_8_142933_1.root',   #Size=2047Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_3_142953_1.root',   #Size=1132Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_4_142954_1.root',   #Size=985Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_12_142970_1.root',   #Size=686Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_13_142971_1.root',   #Size=2047Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_15_143005_1.root',   #Size=977Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_17_143007_1.root',   #Size=2047Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_24_143181_1.root',   #Size=2047Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_25_143187_1.root',   #Size=810Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_11_143320_1.root',   #Size=564Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_37_143322_1.root',   #Size=588Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_14_143323_1.root',   #Size=1603Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_41_143326_1.root',   #Size=612Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_43_143328_1.root',   #Size=825Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_16_143657_1.root',   #Size=2047Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_50_143727_1.root',   #Size=1450Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_30_143827_1.root',   #Size=2047Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_2_143833_1.root',   #Size=1791Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_28_143953_1.root',   #Size=2047Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_29_143954_1.root',   #Size=832Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_56_143957_1.root',   #Size=594Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_36_143961_1.root',   #Size=1117Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_13_143962_1.root',   #Size=1182Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_8_144011_1.root',   #Size=1888Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_18_144086_1.root',   #Size=1345Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_12_144089_1.root',   #Size=2047Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_51_144112_1.root',   #Size=2047Mo
+XXX_CALIBTREE_XXX
 )
 process.SiStripCalib.FirstSetOfConstants = cms.untracked.bool(False)
-
+process.SiStripCalib.CalibrationLevel    = cms.untracked.int32(0) # 0==APV, 1==Laser, 2==module
 
 
 process.PoolDBOutputService = cms.Service("PoolDBOutputService",

--- a/CalibTracker/SiStripChannelGain/test/7TeVData/PlotFunction.h
+++ b/CalibTracker/SiStripChannelGain/test/7TeVData/PlotFunction.h
@@ -38,7 +38,7 @@ void DrawPreliminary(int Type, double X=0.28, double Y=0.98, double W=0.85, doub
    T->Draw("same");
 }
 
-void DrawLegend (TObject** Histos, std::vector<string> legend, string Title, string Style, double X=0.79, double Y=0.93, double W=0.20, double H=0.05)
+void DrawLegend (TObject** Histos, std::vector<string> legend, string Title, string StyleCase, double X=0.79, double Y=0.93, double W=0.20, double H=0.05)
 {
    int    N             = legend.size();
    
@@ -50,7 +50,7 @@ void DrawLegend (TObject** Histos, std::vector<string> legend, string Title, str
       //leg->SetTextAlign(32);
       if(Title!="")leg->SetHeader(Title.c_str());
 
-      if(Style=="DataMC"){
+      if(StyleCase=="DataMC"){
          for(int i=0;i<N;i++){
             TH2D* temp = (TH2D*)Histos[i]->Clone();
             temp->SetMarkerSize(1.3);
@@ -64,7 +64,7 @@ void DrawLegend (TObject** Histos, std::vector<string> legend, string Title, str
          for(int i=0;i<N;i++){
             TH2D* temp = (TH2D*)Histos[i]->Clone();
             temp->SetMarkerSize(1.3);
-            leg->AddEntry(temp, legend[i].c_str() ,Style.c_str());
+            leg->AddEntry(temp, legend[i].c_str() ,StyleCase.c_str());
          }
       }
       leg->Draw();
@@ -104,7 +104,7 @@ void DrawStatBox(TObject** Histos, std::vector<string> legend, bool Mean, double
 
 
 
-void DrawTH2D(TH2D** Histos, std::vector<string> legend, string Style, string Xlegend, string Ylegend, double xmin, double xmax, double ymin, double ymax)
+void DrawTH2D(TH2D** Histos, std::vector<string> legend, string StyleCase, string Xlegend, string Ylegend, double xmin, double xmax, double ymin, double ymax)
 {
    int    N             = legend.size();
    
@@ -123,15 +123,15 @@ void DrawTH2D(TH2D** Histos, std::vector<string> legend, string Style, string Xl
    }
 
    char Buffer[256];
-   Histos[0]->Draw(Style.c_str());
+   Histos[0]->Draw(StyleCase.c_str());
    for(int i=1;i<N;i++){
-        sprintf(Buffer,"%s same",Style.c_str());
+        sprintf(Buffer,"%s same",StyleCase.c_str());
         Histos[i]->Draw(Buffer);
    }
 }
 
 
-void DrawSuperposedHistos(TH1** Histos, std::vector<string> legend, string Style,  string Xlegend, string Ylegend, double xmin, double xmax, double ymin, double ymax, bool Normalize=false)
+void DrawSuperposedHistos(TH1** Histos, std::vector<string> legend, string StyleCase,  string Xlegend, string Ylegend, double xmin, double xmax, double ymin, double ymax, bool Normalize=false)
 {
    int    N             = legend.size();
 
@@ -154,7 +154,7 @@ void DrawSuperposedHistos(TH1** Histos, std::vector<string> legend, string Style
         Histos[i]->SetMarkerSize(1.0);
         Histos[i]->SetLineColor(Color[i]);
         Histos[i]->SetLineWidth(2);
-       if(Style=="DataMC" && i==0){
+       if(StyleCase=="DataMC" && i==0){
            Histos[i]->SetFillColor(0);
            Histos[i]->SetMarkerStyle(20);
            Histos[i]->SetMarkerColor(1);
@@ -171,7 +171,7 @@ void DrawSuperposedHistos(TH1** Histos, std::vector<string> legend, string Style
    }
 
    char Buffer[256];
-   if(Style=="DataMC"){
+   if(StyleCase=="DataMC"){
       if(HistoHeighest==0){
          Histos[HistoHeighest]->Draw("E1");
       }else{
@@ -185,10 +185,10 @@ void DrawSuperposedHistos(TH1** Histos, std::vector<string> legend, string Style
            }
       }
    }else{
-      Histos[HistoHeighest]->Draw(Style.c_str());
+      Histos[HistoHeighest]->Draw(StyleCase.c_str());
       for(int i=0;i<N;i++){
-           if(Style!=""){
-              sprintf(Buffer,"same %s",Style.c_str());
+           if(StyleCase!=""){
+              sprintf(Buffer,"same %s",StyleCase.c_str());
            }else{
               sprintf(Buffer,"same");
            }

--- a/CalibTracker/SiStripChannelGain/test/7TeVData/PlotMacro.C
+++ b/CalibTracker/SiStripChannelGain/test/7TeVData/PlotMacro.C
@@ -1,5 +1,3 @@
-
-
 #include "TROOT.h"
 #include "TFile.h"
 #include "TDirectory.h"
@@ -232,7 +230,15 @@ void PlotMacro_Core(string input, string moduleName, string output)
    TH1D* ChargeAbsTECM1 = new TH1D("ChargeAbsTECM1","ChargeAbsTECM1",                500, 0,2000);
    TH1D* ChargeAbsTECM2 = new TH1D("ChargeAbsTECM2","ChargeAbsTECM2",                500, 0,2000);
 
+   TH1D* DiffWRTPrevGainTIB      = new TH1D("DiffWRTPrevGainTIB"     ,"DiffWRTPrevGainTIB"     ,               250, 0,2);
+   TH1D* DiffWRTPrevGainTID      = new TH1D("DiffWRTPrevGainTID"     ,"DiffWRTPrevGainTID"     ,               250, 0,2);
+   TH1D* DiffWRTPrevGainTOB      = new TH1D("DiffWRTPrevGainTOB"     ,"DiffWRTPrevGainTOB"     ,               250, 0,2);
+   TH1D* DiffWRTPrevGainTEC      = new TH1D("DiffWRTPrevGainTEC"     ,"DiffWRTPrevGainTEC"     ,               250, 0,2);
 
+   TH2D* GainVsPrevGainTIB      = new TH2D("GainVsPrevGainTIB"     ,"GainVsPrevGainTIB"     ,               100, 0,2, 100, 0,2);
+   TH2D* GainVsPrevGainTID      = new TH2D("GainVsPrevGainTID"     ,"GainVsPrevGainTID"     ,               100, 0,2, 100, 0,2);
+   TH2D* GainVsPrevGainTOB      = new TH2D("GainVsPrevGainTOB"     ,"GainVsPrevGainTOB"     ,               100, 0,2, 100, 0,2);
+   TH2D* GainVsPrevGainTEC      = new TH2D("GainVsPrevGainTEC"     ,"GainVsPrevGainTEC"     ,               100, 0,2, 100, 0,2);
 
 
    printf("Progressing Bar              :0%%       20%%       40%%       60%%       80%%       100%%\n");
@@ -245,6 +251,8 @@ void PlotMacro_Core(string input, string moduleName, string output)
       TH1D* Proj         = ChargeDistrib ->ProjectionY("proj" ,bin, bin);
       TH1D* ProjAbsolute = ChargeDistribA->ProjectionY("projA",bin, bin);
 
+      if(tree_FitMPV<0                        ) NoMPV         ->Fill(tree_z ,tree_R);
+      if(tree_FitMPV>=0){
 
       if(tree_SubDet==3                       ) MPV_Vs_EtaTIB ->Fill(tree_Eta,tree_FitMPV);
       if(tree_SubDet==4                       ) MPV_Vs_EtaTID ->Fill(tree_Eta,tree_FitMPV);
@@ -279,14 +287,12 @@ void PlotMacro_Core(string input, string moduleName, string output)
       if(tree_SubDet==6 && tree_Thickness<0.04 && tree_Eta<0) MPVsTECM1      ->Fill(         tree_FitMPV);
       if(tree_SubDet==6 && tree_Thickness>0.04 && tree_Eta<0) MPVsTECM2      ->Fill(         tree_FitMPV);
 
-
-      if(tree_FitMPV<0                        ) NoMPV         ->Fill(tree_z ,tree_R);
-
                                                 MPVError      ->Fill(         tree_FitMPVErr);    
                                                 MPVErrorVsMPV ->Fill(tree_FitMPV,tree_FitMPVErr);
                                                 MPVErrorVsEta ->Fill(tree_Eta,tree_FitMPVErr);
                                                 MPVErrorVsPhi ->Fill(tree_Phi,tree_FitMPVErr);
                                                 MPVErrorVsN   ->Fill(tree_NEntries,tree_FitMPVErr);
+      }
 
 
       if(tree_SubDet==3                       ) ChargeTIB  ->Add(Proj,1);
@@ -320,7 +326,15 @@ void PlotMacro_Core(string input, string moduleName, string output)
       if(tree_SubDet==6 && tree_Eta>0 && tree_Thickness<0.04) ChargeAbsTECP1 ->Add(ProjAbsolute,1);
       if(tree_SubDet==6 && tree_Eta>0 && tree_Thickness>0.04) ChargeAbsTECP2 ->Add(ProjAbsolute,1);
 
+      if(tree_SubDet==3                       ) DiffWRTPrevGainTIB  ->Fill(tree_Gain/tree_PrevGain);
+      if(tree_SubDet==4                       ) DiffWRTPrevGainTID  ->Fill(tree_Gain/tree_PrevGain);
+      if(tree_SubDet==5                       ) DiffWRTPrevGainTOB  ->Fill(tree_Gain/tree_PrevGain);
+      if(tree_SubDet==6                       ) DiffWRTPrevGainTEC  ->Fill(tree_Gain/tree_PrevGain);
 
+      if(tree_SubDet==3                       ) GainVsPrevGainTIB  ->Fill(tree_PrevGain,tree_Gain);
+      if(tree_SubDet==4                       ) GainVsPrevGainTID  ->Fill(tree_PrevGain,tree_Gain);
+      if(tree_SubDet==5                       ) GainVsPrevGainTOB  ->Fill(tree_PrevGain,tree_Gain);
+      if(tree_SubDet==6                       ) GainVsPrevGainTEC  ->Fill(tree_PrevGain,tree_Gain);
 
       delete Proj;
       delete ProjAbsolute;
@@ -335,6 +349,25 @@ void PlotMacro_Core(string input, string moduleName, string output)
    unsigned int CountAPV_NoGain   = 0;
    unsigned int CountAPV_NoGainU  = 0;
    unsigned int CountAPV_LowGain  = 0;
+   unsigned int CountAPV_DiffGain = 0;
+
+   pFile = fopen((output + "_MAP.txt").c_str(),"w");
+   fprintf(pFile,"#maxValue = 1.5\n");
+   fprintf(pFile,"#minValue = 0.5\n");
+   fprintf(pFile,"#defaultColor = 1.0,1.0,1.0,0.1\n");
+   printf("Looping on the Tree          :");
+   double MaxGain=0;  unsigned int previousMod=0;
+   for (unsigned int ientry = 0; ientry < t1->GetEntries(); ientry++) {
+      if(ientry%TreeStep==0){printf(".");fflush(stdout);}     
+      t1->GetEntry(ientry);
+      if(previousMod>0&&tree_APVId==0){fprintf(pFile,"%i %f\n",previousMod,MaxGain); MaxGain=1;  } 
+      previousMod = tree_DetId;
+      if(fabs(tree_Gain-MaxGain)>fabs(MaxGain-1))MaxGain=tree_Gain;
+   }printf("\n");
+   if(previousMod>0){fprintf(pFile,"%i %f\n",previousMod,MaxGain); }
+   fclose(pFile);
+
+
 
    pFile = fopen((output + "_LowResponseModule.txt").c_str(),"w");
    fprintf(pFile,"\n\nALL APVs WITH NO ENTRIES (NO RECO CLUSTER ON IT)\n--------------------------------------------\n");
@@ -379,11 +412,19 @@ void PlotMacro_Core(string input, string moduleName, string output)
    for (unsigned int ientry = 0; ientry < t1->GetEntries(); ientry++) {
       if(ientry%TreeStep==0){printf(".");fflush(stdout);}
       t1->GetEntry(ientry);
-      if(tree_FitMPV>0 && tree_FitMPV<220){fprintf(pFile,"%i-%i, ",tree_DetId,tree_APVId); CountAPV_LowGain++;}
+      if(tree_FitMPV>0 && tree_FitMPV<220 && !tree_isMasked){fprintf(pFile,"%i-%i, ",tree_DetId,tree_APVId); CountAPV_LowGain++;}
    }printf("\n");
    fprintf(pFile,"\n--> %i / %i = %f%% APV Concerned\n",CountAPV_LowGain,CountAPV_Total,(100.0*CountAPV_LowGain)/CountAPV_Total);
-   fclose(pFile);
 
+   fprintf(pFile,"\n\nUNMASKED APVs WITH SIGNIFICANT CHANGE OF GAIN VALUE\n--------------------------------------------\n");
+   printf("Looping on the Tree          :");
+   for (unsigned int ientry = 0; ientry < t1->GetEntries(); ientry++) {
+      if(ientry%TreeStep==0){printf(".");fflush(stdout);}
+      t1->GetEntry(ientry);
+      if(tree_FitMPV>0 && !tree_isMasked && (tree_Gain/tree_PrevGain<0.7 || tree_Gain/tree_PrevGain>1.3)){fprintf(pFile,"%i-%i, ",tree_DetId,tree_APVId); CountAPV_DiffGain++;}
+   }printf("\n");
+   fprintf(pFile,"\n--> %i / %i = %f%% APV Concerned\n",CountAPV_DiffGain,CountAPV_Total,(100.0*CountAPV_DiffGain)/CountAPV_Total);
+   fclose(pFile);
 
 
 
@@ -692,6 +733,37 @@ void PlotMacro_Core(string input, string moduleName, string output)
     DrawLegend(Histos,legend,"","L");
     SaveCanvas(c1,output,"MPV_Vs_PathSubDet");
     delete c1;
+
+
+    c1 = new TCanvas("c1","c1,",600,600);          legend.clear();
+    Histos[0] = DiffWRTPrevGainTIB;                legend.push_back("TIB");
+    Histos[1] = DiffWRTPrevGainTID;                legend.push_back("TID");
+    Histos[2] = DiffWRTPrevGainTOB;                legend.push_back("TOB");
+    Histos[3] = DiffWRTPrevGainTEC;                legend.push_back("TEC");
+    DrawSuperposedHistos((TH1**)Histos, legend, "HIST",  "New Gain / Previous Gain", "Number of APV", 0.0,2.0 ,0,0);
+    DrawLegend(Histos,legend,"","L");
+    c1->SetLogy(true);
+    DrawStatBox(Histos,legend,true, 0.6, 0.7);
+    SaveCanvas(c1,output,"GainDividedPrevGain");
+    delete c1;
+
+
+   c1 = new TCanvas("c1","c1,",600,600);          legend.clear();
+   Histos[0] = GainVsPrevGainTEC;                 legend.push_back("TEC");
+   Histos[1] = GainVsPrevGainTIB;                 legend.push_back("TIB");
+   Histos[2] = GainVsPrevGainTID;                 legend.push_back("TID");
+   Histos[3] = GainVsPrevGainTOB;                 legend.push_back("TOB");
+   DrawTH2D((TH2D**)Histos,legend, "", "Previous Gain", "New Gain", 0.5,1.8, 0.5,1.8);
+   TLine diagonal(0.5,0.5,1.8,1.8);
+   diagonal.SetLineWidth(3);
+   diagonal.SetLineStyle(2);
+   diagonal.Draw("same");
+   DrawLegend (Histos,legend,"","P");
+   DrawStatBox(Histos,legend,false);
+   SaveCanvas(c1,output,"GainVsPrevGain");
+   delete c1;
+
+
 }
 
 TF1* getLandau(TH1* InputHisto, double* FitResults, double LowRange, double HighRange)

--- a/CalibTracker/SiStripChannelGain/test/7TeVData/Validation_Compute_cfg.py
+++ b/CalibTracker/SiStripChannelGain/test/7TeVData/Validation_Compute_cfg.py
@@ -8,6 +8,11 @@ process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
 
+#this block is there to solve issue related to SiStripQualityRcd
+process.load("CalibTracker.SiStripESProducers.SiStripQualityESProducer_cfi")
+process.load("CalibTracker.SiStripESProducers.fake.SiStripDetVOffFakeESSource_cfi")
+process.es_prefer_fakeSiStripDetVOff = cms.ESPrefer("SiStripDetVOffFakeESSource","siStripDetVOffFakeESSource")
+
 process.MessageLogger = cms.Service("MessageLogger",
     cout = cms.untracked.PSet( threshold = cms.untracked.string('ERROR')  ),
     destinations = cms.untracked.vstring('cout')
@@ -16,8 +21,8 @@ process.MessageLogger = cms.Service("MessageLogger",
 process.source = cms.Source("EmptyIOVSource",
     timetype   = cms.string('runnumber'),
     interval   = cms.uint64(1),
-    firstValue = cms.uint64(140058),
-    lastValue  = cms.uint64(140058)
+    firstValue = cms.uint64(XXX_FIRSTRUN_XXX),
+    lastValue  = cms.uint64(XXX_LASTRUN_XXX)
 )
 
 process.maxEvents = cms.untracked.PSet(
@@ -25,83 +30,17 @@ process.maxEvents = cms.untracked.PSet(
 )
 
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-process.GlobalTag.globaltag = 'GR10_P_V7::All'
-process.prefer("GlobalTag")
+process.GlobalTag.globaltag = 'XXX_GT_XXX::All'
 
 process.load("CalibTracker.SiStripChannelGain.computeGain_cff")
 process.SiStripCalibValidation.InputFiles          = cms.vstring(
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_16_140058_1.root',   #Size=859Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_17_140059_1.root',   #Size=2047Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_43_140124_1.root',   #Size=2047Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_45_140126_1.root',   #Size=1781Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_59_140158_1.root',   #Size=2047Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_60_140159_1.root',   #Size=2047Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_1_140160_1.root',   #Size=1064Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_24_140331_1.root',   #Size=2047Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_30_140352_1.root',   #Size=1691Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_32_140361_1.root',   #Size=808Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_33_140362_1.root',   #Size=1392Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_42_140379_1.root',   #Size=1115Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_52_140382_1.root',   #Size=1786Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_46_140383_1.root',   #Size=2047Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_47_140385_1.root',   #Size=1172Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_49_140387_1.root',   #Size=828Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_50_140388_1.root',   #Size=680Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_56_140399_1.root',   #Size=2047Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_57_140401_1.root',   #Size=1596Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_118_140401_1.root',   #Size=1596Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_20_141874_1.root',   #Size=615Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_21_141876_1.root',   #Size=542Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_24_141880_1.root',   #Size=1149Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_25_141881_1.root',   #Size=2047Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_26_141882_1.root',   #Size=1332Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_42_142187_1.root',   #Size=1616Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_44_142189_1.root',   #Size=650Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_45_142191_1.root',   #Size=586Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_67_142265_1.root',   #Size=604Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_75_142305_1.root',   #Size=873Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_78_142311_1.root',   #Size=1687Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_79_142312_1.root',   #Size=781Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_5_142414_1.root',   #Size=591Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_9_142419_1.root',   #Size=611Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_10_142420_1.root',   #Size=587Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_11_142422_1.root',   #Size=2047Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_25_142524_1.root',   #Size=1140Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_26_142525_1.root',   #Size=519Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_27_142528_1.root',   #Size=2047Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_33_142558_1.root',   #Size=882Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_47_142662_1.root',   #Size=756Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_48_142663_1.root',   #Size=640Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_6_142928_1.root',   #Size=2047Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_8_142933_1.root',   #Size=2047Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_3_142953_1.root',   #Size=1132Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_4_142954_1.root',   #Size=985Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_12_142970_1.root',   #Size=686Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_13_142971_1.root',   #Size=2047Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_15_143005_1.root',   #Size=977Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_17_143007_1.root',   #Size=2047Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_24_143181_1.root',   #Size=2047Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_25_143187_1.root',   #Size=810Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_11_143320_1.root',   #Size=564Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_37_143322_1.root',   #Size=588Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_14_143323_1.root',   #Size=1603Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_41_143326_1.root',   #Size=612Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_43_143328_1.root',   #Size=825Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_16_143657_1.root',   #Size=2047Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_50_143727_1.root',   #Size=1450Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_30_143827_1.root',   #Size=2047Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_2_143833_1.root',   #Size=1791Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_28_143953_1.root',   #Size=2047Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_29_143954_1.root',   #Size=832Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_56_143957_1.root',   #Size=594Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_36_143961_1.root',   #Size=1117Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_13_143962_1.root',   #Size=1182Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_8_144011_1.root',   #Size=1888Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_18_144086_1.root',   #Size=1345Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_12_144089_1.root',   #Size=2047Mo
-          'rfio:/castor/cern.ch/cms/store/group/tracker/strip/calibration/calibrationtree/calibTree_51_144112_1.root',   #Size=2047Mo
+XXX_CALIBTREE_XXX
 )
+
+
+
 process.SiStripCalibValidation.FirstSetOfConstants = cms.untracked.bool(False)
+process.SiStripCalibValidation.CalibrationLevel    = cms.untracked.int32(0) # 0==APV, 1==Laser, 2==module
 
 
 process.TFileService = cms.Service("TFileService",

--- a/CalibTracker/SiStripChannelGain/test/7TeVData/automatic_RunOnCalibTree.py
+++ b/CalibTracker/SiStripChannelGain/test/7TeVData/automatic_RunOnCalibTree.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+
+import os,sys
+import getopt
+import commands
+import time
+import ROOT
+
+def numberOfEvents(file):
+	rootfile = ROOT.TFile.Open(file,'read')
+	tree = ROOT.TTree()
+	rootfile.GetObject("commonCalibrationTree/tree",tree)
+        NEntries = tree.GetEntries()
+        rootfile.Close()
+        print file +' --> '+str(NEntries)
+	return NEntries	
+
+
+globaltag = "GR_P_V32" 
+path = "/store/group/tracker/strip/calibration/calibrationtree/GR12" #"/castor/cern.ch/user/m/mgalanti/calibrationtree/GR11"
+#path = "/castor/cern.ch/user/m/mgalanti/calibrationtree/GR12/"
+firstRun = -1
+#firstRun = 192701	#value of the first run with the new calibration --> this is needed to avoid mixing runs with different calibrations
+lastRun  = -1
+MC=""
+publish = True
+mail = "loic.quertenmont@gmail.com"
+automatic = True;
+
+#go to parent directory = test directory
+os.chdir("..");
+#identify last run of the previous calibration
+if(firstRun<=0):
+	out = commands.getstatusoutput("ls /afs/cern.ch/cms/tracker/sistrvalidation/WWW/CalibrationValidation/ParticleGain/ | grep Run_ | tail -n 1");
+	firstRun = int(out[1].split('_')[3])+1
+
+#Get List of CalibFiles:
+print("Get the list of calibTree from castor (cmsLs" + path + ")")
+calibTreeList = ""
+calibTreeInfo = commands.getstatusoutput("cmsLs "+path)[1].split('\n');
+NTotalEvents = 0;
+run = 0
+print("Check the number of events available");
+for info in calibTreeInfo:
+        if(len(info)<1):continue;
+	subParts = info.split();        
+	size = int(subParts[1])/1048576;
+	if(size < 50): continue	#skip file<50MB
+	run = int(subParts[4].replace(path+'/',"").replace("calibTree_","").replace(".root","")) 
+	if(run<firstRun):continue
+        if(lastRun>0 and run>lastRun):continue
+	os.system("stager_get -M " + subParts[4] + " &");	
+	NEvents = numberOfEvents("root://eoscms//eos/cms"+subParts[4]);	
+	if(calibTreeList==""):firstRun=run;
+	calibTreeList += '  "root://eoscms//eos/cms'+subParts[4]+'", #' + str(size).rjust(6)+'MB  NEvents='+str(NEvents/1000).rjust(8)+'K\n'
+	NTotalEvents += NEvents;
+	if(NTotalEvents>2500000):
+		break;
+
+if(lastRun<=0):lastRun = run
+
+#print calibTreeList
+
+print "RunRange=[" + str(firstRun) + "," + str(lastRun) + "] --> NEvents=" + str(NTotalEvents/1000)+"K"
+if(automatic==True and NTotalEvents<1000000):	#ask at least 1M events to perform the calibration
+	print 'Not Enough events to run the calibration'
+        os.system('echo "Gain calibration postponed" | mail -s "Gain calibration postponed ('+str(firstRun)+' to '+str(lastRun)+') NEvents=' + str(NTotalEvents/1000)+'K" ' + mail)
+#	exit(0);
+
+name = "Run_"+str(firstRun)+"_to_"+str(lastRun); 
+	
+oldDirectory = "7TeVData"
+newDirectory = "Data_"+name;
+os.system("mkdir -p " + newDirectory);
+os.system("cp " + oldDirectory + "/* " + newDirectory+"/.");
+os.system("sed -i 's/XXX_CALIBTREE_XXX/"+calibTreeList.replace('\n','\\n').replace('/','\/')+"/g' "+newDirectory+"/*_cfg.py")
+os.system("sed -i 's/XXX_FIRSTRUN_XXX/"+str(firstRun)+"/g' "+newDirectory+"/*_cfg.py")
+os.system("sed -i 's/XXX_LASTRUN_XXX/"+str(lastRun)+"/g' "+newDirectory+"/*_cfg.py")
+os.system("sed -i 's/XXX_GT_XXX/"+globaltag+"/g' "+newDirectory+"/*_cfg.py")
+os.chdir(newDirectory);
+if(os.system("sh sequence.sh")!=0):
+	os.system('echo "Gain calibration failed" | mail -s "Gain calibration failed ('+name+')" ' + mail)
+else:
+	if(publish==True):os.system("sh sequence.sh " + name);
+	os.system('echo "Gain calibration done\nhttps://test-stripcalibvalidation.web.cern.ch/test-stripcalibvalidation/CalibrationValidation/ParticleGain/" | mail -s "Gain calibration done ('+name+')" ' + mail)

--- a/CalibTracker/SiStripChannelGain/test/7TeVData/automatic_RunOnCalibTree_manual.py
+++ b/CalibTracker/SiStripChannelGain/test/7TeVData/automatic_RunOnCalibTree_manual.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+
+import os,sys
+import getopt
+import commands
+import time
+import ROOT
+
+def numberOfEvents(file):
+	rootfile = ROOT.TFile.Open(file,'read')
+	tree = ROOT.TTree()
+	rootfile.GetObject("commonCalibrationTree/tree",tree)
+        NEntries = tree.GetEntries()
+        rootfile.Close()
+        print file +' --> '+str(NEntries)
+	return NEntries	
+
+
+globaltag = "GR_P_V32" 
+path = "/store/group/tracker/strip/calibration/calibrationtree/GR12" #"/castor/cern.ch/user/m/mgalanti/calibrationtree/GR11"
+#path = "/castor/cern.ch/user/m/mgalanti/calibrationtree/GR12/"
+firstRun = 191919
+#firstRun = 192701	#value of the first run with the new calibration --> this is needed to avoid mixing runs with different calibrations
+lastRun  = 197000
+MC=""
+publish = True
+mail = "loic.quertenmont@gmail.com"
+automatic = True;
+
+#go to parent directory = test directory
+os.chdir("..");
+#identify last run of the previous calibration
+if(firstRun<=0):
+	out = commands.getstatusoutput("ls /afs/cern.ch/cms/tracker/sistrvalidation/WWW/CalibrationValidation/ParticleGain/ | grep Run_ | tail -n 1");
+	firstRun = int(out[1].split('_')[3])+1
+
+#Get List of CalibFiles:
+print("Get the list of calibTree from castor (cmsLs" + path + ")")
+calibTreeList = ""
+calibTreeInfo = commands.getstatusoutput("cmsLs "+path)[1].split('\n');
+NTotalEvents = 0;
+run = 0
+print("Check the number of events available");
+for info in calibTreeInfo:
+        if(len(info)<1):continue;
+	subParts = info.split();        
+	size = int(subParts[1])/1048576;
+	if(size < 50): continue	#skip file<50MB
+	run = int(subParts[4].replace(path+'/',"").replace("calibTree_","").replace(".root","")) 
+	if(run<firstRun):continue
+        if(lastRun>0 and run>lastRun):continue
+	os.system("stager_get -M " + subParts[4] + " &");	
+	NEvents = numberOfEvents("root://eoscms//eos/cms"+subParts[4]);	
+	if(calibTreeList==""):firstRun=run;
+	calibTreeList += '  "root://eoscms//eos/cms'+subParts[4]+'", #' + str(size).rjust(6)+'MB  NEvents='+str(NEvents/1000).rjust(8)+'K\n'
+	NTotalEvents += NEvents;
+	if(NTotalEvents>2500000):
+		break;
+
+if(lastRun==0):lastRun = run
+
+#print calibTreeList
+
+print "RunRange=[" + str(firstRun) + "," + str(lastRun) + "] --> NEvents=" + str(NTotalEvents/1000)+"K"
+if(automatic==True and NTotalEvents<1000000):	#ask at least 1M events to perform the calibration
+	print 'Not Enough events to run the calibration'
+        os.system('echo "Gain calibration postponed" | mail -s "Gain calibration postponed ('+str(firstRun)+' to '+str(lastRun)+') NEvents=' + str(NTotalEvents/1000)+'K" ' + mail)
+#	exit(0);
+
+name = "Run_"+str(firstRun)+"_to_"+str(lastRun); 
+	
+oldDirectory = "7TeVData"
+newDirectory = "Data_"+name;
+os.system("mkdir -p " + newDirectory);
+os.system("cp " + oldDirectory + "/* " + newDirectory+"/.");
+os.system("sed -i 's/XXX_CALIBTREE_XXX/"+calibTreeList.replace('\n','\\n').replace('/','\/')+"/g' "+newDirectory+"/*_cfg.py")
+os.system("sed -i 's/XXX_FIRSTRUN_XXX/"+str(firstRun)+"/g' "+newDirectory+"/*_cfg.py")
+os.system("sed -i 's/XXX_LASTRUN_XXX/"+str(lastRun)+"/g' "+newDirectory+"/*_cfg.py")
+os.system("sed -i 's/XXX_GT_XXX/"+globaltag+"/g' "+newDirectory+"/*_cfg.py")
+os.chdir(newDirectory);
+if(os.system("sh sequence.sh")!=0):
+	os.system('echo "Gain calibration failed" | mail -s "Gain calibration failed ('+name+')" ' + mail)
+else:
+	if(publish==True):os.system("sh sequence.sh " + name);
+	os.system('echo "Gain calibration done\nhttps://test-stripcalibvalidation.web.cern.ch/test-stripcalibvalidation/CalibrationValidation/ParticleGain/" | mail -s "Gain calibration done ('+name+')" ' + mail)

--- a/CalibTracker/SiStripChannelGain/test/PCL/Launch.py
+++ b/CalibTracker/SiStripChannelGain/test/PCL/Launch.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+
+import urllib
+import string
+import os
+import sys
+import commands
+
+DATASET="/MinimumBias/Run2012C-SiStripCalMinBias-v2/ALCARECO"
+FIRSTRUN=0 #200190
+
+runs = []
+results = commands.getstatusoutput('dbs search --query="find run,sum(block.numevents) where dataset='+DATASET+' and run>='+str(FIRSTRUN)+'"')[1].splitlines()
+results.sort()
+for line in results:
+   linesplit = line.split('   ')
+   if(len(linesplit)<2):continue
+   run     = int(line.split('   ')[0])
+   NEvents = int(line.split('   ')[1])
+   if(NEvents>100000): runs.append(run)
+
+
+
+commands.getstatusoutput('mkdir -p runs')
+for r in runs:
+    initEnv=''
+    initEnv+='cd ' + os.getcwd() + '/runs/'+str(r)+'/;'
+    initEnv+='source /afs/cern.ch/cms/cmsset_default.sh' + ';'
+    initEnv+='eval `scramv1 runtime -sh`;'
+    commands.getstatusoutput('mkdir -p runs/'+str(r))
+    print "submitting jobs for run " + str(r)
+    config_file=open('runs/'+str(r)+'/cmsDriver.sh','w')
+    config_file.write( initEnv + 'cmsDriver.py run'+str(r)+' --datatier ALCARECO --conditions auto:com10 -s ALCA:PromptCalibProdSiStripGains --eventcontent ALCARECO -n -1 --dasquery=\'file dataset=/MinimumBias/Run2012C-SiStripCalMinBias-v2/ALCARECO run='+str(r)+'\'  --fileout file:run'+str(r)+'_out.root')
+    config_file.close()
+    out = commands.getstatusoutput('bsub -q 2nw -J gainPCLrun' + str(r) +' "sh ' +  os.getcwd() + '/runs/'+str(r)+'/cmsDriver.sh"')
+#    print('bsub -q 2nw -J gainPCLrun' + str(r) +' " ' + initEnv + 'cmsDriver.py run'+str(r)+' --datatier ALCARECO --conditions auto:com10 -s ALCA:PromptCalibProdSiStripGains --eventcontent ALCARECO -n -1 --dasquery=\'file dataset=/MinimumBias/Run2012C-SiStripCalMinBias-v2/ALCARECO run='+str(r)+'\'  --fileout file:run'+str(r)+'_out.root "')
+
+
+

--- a/CalibTracker/SiStripChannelGain/test/PCL/script.sh
+++ b/CalibTracker/SiStripChannelGain/test/PCL/script.sh
@@ -1,0 +1,19 @@
+#1. produce the DQM histograms needed as input to the calibration. This eventually will run in the AlCaSplitting step @ Tier0 which produces the so called ALCAPROMPT dataset. This step runs in parallel jobs.
+cmsDriver.py step3 --datatier ALCARECO \
+--conditions auto:com10 \
+-s ALCA:PromptCalibProdSiStripGains \
+--eventcontent ALCARECO -n 100 \
+--dasquery='file dataset=/MinimumBias/Run2012C-SiStripCalMinBias-v2/ALCARECO run=200190' \
+--fileout file:step3.root --no_exec
+
+#dasquerry can be replaced by a dasquerry eventually
+#--dbsquery="find file where dataset = /MinimumBias/Run2012C-SiStripCalMinBias-v2/ALCARECO and run=200190" \
+
+
+#2. produce the sqlite and the DQM file to be uplaoded on the GUI. This the so called AlCaHarvesting step @ Tier0 and is actually a unique job running on all the files of a given run.
+cmsDriver.py step4  --data  --conditions auto:com10 \
+--scenario pp \
+-s ALCAHARVEST:SiStripGains \
+--filein file:PromptCalibProdSiStripGains.root -n -1 --no_exec
+
+#'/store/data/Run2012C/MinimumBias/ALCARECO/SiStripCalMinBias-v2/000/200/190/FAFF2948-4EDF-E111-97FB-BCAEC518FF44.root'

--- a/CalibTracker/SiStripChannelGain/test/PCL/step3_ALCA.py
+++ b/CalibTracker/SiStripChannelGain/test/PCL/step3_ALCA.py
@@ -1,0 +1,81 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.381.2.28 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/PyReleaseValidation/python/ConfigBuilder.py,v 
+# with command line options: step3 --datatier ALCARECO --conditions auto:com10 -s ALCA:PromptCalibProdSiStripGains --eventcontent ALCARECO -n 100 --dasquery=file dataset=/MinimumBias/Run2012C-SiStripCalMinBias-v2/ALCARECO run=200190 --fileout file:step3.root --no_exec
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('ALCA')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_38T_cff')
+process.load('Configuration.StandardSequences.AlCaRecoStreams_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(100)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+    secondaryFileNames = cms.untracked.vstring(),
+    fileNames = cms.untracked.vstring('/store/data/Run2012C/MinimumBias/ALCARECO/SiStripCalMinBias-v2/000/200/190/00A42AC9-4ADF-E111-8749-5404A6388697.root', 
+        '/store/data/Run2012C/MinimumBias/ALCARECO/SiStripCalMinBias-v2/000/200/190/0CC85F9E-88DF-E111-904F-001D09F29321.root', 
+        '/store/data/Run2012C/MinimumBias/ALCARECO/SiStripCalMinBias-v2/000/200/190/14F9B88E-56DF-E111-B79B-001D09F24303.root', 
+        '/store/data/Run2012C/MinimumBias/ALCARECO/SiStripCalMinBias-v2/000/200/190/16E003CB-4ADF-E111-8883-BCAEC518FF41.root', 
+        '/store/data/Run2012C/MinimumBias/ALCARECO/SiStripCalMinBias-v2/000/200/190/1800C6E5-55DF-E111-AC90-003048F1C58C.root', 
+        '/store/data/Run2012C/MinimumBias/ALCARECO/SiStripCalMinBias-v2/000/200/190/2462FB44-4EDF-E111-8D3D-BCAEC518FF8A.root', 
+        '/store/data/Run2012C/MinimumBias/ALCARECO/SiStripCalMinBias-v2/000/200/190/268097BA-58DF-E111-93A0-0025901D6288.root', 
+        '/store/data/Run2012C/MinimumBias/ALCARECO/SiStripCalMinBias-v2/000/200/190/26F372C9-5FDF-E111-9418-001D09F242EF.root', 
+        '/store/data/Run2012C/MinimumBias/ALCARECO/SiStripCalMinBias-v2/000/200/190/287CFC74-59DF-E111-9175-5404A63886D4.root', 
+        '/store/data/Run2012C/MinimumBias/ALCARECO/SiStripCalMinBias-v2/000/200/190/3866F4D2-4ADF-E111-8749-5404A63886A0.root')
+)
+
+process.options = cms.untracked.PSet(
+
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('$Revision: 1.381.2.28 $'),
+    annotation = cms.untracked.string('step3 nevts:100'),
+    name = cms.untracked.string('PyReleaseValidation')
+)
+
+# Output definition
+
+
+# Additional output definition
+process.ALCARECOStreamPromptCalibProdSiStripGains = cms.OutputModule("PoolOutputModule",
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('pathALCARECOPromptCalibProdSiStripGains')
+    ),
+    outputCommands = cms.untracked.vstring('drop *', 
+        'keep *_alcaBeamSpotProducer_*_*', 
+        'keep *_MEtoEDMConvertSiStripGains_*_*'),
+    fileName = cms.untracked.string('PromptCalibProdSiStripGains.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string('PromptCalibProdSiStripGains'),
+        dataTier = cms.untracked.string('ALCARECO')
+    ),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880)
+)
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:com10', '')
+
+# Path and EndPath definitions
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.ALCARECOStreamPromptCalibProdSiStripGainsOutPath = cms.EndPath(process.ALCARECOStreamPromptCalibProdSiStripGains)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.pathALCARECOPromptCalibProdSiStripGains,process.endjob_step,process.ALCARECOStreamPromptCalibProdSiStripGainsOutPath)
+

--- a/CalibTracker/SiStripChannelGain/test/PCL/step4_ALCAHARVEST.py
+++ b/CalibTracker/SiStripChannelGain/test/PCL/step4_ALCAHARVEST.py
@@ -1,0 +1,62 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.381.2.28 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/PyReleaseValidation/python/ConfigBuilder.py,v 
+# with command line options: step4 --data --conditions auto:com10 --scenario pp -s ALCAHARVEST:SiStripGains --filein file:PromptCalibProdSiStripGains.root -n -1 --no_exec
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('ALCAHARVEST')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff')
+process.load('Configuration.StandardSequences.AlCaHarvesting_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(-1)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+    secondaryFileNames = cms.untracked.vstring(),
+    fileNames = cms.untracked.vstring('file:PromptCalibProdSiStripGains.root'),
+    processingMode = cms.untracked.string('RunsAndLumis')
+)
+
+process.options = cms.untracked.PSet(
+    Rethrow = cms.untracked.vstring('ProductNotFound'),
+    fileMode = cms.untracked.string('FULLMERGE')
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('$Revision: 1.381.2.28 $'),
+    annotation = cms.untracked.string('step4 nevts:-1'),
+    name = cms.untracked.string('PyReleaseValidation')
+)
+
+# Output definition
+
+# Additional output definition
+
+# Other statements
+process.PoolDBOutputService.toPut.append(process.ALCAHARVESTSiStripGains_dbOutput)
+process.pclMetadataWriter.recordsToMap.append(process.ALCAHARVESTSiStripGains_metadata)
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:com10', '')
+
+# Path and EndPath definitions
+process.BeamSpotByRun = cms.Path(process.ALCAHARVESTBeamSpotByRun)
+process.ALCAHARVESTDQMSaveAndMetadataWriter = cms.Path(process.dqmSaver+process.pclMetadataWriter)
+process.SiStripGains = cms.Path(process.ALCAHARVESTSiStripGains)
+process.BeamSpotByLumi = cms.Path(process.ALCAHARVESTBeamSpotByLumi)
+process.SiStripQuality = cms.Path(process.ALCAHARVESTSiStripQuality)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.SiStripGains,process.ALCAHARVESTDQMSaveAndMetadataWriter)
+

--- a/CalibTracker/SiStripChannelGain/test/SSTGain_PCL_Config_cfg.py
+++ b/CalibTracker/SiStripChannelGain/test/SSTGain_PCL_Config_cfg.py
@@ -1,0 +1,119 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("APVGAIN")
+
+process.load('Configuration.StandardSequences.Geometry_cff')
+process.load('Configuration/StandardSequences/MagneticField_AutoFromDBCurrent_cff')
+process.load("Geometry.CMSCommonData.cmsIdealGeometryXML_cfi")
+process.load("Geometry.TrackerGeometryBuilder.trackerGeometry_cfi")
+process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+
+#this block is there to solve issue related to SiStripQualityRcd
+process.load("CalibTracker.SiStripESProducers.SiStripQualityESProducer_cfi")
+process.load("CalibTracker.SiStripESProducers.fake.SiStripDetVOffFakeESSource_cfi")
+process.es_prefer_fakeSiStripDetVOff = cms.ESPrefer("SiStripDetVOffFakeESSource","siStripDetVOffFakeESSource")
+
+
+process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
+
+#process.MessageLogger = cms.Service("MessageLogger",
+#    cout = cms.untracked.PSet( threshold = cms.untracked.string('ERROR')  ),
+#    destinations = cms.untracked.vstring('cout')
+#)
+
+
+
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+process.source = cms.Source (
+    "PoolSource",
+    fileNames = cms.untracked.vstring('/store/data/Run2012C/MinimumBias/ALCARECO/SiStripCalMinBias-v2/000/200/190/FAFF2948-4EDF-E111-97FB-BCAEC518FF44.root','/store/data/Run2012C/MinimumBias/ALCARECO/SiStripCalMinBias-v2/000/200/190/AA3A95D6-5ADF-E111-ACB3-0025901D629C.root','/store/data/Run2012C/MinimumBias/ALCARECO/SiStripCalMinBias-v2/000/200/190/A6FD8EEA-4CDF-E111-AB2A-BCAEC5329700.root','/store/data/Run2012C/MinimumBias/ALCARECO/SiStripCalMinBias-v2/000/200/190/A2358E47-4EDF-E111-A93D-BCAEC532971B.root','/store/data/Run2012C/MinimumBias/ALCARECO/SiStripCalMinBias-v2/000/200/190/9A59F24F-57DF-E111-B724-5404A63886AE.root','/store/data/Run2012C/MinimumBias/ALCARECO/SiStripCalMinBias-v2/000/200/190/9041A3ED-61DF-E111-B138-BCAEC5329713.root','/store/data/Run2012C/MinimumBias/ALCARECO/SiStripCalMinBias-v2/000/200/190/8E28BE09-64DF-E111-B559-E0CB4E55365D.root','/store/data/Run2012C/MinimumBias/ALCARECO/SiStripCalMinBias-v2/000/200/190/8A4AF852-4ADF-E111-B7D0-003048F024FE.root','/store/data/Run2012C/MinimumBias/ALCARECO/SiStripCalMinBias-v2/000/200/190/629D881A-4FDF-E111-AA10-001D09F34488.root','/store/data/Run2012C/MinimumBias/ALCARECO/SiStripCalMinBias-v2/000/200/190/3866F4D2-4ADF-E111-8749-5404A63886A0.root','/store/data/Run2012C/MinimumBias/ALCARECO/SiStripCalMinBias-v2/000/200/190/287CFC74-59DF-E111-9175-5404A63886D4.root','/store/data/Run2012C/MinimumBias/ALCARECO/SiStripCalMinBias-v2/000/200/190/26F372C9-5FDF-E111-9418-001D09F242EF.root','/store/data/Run2012C/MinimumBias/ALCARECO/SiStripCalMinBias-v2/000/200/190/268097BA-58DF-E111-93A0-0025901D6288.root','/store/data/Run2012C/MinimumBias/ALCARECO/SiStripCalMinBias-v2/000/200/190/2462FB44-4EDF-E111-8D3D-BCAEC518FF8A.root','/store/data/Run2012C/MinimumBias/ALCARECO/SiStripCalMinBias-v2/000/200/190/1800C6E5-55DF-E111-AC90-003048F1C58C.root','/store/data/Run2012C/MinimumBias/ALCARECO/SiStripCalMinBias-v2/000/200/190/16E003CB-4ADF-E111-8883-BCAEC518FF41.root','/store/data/Run2012C/MinimumBias/ALCARECO/SiStripCalMinBias-v2/000/200/190/14F9B88E-56DF-E111-B79B-001D09F24303.root','/store/data/Run2012C/MinimumBias/ALCARECO/SiStripCalMinBias-v2/000/200/190/0CC85F9E-88DF-E111-904F-001D09F29321.root','/store/data/Run2012C/MinimumBias/ALCARECO/SiStripCalMinBias-v2/000/200/190/00A42AC9-4ADF-E111-8749-5404A6388697.root',)
+    )
+
+
+process.GlobalTag.globaltag = 'GR_P_V40::All'
+
+#process.load("CalibTracker.SiStripChannelGain.computeGain_cff")
+#process.SiStripCalib.InputFiles          = cms.vstring(
+#XXX_CALIBTREE_XXX
+#)
+#process.SiStripCalib.FirstSetOfConstants = cms.untracked.bool(False)
+#process.SiStripCalib.CalibrationLevel    = cms.untracked.int32(0) # 0==APV, 1==Laser, 2==module
+
+
+process.SiStripCalib = cms.EDAnalyzer("SiStripGainFromCalibTree",
+    OutputGains         = cms.string('Gains_ASCII.txt'),
+    Tracks              = cms.untracked.InputTag('CalibrationTracksRefit'),
+    AlgoMode            = cms.untracked.string('PCL'),
+
+    #Gain quality cuts
+    minNrEntries        = cms.untracked.double(25),
+    maxChi2OverNDF      = cms.untracked.double(9999999.0),
+    maxMPVError         = cms.untracked.double(25.0),
+
+    #track/cluster quality cuts
+    minTrackMomentum    = cms.untracked.double(2),
+    maxNrStrips         = cms.untracked.uint32(8),
+
+    Validation          = cms.untracked.bool(False),
+    OldGainRemoving     = cms.untracked.bool(False),
+    FirstSetOfConstants = cms.untracked.bool(True),
+
+    CalibrationLevel    = cms.untracked.int32(0), # 0==APV, 1==Laser, 2==module
+
+    InputFiles          = cms.vstring(),
+
+    UseCalibration     = cms.untracked.bool(False),
+    calibrationPath    = cms.untracked.string(""),
+
+    SinceAppendMode     = cms.bool(True),
+    IOVMode             = cms.string('Job'),
+    Record              = cms.string('SiStripApvGainRcd'),
+    doStoreOnDB         = cms.bool(True),
+)
+
+process.SiStripCalib.FirstSetOfConstants = cms.untracked.bool(False)
+process.SiStripCalib.CalibrationLevel    = cms.untracked.int32(0) # 0==APV, 1==Laser, 2==module
+
+process.PoolDBOutputService = cms.Service("PoolDBOutputService",
+    BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
+    DBParameters = cms.PSet(
+        messageLevel = cms.untracked.int32(2),
+        authenticationPath = cms.untracked.string('/afs/cern.ch/cms/DB/conddb')
+    ),
+    timetype = cms.untracked.string('runnumber'),
+    connect = cms.string('sqlite_file:Gains_Sqlite.db'),
+    toPut = cms.VPSet(cms.PSet(
+        record = cms.string('SiStripApvGainRcd'),
+        tag = cms.string('IdealGainTag')
+    ))
+)
+
+process.TFileService = cms.Service("TFileService",
+        fileName = cms.string('Gains_Tree.root')  
+)
+
+
+
+
+
+process.load('Alignment.CommonAlignmentProducer.AlignmentTrackSelector_cfi')
+process.load('RecoVertex.BeamSpotProducer.BeamSpot_cff')
+process.load('RecoTracker.TrackProducer.TrackRefitters_cff')
+
+process.CalibrationTracksRefit = process.TrackRefitter.clone(src = cms.InputTag("CalibrationTracks"))
+process.CalibrationTracks = process.AlignmentTrackSelector.clone(
+#    src = 'generalTracks',
+    src = 'ALCARECOSiStripCalMinBias',
+    filter = True,
+    applyBasicCuts = True,
+    ptMin = 0.8,
+    nHitMin = 6,
+    chi2nMax = 10.,
+    )
+
+# refit and BS can be dropped if done together with RECO.
+# track filter can be moved in acalreco if no otehr users
+process.trackFilterRefit = cms.Sequence( process.CalibrationTracks + process.offlineBeamSpot + process.CalibrationTracksRefit )
+
+process.p = cms.Path(process.trackFilterRefit * process.SiStripCalib)

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdSiStripGains_Output_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdSiStripGains_Output_cff.py
@@ -1,0 +1,18 @@
+import FWCore.ParameterSet.Config as cms
+
+
+
+
+OutALCARECOPromptCalibProdSiStripGains_noDrop = cms.PSet(
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('pathALCARECOPromptCalibProd')
+    ),
+    outputCommands = cms.untracked.vstring(
+        'keep *_alcaBeamSpotProducer_*_*',
+        'keep *_MEtoEDMConvertSiStrip_*_*')
+)
+
+import copy
+
+OutALCARECOPromptCalibProdSiStripGains=copy.deepcopy(OutALCARECOPromptCalibProdSiStripGains_noDrop)
+OutALCARECOPromptCalibProdSiStripGains.outputCommands.insert(0, "drop *")

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdSiStripGains_Output_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdSiStripGains_Output_cff.py
@@ -5,7 +5,7 @@ import FWCore.ParameterSet.Config as cms
 
 OutALCARECOPromptCalibProdSiStripGains_noDrop = cms.PSet(
     SelectEvents = cms.untracked.PSet(
-        SelectEvents = cms.vstring('pathALCARECOPromptCalibProd')
+        SelectEvents = cms.vstring('pathALCARECOPromptCalibProdSiStripGains')
     ),
     outputCommands = cms.untracked.vstring(
         'keep *_alcaBeamSpotProducer_*_*',

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdSiStripGains_Output_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdSiStripGains_Output_cff.py
@@ -9,7 +9,7 @@ OutALCARECOPromptCalibProdSiStripGains_noDrop = cms.PSet(
     ),
     outputCommands = cms.untracked.vstring(
         'keep *_alcaBeamSpotProducer_*_*',
-        'keep *_MEtoEDMConvertSiStrip_*_*')
+        'keep *_MEtoEDMConvertSiStripGains_*_*')
 )
 
 import copy

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdSiStripGains_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdSiStripGains_cff.py
@@ -30,19 +30,13 @@ ALCARECOCalMinBiasFilterForSiStripGains.TriggerResultsTag = cms.InputTag("Trigge
 # ------------------------------------------------------------------------------
 # This is the sequence for track refitting of the track saved by SiStripCalMinBias
 # to have access to transient objects produced during RECO step and not saved
+
 # FIXME: should change names to make sure that there is no interference with any other part of the code when loading this cff
 # (since it will be loaded any time the AlCaReco definitions are loaded)
 
 
 from Alignment.CommonAlignmentProducer.AlignmentTrackSelector_cfi import *
-
-# FIXME: the beam-spot should be kept in the AlCaReco (if not already there) and dropped from here
-from RecoVertex.BeamSpotProducer.BeamSpot_cff import *
-from RecoTracker.TrackProducer.TrackRefitters_cff import *
-
-
-CalibrationTracksRefit = TrackRefitter.clone(src = cms.InputTag("CalibrationTracks"))
-CalibrationTracks = AlignmentTrackSelector.clone(
+ALCARECOCalibrationTracks = AlignmentTrackSelector.clone(
     #    src = 'generalTracks',
     src = 'ALCARECOSiStripCalMinBias',
     filter = True,
@@ -52,50 +46,56 @@ CalibrationTracks = AlignmentTrackSelector.clone(
     chi2nMax = 10.,
     )
 
+# FIXME: the beam-spot should be kept in the AlCaReco (if not already there) and dropped from here
+from RecoVertex.BeamSpotProducer.BeamSpot_cff import *
+
+from RecoTracker.TrackProducer.TrackRefitters_cff import *
+ALCARECOCalibrationTracksRefit = TrackRefitter.clone(src = cms.InputTag("ALCARECOCalibrationTracks"))
+
 # refit and BS can be dropped if done together with RECO.
 # track filter can be moved in acalreco if no otehr users
-ALCARECOTrackFilterRefit = cms.Sequence(CalibrationTracks +
+ALCARECOTrackFilterRefit = cms.Sequence(ALCARECOCalibrationTracks +
                                         offlineBeamSpot +
-                                        CalibrationTracksRefit )
+                                        ALCARECOCalibrationTracksRefit )
 
 
 # ------------------------------------------------------------------------------
 # This is the module actually doing the calibration
 
 # FIXME: the safest option would be to import the basic cfi from a place mantained by the developer
-SiStripCalib = cms.EDAnalyzer("SiStripGainFromCalibTree",
-                              OutputGains         = cms.string('Gains_ASCII.txt'),
-                              Tracks              = cms.untracked.InputTag('CalibrationTracksRefit'),
-                              AlgoMode            = cms.untracked.string('PCL'),
+ALCARECOSiStripCalib = cms.EDAnalyzer("SiStripGainFromCalibTree",
+                                  OutputGains         = cms.string('Gains_ASCII.txt'),
+                                  Tracks              = cms.untracked.InputTag('ALCARECOCalibrationTracksRefit'),
+                                  AlgoMode            = cms.untracked.string('PCL'),
 
-                              #Gain quality cuts
-                              minNrEntries        = cms.untracked.double(25),
-                              maxChi2OverNDF      = cms.untracked.double(9999999.0),
-                              maxMPVError         = cms.untracked.double(25.0),
-                              
-                              #track/cluster quality cuts
-                              minTrackMomentum    = cms.untracked.double(2),
-                              maxNrStrips         = cms.untracked.uint32(8),
-                              
-                              Validation          = cms.untracked.bool(False),
-                              OldGainRemoving     = cms.untracked.bool(False),
-                              FirstSetOfConstants = cms.untracked.bool(True),
-                              
-                              CalibrationLevel    = cms.untracked.int32(0), # 0==APV, 1==Laser, 2==module
-                              
-                              InputFiles          = cms.vstring(),
-                              
-                              UseCalibration     = cms.untracked.bool(False),
-                              calibrationPath    = cms.untracked.string(""),
+                                  #Gain quality cuts
+                                  minNrEntries        = cms.untracked.double(25),
+                                  maxChi2OverNDF      = cms.untracked.double(9999999.0),
+                                  maxMPVError         = cms.untracked.double(25.0),
 
-                              SinceAppendMode     = cms.bool(True),
-                              IOVMode             = cms.string('Job'),
-                              Record              = cms.string('SiStripApvGainRcd'),
-                              doStoreOnDB         = cms.bool(True),
-                              )
+                                  #track/cluster quality cuts
+                                  minTrackMomentum    = cms.untracked.double(2),
+                                  maxNrStrips         = cms.untracked.uint32(8),
 
-SiStripCalib.FirstSetOfConstants = cms.untracked.bool(False)
-SiStripCalib.CalibrationLevel    = cms.untracked.int32(0) # 0==APV, 1==Laser, 2==module
+                                  Validation          = cms.untracked.bool(False),
+                                  OldGainRemoving     = cms.untracked.bool(False),
+                                  FirstSetOfConstants = cms.untracked.bool(True),
+
+                                  CalibrationLevel    = cms.untracked.int32(0), # 0==APV, 1==Laser, 2==module
+
+                                  InputFiles          = cms.vstring(),
+
+                                  UseCalibration     = cms.untracked.bool(False),
+                                  calibrationPath    = cms.untracked.string(""),
+
+                                  SinceAppendMode     = cms.bool(True),
+                                  IOVMode             = cms.string('Job'),
+                                  Record              = cms.string('SiStripApvGainRcd'),
+                                  doStoreOnDB         = cms.bool(True),
+                                  )
+
+ALCARECOSiStripCalib.FirstSetOfConstants = cms.untracked.bool(False)
+ALCARECOSiStripCalib.CalibrationLevel    = cms.untracked.int32(0) # 0==APV, 1==Laser, 2==module
 
 
 # ------------------------------------------------------------------------------
@@ -129,6 +129,6 @@ TFileService = cms.Service("TFileService",
 
 seqALCARECOPromptCalibProdSiStripGains = cms.Sequence(ALCARECOCalMinBiasFilterForSiStripGains *
                                                       ALCARECOTrackFilterRefit *
-                                                      SiStripCalib)
+                                                      ALCARECOSiStripCalib)
 
 

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdSiStripGains_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdSiStripGains_cff.py
@@ -13,7 +13,122 @@ ALCARECOCalMinBiasFilterForSiStripGains.TriggerResultsTag = cms.InputTag("Trigge
 
 
 # ------------------------------------------------------------------------------
-                     
-seqALCARECOPromptCalibProdSiStripGains = cms.Sequence(ALCARECOCalMinBiasFilterForSiStripGains)
+
+
+# FIXME: are the following blocks needed?
+
+#this block is there to solve issue related to SiStripQualityRcd
+#process.load("CalibTracker.SiStripESProducers.SiStripQualityESProducer_cfi")
+#process.load("CalibTracker.SiStripESProducers.fake.SiStripDetVOffFakeESSource_cfi")
+#process.es_prefer_fakeSiStripDetVOff = cms.ESPrefer("SiStripDetVOffFakeESSource","siStripDetVOffFakeESSource")
+
+
+#process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
+
+
+
+# ------------------------------------------------------------------------------
+# This is the sequence for track refitting of the track saved by SiStripCalMinBias
+# to have access to transient objects produced during RECO step and not saved
+# FIXME: should change names to make sure that there is no interference with any other part of the code when loading this cff
+# (since it will be loaded any time the AlCaReco definitions are loaded)
+
+
+from Alignment.CommonAlignmentProducer.AlignmentTrackSelector_cfi import *
+
+# FIXME: the beam-spot should be kept in the AlCaReco (if not already there) and dropped from here
+from RecoVertex.BeamSpotProducer.BeamSpot_cff import *
+from RecoTracker.TrackProducer.TrackRefitters_cff import *
+
+
+CalibrationTracksRefit = TrackRefitter.clone(src = cms.InputTag("CalibrationTracks"))
+CalibrationTracks = AlignmentTrackSelector.clone(
+    #    src = 'generalTracks',
+    src = 'ALCARECOSiStripCalMinBias',
+    filter = True,
+    applyBasicCuts = True,
+    ptMin = 0.8,
+    nHitMin = 6,
+    chi2nMax = 10.,
+    )
+
+# refit and BS can be dropped if done together with RECO.
+# track filter can be moved in acalreco if no otehr users
+ALCARECOTrackFilterRefit = cms.Sequence(CalibrationTracks +
+                                        offlineBeamSpot +
+                                        CalibrationTracksRefit )
+
+
+# ------------------------------------------------------------------------------
+# This is the module actually doing the calibration
+
+# FIXME: the safest option would be to import the basic cfi from a place mantained by the developer
+SiStripCalib = cms.EDAnalyzer("SiStripGainFromCalibTree",
+                              OutputGains         = cms.string('Gains_ASCII.txt'),
+                              Tracks              = cms.untracked.InputTag('CalibrationTracksRefit'),
+                              AlgoMode            = cms.untracked.string('PCL'),
+
+                              #Gain quality cuts
+                              minNrEntries        = cms.untracked.double(25),
+                              maxChi2OverNDF      = cms.untracked.double(9999999.0),
+                              maxMPVError         = cms.untracked.double(25.0),
+                              
+                              #track/cluster quality cuts
+                              minTrackMomentum    = cms.untracked.double(2),
+                              maxNrStrips         = cms.untracked.uint32(8),
+                              
+                              Validation          = cms.untracked.bool(False),
+                              OldGainRemoving     = cms.untracked.bool(False),
+                              FirstSetOfConstants = cms.untracked.bool(True),
+                              
+                              CalibrationLevel    = cms.untracked.int32(0), # 0==APV, 1==Laser, 2==module
+                              
+                              InputFiles          = cms.vstring(),
+                              
+                              UseCalibration     = cms.untracked.bool(False),
+                              calibrationPath    = cms.untracked.string(""),
+
+                              SinceAppendMode     = cms.bool(True),
+                              IOVMode             = cms.string('Job'),
+                              Record              = cms.string('SiStripApvGainRcd'),
+                              doStoreOnDB         = cms.bool(True),
+                              )
+
+SiStripCalib.FirstSetOfConstants = cms.untracked.bool(False)
+SiStripCalib.CalibrationLevel    = cms.untracked.int32(0) # 0==APV, 1==Laser, 2==module
+
+
+# ------------------------------------------------------------------------------
+# Here we define additional services needed by the module
+
+# FIXME: find a better place or remove (PoolDBOutputService is not required in the final config since the DB will be written in the following step
+PoolDBOutputService = cms.Service("PoolDBOutputService",
+                                  BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
+                                  DBParameters = cms.PSet(
+                                      messageLevel = cms.untracked.int32(2),
+                                      authenticationPath = cms.untracked.string('/afs/cern.ch/cms/DB/conddb')
+                                      ),
+                                  timetype = cms.untracked.string('runnumber'),
+                                  connect = cms.string('sqlite_file:Gains_Sqlite.db'),
+                                  toPut = cms.VPSet(cms.PSet(
+                                      record = cms.string('SiStripApvGainRcd'),
+                                      tag = cms.string('IdealGainTag')
+                                      ))
+                                  )
+
+TFileService = cms.Service("TFileService",
+                           fileName = cms.string('Gains_Tree.root')  
+                           )
+
+
+
+
+
+
+
+
+seqALCARECOPromptCalibProdSiStripGains = cms.Sequence(ALCARECOCalMinBiasFilterForSiStripGains *
+                                                      ALCARECOTrackFilterRefit *
+                                                      SiStripCalib)
 
 

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdSiStripGains_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdSiStripGains_cff.py
@@ -96,39 +96,46 @@ ALCARECOSiStripCalib = cms.EDAnalyzer("SiStripGainFromCalibTree",
 
 ALCARECOSiStripCalib.FirstSetOfConstants = cms.untracked.bool(False)
 ALCARECOSiStripCalib.CalibrationLevel    = cms.untracked.int32(0) # 0==APV, 1==Laser, 2==module
+ALCARECOSiStripCalib.harvestingMode    = cms.untracked.bool(False)
+ALCARECOSiStripCalib.doStoreOnDB         = cms.bool(False)
 
 
 # ------------------------------------------------------------------------------
-# Here we define additional services needed by the module
-
-# FIXME: find a better place or remove (PoolDBOutputService is not required in the final config since the DB will be written in the following step
-PoolDBOutputService = cms.Service("PoolDBOutputService",
-                                  BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
-                                  DBParameters = cms.PSet(
-                                      messageLevel = cms.untracked.int32(2),
-                                      authenticationPath = cms.untracked.string('/afs/cern.ch/cms/DB/conddb')
-                                      ),
-                                  timetype = cms.untracked.string('runnumber'),
-                                  connect = cms.string('sqlite_file:Gains_Sqlite.db'),
-                                  toPut = cms.VPSet(cms.PSet(
-                                      record = cms.string('SiStripApvGainRcd'),
-                                      tag = cms.string('IdealGainTag')
-                                      ))
-                                  )
-
-TFileService = cms.Service("TFileService",
-                           fileName = cms.string('Gains_Tree.root')  
-                           )
+MEtoEDMConvertSiStripGains = cms.EDProducer("MEtoEDMConverter",
+                                            Name = cms.untracked.string('MEtoEDMConverter'),
+                                            Verbosity = cms.untracked.int32(0), # 0 provides no output
+                                            # 1 provides basic output
+                                            # 2 provide more detailed output
+                                            Frequency = cms.untracked.int32(50),
+                                            MEPathToSave = cms.untracked.string('AlCaReco/SiStripGains'),
+                                            deleteAfterCopy = cms.untracked.bool(False)
+)
 
 
 
 
+# # ------------------------------------------------------------------------------
+# # Here we define additional services needed by the module
 
-
+# # FIXME: find a better place or remove (PoolDBOutputService is not required in the final config since the DB will be written in the following step
+# PoolDBOutputService = cms.Service("PoolDBOutputService",
+#                                   BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
+#                                   DBParameters = cms.PSet(
+#                                       messageLevel = cms.untracked.int32(2),
+#                                       authenticationPath = cms.untracked.string('/afs/cern.ch/cms/DB/conddb')
+#                                       ),
+#                                   timetype = cms.untracked.string('runnumber'),
+#                                   connect = cms.string('sqlite_file:Gains_Sqlite.db'),
+#                                   toPut = cms.VPSet(cms.PSet(
+#                                       record = cms.string('SiStripApvGainRcd'),
+#                                       tag = cms.string('IdealGainTag')
+#                                       ))
+#                                   )
 
 
 seqALCARECOPromptCalibProdSiStripGains = cms.Sequence(ALCARECOCalMinBiasFilterForSiStripGains *
                                                       ALCARECOTrackFilterRefit *
-                                                      ALCARECOSiStripCalib)
+                                                      ALCARECOSiStripCalib *
+                                                      MEtoEDMConvertSiStripGains)
 
 

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdSiStripGains_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdSiStripGains_cff.py
@@ -1,0 +1,19 @@
+import FWCore.ParameterSet.Config as cms
+
+# ------------------------------------------------------------------------------
+# configure a filter to run only on the events selected by TkAlMinBias AlcaReco
+import copy
+from HLTrigger.HLTfilters.hltHighLevel_cfi import *
+ALCARECOCalMinBiasFilterForSiStripGains = copy.deepcopy(hltHighLevel)
+ALCARECOCalMinBiasFilterForSiStripGains.HLTPaths = ['pathALCARECOSiStripCalMinBias']
+ALCARECOCalMinBiasFilterForSiStripGains.throw = True ## dont throw on unknown path names
+ALCARECOCalMinBiasFilterForSiStripGains.TriggerResultsTag = cms.InputTag("TriggerResults","","RECO")
+#process.TkAlMinBiasFilterForBS.eventSetupPathsKey = 'pathALCARECOTkAlMinBias:RECO'
+#ALCARECODtCalibHLTFilter.andOr = True ## choose logical OR between Triggerbits
+
+
+# ------------------------------------------------------------------------------
+                     
+seqALCARECOPromptCalibProdSiStripGains = cms.Sequence(ALCARECOCalMinBiasFilterForSiStripGains)
+
+

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdSiStripGains_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdSiStripGains_cff.py
@@ -80,25 +80,9 @@ MEtoEDMConvertSiStripGains = cms.EDProducer("MEtoEDMConverter",
 
 
 
-# # ------------------------------------------------------------------------------
-# # Here we define additional services needed by the module
-
-# # FIXME: find a better place or remove (PoolDBOutputService is not required in the final config since the DB will be written in the following step
-# PoolDBOutputService = cms.Service("PoolDBOutputService",
-#                                   BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
-#                                   DBParameters = cms.PSet(
-#                                       messageLevel = cms.untracked.int32(2),
-#                                       authenticationPath = cms.untracked.string('/afs/cern.ch/cms/DB/conddb')
-#                                       ),
-#                                   timetype = cms.untracked.string('runnumber'),
-#                                   connect = cms.string('sqlite_file:Gains_Sqlite.db'),
-#                                   toPut = cms.VPSet(cms.PSet(
-#                                       record = cms.string('SiStripApvGainRcd'),
-#                                       tag = cms.string('IdealGainTag')
-#                                       ))
-#                                   )
 
 
+# the actual sequence
 seqALCARECOPromptCalibProdSiStripGains = cms.Sequence(ALCARECOCalMinBiasFilterForSiStripGains *
                                                       ALCARECOTrackFilterRefit *
                                                       ALCARECOSiStripCalib *

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdSiStripGains_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdSiStripGains_cff.py
@@ -31,10 +31,6 @@ ALCARECOCalMinBiasFilterForSiStripGains.TriggerResultsTag = cms.InputTag("Trigge
 # This is the sequence for track refitting of the track saved by SiStripCalMinBias
 # to have access to transient objects produced during RECO step and not saved
 
-# FIXME: should change names to make sure that there is no interference with any other part of the code when loading this cff
-# (since it will be loaded any time the AlCaReco definitions are loaded)
-
-
 from Alignment.CommonAlignmentProducer.AlignmentTrackSelector_cfi import *
 ALCARECOCalibrationTracks = AlignmentTrackSelector.clone(
     #    src = 'generalTracks',

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdSiStripGains_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdSiStripGains_cff.py
@@ -48,10 +48,14 @@ from RecoVertex.BeamSpotProducer.BeamSpot_cff import *
 from RecoTracker.TrackProducer.TrackRefitters_cff import *
 ALCARECOCalibrationTracksRefit = TrackRefitter.clone(src = cms.InputTag("ALCARECOCalibrationTracks"))
 
+from RecoTracker.MeasurementDet.MeasurementTrackerEventProducer_cfi import *
+
+
 # refit and BS can be dropped if done together with RECO.
 # track filter can be moved in acalreco if no otehr users
 ALCARECOTrackFilterRefit = cms.Sequence(ALCARECOCalibrationTracks +
                                         offlineBeamSpot +
+                                        MeasurementTrackerEvent +
                                         ALCARECOCalibrationTracksRefit )
 
 

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdSiStripGains_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdSiStripGains_cff.py
@@ -58,40 +58,10 @@ ALCARECOTrackFilterRefit = cms.Sequence(ALCARECOCalibrationTracks +
 # ------------------------------------------------------------------------------
 # This is the module actually doing the calibration
 
-# FIXME: the safest option would be to import the basic cfi from a place mantained by the developer
-ALCARECOSiStripCalib = cms.EDAnalyzer("SiStripGainFromCalibTree",
-                                  OutputGains         = cms.string('Gains_ASCII.txt'),
-                                  Tracks              = cms.untracked.InputTag('ALCARECOCalibrationTracksRefit'),
-                                  AlgoMode            = cms.untracked.string('PCL'),
-
-                                  #Gain quality cuts
-                                  minNrEntries        = cms.untracked.double(25),
-                                  maxChi2OverNDF      = cms.untracked.double(9999999.0),
-                                  maxMPVError         = cms.untracked.double(25.0),
-
-                                  #track/cluster quality cuts
-                                  minTrackMomentum    = cms.untracked.double(2),
-                                  maxNrStrips         = cms.untracked.uint32(8),
-
-                                  Validation          = cms.untracked.bool(False),
-                                  OldGainRemoving     = cms.untracked.bool(False),
-                                  FirstSetOfConstants = cms.untracked.bool(True),
-
-                                  CalibrationLevel    = cms.untracked.int32(0), # 0==APV, 1==Laser, 2==module
-
-                                  InputFiles          = cms.vstring(),
-
-                                  UseCalibration     = cms.untracked.bool(False),
-                                  calibrationPath    = cms.untracked.string(""),
-
-                                  SinceAppendMode     = cms.bool(True),
-                                  IOVMode             = cms.string('Job'),
-                                  Record              = cms.string('SiStripApvGainRcd'),
-                                  doStoreOnDB         = cms.bool(True),
-                                  )
-
+from CalibTracker.SiStripChannelGain.computeGain_cff import SiStripCalib as ALCARECOSiStripCalib
+ALCARECOSiStripCalib.AlgoMode = cms.untracked.string('PCL')
+ALCARECOSiStripCalib.Tracks   = cms.untracked.InputTag('ALCARECOCalibrationTracksRefit')
 ALCARECOSiStripCalib.FirstSetOfConstants = cms.untracked.bool(False)
-ALCARECOSiStripCalib.CalibrationLevel    = cms.untracked.int32(0) # 0==APV, 1==Laser, 2==module
 ALCARECOSiStripCalib.harvestingMode    = cms.untracked.bool(False)
 ALCARECOSiStripCalib.doStoreOnDB         = cms.bool(False)
 

--- a/Calibration/TkAlCaRecoProducers/python/AlcaSiStripGainsHarvester_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/AlcaSiStripGainsHarvester_cff.py
@@ -10,4 +10,4 @@ EDMtoMEConvertSiStripGains.runInputTag = cms.InputTag("MEtoEDMConvertSiStripGain
 DQMStore = cms.Service("DQMStore")
 
 ALCAHARVESTSiStripGains = cms.Sequence(EDMtoMEConvertSiStripGains + alcaSiStripGainsHarvester)
-#ALCAHARVESTSiStripQuality = cms.Sequence(EDMtoMEConvertSiStrip + dqmSaver)
+

--- a/Calibration/TkAlCaRecoProducers/python/AlcaSiStripGainsHarvester_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/AlcaSiStripGainsHarvester_cff.py
@@ -1,0 +1,13 @@
+import FWCore.ParameterSet.Config as cms
+
+from Calibration.TkAlCaRecoProducers.AlcaSiStripGainsHarvester_cfi import *
+from DQMServices.Components.EDMtoMEConverter_cfi import *
+
+EDMtoMEConvertSiStripGains = EDMtoMEConverter.clone()
+EDMtoMEConvertSiStripGains.lumiInputTag = cms.InputTag("MEtoEDMConvertSiStripGains","MEtoEDMConverterLumi")
+EDMtoMEConvertSiStripGains.runInputTag = cms.InputTag("MEtoEDMConvertSiStripGains","MEtoEDMConverterRun")
+
+DQMStore = cms.Service("DQMStore")
+
+ALCAHARVESTSiStripGains = cms.Sequence(EDMtoMEConvertSiStripGains + alcaSiStripGainsHarvester)
+#ALCAHARVESTSiStripQuality = cms.Sequence(EDMtoMEConvertSiStrip + dqmSaver)

--- a/Calibration/TkAlCaRecoProducers/python/AlcaSiStripGainsHarvester_cfi.py
+++ b/Calibration/TkAlCaRecoProducers/python/AlcaSiStripGainsHarvester_cfi.py
@@ -1,0 +1,42 @@
+import FWCore.ParameterSet.Config as cms
+
+# FIXME: the safest option would be to import the basic cfi from a place mantained by the developer
+alcaSiStripGainsHarvester =  cms.EDAnalyzer("SiStripGainFromCalibTree",
+
+                                  OutputGains         = cms.string('Gains_ASCII.txt'),
+                                  Tracks              = cms.untracked.InputTag('ALCARECOCalibrationTracksRefit'),
+                                  AlgoMode            = cms.untracked.string('PCL'),
+
+                                  #Gain quality cuts
+                                  minNrEntries        = cms.untracked.double(25),
+                                  maxChi2OverNDF      = cms.untracked.double(9999999.0),
+                                  maxMPVError         = cms.untracked.double(25.0),
+
+                                  #track/cluster quality cuts
+                                  minTrackMomentum    = cms.untracked.double(2),
+                                  maxNrStrips         = cms.untracked.uint32(8),
+
+                                  Validation          = cms.untracked.bool(False),
+                                  OldGainRemoving     = cms.untracked.bool(False),
+                                  FirstSetOfConstants = cms.untracked.bool(True),
+
+                                  CalibrationLevel    = cms.untracked.int32(0), # 0==APV, 1==Laser, 2==module
+
+                                  InputFiles          = cms.vstring(),
+
+                                  UseCalibration     = cms.untracked.bool(False),
+                                  calibrationPath    = cms.untracked.string(""),
+
+                                  SinceAppendMode     = cms.bool(True),
+                                  IOVMode             = cms.string('Job'),
+                                  Record              = cms.string('SiStripApvGainRcd'),
+                                  doStoreOnDB         = cms.bool(True),
+                                  )
+
+alcaSiStripGainsHarvester.FirstSetOfConstants = cms.untracked.bool(False)
+alcaSiStripGainsHarvester.CalibrationLevel    = cms.untracked.int32(0) # 0==APV, 1==Laser, 2==module
+
+# THIS is the crucial parameter to use this in harvesting mode                                  
+alcaSiStripGainsHarvester.harvestingMode      = cms.untracked.bool(True),
+
+

--- a/Calibration/TkAlCaRecoProducers/python/AlcaSiStripGainsHarvester_cfi.py
+++ b/Calibration/TkAlCaRecoProducers/python/AlcaSiStripGainsHarvester_cfi.py
@@ -37,6 +37,6 @@ alcaSiStripGainsHarvester.FirstSetOfConstants = cms.untracked.bool(False)
 alcaSiStripGainsHarvester.CalibrationLevel    = cms.untracked.int32(0) # 0==APV, 1==Laser, 2==module
 
 # THIS is the crucial parameter to use this in harvesting mode                                  
-alcaSiStripGainsHarvester.harvestingMode      = cms.untracked.bool(True),
+alcaSiStripGainsHarvester.harvestingMode      = cms.untracked.bool(True)
 
 

--- a/Calibration/TkAlCaRecoProducers/python/AlcaSiStripGainsHarvester_cfi.py
+++ b/Calibration/TkAlCaRecoProducers/python/AlcaSiStripGainsHarvester_cfi.py
@@ -1,42 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
 # FIXME: the safest option would be to import the basic cfi from a place mantained by the developer
-alcaSiStripGainsHarvester =  cms.EDAnalyzer("SiStripGainFromCalibTree",
 
-                                  OutputGains         = cms.string('Gains_ASCII.txt'),
-                                  Tracks              = cms.untracked.InputTag('ALCARECOCalibrationTracksRefit'),
-                                  AlgoMode            = cms.untracked.string('PCL'),
-
-                                  #Gain quality cuts
-                                  minNrEntries        = cms.untracked.double(25),
-                                  maxChi2OverNDF      = cms.untracked.double(9999999.0),
-                                  maxMPVError         = cms.untracked.double(25.0),
-
-                                  #track/cluster quality cuts
-                                  minTrackMomentum    = cms.untracked.double(2),
-                                  maxNrStrips         = cms.untracked.uint32(8),
-
-                                  Validation          = cms.untracked.bool(False),
-                                  OldGainRemoving     = cms.untracked.bool(False),
-                                  FirstSetOfConstants = cms.untracked.bool(True),
-
-                                  CalibrationLevel    = cms.untracked.int32(0), # 0==APV, 1==Laser, 2==module
-
-                                  InputFiles          = cms.vstring(),
-
-                                  UseCalibration     = cms.untracked.bool(False),
-                                  calibrationPath    = cms.untracked.string(""),
-
-                                  SinceAppendMode     = cms.bool(True),
-                                  IOVMode             = cms.string('Job'),
-                                  Record              = cms.string('SiStripApvGainRcd'),
-                                  doStoreOnDB         = cms.bool(True),
-                                  )
-
+from CalibTracker.SiStripChannelGain.computeGain_cff import SiStripCalib as alcaSiStripGainsHarvester
+alcaSiStripGainsHarvester.AlgoMode = cms.untracked.string('PCL')
+alcaSiStripGainsHarvester.Tracks   = cms.untracked.InputTag('ALCARECOCalibrationTracksRefit')
 alcaSiStripGainsHarvester.FirstSetOfConstants = cms.untracked.bool(False)
 alcaSiStripGainsHarvester.CalibrationLevel    = cms.untracked.int32(0) # 0==APV, 1==Laser, 2==module
-
-# THIS is the crucial parameter to use this in harvesting mode                                  
-alcaSiStripGainsHarvester.harvestingMode      = cms.untracked.bool(True)
-
-
+alcaSiStripGainsHarvester.harvestingMode    = cms.untracked.bool(True)

--- a/Calibration/TkAlCaRecoProducers/python/AlcaSiStripGainsHarvester_cfi.py
+++ b/Calibration/TkAlCaRecoProducers/python/AlcaSiStripGainsHarvester_cfi.py
@@ -1,6 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-# FIXME: the safest option would be to import the basic cfi from a place mantained by the developer
 
 from CalibTracker.SiStripChannelGain.computeGain_cff import SiStripCalib as alcaSiStripGainsHarvester
 alcaSiStripGainsHarvester.AlgoMode = cms.untracked.string('PCL')

--- a/Configuration/EventContent/python/AlCaRecoOutput_cff.py
+++ b/Configuration/EventContent/python/AlCaRecoOutput_cff.py
@@ -100,6 +100,8 @@ from CalibMuon.DTCalibration.ALCARECODtCalibCosmics_Output_cff import *
 ###############################################################
 from Calibration.TkAlCaRecoProducers.ALCARECOPromptCalibProd_Output_cff import *
 from Calibration.TkAlCaRecoProducers.ALCARECOPromptCalibProdSiStrip_Output_cff import *
+from Calibration.TkAlCaRecoProducers.ALCARECOPromptCalibProdSiStripGains_Output_cff import *
+
 from Calibration.TkAlCaRecoProducers.ALCARECOSiStripPCLHistos_Output_cff import *
 
 # stream for the LumiPixels workflow

--- a/Configuration/StandardSequences/python/AlCaHarvesting_cff.py
+++ b/Configuration/StandardSequences/python/AlCaHarvesting_cff.py
@@ -3,9 +3,11 @@ import FWCore.ParameterSet.Config as cms
 # import the needed ingredients
 from Calibration.TkAlCaRecoProducers.AlcaBeamSpotHarvester_cff import *
 from Calibration.TkAlCaRecoProducers.AlcaSiStripQualityHarvester_cff import *
+from Calibration.TkAlCaRecoProducers.AlcaSiStripGainsHarvester_cff import *
+
 from Calibration.TkAlCaRecoProducers.PCLMetadataWriter_cfi import *
 
-# commoon ingredients
+# common ingredients
 from CondCore.DBCommon.CondDBCommon_cfi import CondDBCommon
 CondDBCommon.connect = "sqlite_file:promptCalibConditions.db"
 
@@ -31,14 +33,6 @@ ALCAHARVESTBeamSpotByRun.AlcaBeamSpotHarvesterParameters.outputRecordName = cms.
 
 
 ALCAHARVESTBeamSpotByRun_metadata = cms.PSet(record              = cms.untracked.string('BeamSpotObjectsRcdByRun'),
-#                                              destDB              = cms.untracked.string("oracle://cms_orcon_prod/CMS_COND_31X_BEAMSPOT"),
-#                                              destDBValidation    = cms.untracked.string("oracle://cms_orcoff_prep/CMS_COND_BEAMSPOT"),
-#                                              tag                 = cms.untracked.string("BeamSpotObjects_PCL_byRun_v0_offline"),
-#                                              Timetype            = cms.untracked.string("runnumber"),
-#                                              IOVCheck            = cms.untracked.string("All"),
-#                                              DuplicateTagHLT     = cms.untracked.string("BeamSpotObjects_PCL_byRun_v0_hlt"),
-#                                              DuplicateTagEXPRESS = cms.untracked.string(""),
-#                                              DuplicateTagPROMPT  = cms.untracked.string("BeamSpotObjects_PCL_byRun_v0_prompt"),
                                              )
 
 
@@ -51,16 +45,8 @@ ALCAHARVESTBeamSpotByLumi = alcaBeamSpotHarvester.clone()
 ALCAHARVESTBeamSpotByLumi.AlcaBeamSpotHarvesterParameters.BeamSpotOutputBase = cms.untracked.string("lumibased")
 ALCAHARVESTBeamSpotByLumi.AlcaBeamSpotHarvesterParameters.outputRecordName = cms.untracked.string("BeamSpotObjectsRcdByLumi")
 
-
+# configuration of DropBox metadata and DB output
 ALCAHARVESTBeamSpotByLumi_metadata = cms.PSet(record              = cms.untracked.string('BeamSpotObjectsRcdByLumi'),
-#                                               destDB              = cms.untracked.string("oracle://cms_orcon_prod/CMS_COND_31X_BEAMSPOT"),
-#                                               destDBValidation    = cms.untracked.string("oracle://cms_orcoff_prep/CMS_COND_BEAMSPOT"),
-#                                               tag                 = cms.untracked.string("BeamSpotObjects_PCL_byLumi_v0_offline"),
-#                                               Timetype            = cms.untracked.string("lumiid"),
-#                                               IOVCheck            = cms.untracked.string("All"),
-#                                               DuplicateTagHLT     = cms.untracked.string("BeamSpotObjects_PCL_byLumi_v0_hlt"),
-#                                               DuplicateTagEXPRESS = cms.untracked.string(""),
-#                                               DuplicateTagPROMPT  = cms.untracked.string("BeamSpotObjects_PCL_byLumi_v0_prompt"),
                                               )
 
 ALCAHARVESTBeamSpotByLumi_dbOutput = cms.PSet(record = cms.string('BeamSpotObjectsRcdByLumi'),
@@ -69,14 +55,6 @@ ALCAHARVESTBeamSpotByLumi_dbOutput = cms.PSet(record = cms.string('BeamSpotObjec
 
 
 ALCAHARVESTSiStripQuality_metadata = cms.PSet(record              = cms.untracked.string('SiStripBadStripRcd'),
-#                                               destDB              = cms.untracked.string("oracle://cms_orcon_prod/CMS_COND_31X_STRIP"),
-#                                               destDBValidation    = cms.untracked.string("oracle://cms_orcoff_prep/CMS_COND_STRIP"),
-#                                               tag                 = cms.untracked.string("SiStripBadChannel_PCL_v0_offline"),
-#                                               Timetype            = cms.untracked.string("runnumber"),
-#                                               IOVCheck            = cms.untracked.string("All"),
-#                                               DuplicateTagHLT     = cms.untracked.string("SiStripBadChannel_PCL_v0_hlt"),
-#                                               DuplicateTagEXPRESS = cms.untracked.string(""),
-#                                               DuplicateTagPROMPT  = cms.untracked.string("SiStripBadChannel_PCL_v0_prompt"),
                                               )
 
 
@@ -85,12 +63,22 @@ ALCAHARVESTSiStripQuality_dbOutput = cms.PSet(record = cms.string('SiStripBadStr
                                              timetype   = cms.untracked.string('runnumber'))
 
 
+ALCAHARVESTSiStripGains_metadata = cms.PSet(record              = cms.untracked.string('SiStripApvGainRcd'),
+                                              )
+
+
+ALCAHARVESTSiStripGains_dbOutput = cms.PSet(record = cms.string('SiStripApvGainRcd'),
+                                             tag = cms.string('SiStripApvGain_pcl'),
+                                             timetype   = cms.untracked.string('runnumber'))
+
+
+
 # define the paths
 
-BeamSpotByRun = cms.Path(ALCAHARVESTBeamSpotByRun)
+BeamSpotByRun  = cms.Path(ALCAHARVESTBeamSpotByRun)
 BeamSpotByLumi = cms.Path(ALCAHARVESTBeamSpotByLumi)
 SiStripQuality = cms.Path(ALCAHARVESTSiStripQuality)
-
+SiStripGains   = cms.Path(ALCAHARVESTSiStripGains)
 ALCAHARVESTDQMSaveAndMetadataWriter = cms.Path(dqmSaver+pclMetadataWriter)
 
 #promptCalibHarvest = cms.Path(alcaBeamSpotHarvester)

--- a/Configuration/StandardSequences/python/AlCaRecoStreams_cff.py
+++ b/Configuration/StandardSequences/python/AlCaRecoStreams_cff.py
@@ -93,6 +93,8 @@ from Alignment.CommonAlignmentProducer.ALCARECOMuAlBeamHaloOverlaps_cff import *
 ###############################################################
 from Calibration.TkAlCaRecoProducers.ALCARECOPromptCalibProd_cff import *
 from Calibration.TkAlCaRecoProducers.ALCARECOPromptCalibProdSiStrip_cff import *
+from Calibration.TkAlCaRecoProducers.ALCARECOPromptCalibProdSiStripGains_cff import *
+
 from Calibration.TkAlCaRecoProducers.ALCARECOSiStripPCLHistos_cff import *
 
 
@@ -151,7 +153,11 @@ pathALCARECOTkAlCosmicsRegional0THLT = cms.Path(seqALCARECOTkAlCosmicsRegional0T
 pathALCARECOMuAlGlobalCosmicsInCollisions = cms.Path(seqALCARECOMuAlGlobalCosmicsInCollisions*ALCARECOMuAlGlobalCosmicsInCollisionsDQM)
 pathALCARECOMuAlGlobalCosmics = cms.Path(seqALCARECOMuAlGlobalCosmics*ALCARECOMuAlGlobalCosmicsDQM)
 pathALCARECOPromptCalibProd = cms.Path(seqALCARECOPromptCalibProd)
+<<<<<<< HEAD
 pathALCARECOPromptCalibProdSiStrip = cms.Path(seqALCARECOPromptCalibProdSiStrip)
+=======
+pathALCARECOPromptCalibProdSiStripGains = cms.Path(seqALCARECOPromptCalibProdSiStripGains)
+>>>>>>> Add PromptCalibProdSiStripGains ALCARECO dedicated to PCL workflow for SiStrip Gains determination
 pathALCARECOSiStripPCLHistos = cms.Path(seqALCARECOSiStripPCLHistos)
 
 # AlCaReco event content definitions:
@@ -469,6 +475,7 @@ ALCARECOStreamPromptCalibProd = cms.FilteredStream(
 	)
 
 
+<<<<<<< HEAD
 ALCARECOStreamPromptCalibProdSiStrip = cms.FilteredStream(
 	responsible = 'Gianluca Cerminara',
 	name = 'PromptCalibProdSiStrip',
@@ -478,6 +485,18 @@ ALCARECOStreamPromptCalibProdSiStrip = cms.FilteredStream(
 	dataTier = cms.untracked.string('ALCARECO')
 	)
 
+=======
+ALCARECOStreamPromptCalibProdSiStripGains = cms.FilteredStream(
+	responsible = 'Gianluca Cerminara',
+	name = 'PromptCalibProdSiStripGains',
+	paths  = (pathALCARECOPromptCalibProdSiStripGains),
+	content = OutALCARECOPromptCalibProdSiStripGains.outputCommands,
+	selectEvents = OutALCARECOPromptCalibProdSiStripGains.SelectEvents,
+	dataTier = cms.untracked.string('ALCARECO')
+	)
+
+
+>>>>>>> Add PromptCalibProdSiStripGains ALCARECO dedicated to PCL workflow for SiStrip Gains determination
 ALCARECOStreamSiStripPCLHistos = cms.FilteredStream(
 	responsible = 'Gianluca Cerminara',
 	name = 'SiStripPCLHistos',

--- a/Configuration/StandardSequences/python/AlCaRecoStreams_cff.py
+++ b/Configuration/StandardSequences/python/AlCaRecoStreams_cff.py
@@ -153,11 +153,8 @@ pathALCARECOTkAlCosmicsRegional0THLT = cms.Path(seqALCARECOTkAlCosmicsRegional0T
 pathALCARECOMuAlGlobalCosmicsInCollisions = cms.Path(seqALCARECOMuAlGlobalCosmicsInCollisions*ALCARECOMuAlGlobalCosmicsInCollisionsDQM)
 pathALCARECOMuAlGlobalCosmics = cms.Path(seqALCARECOMuAlGlobalCosmics*ALCARECOMuAlGlobalCosmicsDQM)
 pathALCARECOPromptCalibProd = cms.Path(seqALCARECOPromptCalibProd)
-<<<<<<< HEAD
 pathALCARECOPromptCalibProdSiStrip = cms.Path(seqALCARECOPromptCalibProdSiStrip)
-=======
 pathALCARECOPromptCalibProdSiStripGains = cms.Path(seqALCARECOPromptCalibProdSiStripGains)
->>>>>>> Add PromptCalibProdSiStripGains ALCARECO dedicated to PCL workflow for SiStrip Gains determination
 pathALCARECOSiStripPCLHistos = cms.Path(seqALCARECOSiStripPCLHistos)
 
 # AlCaReco event content definitions:
@@ -475,7 +472,7 @@ ALCARECOStreamPromptCalibProd = cms.FilteredStream(
 	)
 
 
-<<<<<<< HEAD
+
 ALCARECOStreamPromptCalibProdSiStrip = cms.FilteredStream(
 	responsible = 'Gianluca Cerminara',
 	name = 'PromptCalibProdSiStrip',
@@ -485,7 +482,7 @@ ALCARECOStreamPromptCalibProdSiStrip = cms.FilteredStream(
 	dataTier = cms.untracked.string('ALCARECO')
 	)
 
-=======
+
 ALCARECOStreamPromptCalibProdSiStripGains = cms.FilteredStream(
 	responsible = 'Gianluca Cerminara',
 	name = 'PromptCalibProdSiStripGains',
@@ -496,7 +493,7 @@ ALCARECOStreamPromptCalibProdSiStripGains = cms.FilteredStream(
 	)
 
 
->>>>>>> Add PromptCalibProdSiStripGains ALCARECO dedicated to PCL workflow for SiStrip Gains determination
+
 ALCARECOStreamSiStripPCLHistos = cms.FilteredStream(
 	responsible = 'Gianluca Cerminara',
 	name = 'SiStripPCLHistos',


### PR DESCRIPTION
This is the first implementation of the SiStrip Gain computation in PCL workflows able to run at Tier0.
In general all the PCL sequences still need to be migrated to consume, new interfaces for multithreading and new DQMStore....this is work in progress.
