### PR TITLE
added configuration for new UE tunes P6 and P8

### DIFF
--- a/Configuration/Generator/python/Hadronizer_MgmMatchTuneCUEP6S1_13TeV_madgraph_pythia6_cff.py
+++ b/Configuration/Generator/python/Hadronizer_MgmMatchTuneCUEP6S1_13TeV_madgraph_pythia6_cff.py
@@ -1,0 +1,33 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia6_CUEP6S1Settings_cfi import *
+
+generator = cms.EDFilter("Pythia6HadronizerFilter",
+    pythiaHepMCVerbosity = cms.untracked.bool(True),
+    maxEventsToPrint = cms.untracked.int32(0),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    comEnergy = cms.double(13000.0),
+    PythiaParameters = cms.PSet(
+        pythia6CUEP6S1SettingsBlock,
+        processParameters = cms.vstring('MSEL=0 ! User defined processes',
+                        'PMAS(5,1)=4.8 ! b quark mass',
+                        'PMAS(6,1)=172.5 ! t quark mass',
+'MSTJ(1)=1 ! Fragmentation/hadronization on or off',
+'MSTP(61)=1 ! Parton showering on or off'),
+        # This is a vector of ParameterSet names to be read, in this order
+        parameterSets = cms.vstring('pythia6CUEP6S1Settings',
+            'processParameters')
+    ),
+    jetMatching = cms.untracked.PSet(
+       scheme = cms.string("Madgraph"),
+       mode = cms.string("auto"),	# soup, or "inclusive" / "exclusive"
+       MEMAIN_nqmatch = cms.int32(5),
+       MEMAIN_etaclmax = cms.double(-1),
+       MEMAIN_qcut = cms.double(-1),
+       MEMAIN_minjets = cms.int32(-1),
+       MEMAIN_maxjets = cms.int32(-1),
+       MEMAIN_showerkt = cms.double(0),
+       MEMAIN_excres = cms.string(""),
+       outTree_flag = cms.int32(0)
+    )
+)

--- a/Configuration/Generator/python/Hadronizer_MgmMatchTuneCUEP6S1_8TeV_madgraph_pythia6_cff.py
+++ b/Configuration/Generator/python/Hadronizer_MgmMatchTuneCUEP6S1_8TeV_madgraph_pythia6_cff.py
@@ -1,0 +1,33 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia6_CUEP6S1Settings_cfi import *
+
+generator = cms.EDFilter("Pythia6HadronizerFilter",
+    pythiaHepMCVerbosity = cms.untracked.bool(True),
+    maxEventsToPrint = cms.untracked.int32(0),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    comEnergy = cms.double(8000.0),
+    PythiaParameters = cms.PSet(
+        pythia6CUEP6S1SettingsBlock,
+        processParameters = cms.vstring('MSEL=0 ! User defined processes',
+                        'PMAS(5,1)=4.8 ! b quark mass',
+                        'PMAS(6,1)=172.5 ! t quark mass',
+                                        'MSTJ(1)=1 ! Fragmentation/hadronization on or off',
+                                        'MSTP(61)=1 ! Parton showering on or off'),
+        # This is a vector of ParameterSet names to be read, in this order
+        parameterSets = cms.vstring('pythia6CUEP6S1Settings',
+                                    'processParameters')
+        ),
+     jetMatching = cms.untracked.PSet(
+        scheme = cms.string("Madgraph"),
+        mode = cms.string("auto"),	# soup, or "inclusive" / "exclusive"
+        MEMAIN_nqmatch = cms.int32(5),
+       MEMAIN_etaclmax = cms.double(-1),
+       MEMAIN_qcut = cms.double(-1),
+       MEMAIN_minjets = cms.int32(-1),
+       MEMAIN_maxjets = cms.int32(-1),
+       MEMAIN_showerkt = cms.double(0),
+       MEMAIN_excres = cms.string(""),
+       outTree_flag = cms.int32(0)
+    )
+)

