### PR TITLE
Revert Tracking modules back to stream modules

### DIFF
--- a/RecoTracker/CkfPattern/interface/CkfTrackCandidateMaker.h
+++ b/RecoTracker/CkfPattern/interface/CkfTrackCandidateMaker.h
@@ -1,7 +1,7 @@
 #ifndef CkfTrackCandidateMaker_h
 #define CkfTrackCandidateMaker_h
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -23,7 +23,7 @@ class TransientInitialStateEstimator;
 
 namespace cms
 {
-  class CkfTrackCandidateMaker : public edm::EDProducer, public CkfTrackCandidateMakerBase
+  class CkfTrackCandidateMaker : public edm::stream::EDProducer<>, public CkfTrackCandidateMakerBase
   {
   public:
 

--- a/RecoTracker/CkfPattern/interface/CkfTrajectoryMaker.h
+++ b/RecoTracker/CkfPattern/interface/CkfTrajectoryMaker.h
@@ -1,7 +1,7 @@
 #ifndef CkfTrajectoryMaker_h
 #define CkfTrajectoryMaker_h
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -23,7 +23,7 @@ class TransientInitialStateEstimator;
 
 namespace cms
 {
-  class CkfTrajectoryMaker : public edm::EDProducer, public CkfTrackCandidateMakerBase
+  class CkfTrajectoryMaker : public edm::stream::EDProducer<>, public CkfTrackCandidateMakerBase
   {
   public:
     typedef std::vector<Trajectory> TrajectoryCollection;

--- a/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromRegionHitsEDProducer.h
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromRegionHitsEDProducer.h
@@ -1,7 +1,7 @@
 #ifndef RecoTracker_TkSeedGenerator_SeedGeneratorFromRegionHitsEDProducer_H
 #define RecoTracker_TkSeedGenerator_SeedGeneratorFromRegionHitsEDProducer_H
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "RecoTracker/SpecialSeedGenerators/interface/ClusterChecker.h"
 
@@ -11,7 +11,7 @@ class SeedGeneratorFromRegionHits;
 class TrackingRegionProducer;
 class QuadrupletSeedMerger;
 
-class SeedGeneratorFromRegionHitsEDProducer : public edm::EDProducer {
+class SeedGeneratorFromRegionHitsEDProducer : public edm::stream::EDProducer<> {
 public:
 
   SeedGeneratorFromRegionHitsEDProducer(const edm::ParameterSet& cfg);


### PR DESCRIPTION
The static analyzer is reporting that the thread safety issues
with the tracking modules has been fixed so we should be able to
run these as stream modules.
