### PR TITLE
GTs for pre9: migrating accounts to prod DB and updating muon layer alignment

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -1,45 +1,45 @@
 autoCond = { 
     # GlobalTag for MC production with perfectly aligned and calibrated detector                                                                                                                              
-    'mc'                :   'PRE_MC_71_V5::All',
+    'mc'                :   'MC_71_V6::All',
     # GlobalTag for MC production with realistic alignment and calibrations
-    'startup'           :   'PRE_STA71_V4::All',
+    'startup'           :   'START71_V5::All',
     # GlobalTag for MC production of Heavy Ions events with realistic alignment and calibrations
-    'starthi'           :   'PRE_SHI71_V7::All',
+    'starthi'           :   'STARTHI71_V9::All',
     # GlobalTag for MC production of p-Pb events with realistic alignment and calibrations
-    'startpa'           :   'PRE_SHI71_V8::All',
+    'startpa'           :   'STARTHI71_V10::All',
     # GlobalTag for data reprocessing: this should always be the GR_R tag
-    'com10'             :   'PRE_R_71_V3::All',
+    'com10'             :   'GR_R_71_V4::All',
     # GlobalTag for running HLT on recent data: this should be the GR_P (prompt reco) global tag until a compatible GR_H tag is available, 
     # then it should point to the GR_H tag and override the connection string and pfnPrefix for use offline
-    'hltonline'         :   'GR_H_V36::All,frontier://FrontierProd/CMS_COND_31X_GLOBALTAG,frontier://FrontierProd/',
+    'hltonline'         :   'GR_H_V37::All,frontier://FrontierProd/CMS_COND_31X_GLOBALTAG,frontier://FrontierProd/',
     # GlobalTag for POSTLS1 upgrade studies:
-    'upgradePLS1'       :   'PRE_LS171_V9::All',
-    'upgradePLS150ns'   :   'PRE_LS171_V10::All',
+    'upgradePLS1'       :   'POSTLS171_V11::All',
+    'upgradePLS150ns'   :   'POSTLS171_V12::All',
     'upgrade2017'       :   'DES17_70_V2::All', # placeholder (GT not meant for standard RelVal)
     'upgrade2019'       :   'DES19_70_V2::All', # placeholder (GT not meant for standard RelVal)
     'upgradePLS3'       :   'POSTLS262_V1::All', # placeholder (GT not meant for standard RelVal)
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   'PRE_MC_71_V5::All',
+    'run1_design'       :   'MC_71_V6::All',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   'PRE_STA71_V4::All',
+    'run1_mc'           :   'START71_V5::All',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   'PRE_SHI71_V7::All',
+    'run1_mc_hi'        :   'STARTHI71_V9::All',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pPb'       :   'PRE_SHI71_V8::All',
+    'run1_mc_pPb'       :   'STARTHI71_V10::All',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   'PRE_DES71_V2::All',
+    'run2_design'       :   'DESIGN71_V3::All',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   'PRE_LS171_V10::All',
+    'run2_mc_50ns'      :   'POSTLS171_V12::All',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   'PRE_LS171_V9::All',
+    'run2_mc'           :   'POSTLS171_V11::All',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   'PRE_R_71_V3::All',
+    'run1_data'         :   'GR_R_71_V4::All',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   'PRE_R_71_V3::All',
+    'run2_data'         :   'GR_R_71_V4::All',
     # GlobalTag for Run2 HLT: it points to the online GT and overrides the connection string and pfnPrefix for use offline
-    'run2_hlt'          :   'GR_H_V36::All,frontier://FrontierProd/CMS_COND_31X_GLOBALTAG,frontier://FrontierProd/',
+    'run2_hlt'          :   'GR_H_V37::All,frontier://FrontierProd/CMS_COND_31X_GLOBALTAG,frontier://FrontierProd/',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
     'phase1_2017_design' :  'DES17_70_V2::All', # placeholder (GT not meant for standard RelVal)
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019


### PR DESCRIPTION
- Migrating few account in production DB (and thus removing the "PRE" prefix from the GT name)
- Updating muon geometry for data GT fro Run1 having positions of a few internal layers of muon chambers corrected.
- queued for 710_pre9
