### PR TITLE
scenario HeavyIons and --himix decoupled

### DIFF
--- a/Configuration/PyReleaseValidation/python/ConfigBuilder.py
+++ b/Configuration/PyReleaseValidation/python/ConfigBuilder.py
@@ -916,9 +916,9 @@ class ConfigBuilder(object):
             self.DQMDefaultSeq='DQMOfflineCosmics'
 
         if self._options.himix:
-                print "From the presence of the himix option, we have determined that this is heavy ions and will use '--scenario HeavyIons'."
-                self._options.scenario='HeavyIons'
-
+                print "From the presence of the himix option, we have determined that this production should use the HeavyIon EventContent"
+		self.EVTCONTDefaultCFF="Configuration/EventContent/EventContentHeavyIons_cff"
+	    
         if self._options.scenario=='HeavyIons':
 	    if not self._options.beamspot:
 		    self._options.beamspot=VtxSmearedHIDefaultKey


### PR DESCRIPTION
This fix is needed for our pPb MC production. This is the reason: 
For pPb analyses, we use pp-reconstruction, so HI scenario is not wanted. 
On the other hand, the same mixing workflow is applied, using the option --himix, and HI event content (which is a strict superset of pp event content) is needed to keep the signal event (hiSignal).
Therefore the scenario has to be decoupled from himix, but EventContent should always be imposed.
The fix pull-requested here does exactly the above, and nothing else.
