### PR TITLE
Shashlik detId extension

### DIFF
--- a/DataFormats/EcalDetId/interface/EKDetId.h
+++ b/DataFormats/EcalDetId/interface/EKDetId.h
@@ -37,6 +37,15 @@ public:
    */
   EKDetId(int module_ix, int module_iy, int fiber, int ro, int iz); 
   
+  /** Constructor from geometry module ix,iy,iz (iz=+1/-1)
+   * <p>ix runs from 1 to N along x-axis of standard CMS coordinates<br>
+   * iy runs from 1 to N along y-axis of standard CMS coordinates<br>
+   * N depends on the configuration == see ShashlikDDDConstants<br>
+   * iz is -1 for EK- and +1 for EK+<br>
+   * fib and ro are forced to 0 as irrelevant for geometry
+   */
+  EKDetId(int module_ix, int module_iy, int iz); 
+  
   /** Constructor from a generic cell id
    * @param id source detid
    */
@@ -46,6 +55,11 @@ public:
    * @param id source det id
    */ 
   EKDetId& operator=(const DetId& id) {id_ = id.rawId(); return *this;}
+  
+  /** Converter for a geometry cell id
+   * @param id full EKDetId 
+   */
+  EKDetId geometryCell () const {return EKDetId (ix(), iy(), zside());}
   
   /** Set fiber number and RO type
    * @param fib number
@@ -99,7 +113,25 @@ public:
    * @param b det id of second module
    * @return distance
    */
-  static int distanceY(const EKDetId& a,const EKDetId& b); 
+  static int distanceY(const EKDetId& a,const EKDetId& b);
+
+  /** static loose hash index for Geometry EK cells
+   */
+  enum {
+    kSizeForDenseIndexing = 
+    2 * 4 *   // +-Z * 4 sectors
+    21 * 21 * // maximum supermodules in quadrant  
+    5 * 5     // modules in SM
+  };
+
+  /**  static loose hash index for Geometry cell (fiber/ro information is tripped)
+   */
+  uint32_t denseIndex() const;
+
+  /** static loose hash index for Geometry cell (fiber/ro information is tripped) 
+   */
+  static EKDetId detIdFromDenseIndex( uint32_t din );
+ 
 };
 
 std::ostream& operator<<(std::ostream& s,const EKDetId& id);

--- a/DataFormats/EcalDetId/interface/EcalDetIdCollections.h
+++ b/DataFormats/EcalDetId/interface/EcalDetIdCollections.h
@@ -5,6 +5,7 @@
 
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
 #include "DataFormats/EcalDetId/interface/EEDetId.h"
+#include "DataFormats/EcalDetId/interface/EKDetId.h"
 #include "DataFormats/EcalDetId/interface/EcalElectronicsId.h"
 #include "DataFormats/EcalDetId/interface/EcalTrigTowerDetId.h"
 #include "DataFormats/EcalDetId/interface/EcalScDetId.h"
@@ -13,6 +14,7 @@
 
 typedef edm::EDCollection<EBDetId> EBDetIdCollection;
 typedef edm::EDCollection<EEDetId> EEDetIdCollection;
+typedef edm::EDCollection<EKDetId> EKDetIdCollection;
 typedef edm::EDCollection<EcalElectronicsId> EcalElectronicsIdCollection;
 typedef edm::EDCollection<EcalTriggerElectronicsId> EcalTriggerElectronicsIdCollection;
 typedef edm::EDCollection<EcalTrigTowerDetId> EcalTrigTowerDetIdCollection;

--- a/DataFormats/EcalDetId/src/EKDetId.cc
+++ b/DataFormats/EcalDetId/src/EKDetId.cc
@@ -10,6 +10,11 @@ EKDetId::EKDetId(int module_ix, int module_iy, int fiber, int ro,
     ((fiber&0x7)<<16) | ((ro&0x3)<<19) | ((iz>0)?(0x200000):(0));
 }
 
