### PR TITLE
Make QuickTrackAssociatorByHits thread safe

### DIFF
--- a/SimTracker/TrackAssociation/interface/QuickTrackAssociatorByHits.h
+++ b/SimTracker/TrackAssociation/interface/QuickTrackAssociatorByHits.h
@@ -54,51 +54,53 @@ class TrackerHitAssociator;
  *
  * @author Mark Grimes (mark.grimes@cern.ch)
  * @date 09/Nov/2010
- * Significant changes to remove any differences to the standard TrackAssociatorByHits results 07/Jul/2011
+ * Significant changes to remove any differences to the standard TrackAssociatorByHits results 07/Jul/2011.
+ * Association for TrajectorySeeds added by Giuseppe Cerati sometime between 2011 and 2013.
+ * Functionality to associate using pre calculated cluster to TrackingParticle maps added by Subir Sarker sometime in 2013.
+ * Overhauled to remove mutables to make it thread safe by Mark Grimes 01/May/2014.
  */
 class QuickTrackAssociatorByHits : public TrackAssociatorBase
 {
 public:
 	QuickTrackAssociatorByHits( const edm::ParameterSet& config );
 	~QuickTrackAssociatorByHits();
-        virtual
+	virtual
 	reco::RecoToSimCollection associateRecoToSim( edm::Handle<edm::View<reco::Track> >& trackCollectionHandle,
 	                                              edm::Handle<TrackingParticleCollection>& trackingParticleCollectionHandle,
 	                                              const edm::Event* pEvent=0,
 	                                              const edm::EventSetup* pSetup=0 ) const override;
-        virtual
+	virtual
 	reco::SimToRecoCollection associateSimToReco( edm::Handle<edm::View<reco::Track> >& trackCollectionHandle,
 	                                              edm::Handle<TrackingParticleCollection>& trackingParticleCollectionHandle,
 	                                              const edm::Event* pEvent=0,
 	                                              const edm::EventSetup* pSetup=0 ) const override;
-        virtual
+	virtual
 	reco::RecoToSimCollection associateRecoToSim( const edm::RefToBaseVector<reco::Track>& trackCollection,
 												  const edm::RefVector<TrackingParticleCollection>& trackingParticleCollection,
 												  const edm::Event* pEvent=0,
 												  const edm::EventSetup* pSetup=0 ) const override;
-        virtual
+	virtual
 	reco::SimToRecoCollection associateSimToReco( const edm::RefToBaseVector<reco::Track>& trackCollection,
 												  const edm::RefVector<TrackingParticleCollection>& trackingParticleCollection,
 												  const edm::Event* pEvent=0,
 												  const edm::EventSetup* pSetup=0 ) const override;
 
 	//seed
-        virtual
+	virtual
 	reco::RecoToSimCollectionSeed associateRecoToSim(edm::Handle<edm::View<TrajectorySeed> >&,
 							 edm::Handle<TrackingParticleCollection>&,
 							 const edm::Event * event ,
 							 const edm::EventSetup * setup ) const override;
 	
-        virtual
+	virtual
 	reco::SimToRecoCollectionSeed associateSimToReco(edm::Handle<edm::View<TrajectorySeed> >&,
 							 edm::Handle<TrackingParticleCollection>&,
 							 const edm::Event * event ,
 							 const edm::EventSetup * setup ) const override;
 
-        void prepareCluster2TPMap(const edm::Event* pEvent) const;
 
 private:
-	typedef std::pair<uint32_t,EncodedEventId> SimTrackIdentifiers;
+	typedef std::pair<uint32_t,EncodedEventId> SimTrackIdentifiers; ///< @brief This is enough information to uniquely identify a sim track
 	enum SimToRecoDenomType {denomnone,denomsim,denomreco};
 
 	// - added by S. Sarkar
@@ -107,14 +109,22 @@ private:
 	static bool tpIntPairGreater(std::pair<edm::Ref<TrackingParticleCollection>,size_t> i, std::pair<edm::Ref<TrackingParticleCollection>,size_t> j) { return (i.first.key()>j.first.key()); }
 
 	/** @brief The method that does the work for both overloads of associateRecoToSim.
+	 *
+	 * Parts that actually rely on the type of the collections are delegated out to overloaded functions
+	 * in the unnamed namespace of the .cc file. Parts that rely on the type of T_hitOrClusterAssociator
+	 * are delegated out to overloaded methods.
 	 */
-	template<class T_TrackCollection, class T_TrackingParticleCollection>
-	reco::RecoToSimCollection associateRecoToSimImplementation( T_TrackCollection trackCollection, T_TrackingParticleCollection trackingParticleCollection, const edm::Event* pEvent ) const;
+	template<class T_TrackCollection, class T_TrackingParticleCollection, class T_hitOrClusterAssociator>
+	reco::RecoToSimCollection associateRecoToSimImplementation( T_TrackCollection trackCollection, T_TrackingParticleCollection trackingParticleCollection, T_hitOrClusterAssociator hitOrClusterAssociator ) const;
 
 	/** @brief The method that does the work for both overloads of associateSimToReco.
+	 *
+	 * Parts that actually rely on the type of the collections are delegated out to overloaded functions
+	 * in the unnamed namespace of the .cc file. Parts that rely on the type of T_hitOrClusterAssociator
+	 * are delegated out to overloaded methods.
 	 */
-	template<class T_TrackCollection, class T_TrackingParticleCollection>
-	reco::SimToRecoCollection associateSimToRecoImplementation( T_TrackCollection trackCollection, T_TrackingParticleCollection trackingParticleCollection, const edm::Event* pEvent ) const;
+	template<class T_TrackCollection, class T_TrackingParticleCollection, class T_hitOrClusterAssociator>
+	reco::SimToRecoCollection associateSimToRecoImplementation( T_TrackCollection trackCollection, T_TrackingParticleCollection trackingParticleCollection, T_hitOrClusterAssociator hitOrClusterAssociator ) const;
 
 
 	/** @brief Returns the TrackingParticle that has the most associated hits to the given track.
@@ -122,15 +132,28 @@ private:
 	 * Return value is a vector of pairs, where first is an edm::Ref to the associated TrackingParticle, and second is
 	 * the number of associated hits.
 	 */
-	template<typename T_TPCollection,typename iter> std::vector< std::pair<edm::Ref<TrackingParticleCollection>,size_t> > associateTrack( T_TPCollection trackingParticles, iter begin, iter end ) const;
-	template<typename iter> std::vector< std::pair<edm::Ref<TrackingParticleCollection>,size_t> > associateTrackByCluster( iter begin, iter end ) const;
+	template<typename T_TPCollection,typename iter> std::vector< std::pair<edm::Ref<TrackingParticleCollection>,size_t> > associateTrack( const TrackerHitAssociator& hitAssociator, T_TPCollection trackingParticles, iter begin, iter end ) const;
+	/** @brief Returns the TrackingParticle that has the most associated hits to the given track.
+	 *
+	 * See the notes for the other overload for the return type.
+	 *
+	 * Note that the trackingParticles parameter is not actually required since all the information is in clusterToTPMap,
+	 * but the method signature has to match the other overload because it is called from a templated method.
+	 */
+	template<typename T_TPCollection,typename iter> std::vector< std::pair<edm::Ref<TrackingParticleCollection>,size_t> > associateTrack( const ClusterTPAssociationList& clusterToTPMap, T_TPCollection trackingParticles, iter begin, iter end ) const;
 
 
 	/** @brief Returns true if the supplied TrackingParticle has the supplied g4 track identifiers. */
 	bool trackingParticleContainsIdentifier( const TrackingParticle* pTrackingParticle, const SimTrackIdentifiers& identifier ) const;
 
-	/** @brief This method was copied almost verbatim from the standard TrackAssociatorByHits. */
-	template<typename iter> int getDoubleCount( iter begin, iter end, TrackingParticleRef associatedTrackingParticle ) const;
+	/** @brief This method was copied almost verbatim from the standard TrackAssociatorByHits.
+	 *
+	 * Modified 01/May/2014 to take the TrackerHitAssociator as a parameter rather than using a member.
+	 */
+	template<typename iter> int getDoubleCount( const TrackerHitAssociator& hitAssociator, iter begin, iter end, TrackingParticleRef associatedTrackingParticle ) const;
+	/** @brief Overload for when using cluster to TrackingParticle association list.
+	 */
+	template<typename iter> int getDoubleCount( const ClusterTPAssociationList& clusterToTPList, iter begin, iter end, TrackingParticleRef associatedTrackingParticle ) const;
 
 	/** @brief Returns a vector of pairs where first is a SimTrackIdentifiers (see typedef above) and second is the number of hits that came from that sim track.
 	 *
@@ -138,9 +161,9 @@ private:
 	 * E.g. If all the hits in the reco track come from the same sim track, then there will only be one entry with second as the number of hits in
 	 * the track.
 	 */
-	template<typename iter> std::vector< std::pair<SimTrackIdentifiers,size_t> > getAllSimTrackIdentifiers( iter begin, iter end ) const;
+	template<typename iter> std::vector< std::pair<SimTrackIdentifiers,size_t> > getAllSimTrackIdentifiers( const TrackerHitAssociator& hitAssociator, iter begin, iter end ) const;
 
-        // Added by S. Sarkar
+	// Added by S. Sarkar
 	template<typename iter> std::vector< OmniClusterRef> getMatchedClusters( iter begin, iter end ) const;
 
 	const TrackingRecHit* getHitFromIter(trackingRecHit_iterator iter) const {
@@ -151,13 +174,20 @@ private:
 	  return &(*iter);
 	}
 
-	//
-	// Members. Note that there are custom copy constructor and assignment operators, so if any members are added
-	// those methods will need to be updated.
-	//
-	mutable TrackerHitAssociator* pHitAssociator_;
-	const mutable edm::Event* pEventForWhichAssociatorIsValid_;
-	void initialiseHitAssociator( const edm::Event* event ) const;
+	/** @brief creates either a ClusterTPAssociationList OR a TrackerHitAssociator and stores it in the provided unique_ptr. The other will be null.
+	 *
+	 * A decision is made whether to create a ClusterTPAssociationList or a TrackerHitAssociator depending on how this
+	 * track associator was configured. If the ClusterTPAssociationList couldn't be fetched from the event then it
+	 * falls back to creating a TrackerHitAssociator.
+	 *
+	 * Only one type will be created, never both. The other unique_ptr reference will be null so check for that
+	 * and decide which to use.
+	 *
+	 * N.B. The value of useClusterTPAssociation_ should not be used to decide which of the two pointers to use. If
+	 * the cluster to TrackingParticle couldn't be retrieved from the event then pClusterToTPMap will be null but
+	 * useClusterTPAssociation_ is no longer changed to false.
+	 */
+	void prepareEitherHitAssociatorOrClusterToTPMap( const edm::Event* pEvent, std::unique_ptr<ClusterTPAssociationList>& pClusterToTPMap, std::unique_ptr<TrackerHitAssociator>& pHitAssociator ) const;
 
 	edm::ParameterSet hitAssociatorParameters_;
 
@@ -168,10 +198,9 @@ private:
 	bool threeHitTracksAreSpecial_;
 	SimToRecoDenomType simToRecoDenominator_;
 
-        // Added by S. Sarkar
-        mutable bool useClusterTPAssociation_;
+	// Added by S. Sarkar
+	bool useClusterTPAssociation_;
 	edm::InputTag cluster2TPSrc_;
-	mutable ClusterTPAssociationList pCluster2TPList_;
 }; // end of the QuickTrackAssociatorByHits class
 
 #endif // end of ifndef QuickTrackAssociatorByHits_h

--- a/SimTracker/TrackAssociation/interface/QuickTrackAssociatorByHits.h
+++ b/SimTracker/TrackAssociation/interface/QuickTrackAssociatorByHits.h
@@ -61,8 +61,6 @@ class QuickTrackAssociatorByHits : public TrackAssociatorBase
 public:
 	QuickTrackAssociatorByHits( const edm::ParameterSet& config );
 	~QuickTrackAssociatorByHits();
