### PR TITLE
Migration of Higgs validation packages to DQMEDAnalyzer and DQMEDHarvester interface + add few plots in the Higgs validation directory

### DIFF
--- a/HLTriggerOffline/Higgs/interface/HLTHiggsHarvesting.h
+++ b/HLTriggerOffline/Higgs/interface/HLTHiggsHarvesting.h
@@ -1,0 +1,52 @@
+#ifndef HiggsHarvesting_h
+#define HiggsHarvesting_h
+
+/** \class HiggsHarvesting
+ *  
+ *  Class to perform operations on MEs after EDMtoMEConverter
+ *
+ *  \author Hugues Brun
+ */
+
+// framework & common header files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Run.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+//DQM services
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+#include "DQMServices/Core/interface/DQMEDHarvester.h"
+
+#include <iostream>
+#include <stdlib.h>
+#include <string>
+#include <memory>
+#include <vector>
+
+#include "TString.h"
+
+class HiggsHarvesting : public DQMEDHarvester
+{
+  
+ public:
+
+  explicit HiggsHarvesting(const edm::ParameterSet&);
+  virtual ~HiggsHarvesting();
+  virtual void beginJob();
+  virtual void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override;
+  virtual void beginRun(const edm::Run&, const edm::EventSetup&);
+  virtual void endRun(const edm::Run&, const edm::EventSetup&);
+
+  
+private:
+  std::string analysisName;
+
+};
+
+#endif

--- a/HLTriggerOffline/Higgs/interface/HLTHiggsPlotter.h
+++ b/HLTriggerOffline/Higgs/interface/HLTHiggsPlotter.h
@@ -47,21 +47,21 @@ class HLTHiggsPlotter
        	public:
 	      	HLTHiggsPlotter(const edm::ParameterSet & pset, const std::string & hltPath,
 				//const std::string & lastFilter,
-				const std::vector<unsigned int> & objectsType,
-			       	DQMStore * dbe);
+				const std::vector<unsigned int> & objectsType);
 		~HLTHiggsPlotter();
 	      	void beginJob();
 	      	void beginRun(const edm::Run &, const edm::EventSetup &);
-		void analyze(const bool & isPassTrigger,const std::string & source,
+            void bookHistograms(DQMStore::IBooker &);
+            void analyze(const bool & isPassTrigger,const std::string & source,
 				const std::vector<MatchStruct> & matches);
 		
 		inline const std::string gethltpath() const { return _hltPath; }
 		
        	private:
-	      	void bookHist(const std::string & source, const std::string & objType, const std::string & variable);
+	      	void bookHist(const std::string & source, const std::string & objType, const std::string & variable,  DQMStore::IBooker &);
 	      	void fillHist(const bool & passTrigger, const std::string & source, 
-				const std::string & objType, const std::string & var, 
-				const float & value);
+                          const std::string & objType, const std::string & var,
+                          const float & value);
 		
 	      	std::string _hltPath;
 		//std::string _lastFilter;
@@ -81,7 +81,6 @@ class HLTHiggsPlotter
 		std::map<unsigned int,std::vector<double> > _cutsDr;
 		
 		
-	      	DQMStore* _dbe;
-	      	std::map<std::string, MonitorElement *> _elements;		
+        std::map<std::string, MonitorElement *> _elements;
 };
 #endif

--- a/HLTriggerOffline/Higgs/interface/HLTHiggsSubAnalysis.h
+++ b/HLTriggerOffline/Higgs/interface/HLTHiggsSubAnalysis.h
@@ -20,6 +20,7 @@
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
+#include "SimDataFormats/PileupSummaryInfo/interface/PileupSummaryInfo.h"
 #include "DataFormats/HLTReco/interface/TriggerEventWithRefs.h"
 #include "DataFormats/MuonReco/interface/Muon.h"
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
@@ -65,8 +66,9 @@ class HLTHiggsSubAnalysis
 				    edm::ConsumesCollector&& iC);
 		~HLTHiggsSubAnalysis();
 	      	void beginJob();
-	      	void beginRun(const edm::Run & iRun, const edm::EventSetup & iEventSetup);
+            void beginRun(const edm::Run & iRun, const edm::EventSetup & iEventSetup);
 	      	void analyze(const edm::Event & iEvent, const edm::EventSetup & iEventSetup, EVTColContainer * cols);
