### PR TITLE
update serialisation generator script

### DIFF
--- a/CondFormats/Serialization/python/condformats_serialization_generate.py
+++ b/CondFormats/Serialization/python/condformats_serialization_generate.py
@@ -309,7 +309,7 @@ def get_serializable_classes_members(node, all_template_types=None, namespace=''
 
     for (klass, (node, serializable, all_template_types, base_objects, members, transients)) in results.items():
         if serializable and len(members) == 0:
-            logging.warning('No non-transient members found for serializable class %s', klass)
+            logging.info('No non-transient members found for serializable class %s', klass)
 
     return results
 
@@ -466,7 +466,8 @@ class SerializationCodeGenerator(object):
     def _join_package_path(self, *path):
         return os.path.join(self.cmssw_base, self.split_path[0], self.split_path[1], self.split_path[2], *path)
 
-    def cleanFlags(self, flags):
+    def cleanFlags(self, flagsIn):
+	flags = [ flag for flag in flagsIn if not flag.startswith(('-march', '-mtune')) ]
         blackList = ['--', '-fipa-pta']
         return [x for x in flags if x not in blackList]
 


### PR DESCRIPTION
- change the warning about apparently empty classed to "info" as there are legitimate cases where a class does not have data members but needs to be serialised (e.g. if inheriting from another serialised class).
- ignore architecture specific flags (-mtune... and -march...) when processing - this specific part should (once back ported to 71x) replace PR #4067 by A. Bocci.
