### PR TITLE
Updated castor geometry seperated halves v2

### DIFF
--- a/Geometry/ForwardCommonData/data/castor.xml
+++ b/Geometry/ForwardCommonData/data/castor.xml
@@ -41,55 +41,60 @@
         <!-- START OF ELECTROMAGNETIC CALO  -->
         <!--  CASC - StainlessSteel -->
         <Polyhedra name="CAEC" numSide="4" startPhi="0.0*deg" deltaPhi="180.0*deg">
-            <ZSection rMin="39.00*mm" rMax="40.00*mm" z="0.0*mm"/>
-            <ZSection rMin="39.00*mm" rMax="141.00*mm" z="102.0*mm"/>
-            <ZSection rMin="41.50*mm" rMax="144.50*mm" z="104.5*mm"/>
-            <ZSection rMin="144.50*mm" rMax="144.50*mm" z="207.5*mm"/>
+            <ZSection rMin="40.00*mm" rMax="40.00*mm" z="0.00*mm"/>
+            <ZSection rMin="40.00*mm" rMax="143.00*mm" z="103.00*mm"/>
+            <ZSection rMin="40.50*mm" rMax="143.50*mm" z="103.50*mm"/>
+            <ZSection rMin="143.50*mm" rMax="143.50*mm" z="206.50*mm"/>
         </Polyhedra>
         <!-- to have octant StainlessSteel skeleton to support WQ plates  -->
         <!-- CASS sector - Air, 8 copies with deltaPhi=45.0  -->
         <Polyhedra name="CAES" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
-            <ZSection rMin="40.00*mm" rMax="40.00*mm" z="0.0*mm"/>
-            <ZSection rMin="40.00*mm" rMax="144.00*mm" z="103.0*mm"/>
-            <ZSection rMin="40.50*mm" rMax="144.50*mm" z="104.5*mm"/>
-            <ZSection rMin="144.50*mm" rMax="144.50*mm" z="207.5*mm"/>
+            <ZSection rMin="40.00*mm" rMax="40.00*mm" z="0.00*mm"/>
+            <ZSection rMin="40.00*mm" rMax="143.00*mm" z="103.00*mm"/>
+            <ZSection rMin="40.50*mm" rMax="143.50*mm" z="103.50*mm"/>
+            <ZSection rMin="143.50*mm" rMax="143.50*mm" z="206.50*mm"/>
         </Polyhedra>
         <!-- EM read-out channel  with StainlessSteel size  1 copy -->
         <Polyhedra name="CAER" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
-            <ZSection rMin="40.00*mm" rMax="40.00*mm" z="0.0*mm"/>
-            <ZSection rMin="40.00*mm" rMax="91.50*mm" z="51.5*mm"/>
-            <ZSection rMin="93.00*mm" rMax="144.50*mm" z="104.5*mm"/>
-            <ZSection rMin="144.50*mm" rMax="144.50*mm" z="156.0*mm"/>
+            <ZSection rMin="40.00*mm" rMax="40.00*mm" z="0.00*mm"/>
+            <ZSection rMin="40.00*mm" rMax="91.50*mm" z="51.50*mm"/>
+            <ZSection rMin="92.00*mm" rMax="143.50*mm" z="103.50*mm"/>
+            <ZSection rMin="143.50*mm" rMax="143.50*mm" z="155.00*mm"/>
         </Polyhedra>
+        <!-- Air volume -->
         <!-- reduced rMin, rMax by (1.mm (StainlessSteel)/tg(22.5))= 2.41mm-->
-        <!-- the special X,Y shifts are needed  -->
-        <!-- the positions: x = 2.41*cos22.5 = 1.30, y=...sin...=0.54  1 copy     -->
+        <!-- the special X,Y shifts are needed to construct a wall thickness of 1mm. -->
+        <!-- Start the volume below (2.41mm) and then shift upwards in r by (2.41+1)mm.  -->
+        <!-- Shifts are defined further down the code.  -->
+        <!-- shift works on CASTFar 1 sector which points to 10 o'clock for positive eta CASTOR     -->
+        <!-- the shifts are: x = (2.41+1)*sin(22.5) = 3.15, y=...cos...=1.31  1 copy     -->
         <Polyhedra name="CERR" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
-            <ZSection rMin="37.59*mm" rMax="37.59*mm" z="0.0*mm"/>
-            <ZSection rMin="37.59*mm" rMax="89.90*mm" z="51.5*mm"/>
-            <ZSection rMin="90.59*mm" rMax="142.09*mm" z="104.5*mm"/>
-            <ZSection rMin="142.09*mm" rMax="142.09*mm" z="156.0*mm"/>
+            <ZSection rMin="37.59*mm" rMax="37.59*mm" z="1.00*mm"/>
+            <ZSection rMin="37.59*mm" rMax="89.09*mm" z="52.50*mm"/>
+            <ZSection rMin="88.59*mm" rMax="140.09*mm" z="103.50*mm"/>
+            <ZSection rMin="140.09*mm" rMax="140.09*mm" z="155.00*mm"/>
         </Polyhedra>
-        <!-- layer    5 copies (5.+2)*sqrt(2) + 0.40mm = 10.3 (7.07+2.83+0.40) -->
+        <!-- layer    5 copies (5.mm+2mm)/sin(45deg) + 0.40mm = 10.3 (7.07+2.83+0.40) -->
         <!-- 0.4 mm air gap included -->
         <!-- CAEL: Tungsten layer, CAEA: air layer, CAHF: quartz -->
         <Polyhedra name="CAEL" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
