### PR TITLE
DT meantimer tune

### DIFF
--- a/RecoLocalMuon/DTSegment/python/DTMeantimerPatternReco2DAlgo_LinearDriftFromDBLoose_cfi.py
+++ b/RecoLocalMuon/DTSegment/python/DTMeantimerPatternReco2DAlgo_LinearDriftFromDBLoose_cfi.py
@@ -15,7 +15,7 @@ DTMeantimerPatternReco2DAlgo_LinearDriftFromDBLoose = cms.PSet(
         DTLinearDriftFromDBAlgo,
         AlphaMaxPhi = cms.double(100.0),
         AlphaMaxTheta = cms.double(100.),
-        MaxChi2 = cms.double(8.0),
+        MaxChi2 = cms.double(4.0),
         MaxAllowedHits = cms.uint32(50),
         debug = cms.untracked.bool(False),
 

--- a/RecoLocalMuon/DTSegment/python/DTMeantimerPatternReco2DAlgo_LinearDriftFromDB_cfi.py
+++ b/RecoLocalMuon/DTSegment/python/DTMeantimerPatternReco2DAlgo_LinearDriftFromDB_cfi.py
@@ -15,7 +15,7 @@ DTMeantimerPatternReco2DAlgo_LinearDriftFromDB = cms.PSet(
         DTLinearDriftFromDBAlgo,
         AlphaMaxPhi = cms.double(1.0),
         AlphaMaxTheta = cms.double(0.9),
-        MaxChi2 = cms.double(8.0),
+        MaxChi2 = cms.double(4.0),
         MaxAllowedHits = cms.uint32(50),
         debug = cms.untracked.bool(False),
 

--- a/RecoLocalMuon/DTSegment/src/DTMeantimerPatternReco.cc
+++ b/RecoLocalMuon/DTSegment/src/DTMeantimerPatternReco.cc
@@ -276,7 +276,7 @@ DTMeantimerPatternReco::addHits(const DTSuperLayer* sl, vector<DTSegmentCand::As
   }
 
   if (assHits.size()>maxfound) maxfound = assHits.size();
-  if (debug) cout << endl << "   Seg t0= " << t0_corrl << *seg<< endl;
+  if (debug) cout << endl << "   Seg t0= " << t0_corrl << endl << *seg<< endl;
   
   if (checkDoubleCandidates(result,seg.get())) {
     result.push_back(seg.release());
@@ -347,7 +347,7 @@ DTMeantimerPatternReco::fitWithT0(const DTSuperLayer* sl, const vector<DTSegment
 
   // for segments with no t0 information we impose a looser chi2 cut
   if (t0_corr==0) {
-    if (chi2<200.) return seg;
+    if (chi2<100.) return seg;
       else return nullptr; 
   }
 
@@ -366,7 +366,7 @@ DTMeantimerPatternReco::checkDoubleCandidates(vector<DTSegmentCand*>& cands,
     if (*(*cand)==*seg) return false;
     if (((*cand)->nHits()>=seg->nHits()) && ((*cand)->chi2ndof()<seg->chi2ndof()))
       if ((*cand)->nSharedHitPairs(*seg)>int(seg->nHits()-2)) return false;
-  }    
+  }
   return true;
 }
 

--- a/RecoLocalMuon/DTSegment/src/DTSegmentUpdator.cc
+++ b/RecoLocalMuon/DTSegment/src/DTSegmentUpdator.cc
@@ -123,15 +123,15 @@ void DTSegmentUpdator::fit(DTRecSegment4D* seg, bool allow3par)  const {
 
       // fit in-time Phi segments with the 2par fit and out-of-time segments with the 3par fit
       if (fabs(seg->phiSegment()->t0())<40.) {
-        fit(seg->phiSegment(),allow3par,1);
-        fit(seg->zSegment(),allow3par,1);      
-      } else {
         fit(seg->phiSegment(),allow3par,0);
         fit(seg->zSegment(),allow3par,0);      
+      } else {
+        fit(seg->phiSegment(),allow3par,1);
+        fit(seg->zSegment(),allow3par,1);      
       }
 
-    } else fit(seg->phiSegment(),allow3par,0);
-  } else fit(seg->zSegment(),allow3par,0);
+    } else fit(seg->phiSegment(),allow3par,1);
+  } else fit(seg->zSegment(),allow3par,1);
  
   const DTChamber* theChamber = theGeom->chamber(seg->chamberId());
 
@@ -215,7 +215,7 @@ void DTSegmentUpdator::fit(DTRecSegment4D* seg, bool allow3par)  const {
 bool DTSegmentUpdator::fit(DTSegmentCand* seg, bool allow3par, const bool fitdebug) const {
 
 //  if (debug && fitdebug) cout << "[DTSegmentUpdator] Fit DTRecSegment2D" << endl;
-  if (!seg->good()) return false;
+//  if (!seg->good()) return false;
 
 //  DTSuperLayerId DTid = (DTSuperLayerId)seg->superLayer()->id();
 //  if (DTid.superlayer()==2)  
@@ -261,8 +261,7 @@ bool DTSegmentUpdator::fit(DTSegmentCand* seg, bool allow3par, const bool fitdeb
   fit(x,y,lfit,dist,sigy,pos,dir,cminf,vminf,covMat,chi2,allow3par);
   if (cminf!=0) t0_corr=-cminf/0.00543; // convert drift distance to time
 
-  if (debug && fitdebug) cout << "  DTcand chi2: " << chi2 << endl;
-  if (debug && fitdebug) cout << "  DTcand   t0: " << t0_corr << endl;
+  if (debug && fitdebug) cout << "  DTcand chi2: " << chi2 << "/" << x.size() << "   t0: " << t0_corr << endl;
 
   seg->setPosition(pos);
   seg->setDirection(dir);


### PR DESCRIPTION
A small tuning of MT reco following the enabling of realistic hit uncertainties. A very small but consistent improvement in chi2, resolution, efficiency etc in RelVals.
![image](https://cloud.githubusercontent.com/assets/5595497/3083266/6b3e0eca-e4e0-11e3-8b13-0dec66aad3fb.png)
![image](https://cloud.githubusercontent.com/assets/5595497/3083271/86a599a8-e4e0-11e3-90f1-6ebb1c6d34aa.png)

Due to tightened chi2 cuts in segment building the numbers of hits become lower, this is expected (quality improves and efficiency does not suffer):
![image](https://cloud.githubusercontent.com/assets/5595497/3083260/4622c22a-e4e0-11e3-8c3b-a21e9329f22d.png)
