### PR TITLE
use new implementation of MET corrections in PAT jetTools and start refactoring the MET uncertainty tool

### DIFF
--- a/JetMETCorrections/Type1MET/python/correctionTermsPfMetType1Type2_cff.py
+++ b/JetMETCorrections/Type1MET/python/correctionTermsPfMetType1Type2_cff.py
@@ -22,10 +22,10 @@ corrPfMetType2 = cms.EDProducer(
 
 ##____________________________________________________________________________||
 correctionTermsPfMetType1Type2 = cms.Sequence(
-    ak4PFJetsPtrs +
+    pfJetsPtrForMetCorr +
     particleFlowPtrs +
-    pfCandsNotInJetPtrs +
-    pfCandsNotInJet +
+    pfCandsNotInJetsPtrForMetCorr +
+    pfCandsNotInJetsForMetCorr +
     pfCandMETcorr +
     corrPfMetType1 +
     corrPfMetType2

--- a/JetMETCorrections/Type1MET/python/pfMETCorrections_cff.py
+++ b/JetMETCorrections/Type1MET/python/pfMETCorrections_cff.py
@@ -10,7 +10,7 @@ from CommonTools.ParticleFlow.TopProjectors.pfNoJet_cfi import pfNoJet
 # the new TopProjectors now work with Ptrs
 # a conversion is needed if objects are not available
 # add them upfront of the sequence
-ak4PFJetsPtrs = cms.EDProducer("PFJetFwdPtrProducer",
+pfJetsPtrForMetCorr = cms.EDProducer("PFJetFwdPtrProducer",
    src = cms.InputTag("ak4PFJets")
 )
 # this one is needed only if the input file doesn't have it
@@ -22,12 +22,12 @@ from RecoParticleFlow.PFProducer.pfLinker_cff import particleFlowPtrs
 # FIXME: THIS IS A WASTE, BUT NOT CLEAR HOW TO FIX IT CLEANLY: the module
 # downstream operates with View<reco::Candidate>, I wish one could read
 # it from std::vector<PFCandidateFwdPtr> directly
-pfCandsNotInJetPtrs = pfNoJet.clone(
-    topCollection = cms.InputTag('ak4PFJetsPtrs'),
+pfCandsNotInJetsPtrForMetCorr = pfNoJet.clone(
+    topCollection = cms.InputTag('pfJetsPtrForMetCorr'),
     bottomCollection = cms.InputTag('particleFlowPtrs')
 )
-pfCandsNotInJet = cms.EDProducer("PFCandidateFromFwdPtrProducer",
-    src = cms.InputTag("pfCandsNotInJetPtrs")
+pfCandsNotInJetsForMetCorr = cms.EDProducer("PFCandidateFromFwdPtrProducer",
+    src = cms.InputTag("pfCandsNotInJetsPtrForMetCorr")
 )
 
 #--------------------------------------------------------------------------------
@@ -50,7 +50,7 @@ pfJetMETcorr = cms.EDProducer("PFJetMETcorrInputProducer",
 #--------------------------------------------------------------------------------
 # produce Type 2 MET corrections for selected PFCandidates
 pfCandMETcorr = cms.EDProducer("PFCandMETcorrInputProducer",
-    src = cms.InputTag('pfCandsNotInJet')
+    src = cms.InputTag('pfCandsNotInJetsForMetCorr')
 )
 #--------------------------------------------------------------------------------
 
@@ -106,10 +106,10 @@ pfType1p2CorrectedMet = cms.EDProducer("CorrectedPFMETProducer",
 #--------------------------------------------------------------------------------
 # define sequence to run all modules
 producePFMETCorrections = cms.Sequence(
-    ak4PFJetsPtrs
+    pfJetsPtrForMetCorr
    * particleFlowPtrs
-   * pfCandsNotInJetPtrs
-   * pfCandsNotInJet
+   * pfCandsNotInJetsPtrForMetCorr
+   * pfCandsNotInJetsForMetCorr
    * pfJetMETcorr
    * pfCandMETcorr
    * pfchsMETcorr

--- a/PhysicsTools/PatAlgos/python/recoLayer0/metCorrections_cff.py
+++ b/PhysicsTools/PatAlgos/python/recoLayer0/metCorrections_cff.py
@@ -2,8 +2,9 @@ import FWCore.ParameterSet.Config as cms
 
 #from PhysicsTools.PatAlgos.recoLayer0.jetCorrFactors_cfi import *
 from JetMETCorrections.Type1MET.pfMETCorrections_cff import *
-from JetMETCorrections.Type1MET.caloMETCorrections_cff import *
+from JetMETCorrections.Type1MET.correctionTermsCaloMet_cff import *
+from JetMETCorrections.Type1MET.correctedMet_cff import *
 #from JetMETCorrections.Configuration.JetCorrectionServicesAllAlgos_cff import *
 
 ## for scheduled mode
-patMETCorrections = cms.Sequence(produceCaloMETCorrections+producePFMETCorrections)
+patMETCorrections = cms.Sequence(correctionTermsCaloMet+caloMetT1+caloMetT1T2+producePFMETCorrections)

--- a/PhysicsTools/PatAlgos/python/recoLayer0/metCorrections_cff.py
+++ b/PhysicsTools/PatAlgos/python/recoLayer0/metCorrections_cff.py
@@ -1,10 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
 #from PhysicsTools.PatAlgos.recoLayer0.jetCorrFactors_cfi import *
-from JetMETCorrections.Type1MET.pfMETCorrections_cff import *
+from JetMETCorrections.Type1MET.correctionTermsPfMetType1Type2_cff import *
 from JetMETCorrections.Type1MET.correctionTermsCaloMet_cff import *
 from JetMETCorrections.Type1MET.correctedMet_cff import *
 #from JetMETCorrections.Configuration.JetCorrectionServicesAllAlgos_cff import *
 
 ## for scheduled mode
-patMETCorrections = cms.Sequence(correctionTermsCaloMet+caloMetT1+caloMetT1T2+producePFMETCorrections)
+patMETCorrections = cms.Sequence(correctionTermsCaloMet+caloMetT1+caloMetT1T2+correctionTermsPfMetType1Type2+pfMetT1+pfMetT1T2)

--- a/PhysicsTools/PatAlgos/python/tools/jetTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/jetTools.py
@@ -480,12 +480,14 @@ class AddJetCollection(ConfigToolBase):
                 if _labelName != '':
                     _labelCorrName = 'For' + _labelName
                 if _type == 'Calo':
-                    from JetMETCorrections.Type1MET.caloMETCorrections_cff import caloJetMETcorr
-                    from JetMETCorrections.Type1MET.caloMETCorrections_cff import caloType1CorrectedMet
-                    from JetMETCorrections.Type1MET.caloMETCorrections_cff import caloType1p2CorrectedMet
-                    setattr(process,jetCorrections[0]+_labelCorrName+'JetMETcorr'+postfix, caloJetMETcorr.clone(src=jetSource,srcMET = "corMetGlobalMuons",jetCorrections = cms.string(jetCorrections[0]+'CombinedCorrector')))
-                    setattr(process,jetCorrections[0]+_labelCorrName+'Type1CorMet'+postfix, caloType1CorrectedMet.clone(src = "corMetGlobalMuons",srcType1Corrections = cms.VInputTag(cms.InputTag(jetCorrections[0]+_labelCorrName+'JetMETcorr'+postfix, 'type1'))))
-                    setattr(process,jetCorrections[0]+_labelCorrName+'Type1p2CorMet'+postfix,caloType1p2CorrectedMet.clone(src = "corMetGlobalMuons",srcType1Corrections = cms.VInputTag(cms.InputTag(jetCorrections[0]+_labelCorrName+'JetMETcorr'+postfix, 'type1')),srcUnclEnergySums = cms.VInputTag(cms.InputTag(jetCorrections[0]+_labelCorrName+'JetMETcorr'+postfix, 'type2'),cms.InputTag(jetCorrections[0]+_labelCorrName+'JetMETcorr'+postfix, 'offset'),cms.InputTag('muonCaloMETcorr'))))
+                    from JetMETCorrections.Type1MET.correctionTermsCaloMet_cff import corrCaloMetType1
+                    from JetMETCorrections.Type1MET.correctionTermsCaloMet_cff import corrCaloMetType2
+                    from JetMETCorrections.Type1MET.correctedMet_cff import caloMetT1
+                    from JetMETCorrections.Type1MET.correctedMet_cff import caloMetT1T2
+                    setattr(process,jetCorrections[0]+_labelCorrName+'JetMETcorr'+postfix, corrCaloMetType1.clone(src=jetSource,srcMET = "corMetGlobalMuons",jetCorrections = cms.string(jetCorrections[0]+'CombinedCorrector')))
+                    setattr(process,jetCorrections[0]+_labelCorrName+'JetMETcorr2'+postfix, corrCaloMetType2.clone(srcUnclEnergySums = cms.VInputTag(cms.InputTag(jetCorrections[0]+_labelCorrName+'JetMETcorr'+postfix, 'type2'),cms.InputTag(jetCorrections[0]+_labelCorrName+'JetMETcorr'+postfix, 'offset'),cms.InputTag('muCaloMetCorr'))))
+                    setattr(process,jetCorrections[0]+_labelCorrName+'Type1CorMet'+postfix, caloMetT1.clone(src = "corMetGlobalMuons", srcCorrections = cms.VInputTag(cms.InputTag(jetCorrections[0]+_labelCorrName+'JetMETcorr'+postfix, 'type1'))))
+                    setattr(process,jetCorrections[0]+_labelCorrName+'Type1p2CorMet'+postfix, caloMetT1T2.clone(src = "corMetGlobalMuons", srcCorrections = cms.VInputTag(cms.InputTag(jetCorrections[0]+_labelCorrName+'JetMETcorr'+postfix, 'type1'), cms.InputTag(jetCorrections[0]+_labelCorrName+'JetMETcorr2'+postfix))))
 
                 elif _type == 'PF':
                     from JetMETCorrections.Type1MET.pfMETCorrections_cff import pfCandsNotInJet

--- a/PhysicsTools/PatAlgos/python/tools/jetTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/jetTools.py
@@ -490,20 +490,22 @@ class AddJetCollection(ConfigToolBase):
                     setattr(process,jetCorrections[0]+_labelCorrName+'Type1p2CorMet'+postfix, caloMetT1T2.clone(src = "corMetGlobalMuons", srcCorrections = cms.VInputTag(cms.InputTag(jetCorrections[0]+_labelCorrName+'JetMETcorr'+postfix, 'type1'), cms.InputTag(jetCorrections[0]+_labelCorrName+'JetMETcorr2'+postfix))))
 
                 elif _type == 'PF':
-                    from JetMETCorrections.Type1MET.pfMETCorrections_cff import pfJetsPtrForMetCorr
-                    from JetMETCorrections.Type1MET.pfMETCorrections_cff import pfCandsNotInJetsPtrForMetCorr
-                    from JetMETCorrections.Type1MET.pfMETCorrections_cff import pfCandsNotInJetsForMetCorr
-                    from JetMETCorrections.Type1MET.pfMETCorrections_cff import pfJetMETcorr
-                    from JetMETCorrections.Type1MET.pfMETCorrections_cff import pfCandMETcorr
-                    from JetMETCorrections.Type1MET.pfMETCorrections_cff import pfType1CorrectedMet
-                    from JetMETCorrections.Type1MET.pfMETCorrections_cff import pfType1p2CorrectedMet
+                    from JetMETCorrections.Type1MET.correctionTermsPfMetType1Type2_cff import pfJetsPtrForMetCorr
+                    from JetMETCorrections.Type1MET.correctionTermsPfMetType1Type2_cff import pfCandsNotInJetsPtrForMetCorr
+                    from JetMETCorrections.Type1MET.correctionTermsPfMetType1Type2_cff import pfCandsNotInJetsForMetCorr
+                    from JetMETCorrections.Type1MET.correctionTermsPfMetType1Type2_cff import pfCandMETcorr
+                    from JetMETCorrections.Type1MET.correctionTermsPfMetType1Type2_cff import corrPfMetType1
+                    from JetMETCorrections.Type1MET.correctionTermsPfMetType1Type2_cff import corrPfMetType2
+                    from JetMETCorrections.Type1MET.correctedMet_cff import pfMetT1
+                    from JetMETCorrections.Type1MET.correctedMet_cff import pfMetT1T2
                     setattr(process,jetCorrections[0]+_labelCorrName+'pfJetsPtrForMetCorr'+postfix,pfJetsPtrForMetCorr.clone(src = jetSource))
                     setattr(process,jetCorrections[0]+_labelCorrName+'pfCandsNotInJetsPtrForMetCorr'+postfix,pfCandsNotInJetsPtrForMetCorr.clone(topCollection = jetCorrections[0]+_labelCorrName+'pfJetsPtrForMetCorr'+postfix))
                     setattr(process,jetCorrections[0]+_labelCorrName+'pfCandsNotInJetsForMetCorr'+postfix,pfCandsNotInJetsForMetCorr.clone(src = jetCorrections[0]+_labelCorrName+'pfCandsNotInJetsPtrForMetCorr'+postfix))
                     setattr(process,jetCorrections[0]+_labelCorrName+'CandMETcorr'+postfix, pfCandMETcorr.clone(src = cms.InputTag(jetCorrections[0]+_labelCorrName+'pfCandsNotInJetsForMetCorr'+postfix)))
-                    setattr(process,jetCorrections[0]+_labelCorrName+'JetMETcorr'+postfix, pfJetMETcorr.clone(src = jetSource))
-                    setattr(process,jetCorrections[0]+_labelCorrName+'Type1CorMet'+postfix, pfType1CorrectedMet.clone(srcType1Corrections = cms.VInputTag(cms.InputTag(jetCorrections[0]+_labelCorrName+'JetMETcorr'+postfix, 'type1'))))
-                    setattr(process,jetCorrections[0]+_labelCorrName+'Type1p2CorMet'+postfix, pfType1p2CorrectedMet.clone(srcType1Corrections = cms.VInputTag(cms.InputTag(jetCorrections[0]+_labelCorrName+'JetMETcorr'+postfix, 'type1')),srcUnclEnergySums = cms.VInputTag(cms.InputTag(jetCorrections[0]+_labelCorrName+'JetMETcorr'+postfix, 'type2'),cms.InputTag(jetCorrections[0]+_labelCorrName+'JetMETcorr'+postfix, 'offset'),cms.InputTag(jetCorrections[0]+_labelCorrName+'CandMETcorr'+postfix))))
+                    setattr(process,jetCorrections[0]+_labelCorrName+'JetMETcorr'+postfix, corrPfMetType1.clone(src = jetSource))
+                    setattr(process,jetCorrections[0]+_labelCorrName+'corrPfMetType2'+postfix, corrPfMetType2.clone(srcUnclEnergySums = cms.VInputTag(cms.InputTag(jetCorrections[0]+_labelCorrName+'JetMETcorr'+postfix, 'type2'),cms.InputTag(jetCorrections[0]+_labelCorrName+'JetMETcorr'+postfix, 'offset'),cms.InputTag(jetCorrections[0]+_labelCorrName+'CandMETcorr'+postfix))))
+                    setattr(process,jetCorrections[0]+_labelCorrName+'Type1CorMet'+postfix, pfMetT1.clone(srcCorrections = cms.VInputTag(cms.InputTag(jetCorrections[0]+_labelCorrName+'JetMETcorr'+postfix, 'type1'))))
+                    setattr(process,jetCorrections[0]+_labelCorrName+'Type1p2CorMet'+postfix, pfMetT1T2.clone(srcCorrections = cms.VInputTag(cms.InputTag(jetCorrections[0]+_labelCorrName+'JetMETcorr'+postfix, 'type1'), jetCorrections[0]+_labelCorrName+'corrPfMetType2'+postfix)))
 
                 ## common configuration for Calo and PF
                 if ('L1FastJet' in jetCorrections[1] or 'L1Fastjet' in jetCorrections[1]):

--- a/PhysicsTools/PatAlgos/python/tools/jetTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/jetTools.py
@@ -490,13 +490,17 @@ class AddJetCollection(ConfigToolBase):
                     setattr(process,jetCorrections[0]+_labelCorrName+'Type1p2CorMet'+postfix, caloMetT1T2.clone(src = "corMetGlobalMuons", srcCorrections = cms.VInputTag(cms.InputTag(jetCorrections[0]+_labelCorrName+'JetMETcorr'+postfix, 'type1'), cms.InputTag(jetCorrections[0]+_labelCorrName+'JetMETcorr2'+postfix))))
 
                 elif _type == 'PF':
+                    from JetMETCorrections.Type1MET.pfMETCorrections_cff import pfJetsPtrForMetCorr
+                    from JetMETCorrections.Type1MET.pfMETCorrections_cff import pfCandsNotInJetsPtrForMetCorr
                     from JetMETCorrections.Type1MET.pfMETCorrections_cff import pfCandsNotInJetsForMetCorr
                     from JetMETCorrections.Type1MET.pfMETCorrections_cff import pfJetMETcorr
                     from JetMETCorrections.Type1MET.pfMETCorrections_cff import pfCandMETcorr
                     from JetMETCorrections.Type1MET.pfMETCorrections_cff import pfType1CorrectedMet
                     from JetMETCorrections.Type1MET.pfMETCorrections_cff import pfType1p2CorrectedMet
-                    setattr(process,jetCorrections[0]+_labelCorrName+'CandsNotInJet'+postfix,pfCandsNotInJetsForMetCorr.clone(topCollection = jetSource))
-                    setattr(process,jetCorrections[0]+_labelCorrName+'CandMETcorr'+postfix, pfCandMETcorr.clone(src = cms.InputTag(jetCorrections[0]+_labelCorrName+'CandsNotInJet'+postfix)))
+                    setattr(process,jetCorrections[0]+_labelCorrName+'pfJetsPtrForMetCorr'+postfix,pfJetsPtrForMetCorr.clone(src = jetSource))
+                    setattr(process,jetCorrections[0]+_labelCorrName+'pfCandsNotInJetsPtrForMetCorr'+postfix,pfCandsNotInJetsPtrForMetCorr.clone(topCollection = jetCorrections[0]+_labelCorrName+'pfJetsPtrForMetCorr'+postfix))
+                    setattr(process,jetCorrections[0]+_labelCorrName+'pfCandsNotInJetsForMetCorr'+postfix,pfCandsNotInJetsForMetCorr.clone(src = jetCorrections[0]+_labelCorrName+'pfCandsNotInJetsPtrForMetCorr'+postfix))
+                    setattr(process,jetCorrections[0]+_labelCorrName+'CandMETcorr'+postfix, pfCandMETcorr.clone(src = cms.InputTag(jetCorrections[0]+_labelCorrName+'pfCandsNotInJetsForMetCorr'+postfix)))
                     setattr(process,jetCorrections[0]+_labelCorrName+'JetMETcorr'+postfix, pfJetMETcorr.clone(src = jetSource))
                     setattr(process,jetCorrections[0]+_labelCorrName+'Type1CorMet'+postfix, pfType1CorrectedMet.clone(srcType1Corrections = cms.VInputTag(cms.InputTag(jetCorrections[0]+_labelCorrName+'JetMETcorr'+postfix, 'type1'))))
                     setattr(process,jetCorrections[0]+_labelCorrName+'Type1p2CorMet'+postfix, pfType1p2CorrectedMet.clone(srcType1Corrections = cms.VInputTag(cms.InputTag(jetCorrections[0]+_labelCorrName+'JetMETcorr'+postfix, 'type1')),srcUnclEnergySums = cms.VInputTag(cms.InputTag(jetCorrections[0]+_labelCorrName+'JetMETcorr'+postfix, 'type2'),cms.InputTag(jetCorrections[0]+_labelCorrName+'JetMETcorr'+postfix, 'offset'),cms.InputTag(jetCorrections[0]+_labelCorrName+'CandMETcorr'+postfix))))

--- a/PhysicsTools/PatAlgos/python/tools/jetTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/jetTools.py
@@ -490,12 +490,12 @@ class AddJetCollection(ConfigToolBase):
                     setattr(process,jetCorrections[0]+_labelCorrName+'Type1p2CorMet'+postfix, caloMetT1T2.clone(src = "corMetGlobalMuons", srcCorrections = cms.VInputTag(cms.InputTag(jetCorrections[0]+_labelCorrName+'JetMETcorr'+postfix, 'type1'), cms.InputTag(jetCorrections[0]+_labelCorrName+'JetMETcorr2'+postfix))))
 
                 elif _type == 'PF':
-                    from JetMETCorrections.Type1MET.pfMETCorrections_cff import pfCandsNotInJet
+                    from JetMETCorrections.Type1MET.pfMETCorrections_cff import pfCandsNotInJetsForMetCorr
                     from JetMETCorrections.Type1MET.pfMETCorrections_cff import pfJetMETcorr
                     from JetMETCorrections.Type1MET.pfMETCorrections_cff import pfCandMETcorr
                     from JetMETCorrections.Type1MET.pfMETCorrections_cff import pfType1CorrectedMet
                     from JetMETCorrections.Type1MET.pfMETCorrections_cff import pfType1p2CorrectedMet
-                    setattr(process,jetCorrections[0]+_labelCorrName+'CandsNotInJet'+postfix,pfCandsNotInJet.clone(topCollection = jetSource))
+                    setattr(process,jetCorrections[0]+_labelCorrName+'CandsNotInJet'+postfix,pfCandsNotInJetsForMetCorr.clone(topCollection = jetSource))
                     setattr(process,jetCorrections[0]+_labelCorrName+'CandMETcorr'+postfix, pfCandMETcorr.clone(src = cms.InputTag(jetCorrections[0]+_labelCorrName+'CandsNotInJet'+postfix)))
                     setattr(process,jetCorrections[0]+_labelCorrName+'JetMETcorr'+postfix, pfJetMETcorr.clone(src = jetSource))
                     setattr(process,jetCorrections[0]+_labelCorrName+'Type1CorMet'+postfix, pfType1CorrectedMet.clone(srcType1Corrections = cms.VInputTag(cms.InputTag(jetCorrections[0]+_labelCorrName+'JetMETcorr'+postfix, 'type1'))))

--- a/PhysicsTools/PatUtils/python/patPFMETCorrections_cff.py
+++ b/PhysicsTools/PatUtils/python/patPFMETCorrections_cff.py
@@ -91,7 +91,7 @@ patType1p2CorrectedPFMet = cms.EDProducer("CorrectedPATMETProducer",
 # define sequence to run all modules
 producePatPFMETCorrections = cms.Sequence(
     patPFMet
-   * pfCandsNotInJet
+   * pfCandsNotInJetsForMetCorr
    * selectedPatJetsForMETtype1p2Corr
    * selectedPatJetsForMETtype2Corr 
    * patPFJetMETtype1p2Corr

--- a/PhysicsTools/PatUtils/python/tools/metUncertaintyTools.py
+++ b/PhysicsTools/PatUtils/python/tools/metUncertaintyTools.py
@@ -9,6 +9,8 @@ from PhysicsTools.PatUtils.patPFMETCorrections_cff import *
 import RecoMET.METProducers.METSigParams_cfi as jetResolutions
 from PhysicsTools.PatAlgos.producersLayer1.metProducer_cfi import patMETs
 
+from propagateMEtUncertainties import propagateMEtUncertainties
+
 class RunMEtUncertainties(ConfigToolBase):
 
     """ Shift energy of electrons, photons, muons, tau-jets and other jets
@@ -139,62 +141,6 @@ class RunMEtUncertainties(ConfigToolBase):
                                     getattr(process, "metUncertaintySequence"+postfix), postfix)
 
         return smearedJetCollection
-
-    def _propagateMEtUncertainties(self, process,
-                                   particleCollection, particleType, shiftType, particleCollectionShiftUp, particleCollectionShiftDown,
-                                   metProducer, sequence, postfix):
-
-        # produce MET correction objects
-        # (sum of differences in four-momentum between original and up/down shifted particle collection)
-        moduleMETcorrShiftUp = cms.EDProducer("ShiftedParticleMETcorrInputProducer",
-            srcOriginal = cms.InputTag(particleCollection),
-            srcShifted = cms.InputTag(particleCollectionShiftUp)
-        )
-        moduleMETcorrShiftUpName = "patPFMETcorr%s%sUp" % (particleType, shiftType)
-        moduleMETcorrShiftUpName += postfix
-        setattr(process, moduleMETcorrShiftUpName, moduleMETcorrShiftUp)
-        sequence += moduleMETcorrShiftUp
-        moduleMETcorrShiftDown = moduleMETcorrShiftUp.clone(
-            srcShifted = cms.InputTag(particleCollectionShiftDown)
-        )
-        moduleMETcorrShiftDownName = "patPFMETcorr%s%sDown" % (particleType, shiftType)
-        moduleMETcorrShiftDownName += postfix
-        setattr(process, moduleMETcorrShiftDownName, moduleMETcorrShiftDown)
-        sequence += moduleMETcorrShiftDown
-
-        # propagate effects of up/down shifts to MET
-        moduleMETshiftUp = metProducer.clone(
-            src = cms.InputTag(metProducer.label()),
-            srcType1Corrections = cms.VInputTag(
-                cms.InputTag(moduleMETcorrShiftUpName)
-            )
-        )
-        metProducerLabel = metProducer.label()
-        if postfix != "":
-            if metProducerLabel[-len(postfix):] == postfix:
-                metProducerLabel = metProducerLabel[0:-len(postfix)]
-            else:
-                raise StandardError("Tried to remove postfix %s from label %s, but it wasn't there" % (postfix, metProducerLabel))
-        moduleMETshiftUpName = "%s%s%sUp" % (metProducerLabel, particleType, shiftType)
-        moduleMETshiftUpName += postfix
-        setattr(process, moduleMETshiftUpName, moduleMETshiftUp)
-        sequence += moduleMETshiftUp
-        moduleMETshiftDown = moduleMETshiftUp.clone(
-            srcType1Corrections = cms.VInputTag(
-                cms.InputTag(moduleMETcorrShiftDownName)
-            )
-        )
-        moduleMETshiftDownName = "%s%s%sDown" % (metProducerLabel, particleType, shiftType)
-        moduleMETshiftDownName += postfix
-        setattr(process, moduleMETshiftDownName, moduleMETshiftDown)
-        sequence += moduleMETshiftDown
-
-        metCollectionsUp_Down = [
-            moduleMETshiftUpName,
-            moduleMETshiftDownName
-        ]
-
-        return metCollectionsUp_Down
 
     def _initializeInputTag(self, input, default):
         retVal = None
@@ -557,14 +503,14 @@ class RunMEtUncertainties(ConfigToolBase):
 
         # propagate shifts in jet energy to "raw" (uncorrected) and Type 1 corrected MET
         metCollectionsUp_DownForRawMEt = \
-            self._propagateMEtUncertainties(
+            propagateMEtUncertainties(
               process, shiftedParticleCollections['lastJetCollection'], "Jet", "En",
               shiftedParticleCollections['jetCollectionEnUpForRawMEt'], shiftedParticleCollections['jetCollectionEnDownForRawMEt'],
               getattr(process, "patPFMet"+postfix), metUncertaintySequence, postfix)
         collectionsToKeep.extend(metCollectionsUp_DownForRawMEt)
 
         metCollectionsUp_DownForCorrMEt = \
-            self._propagateMEtUncertainties(
+            propagateMEtUncertainties(
               process, shiftedParticleCollections['lastJetCollection'], "Jet", "En",
               shiftedParticleCollections['jetCollectionEnUpForCorrMEt'], shiftedParticleCollections['jetCollectionEnDownForCorrMEt'],
               getattr(process, "patType1CorrectedPFMet"+postfix), metUncertaintySequence, postfix)
@@ -629,7 +575,7 @@ class RunMEtUncertainties(ConfigToolBase):
                                  getattr(process, "patType1CorrectedPFMet"+postfix) ]:
 
                 metCollectionsUp_Down = \
-                    self._propagateMEtUncertainties(
+                    propagateMEtUncertainties(
                       process, shiftedParticleCollections['lastJetCollection'], "Jet", "Res",
                       shiftedParticleCollections['jetCollectionResUp'], shiftedParticleCollections['jetCollectionResDown'],
                       metProducer, metUncertaintySequence, postfix)
@@ -799,7 +745,7 @@ class RunMEtUncertainties(ConfigToolBase):
 
             if self._isValidInputTag(shiftedParticleCollections['electronCollection']):
                 metCollectionsUp_Down = \
-                    self._propagateMEtUncertainties(
+                    propagateMEtUncertainties(
                       process, shiftedParticleCollections['electronCollection'].value(), "Electron", "En",
                       shiftedParticleCollections['electronCollectionEnUp'], shiftedParticleCollections['electronCollectionEnDown'],
                       metProducer, metUncertaintySequence, postfix)
@@ -807,7 +753,7 @@ class RunMEtUncertainties(ConfigToolBase):
 
             if self._isValidInputTag(shiftedParticleCollections['photonCollection']):
                 metCollectionsUp_Down = \
-                    self._propagateMEtUncertainties(
+                    propagateMEtUncertainties(
                       process, shiftedParticleCollections['photonCollection'].value(), "Photon", "En",
                       shiftedParticleCollections['photonCollectionEnUp'], shiftedParticleCollections['photonCollectionEnDown'],
                       metProducer, metUncertaintySequence, postfix)
@@ -815,7 +761,7 @@ class RunMEtUncertainties(ConfigToolBase):
 
             if self._isValidInputTag(shiftedParticleCollections['muonCollection']):
                 metCollectionsUp_Down = \
-                    self._propagateMEtUncertainties(
+                    propagateMEtUncertainties(
                       process, shiftedParticleCollections['muonCollection'].value(), "Muon", "En",
                       shiftedParticleCollections['muonCollectionEnUp'], shiftedParticleCollections['muonCollectionEnDown'],
                       metProducer, metUncertaintySequence, postfix)
@@ -823,7 +769,7 @@ class RunMEtUncertainties(ConfigToolBase):
 
             if self._isValidInputTag(shiftedParticleCollections['tauCollection']):
                 metCollectionsUp_Down = \
-                    self._propagateMEtUncertainties(
+                    propagateMEtUncertainties(
                       process, shiftedParticleCollections['tauCollection'].value(), "Tau", "En",
                       shiftedParticleCollections['tauCollectionEnUp'], shiftedParticleCollections['tauCollectionEnDown'],
                       metProducer, metUncertaintySequence, postfix)

--- a/PhysicsTools/PatUtils/python/tools/metUncertaintyTools.py
+++ b/PhysicsTools/PatUtils/python/tools/metUncertaintyTools.py
@@ -460,7 +460,7 @@ class RunMEtUncertainties(ConfigToolBase):
                 configtools.cloneProcessingSnippet(process, process.producePatPFMETCorrections, postfix)
 
         # add "nominal" (unshifted) pat::MET collections
-        getattr(process, "pfCandsNotInJet"+postfix).bottomCollection = pfCandCollection
+        getattr(process, "pfCandsNotInJetsForMetCorr"+postfix).bottomCollection = pfCandCollection
         getattr(process, "selectedPatJetsForMETtype1p2Corr"+postfix).src = shiftedParticleCollections['lastJetCollection']
         getattr(process, "selectedPatJetsForMETtype2Corr"+postfix).src = shiftedParticleCollections['lastJetCollection']
 
@@ -1071,7 +1071,7 @@ class RunMEtUncertainties(ConfigToolBase):
                                         'pfMEtMVAJetResDown'+postfix, 'patPFMetMVAJetResDown', collectionsToKeep, postfix)
 
             setattr(process, "pfCandsNotInJetUnclusteredEnUpForPFMEtByMVA"+postfix, cms.EDProducer("ShiftedPFCandidateProducer",
-                src = cms.InputTag('pfCandsNotInJet'),
+                src = cms.InputTag('pfCandsNotInJetsForMetCorr'),
                 shiftBy = cms.double(+1.*varyByNsigmas),
                 uncertainty = cms.double(0.10)
             ))

--- a/PhysicsTools/PatUtils/python/tools/propagateMEtUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/propagateMEtUncertainties.py
@@ -1,0 +1,58 @@
+import FWCore.ParameterSet.Config as cms
+
+def propagateMEtUncertainties(process,
+                              particleCollection, particleType, shiftType, particleCollectionShiftUp, particleCollectionShiftDown,
+                              metProducer, sequence, postfix):
+    
+    # produce MET correction objects
+    # (sum of differences in four-momentum between original and up/down shifted particle collection)
+    moduleMETcorrShiftUp = cms.EDProducer("ShiftedParticleMETcorrInputProducer",
+        srcOriginal = cms.InputTag(particleCollection),
+        srcShifted = cms.InputTag(particleCollectionShiftUp)
+    )
+    moduleMETcorrShiftUpName = "patPFMETcorr%s%sUp" % (particleType, shiftType)
+    moduleMETcorrShiftUpName += postfix
+    setattr(process, moduleMETcorrShiftUpName, moduleMETcorrShiftUp)
+    sequence += moduleMETcorrShiftUp
+    moduleMETcorrShiftDown = moduleMETcorrShiftUp.clone(
+        srcShifted = cms.InputTag(particleCollectionShiftDown)
+    )
+    moduleMETcorrShiftDownName = "patPFMETcorr%s%sDown" % (particleType, shiftType)
+    moduleMETcorrShiftDownName += postfix
+    setattr(process, moduleMETcorrShiftDownName, moduleMETcorrShiftDown)
+    sequence += moduleMETcorrShiftDown
+    
+    # propagate effects of up/down shifts to MET
+    moduleMETshiftUp = metProducer.clone(
+        src = cms.InputTag(metProducer.label()),
+        srcType1Corrections = cms.VInputTag(
+            cms.InputTag(moduleMETcorrShiftUpName)
+        )
+    )
+    metProducerLabel = metProducer.label()
+    if postfix != "":
+        if metProducerLabel[-len(postfix):] == postfix:
+            metProducerLabel = metProducerLabel[0:-len(postfix)]
+        else:
+            raise StandardError("Tried to remove postfix %s from label %s, but it wasn't there" % (postfix, metProducerLabel))
+    moduleMETshiftUpName = "%s%s%sUp" % (metProducerLabel, particleType, shiftType)
+    moduleMETshiftUpName += postfix
+    setattr(process, moduleMETshiftUpName, moduleMETshiftUp)
+    sequence += moduleMETshiftUp
+    moduleMETshiftDown = moduleMETshiftUp.clone(
+        srcType1Corrections = cms.VInputTag(
+            cms.InputTag(moduleMETcorrShiftDownName)
+        )
+    )
+    moduleMETshiftDownName = "%s%s%sDown" % (metProducerLabel, particleType, shiftType)
+    moduleMETshiftDownName += postfix
+    setattr(process, moduleMETshiftDownName, moduleMETshiftDown)
+    sequence += moduleMETshiftDown
+    
+    metCollectionsUp_Down = [
+        moduleMETshiftUpName,
+        moduleMETshiftDownName
+    ]
+    
+    return metCollectionsUp_Down
+


### PR DESCRIPTION
This PR replaces the old implementation of CaloMET corrections in PAT jetTools with the new one.

We are preparing to delete the old implementation (https://github.com/cms-sw/cmssw/pull/4014).

Incidentally, we plan to discontinue configuring MET corrections in jetTools. The plan was made a while ago (see slide2 https://indico.cern.ch/event/187209/contribution/3) but hasn't been implemented.
