### PR TITLE
Move edm::stream::imll::makeGlobal to own file

### DIFF
--- a/FWCore/Framework/interface/stream/EDAnalyzerAdaptor.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerAdaptor.h
@@ -28,35 +28,13 @@
 #include "FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h"
 #include "FWCore/Framework/interface/stream/callAbilities.h"
 #include "FWCore/Framework/interface/stream/dummy_helpers.h"
+#include "FWCore/Framework/interface/stream/makeGlobal.h"
 #include "FWCore/Framework/src/MakeModuleHelper.h"
 
 // forward declarations
 
 namespace edm {
   namespace stream {
-
-    namespace impl {
-      template<typename T, typename G>
-      std::unique_ptr<G> makeGlobal(edm::ParameterSet const& iPSet, G const*) {
-        return T::initializeGlobalCache(iPSet);
-      }
-      template<typename T>
-      dummy_ptr makeGlobal(edm::ParameterSet const& iPSet, void const*) {
-        return dummy_ptr();
-      }
-      
-      template< typename T, typename G>
-      T* makeStreamModule(edm::ParameterSet const& iPSet,
-                                          G const* iGlobal) {
-        return new T(iPSet,iGlobal);
-      }
-
-      template< typename T>
-      T* makeStreamModule(edm::ParameterSet const& iPSet,
-                                          void const* ) {
-        return new T(iPSet);
-      }
-    }
 
     template<typename ABase, typename ModType> struct BaseToAdaptor;
 

--- a/FWCore/Framework/interface/stream/ProducingModuleAdaptor.h
+++ b/FWCore/Framework/interface/stream/ProducingModuleAdaptor.h
@@ -27,32 +27,11 @@
 #include "FWCore/Framework/interface/LuminosityBlockPrincipal.h"
 #include "FWCore/Framework/interface/stream/callAbilities.h"
 #include "FWCore/Framework/interface/stream/dummy_helpers.h"
+#include "FWCore/Framework/interface/stream/makeGlobal.h"
 // forward declarations
 
 namespace edm {
   namespace stream {
-    namespace impl {
-      template<typename T, typename G>
-      std::unique_ptr<G> makeGlobal(edm::ParameterSet const& iPSet, G const*) {
-        return T::initializeGlobalCache(iPSet);
-      }
-      template<typename T>
-      dummy_ptr makeGlobal(edm::ParameterSet const& iPSet, void const*) {
-        return dummy_ptr();
-      }
-      
-      template< typename T, typename G>
-      T* makeStreamModule(edm::ParameterSet const& iPSet,
-                                          G const* iGlobal) {
-        return new T(iPSet,iGlobal);
-      }
-
-      template< typename T>
-      T* makeStreamModule(edm::ParameterSet const& iPSet,
-                                          void const* ) {
-        return new T(iPSet);
-      }
-    }
     
     template<typename T, typename M, typename B>
     class ProducingModuleAdaptor : public B

--- a/FWCore/Framework/interface/stream/makeGlobal.h
+++ b/FWCore/Framework/interface/stream/makeGlobal.h
@@ -1,0 +1,53 @@
+#ifndef FWCore_Framework_stream_makeGlobal_h
+#define FWCore_Framework_stream_makeGlobal_h
+// -*- C++ -*-
+//
+// Package:     FWCore/Framework
+// Class  :     makeGlobal
+// 
+/** Helper functions for making stream modules
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  Thu, 22 May 2014 13:55:01 GMT
+//
+
+// system include files
+
+// user include files
+
+// forward declarations
+
+namespace edm {
+  namespace stream {
+    namespace impl {
+      template<typename T, typename G>
+      std::unique_ptr<G> makeGlobal(edm::ParameterSet const& iPSet, G const*) {
+        return T::initializeGlobalCache(iPSet);
+      }
+      template<typename T>
+      dummy_ptr makeGlobal(edm::ParameterSet const& iPSet, void const*) {
+        return dummy_ptr();
+      }
+      
+      template< typename T, typename G>
+      T* makeStreamModule(edm::ParameterSet const& iPSet,
+                          G const* iGlobal) {
+        return new T(iPSet,iGlobal);
+      }
+      
+      template< typename T>
+      T* makeStreamModule(edm::ParameterSet const& iPSet,
+                          void const* ) {
+        return new T(iPSet);
+      }
+    }
+  }
+}
+#endif


### PR DESCRIPTION
The function was declared in two different headers which caused problems when they were included in the same source file. This moves the functions to just one file.
