### PR TITLE
Access function for object member

### DIFF
--- a/DataFormats/HeavyIonEvent/interface/VoronoiBackground.h
+++ b/DataFormats/HeavyIonEvent/interface/VoronoiBackground.h
@@ -22,6 +22,8 @@ public:
   double mt_equalized() const{ return mt_posteq; }
   double mt_initial() const{ return mt_preeq; }
 
+  double area() const{ return voronoi_area; }
+
 protected:
 
   double pt_preeq;


### PR DESCRIPTION
Previously the access function for the voronoi_area variable was missing, it wasn't able to be used. 
Only the function is added, data format is not changed. 
Not used in reconstruction, only to be used in analysis of the object.
Tested to be compatible with data from CMSSW_5_3_16.
