### PR TITLE
Reduce rate of calls to return type final

### DIFF
--- a/CommonTools/Utils/src/MethodInvoker.cc
+++ b/CommonTools/Utils/src/MethodInvoker.cc
@@ -7,7 +7,6 @@
 #include "FWCore/Utilities/interface/EDMException.h"
 
 #include <algorithm>
-
 using namespace reco::parser;
 using namespace std;
 
@@ -20,6 +19,9 @@ MethodInvoker(const edm::FunctionWithDict& method,
   , isFunction_(true)
 {
   setArgs();
+  if (isFunction_) {
+    retTypeFinal_ = method_.finalReturnType();
+  }
   //std::cout <<
   //   "Booking " <<
   //   methodName() <<
@@ -62,6 +64,7 @@ MethodInvoker(const MethodInvoker& rhs)
   , member_(rhs.member_)
   , ints_(rhs.ints_)
   , isFunction_(rhs.isFunction_)
+  , retTypeFinal_(rhs.retTypeFinal_)
 {
   setArgs();
 }
@@ -75,6 +78,8 @@ operator=(const MethodInvoker& rhs)
     member_ = rhs.member_;
     ints_ = rhs.ints_;
     isFunction_ = rhs.isFunction_;
+    retTypeFinal_ =rhs.retTypeFinal_;
+
     setArgs();
   }
   return *this;
@@ -124,7 +129,7 @@ invoke(const edm::ObjectWithDict& o, edm::ObjectWithDict& retstore) const
     //  << std::endl;
     method_.invoke(o, &ret, args_);
     // this is correct, it takes pointers and refs into account
-    retType = method_.finalReturnType();
+    retType = retTypeFinal_; 
   }
   else {
     //std::cout << "Invoking " << methodName()

--- a/CommonTools/Utils/src/MethodInvoker.h
+++ b/CommonTools/Utils/src/MethodInvoker.h
@@ -23,7 +23,9 @@ private: // Private Data Members
   edm::MemberWithDict member_;
   std::vector<AnyMethodArgument> ints_; // already fixed to the correct type
   std::vector<void*> args_;
+
   bool isFunction_;
+  edm::TypeWithDict retTypeFinal_;
 private: // Private Function Members
   void setArgs();
 public: // Public Function Members


### PR DESCRIPTION
move call to method_.finalReturnType() to constructor to reduce calls to it (which seems to make a big difference in root6 memory hoarding
(can be a lot better with changes to the callers of the cut parser)
