### PR TITLE
Changing the vertex matching algorithm for taus

### DIFF
--- a/RecoTauTag/RecoTau/interface/RecoTauVertexAssociator.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauVertexAssociator.h
@@ -75,7 +75,7 @@ class RecoTauVertexAssociator {
     //PJ adding quality cuts
     RecoTauQualityCuts* qcuts_;
     bool recoverLeadingTrk_;
-    enum { kLeadTrack, kLeadPFCand };
+    enum { kLeadTrack, kLeadPFCand, kFirstTrack };
     int leadingTrkOrPFCandOption_;
     edm::EDGetTokenT<reco::VertexCollection> vxToken_;
     // containers for holding vertices associated to jets

--- a/RecoTauTag/RecoTau/interface/RecoTauVertexAssociator.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauVertexAssociator.h
@@ -26,6 +26,9 @@
 
 #include "DataFormats/Common/interface/AssociationMap.h"
 #include "DataFormats/JetReco/interface/PFJetCollection.h"
+
+#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
+
 #include <map>
 
 // Forward declarations
@@ -51,33 +54,34 @@ class RecoTauVertexAssociator {
     };
 
     RecoTauVertexAssociator (const edm::ParameterSet& pset,  edm::ConsumesCollector&& iC);
-    virtual ~RecoTauVertexAssociator (){}
-    /// Get the primary vertex associated to a given jet. Returns a null Ref if
-    /// no vertex is found.
-    reco::VertexRef associatedVertex(const PFJet& tau) const;
-    reco::VertexRef associatedVertex(const PFJetRef jet) const;
+    virtual ~RecoTauVertexAssociator(); 
+    /// Get the primary vertex associated to a given jet. 
+    /// Returns a null Ref if no vertex is found.
+    reco::VertexRef associatedVertex(const PFJet& jet) const;
     /// Convenience function to get the PV associated to the jet that
     /// seeded this tau.
     reco::VertexRef associatedVertex(const PFTau& tau) const;
     /// Load the vertices from the event.
     void setEvent(const edm::Event& evt);
     reco::TrackBaseRef getLeadTrack(const PFJet& jet) const;
-    //    std::map<const PFJet*,reco::VertexRef> Employees;
-    // containers for holding vertices associated to jets
-    std::map<const reco::PFJet*,reco::VertexRef> *JetToVertexAssociation;
-    int  myEventNumber;
-
 
   private:
-    std::vector<reco::VertexRef> vertices_;
     edm::InputTag vertexTag_;
+    bool vxTrkFiltering_;
+    StringCutObjectSelector<reco::Vertex>* vertexSelector_;
+    std::vector<reco::VertexRef> selectedVertices_;
+    std::string algorithm_;
     Algorithm algo_;
     //PJ adding quality cuts
-    RecoTauQualityCuts qcuts_;
-    bool recoverLeadingTrk;
-
-    edm::EDGetTokenT<reco::VertexCollection> vx_token;
-
+    RecoTauQualityCuts* qcuts_;
+    bool recoverLeadingTrk_;
+    enum { kLeadTrack, kLeadPFCand };
+    int leadingTrkOrPFCandOption_;
+    edm::EDGetTokenT<reco::VertexCollection> vxToken_;
+    // containers for holding vertices associated to jets
+    std::map<const reco::PFJet*, reco::VertexRef>* jetToVertexAssociation_;
+    int lastEvent_;    
+    int verbosity_;
 };
 
 } /* tau */ } /* reco */

--- a/RecoTauTag/RecoTau/python/PFRecoTauQualityCuts_cfi.py
+++ b/RecoTauTag/RecoTau/python/PFRecoTauQualityCuts_cfi.py
@@ -44,11 +44,12 @@ PFTauQualityCuts = cms.PSet(
             ),
     # The central definition of primary vertex source.
     primaryVertexSrc = cms.InputTag("offlinePrimaryVertices"),
-    # Possible algorithms are: highestPtInEvent, closestInDeltaZ, combined
-    pvFindingAlgo = cms.string("highestWeightForLeadTrack"),
+    # Possible algorithms are: 'highestPtInEvent', 'closestInDeltaZ', 'highestWeightForLeadTrack' and 'combined'
+    pvFindingAlgo = cms.string("closestInDeltaZ"),
     vertexTrackFiltering = cms.bool(False),
     recoverLeadingTrk = cms.bool(False),
     # produce histograms when running in debug mode
     # makeHisto = cms.bool(False)
-
+    leadingTrkOrPFCandOption = cms.string("leadPFCand")
+    ##leadingTrkOrPFCandOption = cms.string("leadTrack")
 )

