### PR TITLE
Bugfix for pilot blade enabling/disabling in digitizer

### DIFF
--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.cc
@@ -179,9 +179,11 @@ namespace cms
         if((isub == PixelSubdetector::PixelBarrel) || (isub == PixelSubdetector::PixelEndcap)) {  
           auto pixdet = dynamic_cast<const PixelGeomDetUnit*>((*iu));
           assert(pixdet != 0);
-	  unsigned int disk = tTopo->pxfDisk(detId);
-	  //if using pilot blades, then allowing it for current detector only
-	  if ((disk == 3)&&((!pilotBlades)&&(NumberOfEndcapDisks == 2))) continue;
+	  if (isub==PixelSubdetector::PixelEndcap) {
+	    unsigned int disk = tTopo->pxfDisk(detId);
+	    //if using pilot blades, then allowing it for current detector only
+	    if ((disk == 3)&&((!pilotBlades)&&(NumberOfEndcapDisks == 2))) continue;
+	  }
           detectorUnits.insert(std::make_pair(detId, pixdet));
         }
       }


### PR DESCRIPTION
This is an urgent patch for PR #3754.
Explanation:
In the /DataFormats/TrackerCommon/TrackerTopologys pxfDisk () method  the startbit for layer is the same as for the disk, therefore when the code checks the disk == 3, the statement is also true for layer ==3, which need to be fixed as soon as possible.
