### PR TITLE
Pilot blades enabling/disabling in pixel digitizer

### DIFF
--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.cc
@@ -142,7 +142,7 @@ namespace cms
            // The insert succeeded, so this detector element has not yet been processed.
            unsigned int isub = DetId(detId).subdetId();
            if((isub == PixelSubdetector::PixelBarrel) || (isub == PixelSubdetector::PixelEndcap)) {
-	     std::map<unsigned int, PixelGeomDetUnit*>::iterator itDet = detectorUnits.find(detId);	     
+	     std::map<unsigned int, PixelGeomDetUnit const *>::iterator itDet = detectorUnits.find(detId);	     
 	     if (itDet == detectorUnits.end()) continue;
              auto pixdet = itDet->second;
              //access to magnetic field in global coordinates

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.cc
@@ -51,6 +51,7 @@
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetType.h"
 
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
@@ -96,7 +97,9 @@ namespace cms
     _pixeldigialgo(),
     hitsProducer(iConfig.getParameter<std::string>("hitsProducer")),
     trackerContainers(iConfig.getParameter<std::vector<std::string> >("ROUList")),
-    geometryType(iConfig.getParameter<std::string>("GeometryType"))
+    geometryType(iConfig.getParameter<std::string>("GeometryType")),
+    pilotBlades(iConfig.exists("enablePilotBlades")?iConfig.getParameter<bool>("enablePilotBlades"):false),
+    NumberOfEndcapDisks(iConfig.exists("NumPixelEndcap")?iConfig.getParameter<int>("NumPixelEndcap"):2)
   {
     edm::LogInfo ("PixelDigitizer ") <<"Enter the Pixel Digitizer";
     
@@ -139,7 +142,9 @@ namespace cms
            // The insert succeeded, so this detector element has not yet been processed.
            unsigned int isub = DetId(detId).subdetId();
            if((isub == PixelSubdetector::PixelBarrel) || (isub == PixelSubdetector::PixelEndcap)) {
-             PixelGeomDetUnit* pixdet = detectorUnits[detId];
+	     std::map<unsigned int, PixelGeomDetUnit*>::iterator itDet = detectorUnits.find(detId);	     
+	     if (itDet == detectorUnits.end()) continue;
+             PixelGeomDetUnit* pixdet = itDet->second;
              //access to magnetic field in global coordinates
              GlobalVector bfield = pSetup->inTesla(pixdet->surface().position());
              LogDebug ("PixelDigitizer ") << "B-field(T) at " << pixdet->surface().position() << "(cm): " 
@@ -160,6 +165,9 @@ namespace cms
     _pixeldigialgo->initializeEvent();
     iSetup.get<TrackerDigiGeometryRecord>().get(geometryType, pDD);
     iSetup.get<IdealMagneticFieldRecord>().get(pSetup);
+    edm::ESHandle<TrackerTopology> tTopoHand;
+    iSetup.get<IdealGeometryRecord>().get(tTopoHand);
+    const TrackerTopology *tTopo=tTopoHand.product();
 
     // FIX THIS! We only need to clear and (re)fill this map when the geometry type IOV changes.  Use ESWatcher to determine this.
     if(true) { // Replace with ESWatcher 
@@ -171,6 +179,9 @@ namespace cms
         if((isub == PixelSubdetector::PixelBarrel) || (isub == PixelSubdetector::PixelEndcap)) {  
           PixelGeomDetUnit* pixdet = dynamic_cast<PixelGeomDetUnit*>((*iu));
           assert(pixdet != 0);
+	  unsigned int disk = tTopo->pxfDisk(detId);
+	  //if using pilot blades, then allowing it for current detector only
+	  if ((disk == 3)&&((!pilotBlades)&&(NumberOfEndcapDisks == 2))) continue;
           detectorUnits.insert(std::make_pair(detId, pixdet));
         }
       }

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.h
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.h
@@ -83,7 +83,10 @@ namespace cms {
     std::vector<CLHEP::HepRandomEngine*> randomEngines_;
 
     PileupMixingContent* PileupInfo_;
-
+    
+    const bool pilotBlades; // Default = false
+    const int NumberOfEndcapDisks; // Default = 2
+    
     // infrastructure to reject dead pixels as defined in db (added by F.Blekman)
   };
 }


### PR DESCRIPTION
Prevent the digitisation and reconstruction of simhits originated from pilot blades.
