### PR TITLE
SUSYBSMfix in TriggerValidator

### DIFF
--- a/HLTriggerOffline/SUSYBSM/src/TriggerValidator.cc
+++ b/HLTriggerOffline/SUSYBSM/src/TriggerValidator.cc
@@ -317,8 +317,8 @@ TriggerValidator::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
   }
 
   //Calculate the overlap among HLT paths
-  for(unsigned int i=0; i< hlNames_.size(); i++) {
-    for(unsigned int j=0; j< hlNames_.size(); j++) {
+  for(unsigned int i=0; i< hltbits.size(); i++) {
+    for(unsigned int j=0; j< hltbits.size(); j++) {
       if(hltbits[i]*hltbits[j]) vCorrHlt[i][j]++;
     }
   }


### PR DESCRIPTION
Fix of SUSYBSM TriggerValidator:

Actual number of HLT paths in HLT menu to be analyzed are one less than size of hlTName_,
because hlNames_ contains in addition a meta/summary "path" called TOTAL as well:

```
  hlNames_.push_back("Total");
```
