### PR TITLE
share EM physics process objects between particles

### DIFF
--- a/SimG4Core/PhysicsLists/src/CMSEmStandardPhysics.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmStandardPhysics.cc
@@ -129,6 +129,10 @@ void CMSEmStandardPhysics::ConstructProcess() {
     G4cout << "### " << GetPhysicsName() << " Construct Processes " << G4endl;
   }
 
+  // This EM builder takes default models of Geant4 10 EMV.
+  // Multiple scattering by Urban for all particles
+  // except e+e- below 100 MeV for which the Urban93 model is used
+
   G4PhysicsListHelper* ph = G4PhysicsListHelper::GetPhysicsListHelper();
 
   // muon & hadron bremsstrahlung and pair production

--- a/SimG4Core/PhysicsLists/src/CMSEmStandardPhysics95.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmStandardPhysics95.cc
@@ -133,7 +133,21 @@ void CMSEmStandardPhysics95::ConstructProcess()
   }
   */
 
+  // This EM builder takes default models of Geant4 10 EMV.
+  // Multiple scattering by Urban for all particles
+
   G4PhysicsListHelper* ph = G4PhysicsListHelper::GetPhysicsListHelper();
+
+  G4MuBremsstrahlung* mub = new G4MuBremsstrahlung();
+  G4MuPairProduction* mup = new G4MuPairProduction();
+  G4hBremsstrahlung*  pib = new G4hBremsstrahlung();
+  G4hPairProduction*  pip = new G4hPairProduction();
+  G4hBremsstrahlung*  kb  = new G4hBremsstrahlung();
+  G4hPairProduction*  kp  = new G4hPairProduction();
+  G4hBremsstrahlung*  pb  = new G4hBremsstrahlung();
+  G4hPairProduction*  pp  = new G4hPairProduction();
+
+  G4hMultipleScattering* hmsc = new G4hMultipleScattering("ionmsc");
 
   // Add standard EM Processes
   aParticleIterator->reset();
@@ -148,11 +162,7 @@ void CMSEmStandardPhysics95::ConstructProcess()
 
       ph->RegisterProcess(new G4PhotoElectricEffect(), particle);
       ph->RegisterProcess(new G4ComptonScattering(), particle);
-      G4GammaConversion* conv = new G4GammaConversion();
-      G4PairProductionRelModel* mod = new G4PairProductionRelModel();
-      mod->SetLowEnergyLimit(80*GeV);
-      conv->AddEmModel(0, mod);
-      ph->RegisterProcess(conv, particle);
+      ph->RegisterProcess(new G4GammaConversion(), particle);
 
     } else if (particleName == "e-") {
 
@@ -185,9 +195,6 @@ void CMSEmStandardPhysics95::ConstructProcess()
                particleName == "mu-"    ) {
 
       G4MuMultipleScattering* msc = new G4MuMultipleScattering();
-      G4MuBremsstrahlung* mub = new G4MuBremsstrahlung();
-      G4MuPairProduction* mup = new G4MuPairProduction();
-
       ph->RegisterProcess(msc, particle);
       ph->RegisterProcess(new G4MuIonisation(), particle);
       ph->RegisterProcess(mub, particle);
@@ -207,9 +214,6 @@ void CMSEmStandardPhysics95::ConstructProcess()
     } else if (particleName == "pi+" || 
 	       particleName == "pi-" ) {
 
-      G4hBremsstrahlung* pib = new G4hBremsstrahlung();
-      G4hPairProduction* pip = new G4hPairProduction();
-
       ph->RegisterProcess(new G4hMultipleScattering(), particle);
       ph->RegisterProcess(new G4hIonisation(), particle);
       ph->RegisterProcess(pib, particle);
@@ -218,20 +222,18 @@ void CMSEmStandardPhysics95::ConstructProcess()
     } else if (particleName == "kaon+" ||
                particleName == "kaon-" ) {
 
-      G4hBremsstrahlung* kb = new G4hBremsstrahlung();
-      G4hPairProduction* kp = new G4hPairProduction();
-
       ph->RegisterProcess(new G4hMultipleScattering(), particle);
       ph->RegisterProcess(new G4hIonisation(), particle);
       ph->RegisterProcess(kb, particle);
       ph->RegisterProcess(kp, particle);
 
-    } else if (particleName == "proton" ) {
+    } else if (particleName == "proton" || 
+	       particleName == "anti_proton") {
 
       ph->RegisterProcess(new G4hMultipleScattering(), particle);
       ph->RegisterProcess(new G4hIonisation(), particle);
-      ph->RegisterProcess(new G4hBremsstrahlung(), particle);
-      ph->RegisterProcess(new G4hPairProduction(), particle);
+      ph->RegisterProcess(pb, particle);
+      ph->RegisterProcess(pp, particle);
 
     } else if (particleName == "B+" ||
 	       particleName == "B-" ||
@@ -244,7 +246,6 @@ void CMSEmStandardPhysics95::ConstructProcess()
                particleName == "anti_deuteron" ||
                particleName == "anti_lambda_c+" ||
                particleName == "anti_omega-" ||
-	       particleName == "anti_proton" ||
                particleName == "anti_sigma_c+" ||
                particleName == "anti_sigma_c++" ||
                particleName == "anti_sigma+" ||
@@ -265,7 +266,7 @@ void CMSEmStandardPhysics95::ConstructProcess()
                particleName == "xi_c+" ||
                particleName == "xi-" ) {
 
-      ph->RegisterProcess(new G4hMultipleScattering(), particle);
+      ph->RegisterProcess(hmsc, particle);
       ph->RegisterProcess(new G4hIonisation(), particle);
     }
   }

