### PR TITLE
Replace SMatrixNoInit

### DIFF
--- a/DataFormats/Math/test/Similarity_t.cpp
+++ b/DataFormats/Math/test/Similarity_t.cpp
@@ -66,7 +66,7 @@ namespace ROOT {
 							 const SMatrix<T,D2,D2,MatRepStd<T,D2> >& rhs) {
       SMatrix<T,D1,D2, MatRepStd<T,D1,D2> > tmp = lhs * rhs;
       typedef  SMatrix<T,D1,D1,MatRepSym<T,D1> > SMatrixSym; 
-      SMatrixSym mret{SMatrixNoInit{}}; 
+      SMatrixSym mret{SMatrixIdentity{}}; 
       AssignSym::Evaluate(mret,  tmp * Transpose(lhs)  ); 
       return mret; 
     }
@@ -76,7 +76,7 @@ namespace ROOT {
 							 const SMatrix<T,D2,D2,MatRepStd<T,D2> > & rhs) {
       SMatrix<T,D1,D2, MatRepStd<T,D1,D2> > tmp = lhs * rhs;
       typedef  SMatrix<T,D1,D1,MatRepStd<T,D1> > SMatrixSym; 
-      SMatrixSym mret = SMatrixNoInit(); 
+      SMatrixSym mret = SMatrixIdentity(); 
       AssignAsSym::Evaluate(mret,  tmp * Transpose(lhs)  ); 
       return mret; 
     }

--- a/RecoVertex/KinematicFit/interface/KinematicConstrainedVertexFitterT.h
+++ b/RecoVertex/KinematicFit/interface/KinematicConstrainedVertexFitterT.h
@@ -214,7 +214,7 @@ KinematicConstrainedVertexFitterT< nTrk, nConstraint>::fit(const std::vector<Ref
   
   GlobalPoint lPoint  = linPoint;
   RefCountedKinematicVertex rVtx;
-  ROOT::Math::SMatrix<double, 3+7*nTrk,3+7*nTrk ,ROOT::Math::MatRepSym<double,3+7*nTrk> > refCCov  = ROOT::Math::SMatrixNoInit();
+  ROOT::Math::SMatrix<double, 3+7*nTrk,3+7*nTrk ,ROOT::Math::MatRepSym<double,3+7*nTrk> > refCCov  = ROOT::Math::SMatrixIdentity();
   
   double chisq = 1e6;
   bool convergence = false;

--- a/RecoVertex/KinematicFit/interface/KinematicConstrainedVertexUpdatorT.h
+++ b/RecoVertex/KinematicFit/interface/KinematicConstrainedVertexUpdatorT.h
@@ -62,9 +62,9 @@ private:
   ROOT::Math::SVector<double,nConstraint+4> val;
   ROOT::Math::SVector<double, 3+7*nTrk> finPar;
   ROOT::Math::SVector<double, nConstraint+4> lambda;
-  ROOT::Math::SMatrix<double,3,3,ROOT::Math::MatRepSym<double,3> > pCov = ROOT::Math::SMatrixNoInit(); 
-  ROOT::Math::SMatrix<double,7,7,ROOT::Math::MatRepSym<double,7> > nCovariance = ROOT::Math::SMatrixNoInit();
-  ROOT::Math::SMatrix<double,nConstraint+4,nConstraint+4,ROOT::Math::MatRepSym<double,nConstraint+4> > v_g_sym = ROOT::Math::SMatrixNoInit();   
+  ROOT::Math::SMatrix<double,3,3,ROOT::Math::MatRepSym<double,3> > pCov = ROOT::Math::SMatrixIdentity(); 
+  ROOT::Math::SMatrix<double,7,7,ROOT::Math::MatRepSym<double,7> > nCovariance = ROOT::Math::SMatrixIdentity();
+  ROOT::Math::SMatrix<double,nConstraint+4,nConstraint+4,ROOT::Math::MatRepSym<double,nConstraint+4> > v_g_sym = ROOT::Math::SMatrixIdentity();   
   
 };
 

