### PR TITLE
Cut based discriminator against electron (AgainstElectron2)

### DIFF
--- a/RecoTauTag/RecoTau/interface/AntiElectronIDCut2.h
+++ b/RecoTauTag/RecoTau/interface/AntiElectronIDCut2.h
@@ -1,0 +1,182 @@
+//--------------------------------------------------------------------------------------------------
+// AntiElectronIDCut2
+//
+// Helper Class for applying simple cut based anti-electron discrimination
+//
+// Authors: A Nayak
+//--------------------------------------------------------------------------------------------------
+
+#ifndef RECOTAUTAG_RECOTAU_AntiElectronIDCut2_H
+#define RECOTAUTAG_RECOTAU_AntiElectronIDCut2_H
+
+#include "DataFormats/TauReco/interface/PFTau.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
+#include "DataFormats/Math/interface/deltaR.h"
+
+#include <vector>
+
+typedef std::pair<double, double> pdouble;
+
+class AntiElectronIDCut2 
+{
+  public:
+
+    AntiElectronIDCut2();
+    ~AntiElectronIDCut2(); 
+
+    double Discriminator(Float_t TauPt,
+                         Float_t TauEta,
+                         Float_t TauLeadChargedPFCandPt,
+                         Float_t TauLeadChargedPFCandEtaAtEcalEntrance,
+                         Float_t TauLeadPFChargedHadrEoP,
+                         Float_t TauHcal3x3OverPLead,
+                         Float_t TauGammaEtaMom,
+                         Float_t TauGammaPhiMom,
+                         Float_t TauGammaEnFrac
+			 );
+
+    double Discriminator(Float_t TauPt,
+			 Float_t TauEta,
+			 Float_t TauLeadChargedPFCandPt,
+			 Float_t TauLeadChargedPFCandEtaAtEcalEntrance,
+			 Float_t TauLeadPFChargedHadrEoP,
+			 Float_t TauHcal3x3OverPLead,
+			 const std::vector<Float_t>& GammasdEta,
+			 const std::vector<Float_t>& GammasdPhi,
+			 const std::vector<Float_t>& GammasPt
+			 );
+
+    template<typename T> 
+      double Discriminator(const T& thePFTau)
+      {
+	float TauLeadChargedPFCandEtaAtEcalEntrance = -99.;
+	float TauLeadChargedPFCandPt = -99.;
+	const std::vector<reco::PFCandidatePtr>& signalPFCands = thePFTau.signalPFCands();
+	for ( std::vector<reco::PFCandidatePtr>::const_iterator pfCandidate = signalPFCands.begin();
+	      pfCandidate != signalPFCands.end(); ++pfCandidate ) {
+	  const reco::Track* track = 0;
+	  if ( (*pfCandidate)->trackRef().isNonnull() ) track = (*pfCandidate)->trackRef().get();
+	  else if ( (*pfCandidate)->muonRef().isNonnull() && (*pfCandidate)->muonRef()->innerTrack().isNonnull()  ) track = (*pfCandidate)->muonRef()->innerTrack().get();
+	  else if ( (*pfCandidate)->muonRef().isNonnull() && (*pfCandidate)->muonRef()->globalTrack().isNonnull() ) track = (*pfCandidate)->muonRef()->globalTrack().get();
+	  else if ( (*pfCandidate)->muonRef().isNonnull() && (*pfCandidate)->muonRef()->outerTrack().isNonnull()  ) track = (*pfCandidate)->muonRef()->outerTrack().get();
+	  else if ( (*pfCandidate)->gsfTrackRef().isNonnull() ) track = (*pfCandidate)->gsfTrackRef().get();
+	  if ( track ) {
+	    if ( track->pt() > TauLeadChargedPFCandPt ) {
+	      TauLeadChargedPFCandEtaAtEcalEntrance = (*pfCandidate)->positionAtECALEntrance().eta();
+	      TauLeadChargedPFCandPt = track->pt();
+	    }
+	  }
+	}
+	
+	Float_t TauPt = thePFTau.pt();
+	Float_t TauEta = thePFTau.eta();
+	//Float_t TauLeadPFChargedHadrHoP = 0.;
+	Float_t TauLeadPFChargedHadrEoP = 0.;
+	if ( thePFTau.leadPFChargedHadrCand()->p() > 0. ) {
+	  //TauLeadPFChargedHadrHoP = thePFTau.leadPFChargedHadrCand()->hcalEnergy()/thePFTau.leadPFChargedHadrCand()->p();
+	  TauLeadPFChargedHadrEoP = thePFTau.leadPFChargedHadrCand()->ecalEnergy()/thePFTau.leadPFChargedHadrCand()->p();
+	}
+	
+	std::vector<Float_t> GammasdEta;
+	std::vector<Float_t> GammasdPhi;
+	std::vector<Float_t> GammasPt;
+	for ( unsigned i = 0 ; i < thePFTau.signalPFGammaCands().size(); ++i ) {
+	  reco::PFCandidatePtr gamma = thePFTau.signalPFGammaCands().at(i);
+	  if ( thePFTau.leadPFChargedHadrCand().isNonnull() ) {
+	    GammasdEta.push_back(gamma->eta() - thePFTau.leadPFChargedHadrCand()->eta());
+	    GammasdPhi.push_back(gamma->phi() - thePFTau.leadPFChargedHadrCand()->phi());
+	  } else {
+	    GammasdEta.push_back(gamma->eta() - thePFTau.eta());
+	    GammasdPhi.push_back(gamma->phi() - thePFTau.phi());
+	  }
+	  GammasPt.push_back(gamma->pt());
+	}
+	
+	Float_t TauHcal3x3OverPLead = thePFTau.hcal3x3OverPLead();
+	
+	return Discriminator(TauPt,
+			     TauEta,
+			     TauLeadChargedPFCandPt,
+			     TauLeadChargedPFCandEtaAtEcalEntrance,
+			     TauLeadPFChargedHadrEoP,
+			     TauHcal3x3OverPLead,
+			     GammasdEta,
+			     GammasdPhi,
+			     GammasPt
+			     );
+      };
+    
+    void SetBarrelCutValues(Float_t TauLeadPFChargedHadrEoP_min,
+			    Float_t TauLeadPFChargedHadrEoP_max,
+			    Float_t TauHcal3x3OverPLead_max,
+			    Float_t TauGammaEtaMom_max,
+			    Float_t TauGammaPhiMom_max,
+			    Float_t TauGammaEnFrac_max
+			    );
+
+    void SetEndcapCutValues(Float_t TauLeadPFChargedHadrEoP_min_1,
+                            Float_t TauLeadPFChargedHadrEoP_max_1,
+			    Float_t TauLeadPFChargedHadrEoP_min_2,
+                            Float_t TauLeadPFChargedHadrEoP_max_2,
+                            Float_t TauHcal3x3OverPLead_max,
+                            Float_t TauGammaEtaMom_max,
+                            Float_t TauGammaPhiMom_max,
+                            Float_t TauGammaEnFrac_max
+                            );
+    void ApplyCut_EcalCrack(bool keepAll_, bool rejectAll_){
+      keepAllInEcalCrack_ = keepAll_;
+      rejectAllInEcalCrack_ = rejectAll_;
+    };
+    
+    void ApplyCuts(bool applyCut_hcal3x3OverPLead, 
+		   bool applyCut_leadPFChargedHadrEoP, 
+		   bool applyCut_GammaEtaMom, 
+		   bool applyCut_GammaPhiMom, 
+		   bool applyCut_GammaEnFrac, 
+		   bool applyCut_HLTSpecific
+		   );
+
+    void SetEcalCracks(const std::vector<pdouble>& etaCracks)
+    {
+      ecalCracks_.clear();
+      for(size_t i = 0; i < etaCracks.size(); i++)
+	ecalCracks_.push_back(etaCracks[i]);
+    }
+    
+ private:
+
+    bool isInEcalCrack(double eta) const; 
+    
+    float TauLeadPFChargedHadrEoP_barrel_min_;
+    float TauLeadPFChargedHadrEoP_barrel_max_;
+    float TauHcal3x3OverPLead_barrel_max_;
+    float TauGammaEtaMom_barrel_max_;
+    float TauGammaPhiMom_barrel_max_;
+    float TauGammaEnFrac_barrel_max_;
+    float TauLeadPFChargedHadrEoP_endcap_min1_;
+    float TauLeadPFChargedHadrEoP_endcap_max1_;
+    float TauLeadPFChargedHadrEoP_endcap_min2_;
+    float TauLeadPFChargedHadrEoP_endcap_max2_;
+    float TauHcal3x3OverPLead_endcap_max_;
+    float TauGammaEtaMom_endcap_max_;
+    float TauGammaPhiMom_endcap_max_;
+    float TauGammaEnFrac_endcap_max_;
+
+    bool keepAllInEcalCrack_;
+    bool rejectAllInEcalCrack_;
+
+    bool Tau_applyCut_hcal3x3OverPLead_;
+    bool Tau_applyCut_leadPFChargedHadrEoP_;
+    bool Tau_applyCut_GammaEtaMom_;
+    bool Tau_applyCut_GammaPhiMom_;
+    bool Tau_applyCut_GammaEnFrac_;
+    bool Tau_applyCut_HLTSpecific_;
+
+    std::vector<pdouble> ecalCracks_;
+    
+    int verbosity_;
+};
+
+#endif

