### PR TITLE
Tkdetmap threadfix

### DIFF
--- a/CalibTracker/SiStripCommon/interface/TkDetMap.h
+++ b/CalibTracker/SiStripCommon/interface/TkDetMap.h
@@ -75,7 +75,7 @@ class TkLayerMap{
   static const int16_t layerSearch(uint32_t detid);
 
   uint32_t getDetFromBin(int ix, int iy) const;
-  uint32_t* getBinToDet() const {return binToDet;}
+  const uint32_t* getBinToDet() const {return binToDet;}
 
  private:
 
@@ -116,17 +116,17 @@ class TkDetMap{
 
   const TkLayerMap::XYbin& getXY(uint32_t& , uint32_t& cached_detid , int16_t& cached_layer , TkLayerMap::XYbin& cached_XYbin) const;
   std::string getLayerName(int& in) const;
-  int getLayerNum(std::string& in) const;
+  int getLayerNum(const std::string& in) const;
   void getSubDetLayerSide(int& in,SiStripDetId::SubDetector&,uint32_t& layer,uint32_t& side) const;
 
   int16_t FindLayer(uint32_t& detid , uint32_t& cached_detid , int16_t& cached_layer , TkLayerMap::XYbin& cached_XYbin) const;
 
-  void getComponents(int& layer,
+  void getComponents(int layer,
 		     int& nchX,double& lowX,double& highX,
 		     int& nchY,double& lowY,double& highY) const;
  
   uint32_t getDetFromBin(int layer, int ix, int iy) const { return TkMap[layer]->getDetFromBin(ix,iy); }
-  uint32_t getDetFromBin(std::string layerName, int ix, int iy) const {return getDetFromBin(getLayerNum(layerName),ix,iy);}
+  uint32_t getDetFromBin(const std::string& layerName, int ix, int iy) const {return getDetFromBin(getLayerNum(layerName),ix,iy);}
 
   void getDetsForLayer(int layer,std::vector<uint32_t>& output) const;
 

--- a/CalibTracker/SiStripCommon/interface/TkDetMap.h
+++ b/CalibTracker/SiStripCommon/interface/TkDetMap.h
@@ -7,6 +7,7 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/SiStripDetId/interface/SiStripDetId.h"
+#include "DataFormats/SiStripDetId/interface/TIBDetId.h"
 
 class TkLayerMap{
 
@@ -62,26 +63,26 @@ class TkLayerMap{
     delete [] binToDet;
   };
   
-  const XYbin getXY(uint32_t& detid, int layerEnumNb=0);
+  const XYbin getXY(uint32_t detid, int layerEnumNb=0) const;
 
-  int& get_nchX(){return nchX;}
-  int& get_nchY(){return nchY;}
-  double& get_lowX(){return lowX;}
-  double& get_highX(){return highX;}
-  double& get_lowY(){return lowY;}
-  double& get_highY(){return highY;}
+  int get_nchX( ) const {return nchX;}
+  int get_nchY( ) const {return nchY;}
+  double get_lowX( ) const {return lowX;}
+  double get_highX( ) const {return highX;}
+  double get_lowY( ) const {return lowY;}
+  double get_highY( ) const {return highY;}
 
   static const int16_t layerSearch(uint32_t detid);
 
-  uint32_t getDetFromBin(int ix, int iy);
-  uint32_t* getBinToDet(){return binToDet;}
+  uint32_t getDetFromBin(int ix, int iy) const;
+  uint32_t* getBinToDet() const {return binToDet;}
 
  private:
 
-  XYbin getXY_TIB(uint32_t& detid, int layerEnumNb=0);
-  XYbin getXY_TOB(uint32_t& detid, int layerEnumNb=0);
-  XYbin getXY_TID(uint32_t& detid, int layerEnumNb=0);
-  XYbin getXY_TEC(uint32_t& detid, int layerEnumNb=0);
+  XYbin getXY_TIB(uint32_t detid, int layerEnumNb=0) const;
+  XYbin getXY_TOB(uint32_t detid, int layerEnumNb=0) const;
+  XYbin getXY_TID(uint32_t detid, int layerEnumNb=0) const;
+  XYbin getXY_TEC(uint32_t detid, int layerEnumNb=0) const;
 
   void initialize(int layer);
 
@@ -91,8 +92,9 @@ class TkLayerMap{
   void createTEC(std::vector<uint32_t>& TkDetIdList, int layer);
 
  private:
+  uint32_t get_Offset( TIBDetId ) const;
+
   uint32_t* binToDet;
-  XYbin xybin;
 
   int layerEnumNb_; //In the enumerator sequence
   int nchX;
@@ -112,32 +114,32 @@ class TkDetMap{
   TkDetMap(const edm::ParameterSet&,const edm::ActivityRegistry&);
   ~TkDetMap();
 
-  const TkLayerMap::XYbin& getXY(uint32_t& , uint32_t& cached_detid , int16_t& cached_layer);
-  std::string getLayerName(int& in);
-  int getLayerNum(std::string& in);
-  void getSubDetLayerSide(int& in,SiStripDetId::SubDetector&,uint32_t& layer,uint32_t& side);
+  const TkLayerMap::XYbin& getXY(uint32_t& , uint32_t& cached_detid , int16_t& cached_layer , TkLayerMap::XYbin& cached_XYbin) const;
+  std::string getLayerName(int& in) const;
+  int getLayerNum(std::string& in) const;
+  void getSubDetLayerSide(int& in,SiStripDetId::SubDetector&,uint32_t& layer,uint32_t& side) const;
 
-  int16_t FindLayer(uint32_t& detid , uint32_t& cached_detid , int16_t& cached_layer);
+  int16_t FindLayer(uint32_t& detid , uint32_t& cached_detid , int16_t& cached_layer , TkLayerMap::XYbin& cached_XYbin) const;
 
   void getComponents(int& layer,
 		     int& nchX,double& lowX,double& highX,
-		     int& nchY,double& lowY,double& highY);
+		     int& nchY,double& lowY,double& highY) const;
  
-  uint32_t getDetFromBin(int layer, int ix, int iy){ return TkMap[layer]->getDetFromBin(ix,iy); }
-  uint32_t getDetFromBin(std::string layerName, int ix, int iy){return getDetFromBin(getLayerNum(layerName),ix,iy);}
+  uint32_t getDetFromBin(int layer, int ix, int iy) const { return TkMap[layer]->getDetFromBin(ix,iy); }
+  uint32_t getDetFromBin(std::string layerName, int ix, int iy) const {return getDetFromBin(getLayerNum(layerName),ix,iy);}
 
-  void getDetsForLayer(int layer,std::vector<uint32_t>& output);
+  void getDetsForLayer(int layer,std::vector<uint32_t>& output) const;
 
  private:
 
   void doMe();
 
  private:
-  typedef std::vector<TkLayerMap*> detmapType;
+  typedef std::vector<const TkLayerMap*> detmapType;
   detmapType TkMap;
   //uint32_t cached_detid;
   //int16_t cached_layer;
-  TkLayerMap::XYbin cached_XYbin;
+  //TkLayerMap::XYbin cached_XYbin;
 };
 
 

--- a/CalibTracker/SiStripCommon/interface/TkDetMap.h
+++ b/CalibTracker/SiStripCommon/interface/TkDetMap.h
@@ -112,12 +112,12 @@ class TkDetMap{
   TkDetMap(const edm::ParameterSet&,const edm::ActivityRegistry&);
   ~TkDetMap();
 
-  const TkLayerMap::XYbin& getXY(uint32_t&);
+  const TkLayerMap::XYbin& getXY(uint32_t& , uint32_t& cached_detid , int16_t& cached_layer);
   std::string getLayerName(int& in);
   int getLayerNum(std::string& in);
   void getSubDetLayerSide(int& in,SiStripDetId::SubDetector&,uint32_t& layer,uint32_t& side);
 
-  int16_t FindLayer(uint32_t& detid);
+  int16_t FindLayer(uint32_t& detid , uint32_t& cached_detid , int16_t& cached_layer);
 
   void getComponents(int& layer,
 		     int& nchX,double& lowX,double& highX,
@@ -135,8 +135,8 @@ class TkDetMap{
  private:
   typedef std::vector<TkLayerMap*> detmapType;
   detmapType TkMap;
-  uint32_t cached_detid;
-  int16_t cached_layer;
+  //uint32_t cached_detid;
+  //int16_t cached_layer;
   TkLayerMap::XYbin cached_XYbin;
 };
 

--- a/CalibTracker/SiStripCommon/src/TkDetMap.cc
+++ b/CalibTracker/SiStripCommon/src/TkDetMap.cc
@@ -78,7 +78,7 @@ TkLayerMap::TkLayerMap(int in):layerEnumNb_(in){
     }
 }
 
-uint32_t TkLayerMap::getDetFromBin(int ix, int iy){
+uint32_t TkLayerMap::getDetFromBin(int ix, int iy) const {
   
   int val=(ix-1)+nchX*(iy-1);
   if(val>-1 && val < nchX*nchY)
@@ -86,7 +86,7 @@ uint32_t TkLayerMap::getDetFromBin(int ix, int iy){
   return 0;
 }
 
-const int16_t TkLayerMap::layerSearch(uint32_t detid){
+const int16_t TkLayerMap::layerSearch(uint32_t detid) {
   
     //  switch((detid>>25)&0x7){
   if(SiStripDetId(detid).subDetector()==SiStripDetId::TIB){
@@ -104,6 +104,7 @@ const int16_t TkLayerMap::layerSearch(uint32_t detid){
   }
   return 0;
 }
+
 
 void TkLayerMap::initialize(int layer){
 
@@ -123,7 +124,7 @@ void TkLayerMap::initialize(int layer){
     highY=(Nstring_ext+1);
     
     break;
-    case TkLayerMap::TIB_L2:
+  case TkLayerMap::TIB_L2:
     
     Nstring_ext=38;
     SingleExtString.insert(SingleExtString.begin(),10,0);
@@ -443,10 +444,12 @@ void TkLayerMap::createTIB(std::vector<uint32_t>& TkDetIdList,int layerEnumNb){
 
   LogTrace("TkLayerMap") << "[TkLayerMap::createTIB12] layer " << layerEnumNb  << " number of dets " << LayerDetIdList.size() << " lowY " << lowY << " high " << highY << " Nstring " << Nstring_ext;
 
+  XYbin xyb;
+
   for(size_t j=0;j<LayerDetIdList.size();++j){
-    xybin=getXY_TIB(LayerDetIdList[j],layerEnumNb);
-    binToDet[(xybin.ix-1)+nchX*(xybin.iy-1)]=LayerDetIdList[j];
-    LogTrace("TkLayerMap") << "[TkLayerMap::createTIB] " << LayerDetIdList[j]<< " " << xybin.ix << " " << xybin.iy  << " " << xybin.x << " " << xybin.y ;
+    xyb=getXY_TIB(LayerDetIdList[j],layerEnumNb);
+    binToDet[(xyb.ix-1)+nchX*(xyb.iy-1)]=LayerDetIdList[j];
+    LogTrace("TkLayerMap") << "[TkLayerMap::createTIB] " << LayerDetIdList[j]<< " " << xyb.ix << " " << xyb.iy  << " " << xyb.x << " " << xyb.y ;
   }
 }
 
@@ -460,10 +463,12 @@ void TkLayerMap::createTOB(std::vector<uint32_t>& TkDetIdList,int layerEnumNb){
 
   LogTrace("TkLayerMap") << "[TkLayerMap::createTOB] layer " << layerEnumNb-10  << " number of dets " << LayerDetIdList.size() << " lowY " << lowY << " high " << highY << " Nstring " << Nstring_ext;
 
+  XYbin xyb;
+
   for(size_t j=0;j<LayerDetIdList.size();++j){
-    xybin=getXY_TOB(LayerDetIdList[j],layerEnumNb);
-    binToDet[(xybin.ix-1)+nchX*(xybin.iy-1)]=LayerDetIdList[j];
-    LogTrace("TkLayerMap") << "[TkLayerMap::createTOB] " << LayerDetIdList[j]<< " " << xybin.ix << " " << xybin.iy  << " " << xybin.x << " " << xybin.y ;
+    xyb=getXY_TOB(LayerDetIdList[j],layerEnumNb);
+    binToDet[(xyb.ix-1)+nchX*(xyb.iy-1)]=LayerDetIdList[j];
+    LogTrace("TkLayerMap") << "[TkLayerMap::createTOB] " << LayerDetIdList[j]<< " " << xyb.ix << " " << xyb.iy  << " " << xyb.x << " " << xyb.y ;
   }
 }
 
@@ -477,10 +482,12 @@ void TkLayerMap::createTID(std::vector<uint32_t>& TkDetIdList,int layerEnumNb){
 
   LogTrace("TkLayerMap") << "[TkLayerMap::createTID] layer side " << (layerEnumNb-TkLayerMap::TIDM_D1)/3+1 << " nb " << (layerEnumNb-TkLayerMap::TIDM_D1)%3+1  << " number of dets " << LayerDetIdList.size() << " lowY " << lowY << " high " << highY << " Nstring " << Nstring_ext;
   
+  XYbin xyb;
+
   for(size_t j=0;j<LayerDetIdList.size();++j){
-    xybin=getXY_TID(LayerDetIdList[j],layerEnumNb);
-    binToDet[(xybin.ix-1)+nchX*(xybin.iy-1)]=LayerDetIdList[j];
-    LogTrace("TkLayerMap") << "[TkLayerMap::createTID] " << LayerDetIdList[j]<< " " << xybin.ix << " " << xybin.iy  << " " << xybin.x << " " << xybin.y ;
+    xyb=getXY_TID(LayerDetIdList[j],layerEnumNb);
+    binToDet[(xyb.ix-1)+nchX*(xyb.iy-1)]=LayerDetIdList[j];
+    LogTrace("TkLayerMap") << "[TkLayerMap::createTID] " << LayerDetIdList[j]<< " " << xyb.ix << " " << xyb.iy  << " " << xyb.x << " " << xyb.y ;
   }
 }
 
@@ -494,16 +501,18 @@ void TkLayerMap::createTEC(std::vector<uint32_t>& TkDetIdList,int layerEnumNb){
   
   LogTrace("TkLayerMap") << "[TkLayerMap::createTEC] layer side " << (layerEnumNb-TkLayerMap::TECM_W1)/9+1 << " " << (layerEnumNb-TkLayerMap::TECM_W1)%9+1  << " number of dets " << LayerDetIdList.size() << " lowY " << lowY << " high " << highY << " Nstring " << Nstring_ext;
 
+  XYbin xyb;
+
   for(size_t j=0;j<LayerDetIdList.size();++j){
-    xybin=getXY_TEC(LayerDetIdList[j],layerEnumNb);
-    binToDet[(xybin.ix-1)+nchX*(xybin.iy-1)]=LayerDetIdList[j];
-    LogTrace("TkLayerMap") << "[TkLayerMap::createTEC] " << LayerDetIdList[j]<< " " << xybin.ix << " " << xybin.iy  << " " << xybin.x << " " << xybin.y ;
+    xyb=getXY_TEC(LayerDetIdList[j],layerEnumNb);
+    binToDet[(xyb.ix-1)+nchX*(xyb.iy-1)]=LayerDetIdList[j];
+    LogTrace("TkLayerMap") << "[TkLayerMap::createTEC] " << LayerDetIdList[j]<< " " << xyb.ix << " " << xyb.iy  << " " << xyb.x << " " << xyb.y ;
     
   }
 }
 
 
-const TkLayerMap::XYbin TkLayerMap::getXY(uint32_t& detid, int layerEnumNb){
+const TkLayerMap::XYbin TkLayerMap::getXY(uint32_t detid, int layerEnumNb) const {
   LogTrace("TkLayerMap") << "[TkLayerMap::getXY] " << detid << " layer " << layerEnumNb; 
 
   if(!layerEnumNb)
@@ -524,78 +533,92 @@ const TkLayerMap::XYbin TkLayerMap::getXY(uint32_t& detid, int layerEnumNb){
     return getXY_TEC(detid,layerEnumNb); 
 }
 
-TkLayerMap::XYbin TkLayerMap::getXY_TIB(uint32_t& detid, int layerEnumNb){  
+uint32_t TkLayerMap::get_Offset( TIBDetId D ) const {
+  if(D.layerNumber()%2)
+    return D.isInternalString()?2:1;
+  else
+    return D.isInternalString()?1:2;
+}
+
+
+TkLayerMap::XYbin TkLayerMap::getXY_TIB(uint32_t detid, int layerEnumNb) const {  
   if(!layerEnumNb)
     layerEnumNb=layerSearch(detid);
 
   TIBDetId D(detid);
-  if(D.layerNumber()%2){
-    Offset=D.isInternalString()?2:1;
-  }else{
-    Offset=D.isInternalString()?1:2;
-  }
-  xybin.ix=2*(D.isZMinusSide()?-1*D.moduleNumber()+3:D.moduleNumber()+2)+Offset;
-  xybin.iy=D.isInternalString()?D.stringNumber()+SingleExtString[D.stringNumber()]:D.stringNumber();
+
+  XYbin xyb;
+  xyb.ix=2*(D.isZMinusSide()?-1*D.moduleNumber()+3:D.moduleNumber()+2)+get_Offset(D);
+  xyb.iy=D.isInternalString()?D.stringNumber()+SingleExtString[D.stringNumber()]:D.stringNumber();
   if(D.layerNumber()<3 && !D.isStereo())
-    xybin.iy+=Nstring_ext+2;
+    xyb.iy+=Nstring_ext+2;
   
-  xybin.x=lowX+xybin.ix-0.5;
-  xybin.y=lowY+xybin.iy-0.5;
-  return xybin;
+  xyb.x=lowX+xyb.ix-0.5;
+  xyb.y=lowY+xyb.iy-0.5;
+  return xyb;
+
 }
 
-TkLayerMap::XYbin TkLayerMap::getXY_TOB(uint32_t& detid, int layerEnumNb){  
+TkLayerMap::XYbin TkLayerMap::getXY_TOB(uint32_t detid, int layerEnumNb) const {  
   if(!layerEnumNb)
     layerEnumNb=layerSearch(detid);
 
   TOBDetId D(detid);
-  xybin.ix=D.isZMinusSide()?-1*D.moduleNumber()+7:D.moduleNumber()+6;
-  xybin.iy=D.rodNumber();  
-  if(D.layerNumber()<3 && !D.isStereo())
-    xybin.iy+=Nrod+2;
 
-  xybin.x=lowX+xybin.ix-0.5;
-  xybin.y=lowY+xybin.iy-0.5;
-  return xybin;
+  XYbin xyb;
+  xyb.ix=D.isZMinusSide()?-1*D.moduleNumber()+7:D.moduleNumber()+6;
+  xyb.iy=D.rodNumber();  
+  if(D.layerNumber()<3 && !D.isStereo())
+    xyb.iy+=Nrod+2;
+
+  xyb.x=lowX+xyb.ix-0.5;
+  xyb.y=lowY+xyb.iy-0.5;
+  return xyb;
 }
 
-TkLayerMap::XYbin TkLayerMap::getXY_TID(uint32_t& detid, int layerEnumNb){  
+TkLayerMap::XYbin TkLayerMap::getXY_TID(uint32_t detid, int layerEnumNb) const {  
   if(!layerEnumNb)
     layerEnumNb=layerSearch(detid);
 
   TIDDetId D(detid);
-  xybin.ix=D.isZMinusSide()?-3*D.ring()+10:3*D.ring()-2;
-  if(D.isStereo())
-    xybin.ix+=(D.isZMinusSide()?-1:1);
-  xybin.iy= int(2. * D.moduleNumber() - (D.isBackRing()?0.:1.));
 
-  xybin.x=lowX+xybin.ix-0.5;
-  xybin.y=lowY+xybin.iy-0.5;
-  return xybin;
+  XYbin xyb;
+
+  xyb.ix=D.isZMinusSide()?-3*D.ring()+10:3*D.ring()-2;
+  if(D.isStereo())
+    xyb.ix+=(D.isZMinusSide()?-1:1);
+  xyb.iy= int(2. * D.moduleNumber() - (D.isBackRing()?0.:1.));
+
+  xyb.x=lowX+xyb.ix-0.5;
+  xyb.y=lowY+xyb.iy-0.5;
+  return xyb;
 }
 
-TkLayerMap::XYbin TkLayerMap::getXY_TEC(uint32_t& detid, int layerEnumNb){  
+TkLayerMap::XYbin TkLayerMap::getXY_TEC(uint32_t detid, int layerEnumNb) const {  
   if(!layerEnumNb)
     layerEnumNb=layerSearch(detid);
 
   TECDetId D(detid);
-  xybin.ix=D.isZMinusSide()?BinForRing[7]-BinForRing[D.ring()]+1:BinForRing[D.ring()]; //after the introduction of plus and minus histos, the BinForRing should have been changed. on the contrary we hack this part of the code 
+
+  XYbin xyb;
+
+  xyb.ix=D.isZMinusSide()?BinForRing[7]-BinForRing[D.ring()]+1:BinForRing[D.ring()]; //after the introduction of plus and minus histos, the BinForRing should have been changed. on the contrary we hack this part of the code 
   if(D.isStereo())
-    xybin.ix+=(D.isZMinusSide()?-1:1);
+    xyb.ix+=(D.isZMinusSide()?-1:1);
 
   if(D.isZMinusSide()){
-    xybin.iy= (D.petalNumber()-1)*(ModulesInRingFront[D.ring()]+ModulesInRingBack[D.ring()]) + ModulesInRingFront[D.ring()] - D.moduleNumber() +1;
+    xyb.iy= (D.petalNumber()-1)*(ModulesInRingFront[D.ring()]+ModulesInRingBack[D.ring()]) + ModulesInRingFront[D.ring()] - D.moduleNumber() +1;
     if(D.isBackPetal())
-      xybin.iy+=ModulesInRingBack[D.ring()];
+      xyb.iy+=ModulesInRingBack[D.ring()];
   }else{ 
-    xybin.iy= (D.petalNumber()-1)*(ModulesInRingFront[D.ring()]+ModulesInRingBack[D.ring()])+D.moduleNumber();
+    xyb.iy= (D.petalNumber()-1)*(ModulesInRingFront[D.ring()]+ModulesInRingBack[D.ring()])+D.moduleNumber();
     if(D.isBackPetal())
-      xybin.iy+=ModulesInRingFront[D.ring()];
+      xyb.iy+=ModulesInRingFront[D.ring()];
   }
 
-  xybin.x=lowX+xybin.ix-0.5;
-  xybin.y=lowY+xybin.iy-0.5;
-  return xybin;
+  xyb.x=lowX+xyb.ix-0.5;
+  xyb.y=lowY+xyb.iy-0.5;
+  return xyb;
 }
 
 //--------------------------------------
@@ -608,7 +631,7 @@ TkDetMap::TkDetMap(){
   doMe();
 }
 
-void TkDetMap::doMe(){
+void TkDetMap::doMe() {
   LogTrace("TkDetMap") <<"TkDetMap::constructor ";
 
   TkMap.resize(35);
@@ -626,20 +649,19 @@ TkDetMap::~TkDetMap(){
     delete (*iter);  
 }
 
-const TkLayerMap::XYbin& TkDetMap::getXY(uint32_t& detid , uint32_t& cached_detid , int16_t& cached_layer){
-
+const TkLayerMap::XYbin& TkDetMap::getXY(uint32_t& detid , uint32_t& cached_detid , int16_t& cached_layer , TkLayerMap::XYbin& cached_XYbin) const {
   LogTrace("TkDetMap") <<"[getXY] detid "<< detid << " cache " << cached_detid << " layer " << cached_layer << " XY " << cached_XYbin.ix << " " << cached_XYbin.iy  << " " << cached_XYbin.x << " " << cached_XYbin.y ;    
   if(detid==cached_detid)
     return cached_XYbin;
 
   /*FIXME*/
   //if (layer!=INVALID)
-  FindLayer(detid , cached_detid , cached_layer);
+  FindLayer(detid , cached_detid , cached_layer , cached_XYbin );
   LogTrace("TkDetMap") <<"[getXY] detid "<< detid << " cache " << cached_detid << " layer " << cached_layer << " XY " << cached_XYbin.ix << " " << cached_XYbin.iy  << " " << cached_XYbin.x << " " << cached_XYbin.y ;    
   return cached_XYbin;
 }
 
-int16_t TkDetMap::FindLayer(uint32_t& detid , uint32_t& cached_detid , int16_t& cached_layer){ 
+int16_t TkDetMap::FindLayer(uint32_t& detid , uint32_t& cached_detid , int16_t& cached_layer , TkLayerMap::XYbin& cached_XYbin) const { 
 
   if(detid==cached_detid)
     return cached_layer;
@@ -661,7 +683,7 @@ int16_t TkDetMap::FindLayer(uint32_t& detid , uint32_t& cached_detid , int16_t& 
 
 void TkDetMap::getComponents(int& layer,
 			     int& nchX,double& lowX,double& highX,
-			     int& nchY,double& lowY,double& highY){
+			     int& nchY,double& lowY,double& highY) const {
   nchX=TkMap[layer]->get_nchX();
   lowX=TkMap[layer]->get_lowX();
   highX=TkMap[layer]->get_highX();
@@ -670,14 +692,14 @@ void TkDetMap::getComponents(int& layer,
   highY=TkMap[layer]->get_highY();
 }
 
-void TkDetMap::getDetsForLayer(int layer,std::vector<uint32_t>& output){
+void TkDetMap::getDetsForLayer(int layer,std::vector<uint32_t>& output) const {
   output.clear();
   size_t size_=TkMap[layer]->get_nchX()*TkMap[layer]->get_nchY();
   output.resize(size_);
   memcpy((void*)&output[0],(void*)TkMap[layer]->getBinToDet(),size_*sizeof(uint32_t));
 }
 
-std::string TkDetMap::getLayerName(int& in){
+std::string TkDetMap::getLayerName(int& in) const {
   switch (in)
     {
     case TkLayerMap::TIB_L1:
@@ -752,7 +774,7 @@ std::string TkDetMap::getLayerName(int& in){
   return "Invalid";
 }
 
-int TkDetMap::getLayerNum(std::string& in){
+int TkDetMap::getLayerNum(std::string& in) const {
   if(in.compare( "TIB_L1")==0)
     return TkLayerMap::TIB_L1;
   if(in.compare( "TIB_L2")==0)
@@ -824,7 +846,7 @@ int TkDetMap::getLayerNum(std::string& in){
   return 0;
 }
 
-void TkDetMap::getSubDetLayerSide(int& in,SiStripDetId::SubDetector& subDet,uint32_t& layer,uint32_t& side){
+void TkDetMap::getSubDetLayerSide(int& in,SiStripDetId::SubDetector& subDet,uint32_t& layer,uint32_t& side) const {
   switch (in)
     {
     case TkLayerMap::TIB_L1:

--- a/CalibTracker/SiStripCommon/src/TkDetMap.cc
+++ b/CalibTracker/SiStripCommon/src/TkDetMap.cc
@@ -681,7 +681,7 @@ int16_t TkDetMap::FindLayer(uint32_t& detid , uint32_t& cached_detid , int16_t& 
 
 
 
-void TkDetMap::getComponents(int& layer,
+void TkDetMap::getComponents(int layer,
 			     int& nchX,double& lowX,double& highX,
 			     int& nchY,double& lowY,double& highY) const {
   nchX=TkMap[layer]->get_nchX();
@@ -774,7 +774,7 @@ std::string TkDetMap::getLayerName(int& in) const {
   return "Invalid";
 }
 
-int TkDetMap::getLayerNum(std::string& in) const {
+int TkDetMap::getLayerNum(const std::string& in) const {
   if(in.compare( "TIB_L1")==0)
     return TkLayerMap::TIB_L1;
   if(in.compare( "TIB_L2")==0)

--- a/CalibTracker/SiStripCommon/src/TkDetMap.cc
+++ b/CalibTracker/SiStripCommon/src/TkDetMap.cc
@@ -600,15 +600,11 @@ TkLayerMap::XYbin TkLayerMap::getXY_TEC(uint32_t& detid, int layerEnumNb){
 
 //--------------------------------------
 
-TkDetMap::TkDetMap(const edm::ParameterSet& p,const edm::ActivityRegistry& a)
-  :cached_detid(0),
-   cached_layer(TkLayerMap::INVALID){
+TkDetMap::TkDetMap(const edm::ParameterSet& p,const edm::ActivityRegistry& a){
   doMe();
 }
 
-TkDetMap::TkDetMap()
-:cached_detid(0),
- cached_layer(TkLayerMap::INVALID){
+TkDetMap::TkDetMap(){
   doMe();
 }
 
@@ -630,7 +626,7 @@ TkDetMap::~TkDetMap(){
     delete (*iter);  
 }
 
-const TkLayerMap::XYbin& TkDetMap::getXY(uint32_t& detid){
+const TkLayerMap::XYbin& TkDetMap::getXY(uint32_t& detid , uint32_t& cached_detid , int16_t& cached_layer){
 
   LogTrace("TkDetMap") <<"[getXY] detid "<< detid << " cache " << cached_detid << " layer " << cached_layer << " XY " << cached_XYbin.ix << " " << cached_XYbin.iy  << " " << cached_XYbin.x << " " << cached_XYbin.y ;    
   if(detid==cached_detid)
@@ -638,12 +634,12 @@ const TkLayerMap::XYbin& TkDetMap::getXY(uint32_t& detid){
 
   /*FIXME*/
   //if (layer!=INVALID)
-  FindLayer(detid);
+  FindLayer(detid , cached_detid , cached_layer);
   LogTrace("TkDetMap") <<"[getXY] detid "<< detid << " cache " << cached_detid << " layer " << cached_layer << " XY " << cached_XYbin.ix << " " << cached_XYbin.iy  << " " << cached_XYbin.x << " " << cached_XYbin.y ;    
   return cached_XYbin;
 }
 
-int16_t TkDetMap::FindLayer(uint32_t& detid){ 
+int16_t TkDetMap::FindLayer(uint32_t& detid , uint32_t& cached_detid , int16_t& cached_layer){ 
 
   if(detid==cached_detid)
     return cached_layer;

--- a/DQM/SiStripCommon/interface/TkHistoMap.h
+++ b/DQM/SiStripCommon/interface/TkHistoMap.h
@@ -56,6 +56,7 @@ class TkHistoMap{
   TkDetMap* tkdetmap_;
   uint32_t cached_detid;
   int16_t cached_layer;
+  TkLayerMap::XYbin cached_XYbin;
   std::vector<MonitorElement*> tkHistoMap_;
   int HistoNumber;
   std::string MapName_;

--- a/DQM/SiStripCommon/interface/TkHistoMap.h
+++ b/DQM/SiStripCommon/interface/TkHistoMap.h
@@ -54,6 +54,8 @@ class TkHistoMap{
 
   DQMStore* dqmStore_;
   TkDetMap* tkdetmap_;
+  uint32_t cached_detid;
+  int16_t cached_layer;
   std::vector<MonitorElement*> tkHistoMap_;
   int HistoNumber;
   std::string MapName_;

--- a/DQM/SiStripCommon/python/TkHistoMap_cfi.py
+++ b/DQM/SiStripCommon/python/TkHistoMap_cfi.py
@@ -1,4 +1,4 @@
 import FWCore.ParameterSet.Config as cms
 
-#TkDetMap = cms.Service("TkDetMap");
+TkDetMap = cms.Service("TkDetMap");
 SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader");

--- a/DQM/SiStripCommon/src/TkHistoMap.cc
+++ b/DQM/SiStripCommon/src/TkHistoMap.cc
@@ -7,6 +7,7 @@ TkHistoMap::TkHistoMap():
   HistoNumber(35){
   cached_detid=0;
   cached_layer=0;
+  
   LogTrace("TkHistoMap") <<"TkHistoMap::constructor without parameters"; 
   loadServices();
 }
@@ -177,8 +178,8 @@ void TkHistoMap::fillFromAscii(std::string filename){
 }
 
 void TkHistoMap::fill(uint32_t& detid,float value){
-  int16_t layer=tkdetmap_->FindLayer(detid , cached_detid , cached_layer);
-  TkLayerMap::XYbin xybin = tkdetmap_->getXY(detid , cached_detid , cached_layer);
+  int16_t layer=tkdetmap_->FindLayer(detid , cached_detid , cached_layer , cached_XYbin);
+  TkLayerMap::XYbin xybin = tkdetmap_->getXY(detid , cached_detid , cached_layer , cached_XYbin);
 #ifdef debug_TkHistoMap
   LogTrace("TkHistoMap") << "[TkHistoMap::fill] Fill detid " << detid << " Layer " << layer << " value " << value << " ix,iy "  << xybin.ix << " " << xybin.iy  << " " << xybin.x << " " << xybin.y << " " << tkHistoMap_[layer]->getTProfile2D()->GetName();
 #endif
@@ -193,8 +194,8 @@ void TkHistoMap::fill(uint32_t& detid,float value){
 }
 
 void TkHistoMap::setBinContent(uint32_t& detid,float value){
-  int16_t layer=tkdetmap_->FindLayer(detid , cached_detid , cached_layer);
-  TkLayerMap::XYbin xybin = tkdetmap_->getXY(detid , cached_detid , cached_layer);
+  int16_t layer=tkdetmap_->FindLayer(detid , cached_detid , cached_layer , cached_XYbin);
+  TkLayerMap::XYbin xybin = tkdetmap_->getXY(detid , cached_detid , cached_layer , cached_XYbin);
   tkHistoMap_[layer]->getTProfile2D()->SetBinEntries(tkHistoMap_[layer]->getTProfile2D()->GetBin(xybin.ix,xybin.iy),1);
   tkHistoMap_[layer]->getTProfile2D()->SetBinContent(tkHistoMap_[layer]->getTProfile2D()->GetBin(xybin.ix,xybin.iy),value);
 
@@ -213,20 +214,20 @@ void TkHistoMap::add(uint32_t& detid,float value){
 #ifdef debug_TkHistoMap
   LogTrace("TkHistoMap") << "[TkHistoMap::add]";
 #endif
-  int16_t layer=tkdetmap_->FindLayer(detid , cached_detid , cached_layer);
-  TkLayerMap::XYbin xybin = tkdetmap_->getXY(detid , cached_detid , cached_layer);
+  int16_t layer=tkdetmap_->FindLayer(detid , cached_detid , cached_layer , cached_XYbin);
+  TkLayerMap::XYbin xybin = tkdetmap_->getXY(detid , cached_detid , cached_layer , cached_XYbin);
   setBinContent(detid,tkHistoMap_[layer]->getTProfile2D()->GetBinContent(tkHistoMap_[layer]->getTProfile2D()->GetBin(xybin.ix,xybin.iy))+value);
   
 }
 
 float TkHistoMap::getValue(uint32_t& detid){
-  int16_t layer=tkdetmap_->FindLayer(detid , cached_detid , cached_layer);
-  TkLayerMap::XYbin xybin = tkdetmap_->getXY(detid , cached_detid , cached_layer);
+  int16_t layer=tkdetmap_->FindLayer(detid , cached_detid , cached_layer , cached_XYbin);
+  TkLayerMap::XYbin xybin = tkdetmap_->getXY(detid , cached_detid , cached_layer , cached_XYbin);
   return tkHistoMap_[layer]->getTProfile2D()->GetBinContent(tkHistoMap_[layer]->getTProfile2D()->GetBin(xybin.ix,xybin.iy));
 }
 float TkHistoMap::getEntries(uint32_t& detid){
-  int16_t layer=tkdetmap_->FindLayer(detid , cached_detid , cached_layer);
-  TkLayerMap::XYbin xybin = tkdetmap_->getXY(detid , cached_detid , cached_layer);
+  int16_t layer=tkdetmap_->FindLayer(detid , cached_detid , cached_layer , cached_XYbin);
+  TkLayerMap::XYbin xybin = tkdetmap_->getXY(detid , cached_detid , cached_layer , cached_XYbin);
   return tkHistoMap_[layer]->getTProfile2D()->GetBinEntries(tkHistoMap_[layer]->getTProfile2D()->GetBin(xybin.ix,xybin.iy));
 }
 

--- a/DQM/SiStripCommon/src/TkHistoMap.cc
+++ b/DQM/SiStripCommon/src/TkHistoMap.cc
@@ -5,6 +5,8 @@
 
 TkHistoMap::TkHistoMap():
   HistoNumber(35){
+  cached_detid=0;
+  cached_layer=0;
   LogTrace("TkHistoMap") <<"TkHistoMap::constructor without parameters"; 
   loadServices();
 }
@@ -14,6 +16,8 @@ TkHistoMap::TkHistoMap(std::string path, std::string MapName,float baseline, boo
   HistoNumber(35),
   MapName_(MapName)
 {
+  cached_detid=0;
+  cached_layer=0;
   LogTrace("TkHistoMap") <<"TkHistoMap::constructor with parameters"; 
   loadServices();
   createTkHistoMap(path,MapName_, baseline, mechanicalView);
@@ -23,6 +27,8 @@ TkHistoMap::TkHistoMap(DQMStore::IBooker & ibooker , std::string path, std::stri
   HistoNumber(35),
   MapName_(MapName)
 {
+  cached_detid=0;
+  cached_layer=0;
   LogTrace("TkHistoMap") <<"TkHistoMap::constructor with parameters"; 
   loadServices();
   createTkHistoMap(ibooker , path,MapName_, baseline, mechanicalView);
@@ -171,8 +177,8 @@ void TkHistoMap::fillFromAscii(std::string filename){
 }
 
 void TkHistoMap::fill(uint32_t& detid,float value){
-  int16_t layer=tkdetmap_->FindLayer(detid);
-  TkLayerMap::XYbin xybin = tkdetmap_->getXY(detid);
+  int16_t layer=tkdetmap_->FindLayer(detid , cached_detid , cached_layer);
+  TkLayerMap::XYbin xybin = tkdetmap_->getXY(detid , cached_detid , cached_layer);
 #ifdef debug_TkHistoMap
   LogTrace("TkHistoMap") << "[TkHistoMap::fill] Fill detid " << detid << " Layer " << layer << " value " << value << " ix,iy "  << xybin.ix << " " << xybin.iy  << " " << xybin.x << " " << xybin.y << " " << tkHistoMap_[layer]->getTProfile2D()->GetName();
 #endif
@@ -187,8 +193,8 @@ void TkHistoMap::fill(uint32_t& detid,float value){
 }
 
 void TkHistoMap::setBinContent(uint32_t& detid,float value){
-  int16_t layer=tkdetmap_->FindLayer(detid);
-  TkLayerMap::XYbin xybin = tkdetmap_->getXY(detid);
+  int16_t layer=tkdetmap_->FindLayer(detid , cached_detid , cached_layer);
+  TkLayerMap::XYbin xybin = tkdetmap_->getXY(detid , cached_detid , cached_layer);
   tkHistoMap_[layer]->getTProfile2D()->SetBinEntries(tkHistoMap_[layer]->getTProfile2D()->GetBin(xybin.ix,xybin.iy),1);
   tkHistoMap_[layer]->getTProfile2D()->SetBinContent(tkHistoMap_[layer]->getTProfile2D()->GetBin(xybin.ix,xybin.iy),value);
 
@@ -207,20 +213,20 @@ void TkHistoMap::add(uint32_t& detid,float value){
 #ifdef debug_TkHistoMap
   LogTrace("TkHistoMap") << "[TkHistoMap::add]";
 #endif
-  int16_t layer=tkdetmap_->FindLayer(detid);
-  TkLayerMap::XYbin xybin = tkdetmap_->getXY(detid);
+  int16_t layer=tkdetmap_->FindLayer(detid , cached_detid , cached_layer);
+  TkLayerMap::XYbin xybin = tkdetmap_->getXY(detid , cached_detid , cached_layer);
   setBinContent(detid,tkHistoMap_[layer]->getTProfile2D()->GetBinContent(tkHistoMap_[layer]->getTProfile2D()->GetBin(xybin.ix,xybin.iy))+value);
   
 }
 
 float TkHistoMap::getValue(uint32_t& detid){
-  int16_t layer=tkdetmap_->FindLayer(detid);
-  TkLayerMap::XYbin xybin = tkdetmap_->getXY(detid);
+  int16_t layer=tkdetmap_->FindLayer(detid , cached_detid , cached_layer);
+  TkLayerMap::XYbin xybin = tkdetmap_->getXY(detid , cached_detid , cached_layer);
   return tkHistoMap_[layer]->getTProfile2D()->GetBinContent(tkHistoMap_[layer]->getTProfile2D()->GetBin(xybin.ix,xybin.iy));
 }
 float TkHistoMap::getEntries(uint32_t& detid){
-  int16_t layer=tkdetmap_->FindLayer(detid);
-  TkLayerMap::XYbin xybin = tkdetmap_->getXY(detid);
+  int16_t layer=tkdetmap_->FindLayer(detid , cached_detid , cached_layer);
+  TkLayerMap::XYbin xybin = tkdetmap_->getXY(detid , cached_detid , cached_layer);
   return tkHistoMap_[layer]->getTProfile2D()->GetBinEntries(tkHistoMap_[layer]->getTProfile2D()->GetBin(xybin.ix,xybin.iy));
 }
 

--- a/DQM/SiStripMonitorClient/interface/SiStripTrackerMapCreator.h
+++ b/DQM/SiStripMonitorClient/interface/SiStripTrackerMapCreator.h
@@ -6,6 +6,7 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "CalibFormats/SiStripObjects/interface/SiStripDetCabling.h"
 //#include "CalibTracker/SiStripDCS/interface/SiStripPsuDetIdMap.h"
+#include "CalibTracker/SiStripCommon/interface/TkDetMap.h"
 
 #include <fstream>
 #include <map>
@@ -62,5 +63,6 @@ class SiStripTrackerMapCreator {
   //  SiStripPsuDetIdMap psumap_;
   uint32_t cached_detid;
   int16_t cached_layer;
+  TkLayerMap::XYbin cached_XYbin;
 };
 #endif

--- a/DQM/SiStripMonitorClient/interface/SiStripTrackerMapCreator.h
+++ b/DQM/SiStripMonitorClient/interface/SiStripTrackerMapCreator.h
@@ -60,5 +60,7 @@ class SiStripTrackerMapCreator {
   const edm::EventSetup& eSetup_;
   edm::ESHandle< SiStripDetCabling > detcabling_;
   //  SiStripPsuDetIdMap psumap_;
+  uint32_t cached_detid;
+  int16_t cached_layer;
 };
 #endif

--- a/DQM/SiStripMonitorClient/python/SiStripClientConfigP5_Cosmic_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripClientConfigP5_Cosmic_cff.py
@@ -63,5 +63,5 @@ TrackEffClient.FolderName = 'Tracking/TrackParameters/TrackEfficiency'
 TrackEffClient.AlgoName   = 'CKFTk'
 
 # Services needed for TkHistoMap
-#TkDetMap = cms.Service("TkDetMap")
+TkDetMap = cms.Service("TkDetMap")
 

--- a/DQM/SiStripMonitorClient/python/SiStripClientConfigP5_HeavyIons_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripClientConfigP5_HeavyIons_cff.py
@@ -63,5 +63,5 @@ TrackEffClient.FolderName = 'Tracking/TrackParameters/TrackEfficiency'
 TrackEffClient.AlgoName   = 'CKFTk'
 
 # Services needed for TkHistoMap
-#TkDetMap = cms.Service("TkDetMap")
+TkDetMap = cms.Service("TkDetMap")
 

--- a/DQM/SiStripMonitorClient/python/SiStripClientConfigP5_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripClientConfigP5_cff.py
@@ -63,5 +63,5 @@ TrackEffClient.FolderName = 'Tracking/TrackParameters/TrackEfficiency'
 TrackEffClient.AlgoName   = 'CKFTk'
 
 # Services needed for TkHistoMap
-#TkDetMap = cms.Service("TkDetMap")
+TkDetMap = cms.Service("TkDetMap")
 

--- a/DQM/SiStripMonitorClient/python/SiStripClientConfig_Tier0_Cosmic_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripClientConfig_Tier0_Cosmic_cff.py
@@ -41,11 +41,11 @@ TrackEffClient.FolderName = 'Tracking/TrackParameters/TrackEfficiency'
 TrackEffClient.AlgoName   = 'CKFTk'
 
 # Sequence
+SiStripCosmicDQMClient = cms.Sequence(siStripQTester*siStripOfflineAnalyser*TrackEffClient)
 #removed modules using TkDetMap
-#SiStripCosmicDQMClient = cms.Sequence(siStripQTester*siStripOfflineAnalyser*TrackEffClient)
-SiStripCosmicDQMClient = cms.Sequence(siStripQTester*TrackEffClient)
+#SiStripCosmicDQMClient = cms.Sequence(siStripQTester*TrackEffClient)
 
 
 # Services needed for TkHistoMap
-#TkDetMap = cms.Service("TkDetMap")
+TkDetMap = cms.Service("TkDetMap")
 SiStripDetInfoFileReade = cms.Service("SiStripDetInfoFileReader")

--- a/DQM/SiStripMonitorClient/python/SiStripClientConfig_Tier0_HeavyIons_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripClientConfig_Tier0_HeavyIons_cff.py
@@ -34,9 +34,9 @@ siStripQTesterHI = cms.EDAnalyzer("QualityTester",
 
 # define new HI sequence
 #removed modules using TkDetMap
-#SiStripOfflineDQMClientHI = cms.Sequence(siStripQTesterHI*siStripOfflineAnalyser)
-SiStripOfflineDQMClientHI = cms.Sequence(siStripQTesterHI)
+#SiStripOfflineDQMClientHI = cms.Sequence(siStripQTesterHI)
+SiStripOfflineDQMClientHI = cms.Sequence(siStripQTesterHI*siStripOfflineAnalyser)
 
 # Services needed for TkHistoMap
-#TkDetMap = cms.Service("TkDetMap")
+TkDetMap = cms.Service("TkDetMap")
 SiStripDetInfoFileReade = cms.Service("SiStripDetInfoFileReader")

--- a/DQM/SiStripMonitorClient/python/SiStripClientConfig_Tier0_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripClientConfig_Tier0_cff.py
@@ -39,11 +39,11 @@ siStripQTester = cms.EDAnalyzer("QualityTester",
 
 
 # Sequence
+SiStripOfflineDQMClient = cms.Sequence(siStripQTester*siStripOfflineAnalyser)
 #removed modules using TkDetMap
-#SiStripOfflineDQMClient = cms.Sequence(siStripQTester*siStripOfflineAnalyser)
-SiStripOfflineDQMClient = cms.Sequence(siStripQTester)
+#SiStripOfflineDQMClient = cms.Sequence(siStripQTester)
 
 
 # Services needed for TkHistoMap
-#TkDetMap = cms.Service("TkDetMap")
+TkDetMap = cms.Service("TkDetMap")
 SiStripDetInfoFileReade = cms.Service("SiStripDetInfoFileReader")

--- a/DQM/SiStripMonitorClient/python/SiStripClientConfig_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripClientConfig_cff.py
@@ -82,5 +82,5 @@ SiStripOnlineDQMClient = cms.Sequence(onlineAnalyser)
 SiStripOfflineDQMClient = cms.Sequence(offlineAnalyser)
 
 # Services needed for TkHistoMap
-#TkDetMap = cms.Service("TkDetMap")
+TkDetMap = cms.Service("TkDetMap")
 

--- a/DQM/SiStripMonitorClient/python/SiStripSourceConfigP5_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripSourceConfigP5_cff.py
@@ -205,5 +205,5 @@ TrackEffMon_hi.AlgoName                            = 'HeavyIonTk'
 TrackEffMon_hi.FolderName                          = 'Tracking/TrackParameters/TrackEfficiency'
 
 # Services needed for TkHistoMap
-#TkDetMap = cms.Service("TkDetMap")
+TkDetMap = cms.Service("TkDetMap")
 SiStripDetInfoFileReade = cms.Service("SiStripDetInfoFileReader")

--- a/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_Cosmic_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_Cosmic_cff.py
@@ -170,7 +170,7 @@ dqmInfoSiStrip = cms.EDAnalyzer("DQMEventInfo",
 )
 
 # Services needed for TkHistoMap
-#TkDetMap = cms.Service("TkDetMap")
+TkDetMap = cms.Service("TkDetMap")
 SiStripDetInfoFileReade = cms.Service("SiStripDetInfoFileReader")
 
 # Event History Producer
@@ -183,11 +183,11 @@ from DPGAnalysis.SiStripTools.apvcyclephaseproducerfroml1tsDB_cfi import *
 SiStripDQMTier0_cosmicTk = cms.Sequence(APVPhases*consecutiveHEs*SiStripMonitorTrack_cosmicTk*MonitorTrackResiduals_cosmicTk*TrackMon_cosmicTk*TrackEffMon_cosmicTk)
 
 #removed modules using TkDetMap
-#SiStripDQMTier0_ckf = cms.Sequence(APVPhases*consecutiveHEs*SiStripMonitorTrack_ckf*MonitorTrackResiduals_ckf*TrackMon_ckf*TrackEffMon_ckf)
-SiStripDQMTier0_ckf = cms.Sequence(APVPhases*consecutiveHEs*MonitorTrackResiduals_ckf*TrackMon_ckf*TrackEffMon_ckf)
+#SiStripDQMTier0_ckf = cms.Sequence(APVPhases*consecutiveHEs*MonitorTrackResiduals_ckf*TrackMon_ckf*TrackEffMon_ckf)
+SiStripDQMTier0_ckf = cms.Sequence(APVPhases*consecutiveHEs*SiStripMonitorTrack_ckf*MonitorTrackResiduals_ckf*TrackMon_ckf*TrackEffMon_ckf)
 
 #SiStripDQMTier0_rs = cms.Sequence(APVPhases*consecutiveHEs*SiStripMonitorTrack_rs*MonitorTrackResiduals_rs*TrackMon_rs*TrackEffMon_rs)
 
 #removed modules using TkDetMap
-#SiStripDQMTier0 = cms.Sequence(APVPhases*consecutiveHEs*siStripFEDCheck*siStripFEDMonitor*SiStripMonitorDigi*SiStripMonitorCluster*SiStripMonitorTrack_ckf*MonitorTrackResiduals_ckf*TrackMon_cosmicTk*TrackMon_ckf*TrackEffMon_ckf*TrackSplitMonitor*dqmInfoSiStrip)
-SiStripDQMTier0 = cms.Sequence(APVPhases*consecutiveHEs*siStripFEDCheck*MonitorTrackResiduals_ckf*TrackMon_cosmicTk*TrackMon_ckf*TrackEffMon_ckf*TrackSplitMonitor*dqmInfoSiStrip)
+#SiStripDQMTier0 = cms.Sequence(APVPhases*consecutiveHEs*siStripFEDCheck*MonitorTrackResiduals_ckf*TrackMon_cosmicTk*TrackMon_ckf*TrackEffMon_ckf*TrackSplitMonitor*dqmInfoSiStrip)
+SiStripDQMTier0 = cms.Sequence(APVPhases*consecutiveHEs*siStripFEDCheck*siStripFEDMonitor*SiStripMonitorDigi*SiStripMonitorCluster*SiStripMonitorTrack_ckf*MonitorTrackResiduals_ckf*TrackMon_cosmicTk*TrackMon_ckf*TrackEffMon_ckf*TrackSplitMonitor*dqmInfoSiStrip)

--- a/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_HeavyIons_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_HeavyIons_cff.py
@@ -24,13 +24,13 @@ TrackMon_hi.FolderName          = 'Tracking/TrackParameters'
 TrackMon_hi.BSFolderName        = 'Tracking/TrackParameters/BeamSpotParameters'
 
 #removed all modules using TkDetMap service
-#SiStripDQMTier0_hi = cms.Sequence(APVPhases * consecutiveHEs *
-#                                  siStripFEDCheck * siStripFEDMonitor *
-#                                  SiStripMonitorDigi * SiStripMonitorCluster *
-#                                  SiStripMonitorTrack_hi *
+#SiStripDQMTier0_hi = cms.Sequence(APVPhases * consecutiveHEs * 
+#                                  siStripFEDCheck * 
 #                                  MonitorTrackResiduals_hi *
 #                                  TrackMon_hi)
 SiStripDQMTier0_hi = cms.Sequence(APVPhases * consecutiveHEs *
-                                  siStripFEDCheck * 
+                                  siStripFEDCheck * siStripFEDMonitor *
+                                  SiStripMonitorDigi * SiStripMonitorCluster *
+                                  SiStripMonitorTrack_hi *
                                   MonitorTrackResiduals_hi *
                                   TrackMon_hi)

--- a/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_cff.py
@@ -109,7 +109,7 @@ dqmInfoSiStrip = cms.EDAnalyzer("DQMEventInfo",
 )
 
 # Services needed for TkHistoMap
-#TkDetMap = cms.Service("TkDetMap")
+TkDetMap = cms.Service("TkDetMap")
 SiStripDetInfoFileReade = cms.Service("SiStripDetInfoFileReader")
 
 # Event History Producer
@@ -124,31 +124,33 @@ from RecoLuminosity.LumiProducer.lumiProducer_cff import *
 # Sequence
 #removed modules using TkDetMap service
 #SiStripDQMTier0 = cms.Sequence(
-#    APVPhases*consecutiveHEs*siStripFEDCheck*siStripFEDMonitor*SiStripMonitorDigi*SiStripMonitorClusterBPTX
-#    *SiStripMonitorTrackCommon*MonitorTrackResiduals
+#    APVPhases*consecutiveHEs*siStripFEDCheck
+#    *MonitorTrackResiduals
 #    *dqmInfoSiStrip)
 
 #SiStripDQMTier0Common = cms.Sequence(
-#    APVPhases*consecutiveHEs*siStripFEDCheck*siStripFEDMonitor*SiStripMonitorDigi*SiStripMonitorClusterBPTX        
-#    *SiStripMonitorTrackCommon
+#    APVPhases*consecutiveHEs*siStripFEDCheck
 #    *dqmInfoSiStrip)
 
 #SiStripDQMTier0MinBias = cms.Sequence(
-#    APVPhases*consecutiveHEs*siStripFEDCheck*siStripFEDMonitor*SiStripMonitorDigi*SiStripMonitorClusterBPTX
+#    APVPhases*consecutiveHEs*siStripFEDCheck
 #    *SiStripMonitorTrackMB*MonitorTrackResiduals
 #    *dqmInfoSiStrip)
 
 SiStripDQMTier0 = cms.Sequence(
-    APVPhases*consecutiveHEs*siStripFEDCheck
-    *MonitorTrackResiduals
+    APVPhases*consecutiveHEs*siStripFEDCheck*siStripFEDMonitor*SiStripMonitorDigi*SiStripMonitorClusterBPTX
+    *SiStripMonitorTrackCommon*MonitorTrackResiduals
     *dqmInfoSiStrip)
 
 SiStripDQMTier0Common = cms.Sequence(
-    APVPhases*consecutiveHEs*siStripFEDCheck
+    APVPhases*consecutiveHEs*siStripFEDCheck*siStripFEDMonitor*SiStripMonitorDigi*SiStripMonitorClusterBPTX        
+    *SiStripMonitorTrackCommon
     *dqmInfoSiStrip)
 
 SiStripDQMTier0MinBias = cms.Sequence(
-    APVPhases*consecutiveHEs*siStripFEDCheck
+    APVPhases*consecutiveHEs*siStripFEDCheck*siStripFEDMonitor*SiStripMonitorDigi*SiStripMonitorClusterBPTX
     *SiStripMonitorTrackMB*MonitorTrackResiduals
     *dqmInfoSiStrip)
+
+
 

--- a/DQM/SiStripMonitorClient/python/SiStripSourceConfig_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripSourceConfig_cff.py
@@ -85,12 +85,12 @@ TrackMonColl.AlgoName = 'CKFTk'
 TrackMonColl.doSeedParameterHistos = True
 # Sequences
 #removed modules using TkDetMap service
-#SiStripSourcesSimData = cms.Sequence(SiStripMonitorDigi*SiStripMonitorCluster*SiStripMonitorTrackSim*MonitorTrackResidualsSim*TrackMonSim)
-#SiStripSourcesRealData = cms.Sequence(SiStripMonitorDigi*SiStripMonitorCluster*SiStripMonitorTrackReal*MonitorTrackResidualsReal*TrackMonReal)
-#SiStripSourcesRealDataCollision = cms.Sequence(SiStripMonitorDigi*SiStripMonitorCluster*SiStripMonitorTrackColl*MonitorTrackResidualsColl*TrackMonColl)
-SiStripSourcesSimData = cms.Sequence(SiStripMonitorTrackSim*MonitorTrackResidualsSim*TrackMonSim)
-SiStripSourcesRealData = cms.Sequence(SiStripMonitorTrackReal*MonitorTrackResidualsReal*TrackMonReal)
-SiStripSourcesRealDataCollision = cms.Sequence(SiStripMonitorTrackColl*MonitorTrackResidualsColl*TrackMonColl)
+#SiStripSourcesSimData = cms.Sequence(SiStripMonitorTrackSim*MonitorTrackResidualsSim*TrackMonSim)
+#SiStripSourcesRealData = cms.Sequence(SiStripMonitorTrackReal*MonitorTrackResidualsReal*TrackMonReal)
+#SiStripSourcesRealDataCollision = cms.Sequence(SiStripMonitorTrackColl*MonitorTrackResidualsColl*TrackMonColl)
+SiStripSourcesSimData = cms.Sequence(SiStripMonitorDigi*SiStripMonitorCluster*SiStripMonitorTrackSim*MonitorTrackResidualsSim*TrackMonSim)
+SiStripSourcesRealData = cms.Sequence(SiStripMonitorDigi*SiStripMonitorCluster*SiStripMonitorTrackReal*MonitorTrackResidualsReal*TrackMonReal)
+SiStripSourcesRealDataCollision = cms.Sequence(SiStripMonitorDigi*SiStripMonitorCluster*SiStripMonitorTrackColl*MonitorTrackResidualsColl*TrackMonColl)
 
 
 

--- a/DQM/SiStripMonitorClient/src/SiStripTrackerMapCreator.cc
+++ b/DQM/SiStripMonitorClient/src/SiStripTrackerMapCreator.cc
@@ -399,7 +399,7 @@ void SiStripTrackerMapCreator::paintTkMapFromHistogram(DQMStore* dqm_store, Moni
     uint32_t det_id= (*idet);
     if (det_id <= 0) continue;
     nDet++;
-    const TkLayerMap::XYbin& xyval = tkDetMap_->getXY(det_id , cached_detid , cached_layer);
+    const TkLayerMap::XYbin& xyval = tkDetMap_->getXY(det_id , cached_detid , cached_layer , cached_XYbin);
     float fval = 0.0;
     if ( (name.find("NumberOfOfffTrackCluster") != std::string::npos) || 
          (name.find("NumberOfOnTrackCluster") != std::string::npos) ) {

--- a/DQM/SiStripMonitorClient/src/SiStripTrackerMapCreator.cc
+++ b/DQM/SiStripMonitorClient/src/SiStripTrackerMapCreator.cc
@@ -38,6 +38,8 @@ SiStripTrackerMapCreator::SiStripTrackerMapCreator() {
 SiStripTrackerMapCreator::SiStripTrackerMapCreator(const edm::EventSetup& eSetup): meanToMaxFactor_(2.5),eSetup_(eSetup)
 						  //, psumap_() 
 {
+  cached_detid=0;
+  cached_layer=0;
   trackerMap_ = 0;
   stripTopLevelDir_="";
   eSetup_.get<SiStripDetCablingRcd>().get(detcabling_);
@@ -397,7 +399,7 @@ void SiStripTrackerMapCreator::paintTkMapFromHistogram(DQMStore* dqm_store, Moni
     uint32_t det_id= (*idet);
     if (det_id <= 0) continue;
     nDet++;
-    const TkLayerMap::XYbin& xyval = tkDetMap_->getXY(det_id);
+    const TkLayerMap::XYbin& xyval = tkDetMap_->getXY(det_id , cached_detid , cached_layer);
     float fval = 0.0;
     if ( (name.find("NumberOfOfffTrackCluster") != std::string::npos) || 
          (name.find("NumberOfOnTrackCluster") != std::string::npos) ) {

--- a/DQM/SiStripMonitorTrack/interface/SiStripMonitorMuonHLT.h
+++ b/DQM/SiStripMonitorTrack/interface/SiStripMonitorMuonHLT.h
@@ -144,6 +144,7 @@ class SiStripMonitorMuonHLT : public thread_unsafe::DQMEDAnalyzer {
       TkDetMap* tkdetmap_;
       uint32_t cached_detid;
       int16_t cached_layer;
+      TkLayerMap::XYbin cached_XYbin;
       std::map<std::string, LayerMEs> LayerMEMap;
       //2D info from TkHistoMap 
       TkHistoMap* tkmapAllClusters;

--- a/DQM/SiStripMonitorTrack/interface/SiStripMonitorMuonHLT.h
+++ b/DQM/SiStripMonitorTrack/interface/SiStripMonitorMuonHLT.h
@@ -115,7 +115,6 @@ class SiStripMonitorMuonHLT : public thread_unsafe::DQMEDAnalyzer {
 
       edm::ParameterSet parameters_;
 
-      DQMStore* dbe_;   
       std::string monitorName_;
       std::string outputFile_;
       int counterEvt_;      ///counter
@@ -143,6 +142,8 @@ class SiStripMonitorMuonHLT : public thread_unsafe::DQMEDAnalyzer {
 
       int HistoNumber; //nof layers in Tracker = 34 
       TkDetMap* tkdetmap_;
+      uint32_t cached_detid;
+      int16_t cached_layer;
       std::map<std::string, LayerMEs> LayerMEMap;
       //2D info from TkHistoMap 
       TkHistoMap* tkmapAllClusters;

--- a/DQM/SiStripMonitorTrack/src/SiStripMonitorMuonHLT.cc
+++ b/DQM/SiStripMonitorTrack/src/SiStripMonitorMuonHLT.cc
@@ -25,7 +25,6 @@ SiStripMonitorMuonHLT::SiStripMonitorMuonHLT (const edm::ParameterSet & iConfig)
 {
   cached_detid=0;
   cached_layer=0;
-
   //now do what ever initialization is needed
   parameters_ = iConfig;
   verbose_ = parameters_.getUntrackedParameter<bool>("verbose",false);
@@ -152,7 +151,7 @@ SiStripMonitorMuonHLT::analyze (const edm::Event & iEvent, const edm::EventSetup
 	  
 	  uint detID = 0; // zero since long time clust->geographicalId ();
 	  std::stringstream ss;
-	  int layer = tkdetmap_->FindLayer (detID , cached_detid , cached_layer);
+	  int layer = tkdetmap_->FindLayer (detID , cached_detid , cached_layer , cached_XYbin);
 	  std::string label = tkdetmap_->getLayerName (layer);
 	  const StripGeomDetUnit *theGeomDet = dynamic_cast < const StripGeomDetUnit * >(theTracker.idToDet (detID));
 	  const StripTopology *topol = dynamic_cast < const StripTopology * >(&(theGeomDet->specificTopology ()));
@@ -212,7 +211,7 @@ void SiStripMonitorMuonHLT::analyzeOnTrackClusters( const reco::Track* l3tk, con
 		  // if SiStripRecHit1D
 		  if (hit1D != 0)
 		    {
-		      int layer = tkdetmap_->FindLayer (detID , cached_detid , cached_layer);
+		      int layer = tkdetmap_->FindLayer (detID , cached_detid , cached_layer , cached_XYbin);
 		      std::string label = tkdetmap_->getLayerName (layer);
 		      const StripGeomDetUnit *theGeomDet = dynamic_cast < const StripGeomDetUnit * >(theTracker.idToDet (detID));
 		      if (theGeomDet != 0)
@@ -248,7 +247,7 @@ void SiStripMonitorMuonHLT::analyzeOnTrackClusters( const reco::Track* l3tk, con
 		  // if SiStripRecHit2D
 		  if (hit2D != 0)
 		    {
-		      int layer = tkdetmap_->FindLayer (detID , cached_detid , cached_layer);
+		      int layer = tkdetmap_->FindLayer (detID , cached_detid , cached_layer , cached_XYbin);
 		      std::string label = tkdetmap_->getLayerName (layer);
 		      const StripGeomDetUnit *theGeomDet = dynamic_cast < const StripGeomDetUnit * >(theTracker.idToDet (detID));
 		      if (theGeomDet != 0)
@@ -287,7 +286,7 @@ void SiStripMonitorMuonHLT::analyzeOnTrackClusters( const reco::Track* l3tk, con
 		    {
 		      //hit mono
 	              detID = hitMatched2D->monoId();
-		      int layer = tkdetmap_->FindLayer (detID , cached_detid , cached_layer);
+		      int layer = tkdetmap_->FindLayer (detID , cached_detid , cached_layer , cached_XYbin);
 		      std::string label = tkdetmap_->getLayerName (layer);
 		      const StripGeomDetUnit *theGeomDet = dynamic_cast < const StripGeomDetUnit * >(theTracker.idToDet (detID));
 		      if (theGeomDet != 0)
@@ -322,7 +321,7 @@ void SiStripMonitorMuonHLT::analyzeOnTrackClusters( const reco::Track* l3tk, con
 
 		      //hit stereo
 	              detID = hitMatched2D->stereoId ();
-		      layer = tkdetmap_->FindLayer (detID , cached_detid , cached_layer);
+		      layer = tkdetmap_->FindLayer (detID , cached_detid , cached_layer , cached_XYbin);
 		      label = tkdetmap_->getLayerName (layer);
 		      const StripGeomDetUnit *theGeomDet2 = dynamic_cast < const StripGeomDetUnit * >(theTracker.idToDet (detID));
 		      if (theGeomDet2 != 0)
@@ -361,7 +360,7 @@ void SiStripMonitorMuonHLT::analyzeOnTrackClusters( const reco::Track* l3tk, con
 		  if (hitProj2D != 0)
 		    {
 	              detID = hitProj2D->geographicalId ();
-		      int layer = tkdetmap_->FindLayer (detID , cached_detid , cached_layer);
+		      int layer = tkdetmap_->FindLayer (detID , cached_detid , cached_layer , cached_XYbin);
 		      std::string label = tkdetmap_->getLayerName (layer);
 		      const StripGeomDetUnit *theGeomDet = dynamic_cast < const StripGeomDetUnit * >(theTracker.idToDet (detID));
 		      if (theGeomDet != 0)
@@ -640,7 +639,7 @@ SiStripMonitorMuonHLT::GeometryFromTrackGeom (const std::vector<DetId>& Dets,con
       GlobalPoint clustgp = theGeomDet->surface ().toGlobal (clustlp);
 
       // Get the eta, phi of modules
-      mylayer = tkdetmap_->FindLayer (detid , cached_detid , cached_layer);
+      mylayer = tkdetmap_->FindLayer (detid , cached_detid , cached_layer , cached_XYbin);
       mylabelHisto = tkdetmap_->getLayerName (mylayer);
 
       //      SiStripDetId stripdet = SiStripDetId(detid);
@@ -821,7 +820,7 @@ SiStripMonitorMuonHLT::Normalizer (const std::vector<DetId>& Dets,const TrackerG
       //      const StripTopology *topol = dynamic_cast < const StripTopology * >(&(theGeomDet->specificTopology ()));
 
       // Get the eta, phi of modules
-      mylayer = tkdetmap_->FindLayer (detid , cached_detid , cached_layer);
+      mylayer = tkdetmap_->FindLayer (detid , cached_detid , cached_layer , cached_XYbin);
       mylabelHisto = tkdetmap_->getLayerName (mylayer);
 
       //      SiStripDetId stripdet = SiStripDetId(detid);

--- a/DQM/SiStripMonitorTrack/src/SiStripMonitorMuonHLT.cc
+++ b/DQM/SiStripMonitorTrack/src/SiStripMonitorMuonHLT.cc
@@ -23,6 +23,9 @@
 //
 SiStripMonitorMuonHLT::SiStripMonitorMuonHLT (const edm::ParameterSet & iConfig)
 {
+  cached_detid=0;
+  cached_layer=0;
+
   //now do what ever initialization is needed
   parameters_ = iConfig;
   verbose_ = parameters_.getUntrackedParameter<bool>("verbose",false);
@@ -49,16 +52,6 @@ SiStripMonitorMuonHLT::SiStripMonitorMuonHLT (const edm::ParameterSet & iConfig)
   HistoNumber = 35;
 
   //services
-  dbe_ = 0;
-  if (!edm::Service < DQMStore > ().isAvailable ())
-    {
-      edm::LogError ("TkHistoMap") <<
-	"\n------------------------------------------"
-	"\nUnAvailable Service DQMStore: please insert in the configuration file an instance like" "\n\tprocess.load(\"DQMServices.Core.DQMStore_cfg\")" "\n------------------------------------------";
-    }
-  dbe_ = edm::Service < DQMStore > ().operator-> ();
-  dbe_->setVerbose (0);
-
   tkdetmap_ = 0;
   if (!edm::Service < TkDetMap > ().isAvailable ())
     {
@@ -75,7 +68,6 @@ SiStripMonitorMuonHLT::SiStripMonitorMuonHLT (const edm::ParameterSet & iConfig)
 
   bool disable = parameters_.getUntrackedParameter < bool > ("disableROOToutput",false);
   if (disable) outputFile_ = "";
-  if (dbe_ != NULL) dbe_->setCurrentFolder (monitorName_);
 
 }
 
@@ -119,8 +111,6 @@ float SiStripMonitorMuonHLT::GetPhiWeight(std::string label, GlobalPoint clustgp
 void
 SiStripMonitorMuonHLT::analyze (const edm::Event & iEvent, const edm::EventSetup & iSetup)
 {
-  if (!dbe_)
-    return;
   counterEvt_++;
   if (prescaleEvt_ > 0 && counterEvt_ % prescaleEvt_ != 0)
     return;
@@ -162,7 +152,7 @@ SiStripMonitorMuonHLT::analyze (const edm::Event & iEvent, const edm::EventSetup
 	  
 	  uint detID = 0; // zero since long time clust->geographicalId ();
 	  std::stringstream ss;
-	  int layer = tkdetmap_->FindLayer (detID);
+	  int layer = tkdetmap_->FindLayer (detID , cached_detid , cached_layer);
 	  std::string label = tkdetmap_->getLayerName (layer);
 	  const StripGeomDetUnit *theGeomDet = dynamic_cast < const StripGeomDetUnit * >(theTracker.idToDet (detID));
 	  const StripTopology *topol = dynamic_cast < const StripTopology * >(&(theGeomDet->specificTopology ()));
@@ -222,7 +212,7 @@ void SiStripMonitorMuonHLT::analyzeOnTrackClusters( const reco::Track* l3tk, con
 		  // if SiStripRecHit1D
 		  if (hit1D != 0)
 		    {
-		      int layer = tkdetmap_->FindLayer (detID);
+		      int layer = tkdetmap_->FindLayer (detID , cached_detid , cached_layer);
 		      std::string label = tkdetmap_->getLayerName (layer);
 		      const StripGeomDetUnit *theGeomDet = dynamic_cast < const StripGeomDetUnit * >(theTracker.idToDet (detID));
 		      if (theGeomDet != 0)
@@ -258,7 +248,7 @@ void SiStripMonitorMuonHLT::analyzeOnTrackClusters( const reco::Track* l3tk, con
 		  // if SiStripRecHit2D
 		  if (hit2D != 0)
 		    {
-		      int layer = tkdetmap_->FindLayer (detID);
+		      int layer = tkdetmap_->FindLayer (detID , cached_detid , cached_layer);
 		      std::string label = tkdetmap_->getLayerName (layer);
 		      const StripGeomDetUnit *theGeomDet = dynamic_cast < const StripGeomDetUnit * >(theTracker.idToDet (detID));
 		      if (theGeomDet != 0)
@@ -297,7 +287,7 @@ void SiStripMonitorMuonHLT::analyzeOnTrackClusters( const reco::Track* l3tk, con
 		    {
 		      //hit mono
 	              detID = hitMatched2D->monoId();
-		      int layer = tkdetmap_->FindLayer (detID);
+		      int layer = tkdetmap_->FindLayer (detID , cached_detid , cached_layer);
 		      std::string label = tkdetmap_->getLayerName (layer);
 		      const StripGeomDetUnit *theGeomDet = dynamic_cast < const StripGeomDetUnit * >(theTracker.idToDet (detID));
 		      if (theGeomDet != 0)
@@ -332,7 +322,7 @@ void SiStripMonitorMuonHLT::analyzeOnTrackClusters( const reco::Track* l3tk, con
 
 		      //hit stereo
 	              detID = hitMatched2D->stereoId ();
-		      layer = tkdetmap_->FindLayer (detID);
+		      layer = tkdetmap_->FindLayer (detID , cached_detid , cached_layer);
 		      label = tkdetmap_->getLayerName (layer);
 		      const StripGeomDetUnit *theGeomDet2 = dynamic_cast < const StripGeomDetUnit * >(theTracker.idToDet (detID));
 		      if (theGeomDet2 != 0)
@@ -371,7 +361,7 @@ void SiStripMonitorMuonHLT::analyzeOnTrackClusters( const reco::Track* l3tk, con
 		  if (hitProj2D != 0)
 		    {
 	              detID = hitProj2D->geographicalId ();
-		      int layer = tkdetmap_->FindLayer (detID);
+		      int layer = tkdetmap_->FindLayer (detID , cached_detid , cached_layer);
 		      std::string label = tkdetmap_->getLayerName (layer);
 		      const StripGeomDetUnit *theGeomDet = dynamic_cast < const StripGeomDetUnit * >(theTracker.idToDet (detID));
 		      if (theGeomDet != 0)
@@ -650,7 +640,7 @@ SiStripMonitorMuonHLT::GeometryFromTrackGeom (const std::vector<DetId>& Dets,con
       GlobalPoint clustgp = theGeomDet->surface ().toGlobal (clustlp);
 
       // Get the eta, phi of modules
-      mylayer = tkdetmap_->FindLayer (detid);
+      mylayer = tkdetmap_->FindLayer (detid , cached_detid , cached_layer);
       mylabelHisto = tkdetmap_->getLayerName (mylayer);
 
       //      SiStripDetId stripdet = SiStripDetId(detid);
@@ -831,7 +821,7 @@ SiStripMonitorMuonHLT::Normalizer (const std::vector<DetId>& Dets,const TrackerG
       //      const StripTopology *topol = dynamic_cast < const StripTopology * >(&(theGeomDet->specificTopology ()));
 
       // Get the eta, phi of modules
-      mylayer = tkdetmap_->FindLayer (detid);
+      mylayer = tkdetmap_->FindLayer (detid , cached_detid , cached_layer);
       mylabelHisto = tkdetmap_->getLayerName (mylayer);
 
       //      SiStripDetId stripdet = SiStripDetId(detid);
@@ -1256,20 +1246,18 @@ SiStripMonitorMuonHLT::PrintNormalization (const std::vector<std::string>& v_Lab
 
 void SiStripMonitorMuonHLT::bookHistograms(DQMStore::IBooker & ibooker , const edm::Run & run, const edm::EventSetup & es)
 {
-  //if (dbe_)
-  //{
-      if (monitorName_ != "")
-        monitorName_ = monitorName_ + "/";
-      edm::LogInfo ("HLTMuonDQMSource") << "===>DQM event prescale = " << prescaleEvt_ << " events " << std::endl;
-      createMEs (ibooker , es);
-      //create TKHistoMap
-      if(runOnClusters_)
-        tkmapAllClusters = new TkHistoMap(ibooker , "HLT/HLTMonMuon/SiStrip" ,"TkHMap_AllClusters",0.0,0);
-      if(runOnTracks_)
-        tkmapOnTrackClusters = new TkHistoMap(ibooker , "HLT/HLTMonMuon/SiStrip" ,"TkHMap_OnTrackClusters",0.0,0);
-      if(runOnMuonCandidates_)
-        tkmapL3MuTrackClusters = new TkHistoMap(ibooker , "HLT/HLTMonMuon/SiStrip" ,"TkHMap_L3MuTrackClusters",0.0,0);
-      //}
+  if (monitorName_ != "")
+    monitorName_ = monitorName_ + "/";
+  ibooker.setCurrentFolder (monitorName_);
+  edm::LogInfo ("HLTMuonDQMSource") << "===>DQM event prescale = " << prescaleEvt_ << " events " << std::endl;
+  createMEs (ibooker , es);
+  //create TKHistoMap
+  if(runOnClusters_)
+    tkmapAllClusters = new TkHistoMap(ibooker , "HLT/HLTMonMuon/SiStrip" ,"TkHMap_AllClusters",0.0,0);
+  if(runOnTracks_)
+    tkmapOnTrackClusters = new TkHistoMap(ibooker , "HLT/HLTMonMuon/SiStrip" ,"TkHMap_OnTrackClusters",0.0,0);
+  if(runOnMuonCandidates_)
+    tkmapL3MuTrackClusters = new TkHistoMap(ibooker , "HLT/HLTMonMuon/SiStrip" ,"TkHMap_L3MuTrackClusters",0.0,0);
 }
 
 // ------------ method called once each job just after ending the event loop  ------------


### PR DESCRIPTION
TkDetMap made thread-safe with minimal changes: still kept as a Service, but issue reported here:
https://twiki.cern.ch/twiki/bin/view/CMSPublic/FWMultithreadedServicesReview#TkDetMap

should be now avoided by moving the cached_detid and cached_layer data members outside the class.

This is a temporary fix in order to put back asap all the DQM modules removed from sequences:
https://github.com/cms-sw/cmssw/commit/fa306b4747c95e12ff12d772b845d0cb7256de27
