### PR TITLE
Fastsim/PF threading issues

### DIFF
--- a/FastSimulation/Event/test/testEvent.cc
+++ b/FastSimulation/Event/test/testEvent.cc
@@ -30,6 +30,7 @@ public :
 private:
   
   // See RecoParticleFlow/PFProducer/interface/PFProducer.h
+  std::unique_ptr<ParticleTable::Sentry> pTableSentry_;
   bool isGeant;
   edm::ParameterSet particleFilter_;
   std::vector<FSimEvent*> mySimEvent;
@@ -74,7 +75,9 @@ void testEvent::beginRun(edm::Run const&, edm::EventSetup const& es)
   // init Particle data table (from Pythia)
   edm::ESHandle < HepPDT::ParticleDataTable > pdt;
   es.getData(pdt);
-  if ( !ParticleTable::instance() ) ParticleTable::instance(&(*pdt));
+  if ( !ParticleTable::instance() ) {
+    pTableSentry_.reset( new ParticleTable::Sentry(pdt.product()) );
+  }
   if ( isGeant ) mySimEvent[0]->initializePdt(&(*pdt));
   mySimEvent[1]->initializePdt(&(*pdt));
 

--- a/FastSimulation/Event/test/testEvent.cc
+++ b/FastSimulation/Event/test/testEvent.cc
@@ -30,7 +30,6 @@ public :
 private:
   
   // See RecoParticleFlow/PFProducer/interface/PFProducer.h
-  std::unique_ptr<ParticleTable::Sentry> pTableSentry_;
   bool isGeant;
   edm::ParameterSet particleFilter_;
   std::vector<FSimEvent*> mySimEvent;
@@ -75,9 +74,7 @@ void testEvent::beginRun(edm::Run const&, edm::EventSetup const& es)
   // init Particle data table (from Pythia)
   edm::ESHandle < HepPDT::ParticleDataTable > pdt;
   es.getData(pdt);
-  if ( !ParticleTable::instance() ) {
-    pTableSentry_.reset( new ParticleTable::Sentry(pdt.product()) );
-  }
+  
   if ( isGeant ) mySimEvent[0]->initializePdt(&(*pdt));
   mySimEvent[1]->initializePdt(&(*pdt));
 
