### PR TITLE
Fixed incorrect virtual function overload in TSelectorAnalyzer

### DIFF
--- a/PhysicsTools/ParallelAnalysis/interface/TSelectorAnalyzer.h
+++ b/PhysicsTools/ParallelAnalysis/interface/TSelectorAnalyzer.h
@@ -9,10 +9,10 @@ public:
   TSelectorAnalyzer( const edm::ParameterSet & cfg ) :
     list_(), algo_( 0, list_ ) {
   }
-  void analyze( const edm::Event & evt, const edm::EventSetup & ) {
+  void analyze( const edm::Event & evt, const edm::EventSetup & ) override {
     algo_.process( evt );
   }  
-  void endJob( const edm::EventSetup & ) {
+  void endJob() override {
     algo_.postProcess( list_ );
     algo_.terminate( list_ );
   }


### PR DESCRIPTION
The TSelectorAnalyzer::endJob had the wrong function signature and therefore was not overriding the base class and was never called.