--- a/TrackingTools/AnalyticalJacobians/interface/AnalyticalCurvilinearJacobian.h
+++ b/TrackingTools/AnalyticalJacobians/interface/AnalyticalCurvilinearJacobian.h
@@ -21,7 +21,7 @@ class GlobalTrajectoryParameters;
 class AnalyticalCurvilinearJacobian  {
  public:
   /// default constructor (for tests)
-  AnalyticalCurvilinearJacobian() : theJacobian(ROOT::Math::SMatrixNoInit()) {}
+  AnalyticalCurvilinearJacobian() : theJacobian(ROOT::Math::SMatrixIdentity()) {}
 
   /// get Field at starting state (internally)
   AnalyticalCurvilinearJacobian(const GlobalTrajectoryParameters& globalParameters,

--- a/TrackingTools/AnalyticalJacobians/src/JacobianCurvilinearToLocal.cc
+++ b/TrackingTools/AnalyticalJacobians/src/JacobianCurvilinearToLocal.cc
@@ -8,7 +8,7 @@
 JacobianCurvilinearToLocal::
 JacobianCurvilinearToLocal(const Surface& surface, 
 			   const LocalTrajectoryParameters& localParameters,
-			   const MagneticField& magField) : theJacobian(ROOT::Math::SMatrixNoInit()) {
+			   const MagneticField& magField) : theJacobian(ROOT::Math::SMatrixIdentity()) {
  
   GlobalPoint  x = surface.toGlobal(localParameters.position());
   GlobalVector h  = magField.inInverseGeV(x);
@@ -34,7 +34,7 @@ JacobianCurvilinearToLocal::
 JacobianCurvilinearToLocal(const Surface& surface, 
 			   const LocalTrajectoryParameters& localParameters,
 			   const GlobalTrajectoryParameters& globalParameters,
-			   const MagneticField& magField) : theJacobian(ROOT::Math::SMatrixNoInit()) {
+			   const MagneticField& magField) : theJacobian(ROOT::Math::SMatrixIdentity()) {
  
   // GlobalPoint  x =  globalParameters.position();
   // GlobalVector h  = magField.inInverseGeV(x);

--- a/TrackingTools/AnalyticalJacobians/src/JacobianLocalToCurvilinear.cc
+++ b/TrackingTools/AnalyticalJacobians/src/JacobianLocalToCurvilinear.cc
@@ -8,7 +8,7 @@
 JacobianLocalToCurvilinear::
 JacobianLocalToCurvilinear(const Surface& surface, 
 			   const LocalTrajectoryParameters& localParameters,
-			   const MagneticField& magField) : theJacobian(ROOT::Math::SMatrixNoInit()) {
+			   const MagneticField& magField) : theJacobian(ROOT::Math::SMatrixIdentity()) {
   
 
   GlobalPoint  x = surface.toGlobal(localParameters.position());
@@ -30,7 +30,7 @@ JacobianLocalToCurvilinear::
 JacobianLocalToCurvilinear(const Surface& surface, 
 			   const LocalTrajectoryParameters& localParameters,
 			   const GlobalTrajectoryParameters& globalParameters,
-			   const MagneticField& magField) : theJacobian(ROOT::Math::SMatrixNoInit()) {
+			   const MagneticField& magField) : theJacobian(ROOT::Math::SMatrixIdentity()) {
 
   // GlobalPoint  x =  globalParameters.position();
   // GlobalVector h  = magField.inInverseGeV(x);

--- a/TrackingTools/GsfTools/interface/SingleGaussianState.h
+++ b/TrackingTools/GsfTools/interface/SingleGaussianState.h
@@ -67,7 +67,7 @@ private:
   Vector theMean;
   double theWeight;
 
-  mutable Matrix theWeightMatrix = ROOT::Math::SMatrixNoInit();
+  mutable Matrix theWeightMatrix = ROOT::Math::SMatrixIdentity();
   mutable bool theHasWeightMatrix;
 
 // public:

--- a/TrackingTools/TrajectoryParametrization/interface/CurvilinearTrajectoryError.h
+++ b/TrackingTools/TrajectoryParametrization/interface/CurvilinearTrajectoryError.h
@@ -35,7 +35,7 @@ public:
 // construct
   CurvilinearTrajectoryError() {}
 
-  CurvilinearTrajectoryError(InvalidError) : theCovarianceMatrix(ROOT::Math::SMatrixNoInit()) {theCovarianceMatrix(0,0)=-99999.e10;}
+  CurvilinearTrajectoryError(InvalidError) : theCovarianceMatrix(ROOT::Math::SMatrixIdentity()) {theCovarianceMatrix(0,0)=-99999.e10;}
 
   /** Constructing class from a full covariance matrix. The sequence of the parameters is
    *  the same as the one described above.

--- a/TrackingTools/TrajectoryParametrization/interface/LocalTrajectoryError.h
+++ b/TrackingTools/TrajectoryParametrization/interface/LocalTrajectoryError.h
@@ -23,7 +23,7 @@ public:
   // construct
   LocalTrajectoryError(){}
 
-  LocalTrajectoryError(InvalidError) : theCovarianceMatrix(ROOT::Math::SMatrixNoInit()) {theCovarianceMatrix(0,0)=-99999.e10;}
+  LocalTrajectoryError(InvalidError) : theCovarianceMatrix(ROOT::Math::SMatrixIdentity()) {theCovarianceMatrix(0,0)=-99999.e10;}
   // destruct
   ~LocalTrajectoryError(){}
 


### PR DESCRIPTION
ROOT6 has replaced SMatrixNoInit() with SMatrixIdentity().
This pull request adapts CMSSW to this change, and fixes most, perhaps all, of the compilation errors in the latest ROOT6 IB.  Please merge ASAP.
