### PR TITLE
Removed unused variable to avoid valgrind error in SoftElectronMVAEstimator

### DIFF
--- a/RecoEgamma/ElectronIdentification/interface/SoftElectronMVAEstimator.h
+++ b/RecoEgamma/ElectronIdentification/interface/SoftElectronMVAEstimator.h
@@ -49,7 +49,7 @@ class SoftElectronMVAEstimator {
     Float_t                    OneMinusE1x5E5x5;
 
     Float_t                    HoE;
-    Float_t                    EoP;
+    //Float_t                    EoP; //Not being used
     Float_t                    eleEoPout;
 
     Float_t 			spp;

--- a/RecoEgamma/ElectronIdentification/src/SoftElectronMVAEstimator.cc
+++ b/RecoEgamma/ElectronIdentification/src/SoftElectronMVAEstimator.cc
@@ -196,8 +196,8 @@ void SoftElectronMVAEstimator::bindVariables() {
     dphi = 0.6;
 
 
-  if(EoP > 20.)
-    EoP = 20.;
+  //if(EoP > 20.)
+  //  EoP = 20.;
 
   if(eleEoPout > 20.)
     eleEoPout = 20.;


### PR DESCRIPTION
A member variable which was not being used was being compared against and
valgrind was flagging it as an error. It was trivial to comment out the
variable.
