### PR TITLE
72X - update test input RelVal RecoMET/METProducers

### DIFF
--- a/RecoMET/METProducers/python/testInputFiles_cff.py
+++ b/RecoMET/METProducers/python/testInputFiles_cff.py
@@ -4,14 +4,14 @@ import FWCore.ParameterSet.Config as cms
 from PhysicsTools.PatAlgos.tools.cmsswVersionTools import pickRelValInputFiles
 recoMETtestInputFiles = pickRelValInputFiles(
     useDAS = True,
-    cmsswVersion = 'CMSSW_7_1_0_pre2',
+    cmsswVersion = 'CMSSW_7_1_0_pre4_AK4',
     dataTier = 'GEN-SIM-RECO',
     relVal = 'RelValTTbar_13',
-    globalTag = 'PU50ns_POSTLS170_V4'
+    globalTag = 'PU50ns_POSTLS171_V2',
+    maxVersions = 2
     )
 
 # recoMETtestInputFiles = [
-#     '/store/relval/CMSSW_7_1_0_pre2/RelValTTbar_13/GEN-SIM-RECO/PU50ns_POSTLS170_V4-v1/00000/FAA1E1EE-BE8F-E311-B633-0026189438BC.root',
+#     '/store/relval/CMSSW_7_1_0_pre4_AK4/RelValTTbar_13/GEN-SIM-RECO/PU50ns_POSTLS171_V2-v2/00000/1487CD0E-A4B3-E311-96D2-0025904C678A.root',
 #     ]
-
 ##____________________________________________________________________________||


### PR DESCRIPTION
This commit has been kindly dropped by @TaiSakuma originally from #3801 (71X "parent" version of #3942 ) in order not to conflict with #3938. After the issue the latter one addressed has been solved at its origin, #3938 became obsolete and was closed, and the missing piece can be re-injected.
