### PR TITLE
Generator and custom hadron physlist constructor cleanup

### DIFF
--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -127,14 +127,15 @@ g4SimHits = cms.EDProducer("OscarProducer",
         ApplyPCuts = cms.bool(True),
         ApplyPtransCut = cms.bool(False),
         MinPCut = cms.double(0.04), ## the cut is in GeV 
-        MaxPCut = cms.double(99999.0), ## the pmax=99.TeV in this case
+        MaxPCut = cms.double(99999.0), ## the pmax=99.TeV 
         ApplyEtaCuts = cms.bool(True),
         MinEtaCut = cms.double(-5.5),
         MaxEtaCut = cms.double(5.5),
+        RDecLenCut = cms.double(2.9), ## (cm) the cut on vertex radius
+        LDecLenCut = cms.double(30.0), ## (cm) decay volume length
         ApplyPhiCuts = cms.bool(False),
-        MinPhiCut = cms.double(-3.14159265359), ## in radians
+        MinPhiCut = cms.double(-3.14159265359), ## (radians)
         MaxPhiCut = cms.double(3.14159265359), ## according to CMS conventions
-        RDecLenCut = cms.double(2.9), ## the minimum decay length in cm (!) for mother tracking
         Verbosity = cms.untracked.int32(0)
     ),
     RunAction = cms.PSet(

--- a/SimG4Core/Generators/interface/Generator.h
+++ b/SimG4Core/Generators/interface/Generator.h
@@ -22,7 +22,7 @@ public:
   virtual ~Generator();
 
   void setGenEvent( const HepMC::GenEvent* inpevt ) 
-    { evt_ = (HepMC::GenEvent*)inpevt; }
+    { evt_ = (HepMC::GenEvent*)inpevt; return ; }
   void HepMC2G4(const HepMC::GenEvent * g,G4Event * e);
   void nonBeamEvent2G4(const HepMC::GenEvent * g,G4Event * e);
   virtual const HepMC::GenEvent*  genEvent() const { return evt_; }
@@ -35,7 +35,7 @@ private:
   void particleAssignDaughters(G4PrimaryParticle * p, HepMC::GenParticle * hp, 
 			       double length);
   void setGenId(G4PrimaryParticle* p, int id) const 
-  { p->SetUserInformation(new GenParticleInfo(id)); }
+  { p->SetUserInformation(new GenParticleInfo(id));}
 
 private:
   bool   fPCuts;

--- a/SimG4Core/Generators/interface/Generator.h
+++ b/SimG4Core/Generators/interface/Generator.h
@@ -11,8 +11,6 @@
 #include "HepMC/GenParticle.h"
 
 #include <vector>
-//#include <map>
-//#include <string>
     
 class G4Event;
 class G4PrimaryParticle;
@@ -22,20 +20,22 @@ class Generator
 public:
   Generator(const edm::ParameterSet & p);
   virtual ~Generator();
-  // temp.(?) method
+
   void setGenEvent( const HepMC::GenEvent* inpevt ) 
-    { evt_ = (HepMC::GenEvent*)inpevt; return ; }
+    { evt_ = (HepMC::GenEvent*)inpevt; }
   void HepMC2G4(const HepMC::GenEvent * g,G4Event * e);
   void nonBeamEvent2G4(const HepMC::GenEvent * g,G4Event * e);
   virtual const HepMC::GenEvent*  genEvent() const { return evt_; }
   virtual const math::XYZTLorentzVector* genVertex() const { return vtx_; }
   virtual const double eventWeight() const { return weight_; }
+
 private:
-  bool particlePassesPrimaryCuts(const G4PrimaryParticle * p) const;
+
+  bool particlePassesPrimaryCuts(const G4ThreeVector& p) const;
   void particleAssignDaughters(G4PrimaryParticle * p, HepMC::GenParticle * hp, 
 			       double length);
   void setGenId(G4PrimaryParticle* p, int id) const 
-  {p->SetUserInformation(new GenParticleInfo(id));}
+  { p->SetUserInformation(new GenParticleInfo(id)); }
 
 private:
   bool   fPCuts;
@@ -49,8 +49,9 @@ private:
   double theMinPCut;
   double theMinPtCut2;
   double theMaxPCut;
-  double theRDecLenCut2;
+  double theDecRCut2;
   double theEtaCutForHector; 
+  double theDecLenCut;
   int verbose;
   HepMC::GenEvent*  evt_;
   math::XYZTLorentzVector* vtx_;
@@ -58,6 +59,7 @@ private:
   double Z_lmin,Z_lmax,Z_hector;
   std::vector<int> pdgFilter;
   bool pdgFilterSel;
+  bool fPDGFilter;
 };
 
 #endif

