### PR TITLE
Changed mutables to std::atomic in PixelCPEBase

### DIFF
--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEBase.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEBase.h
@@ -44,6 +44,9 @@
 #include <unordered_map>
 
 #include <iostream>
+#ifdef EDM_ML_DEBUG
+#include <atomic>
+#endif
 
 class RectangularPixelTopology;
 class MagneticField;
@@ -217,8 +220,8 @@ private:
 
   //--- Counters
 #ifdef EDM_ML_DEBUG
-  mutable int    nRecHitsTotal_ ; //for debugging only
-  mutable int    nRecHitsUsedEdge_ ; //for debugging only
+  mutable std::atomic<int>    nRecHitsTotal_ ; //for debugging only
+  mutable std::atomic<int>    nRecHitsUsedEdge_ ; //for debugging only
 #endif 
 
   // Added new members


### PR DESCRIPTION
To avoid complaints from the static analyzer, converted mutable
debug counters to std::atomic. These debug counters are only used
if a CPP variable is set. This change compiles when that variable is
set, however other code in this package fails even without this change.
