### PR TITLE
fixed warnings on materials at SIM step

### DIFF
--- a/Geometry/CMSCommonData/data/materials.xml
+++ b/Geometry/CMSCommonData/data/materials.xml
@@ -245,7 +245,7 @@
    </MaterialFraction>
   </CompositeMaterial>
   <CompositeMaterial name="Heavy Boron concrete" density="3.574*g/cm3" symbol=" " method="mixture by weight">
-   <MaterialFraction fraction="0.5192746">
+   <MaterialFraction fraction="0.5203954">
     <rMaterial name="materials:Iron"/>
    </MaterialFraction>
    <MaterialFraction fraction="0.34702">

--- a/Geometry/ForwardCommonData/data/bundle/forwardshield.xml
+++ b/Geometry/ForwardCommonData/data/bundle/forwardshield.xml
@@ -551,55 +551,55 @@
 		</LogicalPart>
 		<LogicalPart name="FibreBundle1" category="unspecified">
 			<rSolid name="FibreBundle1"/>
-			<rMaterial name="hcalforwardmaterial:Quartz"/>
+			<rMaterial name="hcalforwardmaterial:QuartzF"/>
 		</LogicalPart>
 		<LogicalPart name="FibreBundle2" category="unspecified">
 			<rSolid name="FibreBundle2"/>
-			<rMaterial name="hcalforwardmaterial:Quartz"/>
+			<rMaterial name="hcalforwardmaterial:QuartzF"/>
 		</LogicalPart>
 		<LogicalPart name="FibreBundle3" category="unspecified">
 			<rSolid name="FibreBundle3"/>
-			<rMaterial name="hcalforwardmaterial:Quartz"/>
+			<rMaterial name="hcalforwardmaterial:QuartzF"/>
 		</LogicalPart>
 		<LogicalPart name="FibreBundle4" category="unspecified">
 			<rSolid name="FibreBundle4"/>
-			<rMaterial name="hcalforwardmaterial:Quartz"/>
+			<rMaterial name="hcalforwardmaterial:QuartzF"/>
 		</LogicalPart>
 		<LogicalPart name="FibreBundle5" category="unspecified">
 			<rSolid name="FibreBundle5"/>
-			<rMaterial name="hcalforwardmaterial:Quartz"/>
+			<rMaterial name="hcalforwardmaterial:QuartzF"/>
 		</LogicalPart>
 		<LogicalPart name="FibreBundle6" category="unspecified">
 			<rSolid name="FibreBundle6"/>
-			<rMaterial name="hcalforwardmaterial:Quartz"/>
+			<rMaterial name="hcalforwardmaterial:QuartzF"/>
 		</LogicalPart>
 		<LogicalPart name="FibreBundle7" category="unspecified">
 			<rSolid name="FibreBundle7"/>
-			<rMaterial name="hcalforwardmaterial:Quartz"/>
+			<rMaterial name="hcalforwardmaterial:QuartzF"/>
 		</LogicalPart>
 		<LogicalPart name="FibreBundle8" category="unspecified">
 			<rSolid name="FibreBundle8"/>
-			<rMaterial name="hcalforwardmaterial:Quartz"/>
+			<rMaterial name="hcalforwardmaterial:QuartzF"/>
 		</LogicalPart>
 		<LogicalPart name="FibreBundle9" category="unspecified">
 			<rSolid name="FibreBundle9"/>
-			<rMaterial name="hcalforwardmaterial:Quartz"/>
+			<rMaterial name="hcalforwardmaterial:QuartzF"/>
 		</LogicalPart>
 		<LogicalPart name="FibreBundle10" category="unspecified">
 			<rSolid name="FibreBundle10"/>
-			<rMaterial name="hcalforwardmaterial:Quartz"/>
+			<rMaterial name="hcalforwardmaterial:QuartzF"/>
 		</LogicalPart>
 		<LogicalPart name="FibreBundle11" category="unspecified">
 			<rSolid name="FibreBundle11"/>
-			<rMaterial name="hcalforwardmaterial:Quartz"/>
+			<rMaterial name="hcalforwardmaterial:QuartzF"/>
 		</LogicalPart>
 		<LogicalPart name="FibreBundle12" category="unspecified">
 			<rSolid name="FibreBundle12"/>
-			<rMaterial name="hcalforwardmaterial:Quartz"/>
+			<rMaterial name="hcalforwardmaterial:QuartzF"/>
 		</LogicalPart>
 		<LogicalPart name="FibreBundle13" category="unspecified">
 			<rSolid name="FibreBundle13"/>
-			<rMaterial name="hcalforwardmaterial:Quartz"/>
+			<rMaterial name="hcalforwardmaterial:QuartzF"/>
 		</LogicalPart>
 	</LogicalPartSection>
 	<PosPartSection label="forwardshield.xml">