--- a/SimG4Core/PhysicsLists/src/CMSEmStandardPhysics95msc93.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmStandardPhysics95msc93.cc
@@ -124,6 +124,22 @@ void CMSEmStandardPhysics95msc93::ConstructProcess()
 {
   // Add standard EM Processes
 
+  // muon & hadron bremsstrahlung and pair production
+  G4MuBremsstrahlung* mub = new G4MuBremsstrahlung();
+  G4MuPairProduction* mup = new G4MuPairProduction();
+  G4hBremsstrahlung* pib = new G4hBremsstrahlung();
+  G4hPairProduction* pip = new G4hPairProduction();
+  G4hBremsstrahlung* kb = new G4hBremsstrahlung();
+  G4hPairProduction* kp = new G4hPairProduction();
+  G4hBremsstrahlung* pb = new G4hBremsstrahlung();
+  G4hPairProduction* pp = new G4hPairProduction();
+
+  G4hMultipleScattering* hmsc = new G4hMultipleScattering("ionmsc");
+
+  // This EM builder takes default models of Geant4 10 EMV.
+  // Multiple scattering by Urban for all particles
+  // except e+e- for which the Urban93 model is used
+
   aParticleIterator->reset();
   while( (*aParticleIterator)() ){
     G4ParticleDefinition* particle = aParticleIterator->value();
@@ -137,11 +153,7 @@ void CMSEmStandardPhysics95msc93::ConstructProcess()
 
       pmanager->AddDiscreteProcess(new G4PhotoElectricEffect);
       pmanager->AddDiscreteProcess(new G4ComptonScattering);
-      G4GammaConversion* conv = new G4GammaConversion();
-      G4PairProductionRelModel* mod = new G4PairProductionRelModel();
-      mod->SetLowEnergyLimit(80*GeV);
-      conv->AddEmModel(0, mod);
-      pmanager->AddDiscreteProcess(conv);
+      pmanager->AddDiscreteProcess(new G4GammaConversion());
 
     } else if (particleName == "e-") {
 
@@ -161,6 +173,7 @@ void CMSEmStandardPhysics95msc93::ConstructProcess()
 
       G4eIonisation* eioni = new G4eIonisation();
       eioni->SetStepFunction(0.8, 1.0*mm);
+
       G4eMultipleScattering* msc = new G4eMultipleScattering;
       msc->SetStepLimitType(fMinimal);
       msc->AddEmModel(0,new UrbanMscModel93());
@@ -177,26 +190,39 @@ void CMSEmStandardPhysics95msc93::ConstructProcess()
 
       pmanager->AddProcess(new G4hMultipleScattering, -1, 1, 1);
       pmanager->AddProcess(new G4MuIonisation,        -1, 2, 2);
-      pmanager->AddProcess(new G4MuBremsstrahlung,    -1,-3, 3);
-      pmanager->AddProcess(new G4MuPairProduction,    -1,-4, 4);
+      pmanager->AddProcess(mub,    -1,-3, 3);
+      pmanager->AddProcess(mup,    -1,-4, 4);
 
     } else if (particleName == "alpha" ||
                particleName == "He3" ||
                particleName == "GenericIon") {
 
-      pmanager->AddProcess(new G4hMultipleScattering, -1, 1, 1);
-      pmanager->AddProcess(new G4ionIonisation,       -1, 2, 2);
+      pmanager->AddProcess(hmsc,                  -1, 1, 1);
+      pmanager->AddProcess(new G4ionIonisation,   -1, 2, 2);
 
     } else if (particleName == "pi+" ||
-	       particleName == "kaon+" ||
-	       particleName == "kaon-" ||
-	       particleName == "proton" ||
 	       particleName == "pi-" ) {
 
       pmanager->AddProcess(new G4hMultipleScattering, -1, 1, 1);
       pmanager->AddProcess(new G4hIonisation,         -1, 2, 2);
-      pmanager->AddProcess(new G4hBremsstrahlung(),   -1,-3, 3);
-      pmanager->AddProcess(new G4hPairProduction(),   -1,-4, 4);
+      pmanager->AddProcess(pib,   -1,-3, 3);
+      pmanager->AddProcess(pip,   -1,-4, 4);
+
+    } else if (particleName == "kaon+" ||
+	       particleName == "kaon-"  ) {
+
+      pmanager->AddProcess(new G4hMultipleScattering, -1, 1, 1);
+      pmanager->AddProcess(new G4hIonisation,         -1, 2, 2);
+      pmanager->AddProcess(kb,   -1,-3, 3);
+      pmanager->AddProcess(kp,   -1,-4, 4);
+
+    } else if (particleName == "proton" || 
+	       particleName == "anti_proton" ) {
+
+      pmanager->AddProcess(new G4hMultipleScattering, -1, 1, 1);
+      pmanager->AddProcess(new G4hIonisation,         -1, 2, 2);
+      pmanager->AddProcess(pb,   -1,-3, 3);
+      pmanager->AddProcess(pp,   -1,-4, 4);
 
     } else if (particleName == "B+" ||
 	       particleName == "B-" ||
@@ -226,8 +252,8 @@ void CMSEmStandardPhysics95msc93::ConstructProcess()
                particleName == "xi_c+" ||
                particleName == "xi-" ) {
 
-      pmanager->AddProcess(new G4hMultipleScattering, -1, 1, 1);
-      pmanager->AddProcess(new G4hIonisation,         -1, 2, 2);
+      pmanager->AddProcess(hmsc,                -1, 1, 1);
+      pmanager->AddProcess(new G4hIonisation,   -1, 2, 2);
     }
   }
 
