### PR TITLE
Egamma HLT RelVal improvements for harvesting module

### DIFF
--- a/HLTriggerOffline/Egamma/interface/EmDQMPostProcessor.h
+++ b/HLTriggerOffline/Egamma/interface/EmDQMPostProcessor.h
@@ -3,20 +3,20 @@
 
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/DQMEDHarvester.h"
 
-class EmDQMPostProcessor : public edm::EDAnalyzer {
+class EmDQMPostProcessor : public DQMEDHarvester {
  public:
   EmDQMPostProcessor(const edm::ParameterSet& pset);
   ~EmDQMPostProcessor() {};
 
-  void analyze(const edm::Event& event, const edm::EventSetup& eventSetup) {};
-  void endRun(edm::Run const&, edm::EventSetup const&);
-  TProfile* dividehistos(DQMStore * dqm, const std::string& num, const std::string& denom, const std::string& out,const std::string& label, const std::string& titel= "");
+  void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override;
+  TProfile* dividehistos(DQMStore::IBooker & ibooker, DQMStore::IGetter & igetter, const std::string& num, const std::string& denom, const std::string& out,const std::string& label, const std::string& titel= "");
 
  private:
   
+  DQMStore * dqm;
+
   /** a replacement for the function TGraphAsymmErrors::Efficiency(..) used with earlier 
       versions of ROOT (this functionality has been moved to a separate class TEfficiency) */
   static void Efficiency(int passing, int total, double level, double &mode, double &lowerBound, double &upperBound);
@@ -31,7 +31,7 @@ class EmDQMPostProcessor : public edm::EDAnalyzer {
   /** convenience method to get a histogram but checks first
       whether the corresponding MonitorElement is non-null.
       @return null if the MonitorElement is null */
-  TH1F *getHistogram(DQMStore *dqm, const std::string &histoPath);
+  TH1F *getHistogram(DQMStore::IBooker & ibooker, DQMStore::IGetter & igetter, const std::string &histoPath);
 
   std::string subDir_;
   

--- a/HLTriggerOffline/Egamma/interface/EmDQMPostProcessor.h
+++ b/HLTriggerOffline/Egamma/interface/EmDQMPostProcessor.h
@@ -15,8 +15,6 @@ class EmDQMPostProcessor : public DQMEDHarvester {
 
  private:
   
-  DQMStore * dqm;
-
   /** a replacement for the function TGraphAsymmErrors::Efficiency(..) used with earlier 
       versions of ROOT (this functionality has been moved to a separate class TEfficiency) */
   static void Efficiency(int passing, int total, double level, double &mode, double &lowerBound, double &upperBound);

--- a/HLTriggerOffline/Egamma/interface/EmDQMPostProcessor.h
+++ b/HLTriggerOffline/Egamma/interface/EmDQMPostProcessor.h
@@ -25,6 +25,7 @@ class EmDQMPostProcessor : public DQMEDHarvester {
       running on data. */
   bool noPhiPlots;
   bool normalizeToReco;
+  bool ignoreEmpty;
 
   /** convenience method to get a histogram but checks first
       whether the corresponding MonitorElement is non-null.

--- a/HLTriggerOffline/Egamma/src/EmDQMPostProcessor.cc
+++ b/HLTriggerOffline/Egamma/src/EmDQMPostProcessor.cc
@@ -29,12 +29,6 @@ EmDQMPostProcessor::EmDQMPostProcessor(const edm::ParameterSet& pset)
 
 void EmDQMPostProcessor::dqmEndJob(DQMStore::IBooker & ibooker, DQMStore::IGetter & igetter)
 {
-  //////////////////////////////////
-  // setup DQM stor               //
-  //////////////////////////////////
-  dqm = 0;
-  dqm = edm::Service<DQMStore>().operator->();
-
   //go to the directory to be processed
   if(igetter.dirExists(subDir_)) ibooker.cd(subDir_);
   else {
@@ -120,12 +114,12 @@ void EmDQMPostProcessor::dqmEndJob(DQMStore::IBooker & ibooker, DQMStore::IGette
     for(std::vector<std::string>::iterator dir = subdirectories.begin(); dir!= subdirectories.end(); dir++) {
       ibooker.cd(*dir);
 
-      TH1F* basehist = getHistogram(ibooker, igetter, dqm->pwd() + "/" + baseName);
+      TH1F* basehist = getHistogram(ibooker, igetter, ibooker.pwd() + "/" + baseName);
       if (basehist == NULL)
 	{
-	  //edm::LogWarning("EmDQMPostProcessor") << "histogram " << (dqm->pwd() + "/" + baseName) << " does not exist, skipping postfix '" << *postfix << "'";
+	  //edm::LogWarning("EmDQMPostProcessor") << "histogram " << (ibooker.pwd() + "/" + baseName) << " does not exist, skipping postfix '" << *postfix << "'";
           pop = true;
-          dqm->goUp();
+          ibooker.goUp();
 	  continue;
 	}
       // at least one histogram with postfix was found
@@ -217,12 +211,12 @@ void EmDQMPostProcessor::dqmEndJob(DQMStore::IBooker & ibooker, DQMStore::IGette
       //loop over variables (eta/phi/et)
       for(std::vector<std::string>::iterator var = varNames.begin(); var != varNames.end() ; var++){
 	
-	numName   = dqm->pwd() + "/" + filterName2 + *var + *postfix;
+	numName   = ibooker.pwd() + "/" + filterName2 + *var + *postfix;
 
 	if (normalizeToReco)
-	  genName   = dqm->pwd() + "/reco_" + *var ;
+	  genName   = ibooker.pwd() + "/reco_" + *var ;
 	else
-	  genName   = dqm->pwd() + "/gen_" + *var ;
+	  genName   = ibooker.pwd() + "/gen_" + *var ;
 
 	// Create the efficiency plot
 	if(!dividehistos(ibooker,igetter,numName,genName,"efficiency_"+filterName2+"_vs_"+*var +*postfix,*var,"eff. of"+filterName2+" vs "+*var +*postfix))
@@ -236,16 +230,16 @@ void EmDQMPostProcessor::dqmEndJob(DQMStore::IBooker & ibooker, DQMStore::IGette
 	
 	//loop over variables (eta/et/phi)
 	for(std::vector<std::string>::iterator var = varNames.begin(); var != varNames.end() ; var++){
-	  numName   = dqm->pwd() + "/" + filterName2 + *var + *postfix;
-	  denomName = dqm->pwd() + "/" + filterName  + *var + *postfix;
+	  numName   = ibooker.pwd() + "/" + filterName2 + *var + *postfix;
+	  denomName = ibooker.pwd() + "/" + filterName  + *var + *postfix;
 
 	  // Is this the last filter? Book efficiency vs gen (or reco, for data) level
 	  std::string temp = *postfix;
           if (filter==total->GetNbinsX()-3 && temp.find("matched")!=std::string::npos) {
 	    if (normalizeToReco)
-	      genName = dqm->pwd() + "/reco_" + *var;
+	      genName = ibooker.pwd() + "/reco_" + *var;
 	    else
-	      genName = dqm->pwd() + "/gen_" + *var;
+	      genName = ibooker.pwd() + "/gen_" + *var;
 
 	    if(!dividehistos(ibooker,igetter,numName,genName,"final_eff_vs_"+*var,*var,"Efficiency Compared to " + shortReferenceName + " vs "+*var))
 	      break;
@@ -257,7 +251,7 @@ void EmDQMPostProcessor::dqmEndJob(DQMStore::IBooker & ibooker, DQMStore::IGette
 	} // loop over variables
       } // loop over monitoring modules within path
 
-      dqm->goUp();
+      ibooker.goUp();
 
       // have a per-step histogram of the path on the front page
       std::string trigName = dir->substr(dir->rfind("/") + 1);

--- a/HLTriggerOffline/Egamma/src/EmDQMPostProcessor.cc
+++ b/HLTriggerOffline/Egamma/src/EmDQMPostProcessor.cc
@@ -1,6 +1,5 @@
 #include "HLTriggerOffline/Egamma/interface/EmDQMPostProcessor.h"
 
-#include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -28,23 +27,16 @@ EmDQMPostProcessor::EmDQMPostProcessor(const edm::ParameterSet& pset)
 
 //----------------------------------------------------------------------
 
-void EmDQMPostProcessor::endRun(edm::Run const& run, edm::EventSetup const& es)
+void EmDQMPostProcessor::dqmEndJob(DQMStore::IBooker & ibooker, DQMStore::IGetter & igetter)
 {
   //////////////////////////////////
   // setup DQM stor               //
   //////////////////////////////////
-  
-  DQMStore * dqm = 0;
+  dqm = 0;
   dqm = edm::Service<DQMStore>().operator->();
 
-  if ( ! dqm ) {
-    edm::LogInfo("EmDQMPostProcessor") << "Cannot create DQMStore instance\n";
-    return;
-  }
-
-
   //go to the directory to be processed
-  if(dqm->dirExists(subDir_)) dqm->cd(subDir_);
+  if(igetter.dirExists(subDir_)) ibooker.cd(subDir_);
   else {
     edm::LogWarning("EmDQMPostProcessor") << "cannot find directory: " << subDir_ << " , skipping";
     return;
@@ -78,9 +70,9 @@ void EmDQMPostProcessor::endRun(edm::Run const& run, edm::EventSetup const& es)
   // So we store the name of the dataset as the title of a histogram,
   // which is much easier to access...
   // TH1D *dataSetNameHisto = 
-  dqm->book1D("DataSetNameHistogram",dataSet_,1,0,1);
+  ibooker.book1D("DataSetNameHistogram",dataSet_,1,0,1);
 
-  std::vector<std::string> subdirectories = dqm->getSubdirs();
+  std::vector<std::string> subdirectories = igetter.getSubdirs();
   ////////////////////////////////////////////////////////
   // Do everything twice: once for mc-matched histos,   //
   // once for unmatched histos                          //
@@ -126,9 +118,9 @@ void EmDQMPostProcessor::endRun(edm::Run const& run, edm::EventSetup const& es)
     allPhotonPaths.push_back(new TProfile(allPhotonHistoName.c_str(), allPhotonHistoLabel.c_str(), nPhoton, 0., (double)nPhoton, 0., 1.2));
 
     for(std::vector<std::string>::iterator dir = subdirectories.begin(); dir!= subdirectories.end(); dir++) {
-      dqm->cd(*dir);
+      ibooker.cd(*dir);
 
-      TH1F* basehist = getHistogram(dqm, dqm->pwd() + "/" + baseName);
+      TH1F* basehist = getHistogram(ibooker, igetter, dqm->pwd() + "/" + baseName);
       if (basehist == NULL)
 	{
 	  //edm::LogWarning("EmDQMPostProcessor") << "histogram " << (dqm->pwd() + "/" + baseName) << " does not exist, skipping postfix '" << *postfix << "'";
@@ -139,10 +131,10 @@ void EmDQMPostProcessor::endRun(edm::Run const& run, edm::EventSetup const& es)
       // at least one histogram with postfix was found
       pop = false;
           
-      TProfile* total = dqm->bookProfile(histoName,histoName,basehist->GetXaxis()->GetNbins(),basehist->GetXaxis()->GetXmin(),basehist->GetXaxis()->GetXmax(),0.,1.2)->getTProfile();
+      TProfile* total = ibooker.bookProfile(histoName,histoName,basehist->GetXaxis()->GetNbins(),basehist->GetXaxis()->GetXmin(),basehist->GetXaxis()->GetXmax(),0.,1.2)->getTProfile();
       total->GetXaxis()->SetBinLabel(1,basehist->GetXaxis()->GetBinLabel(1));
       
-//       std::vector<std::string> mes = dqm->getMEs();
+//       std::vector<std::string> mes = igetter.getMEs();
 //       for(std::vector<std::string>::iterator me = mes.begin() ;me!= mes.end(); me++ )
 // 	std::cout <<*me <<std::endl;
 //       std::cout <<std::endl;
@@ -233,7 +225,7 @@ void EmDQMPostProcessor::endRun(edm::Run const& run, edm::EventSetup const& es)
 	  genName   = dqm->pwd() + "/gen_" + *var ;
 
 	// Create the efficiency plot
-	if(!dividehistos(dqm,numName,genName,"efficiency_"+filterName2+"_vs_"+*var +*postfix,*var,"eff. of"+filterName2+" vs "+*var +*postfix))
+	if(!dividehistos(ibooker,igetter,numName,genName,"efficiency_"+filterName2+"_vs_"+*var +*postfix,*var,"eff. of"+filterName2+" vs "+*var +*postfix))
 	  break;
       } // loop over variables
     
@@ -255,11 +247,11 @@ void EmDQMPostProcessor::endRun(edm::Run const& run, edm::EventSetup const& es)
 	    else
 	      genName = dqm->pwd() + "/gen_" + *var;
 
-	    if(!dividehistos(dqm,numName,genName,"final_eff_vs_"+*var,*var,"Efficiency Compared to " + shortReferenceName + " vs "+*var))
+	    if(!dividehistos(ibooker,igetter,numName,genName,"final_eff_vs_"+*var,*var,"Efficiency Compared to " + shortReferenceName + " vs "+*var))
 	      break;
 	  }
 
-	  if(!dividehistos(dqm,numName,denomName,"efficiency_"+filterName2+"_vs_"+*var +*postfix,*var,"efficiency_"+filterName2+"_vs_"+*var + *postfix))
+	  if(!dividehistos(ibooker,igetter,numName,denomName,"efficiency_"+filterName2+"_vs_"+*var +*postfix,*var,"efficiency_"+filterName2+"_vs_"+*var + *postfix))
 	    break;
 
 	} // loop over variables
@@ -270,7 +262,7 @@ void EmDQMPostProcessor::endRun(edm::Run const& run, edm::EventSetup const& es)
       // have a per-step histogram of the path on the front page
       std::string trigName = dir->substr(dir->rfind("/") + 1);
       trigName = trigName.replace(trigName.rfind("_DQM"),4,"");
-      TProfile* pathEffPerStep = dqm->bookProfile(trigName + "__" + histoName, total)->getTProfile();
+      TProfile* pathEffPerStep = ibooker.bookProfile(trigName + "__" + histoName, total)->getTProfile();
       pathEffPerStep->SetTitle((trigName + "__" + histoName).c_str());
 
       // fill overall efficiency histograms
@@ -299,8 +291,8 @@ void EmDQMPostProcessor::endRun(edm::Run const& run, edm::EventSetup const& es)
     else {
       allElePaths.back()->GetXaxis()->SetLabelSize(0.03);
       allPhotonPaths.back()->GetXaxis()->SetLabelSize(0.03);
-      dqm->bookProfile(allEleHistoName, allElePaths.back());
-      dqm->bookProfile(allPhotonHistoName, allPhotonPaths.back());
+      ibooker.bookProfile(allEleHistoName, allElePaths.back());
+      ibooker.bookProfile(allPhotonHistoName, allPhotonPaths.back());
     }
   } // loop over postfixes
   
@@ -308,13 +300,13 @@ void EmDQMPostProcessor::endRun(edm::Run const& run, edm::EventSetup const& es)
 
 //----------------------------------------------------------------------
 
-TProfile* EmDQMPostProcessor::dividehistos(DQMStore * dqm, const std::string& numName, const std::string& denomName, const std::string& outName,const std::string& label,const std::string& titel){
+TProfile* EmDQMPostProcessor::dividehistos(DQMStore::IBooker & ibooker, DQMStore::IGetter & igetter, const std::string& numName, const std::string& denomName, const std::string& outName,const std::string& label,const std::string& titel){
   //std::cout << numName <<std::endl;
 
-  TH1F* num = getHistogram(dqm,numName);
+  TH1F* num = getHistogram(ibooker,igetter,numName);
 
   //std::cout << denomName << std::endl;
-  TH1F* denom = getHistogram(dqm, denomName);
+  TH1F* denom = getHistogram(ibooker,igetter, denomName);
 
   if (num == NULL)
     edm::LogWarning("EmDQMPostProcessor") << "numerator histogram " << numName << " does not exist";
@@ -326,10 +318,7 @@ TProfile* EmDQMPostProcessor::dividehistos(DQMStore * dqm, const std::string& nu
 
   if(!num || !denom) return 0;
 
-  // Make sure we are able to book new element
-  if (!dqm) return 0;
-  
-  TProfile* out = dqm->bookProfile(outName,titel,num->GetXaxis()->GetNbins(),num->GetXaxis()->GetXmin(),num->GetXaxis()->GetXmax(),0.,1.2)->getTProfile();
+  TProfile* out = ibooker.bookProfile(outName,titel,num->GetXaxis()->GetNbins(),num->GetXaxis()->GetXmin(),num->GetXaxis()->GetXmax(),0.,1.2)->getTProfile();
   out->GetXaxis()->SetTitle(label.c_str());
   out->SetYTitle("Efficiency");
   out->SetOption("PE");
@@ -354,9 +343,9 @@ TProfile* EmDQMPostProcessor::dividehistos(DQMStore * dqm, const std::string& nu
 //----------------------------------------------------------------------
 
 TH1F *
-EmDQMPostProcessor::getHistogram(DQMStore *dqm, const std::string &histoPath)
+EmDQMPostProcessor::getHistogram(DQMStore::IBooker & ibooker, DQMStore::IGetter & igetter, const std::string &histoPath)
 {
-  MonitorElement *monElement = dqm->get(histoPath);
+  MonitorElement *monElement = igetter.get(histoPath);
   if (monElement != NULL)
     return monElement->getTH1F();
   else

--- a/HLTriggerOffline/Egamma/test/egammaHltPrintRelvalEfficiencies.py
+++ b/HLTriggerOffline/Egamma/test/egammaHltPrintRelvalEfficiencies.py
@@ -160,14 +160,19 @@ if top_dir == None:
 # determine the length of the longest path name (for nice printout)
 #--------------------
 
-maxPathNameLen = None
+maxPathNameLen = 100
 allPathNames = []
 
 for path_key in top_dir.GetListOfKeys():
-
     pathName = path_key.GetName()
 
-    if len(options.selected_paths) != 0 and not path_name in options.selected_paths:
+    # just select directories (there are also other
+    # objects in the top directory)
+    path_dir = top_dir.Get(pathName)
+    if not isinstance(path_dir,ROOT.TDirectoryFile):
+        continue
+
+    if len(options.selected_paths) != 0 and not pathName in options.selected_paths:
         continue
 
     # further checks which are done in the next
@@ -227,7 +232,7 @@ for path_name in allPathNames:
     print ("PATH: %-" + str(maxPathNameLen) + "s") % path_name,
 
     if num_gen_events > 0:
-        print "(%.1f%% eff.)" % (100 * total / float(num_gen_events)),
+        print "(%5.1f%% eff.)" % (100 * total / float(num_gen_events)),
 
     elif options.summary_mode:
         print "(no entries)",

--- a/HLTriggerOffline/Egamma/test/testEmDQM_cfg.py
+++ b/HLTriggerOffline/Egamma/test/testEmDQM_cfg.py
@@ -15,10 +15,10 @@ process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
 
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring(
-#        '/store/relval/CMSSW_7_1_0_pre7/RelValZEE_13/GEN-SIM-DIGI-RAW-HLTDEBUG/PRE_LS171_V7-v1/00000/06D540C7-B1D0-E311-A86E-02163E00E81C.root',
+        '/store/relval/CMSSW_7_1_0_pre7/RelValZEE_13/GEN-SIM-DIGI-RAW-HLTDEBUG/PRE_LS171_V7-v1/00000/06D540C7-B1D0-E311-A86E-02163E00E81C.root',
 #        '/store/relval/CMSSW_7_1_0_pre7/RelValH130GGgluonfusion_13/GEN-SIM-DIGI-RAW-HLTDEBUG/PRE_LS171_V7-v1/00000/C87CDC3A-B1D0-E311-8890-02163E00E6DE.root',
 #        '/store/relval/CMSSW_7_1_0_pre7/RelValWE_13/GEN-SIM-DIGI-RAW-HLTDEBUG/PRE_LS171_V7-v1/00000/665BE840-B4D0-E311-BBA6-02163E00E694.root',
-        '/store/relval/CMSSW_7_1_0_pre7/RelValPhotonJets_Pt_10_13/GEN-SIM-DIGI-RAW-HLTDEBUG/PRE_LS171_V7-v1/00000/C0AB31B9-A2D0-E311-A15D-02163E00E725.root',
+#        '/store/relval/CMSSW_7_1_0_pre7/RelValPhotonJets_Pt_10_13/GEN-SIM-DIGI-RAW-HLTDEBUG/PRE_LS171_V7-v1/00000/C0AB31B9-A2D0-E311-A15D-02163E00E725.root',
     )
 )
 
@@ -53,12 +53,10 @@ process.post=cms.EDAnalyzer("EmDQMPostProcessor",
 #----------------------------------------
 process.load("DQMServices.Core.DQM_cfg")
 process.load("DQMServices.Components.DQMEnvironment_cfi")
-process.DQMStore.verbose = 0
-#process.DQM.collectorHost = ''
 process.dqmSaver.convention = 'Offline'
-process.dqmSaver.workflow = '/A/B/C'
-process.dqmSaver.saveByRun = 1
-process.dqmSaver.saveAtJobEnd = True
+process.dqmSaver.workflow = '/RelVal/HLTriggerOffline/Egamma'
+process.dqmSaver.saveByRun = cms.untracked.int32(-1)
+process.dqmSaver.saveAtJobEnd = cms.untracked.bool(True)
 
 process.ppost = cms.EndPath(process.post+process.dqmSaver)
 

--- a/HLTriggerOffline/Egamma/test/testEmDQM_cfg.py
+++ b/HLTriggerOffline/Egamma/test/testEmDQM_cfg.py
@@ -54,7 +54,7 @@ process.post=cms.EDAnalyzer("EmDQMPostProcessor",
 process.load("DQMServices.Core.DQM_cfg")
 process.load("DQMServices.Components.DQMEnvironment_cfi")
 process.DQMStore.verbose = 0
-process.DQM.collectorHost = ''
+#process.DQM.collectorHost = ''
 process.dqmSaver.convention = 'Online'
 process.dqmSaver.saveByRun = 1
 process.dqmSaver.saveAtJobEnd = True

--- a/HLTriggerOffline/Egamma/test/testEmDQM_cfg.py
+++ b/HLTriggerOffline/Egamma/test/testEmDQM_cfg.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("emdqm")
 
 process.load('Configuration/StandardSequences/FrontierConditions_GlobalTag_cff')
-process.GlobalTag.globaltag = 'START70_V1::All'
+process.GlobalTag.globaltag = 'PRE_LS171_V7::All'
 
 process.load("FWCore.MessageService.MessageLogger_cfi")
 # suppress printout of error messages on every event when a collection is missing in the event
@@ -15,10 +15,10 @@ process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
 
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring(
-        '/store/relval/CMSSW_7_0_0_pre8/RelValZEE/GEN-SIM-DIGI-RAW-HLTDEBUG/PU_START70_V1-v1/00000/1C634144-E94A-E311-964E-002618943866.root',
-#        '/store/relval/CMSSW_7_0_0_pre8/RelValH130GGgluonfusion/GEN-SIM-DIGI-RAW-HLTDEBUG/PU_START70_V1-v1/00000/269313CD-E54A-E311-9EB4-002618943894.root',
-#        '/store/relval/CMSSW_7_0_0_pre8/RelValWE/GEN-SIM-DIGI-RAW-HLTDEBUG/START70_V2_RR-v7/00000/96E6CAB6-3B59-E311-9593-002618943925.root',
-#        '/store/relval/CMSSW_7_0_0_pre8/RelValPhotonJets_Pt_10/GEN-SIM-DIGI-RAW-HLTDEBUG/START70_V2_RR-v7/00000/B6FDCDBB-3D59-E311-AB2B-002618943857.root',
+#        '/store/relval/CMSSW_7_1_0_pre7/RelValZEE_13/GEN-SIM-DIGI-RAW-HLTDEBUG/PRE_LS171_V7-v1/00000/06D540C7-B1D0-E311-A86E-02163E00E81C.root',
+#        '/store/relval/CMSSW_7_1_0_pre7/RelValH130GGgluonfusion_13/GEN-SIM-DIGI-RAW-HLTDEBUG/PRE_LS171_V7-v1/00000/C87CDC3A-B1D0-E311-8890-02163E00E6DE.root',
+#        '/store/relval/CMSSW_7_1_0_pre7/RelValWE_13/GEN-SIM-DIGI-RAW-HLTDEBUG/PRE_LS171_V7-v1/00000/665BE840-B4D0-E311-BBA6-02163E00E694.root',
+        '/store/relval/CMSSW_7_1_0_pre7/RelValPhotonJets_Pt_10_13/GEN-SIM-DIGI-RAW-HLTDEBUG/PRE_LS171_V7-v1/00000/C0AB31B9-A2D0-E311-A15D-02163E00E725.root',
     )
 )
 

--- a/HLTriggerOffline/Egamma/test/testEmDQM_cfg.py
+++ b/HLTriggerOffline/Egamma/test/testEmDQM_cfg.py
@@ -55,7 +55,8 @@ process.load("DQMServices.Core.DQM_cfg")
 process.load("DQMServices.Components.DQMEnvironment_cfi")
 process.DQMStore.verbose = 0
 #process.DQM.collectorHost = ''
-process.dqmSaver.convention = 'Online'
+process.dqmSaver.convention = 'Offline'
+process.dqmSaver.workflow = '/A/B/C'
 process.dqmSaver.saveByRun = 1
 process.dqmSaver.saveAtJobEnd = True
 

--- a/HLTriggerOffline/Egamma/test/testEmDQM_cfg.py
+++ b/HLTriggerOffline/Egamma/test/testEmDQM_cfg.py
@@ -44,6 +44,7 @@ process.post=cms.EDAnalyzer("EmDQMPostProcessor",
                             subDir = cms.untracked.string("HLT/HLTEgammaValidation"),
                             dataSet = cms.untracked.string("unknown"),
                             noPhiPlots = cms.untracked.bool(False),
+                            ignoreEmpty = cms.untracked.bool(False),
                            )
 
 #process.options = cms.untracked.PSet(wantSummary = cms.untracked.bool(True))


### PR DESCRIPTION
Dropped duplicate efficiency plots that were introduced with 7.1.0.pre6 since the transition is now done.
Only non-empty efficieny plots are stored now (can be switched off with config file flag).
