### PR TITLE
Full 5x5 shapes for offline electrons

### DIFF
--- a/DataFormats/EgammaCandidates/interface/GsfElectron.h
+++ b/DataFormats/EgammaCandidates/interface/GsfElectron.h
@@ -1,4 +1,4 @@
- #ifndef GsfElectron_h
+#ifndef GsfElectron_h
 #define GsfElectron_h
 
 #include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
@@ -411,24 +411,24 @@ class GsfElectron : public RecoCandidate
     const ShowerShape & showerShape() const { return showerShape_ ; }
     // non-zero-suppressed and no-fractions shower shapes
     // ecal energy is always that from the full 5x5 
-    float noZS_sigmaEtaEta() const { return noZS_showerShape_.sigmaEtaEta ; }
-    float noZS_sigmaIetaIeta() const { return noZS_showerShape_.sigmaIetaIeta ; }
-    float noZS_sigmaIphiIphi() const { return noZS_showerShape_.sigmaIphiIphi ; }
-    float noZS_e1x5() const { return noZS_showerShape_.e1x5 ; }
-    float noZS_e2x5Max() const { return noZS_showerShape_.e2x5Max ; }
-    float noZS_e5x5() const { return noZS_showerShape_.e5x5 ; }
-    float noZS_r9() const { return noZS_showerShape_.r9 ; }
-    float noZS_hcalDepth1OverEcal() const { return noZS_showerShape_.hcalDepth1OverEcal ; }
-    float noZS_hcalDepth2OverEcal() const { return noZS_showerShape_.hcalDepth2OverEcal ; }
-    float noZS_hcalOverEcal() const { return noZS_hcalDepth1OverEcal() + noZS_hcalDepth2OverEcal() ; }    
-    float noZS_hcalDepth1OverEcalBc() const { return noZS_showerShape_.hcalDepth1OverEcalBc ; }
-    float noZS_hcalDepth2OverEcalBc() const { return noZS_showerShape_.hcalDepth2OverEcalBc ; }
-    float noZS_hcalOverEcalBc() const { return noZS_hcalDepth1OverEcalBc() + noZS_hcalDepth2OverEcalBc() ; }
-    const ShowerShape & noZS_showerShape() const { return noZS_showerShape_ ; }
+    float full5x5_sigmaEtaEta() const { return full5x5_showerShape_.sigmaEtaEta ; }
+    float full5x5_sigmaIetaIeta() const { return full5x5_showerShape_.sigmaIetaIeta ; }
+    float full5x5_sigmaIphiIphi() const { return full5x5_showerShape_.sigmaIphiIphi ; }
+    float full5x5_e1x5() const { return full5x5_showerShape_.e1x5 ; }
+    float full5x5_e2x5Max() const { return full5x5_showerShape_.e2x5Max ; }
+    float full5x5_e5x5() const { return full5x5_showerShape_.e5x5 ; }
+    float full5x5_r9() const { return full5x5_showerShape_.r9 ; }
+    float full5x5_hcalDepth1OverEcal() const { return full5x5_showerShape_.hcalDepth1OverEcal ; }
+    float full5x5_hcalDepth2OverEcal() const { return full5x5_showerShape_.hcalDepth2OverEcal ; }
+    float full5x5_hcalOverEcal() const { return full5x5_hcalDepth1OverEcal() + full5x5_hcalDepth2OverEcal() ; }    
+    float full5x5_hcalDepth1OverEcalBc() const { return full5x5_showerShape_.hcalDepth1OverEcalBc ; }
+    float full5x5_hcalDepth2OverEcalBc() const { return full5x5_showerShape_.hcalDepth2OverEcalBc ; }
+    float full5x5_hcalOverEcalBc() const { return full5x5_hcalDepth1OverEcalBc() + full5x5_hcalDepth2OverEcalBc() ; }
+    const ShowerShape & full5x5_showerShape() const { return full5x5_showerShape_ ; }
 
     // setters (if you know what you're doing)
     void setShowerShape(const ShowerShape &s) { showerShape_ = s; }
-    void noZS_setShowerShape(const ShowerShape &s) { noZS_showerShape_ = s; }
+    void full5x5_setShowerShape(const ShowerShape &s) { full5x5_showerShape_ = s; }
 
     // for backward compatibility (this will only ever be the ZS shapes!)
     float scSigmaEtaEta() const { return sigmaEtaEta() ; }
