### PR TITLE
Re-add missing features in multisource code

### DIFF
--- a/Utilities/XrdAdaptor/plugins/XrdStorageMaker.cc
+++ b/Utilities/XrdAdaptor/plugins/XrdStorageMaker.cc
@@ -26,6 +26,15 @@ public:
 
   XrdStorageMaker()
   {
+    // When CMSSW loads, both XrdCl and XrdClient end up being loaded
+    // (ROOT loads XrdClient).  XrdClient forces IPv4-only.  Accordingly,
+    // we must explicitly set the default network stack in XrdCl to
+    // whatever is available on the node (IPv4 or IPv6).
+    XrdCl::Env *env = XrdCl::DefaultEnv::GetEnv();
+    if (env)
+    {
+      env->PutString("NetworkStack", "IPAll");
+    }
     setTimeout(XRD_DEFAULT_TIMEOUT);
   }
 


### PR DESCRIPTION
Two features were found to be missing in the multisource code:

1) Sending monitoring data to the xrootd server (this allows the Dashboard to associate Xrootd activity with a particular grid job).  This was a regression from the prior XrdFile.
2) IPv6 support.  This was accidentally disabled because ROOT loads XrdClient after loading XrdCl.

This pull requests adds support
