### PR TITLE
fix unrunable schedule

### DIFF
--- a/FastSimulation/Configuration/python/FamosSequences_cff.py
+++ b/FastSimulation/Configuration/python/FamosSequences_cff.py
@@ -415,6 +415,8 @@ famosEcalDrivenElectronSequence = cms.Sequence(
     egammaEcalDrivenReco
 )
 
+simulationSequence.insert(0,genParticles)
+
 # The reconstruction sequence
 if(CaloMode==3):
     if(MixingMode=='GenMixing'):


### PR DESCRIPTION
FastSim: fix unrunable schedule

"""
famosSimHits consumes genParticles, genParticles after particleBasedIsolation [path reconstruction_step], particleBasedIsolation consumes particleFlowEGamma, particleFlowEGamma consumes offlinePrimaryVertices, offlinePrimaryVertices consumes generalTracks, generalTracks consumes initialStepTracks, initialStepTracks consumes iterativeInitialTrackCandidates, iterativeInitialTrackCandidates consumes famosSimHits
"""
