### PR TITLE
Make statics be const statics in TrackerBounds

### DIFF
--- a/TrackingTools/GeomPropagators/interface/TrackerBounds.h
+++ b/TrackingTools/GeomPropagators/interface/TrackerBounds.h
@@ -24,9 +24,9 @@ class Disk;
 class TrackerBounds {
 public:
 
-  static const Cylinder& barrelBound()    {check(); return *theCylinder;}
-  static const Disk& negativeEndcapDisk() {check(); return *theNegativeDisk;}
-  static const Disk& positiveEndcapDisk() {check(); return *thePositiveDisk;}
+  static const Cylinder& barrelBound()    {return *theCylinder;}
+  static const Disk& negativeEndcapDisk() {return *theNegativeDisk;}
+  static const Disk& positiveEndcapDisk() {return *thePositiveDisk;}
 
   /** Hard-wired numbers defining the envelope of the sensitive volumes.
    */
@@ -36,14 +36,9 @@ public:
 
 private:
 
-  static ReferenceCountingPointer<Cylinder>  theCylinder;
-  static ReferenceCountingPointer<Disk>      theNegativeDisk;
-  static ReferenceCountingPointer<Disk>      thePositiveDisk;
-  static bool theInit;
-
-  static void check() {if (!theInit) initialize();}
-
-  static void initialize();
+  static const ReferenceCountingPointer<Cylinder>  theCylinder;
+  static const ReferenceCountingPointer<Disk>      theNegativeDisk;
+  static const ReferenceCountingPointer<Disk>      thePositiveDisk;
 };
 
 #endif

--- a/TrackingTools/GeomPropagators/src/TrackerBounds.cc
+++ b/TrackingTools/GeomPropagators/src/TrackerBounds.cc
@@ -7,43 +7,46 @@
 
 //Ported from ORCA
 
-void TrackerBounds::initialize() 
+static const float epsilon = 0.001; // should not matter at all
+
+static Cylinder * initCylinder()
 {
-  const float epsilon = 0.001; // should not matter at all
-
   Surface::RotationType rot; // unit rotation matrix
-  auto cb = new SimpleCylinderBounds( radius()-epsilon, 
-				      radius()+epsilon, 
-				      -halfLength(),  halfLength()
+  auto cb = new SimpleCylinderBounds( TrackerBounds::radius()-epsilon, 
+				      TrackerBounds::radius()+epsilon, 
+				      -TrackerBounds::halfLength(),  TrackerBounds::halfLength()
                                      );
+ return new Cylinder(Cylinder::computeRadius(*cb), Surface::PositionType(0,0,0), rot, cb);
+}
 
- theCylinder = new Cylinder(Cylinder::computeRadius(*cb), Surface::PositionType(0,0,0), rot, cb);
+static Disk* initNegative()
+{
+  Surface::RotationType rot; // unit rotation matrix
+
+  return new Disk( Surface::PositionType( 0, 0, -TrackerBounds::halfLength()), rot, 
+		   new SimpleDiskBounds( 0, TrackerBounds::radius(), -epsilon, epsilon));
+}
+
+static Disk* initPositive()
+{
+  Surface::RotationType rot; // unit rotation matrix
 
 
-  theNegativeDisk = 
-    new Disk( Surface::PositionType( 0, 0, -halfLength()), rot, 
-		   new SimpleDiskBounds( 0, radius(), -epsilon, epsilon));
-
-  thePositiveDisk = 
-    new Disk( Surface::PositionType( 0, 0, halfLength()), rot, 
-		   new SimpleDiskBounds( 0, radius(), -epsilon, epsilon));
-
-
-  theInit = true;
+  return new Disk( Surface::PositionType( 0, 0, TrackerBounds::halfLength()), rot, 
+		   new SimpleDiskBounds( 0, TrackerBounds::radius(), -epsilon, epsilon));
 }
 
 bool TrackerBounds::isInside(const GlobalPoint &point){
-  return (point.perp() <= radius() &&
-	  fabs(point.z()) <= halfLength());
+  return (point.perp() <= TrackerBounds::radius() &&
+	  fabs(point.z()) <= TrackerBounds::halfLength());
 }
 
 
 // static initializers
 
-ReferenceCountingPointer<BoundCylinder>  TrackerBounds::theCylinder = 0;
-ReferenceCountingPointer<BoundDisk>      TrackerBounds::theNegativeDisk = 0;
-ReferenceCountingPointer<BoundDisk>      TrackerBounds::thePositiveDisk = 0;
+const ReferenceCountingPointer<BoundCylinder>  TrackerBounds::theCylinder = initCylinder();
+const ReferenceCountingPointer<BoundDisk>      TrackerBounds::theNegativeDisk = initNegative();
+const ReferenceCountingPointer<BoundDisk>      TrackerBounds::thePositiveDisk = initPositive();
 
-bool TrackerBounds::theInit = false;
 
 


### PR DESCRIPTION
To avoid thread safety issues, converted statics in TrackerBounds
to const statics. The modification was simply to use helper functions
to do the proper initialization.