@@ -445,7 +445,7 @@ class GsfElectron : public RecoCandidate
 
     // attributes
     ShowerShape showerShape_ ;
-    ShowerShape noZS_showerShape_ ;
+    ShowerShape full5x5_showerShape_ ;
 
 
   //=======================================================

--- a/DataFormats/EgammaCandidates/interface/GsfElectron.h
+++ b/DataFormats/EgammaCandidates/interface/GsfElectron.h
@@ -87,6 +87,19 @@ class GsfElectron : public RecoCandidate
       const ShowerShape &,
       const ConversionRejection &
      ) ;
+     GsfElectron
+     (
+      int charge,
+      const ChargeInfo &,
+      const GsfElectronCoreRef &,
+      const TrackClusterMatching &,
+      const TrackExtrapolations &,
+      const ClosestCtfTrack &,
+      const FiducialFlags &,
+      const ShowerShape &,
+      const ShowerShape &,
+      const ConversionRejection &
+     ) ;
     GsfElectron * clone() const ;
     GsfElectron * clone
      (
@@ -396,11 +409,28 @@ class GsfElectron : public RecoCandidate
     float hcalDepth2OverEcalBc() const { return showerShape_.hcalDepth2OverEcalBc ; }
     float hcalOverEcalBc() const { return hcalDepth1OverEcalBc() + hcalDepth2OverEcalBc() ; }
     const ShowerShape & showerShape() const { return showerShape_ ; }
+    // non-zero-suppressed and no-fractions shower shapes
+    // ecal energy is always that from the full 5x5 
+    float noZS_sigmaEtaEta() const { return noZS_showerShape_.sigmaEtaEta ; }
+    float noZS_sigmaIetaIeta() const { return noZS_showerShape_.sigmaIetaIeta ; }
+    float noZS_sigmaIphiIphi() const { return noZS_showerShape_.sigmaIphiIphi ; }
+    float noZS_e1x5() const { return noZS_showerShape_.e1x5 ; }
+    float noZS_e2x5Max() const { return noZS_showerShape_.e2x5Max ; }
+    float noZS_e5x5() const { return noZS_showerShape_.e5x5 ; }
+    float noZS_r9() const { return noZS_showerShape_.r9 ; }
+    float noZS_hcalDepth1OverEcal() const { return noZS_showerShape_.hcalDepth1OverEcal ; }
+    float noZS_hcalDepth2OverEcal() const { return noZS_showerShape_.hcalDepth2OverEcal ; }
+    float noZS_hcalOverEcal() const { return noZS_hcalDepth1OverEcal() + noZS_hcalDepth2OverEcal() ; }    
+    float noZS_hcalDepth1OverEcalBc() const { return noZS_showerShape_.hcalDepth1OverEcalBc ; }
+    float noZS_hcalDepth2OverEcalBc() const { return noZS_showerShape_.hcalDepth2OverEcalBc ; }
+    float noZS_hcalOverEcalBc() const { return noZS_hcalDepth1OverEcalBc() + noZS_hcalDepth2OverEcalBc() ; }
+    const ShowerShape & noZS_showerShape() const { return noZS_showerShape_ ; }
 
     // setters (if you know what you're doing)
     void setShowerShape(const ShowerShape &s) { showerShape_ = s; }
+    void noZS_setShowerShape(const ShowerShape &s) { noZS_showerShape_ = s; }
 
-    // for backward compatibility
+    // for backward compatibility (this will only ever be the ZS shapes!)
     float scSigmaEtaEta() const { return sigmaEtaEta() ; }
     float scSigmaIEtaIEta() const { return sigmaIetaIeta() ; }
     float scE1x5() const { return e1x5() ; }
@@ -415,6 +445,7 @@ class GsfElectron : public RecoCandidate
 
     // attributes
     ShowerShape showerShape_ ;
+    ShowerShape noZS_showerShape_ ;
 
 
   //=======================================================

--- a/DataFormats/EgammaCandidates/src/GsfElectron.cc
+++ b/DataFormats/EgammaCandidates/src/GsfElectron.cc
@@ -51,14 +51,14 @@ GsfElectron::GsfElectron
    const TrackClusterMatching & tcm, const TrackExtrapolations & te,
    const ClosestCtfTrack & ctfInfo,
    const FiducialFlags & ff, const ShowerShape & ss,
-   const ShowerShape& noZS_ss,
+   const ShowerShape& full5x5_ss,
    const ConversionRejection & crv
  )
  : chargeInfo_(chargeInfo),
    core_(core),
    trackClusterMatching_(tcm), trackExtrapolations_(te),
    //closestCtfTrack_(ctfInfo),
