### PR TITLE
71X - remove TCMET

### DIFF
--- a/PhysicsTools/PatAlgos/python/producersLayer1/muonProducer_cfi.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/muonProducer_cfi.py
@@ -47,7 +47,7 @@ patMuons = cms.EDProducer("PATMuonProducer",
     embedCaloMETMuonCorrs = cms.bool(True),
     caloMETMuonCorrs = cms.InputTag("muonMETValueMapProducer"  , "muCorrData"),
     # embedding of muon MET corrections for tcMET
-    embedTcMETMuonCorrs   = cms.bool(True),
+    embedTcMETMuonCorrs   = cms.bool(False), # removed from RECO/AOD!
     tcMETMuonCorrs   = cms.InputTag("muonTCMETValueMapProducer", "muCorrData"),
 
     # embed IsoDeposits

--- a/PhysicsTools/PatAlgos/test/patTuple_addJets_cfg.py
+++ b/PhysicsTools/PatAlgos/test/patTuple_addJets_cfg.py
@@ -10,7 +10,7 @@ process.load("PhysicsTools.PatAlgos.selectionLayer1.selectedPatCandidates_cff")
 from PhysicsTools.PatAlgos.tools.metTools import addMETCollection
 addMETCollection(process, labelName='patMETCalo', metSource='met')
 addMETCollection(process, labelName='patMETPF', metSource='pfType1CorrectedMet')
-addMETCollection(process, labelName='patMETTC', metSource='tcMet')
+#addMETCollection(process, labelName='patMETTC', metSource='tcMet') # FIXME: removed from RECO/AOD; needs functionality to add to processing
 
 ## uncomment the following line to add different jet collections
 ## to the event content
@@ -53,10 +53,11 @@ labelCA8PFCHSPruned = 'CA8PFCHSPruned'
 addJetCollection(
    process,
    labelName = labelCA8PFCHSPruned,
-   jetSource = cms.InputTag('ca8PFJetsCHSPruned'),
+   jetSource = cms.InputTag('ca8PFJetsCHSPruned',''),
    algo = 'CA8',
    rParam = 0.8,
-   genJetCollection = cms.InputTag('ak8GenJets'),
+   #genJetCollection = cms.InputTag('ak8GenJets'), # not in used SIM yet
+   genJetCollection = cms.InputTag('ak5GenJets'),
    jetCorrections = ('AK5PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'None'), # FIXME: Use proper JECs, as soon as available
    btagDiscriminators = [
        'combinedSecondaryVertexBJetTags'


### PR DESCRIPTION
710pre8 RelVals do not have TCMET anymore after #3650 .
Also `ak8GenJets` are not yet available in the underlying SIM.
