### PR TITLE
Remove workaround for fixed ROOT6 bug

### DIFF
--- a/CondFormats/HcalObjects/interface/HcalCondObjectContainer.h
+++ b/CondFormats/HcalObjects/interface/HcalCondObjectContainer.h
@@ -14,7 +14,6 @@ class HcalTopology;
 
 class HcalCondObjectContainerBase {
 public:
-  HcalCondObjectContainerBase() : topo_(nullptr) {}
   const HcalTopology* topo() const { return topo_; }
   int getCreatorPackedIndexVersion() const { return packedIndexVersion_; }
   void setTopo(const HcalTopology* topo) const;
@@ -34,7 +33,6 @@ template<class Item>
 class HcalCondObjectContainer : public HcalCondObjectContainerBase {
 public:
   // default constructor
-  HcalCondObjectContainer() : HcalCondObjectContainerBase() {}
   HcalCondObjectContainer(const HcalTopology* topo) : HcalCondObjectContainerBase(topo) { }
 
   // destructor:


### PR DESCRIPTION
There was a bug in ROOT6 that caused fatal errors if certain classes did not have a default ctor,
We added default ctor's in the ROOT6 branch to two classes to avoid the problem.
The ROOT6 bug has now been fixed, and the fix is in the CMSSW ROOT6 IB.
This pull request removes the workaround, which is no longer needed.