--- a/Configuration/Generator/python/Hadronizer_MgmMatchTuneCUEP8S1CTEQ6L1_13TeV_madgraph_pythia8_Tauola_cff.py
+++ b/Configuration/Generator/python/Hadronizer_MgmMatchTuneCUEP8S1CTEQ6L1_13TeV_madgraph_pythia8_Tauola_cff.py
@@ -1,0 +1,45 @@
+import FWCore.ParameterSet.Config as cms
+from GeneratorInterface.ExternalDecays.TauolaSettings_cff import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+                         ExternalDecays = cms.PSet(
+        Tauola = cms.untracked.PSet(
+            TauolaPolar,
+            TauolaDefaultInputCards
+            ),
+        parameterSets = cms.vstring('Tauola')
+        ),
+                         UseExternalGenerators = cms.untracked.bool(True),
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13000.),
+                         jetMatching = cms.untracked.PSet(
+        scheme = cms.string("Madgraph"),
+        mode = cms.string("auto"),# soup, or "inclusive" / "exclusive"
+        MEMAIN_etaclmax = cms.double(-1),
+        MEMAIN_qcut = cms.double(-1),
+        MEMAIN_minjets = cms.int32(-1),
+        MEMAIN_maxjets = cms.int32(-1),
+        MEMAIN_showerkt = cms.double(0), # use 1=yes only for pt-ordered showers !
+        MEMAIN_nqmatch = cms.int32(5), #PID of the flavor until which the QCD radiation are kept in the matching procedure;
+        # if nqmatch=4, then all showered partons from b's are NOT taken into account
+        # Note (JY): I think the default should be 5 (b); anyway, don't try -1 as it'll result in a throw...
+        MEMAIN_excres = cms.string(""),
+        outTree_flag = cms.int32(0) # 1=yes, write out the tree for future sanity check
+        ),
+                         PythiaParameters = cms.PSet(
+        processParameters = cms.vstring(
+            'Main:timesAllowErrors = 10000',
+            'ParticleDecays:tauMax = 10',
+            'Tune:ee 3',
+            'Tune:pp 5',
+            'MultipleInteractions:pT0Ref=2.1006',
+            'MultipleInteractions:ecmPow=0.21057',
+            'MultipleInteractions:expPow=1.6089',
+            'BeamRemnants:reconnectRange=3.31257',
+            ),
+    parameterSets = cms.vstring('processParameters')
+    )
+)

--- a/Configuration/Generator/python/Hadronizer_MgmMatchTuneCUEP8S1CTEQ6L1_8TeV_madgraph_pythia8_Tauola_cff.py
+++ b/Configuration/Generator/python/Hadronizer_MgmMatchTuneCUEP8S1CTEQ6L1_8TeV_madgraph_pythia8_Tauola_cff.py
@@ -1,0 +1,45 @@
+import FWCore.ParameterSet.Config as cms
+from GeneratorInterface.ExternalDecays.TauolaSettings_cff import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+                         ExternalDecays = cms.PSet(
+        Tauola = cms.untracked.PSet(
+            TauolaPolar,
+            TauolaDefaultInputCards
+            ),
+        parameterSets = cms.vstring('Tauola')
+        ),
+                         UseExternalGenerators = cms.untracked.bool(True),
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(8000.),
+                         jetMatching = cms.untracked.PSet(
+        scheme = cms.string("Madgraph"),
+        mode = cms.string("auto"),# soup, or "inclusive" / "exclusive"
+        MEMAIN_etaclmax = cms.double(-1),
+        MEMAIN_qcut = cms.double(-1),
+        MEMAIN_minjets = cms.int32(-1),
+        MEMAIN_maxjets = cms.int32(-1),
+        MEMAIN_showerkt = cms.double(0), # use 1=yes only for pt-ordered showers !
+        MEMAIN_nqmatch = cms.int32(5), #PID of the flavor until which the QCD radiation are kept in the matching procedure;
+        # if nqmatch=4, then all showered partons from b's are NOT taken into account
+        # Note (JY): I think the default should be 5 (b); anyway, don't try -1 as it'll result in a throw...
+        MEMAIN_excres = cms.string(""),
+        outTree_flag = cms.int32(0) # 1=yes, write out the tree for future sanity check
+        ),
+                         PythiaParameters = cms.PSet(
+        processParameters = cms.vstring(
+            'Main:timesAllowErrors = 10000',
+            'ParticleDecays:tauMax = 10',
+            'Tune:ee 3',
+            'Tune:pp 5',
+            'MultipleInteractions:pT0Ref=2.1006',
+            'MultipleInteractions:ecmPow=0.21057',
+            'MultipleInteractions:expPow=1.6089',
+            'BeamRemnants:reconnectRange=3.31257',
+            ),
+    parameterSets = cms.vstring('processParameters')
+    )
+)

