### PR TITLE
Change cfg parameter so that the correct collections are read

### DIFF
--- a/DQM/DTMonitorModule/python/dtDataIntegrityTask_cfi.py
+++ b/DQM/DTMonitorModule/python/dtDataIntegrityTask_cfi.py
@@ -4,8 +4,8 @@ DTDataIntegrityTask = cms.EDAnalyzer("DTDataIntegrityTask",
                                      getSCInfo = cms.untracked.bool(True),
                                      fedIntegrityFolder = cms.untracked.string("DT/FEDIntegrity"),
                                      processingMode     = cms.untracked.string("Online"),
-                                     dtDDULabel         = cms.InputTag("dtunpacker"),
-                                     dtROS25Label       = cms.InputTag("dtunpacker")
+                                     dtDDULabel         = cms.InputTag("dtDataIntegrityUnpacker"),
+                                     dtROS25Label       = cms.InputTag("dtDataIntegrityUnpacker")
 )
 
 


### PR DESCRIPTION
This change solves the problem of empty plots in the DTDataIntegrity DQM.
The code to read the collections and fill the plots was already present in the past PR, but the configuration was pointing to a wrong InputTag.
