### PR TITLE
Fix bug affecting SubProcesses

### DIFF
--- a/DataFormats/Provenance/interface/BranchIDListHelper.h
+++ b/DataFormats/Provenance/interface/BranchIDListHelper.h
@@ -21,6 +21,9 @@ namespace edm {
 
     //CMS-THREADING called when a new file is opened
     bool updateFromInput(BranchIDLists const& bidlists);
+
+    void updateFromParent(BranchIDLists const& bidlists);
+
     ///Called by sources to convert their read indexes into the indexes used by the job
     void fixBranchListIndexes(BranchListIndexes& indexes) const;
 
@@ -42,6 +45,7 @@ namespace edm {
     BranchIDToIndexMap branchIDToIndexMap_;
     std::vector<BranchListIndex> inputIndexToJobIndex_;
     BranchListIndex producedBranchListIndex_;
+    BranchIDLists::size_type nAlreadyCopied_;
   };
 }
 

--- a/DataFormats/Provenance/src/BranchIDListHelper.cc
+++ b/DataFormats/Provenance/src/BranchIDListHelper.cc
@@ -11,7 +11,8 @@ namespace edm {
     branchIDLists_(),
     branchIDToIndexMap_(),
     inputIndexToJobIndex_(),
-    producedBranchListIndex_(std::numeric_limits<BranchListIndex>::max())
+    producedBranchListIndex_(std::numeric_limits<BranchListIndex>::max()),
+    nAlreadyCopied_(0)
   {}
 
   bool
@@ -40,6 +41,23 @@ namespace edm {
       }
     }
     return unchanged;
+  }
+
+  void
+  BranchIDListHelper::updateFromParent(BranchIDLists const& bidlists) {
+
+    inputIndexToJobIndex_.resize(bidlists.size());
+    for(auto it = bidlists.begin() + nAlreadyCopied_, itEnd = bidlists.end(); it != itEnd; ++it) {
+      BranchListIndex oldBlix = it - bidlists.begin();
+      BranchListIndex blix = branchIDLists_.size();
+      branchIDLists_.push_back(*it);
+      for(BranchIDList::const_iterator i = it->begin(), iEnd = it->end(); i != iEnd; ++i) {
+        ProductIndex pix = i - it->begin();
+        branchIDToIndexMap_.insert(std::make_pair(BranchID(*i), std::make_pair(blix, pix)));
+      }
+      inputIndexToJobIndex_[oldBlix]=blix;
+    }
+    nAlreadyCopied_ = bidlists.size();
   }
 
   void

--- a/FWCore/Framework/interface/FileBlock.h
+++ b/FWCore/Framework/interface/FileBlock.h
@@ -9,7 +9,6 @@ FileBlock: Properties of an input file.
 
 #include "DataFormats/Provenance/interface/FileFormatVersion.h"
 #include "DataFormats/Provenance/interface/BranchChildren.h"
-#include "DataFormats/Provenance/interface/BranchIDList.h"
 #include "FWCore/Utilities/interface/BranchType.h"
 class TTree;
 #include "boost/shared_ptr.hpp"