@@ -86,6 +83,8 @@ void testEvent::beginRun(edm::Run const&, edm::EventSetup const& es)
 void
 testEvent::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup )
 {
+  ParticleTable::Sentry ptable(mySimEvent[1]->theTable()); // one sentry is fine
+
   if ( isGeant ) { 
     edm::Handle<std::vector<SimTrack> > fullSimTracks;
     iEvent.getByLabel("g4SimHits","",fullSimTracks);

--- a/FastSimulation/EventProducer/interface/FamosManager.h
+++ b/FastSimulation/EventProducer/interface/FamosManager.h
@@ -4,6 +4,7 @@
 #include "DataFormats/HepMCCandidate/interface/GenParticleFwd.h"
 #include "SimDataFormats/CrossingFrame/interface/CrossingFrame.h"
 #include <string>
+#include "FastSimulation/Particle/interface/ParticleTable.h"
 
 namespace HepMC {
   class GenEvent;
@@ -69,6 +70,7 @@ class FamosManager
 
   int iEvent;
   //  const HepMC::GenEvent* myGenEvent;
+  std::unique_ptr<ParticleTable::Sentry> pTableSentry_;
   FSimEvent* mySimEvent;
   TrajectoryManager* myTrajectoryManager;
   PileUpSimulator* myPileUpSimulator;

--- a/FastSimulation/EventProducer/interface/FamosManager.h
+++ b/FastSimulation/EventProducer/interface/FamosManager.h
@@ -70,7 +70,6 @@ class FamosManager
 
   int iEvent;
   //  const HepMC::GenEvent* myGenEvent;
-  std::unique_ptr<ParticleTable::Sentry> pTableSentry_;
   FSimEvent* mySimEvent;
   TrajectoryManager* myTrajectoryManager;
   PileUpSimulator* myPileUpSimulator;

--- a/FastSimulation/EventProducer/src/FamosManager.cc
+++ b/FastSimulation/EventProducer/src/FamosManager.cc
@@ -54,6 +54,7 @@ FamosManager::FamosManager(edm::ParameterSet const & p)
       m_pRunNumber(p.getUntrackedParameter<int>("RunNumber",1)),
       m_pVerbose(p.getUntrackedParameter<int>("Verbosity",1))
 {
+  pTableSentry_.reset((ParticleTable::Sentry*)NULL);
   // Initialize the FSimEvent
   mySimEvent = 
     new FSimEvent(p.getParameter<edm::ParameterSet>("VertexGenerator"),
@@ -94,7 +95,10 @@ FamosManager::setupGeometryAndField(edm::Run const& run, const edm::EventSetup &
   edm::ESHandle < HepPDT::ParticleDataTable > pdt;
   es.getData(pdt);
   mySimEvent->initializePdt(&(*pdt));
-  ParticleTable::instance(&(*pdt));
+  
+  if( !ParticleTable::instance() ) {
+    pTableSentry_.reset( new ParticleTable::Sentry(pdt.product()) );
+  }
 
   // Initialize the full (misaligned) tracker geometry 
   // (only if tracking is requested)

--- a/FastSimulation/EventProducer/src/FamosManager.cc
+++ b/FastSimulation/EventProducer/src/FamosManager.cc
@@ -54,7 +54,6 @@ FamosManager::FamosManager(edm::ParameterSet const & p)
       m_pRunNumber(p.getUntrackedParameter<int>("RunNumber",1)),
       m_pVerbose(p.getUntrackedParameter<int>("Verbosity",1))
 {
-  pTableSentry_.reset((ParticleTable::Sentry*)NULL);
   // Initialize the FSimEvent
   mySimEvent = 
     new FSimEvent(p.getParameter<edm::ParameterSet>("VertexGenerator"),
@@ -96,10 +95,6 @@ FamosManager::setupGeometryAndField(edm::Run const& run, const edm::EventSetup &
   es.getData(pdt);
   mySimEvent->initializePdt(&(*pdt));
   
-  if( !ParticleTable::instance() ) {
-    pTableSentry_.reset( new ParticleTable::Sentry(pdt.product()) );
-  }
-
   // Initialize the full (misaligned) tracker geometry 
   // (only if tracking is requested)
   std::string misAligned = m_Alignment ? "MisAligned" : "";
@@ -161,7 +156,6 @@ FamosManager::reconstruct(const HepMC::GenEvent* evt,
 			  const TrackerTopology *tTopo,
                           RandomEngineAndDistribution const* random)
 {
-
   //  myGenEvent = evt;
   
   if (evt != 0 || particles != 0) {

--- a/FastSimulation/EventProducer/src/FamosProducer.cc
+++ b/FastSimulation/EventProducer/src/FamosProducer.cc
@@ -81,6 +81,7 @@ void FamosProducer::endJob()
  
 void FamosProducer::produce(edm::Event & iEvent, const edm::EventSetup & es)
 {
+  ParticleTable::Sentry ptable(famosManager_->simEvent()->theTable());
    using namespace edm;
 
    RandomEngineAndDistribution random(iEvent.streamID());

--- a/FastSimulation/MaterialEffects/test/testMaterialEffects.cc
+++ b/FastSimulation/MaterialEffects/test/testMaterialEffects.cc
@@ -31,6 +31,7 @@ private:
   
   // See RecoParticleFlow/PFProducer/interface/PFProducer.h
   edm::ParameterSet particleFilter_;
+  std::unique_ptr<ParticleTable::Sentry> pTableSentry_;
   std::vector<FSimEvent*> mySimEvent;
   std::string simModuleLabel_;  
   DQMStore * dbe;
@@ -568,7 +569,9 @@ void testMaterialEffects::beginRun(edm::Run const&, edm::EventSetup const& es)
   // init Particle data table (from Pythia)
   edm::ESHandle < HepPDT::ParticleDataTable > pdt;
   es.getData(pdt);
-  if ( !ParticleTable::instance() ) ParticleTable::instance(&(*pdt));
+  if ( !ParticleTable::instance() ) {
+    pTableSentry_.reset( new ParticleTable::Sentry(pdt.product()) );
+  }
   mySimEvent[0]->initializePdt(&(*pdt));
   mySimEvent[1]->initializePdt(&(*pdt));
 

--- a/FastSimulation/MaterialEffects/test/testMaterialEffects.cc
+++ b/FastSimulation/MaterialEffects/test/testMaterialEffects.cc
@@ -31,7 +31,6 @@ private:
   
   // See RecoParticleFlow/PFProducer/interface/PFProducer.h
   edm::ParameterSet particleFilter_;
-  std::unique_ptr<ParticleTable::Sentry> pTableSentry_;
   std::vector<FSimEvent*> mySimEvent;
   std::string simModuleLabel_;  
   DQMStore * dbe;
@@ -569,9 +568,6 @@ void testMaterialEffects::beginRun(edm::Run const&, edm::EventSetup const& es)
   // init Particle data table (from Pythia)
   edm::ESHandle < HepPDT::ParticleDataTable > pdt;
   es.getData(pdt);
-  if ( !ParticleTable::instance() ) {
-    pTableSentry_.reset( new ParticleTable::Sentry(pdt.product()) );
-  }
   mySimEvent[0]->initializePdt(&(*pdt));
   mySimEvent[1]->initializePdt(&(*pdt));
 
@@ -580,6 +576,7 @@ void testMaterialEffects::beginRun(edm::Run const&, edm::EventSetup const& es)
 void
 testMaterialEffects::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup )
 {
+  ParticleTable::Sentry(mySimEvent[0]->theTable());
 
   if( ( nevt < 100 && nevt%10 == 0)   || 
       ( nevt < 1000 && nevt%100 == 0) || 

--- a/FastSimulation/MaterialEffects/test/testNuclearInteractions.cc
+++ b/FastSimulation/MaterialEffects/test/testNuclearInteractions.cc
@@ -38,7 +38,6 @@ private:
   
   // See RecoParticleFlow/PFProducer/interface/PFProducer.h
   edm::ParameterSet particleFilter_;
-  std::unique_ptr<ParticleTable::Sentry> pTableSentry_;
   bool saveNU;
   std::vector<FSimEvent*> mySimEvent;
   NUEvent* nuEvent;
@@ -649,9 +648,7 @@ void testNuclearInteractions::beginRun(edm::Run const&, const edm::EventSetup & 
   // init Particle data table (from Pythia)
   edm::ESHandle < HepPDT::ParticleDataTable > pdt;
   es.getData(pdt);
-  if ( !ParticleTable::instance() ) {
-    pTableSentry_.reset( new ParticleTable::Sentry(pdt.product()) );
-  }
+ 
   mySimEvent[0]->initializePdt(&(*pdt));
   mySimEvent[1]->initializePdt(&(*pdt));
 
@@ -660,6 +657,7 @@ void testNuclearInteractions::beginRun(edm::Run const&, const edm::EventSetup & 
 void
 testNuclearInteractions::produce(edm::Event& iEvent, const edm::EventSetup& iSetup )
 {
+  ParticleTable::Sentry ptable(mySimEvent[0]->theTable());
 
   ++totalNEvt;
   if ( totalNEvt/1000*1000 == totalNEvt ) 

--- a/FastSimulation/MaterialEffects/test/testNuclearInteractions.cc
+++ b/FastSimulation/MaterialEffects/test/testNuclearInteractions.cc
@@ -38,6 +38,7 @@ private:
   
   // See RecoParticleFlow/PFProducer/interface/PFProducer.h
   edm::ParameterSet particleFilter_;
+  std::unique_ptr<ParticleTable::Sentry> pTableSentry_;
   bool saveNU;
   std::vector<FSimEvent*> mySimEvent;
   NUEvent* nuEvent;
@@ -648,7 +649,9 @@ void testNuclearInteractions::beginRun(edm::Run const&, const edm::EventSetup & 
   // init Particle data table (from Pythia)
   edm::ESHandle < HepPDT::ParticleDataTable > pdt;
   es.getData(pdt);
-  if ( !ParticleTable::instance() ) ParticleTable::instance(&(*pdt));
+  if ( !ParticleTable::instance() ) {
+    pTableSentry_.reset( new ParticleTable::Sentry(pdt.product()) );
+  }
   mySimEvent[0]->initializePdt(&(*pdt));
   mySimEvent[1]->initializePdt(&(*pdt));
 

--- a/FastSimulation/MuonSimHitProducer/src/MuonSimHitProducer.cc
+++ b/FastSimulation/MuonSimHitProducer/src/MuonSimHitProducer.cc
@@ -56,6 +56,8 @@
 #include "DataFormats/GeometrySurface/interface/PlaneBuilder.h"
 #include "DataFormats/GeometrySurface/interface/TangentPlane.h"
 
+// for particle table
+#include "FastSimulation/Particle/interface/ParticleTable.h"
 
 ////////////////////////////////////////////////////////////////////////////
 // Geometry, Magnetic Field
@@ -153,6 +155,9 @@ void
 MuonSimHitProducer::produce(edm::Event& iEvent,const edm::EventSetup& iSetup) {
   // using namespace edm;
   // using namespace std;
+  edm::ESHandle < HepPDT::ParticleDataTable > pdg;
+  iSetup.getData(pdg);
+  ParticleTable::Sentry ptable(pdg.product());
 
   RandomEngineAndDistribution random(iEvent.streamID());
 

--- a/FastSimulation/Particle/interface/ParticleTable.h
+++ b/FastSimulation/Particle/interface/ParticleTable.h
@@ -3,6 +3,8 @@
 
 // HepPDT header
 #include "SimGeneral/HepPDTRecord/interface/ParticleDataTable.h"
+#include <atomic>
+#include <mutex>
 
 class ParticleTable {
 
@@ -11,14 +13,14 @@ public:
   /// Get the pointer to the particle data table
   const HepPDT::ParticleDataTable* theTable() const {return pdt_;}
 
-  static ParticleTable* instance(const HepPDT::ParticleDataTable* pdt);
-  static inline ParticleTable* instance() { return myself; }
+  static ParticleTable* instance(const HepPDT::ParticleDataTable* pdt=NULL);
 
 private:
 
-  ParticleTable(const HepPDT::ParticleDataTable* pdt) : pdt_(pdt) {;}
-  static ParticleTable* myself;
-  const HepPDT::ParticleDataTable * pdt_;
+  ParticleTable(const HepPDT::ParticleDataTable* pdt) : pdt_(pdt) {}
+  static std::atomic<ParticleTable*> myself;
+  static std::mutex _mutex;
+  const HepPDT::ParticleDataTable* pdt_;
 
 };
 

--- a/FastSimulation/Particle/interface/ParticleTable.h
+++ b/FastSimulation/Particle/interface/ParticleTable.h
@@ -3,25 +3,31 @@
 
 // HepPDT header
 #include "SimGeneral/HepPDTRecord/interface/ParticleDataTable.h"
-#include <atomic>
-#include <mutex>
+#include <memory>
+
 
 class ParticleTable {
 
 public:
+  struct Sentry{
+    Sentry(const HepPDT::ParticleDataTable* pdt) { ParticleTable::set(pdt); }
+    ~Sentry() { ParticleTable::set(NULL); }
+  };
 
   /// Get the pointer to the particle data table
-  const HepPDT::ParticleDataTable* theTable() const {return pdt_;}
+  const HepPDT::ParticleDataTable* theTable() const { return pdt_; }
 
-  static ParticleTable* instance(const HepPDT::ParticleDataTable* pdt=NULL);
+  static const ParticleTable* instance() 
+  { return myself.get(); }
 
 private:
+ ParticleTable(const HepPDT::ParticleDataTable* pdt) : pdt_(pdt) {}
+  static void set( const HepPDT::ParticleDataTable* );
+  static thread_local std::unique_ptr<const ParticleTable> myself;
 
-  ParticleTable(const HepPDT::ParticleDataTable* pdt) : pdt_(pdt) {}
-  static std::atomic<ParticleTable*> myself;
-  static std::mutex _mutex;
   const HepPDT::ParticleDataTable* pdt_;
 
+  friend struct Sentry;
 };
 
 #endif // FastSimulation_Particle_ParticleTable_H

--- a/FastSimulation/Particle/interface/ParticleTable.h
+++ b/FastSimulation/Particle/interface/ParticleTable.h
@@ -5,29 +5,52 @@
 #include "SimGeneral/HepPDTRecord/interface/ParticleDataTable.h"
 #include <memory>
 
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 class ParticleTable {
 
 public:
   struct Sentry{
-    Sentry(const HepPDT::ParticleDataTable* pdt) { ParticleTable::set(pdt); }
-    ~Sentry() { ParticleTable::set(NULL); }
+    Sentry(const HepPDT::ParticleDataTable* pdt) { 
+      edm::LogError("particletable") << "  Sentry() - set pdt to: " << pdt 
+				     << ' ' << ParticleTable::myself 
+				     << std::endl;
+      ParticleTable::myself->set(pdt); 
+    }
+    ~Sentry() { 
+      edm::LogError("particletable") << " ~Sentry() - set pdt to NULL" 
+				      << ' ' << ParticleTable::myself 
+				     << std::endl;
+      ParticleTable::myself->set(nullptr); 
+    }
   };
 
-  /// Get the pointer to the particle data table
-  const HepPDT::ParticleDataTable* theTable() const { return pdt_; }
+  ~ParticleTable() { 
+    edm::LogError("particletable") << "~ParticleTable()" << std::endl;
+  }
 
-  static const ParticleTable* instance() 
-  { return myself.get(); }
+  /// Get the pointer to the particle data table
+  const HepPDT::ParticleDataTable* theTable() const { 
+    edm::LogError("particletable") << "Asked for theTable at : " << pdt_ << std::endl;
+    return pdt_; 
+  }
+
+  static ParticleTable* const instance() { 
+    edm::LogError("particletable") << "Asked for myself : " << &myself << std::endl;
+    return myself; 
+  }
 
 private:
- ParticleTable(const HepPDT::ParticleDataTable* pdt) : pdt_(pdt) {}
-  static void set( const HepPDT::ParticleDataTable* );
-  static thread_local std::unique_ptr<const ParticleTable> myself;
+  ParticleTable() : pdt_(nullptr) {}
+  ParticleTable(const HepPDT::ParticleDataTable* pdt=nullptr) : pdt_(pdt) {}
+  void set( const HepPDT::ParticleDataTable* pdt) { pdt_ = pdt; } 
+  static thread_local ParticleTable* myself;
 
   const HepPDT::ParticleDataTable* pdt_;
 
   friend struct Sentry;
 };
+
+
 
 #endif // FastSimulation_Particle_ParticleTable_H

--- a/FastSimulation/Particle/interface/ParticleTable.h
+++ b/FastSimulation/Particle/interface/ParticleTable.h
@@ -11,37 +11,29 @@ class ParticleTable {
 
 public:
   struct Sentry{
-    Sentry(const HepPDT::ParticleDataTable* pdt) { 
-      edm::LogError("particletable") << "  Sentry() - set pdt to: " << pdt 
-				     << ' ' << ParticleTable::myself 
-				     << std::endl;
-      ParticleTable::myself->set(pdt); 
+    Sentry(const HepPDT::ParticleDataTable* pdt) {       
+      ParticleTable::instance()->set(pdt); 
     }
-    ~Sentry() { 
-      edm::LogError("particletable") << " ~Sentry() - set pdt to NULL" 
-				      << ' ' << ParticleTable::myself 
-				     << std::endl;
-      ParticleTable::myself->set(nullptr); 
+    ~Sentry() {       
+      ParticleTable::instance()->set(nullptr); 
     }
   };
 
-  ~ParticleTable() { 
-    edm::LogError("particletable") << "~ParticleTable()" << std::endl;
+  ~ParticleTable() {     
   }
 
   /// Get the pointer to the particle data table
-  const HepPDT::ParticleDataTable* theTable() const { 
-    edm::LogError("particletable") << "Asked for theTable at : " << pdt_ << std::endl;
+  const HepPDT::ParticleDataTable* theTable() const {    
     return pdt_; 
   }
 
-  static ParticleTable* const instance() { 
-    edm::LogError("particletable") << "Asked for myself : " << &myself << std::endl;
+  static ParticleTable* const instance() {     
+    if( !myself ) myself = new ParticleTable();
     return myself; 
   }
 
 private:
-  ParticleTable() : pdt_(nullptr) {}
+  
   ParticleTable(const HepPDT::ParticleDataTable* pdt=nullptr) : pdt_(pdt) {}
   void set( const HepPDT::ParticleDataTable* pdt) { pdt_ = pdt; } 
   static thread_local ParticleTable* myself;

--- a/FastSimulation/Particle/interface/RawParticle.h
+++ b/FastSimulation/Particle/interface/RawParticle.h
@@ -17,6 +17,7 @@ class ParticleTable;
 #include <string>
 #include <iosfwd>
 
+#include<memory>
 
 
 /**
@@ -255,7 +256,7 @@ public:
   const ParticleData* myInfo;         //!< The pointer to the PDG info
   
  private:
-  ParticleTable* tab;
+  const ParticleTable* tab;
 };
 
 

--- a/FastSimulation/Particle/src/ParticleTable.cc
+++ b/FastSimulation/Particle/src/ParticleTable.cc
@@ -1,23 +1,8 @@
 #include "FastSimulation/Particle/interface/ParticleTable.h"
 
-std::atomic<ParticleTable*> ParticleTable::myself(NULL); 
+thread_local std::unique_ptr<const ParticleTable> 
+ParticleTable::myself((const ParticleTable*)NULL); 
 
-std::mutex ParticleTable::_mutex;
-
-ParticleTable* 
-ParticleTable::instance(const HepPDT::ParticleDataTable* pdt) {  
-  ParticleTable* tmp  = myself.load(std::memory_order_relaxed);
-  std::atomic_thread_fence(std::memory_order_acquire);
-  if( tmp == NULL ) {
-    std::lock_guard<std::mutex> lock(_mutex);
-    tmp = myself.load(std::memory_order_relaxed);
-    if( tmp == NULL && pdt ) { 
-      // && means we load the singleton the first time we get non-null pdt
-      // since we have acquired a lock here this is thread safe
-      tmp = new ParticleTable(pdt);
-      std::atomic_thread_fence(std::memory_order_release);
-      myself.store(tmp);
-    }
-  }
-  return tmp;
+void ParticleTable::set(const HepPDT::ParticleDataTable* pdt) { 
+  myself.reset( new ParticleTable(pdt) );  
 }

--- a/FastSimulation/Particle/src/ParticleTable.cc
+++ b/FastSimulation/Particle/src/ParticleTable.cc
@@ -1,8 +1,4 @@
 #include "FastSimulation/Particle/interface/ParticleTable.h"
 
-thread_local std::unique_ptr<const ParticleTable> 
-ParticleTable::myself((const ParticleTable*)NULL); 
+thread_local ParticleTable* ParticleTable::myself = new ParticleTable(nullptr);
 
-void ParticleTable::set(const HepPDT::ParticleDataTable* pdt) { 
-  myself.reset( new ParticleTable(pdt) );  
-}

--- a/FastSimulation/Particle/src/ParticleTable.cc
+++ b/FastSimulation/Particle/src/ParticleTable.cc
@@ -1,6 +1,6 @@
 #include "FastSimulation/Particle/interface/ParticleTable.h"
 
-std::atomic<ParticleTable*> ParticleTable::myself; 
+std::atomic<ParticleTable*> ParticleTable::myself(NULL); 
 
 std::mutex ParticleTable::_mutex;
 
@@ -11,9 +11,9 @@ ParticleTable::instance(const HepPDT::ParticleDataTable* pdt) {
   if( tmp == NULL ) {
     std::lock_guard<std::mutex> lock(_mutex);
     tmp = myself.load(std::memory_order_relaxed);
-    if( tmp == NULL || pdt ) { // load a new singleton if given data table
+    if( tmp == NULL && pdt ) { 
+      // && means we load the singleton the first time we get non-null pdt
       // since we have acquired a lock here this is thread safe
-      if( tmp ) delete tmp;
       tmp = new ParticleTable(pdt);
       std::atomic_thread_fence(std::memory_order_release);
       myself.store(tmp);

--- a/FastSimulation/Particle/src/ParticleTable.cc
+++ b/FastSimulation/Particle/src/ParticleTable.cc
@@ -1,10 +1,23 @@
 #include "FastSimulation/Particle/interface/ParticleTable.h"
 
-ParticleTable*
-ParticleTable::myself=0; 
+std::atomic<ParticleTable*> ParticleTable::myself; 
+
+std::mutex ParticleTable::_mutex;
 
 ParticleTable* 
-ParticleTable::instance(const HepPDT::ParticleDataTable* pdt) {
-  if (!myself) myself = new ParticleTable(pdt);
-  return myself;
+ParticleTable::instance(const HepPDT::ParticleDataTable* pdt) {  
+  ParticleTable* tmp  = myself.load(std::memory_order_relaxed);
+  std::atomic_thread_fence(std::memory_order_acquire);
+  if( tmp == NULL ) {
+    std::lock_guard<std::mutex> lock(_mutex);
+    tmp = myself.load(std::memory_order_relaxed);
+    if( tmp == NULL || pdt ) { // load a new singleton if given data table
+      // since we have acquired a lock here this is thread safe
+      if( tmp ) delete tmp;
+      tmp = new ParticleTable(pdt);
+      std::atomic_thread_fence(std::memory_order_release);
+      myself.store(tmp);
+    }
+  }
+  return tmp;
 }

--- a/FastSimulation/Particle/src/ParticleTable.cc
+++ b/FastSimulation/Particle/src/ParticleTable.cc
@@ -1,4 +1,4 @@
 #include "FastSimulation/Particle/interface/ParticleTable.h"
 
-thread_local ParticleTable* ParticleTable::myself = new ParticleTable(nullptr);
+thread_local ParticleTable* ParticleTable::myself = nullptr;
 

--- a/FastSimulation/Particle/src/RawParticle.cc
+++ b/FastSimulation/Particle/src/RawParticle.cc
@@ -15,45 +15,47 @@
 
 //using namespace HepPDT;
 
-RawParticle::RawParticle() {
+RawParticle::RawParticle():
+  tab( ParticleTable::instance() ) {
   init();
 }
 
 RawParticle::RawParticle(const XYZTLorentzVector& p) 
-  : XYZTLorentzVector(p) {
+  : XYZTLorentzVector(p), tab( ParticleTable::instance() )  {
   init();
 }
 
 RawParticle::RawParticle(const int id, 
 			 const XYZTLorentzVector& p) 
-  : XYZTLorentzVector(p) {
+  : XYZTLorentzVector(p), tab( ParticleTable::instance() ) {
   this->init();
   this->setID(id);
 }
 
 RawParticle::RawParticle(const std::string name, 
 			 const XYZTLorentzVector& p) 
-  : XYZTLorentzVector(p) {
+  : XYZTLorentzVector(p), tab( ParticleTable::instance() ) {
   this->init();
   this->setID(name);
 }
 
 RawParticle::RawParticle(const XYZTLorentzVector& p, 
 			 const XYZTLorentzVector& xStart)  : 
-  XYZTLorentzVector(p)
+  XYZTLorentzVector(p), tab( ParticleTable::instance() )
 {
   init();
   myVertex = xStart;
 }
 
 RawParticle::RawParticle(double px, double py, double pz, double e) : 
-  XYZTLorentzVector(px,py,pz,e)
+  XYZTLorentzVector(px,py,pz,e), tab( ParticleTable::instance() )
 {
   init();
 }
 
 RawParticle::RawParticle(const RawParticle &right) : 
-  XYZTLorentzVector(right.Px(),right.Py(),right.Pz(),right.E()) 
+  XYZTLorentzVector(right.Px(),right.Py(),right.Pz(),right.E()),
+  tab( ParticleTable::instance() )
 {
   myId     = right.myId; 
   myStatus = right.myStatus;
@@ -61,7 +63,6 @@ RawParticle::RawParticle(const RawParticle &right) :
   myCharge = right.myCharge;
   myMass   = right.myMass;
   myVertex = (right.myVertex);
-  tab = (right.tab);
   myInfo = (right.myInfo);
 }
 
@@ -80,7 +81,7 @@ RawParticle::operator = (const RawParticle & right ) {
     myCharge = right.myCharge;
     myMass   = right.myMass;
     myVertex = right.myVertex;
-    tab      = right.tab;
+    tab      = ParticleTable::instance();
     myInfo   = right.myInfo;
   }
   return *this;
@@ -93,7 +94,7 @@ RawParticle::init() {
   myUsed=0;
   myCharge=0.;
   myMass=0.;
-  tab = ParticleTable::instance();
+  //tab = ParticleTable::instance();
   myInfo=0;
 }
 

--- a/FastSimulation/PileUpProducer/test/producePileUpEvents.cc
+++ b/FastSimulation/PileUpProducer/test/producePileUpEvents.cc
@@ -38,6 +38,7 @@ private:
   
   // See RecoParticleFlow/PFProducer/interface/PFProducer.h
   edm::ParameterSet particleFilter_;
+  std::unique_ptr<ParticleTable::Sentry> pTableSentry_;
   FSimEvent* mySimEvent;
   PUEvent* puEvent;
   TTree* puTree;
@@ -136,7 +137,9 @@ void producePileUpEvents::beginRun(edm::Run const&, edm::EventSetup const& es)
   // init Particle data table (from Pythia)
   edm::ESHandle < HepPDT::ParticleDataTable > pdt;
   es.getData(pdt);
-  if ( !ParticleTable::instance() ) ParticleTable::instance(&(*pdt));
+  if ( !ParticleTable::instance() ) {
+    pTableSentry_.reset( new ParticleTable::Sentry(pdt.product()) );
+  }
   mySimEvent->initializePdt(&(*pdt));
 
 }

--- a/FastSimulation/PileUpProducer/test/producePileUpEvents.cc
+++ b/FastSimulation/PileUpProducer/test/producePileUpEvents.cc
@@ -38,7 +38,6 @@ private:
   
   // See RecoParticleFlow/PFProducer/interface/PFProducer.h
   edm::ParameterSet particleFilter_;
-  std::unique_ptr<ParticleTable::Sentry> pTableSentry_;
   FSimEvent* mySimEvent;
   PUEvent* puEvent;
   TTree* puTree;
@@ -137,9 +136,7 @@ void producePileUpEvents::beginRun(edm::Run const&, edm::EventSetup const& es)
   // init Particle data table (from Pythia)
   edm::ESHandle < HepPDT::ParticleDataTable > pdt;
   es.getData(pdt);
-  if ( !ParticleTable::instance() ) {
-    pTableSentry_.reset( new ParticleTable::Sentry(pdt.product()) );
-  }
+  
   mySimEvent->initializePdt(&(*pdt));
 
 }
@@ -147,7 +144,7 @@ void producePileUpEvents::beginRun(edm::Run const&, edm::EventSetup const& es)
 void
 producePileUpEvents::produce(edm::Event& iEvent, const edm::EventSetup& iSetup )
 {
-
+  ParticleTable::Sentry(mySimEvent->theTable());
   ++totalPU;
   if ( totalPU/1000*1000 == totalPU ) 
     std::cout << "Number of events produced "

--- a/FastSimulation/Tracking/test/testGeneralTracks.cc
+++ b/FastSimulation/Tracking/test/testGeneralTracks.cc
@@ -49,6 +49,7 @@ private:
   
   // See RecoParticleFlow/PFProducer/interface/PFProducer.h
   edm::ParameterSet particleFilter_;
+  std::unique_ptr<ParticleTable::Sentry> pTableSentry_;
   std::vector<edm::InputTag> allTracks;
   bool saveNU;
   std::vector<FSimEvent*> mySimEvent;
@@ -148,7 +149,9 @@ void testGeneralTracks::beginRun(edm::Run const&, edm::EventSetup const& es)
   // init Particle data table (from Pythia)
   edm::ESHandle < HepPDT::ParticleDataTable > pdt;
   es.getData(pdt);
-  if ( !ParticleTable::instance() ) ParticleTable::instance(&(*pdt));
+  if ( !ParticleTable::instance() ) {
+    pTableSentry_.reset( new ParticleTable::Sentry(pdt.product()) );
+  }
   mySimEvent[0]->initializePdt(&(*pdt));
   mySimEvent[1]->initializePdt(&(*pdt));
 

--- a/FastSimulation/Tracking/test/testGeneralTracks.cc
+++ b/FastSimulation/Tracking/test/testGeneralTracks.cc
@@ -49,7 +49,6 @@ private:
   
   // See RecoParticleFlow/PFProducer/interface/PFProducer.h
   edm::ParameterSet particleFilter_;
-  std::unique_ptr<ParticleTable::Sentry> pTableSentry_;
   std::vector<edm::InputTag> allTracks;
   bool saveNU;
   std::vector<FSimEvent*> mySimEvent;
@@ -149,9 +148,7 @@ void testGeneralTracks::beginRun(edm::Run const&, edm::EventSetup const& es)
   // init Particle data table (from Pythia)
   edm::ESHandle < HepPDT::ParticleDataTable > pdt;
   es.getData(pdt);
-  if ( !ParticleTable::instance() ) {
-    pTableSentry_.reset( new ParticleTable::Sentry(pdt.product()) );
-  }
+  
   mySimEvent[0]->initializePdt(&(*pdt));
   mySimEvent[1]->initializePdt(&(*pdt));
 
@@ -168,7 +165,8 @@ void testGeneralTracks::beginRun(edm::Run const&, edm::EventSetup const& es)
 void
 testGeneralTracks::produce(edm::Event& iEvent, const edm::EventSetup& iSetup )
 {
-  
+  ParticleTable::Sentry ptable(mySimEvent[0]->theTable());
+
   ++totalNEvt;
   
   //  std::cout << " >>>>>>>>> Analizying Event " << totalNEvt << "<<<<<<< " << std::endl; 

--- a/FastSimulation/Tracking/test/testTrackingIterations.cc
+++ b/FastSimulation/Tracking/test/testTrackingIterations.cc
@@ -52,7 +52,6 @@ private:
   
   // See RecoParticleFlow/PFProducer/interface/PFProducer.h
   edm::ParameterSet particleFilter_;
-  std::unique_ptr<ParticleTable::Sentry> pTableSentry_;
   std::vector<edm::InputTag> zeroTracks;
   std::vector<edm::InputTag> firstTracks;
   std::vector<edm::InputTag> secondTracks;
@@ -333,9 +332,7 @@ void testTrackingIterations::beginRun(edm::Run const&, edm::EventSetup const& es
   // init Particle data table (from Pythia)
   edm::ESHandle < HepPDT::ParticleDataTable > pdt;
   es.getData(pdt);
-  if ( !ParticleTable::instance() ) {
-    pTableSentry_.reset( new ParticleTable::Sentry(pdt.product()) );
-  }
+  
   mySimEvent[0]->initializePdt(&(*pdt));
   mySimEvent[1]->initializePdt(&(*pdt));
 
@@ -351,6 +348,8 @@ void testTrackingIterations::beginRun(edm::Run const&, edm::EventSetup const& es
 void
 testTrackingIterations::produce(edm::Event& iEvent, const edm::EventSetup& iSetup )
 {
+  ParticleTable::Sentry ptable(mySimEvent[0]->theTable());
+
   //Retrieve tracker topology from geometry
   edm::ESHandle<TrackerTopology> tTopoHand;
   iSetup.get<IdealGeometryRecord>().get(tTopoHand);

--- a/FastSimulation/Tracking/test/testTrackingIterations.cc
+++ b/FastSimulation/Tracking/test/testTrackingIterations.cc
@@ -52,6 +52,7 @@ private:
   
   // See RecoParticleFlow/PFProducer/interface/PFProducer.h
   edm::ParameterSet particleFilter_;
+  std::unique_ptr<ParticleTable::Sentry> pTableSentry_;
   std::vector<edm::InputTag> zeroTracks;
   std::vector<edm::InputTag> firstTracks;
   std::vector<edm::InputTag> secondTracks;
@@ -332,7 +333,9 @@ void testTrackingIterations::beginRun(edm::Run const&, edm::EventSetup const& es
   // init Particle data table (from Pythia)
   edm::ESHandle < HepPDT::ParticleDataTable > pdt;
   es.getData(pdt);
-  if ( !ParticleTable::instance() ) ParticleTable::instance(&(*pdt));
+  if ( !ParticleTable::instance() ) {
+    pTableSentry_.reset( new ParticleTable::Sentry(pdt.product()) );
+  }
   mySimEvent[0]->initializePdt(&(*pdt));
   mySimEvent[1]->initializePdt(&(*pdt));
 

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFCTRecHitProducer.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFCTRecHitProducer.h
@@ -7,7 +7,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -32,7 +32,7 @@ class CaloSubdetectorTopology;
 class CaloSubdetectorGeometry;
 class DetId;
 
-class PFCTRecHitProducer : public edm::stream::EDProducer<> {
+class PFCTRecHitProducer : public edm::EDProducer {
  public:
   explicit PFCTRecHitProducer(const edm::ParameterSet&);
   ~PFCTRecHitProducer();

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFRecHitProducer.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFRecHitProducer.h
@@ -4,7 +4,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -18,7 +18,7 @@
 // class declaration
 //
 
-class PFRecHitProducer : public edm::stream::EDProducer<> {
+class PFRecHitProducer : public edm::EDProducer {
    public:
       explicit PFRecHitProducer(const edm::ParameterSet& iConfig);
       ~PFRecHitProducer();

--- a/RecoParticleFlow/PFSimProducer/plugins/PFSimParticleProducer.cc
+++ b/RecoParticleFlow/PFSimProducer/plugins/PFSimParticleProducer.cc
@@ -121,7 +121,9 @@ PFSimParticleProducer::beginRun(const edm::Run& run,
   edm::ESHandle < HepPDT::ParticleDataTable > pdt;
   //  edm::ESHandle < DefaultConfig::ParticleDataTable > pdt;
   es.getData(pdt);
-  if ( !ParticleTable::instance() ) ParticleTable::instance(&(*pdt));
+  if ( !ParticleTable::instance() ) {
+    pTableSentry_.reset( new ParticleTable::Sentry(pdt.product()) );
+  }
   mySimEvent->initializePdt(&(*pdt));
 
 }

--- a/RecoParticleFlow/PFSimProducer/plugins/PFSimParticleProducer.cc
+++ b/RecoParticleFlow/PFSimProducer/plugins/PFSimParticleProducer.cc
@@ -115,24 +115,19 @@ PFSimParticleProducer::~PFSimParticleProducer()
 void 
 PFSimParticleProducer::beginRun(const edm::Run& run,
 				const edm::EventSetup & es)
-{
-  
+{  
   // init Particle data table (from Pythia)
   edm::ESHandle < HepPDT::ParticleDataTable > pdt;
   //  edm::ESHandle < DefaultConfig::ParticleDataTable > pdt;
   es.getData(pdt);
-  if ( !ParticleTable::instance() ) {
-    pTableSentry_.reset( new ParticleTable::Sentry(pdt.product()) );
-  }
   mySimEvent->initializePdt(&(*pdt));
-
 }
 
 
 void PFSimParticleProducer::produce(Event& iEvent, 
 				    const EventSetup& iSetup) 
-{
-  
+{  
+  ParticleTable::Sentry ptable(mySimEvent->theTable());
   LogDebug("PFSimParticleProducer")<<"START event: "<<iEvent.id().event()
 				   <<" in run "<<iEvent.id().run()<<endl;
  

--- a/RecoParticleFlow/PFSimProducer/plugins/PFSimParticleProducer.h
+++ b/RecoParticleFlow/PFSimProducer/plugins/PFSimParticleProducer.h
@@ -22,6 +22,7 @@
 
 #include "RecoParticleFlow/PFProducer/interface/PFBlockAlgo.h"
 
+#include "FastSimulation/Particle/interface/ParticleTable.h"
 
 /**\class PFSimParticleProducer 
 \brief Producer for PFRecTracks and PFSimParticles
@@ -78,6 +79,8 @@ class PFSimParticleProducer : public edm::EDProducer {
 
   /// verbose ?
   bool   verbose_;
+
+  std::unique_ptr<ParticleTable::Sentry> pTableSentry_;
 
 };  
 

--- a/RecoParticleFlow/PFSimProducer/plugins/PFSimParticleProducer.h
+++ b/RecoParticleFlow/PFSimProducer/plugins/PFSimParticleProducer.h
@@ -80,8 +80,6 @@ class PFSimParticleProducer : public edm::EDProducer {
   /// verbose ?
   bool   verbose_;
 
-  std::unique_ptr<ParticleTable::Sentry> pTableSentry_;
-
 };  
 
 #endif

--- a/RecoParticleFlow/PFSimProducer/plugins/TauHadronDecayFilter.cc
+++ b/RecoParticleFlow/PFSimProducer/plugins/TauHadronDecayFilter.cc
@@ -96,8 +96,9 @@ TauHadronDecayFilter::beginRun(const edm::Run& run,
   // edm::ESHandle < DefaultConfig::ParticleDataTable > pdt;
 
   es.getData(pdt);
-  if ( !ParticleTable::instance() ) 
-    ParticleTable::instance(&(*pdt));
+  if ( !ParticleTable::instance() ) {
+    pTableSentry_.reset( new ParticleTable::Sentry(pdt.product()) );
+  }
   mySimEvent->initializePdt(&(*pdt));
 
 }

--- a/RecoParticleFlow/PFSimProducer/plugins/TauHadronDecayFilter.cc
+++ b/RecoParticleFlow/PFSimProducer/plugins/TauHadronDecayFilter.cc
@@ -54,8 +54,8 @@ TauHadronDecayFilter::~TauHadronDecayFilter() {
 bool
 TauHadronDecayFilter::filter(edm::Event& iEvent, 
 			     const edm::EventSetup& iSetup) {
-
-  
+  ParticleTable::Sentry ptable(mySimEvent->theTable());
+    
   Handle<vector<SimTrack> > simTracks;
   iEvent.getByLabel("g4SimHits",simTracks);
   Handle<vector<SimVertex> > simVertices;
@@ -96,9 +96,6 @@ TauHadronDecayFilter::beginRun(const edm::Run& run,
   // edm::ESHandle < DefaultConfig::ParticleDataTable > pdt;
 
   es.getData(pdt);
-  if ( !ParticleTable::instance() ) {
-    pTableSentry_.reset( new ParticleTable::Sentry(pdt.product()) );
-  }
   mySimEvent->initializePdt(&(*pdt));
 
 }

--- a/RecoParticleFlow/PFSimProducer/plugins/TauHadronDecayFilter.h
+++ b/RecoParticleFlow/PFSimProducer/plugins/TauHadronDecayFilter.h
@@ -4,6 +4,7 @@
 #include "FWCore/Framework/interface/EDFilter.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
+#include "FastSimulation/Particle/interface/ParticleTable.h"
 
 // -*- C++ -*-
 //
@@ -40,6 +41,7 @@ class TauHadronDecayFilter : public edm::EDFilter {
   edm::ParameterSet  vertexGenerator_; 
   edm::ParameterSet  particleFilter_;
   FSimEvent* mySimEvent;
+  std::unique_ptr<ParticleTable::Sentry> pTableSentry_;
 };
 
 #endif


### PR DESCRIPTION
@Dr15Jones

Fix singleton inside of fastim to be thread safe (memory barrier + mutex for possible loading).
Revert rechit producers back to standard EDProducers due to unsafe HcalChannelQuality ES product.
I'll try to make HcalChannelQuality safe, when I get a little more time.