+            void bookHistograms(DQMStore::IBooker &);
 
 		//! Extract what objects need this analysis
 		const std::vector<unsigned int> getObjectsType(const std::string & hltpath) const;
@@ -80,7 +82,7 @@ class HLTHiggsSubAnalysis
 				std::vector<MatchStruct> * matches);
 
 		void bookHist(const std::string & source, const std::string & objType,
-			       	const std::string & variable);
+			       	const std::string & variable, DQMStore::IBooker &);
 		void fillHist(const std::string & source,const std::string & objType, 
 				const std::string & variable, const float & value );
 
@@ -111,12 +113,14 @@ class HLTHiggsSubAnalysis
 		edm::EDGetTokenT<reco::PhotonCollection> _recLabelsPhoton;
 		edm::EDGetTokenT<reco::CaloMETCollection> _recLabelsCaloMET;
 		edm::EDGetTokenT<reco::PFTauCollection> _recLabelsPFTau;
+		edm::EDGetTokenT<std::vector< PileupSummaryInfo > > _puSummaryInfo;
 
 		
 		//! Some kinematical parameters
-	      	std::vector<double> _parametersEta;
-	      	std::vector<double> _parametersPhi;
-	      	std::vector<double> _parametersTurnOn;
+        std::vector<double> _parametersEta;
+        std::vector<double> _parametersPhi;
+        std::vector<double> _parametersPu;
+        std::vector<double> _parametersTurnOn;
 		edm::EDGetTokenT<edm::TriggerResults> _trigResultsTag;
 
 		
@@ -144,8 +148,7 @@ class HLTHiggsSubAnalysis
 		
 		HLTConfigProvider _hltConfig;
 		
-	      	DQMStore* _dbe;
-	      	std::map<std::string, MonitorElement *> _elements;		
+	      	std::map<std::string, MonitorElement *> _elements;
 };
 
 

--- a/HLTriggerOffline/Higgs/interface/HLTHiggsValidator.h
+++ b/HLTriggerOffline/Higgs/interface/HLTHiggsValidator.h
@@ -14,7 +14,7 @@
 //#include "FWCore/PluginManager/interface/ModuleDef.h"
 //#include "FWCore/Framework/interface/MakerMacros.h"
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -29,7 +29,7 @@
 
 class EVTColContainer;
 
-class HLTHiggsValidator : public edm::EDAnalyzer 
+class HLTHiggsValidator : public DQMEDAnalyzer
 {
 	public:
 		//! Constructor
@@ -38,11 +38,10 @@ class HLTHiggsValidator : public edm::EDAnalyzer
 
 	private:
 		// concrete analyzer methods
-	      	virtual void beginJob();
-	      	virtual void beginRun(const edm::Run &iRun, const edm::EventSetup & iSetup);
-	      	virtual void analyze(const edm::Event & iEvent, const edm::EventSetup & iSetup);
-		virtual void endRun(const edm::Run & iRun, const edm::EventSetup & iSetup);
-		virtual void endJob();
+        virtual void bookHistograms(DQMStore::IBooker &, const edm::Run &, const edm::EventSetup &) override;
+        virtual void dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) override;
+  	    virtual void analyze(const edm::Event & iEvent, const edm::EventSetup & iSetup) override;
+		virtual void endRun(const edm::Run & iRun, const edm::EventSetup & iSetup) override;
 
 		//! Input from configuration file
 		edm::ParameterSet _pset;

--- a/HLTriggerOffline/Higgs/interface/HLTHiggsValidator.h
+++ b/HLTriggerOffline/Higgs/interface/HLTHiggsValidator.h
@@ -54,8 +54,6 @@ class HLTHiggsValidator : public DQMEDAnalyzer
 		//! The container with all the collections needed
 		EVTColContainer * _collections;
 		
-		// Access to the DQM
-		DQMStore * _dbe;      	
 };
 
 #endif

--- a/HLTriggerOffline/Higgs/python/HLTHiggsPostVal_cff.py
+++ b/HLTriggerOffline/Higgs/python/HLTHiggsPostVal_cff.py
@@ -3,6 +3,6 @@ import FWCore.ParameterSet.Config as cms
 from HLTriggerOffline.Higgs.hltHiggsPostProcessors_cff import *
 
 HLTHiggsPostVal = cms.Sequence( 
-		hltHiggsPostProcessors
+		hltHiggsPostProcessors * hltEffPost
 		)
 

