### PR TITLE
Make mutable in EventSetupRecord atomic

### DIFF
--- a/CondFormats/SiPixelObjects/interface/SiPixelQuality.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelQuality.h
@@ -14,12 +14,15 @@
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/GeometryVector/interface/LocalPoint.h"
 #include "CondFormats/SiPixelObjects/interface/GlobalPixel.h"
-#include "CondFormats/DataRecord/interface/SiPixelFedCablingMapRcd.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingMap.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixelFedCabling.h"
 #include "CondFormats/SiPixelObjects/interface/PixelROC.h"
 #include "CondFormats/SiPixelObjects/interface/LocalPixel.h"
 #include "CondFormats/SiStripObjects/interface/SiStripDetVOff.h"
+
+namespace edm {
+  class EventSetup;
+}
 
 class TrackerGeometry;
 

--- a/CondTools/SiPixel/test/SiPixelBadModuleReader.cc
+++ b/CondTools/SiPixel/test/SiPixelBadModuleReader.cc
@@ -1,6 +1,7 @@
 #include "CondFormats/SiPixelObjects/interface/SiPixelQuality.h"
 #include "CondFormats/DataRecord/interface/SiPixelQualityFromDbRcd.h"
 #include "CondFormats/DataRecord/interface/SiPixelQualityRcd.h"
+#include "CondFormats/DataRecord/interface/SiPixelFedCablingMapRcd.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingMap.h"
 #include "CondTools/SiPixel/test/SiPixelBadModuleReader.h"
 #include "DataFormats/DetId/interface/DetId.h"

--- a/DPGAnalysis/SiStripTools/interface/Multiplicities.h
+++ b/DPGAnalysis/SiStripTools/interface/Multiplicities.h
@@ -6,6 +6,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "CalibTracker/Records/interface/SiStripQualityRcd.h"
 #endif
 
 #include "DataFormats/Common/interface/DetSetVector.h"
@@ -22,8 +23,10 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "CalibFormats/SiStripObjects/interface/SiStripQuality.h"
-#include "CalibTracker/Records/interface/SiStripQualityRcd.h"
 
+namespace edm {
+  class EventSetup;
+};
 
 #include <string>
 

--- a/FWCore/Framework/interface/EventSetupRecord.h
+++ b/FWCore/Framework/interface/EventSetupRecord.h
@@ -57,6 +57,7 @@ using the 'setEventSetup' and 'clearEventSetup' functions.
 // system include files
 #include <map>
 #include <vector>
+#include <atomic>
 
 // forward declarations
 namespace cms {
@@ -212,7 +213,7 @@ namespace edm {
          std::map<DataKey, DataProxy const*> proxies_ ;
          EventSetup const* eventSetup_;
          unsigned long long cacheIdentifier_;
-         mutable bool transientAccessRequested_;
+         mutable std::atomic<bool> transientAccessRequested_;
       };
    }
 }


### PR DESCRIPTION
The transient access bool is now atomic since multiple threads could attempt to change it.