-            <ZSection rMin="37.59*mm" rMax="37.59*mm" z="0.0*mm"/>
-            <ZSection rMin="37.59*mm" rMax="47.89*mm" z="10.3*mm"/>
-            <ZSection rMin="131.79*mm" rMax="142.09*mm" z="104.5*mm"/>
-            <ZSection rMin="142.09*mm" rMax="142.09*mm" z="114.8*mm"/>
+            <ZSection rMin="37.59*mm" rMax="37.59*mm" z="1.00*mm"/>
+            <ZSection rMin="37.59*mm" rMax="47.89*mm" z="11.30*mm"/>
+            <ZSection rMin="129.79*mm" rMax="140.09*mm" z="103.50*mm"/>
+            <ZSection rMin="140.09*mm" rMax="140.09*mm" z="113.80*mm"/>
         </Polyhedra>
         <Polyhedra name="CAEA" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
-            <ZSection rMin="37.59*mm" rMax="37.59*mm" z="0.0*mm"/>
-            <ZSection rMin="37.59*mm" rMax="40.82*mm" z="3.23*mm"/>
-            <ZSection rMin="138.86*mm" rMax="142.09*mm" z="104.5*mm"/>
-            <ZSection rMin="142.09*mm" rMax="142.09*mm" z="107.73*mm"/>
+            <ZSection rMin="37.59*mm" rMax="37.59*mm" z="1.00*mm"/>
+            <ZSection rMin="37.59*mm" rMax="40.82*mm" z="4.23*mm"/>
+            <ZSection rMin="136.86*mm" rMax="140.09*mm" z="103.50*mm"/>
+            <ZSection rMin="140.09*mm" rMax="140.09*mm" z="106.73*mm"/>
         </Polyhedra>
         <Polyhedra name="CAEF" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
-            <ZSection rMin="37.59*mm" rMax="37.59*mm" z="0.0*mm"/>
-            <ZSection rMin="37.59*mm" rMax="40.42*mm" z="2.83*mm"/>
-            <ZSection rMin="139.26*mm" rMax="142.09*mm" z="104.5*mm"/>
-            <ZSection rMin="142.09*mm" rMax="142.09*mm" z="107.33*mm"/>
+            <ZSection rMin="37.59*mm" rMax="37.59*mm" z="1.00*mm"/>
+            <ZSection rMin="37.59*mm" rMax="40.42*mm" z="3.83*mm"/>
+            <ZSection rMin="137.26*mm" rMax="140.09*mm" z="103.50*mm"/>
+            <ZSection rMin="140.09*mm" rMax="140.09*mm" z="106.33*mm"/>
+
         </Polyhedra>
         <!-- shape to be used for Intersection to create C3TF,C4TF semi-trapezoid solids   -->
         <!-- dz=Height of plate/2 + 3 mm (arbitrary) ; dy = B/2 -->
@@ -111,53 +116,55 @@
         <!--  -->
         <!--  -->
         <Polyhedra name="CAHC" numSide="4" startPhi="0.0*deg" deltaPhi="180.0*deg">
-            <ZSection rMin="39.00*mm" rMax="40.00*mm" z="0.0*mm"/>
-            <ZSection rMin="39.00*mm" rMax="178.40*mm" z="138.4*mm"/>
-            <ZSection rMin="39.00*mm" rMax="178.40*mm" z="1211.0*mm"/>
-            <ZSection rMin="178.40*mm" rMax="178.40*mm" z="1350.4*mm"/>
+            <ZSection rMin="40.00*mm" rMax="40.00*mm" z="0.0*mm"/>
+            <ZSection rMin="40.00*mm" rMax="177.40*mm" z="137.4*mm"/>
+            <ZSection rMin="40.00*mm" rMax="177.40*mm" z="1212.0*mm"/>
+            <ZSection rMin="177.40*mm" rMax="177.40*mm" z="1349.4*mm"/>
         </Polyhedra>
         <!-- to have octant StainlessSteel skeleton to support WQ plates  -->
         <!-- CAHS sector - Air, 8 copies with deltaPhi=45.0  -->
         <Polyhedra name="CAHS" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
             <ZSection rMin="40.00*mm" rMax="40.00*mm" z="0.0*mm"/>
-            <ZSection rMin="40.00*mm" rMax="178.40*mm" z="138.4*mm"/>
-            <ZSection rMin="40.00*mm" rMax="178.40*mm" z="1212.0*mm"/>
-            <ZSection rMin="178.40*mm" rMax="178.40*mm" z="1350.4*mm"/>
+            <ZSection rMin="40.00*mm" rMax="177.40*mm" z="137.4*mm"/>
+            <ZSection rMin="40.00*mm" rMax="177.40*mm" z="1212.0*mm"/>
+            <ZSection rMin="177.40*mm" rMax="177.40*mm" z="1349.4*mm"/>
         </Polyhedra>
         <!-- HAD read-out channel  with StainlessSteel size  12 copies -->
         <Polyhedra name="CAHR" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
             <ZSection rMin="40.00*mm" rMax="40.00*mm" z="0.0*mm"/>
             <ZSection rMin="40.00*mm" rMax="141.00*mm" z="101.0*mm"/>
-            <ZSection rMin="77.40*mm" rMax="178.40*mm" z="138.4*mm"/>
-            <ZSection rMin="178.40*mm" rMax="178.40*mm" z="239.9*mm"/>
+            <ZSection rMin="76.40*mm" rMax="177.40*mm" z="137.4*mm"/>
+            <ZSection rMin="177.40*mm" rMax="177.40*mm" z="238.4*mm"/>
         </Polyhedra>
         <!-- reduced rMin,rMax by (1.mm (StainlessSteel)/tg(22.5))= 2.41mm-->
-        <!-- the special X,Y shifts are needed  -->
-        <!-- the positions: x = 2.41*cos22.5 = 1.30, y=...sin...=0.54  1 copy     -->
+        <!-- the special X,Y shifts are needed (see CERR) -->
         <Polyhedra name="CHRR" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
