### PR TITLE
primary vertex trimmer (HLT)

### DIFF
--- a/RecoPixelVertexing/PixelVertexFinding/python/PVClusterComparer_cfi.py
+++ b/RecoPixelVertexing/PixelVertexFinding/python/PVClusterComparer_cfi.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+
+pvClusterComparer = cms.PSet(
+  track_pt_min   = cms.double(     1.0),
+  track_pt_max   = cms.double(    10.0), # SD: 20.
+  track_chi2_max = cms.double(999999. ), # SD: 20
+  track_prob_min = cms.double(    -1. ), # RM: 0.001
+)

--- a/RecoPixelVertexing/PixelVertexFinding/python/PixelVertexes_cfi.py
+++ b/RecoPixelVertexing/PixelVertexFinding/python/PixelVertexes_cfi.py
@@ -13,10 +13,14 @@ pixelVertices = cms.EDProducer("PixelVertexProducer",
     Finder = cms.string('DivisiveVertexFinder'),
     PtMin = cms.double(1.0),
     PVcomparer = cms.PSet(
-        track_pt_max   = cms.double(    10.0), # SD: 20.
-        track_chi2_max = cms.double(999999. ), # SD: 20
-        track_prob_min = cms.double(    -1. ), # RM: 0.001
+       refToPSet_ = cms.string('pvClusterComparer')
     )
+#  PVcomparer = cms.PSet(
+#      track_pt_min   = cms.double(     1.0),
+#      track_pt_max   = cms.double(    10.0), # SD: 20.
+#      track_chi2_max = cms.double(999999. ), # SD: 20
+#      track_prob_min = cms.double(    -1. ), # RM: 0.001
+#   )
 )
 
 

--- a/RecoPixelVertexing/PixelVertexFinding/python/PixelVertexes_cfi.py
+++ b/RecoPixelVertexing/PixelVertexFinding/python/PixelVertexes_cfi.py
@@ -17,12 +17,6 @@ pixelVertices = cms.EDProducer("PixelVertexProducer",
     PVcomparer = cms.PSet(
        refToPSet_ = cms.string('pvClusterComparer')
     )
-#  PVcomparer = cms.PSet(
-#      track_pt_min   = cms.double(     1.0),
-#      track_pt_max   = cms.double(    10.0), # SD: 20.
-#      track_chi2_max = cms.double(999999. ), # SD: 20
-#      track_prob_min = cms.double(    -1. ), # RM: 0.001
-#   )
 )
 
 