@@ -1123,7 +1123,7 @@
 		<Numeric name="DeltaZ" value="([CalShldZ1]-[cms:ForwdVcalZ2])"/>
 		<Numeric name="NumberPhi" value="4"/>
 		<Numeric name="TiltAngle" value="5.0*deg"/>
-		<String name="Material" value="hcalforwardmaterial:Quartz"/>
+		<String name="Material" value="hcalforwardmaterial:QuartzF"/>
 		<String name="Child" value="VcalFibreBundleL"/>
 		<Vector name="AreaSection" type="numeric" nEntries="13">
 			551*mm2, 652*mm2, 469*mm2, 324*mm2, 231*mm2, 167*mm2,
@@ -1148,7 +1148,7 @@
 		<Numeric name="DeltaZ" value="([CalShldZ1]-[cms:ForwdVcalZ2])"/>
 		<Numeric name="NumberPhi" value="4"/>
 		<Numeric name="TiltAngle" value="5.0*deg"/>
-		<String name="Material" value="hcalforwardmaterial:Quartz"/>
+		<String name="Material" value="hcalforwardmaterial:QuartzF"/>
 		<String name="Child" value="VcalFibreBundleR"/>
 		<Vector name="AreaSection" type="numeric" nEntries="13">
 			551*mm2, 652*mm2, 469*mm2, 324*mm2, 231*mm2, 167*mm2,

--- a/Geometry/ForwardCommonData/data/v2/forwardshield.xml
+++ b/Geometry/ForwardCommonData/data/v2/forwardshield.xml
@@ -538,55 +538,55 @@
 		</LogicalPart>
 		<LogicalPart name="FibreBundle1" category="unspecified">
 			<rSolid name="FibreBundle1"/>
-			<rMaterial name="hcalforwardmaterial:Quartz"/>
+			<rMaterial name="hcalforwardmaterial:QuartzF"/>
 		</LogicalPart>
 		<LogicalPart name="FibreBundle2" category="unspecified">
 			<rSolid name="FibreBundle2"/>
-			<rMaterial name="hcalforwardmaterial:Quartz"/>
+			<rMaterial name="hcalforwardmaterial:QuartzF"/>
 		</LogicalPart>
 		<LogicalPart name="FibreBundle3" category="unspecified">
 			<rSolid name="FibreBundle3"/>
-			<rMaterial name="hcalforwardmaterial:Quartz"/>
+			<rMaterial name="hcalforwardmaterial:QuartzF"/>
 		</LogicalPart>
 		<LogicalPart name="FibreBundle4" category="unspecified">
 			<rSolid name="FibreBundle4"/>
-			<rMaterial name="hcalforwardmaterial:Quartz"/>
+			<rMaterial name="hcalforwardmaterial:QuartzF"/>
 		</LogicalPart>
 		<LogicalPart name="FibreBundle5" category="unspecified">
 			<rSolid name="FibreBundle5"/>
-			<rMaterial name="hcalforwardmaterial:Quartz"/>
+			<rMaterial name="hcalforwardmaterial:QuartzF"/>
 		</LogicalPart>
 		<LogicalPart name="FibreBundle6" category="unspecified">
 			<rSolid name="FibreBundle6"/>
-			<rMaterial name="hcalforwardmaterial:Quartz"/>
+			<rMaterial name="hcalforwardmaterial:QuartzF"/>
 		</LogicalPart>
 		<LogicalPart name="FibreBundle7" category="unspecified">
 			<rSolid name="FibreBundle7"/>
-			<rMaterial name="hcalforwardmaterial:Quartz"/>
+			<rMaterial name="hcalforwardmaterial:QuartzF"/>
 		</LogicalPart>
 		<LogicalPart name="FibreBundle8" category="unspecified">
 			<rSolid name="FibreBundle8"/>
-			<rMaterial name="hcalforwardmaterial:Quartz"/>
+			<rMaterial name="hcalforwardmaterial:QuartzF"/>
 		</LogicalPart>
 		<LogicalPart name="FibreBundle9" category="unspecified">
 			<rSolid name="FibreBundle9"/>
-			<rMaterial name="hcalforwardmaterial:Quartz"/>
+			<rMaterial name="hcalforwardmaterial:QuartzF"/>
 		</LogicalPart>
 		<LogicalPart name="FibreBundle10" category="unspecified">
 			<rSolid name="FibreBundle10"/>
-			<rMaterial name="hcalforwardmaterial:Quartz"/>
+			<rMaterial name="hcalforwardmaterial:QuartzF"/>
 		</LogicalPart>
 		<LogicalPart name="FibreBundle11" category="unspecified">
 			<rSolid name="FibreBundle11"/>
