### PR TITLE
fix hasattr lines added in PR3519

### DIFF
--- a/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py
+++ b/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py
@@ -61,7 +61,8 @@ def customise_Validation(process):
 
 def customise_Digi(process):
     process=digiEventContent(process)
-    if hasattr(process,"mix.digitizers.hcal.ho"):
+    if hasattr(process,'mix') and hasattr(process.mix,'digitizers'): 
+        if hasattr(process.mix.digitizers,'hcal') and hasattr(process.mix.digitiziers.hcal,'ho'):
         process.mix.digitizers.hcal.ho.photoelectronsToAnalog = cms.vdouble([4.0]*16)
         process.mix.digitizers.hcal.ho.siPMCode = cms.int32(1)
         process.mix.digitizers.hcal.ho.pixels = cms.int32(2500)

--- a/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py
+++ b/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py
@@ -63,10 +63,10 @@ def customise_Digi(process):
     process=digiEventContent(process)
     if hasattr(process,'mix') and hasattr(process.mix,'digitizers'): 
         if hasattr(process.mix.digitizers,'hcal') and hasattr(process.mix.digitiziers.hcal,'ho'):
-        process.mix.digitizers.hcal.ho.photoelectronsToAnalog = cms.vdouble([4.0]*16)
-        process.mix.digitizers.hcal.ho.siPMCode = cms.int32(1)
-        process.mix.digitizers.hcal.ho.pixels = cms.int32(2500)
-        process.mix.digitizers.hcal.ho.doSiPMSmearing = cms.bool(False)
+            process.mix.digitizers.hcal.ho.photoelectronsToAnalog = cms.vdouble([4.0]*16)
+            process.mix.digitizers.hcal.ho.siPMCode = cms.int32(1)
+            process.mix.digitizers.hcal.ho.pixels = cms.int32(2500)
+            process.mix.digitizers.hcal.ho.doSiPMSmearing = cms.bool(False)
     return process
 
 


### PR DESCRIPTION
hasattr(blah,"a.b.e.d.c") is not valid python syntax for checking if blah.a.b.e.d has attribute c. Fixing though I'm not sure the cascade of hasattr checks in this case is needed… HO in 2015 configuration broken without this fix - thanks to Salavat for noticing the problem.