--- a/Configuration/Generator/python/Hadronizer_MgmMatchTuneCUEP8S1Herapdf15LO_13TeV_madgraph_pythia8_Tauola_cff.py
+++ b/Configuration/Generator/python/Hadronizer_MgmMatchTuneCUEP8S1Herapdf15LO_13TeV_madgraph_pythia8_Tauola_cff.py
@@ -1,0 +1,47 @@
+import FWCore.ParameterSet.Config as cms
+from GeneratorInterface.ExternalDecays.TauolaSettings_cff import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+                         ExternalDecays = cms.PSet(
+        Tauola = cms.untracked.PSet(
+            TauolaPolar,
+            TauolaDefaultInputCards
+            ),
+        parameterSets = cms.vstring('Tauola')
+        ),
+                         UseExternalGenerators = cms.untracked.bool(True),
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13000.),
+                         jetMatching = cms.untracked.PSet(
+        scheme = cms.string("Madgraph"),
+        mode = cms.string("auto"),# soup, or "inclusive" / "exclusive"
+        MEMAIN_etaclmax = cms.double(-1),
+        MEMAIN_qcut = cms.double(-1),
+        MEMAIN_minjets = cms.int32(-1),
+        MEMAIN_maxjets = cms.int32(-1),
+        MEMAIN_showerkt = cms.double(0), # use 1=yes only for pt-ordered showers !
+        MEMAIN_nqmatch = cms.int32(5), #PID of the flavor until which the QCD radiation are kept in the matching procedure;
+        # if nqmatch=4, then all showered partons from b's are NOT taken into account
+        # Note (JY): I think the default should be 5 (b); anyway, don't try -1 as it'll result in a throw...
+        MEMAIN_excres = cms.string(""),
+        outTree_flag = cms.int32(0) # 1=yes, write out the tree for future sanity check
+        ),
+                         PythiaParameters = cms.PSet(
+        processParameters = cms.vstring(
+            'Main:timesAllowErrors = 10000',
+            'ParticleDecays:tauMax = 10',
+            'Tune:ee 3',
+            'Tune:pp 5',
+            'PDF:useLHAPDF=on',
+            'PDF:LHAPDFset=HERAPDF1.5LO_EIG.LHgrid',
+            'MultipleInteractions:pT0Ref=2.000072e+00',
+            'MultipleInteractions:ecmPow=2.498802e-01',
+            'MultipleInteractions:expPow=1.690506e+00',
+            'BeamRemnants:reconnectRange=6.096364e+00',
+            ),
+    parameterSets = cms.vstring('processParameters')
+    )
+)

--- a/Configuration/Generator/python/Hadronizer_MgmMatchTuneCUEP8S1Herapdf15LO_8TeV_madgraph_pythia8_Tauola_cff.py
+++ b/Configuration/Generator/python/Hadronizer_MgmMatchTuneCUEP8S1Herapdf15LO_8TeV_madgraph_pythia8_Tauola_cff.py
@@ -1,0 +1,47 @@
+import FWCore.ParameterSet.Config as cms
+from GeneratorInterface.ExternalDecays.TauolaSettings_cff import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+                         ExternalDecays = cms.PSet(
+        Tauola = cms.untracked.PSet(
+            TauolaPolar,
+            TauolaDefaultInputCards
+            ),
+        parameterSets = cms.vstring('Tauola')
+        ),
+                         UseExternalGenerators = cms.untracked.bool(True),
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(8000.),
+                         jetMatching = cms.untracked.PSet(
+        scheme = cms.string("Madgraph"),
+        mode = cms.string("auto"),# soup, or "inclusive" / "exclusive"
+        MEMAIN_etaclmax = cms.double(-1),
+        MEMAIN_qcut = cms.double(-1),
+        MEMAIN_minjets = cms.int32(-1),
+        MEMAIN_maxjets = cms.int32(-1),
+        MEMAIN_showerkt = cms.double(0), # use 1=yes only for pt-ordered showers !
+        MEMAIN_nqmatch = cms.int32(5), #PID of the flavor until which the QCD radiation are kept in the matching procedure;
+        # if nqmatch=4, then all showered partons from b's are NOT taken into account
+        # Note (JY): I think the default should be 5 (b); anyway, don't try -1 as it'll result in a throw...
+        MEMAIN_excres = cms.string(""),
+        outTree_flag = cms.int32(0) # 1=yes, write out the tree for future sanity check
+        ),
+                         PythiaParameters = cms.PSet(
+        processParameters = cms.vstring(
+            'Main:timesAllowErrors = 10000',
+            'ParticleDecays:tauMax = 10',
+            'Tune:ee 3',
+            'Tune:pp 5',
+            'PDF:useLHAPDF=on',
+            'PDF:LHAPDFset=HERAPDF1.5LO_EIG.LHgrid',
+            'MultipleInteractions:pT0Ref=2.000072e+00',
+            'MultipleInteractions:ecmPow=2.498802e-01',
+            'MultipleInteractions:expPow=1.690506e+00',
+            'BeamRemnants:reconnectRange=6.096364e+00',
+            ),
+    parameterSets = cms.vstring('processParameters')
+    )
+)

--- a/Configuration/Generator/python/Hadronizer_TuneCUEP8S1CTEQ6L1_13TeV_generic_LHE_pythia8_Tauola_cff.py
+++ b/Configuration/Generator/python/Hadronizer_TuneCUEP8S1CTEQ6L1_13TeV_generic_LHE_pythia8_Tauola_cff.py
@@ -1,0 +1,32 @@
+import FWCore.ParameterSet.Config as cms
+
+from GeneratorInterface.ExternalDecays.TauolaSettings_cff import *
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+                         ExternalDecays = cms.PSet(
+    Tauola = cms.untracked.PSet(
+    TauolaPolar,
+    TauolaDefaultInputCards
+    ),
+    parameterSets = cms.vstring('Tauola')
+    ),
+                         UseExternalGenerators = cms.untracked.bool(True),
+                         
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13000.),
+                         PythiaParameters = cms.PSet(
+    processParameters = cms.vstring(
+    'Main:timesAllowErrors = 10000',
+    'ParticleDecays:tauMax = 10',
+    'Tune:ee 3',
+    'Tune:pp 5',
+    'MultipleInteractions:pT0Ref=2.1006',
+    'MultipleInteractions:ecmPow=0.21057',
+    'MultipleInteractions:expPow=1.6089',
+    'BeamRemnants:reconnectRange=3.31257',
+    ),
+    parameterSets = cms.vstring('processParameters')
+    )
+                         )

