### PR TITLE
ClangSA fix statics report

### DIFF
--- a/Utilities/StaticAnalyzers/scripts/statics.py
+++ b/Utilities/StaticAnalyzers/scripts/statics.py
@@ -5,7 +5,7 @@ baseclass = re.compile("edm::(one::|stream::|global::)?ED(Producer|Filter|Analyz
 farg = re.compile("\(.*\)")
 statics = set()
 toplevelfuncs = set()
-skipfunc = re.compile("(edm::eventsetup::EventSetupRecord::get\(.*\) const)|(BareRootProductGetter::getIt\(.*\) const)|(edm::eventsetup::DataProxy::getImpl\(.*\))|(edm::EventPrincipal::unscheduledFill\(.*\) const)|(edm::ServiceRegistry::get\(.*\) const)|(fwlite::internal::ProductGetter::getIt\(.*\) const)|(edm::eventsetup::EventSetupRecord::getImplementation\(.*\) const)|(edm::eventsetup::EventSetupRecord::getFromProxy\(.*\) const)|(edm::eventsetup::DataProxy::get\(.*\) const)")
+skipfunc = re.compile("(edm::eventsetup::EventSetupRecord::get)|(BareRootProductGetter::getIt)|(edm::eventsetup::DataProxy::getImpl)|(edm::EventPrincipal::unscheduledFill)|(edm::ServiceRegistry::get)|(fwlite::internal::ProductGetter::getIt)|(edm::eventsetup::EventSetupRecord::getImplementation)|(edm::eventsetup::EventSetupRecord::getFromProxy)|(edm::eventsetup::DataProxy::get)")
 skipfuncs=set()
 
 import networkx as nx
@@ -16,19 +16,21 @@ f = open('db.txt')
 for line in f :
 	fields = line.split("'")
 	if fields[2] == ' calls function ' :
-		if skipfunc.search(fields[3]) : skipfuncs.add(line)
+		if skipfunc.search(line) : skipfuncs.add(line)
 		else : G.add_edge(fields[1],fields[3],kind=fields[2])
 	if fields[2] == ' overrides function ' :
 		if baseclass.search(fields[3]) :
 			if topfunc.search(fields[3]) : toplevelfuncs.add(fields[1])
 			G.add_edge(fields[1],fields[3],kind=' overrides function ')
 		else :
-			if skipfunc.search(fields[3]) : skipfuncs.add(line)
+			if skipfunc.search(line) : skipfuncs.add(line)
 			else : G.add_edge(fields[3],fields[1],kind=' calls function ')
 	if fields[2] == ' static variable ' :
 		G.add_edge(fields[1],fields[3],kind=' static variable ')
 		statics.add(fields[3])
 f.close()
+
+for skipfunc in sorted(skipfuncs): print "skipped : ",skipfunc
 
 for static in statics:
 	for tfunc in toplevelfuncs:


### PR DESCRIPTION
The regexp for functions to skip was not picking up any functions. Removed the (.*) from the regexp.
