### PR TITLE
71X - update RelVal input for AK4 migration

### DIFF
--- a/JetMETCorrections/Type1MET/python/testInputFiles_cff.py
+++ b/JetMETCorrections/Type1MET/python/testInputFiles_cff.py
@@ -4,14 +4,15 @@ import FWCore.ParameterSet.Config as cms
 from PhysicsTools.PatAlgos.tools.cmsswVersionTools import pickRelValInputFiles
 corrMETtestInputFiles = pickRelValInputFiles(
     useDAS = True,
-    cmsswVersion = 'CMSSW_7_1_0_pre2',
+    cmsswVersion = 'CMSSW_7_1_0_pre4_AK4',
     dataTier = 'GEN-SIM-RECO',
     relVal = 'RelValTTbar_13',
-    globalTag = 'PU50ns_POSTLS170_V4'
+    globalTag = 'PU50ns_POSTLS171_V2',
+    maxVersions = 2
     )
 
 # corrMETtestInputFiles = [
-#     '/store/relval/CMSSW_7_1_0_pre2/RelValTTbar_13/GEN-SIM-RECO/PU50ns_POSTLS170_V4-v1/00000/FAA1E1EE-BE8F-E311-B633-0026189438BC.root',
+#     '/store/relval/CMSSW_7_1_0_pre4_AK4/RelValTTbar_13/GEN-SIM-RECO/PU50ns_POSTLS171_V2-v2/00000/1487CD0E-A4B3-E311-96D2-0025904C678A.root',
 #     ]
 
 ##____________________________________________________________________________||

--- a/PhysicsTools/PatAlgos/python/patInputFiles_cff.py
+++ b/PhysicsTools/PatAlgos/python/patInputFiles_cff.py
@@ -1,67 +1,67 @@
 import FWCore.ParameterSet.Config as cms
 from PhysicsTools.PatAlgos.tools.cmsswVersionTools import pickRelValInputFiles
 
-# /RelValProdTTbar/CMSSW_7_1_0_pre1-START70_V5-v1/AODSIM
+# /RelValProdTTbar/CMSSW_7_1_0_pre4_AK4-START71_V1-v2/AODSIM
 filesRelValProdTTbarAODSIM = cms.untracked.vstring(
-    #pickRelValInputFiles( cmsswVersion  = 'CMSSW_7_1_0_pre1'
+    #pickRelValInputFiles( cmsswVersion  = 'CMSSW_7_1_0_pre4_AK4'
                         #, relVal        = 'RelValProdTTbar'
-                        #, globalTag     = 'START70_V5'
+                        #, globalTag     = 'START71_V1'
                         #, dataTier      = 'AODSIM'
-                        #, maxVersions   = 1
+                        #, maxVersions   = 2
                         #, numberOfFiles = 1
                         #, useDAS        = True
                         #)
-        '/store/relval/CMSSW_7_1_0_pre1/RelValProdTTbar/AODSIM/START70_V5-v1/00000/F4EB9159-3286-E311-8D80-02163E008DB4.root'
+        '/store/relval/CMSSW_7_1_0_pre4_AK4/RelValProdTTbar/AODSIM/START71_V1-v2/00000/7A3637AA-28B5-E311-BC25-003048678B94.root'
     )
 
-# /RelValProdTTbar/CMSSW_7_1_0_pre1-START70_V5-v1/GEN-SIM-RECO
+# /RelValProdTTbar/CMSSW_7_1_0_pre4_AK4-START71_V1-v2/GEN-SIM-RECO
 filesRelValProdTTbarGENSIMRECO = cms.untracked.vstring(
-    #pickRelValInputFiles( cmsswVersion  = 'CMSSW_7_1_0_pre1'
+    #pickRelValInputFiles( cmsswVersion  = 'CMSSW_7_1_0_pre4_AK4'
                         #, relVal        = 'RelValProdTTbar'
-                        #, globalTag     = 'START70_V5'
+                        #, globalTag     = 'START71_V1'
                         #, dataTier      = 'GEN-SIM-RECO'
-                        #, maxVersions   = 1
+                        #, maxVersions   = 2
                         #, numberOfFiles = 1
                         #, useDAS        = True
                         #)
-        '/store/relval/CMSSW_7_1_0_pre1/RelValProdTTbar/GEN-SIM-RECO/START70_V5-v1/00000/14842A6B-2086-E311-B5CB-02163E00E8DA.root'
+        '/store/relval/CMSSW_7_1_0_pre4_AK4/RelValProdTTbar/GEN-SIM-RECO/START71_V1-v2/00000/04DF20AC-28B5-E311-814A-003048679296.root'
     )
 
