### PR TITLE
Reverted modules using TGraph::Fit back to legacy edm::Producer

### DIFF
--- a/RecoLocalCalo/EcalRecProducers/plugins/ESRecHitProducer.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/ESRecHitProducer.h
@@ -1,7 +1,7 @@
 #ifndef RecoLocalCalo_EcalRecProducers_ESRecHitProducer_HH
 #define RecoLocalCalo_EcalRecProducers_ESRecHitProducer_HH
 
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -14,13 +14,13 @@
 
 class ESDigiCollection;
 
-class ESRecHitProducer : public edm::stream::EDProducer<> {
+class ESRecHitProducer : public edm::EDProducer {
 
  public:
 
   explicit ESRecHitProducer(const edm::ParameterSet& ps);
   virtual ~ESRecHitProducer();
-  virtual void produce(edm::Event& e, const edm::EventSetup& es);
+  virtual void produce(edm::Event& e, const edm::EventSetup& es) override;
 
  private:
 

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitProducer.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitProducer.h
@@ -1,7 +1,7 @@
 #ifndef RecoLocalCalo_EcalRecProducers_EcalUncalibRecHitProducer_hh
 #define RecoLocalCalo_EcalRecProducers_EcalUncalibRecHitProducer_hh
 
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -15,12 +15,12 @@
 class EBDigiCollection;
 class EEDigiCollection;
 
-class EcalUncalibRecHitProducer : public edm::stream::EDProducer<> {
+class EcalUncalibRecHitProducer : public edm::EDProducer {
 
         public:
                 explicit EcalUncalibRecHitProducer(const edm::ParameterSet& ps);
                 ~EcalUncalibRecHitProducer();
-                virtual void produce(edm::Event& evt, const edm::EventSetup& es);
+                virtual void produce(edm::Event& evt, const edm::EventSetup& es) override;
 
         private:
 


### PR DESCRIPTION
ROOT's underlying implementation of TGraph::Fit is not thread safe
so we must avoid having more than one module calling it at one time.
The static analyzer determined the following code paths linking modules
to TGraph::Fit
ESRecHitProducer::produce();  ESRecHitWorkerBaseClass::run();  ESRecHitWorker::run();  ESRecHitFitAlgo::reconstruct() const;  ESRecHitFitAlgo::EvalAmplitude() const;  TGraph::Fit();
EcalUncalibRecHitProducer::produce();  EcalUncalibRecHitWorkerBaseClass::run();  EcalUncalibRecHitWorkerAnalFit::run();  EcalUncalibRecHitRecAnalFitAlgo<EBDataFrame>::makeRecHit();  TGraph::Fit();
in both cases, the module is linked to TGraph::Fit via a class which inherits
from a base class which the module uses. To fix this problem we either
1) wait till ROOT makes TGraph::Fit thread safe
2) drop the use of the inheriting class using TGraph::Fit.
