### PR TITLE
Made GEMGeometry const thread-safe

### DIFF
--- a/Geometry/GEMGeometry/interface/GEMGeometry.h
+++ b/Geometry/GEMGeometry/interface/GEMGeometry.h
@@ -28,25 +28,25 @@ class GEMGeometry : public TrackingGeometry {
   virtual ~GEMGeometry();
 
   // Return a vector of all det types
-  virtual const DetTypeContainer&  detTypes() const;
+  virtual const DetTypeContainer&  detTypes() const override;
 
   // Return a vector of all GeomDetUnit
-  virtual const DetUnitContainer& detUnits() const;
+  virtual const DetUnitContainer& detUnits() const override;
 
   // Return a vector of all GeomDet
-  virtual const DetContainer& dets() const;
+  virtual const DetContainer& dets() const override;
   
   // Return a vector of all GeomDetUnit DetIds
-  virtual const DetIdContainer& detUnitIds() const;
+  virtual const DetIdContainer& detUnitIds() const override;
 
   // Return a vector of all GeomDet DetIds
-  virtual const DetIdContainer& detIds() const;
+  virtual const DetIdContainer& detIds() const override;
 
   // Return the pointer to the GeomDetUnit corresponding to a given DetId
-  virtual const GeomDetUnit* idToDetUnit(DetId) const;
+  virtual const GeomDetUnit* idToDetUnit(DetId) const override;
 
   // Return the pointer to the GeomDet corresponding to a given DetId
-  virtual const GeomDet* idToDet(DetId) const;
+  virtual const GeomDet* idToDet(DetId) const override;
 
 
   //---- Extension of the interface
@@ -55,7 +55,7 @@ class GEMGeometry : public TrackingGeometry {
   //  const std::vector<GEMChamber*>& chambers() const;
 
   /// Return a vector of all GEM eta partitions
-  const std::vector<GEMEtaPartition*>& etaPartitions() const;
+  const std::vector<const GEMEtaPartition*>& etaPartitions() const;
 
   // Return a GEMChamber given its id
   //  const GEMChamber* chamber(GEMDetId id) const;
@@ -79,7 +79,7 @@ class GEMGeometry : public TrackingGeometry {
   // Map for efficient lookup by DetId 
   mapIdToDet theMap;
 
-  std::vector<GEMEtaPartition*> allEtaPartitions; // Are not owned by this class; are owned by their chamber.
+  std::vector<const GEMEtaPartition*> allEtaPartitions; // Are not owned by this class; are owned by their chamber.
   //  std::vector<GEMChamber*> allChambers; // Are owned by this class.
 
 };

--- a/Geometry/GEMGeometry/src/GEMGeometry.cc
+++ b/Geometry/GEMGeometry/src/GEMGeometry.cc
@@ -54,7 +54,7 @@ const std::vector<GEMChamber*>& GEMGeometry::chambers() const {
 */
 
 
-const std::vector<GEMEtaPartition*>& GEMGeometry::etaPartitions() const{
+const std::vector<const GEMEtaPartition*>& GEMGeometry::etaPartitions() const{
   return allEtaPartitions;
 }
 
@@ -74,9 +74,9 @@ GEMGeometry::add(GEMEtaPartition* etaPartition){
   theEtaPartitions.push_back(etaPartition);
   theEtaPartitionIds.push_back(etaPartition->geographicalId());
   theDetIds.push_back(etaPartition->geographicalId());
-  GeomDetType* _t = const_cast<GeomDetType*>(&etaPartition->type());
+  GeomDetType const* _t = &etaPartition->type();
   theEtaPartitionTypes.push_back(_t);
-  theMap.insert(std::pair<DetId,GeomDetUnit*>
+  theMap.insert(std::pair<DetId,const GeomDetUnit*>
 		(etaPartition->geographicalId(),etaPartition));
 }
 


### PR DESCRIPTION
const functions now only return containers which hold const pointers
to internal data. This now matches all other geometry containers.
