### PR TITLE
Fix for double usage of the seeding track in IVF

### DIFF
--- a/RecoVertex/AdaptiveVertexFinder/plugins/InclusiveVertexFinder.cc
+++ b/RecoVertex/AdaptiveVertexFinder/plugins/InclusiveVertexFinder.cc
@@ -166,10 +166,8 @@ void InclusiveVertexFinder::produce(edm::Event &event, const edm::EventSetup &es
 	for(std::vector<TracksClusteringFromDisplacedSeed::Cluster>::iterator cluster = clusters.begin();
 	    cluster != clusters.end(); ++cluster,++i)
         {
-                if(cluster->tracks.size() == 0 || cluster->tracks.size() > maxNTracks ) 
+                if(cluster->tracks.size() < 2 || cluster->tracks.size() > maxNTracks ) 
 		     continue;
-        
- 	        cluster->tracks.push_back(cluster->seedingTrack); //add the seed to the list of tracks to fit
 	 	std::vector<TransientVertex> vertices;
 		if(useVertexReco) {
 			vertices = vtxReco->vertices(cluster->tracks, bs);  // attempt with config given reconstructor


### PR DESCRIPTION
Fix for double usage of the seeding track in IVF. Impact on the b-tagging performance small as can be seen from the attached plot (red with fix, black without).

![image](https://cloud.githubusercontent.com/assets/4885289/2910017/44e64908-d63b-11e3-9ffb-326417ecac50.png)
