### PR TITLE
Fix compilation warnings

### DIFF
--- a/CondFormats/Serialization/interface/eos/portable_oarchive.hpp
+++ b/CondFormats/Serialization/interface/eos/portable_oarchive.hpp
@@ -321,8 +321,15 @@ namespace eos {
 				// examine the number of bytes
 				// needed to represent the number
 				signed char size = 0;
-				do { temp >>= CHAR_BIT; ++size; } 
-				while (temp != 0 && temp != (T) -1);
+				if(sizeof(T) == 1)
+				{
+					size = 1;
+				}
+				else
+				{
+					do { temp >>= CHAR_BIT; ++size; } 
+					while (temp != 0 && temp != (T) -1);
+				}
 
 				// encode the sign bit into the size
 				save_signed_char(t > 0 ? size : -size);


### PR DESCRIPTION
Fix compilation warnings in ROOT6 build coming from compilation of dictionaries.  All the warnings are from the same header:
CondFormats/Serialization/interface/eos/portable_oarchive.hpp:324:15: warning: shift count >= width of type [-Wshift-count-overflow]
The warnings are fixed by special casing calculating the size of single byte types. Single byte types cause the warning because the shift count of 8 is >= 8(the size of the type in bits).
