### PR TITLE
Make GsfElectronCoreBaseProducer a stream module

### DIFF
--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronCoreBaseProducer.h
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronCoreBaseProducer.h
@@ -8,7 +8,7 @@
 // Description:
 
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 
@@ -28,7 +28,7 @@ namespace edm
 #include "DataFormats/GsfTrackReco/interface/GsfTrackFwd.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 
-class GsfElectronCoreBaseProducer : public edm::EDProducer
+class GsfElectronCoreBaseProducer : public edm::stream::EDProducer<>
  {
   public:
 


### PR DESCRIPTION
The static analyzer and helgrind report that all classes that inherit
from GsfElectronCoreBaseProducer are safe to be stream modules.

This is needed to avoid stalling in threaded RECO jobs.