-	QuickTrackAssociatorByHits( const QuickTrackAssociatorByHits& otherAssociator );
-	QuickTrackAssociatorByHits& operator=( const QuickTrackAssociatorByHits& otherAssociator );
         virtual
 	reco::RecoToSimCollection associateRecoToSim( edm::Handle<edm::View<reco::Track> >& trackCollectionHandle,
 	                                              edm::Handle<TrackingParticleCollection>& trackingParticleCollectionHandle,
@@ -110,18 +108,21 @@ private:
 
 	/** @brief The method that does the work for both overloads of associateRecoToSim.
 	 */
-	reco::RecoToSimCollection associateRecoToSimImplementation() const;
+	template<class T_TrackCollection, class T_TrackingParticleCollection>
+	reco::RecoToSimCollection associateRecoToSimImplementation( T_TrackCollection trackCollection, T_TrackingParticleCollection trackingParticleCollection, const edm::Event* pEvent ) const;
 
 	/** @brief The method that does the work for both overloads of associateSimToReco.
 	 */
-	reco::SimToRecoCollection associateSimToRecoImplementation() const;
+	template<class T_TrackCollection, class T_TrackingParticleCollection>
+	reco::SimToRecoCollection associateSimToRecoImplementation( T_TrackCollection trackCollection, T_TrackingParticleCollection trackingParticleCollection, const edm::Event* pEvent ) const;
+
 
 	/** @brief Returns the TrackingParticle that has the most associated hits to the given track.
 	 *
 	 * Return value is a vector of pairs, where first is an edm::Ref to the associated TrackingParticle, and second is
 	 * the number of associated hits.
 	 */
-	template<typename iter> std::vector< std::pair<edm::Ref<TrackingParticleCollection>,size_t> > associateTrack( iter begin, iter end ) const;
+	template<typename T_TPCollection,typename iter> std::vector< std::pair<edm::Ref<TrackingParticleCollection>,size_t> > associateTrack( T_TPCollection trackingParticles, iter begin, iter end ) const;
 	template<typename iter> std::vector< std::pair<edm::Ref<TrackingParticleCollection>,size_t> > associateTrackByCluster( iter begin, iter end ) const;
 
 
@@ -166,37 +167,6 @@ private:
 	double cutRecoToSim_;
 	bool threeHitTracksAreSpecial_;
 	SimToRecoDenomType simToRecoDenominator_;
-
-	/** @brief Pointer to the handle to the track collection.
-	 *
-	 * Only one of pTrackCollectionHandle_ or pTrackCollection_ will ever be non Null. This is so that both flavours of the
-	 * associateRecoToSim (one takes a Handle, the other a RefToBaseVector) can use the same associateRecoToSimImplementation
-	 * method and keep the logic for both in one place.  The old implementation for the handle flavour copied everything into
-	 * a new RefToBaseVector, wasting memory.  I tried to do something clever with templates but couldn't get it to work, so
-	 * the associateRecoToSimImplementation method checks which is non Null and uses that to get the tracks.
-	 */
-	mutable edm::Handle<edm::View<reco::Track> >* pTrackCollectionHandle_;
-
-	/** @brief Pointer to the track collection.
-	 *
-	 * Either this or pTrackCollectionHandle_ will be set, the other will be Null. See the comment on pTrackCollectionHandle_
-	 * for reasons why.
-	 */
-	mutable const edm::RefToBaseVector<reco::Track>* pTrackCollection_;
-
-	/** @brief Pointer to the TrackingParticle collection handle
-	 *
-	 * Either this or pTrackingParticleCollection_ will be set, the other will be Null. See the comment on pTrackCollectionHandle_
-	 * for reasons why.
-	 */
-	mutable edm::Handle<TrackingParticleCollection>* pTrackingParticleCollectionHandle_;
-
-	/** @brief Pointer to the TrackingParticle collection handle
-	 *
-	 * Either this or pTrackingParticleCollectionHandle_ will be set, the other will be Null. See the comment on pTrackCollectionHandle_
-	 * for reasons why.
-	 */
-	mutable const edm::RefVector<TrackingParticleCollection>* pTrackingParticleCollection_;
 
         // Added by S. Sarkar
         mutable bool useClusterTPAssociation_;

--- a/SimTracker/TrackAssociation/src/QuickTrackAssociatorByHits.cc
+++ b/SimTracker/TrackAssociation/src/QuickTrackAssociatorByHits.cc
@@ -99,38 +99,37 @@ QuickTrackAssociatorByHits::QuickTrackAssociatorByHits( const edm::ParameterSet&
 	// Check whether the denominator when working out the percentage of shared hits should
 	// be the number of simulated hits or the number of reconstructed hits.
 	//
-	std::string denominatorString=config.getParameter < std::string > ("SimToRecoDenominator");
-	if( denominatorString == "sim" ) simToRecoDenominator_=denomsim;
-	else if( denominatorString == "reco" ) simToRecoDenominator_=denomreco;
+	std::string denominatorString=config.getParameter<std::string>("SimToRecoDenominator");
+	if( denominatorString=="sim" ) simToRecoDenominator_=denomsim;
+	else if( denominatorString=="reco" ) simToRecoDenominator_=denomreco;
 	else throw cms::Exception( "QuickTrackAssociatorByHits" ) << "SimToRecoDenominator not specified as sim or reco";
 
 	//
 	// Set up the parameter set for the hit associator
 	//
-	hitAssociatorParameters_.addParameter<bool>( "associatePixel", config.getParameter<bool>( "associatePixel" ) );
-	hitAssociatorParameters_.addParameter<bool>( "associateStrip", config.getParameter<bool>( "associateStrip" ) );
+	hitAssociatorParameters_.addParameter<bool>( "associatePixel", config.getParameter<bool>("associatePixel") );
+	hitAssociatorParameters_.addParameter<bool>( "associateStrip", config.getParameter<bool>("associateStrip") );
 	// This is the important one, it stops the hit associator searching through the list of sim hits.
 	// I only want to use the hit associator methods that work on the hit IDs (i.e. the uint32_t trackId
 	// and the EncodedEventId eventId) so I'm not interested in matching that to the PSimHit objects.
-	hitAssociatorParameters_.addParameter<bool>( "associateRecoTracks", true );
+	hitAssociatorParameters_.addParameter<bool>("associateRecoTracks",true);
 
 	//
 	// Do some checks on whether UseGrouped or UseSplitting have been set. They're not used
 	// unlike the standard TrackAssociatorByHits so show a warning.
 	//
 	bool useGrouped, useSplitting;
-	if( config.exists( "UseGrouped" ) ) useGrouped=config.getParameter<bool>( "UseGrouped" );
+	if( config.exists("UseGrouped") ) useGrouped=config.getParameter<bool>("UseGrouped");
 	else useGrouped=true;
 
-	if( config.exists( "UseSplitting" ) ) useSplitting=config.getParameter<bool>( "UseSplitting" );
+	if( config.exists("UseSplitting") ) useSplitting=config.getParameter<bool>("UseSplitting");
 	else useSplitting=true;
 
 	// This associator works as though both UseGrouped and UseSplitting were set to true, so show a
 	// warning if this isn't the case.
 	if( !(useGrouped && useSplitting) )
 	{
-		edm::LogWarning( "QuickTrackAssociatorByHits" )
-				<< "UseGrouped and/or UseSplitting has been set to false, but this associator ignores that setting.";
+		edm::LogWarning("QuickTrackAssociatorByHits") << "UseGrouped and/or UseSplitting has been set to false, but this associator ignores that setting.";
 	}
 }
 
@@ -248,7 +247,7 @@ reco::SimToRecoCollection QuickTrackAssociatorByHits::associateSimToRecoImplemen
 
 	size_t collectionSize=::collectionSize(trackCollection); // Delegate away type specific part
 
-	for( size_t i=0; i < collectionSize; ++i )
+	for( size_t i=0; i<collectionSize; ++i )
 	{
 		const reco::Track* pTrack=::getTrackAt(trackCollection,i); // Get a normal pointer for ease of use. This part is type specific so delegate.
 
@@ -256,9 +255,8 @@ reco::SimToRecoCollection QuickTrackAssociatorByHits::associateSimToRecoImplemen
 		std::vector < std::pair<edm::Ref<TrackingParticleCollection>,size_t> > trackingParticleQualityPairs=associateTrack( hitOrClusterAssociator, trackingParticleCollection, pTrack->recHitsBegin(), pTrack->recHitsEnd() );
 
 		// int nt = 0;
-		for( std::vector<std::pair<edm::Ref<TrackingParticleCollection>,size_t> >::const_iterator iTrackingParticleQualityPair=
-				trackingParticleQualityPairs.begin(); iTrackingParticleQualityPair != trackingParticleQualityPairs.end();
-				++iTrackingParticleQualityPair )
+		for( std::vector< std::pair<edm::Ref<TrackingParticleCollection>,size_t> >::const_iterator iTrackingParticleQualityPair=trackingParticleQualityPairs.begin();
+				iTrackingParticleQualityPair!=trackingParticleQualityPairs.end(); ++iTrackingParticleQualityPair )
 		{
 			const edm::Ref<TrackingParticleCollection>& trackingParticleRef=iTrackingParticleQualityPair->first;
 			size_t numberOfSharedHits=iTrackingParticleQualityPair->second;
@@ -266,9 +264,9 @@ reco::SimToRecoCollection QuickTrackAssociatorByHits::associateSimToRecoImplemen
 			size_t numberOfSimulatedHits=0; // Set a few lines below, but only if required.
 
 			//std::cout << ">>> sim2reco. numberOfSharedHits = " << nt++ << ", " << numberOfSharedHits << std::endl;
-			if( numberOfSharedHits == 0 ) continue; // No point in continuing if there was no association
+			if( numberOfSharedHits==0 ) continue; // No point in continuing if there was no association
 
-			if( simToRecoDenominator_ == denomsim || (numberOfSharedHits < 3 && threeHitTracksAreSpecial_) ) // the numberOfSimulatedHits is not always required, so can skip counting in some circumstances
+			if( simToRecoDenominator_==denomsim || (numberOfSharedHits<3 && threeHitTracksAreSpecial_) ) // the numberOfSimulatedHits is not always required, so can skip counting in some circumstances
 			{
 				// Note that in the standard TrackAssociatorByHits, all of the hits in associatedTrackingParticleHits are checked for
 				// various things.  I'm not sure what these checks are for but they depend on the UseGrouping and UseSplitting settings.
@@ -278,21 +276,19 @@ reco::SimToRecoCollection QuickTrackAssociatorByHits::associateSimToRecoImplemen
 			}
 
 			//if electron subtract double counting
-			if( abs( trackingParticleRef->pdgId() ) == 11 && (trackingParticleRef->g4Track_end() - trackingParticleRef->g4Track_begin()) > 1 )
+			if (abs(trackingParticleRef->pdgId())==11 && (trackingParticleRef->g4Track_end() - trackingParticleRef->g4Track_begin()) > 1 )
 			{
-				numberOfSharedHits-=getDoubleCount( hitOrClusterAssociator, pTrack->recHitsBegin(), pTrack->recHitsEnd(), trackingParticleRef );
+				numberOfSharedHits -= getDoubleCount( hitOrClusterAssociator, pTrack->recHitsBegin(), pTrack->recHitsEnd(), trackingParticleRef );
 			}
 
-			double purity=static_cast<double>( numberOfSharedHits ) / static_cast<double>( numberOfValidTrackHits );
+			double purity=static_cast<double>(numberOfSharedHits)/static_cast<double>(numberOfValidTrackHits);
 			double quality;
-			if( absoluteNumberOfHits_ ) quality=static_cast<double>( numberOfSharedHits );
-			else if( simToRecoDenominator_ == denomsim && numberOfSimulatedHits != 0 ) quality=static_cast<double>( numberOfSharedHits )
-					/ static_cast<double>( numberOfSimulatedHits );
-			else if( simToRecoDenominator_ == denomreco && numberOfValidTrackHits != 0 ) quality=purity;
+			if( absoluteNumberOfHits_ ) quality=static_cast<double>(numberOfSharedHits);
+			else if( simToRecoDenominator_==denomsim && numberOfSimulatedHits != 0 ) quality=static_cast<double>(numberOfSharedHits)/static_cast<double>(numberOfSimulatedHits);
+			else if( simToRecoDenominator_==denomreco && numberOfValidTrackHits != 0 ) quality=purity;
 			else quality=0;
 
-			if( quality > qualitySimToReco_ && !(threeHitTracksAreSpecial_ && numberOfSimulatedHits == 3 && numberOfSharedHits < 3)
-					&& (absoluteNumberOfHits_ || (purity > puritySimToReco_)) )
+			if( quality>qualitySimToReco_ && !( threeHitTracksAreSpecial_ && numberOfSimulatedHits==3 && numberOfSharedHits<3 ) && ( absoluteNumberOfHits_ || (purity>puritySimToReco_) ) )
 			{
 				// Getting the RefToBase is dependent on the type of trackCollection, so delegate that to an overload.
 				returnValue.insert( trackingParticleRef, std::make_pair( ::getRefToTrackAt(trackCollection,i), quality ) );
@@ -306,34 +302,32 @@ reco::SimToRecoCollection QuickTrackAssociatorByHits::associateSimToRecoImplemen
 template<typename T_TPCollection,typename iter> std::vector<std::pair<edm::Ref<TrackingParticleCollection>,size_t> > QuickTrackAssociatorByHits::associateTrack( const TrackerHitAssociator& hitAssociator, T_TPCollection trackingParticles, iter begin, iter end ) const
 {
 	// The pairs in this vector have a Ref to the associated TrackingParticle as "first" and the number of associated hits as "second"
-	std::vector < std::pair<edm::Ref<TrackingParticleCollection>,size_t> > returnValue;
+	std::vector< std::pair<edm::Ref<TrackingParticleCollection>,size_t> > returnValue;
 
 	// The pairs in this vector have first as the sim track identifiers, and second the number of reco hits associated to that sim track.
 	// Most reco hits will probably have come from the same sim track, so the number of entries in this vector should be fewer than the
 	// number of reco hits.  The pair::second entries should add up to the total number of reco hits though.
-	std::vector < std::pair<SimTrackIdentifiers,size_t> > hitIdentifiers=getAllSimTrackIdentifiers( hitAssociator, begin, end );
+	std::vector< std::pair<SimTrackIdentifiers,size_t> > hitIdentifiers=getAllSimTrackIdentifiers( hitAssociator, begin, end );
 
 	// Loop over the TrackingParticles
 	size_t collectionSize=::collectionSize(trackingParticles);
 
-	for( size_t i=0; i < collectionSize; ++i )
+	for( size_t i=0; i<collectionSize; ++i )
 	{
 		const TrackingParticle* pTrackingParticle=getTrackingParticleAt( trackingParticles, i );
 
 		// Ignore TrackingParticles with no hits
-		if( pTrackingParticle->numberOfHits() == 0 ) continue;
+		if( pTrackingParticle->numberOfHits()==0 ) continue;
 
 		size_t numberOfAssociatedHits=0;
 		// Loop over all of the sim track identifiers and see if any of them are part of this TrackingParticle. If they are, add
 		// the number of reco hits associated to that sim track to the total number of associated hits.
-		for( std::vector<std::pair<SimTrackIdentifiers,size_t> >::const_iterator iIdentifierCountPair=hitIdentifiers.begin();
-				iIdentifierCountPair != hitIdentifiers.end(); ++iIdentifierCountPair )
+		for( std::vector< std::pair<SimTrackIdentifiers,size_t> >::const_iterator iIdentifierCountPair=hitIdentifiers.begin(); iIdentifierCountPair!=hitIdentifiers.end(); ++iIdentifierCountPair )
 		{
-			if( trackingParticleContainsIdentifier( pTrackingParticle, iIdentifierCountPair->first ) ) numberOfAssociatedHits+=
-					iIdentifierCountPair->second;
+			if( trackingParticleContainsIdentifier( pTrackingParticle, iIdentifierCountPair->first ) ) numberOfAssociatedHits+=iIdentifierCountPair->second;
 		}
 
-		if( numberOfAssociatedHits > 0 )
+		if( numberOfAssociatedHits>0 )
 		{
 			returnValue.push_back( std::make_pair( getRefToTrackingParticleAt(trackingParticles,i), numberOfAssociatedHits ) );
 		}
@@ -433,60 +427,53 @@ template<typename T_TPCollection,typename iter> std::vector< std::pair<edm::Ref<
 	return returnValue;
 }
 
-template<typename iter> std::vector<OmniClusterRef> QuickTrackAssociatorByHits::getMatchedClusters( iter begin, iter end ) const
+template<typename iter> std::vector<OmniClusterRef> QuickTrackAssociatorByHits::getMatchedClusters(iter begin, iter end) const
 {
-	std::vector < OmniClusterRef > returnValue;
-	for( iter iRecHit=begin; iRecHit != end; ++iRecHit )
-	{
-		const TrackingRecHit* rhit=getHitFromIter( iRecHit );
-		if( rhit->isValid() )
-		{
-			int subdetid=rhit->geographicalId().subdetId();
-			if( subdetid == PixelSubdetector::PixelBarrel || subdetid == PixelSubdetector::PixelEndcap )
-			{
-				const SiPixelRecHit* pRHit=dynamic_cast<const SiPixelRecHit*>( rhit );
-				if( !pRHit->cluster().isNonnull() ) edm::LogError( "TrackAssociator" ) << ">>> RecHit does not have an associated cluster!" << " file: " << __FILE__ << " line: " << __LINE__;
-				returnValue.push_back( pRHit->omniClusterRef() );
+	std::vector<OmniClusterRef> returnValue;
+	for (iter iRecHit = begin; iRecHit != end; ++iRecHit) {
+		const TrackingRecHit* rhit = getHitFromIter(iRecHit);
+		if (rhit->isValid()) {
+			int subdetid = rhit->geographicalId().subdetId();
+			if (subdetid==PixelSubdetector::PixelBarrel||subdetid==PixelSubdetector::PixelEndcap) {
+				const SiPixelRecHit* pRHit = dynamic_cast<const SiPixelRecHit*>(rhit);
+				if (!pRHit->cluster().isNonnull())
+					edm::LogError("TrackAssociator") << ">>> RecHit does not have an associated cluster!" << " file: " << __FILE__ << " line: " << __LINE__;
+				returnValue.push_back(pRHit->omniClusterRef());
 			}
-			else if( subdetid == SiStripDetId::TIB || subdetid == SiStripDetId::TOB || subdetid == SiStripDetId::TID
-					|| subdetid == SiStripDetId::TEC )
-			{
-				const std::type_info &tid=typeid( *rhit);
-				if( tid == typeid(SiStripMatchedRecHit2D) )
-				{
-					const SiStripMatchedRecHit2D* sMatchedRHit=dynamic_cast<const SiStripMatchedRecHit2D*>( rhit );
-					if( !sMatchedRHit->monoHit().cluster().isNonnull() || !sMatchedRHit->stereoHit().cluster().isNonnull() ) edm::LogError( "TrackAssociator" ) << ">>> RecHit does not have an associated cluster!" << " file: " << __FILE__ << " line: " << __LINE__;
-					returnValue.push_back( sMatchedRHit->monoClusterRef() );
-					returnValue.push_back( sMatchedRHit->stereoClusterRef() );
+			else if (subdetid==SiStripDetId::TIB||subdetid==SiStripDetId::TOB||subdetid==SiStripDetId::TID||subdetid==SiStripDetId::TEC) {
+				const std::type_info &tid = typeid(*rhit);
+				if (tid == typeid(SiStripMatchedRecHit2D)) {
+					const SiStripMatchedRecHit2D* sMatchedRHit = dynamic_cast<const SiStripMatchedRecHit2D*>(rhit);
+					if (!sMatchedRHit->monoHit().cluster().isNonnull() || !sMatchedRHit->stereoHit().cluster().isNonnull())
+						edm::LogError("TrackAssociator") << ">>> RecHit does not have an associated cluster!" << " file: " << __FILE__ << " line: " << __LINE__;
+					returnValue.push_back(sMatchedRHit->monoClusterRef());
+					returnValue.push_back(sMatchedRHit->stereoClusterRef());
 				}
-				else if( tid == typeid(SiStripRecHit2D) )
-				{
-					const SiStripRecHit2D* sRHit=dynamic_cast<const SiStripRecHit2D*>( rhit );
-					if( !sRHit->cluster().isNonnull() ) edm::LogError( "TrackAssociator" ) << ">>> RecHit does not have an associated cluster!" << " file: " << __FILE__ << " line: " << __LINE__;
-					returnValue.push_back( sRHit->omniClusterRef() );
+				else if (tid == typeid(SiStripRecHit2D)) {
+					const SiStripRecHit2D* sRHit = dynamic_cast<const SiStripRecHit2D*>(rhit);
+					if (!sRHit->cluster().isNonnull())
+						edm::LogError("TrackAssociator") << ">>> RecHit does not have an associated cluster!" << " file: " << __FILE__ << " line: " << __LINE__;
+					returnValue.push_back(sRHit->omniClusterRef());
 				}
-				else if( tid == typeid(SiStripRecHit1D) )
-				{
-					const SiStripRecHit1D* sRHit=dynamic_cast<const SiStripRecHit1D*>( rhit );
-					if( !sRHit->cluster().isNonnull() ) edm::LogError( "TrackAssociator" ) << ">>> RecHit does not have an associated cluster!" << " file: " << __FILE__ << " line: " << __LINE__;
-					returnValue.push_back( sRHit->omniClusterRef() );
+				else if (tid == typeid(SiStripRecHit1D)) {
+					const SiStripRecHit1D* sRHit = dynamic_cast<const SiStripRecHit1D*>(rhit);
+					if (!sRHit->cluster().isNonnull())
+						edm::LogError("TrackAssociator") << ">>> RecHit does not have an associated cluster!" << " file: " << __FILE__ << " line: " << __LINE__;
+					returnValue.push_back(sRHit->omniClusterRef());
 				}
-				else
-				{
-					edm::LogError( "TrackAssociator" ) << ">>> getMatchedClusters: TrackingRecHit not associated to any SiStripCluster! subdetid = "
-							<< subdetid;
+				else {
+					edm::LogError("TrackAssociator") << ">>> getMatchedClusters: TrackingRecHit not associated to any SiStripCluster! subdetid = " << subdetid;
 				}
 			}
-			else
-			{
-				edm::LogError( "TrackAssociator" ) << ">>> getMatchedClusters: TrackingRecHit not associated to any cluster! subdetid = " << subdetid;
+			else {
+				edm::LogError("TrackAssociator") << ">>> getMatchedClusters: TrackingRecHit not associated to any cluster! subdetid = " << subdetid;
 			}
 		}
 	}
 	return returnValue;
 }
 
-template<typename iter> std::vector<std::pair<QuickTrackAssociatorByHits::SimTrackIdentifiers,size_t> > QuickTrackAssociatorByHits::getAllSimTrackIdentifiers( const TrackerHitAssociator& hitAssociator, iter begin, iter end ) const
+template<typename iter> std::vector< std::pair<QuickTrackAssociatorByHits::SimTrackIdentifiers,size_t> > QuickTrackAssociatorByHits::getAllSimTrackIdentifiers( const TrackerHitAssociator& hitAssociator, iter begin, iter end ) const
 {
 	// The pairs in this vector have first as the sim track identifiers, and second the number of reco hits associated to that sim track.
 	std::vector < std::pair<SimTrackIdentifiers,size_t> > returnValue;
@@ -755,7 +742,7 @@ reco::SimToRecoCollectionSeed QuickTrackAssociatorByHits::associateSimToReco( ed
 	}
 	return returnValue;
 
-	LogTrace( "TrackAssociator" ) << "% of Assoc TPs=" << ((double)returnValue.size()) / ((double)trackingParticleCollectionHandle->size());
+	LogTrace("TrackAssociator") << "% of Assoc TPs=" << ((double)returnValue.size())/((double)trackingParticleCollectionHandle->size());
 	returnValue.post_insert();
 	return returnValue;
 }

--- a/SimTracker/TrackAssociation/src/QuickTrackAssociatorByHits.cc
+++ b/SimTracker/TrackAssociation/src/QuickTrackAssociatorByHits.cc
@@ -14,51 +14,114 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DataFormats/Math/interface/deltaR.h"
 
-QuickTrackAssociatorByHits::QuickTrackAssociatorByHits( const edm::ParameterSet& config )
-	: pHitAssociator_(nullptr), pEventForWhichAssociatorIsValid_(nullptr),
-	  absoluteNumberOfHits_( config.getParameter<bool>( "AbsoluteNumberOfHits" ) ),
-	  qualitySimToReco_( config.getParameter<double>( "Quality_SimToReco" ) ),
-	  puritySimToReco_( config.getParameter<double>( "Purity_SimToReco" ) ),
-	  cutRecoToSim_( config.getParameter<double>( "Cut_RecoToSim" ) ),
-	  threeHitTracksAreSpecial_( config.getParameter<bool> ( "ThreeHitTracksAreSpecial" ) ),
-          useClusterTPAssociation_(config.getParameter<bool>("useClusterTPAssociation")),
-          cluster2TPSrc_(config.getParameter<edm::InputTag>("cluster2TPSrc"))
+//
+// Use the unnamed namespace for utility functions only used in this file
+//
+namespace
+{
+	template<class T_element>
+	size_t collectionSize( const edm::RefToBaseVector<T_element>& trackCollection )
+	{
+		return trackCollection.size();
+	}
+
+	template<class T_element>
+	size_t collectionSize( const edm::Handle<T_element>& pTrackCollection )
+	{
+		return pTrackCollection->size();
+	}
+
+	template<class T_element>
+	size_t collectionSize( const edm::RefVector<T_element>& trackCollection )
+	{
+		return trackCollection.size();
+	}
+
+	const reco::Track* getTrackAt( const edm::RefToBaseVector<reco::Track>& trackCollection, size_t index )
+	{
+		return &*trackCollection[index]; // pretty obscure dereference
+	}
+
+	const reco::Track* getTrackAt( const edm::Handle<edm::View<reco::Track> >& pTrackCollection, size_t index )
+	{
+		return &(*pTrackCollection.product())[index];
+	}
+
+	const TrackingParticle* getTrackingParticleAt( const edm::Handle<TrackingParticleCollection>& pCollection, size_t index )
+	{
+		return &(*pCollection.product())[index];
+	}
+
+	const TrackingParticle* getTrackingParticleAt( const edm::RefVector<TrackingParticleCollection>& collection, size_t index )
+	{
+		return &*collection[index];
+	}
+
+	edm::RefToBase<reco::Track> getRefToTrackAt( const edm::RefToBaseVector<reco::Track>& trackCollection, size_t index )
+	{
+		return trackCollection[index];
+	}
+
+	edm::RefToBase<reco::Track> getRefToTrackAt( const edm::Handle<edm::View<reco::Track> >& pTrackCollection, size_t index )
+	{
+		return edm::RefToBase<reco::Track>( pTrackCollection, index );
+	}
+
+	edm::Ref<TrackingParticleCollection> getRefToTrackingParticleAt( const edm::Handle<TrackingParticleCollection>& pCollection, size_t index )
+	{
+		return edm::Ref<TrackingParticleCollection>( pCollection, index );
+	}
+
+	edm::Ref<TrackingParticleCollection> getRefToTrackingParticleAt( const edm::RefVector<TrackingParticleCollection>& collection, size_t index )
+	{
+		return collection[index];
+	}
+
+} // end of the unnamed namespace
+
+
+QuickTrackAssociatorByHits::QuickTrackAssociatorByHits( const edm::ParameterSet& config ) :
+		pHitAssociator_( nullptr ), pEventForWhichAssociatorIsValid_( nullptr ), absoluteNumberOfHits_( config.getParameter<bool>( "AbsoluteNumberOfHits" ) ), qualitySimToReco_( config.getParameter<
+				double>( "Quality_SimToReco" ) ), puritySimToReco_( config.getParameter<double>( "Purity_SimToReco" ) ), cutRecoToSim_( config.getParameter<
+				double>( "Cut_RecoToSim" ) ), threeHitTracksAreSpecial_( config.getParameter<bool>( "ThreeHitTracksAreSpecial" ) ), useClusterTPAssociation_( config.getParameter<
+				bool>( "useClusterTPAssociation" ) ), cluster2TPSrc_( config.getParameter < edm::InputTag > ("cluster2TPSrc") )
 {
 	//
 	// Check whether the denominator when working out the percentage of shared hits should
 	// be the number of simulated hits or the number of reconstructed hits.
 	//
-	std::string denominatorString=config.getParameter<std::string>("SimToRecoDenominator");
-	if( denominatorString=="sim" ) simToRecoDenominator_=denomsim;
-	else if( denominatorString=="reco" ) simToRecoDenominator_=denomreco;
+	std::string denominatorString=config.getParameter < std::string > ("SimToRecoDenominator");
+	if( denominatorString == "sim" ) simToRecoDenominator_=denomsim;
+	else if( denominatorString == "reco" ) simToRecoDenominator_=denomreco;
 	else throw cms::Exception( "QuickTrackAssociatorByHits" ) << "SimToRecoDenominator not specified as sim or reco";
 
 	//
 	// Set up the parameter set for the hit associator
 	//
-	hitAssociatorParameters_.addParameter<bool>( "associatePixel", config.getParameter<bool>("associatePixel") );
-	hitAssociatorParameters_.addParameter<bool>( "associateStrip", config.getParameter<bool>("associateStrip") );
+	hitAssociatorParameters_.addParameter<bool>( "associatePixel", config.getParameter<bool>( "associatePixel" ) );
+	hitAssociatorParameters_.addParameter<bool>( "associateStrip", config.getParameter<bool>( "associateStrip" ) );
 	// This is the important one, it stops the hit associator searching through the list of sim hits.
 	// I only want to use the hit associator methods that work on the hit IDs (i.e. the uint32_t trackId
 	// and the EncodedEventId eventId) so I'm not interested in matching that to the PSimHit objects.
-	hitAssociatorParameters_.addParameter<bool>("associateRecoTracks",true);
+	hitAssociatorParameters_.addParameter<bool>( "associateRecoTracks", true );
 
 	//
 	// Do some checks on whether UseGrouped or UseSplitting have been set. They're not used
 	// unlike the standard TrackAssociatorByHits so show a warning.
 	//
 	bool useGrouped, useSplitting;
-	if( config.exists("UseGrouped") ) useGrouped=config.getParameter<bool>("UseGrouped");
+	if( config.exists( "UseGrouped" ) ) useGrouped=config.getParameter<bool>( "UseGrouped" );
 	else useGrouped=true;
 
-	if( config.exists("UseSplitting") ) useSplitting=config.getParameter<bool>("UseSplitting");
+	if( config.exists( "UseSplitting" ) ) useSplitting=config.getParameter<bool>( "UseSplitting" );
 	else useSplitting=true;
 
 	// This associator works as though both UseGrouped and UseSplitting were set to true, so show a
 	// warning if this isn't the case.
 	if( !(useGrouped && useSplitting) )
 	{
-		edm::LogWarning("QuickTrackAssociatorByHits") << "UseGrouped and/or UseSplitting has been set to false, but this associator ignores that setting.";
+		edm::LogWarning( "QuickTrackAssociatorByHits" )
+				<< "UseGrouped and/or UseSplitting has been set to false, but this associator ignores that setting.";
 	}
 }
 
@@ -67,217 +130,124 @@ QuickTrackAssociatorByHits::~QuickTrackAssociatorByHits()
 	delete pHitAssociator_;
 }
 
-QuickTrackAssociatorByHits::QuickTrackAssociatorByHits( const QuickTrackAssociatorByHits& otherAssociator )
-	: pEventForWhichAssociatorIsValid_(otherAssociator.pEventForWhichAssociatorIsValid_),
-	  hitAssociatorParameters_(otherAssociator.hitAssociatorParameters_),
-	  absoluteNumberOfHits_(otherAssociator.absoluteNumberOfHits_),
-	  qualitySimToReco_(otherAssociator.qualitySimToReco_),
-	  puritySimToReco_(otherAssociator.puritySimToReco_),
-	  cutRecoToSim_(otherAssociator.cutRecoToSim_),
-	  threeHitTracksAreSpecial_(otherAssociator.threeHitTracksAreSpecial_),
-	  simToRecoDenominator_(otherAssociator.simToRecoDenominator_),
-	  pTrackCollectionHandle_(otherAssociator.pTrackCollectionHandle_),
-	  pTrackCollection_(otherAssociator.pTrackCollection_),
-	  pTrackingParticleCollectionHandle_(otherAssociator.pTrackingParticleCollectionHandle_),
-	  pTrackingParticleCollection_(otherAssociator.pTrackingParticleCollection_),
-          useClusterTPAssociation_(otherAssociator.useClusterTPAssociation_),
-          cluster2TPSrc_(otherAssociator.cluster2TPSrc_)
-{
-	// No operation other than the initialiser list. That copies everything straight from the other
-	// associator, except for pHitAssociator_ which needs a deep copy or both instances will try
-	// and free it on deletion.  If it wasn't for pHitAssociator_ the default copy constructor and
-	// assignment operator would be sufficient.
-
-	// Actually, need to check the other hit associator isn't null or the pointer dereference would
-	// probably cause a segmentation fault.
-	if( otherAssociator.pHitAssociator_ ) pHitAssociator_=new TrackerHitAssociator(*otherAssociator.pHitAssociator_);
-	else pHitAssociator_=nullptr;
-}
-
-QuickTrackAssociatorByHits& QuickTrackAssociatorByHits::operator=( const QuickTrackAssociatorByHits& otherAssociator )
-{
-	// Free up the old pHitAssociator_
-	delete pHitAssociator_;
-
-	//
-	// pHitAssociator_ needs to be given a deep copy of the object, but everything else can
-	// can be shallow copied from the other associator.
-	//
-	if( otherAssociator.pHitAssociator_ ) pHitAssociator_=new TrackerHitAssociator(*otherAssociator.pHitAssociator_);
-	else pHitAssociator_=nullptr;
-	pEventForWhichAssociatorIsValid_=otherAssociator.pEventForWhichAssociatorIsValid_;
-	hitAssociatorParameters_=otherAssociator.hitAssociatorParameters_;
-	absoluteNumberOfHits_=otherAssociator.absoluteNumberOfHits_;
-	qualitySimToReco_=otherAssociator.qualitySimToReco_;
-	puritySimToReco_=otherAssociator.puritySimToReco_;
-	cutRecoToSim_=otherAssociator.cutRecoToSim_;
-	threeHitTracksAreSpecial_=otherAssociator.threeHitTracksAreSpecial_;
-        useClusterTPAssociation_ = otherAssociator.useClusterTPAssociation_,
-        cluster2TPSrc_ = otherAssociator.cluster2TPSrc_;
-	simToRecoDenominator_=otherAssociator.simToRecoDenominator_;
-	pTrackCollectionHandle_=otherAssociator.pTrackCollectionHandle_;
-	pTrackCollection_=otherAssociator.pTrackCollection_;
-	pTrackingParticleCollectionHandle_=otherAssociator.pTrackingParticleCollectionHandle_;
-	pTrackingParticleCollection_=otherAssociator.pTrackingParticleCollection_;
-
-	return *this;
-}
-
-reco::RecoToSimCollection QuickTrackAssociatorByHits::associateRecoToSim( edm::Handle<edm::View<reco::Track> >& trackCollectionHandle,
-                                                                              edm::Handle<TrackingParticleCollection>& trackingParticleCollectionHandle,
-                                                                              const edm::Event* pEvent,
-                                                                              const edm::EventSetup* pSetup ) const
+reco::RecoToSimCollection QuickTrackAssociatorByHits::associateRecoToSim( edm::Handle<edm::View<reco::Track> >& trackCollectionHandle, edm::Handle<
+		TrackingParticleCollection>& trackingParticleCollectionHandle, const edm::Event* pEvent, const edm::EventSetup* pSetup ) const
 {
 
-        // get the Cluster2TPMap or initialize hit associator
-        if (useClusterTPAssociation_) prepareCluster2TPMap(pEvent);
-        else initialiseHitAssociator( pEvent );
-
-	pTrackCollectionHandle_=&trackCollectionHandle;
-	pTrackingParticleCollectionHandle_=&trackingParticleCollectionHandle;
-	pTrackCollection_=nullptr;
-	pTrackingParticleCollection_=nullptr;
+	// get the Cluster2TPMap or initialize hit associator
+	if( useClusterTPAssociation_ ) prepareCluster2TPMap( pEvent );
+	else initialiseHitAssociator( pEvent );
 
 	// This method checks which collection type is set to null, and uses the other one.
-	return associateRecoToSimImplementation();
+	return associateRecoToSimImplementation( trackCollectionHandle, trackingParticleCollectionHandle, pEvent );
 }
 
-reco::SimToRecoCollection QuickTrackAssociatorByHits::associateSimToReco( edm::Handle<edm::View<reco::Track> >& trackCollectionHandle,
-                                                                              edm::Handle<TrackingParticleCollection>& trackingParticleCollectionHandle,
-                                                                              const edm::Event * pEvent,
-                                                                              const edm::EventSetup * pSetup ) const
+reco::SimToRecoCollection QuickTrackAssociatorByHits::associateSimToReco( edm::Handle<edm::View<reco::Track> >& trackCollectionHandle, edm::Handle<
+		TrackingParticleCollection>& trackingParticleCollectionHandle, const edm::Event * pEvent, const edm::EventSetup * pSetup ) const
 {
 
-        // get the Cluster2TPMap or initialize hit associator
-        if (useClusterTPAssociation_) prepareCluster2TPMap(pEvent);
-        else initialiseHitAssociator( pEvent );
-
-	pTrackCollectionHandle_=&trackCollectionHandle;
-	pTrackingParticleCollectionHandle_=&trackingParticleCollectionHandle;
-	pTrackCollection_=nullptr;
-	pTrackingParticleCollection_=nullptr;
+	// get the Cluster2TPMap or initialize hit associator
+	if( useClusterTPAssociation_ ) prepareCluster2TPMap( pEvent );
+	else initialiseHitAssociator( pEvent );
 
 	// This method checks which collection type is set to null, and uses the other one.
-	return associateSimToRecoImplementation();
+	return associateSimToRecoImplementation( trackCollectionHandle, trackingParticleCollectionHandle, pEvent );
+}
+
+reco::RecoToSimCollection QuickTrackAssociatorByHits::associateRecoToSim( const edm::RefToBaseVector<reco::Track>& trackCollection, const edm::RefVector<
+		TrackingParticleCollection>& trackingParticleCollection, const edm::Event* pEvent, const edm::EventSetup* pSetup ) const
+{
+
+	// get the Cluster2TPMap or initialize hit associator
+	if( useClusterTPAssociation_ ) prepareCluster2TPMap( pEvent );
+	else initialiseHitAssociator( pEvent );
+
+	// This method checks which collection type is set to null, and uses the other one.
+	return associateRecoToSimImplementation( trackCollection, trackingParticleCollection, pEvent );
+}
+
+reco::SimToRecoCollection QuickTrackAssociatorByHits::associateSimToReco( const edm::RefToBaseVector<reco::Track>& trackCollection, const edm::RefVector<
+		TrackingParticleCollection>& trackingParticleCollection, const edm::Event* pEvent, const edm::EventSetup* pSetup ) const
+{
+
+	// get the Cluster2TPMap or initialize hit associator
+	if( useClusterTPAssociation_ ) prepareCluster2TPMap( pEvent );
+	else initialiseHitAssociator( pEvent );
+
+	// This method checks which collection type is set to null, and uses the other one.
+	return associateSimToRecoImplementation( trackCollection, trackingParticleCollection, pEvent );
 }
 
 
-reco::RecoToSimCollection QuickTrackAssociatorByHits::associateRecoToSim(const edm::RefToBaseVector<reco::Track>& trackCollection,
-									 const edm::RefVector<TrackingParticleCollection>& trackingParticleCollection,
-									 const edm::Event* pEvent,
-									 const edm::EventSetup* pSetup ) const
+template<class T_TrackCollection, class T_TrackingParticleCollection>
+reco::RecoToSimCollection QuickTrackAssociatorByHits::associateRecoToSimImplementation( T_TrackCollection trackCollection, T_TrackingParticleCollection trackingParticleCollection, const edm::Event* pEvent ) const
 {
+	reco::RecoToSimCollection returnValue;
 
-  // get the Cluster2TPMap or initialize hit associator
-  if (useClusterTPAssociation_) prepareCluster2TPMap(pEvent);
-  else initialiseHitAssociator( pEvent );
+	size_t collectionSize=::collectionSize(trackCollection); // Delegate away type specific part
 
-  pTrackCollectionHandle_=nullptr;
-  pTrackingParticleCollectionHandle_=nullptr;
-  pTrackCollection_=&trackCollection;
-  pTrackingParticleCollection_=&trackingParticleCollection;
-
-  // This method checks which collection type is set to null, and uses the other one.
-  return associateRecoToSimImplementation();
-}
-
-reco::SimToRecoCollection QuickTrackAssociatorByHits::associateSimToReco(const edm::RefToBaseVector<reco::Track>& trackCollection,
-									 const edm::RefVector<TrackingParticleCollection>& trackingParticleCollection,
-									 const edm::Event* pEvent,
-									 const edm::EventSetup* pSetup ) const
-{
-
-  // get the Cluster2TPMap or initialize hit associator
-  if (useClusterTPAssociation_) prepareCluster2TPMap(pEvent);
-  else initialiseHitAssociator( pEvent );
-
-  pTrackCollectionHandle_=nullptr;
-  pTrackingParticleCollectionHandle_=nullptr;
-  pTrackCollection_=&trackCollection;
-  pTrackingParticleCollection_=&trackingParticleCollection;
-
-  // This method checks which collection type is set to null, and uses the other one.
-  return associateSimToRecoImplementation();
-}
-
-reco::RecoToSimCollection QuickTrackAssociatorByHits::associateRecoToSimImplementation() const
-{
-  reco::RecoToSimCollection returnValue;
-
-  size_t collectionSize;
-  // Need to check which pointer is valid to get the collection size
-  if ( pTrackCollection_ ) collectionSize=pTrackCollection_->size();
-  else collectionSize=(*pTrackCollectionHandle_)->size();
-
-  //std::cout << "#reco Tracks = " << collectionSize << std::endl;
-  for( size_t i=0; i<collectionSize; ++i )
-  {
-    const reco::Track* pTrack; // Get a normal pointer for ease of use.
-    if( pTrackCollection_ ) pTrack=&*(*pTrackCollection_)[i]; // Possibly the most obscure dereference I've ever had to write
-    else pTrack=&(*pTrackCollectionHandle_->product())[i];
-    //    std::cout << ">>> recoTrack #index = " << i << " pt = " << pTrack->pt() << std::endl;
-
-    // The return of this function has first as the index and second as the number of associated hits
-    std::vector< std::pair<edm::Ref<TrackingParticleCollection>,size_t> > trackingParticleQualityPairs = (useClusterTPAssociation_) 
-      ? associateTrackByCluster( pTrack->recHitsBegin(),pTrack->recHitsEnd() )
-      : associateTrack( pTrack->recHitsBegin(), pTrack->recHitsEnd() );
-
-    // int nt = 0;
-    for (std::vector< std::pair<edm::Ref<TrackingParticleCollection>,size_t> >::const_iterator iTrackingParticleQualityPair=trackingParticleQualityPairs.begin(); iTrackingParticleQualityPair!=trackingParticleQualityPairs.end(); ++iTrackingParticleQualityPair )
-    {
-      const edm::Ref<TrackingParticleCollection>& trackingParticleRef=iTrackingParticleQualityPair->first;
-      size_t numberOfSharedHits=iTrackingParticleQualityPair->second;
-      size_t numberOfValidTrackHits=pTrack->found();
-	  
-      //std::cout << ">>> reco2sim. numberOfSharedHits = " << nt++ << ", " << numberOfSharedHits << std::endl;
-      if (numberOfSharedHits==0) continue; // No point in continuing if there was no association
-
-      //if electron subtract double counting
-      if (abs(trackingParticleRef->pdgId())==11 && (trackingParticleRef->g4Track_end() - trackingParticleRef->g4Track_begin()) > 1 )
-      {
-	numberOfSharedHits -= getDoubleCount( pTrack->recHitsBegin(), pTrack->recHitsEnd(), trackingParticleRef );
-      }
-
-      double quality;
-      if (absoluteNumberOfHits_ ) 
-        quality = static_cast<double>(numberOfSharedHits);
-      else if (numberOfValidTrackHits != 0) 
-        quality = (static_cast<double>(numberOfSharedHits) / static_cast<double>(numberOfValidTrackHits));
-      else 
-        quality = 0;
-      if (quality > cutRecoToSim_ && !( threeHitTracksAreSpecial_ && numberOfValidTrackHits==3 && numberOfSharedHits<3 ) )
-      {
-	if (pTrackCollection_) returnValue.insert( (*pTrackCollection_)[i], std::make_pair( trackingParticleRef, quality ));
-	else returnValue.insert( edm::RefToBase<reco::Track>(*pTrackCollectionHandle_,i), std::make_pair( trackingParticleRef, quality ));
-      }
-    }
-  }
-  return returnValue;
-}
-
-reco::SimToRecoCollection QuickTrackAssociatorByHits::associateSimToRecoImplementation() const
-{
-  reco::SimToRecoCollection returnValue;
-
-	size_t collectionSize;
-	// Need to check which pointer is valid to get the collection size
-	if( pTrackCollection_ ) collectionSize=pTrackCollection_->size();
-	else collectionSize=(*pTrackCollectionHandle_)->size();
-
-	for( size_t i=0; i<collectionSize; ++i )
+	//std::cout << "#reco Tracks = " << collectionSize << std::endl;
+	for( size_t i=0; i < collectionSize; ++i )
 	{
-		const reco::Track* pTrack; // Get a normal pointer for ease of use.
-		if( pTrackCollection_ ) pTrack=&*(*pTrackCollection_)[i]; // Possibly the most obscure dereference I've ever had to write
-		else pTrack=&(*pTrackCollectionHandle_->product())[i];
+		const reco::Track* pTrack=::getTrackAt(trackCollection,i); // Get a normal pointer for ease of use. This part is type specific so delegate.
+		//    std::cout << ">>> recoTrack #index = " << i << " pt = " << pTrack->pt() << std::endl;
 
-		// The return of this function has first as an edm:Ref to the associated TrackingParticle, and second as the number of associated hits
-		std::vector< std::pair<edm::Ref<TrackingParticleCollection>,size_t> > trackingParticleQualityPairs = (useClusterTPAssociation_) 
-		? associateTrackByCluster( pTrack->recHitsBegin(),pTrack->recHitsEnd() )
-		: associateTrack( pTrack->recHitsBegin(),pTrack->recHitsEnd() );
+		// The return of this function has first as the index and second as the number of associated hits
+		std::vector < std::pair<edm::Ref<TrackingParticleCollection>,size_t> > trackingParticleQualityPairs=
+				(useClusterTPAssociation_) ? associateTrackByCluster( pTrack->recHitsBegin(), pTrack->recHitsEnd() ) : associateTrack( trackingParticleCollection, pTrack->recHitsBegin(), pTrack->recHitsEnd() );
 
 		// int nt = 0;
-		for( std::vector< std::pair<edm::Ref<TrackingParticleCollection>,size_t> >::const_iterator iTrackingParticleQualityPair=trackingParticleQualityPairs.begin();
-				iTrackingParticleQualityPair!=trackingParticleQualityPairs.end(); ++iTrackingParticleQualityPair )
+		for( std::vector<std::pair<edm::Ref<TrackingParticleCollection>,size_t> >::const_iterator iTrackingParticleQualityPair=
+				trackingParticleQualityPairs.begin(); iTrackingParticleQualityPair != trackingParticleQualityPairs.end();
+				++iTrackingParticleQualityPair )
+		{
+			const edm::Ref<TrackingParticleCollection>& trackingParticleRef=iTrackingParticleQualityPair->first;
+			size_t numberOfSharedHits=iTrackingParticleQualityPair->second;
+			size_t numberOfValidTrackHits=pTrack->found();
+
+			//std::cout << ">>> reco2sim. numberOfSharedHits = " << nt++ << ", " << numberOfSharedHits << std::endl;
+			if( numberOfSharedHits == 0 ) continue; // No point in continuing if there was no association
+
+			//if electron subtract double counting
+			if( abs( trackingParticleRef->pdgId() ) == 11 && (trackingParticleRef->g4Track_end() - trackingParticleRef->g4Track_begin()) > 1 )
+			{
+				numberOfSharedHits-=getDoubleCount( pTrack->recHitsBegin(), pTrack->recHitsEnd(), trackingParticleRef );
+			}
+
+			double quality;
+			if( absoluteNumberOfHits_ ) quality=static_cast<double>( numberOfSharedHits );
+			else if( numberOfValidTrackHits != 0 ) quality=
+					(static_cast<double>( numberOfSharedHits ) / static_cast<double>( numberOfValidTrackHits ));
+			else quality=0;
+			if( quality > cutRecoToSim_ && !(threeHitTracksAreSpecial_ && numberOfValidTrackHits == 3 && numberOfSharedHits < 3) )
+			{
+				// Getting the RefToBase is dependent on the type of trackCollection, so delegate that to an overload.
+				returnValue.insert( ::getRefToTrackAt(trackCollection,i), std::make_pair( trackingParticleRef, quality ) );
+			}
+		}
+	}
+	return returnValue;
+}
+
+template<class T_TrackCollection, class T_TrackingParticleCollection>
+reco::SimToRecoCollection QuickTrackAssociatorByHits::associateSimToRecoImplementation( T_TrackCollection trackCollection, T_TrackingParticleCollection trackingParticleCollection, const edm::Event* pEvent ) const
+{
+	reco::SimToRecoCollection returnValue;
+
+	size_t collectionSize=::collectionSize(trackCollection); // Delegate away type specific part
+
+	for( size_t i=0; i < collectionSize; ++i )
+	{
+		const reco::Track* pTrack=::getTrackAt(trackCollection,i); // Get a normal pointer for ease of use. This part is type specific so delegate.
+
+		// The return of this function has first as an edm:Ref to the associated TrackingParticle, and second as the number of associated hits
+		std::vector < std::pair<edm::Ref<TrackingParticleCollection>,size_t> > trackingParticleQualityPairs=
+				(useClusterTPAssociation_) ? associateTrackByCluster( pTrack->recHitsBegin(), pTrack->recHitsEnd() ) : associateTrack( trackingParticleCollection, pTrack->recHitsBegin(), pTrack->recHitsEnd() );
+
+		// int nt = 0;
+		for( std::vector<std::pair<edm::Ref<TrackingParticleCollection>,size_t> >::const_iterator iTrackingParticleQualityPair=
+				trackingParticleQualityPairs.begin(); iTrackingParticleQualityPair != trackingParticleQualityPairs.end();
+				++iTrackingParticleQualityPair )
 		{
 			const edm::Ref<TrackingParticleCollection>& trackingParticleRef=iTrackingParticleQualityPair->first;
 			size_t numberOfSharedHits=iTrackingParticleQualityPair->second;
@@ -285,9 +255,9 @@ reco::SimToRecoCollection QuickTrackAssociatorByHits::associateSimToRecoImplemen
 			size_t numberOfSimulatedHits=0; // Set a few lines below, but only if required.
 
 			//std::cout << ">>> sim2reco. numberOfSharedHits = " << nt++ << ", " << numberOfSharedHits << std::endl;
-			if( numberOfSharedHits==0 ) continue; // No point in continuing if there was no association
+			if( numberOfSharedHits == 0 ) continue; // No point in continuing if there was no association
 
-			if( simToRecoDenominator_==denomsim || (numberOfSharedHits<3 && threeHitTracksAreSpecial_) ) // the numberOfSimulatedHits is not always required, so can skip counting in some circumstances
+			if( simToRecoDenominator_ == denomsim || (numberOfSharedHits < 3 && threeHitTracksAreSpecial_) ) // the numberOfSimulatedHits is not always required, so can skip counting in some circumstances
 			{
 				// Note that in the standard TrackAssociatorByHits, all of the hits in associatedTrackingParticleHits are checked for
 				// various things.  I'm not sure what these checks are for but they depend on the UseGrouping and UseSplitting settings.
@@ -296,25 +266,25 @@ reco::SimToRecoCollection QuickTrackAssociatorByHits::associateSimToRecoImplemen
 				numberOfSimulatedHits=trackingParticleRef->numberOfTrackerHits();
 			}
 
-
 			//if electron subtract double counting
-			if (abs(trackingParticleRef->pdgId())==11 && (trackingParticleRef->g4Track_end() - trackingParticleRef->g4Track_begin()) > 1 )
+			if( abs( trackingParticleRef->pdgId() ) == 11 && (trackingParticleRef->g4Track_end() - trackingParticleRef->g4Track_begin()) > 1 )
 			{
-			  numberOfSharedHits -= getDoubleCount( pTrack->recHitsBegin(), pTrack->recHitsEnd(), trackingParticleRef );
+				numberOfSharedHits-=getDoubleCount( pTrack->recHitsBegin(), pTrack->recHitsEnd(), trackingParticleRef );
 			}
 
-
-			double purity=static_cast<double>(numberOfSharedHits)/static_cast<double>(numberOfValidTrackHits);
+			double purity=static_cast<double>( numberOfSharedHits ) / static_cast<double>( numberOfValidTrackHits );
 			double quality;
-			if( absoluteNumberOfHits_ ) quality=static_cast<double>(numberOfSharedHits);
-			else if( simToRecoDenominator_==denomsim && numberOfSimulatedHits != 0 ) quality=static_cast<double>(numberOfSharedHits)/static_cast<double>(numberOfSimulatedHits);
-			else if( simToRecoDenominator_==denomreco && numberOfValidTrackHits != 0 ) quality=purity;
+			if( absoluteNumberOfHits_ ) quality=static_cast<double>( numberOfSharedHits );
+			else if( simToRecoDenominator_ == denomsim && numberOfSimulatedHits != 0 ) quality=static_cast<double>( numberOfSharedHits )
+					/ static_cast<double>( numberOfSimulatedHits );
+			else if( simToRecoDenominator_ == denomreco && numberOfValidTrackHits != 0 ) quality=purity;
 			else quality=0;
 
-			if( quality>qualitySimToReco_ && !( threeHitTracksAreSpecial_ && numberOfSimulatedHits==3 && numberOfSharedHits<3 ) && ( absoluteNumberOfHits_ || (purity>puritySimToReco_) ) )
+			if( quality > qualitySimToReco_ && !(threeHitTracksAreSpecial_ && numberOfSimulatedHits == 3 && numberOfSharedHits < 3)
+					&& (absoluteNumberOfHits_ || (purity > puritySimToReco_)) )
 			{
-				if( pTrackCollection_ ) returnValue.insert( trackingParticleRef, std::make_pair( (*pTrackCollection_)[i], quality ) );
-				else returnValue.insert( trackingParticleRef, std::make_pair( edm::RefToBase<reco::Track>(*pTrackCollectionHandle_,i) , quality ) );
+				// Getting the RefToBase is dependent on the type of trackCollection, so delegate that to an overload.
+				returnValue.insert( trackingParticleRef, std::make_pair( ::getRefToTrackAt(trackCollection,i), quality ) );
 			}
 		}
 	}
@@ -322,268 +292,286 @@ reco::SimToRecoCollection QuickTrackAssociatorByHits::associateSimToRecoImplemen
 
 }
 
-template<typename iter> std::vector< std::pair<edm::Ref<TrackingParticleCollection>,size_t> > QuickTrackAssociatorByHits::associateTrack( iter begin, iter end ) const
+template<typename T_TPCollection,typename iter> std::vector<std::pair<edm::Ref<TrackingParticleCollection>,size_t> > QuickTrackAssociatorByHits::associateTrack( T_TPCollection trackingParticles, iter begin, iter end ) const
 {
 	// The pairs in this vector have a Ref to the associated TrackingParticle as "first" and the number of associated hits as "second"
-	std::vector< std::pair<edm::Ref<TrackingParticleCollection>,size_t> > returnValue;
+	std::vector < std::pair<edm::Ref<TrackingParticleCollection>,size_t> > returnValue;
 
 	// The pairs in this vector have first as the sim track identifiers, and second the number of reco hits associated to that sim track.
 	// Most reco hits will probably have come from the same sim track, so the number of entries in this vector should be fewer than the
 	// number of reco hits.  The pair::second entries should add up to the total number of reco hits though.
-	std::vector< std::pair<SimTrackIdentifiers,size_t> > hitIdentifiers=getAllSimTrackIdentifiers(begin, end);
+	std::vector < std::pair<SimTrackIdentifiers,size_t> > hitIdentifiers=getAllSimTrackIdentifiers( begin, end );
 
 	// Loop over the TrackingParticles
-	size_t collectionSize;
-	if( pTrackingParticleCollection_ ) collectionSize=pTrackingParticleCollection_->size();
-	else collectionSize=(*pTrackingParticleCollectionHandle_)->size();
+	size_t collectionSize=::collectionSize(trackingParticles);
 
-	for( size_t i=0; i<collectionSize; ++i )
+	for( size_t i=0; i < collectionSize; ++i )
 	{
-		const TrackingParticle* pTrackingParticle; // Convert to raw pointer for ease of use
-		if( pTrackingParticleCollection_ ) pTrackingParticle=&*(*pTrackingParticleCollection_)[i];
-		else pTrackingParticle=&(*pTrackingParticleCollectionHandle_->product())[i];
+		const TrackingParticle* pTrackingParticle=getTrackingParticleAt( trackingParticles, i );
 
 		// Ignore TrackingParticles with no hits
-		if( pTrackingParticle->numberOfHits()==0 ) continue;
+		if( pTrackingParticle->numberOfHits() == 0 ) continue;
 
 		size_t numberOfAssociatedHits=0;
 		// Loop over all of the sim track identifiers and see if any of them are part of this TrackingParticle. If they are, add
 		// the number of reco hits associated to that sim track to the total number of associated hits.
-		for( std::vector< std::pair<SimTrackIdentifiers,size_t> >::const_iterator iIdentifierCountPair=hitIdentifiers.begin(); iIdentifierCountPair!=hitIdentifiers.end(); ++iIdentifierCountPair )
+		for( std::vector<std::pair<SimTrackIdentifiers,size_t> >::const_iterator iIdentifierCountPair=hitIdentifiers.begin();
+				iIdentifierCountPair != hitIdentifiers.end(); ++iIdentifierCountPair )
 		{
-			if( trackingParticleContainsIdentifier( pTrackingParticle, iIdentifierCountPair->first ) ) numberOfAssociatedHits+=iIdentifierCountPair->second;
+			if( trackingParticleContainsIdentifier( pTrackingParticle, iIdentifierCountPair->first ) ) numberOfAssociatedHits+=
+					iIdentifierCountPair->second;
 		}
 
-		if( numberOfAssociatedHits>0 )
+		if( numberOfAssociatedHits > 0 )
 		{
-			if( pTrackingParticleCollection_ ) returnValue.push_back( std::make_pair( (*pTrackingParticleCollection_)[i], numberOfAssociatedHits ) );
-			else returnValue.push_back( std::make_pair( edm::Ref<TrackingParticleCollection>( *pTrackingParticleCollectionHandle_, i ), numberOfAssociatedHits ) );
+			returnValue.push_back( std::make_pair( getRefToTrackingParticleAt(trackingParticles,i), numberOfAssociatedHits ) );
 		}
 	}
 
 	return returnValue;
 }
 
-void QuickTrackAssociatorByHits::prepareCluster2TPMap(const edm::Event* pEvent) const
+void QuickTrackAssociatorByHits::prepareCluster2TPMap( const edm::Event* pEvent ) const
 {
-  //get the Cluster2TPList
-  edm::Handle<ClusterTPAssociationList> pCluster2TPListH;
-  pEvent->getByLabel(cluster2TPSrc_, pCluster2TPListH);
-  if (pCluster2TPListH.isValid()) {
-    pCluster2TPList_ = *(pCluster2TPListH.product());
-    //make sure it is properly sorted
-    std::sort(pCluster2TPList_.begin(), pCluster2TPList_.end(), clusterTPAssociationListGreater);
-  } else {
-    edm::LogInfo("TrackAssociator") << "ClusterTPAssociationList with label "<<cluster2TPSrc_<<" not found. Using DigiSimLink based associator";
-    initialiseHitAssociator( pEvent );
-    useClusterTPAssociation_ = false;
-  }
-}
-
-template<typename iter> std::vector< std::pair<edm::Ref<TrackingParticleCollection>,size_t> > QuickTrackAssociatorByHits::associateTrackByCluster(iter begin, iter end) const
-{
-  // The pairs in this vector have a Ref to the associated TrackingParticle as "first" and the number of associated clusters as "second"
-  // Note: typedef edm::Ref<TrackingParticleCollection> TrackingParticleRef;
-  std::vector<std::pair<edm::Ref<TrackingParticleCollection>, size_t> > returnValue;
-  if (!pCluster2TPList_.size()) return returnValue;
-  
-  // The pairs in this vector have first as the TP, and second the number of reco clusters associated to that TP.
-  // Most reco clusters will probably have come from the same sim track (i.e TP), so the number of entries in this 
-  // vector should be fewer than the number of clusters. The pair::second entries should add up to the total 
-  // number of reco clusters though.
-  std::vector<OmniClusterRef> oClusters = getMatchedClusters(begin, end);
-
-  std::map<TrackingParticleRef, size_t> lmap; 
-  for (std::vector<OmniClusterRef>::const_iterator it = oClusters.begin(); it != oClusters.end(); ++it) {
-
-    std::pair<OmniClusterRef, TrackingParticleRef> clusterTPpairWithDummyTP(*it,TrackingParticleRef());//TP is dummy: for clusterTPAssociationListGreater sorting only the cluster is needed
-    auto range = std::equal_range(pCluster2TPList_.begin(), pCluster2TPList_.end(), clusterTPpairWithDummyTP, clusterTPAssociationListGreater);
-    if(range.first != range.second) {
-      for(auto ip = range.first; ip != range.second; ++ip) {
-
-        const TrackingParticleRef trackingParticle = (ip->second);
-
-        // Ignore TrackingParticles with no hits
-        if (trackingParticle->numberOfHits()==0) continue;
-
-	/* Alternative implementation to avoid the use of lmap... memory slightly improved but slightly slower...
-	std::pair<edm::Ref<TrackingParticleCollection>,size_t> tpIntPair(trackingParticle, 1);
-	auto tp_range = std::equal_range(returnValue.begin(), returnValue.end(), tpIntPair, tpIntPairGreater);
-	if ((tp_range.second-tp_range.first)>1) {
-	  edm::LogError("TrackAssociator") << ">>> Error in counting TPs!" << " file: " << __FILE__ << " line: " << __LINE__;
-	}
-	if(tp_range.first != tp_range.second) {
-	  tp_range.first->second++;
-	} else {
-	  returnValue.push_back(tpIntPair);
-	  std::sort(returnValue.begin(), returnValue.end(), tpIntPairGreater);
-	}
-	*/
-        auto jpos = lmap.find(trackingParticle);     
-	if (jpos != lmap.end())
-	  ++jpos->second; 
-        else 
-	  lmap.insert(std::make_pair(trackingParticle, 1));
-      }
-    }
-  }
-  // now copy the map to returnValue
-  for (auto ip = lmap.begin(); ip != lmap.end(); ++ip) {
-    returnValue.push_back(std::make_pair(ip->first, ip->second));
-  }
-  return returnValue;
-}
-
-template<typename iter> std::vector<OmniClusterRef> QuickTrackAssociatorByHits::getMatchedClusters(iter begin, iter end) const
-{
-  std::vector<OmniClusterRef> returnValue;
-  for (iter iRecHit = begin; iRecHit != end; ++iRecHit) {
-    const TrackingRecHit* rhit = getHitFromIter(iRecHit);
-    if (rhit->isValid()) {
-      int subdetid = rhit->geographicalId().subdetId();
-      if (subdetid==PixelSubdetector::PixelBarrel||subdetid==PixelSubdetector::PixelEndcap) {
-	const SiPixelRecHit* pRHit = dynamic_cast<const SiPixelRecHit*>(rhit);
-        if (!pRHit->cluster().isNonnull()) 
-	  edm::LogError("TrackAssociator") << ">>> RecHit does not have an associated cluster!" << " file: " << __FILE__ << " line: " << __LINE__;
-        returnValue.push_back(pRHit->omniClusterRef());
-      }
-      else if (subdetid==SiStripDetId::TIB||subdetid==SiStripDetId::TOB||subdetid==SiStripDetId::TID||subdetid==SiStripDetId::TEC) {
-	const std::type_info &tid = typeid(*rhit);
-	if (tid == typeid(SiStripMatchedRecHit2D)) {
-	  const SiStripMatchedRecHit2D* sMatchedRHit = dynamic_cast<const SiStripMatchedRecHit2D*>(rhit);
-          if (!sMatchedRHit->monoHit().cluster().isNonnull() || !sMatchedRHit->stereoHit().cluster().isNonnull())  
-	    edm::LogError("TrackAssociator") << ">>> RecHit does not have an associated cluster!" << " file: " << __FILE__ << " line: " << __LINE__;
-	  returnValue.push_back(sMatchedRHit->monoClusterRef()); 
-	  returnValue.push_back(sMatchedRHit->stereoClusterRef()); 
-        }
-	else if (tid == typeid(SiStripRecHit2D)) {
-	  const SiStripRecHit2D* sRHit = dynamic_cast<const SiStripRecHit2D*>(rhit);
-          if (!sRHit->cluster().isNonnull()) 
-	    edm::LogError("TrackAssociator") << ">>> RecHit does not have an associated cluster!" << " file: " << __FILE__ << " line: " << __LINE__;
-	  returnValue.push_back(sRHit->omniClusterRef());
-	}
-	else if (tid == typeid(SiStripRecHit1D)) {
-	  const SiStripRecHit1D* sRHit = dynamic_cast<const SiStripRecHit1D*>(rhit);
-          if (!sRHit->cluster().isNonnull()) 
-	    edm::LogError("TrackAssociator") << ">>> RecHit does not have an associated cluster!" << " file: " << __FILE__ << " line: " << __LINE__;
-	  returnValue.push_back(sRHit->omniClusterRef());
-	}
-        else {
-  	  edm::LogError("TrackAssociator") << ">>> getMatchedClusters: TrackingRecHit not associated to any SiStripCluster! subdetid = " << subdetid;
-        }
-      }
-      else {
-	edm::LogError("TrackAssociator") << ">>> getMatchedClusters: TrackingRecHit not associated to any cluster! subdetid = " << subdetid;
-      }
-    }
-  }
-  return returnValue;
-}
-
-template<typename iter> std::vector< std::pair<QuickTrackAssociatorByHits::SimTrackIdentifiers,size_t> > QuickTrackAssociatorByHits::getAllSimTrackIdentifiers( iter begin, iter end ) const
-{
-  // The pairs in this vector have first as the sim track identifiers, and second the number of reco hits associated to that sim track.
-  std::vector< std::pair<SimTrackIdentifiers,size_t> > returnValue;
-
-  std::vector<SimTrackIdentifiers> simTrackIdentifiers;
-  // Loop over all of the rec hits in the track
-  //iter tRHIterBeginEnd = getTRHIterBeginEnd( pTrack );
-  for( iter iRecHit=begin; iRecHit!=end; ++iRecHit )
-  {
-    if( getHitFromIter(iRecHit)->isValid() )
-    {
-      simTrackIdentifiers.clear();
-	  
-      // Get the identifiers for the sim track that this hit came from. There should only be one entry unless clusters
-      // have merged (as far as I know).
-      pHitAssociator_->associateHitId( *(getHitFromIter(iRecHit)), simTrackIdentifiers ); // This call fills simTrackIdentifiers
-      // Loop over each identifier, and add it to the return value only if it's not already in there
-      for ( std::vector<SimTrackIdentifiers>::const_iterator iIdentifier  = simTrackIdentifiers.begin(); 
-	                                                     iIdentifier != simTrackIdentifiers.end(); 
-                                                           ++iIdentifier )
-      {
-	std::vector< std::pair<SimTrackIdentifiers,size_t> >::iterator iIdentifierCountPair;
-	for (iIdentifierCountPair=returnValue.begin(); iIdentifierCountPair!=returnValue.end(); ++iIdentifierCountPair)
+	//get the Cluster2TPList
+	edm::Handle<ClusterTPAssociationList> pCluster2TPListH;
+	pEvent->getByLabel( cluster2TPSrc_, pCluster2TPListH );
+	if( pCluster2TPListH.isValid() )
 	{
-	  if (iIdentifierCountPair->first.first==iIdentifier->first && iIdentifierCountPair->first.second==iIdentifier->second )
-	  {
-	    // This sim track identifier is already in the list, so increment the count of how many hits it relates to.
-	    ++iIdentifierCountPair->second;
-	    break;
-	  }
+		pCluster2TPList_= *(pCluster2TPListH.product());
+		//make sure it is properly sorted
+		std::sort( pCluster2TPList_.begin(), pCluster2TPList_.end(), clusterTPAssociationListGreater );
 	}
-	if( iIdentifierCountPair==returnValue.end() ) returnValue.push_back( std::make_pair(*iIdentifier,1) ); 
-	  // This identifier wasn't found, so add it
-      }
-    }
-  }
-  return returnValue;
+	else
+	{
+		edm::LogInfo( "TrackAssociator" ) << "ClusterTPAssociationList with label " << cluster2TPSrc_
+				<< " not found. Using DigiSimLink based associator";
+		initialiseHitAssociator( pEvent );
+		useClusterTPAssociation_=false;
+	}
+}
+
+template<typename iter> std::vector<std::pair<edm::Ref<TrackingParticleCollection>,size_t> > QuickTrackAssociatorByHits::associateTrackByCluster( iter begin, iter end ) const
+{
+	// The pairs in this vector have a Ref to the associated TrackingParticle as "first" and the number of associated clusters as "second"
+	// Note: typedef edm::Ref<TrackingParticleCollection> TrackingParticleRef;
+	std::vector < std::pair<edm::Ref<TrackingParticleCollection>,size_t> > returnValue;
+	if( !pCluster2TPList_.size() ) return returnValue;
+
+	// The pairs in this vector have first as the TP, and second the number of reco clusters associated to that TP.
+	// Most reco clusters will probably have come from the same sim track (i.e TP), so the number of entries in this
+	// vector should be fewer than the number of clusters. The pair::second entries should add up to the total
+	// number of reco clusters though.
+	std::vector < OmniClusterRef > oClusters=getMatchedClusters( begin, end );
+
+	std::map < TrackingParticleRef, size_t > lmap;
+	for( std::vector<OmniClusterRef>::const_iterator it=oClusters.begin(); it != oClusters.end(); ++it )
+	{
+
+		std::pair < OmniClusterRef, TrackingParticleRef > clusterTPpairWithDummyTP( *it, TrackingParticleRef() ); //TP is dummy: for clusterTPAssociationListGreater sorting only the cluster is needed
+		auto range=std::equal_range( pCluster2TPList_.begin(), pCluster2TPList_.end(), clusterTPpairWithDummyTP, clusterTPAssociationListGreater );
+		if( range.first != range.second )
+		{
+			for( auto ip=range.first; ip != range.second; ++ip )
+			{
+
+				const TrackingParticleRef trackingParticle=(ip->second);
+
+				// Ignore TrackingParticles with no hits
+				if( trackingParticle->numberOfHits() == 0 ) continue;
+
+				/* Alternative implementation to avoid the use of lmap... memory slightly improved but slightly slower...
+				 std::pair<edm::Ref<TrackingParticleCollection>,size_t> tpIntPair(trackingParticle, 1);
+				 auto tp_range = std::equal_range(returnValue.begin(), returnValue.end(), tpIntPair, tpIntPairGreater);
+				 if ((tp_range.second-tp_range.first)>1) {
+				 edm::LogError("TrackAssociator") << ">>> Error in counting TPs!" << " file: " << __FILE__ << " line: " << __LINE__;
+				 }
+				 if(tp_range.first != tp_range.second) {
+				 tp_range.first->second++;
+				 } else {
+				 returnValue.push_back(tpIntPair);
+				 std::sort(returnValue.begin(), returnValue.end(), tpIntPairGreater);
+				 }
+				 */
+				auto jpos=lmap.find( trackingParticle );
+				if( jpos != lmap.end() ) ++jpos->second;
+				else lmap.insert( std::make_pair( trackingParticle, 1 ) );
+			}
+		}
+	}
+	// now copy the map to returnValue
+	for( auto ip=lmap.begin(); ip != lmap.end(); ++ip )
+	{
+		returnValue.push_back( std::make_pair( ip->first, ip->second ) );
+	}
+	return returnValue;
+}
+
+template<typename iter> std::vector<OmniClusterRef> QuickTrackAssociatorByHits::getMatchedClusters( iter begin, iter end ) const
+{
+	std::vector < OmniClusterRef > returnValue;
+	for( iter iRecHit=begin; iRecHit != end; ++iRecHit )
+	{
+		const TrackingRecHit* rhit=getHitFromIter( iRecHit );
+		if( rhit->isValid() )
+		{
+			int subdetid=rhit->geographicalId().subdetId();
+			if( subdetid == PixelSubdetector::PixelBarrel || subdetid == PixelSubdetector::PixelEndcap )
+			{
+				const SiPixelRecHit* pRHit=dynamic_cast<const SiPixelRecHit*>( rhit );
+				if( !pRHit->cluster().isNonnull() ) edm::LogError( "TrackAssociator" ) << ">>> RecHit does not have an associated cluster!" << " file: " << __FILE__ << " line: " << __LINE__;
+				returnValue.push_back( pRHit->omniClusterRef() );
+			}
+			else if( subdetid == SiStripDetId::TIB || subdetid == SiStripDetId::TOB || subdetid == SiStripDetId::TID
+					|| subdetid == SiStripDetId::TEC )
+			{
+				const std::type_info &tid=typeid( *rhit);
+				if( tid == typeid(SiStripMatchedRecHit2D) )
+				{
+					const SiStripMatchedRecHit2D* sMatchedRHit=dynamic_cast<const SiStripMatchedRecHit2D*>( rhit );
+					if( !sMatchedRHit->monoHit().cluster().isNonnull() || !sMatchedRHit->stereoHit().cluster().isNonnull() ) edm::LogError( "TrackAssociator" ) << ">>> RecHit does not have an associated cluster!" << " file: " << __FILE__ << " line: " << __LINE__;
+					returnValue.push_back( sMatchedRHit->monoClusterRef() );
+					returnValue.push_back( sMatchedRHit->stereoClusterRef() );
+				}
+				else if( tid == typeid(SiStripRecHit2D) )
+				{
+					const SiStripRecHit2D* sRHit=dynamic_cast<const SiStripRecHit2D*>( rhit );
+					if( !sRHit->cluster().isNonnull() ) edm::LogError( "TrackAssociator" ) << ">>> RecHit does not have an associated cluster!" << " file: " << __FILE__ << " line: " << __LINE__;
+					returnValue.push_back( sRHit->omniClusterRef() );
+				}
+				else if( tid == typeid(SiStripRecHit1D) )
+				{
+					const SiStripRecHit1D* sRHit=dynamic_cast<const SiStripRecHit1D*>( rhit );
+					if( !sRHit->cluster().isNonnull() ) edm::LogError( "TrackAssociator" ) << ">>> RecHit does not have an associated cluster!" << " file: " << __FILE__ << " line: " << __LINE__;
+					returnValue.push_back( sRHit->omniClusterRef() );
+				}
+				else
+				{
+					edm::LogError( "TrackAssociator" ) << ">>> getMatchedClusters: TrackingRecHit not associated to any SiStripCluster! subdetid = "
+							<< subdetid;
+				}
+			}
+			else
+			{
+				edm::LogError( "TrackAssociator" ) << ">>> getMatchedClusters: TrackingRecHit not associated to any cluster! subdetid = " << subdetid;
+			}
+		}
+	}
+	return returnValue;
+}
+
+template<typename iter> std::vector<std::pair<QuickTrackAssociatorByHits::SimTrackIdentifiers,size_t> > QuickTrackAssociatorByHits::getAllSimTrackIdentifiers( iter begin, iter end ) const
+{
+	// The pairs in this vector have first as the sim track identifiers, and second the number of reco hits associated to that sim track.
+	std::vector < std::pair<SimTrackIdentifiers,size_t> > returnValue;
+
+	std::vector<SimTrackIdentifiers> simTrackIdentifiers;
+	// Loop over all of the rec hits in the track
+	//iter tRHIterBeginEnd = getTRHIterBeginEnd( pTrack );
+	for( iter iRecHit=begin; iRecHit != end; ++iRecHit )
+	{
+		if( getHitFromIter( iRecHit )->isValid() )
+		{
+			simTrackIdentifiers.clear();
+
+			// Get the identifiers for the sim track that this hit came from. There should only be one entry unless clusters
+			// have merged (as far as I know).
+			pHitAssociator_->associateHitId( *(getHitFromIter( iRecHit )), simTrackIdentifiers ); // This call fills simTrackIdentifiers
+			// Loop over each identifier, and add it to the return value only if it's not already in there
+			for( std::vector<SimTrackIdentifiers>::const_iterator iIdentifier=simTrackIdentifiers.begin(); iIdentifier != simTrackIdentifiers.end();
+					++iIdentifier )
+			{
+				std::vector<std::pair<SimTrackIdentifiers,size_t> >::iterator iIdentifierCountPair;
+				for( iIdentifierCountPair=returnValue.begin(); iIdentifierCountPair != returnValue.end(); ++iIdentifierCountPair )
+				{
+					if( iIdentifierCountPair->first.first == iIdentifier->first && iIdentifierCountPair->first.second == iIdentifier->second )
+					{
+						// This sim track identifier is already in the list, so increment the count of how many hits it relates to.
+						++iIdentifierCountPair->second;
+						break;
+					}
+				}
+				if( iIdentifierCountPair == returnValue.end() ) returnValue.push_back( std::make_pair( *iIdentifier, 1 ) );
+				// This identifier wasn't found, so add it
+			}
+		}
+	}
+	return returnValue;
 }
 
 bool QuickTrackAssociatorByHits::trackingParticleContainsIdentifier( const TrackingParticle* pTrackingParticle, const SimTrackIdentifiers& identifier ) const
 {
-  // Loop over all of the g4 tracks in the tracking particle
-  for( std::vector<SimTrack>::const_iterator iSimTrack=pTrackingParticle->g4Track_begin(); iSimTrack!=pTrackingParticle->g4Track_end(); ++iSimTrack )
-    {
-      // And see if the sim track identifiers match
-      if( iSimTrack->eventId()==identifier.second && iSimTrack->trackId()==identifier.first )
+	// Loop over all of the g4 tracks in the tracking particle
+	for( std::vector<SimTrack>::const_iterator iSimTrack=pTrackingParticle->g4Track_begin(); iSimTrack != pTrackingParticle->g4Track_end();
+			++iSimTrack )
 	{
-	  return true;
+		// And see if the sim track identifiers match
+		if( iSimTrack->eventId() == identifier.second && iSimTrack->trackId() == identifier.first )
+		{
+			return true;
+		}
 	}
-    }
 
-  // If control has made it this far then none of the identifiers were found in
-  // any of the g4 tracks, so return false.
-  return false;
+	// If control has made it this far then none of the identifiers were found in
+	// any of the g4 tracks, so return false.
+	return false;
 }
 
 template<typename iter> int QuickTrackAssociatorByHits::getDoubleCount( iter startIterator, iter endIterator, TrackingParticleRef associatedTrackingParticle ) const
 {
-  // This method is largely copied from the standard TrackAssociatorByHits. Once I've tested how much difference
-  // it makes I'll go through and comment it properly.
+	// This method is largely copied from the standard TrackAssociatorByHits. Once I've tested how much difference
+	// it makes I'll go through and comment it properly.
 
-  int doubleCount=0;
-  std::vector<SimHitIdpr> SimTrackIdsDC;
+	int doubleCount=0;
+	std::vector < SimHitIdpr > SimTrackIdsDC;
 
-  for( iter iHit=startIterator; iHit != endIterator; iHit++ )
-    {
-      int idcount=0;
+	for( iter iHit=startIterator; iHit != endIterator; iHit++ )
+	{
+		int idcount=0;
 
-      if (useClusterTPAssociation_) {
-	std::vector<OmniClusterRef> oClusters = getMatchedClusters(iHit, iHit+1);//only for the cluster being checked
-	for (std::vector<OmniClusterRef>::const_iterator it = oClusters.begin(); it != oClusters.end(); ++it) {	  
-	  std::pair<OmniClusterRef, TrackingParticleRef> clusterTPpairWithDummyTP(*it,TrackingParticleRef());//TP is dummy: for clusterTPAssociationListGreater sorting only the cluster is needed
-	  auto range = std::equal_range(pCluster2TPList_.begin(), pCluster2TPList_.end(), clusterTPpairWithDummyTP, clusterTPAssociationListGreater);
-	  if(range.first != range.second) {
-	    for(auto ip = range.first; ip != range.second; ++ip) {
-	      const TrackingParticleRef trackingParticle = (ip->second);
-	      if (associatedTrackingParticle==trackingParticle) {
-		idcount++;
-	      }
-	    }
-	  }
+		if( useClusterTPAssociation_ )
+		{
+			std::vector < OmniClusterRef > oClusters=getMatchedClusters( iHit, iHit + 1 );  //only for the cluster being checked
+			for( std::vector<OmniClusterRef>::const_iterator it=oClusters.begin(); it != oClusters.end(); ++it )
+			{
+				std::pair < OmniClusterRef, TrackingParticleRef > clusterTPpairWithDummyTP( *it, TrackingParticleRef() ); //TP is dummy: for clusterTPAssociationListGreater sorting only the cluster is needed
+				auto range=
+						std::equal_range( pCluster2TPList_.begin(), pCluster2TPList_.end(), clusterTPpairWithDummyTP, clusterTPAssociationListGreater );
+				if( range.first != range.second )
+				{
+					for( auto ip=range.first; ip != range.second; ++ip )
+					{
+						const TrackingParticleRef trackingParticle=(ip->second);
+						if( associatedTrackingParticle == trackingParticle )
+						{
+							idcount++;
+						}
+					}
+				}
+			}
+		}
+		else
+		{
+			SimTrackIdsDC.clear();
+			pHitAssociator_->associateHitId( *(getHitFromIter( iHit )), SimTrackIdsDC );
+			if( SimTrackIdsDC.size() > 1 )
+			{
+				for( TrackingParticle::g4t_iterator g4T=associatedTrackingParticle->g4Track_begin(); g4T != associatedTrackingParticle->g4Track_end();
+						++g4T )
+				{
+					if( find( SimTrackIdsDC.begin(), SimTrackIdsDC.end(), SimHitIdpr( ( *g4T).trackId(), SimTrackIdsDC.begin()->second ) )
+							!= SimTrackIdsDC.end() )
+					{
+						idcount++;
+					}
+				}
+			}
+		}
+		if( idcount > 1 ) doubleCount+=(idcount - 1);
 	}
-      } else {
-	SimTrackIdsDC.clear();
-	pHitAssociator_->associateHitId( *(getHitFromIter(iHit)), SimTrackIdsDC );
-	if( SimTrackIdsDC.size() > 1 )
-	  {
-	    for( TrackingParticle::g4t_iterator g4T=associatedTrackingParticle->g4Track_begin(); g4T != associatedTrackingParticle->g4Track_end(); ++g4T )
-	      {
-		if( find( SimTrackIdsDC.begin(), SimTrackIdsDC.end(), SimHitIdpr( ( *g4T).trackId(), SimTrackIdsDC.begin()->second ) )
-		    != SimTrackIdsDC.end() )
-		  {
-		    idcount++;
-		  }
-	      }
-	  }
-      }
-      if( idcount > 1 ) doubleCount+=(idcount - 1);
-    }
-  
-  return doubleCount;
-}
 
+	return doubleCount;
+}
 
 void QuickTrackAssociatorByHits::initialiseHitAssociator( const edm::Event* pEvent ) const
 {
@@ -602,137 +590,125 @@ void QuickTrackAssociatorByHits::initialiseHitAssociator( const edm::Event* pEve
 	pEventForWhichAssociatorIsValid_=pEvent;
 }
 
+reco::RecoToSimCollectionSeed QuickTrackAssociatorByHits::associateRecoToSim( edm::Handle<edm::View<TrajectorySeed> >& pSeedCollectionHandle_, edm::Handle<
+		TrackingParticleCollection>& trackingParticleCollectionHandle, const edm::Event * pEvent, const edm::EventSetup *setup ) const
+{
 
+	edm::LogVerbatim( "TrackAssociator" ) << "Starting TrackAssociatorByHits::associateRecoToSim - #seeds=" << pSeedCollectionHandle_->size()
+			<< " #TPs=" << trackingParticleCollectionHandle->size();
 
-reco::RecoToSimCollectionSeed  
-QuickTrackAssociatorByHits::associateRecoToSim(edm::Handle<edm::View<TrajectorySeed> >& pSeedCollectionHandle_,
-					       edm::Handle<TrackingParticleCollection>&  trackingParticleCollectionHandle,     
-					       const edm::Event * pEvent,
-					       const edm::EventSetup *setup ) const{
+	initialiseHitAssociator( pEvent );
 
-  edm::LogVerbatim("TrackAssociator") << "Starting TrackAssociatorByHits::associateRecoToSim - #seeds="
-                                      << pSeedCollectionHandle_->size()<<" #TPs="<<trackingParticleCollectionHandle->size();
+	reco::RecoToSimCollectionSeed returnValue;
 
-  initialiseHitAssociator( pEvent );
-  pTrackCollectionHandle_=nullptr;
-  pTrackingParticleCollectionHandle_=&trackingParticleCollectionHandle;
-  pTrackCollection_=nullptr;
-  pTrackingParticleCollection_=nullptr;
+	size_t collectionSize=pSeedCollectionHandle_->size();
 
-  reco::RecoToSimCollectionSeed  returnValue;
-
-  size_t collectionSize=pSeedCollectionHandle_->size();
-  
-  for( size_t i=0; i<collectionSize; ++i )
-    {
-      const TrajectorySeed* pSeed = &(*pSeedCollectionHandle_)[i];
-      
-      // The return of this function has first as the index and second as the number of associated hits
-      std::vector< std::pair<edm::Ref<TrackingParticleCollection>,size_t> > trackingParticleQualityPairs =  (useClusterTPAssociation_) 
-        ? associateTrackByCluster( pSeed->recHits().first,pSeed->recHits().second )
-        : associateTrack( pSeed->recHits().first,pSeed->recHits().second );
-      for( std::vector< std::pair<edm::Ref<TrackingParticleCollection>,size_t> >::const_iterator iTrackingParticleQualityPair=trackingParticleQualityPairs.begin();
-	   iTrackingParticleQualityPair!=trackingParticleQualityPairs.end(); ++iTrackingParticleQualityPair )
+	for( size_t i=0; i < collectionSize; ++i )
 	{
-	  const edm::Ref<TrackingParticleCollection>& trackingParticleRef=iTrackingParticleQualityPair->first;
-	  size_t numberOfSharedHits=iTrackingParticleQualityPair->second;
-	  size_t numberOfValidTrackHits=pSeed->recHits().second-pSeed->recHits().first;
-	  
-	  if( numberOfSharedHits==0 ) continue; // No point in continuing if there was no association
-	  
-	  //if electron subtract double counting
-	  if( abs(trackingParticleRef->pdgId())==11 && (trackingParticleRef->g4Track_end() - trackingParticleRef->g4Track_begin()) > 1 )
-	    {
-	      numberOfSharedHits-=getDoubleCount( pSeed->recHits().first, pSeed->recHits().second, trackingParticleRef );
-	    }
-	  
-	  double quality;
-	  if( absoluteNumberOfHits_ ) quality=static_cast<double>( numberOfSharedHits );
-	  else if( numberOfValidTrackHits != 0 ) quality=(static_cast<double>(numberOfSharedHits) / static_cast<double>(numberOfValidTrackHits) );
-	  else quality=0;
-	  
-	  if( quality > cutRecoToSim_ && !( threeHitTracksAreSpecial_ && numberOfValidTrackHits==3 && numberOfSharedHits<3 ) )
-	    {
-	      returnValue.insert( edm::RefToBase<TrajectorySeed>(pSeedCollectionHandle_,i), std::make_pair( trackingParticleRef, quality ));
-	    }
+		const TrajectorySeed* pSeed= &( *pSeedCollectionHandle_)[i];
+
+		// The return of this function has first as the index and second as the number of associated hits
+		std::vector < std::pair<edm::Ref<TrackingParticleCollection>,size_t> > trackingParticleQualityPairs=
+				(useClusterTPAssociation_) ? associateTrackByCluster( pSeed->recHits().first, pSeed->recHits().second ) : associateTrack( trackingParticleCollectionHandle, pSeed->recHits().first, pSeed->recHits().second );
+		for( std::vector<std::pair<edm::Ref<TrackingParticleCollection>,size_t> >::const_iterator iTrackingParticleQualityPair=
+				trackingParticleQualityPairs.begin(); iTrackingParticleQualityPair != trackingParticleQualityPairs.end();
+				++iTrackingParticleQualityPair )
+		{
+			const edm::Ref<TrackingParticleCollection>& trackingParticleRef=iTrackingParticleQualityPair->first;
+			size_t numberOfSharedHits=iTrackingParticleQualityPair->second;
+			size_t numberOfValidTrackHits=pSeed->recHits().second - pSeed->recHits().first;
+
+			if( numberOfSharedHits == 0 ) continue; // No point in continuing if there was no association
+
+			//if electron subtract double counting
+			if( abs( trackingParticleRef->pdgId() ) == 11 && (trackingParticleRef->g4Track_end() - trackingParticleRef->g4Track_begin()) > 1 )
+			{
+				numberOfSharedHits-=getDoubleCount( pSeed->recHits().first, pSeed->recHits().second, trackingParticleRef );
+			}
+
+			double quality;
+			if( absoluteNumberOfHits_ ) quality=static_cast<double>( numberOfSharedHits );
+			else if( numberOfValidTrackHits != 0 ) quality=
+					(static_cast<double>( numberOfSharedHits ) / static_cast<double>( numberOfValidTrackHits ));
+			else quality=0;
+
+			if( quality > cutRecoToSim_ && !(threeHitTracksAreSpecial_ && numberOfValidTrackHits == 3 && numberOfSharedHits < 3) )
+			{
+				returnValue.insert( edm::RefToBase < TrajectorySeed > (pSeedCollectionHandle_, i), std::make_pair( trackingParticleRef, quality ) );
+			}
+		}
 	}
-    }
-  
-  LogTrace("TrackAssociator") << "% of Assoc Seeds=" << ((double)returnValue.size())/((double)pSeedCollectionHandle_->size());
-  returnValue.post_insert();
-  return returnValue;
-  
+
+	LogTrace( "TrackAssociator" ) << "% of Assoc Seeds=" << ((double)returnValue.size()) / ((double)pSeedCollectionHandle_->size());
+	returnValue.post_insert();
+	return returnValue;
+
 }
 
+reco::SimToRecoCollectionSeed QuickTrackAssociatorByHits::associateSimToReco( edm::Handle<edm::View<TrajectorySeed> >& pSeedCollectionHandle_, edm::Handle<
+		TrackingParticleCollection>& trackingParticleCollectionHandle, const edm::Event * pEvent, const edm::EventSetup *setup ) const
+{
 
-reco::SimToRecoCollectionSeed
-QuickTrackAssociatorByHits::associateSimToReco(edm::Handle<edm::View<TrajectorySeed> >& pSeedCollectionHandle_,
-					       edm::Handle<TrackingParticleCollection>& trackingParticleCollectionHandle, 
-					       const edm::Event * pEvent,
-					       const edm::EventSetup *setup ) const{
+	edm::LogVerbatim( "TrackAssociator" ) << "Starting TrackAssociatorByHits::associateSimToReco - #seeds=" << pSeedCollectionHandle_->size()
+			<< " #TPs=" << trackingParticleCollectionHandle->size();
 
-  edm::LogVerbatim("TrackAssociator") << "Starting TrackAssociatorByHits::associateSimToReco - #seeds="
-                                      <<pSeedCollectionHandle_->size()<<" #TPs="<<trackingParticleCollectionHandle->size();
+	initialiseHitAssociator( pEvent );
 
-  initialiseHitAssociator( pEvent );
-  pTrackCollectionHandle_=nullptr;
-  pTrackingParticleCollectionHandle_=&trackingParticleCollectionHandle;
-  pTrackCollection_=nullptr;
-  pTrackingParticleCollection_=nullptr;
+	reco::SimToRecoCollectionSeed returnValue;
 
-  reco::SimToRecoCollectionSeed  returnValue;
+	size_t collectionSize=pSeedCollectionHandle_->size();
 
-  size_t collectionSize=pSeedCollectionHandle_->size();
-  
-  for( size_t i=0; i<collectionSize; ++i )
-    {
-      const TrajectorySeed* pSeed=&(*pSeedCollectionHandle_)[i];
-      
-      // The return of this function has first as an edm:Ref to the associated TrackingParticle, and second as the number of associated hits
-      std::vector< std::pair<edm::Ref<TrackingParticleCollection>,size_t> > trackingParticleQualityPairs =  (useClusterTPAssociation_) 
-        ? associateTrackByCluster( pSeed->recHits().first,pSeed->recHits().second )
-        : associateTrack( pSeed->recHits().first,pSeed->recHits().second );
-      for( std::vector< std::pair<edm::Ref<TrackingParticleCollection>,size_t> >::const_iterator iTrackingParticleQualityPair=trackingParticleQualityPairs.begin();
-	   iTrackingParticleQualityPair!=trackingParticleQualityPairs.end(); ++iTrackingParticleQualityPair )
+	for( size_t i=0; i < collectionSize; ++i )
 	{
-	  const edm::Ref<TrackingParticleCollection>& trackingParticleRef=iTrackingParticleQualityPair->first;
-	  size_t numberOfSharedHits=iTrackingParticleQualityPair->second;
-	  size_t numberOfValidTrackHits=pSeed->recHits().second-pSeed->recHits().first;
-	  size_t numberOfSimulatedHits=0; // Set a few lines below, but only if required.
-	  
-	  if( numberOfSharedHits==0 ) continue; // No point in continuing if there was no association
+		const TrajectorySeed* pSeed= &( *pSeedCollectionHandle_)[i];
 
-	  //if electron subtract double counting
-	  if( abs(trackingParticleRef->pdgId())==11 && (trackingParticleRef->g4Track_end() - trackingParticleRef->g4Track_begin()) > 1 )
-	    {
-	      numberOfSharedHits-=getDoubleCount( pSeed->recHits().first, pSeed->recHits().second, trackingParticleRef );
-	    }
-	  
-	  if( simToRecoDenominator_==denomsim || (numberOfSharedHits<3 && threeHitTracksAreSpecial_) ) // the numberOfSimulatedHits is not always required, so can skip counting in some circumstances
-	    {
-	      // Note that in the standard TrackAssociatorByHits, all of the hits in associatedTrackingParticleHits are checked for
-	      // various things.  I'm not sure what these checks are for but they depend on the UseGrouping and UseSplitting settings.
-	      // This associator works as though both UseGrouping and UseSplitting were set to true, i.e. just counts the number of
-	      // hits in the tracker.
-	      numberOfSimulatedHits=trackingParticleRef->numberOfTrackerHits();
-	    }
-	  
-	  double purity=static_cast<double>(numberOfSharedHits)/static_cast<double>(numberOfValidTrackHits);
-	  double quality;
-	  if( absoluteNumberOfHits_ ) quality=static_cast<double>(numberOfSharedHits);
-	  else if( simToRecoDenominator_==denomsim && numberOfSimulatedHits != 0 ) quality=static_cast<double>(numberOfSharedHits)/static_cast<double>(numberOfSimulatedHits);
-	  else if( simToRecoDenominator_==denomreco && numberOfValidTrackHits != 0 ) quality=purity;
-	  else quality=0;
-	  
-	  if( quality>qualitySimToReco_ && !( threeHitTracksAreSpecial_ && numberOfSimulatedHits==3 && numberOfSharedHits<3 ) && ( absoluteNumberOfHits_ || (purity>puritySimToReco_) ) )
-	    {
-	      returnValue.insert( trackingParticleRef, std::make_pair( edm::RefToBase<TrajectorySeed>(pSeedCollectionHandle_,i) , quality ) );
-	    }
+		// The return of this function has first as an edm:Ref to the associated TrackingParticle, and second as the number of associated hits
+		std::vector < std::pair<edm::Ref<TrackingParticleCollection>,size_t> > trackingParticleQualityPairs=
+				(useClusterTPAssociation_) ? associateTrackByCluster( pSeed->recHits().first, pSeed->recHits().second ) : associateTrack( trackingParticleCollectionHandle, pSeed->recHits().first, pSeed->recHits().second );
+		for( std::vector<std::pair<edm::Ref<TrackingParticleCollection>,size_t> >::const_iterator iTrackingParticleQualityPair=
+				trackingParticleQualityPairs.begin(); iTrackingParticleQualityPair != trackingParticleQualityPairs.end();
+				++iTrackingParticleQualityPair )
+		{
+			const edm::Ref<TrackingParticleCollection>& trackingParticleRef=iTrackingParticleQualityPair->first;
+			size_t numberOfSharedHits=iTrackingParticleQualityPair->second;
+			size_t numberOfValidTrackHits=pSeed->recHits().second - pSeed->recHits().first;
+			size_t numberOfSimulatedHits=0; // Set a few lines below, but only if required.
+
+			if( numberOfSharedHits == 0 ) continue; // No point in continuing if there was no association
+
+			//if electron subtract double counting
+			if( abs( trackingParticleRef->pdgId() ) == 11 && (trackingParticleRef->g4Track_end() - trackingParticleRef->g4Track_begin()) > 1 )
+			{
+				numberOfSharedHits-=getDoubleCount( pSeed->recHits().first, pSeed->recHits().second, trackingParticleRef );
+			}
+
+			if( simToRecoDenominator_ == denomsim || (numberOfSharedHits < 3 && threeHitTracksAreSpecial_) ) // the numberOfSimulatedHits is not always required, so can skip counting in some circumstances
+			{
+				// Note that in the standard TrackAssociatorByHits, all of the hits in associatedTrackingParticleHits are checked for
+				// various things.  I'm not sure what these checks are for but they depend on the UseGrouping and UseSplitting settings.
+				// This associator works as though both UseGrouping and UseSplitting were set to true, i.e. just counts the number of
+				// hits in the tracker.
+				numberOfSimulatedHits=trackingParticleRef->numberOfTrackerHits();
+			}
+
+			double purity=static_cast<double>( numberOfSharedHits ) / static_cast<double>( numberOfValidTrackHits );
+			double quality;
+			if( absoluteNumberOfHits_ ) quality=static_cast<double>( numberOfSharedHits );
+			else if( simToRecoDenominator_ == denomsim && numberOfSimulatedHits != 0 ) quality=static_cast<double>( numberOfSharedHits )
+					/ static_cast<double>( numberOfSimulatedHits );
+			else if( simToRecoDenominator_ == denomreco && numberOfValidTrackHits != 0 ) quality=purity;
+			else quality=0;
+
+			if( quality > qualitySimToReco_ && !(threeHitTracksAreSpecial_ && numberOfSimulatedHits == 3 && numberOfSharedHits < 3)
+					&& (absoluteNumberOfHits_ || (purity > puritySimToReco_)) )
+			{
+				returnValue.insert( trackingParticleRef, std::make_pair( edm::RefToBase < TrajectorySeed > (pSeedCollectionHandle_, i), quality ) );
+			}
+		}
 	}
-    }
-  return returnValue;
-  
-  LogTrace("TrackAssociator") << "% of Assoc TPs=" << ((double)returnValue.size())/((double)trackingParticleCollectionHandle->size());
-  returnValue.post_insert();
-  return returnValue;
+	return returnValue;
+
+	LogTrace( "TrackAssociator" ) << "% of Assoc TPs=" << ((double)returnValue.size()) / ((double)trackingParticleCollectionHandle->size());
+	returnValue.post_insert();
+	return returnValue;
 }

--- a/SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h
+++ b/SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h
@@ -62,23 +62,23 @@ class TrackerHitAssociator {
   // Destructor
   virtual ~TrackerHitAssociator(){}
   
-  std::vector<PSimHit> associateHit(const TrackingRecHit & thit);
+  std::vector<PSimHit> associateHit(const TrackingRecHit & thit) const;
   //for PU events
-  std::vector<SimHitIdpr> associateHitId(const TrackingRecHit & thit);
-  void associateHitId(const TrackingRecHit & thit,std::vector<SimHitIdpr> &simhitid);
+  std::vector<SimHitIdpr> associateHitId(const TrackingRecHit & thit) const;
+  void associateHitId(const TrackingRecHit & thit,std::vector<SimHitIdpr> &simhitid) const;
   template<typename T>
-    void associateSiStripRecHit(const T *simplerechit, std::vector<SimHitIdpr>& simtrackid);
+    void associateSiStripRecHit(const T *simplerechit, std::vector<SimHitIdpr>& simtrackid) const;
   void associateSimpleRecHitCluster(const SiStripCluster* clust,
 				    const uint32_t& detID,
-				    std::vector<SimHitIdpr>& simtrackid);
+				    std::vector<SimHitIdpr>& simtrackid) const;
 
-  std::vector<SimHitIdpr> associateMatchedRecHit(const SiStripMatchedRecHit2D * matchedrechit);
-  std::vector<SimHitIdpr> associateProjectedRecHit(const ProjectedSiStripRecHit2D * projectedrechit);
-  void associatePixelRecHit(const SiPixelRecHit * pixelrechit, std::vector<SimHitIdpr> & simhitid);
-  std::vector<SimHitIdpr> associateGSRecHit(const SiTrackerGSRecHit2D * gsrechit);
-  std::vector<SimHitIdpr> associateMultiRecHitId(const SiTrackerMultiRecHit * multirechit);
-  std::vector<PSimHit>    associateMultiRecHit(const SiTrackerMultiRecHit * multirechit);
-  std::vector<SimHitIdpr> associateGSMatchedRecHit(const SiTrackerGSMatchedRecHit2D * gsmrechit);
+  std::vector<SimHitIdpr> associateMatchedRecHit(const SiStripMatchedRecHit2D * matchedrechit) const;
+  std::vector<SimHitIdpr> associateProjectedRecHit(const ProjectedSiStripRecHit2D * projectedrechit) const;
+  void associatePixelRecHit(const SiPixelRecHit * pixelrechit, std::vector<SimHitIdpr> & simhitid) const;
+  std::vector<SimHitIdpr> associateGSRecHit(const SiTrackerGSRecHit2D * gsrechit) const;
+  std::vector<SimHitIdpr> associateMultiRecHitId(const SiTrackerMultiRecHit * multirechit) const;
+  std::vector<PSimHit>    associateMultiRecHit(const SiTrackerMultiRecHit * multirechit) const;
+  std::vector<SimHitIdpr> associateGSMatchedRecHit(const SiTrackerGSMatchedRecHit2D * gsmrechit) const;
   
   typedef std::map<unsigned int, std::vector<PSimHit> > simhit_map;
   simhit_map SimHitMap;
@@ -93,8 +93,6 @@ class TrackerHitAssociator {
 
   edm::Handle< edm::DetSetVector<StripDigiSimLink> >  stripdigisimlink;
   edm::Handle< edm::DetSetVector<PixelDigiSimLink> >  pixeldigisimlink;
-  //vector with the trackIds
-  std::vector<SimHitIdpr> simtrackid; 
   
   bool doPixel_, doStrip_, doTrackAssoc_;
   

--- a/SimTracker/TrackerHitAssociation/src/TrackerHitAssociator.cc
+++ b/SimTracker/TrackerHitAssociation/src/TrackerHitAssociator.cc
@@ -118,13 +118,13 @@ TrackerHitAssociator::TrackerHitAssociator(const edm::Event& e, const edm::Param
   
 }
 
-std::vector<PSimHit> TrackerHitAssociator::associateHit(const TrackingRecHit & thit) 
+std::vector<PSimHit> TrackerHitAssociator::associateHit(const TrackingRecHit & thit) const
 {
 
   //vector with the matched SimHit
   std::vector<PSimHit> result; 
   //initialize vectors!
-  simtrackid.clear();
+  std::vector<SimHitIdpr> simtrackid;
   
   //get the Detector type of the rechit
   DetId detid=  thit.geographicalId();
@@ -191,14 +191,14 @@ std::vector<PSimHit> TrackerHitAssociator::associateHit(const TrackingRecHit & t
   return result;  
 }
 
-std::vector< SimHitIdpr > TrackerHitAssociator::associateHitId(const TrackingRecHit & thit) 
+std::vector< SimHitIdpr > TrackerHitAssociator::associateHitId(const TrackingRecHit & thit) const
 {
   std::vector< SimHitIdpr > simhitid;
   associateHitId(thit, simhitid);
   return simhitid;
 }
 
-void TrackerHitAssociator::associateHitId(const TrackingRecHit & thit, std::vector< SimHitIdpr > & simtkid) 
+void TrackerHitAssociator::associateHitId(const TrackingRecHit & thit, std::vector< SimHitIdpr > & simtkid) const
 {
   
     simtkid.clear();
@@ -267,7 +267,7 @@ void TrackerHitAssociator::associateHitId(const TrackingRecHit & thit, std::vect
 }
 
 template<typename T>
-void TrackerHitAssociator::associateSiStripRecHit(const T *simplerechit, std::vector<SimHitIdpr>& simtrackid)
+void TrackerHitAssociator::associateSiStripRecHit(const T *simplerechit, std::vector<SimHitIdpr>& simtrackid) const
 {
   const SiStripCluster* clust = &(*simplerechit->cluster());
   associateSimpleRecHitCluster(clust,simplerechit->geographicalId(),simtrackid);
@@ -275,7 +275,7 @@ void TrackerHitAssociator::associateSiStripRecHit(const T *simplerechit, std::ve
 
 void TrackerHitAssociator::associateSimpleRecHitCluster(const SiStripCluster* clust,
 							const uint32_t& detID,
-							std::vector<SimHitIdpr>& simtrackid){
+							std::vector<SimHitIdpr>& simtrackid) const{
   //  std::cout <<"ASSOCIATE SIMPLE RECHIT" << std::endl;	    
   
   //to store temporary charge information
@@ -339,7 +339,7 @@ void TrackerHitAssociator::associateSimpleRecHitCluster(const SiStripCluster* cl
   }
 }
 
-std::vector<SimHitIdpr>  TrackerHitAssociator::associateMatchedRecHit(const SiStripMatchedRecHit2D * matchedrechit)
+std::vector<SimHitIdpr>  TrackerHitAssociator::associateMatchedRecHit(const SiStripMatchedRecHit2D * matchedrechit) const
 {
   vector<SimHitIdpr> matched_mono;
   vector<SimHitIdpr> matched_st;
@@ -353,8 +353,8 @@ std::vector<SimHitIdpr>  TrackerHitAssociator::associateMatchedRecHit(const SiSt
   associateSiStripRecHit(&st, matched_st );
   
   //save in a vector all the simtrack-id's that are common to mono and stereo hits
+  std::vector<SimHitIdpr> simtrackid;
   if(!matched_mono.empty() && !matched_st.empty()){
-    simtrackid.clear(); //final result vector
     std::vector<SimHitIdpr> idcachev;
     for(vector<SimHitIdpr>::iterator mhit=matched_mono.begin(); mhit != matched_mono.end(); mhit++){
       //save only once the ID
@@ -372,7 +372,7 @@ std::vector<SimHitIdpr>  TrackerHitAssociator::associateMatchedRecHit(const SiSt
 }
 
 
-std::vector<SimHitIdpr>  TrackerHitAssociator::associateProjectedRecHit(const ProjectedSiStripRecHit2D * projectedrechit)
+std::vector<SimHitIdpr>  TrackerHitAssociator::associateProjectedRecHit(const ProjectedSiStripRecHit2D * projectedrechit) const
 {
   //projectedRecHit is a "matched" rechit with only one component
 
@@ -385,7 +385,7 @@ std::vector<SimHitIdpr>  TrackerHitAssociator::associateProjectedRecHit(const Pr
 }
 
 //std::vector<unsigned int>  TrackerHitAssociator::associatePixelRecHit(const SiPixelRecHit * pixelrechit)
-void  TrackerHitAssociator::associatePixelRecHit(const SiPixelRecHit * pixelrechit, std::vector<SimHitIdpr> & simtrackid)
+void  TrackerHitAssociator::associatePixelRecHit(const SiPixelRecHit * pixelrechit, std::vector<SimHitIdpr> & simtrackid) const
 {
   //
   // Pixel associator
@@ -437,7 +437,7 @@ void  TrackerHitAssociator::associatePixelRecHit(const SiPixelRecHit * pixelrech
   }
 }
 
-std::vector<SimHitIdpr>  TrackerHitAssociator::associateGSRecHit(const SiTrackerGSRecHit2D * gsrechit)
+std::vector<SimHitIdpr>  TrackerHitAssociator::associateGSRecHit(const SiTrackerGSRecHit2D * gsrechit) const
 {
   //GSRecHit is the FastSimulation RecHit that contains the TrackId already
 
@@ -448,7 +448,7 @@ std::vector<SimHitIdpr>  TrackerHitAssociator::associateGSRecHit(const SiTracker
   return simtrackid;
 }
 
-std::vector<PSimHit> TrackerHitAssociator::associateMultiRecHit(const SiTrackerMultiRecHit * multirechit){
+std::vector<PSimHit> TrackerHitAssociator::associateMultiRecHit(const SiTrackerMultiRecHit * multirechit) const{
   std::vector<const TrackingRecHit*> componenthits = multirechit->recHits();
   //        std::vector<PSimHit> assimhits;
   int size=multirechit->weights().size(), idmostprobable=0;
@@ -460,7 +460,7 @@ std::vector<PSimHit> TrackerHitAssociator::associateMultiRecHit(const SiTrackerM
   return associateHit(*componenthits[idmostprobable]);
 }
 
-std::vector<SimHitIdpr> TrackerHitAssociator::associateMultiRecHitId(const SiTrackerMultiRecHit * multirechit){
+std::vector<SimHitIdpr> TrackerHitAssociator::associateMultiRecHitId(const SiTrackerMultiRecHit * multirechit) const{
   std::vector<const TrackingRecHit*> componenthits = multirechit->recHits();
   int size=multirechit->weights().size(), idmostprobable=0;
   
@@ -471,7 +471,7 @@ std::vector<SimHitIdpr> TrackerHitAssociator::associateMultiRecHitId(const SiTra
   return associateHitId(*componenthits[idmostprobable]);
 }
 
-std::vector<SimHitIdpr>  TrackerHitAssociator::associateGSMatchedRecHit(const SiTrackerGSMatchedRecHit2D * gsmrechit)
+std::vector<SimHitIdpr>  TrackerHitAssociator::associateGSMatchedRecHit(const SiTrackerGSMatchedRecHit2D * gsmrechit) const
 {
   //GSRecHit is the FastSimulation RecHit that contains the TrackId already
   


### PR DESCRIPTION
Removed all mutable members from QuickTrackAssociatorByHits to (as far as I can tell) make it thread safe.  There are now no members modified outside of the constructor.  I've only done limited testing with the 25202.0 matrix test, results are attached.  Even though it's only 10 events everything appears to overlay exactly.

Note that I expect two differences to the old code:
1. More LogInfo messages when there is a particular failure - The configuration parameter useClusterTPAssociation_ used to be mutable and was changed to false if retrieving the cluster to TrackingParticle map from the event failed.  So previously only one LogInfo message was displayed in this case and then it reverted to permanently using the hit associator.  Now a LogInfo message will be displayed every time this fails (but still reverts to the hit associator).  This failure mode is unlikely anyway.
2. Accidentally fixed (I think) a bug in TrackerHitAssociator where the results from a previous method call could be returned - For convenience I changed all the methods in TrackerHitAssociator to be "const" since no internal changes should be made after construction. In doing so I had to remove a member (simtrackid) which is only ever used as a local variable, and in most cases is actually shadowed by local variables of different types. There is one logic possibility where I think the value of simtrackid from a previous call could be returned.  So I think this actually fixes a bug.  I'll comment on this line specifically once the request is submitted (I don't seem to be able to do so while creating the request??).

Here are some of the tracking validation plots from matrix test 25202.0.

![effandfake1](https://cloud.githubusercontent.com/assets/6480160/2859103/d9feddbc-d199-11e3-9ccc-c867d9f7b1b5.png)
![effandfake2](https://cloud.githubusercontent.com/assets/6480160/2859104/dff82e1c-d199-11e3-9325-67b2af38ebd8.png)
![dupandfake1](https://cloud.githubusercontent.com/assets/6480160/2859109/f118d886-d199-11e3-9d66-c71e657d8e12.png)
![dupandfake2](https://cloud.githubusercontent.com/assets/6480160/2859111/f6f8c374-d199-11e3-821f-9524961806a5.png)
![hitsandpt](https://cloud.githubusercontent.com/assets/6480160/2859112/0e901f3c-d19a-11e3-8c93-0873d55d32db.png)
![pulls](https://cloud.githubusercontent.com/assets/6480160/2859113/1e478d02-d19a-11e3-86f7-5ad9b24d2b7c.png)
