### PR TITLE
enable MT pattern reco in cosmic sequence

### DIFF
--- a/RecoLocalMuon/DTSegment/python/dt2DSegments_MTPatternReco2D_LinearDriftFromDB_cfi.py
+++ b/RecoLocalMuon/DTSegment/python/dt2DSegments_MTPatternReco2D_LinearDriftFromDB_cfi.py
@@ -14,10 +14,10 @@ dt2DSegments = cms.EDProducer("DTRecSegment2DProducer",
 )
 
 #add cosmics reconstruction in collisions
-from RecoLocalMuon.DTSegment.DTCombinatorialPatternReco2DAlgo_LinearDriftFromDB_cfi import *
+from RecoLocalMuon.DTSegment.DTMeantimerPatternReco2DAlgo_LinearDriftFromDBLoose_cfi import *
 dt2DCosmicSegments = cms.EDProducer("DTRecSegment2DProducer",
     # The reconstruction algo and its parameter set
-    DTCombinatorialPatternReco2DAlgo_LinearDriftFromDB,
+    DTMeantimerPatternReco2DAlgo_LinearDriftFromDBLoose,
     # debuggin opt
     debug = cms.untracked.bool(False),
     # name of the rechit 1D collection in the event

--- a/RecoLocalMuon/DTSegment/python/dt2DSegments_MTPatternReco2D_LinearDrift_cfi.py
+++ b/RecoLocalMuon/DTSegment/python/dt2DSegments_MTPatternReco2D_LinearDrift_cfi.py
@@ -14,10 +14,10 @@ dt2DSegments = cms.EDProducer("DTRecSegment2DProducer",
 )
 
 #add cosmics reconstruction in collisions
-from RecoLocalMuon.DTSegment.DTCombinatorialPatternReco2DAlgo_LinearDriftFromDB_cfi import *
+from RecoLocalMuon.DTSegment.DTMeantimerPatternReco2DAlgo_LinearDriftFromDBLoose_cfi import *
 dt2DCosmicSegments = cms.EDProducer("DTRecSegment2DProducer",
     # The reconstruction algo and its parameter set
-    DTCombinatorialPatternReco2DAlgo_LinearDriftFromDB,
+    DTMeantimerPatternReco2DAlgo_LinearDriftFromDBLoose,
     # debuggin opt
     debug = cms.untracked.bool(False),
     # name of the rechit 1D collection in the event

--- a/RecoLocalMuon/DTSegment/python/dt4DSegments_MTPatternReco4D_LinearDriftFromDB_cfi.py
+++ b/RecoLocalMuon/DTSegment/python/dt4DSegments_MTPatternReco4D_LinearDriftFromDB_cfi.py
@@ -15,10 +15,10 @@ dt4DSegments = cms.EDProducer("DTRecSegment4DProducer",
 )
 
 #add cosmics reconstruction in collisions
-from RecoLocalMuon.DTSegment.DTCombinatorialPatternReco4DAlgo_LinearDriftFromDB_CosmicData_cfi import *
+from RecoLocalMuon.DTSegment.DTMeantimerPatternReco4DAlgo_LinearDriftFromDBLoose_cfi import *
 dt4DCosmicSegments = cms.EDProducer("DTRecSegment4DProducer",
     # The reconstruction algo and its parameter set
-    DTCombinatorialPatternReco4DAlgo_LinearDriftFromDB_CosmicData,
+    DTMeantimerPatternReco4DAlgo_LinearDriftFromDBLoose,
     # debuggin opt
     debug = cms.untracked.bool(False),
     # name of the rechit 1D collection in the event


### PR DESCRIPTION
This change enables the new Meantimer pattern recognition in the cosmic sequence. Overall performance improvement is expected due to better handling of out-of-time segments by Meantimer. 