-            <ZSection rMin="37.59*mm" rMax="37.59*mm" z="0.0*mm"/>
-            <ZSection rMin="37.59*mm" rMax="138.59*mm" z="101.0*mm"/>
-            <ZSection rMin="74.99*mm" rMax="175.99*mm" z="138.4*mm"/>
-            <ZSection rMin="175.99*mm" rMax="175.99*mm" z="239.9*mm"/>
+            <ZSection rMin="37.59*mm" rMax="37.59*mm" z="1.00*mm"/>
+            <ZSection rMin="37.59*mm" rMax="138.59*mm" z="102.00*mm"/>
+            <ZSection rMin="72.99*mm" rMax="173.99*mm" z="137.40*mm"/>
+            <ZSection rMin="173.99*mm" rMax="173.99*mm" z="238.40*mm"/>
         </Polyhedra>
-        <!-- layer    7 copies (5.+2)*sqrt(2)+0.60=10.5  (7.07+2.83+0.60) -->
+        <!-- layer    7 copies (10.+4.+0.4)/sin(45deg)=20.2  (14.14+5.66+0.60) -->
+	<!-- tunsten layer -->
         <Polyhedra name="CAHL" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
-            <ZSection rMin="37.59*mm" rMax="37.59*mm" z="0.0*mm"/>
-            <ZSection rMin="37.59*mm" rMax="57.79*mm" z="20.2*mm"/>
-            <ZSection rMin="155.79*mm" rMax="175.99*mm" z="138.4*mm"/>
-            <ZSection rMin="175.99*mm" rMax="175.99*mm" z="158.6*mm"/>
+            <ZSection rMin="37.59*mm" rMax="37.59*mm" z="1.00*mm"/>
+            <ZSection rMin="37.59*mm" rMax="57.79*mm" z="21.20*mm"/>
+            <ZSection rMin="153.79*mm" rMax="173.99*mm" z="137.40*mm"/>
+            <ZSection rMin="173.99*mm" rMax="173.99*mm" z="157.60*mm"/>
         </Polyhedra>
+	<!-- quartz volume layer where wrapping (here simply air?) is included?-->
         <Polyhedra name="CAHA" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
-            <ZSection rMin="37.59*mm" rMax="37.59*mm" z="0.0*mm"/>
-            <ZSection rMin="37.59*mm" rMax="43.65*mm" z="6.06*mm"/>
-            <ZSection rMin="169.93*mm" rMax="175.99*mm" z="138.4*mm"/>
-            <ZSection rMin="175.99*mm" rMax="175.99*mm" z="144.46*mm"/>
+            <ZSection rMin="37.59*mm" rMax="37.59*mm" z="1.00*mm"/>
+            <ZSection rMin="37.59*mm" rMax="43.65*mm" z="7.06*mm"/>
+            <ZSection rMin="167.93*mm" rMax="173.99*mm" z="137.40*mm"/>
+            <ZSection rMin="173.99*mm" rMax="173.99*mm" z="143.46*mm"/>
         </Polyhedra>
+	<!-- quartz volume without wrapping where will be intersected -->
         <Polyhedra name="CAHF" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
-            <ZSection rMin="37.59*mm" rMax="37.59*mm" z="0.0*mm"/>
-            <ZSection rMin="37.59*mm" rMax="43.25*mm" z="5.66*mm"/>
-            <ZSection rMin="170.33*mm" rMax="175.99*mm" z="138.4*mm"/>
-            <ZSection rMin="175.99*mm" rMax="175.99*mm" z="144.06*mm"/>
+            <ZSection rMin="37.59*mm" rMax="37.59*mm" z="1.00*mm"/>
+            <ZSection rMin="37.59*mm" rMax="43.25*mm" z="6.66*mm"/>
+            <ZSection rMin="168.33*mm" rMax="173.99*mm" z="137.40*mm"/>
+            <ZSection rMin="173.99*mm" rMax="173.99*mm" z="143.06*mm"/>
         </Polyhedra>
         <!--  -->
         <!--  -->
@@ -198,19 +205,21 @@
             <ZSection rMin="251.70*mm" rMax="303.20*mm" z="263.2*mm"/>
             <ZSection rMin="303.20*mm" rMax="303.20*mm" z="314.7*mm"/>
         </Polyhedra>
-        <!--  Aluminium (1mm) compartment with Air lightguide (external part)  1 copy -->
-        <Polyhedra name="CEAL" numSide="1" startPhi="11.6287*deg" deltaPhi="21.74255*deg">
+        <!-- compartment with Air lightguide (1 mm wall strength) (external part)  1 copy -->
+	<Constant name="LGAngleBegin" value="11.6287*deg"/>
+	<Constant name="LGAngleDelta" value="21.74255*deg"/>
+        <Polyhedra name="CEAL" numSide="1" startPhi="[castor:LGAngleBegin]" deltaPhi="[castor:LGAngleDelta]">
             <ZSection rMin="67.6913*mm" rMax="67.6913*mm" z="13.50*mm"/>
             <ZSection rMin="67.6913*mm" rMax="98.829*mm" z="39.5*mm"/>
             <ZSection rMin="105.2413*mm" rMax="149.9623*mm" z="82.27*mm"/>
             <ZSection rMin="149.9623*mm" rMax="149.9623*mm" z="133.27*mm"/>
         </Polyhedra>