+EKDetId::EKDetId(int module_ix, int module_iy, int iz) 
+  : DetId( Ecal, EcalShashlik) {
+  id_ |= (module_iy&0xff) | ((module_ix&0xff)<<8) | ((iz>0)?(0x200000):(0));
+}
+
 void EKDetId::setFiber(int fib, int ro) {
   uint32_t idc = (id_ & 0xffe0ffff);
   id_ = (idc) | ((fib&0x7)<<16) | ((ro&0x3)<<19);
@@ -21,6 +26,19 @@ int EKDetId::distanceX(const EKDetId& a,const EKDetId& b) {
 
 int EKDetId::distanceY(const EKDetId& a,const EKDetId& b) {
   return abs(a.iy() - b.iy()); 
+}
+
+const int MAX_ROW = 42; 
+const int MAX_MODULE = MAX_ROW * 5; 
+uint32_t EKDetId::denseIndex() const {
+  return (ix() * MAX_MODULE + iy()) * 2 + (zside()>0 ? 1 : 0);
+}
+
+EKDetId EKDetId::detIdFromDenseIndex( uint32_t din ) {
+  unsigned iz = din % 2;
+  unsigned iy = (din /= 2) % MAX_MODULE; 
+  unsigned ix = (din /= MAX_MODULE) % MAX_MODULE; 
+  return EKDetId (ix, iy, (iz == 0 ? -1 : 1));
 }
 
 #include <ostream>

--- a/DataFormats/EcalDetId/src/classes.h
+++ b/DataFormats/EcalDetId/src/classes.h
@@ -1,6 +1,7 @@
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
 #include <boost/cstdint.hpp> 
 #include "DataFormats/EcalDetId/interface/EEDetId.h"
+#include "DataFormats/EcalDetId/interface/EKDetId.h"
 #include "DataFormats/EcalDetId/interface/ESDetId.h"
 #include "DataFormats/EcalDetId/interface/EcalElectronicsId.h"
 #include "DataFormats/EcalDetId/interface/EcalTriggerElectronicsId.h"
@@ -14,12 +15,14 @@ namespace {
   struct dictionary {
     edm::EDCollection<EBDetId> vEBDI_;
     edm::EDCollection<EEDetId> vEEDI_;
+    edm::EDCollection<EKDetId> vEKDI_;
     edm::EDCollection<EcalTrigTowerDetId> vETTDI_;
     edm::EDCollection<EcalElectronicsId> vEELI_;
     edm::EDCollection<EcalTriggerElectronicsId> vETELI_;
 
     EBDetIdCollection theEBDI_;
     EEDetIdCollection theEEDI_;
+    EKDetIdCollection theEKDI_;
     EcalTrigTowerDetIdCollection theETTDI_;
     EcalScDetIdCollection theESCDI_;
     EcalElectronicsIdCollection theEELI_;
@@ -27,6 +30,7 @@ namespace {
 
     edm::Wrapper<EBDetIdCollection> anotherEBDIw_;
     edm::Wrapper<EEDetIdCollection> anotherEEDIw_;
+    edm::Wrapper<EKDetIdCollection> anotherEKDIw_;
     edm::Wrapper<EcalTrigTowerDetIdCollection> anothertheETTDIw_;
     edm::Wrapper<EcalScDetIdCollection> anothertheESCDIw_;
     edm::Wrapper<EcalElectronicsIdCollection> anothertheEELIw_;
@@ -34,6 +38,7 @@ namespace {
 
     edm::Wrapper< edm::EDCollection<EBDetId> > theEBDIw_;
     edm::Wrapper< edm::EDCollection<EEDetId> > theEEDIw_;
+    edm::Wrapper< edm::EDCollection<EKDetId> > theEKDIw_;
     edm::Wrapper< edm::EDCollection<EcalTrigTowerDetId> > theETTDIw_;
     edm::Wrapper< edm::EDCollection<EcalScDetIdCollection> > theESCDIw_;
     edm::Wrapper< edm::EDCollection<EcalElectronicsId> > theEELIw_;
@@ -42,10 +47,12 @@ namespace {
     // needed for channel recovery
     std::set<EBDetId> _ebDetId;
     std::set<EEDetId> _eeDetId;
+    std::set<EKDetId> _ekDetId;
     std::set<EcalTrigTowerDetId> _TTId;
     std::set<EcalScDetId> _SCId;
     edm::Wrapper< std::set<EBDetId> > _ebDetIdw;
     edm::Wrapper< std::set<EEDetId> > _eeDetIdw;
+    edm::Wrapper< std::set<EKDetId> > _ekDetIdw;
     edm::Wrapper< std::set<EcalTrigTowerDetId> > _TTIdw;
     edm::Wrapper< std::set<EcalScDetId> > _SCIdw;
  };

--- a/DataFormats/EcalDetId/src/classes_def.xml
+++ b/DataFormats/EcalDetId/src/classes_def.xml
@@ -5,6 +5,9 @@
   <class name="EEDetId" ClassVersion="10">
    <version ClassVersion="10" checksum="18639436"/>
   </class>
+  <class name="EKDetId" ClassVersion="10">
+   <version ClassVersion="10" checksum="18993730"/>
+  </class>
   <class name="ESDetId" ClassVersion="10">
    <version ClassVersion="10" checksum="19466122"/>
   </class>
@@ -25,25 +28,30 @@
   </class>
   <class name="std::vector<EBDetId>"/>
   <class name="std::vector<EEDetId>"/>
+  <class name="std::vector<EKDetId>"/>
   <class name="std::vector<EcalTrigTowerDetId>"/>
   <class name="std::vector<EcalElectronicsId>"/>
   <class name="std::vector<EcalTriggerElectronicsId>"/>
   <class name="std::set<EBDetId>"/>
   <class name="std::set<EEDetId>"/>
+  <class name="std::set<EKDetId>"/>
   <class name="std::set<EcalTrigTowerDetId>"/>
   <class name="std::set<EcalScDetId>"/>
   <class name="edm::Wrapper<std::set<EBDetId> > "/>
   <class name="edm::Wrapper<std::set<EEDetId> > "/>
+  <class name="edm::Wrapper<std::set<EKDetId> > "/>
   <class name="edm::Wrapper<std::set<EcalTrigTowerDetId> > "/>
   <class name="edm::Wrapper<std::set<EcalScDetId> > "/>
   <class name="edm::EDCollection<EBDetId> "/>
   <class name="edm::EDCollection<EEDetId> "/>
+  <class name="edm::EDCollection<EKDetId> "/>
   <class name="edm::EDCollection<EcalTrigTowerDetId> "/>
   <class name="edm::EDCollection<EcalScDetId> "/>
   <class name="edm::EDCollection<EcalElectronicsId> " />
   <class name="edm::EDCollection<EcalTriggerElectronicsId> " />
   <class name="edm::Wrapper<edm::EDCollection<EBDetId> > " id="EF1C41A8-6FCA-DDC6-7463-3208C2AEE68F"/>
   <class name="edm::Wrapper<edm::EDCollection<EEDetId> > " id="182A27B1-7C9F-3114-027F-BF26932C6CD0"/>
+  <class name="edm::Wrapper<edm::EDCollection<EKDetId> > " id="a57e7766-5753-5402-b72b-8b69b47e142a"/>
   <class name="edm::Wrapper<edm::EDCollection<EcalTrigTowerDetId> > " id="3177FB3F-B69D-07EC-D5BE-A0AFF6A4D78F"/>
   <class name="edm::Wrapper<edm::EDCollection<EcalScDetId> > " id="364d0ca9-8daa-4baf-8203-9d86881b51ff"/>
   <class name="edm::Wrapper<edm::EDCollection<EcalElectronicsId> > " id="1CCDC3B0-D381-60A8-E3B1-B75C4D0F6802"/>


### PR DESCRIPTION
-Extend Shashlik DetId by geometrical ID and loose hash index
-Define dictionaries for all EKDetId related objects
