### PR TITLE
Me0segment errors bugfix

### DIFF
--- a/RecoLocalMuon/GEMRecHit/src/ME0SegAlgoMM.h
+++ b/RecoLocalMuon/GEMRecHit/src/ME0SegAlgoMM.h
@@ -87,7 +87,7 @@ private:
   double protoChi2;
   double protoNDF;
   LocalVector protoDirection;
-  double protoChiUCorrection;
+  double protoChiUCorrection=1.0; //Hardcoded to 1.0, to fix noninvertibility of errors matrix
 
   std::vector<double> e_Cxx;
 };


### PR DESCRIPTION
Changed protoUCorrection to 1.0, hardcoded.  Fixed non-invertibility of the ME0Segments error matrix.  
