### PR TITLE
Removed unused variables

### DIFF
--- a/FWCore/Framework/bin/cmsRun.cpp
+++ b/FWCore/Framework/bin/cmsRun.cpp
@@ -54,7 +54,6 @@ static char const* const kSizeOfStackForThreadOpt = "sizeOfStackForThreadsInKB";
 static char const* const kHelpOpt = "help";
 static char const* const kHelpCommandOpt = "help,h";
 static char const* const kStrictOpt = "strict";
-static char const* const kProgramName = "cmsRun";
 
 // -----------------------------------------------
 namespace {

--- a/FWCore/Framework/test/EventSelector_t.cpp
+++ b/FWCore/Framework/test/EventSelector_t.cpp
@@ -21,7 +21,6 @@ using namespace edm;
 const size_t numBits = 5;
 const int numPatterns = 11;
 const int numMasks = 9;
-const int numAns = numPatterns * numMasks;
 
 typedef bool Answers[numPatterns][numMasks];
 typedef std::vector<std::string> Strings;

--- a/FWCore/TFWLiteSelector/src/TFWLiteSelectorBasic.cc
+++ b/FWCore/TFWLiteSelector/src/TFWLiteSelectorBasic.cc
@@ -437,7 +437,6 @@ TFWLiteSelectorBasic::setupNewFile(TFile& iFile) {
   edm::ProductRegistry::ProductList& prodList2 = m_->reg_->productListUpdator();
   std::vector<edm::EventEntryDescription> temp(prodList2.size(), edm::EventEntryDescription());
   m_->prov_.swap(temp);
-  std::vector<edm::EventEntryDescription>::iterator itB = m_->prov_.begin();
   m_->pointerToBranchBuffer_.reserve(prodList2.size());
 
   for(auto& item : prodList2) {


### PR DESCRIPTION
The unused variables were causing clang to issue error messages.
