### PR TITLE
initialized var.multiplicity

### DIFF
--- a/PhysicsTools/MVAComputer/src/MVAComputer.cc
+++ b/PhysicsTools/MVAComputer/src/MVAComputer.cc
@@ -126,6 +126,7 @@ void MVAComputer::setup(const Calibration::MVAComputer *calib)
 		InputVar var;
 		var.var = Variable(iter->name, config[i].mask);
 		var.index = i;
+		var.multiplicity = 0;
 		variables.insert(var);
 	}
 


### PR DESCRIPTION
Follow up of :
https://github.com/cms-sw/cmssw/pull/3797
-> initialize var.multiplicity = 0 (line disappeared unintended).
