### PR TITLE
Make TrajectorySmoothers const thread-safe

### DIFF
--- a/Alignment/KalmanAlignmentAlgorithm/plugins/KalmanAlignmentAlgorithm.cc
+++ b/Alignment/KalmanAlignmentAlgorithm/plugins/KalmanAlignmentAlgorithm.cc
@@ -559,12 +559,12 @@ void KalmanAlignmentAlgorithm::initializeAlignmentSetups( const edm::EventSetup&
       if ( aKFSmoother )
       {
 
-	PropagatorWithMaterial propagator( smootherDir, 0.106, aKFSmoother->propagator()->magneticField() );
+	PropagatorWithMaterial propagator( smootherDir, 0.106, aKFSmoother->alongPropagator()->magneticField() );
 	Chi2MeasurementEstimator estimator( 30. );
 	smoother = new KFTrajectorySmoother( &propagator, updator, &estimator );
 // 	smoother = new KFTrajectorySmoother( &propagator, aKFFitter->updator(), &estimator );
 
-	AnalyticalPropagator externalPropagator( aKFSmoother->propagator()->magneticField(), externalSmootherDir );
+	AnalyticalPropagator externalPropagator( aKFSmoother->alongPropagator()->magneticField(), externalSmootherDir );
 	Chi2MeasurementEstimator externalEstimator( 1000. );
 	externalSmoother = new KFTrajectorySmoother( &externalPropagator, aKFSmoother->updator(), &externalEstimator );
       }

--- a/RecoMuon/CosmicMuonProducer/interface/CosmicMuonSmoother.h
+++ b/RecoMuon/CosmicMuonProducer/interface/CosmicMuonSmoother.h
@@ -39,13 +39,13 @@ public:
   CosmicMuonSmoother(const edm::ParameterSet&,const MuonServiceProxy* service);
   virtual ~CosmicMuonSmoother();
 
-  Trajectory trajectory(const Trajectory&) const;
+  Trajectory trajectory(const Trajectory&) const override;
 
-  virtual TrajectoryContainer trajectories(const Trajectory& traj) const {
+  virtual TrajectoryContainer trajectories(const Trajectory& traj) const override {
      return TrajectorySmoother::trajectories(traj);
   }
 
-  virtual CosmicMuonSmoother* clone() const {
+  virtual CosmicMuonSmoother* clone() const override {
     return new CosmicMuonSmoother(*this);
   }
 
@@ -81,9 +81,9 @@ private:
 
   void sortHitsAlongMom(ConstRecHitContainer& hits, const TrajectoryStateOnSurface&) const;
 
-  KFUpdator* theUpdator;
-  Chi2MeasurementEstimator* theEstimator;
-  CosmicMuonUtilities* theUtilities; 
+  const KFUpdator* theUpdator;
+  const Chi2MeasurementEstimator* theEstimator;
+  const CosmicMuonUtilities* theUtilities; 
 
   const MuonServiceProxy* theService;
 

--- a/TrackingTools/GsfTracking/interface/GsfTrajectorySmoother.h
+++ b/TrackingTools/GsfTracking/interface/GsfTrajectorySmoother.h
@@ -40,21 +40,14 @@ public:
 
   virtual ~GsfTrajectorySmoother();
 
-  virtual Trajectory trajectory(const Trajectory& aTraj) const;
+  virtual Trajectory trajectory(const Trajectory& aTraj) const override;
 
-  /** propagator used (full propagator, if material effects are
-   * applied before the update, otherwise purely geometrical part)
-   */
-  const Propagator* propagator() const {
-    if ( thePropagator) return thePropagator;
-    else  return theGeomPropagator;
-  }
   const TrajectoryStateUpdator* updator() const {return theUpdator;}
   const MeasurementEstimator* estimator() const {return theEstimator;}
 
-  virtual GsfTrajectorySmoother* clone() const
+  virtual GsfTrajectorySmoother* clone() const override
   {
-    return new GsfTrajectorySmoother(*thePropagator,*theUpdator,*theEstimator,
+    return new GsfTrajectorySmoother(*theAlongPropagator,*theUpdator,*theEstimator,
 				     *theMerger,theErrorRescaling,theMatBeforeUpdate,theGeometry);
   }
 
@@ -63,7 +56,8 @@ public:
 
 
 private:
-  GsfPropagatorWithMaterial* thePropagator;
+  const GsfPropagatorWithMaterial* theAlongPropagator;
+  const GsfPropagatorWithMaterial* theOppositePropagator;
   const GsfPropagatorAdapter* theGeomPropagator;
   const FullConvolutionWithMaterial* theConvolutor;
   const TrajectoryStateUpdator* theUpdator;

--- a/TrackingTools/TrackFitters/src/KFTrajectorySmoother.cc
+++ b/TrackingTools/TrackFitters/src/KFTrajectorySmoother.cc
@@ -27,7 +27,8 @@
 
 KFTrajectorySmoother::~KFTrajectorySmoother() {
 
-  delete thePropagator;
+  delete theAlongPropagator;
+  delete theOppositePropagator;
   delete theUpdator;
   delete theEstimator;
 
@@ -38,15 +39,14 @@ KFTrajectorySmoother::trajectory(const Trajectory& aTraj) const {
 
   if(aTraj.empty()) return Trajectory();
 
-  if (  aTraj.direction() == alongMomentum) {
-    thePropagator->setPropagationDirection(oppositeToMomentum);
-  } else {
-    thePropagator->setPropagationDirection(alongMomentum);
+  const Propagator* usePropagator = theAlongPropagator;
+  if(aTraj.direction() == alongMomentum) {
+    usePropagator = theOppositePropagator;
   }
-  
+
   const std::vector<TM> & avtm = aTraj.measurements();
   
-  Trajectory ret(aTraj.seed(), thePropagator->propagationDirection());
+  Trajectory ret(aTraj.seed(), usePropagator->propagationDirection());
   Trajectory & myTraj = ret;
   myTraj.reserve(avtm.size());
   
@@ -87,7 +87,7 @@ KFTrajectorySmoother::trajectory(const Trajectory& aTraj) const {
 
 
     if (hitcounter != avtm.size())//no propagation needed for first smoothed (==last fitted) hit 
-      predTsos = thePropagator->propagate( currTsos, *(hit->surface()) );
+      predTsos = usePropagator->propagate( currTsos, *(hit->surface()) );
 
     if unlikely(!predTsos.isValid()) {
 	LogDebug("TrackFitters") << "KFTrajectorySmoother: predicted tsos not valid!";


### PR DESCRIPTION
Most of the TrajectorySmoothers were changing the direction of their
Propagators in a const function. That is not thread safe. To fix the
problem the TrajectorySmoothers now hold two Propagators which only
differ based on their propagation direction.
