### PR TITLE
ClangSA fix looper in FunctionDumper 

### DIFF
--- a/Utilities/StaticAnalyzers/scripts/create_statics_esd_reports.sh
+++ b/Utilities/StaticAnalyzers/scripts/create_statics_esd_reports.sh
@@ -3,7 +3,7 @@ export LC_ALL=C
 eval `scram runtime -sh`
 cd ${LOCALRT}/tmp
 
-if [ ! -f ./db.txt ]
+if [ ! -f ./function-calls-db.txt ]
 	then
 	echo "run ${CMSSW_BASE}/src/Utilities/StaticAnalyzers/scripts/run_class_checker.sh first"
 	exit 1
@@ -17,11 +17,13 @@ if [ ! -f ./classes.txt.dumperft ]
 fi
 
 cat function-calls-db.txt function-statics-db.txt >db.txt 
-${CMSSW_BASE}/src/Utilities/StaticAnalyzers/scripts/statics.py 2>&1 > statics-report.txt.unsorted
-sort -u < statics-report.txt.unsorted > statics-report.txt
-grep -e "^In call stack " statics-report.txt | awk '{print $0"\n"}' > modules2statics.txt
-grep -e "^Non-const static variable " statics-report.txt | awk '{print $0"\n"}' > statics2modules.txt
+
 ${CMSSW_BASE}/src/Utilities/StaticAnalyzers/scripts/data-class-funcs.py 2>&1 > data-class-funcs-report.txt
 grep -v -e "^In call stack " data-class-funcs-report.txt | grep -v -e"Flagged event setup data class"  >override-flagged-classes.txt
 grep -e "^Flagged event setup data class" data-class-funcs-report.txt | sort -u | awk '{print $0"\n\n"}' >esd2tlf.txt
 grep -e "^In call stack" data-class-funcs-report.txt | sort -u | awk '{print $0"\n\n"}' >tlf2esd.txt
+
+${CMSSW_BASE}/src/Utilities/StaticAnalyzers/scripts/statics.py 2>&1 > statics-report.txt.unsorted
+sort -u < statics-report.txt.unsorted > statics-report.txt
+grep -e "^In call stack " statics-report.txt | awk '{print $0"\n"}' > modules2statics.txt
+grep -e "^Non-const static variable " statics-report.txt | awk '{print $0"\n"}' > statics2modules.txt

--- a/Utilities/StaticAnalyzers/scripts/run_class_checker.sh
+++ b/Utilities/StaticAnalyzers/scripts/run_class_checker.sh
@@ -28,9 +28,7 @@ export USER_CXXFLAGS="-DEDM_ML_DEBUG -w"
 export USER_LLVM_CHECKERS="-disable-checker cplusplus -disable-checker unix -enable-checker threadsafety -disable-checker core -disable-checker security -disable-checker deadcode -disable-checker cms -enable-checker optional.ClassChecker -enable-checker cms.FunctionChecker"
 scram b -k -j $J checker  SCRAM_IGNORE_PACKAGES=Fireworks/% SCRAM_IGNORE_SUBDIRS=test 2>&1 > ${LOCALRT}/tmp/class+function-checker.log
 cd ${LOCALRT}/tmp/
+touch check-end
 sort -u < class-checker.txt.unsorted | grep -e"^data class">class-checker.txt
 sort -u < function-checker.txt.unsorted >function-statics-db.txt
-sort -u < function-checker.txt.unsorted >function-statics-db.txt
-sort -u < plugins.txt.unsorted > plugins.txt
-cat  function-calls-db.txt function-statics-db.txt >db.txt
-touch check-end
+rm *.txt.unsorted

--- a/Utilities/StaticAnalyzers/scripts/run_class_dumper.sh
+++ b/Utilities/StaticAnalyzers/scripts/run_class_dumper.sh
@@ -28,12 +28,14 @@ export USER_LLVM_CHECKERS="-disable-checker cplusplus -disable-checker unix -dis
 scram b -k -j $J checker SCRAM_IGNORE_PACKAGES=Fireworks/% SCRAM_IGNORE_SUBDIRS=test 2>&1 > $CMSSW_BASE/tmp/class+function-dumper.log
 find ${LOCALRT}/src/ -name classes\*.h.cc | xargs rm -fv
 cd ${LOCALRT}/tmp
