### PR TITLE
make "alias" optional in *METProducer

### DIFF
--- a/RecoMET/METProducers/src/CaloMETProducer.cc
+++ b/RecoMET/METProducers/src/CaloMETProducer.cc
@@ -39,8 +39,9 @@ namespace cms
   {
     noHF_ = iConfig.getParameter<bool>("noHF");
 
-    std::string alias(iConfig.getParameter<std::string>("alias"));
-    produces<reco::CaloMETCollection>().setBranchAlias(alias.c_str());
+    std::string alias = iConfig.exists("alias") ? iConfig.getParameter<std::string>("alias") : "";
+
+    produces<reco::CaloMETCollection>().setBranchAlias(alias);
 
     if (calculateSignificance_) resolutions_ = new metsig::SignAlgoResolutions(iConfig);
   }

--- a/RecoMET/METProducers/src/ElseMETProducer.cc
+++ b/RecoMET/METProducers/src/ElseMETProducer.cc
@@ -35,8 +35,9 @@ namespace cms
     : inputToken_(consumes<edm::View<reco::Candidate> >(iConfig.getParameter<edm::InputTag>("src")))
     , globalThreshold_(iConfig.getParameter<double>("globalThreshold"))
   {
-    std::string alias(iConfig.getParameter<std::string>("alias"));
-    produces<reco::METCollection>().setBranchAlias(alias.c_str());
+    std::string alias = iConfig.exists("alias") ? iConfig.getParameter<std::string>("alias") : "";
+
+    produces<reco::METCollection>().setBranchAlias(alias);
   }
 
 

--- a/RecoMET/METProducers/src/GenMETProducer.cc
+++ b/RecoMET/METProducers/src/GenMETProducer.cc
@@ -34,8 +34,8 @@ namespace cms
     , applyFiducialThresholdForFractions_(iConfig.getParameter<bool>("applyFiducialThresholdForFractions"))
     , usePt_(iConfig.getParameter<bool>("usePt"))
   {
-    std::string alias(iConfig.getParameter<std::string>("alias"));
-    produces<reco::GenMETCollection>().setBranchAlias(alias.c_str());
+    std::string alias = iConfig.exists("alias") ? iConfig.getParameter<std::string>("alias") : "";
+    produces<reco::GenMETCollection>().setBranchAlias(alias);
   }
 
 

--- a/RecoMET/METProducers/src/PFClusterMETProducer.cc
+++ b/RecoMET/METProducers/src/PFClusterMETProducer.cc
@@ -34,8 +34,8 @@ namespace cms
     : inputToken_(consumes<edm::View<reco::Candidate> >(iConfig.getParameter<edm::InputTag>("src")))
     , globalThreshold_(iConfig.getParameter<double>("globalThreshold"))
   {
-    std::string alias(iConfig.getParameter<std::string>("alias"));
-    produces<reco::PFClusterMETCollection>().setBranchAlias(alias.c_str());
+    std::string alias = iConfig.exists("alias") ? iConfig.getParameter<std::string>("alias") : "";
+    produces<reco::PFClusterMETCollection>().setBranchAlias(alias);
   }
 
 

--- a/RecoMET/METProducers/src/PFMETProducer.cc
+++ b/RecoMET/METProducers/src/PFMETProducer.cc
@@ -41,10 +41,10 @@ namespace cms
 	resolutions_ = new metsig::SignAlgoResolutions(iConfig);
       }
 
-    std::string alias(iConfig.getParameter<std::string>("alias"));
-    produces<reco::PFMETCollection>().setBranchAlias(alias.c_str());
-  }
+    std::string alias = iConfig.exists("alias") ? iConfig.getParameter<std::string>("alias") : "";
 
+    produces<reco::PFMETCollection>().setBranchAlias(alias);
+  }
 
 //____________________________________________________________________________||
   void PFMETProducer::produce(edm::Event& event, const edm::EventSetup& setup)

--- a/RecoMET/METProducers/src/TCMETProducer.cc
+++ b/RecoMET/METProducers/src/TCMETProducer.cc
@@ -22,8 +22,10 @@ namespace cms
 //____________________________________________________________________________||
   TCMETProducer::TCMETProducer(const edm::ParameterSet& iConfig)
   {
-    std::string alias(iConfig.getParameter<std::string>("alias"));
-    produces<reco::METCollection>().setBranchAlias(alias.c_str());
+    std::string alias = iConfig.exists("alias") ? iConfig.getParameter<std::string>("alias") : "";
+
+    produces<reco::METCollection>().setBranchAlias(alias);
+
     tcMetAlgo_.configure(iConfig, consumesCollector());
   }
 


### PR DESCRIPTION
This PR makes "alias" optional in *METProducer so that we don't have to give an alias to every different definition of MET in the python configuration.