--- a/SimG4Core/Generators/src/Generator.cc
+++ b/SimG4Core/Generators/src/Generator.cc
@@ -23,7 +23,7 @@ Generator::Generator(const ParameterSet & p) :
   fPtransCut(p.getParameter<bool>("ApplyPtransCut")),
   fEtaCuts(p.getParameter<bool>("ApplyEtaCuts")), 
   fPhiCuts(p.getParameter<bool>("ApplyPhiCuts")),
-  theMinPhiCut(p.getParameter<double>("MinPhiCut")),// in radians (CMS standard)
+  theMinPhiCut(p.getParameter<double>("MinPhiCut")), // in radians (CMS standard)
   theMaxPhiCut(p.getParameter<double>("MaxPhiCut")),
   theMinEtaCut(p.getParameter<double>("MinEtaCut")),
   theMaxEtaCut(p.getParameter<double>("MaxEtaCut")),
@@ -142,7 +142,7 @@ void Generator::HepMC2G4(const HepMC::GenEvent * evt_orig, G4Event * g4evt)
         break;
       }  
       // The selection is made considering if the partcile with status = 2 
-      // have the end_vertex with a radius (R) greater then the beampipe 
+      // have the end_vertex with a radius greater than the radius of beampipe 
       // cilinder (no requirement on the Z of the vertex is applyed).
       else if (2 == (*pitr)->status()) {
 
@@ -166,7 +166,7 @@ void Generator::HepMC2G4(const HepMC::GenEvent * evt_orig, G4Event * g4evt)
       }
     }
 
