### PR TITLE
Fixed a read of uninitialized memory in CastorMonitorModule

### DIFF
--- a/DQM/CastorMonitor/src/CastorMonitorModule.cc
+++ b/DQM/CastorMonitor/src/CastorMonitorModule.cc
@@ -20,7 +20,6 @@
 //==================================================================//
 CastorMonitorModule::CastorMonitorModule(const edm::ParameterSet& ps)
   {
-  if(fVerbosity>0) std::cout << "CastorMonitorModule Constructor (start)" << std::endl;
 
    ////---- get steerable variables
   inputLabelRaw_ 			= ps.getParameter<edm::InputTag>("rawLabel");
@@ -32,6 +31,7 @@ CastorMonitorModule::CastorMonitorModule(const edm::ParameterSet& ps)
   showTiming_ 				= ps.getUntrackedParameter<bool>("showTiming", false);         //-- show CPU time 
   dump2database_   			= ps.getUntrackedParameter<bool>("dump2database",false);  //-- dumps output to database file
 
+  if(fVerbosity>0) std::cout << "CastorMonitorModule Constructor (start)" << std::endl;
   ////---- initialize Run, LS, Event number and other parameters
   irun_=0; 
   ilumisec_=0; 


### PR DESCRIPTION
valgrind spotted an uninitialized memory access in the constructor.
The problem was only minor and easy to correct.
