### PR TITLE
turn off MET significance calculation in CaloMETs

### DIFF
--- a/RecoMET/METProducers/interface/CaloMETProducer.h
+++ b/RecoMET/METProducers/interface/CaloMETProducer.h
@@ -43,7 +43,7 @@ namespace cms
     {
     public:
       explicit CaloMETProducer(const edm::ParameterSet&);
-      virtual ~CaloMETProducer() { }
+      virtual ~CaloMETProducer();
       virtual void produce(edm::Event&, const edm::EventSetup&) override;
 
     private:

--- a/RecoMET/METProducers/python/CaloMET_cfi.py
+++ b/RecoMET/METProducers/python/CaloMET_cfi.py
@@ -1,17 +1,13 @@
 import FWCore.ParameterSet.Config as cms
 
 ##____________________________________________________________________________||
-from RecoMET.METProducers.METSigParams_cfi import *
-
-##____________________________________________________________________________||
 met = cms.EDProducer(
     "CaloMETProducer",
-    METSignificance_params,
     src = cms.InputTag("towerMaker"),
     alias = cms.string('RawCaloMET'),
     noHF = cms.bool(False),
     globalThreshold = cms.double(0.3),
-    calculateSignificance = cms.bool(True)
+    calculateSignificance = cms.bool(False)
     )
 
 ##____________________________________________________________________________||
@@ -22,12 +18,11 @@ metHO.alias = 'RawCaloMETHO'
 ##____________________________________________________________________________||
 metOpt = cms.EDProducer(
     "CaloMETProducer",
-    METSignificance_params,
     src = cms.InputTag("calotoweroptmaker"),
     alias = cms.string('RawCaloMETOpt'),
     noHF = cms.bool(False),
     globalThreshold = cms.double(0.0),
-    calculateSignificance = cms.bool(True)
+    calculateSignificance = cms.bool(False)
     )
 
 ##____________________________________________________________________________||
@@ -38,12 +33,11 @@ metOptHO.alias = 'RawCaloMETOptHO'
 ##____________________________________________________________________________||
 metNoHF = cms.EDProducer(
     "CaloMETProducer",
-    METSignificance_params,
     src = cms.InputTag("towerMaker"),
     alias = cms.string('RawCaloMETNoHF'),
     noHF = cms.bool(True),
     globalThreshold = cms.double(0.3),
-    calculateSignificance = cms.bool(True)
+    calculateSignificance = cms.bool(False)
 )
 
 ##____________________________________________________________________________||
@@ -54,12 +48,11 @@ metNoHFHO.alias = 'RawCaloMETNoHFHO'
 ##____________________________________________________________________________||
 metOptNoHF = cms.EDProducer(
     "CaloMETProducer",
-    METSignificance_params,
     src = cms.InputTag("calotoweroptmaker"),
     alias = cms.string('RawCaloMETOptNoHF'),
     noHF = cms.bool(True),
     globalThreshold = cms.double(0.0),
-    calculateSignificance = cms.bool(True)
+    calculateSignificance = cms.bool(False)
     )
 
 ##____________________________________________________________________________||

--- a/RecoMET/METProducers/src/CaloMETProducer.cc
+++ b/RecoMET/METProducers/src/CaloMETProducer.cc
@@ -41,7 +41,7 @@ namespace cms
     std::string alias(iConfig.getParameter<std::string>("alias"));
     produces<reco::CaloMETCollection>().setBranchAlias(alias.c_str());
 
-    resolutions_ = new metsig::SignAlgoResolutions(iConfig);
+    if (calculateSignificance_) resolutions_ = new metsig::SignAlgoResolutions(iConfig);
   }
 
 //____________________________________________________________________________||

--- a/RecoMET/METProducers/src/CaloMETProducer.cc
+++ b/RecoMET/METProducers/src/CaloMETProducer.cc
@@ -34,6 +34,7 @@ namespace cms
   CaloMETProducer::CaloMETProducer(const edm::ParameterSet& iConfig)
     : inputToken_(consumes<edm::View<reco::Candidate> >(iConfig.getParameter<edm::InputTag>("src")))
     , calculateSignificance_(iConfig.getParameter<bool>("calculateSignificance"))
+    , resolutions_(0)
     , globalThreshold_(iConfig.getParameter<double>("globalThreshold"))
   {
     noHF_ = iConfig.getParameter<bool>("noHF");
@@ -42,6 +43,12 @@ namespace cms
     produces<reco::CaloMETCollection>().setBranchAlias(alias.c_str());
 
     if (calculateSignificance_) resolutions_ = new metsig::SignAlgoResolutions(iConfig);
+  }
+
+//____________________________________________________________________________||
+  CaloMETProducer::~CaloMETProducer()
+  {
+    if (resolutions_) delete resolutions_;
   }
 
 //____________________________________________________________________________||

--- a/RecoMET/METProducers/test/recoMET_caloMet_cfg.py
+++ b/RecoMET/METProducers/test/recoMET_caloMet_cfg.py
@@ -8,7 +8,9 @@ process.load("FWCore.MessageLogger.MessageLogger_cfi")
 
 ##____________________________________________________________________________||
 process.load("RecoMET.Configuration.CaloTowersOptForMET_cff")
-process.load("RecoMET.Configuration.RecoMET_cff")
+process.load("RecoMET.METProducers.CaloMET_cfi")
+process.load("RecoMET.METProducers.METSigParams_cfi")
+process.load("RecoMET.METProducers.MetMuonCorrections_cff")
 process.load("RecoJets.Configuration.CaloTowersRec_cff")
 process.load("Configuration.StandardSequences.Geometry_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
@@ -43,6 +45,12 @@ process.MessageLogger.cerr.FwkReport.reportEvery = 50
 process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(10))
 
 ##____________________________________________________________________________||
+process.metWithSignificance = process.met.clone(
+    process.METSignificance_params,
+    calculateSignificance = cms.bool(True)
+    )
+
+##____________________________________________________________________________||
 process.p = cms.Path(
     process.calotoweroptmaker *
     process.calotoweroptmakerWithHO *
@@ -55,7 +63,8 @@ process.p = cms.Path(
     process.metOptNoHF *
     process.metOptHO *
     process.metOptNoHFHO *
-    process.corMetGlobalMuons
+    process.corMetGlobalMuons *
+    process.metWithSignificance
     )
 
 process.e1 = cms.EndPath(


### PR DESCRIPTION
This PR turns off MET significance calculation in CaloMETs

We discussed this change at the RECO meeting on 17-Apr-2014: https://indico.cern.ch/event/313948/contribution/18
