### PR TITLE
Fix dqm memory leaks p2

### DIFF
--- a/DQM/Physics/src/SingleTopTChannelLeptonDQM.cc
+++ b/DQM/Physics/src/SingleTopTChannelLeptonDQM.cc
@@ -391,8 +391,8 @@ namespace SingleTopTChannelLepton {
     edm::Handle<edm::View<reco::GsfElectron> > elecs_gsf;
     edm::Handle<edm::View<reco::PFCandidate> > elecs;
     edm::View<reco::PFCandidate>::const_iterator elec_it;
-    StringCutObjectSelector<reco::PFCandidate, true> *elecSelect = new StringCutObjectSelector<reco::PFCandidate, true>(elecSelect_); 
-    StringCutObjectSelector<reco::PFCandidate, true> *elecIso = new StringCutObjectSelector<reco::PFCandidate, true>(elecIso_);
+    StringCutObjectSelector<reco::PFCandidate, true> elecSelect(elecSelect_); 
+    StringCutObjectSelector<reco::PFCandidate, true> elecIso(elecIso_);
     reco::GsfElectronRef elec;
     
     if( !event.getByToken(elecs_, elecs) ) return;
@@ -421,7 +421,7 @@ namespace SingleTopTChannelLepton {
 
       if( electronId_.isUninitialized()  ? true : ( (eID  & eidPattern_) && (eID >=5)) ){ 
 
-	if(!elecSelect || (*elecSelect)(*elec_it)){
+	if( elecSelect(*elec_it)){
 	  double isolationRel = (elec->dr03TkSumPt()+elec->dr03EcalRecHitSumEt()+elec->dr03HcalTowerSumEt())/elec->pt();
 
 	  double isolationChHad = elec->pt()/(elec->pt()+elec->pfIsolationVariables().sumChargedHadronPt);
@@ -442,7 +442,7 @@ namespace SingleTopTChannelLepton {
 	  }
 	  // in addition to the multiplicity counter buffer the iso 
 	  // electron candidates for later overlap check with jets
-	  ++eMult; if( !elecIso || (*elecIso)(*elec_it)){  if(eMultIso == 0) e = *elec; isoElecs.push_back(&(*elec)); ++eMultIso; }
+	  ++eMult; if( (elecIso)(*elec_it)){  if(eMultIso == 0) e = *elec; isoElecs.push_back(&(*elec)); ++eMultIso; }
 	}
       }
       idx_gsf++;


### PR DESCRIPTION
more complete fix to cut parser leaks in SingleTopTChannelLeptonDQM -- but I don't see why these cut parser variables need to be reinitialized every event? Could the experts have a look and comment. thx.
