### PR TITLE
Make DQMRootOutputModule a one module

### DIFF
--- a/DQMServices/FwkIO/plugins/DQMRootOutputModule.cc
+++ b/DQMServices/FwkIO/plugins/DQMRootOutputModule.cc
@@ -27,7 +27,7 @@
 #include "TProfile.h"
 
 // user include files
-#include "FWCore/Framework/interface/OutputModule.h"
+#include "FWCore/Framework/interface/one/OutputModule.h"
 #include "FWCore/Framework/interface/RunPrincipal.h"
 #include "FWCore/Framework/interface/LuminosityBlockPrincipal.h"
 #include "DQMServices/Core/interface/DQMStore.h"
@@ -178,7 +178,7 @@ namespace edm {
   class ModuleCallingContext;
 }
 
-class DQMRootOutputModule : public edm::OutputModule {
+class DQMRootOutputModule : public edm::one::OutputModule<> {
 public:
   explicit DQMRootOutputModule(edm::ParameterSet const& pset);
   virtual ~DQMRootOutputModule();
@@ -267,7 +267,8 @@ makeHelper(unsigned int iTypeIndex,
 // constructors and destructor
 //
 DQMRootOutputModule::DQMRootOutputModule(edm::ParameterSet const& pset):
-edm::OutputModule(pset),
+edm::one::OutputModuleBase::OutputModuleBase(pset),
+edm::one::OutputModule<>(pset),
 m_fileName(pset.getUntrackedParameter<std::string>("fileName")),
 m_logicalFileName(pset.getUntrackedParameter<std::string>("logicalFileName","")),
 m_file(0),


### PR DESCRIPTION
Since ROOT output is thread-safe when a TFile is only being used
on one thread, we can make the DQMRootOutputModule a one module
so it does not stall any legacy modules. The PoolOutputModule is
already a one module.

This is needed to avoid thread stalls in RECO jobs.
