### PR TITLE
Made static const in MSLayersAtAngle

### DIFF
--- a/RecoTracker/TkMSParametrization/src/MSLayersAtAngle.cc
+++ b/RecoTracker/TkMSParametrization/src/MSLayersAtAngle.cc
@@ -83,7 +83,7 @@ float MSLayersAtAngle::sumX0D( int il, int ol,
 
 //------------------------------------------------------------------------------
 
-bool doPrint=false;
+static const bool doPrint=false;
 
 float MSLayersAtAngle::sumX0D(
     const PixelRecoPointRZ & pointI,


### PR DESCRIPTION
The file local static doPrint never changes and is not meant to be
seen outside of the file. Therefore declared the variable static const.
Even if there was logic to change value of doPrint at run time, it
wouldn't work well with the threaded framework.