--- a/Configuration/Generator/python/Hadronizer_TuneCUEP8S1CTEQ6L1_8TeV_generic_LHE_pythia8_Tauola_cff.py
+++ b/Configuration/Generator/python/Hadronizer_TuneCUEP8S1CTEQ6L1_8TeV_generic_LHE_pythia8_Tauola_cff.py
@@ -1,0 +1,32 @@
+import FWCore.ParameterSet.Config as cms
+
+from GeneratorInterface.ExternalDecays.TauolaSettings_cff import *
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+                         ExternalDecays = cms.PSet(
+    Tauola = cms.untracked.PSet(
+    TauolaPolar,
+    TauolaDefaultInputCards
+    ),
+    parameterSets = cms.vstring('Tauola')
+    ),
+                         UseExternalGenerators = cms.untracked.bool(True),
+                         
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(8000.),
+                         PythiaParameters = cms.PSet(
+    processParameters = cms.vstring(
+    'Main:timesAllowErrors = 10000',
+    'ParticleDecays:tauMax = 10',
+    'Tune:ee 3',
+    'Tune:pp 5',
+    'MultipleInteractions:pT0Ref=2.1006',
+    'MultipleInteractions:ecmPow=0.21057',
+    'MultipleInteractions:expPow=1.6089',
+    'BeamRemnants:reconnectRange=3.31257',
+    ),
+    parameterSets = cms.vstring('processParameters')
+    )
+ )

--- a/Configuration/Generator/python/Hadronizer_TuneCUEP8S1Herapdf15LO_13TeV_generic_LHE_pythia8_Tauola_cff.py
+++ b/Configuration/Generator/python/Hadronizer_TuneCUEP8S1Herapdf15LO_13TeV_generic_LHE_pythia8_Tauola_cff.py
@@ -1,0 +1,34 @@
+import FWCore.ParameterSet.Config as cms
+
+from GeneratorInterface.ExternalDecays.TauolaSettings_cff import *
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+                         ExternalDecays = cms.PSet(
+    Tauola = cms.untracked.PSet(
+    TauolaPolar,
+    TauolaDefaultInputCards
+    ),
+    parameterSets = cms.vstring('Tauola')
+    ),
+                         UseExternalGenerators = cms.untracked.bool(True),
+                         
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13000.),
+                         PythiaParameters = cms.PSet(
+    processParameters = cms.vstring(
+    'Main:timesAllowErrors = 10000',
+    'ParticleDecays:tauMax = 10',
+    'Tune:ee 3',
+    'Tune:pp 5',
+    'PDF:useLHAPDF=on',
+    'PDF:LHAPDFset=HERAPDF1.5LO_EIG.LHgrid',
+    'MultipleInteractions:pT0Ref=2.000072e+00',
+    'MultipleInteractions:ecmPow=2.498802e-01',
+    'MultipleInteractions:expPow=1.690506e+00',
+    'BeamRemnants:reconnectRange=6.096364e+00',
+    ),
+    parameterSets = cms.vstring('processParameters')
+    )
+                         )

--- a/Configuration/Generator/python/Hadronizer_TuneCUEP8S1Herapdf15LO_8TeV_generic_LHE_pythia8_Tauola_cff.py
+++ b/Configuration/Generator/python/Hadronizer_TuneCUEP8S1Herapdf15LO_8TeV_generic_LHE_pythia8_Tauola_cff.py
@@ -1,0 +1,34 @@
+import FWCore.ParameterSet.Config as cms
+
+from GeneratorInterface.ExternalDecays.TauolaSettings_cff import *
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+                         ExternalDecays = cms.PSet(
+    Tauola = cms.untracked.PSet(
+    TauolaPolar,
+    TauolaDefaultInputCards
+    ),
+    parameterSets = cms.vstring('Tauola')
+    ),
+                         UseExternalGenerators = cms.untracked.bool(True),
+                         
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(8000.),
+                         PythiaParameters = cms.PSet(
+    processParameters = cms.vstring(
+    'Main:timesAllowErrors = 10000',
+    'ParticleDecays:tauMax = 10',
+    'Tune:ee 3',
+    'Tune:pp 5',
+    'PDF:useLHAPDF=on',
+    'PDF:LHAPDFset=HERAPDF1.5LO_EIG.LHgrid',
+    'MultipleInteractions:pT0Ref=2.000072e+00',
+    'MultipleInteractions:ecmPow=2.498802e-01',
+    'MultipleInteractions:expPow=1.690506e+00',
+    'BeamRemnants:reconnectRange=6.096364e+00',
+    ),
+    parameterSets = cms.vstring('processParameters')
+    )
+                         )

