### PR TITLE
Made statics into atomics in CSCALCTTrailer

### DIFF
--- a/EventFilter/CSCRawToDigi/interface/CSCALCTTrailer.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCALCTTrailer.h
@@ -6,6 +6,7 @@
 */
 
 #include <string.h> // memcpy
+#include <atomic>
 #include "DataFormats/CSCDigi/interface/CSCALCTStatusDigi.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
@@ -124,8 +125,8 @@ public:
   CSCALCTTrailer2007 alctTrailer2007() {return trailer2007;}
 
 private:
-  static bool debug;
-  static unsigned short int firmwareVersion;
+  static std::atomic<bool> debug;
+  static std::atomic<unsigned short int> firmwareVersion;
   CSCALCTTrailer2006 trailer2006;
   CSCALCTTrailer2007 trailer2007;
   unsigned short int theOriginalBuffer[4];

--- a/EventFilter/CSCRawToDigi/src/CSCALCTTrailer.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCALCTTrailer.cc
@@ -4,8 +4,8 @@
 
 #include "EventFilter/CSCRawToDigi/interface/CSCALCTTrailer.h"
 
-bool CSCALCTTrailer::debug=false;
-short unsigned int CSCALCTTrailer::firmwareVersion=2006; 
+std::atomic<bool> CSCALCTTrailer::debug{false};
+std::atomic<short unsigned int> CSCALCTTrailer::firmwareVersion{2006}; 
 
 CSCALCTTrailer2006::CSCALCTTrailer2006() {
   bzero(this,  sizeInWords()*2); ///size of the trailer


### PR DESCRIPTION
Changed statics to atomics becuase helgrind was reporting thread
safety issues.
NOTE: It would be much better if firmwareVersion was made a regular
member data instead of a static. When we are processing multiple
runs simultaneously we may need more than one value in the job.