--- a/HLTriggerOffline/Higgs/python/hltHiggsPostProcessor_cfi.py
+++ b/HLTriggerOffline/Higgs/python/hltHiggsPostProcessor_cfi.py
@@ -9,3 +9,6 @@ hltHiggsPostProcessor  = cms.EDAnalyzer("DQMGenericClient",
     efficiencyProfile = cms.untracked.vstring(),
 )
 
+overallEffPlotter = cms.EDAnalyzer("HiggsHarvesting",
+    analysisName = cms.untracked.string("HWW")
+)

--- a/HLTriggerOffline/Higgs/python/hltHiggsPostProcessors_cff.py
+++ b/HLTriggerOffline/Higgs/python/hltHiggsPostProcessors_cff.py
@@ -80,31 +80,45 @@ for type in plot_types:
 	for trig in triggers:
 	    efficiency_strings.append(efficiency_string(obj,type,trig))
 
+
+#add the summary plots
+for an in _config.analysis:
+    for trig in triggers:
+        efficiency_strings.append("Eff_trueVtxDist_"+an+"_gen_"+trig+" ' Efficiency of "+trig+" vs nb of interactions ; nb events passing each path ' trueVtxDist_"+an+"_gen_"+trig+" trueVtxDist_"+an+"_gen")
+
 add_reco_strings(efficiency_strings)
 
-hltHiggsPostHTauNu = hltHiggsPostProcessor.clone()
-hltHiggsPostHTauNu.subDirs = ['HLT/Higgs/Htaunu']
-hltHiggsPostHTauNu.efficiencyProfile = efficiency_strings
+
 
 hltHiggsPostHWW = hltHiggsPostProcessor.clone()
 hltHiggsPostHWW.subDirs = ['HLT/Higgs/HWW']
 hltHiggsPostHWW.efficiencyProfile = efficiency_strings
+hltHiggsEffPostHWW = overallEffPlotter.clone()
+hltHiggsEffPostHWW.analysisName = cms.untracked.string('HWW')
 
 hltHiggsPostHZZ = hltHiggsPostProcessor.clone()
 hltHiggsPostHZZ.subDirs = ['HLT/Higgs/HZZ']
 hltHiggsPostHZZ.efficiencyProfile = efficiency_strings
+hltHiggsEffPostHZZ = overallEffPlotter.clone()
+hltHiggsEffPostHZZ.analysisName = cms.untracked.string('HZZ')
 
 hltHiggsPostHgg = hltHiggsPostProcessor.clone()
 hltHiggsPostHgg.subDirs = ['HLT/Higgs/Hgg']
 hltHiggsPostHgg.efficiencyProfile = efficiency_strings
+hltHiggsEffPostHgg = overallEffPlotter.clone()
+hltHiggsEffPostHgg.analysisName = cms.untracked.string('Hgg')
 
 hltHiggsPostH2tau = hltHiggsPostProcessor.clone()
 hltHiggsPostH2tau.subDirs = ['HLT/Higgs/H2tau']
 hltHiggsPostH2tau.efficiencyProfile = efficiency_strings
+hltHiggsEffPostH2tau = overallEffPlotter.clone()
+hltHiggsEffPostH2tau.analysisName = cms.untracked.string('H2tau')
 
 hltHiggsPostHtaunu = hltHiggsPostProcessor.clone()
 hltHiggsPostHtaunu.subDirs = ['HLT/Higgs/Htaunu']
 hltHiggsPostHtaunu.efficiencyProfile = efficiency_strings
