### PR TITLE
Const only access to GeometricSearchTracker Geometry

### DIFF
--- a/CalibTracker/SiStripHitEfficiency/src/HitEff.cc
+++ b/CalibTracker/SiStripHitEfficiency/src/HitEff.cc
@@ -364,7 +364,7 @@ void HitEff::analyze(const edm::Event& e, const edm::EventSetup& es){
 	if ( TKlayers==9 && isValid && isLastTOB5 ) {
 	  //	  if ( TKlayers==9 && itm==TMeas.rbegin()) {
 	//	  if ( TKlayers==9 && (itm==TMeas.back()) ) {	  // to check for only the last entry in the trajectory for propagation
-	  std::vector< BarrelDetLayer*> barrelTOBLayers = measurementTrackerHandle->geometricSearchTracker()->tobLayers() ;
+	  std::vector< BarrelDetLayer const*> barrelTOBLayers = measurementTrackerHandle->geometricSearchTracker()->tobLayers() ;
 	  const DetLayer* tob6 = barrelTOBLayers[barrelTOBLayers.size()-1];
 	  const MeasurementEstimator* estimator = est.product();
 	  const LayerMeasurements* theLayerMeasurements = new LayerMeasurements(*measurementTrackerHandle, *measurementTrackerEvent);
@@ -396,9 +396,9 @@ void HitEff::analyze(const edm::Event& e, const edm::EventSetup& es){
 	
 	if ( TKlayers==21 && isValid && isLastTEC8 ) {
 	  
-	  std::vector< ForwardDetLayer*> posTecLayers = measurementTrackerHandle->geometricSearchTracker()->posTecLayers() ;
+	  std::vector< const ForwardDetLayer*> posTecLayers = measurementTrackerHandle->geometricSearchTracker()->posTecLayers() ;
 	  const DetLayer* tec9pos = posTecLayers[posTecLayers.size()-1];
-	  std::vector< ForwardDetLayer*> negTecLayers = measurementTrackerHandle->geometricSearchTracker()->negTecLayers() ;
+	  std::vector< const ForwardDetLayer*> negTecLayers = measurementTrackerHandle->geometricSearchTracker()->negTecLayers() ;
 	  const DetLayer* tec9neg = negTecLayers[negTecLayers.size()-1];
 	  
 	  const MeasurementEstimator* estimator = est.product();

--- a/DQM/SiPixelMonitorTrack/src/SiPixelHitEfficiencySource.cc
+++ b/DQM/SiPixelMonitorTrack/src/SiPixelHitEfficiencySource.cc
@@ -350,7 +350,7 @@ void SiPixelHitEfficiencySource::analyze(const edm::Event& iEvent, const edm::Ev
 	}
       }//end check last valid layer
       if (lastValidL2) {
-	std::vector< BarrelDetLayer*> pxbLayers = measurementTrackerHandle->geometricSearchTracker()->pixelBarrelLayers();
+	std::vector< const BarrelDetLayer*> pxbLayers = measurementTrackerHandle->geometricSearchTracker()->pixelBarrelLayers();
 	const DetLayer* pxb1 = pxbLayers[extrapolateTo_-1];
 	const MeasurementEstimator* estimator = est.product();
 	const LayerMeasurements* theLayerMeasurements =    new LayerMeasurements(*measurementTrackerHandle, *measurementTrackerEventHandle);  

--- a/DQM/TrackingMonitor/src/TrackEfficiencyMonitor.cc
+++ b/DQM/TrackingMonitor/src/TrackEfficiencyMonitor.cc
@@ -647,7 +647,7 @@ int TrackEfficiencyMonitor::compatibleLayers(const NavigationSchool& navigationS
   // check the number of compatible layers
   //---------------------------------------------------   
   
-  std::vector< BarrelDetLayer*> barrelTOBLayers = measurementTrackerHandle->geometricSearchTracker()->tobLayers() ;
+  std::vector< const BarrelDetLayer*> barrelTOBLayers = measurementTrackerHandle->geometricSearchTracker()->tobLayers() ;
   
   unsigned int layers = 0;
   for ( unsigned int k=0 ; k < barrelTOBLayers.size() ; k++ ) 

--- a/FastSimulation/TrackerSetup/src/TrackerInteractionGeometry.cc
+++ b/FastSimulation/TrackerSetup/src/TrackerInteractionGeometry.cc
@@ -290,11 +290,11 @@ TrackerInteractionGeometry::TrackerInteractionGeometry(const edm::ParameterSet& 
 	<< "The pointer to the GeometricSearchTracker was not set"; 
     
     // The vector of Barrel Tracker Layers 
-    std::vector< BarrelDetLayer*> barrelLayers = 
+    auto const& barrelLayers = 
       theGeomSearchTracker->barrelLayers();
     
     // The vector of Forward Tracker Layers (positive z)
-    std::vector< ForwardDetLayer*>  posForwardLayers = 
+    auto const&  posForwardLayers = 
       theGeomSearchTracker->posForwardLayers();
     
     // Local pointers
@@ -311,7 +311,7 @@ TrackerInteractionGeometry::TrackerInteractionGeometry(const edm::ParameterSet& 
     
     // Take the active layer position from the Tracker Reco Geometry
     // Pixel barrel
-    std::vector< BarrelDetLayer*>::const_iterator bl = barrelLayers.begin();
+    auto bl = barrelLayers.begin();
     double maxLength = (**bl).specificSurface().bounds().length()/2.+1.7;
     double maxRadius = (**bl).specificSurface().radius()+0.01;
     // First pixel barrel layer: r=4.41058, l=53.38
@@ -428,7 +428,7 @@ TrackerInteractionGeometry::TrackerInteractionGeometry(const edm::ParameterSet& 
 					-tobOutCablesLength[version],     tobOutCablesLength[version]);
     
     // And now the disks...
-    std::vector< ForwardDetLayer*>::const_iterator fl = posForwardLayers.begin();
+    auto fl = posForwardLayers.begin();
     
     // Pixel disks 
     // First Pixel disk: Z pos 35.5 radii 5.42078, 16.0756

--- a/FastSimulation/TrajectoryManager/src/TrajectoryManager.cc
+++ b/FastSimulation/TrajectoryManager/src/TrajectoryManager.cc
@@ -829,18 +829,18 @@ TrajectoryManager::initializeLayerMap()
 /// ATTENTION: HARD CODED LOGIC! If Famos layer numbering changes this logic needs to 
 /// be adapted to the new numbering!
 
-  std::vector< BarrelDetLayer*>   barrelLayers = 
+  const std::vector< const BarrelDetLayer*>&   barrelLayers = 
     theGeomSearchTracker->barrelLayers();
   LogDebug("FastTracking") << "Barrel DetLayer dump: ";
-  for (std::vector< BarrelDetLayer*>::const_iterator bl=barrelLayers.begin();
+  for (auto bl=barrelLayers.begin();
        bl != barrelLayers.end(); ++bl) {
     LogDebug("FastTracking")<< "radius " << (**bl).specificSurface().radius(); 
   }
 
-  std::vector< ForwardDetLayer*>  posForwardLayers = 
+  const std::vector< const ForwardDetLayer*>&  posForwardLayers = 
     theGeomSearchTracker->posForwardLayers();
   LogDebug("FastTracking") << "Positive Forward DetLayer dump: ";
-  for (std::vector< ForwardDetLayer*>::const_iterator fl=posForwardLayers.begin();
+  for (auto fl=posForwardLayers.begin();
        fl != posForwardLayers.end(); ++fl) {
     LogDebug("FastTracking") << "Z pos "
 			    << (**fl).surface().position().z()
@@ -867,7 +867,7 @@ TrajectoryManager::initializeLayerMap()
     if (cyl != 0) {
       LogDebug("FastTracking") << " cylinder radius " << cyl->radius();
       bool found = false;
-      for (std::vector< BarrelDetLayer*>::const_iterator 
+      for (auto
 	     bl=barrelLayers.begin(); bl != barrelLayers.end(); ++bl) {
 
 	if (fabs( cyl->radius() - (**bl).specificSurface().radius()) < rTolerance) {
@@ -886,7 +886,7 @@ TrajectoryManager::initializeLayerMap()
       LogDebug("FastTracking") << " disk radii " << disk->innerRadius() 
 		 << ", " << disk->outerRadius();
       bool found = false;
-      for (std::vector< ForwardDetLayer*>::const_iterator fl=posForwardLayers.begin();
+      for (auto fl=posForwardLayers.begin();
 	   fl != posForwardLayers.end(); ++fl) {
 	
 	if (fabs( disk->position().z() - (**fl).surface().position().z()) < zTolerance) {
@@ -908,8 +908,8 @@ TrajectoryManager::initializeLayerMap()
   }
 
   // Put the negative layers in the same map but with an offset
-  std::vector< ForwardDetLayer*>  negForwardLayers = theGeomSearchTracker->negForwardLayers();
-  for (std::vector< ForwardDetLayer*>::const_iterator nl=negForwardLayers.begin();
+ const  std::vector< const ForwardDetLayer*>&  negForwardLayers = theGeomSearchTracker->negForwardLayers();
+  for (auto nl=negForwardLayers.begin();
        nl != negForwardLayers.end(); ++nl) {
     for (int i=0; i<=theNegLayerOffset; i++) {
       if (theLayerMap[i] == 0) continue;

--- a/RecoEgamma/EgammaElectronAlgos/interface/PixelMatchStartLayers.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/PixelMatchStartLayers.h
@@ -31,11 +31,11 @@ class GeometricSearchTracker;
 class PixelMatchStartLayers {
 
 public:
-  typedef std::vector<ForwardDetLayer*> ForwardLayerContainer;
-  typedef std::vector<ForwardDetLayer*>::const_iterator ForwardLayerIterator;
+  typedef std::vector<const ForwardDetLayer*> ForwardLayerContainer;
+  typedef std::vector<const ForwardDetLayer*>::const_iterator ForwardLayerIterator;
 
-  typedef std::vector<BarrelDetLayer*> BarrelLayerContainer;
-  typedef std::vector<BarrelDetLayer*>::const_iterator BarrelLayerIterator;
+  typedef std::vector<const BarrelDetLayer*> BarrelLayerContainer;
+  typedef std::vector<const BarrelDetLayer*>::const_iterator BarrelLayerIterator;
 
   PixelMatchStartLayers();
   void setup(const GeometricSearchTracker *);

--- a/RecoEgamma/EgammaElectronAlgos/src/PixelHitMatcher.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/PixelHitMatcher.cc
@@ -240,7 +240,7 @@ PixelHitMatcher::compatibleHits
   pred1Meas.clear();
   pred2Meas.clear();
 
-  typedef vector<BarrelDetLayer*>::const_iterator BarrelLayerIterator;
+  typedef vector<const BarrelDetLayer*>::const_iterator BarrelLayerIterator;
   BarrelLayerIterator firstLayer = startLayers.firstBLayer();
 
   FreeTrajectoryState fts = FTSFromVertexToPointFactory::get(*theMagField,xmeas, vprim, energy, charge);
@@ -309,7 +309,7 @@ PixelHitMatcher::compatibleHits
 
 
   // check if there are compatible 1st hits the forward disks
-  typedef vector<ForwardDetLayer*>::const_iterator ForwardLayerIterator;
+  typedef vector<const ForwardDetLayer*>::const_iterator ForwardLayerIterator;
   ForwardLayerIterator flayer;
 
   TrajectoryStateOnSurface tsosfwd(fts, *bpb(fts.position(), fts.momentum()));

--- a/RecoEgamma/EgammaElectronAlgos/src/SiStripElectronSeedGenerator.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/SiStripElectronSeedGenerator.cc
@@ -213,12 +213,12 @@ void SiStripElectronSeedGenerator::findSeedsFromCluster
   //Use GST to retrieve hits from various DetLayers using layerMeasurements class
   const GeometricSearchTracker* gst = theMeasurementTracker->geometricSearchTracker();
 
-  std::vector<BarrelDetLayer*> tibLayers = gst->tibLayers();
-  DetLayer* tib1 = tibLayers.at(0);
-  DetLayer* tib2 = tibLayers.at(1);
+  std::vector<const BarrelDetLayer*> tibLayers = gst->tibLayers();
+  const DetLayer* tib1 = tibLayers.at(0);
+  const DetLayer* tib2 = tibLayers.at(1);
 
-  std::vector<ForwardDetLayer*> tecLayers;
-  std::vector<ForwardDetLayer*> tidLayers;
+  std::vector<const ForwardDetLayer*> tecLayers;
+  std::vector<const ForwardDetLayer*> tidLayers;
   if(scEta < 0){
     tecLayers = gst->negTecLayers();
     tidLayers = gst->negTidLayers();
@@ -228,12 +228,12 @@ void SiStripElectronSeedGenerator::findSeedsFromCluster
     tidLayers = gst->posTidLayers();
   }
 
-  DetLayer* tid1 = tidLayers.at(0);
-  DetLayer* tid2 = tidLayers.at(1);
-  DetLayer* tid3 = tidLayers.at(2);
-  DetLayer* tec1 = tecLayers.at(0);
-  DetLayer* tec2 = tecLayers.at(1);
-  DetLayer* tec3 = tecLayers.at(2);
+  const DetLayer* tid1 = tidLayers.at(0);
+  const DetLayer* tid2 = tidLayers.at(1);
+  const DetLayer* tid3 = tidLayers.at(2);
+  const DetLayer* tec1 = tecLayers.at(0);
+  const DetLayer* tec2 = tecLayers.at(1);
+  const DetLayer* tec3 = tecLayers.at(2);
 
   //Figure out which DetLayers to use based on SC Eta
   std::vector<bool> useDL = useDetLayer(scEta);

--- a/RecoMuon/DetLayers/interface/MuonDetLayerGeometry.h
+++ b/RecoMuon/DetLayers/interface/MuonDetLayerGeometry.h
@@ -27,49 +27,49 @@ class MuonDetLayerGeometry : public DetLayerGeometry{
   virtual ~MuonDetLayerGeometry();
 
   /// return the DT DetLayers (barrel), inside-out
-  const std::vector<DetLayer*>& allDTLayers() const;
+  const std::vector<const DetLayer*>& allDTLayers() const;
 
   /// return the CSC DetLayers (endcap), -Z to +Z
-  const std::vector<DetLayer*>& allCSCLayers() const;
+  const std::vector<const DetLayer*>& allCSCLayers() const;
 
   /// return the forward (+Z) CSC DetLayers, inside-out
-  const std::vector<DetLayer*>& forwardCSCLayers() const;
+  const std::vector<const DetLayer*>& forwardCSCLayers() const;
 
   /// return the backward (-Z) CSC DetLayers, inside-out
-  const std::vector<DetLayer*>& backwardCSCLayers() const;
+  const std::vector<const DetLayer*>& backwardCSCLayers() const;
 
   /// return all RPC DetLayers, order: backward, barrel, forward
-  const std::vector<DetLayer*>& allRPCLayers() const;
+  const std::vector<const DetLayer*>& allRPCLayers() const;
 
   /// return the barrel RPC DetLayers, inside-out
-  const std::vector<DetLayer*>& barrelRPCLayers() const;
+  const std::vector<const DetLayer*>& barrelRPCLayers() const;
 
   /// return the endcap RPC DetLayers, -Z to +Z
-  const std::vector<DetLayer*>& endcapRPCLayers() const;
+  const std::vector<const DetLayer*>& endcapRPCLayers() const;
 
   /// return the forward (+Z) RPC DetLayers, inside-out
-  const std::vector<DetLayer*>& forwardRPCLayers() const;
+  const std::vector<const DetLayer*>& forwardRPCLayers() const;
 
   /// return the backward (-Z) RPC DetLayers, inside-out
-  const std::vector<DetLayer*>& backwardRPCLayers() const;
+  const std::vector<const DetLayer*>& backwardRPCLayers() const;
 
   /// return all layers (DT+CSC+RPC), order: backward, barrel, forward
-  const std::vector<DetLayer*>& allLayers() const;
+  const std::vector<const DetLayer*>& allLayers() const;
 
   /// return all barrel DetLayers (DT+RPC), inside-out
-  const std::vector<DetLayer*>& allBarrelLayers() const;
+  const std::vector<const DetLayer*>& allBarrelLayers() const;
 
   /// return all endcap DetLayers (CSC+RPC), -Z to +Z
-  const std::vector<DetLayer*>& allEndcapLayers() const;
+  const std::vector<const DetLayer*>& allEndcapLayers() const;
 
   /// return all forward (+Z) layers (CSC+RPC), inside-out
-  const std::vector<DetLayer*>& allForwardLayers() const;
+  const std::vector<const DetLayer*>& allForwardLayers() const;
 
   /// return all backward (-Z) layers (CSC+RPC), inside-out
-  const std::vector<DetLayer*>& allBackwardLayers() const;
+  const std::vector<const DetLayer*>& allBackwardLayers() const;
   
   /// return the DetLayer which correspond to a certain DetId
-  virtual const DetLayer* idToLayer(const DetId& detId) const;
+  virtual const DetLayer* idToLayer(const DetId& detId) const override;
 
  private:
   /// Add CSC layers 
@@ -90,22 +90,22 @@ class MuonDetLayerGeometry : public DetLayerGeometry{
   
   void sortLayers();
 
-  std::vector<DetLayer*> cscLayers_fw;
-  std::vector<DetLayer*> cscLayers_bk;
-  std::vector<DetLayer*> cscLayers_all;
-  std::vector<DetLayer*> rpcLayers_all;
-  std::vector<DetLayer*> rpcLayers_endcap;
-  std::vector<DetLayer*> rpcLayers_fw;
-  std::vector<DetLayer*> rpcLayers_bk;
-  std::vector<DetLayer*> rpcLayers_barrel;
-  std::vector<DetLayer*> dtLayers;
-  std::vector<DetLayer*> allForward;
-  std::vector<DetLayer*> allBackward;
-  std::vector<DetLayer*> allEndcap;
-  std::vector<DetLayer*> allBarrel;
-  std::vector<DetLayer*> allDetLayers;
+  std::vector<const DetLayer*> cscLayers_fw;
+  std::vector<const DetLayer*> cscLayers_bk;
+  std::vector<const DetLayer*> cscLayers_all;
+  std::vector<const DetLayer*> rpcLayers_all;
+  std::vector<const DetLayer*> rpcLayers_endcap;
+  std::vector<const DetLayer*> rpcLayers_fw;
+  std::vector<const DetLayer*> rpcLayers_bk;
+  std::vector<const DetLayer*> rpcLayers_barrel;
+  std::vector<const DetLayer*> dtLayers;
+  std::vector<const DetLayer*> allForward;
+  std::vector<const DetLayer*> allBackward;
+  std::vector<const DetLayer*> allEndcap;
+  std::vector<const DetLayer*> allBarrel;
+  std::vector<const DetLayer*> allDetLayers;
     
-  std::map<DetId,DetLayer*> detLayersMap;
+  std::map<DetId,const DetLayer*> detLayersMap;
 };
 #endif
 

--- a/RecoMuon/DetLayers/src/MuonDetLayerGeometry.cc
+++ b/RecoMuon/DetLayers/src/MuonDetLayerGeometry.cc
@@ -22,7 +22,7 @@ using namespace geomsort;
 MuonDetLayerGeometry::MuonDetLayerGeometry() {}
 
 MuonDetLayerGeometry::~MuonDetLayerGeometry(){
-  for(vector<DetLayer*>::const_iterator it = allDetLayers.begin(); it != allDetLayers.end(); ++it)
+  for(vector<const DetLayer*>::const_iterator it = allDetLayers.begin(); it != allDetLayers.end(); ++it)
   {
     delete *it;
   }
@@ -30,73 +30,69 @@ MuonDetLayerGeometry::~MuonDetLayerGeometry(){
 
 void MuonDetLayerGeometry::addCSCLayers(const pair<vector<DetLayer*>, vector<DetLayer*> >& csclayers) {
     
-  vector<DetLayer*>::const_iterator it;
-  for(it=csclayers.first.begin(); it!=csclayers.first.end(); it++) {
-    cscLayers_fw.push_back(*it);
-    //    cscLayers_all.push_back(*it);
-    allForward.push_back(*it);
-    //    allEndcap.push_back(*it);
-    //    allDetLayers.push_back(*it);
+  for(auto const it : csclayers.first) {
+    cscLayers_fw.push_back(it);
+    //    cscLayers_all.push_back(it);
+    allForward.push_back(it);
+    //    allEndcap.push_back(it);
+    //    allDetLayers.push_back(it);
     
-    detLayersMap[ makeDetLayerId(*it) ] = *it;
+    detLayersMap[ makeDetLayerId(it) ] = it;
   }
-  
-  for(it=csclayers.second.begin(); it!=csclayers.second.end(); it++) {
-    cscLayers_bk.push_back(*it);
-    //    cscLayers_all.push_back(*it);
-    allBackward.push_back(*it);
-    //    allEndcap.push_back(*it);
-    //    allDetLayers.push_back(*it);
+
+  for(auto const it: csclayers.second) {
+    cscLayers_bk.push_back(it);
+    //    cscLayers_all.push_back(it);
+    allBackward.push_back(it);
+    //    allEndcap.push_back(it);
+    //    allDetLayers.push_back(it);
     
-    detLayersMap[ makeDetLayerId(*it) ] = *it;
+    detLayersMap[ makeDetLayerId(it) ] = it;
   }    
 }    
 
 void MuonDetLayerGeometry::addRPCLayers(const vector<DetLayer*>& barrelLayers, const pair<vector<DetLayer*>, vector<DetLayer*> >& endcapLayers) {
   
-  vector<DetLayer*>::const_iterator it;
-  
-  for (it=barrelLayers.begin();it!=barrelLayers.end();it++){
-    rpcLayers_barrel.push_back(*it);
-    //    rpcLayers_all.push_back(*it);
-    allBarrel.push_back(*it);
-    //    allDetLayers.push_back(*it);
+  for(auto const it: barrelLayers) {
+    rpcLayers_barrel.push_back(it);
+    //    rpcLayers_all.push_back(it);
+    allBarrel.push_back(it);
+    //    allDetLayers.push_back(it);
 
-    detLayersMap[ makeDetLayerId(*it) ] = *it;
+    detLayersMap[ makeDetLayerId(it) ] = it;
   }
-  for (it=endcapLayers.first.begin(); it!=endcapLayers.first.end(); it++){
-    rpcLayers_fw.push_back(*it);
-    //    rpcLayers_all.push_back(*it);
-    //    rpcLayers_endcap.push_back(*it);
-    allForward.push_back(*it);
-    //    allEndcap.push_back(*it);
-    //    allDetLayers.push_back(*it);
+  for(auto const it: endcapLayers.first) {
+    rpcLayers_fw.push_back(it);
+    //    rpcLayers_all.push_back(it);
+    //    rpcLayers_endcap.push_back(it);
+    allForward.push_back(it);
+    //    allEndcap.push_back(it);
+    //    allDetLayers.push_back(it);
 
-    detLayersMap[ makeDetLayerId(*it) ] = *it;
+    detLayersMap[ makeDetLayerId(it) ] = it;
   }
-  
-  for (it=endcapLayers.second.begin(); it!=endcapLayers.second.end(); it++){
-    rpcLayers_bk.push_back(*it);
-    //    rpcLayers_all.push_back(*it);
-    //    rpcLayers_endcap.push_back(*it);
-    allBackward.push_back(*it);
-    //    allEndcap.push_back(*it);
-    //    allDetLayers.push_back(*it);
 
-    detLayersMap[ makeDetLayerId(*it) ] = *it;
+  for(auto const it: endcapLayers.second) {
+    rpcLayers_bk.push_back(it);
+    //    rpcLayers_all.push_back(it);
+    //    rpcLayers_endcap.push_back(it);
+    allBackward.push_back(it);
+    //    allEndcap.push_back(it);
+    //    allDetLayers.push_back(it);
+
+    detLayersMap[ makeDetLayerId(it) ] = it;
   }
   
 }    
 
 void MuonDetLayerGeometry::addDTLayers(const vector<DetLayer*>& dtlayers) {
 
-    vector<DetLayer*>::const_iterator it;
-    for(it=dtlayers.begin(); it!=dtlayers.end(); it++) {
-        dtLayers.push_back(*it);
-        allBarrel.push_back(*it);
-	//        allDetLayers.push_back(*it);
+    for(auto const it : dtlayers) {
+        dtLayers.push_back(it);
+        allBarrel.push_back(it);
+	//        allDetLayers.push_back(it);
 
-	detLayersMap[ makeDetLayerId(*it) ] = *it;
+	detLayersMap[ makeDetLayerId(it) ] = it;
     }
 }    
 
@@ -131,83 +127,83 @@ DetId MuonDetLayerGeometry::makeDetLayerId(const DetLayer* detLayer) const{
 }
 
 
-const vector<DetLayer*>& 
+const vector<const DetLayer*>& 
 MuonDetLayerGeometry::allDTLayers() const {    
     return dtLayers; 
 }
 
-const vector<DetLayer*>&
+const vector<const DetLayer*>&
 MuonDetLayerGeometry::allCSCLayers() const {
     return cscLayers_all;
 }
 
 
-const vector<DetLayer*>&
+const vector<const DetLayer*>&
 MuonDetLayerGeometry::forwardCSCLayers() const {
     return cscLayers_fw;
 }
 
 
-const vector<DetLayer*>& 
+const vector<const DetLayer*>& 
 MuonDetLayerGeometry::backwardCSCLayers() const {
     return cscLayers_bk;
 }
 
 
-const vector<DetLayer*>& 
+const vector<const DetLayer*>& 
 MuonDetLayerGeometry::allRPCLayers() const {
     return rpcLayers_all;    
 }
 
 
-const vector<DetLayer*>& 
+const vector<const DetLayer*>& 
 MuonDetLayerGeometry::barrelRPCLayers() const {
     return rpcLayers_barrel; 
 }
 
 
-const vector<DetLayer*>& 
+const vector<const DetLayer*>& 
 MuonDetLayerGeometry::endcapRPCLayers() const {
     return rpcLayers_endcap;    
 }
 
 
-const vector<DetLayer*>& 
+const vector<const DetLayer*>& 
 MuonDetLayerGeometry::forwardRPCLayers() const {
      return rpcLayers_fw; 
 }
 
 
-const vector<DetLayer*>& 
+const vector<const DetLayer*>& 
 MuonDetLayerGeometry::backwardRPCLayers() const {
     return rpcLayers_bk; 
 }
 
 
-const vector<DetLayer*>&
+const vector<const DetLayer*>&
 MuonDetLayerGeometry::allLayers() const {
     return allDetLayers;    
 }    
 
 
-const vector<DetLayer*>&
+const vector<const DetLayer*>&
 MuonDetLayerGeometry::allBarrelLayers() const {
     return allBarrel;    
 }    
 
-const vector<DetLayer*>&
+const vector<const DetLayer*>&
 MuonDetLayerGeometry::allEndcapLayers() const {
     return allEndcap;    
 }    
 
 
-const vector<DetLayer*>&
+const vector<const DetLayer*>&
 MuonDetLayerGeometry::allForwardLayers() const {
     return allForward;    
 }    
 
 
-const vector<DetLayer*>&
+const vector<const DetLayer*>&
 MuonDetLayerGeometry::allBackwardLayers() const {
     return allBackward;    
 }    
@@ -242,7 +238,7 @@ const DetLayer* MuonDetLayerGeometry::idToLayer(const DetId &detId) const{
 
   else throw cms::Exception("InvalidSubdetId")<< detId.subdetId();
 
-  std::map<DetId,DetLayer*>::const_iterator layer = detLayersMap.find(id);
+  std::map<DetId,const DetLayer*>::const_iterator layer = detLayersMap.find(id);
   if (layer == detLayersMap.end()) return 0;
   return layer->second; 
 }
@@ -312,7 +308,7 @@ void MuonDetLayerGeometry::sortLayers() {
   // number layers
   int sq=0;
   for (auto l : allDetLayers) 
-    (*l).setSeqNum(sq++);
+    (*const_cast<DetLayer*>(l)).setSeqNum(sq++);
 
 
 }

--- a/RecoMuon/DetLayers/test/MuonRecoGeometryAnalyzer.cc
+++ b/RecoMuon/DetLayers/test/MuonRecoGeometryAnalyzer.cc
@@ -72,91 +72,91 @@ void MuonRecoGeometryAnalyzer::analyze( const Event& ev,
   // Some printouts
 
   cout << "*** allDTLayers(): " << geo->allDTLayers().size() << endl;
-  for (vector<DetLayer*>::const_iterator dl = geo->allDTLayers().begin();
+  for (auto dl = geo->allDTLayers().begin();
        dl != geo->allDTLayers().end(); ++dl) {
     cout << "  " << (int) (dl-geo->allDTLayers().begin()) << " " << dumpLayer(*dl);
   }
   cout << endl << endl;
 
   cout << "*** allCSCLayers(): " << geo->allCSCLayers().size() << endl;
-  for (vector<DetLayer*>::const_iterator dl = geo->allCSCLayers().begin();
+  for (auto dl = geo->allCSCLayers().begin();
        dl != geo->allCSCLayers().end(); ++dl) {
     cout << "  " << (int) (dl-geo->allCSCLayers().begin()) << " " << dumpLayer(*dl);
   }
   cout << endl << endl;
 
   cout << "*** forwardCSCLayers(): " << geo->forwardCSCLayers().size() << endl;
-  for (vector<DetLayer*>::const_iterator dl = geo->forwardCSCLayers().begin();
+  for (auto dl = geo->forwardCSCLayers().begin();
        dl != geo->forwardCSCLayers().end(); ++dl) {
     cout << "  " << (int) (dl-geo->forwardCSCLayers().begin()) << " " << dumpLayer(*dl);
   }
   cout << endl << endl;
 
   cout << "*** backwardCSCLayers(): " << geo->backwardCSCLayers().size() << endl;
-  for (vector<DetLayer*>::const_iterator dl = geo->backwardCSCLayers().begin();
+  for (auto dl = geo->backwardCSCLayers().begin();
        dl != geo->backwardCSCLayers().end(); ++dl) {
     cout << "  " << (int) (dl-geo->backwardCSCLayers().begin()) << " " << dumpLayer(*dl);
   }
   cout << endl << endl;
 
   cout << "*** allRPCLayers(): " << geo->allRPCLayers().size() << endl;
-  for (vector<DetLayer*>::const_iterator dl = geo->allRPCLayers().begin();
+  for (auto dl = geo->allRPCLayers().begin();
        dl != geo->allRPCLayers().end(); ++dl) {
     cout << "  " << (int) (dl-geo->allRPCLayers().begin()) << " " << dumpLayer(*dl);
   }
   cout << endl << endl;
 
   cout << "*** endcapRPCLayers(): " << geo->endcapRPCLayers().size() << endl;
-  for (vector<DetLayer*>::const_iterator dl = geo->endcapRPCLayers().begin();
+  for (auto dl = geo->endcapRPCLayers().begin();
        dl != geo->endcapRPCLayers().end(); ++dl) {
     cout << "  " << (int) (dl-geo->endcapRPCLayers().begin()) << " " << dumpLayer(*dl);
   }
   cout << endl << endl;
 
   cout << "*** barrelRPCLayers(): " << geo->barrelRPCLayers().size() << endl;
-  for (vector<DetLayer*>::const_iterator dl = geo->barrelRPCLayers().begin();
+  for (auto dl = geo->barrelRPCLayers().begin();
        dl != geo->barrelRPCLayers().end(); ++dl) {
     cout << "  " << (int) (dl-geo->barrelRPCLayers().begin()) << " " << dumpLayer(*dl);
   }
   cout << endl << endl;
 
   cout << "*** forwardRPCLayers(): " << geo->forwardRPCLayers().size() << endl;
-  for (vector<DetLayer*>::const_iterator dl = geo->forwardRPCLayers().begin();
+  for (auto dl = geo->forwardRPCLayers().begin();
        dl != geo->forwardRPCLayers().end(); ++dl) {
     cout << "  " << (int) (dl-geo->forwardRPCLayers().begin()) << " " << dumpLayer(*dl);
   }
   cout << endl << endl;
 
   cout << "*** backwardRPCLayers(): " << geo->backwardRPCLayers().size() << endl;
-  for (vector<DetLayer*>::const_iterator dl = geo->backwardRPCLayers().begin();
+  for (auto dl = geo->backwardRPCLayers().begin();
        dl != geo->backwardRPCLayers().end(); ++dl) {
     cout << "  " << (int) (dl-geo->backwardRPCLayers().begin()) << " " << dumpLayer(*dl);
   }
   cout << endl << endl;
 
   cout << "*** allBarrelLayers(): " << geo->allBarrelLayers().size() << endl;
-  for (vector<DetLayer*>::const_iterator dl = geo->allBarrelLayers().begin();
+  for (auto dl = geo->allBarrelLayers().begin();
        dl != geo->allBarrelLayers().end(); ++dl) {
     cout << "  " << (int) (dl-geo->allBarrelLayers().begin()) << " " << dumpLayer(*dl);
   }
   cout << endl << endl;
 
   cout << "*** allEndcapLayers(): " << geo->allEndcapLayers().size() << endl;
-  for (vector<DetLayer*>::const_iterator dl = geo->allEndcapLayers().begin();
+  for (auto dl = geo->allEndcapLayers().begin();
        dl != geo->allEndcapLayers().end(); ++dl) {
     cout << "  " << (int) (dl-geo->allEndcapLayers().begin()) << " " << dumpLayer(*dl);
   }
   cout << endl << endl;
 
   cout << "*** allForwardLayers(): " << geo->allForwardLayers().size() << endl;
-  for (vector<DetLayer*>::const_iterator dl = geo->allForwardLayers().begin();
+  for (auto dl = geo->allForwardLayers().begin();
        dl != geo->allForwardLayers().end(); ++dl) {
     cout << "  " << (int) (dl-geo->allForwardLayers().begin()) << " " << dumpLayer(*dl);
   }
   cout << endl << endl;
 
   cout << "*** allBackwardLayers(): " << geo->allBackwardLayers().size() << endl;
-  for (vector<DetLayer*>::const_iterator dl = geo->allBackwardLayers().begin();
+  for (auto dl = geo->allBackwardLayers().begin();
        dl != geo->allBackwardLayers().end(); ++dl) {
     cout << "  " << (int) (dl-geo->allBackwardLayers().begin()) << " " << dumpLayer(*dl);
   }
@@ -164,7 +164,7 @@ void MuonRecoGeometryAnalyzer::analyze( const Event& ev,
 
 
   cout << "*** allLayers(): " << geo->allLayers().size() << endl;
-  for (vector<DetLayer*>::const_iterator dl = geo->allLayers().begin();
+  for (auto dl = geo->allLayers().begin();
        dl != geo->allLayers().end(); ++dl) {
     cout << "  " << (int) (dl-geo->allLayers().begin()) << " " << dumpLayer(*dl);
   }
@@ -181,9 +181,9 @@ void MuonRecoGeometryAnalyzer::analyze( const Event& ev,
 
 void MuonRecoGeometryAnalyzer::testDTLayers(const MuonDetLayerGeometry* geo,const MagneticField* field) {
 
-  const vector<DetLayer*>& layers = geo->allDTLayers();
+  const vector<const DetLayer*>& layers = geo->allDTLayers();
 
-  for (vector<DetLayer*>::const_iterator ilay = layers.begin(); ilay!=layers.end(); ++ilay) {
+  for (auto ilay = layers.begin(); ilay!=layers.end(); ++ilay) {
     const MuRodBarrelLayer* layer = (const MuRodBarrelLayer*) (*ilay);
   
     const BoundCylinder& cyl = layer->specificSurface();  
@@ -238,9 +238,9 @@ void MuonRecoGeometryAnalyzer::testDTLayers(const MuonDetLayerGeometry* geo,cons
 }
 
 void MuonRecoGeometryAnalyzer::testCSCLayers(const MuonDetLayerGeometry* geo,const MagneticField* field) {
-  const vector<DetLayer*>& layers = geo->allCSCLayers();
+  const vector<const DetLayer*>& layers = geo->allCSCLayers();
 
-  for (vector<DetLayer*>::const_iterator ilay = layers.begin(); ilay!=layers.end(); ++ilay) {
+  for (auto ilay = layers.begin(); ilay!=layers.end(); ++ilay) {
     const MuRingForwardDoubleLayer* layer = (const MuRingForwardDoubleLayer*) (*ilay);
   
     const BoundDisk& disk = layer->specificSurface();

--- a/RecoMuon/GlobalTrackingTools/src/DirectTrackerNavigation.cc
+++ b/RecoMuon/GlobalTrackingTools/src/DirectTrackerNavigation.cc
@@ -85,10 +85,8 @@ DirectTrackerNavigation::compatibleLayers(const FreeTrajectoryState& fts,
 //
 void DirectTrackerNavigation::inOutPx(const FreeTrajectoryState& fts, vector<const DetLayer*>& output) const {
 
-  const vector<BarrelDetLayer*>& barrel = theGeometricSearchTracker->pixelBarrelLayers();
-
-  for (vector<BarrelDetLayer*>::const_iterator iter_B = barrel.begin(); iter_B != barrel.end(); iter_B++) {
-    if ( checkCompatible(fts,(*iter_B)) ) output.push_back((*iter_B));
+  for (const auto i : theGeometricSearchTracker->pixelBarrelLayers()) {
+    if ( checkCompatible(fts,i) ) output.push_back(i);
   }
 
 }
@@ -99,10 +97,8 @@ void DirectTrackerNavigation::inOutPx(const FreeTrajectoryState& fts, vector<con
 //
 void DirectTrackerNavigation::inOutTIB(const FreeTrajectoryState& fts, vector<const DetLayer*>& output) const {
 
-  const vector<BarrelDetLayer*>& barrel = theGeometricSearchTracker->tibLayers();
-
-  for (vector<BarrelDetLayer*>::const_iterator iter_B = barrel.begin(); iter_B != barrel.end(); iter_B++) {
-    if ( checkCompatible(fts,(*iter_B)) ) output.push_back((*iter_B));
+  for(const auto i : theGeometricSearchTracker->tibLayers() ) {
+    if ( checkCompatible(fts,i) ) output.push_back(i);
   }
 
 }
@@ -113,10 +109,8 @@ void DirectTrackerNavigation::inOutTIB(const FreeTrajectoryState& fts, vector<co
 //
 void DirectTrackerNavigation::inOutTOB(const FreeTrajectoryState& fts, vector<const DetLayer*>& output) const {
 
-  const vector<BarrelDetLayer*>& barrel = theGeometricSearchTracker->tobLayers();
-
-  for (vector<BarrelDetLayer*>::const_iterator iter_B = barrel.begin(); iter_B != barrel.end(); iter_B++) {
-    if ( checkCompatible(fts,(*iter_B)) ) output.push_back((*iter_B));
+  for( const auto i : theGeometricSearchTracker->tobLayers()) {
+    if ( checkCompatible(fts,i) ) output.push_back(i);
   }
 
 }
@@ -127,10 +121,8 @@ void DirectTrackerNavigation::inOutTOB(const FreeTrajectoryState& fts, vector<co
 //
 void DirectTrackerNavigation::inOutFPx(const FreeTrajectoryState& fts, vector<const DetLayer*>& output) const {
 
-  const vector<ForwardDetLayer*>& forward = theGeometricSearchTracker->posPixelForwardLayers();
-
-  for (vector<ForwardDetLayer*>::const_iterator iter_E = forward.begin(); iter_E != forward.end(); iter_E++) {
-    if ( checkCompatible(fts,(*iter_E)) ) output.push_back((*iter_E));
+  for(const auto i : theGeometricSearchTracker->posPixelForwardLayers()) {
+    if ( checkCompatible(fts,i) ) output.push_back(i);
   }
 
 }
@@ -141,10 +133,8 @@ void DirectTrackerNavigation::inOutFPx(const FreeTrajectoryState& fts, vector<co
 //
 void DirectTrackerNavigation::inOutFTID(const FreeTrajectoryState& fts, vector<const DetLayer*>& output) const {
 
-  const vector<ForwardDetLayer*>& forward = theGeometricSearchTracker->posTidLayers();
-
-  for (vector<ForwardDetLayer*>::const_iterator iter_E = forward.begin(); iter_E != forward.end(); iter_E++) {
-    if ( checkCompatible(fts,(*iter_E)) ) output.push_back((*iter_E));
+  for(const auto i: theGeometricSearchTracker->posTidLayers()) {
+    if ( checkCompatible(fts,i) ) output.push_back(i);
   }
 
 }
@@ -155,10 +145,8 @@ void DirectTrackerNavigation::inOutFTID(const FreeTrajectoryState& fts, vector<c
 //
 void DirectTrackerNavigation::inOutFTEC(const FreeTrajectoryState& fts, vector<const DetLayer*>& output) const {
 
-  const vector<ForwardDetLayer*>& forward = theGeometricSearchTracker->posTecLayers();
-
-  for (vector<ForwardDetLayer*>::const_iterator iter_E = forward.begin(); iter_E != forward.end(); iter_E++) {
-    if ( checkCompatible(fts,(*iter_E)) ) output.push_back((*iter_E));
+  for(const auto i : theGeometricSearchTracker->posTecLayers()) {
+    if ( checkCompatible(fts,i) ) output.push_back(i);
   }
 
 }
@@ -169,10 +157,8 @@ void DirectTrackerNavigation::inOutFTEC(const FreeTrajectoryState& fts, vector<c
 //
 void DirectTrackerNavigation::inOutBPx(const FreeTrajectoryState& fts, vector<const DetLayer*>& output) const {
 
-  const vector<ForwardDetLayer*>& forward = theGeometricSearchTracker->negPixelForwardLayers();
-
-  for (vector<ForwardDetLayer*>::const_iterator iter_E = forward.begin(); iter_E != forward.end(); iter_E++) {
-    if ( checkCompatible(fts,(*iter_E)) ) output.push_back((*iter_E));
+  for(const auto i: theGeometricSearchTracker->negPixelForwardLayers()) {
+    if ( checkCompatible(fts,i) ) output.push_back(i);
   }
 
 }
@@ -183,10 +169,8 @@ void DirectTrackerNavigation::inOutBPx(const FreeTrajectoryState& fts, vector<co
 //
 void DirectTrackerNavigation::inOutBTID(const FreeTrajectoryState& fts, vector<const DetLayer*>& output) const {
 
-  const vector<ForwardDetLayer*>& forward = theGeometricSearchTracker->negTidLayers();
-
-  for (vector<ForwardDetLayer*>::const_iterator iter_E = forward.begin(); iter_E != forward.end(); iter_E++) {
-      if ( checkCompatible(fts,(*iter_E)) ) output.push_back((*iter_E));
+  for(const auto i: theGeometricSearchTracker->negTidLayers()) {
+      if ( checkCompatible(fts,i) ) output.push_back(i);
   }
 
 }
@@ -197,10 +181,8 @@ void DirectTrackerNavigation::inOutBTID(const FreeTrajectoryState& fts, vector<c
 //
 void DirectTrackerNavigation::inOutBTEC(const FreeTrajectoryState& fts, vector<const DetLayer*>& output) const {
 
-  const vector<ForwardDetLayer*>& forward = theGeometricSearchTracker->negTecLayers();
-
-  for (vector<ForwardDetLayer*>::const_iterator iter_E = forward.begin(); iter_E != forward.end(); iter_E++) {
-    if ( checkCompatible(fts,(*iter_E)) ) output.push_back((*iter_E));
+  for(const auto i: theGeometricSearchTracker->negTecLayers()) {
+    if ( checkCompatible(fts,i) ) output.push_back(i);
   }
 
 }

--- a/RecoMuon/MuonIdentification/src/MuonShowerInformationFiller.cc
+++ b/RecoMuon/MuonIdentification/src/MuonShowerInformationFiller.cc
@@ -379,9 +379,9 @@ vector<const GeomDet*> MuonShowerInformationFiller::getCompatibleDets(const reco
 
   vector<GlobalPoint> allCrossingPoints;
 
-  const vector<DetLayer*>& dtlayers = theService->detLayerGeometry()->allDTLayers();
+  const vector<const DetLayer*>& dtlayers = theService->detLayerGeometry()->allDTLayers();
 
-  for (vector<DetLayer*>::const_iterator iLayer = dtlayers.begin(); iLayer != dtlayers.end(); ++iLayer) {
+  for (auto iLayer = dtlayers.begin(); iLayer != dtlayers.end(); ++iLayer) {
 
     // crossing points of track with cylinder
     GlobalPoint xPoint = crossingPoint(innerPos, outerPos, dynamic_cast<const BarrelDetLayer*>(*iLayer));
@@ -408,8 +408,8 @@ vector<const GeomDet*> MuonShowerInformationFiller::getCompatibleDets(const reco
   }
   allCrossingPoints.clear();
 
-  const vector<DetLayer*>& csclayers = theService->detLayerGeometry()->allCSCLayers();
-  for (vector<DetLayer*>::const_iterator iLayer = csclayers.begin(); iLayer != csclayers.end(); ++iLayer) {
+  const vector<const DetLayer*>& csclayers = theService->detLayerGeometry()->allCSCLayers();
+  for (auto iLayer = csclayers.begin(); iLayer != csclayers.end(); ++iLayer) {
 
     GlobalPoint xPoint = crossingPoint(innerPos, outerPos, dynamic_cast<const ForwardDetLayer*>(*iLayer));
 

--- a/RecoMuon/MuonSeedGenerator/plugins/CosmicMuonSeedGenerator.cc
+++ b/RecoMuon/MuonSeedGenerator/plugins/CosmicMuonSeedGenerator.cc
@@ -105,11 +105,11 @@ void CosmicMuonSeedGenerator::produce(edm::Event& event, const edm::EventSetup& 
   eSetup.get<MuonRecoGeometryRecord>().get(theMuonLayers);
 
   // get the DT layers
-  vector<DetLayer*> dtLayers = theMuonLayers->allDTLayers();
+  vector<const DetLayer*> dtLayers = theMuonLayers->allDTLayers();
 
   // get the CSC layers
-  vector<DetLayer*> cscForwardLayers = theMuonLayers->forwardCSCLayers();
-  vector<DetLayer*> cscBackwardLayers = theMuonLayers->backwardCSCLayers();
+  vector<const DetLayer*> cscForwardLayers = theMuonLayers->forwardCSCLayers();
+  vector<const DetLayer*> cscBackwardLayers = theMuonLayers->backwardCSCLayers();
 
 
 
@@ -123,7 +123,7 @@ void CosmicMuonSeedGenerator::produce(edm::Event& event, const edm::EventSetup& 
 
   stable_sort(allHits.begin(),allHits.end(),DecreasingGlobalY());
 
-  for (vector<DetLayer*>::reverse_iterator icsclayer = cscForwardLayers.rbegin();
+  for (vector<const DetLayer*>::reverse_iterator icsclayer = cscForwardLayers.rbegin();
        icsclayer != cscForwardLayers.rend() - 1; ++icsclayer) {
        
        MuonRecHitContainer RHMF = muonMeasurements->recHits(*icsclayer);
@@ -131,7 +131,7 @@ void CosmicMuonSeedGenerator::produce(edm::Event& event, const edm::EventSetup& 
 
   }
 
-  for (vector<DetLayer*>::reverse_iterator icsclayer = cscBackwardLayers.rbegin();
+  for (vector<const DetLayer*>::reverse_iterator icsclayer = cscBackwardLayers.rbegin();
        icsclayer != cscBackwardLayers.rend() - 1; ++icsclayer) {
 
        MuonRecHitContainer RHMF = muonMeasurements->recHits(*icsclayer);
@@ -139,7 +139,7 @@ void CosmicMuonSeedGenerator::produce(edm::Event& event, const edm::EventSetup& 
 
   }
 
-  for (vector<DetLayer*>::reverse_iterator idtlayer = dtLayers.rbegin();
+  for (vector<const DetLayer*>::reverse_iterator idtlayer = dtLayers.rbegin();
        idtlayer != dtLayers.rend(); ++idtlayer) {
 
        MuonRecHitContainer RHMB = muonMeasurements->recHits(*idtlayer);

--- a/RecoMuon/MuonSeedGenerator/src/MuonSeedBuilder.cc
+++ b/RecoMuon/MuonSeedGenerator/src/MuonSeedBuilder.cc
@@ -139,7 +139,7 @@ int MuonSeedBuilder::build( edm::Event& event, const edm::EventSetup& eventSetup
   // 1) Get the various stations and store segments in containers for each station (layers)
  
   // 1a. get the DT segments by stations (layers):
-  std::vector<DetLayer*> dtLayers = muonLayers->allDTLayers();
+  std::vector<const DetLayer*> dtLayers = muonLayers->allDTLayers();
  
   SegmentContainer DTlist4 = muonMeasurements->recHits( dtLayers[3], event );
   SegmentContainer DTlist3 = muonMeasurements->recHits( dtLayers[2], event );
@@ -162,7 +162,7 @@ int MuonSeedBuilder::build( edm::Event& event, const edm::EventSetup& eventSetup
 
   // 1b. get the CSC segments by stations (layers):
   // 1b.1 Global z < 0
-  std::vector<DetLayer*> cscBackwardLayers = muonLayers->backwardCSCLayers();    
+  std::vector<const DetLayer*> cscBackwardLayers = muonLayers->backwardCSCLayers();    
   SegmentContainer CSClist4B = muonMeasurements->recHits( cscBackwardLayers[4], event );
   SegmentContainer CSClist3B = muonMeasurements->recHits( cscBackwardLayers[3], event );
   SegmentContainer CSClist2B = muonMeasurements->recHits( cscBackwardLayers[2], event );
@@ -176,7 +176,7 @@ int MuonSeedBuilder::build( edm::Event& event, const edm::EventSetup& eventSetup
   BoolContainer usedCSClist0B(CSClist0B.size(), false);
 
   // 1b.2 Global z > 0
-  std::vector<DetLayer*> cscForwardLayers = muonLayers->forwardCSCLayers();
+  std::vector<const DetLayer*> cscForwardLayers = muonLayers->forwardCSCLayers();
   SegmentContainer CSClist4F = muonMeasurements->recHits( cscForwardLayers[4], event );
   SegmentContainer CSClist3F = muonMeasurements->recHits( cscForwardLayers[3], event );
   SegmentContainer CSClist2F = muonMeasurements->recHits( cscForwardLayers[2], event );

--- a/RecoMuon/MuonSeedGenerator/src/MuonSeedOrcaPatternRecognition.cc
+++ b/RecoMuon/MuonSeedGenerator/src/MuonSeedOrcaPatternRecognition.cc
@@ -67,11 +67,11 @@ void MuonSeedOrcaPatternRecognition::produce(const edm::Event& event, const edm:
   eSetup.get<MuonRecoGeometryRecord>().get(muonLayers);
 
   // get the DT layers
-  vector<DetLayer*> dtLayers = muonLayers->allDTLayers();
+  vector<const DetLayer*> dtLayers = muonLayers->allDTLayers();
 
   // get the CSC layers
-  vector<DetLayer*> cscForwardLayers = muonLayers->forwardCSCLayers();
-  vector<DetLayer*> cscBackwardLayers = muonLayers->backwardCSCLayers();
+  vector<const DetLayer*> cscForwardLayers = muonLayers->forwardCSCLayers();
+  vector<const DetLayer*> cscBackwardLayers = muonLayers->backwardCSCLayers();
     
   // Backward (z<0) EndCap disk
   const DetLayer* ME4Bwd = cscBackwardLayers[4];

--- a/RecoMuon/MuonSeedGenerator/src/RPCSeedGenerator.cc
+++ b/RecoMuon/MuonSeedGenerator/src/RPCSeedGenerator.cc
@@ -185,14 +185,14 @@ RPCSeedGenerator::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     iSetup.get<MuonRecoGeometryRecord>().get(muonLayers);
 
     // Get the RPC layers
-    vector<DetLayer*> RPCBarrelLayers = muonLayers->barrelRPCLayers();
+    vector<const DetLayer*> RPCBarrelLayers = muonLayers->barrelRPCLayers();
     const DetLayer* RB4L  = RPCBarrelLayers[5];
     const DetLayer* RB3L  = RPCBarrelLayers[4];
     const DetLayer* RB22L = RPCBarrelLayers[3];
     const DetLayer* RB21L = RPCBarrelLayers[2];
     const DetLayer* RB12L = RPCBarrelLayers[1];
     const DetLayer* RB11L = RPCBarrelLayers[0];
-    vector<DetLayer*> RPCEndcapLayers = muonLayers->endcapRPCLayers();
+    vector<const DetLayer*> RPCEndcapLayers = muonLayers->endcapRPCLayers();
     const DetLayer* REM3L = RPCEndcapLayers[0];
     const DetLayer* REM2L = RPCEndcapLayers[1];
     const DetLayer* REM1L = RPCEndcapLayers[2];

--- a/RecoMuon/Navigation/interface/MuonBarrelNavigableLayer.h
+++ b/RecoMuon/Navigation/interface/MuonBarrelNavigableLayer.h
@@ -89,7 +89,7 @@ class MuonBarrelNavigableLayer : public MuonNavigableLayer {
       theOuterBackwardLayers(outerBackward),
       theOuterForwardLayers(outerForward) { }
 
-    MuonBarrelNavigableLayer(BarrelDetLayer* bdl,
+    MuonBarrelNavigableLayer(const BarrelDetLayer* bdl,
                              const MapB& outerBarrel,
                              const MapE& outerBackward,
                              const MapE& outerForward,
@@ -105,23 +105,23 @@ class MuonBarrelNavigableLayer : public MuonNavigableLayer {
       theAllOuterForwardLayers(allOuterForward) {}
 
     /// NavigableLayer interface
-    virtual std::vector<const DetLayer*> nextLayers(NavigationDirection dir) const;
+    virtual std::vector<const DetLayer*> nextLayers(NavigationDirection dir) const override;
 
     /// NavigableLayer interface
     virtual std::vector<const DetLayer*> nextLayers(const FreeTrajectoryState& fts, 
-                                               PropagationDirection dir) const;
+                                               PropagationDirection dir) const override;
 
-    virtual std::vector<const DetLayer*> compatibleLayers(NavigationDirection dir) const;
+    virtual std::vector<const DetLayer*> compatibleLayers(NavigationDirection dir) const override;
 
     /// NavigableLayer interface
     virtual std::vector<const DetLayer*> compatibleLayers(const FreeTrajectoryState& fts,
-                                               PropagationDirection dir) const;
+                                               PropagationDirection dir) const override;
 
     /// return DetLayer
-    virtual DetLayer* detLayer() const;
+    virtual const DetLayer* detLayer() const override;
 
     /// set DetLayer
-    virtual void setDetLayer(DetLayer*);
+    virtual void setDetLayer(const DetLayer*) override;
 
     MapB getOuterBarrelLayers() const { return theOuterBarrelLayers; }
     MapB getInnerBarrelLayers() const { return theInnerBarrelLayers; }
@@ -166,7 +166,7 @@ class MuonBarrelNavigableLayer : public MuonNavigableLayer {
 
   private:
 
-    BarrelDetLayer* theDetLayer;
+    const BarrelDetLayer* theDetLayer;
     MapB theOuterBarrelLayers;
     MapB theInnerBarrelLayers;
     MapE theOuterBackwardLayers;

--- a/RecoMuon/Navigation/interface/MuonDetLayerMap.h
+++ b/RecoMuon/Navigation/interface/MuonDetLayerMap.h
@@ -19,12 +19,12 @@
  */
 
 struct MuonDetLayerComp {
-    bool operator()(BarrelDetLayer* l1, BarrelDetLayer* l2) const {
+    bool operator()(const BarrelDetLayer* l1, const BarrelDetLayer* l2) const {
       if ( l1->specificSurface().radius() < l2->specificSurface().radius() ) return true;
       return false;
     }
 
-    bool operator()(ForwardDetLayer* l1, ForwardDetLayer* l2) const {
+    bool operator()(const ForwardDetLayer* l1, const ForwardDetLayer* l2) const {
       if ( fabs(l1->surface().position().z()) < fabs(l2->surface().position().z()) ) return true;
       return false;
     }
@@ -32,8 +32,8 @@ struct MuonDetLayerComp {
 
 
 // FIXME: these names are too generic...
-typedef std::map<BarrelDetLayer*, MuonEtaRange, MuonDetLayerComp> MapB;
-typedef std::map<ForwardDetLayer*, MuonEtaRange, MuonDetLayerComp> MapE;
+typedef std::map<const BarrelDetLayer*, MuonEtaRange, MuonDetLayerComp> MapB;
+typedef std::map<const ForwardDetLayer*, MuonEtaRange, MuonDetLayerComp> MapE;
 typedef MapB::const_iterator MapBI;
 typedef MapE::const_iterator MapEI;
 

--- a/RecoMuon/Navigation/interface/MuonForwardNavigableLayer.h
+++ b/RecoMuon/Navigation/interface/MuonForwardNavigableLayer.h
@@ -34,7 +34,7 @@ class MuonForwardNavigableLayer : public MuonNavigableLayer {
 
   public:
 
-    MuonForwardNavigableLayer(ForwardDetLayer* fdl,
+    MuonForwardNavigableLayer(const ForwardDetLayer* fdl,
                               const MapB& innerBarrel, 
                               const MapE& outerEndcap,
                               const MapE& innerEndcap,
@@ -50,12 +50,12 @@ class MuonForwardNavigableLayer : public MuonNavigableLayer {
       theAllInnerEndcapLayers(allInnerEndcap)  {}
 
     /// Constructor with outer layers only
-    MuonForwardNavigableLayer(ForwardDetLayer* fdl,
+    MuonForwardNavigableLayer(const ForwardDetLayer* fdl,
                               const MapE& outerEndcap) :
       theDetLayer(fdl),
       theOuterEndcapLayers(outerEndcap) {}
     /// Constructor with all outer layers only
-    MuonForwardNavigableLayer(ForwardDetLayer* fdl,
+    MuonForwardNavigableLayer(const ForwardDetLayer* fdl,
                               const MapE& outerEndcap, 
                               const MapE& allOuterEndcap) :
       theDetLayer(fdl),
@@ -64,22 +64,22 @@ class MuonForwardNavigableLayer : public MuonNavigableLayer {
 
 
     /// NavigableLayer interface
-    virtual std::vector<const DetLayer*> nextLayers(NavigationDirection dir) const;
+    virtual std::vector<const DetLayer*> nextLayers(NavigationDirection dir) const override;
 
     /// NavigableLayer interface
     virtual std::vector<const DetLayer*> nextLayers(const FreeTrajectoryState& fts, 
-                                               PropagationDirection dir) const;
+                                               PropagationDirection dir) const override;
 
-    virtual std::vector<const DetLayer*> compatibleLayers(NavigationDirection dir) const;
+    virtual std::vector<const DetLayer*> compatibleLayers(NavigationDirection dir) const override;
 
     /// NavigableLayer interface
     virtual std::vector<const DetLayer*> compatibleLayers(const FreeTrajectoryState& fts,
-                                               PropagationDirection dir) const;
+                                               PropagationDirection dir) const override;
     /// return DetLayer
-    virtual DetLayer* detLayer() const;
+    virtual const DetLayer* detLayer() const override;
 
     /// set DetLayer
-    virtual void setDetLayer(DetLayer*);
+    virtual void setDetLayer(const DetLayer*) override;
 
     /// Operations
     MapE getOuterEndcapLayers() const { return theOuterEndcapLayers; }
@@ -121,7 +121,7 @@ class MuonForwardNavigableLayer : public MuonNavigableLayer {
 
   private:
 
-    ForwardDetLayer* theDetLayer;
+    const ForwardDetLayer* theDetLayer;
     MapB theInnerBarrelLayers;
     MapE theOuterEndcapLayers;
     MapE theInnerEndcapLayers;

--- a/RecoMuon/Navigation/interface/MuonNavigableLayer.h
+++ b/RecoMuon/Navigation/interface/MuonNavigableLayer.h
@@ -41,10 +41,10 @@ class MuonNavigableLayer : public NavigableLayer {
                                                PropagationDirection dir) const=0;
 
     /// return DetLayer
-    virtual DetLayer* detLayer() const=0;
+    virtual const DetLayer* detLayer() const=0;
 
     /// set DetLayer
-    virtual void setDetLayer(DetLayer*)=0;
+    virtual void setDetLayer(const DetLayer*)=0;
 
     MuonEtaRange trackingRange(const FreeTrajectoryState& fts) const;
 

--- a/RecoMuon/Navigation/interface/MuonNavigationPrinter.h
+++ b/RecoMuon/Navigation/interface/MuonNavigationPrinter.h
@@ -30,7 +30,7 @@ class MuonNavigationPrinter {
   MuonNavigationPrinter(const MuonDetLayerGeometry *,MuonNavigationSchool const &, const GeometricSearchTracker *);
 
   private:
-    void printLayer(DetLayer*) const;
+    void printLayer(const DetLayer*) const;
     void printLayers(const std::vector<const DetLayer*>&) const;
     /// return detector part (barrel, forward, backward)
 //    std::string layerPart(const DetLayer*) const;

--- a/RecoMuon/Navigation/interface/MuonNavigationSchool.h
+++ b/RecoMuon/Navigation/interface/MuonNavigationSchool.h
@@ -42,9 +42,9 @@ class MuonNavigationSchool : public NavigationSchool {
     virtual StateType navigableLayers() override;
   private:
     /// add barrel layer
-    void addBarrelLayer(BarrelDetLayer*);
+    void addBarrelLayer(const BarrelDetLayer*);
     /// add endcap layer (backward and forward)
-    void addEndcapLayer(ForwardDetLayer*);
+    void addEndcapLayer(const ForwardDetLayer*);
     /// link barrel layers
     void linkBarrelLayers();
     /// link endcap layers

--- a/RecoMuon/Navigation/src/DirectMuonNavigation.cc
+++ b/RecoMuon/Navigation/src/DirectMuonNavigation.cc
@@ -100,9 +100,9 @@ DirectMuonNavigation::compatibleEndcapLayers( const FreeTrajectoryState& fts,
 void DirectMuonNavigation::inOutBarrel(const FreeTrajectoryState& fts, vector<const DetLayer*>& output) const {
 
   bool cont = false;
-  const vector<DetLayer*>& barrel = theMuonDetLayerGeometry->allBarrelLayers();
+  const vector<const DetLayer*>& barrel = theMuonDetLayerGeometry->allBarrelLayers();
 
-  for (vector<DetLayer*>::const_iterator iter_B = barrel.begin(); iter_B != barrel.end(); iter_B++){
+  for (vector<const DetLayer*>::const_iterator iter_B = barrel.begin(); iter_B != barrel.end(); iter_B++){
 
       if( cont ) output.push_back((*iter_B));
       else if ( checkCompatible(fts,dynamic_cast<const BarrelDetLayer*>(*iter_B))) {
@@ -116,17 +116,17 @@ void DirectMuonNavigation::inOutBarrel(const FreeTrajectoryState& fts, vector<co
 void DirectMuonNavigation::outInBarrel(const FreeTrajectoryState& fts, vector<const DetLayer*>& output) const {
 
 // default barrel layers are in out, reverse order 
-  const vector<DetLayer*>& barrel = theMuonDetLayerGeometry->allBarrelLayers();
+  const vector<const DetLayer*>& barrel = theMuonDetLayerGeometry->allBarrelLayers();
 
   bool cont = false;
-  vector<DetLayer*>::const_iterator rbegin = barrel.end(); 
+  vector<const DetLayer*>::const_iterator rbegin = barrel.end(); 
   rbegin--;
-  vector<DetLayer*>::const_iterator rend = barrel.begin();
+  vector<const DetLayer*>::const_iterator rend = barrel.begin();
   rend--;
 
-  for (vector<DetLayer*>::const_iterator iter_B = rbegin; iter_B != rend; iter_B--){
+  for (vector<const DetLayer*>::const_iterator iter_B = rbegin; iter_B != rend; iter_B--){
       if( cont ) output.push_back((*iter_B));
-      else if ( checkCompatible(fts,dynamic_cast<BarrelDetLayer*>(*iter_B))) {
+      else if ( checkCompatible(fts,dynamic_cast<const BarrelDetLayer*>(*iter_B))) {
       output.push_back((*iter_B));
       cont = true;
       }
@@ -135,12 +135,12 @@ void DirectMuonNavigation::outInBarrel(const FreeTrajectoryState& fts, vector<co
 
 void DirectMuonNavigation::inOutForward(const FreeTrajectoryState& fts, vector<const DetLayer*>& output) const {
 
-  const vector<DetLayer*>& forward = theMuonDetLayerGeometry->allForwardLayers();
+  const vector<const DetLayer*>& forward = theMuonDetLayerGeometry->allForwardLayers();
   bool cont = false;
-  for (vector<DetLayer*>::const_iterator iter_E = forward.begin(); iter_E != forward.end(); 
+  for (vector<const DetLayer*>::const_iterator iter_E = forward.begin(); iter_E != forward.end(); 
 	 iter_E++){
       if( cont ) output.push_back((*iter_E));
-      else if ( checkCompatible(fts,dynamic_cast<ForwardDetLayer*>(*iter_E))) {
+      else if ( checkCompatible(fts,dynamic_cast<const ForwardDetLayer*>(*iter_E))) {
 	output.push_back((*iter_E));
 	cont = true;
       }
@@ -151,15 +151,15 @@ void DirectMuonNavigation::outInForward(const FreeTrajectoryState& fts, vector<c
 // default forward layers are in out, reverse order
 
   bool cont = false;
-  const vector<DetLayer*>& forward = theMuonDetLayerGeometry->allForwardLayers();
-  vector<DetLayer*>::const_iterator rbegin = forward.end();
+  const vector<const DetLayer*>& forward = theMuonDetLayerGeometry->allForwardLayers();
+  vector<const DetLayer*>::const_iterator rbegin = forward.end();
   rbegin--;
-  vector<DetLayer*>::const_iterator rend = forward.begin();
+  vector<const DetLayer*>::const_iterator rend = forward.begin();
   rend--;
-  for (vector<DetLayer*>::const_iterator iter_E = rbegin; iter_E != rend;
+  for (vector<const DetLayer*>::const_iterator iter_E = rbegin; iter_E != rend;
          iter_E--){
       if( cont ) output.push_back((*iter_E));
-      else if ( checkCompatible(fts,dynamic_cast<ForwardDetLayer*>(*iter_E))) {
+      else if ( checkCompatible(fts,dynamic_cast<const ForwardDetLayer*>(*iter_E))) {
         output.push_back((*iter_E));
         cont = true;
       }
@@ -168,12 +168,12 @@ void DirectMuonNavigation::outInForward(const FreeTrajectoryState& fts, vector<c
 
 void DirectMuonNavigation::inOutBackward(const FreeTrajectoryState& fts, vector<const DetLayer*>& output) const {
   bool cont = false;
-  const vector<DetLayer*>& backward = theMuonDetLayerGeometry->allBackwardLayers();
+  const vector<const DetLayer*>& backward = theMuonDetLayerGeometry->allBackwardLayers();
 
-  for (vector<DetLayer*>::const_iterator iter_E = backward.begin(); iter_E != backward.end(); 
+  for (vector<const DetLayer*>::const_iterator iter_E = backward.begin(); iter_E != backward.end(); 
        iter_E++){
       if( cont ) output.push_back((*iter_E));
-      else if ( checkCompatible(fts,dynamic_cast<ForwardDetLayer*>(*iter_E))) {
+      else if ( checkCompatible(fts,dynamic_cast<const ForwardDetLayer*>(*iter_E))) {
 	output.push_back((*iter_E));
 	cont = true;
       }
@@ -183,16 +183,16 @@ void DirectMuonNavigation::inOutBackward(const FreeTrajectoryState& fts, vector<
 void DirectMuonNavigation::outInBackward(const FreeTrajectoryState& fts, vector<const DetLayer*>& output) const {
 
   bool cont = false;
-  const vector<DetLayer*>& backward = theMuonDetLayerGeometry->allBackwardLayers();
+  const vector<const DetLayer*>& backward = theMuonDetLayerGeometry->allBackwardLayers();
 
-  vector<DetLayer*>::const_iterator rbegin = backward.end();
+  vector<const DetLayer*>::const_iterator rbegin = backward.end();
   rbegin--;
-  vector<DetLayer*>::const_iterator rend = backward.begin();
+  vector<const DetLayer*>::const_iterator rend = backward.begin();
   rend--;
-  for (vector<DetLayer*>::const_iterator iter_E = rbegin; iter_E != rend;
+  for (vector<const DetLayer*>::const_iterator iter_E = rbegin; iter_E != rend;
        iter_E--){
       if( cont ) output.push_back((*iter_E));
-      else if ( checkCompatible(fts,dynamic_cast<ForwardDetLayer*>(*iter_E))) {
+      else if ( checkCompatible(fts,dynamic_cast<const ForwardDetLayer*>(*iter_E))) {
         output.push_back((*iter_E));
         cont = true;
       }

--- a/RecoMuon/Navigation/src/MuonBarrelNavigableLayer.cc
+++ b/RecoMuon/Navigation/src/MuonBarrelNavigableLayer.cc
@@ -160,12 +160,12 @@ void MuonBarrelNavigableLayer::pushCompatibleResult(std::vector<const DetLayer*>
 
 }
 
-DetLayer* MuonBarrelNavigableLayer::detLayer() const {
+const DetLayer* MuonBarrelNavigableLayer::detLayer() const {
   return theDetLayer;
 }
 
 
-void MuonBarrelNavigableLayer::setDetLayer(DetLayer* dl) {
+void MuonBarrelNavigableLayer::setDetLayer(const DetLayer* dl) {
   edm::LogError("MuonBarrelNavigableLayer") << "MuonBarrelNavigableLayer::setDetLayer called!! " << endl;
 }
 

--- a/RecoMuon/Navigation/src/MuonForwardNavigableLayer.cc
+++ b/RecoMuon/Navigation/src/MuonForwardNavigableLayer.cc
@@ -164,14 +164,14 @@ void MuonForwardNavigableLayer::pushCompatibleResult(vector<const DetLayer*>& re
 }
 
 
-DetLayer* MuonForwardNavigableLayer::detLayer() const {
+const DetLayer* MuonForwardNavigableLayer::detLayer() const {
 
   return theDetLayer;
 
 }
 
 
-void MuonForwardNavigableLayer::setDetLayer(DetLayer* dl) {
+void MuonForwardNavigableLayer::setDetLayer(const DetLayer* dl) {
 
   edm::LogError ("MuonForwardNavigablaLayer") << "MuonForwardNavigableLayer::setDetLayer called!! " << endl;
 

--- a/RecoMuon/Navigation/src/MuonNavigationPrinter.cc
+++ b/RecoMuon/Navigation/src/MuonNavigationPrinter.cc
@@ -40,7 +40,6 @@ MuonNavigationPrinter::MuonNavigationPrinter(const MuonDetLayerGeometry * muonLa
   school(&sh) {
 
   PRINT("MuonNavigationPrinter")<< "MuonNavigationPrinter::MuonNavigationPrinter" << std::endl;
-  vector<DetLayer*>::const_iterator iter;
   PRINT("MuonNavigationPrinter")<<"================================" << std::endl;
   PRINT("MuonNavigationPrinter")<< "BARREL:" << std::endl;
   vector<DetLayer*> barrel;
@@ -48,7 +47,7 @@ MuonNavigationPrinter::MuonNavigationPrinter(const MuonDetLayerGeometry * muonLa
   else barrel = muonLayout->allDTLayers();
 
   PRINT("MuonNavigationPrinter")<<"There are "<<barrel.size()<<" Barrel DetLayers";
-  for ( iter = barrel.begin(); iter != barrel.end(); iter++ ) printLayer(*iter);
+  for (auto i: barrel ) printLayer(i);
   PRINT("MuonNavigationPrinter")<<"================================" << std::endl;
   PRINT("MuonNavigationPrinter")  << "BACKWARD:" << std::endl;
 
@@ -57,7 +56,7 @@ MuonNavigationPrinter::MuonNavigationPrinter(const MuonDetLayerGeometry * muonLa
   else backward = muonLayout->backwardCSCLayers();
 
   PRINT("MuonNavigationPrinter")<<"There are "<<backward.size()<<" Backward DetLayers";
-  for ( iter = backward.begin(); iter != backward.end(); iter++ ) printLayer(*iter);
+  for (auto i : backward ) printLayer(i);
   PRINT("MuonNavigationPrinter") << "==============================" << std::endl;
   PRINT("MuonNavigationPrinter") << "FORWARD:" << std::endl;
   vector<DetLayer*> forward;
@@ -65,7 +64,7 @@ MuonNavigationPrinter::MuonNavigationPrinter(const MuonDetLayerGeometry * muonLa
   else forward = muonLayout->forwardCSCLayers();
 
   PRINT("MuonNavigationPrinter")<<"There are "<<forward.size()<<" Forward DetLayers" << std::endl;
-  for ( iter = forward.begin(); iter != forward.end(); iter++ ) printLayer(*iter);
+  for (auto i : forward ) printLayer(i);
 
 }
 
@@ -73,42 +72,41 @@ MuonNavigationPrinter::MuonNavigationPrinter(const MuonDetLayerGeometry * muonLa
   school(&sh){
 
   PRINT("MuonNavigationPrinter")<< "MuonNavigationPrinter::MuonNavigationPrinter" << std::endl ;
-  vector<DetLayer*>::const_iterator iter;
 //  vector<BarrelDetLayer*>::const_iterator tkiter;
 //  vector<ForwardDetLayer*>::const_iterator tkfiter;
   PRINT("MuonNavigationPrinter")<<"================================" << std::endl;
   PRINT("MuonNavigationPrinter")<< "BARREL:" << std::endl;
-  vector<BarrelDetLayer*> tkbarrel = tracker->barrelLayers();
+  vector<const BarrelDetLayer*> tkbarrel = tracker->barrelLayers();
   PRINT("MuonNavigationPrinter")<<"There are "<<tkbarrel.size()<<" Tk Barrel DetLayers" << std::endl;
 //  for ( tkiter = tkbarrel.begin(); tkiter != tkbarrel.end(); tkiter++ ) printLayer(*tkiter);
   vector<DetLayer*> barrel = muonLayout->allBarrelLayers();
   PRINT("MuonNavigationPrinter")<<"There are "<<barrel.size()<<" Mu Barrel DetLayers";
-  for ( iter = barrel.begin(); iter != barrel.end(); iter++ ) printLayer(*iter);
+  for ( auto i : barrel ) printLayer(i);
   PRINT("MuonNavigationPrinter")<<"================================" << std::endl;
   PRINT("MuonNavigationPrinter")  << "BACKWARD:" << std::endl;
-  vector<ForwardDetLayer*> tkbackward = tracker->negForwardLayers();
+  vector<const ForwardDetLayer*> tkbackward = tracker->negForwardLayers();
   PRINT("MuonNavigationPrinter")<<"There are "<<tkbackward.size()<<" Tk Backward DetLayers" << std::endl;
 ///  for ( tkfiter = tkbackward.begin(); tkfiter != tkbackward.end(); tkfiter++ ) printLayer(*tkfiter);
   vector<DetLayer*> backward = muonLayout->allBackwardLayers();
   PRINT("MuonNavigationPrinter")<<"There are "<<backward.size()<<" Mu Backward DetLayers << std::endl";
-  for ( iter = backward.begin(); iter != backward.end(); iter++ ) printLayer(*iter);
+  for (auto i : backward ) printLayer(i);
   PRINT("MuonNavigationPrinter") << "==============================" << std::endl;
   PRINT("MuonNavigationPrinter") << "FORWARD:" << std::endl;
-  vector<ForwardDetLayer*> tkforward =  tracker->posForwardLayers();
+  vector<const ForwardDetLayer*> tkforward =  tracker->posForwardLayers();
   PRINT("MuonNavigationPrinter")<<"There are "<<tkforward.size()<<" Tk Forward DetLayers" << std::endl;
 //  for ( tkfiter = tkforward.begin(); tkfiter != tkforward.end(); tkfiter++ ) printLayer(*tkfiter);
 
   vector<DetLayer*> forward = muonLayout->allForwardLayers();
   PRINT("MuonNavigationPrinter")<<"There are "<<forward.size()<<" Mu Forward DetLayers";
-  for ( iter = forward.begin(); iter != forward.end(); iter++ ) printLayer(*iter);
+  for ( auto i : forward ) printLayer(i);
 
 }
 
 /// print layer
-void MuonNavigationPrinter::printLayer(DetLayer* layer) const {
+void MuonNavigationPrinter::printLayer(const DetLayer* layer) const {
   vector<const DetLayer*> nextLayers = school->nextLayers(*layer,insideOut);
   vector<const DetLayer*> compatibleLayers = school->compatibleLayers(*layer,insideOut);
-  if (BarrelDetLayer* bdl = dynamic_cast<BarrelDetLayer*>(layer)) {
+  if (const BarrelDetLayer* bdl = dynamic_cast<const BarrelDetLayer*>(layer)) {
     PRINT("MuonNavigationPrinter") 
          << layer->location() << " " << layer->subDetector() << " layer at R: "
          << setiosflags(ios::showpoint | ios::fixed)
@@ -118,7 +116,7 @@ void MuonNavigationPrinter::printLayer(DetLayer* layer) const {
          << layer->surface().bounds().length() << std::endl;
           
   }
-  else if (ForwardDetLayer* fdl = dynamic_cast<ForwardDetLayer*>(layer)) {
+  else if (const ForwardDetLayer* fdl = dynamic_cast<const ForwardDetLayer*>(layer)) {
     PRINT("MuonNavigationPrinter") << endl
          << layer->location() << " " << layer->subDetector() << "layer at z: "
          << setiosflags(ios::showpoint | ios::fixed)

--- a/RecoMuon/Navigation/src/MuonNavigationPrinter.cc
+++ b/RecoMuon/Navigation/src/MuonNavigationPrinter.cc
@@ -42,7 +42,7 @@ MuonNavigationPrinter::MuonNavigationPrinter(const MuonDetLayerGeometry * muonLa
   PRINT("MuonNavigationPrinter")<< "MuonNavigationPrinter::MuonNavigationPrinter" << std::endl;
   PRINT("MuonNavigationPrinter")<<"================================" << std::endl;
   PRINT("MuonNavigationPrinter")<< "BARREL:" << std::endl;
-  vector<DetLayer*> barrel;
+  vector<const DetLayer*> barrel;
   if ( enableRPC ) barrel = muonLayout->allBarrelLayers();
   else barrel = muonLayout->allDTLayers();
 
@@ -51,7 +51,7 @@ MuonNavigationPrinter::MuonNavigationPrinter(const MuonDetLayerGeometry * muonLa
   PRINT("MuonNavigationPrinter")<<"================================" << std::endl;
   PRINT("MuonNavigationPrinter")  << "BACKWARD:" << std::endl;
 
-  vector<DetLayer*> backward;
+  vector<const DetLayer*> backward;
   if ( enableRPC ) backward = muonLayout->allBackwardLayers();
   else backward = muonLayout->backwardCSCLayers();
 
@@ -59,7 +59,7 @@ MuonNavigationPrinter::MuonNavigationPrinter(const MuonDetLayerGeometry * muonLa
   for (auto i : backward ) printLayer(i);
   PRINT("MuonNavigationPrinter") << "==============================" << std::endl;
   PRINT("MuonNavigationPrinter") << "FORWARD:" << std::endl;
-  vector<DetLayer*> forward;
+  vector<const DetLayer*> forward;
   if ( enableRPC ) forward = muonLayout->allForwardLayers();
   else forward = muonLayout->forwardCSCLayers();
 
@@ -79,7 +79,7 @@ MuonNavigationPrinter::MuonNavigationPrinter(const MuonDetLayerGeometry * muonLa
   vector<const BarrelDetLayer*> tkbarrel = tracker->barrelLayers();
   PRINT("MuonNavigationPrinter")<<"There are "<<tkbarrel.size()<<" Tk Barrel DetLayers" << std::endl;
 //  for ( tkiter = tkbarrel.begin(); tkiter != tkbarrel.end(); tkiter++ ) printLayer(*tkiter);
-  vector<DetLayer*> barrel = muonLayout->allBarrelLayers();
+  vector<const DetLayer*> barrel = muonLayout->allBarrelLayers();
   PRINT("MuonNavigationPrinter")<<"There are "<<barrel.size()<<" Mu Barrel DetLayers";
   for ( auto i : barrel ) printLayer(i);
   PRINT("MuonNavigationPrinter")<<"================================" << std::endl;
@@ -87,7 +87,7 @@ MuonNavigationPrinter::MuonNavigationPrinter(const MuonDetLayerGeometry * muonLa
   vector<const ForwardDetLayer*> tkbackward = tracker->negForwardLayers();
   PRINT("MuonNavigationPrinter")<<"There are "<<tkbackward.size()<<" Tk Backward DetLayers" << std::endl;
 ///  for ( tkfiter = tkbackward.begin(); tkfiter != tkbackward.end(); tkfiter++ ) printLayer(*tkfiter);
-  vector<DetLayer*> backward = muonLayout->allBackwardLayers();
+  vector<const DetLayer*> backward = muonLayout->allBackwardLayers();
   PRINT("MuonNavigationPrinter")<<"There are "<<backward.size()<<" Mu Backward DetLayers << std::endl";
   for (auto i : backward ) printLayer(i);
   PRINT("MuonNavigationPrinter") << "==============================" << std::endl;
@@ -96,7 +96,7 @@ MuonNavigationPrinter::MuonNavigationPrinter(const MuonDetLayerGeometry * muonLa
   PRINT("MuonNavigationPrinter")<<"There are "<<tkforward.size()<<" Tk Forward DetLayers" << std::endl;
 //  for ( tkfiter = tkforward.begin(); tkfiter != tkforward.end(); tkfiter++ ) printLayer(*tkfiter);
 
-  vector<DetLayer*> forward = muonLayout->allForwardLayers();
+  vector<const DetLayer*> forward = muonLayout->allForwardLayers();
   PRINT("MuonNavigationPrinter")<<"There are "<<forward.size()<<" Mu Forward DetLayers";
   for ( auto i : forward ) printLayer(i);
 

--- a/RecoMuon/Navigation/src/MuonNavigationSchool.cc
+++ b/RecoMuon/Navigation/src/MuonNavigationSchool.cc
@@ -37,13 +37,13 @@ using namespace std;
 /// Constructor
 MuonNavigationSchool::MuonNavigationSchool(const MuonDetLayerGeometry * muonLayout, bool enableRPC ) : theMuonDetLayerGeometry(muonLayout) {
 
-  theAllDetLayersInSystem=reinterpret_cast<const std::vector<const DetLayer*>*>(&muonLayout->allLayers()); 
+  theAllDetLayersInSystem=&muonLayout->allLayers(); 
   theAllNavigableLayer.resize(muonLayout->allLayers().size(),nullptr);
 
 
 
   // get all barrel DetLayers (DT + optional RPC) 
-  vector<DetLayer*> barrel;
+  vector<const DetLayer*> barrel;
   if ( enableRPC ) barrel = muonLayout->allBarrelLayers();
   else barrel = muonLayout->allDTLayers();
 
@@ -54,7 +54,7 @@ MuonNavigationSchool::MuonNavigationSchool(const MuonDetLayerGeometry * muonLayo
   }
 
   // get all endcap DetLayers (CSC + optional RPC)
-  vector<DetLayer*> endcap;
+  vector<const DetLayer*> endcap;
   if ( enableRPC ) endcap = muonLayout->allEndcapLayers();
   else endcap = muonLayout->allCSCLayers();
 

--- a/RecoMuon/Navigation/src/MuonNavigationSchool.cc
+++ b/RecoMuon/Navigation/src/MuonNavigationSchool.cc
@@ -37,7 +37,7 @@ using namespace std;
 /// Constructor
 MuonNavigationSchool::MuonNavigationSchool(const MuonDetLayerGeometry * muonLayout, bool enableRPC ) : theMuonDetLayerGeometry(muonLayout) {
 
-  theAllDetLayersInSystem=&muonLayout->allLayers(); 
+  theAllDetLayersInSystem=reinterpret_cast<const std::vector<const DetLayer*>*>(&muonLayout->allLayers()); 
   theAllNavigableLayer.resize(muonLayout->allLayers().size(),nullptr);
 
 
@@ -47,8 +47,8 @@ MuonNavigationSchool::MuonNavigationSchool(const MuonDetLayerGeometry * muonLayo
   if ( enableRPC ) barrel = muonLayout->allBarrelLayers();
   else barrel = muonLayout->allDTLayers();
 
-  for ( vector<DetLayer*>::const_iterator i = barrel.begin(); i != barrel.end(); i++ ) {
-    BarrelDetLayer* mbp = dynamic_cast<BarrelDetLayer*>(*i);
+  for ( auto i = barrel.begin(); i != barrel.end(); i++ ) {
+    const BarrelDetLayer* mbp = dynamic_cast<const BarrelDetLayer*>(*i);
     if ( mbp == 0 ) throw cms::Exception("MuonNavigationSchool", "Bad BarrelDetLayer");
     addBarrelLayer(mbp);
   }
@@ -58,8 +58,8 @@ MuonNavigationSchool::MuonNavigationSchool(const MuonDetLayerGeometry * muonLayo
   if ( enableRPC ) endcap = muonLayout->allEndcapLayers();
   else endcap = muonLayout->allCSCLayers();
 
-  for ( vector<DetLayer*>::const_iterator i = endcap.begin(); i != endcap.end(); i++ ) {
-    ForwardDetLayer* mep = dynamic_cast<ForwardDetLayer*>(*i);
+  for ( auto i = endcap.begin(); i != endcap.end(); i++ ) {
+    const ForwardDetLayer* mep = dynamic_cast<const ForwardDetLayer*>(*i);
     if ( mep == 0 ) throw cms::Exception("MuonNavigationSchool", "Bad ForwardDetLayer");
     addEndcapLayer(mep);
   }
@@ -112,7 +112,7 @@ MuonNavigationSchool::navigableLayers() {
 
 
 /// create barrel layer map
-void MuonNavigationSchool::addBarrelLayer(BarrelDetLayer* mbp) {
+void MuonNavigationSchool::addBarrelLayer(const BarrelDetLayer* mbp) {
 
   const BoundCylinder& bc = mbp->specificSurface();
   float radius = bc.radius();
@@ -127,7 +127,7 @@ void MuonNavigationSchool::addBarrelLayer(BarrelDetLayer* mbp) {
 
 
 /// create forwrad/backward layer maps
-void MuonNavigationSchool::addEndcapLayer(ForwardDetLayer* mep) {
+void MuonNavigationSchool::addEndcapLayer(const ForwardDetLayer* mep) {
 
   const BoundDisk& bd = mep->specificSurface();
   float outRadius = bd.outerRadius();

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGForRoadSearch.cc
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGForRoadSearch.cc
@@ -130,7 +130,7 @@ void TSGForRoadSearch::makeSeeds_0(const reco::Track & muon, std::vector<Traject
   if (!IPfts(muon, cIPFTS)) return;
 
   //take state at inner surface and check the first part reached
-  const std::vector<BarrelDetLayer*> & blc = theGeometricSearchTracker->tibLayers();
+  const std::vector<const BarrelDetLayer*> & blc = theGeometricSearchTracker->tibLayers();
   TrajectoryStateOnSurface inner = theProxyService->propagator(thePropagatorName)->propagate(cIPFTS,blc.front()->surface());
   if ( !inner.isValid() ) {LogDebug(theCategory) <<"inner state is not valid. no seed."; return;}
 
@@ -139,10 +139,10 @@ void TSGForRoadSearch::makeSeeds_0(const reco::Track & muon, std::vector<Traject
 
   double z = inner.globalPosition().z();
 
-  const std::vector<ForwardDetLayer*> &ptidc = theGeometricSearchTracker->posTidLayers();
-  const std::vector<ForwardDetLayer*> &ptecc = theGeometricSearchTracker->posTecLayers();
-  const std::vector<ForwardDetLayer*> &ntidc = theGeometricSearchTracker->negTidLayers();
-  const std::vector<ForwardDetLayer*> &ntecc = theGeometricSearchTracker->negTecLayers();
+  const std::vector<const ForwardDetLayer*> &ptidc = theGeometricSearchTracker->posTidLayers();
+  const std::vector<const ForwardDetLayer*> &ptecc = theGeometricSearchTracker->posTecLayers();
+  const std::vector<const ForwardDetLayer*> &ntidc = theGeometricSearchTracker->negTidLayers();
+  const std::vector<const ForwardDetLayer*> &ntecc = theGeometricSearchTracker->negTecLayers();
 
   const DetLayer *inLayer = 0;
   if( fabs(z) < ptidc.front()->surface().position().z()  ) {
@@ -205,7 +205,7 @@ void TSGForRoadSearch::makeSeeds_3(const reco::Track & muon, std::vector<Traject
   if (!IPfts(muon, cIPFTS)) return;
 
   //take state at outer surface and check the first part reached
-  const std::vector<BarrelDetLayer*> &blc = theGeometricSearchTracker->tobLayers();
+  const std::vector<const BarrelDetLayer*> &blc = theGeometricSearchTracker->tobLayers();
 
   //  TrajectoryStateOnSurface outer = theProxyService->propagator(thePropagatorName)->propagate(cIPFTS,blc.back()->surface());
   StateOnTrackerBound onBounds(theProxyService->propagator(thePropagatorName).product());
@@ -218,8 +218,8 @@ void TSGForRoadSearch::makeSeeds_3(const reco::Track & muon, std::vector<Traject
 
   double z = outer.globalPosition().z();
 
-  const std::vector<ForwardDetLayer*> &ptecc = theGeometricSearchTracker->posTecLayers();
-  const std::vector<ForwardDetLayer*> &ntecc = theGeometricSearchTracker->negTecLayers();
+  const std::vector<const ForwardDetLayer*> &ptecc = theGeometricSearchTracker->posTecLayers();
+  const std::vector<const ForwardDetLayer*> &ntecc = theGeometricSearchTracker->negTecLayers();
 
   LogDebug(theCategory)<<"starting looking for a compatible layer from: "<<outer<<"\nz: "<<z<<"TEC1 z: "<<ptecc.front()->surface().position().z();
 
@@ -296,7 +296,7 @@ void TSGForRoadSearch::makeSeeds_4(const reco::Track & muon, std::vector<Traject
   if (!IPfts(muon, cIPFTS)) return;
 
   //take state at inner surface and check the first part reached
-  const std::vector<BarrelDetLayer*> & blc = theGeometricSearchTracker->pixelBarrelLayers();
+  const std::vector<const BarrelDetLayer*> & blc = theGeometricSearchTracker->pixelBarrelLayers();
   if (blc.empty()){edm::LogError(theCategory)<<"want to start from pixel layer, but no barrel exists. trying without pixel."; 
     makeSeeds_0(muon, result);
     return;}
@@ -309,12 +309,12 @@ void TSGForRoadSearch::makeSeeds_4(const reco::Track & muon, std::vector<Traject
     
   double z = inner.globalPosition().z();
 
-  const std::vector<ForwardDetLayer*> &ppxlc = theGeometricSearchTracker->posPixelForwardLayers();
-  const std::vector<ForwardDetLayer*> &npxlc = theGeometricSearchTracker->negPixelForwardLayers();
-  const std::vector<ForwardDetLayer*> &ptidc = theGeometricSearchTracker->posTidLayers();
-  const std::vector<ForwardDetLayer*> &ptecc = theGeometricSearchTracker->posTecLayers();
-  const std::vector<ForwardDetLayer*> &ntidc = theGeometricSearchTracker->negTidLayers();
-  const std::vector<ForwardDetLayer*> &ntecc = theGeometricSearchTracker->negTecLayers();
+  const std::vector<const ForwardDetLayer*> &ppxlc = theGeometricSearchTracker->posPixelForwardLayers();
+  const std::vector<const ForwardDetLayer*> &npxlc = theGeometricSearchTracker->negPixelForwardLayers();
+  const std::vector<const ForwardDetLayer*> &ptidc = theGeometricSearchTracker->posTidLayers();
+  const std::vector<const ForwardDetLayer*> &ptecc = theGeometricSearchTracker->posTecLayers();
+  const std::vector<const ForwardDetLayer*> &ntidc = theGeometricSearchTracker->negTidLayers();
+  const std::vector<const ForwardDetLayer*> &ntecc = theGeometricSearchTracker->negTecLayers();
 
   if ((ppxlc.empty() || npxlc.empty()) && (ptidc.empty() || ptecc.empty()) )
     { edm::LogError(theCategory)<<"want to start from pixel layer, but no forward layer exists. trying without pixel.";
@@ -322,7 +322,7 @@ void TSGForRoadSearch::makeSeeds_4(const reco::Track & muon, std::vector<Traject
       return;}
 
   const DetLayer *inLayer = 0;
-  std::vector<ForwardDetLayer*>::const_iterator layerIt ;
+  std::vector<const ForwardDetLayer*>::const_iterator layerIt ;
 
   double fz=fabs(z);
   
@@ -353,12 +353,12 @@ void TSGForRoadSearch::makeSeeds_4(const reco::Track & muon, std::vector<Traject
   
   //if none were found. you should do something more.
   if (compatible.size()==0){
-    std::vector<ForwardDetLayer*>::const_iterator pxlEnd = (z>0)? ppxlc.end() : npxlc.end();
-    std::vector<ForwardDetLayer*>::const_iterator tidEnd = (z>0)? ptidc.end() : ntidc.end();
-    std::vector<ForwardDetLayer*>::const_iterator tecEnd = (z>0)? ptecc.end() : ntecc.end();
-    std::vector<ForwardDetLayer*>::const_iterator pxlBegin = (z>0)? ppxlc.begin() : npxlc.begin();
-    std::vector<ForwardDetLayer*>::const_iterator tidBegin = (z>0)? ptidc.begin() : ntidc.begin();
-    std::vector<ForwardDetLayer*>::const_iterator tecBegin = (z>0)? ptecc.begin() : ntecc.begin();
+    std::vector<const ForwardDetLayer*>::const_iterator pxlEnd = (z>0)? ppxlc.end() : npxlc.end();
+    std::vector<const ForwardDetLayer*>::const_iterator tidEnd = (z>0)? ptidc.end() : ntidc.end();
+    std::vector<const ForwardDetLayer*>::const_iterator tecEnd = (z>0)? ptecc.end() : ntecc.end();
+    std::vector<const ForwardDetLayer*>::const_iterator pxlBegin = (z>0)? ppxlc.begin() : npxlc.begin();
+    std::vector<const ForwardDetLayer*>::const_iterator tidBegin = (z>0)? ptidc.begin() : ntidc.begin();
+    std::vector<const ForwardDetLayer*>::const_iterator tecBegin = (z>0)? ptecc.begin() : ntecc.begin();
 
     //go to first disk if not already in a disk situation
     if (!dynamic_cast<const ForwardDetLayer*>(inLayer)) layerIt =pxlBegin--;

--- a/RecoParticleFlow/PFSimProducer/plugins/ConvBremSeedProducer.cc
+++ b/RecoParticleFlow/PFSimProducer/plugins/ConvBremSeedProducer.cc
@@ -445,18 +445,18 @@ ConvBremSeedProducer::initializeLayerMap()
   /// ATTENTION: HARD CODED LOGIC! If Famos layer numbering changes this logic needs to 
   /// be adapted to the new numbering!
     
-    std::vector< BarrelDetLayer*>   barrelLayers = 
+    const std::vector< const BarrelDetLayer*>&   barrelLayers = 
       geomSearchTracker_->barrelLayers();
     LogDebug("FastTracker") << "Barrel DetLayer dump: ";
-    for (std::vector< BarrelDetLayer*>::const_iterator bl=barrelLayers.begin();
+    for (auto bl=barrelLayers.begin();
 	 bl != barrelLayers.end(); ++bl) {
       LogDebug("FastTracker")<< "radius " << (**bl).specificSurface().radius(); 
     }
 
-  std::vector< ForwardDetLayer*>  posForwardLayers = 
+  const std::vector< const ForwardDetLayer*>&  posForwardLayers = 
     geomSearchTracker_->posForwardLayers();
   LogDebug("FastTracker") << "Positive Forward DetLayer dump: ";
-  for (std::vector< ForwardDetLayer*>::const_iterator fl=posForwardLayers.begin();
+  for (auto fl=posForwardLayers.begin();
        fl != posForwardLayers.end(); ++fl) {
     LogDebug("FastTracker") << "Z pos "
 			    << (**fl).surface().position().z()
@@ -485,7 +485,7 @@ ConvBremSeedProducer::initializeLayerMap()
       LogDebug("FastTracker") << " cylinder radius " << cyl->radius();
       bool found = false;
 
-      for (std::vector< BarrelDetLayer*>::const_iterator 
+      for (auto
 	     bl=barrelLayers.begin(); bl != barrelLayers.end(); ++bl) {
 
 	if (fabs( cyl->radius() - (**bl).specificSurface().radius()) < rTolerance) {
@@ -508,7 +508,7 @@ ConvBremSeedProducer::initializeLayerMap()
 
       bool found = false;
 
-      for (std::vector< ForwardDetLayer*>::const_iterator fl=posForwardLayers.begin();
+      for (auto fl=posForwardLayers.begin();
 	   fl != posForwardLayers.end(); ++fl) {
 	if (fabs( disk->position().z() - (**fl).surface().position().z()) < zTolerance) {
 	  layerMap_[i->layerNumber()] = *fl;

--- a/RecoPixelVertexing/PixelTriplets/interface/CosmicLayerTriplets.h
+++ b/RecoPixelVertexing/PixelTriplets/interface/CosmicLayerTriplets.h
@@ -44,9 +44,9 @@ private:
   LayerWithHits *lh3;
   LayerWithHits *lh4;
 
-   std::vector<BarrelDetLayer*> bl;
-   std::vector<ForwardDetLayer*> fpos;
-   std::vector<ForwardDetLayer*> fneg;
+   std::vector<BarrelDetLayer const*> bl;
+   std::vector<ForwardDetLayer const*> fpos;
+   std::vector<ForwardDetLayer const*> fneg;
    //MP
    std::vector<LayerWithHits*> allLayersWithHits;
    bool isFirstCall;

--- a/RecoPixelVertexing/PixelTriplets/src/CosmicLayerTriplets.cc
+++ b/RecoPixelVertexing/PixelTriplets/src/CosmicLayerTriplets.cc
@@ -77,9 +77,9 @@ void CosmicLayerTriplets::init(const SiStripRecHit2DCollection &collstereo,
   allLayersWithHits.clear();
   LogDebug("CosmicSeedFinder") <<"Reconstruction for geometry  "<<_geometry;
   if (_geometry=="STANDARD"  || _geometry=="TECPAIRS_TOBTRIPLETS"){
-    const DetLayer*  bl1=dynamic_cast<DetLayer*>(bl[10]);
-    const DetLayer*  bl2=dynamic_cast<DetLayer*>(bl[11]);
-    const DetLayer*  bl3=dynamic_cast<DetLayer*>(bl[12]);
+    const DetLayer*  bl1=dynamic_cast<DetLayer const*>(bl[10]);
+    const DetLayer*  bl2=dynamic_cast<DetLayer const*>(bl[11]);
+    const DetLayer*  bl3=dynamic_cast<DetLayer const*>(bl[12]);
     //   //LayersWithHits
     lh1=new  LayerWithHits(bl1,collrphi,acc.stripTOBLayer(4));   allLayersWithHits.push_back(lh1);
     lh2=new  LayerWithHits(bl2,collrphi,acc.stripTOBLayer(5));   allLayersWithHits.push_back(lh2);
@@ -87,10 +87,10 @@ void CosmicLayerTriplets::init(const SiStripRecHit2DCollection &collstereo,
   }
   if(_geometry=="MTCC"){ 
 
-    const DetLayer*  bl1=dynamic_cast<DetLayer*>(bl[0]);
-    const DetLayer*  bl2=dynamic_cast<DetLayer*>(bl[1]);
-    const DetLayer*  bl3=dynamic_cast<DetLayer*>(bl[2]);
-    const DetLayer*  bl4=dynamic_cast<DetLayer*>(bl[3]);
+    const DetLayer*  bl1=dynamic_cast<DetLayer const*>(bl[0]);
+    const DetLayer*  bl2=dynamic_cast<DetLayer const*>(bl[1]);
+    const DetLayer*  bl3=dynamic_cast<DetLayer const*>(bl[2]);
+    const DetLayer*  bl4=dynamic_cast<DetLayer const*>(bl[3]);
 
     lh1=new  LayerWithHits(bl1,collrphi,acc.stripTIBLayer(1)); allLayersWithHits.push_back(lh1);
     lh2=new  LayerWithHits(bl2,collrphi,acc.stripTIBLayer(2)); allLayersWithHits.push_back(lh2);

--- a/RecoTracker/GeometryESProducer/test/TrackerRecoGeometryAnalyzer.cc
+++ b/RecoTracker/GeometryESProducer/test/TrackerRecoGeometryAnalyzer.cc
@@ -66,11 +66,11 @@ TrackerRecoGeometryAnalyzer::analyze( const edm::Event& iEvent, const edm::Event
    iSetup.get<TrackerRecoGeometryRecord>().get( track );     
    
    //---- testing access to barrelLayers ----
-   vector<BarrelDetLayer*> theBarrelLayers = track->barrelLayers();
+   vector<const BarrelDetLayer*> theBarrelLayers = track->barrelLayers();
    edm::LogInfo("analyzer") << "number of BarrelLayers: " << theBarrelLayers.size() ;
 
    for(unsigned int i=0; i<3; i++){
-     BarrelDetLayer* theLayer = theBarrelLayers[i];   
+     const BarrelDetLayer* theLayer = theBarrelLayers[i];   
      edm::LogInfo("analyzer") << "theLayer[" << i << "]->position().perp(): " 
 	  << theLayer->components().front()->surface().position().perp() ;     
    }   

--- a/RecoTracker/SpecialSeedGenerators/src/OutsideInMuonSeeder.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/OutsideInMuonSeeder.cc
@@ -165,9 +165,9 @@ OutsideInMuonSeeder::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
             state = trajectoryStateTransform::innerStateOnSurface(tk, *geometry_, magfield_.product());
         }
         if (std::abs(tk.eta()) < maxEtaForTOB_) {
-            std::vector< BarrelDetLayer * > const & tob = measurementTracker->geometricSearchTracker()->tobLayers();
+            std::vector< BarrelDetLayer const* > const & tob = measurementTracker->geometricSearchTracker()->tobLayers();
             int iLayer = 6, found = 0;
-            for (std::vector<BarrelDetLayer *>::const_reverse_iterator it = tob.rbegin(), ed = tob.rend(); it != ed; ++it, --iLayer) {
+            for (auto it = tob.rbegin(), ed = tob.rend(); it != ed; ++it, --iLayer) {
                 if (debug_) std::cout << "\n ==== Trying TOB " << iLayer << " ====" << std::endl;
                 if (doLayer(**it, state, *out,
                             *(pmuon_cloned.get()),
@@ -179,8 +179,8 @@ OutsideInMuonSeeder::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
         }
         if (tk.eta() > minEtaForTEC_) {
             int iLayer = 9, found = 0;
-            std::vector< ForwardDetLayer * > const & tec = measurementTracker->geometricSearchTracker()->posTecLayers();
-            for (std::vector<ForwardDetLayer *>::const_reverse_iterator it = tec.rbegin(), ed = tec.rend(); it != ed; ++it, --iLayer) {
+            std::vector< ForwardDetLayer const* > const & tec = measurementTracker->geometricSearchTracker()->posTecLayers();
+            for (auto it = tec.rbegin(), ed = tec.rend(); it != ed; ++it, --iLayer) {
                 if (debug_) std::cout << "\n ==== Trying TEC " << +iLayer << " ====" << std::endl;
                 if (doLayer(**it, state, *out,
                             *(pmuon_cloned.get()),
@@ -192,8 +192,8 @@ OutsideInMuonSeeder::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
         }
         if (tk.eta() < -minEtaForTEC_) {
             int iLayer = 9, found = 0;
-            std::vector< ForwardDetLayer * > const & tec = measurementTracker->geometricSearchTracker()->negTecLayers();
-            for (std::vector<ForwardDetLayer *>::const_reverse_iterator it = tec.rbegin(), ed = tec.rend(); it != ed; ++it, --iLayer) {
+            std::vector< ForwardDetLayer const* > const & tec = measurementTracker->geometricSearchTracker()->negTecLayers();
+            for (auto it = tec.rbegin(), ed = tec.rend(); it != ed; ++it, --iLayer) {
                 if (debug_) std::cout << "\n ==== Trying TEC " << -iLayer << " ====" << std::endl;
                 if (doLayer(**it, state, *out,
                             *(pmuon_cloned.get()),

--- a/RecoTracker/TkDetLayers/interface/GeometricSearchTracker.h
+++ b/RecoTracker/TkDetLayers/interface/GeometricSearchTracker.h
@@ -25,7 +25,7 @@ class GeometricSearchTracker: public DetLayerGeometry {
   
   virtual ~GeometricSearchTracker() __attribute__ ((cold));
 
-  std::vector<DetLayer*> const & allLayers()     const {return theAllLayers;}  
+  std::vector<DetLayer const*> const & allLayers()     const {return theAllLayers;}  
 
   std::vector<BarrelDetLayer*>  const &  barrelLayers()  const {return theBarrelLayers;}
 
@@ -53,7 +53,7 @@ class GeometricSearchTracker: public DetLayerGeometry {
   const DetLayer*   detLayer( const DetId& id) const {return idToLayer(id);};
 
  private:
-  std::vector<DetLayer*>        theAllLayers;
+  std::vector<DetLayer const*>        theAllLayers;
   std::vector<BarrelDetLayer*>  theBarrelLayers;
   std::vector<ForwardDetLayer*> theForwardLayers;
   std::vector<ForwardDetLayer*> theNegForwardLayers;

--- a/RecoTracker/TkDetLayers/interface/GeometricSearchTracker.h
+++ b/RecoTracker/TkDetLayers/interface/GeometricSearchTracker.h
@@ -13,37 +13,37 @@
 class GeometricSearchTracker: public DetLayerGeometry {
  public:
 
-  GeometricSearchTracker(const std::vector<BarrelDetLayer*>& pxlBar,
-			 const std::vector<BarrelDetLayer*>& tib,
-			 const std::vector<BarrelDetLayer*>& tob,
-			 const std::vector<ForwardDetLayer*>& negPxlFwd,
-			 const std::vector<ForwardDetLayer*>& negTid,
-			 const std::vector<ForwardDetLayer*>& negTec,
-			 const std::vector<ForwardDetLayer*>& posPxlFwd,
-			 const std::vector<ForwardDetLayer*>& posTid,
-			 const std::vector<ForwardDetLayer*>& posTec) __attribute__ ((cold));
+  GeometricSearchTracker(const std::vector<BarrelDetLayer const*>& pxlBar,
+			 const std::vector<BarrelDetLayer const*>& tib,
+			 const std::vector<BarrelDetLayer const*>& tob,
+			 const std::vector<ForwardDetLayer const*>& negPxlFwd,
+			 const std::vector<ForwardDetLayer const*>& negTid,
+			 const std::vector<ForwardDetLayer const*>& negTec,
+			 const std::vector<ForwardDetLayer const*>& posPxlFwd,
+			 const std::vector<ForwardDetLayer const*>& posTid,
+			 const std::vector<ForwardDetLayer const*>& posTec) __attribute__ ((cold));
   
   virtual ~GeometricSearchTracker() __attribute__ ((cold));
 
   std::vector<DetLayer const*> const & allLayers()     const {return theAllLayers;}  
 
-  std::vector<BarrelDetLayer*>  const &  barrelLayers()  const {return theBarrelLayers;}
+  std::vector<BarrelDetLayer const*>  const &  barrelLayers()  const {return theBarrelLayers;}
 
-  std::vector<ForwardDetLayer*> const & forwardLayers() const {return theForwardLayers;}
-  std::vector<ForwardDetLayer*> const & negForwardLayers() const {return theNegForwardLayers;}
-  std::vector<ForwardDetLayer*> const & posForwardLayers() const {return thePosForwardLayers;}
+  std::vector<ForwardDetLayer const*> const & forwardLayers() const {return theForwardLayers;}
+  std::vector<ForwardDetLayer const*> const & negForwardLayers() const {return theNegForwardLayers;}
+  std::vector<ForwardDetLayer const*> const & posForwardLayers() const {return thePosForwardLayers;}
 
-  std::vector<BarrelDetLayer*>  const & pixelBarrelLayers() const {return thePixelBarrelLayers;}
-  std::vector<BarrelDetLayer*>  const & tibLayers() const {return theTibLayers;}
-  std::vector<BarrelDetLayer*>  const & tobLayers() const {return theTobLayers;}
+  std::vector<BarrelDetLayer const*>  const & pixelBarrelLayers() const {return thePixelBarrelLayers;}
+  std::vector<BarrelDetLayer const*>  const & tibLayers() const {return theTibLayers;}
+  std::vector<BarrelDetLayer const*>  const & tobLayers() const {return theTobLayers;}
 
-  std::vector<ForwardDetLayer*> const & negPixelForwardLayers() const {return theNegPixelForwardLayers;}
-  std::vector<ForwardDetLayer*> const &  negTidLayers() const {return theNegTidLayers;}
-  std::vector<ForwardDetLayer*> const &  negTecLayers() const {return theNegTecLayers;}
+  std::vector<ForwardDetLayer const*> const & negPixelForwardLayers() const {return theNegPixelForwardLayers;}
+  std::vector<ForwardDetLayer const*> const &  negTidLayers() const {return theNegTidLayers;}
+  std::vector<ForwardDetLayer const*> const &  negTecLayers() const {return theNegTecLayers;}
 
-  std::vector<ForwardDetLayer*> const &  posPixelForwardLayers() const {return thePosPixelForwardLayers;}
-  std::vector<ForwardDetLayer*> const &  posTidLayers() const {return thePosTidLayers;}
-  std::vector<ForwardDetLayer*> const &  posTecLayers() const {return thePosTecLayers;}
+  std::vector<ForwardDetLayer const*> const &  posPixelForwardLayers() const {return thePosPixelForwardLayers;}
+  std::vector<ForwardDetLayer const*> const &  posTidLayers() const {return thePosTidLayers;}
+  std::vector<ForwardDetLayer const*> const &  posTecLayers() const {return thePosTecLayers;}
 
   
   /// Give the DetId of a module, returns the pointer to the corresponding DetLayer
@@ -54,21 +54,21 @@ class GeometricSearchTracker: public DetLayerGeometry {
 
  private:
   std::vector<DetLayer const*>        theAllLayers;
-  std::vector<BarrelDetLayer*>  theBarrelLayers;
-  std::vector<ForwardDetLayer*> theForwardLayers;
-  std::vector<ForwardDetLayer*> theNegForwardLayers;
-  std::vector<ForwardDetLayer*> thePosForwardLayers;
+  std::vector<BarrelDetLayer const*>  theBarrelLayers;
+  std::vector<ForwardDetLayer const*> theForwardLayers;
+  std::vector<ForwardDetLayer const*> theNegForwardLayers;
+  std::vector<ForwardDetLayer const*> thePosForwardLayers;
 
-  std::vector<BarrelDetLayer*>  thePixelBarrelLayers;
-  std::vector<BarrelDetLayer*>  theTibLayers;
-  std::vector<BarrelDetLayer*>  theTobLayers;
+  std::vector<BarrelDetLayer const*>  thePixelBarrelLayers;
+  std::vector<BarrelDetLayer const*>  theTibLayers;
+  std::vector<BarrelDetLayer const*>  theTobLayers;
 
-  std::vector<ForwardDetLayer*> theNegPixelForwardLayers;
-  std::vector<ForwardDetLayer*> theNegTidLayers;
-  std::vector<ForwardDetLayer*> theNegTecLayers;
-  std::vector<ForwardDetLayer*> thePosPixelForwardLayers;
-  std::vector<ForwardDetLayer*> thePosTidLayers;
-  std::vector<ForwardDetLayer*> thePosTecLayers;
+  std::vector<ForwardDetLayer const*> theNegPixelForwardLayers;
+  std::vector<ForwardDetLayer const*> theNegTidLayers;
+  std::vector<ForwardDetLayer const*> theNegTecLayers;
+  std::vector<ForwardDetLayer const*> thePosPixelForwardLayers;
+  std::vector<ForwardDetLayer const*> thePosTidLayers;
+  std::vector<ForwardDetLayer const*> thePosTecLayers;
 };
 
 

--- a/RecoTracker/TkDetLayers/src/GeometricSearchTracker.cc
+++ b/RecoTracker/TkDetLayers/src/GeometricSearchTracker.cc
@@ -45,7 +45,7 @@ GeometricSearchTracker::GeometricSearchTracker(const vector<BarrelDetLayer*>& px
   // number the layers 
   int sq=0;
   for (auto l : theAllLayers) 
-    (*l).setSeqNum(sq++);
+    const_cast<DetLayer&>(*l).setSeqNum(sq++);
 
   edm::LogInfo("TkDetLayers")
     << "------ GeometricSearchTracker constructed with: ------" << "\n"
@@ -73,9 +73,8 @@ GeometricSearchTracker::GeometricSearchTracker(const vector<BarrelDetLayer*>& px
 
 
 GeometricSearchTracker::~GeometricSearchTracker(){
-  for(vector<DetLayer*>::const_iterator it=theAllLayers.begin(); it!=theAllLayers.end();it++){
-    delete *it;
-  }
+    for (auto l : theAllLayers)
+    delete const_cast<DetLayer*>(l);
   
 }
 

--- a/RecoTracker/TkDetLayers/src/GeometricSearchTracker.cc
+++ b/RecoTracker/TkDetLayers/src/GeometricSearchTracker.cc
@@ -3,15 +3,15 @@
 
 using namespace std;
 
-GeometricSearchTracker::GeometricSearchTracker(const vector<BarrelDetLayer*>& pxlBar,
-					       const vector<BarrelDetLayer*>& tib,
-					       const vector<BarrelDetLayer*>& tob,
-					       const vector<ForwardDetLayer*>& negPxlFwd,
-					       const vector<ForwardDetLayer*>& negTid,
-					       const vector<ForwardDetLayer*>& negTec,
-					       const vector<ForwardDetLayer*>& posPxlFwd,
-					       const vector<ForwardDetLayer*>& posTid,
-					       const vector<ForwardDetLayer*>& posTec):
+GeometricSearchTracker::GeometricSearchTracker(const vector<BarrelDetLayer const*>& pxlBar,
+					       const vector<BarrelDetLayer const*>& tib,
+					       const vector<BarrelDetLayer const*>& tob,
+					       const vector<ForwardDetLayer const*>& negPxlFwd,
+					       const vector<ForwardDetLayer const*>& negTid,
+					       const vector<ForwardDetLayer const*>& negTec,
+					       const vector<ForwardDetLayer const*>& posPxlFwd,
+					       const vector<ForwardDetLayer const*>& posTid,
+					       const vector<ForwardDetLayer const*>& posTec):
   thePixelBarrelLayers(pxlBar.begin(),pxlBar.end()),
   theTibLayers(tib.begin(),tib.end()),
   theTobLayers(tob.begin(),tob.end()),

--- a/RecoTracker/TkDetLayers/src/GeometricSearchTrackerBuilder.cc
+++ b/RecoTracker/TkDetLayers/src/GeometricSearchTrackerBuilder.cc
@@ -29,15 +29,15 @@ GeometricSearchTrackerBuilder::build(const GeometricDet* theGeometricTracker,
   TIDLayerBuilder aTIDLayerBuilder;
   TECLayerBuilder aTECLayerBuilder;
 
-  vector<BarrelDetLayer*>  thePxlBarLayers;
-  vector<BarrelDetLayer*>  theTIBLayers;
-  vector<BarrelDetLayer*>  theTOBLayers;
-  vector<ForwardDetLayer*> theNegPxlFwdLayers;
-  vector<ForwardDetLayer*> thePosPxlFwdLayers;
-  vector<ForwardDetLayer*> theNegTIDLayers;
-  vector<ForwardDetLayer*> thePosTIDLayers;
-  vector<ForwardDetLayer*> theNegTECLayers;
-  vector<ForwardDetLayer*> thePosTECLayers;
+  vector<BarrelDetLayer const*>  thePxlBarLayers;
+  vector<BarrelDetLayer const*>  theTIBLayers;
+  vector<BarrelDetLayer const*>  theTOBLayers;
+  vector<ForwardDetLayer const*> theNegPxlFwdLayers;
+  vector<ForwardDetLayer const*> thePosPxlFwdLayers;
+  vector<ForwardDetLayer const*> theNegTIDLayers;
+  vector<ForwardDetLayer const*> thePosTIDLayers;
+  vector<ForwardDetLayer const*> theNegTECLayers;
+  vector<ForwardDetLayer const*> thePosTECLayers;
   
   using namespace trackerTrie;
 

--- a/RecoTracker/TkHitPairs/interface/CosmicLayerPairs.h
+++ b/RecoTracker/TkHitPairs/interface/CosmicLayerPairs.h
@@ -35,9 +35,9 @@ private:
    //bool isFirstCall;
    std::string _geometry;
 
-   std::vector<BarrelDetLayer*> bl;
-   std::vector<ForwardDetLayer*> fpos;
-   std::vector<ForwardDetLayer*> fneg;
+   std::vector<BarrelDetLayer const*> bl;
+   std::vector<ForwardDetLayer const*> fpos;
+   std::vector<ForwardDetLayer const*> fneg;
    edm::OwnVector<LayerWithHits> TECPlusLayerWithHits;
    edm::OwnVector<LayerWithHits> TECMinusLayerWithHits;
    edm::OwnVector<LayerWithHits> TIBLayerWithHits;

--- a/RecoTracker/TkMSParametrization/src/MultipleScatteringGeometry.cc
+++ b/RecoTracker/TkMSParametrization/src/MultipleScatteringGeometry.cc
@@ -25,11 +25,11 @@ MultipleScatteringGeometry::MultipleScatteringGeometry(const edm::EventSetup &iS
   edm::ESHandle<GeometricSearchTracker> track;
   iSetup.get<TrackerRecoGeometryRecord>().get( track ); 
 
-  vector<BarrelDetLayer*> barrelLayers=track->barrelLayers();
-  vector<BarrelDetLayer*>::const_iterator ib;
-  vector<ForwardDetLayer*> forwardPosLayers=track->posForwardLayers();
-  vector<ForwardDetLayer*> forwardNegLayers=track->negForwardLayers();
-  vector<ForwardDetLayer*>::const_iterator ie;
+  vector<BarrelDetLayer const*> barrelLayers=track->barrelLayers();
+  vector<BarrelDetLayer const*>::const_iterator ib;
+  vector<ForwardDetLayer const*> forwardPosLayers=track->posForwardLayers();
+  vector<ForwardDetLayer const*> forwardNegLayers=track->negForwardLayers();
+  vector<ForwardDetLayer const*>::const_iterator ie;
   // barrelLayers = accessor.barrelLayers();
   for (ib = barrelLayers.begin(); ib != barrelLayers.end(); ib++)
     theLayers.push_back(*ib);

--- a/RecoTracker/TkMSParametrization/test/TestMS.cc
+++ b/RecoTracker/TkMSParametrization/test/TestMS.cc
@@ -83,9 +83,9 @@ void TestMS::beginRun(edm::Run & run, const edm::EventSetup& es)
   edm::ESHandle<GeometricSearchTracker> tracker;
   es.get<TrackerRecoGeometryRecord>().get( tracker );
 
-  vector<BarrelDetLayer*> barrel=tracker->barrelLayers();
+  vector<BarrelDetLayer const*> barrel=tracker->barrelLayers();
 //  vector<ForwardDetLayer*> endcap=tracker->posForwardLayers();
-  vector<ForwardDetLayer*> endcap=tracker->negForwardLayers();
+  vector<ForwardDetLayer const*> endcap=tracker->negForwardLayers();
 
 
   MultipleScatteringParametrisation sb1(barrel[0],es);

--- a/RecoTracker/TkNavigation/interface/BeamHaloNavigationSchool.h
+++ b/RecoTracker/TkNavigation/interface/BeamHaloNavigationSchool.h
@@ -19,8 +19,8 @@ public:
  protected:
   //addon to SimpleNavigationSchool
   void linkOtherEndLayers( SymmetricLayerFinder& symFinder);
-  void addInward(DetLayer * det, const FDLC& news);
-  void addInward(DetLayer * det, ForwardDetLayer * newF);
+  void addInward(const DetLayer * det, const FDLC& news);
+  void addInward(const DetLayer * det, const ForwardDetLayer * newF);
   void establishInverseRelations();
   FDLC reachableFromHorizontal();
 };

--- a/RecoTracker/TkNavigation/interface/SimpleBarrelNavigableLayer.h
+++ b/RecoTracker/TkNavigation/interface/SimpleBarrelNavigableLayer.h
@@ -13,7 +13,7 @@ class SimpleBarrelNavigableLayer GCC11_FINAL : public SimpleNavigableLayer {
 
 public:
 
-  SimpleBarrelNavigableLayer( BarrelDetLayer* detLayer,
+  SimpleBarrelNavigableLayer( BarrelDetLayer const* detLayer,
 			      const BDLC& outerBLC, 
 			      const FDLC& outerLeftFL, 
 			      const FDLC& outerRightFL,
@@ -24,31 +24,31 @@ public:
   
   // NavigableLayer interface
   virtual std::vector<const DetLayer*> 
-  nextLayers( NavigationDirection direction) const;
+  nextLayers( NavigationDirection direction) const override;
 
   virtual std::vector<const DetLayer*> 
   nextLayers( const FreeTrajectoryState& fts, 
-	      PropagationDirection timeDirection) const;
+	      PropagationDirection timeDirection) const override;
 
   virtual std::vector<const DetLayer*> 
-  compatibleLayers( NavigationDirection direction) const;
+  compatibleLayers( NavigationDirection direction) const override;
 
   virtual std::vector<const DetLayer*> 
   compatibleLayers( const FreeTrajectoryState& fts, 
-		    PropagationDirection dir) const {
+		    PropagationDirection dir) const override {
     int counter=0;
     return SimpleNavigableLayer::compatibleLayers(fts,dir,counter);
   }
 
-  virtual void setAdditionalLink(DetLayer*, NavigationDirection direction=insideOut);
+  virtual void setAdditionalLink(const DetLayer*, NavigationDirection direction=insideOut) override;
 
-  virtual DetLayer* detLayer() const { return theDetLayer;}
-  virtual void   setDetLayer( DetLayer* dl);
+  virtual const DetLayer* detLayer() const override { return theDetLayer;}
+  virtual void   setDetLayer( const DetLayer* dl) override;
   
-  virtual void setInwardLinks(const BDLC& theBarrelv, const FDLC& theForwardv,TkLayerLess sorter = TkLayerLess(outsideIn));
+  virtual void setInwardLinks(const BDLC& theBarrelv, const FDLC& theForwardv,TkLayerLess sorter = TkLayerLess(outsideIn)) override;
 
 private:
-  BarrelDetLayer*   theDetLayer;
+  const BarrelDetLayer*   theDetLayer;
   BDLC              theOuterBarrelLayers;
   BDLC              theInnerBarrelLayers;
 

--- a/RecoTracker/TkNavigation/interface/SimpleForwardNavigableLayer.h
+++ b/RecoTracker/TkNavigation/interface/SimpleForwardNavigableLayer.h
@@ -10,7 +10,7 @@ class SimpleForwardNavigableLayer GCC11_FINAL : public SimpleNavigableLayer {
 
 public:
 
-  SimpleForwardNavigableLayer( ForwardDetLayer* detLayer,
+  SimpleForwardNavigableLayer( const ForwardDetLayer* detLayer,
 			       const BDLC& outerBL, 
 			       const FDLC& outerFL, 
 			       const MagneticField* field,
@@ -19,31 +19,31 @@ public:
 
   // NavigableLayer interface
   virtual std::vector<const DetLayer*> 
-  nextLayers( NavigationDirection direction) const;
+  nextLayers( NavigationDirection direction) const override;
 
   virtual std::vector<const DetLayer*> 
   nextLayers( const FreeTrajectoryState& fts, 
-	      PropagationDirection timeDirection) const;
+	      PropagationDirection timeDirection) const override;
 
   virtual std::vector<const DetLayer*> 
-  compatibleLayers( NavigationDirection direction) const;
+  compatibleLayers( NavigationDirection direction) const override;
 
   virtual std::vector<const DetLayer*> 
   compatibleLayers( const FreeTrajectoryState& fts, 
-		    PropagationDirection dir) const {
+		    PropagationDirection dir) const override {
     int counter=0;
     return SimpleNavigableLayer::compatibleLayers(fts,dir,counter);
   }
 
-  virtual void setAdditionalLink(DetLayer*, NavigationDirection direction=insideOut);
+  virtual void setAdditionalLink(const DetLayer*, NavigationDirection direction=insideOut) override;
 
-  virtual DetLayer* detLayer() const { return theDetLayer;}
-  virtual void   setDetLayer( DetLayer* dl);
+  virtual const DetLayer* detLayer() const override { return theDetLayer;} 
+  virtual void   setDetLayer( const DetLayer* dl) override;
 
-  virtual void setInwardLinks( const BDLC&, const FDLC&, TkLayerLess sorter = TkLayerLess(outsideIn));
+  virtual void setInwardLinks( const BDLC&, const FDLC&, TkLayerLess sorter = TkLayerLess(outsideIn)) override;
 
 private:
-  ForwardDetLayer*  theDetLayer;
+  const ForwardDetLayer*  theDetLayer;
   BDLC              theOuterBarrelLayers;
   BDLC              theInnerBarrelLayers;
 

--- a/RecoTracker/TkNavigation/interface/SimpleNavigableLayer.h
+++ b/RecoTracker/TkNavigation/interface/SimpleNavigableLayer.h
@@ -20,15 +20,15 @@ class SimpleNavigableLayer : public NavigableLayer {
 public:
 
   typedef std::vector<const DetLayer*>              DLC;
-  typedef std::vector<BarrelDetLayer*>              BDLC;
-  typedef std::vector<ForwardDetLayer*>             FDLC;
+  typedef std::vector<const BarrelDetLayer*>        BDLC;
+  typedef std::vector<const ForwardDetLayer*>       FDLC;
 
   SimpleNavigableLayer( const MagneticField* field,float eps,bool checkCrossingSide=true) :
     theField(field), theEpsilon(eps),theCheckCrossingSide(checkCrossingSide),theSelfSearch(false) {}
 
   virtual void setInwardLinks(const BDLC&, const FDLC&, TkLayerLess sorter = TkLayerLess(outsideIn)) = 0;
   
-  virtual void setAdditionalLink(DetLayer*, NavigationDirection direction=insideOut) = 0;
+  virtual void setAdditionalLink(const DetLayer*, NavigationDirection direction=insideOut) = 0;
 
   void setCheckCrossingSide(bool docheck) {theCheckCrossingSide = docheck;}
 

--- a/RecoTracker/TkNavigation/interface/SimpleNavigationSchool.h
+++ b/RecoTracker/TkNavigation/interface/SimpleNavigationSchool.h
@@ -31,8 +31,8 @@ public:
 protected:
 
   typedef std::vector<const DetLayer*>              DLC;
-  typedef std::vector<BarrelDetLayer*>              BDLC;
-  typedef std::vector<ForwardDetLayer*>             FDLC;
+  typedef std::vector<const BarrelDetLayer*>        BDLC;
+  typedef std::vector<const ForwardDetLayer*>       FDLC;
   typedef DLC::iterator                        DLI;
   typedef BDLC::iterator                       BDLI;
   typedef FDLC::iterator                       FDLI;
@@ -53,13 +53,13 @@ protected:
   virtual void linkBarrelLayers( SymmetricLayerFinder& symFinder);
   virtual void linkForwardLayers( SymmetricLayerFinder& symFinder);
 
-  virtual void linkNextForwardLayer( BarrelDetLayer*, FDLC&);
+  virtual void linkNextForwardLayer( BarrelDetLayer const*, FDLC&);
 
   virtual void linkNextLargerLayer( BDLI, BDLI, BDLC&);
 
-  virtual void linkNextBarrelLayer( ForwardDetLayer* fl, BDLC&);
+  virtual void linkNextBarrelLayer( ForwardDetLayer const* fl, BDLC&);
 
-  virtual void linkOuterGroup( ForwardDetLayer* fl,
+  virtual void linkOuterGroup( ForwardDetLayer const* fl,
 		       const FDLC& group,
 		       FDLC& reachableFL);
 

--- a/RecoTracker/TkNavigation/interface/StartingLayerFinder.h
+++ b/RecoTracker/TkNavigation/interface/StartingLayerFinder.h
@@ -53,8 +53,8 @@ public:
   std::vector<const DetLayer*> startingLayers(const TrajectorySeed& aSeed) const;
 
   const BarrelDetLayer* firstPixelBarrelLayer() const;
-  const std::vector<ForwardDetLayer*> firstNegPixelFwdLayer() const;
-  const std::vector<ForwardDetLayer*> firstPosPixelFwdLayer() const;
+  const std::vector<const ForwardDetLayer*> firstNegPixelFwdLayer() const;
+  const std::vector<const ForwardDetLayer*> firstPosPixelFwdLayer() const;
 
   const Propagator* propagator() const {return thePropagator;}
 
@@ -65,9 +65,9 @@ private:
   const Propagator* thePropagator;
   const MeasurementTracker*     theMeasurementTracker;
   mutable bool thePixelLayersValid;
-  mutable BarrelDetLayer* theFirstPixelBarrelLayer;
-  mutable std::vector<ForwardDetLayer*> theFirstNegPixelFwdLayer;
-  mutable std::vector<ForwardDetLayer*> theFirstPosPixelFwdLayer;
+  mutable const BarrelDetLayer* theFirstPixelBarrelLayer;
+  mutable std::vector<const ForwardDetLayer*> theFirstNegPixelFwdLayer;
+  mutable std::vector<const ForwardDetLayer*> theFirstPosPixelFwdLayer;
 
 
   void checkPixelLayers() const;

--- a/RecoTracker/TkNavigation/interface/SymmetricLayerFinder.h
+++ b/RecoTracker/TkNavigation/interface/SymmetricLayerFinder.h
@@ -15,16 +15,16 @@ class ForwardDetLayer;
 
 class SymmetricLayerFinder {
 
-  typedef std::vector<ForwardDetLayer*>                   FDLC;
+  typedef std::vector<const ForwardDetLayer*>             FDLC;
   typedef FDLC::iterator                                  FDLI;
   typedef FDLC::const_iterator                            ConstFDLI;
-  typedef std::pair< ForwardDetLayer*, ForwardDetLayer*>  PairType;
+  typedef std::pair< const ForwardDetLayer*, const ForwardDetLayer*>  PairType;
 
 public:
 
   SymmetricLayerFinder( const FDLC&);
 
-  ForwardDetLayer* mirror( const ForwardDetLayer* layer) {
+  const ForwardDetLayer* mirror( const ForwardDetLayer* layer) {
     return theForwardMap[layer];
   }
 
@@ -33,12 +33,12 @@ public:
 private:
 
   //  typedef map< const ForwardDetLayer*, const ForwardDetLayer*, less<const ForwardDetLayer*> >
-  typedef std::map< const ForwardDetLayer*, ForwardDetLayer*, std::less<const ForwardDetLayer*> >
+  typedef std::map< const ForwardDetLayer*, const ForwardDetLayer*, std::less<const ForwardDetLayer*> >
     ForwardMapType;
 
   ForwardMapType theForwardMap;
 
-  ForwardDetLayer* mirrorPartner( const ForwardDetLayer* layer,
+  const ForwardDetLayer* mirrorPartner( const ForwardDetLayer* layer,
 				  const FDLC& rightLayers);
   
 

--- a/RecoTracker/TkNavigation/src/BeamHaloNavigationSchool.cc
+++ b/RecoTracker/TkNavigation/src/BeamHaloNavigationSchool.cc
@@ -33,9 +33,8 @@ BeamHaloNavigationSchool::BeamHaloNavigationSchool(const GeometricSearchTracker*
       }*/
 
   // get forward layers
-  vector<ForwardDetLayer*> flc = theTracker->forwardLayers(); 
-  for ( vector<ForwardDetLayer*>::iterator i = flc.begin(); i != flc.end(); i++) {
-    theForwardLayers.push_back( (*i) );
+  for( auto const& l : theTracker->forwardLayers()) {
+    theForwardLayers.push_back(l);
   }
   
   FDLI middle = find_if( theForwardLayers.begin(), theForwardLayers.end(),
@@ -82,8 +81,8 @@ void BeamHaloNavigationSchool::establishInverseRelations() {
 
   // find for each layer which are the barrel and forward
   // layers that point to it
-  typedef map<const DetLayer*, vector<BarrelDetLayer*>, less<const DetLayer*> > BarrelMapType;
-  typedef map<const DetLayer*, vector<ForwardDetLayer*>, less<const DetLayer*> > ForwardMapType;
+  typedef map<const DetLayer*, vector<BarrelDetLayer const*>, less<const DetLayer*> > BarrelMapType;
+  typedef map<const DetLayer*, vector<ForwardDetLayer const*>, less<const DetLayer*> > ForwardMapType;
 
 
   BarrelMapType reachedBarrelLayersMap;
@@ -106,12 +105,11 @@ void BeamHaloNavigationSchool::establishInverseRelations() {
   }
 
 
-  vector<DetLayer*> lc = theTracker->allLayers();
-  for ( vector<DetLayer*>::iterator i = lc.begin(); i != lc.end(); i++) {
+  for ( auto const i : theTracker->allLayers()) {
     SimpleNavigableLayer* navigableLayer =
-     dynamic_cast<SimpleNavigableLayer*>(theAllNavigableLayer[(*i)->seqNum()]);
+     dynamic_cast<SimpleNavigableLayer*>(theAllNavigableLayer[i->seqNum()]);
     if (!navigableLayer) {edm::LogInfo("BeamHaloNavigationSchool")<<"a detlayer does not have a navigable layer, which is normal in beam halo navigation.";}
-    if (navigableLayer){navigableLayer->setInwardLinks( reachedBarrelLayersMap[*i],reachedForwardLayersMap[*i], TkLayerLess(outsideIn, (*i)) );}
+    if (navigableLayer){navigableLayer->setInwardLinks( reachedBarrelLayersMap[i],reachedForwardLayersMap[i], TkLayerLess(outsideIn, i) );}
   }
 
 }
@@ -130,10 +128,10 @@ linkOtherEndLayers(  SymmetricLayerFinder& symFinder){
     {
       LogDebug("BeamHaloNavigationSchool")<<"adding inward from right";
       //link it inward to the mirror reachable from horizontal
-      addInward((DetLayer*)*fl,symFinder.mirror(*fl));
+      addInward(static_cast<DetLayer const*>(*fl),symFinder.mirror(*fl));
       
       LogDebug("BeamHaloNavigationSchool")<<"adding inward from mirror of right (left?)";
-      addInward((DetLayer*)symFinder.mirror(*fl),*fl);
+      addInward(static_cast<DetLayer const*>(symFinder.mirror(*fl)),*fl);
     }
 
 
@@ -142,7 +140,7 @@ linkOtherEndLayers(  SymmetricLayerFinder& symFinder){
 }
 
 void BeamHaloNavigationSchool::
-addInward(DetLayer * det, ForwardDetLayer * newF){
+addInward(const DetLayer * det, const ForwardDetLayer * newF){
   //get the navigable layer for this DetLayer
   SimpleNavigableLayer* navigableLayer =
     dynamic_cast<SimpleNavigableLayer*>(theAllNavigableLayer[(det)->seqNum()]);
@@ -183,7 +181,7 @@ addInward(DetLayer * det, ForwardDetLayer * newF){
 }
 
 void BeamHaloNavigationSchool::
-addInward(DetLayer * det, const FDLC& news){
+addInward(const DetLayer * det, const FDLC& news){
   //get the navigable layer for this DetLayer
   SimpleNavigableLayer* navigableLayer =
     dynamic_cast<SimpleNavigableLayer*>(theAllNavigableLayer[(det)->seqNum()]);

--- a/RecoTracker/TkNavigation/src/CosmicNavigationSchool.cc
+++ b/RecoTracker/TkNavigation/src/CosmicNavigationSchool.cc
@@ -52,8 +52,8 @@ void CosmicNavigationSchool::build(const GeometricSearchTracker* theInputTracker
 
 
   // Get barrel layers
-  vector<BarrelDetLayer*> blc = theTracker->barrelLayers();
-  for ( vector<BarrelDetLayer*>::iterator i = blc.begin(); i != blc.end(); i++) {
+  vector<BarrelDetLayer const*> const& blc = theTracker->barrelLayers();
+  for ( auto i = blc.begin(); i != blc.end(); i++) {
     if (conf.noPXB && (*i)->subDetector() == GeomDetEnumerators::PixelBarrel) continue;
     if (conf.noTOB && (*i)->subDetector() == GeomDetEnumerators::TOB) continue;
     if (conf.noTIB && (*i)->subDetector() == GeomDetEnumerators::TIB) continue;
@@ -61,8 +61,8 @@ void CosmicNavigationSchool::build(const GeometricSearchTracker* theInputTracker
   }
 
   // get forward layers
-  vector<ForwardDetLayer*> flc = theTracker->forwardLayers();
-  for ( vector<ForwardDetLayer*>::iterator i = flc.begin(); i != flc.end(); i++) {
+  vector<ForwardDetLayer const*> const& flc = theTracker->forwardLayers();
+  for ( auto i = flc.begin(); i != flc.end(); i++) {
     if (conf.noPXF && (*i)->subDetector() == GeomDetEnumerators::PixelEndcap) continue;
     if (conf.noTEC && (*i)->subDetector() == GeomDetEnumerators::TEC) continue;
     if (conf.noTID && (*i)->subDetector() == GeomDetEnumerators::TID) continue;
@@ -87,11 +87,11 @@ void CosmicNavigationSchool::build(const GeometricSearchTracker* theInputTracker
     //   NavigationSetter setter(*this);
 
     //add TOB1->TOB1 inward link
-    const std::vector< BarrelDetLayer * > &  tobL = theInputTracker->tobLayers();
+    const std::vector< const BarrelDetLayer * > &  tobL = theInputTracker->tobLayers();
     if (tobL.size()>=1){
       if (conf.allSelf){
 	LogDebug("CosmicNavigationSchool")<<" adding all TOB self search.";
-	for (std::vector< BarrelDetLayer * >::const_iterator lIt = tobL.begin(); lIt!=tobL.end(); ++lIt)
+	for (auto lIt = tobL.begin(); lIt!=tobL.end(); ++lIt)
 	  dynamic_cast<SimpleNavigableLayer*>(theAllNavigableLayer[(*lIt)->seqNum()])->theSelfSearch = true;
       }else{
 	SimpleNavigableLayer* navigableLayer = 
@@ -100,11 +100,11 @@ void CosmicNavigationSchool::build(const GeometricSearchTracker* theInputTracker
 	navigableLayer->theSelfSearch = true;
       }
     }
-    const std::vector< BarrelDetLayer * > &  tibL = theInputTracker->tibLayers();
+    const std::vector< const BarrelDetLayer * > &  tibL = theInputTracker->tibLayers();
     if (tibL.size()>=1){
       if (conf.allSelf){
 	LogDebug("CosmicNavigationSchool")<<" adding all TIB self search.";
-	for (std::vector< BarrelDetLayer * >::const_iterator lIt = tibL.begin(); lIt!=tibL.end(); ++lIt)
+	for (auto lIt = tibL.begin(); lIt!=tibL.end(); ++lIt)
 	  dynamic_cast<SimpleNavigableLayer*>(theAllNavigableLayer[(*lIt)->seqNum()])->theSelfSearch = true;
       }else{
 	SimpleNavigableLayer* navigableLayer = 
@@ -113,11 +113,11 @@ void CosmicNavigationSchool::build(const GeometricSearchTracker* theInputTracker
 	navigableLayer->theSelfSearch = true;
       }
     }
-    const std::vector< BarrelDetLayer * > &  pxbL = theInputTracker->pixelBarrelLayers();
+    const std::vector< const BarrelDetLayer * > &  pxbL = theInputTracker->pixelBarrelLayers();
     if (pxbL.size()>=1){
       if (conf.allSelf){
 	LogDebug("CosmicNavigationSchool")<<" adding all PXB self search.";
-        for (std::vector< BarrelDetLayer * >::const_iterator lIt = pxbL.begin(); lIt!=pxbL.end(); ++lIt)
+        for (auto lIt = pxbL.begin(); lIt!=pxbL.end(); ++lIt)
           dynamic_cast<SimpleNavigableLayer*>(theAllNavigableLayer[(*lIt)->seqNum()])->theSelfSearch = true;
       }else{
 	SimpleNavigableLayer* navigableLayer =
@@ -175,8 +175,8 @@ void CosmicNavigationSchool::establishInverseRelations(SymmetricLayerFinder& sym
 
     // find for each layer which are the barrel and forward
     // layers that point to it
-    typedef map<const DetLayer*, vector<BarrelDetLayer*>, less<const DetLayer*> > BarrelMapType;
-    typedef map<const DetLayer*, vector<ForwardDetLayer*>, less<const DetLayer*> > ForwardMapType;
+    typedef map<const DetLayer*, vector<const BarrelDetLayer*>, less<const DetLayer*> > BarrelMapType;
+    typedef map<const DetLayer*, vector<const ForwardDetLayer*>, less<const DetLayer*> > ForwardMapType;
 
 
     BarrelMapType reachedBarrelLayersMap;

--- a/RecoTracker/TkNavigation/src/SimpleBarrelNavigableLayer.cc
+++ b/RecoTracker/TkNavigation/src/SimpleBarrelNavigableLayer.cc
@@ -20,7 +20,7 @@ using namespace std;
 
 
 SimpleBarrelNavigableLayer::
-SimpleBarrelNavigableLayer( BarrelDetLayer* detLayer,
+SimpleBarrelNavigableLayer( const BarrelDetLayer* detLayer,
 			    const BDLC& outerBLC, 
 			    const FDLC& outerLeftFL, 
 			    const FDLC& outerRightFL,
@@ -189,7 +189,7 @@ SimpleBarrelNavigableLayer::compatibleLayers( NavigationDirection dir) const {
 
 
 
-void   SimpleBarrelNavigableLayer::setDetLayer( DetLayer* dl) {
+void   SimpleBarrelNavigableLayer::setDetLayer( const DetLayer* dl) {
   cerr << "Warniong: SimpleBarrelNavigableLayer::setDetLayer called."
        << endl << "This should never happen!" << endl;
 }
@@ -236,9 +236,9 @@ void SimpleBarrelNavigableLayer::setInwardLinks(const BDLC& theBarrelv,
 
 }
 
-void SimpleBarrelNavigableLayer::setAdditionalLink(DetLayer* additional, NavigationDirection direction){
-  ForwardDetLayer* fadditional = dynamic_cast<ForwardDetLayer*>(additional);
-  BarrelDetLayer*  badditional = dynamic_cast<BarrelDetLayer*>(additional);
+void SimpleBarrelNavigableLayer::setAdditionalLink(const DetLayer* additional, NavigationDirection direction){
+  const ForwardDetLayer* fadditional = dynamic_cast<const ForwardDetLayer*>(additional);
+  const BarrelDetLayer*  badditional = dynamic_cast<const BarrelDetLayer*>(additional);
   if (badditional){	
   	if (direction==insideOut){
 		theOuterBarrelLayers.push_back(badditional);

--- a/RecoTracker/TkNavigation/src/SimpleForwardNavigableLayer.cc
+++ b/RecoTracker/TkNavigation/src/SimpleForwardNavigableLayer.cc
@@ -14,7 +14,7 @@
 using namespace std;
 
 SimpleForwardNavigableLayer::
-SimpleForwardNavigableLayer( ForwardDetLayer* detLayer,
+SimpleForwardNavigableLayer( const ForwardDetLayer* detLayer,
 			     const BDLC& outerBL, 
 			     const FDLC& outerFL, 
 			     const MagneticField* field,
@@ -121,7 +121,7 @@ SimpleForwardNavigableLayer::compatibleLayers( NavigationDirection dir) const {
 }
 
 
-void SimpleForwardNavigableLayer::setDetLayer( DetLayer* dl) {
+void SimpleForwardNavigableLayer::setDetLayer( const DetLayer* dl) {
   cerr << "Warning: SimpleForwardNavigableLayer::setDetLayer called."
        << endl << "This should never happen!" << endl;
 }
@@ -147,9 +147,9 @@ void SimpleForwardNavigableLayer::setInwardLinks(const BDLC& innerBL,
 
 }
 
-void SimpleForwardNavigableLayer::setAdditionalLink(DetLayer* additional, NavigationDirection direction){
-  ForwardDetLayer* fadditional = dynamic_cast<ForwardDetLayer*>(additional);
-  BarrelDetLayer*  badditional = dynamic_cast<BarrelDetLayer*>(additional);
+void SimpleForwardNavigableLayer::setAdditionalLink(const DetLayer* additional, NavigationDirection direction){
+  const ForwardDetLayer* fadditional = dynamic_cast<const ForwardDetLayer*>(additional);
+  const BarrelDetLayer*  badditional = dynamic_cast<const BarrelDetLayer*>(additional);
   if (badditional){
         if (direction==insideOut){
 	  theOuterBarrelLayers.push_back(badditional);

--- a/RecoTracker/TkNavigation/src/SimpleNavigationSchool.cc
+++ b/RecoTracker/TkNavigation/src/SimpleNavigationSchool.cc
@@ -36,15 +36,13 @@ SimpleNavigationSchool::SimpleNavigationSchool(const GeometricSearchTracker* the
 
 
   // Get barrel layers
-  vector<BarrelDetLayer*> blc = theTracker->barrelLayers(); 
-  for ( vector<BarrelDetLayer*>::iterator i = blc.begin(); i != blc.end(); i++) {
-    theBarrelLayers.push_back( (*i) );
+  for( auto i : theTracker->barrelLayers()) {
+    theBarrelLayers.push_back( i );
   }
 
   // get forward layers
-  vector<ForwardDetLayer*> flc = theTracker->forwardLayers(); 
-  for ( vector<ForwardDetLayer*>::iterator i = flc.begin(); i != flc.end(); i++) {
-    theForwardLayers.push_back( (*i) );
+  for( auto i : theTracker->forwardLayers()) {
+    theForwardLayers.push_back( i );
   }
   
   FDLI middle = find_if( theForwardLayers.begin(), theForwardLayers.end(),
@@ -118,7 +116,7 @@ linkBarrelLayers( SymmetricLayerFinder& symFinder)
   }
 }
 
-void SimpleNavigationSchool::linkNextForwardLayer( BarrelDetLayer* bl, 
+void SimpleNavigationSchool::linkNextForwardLayer( const BarrelDetLayer* bl, 
 						   FDLC& rightFL)
 {
   // find first forward layer with larger Z and larger outer radius
@@ -209,7 +207,7 @@ linkForwardLayers( SymmetricLayerFinder& symFinder)
 //    }
 }
 
-void SimpleNavigationSchool::linkNextBarrelLayer( ForwardDetLayer* fl,
+void SimpleNavigationSchool::linkNextBarrelLayer( const ForwardDetLayer* fl,
 						  BDLC& reachableBL)
 {
   if ( fl->position().z() > barrelLength()) return;
@@ -259,7 +257,7 @@ void SimpleNavigationSchool::linkNextLayerInGroup( FDLI fli,
 }
 
 
-void SimpleNavigationSchool::linkOuterGroup( ForwardDetLayer* fl,
+void SimpleNavigationSchool::linkOuterGroup( const ForwardDetLayer* fl,
 					     const FDLC& group,
 					     FDLC& reachableFL)
 {
@@ -369,8 +367,8 @@ void SimpleNavigationSchool::establishInverseRelations() {
 
     // find for each layer which are the barrel and forward
     // layers that point to it
-    typedef map<const DetLayer*, vector<BarrelDetLayer*>, less<const DetLayer*> > BarrelMapType;
-    typedef map<const DetLayer*, vector<ForwardDetLayer*>, less<const DetLayer*> > ForwardMapType;
+    typedef map<const DetLayer*, vector<const BarrelDetLayer*>, less<const DetLayer*> > BarrelMapType;
+    typedef map<const DetLayer*, vector<const ForwardDetLayer*>, less<const DetLayer*> > ForwardMapType;
 
 
     BarrelMapType reachedBarrelLayersMap;

--- a/RecoTracker/TkNavigation/src/StartingLayerFinder.cc
+++ b/RecoTracker/TkNavigation/src/StartingLayerFinder.cc
@@ -50,34 +50,30 @@ StartingLayerFinder::startingLayers(const FTS& aFts, float dr, float dz) const {
 
   //negative fwd pixel
 
-  const vector<ForwardDetLayer*> nfwd = firstPosPixelFwdLayer();
-  for(vector<ForwardDetLayer*>::const_iterator infwd = nfwd.begin();
-      infwd != nfwd.end(); infwd++) {
-    pTsos = propagator()->propagate(fastFts, (*infwd)->surface());  
+  for(auto infwd : firstPosPixelFwdLayer() ) {
+    pTsos = propagator()->propagate(fastFts, infwd->surface());  
     if(pTsos.isValid()) {
-      Range nfwdRRange((*infwd)->specificSurface().innerRadius(),
-		       (*infwd)->specificSurface().outerRadius());
+      Range nfwdRRange(infwd->specificSurface().innerRadius(),
+		       infwd->specificSurface().outerRadius());
       Range trajRRange(pTsos.globalPosition().perp() - dr,
 		       pTsos.globalPosition().perp() + dr);
       if(rangesIntersect(trajRRange, nfwdRRange)) {
-	mylayers.push_back(*infwd);
+	mylayers.push_back(infwd);
 
       }
     }
   }
 
   //positive fwd pixel
-  const vector<ForwardDetLayer*> pfwd = firstPosPixelFwdLayer();
-  for(vector<ForwardDetLayer*>::const_iterator ipfwd = pfwd.begin();
-      ipfwd != pfwd.end(); ipfwd++) {
-    pTsos = propagator()->propagate(fastFts, (*ipfwd)->surface());
+  for(auto ipfwd: firstPosPixelFwdLayer()) {
+    pTsos = propagator()->propagate(fastFts, ipfwd->surface());
     if(pTsos.isValid()) {
-      Range pfwdRRange((*ipfwd)->specificSurface().innerRadius(),
-		       (*ipfwd)->specificSurface().outerRadius());
+      Range pfwdRRange(ipfwd->specificSurface().innerRadius(),
+		       ipfwd->specificSurface().outerRadius());
       Range trajRRange(pTsos.globalPosition().perp() - dr,
 		       pTsos.globalPosition().perp() + dr);
       if(rangesIntersect(trajRRange, pfwdRRange)) {
-	mylayers.push_back(*ipfwd);
+	mylayers.push_back(ipfwd);
 
       }
     }
@@ -146,12 +142,12 @@ const BarrelDetLayer* StartingLayerFinder::firstPixelBarrelLayer() const {
   return theFirstPixelBarrelLayer;  
 }
 
-const vector<ForwardDetLayer*> StartingLayerFinder::firstNegPixelFwdLayer() const {
+const vector<const ForwardDetLayer*> StartingLayerFinder::firstNegPixelFwdLayer() const {
   checkPixelLayers();
   return theFirstNegPixelFwdLayer;
 }
 
-const vector<ForwardDetLayer*>  StartingLayerFinder::firstPosPixelFwdLayer() const {
+const vector<const ForwardDetLayer*>  StartingLayerFinder::firstPosPixelFwdLayer() const {
   checkPixelLayers();
   return theFirstPosPixelFwdLayer;
 }

--- a/RecoTracker/TkNavigation/src/SymmetricLayerFinder.cc
+++ b/RecoTracker/TkNavigation/src/SymmetricLayerFinder.cc
@@ -40,7 +40,7 @@ SymmetricLayerFinder::SymmetricLayerFinder( const FDLC& flc)
   vector<PairType> foundPairs;
 
   for ( FDLI i = leftLayers.begin(); i != leftLayers.end(); i++) {
-    ForwardDetLayer* partner = mirrorPartner( *i, rightLayers);
+   const  ForwardDetLayer* partner = mirrorPartner( *i, rightLayers);
     //if ( partner == 0) throw DetLogicError("Assymmetric forward layers in Tracker");
     if ( partner == 0) throw cms::Exception("SymmetricLayerFinder", "Assymmetric forward layers in Tracker");
 
@@ -55,7 +55,7 @@ SymmetricLayerFinder::SymmetricLayerFinder( const FDLC& flc)
   }
 }
 
-ForwardDetLayer* SymmetricLayerFinder::mirrorPartner( const ForwardDetLayer* layer,
+const ForwardDetLayer* SymmetricLayerFinder::mirrorPartner( const ForwardDetLayer* layer,
 						      const FDLC& rightLayers)
 {
   ConstFDLI result =

--- a/RecoTracker/TkSeedingLayers/src/SeedingLayerSetsBuilder.cc
+++ b/RecoTracker/TkSeedingLayers/src/SeedingLayerSetsBuilder.cc
@@ -275,17 +275,17 @@ void SeedingLayerSetsBuilder::updateEventSetup(const edm::EventSetup& es) {
   es.get<TrackerRecoGeometryRecord>().get( htracker );
   const GeometricSearchTracker& tracker = *htracker;
 
-  const std::vector<BarrelDetLayer*>&  bpx  = tracker.barrelLayers();
-  const std::vector<BarrelDetLayer*>&  tib  = tracker.tibLayers();
-  const std::vector<BarrelDetLayer*>&  tob  = tracker.tobLayers();
+  const std::vector<BarrelDetLayer const*>&  bpx  = tracker.barrelLayers();
+  const std::vector<BarrelDetLayer const*>&  tib  = tracker.tibLayers();
+  const std::vector<BarrelDetLayer const*>&  tob  = tracker.tobLayers();
 
-  const std::vector<ForwardDetLayer*>& fpx_pos = tracker.posForwardLayers();
-  const std::vector<ForwardDetLayer*>& tid_pos = tracker.posTidLayers();
-  const std::vector<ForwardDetLayer*>& tec_pos = tracker.posTecLayers();
+  const std::vector<ForwardDetLayer const*>& fpx_pos = tracker.posForwardLayers();
+  const std::vector<ForwardDetLayer const*>& tid_pos = tracker.posTidLayers();
+  const std::vector<ForwardDetLayer const*>& tec_pos = tracker.posTecLayers();
 
-  const std::vector<ForwardDetLayer*>& fpx_neg = tracker.negForwardLayers();
-  const std::vector<ForwardDetLayer*>& tid_neg = tracker.negTidLayers();
-  const std::vector<ForwardDetLayer*>& tec_neg = tracker.negTecLayers();
+  const std::vector<ForwardDetLayer const*>& fpx_neg = tracker.negForwardLayers();
+  const std::vector<ForwardDetLayer const*>& tid_neg = tracker.negTidLayers();
+  const std::vector<ForwardDetLayer const*>& tec_neg = tracker.negTecLayers();
 
   for(size_t i=0, n=theLayers.size(); i<n; ++i) {
     const LayerSpec& layer = theLayers[i];

--- a/TrackingTools/DetLayers/interface/NavigableLayer.h
+++ b/TrackingTools/DetLayers/interface/NavigableLayer.h
@@ -49,8 +49,8 @@ public:
     return  std::vector<const DetLayer*>() ;
   }
 
-  virtual DetLayer* detLayer() const = 0;
-  virtual void   setDetLayer( DetLayer* dl) = 0;
+  virtual DetLayer const* detLayer() const = 0;
+  virtual void   setDetLayer( DetLayer const* dl) = 0;
 
   void setSchool(NavigationSchool const * sh) {school = sh;}
 

--- a/TrackingTools/DetLayers/interface/NavigationSchool.h
+++ b/TrackingTools/DetLayers/interface/NavigationSchool.h
@@ -71,9 +71,9 @@ protected:
 
   // will be obsoleted together with NAvigationSetter
 public:
-  const std::vector<DetLayer*> & allLayersInSystem() const {return *theAllDetLayersInSystem;}
+  const std::vector<const DetLayer*> & allLayersInSystem() const {return *theAllDetLayersInSystem;}
  protected:
-  const std::vector<DetLayer*> * theAllDetLayersInSystem;
+  const std::vector<const DetLayer*> * theAllDetLayersInSystem;
 };
 
 #endif // NavigationSchool_H


### PR DESCRIPTION
Modified the interface to GeometricSearchTracker to only give const access to the underlying geometry objects. This allows us to guarantee proper thread-safe interactions with the class. 
All clients of GeometricSearchTracker were updated to be compatible with the new interface.