-        <!-- Air compartment - lightguide (internal part of LG)  1 copy -->
-        <Polyhedra name="CEAI" numSide="1" startPhi="11.6287*deg" deltaPhi="21.74255*deg">
-            <ZSection rMin="62.4836*mm" rMax="62.4836*mm" z="14.5*mm"/>
-            <ZSection rMin="62.4836*mm" rMax="91.2261*mm" z="38.5*mm"/>
-            <ZSection rMin="101.7908*mm" rMax="144.7546*mm" z="83.27*mm"/>
-            <ZSection rMin="144.7546*mm" rMax="144.7546*mm" z="132.27*mm"/>
+        <!-- Air compartment in CEAL (lightguide) (internal part of LG)  1 copy -->
+        <Polyhedra name="CEAI" numSide="1" startPhi="[castor:LGAngleBegin]" deltaPhi="[castor:LGAngleDelta]">
+           <ZSection rMin="62.48432*mm" rMax="62.48432*mm" z="14.50*mm"/>
+           <ZSection rMin="62.48432*mm" rMax="91.22937*mm" z="38.50*mm"/>
+           <ZSection rMin="101.78906*mm" rMax="144.75532*mm" z="83.27*mm"/>
+           <ZSection rMin="144.75532*mm" rMax="144.75532*mm" z="132.27*mm"/>
         </Polyhedra>
         <!-- Air volume to be filled by PMT  1 copy -->
         <!-- volume for PMT's -->
@@ -431,7 +440,9 @@
             <rRotation name="castor:CASTFarTilt"/>
             <!-- please multiply x by -1 since CASTOR on eta minus side is mirrored-->
             <!-- the tilt is defined so that the face position center face position does not change-->
-            <Translation x="0.0*cm - [castor:castLength]*sin([castor:CASTFarTiltAngle])" y="0.0*cm" z="0*mm + [castor:castLength]*(1-cos([castor:CASTFarTiltAngle]))"/>
+            <Translation x="0.0*cm - [castor:castLength]*sin([castor:CASTFarTiltAngle])"
+			 y="0.0*cm"
+			 z="0*mm + [castor:castLength]*(1-cos([castor:CASTFarTiltAngle]))"/>
         </PosPart>
         <PosPart copyNumber="1">
             <rParent name="forward:CastorB"/>
@@ -439,7 +450,9 @@
             <rRotation name="castor:CASTNearTilt"/>
             <!-- please multiply x by -1 since CASTOR on eta minus side is mirrored-->
             <!-- the tilt is defined so that the face position center face position does not change-->
-            <Translation x="0.0*cm - [castor:castLength]*sin([castor:CASTNearTiltAngle])" y="0.0*cm" z="0*mm + [castor:castLength]*(1-cos([castor:CASTNearTiltAngle]))"/>
+            <Translation x="0.0*cm - [castor:castLength]*sin([castor:CASTNearTiltAngle])"
+			 y="0.0*cm"
+			 z="0*mm + [castor:castLength]*(1-cos([castor:CASTNearTiltAngle]))"/>
         </PosPart>
 
         <PosPart copyNumber="2">
@@ -546,7 +559,7 @@
             <rParent name="castor:CAER"/>
             <rChild name="castor:CERR"/>
             <rRotation name="rotations:000D"/>
-            <Translation x="+1.30*mm" y="+0.54*mm" z="0.0*mm"/>
+            <Translation x="3.1543220299*mm" y="1.30656296488*mm" z="0.0*mm"/>
         </PosPart>
         <!--  -->
         <!-- HAD read-out channel  12 copies include 5 layers -->
@@ -628,7 +641,7 @@
             <rParent name="castor:CAHR"/>
             <rChild name="castor:CHRR"/>
             <rRotation name="rotations:000D"/>
-            <Translation x="+1.30*mm" y="+0.54*mm" z="0.0*mm"/>
+            <Translation x="3.1543220299*mm" y="1.30656296488*mm" z="0.0*mm"/>
         </PosPart>
         <!--  -->
         <!-- EM layers :   5 copies -->
@@ -736,7 +749,7 @@
             <rParent name="castor:CAHA"/>
             <rChild name="castor:CAHF"/>
             <rRotation name="rotations:000D"/>
-            <Translation x="0.0*mm" y="0.0*mm" z="0.2*mm"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="0.28142*mm"/>
         </PosPart>
         <PosPart copyNumber="1">
             <rParent name="castor:CAHF"/>
@@ -900,11 +913,20 @@
             <rRotation name="rotations:CABK"/>
             <Translation x="260.5945*mm" y="140.33465*mm" z="239.2853*mm"/>
         </PosPart>
+	<!-- shift back by rShift in direction of axis -->
+	<Constant name="LGrShift"
+		  value="1*mm/tan([castor:LGAngleDelta]/2)"/>
+	<Constant name="LGxShift"
+		  value="[castor:LGrShift] * cos([castor:LGAngleBegin]+[castor:LGAngleDelta]/2)"/>
+	<Constant name="LGyShift"
+		  value="[castor:LGrShift] * sin([castor:LGAngleBegin]+[castor:LGAngleDelta]/2)"/>
         <PosPart copyNumber="1">
             <rParent name="castor:CEAL"/>
             <rChild name="castor:CEAI"/>
             <rRotation name="rotations:000D"/>
-            <Translation x="6.0815*mm" y="2.51905*mm" z="0.0*mm"/>
+            <Translation x="[castor:LGxShift]"
+			 y="[castor:LGyShift]"
+			 z="0.0*mm"/>
         </PosPart>
         <PosPart copyNumber="1">
             <rParent name="castor:CEDR"/>

--- a/Geometry/ForwardCommonData/data/castor.xml
+++ b/Geometry/ForwardCommonData/data/castor.xml
@@ -41,60 +41,55 @@
         <!-- START OF ELECTROMAGNETIC CALO  -->
         <!--  CASC - StainlessSteel -->
         <Polyhedra name="CAEC" numSide="4" startPhi="0.0*deg" deltaPhi="180.0*deg">
