### PR TITLE
SingleObjectSelector as stream module

### DIFF
--- a/CommonTools/CandAlgos/interface/CandDecaySelector.h
+++ b/CommonTools/CandAlgos/interface/CandDecaySelector.h
@@ -43,10 +43,10 @@ namespace helper {
     std::auto_ptr<reco::CandidateCollection> selCands_;
   };
   
-  template<>
-  struct StoreManagerTrait<reco::CandidateCollection> {
+  template<typename EdmFilter>
+  struct StoreManagerTrait<reco::CandidateCollection, EdmFilter> {
     typedef CandDecayStoreManager type;
-    typedef ObjectSelectorBase<reco::CandidateCollection> base;
+    typedef ObjectSelectorBase<reco::CandidateCollection, EdmFilter> base;
   };
 
 }

--- a/CommonTools/RecoAlgos/plugins/VertexSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/VertexSelector.cc
@@ -26,9 +26,9 @@
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 
- typedef SingleObjectSelectorLegacy<
+ using VertexSelector = SingleObjectSelectorStream<
            reco::VertexCollection, 
            StringCutObjectSelector<reco::Vertex> 
-         > VertexSelector;
+         >;
 
 DEFINE_FWK_MODULE(VertexSelector);

--- a/CommonTools/RecoAlgos/plugins/VertexSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/VertexSelector.cc
@@ -26,7 +26,7 @@
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 
- typedef SingleObjectSelector<
+ typedef SingleObjectSelectorLegacy<
            reco::VertexCollection, 
            StringCutObjectSelector<reco::Vertex> 
          > VertexSelector;

