### PR TITLE
Fix momentumTensor calculation

### DIFF
--- a/PhysicsTools/CandUtils/src/EventShapeVariables.cc
+++ b/PhysicsTools/CandUtils/src/EventShapeVariables.cc
@@ -92,7 +92,7 @@ EventShapeVariables::compMomentumTensor(double r) const
   }
 
   // fill momentumTensor from inputVectors
-  double norm = 1.;
+  double norm = 0.;
   for ( int i = 0; i < (int)inputVectors_.size(); ++i ){
     double p2 = inputVectors_[i].Dot(inputVectors_[i]);
     double pR = ( r == 2. ) ? p2 : TMath::Power(p2, 0.5*r);


### PR DESCRIPTION
Norm of momentumTensor should be initialized with zero
