### PR TITLE
Mark functions as thread safe

### DIFF
--- a/DataFormats/TrackReco/interface/Track.h
+++ b/DataFormats/TrackReco/interface/Track.h
@@ -20,6 +20,7 @@
 #include "DataFormats/TrackReco/interface/TrackExtra.h"
 #include "DataFormats/TrackReco/interface/TrackExtraFwd.h" 
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 namespace reco {
 
@@ -51,9 +52,9 @@ namespace reco {
     /// innermost trajectory state curvilinear errors
     CovarianceMatrix innerStateCovariance() const { return extra_->innerStateCovariance(); }
     /// fill outermost trajectory state curvilinear errors
-    CovarianceMatrix & fillOuter( CovarianceMatrix & v ) const { return extra_->fillOuter( v ); }
+    CovarianceMatrix & fillOuter CMS_THREAD_SAFE ( CovarianceMatrix & v ) const { return extra_->fillOuter( v ); }
     /// fill outermost trajectory state curvilinear errors
-    CovarianceMatrix & fillInner( CovarianceMatrix & v ) const { return extra_->fillInner( v ); }
+    CovarianceMatrix & fillInner CMS_THREAD_SAFE ( CovarianceMatrix & v ) const { return extra_->fillInner( v ); }
     /// DetId of the detector on which surface the outermost state is located
     unsigned int outerDetId() const { return extra_->outerDetId(); }
     /// DetId of the detector on which surface the innermost state is located

--- a/DataFormats/TrackReco/interface/TrackExtra.h
+++ b/DataFormats/TrackReco/interface/TrackExtra.h
@@ -19,6 +19,7 @@
 #include "DataFormats/TrackReco/interface/TrackResiduals.h"
 #include "DataFormats/TrajectorySeed/interface/PropagationDirection.h"
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeed.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 namespace reco {
   class TrackExtra : public TrackExtraBase {
@@ -109,9 +110,9 @@ namespace reco {
     /// innermost trajectory state curvilinear errors
     CovarianceMatrix innerStateCovariance() const;
     /// fill outermost trajectory state curvilinear errors
-    CovarianceMatrix & fillOuter( CovarianceMatrix & v ) const;
+    CovarianceMatrix & fillOuter CMS_THREAD_SAFE ( CovarianceMatrix & v ) const;
     /// fill outermost trajectory state curvilinear errors
-    CovarianceMatrix & fillInner( CovarianceMatrix & v ) const;
+    CovarianceMatrix & fillInner CMS_THREAD_SAFE ( CovarianceMatrix & v ) const;
     /// DetId of the detector on which surface the outermost state is located
     unsigned int outerDetId() const { return outerDetId_; }
     /// DetId of the detector on which surface the innermost state is located


### PR DESCRIPTION
Use attribute to mark some functions thread safe
that are falsely flagged as a problem by the static
analyzer.