-   fiducialFlags_(ff), showerShape_(ss), noZS_showerShape_(noZS_ss),
+   fiducialFlags_(ff), showerShape_(ss), full5x5_showerShape_(full5x5_ss),
    conversionRejection_(crv)
  {
   init() ;
@@ -115,6 +115,7 @@ GsfElectron::GsfElectron
    //closestCtfTrack_(electron.closestCtfTrack_),
    fiducialFlags_(electron.fiducialFlags_),
    showerShape_(electron.showerShape_),
+   full5x5_showerShape_(electron.full5x5_showerShape_),
    dr03_(electron.dr03_), dr04_(electron.dr04_),
    conversionRejection_(electron.conversionRejection_),
    pfShowerShape_(electron.pfShowerShape_),

--- a/DataFormats/EgammaCandidates/src/GsfElectron.cc
+++ b/DataFormats/EgammaCandidates/src/GsfElectron.cc
@@ -45,6 +45,30 @@ GsfElectron::GsfElectron
   assert(ctfInfo.ctfTrack==(GsfElectron::core()->ctfTrack())) ;
   assert(ctfInfo.shFracInnerHits==(GsfElectron::core()->ctfGsfOverlap())) ;
  }
+GsfElectron::GsfElectron
+ ( int charge, const ChargeInfo & chargeInfo,
+   const GsfElectronCoreRef & core,
+   const TrackClusterMatching & tcm, const TrackExtrapolations & te,
+   const ClosestCtfTrack & ctfInfo,
+   const FiducialFlags & ff, const ShowerShape & ss,
+   const ShowerShape& noZS_ss,
+   const ConversionRejection & crv
+ )
+ : chargeInfo_(chargeInfo),
+   core_(core),
+   trackClusterMatching_(tcm), trackExtrapolations_(te),
+   //closestCtfTrack_(ctfInfo),
+   fiducialFlags_(ff), showerShape_(ss), noZS_showerShape_(noZS_ss),
+   conversionRejection_(crv)
+ {
+  init() ;
+  setCharge(charge) ;
+  setVertex(math::XYZPoint(te.positionAtVtx.x(),te.positionAtVtx.y(),te.positionAtVtx.z())) ;
+  setPdgId(-11*charge) ;
+  /*if (ecalDrivenSeed())*/ corrections_.correctedEcalEnergy = superCluster()->energy() ;
+  assert(ctfInfo.ctfTrack==(GsfElectron::core()->ctfTrack())) ;
+  assert(ctfInfo.shFracInnerHits==(GsfElectron::core()->ctfGsfOverlap())) ;
+ }
 
 GsfElectron::GsfElectron
  ( const GsfElectron & electron,

--- a/DataFormats/EgammaCandidates/src/classes_def.xml
+++ b/DataFormats/EgammaCandidates/src/classes_def.xml
@@ -200,7 +200,8 @@
   <class name="reco::GsfElectron::ClassificationVariables" ClassVersion="11">
    <version ClassVersion="11" checksum="2094185381"/>
   </class>
-  <class name="reco::GsfElectron" ClassVersion="13">
+  <class name="reco::GsfElectron" ClassVersion="14">
+   <version ClassVersion="14" checksum="1650925096"/>
    <version ClassVersion="13" checksum="2991498573"/>
    <version ClassVersion="12" checksum="2835360780"/>
    <version ClassVersion="11" checksum="1755683850"/>

--- a/DataFormats/EgammaCandidates/src/classes_def.xml
+++ b/DataFormats/EgammaCandidates/src/classes_def.xml
@@ -201,7 +201,7 @@
    <version ClassVersion="11" checksum="2094185381"/>
   </class>
   <class name="reco::GsfElectron" ClassVersion="14">
-   <version ClassVersion="14" checksum="1650925096"/>
+   <version ClassVersion="14" checksum="3918953183"/>
    <version ClassVersion="13" checksum="2991498573"/>
    <version ClassVersion="12" checksum="2835360780"/>
    <version ClassVersion="11" checksum="1755683850"/>

--- a/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h
@@ -247,7 +247,7 @@ class GsfElectronAlgo {
     void setPflowPreselectionFlag( reco::GsfElectron * ele ) ;
     bool isPreselected( reco::GsfElectron * ele ) ;
     void calculateShowerShape( const reco::SuperClusterRef &, bool pflow, reco::GsfElectron::ShowerShape & ) ;
-    void calculateShowerShape_noZS( const reco::SuperClusterRef &, bool pflow, reco::GsfElectron::ShowerShape & ) ;
+    void calculateShowerShape_full5x5( const reco::SuperClusterRef &, bool pflow, reco::GsfElectron::ShowerShape & ) ;
 
 
     // associations

--- a/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h
@@ -247,6 +247,7 @@ class GsfElectronAlgo {
     void setPflowPreselectionFlag( reco::GsfElectron * ele ) ;
     bool isPreselected( reco::GsfElectron * ele ) ;
     void calculateShowerShape( const reco::SuperClusterRef &, bool pflow, reco::GsfElectron::ShowerShape & ) ;
+    void calculateShowerShape_noZS( const reco::SuperClusterRef &, bool pflow, reco::GsfElectron::ShowerShape & ) ;
 
 
     // associations

--- a/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
@@ -577,7 +577,7 @@ void GsfElectronAlgo::calculateShowerShape( const reco::SuperClusterRef & theClu
    }
  }
 
-void GsfElectronAlgo::calculateShowerShape_noZS( const reco::SuperClusterRef & theClus, bool pflow, reco::GsfElectron::ShowerShape & showerShape )
+void GsfElectronAlgo::calculateShowerShape_full5x5( const reco::SuperClusterRef & theClus, bool pflow, reco::GsfElectron::ShowerShape & showerShape )
  {
   const reco::CaloCluster & seedCluster = *(theClus->seed()) ;
   // temporary, till CaloCluster->seed() is made available
@@ -1363,8 +1363,8 @@ void GsfElectronAlgo::createElectron()
   reco::GsfElectron::ShowerShape showerShape ;
   calculateShowerShape(electronData_->superClusterRef,!(electronData_->coreRef->ecalDrivenSeed()),showerShape) ;
 
-  reco::GsfElectron::ShowerShape noZS_showerShape ;
-  calculateShowerShape_noZS(electronData_->superClusterRef,!(electronData_->coreRef->ecalDrivenSeed()),showerShape) ;
+  reco::GsfElectron::ShowerShape full5x5_showerShape ;
+  calculateShowerShape_full5x5(electronData_->superClusterRef,!(electronData_->coreRef->ecalDrivenSeed()),showerShape) ;
 
   //====================================================
   // ConversionRejection
@@ -1405,7 +1405,7 @@ void GsfElectronAlgo::createElectron()
     GsfElectron
      ( eleCharge,eleChargeInfo,electronData_->coreRef,
        tcMatching, tkExtra, ctfInfo,
-       fiducialFlags,showerShape, noZS_showerShape,
+       fiducialFlags,showerShape, full5x5_showerShape,
        conversionVars ) ;
   // Will be overwritten later in the case of the regression
   ele->setCorrectedEcalEnergyError(generalData_->superClusterErrorFunction->getValue(*(ele->superCluster()),0)) ;

--- a/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
@@ -1364,7 +1364,7 @@ void GsfElectronAlgo::createElectron()
   calculateShowerShape(electronData_->superClusterRef,!(electronData_->coreRef->ecalDrivenSeed()),showerShape) ;
 
   reco::GsfElectron::ShowerShape full5x5_showerShape ;
-  calculateShowerShape_full5x5(electronData_->superClusterRef,!(electronData_->coreRef->ecalDrivenSeed()),showerShape) ;
+  calculateShowerShape_full5x5(electronData_->superClusterRef,!(electronData_->coreRef->ecalDrivenSeed()),full5x5_showerShape) ;
 
   //====================================================
   // ConversionRejection

--- a/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
@@ -577,6 +577,59 @@ void GsfElectronAlgo::calculateShowerShape( const reco::SuperClusterRef & theClu
    }
  }
 
+void GsfElectronAlgo::calculateShowerShape_noZS( const reco::SuperClusterRef & theClus, bool pflow, reco::GsfElectron::ShowerShape & showerShape )
+ {
+  const reco::CaloCluster & seedCluster = *(theClus->seed()) ;
+  // temporary, till CaloCluster->seed() is made available
+  DetId seedXtalId = seedCluster.hitsAndFractions()[0].first ;
+  int detector = seedXtalId.subdetId() ;
+
+  const CaloTopology * topology = eventSetupData_->caloTopo.product() ;
+  const CaloGeometry * geometry = eventSetupData_->caloGeom.product() ;
+  const EcalRecHitCollection * recHits = 0 ;
+  std::vector<int> recHitFlagsToBeExcluded ;
+  std::vector<int> recHitSeverityToBeExcluded ;
+  if (detector==EcalBarrel)
+   {
+    recHits = eventData_->barrelRecHits.product() ;
+    recHitFlagsToBeExcluded = generalData_->recHitsCfg.recHitFlagsToBeExcludedBarrel ;
+    recHitSeverityToBeExcluded = generalData_->recHitsCfg.recHitSeverityToBeExcludedBarrel ;
+   }
+  else
+   {
+    recHits = eventData_->endcapRecHits.product() ;
+    recHitFlagsToBeExcluded = generalData_->recHitsCfg.recHitFlagsToBeExcludedEndcaps ;
+    recHitSeverityToBeExcluded = generalData_->recHitsCfg.recHitSeverityToBeExcludedEndcaps ;
+   }
+
+  std::vector<float> covariances = noZS::EcalClusterTools::covariances(seedCluster,recHits,topology,geometry) ;
+  std::vector<float> localCovariances = noZS::EcalClusterTools::localCovariances(seedCluster,recHits,topology) ;
+  showerShape.sigmaEtaEta = sqrt(covariances[0]) ;
+  showerShape.sigmaIetaIeta = sqrt(localCovariances[0]) ;
+  if (!edm::isNotFinite(localCovariances[2])) showerShape.sigmaIphiIphi = sqrt(localCovariances[2]) ;
+  showerShape.e1x5 = noZS::EcalClusterTools::e1x5(seedCluster,recHits,topology)  ;
+  showerShape.e2x5Max = noZS::EcalClusterTools::e2x5Max(seedCluster,recHits,topology)  ;
+  showerShape.e5x5 = noZS::EcalClusterTools::e5x5(seedCluster,recHits,topology) ;
+  showerShape.r9 = noZS::EcalClusterTools::e3x3(seedCluster,recHits,topology)/theClus->rawEnergy() ;
+
+  if (pflow)
+   {
+    showerShape.hcalDepth1OverEcal = generalData_->hcalHelperPflow->hcalESumDepth1(*theClus)/theClus->energy() ;
+    showerShape.hcalDepth2OverEcal = generalData_->hcalHelperPflow->hcalESumDepth2(*theClus)/theClus->energy() ;
+    showerShape.hcalTowersBehindClusters = generalData_->hcalHelperPflow->hcalTowersBehindClusters(*theClus) ;
+    showerShape.hcalDepth1OverEcalBc = generalData_->hcalHelperPflow->hcalESumDepth1BehindClusters(showerShape.hcalTowersBehindClusters)/showerShape.e5x5 ;
+    showerShape.hcalDepth2OverEcalBc = generalData_->hcalHelperPflow->hcalESumDepth2BehindClusters(showerShape.hcalTowersBehindClusters)/showerShape.e5x5 ;
+   }
+  else
+   {
+    showerShape.hcalDepth1OverEcal = generalData_->hcalHelper->hcalESumDepth1(*theClus)/theClus->energy() ;
+    showerShape.hcalDepth2OverEcal = generalData_->hcalHelper->hcalESumDepth2(*theClus)/theClus->energy() ;
+    showerShape.hcalTowersBehindClusters = generalData_->hcalHelper->hcalTowersBehindClusters(*theClus) ;
+    showerShape.hcalDepth1OverEcalBc = generalData_->hcalHelper->hcalESumDepth1BehindClusters(showerShape.hcalTowersBehindClusters)/showerShape.e5x5 ;
+    showerShape.hcalDepth2OverEcalBc = generalData_->hcalHelper->hcalESumDepth2BehindClusters(showerShape.hcalTowersBehindClusters)/showerShape.e5x5 ;
+   }
+ }
+
 
 //===================================================================
 // GsfElectronAlgo
@@ -1310,6 +1363,8 @@ void GsfElectronAlgo::createElectron()
   reco::GsfElectron::ShowerShape showerShape ;
   calculateShowerShape(electronData_->superClusterRef,!(electronData_->coreRef->ecalDrivenSeed()),showerShape) ;
 
+  reco::GsfElectron::ShowerShape noZS_showerShape ;
+  calculateShowerShape_noZS(electronData_->superClusterRef,!(electronData_->coreRef->ecalDrivenSeed()),showerShape) ;
 
   //====================================================
   // ConversionRejection
@@ -1350,7 +1405,7 @@ void GsfElectronAlgo::createElectron()
     GsfElectron
      ( eleCharge,eleChargeInfo,electronData_->coreRef,
        tcMatching, tkExtra, ctfInfo,
-       fiducialFlags,showerShape,
+       fiducialFlags,showerShape, noZS_showerShape,
        conversionVars ) ;
   // Will be overwritten later in the case of the regression
   ele->setCorrectedEcalEnergyError(generalData_->superClusterErrorFunction->getValue(*(ele->superCluster()),0)) ;

--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronFull5x5Filler.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronFull5x5Filler.cc
@@ -1,0 +1,147 @@
+
+#include "GsfElectronFull5x5Filler.h"
+#include "RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h"
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+#include "DataFormats/Common/interface/ValueMap.h"
+
+#include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
+#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
+
+#include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
+
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+#include "Geometry/CaloTopology/interface/CaloTopology.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "Geometry/Records/interface/CaloTopologyRecord.h"
+
+#include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidateEGammaExtra.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidateEGammaExtraFwd.h"
+#include "RecoParticleFlow/PFProducer/interface/GsfElectronEqual.h"
+
+#include "RecoEcal/EgammaCoreTools/interface/EcalClusterTools.h"
+#include "FWCore/Utilities/interface/isFinite.h"
+
+#include <iostream>
+#include <string>
+
+using namespace reco;
+
+GsfElectronFull5x5Filler::GsfElectronFull5x5Filler( const edm::ParameterSet & cfg )
+ {
+   _source = consumes<reco::GsfElectronCollection>(cfg.getParameter<edm::InputTag>("source"));
+   
+   ElectronHcalHelper::Configuration hcalCfg, hcalCfgPflow;
+   
+   hcalCfg.hOverEConeSize = cfg.getParameter<double>("hOverEConeSize") ;
+   if (hcalCfg.hOverEConeSize>0)
+     {
+       hcalCfg.useTowers = true ;
+       hcalCfg.hcalTowers = 
+	 consumes<CaloTowerCollection>(cfg.getParameter<edm::InputTag>("hcalTowers")) ;
+       hcalCfg.hOverEPtMin = cfg.getParameter<double>("hOverEPtMin") ;
+     }
+   hcalCfgPflow.hOverEConeSize = cfg.getParameter<double>("hOverEConeSizePflow") ;
+   if (hcalCfgPflow.hOverEConeSize>0)
+     {
+       hcalCfgPflow.useTowers = true ;
+       hcalCfgPflow.hcalTowers = 
+	 consumes<CaloTowerCollection>(cfg.getParameter<edm::InputTag>("hcalTowers")) ;
+       hcalCfgPflow.hOverEPtMin = cfg.getParameter<double>("hOverEPtMinPflow") ;
+     }
+   _hcalHelper.reset(new ElectronHcalHelper(hcalCfg));
+   _hcalHelperPflow.reset(new ElectronHcalHelper(hcalCfg));
+   
+   _ebRecHitsToken = consumes<EcalRecHitCollection>(cfg.getParameter<edm::InputTag>("barrelRecHitCollectionTag"));
+   _eeRecHitsToken = consumes<EcalRecHitCollection>(cfg.getParameter<edm::InputTag>("endcapRecHitCollectionTag"));
+   
+   produces<reco::GsfElectronCollection >();
+ }
+
+GsfElectronFull5x5Filler::~GsfElectronFull5x5Filler()
+ {}
+
+// ------------ method called to produce the data  ------------
+void GsfElectronFull5x5Filler::produce( edm::Event & event, const edm::EventSetup & setup )
+ {
+   std::auto_ptr<reco::GsfElectronCollection> out(new reco::GsfElectronCollection);
+   
+   edm::Handle<reco::GsfElectronCollection> eles;
+   event.getByToken(_source,eles);
+   
+   event.getByToken(_ebRecHitsToken,_ebRecHits);
+   event.getByToken(_eeRecHitsToken,_eeRecHits);
+
+   for( const auto& ele : *eles ) {
+     reco::GsfElectron temp(ele);
+     reco::GsfElectron::ShowerShape full5x5_ss;
+     calculateShowerShape_full5x5(temp.superCluster(),true,full5x5_ss);
+     temp.full5x5_setShowerShape(full5x5_ss);
+     out->push_back(temp);
+   }
+   
+   event.put(out);
+ }
+
+void GsfElectronFull5x5Filler::beginLuminosityBlock(edm::LuminosityBlock const& lb, 
+						 edm::EventSetup const& es) {
+  edm::ESHandle<CaloGeometry> caloGeom ;
+  edm::ESHandle<CaloTopology> caloTopo ;
+  es.get<CaloGeometryRecord>().get(caloGeom);
+  es.get<CaloTopologyRecord>().get(caloTopo);
+  _geometry = caloGeom.product();
+  _topology = caloTopo.product();
+}
+
+void GsfElectronFull5x5Filler::calculateShowerShape_full5x5( const reco::SuperClusterRef & theClus, bool pflow, reco::GsfElectron::ShowerShape & showerShape )
+ {
+  const reco::CaloCluster & seedCluster = *(theClus->seed()) ;
+  // temporary, till CaloCluster->seed() is made available
+  DetId seedXtalId = seedCluster.hitsAndFractions()[0].first ;
+  int detector = seedXtalId.subdetId() ;
+  
+  const EcalRecHitCollection * recHits = 0 ;
+  if (detector==EcalBarrel)
+   {
+    recHits = _ebRecHits.product() ;
+   }
+  else
+   {
+    recHits = _eeRecHits.product() ;
+   }
+
+  std::vector<float> covariances = noZS::EcalClusterTools::covariances(seedCluster,recHits,_topology,_geometry) ;
+  std::vector<float> localCovariances = noZS::EcalClusterTools::localCovariances(seedCluster,recHits,_topology) ;
+  showerShape.sigmaEtaEta = sqrt(covariances[0]) ;
+  showerShape.sigmaIetaIeta = sqrt(localCovariances[0]) ;
+  if (!edm::isNotFinite(localCovariances[2])) showerShape.sigmaIphiIphi = sqrt(localCovariances[2]) ;
+  showerShape.e1x5 = noZS::EcalClusterTools::e1x5(seedCluster,recHits,_topology)  ;
+  showerShape.e2x5Max = noZS::EcalClusterTools::e2x5Max(seedCluster,recHits,_topology)  ;
+  showerShape.e5x5 = noZS::EcalClusterTools::e5x5(seedCluster,recHits,_topology) ;
+  showerShape.r9 = noZS::EcalClusterTools::e3x3(seedCluster,recHits,_topology)/theClus->rawEnergy() ;
+
+  if (pflow)
+   {
+    showerShape.hcalDepth1OverEcal = _hcalHelperPflow->hcalESumDepth1(*theClus)/theClus->energy() ;
+    showerShape.hcalDepth2OverEcal = _hcalHelperPflow->hcalESumDepth2(*theClus)/theClus->energy() ;
+    showerShape.hcalTowersBehindClusters = _hcalHelperPflow->hcalTowersBehindClusters(*theClus) ;
+    showerShape.hcalDepth1OverEcalBc = _hcalHelperPflow->hcalESumDepth1BehindClusters(showerShape.hcalTowersBehindClusters)/showerShape.e5x5 ;
+    showerShape.hcalDepth2OverEcalBc = _hcalHelperPflow->hcalESumDepth2BehindClusters(showerShape.hcalTowersBehindClusters)/showerShape.e5x5 ;
+   }
+  else
+   {
+    showerShape.hcalDepth1OverEcal = _hcalHelper->hcalESumDepth1(*theClus)/theClus->energy() ;
+    showerShape.hcalDepth2OverEcal = _hcalHelper->hcalESumDepth2(*theClus)/theClus->energy() ;
+    showerShape.hcalTowersBehindClusters = _hcalHelper->hcalTowersBehindClusters(*theClus) ;
+    showerShape.hcalDepth1OverEcalBc = _hcalHelper->hcalESumDepth1BehindClusters(showerShape.hcalTowersBehindClusters)/showerShape.e5x5 ;
+    showerShape.hcalDepth2OverEcalBc = _hcalHelper->hcalESumDepth2BehindClusters(showerShape.hcalTowersBehindClusters)/showerShape.e5x5 ;
+   }
+ }

--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronFull5x5Filler.h
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronFull5x5Filler.h
@@ -1,0 +1,39 @@
+
+#ifndef GsfElectronFull5x5Filler_h
+#define GsfElectronFull5x5Filler_h
+
+#include "GsfElectronBaseProducer.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
+#include <map>
+
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+
+class GsfElectronFull5x5Filler : public edm::stream::EDProducer<>
+ {
+  public:
+
+    //static void fillDescriptions( edm::ConfigurationDescriptions & ) ;
+
+    explicit GsfElectronFull5x5Filler( const edm::ParameterSet & ) ;
+    virtual ~GsfElectronFull5x5Filler() ;
+    virtual void produce( edm::Event &, const edm::EventSetup & ) ;
+    void calculateShowerShape_full5x5(const reco::SuperClusterRef & theClus, bool pflow, reco::GsfElectron::ShowerShape & showerShape);
+
+    void beginLuminosityBlock(edm::LuminosityBlock const&, 
+			      edm::EventSetup const&) override;
+
+ private:
+    edm::EDGetTokenT<reco::GsfElectronCollection> _source;
+    edm::EDGetTokenT<EcalRecHitCollection> _ebRecHitsToken, _eeRecHitsToken;
+    std::unique_ptr<ElectronHcalHelper> _hcalHelper, _hcalHelperPflow ;
+    edm::Handle<EcalRecHitCollection> _ebRecHits;
+    edm::Handle<EcalRecHitCollection> _eeRecHits;
+    const CaloTopology * _topology;
+    const CaloGeometry * _geometry;
+    
+ private:
+ };
+
+#endif

--- a/RecoEgamma/EgammaElectronProducers/plugins/SealModule.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/SealModule.cc
@@ -12,6 +12,7 @@
 #include "GsfElectronEcalDrivenProducer.h"
 #include "GsfElectronCoreProducer.h"
 #include "GsfElectronProducer.h"
+#include "GsfElectronFull5x5Filler.h"
 //#include "GlobalGsfElectronProducer.h"
 
 #include "GEDGsfElectronCoreProducer.h"
@@ -22,6 +23,7 @@ DEFINE_FWK_MODULE(SiStripElectronProducer);
 DEFINE_FWK_MODULE(SiStripElectronAssociator);
 DEFINE_FWK_MODULE(ElectronSeedProducer);
 //DEFINE_FWK_MODULE(GlobalSeedProducer);
+DEFINE_FWK_MODULE(GsfElectronFull5x5Filler);
 DEFINE_FWK_MODULE(GsfElectronCoreEcalDrivenProducer);
 DEFINE_FWK_MODULE(GsfElectronEcalDrivenProducer);
 DEFINE_FWK_MODULE(GsfElectronCoreProducer);


### PR DESCRIPTION
Built ontop of CMSSW_7_1_X_2014-05-12-1400.
The "real" PR is only the last two commits.

This PR stores the shower shapes calculated using the full 5x5 crystal matrix with no fractions in GsfElectrons in addition to the old shower shapes. Other shower shapes are not touched.

A similar PR for photons will come soon.

@Sam-Harper
