### PR TITLE
SIM code cleanup for Geant4 10

### DIFF
--- a/SimG4CMS/Calo/interface/CaloG4Hit.h
+++ b/SimG4CMS/Calo/interface/CaloG4Hit.h
@@ -118,16 +118,16 @@ public:
   }
 };
 
-extern G4Allocator<CaloG4Hit> CaloG4HitAllocator;
+extern G4ThreadLocal G4Allocator<CaloG4Hit> *fpCaloG4HitAllocator;
 
 inline void * CaloG4Hit::operator new(size_t) {
-  void * aHit;
-  aHit = (void *) CaloG4HitAllocator.MallocSingle();
-  return aHit;
+  if (!fpCaloG4HitAllocator) fpCaloG4HitAllocator = 
+    new G4Allocator<CaloG4Hit>;
+  return (void*)fpCaloG4HitAllocator->MallocSingle();
 }
 
 inline void CaloG4Hit::operator delete(void * aHit) {  
-  CaloG4HitAllocator.FreeSingle((CaloG4Hit*) aHit); 
+  fpCaloG4HitAllocator->FreeSingle((CaloG4Hit*) aHit); 
 }
 
 std::ostream& operator<<(std::ostream&, const CaloG4Hit&);

--- a/SimG4CMS/Calo/src/CaloG4Hit.cc
+++ b/SimG4CMS/Calo/src/CaloG4Hit.cc
@@ -7,7 +7,7 @@
 
 #include "G4SystemOfUnits.hh"
 
-G4Allocator<CaloG4Hit> CaloG4HitAllocator;
+G4ThreadLocal G4Allocator<CaloG4Hit> *fpCaloG4HitAllocator = 0;
 
 CaloG4Hit::CaloG4Hit(){
 

--- a/SimG4Core/Application/src/RunManager.cc
+++ b/SimG4Core/Application/src/RunManager.cc
@@ -45,6 +45,7 @@
 #include "HepPDT/ParticleDataTable.hh"
 #include "SimGeneral/HepPDTRecord/interface/PDTRecord.h"
 
+#include "G4GeometryManager.hh"
 #include "G4StateManager.hh"
 #include "G4ApplicationState.hh"
 #include "G4RunManagerKernel.hh"
@@ -142,9 +143,6 @@ RunManager::RunManager(edm::ParameterSet const & p)
   m_FieldFile = p.getUntrackedParameter<std::string>("FileNameField","");
   if("" != m_FieldFile) { m_FieldFile += ".txt"; } 
 
-  m_currentRun = 0;
-  m_currentEvent = 0;
-  m_simEvent = 0;
   m_userRunAction = 0;
   m_runInterface = 0;
 
@@ -166,6 +164,8 @@ RunManager::~RunManager()
 { 
   if (!m_runTerminated) { terminateRun(); }
   G4StateManager::GetStateManager()->SetNewState(G4State_Quit);
+  G4GeometryManager::GetInstance()->OpenGeometry();
+  //   if (m_kernel!=0) delete m_kernel; 
   delete m_runInterface;
 }
 
@@ -313,9 +313,8 @@ void RunManager::initG4(const edm::EventSetup & es)
 
 void RunManager::stopG4()
 {
-  //std::cout << "RunManager::stopG4" << std::endl;
-  if (!m_runTerminated) { terminateRun(); }
   G4StateManager::GetStateManager()->SetNewState(G4State_Quit);
+  if (!m_runTerminated) { terminateRun(); }
 }
 
 void RunManager::produce(edm::Event& inpevt, const edm::EventSetup & es)
@@ -460,8 +459,6 @@ void RunManager::initializeRun()
  
 void RunManager::terminateRun()
 {
-  G4StateManager::GetStateManager()->SetNewState(G4State_Quit);
-  m_runTerminated = false;
   if (m_userRunAction!=0) {
     m_userRunAction->EndOfRunAction(m_currentRun);
     delete m_userRunAction; 
@@ -491,7 +488,7 @@ void RunManager::abortRun(bool softAbort)
   if (m_currentRun!=0) { delete m_currentRun; m_currentRun = 0; }
   m_runInitialized = false;
   m_runAborted = true;
-  G4StateManager::GetStateManager()->SetNewState(G4State_Quit);
+  terminateRun();
 }
 
 void RunManager::resetGenParticleId( edm::Event& inpevt ) 

--- a/SimG4Core/GFlash/BuildFile.xml
+++ b/SimG4Core/GFlash/BuildFile.xml
@@ -1,4 +1,3 @@
-<use   name="FWCore/Framework"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="FWCore/MessageLogger"/>
 <use   name="FWCore/PluginManager"/>

--- a/SimG4Core/Notification/interface/TrackInformation.h
+++ b/SimG4Core/Notification/interface/TrackInformation.h
@@ -76,16 +76,18 @@ private:
     friend class NewTrackAction;
 };
 
-extern G4Allocator<TrackInformation> TrackInformationAllocator;
+extern G4ThreadLocal G4Allocator<TrackInformation> *fpTrackInformationAllocator;
 
 inline void * TrackInformation::operator new(size_t)
 {
-    void * trkInfo;
-    trkInfo = (void *) TrackInformationAllocator.MallocSingle();
-    return trkInfo;
+  if (!fpTrackInformationAllocator) fpTrackInformationAllocator = 
+    new G4Allocator<TrackInformation>;
+  return (void*)fpTrackInformationAllocator->MallocSingle();
 }
 
 inline void TrackInformation::operator delete(void * trkInfo)
-{  TrackInformationAllocator.FreeSingle((TrackInformation*) trkInfo); }
+{  
+  fpTrackInformationAllocator->FreeSingle((TrackInformation*) trkInfo); 
+}
 
 #endif

--- a/SimG4Core/Notification/interface/TrackWithHistory.h
+++ b/SimG4Core/Notification/interface/TrackWithHistory.h
@@ -68,16 +68,16 @@ private:
     int extractGenID(const G4Track * gt) const;
 };
 
