### PR TITLE
Revert PFElecTkProducer to legacy module because of TMVA

### DIFF
--- a/RecoParticleFlow/PFTracking/interface/PFElecTkProducer.h
+++ b/RecoParticleFlow/PFTracking/interface/PFElecTkProducer.h
@@ -4,7 +4,7 @@
 #include "DataFormats/ParticleFlowReco/interface/PFConversion.h"
 #include "DataFormats/ParticleFlowReco/interface/PFV0.h"
 
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -41,7 +41,7 @@ class ConvBremPFTrackFinder;
  and transform them in PFGsfRecTracks.
 */
 
-class PFElecTkProducer : public edm::stream::EDProducer<> {
+class PFElecTkProducer : public edm::EDProducer {
  public:
   
      ///Constructor


### PR DESCRIPTION
The TMVA code is not thread safe so PFElecTkProducer which uses this
must be reverted back to a legacy module.
