### PR TITLE
Fixed problems found by clang

### DIFF
--- a/FWCore/Framework/interface/SubProcess.h
+++ b/FWCore/Framework/interface/SubProcess.h
@@ -1,4 +1,4 @@
-#ifndef FwCore_Framework_SubProcess_h
+#ifndef FWCore_Framework_SubProcess_h
 #define FWCore_Framework_SubProcess_h
 
 #include "FWCore/Framework/interface/EventSetupProvider.h"

--- a/FWCore/Framework/src/StreamSchedule.cc
+++ b/FWCore/Framework/src/StreamSchedule.cc
@@ -81,10 +81,6 @@ namespace edm {
       return ptr;
     }
 
-    inline bool binary_search_string(std::vector<std::string> const& v, std::string const& s) {
-      return std::binary_search(v.begin(), v.end(), s);
-    }
-    
     void
     initializeBranchToReadingWorker(ParameterSet const& opts,
                                     ProductRegistry const& preg,

--- a/FWCore/Framework/src/Worker.cc
+++ b/FWCore/Framework/src/Worker.cc
@@ -66,12 +66,6 @@ private:
       ModuleCallingContext const& mcc_;
     };
 
-    inline cms::Exception& exceptionContext(ModuleDescription const& iMD,
-                                     cms::Exception& iEx) {
-      iEx << iMD.moduleName() << "/" << iMD.moduleLabel() << "\n";
-      return iEx;
-    }
-
   }
 
   Worker::Worker(ModuleDescription const& iMD, 

--- a/FWCore/Framework/test/one_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/one_outputmodule_t.cppunit.cc
@@ -57,8 +57,6 @@ public:
   void fileTest();
   void resourceTest();
 
-private:
-
   enum class Trans {
     kBeginJob,
     kGlobalOpenInputFile,
@@ -72,8 +70,11 @@ private:
     kEndJob
   };
   
-  std::map<Trans,std::function<void(edm::Worker*,edm::OutputModuleCommunicator*)>> m_transToFunc;
   typedef std::vector<Trans> Expectations;
+
+private:
+
+  std::map<Trans,std::function<void(edm::Worker*,edm::OutputModuleCommunicator*)>> m_transToFunc;
   
   edm::ProcessConfiguration m_procConfig;
   boost::shared_ptr<edm::ProductRegistry> m_prodReg;

--- a/FWCore/Framework/test/stream_module_t.cppunit.cc
+++ b/FWCore/Framework/test/stream_module_t.cppunit.cc
@@ -66,8 +66,6 @@ public:
   void endRunSummaryProdTest();
   void endLumiSummaryProdTest();
 
-private:
-
   enum class Trans {
     kBeginJob, //0
     kBeginStream, //1
@@ -84,8 +82,11 @@ private:
     kEndJob //12
   };
   
-  std::map<Trans,std::function<void(edm::Worker*)>> m_transToFunc;
   typedef std::vector<Trans> Expectations;
+
+private:
+
+  std::map<Trans,std::function<void(edm::Worker*)>> m_transToFunc;
   
   edm::ProcessConfiguration m_procConfig;
   boost::shared_ptr<edm::ProductRegistry> m_prodReg;


### PR DESCRIPTION
Fixed warnings and errors from the clang compiler. None of these change any functionality.
