### PR TITLE
Make GctRawToDigi thread safe

### DIFF
--- a/EventFilter/GctRawToDigi/plugins/GctRawToDigi.cc
+++ b/EventFilter/GctRawToDigi/plugins/GctRawToDigi.cc
@@ -106,7 +106,6 @@ GctRawToDigi::GctRawToDigi(const edm::ParameterSet& iConfig) :
   
   // Error collection
   produces<L1TriggerErrorCollection>();
-  usesResource("GctRawToDigi");
   consumes<FEDRawDataCollection>(inputLabel_);
 }
 
@@ -122,12 +121,6 @@ GctRawToDigi::~GctRawToDigi()
 //
 // member functions
 //
-
-// ------------ method called once each job just before starting event loop  ------------
-void GctRawToDigi::beginJob()
-{
-}
-
 
 // ------------ method called to produce the data  ------------
 void GctRawToDigi::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)

--- a/EventFilter/GctRawToDigi/plugins/GctRawToDigi.h
+++ b/EventFilter/GctRawToDigi/plugins/GctRawToDigi.h
@@ -26,7 +26,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/one/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -41,7 +41,7 @@
 // ***  THE UNPACK PROCESS MUST NEVER THROW ANY KIND OF EXCEPTION! *** 
 // *******************************************************************
 
