### PR TITLE
FilterOutScrapping consumes migration

### DIFF
--- a/DPGAnalysis/Skims/interface/FilterOutScraping.h
+++ b/DPGAnalysis/Skims/interface/FilterOutScraping.h
@@ -43,8 +43,7 @@ private:
   bool debugOn;
   double thresh;
   unsigned int numtrack;
-  edm::InputTag tracks_;
-
+  edm::EDGetTokenT<reco::TrackCollection> tracks_;
   reco::TrackBase::TrackQuality _trackQuality;
 };
 

--- a/DPGAnalysis/Skims/src/FilterOutScraping.cc
+++ b/DPGAnalysis/Skims/src/FilterOutScraping.cc
@@ -35,7 +35,7 @@ FilterOutScraping::FilterOutScraping(const edm::ParameterSet& iConfig)
   debugOn     = iConfig.getUntrackedParameter<bool>("debugOn",false);
   thresh =  iConfig.getUntrackedParameter<double>("thresh",0.2);
   numtrack = iConfig.getUntrackedParameter<unsigned int>("numtrack",10);
-  tracks_ = iConfig.getUntrackedParameter<edm::InputTag>("src",edm::InputTag("generalTracks"));
+  tracks_ = consumes<reco::TrackCollection>(iConfig.getUntrackedParameter<edm::InputTag>("src",edm::InputTag("generalTracks")));
 }
 
 FilterOutScraping::~FilterOutScraping()
@@ -50,7 +50,7 @@ bool FilterOutScraping::filter( edm::Event& iEvent, const edm::EventSetup& iSetu
   // get GeneralTracks collection
 
   edm::Handle<reco::TrackCollection> tkRef;
-  iEvent.getByLabel(tracks_,tkRef);    
+  iEvent.getByToken(tracks_,tkRef);    
   const reco::TrackCollection* tkColl = tkRef.product();
 
   //std::cout << "Total Number of Tracks " << tkColl->size() << std::endl;


### PR DESCRIPTION
do consumes for FilterOutScrapping (again trivial)
