### PR TITLE
Update to sourcing data format and unpacker

### DIFF
--- a/DataFormats/HcalRecHit/interface/HcalSourcePositionData.h
+++ b/DataFormats/HcalRecHit/interface/HcalSourcePositionData.h
@@ -18,11 +18,11 @@ public:
   inline int motorCurrent() const { return motorCurrent_; }
   inline int speed() const { return -1; } // no longer implemented
   inline int motorVoltage() const { return motorVoltage_; }
-  inline int tubeId() const { return tubeId_; }
+  inline int tubeId() const { return -1; } // no longer implemented
   inline int driverId() const { return driverId_; }
   inline int sourceId() const { return sourceId_; }
   inline std::string tubeNameFromCoord() const { return tubeNameFromCoord_; }
-  inline std::string tubeNameFromSD() const { return tubeNameFromSD_; }
+  inline std::string tubeDescriptionFromSD() const { return tubeDescriptionFromSD_; }
   inline std::string lastCommand() const { return lastCommand_; }
   inline std::string message() const { return message_; }
 
@@ -39,11 +39,10 @@ public:
 		 int reel_counter,
 		 int motor_current,
 		 int motor_voltage,
-		 int tube_id,
 		 int driver_id,
      int source_id,
      std::string tubeNameFromCoord,
-     std::string tubeNameFromSD,
+     std::string tubeDescFromSD,
      std::string lastCommand,
      std::string message);
 
@@ -62,7 +61,7 @@ private:
   int driverId_;
   int sourceId_;
   std::string tubeNameFromCoord_;
-  std::string tubeNameFromSD_;
+  std::string tubeDescriptionFromSD_;
   std::string lastCommand_;
   std::string message_;
 };

--- a/DataFormats/HcalRecHit/src/HcalSourcePositionData.cc
+++ b/DataFormats/HcalRecHit/src/HcalSourcePositionData.cc
@@ -17,6 +17,10 @@ HcalSourcePositionData::HcalSourcePositionData(){
   tubeId_=-1;
   driverId_=-1;
   sourceId_=-1;
+  tubeNameFromCoord_="";
+  tubeDescriptionFromSD_="";
+  lastCommand_="";
+  message_="";
 }
 
 void HcalSourcePositionData::set(int message_counter,
@@ -29,11 +33,10 @@ void HcalSourcePositionData::set(int message_counter,
 				       int reel_counter,
 				       int motor_current,
 				       int motor_voltage,
-				       int tube_id,
 				       int driver_id,
                int source_id,
                std::string tubeNameFromCoord,
-               std::string tubeNameFromSD,
+               std::string tubeDescFromSD,
                std::string lastCommand,
                std::string message)
 {
@@ -48,11 +51,10 @@ void HcalSourcePositionData::set(int message_counter,
   status_=status;
   motorCurrent_=motor_current;
   motorVoltage_=motor_voltage;
-  tubeId_=tube_id;
   driverId_=driver_id;
   sourceId_=source_id;
   tubeNameFromCoord_=tubeNameFromCoord;
-  tubeNameFromSD_=tubeNameFromSD;
+  tubeDescriptionFromSD_=tubeDescFromSD;
   lastCommand_=lastCommand;
   message_=message;
 }
@@ -69,19 +71,19 @@ void HcalSourcePositionData::getDAQTimestamp(int& seconds, int& useconds) const{
 
 ostream& operator<<(ostream& s, const HcalSourcePositionData& hspd) {
 
-  s << "  Message Counter   =" << hspd.messageCounter() << endl;
-  s << "  Index Counter     =" << hspd.indexCounter() << endl;
-  s << "  Reel Counter      =" << hspd.reelCounter() << endl;
-  s << "  Status            =" << hex << hspd.status() << dec << endl;
-  s << "  Motor Current     =" << hspd.motorCurrent() << endl;
-  s << "  Motor Voltage     =" << hspd.motorVoltage() << endl;
-  s << "  Tube Id           =" << hspd.tubeId() << endl;
-  s << "  Driver Id         =" << hspd.driverId() << endl;
-  s << "  Source Id         =" << hspd.sourceId() << endl;
-  s << "  TubeNameFromCoord =" << hspd.tubeNameFromCoord() << endl;
-  s << "  TubeNameFromSD    =" << hspd.tubeNameFromSD() << endl;
-  s << "  Last Command      =" << hspd.lastCommand() << endl;
-  s << "  Message           =" << hspd.message() << endl;
+  s << "  Message Counter       =" << hspd.messageCounter() << endl;
+  s << "  Index Counter         =" << hspd.indexCounter() << endl;
+  s << "  Reel Counter          =" << hspd.reelCounter() << endl;
+  s << "  Status                =" << hex << hspd.status() << dec << endl;
+  s << "  Motor Current         =" << hspd.motorCurrent() << endl;
+  s << "  Motor Voltage         =" << hspd.motorVoltage() << endl;
+  s << "  Tube Id               =" << hspd.tubeId() << endl;
+  s << "  Driver Id             =" << hspd.driverId() << endl;
+  s << "  Source Id             =" << hspd.sourceId() << endl;
+  s << "  TubeNameFromCoord     =" << hspd.tubeNameFromCoord() << endl;
+  s << "  TubeDescriptionFromSD =" << hspd.tubeDescriptionFromSD() << endl;
+  s << "  Last Command          =" << hspd.lastCommand() << endl;
+  s << "  Message               =" << hspd.message() << endl;
   
   int timebase =0; int timeusec=0;
   hspd.getDriverTimestamp(timebase,timeusec);

--- a/DataFormats/HcalRecHit/src/classes_def.xml
+++ b/DataFormats/HcalRecHit/src/classes_def.xml
@@ -21,8 +21,8 @@
    <class name="HcalCalibRecHit" ClassVersion="10">
     <version ClassVersion="10" checksum="1085028533"/>
    </class>
-   <class name="HcalSourcePositionData" ClassVersion="11">
-    <version ClassVersion="11" checksum="913740682"/>
+   <class name="HcalSourcePositionData" ClassVersion="12">
+    <version ClassVersion="12" checksum="2888252873"/>
    </class>
    <class name="std::vector<HBHERecHit>"/>
    <class name="std::vector<HORecHit>"/>

--- a/RecoTBCalo/HcalTBObjectUnpacker/src/HcalTBSourcePositionDataUnpacker.cc
+++ b/RecoTBCalo/HcalTBObjectUnpacker/src/HcalTBSourcePositionDataUnpacker.cc
@@ -82,16 +82,15 @@ namespace hcaltb {
 		 sp_dblmap["TIME_STAMP2"],//double timestamp1_usec
 		 -1,//double timestamp2_sec
 		 -1,//double timestamp2_usec
-		 -1,//double status
+		 sp_dblmap["STATUS"],//double status
 		 sp_dblmap["INDEX"],//double index_counter
 		 sp_dblmap["REEL"],//double reel_counter
 		 sp_dblmap["MOTOR_CURRENT"],//double motor_current
 		 sp_dblmap["MOTOR_VOLTAGE"],//double motor_voltage
-		 -1,//double tube_id
 		 -1,//double driver_id
      -1,//double source_id
      sp_strmap["CURRENT_TUBENAME_FROM_COORD"],
-     "", // current tubeName from SD
+     sp_strmap["INDEX_DESCRIPTION"],
      sp_strmap["LAST_COMMAND"],
      sp_strmap["MESSAGE"]
      );


### PR DESCRIPTION
Update to sourcing data format and unpacker.  Add tube description, and make status word available to data format object.  TubeID is deprecated.  Only affects local runs with sourcing configuration.