-extern G4Allocator<TrackWithHistory> TrackWithHistoryAllocator;
+extern G4ThreadLocal G4Allocator<TrackWithHistory> *fpTrackWithHistoryAllocator;
 
 inline void * TrackWithHistory::operator new(size_t) {
-  void * aTwH;
-  aTwH = (void *) TrackWithHistoryAllocator.MallocSingle();
-  return aTwH;
+  if (!fpTrackWithHistoryAllocator) fpTrackWithHistoryAllocator = 
+    new G4Allocator<TrackWithHistory>;
+  return (void*)fpTrackWithHistoryAllocator->MallocSingle();
 }
 
 inline void TrackWithHistory::operator delete(void * aTwH) {  
-  TrackWithHistoryAllocator.FreeSingle((TrackWithHistory*) aTwH); 
+  fpTrackWithHistoryAllocator->FreeSingle((TrackWithHistory*) aTwH); 
 }
 
 

--- a/SimG4Core/Notification/src/TrackInformation.cc
+++ b/SimG4Core/Notification/src/TrackInformation.cc
@@ -3,7 +3,7 @@
 
 #include <iostream>
 
-G4Allocator<TrackInformation> TrackInformationAllocator;
+G4ThreadLocal G4Allocator<TrackInformation> *fpTrackInformationAllocator = 0;
 
 void TrackInformation::Print() const {
   LogDebug("TrackInformation") << " TrackInformation : storeTrack = " << storeTrack_ << "\n"

--- a/SimG4Core/Notification/src/TrackWithHistory.cc
+++ b/SimG4Core/Notification/src/TrackWithHistory.cc
@@ -10,7 +10,7 @@
 
 #include <iostream>
 
-G4Allocator<TrackWithHistory> TrackWithHistoryAllocator;
+G4ThreadLocal G4Allocator<TrackWithHistory> *fpTrackWithHistoryAllocator = 0;
 
 //#define DEBUG
 


### PR DESCRIPTION
Includes fix of warning on geometry at the end of all Geant4 runs.

Changing usage of G4Allocator - instead of instance pointer is used. No affect production but is necessary for multi-threaded version. 
