### PR TITLE
Fix memory leak in PFRecHitCaloNavigator*

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitCaloNavigator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitCaloNavigator.h
@@ -21,14 +21,16 @@
 #include "DataFormats/CaloTowers/interface/CaloTowerDetId.h"
 
 
-template <typename DET,typename TOPO>
+template <typename DET,typename TOPO,bool ownsTopo=true>
 class PFRecHitCaloNavigator : public PFRecHitNavigatorBase {
  public:
+
+ virtual ~PFRecHitCaloNavigator() { if(!ownsTopo) { topology_.release(); } }
 
   void associateNeighbours(reco::PFRecHit& hit,std::auto_ptr<reco::PFRecHitCollection>& hits,edm::RefProd<reco::PFRecHitCollection>& refProd) {
       DetId detid( hit.detId() );
       
-      CaloNavigator<DET> navigator(detid, topology_);
+      CaloNavigator<DET> navigator(detid, topology_.get());
       
       DetId N(0);
       DetId E(0);
@@ -99,7 +101,7 @@ class PFRecHitCaloNavigator : public PFRecHitNavigatorBase {
 
 
  protected:
-  const TOPO *topology_;
+  std::unique_ptr<const TOPO> topology_;
 
 
 };

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitCaloNavigatorWithTime.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitCaloNavigatorWithTime.h
@@ -22,7 +22,7 @@
 
 #include "RecoParticleFlow/PFClusterProducer/interface/ECALRecHitResolutionProvider.h"
 
-template <typename D,typename T>
+template <typename D,typename T,bool ownsTopo=true>
 class PFRecHitCaloNavigatorWithTime : public PFRecHitNavigatorBase {
  public:
   PFRecHitCaloNavigatorWithTime(const edm::ParameterSet& iConfig) {
@@ -39,10 +39,13 @@ class PFRecHitCaloNavigatorWithTime : public PFRecHitNavigatorBase {
     }
   }
 
+ virtual ~PFRecHitCaloNavigatorWithTime() { if(!ownsTopo) { topology_.release(); } }
+
+
   void associateNeighbours(reco::PFRecHit& hit,std::auto_ptr<reco::PFRecHitCollection>& hits,edm::RefProd<reco::PFRecHitCollection>& refProd) {
       DetId detid( hit.detId() );
       
-      CaloNavigator<D> navigator(detid, topology_);
+      CaloNavigator<D> navigator(detid, topology_.get());
       
       DetId N(0);
       DetId E(0);
@@ -143,7 +146,7 @@ class PFRecHitCaloNavigatorWithTime : public PFRecHitNavigatorBase {
     }
   }
 
-  const T *topology_;
+  std::unique_ptr<const T> topology_;
   double noiseLevel2_;
   double noiseTerm2_;
   double constantTerm2_;

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitNavigatorBase.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitNavigatorBase.h
@@ -27,6 +27,8 @@ class PFRecHitNavigatorBase {
   PFRecHitNavigatorBase() {}
   PFRecHitNavigatorBase(const edm::ParameterSet& iConfig) {}
 
+  virtual ~PFRecHitNavigatorBase() {}
+
   virtual void beginEvent(const edm::EventSetup&)=0;
   virtual void associateNeighbours(reco::PFRecHit&,std::auto_ptr<reco::PFRecHitCollection>&,edm::RefProd<reco::PFRecHitCollection>&)=0;
 

--- a/RecoParticleFlow/PFClusterProducer/src/Navigators.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/Navigators.cc
@@ -17,7 +17,7 @@ class PFRecHitEcalBarrelNavigatorWithTime : public PFRecHitCaloNavigatorWithTime
   void beginEvent(const edm::EventSetup& iSetup) {
     edm::ESHandle<CaloGeometry> geoHandle;
     iSetup.get<CaloGeometryRecord>().get(geoHandle);
-    topology_ = new EcalBarrelTopology(geoHandle);
+    topology_.reset( new EcalBarrelTopology(geoHandle) );
   }
 };
 
@@ -32,7 +32,7 @@ class PFRecHitEcalEndcapNavigatorWithTime : public PFRecHitCaloNavigatorWithTime
   void beginEvent(const edm::EventSetup& iSetup) {
     edm::ESHandle<CaloGeometry> geoHandle;
     iSetup.get<CaloGeometryRecord>().get(geoHandle);
-    topology_ = new EcalEndcapTopology(geoHandle);
+    topology_.reset( new EcalEndcapTopology(geoHandle) );
   }
 };
 
@@ -45,7 +45,7 @@ class PFRecHitEcalBarrelNavigator : public PFRecHitCaloNavigator<EBDetId,EcalBar
   void beginEvent(const edm::EventSetup& iSetup) {
     edm::ESHandle<CaloGeometry> geoHandle;
     iSetup.get<CaloGeometryRecord>().get(geoHandle);
-    topology_ = new EcalBarrelTopology(geoHandle);
+    topology_.reset( new EcalBarrelTopology(geoHandle) );
   }
 };
 
@@ -58,7 +58,7 @@ class PFRecHitEcalEndcapNavigator : public PFRecHitCaloNavigator<EEDetId,EcalEnd
   void beginEvent(const edm::EventSetup& iSetup) {
     edm::ESHandle<CaloGeometry> geoHandle;
     iSetup.get<CaloGeometryRecord>().get(geoHandle);
-    topology_ = new EcalEndcapTopology(geoHandle);
+    topology_.reset( new EcalEndcapTopology(geoHandle) );
   }
 };
 
@@ -72,22 +72,23 @@ class PFRecHitPreshowerNavigator : public PFRecHitCaloNavigator<ESDetId,EcalPres
   void beginEvent(const edm::EventSetup& iSetup) {
     edm::ESHandle<CaloGeometry> geoHandle;
     iSetup.get<CaloGeometryRecord>().get(geoHandle);
-    topology_ = new EcalPreshowerTopology(geoHandle);
+    topology_.reset( new EcalPreshowerTopology(geoHandle) );
   }
 };
 
 
-class PFRecHitHCALNavigator : public PFRecHitCaloNavigator<HcalDetId,HcalTopology> {
+class PFRecHitHCALNavigator : public PFRecHitCaloNavigator<HcalDetId,HcalTopology,false> {
  public:
   PFRecHitHCALNavigator(const edm::ParameterSet& iConfig) {
 
   }
 
 
-  void beginEvent(const edm::EventSetup& iSetup) {
+  void beginEvent(const edm::EventSetup& iSetup) {    
       edm::ESHandle<HcalTopology> hcalTopology;
       iSetup.get<IdealGeometryRecord>().get( hcalTopology );
-      topology_ = hcalTopology.product();
+      topology_.release();
+      topology_.reset(hcalTopology.product());
   }
 };
 
@@ -100,7 +101,7 @@ class PFRecHitCaloTowerNavigator : public PFRecHitCaloNavigator<CaloTowerDetId,C
 
 
   void beginEvent(const edm::EventSetup& iSetup) {
-      topology_ = new CaloTowerTopology();
+    topology_.reset( new CaloTowerTopology() );
   }
 };
 


### PR DESCRIPTION
Multiple times per-event memory leak in PFRecHitCaloNavigator from respawning owned topology class.
Fixed with unique_ptr and ownership flag.