--- a/Configuration/Generator/python/Pythia6CUEP6S1Settings_cfi.py
+++ b/Configuration/Generator/python/Pythia6CUEP6S1Settings_cfi.py
@@ -1,0 +1,37 @@
+import FWCore.ParameterSet.Config as cms
+
+pythia6CUEP6S1SettingsBlock = cms.PSet(
+    pythia6CUEP6S1Settings = cms.vstring('MSTU(21)=1     ! Check on possible errors during program execution', 
+            'MSTJ(22)=2     ! Decay those unstable particles', 
+            'PARJ(71)=10 .  ! for which ctau  10 mm', 
+            'MSTP(33)=0     ! no K factors in hard cross sections', 
+            'MSTP(2)=1      ! which order running alphaS', 
+            'MSTP(51)=10042 ! structure function chosen (external PDF CTEQ6L1)', 
+            'MSTP(52)=2     ! work with LHAPDF', 
+    	    'PARP(82)=1.9096 ! pt cutoff for multiparton interactions', 
+            'PARP(89)=1800. ! sqrts for which PARP82 is set', 
+            'PARP(90)=0.2479! Multiple interactions: rescaling power', 
+            'MSTP(95)=6     ! CR (color reconnection parameters)', 
+            'PARP(77)=0.6646 ! CR', 
+            'PARP(78)=0.5454 ! CR', 
+            'PARP(80)=0.1   ! Prob. colored parton from BBR', 
+            'PARP(83)=0.8217 ! Multiple interactions: matter distribution parameter', 
+            'PARP(84)=0.651 ! Multiple interactions: matter distribution parameter', 
+            'PARP(62)=1.025 ! ISR cutoff', 
+            'MSTP(91)=1     ! Gaussian primordial kT', 
+            'PARP(93)=10.0  ! primordial kT-max', 
+            'MSTP(81)=21    ! multiple parton interactions 1 is Pythia default', 
+            'MSTP(82)=4     ! Defines the multi-parton model',
+            'PARJ(1) =  0.08 ! HAD diquark suppression',
+            'PARJ(2) = 0.21 ! HAD strangeness suppression',
+            'PARJ(3) = 0.94 ! HAD strange diquark suppression',
+            'PARJ(4) = 0.04 ! HAD vectior diquark suppression',
+            'PARJ(11) = 0.35 ! HAD P(vector meson), u and d only',
+            'PARJ(12) = 0.35 ! HAD P(vector meson) contains ',
+            'PARJ(13) = 0.54 ! HAD P(vector meson), heavy quarks',
+            'PARJ(21) = 0.34 ! HAD fragmentation pt',
+            'PARJ(25) = 0.63 ! HAD eta0 suppression',
+            'PARJ(26) = 0.12 ! HAD eta0 suppression'
+   )
+)
+

--- a/Configuration/Generator/python/Pythia8CUEP8S1CTEQ6L1Settings_cfi.py
+++ b/Configuration/Generator/python/Pythia8CUEP8S1CTEQ6L1Settings_cfi.py
@@ -1,0 +1,13 @@
+import FWCore.ParameterSet.Config as cms
+
+pythia8CUEP8S1cteqSettingsBlock = cms.PSet(
+    pythia8CUEP8S1cteqSettings = cms.vstring(
+        'Tune:pp 5',
+        'Tune:ee 3',
+        'MultipleInteractions:pT0Ref=2.1006',
+        'MultipleInteractions:ecmPow=0.21057',
+        'MultipleInteractions:expPow=1.6089',
+	'BeamRemnants:reconnectRange=3.31257',
+   )
+)
+

--- a/Configuration/Generator/python/Pythia8CUEP8S1Herapdf15LOSettings_cfi.py
+++ b/Configuration/Generator/python/Pythia8CUEP8S1Herapdf15LOSettings_cfi.py
@@ -1,0 +1,15 @@
+import FWCore.ParameterSet.Config as cms
+
+pythia8CUEP8S1herapdfSettingsBlock = cms.PSet(
+    pythia8CUEP8S1herapdfSettings = cms.vstring(
+        'Tune:pp 5',
+        'Tune:ee 3',
+        'PDF:useLHAPDF=on',
+	'PDF:LHAPDFset=HERAPDF1.5LO_EIG.LHgrid',
+        'MultipleInteractions:pT0Ref=2.000072e+00',
+	'MultipleInteractions:ecmPow=2.498802e-01',
+	'MultipleInteractions:expPow=1.690506e+00',
+	'BeamRemnants:reconnectRange=6.096364e+00',        
+   )
+)
+

