### PR TITLE
Make SiStripClusterizer prods stream modules

### DIFF
--- a/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
@@ -17,7 +17,7 @@
 #include "CalibFormats/SiStripObjects/interface/SiStripDetCabling.h"
 
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -173,7 +173,7 @@ namespace {
 
 
 
-class SiStripClusterizerFromRaw final : public edm::EDProducer  {
+class SiStripClusterizerFromRaw final : public edm::stream::EDProducer<>  {
   
  public:
   

--- a/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusterToDigiProducer.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusterToDigiProducer.cc
@@ -1,5 +1,5 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -17,7 +17,7 @@
 #include "boost/foreach.hpp"
 #include <numeric>
 
-class SiStripClusterToDigiProducer : public edm::EDProducer  {
+class SiStripClusterToDigiProducer : public edm::stream::EDProducer<>  {
 
   typedef   edmNew::DetSetVector<SiStripCluster> ClusterCollection;
   typedef   edmNew::DetSet<SiStripCluster> DetClusterCollection;


### PR DESCRIPTION
Needed to convert ClustersFromRawProducer to a stream module so that we get a unique lazy filler of DetSetVector for each stream. This avoids threading problems when running with multiple events. It also makes the threading jobs more efficient.
Also converted SiStripClusterToDigiProducer to stream since it appears to be safe to do so (static analyzer gives it a clean bill of health).
