### PR TITLE
Move tracking modules back to stream modules

### DIFF
--- a/RecoEgamma/EgammaPhotonProducers/interface/ConversionTrackCandidateProducer.h
+++ b/RecoEgamma/EgammaPhotonProducers/interface/ConversionTrackCandidateProducer.h
@@ -7,7 +7,7 @@
  **
  ***/
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -35,7 +35,7 @@ class OutInConversionTrackFinder;
 class InOutConversionTrackFinder;
 
 // ConversionTrackCandidateProducer inherits from EDProducer, so it can be a module:
-class ConversionTrackCandidateProducer : public edm::EDProducer {
+class ConversionTrackCandidateProducer : public edm::stream::EDProducer<> {
 
  public:
 

--- a/RecoEgamma/EgammaPhotonProducers/interface/TrackProducerWithSCAssociation.h
+++ b/RecoEgamma/EgammaPhotonProducers/interface/TrackProducerWithSCAssociation.h
@@ -9,14 +9,14 @@
  ** 
  ***/
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "RecoTracker/TrackProducer/interface/TrackProducerBase.h"
 #include "RecoTracker/TrackProducer/interface/TrackProducerAlgorithm.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
 #include "DataFormats/EgammaTrackReco/interface/TrackCandidateCaloClusterAssociation.h"
 
-class TrackProducerWithSCAssociation : public TrackProducerBase<reco::Track>, public edm::EDProducer {
+class TrackProducerWithSCAssociation : public TrackProducerBase<reco::Track>, public edm::stream::EDProducer<> {
 public:
 
   explicit TrackProducerWithSCAssociation(const edm::ParameterSet& iConfig);

--- a/RecoTracker/TrackProducer/plugins/TrackProducer.h
+++ b/RecoTracker/TrackProducer/plugins/TrackProducer.h
@@ -7,13 +7,13 @@
  *  \author cerati
  */
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "RecoTracker/TrackProducer/interface/KfTrackProducerBase.h"
 #include "RecoTracker/TrackProducer/interface/TrackProducerAlgorithm.h"
 
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
 
-class TrackProducer : public KfTrackProducerBase, public edm::EDProducer {
+class TrackProducer : public KfTrackProducerBase, public edm::stream::EDProducer<> {
 public:
 
   /// Constructor


### PR DESCRIPTION
The threading issues that required these modules to be legacy have
been fixed so they can be made stream modules.
