### PR TITLE
updated magnetic field and generator for Geant4 10

### DIFF
--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -131,7 +131,7 @@ g4SimHits = cms.EDProducer("OscarProducer",
         # string HepMCProductLabel = "VtxSmeared"
         HepMCProductLabel = cms.string('generator'),
         ApplyPCuts = cms.bool(True),
-        ApplyPtransCuts = cms.bool(False),
+        ApplyPtransCut = cms.bool(False),
         MinPCut = cms.double(0.04), ## the cut is in GeV 
         MaxPCut = cms.double(99999.0), ## the pmax=99.TeV in this case
         ApplyEtaCuts = cms.bool(True),

--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -131,8 +131,9 @@ g4SimHits = cms.EDProducer("OscarProducer",
         # string HepMCProductLabel = "VtxSmeared"
         HepMCProductLabel = cms.string('generator'),
         ApplyPCuts = cms.bool(True),
-        MinPCut = cms.double(0.04), ## the pt-cut is in GeV (CMS conventions)
-        MaxPCut = cms.double(99999.0), ## the ptmax=99.TeV in this case
+        ApplyPtransCuts = cms.bool(False),
+        MinPCut = cms.double(0.04), ## the cut is in GeV 
+        MaxPCut = cms.double(99999.0), ## the pmax=99.TeV in this case
         ApplyEtaCuts = cms.bool(True),
         MinEtaCut = cms.double(-5.5),
         MaxEtaCut = cms.double(5.5),

--- a/SimG4Core/Generators/interface/Generator.h
+++ b/SimG4Core/Generators/interface/Generator.h
@@ -32,8 +32,6 @@ public:
   virtual const double eventWeight() const { return weight_; }
 private:
   bool particlePassesPrimaryCuts(const G4PrimaryParticle * p) const;
-  bool particlePassesPrimaryCuts( const math::XYZTLorentzVector& mom, 
-				  const double zimp ) const ;
   void particleAssignDaughters(G4PrimaryParticle * p, HepMC::GenParticle * hp, 
 			       double length);
   void setGenId(G4PrimaryParticle* p, int id) const 
@@ -48,8 +46,9 @@ private:
   double theMinEtaCut;
   double theMaxEtaCut;
   double theMinPCut;
+  double theMinPCut2;
   double theMaxPCut;
-  double theRDecLenCut;
+  double theRDecLenCut2;
   double theEtaCutForHector; 
   int verbose;
   HepMC::GenEvent*  evt_;

--- a/SimG4Core/Generators/interface/Generator.h
+++ b/SimG4Core/Generators/interface/Generator.h
@@ -39,6 +39,7 @@ private:
 
 private:
   bool   fPCuts;
+  bool   fPtransCut;
   bool   fEtaCuts;
   bool   fPhiCuts;
   double theMinPhiCut;
@@ -46,7 +47,7 @@ private:
   double theMinEtaCut;
   double theMaxEtaCut;
   double theMinPCut;
-  double theMinPCut2;
+  double theMinPtCut2;
   double theMaxPCut;
   double theRDecLenCut2;
   double theEtaCutForHector; 

--- a/SimG4Core/Generators/src/Generator.cc
+++ b/SimG4Core/Generators/src/Generator.cc
@@ -14,22 +14,19 @@
 #include "G4PhysicalConstants.hh"
 
 using namespace edm;
-using std::cout;
-using std::endl;
-//using std::string;
-
+//using std::cout;
+//using std::endl;
 
 Generator::Generator(const ParameterSet & p) : 
   fPCuts(p.getParameter<bool>("ApplyPCuts")),
   fEtaCuts(p.getParameter<bool>("ApplyEtaCuts")), 
   fPhiCuts(p.getParameter<bool>("ApplyPhiCuts")),
-  theMinPhiCut(p.getParameter<double>("MinPhiCut")),   // now operates in radians (CMS standard)
+  theMinPhiCut(p.getParameter<double>("MinPhiCut")), // in radians (CMS standard)
   theMaxPhiCut(p.getParameter<double>("MaxPhiCut")),
   theMinEtaCut(p.getParameter<double>("MinEtaCut")),
   theMaxEtaCut(p.getParameter<double>("MaxEtaCut")),
-  theMinPCut(p.getParameter<double>("MinPCut")),    // now operates in GeV (CMS standard)
+  theMinPCut(p.getParameter<double>("MinPCut")),    // in GeV (CMS standard)
   theMaxPCut(p.getParameter<double>("MaxPCut")),   
-  theRDecLenCut(p.getParameter<double>("RDecLenCut")*cm),
   theEtaCutForHector(p.getParameter<double>("EtaCutForHector")),
   verbose(p.getUntrackedParameter<int>("Verbosity",0)),
   evt_(0),
@@ -40,6 +37,9 @@ Generator::Generator(const ParameterSet & p) :
   Z_hector(0),
   pdgFilterSel(false) 
 {
+  double theRDecLenCut = p.getParameter<double>("RDecLenCut")*cm;
+  theRDecLenCut2 = theRDecLenCut*theRDecLenCut;
+  theMinPCut2 = theMinPCut*theMinPCut;
 
   pdgFilter.resize(0);
   if ( p.exists("PDGselection") ) {
@@ -48,54 +48,53 @@ Generator::Generator(const ParameterSet & p) :
       (p.getParameter<edm::ParameterSet>("PDGselection")).getParameter<bool>("PDGfilterSel");
     pdgFilter = 
       (p.getParameter<edm::ParameterSet>("PDGselection")).getParameter<std::vector< int > >("PDGfilter");
-    for ( unsigned int ii = 0; ii < pdgFilter.size() ; ii++ ) {
+    for ( unsigned int ii = 0; ii < pdgFilter.size(); ++ii) {
       if (pdgFilterSel) {
-        edm::LogWarning("SimG4CoreGenerator") << " *** Selecting only PDG ID = " << pdgFilter[ii];
+        edm::LogWarning("SimG4CoreGenerator") << " *** Selecting only PDG ID = " 
+					      << pdgFilter[ii];
       } else {
-        edm::LogWarning("SimG4CoreGenerator") << " *** Filtering out PDG ID = " << pdgFilter[ii];
+        edm::LogWarning("SimG4CoreGenerator") << " *** Filtering out PDG ID = " 
+					      << pdgFilter[ii];
       }
     }
-  
   }
 
   if(fEtaCuts){
-    Z_lmax = theRDecLenCut*( ( 1 - exp(-2*theMaxEtaCut) ) / ( 2*exp(-theMaxEtaCut) ) );
-    Z_lmin = theRDecLenCut*( ( 1 - exp(-2*theMinEtaCut) ) / ( 2*exp(-theMinEtaCut) ) );
+    Z_lmax = theRDecLenCut*((1 - exp(-2*theMaxEtaCut) )/( 2*exp(-theMaxEtaCut)));
+    Z_lmin = theRDecLenCut*((1 - exp(-2*theMinEtaCut) )/( 2*exp(-theMinEtaCut)));
   }
 
-  Z_hector = theRDecLenCut*( ( 1 - exp(-2*theEtaCutForHector) ) / ( 2*exp(-theEtaCutForHector) ) );
+  Z_hector = theRDecLenCut*((1 - exp(-2*theEtaCutForHector)) 
+			    / ( 2*exp(-theEtaCutForHector) ) );
 
-  if ( verbose > 0 ) LogDebug("SimG4CoreGenerator") 
-    << "Z_min = " << Z_lmin << " Z_max = " << Z_lmax << " Z_hector = " << Z_hector 
-    << std::endl;
-
+  edm::LogInfo("SimG4CoreGenerator") 
+    << "Z_min = " << Z_lmin << " Z_max = " << Z_lmax << " Z_hector = " << Z_hector;
+  if(0 < verbose) LogDebug("SimG4CoreGenerator")
+    << "Z_min = " << Z_lmin << " Z_max = " << Z_lmax << " Z_hector = " << Z_hector;
 }
 
 Generator::~Generator() 
-{ 
-}
+{}
 
 void Generator::HepMC2G4(const HepMC::GenEvent * evt_orig, G4Event * g4evt)
 {
 
-  if ( *(evt_orig->vertices_begin()) == 0 )
-    {
-      throw SimG4Exception( "SimG4CoreGenerator: Corrupted Event - GenEvent with no vertex" ) ;
-    }
+  if ( *(evt_orig->vertices_begin()) == 0 ) {
+    throw SimG4Exception("SimG4CoreGenerator: Corrupted Event - GenEvent with no vertex");
+  }  
   
+  HepMC::GenEvent* evt = new HepMC::GenEvent(*evt_orig);
   
-  HepMC::GenEvent* evt = new HepMC::GenEvent(*evt_orig) ;
-  
-  if ( evt->weights().size() > 0 )
-    {
-      weight_ = evt->weights()[0] ;
-      for ( unsigned int iw=1; iw<evt->weights().size(); iw++ )
-        {
-          // terminate if the versot of weights contains a zero-weight
-          if ( evt->weights()[iw] <= 0 ) break;
-          weight_ *= evt->weights()[iw] ;
-        }     
-    }
+  if (evt->weights().size() > 0) {
+
+    weight_ = evt->weights()[0] ;
+    for (unsigned int iw=1; iw<evt->weights().size(); ++iw) {
+
+      // terminate if the versot of weights contains a zero-weight
+      if ( evt->weights()[iw] <= 0 ) break;
+      weight_ *= evt->weights()[iw] ;
+    }     
+  }
   
   if (vtx_ != 0) delete vtx_;
   vtx_ = new math::XYZTLorentzVector((*(evt->vertices_begin()))->position().x(),
@@ -103,71 +102,87 @@ void Generator::HepMC2G4(const HepMC::GenEvent * evt_orig, G4Event * g4evt)
                                      (*(evt->vertices_begin()))->position().z(),
                                      (*(evt->vertices_begin()))->position().t());
   
-  if(verbose >0){
+  if(verbose > 0) {
     evt->print();
-    LogDebug("SimG4CoreGenerator") << "Primary Vertex = (" << vtx_->x() << "," 
-                                   << vtx_->y() << ","
-                                   << vtx_->z() << ")";
+    LogDebug("SimG4CoreGenerator") << "Primary Vertex = (" 
+					<< vtx_->x() << "," 
+					<< vtx_->y() << ","
+					<< vtx_->z() << ")";
   }
-  
-  //  double x0 = vtx_->x();
-  //  double y0 = vtx_->y();
-  
+    
   unsigned int ng4vtx = 0;
 
   for(HepMC::GenEvent::vertex_const_iterator vitr= evt->vertices_begin();
       vitr != evt->vertices_end(); ++vitr ) { 
+
     // loop for vertex ...
     // real vertex?
     G4bool qvtx=false;
-    
-    for (HepMC::GenVertex::particle_iterator pitr= (*vitr)->particles_begin(HepMC::children);
+    HepMC::GenVertex::particle_iterator pitr;
+    for (pitr= (*vitr)->particles_begin(HepMC::children);
          pitr != (*vitr)->particles_end(HepMC::children); ++pitr) {
+
       // Admit also status=1 && end_vertex for long vertex special decay treatment 
-      if ((*pitr)->status()==1) {
-        qvtx=true;
-        if ( verbose > 2 ) LogDebug("SimG4CoreGenerator") 
+      if (1 == (*pitr)->status()) {
+
+        qvtx = true;
+        if (verbose > 1) LogDebug("SimG4CoreGenerator") 
 	  << "GenVertex barcode = " << (*vitr)->barcode() 
-	  << " selected for GenParticle barcode = " << (*pitr)->barcode() 
-	  << std::endl;
+	  << " selected for GenParticle barcode = " << (*pitr)->barcode();
         break;
       }  
-      // The selection is made considering if the partcile with status = 2 have the end_vertex
-      // with a radius (R) greater then the theRDecLenCut that means: the end_vertex is outside
-      // the beampipe cilinder (no requirement on the Z of the vertex is applyed).
-      else if ( (*pitr)->status()== 2 ) {
+      // The selection is made considering if the partcile with status = 2 
+      // have the end_vertex with a radius (R) greater then the theRDecLenCut 
+      // that means: the end_vertex is outside the beampipe cilinder 
+      // (no requirement on the Z of the vertex is applyed).
+      else if (2 == (*pitr)->status()) {
+
         if ( (*pitr)->end_vertex() != 0  ) { 
-          //double xx = x0-(*pitr)->end_vertex()->position().x();
-          //double yy = y0-(*pitr)->end_vertex()->position().y();
           double xx = (*pitr)->end_vertex()->position().x();
           double yy = (*pitr)->end_vertex()->position().y();
-          double r_dd=std::sqrt(xx*xx+yy*yy);
-          if (r_dd>theRDecLenCut){
-            qvtx=true;
-            if ( verbose > 2 ) LogDebug("SimG4CoreGenerator") 
+          double r_dd = xx*xx+yy*yy;
+          if (r_dd > theRDecLenCut2){
+            qvtx = true;
+            if (verbose > 1) LogDebug("SimG4CoreGenerator") 
 	      << "GenVertex barcode = " << (*vitr)->barcode() 
 	      << " selected for GenParticle barcode = " 
-	      << (*pitr)->barcode() << " radius = " << r_dd << std::endl;
+	      << (*pitr)->barcode() << " radius = " << std::sqrt(r_dd);
             break;
           }
-        }
+        } else {
+	  // particles with stus 2 without end_vertex are equivalent to stable
+	  qvtx = true;
+	}
       }
     }
 
-
+    // if this vertex has no long-lived secondary the vertex is not saved 
     if (!qvtx) {
       continue;
     }
     
-    double x1 = (*vitr)->position().x();
-    double y1 = (*vitr)->position().y();
-    double z1 = (*vitr)->position().z();
-    double t1 = (*vitr)->position().t();	
-    G4PrimaryVertex* g4vtx= 
-      new G4PrimaryVertex(x1*mm, y1*mm, z1*mm, t1*mm/c_light);
+    double x1 = (*vitr)->position().x()*mm;
+    double y1 = (*vitr)->position().y()*mm;
+    double z1 = (*vitr)->position().z()*mm;
+    double t1 = (*vitr)->position().t()*mm/c_light;
+
+    G4PrimaryVertex* g4vtx = new G4PrimaryVertex(x1, y1, z1, t1);
     
-    for (HepMC::GenVertex::particle_iterator vpitr= (*vitr)->particles_begin(HepMC::children);
-         vpitr != (*vitr)->particles_end(HepMC::children); ++vpitr){
+    for (pitr= (*vitr)->particles_begin(HepMC::children);
+         pitr != (*vitr)->particles_end(HepMC::children); ++pitr){
+
+      // Filter on allowed particle species if required      
+      if ( pdgFilter.size() > 0 ) {
+        std::vector<int>::iterator it = find(pdgFilter.begin(),pdgFilter.end(),
+					     (*pitr)->pdg_id()); 
+        if ( (it != pdgFilter.end() && !pdgFilterSel) 
+	     || ( it == pdgFilter.end() && pdgFilterSel ) ) {
+          if (verbose > 1) LogDebug("SimG4CoreGenerator") 
+	    << "Skip GenParticle barcode = " << (*pitr)->barcode() 
+	    << " PDG Id = " << (*pitr)->pdg_id();
+          continue;
+        }
+      }
 
       // Special cases:
       // 1) import in Geant4 a full decay chain (e.g. also particles with status == 2) 
@@ -177,113 +192,152 @@ void Generator::HepMC2G4(const HepMC::GenEvent * evt_orig, G4Event * g4evt)
       // 2) import in Geant4 particles with status == 1 but a final end vertex. 
       //    The time of the vertex is used as the time of flight to be forced for the particle 
       
-      double r_decay_length=-1;
-      double decay_length=-1;
+      double x2 = 0.0;
+      double y2 = 0.0;
+      double z2 = 0.0;
+      double decay_length = 0.0;
+      int status = (*pitr)->status();
 
-      if ( (*vpitr)->status() == 1 || (*vpitr)->status() == 2 ) {
-        // this particle has decayed
-        if ( (*vpitr)->end_vertex() != 0 ) { 
-          // needed some particles have status 2 and no end_vertex 
-          // Which are the particles with status 2 and not end_vertex, what are suppose to di such kind of particles
-          // when propagated to geant?
-          
-          double x2 = (*vpitr)->end_vertex()->position().x();
-          double y2 = (*vpitr)->end_vertex()->position().y();
-          double z2 = (*vpitr)->end_vertex()->position().z();
-          r_decay_length=std::sqrt(x2*x2+y2*y2);
-          decay_length=std::sqrt((x1-x2)*(x1-x2)+(y1-y2)*(y1-y2)+(z1-z2)*(z1-z2));
+      if (1 == status || 2 == status) {
 
-        }
+        // this particle has decayed but have no vertex
+	// it is an exotic case
+        if ( !(*pitr)->end_vertex() ) { 
+          status = 1; 
+	} else {
+          x2 = (*pitr)->end_vertex()->position().x();
+          y2 = (*pitr)->end_vertex()->position().y();
+          z2 = (*pitr)->end_vertex()->position().z();
+	  decay_length = 
+	      std::sqrt((x2-x1)*(x2-x1)+(y2-y1)*(y2-y1)+(z2-z1)*(z2-z1));
+	}
       } 
-      // end modification
 
       bool toBeAdded = false;
-      math::XYZTLorentzVector p((*vpitr)->momentum().px(),
-                                (*vpitr)->momentum().py(),
-                                (*vpitr)->momentum().pz(),
-                                (*vpitr)->momentum().e());
+      double px = (*pitr)->momentum().px();
+      double py = (*pitr)->momentum().py();
+      double pz = (*pitr)->momentum().pz();
+      double ptot = std::sqrt(px*px + py*py + pz*pz);
+      math::XYZTLorentzVector p(px, py, pz, (*pitr)->momentum().e());
+      
+      double ximpact = x1;
+      double yimpact = y1;
+      double zimpact = z1;
 
       // protection against numerical problems for extremely low momenta
       const double minTan = 1.e-20;
-      double zimpact = Z_hector+1.;
-      if ( fabs(z1) < Z_hector && fabs(p.pt()/p.pz()) >= minTan ) { 
-        // write tan(p.Theta()) as p.Pt()/p.Pz()
-        zimpact = (theRDecLenCut-sqrt(x1*x1+y1*y1))*(p.pz()/p.pt())+z1;
+      if(fabs(z1) < Z_hector && fabs(pz) >= minTan*ptot) {
+        if(pz > 0.0) { zimpact =  Z_hector; }
+	else         { zimpact = -Z_hector; }
+        double del = (zimpact - z1)/pz;
+        ximpact += del*px;
+        yimpact += del*py;
       }
+      double rimpact2 = ximpact*ximpact + yimpact*yimpact;
       
-      if ( verbose > 2 ) LogDebug("SimG4CoreGenerator") 
-	<< "Processing GenParticle barcode = " << (*vpitr)->barcode() 
-	<< " status = " << (*vpitr)->status() 
-	<< " zimpact = " << zimpact;
-      
-      // Filter on allowed particle species if required
-      
-      if ( pdgFilter.size() > 0 ) {
-        std::vector<int>::iterator it = find(pdgFilter.begin(),pdgFilter.end(),(*vpitr)->pdg_id()); 
-        if ( (it != pdgFilter.end() && !pdgFilterSel) || ( it == pdgFilter.end() && pdgFilterSel ) ) {
-          toBeAdded = false;         
-          if ( verbose > 2 ) LogDebug("SimG4CoreGenerator") 
-	    << "Skip GenParticle barcode = " << (*vpitr)->barcode() 
-	    << " PDG Id = " << (*vpitr)->pdg_id() << std::endl;
-          continue;
-        }
-      }
-      
-      
-      // Standard case: particles not decayed by the generator
-      if( (*vpitr)->status() == 1 && fabs(zimpact) < Z_hector ) {
-        if ( !particlePassesPrimaryCuts( p, zimpact ) ) {
-          continue ;
-        }
-        toBeAdded = true;
-        if ( verbose > 2 ) LogDebug("SimG4CoreGenerator") 
-	  << "GenParticle barcode = " << (*vpitr)->barcode() 
-	  << " passed case 1" << std::endl;
-      }
-      
-      // Decay chain entering exiting the fiducial cylinder defined by theRDecLenCut
-      else if((*vpitr)->status() == 2 && r_decay_length > theRDecLenCut  && 
-         fabs(zimpact) < Z_hector ) {
-        toBeAdded=true;
-        if ( verbose > 2 ) LogDebug("SimG4CoreGenerator") 
-	  << "GenParticle barcode = " << (*vpitr)->barcode() 
-	  << " passed case 2" << std::endl;
-      }
-      
+      if (verbose > 1) LogDebug("SimG4CoreGenerator") 
+	<< "Processing GenParticle barcode= " << (*pitr)->barcode() 
+	<< " status= " << (*pitr)->status() 
+	<< " st= " << status 
+	<< " rimpact(cm)= " << std::sqrt(rimpact2)/cm
+	<< " zimpact(cm)= " << zimpact/cm
+	<< " ptot(GeV)= " << ptot;
+
       // Particles trasnported along the beam pipe for forward detectors (HECTOR)
       // Always pass to Geant4 without cuts (to be checked)
-      else if( (*vpitr)->status() == 1 && fabs(zimpact) >= Z_hector && fabs(z1) >= Z_hector) {
+      if( 1 == status && 
+	  fabs(zimpact) >= Z_hector && rimpact2 <= theRDecLenCut2) {
         toBeAdded = true;
-        if ( verbose > 2 ) LogDebug("SimG4CoreGenerator") 
-	  << "GenParticle barcode = " << (*vpitr)->barcode() 
-	  << " passed case 3" << std::endl;
-      }
+        if ( verbose > 1 ) LogDebug("SimG4CoreGenerator") 
+	  << "GenParticle barcode = " << (*pitr)->barcode() 
+	  << " passed case 3";
+      } else {
 
+        double decay_length = 0.0;
+	// Standard case: particles not decayed by the generator
+	// or particle decying without end vertex
+	if(1 == status && 
+	   (fabs(zimpact) < Z_hector || rimpact2 > theRDecLenCut2)) {
+
+	  // Ptot cut (was assumed to be Pt?)
+	  //if (fPCuts && (ptot < theMinPCut || ptot > theMaxPCut)) {
+	  if (fPCuts && (px*px + py*py < theMinPCut2 || ptot > theMaxPCut)) {
+            continue;
+	  }
+          // phi cut
+	  if (fPhiCuts) {
+            double phi = p.phi();
+	    if(phi < theMinPhiCut || phi  > theMaxPhiCut) {
+	      continue;
+	    }
+	  }
+
+	  // eta cut
+	  double xi = x1;
+	  double yi = y1;
+	  double zi = z1;
+
+	  // can be propagated along Z
+	  if(fabs(pz) >= minTan*ptot) {
+	    if(zi >= Z_lmax && pz < 0.0) {
+              zi = Z_lmax;
+	    } else if(zi <= Z_lmin && pz > 0.0) {
+              zi = Z_lmin;
+	    } else {
+              if(pz > 0) { zi = Z_lmax; }
+              else { zi = Z_lmin; }
+	    }
+	    double del = (zi - z1)/pz;
+	    xi += del*px;
+	    yi += del*py;
+	  }
+	  // check eta cut
+	  if(xi*xi + yi*yi < theRDecLenCut2) {
+	    continue;
+	  }
+	  toBeAdded = true;
+	  if ( verbose > 1 ) LogDebug("SimG4CoreGenerator") 
+	    << "GenParticle barcode = " << (*pitr)->barcode() 
+	    << " passed case 1";
+	}
+      
+	// Decay chain entering exiting the fiducial cylinder 
+	// defined by theRDecLenCut
+	if(2 == status && x2*x2 + y2*y2 >= theRDecLenCut2 && fabs(z2) < Z_hector) {
+	  toBeAdded=true;
+
+	  if ( verbose > 1 ) LogDebug("SimG4CoreGenerator") 
+	    << "GenParticle barcode = " << (*pitr)->barcode() 
+	    << " passed case 2" 
+	    << " decay_length(cm)= " << decay_length/cm;
+	}
+      }
       if(toBeAdded){
         
-        G4int pdgcode= (*vpitr)-> pdg_id();
+        G4int pdgcode= (*pitr)-> pdg_id();
         G4PrimaryParticle* g4prim= 
-          new G4PrimaryParticle(pdgcode, p.Px()*GeV, p.Py()*GeV, p.Pz()*GeV);
+          new G4PrimaryParticle(pdgcode, px*GeV, py*GeV, pz*GeV);
         
         if ( g4prim->GetG4code() != 0 ){ 
-          g4prim->SetMass( g4prim->GetG4code()->GetPDGMass() ) ;
-          g4prim->SetCharge( g4prim->GetG4code()->GetPDGCharge() ) ;  
+          g4prim->SetMass( g4prim->GetG4code()->GetPDGMass() );
+          g4prim->SetCharge( g4prim->GetG4code()->GetPDGCharge() );  
         }
 
 	// V.I. do not use SetWeight but the same code
         // value of the code compute inside TrackWithHistory        
         //g4prim->SetWeight( 10000*(*vpitr)->barcode() ) ;
-        setGenId( g4prim, (*vpitr)->barcode() ) ;
+        setGenId( g4prim, (*pitr)->barcode() );
 
-        if ( (*vpitr)->status() == 2 ) {
+        if (2 == status) {
           particleAssignDaughters(g4prim,
-				  (HepMC::GenParticle *) *vpitr, decay_length);
+				  (HepMC::GenParticle *) *pitr, decay_length);
 	}
         if ( verbose > 1 ) g4prim->Print();
         g4vtx->SetPrimary(g4prim);
+
         // impose also proper time for status=1 and available end_vertex
-        if ( (*vpitr)->status()==1 && (*vpitr)->end_vertex()!=0) {
-          double proper_time=decay_length/(p.Beta()*p.Gamma()*c_light);
+        if ( 1 == status && decay_length > 0.0) {
+          double proper_time = decay_length/(p.Beta()*p.Gamma()*c_light);
           if ( verbose > 1 ) LogDebug("SimG4CoreGenerator") 
 	    <<"Setting proper time for beta="<<p.Beta()<<" gamma="
 	    <<p.Gamma()<<" Proper time=" <<proper_time/ns<<" ns" ;
@@ -294,46 +348,45 @@ void Generator::HepMC2G4(const HepMC::GenEvent * evt_orig, G4Event * g4evt)
 
     if (verbose > 1 ) g4vtx->Print();
     g4evt->AddPrimaryVertex(g4vtx);
-    ng4vtx++;
+    ++ng4vtx;
   }
   
-  // Add a protection for completely empty events (produced by LHCTransport): add a dummy vertex with no particle attached to it
+  // Add a protection for completely empty events (produced by LHCTransport): 
+  // add a dummy vertex with no particle attached to it
   if ( ng4vtx == 0 ) {
-    double x1 = 0.;
-    double y1 = 0.;
-    double z1 = 0.;
-    double t1 = 0.;
-    G4PrimaryVertex* g4vtx= 
-      new G4PrimaryVertex(x1*mm, y1*mm, z1*mm, t1*mm/c_light);
+    G4PrimaryVertex* g4vtx = new G4PrimaryVertex(0.0, 0.0, 0.0, 0.0);
     if (verbose > 1 ) g4vtx->Print();
     g4evt->AddPrimaryVertex(g4vtx);
   }
   
-  delete evt ;  
-  
-  return ;
+  delete evt;
 }
 
-void Generator::particleAssignDaughters( G4PrimaryParticle* g4p, HepMC::GenParticle* vp, double decaylength)
+void Generator::particleAssignDaughters( G4PrimaryParticle* g4p, 
+					 HepMC::GenParticle* vp, double decaylength)
 {
- 
-  if ( !(vp->end_vertex())  ) return ;
+  // not needed anymore
+  //if (!(vp->end_vertex())) return;
    
   if ( verbose > 1 ) 
-    LogDebug("SimG4CoreGenerator") << "Special case of long decay length \n" 
-                                   << "Assign daughters with to mother with decaylength=" << decaylength << "mm";
-  math::XYZTLorentzVector p(vp->momentum().px(), vp->momentum().py(), vp->momentum().pz(), vp->momentum().e());
-  double proper_time=decaylength/(p.Beta()*p.Gamma()*c_light);
-  if ( verbose > 2 ) {
-    LogDebug("SimG4CoreGenerator") <<" px="<<vp->momentum().px()
-                                   <<" py="<<vp->momentum().py()
-                                   <<" pz="<<vp->momentum().pz()
-                                   <<" e="<<vp->momentum().e()
-                                   <<" beta="<<p.Beta()
-                                   <<" gamma="<<p.Gamma()
-                                   <<" Proper time=" <<proper_time<<" ns" ;
+    LogDebug("SimG4CoreGenerator") 
+      << "Special case of long decay length \n" 
+      << "Assign daughters with to mother with decaylength=" 
+      << decaylength/cm << " cm";
+  math::XYZTLorentzVector p(vp->momentum().px(), vp->momentum().py(), 
+			    vp->momentum().pz(), vp->momentum().e());
+  double proper_time = decaylength/(p.Beta()*p.Gamma()*c_light);
+  if( verbose > 1 ) {
+    LogDebug("SimG4CoreGenerator") <<" px= "<< p.px()
+					<<" py= "<< p.py()
+					<<" pz= "<< p.pz()
+					<<" e= " <<  p.e()
+					<<" beta= "<< p.Beta()
+					<<" gamma= " << p.Gamma()
+					<<" Proper time= " <<proper_time/ns <<" ns";
   }
-  g4p->SetProperTime(proper_time*ns); // the particle will decay after the same length if it has not interacted before
+  g4p->SetProperTime(proper_time); 
+  // the particle will decay after the same length if it has not interacted before
   double x1 = vp->end_vertex()->position().x();
   double y1 = vp->end_vertex()->position().y();
   double z1 = vp->end_vertex()->position().z();
@@ -357,9 +410,11 @@ void Generator::particleAssignDaughters( G4PrimaryParticle* g4p, HepMC::GenParti
     // V.I. do not use SetWeight but the same code
     // value of the code compute inside TrackWithHistory        
     //g4daught->SetWeight( 10000*(*vpdec)->barcode() ) ;
-    setGenId( g4daught, (*vpdec)->barcode() ) ;
-    if ( verbose > 1 ) LogDebug("SimG4CoreGenerator") <<"Assigning a "<<(*vpdec)->pdg_id()
-                                                      <<" as daughter of a " <<vp->pdg_id() ;
+    setGenId( g4daught, (*vpdec)->barcode() );
+
+    if ( verbose > 1 ) LogDebug("SimG4CoreGenerator") 
+      <<"Assigning a "<<(*vpdec)->pdg_id()
+      <<" as daughter of a " <<vp->pdg_id();
     if ( (*vpdec)->status() == 2 && (*vpdec)->end_vertex() != 0 ) 
       {
         double x2 = (*vpdec)->end_vertex()->position().x();
@@ -374,34 +429,14 @@ void Generator::particleAssignDaughters( G4PrimaryParticle* g4p, HepMC::GenParti
   return;
 }
 
-bool Generator::particlePassesPrimaryCuts( const math::XYZTLorentzVector& mom, const double zimp ) const 
-{
-  
-  double phi = mom.Phi() ;   
-  double nrg  = mom.P() ;
-  bool   flag = true;
-
-  if ( (fEtaCuts) && (zimp < Z_lmin       || zimp > Z_lmax)      ) {
-    flag = false;
-  } else if ( (fPCuts)  && (nrg   < theMinPCut   || nrg  > theMaxPCut) ) {
-    flag = false;
-  } else if ( (fPhiCuts) && (phi  < theMinPhiCut || phi  > theMaxPhiCut) ) {
-    flag = false;
-  }
-
-  if ( verbose > 2 ) LogDebug("SimG4CoreGenerator") << "Generator p = " << nrg << " z_imp = " << zimp << " phi = " << mom.Phi() << " Flag = " << flag;
-  
-  return flag;
-}
-
 bool Generator::particlePassesPrimaryCuts(const G4PrimaryParticle * p) const 
 {
 
   G4ThreeVector mom = p->GetMomentum();
-  double        phi = mom.phi() ;
-  double        nrg  = sqrt(p->GetPx()*p->GetPx() + p->GetPy()*p->GetPy() + p->GetPz()*p->GetPz());
-  nrg /= GeV ;  // need to convert, since Geant4 operates in MeV
-  double        eta = -log(tan(mom.theta()/2));
+  double        phi = mom.phi();
+  double        nrg = mom.mag()/GeV;
+
+  double        eta = -log(0.5*tan(mom.theta()));
   bool   flag = true;
 
   if ( (fEtaCuts) && (eta < theMinEtaCut || eta > theMaxEtaCut) ) {
@@ -412,49 +447,47 @@ bool Generator::particlePassesPrimaryCuts(const G4PrimaryParticle * p) const
     flag = false;
   }
   
-  if ( verbose > 2 ) LogDebug("SimG4CoreGenerator") << "Generator p = " << nrg  << " eta = " << eta << " theta = " << mom.theta() << " phi = " << phi << " Flag = " << flag;
+  if ( verbose > 1 ) LogDebug("SimG4CoreGenerator") 
+    << "Generator p = " << nrg  << " eta = " << eta 
+    << " theta = " << mom.theta() << " phi = " << phi << " Flag = " << flag;
 
   return flag;
-
 }
 
 void Generator::nonBeamEvent2G4(const HepMC::GenEvent * evt, G4Event * g4evt) 
 {
   int i = 0; 
   for(HepMC::GenEvent::particle_const_iterator it = evt->particles_begin(); 
-      it != evt->particles_end(); ++it ) 
-    {
-      i++;
-      HepMC::GenParticle * g = (*it);	
-      int g_status = g->status();
-      // storing only particle with status == 1 	
-      if (g_status == 1) 
-	{
-	  int g_id = g->pdg_id();	    
-	  G4PrimaryParticle * g4p = 
-	    new G4PrimaryParticle(g_id,g->momentum().px()*GeV,g->momentum().py()*GeV,g->momentum().pz()*GeV);
-	  if (g4p->GetG4code() != 0) 
-	    { 
-	      g4p->SetMass(g4p->GetG4code()->GetPDGMass());
-	      g4p->SetCharge(g4p->GetG4code()->GetPDGCharge()) ;
-	    }
-	  // V.I. do not use SetWeight but the same code
-	  // value of the code compute inside TrackWithHistory        
-	  //g4p->SetWeight(i*10000);
-	  setGenId(g4p,i);
-	  if (particlePassesPrimaryCuts(g4p)) 
-	    {
-	      G4PrimaryVertex * v = new 
-		G4PrimaryVertex(g->production_vertex()->position().x()*mm,
-				g->production_vertex()->position().y()*mm,
-				g->production_vertex()->position().z()*mm,
-				g->production_vertex()->position().t()*mm/c_light);
-	      v->SetPrimary(g4p);
-	      g4evt->AddPrimaryVertex(v);
-	      if(verbose >0) {
-		v->Print();
-	      }
-	    }
+      it != evt->particles_end(); ++it ) {
+    ++i;
+    HepMC::GenParticle * g = (*it);	
+    int g_status = g->status();
+    // storing only particle with status == 1 	
+    if (g_status == 1) {
+      int g_id = g->pdg_id();	    
+      G4PrimaryParticle * g4p = 
+	new G4PrimaryParticle(g_id,g->momentum().px()*GeV,
+			      g->momentum().py()*GeV,g->momentum().pz()*GeV);
+      if (g4p->GetG4code() != 0) { 
+	g4p->SetMass(g4p->GetG4code()->GetPDGMass());
+	g4p->SetCharge(g4p->GetG4code()->GetPDGCharge()) ;
+      }
+      // V.I. do not use SetWeight but the same code
+      // value of the code compute inside TrackWithHistory        
+      //g4p->SetWeight(i*10000);
+      setGenId(g4p,i);
+      if (particlePassesPrimaryCuts(g4p)) {
+	G4PrimaryVertex * v = 
+	  new G4PrimaryVertex(g->production_vertex()->position().x()*mm,
+			      g->production_vertex()->position().y()*mm,
+			      g->production_vertex()->position().z()*mm,
+			      g->production_vertex()->position().t()*mm/c_light);
+	v->SetPrimary(g4p);
+	g4evt->AddPrimaryVertex(v);
+	if(verbose >0) {
+	  v->Print();
 	}
-    } // end loop on HepMC particles
+      }
+    }
+  } // end loop on HepMC particles
 }

--- a/SimG4Core/MagneticField/interface/FieldBuilder.h
+++ b/SimG4Core/MagneticField/interface/FieldBuilder.h
@@ -61,6 +61,7 @@ namespace sim {
     double maxLoopCount;
     double minEpsilonStep;
     double maxEpsilonStep;
+    double delta;
     edm::ParameterSet thePSet ;
   };
 }

--- a/SimG4Core/MagneticField/interface/FieldStepper.h
+++ b/SimG4Core/MagneticField/interface/FieldStepper.h
@@ -9,7 +9,7 @@ namespace sim {
    class FieldStepper : public G4MagIntegratorStepper
    {
       public:
-	 FieldStepper(G4Mag_UsualEqRhs * eq);
+     FieldStepper(G4Mag_UsualEqRhs * eq, double del = 0.0);
 	 ~FieldStepper();
 	 virtual void Stepper(const double y[],const double dydx[],double h,
 			      double yout[],double yerr[]);
@@ -19,6 +19,7 @@ namespace sim {
       private:
 	 G4MagIntegratorStepper * theStepper;
 	 G4Mag_UsualEqRhs * theEquation;  
+         double delta;
    };
 }
 

--- a/SimG4Core/MagneticField/src/FieldBuilder.cc
+++ b/SimG4Core/MagneticField/src/FieldBuilder.cc
@@ -32,20 +32,20 @@ using namespace sim;
 
 FieldBuilder::FieldBuilder(const MagneticField * f, 
 			   const edm::ParameterSet & p) 
-   : theField( new Field(f,p.getParameter<double>("delta"))), 
-     theFieldEquation(new G4Mag_UsualEqRhs(theField.get())),
-     theTopVolume(0), fChordFinder(0), fChordFinderMonopole(0),
-     fieldValue(0.), minStep(0.), dChord(0.), dOneStep(0.),
-     dIntersection(0.), dIntersectionAndOneStep(0.), 
-     maxLoopCount(0), minEpsilonStep(0.), maxEpsilonStep(0.), 
-     thePSet(p) {
-
+  : theField(new Field(f, p.getParameter<double>("delta"))),
+    theFieldEquation(new G4Mag_UsualEqRhs(theField.get())),
+    theTopVolume(0), fChordFinder(0), fChordFinderMonopole(0),
+    fieldValue(0.), minStep(0.), dChord(0.), dOneStep(0.),
+    dIntersection(0.), dIntersectionAndOneStep(0.), 
+    maxLoopCount(0), minEpsilonStep(0.), maxEpsilonStep(0.), 
+    thePSet(p) 
+{
+  delta = p.getParameter<double>("delta");
   theField->fieldEquation(theFieldEquation);
 }
 
-
-void FieldBuilder::build( G4FieldManager* fM, G4PropagatorInField* fP) {
-    
+void FieldBuilder::build( G4FieldManager* fM, G4PropagatorInField* fP) 
+{    
   edm::ParameterSet thePSetForGMFM =
     thePSet.getParameter<edm::ParameterSet>("ConfGlobalMFM");
 
@@ -59,6 +59,9 @@ void FieldBuilder::build( G4FieldManager* fM, G4PropagatorInField* fP) {
   // configure( "MagneticFieldType", fM, fP ) ;
 
   if ( thePSet.getParameter<bool>("UseLocalMagFieldManager") )  {
+
+    edm::LogInfo("SimG4CoreApplication") 
+      << " FieldBuilder: Local magnetic field is used";
 
     edm::ParameterSet defpset ;
     edm::ParameterSet thePSetForLMFM = 
@@ -85,16 +88,17 @@ void FieldBuilder::build( G4FieldManager* fM, G4PropagatorInField* fP) {
       fLM->SetVerbosity(thePSet.getUntrackedParameter<bool>("Verbosity",false));
       theTopVolume->SetFieldManager( fLM, true ) ;
     }
+  } else {
+    edm::LogInfo("SimG4CoreApplication") 
+      << " FieldBuilder: Global magnetic field is used";
   }
-  return ;
- 
 }
 
 void FieldBuilder::configureForVolume( const std::string& volName,
                                        edm::ParameterSet& volPSet,
 				       G4FieldManager * fM,
-				       G4PropagatorInField * fP ) {
-
+				       G4PropagatorInField * fP ) 
+{
   G4LogicalVolumeStore* theStore = G4LogicalVolumeStore::GetInstance();
   for (unsigned int i=0; i<(*theStore).size(); ++i ) {
     std::string curVolName = ((*theStore)[i])->GetName();
@@ -111,7 +115,8 @@ void FieldBuilder::configureForVolume( const std::string& volName,
   dChord        = stpPSet.getParameter<double>("DeltaChord") ;
   dOneStep      = stpPSet.getParameter<double>("DeltaOneStep") ;
   dIntersection = stpPSet.getParameter<double>("DeltaIntersection") ;
-  dIntersectionAndOneStep = stpPSet.getUntrackedParameter<double>("DeltaIntersectionAndOneStep",-1.);
+  dIntersectionAndOneStep = 
+    stpPSet.getUntrackedParameter<double>("DeltaIntersectionAndOneStep",-1.);
   maxLoopCount = stpPSet.getUntrackedParameter<double>("MaximumLoopCounts",1000);
   minEpsilonStep = stpPSet.getUntrackedParameter<double>("MinimumEpsilonStep",0.00001);
   maxEpsilonStep = stpPSet.getUntrackedParameter<double>("MaximumEpsilonStep",0.01);
@@ -119,8 +124,9 @@ void FieldBuilder::configureForVolume( const std::string& volName,
   if (fM!=0) configureFieldManager(fM);
   if (fP!=0) configurePropagatorInField(fP);	
 
-  return;
-
+  edm::LogInfo("SimG4CoreApplication") 
+    << " FieldBuilder: Selected stepper: <" << stepper 
+    << ">  const field delta(mm)= " << delta;
 }
 
 G4LogicalVolume * FieldBuilder::fieldTopVolume() { return theTopVolume; }
@@ -136,13 +142,12 @@ void FieldBuilder::setStepperAndChordFinder(G4FieldManager * fM, int val) {
     }
   }
 }
-
  
 void FieldBuilder::configureFieldManager(G4FieldManager * fM) {
 
   if (fM!=0) {
     fM->SetDetectorField(theField.get());
-    FieldStepper * theStepper = new FieldStepper(theField->fieldEquation());
+    FieldStepper * theStepper = new FieldStepper(theField->fieldEquation(), delta);
     theStepper->select(stepper);
     G4ChordFinder * CF = new G4ChordFinder(theField.get(),minStep,theStepper);
     CF->SetDeltaChord(dChord);
@@ -161,11 +166,11 @@ void FieldBuilder::configureFieldManager(G4FieldManager * fM) {
 }
 
 void FieldBuilder::configurePropagatorInField(G4PropagatorInField * fP) {
-  if (fP==0) return;
-  fP->SetMaxLoopCount(int(maxLoopCount));
-  fP->SetMinimumEpsilonStep(minEpsilonStep);
-  fP->SetMaximumEpsilonStep(maxEpsilonStep);
-  fP->SetVerboseLevel(0);
-  return;
+  if(fP!=0) {
+    fP->SetMaxLoopCount(int(maxLoopCount));
+    fP->SetMinimumEpsilonStep(minEpsilonStep);
+    fP->SetMaximumEpsilonStep(maxEpsilonStep);
+    fP->SetVerboseLevel(0);
+  }
 }
 

--- a/SimG4Core/MagneticField/src/FieldStepper.cc
+++ b/SimG4Core/MagneticField/src/FieldStepper.cc
@@ -12,11 +12,12 @@
 #include "G4HelixImplicitEuler.hh"
 #include "G4HelixSimpleRunge.hh"
 #include "G4HelixHeum.hh"
+#include "G4NystromRK4.hh"
 
 using namespace sim;
 
-FieldStepper::FieldStepper(G4Mag_UsualEqRhs * eq) :
-    G4MagIntegratorStepper(eq, 6), theEquation(eq) {}
+FieldStepper::FieldStepper(G4Mag_UsualEqRhs * eq, double del) :
+  G4MagIntegratorStepper(eq, 6), theEquation(eq), delta(del) {}
 
 FieldStepper::~FieldStepper() {}
 
@@ -29,19 +30,20 @@ double FieldStepper::DistChord() const { return theStepper->DistChord(); }
 int FieldStepper::IntegratorOrder() const
 { return theStepper->IntegratorOrder(); }
 
-G4MagIntegratorStepper * FieldStepper::select(const std::string & s)
+G4MagIntegratorStepper * FieldStepper::select(const std::string & ss)
 {
-    if      (s == "G4ClassicalRK4")       theStepper = new G4ClassicalRK4(theEquation);
-    else if (s == "G4SimpleRunge")        theStepper = new G4SimpleRunge(theEquation);
-    else if (s == "G4SimpleHeum")         theStepper = new G4SimpleHeum(theEquation);
-    else if (s == "G4CashKarpRKF45")      theStepper = new G4CashKarpRKF45(theEquation);
-    else if (s == "G4RKG3_Stepper")       theStepper = new G4RKG3_Stepper(theEquation);
-    else if (s == "G4ExplicitEuler")      theStepper = new G4ExplicitEuler(theEquation);
-    else if (s == "G4ImplicitEuler")      theStepper = new G4ImplicitEuler(theEquation);
-    else if (s == "G4HelixExplicitEuler") theStepper = new G4HelixExplicitEuler(theEquation);
-    else if (s == "G4HelixImplicitEuler") theStepper = new G4HelixImplicitEuler(theEquation);
-    else if (s == "G4HelixSimpleRunge")   theStepper = new G4HelixSimpleRunge(theEquation);
-    else if (s == "G4HelixHeum")          theStepper = new G4HelixHeum(theEquation);
+    if      (ss == "G4ClassicalRK4")       theStepper = new G4ClassicalRK4(theEquation);
+    else if (ss == "G4NystromRK4")         theStepper = new G4NystromRK4(theEquation, delta);
+    else if (ss == "G4SimpleRunge")        theStepper = new G4SimpleRunge(theEquation);
+    else if (ss == "G4SimpleHeum")         theStepper = new G4SimpleHeum(theEquation);
+    else if (ss == "G4CashKarpRKF45")      theStepper = new G4CashKarpRKF45(theEquation);
+    else if (ss == "G4RKG3_Stepper")       theStepper = new G4RKG3_Stepper(theEquation);
+    else if (ss == "G4ExplicitEuler")      theStepper = new G4ExplicitEuler(theEquation);
+    else if (ss == "G4ImplicitEuler")      theStepper = new G4ImplicitEuler(theEquation);
+    else if (ss == "G4HelixExplicitEuler") theStepper = new G4HelixExplicitEuler(theEquation);
+    else if (ss == "G4HelixImplicitEuler") theStepper = new G4HelixImplicitEuler(theEquation);
+    else if (ss == "G4HelixSimpleRunge")   theStepper = new G4HelixSimpleRunge(theEquation);
+    else if (ss == "G4HelixHeum")          theStepper = new G4HelixHeum(theEquation);
     else
     {
         std::cout << " FieldStepper invalid choice, defaulting to G4ClassicalRK4 " << std::endl;

--- a/SimG4Core/MagneticField/src/FieldStepper.cc
+++ b/SimG4Core/MagneticField/src/FieldStepper.cc
@@ -1,4 +1,5 @@
 #include "SimG4Core/MagneticField/interface/FieldStepper.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "G4Mag_UsualEqRhs.hh"
 #include "G4ClassicalRK4.hh"
@@ -46,8 +47,9 @@ G4MagIntegratorStepper * FieldStepper::select(const std::string & ss)
     else if (ss == "G4HelixHeum")          theStepper = new G4HelixHeum(theEquation);
     else
     {
-        std::cout << " FieldStepper invalid choice, defaulting to G4ClassicalRK4 " << std::endl;
-        theStepper = new G4ClassicalRK4(theEquation);
+      edm::LogWarning("SimG4CoreMagneticField") 
+        << " FieldStepper invalid choice, defaulting to G4ClassicalRK4 ";
+      theStepper = new G4ClassicalRK4(theEquation);
     }
     return theStepper;
 }


### PR DESCRIPTION
Some clean-up inside SIM.

Added alternative stepper for magnetic field G4NystromRK4 - it was developed for ATLAS and shows better CPU performance without compromising of tracking accuracy.

Changed logic in selection of primary particles from HepMC in the Generator:
    1) if a particle has status=2 but has no end vertex defined process it as an ordinary particle with status=1, to avoid lost of long lived exotics;
    2) check on total momentum to be above 40 MeV/c; added new option to cut charged particles with Pt < 40 MeV/c (disabled by default) 
    3) when apply eta cut and selection of beam particles  do not assume that primary vertex is at Z axis.  
