### PR TITLE
Make sure files are at CERN also when specifying multiple runs.

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -73,7 +73,7 @@ class InputInfo(object):
         query_by = "block" if self.ib_block else "dataset"
         query_source = "{0}#{1}".format(self.dataSet, self.ib_block) if self.ib_block else self.dataSet
         if len(self.run) is not 0:
-            return ["file {0}={1} run={2}".format(query_by, query_source, query_run) for query_run in self.run]
+            return ["file {0}={1} run={2} site=T2_CH_CERN".format(query_by, query_source, query_run) for query_run in self.run]
         else:
             return ["file {0}={1} site=T2_CH_CERN".format(query_by, query_source)]
 


### PR DESCRIPTION
This will solve the issue with 4.68 where only one of the two runs (the second one) has data files at CERN. Given we already do that for single run tests, I do not see any drawbacks. A proper solution probably should allow for site to be specified as runTheMatrix option.