-			<rMaterial name="hcalforwardmaterial:Quartz"/>
+			<rMaterial name="hcalforwardmaterial:QuartzF"/>
 		</LogicalPart>
 		<LogicalPart name="FibreBundle12" category="unspecified">
 			<rSolid name="FibreBundle12"/>
-			<rMaterial name="hcalforwardmaterial:Quartz"/>
+			<rMaterial name="hcalforwardmaterial:QuartzF"/>
 		</LogicalPart>
 		<LogicalPart name="FibreBundle13" category="unspecified">
 			<rSolid name="FibreBundle13"/>
-			<rMaterial name="hcalforwardmaterial:Quartz"/>
+			<rMaterial name="hcalforwardmaterial:QuartzF"/>
 		</LogicalPart>
 	</LogicalPartSection>
 	<PosPartSection label="forwardshield.xml">
@@ -1125,7 +1125,7 @@
 		<Numeric name="DeltaZ" value="([CalShldZ1]-[cms:ForwdVcalZ2])"/>
 		<Numeric name="NumberPhi" value="4"/>
 		<Numeric name="TiltAngle" value="5.0*deg"/>
-		<String name="Material" value="hcalforwardmaterial:Quartz"/>
+		<String name="Material" value="hcalforwardmaterial:QuartzF"/>
 		<String name="Child" value="VcalFibreBundleL"/>
 		<Vector name="AreaSection" type="numeric" nEntries="13">
 			551*mm2, 652*mm2, 469*mm2, 324*mm2, 231*mm2, 167*mm2,
@@ -1150,7 +1150,7 @@
 		<Numeric name="DeltaZ" value="([CalShldZ1]-[cms:ForwdVcalZ2])"/>
 		<Numeric name="NumberPhi" value="4"/>
 		<Numeric name="TiltAngle" value="5.0*deg"/>
-		<String name="Material" value="hcalforwardmaterial:Quartz"/>
+		<String name="Material" value="hcalforwardmaterial:QuartzF"/>
 		<String name="Child" value="VcalFibreBundleR"/>
 		<Vector name="AreaSection" type="numeric" nEntries="13">
 			551*mm2, 652*mm2, 469*mm2, 324*mm2, 231*mm2, 167*mm2,

--- a/Geometry/HcalCommonData/data/average/hcalforwardmaterial.xml
+++ b/Geometry/HcalCommonData/data/average/hcalforwardmaterial.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../../DetectorDescription/Schema/DDLSchema.xsd">
  <MaterialSection label="hcalforwardmaterial.xml">
-  <CompositeMaterial name="Quartz" density="2.20*g/cm3" symbol=" " method="mixture by weight">
+  <CompositeMaterial name="QuartzF" density="2.20*g/cm3" symbol=" " method="mixture by weight">
    <MaterialFraction fraction="0.46748103">
     <rMaterial name="materials:Silicon"/>
    </MaterialFraction>
@@ -25,7 +25,7 @@
     <rMaterial name="materials:Air"/>
    </MaterialFraction>
    <MaterialFraction fraction="0.001993">
-    <rMaterial name="hcalforwardmaterial:Quartz"/>
+    <rMaterial name="hcalforwardmaterial:QuartzF"/>
    </MaterialFraction>
    <MaterialFraction fraction="0.001189">
     <rMaterial name="hcalforwardmaterial:Plastic"/>

--- a/Geometry/HcalCommonData/data/hcalforwardfibre.xml
+++ b/Geometry/HcalCommonData/data/hcalforwardfibre.xml
@@ -51,11 +51,11 @@
 		</LogicalPart>
 		<LogicalPart name="HFFibreS" category="unspecified">
 			<rSolid name="HFFibreS"/>
-			<rMaterial name="hcalforwardmaterial:Quartz"/>
+			<rMaterial name="hcalforwardmaterial:QuartzF"/>
 		</LogicalPart>
 		<LogicalPart name="HFFibreL" category="unspecified">
 			<rSolid name="HFFibreL"/>
-			<rMaterial name="hcalforwardmaterial:Quartz"/>
+			<rMaterial name="hcalforwardmaterial:QuartzF"/>
 		</LogicalPart>
 	</LogicalPartSection>
 	<PosPartSection label="hcalforwardfibre.xml">

--- a/Geometry/HcalCommonData/data/hcalforwardmaterial.xml
+++ b/Geometry/HcalCommonData/data/hcalforwardmaterial.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
  <MaterialSection label="hcalforwardmaterial.xml">
-  <CompositeMaterial name="Quartz" density="2.20*g/cm3" symbol=" " method="mixture by weight">
+  <CompositeMaterial name="QuartzF" density="2.20*g/cm3" symbol=" " method="mixture by weight">
    <MaterialFraction fraction="0.46748103">
     <rMaterial name="materials:Silicon"/>
    </MaterialFraction>