--- a/RecoTauTag/RecoTau/interface/AntiElectronIDCut2.h
+++ b/RecoTauTag/RecoTau/interface/AntiElectronIDCut2.h
@@ -26,26 +26,26 @@ class AntiElectronIDCut2
     AntiElectronIDCut2();
     ~AntiElectronIDCut2(); 
 
-    double Discriminator(Float_t TauPt,
-                         Float_t TauEta,
-                         Float_t TauLeadChargedPFCandPt,
-                         Float_t TauLeadChargedPFCandEtaAtEcalEntrance,
-                         Float_t TauLeadPFChargedHadrEoP,
-                         Float_t TauHcal3x3OverPLead,
-                         Float_t TauGammaEtaMom,
-                         Float_t TauGammaPhiMom,
-                         Float_t TauGammaEnFrac
+    double Discriminator(float TauPt,
+                         float TauEta,
+                         float TauLeadChargedPFCandPt,
+                         float TauLeadChargedPFCandEtaAtEcalEntrance,
+                         float TauLeadPFChargedHadrEoP,
+                         float TauHcal3x3OverPLead,
+                         float TauGammaEtaMom,
+                         float TauGammaPhiMom,
+                         float TauGammaEnFrac
 			 );
 
-    double Discriminator(Float_t TauPt,
-			 Float_t TauEta,
-			 Float_t TauLeadChargedPFCandPt,
-			 Float_t TauLeadChargedPFCandEtaAtEcalEntrance,
-			 Float_t TauLeadPFChargedHadrEoP,
-			 Float_t TauHcal3x3OverPLead,
-			 const std::vector<Float_t>& GammasdEta,
-			 const std::vector<Float_t>& GammasdPhi,
-			 const std::vector<Float_t>& GammasPt
+    double Discriminator(float TauPt,
+			 float TauEta,
+			 float TauLeadChargedPFCandPt,
+			 float TauLeadChargedPFCandEtaAtEcalEntrance,
+			 float TauLeadPFChargedHadrEoP,
+			 float TauHcal3x3OverPLead,
+			 const std::vector<float>& GammasdEta,
+			 const std::vector<float>& GammasdPhi,
+			 const std::vector<float>& GammasPt
 			 );
 
     template<typename T> 
@@ -70,18 +70,18 @@ class AntiElectronIDCut2
 	  }
 	}
 	
-	Float_t TauPt = thePFTau.pt();
-	Float_t TauEta = thePFTau.eta();
-	//Float_t TauLeadPFChargedHadrHoP = 0.;
-	Float_t TauLeadPFChargedHadrEoP = 0.;
+	float TauPt = thePFTau.pt();
+	float TauEta = thePFTau.eta();
+	//float TauLeadPFChargedHadrHoP = 0.;
+	float TauLeadPFChargedHadrEoP = 0.;
 	if ( thePFTau.leadPFChargedHadrCand()->p() > 0. ) {
 	  //TauLeadPFChargedHadrHoP = thePFTau.leadPFChargedHadrCand()->hcalEnergy()/thePFTau.leadPFChargedHadrCand()->p();
 	  TauLeadPFChargedHadrEoP = thePFTau.leadPFChargedHadrCand()->ecalEnergy()/thePFTau.leadPFChargedHadrCand()->p();
 	}
 	