-# /RelValTTbar/CMSSW_7_1_0_pre1-PU_START70_V5_FastSim-v2/GEN-SIM-DIGI-RECO
+# /RelValTTbar/CMSSW_7_1_0_pre4_AK4-PU_START71_V1_FastSim-v2/GEN-SIM-DIGI-RECO
 filesRelValTTbarPileUpFastSimGENSIMDIGIRECO = cms.untracked.vstring(
-    #pickRelValInputFiles( cmsswVersion  = 'CMSSW_7_1_0_pre1'
+    #pickRelValInputFiles( cmsswVersion  = 'CMSSW_7_1_0_pre4_AK4'
                         #, relVal        = 'RelValTTbar'
-                        #, globalTag     = 'PU_START70_V5_FastSim'
+                        #, globalTag     = 'PU_START71_V1_FastSim'
                         #, dataTier      = 'GEN-SIM-DIGI-RECO'
                         #, maxVersions   = 2
                         #, numberOfFiles = 1
                         #, useDAS        = True
                         #)
-        '/store/relval/CMSSW_7_1_0_pre1/RelValTTbar/GEN-SIM-DIGI-RECO/PU_START70_V5_FastSim-v2/00000/00865693-258F-E311-B41F-0025905A6092.root'
+        '/store/relval/CMSSW_7_1_0_pre4_AK4/RelValTTbar/GEN-SIM-DIGI-RECO/PU_START71_V1_FastSim-v2/00000/04149ADF-FCB3-E311-8707-0025904C6788.root'
     )
 
-# /RelValTTbar_13/CMSSW_7_1_0_pre1-PU50ns_POSTLS170_V1-v1/GEN-SIM-RECO
+# /RelValTTbar_13/CMSSW_7_1_0_pre4_AK4-PU50ns_POSTLS171_V2-v2/GEN-SIM-RECO
 filesRelValTTbarPileUpGENSIMRECO = cms.untracked.vstring(
-    #pickRelValInputFiles( cmsswVersion  = 'CMSSW_7_1_0_pre1'
+    #pickRelValInputFiles( cmsswVersion  = 'CMSSW_7_1_0_pre4_AK4'
                         #, relVal        = 'RelValTTbar_13'
-                        #, globalTag     = 'PU50ns_POSTLS170_V1'
+                        #, globalTag     = 'PU50ns_POSTLS171_V2'
                         #, dataTier      = 'GEN-SIM-RECO'
-                        #, maxVersions   = 1
+                        #, maxVersions   = 2
                         #, numberOfFiles = 1
                         #, useDAS        = True
                         #)
-        '/store/relval/CMSSW_7_1_0_pre1/RelValTTbar_13/GEN-SIM-RECO/PU50ns_POSTLS170_V1-v1/00000/0E08B589-BC8B-E311-BD48-02163E00EA0D.root'
+        '/store/relval/CMSSW_7_1_0_pre4_AK4/RelValTTbar_13/GEN-SIM-RECO/PU50ns_POSTLS171_V2-v2/00000/1487CD0E-A4B3-E311-96D2-0025904C678A.root'
     )
 