--- a/CommonTools/UtilAlgos/interface/NullPostProcessor.h
+++ b/CommonTools/UtilAlgos/interface/NullPostProcessor.h
@@ -7,12 +7,12 @@
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 namespace helper {
 
-  template<typename OutputCollection>
+  template<typename OutputCollection, typename EdmFilter=edm::EDFilter>
   struct NullPostProcessor {
     NullPostProcessor( const edm::ParameterSet & iConfig, edm::ConsumesCollector && iC ) :
       NullPostProcessor( iConfig ) { }
     NullPostProcessor( const edm::ParameterSet & iConfig ) { }
-    void init( edm::EDFilter & ) { }
+    void init( EdmFilter & ) { }
     void process( edm::OrphanHandle<OutputCollection>, edm::Event & ) { }
   };
 

--- a/CommonTools/UtilAlgos/interface/ObjectSelector.h
+++ b/CommonTools/UtilAlgos/interface/ObjectSelector.h
@@ -31,21 +31,22 @@
 template<typename Selector,
          typename OutputCollection = typename ::helper::SelectedOutputCollectionTrait<typename Selector::collection>::type,
 	 typename SizeSelector = NonNullNumberSelector,
-	 typename PostProcessor = ::helper::NullPostProcessor<OutputCollection>,
-	 typename StoreManager = typename ::helper::StoreManagerTrait<OutputCollection>::type,
-	 typename Base = typename ::helper::StoreManagerTrait<OutputCollection>::base,
+	 typename PostProcessor = ::helper::NullPostProcessor<OutputCollection, edm::EDFilter>,
+	 typename StoreManager = typename ::helper::StoreManagerTrait<OutputCollection, edm::EDFilter>::type,
+	 typename Base = typename ::helper::StoreManagerTrait<OutputCollection, edm::EDFilter>::base,
 	 typename Init = typename ::reco::modules::EventSetupInit<Selector>::type
 	 >
 class ObjectSelector : public Base {
 public:
   /// constructor
+  // ObjectSelector()=default;
   explicit ObjectSelector(const edm::ParameterSet & cfg) :
     Base(cfg),
-    srcToken_(edm::EDFilter::consumes<typename Selector::collection>(cfg.template getParameter<edm::InputTag>("src"))),
+    srcToken_( this-> template consumes<typename Selector::collection>(cfg.template getParameter<edm::InputTag>("src"))),
     filter_(false),
-    selector_(cfg, edm::EDFilter::consumesCollector()),
+    selector_(cfg, this->consumesCollector()),
     sizeSelector_(reco::modules::make<SizeSelector>(cfg)),
-    postProcessor_(cfg, edm::EDFilter::consumesCollector()) {
+    postProcessor_(cfg, this->consumesCollector()) {
     const std::string filter("filter");
     std::vector<std::string> bools = cfg.template getParameterNamesForType<bool>();
     bool found = std::find(bools.begin(), bools.end(), filter) != bools.end();

--- a/CommonTools/UtilAlgos/interface/SingleObjectRefSelector.h
+++ b/CommonTools/UtilAlgos/interface/SingleObjectRefSelector.h
@@ -15,8 +15,8 @@ template<typename InputType, typename Selector,
 	 typename OutputCollection = typename ::helper::SelectedOutputCollectionTrait<edm::View<InputType> >::type,
 	 typename StoreContainer = typename ::helper::StoreContainerTrait<OutputCollection>::type,
 	 typename PostProcessor = ::helper::NullPostProcessor<OutputCollection>,
-	 typename StoreManager = typename ::helper::StoreManagerTrait<OutputCollection>::type,
-	 typename Base = typename ::helper::StoreManagerTrait<OutputCollection>::base,
+	 typename StoreManager = typename ::helper::StoreManagerTrait<OutputCollection, edm::EDFilter>::type,
+	 typename Base = typename ::helper::StoreManagerTrait<OutputCollection, edm::EDFilter>::base,
 	 typename RefAdder = typename ::helper::SelectionAdderTrait<edm::View<InputType>, StoreContainer>::type>
 class SingleObjectRefSelector :
   public ObjectSelector<SingleElementCollectionRefSelector<InputType, Selector, OutputCollection, StoreContainer, RefAdder>,

--- a/CommonTools/UtilAlgos/interface/SingleObjectSelector.h
+++ b/CommonTools/UtilAlgos/interface/SingleObjectSelector.h
@@ -62,8 +62,8 @@ using SingleObjectSelectorStream = SingleObjectSelectorBase<InputCollection,Sele
 template<typename InputCollection, typename Selector,
 	 typename OutputCollection = typename ::helper::SelectedOutputCollectionTrait<InputCollection>::type,
 	 typename StoreContainer = typename ::helper::StoreContainerTrait<OutputCollection>::type,
-	 typename PostProcessor = ::helper::NullPostProcessor<OutputCollection, edm::EDFilter> >
-using SingleObjectSelector = SingleObjectSelectorLegacy<InputCollection,Selector,
+	 typename PostProcessor = ::helper::NullPostProcessor<OutputCollection, edm::stream::EDFilter<> > >
+using SingleObjectSelector = SingleObjectSelectorStream<InputCollection,Selector,
 							OutputCollection,StoreContainer,PostProcessor>;
 
 

--- a/CommonTools/UtilAlgos/interface/SingleObjectSelector.h
+++ b/CommonTools/UtilAlgos/interface/SingleObjectSelector.h
@@ -18,20 +18,21 @@
 
 
 template<typename InputCollection, typename Selector, 
+	 typename EdmFilter,
 	 typename OutputCollection = typename ::helper::SelectedOutputCollectionTrait<InputCollection>::type,
 	 typename StoreContainer = typename ::helper::StoreContainerTrait<OutputCollection>::type,
-	 typename PostProcessor = ::helper::NullPostProcessor<OutputCollection>,
-	 typename EdmFilter=edm::EDFilter,
-	 typename StoreManager = typename ::helper::StoreManagerTrait<OutputCollection>::type,
+	 typename PostProcessor = ::helper::NullPostProcessor<OutputCollection, EdmFilter>,
+	 typename StoreManager = typename ::helper::StoreManagerTrait<OutputCollection, EdmFilter>::type,
 	 typename Base = typename ::helper::StoreManagerTrait<OutputCollection, EdmFilter>::base,
 	 typename RefAdder = typename ::helper::SelectionAdderTrait<InputCollection, StoreContainer>::type>
 class SingleObjectSelectorBase : 
   public ObjectSelector<SingleElementCollectionSelector<InputCollection, Selector, OutputCollection, StoreContainer, RefAdder>, 
 			OutputCollection, NonNullNumberSelector, PostProcessor, StoreManager, Base> {
 public:
+  // SingleObjectSelectorBase() = default;
   explicit SingleObjectSelectorBase( const edm::ParameterSet & cfg ) :
     ObjectSelector<SingleElementCollectionSelector<InputCollection, Selector, OutputCollection, StoreContainer, RefAdder>, 
-		   OutputCollection, NonNullNumberSelector, PostProcessor>( cfg ) { }
+		   OutputCollection, NonNullNumberSelector, PostProcessor, StoreManager, Base>( cfg ) { }
   virtual ~SingleObjectSelectorBase() { }
 };
 
@@ -40,35 +41,28 @@ public:
 template<typename InputCollection, typename Selector,
 	 typename OutputCollection = typename ::helper::SelectedOutputCollectionTrait<InputCollection>::type,
 	 typename StoreContainer = typename ::helper::StoreContainerTrait<OutputCollection>::type,
-	 typename PostProcessor = ::helper::NullPostProcessor<OutputCollection> >
-using SingleObjectSelectorLegacy = SingleObjectSelectorBase<InputCollection,Selector, 
-							    OutputCollection,StoreContainer,PostProcessor,
-							    edm::EDFilter>;
+	 typename PostProcessor = ::helper::NullPostProcessor<OutputCollection, edm::EDFilter> >
+using SingleObjectSelectorLegacy = SingleObjectSelectorBase<InputCollection,Selector, edm::EDFilter, 
+							    OutputCollection,StoreContainer,PostProcessor
+							    >;
 
 
 
-/*
 #include "FWCore/Framework/interface/stream/EDFilter.h"
 
 template<typename InputCollection, typename Selector,
 	 typename OutputCollection = typename ::helper::SelectedOutputCollectionTrait<InputCollection>::type,
 	 typename StoreContainer = typename ::helper::StoreContainerTrait<OutputCollection>::type,
-	 typename PostProcessor = ::helper::NullPostProcessor<OutputCollection>>
-  class SingleObjectSelectorStream : public SingleObjectSelectorBase<InputCollection,Selector, 
-								     OutputCollection,StoreContainer,PostProcessor, 
-								     edm::stream::EDFilter<> > {
-  public:
-    explicit SingleObjectSelectorStream( const edm::ParameterSet & cfg ) : 
-      SingleObjectSelectorBase<InputCollection,Selector, 
-			       OutputCollection,StoreContainer,PostProcessor, edm::stream::EDFilter<> > (cfg){}
-  };
-*/
+	 typename PostProcessor = ::helper::NullPostProcessor<OutputCollection, edm::stream::EDFilter<> > >
+using SingleObjectSelectorStream = SingleObjectSelectorBase<InputCollection,Selector, edm::stream::EDFilter<>,
+							    OutputCollection,StoreContainer,PostProcessor
+							    >;
 
 
 template<typename InputCollection, typename Selector,
 	 typename OutputCollection = typename ::helper::SelectedOutputCollectionTrait<InputCollection>::type,
 	 typename StoreContainer = typename ::helper::StoreContainerTrait<OutputCollection>::type,
-	 typename PostProcessor = ::helper::NullPostProcessor<OutputCollection> >
+	 typename PostProcessor = ::helper::NullPostProcessor<OutputCollection, edm::EDFilter> >
 using SingleObjectSelector = SingleObjectSelectorLegacy<InputCollection,Selector,
 							OutputCollection,StoreContainer,PostProcessor>;
 

--- a/CommonTools/UtilAlgos/interface/SingleObjectSelector.h
+++ b/CommonTools/UtilAlgos/interface/SingleObjectSelector.h
@@ -35,18 +35,17 @@ public:
   virtual ~SingleObjectSelectorBase() { }
 };
 
+
+
 template<typename InputCollection, typename Selector,
 	 typename OutputCollection = typename ::helper::SelectedOutputCollectionTrait<InputCollection>::type,
 	 typename StoreContainer = typename ::helper::StoreContainerTrait<OutputCollection>::type,
 	 typename PostProcessor = ::helper::NullPostProcessor<OutputCollection> >
-class SingleObjectSelectorLegacy : public SingleObjectSelectorBase<InputCollection,Selector, 
-								   OutputCollection,StoreContainer,PostProcessor,
-								   edm::EDFilter> {
-public:
-  explicit SingleObjectSelectorLegacy( const edm::ParameterSet & cfg ) : 
-    SingleObjectSelectorBase<InputCollection,Selector, 
-			     OutputCollection,StoreContainer,PostProcessor,edm::EDFilter> (cfg){}
-};
+using SingleObjectSelectorLegacy = SingleObjectSelectorBase<InputCollection,Selector, 
+							    OutputCollection,StoreContainer,PostProcessor,
+							    edm::EDFilter>;
+
+
 
 /*
 #include "FWCore/Framework/interface/stream/EDFilter.h"
@@ -70,16 +69,8 @@ template<typename InputCollection, typename Selector,
 	 typename OutputCollection = typename ::helper::SelectedOutputCollectionTrait<InputCollection>::type,
 	 typename StoreContainer = typename ::helper::StoreContainerTrait<OutputCollection>::type,
 	 typename PostProcessor = ::helper::NullPostProcessor<OutputCollection> >
-class  SingleObjectSelector: public SingleObjectSelectorLegacy<InputCollection,Selector,
-							       OutputCollection,StoreContainer,PostProcessor> {
-public:
-
-  explicit SingleObjectSelector( const edm::ParameterSet & cfg ) : 
-    SingleObjectSelectorLegacy<InputCollection,Selector,
-			     OutputCollection,StoreContainer,PostProcessor> (cfg){}
-
-
-};
+using SingleObjectSelector = SingleObjectSelectorLegacy<InputCollection,Selector,
+							OutputCollection,StoreContainer,PostProcessor>;
 
 
 

--- a/CommonTools/UtilAlgos/interface/SingleObjectSelector.h
+++ b/CommonTools/UtilAlgos/interface/SingleObjectSelector.h
@@ -9,22 +9,79 @@
 #include "CommonTools/UtilAlgos/interface/SelectionAdderTrait.h"
 #include "CommonTools/UtilAlgos/interface/SingleElementCollectionSelector.h"
 
+
+
+/* the following is just to ease transition
+ *    grep -r SingleObjectSelector * | wc 
+ *      209     540   22532
+ */
+
+
 template<typename InputCollection, typename Selector, 
 	 typename OutputCollection = typename ::helper::SelectedOutputCollectionTrait<InputCollection>::type,
 	 typename StoreContainer = typename ::helper::StoreContainerTrait<OutputCollection>::type,
 	 typename PostProcessor = ::helper::NullPostProcessor<OutputCollection>,
+	 typename EdmFilter=edm::EDFilter,
 	 typename StoreManager = typename ::helper::StoreManagerTrait<OutputCollection>::type,
-	 typename Base = typename ::helper::StoreManagerTrait<OutputCollection>::base,
+	 typename Base = typename ::helper::StoreManagerTrait<OutputCollection, EdmFilter>::base,
 	 typename RefAdder = typename ::helper::SelectionAdderTrait<InputCollection, StoreContainer>::type>
-class SingleObjectSelector : 
+class SingleObjectSelectorBase : 
   public ObjectSelector<SingleElementCollectionSelector<InputCollection, Selector, OutputCollection, StoreContainer, RefAdder>, 
 			OutputCollection, NonNullNumberSelector, PostProcessor, StoreManager, Base> {
 public:
-  explicit SingleObjectSelector( const edm::ParameterSet & cfg ) :
+  explicit SingleObjectSelectorBase( const edm::ParameterSet & cfg ) :
     ObjectSelector<SingleElementCollectionSelector<InputCollection, Selector, OutputCollection, StoreContainer, RefAdder>, 
 		   OutputCollection, NonNullNumberSelector, PostProcessor>( cfg ) { }
-  virtual ~SingleObjectSelector() { }
+  virtual ~SingleObjectSelectorBase() { }
 };
+
+template<typename InputCollection, typename Selector,
+	 typename OutputCollection = typename ::helper::SelectedOutputCollectionTrait<InputCollection>::type,
+	 typename StoreContainer = typename ::helper::StoreContainerTrait<OutputCollection>::type,
+	 typename PostProcessor = ::helper::NullPostProcessor<OutputCollection> >
+class SingleObjectSelectorLegacy : public SingleObjectSelectorBase<InputCollection,Selector, 
+								   OutputCollection,StoreContainer,PostProcessor,
+								   edm::EDFilter> {
+public:
+  explicit SingleObjectSelectorLegacy( const edm::ParameterSet & cfg ) : 
+    SingleObjectSelectorBase<InputCollection,Selector, 
+			     OutputCollection,StoreContainer,PostProcessor,edm::EDFilter> (cfg){}
+};
+
+/*
+#include "FWCore/Framework/interface/stream/EDFilter.h"
+
+template<typename InputCollection, typename Selector,
+	 typename OutputCollection = typename ::helper::SelectedOutputCollectionTrait<InputCollection>::type,
+	 typename StoreContainer = typename ::helper::StoreContainerTrait<OutputCollection>::type,
+	 typename PostProcessor = ::helper::NullPostProcessor<OutputCollection>>
+  class SingleObjectSelectorStream : public SingleObjectSelectorBase<InputCollection,Selector, 
+								     OutputCollection,StoreContainer,PostProcessor, 
+								     edm::stream::EDFilter<> > {
+  public:
+    explicit SingleObjectSelectorStream( const edm::ParameterSet & cfg ) : 
+      SingleObjectSelectorBase<InputCollection,Selector, 
+			       OutputCollection,StoreContainer,PostProcessor, edm::stream::EDFilter<> > (cfg){}
+  };
+*/
+
+
+template<typename InputCollection, typename Selector,
+	 typename OutputCollection = typename ::helper::SelectedOutputCollectionTrait<InputCollection>::type,
+	 typename StoreContainer = typename ::helper::StoreContainerTrait<OutputCollection>::type,
+	 typename PostProcessor = ::helper::NullPostProcessor<OutputCollection> >
+class  SingleObjectSelector: public SingleObjectSelectorLegacy<InputCollection,Selector,
+							       OutputCollection,StoreContainer,PostProcessor> {
+public:
+
+  explicit SingleObjectSelector( const edm::ParameterSet & cfg ) : 
+    SingleObjectSelectorLegacy<InputCollection,Selector,
+			     OutputCollection,StoreContainer,PostProcessor> (cfg){}
+
+
+};
+
+
 
 #endif
 

--- a/CommonTools/UtilAlgos/interface/StoreManagerTrait.h
+++ b/CommonTools/UtilAlgos/interface/StoreManagerTrait.h
@@ -89,7 +89,7 @@ namespace helper {
     std::auto_ptr<collection> selected_;
   };
 
-  template<typename OutputCollection, typename EdmFilter=edm::EDFilter>
+  template<typename OutputCollection, typename EdmFilter>
   struct ObjectSelectorBase : public EdmFilter {
     ObjectSelectorBase( const edm::ParameterSet &) {
       this-> template produces<OutputCollection>();

--- a/CommonTools/UtilAlgos/interface/StoreManagerTrait.h
+++ b/CommonTools/UtilAlgos/interface/StoreManagerTrait.h
@@ -63,30 +63,7 @@ namespace helper {
     }
   };
 
-  /*
-  template<typename OutputCollection, typename InputCollection>
-  struct OutputCollectionCreator {
-    static std::auto_ptr<OutputCollection> createNewCollection( const edm::Handle<InputCollection> & ) {
-      return std::auto_ptr<OutputCollection>( new OutputCollection );
-    }
-  };
 
-  template<typename T, typename InputCollection>
-  struct OutputCollectionCreator<edm::RefToBaseVector<T>, InputCollection> {
-    static std::auto_ptr<edm::RefToBaseVector<T> > createNewCollection( const edm::Handle<InputCollection> & h ) {
-      return std::auto_ptr<edm::RefToBaseVector<T> >( new edm::RefToBaseVector<T>(h) );
-    }
-  };
-  */
-
-  /*
-  template<typename T1, typename T2>
-  struct OutputCollectionCreator<RefToBaseVector<T1>, RefToBaseVector<T2> > {
-    static RefToBaseVector<T1> * createNewCollection( const edm::Handle<RefToBaseVector<T2> > & h ) {
-      return new RefToBaseVector<T1>(h);
-    }
-  };
-  */
 
   template<typename OutputCollection, 
 	   typename ClonePolicy = IteratorToObjectConverter<OutputCollection> >
@@ -94,8 +71,7 @@ namespace helper {
     typedef OutputCollection collection;
     template<typename C>
     CollectionStoreManager( const edm::Handle<C> & h ) :
-    selected_( new OutputCollection ) { 
-      //      selected_ = OutputCollectionCreator<OutputCollection, C>::createNewCollection(h);
+      selected_( new OutputCollection ) { 
     }
     template<typename I>
     void cloneAndStore( const I & begin, const I & end, edm::Event & ) {
@@ -113,17 +89,17 @@ namespace helper {
     std::auto_ptr<collection> selected_;
   };
 
-  template<typename OutputCollection>
-  struct ObjectSelectorBase : public edm::EDFilter {
-    ObjectSelectorBase( const edm::ParameterSet & cfg ) {
-      produces<OutputCollection>();
+  template<typename OutputCollection, typename EdmFilter=edm::EDFilter>
+  struct ObjectSelectorBase : public EdmFilter {
+    ObjectSelectorBase( const edm::ParameterSet &) {
+      this-> template produces<OutputCollection>();
     }    
   };
 
-  template<typename OutputCollection>
+  template<typename OutputCollection, typename EdmFilter=edm::EDFilter>
   struct StoreManagerTrait {
-    typedef CollectionStoreManager<OutputCollection> type;
-    typedef ObjectSelectorBase<OutputCollection> base;
+    using type = CollectionStoreManager<OutputCollection>;
+    using base = ObjectSelectorBase<OutputCollection, EdmFilter>;
   };
 
 }

--- a/Validation/RecoTrack/plugins/SealModule.cc
+++ b/Validation/RecoTrack/plugins/SealModule.cc
@@ -52,6 +52,7 @@ DEFINE_EDM_PLUGIN(MTVHistoProducerAlgoFactory, MTVHistoProducerAlgoForTracker,  
 // TPSelectorForFakeRate ;
 // DEFINE_FWK_MODULE( TPSelectorForFakeRate );
 
+/*
 #include "CommonTools/UtilAlgos/interface/StringCutObjectSelector.h"
 #include "CommonTools/UtilAlgos/interface/SingleObjectSelector.h"
 #include "DataFormats/TrackReco/interface/Track.h"
@@ -63,3 +64,4 @@ typedef SingleObjectSelector<
         > TrackSelectorForValidation;
 
 DEFINE_FWK_MODULE(TrackSelectorForValidation);
+*/

--- a/Validation/RecoTrack/plugins/SealModule2.cc
+++ b/Validation/RecoTrack/plugins/SealModule2.cc
@@ -1,0 +1,14 @@
+#include "FWCore/PluginManager/interface/ModuleDef.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "CommonTools/UtilAlgos/interface/StringCutObjectSelector.h"
+#include "CommonTools/UtilAlgos/interface/SingleObjectSelector.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+
+typedef SingleObjectSelector<
+            std::vector<reco::Track>,
+            StringCutObjectSelector<reco::Track>
+        > TrackSelectorForValidation;
+
+DEFINE_FWK_MODULE(TrackSelectorForValidation);


### PR DESCRIPTION
allow a SingleObjectSelector to be a stream::EDFilter
make VertexSelector a stream module

edm::EDFilter is pretty pervasive in CommonTools.
In my opinion it will be a hard task to migrate all those filters to be stream modules selectively...

just syntax, 
no regression expected
no regression observed
