### PR TITLE
Fftjet consumes migration

### DIFF
--- a/RecoJets/FFTJetProducers/interface/FFTJetInterface.h
+++ b/RecoJets/FFTJetProducers/interface/FFTJetInterface.h
@@ -28,6 +28,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Framework/interface/EDProducer.h"
 
 #include "DataFormats/Candidate/interface/Particle.h"
 
@@ -37,6 +38,9 @@
 #include "DataFormats/Candidate/interface/CandidateFwd.h"
 #include "DataFormats/Common/interface/Handle.h"
 
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+
 // local FFTJet-related definitions
 #include "RecoJets/FFTJetAlgorithms/interface/fftjetTypedefs.h"
 #include "RecoJets/FFTJetProducers/interface/JetType.h"
@@ -45,7 +49,7 @@
 // class declaration
 //
 namespace fftjetcms {
-  class FFTJetInterface
+  class FFTJetInterface : public edm::EDProducer
   {
   public:
     virtual ~FFTJetInterface() {}
@@ -109,6 +113,9 @@ namespace fftjetcms {
     const bool insertCompleteEvent;
     const double completeEventScale;
     reco::Particle::Point vertex_;
+
+    edm::EDGetTokenT<reco::CandidateView> inputToken;
+    edm::EDGetTokenT<reco::VertexCollection> srcPVsToken;
   };
 }
 

--- a/RecoJets/FFTJetProducers/plugins/FFTJetEFlowSmoother.cc
+++ b/RecoJets/FFTJetProducers/plugins/FFTJetEFlowSmoother.cc
@@ -30,12 +30,10 @@
 
 // framework include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "DataFormats/Common/interface/View.h"
-#include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Histograms/interface/MEtoEDMFormat.h"
 
 // parameter parser header
@@ -49,7 +47,7 @@ using namespace fftjetcms;
 //
 // class declaration
 //
-class FFTJetEFlowSmoother : public edm::EDProducer, public FFTJetInterface
+class FFTJetEFlowSmoother : public FFTJetInterface
 {
 public:
     explicit FFTJetEFlowSmoother(const edm::ParameterSet&);

--- a/RecoJets/FFTJetProducers/plugins/FFTJetPatRecoProducer.cc
+++ b/RecoJets/FFTJetProducers/plugins/FFTJetPatRecoProducer.cc
@@ -29,13 +29,10 @@
 
 // framework include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "DataFormats/Common/interface/View.h"
-#include "DataFormats/Common/interface/Handle.h"
-#include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/JetReco/interface/CaloJetCollection.h"
 #include "DataFormats/JetReco/interface/GenJetCollection.h"
 #include "DataFormats/JetReco/interface/PFJetCollection.h"
@@ -63,7 +60,7 @@ using namespace fftjetcms;
 //
 // class declaration
 //
-class FFTJetPatRecoProducer : public edm::EDProducer, public FFTJetInterface
+class FFTJetPatRecoProducer : public FFTJetInterface
 {
 public:
     explicit FFTJetPatRecoProducer(const edm::ParameterSet&);

--- a/RecoJets/FFTJetProducers/plugins/FFTJetPileupEstimator.cc
+++ b/RecoJets/FFTJetProducers/plugins/FFTJetPileupEstimator.cc
@@ -74,6 +74,8 @@ private:
     }
 
     edm::InputTag inputLabel;
+    edm::EDGetTokenT<reco::DiscretizedEnergyFlow> inputToken;
+
     std::string outputLabel;
     double cdfvalue;
     double ptToDensityFactor;
@@ -128,6 +130,8 @@ FFTJetPileupEstimator::FFTJetPileupEstimator(const edm::ParameterSet& ps)
         ps.getParameter<edm::ParameterSet>("uncertaintyCurve"));
     checkConfig(uncertaintyCurve, "bad uncertainty curve definition");
 
+    inputToken = consumes<reco::DiscretizedEnergyFlow>(inputLabel);
+
     produces<reco::FFTJetPileupSummary>(outputLabel);
 }
 
