### PR TITLE
tau quality cuts update

### DIFF
--- a/RecoTauTag/RecoTau/interface/RecoTauVertexAssociator.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauVertexAssociator.h
@@ -75,7 +75,7 @@ class RecoTauVertexAssociator {
     //PJ adding quality cuts
     RecoTauQualityCuts* qcuts_;
     bool recoverLeadingTrk_;
-    enum { kLeadTrack, kLeadPFCand, kFirstTrack };
+    enum { kLeadTrack, kLeadPFCand, kMinLeadTrackOrPFCand, kFirstTrack };
     int leadingTrkOrPFCandOption_;
     edm::EDGetTokenT<reco::VertexCollection> vxToken_;
     // containers for holding vertices associated to jets

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin2.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin2.cc
@@ -148,7 +148,7 @@ void RecoTauPiZeroStripPlugin2::addCandsToStrip(RecoTauPiZero& strip, PFCandPtrs
 						std::set<size_t>& candIdsCurrentStrip, bool& isCandAdded) const
 {
   if ( verbosity_ >= 1 ) {
-    std::cout << "<RecoTauPiZeroStripPlugin2::addCandsToStrip>:" << std::endl;
+    edm::LogPrint("RecoTauPiZeroStripPlugin2") << "<RecoTauPiZeroStripPlugin2::addCandsToStrip>:" ;
   }
   size_t numCands = cands.size();
   for ( size_t candId = 0; candId < numCands; ++candId ) {
@@ -157,7 +157,7 @@ void RecoTauPiZeroStripPlugin2::addCandsToStrip(RecoTauPiZero& strip, PFCandPtrs
       if ( fabs(strip.eta() - cand->eta()) < etaAssociationDistance_ && // check if cand is within eta-phi window centered on strip 
 	   fabs(strip.phi() - cand->phi()) < phiAssociationDistance_ ) {
 	if ( verbosity_ >= 2 ) {
-	  std::cout << "--> adding PFCand #" << candId << " (" << cand.id() << ":" << cand.key() << "): Et = " << cand->et() << ", eta = " << cand->eta() << ", phi = " << cand->phi() << std::endl;
+	  edm::LogPrint("RecoTauPiZeroStripPlugin2") << "--> adding PFCand #" << candId << " (" << cand.id() << ":" << cand.key() << "): Et = " << cand->et() << ", eta = " << cand->eta() << ", phi = " << cand->phi() ;
 	}
 	strip.addDaughter(cand);
 	if ( updateStripAfterEachDaughter_ ) p4Builder_.set(strip);
@@ -188,10 +188,10 @@ namespace {
 RecoTauPiZeroStripPlugin2::return_type RecoTauPiZeroStripPlugin2::operator()(const reco::PFJet& jet) const 
 {
   if ( verbosity_ >= 1 ) {
-    std::cout << "<RecoTauPiZeroStripPlugin2::operator()>:" << std::endl;
-    std::cout << " minGammaEtStripSeed = " << minGammaEtStripSeed_ << std::endl;
-    std::cout << " minGammaEtStripAdd = " << minGammaEtStripAdd_ << std::endl;
-    std::cout << " minStripEt = " << minStripEt_ << std::endl;
+    edm::LogPrint("RecoTauPiZeroStripPlugin2") << "<RecoTauPiZeroStripPlugin2::operator()>:" ;
+    edm::LogPrint("RecoTauPiZeroStripPlugin2") << " minGammaEtStripSeed = " << minGammaEtStripSeed_ ;
+    edm::LogPrint("RecoTauPiZeroStripPlugin2") << " minGammaEtStripAdd = " << minGammaEtStripAdd_ ;
+    edm::LogPrint("RecoTauPiZeroStripPlugin2") << " minStripEt = " << minStripEt_ ;
   }
 
   PiZeroVector output;
@@ -207,27 +207,27 @@ RecoTauPiZeroStripPlugin2::return_type RecoTauPiZeroStripPlugin2::operator()(con
   for ( PFCandPtrs::iterator cand = candsVector.begin();
 	cand != candsVector.end(); ++cand ) {
     if ( verbosity_ >= 1 ) {
-      std::cout << "PFGamma #" << idx << " (" << cand->id() << ":" << cand->key() << "): Et = " << (*cand)->et() << ", eta = " << (*cand)->eta() << ", phi = " << (*cand)->phi() << std::endl;
+      edm::LogPrint("RecoTauPiZeroStripPlugin2") << "PFGamma #" << idx << " (" << cand->id() << ":" << cand->key() << "): Et = " << (*cand)->et() << ", eta = " << (*cand)->eta() << ", phi = " << (*cand)->phi() ;
     } 
     if ( (*cand)->et() > minGammaEtStripSeed_ ) {
       if ( verbosity_ >= 2 ) {
-	std::cout << "--> assigning seedCandId = " << seedCands.size() << std::endl;
+	edm::LogPrint("RecoTauPiZeroStripPlugin2") << "--> assigning seedCandId = " << seedCands.size() ;
         const reco::TrackBaseRef candTrack = getTrack(*cand);
         if ( candTrack.isNonnull() ) {
-	  std::cout << "track: Pt = " << candTrack->pt() << " eta = " << candTrack->eta() << ", phi = " << candTrack->phi() << ", charge = " << candTrack->charge() << std::endl;
-	  std::cout << " (dZ = " << candTrack->dz(vertexAssociator_.associatedVertex(jet)->position()) << ", dXY = " << candTrack->dxy(vertexAssociator_.associatedVertex(jet)->position()) << "," 
+	  edm::LogPrint("RecoTauPiZeroStripPlugin2") << "track: Pt = " << candTrack->pt() << " eta = " << candTrack->eta() << ", phi = " << candTrack->phi() << ", charge = " << candTrack->charge() ;
+	  edm::LogPrint("RecoTauPiZeroStripPlugin2") << " (dZ = " << candTrack->dz(vertexAssociator_.associatedVertex(jet)->position()) << ", dXY = " << candTrack->dxy(vertexAssociator_.associatedVertex(jet)->position()) << "," 
 		    << " numHits = " << candTrack->hitPattern().numberOfValidTrackerHits() << ", numPxlHits = " << candTrack->hitPattern().numberOfValidPixelHits() << "," 
-		    << " chi2 = " << candTrack->normalizedChi2() << ", dPt/Pt = " << (candTrack->ptError()/candTrack->pt()) << ")" << std::endl;
+		    << " chi2 = " << candTrack->normalizedChi2() << ", dPt/Pt = " << (candTrack->ptError()/candTrack->pt()) << ")" ;
 	}
-	std::cout << "ECAL Et: calibrated = " << (*cand)->ecalEnergy()*sin((*cand)->theta()) << "," 
-		  << " raw = " << (*cand)->rawEcalEnergy()*sin((*cand)->theta()) << std::endl;
-	std::cout << "HCAL Et: calibrated = " << (*cand)->hcalEnergy()*sin((*cand)->theta()) << "," 
-		  << " raw = " << (*cand)->rawHcalEnergy()*sin((*cand)->theta()) << std::endl;
+	edm::LogPrint("RecoTauPiZeroStripPlugin2") << "ECAL Et: calibrated = " << (*cand)->ecalEnergy()*sin((*cand)->theta()) << "," 
+		  << " raw = " << (*cand)->rawEcalEnergy()*sin((*cand)->theta()) ;
+	edm::LogPrint("RecoTauPiZeroStripPlugin2") << "HCAL Et: calibrated = " << (*cand)->hcalEnergy()*sin((*cand)->theta()) << "," 
+		  << " raw = " << (*cand)->rawHcalEnergy()*sin((*cand)->theta()) ;
       }
       seedCands.push_back(*cand);
     } else if ( (*cand)->et() > minGammaEtStripAdd_  ) {
       if ( verbosity_ >= 2 ) {
-	std::cout << "--> assigning addCandId = " << addCands.size() << std::endl;
+	edm::LogPrint("RecoTauPiZeroStripPlugin2") << "--> assigning addCandId = " << addCands.size() ;
       }
       addCands.push_back(*cand);
     }
@@ -242,7 +242,7 @@ RecoTauPiZeroStripPlugin2::return_type RecoTauPiZeroStripPlugin2::operator()(con
 
   size_t idxSeed = 0;
   while ( idxSeed < seedCands.size() ) {
-    if ( verbosity_ >= 2 ) std::cout << "processing seed #" << idxSeed << std::endl;
+    if ( verbosity_ >= 2 ) edm::LogPrint("RecoTauPiZeroStripPlugin2") << "processing seed #" << idxSeed ;
 
     seedCandIdsCurrentStrip.clear();
     addCandIdsCurrentStrip.clear();
@@ -256,9 +256,9 @@ RecoTauPiZeroStripPlugin2::return_type RecoTauPiZeroStripPlugin2::operator()(con
     do {
       isCandAdded = false;
 
-      //if ( verbosity_ >= 2 ) std::cout << " adding seedCands to strip..." << std::endl;
+      //if ( verbosity_ >= 2 ) edm::LogPrint("RecoTauPiZeroStripPlugin2") << " adding seedCands to strip..." ;
       addCandsToStrip(*strip, seedCands, seedCandFlags, seedCandIdsCurrentStrip, isCandAdded);
-      //if ( verbosity_ >= 2 ) std::cout << " adding addCands to strip..." << std::endl;
+      //if ( verbosity_ >= 2 ) edm::LogPrint("RecoTauPiZeroStripPlugin2") << " adding addCands to strip..." ;
       addCandsToStrip(*strip, addCands,  addCandFlags,  addCandIdsCurrentStrip, isCandAdded);
 
       if ( !updateStripAfterEachDaughter_ ) p4Builder_.set(*strip);
@@ -267,7 +267,7 @@ RecoTauPiZeroStripPlugin2::return_type RecoTauPiZeroStripPlugin2::operator()(con
     } while ( isCandAdded && (stripBuildIteration < maxStripBuildIterations_ || maxStripBuildIterations_ == -1) );
 
     if ( strip->et() > minStripEt_ ) { // strip passed Et cuts, add it to the event
-      if ( verbosity_ >= 2 ) std::cout << "Building strip: Et = " << strip->et() << ", eta = " << strip->eta() << ", phi = " << strip->phi() << std::endl;
+      if ( verbosity_ >= 2 ) edm::LogPrint("RecoTauPiZeroStripPlugin2") << "Building strip: Et = " << strip->et() << ", eta = " << strip->eta() << ", phi = " << strip->phi() ;
 
       // Update the vertex
       if ( strip->daughterPtr(0).isNonnull() ) strip->setVertex(strip->daughterPtr(0)->vertex());
@@ -277,7 +277,7 @@ RecoTauPiZeroStripPlugin2::return_type RecoTauPiZeroStripPlugin2::operator()(con
       markCandsInStrip(seedCandFlags, seedCandIdsCurrentStrip);
       markCandsInStrip(addCandFlags,  addCandIdsCurrentStrip);
     } else { // strip failed Et cuts, just skip it
-      if ( verbosity_ >= 2 ) std::cout << "Discarding strip: Et = " << strip->et() << ", eta = " << strip->eta() << ", phi = " << strip->phi() << std::endl;
+      if ( verbosity_ >= 2 ) edm::LogPrint("RecoTauPiZeroStripPlugin2") << "Discarding strip: Et = " << strip->et() << ", eta = " << strip->eta() << ", phi = " << strip->phi() ;
     }
 
     ++idxSeed;

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin2.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin2.cc
@@ -10,6 +10,7 @@
  *                     Christian Veelken (LLR)
  *
  */
+
 #include <algorithm>
 #include <memory>
 
@@ -50,7 +51,7 @@ namespace {
 class RecoTauPiZeroStripPlugin2 : public RecoTauPiZeroBuilderPlugin 
 {
  public:
-  explicit RecoTauPiZeroStripPlugin2(const edm::ParameterSet&,edm::ConsumesCollector &&iC);
+  explicit RecoTauPiZeroStripPlugin2(const edm::ParameterSet&, edm::ConsumesCollector &&iC);
   virtual ~RecoTauPiZeroStripPlugin2();
   // Return type is auto_ptr<PiZeroVector>
   return_type operator()(const reco::PFJet&) const override;
@@ -83,22 +84,19 @@ class RecoTauPiZeroStripPlugin2 : public RecoTauPiZeroBuilderPlugin
   double combinatoricStripMassHypo_;
 
   AddFourMomenta p4Builder_;
+
+  int verbosity_;
 };
 
-  RecoTauPiZeroStripPlugin2::RecoTauPiZeroStripPlugin2(const edm::ParameterSet& pset, edm::ConsumesCollector &&iC)
-    : RecoTauPiZeroBuilderPlugin(pset,std::move(iC)),
-      vertexAssociator_(pset.getParameter<edm::ParameterSet>("qualityCuts"),std::move(iC)),
+RecoTauPiZeroStripPlugin2::RecoTauPiZeroStripPlugin2(const edm::ParameterSet& pset, edm::ConsumesCollector &&iC)
+  : RecoTauPiZeroBuilderPlugin(pset, std::move(iC)),
+    vertexAssociator_(pset.getParameter<edm::ParameterSet>("qualityCuts"), std::move(iC)),
     qcuts_(0)
 {
-  LogTrace("RecoTauPiZeroStripPlugin2") << "<RecoTauPiZeroStripPlugin2::RecoTauPiZeroStripPlugin2>:" ;
-
   minGammaEtStripSeed_ = pset.getParameter<double>("minGammaEtStripSeed");
-  LogTrace("RecoTauPiZeroStripPlugin2") << " minGammaEtStripSeed = " << minGammaEtStripSeed_ ;
   minGammaEtStripAdd_ = pset.getParameter<double>("minGammaEtStripAdd");
-  LogTrace("RecoTauPiZeroStripPlugin2") << " minGammaEtStripAdd = " << minGammaEtStripAdd_ ;
 
   minStripEt_ = pset.getParameter<double>("minStripEt");
-  LogTrace("RecoTauPiZeroStripPlugin2") << " minStripEt = " << minStripEt_ ;
   
   edm::ParameterSet qcuts_pset = pset.getParameterSet("qualityCuts").getParameterSet("signalQualityCuts");
 //-------------------------------------------------------------------------------
@@ -109,7 +107,7 @@ class RecoTauPiZeroStripPlugin2 : public RecoTauPiZeroBuilderPlugin
     qcuts_pset.addParameter<double>("minTrackPt", std::min(minGammaEtStripSeed_, minGammaEtStripAdd_));
     qcuts_pset.addParameter<double>("maxTrackChi2", 1.e+9);
     qcuts_pset.addParameter<double>("maxTransverseImpactParameter", 1.e+9);
-    qcuts_pset.addParameter<double>("maxDeltaZ", 1.);
+    qcuts_pset.addParameter<double>("maxDeltaZ", 1.e+9);
     qcuts_pset.addParameter<double>("minTrackVertexWeight", -1.);
     qcuts_pset.addParameter<unsigned>("minTrackPixelHits", 0);
     qcuts_pset.addParameter<unsigned>("minTrackHits", 0);
@@ -130,6 +128,9 @@ class RecoTauPiZeroStripPlugin2 : public RecoTauPiZeroBuilderPlugin
     maxStrips_ = pset.getParameter<int>("maxInputStrips");
     combinatoricStripMassHypo_ = pset.getParameter<double>("stripMassWhenCombining");
   }
+
+  verbosity_ = ( pset.exists("verbosity") ) ?
+    pset.getParameter<int>("verbosity") : 0;
 }
   
 RecoTauPiZeroStripPlugin2::~RecoTauPiZeroStripPlugin2()
@@ -146,13 +147,18 @@ void RecoTauPiZeroStripPlugin2::beginEvent()
 void RecoTauPiZeroStripPlugin2::addCandsToStrip(RecoTauPiZero& strip, PFCandPtrs& cands, const std::vector<bool>& candFlags, 
 						std::set<size_t>& candIdsCurrentStrip, bool& isCandAdded) const
 {
+  if ( verbosity_ >= 1 ) {
+    std::cout << "<RecoTauPiZeroStripPlugin2::addCandsToStrip>:" << std::endl;
+  }
   size_t numCands = cands.size();
   for ( size_t candId = 0; candId < numCands; ++candId ) {
     if ( (!candFlags[candId]) && candIdsCurrentStrip.find(candId) == candIdsCurrentStrip.end() ) { // do not include same cand twice
       reco::PFCandidatePtr cand = cands[candId];
       if ( fabs(strip.eta() - cand->eta()) < etaAssociationDistance_ && // check if cand is within eta-phi window centered on strip 
 	   fabs(strip.phi() - cand->phi()) < phiAssociationDistance_ ) {
-	LogTrace("RecoTauPiZeroStripPlugin2") << "--> candId = " << candId << " has been added." ;
+	if ( verbosity_ >= 2 ) {
+	  std::cout << "--> adding PFCand #" << candId << " (" << cand.id() << ":" << cand.key() << "): Et = " << cand->et() << ", eta = " << cand->eta() << ", phi = " << cand->phi() << std::endl;
+	}
 	strip.addDaughter(cand);
 	if ( updateStripAfterEachDaughter_ ) p4Builder_.set(strip);
 	isCandAdded = true;
@@ -181,6 +187,13 @@ namespace {
 
 RecoTauPiZeroStripPlugin2::return_type RecoTauPiZeroStripPlugin2::operator()(const reco::PFJet& jet) const 
 {
+  if ( verbosity_ >= 1 ) {
+    std::cout << "<RecoTauPiZeroStripPlugin2::operator()>:" << std::endl;
+    std::cout << " minGammaEtStripSeed = " << minGammaEtStripSeed_ << std::endl;
+    std::cout << " minGammaEtStripAdd = " << minGammaEtStripAdd_ << std::endl;
+    std::cout << " minStripEt = " << minStripEt_ << std::endl;
+  }
+
   PiZeroVector output;
 
   // Get the candidates passing our quality cuts
@@ -193,34 +206,31 @@ RecoTauPiZeroStripPlugin2::return_type RecoTauPiZeroStripPlugin2::operator()(con
   int idx = 0;
   for ( PFCandPtrs::iterator cand = candsVector.begin();
 	cand != candsVector.end(); ++cand ) {
-    LogTrace("RecoTauPiZeroStripPlugin2") << "PFGamma (" << idx << "): Et = " << (*cand)->et() << "," 
-    	        << " eta = " << (*cand)->eta() << ", phi = " << (*cand)->phi(); 
+    if ( verbosity_ >= 1 ) {
+      std::cout << "PFGamma #" << idx << " (" << cand->id() << ":" << cand->key() << "): Et = " << (*cand)->et() << ", eta = " << (*cand)->eta() << ", phi = " << (*cand)->phi() << std::endl;
+    } 
     if ( (*cand)->et() > minGammaEtStripSeed_ ) {
-      LogTrace("RecoTauPiZeroStripPlugin2") << " --> assigning seedCandId = " << seedCands.size() ;
-#ifdef EDM_ML_DEBUG
+      if ( verbosity_ >= 2 ) {
+	std::cout << "--> assigning seedCandId = " << seedCands.size() << std::endl;
         const reco::TrackBaseRef candTrack = getTrack(*cand);
         if ( candTrack.isNonnull() ) {
-	LogTrace("RecoTauPiZeroStripPlugin2") << "has Track: pt = " << candTrack->pt() << " +/- " << candTrack->ptError() << "," 
-		    << " eta = " << candTrack->eta() << ", phi = " << candTrack->phi() << ","
-		    << " charge = " << candTrack->charge() ;
-	LogTrace("RecoTauPiZeroStripPlugin2") << " chi2 = " << candTrack->normalizedChi2() ;
-	LogTrace("RecoTauPiZeroStripPlugin2") << " dIP = " << std::abs(candTrack->dxy(vertexAssociator_.associatedVertex(jet)->position())) ;
-	LogTrace("RecoTauPiZeroStripPlugin2") << " dZ = " << std::abs(candTrack->dz(vertexAssociator_.associatedVertex(jet)->position())) ;
-	LogTrace("RecoTauPiZeroStripPlugin2") << " vtxAssocWeight = " << vertexAssociator_.associatedVertex(jet)->trackWeight(candTrack) ;
-	LogTrace("RecoTauPiZeroStripPlugin2") << " numPxlHits = " << candTrack->hitPattern().numberOfValidPixelHits() ;
-        LogTrace("RecoTauPiZeroStripPlugin2") << " numTrkHits = " << candTrack->hitPattern().numberOfValidHits() ;
+	  std::cout << "track: Pt = " << candTrack->pt() << " eta = " << candTrack->eta() << ", phi = " << candTrack->phi() << ", charge = " << candTrack->charge() << std::endl;
+	  std::cout << " (dZ = " << candTrack->dz(vertexAssociator_.associatedVertex(jet)->position()) << ", dXY = " << candTrack->dxy(vertexAssociator_.associatedVertex(jet)->position()) << "," 
+		    << " numHits = " << candTrack->hitPattern().numberOfValidTrackerHits() << ", numPxlHits = " << candTrack->hitPattern().numberOfValidPixelHits() << "," 
+		    << " chi2 = " << candTrack->normalizedChi2() << ", dPt/Pt = " << (candTrack->ptError()/candTrack->pt()) << ")" << std::endl;
 	}
-#endif
-      LogTrace("RecoTauPiZeroStripPlugin2") << "ECAL Et: calibrated = " << (*cand)->ecalEnergy()*sin((*cand)->theta()) << "," 
-      	  << " raw = " << (*cand)->rawEcalEnergy()*sin((*cand)->theta()) ;
-      LogTrace("RecoTauPiZeroStripPlugin2") << "HCAL Et: calibrated = " << (*cand)->hcalEnergy()*sin((*cand)->theta()) << "," 
-      	  << " raw = " << (*cand)->rawHcalEnergy()*sin((*cand)->theta()) ;
+	std::cout << "ECAL Et: calibrated = " << (*cand)->ecalEnergy()*sin((*cand)->theta()) << "," 
+		  << " raw = " << (*cand)->rawEcalEnergy()*sin((*cand)->theta()) << std::endl;
+	std::cout << "HCAL Et: calibrated = " << (*cand)->hcalEnergy()*sin((*cand)->theta()) << "," 
+		  << " raw = " << (*cand)->rawHcalEnergy()*sin((*cand)->theta()) << std::endl;
+      }
       seedCands.push_back(*cand);
     } else if ( (*cand)->et() > minGammaEtStripAdd_  ) {
-      LogTrace("RecoTauPiZeroStripPlugin2") << " --> assigning addCandId = " << addCands.size();
+      if ( verbosity_ >= 2 ) {
+	std::cout << "--> assigning addCandId = " << addCands.size() << std::endl;
+      }
       addCands.push_back(*cand);
     }
-    LogTrace("RecoTauPiZeroStripPlugin2") ;
     ++idx;
   }
 
@@ -232,7 +242,7 @@ RecoTauPiZeroStripPlugin2::return_type RecoTauPiZeroStripPlugin2::operator()(con
 
   size_t idxSeed = 0;
   while ( idxSeed < seedCands.size() ) {
-    LogTrace("RecoTauPiZeroStripPlugin2") << "idxSeed = " << idxSeed ;
+    if ( verbosity_ >= 2 ) std::cout << "processing seed #" << idxSeed << std::endl;
 
     seedCandIdsCurrentStrip.clear();
     addCandIdsCurrentStrip.clear();
@@ -246,9 +256,9 @@ RecoTauPiZeroStripPlugin2::return_type RecoTauPiZeroStripPlugin2::operator()(con
     do {
       isCandAdded = false;
 
-      LogTrace("RecoTauPiZeroStripPlugin2") << " adding seedCands to strip..." ;
+      //if ( verbosity_ >= 2 ) std::cout << " adding seedCands to strip..." << std::endl;
       addCandsToStrip(*strip, seedCands, seedCandFlags, seedCandIdsCurrentStrip, isCandAdded);
-      LogTrace("RecoTauPiZeroStripPlugin2") << " adding addCands to strip..." ;
+      //if ( verbosity_ >= 2 ) std::cout << " adding addCands to strip..." << std::endl;
       addCandsToStrip(*strip, addCands,  addCandFlags,  addCandIdsCurrentStrip, isCandAdded);
 
       if ( !updateStripAfterEachDaughter_ ) p4Builder_.set(*strip);
@@ -257,9 +267,7 @@ RecoTauPiZeroStripPlugin2::return_type RecoTauPiZeroStripPlugin2::operator()(con
     } while ( isCandAdded && (stripBuildIteration < maxStripBuildIterations_ || maxStripBuildIterations_ == -1) );
 
     if ( strip->et() > minStripEt_ ) { // strip passed Et cuts, add it to the event
-      LogTrace("RecoTauPiZeroStripPlugin2") << "Strip: Et = " << strip->et() << "," 
-      	  << " eta = " << strip->eta() << ", phi = " << strip->phi() 
-      	  << " --> building it !!" ;
+      if ( verbosity_ >= 2 ) std::cout << "Building strip: Et = " << strip->et() << ", eta = " << strip->eta() << ", phi = " << strip->phi() << std::endl;
 
       // Update the vertex
       if ( strip->daughterPtr(0).isNonnull() ) strip->setVertex(strip->daughterPtr(0)->vertex());
@@ -269,9 +277,7 @@ RecoTauPiZeroStripPlugin2::return_type RecoTauPiZeroStripPlugin2::operator()(con
       markCandsInStrip(seedCandFlags, seedCandIdsCurrentStrip);
       markCandsInStrip(addCandFlags,  addCandIdsCurrentStrip);
     } else { // strip failed Et cuts, just skip it
-      LogTrace("RecoTauPiZeroStripPlugin2") << "Strip: Et = " << strip->et() << "," 
-    	  << " eta = " << strip->eta() << ", phi = " << strip->phi() 
-      	  << " --> discarding it !!" ;
+      if ( verbosity_ >= 2 ) std::cout << "Discarding strip: Et = " << strip->et() << ", eta = " << strip->eta() << ", phi = " << strip->phi() << std::endl;
     }
 
     ++idxSeed;

--- a/RecoTauTag/RecoTau/python/PFRecoTauQualityCuts_cfi.py
+++ b/RecoTauTag/RecoTau/python/PFRecoTauQualityCuts_cfi.py
@@ -5,17 +5,16 @@ import FWCore.ParameterSet.Config as cms
 
 PFTauQualityCuts = cms.PSet(
     signalQualityCuts = cms.PSet(
-        minTrackPt                   = cms.double(0.5),  # filter PFChargedHadrons below given pt
-        maxTrackChi2                 = cms.double(100.), # require track Chi2
-        maxTransverseImpactParameter = cms.double(0.03), # w.r.t. PV
-        maxDeltaZ                    = cms.double(0.4),  # w.r.t. PV
+        minTrackPt                   = cms.double(0.5),    # filter PFChargedHadrons below given pt
+        maxTrackChi2                 = cms.double(100.),   # require track Chi2
+        maxTransverseImpactParameter = cms.double(0.1),    # wrt. PV
+        maxDeltaZ                    = cms.double(0.4),    # wrt. PV
         #minTrackVertexWeight         = cms.double(10e-4), # Tracks weight in vertex
-        minTrackVertexWeight         = cms.double(-1.), # Tracks weight in vertex
-        minTrackPixelHits            = cms.uint32(0),    # pixel-only hits (note that these cuts are turned off,
-        # the tracking cuts might be higher)
-        minTrackHits                 = cms.uint32(3),    # total track hits
-        minGammaEt                   = cms.double(0.5),  # filter PFgammas below given Pt
-        #useTracksInsteadOfPFHadrons  = cms.bool(False),  # if true, use generalTracks, instead of PFChargedHadrons
+        minTrackVertexWeight         = cms.double(-1.),    # Tracks weight in vertex
+        minTrackPixelHits            = cms.uint32(0),      # pixel-only hits
+        minTrackHits                 = cms.uint32(3),      # total track hits
+        minGammaEt                   = cms.double(0.5),    # filter PFgammas below given Pt
+        #useTracksInsteadOfPFHadrons  = cms.bool(False),   # if true, use generalTracks, instead of PFChargedHadrons
         minNeutralHadronEt           = cms.double(30.)
     ),
     isolationQualityCuts = cms.PSet(
@@ -23,25 +22,22 @@ PFTauQualityCuts = cms.PSet(
         maxTrackChi2                 = cms.double(100.),
         maxTransverseImpactParameter = cms.double(0.03),
         maxDeltaZ                    = cms.double(0.2),
-        minTrackVertexWeight         = cms.double(-1.), # Tracks weight in vertex
+        minTrackVertexWeight         = cms.double(-1.),    # Tracks weight in vertex
         minTrackPixelHits            = cms.uint32(0),
         minTrackHits                 = cms.uint32(8),
         minGammaEt                   = cms.double(1.5),
         #useTracksInsteadOfPFHadrons  = cms.bool(False),
     ),
     vxAssocQualityCuts = cms.PSet(
-            minTrackPt                   = cms.double(0.5),  # filter PFChargedHadrons below given pt
-            maxTrackChi2                 = cms.double(100.), # require track Chi2
-            maxTransverseImpactParameter = cms.double(0.03), # w.r.t. PV
-            #maxDeltaZ                    = cms.double(0.2),  # w.r.t. PV
-            #minTrackVertexWeight         = cms.double(10e-4), # Tracks weight in vertex
-            minTrackVertexWeight         = cms.double(-1.), # Tracks weight in vertex
-            minTrackPixelHits            = cms.uint32(0),    # pixel-only hits (note that these cuts are turned off,
-            # the tracking cuts might be higher)
-            minTrackHits                 = cms.uint32(3),    # total track hits
-            minGammaEt                   = cms.double(0.5)  # filter PFgammas below given Pt
-            #useTracksInsteadOfPFHadrons  = cms.bool(False),  # if true, use generalTracks, instead of PFChargedHadrons
-            ),
+        minTrackPt                   = cms.double(0.5),    # filter PFChargedHadrons below given pt
+        maxTrackChi2                 = cms.double(100.),   # require track Chi2
+        maxTransverseImpactParameter = cms.double(0.1),    # wrt. PV
+        minTrackVertexWeight         = cms.double(-1.),    # Tracks weight in vertex
+        minTrackPixelHits            = cms.uint32(0),      # pixel-only hits
+        minTrackHits                 = cms.uint32(3),      # total track hits
+        minGammaEt                   = cms.double(0.5)     # filter PFgammas below given Pt
+        #useTracksInsteadOfPFHadrons  = cms.bool(False),   # if true, use generalTracks, instead of PFChargedHadrons
+    ),
     # The central definition of primary vertex source.
     primaryVertexSrc = cms.InputTag("offlinePrimaryVertices"),
     # Possible algorithms are: 'highestPtInEvent', 'closestInDeltaZ', 'highestWeightForLeadTrack' and 'combined'
@@ -52,5 +48,6 @@ PFTauQualityCuts = cms.PSet(
     # makeHisto = cms.bool(False)
     leadingTrkOrPFCandOption = cms.string("leadPFCand")
     ##leadingTrkOrPFCandOption = cms.string("leadTrack")
+    ##leadingTrkOrPFCandOption = cms.string("minLeadTrackOrPFCand")
     ##leadingTrkOrPFCandOption = cms.string("firstTrack") #default behaviour until 710 (first track in the collection)
 )

--- a/RecoTauTag/RecoTau/src/RecoTauVertexAssociator.cc
+++ b/RecoTauTag/RecoTau/src/RecoTauVertexAssociator.cc
@@ -11,6 +11,8 @@
 #include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 
+#include <TMath.h>
+
 namespace reco { namespace tau {
 
 // Get the highest pt track in a jet.
@@ -57,7 +59,9 @@ reco::TrackBaseRef RecoTauVertexAssociator::getLeadTrack(const PFJet& jet) const
   	  trackPt = track->pt() - 2.*track->ptError();
         } else if ( leadingTrkOrPFCandOption_ == kLeadPFCand ) {
 	  trackPt = (*pfCand)->pt();
-        } else assert(0);
+        } else if ( leadingTrkOrPFCandOption_ == kMinLeadTrackOrPFCand ) {
+	  trackPt = TMath::Min(track->pt(), (double)(*pfCand)->pt());
+	} else assert(0);
         if ( trackPt > leadTrackPt ) {
           leadPFCand = (*pfCand);
 	  leadTrackPt = trackPt;
@@ -192,6 +196,7 @@ RecoTauVertexAssociator::RecoTauVertexAssociator(const edm::ParameterSet& pset, 
   std::string leadingTrkOrPFCandOption_string = pset.exists("leadingTrkOrPFCandOption") ? pset.getParameter<std::string>("leadingTrkOrPFCandOption") : "firstTrack" ;
   if      ( leadingTrkOrPFCandOption_string == "leadTrack"  ) leadingTrkOrPFCandOption_ = kLeadTrack;
   else if ( leadingTrkOrPFCandOption_string == "leadPFCand" ) leadingTrkOrPFCandOption_ = kLeadPFCand;
+  else if ( leadingTrkOrPFCandOption_string == "minLeadTrackOrPFCand" ) leadingTrkOrPFCandOption_ = kMinLeadTrackOrPFCand;
   else if ( leadingTrkOrPFCandOption_string == "firstTrack" ) leadingTrkOrPFCandOption_ = kFirstTrack;
   else throw cms::Exception("BadVertexAssociatorConfig")
     << "Invalid Configuration parameter 'leadingTrkOrPFCandOption' " << leadingTrkOrPFCandOption_string << "." 


### PR DESCRIPTION
Several changes waiting in the pipeline
1) additional option of how to select a leading track in jet for vertex association 
-> switched off by default, no effect on RECO sequence
2) loosening of cuts on the maximal transverse impact parameter
-> it is beneficial for high pt taus (efficiency gain) and we do not loose performance for low pt ones. Small performance change expected - more details in https://indico.cern.ch/event/316898/material/2/0.pdf
3) code cleanup and printout optimization

@monicava, @veelken 
