### PR TITLE
Clang skip static std::once_flag

### DIFF
--- a/Utilities/StaticAnalyzers/scripts/callgraph.py
+++ b/Utilities/StaticAnalyzers/scripts/callgraph.py
@@ -1,0 +1,43 @@
+#! /usr/bin/env python
+import re
+topfunc = re.compile("::(produce|analyze|filter|beginLuminosityBlock|beginRun)\(")
+baseclass = re.compile("edm::(one::|stream::|global::)?ED(Producer|Filter|Analyzer)(Base)?")
+farg = re.compile("\(.*\)")
+toplevelfuncs = set()
+epfunc = re.compile("TGraph::(.*)\(.*\)")
+skipfunc = re.compile("TGraph::IsA\(.*\)")
+epfuncs=set()
+
+import networkx as nx
+G=nx.DiGraph()
+
+f = open('function-calls-db.txt')
+
+for line in f :
+	fields = line.split("'")
+	if fields[2] == ' calls function ' :
+		if not skipfunc.search(line) : 
+			G.add_edge(fields[1],fields[3],kind=fields[2])
+			if epfunc.search(fields[3])  : epfuncs.add(fields[3])
+	if fields[2] == ' overrides function ' :
+		if baseclass.search(fields[3]) :
+			if topfunc.search(fields[3]) : toplevelfuncs.add(fields[1])
+			G.add_edge(fields[1],fields[3],kind=' overrides function ')
+		else :
+			if not skipfunc.search(line) : 
+				G.add_edge(fields[3],fields[1],kind=' calls override function ')
+				if epfunc.search(fields[1]) : epfuncs.add(fields[1])
+f.close()
+
+for epfunc in sorted(epfuncs): print epfunc
+print
+
+for epfunc in epfuncs:
+	for tfunc in toplevelfuncs:
+		if nx.has_path(G,tfunc,epfunc) : 
+			path = nx.shortest_path(G,tfunc,epfunc)
+			print "Call stack \'",
+			for p in path :			
+				print re.sub(farg,"()",p)+"; ",
+			print " \'. "
+

--- a/Utilities/StaticAnalyzers/scripts/create_statics_esd_reports.sh
+++ b/Utilities/StaticAnalyzers/scripts/create_statics_esd_reports.sh
@@ -16,12 +16,12 @@ if [ ! -f ./classes.txt.dumperft ]
 	exit 2
 fi
 
+cat function-calls-db.txt function-statics-db.txt >db.txt 
 ${CMSSW_BASE}/src/Utilities/StaticAnalyzers/scripts/statics.py 2>&1 > statics-report.txt.unsorted
 sort -u < statics-report.txt.unsorted > statics-report.txt
-awk -F\' 'NR==FNR{a[" "$0"::"]=1;next} {n=0;for(i in a){if(index($2,i) && $1 == "In call stack "){n=1}}} n' plugins.txt statics-report.txt | sort -u  | awk '{print $0"\n"}' > modules2statics.txt
-awk -F\' 'NR==FNR{a[" "$0"::"]=1;next} {n=0;for(i in a){if(index($4,i) && $1 == "Non-const static variable "){n=1}}} n' plugins.txt statics-report.txt | sort -u  | awk '{print $0"\n"}' > statics2modules.txt
-
+grep -e "^In call stack " statics-report.txt | awk '{print $0"\n"}' > modules2statics.txt
+grep -e "^Non-const static variable " statics-report.txt | awk '{print $0"\n"}' > statics2modules.txt
 ${CMSSW_BASE}/src/Utilities/StaticAnalyzers/scripts/data-class-funcs.py 2>&1 > data-class-funcs-report.txt
-grep -v -e "^In call stack " data-class-funcs-report.txt | grep -v -e"Flagged event setup data class"| sort -u  >override-flagged-classes.txt
+grep -v -e "^In call stack " data-class-funcs-report.txt | grep -v -e"Flagged event setup data class"  >override-flagged-classes.txt
 grep -e "^Flagged event setup data class" data-class-funcs-report.txt | sort -u | awk '{print $0"\n\n"}' >esd2tlf.txt
 grep -e "^In call stack" data-class-funcs-report.txt | sort -u | awk '{print $0"\n\n"}' >tlf2esd.txt

--- a/Utilities/StaticAnalyzers/scripts/run_class_checker.sh
+++ b/Utilities/StaticAnalyzers/scripts/run_class_checker.sh
@@ -12,6 +12,7 @@ eval `scram runtime -sh`
 ulimit -m 2000000
 ulimit -v 2000000
 ulimit -t 1200
+ulimit -f 40000000
 if [ ! -f ${LOCALRT}/tmp/classes.txt ] 
 	then 
 	echo "run ${CMSSW_BASE}/src/Utilities/StaticAnalyzers/scripts/run_class_dumper.sh first"

--- a/Utilities/StaticAnalyzers/scripts/run_class_dumper.sh
+++ b/Utilities/StaticAnalyzers/scripts/run_class_dumper.sh
@@ -12,6 +12,7 @@ eval `scram runtime -sh`
 ulimit -m 2000000
 ulimit -v 2000000
 ulimit -t 1200
