### PR TITLE
bugfixes and restoring backwards compatibility of Combinatorial DT reco

### DIFF
--- a/RecoLocalMuon/DTSegment/src/DTCombinatorialExtendedPatternReco.cc
+++ b/RecoLocalMuon/DTSegment/src/DTCombinatorialExtendedPatternReco.cc
@@ -66,7 +66,7 @@ DTCombinatorialExtendedPatternReco::reconstruct(const DTSuperLayer* sl,
     
     DTSLRecSegment2D *segment = (**cand);
 
-    theUpdator->update(segment);
+    theUpdator->update(segment,0);
 
     result.push_back(segment);
 
@@ -419,7 +419,7 @@ DTCombinatorialExtendedPatternReco::buildPointsCollection(vector<DTSegmentCand::
     }
 
     DTSegmentCand* newCand = new DTSegmentCand(pointsSet,sl);
-    if (theUpdator->fit(newCand)) candidates.push_back(newCand);
+    if (theUpdator->fit(newCand,0,0)) candidates.push_back(newCand);
     else delete newCand; // bad seg, too few hits
   }
 }
@@ -490,7 +490,7 @@ DTCombinatorialExtendedPatternReco::extendCandidates(vector<DTSegmentCand*>& can
       }
       // fit the segment
       if (debug) cout << "extended cands nHits: " << extendedCand->nHits() <<endl;