+hltHiggsEffPostHtaunu = overallEffPlotter.clone()
+hltHiggsEffPostHtaunu.analysisName = cms.untracked.string('Htaunu')
 
 
 hltHiggsPostProcessors = cms.Sequence(
@@ -113,4 +127,12 @@ hltHiggsPostProcessors = cms.Sequence(
 		hltHiggsPostHgg+
 		hltHiggsPostHtaunu+
 		hltHiggsPostH2tau
+)
+
+hltEffPost = cms.Sequence(
+    hltHiggsEffPostHWW+
+    hltHiggsEffPostHZZ+
+    hltHiggsEffPostHgg+
+    hltHiggsEffPostH2tau+
+    hltHiggsEffPostHtaunu
 )

--- a/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
+++ b/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
@@ -9,6 +9,9 @@ hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
     # -- The instance name of the reco::GenParticles collection
     genParticleLabel = cms.string("genParticles"),
 
+    # -- The nomber of interactions in the event
+    pileUpInfoLabel  = cms.string("addPileupInfo"),
+
     # -- The binning of the Pt efficiency plots
     parametersTurnOn = cms.vdouble(0,
                                    1, 8, 9, 10,
@@ -18,9 +21,10 @@ hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
                                    80, 100,
                                    ),
 
-    # -- (NBins, minVal, maxValue) for the Eta and Phi efficiency plots
+    # -- (NBins, minVal, maxValue) for the Eta,Phi and nInterations efficiency plots
     parametersEta      = cms.vdouble(48, -2.400, 2.400),
     parametersPhi      = cms.vdouble(50, -3.142, 3.142),
+    parametersPu       = cms.vdouble(10, 0, 20),
 
     # TO BE DEPRECATED --------------------------------------------
     cutsDr = cms.vdouble(0.4, 0.4, 0.015), # TO BE DEPRECATED

--- a/HLTriggerOffline/Higgs/src/HLTHiggsHarvesting.cc
+++ b/HLTriggerOffline/Higgs/src/HLTHiggsHarvesting.cc
@@ -1,0 +1,70 @@
+#include "HLTriggerOffline/Higgs/interface/HLTHiggsHarvesting.h"
+
+HiggsHarvesting::HiggsHarvesting(const edm::ParameterSet& iPSet)
+{
+    
+    analysisName = iPSet.getUntrackedParameter<std::string>("analysisName");
+    
+
+}
+
+HiggsHarvesting::~HiggsHarvesting() {}
+
+void HiggsHarvesting::beginJob()
+{
+    return;
+}
+
+void HiggsHarvesting::dqmEndJob(DQMStore::IBooker &iBooker, DQMStore::IGetter &iGetter)
+{
+
+    
+    //define type of sources :
+    std::vector<std::string> sources(2);
+    sources[0] = "gen";
+    sources[1] = "rec";
+    for(size_t i = 0; i < sources.size(); i++) {
+        // monitoring element numerator and denominator histogram
+        MonitorElement *meN =
+        iGetter.get("HLT/Higgs/"+analysisName+"/SummaryPaths_"+analysisName+"_"+sources[i]+"_passingHLT");
+        MonitorElement *meD =
+        iGetter.get("HLT/Higgs/"+analysisName+"/SummaryPaths_"+analysisName+"_"+sources[i]);
+        
+        if (meN && meD) {
+            // get the numerator and denominator histogram
+            TH1F *numerator = meN->getTH1F();
+            TH1F *denominator = meD->getTH1F();
+            
+            // set the current directory
+            iBooker.setCurrentFolder("HLT/Higgs/"+analysisName);
+            
+            // booked the new histogram to contain the results
+            TString nameEffHisto = "efficiencySummary_"+sources[i];
+            TH1F *efficiencySummary = (TH1F*) numerator->Clone(nameEffHisto);
+            std::string histoTitle = "efficiency of paths used in " + analysisName;
+            efficiencySummary->SetTitle(histoTitle.c_str());
+            MonitorElement *me = iBooker.book1D(nameEffHisto, efficiencySummary );
+            
+                // Calculate the efficiency
+            me->getTH1F()->Divide(numerator, denominator, 1., 1., "B");
+        
+        } else {
+            std::cout << "Monitor elements don't exist" << std::endl;
+        }
+    }
+    
+    return;
+}
+
+void HiggsHarvesting::beginRun(const edm::Run& iRun,
+                                  const edm::EventSetup& iSetup)
+{
+    return;
+}
+
+void HiggsHarvesting::endRun(const edm::Run& iRun, 
+                                const edm::EventSetup& iSetup)
+{
+    return;
+}
+

--- a/HLTriggerOffline/Higgs/src/HLTHiggsSubAnalysis.cc
+++ b/HLTriggerOffline/Higgs/src/HLTHiggsSubAnalysis.cc
@@ -37,8 +37,9 @@ HLTHiggsSubAnalysis::HLTHiggsSubAnalysis(const edm::ParameterSet & pset,
 	_minCandidates(0),
 	_hltProcessName(pset.getParameter<std::string>("hltProcessName")),
 	_genParticleLabel(iC.consumes<reco::GenParticleCollection>(pset.getParameter<std::string>("genParticleLabel"))),
-      	_parametersEta(pset.getParameter<std::vector<double> >("parametersEta")),
+    _parametersEta(pset.getParameter<std::vector<double> >("parametersEta")),
   	_parametersPhi(pset.getParameter<std::vector<double> >("parametersPhi")),
+  	_parametersPu(pset.getParameter<std::vector<double> >("parametersPu")),
   	_parametersTurnOn(pset.getParameter<std::vector<double> >("parametersTurnOn")),
 	_trigResultsTag(iC.consumes<edm::TriggerResults>(edm::InputTag("TriggerResults","",_hltProcessName))),
 	_recMuonSelector(0),
@@ -46,8 +47,7 @@ HLTHiggsSubAnalysis::HLTHiggsSubAnalysis(const edm::ParameterSet & pset,
 	_recCaloMETSelector(0),
 	_recPFTauSelector(0),
 	_recPhotonSelector(0),
-	_recTrackSelector(0),
-	_dbe(0)
+	_recTrackSelector(0)
 {
 	// Specific parameters for this analysis
 	edm::ParameterSet anpset = pset.getParameter<edm::ParameterSet>(analysisname);
@@ -92,9 +92,12 @@ HLTHiggsSubAnalysis::HLTHiggsSubAnalysis(const edm::ParameterSet & pset,
 	
 	_hltPathsToCheck = anpset.getParameter<std::vector<std::string> >("hltPathsToCheck");
 	_minCandidates = anpset.getParameter<unsigned int>("minCandidates");
+    
+    if( pset.exists("pileUpInfoLabel") )
+	{
+        _puSummaryInfo = iC.consumes<std::vector< PileupSummaryInfo > >(pset.getParameter<std::string>("pileUpInfoLabel"));
+	}
 
-	_dbe = edm::Service<DQMStore>().operator->();
-      	_dbe->setVerbose(0);
 }
 
 HLTHiggsSubAnalysis::~HLTHiggsSubAnalysis()
@@ -123,13 +126,12 @@ HLTHiggsSubAnalysis::~HLTHiggsSubAnalysis()
 void HLTHiggsSubAnalysis::beginJob() 
 {
 }
-
+ 
 
 
 void HLTHiggsSubAnalysis::beginRun(const edm::Run & iRun, const edm::EventSetup & iSetup)
 {
-	std::string baseDir = "HLT/Higgs/"+_analysisname+"/";
-      	_dbe->setCurrentFolder(baseDir);
+
 
 	// Initialize the confighlt
 	bool changedConfig;
@@ -211,35 +213,80 @@ void HLTHiggsSubAnalysis::beginRun(const edm::Run & iRun, const edm::EventSetup 
 		
 		// the hlt path, the objects (elec,muons,photons,...)
 		// needed to evaluate the path are the argumens of the plotter
-		HLTHiggsPlotter analyzer(_pset, shortpath,objsNeedHLT, _dbe);
+		HLTHiggsPlotter analyzer(_pset, shortpath,objsNeedHLT);
 		_analyzers.push_back(analyzer);
     	}
 
-      	// Call the beginRun (which books all the path dependent histograms)
-      	for(std::vector<HLTHiggsPlotter>::iterator it = _analyzers.begin(); 
-			it != _analyzers.end(); ++it) 
-	{
-	    	it->beginRun(iRun, iSetup);
-	}
+}
 
+void HLTHiggsSubAnalysis::bookHistograms(DQMStore::IBooker &ibooker)
+{
+    std::string baseDir = "HLT/Higgs/"+_analysisname+"/";
+    ibooker.setCurrentFolder(baseDir);
 	// Book the gen/reco analysis-dependent histograms (denominators)
+    std::vector<std::string> sources(2);
+    sources[0] = "gen";
+    sources[1] = "rec";
+    
 	for(std::map<unsigned int,std::string>::const_iterator it = _recLabels.begin();
 			it != _recLabels.end(); ++it)
 	{
 		const std::string objStr = EVTColContainer::getTypeString(it->first);
-		std::vector<std::string> sources(2);
-		sources[0] = "gen";
-		sources[1] = "rec";
-	  
+
 		for(size_t i = 0; i < sources.size(); i++) 
 		{
 			std::string source = sources[i];
-			bookHist(source, objStr, "Eta");
-			bookHist(source, objStr, "Phi");
-			bookHist(source, objStr, "MaxPt1");
-			bookHist(source, objStr, "MaxPt2");
+			bookHist(source, objStr, "Eta", ibooker);
+			bookHist(source, objStr, "Phi", ibooker);
+			bookHist(source, objStr, "MaxPt1", ibooker);
+			bookHist(source, objStr, "MaxPt2", ibooker);
 		}
 	}
+    
+    // Call the bookHistograms (which books all the path dependent histograms)
+    for(std::vector<HLTHiggsPlotter>::iterator it = _analyzers.begin();
+        it != _analyzers.end(); ++it)
+	{
+        it->bookHistograms(ibooker);
+	}
+    //booking the histograms for overall trigger efficiencies
+    for(size_t i = 0; i < sources.size(); i++)
+    {
+        std::string nameGlobalEfficiency = "SummaryPaths_"+_analysisname+"_"+sources[i];
+        
+        TH1F *hSummary = new TH1F(nameGlobalEfficiency.c_str(),nameGlobalEfficiency.c_str(),_hltPathsToCheck.size(), 0, _hltPathsToCheck.size());
+        hSummary->Sumw2();
+        _elements[nameGlobalEfficiency] = ibooker.book1D(nameGlobalEfficiency, hSummary);
+        delete hSummary;
+        
+        std::string nameGlobalEfficiencyPassing= nameGlobalEfficiency+"_passingHLT";
+        TH1F *hSummaryPassing = new TH1F(nameGlobalEfficiencyPassing.c_str(),nameGlobalEfficiencyPassing.c_str(),_hltPathsToCheck.size(), 0, _hltPathsToCheck.size());
+        hSummaryPassing->Sumw2();
+        _elements[nameGlobalEfficiencyPassing] = ibooker.book1D(nameGlobalEfficiencyPassing, hSummaryPassing);
+        delete hSummaryPassing;
+        
+        std::string title = "nb of interations in the event";
+        std::string nameVtxPlot = "trueVtxDist_"+_analysisname+"_"+sources[i];
+        std::vector<double> params = _parametersPu;
+        int    nBins = (int)params[0];
+        double min   = params[1];
+        double max   = params[2];
+        TH1F *hPu = new TH1F(nameVtxPlot.c_str(), title.c_str(), nBins, min, max);
+        hPu->Sumw2();
+        _elements[nameVtxPlot] = ibooker.book1D(nameVtxPlot, hPu);
+        for (size_t j = 0 ; j < _hltPathsToCheck.size() ; j++){
+                std::string path = _hltPathsToCheck[j];
+                std::string shortpath = path;
+                if(path.rfind("_v") < path.length())
+                {
+                        shortpath = path.substr(0, path.rfind("_v"));
+                }
+            std::string titlePassing = "nb of interations in the event passing path " + shortpath;
+            hPu->SetTitle(titlePassing.c_str());
+        	_elements[nameVtxPlot+"_"+shortpath] = ibooker.book1D(nameVtxPlot+"_"+shortpath, hPu);
+        }
+        delete hPu;
+    }
 }
 
 
@@ -253,6 +300,19 @@ void HLTHiggsSubAnalysis::analyze(const edm::Event & iEvent, const edm::EventSet
 	std::map<unsigned int,std::string> u2str;
 	u2str[GEN]="gen";
 	u2str[RECO]="rec";
+    
+    edm::Handle<std::vector< PileupSummaryInfo > > puInfo;
+    iEvent.getByToken(_puSummaryInfo,puInfo);
+    int nbMCvtx = -1;
+    if (puInfo.isValid()) {
+        std::vector<PileupSummaryInfo>::const_iterator PVI;
+        for(PVI = puInfo->begin(); PVI != puInfo->end(); ++PVI) {
+            if(PVI->getBunchCrossing()==0){
+                nbMCvtx = PVI->getPU_NumInteractions();
+                break;
+            }
+        }
+    }
 
 	// Extract the match structure containing the gen/reco candidates (electron, muons,...)
 	// common to all the SubAnalysis
@@ -374,20 +434,36 @@ void HLTHiggsSubAnalysis::analyze(const edm::Event & iEvent, const edm::EventSet
 			}				
 		}
 		delete countobjects;
+        
+        //fill the efficiency vs nb of interactions
+        std::string nameVtxPlot = "trueVtxDist_"+_analysisname+"_"+u2str[it->first];
+        _elements[nameVtxPlot]->Fill(nbMCvtx);
 	
 		// Calling to the plotters analysis (where the evaluation of the different trigger paths are done)
+        std::string SummaryName = "SummaryPaths_"+_analysisname+"_"+u2str[it->first];
 		const std::string source = u2str[it->first];
+        TH1F* hGlobalEffic = _elements[SummaryName]->getTH1F();
+        TH1F* hGlobalEfficTrig = _elements[SummaryName+"_passingHLT"]->getTH1F();
 		for(std::vector<HLTHiggsPlotter>::iterator an = _analyzers.begin();
 				an != _analyzers.end(); ++an)
 		{
 			const std::string hltPath = _shortpath2long[an->gethltpath()];
+            		const std::string fillShortPath = an->gethltpath();
 			const bool ispassTrigger =  cols->triggerResults->accept(trigNames.triggerIndex(hltPath));
 			an->analyze(ispassTrigger,source,it->second);
+            		hGlobalEffic->Fill(fillShortPath.c_str(),1);
+           		if (ispassTrigger) {
+				hGlobalEfficTrig->Fill(fillShortPath.c_str(),1);
+				_elements[nameVtxPlot+"_"+fillShortPath.c_str()]->Fill(nbMCvtx);
+			}
+            		else { 
+				hGlobalEfficTrig->Fill(fillShortPath.c_str(),0);
+			}
 		}
 	}
 }
 
-// Return the objects (muons,electrons,photons,...) needed by a hlt path. 
+// Return the objects (muons,electrons,photons,...) needed by a hlt path.
 const std::vector<unsigned int> HLTHiggsSubAnalysis::getObjectsType(const std::string & hltPath) const
 {
 	static const unsigned int objSize = 5; //6;
@@ -456,6 +532,7 @@ void HLTHiggsSubAnalysis::bookobjects( const edm::ParameterSet & anpset, edm::Co
 		_genSelectorMap[EVTColContainer::TRACK] = 0 ;
 	}*/
 
+    
 	if( _recLabels.size() < 1 )
 	{
 		edm::LogError("HiggsValidation") << "HLTHiggsSubAnalysis::bookobjects, " 
@@ -534,15 +611,14 @@ void HLTHiggsSubAnalysis::initobjects(const edm::Event & iEvent, EVTColContainer
 }
 
 void HLTHiggsSubAnalysis::bookHist(const std::string & source, 
-		const std::string & objType, const std::string & variable)
+		const std::string & objType, const std::string & variable, DQMStore::IBooker &ibooker)
 {
 	std::string sourceUpper = source; 
-      	sourceUpper[0] = std::toupper(sourceUpper[0]);
+    sourceUpper[0] = std::toupper(sourceUpper[0]);
 	std::string name = source + objType + variable ;
-      	TH1F * h = 0;
+    TH1F * h = 0;
 
-      	if(variable.find("MaxPt") != std::string::npos) 
-	{
+    if(variable.find("MaxPt") != std::string::npos){
 		std::string desc = (variable == "MaxPt1") ? "Leading" : "Next-to-Leading";
 		std::string title = "pT of " + desc + " " + sourceUpper + " " + objType;
 	    	const size_t nBins = _parametersTurnOn.size() - 1;
@@ -566,7 +642,7 @@ void HLTHiggsSubAnalysis::bookHist(const std::string & source,
 	    	h = new TH1F(name.c_str(), title.c_str(), nBins, min, max);
       	}
       	h->Sumw2();
-      	_elements[name] = _dbe->book1D(name, h);
+      	_elements[name] = ibooker.book1D(name, h);
       	delete h;
 }
 

--- a/HLTriggerOffline/Higgs/src/HLTHiggsValidator.cc
+++ b/HLTriggerOffline/Higgs/src/HLTHiggsValidator.cc
@@ -47,7 +47,7 @@ HLTHiggsValidator::~HLTHiggsValidator()
 	}
 }
 
-void HLTHiggsValidator::beginRun(const edm::Run & iRun, const edm::EventSetup & iSetup) 
+void HLTHiggsValidator::dqmBeginRun(const edm::Run & iRun, const edm::EventSetup & iSetup)
 {
 	// Call the Plotter beginRun (which stores the triggers paths..:)
       	for(std::vector<HLTHiggsSubAnalysis>::iterator iter = _analyzers.begin(); 
@@ -57,6 +57,15 @@ void HLTHiggsValidator::beginRun(const edm::Run & iRun, const edm::EventSetup & 
 	}
 }
 	
+void HLTHiggsValidator::bookHistograms(DQMStore::IBooker &ibooker, const edm::Run &iRun, const edm::EventSetup &iSetup){
+    // Call the Plotter bookHistograms (which stores the triggers paths..:)
+    for(std::vector<HLTHiggsSubAnalysis>::iterator iter = _analyzers.begin();
+        iter != _analyzers.end(); ++iter)
+	{
+        iter->bookHistograms(ibooker);
+	}
+    
+}
 
 void HLTHiggsValidator::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
@@ -77,9 +86,6 @@ void HLTHiggsValidator::analyze(const edm::Event& iEvent, const edm::EventSetup&
 
 
 
-void HLTHiggsValidator::beginJob()
-{
-}
 
 void HLTHiggsValidator::endRun(const edm::Run & iRun, const edm::EventSetup& iSetup)
 {
@@ -92,9 +98,6 @@ void HLTHiggsValidator::endRun(const edm::Run & iRun, const edm::EventSetup& iSe
 }
 
 
-void HLTHiggsValidator::endJob()
-{
-}
 
 
 

--- a/HLTriggerOffline/Higgs/src/HLTHiggsValidator.cc
+++ b/HLTriggerOffline/Higgs/src/HLTHiggsValidator.cc
@@ -24,8 +24,7 @@
 HLTHiggsValidator::HLTHiggsValidator(const edm::ParameterSet& pset) :
       	_pset(pset),
 	_analysisnames(pset.getParameter<std::vector<std::string> >("analysis")),
-	_collections(0),
-	_dbe(0)
+	_collections(0)
 {
 	_collections = new EVTColContainer;
 

--- a/HLTriggerOffline/Higgs/src/HLTHiggsValidator.cc
+++ b/HLTriggerOffline/Higgs/src/HLTHiggsValidator.cc
@@ -68,10 +68,7 @@ void HLTHiggsValidator::bookHistograms(DQMStore::IBooker &ibooker, const edm::Ru
 
 void HLTHiggsValidator::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
-      	static int eventNumber = 0;
-      	eventNumber++;
-      	LogTrace("HiggsValidation") << "In HLTHiggsSubAnalysis::analyze,  " 
-		<< "Event: " << eventNumber;
+
 	
 	// Initialize the event collections
 	this->_collections->reset();

--- a/HLTriggerOffline/Higgs/src/SealModules.cc
+++ b/HLTriggerOffline/Higgs/src/SealModules.cc
@@ -3,5 +3,7 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "HLTriggerOffline/Higgs/interface/HLTHiggsValidator.h"
+#include "HLTriggerOffline/Higgs/interface/HLTHiggsHarvesting.h"
 
 DEFINE_FWK_MODULE(HLTHiggsValidator);
+DEFINE_FWK_MODULE(HiggsHarvesting);


### PR DESCRIPTION
The PR contains in fact two parts: 
-first is the migration of the Higgs validation package to the DQMEDAlayzer and DQMEDHarvester interface. I followed the recipe according to:
https://twiki.cern.ch/twiki/bin/view/CMS/ThreadedDQM

-second is an addition of few plots:
   -> a summary plot for each analysis showing the efficiency of every path of the analysis in the same plot
   -> a plot showing for each path the efficiency versus the number of interactions in the event

I estimated the increase of memory using the recipe in https://twiki.cern.ch/twiki/bin/viewauth/CMS/DQMStoreStats

| subsystem/folder | histograms | bins | Empty bins | Empty/Total | bins per histogram | MB | kB per histogram |
| --- | --- | --- | --- | --- | --- | --- | --- |
| Standard | 240 | 9720 | 8547 | 0.879 | 40.5 | 0.0371 | 0.158 |
| with plots added | 298 | 10156 | 8875 | 0.874 | 34.1 | 0.0387 | 0.133 |