-	std::vector<Float_t> GammasdEta;
-	std::vector<Float_t> GammasdPhi;
-	std::vector<Float_t> GammasPt;
+	std::vector<float> GammasdEta;
+	std::vector<float> GammasdPhi;
+	std::vector<float> GammasPt;
 	for ( unsigned i = 0 ; i < thePFTau.signalPFGammaCands().size(); ++i ) {
 	  reco::PFCandidatePtr gamma = thePFTau.signalPFGammaCands().at(i);
 	  if ( thePFTau.leadPFChargedHadrCand().isNonnull() ) {
@@ -94,7 +94,7 @@ class AntiElectronIDCut2
 	  GammasPt.push_back(gamma->pt());
 	}
 	
-	Float_t TauHcal3x3OverPLead = thePFTau.hcal3x3OverPLead();
+	float TauHcal3x3OverPLead = thePFTau.hcal3x3OverPLead();
 	
 	return Discriminator(TauPt,
 			     TauEta,
@@ -108,22 +108,22 @@ class AntiElectronIDCut2
 			     );
       };
     
-    void SetBarrelCutValues(Float_t TauLeadPFChargedHadrEoP_min,
-			    Float_t TauLeadPFChargedHadrEoP_max,
-			    Float_t TauHcal3x3OverPLead_max,
-			    Float_t TauGammaEtaMom_max,
-			    Float_t TauGammaPhiMom_max,
-			    Float_t TauGammaEnFrac_max
+    void SetBarrelCutValues(float TauLeadPFChargedHadrEoP_min,
+			    float TauLeadPFChargedHadrEoP_max,
+			    float TauHcal3x3OverPLead_max,
+			    float TauGammaEtaMom_max,
+			    float TauGammaPhiMom_max,
+			    float TauGammaEnFrac_max
 			    );
 
-    void SetEndcapCutValues(Float_t TauLeadPFChargedHadrEoP_min_1,
-                            Float_t TauLeadPFChargedHadrEoP_max_1,
-			    Float_t TauLeadPFChargedHadrEoP_min_2,
-                            Float_t TauLeadPFChargedHadrEoP_max_2,
-                            Float_t TauHcal3x3OverPLead_max,
-                            Float_t TauGammaEtaMom_max,
-                            Float_t TauGammaPhiMom_max,
-                            Float_t TauGammaEnFrac_max
+    void SetEndcapCutValues(float TauLeadPFChargedHadrEoP_min_1,
+                            float TauLeadPFChargedHadrEoP_max_1,
+			    float TauLeadPFChargedHadrEoP_min_2,
+                            float TauLeadPFChargedHadrEoP_max_2,
+                            float TauHcal3x3OverPLead_max,
+                            float TauGammaEtaMom_max,
+                            float TauGammaPhiMom_max,
+                            float TauGammaEnFrac_max
                             );
     void ApplyCut_EcalCrack(bool keepAll_, bool rejectAll_){
       keepAllInEcalCrack_ = keepAll_;

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstElectron2.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstElectron2.cc
@@ -1,0 +1,195 @@
+/* class PFRecoTauDiscriminationAgainstElectron2
+ * created : Apr 3, 2014
+ * revised : ,
+ * Authorss : Aruna Nayak (DESY)
+ */
+
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include "RecoTauTag/RecoTau/interface/TauDiscriminationProducerBase.h"
+#include "RecoTauTag/RecoTau/interface/AntiElectronIDCut2.h"
+
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TauReco/interface/PFTauDiscriminator.h"
+#include "DataFormats/Math/interface/deltaR.h"
+
+#include <TMath.h>
+#include "TPRegexp.h"
+
+#include <iostream>
+#include <sstream>
+#include <fstream>
+#include <vector>
+ 
+using namespace reco;
+typedef std::pair<double, double> pdouble;
+
+class PFRecoTauDiscriminationAgainstElectron2 : public PFTauDiscriminationProducerBase  {
+public:
+  explicit PFRecoTauDiscriminationAgainstElectron2(const edm::ParameterSet& iConfig)
+    : PFTauDiscriminationProducerBase(iConfig)
+  {
+
+    LeadPFChargedHadrEoP_barrel_min_ = iConfig.getParameter<double>("LeadPFChargedHadrEoP_barrel_min");
+    LeadPFChargedHadrEoP_barrel_max_ = iConfig.getParameter<double>("LeadPFChargedHadrEoP_barrel_max");
+    Hcal3x3OverPLead_barrel_max_ = iConfig.getParameter<double>("Hcal3x3OverPLead_barrel_max");
+    GammaEtaMom_barrel_max_ = iConfig.getParameter<double>("GammaEtaMom_barrel_max");
+    GammaPhiMom_barrel_max_ = iConfig.getParameter<double>("GammaPhiMom_barrel_max");
+    GammaEnFrac_barrel_max_ = iConfig.getParameter<double>("GammaEnFrac_barrel_max");
+    LeadPFChargedHadrEoP_endcap_min1_ = iConfig.getParameter<double>("LeadPFChargedHadrEoP_endcap_min1");
+    LeadPFChargedHadrEoP_endcap_max1_ = iConfig.getParameter<double>("LeadPFChargedHadrEoP_endcap_max1");
+    LeadPFChargedHadrEoP_endcap_min2_ = iConfig.getParameter<double>("LeadPFChargedHadrEoP_endcap_min2");
+    LeadPFChargedHadrEoP_endcap_max2_ = iConfig.getParameter<double>("LeadPFChargedHadrEoP_endcap_max2");
+    Hcal3x3OverPLead_endcap_max_ = iConfig.getParameter<double>("Hcal3x3OverPLead_endcap_max");
+    GammaEtaMom_endcap_max_ = iConfig.getParameter<double>("GammaEtaMom_endcap_max");
+    GammaPhiMom_endcap_max_ = iConfig.getParameter<double>("GammaPhiMom_endcap_max");
+    GammaEnFrac_endcap_max_ = iConfig.getParameter<double>("GammaEnFrac_endcap_max");
+    keepTausInEcalCrack_ = iConfig.getParameter<bool>("keepTausInEcalCrack");
+    rejectTausInEcalCrack_ = iConfig.getParameter<bool>("rejectTausInEcalCrack"); 
+
+    applyCut_hcal3x3OverPLead_ = iConfig.getParameter<bool>("applyCut_hcal3x3OverPLead");  
+    applyCut_leadPFChargedHadrEoP_ = iConfig.getParameter<bool>("applyCut_leadPFChargedHadrEoP");  
+    applyCut_GammaEtaMom_ = iConfig.getParameter<bool>("applyCut_GammaEtaMom");  
+    applyCut_GammaPhiMom_ = iConfig.getParameter<bool>("applyCut_GammaPhiMom");  
+    applyCut_GammaEnFrac_ = iConfig.getParameter<bool>("applyCut_GammaEnFrac");  
+    applyCut_HLTSpecific_ = iConfig.getParameter<bool>("applyCut_HLTSpecific");
+
+    etaCracks_string_ = iConfig.getParameter<std::vector<std::string>>("etaCracks");
+    
+    verbosity_ = ( iConfig.exists("verbosity") ) ?
+      iConfig.getParameter<int>("verbosity") : 0;
+
+    cuts2_ = new AntiElectronIDCut2();
+  }
+
+  void beginEvent(const edm::Event&, const edm::EventSetup&);
+
+  double discriminate(const PFTauRef&);
+  
+  ~PFRecoTauDiscriminationAgainstElectron2()
+  {  }
+
+private:
+  bool isInEcalCrack(double) const;
+  std::vector<pdouble> etaCracks_;
+  std::vector<std::string> etaCracks_string_;
+
+  AntiElectronIDCut2* cuts2_;
+  
+  double LeadPFChargedHadrEoP_barrel_min_;
+  double LeadPFChargedHadrEoP_barrel_max_;
+  double Hcal3x3OverPLead_barrel_max_;
+  double GammaEtaMom_barrel_max_;
+  double GammaPhiMom_barrel_max_;
+  double GammaEnFrac_barrel_max_;
+  double LeadPFChargedHadrEoP_endcap_min1_;
+  double LeadPFChargedHadrEoP_endcap_max1_;
+  double LeadPFChargedHadrEoP_endcap_min2_;
+  double LeadPFChargedHadrEoP_endcap_max2_;
+  double Hcal3x3OverPLead_endcap_max_;
+  double GammaEtaMom_endcap_max_;
+  double GammaPhiMom_endcap_max_;
+  double GammaEnFrac_endcap_max_;
+
+  bool keepTausInEcalCrack_;
+  bool rejectTausInEcalCrack_;
+
+  bool applyCut_hcal3x3OverPLead_; 
+  bool applyCut_leadPFChargedHadrEoP_; 
+  bool applyCut_GammaEtaMom_; 
+  bool applyCut_GammaPhiMom_; 
+  bool applyCut_GammaEnFrac_; 
+  bool applyCut_HLTSpecific_;
+
+  int verbosity_;
+};
+
+void PFRecoTauDiscriminationAgainstElectron2::beginEvent(const edm::Event& evt, const edm::EventSetup& es)
+{
+  cuts2_->SetBarrelCutValues(LeadPFChargedHadrEoP_barrel_min_,
+                            LeadPFChargedHadrEoP_barrel_max_,
+                            Hcal3x3OverPLead_barrel_max_,
+                            GammaEtaMom_barrel_max_,
+                            GammaPhiMom_barrel_max_,
+                            GammaEnFrac_barrel_max_
+                            );
+  
+  cuts2_->SetEndcapCutValues(LeadPFChargedHadrEoP_endcap_min1_,
+                            LeadPFChargedHadrEoP_endcap_max1_,
+                            LeadPFChargedHadrEoP_endcap_min2_,
+                            LeadPFChargedHadrEoP_endcap_max2_,
+                            Hcal3x3OverPLead_endcap_max_,
+                            GammaEtaMom_endcap_max_,
+                            GammaPhiMom_endcap_max_,
+                            GammaEnFrac_endcap_max_
+                            );
+
+  cuts2_->ApplyCut_EcalCrack(keepTausInEcalCrack_, rejectTausInEcalCrack_);
+
+  cuts2_->ApplyCuts(applyCut_hcal3x3OverPLead_,  
+		    applyCut_leadPFChargedHadrEoP_,  
+		    applyCut_GammaEtaMom_,  
+		    applyCut_GammaPhiMom_,  
+		    applyCut_GammaEnFrac_,  
+		    applyCut_HLTSpecific_ 
+		    );
+  //Ecal cracks in eta
+  etaCracks_.clear();
+  TPRegexp regexpParser_range("([0-9.e+/-]+):([0-9.e+/-]+)");
+  for ( std::vector<std::string>::const_iterator etaCrack = etaCracks_string_.begin();
+	etaCrack != etaCracks_string_.end(); ++etaCrack ) {
+    TObjArray* subStrings = regexpParser_range.MatchS(etaCrack->data());
+    if ( subStrings->GetEntries() == 3 ) {
+      //std::cout << "substrings(1) = " << ((TObjString*)subStrings->At(1))->GetString() << std::endl;
+      double range_begin = ((TObjString*)subStrings->At(1))->GetString().Atof();
+      //std::cout << "substrings(2) = " << ((TObjString*)subStrings->At(2))->GetString() << std::endl;
+      double range_end = ((TObjString*)subStrings->At(2))->GetString().Atof();
+      etaCracks_.push_back(pdouble(range_begin, range_end));
+    }
+  }
+  
+  cuts2_->SetEcalCracks(etaCracks_);
+
+}
+
+double PFRecoTauDiscriminationAgainstElectron2::discriminate(const PFTauRef& thePFTauRef)
+{
+  double discriminator = 0.;
+  
+  // ensure tau has at least one charged object
+
+  if( (*thePFTauRef).leadPFChargedHadrCand().isNull() )
+    {
+      return 0.;
+    } 
+  else
+    {
+      discriminator = cuts2_->Discriminator(*thePFTauRef);
+    }
+
+
+  if ( verbosity_ ) {
+    std::cout<<" Taus : "<<TauProducer_<<std::endl;
+    std::cout << "<PFRecoTauDiscriminationAgainstElectron2::discriminate>:" << std::endl;
+    std::cout << " tau: Pt = " << thePFTauRef->pt() << ", eta = " << thePFTauRef->eta() << ", phi = " << thePFTauRef->phi() << std::endl;
+    std::cout << " discriminator value = " << discriminator << std::endl;
+    std::cout << " Prongs in tau: " << thePFTauRef->signalPFChargedHadrCands().size() << std::endl;
+  }
+
+  return discriminator;
+}
+
+bool
+PFRecoTauDiscriminationAgainstElectron2::isInEcalCrack(double eta) const
+{
+  eta = fabs(eta);
+  return (eta < 0.018 ||
+          (eta>0.423 && eta<0.461) ||
+          (eta>0.770 && eta<0.806) ||
+          (eta>1.127 && eta<1.163) ||
+          (eta>1.460 && eta<1.558));
+}
+
+DEFINE_FWK_MODULE(PFRecoTauDiscriminationAgainstElectron2);

--- a/RecoTauTag/RecoTau/python/PFRecoTauDiscriminationAgainstElectron2_cfi.py
+++ b/RecoTauTag/RecoTau/python/PFRecoTauDiscriminationAgainstElectron2_cfi.py
@@ -1,0 +1,42 @@
+import FWCore.ParameterSet.Config as cms
+from RecoTauTag.RecoTau.TauDiscriminatorTools import requireLeadTrack
+
+pfRecoTauDiscriminationAgainstElectron2 = cms.EDProducer("PFRecoTauDiscriminationAgainstElectron2",
+
+    # tau collection to discriminate
+    PFTauProducer = cms.InputTag('pfRecoTauProducer'),
+
+    # Require leading pion ensures that:
+    #  1) these is at least one track above threshold (0.5 GeV) in the signal cone
+    #  2) a track OR a pi-zero in the signal cone has pT > 5 GeV
+    Prediscriminants = requireLeadTrack,
+
+    #cuts to be applied
+    keepTausInEcalCrack = cms.bool(True), 
+    rejectTausInEcalCrack = cms.bool(False),
+    etaCracks = cms.vstring("0.0:0.018","0.423:0.461","0.770:0.806","1.127:1.163","1.460:1.558"),
+                                                         
+    applyCut_hcal3x3OverPLead = cms.bool(True),
+    applyCut_leadPFChargedHadrEoP = cms.bool(True),
+    applyCut_GammaEtaMom = cms.bool(False),
+    applyCut_GammaPhiMom = cms.bool(False),
+    applyCut_GammaEnFrac = cms.bool(True),
+    applyCut_HLTSpecific = cms.bool(True),
+                                                        
+    LeadPFChargedHadrEoP_barrel_min = cms.double(0.99),
+    LeadPFChargedHadrEoP_barrel_max = cms.double(1.01),
+    Hcal3x3OverPLead_barrel_max = cms.double(0.2),
+    GammaEtaMom_barrel_max = cms.double(1.5),
+    GammaPhiMom_barrel_max = cms.double(1.5),
+    GammaEnFrac_barrel_max = cms.double(0.15),
+    LeadPFChargedHadrEoP_endcap_min1 = cms.double(0.7),
+    LeadPFChargedHadrEoP_endcap_max1 = cms.double(1.3),
+    LeadPFChargedHadrEoP_endcap_min2 = cms.double(0.99),
+    LeadPFChargedHadrEoP_endcap_max2 = cms.double(1.01),
+    Hcal3x3OverPLead_endcap_max = cms.double(0.1),
+    GammaEtaMom_endcap_max = cms.double(1.5),
+    GammaPhiMom_endcap_max = cms.double(1.5),
+    GammaEnFrac_endcap_max = cms.double(0.2),
+)
+
+

--- a/RecoTauTag/RecoTau/src/AntiElectronIDCut2.cc
+++ b/RecoTauTag/RecoTau/src/AntiElectronIDCut2.cc
@@ -1,0 +1,269 @@
+#include "RecoTauTag/RecoTau/interface/AntiElectronIDCut2.h"
+
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
+#include <TMath.h>
+
+AntiElectronIDCut2::AntiElectronIDCut2()
+{
+  //Default values for the HLT
+  TauLeadPFChargedHadrEoP_barrel_min_ = 0.99;
+  TauLeadPFChargedHadrEoP_barrel_max_ = 1.01;
+  TauHcal3x3OverPLead_barrel_max_ = 0.2;
+  TauGammaEtaMom_barrel_max_ = 1.5;
+  TauGammaPhiMom_barrel_max_ = 1.5;
+  TauGammaEnFrac_barrel_max_ = 0.15;
+  TauLeadPFChargedHadrEoP_endcap_min1_ = 0.7;
+  TauLeadPFChargedHadrEoP_endcap_max1_ = 1.3;
+  TauLeadPFChargedHadrEoP_endcap_min2_ = 0.99;
+  TauLeadPFChargedHadrEoP_endcap_max2_ = 1.01;
+  TauHcal3x3OverPLead_endcap_max_ = 0.1;
+  TauGammaEtaMom_endcap_max_ = 1.5;
+  TauGammaPhiMom_endcap_max_ = 1.5;
+  TauGammaEnFrac_endcap_max_ = 0.2;
+
+  //default, keep all taus in cracks for HLT 
+  keepAllInEcalCrack_ = true;
+  rejectAllInEcalCrack_ = false;
+
+  //Default Cuts to be applied
+  Tau_applyCut_hcal3x3OverPLead_ = true; 
+  Tau_applyCut_leadPFChargedHadrEoP_ = true; 
+  Tau_applyCut_GammaEtaMom_ = true; 
+  Tau_applyCut_GammaPhiMom_ = false; 
+  Tau_applyCut_GammaEnFrac_ = false; 
+  Tau_applyCut_HLTSpecific_ = true; 
+
+  verbosity_ = 0;
+
+  //Set default ecal crack region
+  ecalCracks_.push_back(pdouble(1.460, 1.558));
+}
+
+AntiElectronIDCut2::~AntiElectronIDCut2()
+{}
+
+double
+AntiElectronIDCut2::Discriminator(Float_t TauPt,
+                                  Float_t TauEta,
+                                  Float_t TauLeadChargedPFCandPt,
+                                  Float_t TauLeadChargedPFCandEtaAtEcalEntrance,
+                                  Float_t TauLeadPFChargedHadrEoP,
+                                  Float_t TauHcal3x3OverPLead,
+				  Float_t TauGammaEtaMom,
+				  Float_t TauGammaPhiMom,
+				  Float_t TauGammaEnFrac)
+{
+
+  if(verbosity_){  
+    std::cout<<"Tau GammaEnFrac "<<TauGammaEnFrac<<std::endl;  
+    std::cout<<"Tau GammaEtaMom "<<TauGammaEtaMom<<std::endl;  
+    std::cout<<"Tau GammaPhiMom "<<TauGammaPhiMom<<std::endl;  
+    std::cout<<"Tau Hcal3x3OverPLead "<<TauHcal3x3OverPLead<<std::endl;
+    std::cout<<"Tau LeadPFChargedHadrEoP "<<TauLeadPFChargedHadrEoP<<std::endl;
+    std::cout<<"Tau LeadChargedPFCandEtaAtEcalEntrance "<<TauLeadChargedPFCandEtaAtEcalEntrance<<std::endl;
+    std::cout<<"Tau LeadChargedPFCandPt "<<TauLeadChargedPFCandPt<<std::endl;
+    std::cout<<"Tau Eta "<<TauEta<<std::endl;
+    std::cout<<"Tau Pt "<<TauPt<<std::endl;
+  }
+  
+  // ensure tau has at least one charged object
+  if( TauLeadChargedPFCandPt <= 0 )
+    {
+      return 0.;
+    }
+  else {
+    // Check if track goes to Ecal Crack
+    if(isInEcalCrack(TauLeadChargedPFCandEtaAtEcalEntrance))
+      {
+	if(keepAllInEcalCrack_)
+	  return 1.0;
+	else if(rejectAllInEcalCrack_)
+	  return 0.;
+      }
+  }
+  
+  bool decision = false;
+  //Apply separate cuts for barrel and endcap
+  if(TMath::Abs(TauEta) < 1.479)
+    {
+      
+      //Apply cut for barrel
+      if(Tau_applyCut_GammaEnFrac_ && TauGammaEnFrac > TauGammaEnFrac_barrel_max_)  
+        decision = true;
+
+      if(Tau_applyCut_GammaPhiMom_ && TauGammaPhiMom > TauGammaPhiMom_barrel_max_) 
+        decision = true;
+
+      if(Tau_applyCut_GammaEtaMom_ && TauGammaEtaMom > TauGammaEtaMom_barrel_max_)
+	decision = true;
+
+      if(Tau_applyCut_hcal3x3OverPLead_ && TauHcal3x3OverPLead > TauHcal3x3OverPLead_barrel_max_)
+	decision = true;
+
+      if(Tau_applyCut_leadPFChargedHadrEoP_ &&
+	 (TauLeadPFChargedHadrEoP < TauLeadPFChargedHadrEoP_barrel_min_ ||
+	  TauLeadPFChargedHadrEoP > TauLeadPFChargedHadrEoP_barrel_max_)) 
+	decision = true;
+    }
+  else {
+    
+    //Apply cut for endcap
+    if(Tau_applyCut_GammaEnFrac_ && TauGammaEnFrac > TauGammaEnFrac_endcap_max_)   
+      decision = true; 
+ 
+    if(Tau_applyCut_GammaPhiMom_ && TauGammaPhiMom > TauGammaPhiMom_endcap_max_)  
+      decision = true;
+    
+    if(Tau_applyCut_GammaEtaMom_ && TauGammaEtaMom > TauGammaEtaMom_endcap_max_)
+      decision = true;
+
+    //This cut is for both offline and HLT. For offline, use cut 0.99-1.01, 
+    //For HLT use cut 0.7-1.3
+    if(Tau_applyCut_leadPFChargedHadrEoP_ &&
+       (TauLeadPFChargedHadrEoP < TauLeadPFChargedHadrEoP_endcap_min1_ ||
+	TauLeadPFChargedHadrEoP > TauLeadPFChargedHadrEoP_endcap_max1_)) 
+      decision = true;
+
+    //This cut is only for HLT. For HLT, use cut like 0.99-1.01 & H3x3/P>0.1
+    //For offline, keep the values same as above : 0.99-1.01 & H3x3/P>0, otherwise it may select events in a wrong way. 
+    if(Tau_applyCut_HLTSpecific_ && 
+       (TauLeadPFChargedHadrEoP < TauLeadPFChargedHadrEoP_endcap_min2_ || 
+	TauLeadPFChargedHadrEoP > TauLeadPFChargedHadrEoP_endcap_max2_) &&
+       TauHcal3x3OverPLead > TauHcal3x3OverPLead_endcap_max_)
+      decision = true;
+  }
+
+  return (decision ? 1. : 0.);
+}  
+
+double
+AntiElectronIDCut2::Discriminator(Float_t TauPt,
+				  Float_t TauEta,
+				  Float_t TauLeadChargedPFCandPt,
+				  Float_t TauLeadChargedPFCandEtaAtEcalEntrance,
+				  Float_t TauLeadPFChargedHadrEoP,
+				  Float_t TauHcal3x3OverPLead,
+				  const std::vector<Float_t>& GammasdEta,
+				  const std::vector<Float_t>& GammasdPhi,
+				  const std::vector<Float_t>& GammasPt
+				  )
+{
+
+  double sumPt  = 0.;
+  double dEta   = 0.;
+  double dEta2  = 0.;
+  double dPhi   = 0.;
+  double dPhi2  = 0.;
+  double sumPt2 = 0.;
+  for ( unsigned int i = 0 ; i < GammasPt.size() ; ++i ) {
+    double pt_i  = GammasPt[i];
+    double phi_i = GammasdPhi[i];
+    if ( GammasdPhi[i] > TMath::Pi() ) phi_i = GammasdPhi[i] - 2*TMath::Pi();
+    else if ( GammasdPhi[i] < -TMath::Pi() ) phi_i = GammasdPhi[i] + 2*TMath::Pi();
+    double eta_i = GammasdEta[i];
+    sumPt  +=  pt_i;
+    sumPt2 += (pt_i*pt_i);
+    dEta   += (pt_i*eta_i);
+    dEta2  += (pt_i*eta_i*eta_i);
+    dPhi   += (pt_i*phi_i);
+    dPhi2  += (pt_i*phi_i*phi_i);
+  }
+
+  Float_t TauGammaEnFrac = sumPt/TauPt;
+
+  if ( sumPt > 0. ) {
+    dEta  /= sumPt;
+    dPhi  /= sumPt;
+    dEta2 /= sumPt;
+    dPhi2 /= sumPt;
+  }
+
+  Float_t TauGammaEtaMom = TMath::Sqrt(dEta2)*TMath::Sqrt(TauGammaEnFrac)*TauPt;
+  Float_t TauGammaPhiMom = TMath::Sqrt(dPhi2)*TMath::Sqrt(TauGammaEnFrac)*TauPt;
+
+  return Discriminator(TauPt,
+                       TauEta,
+                       TauLeadChargedPFCandPt,
+                       TauLeadChargedPFCandEtaAtEcalEntrance,
+                       TauLeadPFChargedHadrEoP,
+                       TauHcal3x3OverPLead,
+                       TauGammaEtaMom,
+                       TauGammaPhiMom,
+		       TauGammaEnFrac
+		       );
+}
+
+void 
+AntiElectronIDCut2::SetBarrelCutValues(Float_t TauLeadPFChargedHadrEoP_min,
+				       Float_t TauLeadPFChargedHadrEoP_max,
+				       Float_t TauHcal3x3OverPLead_max,
+				       Float_t TauGammaEtaMom_max,
+				       Float_t TauGammaPhiMom_max,
+				       Float_t TauGammaEnFrac_max
+				       )
+{
+  TauLeadPFChargedHadrEoP_barrel_min_ = TauLeadPFChargedHadrEoP_min;
+  TauLeadPFChargedHadrEoP_barrel_max_ = TauLeadPFChargedHadrEoP_max;
+  TauHcal3x3OverPLead_barrel_max_ = TauHcal3x3OverPLead_max;
+  TauGammaEtaMom_barrel_max_ = TauGammaEtaMom_max;
+  TauGammaPhiMom_barrel_max_ = TauGammaPhiMom_max;
+  TauGammaEnFrac_barrel_max_ = TauGammaEnFrac_max;
+}
+
+void 
+AntiElectronIDCut2::SetEndcapCutValues(Float_t TauLeadPFChargedHadrEoP_min_1,
+				       Float_t TauLeadPFChargedHadrEoP_max_1,
+				       Float_t TauLeadPFChargedHadrEoP_min_2,
+				       Float_t TauLeadPFChargedHadrEoP_max_2,
+				       Float_t TauHcal3x3OverPLead_max,
+				       Float_t TauGammaEtaMom_max,
+				       Float_t TauGammaPhiMom_max,
+				       Float_t TauGammaEnFrac_max
+				       )
+{
+  TauLeadPFChargedHadrEoP_endcap_min1_ = TauLeadPFChargedHadrEoP_min_1;
+  TauLeadPFChargedHadrEoP_endcap_max1_ = TauLeadPFChargedHadrEoP_max_1;
+  TauLeadPFChargedHadrEoP_endcap_min2_ = TauLeadPFChargedHadrEoP_min_2;
+  TauLeadPFChargedHadrEoP_endcap_max2_ = TauLeadPFChargedHadrEoP_max_2;
+  TauHcal3x3OverPLead_endcap_max_ = TauHcal3x3OverPLead_max;
+  TauGammaEtaMom_endcap_max_ = TauGammaEtaMom_max;
+  TauGammaPhiMom_endcap_max_ = TauGammaPhiMom_max;
+  TauGammaEnFrac_endcap_max_ = TauGammaEnFrac_max;
+}
+
+void
+AntiElectronIDCut2::ApplyCuts(bool applyCut_hcal3x3OverPLead,  
+			      bool applyCut_leadPFChargedHadrEoP,  
+			      bool applyCut_GammaEtaMom,  
+			      bool applyCut_GammaPhiMom,  
+			      bool applyCut_GammaEnFrac,  
+			      bool applyCut_HLTSpecific 
+			      )
+{
+  Tau_applyCut_hcal3x3OverPLead_ = applyCut_hcal3x3OverPLead; 
+  Tau_applyCut_leadPFChargedHadrEoP_ = applyCut_leadPFChargedHadrEoP; 
+  Tau_applyCut_GammaEtaMom_ = applyCut_GammaEtaMom; 
+  Tau_applyCut_GammaPhiMom_ = applyCut_GammaPhiMom; 
+  Tau_applyCut_GammaEnFrac_ = applyCut_GammaEnFrac; 
+  Tau_applyCut_HLTSpecific_ = applyCut_HLTSpecific; 
+}
+
+bool
+AntiElectronIDCut2::isInEcalCrack(double eta) const
+{
+  bool in_ecal_crack = false;
+
+  eta = fabs(eta);
+  for(std::vector<pdouble>::const_iterator etaCrack = ecalCracks_.begin(); 
+      etaCrack != ecalCracks_.end(); ++etaCrack)
+    if(eta >= etaCrack->first && eta < etaCrack->second)
+      in_ecal_crack = true;
+  
+  return in_ecal_crack;
+}
+

--- a/RecoTauTag/RecoTau/src/AntiElectronIDCut2.cc
+++ b/RecoTauTag/RecoTau/src/AntiElectronIDCut2.cc
@@ -10,22 +10,6 @@
 
 AntiElectronIDCut2::AntiElectronIDCut2()
 {
-  //Default values for the HLT
-  TauLeadPFChargedHadrEoP_barrel_min_ = 0.99;
-  TauLeadPFChargedHadrEoP_barrel_max_ = 1.01;
-  TauHcal3x3OverPLead_barrel_max_ = 0.2;
-  TauGammaEtaMom_barrel_max_ = 1.5;
-  TauGammaPhiMom_barrel_max_ = 1.5;
-  TauGammaEnFrac_barrel_max_ = 0.15;
-  TauLeadPFChargedHadrEoP_endcap_min1_ = 0.7;
-  TauLeadPFChargedHadrEoP_endcap_max1_ = 1.3;
-  TauLeadPFChargedHadrEoP_endcap_min2_ = 0.99;
-  TauLeadPFChargedHadrEoP_endcap_max2_ = 1.01;
-  TauHcal3x3OverPLead_endcap_max_ = 0.1;
-  TauGammaEtaMom_endcap_max_ = 1.5;
-  TauGammaPhiMom_endcap_max_ = 1.5;
-  TauGammaEnFrac_endcap_max_ = 0.2;
-
   //default, keep all taus in cracks for HLT 
   keepAllInEcalCrack_ = true;
   rejectAllInEcalCrack_ = false;
@@ -40,23 +24,21 @@ AntiElectronIDCut2::AntiElectronIDCut2()
 
   verbosity_ = 0;
 
-  //Set default ecal crack region
-  ecalCracks_.push_back(pdouble(1.460, 1.558));
 }
 
 AntiElectronIDCut2::~AntiElectronIDCut2()
 {}
 
 double
-AntiElectronIDCut2::Discriminator(Float_t TauPt,
-                                  Float_t TauEta,
-                                  Float_t TauLeadChargedPFCandPt,
-                                  Float_t TauLeadChargedPFCandEtaAtEcalEntrance,
-                                  Float_t TauLeadPFChargedHadrEoP,
-                                  Float_t TauHcal3x3OverPLead,
-				  Float_t TauGammaEtaMom,
-				  Float_t TauGammaPhiMom,
-				  Float_t TauGammaEnFrac)
+AntiElectronIDCut2::Discriminator(float TauPt,
+                                  float TauEta,
+                                  float TauLeadChargedPFCandPt,
+                                  float TauLeadChargedPFCandEtaAtEcalEntrance,
+                                  float TauLeadPFChargedHadrEoP,
+                                  float TauHcal3x3OverPLead,
+				  float TauGammaEtaMom,
+				  float TauGammaPhiMom,
+				  float TauGammaEnFrac)
 {
 
   if(verbosity_){  
@@ -142,15 +124,15 @@ AntiElectronIDCut2::Discriminator(Float_t TauPt,
 }  
 
 double
-AntiElectronIDCut2::Discriminator(Float_t TauPt,
-				  Float_t TauEta,
-				  Float_t TauLeadChargedPFCandPt,
-				  Float_t TauLeadChargedPFCandEtaAtEcalEntrance,
-				  Float_t TauLeadPFChargedHadrEoP,
-				  Float_t TauHcal3x3OverPLead,
-				  const std::vector<Float_t>& GammasdEta,
-				  const std::vector<Float_t>& GammasdPhi,
-				  const std::vector<Float_t>& GammasPt
+AntiElectronIDCut2::Discriminator(float TauPt,
+				  float TauEta,
+				  float TauLeadChargedPFCandPt,
+				  float TauLeadChargedPFCandEtaAtEcalEntrance,
+				  float TauLeadPFChargedHadrEoP,
+				  float TauHcal3x3OverPLead,
+				  const std::vector<float>& GammasdEta,
+				  const std::vector<float>& GammasdPhi,
+				  const std::vector<float>& GammasPt
 				  )
 {
 
@@ -174,7 +156,7 @@ AntiElectronIDCut2::Discriminator(Float_t TauPt,
     dPhi2  += (pt_i*phi_i*phi_i);
   }
 
-  Float_t TauGammaEnFrac = sumPt/TauPt;
+  float TauGammaEnFrac = sumPt/TauPt;
 
   if ( sumPt > 0. ) {
     dEta  /= sumPt;
@@ -183,8 +165,8 @@ AntiElectronIDCut2::Discriminator(Float_t TauPt,
     dPhi2 /= sumPt;
   }
 
-  Float_t TauGammaEtaMom = TMath::Sqrt(dEta2)*TMath::Sqrt(TauGammaEnFrac)*TauPt;
-  Float_t TauGammaPhiMom = TMath::Sqrt(dPhi2)*TMath::Sqrt(TauGammaEnFrac)*TauPt;
+  float TauGammaEtaMom = TMath::Sqrt(dEta2)*TMath::Sqrt(TauGammaEnFrac)*TauPt;
+  float TauGammaPhiMom = TMath::Sqrt(dPhi2)*TMath::Sqrt(TauGammaEnFrac)*TauPt;
 
   return Discriminator(TauPt,
                        TauEta,
@@ -199,12 +181,12 @@ AntiElectronIDCut2::Discriminator(Float_t TauPt,
 }
 
 void 
-AntiElectronIDCut2::SetBarrelCutValues(Float_t TauLeadPFChargedHadrEoP_min,
-				       Float_t TauLeadPFChargedHadrEoP_max,
-				       Float_t TauHcal3x3OverPLead_max,
-				       Float_t TauGammaEtaMom_max,
-				       Float_t TauGammaPhiMom_max,
-				       Float_t TauGammaEnFrac_max
+AntiElectronIDCut2::SetBarrelCutValues(float TauLeadPFChargedHadrEoP_min,
+				       float TauLeadPFChargedHadrEoP_max,
+				       float TauHcal3x3OverPLead_max,
+				       float TauGammaEtaMom_max,
+				       float TauGammaPhiMom_max,
+				       float TauGammaEnFrac_max
 				       )
 {
   TauLeadPFChargedHadrEoP_barrel_min_ = TauLeadPFChargedHadrEoP_min;
@@ -216,14 +198,14 @@ AntiElectronIDCut2::SetBarrelCutValues(Float_t TauLeadPFChargedHadrEoP_min,
 }
 
 void 
-AntiElectronIDCut2::SetEndcapCutValues(Float_t TauLeadPFChargedHadrEoP_min_1,
-				       Float_t TauLeadPFChargedHadrEoP_max_1,
-				       Float_t TauLeadPFChargedHadrEoP_min_2,
-				       Float_t TauLeadPFChargedHadrEoP_max_2,
-				       Float_t TauHcal3x3OverPLead_max,
-				       Float_t TauGammaEtaMom_max,
-				       Float_t TauGammaPhiMom_max,
-				       Float_t TauGammaEnFrac_max
+AntiElectronIDCut2::SetEndcapCutValues(float TauLeadPFChargedHadrEoP_min_1,
+				       float TauLeadPFChargedHadrEoP_max_1,
+				       float TauLeadPFChargedHadrEoP_min_2,
+				       float TauLeadPFChargedHadrEoP_max_2,
+				       float TauHcal3x3OverPLead_max,
+				       float TauGammaEtaMom_max,
+				       float TauGammaPhiMom_max,
+				       float TauGammaEnFrac_max
 				       )
 {
   TauLeadPFChargedHadrEoP_endcap_min1_ = TauLeadPFChargedHadrEoP_min_1;


### PR DESCRIPTION
This request is to add a new cut-based tau discriminator against electron (PFRecoTauDiscriminationAgainstElectron2) which is expected to be used at HLT. The discriminator will be also a simple (and less performant) alternative for a MVA-based discriminant at offline.
