### PR TITLE
Fix det id version number

### DIFF
--- a/DataFormats/DetId/src/classes_def.xml
+++ b/DataFormats/DetId/src/classes_def.xml
@@ -1,6 +1,5 @@
 <lcgdict>
-  <class name="DetId" ClassVersion="11">
-   <version ClassVersion="11" checksum="9999999999"/>
+  <class name="DetId" ClassVersion="10">
    <version ClassVersion="10" checksum="1024501242"/>
   </class>
   <class name="std::vector<DetId>"/>


### PR DESCRIPTION
Due to recent changes in ROOT6, the version number of class DetId (among others) needs to be reverted to the same version number as in ROOT5.  DetId is the only such class causing a problem now, so this pull request reverts its specification to that used in ROOT 5.
Please merge this request promptly unless there are issues.
