### PR TITLE
CaloTower fixes for Phase 2

### DIFF
--- a/Geometry/CaloEventSetup/plugins/CaloTowerConstituentsMapBuilder.cc
+++ b/Geometry/CaloEventSetup/plugins/CaloTowerConstituentsMapBuilder.cc
@@ -86,7 +86,7 @@ CaloTowerConstituentsMapBuilder::produce(const CaloGeometryRecord& iRecord)
   if (!mapFile_.empty()) {
     parseTextMap(mapFile_,*prod);
   } else {
-    assignEEtoHE(geometry, *prod);
+    assignEEtoHE(geometry, *prod, &*cttopo);
   }
   prod->sort();
   
@@ -117,7 +117,7 @@ CaloTowerConstituentsMapBuilder::parseTextMap( const std::string& filename, Calo
 }
 
 //algorithm to assign EE cells to HE towers if no text map is provided
-void CaloTowerConstituentsMapBuilder::assignEEtoHE(const CaloGeometry* geometry, CaloTowerConstituentsMap& theMap){
+void CaloTowerConstituentsMapBuilder::assignEEtoHE(const CaloGeometry* geometry, CaloTowerConstituentsMap& theMap, const CaloTowerTopology * cttopo){
   //get EE and HE geometries
   const CaloSubdetectorGeometry* geomEE ( geometry->getSubdetectorGeometry( DetId::Ecal, EcalEndcap ) );
   const CaloSubdetectorGeometry* geomHE ( geometry->getSubdetectorGeometry( DetId::Hcal, HcalEndcap ) );
@@ -135,7 +135,7 @@ void CaloTowerConstituentsMapBuilder::assignEEtoHE(const CaloGeometry* geometry,
     const HcalDetId closestCell ( geomHE->getClosestCell( gp ) ) ;
     
     //assign to appropriate CaloTower
-    CaloTowerDetId tid(closestCell.ieta(), closestCell.iphi());
+    CaloTowerDetId tid(cttopo->convertHcaltoCT(closestCell.ietaAbs(),closestCell.subdet())*closestCell.zside(), closestCell.iphi());
     theMap.assign(vec[ic],tid);
   }
 }

--- a/Geometry/CaloEventSetup/plugins/CaloTowerConstituentsMapBuilder.h
+++ b/Geometry/CaloEventSetup/plugins/CaloTowerConstituentsMapBuilder.h
@@ -51,7 +51,7 @@ public:
 
 private:
   void parseTextMap(const std::string& filename,CaloTowerConstituentsMap& theMap);
-  void assignEEtoHE(const CaloGeometry* geometry, CaloTowerConstituentsMap& theMap);
+  void assignEEtoHE(const CaloGeometry* geometry, CaloTowerConstituentsMap& theMap, const CaloTowerTopology * cttopo);
   std::string mapFile_;
 };
 

--- a/Geometry/CaloTopology/src/CaloTowerConstituentsMap.cc
+++ b/Geometry/CaloTopology/src/CaloTowerConstituentsMap.cc
@@ -30,10 +30,7 @@ CaloTowerDetId CaloTowerConstituentsMap::towerOf(const DetId& id) const {
 	   (hid.subdet()==HcalEndcap && standardHE_ )  ||
 	   (hid.subdet()==HcalOuter  && standardHO_ )  ||
 	   (hid.subdet()==HcalForward && standardHF_) ) {
-	if ((hid.subdet()==HcalForward) && hid.ietaAbs()==m_hcaltopo->firstHFRing())  // special handling for first HF tower
-	  tid=CaloTowerDetId((m_hcaltopo->firstHFRing()+1)*hid.zside(),hid.iphi());
-	else 
-	  tid=CaloTowerDetId(hid.ieta(),hid.iphi());
+        tid = CaloTowerDetId(m_cttopo->convertHcaltoCT(hid.ietaAbs(),hid.subdet())*hid.zside(),hid.iphi());
       }      
     } else if (id.det()==DetId::Ecal) {
       EcalSubdetector esd=(EcalSubdetector)id.subdetId();

--- a/Geometry/CaloTopology/src/CaloTowerTopology.cc
+++ b/Geometry/CaloTopology/src/CaloTowerTopology.cc
@@ -22,7 +22,8 @@ CaloTowerTopology::CaloTowerTopology(const HcalTopology * topology) : hcaltopo(t
   lastHORing_ = firstHORing_ + nEtaHO_ - 1;
   
   //translate phi segmentation boundaries into continuous ieta
-  firstHEDoublePhiRing_ = firstHERing_ + (hcaltopo->firstHEDoublePhiRing() - hcaltopo->firstHERing());
+  if(hcaltopo->firstHEDoublePhiRing()==999) firstHEDoublePhiRing_ = firstHFRing_;
+  else firstHEDoublePhiRing_ = firstHERing_ + (hcaltopo->firstHEDoublePhiRing() - hcaltopo->firstHERing());
   firstHEQuadPhiRing_ = firstHERing_ + (hcaltopo->firstHEQuadPhiRing() - hcaltopo->firstHERing());
   firstHFQuadPhiRing_ = firstHFRing_ - 1 + (hcaltopo->firstHFQuadPhiRing() - hcaltopo->firstHFRing());
   


### PR DESCRIPTION
This commit fixes a few CaloTower bugs for Phase 2 HCAL geometries:
1) Correctly interprets geometries where the entire HE has 5 degree ("single") phi segmentation, so the 10 degree ("double") segmentation doesn't start until HF.
2) Uses the CaloTower continuous ieta values in the constituents map for CaloTower DetIds (instead of the HCAL ieta values which may not be continuous in Phase 2 geometries).

I'm hoping this pull request can be accepted before the SLHC13 deadline tomorrow...
