### PR TITLE
Thread safe use of t base class

### DIFF
--- a/CommonTools/Utils/src/findDataMember.cc
+++ b/CommonTools/Utils/src/findDataMember.cc
@@ -12,6 +12,9 @@
 //
 
 // system include files
+#include "TInterpreter.h"
+#include "TVirtualMutex.h"
+
 #include "FWCore/Utilities/interface/BaseWithDict.h"
 
 // user include files
@@ -34,6 +37,7 @@ namespace reco {
          returnValue = type.dataMemberByName(iName);
          if(!returnValue) {
             //check inheriting classes
+            R__LOCKGUARD(gCINTMutex);
             edm::TypeBases bases(type);
             for(auto const& base : bases) {
                returnValue = findDataMember(edm::BaseWithDict(base).typeOf(), iName, oError);

--- a/CommonTools/Utils/src/findMethod.cc
+++ b/CommonTools/Utils/src/findMethod.cc
@@ -3,6 +3,8 @@
 #include "CommonTools/Utils/interface/Exception.h"
 #include "FWCore/Utilities/interface/BaseWithDict.h"
 #include "FWCore/Utilities/interface/TypeWithDict.h"
+#include "TInterpreter.h"
+#include "TVirtualMutex.h"
 #include <cassert>
 
 using namespace std;
@@ -141,6 +143,7 @@ namespace reco {
     // if nothing was found, look in parent scopes (without checking for cross-scope overloading, as it's not allowed)
     int baseError=parser::kNameDoesNotExist;
     if(! mem.first) {
+      R__LOCKGUARD(gCINTMutex);
       edm::TypeBases bases(type);
       for(auto const& base : bases) {
 	      if((mem = findMethod(edm::BaseWithDict(base).typeOf(), name, args, fixuppedArgs,iIterator,baseError)).first) break;

--- a/FWCore/Utilities/interface/BaseWithDict.h
+++ b/FWCore/Utilities/interface/BaseWithDict.h
@@ -16,6 +16,18 @@ namespace edm {
   class TypeWithDict;
 
   class BaseWithDict {
+  // NOTE: Any use of class BaseWithDict in ROOT 5 is not thread safe without use
+  // of a properly scoped CINT mutex as in this example:
+  // {
+  //   R__LOCKGUARD(gCintMutex);
+  //   TypeBases bases(myType);
+  //   for (auto const& b : bases) {
+  //     BaseWithDict base(b);
+  //     ...
+  //   }
+  //   //  other use of bases goes here
+  // }
+  // The situation in ROOT 6 is not yet determined.
   public:
     BaseWithDict();
 

--- a/FWCore/Utilities/interface/TypeWithDict.h
+++ b/FWCore/Utilities/interface/TypeWithDict.h
@@ -187,6 +187,14 @@ namespace edm {
   std::ostream& operator<<(std::ostream& os, TypeWithDict const& id);
 
   class TypeBases {
+  // NOTE: Any use of class TypeBases in ROOT 5 is not thread safe without use
+  // of a properly scoped CINT mutex as in this example:
+  // {
+  //     R__LOCKGUARD(gCintMutex);
+  //     TypeBases bases(myType);
+  //     // use of bases goes here
+  // }
+  // The situation in ROOT 6 is not yet determined.
   public:
     explicit TypeBases(TypeWithDict const& type) : type_(type.type_), class_(type.class_) {}
     IterWithDict<TBaseClass> begin() const;

--- a/FWCore/Utilities/src/DictionaryTools.cc
+++ b/FWCore/Utilities/src/DictionaryTools.cc
@@ -8,6 +8,8 @@
 #include "Api.h" // for G__ClassInfo
 
 #include "TROOT.h"
+#include "TInterpreter.h"
+#include "TVirtualMutex.h"
 
 #include "boost/algorithm/string.hpp"
 #include "boost/thread/tss.hpp"
@@ -160,10 +162,13 @@ namespace edm {
             checkType(m.typeOf());
           }
         }
-        TypeBases bases(t);
-        for(auto const& base : bases) {
-          BaseWithDict b(base);
-          checkType(b.typeOf());
+        {
+          R__LOCKGUARD(gCINTMutex);
+          TypeBases bases(t);
+          for(auto const& base : bases) {
+            BaseWithDict b(base);
+            checkType(b.typeOf());
+          }
         }
       }
     }
@@ -246,7 +251,7 @@ namespace edm {
 
     TypeWithDict type(typeID.typeInfo());
     if(type.isClass()) {
-
+      R__LOCKGUARD(gCINTMutex);
       TypeBases bases(type);
       for(auto const& basex : bases) {
         BaseWithDict base(basex);


### PR DESCRIPTION
In ROOT 5, the use of TBaseClass is not thread safe. This pull request, issued at the request of Chris Jones,
adds mutexes for CINT around the uses of TBaseClass, except for those in Fireworks, since Fireworks need not be thread safe.