+ulimit -f 40000000
 for file in `cmsglimpse -l -F src/classes.*.h$ include`;do 
 	dir=`dirname $file`;
 	echo \#include \<$file\> >${LOCALRT}/src/$dir/`basename $file`.cc ; 

--- a/Utilities/StaticAnalyzers/scripts/statics.py
+++ b/Utilities/StaticAnalyzers/scripts/statics.py
@@ -5,6 +5,8 @@ baseclass = re.compile("edm::(one::|stream::|global::)?ED(Producer|Filter|Analyz
 farg = re.compile("\(.*\)")
 statics = set()
 toplevelfuncs = set()
+skipfunc = re.compile("(edm::eventsetup::EventSetupRecord::get\(.*\) const)|(BareRootProductGetter::getIt\(.*\) const)|(edm::eventsetup::DataProxy::getImpl\(.*\))|(edm::EventPrincipal::unscheduledFill\(.*\) const)|(edm::ServiceRegistry::get\(.*\) const)|(fwlite::internal::ProductGetter::getIt\(.*\) const)|(edm::eventsetup::EventSetupRecord::getImplementation\(.*\) const)|(edm::eventsetup::EventSetupRecord::getFromProxy\(.*\) const)|(edm::eventsetup::DataProxy::get\(.*\) const)")
+skipfuncs=set()
 
 import networkx as nx
 G=nx.DiGraph()
@@ -14,18 +16,19 @@ f = open('db.txt')
 for line in f :
 	fields = line.split("'")
 	if fields[2] == ' calls function ' :
-		G.add_edge(fields[1],fields[3],kind=fields[2])
+		if skipfunc.search(fields[3]) : skipfuncs.add(line)
+		else : G.add_edge(fields[1],fields[3],kind=fields[2])
 	if fields[2] == ' overrides function ' :
 		if baseclass.search(fields[3]) :
 			if topfunc.search(fields[3]) : toplevelfuncs.add(fields[1])
 			G.add_edge(fields[1],fields[3],kind=' overrides function ')
 		else :
-			G.add_edge(fields[3],fields[1],kind=' calls function ')
+			if skipfunc.search(fields[3]) : skipfuncs.add(line)
+			else : G.add_edge(fields[3],fields[1],kind=' calls function ')
 	if fields[2] == ' static variable ' :
 		G.add_edge(fields[1],fields[3],kind=' static variable ')
 		statics.add(fields[3])
 f.close()
-
 
 for static in statics:
 	for tfunc in toplevelfuncs:

--- a/Utilities/StaticAnalyzers/src/CmsSupport.cpp
+++ b/Utilities/StaticAnalyzers/src/CmsSupport.cpp
@@ -100,6 +100,8 @@ bool support::isSafeClassName(const std::string &name) {
   std::string ctbb = "class tbb::";
   std::string eap = "edm::AtomicPtrCache";
   std::string ceap = "class edm::AtomicPtrCache";
+  std::string once = "std::once_flag";
+  std::string conce = "struct std::once_flag";
   
   if ( name.substr(0,atomic.length()) == atomic || name.substr(0,catomic.length()) == catomic
 	|| name.substr(0,uatomic.length()) == uatomic  || name.substr(0,cuatomic.length()) == cuatomic
@@ -108,6 +110,7 @@ bool support::isSafeClassName(const std::string &name) {
 	|| name.substr(0,btsp.length()) == btsp || name.substr(0,cbtsp.length()) == cbtsp 
 	|| name.substr(0,ctbb.length()) == ctbb 
 	|| name.substr(0,eap.length()) == eap || name.substr(0,ceap.length()) == ceap
+	|| name.substr(0,once.length()) == once || name.substr(0,conce.length()) == conce
 	) 
 	return true;	
   return false;

--- a/Utilities/StaticAnalyzers/src/GlobalStaticChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/GlobalStaticChecker.cpp
@@ -30,7 +30,7 @@ void GlobalStaticChecker::checkASTDecl(const clang::VarDecl *D,
 
 	    if ( ! m_exception.reportGlobalStaticForType( t, DLoc, BR ) )
 		   return;
-	    if ( support::isSafeClassName( D->getCanonicalDecl()->getQualifiedNameAsString() ) ) return;
+	    if ( support::isSafeClassName( t.getCanonicalType().getAsString() ) ) return;
 
 	    std::string buf;
 	    llvm::raw_string_ostream os(buf);

--- a/Utilities/StaticAnalyzers/src/StaticLocalChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/StaticLocalChecker.cpp
@@ -28,7 +28,7 @@ void StaticLocalChecker::checkASTDecl(const clang::VarDecl *D,
 
 	    if ( ! m_exception.reportGlobalStaticForType( t, DLoc, BR ) )
 			return;
-	    if ( support::isSafeClassName( t.getAsString() ) ) return;
+	    if ( support::isSafeClassName( t.getCanonicalType().getAsString() ) ) return;
 
 	    std::string buf;
 	    llvm::raw_string_ostream os(buf);


### PR DESCRIPTION
remove nodes for certain "safe" functions from calls graph 
