### PR TITLE
Hgcal slhc14 sim detidfix

### DIFF
--- a/DataFormats/ForwardDetId/src/HGCalDetId.cc
+++ b/DataFormats/ForwardDetId/src/HGCalDetId.cc
@@ -8,6 +8,23 @@ HGCalDetId::HGCalDetId(uint32_t rawid) : DetId(rawid) {
 }
 
 HGCalDetId::HGCalDetId(ForwardSubdetector subdet, int zp, int lay, int sec, int subsec, int cell) : DetId(Forward,subdet) {  
+
+  if( cell > 0xffff || sec>0x7f || subsec > 0x1 || lay>0x7f )
+    {
+      //edm::LogWarning("HGCalDetId") 
+      std::cout 
+	<< "[HGCalDetId] request for new id for layer=" << lay
+	<< " @ zp=" << zp 
+	<< " sector=" << sec 
+	<< " subsec=" << subsec 
+	<< " cell=" << cell 
+	<< " for subdet=" << subdet 
+	<< " has one or more fields out of bounds and will be reset" 
+	<< std::endl;
+      cell=0;  sec=0;  subsec=0; lay=0;
+    }
+  
+
   uint32_t rawid=0;
   rawid |= ((cell   & 0xffff) << 0 );
   rawid |= ((sec    & 0x7f)   << 16);

--- a/DataFormats/ForwardDetId/src/HGCalDetId.cc
+++ b/DataFormats/ForwardDetId/src/HGCalDetId.cc
@@ -11,16 +11,13 @@ HGCalDetId::HGCalDetId(ForwardSubdetector subdet, int zp, int lay, int sec, int 
 
   if( cell > 0xffff || sec>0x7f || subsec > 0x1 || lay>0x7f )
     {
-      //edm::LogWarning("HGCalDetId") 
-      std::cout 
-	<< "[HGCalDetId] request for new id for layer=" << lay
-	<< " @ zp=" << zp 
-	<< " sector=" << sec 
-	<< " subsec=" << subsec 
-	<< " cell=" << cell 
-	<< " for subdet=" << subdet 
-	<< " has one or more fields out of bounds and will be reset" 
-	<< std::endl;
+      //       std::cout << "[HGCalDetId] request for new id for layer=" << lay
+      // 		<< " @ zp=" << zp 
+      // 		<< " sector=" << sec 
+      // 		<< " subsec=" << subsec 
+      // 		<< " cell=" << cell 
+      // 		<< " for subdet=" << subdet 
+      // 		<< " has one or more fields out of bounds and will be reset" << std::endl;
       cell=0;  sec=0;  subsec=0; lay=0;
     }
   

--- a/DataFormats/HGCDigi/interface/HGCSample.h
+++ b/DataFormats/HGCDigi/interface/HGCSample.h
@@ -13,8 +13,8 @@ class HGCSample {
 
 public:
 
-  enum HGCSampleMasks {ADC_MASK=0xffff };
-  enum HGCSamplePos   {ADC_POS=0x0     };
+  enum HGCSampleMasks {ADC_MASK=0x7fff, GAIN_MASK=0x1 };
+  enum HGCSamplePos   {ADC_POS=0      , GAIN_POS=15 };
 
   /**
      @short CTOR
@@ -25,16 +25,30 @@ public:
   /**
      @short setters
    */
-  void setADC(uint16_t adc) { value_ = ((adc & ADC_MASK) << ADC_POS); }
-  
+  void setGain(uint16_t gain)           { setWord(gain,GAIN_MASK,GAIN_POS);               }
+  void setADC(uint16_t adc)             { setWord(adc,ADC_MASK,ADC_POS);                  }
+  void set(uint16_t gain, uint16_t adc) { setGain(gain);                     setADC(adc); }  
+
   /**
      @short getters
-   */
-  uint16_t raw() const { return value_; }
-  int adc()      const { return ((value_ >> ADC_POS) & ADC_MASK); }
+  */
+  uint16_t raw()  const { return value_; }
+  uint16_t gain() const { return ((value_ >> GAIN_POS) & GAIN_MASK); }
+  uint16_t adc()  const { return ((value_ >> ADC_POS) & ADC_MASK); }
   uint16_t operator()() { return value_; }
   
 private:
+
+  /**
+     @short wrapper to reset words at a given position
+   */
+  void setWord(uint16_t word, uint16_t mask, uint16_t pos)
+  {
+    //clear required bits
+    value_ &= ~((word & mask) << pos); 
+    //now set the new value
+    value_ |= ((word & mask) << pos);
+  }
 
   // the word
   uint16_t value_;

--- a/SimCalorimetry/HGCSimProducers/interface/HGCDigitizer.h
+++ b/SimCalorimetry/HGCSimProducers/interface/HGCDigitizer.h
@@ -2,6 +2,7 @@
 #define HGcalSimProducers_HGCDigitizer_h
 
 #include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/ForwardDetId/interface/ForwardSubdetector.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 
 #include "SimDataFormats/CaloHit/interface/PCaloHit.h"
@@ -70,6 +71,9 @@ private :
   HGCEEDigitizer theHGCEEDigitizer_;
   HGCHEbackDigitizer theHGCHEbackDigitizer_;
   HGCHEfrontDigitizer theHGCHEfrontDigitizer_;
+
+  //subdetector id
+  ForwardSubdetector mySubDet_;
 };
 
 #endif

--- a/SimCalorimetry/HGCSimProducers/interface/HGCDigitizerBase.h
+++ b/SimCalorimetry/HGCSimProducers/interface/HGCDigitizerBase.h
@@ -66,10 +66,17 @@ class HGCDigitizerBase {
 	double noiseEn=simpleNoiseGen_->fire();
 	if(noiseEn<0) noiseEn=0;
  
-	//round to integer
+	//round to integer (sample will saturate the value according to available bits)
 	uint16_t totalEnInt = floor((totalEn+noiseEn)/lsbInMeV_);
 
-	HGCSample singleSample( totalEnInt );
+	//0 gain for the moment
+	HGCSample singleSample;
+	singleSample.set(0, totalEnInt );
+	
+	// 	std::cout << totalEn << " -> " << totalEnInt << " " 
+	// 		  << singleSample.gain() << " " << singleSample.adc() << " " 
+	// 		  << std::hex << singleSample.raw() << std::dec << std::endl;
+	
 	if(singleSample.adc()==0) continue;
  
 	//no time information

--- a/SimCalorimetry/HGCSimProducers/plugins/HGCDigiProducer.cc
+++ b/SimCalorimetry/HGCSimProducers/plugins/HGCDigiProducer.cc
@@ -3,14 +3,16 @@
 #include "SimCalorimetry/HGCSimProducers/plugins/HGCDigiProducer.h"
 #include "FWCore/Framework/interface/EDProducer.h"
 
+//
 HGCDigiProducer::HGCDigiProducer(edm::ParameterSet const& pset, edm::EDProducer& mixMod) :
   DigiAccumulatorMixMod(),
-  theDigitizer_(pset) {
+  theDigitizer_(pset), 
+  numberingScheme_(0) 
+{
   if( theDigitizer_.producesEEDigis()     )
     mixMod.produces<HGCEEDigiCollection>(theDigitizer_.digiCollection());
   if( theDigitizer_.producesHEfrontDigis() || theDigitizer_.producesHEbackDigis() )
     mixMod.produces<HGCHEDigiCollection>(theDigitizer_.digiCollection());
-  
 }
 
 //

--- a/SimCalorimetry/HGCSimProducers/plugins/HGCDigiProducer.cc
+++ b/SimCalorimetry/HGCSimProducers/plugins/HGCDigiProducer.cc
@@ -6,8 +6,7 @@
 //
 HGCDigiProducer::HGCDigiProducer(edm::ParameterSet const& pset, edm::EDProducer& mixMod) :
   DigiAccumulatorMixMod(),
-  theDigitizer_(pset), 
-  numberingScheme_(0) 
+  theDigitizer_(pset) 
 {
   if( theDigitizer_.producesEEDigis()     )
     mixMod.produces<HGCEEDigiCollection>(theDigitizer_.digiCollection());

--- a/SimCalorimetry/HGCSimProducers/src/HGCDigitizer.cc
+++ b/SimCalorimetry/HGCSimProducers/src/HGCDigitizer.cc
@@ -1,4 +1,6 @@
 #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
+#include "DataFormats/ForwardDetId/interface/HGCEEDetId.h"
+#include "DataFormats/ForwardDetId/interface/HGCHEDetId.h"
 #include "SimCalorimetry/HGCSimProducers/interface/HGCDigitizer.h"
 #include "SimDataFormats/CaloHit/interface/PCaloHitContainer.h"
 #include "SimDataFormats/CrossingFrame/interface/CrossingFrame.h"
@@ -14,7 +16,8 @@
 HGCDigitizer::HGCDigitizer(const edm::ParameterSet& ps) :
   theHGCEEDigitizer_(ps),
   theHGCHEbackDigitizer_(ps),
-  theHGCHEfrontDigitizer_(ps)
+  theHGCHEfrontDigitizer_(ps),
+  mySubDet_(ForwardSubdetector::ForwardEmpty)
 {
   //configure from cfg
   hitCollection_     = ps.getUntrackedParameter< std::string >("hitCollection");
@@ -32,6 +35,11 @@ HGCDigitizer::HGCDigitizer(const edm::ParameterSet& ps) :
   theHGCEEDigitizer_.setRandomNumberEngine(engine);
   theHGCHEbackDigitizer_.setRandomNumberEngine(engine);
   theHGCHEfrontDigitizer_.setRandomNumberEngine(engine);
+
+  //subdetector
+  if( producesEEDigis() )      mySubDet_=ForwardSubdetector::HGCEE;
+  if( producesHEfrontDigis() ) mySubDet_=ForwardSubdetector::HGCHEF;
+  if( producesHEbackDigis() )  mySubDet_=ForwardSubdetector::HGCHEB;
 }
 
 //
@@ -103,8 +111,12 @@ void HGCDigitizer::accumulate(edm::Handle<edm::PCaloHitContainer> const &hits, i
     {
       //for now use a single time sample
       int    itime = 0; //(int) ( hit_it->time() - bxTime_*bxCrossing ); // - jitter etc.;
-      HGCalDetId id( hit_it->id() );
-
+      HGCalDetId simId( hit_it->id() );
+      
+      //this could be changed in the future to use the geometry record
+      uint32_t id = producesEEDigis() ?
+	(uint32_t)HGCEEDetId(mySubDet_,simId.zside(),simId.layer(),simId.sector(),simId.subsector(),simId.cell()):
+	(uint32_t)HGCHEDetId(mySubDet_,simId.zside(),simId.layer(),simId.sector(),simId.subsector(),simId.cell());
 
       double ien   = hit_it->energy();
 

--- a/SimCalorimetry/HGCSimProducers/src/HGCDigitizer.cc
+++ b/SimCalorimetry/HGCSimProducers/src/HGCDigitizer.cc
@@ -1,3 +1,4 @@
+#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 #include "SimCalorimetry/HGCSimProducers/interface/HGCDigitizer.h"
 #include "SimDataFormats/CaloHit/interface/PCaloHitContainer.h"
 #include "SimDataFormats/CrossingFrame/interface/CrossingFrame.h"
@@ -102,7 +103,9 @@ void HGCDigitizer::accumulate(edm::Handle<edm::PCaloHitContainer> const &hits, i
     {
       //for now use a single time sample
       int    itime = 0; //(int) ( hit_it->time() - bxTime_*bxCrossing ); // - jitter etc.;
-      uint32_t id  = hit_it->id();
+      HGCalDetId id( hit_it->id() );
+
+
       double ien   = hit_it->energy();
 
       HGCSimHitDataAccumulator::iterator simHitIt=simHitAccumulator_.find(id);

--- a/SimG4CMS/Calo/src/HGCSD.cc
+++ b/SimG4CMS/Calo/src/HGCSD.cc
@@ -110,6 +110,8 @@ uint32_t HGCSD::setDetUnitId(G4Step * aStep) {
 
   //determine the exact position in global coordinates in the mass geometry 
   G4ThreeVector hitPoint    = preStepPoint->GetPosition();
+  float globalZ=touch->GetTranslation(0).z();
+  int iz( globalZ>0 ? 1 : -1);
 
   //convert to local coordinates (=local to the current volume): 
   G4ThreeVector localpos = touch->GetHistory()->GetTopTransform().TransformPoint(hitPoint);
@@ -119,14 +121,21 @@ uint32_t HGCSD::setDetUnitId(G4Step * aStep) {
 
   int layer  = touch->GetReplicaNumber(0);
   int module = touch->GetReplicaNumber(1);
-  int iz     = touch->GetReplicaNumber(3)==1 ? 1 : -1;
-  
-  //  std::cout << "layer=" << layer << "=" << touch->GetReplicaNumber(0) << "\t"
-  //  	    << "mod="   << module << "=" << touch->GetReplicaNumber(1) << "\t"
-  //	    << "izplmin=" << iz  << "=" << touch->GetReplicaNumber(3) << std::endl; 
-  //    int layer    = (touch->GetReplicaNumber(0));
-  //  int module = (touch->GetReplicaNumber(1));
-  //  int izplmin = (touch->GetReplicaNumber(3)); 
+
+  //gang in layers (otherwise DetId is not enough to accomodate all layers)
+  //new layer is negative if not to be looked at : set DetId to 0
+  if(numberingScheme)
+    {
+      layer=numberingScheme->getDDDConstants()->simToReco(1,layer,true).second;
+      if(layer<0) return 0;  
+    }
+
+  // if(iz<0) {
+  //     std::cout << "layer=" << layer << "=" << touch->GetReplicaNumber(0) << "\t"
+  // 	      << "mod="   << module << "=" << touch->GetReplicaNumber(1) << "\t"
+  // 	      << "izplmin=" << iz  << "=" << touch->GetReplicaNumber(3) << "\t"
+  // 	      << "globalZ=" << globalZ << std::endl; 
+  //}
 
   return setDetUnitId (subdet, layer, module, iz, localpos);
 }

--- a/SimGeneral/MixingModule/python/hgcalDigitizer_cfi.py
+++ b/SimGeneral/MixingModule/python/hgcalDigitizer_cfi.py
@@ -7,19 +7,20 @@ hgceeDigitizer = cms.PSet( accumulatorType   = cms.string("HGCDigiProducer"),
                            bxTime            = cms.untracked.int32(25),
                            doTrivialDigis    = cms.untracked.bool(True),
                            makeDigiSimLinks  = cms.untracked.bool(False),
-                           digiCfg = cms.untracked.PSet( lsbInMeV   = cms.untracked.double(10),
-                                                         noiseInMeV = cms.untracked.double(10)
+                           digiCfg = cms.untracked.PSet( lsbInMeV   = cms.untracked.double(12.0),
+                                                         noiseInMeV = cms.untracked.double(0)
                                                          )
                            )
 
 hgchefrontDigitizer = hgceeDigitizer.clone()
 hgchefrontDigitizer.hitCollection  = cms.untracked.string("HGCHitsHEfront")
 hgchefrontDigitizer.digiCollection = cms.untracked.string("HGCDigisHEfront")
+hgchefrontDigitizer.digiCfg.lsbInMev = cms.untracked.double(17.6)
 
 hgchebackDigitizer = hgceeDigitizer.clone()
 hgchebackDigitizer.hitCollection = cms.untracked.string("HGCHitsHEback")
 hgchebackDigitizer.digiCollection = cms.untracked.string("HGCDigisHEback")
-                   
+hgchebackDigitizer.digiCfg.lsbInMev = cms.untracked.double(310.8)
 
 
 


### PR DESCRIPTION
Fixes issue found with DetId for SimHits due to large number of layers in EE and HEfront.
Added translation from SimHit DetId to HGC DetId at digitization level.
Adding MIP/5 like thresholds to the trivial digitizer and removed noise. 
@vandreev11 @bsunanda @amagnan - check it as well, please.
