### PR TITLE
Thread safety cleanup in IOVService

### DIFF
--- a/CondCore/IOVService/interface/IOVProxy.h
+++ b/CondCore/IOVService/interface/IOVProxy.h
@@ -233,7 +233,7 @@ namespace cond {
       return SequenceState(iov());
     }
 
-    DbSession& db() const;
+    DbSession& db();
 
   private:
     boost::shared_ptr<IOVProxyData> m_iov;

--- a/CondCore/IOVService/src/IOVProxy.cc
+++ b/CondCore/IOVService/src/IOVProxy.cc
@@ -309,7 +309,7 @@ cond::Time_t cond::IOVProxy::timestamp() const {
   return iov().timestamp();
 }
 
-cond::DbSession& cond::IOVProxy::db() const {
+cond::DbSession& cond::IOVProxy::db() {
   return m_iov->dbSession;
 }
 


### PR DESCRIPTION
To resolve a warning from the thread safety static checker,
change a function from const to non-const. The function
return value allows one to modify a data member it owns
through a pointer.