-            <ZSection rMin="40.00*mm" rMax="40.00*mm" z="0.00*mm"/>
-            <ZSection rMin="40.00*mm" rMax="143.00*mm" z="103.00*mm"/>
-            <ZSection rMin="40.50*mm" rMax="143.50*mm" z="103.50*mm"/>
-            <ZSection rMin="143.50*mm" rMax="143.50*mm" z="206.50*mm"/>
+            <ZSection rMin="39.00*mm" rMax="40.00*mm" z="0.0*mm"/>
+            <ZSection rMin="39.00*mm" rMax="141.00*mm" z="102.0*mm"/>
+            <ZSection rMin="41.50*mm" rMax="144.50*mm" z="104.5*mm"/>
+            <ZSection rMin="144.50*mm" rMax="144.50*mm" z="207.5*mm"/>
         </Polyhedra>
         <!-- to have octant StainlessSteel skeleton to support WQ plates  -->
         <!-- CASS sector - Air, 8 copies with deltaPhi=45.0  -->
         <Polyhedra name="CAES" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
-            <ZSection rMin="40.00*mm" rMax="40.00*mm" z="0.00*mm"/>
-            <ZSection rMin="40.00*mm" rMax="143.00*mm" z="103.00*mm"/>
-            <ZSection rMin="40.50*mm" rMax="143.50*mm" z="103.50*mm"/>
-            <ZSection rMin="143.50*mm" rMax="143.50*mm" z="206.50*mm"/>
+            <ZSection rMin="40.00*mm" rMax="40.00*mm" z="0.0*mm"/>
+            <ZSection rMin="40.00*mm" rMax="144.00*mm" z="103.0*mm"/>
+            <ZSection rMin="40.50*mm" rMax="144.50*mm" z="104.5*mm"/>
+            <ZSection rMin="144.50*mm" rMax="144.50*mm" z="207.5*mm"/>
         </Polyhedra>
         <!-- EM read-out channel  with StainlessSteel size  1 copy -->
         <Polyhedra name="CAER" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
-            <ZSection rMin="40.00*mm" rMax="40.00*mm" z="0.00*mm"/>
-            <ZSection rMin="40.00*mm" rMax="91.50*mm" z="51.50*mm"/>
-            <ZSection rMin="92.00*mm" rMax="143.50*mm" z="103.50*mm"/>
-            <ZSection rMin="143.50*mm" rMax="143.50*mm" z="155.00*mm"/>
+            <ZSection rMin="40.00*mm" rMax="40.00*mm" z="0.0*mm"/>
+            <ZSection rMin="40.00*mm" rMax="91.50*mm" z="51.5*mm"/>
+            <ZSection rMin="93.00*mm" rMax="144.50*mm" z="104.5*mm"/>
+            <ZSection rMin="144.50*mm" rMax="144.50*mm" z="156.0*mm"/>
         </Polyhedra>
-        <!-- Air volume -->
         <!-- reduced rMin, rMax by (1.mm (StainlessSteel)/tg(22.5))= 2.41mm-->
-        <!-- the special X,Y shifts are needed to construct a wall thickness of 1mm. -->
-        <!-- Start the volume below (2.41mm) and then shift upwards in r by (2.41+1)mm.  -->
-        <!-- Shifts are defined further down the code.  -->
-        <!-- shift works on CASTFar 1 sector which points to 10 o'clock for positive eta CASTOR     -->
-        <!-- the shifts are: x = (2.41+1)*sin(22.5) = 3.15, y=...cos...=1.31  1 copy     -->
+        <!-- the special X,Y shifts are needed  -->
+        <!-- the positions: x = 2.41*cos22.5 = 1.30, y=...sin...=0.54  1 copy     -->
         <Polyhedra name="CERR" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
-            <ZSection rMin="37.59*mm" rMax="37.59*mm" z="1.00*mm"/>
-            <ZSection rMin="37.59*mm" rMax="89.09*mm" z="52.50*mm"/>
-            <ZSection rMin="88.59*mm" rMax="140.09*mm" z="103.50*mm"/>
-            <ZSection rMin="140.09*mm" rMax="140.09*mm" z="155.00*mm"/>
+            <ZSection rMin="37.59*mm" rMax="37.59*mm" z="0.0*mm"/>
+            <ZSection rMin="37.59*mm" rMax="89.90*mm" z="51.5*mm"/>
+            <ZSection rMin="90.59*mm" rMax="142.09*mm" z="104.5*mm"/>
+            <ZSection rMin="142.09*mm" rMax="142.09*mm" z="156.0*mm"/>
         </Polyhedra>
-        <!-- layer    5 copies (5.mm+2mm)/sin(45deg) + 0.40mm = 10.3 (7.07+2.83+0.40) -->
+        <!-- layer    5 copies (5.+2)*sqrt(2) + 0.40mm = 10.3 (7.07+2.83+0.40) -->
         <!-- 0.4 mm air gap included -->
         <!-- CAEL: Tungsten layer, CAEA: air layer, CAHF: quartz -->
         <Polyhedra name="CAEL" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
-            <ZSection rMin="37.59*mm" rMax="37.59*mm" z="1.00*mm"/>
-            <ZSection rMin="37.59*mm" rMax="47.89*mm" z="11.30*mm"/>
-            <ZSection rMin="129.79*mm" rMax="140.09*mm" z="103.50*mm"/>
-            <ZSection rMin="140.09*mm" rMax="140.09*mm" z="113.80*mm"/>
+            <ZSection rMin="37.59*mm" rMax="37.59*mm" z="0.0*mm"/>
+            <ZSection rMin="37.59*mm" rMax="47.89*mm" z="10.3*mm"/>
+            <ZSection rMin="131.79*mm" rMax="142.09*mm" z="104.5*mm"/>
+            <ZSection rMin="142.09*mm" rMax="142.09*mm" z="114.8*mm"/>
         </Polyhedra>
         <Polyhedra name="CAEA" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
