### PR TITLE
Added tryToGet method to EventSetup and EventSetupRecord

### DIFF
--- a/FWCore/Framework/interface/DependentRecordImplementation.h
+++ b/FWCore/Framework/interface/DependentRecordImplementation.h
@@ -44,28 +44,33 @@ class DependentRecordImplementation : public EventSetupRecordImplementation<Reco
       // ---------- const member functions ---------------------
       template<class DepRecordT>
       const DepRecordT& getRecord() const {
-	 //Make sure that DepRecordT is a type in ListT
-	 typedef typename boost::mpl::end< ListT >::type EndItrT;
-	 typedef typename boost::mpl::find< ListT, DepRecordT>::type FoundItrT; 
-	 BOOST_STATIC_ASSERT((! boost::is_same<FoundItrT, EndItrT>::value));
-	 EventSetup const& eventSetupT = this->eventSetup();
-	 //can't do the following because of a compiler error in gcc 3.*
-	 // return eventSetupT.get<DepRecordT>();
-	 const DepRecordT* temp = 0;
-	 try { 
-	    eventSetupT.getAvoidCompilerBug(temp);
-	 } catch(NoRecordException<DepRecordT>&) {
-	    //rethrow but this time with dependent information.
-	    throw NoRecordException<DepRecordT>(this->key());
-	 } catch(cms::Exception& e) {  
-	    e<<"Exception occurred while getting dependent record from record \""<<
-	       this->key().type().name()<<"\""<<std::endl;
-	    throw;
-	 }
-	 
-	 return *temp;
+        //Make sure that DepRecordT is a type in ListT
+        typedef typename boost::mpl::end< ListT >::type EndItrT;
+        typedef typename boost::mpl::find< ListT, DepRecordT>::type FoundItrT;
+        BOOST_STATIC_ASSERT((! boost::is_same<FoundItrT, EndItrT>::value));
+        try {
+          EventSetup const& eventSetupT = this->eventSetup();
+          return eventSetupT.get<DepRecordT>();
+        } catch(NoRecordException<DepRecordT>&) {
+          //rethrow but this time with dependent information.
+          throw NoRecordException<DepRecordT>(this->key());
+        } catch(cms::Exception& e) {
+          e<<"Exception occurred while getting dependent record from record \""<<
+          this->key().type().name()<<"\""<<std::endl;
+          throw;
+        }
       }
-      
+
+      template<class DepRecordT>
+      const DepRecordT* tryToGetRecord() const {
+        //Make sure that DepRecordT is a type in ListT
+        typedef typename boost::mpl::end< ListT >::type EndItrT;
+        typedef typename boost::mpl::find< ListT, DepRecordT>::type FoundItrT;
+        BOOST_STATIC_ASSERT((! boost::is_same<FoundItrT, EndItrT>::value));
+        EventSetup const& eventSetupT = this->eventSetup();
+        return eventSetupT.tryToGet<DepRecordT>();
+      }
+
       // ---------- static member functions --------------------
 
       // ---------- member functions ---------------------------

--- a/FWCore/Framework/interface/EventSetup.h
+++ b/FWCore/Framework/interface/EventSetup.h
@@ -56,12 +56,23 @@ class EventSetup
             //NOTE: this will catch the case where T does not inherit from EventSetupRecord
             //  HOWEVER the error message under gcc 3.x is awful
             BOOST_STATIC_ASSERT((boost::is_base_and_derived<edm::eventsetup::EventSetupRecord, T>::value));
-            const T* value = 0;
+            const T* value = nullptr;
             eventSetupGetImplementation(*this, value);
             //NOTE: by construction, eventSetupGetImplementation should thrown an exception rather than return a null value
             assert(0 != value);
             return *value;
          }
+      /** returns the Record of type T.  If no such record available
+       a null pointer is returned */
+      template< typename T>
+      const T* tryToGet() const {
+        //NOTE: this will catch the case where T does not inherit from EventSetupRecord
+        BOOST_STATIC_ASSERT((boost::is_base_and_derived<edm::eventsetup::EventSetupRecord, T>::value));
+        const T* value = nullptr;
+        eventSetupTryToGetImplementation(*this, value);
+        return *value;
+      }
+
       /** can directly access data if data_default_record_trait<> is defined for this data type **/
       template< typename T>
          void getData(T& iHolder) const {

--- a/FWCore/Framework/interface/eventSetupGetImplementation.h
+++ b/FWCore/Framework/interface/eventSetupGetImplementation.h
@@ -35,6 +35,12 @@ namespace edm {
          }
          iValue = temp;
       }
+     
+     template< class T>
+     inline void eventSetupTryToGetImplementation(EventSetup const& iEventSetup, T const*& iValue) {
+       iValue = heterocontainer::find<EventSetupRecordKey, T const>(iEventSetup);
+     }
+
    }
 }
 


### PR DESCRIPTION
Added the method tryToGet to EventSetup and EventSetupRecord to allow attempting to get a Record without having an exception happen if it fails. Instead of an exception, a null pointer is returned.
