### PR TITLE
Make KfComponentsHolder thread safe

### DIFF
--- a/DataFormats/TrackerRecHit2D/src/BaseTrackerRecHit.cc
+++ b/DataFormats/TrackerRecHit2D/src/BaseTrackerRecHit.cc
@@ -1,4 +1,5 @@
 #include "DataFormats/TrackerRecHit2D/interface/BaseTrackerRecHit.h"
+#include "DataFormats/TrackingRecHit/interface/KfComponentsHolder.h"
 #include "DataFormats/Math/interface/ProjectMatrix.h"
 #include "FWCore/Utilities/interface/Exception.h"
 

--- a/DataFormats/TrackingRecHit/interface/KfComponentsHolder.h
+++ b/DataFormats/TrackingRecHit/interface/KfComponentsHolder.h
@@ -160,7 +160,7 @@ void KfComponentsHolder::setup(
     assert(size_ == 0); // which means it was uninitialized
     size_ = D;
 #endif
-    static ProjectMatrix<double,5,D> dummy;
+    static thread_local ProjectMatrix<double,5,D> dummy;
     params_     = params;
     errors_     = errors;
     projection_ = projection;

--- a/DataFormats/TrackingRecHit/interface/TrackingRecHit.h
+++ b/DataFormats/TrackingRecHit/interface/TrackingRecHit.h
@@ -11,7 +11,6 @@
 #include "DataFormats/GeometrySurface/interface/Surface.h" 
 
 
-#include "DataFormats/TrackingRecHit/interface/KfComponentsHolder.h"
 #include "FWCore/Utilities/interface/GCC11Compatibility.h"
 #if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
 #define NO_DICT
@@ -24,6 +23,7 @@ class GeomDet;
 class GeomDetUnit;
 class TkCloner;
 class TrajectoryStateOnSurface;
+class KfComponentsHolder;
 
 class TrackingRecHit {
 public:

--- a/DataFormats/TrackingRecHit/src/TrackingRecHit.cc
+++ b/DataFormats/TrackingRecHit/src/TrackingRecHit.cc
@@ -1,4 +1,5 @@
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
+#include "DataFormats/TrackingRecHit/interface/KfComponentsHolder.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
 
 #include "FWCore/Utilities/interface/Exception.h"

--- a/TrackingTools/KalmanUpdators/src/Chi2MeasurementEstimator.cc
+++ b/TrackingTools/KalmanUpdators/src/Chi2MeasurementEstimator.cc
@@ -1,6 +1,7 @@
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 #include "TrackingTools/KalmanUpdators/interface/Chi2MeasurementEstimator.h"
 #include "TrackingTools/PatternTools/interface/MeasurementExtractor.h"
+#include "DataFormats/TrackingRecHit/interface/KfComponentsHolder.h"
 #include "DataFormats/GeometrySurface/interface/Plane.h"
 #include "DataFormats/Math/interface/invertPosDefMatrix.h"
 


### PR DESCRIPTION
Valgrind report was complaining about multiple threads changing a dummy function static simultaneously. Fix was to make it thread_local. However, thread_local is not parseable by gccxml so changed TrackingRecHit.h to only forward declare KfComponentsHolder. 
Discovered that way to much of CMSSW depends on TrackingRecHit.h.
