### PR TITLE
Fix clang errors in EventFilter.

### DIFF
--- a/EventFilter/CSCRawToDigi/interface/CSCALCTHeader.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCALCTHeader.h
@@ -38,7 +38,7 @@ class CSCALCTHeader {
   enum FIFO_MODE {NO_DUMP, FULL_DUMP, LOCAL_DUMP};
   unsigned short int FIFOMode()       const {return header2006.fifoMode;} 
   unsigned short int NTBins()         const {
-    switch (firmwareVersion)
+    switch (firmwareVersion.load())
       {
       case 2006:
         return header2006.nTBins;
@@ -54,7 +54,7 @@ class CSCALCTHeader {
   unsigned short int ExtTrig()        const {return header2006.extTrig;}
   unsigned short int CSCID()          const {return header2006.cscID;}
   unsigned short int BXNCount()       const {
-    switch (firmwareVersion)
+    switch (firmwareVersion.load())
       {
       case 2006:
         return header2006.bxnCount;
@@ -67,7 +67,7 @@ class CSCALCTHeader {
       }
   }
   unsigned short int L1Acc()          const {
-    switch (firmwareVersion)
+    switch (firmwareVersion.load())
       {
       case 2006:
         return header2006.l1Acc;
@@ -97,7 +97,7 @@ class CSCALCTHeader {
  
   /// in 16-bit words
   int sizeInWords() {
-    switch (firmwareVersion)
+    switch (firmwareVersion.load())
       {
       case 2006:
         return 8;
@@ -111,7 +111,7 @@ class CSCALCTHeader {
   }
   
   bool check() const {
-    switch (firmwareVersion)
+    switch (firmwareVersion.load())
       {
       case 2006:
 	return header2006.flag_0 == 0xC;

--- a/EventFilter/CSCRawToDigi/plugins/CSCDCCUnpacker.cc
+++ b/EventFilter/CSCRawToDigi/plugins/CSCDCCUnpacker.cc
@@ -946,7 +946,7 @@ void CSCDCCUnpacker::visual_raw(int hl,int id, int run, int event,bool fedshort,
 		 }
 		 
 		 //DDU Trailer 3
-	  else if((ddu_tr1_check[-1])&&(tempbuf_short[0]==ddu_trailer3_bit[0])){
+	  else if((ddu_h2_h1)&&(tempbuf_short[0]==ddu_trailer3_bit[0])){
 	  //&&(tempbuf_short[0]==ddu_trailer3_bit[0])){
                  ddu_inst_i = ddu_h1_n_coll.size();
                  if(ddu_inst_i>0){ 

--- a/EventFilter/CSCRawToDigi/src/CSCALCTHeader.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCALCTHeader.cc
@@ -54,7 +54,7 @@ CSCALCTHeader::CSCALCTHeader(const unsigned short * buf) {
   LogTrace("CSCALCTHeader|CSCRawToDigi") << "firmware version - " << firmwareVersion;
 
   ///Now fill data 
-  switch (firmwareVersion) {
+  switch (firmwareVersion.load()) {
   case 2006:
     memcpy(&header2006, buf, header2006.sizeInWords()*2);///the header part
     buf +=header2006.sizeInWords();
@@ -140,7 +140,7 @@ std::vector<CSCALCTDigi> CSCALCTHeader::ALCTDigis() const
 { 
   std::vector<CSCALCTDigi> result;
 
-  switch (firmwareVersion) {
+  switch (firmwareVersion.load()) {
   case 2006:
     {
       result = alcts2006.ALCTDigis();

--- a/EventFilter/CSCRawToDigi/src/CSCCFEBTimeSlice.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCCFEBTimeSlice.cc
@@ -5,9 +5,7 @@
 
 // a Gray code is An ordering of 2n binary numbers such that
 // only one bit changes from one entry to the next
-const unsigned layerGrayCode[] = {3,1,5,6,4,2};
 const unsigned layerInverseGrayCode[] = {1,5,0,4,2,3};
-const unsigned channelGrayCode[] = {0,1,3,2, 6,7,5,4, 12,13,15,14, 10,11,9,8};
 const unsigned channelInverseGrayCode[] = {0,1,3,2, 7,6,4,5, 15,14,12,13, 8,9,11,10};
 
 CSCCFEBTimeSlice::CSCCFEBTimeSlice() 

--- a/EventFilter/SiPixelRawToDigi/src/ErrorChecker.cc
+++ b/EventFilter/SiPixelRawToDigi/src/ErrorChecker.cc
@@ -40,8 +40,6 @@ namespace {
   constexpr ErrorChecker::Word32 ERROR_mask = ~(~ErrorChecker::Word32(0) << ROC_bits);
   constexpr ErrorChecker::Word32 LINK_mask = ~(~ErrorChecker::Word32(0) << LINK_bits);
   constexpr ErrorChecker::Word32 ROC_mask  = ~(~ErrorChecker::Word32(0) << ROC_bits);
-  constexpr ErrorChecker::Word32 DCOL_mask = ~(~ErrorChecker::Word32(0) << DCOL_bits);
-  constexpr ErrorChecker::Word32 PXID_mask = ~(~ErrorChecker::Word32(0) << PXID_bits);
   constexpr ErrorChecker::Word32 OMIT_ERR_mask = ~(~ErrorChecker::Word32(0) << OMIT_ERR_bits);
 }  
 

--- a/EventFilter/SiPixelRawToDigi/src/PixelDataFormatter.cc
+++ b/EventFilter/SiPixelRawToDigi/src/PixelDataFormatter.cc
@@ -41,7 +41,6 @@ namespace {
   constexpr PixelDataFormatter::Word32 PXID_mask = ~(~PixelDataFormatter::Word32(0) << PXID_bits);
   constexpr PixelDataFormatter::Word32 ADC_mask  = ~(~PixelDataFormatter::Word32(0) << ADC_bits);
 
-  constexpr PixelDataFormatter::Word64 WORD32_mask = 0xffffffff;
 }
 
 PixelDataFormatter::PixelDataFormatter( const SiPixelFedCabling* map)

--- a/EventFilter/Utilities/src/DataPoint.cc
+++ b/EventFilter/Utilities/src/DataPoint.cc
@@ -18,8 +18,10 @@
 
 using namespace jsoncollector;
 
-template class HistoJ<unsigned int>;
-template class HistoJ<double>;
+namespace jsoncollector {
+  template class HistoJ<unsigned int>;
+  template class HistoJ<double>;
+}
 
 const std::string DataPoint::SOURCE = "source";
 const std::string DataPoint::DEFINITION = "definition";


### PR DESCRIPTION
Most of them are trivial. However have a look at the one in:

EventFilter/CSCRawToDigi/plugins/CSCDCCUnpacker.cc

where a -1 index is used. I changed it with the actual name of the preceding variable, however someone should check this is not a typo. 