@@ -239,12 +265,4 @@ void CMSEmStandardPhysics95msc93::ConstructProcess()
   // ApplyCuts
   //
   opt.SetApplyCuts(true);
-
-  // Physics tables
-  //
-  opt.SetMinEnergy(100.*eV);
-  opt.SetMaxEnergy(10.*TeV);
-  opt.SetDEDXBinning(77);
-  opt.SetLambdaBinning(77);
-
 }

--- a/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsLPM.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsLPM.cc
@@ -126,6 +126,23 @@ void CMSEmStandardPhysicsLPM::ConstructProcess()
 {
   // Add standard EM Processes
 
+  // muon & hadron bremsstrahlung and pair production
+  G4MuBremsstrahlung* mub = new G4MuBremsstrahlung();
+  G4MuPairProduction* mup = new G4MuPairProduction();
+  G4hBremsstrahlung* pib = new G4hBremsstrahlung();
+  G4hPairProduction* pip = new G4hPairProduction();
+  G4hBremsstrahlung* kb = new G4hBremsstrahlung();
+  G4hPairProduction* kp = new G4hPairProduction();
+  G4hBremsstrahlung* pb = new G4hBremsstrahlung();
+  G4hPairProduction* pp = new G4hPairProduction();
+
+  G4hMultipleScattering* hmsc = new G4hMultipleScattering("ionmsc");
+
+  // This EM builder takes default models of Geant4 10 EMV.
+  // Multiple scattering by Urban for all particles
+  // except e+e- for which the Urban93 model is used
+  // and WentzelVI+SingleScattering for muons
+
   aParticleIterator->reset();
   while( (*aParticleIterator)() ){
     G4ParticleDefinition* particle = aParticleIterator->value();
@@ -139,11 +156,7 @@ void CMSEmStandardPhysicsLPM::ConstructProcess()
 
       pmanager->AddDiscreteProcess(new G4PhotoElectricEffect);
       pmanager->AddDiscreteProcess(new G4ComptonScattering);
-      G4GammaConversion* conv = new G4GammaConversion();
-      G4PairProductionRelModel* mod = new G4PairProductionRelModel();
-      mod->SetLowEnergyLimit(80*GeV);
-      conv->AddEmModel(0, mod);
-      pmanager->AddDiscreteProcess(conv);
+      pmanager->AddDiscreteProcess(new G4GammaConversion());
 
     } else if (particleName == "e-") {
 
@@ -181,27 +194,40 @@ void CMSEmStandardPhysicsLPM::ConstructProcess()
       mumsc->AddEmModel(0, new G4WentzelVIModel());
       pmanager->AddProcess(mumsc,                     -1, 1, 1);
       pmanager->AddProcess(new G4MuIonisation,        -1, 2, 2);
-      pmanager->AddProcess(new G4MuBremsstrahlung,    -1,-3, 3);
-      pmanager->AddProcess(new G4MuPairProduction,    -1,-4, 4);
+      pmanager->AddProcess(mub,    -1,-3, 3);
+      pmanager->AddProcess(mup,    -1,-4, 4);
       pmanager->AddProcess(new G4CoulombScattering,   -1,-4, 5);
 
     } else if (particleName == "alpha" ||
                particleName == "He3" ||
                particleName == "GenericIon") {
 
-      pmanager->AddProcess(new G4hMultipleScattering, -1, 1, 1);
-      pmanager->AddProcess(new G4ionIonisation,       -1, 2, 2);
+      pmanager->AddProcess(hmsc,                -1, 1, 1);
+      pmanager->AddProcess(new G4ionIonisation, -1, 2, 2);
 
     } else if (particleName == "pi+" ||
-	       particleName == "kaon+" ||
-	       particleName == "kaon-" ||
-	       particleName == "proton" ||
 	       particleName == "pi-" ) {
 
       pmanager->AddProcess(new G4hMultipleScattering, -1, 1, 1);
       pmanager->AddProcess(new G4hIonisation,         -1, 2, 2);
-      pmanager->AddProcess(new G4hBremsstrahlung(),   -1,-3, 3);
-      pmanager->AddProcess(new G4hPairProduction(),   -1,-4, 4);
+      pmanager->AddProcess(pib,   -1,-3, 3);
+      pmanager->AddProcess(pip,   -1,-4, 4);
+
+    } else if (particleName == "kaon+" ||
+	       particleName == "kaon-"  ) {
+
+      pmanager->AddProcess(new G4hMultipleScattering, -1, 1, 1);
+      pmanager->AddProcess(new G4hIonisation,         -1, 2, 2);
+      pmanager->AddProcess(kb,   -1,-3, 3);
+      pmanager->AddProcess(kp,   -1,-4, 4);
+
+    } else if (particleName == "proton" || 
+	       particleName == "anti_proton" ) {
+
+      pmanager->AddProcess(new G4hMultipleScattering, -1, 1, 1);
+      pmanager->AddProcess(new G4hIonisation,         -1, 2, 2);
+      pmanager->AddProcess(pb,   -1,-3, 3);
+      pmanager->AddProcess(pp,   -1,-4, 4);
 
     } else if (particleName == "B+" ||
 	       particleName == "B-" ||
@@ -211,7 +237,6 @@ void CMSEmStandardPhysicsLPM::ConstructProcess()
 	       particleName == "Ds-" ||
                particleName == "anti_lambda_c+" ||
                particleName == "anti_omega-" ||
-               particleName == "anti_proton" ||
                particleName == "anti_sigma_c+" ||
                particleName == "anti_sigma_c++" ||
                particleName == "anti_sigma+" ||
@@ -231,8 +256,8 @@ void CMSEmStandardPhysicsLPM::ConstructProcess()
                particleName == "xi_c+" ||
                particleName == "xi-" ) {
 
-      pmanager->AddProcess(new G4hMultipleScattering, -1, 1, 1);
-      pmanager->AddProcess(new G4hIonisation,         -1, 2, 2);
+      pmanager->AddProcess(hmsc,              -1, 1, 1);
+      pmanager->AddProcess(new G4hIonisation, -1, 2, 2);
     }
   }
 
@@ -247,12 +272,4 @@ void CMSEmStandardPhysicsLPM::ConstructProcess()
   // ApplyCuts
   //
   opt.SetApplyCuts(true);
-
-  // Physics tables
-  //
-  opt.SetMinEnergy(100.*eV);
-  opt.SetMaxEnergy(10.*TeV);
-  opt.SetDEDXBinning(77);
-  opt.SetLambdaBinning(77);
-
 }


### PR DESCRIPTION
For Geant4 10 it is possible to share some EM processes between particles. This was already used in production Physics List. Now the feature is implemented in alternative EM physics constructors. Should not affect any validation result.