--- a/RecoTauTag/RecoTau/python/PFRecoTauQualityCuts_cfi.py
+++ b/RecoTauTag/RecoTau/python/PFRecoTauQualityCuts_cfi.py
@@ -52,4 +52,5 @@ PFTauQualityCuts = cms.PSet(
     # makeHisto = cms.bool(False)
     leadingTrkOrPFCandOption = cms.string("leadPFCand")
     ##leadingTrkOrPFCandOption = cms.string("leadTrack")
+    ##leadingTrkOrPFCandOption = cms.string("firstTrack") #default behaviour until 710 (first track in the collection)
 )

--- a/RecoTauTag/RecoTau/src/RecoTauVertexAssociator.cc
+++ b/RecoTauTag/RecoTau/src/RecoTauVertexAssociator.cc
@@ -11,231 +11,336 @@
 #include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 
-
 namespace reco { namespace tau {
-
-  bool vxTrkFiltering;
 
 // Get the highest pt track in a jet.
 // Get the KF track if it exists.  Otherwise, see if it has a GSF track.
-  reco::TrackBaseRef RecoTauVertexAssociator::getLeadTrack(const PFJet& jet) const{
-  std::vector<PFCandidatePtr> allTracks = pfChargedCands(jet, true);
-  std::vector<PFCandidatePtr> tracks;
-  //PJ filtering of tracks 
-  if (!allTracks.size()){
-    LogDebug("VxTrkAssocInfo") << " No tracks at this jet! Returning empty reference.";
+reco::TrackBaseRef RecoTauVertexAssociator::getLeadTrack(const PFJet& jet) const
+{
+  std::vector<PFCandidatePtr> chargedPFCands = pfChargedCands(jet, true);
+  if ( verbosity_ >= 1 ) {
+    std::cout << "<RecoTauVertexAssociator::getLeadTrack>:" << std::endl;
+    std::cout << " jet: Pt = " << jet.pt() << ", eta = " << jet.eta() << ", phi = " << jet.phi() << std::endl;
+    std::cout << " num. chargedPFCands = " << chargedPFCands.size() << std::endl;
+    std::cout << " vxTrkFiltering = " << vxTrkFiltering_ << std::endl;
+  }
+
+  if ( chargedPFCands.size() == 0 ) {
     return reco::TrackBaseRef();
   }
-  if(vxTrkFiltering) tracks = qcuts_.filterCandRefs(allTracks);
-  else{ 
-    tracks = allTracks;
-    LogDebug("VxTrkAssocInfo") << " No quality cuts applied. All tracks passing.";
-  }
-  PFCandidatePtr cand;
-  if (!tracks.size()){
-    if(!recoverLeadingTrk){
-      LogDebug("VxTrkAssocInfo") << " All " << allTracks.size() << " tracks rejected!";
-      return reco::TrackBaseRef();
-    }else{
-      cand = allTracks[0];
-      LogDebug("VxTrkAssocInfo") << " All " << allTracks.size() << " tracks rejected but leading track was recovered!";
-    }
-  }else cand = tracks[0];
 
-  if (cand->trackRef().isNonnull())
-    return reco::TrackBaseRef(cand->trackRef());
-  else if (cand->gsfTrackRef().isNonnull()) {
-    return reco::TrackBaseRef(cand->gsfTrackRef());
+  std::vector<PFCandidatePtr> selectedPFCands;
+  if ( vxTrkFiltering_ ) {
+    selectedPFCands = qcuts_->filterCandRefs(chargedPFCands);
+  } else { 
+    selectedPFCands = chargedPFCands;
   }
+  if ( verbosity_ >= 1 ) {
+    std::cout << " num. selectedPFCands = " << selectedPFCands.size() << std::endl;
+  }
+
+  PFCandidatePtr leadPFCand;
+  if ( selectedPFCands.size() >= 1 ) {
+    double leadTrackPt = 0.;
+    for ( std::vector<PFCandidatePtr>::const_iterator pfCand = selectedPFCands.begin();
+	  pfCand != selectedPFCands.end(); ++pfCand ) {
+      const reco::Track* track = 0;
+      if ( (*pfCand)->trackRef().isNonnull() ) track = (*pfCand)->trackRef().get();
+      else if ( (*pfCand)->gsfTrackRef().isNonnull() ) track = (*pfCand)->gsfTrackRef().get();
+      if ( !track ) continue;
+      double trackPt = 0.;
+      if ( leadingTrkOrPFCandOption_ == kLeadTrack ) {
+	//double trackPt = track->pt();
+	trackPt = track->pt() - 2.*track->ptError();
+      } else if ( leadingTrkOrPFCandOption_ == kLeadPFCand ) {
+	trackPt = (*pfCand)->pt();
+      } else assert(0);
+      if ( trackPt > leadTrackPt ) {
+	leadPFCand = (*pfCand);
+	leadTrackPt = trackPt;
+      }
+    }
+  }
+  if ( leadPFCand.isNull() ) {
+    if ( recoverLeadingTrk_ ) {
+      leadPFCand = chargedPFCands[0];
+    } else {
+      return reco::TrackBaseRef();
+    } 
+  }
+  if ( verbosity_ >= 1 ) {
+    std::cout << "leadPFCand: Pt = " << leadPFCand->pt() << ", eta = " << leadPFCand->eta() << ", phi = " << leadPFCand->phi() << std::endl;
+  }
+  
+  if ( leadPFCand->trackRef().isNonnull() ) {
+    return reco::TrackBaseRef(leadPFCand->trackRef());
+  } else if ( leadPFCand->gsfTrackRef().isNonnull() ) {
+    return reco::TrackBaseRef(leadPFCand->gsfTrackRef());
+  } 
   return reco::TrackBaseRef();
-  }
-  namespace {
-// Define functors which extract the relevant information from a collection of
-// vertices.
-class DZtoTrack : public std::unary_function<double, reco::VertexRef> {
-  public:
-    DZtoTrack(const reco::TrackBaseRef& trk):trk_(trk){}
-    double operator()(const reco::VertexRef& vtx) const {
-      if (!trk_ || !vtx) {
+}
+
+namespace {
+  // Define functors which extract the relevant information from a collection of
+  // vertices.
+  class DZtoTrack : public std::unary_function<double, reco::VertexRef> 
+  {
+   public:
+    DZtoTrack(const reco::TrackBaseRef& trk) 
+      : trk_(trk) 
+    {}
+    double operator()(const reco::VertexRef& vtx) const 
+    {
+      if ( !trk_ || !vtx ) {
         return std::numeric_limits<double>::infinity();
       }
       return std::abs(trk_->dz(vtx->position()));
     }
-  private:
+   private:
     const reco::TrackBaseRef trk_;
-};
-
-class TrackWeightInVertex : public std::unary_function<double, reco::VertexRef>
-{
-  public:
-    TrackWeightInVertex(const reco::TrackBaseRef& trk):trk_(trk){}
-    double operator()(const reco::VertexRef& vtx) const {
-      if (!trk_ || !vtx) {
+  };
+  
+  class TrackWeightInVertex : public std::unary_function<double, reco::VertexRef>
+  {
+   public:
+    TrackWeightInVertex(const reco::TrackBaseRef& trk)
+      : trk_(trk)
+    {}
+    double operator()(const reco::VertexRef& vtx) const 
+    {
+      if ( !trk_ || !vtx ) {
         return 0.0;
       }
       return vtx->trackWeight(trk_);
     }
-  private:
+   private:
     const reco::TrackBaseRef trk_;
-};
+  };
+}
 
-  }
-
-RecoTauVertexAssociator::RecoTauVertexAssociator(
-						 const edm::ParameterSet& pset, edm::ConsumesCollector && iC):  qcuts_(pset.exists("vxAssocQualityCuts") ? pset.getParameterSet("vxAssocQualityCuts") : pset.getParameterSet("signalQualityCuts"))
+RecoTauVertexAssociator::RecoTauVertexAssociator(const edm::ParameterSet& pset, edm::ConsumesCollector && iC)
+  : vertexSelector_(0),
+    qcuts_(0),
+    jetToVertexAssociation_(0),
+    lastEvent_(-1)
 {
-  //   qcuts_ = pset.exists("vxAssocQualityCuts") ? pset.getParameterSet("vxAssocQualityCuts") : pset.getParameterSet("signalQualityCuts");
+  //std::cout << "<RecoTauVertexAssociator::RecoTauVertexAssociator>:" << std::endl;
+
   vertexTag_ = edm::InputTag("offlinePrimaryVertices", "");
-  std::string algorithm = "highestPtInEvent";
+  algorithm_ = "highestPtInEvent";
   // Sanity check, will remove once HLT module configs are updated.
-  if (!pset.exists("primaryVertexSrc") || !pset.exists("pvFindingAlgo")) {
+  if ( !pset.exists("primaryVertexSrc") || !pset.exists("pvFindingAlgo") ) {
     edm::LogWarning("NoVertexFindingMethodSpecified")
-      << "The PSet passed to the RecoTauVertexAssociator was"
-      << " incorrectly configured. The vertex will be taken as the "
-      << "highest Pt vertex from the offlinePrimaryVertices collection."
+      << "The PSet passed to the RecoTauVertexAssociator was incorrectly configured."
+      << " The vertex will be taken as the highest Pt vertex from the 'offlinePrimaryVertices' collection."
       << std::endl;
   } else {
     vertexTag_ = pset.getParameter<edm::InputTag>("primaryVertexSrc");
-    algorithm = pset.getParameter<std::string>("pvFindingAlgo");
+    algorithm_ = pset.getParameter<std::string>("pvFindingAlgo");
   }
-  vxTrkFiltering = false;
-  if(!pset.exists("vertexTrackFiltering") && pset.exists("vxAssocQualityCuts")){
-       edm::LogWarning("NoVertexTrackFilteringSpecified")
-	 << "The PSet passed to the RecoTauVertexAssociator was"
-	 << " incorrectly configured. Please define vertexTrackFiltering in config file." 
-	 << " No filtering of tracks to vertices will be applied"
-	 << std::endl;
-     }else{
-    vxTrkFiltering = pset.exists("vertexTrackFiltering") ? pset.getParameter<bool>("vertexTrackFiltering") : false;
-     }
+    
+  if ( pset.exists("vxAssocQualityCuts") ) {
+    //std::cout << " reading 'vxAssocQualityCuts'" << std::endl;
+    qcuts_ = new RecoTauQualityCuts(pset.getParameterSet("vxAssocQualityCuts"));
+  } else {
+    //std::cout << " reading 'signalQualityCuts'" << std::endl;
+    qcuts_ = new RecoTauQualityCuts(pset.getParameterSet("signalQualityCuts"));
+  }
+  assert(qcuts_);
+
+  vxTrkFiltering_ = false;
+  if ( !pset.exists("vertexTrackFiltering") && pset.exists("vxAssocQualityCuts") ) {
+    edm::LogWarning("NoVertexTrackFilteringSpecified")
+      << "The PSet passed to the RecoTauVertexAssociator was incorrectly configured." 
+      << " Please define vertexTrackFiltering in config file." 
+      << " No filtering of tracks to vertices will be applied."
+      << std::endl;
+  } else {
+    vxTrkFiltering_ = pset.exists("vertexTrackFiltering") ? 
+      pset.getParameter<bool>("vertexTrackFiltering") : false;
+  }
+  if ( pset.exists("vertexSelection") ) {
+    std::string vertexSelection = pset.getParameter<std::string>("vertexSelection");
+    if ( vertexSelection != "" ) {
+      vertexSelector_ = new StringCutObjectSelector<reco::Vertex>(vertexSelection);
+    }
+  }
   
-  LogDebug("TauVxAssociatorInfo") << " ----> Using " << algorithm << " algorithm to select vertex.";
-  if (algorithm == "highestPtInEvent") {
+  if ( algorithm_ == "highestPtInEvent" ) {
     algo_ = kHighestPtInEvent;
-  } else if (algorithm == "closestInDeltaZ") {
+  } else if ( algorithm_ == "closestInDeltaZ" ) {
     algo_ = kClosestDeltaZ;
-  } else if (algorithm == "highestWeightForLeadTrack") {
+  } else if ( algorithm_ == "highestWeightForLeadTrack" ) {
     algo_ = kHighestWeigtForLeadTrack;
-  } else if (algorithm == "combined"){
+  } else if ( algorithm_ == "combined" ) {
     algo_ = kCombined;
   } else {
     throw cms::Exception("BadVertexAssociatorConfig")
-      << "The algorithm specified for tau-vertex association "
-      << algorithm << " is invalid. Options are: "  << std::endl
-      <<  "highestPtInEvent, "
-      <<  "closestInDeltaZ, "
-      <<  "highestWeightForLeadTrack, "
-      <<  " or combined." << std::endl;
+      << "Invalid Configuration parameter 'algorithm' " << algorithm_ << "." 
+      << " Valid options are: 'highestPtInEvent', 'closestInDeltaZ', 'highestWeightForLeadTrack' and 'combined'.\n";
   }
-  vx_token = iC.consumes<reco::VertexCollection>(vertexTag_);
-  recoverLeadingTrk = pset.exists("recoverLeadingTrk") ? pset.getParameter<bool>("recoverLeadingTrk") : false;
-  // containers for holding vertices associated to jets
-  JetToVertexAssociation=0;
-  myEventNumber = -999;
 
- }
+  vxToken_ = iC.consumes<reco::VertexCollection>(vertexTag_);
 
+  recoverLeadingTrk_ = pset.exists("recoverLeadingTrk") ? 
+    pset.getParameter<bool>("recoverLeadingTrk") : false;
 
-void RecoTauVertexAssociator::setEvent(const edm::Event& evt) {
-  edm::Handle<reco::VertexCollection> verticesH_;
-  evt.getByToken(vx_token, verticesH_);
-  vertices_.clear();
-  vertices_.reserve(verticesH_->size());
-  for(size_t i = 0; i < verticesH_->size(); ++i) {
-    vertices_.push_back(reco::VertexRef(verticesH_, i));
+  std::string leadingTrkOrPFCandOption_string = pset.getParameter<std::string>("leadingTrkOrPFCandOption");
+  if      ( leadingTrkOrPFCandOption_string == "leadTrack"  ) leadingTrkOrPFCandOption_ = kLeadTrack;
+  else if ( leadingTrkOrPFCandOption_string == "leadPFCand" ) leadingTrkOrPFCandOption_ = kLeadPFCand;
+  else throw cms::Exception("BadVertexAssociatorConfig")
+    << "Invalid Configuration parameter 'leadingTrkOrPFCandOption' " << leadingTrkOrPFCandOption_string << "." 
+    << " Valid options are: 'leadTrack', 'leadPFCand'.\n";
+  
+  verbosity_ = ( pset.exists("verbosity") ) ?
+    pset.getParameter<int>("verbosity") : 0;
+}
+
+RecoTauVertexAssociator::~RecoTauVertexAssociator()
+{ 
+  delete vertexSelector_; 
+  delete qcuts_;
+}
+
+void RecoTauVertexAssociator::setEvent(const edm::Event& evt) 
+{
+  edm::Handle<reco::VertexCollection> vertices;
+  evt.getByToken(vxToken_, vertices);
+  selectedVertices_.clear();
+  selectedVertices_.reserve(vertices->size());
+  for ( size_t idxVertex = 0; idxVertex < vertices->size(); ++idxVertex ) {
+    reco::VertexRef vertex(vertices, idxVertex);
+    if ( vertexSelector_ && !(*vertexSelector_)(*vertex) ) continue;
+    selectedVertices_.push_back(vertex);
   }
-  if(vertices_.size()>0 ) qcuts_.setPV(vertices_[0]);
+  if ( selectedVertices_.size() > 0 ) {
+    qcuts_->setPV(selectedVertices_[0]);
+  }
   int currentEvent = evt.id().event();
-  if(myEventNumber == -999 || myEventNumber!=currentEvent)
-    {
-      if(myEventNumber==-999) JetToVertexAssociation= new std::map<const reco::PFJet*,reco::VertexRef>;
-      else JetToVertexAssociation->clear();
-      myEventNumber = currentEvent;
-    }
+  if ( currentEvent != lastEvent_ || !jetToVertexAssociation_ ) {
+    if ( !jetToVertexAssociation_ ) jetToVertexAssociation_ = new std::map<const reco::PFJet*, reco::VertexRef>;
+    else jetToVertexAssociation_->clear();
+    lastEvent_ = currentEvent;
+  }
 }
 
 reco::VertexRef
-RecoTauVertexAssociator::associatedVertex(const PFTau& tau) const {
+RecoTauVertexAssociator::associatedVertex(const PFTau& tau) const 
+{
   reco::PFJetRef jetRef = tau.jetRef();
   // FIXME workaround for HLT which does not use updated data format
-  if (jetRef.isNull())
-    jetRef = tau.pfTauTagInfoRef()->pfjetRef();
+  if ( jetRef.isNull() ) jetRef = tau.pfTauTagInfoRef()->pfjetRef();
   return associatedVertex(*jetRef);
 }
 
 reco::VertexRef
-RecoTauVertexAssociator::associatedVertex(const PFJet& jet) const {
-  reco::VertexRef output = vertices_.size() ? vertices_[0] : reco::VertexRef();
-  PFJet const* my_jet_ptr = &jet;
-  LogDebug("VxTrkAssocInfo") << "There are " << vertices_.size() << " vertices in this event. The jet is " << jet;
-  LogTrace("VxTrkAssocInfo") << "The lenght of assoc map is "<< JetToVertexAssociation->size();
+RecoTauVertexAssociator::associatedVertex(const PFJet& jet) const 
+{
+  if ( verbosity_ >= 1 ) {
+    std::cout << "<RecoTauVertexAssociator::associatedVertex>:" << std::endl;
+    std::cout << " jet: Pt = " << jet.pt() << ", eta = " << jet.eta() << ", phi = " << jet.phi() << std::endl;
+    std::cout << " num. Vertices = " << selectedVertices_.size() << std::endl;
+    std::cout << " size(jetToVertexAssociation) = " << jetToVertexAssociation_->size() << std::endl;
+    std::cout << " vertexTag = " << vertexTag_ << std::endl;
+    std::cout << " algorithm = " << algorithm_ << std::endl;
+    std::cout << " recoverLeadingTrk = " << recoverLeadingTrk_ << std::endl;
+  }
 
+  reco::VertexRef jetVertex = ( selectedVertices_.size() > 0 ) ? selectedVertices_[0] : reco::VertexRef();
+  const PFJet* jetPtr = &jet;
 
-  std::map<const reco::PFJet*,reco::VertexRef>::iterator it = JetToVertexAssociation->find(my_jet_ptr);
-   if(it!=JetToVertexAssociation->end())
-     {
-       LogTrace("VxTrkAssocInfo") << "I have seen this jet! Returning pointer to stored value.";
-       return it->second;
-     }
-   // Vx counters
-   reco::TrackBaseRef leadTrack;
-  if (algo_ == kHighestPtInEvent) {
-    return output;
-  } else if (algo_ == kClosestDeltaZ) {
-    leadTrack = getLeadTrack(jet);
-    if(!leadTrack){
-      LogTrace("VxTrkAssocInfo") << "No track to associate to! Returning vx no. 0.";
-      JetToVertexAssociation->insert(std::pair<const PFJet*, reco::VertexRef>(my_jet_ptr,output));
-      return output;
-    }
-    double closestDistance = std::numeric_limits<double>::infinity();
-    DZtoTrack dzComputer(leadTrack);
-    // Find the vertex that has the lowest DZ to the lead track
-    BOOST_FOREACH(const reco::VertexRef& vtx, vertices_) {
-      double dz = dzComputer(vtx);
-      if (dz < closestDistance) {
-        closestDistance = dz;
-        output = vtx;
-
+  // check if jet-vertex association has been determined for this jet before
+  std::map<const reco::PFJet*, reco::VertexRef>::iterator vertexPtr = jetToVertexAssociation_->find(jetPtr);
+  if ( vertexPtr != jetToVertexAssociation_->end() ) {
+    jetVertex = vertexPtr->second;
+  } else {
+    // no jet-vertex association exists for this jet yet, compute it!
+    if ( algo_ == kHighestPtInEvent ) {
+      if ( selectedVertices_.size() > 0 ) jetVertex = selectedVertices_[0];
+    } else if ( algo_ == kClosestDeltaZ ) {
+      // find "leading" (highest Pt) track in jet
+      reco::TrackBaseRef leadTrack = getLeadTrack(jet);
+      if ( verbosity_ ) {
+	if ( leadTrack.isNonnull() ) std::cout << "leadTrack: Pt = " << leadTrack->pt() << ", eta = " << leadTrack->eta() << ", phi = " << leadTrack->phi() << std::endl;
+	else std::cout << "leadTrack: N/A" << std::endl;
       }
-    }
-  } else if (algo_ == kHighestWeigtForLeadTrack || algo_ == kCombined) {
-    leadTrack = getLeadTrack(jet);
-    if(!leadTrack){
-      LogTrace("VxTrkAssocInfo") << "No track to associate to! Returning vx no. 0.";
-      JetToVertexAssociation->insert(std::pair<const PFJet*, reco::VertexRef>(my_jet_ptr,output));
-      return output;
-    }
-    double largestWeight = 0.;
-    // Find the vertex that gives the lead track the highest weight.
-    TrackWeightInVertex weightComputer(leadTrack);
-    BOOST_FOREACH(const reco::VertexRef& vtx, vertices_) {
-      double weight = weightComputer(vtx);
-     if (weight > largestWeight) {
-        largestWeight = weight;
-        output = vtx;
+      if ( leadTrack.isNonnull() ) {
+	double closestDistance = 1.e+6;
+	DZtoTrack dzComputer(leadTrack);
+	// Find the vertex that has the lowest dZ to the leading track
+	int idxVertex = 0;
+	for ( std::vector<reco::VertexRef>::const_iterator selectedVertex = selectedVertices_.begin();
+	      selectedVertex != selectedVertices_.end(); ++selectedVertex ) {
+	  double dZ = dzComputer(*selectedVertex);
+	  if ( verbosity_ ) {
+	    std::cout << "vertex #" << idxVertex << ": x = " << (*selectedVertex)->position().x() << ", y = " << (*selectedVertex)->position().y() << ", z = " << (*selectedVertex)->position().z() 
+		      << " --> dZ = " << dZ << std::endl;
+	  }
+	  if ( dZ < closestDistance ) {
+	    jetVertex = (*selectedVertex);
+	    closestDistance = dZ;
+	  }
+	  ++idxVertex;
+	}
       }
-    }
-    // the weight was never larger than zero
-    if(algo_==kCombined && largestWeight < 1e-7){
-      LogTrace("VxTrkAssocInfo") << " No vertex had positive weight! Trying dZ instead... ";
-      DZtoTrack dzComputer(leadTrack);
-      double closestDistance = std::numeric_limits<double>::infinity();
-      BOOST_FOREACH(const reco::VertexRef& vtx, vertices_) {
-	double dz_i = dzComputer(vtx);
-	if (dz_i < closestDistance) {
-	  closestDistance = dz_i;
-	  output = vtx;
+    } else if ( algo_ == kHighestWeigtForLeadTrack || algo_ == kCombined ) {
+      reco::TrackBaseRef leadTrack = getLeadTrack(jet);
+      if ( verbosity_ ) {
+	if ( leadTrack.isNonnull() ) std::cout << "leadTrack: Pt = " << leadTrack->pt() << ", eta = " << leadTrack->eta() << ", phi = " << leadTrack->phi() << std::endl;
+	else std::cout << "leadTrack: N/A" << std::endl;
+      }
+      if ( leadTrack.isNonnull() ) {
+	double largestWeight = -1.;
+	// Find the vertex that has the highest association probability to the leading track
+	TrackWeightInVertex weightComputer(leadTrack);
+	int idxVertex = 0;
+	for ( std::vector<reco::VertexRef>::const_iterator selectedVertex = selectedVertices_.begin();
+	      selectedVertex != selectedVertices_.end(); ++selectedVertex ) {
+	  double weight = weightComputer(*selectedVertex);
+	  if ( verbosity_ ) {
+	    std::cout << "vertex #" << idxVertex << ": x = " << (*selectedVertex)->position().x() << ", y = " << (*selectedVertex)->position().y() << ", z = " << (*selectedVertex)->position().z() 
+		      << " --> weight = " << weight << std::endl;
+	  }
+	  if ( weight > largestWeight ) {
+	    jetVertex = (*selectedVertex);
+	    largestWeight = weight;
+	  }
+	  ++idxVertex;
+	}
+	// the weight was never larger than zero
+	if ( algo_ == kCombined && largestWeight < 1.e-7 ) {
+	  if ( verbosity_ ) {
+	    std::cout << "No vertex had positive weight! Trying dZ instead... " << std::endl;
+	  }
+	  double closestDistance = 1.e+6;
+	  DZtoTrack dzComputer(leadTrack);
+	  // Find the vertex that has the lowest dZ to the leading track
+	  int idxVertex = 0;
+	  for ( std::vector<reco::VertexRef>::const_iterator selectedVertex = selectedVertices_.begin();
+		selectedVertex != selectedVertices_.end(); ++selectedVertex ) {
+	    double dZ = dzComputer(*selectedVertex);
+	    if ( verbosity_ ) {
+	      std::cout << "vertex #" << idxVertex << ": x = " << (*selectedVertex)->position().x() << ", y = " << (*selectedVertex)->position().y() << ", z = " << (*selectedVertex)->position().z() 
+			<< " --> dZ = " << dZ << std::endl;
+	    }
+	    if ( dZ < closestDistance ) {
+	      jetVertex = (*selectedVertex);
+	      closestDistance = dZ;
+	    }
+	    ++idxVertex;
+	  }
 	}
       }
     }
+    
+    jetToVertexAssociation_->insert(std::pair<const PFJet*, reco::VertexRef>(jetPtr, jetVertex));
   }
 
-  JetToVertexAssociation->insert(std::pair<const PFJet*, reco::VertexRef>(my_jet_ptr,output));
-
-  return output;
+  if ( verbosity_ >= 1 ) {
+    std::cout << "--> returning vertex: x = " << jetVertex->position().x() << ", y = " << jetVertex->position().y() << ", z = " << jetVertex->position().z() << std::endl;
+  }
+  
+  return jetVertex;
 }
-
-
 
 }}

--- a/RecoTauTag/RecoTau/src/RecoTauVertexAssociator.cc
+++ b/RecoTauTag/RecoTau/src/RecoTauVertexAssociator.cc
@@ -205,6 +205,7 @@ RecoTauVertexAssociator::~RecoTauVertexAssociator()
 { 
   delete vertexSelector_; 
   delete qcuts_;
+  delete jetToVertexAssociation_;
 }
 
 void RecoTauVertexAssociator::setEvent(const edm::Event& evt) 

--- a/RecoTauTag/RecoTau/src/RecoTauVertexAssociator.cc
+++ b/RecoTauTag/RecoTau/src/RecoTauVertexAssociator.cc
@@ -42,22 +42,26 @@ reco::TrackBaseRef RecoTauVertexAssociator::getLeadTrack(const PFJet& jet) const
   PFCandidatePtr leadPFCand;
   if ( selectedPFCands.size() >= 1 ) {
     double leadTrackPt = 0.;
-    for ( std::vector<PFCandidatePtr>::const_iterator pfCand = selectedPFCands.begin();
-	  pfCand != selectedPFCands.end(); ++pfCand ) {
-      const reco::Track* track = 0;
-      if ( (*pfCand)->trackRef().isNonnull() ) track = (*pfCand)->trackRef().get();
-      else if ( (*pfCand)->gsfTrackRef().isNonnull() ) track = (*pfCand)->gsfTrackRef().get();
-      if ( !track ) continue;
-      double trackPt = 0.;
-      if ( leadingTrkOrPFCandOption_ == kLeadTrack ) {
-	//double trackPt = track->pt();
-	trackPt = track->pt() - 2.*track->ptError();
-      } else if ( leadingTrkOrPFCandOption_ == kLeadPFCand ) {
-	trackPt = (*pfCand)->pt();
-      } else assert(0);
-      if ( trackPt > leadTrackPt ) {
-	leadPFCand = (*pfCand);
-	leadTrackPt = trackPt;
+    if ( leadingTrkOrPFCandOption_ == kFirstTrack){ leadPFCand=selectedPFCands[0];}
+    else
+    {
+      for ( std::vector<PFCandidatePtr>::const_iterator pfCand = selectedPFCands.begin();
+  	  pfCand != selectedPFCands.end(); ++pfCand ) {
+        const reco::Track* track = 0;
+        if ( (*pfCand)->trackRef().isNonnull() ) track = (*pfCand)->trackRef().get();
+        else if ( (*pfCand)->gsfTrackRef().isNonnull() ) track = (*pfCand)->gsfTrackRef().get();
+        if ( !track ) continue;
+        double trackPt = 0.;
+        if ( leadingTrkOrPFCandOption_ == kLeadTrack ) {
+  	  //double trackPt = track->pt();
+  	  trackPt = track->pt() - 2.*track->ptError();
+        } else if ( leadingTrkOrPFCandOption_ == kLeadPFCand ) {
+	  trackPt = (*pfCand)->pt();
+        } else assert(0);
+        if ( trackPt > leadTrackPt ) {
+          leadPFCand = (*pfCand);
+	  leadTrackPt = trackPt;
+        }
       }
     }
   }
@@ -185,12 +189,13 @@ RecoTauVertexAssociator::RecoTauVertexAssociator(const edm::ParameterSet& pset, 
   recoverLeadingTrk_ = pset.exists("recoverLeadingTrk") ? 
     pset.getParameter<bool>("recoverLeadingTrk") : false;
 
-  std::string leadingTrkOrPFCandOption_string = pset.getParameter<std::string>("leadingTrkOrPFCandOption");
+  std::string leadingTrkOrPFCandOption_string = pset.exists("leadingTrkOrPFCandOption") ? pset.getParameter<std::string>("leadingTrkOrPFCandOption") : "firstTrack" ;
   if      ( leadingTrkOrPFCandOption_string == "leadTrack"  ) leadingTrkOrPFCandOption_ = kLeadTrack;
   else if ( leadingTrkOrPFCandOption_string == "leadPFCand" ) leadingTrkOrPFCandOption_ = kLeadPFCand;
+  else if ( leadingTrkOrPFCandOption_string == "firstTrack" ) leadingTrkOrPFCandOption_ = kFirstTrack;
   else throw cms::Exception("BadVertexAssociatorConfig")
     << "Invalid Configuration parameter 'leadingTrkOrPFCandOption' " << leadingTrkOrPFCandOption_string << "." 
-    << " Valid options are: 'leadTrack', 'leadPFCand'.\n";
+    << " Valid options are: 'leadTrack', 'leadPFCand', 'firstTrack'.\n";
   
   verbosity_ = ( pset.exists("verbosity") ) ?
     pset.getParameter<int>("verbosity") : 0;


### PR DESCRIPTION
Redesign of vertex-to-jet matching algorithm used by tauReco. The only functional change is the possibility to select which way the jet leading PFcandidate will be selected. Also, the default matching was changed from using track weights to using deltaZ.

The performance is slightly affected in a positive way - increased efficiency and decreased fake rate

The change in performance is documented here: https://indico.cern.ch/event/316898/material/1/0.pdf

This pull request contains the fix for memory leak from #3666 and does not interfere with ak5->ak4 transition

@monicava, @veelken - you want to watch this
