### PR TITLE
Send module event signals within sync barrier

### DIFF
--- a/FWCore/Framework/interface/EDAnalyzer.h
+++ b/FWCore/Framework/interface/EDAnalyzer.h
@@ -16,6 +16,7 @@ namespace edm {
 
   class ModuleCallingContext;
   class PreallocationConfiguration;
+  class ActivityRegistry;
 
   namespace maker {
     template<typename T> class ModuleHolderT;
@@ -43,6 +44,7 @@ namespace edm {
 
   private:
     bool doEvent(EventPrincipal const& ep, EventSetup const& c,
+                 ActivityRegistry* act,
                  ModuleCallingContext const* mcc);
     void doPreallocate(PreallocationConfiguration const&) {}
     void doBeginJob();

--- a/FWCore/Framework/interface/EDFilter.h
+++ b/FWCore/Framework/interface/EDFilter.h
@@ -30,6 +30,7 @@ namespace edm {
 
   class ModuleCallingContext;
   class PreallocationConfiguration;
+  class ActivityRegistry;
 
   class EDFilter : public ProducerBase, public EDConsumerBase {
   public:
@@ -50,6 +51,7 @@ namespace edm {
 
   private:    
     bool doEvent(EventPrincipal& ep, EventSetup const& c,
+                 ActivityRegistry* act,
                  ModuleCallingContext const* mcc);
     void doPreallocate(PreallocationConfiguration const&) {}
     void doBeginJob();

--- a/FWCore/Framework/interface/EDProducer.h
+++ b/FWCore/Framework/interface/EDProducer.h
@@ -24,6 +24,7 @@ namespace edm {
 
   class ModuleCallingContext;
   class PreallocationConfiguration;
+  class ActivityRegistry;
   
   namespace maker {
     template<typename T> class ModuleHolderT;
@@ -47,6 +48,7 @@ namespace edm {
 
   private:
     bool doEvent(EventPrincipal& ep, EventSetup const& c,
+                 ActivityRegistry* act,
                  ModuleCallingContext const* mcc);
     void doPreallocate(PreallocationConfiguration const&) {}
     void doBeginJob();

--- a/FWCore/Framework/interface/OutputModule.h
+++ b/FWCore/Framework/interface/OutputModule.h
@@ -36,6 +36,7 @@ namespace edm {
 
   class ModuleCallingContext;
   class PreallocationConfiguration;
+  class ActivityRegistry;
 
   namespace maker {
     template<typename T> class ModuleHolderT;
@@ -101,6 +102,7 @@ namespace edm {
     void doBeginJob();
     void doEndJob();
     bool doEvent(EventPrincipal const& ep, EventSetup const& c,
+                 ActivityRegistry* act,
                  ModuleCallingContext const* mcc);
     bool doBeginRun(RunPrincipal const& rp, EventSetup const& c,
                     ModuleCallingContext const* mcc);

--- a/FWCore/Framework/interface/global/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/global/EDAnalyzerBase.h
@@ -32,6 +32,7 @@ namespace edm {
   class ModuleCallingContext;
   class PreallocationConfiguration;
   class StreamID;
+  class ActivityRegistry;
   
   namespace maker {
     template<typename T> class ModuleHolderT;
@@ -59,6 +60,7 @@ namespace edm {
 
     private:
       bool doEvent(EventPrincipal& ep, EventSetup const& c,
+                   ActivityRegistry*,
                    ModuleCallingContext const*);
       void doPreallocate(PreallocationConfiguration const&);
       void doBeginJob();

--- a/FWCore/Framework/interface/global/EDFilterBase.h
+++ b/FWCore/Framework/interface/global/EDFilterBase.h
@@ -34,6 +34,7 @@ namespace edm {
   class ModuleCallingContext;
   class PreallocationConfiguration;
   class StreamID;
+  class ActivityRegistry;
   
   namespace maker {
     template<typename T> class ModuleHolderT;
@@ -61,6 +62,7 @@ namespace edm {
 
     private:
       bool doEvent(EventPrincipal& ep, EventSetup const& c,
+                   ActivityRegistry*,
                    ModuleCallingContext const*);
       void doPreallocate(PreallocationConfiguration const&);
       void doBeginJob();

--- a/FWCore/Framework/interface/global/EDProducerBase.h
+++ b/FWCore/Framework/interface/global/EDProducerBase.h
@@ -35,6 +35,7 @@ namespace edm {
   class PreallocationConfiguration;
   class StreamID;
   class GlobalSchedule;
+  class ActivityRegistry;
   
   namespace maker {
     template<typename T> class ModuleHolderT;
@@ -64,6 +65,7 @@ namespace edm {
 
     private:
       bool doEvent(EventPrincipal& ep, EventSetup const& c,
+                   ActivityRegistry*,
                    ModuleCallingContext const*);
       void doPreallocate(PreallocationConfiguration const&);
       void doBeginJob();

--- a/FWCore/Framework/interface/one/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/one/EDAnalyzerBase.h
@@ -33,6 +33,7 @@ namespace edm {
 
   class ModuleCallingContext;
   class PreallocationConfiguration;
+  class ActivityRegistry;
 
   namespace maker {
     template<typename T> class ModuleHolderT;
@@ -66,6 +67,7 @@ namespace edm {
 
     private:
       bool doEvent(EventPrincipal& ep, EventSetup const& c,
+                   ActivityRegistry*,
                    ModuleCallingContext const*);
       void doPreallocate(PreallocationConfiguration const&) {}
       void doBeginJob();

--- a/FWCore/Framework/interface/one/EDFilterBase.h
+++ b/FWCore/Framework/interface/one/EDFilterBase.h
@@ -34,6 +34,7 @@ namespace edm {
 
   class ModuleCallingContext;
   class PreallocationConfiguration;
+  class ActivityRegistry;
   
   namespace maker {
     template<typename T> class ModuleHolderT;
@@ -62,6 +63,7 @@ namespace edm {
 
     private:
       bool doEvent(EventPrincipal& ep, EventSetup const& c,
+                   ActivityRegistry*,
                    ModuleCallingContext const*);
       void doPreallocate(PreallocationConfiguration const&) {}
       void doBeginJob();

--- a/FWCore/Framework/interface/one/EDProducerBase.h
+++ b/FWCore/Framework/interface/one/EDProducerBase.h
@@ -34,6 +34,7 @@ namespace edm {
 
   class ModuleCallingContext;
   class PreallocationConfiguration;
+  class ActivityRegistry;
   namespace maker {
     template<typename T> class ModuleHolderT;
   }
@@ -61,6 +62,7 @@ namespace edm {
 
     private:
       bool doEvent(EventPrincipal& ep, EventSetup const& c,
+                   ActivityRegistry*,
                    ModuleCallingContext const*);
       void doPreallocate(PreallocationConfiguration const&) {}
       void doBeginJob();

--- a/FWCore/Framework/interface/one/OutputModuleBase.h
+++ b/FWCore/Framework/interface/one/OutputModuleBase.h
@@ -48,6 +48,7 @@ namespace edm {
 
   class ModuleCallingContext;
   class PreallocationConfiguration;
+  class ActivityRegistry;
   template <typename T> class OutputModuleCommunicatorT;
   
   namespace maker {
@@ -113,6 +114,7 @@ namespace edm {
       void doBeginJob();
       void doEndJob();
       bool doEvent(EventPrincipal const& ep, EventSetup const& c,
+                   ActivityRegistry*,
                    ModuleCallingContext const*);
       bool doBeginRun(RunPrincipal const& rp, EventSetup const& c,
                       ModuleCallingContext const*);

--- a/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
@@ -40,6 +40,7 @@ namespace edm {
   class EDConsumerBase;
   class PreallocationConfiguration;
   class ProductHolderIndexAndSkipBit;
+  class ActivityRegistry;
 
   namespace maker {
     template<typename T> class ModuleHolderT;
@@ -93,6 +94,7 @@ namespace edm {
       const EDAnalyzerAdaptorBase& operator=(const EDAnalyzerAdaptorBase&); // stop default
       
       bool doEvent(EventPrincipal& ep, EventSetup const& c,
+                   ActivityRegistry*,
                    ModuleCallingContext const*) ;
       void doPreallocate(PreallocationConfiguration const&);
       

--- a/FWCore/Framework/interface/stream/EDFilterAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/EDFilterAdaptorBase.h
@@ -35,6 +35,7 @@
 namespace edm {
 
   class ModuleCallingContext;
+  class ActivityRegistry;
   
   namespace maker {
     template<typename T> class ModuleHolderT;
@@ -67,6 +68,7 @@ namespace edm {
       const EDFilterAdaptorBase& operator=(const EDFilterAdaptorBase&) =delete; // stop default
       
       bool doEvent(EventPrincipal& ep, EventSetup const& c,
+                   ActivityRegistry*,
                    ModuleCallingContext const*) ;
     };
   }

--- a/FWCore/Framework/interface/stream/EDProducerAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/EDProducerAdaptorBase.h
@@ -35,6 +35,7 @@
 namespace edm {
 
   class ModuleCallingContext;
+  class ActivityRegistry;
   
   namespace maker {
     template<typename T> class ModuleHolderT;
@@ -67,6 +68,7 @@ namespace edm {
       const EDProducerAdaptorBase& operator=(const EDProducerAdaptorBase&) =delete; // stop default
       
       bool doEvent(EventPrincipal& ep, EventSetup const& c,
+                   ActivityRegistry*,
                    ModuleCallingContext const*) ;
     };
   }

--- a/FWCore/Framework/src/EDAnalyzer.cc
+++ b/FWCore/Framework/src/EDAnalyzer.cc
@@ -9,6 +9,7 @@
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/src/edmodule_mightGet_config.h"
 #include "FWCore/Framework/interface/ConstProductRegistry.h"
+#include "FWCore/Framework/src/EventSignalsSentry.h"
 
 #include "SharedResourcesRegistry.h"
 
@@ -30,12 +31,14 @@ namespace edm {
 
   bool
   EDAnalyzer::doEvent(EventPrincipal const& ep, EventSetup const& c,
+                      ActivityRegistry* act,
                       ModuleCallingContext const* mcc) {
     Event e(const_cast<EventPrincipal&>(ep), moduleDescription_, mcc);
     e.setConsumer(this);
     {
       std::lock_guard<std::mutex> guard(mutex_);
       std::lock_guard<SharedResourcesAcquirer> guardAcq(resourceAcquirer_);
+      EventSignalsSentry sentry(act,mcc);
       this->analyze(e, c);
     }
     return true;

--- a/FWCore/Framework/src/EDFilter.cc
+++ b/FWCore/Framework/src/EDFilter.cc
@@ -8,6 +8,7 @@
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/src/edmodule_mightGet_config.h"
+#include "FWCore/Framework/src/EventSignalsSentry.h"
 
 #include "SharedResourcesRegistry.h"
 
@@ -27,6 +28,7 @@ namespace edm {
 
   bool
   EDFilter::doEvent(EventPrincipal& ep, EventSetup const& c,
+                    ActivityRegistry* act,
                     ModuleCallingContext const* mcc) {
     bool rc = false;
     Event e(ep, moduleDescription_, mcc);
@@ -35,6 +37,7 @@ namespace edm {
       std::lock_guard<std::mutex> guard(mutex_);
       {
         std::lock_guard<SharedResourcesAcquirer> guardAcq(resourceAcquirer_);
+        EventSignalsSentry sentry(act,mcc);
         rc = this->filter(e, c);
       }
       commit_(e,&previousParentage_, &previousParentageId_);

--- a/FWCore/Framework/src/EDProducer.cc
+++ b/FWCore/Framework/src/EDProducer.cc
@@ -8,6 +8,7 @@
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/src/edmodule_mightGet_config.h"
+#include "FWCore/Framework/src/EventSignalsSentry.h"
 
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
@@ -28,6 +29,7 @@ namespace edm {
 
   bool
   EDProducer::doEvent(EventPrincipal& ep, EventSetup const& c,
+                      ActivityRegistry* act,
                       ModuleCallingContext const* mcc) {
     Event e(ep, moduleDescription_, mcc);
     e.setConsumer(this);
@@ -35,6 +37,7 @@ namespace edm {
       std::lock_guard<std::mutex> guard(mutex_);
       {
         std::lock_guard<SharedResourcesAcquirer> guardAcq(resourceAcquirer_);
+        EventSignalsSentry sentry(act,mcc);
         this->produce(e, c);
       }
       commit_(e, &previousParentage_, &previousParentageId_);

--- a/FWCore/Framework/src/EventSignalsSentry.h
+++ b/FWCore/Framework/src/EventSignalsSentry.h
@@ -1,0 +1,49 @@
+#ifndef FWCore_Framework_EventSignalsSentry_h
+#define FWCore_Framework_EventSignalsSentry_h
+// -*- C++ -*-
+//
+// Package:     FWCore/Framework
+// Class  :     EventSignalsSentry
+// 
+/**\class edm::EventSignalsSentry EventSignalsSentry.h "EventSignalsSentry.h"
+
+ Description: Guarantees that the pre/post module Event signals are sent
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  Mon, 12 May 2014 19:18:21 GMT
+//
+
+// system include files
+#include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
+#include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
+
+// user include files
+
+// forward declarations
+namespace edm {
+  class EventSignalsSentry {
+
+  public:
+    EventSignalsSentry(ActivityRegistry* iReg,
+                       ModuleCallingContext const * iContext) :
+      m_reg(iReg),
+      m_context(iContext)
+    { iReg->preModuleEventSignal_( *(iContext->getStreamContext()), *iContext);}
+    
+    ~EventSignalsSentry() {
+      m_reg->postModuleEventSignal_( *(m_context->getStreamContext()), *m_context);
+    }
+    
+  private:
+    // ---------- member data --------------------------------
+    ActivityRegistry* m_reg;
+    ModuleCallingContext const* m_context;
+  };
+}
+
+#endif

--- a/FWCore/Framework/src/OutputModule.cc
+++ b/FWCore/Framework/src/OutputModule.cc
@@ -13,6 +13,7 @@
 #include "FWCore/Framework/interface/EventPrincipal.h"
 #include "FWCore/Framework/interface/OutputModuleDescription.h"
 #include "FWCore/Framework/interface/TriggerNamesService.h"
+#include "FWCore/Framework/src/EventSignalsSentry.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
@@ -180,6 +181,7 @@ namespace edm {
   bool
   OutputModule::doEvent(EventPrincipal const& ep,
                         EventSetup const&,
+                        ActivityRegistry* act,
                         ModuleCallingContext const* mcc) {
 
     FDEBUG(2) << "writeEvent called\n";
@@ -195,6 +197,7 @@ namespace edm {
       
       {
         std::lock_guard<SharedResourcesAcquirer> guardAcq(resourceAcquirer_);
+        EventSignalsSentry signals(act,mcc);
         write(ep, mcc);
       }
       updateBranchParents(ep);

--- a/FWCore/Framework/src/Worker.h
+++ b/FWCore/Framework/src/Worker.h
@@ -156,6 +156,8 @@ namespace edm {
     virtual void implEndStream(StreamID) = 0;
     
     void resetModuleDescription(ModuleDescription const*);
+    
+    ActivityRegistry* activityRegistry() { return actReg_.get(); }
 
   private:
 
@@ -195,7 +197,7 @@ namespace edm {
     public:
       ModuleSignalSentry(ActivityRegistry *a,
                          typename T::Context const* context,
-                         ModuleCallingContext* moduleCallingContext) :
+                         ModuleCallingContext const* moduleCallingContext) :
         a_(a), context_(context), moduleCallingContext_(moduleCallingContext) {
 
 	if(a_) T::preModuleSignal(a_, context, moduleCallingContext_);
@@ -208,7 +210,7 @@ namespace edm {
     private:
       ActivityRegistry* a_;
       typename T::Context const* context_;
-      ModuleCallingContext* moduleCallingContext_;
+      ModuleCallingContext const* moduleCallingContext_;
     };
 
     template <typename T>
@@ -272,8 +274,13 @@ namespace edm {
     template<>
     class CallImpl<OccurrenceTraits<EventPrincipal, BranchActionStreamBegin>> {
     public:
-      static bool call(Worker* iWorker, StreamID, EventPrincipal& ep, EventSetup const& es,
-                       ModuleCallingContext const* mcc) {
+      typedef OccurrenceTraits<EventPrincipal, BranchActionStreamBegin> Arg;
+      static bool call(Worker* iWorker, StreamID,
+                       EventPrincipal& ep, EventSetup const& es,
+                       ActivityRegistry* actReg,
+                       ModuleCallingContext const* mcc,
+                       Arg::Context const* context) {
+        //Signal sentry is handled by the module
         return iWorker->implDo(ep,es, mcc);
       }
     };
@@ -281,32 +288,52 @@ namespace edm {
     template<>
     class CallImpl<OccurrenceTraits<RunPrincipal, BranchActionGlobalBegin>>{
     public:
-      static bool call(Worker* iWorker,StreamID, RunPrincipal& ep, EventSetup const& es,
-                       ModuleCallingContext const* mcc) {
+      typedef OccurrenceTraits<RunPrincipal, BranchActionGlobalBegin> Arg;
+      static bool call(Worker* iWorker,StreamID,
+                       RunPrincipal& ep, EventSetup const& es,
+                       ActivityRegistry* actReg,
+                       ModuleCallingContext const* mcc,
+                       Arg::Context const* context) {
+        ModuleSignalSentry<Arg> cpp(actReg, context, mcc);
         return iWorker->implDoBegin(ep,es, mcc);
       }
     };
     template<>
     class CallImpl<OccurrenceTraits<RunPrincipal, BranchActionStreamBegin>>{
     public:
-      static bool call(Worker* iWorker,StreamID id, RunPrincipal& ep, EventSetup const& es,
-                       ModuleCallingContext const* mcc) {
+      typedef OccurrenceTraits<RunPrincipal, BranchActionStreamBegin> Arg;
+      static bool call(Worker* iWorker,StreamID id,
+                       RunPrincipal& ep, EventSetup const& es,
+                       ActivityRegistry* actReg,
+                       ModuleCallingContext const* mcc,
+                       Arg::Context const* context) {
+        ModuleSignalSentry<Arg> cpp(actReg, context, mcc);
         return iWorker->implDoStreamBegin(id,ep,es, mcc);
       }
     };
     template<>
     class CallImpl<OccurrenceTraits<RunPrincipal, BranchActionGlobalEnd>>{
     public:
-      static bool call(Worker* iWorker,StreamID, RunPrincipal& ep, EventSetup const& es,
-                       ModuleCallingContext const* mcc) {
+      typedef OccurrenceTraits<RunPrincipal, BranchActionGlobalEnd> Arg;
+      static bool call(Worker* iWorker,StreamID,
+                       RunPrincipal& ep, EventSetup const& es,
+                       ActivityRegistry* actReg,
+                       ModuleCallingContext const* mcc,
+                       Arg::Context const* context) {
+        ModuleSignalSentry<Arg> cpp(actReg, context, mcc);
         return iWorker->implDoEnd(ep,es, mcc);
       }
     };
     template<>
     class CallImpl<OccurrenceTraits<RunPrincipal, BranchActionStreamEnd>>{
     public:
-      static bool call(Worker* iWorker,StreamID id, RunPrincipal& ep, EventSetup const& es,
-                       ModuleCallingContext const* mcc) {
+      typedef OccurrenceTraits<RunPrincipal, BranchActionStreamEnd> Arg;
+      static bool call(Worker* iWorker,StreamID id,
+                       RunPrincipal& ep, EventSetup const& es,
+                       ActivityRegistry* actReg,
+                       ModuleCallingContext const* mcc,
+                       Arg::Context const* context) {
+        ModuleSignalSentry<Arg> cpp(actReg, context, mcc);
         return iWorker->implDoStreamEnd(id,ep,es, mcc);
       }
     };
@@ -314,16 +341,26 @@ namespace edm {
     template<>
     class CallImpl<OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalBegin>>{
     public:
-      static bool call(Worker* iWorker,StreamID, LuminosityBlockPrincipal& ep, EventSetup const& es,
-                       ModuleCallingContext const* mcc) {
+      typedef OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalBegin> Arg;
+      static bool call(Worker* iWorker,StreamID,
+                       LuminosityBlockPrincipal& ep, EventSetup const& es,
+                       ActivityRegistry* actReg,
+                       ModuleCallingContext const* mcc,
+                       Arg::Context const* context) {
+        ModuleSignalSentry<Arg> cpp(actReg, context, mcc);
         return iWorker->implDoBegin(ep,es, mcc);
       }
     };
     template<>
     class CallImpl<OccurrenceTraits<LuminosityBlockPrincipal, BranchActionStreamBegin>>{
     public:
-      static bool call(Worker* iWorker,StreamID id, LuminosityBlockPrincipal& ep, EventSetup const& es,
-                       ModuleCallingContext const* mcc) {
+      typedef OccurrenceTraits<LuminosityBlockPrincipal, BranchActionStreamBegin> Arg;
+      static bool call(Worker* iWorker,StreamID id,
+                       LuminosityBlockPrincipal& ep, EventSetup const& es,
+                       ActivityRegistry* actReg,
+                       ModuleCallingContext const* mcc,
+                       Arg::Context const* context) {
+        ModuleSignalSentry<Arg> cpp(actReg, context, mcc);
         return iWorker->implDoStreamBegin(id,ep,es, mcc);
       }
     };
@@ -331,16 +368,26 @@ namespace edm {
     template<>
     class CallImpl<OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalEnd>>{
     public:
-      static bool call(Worker* iWorker,StreamID, LuminosityBlockPrincipal& ep, EventSetup const& es,
-                       ModuleCallingContext const* mcc) {
+      typedef OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalEnd> Arg;
+      static bool call(Worker* iWorker,StreamID,
+                       LuminosityBlockPrincipal& ep, EventSetup const& es,
+                       ActivityRegistry* actReg,
+                       ModuleCallingContext const* mcc,
+                       Arg::Context const* context) {
+        ModuleSignalSentry<Arg> cpp(actReg, context, mcc);
         return iWorker->implDoEnd(ep,es, mcc);
       }
     };
     template<>
     class CallImpl<OccurrenceTraits<LuminosityBlockPrincipal, BranchActionStreamEnd>>{
     public:
-      static bool call(Worker* iWorker,StreamID id, LuminosityBlockPrincipal& ep, EventSetup const& es,
-                       ModuleCallingContext const* mcc) {
+      typedef OccurrenceTraits<LuminosityBlockPrincipal, BranchActionStreamEnd> Arg;
+      static bool call(Worker* iWorker,StreamID id,
+                       LuminosityBlockPrincipal& ep, EventSetup const& es,
+                       ActivityRegistry* actReg,
+                       ModuleCallingContext const* mcc,
+                       Arg::Context const* context) {
+        ModuleSignalSentry<Arg> cpp(actReg, context, mcc);
         return iWorker->implDoStreamEnd(id,ep,es, mcc);
       }
     };
@@ -392,8 +439,7 @@ namespace edm {
         }
 
         moduleCallingContext_.setState(ModuleCallingContext::State::kRunning);
-        ModuleSignalSentry<T> cpp(actReg_.get(), context, &moduleCallingContext_);
-        rc = workerhelper::CallImpl<T>::call(this,streamID,ep,es, &moduleCallingContext_);
+        rc = workerhelper::CallImpl<T>::call(this,streamID,ep,es, actReg_.get(), &moduleCallingContext_, context);
 
         if (rc) {
           state_ = Pass;

--- a/FWCore/Framework/src/WorkerT.cc
+++ b/FWCore/Framework/src/WorkerT.cc
@@ -116,7 +116,7 @@ namespace edm{
   bool
   WorkerT<T>::implDo(EventPrincipal& ep, EventSetup const& c, ModuleCallingContext const* mcc) {
     boost::shared_ptr<Worker> sentry(this,[&ep](Worker* obj) {obj->postDoEvent(ep);});
-    return module_->doEvent(ep, c, mcc);
+    return module_->doEvent(ep, c, activityRegistry(), mcc);
   }
   
   template<typename T>

--- a/FWCore/Framework/src/global/EDAnalyzerBase.cc
+++ b/FWCore/Framework/src/global/EDAnalyzerBase.cc
@@ -19,6 +19,7 @@
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/src/edmodule_mightGet_config.h"
 #include "FWCore/Framework/src/PreallocationConfiguration.h"
+#include "FWCore/Framework/src/EventSignalsSentry.h"
 
 
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
@@ -51,9 +52,11 @@ namespace edm {
     
     bool
     EDAnalyzerBase::doEvent(EventPrincipal& ep, EventSetup const& c,
+                            ActivityRegistry* act,
                             ModuleCallingContext const* mcc) {
       Event e(ep, moduleDescription_, mcc);
       e.setConsumer(this);
+      EventSignalsSentry sentry(act,mcc);
       this->analyze(e.streamID(), e, c);
       return true;
     }

--- a/FWCore/Framework/src/global/EDFilterBase.cc
+++ b/FWCore/Framework/src/global/EDFilterBase.cc
@@ -19,6 +19,7 @@
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/src/edmodule_mightGet_config.h"
 #include "FWCore/Framework/src/PreallocationConfiguration.h"
+#include "FWCore/Framework/src/EventSignalsSentry.h"
 
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
@@ -48,9 +49,11 @@ namespace edm {
     
     bool
     EDFilterBase::doEvent(EventPrincipal& ep, EventSetup const& c,
+                          ActivityRegistry* act,
                           ModuleCallingContext const* mcc) {
       Event e(ep, moduleDescription_, mcc);
       e.setConsumer(this);
+      EventSignalsSentry sentry(act,mcc);
       bool returnValue = this->filter(e.streamID(), e, c);
       const auto streamIndex =e.streamID().value();
       commit_(e,&previousParentages_[streamIndex], &previousParentageIds_[streamIndex]);

--- a/FWCore/Framework/src/global/EDProducerBase.cc
+++ b/FWCore/Framework/src/global/EDProducerBase.cc
@@ -19,6 +19,7 @@
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/src/edmodule_mightGet_config.h"
 #include "FWCore/Framework/src/PreallocationConfiguration.h"
+#include "FWCore/Framework/src/EventSignalsSentry.h"
 
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
@@ -48,9 +49,11 @@ namespace edm {
     
     bool
     EDProducerBase::doEvent(EventPrincipal& ep, EventSetup const& c,
+                            ActivityRegistry* act,
                             ModuleCallingContext const* mcc) {
       Event e(ep, moduleDescription_, mcc);
       e.setConsumer(this);
+      EventSignalsSentry sentry(act,mcc);
       this->produce(e.streamID(), e, c);
       const auto streamIndex = e.streamID().value();
       commit_(e,&previousParentages_[streamIndex], &previousParentageIds_[streamIndex]);

--- a/FWCore/Framework/src/one/EDAnalyzerBase.cc
+++ b/FWCore/Framework/src/one/EDAnalyzerBase.cc
@@ -18,6 +18,7 @@
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/src/edmodule_mightGet_config.h"
+#include "FWCore/Framework/src/EventSignalsSentry.h"
 
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
@@ -47,12 +48,14 @@ namespace edm {
     
     bool
     EDAnalyzerBase::doEvent(EventPrincipal& ep, EventSetup const& c,
+                            ActivityRegistry* act,
                             ModuleCallingContext const* mcc) {
       Event e(ep, moduleDescription_, mcc);
       e.setConsumer(this);
       {
         std::lock_guard<std::mutex> guard(mutex_);
         std::lock_guard<SharedResourcesAcquirer> guardResources(resourcesAcquirer_);
+        EventSignalsSentry sentry(act,mcc);
         this->analyze(e, c);
       }
       return true;

--- a/FWCore/Framework/src/one/EDFilterBase.cc
+++ b/FWCore/Framework/src/one/EDFilterBase.cc
@@ -18,6 +18,7 @@
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/src/edmodule_mightGet_config.h"
+#include "FWCore/Framework/src/EventSignalsSentry.h"
 
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
@@ -49,6 +50,7 @@ namespace edm {
     
     bool
     EDFilterBase::doEvent(EventPrincipal& ep, EventSetup const& c,
+                          ActivityRegistry* act,
                           ModuleCallingContext const* mcc) {
       Event e(ep, moduleDescription_, mcc);
       e.setConsumer(this);
@@ -57,6 +59,7 @@ namespace edm {
         std::lock_guard<std::mutex> guard(mutex_);
         {
           std::lock_guard<SharedResourcesAcquirer> guard(resourcesAcquirer_);
+          EventSignalsSentry sentry(act,mcc);
           returnValue = this->filter(e, c);
         }
         commit_(e,&previousParentage_, &previousParentageId_);

--- a/FWCore/Framework/src/one/EDProducerBase.cc
+++ b/FWCore/Framework/src/one/EDProducerBase.cc
@@ -18,6 +18,7 @@
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/src/edmodule_mightGet_config.h"
+#include "FWCore/Framework/src/EventSignalsSentry.h"
 
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
@@ -48,6 +49,7 @@ namespace edm {
     
     bool
     EDProducerBase::doEvent(EventPrincipal& ep, EventSetup const& c,
+                            ActivityRegistry* act,
                             ModuleCallingContext const* mcc) {
       Event e(ep, moduleDescription_, mcc);
       e.setConsumer(this);
@@ -55,6 +57,7 @@ namespace edm {
         std::lock_guard<std::mutex> guard(mutex_);
         {
           std::lock_guard<SharedResourcesAcquirer> guard(resourcesAcquirer_);
+          EventSignalsSentry sentry(act,mcc);
           this->produce(e, c);
         }
         commit_(e,&previousParentage_, &previousParentageId_);

--- a/FWCore/Framework/src/one/OutputModuleBase.cc
+++ b/FWCore/Framework/src/one/OutputModuleBase.cc
@@ -25,6 +25,7 @@
 #include "FWCore/Framework/interface/EventPrincipal.h"
 #include "FWCore/Framework/interface/OutputModuleDescription.h"
 #include "FWCore/Framework/interface/TriggerNamesService.h"
+#include "FWCore/Framework/src/EventSignalsSentry.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
@@ -186,6 +187,7 @@ namespace edm {
     bool
     OutputModuleBase::doEvent(EventPrincipal const& ep,
                               EventSetup const&,
+                              ActivityRegistry* act,
                               ModuleCallingContext const* mcc) {
       
       {
@@ -198,6 +200,7 @@ namespace edm {
         }
         {
           std::lock_guard<SharedResourcesAcquirer> guard(resourcesAcquirer_);
+          EventSignalsSentry sentry(act,mcc);
           write(ep, mcc);
         }
         updateBranchParents(ep);

--- a/FWCore/Framework/src/stream/EDAnalyzerAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/EDAnalyzerAdaptorBase.cc
@@ -23,6 +23,7 @@
 #include "FWCore/Framework/interface/RunPrincipal.h"
 
 #include "FWCore/Framework/src/PreallocationConfiguration.h"
+#include "FWCore/Framework/src/EventSignalsSentry.h"
 
 using namespace edm::stream;
 //
@@ -120,11 +121,13 @@ EDAnalyzerAdaptorBase::modulesDependentUpon(const std::string& iProcessName,
 
 bool
 EDAnalyzerAdaptorBase::doEvent(EventPrincipal& ep, EventSetup const& c,
+                               ActivityRegistry* act,
                                ModuleCallingContext const* mcc) {
   assert(ep.streamID()<m_streamModules.size());
   auto mod = m_streamModules[ep.streamID()];
   Event e(ep, moduleDescription_, mcc);
   e.setConsumer(mod);
+  EventSignalsSentry sentry(act,mcc);
   mod->analyze(e, c);
   return true;
 }

--- a/FWCore/Framework/src/stream/EDFilterAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/EDFilterAdaptorBase.cc
@@ -21,6 +21,7 @@
 #include "FWCore/Framework/interface/EventPrincipal.h"
 #include "FWCore/Framework/interface/LuminosityBlockPrincipal.h"
 #include "FWCore/Framework/interface/RunPrincipal.h"
+#include "FWCore/Framework/src/EventSignalsSentry.h"
 #include "FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc"
 
 
@@ -46,11 +47,13 @@ namespace edm {
     
     bool
     EDFilterAdaptorBase::doEvent(EventPrincipal& ep, EventSetup const& c,
+                                 ActivityRegistry* act,
                                  ModuleCallingContext const* mcc) {
       assert(ep.streamID()<m_streamModules.size());
       auto mod = m_streamModules[ep.streamID()];
       Event e(ep, moduleDescription(), mcc);
       e.setConsumer(mod);
+      EventSignalsSentry sentry(act,mcc);
       bool result = mod->filter(e, c);
       commit(e,&mod->previousParentage_, &mod->previousParentageId_);
       return result;

--- a/FWCore/Framework/src/stream/EDProducerAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/EDProducerAdaptorBase.cc
@@ -21,6 +21,7 @@
 #include "FWCore/Framework/interface/EventPrincipal.h"
 #include "FWCore/Framework/interface/LuminosityBlockPrincipal.h"
 #include "FWCore/Framework/interface/RunPrincipal.h"
+#include "FWCore/Framework/src/EventSignalsSentry.h"
 #include "FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc"
 
 
@@ -46,11 +47,13 @@ namespace edm {
     
     bool
     EDProducerAdaptorBase::doEvent(EventPrincipal& ep, EventSetup const& c,
+                                   ActivityRegistry* act,
                                    ModuleCallingContext const* mcc) {
       assert(ep.streamID()<m_streamModules.size());
       auto mod = m_streamModules[ep.streamID()];
       Event e(ep, moduleDescription(), mcc);
       e.setConsumer(mod);
+      EventSignalsSentry sentry(act,mcc);
       mod->produce(e, c);
       commit(e,&mod->previousParentage_, &mod->previousParentageId_);
       return true;

--- a/FWCore/Framework/test/global_module_t.cppunit.cc
+++ b/FWCore/Framework/test/global_module_t.cppunit.cc
@@ -21,6 +21,7 @@
 #include "FWCore/Framework/interface/HistoryAppender.h"
 #include "FWCore/ServiceRegistry/interface/ParentContext.h"
 #include "FWCore/ServiceRegistry/interface/StreamContext.h"
+#include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
 #include "FWCore/Utilities/interface/GlobalIdentifier.h"
 
 
@@ -95,6 +96,7 @@ private:
   edm::HistoryAppender historyAppender_;
   boost::shared_ptr<edm::LuminosityBlockPrincipal> m_lbp;
   boost::shared_ptr<edm::RunPrincipal> m_rp;
+  boost::shared_ptr<edm::ActivityRegistry> m_actReg;
   edm::EventSetup* m_es = nullptr;
   edm::ModuleDescription m_desc = {"Dummy","dummy"};
   edm::CPUTimer* m_timer = nullptr;
@@ -364,6 +366,7 @@ m_ep()
   edm::ProcessHistoryRegistry phr;
   m_ep->fillEventPrincipal(eventAux, phr);
   m_ep->setLuminosityBlockPrincipal(m_lbp);
+  m_actReg.reset(new edm::ActivityRegistry);
 
 
   //For each transition, bind a lambda which will call the proper method of the Worker
@@ -392,7 +395,9 @@ m_ep()
   
   m_transToFunc[Trans::kEvent] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::EventPrincipal, edm::BranchActionStreamBegin> Traits;
-    edm::ParentContext nullParentContext;
+    edm::StreamContext streamContext(s_streamID0, nullptr);
+    edm::ParentContext nullParentContext(&streamContext);
+    iBase->setActivityRegistry(m_actReg);
     iBase->doWork<Traits>(*m_ep,*m_es,m_timer, s_streamID0, nullParentContext, nullptr); };
 
   m_transToFunc[Trans::kStreamEndLuminosityBlock] = [this](edm::Worker* iBase) {

--- a/FWCore/Framework/test/stream_module_t.cppunit.cc
+++ b/FWCore/Framework/test/stream_module_t.cppunit.cc
@@ -95,6 +95,7 @@ private:
   edm::HistoryAppender historyAppender_;
   boost::shared_ptr<edm::LuminosityBlockPrincipal> m_lbp;
   boost::shared_ptr<edm::RunPrincipal> m_rp;
+  boost::shared_ptr<edm::ActivityRegistry> m_actReg;
   edm::EventSetup* m_es = nullptr;
   edm::ModuleDescription m_desc = {"Dummy","dummy"};
   edm::CPUTimer* m_timer = nullptr;
@@ -394,6 +395,7 @@ m_ep()
   edm::ProcessHistoryRegistry phr;
   m_ep->fillEventPrincipal(eventAux, phr);
   m_ep->setLuminosityBlockPrincipal(m_lbp);
+  m_actReg.reset(new edm::ActivityRegistry);
 
 
   //For each transition, bind a lambda which will call the proper method of the Worker
@@ -421,7 +423,9 @@ m_ep()
   
   m_transToFunc[Trans::kEvent] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::EventPrincipal, edm::BranchActionStreamBegin> Traits;
-    edm::ParentContext parentContext;
+    edm::StreamContext streamContext(s_streamID0, nullptr);
+    edm::ParentContext parentContext(&streamContext);
+    iBase->setActivityRegistry(m_actReg);
     iBase->doWork<Traits>(*m_ep,*m_es,m_timer, s_streamID0, parentContext, nullptr); };
 
   m_transToFunc[Trans::kStreamEndLuminosityBlock] = [this](edm::Worker* iBase) {


### PR DESCRIPTION
The pre/post module Service signals are now emitted after the framework has gotten all the
resources needed for the module so that the module can immediately be run. This is the
behavior we will have once we switch to the full task based threaded system.
