### PR TITLE
Atomic ptr cache data is transient

### DIFF
--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -29,7 +29,9 @@
    <version ClassVersion="10" checksum="1662079993"/>
   </class>
   <!--NOTE: the declaration of AtomicPtrCache are a temporary work around until ROOT 6 where they will not be needed -->
-  <class name="edm::AtomicPtrCache<std::vector<reco::SuperCluster> >" />
+  <class name="edm::AtomicPtrCache<std::vector<reco::SuperCluster> >">
+   <field name="m_data" transient="true"/>
+  </class>
   <ioread sourceClass="pat::Electron" targetClass="pat::Electron" version="[1-]" source="" target="superClusterRelinked_">
     <![CDATA[superClusterRelinked_.reset();]]>
   </ioread>
@@ -56,8 +58,12 @@
    <version ClassVersion="10" checksum="2244564938"/>
   </class>
   <!--NOTE: the declaration of AtomicPtrCache are a temporary work around until ROOT 6 where they will not be needed -->
-   <class name="edm::AtomicPtrCache<reco::TrackRefVector>"/>
-   <class name="edm::AtomicPtrCache<std::vector<reco::PFCandidatePtr> >" />
+   <class name="edm::AtomicPtrCache<reco::TrackRefVector>">
+     <field name="m_data" transient="true"/>
+  </class>
+   <class name="edm::AtomicPtrCache<std::vector<reco::PFCandidatePtr> >">
+     <field name="m_data" transient="true"/>
+  </class>
   <ioread sourceClass="pat::Tau" targetClass="pat::Tau" version="[1-]" source="" target="isolationTracksTransientRefVector_">
   <![CDATA[isolationTracksTransientRefVector_.reset();]]>
   </ioread>


### PR DESCRIPTION
This pull request is a fix for the failure in the pat1 "other" test.  Data that should have been declared transient was not.  This problem can be seen in IB CMSSW_7_1_ROOT6_X_2014-05-19-1400 and prior IB's.  In later IB's this error is hidden by other problems.
Please merge this as soon as convenient, unless there are problems.
This should also propagate to the cms-sw:CMSSW_7_2_ROOT6_X branch.
