### PR TITLE
prepare to delete old definitions of corrected CaloMETs

### DIFF
--- a/JetMETCorrections/Type1MET/python/caloMETCorrections_Old_cff.py
+++ b/JetMETCorrections/Type1MET/python/caloMETCorrections_Old_cff.py
@@ -1,3 +1,24 @@
+import FWCore.ParameterSet.Config as cms
+
+##____________________________________________________________________________||
+from JetMETCorrections.Configuration.JetCorrectionServices_cff import *
+
+##____________________________________________________________________________||
+caloJetMETcorr = cms.EDProducer("CaloJetMETcorrInputProducer",
+    src = cms.InputTag('ak4CaloJets'),
+    jetCorrLabel = cms.string("ak4CaloL2L3"), # NOTE: use "ak4CaloL2L3" for MC / "ak4CaloL2L3Residual" for Data
+    jetCorrEtaMax = cms.double(9.9),
+    type1JetPtThreshold = cms.double(20.0),
+    skipEM = cms.bool(True),
+    skipEMfractionThreshold = cms.double(0.90),
+    srcMET = cms.InputTag('corMetGlobalMuons')
+)
+
+##____________________________________________________________________________||
+muonCaloMETcorr = cms.EDProducer("MuonMETcorrInputProducer",
+    src = cms.InputTag('muons'),
+    srcMuonCorrections = cms.InputTag('muonMETValueMapProducer', 'muCorrData')
+)
 
 ##____________________________________________________________________________||
 caloType1CorrectedMet = cms.EDProducer("CorrectedCaloMETProducer",

--- a/JetMETCorrections/Type1MET/python/caloMETCorrections_Old_cff.py
+++ b/JetMETCorrections/Type1MET/python/caloMETCorrections_Old_cff.py
@@ -1,0 +1,40 @@
+
+##____________________________________________________________________________||
+caloType1CorrectedMet = cms.EDProducer("CorrectedCaloMETProducer",
+    src = cms.InputTag('corMetGlobalMuons'),
+    applyType1Corrections = cms.bool(True),
+    srcType1Corrections = cms.VInputTag(
+        cms.InputTag('caloJetMETcorr', 'type1')
+    ),
+    applyType2Corrections = cms.bool(False)
+)
+
+##____________________________________________________________________________||
+caloType1p2CorrectedMet = cms.EDProducer("CorrectedCaloMETProducer",
+    src = cms.InputTag('corMetGlobalMuons'),
+    applyType1Corrections = cms.bool(True),
+    srcType1Corrections = cms.VInputTag(
+        cms.InputTag('caloJetMETcorr', 'type1')
+    ),
+    applyType2Corrections = cms.bool(True),
+    srcUnclEnergySums = cms.VInputTag(
+        cms.InputTag('caloJetMETcorr', 'type2'),
+        cms.InputTag('muonCaloMETcorr') # NOTE: use 'muonCaloMETcorr' for 'corMetGlobalMuons', do **not** use it for 'met' !!
+    ),
+    type2CorrFormula = cms.string("A + B*TMath::Exp(-C*x)"),
+    type2CorrParameter = cms.PSet(
+        A = cms.double(2.0),
+        B = cms.double(1.3),
+        C = cms.double(0.1)
+    )
+)
+
+##____________________________________________________________________________||
+produceCaloMETCorrections = cms.Sequence(
+    caloJetMETcorr
+   * muonCaloMETcorr
+   * caloType1CorrectedMet
+   * caloType1p2CorrectedMet
+)
+
+##____________________________________________________________________________||

--- a/JetMETCorrections/Type1MET/python/caloMETCorrections_cff.py
+++ b/JetMETCorrections/Type1MET/python/caloMETCorrections_cff.py
@@ -1,10 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 
-# load jet energy correction parameters
+##____________________________________________________________________________||
 from JetMETCorrections.Configuration.JetCorrectionServices_cff import *
 
-#--------------------------------------------------------------------------------
-# produce Type 1 + 2 MET corrections for CaloJets
+##____________________________________________________________________________||
 caloJetMETcorr = cms.EDProducer("CaloJetMETcorrInputProducer",
     src = cms.InputTag('ak4CaloJets'),
     jetCorrLabel = cms.string("ak4CaloL2L3"), # NOTE: use "ak4CaloL2L3" for MC / "ak4CaloL2L3Residual" for Data
@@ -14,18 +13,14 @@ caloJetMETcorr = cms.EDProducer("CaloJetMETcorrInputProducer",
     skipEMfractionThreshold = cms.double(0.90),
     srcMET = cms.InputTag('corMetGlobalMuons')
 )
-#--------------------------------------------------------------------------------
 
-#--------------------------------------------------------------------------------
-# compute sum of muon corrections
+##____________________________________________________________________________||
 muonCaloMETcorr = cms.EDProducer("MuonMETcorrInputProducer",
     src = cms.InputTag('muons'),
     srcMuonCorrections = cms.InputTag('muonMETValueMapProducer', 'muCorrData')
 )
-#--------------------------------------------------------------------------------
 
-#--------------------------------------------------------------------------------
-# use MET corrections to produce Type 1 / Type 1 + 2 corrected CaloMET objects
+##____________________________________________________________________________||
 caloType1CorrectedMet = cms.EDProducer("CorrectedCaloMETProducer",
     src = cms.InputTag('corMetGlobalMuons'),
     applyType1Corrections = cms.bool(True),
@@ -35,6 +30,7 @@ caloType1CorrectedMet = cms.EDProducer("CorrectedCaloMETProducer",
     applyType2Corrections = cms.bool(False)
 )
 
+##____________________________________________________________________________||
 caloType1p2CorrectedMet = cms.EDProducer("CorrectedCaloMETProducer",
     src = cms.InputTag('corMetGlobalMuons'),
     applyType1Corrections = cms.bool(True),
@@ -53,14 +49,13 @@ caloType1p2CorrectedMet = cms.EDProducer("CorrectedCaloMETProducer",
         C = cms.double(0.1)
     )
 )
-#--------------------------------------------------------------------------------
 
-#--------------------------------------------------------------------------------
-# define sequence to run all modules
+##____________________________________________________________________________||
 produceCaloMETCorrections = cms.Sequence(
     caloJetMETcorr
    * muonCaloMETcorr
    * caloType1CorrectedMet
    * caloType1p2CorrectedMet
 )
-#--------------------------------------------------------------------------------
+
+##____________________________________________________________________________||

--- a/JetMETCorrections/Type1MET/python/caloMETCorrections_cff.py
+++ b/JetMETCorrections/Type1MET/python/caloMETCorrections_cff.py
@@ -21,41 +21,6 @@ muonCaloMETcorr = cms.EDProducer("MuonMETcorrInputProducer",
 )
 
 ##____________________________________________________________________________||
-caloType1CorrectedMet = cms.EDProducer("CorrectedCaloMETProducer",
-    src = cms.InputTag('corMetGlobalMuons'),
-    applyType1Corrections = cms.bool(True),
-    srcType1Corrections = cms.VInputTag(
-        cms.InputTag('caloJetMETcorr', 'type1')
-    ),
-    applyType2Corrections = cms.bool(False)
-)
-
-##____________________________________________________________________________||
-caloType1p2CorrectedMet = cms.EDProducer("CorrectedCaloMETProducer",
-    src = cms.InputTag('corMetGlobalMuons'),
-    applyType1Corrections = cms.bool(True),
-    srcType1Corrections = cms.VInputTag(
-        cms.InputTag('caloJetMETcorr', 'type1')
-    ),
-    applyType2Corrections = cms.bool(True),
-    srcUnclEnergySums = cms.VInputTag(
-        cms.InputTag('caloJetMETcorr', 'type2'),
-        cms.InputTag('muonCaloMETcorr') # NOTE: use 'muonCaloMETcorr' for 'corMetGlobalMuons', do **not** use it for 'met' !!
-    ),
-    type2CorrFormula = cms.string("A + B*TMath::Exp(-C*x)"),
-    type2CorrParameter = cms.PSet(
-        A = cms.double(2.0),
-        B = cms.double(1.3),
-        C = cms.double(0.1)
-    )
-)
-
-##____________________________________________________________________________||
-produceCaloMETCorrections = cms.Sequence(
-    caloJetMETcorr
-   * muonCaloMETcorr
-   * caloType1CorrectedMet
-   * caloType1p2CorrectedMet
-)
+from JetMETCorrections.Type1MET.caloMETCorrections_Old_cff import *
 
 ##____________________________________________________________________________||

--- a/JetMETCorrections/Type1MET/python/caloMETCorrections_cff.py
+++ b/JetMETCorrections/Type1MET/python/caloMETCorrections_cff.py
@@ -1,26 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
 ##____________________________________________________________________________||
-from JetMETCorrections.Configuration.JetCorrectionServices_cff import *
-
-##____________________________________________________________________________||
-caloJetMETcorr = cms.EDProducer("CaloJetMETcorrInputProducer",
-    src = cms.InputTag('ak4CaloJets'),
-    jetCorrLabel = cms.string("ak4CaloL2L3"), # NOTE: use "ak4CaloL2L3" for MC / "ak4CaloL2L3Residual" for Data
-    jetCorrEtaMax = cms.double(9.9),
-    type1JetPtThreshold = cms.double(20.0),
-    skipEM = cms.bool(True),
-    skipEMfractionThreshold = cms.double(0.90),
-    srcMET = cms.InputTag('corMetGlobalMuons')
-)
-
-##____________________________________________________________________________||
-muonCaloMETcorr = cms.EDProducer("MuonMETcorrInputProducer",
-    src = cms.InputTag('muons'),
-    srcMuonCorrections = cms.InputTag('muonMETValueMapProducer', 'muCorrData')
-)
-
-##____________________________________________________________________________||
 from JetMETCorrections.Type1MET.caloMETCorrections_Old_cff import *
 
 ##____________________________________________________________________________||

--- a/JetMETCorrections/Type1MET/python/correctionTermsCaloMet_cff.py
+++ b/JetMETCorrections/Type1MET/python/correctionTermsCaloMet_cff.py
@@ -4,7 +4,16 @@ import FWCore.ParameterSet.Config as cms
 from JetMETCorrections.Type1MET.caloMETCorrections_cff import *
 
 ##____________________________________________________________________________||
-corrCaloMetType1 = caloJetMETcorr.clone()
+corrCaloMetType1 = cms.EDProducer(
+    "CaloJetMETcorrInputProducer",
+    src = cms.InputTag('ak4CaloJets'),
+    jetCorrLabel = cms.string("ak4CaloL2L3"), # NOTE: use "ak4CaloL2L3" for MC / "ak4CaloL2L3Residual" for Data
+    jetCorrEtaMax = cms.double(9.9),
+    type1JetPtThreshold = cms.double(20.0),
+    skipEM = cms.bool(True),
+    skipEMfractionThreshold = cms.double(0.90),
+    srcMET = cms.InputTag('corMetGlobalMuons')
+)
 
 ##____________________________________________________________________________||
 corrCaloMetType2 = cms.EDProducer(

--- a/JetMETCorrections/Type1MET/python/correctionTermsCaloMet_cff.py
+++ b/JetMETCorrections/Type1MET/python/correctionTermsCaloMet_cff.py
@@ -1,9 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
 ##____________________________________________________________________________||
-from JetMETCorrections.Type1MET.caloMETCorrections_cff import *
+from JetMETCorrections.Configuration.JetCorrectionServices_cff import *
 
-##____________________________________________________________________________||
 corrCaloMetType1 = cms.EDProducer(
     "CaloJetMETcorrInputProducer",
     src = cms.InputTag('ak4CaloJets'),
@@ -16,11 +15,17 @@ corrCaloMetType1 = cms.EDProducer(
 )
 
 ##____________________________________________________________________________||
+muCaloMetCorr = cms.EDProducer("MuonMETcorrInputProducer",
+    src = cms.InputTag('muons'),
+    srcMuonCorrections = cms.InputTag('muonMETValueMapProducer', 'muCorrData')
+)
+
+##____________________________________________________________________________||
 corrCaloMetType2 = cms.EDProducer(
     "Type2CorrectionProducer",
     srcUnclEnergySums = cms.VInputTag(
         cms.InputTag('corrCaloMetType1', 'type2'),
-        cms.InputTag('muonCaloMETcorr') # NOTE: use 'muonCaloMETcorr' for 'corMetGlobalMuons', do **not** use it for 'met' !!
+        cms.InputTag('muCaloMetCorr') # NOTE: use this for 'corMetGlobalMuons', do **not** use it for 'met' !!
         ),
     type2CorrFormula = cms.string("A + B*TMath::Exp(-C*x)"),
     type2CorrParameter = cms.PSet(
@@ -33,7 +38,7 @@ corrCaloMetType2 = cms.EDProducer(
 ##____________________________________________________________________________||
 correctionTermsCaloMet = cms.Sequence(
     corrCaloMetType1 +
-    muonCaloMETcorr +
+    muCaloMetCorr +
     corrCaloMetType2
     )
 


### PR DESCRIPTION
This PR prepares to delete _caloType1CorrectedMet_ and _caloType1p2CorrectedMet_, which have been replaced by _caloMetT1_ and _caloMetT1T2_ respectively, which are defined at:
https://github.com/cms-sw/cmssw/blob/CMSSW_7_1_0_pre8/JetMETCorrections/Type1MET/python/correctedMet_cff.py

The MET workbook started using these _caloMetT1_ and _caloMetT1T2_ in Sep. 2013 at its revision 155:
https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMetAnalysis?rev=155

Similarly, we plan to delete _pfType1CorrectedMet_ and _pfType1p2CorrectedMet_ soon. These have been replaced by _pfMetT1_ and _pfMetT1T2_ respectively. 
