### PR TITLE
Changed TrackWithVertexRefSelector to a stream module.

### DIFF
--- a/CommonTools/RecoAlgos/plugins/TrackWithVertexRefSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/TrackWithVertexRefSelector.cc
@@ -1,5 +1,5 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "CommonTools/UtilAlgos/interface/ObjectSelector.h"
+#include "CommonTools/UtilAlgos/interface/ObjectSelectorStream.h"
 
 #include "CommonTools/UtilAlgos/interface/SingleElementCollectionSelectorPlusEvent.h"
 #include "CommonTools/RecoAlgos/interface/TrackWithVertexSelector.h"
@@ -7,7 +7,7 @@
 namespace reco { 
   namespace modules {
 
-typedef ObjectSelector<
+typedef ObjectSelectorStream<
   SingleElementCollectionSelectorPlusEvent<
           reco::TrackCollection,
           ::TrackWithVertexSelector,

--- a/CommonTools/UtilAlgos/interface/ObjectSelectorStream.h
+++ b/CommonTools/UtilAlgos/interface/ObjectSelectorStream.h
@@ -1,0 +1,34 @@
+#ifndef CommonTools_UtilAlgos_ObjectSelectorStream_h
+#define CommonTools_UtilAlgos_ObjectSelectorStream_h
+// -*- C++ -*-
+//
+// Package:     CommonTools/UtilAlgos
+// Class  :     ObjectSelectorStream
+// 
+/**\class ObjectSelectorStream ObjectSelectorStream.h "CommonTools/UtilAlgos/interface/ObjectSelectorStream.h"
+
+ Description: Template for constructing stream based object selector modules
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Christopher Jones
+//         Created:  Fri, 30 May 2014 18:56:48 GMT
+//
+
+// system include files
+#include "FWCore/Framework/interface/stream/EDFilter.h"
+#include "CommonTools/UtilAlgos/interface/ObjectSelector.h"
+
+template<typename Selector,
+         typename OutputCollection = typename ::helper::SelectedOutputCollectionTrait<typename Selector::collection>::type,
+	 typename SizeSelector = NonNullNumberSelector,
+  typename PostProcessor = ::helper::NullPostProcessor<OutputCollection, edm::stream::EDFilter<>>,
+  typename StoreManager = typename ::helper::StoreManagerTrait<OutputCollection, edm::stream::EDFilter<>>::type,
+  typename Init = typename ::reco::modules::EventSetupInit<Selector>::type
+  >
+  using ObjectSelectorStream = ObjectSelector<Selector,OutputCollection,SizeSelector, PostProcessor,StoreManager, typename ::helper::StoreManagerTrait<OutputCollection, edm::stream::EDFilter<>>::base, Init>;
+
+#endif


### PR DESCRIPTION
Static analysis and helgrind showed it is safe to convert this
module to a stream module. Thread performance analysis showed
this conversion is needed for efficient threading.
To do the conversion, I introduced ObjectSelectorStream templated
base class.
