### PR TITLE
Final clang fix.

### DIFF
--- a/FWCore/TFWLiteSelectorTest/src/ThingsTSelector2.h
+++ b/FWCore/TFWLiteSelectorTest/src/ThingsTSelector2.h
@@ -34,4 +34,5 @@ private:
     ClassDef(ThingsTSelector2,2)
   };
 }
+template<> atomic_TClass_ptr TFWLiteSelector<tfwliteselectortest::ThingsWorker>::fgIsA;
 #endif

--- a/PhysicsTools/ParallelAnalysis/interface/TrackAnalysisAlgorithm.h
+++ b/PhysicsTools/ParallelAnalysis/interface/TrackAnalysisAlgorithm.h
@@ -9,6 +9,7 @@
  *
  */
 
+#include "FWCore/TFWLiteSelector/interface/TFWLiteSelector.h"
 class TH1F;
 class TList;
 class TCanvas;
@@ -36,4 +37,5 @@ namespace examples {
 
 }
 
+template<> atomic_TClass_ptr TFWLiteSelector<examples::TrackAnalysisAlgorithm>::fgIsA;
 #endif


### PR DESCRIPTION
Fixes complain about:

```
.../xr.cc: error: explicit specialization of 'fgIsA' after instantiation
template<> atomic_TClass_ptr TFWLiteSelector<XXXX>::fgIsA(0);
                                             ^
.../xr.cc:111:9: note: implicit instantiation first required here
```
