### PR TITLE
Preclustering some jet algos

### DIFF
--- a/Alignment/ReferenceTrajectories/plugins/TwoBodyDecayTrajectoryFactory.cc
+++ b/Alignment/ReferenceTrajectories/plugins/TwoBodyDecayTrajectoryFactory.cc
@@ -267,7 +267,7 @@ bool TwoBodyDecayTrajectoryFactory::match( const TrajectoryStateOnSurface& state
   double varX = le.xx();
   double varY = le.yy();
 
-  AlignmentPositionError* gape = recHit->det()->alignmentPositionError();
+  AlignmentPositionError const* gape = recHit->det()->alignmentPositionError();
   if ( gape )
   {
     ErrorFrameTransformer eft;

--- a/Configuration/PyReleaseValidation/python/relval_standard.py
+++ b/Configuration/PyReleaseValidation/python/relval_standard.py
@@ -165,7 +165,8 @@ workflows[33] = ['', ['PhotonJets_Pt_10','DIGI','RECO','HARVEST']]
 workflows[34] = ['', ['QQH1352T_Tauola','DIGI','RECO','HARVEST']]
 workflows[46] = ['', ['ZmumuJets_Pt_20_300']]
 
-workflows[7]  = ['', ['Cosmics','DIGICOS','RECOCOS','ALCACOS','HARVESTCOS']]
+# wip gen-sim being made in 71x_pre7: wf uncomment once available 
+# workflows[7]  = ['', ['Cosmics','DIGICOS','RECOCOS','ALCACOS','HARVESTCOS']]
 workflows[8]  = ['', ['BeamHalo','DIGICOS','RECOCOS','ALCABH','HARVESTCOS']]
 workflows[11] = ['', ['MinBias','DIGI','RECOMIN','HARVEST','ALCAMIN']]
 workflows[28] = ['', ['QCD_Pt_80_120','DIGI','RECO','HARVEST']]
@@ -200,6 +201,7 @@ workflows[1333] = ['', ['PhotonJets_Pt_10_13','DIGIUP15','RECOUP15','HARVESTUP15
 workflows[1334] = ['', ['QQH1352T_Tauola_13','DIGIUP15','RECOUP15','HARVESTUP15']]
 workflows[1346] = ['', ['ZmumuJets_Pt_20_300_13']]
 
+workflows[1307]  = ['', ['Cosmics_UP15','DIGIHAL','RECOHAL','ALCAHAL','HARVESTHAL']]
 workflows[1308]  = ['', ['BeamHalo_13','DIGIHAL','RECOHAL','ALCAHAL','HARVESTHAL']]
 workflows[1311] = ['', ['MinBias_13','DIGIUP15','RECOMINUP15','HARVESTUP15','ALCAMIN']]
 workflows[1328] = ['', ['QCD_Pt_80_120_13','DIGIUP15','RECOUP15','HARVESTUP15']]

--- a/Configuration/PyReleaseValidation/python/relval_standard.py
+++ b/Configuration/PyReleaseValidation/python/relval_standard.py
@@ -166,7 +166,7 @@ workflows[34] = ['', ['QQH1352T_Tauola','DIGI','RECO','HARVEST']]
 workflows[46] = ['', ['ZmumuJets_Pt_20_300']]
 
 # wip gen-sim being made in 71x_pre7: GF wf uncomment once available 
-# workflows[7]  = ['', ['Cosmics','DIGICOS','RECOCOS','ALCACOS','HARVESTCOS']]
+workflows[7]  = ['', ['Cosmics','DIGICOS','RECOCOS','ALCACOS','HARVESTCOS']]
 workflows[8]  = ['', ['BeamHalo','DIGICOS','RECOCOS','ALCABH','HARVESTCOS']]
 workflows[11] = ['', ['MinBias','DIGI','RECOMIN','HARVEST','ALCAMIN']]
 workflows[28] = ['', ['QCD_Pt_80_120','DIGI','RECO','HARVEST']]

--- a/Configuration/PyReleaseValidation/python/relval_standard.py
+++ b/Configuration/PyReleaseValidation/python/relval_standard.py
@@ -165,7 +165,7 @@ workflows[33] = ['', ['PhotonJets_Pt_10','DIGI','RECO','HARVEST']]
 workflows[34] = ['', ['QQH1352T_Tauola','DIGI','RECO','HARVEST']]
 workflows[46] = ['', ['ZmumuJets_Pt_20_300']]
 
-# wip gen-sim being made in 71x_pre7: wf uncomment once available 
+# wip gen-sim being made in 71x_pre7: GF wf uncomment once available 
 # workflows[7]  = ['', ['Cosmics','DIGICOS','RECOCOS','ALCACOS','HARVESTCOS']]
 workflows[8]  = ['', ['BeamHalo','DIGICOS','RECOCOS','ALCABH','HARVESTCOS']]
 workflows[11] = ['', ['MinBias','DIGI','RECOMIN','HARVEST','ALCAMIN']]

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -321,8 +321,8 @@ steps['SingleMuPt10_ID']=identitySim(steps['SingleMuPt10'])
 steps['TTbar_ID']=identitySim(steps['TTbar'])
 
 baseDataSetRelease=[
-    'CMSSW_6_2_0_pre8-PRE_ST62_V8-v1',  # 8 TeV , keep old GEN-SIM for samples not routinely produced
-    'CMSSW_7_1_0_pre5-STARTHI71_V1-v1', # Run1 HI GEN-SIM (only MB = wf 140)
+    'CMSSW_7_1_0_pre7-PRE_STA71_V3-v1', # run1 samples; keep GEN-SIM fixed to 710_pre7, for samples not routinely produced
+    'CMSSW_7_1_0_pre6-PRE_SHI71_V3-v1', # Run1 HI GEN-SIM (only MB = wf 140)
     'CMSSW_6_2_0_pre8-PRE_ST62_V8_FastSim-v1', # for fastsim id test
     'CMSSW_6_2_0_pre8-PRE_SH62_V15-v2', # Run1 HI GEN-SIM (only HydjetQ_B3_2760)
     'CMSSW_6_1_0_pre6-STARTHI61_V6-v1', # Run1 HI GEN-SIM (only HydjetQ_B0_2760)
@@ -332,13 +332,11 @@ baseDataSetRelease=[
     'CMSSW_7_1_0_pre5-START71_V1-v1',   # 8 TeV , for the one sample which is part of the routine relval production (MinBias)
     'CMSSW_7_1_0_pre5-START71_V1-v2',   # 8 TeV , for the one sample which is part of the routine relval production (RelValZmumuJets_Pt_20_300, because of -v2)
                                         # this an previous should be unified, when -v2 will be gone
-#    'CMSSW_7_1_0_pre6-PRE_LS171_V3-v1', # 13 TeV samples with GEN-SIM from 710pre6 done w/ GT which gives the geometry of 710pre5
     'CMSSW_7_1_0_pre6-PRE_LS171_V5-v1', # 13 TeV samples with GEN-SIM from 710pre6; geometry is the updated one provuded by the 710pre6 GT
-    'CMSSW_7_1_0_pre6-PRE_STA71_V2-v1', # 8 TeV samples with GEN-SIM from 710pre6
     ]
 
 # note: INPUT commands to be added once GEN-SIM w/ 13TeV+PostLS1Geo will be available 
-steps['MinBiasINPUT']={'INPUT':InputInfo(dataSet='/RelValMinBias/%s/GEN-SIM'%(baseDataSetRelease[11],),location='STD')} #was [0] 
+steps['MinBiasINPUT']={'INPUT':InputInfo(dataSet='/RelValMinBias/%s/GEN-SIM'%(baseDataSetRelease[0],),location='STD')} #was [0] 
 steps['QCD_Pt_3000_3500INPUT']={'INPUT':InputInfo(dataSet='/RelValQCD_Pt_3000_3500/%s/GEN-SIM'%(baseDataSetRelease[0],),location='STD')}
 steps['QCD_Pt_600_800INPUT']={'INPUT':InputInfo(dataSet='/RelValQCD_Pt_600_800/%s/GEN-SIM'%(baseDataSetRelease[0],),location='STD')}
 steps['QCD_Pt_80_120INPUT']={'INPUT':InputInfo(dataSet='/RelValQCD_Pt_80_120/%s/GEN-SIM'%(baseDataSetRelease[0],),location='STD')}
@@ -364,9 +362,10 @@ steps['Wjet_Pt_3000_3500INPUT']={'INPUT':InputInfo(dataSet='/RelValWjet_Pt_3000_
 steps['LM1_sftsINPUT']={'INPUT':InputInfo(dataSet='/RelValLM1_sfts/%s/GEN-SIM'%(baseDataSetRelease[0],),location='STD')}
 steps['QCD_FlatPt_15_3000INPUT']={'INPUT':InputInfo(dataSet='/RelValQCD_FlatPt_15_3000/%s/GEN-SIM'%(baseDataSetRelease[0],),location='STD')}
 
-steps['QCD_FlatPt_15_3000HSINPUT']={'INPUT':InputInfo(dataSet='/RelValQCD_FlatPt_15_3000HS/CMSSW_6_2_0_pre8-PRE_ST62_V8-v1/GEN-SIM',location='STD')}
-#the following dataset used to be in input but is currently not valid dbs datasets
-steps['QCD_FlatPt_15_3000HS__DIGIPU1INPUT']={'INPUT':InputInfo(dataSet='/RelValQCD_FlatPt_15_3000/CMSSW_5_2_2-PU_START52_V4_special_120326-v1/GEN-SIM-DIGI-RAW-HLTDEBUG',location='STD')}
+steps['QCD_FlatPt_15_3000HSINPUT']={'INPUT':InputInfo(dataSet='/RelValQCD_FlatPt_15_3000HS/%s/GEN-SIM'%(baseDataSetRelease[0],),location='STD')}
+# the following dataset used to be in input but is currently not valid dbs datasets
+# candidate for removal..
+# steps['QCD_FlatPt_15_3000HS__DIGIPU1INPUT']={'INPUT':InputInfo(dataSet='/RelValQCD_FlatPt_15_3000/CMSSW_5_2_2-PU_START52_V4_special_120326-v1/GEN-SIM-DIGI-RAW-HLTDEBUG',location='STD')}
 steps['TTbar__DIGIPU1INPUT']={'INPUT':InputInfo(dataSet='/RelValTTbar/CMSSW_5_2_2-PU_START52_V4_special_120326-v1/GEN-SIM-DIGI-RAW-HLTDEBUG',location='STD')}
 
 # 13 TeV recycle GEN-SIM input
@@ -401,6 +400,8 @@ steps['ZmumuJets_Pt_20_300_13INPUT']={'INPUT':InputInfo(dataSet='/RelValZmumuJet
 steps['ADDMonoJet_d3MD3_13INPUT']={'INPUT':InputInfo(dataSet='/RelValADDMonoJet_d3MD3_13/%s/GEN-SIM'%(baseDataSetRelease[10],),location='STD')}
 steps['RSKKGluon_m3000GeV_13INPUT']={'INPUT':InputInfo(dataSet='/RelValRSKKGluon_m3000GeV_13/%s/GEN-SIM'%(baseDataSetRelease[10],),location='STD')}
 steps['Pythia6_BuJpsiK_TuneZ2star_13INPUT']={'INPUT':InputInfo(dataSet='/RelValPythia6_BuJpsiK_TuneZ2star_13/%s/GEN-SIM'%(baseDataSetRelease[10],),location='STD')}
+# new wf, GEN-SIM being made in 71x_pre6: GF uncomment when they'll be available
+#steps['Cosmics_UP15INPUT']={'INPUT':InputInfo(dataSet='/RelValCosmics_UP15/%s/GEN-SIM'%(baseDataSetRelease[10],),location='STD')}
 steps['BeamHalo_13INPUT']={'INPUT':InputInfo(dataSet='/RelValBeamHalo_13/%s/GEN-SIM'%(baseDataSetRelease[10],),location='STD')}
 # particle guns with postLS1 geometry recycle GEN-SIM input
 steps['SingleElectronPt10_UP15INPUT']={'INPUT':InputInfo(dataSet='/RelValSingleElectronPt10_UP15/%s/GEN-SIM'%(baseDataSetRelease[10],),location='STD')}
@@ -498,10 +499,11 @@ steps['ZpEE_2250_8TeV_TauolaINPUT']={'INPUT':InputInfo(dataSet='/RelValZpEE_2250
 steps['ZpTT_1500_8TeV_TauolaINPUT']={'INPUT':InputInfo(dataSet='/RelValZpTT_1500_8TeV_Tauola/%s/GEN-SIM'%(baseDataSetRelease[0],),location='STD')}
 
 
-steps['ZmumuJets_Pt_20_300INPUT']={'INPUT':InputInfo(dataSet='/RelValZmumuJets_Pt_20_300/%s/GEN-SIM'%(baseDataSetRelease[11],),location='STD')}
+steps['ZmumuJets_Pt_20_300INPUT']={'INPUT':InputInfo(dataSet='/RelValZmumuJets_Pt_20_300/%s/GEN-SIM'%(baseDataSetRelease[0],),location='STD')}
 
 
 steps['Cosmics']=merge([{'cfg':'UndergroundCosmicMu_cfi.py','--scenario':'cosmics'},Kby(666,100000),step1Defaults])
+steps['Cosmics_UP15']=merge([{'cfg':'UndergroundCosmicMu_cfi.py','--scenario':'cosmics'},Kby(666,100000),step1Up2015Defaults])
 steps['BeamHalo']=merge([{'cfg':'BeamHalo_cfi.py','--scenario':'cosmics'},Kby(9,100),step1Defaults])
 steps['BeamHalo_13']=merge([{'cfg':'BeamHalo_13TeV_cfi.py','--scenario':'cosmics'},Kby(9,100),step1Up2015Defaults])
 
@@ -761,11 +763,6 @@ steps['MinBias_TuneZ2star_UPG2017_14']=gen2017('MinBias_TuneZ2star_14TeV_pythia6
 steps['WM_UPG2017_14']=gen2017('WM_14TeV_cfi',Kby(9,200))
 steps['ZMM_UPG2017_14']=gen2017('ZMM_14TeV_cfi',Kby(18,300))
 
-#steps['ADDMonoJet_d3MD3_UPG2017_14']=gen2017('ADDMonoJet_14TeV_d3MD3_cfi',Kby(9,100))
-#steps['ZpMM_UPG2017_14']=gen2017('ZpMM_14TeV_cfi',Kby(9,200))
-#steps['WpM_UPG2017_14']=gen2017('WpM_14TeV_cfi',Kby(9,200))
-
-
 
 ## pPb tests
 step1PPbDefaults={'--beamspot':'Realistic8TeVCollisionPPbBoost'}
@@ -914,7 +911,8 @@ steps['ReggeGribovPartonMC_EposLHC_5TeV_pPb']=genvalid('GeneratorInterface/Regge
 
 #PU for FullSim
 PU={'-n':10,'--pileup':'default','--pileup_input':'das:/RelValMinBias/%s/GEN-SIM'%(baseDataSetRelease[0],)}
-PU2={'-n':10,'--pileup':'default','--pileup_input':'das:/RelValMinBias/%s/GEN-SIM'%(baseDataSetRelease[11],)}
+# pu2 can be removed
+PU2={'-n':10,'--pileup':'default','--pileup_input':'das:/RelValMinBias/%s/GEN-SIM'%(baseDataSetRelease[0],)}
 PU25={'-n':10,'--pileup':'AVE_10_BX_25ns_m8','--pileup_input':'das:/RelValMinBias_13/%s/GEN-SIM'%(baseDataSetRelease[10],)}
 PU50={'-n':10,'--pileup':'AVE_20_BX_50ns_m8','--pileup_input':'das:/RelValMinBias_13/%s/GEN-SIM'%(baseDataSetRelease[10],)}
 

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -507,7 +507,8 @@ steps['Cosmics_UP15']=merge([{'cfg':'UndergroundCosmicMu_cfi.py','--scenario':'c
 steps['BeamHalo']=merge([{'cfg':'BeamHalo_cfi.py','--scenario':'cosmics'},Kby(9,100),step1Defaults])
 steps['BeamHalo_13']=merge([{'cfg':'BeamHalo_13TeV_cfi.py','--scenario':'cosmics'},Kby(9,100),step1Up2015Defaults])
 
-steps['CosmicsINPUT']={'INPUT':InputInfo(dataSet='/RelValCosmics/%s/GEN-SIM'%(baseDataSetRelease[0],),location='STD')}
+# GF re-introduce INPUT command once GEN-SIM will be available
+# steps['CosmicsINPUT']={'INPUT':InputInfo(dataSet='/RelValCosmics/%s/GEN-SIM'%(baseDataSetRelease[0],),location='STD')}
 steps['BeamHaloINPUT']={'INPUT':InputInfo(dataSet='/RelValBeamHalo/%s/GEN-SIM'%(baseDataSetRelease[0],),location='STD')}
 
 steps['QCD_Pt_50_80']=genS('QCD_Pt_50_80_8TeV_cfi',Kby(25,100))

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -768,7 +768,8 @@ steps['ZMM_UPG2017_14']=gen2017('ZMM_14TeV_cfi',Kby(18,300))
 ## pPb tests
 step1PPbDefaults={'--beamspot':'Realistic8TeVCollisionPPbBoost'}
 steps['AMPT_PPb_5020GeV_MinimumBias']=merge([{'-n':10},step1PPbDefaults,genS('AMPT_PPb_5020GeV_MinimumBias_cfi',Kby(9,100))])
-steps['AMPT_PPb_5020GeV_MinimumBiasINPUT']={'INPUT':InputInfo(dataSet='/RelValAMPT_PPb_5020GeV_MinimumBias/%s/GEN-SIM'%(baseDataSetRelease[5],),location='STD')}
+# GF to be uncommented when GEN-SIM becomes available
+# steps['AMPT_PPb_5020GeV_MinimumBiasINPUT']={'INPUT':InputInfo(dataSet='/RelValAMPT_PPb_5020GeV_MinimumBias/%s/GEN-SIM'%(baseDataSetRelease[5],),location='STD')}
 
 ## heavy ions tests
 U2000by1={'--relval': '2000,1'}

--- a/DQM/Physics/python/B2GDQM_cfi.py
+++ b/DQM/Physics/python/B2GDQM_cfi.py
@@ -11,7 +11,7 @@ B2GDQM = cms.EDAnalyzer(
     jetLabels = cms.VInputTag(
         'ak5PFJets',
         'ak5PFJetsCHS',
-        'ca8PFJetsCHS',
+        #'ca8PFJetsCHS',
         'ca8PFJetsCHSPruned',
         'cmsTopTagPFJetsCHS'
         ),

--- a/Geometry/CommonDetUnit/interface/GeomDet.h
+++ b/Geometry/CommonDetUnit/interface/GeomDet.h
@@ -85,7 +85,7 @@ public:
   virtual const GeomDet* component(DetId /*id*/) const {return 0;}
 
   /// Return pointer to alignment errors. 
-  AlignmentPositionError* alignmentPositionError() const { return theAlignmentPositionError;}
+  AlignmentPositionError const* alignmentPositionError() const { return theAlignmentPositionError;}
 
 
   // specific unix index in a given subdetector (such as Tracker)

--- a/PhysicsTools/MVAComputer/src/MVAComputer.cc
+++ b/PhysicsTools/MVAComputer/src/MVAComputer.cc
@@ -126,6 +126,7 @@ void MVAComputer::setup(const Calibration::MVAComputer *calib)
 		InputVar var;
 		var.var = Variable(iter->name, config[i].mask);
 		var.index = i;
+		var.multiplicity = 0;
 		variables.insert(var);
 	}
 

--- a/RecoJets/Configuration/python/RecoJets_EventContent_cff.py
+++ b/RecoJets/Configuration/python/RecoJets_EventContent_cff.py
@@ -65,16 +65,17 @@ RecoJetsRECO = cms.PSet(
                                            'keep *_ak4PFJets_*_*',
                                            'keep *_ak5PFJets_*_*',
                                            #'keep *_ak7PFJets_*_*',
-                                           'keep *_ak8PFJets_*_*',                                           
+                                           'keep *_ak8PFJets_*_*',
                                            'keep *_ak4PFJetsCHS_*_*',
                                            'keep *_ak5PFJetsCHS_*_*',
                                            'keep *_ak8PFJetsCHS_*_*',
-                                           'keep *_ca8PFJetsCHS_*_*',
-                                           'keep *_ca8PFJetsCHSPruned_*_*',                                           
+                                           'keep *_ak15PFJetsCHS_*_*',
+                                           'keep *_ca8PFJetsCHSPruned_*_*',
+                                           'keep *_ca8PFJetsCHSPrunedLinks_*_*',
                                            'keep *_cmsTopTagPFJetsCHS_*_*',
-                                           #'keep *_hepTopTagPFJetsCHS_*_*',
-                                           #'keep *_ca15PFJetsCHSMassDropFiltered_*_*',
-                                           #'keep *_ca15PFJetsCHSFiltered_*_*',
+                                           'keep *_hepTopTagPFJetsCHS_*_*',
+                                           'keep *_ca15PFJetsCHSMassDropFiltered_*_*',
+                                           'keep *_ca15PFJetsCHSFiltered_*_*',
                                            'keep *_JetPlusTrackZSPCorJetAntiKt5_*_*',                                  
                                            'keep *_ak5TrackJets_*_*',
                                            #'keep *_kt4TrackJets_*_*',
@@ -102,17 +103,14 @@ RecoJetsRECO = cms.PSet(
                                            'keep double_kt6PFJetsCentralChargedPileUp_*_*',
                                            'keep double_kt6PFJetsCentralNeutral_*_*',
                                            'keep double_kt6PFJetsCentralNeutralTight_*_*',
-                                           'keep *_fixedGridRho*_*_*',
-                                           'keep *_ca8PFJetsCHSPrunedLinks_*_*'                                 
+                                           'keep *_fixedGridRho*_*_*'
                                            )
 )
 RecoGenJetsRECO = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep *_kt4GenJets_*_*', 
-                                           'keep *_kt6GenJets_*_*',
+    outputCommands = cms.untracked.vstring(
                                            'keep *_ak4GenJets_*_*',
                                            'keep *_ak5GenJets_*_*',
                                            'keep *_ak7GenJets_*_*',
-                                           'keep *_iterativeCone5GenJets_*_*',
                                            'keep *_genParticle_*_*')
     )
 #AOD content
@@ -124,12 +122,12 @@ RecoJetsAOD = cms.PSet(
                                            'keep *_ak4PFJetsCHS_*_*',
                                            'keep *_ak5PFJetsCHS_*_*',
                                            'keep *_ak8PFJetsCHS_*_*',
-                                           'keep *_ca8PFJetsCHS_*_*',
                                            'keep *_ca8PFJetsCHSPruned_*_*',
+                                           'keep *_ca8PFJetsCHSPrunedLinks_*_*',
                                            'keep *_cmsTopTagPFJetsCHS_*_*',
-                                           #'keep *_hepTopTagPFJetsCHS_*_*',
-                                           #'keep *_ca15PFJetsCHSMassDropFiltered_*_*',
-                                           #'keep *_ca15PFJetsCHSFiltered_*_*',
+                                           'keep *_hepTopTagPFJetsCHS_*_*',
+                                           'keep *_ca15PFJetsCHSMassDropFiltered_*_*',
+                                           'keep *_ca15PFJetsCHSFiltered_*_*',
                                            #        'keep *_ak7CaloJets_*_*',
                                            #        'keep *_iterativeCone5CaloJets_*_*', 
                                            #        'keep *_iterativeCone15CaloJets_*_*', 
@@ -169,8 +167,7 @@ RecoJetsAOD = cms.PSet(
                                            'keep double_kt6PFJetsCentralNeutralTight_*_*',
                                            'keep *_fixedGridRho*_*_*',
                                            'drop doubles_*Jets_rhos_*',
-                                           'drop doubles_*Jets_sigmas_*',
-                                           'keep *_ca8PFJetsCHSPrunedLinks_*_*'                                           
+                                           'drop doubles_*Jets_sigmas_*'
                                            )
     )
 RecoGenJetsAOD = cms.PSet(

--- a/RecoJets/Configuration/python/RecoPFJets_cff.py
+++ b/RecoJets/Configuration/python/RecoPFJets_cff.py
@@ -66,92 +66,80 @@ fixedGridRhoFastjetCentralNeutral = fixedGridRhoFastjetAll.clone(
     )
 
 
-
+# Constituents for preclustering R=0.8 and R=1.5 jets
 ak8PFJetsCHSConstituents = cms.EDFilter("PFJetConstituentSelector",
                                         src = cms.InputTag("ak8PFJetsCHS"),
                                         cut = cms.string("pt > 100.0 && abs(rapidity()) < 2.4")
                                         )
-
+ak15PFJetsCHSConstituents = cms.EDFilter("PFJetConstituentSelector",
+                                        src = cms.InputTag("ak15PFJetsCHS"),
+                                        cut = cms.string("pt > 100.0 && abs(rapidity()) < 2.4")
+                                        )
 
 # Advanced Algorithms for AK4, AK5, AK8 and CA8 :
 #   - CHS, ungroomed
 #   - CHS, pruned
 #   - CHS, filtered
 #   - CHS, trimmed
-ak5PFJetsCHS = ak5PFJets.clone(
-    src = cms.InputTag("pfNoPileUpJME")
-    )
-
-ak5PFJetsCHSPruned = ak5PFJetsPruned.clone(
-    src = cms.InputTag("pfNoPileUpJME")
-    )
-
-ak5PFJetsCHSFiltered = ak5PFJetsFiltered.clone(
-    src = cms.InputTag("pfNoPileUpJME")
-    )
-
-ak5PFJetsCHSTrimmed = ak5PFJetsTrimmed.clone(
-    src = cms.InputTag("pfNoPileUpJME")
-    )
-    
-ak4PFJetsCHS = ak5PFJetsCHS.clone(
+ak4PFJetsCHS = ak5PFJets.clone(
+    src = cms.InputTag("pfNoPileUpJME"),
     rParam = 0.4
     )    
 
+ak5PFJetsCHS = ak5PFJets.clone(
+    src = cms.InputTag("pfNoPileUpJME")
+    )
+    
 ak8PFJetsCHS = ak5PFJetsCHS.clone(
     rParam = 0.8,
     jetPtMin = 15.0
     )
 
-ak8PFJetsCHSPruned = ak5PFJetsCHSPruned.clone(
+ak15PFJetsCHS = ak5PFJetsCHS.clone(
+    rParam = 1.5,
+    jetPtMin = 100.0
+    )
+
+ca8PFJetsCHSPruned = ak5PFJetsPruned.clone(
     rParam = 0.8,
-    jetPtMin = 15.0
+    jetPtMin = 100.0,
+    jetAlgorithm = cms.string("CambridgeAachen"),
+    src = cms.InputTag("ak8PFJetsCHSConstituents", "constituents")
     )
 
-ak8PFJetsCHSFiltered = ak5PFJetsCHSFiltered.clone(
+ca8PFJetsCHSFiltered = ak5PFJetsFiltered.clone(
     rParam = 0.8,
-    jetPtMin = 15.0
+    jetPtMin = 100.0,
+    jetAlgorithm = cms.string("CambridgeAachen"),
+    src = cms.InputTag("ak8PFJetsCHSConstituents", "constituents")
     )
 
-ak8PFJetsCHSTrimmed = ak5PFJetsCHSTrimmed.clone(
+ca8PFJetsCHSTrimmed = ak5PFJetsTrimmed.clone(
     rParam = 0.8,
-    jetPtMin = 15.0
-    )
-
-ca8PFJetsCHS = ak8PFJetsCHS.clone(
-    jetAlgorithm = cms.string("CambridgeAachen")
-    )
-
-ca8PFJetsCHSPruned = ak8PFJetsCHSPruned.clone(
-    jetAlgorithm = cms.string("CambridgeAachen")
-    )
-
-ca8PFJetsCHSFiltered = ak8PFJetsCHSFiltered.clone(
-    jetAlgorithm = cms.string("CambridgeAachen")
-    )
-
-ca8PFJetsCHSTrimmed = ak8PFJetsCHSTrimmed.clone(
-    jetAlgorithm = cms.string("CambridgeAachen")
+    jetPtMin = 100.0,
+    jetAlgorithm = cms.string("CambridgeAachen"),
+    src = cms.InputTag("ak8PFJetsCHSConstituents", "constituents")
     )
 
 
 # Higgs taggers
 ca15PFJetsCHSMassDropFiltered = ak5PFJetsMassDropFiltered.clone(
     jetAlgorithm = cms.string("CambridgeAachen"),
-    src = cms.InputTag("pfNoPileUpJME"),
+    src = cms.InputTag("ak15PFJetsCHSConstituents", "constituents"),
     rParam = 1.5,
     jetPtMin=100.0
     )
 
 ca15PFJetsCHSFiltered = ak5PFJetsFiltered.clone(
     jetAlgorithm = cms.string("CambridgeAachen"),
-    src = cms.InputTag("pfNoPileUpJME"),
+    src = cms.InputTag("ak15PFJetsCHSConstituents", "constituents"),
     rParam = 1.5,
     jetPtMin=100.0
     )
 
+# Top taggers
 cmsTopTagPFJetsCHS.src = cms.InputTag("ak8PFJetsCHSConstituents", "constituents")
-hepTopTagPFJetsCHS.src = cms.InputTag("ak8PFJetsCHSConstituents", "constituents")
+hepTopTagPFJetsCHS.src = cms.InputTag("ak15PFJetsCHSConstituents", "constituents")
 
 
 
@@ -166,11 +154,12 @@ recoPFJets   =cms.Sequence(#kt4PFJets+kt6PFJets+
                            fixedGridRhoFastjetCentralNeutral+
                            ak5PFJets+ak8PFJets+
                            pfNoPileUpJMESequence+
+                           ak4PFJetsCHS+
                            ak5PFJetsCHS+
-                           ak4PFJetsCHS+                           
                            ak8PFJetsCHS+
-                           ca8PFJetsCHS+
+                           ak15PFJetsCHS+
                            ak8PFJetsCHSConstituents+
+                           ak15PFJetsCHSConstituents+
                            ca8PFJetsCHSPruned+
                            ca8PFJetsCHSPrunedLinks+
                            cmsTopTagPFJetsCHS+
@@ -196,21 +185,16 @@ recoAllPFJets=cms.Sequence(sisCone5PFJets+sisCone7PFJets+
                            ca4PFJets+ca8PFJets+
                            pfNoPileUpJMESequence+
                            ak5PFJetsCHS+
-                           ak5PFJetsCHSPruned+
-                           ak5PFJetsCHSFiltered+
-                           ak5PFJetsCHSTrimmed+
-                           ak4PFJetsCHS+                                                      
+                           ak4PFJetsCHS+
                            ak8PFJetsCHS+
-                           ak8PFJetsCHSPruned+
-                           ak8PFJetsCHSFiltered+
-                           ak8PFJetsCHSTrimmed+
-                           ca8PFJetsCHS+
                            ca8PFJetsCHSPruned+
                            ca8PFJetsCHSFiltered+
                            ca8PFJetsCHSTrimmed+
                            ca8PFJetsCHSPrunedLinks+
                            ca8PFJetsCHSTrimmedLinks+
                            ca8PFJetsCHSFilteredLinks+
+                           ak15PFJetsCHS+
+                           ak15PFJetsCHSConstituents+
                            cmsTopTagPFJetsCHS+
                            hepTopTagPFJetsCHS+
                            ca15PFJetsCHSMassDropFiltered+

--- a/RecoJets/JetProducers/python/ca8PFJetsCHS_groomingValueMaps_cfi.py
+++ b/RecoJets/JetProducers/python/ca8PFJetsCHS_groomingValueMaps_cfi.py
@@ -4,21 +4,21 @@ import FWCore.ParameterSet.Config as cms
 # Delta-R matching value maps
 
 ca8PFJetsCHSPrunedLinks = cms.EDProducer("RecoJetDeltaRValueMapProducer",
-                                         src = cms.InputTag("ca8PFJetsCHS"),
+                                         src = cms.InputTag("ak8PFJetsCHS"),
                                          matched = cms.InputTag("ca8PFJetsCHSPruned"),
                                          distMin = cms.double(0.8),
                                          value = cms.string('mass')
                         )
 
 ca8PFJetsCHSTrimmedLinks = cms.EDProducer("RecoJetDeltaRValueMapProducer",
-                                         src = cms.InputTag("ca8PFJetsCHS"),
+                                         src = cms.InputTag("ak8PFJetsCHS"),
                                          matched = cms.InputTag("ca8PFJetsCHSTrimmed"),                                         
                                          distMin = cms.double(0.8),
                                          value = cms.string('mass')
                         )
 
 ca8PFJetsCHSFilteredLinks = cms.EDProducer("RecoJetDeltaRValueMapProducer",
-                                         src = cms.InputTag("ca8PFJetsCHS"),
+                                         src = cms.InputTag("ak8PFJetsCHS"),
                                          matched = cms.InputTag("ca8PFJetsCHSFiltered"),                                         
                                          distMin = cms.double(0.8),
                                          value = cms.string('mass')  


### PR DESCRIPTION
Preclustering all jet taggers with anti-kT with a pt cut of 100.0 to reduce computation time. 

There are also a couple of algorithms that were being run but not kept in AOD. They have cuts of pt > 100 GeV so they won't affect the size. 
