### PR TITLE
Use concurrent unordered map for thread safety

### DIFF
--- a/FWCore/Utilities/BuildFile.xml
+++ b/FWCore/Utilities/BuildFile.xml
@@ -3,6 +3,7 @@
 <use   name="boost_regex"/>
 <use   name="rootcore"/>
 <use   name="libuuid"/>
+<use   name="tbb"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/FWCore/Utilities/src/TypeWithDict.cc
+++ b/FWCore/Utilities/src/TypeWithDict.cc
@@ -18,6 +18,8 @@
 
 #include "boost/thread/tss.hpp"
 
+#include "tbb/concurrent_unordered_map.h"
+
 #include <cassert>
 #include <cstdio>
 #include <cstdlib>
@@ -35,8 +37,7 @@ namespace edm {
     //       ignores those properties, so we must store them
     //       separately.
 
-    // Yes, I know this is not thread safe
-    typedef std::map<std::string, TypeWithDict> TypeMap;
+    typedef tbb::concurrent_unordered_map<std::string, TypeWithDict> TypeMap;
     static TypeMap typeMap;
     TypeMap::const_iterator it = typeMap.find(name);
     if(it != typeMap.end()) {


### PR DESCRIPTION
Our code for ROOT6 uses a static map as a cache.  This pull request replaces the std::map with tbb::coucurrent_unordered_map for thread safety.  The concurrent_unordered_map is not thread safe for deletions, but that is OK since we never delete anything from the map.