--- a/genproductions/python/EightTeV/Hadronizer_MgmMatchTuneCUEP6S1_8TeV_madgraph_pythia6_cff.py
+++ b/genproductions/python/EightTeV/Hadronizer_MgmMatchTuneCUEP6S1_8TeV_madgraph_pythia6_cff.py
@@ -1,0 +1,33 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia6CUEP6S1Settings_cfi import *
+
+generator = cms.EDFilter("Pythia6HadronizerFilter",
+    pythiaHepMCVerbosity = cms.untracked.bool(True),
+    maxEventsToPrint = cms.untracked.int32(0),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    comEnergy = cms.double(8000.0),
+    PythiaParameters = cms.PSet(
+        pythia6CUEP6S1SettingsBlock,
+        processParameters = cms.vstring('MSEL=0 ! User defined processes',
+                        'PMAS(5,1)=4.8 ! b quark mass',
+                        'PMAS(6,1)=172.5 ! t quark mass',
+                        'MSTJ(1)=1 ! Fragmentation/hadronization on or off',
+                        'MSTP(61)=1 ! Parton showering on or off'),
+        # This is a vector of ParameterSet names to be read, in this order
+        parameterSets = cms.vstring('pythia6CUEP6S1Settings',
+                                    'processParameters')
+        ),
+     jetMatching = cms.untracked.PSet(
+        scheme = cms.string("Madgraph"),
+        mode = cms.string("auto"),	# soup, or "inclusive" / "exclusive"
+        MEMAIN_nqmatch = cms.int32(5),
+       MEMAIN_etaclmax = cms.double(-1),
+       MEMAIN_qcut = cms.double(-1),
+       MEMAIN_minjets = cms.int32(-1),
+       MEMAIN_maxjets = cms.int32(-1),
+       MEMAIN_showerkt = cms.double(0),
+       MEMAIN_excres = cms.string(""),
+       outTree_flag = cms.int32(0)
+    )
+)

--- a/genproductions/python/EightTeV/Hadronizer_MgmMatchTuneCUEP8S1CTEQ6L1_8TeV_madgraph_pythia8_Tauola_cff.py
+++ b/genproductions/python/EightTeV/Hadronizer_MgmMatchTuneCUEP8S1CTEQ6L1_8TeV_madgraph_pythia8_Tauola_cff.py
@@ -1,0 +1,42 @@
+import FWCore.ParameterSet.Config as cms
+from GeneratorInterface.ExternalDecays.TauolaSettings_cff import *
+from Configuration.Generator.Pythia8CUEP8S1CTEQ6L1Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+                         ExternalDecays = cms.PSet(
+        Tauola = cms.untracked.PSet(
+            TauolaPolar,
+            TauolaDefaultInputCards
+            ),
+        parameterSets = cms.vstring('Tauola')
+        ),
+                         UseExternalGenerators = cms.untracked.bool(True),
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(8000.),
+                         jetMatching = cms.untracked.PSet(
+        scheme = cms.string("Madgraph"),
+        mode = cms.string("auto"),# soup, or "inclusive" / "exclusive"
+        MEMAIN_etaclmax = cms.double(-1),
+        MEMAIN_qcut = cms.double(-1),
+        MEMAIN_minjets = cms.int32(-1),
+        MEMAIN_maxjets = cms.int32(-1),
+        MEMAIN_showerkt = cms.double(0), # use 1=yes only for pt-ordered showers !
+        MEMAIN_nqmatch = cms.int32(5), #PID of the flavor until which the QCD radiation are kept in the matching procedure;
+        # if nqmatch=4, then all showered partons from b's are NOT taken into account
+        # Note (JY): I think the default should be 5 (b); anyway, don't try -1 as it'll result in a throw...
+        MEMAIN_excres = cms.string(""),
+        outTree_flag = cms.int32(0) # 1=yes, write out the tree for future sanity check
+        ),
+                         PythiaParameters = cms.PSet(
+        pythia8CUEP8S1cteqSettingsBlock,
+        processParameters = cms.vstring(
+            'Main:timesAllowErrors = 10000',
+            'ParticleDecays:tauMax = 10',
+            ),
+    parameterSets = cms.vstring('pythia8CUEP8S1cteqSettings',
+                                'ProcessParameters')
+    )
+)

