### PR TITLE
Revert CSCSegmentProducer back to legacy module

### DIFF
--- a/RecoLocalMuon/CSCSegment/src/CSCSegmentProducer.h
+++ b/RecoLocalMuon/CSCSegment/src/CSCSegmentProducer.h
@@ -9,22 +9,22 @@
 
 #include <FWCore/Framework/interface/ConsumesCollector.h>
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include <DataFormats/CSCRecHit/interface/CSCRecHit2DCollection.h>
+#include "DataFormats/CSCRecHit/interface/CSCRecHit2DCollection.h"
 
 class CSCSegmentBuilder; 
 
-class CSCSegmentProducer : public edm::stream::EDProducer<> {
+class CSCSegmentProducer : public edm::EDProducer {
 public:
     /// Constructor
     explicit CSCSegmentProducer(const edm::ParameterSet&);
     /// Destructor
     ~CSCSegmentProducer();
     /// Produce the CSCSegment collection
-    virtual void produce(edm::Event&, const edm::EventSetup&);
+    virtual void produce(edm::Event&, const edm::EventSetup&) override;
 
 private:
     int iev; // events through


### PR DESCRIPTION
The CSCSegmentProducer uses CLHEP matrix code which is not thread
safe. Therefore this producer can't be a stream module.
