### PR TITLE
remove direct calls of DQMStore, move SusyPostProcessor to DQMHarvester

### DIFF
--- a/DQMOffline/JetMET/interface/BeamHaloAnalyzer.h
+++ b/DQMOffline/JetMET/interface/BeamHaloAnalyzer.h
@@ -158,11 +158,8 @@ class BeamHaloAnalyzer: public DQMEDAnalyzer {
  
  private:
 
-  virtual void beginJob();
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   virtual void analyze(const edm::Event& , const edm::EventSetup&);
-  virtual void endJob();
-  virtual void endRun(const edm::Run&, const edm::EventSetup&){ if (OutputFileName!="") dqm->save(OutputFileName);}
 
   edm::InputTag IT_L1MuGMTReadout;
 
@@ -211,8 +208,6 @@ class BeamHaloAnalyzer: public DQMEDAnalyzer {
 
   bool StandardDQM;
 
-  // DAQ Tools
-  DQMStore* dqm;
 
   MonitorElement* hEcalHaloData_PhiWedgeMultiplicity;
   MonitorElement* hEcalHaloData_PhiWedgeConstituents;

--- a/DQMOffline/JetMET/interface/ECALRecHitAnalyzer.h
+++ b/DQMOffline/JetMET/interface/ECALRecHitAnalyzer.h
@@ -88,15 +88,13 @@ public:
   virtual void analyze(const edm::Event&, const edm::EventSetup&);
   //  virtual void beginJob(void) ;
   virtual void dqmbeginRun(const edm::Run&, const edm::EventSetup&) ;
-  virtual void endJob() ;
 
   void WriteECALRecHits(const edm::Event&, const edm::EventSetup&);
   void FillGeometry(const edm::EventSetup&);
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
  private:
-  // DAQ Tools
-  DQMStore* dbe_;
+
 
   // Inputs from Configuration
   edm::EDGetTokenT<EBRecHitCollection> EBRecHitsLabel_;

--- a/DQMOffline/JetMET/interface/HCALRecHitAnalyzer.h
+++ b/DQMOffline/JetMET/interface/HCALRecHitAnalyzer.h
@@ -31,13 +31,10 @@ class HCALRecHitAnalyzer: public DQMEDAnalyzer {
   virtual void analyze(const edm::Event&, const edm::EventSetup&);
   //  virtual void beginJob(void);
   //  virtual void beginRun(const edm::Run&, const edm::EventSetup&);
-  virtual void endJob();
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void dqmBeginRun(const edm::Run&, const edm::EventSetup&) ;
  private:
 
-  // DAQ Tools
-  DQMStore* dbe_;
 
   // Inputs from Configuration
   edm::EDGetTokenT<HBHERecHitCollection> hBHERecHitsLabel_;

--- a/DQMOffline/JetMET/interface/HTMHTAnalyzer.h
+++ b/DQMOffline/JetMET/interface/HTMHTAnalyzer.h
@@ -37,8 +37,6 @@ class HTMHTAnalyzer : public DQMEDAnalyzer {
   /// Destructor
   virtual ~HTMHTAnalyzer();
 
-  /// Inizialize parameters for histo binning
-  void beginJob(DQMStore * dbe);
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   /// Get the analysis
   void analyze(const edm::Event&, const edm::EventSetup&, 

--- a/DQMOffline/JetMET/interface/JetAnalyzer.h
+++ b/DQMOffline/JetMET/interface/JetAnalyzer.h
@@ -79,8 +79,6 @@ class JetAnalyzer : public thread_unsafe::DQMEDAnalyzer {
   /// Get the analysis
  void analyze(const edm::Event&, const edm::EventSetup&);
 
-  /// Save the histos
-  void endJob(void);
 
   /// Initialize run-based parameters
   void dqmBeginRun(const edm::Run&,  const edm::EventSetup&);
@@ -103,8 +101,6 @@ class JetAnalyzer : public thread_unsafe::DQMEDAnalyzer {
   //jetAnalysis::TrackPropagatorToCalo trackPropagator_;
   /// Helper object to calculate strip SoN for tracks
   //jetAnalysis::StripSignalOverNoiseCalculator sOverNCalculator_;
-
-  DQMStore* dbe_;
 
   //try to put one collection as start
   edm::InputTag mInputCollection_;

--- a/DQMOffline/JetMET/interface/METAnalyzer.h
+++ b/DQMOffline/JetMET/interface/METAnalyzer.h
@@ -87,9 +87,6 @@ class METAnalyzer : public thread_unsafe::DQMEDAnalyzer{
   /// Destructor
   virtual ~METAnalyzer();
 
-  /// Finish up a job
-  void endJob();
-
 /// Inizialize parameters for histo binning
 //  void beginJob(void);
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
@@ -129,9 +126,6 @@ class METAnalyzer : public thread_unsafe::DQMEDAnalyzer{
   // Switch for verbosity
   int verbose_;
 
-  //edm::ConsumesCollector iC;
-
-  DQMStore * dbe_;
 
   std::string MetType_;
   bool outputMEsInRootFile;

--- a/DQMOffline/JetMET/interface/SUSYDQMAnalyzer.h
+++ b/DQMOffline/JetMET/interface/SUSYDQMAnalyzer.h
@@ -27,10 +27,8 @@ class SUSYDQMAnalyzer: public DQMEDAnalyzer {
  private:
   edm::ParameterSet iConfig;
 
-  virtual void beginJob();
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   virtual void analyze(const edm::Event& , const edm::EventSetup&);
-  virtual void endRun(const edm::Run&, const edm::EventSetup&);
 
   edm::EDGetTokenT<reco::PFMETCollection> thePFMETCollectionToken;
   edm::EDGetTokenT<std::vector<reco::PFJet> > thePFJetCollectionToken;
@@ -46,8 +44,6 @@ class SUSYDQMAnalyzer: public DQMEDAnalyzer {
 
   std::string SUSYFolder;
   static const char* messageLoggerCatregory;
-  
-  DQMStore* dqm;
 
   //Susy DQM storing elements
   //remove TCMET and JPT related variables

--- a/DQMOffline/JetMET/plugins/SusyPostProcessor.h
+++ b/DQMOffline/JetMET/plugins/SusyPostProcessor.h
@@ -9,8 +9,8 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 
-#include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
+#include "DQMServices/Core/interface/DQMEDHarvester.h"
 
 #include <vector>
 #include <string>
@@ -19,30 +19,24 @@
 #include "TH1.h"
 #include "TMath.h"
 
-class SusyPostProcessor : public edm::EDAnalyzer
+class SusyPostProcessor : public DQMEDHarvester
 {
  public:
   explicit SusyPostProcessor( const edm::ParameterSet& pSet ) ;
   ~SusyPostProcessor();
                                    
-      
-  virtual void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup ) ;
-  virtual void beginJob(void) ;
-  virtual void beginRun(const edm::Run&, const edm::EventSetup& iSetup);
-  virtual void endJob();
-  void endRun(const edm::Run& , const edm::EventSetup& ) ;
 
  private:
 
   edm::ParameterSet iConfig;
-  void QuantilePlots(MonitorElement* ME, double q_value);
+  virtual void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) ;
+  void QuantilePlots(MonitorElement* &, double, DQMStore::IBooker &);
 
   static const char* messageLoggerCatregory;
 
   std::string SUSYFolder;
   double _quantile;
 
-  DQMStore* dqm;
   std::vector<MonitorElement*> histoVector;
   std::vector<std::string> Dirs;
 

--- a/DQMOffline/JetMET/src/BeamHaloAnalyzer.cc
+++ b/DQMOffline/JetMET/src/BeamHaloAnalyzer.cc
@@ -76,9 +76,6 @@ BeamHaloAnalyzer::BeamHaloAnalyzer( const edm::ParameterSet& iConfig)
 
 }
 
-
-void BeamHaloAnalyzer::beginJob(void){}
-
   
 void BeamHaloAnalyzer::bookHistograms(DQMStore::IBooker & ibooker,
 					edm::Run const & iRun,
@@ -873,11 +870,6 @@ void BeamHaloAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& 
 	}
     }
   
-}
-
-void BeamHaloAnalyzer::endJob()
-{
-
 }
 
 BeamHaloAnalyzer::~BeamHaloAnalyzer(){

--- a/DQMOffline/JetMET/src/ECALRecHitAnalyzer.cc
+++ b/DQMOffline/JetMET/src/ECALRecHitAnalyzer.cc
@@ -19,11 +19,6 @@ ECALRecHitAnalyzer::ECALRecHitAnalyzer(const edm::ParameterSet& iConfig)
   //  EERecHitsLabel_= consumes<EcalRecHitCollection>(edm::InputTag(EERecHitsLabel_));
 }
 
-void ECALRecHitAnalyzer::endJob() {
-
-} 
-
-//void ECALRecHitAnalyzer::beginJob(void){
 void ECALRecHitAnalyzer::dqmbeginRun(const edm::Run& iRun,const edm::EventSetup& iSetup){
   CurrentEvent = -1;
   // Fill the geometry histograms
@@ -35,7 +30,6 @@ void ECALRecHitAnalyzer::bookHistograms(DQMStore::IBooker & ibooker,
 					edm::EventSetup const & )
 {
   // get ahold of back-end interface
-  //  dbe_ = edm::Service<DQMStore>().operator->();
      // Book Geometry Histograms
     ibooker.setCurrentFolder(FolderName_+"/geometry");
     

--- a/DQMOffline/JetMET/src/HCALRecHitAnalyzer.cc
+++ b/DQMOffline/JetMET/src/HCALRecHitAnalyzer.cc
@@ -869,9 +869,3 @@ void HCALRecHitAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup
 
 }
 
-
-void HCALRecHitAnalyzer::endJob()
-{
-
-
-} 

--- a/DQMOffline/JetMET/src/HTMHTAnalyzer.cc
+++ b/DQMOffline/JetMET/src/HTMHTAnalyzer.cc
@@ -36,9 +36,7 @@ HTMHTAnalyzer::HTMHTAnalyzer(const edm::ParameterSet& pSet) {
 // ***********************************************************
 HTMHTAnalyzer::~HTMHTAnalyzer() { }
 
-void HTMHTAnalyzer::beginJob(DQMStore * dbe) {
 
-}
 
 void HTMHTAnalyzer::bookHistograms(DQMStore::IBooker & ibooker,
 				     edm::Run const & iRun,

--- a/DQMOffline/JetMET/src/JetAnalyzer.cc
+++ b/DQMOffline/JetMET/src/JetAnalyzer.cc
@@ -246,8 +246,6 @@ JetAnalyzer::JetAnalyzer(const edm::ParameterSet& pSet)
   ptThresholdUnc_=parameters_.getParameter<double>("ptThresholdUnc");
   asymmetryThirdJetCut_ = parameters_.getParameter<double>("asymmetryThirdJetCut");
   balanceThirdJetCut_   = parameters_.getParameter<double>("balanceThirdJetCut");
-
-  dbe_= edm::Service<DQMStore>().operator->();
 }  
   
 
@@ -260,11 +258,6 @@ JetAnalyzer::~JetAnalyzer() {
   delete DCSFilterForDCSMonitoring_;
   delete DCSFilterForJetMonitoring_;
   LogTrace(metname)<<"[JetAnalyzer] Saving the histos";
-  //--- Jet
-  if(outputMEsInRootFile){
-      //dbe_->save(mOutputFile_);
-    dbe_->save(mOutputFile_);
-  }
 }
 
 // ***********************************************************
@@ -2318,10 +2311,6 @@ void JetAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
     }//DPhi cut of 2.1
   }//dijet selection, check if both leading jets are IDed
   
-}
-
-// ***********************************************************
-void JetAnalyzer::endJob(void) {
 }
 
 

--- a/DQMOffline/JetMET/src/METAnalyzer.cc
+++ b/DQMOffline/JetMET/src/METAnalyzer.cc
@@ -145,7 +145,6 @@ METAnalyzer::METAnalyzer(const edm::ParameterSet& pSet) {
 
  FolderName_              = parameters.getUntrackedParameter<std::string>("FolderName");
 
- dbe_ = edm::Service<DQMStore>().operator->();
 }
 
 // ***********************************************************
@@ -154,34 +153,14 @@ METAnalyzer::~METAnalyzer() {
     delete *it;
   }
   delete DCSFilter_;
-
-  if(outputMEsInRootFile){
-      //dbe->save(mOutputFile_);
-    dbe_->save(mOutputFile_);
-  }
-
-
-  //delete DCSFilter_;
-
-//  delete highPtJetEventFlag_;
-//  delete lowPtJetEventFlag_;
-//  delete minBiasEventFlag_;
-//  delete highMETEventFlag_;
-//  delete eleEventFlag_;
-//  delete muonEventFlag_;
 }
 
 
 void METAnalyzer::bookHistograms(DQMStore::IBooker & ibooker,
 				     edm::Run const & iRun,
 				 edm::EventSetup const &) {
-  // DQStore stuff
-  //dbe_ = edm::Service<DQMStore>().operator->();
-  //LogTrace(metname)<<"[METAnalyzer] Parameters initialization";
   std::string DirName = FolderName_+metCollectionLabel_.label();
   ibooker.setCurrentFolder(DirName);
-
-  //dbe_ = dbe;
 
   folderNames_.push_back("Uncleaned");
   folderNames_.push_back("Cleaned");
@@ -193,17 +172,6 @@ void METAnalyzer::bookHistograms(DQMStore::IBooker & ibooker,
     }
 }
 
-// ***********************************************************
-void METAnalyzer::endJob() {
-
-  //delete DCSFilter_;
-
-  //if(outputMEsInRootFile){
-      //dbe->save(mOutputFile_);
-  //dbe_->save(mOutputFile_);
-  //}
-
-}
 
 // ***********************************************************
 void METAnalyzer::bookMESet(std::string DirName, DQMStore::IBooker & ibooker, std::map<std::string,MonitorElement*>& map_of_MEs)

--- a/DQMOffline/JetMET/src/SUSYDQMAnalyzer.cc
+++ b/DQMOffline/JetMET/src/SUSYDQMAnalyzer.cc
@@ -74,7 +74,6 @@ SUSYDQMAnalyzer::SUSYDQMAnalyzer( const edm::ParameterSet& pSet)
   iConfig = pSet;
   
   SUSYFolder = iConfig.getParameter<std::string>("folderName");
-  dqm = edm::Service<DQMStore>().operator->();
   // Load parameters 
   thePFMETCollectionToken     = consumes<reco::PFMETCollection>   (iConfig.getParameter<edm::InputTag>("PFMETCollectionLabel"));
   theCaloMETCollectionToken   = consumes<reco::CaloMETCollection> (iConfig.getParameter<edm::InputTag>("CaloMETCollectionLabel"));
@@ -94,9 +93,6 @@ SUSYDQMAnalyzer::SUSYDQMAnalyzer( const edm::ParameterSet& pSet)
 
 const char* SUSYDQMAnalyzer::messageLoggerCatregory = "SUSYDQM";
 
-void SUSYDQMAnalyzer::beginJob(void){
-
-}
 
 void SUSYDQMAnalyzer::bookHistograms(DQMStore::IBooker & ibooker,
 				     edm::Run const & iRun,
@@ -273,8 +269,6 @@ void SUSYDQMAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& i
 
 }
 
-void SUSYDQMAnalyzer::endRun(const edm::Run&, const edm::EventSetup&){  
-}
 
 SUSYDQMAnalyzer::~SUSYDQMAnalyzer(){
 }

--- a/DQMOffline/JetMET/test/run_PromptAna.py
+++ b/DQMOffline/JetMET/test/run_PromptAna.py
@@ -56,7 +56,8 @@ else:
 #'/store/relval/CMSSW_7_0_0_pre8/RelValQCD_FlatPt_15_3000/GEN-SIM-RECO/PU_START70_V2_eg-v1/00000/FEFD7ED7-D952-E311-962B-0025905A605E.root'
 ###'/store/relval/CMSSW_5_3_6-GR_R_53_V15_RelVal_jet2012B/JetHT/RECO/v2/00000/FEC61CBE-062A-E211-AA5D-0026189438E4.root').split(",")
 #'/store/relval/CMSSW_7_0_0_pre11/RelValQCD_FlatPt_15_3000HS_13/GEN-SIM-RECO/POSTLS162_V4-v1/00000/F0127B3E-8A6A-E311-9A07-002590593902.root'
-'/store/relval/CMSSW_7_1_0_pre2/RelValTTbar_13/GEN-SIM-RECO/PU50ns_POSTLS170_V4-v1/00000/FAA1E1EE-BE8F-E311-B633-0026189438BC.root'
+#'/store/relval/CMSSW_7_1_0_pre4_AK4/RelValTTbar_13/GEN-SIM-RECO/POSTLS171_V1-v2/00000/7E11BD2A-5CB5-E311-B931-0025905A60A0.root'
+'/store/relval/CMSSW_7_1_0_pre7/RelValTTbar_13/GEN-SIM-RECO/PRE_LS171_V7-v1/00000/BAD462A0-0CD1-E311-B8EA-02163E00E8E4.root'
 )
 print 'List of input files'
 print inputfiles
@@ -72,7 +73,7 @@ process.load("FWCore.MessageLogger.MessageLogger_cfi")
 #
 # DQM
 #
-process.load("DQMServices.Core.DQM_cfg")
+#process.load("DQMServices.Core.DQM_cfg")
 
 process.load("DQMServices.Components.MEtoEDMConverter_cfi")
 
@@ -105,10 +106,10 @@ else:
   process.load("DQMOffline.JetMET.jetMETDQMOfflineSource_cff")
 
 #change values for first jet and met analyzer parameterset -> all other parametersets are cloned from these
-process.jetDQMAnalyzerAk5CaloUncleaned.OutputMEsInRootFile = cms.bool(True)
-process.jetDQMAnalyzerAk5CaloUncleaned.OutputFileName = cms.string("jetMETMonitoring_%s.root" % jobname)
-process.jetDQMAnalyzerAk5CaloUncleaned.TriggerResultsLabel = cms.InputTag("TriggerResults","",trigger_set)
-process.jetDQMAnalyzerAk5CaloUncleaned.processname = cms.string(trigger_set)
+process.jetDQMAnalyzerAk4CaloUncleaned.OutputMEsInRootFile = cms.bool(True)
+process.jetDQMAnalyzerAk4CaloUncleaned.OutputFileName = cms.string("jetMETMonitoring_%s.root" % jobname)
+process.jetDQMAnalyzerAk4CaloUncleaned.TriggerResultsLabel = cms.InputTag("TriggerResults","",trigger_set)
+process.jetDQMAnalyzerAk4CaloUncleaned.processname = cms.string(trigger_set)
 #process.tcMetDQMAnalyzer.OutputMEsInRootFile = cms.bool(True)
 #process.tcMetDQMAnalyzer.OutputFileName = cms.string("jetMETMonitoring_%s.root" % jobname)
 #process.tcMetDQMAnalyzer.TriggerResultsLabel = cms.InputTag("TriggerResults","",trigger_set)
@@ -170,7 +171,7 @@ process.Timing = cms.Service("Timing")
 
 ## # Comment this out or reconfigure to see error messages 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring('tcMetDQMAnalyzer'),
+    debugModules = cms.untracked.vstring('caloMetDQMAnalyzer'),
     cout = cms.untracked.PSet(
         default = cms.untracked.PSet(
             limit = cms.untracked.int32(0)
@@ -188,6 +189,13 @@ process.MessageLogger = cms.Service("MessageLogger",
     destinations = cms.untracked.vstring('cout')
 )
 
+
+process.load('Configuration/StandardSequences/EDMtoMEAtRunEnd_cff')
+process.dqmSaver.referenceHandling = cms.untracked.string('all')
+#
+cmssw_version = os.environ.get('CMSSW_VERSION','CMSSW_X_Y_Z')
+Workflow = '/JetMET/'+str(cmssw_version)+'/Harvesting'
+process.dqmSaver.workflow = Workflow
 
 #process.load('RecoJets.JetProducers.fixedGridRhoProducerFastjet_cfi')
 
@@ -219,9 +227,8 @@ else:
   process.p = cms.Path(#process.BeamHaloId
 #                       process.fixedGridRhoFastjetAllCalo
                        process.jetMETDQMOfflineSource
-                     * process.dqmStoreStats
+                     * process.dqmStoreStats* process.dqmSaver
 ###                       * process.MEtoEDMConverter
                      )
 
 process.outpath = cms.EndPath(process.FEVT)
-process.DQM.collectorHost = ''


### PR DESCRIPTION
leftover calls of DQMStore and beginJob and endJob have been removed from all modules (endRun where not needed as well), the SusyPostProcessor has been move to DQMEDHarvester class.

The code was checked by running the matrix, since we call a value map for the ak4jetid of calojets, which has been added to the RECO sequence only recently. Development started from 7_1_X_2014-5-19-0200
