### PR TITLE
71X - avoid RecoMET/METProducers DAS errors

### DIFF
--- a/RecoMET/METProducers/python/testInputFiles_cff.py
+++ b/RecoMET/METProducers/python/testInputFiles_cff.py
@@ -4,14 +4,15 @@ import FWCore.ParameterSet.Config as cms
 # from PhysicsTools.PatAlgos.tools.cmsswVersionTools import pickRelValInputFiles
 # recoMETtestInputFiles = pickRelValInputFiles(
 #     useDAS = True,
-#     cmsswVersion = 'CMSSW_7_1_0_pre2',
+#     cmsswVersion = 'CMSSW_7_1_0_pre4_AK4',
 #     dataTier = 'GEN-SIM-RECO',
 #     relVal = 'RelValTTbar_13',
-#     globalTag = 'PU50ns_POSTLS170_V4'
+#     globalTag = 'PU50ns_POSTLS171_V2'
+#     maxVersions = 2
 #     )
 
 recoMETtestInputFiles = [
-    '/store/relval/CMSSW_7_1_0_pre2/RelValTTbar_13/GEN-SIM-RECO/PU50ns_POSTLS170_V4-v1/00000/FAA1E1EE-BE8F-E311-B633-0026189438BC.root',
+    '/store/relval/CMSSW_7_1_0_pre4_AK4/RelValTTbar_13/GEN-SIM-RECO/PU50ns_POSTLS171_V2-v2/00000/1487CD0E-A4B3-E311-96D2-0025904C678A.root',
     ]
 
 ##____________________________________________________________________________||

--- a/RecoMET/METProducers/python/testInputFiles_cff.py
+++ b/RecoMET/METProducers/python/testInputFiles_cff.py
@@ -1,17 +1,17 @@
 import FWCore.ParameterSet.Config as cms
 
 ##____________________________________________________________________________||
-from PhysicsTools.PatAlgos.tools.cmsswVersionTools import pickRelValInputFiles
-recoMETtestInputFiles = pickRelValInputFiles(
-    useDAS = True,
-    cmsswVersion = 'CMSSW_7_1_0_pre2',
-    dataTier = 'GEN-SIM-RECO',
-    relVal = 'RelValTTbar_13',
-    globalTag = 'PU50ns_POSTLS170_V4'
-    )
+# from PhysicsTools.PatAlgos.tools.cmsswVersionTools import pickRelValInputFiles
+# recoMETtestInputFiles = pickRelValInputFiles(
+#     useDAS = True,
+#     cmsswVersion = 'CMSSW_7_1_0_pre2',
+#     dataTier = 'GEN-SIM-RECO',
+#     relVal = 'RelValTTbar_13',
+#     globalTag = 'PU50ns_POSTLS170_V4'
+#     )
 
-# recoMETtestInputFiles = [
-#     '/store/relval/CMSSW_7_1_0_pre2/RelValTTbar_13/GEN-SIM-RECO/PU50ns_POSTLS170_V4-v1/00000/FAA1E1EE-BE8F-E311-B633-0026189438BC.root',
-#     ]
+recoMETtestInputFiles = [
+    '/store/relval/CMSSW_7_1_0_pre2/RelValTTbar_13/GEN-SIM-RECO/PU50ns_POSTLS170_V4-v1/00000/FAA1E1EE-BE8F-E311-B633-0026189438BC.root',
+    ]
 
 ##____________________________________________________________________________||


### PR DESCRIPTION
This PR tries to get rid of the repeated (and annoying) problems from DAS queries in integration tests like e.g. https://github.com/cms-sw/cmssw/pull/3717#issuecomment-43599544
The errors appear when DAS is used to determine input files with `pickRelValInputFiles`, but seem unrelated to that script. The DAS reply contains usually messages like

```
[{u\'reason\': u\'HTTPError, system=phedex, url=https://cmsweb.cern.ch/phedex/datasvc/xml/prod/fileReplicas, args={"dataset": "/RelValTTbar_13/CMSSW_7_1_0_pre2-PU50ns_POSTLS170_V4-v2/GEN-SIM-RECO"}, headers={"Accept": "application/xml;text/xml", "User-Agent": "das-server/2.6.1::python/2.6"}\', u\'ts\': 1400572838.24, u\'error\': u\'Unable to contact phedex data-service.\'}]
```

This PR hides the problem rather than fixing it.
@davidlange6 : Maybe we should discuss in the ORP, if we want that - but I am rather sure, we do for CMSSW tests.

P.S.:
I did not see problems with the DAS queries in my local tests.
