### PR TITLE
fixed duplicateReflexLibrarySearch for patch releases

### DIFF
--- a/Utilities/ReleaseScripts/scripts/duplicateReflexLibrarySearch.py
+++ b/Utilities/ReleaseScripts/scripts/duplicateReflexLibrarySearch.py
@@ -32,12 +32,13 @@ typedefsDict = \
 #Ordered List to search for matched packages
 equivDict = \
      [
+         {'L1TCalorimeter'        : ['l1t::CaloTower.*']},
          {'GsfTracking'           : ['reco::GsfTrack(Collection|).*(MomentumConstraint|VertexConstraint)', 'Trajectory.*reco::GsfTrack']},
          {'ParallelAnalysis'      : ['examples::TrackAnalysisAlgorithm']},
          {'PatCandidates'         : ['pat::PATObject','pat::Lepton']},
          {'BTauReco'              : ['reco::SoftLeptonProperties','reco::SecondaryVertexTagInfo']},
          {'CastorReco'            : ['reco::CastorJet']},
-         {'JetMatching'           : ['reco::JetFlavour','reco::MatchedPartons']},
+         {'JetMatching'           : ['reco::JetFlavourInfo', 'reco::JetFlavour','reco::MatchedPartons']},
          {'TrackingAnalysis'      : ['TrackingParticle']},
          {'Egamma'                : ['reco::ElectronID']},
          {'TopObjects'            : ['reco::CATopJetProperties']},
@@ -233,15 +234,11 @@ def searchClassDefXml ():
 def searchDuplicatePlugins ():
     """ Searches the edmpluginFile to find any duplicate
     plugins."""
-    edmpluginFile = os.path.join(os.environ.get('CMSSW_BASE'),'lib',os.environ.get('SCRAM_ARCH'),'.edmplugincache')
-    baseRel = ""
-    if len (os.environ.get('CMSSW_RELEASE_BASE')):
-      baseRel = os.environ.get('CMSSW_RELEASE_BASE')
-    elif os.path.exists(os.path.join(os.environ.get('CMSSW_BASE'),'.SCRAM',os.environ.get('SCRAM_ARCH'),'InstalledTools','cmssw')):
-        cmd = "scram tool info cmssw | grep CMSSW_BASE= | sed -e 's|CMSSW_BASE=||'"
-        baseRel = commands.getoutput (cmd).split('\n')[0]
-    if len(baseRel):
-      edmpluginFile = edmpluginFile+ ' ' + os.path.join(baseRel,'lib',os.environ.get('SCRAM_ARCH'),'.edmplugincache')
+    edmpluginFile = ''
+    libenv = 'LD_LIBRARY_PATH'
+    if os.environ.get('SCRAM_ARCH').startswith('osx'): libenv = 'DYLD_FALLBACK_LIBRARY_PATH'
+    for libdir in os.environ.get(libenv).split(':'):
+      if os.path.exists(libdir+'/.edmplugincache'): edmpluginFile = edmpluginFile + ' ' + libdir+'/.edmplugincache'
     cmd = "cat %s | awk '{print $2\" \"$1}' | sort | uniq | awk '{print $1}' | sort | uniq -c | grep '2 ' | awk '{print $2}'" % edmpluginFile
     output = commands.getoutput (cmd).split('\n')
     for line in output:


### PR DESCRIPTION
fixes for patch release: follow symlinks under src tree too to find theclasses.h files; search for all .edmplugincache files in LD_LIBRARY_PATH; fix lostDefs for l1t::CaloTower