--- a/genproductions/python/EightTeV/Hadronizer_MgmMatchTuneCUEP8S1Herapdf15LO_8TeV_madgraph_pythia8_Tauola_cff.py
+++ b/genproductions/python/EightTeV/Hadronizer_MgmMatchTuneCUEP8S1Herapdf15LO_8TeV_madgraph_pythia8_Tauola_cff.py
@@ -1,0 +1,42 @@
+import FWCore.ParameterSet.Config as cms
+from GeneratorInterface.ExternalDecays.TauolaSettings_cff import *
+from Configuration.Generator.Pythia8CUEP8S1Herapdf15LOSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+                         ExternalDecays = cms.PSet(
+        Tauola = cms.untracked.PSet(
+            TauolaPolar,
+            TauolaDefaultInputCards
+            ),
+        parameterSets = cms.vstring('Tauola')
+        ),
+                         UseExternalGenerators = cms.untracked.bool(True),
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(8000.),
+                         jetMatching = cms.untracked.PSet(
+        scheme = cms.string("Madgraph"),
+        mode = cms.string("auto"),# soup, or "inclusive" / "exclusive"
+        MEMAIN_etaclmax = cms.double(-1),
+        MEMAIN_qcut = cms.double(-1),
+        MEMAIN_minjets = cms.int32(-1),
+        MEMAIN_maxjets = cms.int32(-1),
+        MEMAIN_showerkt = cms.double(0), # use 1=yes only for pt-ordered showers !
+        MEMAIN_nqmatch = cms.int32(5), #PID of the flavor until which the QCD radiation are kept in the matching procedure;
+        # if nqmatch=4, then all showered partons from b's are NOT taken into account
+        # Note (JY): I think the default should be 5 (b); anyway, don't try -1 as it'll result in a throw...
+        MEMAIN_excres = cms.string(""),
+        outTree_flag = cms.int32(0) # 1=yes, write out the tree for future sanity check
+        ),
+                         PythiaParameters = cms.PSet(
+        pythia8CUEP8S1herapdfSettingsBlock,
+        processParameters = cms.vstring(
+            'Main:timesAllowErrors = 10000',
+            'ParticleDecays:tauMax = 10',
+            ),
+    parameterSets = cms.vstring('pythia8CUEP8S1herapdfSettings',
+                                'processParameters')
+    )
+)

--- a/genproductions/python/EightTeV/Hadronizer_TuneCUEP8S1CTEQ6L1_8TeV_generic_LHE_pythia8_Tauola_cff.py
+++ b/genproductions/python/EightTeV/Hadronizer_TuneCUEP8S1CTEQ6L1_8TeV_generic_LHE_pythia8_Tauola_cff.py
@@ -1,0 +1,29 @@
+import FWCore.ParameterSet.Config as cms
+
+from GeneratorInterface.ExternalDecays.TauolaSettings_cff import *
+from Configuration.Generator.Pythia8CUEP8S1CTEQ6L1Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+                         ExternalDecays = cms.PSet(
+        Tauola = cms.untracked.PSet(
+            TauolaPolar,
+            TauolaDefaultInputCards
+            ),
+        parameterSets = cms.vstring('Tauola')
+        ),
+                         UseExternalGenerators = cms.untracked.bool(True),                        
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(8000.),
+                         PythiaParameters = cms.PSet(
+        pythia8CUEP8S1cteqSettingsBlock,
+        processParameters = cms.vstring(
+            'Main:timesAllowErrors = 10000',
+            'ParticleDecays:tauMax = 10',
+            ),
+        parameterSets = cms.vstring('pythia8CUEP8S1cteqSettings',
+                                    'processParameters')
+        )
+ )

--- a/genproductions/python/EightTeV/Hadronizer_TuneCUEP8S1Herapdf15LO_8TeV_generic_LHE_pythia8_Tauola_cff.py
+++ b/genproductions/python/EightTeV/Hadronizer_TuneCUEP8S1Herapdf15LO_8TeV_generic_LHE_pythia8_Tauola_cff.py
@@ -1,0 +1,29 @@
+import FWCore.ParameterSet.Config as cms
+
+from GeneratorInterface.ExternalDecays.TauolaSettings_cff import *
+from Configuration.Generator.Pythia8CUEP8S1Herapdf15LOSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+                         ExternalDecays = cms.PSet(
+        Tauola = cms.untracked.PSet(
+            TauolaPolar,
+            TauolaDefaultInputCards
+            ),
+        parameterSets = cms.vstring('Tauola')
+        ),
+                         UseExternalGenerators = cms.untracked.bool(True),                         
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(8000.),
+                         PythiaParameters = cms.PSet(
+        pythia8CUEP8S1herapdfSettingsBlock
+        processParameters = cms.vstring(
+            'Main:timesAllowErrors = 10000',
+            'ParticleDecays:tauMax = 10',
+            ),
+        parameterSets = cms.vstring('pythia8CUEP8S1herapdfSettings',
+                                    'processParameters')
+        )
+ )

