### PR TITLE
Fix check for valid type with dictionary

### DIFF
--- a/DataFormats/Provenance/src/BranchDescription.cc
+++ b/DataFormats/Provenance/src/BranchDescription.cc
@@ -11,8 +11,6 @@
 #include "TDictAttributeMap.h"
 
 #include <cassert>
-#include <cstdio>
-#include <cstdlib>
 #include <ostream>
 #include <sstream>
 
@@ -185,13 +183,8 @@ namespace edm {
     //edm::FunctionWithDict giFunc = wrType.FunctionMemberByName("getInterface");
     //giFunc.Invoke(wrapperInterfaceBase());
     edm::invokeByName(wrapperInterfaceBase(), wrType, "getInterface");
-    assert((wrapperInterfaceBase() != 0) && "BranchDescription::initFromDictionary(): "
+    assert((wrapperInterfaceBase() != nullptr) && "BranchDescription::initFromDictionary(): "
       "wrapperInterfaceBase() is nullptr!!");
-    if (wrapperInterfaceBase() == nullptr) {
-      fprintf(stderr, "BranchDescription::initFromDictionary(): "
-        "wrapperInterfaceBase() is nullptr!\n");
-      abort();
-    }
     setTransient(false);
     setSplitLevel(invalidSplitLevel);
     setBasketSize(invalidBasketSize);


### PR DESCRIPTION
Relval matrix test 1001 is failing with a segfault.  The segfault is due to two things:
1) A missing dictionary for a class that needs a TypeWithDict constructed
2) An incorrect check in TypeWithDict for the presence of the dictionary.
This pull request fixes the invalid check, so that test 1001 will throw a proper exception due to the missing dictionary.  The missing dictionary will be added lter in a separate pull request.
This pull request also converts many calls to abort(), used for testing purposes, to throw exceptions instead.
Please merge promptly unless there are issues.
