### PR TITLE
memory optimization and minor bug fix

### DIFF
--- a/SimTracker/TrackTriggerAssociation/plugins/TTClusterAssociator.cc
+++ b/SimTracker/TrackTriggerAssociation/plugins/TTClusterAssociator.cc
@@ -178,8 +178,11 @@ void TTClusterAssociator< Ref_PixelDigi_ >::produce( edm::Event& iEvent, const e
             else 
             {
               /// In case no TrackingParticle is found, store a NULL pointer
-              edm::Ptr< TrackingParticle >* tempTPPtr = new edm::Ptr< TrackingParticle >();
-              clusterToTrackingParticleVectorMap.find( tempCluRef )->second.push_back( *tempTPPtr );
+/* IR 2014 04 20
+ * from pointer to object to deallocate memory in the correct way
+*/
+              edm::Ptr< TrackingParticle > tempTPPtr; // = new edm::Ptr< TrackingParticle >();
+              clusterToTrackingParticleVectorMap.find( tempCluRef )->second.push_back( tempTPPtr );
             }
           } /// End of loop over PixelDigiSimLink
         } /// End of loop over all the hits composing the Cluster


### PR DESCRIPTION
memory optimization: moved from "pointers to vectors" to "vectors" to correctly deallocate memory at the end of loops.
minor bug fix: information stored in StubAccepted TTStub collection - correct correspondence between half-strip units and full-strip units is restored. this does not affect the stub finding step but just how the information is stored in the class data members
