### PR TITLE
Tracking: Switch off cluster shape in step6 seeding

### DIFF
--- a/RecoPixelVertexing/PixelLowPtUtilities/interface/ClusterShapeHitFilter.h
+++ b/RecoPixelVertexing/PixelLowPtUtilities/interface/ClusterShapeHitFilter.h
@@ -164,6 +164,9 @@ class ClusterShapeHitFilter
  
   ~ClusterShapeHitFilter();
 
+  void setShapeCuts(bool cutOnPixelShape, bool cutOnStripShape) {
+    cutOnPixelShape_ = cutOnPixelShape; cutOnStripShape_ = cutOnStripShape;}
+
   void setChargeCuts(bool cutOnPixelCharge, float minGoodPixelCharge,
 	bool cutOnStripCharge, float minGoodStripCharge) {
     cutOnPixelCharge_ = cutOnPixelCharge; minGoodPixelCharge_= minGoodPixelCharge;
@@ -248,6 +251,7 @@ class ClusterShapeHitFilter
   float theAngle[6];
   bool cutOnPixelCharge_, cutOnStripCharge_;
   float minGoodPixelCharge_, minGoodStripCharge_;
+  bool cutOnPixelShape_, cutOnStripShape_;
   bool checkClusterCharge(DetId detId, const SiStripCluster& cluster, const LocalVector & ldir) const;
   bool checkClusterCharge(DetId detId, const SiPixelCluster& cluster, const LocalVector & ldir) const;
 };

--- a/RecoPixelVertexing/PixelLowPtUtilities/interface/ClusterShapeHitFilterESProducer.h
+++ b/RecoPixelVertexing/PixelLowPtUtilities/interface/ClusterShapeHitFilterESProducer.h
@@ -51,6 +51,7 @@ class ClusterShapeHitFilterESProducer : public edm::ESProducer
   const std::string use_PixelShapeFile;
   bool cutOnPixelCharge_, cutOnStripCharge_;
   float minGoodPixelCharge_, minGoodStripCharge_;
+  bool cutOnPixelShape_, cutOnStripShape_;
 };
 
 #endif

--- a/RecoPixelVertexing/PixelLowPtUtilities/src/ClusterShapeHitFilter.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/src/ClusterShapeHitFilter.cc
@@ -55,6 +55,7 @@ ClusterShapeHitFilter::ClusterShapeHitFilter
   // Load strip limits
   loadStripLimits();
   cutOnPixelCharge_ = cutOnStripCharge_ = false;
+  cutOnPixelShape_ = cutOnStripShape_ = true;
 }
 
 /*****************************************************************************/
@@ -306,6 +307,7 @@ bool ClusterShapeHitFilter::isCompatible
 {
  // Get detector
   if (cutOnPixelCharge_ && (!checkClusterCharge(recHit.geographicalId(), *(recHit.cluster()), ldir))) return false;
+  if (!cutOnPixelShape_) return true;
 
   const PixelData & pd = getpd(recHit,ipd);
 
@@ -387,6 +389,7 @@ bool ClusterShapeHitFilter::isCompatible
   float pred;
 
   if (cutOnStripCharge_ && (!checkClusterCharge(detId, cluster, ldir))) return false;
+  if (!cutOnStripShape_) return true;
 
   if(getSizes(detId, cluster, ldir, meas, pred))
   {

--- a/RecoPixelVertexing/PixelLowPtUtilities/src/ClusterShapeHitFilterESProducer.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/src/ClusterShapeHitFilterESProducer.cc
@@ -19,6 +19,8 @@ ClusterShapeHitFilterESProducer::ClusterShapeHitFilterESProducer
   cutOnStripCharge_ = iConfig.exists("minGoodStripCharge");
   minGoodPixelCharge_= (cutOnPixelCharge_ ? iConfig.getParameter<double>("minGoodPixelCharge") : 0); 
   minGoodStripCharge_= (cutOnStripCharge_ ? iConfig.getParameter<double>("minGoodStripCharge") : 0);
+  cutOnPixelShape_ = (iConfig.exists("doPixelShapeCut") ? iConfig.getParameter<bool>("doPixelShapeCut") : true);
+  cutOnStripShape_ = (iConfig.exists("doStripShapeCut") ? iConfig.getParameter<bool>("doStripShapeCut") : true);
 
   edm::LogInfo("ClusterShapeHitFilterESProducer")
     << " with name: "            << componentName;
@@ -67,6 +69,7 @@ ClusterShapeHitFilterESProducer::produce
                                       pixel.product(),
                                       strip.product(),
                                       &use_PixelShapeFile));
+  aFilter->setShapeCuts(cutOnPixelShape_, cutOnStripShape_);
   aFilter->setChargeCuts(cutOnPixelCharge_, minGoodPixelCharge_, cutOnStripCharge_,
     minGoodStripCharge_);
   return aFilter;

--- a/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
@@ -100,7 +100,8 @@ import RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cf
 tobTecStepClusterShapeHitFilter  = RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi.ClusterShapeHitFilterESProducer.clone(
 	ComponentName = cms.string('tobTecStepClusterShapeHitFilter'),
         PixelShapeFile= cms.string('RecoPixelVertexing/PixelLowPtUtilities/data/pixelShape.par'),
-	minGoodStripCharge = cms.double(2069)
+	minGoodStripCharge = cms.double(2069),
+	doStripShapeCut  = cms.bool(False)
 	)
 
 import RecoTracker.TkSeedGenerator.GlobalMixedSeeds_cff


### PR DESCRIPTION
By removing the cluster shape filter in the TobTec step seeding, the efficiency for displaced tracks is increased from ~23 to ~26 %. This recovers the lost efficiency when the CCC was introduced.
