### PR TITLE
Revert back endJob to endRun done my mistake -> get back efficiency plot...

### DIFF
--- a/Validation/RecoB/plugins/BTagPerformanceAnalyzerMC.cc
+++ b/Validation/RecoB/plugins/BTagPerformanceAnalyzerMC.cc
@@ -617,7 +617,8 @@ bool  BTagPerformanceAnalyzerMC::getJetWithFlavour(edm::RefToBase<Jet> jetRef, c
   return true;
 }
 
-void BTagPerformanceAnalyzerMC::endRun(const edm::Run & run, const edm::EventSetup & es)
+//void BTagPerformanceAnalyzerMC::endRun(const edm::Run & run, const edm::EventSetup & es)
+void BTagPerformanceAnalyzerMC::endJob()
 {
   if (!finalize) return;
   setTDRStyle();

--- a/Validation/RecoB/plugins/BTagPerformanceAnalyzerMC.h
+++ b/Validation/RecoB/plugins/BTagPerformanceAnalyzerMC.h
@@ -50,7 +50,8 @@ class BTagPerformanceAnalyzerMC : public DQMEDAnalyzer {
 
       virtual void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup);
 
-      virtual void endRun(const edm::Run & run, const edm::EventSetup & es);
+      //virtual void endRun(const edm::Run & run, const edm::EventSetup & es);
+      virtual void endJob();
       
    private:
 


### PR DESCRIPTION
Revert back change from endJob to endRun done my mistake -> get back efficiency plots in RelVal production.