-class GctRawToDigi : public edm::one::EDProducer<edm::one::SharedResources>
+class GctRawToDigi : public edm::stream::EDProducer<>
 {
 public:
 
@@ -51,8 +51,7 @@ public:
   
 private: // methods
 
-  virtual void beginJob();
-  virtual void produce(edm::Event&, const edm::EventSetup&);
+  virtual void produce(edm::Event&, const edm::EventSetup&) override;
   
   /// Unpacks the raw data
   /*! \param invalidDataFlag - if true, then won't attempt unpack but just output empty collecions. */

--- a/EventFilter/GctRawToDigi/src/GctFormatTranslateBase.h
+++ b/EventFilter/GctRawToDigi/src/GctFormatTranslateBase.h
@@ -87,19 +87,14 @@ protected:
   /* PROTECTED METHODS */
 
   /* Static data member access methods */
-  virtual BlockLengthMap& blockLengthMap() = 0; ///< get the static block ID to block-length map.
   virtual const BlockLengthMap& blockLengthMap() const = 0; ///< get the static block ID to block-length map.
   
-  virtual BlockNameMap& blockNameMap() = 0;  ///< get the static block ID to block-name map.
   virtual const BlockNameMap& blockNameMap() const = 0;  ///< get the static block ID to blockname map.
   
-  virtual BlkToRctCrateMap& rctEmCrateMap() = 0;  ///< get the static block ID to RCT crate map for electrons.
   virtual const BlkToRctCrateMap& rctEmCrateMap() const = 0;  ///< get static the block ID to RCT crate map for electrons.
  
-  virtual BlkToRctCrateMap& rctJetCrateMap() = 0;  ///< get the static block ID to RCT crate map for jets
   virtual const BlkToRctCrateMap& rctJetCrateMap() const = 0;  ///< get the static block ID to RCT crate map for jets
 
-  virtual BlockIdToEmCandIsoBoundMap& internEmIsoBounds() = 0;  ///< get the static intern EM cand isolated boundary map.
   virtual const BlockIdToEmCandIsoBoundMap& internEmIsoBounds() const = 0;  ///< get the static intern EM cand isolated boundary map.
 
 

--- a/EventFilter/GctRawToDigi/src/GctFormatTranslateMCLegacy.h
+++ b/EventFilter/GctRawToDigi/src/GctFormatTranslateMCLegacy.h
@@ -31,10 +31,10 @@ public:
   virtual ~GctFormatTranslateMCLegacy(); ///< Destructor.
 
   /// Generate a block header from four 8-bit values.
-  virtual GctBlockHeader generateBlockHeader(const unsigned char * data) const;
+  virtual GctBlockHeader generateBlockHeader(const unsigned char * data) const override;
   
   /// Get digis from the block - will return true if it succeeds, false otherwise.
-  virtual bool convertBlock(const unsigned char * d, const GctBlockHeader& hdr);
+  virtual bool convertBlock(const unsigned char * d, const GctBlockHeader& hdr) override;
 
 
   /* ------------------------------ */
@@ -72,20 +72,15 @@ protected:
   /* PROTECTED METHODS */
 
   /* Static data member access methods */
-  virtual BlockLengthMap& blockLengthMap() { return m_blockLength; } ///< get the static block ID to block-length map.
-  virtual const BlockLengthMap& blockLengthMap() const { return m_blockLength; } ///< get the static block ID to block-length map.
+  virtual const BlockLengthMap& blockLengthMap() const override final { return m_blockLength; } ///< get the static block ID to block-length map.
   
-  virtual BlockNameMap& blockNameMap() { return m_blockName; }  ///< get the static block ID to block-name map.
-  virtual const BlockNameMap& blockNameMap() const { return m_blockName; }  ///< get the static block ID to blockname map.
+  virtual const BlockNameMap& blockNameMap() const override final { return m_blockName; }  ///< get the static block ID to blockname map.
   
-  virtual BlkToRctCrateMap& rctEmCrateMap() { return m_rctEmCrate; }  ///< get the static block ID to RCT crate map for electrons.
-  virtual const BlkToRctCrateMap& rctEmCrateMap() const { return m_rctEmCrate; }  ///< get static the block ID to RCT crate map for electrons.
+  virtual const BlkToRctCrateMap& rctEmCrateMap() const override final { return m_rctEmCrate; }  ///< get static the block ID to RCT crate map for electrons.
  
-  virtual BlkToRctCrateMap& rctJetCrateMap() { return m_rctJetCrate; }  ///< get the static block ID to RCT crate map for jets
-  virtual const BlkToRctCrateMap& rctJetCrateMap() const { return m_rctJetCrate; }  ///< get the static block ID to RCT crate map for jets
+  virtual const BlkToRctCrateMap& rctJetCrateMap() const override final { return m_rctJetCrate; }  ///< get the static block ID to RCT crate map for jets
 
-  virtual BlockIdToEmCandIsoBoundMap& internEmIsoBounds() { return m_internEmIsoBounds; }  ///< get the static intern EM cand isolated boundary map.
-  virtual const BlockIdToEmCandIsoBoundMap& internEmIsoBounds() const { return m_internEmIsoBounds; }  ///< get the static intern EM cand isolated boundary map.
+  virtual const BlockIdToEmCandIsoBoundMap& internEmIsoBounds() const override final { return m_internEmIsoBounds; }  ///< get the static intern EM cand isolated boundary map.
 
 
   /* Other general methods */
@@ -109,23 +104,23 @@ private:
   /* PRIVATE MEMBER DATA */
   
   /// Map to translate block number to fundamental size of a block (i.e. for 1 time-sample).
-  static BlockLengthMap m_blockLength;
+  static const BlockLengthMap m_blockLength;
   
   /// Map to hold a description for each block number.
-  static BlockNameMap m_blockName;
+  static const BlockNameMap m_blockName;
   
   /// Map to relate capture block ID to the RCT crate the data originated from (for electrons).
-  static BlkToRctCrateMap m_rctEmCrate;
+  static const BlkToRctCrateMap m_rctEmCrate;
 
   /// Map to relate capture block ID to the RCT crate the data originated from (for jets).
-  static BlkToRctCrateMap m_rctJetCrate;
+  static const BlkToRctCrateMap m_rctJetCrate;
   
   /*! A map of Block IDs to IsoBoundaryPairs for storing the location of the isolated
    *  Internal EM cands in the pipeline, as this differs with Block ID. */ 
-  static BlockIdToEmCandIsoBoundMap m_internEmIsoBounds;
+  static const BlockIdToEmCandIsoBoundMap m_internEmIsoBounds;
 
   /// Block ID to unpack function map.
-  static BlockIdToUnpackFnMap m_blockUnpackFn;
+  static const BlockIdToUnpackFnMap m_blockUnpackFn;
   
 
   /* PRIVATE METHODS */

--- a/EventFilter/GctRawToDigi/src/GctFormatTranslateV35.h
+++ b/EventFilter/GctRawToDigi/src/GctFormatTranslateV35.h
@@ -28,10 +28,10 @@ public:
   virtual ~GctFormatTranslateV35(); ///< Destructor.
 
   /// Generate a block header from four 8-bit values.
-  virtual GctBlockHeader generateBlockHeader(const unsigned char * data) const;
+  virtual GctBlockHeader generateBlockHeader(const unsigned char * data) const override;
   
   /// Get digis from the block - will return true if it succeeds, false otherwise.
-  virtual bool convertBlock(const unsigned char * d, const GctBlockHeader& hdr);
+  virtual bool convertBlock(const unsigned char * d, const GctBlockHeader& hdr) override;
 
 
   /* ------------------------------ */
@@ -46,20 +46,15 @@ protected:
   /* PROTECTED METHODS */
 
   /* Static data member access methods */
-  virtual BlockLengthMap& blockLengthMap() { return m_blockLength; } ///< get the static block ID to block-length map.
-  virtual const BlockLengthMap& blockLengthMap() const { return m_blockLength; } ///< get the static block ID to block-length map.
+  virtual const BlockLengthMap& blockLengthMap() const override final { return m_blockLength; } ///< get the static block ID to block-length map.
   
-  virtual BlockNameMap& blockNameMap() { return m_blockName; }  ///< get the static block ID to block-name map.
-  virtual const BlockNameMap& blockNameMap() const { return m_blockName; }  ///< get the static block ID to blockname map.
+  virtual const BlockNameMap& blockNameMap() const override final { return m_blockName; }  ///< get the static block ID to blockname map.
   
-  virtual BlkToRctCrateMap& rctEmCrateMap() { return m_rctEmCrate; }  ///< get the static block ID to RCT crate map for electrons.
-  virtual const BlkToRctCrateMap& rctEmCrateMap() const { return m_rctEmCrate; }  ///< get static the block ID to RCT crate map for electrons.
+  virtual const BlkToRctCrateMap& rctEmCrateMap() const override final { return m_rctEmCrate; }  ///< get static the block ID to RCT crate map for electrons.
  
-  virtual BlkToRctCrateMap& rctJetCrateMap() { return m_rctJetCrate; }  ///< get the static block ID to RCT crate map for jets
-  virtual const BlkToRctCrateMap& rctJetCrateMap() const { return m_rctJetCrate; }  ///< get the static block ID to RCT crate map for jets
+  virtual const BlkToRctCrateMap& rctJetCrateMap() const override final { return m_rctJetCrate; }  ///< get the static block ID to RCT crate map for jets
 
-  virtual BlockIdToEmCandIsoBoundMap& internEmIsoBounds() { return m_internEmIsoBounds; }  ///< get the static intern EM cand isolated boundary map.
-  virtual const BlockIdToEmCandIsoBoundMap& internEmIsoBounds() const { return m_internEmIsoBounds; }  ///< get the static intern EM cand isolated boundary map.
+  virtual const BlockIdToEmCandIsoBoundMap& internEmIsoBounds() const override final { return m_internEmIsoBounds; }  ///< get the static intern EM cand isolated boundary map.
 
 
   /* Other general methods */
@@ -67,7 +62,7 @@ protected:
   virtual uint32_t generateRawHeader(const uint32_t blockId,
                                      const uint32_t nSamples,
                                      const uint32_t bxId,
-                                     const uint32_t eventId) const;
+                                     const uint32_t eventId) const override;
 
 
 private:
