### PR TITLE
Make GsfElectronBaseProducer a stream module.

### DIFF
--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronBaseProducer.h
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronBaseProducer.h
@@ -7,7 +7,7 @@
 #include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 
@@ -25,7 +25,7 @@ namespace edm
 #include "RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h"
 #include "DataFormats/Common/interface/Handle.h"
 
-class GsfElectronBaseProducer : public edm::EDProducer
+class GsfElectronBaseProducer : public edm::stream::EDProducer<>
  {
   public:
 


### PR DESCRIPTION
Static analyzer and helgrind show it is safe to convert this class
and all classes inheriting from it to be a stream based Producer.
Thread performance analysis showed this conversion is needed for
efficient threading.
