### PR TITLE
Revert MuonDetLayerGeometry using modules to stream modules

### DIFF
--- a/RecoMuon/CosmicMuonProducer/src/CosmicMuonProducer.h
+++ b/RecoMuon/CosmicMuonProducer/src/CosmicMuonProducer.h
@@ -6,13 +6,13 @@
  *  \author Chang Liu
  */
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
 
 class MuonTrackFinder;
 class MuonServiceProxy;
 
-class CosmicMuonProducer : public edm::EDProducer {
+class CosmicMuonProducer : public edm::stream::EDProducer<> {
 public:
   explicit CosmicMuonProducer(const edm::ParameterSet&);
 

--- a/RecoMuon/CosmicMuonProducer/src/GlobalCosmicMuonProducer.h
+++ b/RecoMuon/CosmicMuonProducer/src/GlobalCosmicMuonProducer.h
@@ -9,7 +9,7 @@
  *  \author Chang Liu  -  Purdue University <Chang.Liu@cern.ch>
  */
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
@@ -17,7 +17,7 @@
 class MuonTrackFinder;
 class MuonServiceProxy;
 
-class GlobalCosmicMuonProducer : public edm::EDProducer {
+class GlobalCosmicMuonProducer : public edm::stream::EDProducer<> {
 public:
   explicit GlobalCosmicMuonProducer(const edm::ParameterSet&);
 

--- a/RecoMuon/GlobalMuonProducer/src/GlobalMuonProducer.h
+++ b/RecoMuon/GlobalMuonProducer/src/GlobalMuonProducer.h
@@ -13,7 +13,7 @@
  *   \author  R.Bellan - INFN TO
  */
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 // Input and output collection
 #include "DataFormats/TrackReco/interface/Track.h"
@@ -29,7 +29,7 @@ namespace edm {class ParameterSet; class Event; class EventSetup;}
 class MuonTrackFinder;
 class MuonServiceProxy;
 
-class GlobalMuonProducer : public edm::EDProducer {
+class GlobalMuonProducer : public edm::stream::EDProducer<> {
 
  public:
 

--- a/RecoMuon/GlobalMuonProducer/src/TevMuonProducer.h
+++ b/RecoMuon/GlobalMuonProducer/src/TevMuonProducer.h
@@ -13,7 +13,7 @@
  *   \author  R.Bellan - INFN TO
  */
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "RecoMuon/GlobalTrackingTools/interface/GlobalMuonRefitter.h"
 #include "RecoMuon/TrackingTools/interface/MuonTrackLoader.h"
 
@@ -36,7 +36,7 @@ namespace edm {class ParameterSet; class Event; class EventSetup;}
 class MuonTrackFinder;
 class MuonServiceProxy;
 
-class TevMuonProducer : public edm::EDProducer {
+class TevMuonProducer : public edm::stream::EDProducer<> {
 
  public:
 

--- a/RecoMuon/GlobalTrackingTools/plugins/GlobalTrackQualityProducer.h
+++ b/RecoMuon/GlobalTrackingTools/plugins/GlobalTrackQualityProducer.h
@@ -9,7 +9,7 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -24,7 +24,7 @@
 
 class GlobalMuonRefitter;
 
-class GlobalTrackQualityProducer : public edm::EDProducer {
+class GlobalTrackQualityProducer : public edm::stream::EDProducer<> {
  public:
   explicit GlobalTrackQualityProducer(const edm::ParameterSet& iConfig);
 

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.h
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.h
@@ -26,7 +26,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -64,7 +64,7 @@
 class MuonMesh;
 class MuonKinkFinder;
 
-class MuonIdProducer : public edm::EDProducer {
+class MuonIdProducer : public edm::stream::EDProducer<> {
  public:
    typedef reco::Muon::MuonTrackType TrackType;
   

--- a/RecoMuon/MuonIdentification/plugins/MuonTimingProducer.h
+++ b/RecoMuon/MuonIdentification/plugins/MuonTimingProducer.h
@@ -25,7 +25,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -40,7 +40,7 @@
 // class decleration
 //
 
-class MuonTimingProducer : public edm::EDProducer {
+class MuonTimingProducer : public edm::stream::EDProducer<> {
    public:
       explicit MuonTimingProducer(const edm::ParameterSet&);
       ~MuonTimingProducer();

--- a/RecoMuon/MuonSeedGenerator/plugins/CosmicMuonSeedGenerator.h
+++ b/RecoMuon/MuonSeedGenerator/plugins/CosmicMuonSeedGenerator.h
@@ -7,7 +7,7 @@
  *  \author Chang Liu - Purdue University 
  */
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
@@ -23,7 +23,7 @@ class TrajectoryStateTransform;
 
 namespace edm {class ParameterSet; class Event; class EventSetup;}
 
-class CosmicMuonSeedGenerator: public edm::EDProducer {
+class CosmicMuonSeedGenerator: public edm::stream::EDProducer<> {
  public:
 
   /// Constructor

--- a/RecoMuon/MuonSeedGenerator/plugins/MuonSeedGenerator.h
+++ b/RecoMuon/MuonSeedGenerator/plugins/MuonSeedGenerator.h
@@ -7,7 +7,7 @@
  *  \author R. Bellan - INFN Torino
  */
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
 #include <vector>
@@ -17,7 +17,7 @@ class MuonSeedVFinder;
 class MuonSeedVPatternRecognition;
 class MuonSeedVCleaner;
 
-class MuonSeedGenerator: public edm::EDProducer {
+class MuonSeedGenerator: public edm::stream::EDProducer<> {
  public:
 
   /// Constructor

--- a/RecoMuon/MuonSeedGenerator/plugins/MuonSeedProducer.h
+++ b/RecoMuon/MuonSeedGenerator/plugins/MuonSeedProducer.h
@@ -13,16 +13,16 @@
  *
  */
 
-#include "FWCore/Framework/interface/EDProducer.h"
-#include <FWCore/Framework/interface/Frameworkfwd.h>
-#include <FWCore/Framework/interface/Event.h>
-#include <FWCore/ParameterSet/interface/ParameterSet.h>
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include <DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h>
+#include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
 
 class MuonSeedBuilder;
 
-class MuonSeedProducer: public edm::EDProducer {
+class MuonSeedProducer: public edm::stream::EDProducer<> {
  public:
 
   /// Constructor

--- a/RecoMuon/MuonSeedGenerator/plugins/SETMuonSeedProducer.h
+++ b/RecoMuon/MuonSeedGenerator/plugins/SETMuonSeedProducer.h
@@ -10,7 +10,7 @@
 //---- provided need to be fitted properly (starting from the initial estimates also provided).
 //---- Technically all this information is stored as a TrajectorySeed. SS 
 
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "RecoMuon/TrackingTools/interface/RecoMuonEnumerators.h"
 
@@ -27,7 +27,7 @@ class STAFilter;
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 
-class SETMuonSeedProducer : public edm::stream::EDProducer<> {
+class SETMuonSeedProducer : public edm::EDProducer {
   
  public:
   typedef MuonTransientTrackingRecHit::MuonRecHitContainer MuonRecHitContainer;

--- a/RecoMuon/MuonSeedGenerator/plugins/SETMuonSeedProducer.h
+++ b/RecoMuon/MuonSeedGenerator/plugins/SETMuonSeedProducer.h
@@ -10,11 +10,11 @@
 //---- provided need to be fitted properly (starting from the initial estimates also provided).
 //---- Technically all this information is stored as a TrajectorySeed. SS 
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "RecoMuon/TrackingTools/interface/RecoMuonEnumerators.h"
 
-#include <RecoMuon/TrackingTools/interface/MuonServiceProxy.h>
+#include "RecoMuon/TrackingTools/interface/MuonServiceProxy.h"
 
 #include "RecoMuon/MuonSeedGenerator/src/SETFilter.h"
 #include "RecoMuon/TransientTrackingRecHit/interface/MuonTransientTrackingRecHit.h" 
@@ -27,7 +27,7 @@ class STAFilter;
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 
-class SETMuonSeedProducer : public edm::EDProducer {
+class SETMuonSeedProducer : public edm::stream::EDProducer<> {
   
  public:
   typedef MuonTransientTrackingRecHit::MuonRecHitContainer MuonRecHitContainer;

--- a/RecoMuon/MuonSeedGenerator/src/SETSeedFinder.cc
+++ b/RecoMuon/MuonSeedGenerator/src/SETSeedFinder.cc
@@ -41,14 +41,16 @@ void SETSeedFinder::seeds(const MuonRecHitContainer & cluster,
 
 
 // there is an existing sorter somewhere in the CMSSW code (I think) - delete that
+namespace {
 struct sorter{
   bool operator() (MuonTransientTrackingRecHit::MuonRecHitPointer const & hit_1,
-                   MuonTransientTrackingRecHit::MuonRecHitPointer const & hit_2){
+                   MuonTransientTrackingRecHit::MuonRecHitPointer const & hit_2) const {
     return (hit_1->globalPosition().mag2()<hit_2->globalPosition().mag2());
 
   }
-} sortSegRadius;// smaller first
-
+};// smaller first
+  const sorter sortSegRadius;
+}
 
 
 std::vector<SETSeedFinder::MuonRecHitContainer>

--- a/RecoMuon/StandAloneMuonProducer/src/StandAloneMuonProducer.h
+++ b/RecoMuon/StandAloneMuonProducer/src/StandAloneMuonProducer.h
@@ -13,7 +13,7 @@
  *   \author  R.Bellan - INFN TO
  */
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
 
@@ -22,7 +22,7 @@ namespace edm {class ParameterSet; class Event; class EventSetup;}
 class MuonTrackFinder;
 class MuonServiceProxy;
 
-class StandAloneMuonProducer : public edm::EDProducer {
+class StandAloneMuonProducer : public edm::stream::EDProducer<> {
 
  public:
 


### PR DESCRIPTION
The MuonDetLayerGeometry class was made const thread-safe so it is safe to make the modules which use it stream modules. In addition, performance tests of the threaded framework were showing some of these modules were causing bottlenecks when they were legacy modules.
