### PR TITLE
Remove reflex include

### DIFF
--- a/FWCore/Services/src/InitRootHandlers.cc
+++ b/FWCore/Services/src/InitRootHandlers.cc
@@ -28,8 +28,6 @@
 
 #include "TThread.h"
 #include "TClassTable.h"
-#include "Reflex/Type.h"
-
 
 namespace {
   enum class SeverityLevel {


### PR DESCRIPTION
Remove include of Reflex header (obsolete and unneeded in ROOT6) that causes a compilation error.
Please merge this totally trivial pull request promptly.