-    // if this vertex is inside fiductial volume inside beam pipe
+    // if this vertex is inside fiductial volume inside the beam pipe
     // and has no long-lived secondary the vertex is not saved 
     if (!qvtx) {
       continue;

--- a/SimG4Core/Generators/src/Generator.cc
+++ b/SimG4Core/Generators/src/Generator.cc
@@ -12,6 +12,7 @@
 #include "G4UnitsTable.hh"
 #include "G4SystemOfUnits.hh"
 #include "G4PhysicalConstants.hh"
+#include "G4Log.hh"
 
 using namespace edm;
 //using std::cout;
@@ -22,7 +23,7 @@ Generator::Generator(const ParameterSet & p) :
   fPtransCut(p.getParameter<bool>("ApplyPtransCut")),
   fEtaCuts(p.getParameter<bool>("ApplyEtaCuts")), 
   fPhiCuts(p.getParameter<bool>("ApplyPhiCuts")),
-  theMinPhiCut(p.getParameter<double>("MinPhiCut")), // in radians (CMS standard)
+  theMinPhiCut(p.getParameter<double>("MinPhiCut")),// in radians (CMS standard)
   theMaxPhiCut(p.getParameter<double>("MaxPhiCut")),
   theMinEtaCut(p.getParameter<double>("MinEtaCut")),
   theMaxEtaCut(p.getParameter<double>("MaxEtaCut")),
@@ -36,26 +37,32 @@ Generator::Generator(const ParameterSet & p) :
   Z_lmin(0),
   Z_lmax(0),
   Z_hector(0),
-  pdgFilterSel(false) 
+  pdgFilterSel(false), 
+  fPDGFilter(false) 
 {
   double theRDecLenCut = p.getParameter<double>("RDecLenCut")*cm;
-  theRDecLenCut2 = theRDecLenCut*theRDecLenCut;
+  theDecRCut2 = theRDecLenCut*theRDecLenCut;
+
   theMinPtCut2 = theMinPCut*theMinPCut;
+
+  double theDecLenCut = p.getParameter<double>("LDecLenCut")*cm;
 
   pdgFilter.resize(0);
   if ( p.exists("PDGselection") ) {
-
-    pdgFilterSel = 
-      (p.getParameter<edm::ParameterSet>("PDGselection")).getParameter<bool>("PDGfilterSel");
-    pdgFilter = 
-      (p.getParameter<edm::ParameterSet>("PDGselection")).getParameter<std::vector< int > >("PDGfilter");
-    for ( unsigned int ii = 0; ii < pdgFilter.size(); ++ii) {
-      if (pdgFilterSel) {
-        edm::LogWarning("SimG4CoreGenerator") << " *** Selecting only PDG ID = " 
-					      << pdgFilter[ii];
-      } else {
-        edm::LogWarning("SimG4CoreGenerator") << " *** Filtering out PDG ID = " 
-					      << pdgFilter[ii];
+    pdgFilterSel = (p.getParameter<edm::ParameterSet>("PDGselection")).
+                    getParameter<bool>("PDGfilterSel");
+    pdgFilter = (p.getParameter<edm::ParameterSet>("PDGselection")).
+                    getParameter<std::vector< int > >("PDGfilter");
+    if(0 < pdgFilter.size()) { 
+      fPDGFilter = true; 
+      for ( unsigned int ii = 0; ii < pdgFilter.size(); ++ii) {
+	if (pdgFilterSel) {
+	  edm::LogWarning("SimG4CoreGenerator") 
+	    << " *** Selecting only PDG ID = " << pdgFilter[ii];
+	} else {
+	  edm::LogWarning("SimG4CoreGenerator") << " *** Filtering out PDG ID = " 
+						<< pdgFilter[ii];
+	}
       }
     }
   }
@@ -69,9 +76,13 @@ Generator::Generator(const ParameterSet & p) :
 			    / ( 2*exp(-theEtaCutForHector) ) );
 
   edm::LogInfo("SimG4CoreGenerator") 
-    << "Z_min = " << Z_lmin << " Z_max = " << Z_lmax << " Z_hector = " << Z_hector;
-  if(0 < verbose) LogDebug("SimG4CoreGenerator")
-    << "Z_min = " << Z_lmin << " Z_max = " << Z_lmax << " Z_hector = " << Z_hector;
+    << " Rdecaycut= " << theRDecLenCut/cm 
+    << " cm;  Zdecaycut= " << theDecLenCut/cm 
+    << "Z_min= " << Z_lmin/cm << " cm; Z_max= " << Z_lmax 
+    << " cm;  Z_hector = " << Z_hector << " cm\n"
+    << "ApplyPCuts: " << fPCuts << "  ApplyPtransCut: " << fPtransCut
+    << "  ApplyEtaCuts: " << fEtaCuts 
+    << "  ApplyPhiCuts: " << fPhiCuts;
 }
 
 Generator::~Generator() 
@@ -116,48 +127,47 @@ void Generator::HepMC2G4(const HepMC::GenEvent * evt_orig, G4Event * g4evt)
   for(HepMC::GenEvent::vertex_const_iterator vitr= evt->vertices_begin();
       vitr != evt->vertices_end(); ++vitr ) { 
 
-    // loop for vertex ...
-    // real vertex?
+    // loop for vertex, is it a real vertex?
     G4bool qvtx=false;
     HepMC::GenVertex::particle_iterator pitr;
     for (pitr= (*vitr)->particles_begin(HepMC::children);
          pitr != (*vitr)->particles_end(HepMC::children); ++pitr) {
 
-      // Admit also status=1 && end_vertex for long vertex special decay treatment 
+      // Particles which are not decayed by generator
       if (1 == (*pitr)->status()) {
-
         qvtx = true;
-        if (verbose > 1) LogDebug("SimG4CoreGenerator") 
+        if (verbose > 2) LogDebug("SimG4CoreGenerator") 
 	  << "GenVertex barcode = " << (*vitr)->barcode() 
 	  << " selected for GenParticle barcode = " << (*pitr)->barcode();
         break;
       }  
       // The selection is made considering if the partcile with status = 2 
-      // have the end_vertex with a radius (R) greater then the theRDecLenCut 
-      // that means: the end_vertex is outside the beampipe cilinder 
-      // (no requirement on the Z of the vertex is applyed).
+      // have the end_vertex with a radius (R) greater then the beampipe 
+      // cilinder (no requirement on the Z of the vertex is applyed).
       else if (2 == (*pitr)->status()) {
 
         if ( (*pitr)->end_vertex() != 0  ) { 
           double xx = (*pitr)->end_vertex()->position().x();
           double yy = (*pitr)->end_vertex()->position().y();
           double r_dd = xx*xx+yy*yy;
-          if (r_dd > theRDecLenCut2){
+          if (r_dd > theDecRCut2) {
             qvtx = true;
-            if (verbose > 1) LogDebug("SimG4CoreGenerator") 
+            if (verbose > 2) LogDebug("SimG4CoreGenerator") 
 	      << "GenVertex barcode = " << (*vitr)->barcode() 
 	      << " selected for GenParticle barcode = " 
 	      << (*pitr)->barcode() << " radius = " << std::sqrt(r_dd);
             break;
           }
         } else {
-	  // particles with stus 2 without end_vertex are equivalent to stable
+	  // particles with status 2 without end_vertex are 
+	  // equivalent to stable
 	  qvtx = true;
 	}
       }
     }
 
-    // if this vertex has no long-lived secondary the vertex is not saved 
+    // if this vertex is inside fiductial volume inside beam pipe
+    // and has no long-lived secondary the vertex is not saved 
     if (!qvtx) {
       continue;
     }
@@ -173,32 +183,25 @@ void Generator::HepMC2G4(const HepMC::GenEvent * evt_orig, G4Event * g4evt)
          pitr != (*vitr)->particles_end(HepMC::children); ++pitr){
 
       // Filter on allowed particle species if required      
-      if ( pdgFilter.size() > 0 ) {
+      if (fPDGFilter) {
         std::vector<int>::iterator it = find(pdgFilter.begin(),pdgFilter.end(),
 					     (*pitr)->pdg_id()); 
         if ( (it != pdgFilter.end() && !pdgFilterSel) 
 	     || ( it == pdgFilter.end() && pdgFilterSel ) ) {
-          if (verbose > 1) LogDebug("SimG4CoreGenerator") 
+          if (verbose > 2) LogDebug("SimG4CoreGenerator") 
 	    << "Skip GenParticle barcode = " << (*pitr)->barcode() 
 	    << " PDG Id = " << (*pitr)->pdg_id();
           continue;
         }
       }
 
-      // Special cases:
-      // 1) import in Geant4 a full decay chain (e.g. also particles with status == 2) 
-      //    from the generator in case the decay radius is larger than theRDecLenCut
-      //    In this case no cuts will be applied to select the particles hat has to be 
-      //    processed by geant
-      // 2) import in Geant4 particles with status == 1 but a final end vertex. 
-      //    The time of the vertex is used as the time of flight to be forced for the particle 
-      
       double x2 = 0.0;
       double y2 = 0.0;
       double z2 = 0.0;
       double decay_length = 0.0;
       int status = (*pitr)->status();
 
+      // check the status, 2 has end point with decay defined by generator
       if (1 == status || 2 == status) {
 
         // this particle has decayed but have no vertex
@@ -226,6 +229,7 @@ void Generator::HepMC2G4(const HepMC::GenEvent * evt_orig, G4Event * g4evt)
       double zimpact = z1;
 
       // protection against numerical problems for extremely low momenta
+      // compute impact point at transition to Hector
       const double minTan = 1.e-20;
       if(fabs(z1) < Z_hector && fabs(pz) >= minTan*ptot) {
         if(pz > 0.0) { zimpact =  Z_hector; }
@@ -236,78 +240,83 @@ void Generator::HepMC2G4(const HepMC::GenEvent * evt_orig, G4Event * g4evt)
       }
       double rimpact2 = ximpact*ximpact + yimpact*yimpact;
       
-      if (verbose > 1) LogDebug("SimG4CoreGenerator") 
+      if (verbose > 2) LogDebug("SimG4CoreGenerator") 
 	<< "Processing GenParticle barcode= " << (*pitr)->barcode() 
+	<< " pdg= " << (*pitr)-> pdg_id()
 	<< " status= " << (*pitr)->status() 
 	<< " st= " << status 
 	<< " rimpact(cm)= " << std::sqrt(rimpact2)/cm
 	<< " zimpact(cm)= " << zimpact/cm
-	<< " ptot(GeV)= " << ptot;
+	<< " ptot(GeV)= " << ptot
+	<< " pz(GeV)= " << pz;
 
-      // Particles trasnported along the beam pipe for forward detectors (HECTOR)
-      // Always pass to Geant4 without cuts (to be checked)
+      // Particles of status 1 trasnported along the beam pipe for forward 
+      // detectors (HECTOR) always pass to Geant4 without cuts 
       if( 1 == status && 
-	  fabs(zimpact) >= Z_hector && rimpact2 <= theRDecLenCut2) {
+	  fabs(zimpact) >= Z_hector && rimpact2 <= theDecRCut2) {
         toBeAdded = true;
-        if ( verbose > 1 ) LogDebug("SimG4CoreGenerator") 
+        if ( verbose > 2 ) LogDebug("SimG4CoreGenerator") 
 	  << "GenParticle barcode = " << (*pitr)->barcode() 
 	  << " passed case 3";
       } else {
 
-        double decay_length = 0.0;
 	// Standard case: particles not decayed by the generator
-	// or particle decying without end vertex
 	if(1 == status && 
-	   (fabs(zimpact) < Z_hector || rimpact2 > theRDecLenCut2)) {
+           (fabs(zimpact) < Z_hector || rimpact2 > theDecRCut2)) {
 
-	  // Ptot cut (was assumed to be Pt?)
+	  // Ptot cut for all particles
 	  if (fPCuts && (ptot < theMinPCut || ptot > theMaxPCut)) {
             continue;
 	  }
-          // phi cut
+	  // phi cut is applied mainly for particle gun
 	  if (fPhiCuts) {
-            double phi = p.phi();
+	    double phi = p.phi();
 	    if(phi < theMinPhiCut || phi  > theMaxPhiCut) {
 	      continue;
 	    }
 	  }
+	  // eta cut is applied if position of the decay
+	  // is within vacuum chamber and limited in Z
+	  if(fEtaCuts) {
 
-	  // eta cut
-	  double xi = x1;
-	  double yi = y1;
-	  double zi = z1;
+	    // eta cut
+	    double xi = x1;
+	    double yi = y1;
+	    double zi = z1;
 
-	  // can be propagated along Z
-	  if(fabs(pz) >= minTan*ptot) {
-	    if((zi >= Z_lmax) & (pz < 0.0)) {
-              zi = Z_lmax;
-	    } else if((zi <= Z_lmin) & (pz > 0.0)) {
-              zi = Z_lmin;
-	    } else {
-              if(pz > 0) { zi = Z_lmax; }
-              else { zi = Z_lmin; }
+	    // can be propagated along Z
+	    if(fabs(pz) >= minTan*ptot) {
+	      if((zi >= Z_lmax) & (pz < 0.0)) {
+		zi = Z_lmax;
+	      } else if((zi <= Z_lmin) & (pz > 0.0)) {
+		zi = Z_lmin;
+	      } else {
+		if(pz > 0) { zi = Z_lmax; }
+		else { zi = Z_lmin; }
+	      }
+	      double del = (zi - z1)/pz;
+	      xi += del*px;
+	      yi += del*py;
 	    }
-	    double del = (zi - z1)/pz;
-	    xi += del*px;
-	    yi += del*py;
-	  }
-	  // check eta cut
-	  if((zi >= Z_lmin) & (zi <= Z_lmax) 
-	     & (xi*xi + yi*yi < theRDecLenCut2)) {
-	    continue;
+	    // check eta cut
+	    if((zi >= Z_lmin) & (zi <= Z_lmax) 
+	       & (xi*xi + yi*yi < theDecRCut2)) {
+	      continue;
+	    }
 	  }
 	  toBeAdded = true;
-	  if ( verbose > 1 ) LogDebug("SimG4CoreGenerator") 
+	  if ( verbose > 2 ) LogDebug("SimG4CoreGenerator") 
 	    << "GenParticle barcode = " << (*pitr)->barcode() 
 	    << " passed case 1";
-	} else if(2 == status && 
-		  x2*x2 + y2*y2 >= theRDecLenCut2 && fabs(z2) < Z_hector){
 
-	  // Decay chain entering exiting the fiducial cylinder 
-	  // defined by theRDecLenCut
-	  toBeAdded=true;
+	  // Decay chain outside the fiducial cylinder defined by theRDecLenCut
+	  // are used for Geant4 tracking with predefined decay channel
+	  // In the case of decay in vacuum particle is not tracked by Geant4
+	} else if(2 == status &&
+		  x2*x2 + y2*y2 >= theDecRCut2 && fabs(z2) < Z_hector) {
 
-	  if ( verbose > 1 ) LogDebug("SimG4CoreGenerator") 
+	  toBeAdded = true;
+	  if ( verbose > 2 ) LogDebug("SimG4CoreGenerator") 
 	    << "GenParticle barcode = " << (*pitr)->barcode() 
 	    << " passed case 2" 
 	    << " decay_length(cm)= " << decay_length/cm;
@@ -345,6 +354,8 @@ void Generator::HepMC2G4(const HepMC::GenEvent * evt_orig, G4Event * g4evt)
         g4vtx->SetPrimary(g4prim);
 
         // impose also proper time for status=1 and available end_vertex
+        // VI: this is impossible, so commented out 
+	/*
         if ( 1 == status && decay_length > 0.0) {
           double proper_time = decay_length/(p.Beta()*p.Gamma()*c_light);
           if ( verbose > 1 ) LogDebug("SimG4CoreGenerator") 
@@ -352,10 +363,11 @@ void Generator::HepMC2G4(const HepMC::GenEvent * evt_orig, G4Event * g4evt)
 	    <<p.Gamma()<<" Proper time=" <<proper_time/ns<<" ns" ;
           g4prim->SetProperTime(proper_time);
         }
+	*/
       }
     }
 
-    if (verbose > 1 ) g4vtx->Print();
+    if ( verbose > 1 ) g4vtx->Print();
     g4evt->AddPrimaryVertex(g4vtx);
     ++ng4vtx;
   }
@@ -364,7 +376,7 @@ void Generator::HepMC2G4(const HepMC::GenEvent * evt_orig, G4Event * g4evt)
   // add a dummy vertex with no particle attached to it
   if ( ng4vtx == 0 ) {
     G4PrimaryVertex* g4vtx = new G4PrimaryVertex(0.0, 0.0, 0.0, 0.0);
-    if (verbose > 1 ) g4vtx->Print();
+    if ( verbose > 1 ) g4vtx->Print();
     g4evt->AddPrimaryVertex(g4vtx);
   }
   
@@ -372,9 +384,10 @@ void Generator::HepMC2G4(const HepMC::GenEvent * evt_orig, G4Event * g4evt)
 }
 
 void Generator::particleAssignDaughters( G4PrimaryParticle* g4p, 
-					 HepMC::GenParticle* vp, double decaylength)
+					 HepMC::GenParticle* vp, 
+					 double decaylength)
 {
-  // not needed anymore
+  // V.I.: not needed anymore
   //if (!(vp->end_vertex())) return;
    
   if ( verbose > 1 ) 
@@ -382,10 +395,15 @@ void Generator::particleAssignDaughters( G4PrimaryParticle* g4p,
       << "Special case of long decay length \n" 
       << "Assign daughters with to mother with decaylength=" 
       << decaylength/cm << " cm";
+
   math::XYZTLorentzVector p(vp->momentum().px(), vp->momentum().py(), 
 			    vp->momentum().pz(), vp->momentum().e());
+
+  // defined preassigned decay time
   double proper_time = decaylength/(p.Beta()*p.Gamma()*c_light);
-  if( verbose > 1 ) {
+  g4p->SetProperTime(proper_time); 
+
+  if( verbose > 2 ) {
     LogDebug("SimG4CoreGenerator") <<" px= "<< p.px()
 				   <<" py= "<< p.py()
 				   <<" pz= "<< p.pz()
@@ -394,12 +412,13 @@ void Generator::particleAssignDaughters( G4PrimaryParticle* g4p,
 				   <<" gamma= " << p.Gamma()
 				   <<" Proper time= " <<proper_time/ns <<" ns";
   }
-  g4p->SetProperTime(proper_time); 
+
   // the particle will decay after the same length if it 
   // has not interacted before
   double x1 = vp->end_vertex()->position().x();
   double y1 = vp->end_vertex()->position().y();
   double z1 = vp->end_vertex()->position().z();
+
   for (HepMC::GenVertex::particle_iterator 
          vpdec= vp->end_vertex()->particles_begin(HepMC::children);
        vpdec != vp->end_vertex()->particles_end(HepMC::children); ++vpdec) {
@@ -409,22 +428,26 @@ void Generator::particleAssignDaughters( G4PrimaryParticle* g4p,
                                  (*vpdec)->momentum().py(),
                                  (*vpdec)->momentum().pz(),
                                  (*vpdec)->momentum().e());
+
     // children should only be taken into account once
     G4PrimaryParticle * g4daught= 
-      new G4PrimaryParticle((*vpdec)->pdg_id(), pdec.x()*GeV, pdec.y()*GeV, pdec.z()*GeV);
+      new G4PrimaryParticle((*vpdec)->pdg_id(), pdec.x()*GeV, 
+			    pdec.y()*GeV, pdec.z()*GeV);
+
     if ( g4daught->GetG4code() != 0 )
       { 
         g4daught->SetMass( g4daught->GetG4code()->GetPDGMass() ) ;
         g4daught->SetCharge( g4daught->GetG4code()->GetPDGCharge() ) ;  
       }
+
     // V.I. do not use SetWeight but the same code
     // value of the code compute inside TrackWithHistory        
     //g4daught->SetWeight( 10000*(*vpdec)->barcode() ) ;
     setGenId( g4daught, (*vpdec)->barcode() );
 
-    if ( verbose > 1 ) LogDebug("SimG4CoreGenerator") 
-      <<"Assigning a "<<(*vpdec)->pdg_id()
-      <<" as daughter of a " <<vp->pdg_id();
+    if ( verbose > 2 ) LogDebug("SimG4CoreGenerator") 
+      <<"Assigning a "<< (*vpdec)->pdg_id()
+      <<" as daughter of a " << vp->pdg_id();
     if ( (*vpdec)->status() == 2 && (*vpdec)->end_vertex() != 0 ) 
       {
         double x2 = (*vpdec)->end_vertex()->position().x();
@@ -433,33 +456,43 @@ void Generator::particleAssignDaughters( G4PrimaryParticle* g4p,
         double dd = std::sqrt((x1-x2)*(x1-x2)+(y1-y2)*(y1-y2)+(z1-z2)*(z1-z2));
         particleAssignDaughters(g4daught,*vpdec,dd);
       }
+
     (*vpdec)->set_status(1000+(*vpdec)->status()); 
     g4p->SetDaughter(g4daught);
+    if ( verbose > 1 ) g4daught->Print();
   }
-  return;
 }
 
-bool Generator::particlePassesPrimaryCuts(const G4PrimaryParticle * p) const 
+// Used for non-beam particles
+bool Generator::particlePassesPrimaryCuts(const G4ThreeVector& p) const 
 {
-
-  G4ThreeVector mom = p->GetMomentum();
-  double        phi = mom.phi();
-  double        nrg = mom.mag()/GeV;
-
-  double        eta = -log(0.5*tan(mom.theta()));
-  bool   flag = true;
-
-  if ( (fEtaCuts) && (eta < theMinEtaCut || eta > theMaxEtaCut) ) {
+  bool flag = true;
+  double ptot = p.mag();
+  if (fPCuts && (ptot < theMinPCut*GeV || ptot > theMaxPCut*GeV)) {
     flag = false;
-  } else if ( (fPCuts)  &&  (nrg  < theMinPCut  || nrg > theMaxPCut)   ) {
-    flag = false;
-  } else if ( (fPhiCuts) && (phi < theMinPhiCut || phi > theMaxPhiCut) ) {
-    flag = false;
+  } 
+  if (fEtaCuts && flag) {
+    double pz = p.z();
+    if(ptot < pz + 1.e-10) { 
+      flag = false;
+
+    } else {
+      double eta = 0.5*G4Log((ptot + pz)/(ptot - pz));
+      if(eta < theMinEtaCut || eta > theMaxEtaCut) {
+	flag = false;
+      }
+    }
+  }
+  if (fPhiCuts && flag) {
+    double phi = p.phi();
+    if(phi < theMinPhiCut || phi > theMaxPhiCut) {
+      flag = false;
+    }
   }
   
-  if ( verbose > 1 ) LogDebug("SimG4CoreGenerator") 
-    << "Generator p = " << nrg  << " eta = " << eta 
-    << " theta = " << mom.theta() << " phi = " << phi << " Flag = " << flag;
+  if ( verbose > 2 ) LogDebug("SimG4CoreGenerator") 
+    << "Generator ptot(GeV)= " << ptot/GeV << " eta= " << p.eta() 
+    << "  phi= " << p.phi() << " Flag= " << flag;
 
   return flag;
 }
@@ -470,33 +503,35 @@ void Generator::nonBeamEvent2G4(const HepMC::GenEvent * evt, G4Event * g4evt)
   for(HepMC::GenEvent::particle_const_iterator it = evt->particles_begin(); 
       it != evt->particles_end(); ++it ) {
     ++i;
-    HepMC::GenParticle * g = (*it);	
-    int g_status = g->status();
+    HepMC::GenParticle * gp = (*it);	
+    int g_status = gp->status();
     // storing only particle with status == 1 	
     if (g_status == 1) {
-      int g_id = g->pdg_id();	    
+      int g_id = gp->pdg_id();	    
       G4PrimaryParticle * g4p = 
-	new G4PrimaryParticle(g_id,g->momentum().px()*GeV,
-			      g->momentum().py()*GeV,g->momentum().pz()*GeV);
+	new G4PrimaryParticle(g_id,gp->momentum().px()*GeV,
+			      gp->momentum().py()*GeV,
+			      gp->momentum().pz()*GeV);
       if (g4p->GetG4code() != 0) { 
 	g4p->SetMass(g4p->GetG4code()->GetPDGMass());
-	g4p->SetCharge(g4p->GetG4code()->GetPDGCharge()) ;
+	g4p->SetCharge(g4p->GetG4code()->GetPDGCharge());
       }
       // V.I. do not use SetWeight but the same code
       // value of the code compute inside TrackWithHistory        
       //g4p->SetWeight(i*10000);
       setGenId(g4p,i);
-      if (particlePassesPrimaryCuts(g4p)) {
+      if (particlePassesPrimaryCuts(g4p->GetMomentum())) {
 	G4PrimaryVertex * v = 
-	  new G4PrimaryVertex(g->production_vertex()->position().x()*mm,
-			      g->production_vertex()->position().y()*mm,
-			      g->production_vertex()->position().z()*mm,
-			      g->production_vertex()->position().t()*mm/c_light);
+	  new G4PrimaryVertex(gp->production_vertex()->position().x()*mm,
+			      gp->production_vertex()->position().y()*mm,
+			      gp->production_vertex()->position().z()*mm,
+			      gp->production_vertex()->position().t()*mm/c_light);
 	v->SetPrimary(g4p);
 	g4evt->AddPrimaryVertex(v);
-	if(verbose >0) {
-	  v->Print();
-	}
+	if(verbose > 0) { v->Print(); }
+
+      } else {
+	delete g4p;
       }
     }
   } // end loop on HepMC particles

--- a/SimG4Core/PhysicsLists/interface/HadronPhysicsQGSPCMS_FTFP_BERT.h
+++ b/SimG4Core/PhysicsLists/interface/HadronPhysicsQGSPCMS_FTFP_BERT.h
@@ -5,59 +5,63 @@
 #include "G4ios.hh"
 
 #include "G4VPhysicsConstructor.hh"
-//#include "G4MiscLHEPBuilder.hh"
 
 #include "G4PiKBuilder.hh"
-#include "SimG4Core/PhysicsLists/interface/CMSFTFPPiKBuilder.hh"
+#include "G4FTFPPiKBuilder.hh"
 #include "G4QGSPPiKBuilder.hh"
 #include "G4BertiniPiKBuilder.hh"
 
 #include "G4ProtonBuilder.hh"
-#include "SimG4Core/PhysicsLists/interface/CMSFTFPProtonBuilder.hh"
+#include "G4FTFPProtonBuilder.hh"
 #include "G4QGSPProtonBuilder.hh"
 #include "G4BertiniProtonBuilder.hh"
 
 #include "G4NeutronBuilder.hh"
-#include "SimG4Core/PhysicsLists/interface/CMSFTFPNeutronBuilder.hh"
+#include "G4FTFPNeutronBuilder.hh"
 #include "G4QGSPNeutronBuilder.hh"
 #include "G4BertiniNeutronBuilder.hh"
-//#include "G4LEPNeutronBuilder.hh"
+
+#include "G4HyperonFTFPBuilder.hh"
+#include "G4AntiBarionBuilder.hh"
+#include "G4FTFPAntiBarionBuilder.hh"
 
 class HadronPhysicsQGSPCMS_FTFP_BERT : public G4VPhysicsConstructor
 {
   public: 
-    HadronPhysicsQGSPCMS_FTFP_BERT(const G4String& name ="hadron",G4bool quasiElastic=true);
+    HadronPhysicsQGSPCMS_FTFP_BERT(G4int verbose);
     virtual ~HadronPhysicsQGSPCMS_FTFP_BERT();
 
-  public: 
     virtual void ConstructParticle();
     virtual void ConstructProcess();
 
-    void SetQuasiElastic(G4bool value) {QuasiElastic = value;}; 
-    void SetProjectileDiffraction(G4bool value) {ProjectileDiffraction = value;}; 
-
   private:
     void CreateModels();
-    G4NeutronBuilder * theNeutrons;
-    CMSFTFPNeutronBuilder * theFTFPNeutron;
-    G4QGSPNeutronBuilder * theQGSPNeutron;
-    G4BertiniNeutronBuilder * theBertiniNeutron;
-    //    G4LEPNeutronBuilder * theLEPNeutron;
+
+    struct ThreadPrivate {
+      G4NeutronBuilder * theNeutrons;
+      G4FTFPNeutronBuilder * theFTFPNeutron;
+      G4QGSPNeutronBuilder * theQGSPNeutron;
+      G4BertiniNeutronBuilder * theBertiniNeutron;
     
-    G4PiKBuilder * thePiK;
-    CMSFTFPPiKBuilder * theFTFPPiK;
-    G4QGSPPiKBuilder * theQGSPPiK;
-    G4BertiniPiKBuilder * theBertiniPiK;
+      G4PiKBuilder * thePiK;
+      G4FTFPPiKBuilder * theFTFPPiK;
+      G4QGSPPiKBuilder * theQGSPPiK;
+      G4BertiniPiKBuilder * theBertiniPiK;
     
-    G4ProtonBuilder * thePro;
-    CMSFTFPProtonBuilder * theFTFPPro;
-    G4QGSPProtonBuilder * theQGSPPro; 
-    G4BertiniProtonBuilder * theBertiniPro;
+      G4ProtonBuilder * thePro;
+      G4FTFPProtonBuilder * theFTFPPro;
+      G4QGSPProtonBuilder * theQGSPPro; 
+      G4BertiniProtonBuilder * theBertiniPro;
     
-    // G4MiscLHEPBuilder * theMiscLHEP;
-    
-    G4bool QuasiElastic;
-    G4bool ProjectileDiffraction;
+      G4HyperonFTFPBuilder *theHyperon;
+
+      G4AntiBarionBuilder     *theAntiBaryon;
+      G4FTFPAntiBarionBuilder *theFTFPAntiBaryon;
+
+      G4VCrossSectionDataSet * xsNeutronInelasticXS;
+      G4VCrossSectionDataSet * xsNeutronCaptureXS;
+    };
+    static G4ThreadLocal ThreadPrivate* tpdata;    
 };
 
 #endif

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EML95msc93.cc
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EML95msc93.cc
@@ -1,6 +1,7 @@
 #include "QGSPCMS_FTFP_BERT_EML95msc93.hh"
 #include "SimG4Core/PhysicsLists/interface/CMSEmStandardPhysics95msc93.h"
 #include "SimG4Core/PhysicsLists/interface/CMSMonopolePhysics.h"
+#include "SimG4Core/PhysicsLists/interface/HadronPhysicsQGSPCMS_FTFP_BERT.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "G4DecayPhysics.hh"
@@ -51,7 +52,7 @@ QGSPCMS_FTFP_BERT_EML95msc93::QGSPCMS_FTFP_BERT_EML95msc93(G4LogicalVolumeToDDLo
     RegisterPhysics( new G4HadronElasticPhysics(ver));
 
     // Hadron Physics
-    RegisterPhysics(  new G4HadronPhysicsQGSP_FTFP_BERT(ver));
+    RegisterPhysics( new HadronPhysicsQGSPCMS_FTFP_BERT(ver));
 
     // Stopping Physics
     RegisterPhysics( new G4StoppingPhysics(ver));


### PR DESCRIPTION
Generator class has been reviewed, debug printouts and comments were updated, a small optimisation of the code done. Filtering of HepMC particles is not changed compared to previous version of the code.

Alternative PhysicsList QGSP_FTPF_BERT_EML95msc93 was changed - instead of native Geant4 hadron inelastic builder a CMS custom HadronPhysicsQGSPCMS_FTFP_BERT is used. The latest is copied from Geant4 10.0. This is needed for easier customisation of hadronic physics in the case of any issue will be discovered in future.

These modifications should not affect results.
