### PR TITLE
Bugfix for edm::FwdRef

### DIFF
--- a/DataFormats/Common/interface/FwdPtr.h
+++ b/DataFormats/Common/interface/FwdPtr.h
@@ -34,6 +34,7 @@
 // system include files
 #include "boost/type_traits/is_base_of.hpp"
 #include "boost/utility/enable_if.hpp"
+#include <cassert>
 
 // forward declarations
 namespace edm {
@@ -49,7 +50,7 @@ namespace edm {
     template<typename C>
     FwdPtr(const Ptr<C>& f, const Ptr<C>& b):
     ptr_(f), backPtr_(b)
-    {}
+    { assert(f.isNull() == b.isNull()); }
     
   FwdPtr() :
     ptr_(), backPtr_()
@@ -72,14 +73,14 @@ namespace edm {
     
     /// Dereference operator
     T const&
-    operator*() const { return ptr_.isNonnull() ? ptr_.operator*() : backPtr_.operator*();}
+    operator*() const { return ptr_.isAvailable() ? ptr_.operator*() : backPtr_.operator*();}
 
     /// Member dereference operator
     T const*
-    operator->() const{ return ptr_.isNonnull() ? ptr_.operator->() : backPtr_.operator->();}
+    operator->() const{ return ptr_.isAvailable() ? ptr_.operator->() : backPtr_.operator->();}
 
     /// Returns C++ pointer to the item
-    T const* get() const { return ptr_.isNonnull() ? ptr_.get() : backPtr_.get();}
+    T const* get() const { return ptr_.isAvailable() ? ptr_.get() : backPtr_.get();}
 
 
     /// Checks for null

--- a/DataFormats/Common/interface/FwdRef.h
+++ b/DataFormats/Common/interface/FwdRef.h
@@ -140,7 +140,7 @@ namespace edm {
     /// General purpose constructor from 2 refs (forward and backward.
     FwdRef(Ref<C,T,F> const & ref,
 	   Ref<C,T,F> const & backRef) :
-        ref_(ref), backRef_(backRef) {}
+        ref_(ref), backRef_(backRef) { assert(ref.isNull() == backRef.isNull()); }
   
     /// Destructor
     ~FwdRef() {}
@@ -155,12 +155,10 @@ namespace edm {
 
     /// Returns C++ pointer to the item
     T const* get() const {
-      if ( ref_.isNonnull() ) {
+      if ( ref_.isAvailable() ) {
 	return ref_.get();
-      } else if ( backRef_.isNonnull() ) {
-	return backRef_.get();
       } else {
-	return 0;
+	return backRef_.get();
       }
     }
 


### PR DESCRIPTION
@gpetruc @rappoccio
Fix FwdRef so that at get() time it checks Availability rather than Nullness.
Should fix the access when the original collection is kept and the forward pointed is dropped.
This way should also be complaint with the implementation of edm::FwdRef::isAvailable that return true if any of the two collections is available. With old implementation despite isAvailable being true, dereferencing would throw if the fwd pointed was dropped.

See:
https://hypernews.cern.ch/HyperNews/CMS/get/edmFramework/3282.html

Similar to PR #3850