@@ -83,23 +78,23 @@ private:
   /* PRIVATE MEMBER DATA */
   
   /// Map to translate block number to fundamental size of a block (i.e. for 1 time-sample).
-  static BlockLengthMap m_blockLength;
+  static const BlockLengthMap m_blockLength;
   
   /// Map to hold a description for each block number.
-  static BlockNameMap m_blockName;
+  static const BlockNameMap m_blockName;
   
   /// Map to relate capture block ID to the RCT crate the data originated from (for electrons).
-  static BlkToRctCrateMap m_rctEmCrate;
+  static const BlkToRctCrateMap m_rctEmCrate;
 
   /// Map to relate capture block ID to the RCT crate the data originated from (for jets).
-  static BlkToRctCrateMap m_rctJetCrate;
+  static const BlkToRctCrateMap m_rctJetCrate;
   
   /*! A map of Block IDs to IsoBoundaryPairs for storing the location of the isolated
    *  Internal EM cands in the pipeline, as this differs with Block ID. */ 
-  static BlockIdToEmCandIsoBoundMap m_internEmIsoBounds;
+  static const BlockIdToEmCandIsoBoundMap m_internEmIsoBounds;
 
   /// Block ID to unpack function map.
-  static BlockIdToUnpackFnMap m_blockUnpackFn;
+  static const BlockIdToUnpackFnMap m_blockUnpackFn;
   
 
   /* PRIVATE METHODS */

--- a/EventFilter/GctRawToDigi/src/GctFormatTranslateV38.h
+++ b/EventFilter/GctRawToDigi/src/GctFormatTranslateV38.h
@@ -31,10 +31,10 @@ public:
   virtual ~GctFormatTranslateV38(); ///< Destructor.
 
   /// Generate a block header from four 8-bit values.
-  virtual GctBlockHeader generateBlockHeader(const unsigned char * data) const;
+  virtual GctBlockHeader generateBlockHeader(const unsigned char * data) const override;
   
   /// Get digis from the block - will return true if it succeeds, false otherwise.
