### PR TITLE
Cleanup #4004

### DIFF
--- a/MuonAnalysis/MomentumScaleCalibration/plugins/TestCorrection.cc
+++ b/MuonAnalysis/MomentumScaleCalibration/plugins/TestCorrection.cc
@@ -264,9 +264,9 @@ void TestCorrection::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
     // Use the correction function to correct the pt scale of the muons. Note that this takes into
     // account the corrections from all iterations.
     lorentzVector recMu1;
-    correctMuon(recMu1);
+    recMu1 = correctMuon(recMu1);
     lorentzVector recMu2;
-    correctMuon(recMu2);
+    recMu2 = correctMuon(recMu2);
 
     reco::Particle::LorentzVector bestRecRes (recMu1+recMu2);
 


### PR DESCRIPTION
As discussed, this corrects the behavior of #4004 getting back the old behavior and still keeping clang happy.
