### PR TITLE
Fix Shashlik assert

### DIFF
--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaRecHitExtractor.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaRecHitExtractor.cc
@@ -121,15 +121,10 @@ reco::IsoDeposit EgammaRecHitExtractor::deposit(const edm::Event & iEvent,
     
   const CaloGeometry* caloGeom = pG.product(); 
   const CaloSubdetectorGeometry* barrelgeom = caloGeom->getSubdetectorGeometry(DetId::Ecal,EcalBarrel);
-  const CaloSubdetectorGeometry* endcapgeom = caloGeom->getSubdetectorGeometry(DetId::Ecal,EcalEndcap) != NULL ?
-    caloGeom->getSubdetectorGeometry(DetId::Ecal,EcalEndcap)  :
-    caloGeom->getSubdetectorGeometry(DetId::Ecal,EcalShashlik); //Shervin
+  const CaloSubdetectorGeometry* endcapgeom = caloGeom->getSubdetectorGeometry(DetId::Ecal,EcalEndcap);
+  if( endcapgeom==nullptr ) endcapgeom=caloGeom->getSubdetectorGeometry(DetId::Ecal,EcalShashlik); //Shervin
   
-  if(endcapgeom!=caloGeom->getSubdetectorGeometry(DetId::Ecal,EcalShashlik)){
-    assert(endcapgeom==caloGeom->getSubdetectorGeometry(DetId::Ecal,EcalShashlik));
-  }
-  if(endcapgeom==NULL)
-    assert(endcapgeom!=NULL);
+  assert(endcapgeom!=nullptr);
 
   static std::string metname = "EgammaIsolationAlgos|EgammaRecHitExtractor";
   


### PR DESCRIPTION
Previous code tried to instantiate StdGeom endcap, then if that failed instantiate Shashlik endcap, then assert that the endcap is Shashlik.  Hence the program would terminate if the geometry was anything other than Shashlik.
I just removed the assert.  Also changed a tertiary conditional to a binary to avoid repeated calls of the same method.
