### PR TITLE
Use move semantics to push TrajectorySeeds into a vector

### DIFF
--- a/RecoTracker/TkSeedGenerator/plugins/SeedFromConsecutiveHitsCreator.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedFromConsecutiveHitsCreator.cc
@@ -159,7 +159,7 @@ void SeedFromConsecutiveHitsCreator::buildSeed(
   PTrajectoryStateOnDet const & PTraj = 
     trajectoryStateTransform::persistentState(updatedState, hit->geographicalId().rawId());
   TrajectorySeed seed(PTraj,std::move(seedHits),alongMomentum); 
-  if ( !filter || filter->compatible(seed)) seedCollection.push_back(seed);
+  if ( !filter || filter->compatible(seed)) seedCollection.push_back(std::move(seed));
 
 }
 


### PR DESCRIPTION
TrajectorySeed has a move constructor (https://github.com/cms-sw/cmssw/blob/CMSSW_7_1_X/DataFormats/TrajectorySeed/interface/TrajectorySeed.h#L65) which previously wasn't used for the vector push.

I haven't done any benchmarking, but each individual push_back should be quite small.  At 140 pileup however pixelPairStepSeeds has O(100000) of these push_backs, and that's just one of the tracking steps.