--- a/genproductions/python/ThirteenTeV/Hadronizer_MgmMatchTuneCUEP6S1_13TeV_madgraph_pythia6_cff.py
+++ b/genproductions/python/ThirteenTeV/Hadronizer_MgmMatchTuneCUEP6S1_13TeV_madgraph_pythia6_cff.py
@@ -1,0 +1,33 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia6CUEP6S1Settings_cfi import *
+
+generator = cms.EDFilter("Pythia6HadronizerFilter",
+    pythiaHepMCVerbosity = cms.untracked.bool(True),
+    maxEventsToPrint = cms.untracked.int32(0),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    comEnergy = cms.double(13000.0),
+    PythiaParameters = cms.PSet(
+        pythia6CUEP6S1SettingsBlock,
+        processParameters = cms.vstring('MSEL=0 ! User defined processes',
+                        'PMAS(5,1)=4.8 ! b quark mass',
+                        'PMAS(6,1)=172.5 ! t quark mass',
+'MSTJ(1)=1 ! Fragmentation/hadronization on or off',
+'MSTP(61)=1 ! Parton showering on or off'),
+        # This is a vector of ParameterSet names to be read, in this order
+        parameterSets = cms.vstring('pythia6CUEP6S1Settings',
+            'processParameters')
+    ),
+    jetMatching = cms.untracked.PSet(
+       scheme = cms.string("Madgraph"),
+       mode = cms.string("auto"),	# soup, or "inclusive" / "exclusive"
+       MEMAIN_nqmatch = cms.int32(5),
+       MEMAIN_etaclmax = cms.double(-1),
+       MEMAIN_qcut = cms.double(-1),
+       MEMAIN_minjets = cms.int32(-1),
+       MEMAIN_maxjets = cms.int32(-1),
+       MEMAIN_showerkt = cms.double(0),
+       MEMAIN_excres = cms.string(""),
+       outTree_flag = cms.int32(0)
+    )
+)

--- a/genproductions/python/ThirteenTeV/Hadronizer_MgmMatchTuneCUEP8S1CTEQ6L1_13TeV_madgraph_pythia8_Tauola_cff.py
+++ b/genproductions/python/ThirteenTeV/Hadronizer_MgmMatchTuneCUEP8S1CTEQ6L1_13TeV_madgraph_pythia8_Tauola_cff.py
@@ -1,0 +1,41 @@
+import FWCore.ParameterSet.Config as cms
+from GeneratorInterface.ExternalDecays.TauolaSettings_cff import *
+from Configuration.Generator.Pythia8CUEP8S1CTEQ6L1Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+                         ExternalDecays = cms.PSet(
+        Tauola = cms.untracked.PSet(
+            TauolaPolar,
+            TauolaDefaultInputCards
+            ),
+        parameterSets = cms.vstring('Tauola')
+        ),
+                         UseExternalGenerators = cms.untracked.bool(True),
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13000.),
+                         jetMatching = cms.untracked.PSet(
+        scheme = cms.string("Madgraph"),
+        mode = cms.string("auto"),# soup, or "inclusive" / "exclusive"
+        MEMAIN_etaclmax = cms.double(-1),
+        MEMAIN_qcut = cms.double(-1),
+        MEMAIN_minjets = cms.int32(-1),
+        MEMAIN_maxjets = cms.int32(-1),
+        MEMAIN_showerkt = cms.double(0), # use 1=yes only for pt-ordered showers !
+        MEMAIN_nqmatch = cms.int32(5), #PID of the flavor until which the QCD radiation are kept in the matching procedure;
+        # if nqmatch=4, then all showered partons from b's are NOT taken into account
+        # Note (JY): I think the default should be 5 (b); anyway, don't try -1 as it'll result in a throw...
+        MEMAIN_excres = cms.string(""),
+        outTree_flag = cms.int32(0) # 1=yes, write out the tree for future sanity check
+        ),
+                         PythiaParameters = cms.PSet(
+        processParameters = cms.vstring(
+            'Main:timesAllowErrors = 10000',
+            'ParticleDecays:tauMax = 10',
+            ),
+    parameterSets = cms.vstring('pythia8CUEP8S1cteqSettings',
+                                'processParameters')
+    )
+)

--- a/genproductions/python/ThirteenTeV/Hadronizer_TuneCUEP8S1CTEQ6L1_13TeV_generic_LHE_pythia8_Tauola_cff.py
+++ b/genproductions/python/ThirteenTeV/Hadronizer_TuneCUEP8S1CTEQ6L1_13TeV_generic_LHE_pythia8_Tauola_cff.py
@@ -1,0 +1,29 @@
+import FWCore.ParameterSet.Config as cms
+
+from GeneratorInterface.ExternalDecays.TauolaSettings_cff import *
+from Configuration.Generator.Pythia8CUEP8S1CTEQ6L1Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+                         ExternalDecays = cms.PSet(
+        Tauola = cms.untracked.PSet(
+            TauolaPolar,
+            TauolaDefaultInputCards
+            ),
+        parameterSets = cms.vstring('Tauola')
+        ),
+                         UseExternalGenerators = cms.untracked.bool(True),                        
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13000.),
+                         PythiaParameters = cms.PSet(
+        pythia8CUEP8S1cteqSettingsBlock,
+        processParameters = cms.vstring(
+            'Main:timesAllowErrors = 10000',
+            'ParticleDecays:tauMax = 10',
+            ),
+        parameterSets = cms.vstring('pythia8CUEP8S1cteqSettings',
+                                    'processParameters')
+        )
+)


### PR DESCRIPTION
Added configuration for the new UE tunes (CUEP6S1, CUEP8S1, documented in GEN-14-001) and some examples of hadronizers for 8 and 13 TeV with the new UE tunes
