### PR TITLE
Workaround for Double32_t bug

### DIFF
--- a/DataFormats/JetReco/interface/TrackExtrapolation.h
+++ b/DataFormats/JetReco/interface/TrackExtrapolation.h
@@ -20,8 +20,11 @@
 
 namespace reco {
   class TrackExtrapolation {
-    typedef ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<Double32_t> > Point;
-    typedef ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Double32_t> > Vector;
+    // Next two typedefs use double in ROOT 6 rather than Double32_t due to a bug in ROOT 5,
+    // which otherwise would make ROOT5 files unreadable in ROOT6.  This does not increase
+    // the size on disk, because due to the bug, double was actually stored on disk in ROOT 5.
+    typedef ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<double> > Point;
+    typedef ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<double> > Vector;
   public:
 
 

--- a/DataFormats/ParticleFlowReco/interface/PFCluster.h
+++ b/DataFormats/ParticleFlowReco/interface/PFCluster.h
@@ -48,7 +48,10 @@ namespace reco {
   public:
 
     typedef std::vector<std::pair<CaloClusterPtr::key_type,edm::Ptr<PFCluster> > > EEtoPSAssociation;
-    typedef ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<Double32_t> > REPPoint;
+    // Next typedef uses double in ROOT 6 rather than Double32_t due to a bug in ROOT 5,
+    // which otherwise would make ROOT5 files unreadable in ROOT6.  This does not increase
+    // the size on disk, because due to the bug, double was actually stored on disk in ROOT 5.
+    typedef ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<double> > REPPoint;
   
     PFCluster() : CaloCluster(CaloCluster::particleFlow), time_(-99.0), layer_(PFLayer::NONE), color_(1) {}
 

--- a/DataFormats/ParticleFlowReco/interface/PFRecHit.h
+++ b/DataFormats/ParticleFlowReco/interface/PFRecHit.h
@@ -36,7 +36,10 @@ namespace reco {
 
   public:
 
-    typedef ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<Double32_t> > REPPoint;
+    // Next typedef uses double in ROOT 6 rather than Double32_t due to a bug in ROOT 5,
+    // which otherwise would make ROOT5 files unreadable in ROOT6.  This does not increase
+    // the size on disk, because due to the bug, double was actually stored on disk in ROOT 5.
+    typedef ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<double> > REPPoint;
 
     typedef std::vector<REPPoint> REPPointVector;
 

--- a/DataFormats/ParticleFlowReco/interface/PFTrajectoryPoint.h
+++ b/DataFormats/ParticleFlowReco/interface/PFTrajectoryPoint.h
@@ -26,7 +26,10 @@ namespace reco {
   class PFTrajectoryPoint {
 
   public:
-    typedef ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<Double32_t> > REPPoint;
+    // Next typedef uses double in ROOT 6 rather than Double32_t due to a bug in ROOT 5,
+    // which otherwise would make ROOT5 files unreadable in ROOT6.  This does not increase
+    // the size on disk, because due to the bug, double was actually stored on disk in ROOT 5.
+    typedef ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<double> > REPPoint;
 
     /// Define the different layers where the track can be propagated
     enum LayerType {

--- a/RecoEgamma/EgammaElectronAlgos/interface/PixelHitMatcher.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/PixelHitMatcher.h
@@ -172,7 +172,10 @@ class PixelHitMatcher
     typedef TransientTrackingRecHit::ConstRecHitPointer   ConstRecHitPointer;
     typedef TransientTrackingRecHit::RecHitPointer        RecHitPointer;
     typedef TransientTrackingRecHit::RecHitContainer      RecHitContainer;
-    typedef ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<Double32_t> > REPPoint;
+    // Next typedef uses double in ROOT 6 rather than Double32_t due to a bug in ROOT 5,
+    // which otherwise would make ROOT5 files unreadable in ROOT6.  This does not increase
+    // the size on disk, because due to the bug, double was actually stored on disk in ROOT 5.
+    typedef ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<double> > REPPoint;
 
     PixelHitMatcher
      ( float phi1min, float phi1max,


### PR DESCRIPTION
This is a workaround for a ROOT bug that causes two relval tests to fail while reading files written with ROOT5.
Fixing the ROOT bug cannot cure the problem, because the ROOT bug is in ROOT5, not ROOT 6, and fixing the bug in ROOT5 would not magically update all files already written with ROOT 5.
The bug is that if a member of a persistent class specified in an xml selection file contains a Double32_t, the Double32_t is properly stored on disk only if there is a iotype selection rule for that field.  If not, the item is stored as a double.  The bug does not exist in ROOT6.  ROOT6 expects a Double32_t, and cannot convert the double to a Double32_t, causing a fatal error.  It is not easy to modify ROOT6 to do the conversion.
The easiest fix is to replace Double32_t with double in the code for those cases where there was no iotype selection rule.  This does not increase the size on disk, because in these cases, they are already stored as double.
NOTE: At some time in the future, if we can enhance ROOT6 to do the double=>Double32_conversion when reading a file, this workaround could be removed.  I do not know if that is feasible or not.
