### PR TITLE
Removed static from CachingSeedCleanerByHitPosition::good

### DIFF
--- a/RecoTracker/CkfPattern/src/CachingSeedCleanerByHitPosition.cc
+++ b/RecoTracker/CkfPattern/src/CachingSeedCleanerByHitPosition.cc
@@ -36,7 +36,7 @@ void CachingSeedCleanerByHitPosition::add(const Trajectory *trj) {
 }
 
 bool CachingSeedCleanerByHitPosition::good(const TrajectorySeed *seed) {
-    static RecHitComparatorByPosition comp;
+    const RecHitComparatorByPosition comp;
     typedef TrajectorySeed::const_iterator SI;
     typedef Trajectory::RecHitContainer::const_iterator TI;
     TrajectorySeed::range range = seed->recHits();


### PR DESCRIPTION
The function local static was to a class with no member data and
no virtual functions. Since it had no state there was no need to make
it static and making it static meant the compiler had to use lots of
extra machine code. Removing the static and making it const makes the
code easier to reason about and avoids complaints from the static
analyzer.
