### PR TITLE
New DB tools: fix for support of authenticaton path

### DIFF
--- a/CondCore/Utilities/bin/conddb_copy_iov.cpp
+++ b/CondCore/Utilities/bin/conddb_copy_iov.cpp
@@ -44,12 +44,17 @@ int cond::CopyIovUtilities::execute(){
   if( hasOptionValue("destSince") ) destSince = getOptionValue<cond::Time_t>( "destSince");
 
   persistency::ConnectionPool connPool;
+  if( hasOptionValue("authPath") ){
+    connPool.setAuthenticationPath( getOptionValue<std::string>( "authPath") ); 
+  }
+  connPool.configure();
+
   std::cout <<"# Connecting to source database on "<<connect<<std::endl;
   persistency::Session session = connPool.createSession( connect, true, COND_DB );
 
   bool imported = copyIov( session, inputTag, tag, sourceSince, destSince, true );
     
-  if( imported ) std::cout <<"# 1 iov imported. "<<std::endl;
+  if( imported ) std::cout <<"# 1 iov copied. "<<std::endl;
 
   return 0;
 }

--- a/CondCore/Utilities/bin/conddb_import.cpp
+++ b/CondCore/Utilities/bin/conddb_import.cpp
@@ -52,6 +52,10 @@ int cond::ImportUtilities::execute(){
 
 
   persistency::ConnectionPool connPool;
+  if( hasOptionValue("authPath") ){
+    connPool.setAuthenticationPath( getOptionValue<std::string>( "authPath") ); 
+  }
+  connPool.configure();
   std::cout <<"# Connecting to source database on "<<sourceConnect<<std::endl;
   persistency::Session sourceSession = connPool.createSession( sourceConnect );
 


### PR DESCRIPTION
Adding the proper support of authentication path in the import/copy tools for new database, it was ignored before.
Packages:
CondCore/Utilities