-            <ZSection rMin="37.59*mm" rMax="37.59*mm" z="1.00*mm"/>
-            <ZSection rMin="37.59*mm" rMax="40.82*mm" z="4.23*mm"/>
-            <ZSection rMin="136.86*mm" rMax="140.09*mm" z="103.50*mm"/>
-            <ZSection rMin="140.09*mm" rMax="140.09*mm" z="106.73*mm"/>
+            <ZSection rMin="37.59*mm" rMax="37.59*mm" z="0.0*mm"/>
+            <ZSection rMin="37.59*mm" rMax="40.82*mm" z="3.23*mm"/>
+            <ZSection rMin="138.86*mm" rMax="142.09*mm" z="104.5*mm"/>
+            <ZSection rMin="142.09*mm" rMax="142.09*mm" z="107.73*mm"/>
         </Polyhedra>
         <Polyhedra name="CAEF" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
-            <ZSection rMin="37.59*mm" rMax="37.59*mm" z="1.00*mm"/>
-            <ZSection rMin="37.59*mm" rMax="40.42*mm" z="3.83*mm"/>
-            <ZSection rMin="137.26*mm" rMax="140.09*mm" z="103.50*mm"/>
-            <ZSection rMin="140.09*mm" rMax="140.09*mm" z="106.33*mm"/>
-
+            <ZSection rMin="37.59*mm" rMax="37.59*mm" z="0.0*mm"/>
+            <ZSection rMin="37.59*mm" rMax="40.42*mm" z="2.83*mm"/>
+            <ZSection rMin="139.26*mm" rMax="142.09*mm" z="104.5*mm"/>
+            <ZSection rMin="142.09*mm" rMax="142.09*mm" z="107.33*mm"/>
         </Polyhedra>
         <!-- shape to be used for Intersection to create C3TF,C4TF semi-trapezoid solids   -->
         <!-- dz=Height of plate/2 + 3 mm (arbitrary) ; dy = B/2 -->
@@ -116,55 +111,53 @@
         <!--  -->
         <!--  -->
         <Polyhedra name="CAHC" numSide="4" startPhi="0.0*deg" deltaPhi="180.0*deg">
-            <ZSection rMin="40.00*mm" rMax="40.00*mm" z="0.0*mm"/>
-            <ZSection rMin="40.00*mm" rMax="177.40*mm" z="137.4*mm"/>
-            <ZSection rMin="40.00*mm" rMax="177.40*mm" z="1212.0*mm"/>
-            <ZSection rMin="177.40*mm" rMax="177.40*mm" z="1349.4*mm"/>
+            <ZSection rMin="39.00*mm" rMax="40.00*mm" z="0.0*mm"/>
+            <ZSection rMin="39.00*mm" rMax="178.40*mm" z="138.4*mm"/>
+            <ZSection rMin="39.00*mm" rMax="178.40*mm" z="1211.0*mm"/>
+            <ZSection rMin="178.40*mm" rMax="178.40*mm" z="1350.4*mm"/>
         </Polyhedra>
         <!-- to have octant StainlessSteel skeleton to support WQ plates  -->
         <!-- CAHS sector - Air, 8 copies with deltaPhi=45.0  -->
         <Polyhedra name="CAHS" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
             <ZSection rMin="40.00*mm" rMax="40.00*mm" z="0.0*mm"/>
-            <ZSection rMin="40.00*mm" rMax="177.40*mm" z="137.4*mm"/>
-            <ZSection rMin="40.00*mm" rMax="177.40*mm" z="1212.0*mm"/>
-            <ZSection rMin="177.40*mm" rMax="177.40*mm" z="1349.4*mm"/>
+            <ZSection rMin="40.00*mm" rMax="178.40*mm" z="138.4*mm"/>
+            <ZSection rMin="40.00*mm" rMax="178.40*mm" z="1212.0*mm"/>
+            <ZSection rMin="178.40*mm" rMax="178.40*mm" z="1350.4*mm"/>
         </Polyhedra>
         <!-- HAD read-out channel  with StainlessSteel size  12 copies -->
         <Polyhedra name="CAHR" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
             <ZSection rMin="40.00*mm" rMax="40.00*mm" z="0.0*mm"/>
             <ZSection rMin="40.00*mm" rMax="141.00*mm" z="101.0*mm"/>
-            <ZSection rMin="76.40*mm" rMax="177.40*mm" z="137.4*mm"/>
-            <ZSection rMin="177.40*mm" rMax="177.40*mm" z="238.4*mm"/>
+            <ZSection rMin="77.40*mm" rMax="178.40*mm" z="138.4*mm"/>
+            <ZSection rMin="178.40*mm" rMax="178.40*mm" z="239.9*mm"/>
         </Polyhedra>
         <!-- reduced rMin,rMax by (1.mm (StainlessSteel)/tg(22.5))= 2.41mm-->
-        <!-- the special X,Y shifts are needed (see CERR) -->
+        <!-- the special X,Y shifts are needed  -->
+        <!-- the positions: x = 2.41*cos22.5 = 1.30, y=...sin...=0.54  1 copy     -->
         <Polyhedra name="CHRR" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
-            <ZSection rMin="37.59*mm" rMax="37.59*mm" z="1.00*mm"/>
-            <ZSection rMin="37.59*mm" rMax="138.59*mm" z="102.00*mm"/>
-            <ZSection rMin="72.99*mm" rMax="173.99*mm" z="137.40*mm"/>
-            <ZSection rMin="173.99*mm" rMax="173.99*mm" z="238.40*mm"/>
+            <ZSection rMin="37.59*mm" rMax="37.59*mm" z="0.0*mm"/>
+            <ZSection rMin="37.59*mm" rMax="138.59*mm" z="101.0*mm"/>
+            <ZSection rMin="74.99*mm" rMax="175.99*mm" z="138.4*mm"/>
+            <ZSection rMin="175.99*mm" rMax="175.99*mm" z="239.9*mm"/>
         </Polyhedra>