-# /SingleMu/CMSSW_6_2_0_pre8-PRE_62_V8_RelVal_mu2012D-v1/RECO
+# /SingleMu/CMSSW_7_1_0_pre4_AK4-GR_R_71_V1_RelVal_mu2012D-v2/RECO
 filesSingleMuRECO = cms.untracked.vstring(
-    #pickRelValInputFiles( cmsswVersion  = 'CMSSW_6_2_0_pre8' # no 70X data RelVals at CERN
+    #pickRelValInputFiles( cmsswVersion  = 'CMSSW_7_1_0_pre4_AK4' # not at CERN
                         #, relVal        = 'SingleMu'
                         #, dataTier      = 'RECO'
-                        #, globalTag     = 'PRE_62_V8_RelVal_mu2012D'
-                        #, maxVersions   = 1
+                        #, globalTag     = 'GR_R_71_V1_RelVal_mu2012D'
+                        #, maxVersions   = 2
                         #, numberOfFiles = 1
                         #, useDAS        = True
                         #)
-        '/store/relval/CMSSW_6_2_0_pre8/SingleMu/RECO/PRE_62_V8_RelVal_mu2012D-v1/00000/005835E9-05E0-E211-BA7B-003048F1C7C0.root'
+        '/store/relval/CMSSW_7_1_0_pre4_AK4/SingleMu/RECO/GR_R_71_V1_RelVal_mu2012D-v2/00000/00255F2D-36B5-E311-9749-0025905AA9CC.root'
     )

