### PR TITLE
e/gamma consumes migration

### DIFF
--- a/RecoEgamma/EgammaPhotonAlgos/interface/ConversionSeedFinder.h
+++ b/RecoEgamma/EgammaPhotonAlgos/interface/ConversionSeedFinder.h
@@ -39,7 +39,9 @@
 
 
 //
-
+namespace edm {
+  class ConsumesCollector;
+}
 
 class DetLayer;
 class FreeTrajectoryState;
@@ -53,7 +55,7 @@ class ConversionSeedFinder {
   
 
   ConversionSeedFinder();
-  ConversionSeedFinder( const edm::ParameterSet& config );
+  ConversionSeedFinder( const edm::ParameterSet& config,edm::ConsumesCollector & iC );
   
   virtual ~ConversionSeedFinder(){}
 
@@ -82,7 +84,7 @@ class ConversionSeedFinder {
  protected:
 
 
-  edm::ParameterSet conf_;
+  //edm::ParameterSet conf_; found this to be completely unused
   void findLayers() const ;
   void findLayers(const FreeTrajectoryState & fts) const  ; 
 
@@ -107,6 +109,9 @@ class ConversionSeedFinder {
  
   edm::ESHandle<MagneticField> theMF_;
   edm::ESHandle<GeometricSearchTracker>       theGeomSearchTracker_;
+
+  edm::EDGetTokenT<reco::BeamSpot> beamSpotToken_;
+  edm::EDGetTokenT<MeasurementTrackerEvent> measurementTrkToken_;
 
 
   KFUpdator                  theUpdator_;

--- a/RecoEgamma/EgammaPhotonAlgos/interface/InOutConversionSeedFinder.h
+++ b/RecoEgamma/EgammaPhotonAlgos/interface/InOutConversionSeedFinder.h
@@ -46,7 +46,7 @@ class InOutConversionSeedFinder : public ConversionSeedFinder {
     
     
     
-    InOutConversionSeedFinder( const edm::ParameterSet& config );
+  InOutConversionSeedFinder( const edm::ParameterSet& config,edm::ConsumesCollector && iC);
   
   
   

--- a/RecoEgamma/EgammaPhotonAlgos/interface/OutInConversionSeedFinder.h
+++ b/RecoEgamma/EgammaPhotonAlgos/interface/OutInConversionSeedFinder.h
@@ -40,7 +40,7 @@ class OutInConversionSeedFinder : public ConversionSeedFinder {
   public :
     
   
-    OutInConversionSeedFinder( const edm::ParameterSet& config );
+  OutInConversionSeedFinder( const edm::ParameterSet& config,edm::ConsumesCollector && iC );
   
   virtual ~OutInConversionSeedFinder();
   

--- a/RecoEgamma/EgammaPhotonAlgos/src/ConversionSeedFinder.cc
+++ b/RecoEgamma/EgammaPhotonAlgos/src/ConversionSeedFinder.cc
@@ -1,4 +1,5 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "RecoEgamma/EgammaPhotonAlgos/interface/ConversionSeedFinder.h"
 // Field
 // Geometry
@@ -12,10 +13,13 @@
 #include "RecoTracker/Record/interface/TrackerRecoGeometryRecord.h"
 #include "RecoTracker/Record/interface/CkfComponentsRecord.h"
 
-ConversionSeedFinder::ConversionSeedFinder(const edm::ParameterSet& config ): 
-  conf_(config),
+ConversionSeedFinder::ConversionSeedFinder(const edm::ParameterSet& config,edm::ConsumesCollector & iC ): 
+  //  conf_(config),
   theUpdator_()
 {
+
+  measurementTrkToken_=iC.consumes<MeasurementTrackerEvent>(edm::InputTag("MeasurementTrackerEvent")); //hardcoded because the original was and no time to fix (sigh)
+  beamSpotToken_=iC.consumes<reco::BeamSpot>(edm::InputTag("offlineBeamSpot"));  //hardcoded because the original was and no time to fix (sigh)
 
   LogDebug("ConversionSeedFinder")  << " CTOR " << "\n";
 
@@ -30,10 +34,10 @@ void ConversionSeedFinder::setEvent(const edm::Event& evt  )  {
 
   //get the BeamSpot
   edm::Handle<reco::BeamSpot> recoBeamSpotHandle;
-  evt.getByLabel("offlineBeamSpot",recoBeamSpotHandle);
+  evt.getByToken(beamSpotToken_,recoBeamSpotHandle);
   theBeamSpot_ = *recoBeamSpotHandle;
 
-  evt.getByLabel(edm::InputTag("MeasurementTrackerEvent"), theTrackerData_);
+  evt.getByToken(measurementTrkToken_, theTrackerData_);
 
 }
 

--- a/RecoEgamma/EgammaPhotonAlgos/src/InOutConversionSeedFinder.cc
+++ b/RecoEgamma/EgammaPhotonAlgos/src/InOutConversionSeedFinder.cc
@@ -18,8 +18,8 @@
 //
 //
 
-InOutConversionSeedFinder::InOutConversionSeedFinder( const edm::ParameterSet& conf ):
-  ConversionSeedFinder( conf ), conf_(conf)  
+InOutConversionSeedFinder::InOutConversionSeedFinder( const edm::ParameterSet& conf,edm::ConsumesCollector && iC ):
+  ConversionSeedFinder( conf,iC ), conf_(conf)  
 {
   
   

--- a/RecoEgamma/EgammaPhotonAlgos/src/OutInConversionSeedFinder.cc
+++ b/RecoEgamma/EgammaPhotonAlgos/src/OutInConversionSeedFinder.cc
@@ -34,7 +34,7 @@ namespace {
 }
 
 
-OutInConversionSeedFinder::OutInConversionSeedFinder( const edm::ParameterSet& conf ): ConversionSeedFinder( conf ), conf_(conf)  
+OutInConversionSeedFinder::OutInConversionSeedFinder( const edm::ParameterSet& conf,edm::ConsumesCollector && iC): ConversionSeedFinder( conf,iC ), conf_(conf)  
 {
 
   LogDebug("OutInConversionSeedFinder") << "OutInConversionSeedFinder CTOR " << "\n";      

--- a/RecoEgamma/EgammaPhotonProducers/interface/ConversionTrackCandidateProducer.h
+++ b/RecoEgamma/EgammaPhotonProducers/interface/ConversionTrackCandidateProducer.h
@@ -66,6 +66,7 @@ class ConversionTrackCandidateProducer : public edm::EDProducer {
   edm::EDGetTokenT<CaloTowerCollection> hcalTowers_;
   edm::EDGetTokenT<EcalRecHitCollection> barrelecalCollection_;
   edm::EDGetTokenT<EcalRecHitCollection> endcapecalCollection_;
+  edm::EDGetTokenT<MeasurementTrackerEvent> measurementTrkEvtToken_;
  
   double hOverEConeSize_;
   double maxHOverE_;

--- a/RecoEgamma/EgammaPhotonProducers/interface/TrackProducerWithSCAssociation.h
+++ b/RecoEgamma/EgammaPhotonProducers/interface/TrackProducerWithSCAssociation.h
@@ -33,7 +33,8 @@ private:
   std::string trackCSuperClusterAssociationCollection_;
   std::string trackSuperClusterAssociationCollection_;
   edm::EDGetTokenT<reco::TrackCandidateCaloClusterPtrAssociation> assoc_token;
-  edm::OrphanHandle<reco::TrackCollection> rTracks_;
+  edm::OrphanHandle<reco::TrackCollection> rTracks_; 
+  edm::EDGetTokenT<MeasurementTrackerEvent> measurementTrkToken_;
   bool myTrajectoryInEvent_;
   bool validTrackCandidateSCAssociationInput_;
 

--- a/RecoEgamma/EgammaPhotonProducers/src/ConversionTrackCandidateProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/ConversionTrackCandidateProducer.cc
@@ -54,9 +54,9 @@ namespace {
 
 ConversionTrackCandidateProducer::ConversionTrackCandidateProducer(const edm::ParameterSet& config) : 
   theTrajectoryBuilder_(createBaseCkfTrajectoryBuilder(config.getParameter<edm::ParameterSet>("TrajectoryBuilderPSet"), consumesCollector())),
-  theOutInSeedFinder_(new OutInConversionSeedFinder(config)),
+  theOutInSeedFinder_(new OutInConversionSeedFinder(config,consumesCollector())),
   theOutInTrackFinder_(new OutInConversionTrackFinder(config, theTrajectoryBuilder_.get())),
-  theInOutSeedFinder_(new InOutConversionSeedFinder(config)),
+  theInOutSeedFinder_(new InOutConversionSeedFinder(config,consumesCollector())),
   theInOutTrackFinder_(new InOutConversionTrackFinder(config, theTrajectoryBuilder_.get()))
 {  
   //std::cout << "ConversionTrackCandidateProducer CTOR " << "\n";
@@ -86,9 +86,10 @@ ConversionTrackCandidateProducer::ConversionTrackCandidateProducer(const edm::Pa
     consumes<EcalRecHitCollection>(config.getParameter<edm::InputTag>("barrelEcalRecHitCollection"));
   endcapecalCollection_ = 
     consumes<EcalRecHitCollection>(config.getParameter<edm::InputTag>("endcapEcalRecHitCollection"));
-  
   hcalTowers_        = 
     consumes<CaloTowerCollection>(config.getParameter<edm::InputTag>("hcalTowers"));
+  measurementTrkEvtToken_ = 
+    consumes<MeasurementTrackerEvent>(edm::InputTag("MeasurementTrackerEvent"));
   hOverEConeSize_    = config.getParameter<double>("hOverEConeSize");
   maxHOverE_         = config.getParameter<double>("maxHOverE");
   minSCEt_           = config.getParameter<double>("minSCEt");
@@ -137,7 +138,7 @@ ConversionTrackCandidateProducer::ConversionTrackCandidateProducer(const edm::Pa
 
 }
 
-ConversionTrackCandidateProducer::~ConversionTrackCandidateProducer() {}
+ConversionTrackCandidateProducer::~ConversionTrackCandidateProducer(){}
 
 void  ConversionTrackCandidateProducer::setEventSetup (const edm::EventSetup & theEventSetup) {
   theOutInSeedFinder_->setEventSetup(theEventSetup);
@@ -168,7 +169,7 @@ void ConversionTrackCandidateProducer::produce(edm::Event& theEvent, const edm::
   
   // get the trajectory builder and initialize it with the data
   edm::Handle<MeasurementTrackerEvent> data;
-  theEvent.getByLabel(edm::InputTag("MeasurementTrackerEvent"), data);
+  theEvent.getByToken( measurementTrkEvtToken_, data);
   theTrajectoryBuilder_->setEvent(theEvent, theEventSetup, &*data);
 
 

--- a/RecoEgamma/EgammaPhotonProducers/src/TrackProducerWithSCAssociation.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/TrackProducerWithSCAssociation.cc
@@ -43,6 +43,9 @@ TrackProducerWithSCAssociation::TrackProducerWithSCAssociation(const edm::Parame
     consumes<reco::TrackCandidateCaloClusterPtrAssociation>(
 		    edm::InputTag(conversionTrackCandidateProducer_,
 				  trackCSuperClusterAssociationCollection_));
+  measurementTrkToken_=
+    consumes<MeasurementTrackerEvent>(edm::InputTag("MeasurementTrackerEvent")); //hardcoded because the original was and no time to fix (sigh)
+  
  
   //register your products
   produces<reco::TrackCollection>().setBranchAlias( alias_ + "Tracks" );
@@ -331,7 +334,7 @@ TrackingRecHitRefProd rHits = evt.getRefBeforePut<TrackingRecHitCollection>();
     if (theSchool.isValid())
       {
         edm::Handle<MeasurementTrackerEvent> mte;
-        evt.getByLabel(edm::InputTag("MeasurementTrackerEvent"), mte);
+        evt.getByToken(measurementTrkToken_, mte);
 	setSecondHitPattern(theTraj,track,thePropagator,&*mte);
       }
     //==============================================================


### PR DESCRIPTION
Missed a module for the E/gamma consumes migration. Builds and passes runTheMatrix.py -s in CMSSW_7_1_X_2014-05-05-1400 IB. 