-  virtual bool convertBlock(const unsigned char * d, const GctBlockHeader& hdr);
+  virtual bool convertBlock(const unsigned char * d, const GctBlockHeader& hdr) override;
 
 
   /* ------------------------------ */
@@ -49,20 +49,15 @@ protected:
   /* PROTECTED METHODS */
 
   /* Static data member access methods */
-  virtual BlockLengthMap& blockLengthMap() { return m_blockLength; } ///< get the static block ID to block-length map.
-  virtual const BlockLengthMap& blockLengthMap() const { return m_blockLength; } ///< get the static block ID to block-length map.
+  virtual const BlockLengthMap& blockLengthMap() const override final { return m_blockLength; } ///< get the static block ID to block-length map.
   
-  virtual BlockNameMap& blockNameMap() { return m_blockName; }  ///< get the static block ID to block-name map.
-  virtual const BlockNameMap& blockNameMap() const { return m_blockName; }  ///< get the static block ID to blockname map.
+  virtual const BlockNameMap& blockNameMap() const override final { return m_blockName; }  ///< get the static block ID to blockname map.
   
-  virtual BlkToRctCrateMap& rctEmCrateMap() { return m_rctEmCrate; }  ///< get the static block ID to RCT crate map for electrons.
-  virtual const BlkToRctCrateMap& rctEmCrateMap() const { return m_rctEmCrate; }  ///< get static the block ID to RCT crate map for electrons.
+  virtual const BlkToRctCrateMap& rctEmCrateMap() const override final { return m_rctEmCrate; }  ///< get static the block ID to RCT crate map for electrons.
  
-  virtual BlkToRctCrateMap& rctJetCrateMap() { return m_rctJetCrate; }  ///< get the static block ID to RCT crate map for jets
-  virtual const BlkToRctCrateMap& rctJetCrateMap() const { return m_rctJetCrate; }  ///< get the static block ID to RCT crate map for jets
+  virtual const BlkToRctCrateMap& rctJetCrateMap() const override final { return m_rctJetCrate; }  ///< get the static block ID to RCT crate map for jets
 
-  virtual BlockIdToEmCandIsoBoundMap& internEmIsoBounds() { return m_internEmIsoBounds; }  ///< get the static intern EM cand isolated boundary map.
-  virtual const BlockIdToEmCandIsoBoundMap& internEmIsoBounds() const { return m_internEmIsoBounds; }  ///< get the static intern EM cand isolated boundary map.
+  virtual const BlockIdToEmCandIsoBoundMap& internEmIsoBounds() const override final { return m_internEmIsoBounds; }  ///< get the static intern EM cand isolated boundary map.
 
 
   /* Other general methods */
@@ -70,7 +65,7 @@ protected:
   virtual uint32_t generateRawHeader(const uint32_t blockId,
                                      const uint32_t nSamples,
                                      const uint32_t bxId,
-                                     const uint32_t eventId) const;
+                                     const uint32_t eventId) const override;
 
 
 private:
@@ -86,23 +81,23 @@ private:
   /* PRIVATE MEMBER DATA */
   
   /// Map to translate block number to fundamental size of a block (i.e. for 1 time-sample).
-  static BlockLengthMap m_blockLength;
+  static const BlockLengthMap m_blockLength;
   
   /// Map to hold a description for each block number.
-  static BlockNameMap m_blockName;
+  static const BlockNameMap m_blockName;
   
   /// Map to relate capture block ID to the RCT crate the data originated from (for electrons).
-  static BlkToRctCrateMap m_rctEmCrate;
+  static const BlkToRctCrateMap m_rctEmCrate;
 
   /// Map to relate capture block ID to the RCT crate the data originated from (for jets).
-  static BlkToRctCrateMap m_rctJetCrate;
+  static const BlkToRctCrateMap m_rctJetCrate;
   
   /*! A map of Block IDs to IsoBoundaryPairs for storing the location of the isolated
    *  Internal EM cands in the pipeline, as this differs with Block ID. */ 
-  static BlockIdToEmCandIsoBoundMap m_internEmIsoBounds;
+  static const BlockIdToEmCandIsoBoundMap m_internEmIsoBounds;
 
   /// Block ID to unpack function map.
-  static BlockIdToUnpackFnMap m_blockUnpackFn;
+  static const BlockIdToUnpackFnMap m_blockUnpackFn;
   
   /// Number of BXs of GCT data to unpack (assuming they are in the raw data)
   const unsigned m_numberOfGctSamplesToUnpack; 


### PR DESCRIPTION
Converted all the statics accessed by GctRawToDigi to be const by using initializer lists. This made it safe to switch GctRawToDigi to a stream module.