--- a/Geometry/HcalCommonData/data/hcalforwardshower.xml
+++ b/Geometry/HcalCommonData/data/hcalforwardshower.xml
@@ -71,11 +71,11 @@
 		</LogicalPart>
 		<LogicalPart name="HFFibreS" category="unspecified">
 			<rSolid name="HFFibreS"/>
-			<rMaterial name="hcalforwardmaterial:Quartz"/>
+			<rMaterial name="hcalforwardmaterial:QuartzF"/>
 		</LogicalPart>
 		<LogicalPart name="HFFibreL" category="unspecified">
 			<rSolid name="HFFibreL"/>
-			<rMaterial name="hcalforwardmaterial:Quartz"/>
+			<rMaterial name="hcalforwardmaterial:QuartzF"/>
 		</LogicalPart>
 	</LogicalPartSection>
 	<PosPartSection label="hcalforwardshower.xml">

--- a/Geometry/HcalCommonData/data/v1/hcalforwardshower.xml
+++ b/Geometry/HcalCommonData/data/v1/hcalforwardshower.xml
@@ -71,11 +71,11 @@
 		</LogicalPart>
 		<LogicalPart name="HFFibreS" category="unspecified">
 			<rSolid name="HFFibreS"/>
-			<rMaterial name="hcalforwardmaterial:Quartz"/>
+			<rMaterial name="hcalforwardmaterial:QuartzF"/>
 		</LogicalPart>
 		<LogicalPart name="HFFibreL" category="unspecified">
 			<rSolid name="HFFibreL"/>
-			<rMaterial name="hcalforwardmaterial:Quartz"/>
+			<rMaterial name="hcalforwardmaterial:QuartzF"/>
 		</LogicalPart>
 	</LogicalPartSection>
 	<PosPartSection label="hcalforwardshower.xml">

--- a/Geometry/TrackerCommonData/data/trackermaterial.xml
+++ b/Geometry/TrackerCommonData/data/trackermaterial.xml
@@ -432,7 +432,7 @@
         <rMaterial name="trackermaterial:TS_SignalCable" />
       </MaterialFraction>
     </CompositeMaterial>
-    <CompositeMaterial name="Tk_panels_mid1" density="1.17876*0.67*g/cm3" method="mixture by weight" symbol=" ">
+      <CompositeMaterial name="Tk_panels_mid1" density="1.17876*0.67*g/cm3" method="mixture by weight" symbol=" ">
       <MaterialFraction fraction="1e-05">
         <rMaterial name="materials:Quartz" />
       </MaterialFraction>
@@ -446,20 +446,20 @@
         <rMaterial name="materials:C6F14" />
       </MaterialFraction>
     </CompositeMaterial>
-    <CompositeMaterial name="Tk_panels_mid1b" density="1.17876*g/cm3" method="mixture by weight" symbol=" ">
-      <MaterialFraction fraction="1e-05">
-        <rMaterial name="materials:Quartz"/>
-      </MaterialFraction>
-      <MaterialFraction fraction="0.08405">
-        <rMaterial name="materials:Polyethylene"/>
-      </MaterialFraction>
-      <MaterialFraction fraction="0.84501">
-        <rMaterial name="trackermaterial:T_Copper"/>
-      </MaterialFraction>
-      <MaterialFraction fraction="0.07094">
-        <rMaterial name="materials:C6F14"/>
-      </MaterialFraction>
-    </CompositeMaterial>
+    <CompositeMaterial name="Tk_panels_mid1b" density="1.17876*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="1e-05">
+         <rMaterial name="materials:Quartz"/>
+      </MaterialFraction>
+      <MaterialFraction fraction="0.08405">
+         <rMaterial name="materials:Polyethylene"/>
+      </MaterialFraction>
+      <MaterialFraction fraction="0.84501">
+         <rMaterial name="trackermaterial:T_Copper"/>
+      </MaterialFraction>
+      <MaterialFraction fraction="0.07094">
+         <rMaterial name="materials:C6F14"/>
+      </MaterialFraction>
+    </CompositeMaterial>
     <CompositeMaterial name="Tk_panels_mid2" density="0.35866*g/cm3" method="mixture by weight" symbol=" ">
       <MaterialFraction fraction="1e-05">
         <rMaterial name="materials:Quartz" />


### PR DESCRIPTION
Minor clean-up on materials:

1) Material Quartz was defined in the main material list with density 2.64 and in forward materials list with the density 2.2, this is HF specific material.  To remove the warning the last is renamed to QuartzF.

2) Heavy Boron Concrete definition had a minor problem: sum of mass fractions for components was not exact 1.0. The mass fraction of the first (largest) component is slightly increased.

3) In trackermaterial.xml there were number of hidden symbols

Overall this modifications should not affect any results.
