### PR TITLE
adding default HLT configs for taus

### DIFF
--- a/RecoTauTag/RecoTau/python/PFTauDiscriminatorLogicalAndProducer_cfi.py
+++ b/RecoTauTag/RecoTau/python/PFTauDiscriminatorLogicalAndProducer_cfi.py
@@ -1,0 +1,26 @@
+'''
+
+Select PFTaus that pass either all (option "and") or at least one (option "or") discriminators specified in "Prediscriminants" list.
+
+
+'''
+
+import FWCore.ParameterSet.Config as cms
+
+PFTauDiscriminatorLogicalAndProducer = cms.EDProducer("PFTauDiscriminatorLogicalAndProducer",
+    PFTauProducer = cms.InputTag("pfRecoTauProducer"),
+    Prediscriminants = cms.PSet(
+        BooleanOperator = cms.string("and"), # pass all discriminats in the list
+#         BooleanOperator = cms.string("or"), # pass at least one discriminat in the list
+        discr1 = cms.PSet(
+            Producer = cms.InputTag("pfRecoTauDiscriminationByIsolation"),
+            cut = cms.double(0.5)
+        ),
+        discr2 = cms.PSet(
+            Producer = cms.InputTag("pfRecoTauDiscriminationAgainstElectron"),
+            cut = cms.double(0.5)
+        )
+    ),
+    PassValue = cms.double(1.),
+    FailValue = cms.double(0.)
+)

--- a/RecoTauTag/RecoTau/python/RecoTauShrinkingConeProducer_cfi.py
+++ b/RecoTauTag/RecoTau/python/RecoTauShrinkingConeProducer_cfi.py
@@ -32,6 +32,7 @@ shrinkingConeRecoTaus = cms.EDProducer(
     jetSrc = cms.InputTag("ak5PFJets"),
     piZeroSrc = cms.InputTag("ak5PFJetsRecoTauPiZeros"),
     jetRegionSrc = cms.InputTag("recoTauAK5PFJets08Region"),
+    chargedHadronSrc = cms.InputTag('ak5PFJetsRecoTauChargedHadrons'),
     builders = cms.VPSet(
         _shrinkingConeRecoTausConfig
     ),


### PR DESCRIPTION
Adding dummy python fragments for HLT config as suggested by @mbluj

This change does not conflict with ak5->ak4 transition nor with #3594 and should be included in 710

FYI, @monicava and @veelken 