-        <!-- layer    7 copies (10.+4.+0.4)/sin(45deg)=20.2  (14.14+5.66+0.60) -->
-	<!-- tunsten layer -->
+        <!-- layer    7 copies (5.+2)*sqrt(2)+0.60=10.5  (7.07+2.83+0.60) -->
         <Polyhedra name="CAHL" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
-            <ZSection rMin="37.59*mm" rMax="37.59*mm" z="1.00*mm"/>
-            <ZSection rMin="37.59*mm" rMax="57.79*mm" z="21.20*mm"/>
-            <ZSection rMin="153.79*mm" rMax="173.99*mm" z="137.40*mm"/>
-            <ZSection rMin="173.99*mm" rMax="173.99*mm" z="157.60*mm"/>
+            <ZSection rMin="37.59*mm" rMax="37.59*mm" z="0.0*mm"/>
+            <ZSection rMin="37.59*mm" rMax="57.79*mm" z="20.2*mm"/>
+            <ZSection rMin="155.79*mm" rMax="175.99*mm" z="138.4*mm"/>
+            <ZSection rMin="175.99*mm" rMax="175.99*mm" z="158.6*mm"/>
         </Polyhedra>
-	<!-- quartz volume layer where wrapping (here simply air?) is included?-->
         <Polyhedra name="CAHA" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
-            <ZSection rMin="37.59*mm" rMax="37.59*mm" z="1.00*mm"/>
-            <ZSection rMin="37.59*mm" rMax="43.65*mm" z="7.06*mm"/>
-            <ZSection rMin="167.93*mm" rMax="173.99*mm" z="137.40*mm"/>
-            <ZSection rMin="173.99*mm" rMax="173.99*mm" z="143.46*mm"/>
+            <ZSection rMin="37.59*mm" rMax="37.59*mm" z="0.0*mm"/>
+            <ZSection rMin="37.59*mm" rMax="43.65*mm" z="6.06*mm"/>
+            <ZSection rMin="169.93*mm" rMax="175.99*mm" z="138.4*mm"/>
+            <ZSection rMin="175.99*mm" rMax="175.99*mm" z="144.46*mm"/>
         </Polyhedra>
-	<!-- quartz volume without wrapping where will be intersected -->
         <Polyhedra name="CAHF" numSide="1" startPhi="0.0*deg" deltaPhi="45.0*deg">
-            <ZSection rMin="37.59*mm" rMax="37.59*mm" z="1.00*mm"/>
-            <ZSection rMin="37.59*mm" rMax="43.25*mm" z="6.66*mm"/>
-            <ZSection rMin="168.33*mm" rMax="173.99*mm" z="137.40*mm"/>
-            <ZSection rMin="173.99*mm" rMax="173.99*mm" z="143.06*mm"/>
+            <ZSection rMin="37.59*mm" rMax="37.59*mm" z="0.0*mm"/>
+            <ZSection rMin="37.59*mm" rMax="43.25*mm" z="5.66*mm"/>
+            <ZSection rMin="170.33*mm" rMax="175.99*mm" z="138.4*mm"/>
+            <ZSection rMin="175.99*mm" rMax="175.99*mm" z="144.06*mm"/>
         </Polyhedra>
         <!--  -->
         <!--  -->
@@ -205,21 +198,19 @@
             <ZSection rMin="251.70*mm" rMax="303.20*mm" z="263.2*mm"/>
             <ZSection rMin="303.20*mm" rMax="303.20*mm" z="314.7*mm"/>
         </Polyhedra>
-        <!-- compartment with Air lightguide (1 mm wall strength) (external part)  1 copy -->
-	<Constant name="LGAngleBegin" value="11.6287*deg"/>
-	<Constant name="LGAngleDelta" value="21.74255*deg"/>
-        <Polyhedra name="CEAL" numSide="1" startPhi="[castor:LGAngleBegin]" deltaPhi="[castor:LGAngleDelta]">
+        <!--  Aluminium (1mm) compartment with Air lightguide (external part)  1 copy -->
+        <Polyhedra name="CEAL" numSide="1" startPhi="11.6287*deg" deltaPhi="21.74255*deg">
             <ZSection rMin="67.6913*mm" rMax="67.6913*mm" z="13.50*mm"/>
             <ZSection rMin="67.6913*mm" rMax="98.829*mm" z="39.5*mm"/>
             <ZSection rMin="105.2413*mm" rMax="149.9623*mm" z="82.27*mm"/>
             <ZSection rMin="149.9623*mm" rMax="149.9623*mm" z="133.27*mm"/>
         </Polyhedra>
-        <!-- Air compartment in CEAL (lightguide) (internal part of LG)  1 copy -->
-        <Polyhedra name="CEAI" numSide="1" startPhi="[castor:LGAngleBegin]" deltaPhi="[castor:LGAngleDelta]">
-           <ZSection rMin="62.48432*mm" rMax="62.48432*mm" z="14.50*mm"/>
-           <ZSection rMin="62.48432*mm" rMax="91.22937*mm" z="38.50*mm"/>
-           <ZSection rMin="101.78906*mm" rMax="144.75532*mm" z="83.27*mm"/>
-           <ZSection rMin="144.75532*mm" rMax="144.75532*mm" z="132.27*mm"/>
+        <!-- Air compartment - lightguide (internal part of LG)  1 copy -->
+        <Polyhedra name="CEAI" numSide="1" startPhi="11.6287*deg" deltaPhi="21.74255*deg">
+            <ZSection rMin="62.4836*mm" rMax="62.4836*mm" z="14.5*mm"/>
+            <ZSection rMin="62.4836*mm" rMax="91.2261*mm" z="38.5*mm"/>
+            <ZSection rMin="101.7908*mm" rMax="144.7546*mm" z="83.27*mm"/>
+            <ZSection rMin="144.7546*mm" rMax="144.7546*mm" z="132.27*mm"/>
         </Polyhedra>
         <!-- Air volume to be filled by PMT  1 copy -->
         <!-- volume for PMT's -->
