### PR TITLE
Made static a member variable of RecoTauVertexAssociator

### DIFF
--- a/RecoTauTag/RecoTau/interface/RecoTauVertexAssociator.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauVertexAssociator.h
@@ -75,6 +75,7 @@ class RecoTauVertexAssociator {
     //PJ adding quality cuts
     RecoTauQualityCuts qcuts_;
     bool recoverLeadingTrk;
+    bool vxTrkFiltering;
 
     edm::EDGetTokenT<reco::VertexCollection> vx_token;
 

--- a/RecoTauTag/RecoTau/src/RecoTauVertexAssociator.cc
+++ b/RecoTauTag/RecoTau/src/RecoTauVertexAssociator.cc
@@ -14,8 +14,6 @@
 
 namespace reco { namespace tau {
 
-  bool vxTrkFiltering;
-
 // Get the highest pt track in a jet.
 // Get the KF track if it exists.  Otherwise, see if it has a GSF track.
   reco::TrackBaseRef RecoTauVertexAssociator::getLeadTrack(const PFJet& jet) const{


### PR DESCRIPTION
A static was being used as if it were a member data. This was being
flagged by the static analyzer. It was trivial to make the variable
an actual member variable.
