### PR TITLE
Fix thread-safety issue in PrimaryVertexGenerator

### DIFF
--- a/FastSimulation/Event/interface/PrimaryVertexGenerator.h
+++ b/FastSimulation/Event/interface/PrimaryVertexGenerator.h
@@ -22,7 +22,8 @@ public:
   /// Generation process (to be implemented)
   virtual void generate(RandomEngineAndDistribution const*) = 0;
 
-  TMatrixD* boost() const;
+  TMatrixD* boost();
+  const TMatrixD* boost() const;
 
   /// Return x0, y0, z0
   inline const math::XYZPoint& beamSpot() const { return beamSpot_; }

--- a/FastSimulation/Event/src/PrimaryVertexGenerator.cc
+++ b/FastSimulation/Event/src/PrimaryVertexGenerator.cc
@@ -11,8 +11,13 @@ PrimaryVertexGenerator::~PrimaryVertexGenerator() {
   if ( boost_ ) delete boost_; 
 }
 
-TMatrixD* 
+const TMatrixD* 
 PrimaryVertexGenerator::boost() const { 
+  return boost_;
+}
+
+TMatrixD* 
+PrimaryVertexGenerator::boost() { 
   return boost_;
 }
 


### PR DESCRIPTION
The static analyzer found that PrimaryVertexGenerator was return
a non-const pointer to its internal data from a const function. This
was changed to returning a const pointer and a non-const function was
added which returned the non-const pointer.