--- a/RecoPixelVertexing/PixelVertexFinding/python/PixelVertexes_cfi.py
+++ b/RecoPixelVertexing/PixelVertexFinding/python/PixelVertexes_cfi.py
@@ -1,5 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
+from RecoPixelVertexing.PixelVertexFinding.PVClusterComparer_cfi import *
+
 pixelVertices = cms.EDProducer("PixelVertexProducer",
     WtAverage = cms.bool(True),
     ZOffset = cms.double(5.0),

--- a/RecoPixelVertexing/PixelVertexFinding/python/pixelVertexCollectionTrimmer_cfi.py
+++ b/RecoPixelVertexing/PixelVertexFinding/python/pixelVertexCollectionTrimmer_cfi.py
@@ -1,0 +1,19 @@
+import FWCore.ParameterSet.Config as cms
+
+from RecoPixelVertexing.PixelVertexFinding.PVClusterComparer_cfi import *
+
+pixelVertexCollectionTrimmer = cms.EDProducer('PixelVertexCollectionTrimmer',
+  src            = cms.InputTag(''),
+  maxVtx         = cms.int32(100) ,
+  fractionSumPt2 = cms.double(0.3) ,
+  minSumPt2      = cms.double(0.),
+  PVcomparer = cms.PSet(
+     refToPSet_ = cms.string('pvClusterComparer')
+  )
+#  PVcomparer = cms.PSet(
+#      track_pt_min   = cms.double(     1.0),
+#      track_pt_max   = cms.double(    10.0), # SD: 20.
+#      track_chi2_max = cms.double(999999. ), # SD: 20
+#      track_prob_min = cms.double(    -1. ), # RM: 0.001
+#   )
+)

--- a/RecoPixelVertexing/PixelVertexFinding/python/pixelVertexCollectionTrimmer_cfi.py
+++ b/RecoPixelVertexing/PixelVertexFinding/python/pixelVertexCollectionTrimmer_cfi.py
@@ -10,10 +10,4 @@ pixelVertexCollectionTrimmer = cms.EDProducer('PixelVertexCollectionTrimmer',
   PVcomparer = cms.PSet(
      refToPSet_ = cms.string('pvClusterComparer')
   )
-#  PVcomparer = cms.PSet(
-#      track_pt_min   = cms.double(     1.0),
-#      track_pt_max   = cms.double(    10.0), # SD: 20.
-#      track_chi2_max = cms.double(999999. ), # SD: 20
-#      track_prob_min = cms.double(    -1. ), # RM: 0.001
-#   )
 )

--- a/RecoPixelVertexing/PixelVertexFinding/python/pixelVertexCollectionTrimmer_cfi.py
+++ b/RecoPixelVertexing/PixelVertexFinding/python/pixelVertexCollectionTrimmer_cfi.py
@@ -4,7 +4,7 @@ from RecoPixelVertexing.PixelVertexFinding.PVClusterComparer_cfi import *
 
 pixelVertexCollectionTrimmer = cms.EDProducer('PixelVertexCollectionTrimmer',
   src            = cms.InputTag(''),
-  maxVtx         = cms.int32(100) ,
+  maxVtx         = cms.uint32(100) ,
   fractionSumPt2 = cms.double(0.3) ,
   minSumPt2      = cms.double(0.),
   PVcomparer = cms.PSet(

--- a/RecoPixelVertexing/PixelVertexFinding/src/PixelVertexCollectionTrimmer.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/src/PixelVertexCollectionTrimmer.cc
@@ -22,7 +22,7 @@ Implementation:
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -37,7 +37,7 @@ Implementation:
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
-class PixelVertexCollectionTrimmer : public edm::EDProducer {
+class PixelVertexCollectionTrimmer : public edm::stream::EDProducer<> {
 public:
   explicit PixelVertexCollectionTrimmer(const edm::ParameterSet&);
   ~PixelVertexCollectionTrimmer();
@@ -45,9 +45,7 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  virtual void beginJob() override;
   virtual void produce(edm::Event&, const edm::EventSetup&) override;
-  virtual void endJob() override;
 
   edm::EDGetTokenT<reco::VertexCollection> vtxToken_;
   int maxVtx_ ;
@@ -121,17 +119,6 @@ PixelVertexCollectionTrimmer::produce(edm::Event& iEvent, const edm::EventSetup&
     
 }
 
-// ------------ method called once each job just before starting event loop ------------
-void
-PixelVertexCollectionTrimmer::beginJob()
-{
-}
-
-// ------------ method called once each job just after ending the event loop ------------
-void
-PixelVertexCollectionTrimmer::endJob() {
-}
- 
 // ------------ method fills 'descriptions' with the allowed parameters for the module ------------
 void
 PixelVertexCollectionTrimmer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/RecoPixelVertexing/PixelVertexFinding/src/PixelVertexCollectionTrimmer.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/src/PixelVertexCollectionTrimmer.cc
@@ -34,6 +34,9 @@ Implementation:
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "RecoPixelVertexing/PixelVertexFinding/interface/PVClusterComparer.h"
 
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
 class PixelVertexCollectionTrimmer : public edm::EDProducer {
 public:
   explicit PixelVertexCollectionTrimmer(const edm::ParameterSet&);
@@ -135,8 +138,26 @@ PixelVertexCollectionTrimmer::fillDescriptions(edm::ConfigurationDescriptions& d
   //The following says we do not know what parameters are allowed so do no validation
   // Please change this to state exactly what you do use, even if it is no parameters
   edm::ParameterSetDescription desc;
-  desc.setUnknown();
-  descriptions.addDefault(desc);
+  desc.add<edm::InputTag>    ("src",           edm::InputTag(""))
+    ->setComment("input (pixel) vertex collection");
+  desc.add<int>              ("maxVtx",        100)
+    ->setComment("max output collection size (number of accepted vertices)");
+  desc.add<double>           ("fractionSumPt2",  0.3)
+    ->setComment("threshold on sumPt2 fraction of the leading vertex");
+  desc.add<double>           ("minSumPt2",       0. )
+    ->setComment("min sumPt2");
+  edm::ParameterSetDescription PVcomparerPSet;
+  PVcomparerPSet.add<double>("track_pt_min",1.0)
+    ->setComment("min track p_T");
+  PVcomparerPSet.add<double>("track_pt_max",10.0)
+    ->setComment("max track p_T");
+  PVcomparerPSet.add<double>("track_chi2_max",99999.)
+    ->setComment("max track chi2");
+  PVcomparerPSet.add<double>("track_prob_min",-1.)
+    ->setComment("min track prob");
+  desc.add<edm::ParameterSetDescription>("PVcomparer", PVcomparerPSet)
+    ->setComment("from RecoPixelVertexing/PixelVertexFinding/python/PVClusterComparer_cfi.py");
+  descriptions.add("hltPixelVertexCollectionTrimmer",desc);
 }
 
 //define this as a plug-in

--- a/RecoPixelVertexing/PixelVertexFinding/src/PixelVertexCollectionTrimmer.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/src/PixelVertexCollectionTrimmer.cc
@@ -1,0 +1,149 @@
+// -*- C++ -*-
+//
+// Package: RecoPixelVertexing/PixelVertexFinding
+// Class: PixelVertexCollectionTrimmer
+//
+/**\class PixelVertexCollectionTrimmer PixelVertexCollectionTrimmer.cc RecoPixelVertexing/PixelVertexFinding/src/PixelVertexCollectionTrimmer.cc
+
+Description: [one line class summary]
+
+Implementation:
+[Notes on implementation]
+*/
+//
+// Original Author: Riccardo Manzoni
+// Created: Tue, 01 Apr 2014 10:11:16 GMT
+//
+//
+
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "RecoPixelVertexing/PixelVertexFinding/interface/PVClusterComparer.h"
+
+class PixelVertexCollectionTrimmer : public edm::EDProducer {
+public:
+  explicit PixelVertexCollectionTrimmer(const edm::ParameterSet&);
+  ~PixelVertexCollectionTrimmer();
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  virtual void beginJob() override;
+  virtual void produce(edm::Event&, const edm::EventSetup&) override;
+  virtual void endJob() override;
+
+  edm::EDGetTokenT<reco::VertexCollection> vtxToken_;
+  int maxVtx_ ;
+  double fractionSumPt2_ ;
+  double minSumPt2_ ;
+
+  PVClusterComparer* pvComparer_;
+};
+
+PixelVertexCollectionTrimmer::PixelVertexCollectionTrimmer(const edm::ParameterSet& iConfig)
+{
+
+  edm::InputTag vtxInputTag = iConfig.getParameter<edm::InputTag>("src" );
+  vtxToken_ = consumes<reco::VertexCollection>(vtxInputTag);
+  maxVtx_         = iConfig.getParameter<int> ("maxVtx" );
+  fractionSumPt2_ = iConfig.getParameter<double> ("fractionSumPt2" );
+  minSumPt2_      = iConfig.getParameter<double> ("minSumPt2" );
+
+  double track_pt_min =  1.0;
+  double track_pt_max = 10.;
+  double track_chi2_max = 9999999.;
+  double track_prob_min = -1.;
+
+  if ( iConfig.exists("PVcomparer") ) {
+    edm::ParameterSet PVcomparerPSet = iConfig.getParameter<edm::ParameterSet>("PVcomparer");
+    track_pt_min   = PVcomparerPSet.getParameter<double>("track_pt_min");
+    track_pt_max   = PVcomparerPSet.getParameter<double>("track_pt_max");
+    track_chi2_max = PVcomparerPSet.getParameter<double>("track_chi2_max");
+    track_prob_min = PVcomparerPSet.getParameter<double>("track_prob_min");
+  }
+  pvComparer_ = new PVClusterComparer(track_pt_min, track_pt_max, track_chi2_max, track_prob_min);
+
+  produces<reco::VertexCollection>();
+}
+
+PixelVertexCollectionTrimmer::~PixelVertexCollectionTrimmer()
+{
+}
+
+// ------------ method called to produce the data ------------
+void
+PixelVertexCollectionTrimmer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+  using namespace edm;
+   
+  std::auto_ptr<reco::VertexCollection> vtxs_trim(new reco::VertexCollection);
+
+  edm::Handle<reco::VertexCollection> vtxs;
+  iEvent.getByToken(vtxToken_,vtxs);
+
+  double sumpt2 ;
+  //double sumpt2previous = -99. ;
+  int counter = 0 ;
+
+  // this is not the logic we want, at least for now
+  // if requires the sumpt2 for vtx_n to be > threshold * sumpt2 vtx_n-1
+  // for (reco::VertexCollection::const_iterator vtx = vtxs->begin(); vtx != vtxs->end(); ++vtx, ++counter){
+  // if (counter > maxVtx_) break ;
+  // sumpt2 = PVCluster.pTSquaredSum(*vtx) ;
+  // if (sumpt2 > sumpt2previous*fractionSumPt2_ && sumpt2 > minSumPt2_ ) vtxs_trim->push_back(*vtx) ;
+  // else if (counter == 0 ) vtxs_trim->push_back(*vtx) ;
+  // sumpt2previous = sumpt2 ;
+  // }
+
+  double sumpt2first = pvComparer_->pTSquaredSum(*(vtxs->begin())) ;
+
+  for (reco::VertexCollection::const_iterator vtx = vtxs->begin(), evtx=vtxs->end(); 
+       vtx != evtx; ++vtx) {
+    if (counter > maxVtx_) break ;
+    sumpt2 = pvComparer_->pTSquaredSum(*vtx) ;
+    //    std::cout << "sumpt2: " << sumpt2 << "[" << sumpt2first << "]" << std::endl;
+    if (sumpt2 >= sumpt2first*fractionSumPt2_ && sumpt2 > minSumPt2_ ) vtxs_trim->push_back(*vtx) ;
+    counter++;
+  }
+  //  std::cout << " ==> # vertices: " << vtxs_trim->size() << std::endl;
+  iEvent.put(vtxs_trim);
+    
+}
+
+// ------------ method called once each job just before starting event loop ------------
+void
+PixelVertexCollectionTrimmer::beginJob()
+{
+}
+
+// ------------ method called once each job just after ending the event loop ------------
+void
+PixelVertexCollectionTrimmer::endJob() {
+}
+ 
+// ------------ method fills 'descriptions' with the allowed parameters for the module ------------
+void
+PixelVertexCollectionTrimmer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(PixelVertexCollectionTrimmer);

--- a/RecoPixelVertexing/PixelVertexFinding/src/PixelVertexCollectionTrimmer.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/src/PixelVertexCollectionTrimmer.cc
@@ -48,7 +48,7 @@ private:
   virtual void produce(edm::Event&, const edm::EventSetup&) override;
 
   edm::EDGetTokenT<reco::VertexCollection> vtxToken_;
-  int maxVtx_ ;
+  size_t maxVtx_ ;
   double fractionSumPt2_ ;
   double minSumPt2_ ;
 
@@ -60,7 +60,7 @@ PixelVertexCollectionTrimmer::PixelVertexCollectionTrimmer(const edm::ParameterS
 
   edm::InputTag vtxInputTag = iConfig.getParameter<edm::InputTag>("src" );
   vtxToken_ = consumes<reco::VertexCollection>(vtxInputTag);
-  maxVtx_         = iConfig.getParameter<int> ("maxVtx" );
+  maxVtx_         = iConfig.getParameter<unsigned int> ("maxVtx" );
   fractionSumPt2_ = iConfig.getParameter<double> ("fractionSumPt2" );
   minSumPt2_      = iConfig.getParameter<double> ("minSumPt2" );
 
@@ -92,7 +92,6 @@ PixelVertexCollectionTrimmer::produce(edm::Event& iEvent, const edm::EventSetup&
 
   double sumpt2 ;
   //double sumpt2previous = -99. ;
-  int counter = 0 ;
 
   // this is not the logic we want, at least for now
   // if requires the sumpt2 for vtx_n to be > threshold * sumpt2 vtx_n-1
@@ -108,11 +107,11 @@ PixelVertexCollectionTrimmer::produce(edm::Event& iEvent, const edm::EventSetup&
 
   for (reco::VertexCollection::const_iterator vtx = vtxs->begin(), evtx=vtxs->end(); 
        vtx != evtx; ++vtx) {
-    if (counter > maxVtx_) break ;
+    if (vtxs_trim->size() > maxVtx_) break ;
     sumpt2 = pvComparer_->pTSquaredSum(*vtx) ;
     //    std::cout << "sumpt2: " << sumpt2 << "[" << sumpt2first << "]" << std::endl;
+    //    if (sumpt2 >= sumpt2first*fractionSumPt2_ && sumpt2 > minSumPt2_ ) vtxs_trim->push_back(*vtx) ;
     if (sumpt2 >= sumpt2first*fractionSumPt2_ && sumpt2 > minSumPt2_ ) vtxs_trim->push_back(*vtx) ;
-    counter++;
   }
   //  std::cout << " ==> # vertices: " << vtxs_trim->size() << std::endl;
   iEvent.put(vtxs_trim);

--- a/RecoPixelVertexing/PixelVertexFinding/src/PixelVertexCollectionTrimmer.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/src/PixelVertexCollectionTrimmer.cc
@@ -68,13 +68,12 @@ PixelVertexCollectionTrimmer::PixelVertexCollectionTrimmer(const edm::ParameterS
   double track_chi2_max = 9999999.;
   double track_prob_min = -1.;
 
-  if ( iConfig.exists("PVcomparer") ) {
-    edm::ParameterSet PVcomparerPSet = iConfig.getParameter<edm::ParameterSet>("PVcomparer");
-    track_pt_min   = PVcomparerPSet.getParameter<double>("track_pt_min");
-    track_pt_max   = PVcomparerPSet.getParameter<double>("track_pt_max");
-    track_chi2_max = PVcomparerPSet.getParameter<double>("track_chi2_max");
-    track_prob_min = PVcomparerPSet.getParameter<double>("track_prob_min");
-  }
+  edm::ParameterSet PVcomparerPSet = iConfig.getParameter<edm::ParameterSet>("PVcomparer");
+  track_pt_min   = PVcomparerPSet.getParameter<double>("track_pt_min");
+  track_pt_max   = PVcomparerPSet.getParameter<double>("track_pt_max");
+  track_chi2_max = PVcomparerPSet.getParameter<double>("track_chi2_max");
+  track_prob_min = PVcomparerPSet.getParameter<double>("track_prob_min");
+
   pvComparer_ = new PVClusterComparer(track_pt_min, track_pt_max, track_chi2_max, track_prob_min);
 
   produces<reco::VertexCollection>();

--- a/RecoPixelVertexing/PixelVertexFinding/src/PixelVertexCollectionTrimmer.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/src/PixelVertexCollectionTrimmer.cc
@@ -63,16 +63,11 @@ PixelVertexCollectionTrimmer::PixelVertexCollectionTrimmer(const edm::ParameterS
   fractionSumPt2_ = iConfig.getParameter<double> ("fractionSumPt2" );
   minSumPt2_      = iConfig.getParameter<double> ("minSumPt2" );
 
-  double track_pt_min =  1.0;
-  double track_pt_max = 10.;
-  double track_chi2_max = 9999999.;
-  double track_prob_min = -1.;
-
   edm::ParameterSet PVcomparerPSet = iConfig.getParameter<edm::ParameterSet>("PVcomparer");
-  track_pt_min   = PVcomparerPSet.getParameter<double>("track_pt_min");
-  track_pt_max   = PVcomparerPSet.getParameter<double>("track_pt_max");
-  track_chi2_max = PVcomparerPSet.getParameter<double>("track_chi2_max");
-  track_prob_min = PVcomparerPSet.getParameter<double>("track_prob_min");
+  double track_pt_min   = PVcomparerPSet.getParameter<double>("track_pt_min");
+  double track_pt_max   = PVcomparerPSet.getParameter<double>("track_pt_max");
+  double track_chi2_max = PVcomparerPSet.getParameter<double>("track_chi2_max");
+  double track_prob_min = PVcomparerPSet.getParameter<double>("track_prob_min");
 
   pvComparer_ = new PVClusterComparer(track_pt_min, track_pt_max, track_chi2_max, track_prob_min);
 

--- a/RecoPixelVertexing/PixelVertexFinding/src/PixelVertexProducer.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/src/PixelVertexProducer.cc
@@ -31,12 +31,16 @@ PixelVertexProducer::PixelVertexProducer(const edm::ParameterSet& conf)
   token_BeamSpot = consumes<reco::BeamSpot>(conf.getParameter<edm::InputTag>("beamSpot"));
   method2 = conf.getParameter<bool>("Method2");
 
+  double track_pt_min   = ptMin_;
   double track_pt_max   = 10.;
   double track_chi2_max = 9999999.;
   double track_prob_min = -1.;
 
   if ( conf.exists("PVcomparer") ) {
     edm::ParameterSet PVcomparerPSet = conf.getParameter<edm::ParameterSet>("PVcomparer");
+    track_pt_min   = PVcomparerPSet.getParameter<double>("track_pt_min");    
+    if (track_pt_min != ptMin_)
+      edm::LogWarning("PixelVertexProducer") << "minimum track pT setting differs between PixelVertexProducer (" << ptMin_ << ") and PVcomparer (" << track_pt_min << ") !!!";
     track_pt_max   = PVcomparerPSet.getParameter<double>("track_pt_max");
     track_chi2_max = PVcomparerPSet.getParameter<double>("track_chi2_max");
     track_prob_min = PVcomparerPSet.getParameter<double>("track_prob_min");
@@ -44,7 +48,7 @@ PixelVertexProducer::PixelVertexProducer(const edm::ParameterSet& conf)
 
   if (finder == "DivisiveVertexFinder") {
     if (verbose_ > 0) edm::LogInfo("PixelVertexProducer") << ": Using the DivisiveVertexFinder\n";
-    dvf_ = new DivisiveVertexFinder(ptMin_,track_pt_max,track_chi2_max,track_prob_min,zOffset, ntrkMin, useError, zSeparation, wtAverage, verbose_);
+    dvf_ = new DivisiveVertexFinder(track_pt_min,track_pt_max,track_chi2_max,track_prob_min,zOffset, ntrkMin, useError, zSeparation, wtAverage, verbose_);
   }
   else { // Finder not supported, or you made a mistake in your request
     // throw an exception once I figure out how CMSSW does this


### PR DESCRIPTION
new module PixelVertexCollectionTrimmer has been added
in order to trim the primary vertex collection (HLT porpoises)

moreover, a config file for setting the PVClusterComparer PSet has been added
w/ the idea of exploiting the new refToPSet_ feature
and try to have a coherent setting among different customers of the PVClusterComparer
and --above all-- to guarantee the consistency w/in the PV producer between the track pt min threshold 

@martin @perrotta @cerati @rovere @innocente @bluj