--- a/PhysicsTools/PatAlgos/test/patTuple_addBTagging_cfg.py
+++ b/PhysicsTools/PatAlgos/test/patTuple_addBTagging_cfg.py
@@ -14,8 +14,8 @@ from PhysicsTools.PatAlgos.tools.jetTools import addJetCollection
 # uncomment the following lines to add ak5PFJets with new b-tags to your PAT output
 addJetCollection(
    process,
-   labelName = 'AK5PF',
-   jetSource = cms.InputTag('ak5PFJets'),
+   labelName = 'AK4PF',
+   jetSource = cms.InputTag('ak4PFJets'),
    jetCorrections = ('AK5PF', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'Type-2'),
    btagDiscriminators = [
        'jetBProbabilityBJetTags'
@@ -76,10 +76,12 @@ addJetCollection(
       #,'negativeCombinedSecondaryVertexSoftPFLeptonV1BJetTags'
     ],
   )
-process.patJetsAK5PF.addTagInfos = True
-process.patJetsAK5PF.addJetID    = True
-process.patJetsAK5PF.jetIDMap    = "ak5JetID"
-process.out.outputCommands.append( 'drop *_selectedPatJetsAK5PF_caloTowers_*' )
+process.patJetsAK4PF.addTagInfos = True
+## JetID works only with RECO input for the CaloTowers (s. below for 'process.source.fileNames')
+#process.patJets.addJetID=True
+#process.load("RecoJets.JetProducers.ak4JetID_cfi")
+#process.patJets.jetIDMap="ak4JetID"
+process.out.outputCommands.append( 'drop *_selectedPatJetsAK4PF_caloTowers_*' )
 
 ## let it run
 process.p = cms.Path(
@@ -96,6 +98,8 @@ process.p = cms.Path(
 ## switch to RECO input
 from PhysicsTools.PatAlgos.patInputFiles_cff import filesRelValProdTTbarAODSIM
 process.source.fileNames = filesRelValProdTTbarAODSIM
+#from PhysicsTools.PatAlgos.patInputFiles_cff import filesRelValProdTTbarGENSIMRECO
+#process.source.fileNames = filesRelValProdTTbarGENSIMRECO
 #                                         ##
 process.maxEvents.input = 10
 #                                         ##

--- a/PhysicsTools/PatAlgos/test/patTuple_addJets_cfg.py
+++ b/PhysicsTools/PatAlgos/test/patTuple_addJets_cfg.py
@@ -18,21 +18,21 @@ from PhysicsTools.PatAlgos.tools.jetTools import addJetCollection
 from PhysicsTools.PatAlgos.tools.jetTools import switchJetCollection
 
 ## uncomment the following lines to add ak5PFJetsCHS to your PAT output
-postfixAK5PFCHS = 'Copy'
+postfixAK4PFCHS = 'Copy'
 addJetCollection(
    process,
-   postfix   = postfixAK5PFCHS,
-   labelName = 'AK5PFCHS',
-   jetSource = cms.InputTag('ak5PFJetsCHS'),
+   postfix   = postfixAK4PFCHS,
+   labelName = 'AK4PFCHS',
+   jetSource = cms.InputTag('ak4PFJetsCHS'),
    jetCorrections = ('AK5PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'Type-2')
    )
-process.out.outputCommands.append( 'drop *_selectedPatJetsAK5PFCHS%s_caloTowers_*'%( postfixAK5PFCHS ) )
+process.out.outputCommands.append( 'drop *_selectedPatJetsAK5PFCHS%s_caloTowers_*'%( postfixAK4PFCHS ) )
 
 # uncomment the following lines to add ak5PFJets to your PAT output
 addJetCollection(
    process,
-   labelName = 'AK5PF',
-   jetSource = cms.InputTag('ak5PFJets'),
+   labelName = 'AK4PF',
+   jetSource = cms.InputTag('ak4PFJets'),
    jetCorrections = ('AK5PF', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'Type-1'),
    btagDiscriminators = [
        'jetBProbabilityBJetTags'
@@ -49,8 +49,8 @@ process.out.outputCommands.append( 'drop *_selectedPatJetsAK5PF_caloTowers_*' )
 # uncomment the following lines to switch to ak5CaloJets in your PAT output
 switchJetCollection(
    process,
-   jetSource = cms.InputTag('ak5CaloJets'),
-   jetCorrections = ('AK5Calo', cms.vstring(['L1Offset', 'L2Relative', 'L3Absolute']), 'Type-1'),
+   jetSource = cms.InputTag('ak4CaloJets'),
+   jetCorrections = ('AK5Calo', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'Type-1'),
    btagDiscriminators = [
        'jetBProbabilityBJetTags'
      , 'jetProbabilityBJetTags'
@@ -61,8 +61,10 @@ switchJetCollection(
      , 'combinedSecondaryVertexBJetTags'
      ],
    )
-process.patJets.addJetID=True
-process.patJets.jetIDMap="ak5JetID"
+## JetID works only with RECO input for the CaloTowers (s. below for 'process.source.fileNames')
+#process.patJets.addJetID=True
+#process.load("RecoJets.JetProducers.ak4JetID_cfi")
+#process.patJets.jetIDMap="ak4JetID"
 process.patJets.useLegacyJetMCFlavour=True # Need to use legacy flavour since the new flavour requires jet constituents which are dropped for CaloJets from AOD
 process.out.outputCommands.append( 'keep *_selectedPatJets_caloTowers_*' )
 process.out.outputCommands.append( 'drop *_selectedPatJets_pfCandidates_*' )
@@ -78,6 +80,8 @@ process.out.outputCommands.append( 'drop *_selectedPatJets_pfCandidates_*' )
 #                                         ##
 from PhysicsTools.PatAlgos.patInputFiles_cff import filesRelValProdTTbarAODSIM
 process.source.fileNames = filesRelValProdTTbarAODSIM
+#from PhysicsTools.PatAlgos.patInputFiles_cff import filesRelValProdTTbarGENSIMRECO
+#process.source.fileNames = filesRelValProdTTbarGENSIMRECO
 #                                         ##
 process.maxEvents.input = 10
 #                                         ##

--- a/PhysicsTools/PatAlgos/test/patTuple_metUncertainties_cfg.py
+++ b/PhysicsTools/PatAlgos/test/patTuple_metUncertainties_cfg.py
@@ -9,14 +9,9 @@ process.load("PhysicsTools.PatUtils.patPFMETCorrections_cff")
 
 from PhysicsTools.PatAlgos.tools.jetTools import switchJetCollection
 switchJetCollection(process,
-                    jetSource = cms.InputTag('ak5PFJets'),
+                    jetSource = cms.InputTag('ak4PFJets'),
                     jetCorrections = ('AK5PF', ['L1FastJet', 'L2Relative', 'L3Absolute'], '')
                     )
-
-## let it run
-process.p = cms.Path(
-    process.selectedPatCandidates
-)
 
 # apply type I/type I + II PFMEt corrections to pat::MET object
 # and estimate systematic uncertainties on MET


### PR DESCRIPTION
Use RelVals from CMSSW_7_1_0_pre4_AK4 as test input after AK4 migration merge.