@@ -66,8 +65,7 @@ namespace edm {
       fileName_(),
       branchListIndexesUnchanged_(false),
       modifiedIDs_(false),
-      branchChildren_(new BranchChildren),
-      branchIDLists_(new BranchIDLists) {}
+      branchChildren_(new BranchChildren) {}
 
     FileBlock(FileFormatVersion const& version,
               TTree const* ev, TTree const* meta,
@@ -78,8 +76,7 @@ namespace edm {
               std::string const& fileName,
               bool branchListIndexesUnchanged,
               bool modifiedIDs,
-              boost::shared_ptr<BranchChildren> branchChildren,
-              boost::shared_ptr<BranchIDLists const> branchIDLists) :
+              boost::shared_ptr<BranchChildren> branchChildren) :
       fileFormatVersion_(version),
       tree_(const_cast<TTree*>(ev)),
       metaTree_(const_cast<TTree*>(meta)),
@@ -92,8 +89,7 @@ namespace edm {
       fileName_(fileName),
       branchListIndexesUnchanged_(branchListIndexesUnchanged),
       modifiedIDs_(modifiedIDs),
-      branchChildren_(branchChildren),
-      branchIDLists_(branchIDLists) {}
+      branchChildren_(branchChildren) {}
 
     ~FileBlock() {}
 
@@ -115,7 +111,6 @@ namespace edm {
       whyNotFastClonable_ |= why;
     }
     BranchChildren const& branchChildren() const { return *branchChildren_; }
-    BranchIDLists const& branchIDLists() const { return *branchIDLists_; }
     void close () {runMetaTree_ = lumiMetaTree_ = metaTree_ = runTree_ = lumiTree_ = tree_ = 0;}
 
   private:
@@ -133,7 +128,6 @@ namespace edm {
     bool branchListIndexesUnchanged_;
     bool modifiedIDs_;
     boost::shared_ptr<BranchChildren> branchChildren_;
-    boost::shared_ptr<BranchIDLists const> branchIDLists_;
   };
 }
 #endif

--- a/FWCore/Framework/interface/ScheduleItems.h
+++ b/FWCore/Framework/interface/ScheduleItems.h
@@ -27,7 +27,7 @@ namespace edm {
   struct ScheduleItems {
     ScheduleItems();
 
-    ScheduleItems(ProductRegistry const& preg, BranchIDListHelper const& branchIDListHelper, SubProcess const& om);
+    ScheduleItems(ProductRegistry const& preg, SubProcess const& om);
 
     ScheduleItems(ScheduleItems const&) = delete; // Disallow copying and moving
     ScheduleItems& operator=(ScheduleItems const&) = delete; // Disallow copying and moving

--- a/FWCore/Framework/interface/SubProcess.h
+++ b/FWCore/Framework/interface/SubProcess.h
@@ -110,6 +110,8 @@ namespace edm {
       if(subProcess_.get()) subProcess_->openOutputFiles(fb);
     }
 
+    void updateBranchIDListHelper(BranchIDLists const&);
+
     // Call respondToOpenInputFile() on all Modules
     void respondToOpenInputFile(FileBlock const& fb);
 

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -1466,6 +1466,9 @@ namespace edm {
   }
 
   void EventProcessor::respondToOpenInputFile() {
+    if(hasSubProcess()) {
+      subProcess_->updateBranchIDListHelper(branchIDListHelper_->branchIDLists());
+    }
     if (fb_.get() != nullptr) {
       schedule_->respondToOpenInputFile(*fb_);
       if(hasSubProcess()) subProcess_->respondToOpenInputFile(*fb_);

--- a/FWCore/Framework/src/ScheduleItems.cc
+++ b/FWCore/Framework/src/ScheduleItems.cc
@@ -24,15 +24,15 @@ namespace edm {
   ScheduleItems::ScheduleItems() :
       actReg_(new ActivityRegistry),
       preg_(new SignallingProductRegistry),
-      branchIDListHelper_(new BranchIDListHelper()),
+      branchIDListHelper_(new BranchIDListHelper),
       act_table_(),
       processConfiguration_() {
   }
 
-  ScheduleItems::ScheduleItems(ProductRegistry const& preg, BranchIDListHelper const& branchIDListHelper, SubProcess const& om) :
+  ScheduleItems::ScheduleItems(ProductRegistry const& preg, SubProcess const& om) :
       actReg_(new ActivityRegistry),
       preg_(new SignallingProductRegistry(preg)),
-      branchIDListHelper_(new BranchIDListHelper(branchIDListHelper)),
+      branchIDListHelper_(new BranchIDListHelper),
       act_table_(),
       processConfiguration_() {
 

--- a/FWCore/Integration/test/ref_merge_subprocess_cfg.py
+++ b/FWCore/Integration/test/ref_merge_subprocess_cfg.py
@@ -9,6 +9,9 @@ process.source = cms.Source("PoolSource",
 testProcess = cms.Process("TEST")
 process.subProcess = cms.SubProcess(testProcess)
 
+testProcess.a = cms.EDProducer("IntProducer",
+                           ivalue = cms.int32(1))
+
 testProcess.tester = cms.EDAnalyzer("OtherThingAnalyzer",
                                 other = cms.untracked.InputTag("d","testUserTag"))
 
@@ -16,4 +19,23 @@ testProcess.out = cms.OutputModule("PoolOutputModule",
     fileName = cms.untracked.string('refInSubProcess.root')
 )
 
+testProcess.p = cms.Path(testProcess.a)
+
 testProcess.e = cms.EndPath(testProcess.tester*testProcess.out)
+
+testProcessA = cms.Process("TESTA")
+testProcess.subProcess = cms.SubProcess(testProcessA)
+
+testProcessA.a = cms.EDProducer("IntProducer",
+                           ivalue = cms.int32(1))
+
+testProcessA.tester = cms.EDAnalyzer("OtherThingAnalyzer",
+                                other = cms.untracked.InputTag("d","testUserTag"))
+
+testProcessA.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('refInSubProcessA.root')
+)
+
+testProcessA.p = cms.Path(testProcessA.a)
+
+testProcessA.e = cms.EndPath(testProcessA.tester*testProcessA.out)

--- a/FWCore/Integration/test/standalone_t.cppunit.cc
+++ b/FWCore/Integration/test/standalone_t.cppunit.cc
@@ -22,8 +22,7 @@ if the MessageLogger is not runnning.
 class testStandalone: public CppUnit::TestFixture
 {
   CPPUNIT_TEST_SUITE(testStandalone);
-  CPPUNIT_TEST(writeFile);
-  CPPUNIT_TEST(readFile);
+  CPPUNIT_TEST(writeAndReadFile);
   CPPUNIT_TEST_SUITE_END();
 
 
@@ -38,8 +37,7 @@ class testStandalone: public CppUnit::TestFixture
     m_handler.reset();
   }
 
-  void writeFile();
-  void readFile();
+  void writeAndReadFile();
 
  private:
 
@@ -51,45 +49,46 @@ CPPUNIT_TEST_SUITE_REGISTRATION(testStandalone);
 
 
 
-void testStandalone::writeFile()
+void testStandalone::writeAndReadFile()
 {
-  std::string configuration("import FWCore.ParameterSet.Config as cms\n"
-                            "process = cms.Process('TEST')\n"
-                            "process.maxEvents = cms.untracked.PSet(\n"
-                            "    input = cms.untracked.int32(5)\n"
-                            ")\n"
-                            "process.source = cms.Source('EmptySource')\n"
-                            "process.JobReportService = cms.Service('JobReportService')\n"
-                            "process.InitRootHandlers = cms.Service('InitRootHandlers')\n"
-                            "process.m1 = cms.EDProducer('IntProducer',\n"
-                            "    ivalue = cms.int32(11)\n"
-                            ")\n"
-                            "process.out = cms.OutputModule('PoolOutputModule',\n"
-                            "    fileName = cms.untracked.string('testStandalone.root')\n"
-                            ")\n"
-                            "process.p = cms.Path(process.m1)\n"
-                            "process.e = cms.EndPath(process.out)\n");
+  {
+    std::string configuration("import FWCore.ParameterSet.Config as cms\n"
+                              "process = cms.Process('TEST')\n"
+                              "process.maxEvents = cms.untracked.PSet(\n"
+                              "    input = cms.untracked.int32(5)\n"
+                              ")\n"
+                              "process.source = cms.Source('EmptySource')\n"
+                              "process.JobReportService = cms.Service('JobReportService')\n"
+                              "process.InitRootHandlers = cms.Service('InitRootHandlers')\n"
+                              "process.m1 = cms.EDProducer('IntProducer',\n"
+                              "    ivalue = cms.int32(11)\n"
+                              ")\n"
+                              "process.out = cms.OutputModule('PoolOutputModule',\n"
+                              "    fileName = cms.untracked.string('testStandalone.root')\n"
+                              ")\n"
+                              "process.p = cms.Path(process.m1)\n"
+                              "process.e = cms.EndPath(process.out)\n");
 
-  edm::EventProcessor proc(configuration, true);
-  proc.beginJob();
-  proc.run();
-  proc.endJob();
-}
+    edm::EventProcessor proc(configuration, true);
+    proc.beginJob();
+    proc.run();
+    proc.endJob();
+  }
 
-void testStandalone::readFile()
-{
-  std::string configuration("import FWCore.ParameterSet.Config as cms\n"
-                            "process = cms.Process('TEST1')\n"
-                            "process.source = cms.Source('PoolSource',\n"
-                            "    fileNames = cms.untracked.vstring('file:testStandalone.root')\n"
-                            ")\n"
-                            "process.InitRootHandlers = cms.Service('InitRootHandlers')\n"
-                            "process.JobReportService = cms.Service('JobReportService')\n"
-                            "process.add_(cms.Service('SiteLocalConfigService'))\n"
-                           );
+  {
+    std::string configuration("import FWCore.ParameterSet.Config as cms\n"
+                              "process = cms.Process('TEST1')\n"
+                              "process.source = cms.Source('PoolSource',\n"
+                              "    fileNames = cms.untracked.vstring('file:testStandalone.root')\n"
+                              ")\n"
+                              "process.InitRootHandlers = cms.Service('InitRootHandlers')\n"
+                              "process.JobReportService = cms.Service('JobReportService')\n"
+                              "process.add_(cms.Service('SiteLocalConfigService'))\n"
+                             );
 
-  edm::EventProcessor proc(configuration, true);
-  proc.beginJob();
-  proc.run();
-  proc.endJob();
+    edm::EventProcessor proc(configuration, true);
+    proc.beginJob();
+    proc.run();
+    proc.endJob();
+  }
 }

--- a/IOPool/Input/src/RootFile.cc
+++ b/IOPool/Input/src/RootFile.cc
@@ -643,8 +643,7 @@ namespace edm {
                                                      file_,
                                                      branchListIndexesUnchanged(),
                                                      modifiedIDs(),
-                                                     branchChildren_,
-                                                     branchIDLists_));
+                                                     branchChildren_));
   }
 
   std::string const&

--- a/IOPool/Output/test/TestPoolOutput.sh
+++ b/IOPool/Output/test/TestPoolOutput.sh
@@ -2,6 +2,8 @@
 # Pass in name and status
 function die { echo $1: status $2 ;  exit $2; }
 
+pushd ${LOCAL_TMP_DIR}
+
 cmsRun --parameter-set ${LOCAL_TEST_DIR}/PoolOutputTest_cfg.py || die 'Failure using PoolOutputTest_cfg.py' $?
 
 cmsRun --parameter-set ${LOCAL_TEST_DIR}/PoolParallelOutputCopy_cfg.py || die 'Failure using PoolParallelOutputCopy_cfg.py' $?
@@ -36,3 +38,5 @@ cmsRun ${LOCAL_TEST_DIR}/TestProvC_cfg.py || die 'Failure using TestProvC_cfg.py
 
 cmsRun ${LOCAL_TEST_DIR}/PoolOutputTestUnscheduled_cfg.py || die 'Failure using PoolOutputTestUnscheduled_cfg.py' $?
 cmsRun ${LOCAL_TEST_DIR}/PoolOutputTestUnscheduledRead_cfg.py || die 'Failure using PoolOutputTestUnscheduledRead_cfg.py' $?
+
+popd

--- a/IOPool/SecondaryInput/test/TestSecondaryInput.sh
+++ b/IOPool/SecondaryInput/test/TestSecondaryInput.sh
@@ -2,6 +2,8 @@
 # Pass in name and status
 function die { echo $1: status $2 ;  exit $2; }
 
+pushd ${LOCAL_TMP_DIR}
+
 cmsRun --parameter-set ${LOCAL_TEST_DIR}/PreSecondaryInputTest2_cfg.py || die 'Failure using PreSecondaryInputTest2_cfg.py' $?
 
 cmsRun --parameter-set ${LOCAL_TEST_DIR}/PreSecondaryInputTest_cfg.py || die 'Failure using PreSecondaryInputTest_cfg.py' $?
@@ -15,3 +17,5 @@ cmsRun --parameter-set ${LOCAL_TEST_DIR}/SecondaryInLumiInputTest_cfg.py || die 
 cmsRun --parameter-set ${LOCAL_TEST_DIR}/SecondarySeqInLumiInputTest_cfg.py || die 'Failure using SecondarySeqInLumiInputTest_cfg.py' $?
 
 cmsRun --parameter-set ${LOCAL_TEST_DIR}/SecondarySpecInputTest_cfg.py || die 'Failure using SecondarySpecInputTest_cfg.py' $?
+
+popd


### PR DESCRIPTION
Fix a bug affecting SubProcesses. It affects
them when input files are being merged and
the input files have differing BranchIDLists
and the SubProcess produces something.
An attempt to use a Ref or Ptr in the SubProcess
or any subsequent job using its output can result
in a failed assert which aborts the job. The
BranchListIndexes which are used to reference
Ref's become corrupt.
