### PR TITLE
update the DQMService to see the new fwk signals

### DIFF
--- a/DQMServices/Core/src/DQMService.h
+++ b/DQMServices/Core/src/DQMService.h
@@ -17,7 +17,7 @@ public:
   ~DQMService(void);
    
 public:
-  void flush(const edm::Event &, const edm::EventSetup &);
+  void flush(edm::StreamContext const & sc);
 private:
   void shutdown(void);
 


### PR DESCRIPTION
this is needed to run the DQM online during the next global runs. these changes have to be propagated to 72X also (this should be done automatically).
