### PR TITLE
Saving tau decay mode inside PFTau and patTau

### DIFF
--- a/DataFormats/PatCandidates/src/TauPFSpecific.cc
+++ b/DataFormats/PatCandidates/src/TauPFSpecific.cc
@@ -44,6 +44,7 @@ pat::tau::TauPFSpecific::TauPFSpecific(const reco::PFTau& tau) :
     caloComp_(tau.caloComp()),
     segComp_(tau.segComp()),
     muonDecision_(tau.muonDecision()),
+    decayMode_(tau.decayMode()),
     dxy_(0.),
     dxy_error_(1.e+3),
     hasSV_(false)

--- a/DataFormats/TauReco/interface/PFTau.h
+++ b/DataFormats/TauReco/interface/PFTau.h
@@ -148,6 +148,8 @@ class PFTau : public BaseTau {
     /// Retrieve the identified hadronic decay mode according to the number of
     /// charged and piZero candidates in the signal cone
     hadronicDecayMode decayMode() const;
+    hadronicDecayMode calculateDecayMode() const;
+    void setDecayMode(const hadronicDecayMode&);
 
     //Electron rejection
     float emFraction() const; // Ecal/Hcal Cluster Energy
@@ -221,6 +223,8 @@ class PFTau : public BaseTau {
     // Muon rejection variables
     float caloComp_;
     float segComp_;
+
+    hadronicDecayMode decayMode_;
 
     reco::PFJetRef jetRef_;
     PFTauTagInfoRef PFTauTagInfoRef_;

--- a/DataFormats/TauReco/src/PFTau.cc
+++ b/DataFormats/TauReco/src/PFTau.cc
@@ -22,6 +22,7 @@ PFTau::PFTau()
     caloComp_ = NAN;
     segComp_ = NAN;
     muonDecision_ = NAN;
+    decayMode_=kNull;
 }
 
 PFTau::PFTau(Charge q, const LorentzVector& p4, const Point& vtx) 
@@ -44,6 +45,7 @@ PFTau::PFTau(Charge q, const LorentzVector& p4, const Point& vtx)
    caloComp_ = NAN;
    segComp_ = NAN;
    muonDecision_ = NAN;
+   decayMode_=kNull;
 }
 
 PFTau* PFTau::clone() const { return new PFTau(*this); }
@@ -173,7 +175,9 @@ void PFTau::setIsolationTauChargedHadronCandidatesRefs(const PFRecoTauChargedHad
   isolationTauChargedHadronCandidatesRefs_ = cands;
 }
 
-PFTau::hadronicDecayMode PFTau::decayMode() const {
+PFTau::hadronicDecayMode PFTau::decayMode() const { return decayMode_; }
+
+PFTau::hadronicDecayMode PFTau::calculateDecayMode() const {
   unsigned int nCharged = signalTauChargedHadronCandidates().size();
   unsigned int nPiZeros = signalPiZeroCandidates().size();
   // If no tracks exist, this is definitely not a tau!
@@ -184,10 +188,12 @@ PFTau::hadronicDecayMode PFTau::decayMode() const {
   unsigned int trackIndex = (nCharged - 1)*(maxPiZeros + 1);
   // Check if we handle the given number of tracks
   if ( trackIndex >= kRareDecayMode ) return kRareDecayMode;
-  
-  nPiZeros = ( nPiZeros <= maxPiZeros ) ? nPiZeros : maxPiZeros;
+
+  if(nPiZeros>maxPiZeros) nPiZeros=maxPiZeros;
   return static_cast<PFTau::hadronicDecayMode>(trackIndex + nPiZeros);
 }
+
+void PFTau::setDecayMode(const PFTau::hadronicDecayMode& dm){ decayMode_=dm;}
 
 // Setting information about the isolation region
 float PFTau::isolationPFChargedHadrCandsPtSum() const {return isolationPFChargedHadrCandsPtSum_;}

--- a/DataFormats/TauReco/src/classes_def_2.xml
+++ b/DataFormats/TauReco/src/classes_def_2.xml
@@ -1,6 +1,7 @@
 <lcgdict>
   
-  <class name="reco::PFTau" ClassVersion="14">
+  <class name="reco::PFTau" ClassVersion="15">
+    <version ClassVersion="15" checksum="4105994460"/>
     <version ClassVersion="14" checksum="3087106015"/>
     <version ClassVersion="13" checksum="1088944403"/>
     <version ClassVersion="12" checksum="3369965409"/>

--- a/RecoTauTag/RecoTau/src/RecoTauConstructor.cc
+++ b/RecoTauTag/RecoTau/src/RecoTauConstructor.cc
@@ -340,7 +340,11 @@ std::auto_ptr<reco::PFTau> RecoTauConstructor::get(bool setupLeadingObjects)
 //        getCollection(kSignal, kAll)->end()
 //        )
 //      );
-  LogDebug("TauConstructorGet") << "Pt = " << tau_->pt() << ", eta = " << tau_->eta() << ", phi = " << tau_->phi() << ", mass = " << tau_->mass() ;
+  // Set Decay Mode
+  PFTau::hadronicDecayMode dm = tau_->calculateDecayMode();
+  tau_->setDecayMode(dm);
+
+  LogDebug("TauConstructorGet") << "Pt = " << tau_->pt() << ", eta = " << tau_->eta() << ", phi = " << tau_->phi() << ", mass = " << tau_->mass() << ", dm = " << tau_->decayMode() ;
 
   // Set charged isolation quantities
   tau_->setisolationPFChargedHadrCandsPtSum(


### PR DESCRIPTION
Fixing long standing issue when decay mode was not saved in PFTaus and it was not possible to recalculate it on-the-fly (it depends on nChargedHadrons and nPiZeros which are only transient). The decay mode is now saved also in patTau. Although the data member existed in pat::Tau before, it was not filled by default. Now it is filled during construction from the PFTau.

The RECO event size is increased by this PR, but the increase is very small. The top estimate is ~100b/event which I got for workflow 25202. The relative size increase was 0.5-1.0E-4 depending on the density of the event

@monicava, @veelken
