### PR TITLE
condformats_serialization_generate.py: support for aarch64

### DIFF
--- a/CondFormats/Serialization/python/condformats_serialization_generate.py
+++ b/CondFormats/Serialization/python/condformats_serialization_generate.py
@@ -76,10 +76,10 @@ def is_definition_by_loc(node):
 
 def is_serializable_class(node):
     for child in node.get_children():
-        if child.spelling != 'serialize' or child.kind != clang.cindex.CursorKind.FUNCTION_TEMPLATE or child.is_definition():
+        if child.spelling != 'serialize' or child.kind != clang.cindex.CursorKind.FUNCTION_TEMPLATE or is_definition_by_loc(child):
             continue
 
-        if [(x.spelling, x.kind, x.is_definition(), x.type.kind) for x in child.get_children()] != [
+        if [(x.spelling, x.kind, is_definition_by_loc(x), x.type.kind) for x in child.get_children()] != [
             ('Archive', clang.cindex.CursorKind.TEMPLATE_TYPE_PARAMETER, True, clang.cindex.TypeKind.UNEXPOSED),
             ('ar', clang.cindex.CursorKind.PARM_DECL, True, clang.cindex.TypeKind.LVALUEREFERENCE),
             ('version', clang.cindex.CursorKind.PARM_DECL, True, clang.cindex.TypeKind.UINT),

--- a/CondFormats/Serialization/python/condformats_serialization_generate.py
+++ b/CondFormats/Serialization/python/condformats_serialization_generate.py
@@ -67,6 +67,12 @@ skip_namespaces = frozenset([
     'ROOT', 'edm', 'ora', 'coral', 'CLHEP', 'Geom', 'HepGeom',
 ])
 
+def is_definition_by_loc(node):
+    if node.get_definition() is None:
+        return False
+    if node.location is None or node.get_definition().location is None:
+        return False
+    return node.location == node.get_definition().location
 
 def is_serializable_class(node):
     for child in node.get_children():
@@ -87,7 +93,7 @@ def is_serializable_class(node):
 
 def is_serializable_class_manual(node):
     for child in node.get_children():
-        if child.spelling == 'cond_serialization_manual' and child.kind == clang.cindex.CursorKind.CXX_METHOD and not child.is_definition():
+        if child.spelling == 'cond_serialization_manual' and child.kind == clang.cindex.CursorKind.CXX_METHOD and not is_definition_by_loc(child):
             return True
 
     return False
@@ -158,7 +164,7 @@ def get_serializable_classes_members(node, all_template_types=None, namespace=''
             results.update(get_serializable_classes_members(child, all_template_types, namespace + child.spelling + '::', only_from_path))
             continue
 
-        if child.kind in [clang.cindex.CursorKind.CLASS_DECL, clang.cindex.CursorKind.STRUCT_DECL, clang.cindex.CursorKind.CLASS_TEMPLATE] and child.is_definition():
+        if child.kind in [clang.cindex.CursorKind.CLASS_DECL, clang.cindex.CursorKind.STRUCT_DECL, clang.cindex.CursorKind.CLASS_TEMPLATE] and is_definition_by_loc(child):
             logging.debug('Found struct/class/template definition: %s', child.spelling if child.spelling else '<anonymous>')
 
             if only_from_path is not None \
@@ -222,7 +228,7 @@ def get_serializable_classes_members(node, all_template_types=None, namespace=''
                     base_objects.append(base_object)
 
                 # Member variables
-                elif member.kind == clang.cindex.CursorKind.FIELD_DECL and member.is_definition():
+                elif member.kind == clang.cindex.CursorKind.FIELD_DECL and is_definition_by_loc(member):
                     # While clang 3.3 does not ignore unrecognized attributes
                     # (see http://llvm.org/viewvc/llvm-project?revision=165082&view=revision )
                     # for some reason they do not appear in the bindings yet


### PR DESCRIPTION
`libClang` seems to act differently on AArch64 causing `condformats_serialization_generate.py` always to select 0 classes. It happens that `is_definition()` on AST node mostly returns false.

Even on such small examples:

```
$ cat my.h
struct timespec
{
  int tv_sec;
  int tv_nsec;
};
```

On Fedora 20 on x86_64 

```
displayname: timespec, kind: CursorKind.STRUCT_DECL, is_definition: True,  location:<SourceLocation file 'my.h', line 1, column 8>
>> get_definition().location: <SourceLocation file 'my.h', line 1, column 8>
```

On Fedora 19 on aarch64

```
displayname: timespec, kind: CursorKind.STRUCT_DECL, is_definition: False,  location:<SourceLocation file 'my.h', line 1, column 8>
>> get_definition().location: <SourceLocation file 'my.h', line 1, column 8>
```

Change checks if node (declaration record) and it's definition location (file, line and column) match. If match is found, it's a definition.

Details from `libClang` side:

```
Breakpoint 1, clang_isCursorDefinition (C=...)
   at /home/david.abdurachmanov/new-arch/test/BUILD/fc19_aarch64_gcc490/external/llvm/3.4-cms2/llvm-3.4-6800b6d2afc/tools/clang/tools/libclang/CIndex.cpp:4709
4709      if (!clang_isDeclaration(C.kind))
(gdb) p C
$1 = {kind = CXCursor_ClassDecl, xdata = 0, data = {0x7fb39e60e0, 0x0, 0x7fb000cfb0}}
(gdb) p clang_getCString(clang_getCursorDisplayName(C))
$2 = 0x9a5cd0 "RunNumber"
(gdb) p C.
data   kind   xdata
(gdb) set $foo = clang_getCursorDefinition(C)
(gdb) p $foo
$3 = {kind = CXCursor_ClassDecl, xdata = 0, data = {0x7fb39e60e0, 0x1, 0x7fb000cfb0}}

As you can see C != clang_getCursorDefinition(C), because C.data[1] != clang_getCursorDefinition(C).data[1]

clang::cxcursor::operator== (X=..., Y=...)
   at /home/david.abdurachmanov/new-arch/test/BUILD/fc19_aarch64_gcc490/external/llvm/3.4-cms2/llvm-3.4-6800b6d2afc/tools/clang/tools/libclang/CXCursor.cpp:936
936       return X.kind == Y.kind && X.data[0] == Y.data[0] && X.data[1] == Y.data[1] &&
(gdb) info args
X = {kind = CXCursor_ClassDecl, xdata = 0, data = {0x7fb39e60e0, 0x1, 0x7fb000cfb0}}
Y = {kind = CXCursor_ClassDecl, xdata = 0, data = {0x7fb39e60e0, 0x0, 0x7fb000cfb0}}
```

`data[1]` seems to `SourceLocation.ID`.

I compared md5 hashes of `Serialization.cc` files using untouched and modified `condformats_serialization_generate.py`. All were identical.

This is my initial proposal until I understand better the difference in libClang behavior on aarch64 and x86_64, or it's fixed in upstream.
