### PR TITLE
Multithreading cleanup up in GeomDet

### DIFF
--- a/Alignment/ReferenceTrajectories/plugins/TwoBodyDecayTrajectoryFactory.cc
+++ b/Alignment/ReferenceTrajectories/plugins/TwoBodyDecayTrajectoryFactory.cc
@@ -267,7 +267,7 @@ bool TwoBodyDecayTrajectoryFactory::match( const TrajectoryStateOnSurface& state
   double varX = le.xx();
   double varY = le.yy();
 
-  AlignmentPositionError* gape = recHit->det()->alignmentPositionError();
+  AlignmentPositionError const* gape = recHit->det()->alignmentPositionError();
   if ( gape )
   {
     ErrorFrameTransformer eft;

--- a/Geometry/CommonDetUnit/interface/GeomDet.h
+++ b/Geometry/CommonDetUnit/interface/GeomDet.h
@@ -85,7 +85,7 @@ public:
   virtual const GeomDet* component(DetId /*id*/) const {return 0;}
 
   /// Return pointer to alignment errors. 
-  AlignmentPositionError* alignmentPositionError() const { return theAlignmentPositionError;}
+  AlignmentPositionError const* alignmentPositionError() const { return theAlignmentPositionError;}
 
 
   // specific unix index in a given subdetector (such as Tracker)


### PR DESCRIPTION
Add const to the declaration of a function
return type. The returned pointer was not
being used to modify anything. Eliminates
a static analyzer warning.