-      if (theUpdator->fit(extendedCand)) {
+      if (theUpdator->fit(extendedCand,0,0)) {
         // add to result
         result.push_back(extendedCand);
       } else {

--- a/RecoLocalMuon/DTSegment/src/DTCombinatorialPatternReco.cc
+++ b/RecoLocalMuon/DTSegment/src/DTCombinatorialPatternReco.cc
@@ -65,7 +65,7 @@ DTCombinatorialPatternReco::reconstruct(const DTSuperLayer* sl,
     
     DTSLRecSegment2D *segment = (**cand);
 
-    theUpdator->update(segment);
+    theUpdator->update(segment,0);
 
     result.push_back(segment);
 
@@ -427,7 +427,7 @@ DTCombinatorialPatternReco::buildPointsCollection(vector<DTSegmentCand::AssPoint
     }
 
     DTSegmentCand* newCand = new DTSegmentCand(pointsSet,sl);
-    if (theUpdator->fit(newCand)) candidates.push_back(newCand);
+    if (theUpdator->fit(newCand,0,0)) candidates.push_back(newCand);
     else delete newCand; // bad seg, too few hits
   }
 }

--- a/RecoLocalMuon/DTSegment/src/DTCombinatorialPatternReco4D.cc
+++ b/RecoLocalMuon/DTSegment/src/DTCombinatorialPatternReco4D.cc
@@ -169,7 +169,7 @@ DTCombinatorialPatternReco4D::reconstruct() {
 
       std::auto_ptr<DTChamberRecSegment2D> superPhi(**phi);
 
-      theUpdator->update(superPhi.get());
+      theUpdator->update(superPhi.get(),0);
       if(debug) cout << "superPhi: " << *superPhi << endl;
 
       if (hasZed) {
@@ -201,12 +201,12 @@ DTCombinatorialPatternReco4D::reconstruct() {
           if (debug) cout << "Created a 4D seg " << *newSeg << endl;
 
           /// 4d segment: I have the pos along the wire => further update!
-	  theUpdator->update(newSeg);
+	  theUpdator->update(newSeg,0,0);
           if (debug) cout << "     seg updated " <<  *newSeg << endl;
 
 
 	  if(!applyT0corr && computeT0corr) theUpdator->calculateT0corr(newSeg);
-          if(applyT0corr) theUpdator->update(newSeg,true);
+          if(applyT0corr) theUpdator->update(newSeg,true,0);
 
           result.push_back(newSeg);
         }
@@ -219,7 +219,7 @@ DTCombinatorialPatternReco4D::reconstruct() {
 
        //update the segment with the t0 and possibly vdrift correction
         if(!applyT0corr && computeT0corr) theUpdator->calculateT0corr(newSeg);
- 	if(applyT0corr) theUpdator->update(newSeg,true);
+ 	if(applyT0corr) theUpdator->update(newSeg,true,0);
 
         result.push_back(newSeg);
       }
@@ -243,7 +243,7 @@ DTCombinatorialPatternReco4D::reconstruct() {
 		     *newSeg << endl;
 
         if(!applyT0corr && computeT0corr) theUpdator->calculateT0corr(newSeg);
- 	if(applyT0corr) theUpdator->update(newSeg,true);
+ 	if(applyT0corr) theUpdator->update(newSeg,true,0);
 
         result.push_back(newSeg);
       }

--- a/RecoLocalMuon/DTSegment/src/DTLinearFit.cc
+++ b/RecoLocalMuon/DTSegment/src/DTLinearFit.cc
@@ -292,7 +292,7 @@ void DTLinearFit::fit4Var( const vector<float>& xfit,
 
   if (nptfit >= 3) {
 
-    fitNpar(3,xfit,yfit,lfit,tfit,sigy,aminf,bminf,cminf,vminf,chi2fit,debug);
+    fitNpar(3,xfit,yfit,lfit,tfit,sigy,bminf,aminf,cminf,vminf,chi2fit,debug);
     chi2fit3 = chi2fit;
   
     if (cminf!=-999.) {
@@ -320,14 +320,14 @@ void DTLinearFit::fit4Var( const vector<float>& xfit,
 
 
     if (nptfit>=5) {
-      fitNpar(4,xfit,yfit,lfit,tfit,sigy,aminf,bminf,cminf,vminf,chi2fit,debug);
-       
+      fitNpar(4,xfit,yfit,lfit,tfit,sigy,bminf,aminf,cminf,vminf,chi2fit,debug);
+
       if (vminf!=0) { 
         nppar = 4;
         if (nptfit<=nppar){ 
           chi2fitN4=-1;
         } else{
-          chi2fitN4= chi2fit / (nptfit-nppar); 
+          chi2fitN4= chi2fit / (nptfit-nppar);
         }
       } else {
         if (nptfit <= nppar) chi2fitN4=-1;

--- a/RecoLocalMuon/DTSegment/src/DTMeantimerPatternReco.cc
+++ b/RecoLocalMuon/DTSegment/src/DTMeantimerPatternReco.cc
@@ -71,7 +71,7 @@ DTMeantimerPatternReco::reconstruct(const DTSuperLayer* sl,
   while (cand<candidates.end()) {
     
     DTSLRecSegment2D *segment = (**cand);
-    theUpdator->update(segment);
+    theUpdator->update(segment,1);
 
     if (debug) 
       cout<<"Reconstructed 2D segments "<<*segment<<endl;
@@ -207,7 +207,7 @@ DTMeantimerPatternReco::addHits(const DTSuperLayer* sl, vector<DTSegmentCand::As
 //    cout << "DTMeantimerPatternReco::addHit " << endl << "   Picked " << assHits.size() << " hits, " << hits.size() << " left." << endl;
   
   if (assHits.size()+hits.size()<maxfound) return;
-          
+
   // loop over the remaining hits
   for (hitCont::const_iterator hit=hits.begin(); hit!=hits.end(); ++hit) {
 
@@ -216,7 +216,7 @@ DTMeantimerPatternReco::addHits(const DTSuperLayer* sl, vector<DTSegmentCand::As
 //      cout << "     Trying B: " << **hit<< " wire: " << (*hit)->id() << endl;
 //      printPattern(assHits,*hit);
 //    }
-            
+
     assHits.push_back(DTSegmentCand::AssPoint(*hit, DTEnums::Left));
     std::unique_ptr<DTSegmentCand> left_seg = fitWithT0(sl,assHits, chi2l, t0_corrl,0);
     assHits.pop_back();
@@ -231,7 +231,7 @@ DTMeantimerPatternReco::addHits(const DTSuperLayer* sl, vector<DTSegmentCand::As
 
     bool left_ok=(left_seg)?true:false;
     bool right_ok=(right_seg)?true:false;
-    
+
     if (!left_ok && !right_ok) continue;
 
     foundSomething = true;    
@@ -240,7 +240,7 @@ DTMeantimerPatternReco::addHits(const DTSuperLayer* sl, vector<DTSegmentCand::As
     hitCont hitsForFit;
     for (hitCont::const_iterator tmpHit=hit+1; tmpHit!=hits.end(); tmpHit++) 
       if (geometryFilter((*tmpHit)->id(),(*hit)->id())) hitsForFit.push_back(*tmpHit); 
-      
+
     reverse(hitsForFit.begin(),hitsForFit.end());
 
     // choose only one - left or right
@@ -387,7 +387,7 @@ DTMeantimerPatternReco::printPattern( vector<DTSegmentCand::AssPoint>& assHits, 
   int lay  = ((*hit).id().superlayerId().superLayer()-1)*4 + (*hit).id().layerId().layer() - 1;
   wire[lay]= (*hit).id().wire();
   mark[lay*2]='*';
-  
+
   cout << "   " << mark << endl << "  ";
   for (int i=0; i<12; i++) if (wire[i]) cout << setw(2) << wire[i]; else cout << "  ";
   cout << endl;

--- a/RecoLocalMuon/DTSegment/src/DTMeantimerPatternReco4D.cc
+++ b/RecoLocalMuon/DTSegment/src/DTMeantimerPatternReco4D.cc
@@ -170,7 +170,7 @@ DTMeantimerPatternReco4D::reconstruct(){
 
       std::auto_ptr<DTChamberRecSegment2D> superPhi(**phi);
 
-      theUpdator->update(superPhi.get());
+      theUpdator->update(superPhi.get(),1);
       if(debug) cout << "superPhi: " << *superPhi << endl;
 
       if (hasZed) {
@@ -199,12 +199,12 @@ DTMeantimerPatternReco4D::reconstruct(){
           DTRecSegment4D* newSeg = new DTRecSegment4D(*superPhi,*zed,posZInCh,dirZInCh);
 
           /// 4d segment: I have the pos along the wire => further update!
-          theUpdator->update(newSeg);
+          theUpdator->update(newSeg,0,1);
           if (debug) cout << "Created a 4D seg " << *newSeg << endl;
 
           //update the segment with the t0 and possibly vdrift correction
           if(!applyT0corr && computeT0corr) theUpdator->calculateT0corr(newSeg);
-          if(applyT0corr) theUpdator->update(newSeg,true);
+          if(applyT0corr) theUpdator->update(newSeg,true,1);
 
           result.push_back(newSeg);
         }
@@ -216,7 +216,7 @@ DTMeantimerPatternReco4D::reconstruct(){
 
         //update the segment with the t0 and possibly vdrift correction
         if(!applyT0corr && computeT0corr) theUpdator->calculateT0corr(newSeg);
-        if(applyT0corr) theUpdator->update(newSeg,true);
+        if(applyT0corr) theUpdator->update(newSeg,true,1);
 
         result.push_back(newSeg);
       }
@@ -239,7 +239,7 @@ DTMeantimerPatternReco4D::reconstruct(){
         if (debug) cout << "Created a 4D segment using only the 2D Theta segment" << endl;
 
         if(!applyT0corr && computeT0corr) theUpdator->calculateT0corr(newSeg);
-        if(applyT0corr) theUpdator->update(newSeg,true);
+        if(applyT0corr) theUpdator->update(newSeg,true,1);
 
         result.push_back(newSeg);
       }

--- a/RecoLocalMuon/DTSegment/src/DTRefitAndCombineReco4D.cc
+++ b/RecoLocalMuon/DTSegment/src/DTRefitAndCombineReco4D.cc
@@ -125,7 +125,7 @@ DTRefitAndCombineReco4D::reconstruct(){
 	  //<<
 
           /// 4d segment: I have the pos along the wire => further update!
-          theUpdator->update(newSeg);
+          theUpdator->update(newSeg,0,1);
           if (debug) cout << "Created a 4D seg " << endl;
 	  result.push_back(newSeg);
         }
@@ -186,7 +186,7 @@ vector<DTChamberRecSegment2D> DTRefitAndCombineReco4D::refitSuperSegments(){
       DTChamberRecSegment2D superPhi(chId,recHitsSeg2DPhi1); 
       
       // refit it!
-      theUpdator->fit(&superPhi,0);
+      theUpdator->fit(&superPhi,0,0);
       
       // cut on the chi^2
       if (superPhi.chi2() > theMaxChi2forPhi)

--- a/RecoLocalMuon/DTSegment/src/DTSegment4DT0Corrector.cc
+++ b/RecoLocalMuon/DTSegment/src/DTSegment4DT0Corrector.cc
@@ -82,7 +82,7 @@ void DTSegment4DT0Corrector::produce(Event& event, const EventSetup& setup){
 
       if(newSeg == 0) continue;
 
-      theUpdator->update(newSeg,true);
+      theUpdator->update(newSeg,true,0);
       result.push_back(*newSeg);
 
     }

--- a/RecoLocalMuon/DTSegment/src/DTSegmentCand.cc
+++ b/RecoLocalMuon/DTSegment/src/DTSegmentCand.cc
@@ -88,7 +88,7 @@ DTSegmentCand::AssPointCont
 DTSegmentCand::conflictingHitPairs(const DTSegmentCand& seg) const{
   AssPointCont result;
   const AssPointCont & hits2 = seg.theHits;
-  
+
 //  if (nSharedHitPairs(seg)==0) return result;
 
   AssPointCont::const_iterator hitBegin2 = hits2.begin(),   hitEnd2 = hits2.end();
@@ -224,8 +224,9 @@ bool DTSegmentCand::AssPointLessZ::operator()(const AssPoint& pt1,
 }
 
 std::ostream& operator<<(std::ostream& out, const DTSegmentCand& seg) {
-  out <<  " pos: " << seg.position() << " dir: " << seg.direction() 
-      << " chi2/nHits: " << seg.chi2() << "/" << seg.DTSegmentCand::nHits();
+  out <<  " pos: " << seg.position() << " dir: " << seg.direction()
+      << " chi2/nHits: " << seg.chi2() << "/" << seg.DTSegmentCand::nHits()
+      << " t0: " << seg.t0();
   return out;
 }
 

--- a/RecoLocalMuon/DTSegment/src/DTSegmentUpdator.cc
+++ b/RecoLocalMuon/DTSegment/src/DTSegmentUpdator.cc
@@ -71,7 +71,7 @@ void DTSegmentUpdator::setES(const EventSetup& setup){
   theAlgo->setES(setup);
 }
 
-void DTSegmentUpdator::update(DTRecSegment4D* seg, const bool calcT0) const {
+void DTSegmentUpdator::update(DTRecSegment4D* seg, const bool calcT0, bool allow3par) const {
 
   if(debug) cout << "[DTSegmentUpdator] Starting to update the DTRecSegment4D" << endl;
 
@@ -94,19 +94,19 @@ void DTSegmentUpdator::update(DTRecSegment4D* seg, const bool calcT0) const {
   if(hasPhi) updateHits(seg->phiSegment(),pos,dir,step);
   if(hasZed) updateHits(seg->zSegment()  ,pos,dir,step);
 
-  fit(seg);
+  fit(seg,allow3par);
 }
 
-void DTSegmentUpdator::update(DTRecSegment2D* seg) const {
+void DTSegmentUpdator::update(DTRecSegment2D* seg, bool allow3par) const {
   if(debug) cout << "[DTSegmentUpdator] Starting to update the DTRecSegment2D" << endl;
   GlobalPoint pos = (theGeom->idToDet(seg->geographicalId()))->toGlobal(seg->localPosition());
   GlobalVector dir = (theGeom->idToDet(seg->geographicalId()))->toGlobal(seg->localDirection());
 
   updateHits(seg,pos,dir);
-  fit(seg,1);
+  fit(seg,allow3par,0);
 }
 
-void DTSegmentUpdator::fit(DTRecSegment4D* seg)  const {
+void DTSegmentUpdator::fit(DTRecSegment4D* seg, bool allow3par)  const {
   if(debug) cout << "[DTSegmentUpdator] Fit DTRecSegment4D:" << endl;
   // after the update must refit the segments
   
@@ -123,15 +123,15 @@ void DTSegmentUpdator::fit(DTRecSegment4D* seg)  const {
 
       // fit in-time Phi segments with the 2par fit and out-of-time segments with the 3par fit
       if (fabs(seg->phiSegment()->t0())<40.) {
-        fit(seg->phiSegment(),0);
-        fit(seg->zSegment(),0);      
+        fit(seg->phiSegment(),allow3par,1);
+        fit(seg->zSegment(),allow3par,1);      
       } else {
-        fit(seg->phiSegment(),1);        
-        fit(seg->zSegment(),1);      
+        fit(seg->phiSegment(),allow3par,0);
+        fit(seg->zSegment(),allow3par,0);      
       }
 
-    } else fit(seg->phiSegment(),1);
-  } else fit(seg->zSegment(),1);
+    } else fit(seg->phiSegment(),allow3par,0);
+  } else fit(seg->zSegment(),allow3par,0);
  
   const DTChamber* theChamber = theGeom->chamber(seg->chamberId());
 
@@ -277,7 +277,7 @@ bool DTSegmentUpdator::fit(DTSegmentCand* seg, bool allow3par, const bool fitdeb
   return true;
 }
 
-void DTSegmentUpdator::fit(DTRecSegment2D* seg, bool allow3par) const {
+void DTSegmentUpdator::fit(DTRecSegment2D* seg, bool allow3par, bool block3par) const {
 
   if(debug) cout << "[DTSegmentUpdator] Fit DTRecSegment2D - 3par: " << allow3par << endl;
 
@@ -330,7 +330,7 @@ void DTSegmentUpdator::fit(DTRecSegment2D* seg, bool allow3par) const {
   float vminf=0.;
   double t0_corr = 0.;
 
-  fit(x,y,lfit,dist,sigy,pos,dir,cminf,vminf,covMat,chi2,allow3par);
+  fit(x,y,lfit,dist,sigy,pos,dir,cminf,vminf,covMat,chi2,allow3par,block3par);
   if (cminf!=0) t0_corr=-cminf/0.00543; // convert drift distance to time
 
   if (debug) cout << "   DTSeg2d chi2: " << chi2 << endl;
@@ -357,7 +357,8 @@ void DTSegmentUpdator::fit(const vector<float>& x,
                            float& vminf,
                            AlgebraicSymMatrix& covMatrix,
                            double& chi2,
-                           const bool allow3par)  const {
+                           const bool allow3par,
+                           const bool block3par)  const {
 
   float slope     = 0.;
   float intercept = 0.;
@@ -376,10 +377,10 @@ void DTSegmentUpdator::fit(const vector<float>& x,
 
   // If we have at least one left and one right hit we can try the 3 parameter fit (if it is switched on)
   // FIXME: currently the covariance matrix from the 2-par fit is kept
-  if (leftHits && rightHits && (leftHits+rightHits>3)) {
+  if (leftHits && rightHits && (leftHits+rightHits>3) && allow3par) {
     theFitter->fitNpar(3,x,y,lfit,dist,sigy,slope,intercept,cminf,vminf,chi2,debug);	
     double t0_corr=-cminf/0.00543;
-    if (fabs(t0_corr)<20. && !allow3par) {
+    if (fabs(t0_corr)<20. && block3par) {
       theFitter->fit(x,y,x.size(),sigy,slope,intercept,chi2,covss,covii,covsi);
       cminf=0;
     }
@@ -585,16 +586,16 @@ void DTSegmentUpdator::rejectBadHits(DTChamberRecSegment2D* phiSeg) const {
     }
   }
 	
-  phiSeg->update(updatedRecHits);	
-  
+  phiSeg->update(updatedRecHits);
+
   //final check!
-  if(debug){ 
-  
+  if(debug){
+
     vector<float> x_upd;
     vector<float> y_upd;
- 
+
     cout << " Check the update action: " << endl;
- 
+
     vector<DTRecHit1D> hits_upd = phiSeg->specificRecHits();
     for (vector<DTRecHit1D>::const_iterator hit=hits_upd.begin();
 	 hit!=hits_upd.end(); ++hit) {

--- a/RecoLocalMuon/DTSegment/src/DTSegmentUpdator.h
+++ b/RecoLocalMuon/DTSegment/src/DTSegmentUpdator.h
@@ -51,24 +51,24 @@ class DTSegmentUpdator{
 
     /** do the linear fit on the hits of the segment candidate and update it.
      * Returns false if the segment candidate is not good() */
-    bool fit(DTSegmentCand* seg, bool allow3par = false, const bool fitdebug = false) const;
+    bool fit(DTSegmentCand* seg, bool allow3par, const bool fitdebug) const;
 
     /** ditto for true segment: since the fit is applied on a true segment, by
      * definition the segment is "good", while it's not the case for just
      * candidates */
-    void fit(DTRecSegment2D* seg, bool allow3par) const;
+    void fit(DTRecSegment2D* seg, bool allow3par, bool block3par) const;
 
     /** ditto for true segment 4D, the fit is done on either projection and then
      * the 4D direction and position is built. Since the fit is applied on a
      * true segment, by definition the segment is "good", while it's not the
      * case for just candidates */
-    void fit(DTRecSegment4D* seg) const;
+    void fit(DTRecSegment4D* seg, bool allow3par) const;
 
     /// recompute hits position and refit the segment4D
-    void update(DTRecSegment4D* seg, const bool calcT0 = false) const;
+    void update(DTRecSegment4D* seg, const bool calcT0, bool allow3par) const;
 
     /// recompute hits position and refit the segment2D
-    void update(DTRecSegment2D* seg) const;
+    void update(DTRecSegment2D* seg, bool allow3par) const;
 
     void calculateT0corr(DTRecSegment2D* seg) const;
     void calculateT0corr(DTRecSegment4D* seg) const;
@@ -103,7 +103,8 @@ class DTSegmentUpdator{
              float& vminf,
              AlgebraicSymMatrix& covMat,
              double& chi2,
-             const bool allow3par = false) const;
+             const bool allow3par = false,
+             const bool block3par = false) const;
 
     bool vdrift_4parfit;
     double T0_hit_resolution;


### PR DESCRIPTION
This is an update of the "physics changes" that were taken out of #3450. 
The performance of HLT muons should return to the state from pre4, as HLT muons use the (old) combinatorial pattern recognition DT algorithm.
The same should happen to cosmic muons as they also use the old algorithm, though this is changing right now (#3722).

Reco muons change little from pre5/pre6 and the changes should in general be improvements (slightly better segments chi2, better segment angular resolution etc)