@@ -440,9 +431,7 @@
             <rRotation name="castor:CASTFarTilt"/>
             <!-- please multiply x by -1 since CASTOR on eta minus side is mirrored-->
             <!-- the tilt is defined so that the face position center face position does not change-->
-            <Translation x="0.0*cm - [castor:castLength]*sin([castor:CASTFarTiltAngle])"
-			 y="0.0*cm"
-			 z="0*mm + [castor:castLength]*(1-cos([castor:CASTFarTiltAngle]))"/>
+            <Translation x="0.0*cm - [castor:castLength]*sin([castor:CASTFarTiltAngle])" y="0.0*cm" z="0*mm + [castor:castLength]*(1-cos([castor:CASTFarTiltAngle]))"/>
         </PosPart>
         <PosPart copyNumber="1">
             <rParent name="forward:CastorB"/>
@@ -450,9 +439,7 @@
             <rRotation name="castor:CASTNearTilt"/>
             <!-- please multiply x by -1 since CASTOR on eta minus side is mirrored-->
             <!-- the tilt is defined so that the face position center face position does not change-->
-            <Translation x="0.0*cm - [castor:castLength]*sin([castor:CASTNearTiltAngle])"
-			 y="0.0*cm"
-			 z="0*mm + [castor:castLength]*(1-cos([castor:CASTNearTiltAngle]))"/>
+            <Translation x="0.0*cm - [castor:castLength]*sin([castor:CASTNearTiltAngle])" y="0.0*cm" z="0*mm + [castor:castLength]*(1-cos([castor:CASTNearTiltAngle]))"/>
         </PosPart>
 
         <PosPart copyNumber="2">
@@ -559,7 +546,7 @@
             <rParent name="castor:CAER"/>
             <rChild name="castor:CERR"/>
             <rRotation name="rotations:000D"/>
-            <Translation x="3.1543220299*mm" y="1.30656296488*mm" z="0.0*mm"/>
+            <Translation x="+1.30*mm" y="+0.54*mm" z="0.0*mm"/>
         </PosPart>
         <!--  -->
         <!-- HAD read-out channel  12 copies include 5 layers -->
@@ -641,7 +628,7 @@
             <rParent name="castor:CAHR"/>
             <rChild name="castor:CHRR"/>
             <rRotation name="rotations:000D"/>
-            <Translation x="3.1543220299*mm" y="1.30656296488*mm" z="0.0*mm"/>
+            <Translation x="+1.30*mm" y="+0.54*mm" z="0.0*mm"/>
         </PosPart>
         <!--  -->
         <!-- EM layers :   5 copies -->
@@ -749,7 +736,7 @@
             <rParent name="castor:CAHA"/>
             <rChild name="castor:CAHF"/>
             <rRotation name="rotations:000D"/>
-            <Translation x="0.0*mm" y="0.0*mm" z="0.28142*mm"/>
+            <Translation x="0.0*mm" y="0.0*mm" z="0.2*mm"/>
         </PosPart>
         <PosPart copyNumber="1">
             <rParent name="castor:CAHF"/>
@@ -913,20 +900,11 @@
             <rRotation name="rotations:CABK"/>
             <Translation x="260.5945*mm" y="140.33465*mm" z="239.2853*mm"/>
         </PosPart>
-	<!-- shift back by rShift in direction of axis -->
-	<Constant name="LGrShift"
-		  value="1*mm/tan([castor:LGAngleDelta]/2)"/>
-	<Constant name="LGxShift"
-		  value="[castor:LGrShift] * cos([castor:LGAngleBegin]+[castor:LGAngleDelta]/2)"/>
-	<Constant name="LGyShift"
-		  value="[castor:LGrShift] * sin([castor:LGAngleBegin]+[castor:LGAngleDelta]/2)"/>
         <PosPart copyNumber="1">
             <rParent name="castor:CEAL"/>
             <rChild name="castor:CEAI"/>
             <rRotation name="rotations:000D"/>
-            <Translation x="[castor:LGxShift]"
-			 y="[castor:LGyShift]"
-			 z="0.0*mm"/>
+            <Translation x="6.0815*mm" y="2.51905*mm" z="0.0*mm"/>
         </PosPart>
         <PosPart copyNumber="1">
             <rParent name="castor:CEDR"/>

--- a/SimG4CMS/Forward/interface/CastorNumberingScheme.h
+++ b/SimG4CMS/Forward/interface/CastorNumberingScheme.h
@@ -62,8 +62,6 @@ private:
 
   lvp lvCASTFar, lvCASTNear, lvCAST, lvCAES, lvCEDS, lvCAHS, lvCHDS, lvCAER, lvCEDR;
   lvp lvCAHR, lvCHDR, lvC3EF, lvC3HF, lvC4EF, lvC4HF;
-  
-  int copyNoToSector[17];
 
 };
 


### PR DESCRIPTION
This is an update to:
https://github.com/cms-sw/cmssw/pull/2722

We were asked to provide backward compatibility to old geometry. The numbering scheme now detects whether it's new or old geometry by looking for CASTFar/Near volumes which only exist in the (new) separated half geometry. With this change (even if old xml file or db is selected) no warning messages appear and det IDs are properly returned.
We can discuss this in simulation meeting on Friday...

(Including Hans @hvanhaev)
