### PR TITLE
fix NavigationSchoolESProducer template

### DIFF
--- a/RecoTracker/TkNavigation/python/BeamHaloNavigationSchoolESProducer_cfi.py
+++ b/RecoTracker/TkNavigation/python/BeamHaloNavigationSchoolESProducer_cfi.py
@@ -1,7 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
-beamHaloNavigationSchoolESProducer = cms.ESProducer("NavigationSchoolESProducer",
-    ComponentName = cms.string('BeamHaloNavigationSchool')
-)
+from RecoTracker.TkNavigation.NavigationSchoolESProducer_cfi import *
+beamHaloNavigationSchoolESProducer = navigationSchoolESProducer.clone()
+beamHaloNavigationSchoolESProducer.ComponentName       = cms.string('BeamHaloNavigationSchool')
+beamHaloNavigationSchoolESProducer.SimpleMagneticField = cms.string('')
 
 


### PR DESCRIPTION
update BeamHaloNavigationSchoolESProducer_cfi.py 
in order to have only one instance of the NavigationSchool producer
this is needed for a proper CMSSW templates parsing and corresponding injection into confDB
@Martin-Grunewald @fwyzard @cerati @rovere @perrotta 
