### PR TITLE
TMVA code is not thread safe so modules must be legacy

### DIFF
--- a/RecoEgamma/ElectronIdentification/plugins/ElectronIdMVABased.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/ElectronIdMVABased.cc
@@ -22,7 +22,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/stream/EDFilter.h"
+#include "FWCore/Framework/interface/EDFilter.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -39,7 +39,7 @@
 
 using namespace std;
 using namespace reco;
-class ElectronIdMVABased : public edm::stream::EDFilter<> {
+class ElectronIdMVABased : public edm::EDFilter {
 	public:
 		explicit ElectronIdMVABased(const edm::ParameterSet&);
 		~ElectronIdMVABased();

--- a/RecoParticleFlow/PFTracking/interface/GoodSeedProducer.h
+++ b/RecoParticleFlow/PFTracking/interface/GoodSeedProducer.h
@@ -1,12 +1,12 @@
-#ifndef GoodSeedProducer_H
-#define GoodSeedProducer_H
+#ifndef RecoParticleFlow_PFTracking_GoodSeedProducer_H
+#define RecoParticleFlow_PFTracking_GoodSeedProducer_H
 // system include files
 #include <memory>
 
 // user include files
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/EDProducer.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -49,7 +49,7 @@ class TrackerGeometry;
 class TrajectoryStateOnSurface;
 
 
-class GoodSeedProducer : public edm::stream::EDProducer<> {
+class GoodSeedProducer : public edm::EDProducer {
   typedef TrajectoryStateOnSurface TSOS;
    public:
       explicit GoodSeedProducer(const edm::ParameterSet&);


### PR DESCRIPTION
Helgrind identified ElectronIdMVABased and GoodSeedProducer as interacting
with the singleton buried within TMVA at event time. This is not thread
safe so these modules must be downgraded to legacy.
A quick review of TMVA actually shows that if more than one TMVA::Reader
is used in an application that it can lead to a segmentation fault
because of poor ownership of the singleton within TMVA.
