### PR TITLE
Backport from 70x/71x releases (JEC onfly, PU classification...)

### DIFF
--- a/DQMOffline/Configuration/python/DQMOffline_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_cff.py
@@ -49,7 +49,6 @@ DQMOfflinePrePOG = cms.Sequence( muonMonitors *
                                  l1TriggerDqmOffline *
                                  triggerOfflineDQMSource *
                                  pvMonitor *
-                                 prebTagSequence *
                                  bTagPlotsDATA *
                                  alcaBeamMonitor *
                                  dqmPhysics *
@@ -64,7 +63,6 @@ DQMOffline = cms.Sequence( DQMOfflinePreDPG *
                            DQMMessageLogger )
 
 DQMOfflinePrePOGMC = cms.Sequence( pvMonitor *
-                                   prebTagSequence *
                                    bTagPlotsDATA *
                                    dqmPhysics )
 
@@ -114,7 +112,6 @@ DQMOfflineJetMET = cms.Sequence( jetMETDQMOfflineSource )
 
 DQMOfflineEGamma = cms.Sequence( egammaDQMOffline )
 
-DQMOfflineBTag = cms.Sequence( prebTagSequence *
-                               bTagPlotsDATA )
+DQMOfflineBTag = cms.Sequence( bTagPlotsDATA )
                                                                  
 

--- a/DQMOffline/RecoB/interface/AcceptJet.h
+++ b/DQMOffline/RecoB/interface/AcceptJet.h
@@ -15,9 +15,10 @@ class AcceptJet {
 
  public:
   AcceptJet(const double& etaMin_, const double& etaMax_, const double& ptMin_, const double& ptMax_,
-            const double& pMin_, const double& pMax_, const double& ratioMin_, const double& ratioMax_);
+            const double& pMin_, const double& pMax_, const double& ratioMin_, const double& ratioMax_,
+	    const bool& doJetID_);
   /// Returns true if jet and associated parton satisfy kinematic cuts.
-  bool operator() (const reco::Jet & jet, const int & jetFlavour, const edm::Handle<reco::SoftLeptonTagInfoCollection> & infos) const;
+  bool operator() (const reco::Jet & jet, const edm::Handle<reco::SoftLeptonTagInfoCollection> & infos, const double jec) const;
 
   /// Set cut parameters
   void setEtaMin            ( double d ) { etaMin            = d ; } 
@@ -30,6 +31,7 @@ class AcceptJet {
   void setPRecJetMax        ( double d ) { pRecJetMax        = d ; }
   void setRatioMin          ( double d ) { ratioMin          = d ; }
   void setRatioMax          ( double d ) { ratioMax          = d ; }
+  void setDoJetID           ( bool   b ) { doJetID           = b ; }
 
 //   void setPtPartonMin       ( double d ) { ptPartonMin       = d ; } 
 //   void setPtPartonMax       ( double d ) { ptPartonMax       = d ; } 
@@ -61,6 +63,8 @@ class AcceptJet {
   double ratioMin ;
   double ratioMax ;
   
+  //Apply loose Jet ID in case of PF jets
+  bool doJetID;
 } ;
 
 #endif

--- a/DQMOffline/RecoB/interface/BTagDifferentialPlot.h
+++ b/DQMOffline/RecoB/interface/BTagDifferentialPlot.h
@@ -49,9 +49,7 @@ class BTagDifferentialPlot {
   TH1F * getDifferentialHistoB_ni   () { return theDifferentialHistoB_ni->getTH1F()   ; }
   TH1F * getDifferentialHistoB_dus  () { return theDifferentialHistoB_dus->getTH1F()  ; }
   TH1F * getDifferentialHistoB_dusg () { return theDifferentialHistoB_dusg->getTH1F() ; }
-  
-  
-
+  TH1F * getDifferentialHistoB_pu   () { return theDifferentialHistoB_pu->getTH1F()   ; }
 
   
  private:
@@ -98,6 +96,7 @@ class BTagDifferentialPlot {
   MonitorElement * theDifferentialHistoB_ni   ;
   MonitorElement * theDifferentialHistoB_dus  ;
   MonitorElement * theDifferentialHistoB_dusg ;
+  MonitorElement * theDifferentialHistoB_pu   ;
 
   // the plot Canvas
 //   TCanvas * thePlotCanvas ;

--- a/DQMOffline/RecoB/interface/BaseTagInfoPlotter.h
+++ b/DQMOffline/RecoB/interface/BaseTagInfoPlotter.h
@@ -16,10 +16,10 @@ class BaseTagInfoPlotter : public BaseBTagPlotter {
 	    BaseBTagPlotter(tagName, etaPtBin) {};
 
   virtual ~BaseTagInfoPlotter () {};
-  virtual void analyzeTag(const reco::BaseTagInfo * tagInfo, const int & jetFlavour);
-  virtual void analyzeTag(const std::vector<const reco::BaseTagInfo *> &tagInfos, const int & jetFlavour);
-  virtual void analyzeTag(const reco::BaseTagInfo * tagInfo, const int & jetFlavour, const float & w);
-  virtual void analyzeTag(const std::vector<const reco::BaseTagInfo *> &tagInfos, const int & jetFlavour, const float & w);
+  virtual void analyzeTag(const reco::BaseTagInfo * tagInfo, const double & jec, const int & jetFlavour);
+  virtual void analyzeTag(const std::vector<const reco::BaseTagInfo *> &tagInfos, const double & jec, const int & jetFlavour);
+  virtual void analyzeTag(const reco::BaseTagInfo * tagInfo, const double & jec, const int & jetFlavour, const float & w);
+  virtual void analyzeTag(const std::vector<const reco::BaseTagInfo *> &tagInfos, const double & jec, const int & jetFlavour, const float & w);
 
   virtual void setEventSetup(const edm::EventSetup & setup);
   virtual std::vector<std::string> tagInfoRequirements() const;

--- a/DQMOffline/RecoB/interface/EffPurFromHistos.h
+++ b/DQMOffline/RecoB/interface/EffPurFromHistos.h
@@ -17,9 +17,10 @@ class EffPurFromHistos {
  public:
 
   EffPurFromHistos ( const std::string & ext, TH1F * h_d, TH1F * h_u,
-	TH1F * h_s, TH1F * h_c, TH1F * h_b, TH1F * h_g,	TH1F * h_ni,
-		     TH1F * h_dus, TH1F * h_dusg, const std::string& label, const unsigned int& mc,
-	int nBin = 100 , double startO = 0.005 , double endO = 1.005 ) ;
+		     TH1F * h_s, TH1F * h_c, TH1F * h_b, TH1F * h_g,	TH1F * h_ni,
+		     TH1F * h_dus, TH1F * h_dusg, TH1F * h_pu, 
+		     const std::string& label, const unsigned int& mc,
+		     int nBin = 100 , double startO = 0.005 , double endO = 1.005 ) ;
 	// defaults reasonable for lifetime based tags
 
   EffPurFromHistos (const FlavourHistograms<double> * dDiscriminatorFC, const std::string& label, const unsigned int& mc,
@@ -32,8 +33,7 @@ class EffPurFromHistos {
   void compute () ;
 
   // return the newly created histos
-  TH1F * getEffFlavVsBEff_d    () { 
-    return EffFlavVsBEff_d->getTH1F()    ; };
+  TH1F * getEffFlavVsBEff_d    () { return EffFlavVsBEff_d->getTH1F()    ; };
   TH1F * getEffFlavVsBEff_u    () { return EffFlavVsBEff_u->getTH1F()    ; };
   TH1F * getEffFlavVsBEff_s    () { return EffFlavVsBEff_s ->getTH1F()   ; };
   TH1F * getEffFlavVsBEff_c    () { return EffFlavVsBEff_c ->getTH1F()   ; };
@@ -42,6 +42,7 @@ class EffPurFromHistos {
   TH1F * getEffFlavVsBEff_ni   () { return EffFlavVsBEff_ni ->getTH1F()  ; };
   TH1F * getEffFlavVsBEff_dus  () { return EffFlavVsBEff_dus ->getTH1F() ; };
   TH1F * getEffFlavVsBEff_dusg () { return EffFlavVsBEff_dusg ->getTH1F(); };
+  TH1F * getEffFlavVsBEff_pu   () { return EffFlavVsBEff_pu ->getTH1F(); };
 
  
 
@@ -84,6 +85,7 @@ class EffPurFromHistos {
   TH1F * effVersusDiscr_ni   ;
   TH1F * effVersusDiscr_dus  ;
   TH1F * effVersusDiscr_dusg ;
+  TH1F * effVersusDiscr_pu   ;
 
 
   // the corresponding output histograms (flavour-eff vs. b-efficiency)
@@ -105,6 +107,7 @@ class EffPurFromHistos {
   MonitorElement * EffFlavVsBEff_ni   ;
   MonitorElement * EffFlavVsBEff_dus  ;
   MonitorElement * EffFlavVsBEff_dusg ;
+  MonitorElement * EffFlavVsBEff_pu   ;
 
   //  DQMStore * dqmStore_; 
   std::string label_;

--- a/DQMOffline/RecoB/interface/EtaPtBin.h
+++ b/DQMOffline/RecoB/interface/EtaPtBin.h
@@ -43,7 +43,7 @@ class EtaPtBin {
 
   /// Check if jet/parton are within rapidity/pt cuts.
   bool inBin(const double & eta , const double & pt) const;
-  bool inBin(const reco::Jet & jet) const;
+  bool inBin(const reco::Jet & jet, const double jec) const;
 //   bool inBin(const BTagMCTools::JetFlavour & jetFlavour) const;
 
  private:

--- a/DQMOffline/RecoB/interface/FlavourHistorgrams.h
+++ b/DQMOffline/RecoB/interface/FlavourHistorgrams.h
@@ -88,6 +88,7 @@ public:
   inline TH1F * histo_ni   () const { return theHisto_ni->getTH1F()   ; }
   inline TH1F * histo_dus  () const { return theHisto_dus->getTH1F()  ; }
   inline TH1F * histo_dusg () const { return theHisto_dusg->getTH1F() ; }
+  inline TH1F * histo_pu () const { return theHisto_pu->getTH1F() ; }
 
   std::vector<TH1F*> getHistoVector() const;
   
@@ -129,6 +130,7 @@ protected:
   MonitorElement *theHisto_ni   ;
   MonitorElement *theHisto_dus  ;
   MonitorElement *theHisto_dusg ;
+  MonitorElement *theHisto_pu ;
 
   //  DQMStore * dqmStore_; 
 
@@ -192,6 +194,7 @@ FlavourHistograms<T>::FlavourHistograms (const std::string& baseNameTitle_ , con
       theHisto_b     = (prov.book1D ( theBaseNameTitle + "B"    , theBaseNameDescription + " b-jets"    , theNBins , theLowerBound , theUpperBound )) ; 
       theHisto_ni    = (prov.book1D ( theBaseNameTitle + "NI"   , theBaseNameDescription + " ni-jets"   , theNBins , theLowerBound , theUpperBound )) ; 
       theHisto_dusg  = (prov.book1D ( theBaseNameTitle + "DUSG" , theBaseNameDescription + " dusg-jets" , theNBins , theLowerBound , theUpperBound )) ;
+      theHisto_pu    = (prov.book1D ( theBaseNameTitle + "PU"   , theBaseNameDescription + " pu-jets"   , theNBins , theLowerBound , theUpperBound )) ; 
     }else{
       theHisto_d = 0;
       theHisto_u = 0;
@@ -202,6 +205,7 @@ FlavourHistograms<T>::FlavourHistograms (const std::string& baseNameTitle_ , con
       theHisto_ni = 0;
       theHisto_dus = 0;
       theHisto_dusg = 0;
+      theHisto_pu = 0;
     }
 
       // statistics if requested
@@ -219,6 +223,7 @@ FlavourHistograms<T>::FlavourHistograms (const std::string& baseNameTitle_ , con
 	theHisto_b   ->getTH1F()->Sumw2() ; 
 	theHisto_ni  ->getTH1F()->Sumw2() ; 
 	theHisto_dusg->getTH1F()->Sumw2() ;
+	theHisto_pu  ->getTH1F()->Sumw2() ;
       }
     }
   } else {
@@ -236,6 +241,7 @@ FlavourHistograms<T>::FlavourHistograms (const std::string& baseNameTitle_ , con
       theHisto_b     = prov.access(theBaseNameTitle + "B"   ) ; 
       theHisto_ni    = prov.access(theBaseNameTitle + "NI"  ) ; 
       theHisto_dusg  = prov.access(theBaseNameTitle + "DUSG") ;
+      theHisto_pu  = prov.access(theBaseNameTitle + "PU") ;
     }
   }
 
@@ -317,6 +323,7 @@ void FlavourHistograms<T>::settitle(const char* title) {
       theHisto_b   ->setAxisTitle(title) ;
       theHisto_ni  ->setAxisTitle(title) ;
       theHisto_dusg->setAxisTitle(title) ;
+      theHisto_pu->setAxisTitle(title) ;
     }
 }
 
@@ -490,6 +497,7 @@ void FlavourHistograms<T>::divide ( const FlavourHistograms<T> & bHD ) const {
       theHisto_b    ->getTH1F()-> Divide ( theHisto_b ->getTH1F()   , bHD.histo_b   () , 1.0 , 1.0 , "b" ) ;
       theHisto_ni   ->getTH1F()-> Divide ( theHisto_ni->getTH1F()   , bHD.histo_ni  () , 1.0 , 1.0 , "b" ) ;
       theHisto_dusg ->getTH1F()-> Divide ( theHisto_dusg->getTH1F() , bHD.histo_dusg() , 1.0 , 1.0 , "b" ) ;
+      theHisto_pu   ->getTH1F()-> Divide ( theHisto_pu->getTH1F() , bHD.histo_pu() , 1.0 , 1.0 , "b" ) ;
     }
 }
   
@@ -541,6 +549,9 @@ void FlavourHistograms<T>::fillVariable ( const int & flavour , const T & var , 
     case 12321:
       if (theBaseNameDescription == "Jet Multiplicity") theHisto_dusg->Fill( var ,w);
       return;
+    case 20:
+      theHisto_pu->Fill( var ,w);
+      return;
     default:
       theHisto_ni->Fill( var ,w);
       return;
@@ -564,6 +575,7 @@ std::vector<TH1F*> FlavourHistograms<T>::getHistoVector() const
       histoVector.push_back ( theHisto_b->getTH1F()   );
       histoVector.push_back ( theHisto_ni->getTH1F()  );
       histoVector.push_back ( theHisto_dusg->getTH1F());
+      histoVector.push_back ( theHisto_pu->getTH1F());
     }
   return histoVector;
 }

--- a/DQMOffline/RecoB/interface/FlavourHistorgrams2D.h
+++ b/DQMOffline/RecoB/interface/FlavourHistorgrams2D.h
@@ -85,6 +85,7 @@ public:
   inline TH2F * histo_ni   () const { return theHisto_ni->getTH2F()   ; }
   inline TH2F * histo_dus  () const { return theHisto_dus->getTH2F()  ; }
   inline TH2F * histo_dusg () const { return theHisto_dusg->getTH2F() ; }
+  inline TH2F * histo_pu   () const { return theHisto_pu->getTH2F()   ; }
 
   TProfile * profile_all  () const { return theProfile_all->getTProfile()  ; }    
   TProfile * profile_d    () const { return theProfile_d ->getTProfile()   ; }    
@@ -96,6 +97,7 @@ public:
   TProfile * profile_ni   () const { return theProfile_ni->getTProfile()   ; }
   TProfile * profile_dus  () const { return theProfile_dus->getTProfile()  ; }
   TProfile * profile_dusg () const { return theProfile_dusg->getTProfile() ; }
+  TProfile * profile_pu   () const { return theProfile_pu->getTProfile()   ; }
 
   std::vector<TH2F*> getHistoVector() const;
 
@@ -140,6 +142,7 @@ protected:
   MonitorElement *theHisto_ni   ;
   MonitorElement *theHisto_dus  ;
   MonitorElement *theHisto_dusg ;
+  MonitorElement *theHisto_pu ;
 
   // the profiles
   MonitorElement *theProfile_all  ;    
@@ -152,6 +155,7 @@ protected:
   MonitorElement *theProfile_ni   ;
   MonitorElement *theProfile_dus  ;
   MonitorElement *theProfile_dusg ;
+  MonitorElement *theProfile_pu ;
 
   //  DQMStore * dqmStore_; 
 
@@ -208,6 +212,7 @@ FlavourHistograms2D<T, G>::FlavourHistograms2D (TString baseNameTitle_ , TString
       theHisto_b     = (prov.book2D ( theBaseNameTitle + "B"    , theBaseNameDescription + " b-jets"    , theNBinsX , theLowerBoundX , theUpperBoundX , theNBinsY, theLowerBoundY, theUpperBoundY)) ; 
       theHisto_ni    = (prov.book2D ( theBaseNameTitle + "NI"   , theBaseNameDescription + " ni-jets"   , theNBinsX , theLowerBoundX , theUpperBoundX , theNBinsY, theLowerBoundY, theUpperBoundY)) ; 
       theHisto_dusg  = (prov.book2D ( theBaseNameTitle + "DUSG" , theBaseNameDescription + " dusg-jets" , theNBinsX , theLowerBoundX , theUpperBoundX , theNBinsY, theLowerBoundY, theUpperBoundY)) ;
+      theHisto_pu    = (prov.book2D ( theBaseNameTitle + "PU"   , theBaseNameDescription + " pu-jets"   , theNBinsX , theLowerBoundX , theUpperBoundX , theNBinsY, theLowerBoundY, theUpperBoundY)) ;
     }else{
       theHisto_d = 0;
       theHisto_u = 0;
@@ -218,6 +223,7 @@ FlavourHistograms2D<T, G>::FlavourHistograms2D (TString baseNameTitle_ , TString
       theHisto_ni = 0;
       theHisto_dus = 0;
       theHisto_dusg = 0;
+      theHisto_pu = 0;
     }
 
     if (createProfile_) {
@@ -242,6 +248,7 @@ FlavourHistograms2D<T, G>::FlavourHistograms2D (TString baseNameTitle_ , TString
         theProfile_b     = (prov.bookProfile ( theBaseNameTitle + "_Profile_B"    , theBaseNameDescription + " b-jets"    , theNBinsX , theLowerBoundX , theUpperBoundX , theNBinsY, theLowerBoundY, theUpperBoundY)) ; 
         theProfile_ni    = (prov.bookProfile ( theBaseNameTitle + "_Profile_NI"   , theBaseNameDescription + " ni-jets"   , theNBinsX , theLowerBoundX , theUpperBoundX , theNBinsY, theLowerBoundY, theUpperBoundY)) ; 
         theProfile_dusg  = (prov.bookProfile ( theBaseNameTitle + "_Profile_DUSG" , theBaseNameDescription + " dusg-jets" , theNBinsX , theLowerBoundX , theUpperBoundX , theNBinsY, theLowerBoundY, theUpperBoundY)) ;
+        theProfile_pu    = (prov.bookProfile ( theBaseNameTitle + "_Profile_PU"   , theBaseNameDescription + " pu-jets"   , theNBinsX , theLowerBoundX , theUpperBoundX , theNBinsY, theLowerBoundY, theUpperBoundY)) ;
       } else{
           theProfile_d = 0;
           theProfile_u = 0;
@@ -252,6 +259,7 @@ FlavourHistograms2D<T, G>::FlavourHistograms2D (TString baseNameTitle_ , TString
           theProfile_ni = 0;
           theProfile_dus = 0;
           theProfile_dusg = 0;
+          theProfile_pu = 0;
       } 
     }  else {
           theProfile_all = 0;
@@ -264,6 +272,7 @@ FlavourHistograms2D<T, G>::FlavourHistograms2D (TString baseNameTitle_ , TString
           theProfile_ni = 0;
           theProfile_dus = 0;
           theProfile_dusg = 0;
+          theProfile_pu = 0;
     }
       // statistics if requested
     if ( theStatistics ) {
@@ -282,6 +291,7 @@ FlavourHistograms2D<T, G>::FlavourHistograms2D (TString baseNameTitle_ , TString
 	theHisto_b   ->getTH2F()->Sumw2() ; 
 	theHisto_ni  ->getTH2F()->Sumw2() ; 
 	theHisto_dusg->getTH2F()->Sumw2() ;
+	theHisto_pu  ->getTH2F()->Sumw2() ;
 
         if(createProfile) {
 	  if (mcPlots_>2) {
@@ -295,6 +305,7 @@ FlavourHistograms2D<T, G>::FlavourHistograms2D (TString baseNameTitle_ , TString
 	  theProfile_b   ->getTProfile()->Sumw2() ; 
 	  theProfile_ni  ->getTProfile()->Sumw2() ; 
 	  theProfile_dusg->getTProfile()->Sumw2() ;
+	  theProfile_pu  ->getTProfile()->Sumw2() ;
         }
       }
     }
@@ -313,6 +324,7 @@ FlavourHistograms2D<T, G>::FlavourHistograms2D (TString baseNameTitle_ , TString
       theHisto_b     = prov.access(theBaseNameTitle + "B"   ) ; 
       theHisto_ni    = prov.access(theBaseNameTitle + "NI"  ) ; 
       theHisto_dusg  = prov.access(theBaseNameTitle + "DUSG") ;
+      theHisto_pu    = prov.access(theBaseNameTitle + "PU"  ) ;
     }
 
     if(createProfile_) {
@@ -329,6 +341,7 @@ FlavourHistograms2D<T, G>::FlavourHistograms2D (TString baseNameTitle_ , TString
         theProfile_b     = prov.access(theBaseNameTitle + "_Profile_B"   ) ; 
         theProfile_ni    = prov.access(theBaseNameTitle + "_Profile_NI"  ) ; 
         theProfile_dusg  = prov.access(theBaseNameTitle + "_Profile_DUSG") ;
+        theProfile_pu    = prov.access(theBaseNameTitle + "_Profile_PU"  ) ;
       }
     }
   }
@@ -420,6 +433,7 @@ void FlavourHistograms2D<T, G>::settitle(const char* titleX, const char* titleY)
       if(theHisto_ni) theHisto_ni  ->setAxisTitle(titleY, 2) ;
       if(theHisto_dus) theHisto_dus ->setAxisTitle(titleY, 2) ;
       if(theHisto_dusg)theHisto_dusg->setAxisTitle(titleY, 2) ;
+      if(theHisto_pu) theHisto_pu  ->setAxisTitle(titleY, 2) ;
     }
 
   if(createProfile_) {
@@ -445,6 +459,7 @@ void FlavourHistograms2D<T, G>::settitle(const char* titleX, const char* titleY)
       if(theProfile_ni) theProfile_ni  ->setAxisTitle(titleY, 2) ;
       if(theProfile_dus) theProfile_dus ->setAxisTitle(titleY, 2) ;
       if(theProfile_dusg)theProfile_dusg->setAxisTitle(titleY, 2) ;
+      if(theProfile_pu) theProfile_pu  ->setAxisTitle(titleY, 2) ;
     }
   }
 }
@@ -471,6 +486,7 @@ void FlavourHistograms2D<T, G>::divide ( const FlavourHistograms2D<T, G> & bHD )
       theHisto_b    ->getTH2F()-> Divide ( theHisto_b ->getTH2F()   , bHD.histo_b   () , 1.0 , 1.0 , "b" ) ;
       theHisto_ni   ->getTH2F()-> Divide ( theHisto_ni->getTH2F()   , bHD.histo_ni  () , 1.0 , 1.0 , "b" ) ;
       theHisto_dusg ->getTH2F()-> Divide ( theHisto_dusg->getTH2F() , bHD.histo_dusg() , 1.0 , 1.0 , "b" ) ;
+      theHisto_pu   ->getTH2F()-> Divide ( theHisto_pu->getTH2F()   , bHD.histo_pu  () , 1.0 , 1.0 , "b" ) ;
     }
 }
   
@@ -559,6 +575,11 @@ template <class T, class G>
         theProfile_dusg->Fill(varX, varY);
       }
       return;
+    case 20:
+      theHisto_pu->Fill( varX, varY,w );
+      //if(createProfile_) theProfile_pu->Fill(varX, varY,w);                                                                                                                                 
+      if(createProfile_) theProfile_pu->Fill(varX, varY);
+      return;
     default:
       theHisto_ni->Fill( varX, varY,w );
       //if(createProfile_) theProfile_ni->Fill(varX, varY,w);
@@ -584,6 +605,7 @@ std::vector<TH2F*> FlavourHistograms2D<T, G>::getHistoVector() const
       histoVector.push_back ( theHisto_b->getTH2F()   );
       histoVector.push_back ( theHisto_ni->getTH2F()  );
       histoVector.push_back ( theHisto_dusg->getTH2F());
+      histoVector.push_back ( theHisto_pu->getTH2F()  );
     }
   return histoVector;
 }
@@ -606,6 +628,7 @@ std::vector<TProfile*> FlavourHistograms2D<T, G>::getProfileVector() const
         profileVector.push_back ( theProfile_b->getTProfile()   );
         profileVector.push_back ( theProfile_ni->getTProfile()  );
         profileVector.push_back ( theProfile_dusg->getTProfile());
+        profileVector.push_back ( theProfile_pu->getTProfile()  );
       }
   }
   return profileVector;

--- a/DQMOffline/RecoB/interface/JetTagPlotter.h
+++ b/DQMOffline/RecoB/interface/JetTagPlotter.h
@@ -23,10 +23,10 @@ class JetTagPlotter : public BaseBTagPlotter {
 
   void analyzeTag (); //added to fill the jet multiplicity on data 
   void analyzeTag (const float & w); //added to fill the jet multiplicity on mc 
-  void analyzeTag (const reco::JetTag & jetTag, const int & jetFlavour);
-  void analyzeTag (const reco::JetTag & jetTag, const int & jetFlavour, const float & w);
-  void analyzeTag (const reco::Jet & jet, const float& discriminator, const int& jetFlavour);
-  void analyzeTag (const reco::Jet & jet, const float& discriminator, const int& jetFlavour, const float & w);
+  void analyzeTag (const reco::JetTag & jetTag, const double & jec, const int & jetFlavour);
+  void analyzeTag (const reco::JetTag & jetTag, const double & jec, const int & jetFlavour, const float & w);
+  void analyzeTag (const reco::Jet & jet, const double & jec, const float& discriminator, const int& jetFlavour);
+  void analyzeTag (const reco::Jet & jet, const double & jec, const float& discriminator, const int& jetFlavour, const float & w);
 
   // final computation, plotting, printing .......
   void createPlotsForFinalize();

--- a/DQMOffline/RecoB/interface/MVAJetTagPlotter.h
+++ b/DQMOffline/RecoB/interface/MVAJetTagPlotter.h
@@ -22,8 +22,8 @@ class MVAJetTagPlotter : public BaseTagInfoPlotter {
 
   ~MVAJetTagPlotter ();
 
-  virtual void analyzeTag (const std::vector<const reco::BaseTagInfo *> & baseTagInfos, const int & jetFlavour);
-  virtual void analyzeTag (const std::vector<const reco::BaseTagInfo *> & baseTagInfos, const int & jetFlavour, const float & w);
+  virtual void analyzeTag (const std::vector<const reco::BaseTagInfo *> & baseTagInfos, const double & jec, const int & jetFlavour);
+  virtual void analyzeTag (const std::vector<const reco::BaseTagInfo *> & baseTagInfos, const double & jec, const int & jetFlavour, const float & w);
 
   virtual void finalize ();
 

--- a/DQMOffline/RecoB/interface/SoftLeptonTagPlotter.h
+++ b/DQMOffline/RecoB/interface/SoftLeptonTagPlotter.h
@@ -15,8 +15,8 @@ public:
   
   ~SoftLeptonTagPlotter( void ) ;
 
-  void analyzeTag (const reco::BaseTagInfo * baseTagInfo, const int & jetFlavour);
-  void analyzeTag (const reco::BaseTagInfo * baseTagInfo, const int & jetFlavour, const float & w);
+  void analyzeTag (const reco::BaseTagInfo * baseTagInfo, const double & jec, const int & jetFlavour);
+  void analyzeTag (const reco::BaseTagInfo * baseTagInfo, const double & jec, const int & jetFlavour, const float & w);
 
   virtual void finalize( void ) {}
 

--- a/DQMOffline/RecoB/interface/TaggingVariablePlotter.h
+++ b/DQMOffline/RecoB/interface/TaggingVariablePlotter.h
@@ -24,11 +24,11 @@ class TaggingVariablePlotter : public BaseTagInfoPlotter {
 
   ~TaggingVariablePlotter () ;
 
-  void analyzeTag (const reco::BaseTagInfo * baseTagInfo, const int & jetFlavour);
+  void analyzeTag (const reco::BaseTagInfo * baseTagInfo, const double & jec, const int & jetFlavour);
 
   void analyzeTag (const reco::TaggingVariableList & variables, const int & jetFlavour);
 
-  void analyzeTag (const reco::BaseTagInfo * baseTagInfo, const int & jetFlavour, const float & w);
+  void analyzeTag (const reco::BaseTagInfo * baseTagInfo, const double & jec, const int & jetFlavour, const float & w);
 
   void analyzeTag (const reco::TaggingVariableList & variables, const int & jetFlavour, const float & w);
 

--- a/DQMOffline/RecoB/interface/TrackCountingTagPlotter.h
+++ b/DQMOffline/RecoB/interface/TrackCountingTagPlotter.h
@@ -18,8 +18,8 @@ class TrackCountingTagPlotter : public BaseTagInfoPlotter {
 
   ~TrackCountingTagPlotter () ;
 
-  void analyzeTag (const reco::BaseTagInfo * baseTagInfo, const int & jetFlavour);
-  void analyzeTag (const reco::BaseTagInfo * baseTagInfo, const int & jetFlavour, const float & w);
+  void analyzeTag (const reco::BaseTagInfo * baseTagInfo, const double & jec, const int & jetFlavour);
+  void analyzeTag (const reco::BaseTagInfo * baseTagInfo, const double & jec, const int & jetFlavour, const float & w);
 
   virtual void finalize ();
   virtual void createPlotsForFinalize ();

--- a/DQMOffline/RecoB/interface/TrackIPTagPlotter.h
+++ b/DQMOffline/RecoB/interface/TrackIPTagPlotter.h
@@ -19,8 +19,8 @@ class TrackIPTagPlotter : public BaseTagInfoPlotter {
 
   ~TrackIPTagPlotter () ;
 
-  void analyzeTag (const reco::BaseTagInfo * baseTagInfo, const int & jetFlavour);
-  void analyzeTag (const reco::BaseTagInfo * baseTagInfo, const int & jetFlavour, const float & w);
+  void analyzeTag (const reco::BaseTagInfo * baseTagInfo, const double & jec, const int & jetFlavour);
+  void analyzeTag (const reco::BaseTagInfo * baseTagInfo, const double & jec, const int & jetFlavour, const float & w);
 
   virtual void createPlotsForFinalize ();
   virtual void finalize ();

--- a/DQMOffline/RecoB/interface/TrackProbabilityTagPlotter.h
+++ b/DQMOffline/RecoB/interface/TrackProbabilityTagPlotter.h
@@ -19,9 +19,9 @@ class TrackProbabilityTagPlotter : public BaseTagInfoPlotter {
 
   ~TrackProbabilityTagPlotter () ;
 
-  void analyzeTag (const reco::BaseTagInfo * tagInfo, const int & jetFlavour);
+  void analyzeTag (const reco::BaseTagInfo * tagInfo, const double & jec, const int & jetFlavour);
 
-  void analyzeTag (const reco::BaseTagInfo * tagInfo, const int & jetFlavour, const float & w);
+  void analyzeTag (const reco::BaseTagInfo * tagInfo, const double & jec, const int & jetFlavour, const float & w);
 
   virtual void createPlotsForFinalize ();
   virtual void finalize ();

--- a/DQMOffline/RecoB/plugins/BTagPerformanceAnalyzerOnData.h
+++ b/DQMOffline/RecoB/plugins/BTagPerformanceAnalyzerOnData.h
@@ -20,6 +20,7 @@
 #include "DQMOffline/RecoB/interface/Tools.h"
 #include "DataFormats/JetReco/interface/Jet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
 
 #include <string>
 #include <vector>
@@ -39,6 +40,8 @@ class BTagPerformanceAnalyzerOnData : public edm::EDAnalyzer {
 
       ~BTagPerformanceAnalyzerOnData();
 
+      void beginRun(const edm::Run & run, const edm::EventSetup & es);
+
       virtual void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup);
 
       void endRun(const edm::Run & run, const edm::EventSetup & es);
@@ -53,7 +56,7 @@ class BTagPerformanceAnalyzerOnData : public edm::EDAnalyzer {
   };
 
   // Get histogram plotting options from configuration.
-  void bookHistos(const edm::ParameterSet& pSet);
+  void bookHistos();
   EtaPtBin getEtaPtBin(const int& iEta, const int& iPt);
 
   std::vector<std::string> tiDataFormatType;
@@ -62,6 +65,8 @@ class BTagPerformanceAnalyzerOnData : public edm::EDAnalyzer {
   std::vector<double> etaRanges, ptRanges;
   bool produceEps, producePs;
   std::string psBaseName, epsBaseName, inputFile;
+  std::string JECsource;
+  bool doJEC;
   bool update, allHisto;
   bool finalize;
   bool finalizeOnly;
@@ -79,6 +84,13 @@ class BTagPerformanceAnalyzerOnData : public edm::EDAnalyzer {
   std::map<BaseTagInfoPlotter*, size_t> binTagInfoPlottersToModuleConfig;
 
   unsigned int mcPlots_;
+
+  //add consumes
+  edm::EDGetTokenT<GenEventInfoProduct> genToken;
+  edm::EDGetTokenT<reco::SoftLeptonTagInfoCollection> slInfoToken;
+  std::vector< edm::EDGetTokenT<reco::JetTagCollection> > jetTagToken;
+  std::vector< std::pair<edm::EDGetTokenT<reco::JetTagCollection>, edm::EDGetTokenT<reco::JetTagCollection>> > tagCorrelationToken;
+  std::vector<std::vector <edm::EDGetTokenT<edm::View<reco::BaseTagInfo>> >> tagInfoToken;
 
 };
 

--- a/DQMOffline/RecoB/python/bTagCommon_cff.py
+++ b/DQMOffline/RecoB/python/bTagCommon_cff.py
@@ -49,7 +49,10 @@ bTagCommonBlock = cms.PSet(
     ptRecJetMax = cms.double(40000.0),
     ptPartonMax = cms.double(99999.0),
     producePs = cms.bool(False),
-    inputfile = cms.string('')
+    inputfile = cms.string(''),
+    doJetID = cms.bool(False),
+    doJEC = cms.bool(False),
+    JECsource = cms.string("ak5PFCHSL1FastL2L3")
 )
 
 

--- a/DQMOffline/RecoB/python/bTagSequences_cff.py
+++ b/DQMOffline/RecoB/python/bTagSequences_cff.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
 #define you jet ID
-jetID = cms.InputTag("ak5PFJets")
-
+jetID = cms.InputTag("ak5PFJetsCHS")
+corr = 'ak5PFCHSL1FastL2L3'
 #JTA for your jets
 from RecoJets.JetAssociationProducers.j2tParametersVX_cfi import *
 myak5JetTracksAssociatorAtVertex = cms.EDProducer("JetTracksAssociatorAtVertex",
@@ -42,15 +42,37 @@ bTagHLT  = hltHighLevel.clone(TriggerResultsTag = "TriggerResults::HLT", HLTPath
 #for the  use of JEC, could change with time : be careful if recommandations change for the correctors
 #define you sequence like  process.JECAlgo = cms.Sequence(process.ak5PFJetsJEC * process.PFJetsFilter)
 JetCut=cms.string("neutralHadronEnergyFraction < 0.99 && neutralEmEnergyFraction < 0.99 && nConstituents > 1 && chargedHadronEnergyFraction > 0.0 && chargedMultiplicity > 0.0 && chargedEmEnergyFraction < 0.99")
+#JetCut=cms.string("chargedEmEnergyFraction < 99999")
 
 from JetMETCorrections.Configuration.DefaultJEC_cff import *
-ak5PFJetsJEC = ak5PFJetsL2L3.clone(
-        src = 'ak5PFJets',
-        correctors = ['ak5PFL2L3']
-        )
+from JetMETCorrections.Configuration.JetCorrectionServices_cff import *
+ak5PFchsL1Fastjet = ak5PFL1Fastjet.clone(algorithm='AK5PFchs', srcRho=cms.InputTag('kt6PFJets','rho'))
+ak5PFchsL2Relative = ak5PFL2Relative.clone( algorithm = 'AK5PFchs' )
+ak5PFchsL3Absolute = ak5PFL3Absolute.clone( algorithm = 'AK5PFchs' )
+ak5PFchsResidual = ak5PFResidual.clone( algorithm = 'AK5PFchs' )
+ak5PFCHSL2L3 = cms.ESProducer(
+        'JetCorrectionESChain',
+            correctors = cms.vstring('ak5PFchsL2Relative','ak5PFchsL3Absolute')
+            )
+ak5PFCHSL2L3Residual = cms.ESProducer(
+        'JetCorrectionESChain',
+            correctors = cms.vstring('ak5PFchsL2Relative','ak5PFchsL3Absolute','ak5PFchsResidual')
+            )
+ak5PFCHSL1FastL2L3 = cms.ESProducer(
+        'JetCorrectionESChain',
+            correctors = cms.vstring('ak5PFchsL1Fastjet','ak5PFchsL2Relative','ak5PFchsL3Absolute')
+            )
+ak5PFCHSL1FastL2L3Residual = cms.ESProducer(
+        'JetCorrectionESChain',
+            correctors = cms.vstring('ak5PFchsL1Fastjet','ak5PFchsL2Relative','ak5PFchsL3Absolute','ak5PFchsResidual')
+            )
+
+ak5JetsJEC = ak5PFJetsL2L3.clone(
+        src = jetID,
+        correctors = [corr]        )
 
 PFJetsFilter = cms.EDFilter("PFJetSelector",
-                            src = cms.InputTag("ak5PFJetsJEC"),
+                            src = cms.InputTag("ak5JetsJEC"),
                             cut = JetCut,
                             filter = cms.bool(True)
                             )

--- a/DQMOffline/RecoB/python/dqmAnalyzer_cff.py
+++ b/DQMOffline/RecoB/python/dqmAnalyzer_cff.py
@@ -1,269 +1,64 @@
 import FWCore.ParameterSet.Config as cms
 
+#not useful anymore for b-tagging but used in some other sequences
+#from JetMETCorrections.Configuration.JetCorrectionServices_cff import ak5PFL2L3,ak5PFL2Relative,ak5PFL3Absolute
+
+#JEC for CHS
+from JetMETCorrections.Configuration.JetCorrectionServices_cff import ak5PFL1Fastjet, ak5PFL2Relative, ak5PFL3Absolute, ak5PFResidual, ak5PFL1FastL2L3, ak5PFL1FastL2L3Residual
+newak5PFCHSL1Fastjet = ak5PFL1Fastjet.clone(algorithm = 'AK5PFchs')
+newak5PFCHSL2Relative = ak5PFL2Relative.clone(algorithm = 'AK5PFchs')
+newak5PFCHSL3Absolute = ak5PFL3Absolute.clone(algorithm = 'AK5PFchs')
+newak5PFCHSResidual = ak5PFResidual.clone(algorithm = 'AK5PFchs')
+
+newak5PFCHSL1FastL2L3 = ak5PFL1FastL2L3.clone(correctors = cms.vstring('newak5PFCHSL1Fastjet','newak5PFCHSL2Relative','newak5PFCHSL3Absolute'))
+newak5PFCHSL1FastL2L3Residual = ak5PFL1FastL2L3Residual.clone(correctors = cms.vstring('newak5PFCHSL1Fastjet','newak5PFCHSL2Relative','newak5PFCHSL3Absolute','newak5PFCHSResidual'))
+
+######### DATA ############
 from DQMOffline.RecoB.bTagAnalysisData_cfi import *
-calobTagAnalysis = bTagAnalysis.clone()
-bTagPlots = cms.Sequence(calobTagAnalysis)
-calobTagAnalysis.finalizePlots = False
-calobTagAnalysis.finalizeOnly = False
-
-
-#Jet collection
-JetCut=cms.string("neutralHadronEnergyFraction < 0.99 && neutralEmEnergyFraction < 0.99 && nConstituents > 1 && chargedHadronEnergyFraction > 0.0 && chargedMultiplicity > 0.0 && chargedEmEnergyFraction < 0.99")
-
-from JetMETCorrections.Configuration.JetCorrectionServices_cff import ak5PFL2L3,ak5PFL2Relative,ak5PFL3Absolute
-newAk5PFL2L3 = ak5PFL2L3.clone()
-
-from JetMETCorrections.Configuration.DefaultJEC_cff import ak5PFJetsL2L3
-ak5PFJetsJEC = ak5PFJetsL2L3.clone(
-    correctors = ['newAk5PFL2L3']
-    )
-
-PFJetsFilter = cms.EDFilter("PFJetSelector",
-                            src = cms.InputTag("ak5PFJetsJEC"),
-                            cut = JetCut,
-                            filter = cms.bool(False)
-                            )
-
-jetID = cms.InputTag("PFJetsFilter")
-
-#JTA
-from RecoJets.JetAssociationProducers.ak5JTA_cff import *
-pfAk5JetTracksAssociatorAtVertex = ak5JetTracksAssociatorAtVertex.clone(jets = jetID)
-
-#btag sequence
-from RecoBTag.Configuration.RecoBTag_cff import *
-
-pfImpactParameterTagInfos = impactParameterTagInfos.clone(jetTracks = cms.InputTag("pfAk5JetTracksAssociatorAtVertex"))
-pfSecondaryVertexTagInfos = secondaryVertexTagInfos.clone(trackIPTagInfos = "pfImpactParameterTagInfos")
-
-pfTrackCountingHighEffBJetTags = trackCountingHighEffBJetTags.clone(tagInfos = cms.VInputTag(cms.InputTag("pfImpactParameterTagInfos")))
-pfTrackCountingHighPurBJetTags = trackCountingHighPurBJetTags.clone(tagInfos = cms.VInputTag(cms.InputTag("pfImpactParameterTagInfos")))
-
-pfJetProbabilityBJetTags = jetProbabilityBJetTags.clone(tagInfos = cms.VInputTag(cms.InputTag("pfImpactParameterTagInfos")))
-pfJetBProbabilityBJetTags = jetBProbabilityBJetTags.clone(tagInfos = cms.VInputTag(cms.InputTag("pfImpactParameterTagInfos")))
-
-pfSimpleSecondaryVertexHighEffBJetTags = simpleSecondaryVertexHighEffBJetTags.clone(tagInfos = cms.VInputTag(cms.InputTag("pfSecondaryVertexTagInfos")))
-pfSimpleSecondaryVertexHighPurBJetTags = simpleSecondaryVertexHighPurBJetTags.clone(tagInfos = cms.VInputTag(cms.InputTag("pfSecondaryVertexTagInfos")))
-
-pfGhostTrackVertexTagInfos = pfSecondaryVertexTagInfos.clone()
-pfGhostTrackVertexTagInfos.vertexReco = ghostTrackVertexRecoBlock.vertexReco
-pfGhostTrackVertexTagInfos.vertexCuts.multiplicityMin = 1
-pfGhostTrackBJetTags = ghostTrackBJetTags.clone(
-    tagInfos = cms.VInputTag(cms.InputTag("pfImpactParameterTagInfos"),
-                             cms.InputTag("pfGhostTrackVertexTagInfos"))
-    )
-
-pfCombinedSecondaryVertexBJetTags = combinedSecondaryVertexBJetTags.clone(
-    tagInfos = cms.VInputTag(cms.InputTag("pfImpactParameterTagInfos"),
-                             cms.InputTag("pfSecondaryVertexTagInfos"))
-    )
-pfCombinedSecondaryVertexMVABJetTags = combinedSecondaryVertexMVABJetTags.clone(
-    tagInfos = cms.VInputTag(cms.InputTag("pfImpactParameterTagInfos"),
-                             cms.InputTag("pfSecondaryVertexTagInfos"))
-    )
-
-pfSoftPFMuonsTagInfos = softPFMuonsTagInfos.clone(jets = jetID)
-pfSoftPFElectronsTagInfos = softPFElectronsTagInfos.clone(jets = jetID)
-pfSoftPFMuonBJetTags = softPFMuonBJetTags.clone(tagInfos = cms.VInputTag(cms.InputTag("pfSoftPFMuonsTagInfos")))
-pfSoftPFElectronBJetTags = softPFElectronBJetTags.clone(tagInfos = cms.VInputTag(cms.InputTag("pfSoftPFElectronsTagInfos")))
-
-pfbtagging = cms.Sequence(
-    pfImpactParameterTagInfos *
-    ( pfTrackCountingHighEffBJetTags +
-      pfTrackCountingHighPurBJetTags +
-      pfJetProbabilityBJetTags +
-      pfJetBProbabilityBJetTags +
-      
-      pfSecondaryVertexTagInfos *
-      ( pfSimpleSecondaryVertexHighEffBJetTags +
-        pfSimpleSecondaryVertexHighPurBJetTags +
-        pfCombinedSecondaryVertexBJetTags +
-        pfCombinedSecondaryVertexMVABJetTags
-        ) +
-      pfGhostTrackVertexTagInfos *
-      pfGhostTrackBJetTags
-      ) +
-    
-    #softPFLeptonsTagInfos*
-    pfSoftPFMuonsTagInfos*
-    pfSoftPFElectronsTagInfos*
-    pfSoftPFElectronBJetTags*
-    pfSoftPFMuonBJetTags 
-)
-
-
-#preSeq
-prebTagSequence = cms.Sequence(ak5PFJetsJEC*PFJetsFilter*pfAk5JetTracksAssociatorAtVertex*pfbtagging)
-
-# Module execution for data
-#from DQMOffline.RecoB.bTagAnalysisData_cfi import *
-pfbTagAnalysis = bTagAnalysis.clone(
-    tagConfig = cms.VPSet(
-       cms.PSet(
-           bTagTrackIPAnalysisBlock,
-           type = cms.string('TrackIP'),
-           label = cms.InputTag("pfImpactParameterTagInfos"),
-           folder = cms.string("IPTag")
-           ),
-       cms.PSet(
-           bTagCombinedSVAnalysisBlock,
-           ipTagInfos = cms.InputTag("pfImpactParameterTagInfos"),
-           type = cms.string('GenericMVA'),
-           svTagInfos = cms.InputTag("pfSecondaryVertexTagInfos"),
-           label = cms.InputTag("combinedSecondaryVertex"),
-           folder = cms.string("CSVTag")
-           ),
-       cms.PSet(
-           bTagTrackCountingAnalysisBlock,
-           label = cms.InputTag("pfTrackCountingHighEffBJetTags"),
-           folder = cms.string("TCHE")
-           ),
-       cms.PSet(
-           bTagTrackCountingAnalysisBlock,
-           label = cms.InputTag("pfTrackCountingHighPurBJetTags"),
-           folder = cms.string("TCHP")
-           ),
-       cms.PSet(
-           bTagProbabilityAnalysisBlock,
-           label = cms.InputTag("pfJetProbabilityBJetTags"),
-           folder = cms.string("JP")
-           ),
-       cms.PSet(
-           bTagBProbabilityAnalysisBlock,
-           label = cms.InputTag("pfJetBProbabilityBJetTags"),
-           folder = cms.string("JBP")
-           ),
-       cms.PSet(
-           bTagSimpleSVAnalysisBlock,
-           label = cms.InputTag("pfSimpleSecondaryVertexHighEffBJetTags"),
-           folder = cms.string("SSVHE")
-           ),
-       cms.PSet(
-           bTagSimpleSVAnalysisBlock,
-           label = cms.InputTag("pfSimpleSecondaryVertexHighPurBJetTags"),
-           folder = cms.string("SSVHP")
-           ),
-       cms.PSet(
-           bTagGenericAnalysisBlock,
-           label = cms.InputTag("pfCombinedSecondaryVertexBJetTags"),
-           folder = cms.string("CSV")
-           ),
-       cms.PSet(
-           bTagGenericAnalysisBlock,
-           label = cms.InputTag("pfCombinedSecondaryVertexMVABJetTags"),
-           folder = cms.string("CSVMVA")
-           ),
-       cms.PSet(
-           bTagGenericAnalysisBlock,
-           label = cms.InputTag("pfGhostTrackBJetTags"),
-           folder = cms.string("GhTrk")
-           ),
-       cms.PSet(
-           bTagSoftLeptonAnalysisBlock,
-           label = cms.InputTag("pfSoftPFMuonBJetTags"),
-           folder = cms.string("SMT")
-           ),
-       cms.PSet(
-           bTagSoftLeptonAnalysisBlock,
-           label = cms.InputTag("pfSoftPFElectronBJetTags"),
-           folder = cms.string("SET")
-           ),
-       ),
-    )
-pfbTagAnalysis.finalizePlots = False
-pfbTagAnalysis.finalizeOnly = False
-pfbTagAnalysis.ptRanges = cms.vdouble(0.0)
-bTagPlotsDATA = cms.Sequence(pfbTagAnalysis)
-
+bTagAnalysis.finalizePlots = False
+bTagAnalysis.finalizeOnly = False
+bTagAnalysis.ptRanges = cms.vdouble(0.0)
+#Residual correction will be added inside the c++ code only for data (checking the presence of genParticles collection), not explicit here as this sequence also ran on MC FullSim
+bTagAnalysis.doJetID = True
+bTagAnalysis.doJEC = True
+bTagAnalysis.JECsource = cms.string("newak5PFCHSL1FastL2L3") 
+bTagPlotsDATA = cms.Sequence(bTagAnalysis)
 
 ########## MC ############
 #Matching
 from PhysicsTools.JetMCAlgos.CaloJetsMCFlavour_cfi import *
-AK5byRef.jets = jetID
+AK5byRef.jets = cms.InputTag("ak5PFJetsCHS")
+#Get gen jet collection for real jets
+ak5GenJetsForPUid = cms.EDFilter("GenJetSelector",
+                                 src = cms.InputTag("ak5GenJets"),
+                                 cut = cms.string('pt > 8.'),
+                                 filter = cms.bool(False)
+                                 )
+#do reco gen - reco matching
+from PhysicsTools.PatAlgos.mcMatchLayer0.jetMatch_cfi import patJetGenJetMatch
+newpatJetGenJetMatch = patJetGenJetMatch.clone(
+    src = cms.InputTag("ak5PFJetsCHS"),
+    matched = cms.InputTag("ak5GenJetsForPUid"),
+    maxDeltaR = cms.double(0.25),
+    resolveAmbiguities = cms.bool(True)
+)
 
 # Module execution for MC
 from Validation.RecoB.bTagAnalysis_cfi import *
-pfbTagValidation = bTagValidation.clone(
-    tagConfig = cms.VPSet(
-       cms.PSet(
-           bTagTrackIPAnalysisBlock,
-           type = cms.string('TrackIP'),
-           label = cms.InputTag("pfImpactParameterTagInfos"),
-           folder = cms.string("IPTag")
-           ),
-       cms.PSet(
-           bTagCombinedSVAnalysisBlock,
-           ipTagInfos = cms.InputTag("pfImpactParameterTagInfos"),
-           type = cms.string('GenericMVA'),
-           svTagInfos = cms.InputTag("pfSecondaryVertexTagInfos"),
-           label = cms.InputTag("combinedSecondaryVertex"),
-           folder = cms.string("CSVTag")
-           ),
-       cms.PSet(
-           bTagTrackCountingAnalysisBlock,
-           label = cms.InputTag("pfTrackCountingHighEffBJetTags"),
-           folder = cms.string("TCHE")
-           ),
-       cms.PSet(
-           bTagTrackCountingAnalysisBlock,
-           label = cms.InputTag("pfTrackCountingHighPurBJetTags"),
-           folder = cms.string("TCHP")
-           ),
-       cms.PSet(
-           bTagProbabilityAnalysisBlock,
-           label = cms.InputTag("pfJetProbabilityBJetTags"),
-           folder = cms.string("JP")
-           ),
-       cms.PSet(
-           bTagBProbabilityAnalysisBlock,
-           label = cms.InputTag("pfJetBProbabilityBJetTags"),
-           folder = cms.string("JBP")
-           ),
-       cms.PSet(
-           bTagSimpleSVAnalysisBlock,
-           label = cms.InputTag("pfSimpleSecondaryVertexHighEffBJetTags"),
-           folder = cms.string("SSVHE")
-           ),
-       cms.PSet(
-           bTagSimpleSVAnalysisBlock,
-           label = cms.InputTag("pfSimpleSecondaryVertexHighPurBJetTags"),
-           folder = cms.string("SSVHP")
-           ),
-       cms.PSet(
-           bTagGenericAnalysisBlock,
-           label = cms.InputTag("pfCombinedSecondaryVertexBJetTags"),
-           folder = cms.string("CSV")
-           ),
-       cms.PSet(
-           bTagGenericAnalysisBlock,
-           label = cms.InputTag("pfCombinedSecondaryVertexMVABJetTags"),
-           folder = cms.string("CSVMVA")
-           ),
-       cms.PSet(
-           bTagGenericAnalysisBlock,
-           label = cms.InputTag("pfGhostTrackBJetTags"),
-           folder = cms.string("GhTrk")
-           ),
-       cms.PSet(
-           bTagSoftLeptonAnalysisBlock,
-           label = cms.InputTag("pfSoftPFMuonBJetTags"),
-           folder = cms.string("SMT")
-           ),
-       cms.PSet(
-           bTagSoftLeptonAnalysisBlock,
-           label = cms.InputTag("pfSoftPFElectronBJetTags"),
-           folder = cms.string("SET")
-           ),
-       ),
-    )
-pfbTagValidation.finalizePlots = False
-pfbTagValidation.finalizeOnly = False
-pfbTagValidation.jetMCSrc = 'AK5byValAlgo'
-pfbTagValidation.ptRanges = cms.vdouble(0.0)
-pfbTagValidation.etaRanges = cms.vdouble(0.0)
+bTagValidation.finalizePlots = False
+bTagValidation.finalizeOnly = False
+bTagValidation.jetMCSrc = 'AK5byValAlgo'
+bTagValidation.ptRanges = cms.vdouble(0.0)
+bTagValidation.etaRanges = cms.vdouble(0.0)
+bTagValidation.doJetID = True
+bTagValidation.doJEC = True
+bTagValidation.JECsource = cms.string("newak5PFCHSL1FastL2L3")
+bTagValidation.doPUid = cms.bool(True)
+bTagValidation.genJetsMatched = cms.InputTag("newpatJetGenJetMatch")
 #to run on fastsim
-bTagPlotsMC = cms.Sequence(myPartons*AK5Flavour*pfbTagValidation)
+prebTagSequenceMC = cms.Sequence(ak5GenJetsForPUid*newpatJetGenJetMatch*myPartons*AK5Flavour)
+bTagPlotsMC = cms.Sequence(bTagValidation)
 
 #to run on fullsim in the validation sequence, all histograms produced in the dqmoffline sequence
-pfbTagValidationNoall = pfbTagValidation.clone(flavPlots="noall")
-bTagPlotsMCbcl = cms.Sequence(myPartons*AK5Flavour*pfbTagValidationNoall)
+bTagValidationNoall = bTagValidation.clone(flavPlots="noall")
+bTagPlotsMCbcl = cms.Sequence(myPartons*AK5Flavour*bTagValidationNoall)

--- a/DQMOffline/RecoB/python/dqmCollector_cff.py
+++ b/DQMOffline/RecoB/python/dqmCollector_cff.py
@@ -3,17 +3,8 @@ import FWCore.ParameterSet.Config as cms
 from RecoBTag.Configuration.RecoBTag_cff import *
 from DQMOffline.RecoB.dqmAnalyzer_cff import *
 
-
-#Calo collector
-calobTagCollector = calobTagAnalysis.clone()
-# module execution
-bTagCollectorSequence = cms.Sequence(calobTagCollector)
-calobTagCollector.finalizePlots = True
-calobTagCollector.finalizeOnly = True
-
-
 #pf DATA collector
-bTagCollectorDATA = pfbTagAnalysis.clone()
+bTagCollectorDATA = bTagAnalysis.clone()
 # module execution
 bTagCollectorSequenceDATA = cms.Sequence(bTagCollectorDATA)
 bTagCollectorDATA.ptRanges = cms.vdouble(0.0)
@@ -22,7 +13,7 @@ bTagCollectorDATA.finalizeOnly = True
 
 
 #pf MC collector
-bTagCollectorMC = pfbTagAnalysis.clone(
+bTagCollectorMC = bTagAnalysis.clone(
     finalizePlots = True,
     finalizeOnly = True,
     mcPlots = 2, #harvest all, b, c, dusg and ni histos 

--- a/DQMOffline/RecoB/src/AcceptJet.cc
+++ b/DQMOffline/RecoB/src/AcceptJet.cc
@@ -1,37 +1,28 @@
 #include "DQMOffline/RecoB/interface/AcceptJet.h"
 #include "DataFormats/Math/interface/deltaR.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "DataFormats/JetReco/interface/PFJet.h"
 
 #include<iostream>
 
 using namespace std;
 
 AcceptJet::AcceptJet(const double& etaMin_, const double& etaMax_, const double& ptMin_, const double& ptMax_,
-          const double& pMin_, const double& pMax_, const double& ratioMin_, const double& ratioMax_) :
+		     const double& pMin_, const double& pMax_, const double& ratioMin_, const double& ratioMax_, const bool& doJetID_) :
   etaMin(etaMin_), etaMax(etaMax_), ptRecJetMin(ptMin_), ptRecJetMax(ptMax_), pRecJetMin(pMin_),
-  pRecJetMax(pMax_), ratioMin(ratioMin_), ratioMax(ratioMax_) {}
+  pRecJetMax(pMax_), ratioMin(ratioMin_), ratioMax(ratioMax_), doJetID(doJetID_) {}
 
 
-bool AcceptJet::operator() (const reco::Jet & jet, const int & jetFlavour, const edm::Handle<reco::SoftLeptonTagInfoCollection> & infos) const
+bool AcceptJet::operator() (const reco::Jet & jet, const edm::Handle<reco::SoftLeptonTagInfoCollection> & infos, const double jec) const
 {
-
-  // temporary fudge to correct for double loop error
-  //  jetPartonMomentum /= 2.0;
-
   if ( fabs(jet.eta()) < etaMin  ||
        fabs(jet.eta()) > etaMax  ) return false;
 
-//   if ( jetFlavour.underlyingParton4Vec().P() < pPartonMin  ||
-//        jetFlavour.underlyingParton4Vec().P() > pPartonMax  ) accept = false;
-// 
-//   if ( jetFlavour.underlyingParton4Vec().Pt() < ptPartonMin  ||
-//        jetFlavour.underlyingParton4Vec().Pt() > ptPartonMax  ) accept = false;
+  if ( jet.pt()*jec < ptRecJetMin ||
+       jet.pt()*jec > ptRecJetMax ) return false;
 
-  if ( jet.pt() < ptRecJetMin ||
-       jet.pt() > ptRecJetMax ) return false;
-
-  if ( jet.p() < pRecJetMin ||
-       jet.p() > pRecJetMax ) return false;
+  if ( jet.p()*jec < pRecJetMin ||
+       jet.p()*jec > pRecJetMax ) return false;
 
   if ( !infos.isValid() ) {
     edm::LogWarning("infos not valid") << "A valid SoftLeptonTagInfoCollection was not found!"
@@ -39,10 +30,30 @@ bool AcceptJet::operator() (const reco::Jet & jet, const int & jetFlavour, const
   }
   else {
     double pToEratio = ratio( jet, infos );
-    if ( pToEratio < ratioMin ||
-         pToEratio > ratioMax ) return false;
+    if ( pToEratio/jec < ratioMin ||
+         pToEratio/jec > ratioMax ) return false;
   }
 
+  if(doJetID){
+    const reco::PFJet * pfjet = dynamic_cast<const reco::PFJet *>(&jet);
+    if(pfjet) {
+      double neutralHadronEnergyFraction = pfjet->neutralHadronEnergy()/(jet.energy()*jec);
+      double neutralEmEnergyFraction = pfjet->neutralEmEnergy()/(jet.energy()*jec);
+      int nConstituents = pfjet->getPFConstituents().size();
+      double chargedHadronEnergyFraction = pfjet->chargedHadronEnergy()/(jet.energy()*jec);
+      int chargedMultiplicity = pfjet->chargedMultiplicity();
+      double chargedEmEnergyFraction = pfjet->chargedEmEnergy()/(jet.energy()*jec);
+      if(!(neutralHadronEnergyFraction < 0.99 
+	   && neutralEmEnergyFraction < 0.99 
+	   && nConstituents > 1 
+	   && chargedHadronEnergyFraction > 0.0 
+	   && chargedMultiplicity > 0.0 
+	   && chargedEmEnergyFraction < 0.99)) 
+	return false; //2012 values
+    }
+    else std::cout<<"Jets are not PF jets, put 'doJetID' to False."<<std::endl;
+  }
+  
   return true;
 }
 

--- a/DQMOffline/RecoB/src/BTagDifferentialPlot.cc
+++ b/DQMOffline/RecoB/src/BTagDifferentialPlot.cc
@@ -31,7 +31,8 @@ BTagDifferentialPlot::BTagDifferentialPlot (const double& bEff, const ConstVarTy
 	theDifferentialHistoB_g    ( 0 ) ,
 	theDifferentialHistoB_ni   ( 0 ) ,
 	theDifferentialHistoB_dus  ( 0 ) ,
-	theDifferentialHistoB_dusg ( 0 )  {}
+	theDifferentialHistoB_dusg ( 0 ) ,
+	theDifferentialHistoB_pu   ( 0 ) {}
 
 
 BTagDifferentialPlot::~BTagDifferentialPlot () {
@@ -259,6 +260,7 @@ void BTagDifferentialPlot::bookHisto () {
   theDifferentialHistoB_ni   = (prov.book1D ( "NI_"   + commonName , "NI_"   + commonName , nBins , binArray )) ;
   theDifferentialHistoB_dus  = (prov.book1D ( "DUS_"  + commonName , "DUS_"  + commonName , nBins , binArray )) ;
   theDifferentialHistoB_dusg = (prov.book1D ( "DUSG_" + commonName , "DUSG_" + commonName , nBins , binArray )) ;
+  theDifferentialHistoB_pu   = (prov.book1D ( "PU_"   + commonName , "PU_"   + commonName , nBins , binArray )) ;
 }
 
 
@@ -304,6 +306,7 @@ void BTagDifferentialPlot::fillHisto () {
     effPurDifferentialPairs.push_back ( make_pair ( currentEffPurFromHistos->getEffFlavVsBEff_ni()   , theDifferentialHistoB_ni ->getTH1F()  ) ) ;
     effPurDifferentialPairs.push_back ( make_pair ( currentEffPurFromHistos->getEffFlavVsBEff_dus()  , theDifferentialHistoB_dus->getTH1F()  ) ) ;
     effPurDifferentialPairs.push_back ( make_pair ( currentEffPurFromHistos->getEffFlavVsBEff_dusg() , theDifferentialHistoB_dusg->getTH1F() ) ) ;
+    effPurDifferentialPairs.push_back ( make_pair ( currentEffPurFromHistos->getEffFlavVsBEff_pu()   , theDifferentialHistoB_pu->getTH1F()   ) ) ;
 
     for ( vector< pair<TH1F*,TH1F*> >::const_iterator itP  = effPurDifferentialPairs.begin() ;
 	                                              itP != effPurDifferentialPairs.end()   ; ++itP ) {

--- a/DQMOffline/RecoB/src/BaseTagInfoPlotter.cc
+++ b/DQMOffline/RecoB/src/BaseTagInfoPlotter.cc
@@ -9,36 +9,36 @@
 using namespace std;
 using namespace reco;
 
-void BaseTagInfoPlotter::analyzeTag(const BaseTagInfo * tagInfo, const int & jetFlavour)
+void BaseTagInfoPlotter::analyzeTag(const BaseTagInfo * tagInfo, const double & jec, const int & jetFlavour)
 {
   throw cms::Exception("MissingVirtualMethod")
   	<< "No analyzeTag method overloaded from BaseTagInfoPlotter." << endl;
 }
 
-void BaseTagInfoPlotter::analyzeTag(const BaseTagInfo * tagInfo, const int & jetFlavour, const float & w)
+void BaseTagInfoPlotter::analyzeTag(const BaseTagInfo * tagInfo, const double & jec, const int & jetFlavour, const float & w)
 {
   throw cms::Exception("MissingVirtualMethod")
   	<< "No analyzeTag method overloaded from BaseTagInfoPlotter." << endl;
 }
 
-void BaseTagInfoPlotter::analyzeTag(const vector<const BaseTagInfo *> &tagInfos, const int & jetFlavour, const float & w)
+void BaseTagInfoPlotter::analyzeTag(const vector<const BaseTagInfo *> &tagInfos, const double & jec, const int & jetFlavour, const float & w)
 {
 
   if (tagInfos.size() != 1)
     throw cms::Exception("MismatchedTagInfos")
     	<< tagInfos.size() << " BaseTagInfos passed, but only one expected." << endl;
 
-  analyzeTag(tagInfos.front(), jetFlavour, w);
+  analyzeTag(tagInfos.front(), jec, jetFlavour, w);
 
 }
 
-void BaseTagInfoPlotter::analyzeTag(const vector<const BaseTagInfo *> &tagInfos, const int & jetFlavour)
+void BaseTagInfoPlotter::analyzeTag(const vector<const BaseTagInfo *> &tagInfos, const double & jec, const int & jetFlavour)
 {
   if (tagInfos.size() != 1)
     throw cms::Exception("MismatchedTagInfos")
       << tagInfos.size() << " BaseTagInfos passed, but only one expected." << endl;
   
-  analyzeTag(tagInfos.front(), jetFlavour);
+  analyzeTag(tagInfos.front(), jec, jetFlavour);
 }
 
 void BaseTagInfoPlotter::setEventSetup(const edm::EventSetup & setup)

--- a/DQMOffline/RecoB/src/EffPurFromHistos.cc
+++ b/DQMOffline/RecoB/src/EffPurFromHistos.cc
@@ -18,14 +18,16 @@ using namespace RecoBTag;
 
 
 EffPurFromHistos::EffPurFromHistos ( const std::string & ext, TH1F * h_d, TH1F * h_u,
-	TH1F * h_s, TH1F * h_c, TH1F * h_b, TH1F * h_g,	TH1F * h_ni,
-	TH1F * h_dus, TH1F * h_dusg, const std::string& label, const unsigned int& mc, int nBin, double startO, double endO) :
+				     TH1F * h_s, TH1F * h_c, TH1F * h_b, TH1F * h_g,	TH1F * h_ni,
+				     TH1F * h_dus, TH1F * h_dusg, TH1F * h_pu, 
+				     const std::string& label, const unsigned int& mc, int nBin, double startO, double endO) :
 	//BTagPlotPrintC(),
         fromDiscriminatorDistr(false),
 	histoExtension(ext), effVersusDiscr_d(h_d), effVersusDiscr_u(h_u),
 	effVersusDiscr_s(h_s), effVersusDiscr_c(h_c), effVersusDiscr_b(h_b),
 	effVersusDiscr_g(h_g), effVersusDiscr_ni(h_ni), effVersusDiscr_dus(h_dus),
-	effVersusDiscr_dusg(h_dusg), nBinOutput(nBin), startOutput(startO),
+	effVersusDiscr_dusg(h_dusg), effVersusDiscr_pu(h_pu), 
+	nBinOutput(nBin), startOutput(startO),
 	endOutput(endO),  mcPlots_(mc), label_(label)
 {
   // consistency check
@@ -71,6 +73,7 @@ EffPurFromHistos::EffPurFromHistos
     effVersusDiscr_b =    discrCutEfficScan->histo_b   ();
     effVersusDiscr_ni =   discrCutEfficScan->histo_ni  ();
     effVersusDiscr_dusg = discrCutEfficScan->histo_dusg();
+    effVersusDiscr_pu = discrCutEfficScan->histo_pu();
 
   
     if(mcPlots_>2){
@@ -93,6 +96,8 @@ EffPurFromHistos::EffPurFromHistos
     effVersusDiscr_ni->GetXaxis()->SetTitleOffset ( 0.75 );
     effVersusDiscr_dusg->SetXTitle ( "Discriminant" );
     effVersusDiscr_dusg->GetXaxis()->SetTitleOffset ( 0.75 );
+    effVersusDiscr_pu->SetXTitle ( "Discriminant" );
+    effVersusDiscr_pu->GetXaxis()->SetTitleOffset ( 0.75 );
   }
   else{
     effVersusDiscr_d =    0;
@@ -104,6 +109,7 @@ EffPurFromHistos::EffPurFromHistos
     effVersusDiscr_ni =   0;
     effVersusDiscr_dus =  0;
     effVersusDiscr_dusg = 0;
+    effVersusDiscr_pu = 0;
   }
 
   // discr. for computation
@@ -283,6 +289,7 @@ void EffPurFromHistos::plot (TPad * plotCanvas /* = 0 */) {
   EffFlavVsBEff_b ->getTH1F()-> SetMinimum(0.01);
   EffFlavVsBEff_ni ->getTH1F()-> SetMinimum(0.01);
   EffFlavVsBEff_dusg ->getTH1F()-> SetMinimum(0.01);
+  EffFlavVsBEff_pu ->getTH1F()-> SetMinimum(0.01);
 
   // plot separately u,d and s
 //  EffFlavVsBEff_d ->GetXaxis()->SetTitle ( "b-jet efficiency" );
@@ -343,6 +350,7 @@ void EffPurFromHistos::check () {
   const int& nBins_b    = effVersusDiscr_b    -> GetNbinsX();
   const int& nBins_ni   = effVersusDiscr_ni   -> GetNbinsX();
   const int& nBins_dusg = effVersusDiscr_dusg -> GetNbinsX();
+  const int& nBins_pu   = effVersusDiscr_pu   -> GetNbinsX();
 
   const bool& lNBins =
     ( (nBins_d == nBins_u    &&
@@ -355,7 +363,8 @@ void EffPurFromHistos::check () {
        nBins_d == nBins_dusg)||
       (nBins_c == nBins_b    &&
        nBins_c == nBins_dusg &&
-       nBins_c == nBins_ni)    );
+       nBins_c == nBins_ni   &&
+       nBins_c == nBins_pu)    );
 
   if ( !lNBins ) {
     throw cms::Exception("Configuration")
@@ -380,6 +389,7 @@ void EffPurFromHistos::check () {
   const float& sBin_b    = effVersusDiscr_b    -> GetBinCenter(1);
   const float& sBin_ni   = effVersusDiscr_ni   -> GetBinCenter(1);
   const float& sBin_dusg = effVersusDiscr_dusg -> GetBinCenter(1);
+  const float& sBin_pu   = effVersusDiscr_pu   -> GetBinCenter(1);
 
   const bool& lSBin =
     ( (sBin_d == sBin_u    &&
@@ -392,7 +402,8 @@ void EffPurFromHistos::check () {
        sBin_d == sBin_dusg)||
       (sBin_c == sBin_b    &&
        sBin_c == sBin_dusg &&
-       sBin_c == sBin_ni)    );
+       sBin_c == sBin_ni   &&
+       sBin_c == sBin_pu)    );
 
   if ( !lSBin ) {
     throw cms::Exception("Configuration")
@@ -417,6 +428,7 @@ void EffPurFromHistos::check () {
   const float& eBin_b    = effVersusDiscr_b    -> GetBinCenter( nBins_d - 1 );
   const float& eBin_ni   = effVersusDiscr_ni   -> GetBinCenter( nBins_d - 1 );
   const float& eBin_dusg = effVersusDiscr_dusg -> GetBinCenter( nBins_d - 1 );
+  const float& eBin_pu   = effVersusDiscr_pu   -> GetBinCenter( nBins_d - 1 );
 
   const bool& lEBin =
     ( (eBin_d == eBin_u    &&
@@ -429,7 +441,8 @@ void EffPurFromHistos::check () {
        eBin_d == eBin_dusg)||
       (eBin_c == eBin_b    &&
        eBin_c == eBin_dusg &&
-       eBin_c == eBin_ni)     );
+       eBin_c == eBin_ni   &&
+       eBin_c == eBin_pu)     );
 
   if ( !lEBin ) {
     throw cms::Exception("Configuration")
@@ -451,6 +464,7 @@ void EffPurFromHistos::compute ()
     EffFlavVsBEff_ni = 0; 
     EffFlavVsBEff_dus = 0; 
     EffFlavVsBEff_dusg = 0; 
+    EffFlavVsBEff_pu = 0; 
     
     return; 
  
@@ -483,6 +497,7 @@ void EffPurFromHistos::compute ()
   EffFlavVsBEff_b    = (prov.book1D ( hB + "B"    + hE , hB + "B"    + hE , nBinOutput , startOutput , endOutput )) ;
   EffFlavVsBEff_ni   = (prov.book1D ( hB + "NI"   + hE , hB + "NI"   + hE , nBinOutput , startOutput , endOutput )) ;
   EffFlavVsBEff_dusg = (prov.book1D ( hB + "DUSG" + hE , hB + "DUSG" + hE , nBinOutput , startOutput , endOutput )) ;
+  EffFlavVsBEff_pu   = (prov.book1D ( hB + "PU"   + hE , hB + "PU"   + hE , nBinOutput , startOutput , endOutput )) ;
 
   if(mcPlots_>2){
     EffFlavVsBEff_d->getTH1F()->SetXTitle ( "b-jet efficiency" );
@@ -522,6 +537,10 @@ void EffPurFromHistos::compute ()
   EffFlavVsBEff_dusg->getTH1F()->SetYTitle ( "non b-jet efficiency" );
   EffFlavVsBEff_dusg->getTH1F()->GetXaxis()->SetTitleOffset ( 0.75 );
   EffFlavVsBEff_dusg->getTH1F()->GetYaxis()->SetTitleOffset ( 0.75 );
+  EffFlavVsBEff_pu->getTH1F()->SetXTitle ( "b-jet efficiency" );
+  EffFlavVsBEff_pu->getTH1F()->SetYTitle ( "non b-jet efficiency" );
+  EffFlavVsBEff_pu->getTH1F()->GetXaxis()->SetTitleOffset ( 0.75 );
+  EffFlavVsBEff_pu->getTH1F()->GetYaxis()->SetTitleOffset ( 0.75 );
 
 
   // loop over eff. vs. discriminator cut b-histo and look in which bin the closest entry is;
@@ -555,6 +574,7 @@ void EffPurFromHistos::compute ()
       EffFlavVsBEff_b    -> Fill ( effBMid , effVersusDiscr_b   ->GetBinContent ( binClosest ) );
       EffFlavVsBEff_ni   -> Fill ( effBMid , effVersusDiscr_ni  ->GetBinContent ( binClosest ) );
       EffFlavVsBEff_dusg -> Fill ( effBMid , effVersusDiscr_dusg->GetBinContent ( binClosest ) );
+      EffFlavVsBEff_pu   -> Fill ( effBMid , effVersusDiscr_pu  ->GetBinContent ( binClosest ) );
 
       if(mcPlots_>2){
 	EffFlavVsBEff_d  ->getTH1F()  -> SetBinError ( iBinB , effVersusDiscr_d   ->GetBinError ( binClosest ) );
@@ -567,6 +587,7 @@ void EffPurFromHistos::compute ()
       EffFlavVsBEff_b  ->getTH1F()  -> SetBinError ( iBinB , effVersusDiscr_b   ->GetBinError ( binClosest ) );
       EffFlavVsBEff_ni ->getTH1F()  -> SetBinError ( iBinB , effVersusDiscr_ni  ->GetBinError ( binClosest ) );
       EffFlavVsBEff_dusg->getTH1F() -> SetBinError ( iBinB , effVersusDiscr_dusg->GetBinError ( binClosest ) );
+      EffFlavVsBEff_pu ->getTH1F()  -> SetBinError ( iBinB , effVersusDiscr_pu  ->GetBinError ( binClosest ) );
     }
     else {
       //cout << "Did not find right bin for b-efficiency : " << effBMid << endl;

--- a/DQMOffline/RecoB/src/EtaPtBin.cc
+++ b/DQMOffline/RecoB/src/EtaPtBin.cc
@@ -41,9 +41,9 @@ std::string EtaPtBin::buildDescriptionString
   return descr;
 }
 
-bool EtaPtBin::inBin(const reco::Jet & jet) const
+bool EtaPtBin::inBin(const reco::Jet & jet, const double jec) const
 {
-  return inBin(jet.eta(), jet.pt());
+  return inBin(jet.eta(), jet.pt()*jec);
 }
 
 // bool EtaPtBin::inBin(const BTagMCTools::JetFlavour & jetFlavour) const

--- a/DQMOffline/RecoB/src/JetTagPlotter.cc
+++ b/DQMOffline/RecoB/src/JetTagPlotter.cc
@@ -24,7 +24,7 @@ JetTagPlotter::JetTagPlotter (const std::string & tagName, const EtaPtBin & etaP
 
   //added to count the number of jets by event : 0=DATA or NI, 1to5=quarks u,d,s,c,b , 6=gluon
   int nFl = 1;
-  if(mcPlots_) nFl = 7;
+  if(mcPlots_) nFl = 8;
   nJets = new int [nFl];
   for(int i = 0; i < nFl; i++){
     nJets[i]=0;
@@ -32,39 +32,18 @@ JetTagPlotter::JetTagPlotter (const std::string & tagName, const EtaPtBin & etaP
   
   if (mcPlots_){
     // jet flavour
+    //in case you want to add the parton kinematics: you have to use reco::JetFlavor class from the JetFlavourMatchingCollection
     dJetFlav = new FlavourHistograms<int>
       ("jetFlavour" + es, "Jet Flavour", 22, -0.5, 21.5,
        false, false, false, "b", update,jetTagDir, mcPlots_);
-    // associated parton momentum : commented, not really necessary
-    //dJetPartonMomentum = new FlavourHistograms<double>
-    //  ("associatedPartonMomentum" + es, "associated parton momentum",
-    //   200, 0.0, 400.0, false, false, true, "b", update,jetTagDir, mcPlots_);
-    
-    // associated parton pt : commented, not really necessary
-    //dJetPartonPt = new FlavourHistograms<double>
-    //  ("associatedPartonPt" + es, "associated parton pt",
-    //   200, 0.0, 400.0, false, false, true, "b", update,jetTagDir, mcPlots_);
-    
-    // associated parton eta : commented, not really necessary
-    //dJetPartonPseudoRapidity = new FlavourHistograms<double>
-    //  ("associatedPartonEta" + es, "associated parton eta",
-    //   100, -3.5, 3.5, false, false, true, "b", update,jetTagDir, mcPlots_);
   }else {
     dJetFlav=0;
-    //dJetPartonMomentum = 0;
-    //dJetPartonPt = 0;
-    //dJetPartonPseudoRapidity = 0;
   }
 
   // jet multiplicity
   JetMultiplicity = new FlavourHistograms<int>
     ("jetMultiplicity" + es, "Jet Multiplicity", 11, -0.5, 10.5,
      false, true, true, "b", update,jetTagDir, mcPlots_);
-
-  // track multiplicity in jet 
-  //dJetTrackMultiplicity = new FlavourHistograms<int>
-  //	("jetTrackMultiplicity" + es, "Jet Track Multiplicity", 31, -0.5, 30.5,
-  //	false, true, true, "b", update,jetTagDir, mcPlots_);
 
     // Discriminator: again with reasonable binning
   dDiscriminator = new FlavourHistograms<double>
@@ -99,15 +78,11 @@ JetTagPlotter::JetTagPlotter (const std::string & tagName, const EtaPtBin & etaP
 JetTagPlotter::~JetTagPlotter () {
   delete dJetFlav;
   delete JetMultiplicity;
-  //delete dJetTrackMultiplicity;
   delete dDiscriminator;
   delete dJetRecMomentum;
   delete dJetRecPt;
   delete dJetRecPseudoRapidity;
   delete dJetRecPhi;
-  //delete dJetPartonMomentum;
-  //delete dJetPartonPt;
-  //delete dJetPartonPseudoRapidity;
   if (finalized) {
     delete effPurFromHistos;
   }
@@ -117,15 +92,11 @@ void JetTagPlotter::epsPlot(const std::string & name)
 {
   dJetFlav->epsPlot(name);
   JetMultiplicity->epsPlot(name);
-  //dJetTrackMultiplicity->epsPlot(name);
   dDiscriminator->epsPlot(name);
   dJetRecMomentum->epsPlot(name);
   dJetRecPt->epsPlot(name);
   dJetRecPseudoRapidity->epsPlot(name);
   dJetRecPhi->epsPlot(name);
-  //dJetPartonMomentum->epsPlot(name);
-  //dJetPartonPt->epsPlot(name);
-  //dJetPartonPseudoRapidity->epsPlot(name);
   if (finalized) {
     effPurFromHistos->epsPlot(name);
   }
@@ -143,14 +114,12 @@ void JetTagPlotter::psPlot(const std::string & name)
   canvas.cd(1);
   dJetFlav->plot();
   canvas.cd(2);
-  //dJetTrackMultiplicity->plot();
-  canvas.cd(3);
   dDiscriminator->plot();
-  canvas.cd(4);
+  canvas.cd(3);
   dJetRecMomentum->plot();
-  canvas.cd(5);
+  canvas.cd(4);
   dJetRecPt->plot();
-  canvas.cd(6);
+  canvas.cd(5);
   dJetRecPseudoRapidity->plot();
   canvas.Print((name + cName + ".ps").c_str());
   canvas.Clear();
@@ -162,20 +131,14 @@ void JetTagPlotter::psPlot(const std::string & name)
 
   canvas.cd(1);
   dJetRecPhi->plot();
-  canvas.cd(2);
-  //dJetPartonMomentum->plot();
-  canvas.cd(3);
-  //dJetPartonPt->plot();
-  canvas.cd(4);
-  //dJetPartonPseudoRapidity->plot();
   if (finalized) {
-    canvas.cd(5);
+    canvas.cd(2);
     effPurFromHistos->discriminatorNoCutEffic()->plot();
-    canvas.cd(6);
+    canvas.cd(3);
     effPurFromHistos->discriminatorCutEfficScan()->plot();
     canvas.Print((name + cName + ".ps").c_str());
     canvas.Clear();
-    canvas.Divide(2,3);
+    canvas.Divide(1,3);
     canvas.cd(1);
     effPurFromHistos->plot();
   }
@@ -197,12 +160,13 @@ void JetTagPlotter::analyzeTag(const float& w)
     int totNJets = 0;
     int udsNJets = 0;
     int udsgNJets = 0;
-    for(int i = 0; i < 7; i++){
+    for(int i = 0; i < 8; i++){
       totNJets += nJets[i];
       if(i > 0 && i < 4) udsNJets += nJets[i];
       if((i > 0 && i < 4) || i == 6) udsgNJets += nJets[i];
       if(i <= 5 && i >= 1) JetMultiplicity->fill(i, nJets[i], w);
       else if (i==6) JetMultiplicity->fill(21, nJets[i], w);
+      else if (i==7) JetMultiplicity->fill(20, nJets[i], w);
       else JetMultiplicity->fill(0, nJets[i], w);
       nJets[i] = 0; //reset to 0 before the next event
     }
@@ -213,7 +177,7 @@ void JetTagPlotter::analyzeTag(const float& w)
   else 
     {
       int totNJets = 0;
-      for(int i = 0; i < 7; i++){
+      for(int i = 0; i < 8; i++){
 	totNJets += nJets[i];
 	nJets[i] = 0;
       }
@@ -221,107 +185,99 @@ void JetTagPlotter::analyzeTag(const float& w)
     }
 }
 
-void JetTagPlotter::analyzeTag(const reco::Jet & jet,
+void JetTagPlotter::analyzeTag(const reco::Jet & jet, 
+			       const double & jec,
 			       const float& discriminator,
                                const int& jetFlavour)  
 {
   if (mcPlots_) {
     dJetFlav->fill(jetFlavour, jetFlavour);
-//   dJetPartonMomentum->fill(jetFlavour, jetFlavour.underlyingParton4Vec().P() );
-//   dJetPartonPt->fill(jetFlavour, jetFlavour.underlyingParton4Vec().Pt() );
-//   dJetPartonPseudoRapidity->fill(jetFlavour, jetFlavour.underlyingParton4Vec().Eta() );
     if(abs(jetFlavour)>0 && abs(jetFlavour)<6) nJets[abs(jetFlavour)]+=1; //quarks 1 to 5
     else if(abs(jetFlavour)==21) nJets[6]+=1; //gluons
+    else if(jetFlavour==20) nJets[7]+=1; //PU
     else nJets[0]+=1; //NI
   }
   else{
     nJets[0]+=1;
   }
 
-  //  dJetTrackMultiplicity->fill(jetFlavour, jetTag.tracks().size()); //fixme
   if (edm::isNotFinite(discriminator) ) dDiscriminator->fill(jetFlavour, -999.0 );
   else dDiscriminator->fill(jetFlavour, discriminator );
-  dJetRecMomentum->fill(jetFlavour, jet.p() );
-  dJetRecPt->fill(jetFlavour, jet.pt() );
+  dJetRecMomentum->fill(jetFlavour, jet.p()*jec );
+  dJetRecPt->fill(jetFlavour, jet.pt()*jec );
   dJetRecPseudoRapidity->fill(jetFlavour, jet.eta() );
   dJetRecPhi->fill(jetFlavour, jet.phi());
 }
 
-void JetTagPlotter::analyzeTag(const reco::Jet & jet,
+void JetTagPlotter::analyzeTag(const reco::Jet & jet, 
+			       const double & jec,
 			       const float& discriminator,
                                const int& jetFlavour,
 			       const float& w)  
 {
   if (mcPlots_) {
     dJetFlav->fill(jetFlavour, jetFlavour , w );
-//   dJetPartonMomentum->fill(jetFlavour, jetFlavour.underlyingParton4Vec().P() );
-//   dJetPartonPt->fill(jetFlavour, jetFlavour.underlyingParton4Vec().Pt() );
-//   dJetPartonPseudoRapidity->fill(jetFlavour, jetFlavour.underlyingParton4Vec().Eta() );
     if(abs(jetFlavour)>0 && abs(jetFlavour)<6) nJets[abs(jetFlavour)]+=1; //quarks 1 to 5
     else if(abs(jetFlavour)==21) nJets[6]+=1; //gluons
+    else if(jetFlavour==20) nJets[7]+=1; //PU
     else nJets[0]+=1; //NI
   }
   else{
     nJets[0]+=1;
   }
 
-  //  dJetTrackMultiplicity->fill(jetFlavour, jetTag.tracks().size()); //fixme
   if (edm::isNotFinite(discriminator) ) dDiscriminator->fill(jetFlavour, -999.0 , w );
   else dDiscriminator->fill(jetFlavour, discriminator , w );
-  dJetRecMomentum->fill(jetFlavour, jet.p() , w);
-  dJetRecPt->fill(jetFlavour, jet.pt() , w);
+  dJetRecMomentum->fill(jetFlavour, jet.p()*jec , w);
+  dJetRecPt->fill(jetFlavour, jet.pt()*jec , w);
   dJetRecPseudoRapidity->fill(jetFlavour, jet.eta() , w );
   dJetRecPhi->fill(jetFlavour, jet.phi() , w );
 }
 
 
-void JetTagPlotter::analyzeTag(const reco::JetTag & jetTag,
-	const int & jetFlavour)
+void JetTagPlotter::analyzeTag(const reco::JetTag & jetTag, 
+			       const double & jec,
+			       const int & jetFlavour)
 {
   if (mcPlots_) {
   dJetFlav->fill(jetFlavour, jetFlavour);
-//   dJetPartonMomentum->fill(jetFlavour, jetFlavour.underlyingParton4Vec().P() );
-//   dJetPartonPt->fill(jetFlavour, jetFlavour.underlyingParton4Vec().Pt() );
-//   dJetPartonPseudoRapidity->fill(jetFlavour, jetFlavour.underlyingParton4Vec().Eta() );
   if(abs(jetFlavour)>0 && abs(jetFlavour)<6) nJets[abs(jetFlavour)]+=1; //quarks 1 to 5
   else if(abs(jetFlavour)==21) nJets[6]+=1; //gluons
+  else if(jetFlavour==20) nJets[7]+=1; //PU  
   else nJets[0]+=1; //NI
   }
   else{
     nJets[0]+=1;
   }
 
-  //  dJetTrackMultiplicity->fill(jetFlavour, jetTag.tracks().size()); //fixme
   if (edm::isNotFinite(jetTag.second) ) dDiscriminator->fill(jetFlavour, -999.0 );
   else dDiscriminator->fill(jetFlavour, jetTag.second);
-  dJetRecMomentum->fill(jetFlavour, jetTag.first->p() );
-  dJetRecPt->fill(jetFlavour, jetTag.first->pt() );
+  dJetRecMomentum->fill(jetFlavour, jetTag.first->p()*jec );
+  dJetRecPt->fill(jetFlavour, jetTag.first->pt()*jec );
   dJetRecPseudoRapidity->fill(jetFlavour, jetTag.first->eta() );
   dJetRecPhi->fill(jetFlavour, jetTag.first->phi());
 }
 
-void JetTagPlotter::analyzeTag(const reco::JetTag & jetTag,
+void JetTagPlotter::analyzeTag(const reco::JetTag & jetTag, 
+			       const double & jec,
 			       const int & jetFlavour,
 			       const float& w)
 {
   if (mcPlots_) {
     dJetFlav->fill(jetFlavour, jetFlavour, w );
-//   dJetPartonMomentum->fill(jetFlavour, jetFlavour.underlyingParton4Vec().P() );
-//   dJetPartonPt->fill(jetFlavour, jetFlavour.underlyingParton4Vec().Pt() );
-//   dJetPartonPseudoRapidity->fill(jetFlavour, jetFlavour.underlyingParton4Vec().Eta() );
     if(abs(jetFlavour)>0 && abs(jetFlavour)<6) nJets[abs(jetFlavour)]+=1; //quarks 1 to 5
     else if(abs(jetFlavour)==21) nJets[6]+=1; //gluons
+    else if(jetFlavour==20) nJets[7]+=1; //PU  
     else nJets[0]+=1; //NI
   }
   else{
     nJets[0]+=1;
   }
 
-  //  dJetTrackMultiplicity->fill(jetFlavour, jetTag.tracks().size()); //fixme
   if (edm::isNotFinite(jetTag.second) ) dDiscriminator->fill(jetFlavour, -999.0 , w );
   else dDiscriminator->fill(jetFlavour, jetTag.second , w );
-  dJetRecMomentum->fill(jetFlavour, jetTag.first->p() , w );
-  dJetRecPt->fill(jetFlavour, jetTag.first->pt() , w );
+  dJetRecMomentum->fill(jetFlavour, jetTag.first->p()*jec , w );
+  dJetRecPt->fill(jetFlavour, jetTag.first->pt()*jec , w );
   dJetRecPseudoRapidity->fill(jetFlavour, jetTag.first->eta() , w );
   dJetRecPhi->fill(jetFlavour, jetTag.first->phi() , w );
 }

--- a/DQMOffline/RecoB/src/MVAJetTagPlotter.cc
+++ b/DQMOffline/RecoB/src/MVAJetTagPlotter.cc
@@ -61,13 +61,14 @@ void MVAJetTagPlotter::setEventSetup(const edm::EventSetup &setup)
 			   "GenericMVAJetTagComputer." << endl;
 }
 
-void MVAJetTagPlotter::analyzeTag (const vector<const BaseTagInfo*> &baseTagInfos,
+void MVAJetTagPlotter::analyzeTag (const vector<const BaseTagInfo*> &baseTagInfos, const double & jec, 
                                    const int &jetFlavour)
 {
-  analyzeTag(baseTagInfos,jetFlavour,1.);
+  analyzeTag(baseTagInfos,jec,jetFlavour,1.);
 }
 
 void MVAJetTagPlotter::analyzeTag (const vector<const BaseTagInfo*> &baseTagInfos,
+				   const double & jec, 
                                    const int &jetFlavour,
 				   const float & w)
 {

--- a/DQMOffline/RecoB/src/SoftLeptonTagPlotter.cc
+++ b/DQMOffline/RecoB/src/SoftLeptonTagPlotter.cc
@@ -78,13 +78,14 @@ SoftLeptonTagPlotter::~SoftLeptonTagPlotter ()
   }
 }
 
-void SoftLeptonTagPlotter::analyzeTag( const reco::BaseTagInfo * baseTagInfo,
+void SoftLeptonTagPlotter::analyzeTag( const reco::BaseTagInfo * baseTagInfo, const double & jec, 
     const int & jetFlavour )
 {
   analyzeTag(baseTagInfo,jetFlavour,1.);
 }
 
 void SoftLeptonTagPlotter::analyzeTag( const reco::BaseTagInfo * baseTagInfo,
+				       const double & jec, 
 				       const int & jetFlavour,
 				       const float & w)
 {

--- a/DQMOffline/RecoB/src/TaggingVariablePlotter.cc
+++ b/DQMOffline/RecoB/src/TaggingVariablePlotter.cc
@@ -65,13 +65,14 @@ TaggingVariablePlotter::~TaggingVariablePlotter ()
 }
 
 
-void TaggingVariablePlotter::analyzeTag (const BaseTagInfo *baseTagInfo,
+void TaggingVariablePlotter::analyzeTag (const BaseTagInfo *baseTagInfo, const double & jec, 
 	const int &jetFlavour)
 {
   analyzeTag(baseTagInfo->taggingVariables(), jetFlavour,1.);
 }
 
 void TaggingVariablePlotter::analyzeTag (const BaseTagInfo *baseTagInfo,
+					 const double & jec, 
 					 const int &jetFlavour,
 					 const float & w)
 {

--- a/DQMOffline/RecoB/src/TrackCountingTagPlotter.cc
+++ b/DQMOffline/RecoB/src/TrackCountingTagPlotter.cc
@@ -82,13 +82,14 @@ TrackCountingTagPlotter::~TrackCountingTagPlotter ()
   }
 }
 
-void TrackCountingTagPlotter::analyzeTag (const reco::BaseTagInfo * baseTagInfo,
+void TrackCountingTagPlotter::analyzeTag (const reco::BaseTagInfo * baseTagInfo, const double & jec, 
 	const int & jetFlavour)
 {
   analyzeTag(baseTagInfo,jetFlavour,1.);
 }
 
 void TrackCountingTagPlotter::analyzeTag (const reco::BaseTagInfo * baseTagInfo,
+					  const double & jec, 
 					  const int & jetFlavour,
 					  const float & w)
 {

--- a/DQMOffline/RecoB/src/TrackIPTagPlotter.cc
+++ b/DQMOffline/RecoB/src/TrackIPTagPlotter.cc
@@ -590,11 +590,13 @@ TrackIPTagPlotter::~TrackIPTagPlotter ()
 }
 
 void TrackIPTagPlotter::analyzeTag (const reco::BaseTagInfo * baseTagInfo,
+				    const double & jec,
 				    const int & jetFlavour)
 {
-  analyzeTag(baseTagInfo,jetFlavour,1.);
+  analyzeTag(baseTagInfo,jec,jetFlavour,1.);
 }
 void TrackIPTagPlotter::analyzeTag (const reco::BaseTagInfo * baseTagInfo,
+				    const double & jec,
 				    const int & jetFlavour, const float & w)
 {
   const reco::TrackIPTagInfo * tagInfo = 
@@ -768,8 +770,8 @@ void TrackIPTagPlotter::analyzeTag (const reco::BaseTagInfo * baseTagInfo,
   }
 
   //still need to implement weights in FlavourHistograms2D
-  trackMultVsJetPtHisto->fill(jetFlavour, tagInfo->jet()->pt(), tagInfo->tracks().size());
-  selectedTrackMultVsJetPtHisto->fill(jetFlavour, tagInfo->jet()->pt(), nSelectedTracks); //tagInfo->selectedTracks().size());
+  trackMultVsJetPtHisto->fill(jetFlavour, tagInfo->jet()->pt()*jec, tagInfo->tracks().size());
+  selectedTrackMultVsJetPtHisto->fill(jetFlavour, tagInfo->jet()->pt()*jec, nSelectedTracks); //tagInfo->selectedTracks().size());
 }
 
 void TrackIPTagPlotter::createPlotsForFinalize (){

--- a/DQMOffline/RecoB/src/TrackProbabilityTagPlotter.cc
+++ b/DQMOffline/RecoB/src/TrackProbabilityTagPlotter.cc
@@ -74,6 +74,7 @@ TrackProbabilityTagPlotter::~TrackProbabilityTagPlotter ()
 
 
 void TrackProbabilityTagPlotter::analyzeTag (const reco::BaseTagInfo * baseTagInfo,
+					     const double & jec, 
 					     const int & jetFlavour,
 					     const float & w)
 {
@@ -96,7 +97,7 @@ void TrackProbabilityTagPlotter::analyzeTag (const reco::BaseTagInfo * baseTagIn
     tkcntHistosSig3D[4]->fill(jetFlavour, tagInfo->probability(n,0),w);
 }
 
-void TrackProbabilityTagPlotter::analyzeTag (const reco::BaseTagInfo * baseTagInfo,
+void TrackProbabilityTagPlotter::analyzeTag (const reco::BaseTagInfo * baseTagInfo, const double & jec, 
 					     const int & jetFlavour)
 {
   analyzeTag(baseTagInfo,jetFlavour,1.);

--- a/FastSimulation/Validation/python/globalValidation_cff.py
+++ b/FastSimulation/Validation/python/globalValidation_cff.py
@@ -30,7 +30,7 @@ from DQMOffline.RecoB.dqmAnalyzer_cff import *
 globalAssociation = cms.Sequence(recoMuonAssociationFastSim
                                  + simHitTPAssocProducer
                                  + tracksValidationSelectors
-                                 + prebTagSequence)
+                                 + prebTagSequenceMC)
 
 globalValidation = cms.Sequence(trackingTruthValid
                                 +tracksValidationFS

--- a/Validation/Configuration/python/globalValidation_cff.py
+++ b/Validation/Configuration/python/globalValidation_cff.py
@@ -42,7 +42,7 @@ globalPrevalidation = cms.Sequence(
   * tracksValidationSelectors
   * photonPrevalidationSequence
   * produceDenoms
-  * prebTagSequence
+  * prebTagSequenceMC
 )
 
 # filter/producer "pre-" sequence for validation_preprod

--- a/Validation/RecoB/interface/BTagValidator.h
+++ b/Validation/RecoB/interface/BTagValidator.h
@@ -9,7 +9,6 @@
  author: Victor Bazterra, UIC
          Francisco Yumiceva, Fermilab (yumiceva@fnal.gov)
 
- version $Id: BTagValidator.h,v 1.7 2009/12/18 20:45:12 wmtan Exp $
 
 ________________________________________________________________**/
 

--- a/Validation/RecoB/interface/HistoCompare.h
+++ b/Validation/RecoB/interface/HistoCompare.h
@@ -9,7 +9,6 @@
  author: Victor Bazterra, UIC
          Francisco Yumiceva, Fermilab (yumiceva@fnal.gov)
 
- version $Id: HistoCompare.h,v 1.2 2007/02/14 20:09:41 yumiceva Exp $
 
 ________________________________________________________________**/
 
@@ -26,13 +25,13 @@ class HistoCompare {
 
   public:
 	HistoCompare();
-	HistoCompare(TString refFilename);
+	HistoCompare(const TString& refFilename);
 
 	~HistoCompare();
 
-	TH1* Compare(TH1* h, TString hname);
+	TH1* Compare(TH1* h, const TString& hname);
 
-	void SetReferenceFilename(TString filename) {
+	void SetReferenceFilename(const TString& filename) {
 	  refFilename_ = filename;
 	  //if (refFile_) delete refFile_;
 	  refFile_ = new TFile(refFilename_);

--- a/Validation/RecoB/plugins/BTagPerformanceAnalyzerMC.h
+++ b/Validation/RecoB/plugins/BTagPerformanceAnalyzerMC.h
@@ -18,8 +18,6 @@
 #include "DQMOffline/RecoB/interface/TagCorrelationPlotter.h"
 #include "DQMOffline/RecoB/interface/BaseTagInfoPlotter.h"
 #include "DQMOffline/RecoB/interface/Tools.h"
-//#include "RecoBTag/MCTools/interface/JetFlavourIdentifier.h"
-//#include "RecoBTag/MCTools/interface/JetFlavour.h"
 #include "DataFormats/JetReco/interface/Jet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "SimDataFormats/JetMatching/interface/JetFlavourMatching.h"
@@ -29,6 +27,8 @@
 #include "DQMOffline/RecoB/interface/MatchJet.h"
 
 #include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
+#include "DataFormats/JetReco/interface/GenJet.h"
+#include "DataFormats/Common/interface/Association.h"
 
 #include <string>
 #include <vector>
@@ -48,9 +48,11 @@ class BTagPerformanceAnalyzerMC : public edm::EDAnalyzer {
 
       ~BTagPerformanceAnalyzerMC();
 
+      virtual void beginRun(const edm::Run & run, const edm::EventSetup & es);
+
       virtual void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup);
 
-  virtual void endJob();
+      virtual void endJob();
 
    private:
 
@@ -62,16 +64,18 @@ class BTagPerformanceAnalyzerMC : public edm::EDAnalyzer {
   };
 
   // Get histogram plotting options from configuration.
-  void bookHistos(const edm::ParameterSet& pSet);
+  void bookHistos();
   EtaPtBin getEtaPtBin(const int& iEta, const int& iPt);
     typedef std::pair<reco::Jet, reco::JetFlavour> JetWithFlavour;
 typedef std::map<edm::RefToBase<reco::Jet>, unsigned int, JetRefCompare> FlavourMap;
 typedef std::map<edm::RefToBase<reco::Jet>, reco::JetFlavour::Leptons, JetRefCompare> LeptonMap;
   //  reco::JetFlavour getJetFlavour(
   //	edm::RefToBase<reco::Jet> caloRef, FlavourMap flavours);
-  bool getJetWithFlavour( edm::RefToBase<reco::Jet> caloRef,
-                         FlavourMap flavours, JetWithFlavour &jetWithFlavour,
-                         const edm::EventSetup & es);
+  bool getJetWithFlavour(edm::RefToBase<reco::Jet> caloRef,
+                         const FlavourMap& _flavours, JetWithFlavour &jetWithFlavour,
+			 const edm::EventSetup & es, 
+			 edm::Handle<edm::Association<reco::GenJetCollection> > genJetsMatched);
+  bool getJetWithGenJet(edm::RefToBase<reco::Jet> jetRef, edm::Handle<edm::Association<reco::GenJetCollection> > genJetsMatched); 
 
   std::vector<std::string> tiDataFormatType;
   bool partonKinematics;
@@ -80,6 +84,8 @@ typedef std::map<edm::RefToBase<reco::Jet>, reco::JetFlavour::Leptons, JetRefCom
   std::vector<double> etaRanges, ptRanges;
   bool produceEps, producePs;
   std::string psBaseName, epsBaseName, inputFile;
+  std::string JECsource;
+  bool doJEC;
   bool update, allHisto;
   bool finalize;
   bool finalizeOnly;
@@ -88,6 +94,7 @@ typedef std::map<edm::RefToBase<reco::Jet>, reco::JetFlavour::Leptons, JetRefCom
 
   edm::InputTag jetMCSrc;
   edm::InputTag slInfoTag;
+  edm::InputTag genJetsMatchedSrc;
 
   std::vector< std::vector<JetTagPlotter*> > binJetTagPlotters;
   std::vector< std::vector<TagCorrelationPlotter*> > binTagCorrelationPlotters;
@@ -108,8 +115,18 @@ typedef std::map<edm::RefToBase<reco::Jet>, reco::JetFlavour::Leptons, JetRefCom
   CorrectJet jetCorrector;
   MatchJet jetMatcher;
 
+  bool doPUid; 
   bool eventInitialized;
   bool electronPlots, muonPlots, tauPlots;
+
+  //add consumes 
+  edm::EDGetTokenT<GenEventInfoProduct> genToken;
+  edm::EDGetTokenT<edm::Association<reco::GenJetCollection>> genJetsMatchedToken;
+  edm::EDGetTokenT<reco::JetFlavourMatchingCollection> jetToken;
+  edm::EDGetTokenT<reco::SoftLeptonTagInfoCollection> slInfoToken;
+  std::vector< edm::EDGetTokenT<reco::JetTagCollection> > jetTagToken;
+  std::vector< std::pair<edm::EDGetTokenT<reco::JetTagCollection>, edm::EDGetTokenT<reco::JetTagCollection>> > tagCorrelationToken;
+  std::vector<std::vector <edm::EDGetTokenT<edm::View<reco::BaseTagInfo>> >> tagInfoToken;
 };
 
 

--- a/Validation/RecoB/plugins/recoBSVTagInfoValidationAnalyzer.cc
+++ b/Validation/RecoB/plugins/recoBSVTagInfoValidationAnalyzer.cc
@@ -43,8 +43,8 @@ public:
 
 private:
 
-    virtual void analyze(const edm::Event&, const edm::EventSetup&);
-    virtual void endJob() ;
+    virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+    virtual void endJob() override ;
     // Member data
 
     VertexClassifierByProxy<reco::SecondaryVertexTagInfoCollection> classifier_;
@@ -85,6 +85,10 @@ private:
     // Histogram handlers
     std::map<std::string, MonitorElement *> HistIndex_;
 
+  //consumes
+  edm::EDGetTokenT<reco::SecondaryVertexTagInfoCollection> svInfoToken;
+  edm::EDGetTokenT<TrackingVertexCollection> tvToken;
+
 };
 
 
@@ -115,11 +119,9 @@ recoBSVTagInfoValidationAnalyzer::recoBSVTagInfoValidationAnalyzer(const edm::Pa
 
 
     // Get the track collection
-    svTagInfoProducer_ = config.getUntrackedParameter<edm::InputTag> ( "svTagInfoProducer" );
-
+    svInfoToken = consumes<reco::SecondaryVertexTagInfoCollection>(config.getParameter<InputTag>("svTagInfoProducer"));
     // Name of the traking pariticle collection
-    trackingTruth_ = config.getUntrackedParameter<edm::InputTag> ( "trackingTruth" );
-
+    tvToken = consumes<TrackingVertexCollection>(config.getParameter<InputTag>("trackingTruth")); 
     // Number of track categories
     numberVertexClassifier_ = VertexCategories::Unknown+1;
 
@@ -192,8 +194,7 @@ void recoBSVTagInfoValidationAnalyzer::analyze(const edm::Event& event, const ed
 
   // Vertex collection
   edm::Handle<reco::SecondaryVertexTagInfoCollection> svTagInfoCollection;
-  event.getByLabel(svTagInfoProducer_, svTagInfoCollection);
-
+  event.getByToken(svInfoToken, svTagInfoCollection);
   // Get a constant reference to the track history associated to the classifier
   VertexHistory const & tracer = classifier_.history();
 
@@ -305,8 +306,7 @@ void recoBSVTagInfoValidationAnalyzer::analyze(const edm::Event& event, const ed
 
   // Vertex collection
   edm::Handle<TrackingVertexCollection>  TVCollection;
-  event.getByLabel(trackingTruth_, TVCollection);
-    
+  event.getByToken(tvToken, TVCollection);
   // Loop over the TV collection.
   for (std::size_t index = 0; index < TVCollection->size(); ++index){
         

--- a/Validation/RecoB/python/bTagAnalysis_cfi.py
+++ b/Validation/RecoB/python/bTagAnalysis_cfi.py
@@ -102,5 +102,7 @@ bTagValidation = cms.EDAnalyzer("BTagPerformanceAnalyzerMC",
 
     flavPlots = cms.string("allbcl"),                            
     differentialPlots = cms.bool(False), #not needed in validation procedure, put True to produce them  
-    leptonPlots = cms.uint32(0)
+    leptonPlots = cms.uint32(0),
+    genJetsMatched = cms.InputTag("patJetGenJetMatch"),                            
+    doPUid = cms.bool(False)
 )

--- a/Validation/RecoB/src/BTagValidator.cc
+++ b/Validation/RecoB/src/BTagValidator.cc
@@ -6,7 +6,6 @@
  author: Victor Bazterra, UIC
          Francisco Yumiceva, Fermilab (yumiceva@fnal.gov)
 
- version $Id: BTagValidator.cc,v 1.16 2010/07/20 02:58:37 wmtan Exp $
 
 ________________________________________________________________**/
 

--- a/Validation/RecoB/src/HistoCompare.cc
+++ b/Validation/RecoB/src/HistoCompare.cc
@@ -6,7 +6,6 @@
  author: Victor Bazterra, UIC
          Francisco Yumiceva, Fermilab (yumiceva@fnal.gov)
 
- version $Id: HistoCompare.cc,v 1.3 2007/02/14 20:20:08 yumiceva Exp $
 
 ________________________________________________________________**/
 
@@ -19,7 +18,7 @@ HistoCompare::HistoCompare() {
   do_nothing_ = false;
 }
 
-HistoCompare::HistoCompare(TString refFilename) {
+HistoCompare::HistoCompare(const TString& refFilename) {
 
 	result_ = 0;
 	do_nothing_ = false;
@@ -41,7 +40,7 @@ HistoCompare::~HistoCompare() {
 }
 
 
-TH1* HistoCompare::Compare(TH1 *h, TString hname) {
+TH1* HistoCompare::Compare(TH1 *h, const TString& hname) {
 
 	if (do_nothing_) return 0;
 	


### PR DESCRIPTION
Backport of changes which have been included already in 71x: remove producer from b-tag DQMOffline sequence, use of CHS jets, do JEC on the fly, add a PU-jets category, improvement of the config. files to run the b-tag DQM code locally or on the GRID...
