### PR TITLE
Fix b tag bug in top hlt dqm offline and validation codes

### DIFF
--- a/DQMOffline/Trigger/python/singletopHLTEventDQM_cfi.py
+++ b/DQMOffline/Trigger/python/singletopHLTEventDQM_cfi.py
@@ -43,7 +43,7 @@ SingleTopSingleMuonHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM"
     jetExtras = cms.PSet(
       ## when omitted monitor plots for pt will be filled from uncorrected
       ## jets
-      jetCorrector = cms.string("ak4PFL1L2L3"),
+      #jetCorrector = cms.string("ak4PFCHSL1L2L3"),
       ## when omitted no extra selection will be applied on jets before
       ## filling the monitor histograms; if jetCorrector is present the
       ## selection will be applied to corrected jets                                                
@@ -128,7 +128,7 @@ SingleTopSingleMuonHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM"
     cms.PSet(
       label  = cms.string("jets/pf:step2"),
       src    = cms.InputTag("ak5PFJetsCHS"),
-      jetCorrector = cms.string("ak4PFL1L2L3"),
+      #jetCorrector = cms.string("ak4PFCHSL1L2L3"),
       select = cms.string("pt>40 & abs(eta)<5.0"),
       min = cms.int32(2),
     ), 
@@ -180,7 +180,7 @@ SingleTopSingleElectronHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOffline
     jetExtras = cms.PSet(
       ## when omitted monitor plots for pt will be filled from uncorrected
       ## jets
-      jetCorrector = cms.string("ak4PFL1L2L3"),
+      #jetCorrector = cms.string("ak4PFCHSL1L2L3"),
       ## when omitted no extra selection will be applied on jets before
       ## filling the monitor histograms; if jetCorrector is present the
       ## selection will be applied to corrected jets                                                
@@ -259,14 +259,14 @@ SingleTopSingleElectronHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOffline
     #cms.PSet(
     #  label  = cms.string("jets/pf:step2"),
     #  src    = cms.InputTag("ak5PFJetsCHS"),
-    #  jetCorrector = cms.string("ak4PFL1L2L3"),
+    #  jetCorrector = cms.string("ak4PFCHSL1L2L3"),
     #  select = cms.string("pt>40 & abs(eta)<5.0"),
     #  min = cms.int32(1),
     #), 
     cms.PSet(
       label  = cms.string("jets/pf:step2"),
       src    = cms.InputTag("ak5PFJetsCHS"),
-      jetCorrector = cms.string("ak4PFL1L2L3"),
+      #jetCorrector = cms.string("ak4PFCHSL1L2L3"),
       select = cms.string("pt>40 & abs(eta)<5.0"),
       min = cms.int32(2),
     ), 

--- a/DQMOffline/Trigger/python/singletopHLTEventDQM_cfi.py
+++ b/DQMOffline/Trigger/python/singletopHLTEventDQM_cfi.py
@@ -16,7 +16,7 @@ SingleTopSingleMuonHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM"
     sources = cms.PSet(
       muons = cms.InputTag("muons"),
       elecs = cms.InputTag("gedGsfElectrons"),
-      jets  = cms.InputTag("PFJetsFilter"),
+      jets  = cms.InputTag("ak5PFJetsCHS"),
       mets  = cms.VInputTag("met", "tcMet", "pfMet"),
       pvs   = cms.InputTag("offlinePrimaryVertices")
 
@@ -51,15 +51,15 @@ SingleTopSingleMuonHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM"
       ## when omitted monitor histograms for b-tagging will not be filled 
       jetBTaggers  = cms.PSet(
          trackCountingEff = cms.PSet(
-           label = cms.InputTag("pfJetProbabilityBJetTags" ),
+           label = cms.InputTag("jetProbabilityBJetTags" ),
            workingPoint = cms.double(0.275)
          ),
          trackCountingPur = cms.PSet(
-           label = cms.InputTag("pfTrackCountingHighPurBJetTags" ),
+           label = cms.InputTag("trackCountingHighPurBJetTags" ),
            workingPoint = cms.double(3.41)
          ),
          secondaryVertex  = cms.PSet(
-           label = cms.InputTag("pfCombinedSecondaryVertexBJetTags"),
+           label = cms.InputTag("combinedSecondaryVertexBJetTags"),
            workingPoint = cms.double(0.679)
          )
        ),
@@ -120,14 +120,14 @@ SingleTopSingleMuonHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM"
     ),
     #cms.PSet(
     #  label  = cms.string("jets/pf:step2"),
-    #  src    = cms.InputTag("PFJetsFilter"),
+    #  src    = cms.InputTag("ak5PFJetsCHS"),
     #  jetCorrector = cms.string("ak5PFL2L3"),
     #  select = cms.string("pt>40 & abs(eta)<5.0"),
     #  min = cms.int32(1),
     #), 
     cms.PSet(
       label  = cms.string("jets/pf:step2"),
-      src    = cms.InputTag("PFJetsFilter"),
+      src    = cms.InputTag("ak5PFJetsCHS"),
       jetCorrector = cms.string("ak5PFL2L3"),
       select = cms.string("pt>40 & abs(eta)<5.0"),
       min = cms.int32(2),
@@ -151,7 +151,7 @@ SingleTopSingleElectronHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOffline
     sources = cms.PSet(
       muons = cms.InputTag("muons"),
       elecs = cms.InputTag("gedGsfElectrons"),
-      jets  = cms.InputTag("PFJetsFilter"),
+      jets  = cms.InputTag("ak5PFJetsCHS"),
       mets  = cms.VInputTag("met", "tcMet", "pfMet"),
       pvs   = cms.InputTag("offlinePrimaryVertices")
 
@@ -188,15 +188,15 @@ SingleTopSingleElectronHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOffline
       ## when omitted monitor histograms for b-tagging will not be filled  
       jetBTaggers  = cms.PSet(
          trackCountingEff = cms.PSet(
-           label = cms.InputTag("pfJetProbabilityBJetTags" ),
+           label = cms.InputTag("jetProbabilityBJetTags" ),
            workingPoint = cms.double(0.275)
          ),
          trackCountingPur = cms.PSet(
-           label = cms.InputTag("pfTrackCountingHighPurBJetTags" ),
+           label = cms.InputTag("trackCountingHighPurBJetTags" ),
            workingPoint = cms.double(3.41)
          ),
          secondaryVertex  = cms.PSet(
-           label = cms.InputTag("pfCombinedSecondaryVertexBJetTags"),
+           label = cms.InputTag("combinedSecondaryVertexBJetTags"),
            workingPoint = cms.double(0.679)
          )
        ),
@@ -258,14 +258,14 @@ SingleTopSingleElectronHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOffline
     ),
     #cms.PSet(
     #  label  = cms.string("jets/pf:step2"),
-    #  src    = cms.InputTag("PFJetsFilter"),
+    #  src    = cms.InputTag("ak5PFJetsCHS"),
     #  jetCorrector = cms.string("ak5PFL2L3"),
     #  select = cms.string("pt>40 & abs(eta)<5.0"),
     #  min = cms.int32(1),
     #), 
     cms.PSet(
       label  = cms.string("jets/pf:step2"),
-      src    = cms.InputTag("PFJetsFilter"),
+      src    = cms.InputTag("ak5PFJetsCHS"),
       jetCorrector = cms.string("ak5PFL2L3"),
       select = cms.string("pt>40 & abs(eta)<5.0"),
       min = cms.int32(2),

--- a/DQMOffline/Trigger/python/singletopHLTEventDQM_cfi.py
+++ b/DQMOffline/Trigger/python/singletopHLTEventDQM_cfi.py
@@ -11,7 +11,7 @@ SingleTopSingleMuonHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM"
     ## sub-directory to write the monitor histograms to
     ## [mandatory] : should not be changed w/o explicit
     ## communication to TopCom!
-    directory = cms.string("HLTriggerOffline/SingleTop/SingleMuon/"),
+    directory = cms.string("HLT/TopHLTOffline/SingleTop/SingleMuon/"),
     ## [mandatory]
     sources = cms.PSet(
       muons = cms.InputTag("muons"),
@@ -146,7 +146,7 @@ SingleTopSingleElectronHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOffline
     ## sub-directory to write the monitor histograms to
     ## [mandatory] : should not be changed w/o explicit
     ## communication to TopCom!
-    directory = cms.string("HLTriggerOffline/SingleTop/SingleElectron/"),
+    directory = cms.string("HLT/TopHLTOffline/SingleTop/SingleElectron/"),
     ## [mandatory]
     sources = cms.PSet(
       muons = cms.InputTag("muons"),

--- a/DQMOffline/Trigger/python/singletopHLTEventDQM_cfi.py
+++ b/DQMOffline/Trigger/python/singletopHLTEventDQM_cfi.py
@@ -16,7 +16,7 @@ SingleTopSingleMuonHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM"
     sources = cms.PSet(
       muons = cms.InputTag("muons"),
       elecs = cms.InputTag("gedGsfElectrons"),
-      jets  = cms.InputTag("PFJetsFilter"),
+      jets  = cms.InputTag("ak5PFJetsCHS"),
       mets  = cms.VInputTag("met", "tcMet", "pfMet"),
       pvs   = cms.InputTag("offlinePrimaryVertices")
 
@@ -51,15 +51,15 @@ SingleTopSingleMuonHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM"
       ## when omitted monitor histograms for b-tagging will not be filled 
       jetBTaggers  = cms.PSet(
          trackCountingEff = cms.PSet(
-           label = cms.InputTag("pfJetProbabilityBJetTags" ),
+           label = cms.InputTag("jetProbabilityBJetTags" ),
            workingPoint = cms.double(0.275)
          ),
          trackCountingPur = cms.PSet(
-           label = cms.InputTag("pfTrackCountingHighPurBJetTags" ),
+           label = cms.InputTag("trackCountingHighPurBJetTags" ),
            workingPoint = cms.double(3.41)
          ),
          secondaryVertex  = cms.PSet(
-           label = cms.InputTag("pfCombinedSecondaryVertexBJetTags"),
+           label = cms.InputTag("combinedSecondaryVertexBJetTags"),
            workingPoint = cms.double(0.679)
          )
        ),
@@ -120,15 +120,25 @@ SingleTopSingleMuonHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM"
     ),
     #cms.PSet(
     #  label  = cms.string("jets/pf:step2"),
+<<<<<<< HEAD
     #  src    = cms.InputTag("PFJetsFilter"),
     #  jetCorrector = cms.string("ak4PFL2L3"),
+=======
+    #  src    = cms.InputTag("ak5PFJetsCHS"),
+    #  jetCorrector = cms.string("ak5PFL2L3"),
+>>>>>>> 754cc1b... fix btagging in DQMOffline/Trigger, only partially moving to ak4 because of btagging
     #  select = cms.string("pt>40 & abs(eta)<5.0"),
     #  min = cms.int32(1),
     #), 
     cms.PSet(
       label  = cms.string("jets/pf:step2"),
+<<<<<<< HEAD
       src    = cms.InputTag("PFJetsFilter"),
       jetCorrector = cms.string("ak4PFL2L3"),
+=======
+      src    = cms.InputTag("ak5PFJetsCHS"),
+      jetCorrector = cms.string("ak5PFL2L3"),
+>>>>>>> 754cc1b... fix btagging in DQMOffline/Trigger, only partially moving to ak4 because of btagging
       select = cms.string("pt>40 & abs(eta)<5.0"),
       min = cms.int32(2),
     ), 
@@ -151,7 +161,7 @@ SingleTopSingleElectronHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOffline
     sources = cms.PSet(
       muons = cms.InputTag("muons"),
       elecs = cms.InputTag("gedGsfElectrons"),
-      jets  = cms.InputTag("PFJetsFilter"),
+      jets  = cms.InputTag("ak5PFJetsCHS"),
       mets  = cms.VInputTag("met", "tcMet", "pfMet"),
       pvs   = cms.InputTag("offlinePrimaryVertices")
 
@@ -188,15 +198,15 @@ SingleTopSingleElectronHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOffline
       ## when omitted monitor histograms for b-tagging will not be filled  
       jetBTaggers  = cms.PSet(
          trackCountingEff = cms.PSet(
-           label = cms.InputTag("pfJetProbabilityBJetTags" ),
+           label = cms.InputTag("jetProbabilityBJetTags" ),
            workingPoint = cms.double(0.275)
          ),
          trackCountingPur = cms.PSet(
-           label = cms.InputTag("pfTrackCountingHighPurBJetTags" ),
+           label = cms.InputTag("trackCountingHighPurBJetTags" ),
            workingPoint = cms.double(3.41)
          ),
          secondaryVertex  = cms.PSet(
-           label = cms.InputTag("pfCombinedSecondaryVertexBJetTags"),
+           label = cms.InputTag("combinedSecondaryVertexBJetTags"),
            workingPoint = cms.double(0.679)
          )
        ),
@@ -258,15 +268,25 @@ SingleTopSingleElectronHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOffline
     ),
     #cms.PSet(
     #  label  = cms.string("jets/pf:step2"),
+<<<<<<< HEAD
     #  src    = cms.InputTag("PFJetsFilter"),
     #  jetCorrector = cms.string("ak4PFL2L3"),
+=======
+    #  src    = cms.InputTag("ak5PFJetsCHS"),
+    #  jetCorrector = cms.string("ak5PFL2L3"),
+>>>>>>> 754cc1b... fix btagging in DQMOffline/Trigger, only partially moving to ak4 because of btagging
     #  select = cms.string("pt>40 & abs(eta)<5.0"),
     #  min = cms.int32(1),
     #), 
     cms.PSet(
       label  = cms.string("jets/pf:step2"),
+<<<<<<< HEAD
       src    = cms.InputTag("PFJetsFilter"),
       jetCorrector = cms.string("ak4PFL2L3"),
+=======
+      src    = cms.InputTag("ak5PFJetsCHS"),
+      jetCorrector = cms.string("ak5PFL2L3"),
+>>>>>>> 754cc1b... fix btagging in DQMOffline/Trigger, only partially moving to ak4 because of btagging
       select = cms.string("pt>40 & abs(eta)<5.0"),
       min = cms.int32(2),
     ), 

--- a/DQMOffline/Trigger/python/singletopHLTEventDQM_cfi.py
+++ b/DQMOffline/Trigger/python/singletopHLTEventDQM_cfi.py
@@ -43,7 +43,7 @@ SingleTopSingleMuonHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM"
     jetExtras = cms.PSet(
       ## when omitted monitor plots for pt will be filled from uncorrected
       ## jets
-      jetCorrector = cms.string("ak4PFL2L3"),
+      jetCorrector = cms.string("ak5PFL2L3"),
       ## when omitted no extra selection will be applied on jets before
       ## filling the monitor histograms; if jetCorrector is present the
       ## selection will be applied to corrected jets                                                
@@ -180,7 +180,7 @@ SingleTopSingleElectronHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOffline
     jetExtras = cms.PSet(
       ## when omitted monitor plots for pt will be filled from uncorrected
       ## jets
-      jetCorrector = cms.string("ak4PFL2L3"),
+      jetCorrector = cms.string("ak5PFL2L3"),
       ## when omitted no extra selection will be applied on jets before
       ## filling the monitor histograms; if jetCorrector is present the
       ## selection will be applied to corrected jets                                                

--- a/DQMOffline/Trigger/python/singletopHLTEventDQM_cfi.py
+++ b/DQMOffline/Trigger/python/singletopHLTEventDQM_cfi.py
@@ -43,7 +43,7 @@ SingleTopSingleMuonHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM"
     jetExtras = cms.PSet(
       ## when omitted monitor plots for pt will be filled from uncorrected
       ## jets
-      jetCorrector = cms.string("ak5PFL2L3"),
+      jetCorrector = cms.string("ak4PFL1L2L3"),
       ## when omitted no extra selection will be applied on jets before
       ## filling the monitor histograms; if jetCorrector is present the
       ## selection will be applied to corrected jets                                                
@@ -121,14 +121,14 @@ SingleTopSingleMuonHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM"
     #cms.PSet(
     #  label  = cms.string("jets/pf:step2"),
     #  src    = cms.InputTag("ak5PFJetsCHS"),
-    #  jetCorrector = cms.string("ak5PFL2L3"),
+    #  jetCorrector = cms.string("ak4PFL1L2L3"),
     #  select = cms.string("pt>40 & abs(eta)<5.0"),
     #  min = cms.int32(1),
     #), 
     cms.PSet(
       label  = cms.string("jets/pf:step2"),
       src    = cms.InputTag("ak5PFJetsCHS"),
-      jetCorrector = cms.string("ak5PFL2L3"),
+      jetCorrector = cms.string("ak4PFL1L2L3"),
       select = cms.string("pt>40 & abs(eta)<5.0"),
       min = cms.int32(2),
     ), 
@@ -180,7 +180,7 @@ SingleTopSingleElectronHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOffline
     jetExtras = cms.PSet(
       ## when omitted monitor plots for pt will be filled from uncorrected
       ## jets
-      jetCorrector = cms.string("ak5PFL2L3"),
+      jetCorrector = cms.string("ak4PFL1L2L3"),
       ## when omitted no extra selection will be applied on jets before
       ## filling the monitor histograms; if jetCorrector is present the
       ## selection will be applied to corrected jets                                                
@@ -259,14 +259,14 @@ SingleTopSingleElectronHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOffline
     #cms.PSet(
     #  label  = cms.string("jets/pf:step2"),
     #  src    = cms.InputTag("ak5PFJetsCHS"),
-    #  jetCorrector = cms.string("ak5PFL2L3"),
+    #  jetCorrector = cms.string("ak4PFL1L2L3"),
     #  select = cms.string("pt>40 & abs(eta)<5.0"),
     #  min = cms.int32(1),
     #), 
     cms.PSet(
       label  = cms.string("jets/pf:step2"),
       src    = cms.InputTag("ak5PFJetsCHS"),
-      jetCorrector = cms.string("ak5PFL2L3"),
+      jetCorrector = cms.string("ak4PFL1L2L3"),
       select = cms.string("pt>40 & abs(eta)<5.0"),
       min = cms.int32(2),
     ), 

--- a/DQMOffline/Trigger/python/singletopHLTEventDQM_cfi.py
+++ b/DQMOffline/Trigger/python/singletopHLTEventDQM_cfi.py
@@ -120,31 +120,15 @@ SingleTopSingleMuonHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM"
     ),
     #cms.PSet(
     #  label  = cms.string("jets/pf:step2"),
-<<<<<<< HEAD
-<<<<<<< HEAD
-    #  src    = cms.InputTag("PFJetsFilter"),
-    #  jetCorrector = cms.string("ak4PFL2L3"),
-=======
-=======
->>>>>>> 754cc1beaedd51b84ec7d650a47a4981cdabdb1b
     #  src    = cms.InputTag("ak5PFJetsCHS"),
     #  jetCorrector = cms.string("ak5PFL2L3"),
->>>>>>> 754cc1b... fix btagging in DQMOffline/Trigger, only partially moving to ak4 because of btagging
     #  select = cms.string("pt>40 & abs(eta)<5.0"),
     #  min = cms.int32(1),
     #), 
     cms.PSet(
       label  = cms.string("jets/pf:step2"),
-<<<<<<< HEAD
-<<<<<<< HEAD
-      src    = cms.InputTag("PFJetsFilter"),
-      jetCorrector = cms.string("ak4PFL2L3"),
-=======
-=======
->>>>>>> 754cc1beaedd51b84ec7d650a47a4981cdabdb1b
       src    = cms.InputTag("ak5PFJetsCHS"),
       jetCorrector = cms.string("ak5PFL2L3"),
->>>>>>> 754cc1b... fix btagging in DQMOffline/Trigger, only partially moving to ak4 because of btagging
       select = cms.string("pt>40 & abs(eta)<5.0"),
       min = cms.int32(2),
     ), 
@@ -274,31 +258,15 @@ SingleTopSingleElectronHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOffline
     ),
     #cms.PSet(
     #  label  = cms.string("jets/pf:step2"),
-<<<<<<< HEAD
-<<<<<<< HEAD
-    #  src    = cms.InputTag("PFJetsFilter"),
-    #  jetCorrector = cms.string("ak4PFL2L3"),
-=======
-=======
->>>>>>> 754cc1beaedd51b84ec7d650a47a4981cdabdb1b
     #  src    = cms.InputTag("ak5PFJetsCHS"),
     #  jetCorrector = cms.string("ak5PFL2L3"),
->>>>>>> 754cc1b... fix btagging in DQMOffline/Trigger, only partially moving to ak4 because of btagging
     #  select = cms.string("pt>40 & abs(eta)<5.0"),
     #  min = cms.int32(1),
     #), 
     cms.PSet(
       label  = cms.string("jets/pf:step2"),
-<<<<<<< HEAD
-<<<<<<< HEAD
-      src    = cms.InputTag("PFJetsFilter"),
-      jetCorrector = cms.string("ak4PFL2L3"),
-=======
-=======
->>>>>>> 754cc1beaedd51b84ec7d650a47a4981cdabdb1b
       src    = cms.InputTag("ak5PFJetsCHS"),
       jetCorrector = cms.string("ak5PFL2L3"),
->>>>>>> 754cc1b... fix btagging in DQMOffline/Trigger, only partially moving to ak4 because of btagging
       select = cms.string("pt>40 & abs(eta)<5.0"),
       min = cms.int32(2),
     ), 

--- a/DQMOffline/Trigger/python/topDiLeptonHLTEventDQM_cfi.py
+++ b/DQMOffline/Trigger/python/topDiLeptonHLTEventDQM_cfi.py
@@ -116,16 +116,8 @@ topDiLeptonHLTOfflineDQM = cms.EDAnalyzer("TopDiLeptonHLTOfflineDQM",
     ),
     cms.PSet(
       label  = cms.string("jets/pf:step1"),
-<<<<<<< HEAD
-<<<<<<< HEAD
-      src    = cms.InputTag("PFJetsFilter"),
-      jetCorrector = cms.string("ak4PFL2L3"),
-=======
-=======
->>>>>>> 754cc1beaedd51b84ec7d650a47a4981cdabdb1b
       src    = cms.InputTag("ak4PFJetsCHS"),
       jetCorrector = cms.string("ak5PFL2L3"),
->>>>>>> 754cc1b... fix btagging in DQMOffline/Trigger, only partially moving to ak4 because of btagging
       select = cms.string("pt>30. & abs(eta)<2.5"),
       min = cms.int32(2),
     )
@@ -259,16 +251,8 @@ DiMuonHLTOfflineDQM = cms.EDAnalyzer("TopDiLeptonHLTOfflineDQM",
     ),
     cms.PSet(
       label  = cms.string("jets/pf:step2"),
-<<<<<<< HEAD
-<<<<<<< HEAD
-      src    = cms.InputTag("PFJetsFilter"),
-      jetCorrector = cms.string("ak4PFL2L3"),
-=======
-=======
->>>>>>> 754cc1beaedd51b84ec7d650a47a4981cdabdb1b
       src    = cms.InputTag("ak4PFJetsCHS"),
       jetCorrector = cms.string("ak5PFL2L3"),
->>>>>>> 754cc1b... fix btagging in DQMOffline/Trigger, only partially moving to ak4 because of btagging
       select = cms.string("pt>30. & abs(eta)<2.5"),
       min = cms.int32(2),
     ),
@@ -401,16 +385,8 @@ DiElectronHLTOfflineDQM = cms.EDAnalyzer("TopDiLeptonHLTOfflineDQM",
     ),
     cms.PSet(
       label  = cms.string("jets/pf:step2"),
-<<<<<<< HEAD
-<<<<<<< HEAD
-      src    = cms.InputTag("PFJetsFilter"),
-      jetCorrector = cms.string("ak4PFL2L3"),
-=======
-=======
->>>>>>> 754cc1beaedd51b84ec7d650a47a4981cdabdb1b
       src    = cms.InputTag("ak4PFJetsCHS"),
       jetCorrector = cms.string("ak5PFL2L3"),
->>>>>>> 754cc1b... fix btagging in DQMOffline/Trigger, only partially moving to ak4 because of btagging
       select = cms.string("pt>30. & abs(eta)<2.5"),
       min = cms.int32(2),
     ),
@@ -551,16 +527,8 @@ ElecMuonHLTOfflineDQM = cms.EDAnalyzer("TopDiLeptonHLTOfflineDQM",
     ),
     cms.PSet(
       label  = cms.string("jets/pf:step3"),
-<<<<<<< HEAD
-<<<<<<< HEAD
-      src    = cms.InputTag("PFJetsFilter"),
-      jetCorrector = cms.string("ak4PFL2L3"),
-=======
-=======
->>>>>>> 754cc1beaedd51b84ec7d650a47a4981cdabdb1b
       src    = cms.InputTag("ak4PFJetsCHS"),
       jetCorrector = cms.string("ak5PFL2L3"),
->>>>>>> 754cc1b... fix btagging in DQMOffline/Trigger, only partially moving to ak4 because of btagging
       select = cms.string("pt>30. & abs(eta)<2.5"),
       min = cms.int32(2),
     ),

--- a/DQMOffline/Trigger/python/topDiLeptonHLTEventDQM_cfi.py
+++ b/DQMOffline/Trigger/python/topDiLeptonHLTEventDQM_cfi.py
@@ -47,7 +47,7 @@ topDiLeptonHLTOfflineDQM = cms.EDAnalyzer("TopDiLeptonHLTOfflineDQM",
     jetExtras = cms.PSet(
       ## when omitted monitor plots for pt will be filled from uncorrected
       ## jets    
-      jetCorrector = cms.string("ak4PFL1L2L3"),
+      #jetCorrector = cms.string("ak4PFCHSL1L2L3"),
       ## when omitted no extra selection will be applied on jets before
       ## filling the monitor histograms; if jetCorrector is present the
       ## selection will be applied to corrected jets
@@ -117,7 +117,7 @@ topDiLeptonHLTOfflineDQM = cms.EDAnalyzer("TopDiLeptonHLTOfflineDQM",
     cms.PSet(
       label  = cms.string("jets/pf:step1"),
       src    = cms.InputTag("ak4PFJetsCHS"),
-      jetCorrector = cms.string("ak4PFL1L2L3"),
+      #jetCorrector = cms.string("ak4PFCHSL1L2L3"),
       select = cms.string("pt>30. & abs(eta)<2.5"),
       min = cms.int32(2),
     )
@@ -173,7 +173,7 @@ DiMuonHLTOfflineDQM = cms.EDAnalyzer("TopDiLeptonHLTOfflineDQM",
     jetExtras = cms.PSet(
       ## when omitted monitor plots for pt will be filled from uncorrected
       ## jets    
-      jetCorrector = cms.string("ak4PFL1L2L3"),
+      #jetCorrector = cms.string("ak4PFCHSL1L2L3"),
       ## when omitted no extra selection will be applied on jets before
       ## filling the monitor histograms; if jetCorrector is present the
       ## selection will be applied to corrected jets
@@ -252,7 +252,7 @@ DiMuonHLTOfflineDQM = cms.EDAnalyzer("TopDiLeptonHLTOfflineDQM",
     cms.PSet(
       label  = cms.string("jets/pf:step2"),
       src    = cms.InputTag("ak4PFJetsCHS"),
-      jetCorrector = cms.string("ak4PFL1L2L3"),
+      #jetCorrector = cms.string("ak4PFCHSL1L2L3"),
       select = cms.string("pt>30. & abs(eta)<2.5"),
       min = cms.int32(2),
     ),
@@ -306,7 +306,7 @@ DiElectronHLTOfflineDQM = cms.EDAnalyzer("TopDiLeptonHLTOfflineDQM",
     jetExtras = cms.PSet(
       ## when omitted monitor plots for pt will be filled from uncorrected
       ## jets    
-      jetCorrector = cms.string("ak4PFL1L2L3"),
+      #jetCorrector = cms.string("ak4PFCHSL1L2L3"),
       ## when omitted no extra selection will be applied on jets before
       ## filling the monitor histograms; if jetCorrector is present the
       ## selection will be applied to corrected jets
@@ -386,7 +386,7 @@ DiElectronHLTOfflineDQM = cms.EDAnalyzer("TopDiLeptonHLTOfflineDQM",
     cms.PSet(
       label  = cms.string("jets/pf:step2"),
       src    = cms.InputTag("ak4PFJetsCHS"),
-      jetCorrector = cms.string("ak4PFL1L2L3"),
+      #jetCorrector = cms.string("ak4PFCHSL1L2L3"),
       select = cms.string("pt>30. & abs(eta)<2.5"),
       min = cms.int32(2),
     ),
@@ -440,7 +440,7 @@ ElecMuonHLTOfflineDQM = cms.EDAnalyzer("TopDiLeptonHLTOfflineDQM",
     jetExtras = cms.PSet(
       ## when omitted monitor plots for pt will be filled from uncorrected
       ## jets    
-      jetCorrector = cms.string("ak4PFL1L2L3"),
+      #jetCorrector = cms.string("ak4PFCHSL1L2L3"),
       ## when omitted no extra selection will be applied on jets before
       ## filling the monitor histograms; if jetCorrector is present the
       ## selection will be applied to corrected jets
@@ -528,7 +528,7 @@ ElecMuonHLTOfflineDQM = cms.EDAnalyzer("TopDiLeptonHLTOfflineDQM",
     cms.PSet(
       label  = cms.string("jets/pf:step3"),
       src    = cms.InputTag("ak4PFJetsCHS"),
-      jetCorrector = cms.string("ak4PFL1L2L3"),
+      #jetCorrector = cms.string("ak4PFCHSL1L2L3"),
       select = cms.string("pt>30. & abs(eta)<2.5"),
       min = cms.int32(2),
     ),

--- a/DQMOffline/Trigger/python/topDiLeptonHLTEventDQM_cfi.py
+++ b/DQMOffline/Trigger/python/topDiLeptonHLTEventDQM_cfi.py
@@ -17,7 +17,7 @@ topDiLeptonHLTOfflineDQM = cms.EDAnalyzer("TopDiLeptonHLTOfflineDQM",
     sources = cms.PSet(
       muons = cms.InputTag("muons"),
       elecs = cms.InputTag("gedGsfElectrons"),
-      jets  = cms.InputTag("PFJetsFilter"),
+      jets  = cms.InputTag("ak4PFJetsCHS"),
       mets  = cms.VInputTag("met", "tcMet", "pfMet")
     ),
     ## [optional] : when omitted all monitoring plots for electrons
@@ -116,7 +116,7 @@ topDiLeptonHLTOfflineDQM = cms.EDAnalyzer("TopDiLeptonHLTOfflineDQM",
     ),
     cms.PSet(
       label  = cms.string("jets/pf:step1"),
-      src    = cms.InputTag("PFJetsFilter"),
+      src    = cms.InputTag("ak4PFJetsCHS"),
       jetCorrector = cms.string("ak5PFL2L3"),
       select = cms.string("pt>30. & abs(eta)<2.5"),
       min = cms.int32(2),
@@ -143,7 +143,7 @@ DiMuonHLTOfflineDQM = cms.EDAnalyzer("TopDiLeptonHLTOfflineDQM",
     sources = cms.PSet(
       muons = cms.InputTag("muons"),
       elecs = cms.InputTag("gedGsfElectrons"),
-      jets  = cms.InputTag("PFJetsFilter"),
+      jets  = cms.InputTag("ak4PFJetsCHS"),
       mets  = cms.VInputTag("met", "tcMet", "pfMet")
     ),
     ## [optional] : when omitted all monitoring plots for electrons
@@ -251,7 +251,7 @@ DiMuonHLTOfflineDQM = cms.EDAnalyzer("TopDiLeptonHLTOfflineDQM",
     ),
     cms.PSet(
       label  = cms.string("jets/pf:step2"),
-      src    = cms.InputTag("PFJetsFilter"),
+      src    = cms.InputTag("ak4PFJetsCHS"),
       jetCorrector = cms.string("ak5PFL2L3"),
       select = cms.string("pt>30. & abs(eta)<2.5"),
       min = cms.int32(2),
@@ -276,7 +276,7 @@ DiElectronHLTOfflineDQM = cms.EDAnalyzer("TopDiLeptonHLTOfflineDQM",
     sources = cms.PSet(
       muons = cms.InputTag("muons"),
       elecs = cms.InputTag("gedGsfElectrons"),
-      jets  = cms.InputTag("PFJetsFilter"),
+      jets  = cms.InputTag("ak4PFJetsCHS"),
       mets  = cms.VInputTag("met", "tcMet", "pfMet")
     ),
     ## [optional] : when omitted all monitoring plots for electrons
@@ -385,7 +385,7 @@ DiElectronHLTOfflineDQM = cms.EDAnalyzer("TopDiLeptonHLTOfflineDQM",
     ),
     cms.PSet(
       label  = cms.string("jets/pf:step2"),
-      src    = cms.InputTag("PFJetsFilter"),
+      src    = cms.InputTag("ak4PFJetsCHS"),
       jetCorrector = cms.string("ak5PFL2L3"),
       select = cms.string("pt>30. & abs(eta)<2.5"),
       min = cms.int32(2),
@@ -410,7 +410,7 @@ ElecMuonHLTOfflineDQM = cms.EDAnalyzer("TopDiLeptonHLTOfflineDQM",
     sources = cms.PSet(
       muons = cms.InputTag("muons"),
       elecs = cms.InputTag("gedGsfElectrons"),
-      jets  = cms.InputTag("PFJetsFilter"),
+      jets  = cms.InputTag("ak4PFJetsCHS"),
       mets  = cms.VInputTag("met", "tcMet", "pfMet")
     ),
     ## [optional] : when omitted all monitoring plots for electrons
@@ -527,7 +527,7 @@ ElecMuonHLTOfflineDQM = cms.EDAnalyzer("TopDiLeptonHLTOfflineDQM",
     ),
     cms.PSet(
       label  = cms.string("jets/pf:step3"),
-      src    = cms.InputTag("PFJetsFilter"),
+      src    = cms.InputTag("ak4PFJetsCHS"),
       jetCorrector = cms.string("ak5PFL2L3"),
       select = cms.string("pt>30. & abs(eta)<2.5"),
       min = cms.int32(2),

--- a/DQMOffline/Trigger/python/topDiLeptonHLTEventDQM_cfi.py
+++ b/DQMOffline/Trigger/python/topDiLeptonHLTEventDQM_cfi.py
@@ -17,7 +17,7 @@ topDiLeptonHLTOfflineDQM = cms.EDAnalyzer("TopDiLeptonHLTOfflineDQM",
     sources = cms.PSet(
       muons = cms.InputTag("muons"),
       elecs = cms.InputTag("gedGsfElectrons"),
-      jets  = cms.InputTag("PFJetsFilter"),
+      jets  = cms.InputTag("ak4PFJetsCHS"),
       mets  = cms.VInputTag("met", "tcMet", "pfMet")
     ),
     ## [optional] : when omitted all monitoring plots for electrons
@@ -116,8 +116,13 @@ topDiLeptonHLTOfflineDQM = cms.EDAnalyzer("TopDiLeptonHLTOfflineDQM",
     ),
     cms.PSet(
       label  = cms.string("jets/pf:step1"),
+<<<<<<< HEAD
       src    = cms.InputTag("PFJetsFilter"),
       jetCorrector = cms.string("ak4PFL2L3"),
+=======
+      src    = cms.InputTag("ak4PFJetsCHS"),
+      jetCorrector = cms.string("ak5PFL2L3"),
+>>>>>>> 754cc1b... fix btagging in DQMOffline/Trigger, only partially moving to ak4 because of btagging
       select = cms.string("pt>30. & abs(eta)<2.5"),
       min = cms.int32(2),
     )
@@ -143,7 +148,7 @@ DiMuonHLTOfflineDQM = cms.EDAnalyzer("TopDiLeptonHLTOfflineDQM",
     sources = cms.PSet(
       muons = cms.InputTag("muons"),
       elecs = cms.InputTag("gedGsfElectrons"),
-      jets  = cms.InputTag("PFJetsFilter"),
+      jets  = cms.InputTag("ak4PFJetsCHS"),
       mets  = cms.VInputTag("met", "tcMet", "pfMet")
     ),
     ## [optional] : when omitted all monitoring plots for electrons
@@ -251,8 +256,13 @@ DiMuonHLTOfflineDQM = cms.EDAnalyzer("TopDiLeptonHLTOfflineDQM",
     ),
     cms.PSet(
       label  = cms.string("jets/pf:step2"),
+<<<<<<< HEAD
       src    = cms.InputTag("PFJetsFilter"),
       jetCorrector = cms.string("ak4PFL2L3"),
+=======
+      src    = cms.InputTag("ak4PFJetsCHS"),
+      jetCorrector = cms.string("ak5PFL2L3"),
+>>>>>>> 754cc1b... fix btagging in DQMOffline/Trigger, only partially moving to ak4 because of btagging
       select = cms.string("pt>30. & abs(eta)<2.5"),
       min = cms.int32(2),
     ),
@@ -276,7 +286,7 @@ DiElectronHLTOfflineDQM = cms.EDAnalyzer("TopDiLeptonHLTOfflineDQM",
     sources = cms.PSet(
       muons = cms.InputTag("muons"),
       elecs = cms.InputTag("gedGsfElectrons"),
-      jets  = cms.InputTag("PFJetsFilter"),
+      jets  = cms.InputTag("ak4PFJetsCHS"),
       mets  = cms.VInputTag("met", "tcMet", "pfMet")
     ),
     ## [optional] : when omitted all monitoring plots for electrons
@@ -385,8 +395,13 @@ DiElectronHLTOfflineDQM = cms.EDAnalyzer("TopDiLeptonHLTOfflineDQM",
     ),
     cms.PSet(
       label  = cms.string("jets/pf:step2"),
+<<<<<<< HEAD
       src    = cms.InputTag("PFJetsFilter"),
       jetCorrector = cms.string("ak4PFL2L3"),
+=======
+      src    = cms.InputTag("ak4PFJetsCHS"),
+      jetCorrector = cms.string("ak5PFL2L3"),
+>>>>>>> 754cc1b... fix btagging in DQMOffline/Trigger, only partially moving to ak4 because of btagging
       select = cms.string("pt>30. & abs(eta)<2.5"),
       min = cms.int32(2),
     ),
@@ -410,7 +425,7 @@ ElecMuonHLTOfflineDQM = cms.EDAnalyzer("TopDiLeptonHLTOfflineDQM",
     sources = cms.PSet(
       muons = cms.InputTag("muons"),
       elecs = cms.InputTag("gedGsfElectrons"),
-      jets  = cms.InputTag("PFJetsFilter"),
+      jets  = cms.InputTag("ak4PFJetsCHS"),
       mets  = cms.VInputTag("met", "tcMet", "pfMet")
     ),
     ## [optional] : when omitted all monitoring plots for electrons
@@ -527,8 +542,13 @@ ElecMuonHLTOfflineDQM = cms.EDAnalyzer("TopDiLeptonHLTOfflineDQM",
     ),
     cms.PSet(
       label  = cms.string("jets/pf:step3"),
+<<<<<<< HEAD
       src    = cms.InputTag("PFJetsFilter"),
       jetCorrector = cms.string("ak4PFL2L3"),
+=======
+      src    = cms.InputTag("ak4PFJetsCHS"),
+      jetCorrector = cms.string("ak5PFL2L3"),
+>>>>>>> 754cc1b... fix btagging in DQMOffline/Trigger, only partially moving to ak4 because of btagging
       select = cms.string("pt>30. & abs(eta)<2.5"),
       min = cms.int32(2),
     ),

--- a/DQMOffline/Trigger/python/topDiLeptonHLTEventDQM_cfi.py
+++ b/DQMOffline/Trigger/python/topDiLeptonHLTEventDQM_cfi.py
@@ -47,7 +47,7 @@ topDiLeptonHLTOfflineDQM = cms.EDAnalyzer("TopDiLeptonHLTOfflineDQM",
     jetExtras = cms.PSet(
       ## when omitted monitor plots for pt will be filled from uncorrected
       ## jets    
-      jetCorrector = cms.string("ak5PFL2L3"),
+      jetCorrector = cms.string("ak4PFL1L2L3"),
       ## when omitted no extra selection will be applied on jets before
       ## filling the monitor histograms; if jetCorrector is present the
       ## selection will be applied to corrected jets
@@ -117,7 +117,7 @@ topDiLeptonHLTOfflineDQM = cms.EDAnalyzer("TopDiLeptonHLTOfflineDQM",
     cms.PSet(
       label  = cms.string("jets/pf:step1"),
       src    = cms.InputTag("ak4PFJetsCHS"),
-      jetCorrector = cms.string("ak5PFL2L3"),
+      jetCorrector = cms.string("ak4PFL1L2L3"),
       select = cms.string("pt>30. & abs(eta)<2.5"),
       min = cms.int32(2),
     )
@@ -173,7 +173,7 @@ DiMuonHLTOfflineDQM = cms.EDAnalyzer("TopDiLeptonHLTOfflineDQM",
     jetExtras = cms.PSet(
       ## when omitted monitor plots for pt will be filled from uncorrected
       ## jets    
-      jetCorrector = cms.string("ak5PFL2L3"),
+      jetCorrector = cms.string("ak4PFL1L2L3"),
       ## when omitted no extra selection will be applied on jets before
       ## filling the monitor histograms; if jetCorrector is present the
       ## selection will be applied to corrected jets
@@ -252,7 +252,7 @@ DiMuonHLTOfflineDQM = cms.EDAnalyzer("TopDiLeptonHLTOfflineDQM",
     cms.PSet(
       label  = cms.string("jets/pf:step2"),
       src    = cms.InputTag("ak4PFJetsCHS"),
-      jetCorrector = cms.string("ak5PFL2L3"),
+      jetCorrector = cms.string("ak4PFL1L2L3"),
       select = cms.string("pt>30. & abs(eta)<2.5"),
       min = cms.int32(2),
     ),
@@ -306,7 +306,7 @@ DiElectronHLTOfflineDQM = cms.EDAnalyzer("TopDiLeptonHLTOfflineDQM",
     jetExtras = cms.PSet(
       ## when omitted monitor plots for pt will be filled from uncorrected
       ## jets    
-      jetCorrector = cms.string("ak5PFL2L3"),
+      jetCorrector = cms.string("ak4PFL1L2L3"),
       ## when omitted no extra selection will be applied on jets before
       ## filling the monitor histograms; if jetCorrector is present the
       ## selection will be applied to corrected jets
@@ -386,7 +386,7 @@ DiElectronHLTOfflineDQM = cms.EDAnalyzer("TopDiLeptonHLTOfflineDQM",
     cms.PSet(
       label  = cms.string("jets/pf:step2"),
       src    = cms.InputTag("ak4PFJetsCHS"),
-      jetCorrector = cms.string("ak5PFL2L3"),
+      jetCorrector = cms.string("ak4PFL1L2L3"),
       select = cms.string("pt>30. & abs(eta)<2.5"),
       min = cms.int32(2),
     ),
@@ -440,7 +440,7 @@ ElecMuonHLTOfflineDQM = cms.EDAnalyzer("TopDiLeptonHLTOfflineDQM",
     jetExtras = cms.PSet(
       ## when omitted monitor plots for pt will be filled from uncorrected
       ## jets    
-      jetCorrector = cms.string("ak5PFL2L3"),
+      jetCorrector = cms.string("ak4PFL1L2L3"),
       ## when omitted no extra selection will be applied on jets before
       ## filling the monitor histograms; if jetCorrector is present the
       ## selection will be applied to corrected jets
@@ -528,7 +528,7 @@ ElecMuonHLTOfflineDQM = cms.EDAnalyzer("TopDiLeptonHLTOfflineDQM",
     cms.PSet(
       label  = cms.string("jets/pf:step3"),
       src    = cms.InputTag("ak4PFJetsCHS"),
-      jetCorrector = cms.string("ak5PFL2L3"),
+      jetCorrector = cms.string("ak4PFL1L2L3"),
       select = cms.string("pt>30. & abs(eta)<2.5"),
       min = cms.int32(2),
     ),

--- a/DQMOffline/Trigger/python/topDiLeptonHLTEventDQM_cfi.py
+++ b/DQMOffline/Trigger/python/topDiLeptonHLTEventDQM_cfi.py
@@ -11,7 +11,7 @@ topDiLeptonHLTOfflineDQM = cms.EDAnalyzer("TopDiLeptonHLTOfflineDQM",
     ## sub-directory to write the monitor histograms to
     ## [mandatory] : should not be changed w/o explicit 
     ## communication to TopCom!
-    directory = cms.string("HLTriggerOffline/Top/DiLeptonic/"),
+    directory = cms.string("HLT/TopHLTOffline/Top/DiLeptonic/"),
 
     ## [mandatory]
     sources = cms.PSet(
@@ -137,7 +137,7 @@ DiMuonHLTOfflineDQM = cms.EDAnalyzer("TopDiLeptonHLTOfflineDQM",
     ## sub-directory to write the monitor histograms to
     ## [mandatory] : should not be changed w/o explicit 
     ## communication to TopCom!
-    directory = cms.string("HLTriggerOffline/Top/DiMuon/"),
+    directory = cms.string("HLT/TopHLTOffline/Top/DiMuon/"),
 
     ## [mandatory]
     sources = cms.PSet(
@@ -270,7 +270,7 @@ DiElectronHLTOfflineDQM = cms.EDAnalyzer("TopDiLeptonHLTOfflineDQM",
     ## sub-directory to write the monitor histograms to
     ## [mandatory] : should not be changed w/o explicit 
     ## communication to TopCom!
-    directory = cms.string("HLTriggerOffline/Top/DiElectron/"),
+    directory = cms.string("HLT/TopHLTOffline/Top/DiElectron/"),
 
     ## [mandatory]
     sources = cms.PSet(
@@ -404,7 +404,7 @@ ElecMuonHLTOfflineDQM = cms.EDAnalyzer("TopDiLeptonHLTOfflineDQM",
     ## sub-directory to write the monitor histograms to
     ## [mandatory] : should not be changed w/o explicit 
     ## communication to TopCom!
-    directory = cms.string("HLTriggerOffline/Top/ElecMuon/"),
+    directory = cms.string("HLT/TopHLTOffline/Top/ElecMuon/"),
 
     ## [mandatory]
     sources = cms.PSet(

--- a/DQMOffline/Trigger/python/topDiLeptonHLTEventDQM_cfi.py
+++ b/DQMOffline/Trigger/python/topDiLeptonHLTEventDQM_cfi.py
@@ -47,7 +47,7 @@ topDiLeptonHLTOfflineDQM = cms.EDAnalyzer("TopDiLeptonHLTOfflineDQM",
     jetExtras = cms.PSet(
       ## when omitted monitor plots for pt will be filled from uncorrected
       ## jets    
-      jetCorrector = cms.string("ak4PFL2L3"),
+      jetCorrector = cms.string("ak5PFL2L3"),
       ## when omitted no extra selection will be applied on jets before
       ## filling the monitor histograms; if jetCorrector is present the
       ## selection will be applied to corrected jets
@@ -173,7 +173,7 @@ DiMuonHLTOfflineDQM = cms.EDAnalyzer("TopDiLeptonHLTOfflineDQM",
     jetExtras = cms.PSet(
       ## when omitted monitor plots for pt will be filled from uncorrected
       ## jets    
-      jetCorrector = cms.string("ak4PFL2L3"),
+      jetCorrector = cms.string("ak5PFL2L3"),
       ## when omitted no extra selection will be applied on jets before
       ## filling the monitor histograms; if jetCorrector is present the
       ## selection will be applied to corrected jets
@@ -306,7 +306,7 @@ DiElectronHLTOfflineDQM = cms.EDAnalyzer("TopDiLeptonHLTOfflineDQM",
     jetExtras = cms.PSet(
       ## when omitted monitor plots for pt will be filled from uncorrected
       ## jets    
-      jetCorrector = cms.string("ak4PFL2L3"),
+      jetCorrector = cms.string("ak5PFL2L3"),
       ## when omitted no extra selection will be applied on jets before
       ## filling the monitor histograms; if jetCorrector is present the
       ## selection will be applied to corrected jets
@@ -440,7 +440,7 @@ ElecMuonHLTOfflineDQM = cms.EDAnalyzer("TopDiLeptonHLTOfflineDQM",
     jetExtras = cms.PSet(
       ## when omitted monitor plots for pt will be filled from uncorrected
       ## jets    
-      jetCorrector = cms.string("ak4PFL2L3"),
+      jetCorrector = cms.string("ak5PFL2L3"),
       ## when omitted no extra selection will be applied on jets before
       ## filling the monitor histograms; if jetCorrector is present the
       ## selection will be applied to corrected jets

--- a/DQMOffline/Trigger/python/topSingleLeptonHLTEventDQM_cfi.py
+++ b/DQMOffline/Trigger/python/topSingleLeptonHLTEventDQM_cfi.py
@@ -11,7 +11,7 @@ topSingleLeptonHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM",
     ## sub-directory to write the monitor histograms to
     ## [mandatory] : should not be changed w/o explicit 
     ## communication to TopCom!
-    directory = cms.string("HLTriggerOffline/Top/SemiLeptonic/"),
+    directory = cms.string("HLT/TopHLTOffline/Top/SemiLeptonic/"),
     ## [mandatory]
     sources = cms.PSet(
       muons = cms.InputTag("muons"),
@@ -131,7 +131,7 @@ topSingleMuonHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM",
     ## sub-directory to write the monitor histograms to
     ## [mandatory] : should not be changed w/o explicit
     ## communication to TopCom!
-    directory = cms.string("HLTriggerOffline/Top/SemiMuonic/"),
+    directory = cms.string("HLT/TopHLTOffline/Top/SemiMuonic/"),
     ## [mandatory]
     sources = cms.PSet(
       muons = cms.InputTag("muons"),
@@ -281,7 +281,7 @@ topSingleElectronHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM",
     ## sub-directory to write the monitor histograms to
     ## [mandatory] : should not be changed w/o explicit
     ## communication to TopCom!
-    directory = cms.string("HLTriggerOffline/Top/SemiElectronic/"),
+    directory = cms.string("HLT/TopHLTOffline/Top/SemiElectronic/"),
     ## [mandatory]
     sources = cms.PSet(
       muons = cms.InputTag("muons"),

--- a/DQMOffline/Trigger/python/topSingleLeptonHLTEventDQM_cfi.py
+++ b/DQMOffline/Trigger/python/topSingleLeptonHLTEventDQM_cfi.py
@@ -240,62 +240,30 @@ topSingleMuonHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM",
     ),
 #    cms.PSet(
 #      label  = cms.string("jets/pf:step2"),
-<<<<<<< HEAD
-<<<<<<< HEAD
-#      src  = cms.InputTag("PFJetsFilter"),
-#      jetCorrector = cms.string("ak4PFL2L3"),
-=======
-=======
->>>>>>> 754cc1beaedd51b84ec7d650a47a4981cdabdb1b
 #      src  = cms.InputTag("ak5PFJetsCHS"),
 #      jetCorrector = cms.string("ak5PFL2L3"),
->>>>>>> 754cc1b... fix btagging in DQMOffline/Trigger, only partially moving to ak4 because of btagging
 #      select = cms.string("pt>20 & abs(eta)<2.5"),
 #      min = cms.int32(1),                                                
 #    ), 
 #    cms.PSet(
 #      label  = cms.string("jets/pf:step3"),
-<<<<<<< HEAD
-<<<<<<< HEAD
-#      src  = cms.InputTag("PFJetsFilter"),
-#      jetCorrector = cms.string("ak4PFL2L3"),
-=======
-=======
->>>>>>> 754cc1beaedd51b84ec7d650a47a4981cdabdb1b
 #      src  = cms.InputTag("ak5PFJetsCHS"),
 #      jetCorrector = cms.string("ak5PFL2L3"),
->>>>>>> 754cc1b... fix btagging in DQMOffline/Trigger, only partially moving to ak4 because of btagging
 #      select = cms.string("pt>20 & abs(eta)<2.5"),
 #      min = cms.int32(2),                                                
 #    ), 
 #    cms.PSet(
 #      label  = cms.string("jets/pf:step4"),
-<<<<<<< HEAD
-<<<<<<< HEAD
-#      src  = cms.InputTag("PFJetsFilter"),
-#      jetCorrector = cms.string("ak4PFL2L3"),
-=======
-=======
->>>>>>> 754cc1beaedd51b84ec7d650a47a4981cdabdb1b
 #      src  = cms.InputTag("ak5PFJetsCHS"),
 #      jetCorrector = cms.string("ak5PFL2L3"),
->>>>>>> 754cc1b... fix btagging in DQMOffline/Trigger, only partially moving to ak4 because of btagging
 #      select = cms.string("pt>20 & abs(eta)<2.5"),
 #      min = cms.int32(3),                                                
 #    ), 
     cms.PSet(
 #      label  = cms.string("jets/pf:step5"),
       label  = cms.string("jets/pf:step2"),
-<<<<<<< HEAD
-<<<<<<< HEAD
-      src  = cms.InputTag("PFJetsFilter"),
-      jetCorrector = cms.string("ak4PFL2L3"),
-=======
-=======
->>>>>>> 754cc1beaedd51b84ec7d650a47a4981cdabdb1b
       src  = cms.InputTag("ak5PFJetsCHS"),
       jetCorrector = cms.string("ak5PFL2L3"),
->>>>>>> 754cc1b... fix btagging in DQMOffline/Trigger, only partially moving to ak4 because of btagging
       select = cms.string("pt>20 & abs(eta)<2.5"),
       min = cms.int32(4),                                                
     ),
@@ -425,62 +393,30 @@ topSingleElectronHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM",
     ),
 #    cms.PSet(
 #      label  = cms.string("jets/pf:step2"),
-<<<<<<< HEAD
-<<<<<<< HEAD
-#      src  = cms.InputTag("PFJetsFilter"),
-#      jetCorrector = cms.string("ak4PFL2L3"),
-=======
-=======
->>>>>>> 754cc1beaedd51b84ec7d650a47a4981cdabdb1b
 #      src  = cms.InputTag("ak5PFJetsCHS"),
 #      jetCorrector = cms.string("ak5PFL2L3"),
->>>>>>> 754cc1b... fix btagging in DQMOffline/Trigger, only partially moving to ak4 because of btagging
 #      select = cms.string("pt>20 & abs(eta)<2.5"),
 #      min = cms.int32(1),                                                
 #    ), 
 #    cms.PSet(
 #      label  = cms.string("jets/pf:step3"),
-<<<<<<< HEAD
-<<<<<<< HEAD
-#      src  = cms.InputTag("PFJetsFilter"),
-#      jetCorrector = cms.string("ak4PFL2L3"),
-=======
-=======
->>>>>>> 754cc1beaedd51b84ec7d650a47a4981cdabdb1b
 #      src  = cms.InputTag("ak5PFJetsCHS"),
 #      jetCorrector = cms.string("ak5PFL2L3"),
->>>>>>> 754cc1b... fix btagging in DQMOffline/Trigger, only partially moving to ak4 because of btagging
 #      select = cms.string("pt>20 & abs(eta)<2.5"),
 #      min = cms.int32(2),                                                
 #    ), 
 #    cms.PSet(
 #      label  = cms.string("jets/pf:step4"),
-<<<<<<< HEAD
-<<<<<<< HEAD
-#      src  = cms.InputTag("PFJetsFilter"),
-#      jetCorrector = cms.string("ak4PFL2L3"),
-=======
-=======
->>>>>>> 754cc1beaedd51b84ec7d650a47a4981cdabdb1b
 #      src  = cms.InputTag("ak5PFJetsCHS"),
 #      jetCorrector = cms.string("ak5PFL2L3"),
->>>>>>> 754cc1b... fix btagging in DQMOffline/Trigger, only partially moving to ak4 because of btagging
 #      select = cms.string("pt>20 & abs(eta)<2.5"),
 #      min = cms.int32(3),                                                
 #    ), 
     cms.PSet(
 #      label  = cms.string("jets/pf:step5"),
       label  = cms.string("jets/pf:step2"),
-<<<<<<< HEAD
-<<<<<<< HEAD
-      src  = cms.InputTag("PFJetsFilter"),
-      jetCorrector = cms.string("ak4PFL2L3"),
-=======
-=======
->>>>>>> 754cc1beaedd51b84ec7d650a47a4981cdabdb1b
       src  = cms.InputTag("ak5PFJetsCHS"),
       jetCorrector = cms.string("ak5PFL2L3"),
->>>>>>> 754cc1b... fix btagging in DQMOffline/Trigger, only partially moving to ak4 because of btagging
       select = cms.string("pt>20 & abs(eta)<2.5"),
       min = cms.int32(4),                                                
     ),

--- a/DQMOffline/Trigger/python/topSingleLeptonHLTEventDQM_cfi.py
+++ b/DQMOffline/Trigger/python/topSingleLeptonHLTEventDQM_cfi.py
@@ -54,7 +54,7 @@ topSingleLeptonHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM",
     jetExtras = cms.PSet(
       ## when omitted monitor plots for pt will be filled from uncorrected
       ## jets                                            
-      jetCorrector = cms.string("ak4PFL2L3"),
+      jetCorrector = cms.string("ak5PFL2L3"),
       ## when omitted no extra selection will be applied on jets before
       ## filling the monitor histograms; if jetCorrector is present the
       ## selection will be applied to corrected jets
@@ -163,7 +163,7 @@ topSingleMuonHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM",
     jetExtras = cms.PSet(
       ## when omitted monitor plots for pt will be filled from uncorrected
       ## jets
-      jetCorrector = cms.string("ak4PFL2L3"),
+      jetCorrector = cms.string("ak5PFL2L3"),
       ## when omitted no extra selection will be applied on jets before
       ## filling the monitor histograms; if jetCorrector is present the
       ## selection will be applied to corrected jets                                                
@@ -315,7 +315,7 @@ topSingleElectronHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM",
     jetExtras = cms.PSet(
       ## when omitted monitor plots for pt will be filled from uncorrected
       ## jets
-      jetCorrector = cms.string("ak4PFL2L3"),
+      jetCorrector = cms.string("ak5PFL2L3"),
       ## when omitted no extra selection will be applied on jets before
       ## filling the monitor histograms; if jetCorrector is present the
       ## selection will be applied to corrected jets 

--- a/DQMOffline/Trigger/python/topSingleLeptonHLTEventDQM_cfi.py
+++ b/DQMOffline/Trigger/python/topSingleLeptonHLTEventDQM_cfi.py
@@ -16,7 +16,7 @@ topSingleLeptonHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM",
     sources = cms.PSet(
       muons = cms.InputTag("muons"),
       elecs = cms.InputTag("gedGsfElectrons"),
-      jets  = cms.InputTag("PFJetsFilter"),
+      jets  = cms.InputTag("ak5PFJetsCHS"),
       mets  = cms.VInputTag("met", "tcMet", "pfMet"),
       pvs   = cms.InputTag("offlinePrimaryVertices")
     ),
@@ -113,7 +113,7 @@ topSingleLeptonHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM",
     ),
     cms.PSet(
       label  = cms.string("jets/pf:step1"),
-      src  = cms.InputTag("PFJetsFilter"),
+      src  = cms.InputTag("ak5PFJetsCHS"),
       select = cms.string("pt>20 & abs(eta)<2.5"),
       min = cms.int32(4),
     ),
@@ -136,7 +136,7 @@ topSingleMuonHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM",
     sources = cms.PSet(
       muons = cms.InputTag("muons"),
       elecs = cms.InputTag("gedGsfElectrons"),
-      jets  = cms.InputTag("PFJetsFilter"),
+      jets  = cms.InputTag("ak5PFJetsCHS"),
       mets  = cms.VInputTag("met", "tcMet", "pfMet"),
       pvs   = cms.InputTag("offlinePrimaryVertices")
 
@@ -171,15 +171,15 @@ topSingleMuonHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM",
       ## when omitted monitor histograms for b-tagging will not be filled
       jetBTaggers  = cms.PSet(
          trackCountingEff = cms.PSet(
-           label = cms.InputTag("pfJetProbabilityBJetTags" ),
+           label = cms.InputTag("jetProbabilityBJetTags" ),
            workingPoint = cms.double(0.275)
          ),
          trackCountingPur = cms.PSet(
-           label = cms.InputTag("pfTrackCountingHighPurBJetTags" ),
+           label = cms.InputTag("trackCountingHighPurBJetTags" ),
            workingPoint = cms.double(3.41)
          ),
          secondaryVertex  = cms.PSet(
-           label = cms.InputTag("pfCombinedSecondaryVertexBJetTags"),
+           label = cms.InputTag("combinedSecondaryVertexBJetTags"),
            workingPoint = cms.double(0.679)
          )
        ),
@@ -240,21 +240,21 @@ topSingleMuonHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM",
     ),
 #    cms.PSet(
 #      label  = cms.string("jets/pf:step2"),
-#      src  = cms.InputTag("PFJetsFilter"),
+#      src  = cms.InputTag("ak5PFJetsCHS"),
 #      jetCorrector = cms.string("ak5PFL2L3"),
 #      select = cms.string("pt>20 & abs(eta)<2.5"),
 #      min = cms.int32(1),                                                
 #    ), 
 #    cms.PSet(
 #      label  = cms.string("jets/pf:step3"),
-#      src  = cms.InputTag("PFJetsFilter"),
+#      src  = cms.InputTag("ak5PFJetsCHS"),
 #      jetCorrector = cms.string("ak5PFL2L3"),
 #      select = cms.string("pt>20 & abs(eta)<2.5"),
 #      min = cms.int32(2),                                                
 #    ), 
 #    cms.PSet(
 #      label  = cms.string("jets/pf:step4"),
-#      src  = cms.InputTag("PFJetsFilter"),
+#      src  = cms.InputTag("ak5PFJetsCHS"),
 #      jetCorrector = cms.string("ak5PFL2L3"),
 #      select = cms.string("pt>20 & abs(eta)<2.5"),
 #      min = cms.int32(3),                                                
@@ -262,7 +262,7 @@ topSingleMuonHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM",
     cms.PSet(
 #      label  = cms.string("jets/pf:step5"),
       label  = cms.string("jets/pf:step2"),
-      src  = cms.InputTag("PFJetsFilter"),
+      src  = cms.InputTag("ak5PFJetsCHS"),
       jetCorrector = cms.string("ak5PFL2L3"),
       select = cms.string("pt>20 & abs(eta)<2.5"),
       min = cms.int32(4),                                                
@@ -286,7 +286,7 @@ topSingleElectronHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM",
     sources = cms.PSet(
       muons = cms.InputTag("muons"),
       elecs = cms.InputTag("gedGsfElectrons"),
-      jets  = cms.InputTag("PFJetsFilter"),
+      jets  = cms.InputTag("ak5PFJetsCHS"),
       mets  = cms.VInputTag("met", "tcMet", "pfMet"),
       pvs   = cms.InputTag("offlinePrimaryVertices")
 
@@ -323,15 +323,15 @@ topSingleElectronHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM",
       ## when omitted monitor histograms for b-tagging will not be filled
       jetBTaggers  = cms.PSet(
          trackCountingEff = cms.PSet(
-           label = cms.InputTag("pfJetProbabilityBJetTags" ),
+           label = cms.InputTag("jetProbabilityBJetTags" ),
            workingPoint = cms.double(0.275)
          ),
          trackCountingPur = cms.PSet(
-           label = cms.InputTag("pfTrackCountingHighPurBJetTags" ),
+           label = cms.InputTag("trackCountingHighPurBJetTags" ),
            workingPoint = cms.double(3.41)
          ),
          secondaryVertex  = cms.PSet(
-           label = cms.InputTag("pfCombinedSecondaryVertexBJetTags"),
+           label = cms.InputTag("combinedSecondaryVertexBJetTags"),
            workingPoint = cms.double(0.679)
          )
        ),
@@ -393,21 +393,21 @@ topSingleElectronHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM",
     ),
 #    cms.PSet(
 #      label  = cms.string("jets/pf:step2"),
-#      src  = cms.InputTag("PFJetsFilter"),
+#      src  = cms.InputTag("ak5PFJetsCHS"),
 #      jetCorrector = cms.string("ak5PFL2L3"),
 #      select = cms.string("pt>20 & abs(eta)<2.5"),
 #      min = cms.int32(1),                                                
 #    ), 
 #    cms.PSet(
 #      label  = cms.string("jets/pf:step3"),
-#      src  = cms.InputTag("PFJetsFilter"),
+#      src  = cms.InputTag("ak5PFJetsCHS"),
 #      jetCorrector = cms.string("ak5PFL2L3"),
 #      select = cms.string("pt>20 & abs(eta)<2.5"),
 #      min = cms.int32(2),                                                
 #    ), 
 #    cms.PSet(
 #      label  = cms.string("jets/pf:step4"),
-#      src  = cms.InputTag("PFJetsFilter"),
+#      src  = cms.InputTag("ak5PFJetsCHS"),
 #      jetCorrector = cms.string("ak5PFL2L3"),
 #      select = cms.string("pt>20 & abs(eta)<2.5"),
 #      min = cms.int32(3),                                                
@@ -415,7 +415,7 @@ topSingleElectronHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM",
     cms.PSet(
 #      label  = cms.string("jets/pf:step5"),
       label  = cms.string("jets/pf:step2"),
-      src  = cms.InputTag("PFJetsFilter"),
+      src  = cms.InputTag("ak5PFJetsCHS"),
       jetCorrector = cms.string("ak5PFL2L3"),
       select = cms.string("pt>20 & abs(eta)<2.5"),
       min = cms.int32(4),                                                

--- a/DQMOffline/Trigger/python/topSingleLeptonHLTEventDQM_cfi.py
+++ b/DQMOffline/Trigger/python/topSingleLeptonHLTEventDQM_cfi.py
@@ -54,7 +54,7 @@ topSingleLeptonHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM",
     jetExtras = cms.PSet(
       ## when omitted monitor plots for pt will be filled from uncorrected
       ## jets                                            
-      jetCorrector = cms.string("ak5PFL2L3"),
+      jetCorrector = cms.string("ak4PFL1L2L3"),
       ## when omitted no extra selection will be applied on jets before
       ## filling the monitor histograms; if jetCorrector is present the
       ## selection will be applied to corrected jets
@@ -163,7 +163,7 @@ topSingleMuonHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM",
     jetExtras = cms.PSet(
       ## when omitted monitor plots for pt will be filled from uncorrected
       ## jets
-      jetCorrector = cms.string("ak5PFL2L3"),
+      jetCorrector = cms.string("ak4PFL1L2L3"),
       ## when omitted no extra selection will be applied on jets before
       ## filling the monitor histograms; if jetCorrector is present the
       ## selection will be applied to corrected jets                                                
@@ -241,21 +241,21 @@ topSingleMuonHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM",
 #    cms.PSet(
 #      label  = cms.string("jets/pf:step2"),
 #      src  = cms.InputTag("ak5PFJetsCHS"),
-#      jetCorrector = cms.string("ak5PFL2L3"),
+#      jetCorrector = cms.string("ak4PFL1L2L3"),
 #      select = cms.string("pt>20 & abs(eta)<2.5"),
 #      min = cms.int32(1),                                                
 #    ), 
 #    cms.PSet(
 #      label  = cms.string("jets/pf:step3"),
 #      src  = cms.InputTag("ak5PFJetsCHS"),
-#      jetCorrector = cms.string("ak5PFL2L3"),
+#      jetCorrector = cms.string("ak4PFL1L2L3"),
 #      select = cms.string("pt>20 & abs(eta)<2.5"),
 #      min = cms.int32(2),                                                
 #    ), 
 #    cms.PSet(
 #      label  = cms.string("jets/pf:step4"),
 #      src  = cms.InputTag("ak5PFJetsCHS"),
-#      jetCorrector = cms.string("ak5PFL2L3"),
+#      jetCorrector = cms.string("ak4PFL1L2L3"),
 #      select = cms.string("pt>20 & abs(eta)<2.5"),
 #      min = cms.int32(3),                                                
 #    ), 
@@ -263,7 +263,7 @@ topSingleMuonHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM",
 #      label  = cms.string("jets/pf:step5"),
       label  = cms.string("jets/pf:step2"),
       src  = cms.InputTag("ak5PFJetsCHS"),
-      jetCorrector = cms.string("ak5PFL2L3"),
+      jetCorrector = cms.string("ak4PFL1L2L3"),
       select = cms.string("pt>20 & abs(eta)<2.5"),
       min = cms.int32(4),                                                
     ),
@@ -315,7 +315,7 @@ topSingleElectronHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM",
     jetExtras = cms.PSet(
       ## when omitted monitor plots for pt will be filled from uncorrected
       ## jets
-      jetCorrector = cms.string("ak5PFL2L3"),
+      jetCorrector = cms.string("ak4PFL1L2L3"),
       ## when omitted no extra selection will be applied on jets before
       ## filling the monitor histograms; if jetCorrector is present the
       ## selection will be applied to corrected jets 
@@ -394,21 +394,21 @@ topSingleElectronHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM",
 #    cms.PSet(
 #      label  = cms.string("jets/pf:step2"),
 #      src  = cms.InputTag("ak5PFJetsCHS"),
-#      jetCorrector = cms.string("ak5PFL2L3"),
+#      jetCorrector = cms.string("ak4PFL1L2L3"),
 #      select = cms.string("pt>20 & abs(eta)<2.5"),
 #      min = cms.int32(1),                                                
 #    ), 
 #    cms.PSet(
 #      label  = cms.string("jets/pf:step3"),
 #      src  = cms.InputTag("ak5PFJetsCHS"),
-#      jetCorrector = cms.string("ak5PFL2L3"),
+#      jetCorrector = cms.string("ak4PFL1L2L3"),
 #      select = cms.string("pt>20 & abs(eta)<2.5"),
 #      min = cms.int32(2),                                                
 #    ), 
 #    cms.PSet(
 #      label  = cms.string("jets/pf:step4"),
 #      src  = cms.InputTag("ak5PFJetsCHS"),
-#      jetCorrector = cms.string("ak5PFL2L3"),
+#      jetCorrector = cms.string("ak4PFL1L2L3"),
 #      select = cms.string("pt>20 & abs(eta)<2.5"),
 #      min = cms.int32(3),                                                
 #    ), 
@@ -416,7 +416,7 @@ topSingleElectronHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM",
 #      label  = cms.string("jets/pf:step5"),
       label  = cms.string("jets/pf:step2"),
       src  = cms.InputTag("ak5PFJetsCHS"),
-      jetCorrector = cms.string("ak5PFL2L3"),
+      jetCorrector = cms.string("ak4PFL1L2L3"),
       select = cms.string("pt>20 & abs(eta)<2.5"),
       min = cms.int32(4),                                                
     ),

--- a/DQMOffline/Trigger/python/topSingleLeptonHLTEventDQM_cfi.py
+++ b/DQMOffline/Trigger/python/topSingleLeptonHLTEventDQM_cfi.py
@@ -16,7 +16,7 @@ topSingleLeptonHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM",
     sources = cms.PSet(
       muons = cms.InputTag("muons"),
       elecs = cms.InputTag("gedGsfElectrons"),
-      jets  = cms.InputTag("PFJetsFilter"),
+      jets  = cms.InputTag("ak5PFJetsCHS"),
       mets  = cms.VInputTag("met", "tcMet", "pfMet"),
       pvs   = cms.InputTag("offlinePrimaryVertices")
     ),
@@ -113,7 +113,7 @@ topSingleLeptonHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM",
     ),
     cms.PSet(
       label  = cms.string("jets/pf:step1"),
-      src  = cms.InputTag("PFJetsFilter"),
+      src  = cms.InputTag("ak5PFJetsCHS"),
       select = cms.string("pt>20 & abs(eta)<2.5"),
       min = cms.int32(4),
     ),
@@ -136,7 +136,7 @@ topSingleMuonHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM",
     sources = cms.PSet(
       muons = cms.InputTag("muons"),
       elecs = cms.InputTag("gedGsfElectrons"),
-      jets  = cms.InputTag("PFJetsFilter"),
+      jets  = cms.InputTag("ak5PFJetsCHS"),
       mets  = cms.VInputTag("met", "tcMet", "pfMet"),
       pvs   = cms.InputTag("offlinePrimaryVertices")
 
@@ -171,15 +171,15 @@ topSingleMuonHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM",
       ## when omitted monitor histograms for b-tagging will not be filled
       jetBTaggers  = cms.PSet(
          trackCountingEff = cms.PSet(
-           label = cms.InputTag("pfJetProbabilityBJetTags" ),
+           label = cms.InputTag("jetProbabilityBJetTags" ),
            workingPoint = cms.double(0.275)
          ),
          trackCountingPur = cms.PSet(
-           label = cms.InputTag("pfTrackCountingHighPurBJetTags" ),
+           label = cms.InputTag("trackCountingHighPurBJetTags" ),
            workingPoint = cms.double(3.41)
          ),
          secondaryVertex  = cms.PSet(
-           label = cms.InputTag("pfCombinedSecondaryVertexBJetTags"),
+           label = cms.InputTag("combinedSecondaryVertexBJetTags"),
            workingPoint = cms.double(0.679)
          )
        ),
@@ -240,30 +240,50 @@ topSingleMuonHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM",
     ),
 #    cms.PSet(
 #      label  = cms.string("jets/pf:step2"),
+<<<<<<< HEAD
 #      src  = cms.InputTag("PFJetsFilter"),
 #      jetCorrector = cms.string("ak4PFL2L3"),
+=======
+#      src  = cms.InputTag("ak5PFJetsCHS"),
+#      jetCorrector = cms.string("ak5PFL2L3"),
+>>>>>>> 754cc1b... fix btagging in DQMOffline/Trigger, only partially moving to ak4 because of btagging
 #      select = cms.string("pt>20 & abs(eta)<2.5"),
 #      min = cms.int32(1),                                                
 #    ), 
 #    cms.PSet(
 #      label  = cms.string("jets/pf:step3"),
+<<<<<<< HEAD
 #      src  = cms.InputTag("PFJetsFilter"),
 #      jetCorrector = cms.string("ak4PFL2L3"),
+=======
+#      src  = cms.InputTag("ak5PFJetsCHS"),
+#      jetCorrector = cms.string("ak5PFL2L3"),
+>>>>>>> 754cc1b... fix btagging in DQMOffline/Trigger, only partially moving to ak4 because of btagging
 #      select = cms.string("pt>20 & abs(eta)<2.5"),
 #      min = cms.int32(2),                                                
 #    ), 
 #    cms.PSet(
 #      label  = cms.string("jets/pf:step4"),
+<<<<<<< HEAD
 #      src  = cms.InputTag("PFJetsFilter"),
 #      jetCorrector = cms.string("ak4PFL2L3"),
+=======
+#      src  = cms.InputTag("ak5PFJetsCHS"),
+#      jetCorrector = cms.string("ak5PFL2L3"),
+>>>>>>> 754cc1b... fix btagging in DQMOffline/Trigger, only partially moving to ak4 because of btagging
 #      select = cms.string("pt>20 & abs(eta)<2.5"),
 #      min = cms.int32(3),                                                
 #    ), 
     cms.PSet(
 #      label  = cms.string("jets/pf:step5"),
       label  = cms.string("jets/pf:step2"),
+<<<<<<< HEAD
       src  = cms.InputTag("PFJetsFilter"),
       jetCorrector = cms.string("ak4PFL2L3"),
+=======
+      src  = cms.InputTag("ak5PFJetsCHS"),
+      jetCorrector = cms.string("ak5PFL2L3"),
+>>>>>>> 754cc1b... fix btagging in DQMOffline/Trigger, only partially moving to ak4 because of btagging
       select = cms.string("pt>20 & abs(eta)<2.5"),
       min = cms.int32(4),                                                
     ),
@@ -286,7 +306,7 @@ topSingleElectronHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM",
     sources = cms.PSet(
       muons = cms.InputTag("muons"),
       elecs = cms.InputTag("gedGsfElectrons"),
-      jets  = cms.InputTag("PFJetsFilter"),
+      jets  = cms.InputTag("ak5PFJetsCHS"),
       mets  = cms.VInputTag("met", "tcMet", "pfMet"),
       pvs   = cms.InputTag("offlinePrimaryVertices")
 
@@ -323,15 +343,15 @@ topSingleElectronHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM",
       ## when omitted monitor histograms for b-tagging will not be filled
       jetBTaggers  = cms.PSet(
          trackCountingEff = cms.PSet(
-           label = cms.InputTag("pfJetProbabilityBJetTags" ),
+           label = cms.InputTag("jetProbabilityBJetTags" ),
            workingPoint = cms.double(0.275)
          ),
          trackCountingPur = cms.PSet(
-           label = cms.InputTag("pfTrackCountingHighPurBJetTags" ),
+           label = cms.InputTag("trackCountingHighPurBJetTags" ),
            workingPoint = cms.double(3.41)
          ),
          secondaryVertex  = cms.PSet(
-           label = cms.InputTag("pfCombinedSecondaryVertexBJetTags"),
+           label = cms.InputTag("combinedSecondaryVertexBJetTags"),
            workingPoint = cms.double(0.679)
          )
        ),
@@ -393,30 +413,50 @@ topSingleElectronHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM",
     ),
 #    cms.PSet(
 #      label  = cms.string("jets/pf:step2"),
+<<<<<<< HEAD
 #      src  = cms.InputTag("PFJetsFilter"),
 #      jetCorrector = cms.string("ak4PFL2L3"),
+=======
+#      src  = cms.InputTag("ak5PFJetsCHS"),
+#      jetCorrector = cms.string("ak5PFL2L3"),
+>>>>>>> 754cc1b... fix btagging in DQMOffline/Trigger, only partially moving to ak4 because of btagging
 #      select = cms.string("pt>20 & abs(eta)<2.5"),
 #      min = cms.int32(1),                                                
 #    ), 
 #    cms.PSet(
 #      label  = cms.string("jets/pf:step3"),
+<<<<<<< HEAD
 #      src  = cms.InputTag("PFJetsFilter"),
 #      jetCorrector = cms.string("ak4PFL2L3"),
+=======
+#      src  = cms.InputTag("ak5PFJetsCHS"),
+#      jetCorrector = cms.string("ak5PFL2L3"),
+>>>>>>> 754cc1b... fix btagging in DQMOffline/Trigger, only partially moving to ak4 because of btagging
 #      select = cms.string("pt>20 & abs(eta)<2.5"),
 #      min = cms.int32(2),                                                
 #    ), 
 #    cms.PSet(
 #      label  = cms.string("jets/pf:step4"),
+<<<<<<< HEAD
 #      src  = cms.InputTag("PFJetsFilter"),
 #      jetCorrector = cms.string("ak4PFL2L3"),
+=======
+#      src  = cms.InputTag("ak5PFJetsCHS"),
+#      jetCorrector = cms.string("ak5PFL2L3"),
+>>>>>>> 754cc1b... fix btagging in DQMOffline/Trigger, only partially moving to ak4 because of btagging
 #      select = cms.string("pt>20 & abs(eta)<2.5"),
 #      min = cms.int32(3),                                                
 #    ), 
     cms.PSet(
 #      label  = cms.string("jets/pf:step5"),
       label  = cms.string("jets/pf:step2"),
+<<<<<<< HEAD
       src  = cms.InputTag("PFJetsFilter"),
       jetCorrector = cms.string("ak4PFL2L3"),
+=======
+      src  = cms.InputTag("ak5PFJetsCHS"),
+      jetCorrector = cms.string("ak5PFL2L3"),
+>>>>>>> 754cc1b... fix btagging in DQMOffline/Trigger, only partially moving to ak4 because of btagging
       select = cms.string("pt>20 & abs(eta)<2.5"),
       min = cms.int32(4),                                                
     ),

--- a/DQMOffline/Trigger/python/topSingleLeptonHLTEventDQM_cfi.py
+++ b/DQMOffline/Trigger/python/topSingleLeptonHLTEventDQM_cfi.py
@@ -54,7 +54,7 @@ topSingleLeptonHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM",
     jetExtras = cms.PSet(
       ## when omitted monitor plots for pt will be filled from uncorrected
       ## jets                                            
-      jetCorrector = cms.string("ak4PFL1L2L3"),
+      #jetCorrector = cms.string("ak4PFCHSL1L2L3"),
       ## when omitted no extra selection will be applied on jets before
       ## filling the monitor histograms; if jetCorrector is present the
       ## selection will be applied to corrected jets
@@ -163,7 +163,7 @@ topSingleMuonHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM",
     jetExtras = cms.PSet(
       ## when omitted monitor plots for pt will be filled from uncorrected
       ## jets
-      jetCorrector = cms.string("ak4PFL1L2L3"),
+      #jetCorrector = cms.string("ak4PFCHSL1L2L3"),
       ## when omitted no extra selection will be applied on jets before
       ## filling the monitor histograms; if jetCorrector is present the
       ## selection will be applied to corrected jets                                                
@@ -241,21 +241,21 @@ topSingleMuonHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM",
 #    cms.PSet(
 #      label  = cms.string("jets/pf:step2"),
 #      src  = cms.InputTag("ak5PFJetsCHS"),
-#      jetCorrector = cms.string("ak4PFL1L2L3"),
+#      jetCorrector = cms.string("ak4PFCHSL1L2L3"),
 #      select = cms.string("pt>20 & abs(eta)<2.5"),
 #      min = cms.int32(1),                                                
 #    ), 
 #    cms.PSet(
 #      label  = cms.string("jets/pf:step3"),
 #      src  = cms.InputTag("ak5PFJetsCHS"),
-#      jetCorrector = cms.string("ak4PFL1L2L3"),
+#      jetCorrector = cms.string("ak4PFCHSL1L2L3"),
 #      select = cms.string("pt>20 & abs(eta)<2.5"),
 #      min = cms.int32(2),                                                
 #    ), 
 #    cms.PSet(
 #      label  = cms.string("jets/pf:step4"),
 #      src  = cms.InputTag("ak5PFJetsCHS"),
-#      jetCorrector = cms.string("ak4PFL1L2L3"),
+#      jetCorrector = cms.string("ak4PFCHSL1L2L3"),
 #      select = cms.string("pt>20 & abs(eta)<2.5"),
 #      min = cms.int32(3),                                                
 #    ), 
@@ -263,7 +263,7 @@ topSingleMuonHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM",
 #      label  = cms.string("jets/pf:step5"),
       label  = cms.string("jets/pf:step2"),
       src  = cms.InputTag("ak5PFJetsCHS"),
-      jetCorrector = cms.string("ak4PFL1L2L3"),
+      #jetCorrector = cms.string("ak4PFCHSL1L2L3"),
       select = cms.string("pt>20 & abs(eta)<2.5"),
       min = cms.int32(4),                                                
     ),
@@ -315,7 +315,7 @@ topSingleElectronHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM",
     jetExtras = cms.PSet(
       ## when omitted monitor plots for pt will be filled from uncorrected
       ## jets
-      jetCorrector = cms.string("ak4PFL1L2L3"),
+      #jetCorrector = cms.string("ak4PFCHSL1L2L3"),
       ## when omitted no extra selection will be applied on jets before
       ## filling the monitor histograms; if jetCorrector is present the
       ## selection will be applied to corrected jets 
@@ -394,21 +394,21 @@ topSingleElectronHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM",
 #    cms.PSet(
 #      label  = cms.string("jets/pf:step2"),
 #      src  = cms.InputTag("ak5PFJetsCHS"),
-#      jetCorrector = cms.string("ak4PFL1L2L3"),
+#      jetCorrector = cms.string("ak4PFCHSL1L2L3"),
 #      select = cms.string("pt>20 & abs(eta)<2.5"),
 #      min = cms.int32(1),                                                
 #    ), 
 #    cms.PSet(
 #      label  = cms.string("jets/pf:step3"),
 #      src  = cms.InputTag("ak5PFJetsCHS"),
-#      jetCorrector = cms.string("ak4PFL1L2L3"),
+#      jetCorrector = cms.string("ak4PFCHSL1L2L3"),
 #      select = cms.string("pt>20 & abs(eta)<2.5"),
 #      min = cms.int32(2),                                                
 #    ), 
 #    cms.PSet(
 #      label  = cms.string("jets/pf:step4"),
 #      src  = cms.InputTag("ak5PFJetsCHS"),
-#      jetCorrector = cms.string("ak4PFL1L2L3"),
+#      jetCorrector = cms.string("ak4PFCHSL1L2L3"),
 #      select = cms.string("pt>20 & abs(eta)<2.5"),
 #      min = cms.int32(3),                                                
 #    ), 
@@ -416,7 +416,7 @@ topSingleElectronHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM",
 #      label  = cms.string("jets/pf:step5"),
       label  = cms.string("jets/pf:step2"),
       src  = cms.InputTag("ak5PFJetsCHS"),
-      jetCorrector = cms.string("ak4PFL1L2L3"),
+      #jetCorrector = cms.string("ak4PFCHSL1L2L3"),
       select = cms.string("pt>20 & abs(eta)<2.5"),
       min = cms.int32(4),                                                
     ),

--- a/HLTriggerOffline/Top/python/singletopHLTEventValidation_cfi.py
+++ b/HLTriggerOffline/Top/python/singletopHLTEventValidation_cfi.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 # single top muonique
 SingleTopSingleMuonHLTValidation = cms.EDAnalyzer('TopSingleLeptonHLTValidation',
         # Directory
-        sDir         = cms.untracked.string('HLTValidation/SingleTop/SingleMuon/'),
+        sDir         = cms.untracked.string('HLT/TopHLTValidation/SingleTop/SingleMuon/'),
         # Electrons
         sElectrons   = cms.untracked.string('gedGsfElectrons'),
         ptElectrons  = cms.untracked.double(30.),
@@ -17,7 +17,7 @@ SingleTopSingleMuonHLTValidation = cms.EDAnalyzer('TopSingleLeptonHLTValidation'
         isoMuons     = cms.untracked.double(0.12),
         minMuons     = cms.untracked.uint32(1),
         # Jets
-        sJets        = cms.untracked.string('ak5PFJets'),
+        sJets        = cms.untracked.string('ak4PFJetsCHS'),
         ptJets       = cms.untracked.double(40.),
         etaJets      = cms.untracked.double(5.),
         minJets      = cms.untracked.uint32(2),
@@ -29,7 +29,7 @@ SingleTopSingleMuonHLTValidation = cms.EDAnalyzer('TopSingleLeptonHLTValidation'
 # single top electronique
 SingleTopSingleElectronHLTValidation = cms.EDAnalyzer('TopSingleLeptonHLTValidation',
         # Directory
-        sDir         = cms.untracked.string('HLTValidation/SingleTop/SingleElectron/'),
+        sDir         = cms.untracked.string('HLT/TopHLTValidation/SingleTop/SingleElectron/'),
         # Electrons
         sElectrons   = cms.untracked.string('gedGsfElectrons'),
         ptElectrons  = cms.untracked.double(30.),
@@ -43,7 +43,7 @@ SingleTopSingleElectronHLTValidation = cms.EDAnalyzer('TopSingleLeptonHLTValidat
         isoMuons     = cms.untracked.double(0.12),
         minMuons     = cms.untracked.uint32(0),
         # Jets
-        sJets        = cms.untracked.string('ak5PFJets'),
+        sJets        = cms.untracked.string('ak4PFJetsCHS'),
         ptJets       = cms.untracked.double(40.),
         etaJets      = cms.untracked.double(5.),
         minJets      = cms.untracked.uint32(2),

--- a/HLTriggerOffline/Top/python/topDiLeptonHLTEventValidation_cfi.py
+++ b/HLTriggerOffline/Top/python/topDiLeptonHLTEventValidation_cfi.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 # ttbar dimuon
 DiMuonHLTValidation = cms.EDAnalyzer('TopDiLeptonHLTValidation',
         # Directory
-        sDir         = cms.untracked.string('HLTValidation/Top/DiMuon/'),
+        sDir         = cms.untracked.string('HLT/TopHLTValidation/Top/DiMuon/'),
         # Electrons
         sElectrons   = cms.untracked.string('gedGsfElectrons'),
         ptElectrons  = cms.untracked.double(20.),
@@ -17,7 +17,7 @@ DiMuonHLTValidation = cms.EDAnalyzer('TopDiLeptonHLTValidation',
         isoMuons     = cms.untracked.double(0.2),
         minMuons     = cms.untracked.uint32(2),
         # Jets
-        sJets        = cms.untracked.string('ak5PFJets'),
+        sJets        = cms.untracked.string('ak4PFJetsCHS'),
         ptJets       = cms.untracked.double(30.),
         etaJets      = cms.untracked.double(2.5),
         minJets      = cms.untracked.uint32(2),
@@ -29,7 +29,7 @@ DiMuonHLTValidation = cms.EDAnalyzer('TopDiLeptonHLTValidation',
 # ttbar dielec
 DiElectronHLTValidation = cms.EDAnalyzer('TopDiLeptonHLTValidation',
         # Directory
-        sDir         = cms.untracked.string('HLTValidation/Top/DiElectron/'),
+        sDir         = cms.untracked.string('HLT/TopHLTValidation/Top/DiElectron/'),
         # Electrons
         sElectrons   = cms.untracked.string('gedGsfElectrons'),
         ptElectrons  = cms.untracked.double(20.),
@@ -43,7 +43,7 @@ DiElectronHLTValidation = cms.EDAnalyzer('TopDiLeptonHLTValidation',
         isoMuons     = cms.untracked.double(0.2),
         minMuons     = cms.untracked.uint32(0),
         # Jets
-        sJets        = cms.untracked.string('ak5PFJets'),
+        sJets        = cms.untracked.string('ak4PFJetsCHS'),
         ptJets       = cms.untracked.double(30.),
         etaJets      = cms.untracked.double(2.5),
         minJets      = cms.untracked.uint32(2),
@@ -55,7 +55,7 @@ DiElectronHLTValidation = cms.EDAnalyzer('TopDiLeptonHLTValidation',
 # ttbar elec-muon
 ElecMuonHLTValidation = cms.EDAnalyzer('TopDiLeptonHLTValidation',
         # Directory
-        sDir         = cms.untracked.string('HLTValidation/Top/ElecMuon/'),
+        sDir         = cms.untracked.string('HLT/TopHLTValidation/Top/ElecMuon/'),
         # Electrons
         sElectrons   = cms.untracked.string('gedGsfElectrons'),
         ptElectrons  = cms.untracked.double(20.),
@@ -69,7 +69,7 @@ ElecMuonHLTValidation = cms.EDAnalyzer('TopDiLeptonHLTValidation',
         isoMuons     = cms.untracked.double(0.2),
         minMuons     = cms.untracked.uint32(1),
         # Jets
-        sJets        = cms.untracked.string('ak5PFJets'),
+        sJets        = cms.untracked.string('ak4PFJetsCHS'),
         ptJets       = cms.untracked.double(30.),
         etaJets      = cms.untracked.double(2.5),
         minJets      = cms.untracked.uint32(2),

--- a/HLTriggerOffline/Top/python/topHLTValidationHarvest_cff.py
+++ b/HLTriggerOffline/Top/python/topHLTValidationHarvest_cff.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 DiMuonHLTValidationHarvest = cms.EDAnalyzer("DQMGenericClient",
-        subDirs = cms.untracked.vstring("HLTValidation/Top/DiMuon"),
+        subDirs = cms.untracked.vstring("HLT/TopHLTValidation/Top/DiMuon"),
         efficiency = cms.vstring(
             "hEffLeptonEta 'Efficiency vs Eta Lepton ' EtaLeptonSel EtaLeptonAll ",
             "hEffLeptonPt 'Efficiency vs Pt Lepton' PtLeptonSel PtLeptonAll ",
@@ -12,7 +12,7 @@ DiMuonHLTValidationHarvest = cms.EDAnalyzer("DQMGenericClient",
         )
 
 DiElectronHLTValidationHarvest = cms.EDAnalyzer("DQMGenericClient",
-        subDirs = cms.untracked.vstring("HLTValidation/Top/DiElectron"),
+        subDirs = cms.untracked.vstring("HLT/TopHLTValidation/Top/DiElectron"),
         efficiency = cms.vstring(
             "hEffLeptonEta 'Efficiency vs Eta Lepton ' EtaLeptonSel EtaLeptonAll ",
             "hEffLeptonPt 'Efficiency vs Pt Lepton' PtLeptonSel PtLeptonAll ",
@@ -23,7 +23,7 @@ DiElectronHLTValidationHarvest = cms.EDAnalyzer("DQMGenericClient",
         )
 
 ElecMuonHLTValidationHarvest = cms.EDAnalyzer("DQMGenericClient",
-        subDirs = cms.untracked.vstring("HLTValidation/Top/ElecMuon"),
+        subDirs = cms.untracked.vstring("HLT/TopHLTValidation/Top/ElecMuon"),
         efficiency = cms.vstring(
             "hEffLeptonEta 'Efficiency vs Eta Lepton ' EtaLeptonSel EtaLeptonAll ",
             "hEffLeptonPt 'Efficiency vs Pt Lepton' PtLeptonSel PtLeptonAll ",
@@ -34,7 +34,7 @@ ElecMuonHLTValidationHarvest = cms.EDAnalyzer("DQMGenericClient",
         )
 
 topSingleMuonHLTValidationHarvest = cms.EDAnalyzer("DQMGenericClient",
-        subDirs = cms.untracked.vstring("HLTValidation/Top/SemiMuonic"),
+        subDirs = cms.untracked.vstring("HLT/TopHLTValidation/Top/SemiMuonic"),
         efficiency = cms.vstring(
             "hEffLeptonEta 'Efficiency vs Eta Lepton ' EtaLeptonSel EtaLeptonAll ",
             "hEffLeptonPt 'Efficiency vs Pt Lepton' PtLeptonSel PtLeptonAll ",
@@ -45,7 +45,7 @@ topSingleMuonHLTValidationHarvest = cms.EDAnalyzer("DQMGenericClient",
         )
 
 topSingleElectronHLTValidationHarvest = cms.EDAnalyzer("DQMGenericClient",
-        subDirs = cms.untracked.vstring("HLTValidation/Top/SemiElectronic"),
+        subDirs = cms.untracked.vstring("HLT/TopHLTValidation/Top/SemiElectronic"),
         efficiency = cms.vstring(
             "hEffLeptonEta 'Efficiency vs Eta Lepton ' EtaLeptonSel EtaLeptonAll ",
             "hEffLeptonPt 'Efficiency vs Pt Lepton' PtLeptonSel PtLeptonAll ",
@@ -56,7 +56,7 @@ topSingleElectronHLTValidationHarvest = cms.EDAnalyzer("DQMGenericClient",
         )
 
 SingleTopSingleMuonHLTValidationHarvest = cms.EDAnalyzer("DQMGenericClient",
-        subDirs = cms.untracked.vstring("HLTValidation/SingleTop/SingleMuon"),
+        subDirs = cms.untracked.vstring("HLT/TopHLTValidation/SingleTop/SingleMuon"),
         efficiency = cms.vstring(
             "hEffLeptonEta 'Efficiency vs Eta Lepton ' EtaLeptonSel EtaLeptonAll ",
             "hEffLeptonPt 'Efficiency vs Pt Lepton' PtLeptonSel PtLeptonAll ",
@@ -67,7 +67,7 @@ SingleTopSingleMuonHLTValidationHarvest = cms.EDAnalyzer("DQMGenericClient",
         )
 
 SingleTopSingleElectronHLTValidationHarvest = cms.EDAnalyzer("DQMGenericClient",
-        subDirs = cms.untracked.vstring("HLTValidation/SingleTop/SingleElectron"),
+        subDirs = cms.untracked.vstring("HLT/TopHLTValidation/SingleTop/SingleElectron"),
         efficiency = cms.vstring(
             "hEffLeptonEta 'Efficiency vs Eta Lepton ' EtaLeptonSel EtaLeptonAll ",
             "hEffLeptonPt 'Efficiency vs Pt Lepton' PtLeptonSel PtLeptonAll ",

--- a/HLTriggerOffline/Top/python/topSingleLeptonHLTEventValidation_cfi.py
+++ b/HLTriggerOffline/Top/python/topSingleLeptonHLTEventValidation_cfi.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 # ttbar semi muonique
 topSingleMuonHLTValidation = cms.EDAnalyzer('TopSingleLeptonHLTValidation',
         # Directory
-        sDir         = cms.untracked.string('HLTValidation/Top/SemiMuonic/'),
+        sDir         = cms.untracked.string('HLT/TopHLTValidation/Top/SemiMuonic/'),
         # Electrons
         sElectrons   = cms.untracked.string('gedGsfElectrons'),
         ptElectrons  = cms.untracked.double(30.),
@@ -17,7 +17,7 @@ topSingleMuonHLTValidation = cms.EDAnalyzer('TopSingleLeptonHLTValidation',
         isoMuons     = cms.untracked.double(0.12),
         minMuons     = cms.untracked.uint32(1),
         # Jets
-        sJets        = cms.untracked.string('ak5PFJets'),
+        sJets        = cms.untracked.string('ak4PFJetsCHS'),
         ptJets       = cms.untracked.double(20.),
         etaJets      = cms.untracked.double(2.5),
         minJets      = cms.untracked.uint32(4),
@@ -29,7 +29,7 @@ topSingleMuonHLTValidation = cms.EDAnalyzer('TopSingleLeptonHLTValidation',
 # ttbar semi electronique
 topSingleElectronHLTValidation = cms.EDAnalyzer('TopSingleLeptonHLTValidation',
         # Directory
-        sDir         = cms.untracked.string('HLTValidation/Top/SemiElectronic/'),
+        sDir         = cms.untracked.string('HLT/TopHLTValidation/Top/SemiElectronic/'),
         # Electrons
         sElectrons   = cms.untracked.string('gedGsfElectrons'),
         ptElectrons  = cms.untracked.double(30.),
@@ -43,7 +43,7 @@ topSingleElectronHLTValidation = cms.EDAnalyzer('TopSingleLeptonHLTValidation',
         isoMuons     = cms.untracked.double(0.12),
         minMuons     = cms.untracked.uint32(0),
         # Jets
-        sJets        = cms.untracked.string('ak5PFJets'),
+        sJets        = cms.untracked.string('ak4PFJetsCHS'),
         ptJets       = cms.untracked.double(20.),
         etaJets      = cms.untracked.double(2.5),
         minJets      = cms.untracked.uint32(4),


### PR DESCRIPTION
In PR #3457, several EDProducers and EDFilters have been removed, breaking the Top PAG HLT DQM Offline code. The plots produced for validation in CMSSW_7_1_0_pre7 are therefore empty. This PR fixes this problem and need to be merged ASAP to make the validation anew possible.
The occasion is also taken:
- to change the names of the GUI directories to be finally able to use RelMon
- to start the migration from ak5 to ak4 (b tagging being available only for ak5, everything can't be migrated)