+touch dump-end
+sort -u < plugins.txt.unsorted > plugins.txt
 sort -u < classes.txt.dumperct.unsorted | grep -e"^class" >classes.txt.dumperct.sorted
 awk -F\' ' {print "class \47"$2"\47\nclass \47"$4"\47\nclass \47"$6"\47\n" } '  <classes.txt.dumperct.sorted | sort -u >classes.txt.dumperct
 sort -u < classes.txt.dumperft.unsorted | grep -e"^class" >classes.txt.dumperft.sorted
 awk -F\' ' {print "class \47"$2"\47\nclass \47"$4"\47\nclass \47"$6"\47\n" } '  <classes.txt.dumperft.sorted | sort -u >classes.txt.dumperft
 sort -u < classes.txt.dumperall.unsorted | grep -e"^class" >classes.txt.dumperall
-sort -u < function-dumper.txt.unsorted | grep -v -e"BareRootProductGetter::getIt.*overrides"> function-calls-db.txt
+sort -u < function-dumper.txt.unsorted > function-calls-db.txt
 awk -F\' 'NR==FNR{a[$2]=1;next} {n=0;for(i in a){if($4==i && $3==" base class "){print "class \47"$2"\47";print;n=1}} }' classes.txt.dumperft classes.txt.dumperall >classes.txt.inherits 
 cat classes.txt.dumperct classes.txt.dumperft classes.txt.inherits | sort -u |grep -e"^class" >classes.txt
-touch dump-end
+rm *.txt.unsorted

--- a/Utilities/StaticAnalyzers/src/FunctionDumper.cpp
+++ b/Utilities/StaticAnalyzers/src/FunctionDumper.cpp
@@ -64,8 +64,11 @@ void FDumper::VisitChildren( clang::Stmt *S) {
 }
 
 void FDumper::VisitCXXConstructExpr( CXXConstructExpr *CCE ) {
-//	if (wasVisited(CCE)) return;
-//	setVisited(CCE);
+
+	if (!wasVisited(CCE)) {
+		setVisited(CCE);
+		VisitChildren(CCE);
+	}
 	LangOptions LangOpts;
 	LangOpts.CPlusPlus = true;
 	PrintingPolicy Policy(LangOpts);
@@ -85,13 +88,14 @@ void FDumper::VisitCXXConstructExpr( CXXConstructExpr *CCE ) {
 	std::string ostring = "function '"+ mdname +  "' " + "calls function '" + mname + "'\n"; 
 	std::ofstream file(tname.c_str(),std::ios::app);
 	file<<ostring;	
-	VisitChildren(CCE);
 }
 
 
 void FDumper::VisitCallExpr( CallExpr *CE ) {
-//	if (wasVisited(CE)) return;
-//	setVisited(CE);
+	if (!wasVisited(CE)) {
+		setVisited(CE);
+		VisitChildren(CE);
+	}
 	LangOptions LangOpts;
 	LangOpts.CPlusPlus = true;
 	PrintingPolicy Policy(LangOpts);
@@ -112,7 +116,6 @@ void FDumper::VisitCallExpr( CallExpr *CE ) {
 	std::ofstream file(tname.c_str(),std::ios::app);
 	file<<ostring;
 	Visit(CE->getCallee()->IgnoreParens());
-	VisitChildren(CE);
 }
 
 void FunctionDumper::checkASTDecl(const CXXMethodDecl *MD, AnalysisManager& mgr,


### PR DESCRIPTION
This function condPython::defineWhat<SiStripSummary>() caused an infinite loop in FunctionDumper after a call to VisitChildren was added to FunctionDumper. 
https://cmssdt.cern.ch/SDT/lxr/source/CondCore/SiStripPlugins/plugins/SiStripSummaryPyWrapper.cc#112