@@ -145,7 +149,7 @@ void FFTJetPileupEstimator::produce(edm::Event& iEvent,
                                     const edm::EventSetup& iSetup)
 {
     edm::Handle<reco::DiscretizedEnergyFlow> input;
-    iEvent.getByLabel(inputLabel, input);
+    iEvent.getByToken(inputToken, input);
 
     const reco::DiscretizedEnergyFlow& h(*input);
     const unsigned nScales = h.nEtaBins();

--- a/RecoJets/FFTJetProducers/plugins/FFTJetPileupProcessor.cc
+++ b/RecoJets/FFTJetProducers/plugins/FFTJetPileupProcessor.cc
@@ -27,13 +27,10 @@
 
 // framework include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "DataFormats/Common/interface/View.h"
-#include "DataFormats/Common/interface/Handle.h"
-// #include "DataFormats/Histograms/interface/MEtoEDMFormat.h"
 #include "DataFormats/JetReco/interface/DiscretizedEnergyFlow.h"
 
 #include "RecoJets/FFTJetAlgorithms/interface/gridConverters.h"
@@ -53,7 +50,7 @@ using namespace fftjetcms;
 //
 // class declaration
 //
-class FFTJetPileupProcessor : public edm::EDProducer, public FFTJetInterface
+class FFTJetPileupProcessor : public FFTJetInterface
 {
 public:
     explicit FFTJetPileupProcessor(const edm::ParameterSet&);

--- a/RecoJets/FFTJetProducers/plugins/FFTJetProducer.cc
+++ b/RecoJets/FFTJetProducers/plugins/FFTJetProducer.cc
@@ -21,6 +21,8 @@
 #include <functional>
 #include <algorithm>
 
+#include "fftjet/peakEtLifetime.hh"
+
 // Header for this class
 #include "RecoJets/FFTJetProducers/plugins/FFTJetProducer.h"
 
@@ -213,6 +215,8 @@ void FFTJetProducer::loadSparseTreeData(const edm::Event& iEvent)
     sparsePeakTreeFromStorable(*input, iniScales.get(),
                                getEventScale(), &sparseTree);
     sparseTree.sortNodes();
+    fftjet::updateSplitMergeTimes(sparseTree, sparseTree.minScale(),
+                                  sparseTree.maxScale());
 }
 
 

--- a/RecoJets/FFTJetProducers/plugins/FFTJetProducer.h
+++ b/RecoJets/FFTJetProducers/plugins/FFTJetProducer.h
@@ -59,7 +59,6 @@
 // framework include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 
 #include "DataFormats/Candidate/interface/CandidateFwd.h"
@@ -76,8 +75,7 @@ namespace fftjetcms {
 //
 // class declaration
 //
-class FFTJetProducer : public edm::EDProducer, 
-                       public fftjetcms::FFTJetInterface
+class FFTJetProducer : public fftjetcms::FFTJetInterface
 {
 public:
     typedef fftjet::RecombinedJet<fftjetcms::VectorLike> RecoFFTJet;
@@ -112,9 +110,9 @@ public:
 
 protected:
     // Functions which should be overriden from the base
-    virtual void beginJob();
-    virtual void produce(edm::Event&, const edm::EventSetup&);
-    virtual void endJob();
+    virtual void beginJob() override;
+    virtual void produce(edm::Event&, const edm::EventSetup&) override;
+    virtual void endJob() override;
 
     // The following functions can be overriden by derived classes 
     // in order to adjust jet reconstruction algorithm behavior.
@@ -429,8 +427,6 @@ private:
     edm::EDGetTokenT<std::vector<reco::FFTAnyJet<reco::GenJet> > > input_genjet_token_;
     edm::EDGetTokenT<reco::DiscretizedEnergyFlow> input_energyflow_token_;
     edm::EDGetTokenT<reco::FFTJetPileupSummary> input_pusummary_token_;
-
-
 };
 
 #endif // RecoJets_FFTJetProducers_FFTJetProducer_h

--- a/RecoJets/FFTJetProducers/plugins/FFTJetTreeDump.cc
+++ b/RecoJets/FFTJetProducers/plugins/FFTJetTreeDump.cc
@@ -58,6 +58,7 @@ private:
     typedef fftjet::OpenDXPeakTree<long,fftjet::AbsClusteringTree> DXFormatter;
     typedef fftjet::OpenDXPeakTree<long,fftjet::SparseClusteringTree> SparseFormatter;
     typedef fftjet::Functor1<double,fftjet::Peak> PeakProperty;
+    typedef reco::PattRecoTree<Real,reco::PattRecoPeak<Real> > StoredTree;
 
     FFTJetTreeDump();
     FFTJetTreeDump(const FFTJetTreeDump&);
@@ -82,6 +83,8 @@ private:
     ClusteringTree* clusteringTree;
 
     const edm::InputTag treeLabel;
+    edm::EDGetTokenT<StoredTree> treeToken;
+
     const std::string outputPrefix;
     const double etaMax;
     const bool storeInSinglePrecision;
@@ -157,6 +160,8 @@ FFTJetTreeDump::FFTJetTreeDump(const edm::ParameterSet& ps)
 
     // Build the clustering tree
     clusteringTree = new ClusteringTree(distanceCalc.get());
+
+    treeToken = consumes<StoredTree>(treeLabel);
 }
 
 
@@ -173,15 +178,13 @@ template<class Real>
 void FFTJetTreeDump::processTreeData(const edm::Event& iEvent,
                                      std::ofstream& file)
 {
-    typedef reco::PattRecoTree<Real,reco::PattRecoPeak<Real> > StoredTree;
-
     // Get the event number
     const unsigned long runNum = iEvent.id().run();
     const unsigned long evNum = iEvent.id().event();
 
     // Get the input
     edm::Handle<StoredTree> input;
-    iEvent.getByLabel(treeLabel, input);
+    iEvent.getByToken(treeToken, input);
 
     const double eventScale = insertCompleteEvent ? completeEventScale : 0.0;
     if (input->isSparse())

--- a/RecoJets/FFTJetProducers/plugins/FFTJetVertexAdder.cc
+++ b/RecoJets/FFTJetProducers/plugins/FFTJetVertexAdder.cc
@@ -61,6 +61,10 @@ private:
 
     const edm::InputTag beamSpotLabel;
     const edm::InputTag existingVerticesLabel;
+
+    edm::EDGetTokenT<reco::BeamSpot> beamSpotToken;
+    edm::EDGetTokenT<reco::VertexCollection> existingVerticesToken;
+
     const std::string outputLabel;
 
     const bool useBeamSpot;
@@ -105,6 +109,10 @@ FFTJetVertexAdder::FFTJetVertexAdder(const edm::ParameterSet& ps)
       init_param(double, errZ),
       init_param(unsigned, nVerticesToMake)
 {
+    if (useBeamSpot)
+        beamSpotToken = consumes<reco::BeamSpot>(beamSpotLabel);
+    if (addExistingVertices)
+        existingVerticesToken = consumes<reco::VertexCollection>(existingVerticesLabel);
     produces<reco::VertexCollection>(outputLabel);
 }
 
@@ -135,7 +143,7 @@ void FFTJetVertexAdder::produce(
     if (useBeamSpot)
     {
         edm::Handle<reco::BeamSpot> beamSpotHandle;
-        iEvent.getByLabel(beamSpotLabel, beamSpotHandle);
+        iEvent.getByToken(beamSpotToken, beamSpotHandle);
         if (!beamSpotHandle.isValid())
             throw cms::Exception("FFTJetBadConfig")
                 << "ERROR in FFTJetVertexAdder:"
@@ -173,7 +181,7 @@ void FFTJetVertexAdder::produce(
         typedef reco::VertexCollection::const_iterator IV;
 
         edm::Handle<reco::VertexCollection> vertices;
-        iEvent.getByLabel(existingVerticesLabel, vertices);
+        iEvent.getByToken(existingVerticesToken, vertices);
         if (!vertices.isValid())
             throw cms::Exception("FFTJetBadConfig")
                 << "ERROR in FFTJetVertexAdder:"

--- a/RecoJets/FFTJetProducers/python/fftjetcommon_cfi.py
+++ b/RecoJets/FFTJetProducers/python/fftjetcommon_cfi.py
@@ -68,6 +68,15 @@ fftjet_grid_256_128 = cms.PSet(
     title = cms.untracked.string("256 x 128")
 )
 
+fftjet_grid_512_256 = cms.PSet(
+    nEtaBins = cms.uint32(512),
+    etaMin = cms.double(-2.0*math.pi),
+    etaMax = cms.double(2.0*math.pi),
+    nPhiBins = cms.uint32(256),
+    phiBin0Edge = cms.double(0.0),
+    title = cms.untracked.string("512 x 256")
+)
+
 #
 # Definitions for anomalous towers
 # 
@@ -100,6 +109,17 @@ fftjet_patreco_scales_50 = cms.PSet(
     minScale = cms.double(0.087),
     maxScale = cms.double(0.6),
     nScales = cms.uint32(50)
+)
+
+#
+# Scales from 0.05 to 0.6, with 4.0% step.
+# Appropriate for use with the 512 x 256 grid.
+#
+fftjet_patreco_scales_64 = cms.PSet(
+    Class = cms.string("EquidistantInLogSpace"),
+    minScale = cms.double(0.05),
+    maxScale = cms.double(0.6),
+    nScales = cms.uint32(64)
 )
 
 #

--- a/RecoJets/FFTJetProducers/python/fftjetpfpileupcleaner_cfi.py
+++ b/RecoJets/FFTJetProducers/python/fftjetpfpileupcleaner_cfi.py
@@ -49,5 +49,6 @@ fftjetPfPileupCleaner = cms.EDProducer(
     #
     # Vertex quality cuts
     vertexNdofCut = cms.double(4.0),
-    vertexZmaxCut = cms.double(24.0)
+    vertexZmaxCut = cms.double(24.0),
+    vertexRhoCut = cms.double(1.0e20)
 )

--- a/RecoJets/FFTJetProducers/python/fftjetproducer_cfi.py
+++ b/RecoJets/FFTJetProducers/python/fftjetproducer_cfi.py
@@ -165,7 +165,9 @@ fftjetJetMaker = cms.EDProducer(
         magSpeedCut = cms.double(-1.0e100),
         lifeTimeCut = cms.double(-1.0e100),
         NNDCut = cms.double(-1.0e100),
-        etaCut = cms.double(1.0e100)
+        etaCut = cms.double(1.0e100),
+        splitTimeCut = cms.double(-1.0e100),
+        mergeTimeCut = cms.double(-1.0e100)
     ),
     #
     # The jet membership function

--- a/RecoJets/FFTJetProducers/src/FFTJetParameterParser.cc
+++ b/RecoJets/FFTJetProducers/src/FFTJetParameterParser.cc
@@ -50,6 +50,10 @@ static bool parse_peak_member_function(const char* fname,
         *f = &fftjet::Peak::magSpeed;
     else if (strcmp(fname, "lifetime") == 0)
         *f = &fftjet::Peak::lifetime;
+    else if (strcmp(fname, "mergeTime") == 0)
+        *f = &fftjet::Peak::mergeTime;
+    else if (strcmp(fname, "splitTime") == 0)
+        *f = &fftjet::Peak::splitTime;
     else if (strcmp(fname, "scale") == 0)
         *f = &fftjet::Peak::scale;
     else if (strcmp(fname, "nearestNeighborDistance") == 0)
@@ -92,6 +96,10 @@ static bool parse_jet_member_function(const char* fname,
         *f = &RecoFFTJet::magSpeed;
     else if (strcmp(fname, "lifetime") == 0)
         *f = &RecoFFTJet::lifetime;
+    else if (strcmp(fname, "mergeTime") == 0)
+        *f = &RecoFFTJet::mergeTime;
+    else if (strcmp(fname, "splitTime") == 0)
+        *f = &RecoFFTJet::splitTime;
     else if (strcmp(fname, "scale") == 0)
         *f = &RecoFFTJet::scale;
     else if (strcmp(fname, "nearestNeighborDistance") == 0)
@@ -236,9 +244,12 @@ fftjet_PeakSelector_parser(const edm::ParameterSet& ps)
         const double lifeTimeCut = ps.getParameter<double>("lifeTimeCut");
         const double NNDCut = ps.getParameter<double>("NNDCut");
         const double etaCut = ps.getParameter<double>("etaCut");
+        const double splitTimeCut = ps.getParameter<double>("splitTimeCut");
+        const double mergeTimeCut = ps.getParameter<double>("mergeTimeCut");
 
         return return_type(new fftjet::SimplePeakSelector(
-            magCut, driftSpeedCut ,magSpeedCut, lifeTimeCut, NNDCut, etaCut));
+            magCut, driftSpeedCut, magSpeedCut, lifeTimeCut, NNDCut,
+            etaCut, splitTimeCut, mergeTimeCut));
     }
 
     if (!peakselector_type.compare("ScalePowerPeakSelector"))

--- a/RecoJets/JetAnalyzers/src/FFTJetImageRecorder.cc
+++ b/RecoJets/JetAnalyzers/src/FFTJetImageRecorder.cc
@@ -59,6 +59,8 @@ private:
 
     edm::InputTag histoLabel;
     unsigned long counter;
+
+    edm::EDGetTokenT<TH3F> histoToken;
 };
 
 //
@@ -68,6 +70,7 @@ FFTJetImageRecorder::FFTJetImageRecorder(const edm::ParameterSet& ps)
     : init_param(edm::InputTag, histoLabel),
       counter(0)
 {
+    histoToken = consumes<TH3F>(histoLabel);
 }
 
 
@@ -90,13 +93,13 @@ void FFTJetImageRecorder::beginJob()
 
 // ------------ method called to for each event  ------------
 void FFTJetImageRecorder::analyze(const edm::Event& iEvent,
-                                   const edm::EventSetup& iSetup)
+                                  const edm::EventSetup& iSetup)
 {
     const long runnumber = iEvent.id().run();
     const long eventnumber = iEvent.id().event();
 
     edm::Handle<TH3F> input;
-    iEvent.getByLabel(histoLabel, input);
+    iEvent.getByToken(histoToken, input);
 
     edm::Service<TFileService> fs;
     TH3F* copy = new TH3F(*input);

--- a/RecoJets/JetAnalyzers/src/FFTJetPileupAnalyzer.cc
+++ b/RecoJets/JetAnalyzers/src/FFTJetPileupAnalyzer.cc
@@ -73,6 +73,16 @@ private:
     edm::InputTag gridLabel;
     edm::InputTag srcPVs;
     std::string pileupLabel;
+
+    edm::EDGetTokenT<TH2D> histoToken;
+    edm::EDGetTokenT<reco::FFTJetPileupSummary> summaryToken;
+    edm::EDGetTokenT<double> fastJetRhoToken;
+    edm::EDGetTokenT<double> fastJetSigmaToken;
+    edm::EDGetTokenT<reco::DiscretizedEnergyFlow> gridToken;
+    edm::EDGetTokenT<reco::VertexCollection> srcPVsToken;
+    edm::EDGetTokenT<std::vector<PileupSummaryInfo> > pileupToken;
+    edm::EDGetTokenT<std::pair<double,double> > etSumToken;
+
     std::string ntupleName;
     std::string ntupleTitle;
     bool collectHistos;
@@ -124,6 +134,29 @@ FFTJetPileupAnalyzer::FFTJetPileupAnalyzer(const edm::ParameterSet& ps)
       totalNPV(-1),
       counter(0)
 {
+    if (collectPileup || collectOOTPileup)
+        pileupToken = consumes<std::vector<PileupSummaryInfo> >(pileupLabel);
+
+    if (collectHistos)
+        histoToken = consumes<TH2D>(histoLabel);
+
+    if (collectSummaries)
+        summaryToken = consumes<reco::FFTJetPileupSummary>(summaryLabel);
+
+    if (collectFastJetRho)
+    {
+        fastJetRhoToken = consumes<double>(fastJetRhoLabel);
+        fastJetSigmaToken = consumes<double>(fastJetSigmaLabel);
+    }
+
+    if (collectGrids)
+        gridToken = consumes<reco::DiscretizedEnergyFlow>(gridLabel);
+
+    if (collectGridDensity)
+        etSumToken = consumes<std::pair<double,double> >(histoLabel);
+
+    if (collectVertexInfo)
+        srcPVsToken = consumes<reco::VertexCollection>(srcPVs);
 }
 
 
@@ -265,7 +298,7 @@ void FFTJetPileupAnalyzer::analyze(const edm::Event& iEvent,
     if (collectPileup || collectOOTPileup)
     {
         edm::Handle<std::vector<PileupSummaryInfo> > puInfo;
-        if (iEvent.getByLabel(pileupLabel, puInfo))
+        if (iEvent.getByToken(pileupToken, puInfo))
             analyzePileup(*puInfo);
         else
         {
@@ -289,7 +322,7 @@ void FFTJetPileupAnalyzer::analyze(const edm::Event& iEvent,
     if (collectHistos)
     {
         edm::Handle<TH2D> input;
-        iEvent.getByLabel(histoLabel, input);
+        iEvent.getByToken(histoToken, input);
 
         edm::Service<TFileService> fs;
         TH2D* copy = new TH2D(*input);
@@ -306,7 +339,7 @@ void FFTJetPileupAnalyzer::analyze(const edm::Event& iEvent,
     if (collectSummaries)
     {
         edm::Handle<reco::FFTJetPileupSummary> summary;
-        iEvent.getByLabel(summaryLabel, summary);
+        iEvent.getByToken(summaryToken, summary);
 
         ntupleData.push_back(summary->uncalibratedQuantile());
         ntupleData.push_back(summary->pileupRho());
@@ -317,8 +350,8 @@ void FFTJetPileupAnalyzer::analyze(const edm::Event& iEvent,
     if (collectFastJetRho)
     {
         edm::Handle<double> fjrho, fjsigma;
-        iEvent.getByLabel(fastJetRhoLabel, fjrho);
-        iEvent.getByLabel(fastJetSigmaLabel, fjsigma);
+        iEvent.getByToken(fastJetRhoToken, fjrho);
+        iEvent.getByToken(fastJetSigmaToken, fjsigma);
 
         ntupleData.push_back(*fjrho);
         ntupleData.push_back(*fjsigma);
@@ -327,7 +360,7 @@ void FFTJetPileupAnalyzer::analyze(const edm::Event& iEvent,
     if (collectGrids)
     {
         edm::Handle<reco::DiscretizedEnergyFlow> input;
-        iEvent.getByLabel(gridLabel, input);
+        iEvent.getByToken(gridToken, input);
 
         // Make sure the input grid is reasonable
         const double* data = input->data();
@@ -359,7 +392,7 @@ void FFTJetPileupAnalyzer::analyze(const edm::Event& iEvent,
     if (collectGridDensity)
     {
         edm::Handle<std::pair<double,double> > etSum;
-        iEvent.getByLabel(histoLabel, etSum);
+        iEvent.getByToken(etSumToken, etSum);
 
         ntupleData.push_back(etSum->first);
         ntupleData.push_back(etSum->second);
@@ -368,7 +401,7 @@ void FFTJetPileupAnalyzer::analyze(const edm::Event& iEvent,
     if (collectVertexInfo)
     {
         edm::Handle<reco::VertexCollection> pvCollection;
-        iEvent.getByLabel(srcPVs, pvCollection);
+        iEvent.getByToken(srcPVsToken, pvCollection);
         totalNPV = 0;
         if (!pvCollection->empty())
             for (reco::VertexCollection::const_iterator pv = pvCollection->begin();


### PR DESCRIPTION
Added various consumes statements to fftjet-based modules.
Added calls to fftjet cluster split/merge time calculations.
