### PR TITLE
jetAlgo name to AK5PFchs; Cloning corrections, applied on ak4 jets

### DIFF
--- a/DQM/Physics/interface/TopDQMHelpers.h
+++ b/DQM/Physics/interface/TopDQMHelpers.h
@@ -149,7 +149,7 @@ class Calculate {
                      the selection (optional).
     - max          : whether there is a max value on which to reject the whole event after
                      the selection (optional).
-    - electronId   : input tag of an electronId association map and selection pattern
+    - electronId   : input tag of an electronId association map and cut value
                      (optional).
     - jetCorrector : label of jet corrector (optional).
     - jetBTagger   : parameters defining the btag algorithm and working point of choice
@@ -202,7 +202,10 @@ private:
   ///  6: passes conversion rejection and Isolation
   ///  7: passes the whole selection
   /// As described on https://twiki.cern.ch/twiki/bin/view/CMS/SimpleCutBasedEleID
-  int eidPattern_;
+  //int eidPattern_;
+  double eidCutValue_;
+  //rho for Effective Area corrections
+  //edm::EDGetTokenT<double> eventrhoToken_;
   /// jet corrector as extra selection type
   std::string jetCorrector_;
   /// choice for b-tag as extra selection type
@@ -227,6 +230,9 @@ SelectionStep<Object>::SelectionStep(const edm::ParameterSet& cfg, edm::Consumes
   select_(cfg.getParameter<std::string>("select")),
   jetIDSelect_( 0)
 {
+  
+  //  eventrhoToken_ = iC.consumes<double>(edm::InputTag("fixedGridRhoFastjetAll"));
+
   //cout<<"In new constructor"<<endl;
   src_ = iC.consumes<edm::View<Object> >(cfg.getParameter<edm::InputTag>("src"));
   //cout<<"// construct min/max if the corresponding params"<<endl;
@@ -239,7 +245,7 @@ SelectionStep<Object>::SelectionStep(const edm::ParameterSet& cfg, edm::Consumes
   if(cfg.existsAs<edm::ParameterSet>("electronId")){ 
     edm::ParameterSet elecId=cfg.getParameter<edm::ParameterSet>("electronId");
     electronId_= iC.consumes<edm::ValueMap<float> >(elecId.getParameter<edm::InputTag>("src"));
-    eidPattern_= elecId.getParameter<int>("pattern");
+    eidCutValue_= elecId.getParameter<double>("cutValue");
   }
   //cout<<"// read jet corrector label if it exists"<<endl;
   if(cfg.exists("jetCorrector")){ jetCorrector_= cfg.getParameter<std::string>("jetCorrector"); }
@@ -262,6 +268,7 @@ SelectionStep<Object>::SelectionStep(const edm::ParameterSet& cfg, edm::Consumes
 template <typename Object>
 bool SelectionStep<Object>::select(const edm::Event& event)
 {
+
   // fetch input collection
   edm::Handle<edm::View<Object> > src; 
   if( !event.getByToken(src_, src) ) return false;
@@ -272,13 +279,18 @@ bool SelectionStep<Object>::select(const edm::Event& event)
     if( !event.getByToken(electronId_, electronId) ) return false;
   }
 
+  //fill rho for EA corrections
+  //edm::Handle<double> rho_;
+  //if( !event.getByToken(eventrhoToken_,rho_) ) return false;
+  //double rho = *(rho_.product());
+
   // determine multiplicity of selected objects
   int n=0;
   for(typename edm::View<Object>::const_iterator obj=src->begin(); obj!=src->end(); ++obj){
     // special treatment for electrons
     if(dynamic_cast<const reco::GsfElectron*>(&*obj)){
       unsigned int idx = obj-src->begin();
-      if( electronId_.isUninitialized() ? true : ((int)(*electronId)[src->refAt(idx)] & eidPattern_) ){   
+      if( electronId_.isUninitialized() ? true : ((double)(*electronId)[src->refAt(idx)] >= eidCutValue_) ){   
 	if(select_(*obj))++n;
       }
     }
@@ -299,53 +311,51 @@ bool SelectionStep<Object>::select(const edm::Event& event, const std::string& t
   // fetch input collection
   edm::Handle<edm::View<Object> > src;
   if( !event.getByToken(src_, src) ) return false;
-  
+
   // special for gsfElectron
   edm::Handle<edm::View<reco::GsfElectron> > elecs_gsf;
-  
+
   // load electronId value map if configured such
   edm::Handle<edm::ValueMap<float> > electronId;
   if(!electronId_.isUninitialized()){
     if( !event.getByToken(electronId_, electronId) ) return false;
   }
   
+
   // determine multiplicity of selected objects
   int n=0;
-  unsigned int idx_gsf = 0;
+  //  unsigned int idx_gsf = 0;
   for(typename edm::View<Object>::const_iterator obj=src->begin(); obj!=src->end(); ++obj){
-    
     
     // special treatment for PF candidates
     if (dynamic_cast<const reco::PFCandidate*>(&*obj)){
       reco::PFCandidate objtmp = dynamic_cast<const reco::PFCandidate&>(*obj);
       
       if (objtmp.muonRef().isNonnull() && type == "muon") {
-
         if(select_(*obj)){++n;
         }
       }
+      
       else if (objtmp.gsfElectronRef().isNonnull() && type == "electron") {
-        if( !event.getByToken(gsfEs_, elecs_gsf) ) continue;
         if(select_(*obj)){
-          if(elecs_gsf->refAt(idx_gsf).isNonnull()){
-	    int eID=0;
-	    if (!electronId_.isUninitialized()){
-	      eID = (int)(*electronId)[elecs_gsf->refAt(idx_gsf)];
-	    }
-            if( electronId_.isUninitialized() ? true : ( (eID & eidPattern_)  && (eID >= 5) ) )
-              ++n;
-	    
-          }
+	//  cout<<"Electron is selected"<<endl;
+	  if( electronId_.isUninitialized()){
+        //    cout<<"No Id is requested"<<endl;		
+	    ++n;	
+	  } else if(( (double)(*electronId)[obj->gsfElectronRef()] >= eidCutValue_ )){
+          //  cout<<"Id is requested"<<endl;		
+	    ++n;
+	  }	    
+	  
         }
-        idx_gsf++;
+	//        idx_gsf++;
       }
     }
     
     // special treatment for electrons
     else if(dynamic_cast<const reco::GsfElectron*>(&*obj)){
       unsigned int idx = obj-src->begin();
-      int eID = (int)(*electronId)[src->refAt(idx)];
-      if( electronId_.isUninitialized() ? true : ( (eID & eidPattern_)  && (eID >= 5) ) ){
+      if( electronId_.isUninitialized() ? true : ( (double)(*electronId)[src->refAt(idx)] >= eidCutValue_ ) ){
         if(select_(*obj))++n;
       }
     }

--- a/DQM/Physics/python/DQMPhysics_cff.py
+++ b/DQM/Physics/python/DQMPhysics_cff.py
@@ -16,6 +16,24 @@ from DQM.Physics.ExoticaDQM_cfi import *
 from DQM.Physics.B2GDQM_cfi import *
 from DQM.PhysicsHWW.hwwDQM_cfi import *
 
+#############################################################################
+## Temporary due to bad naming of the jet algorithm in correction modules  ##
+from JetMETCorrections.Configuration.JetCorrectionServices_cff import ak4PFCHSL1Offset, ak4PFCHSL1Fastjet, ak4PFCHSL2Relative, ak4PFCHSL3Absolute, ak4PFCHSResidual, ak4PFCHSL2L3, ak4PFCHSL2L3Residual
+ak4PFCHSL1Offset.algorithm = 'AK5PFchs'
+ak4PFCHSL1Fastjet.algorithm = 'AK5PFchs'
+ak4PFCHSL2Relative.algorithm = 'AK5PFchs'
+ak4PFCHSL3Absolute.algorithm = 'AK5PFchs'
+ak4PFCHSResidual.algorithm = 'AK5PFchs'
+
+topDQMak5PFCHSL1Offset = ak4PFCHSL1Offset.clone()
+topDQMak5PFCHSL1Fastjet = ak4PFCHSL1Fastjet.clone()
+topDQMak5PFCHSL2Relative = ak4PFCHSL2Relative.clone()
+topDQMak5PFCHSL3Absolute = ak4PFCHSL3Absolute.clone()
+topDQMak5PFCHSResidual = ak4PFCHSResidual.clone()
+
+topDQMak5PFCHSL2L3 = ak4PFCHSL2L3.clone(correctors = cms.vstring('topDQMak5PFCHSL2Relative','topDQMak5PFCHSL3Absolute'))
+topDQMak5PFCHSL2L3Residual = ak4PFCHSL2L3Residual.clone(correctors = cms.vstring('topDQMak5PFCHSL2Relative','topDQMak5PFCHSL3Absolute','topDQMak5PFCHSResidual'))
+#############################################################################
 
 dqmPhysics = cms.Sequence( bphysicsOniaDQM 
                            *ewkMuDQM

--- a/DQM/Physics/python/singleTopDQM_cfi.py
+++ b/DQM/Physics/python/singleTopDQM_cfi.py
@@ -1,7 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
+EletightIsoCut  = "(gsfElectronRef.pfIsolationVariables.sumChargedHadronPt + max(0., gsfElectronRef.pfIsolationVariables.sumNeutralHadronEt + gsfElectronRef.pfIsolationVariables.sumPhotonEt - 0.5 * gsfElectronRef.pfIsolationVariables.sumPUPt) ) / gsfElectronRef.pt < 0.1"
+ElelooseIsoCut  = "(gsfElectronRef.pfIsolationVariables.sumChargedHadronPt + max(0., gsfElectronRef.pfIsolationVariables.sumNeutralHadronEt + gsfElectronRef.pfIsolationVariables.sumPhotonEt - 0.5 * gsfElectronRef.pfIsolationVariables.sumPUPt) ) / gsfElectronRef.pt < 0.15"
 
-singleTopDQM = cms.EDAnalyzer("SingleTopTChannelLeptonDQM",
+
+singleTopTChannelLeptonDQM = cms.EDAnalyzer("SingleTopTChannelLeptonDQM",
   ## ------------------------------------------------------
   ## SETUP
   ##
@@ -10,13 +13,13 @@ singleTopDQM = cms.EDAnalyzer("SingleTopTChannelLeptonDQM",
   ##
   setup = cms.PSet(
     ## sub-directory to write the monitor histograms to
-    ## [mandatory] : should not be changed w/o explicit
+    ## [mandatory] : should not be changed w/o explicit 
     ## communication to TopCom!
     directory = cms.string("Physics/Top/SingleTopDQM/"),
     ## [mandatory]
     sources = cms.PSet(
       muons = cms.InputTag("muons"),
-      elecs = cms.InputTag("particleFlow"),
+      elecs = cms.InputTag("pfIsolatedElectronsEI"),
       jets  = cms.InputTag("ak4PFJetsCHS"),
       mets  = cms.VInputTag("met", "tcMet", "pfMet"),
       pvs   = cms.InputTag("offlinePrimaryVertices")
@@ -29,41 +32,41 @@ singleTopDQM = cms.EDAnalyzer("SingleTopTChannelLeptonDQM",
     ## will be filled w/o extras
 #    pvExtras = cms.PSet(
       ## when omitted electron plots will be filled w/o additional pre-
-      ## selection of the primary vertex candidates
+      ## selection of the primary vertex candidates                                                                                            
 #      select = cms.string("abs(x)<1. & abs(y)<1. & abs(z)<20. & tracksSize>3 & !isFake")
 #    ),
     ## [optional] : when omitted all monitoring plots for electrons
     ## will be filled w/o extras
     elecExtras = cms.PSet(
       ## when omitted electron plots will be filled w/o cut on electronId
-      electronId = cms.PSet( src = cms.InputTag("simpleEleId70cIso"), pattern = cms.int32(1) ),
+      ##electronId = cms.PSet( src = cms.InputTag("mvaTrigV0"), cutValue = cms.double(0.5) ),  
       ## when omitted electron plots will be filled w/o additional pre-
-      ## selection of the electron candidates
-      select = cms.string("pt>15 & abs(eta)<2.5 & abs(gsfTrack.d0)<1 & abs(gsfTrack.dz)<20"),
+      ## selection of the electron candidates                                                                                            
+      select = cms.string("pt>15 & abs(eta)<2.5 & abs(gsfElectronRef.gsfTrack.d0)<1 & abs(gsfElectronRef.gsfTrack.dz)<20"),
       ## when omitted isolated electron multiplicity plot will be equi-
-      ## valent to inclusive electron multiplicity plot
-#      isolation = cms.string("(dr03TkSumPt+dr04EcalRecHitSumEt+dr04HcalTowerSumEt)/pt<0.1"),
+      ## valent to inclusive electron multiplicity plot 
+      isolation = cms.string(ElelooseIsoCut),
     ),
     ## [optional] : when omitted all monitoring plots for muons
     ## will be filled w/o extras
     muonExtras = cms.PSet(
       ## when omitted muon plots will be filled w/o additional pre-
-      ## selection of the muon candidates
+      ## selection of the muon candidates                                                                                            
       select = cms.string("pt>10 & abs(eta)<2.1 & isGlobalMuon & abs(globalTrack.d0)<1 & abs(globalTrack.dz)<20"),
       ## when omitted isolated muon multiplicity plot will be equi-
-      ## valent to inclusive muon multiplicity plot
+      ## valent to inclusive muon multiplicity plot                                                    
 #      isolation = cms.string("(isolationR03.sumPt+isolationR03.emEt+isolationR03.hadEt)/pt<0.1"),
     ),
     ## [optional] : when omitted all monitoring plots for jets will
     ## be filled from uncorrected jets
     jetExtras = cms.PSet(
       ## when omitted monitor plots for pt will be filled from uncorrected
-      ## jets
-      jetCorrector = cms.string("ak4CaloL2L3"),
+      ## jets                                            
+      jetCorrector = cms.string("ak5CaloL2L3"),
       ## when omitted monitor plots will be filled w/o additional cut on
-      ## jetID
+      ## jetID                                                   
 #      jetID  = cms.PSet(
-#        label  = cms.InputTag("ak4JetID"),
+#        label  = cms.InputTag("ak5JetID"),
 #        select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
 #      ),
       ## when omitted no extra selection will be applied on jets before
@@ -85,8 +88,8 @@ singleTopDQM = cms.EDAnalyzer("SingleTopTChannelLeptonDQM",
                            'HLT_Mu5:HLT_QuadJet15U',
                            'HLT_Mu7:HLT_QuadJet15U',
                            'HLT_Mu9:HLT_QuadJet15U'])
-    )
-  ),
+    )                                            
+  ),                                  
   ## ------------------------------------------------------
   ## PRESELECTION
   ##
@@ -114,18 +117,18 @@ singleTopDQM = cms.EDAnalyzer("SingleTopTChannelLeptonDQM",
   ## by this vector
   ## [mandatory] : may be empty or contain an arbitrary
   ## number of PSets
-  ##
+  ##    
   selection = cms.VPSet(
     cms.PSet(
       label  = cms.string("jets/calo:step0"),
-      src    = cms.InputTag("ak4CaloJets"),
+      src    = cms.InputTag("ak5CaloJets"),
       select = cms.string("pt>20 & abs(eta)<2.1 & 0.05<emEnergyFraction"),
       jetID  = cms.PSet(
-        label  = cms.InputTag("ak4JetID"),
+        label  = cms.InputTag("ak5JetID"),
         select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
       ),
       min = cms.int32(2),
-    ),
+    )
   )
 )
 
@@ -136,7 +139,7 @@ singleTopMuonMediumDQM = cms.EDAnalyzer("SingleTopTChannelLeptonDQM",
   ## configuration of the MonitoringEnsemble(s)
   ## [mandatory] : optional PSets may be omitted
   ##
-                                        setup = cms.PSet(
+    setup = cms.PSet(
     ## sub-directory to write the monitor histograms to
     ## [mandatory] : should not be changed w/o explicit
     ## communication to TopCom!
@@ -145,7 +148,7 @@ singleTopMuonMediumDQM = cms.EDAnalyzer("SingleTopTChannelLeptonDQM",
     sources = cms.PSet(
     muons = cms.InputTag("particleFlow"),
     elecs_gsf = cms.InputTag("gedGsfElectrons"),
-    elecs = cms.InputTag("particleFlow"),
+    elecs = cms.InputTag("pfIsolatedElectronsEI"),
     jets  = cms.InputTag("ak4PFJetsCHS"),
     mets  = cms.VInputTag("met", "tcMet", "pfMet"),
     pvs   = cms.InputTag("offlinePrimaryVertices")
@@ -158,19 +161,19 @@ singleTopMuonMediumDQM = cms.EDAnalyzer("SingleTopTChannelLeptonDQM",
     ## will be filled w/o extras
 #    pvExtras = cms.PSet(
       ## when omitted electron plots will be filled w/o additional pre-
-      ## selection of the primary vertex candidates
+      ## selection of the primary vertex candidates                                                                                            
 #      select = cms.string("") #abs(x)<1. & abs(y)<1. & abs(z)<20. & tracksSize>3 & !isFake")
 #    ),
     ## [optional] : when omitted all monitoring plots for muons
-    ## will be filled w/o extras
-    muonExtras = cms.PSet(
+    ## will be filled w/o extras                                           
+    muonExtras = cms.PSet(  
       ## when omitted muon plots will be filled w/o additional pre-
-      ## selection of the muon candidates
+      ## selection of the muon candidates 
       select    = cms.string("abs(muonRef.eta)<2.1")
       ## & isGlobalMuon & innerTrack.numberOfValidHits>10 & globalTrack.normalizedChi2>-1 & globalTrack.normalizedChi2<10
-      ##& (isolationR03.sumPt+isolationR03.emEt+isolationR03.hadEt)/pt<0.1"),
+      ##& (isolationR03.sumPt+isolationR03.emEt+isolationR03.hadEt)/pt<0.1"),  
       ## when omitted isolated muon multiplicity plot will be equi-
-      ## valent to inclusive muon multiplicity plot
+      ## valent to inclusive muon multiplicity plot                                                    
    ##   isolation = cms.string("(muonRef.isolationR03.sumPt+muonRef.isolationR03.emEt+muonRef.isolationR03.hadEt)/muonRef.pt<10" )
       ##    isolation = cms.string("(muonRef.isolationR03.sumPt+muonRef.isolationR03.emEt+muonRef.isolationR03.hadEt)/muonRef.pt<0.1")
     ),
@@ -179,18 +182,18 @@ singleTopMuonMediumDQM = cms.EDAnalyzer("SingleTopTChannelLeptonDQM",
     jetExtras = cms.PSet(
       ## when omitted monitor plots for pt will be filled from uncorrected
       ## jets
-      jetCorrector = cms.string("ak4PFL2L3"),
+      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
       ## when omitted monitor plots will be filled w/o additional cut on
-      ## jetID
+      ## jetID                                                                                                   
 #      jetID  = cms.PSet(
-#        label  = cms.InputTag("ak4JetID"),
+#        label  = cms.InputTag("ak5JetID"),
 #        select = cms.string(""), ##fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
 #     ),
       ## when omitted no extra selection will be applied on jets before
       ## filling the monitor histograms; if jetCorrector is present the
-      ## selection will be applied to corrected jets
+      ## selection will be applied to corrected jets                                                
       select = cms.string("pt>15 & abs(eta)<2.5"), # & neutralEmEnergyFraction >0.01 & chargedEmEnergyFraction>0.01"),
-      ## when omitted monitor histograms for b-tagging will not be filled
+      ## when omitted monitor histograms for b-tagging will not be filled                                                                                                   
       jetBTaggers  = cms.PSet(
         trackCountingEff = cms.PSet(
           label = cms.InputTag("trackCountingHighEffBJetTags" ),
@@ -208,8 +211,8 @@ singleTopMuonMediumDQM = cms.EDAnalyzer("SingleTopTChannelLeptonDQM",
           label = cms.InputTag("combinedSecondaryVertexBJetTags"),
           workingPoint = cms.double(0.898)
         )
-     ),
-   ),
+     )                                                
+   )
     ## [optional] : when omitted no mass window will be applied
     ## for the W mass before filling the event monitoring plots
 #    massExtras = cms.PSet(
@@ -223,7 +226,7 @@ singleTopMuonMediumDQM = cms.EDAnalyzer("SingleTopTChannelLeptonDQM",
 #     paths = cms.vstring(['HLT_IsoMu17_eta2p1_CentralPFNoPUJet30_BTagIPIter_v1'])
 #                          'HLT_IsoMu24_eta2p1_v12',
 #                          'HLT_IsoMu20_eta2p1_CentralPFJet30_BTagIPIter_v2',
-#                          'HLT_IsoMu20_eta2p1_CentralPFJet30_BTagIPIter_v3'])
+#                          'HLT_IsoMu20_eta2p1_CentralPFJet30_BTagIPIter_v3'])      
 #    )
   ),
   ## ------------------------------------------------------
@@ -258,6 +261,7 @@ singleTopMuonMediumDQM = cms.EDAnalyzer("SingleTopTChannelLeptonDQM",
       label  = cms.string("presel"),
       src    = cms.InputTag("offlinePrimaryVertices"),
       select = cms.string('!isFake && ndof >= 4 && abs(z)<24. && position.Rho <= 2.0 '),
+     
    ),
    cms.PSet(
       label  = cms.string("muons/pf:step0"),
@@ -270,21 +274,21 @@ singleTopMuonMediumDQM = cms.EDAnalyzer("SingleTopTChannelLeptonDQM",
     cms.PSet(
       label  = cms.string("jets/pf:step1"),
       src    = cms.InputTag("ak4PFJetsCHS"),
-      jetCorrector = cms.string("ak4PFL2L3"),
-      select = cms.string(" pt>30 & abs(eta)<4.5 & numberOfDaughters>1 & ((abs(eta)>2.4) || ( chargedHadronEnergyFraction > 0 & chargedMultiplicity>0 & chargedEmEnergyFraction<0.99)) & neutralEmEnergyFraction < 0.99 & neutralHadronEnergyFraction < 0.99"),
+      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
+      select = cms.string(" pt>30 & abs(eta)<4.5 & numberOfDaughters>1 & ((abs(eta)>2.4) || ( chargedHadronEnergyFraction > 0 & chargedMultiplicity>0 & chargedEmEnergyFraction<0.99)) & neutralEmEnergyFraction < 0.99 & neutralHadronEnergyFraction < 0.99"), 
 
       min = cms.int32(1),
       max = cms.int32(1),
-    ),
+    ), 
     cms.PSet(
      label  = cms.string("jets/pf:step2"),
      src    = cms.InputTag("ak4PFJetsCHS"),
-     jetCorrector = cms.string("ak4PFL2L3"),
+     jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
      select = cms.string(" pt>30 & abs(eta)<4.5 & numberOfDaughters>1 & ((abs(eta)>2.4) || ( chargedHadronEnergyFraction > 0 & chargedMultiplicity>0 & chargedEmEnergyFraction<0.99)) & neutralEmEnergyFraction < 0.99 & neutralHadronEnergyFraction < 0.99"),
-
+     
      min = cms.int32(2),
      max = cms.int32(2),
-    ),
+    )
   )
 )
 
@@ -304,7 +308,7 @@ singleTopElectronMediumDQM = cms.EDAnalyzer("SingleTopTChannelLeptonDQM",
     sources = cms.PSet(
       muons = cms.InputTag("particleFlow"),
       elecs_gsf = cms.InputTag("gedGsfElectrons"),
-      elecs = cms.InputTag("particleFlow"),
+      elecs = cms.InputTag("pfIsolatedElectronsEI"),
       jets  = cms.InputTag("ak4PFJetsCHS"),
       mets  = cms.VInputTag("met", "tcMet", "pfMet"),
       pvs   = cms.InputTag("offlinePrimaryVertices")
@@ -318,36 +322,37 @@ singleTopElectronMediumDQM = cms.EDAnalyzer("SingleTopTChannelLeptonDQM",
     ## will be filled w/o extras
 #    pvExtras = cms.PSet(
       ## when omitted electron plots will be filled w/o additional pre-
-      ## selection of the primary vertex candidates
+      ## selection of the primary vertex candidates                                                                                            
 #      select = cms.string("abs(x)<1. & abs(y)<1. & abs(z)<20. & tracksSize>3 & !isFake")
 #    ),
     ## [optional] : when omitted all monitoring plots for electrons
     ## will be filled w/o extras
     elecExtras = cms.PSet(
       ## when omitted electron plots will be filled w/o cut on electronId
-      electronId = cms.PSet( src = cms.InputTag("simpleEleId70cIso"), pattern = cms.int32(1) ),
+      ##electronId = cms.PSet( src = cms.InputTag("mvaTrigV0"), cutValue = cms.double(0.5) ),  
       ## when omitted electron plots will be filled w/o additional pre-
       ## selection of the electron candidates
-      select     = cms.string("gsfElectronRef.pt>25"), ##  & abs(eta)<2.5 & (dr03TkSumPt+dr03EcalRecHitSumEt+dr03HcalTowerSumEt)/pt<0.1"),
+      select     = cms.string("pt>25"), ##  & abs(eta)<2.5 & (dr03TkSumPt+dr03EcalRecHitSumEt+dr03HcalTowerSumEt)/pt<0.1"),
       ## when omitted isolated electron multiplicity plot will be equi-
-      ## valent to inclusive electron multiplicity plot
-     ## isolation  = cms.string("(dr03TkSumPt+dr03EcalRecHitSumEt+dr03HcalTowerSumEt)/pt<0.1"),
+      ## valent to inclusive electron multiplicity plot 
+     ## isolation  = cms.string(ElelooseIsoCut),
+
     ),
     ## [optional] : when omitted all monitoring plots for jets
     ## will be filled w/o extras
     jetExtras = cms.PSet(
       ## when omitted monitor plots for pt will be filled from uncorrected
       ## jets
-      jetCorrector = cms.string("ak4PFL2L3"),
+      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
       ## when omitted monitor plots will be filled w/o additional cut on
       ## jetID
 #      jetID  = cms.PSet(
-#        label  = cms.InputTag("ak4JetID"),
+#        label  = cms.InputTag("ak5JetID"),
 #        select = cms.string(" ")
 #      ),
       ## when omitted no extra selection will be applied on jets before
       ## filling the monitor histograms; if jetCorrector is present the
-      ## selection will be applied to corrected jets
+      ## selection will be applied to corrected jets 
       select = cms.string("pt>15 & abs(eta)<2.5"), ## & emEnergyFraction>0.01"),
       ## when omitted monitor histograms for b-tagging will not be filled
       jetBTaggers  = cms.PSet(
@@ -367,7 +372,7 @@ singleTopElectronMediumDQM = cms.EDAnalyzer("SingleTopTChannelLeptonDQM",
           label = cms.InputTag("combinedSecondaryVertexBJetTags"),
           workingPoint = cms.double(0.898)
         )
-      ),
+      )
     ),
     ## [optional] : when omitted no mass window will be applied
     ## for the W mass before filling the event monitoring plots
@@ -418,26 +423,26 @@ singleTopElectronMediumDQM = cms.EDAnalyzer("SingleTopTChannelLeptonDQM",
    ),
    cms.PSet(
       label = cms.string("elecs/pf:step0"),
-      src   = cms.InputTag("particleFlow"),
-      electronId = cms.PSet( src = cms.InputTag("simpleEleId70cIso"), pattern = cms.int32(1) ),
-      select = cms.string("gsfElectronRef.pt>30 & abs(gsfElectronRef.eta)<2.5 & gsfElectronRef.isNonnull & gsfElectronRef.gsfTrack.isNonnull & ( abs(gsfElectronRef.superCluster.eta)> 1.5660 || abs(gsfElectronRef.superCluster.eta)<1.4442) & (gsfElectronRef.pfIsolationVariables.sumChargedHadronPt + gsfElectronRef.pfIsolationVariables.sumNeutralHadronEt + gsfElectronRef.pfIsolationVariables.sumPhotonEt)/gsfElectronRef.pt<0.125 & abs(gsfElectronRef.gsfTrack.dxy)<0.02 "),
+      src   = cms.InputTag("pfIsolatedElectronsEI"),
+##      electronId = cms.PSet( src = cms.InputTag("mvaTrigV0"), cutValue = cms.double(0.5) ),  
+      select = cms.string("pt>30 & abs(eta)<2.5 & abs(gsfElectronRef.gsfTrack.d0)<0.02 && gsfElectronRef.gsfTrack.trackerExpectedHitsInner.numberOfHits <= 0 && (abs(gsfElectronRef.superCluster.eta) <= 1.4442 || abs(gsfElectronRef.superCluster.eta) >= 1.5660) && " + EletightIsoCut),
       min = cms.int32(1),
       max = cms.int32(1),
     ),
     cms.PSet(
       label = cms.string("jets/pf:step1"),
       src   = cms.InputTag("ak4PFJetsCHS"),
-      jetCorrector = cms.string("ak4PFL2L3"),
-      select = cms.string("pt>30 & abs(eta)<4.5 & numberOfDaughters>1 & ((abs(eta)>2.4) || ( chargedHadronEnergyFraction > 0 & chargedMultiplicity>0 & chargedEmEnergyFraction<0.99)) & neutralEmEnergyFraction < 0.99 & neutralHadronEnergyFraction < 0.99"),
+      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
+      select = cms.string("pt>30 & abs(eta)<4.5 & numberOfDaughters>1 & ((abs(eta)>2.4) || ( chargedHadronEnergyFraction > 0 & chargedMultiplicity>0 & chargedEmEnergyFraction<0.99)) & neutralEmEnergyFraction < 0.99 & neutralHadronEnergyFraction < 0.99"), 
 
       min = cms.int32(1),
       max = cms.int32(1),
-
+      
     ),
     cms.PSet(
       label = cms.string("jets/pf:step2"),
       src   = cms.InputTag("ak4PFJetsCHS"),
-      jetCorrector = cms.string("ak4PFL2L3"),
+      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
       select = cms.string("pt>30 & abs(eta)<4.5 & numberOfDaughters>1 & ((abs(eta)>2.4) || ( chargedHadronEnergyFraction > 0 & chargedMultiplicity>0 & chargedEmEnergyFraction<0.99)) & neutralEmEnergyFraction < 0.99 & neutralHadronEnergyFraction < 0.99"),
 
       min = cms.int32(2),

--- a/DQM/Physics/python/topDiLeptonOfflineDQM_cfi.py
+++ b/DQM/Physics/python/topDiLeptonOfflineDQM_cfi.py
@@ -1,5 +1,11 @@
 import FWCore.ParameterSet.Config as cms
 
+looseMuonCut = "muonRef.isNonnull && (muonRef.isGlobalMuon || muonRef.isTrackerMuon) && muonRef.isPFMuon"
+looseIsoCut  = "(muonRef.pfIsolationR04.sumChargedHadronPt + max(0., muonRef.pfIsolationR04.sumNeutralHadronEt + muonRef.pfIsolationR04.sumPhotonEt - 0.5 * muonRef.pfIsolationR04.sumPUPt) ) / muonRef.pt < 0.2"
+ElelooseIsoCut  = "(gsfElectronRef.pfIsolationVariables.sumChargedHadronPt + max(0., gsfElectronRef.pfIsolationVariables.sumNeutralHadronEt + gsfElectronRef.pfIsolationVariables.sumPhotonEt - 0.5 * gsfElectronRef.pfIsolationVariables.sumPUPt) ) / gsfElectronRef.pt < 0.15"
+EletightIsoCut  = "(gsfElectronRef.pfIsolationVariables.sumChargedHadronPt + max(0., gsfElectronRef.pfIsolationVariables.sumNeutralHadronEt + gsfElectronRef.pfIsolationVariables.sumPhotonEt - 0.5 * gsfElectronRef.pfIsolationVariables.sumPUPt) ) / gsfElectronRef.pt < 0.1"
+
+
 topDiLeptonOfflineDQM = cms.EDAnalyzer("TopDiLeptonOfflineDQM",
   ## ------------------------------------------------------
   ## SETUP
@@ -9,14 +15,14 @@ topDiLeptonOfflineDQM = cms.EDAnalyzer("TopDiLeptonOfflineDQM",
   ##
   setup = cms.PSet(
     ## sub-directory to write the monitor histograms to
-    ## [mandatory] : should not be changed w/o explicit
+    ## [mandatory] : should not be changed w/o explicit 
     ## communication to TopCom!
     directory = cms.string("Physics/Top/TopDiLeptonDQM/"),
 
     ## [mandatory]
     sources = cms.PSet(
-      muons = cms.InputTag("muons"),
-      elecs = cms.InputTag("gedGsfElectrons"),
+      muons = cms.InputTag("pfIsolatedMuonsEI"),
+      elecs = cms.InputTag("pfIsolatedElectronsEI"),
       jets  = cms.InputTag("ak4PFJetsCHS"),
       mets  = cms.VInputTag("met", "tcMet", "pfMet")
     ),
@@ -28,48 +34,44 @@ topDiLeptonOfflineDQM = cms.EDAnalyzer("TopDiLeptonOfflineDQM",
     ## will be filled w/o extras
     elecExtras = cms.PSet(
       ## when omitted electron plots will be filled w/o cut on electronId
-      #electronId = cms.PSet(
-      #  src = cms.InputTag("simpleEleId70cIso"),
-      #  #src     = cms.InputTag("eidRobustLoose"),
-      #  pattern = cms.int32(1)
-      #),
+      ##electronId = cms.PSet( src = cms.InputTag("mvaTrigV0"), cutValue = cms.double(0.0) ),      
       ## when omitted electron plots will be filled w/o additional pre-
-      ## selection of the electron candidates
-      select = cms.string("pt>10. && abs(eta)<2.4 && abs(gsfTrack.d0)<1. && abs(gsfTrack.dz)<20."),
+      ## selection of the electron candidates                                                 
+      select = cms.string("pt>20. && abs(eta)<2.5"),
       ## when omitted isolated electron multiplicity plot will be equi-
-      ## valent to inclusive electron multiplicity plot
-      isolation = cms.string("(dr03TkSumPt+dr03EcalRecHitSumEt+dr03HcalTowerSumEt)/pt<0.2"),
+      ## valent to inclusive electron multiplicity plot                                                
+      isolation = cms.string(ElelooseIsoCut),
     ),
     ## [optional] : when omitted all monitoring plots for muons
     ## will be filled w/o extras
     muonExtras = cms.PSet(
       ## when omitted muon plots will be filled w/o additional pre-
-      ## selection of the muon candidates
-      select = cms.string("pt>10. && abs(eta)<2.4 && abs(globalTrack.d0)<1. && abs(globalTrack.dz)<20."),
+      ## selection of the muon candidates   
+      select = cms.string(looseMuonCut + " && muonRef.pt > 10. && abs(muonRef.eta)<2.4"),
       ## when omitted isolated muon multiplicity plot will be equi-
-      ## valent to inclusive muon multiplicity plot
-      isolation = cms.string("(isolationR03.sumPt+isolationR03.emEt+isolationR03.hadEt)/pt<0.2"),
+      ## valent to inclusive muon multiplicity plot                                                  
+      isolation = cms.string(looseIsoCut),
     ),
     ## [optional] : when omitted all monitoring plots for jets will
     ## be filled from uncorrected jets
     jetExtras = cms.PSet(
       ## when omitted monitor plots for pt will be filled from uncorrected
-      ## jets
-      jetCorrector = cms.string("ak4PFL2L3"),
+      ## jets    
+      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
       ## when omitted monitor plots will be filled w/o additional cut on
-      ## jetID
+      ## jetID                                                   
 #      jetID  = cms.PSet(
-#        label  = cms.InputTag("ak4JetID"),
+#        label  = cms.InputTag("ak5JetID"),
 #        select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
 #      ),
       ## when omitted no extra selection will be applied on jets before
       ## filling the monitor histograms; if jetCorrector is present the
       ## selection will be applied to corrected jets
-#      select = cms.string("pt>30. & abs(eta)<2.4 & emEnergyFraction>0.01"),
-      select = cms.string("pt>30. & abs(eta)<2.4 "),
+#      select = cms.string("pt>30. & abs(eta)<2.4 & emEnergyFraction>0.01"), 
+      select = cms.string("pt>30. & abs(eta)<2.4 "), 
     ),
     ## [optional] : when omitted no mass window will be applied
-    ## for the same flavor lepton monitoring plots
+    ## for the same flavor lepton monitoring plots 
     massExtras = cms.PSet(
       lowerEdge = cms.double( 76.0),
       upperEdge = cms.double(106.0)
@@ -87,9 +89,9 @@ topDiLeptonOfflineDQM = cms.EDAnalyzer("TopDiLeptonOfflineDQM",
                                     #'HLT_DoubleMu3:HLT_Mu9',
                                     #'HLT_Mu9:HLT_DoubleMu3',
                                     #'HLT_Mu15:HLT_DoubleMu3'])
-    #)
+    #)    
   ),
-
+                                  
   ## ------------------------------------------------------
   ## PRESELECTION
   ##
@@ -109,8 +111,8 @@ topDiLeptonOfflineDQM = cms.EDAnalyzer("TopDiLeptonOfflineDQM",
       select = cms.string('abs(x)<1. && abs(y)<1. && abs(z)<20. && tracksSize>3 && !isFake')
     )
   ),
-
-  ## ------------------------------------------------------
+  
+  ## ------------------------------------------------------    
   ## SELECTION
   ##
   ## monitor histrograms are filled after each selection
@@ -128,18 +130,18 @@ topDiLeptonOfflineDQM = cms.EDAnalyzer("TopDiLeptonOfflineDQM",
     #),
     cms.PSet(
       label  = cms.string("muons:step0"),
-      src    = cms.InputTag("muons"),
-      select = cms.string("pt>20 & abs(eta)<2.4 & isGlobalMuon & innerTrack.numberOfValidHits>10 & globalTrack.normalizedChi2>-1 & globalTrack.normalizedChi2<10"),
+      src    = cms.InputTag("pfIsolatedMuonsEI"),
+      select = cms.string(looseMuonCut +" && "+ looseIsoCut + " && muonRef.pt > 20. && abs(muonRef.eta)<2.4"), # CB what to do with iso? CD Added looseIso
       min    = cms.int32(2),
       max    = cms.int32(2),
     ),
     cms.PSet(
       label  = cms.string("jets/pf:step1"),
       src    = cms.InputTag("ak4PFJetsCHS"),
-      jetCorrector = cms.string("ak4PFL2L3"),
+      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
 #      select = cms.string("pt>30. & abs(eta)<2.4 & emEnergyFraction>0.01"),
 #      jetID  = cms.PSet(
-#        label  = cms.InputTag("ak4JetID"),
+#        label  = cms.InputTag("ak5JetID"),
 #        select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
 #     ),
       min = cms.int32(2),
@@ -159,14 +161,14 @@ DiMuonDQM = cms.EDAnalyzer("TopDiLeptonOfflineDQM",
   ##
   setup = cms.PSet(
     ## sub-directory to write the monitor histograms to
-    ## [mandatory] : should not be changed w/o explicit
+    ## [mandatory] : should not be changed w/o explicit 
     ## communication to TopCom!
     directory = cms.string("Physics/Top/TopDiMuonDQM/"),
 
     ## [mandatory]
     sources = cms.PSet(
-      muons = cms.InputTag("muons"),
-      elecs = cms.InputTag("gedGsfElectrons"),
+      muons = cms.InputTag("pfIsolatedMuonsEI"),
+      elecs = cms.InputTag("pfIsolatedElectronsEI"),
       jets  = cms.InputTag("ak4PFJetsCHS"),
       mets  = cms.VInputTag("met", "tcMet", "pfMet")
     ),
@@ -178,48 +180,44 @@ DiMuonDQM = cms.EDAnalyzer("TopDiLeptonOfflineDQM",
     ## will be filled w/o extras
     elecExtras = cms.PSet(
       ## when omitted electron plots will be filled w/o cut on electronId
-      #electronId = cms.PSet(
-      #  src = cms.InputTag("simpleEleId70cIso"),
-        #src     = cms.InputTag("eidRobustLoose"),
-      #  pattern = cms.int32(1)
-      #),
+      ##electronId = cms.PSet( src = cms.InputTag("mvaTrigV0"), cutValue = cms.double(0.0) ),      
       ## when omitted electron plots will be filled w/o additional pre-
-      ## selection of the electron candidates
-      select = cms.string("pt>500. && abs(eta)<2.4 && abs(gsfTrack.d0)<1. && abs(gsfTrack.dz)<20."),
+      ## selection of the electron candidates                                                 
+      select = cms.string("pt>20. && abs(eta)<2.5"),
       ## when omitted isolated electron multiplicity plot will be equi-
-      ## valent to inclusive electron multiplicity plot
-      isolation = cms.string("(dr03TkSumPt+dr03EcalRecHitSumEt+dr03HcalTowerSumEt)/pt<0.2"),
+      ## valent to inclusive electron multiplicity plot                                                
+      isolation = cms.string(ElelooseIsoCut),
     ),
     ## [optional] : when omitted all monitoring plots for muons
     ## will be filled w/o extras
     muonExtras = cms.PSet(
       ## when omitted muon plots will be filled w/o additional pre-
-      ## selection of the muon candidates
-      select = cms.string("pt>20. && abs(eta)<2.4 && abs(globalTrack.d0)<1. && abs(globalTrack.dz)<20."),
+      ## selection of the muon candidates   
+      select = cms.string(looseMuonCut + " && muonRef.pt > 20. && abs(muonRef.eta)<2.4"),
       ## when omitted isolated muon multiplicity plot will be equi-
-      ## valent to inclusive muon multiplicity plot
-      isolation = cms.string("(isolationR03.sumPt+isolationR03.emEt+isolationR03.hadEt)/pt<0.2"),
+      ## valent to inclusive muon multiplicity plot                                                  
+      isolation = cms.string(looseIsoCut),
     ),
     ## [optional] : when omitted all monitoring plots for jets will
     ## be filled from uncorrected jets
     jetExtras = cms.PSet(
       ## when omitted monitor plots for pt will be filled from uncorrected
-      ## jets
-      jetCorrector = cms.string("ak4PFL2L3"),
+      ## jets    
+      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
       ## when omitted monitor plots will be filled w/o additional cut on
-      ## jetID
+      ## jetID                                                   
 #      jetID  = cms.PSet(
-#        label  = cms.InputTag("ak4JetID"),
+#        label  = cms.InputTag("ak5JetID"),
 #        select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
 #      ),
       ## when omitted no extra selection will be applied on jets before
       ## filling the monitor histograms; if jetCorrector is present the
       ## selection will be applied to corrected jets
-#      select = cms.string("pt>30. & abs(eta)<2.4 & emEnergyFraction>0.01"),
-      select = cms.string("pt>30. & abs(eta)<2.4 "),
+#      select = cms.string("pt>30. & abs(eta)<2.4 & emEnergyFraction>0.01"), 
+      select = cms.string("pt>30. & abs(eta)<2.4 "), 
     ),
     ## [optional] : when omitted no mass window will be applied
-    ## for the same flavor lepton monitoring plots
+    ## for the same flavor lepton monitoring plots 
     massExtras = cms.PSet(
       lowerEdge = cms.double( 76.0),
       upperEdge = cms.double(106.0)
@@ -237,9 +235,9 @@ DiMuonDQM = cms.EDAnalyzer("TopDiLeptonOfflineDQM",
                                     #'HLT_DoubleMu3:HLT_Mu9',
                                     #'HLT_Mu9:HLT_DoubleMu3',
                                     #'HLT_Mu15:HLT_DoubleMu3'])
-    #)
+    #)    
   ),
-
+                                  
   ## ------------------------------------------------------
   ## PRESELECTION
   ##
@@ -259,8 +257,8 @@ DiMuonDQM = cms.EDAnalyzer("TopDiLeptonOfflineDQM",
       select = cms.string('abs(x)<1. && abs(y)<1. && abs(z)<20. && tracksSize>3 && !isFake')
     )
   ),
-
-  ## ------------------------------------------------------
+  
+  ## ------------------------------------------------------    
   ## SELECTION
   ##
   ## monitor histrograms are filled after each selection
@@ -278,19 +276,19 @@ DiMuonDQM = cms.EDAnalyzer("TopDiLeptonOfflineDQM",
     #),
     cms.PSet(
       label  = cms.string("muons:step0"),
-      src    = cms.InputTag("muons"),
-      select = cms.string("pt>20 & abs(eta)<2.4 & isGlobalMuon & innerTrack.numberOfValidHits>10 & globalTrack.normalizedChi2>-1 & globalTrack.normalizedChi2<10"),
+      src    = cms.InputTag("pfIsolatedMuonsEI"),
+      select = cms.string(looseMuonCut + " && muonRef.pt > 20. && abs(muonRef.eta)<2.4"), # CB what to do with iso?
       min    = cms.int32(2),
       max    = cms.int32(2),
     ),
     cms.PSet(
       label  = cms.string("jets/pf:step1"),
       src    = cms.InputTag("ak4PFJetsCHS"),
-      jetCorrector = cms.string("ak4PFL2L3"),
+      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
 #      select = cms.string("pt>30. & abs(eta)<2.4 & emEnergyFraction>0.01"),
-      select = cms.string("pt>30. & abs(eta)<2.4 "),
+      select = cms.string("pt>30. & abs(eta)<2.4 "), 
 #      jetID  = cms.PSet(
-#        label  = cms.InputTag("ak4JetID"),
+#        label  = cms.InputTag("ak5JetID"),
 #        select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
 #      ),
       min = cms.int32(2),
@@ -308,14 +306,14 @@ DiElectronDQM = cms.EDAnalyzer("TopDiLeptonOfflineDQM",
   ##
   setup = cms.PSet(
     ## sub-directory to write the monitor histograms to
-    ## [mandatory] : should not be changed w/o explicit
+    ## [mandatory] : should not be changed w/o explicit 
     ## communication to TopCom!
     directory = cms.string("Physics/Top/TopDiElectronDQM/"),
 
     ## [mandatory]
     sources = cms.PSet(
-      muons = cms.InputTag("muons"),
-      elecs = cms.InputTag("gedGsfElectrons"),
+      muons = cms.InputTag("pfIsolatedMuonsEI"),
+      elecs = cms.InputTag("pfIsolatedElectronsEI"),
       jets  = cms.InputTag("ak4PFJetsCHS"),
       mets  = cms.VInputTag("met", "tcMet", "pfMet")
     ),
@@ -327,48 +325,44 @@ DiElectronDQM = cms.EDAnalyzer("TopDiLeptonOfflineDQM",
     ## will be filled w/o extras
     elecExtras = cms.PSet(
       ## when omitted electron plots will be filled w/o cut on electronId
-      #electronId = cms.PSet(
-      #  src = cms.InputTag("simpleEleId70cIso"),
-      #  #src     = cms.InputTag("eidRobustLoose"),
-      #  pattern = cms.int32(1)
-      #),
+      ##electronId = cms.PSet( src = cms.InputTag("mvaTrigV0"), cutValue = cms.double(0.0) ),      
       ## when omitted electron plots will be filled w/o additional pre-
-      ## selection of the electron candidates
-      select = cms.string("pt>10. && abs(eta)<2.4 && abs(gsfTrack.d0)<1. && abs(gsfTrack.dz)<20."),
+      ## selection of the electron candidates                                                 
+      select = cms.string("pt>20. && abs(eta)<2.5"),
       ## when omitted isolated electron multiplicity plot will be equi-
-      ## valent to inclusive electron multiplicity plot
-      isolation = cms.string("(dr03TkSumPt+dr03EcalRecHitSumEt+dr03HcalTowerSumEt)/pt<0.2"),
+      ## valent to inclusive electron multiplicity plot                                                
+      isolation = cms.string(ElelooseIsoCut),
     ),
     ## [optional] : when omitted all monitoring plots for muons
     ## will be filled w/o extras
     muonExtras = cms.PSet(
       ## when omitted muon plots will be filled w/o additional pre-
-      ## selection of the muon candidates
-      select = cms.string("pt>500. && abs(eta)<2.4 && abs(globalTrack.d0)<1. && abs(globalTrack.dz)<20."),
+      ## selection of the muon candidates   
+      select = cms.string(looseMuonCut + " && muonRef.pt > 20. && abs(muonRef.eta)<2.4"),
       ## when omitted isolated muon multiplicity plot will be equi-
-      ## valent to inclusive muon multiplicity plot
-      isolation = cms.string("(isolationR03.sumPt+isolationR03.emEt+isolationR03.hadEt)/pt<0.2"),
+      ## valent to inclusive muon multiplicity plot                                                  
+      isolation = cms.string(looseIsoCut),
     ),
     ## [optional] : when omitted all monitoring plots for jets will
     ## be filled from uncorrected jets
     jetExtras = cms.PSet(
       ## when omitted monitor plots for pt will be filled from uncorrected
-      ## jets
-      jetCorrector = cms.string("ak4PFL2L3"),
+      ## jets    
+      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
       ## when omitted monitor plots will be filled w/o additional cut on
-      ## jetID
+      ## jetID                                                   
 #      jetID  = cms.PSet(
-#        label  = cms.InputTag("ak4JetID"),
+#        label  = cms.InputTag("ak5JetID"),
 #        select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
 #      ),
       ## when omitted no extra selection will be applied on jets before
       ## filling the monitor histograms; if jetCorrector is present the
       ## selection will be applied to corrected jets
-#      select = cms.string("pt>30. & abs(eta)<2.4 & emEnergyFraction>0.01"),
-      select = cms.string("pt>30. & abs(eta)<2.4 "),
+#      select = cms.string("pt>30. & abs(eta)<2.4 & emEnergyFraction>0.01"), 
+      select = cms.string("pt>30. & abs(eta)<2.4 "), 
     ),
     ## [optional] : when omitted no mass window will be applied
-    ## for the same flavor lepton monitoring plots
+    ## for the same flavor lepton monitoring plots 
     massExtras = cms.PSet(
       lowerEdge = cms.double( 76.0),
       upperEdge = cms.double(106.0)
@@ -386,9 +380,9 @@ DiElectronDQM = cms.EDAnalyzer("TopDiLeptonOfflineDQM",
                                     #'HLT_DoubleMu3:HLT_Mu9',
                                     #'HLT_Mu9:HLT_DoubleMu3',
                                     #'HLT_Mu15:HLT_DoubleMu3'])
-    #)
+    #)    
   ),
-
+                                  
   ## ------------------------------------------------------
   ## PRESELECTION
   ##
@@ -408,8 +402,8 @@ DiElectronDQM = cms.EDAnalyzer("TopDiLeptonOfflineDQM",
       select = cms.string('abs(x)<1. && abs(y)<1. && abs(z)<20. && tracksSize>3 && !isFake')
     )
   ),
-
-  ## ------------------------------------------------------
+  
+  ## ------------------------------------------------------    
   ## SELECTION
   ##
   ## monitor histrograms are filled after each selection
@@ -427,23 +421,21 @@ DiElectronDQM = cms.EDAnalyzer("TopDiLeptonOfflineDQM",
     #),
     cms.PSet(
       label = cms.string("elecs:step0"),
-      src   = cms.InputTag("gedGsfElectrons"),
-#      electronId = cms.PSet(
-#        src = cms.InputTag("simpleEleId70cIso"),
-#        pattern = cms.int32(1)
-#      ),
-      select = cms.string("pt>20 & abs(eta)<2.4 & (dr03TkSumPt+dr03EcalRecHitSumEt+dr03HcalTowerSumEt)/pt<0.17"),
+      src   = cms.InputTag("pfIsolatedElectronsEI"),
+      ##electronId = cms.PSet( src = cms.InputTag("mvaTrigV0"), cutValue = cms.double(0.5) ),      
+      select = cms.string("pt>20 & abs(eta)<2.5 && gsfElectronRef.gsfTrack.trackerExpectedHitsInner.numberOfHits <= 0 && " + ElelooseIsoCut),
+      #abs(gsfElectronRef.gsfTrack.d0)<0.04
       min = cms.int32(2),
       max = cms.int32(2),
     ),
     cms.PSet(
       label  = cms.string("jets/pf:step1"),
       src    = cms.InputTag("ak4PFJetsCHS"),
-      jetCorrector = cms.string("ak4PFL2L3"),
-      select = cms.string("pt>30. & abs(eta)<2.4"),
+      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
+      select = cms.string("pt>30. & abs(eta)<2.4"), 
 #      select = cms.string("pt>30. & abs(eta)<2.4 & emEnergyFraction>0.01"),
 #      jetID  = cms.PSet(
-#        label  = cms.InputTag("ak4JetID"),
+#        label  = cms.InputTag("ak5JetID"),
 #        select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
 #      ),
       min = cms.int32(2),
@@ -461,14 +453,14 @@ ElecMuonDQM = cms.EDAnalyzer("TopDiLeptonOfflineDQM",
   ##
   setup = cms.PSet(
     ## sub-directory to write the monitor histograms to
-    ## [mandatory] : should not be changed w/o explicit
+    ## [mandatory] : should not be changed w/o explicit 
     ## communication to TopCom!
     directory = cms.string("Physics/Top/TopElecMuonDQM/"),
 
     ## [mandatory]
     sources = cms.PSet(
-      muons = cms.InputTag("muons"),
-      elecs = cms.InputTag("gedGsfElectrons"),
+      muons = cms.InputTag("pfIsolatedMuonsEI"),
+      elecs = cms.InputTag("pfIsolatedElectronsEI"),
       jets  = cms.InputTag("ak4PFJetsCHS"),
       mets  = cms.VInputTag("met", "tcMet", "pfMet")
     ),
@@ -480,48 +472,44 @@ ElecMuonDQM = cms.EDAnalyzer("TopDiLeptonOfflineDQM",
     ## will be filled w/o extras
     elecExtras = cms.PSet(
       ## when omitted electron plots will be filled w/o cut on electronId
-#      electronId = cms.PSet(
-#        src = cms.InputTag("simpleEleId70cIso"),
-        #src     = cms.InputTag("eidRobustLoose"),
-#        pattern = cms.int32(1)
-#      ),
+      ##electronId = cms.PSet( src = cms.InputTag("mvaTrigV0"), cutValue = cms.double(0.5) ),      
       ## when omitted electron plots will be filled w/o additional pre-
-      ## selection of the electron candidates
-      select = cms.string("pt>10. && abs(eta)<2.4 && abs(gsfTrack.d0)<1. && abs(gsfTrack.dz)<20."),
+      ## selection of the electron candidates                                                 
+      select = cms.string("pt>10. && abs(eta)<2.4 && abs(gsfElectronRef.gsfTrack.d0)<1. && abs(gsfElectronRef.gsfTrack.dz)<20."),
       ## when omitted isolated electron multiplicity plot will be equi-
-      ## valent to inclusive electron multiplicity plot
-      isolation = cms.string("(dr03TkSumPt+dr03EcalRecHitSumEt+dr03HcalTowerSumEt)/pt<0.2"),
+      ## valent to inclusive electron multiplicity plot                                                
+      isolation = cms.string(ElelooseIsoCut),
     ),
     ## [optional] : when omitted all monitoring plots for muons
     ## will be filled w/o extras
     muonExtras = cms.PSet(
       ## when omitted muon plots will be filled w/o additional pre-
       ## selection of the muon candidates
-      select = cms.string("pt>10. && abs(eta)<2.4 && abs(globalTrack.d0)<1. && abs(globalTrack.dz)<20."),
+      select = cms.string(looseMuonCut + " && muonRef.pt > 10. && abs(muonRef.eta)<2.4"),
       ## when omitted isolated muon multiplicity plot will be equi-
-      ## valent to inclusive muon multiplicity plot
-      isolation = cms.string("(isolationR03.sumPt+isolationR03.emEt+isolationR03.hadEt)/pt<0.2"),
+      ## valent to inclusive muon multiplicity plot                                                  
+      isolation = cms.string(looseIsoCut),
     ),
     ## [optional] : when omitted all monitoring plots for jets will
     ## be filled from uncorrected jets
     jetExtras = cms.PSet(
       ## when omitted monitor plots for pt will be filled from uncorrected
-      ## jets
-      jetCorrector = cms.string("ak4PFL2L3"),
+      ## jets    
+      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
       ## when omitted monitor plots will be filled w/o additional cut on
-      ## jetID
+      ## jetID                                                   
 #      jetID  = cms.PSet(
-#        label  = cms.InputTag("ak4JetID"),
+#        label  = cms.InputTag("ak5JetID"),
 #        select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
 #      ),
       ## when omitted no extra selection will be applied on jets before
       ## filling the monitor histograms; if jetCorrector is present the
       ## selection will be applied to corrected jets
-#      select = cms.string("pt>30. & abs(eta)<2.4 & emEnergyFraction>0.01"),
-      select = cms.string("pt>30. & abs(eta)<2.4 "),
+#      select = cms.string("pt>30. & abs(eta)<2.4 & emEnergyFraction>0.01"), 
+      select = cms.string("pt>30. & abs(eta)<2.4 "), 
     ),
     ## [optional] : when omitted no mass window will be applied
-    ## for the same flavor lepton monitoring plots
+    ## for the same flavor lepton monitoring plots 
     massExtras = cms.PSet(
       lowerEdge = cms.double( 76.0),
       upperEdge = cms.double(106.0)
@@ -539,9 +527,9 @@ ElecMuonDQM = cms.EDAnalyzer("TopDiLeptonOfflineDQM",
                                     #'HLT_DoubleMu3:HLT_Mu9',
                                     #'HLT_Mu9:HLT_DoubleMu3',
                                     #'HLT_Mu15:HLT_DoubleMu3'])
-    #)
+    #)    
   ),
-
+                                  
   ## ------------------------------------------------------
   ## PRESELECTION
   ##
@@ -561,8 +549,8 @@ ElecMuonDQM = cms.EDAnalyzer("TopDiLeptonOfflineDQM",
       select = cms.string('abs(x)<1. && abs(y)<1. && abs(z)<20. && tracksSize>3 && !isFake')
     )
   ),
-
-  ## ------------------------------------------------------
+  
+  ## ------------------------------------------------------    
   ## SELECTION
   ##
   ## monitor histrograms are filled after each selection
@@ -580,30 +568,27 @@ ElecMuonDQM = cms.EDAnalyzer("TopDiLeptonOfflineDQM",
     #),
     cms.PSet(
       label  = cms.string("muons:step0"),
-      src    = cms.InputTag("muons"),
-      select = cms.string("pt>20 & abs(eta)<2.4 & isGlobalMuon & innerTrack.numberOfValidHits>10 & globalTrack.normalizedChi2>-1 & globalTrack.normalizedChi2<10"),
+      src    = cms.InputTag("pfIsolatedMuonsEI"),
+      select = cms.string(looseMuonCut + " && " + looseIsoCut + " && muonRef.pt > 20. && abs(muonRef.eta)<2.4"), # CB what to do with iso? CD Added looseIsoCut
       min    = cms.int32(1),
       max    = cms.int32(1),
     ),
     cms.PSet(
       label = cms.string("elecs:step1"),
-      src   = cms.InputTag("gedGsfElectrons"),
-      #electronId = cms.PSet(
-      #  src = cms.InputTag("simpleEleId70cIso"),
-      #  pattern = cms.int32(1)
-      #),
-      select = cms.string("pt>20 & abs(eta)<2.4 & (dr03TkSumPt+dr03EcalRecHitSumEt+dr03HcalTowerSumEt)/pt<0.17"),
+      src   = cms.InputTag("pfIsolatedElectronsEI"),
+      ##electronId = cms.PSet( src = cms.InputTag("mvaTrigV0"), cutValue = cms.double(0.5) ),      
+      select = cms.string("pt>20 & abs(eta)<2.5 && "+ElelooseIsoCut),
       min = cms.int32(1),
       max = cms.int32(1),
     ),
     cms.PSet(
       label  = cms.string("jets/pf:step2"),
       src    = cms.InputTag("ak4PFJetsCHS"),
-      jetCorrector = cms.string("ak4PFL2L3"),
+      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
 #      select = cms.string("pt>30. & abs(eta)<2.4 & emEnergyFraction>0.01"),
-      select = cms.string("pt>30. & abs(eta)<2.4 "),
+      select = cms.string("pt>30. & abs(eta)<2.4 "), 
 #      jetID  = cms.PSet(
-#        label  = cms.InputTag("ak4JetID"),
+#        label  = cms.InputTag("ak5JetID"),
 #        select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
 #      ),
       min = cms.int32(2),

--- a/DQM/Physics/python/topSingleLeptonDQM_PU_cfi.py
+++ b/DQM/Physics/python/topSingleLeptonDQM_PU_cfi.py
@@ -9,14 +9,14 @@ topSingleLeptonDQM = cms.EDAnalyzer("TopSingleLeptonDQM",
   ##
   setup = cms.PSet(
     ## sub-directory to write the monitor histograms to
-    ## [mandatory] : should not be changed w/o explicit
+    ## [mandatory] : should not be changed w/o explicit 
     ## communication to TopCom!
     directory = cms.string("Physics/Top/TopSingleLeptonDQM/"),
     ## [mandatory]
     sources = cms.PSet(
       muons = cms.InputTag("muons"),
       elecs = cms.InputTag("gedGsfElectrons"),
-      jets  = cms.InputTag("ak4PFJetsCHS"),
+      jets  = cms.InputTag("ak5PFJetsCHS"),
       mets  = cms.VInputTag("met", "tcMet", "pfMet"),
       pvs   = cms.InputTag("offlinePrimaryVertices")
     ),
@@ -28,7 +28,7 @@ topSingleLeptonDQM = cms.EDAnalyzer("TopSingleLeptonDQM",
     ## will be filled w/o extras
     pvExtras = cms.PSet(
       ## when omitted electron plots will be filled w/o additional pre-
-      ## selection of the primary vertex candidates
+      ## selection of the primary vertex candidates                                                                                            
       select = cms.string("abs(x)<1. & abs(y)<1. & abs(z)<20. & tracksSize>3 & !isFake")
     ),
     ## [optional] : when omitted all monitoring plots for electrons
@@ -37,32 +37,32 @@ topSingleLeptonDQM = cms.EDAnalyzer("TopSingleLeptonDQM",
       ## when omitted electron plots will be filled w/o cut on electronId
       electronId = cms.PSet( src = cms.InputTag("eidRobustLoose"), pattern = cms.int32(1) ),
       ## when omitted electron plots will be filled w/o additional pre-
-      ## selection of the electron candidates
+      ## selection of the electron candidates                                                                                            
       select = cms.string("pt>15 & abs(eta)<2.5 & abs(gsfTrack.d0)<1 & abs(gsfTrack.dz)<20"),
       ## when omitted isolated electron multiplicity plot will be equi-
-      ## valent to inclusive electron multiplicity plot
+      ## valent to inclusive electron multiplicity plot 
       isolation = cms.string("(dr03TkSumPt+dr04EcalRecHitSumEt+dr04HcalTowerSumEt)/pt<0.1"),
     ),
     ## [optional] : when omitted all monitoring plots for muons
     ## will be filled w/o extras
     muonExtras = cms.PSet(
       ## when omitted muon plots will be filled w/o additional pre-
-      ## selection of the muon candidates
+      ## selection of the muon candidates                                                                                            
       select = cms.string("pt>10 & abs(eta)<2.1 & isGlobalMuon & abs(globalTrack.d0)<1 & abs(globalTrack.dz)<20"),
       ## when omitted isolated muon multiplicity plot will be equi-
-      ## valent to inclusive muon multiplicity plot
+      ## valent to inclusive muon multiplicity plot                                                    
       isolation = cms.string("(isolationR03.sumPt+isolationR03.emEt+isolationR03.hadEt)/pt<0.1"),
     ),
     ## [optional] : when omitted all monitoring plots for jets will
     ## be filled from uncorrected jets
     jetExtras = cms.PSet(
       ## when omitted monitor plots for pt will be filled from uncorrected
-      ## jets
-      jetCorrector = cms.string("ak4PFL2L3"),
+      ## jets                                            
+      jetCorrector = cms.string("ak5PFL2L3"),
       ## when omitted monitor plots will be filled w/o additional cut on
-      ## jetID
+      ## jetID                                                   
 #      jetID  = cms.PSet(
-#        label  = cms.InputTag("ak4JetID"),
+#        label  = cms.InputTag("ak5JetID"),
 #        select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
 #      ),
       ## when omitted no extra selection will be applied on jets before
@@ -84,8 +84,8 @@ topSingleLeptonDQM = cms.EDAnalyzer("TopSingleLeptonDQM",
     #                       'HLT_Mu5:HLT_QuadJet15U',
     #                       'HLT_Mu7:HLT_QuadJet15U',
     #                       'HLT_Mu9:HLT_QuadJet15U'])
-    #)
-  ),
+    #)                                            
+  ),                                  
   ## ------------------------------------------------------
   ## PRESELECTION
   ##
@@ -103,9 +103,9 @@ topSingleLeptonDQM = cms.EDAnalyzer("TopSingleLeptonDQM",
     vertex = cms.PSet(
       src    = cms.InputTag("offlinePrimaryVertices"),
       select = cms.string('abs(x)<1. & abs(y)<1. & abs(z)<20. & tracksSize>3 & !isFake')
-    )
-  ),
-  ## ------------------------------------------------------
+    )                                        
+  ),  
+  ## ------------------------------------------------------    
   ## SELECTION
   ##
   ## monitor histrograms are filled after each selection
@@ -113,15 +113,15 @@ topSingleLeptonDQM = cms.EDAnalyzer("TopSingleLeptonDQM",
   ## by this vector
   ## [mandatory] : may be empty or contain an arbitrary
   ## number of PSets
-  ##
+  ##    
   selection = cms.VPSet(
     cms.PSet(
       label  = cms.string("jets/pf:step0"),
-      src    = cms.InputTag("ak4PFJetsCHS"),
+      src    = cms.InputTag("ak5PFJetsCHS"),
       #select = cms.string("pt>20 & abs(eta)<2.1 & 0.05<emEnergyFraction"),
       select = cms.string("pt>20 & abs(eta)<2.1 "),
 #      jetID  = cms.PSet(
-#        label  = cms.InputTag("ak4JetID"),
+#        label  = cms.InputTag("ak5JetID"),
 #        select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
 #      ),
       min = cms.int32(2),
@@ -145,7 +145,7 @@ topSingleMuonLooseDQM_PU = cms.EDAnalyzer("TopSingleLeptonDQM",
     sources = cms.PSet(
       muons = cms.InputTag("muons"),
       elecs = cms.InputTag("gedGsfElectrons"),
-      jets  = cms.InputTag("ak4PFJetsCHS"),
+      jets  = cms.InputTag("ak5PFJetsCHS"),
       mets  = cms.VInputTag("met", "tcMet", "pfMet"),
       pvs   = cms.InputTag("offlinePrimaryVertices")
     ),
@@ -155,36 +155,36 @@ topSingleMuonLooseDQM_PU = cms.EDAnalyzer("TopSingleLeptonDQM",
     ),
     pvExtras = cms.PSet(
       ## when omitted electron plots will be filled w/o additional pre-
-      ## selection of the primary vertex candidates
+      ## selection of the primary vertex candidates                                                                                            
       select = cms.string("abs(x)<1. & abs(y)<1. & abs(z)<20. & tracksSize>3 & !isFake")
     ),
     ## [optional] : when omitted all monitoring plots for muons
-    ## will be filled w/o extras
+    ## will be filled w/o extras                                           
     muonExtras = cms.PSet(
       ## when omitted muon plots will be filled w/o additional pre-
-      ## selection of the muon candidates
+      ## selection of the muon candidates                                                                                               
       select = cms.string("pt > 10 & abs(eta)<2.1 & isGlobalMuon & innerTrack.numberOfValidHits>10 & globalTrack.normalizedChi2>-1 & globalTrack.normalizedChi2<10"),
       ## when omitted isolated muon multiplicity plot will be equi-
-      ## valent to inclusive muon multiplicity plot
-      isolation = cms.string("(isolationR03.sumPt+isolationR03.emEt+isolationR03.hadEt)/pt<0.1")
+      ## valent to inclusive muon multiplicity plot                                                    
+      isolation = cms.string("(isolationR03.sumPt+isolationR03.emEt+isolationR03.hadEt)/pt<0.1")                                               
     ),
     ## [optional] : when omitted all monitoring plots for jets
     ## will be filled w/o extras
     jetExtras = cms.PSet(
       ## when omitted monitor plots for pt will be filled from uncorrected
-      ## jets
-      jetCorrector = cms.string("ak4PFL2L3"),
+      ## jets                                               
+      jetCorrector = cms.string("ak5PFL2L3"),
       ## when omitted monitor plots will be filled w/o additional cut on
-      ## jetID
+      ## jetID                                                                                                                     
 #      jetID  = cms.PSet(
-#        label  = cms.InputTag("ak4JetID"),
+#        label  = cms.InputTag("ak5JetID"),
 #        select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
-#      ),
+#      ),                                                    
       ## when omitted no extra selection will be applied on jets before
       ## filling the monitor histograms; if jetCorrector is present the
-      ## selection will be applied to corrected jets
+      ## selection will be applied to corrected jets                                                
       select = cms.string("pt>30 & abs(eta)<2.5"),
-      ## when omitted monitor histograms for b-tagging will not be filled
+      ## when omitted monitor histograms for b-tagging will not be filled 
       jetBTaggers  = cms.PSet(
         trackCountingEff = cms.PSet(
           label = cms.InputTag("trackCountingHighEffBJetTags" ),
@@ -201,7 +201,7 @@ topSingleMuonLooseDQM_PU = cms.EDAnalyzer("TopSingleLeptonDQM",
 		cvsVertex = cms.PSet(
           label = cms.InputTag("combinedSecondaryVertexBJetTags"),
 	          workingPoint = cms.double(0.898)
-	          # CSV Tight from https://twiki.cern.ch/twiki/bin/viewauth/CMS/BTagPerformanceOP#B_tagging_Operating_Points_for_5
+	          # CSV Tight from https://twiki.cern.ch/twiki/bin/viewauth/CMS/BTagPerformanceOP#B_tagging_Operating_Points_for_5 
         )
       ),
     ),
@@ -305,7 +305,7 @@ topSingleMuonMediumDQM_PU = cms.EDAnalyzer("TopSingleLeptonDQM",
     sources = cms.PSet(
       muons = cms.InputTag("muons"),
       elecs = cms.InputTag("gedGsfElectrons"),
-      jets  = cms.InputTag("ak4PFJetsCHS"),
+      jets  = cms.InputTag("ak5PFJetsCHS"),
       mets  = cms.VInputTag("met", "tcMet", "pfMet"),
       pvs   = cms.InputTag("offlinePrimaryVertices")
 
@@ -318,17 +318,17 @@ topSingleMuonMediumDQM_PU = cms.EDAnalyzer("TopSingleLeptonDQM",
     ## will be filled w/o extras
     pvExtras = cms.PSet(
       ## when omitted electron plots will be filled w/o additional pre-
-      ## selection of the primary vertex candidates
+      ## selection of the primary vertex candidates                                                                                            
       select = cms.string("abs(x)<1. & abs(y)<1. & abs(z)<20. & tracksSize>3 & !isFake")
     ),
     ## [optional] : when omitted all monitoring plots for muons
-    ## will be filled w/o extras
+    ## will be filled w/o extras                                           
     muonExtras = cms.PSet(
       ## when omitted muon plots will be filled w/o additional pre-
-      ## selection of the muon candidates
-      select    = cms.string("pt>20 & abs(eta)<2.1 & isGlobalMuon & innerTrack.numberOfValidHits>10 & globalTrack.normalizedChi2>-1 & globalTrack.normalizedChi2<10 & (isolationR03.sumPt+isolationR03.emEt+isolationR03.hadEt)/pt<0.1"),
+      ## selection of the muon candidates                                                
+      select    = cms.string("pt>20 & abs(eta)<2.1 & isGlobalMuon & innerTrack.numberOfValidHits>10 & globalTrack.normalizedChi2>-1 & globalTrack.normalizedChi2<10 & (isolationR03.sumPt+isolationR03.emEt+isolationR03.hadEt)/pt<0.1"),  
       ## when omitted isolated muon multiplicity plot will be equi-
-      ## valent to inclusive muon multiplicity plot
+      ## valent to inclusive muon multiplicity plot                                                    
       isolation = cms.string("(isolationR03.sumPt+isolationR03.emEt+isolationR03.hadEt)/pt<0.1")
     ),
     ## [optional] : when omitted all monitoring plots for jets
@@ -336,19 +336,19 @@ topSingleMuonMediumDQM_PU = cms.EDAnalyzer("TopSingleLeptonDQM",
     jetExtras = cms.PSet(
       ## when omitted monitor plots for pt will be filled from uncorrected
       ## jets
-      jetCorrector = cms.string("ak4PFL2L3"),
+      jetCorrector = cms.string("ak5PFL2L3"),
       ## when omitted monitor plots will be filled w/o additional cut on
-      ## jetID
+      ## jetID                                                                                                   
 #      jetID  = cms.PSet(
-#        label  = cms.InputTag("ak4JetID"),
+#        label  = cms.InputTag("ak5JetID"),
 #        select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
 #      ),
       ## when omitted no extra selection will be applied on jets before
       ## filling the monitor histograms; if jetCorrector is present the
-      ## selection will be applied to corrected jets
+      ## selection will be applied to corrected jets                                                
       #select = cms.string("pt>15 & abs(eta)<2.5& emEnergyFraction>0.01"),
       select = cms.string("pt>30 & abs(eta)<2.5"),
-      ## when omitted monitor histograms for b-tagging will not be filled
+      ## when omitted monitor histograms for b-tagging will not be filled                                                                                                   
       jetBTaggers  = cms.PSet(
         trackCountingEff = cms.PSet(
           label = cms.InputTag("trackCountingHighEffBJetTags" ),
@@ -365,9 +365,9 @@ topSingleMuonMediumDQM_PU = cms.EDAnalyzer("TopSingleLeptonDQM",
 		cvsVertex = cms.PSet(
           label = cms.InputTag("combinedSecondaryVertexBJetTags"),
 	          workingPoint = cms.double(0.898)
-	          # CSV Tight from https://twiki.cern.ch/twiki/bin/viewauth/CMS/BTagPerformanceOP#B_tagging_Operating_Points_for_5
+	          # CSV Tight from https://twiki.cern.ch/twiki/bin/viewauth/CMS/BTagPerformanceOP#B_tagging_Operating_Points_for_5 
         )
-      ),
+      ),                                                
     ),
     ## [optional] : when omitted no mass window will be applied
     ## for the W mass before filling the event monitoring plots
@@ -383,7 +383,7 @@ topSingleMuonMediumDQM_PU = cms.EDAnalyzer("TopSingleLeptonDQM",
     #                      'HLT_Mu5:HLT_QuadJet15U',
     #                      'HLT_Mu7:HLT_QuadJet15U',
     #                      'HLT_Mu9:HLT_QuadJet15U',
-    #                      'HLT_Mu11:HLT_QuadJet15U'])
+    #                      'HLT_Mu11:HLT_QuadJet15U'])      
     #)
   ),
   ## ------------------------------------------------------
@@ -417,7 +417,7 @@ topSingleMuonMediumDQM_PU = cms.EDAnalyzer("TopSingleLeptonDQM",
     cms.PSet(
       label  = cms.string("muons:step0"),
       src    = cms.InputTag("muons"),
-      select = cms.string("pt>20 & abs(eta)<2.1 & isGlobalMuon & innerTrack.numberOfValidHits>10 & globalTrack.normalizedChi2>-1 & globalTrack.normalizedChi2<10 & (isolationR03.sumPt+isolationR03.emEt+isolationR03.hadEt)/pt<0.1"),
+      select = cms.string("pt>20 & abs(eta)<2.1 & isGlobalMuon & innerTrack.numberOfValidHits>10 & globalTrack.normalizedChi2>-1 & globalTrack.normalizedChi2<10 & (isolationR03.sumPt+isolationR03.emEt+isolationR03.hadEt)/pt<0.1"),       
       min    = cms.int32(1),
       max    = cms.int32(1),
     ),
@@ -470,7 +470,7 @@ topSingleElectronLooseDQM_PU = cms.EDAnalyzer("TopSingleLeptonDQM",
     sources = cms.PSet(
       muons = cms.InputTag("muons"),
       elecs = cms.InputTag("gedGsfElectrons"),
-      jets  = cms.InputTag("ak4PFJetsCHS"),
+      jets  = cms.InputTag("ak5PFJetsCHS"),
       mets  = cms.VInputTag("met", "tcMet", "pfMet"),
       pvs   = cms.InputTag("offlinePrimaryVertices")
 
@@ -483,7 +483,7 @@ topSingleElectronLooseDQM_PU = cms.EDAnalyzer("TopSingleLeptonDQM",
     ## will be filled w/o extras
     pvExtras = cms.PSet(
       ## when omitted electron plots will be filled w/o additional pre-
-      ## selection of the primary vertex candidates
+      ## selection of the primary vertex candidates                                                                                            
       select = cms.string("abs(x)<1. & abs(y)<1. & abs(z)<20. & tracksSize>3 & !isFake")
     ),
     ## [optional] : when omitted all monitoring plots for electrons
@@ -495,26 +495,26 @@ topSingleElectronLooseDQM_PU = cms.EDAnalyzer("TopSingleLeptonDQM",
       ## selection of the electron candidates
       select     = cms.string("pt>15 & abs(eta)<2.5"),
       ## when omitted isolated electron multiplicity plot will be equi-
-      ## valent to inclusive electron multiplicity plot
-      isolation  = cms.string("(dr03TkSumPt+dr03EcalRecHitSumEt+dr03HcalTowerSumEt)/pt<0.1"),
+      ## valent to inclusive electron multiplicity plot                                                    
+      isolation  = cms.string("(dr03TkSumPt+dr03EcalRecHitSumEt+dr03HcalTowerSumEt)/pt<0.1"),                                                   
     ),
     ## [optional] : when omitted all monitoring plots for jets
     ## will be filled w/o extras
     jetExtras = cms.PSet(
       ## when omitted monitor plots for pt will be filled from uncorrected
       ## jets
-      jetCorrector = cms.string("ak4PFL2L3"),
+      jetCorrector = cms.string("ak5PFL2L3"),
       ## when omitted monitor plots will be filled w/o additional cut on
-      ## jetID
+      ## jetID                                                   
 #      jetID  = cms.PSet(
-#        label  = cms.InputTag("ak4JetID"),
+#        label  = cms.InputTag("ak5JetID"),
 #        select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
 #      ),
       ## when omitted no extra selection will be applied on jets before
       ## filling the monitor histograms; if jetCorrector is present the
       ## selection will be applied to corrected jets
-      select = cms.string("pt>30 & abs(eta)<2.5"),
-      ## when omitted monitor histograms for b-tagging will not be filled
+      select = cms.string("pt>30 & abs(eta)<2.5"), 
+      ## when omitted monitor histograms for b-tagging will not be filled                                                   
       jetBTaggers  = cms.PSet(
         trackCountingEff = cms.PSet(
           label = cms.InputTag("trackCountingHighEffBJetTags" ),
@@ -531,7 +531,7 @@ topSingleElectronLooseDQM_PU = cms.EDAnalyzer("TopSingleLeptonDQM",
 		cvsVertex = cms.PSet(
           label = cms.InputTag("combinedSecondaryVertexBJetTags"),
 	          workingPoint = cms.double(0.898)
-	          # CSV Tight from https://twiki.cern.ch/twiki/bin/viewauth/CMS/BTagPerformanceOP#B_tagging_Operating_Points_for_5
+	          # CSV Tight from https://twiki.cern.ch/twiki/bin/viewauth/CMS/BTagPerformanceOP#B_tagging_Operating_Points_for_5 
         )
       ),
     ),
@@ -632,7 +632,7 @@ topSingleElectronMediumDQM_PU = cms.EDAnalyzer("TopSingleLeptonDQM",
     sources = cms.PSet(
       muons = cms.InputTag("muons"),
       elecs = cms.InputTag("gedGsfElectrons"),
-      jets  = cms.InputTag("ak4PFJetsCHS"),
+      jets  = cms.InputTag("ak5PFJetsCHS"),
       mets  = cms.VInputTag("met", "tcMet", "pfMet"),
       pvs   = cms.InputTag("offlinePrimaryVertices")
 
@@ -645,7 +645,7 @@ topSingleElectronMediumDQM_PU = cms.EDAnalyzer("TopSingleLeptonDQM",
     ## will be filled w/o extras
     pvExtras = cms.PSet(
       ## when omitted electron plots will be filled w/o additional pre-
-      ## selection of the primary vertex candidates
+      ## selection of the primary vertex candidates                                                                                            
       select = cms.string("abs(x)<1. & abs(y)<1. & abs(z)<20. & tracksSize>3 & !isFake")
     ),
     ## [optional] : when omitted all monitoring plots for electrons
@@ -657,7 +657,7 @@ topSingleElectronMediumDQM_PU = cms.EDAnalyzer("TopSingleLeptonDQM",
       ## selection of the electron candidates
       select     = cms.string("pt>25 & abs(eta)<2.5 & (dr03TkSumPt+dr03EcalRecHitSumEt+dr03HcalTowerSumEt)/pt<0.1"),
       ## when omitted isolated electron multiplicity plot will be equi-
-      ## valent to inclusive electron multiplicity plot
+      ## valent to inclusive electron multiplicity plot 
       isolation  = cms.string("(dr03TkSumPt+dr03EcalRecHitSumEt+dr03HcalTowerSumEt)/pt<0.1"),
     ),
     ## [optional] : when omitted all monitoring plots for jets
@@ -665,16 +665,16 @@ topSingleElectronMediumDQM_PU = cms.EDAnalyzer("TopSingleLeptonDQM",
     jetExtras = cms.PSet(
       ## when omitted monitor plots for pt will be filled from uncorrected
       ## jets
-      jetCorrector = cms.string("ak4PFL2L3"),
+      jetCorrector = cms.string("ak5PFL2L3"),
       ## when omitted monitor plots will be filled w/o additional cut on
       ## jetID
 #      jetID  = cms.PSet(
-#        label  = cms.InputTag("ak4JetID"),
+#        label  = cms.InputTag("ak5JetID"),
 #        select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
 #      ),
       ## when omitted no extra selection will be applied on jets before
       ## filling the monitor histograms; if jetCorrector is present the
-      ## selection will be applied to corrected jets
+      ## selection will be applied to corrected jets 
       select = cms.string("pt>30 & abs(eta)<2.5"),
       ## when omitted monitor histograms for b-tagging will not be filled
       jetBTaggers  = cms.PSet(
@@ -693,7 +693,7 @@ topSingleElectronMediumDQM_PU = cms.EDAnalyzer("TopSingleLeptonDQM",
 		cvsVertex = cms.PSet(
           label = cms.InputTag("combinedSecondaryVertexBJetTags"),
 	          workingPoint = cms.double(0.898)
-	          # CSV Tight from https://twiki.cern.ch/twiki/bin/viewauth/CMS/BTagPerformanceOP#B_tagging_Operating_Points_for_5
+	          # CSV Tight from https://twiki.cern.ch/twiki/bin/viewauth/CMS/BTagPerformanceOP#B_tagging_Operating_Points_for_5 
         )
       ),
     ),

--- a/DQM/Physics/python/topSingleLeptonDQM_cfi.py
+++ b/DQM/Physics/python/topSingleLeptonDQM_cfi.py
@@ -1,5 +1,16 @@
 import FWCore.ParameterSet.Config as cms
 
+looseMuonCut = "muonRef.isNonnull && (muonRef.isGlobalMuon || muonRef.isTrackerMuon) && muonRef.isPFMuon"
+looseIsoCut  = "(muonRef.pfIsolationR04.sumChargedHadronPt + max(0., muonRef.pfIsolationR04.sumNeutralHadronEt + muonRef.pfIsolationR04.sumPhotonEt - 0.5 * muonRef.pfIsolationR04.sumPUPt) ) / muonRef.pt < 0.2"
+
+tightMuonCut = "muonRef.isNonnull && muonRef.isGlobalMuon && muonRef.isPFMuon && muonRef.globalTrack.normalizedChi2 < 10. && muonRef.globalTrack.hitPattern.numberOfValidMuonHits > 0 && " + \
+               "muonRef.numberOfMatchedStations > 1 && muonRef.innerTrack.hitPattern.numberOfValidPixelHits > 0 && muonRef.innerTrack.hitPattern.trackerLayersWithMeasurement > 8"
+               # CB PV cut!
+tightIsoCut  = "(muonRef.pfIsolationR04.sumChargedHadronPt + max(0., muonRef.pfIsolationR04.sumNeutralHadronEt + muonRef.pfIsolationR04.sumPhotonEt - 0.5 * muonRef.pfIsolationR04.sumPUPt) ) / muonRef.pt < 0.12"
+
+EletightIsoCut  = "(gsfElectronRef.pfIsolationVariables.sumChargedHadronPt + max(0., gsfElectronRef.pfIsolationVariables.sumNeutralHadronEt + gsfElectronRef.pfIsolationVariables.sumPhotonEt - 0.5 * gsfElectronRef.pfIsolationVariables.sumPUPt) ) / gsfElectronRef.pt < 0.1"
+ElelooseIsoCut  = "(gsfElectronRef.pfIsolationVariables.sumChargedHadronPt + max(0., gsfElectronRef.pfIsolationVariables.sumNeutralHadronEt + gsfElectronRef.pfIsolationVariables.sumPhotonEt - 0.5 * gsfElectronRef.pfIsolationVariables.sumPUPt) ) / gsfElectronRef.pt < 0.15"
+
 topSingleLeptonDQM = cms.EDAnalyzer("TopSingleLeptonDQM",
   ## ------------------------------------------------------
   ## SETUP
@@ -9,13 +20,13 @@ topSingleLeptonDQM = cms.EDAnalyzer("TopSingleLeptonDQM",
   ##
   setup = cms.PSet(
     ## sub-directory to write the monitor histograms to
-    ## [mandatory] : should not be changed w/o explicit
+    ## [mandatory] : should not be changed w/o explicit 
     ## communication to TopCom!
     directory = cms.string("Physics/Top/TopSingleLeptonDQM/"),
     ## [mandatory]
     sources = cms.PSet(
-      muons = cms.InputTag("muons"),
-      elecs = cms.InputTag("gedGsfElectrons"),
+      muons = cms.InputTag("pfIsolatedMuonsEI"),
+      elecs = cms.InputTag("pfIsolatedElectronsEI"),
       jets  = cms.InputTag("ak4PFJetsCHS"),
       mets  = cms.VInputTag("met", "tcMet", "pfMet"),
       pvs   = cms.InputTag("offlinePrimaryVertices")
@@ -28,41 +39,42 @@ topSingleLeptonDQM = cms.EDAnalyzer("TopSingleLeptonDQM",
     ## will be filled w/o extras
     pvExtras = cms.PSet(
       ## when omitted electron plots will be filled w/o additional pre-
-      ## selection of the primary vertex candidates
+      ## selection of the primary vertex candidates                                                                                            
       select = cms.string("abs(x)<1. & abs(y)<1. & abs(z)<20. & tracksSize>3 & !isFake")
     ),
     ## [optional] : when omitted all monitoring plots for electrons
     ## will be filled w/o extras
     elecExtras = cms.PSet(
       ## when omitted electron plots will be filled w/o cut on electronId
-      electronId = cms.PSet( src = cms.InputTag("eidRobustLoose"), pattern = cms.int32(1) ),
+      ##electronId = cms.PSet( src = cms.InputTag("mvaTrigV0"), cutValue = cms.double(0.5) ),
       ## when omitted electron plots will be filled w/o additional pre-
-      ## selection of the electron candidates
+      ## selection of the electron candidates                                                                                            
       select = cms.string("pt>15 & abs(eta)<2.5 & abs(gsfTrack.d0)<1 & abs(gsfTrack.dz)<20"),
       ## when omitted isolated electron multiplicity plot will be equi-
-      ## valent to inclusive electron multiplicity plot
-      isolation = cms.string("(dr03TkSumPt+dr04EcalRecHitSumEt+dr04HcalTowerSumEt)/pt<0.1"),
+      ## valent to inclusive electron multiplicity plot 
+      ##isolation = cms.string("(dr03TkSumPt+dr04EcalRecHitSumEt+dr04HcalTowerSumEt)/pt<0.1"),
+      isolation = cms.string(ElelooseIsoCut),
     ),
     ## [optional] : when omitted all monitoring plots for muons
     ## will be filled w/o extras
     muonExtras = cms.PSet(
       ## when omitted muon plots will be filled w/o additional pre-
-      ## selection of the muon candidates
-      select = cms.string("pt>10 & abs(eta)<2.1 & isGlobalMuon & abs(globalTrack.d0)<1 & abs(globalTrack.dz)<20"),
+      ## selection of the muon candidates                                                                                            
+      select = cms.string(looseMuonCut + " && pt>10 & abs(eta)<2.4"),
       ## when omitted isolated muon multiplicity plot will be equi-
-      ## valent to inclusive muon multiplicity plot
-      isolation = cms.string("(isolationR03.sumPt+isolationR03.emEt+isolationR03.hadEt)/pt<0.1"),
+      ## valent to inclusive muon multiplicity plot                                                    
+      isolation = cms.string(looseIsoCut),
     ),
     ## [optional] : when omitted all monitoring plots for jets will
     ## be filled from uncorrected jets
     jetExtras = cms.PSet(
       ## when omitted monitor plots for pt will be filled from uncorrected
-      ## jets
-      jetCorrector = cms.string("ak4PFL2L3"),
+      ## jets                                            
+      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
       ## when omitted monitor plots will be filled w/o additional cut on
-      ## jetID
+      ## jetID                                                   
       #jetID  = cms.PSet(
-        #label  = cms.InputTag("ak4JetID"),
+        #label  = cms.InputTag("ak5JetID"),
         #select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
 #      ),
       ## when omitted no extra selection will be applied on jets before
@@ -85,8 +97,8 @@ topSingleLeptonDQM = cms.EDAnalyzer("TopSingleLeptonDQM",
                            'HLT_Mu5:HLT_QuadJet15U',
                            'HLT_Mu7:HLT_QuadJet15U',
                            'HLT_Mu9:HLT_QuadJet15U'])
-    )
-  ),
+    )                                            
+  ),                                  
   ## ------------------------------------------------------
   ## PRESELECTION
   ##
@@ -104,9 +116,9 @@ topSingleLeptonDQM = cms.EDAnalyzer("TopSingleLeptonDQM",
     vertex = cms.PSet(
       src    = cms.InputTag("offlinePrimaryVertices"),
       select = cms.string('abs(x)<1. & abs(y)<1. & abs(z)<20. & tracksSize>3 & !isFake')
-    )
-  ),
-  ## ------------------------------------------------------
+    )                                        
+  ),  
+  ## ------------------------------------------------------    
   ## SELECTION
   ##
   ## monitor histrograms are filled after each selection
@@ -114,7 +126,7 @@ topSingleLeptonDQM = cms.EDAnalyzer("TopSingleLeptonDQM",
   ## by this vector
   ## [mandatory] : may be empty or contain an arbitrary
   ## number of PSets
-  ##
+  ##    
   selection = cms.VPSet(
     cms.PSet(
       label  = cms.string("jets/pf:step0"),
@@ -122,7 +134,7 @@ topSingleLeptonDQM = cms.EDAnalyzer("TopSingleLeptonDQM",
       #select = cms.string("pt>20 & abs(eta)<2.1 & 0.05<emEnergyFraction"),
       select = cms.string("pt>30 & abs(eta)<2.5 "),
       #jetID  = cms.PSet(
-        #label  = cms.InputTag("ak4JetID"),
+        #label  = cms.InputTag("ak5JetID"),
         #select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
  #     ),
       min = cms.int32(2),
@@ -144,8 +156,8 @@ topSingleMuonLooseDQM = cms.EDAnalyzer("TopSingleLeptonDQM",
     directory = cms.string("Physics/Top/TopSingleMuonLooseDQM/"),
     ## [mandatory]
     sources = cms.PSet(
-      muons = cms.InputTag("muons"),
-      elecs = cms.InputTag("gedGsfElectrons"),
+      muons = cms.InputTag("pfIsolatedMuonsEI"),
+      elecs = cms.InputTag("pfIsolatedElectronsEI"),
       jets  = cms.InputTag("ak4PFJetsCHS"),
       mets  = cms.VInputTag("met", "tcMet", "pfMet"),
       pvs   = cms.InputTag("offlinePrimaryVertices")
@@ -156,37 +168,37 @@ topSingleMuonLooseDQM = cms.EDAnalyzer("TopSingleLeptonDQM",
     ),
     pvExtras = cms.PSet(
       ## when omitted electron plots will be filled w/o additional pre-
-      ## selection of the primary vertex candidates
+      ## selection of the primary vertex candidates                                                                                            
       select = cms.string("abs(x)<1. & abs(y)<1. & abs(z)<20. & tracksSize>3 & !isFake")
     ),
     ## [optional] : when omitted all monitoring plots for muons
-    ## will be filled w/o extras
+    ## will be filled w/o extras                                           
     muonExtras = cms.PSet(
       ## when omitted muon plots will be filled w/o additional pre-
-      ## selection of the muon candidates
-      select = cms.string("pt > 10 & abs(eta)<2.1 & isGlobalMuon & innerTrack.numberOfValidHits>10 & globalTrack.normalizedChi2>-1 & globalTrack.normalizedChi2<10"),
+      ## selection of the muon candidates                                                                                               
+      select = cms.string(looseMuonCut + " && pt > 10 & abs(eta)<2.4"),
       ## when omitted isolated muon multiplicity plot will be equi-
-      ## valent to inclusive muon multiplicity plot
-      isolation = cms.string("(isolationR03.sumPt+isolationR03.emEt+isolationR03.hadEt)/pt<0.1")
+      ## valent to inclusive muon multiplicity plot                                                    
+      isolation = cms.string(looseIsoCut)                                               
     ),
     ## [optional] : when omitted all monitoring plots for jets
     ## will be filled w/o extras
     jetExtras = cms.PSet(
       ## when omitted monitor plots for pt will be filled from uncorrected
-      ## jets
-      jetCorrector = cms.string("ak4PFL2L3"),
+      ## jets                                               
+      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
       ## when omitted monitor plots will be filled w/o additional cut on
-      ## jetID
+      ## jetID                                                                                                                     
       #jetID  = cms.PSet(
-        #label  = cms.InputTag("ak4JetID"),
+        #label  = cms.InputTag("ak5JetID"),
         #select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
-  #    ),
+  #    ),                                                    
       ## when omitted no extra selection will be applied on jets before
       ## filling the monitor histograms; if jetCorrector is present the
-      ## selection will be applied to corrected jets
+      ## selection will be applied to corrected jets                                                
       #select = cms.string("pt>30 & abs(eta)<2.5 & emEnergyFraction>0.01"),
       select = cms.string("pt>30 & abs(eta)<2.5"),
-      ## when omitted monitor histograms for b-tagging will not be filled
+      ## when omitted monitor histograms for b-tagging will not be filled 
       jetBTaggers  = cms.PSet(
         trackCountingEff = cms.PSet(
           label = cms.InputTag("trackCountingHighEffBJetTags" ),
@@ -202,7 +214,7 @@ topSingleMuonLooseDQM = cms.EDAnalyzer("TopSingleLeptonDQM",
         ),
         cvsVertex = cms.PSet(
           label = cms.InputTag("combinedSecondaryVertexBJetTags"),
-          workingPoint = cms.double(0.898)
+          workingPoint = cms.double(0.898) 
           # CSV Tight from https://twiki.cern.ch/twiki/bin/viewauth/CMS/BTagPerformanceOP#B_tagging_Operating_Points_for_5
         )
       ),
@@ -254,58 +266,58 @@ topSingleMuonLooseDQM = cms.EDAnalyzer("TopSingleLeptonDQM",
   selection = cms.VPSet(
     cms.PSet(
       label  = cms.string("muons:step0"),
-      src    = cms.InputTag("muons"),
-      select = cms.string("pt>10 & abs(eta)<2.1 & isGlobalMuon & innerTrack.numberOfValidHits>10 & globalTrack.normalizedChi2>-1 & globalTrack.normalizedChi2<10"),
+      src    = cms.InputTag("pfIsolatedMuonsEI"),
+      select = cms.string(looseMuonCut + looseIsoCut + " && pt>10 & abs(eta)<2.4"), # CB what about iso? CD Added looseIso
       min    = cms.int32(1),
     ),
     cms.PSet(
       label  = cms.string("jets/pf:step1"),
       src    = cms.InputTag("ak4PFJetsCHS"),
-      jetCorrector = cms.string("ak4PFL2L3"),
+      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
       #select = cms.string("pt>30 & abs(eta)<2.5 & emEnergyFraction>0.01"),
       select = cms.string("pt>30 & abs(eta)<2.5 "),
       #jetID  = cms.PSet(
-        #label  = cms.InputTag("ak4JetID"),
+        #label  = cms.InputTag("ak5JetID"),
         #select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
    #   ),
-      min = cms.int32(1),
-    ),
+      min = cms.int32(1),                                               
+    ), 
     cms.PSet(
       label  = cms.string("jets/pf:step2"),
       src    = cms.InputTag("ak4PFJetsCHS"),
-      jetCorrector = cms.string("ak4PFL2L3"),
+      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
       #select = cms.string("pt>30 & abs(eta)<2.5 & emEnergyFraction>0.01"),
       select = cms.string("pt>30 & abs(eta)<2.5 "),
       #jetID  = cms.PSet(
-        #label  = cms.InputTag("ak4JetID"),
+        #label  = cms.InputTag("ak5JetID"),
         #select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
     #  ),
-      min = cms.int32(2),
-    ),
+      min = cms.int32(2),                                               
+    ), 
     cms.PSet(
       label  = cms.string("jets/pf:step3"),
       src    = cms.InputTag("ak4PFJetsCHS"),
-      jetCorrector = cms.string("ak4PFL2L3"),
+      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
       #select = cms.string("pt>30 & abs(eta)<2.5 & emEnergyFraction>0.01"),
       select = cms.string("pt>30 & abs(eta)<2.5 "),
       #jetID  = cms.PSet(
-        #label  = cms.InputTag("ak4JetID"),
+        #label  = cms.InputTag("ak5JetID"),
         #select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
      # ),
-      min = cms.int32(3),
-    ),
+      min = cms.int32(3),                                               
+    ), 
     cms.PSet(
       label  = cms.string("jets/pf:step4"),
       src    = cms.InputTag("ak4PFJetsCHS"),
-      jetCorrector = cms.string("ak4PFL2L3"),
+      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
       #select = cms.string("pt>30 & abs(eta)<2.5 & emEnergyFraction>0.01"),
       select = cms.string("pt>30 & abs(eta)<2.5 "),
       #jetID  = cms.PSet(
-        #label  = cms.InputTag("ak4JetID"),
+        #label  = cms.InputTag("ak5JetID"),
         #select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
 #      ),
-      min = cms.int32(4),
-    ),
+      min = cms.int32(4),                                               
+    ), 
   )
 )
 topSingleMuonMediumDQM = cms.EDAnalyzer("TopSingleLeptonDQM",
@@ -322,8 +334,9 @@ topSingleMuonMediumDQM = cms.EDAnalyzer("TopSingleLeptonDQM",
     directory = cms.string("Physics/Top/TopSingleMuonMediumDQM/"),
     ## [mandatory]
     sources = cms.PSet(
-      muons = cms.InputTag("muons"),
-      elecs = cms.InputTag("gedGsfElectrons"),
+      muons = cms.InputTag("pfIsolatedMuonsEI"),
+      elecs = cms.InputTag("pfIsolatedElectronsEI"),
+      #jets  = cms.InputTag("ak4PFJetsCHS"),
       jets  = cms.InputTag("ak4PFJetsCHS"),
       mets  = cms.VInputTag("met", "tcMet", "pfMet"),
       pvs   = cms.InputTag("offlinePrimaryVertices")
@@ -337,37 +350,38 @@ topSingleMuonMediumDQM = cms.EDAnalyzer("TopSingleLeptonDQM",
     ## will be filled w/o extras
     pvExtras = cms.PSet(
       ## when omitted electron plots will be filled w/o additional pre-
-      ## selection of the primary vertex candidates
+      ## selection of the primary vertex candidates                                                                                            
       select = cms.string("abs(x)<1. & abs(y)<1. & abs(z)<20. & tracksSize>3 & !isFake")
     ),
     ## [optional] : when omitted all monitoring plots for muons
-    ## will be filled w/o extras
+    ## will be filled w/o extras                                           
     muonExtras = cms.PSet(
       ## when omitted muon plots will be filled w/o additional pre-
-      ## selection of the muon candidates
-      select    = cms.string("pt>20 & abs(eta)<2.1 & isGlobalMuon & innerTrack.numberOfValidHits>10 & globalTrack.normalizedChi2>-1 & globalTrack.normalizedChi2<10 & (isolationR03.sumPt+isolationR03.emEt+isolationR03.hadEt)/pt<0.1"),
+      ## selection of the muon candidates                                                
+      select    = cms.string(looseMuonCut + " && pt>20 & abs(eta)<2.1"),  
       ## when omitted isolated muon multiplicity plot will be equi-
-      ## valent to inclusive muon multiplicity plot
-      isolation = cms.string("(isolationR03.sumPt+isolationR03.emEt+isolationR03.hadEt)/pt<0.1")
+      ## valent to inclusive muon multiplicity plot                                                    
+      isolation = cms.string(looseIsoCut)
     ),
     ## [optional] : when omitted all monitoring plots for jets
     ## will be filled w/o extras
     jetExtras = cms.PSet(
       ## when omitted monitor plots for pt will be filled from uncorrected
       ## jets
-      jetCorrector = cms.string("ak4PFL2L3"),
+#      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
+      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
       ## when omitted monitor plots will be filled w/o additional cut on
-      ## jetID
+      ## jetID                                                                                                   
       #jetID  = cms.PSet(
-        #label  = cms.InputTag("ak4JetID"),
+        #label  = cms.InputTag("ak5JetID"),
         #select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
  #     ),
       ## when omitted no extra selection will be applied on jets before
       ## filling the monitor histograms; if jetCorrector is present the
-      ## selection will be applied to corrected jets
+      ## selection will be applied to corrected jets                                                
       #select = cms.string("pt>30 & abs(eta)<2.5& emEnergyFraction>0.01"),
       select = cms.string("pt>30 & abs(eta)<2.5 "),
-      ## when omitted monitor histograms for b-tagging will not be filled
+      ## when omitted monitor histograms for b-tagging will not be filled                                                                                                   
       jetBTaggers  = cms.PSet(
         trackCountingEff = cms.PSet(
           label = cms.InputTag("trackCountingHighEffBJetTags" ),
@@ -383,10 +397,10 @@ topSingleMuonMediumDQM = cms.EDAnalyzer("TopSingleLeptonDQM",
         ),
         cvsVertex = cms.PSet(
           label = cms.InputTag("combinedSecondaryVertexBJetTags"),
-          workingPoint = cms.double(0.898)
+          workingPoint = cms.double(0.898) 
           # CSV Tight from https://twiki.cern.ch/twiki/bin/viewauth/CMS/BTagPerformanceOP#B_tagging_Operating_Points_for_5
         )
-      ),
+      ),                                                
     ),
     ## [optional] : when omitted no mass window will be applied
     ## for the W mass before filling the event monitoring plots
@@ -396,14 +410,14 @@ topSingleMuonMediumDQM = cms.EDAnalyzer("TopSingleLeptonDQM",
     ),
     ## [optional] : when omitted the monitoring plots for triggering
     ## will be empty
-    triggerExtras = cms.PSet(
-      src   = cms.InputTag("TriggerResults","","HLT"),
-     paths = cms.vstring(['HLT_Mu3:HLT_QuadJet15U',
-                          'HLT_Mu5:HLT_QuadJet15U',
-                          'HLT_Mu7:HLT_QuadJet15U',
-                          'HLT_Mu9:HLT_QuadJet15U',
-                          'HLT_Mu11:HLT_QuadJet15U'])
-    )
+#    triggerExtras = cms.PSet(
+#      src   = cms.InputTag("TriggerResults","","HLT"),
+#     paths = cms.vstring(['HLT_Mu3:HLT_QuadJet15U',
+#                          'HLT_Mu5:HLT_QuadJet15U',
+#                          'HLT_Mu7:HLT_QuadJet15U',
+#                          'HLT_Mu9:HLT_QuadJet15U',
+#                          'HLT_Mu11:HLT_QuadJet15U'])      
+#    )
   ),
   ## ------------------------------------------------------
   ## PRESELECTION
@@ -435,58 +449,66 @@ topSingleMuonMediumDQM = cms.EDAnalyzer("TopSingleLeptonDQM",
   selection = cms.VPSet(
     cms.PSet(
       label  = cms.string("muons:step0"),
-      src    = cms.InputTag("muons"),
-      select = cms.string("pt>20 & abs(eta)<2.1 & isGlobalMuon & innerTrack.numberOfValidHits>10 & globalTrack.normalizedChi2>-1 & globalTrack.normalizedChi2<10 & (isolationR03.sumPt+isolationR03.emEt+isolationR03.hadEt)/pt<0.1"),
+      src    = cms.InputTag("pfIsolatedMuonsEI"),
+      select = cms.string(tightMuonCut +"&&"+ tightIsoCut + " && pt>20 & abs(eta)<2.1"), # CB what about iso? CD Added tightIso      
       min    = cms.int32(1),
       max    = cms.int32(1),
     ),
     cms.PSet(
       label  = cms.string("jets/pf:step1"),
+      #src    = cms.InputTag("ak4PFJetsCHS"),
       src    = cms.InputTag("ak4PFJetsCHS"),
-      jetCorrector = cms.string("ak4PFL2L3"),
+#      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
+      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
       #select = cms.string("pt>30 & abs(eta)<2.5 & emEnergyFraction>0.01"),
       select = cms.string("pt>30 & abs(eta)<2.5 "),
       #jetID  = cms.PSet(
-        #label  = cms.InputTag("ak4JetID"),
+        #label  = cms.InputTag("ak5JetID"),
         #select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
   #    ),
       min = cms.int32(1),
-    ),
+    ), 
     cms.PSet(
       label  = cms.string("jets/pf:step2"),
+      #src    = cms.InputTag("ak4PFJetsCHS"),
       src    = cms.InputTag("ak4PFJetsCHS"),
-      jetCorrector = cms.string("ak4PFL2L3"),
+      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
+      #jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
       #select = cms.string("pt>30 & abs(eta)<2.5 & emEnergyFraction>0.01"),
       select = cms.string("pt>30 & abs(eta)<2.5 "),
       #jetID  = cms.PSet(
-        #label  = cms.InputTag("ak4JetID"),
+        #label  = cms.InputTag("ak5JetID"),
         #select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
    #   ),
       min = cms.int32(2),
-    ),
+    ), 
     cms.PSet(
       label  = cms.string("jets/pf:step3"),
+      #src    = cms.InputTag("ak4PFJetsCHS"),
       src    = cms.InputTag("ak4PFJetsCHS"),
-      jetCorrector = cms.string("ak4PFL2L3"),
+      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
+      #jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
       #select = cms.string("pt>30 & abs(eta)<2.5 & emEnergyFraction>0.01"),
       select = cms.string("pt>30 & abs(eta)<2.5 "),
       #jetID  = cms.PSet(
-        #label  = cms.InputTag("ak4JetID"),
+        #label  = cms.InputTag("ak5JetID"),
         #select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
  #     ),
-      min = cms.int32(3),
-    ),
+      min = cms.int32(3),                                                
+    ), 
     cms.PSet(
       label  = cms.string("jets/pf:step4"),
+      #src    = cms.InputTag("ak4PFJetsCHS"),
       src    = cms.InputTag("ak4PFJetsCHS"),
-      jetCorrector = cms.string("ak4PFL2L3"),
+      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
+      #jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
       #select = cms.string("pt>30 & abs(eta)<2.5 & emEnergyFraction>0.01"),
       select = cms.string("pt>30 & abs(eta)<2.5 "),
       #jetID  = cms.PSet(
-        #label  = cms.InputTag("ak4JetID"),
+        #label  = cms.InputTag("ak5JetID"),
         #select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
 #      ),
-      min = cms.int32(4),
+      min = cms.int32(4),                                                
     ),
   )
 )
@@ -505,8 +527,8 @@ topSingleElectronLooseDQM = cms.EDAnalyzer("TopSingleLeptonDQM",
     directory = cms.string("Physics/Top/TopSingleElectronLooseDQM/"),
     ## [mandatory]
     sources = cms.PSet(
-      muons = cms.InputTag("muons"),
-      elecs = cms.InputTag("gedGsfElectrons"),
+      muons = cms.InputTag("pfIsolatedMuonsEI"),
+      elecs = cms.InputTag("pfIsolatedElectronsEI"),
       jets  = cms.InputTag("ak4PFJetsCHS"),
       mets  = cms.VInputTag("met", "tcMet", "pfMet"),
       pvs   = cms.InputTag("offlinePrimaryVertices")
@@ -520,39 +542,39 @@ topSingleElectronLooseDQM = cms.EDAnalyzer("TopSingleLeptonDQM",
     ## will be filled w/o extras
     pvExtras = cms.PSet(
       ## when omitted electron plots will be filled w/o additional pre-
-      ## selection of the primary vertex candidates
+      ## selection of the primary vertex candidates                                                                                            
       select = cms.string("abs(x)<1. & abs(y)<1. & abs(z)<20. & tracksSize>3 & !isFake")
     ),
     ## [optional] : when omitted all monitoring plots for electrons
     ## will be filled w/o extras
     elecExtras = cms.PSet(
       ## when omitted electron plots will be filled w/o cut on electronId
-      #electronId = cms.PSet( src = cms.InputTag("simpleEleId70cIso"), pattern = cms.int32(1) ),
+      #electronId = cms.PSet( src = cms.InputTag("mvaTrigV0"), cutValue = cms.double(0.0) ),
       ## when omitted electron plots will be filled w/o additional pre-
       ## selection of the electron candidates
-      select     = cms.string("pt>15 & abs(eta)<2.5"),
+      select     = cms.string("pt>20 & abs(eta)<2.5"),
       ## when omitted isolated electron multiplicity plot will be equi-
-      ## valent to inclusive electron multiplicity plot
-      isolation  = cms.string("(dr03TkSumPt+dr03EcalRecHitSumEt+dr03HcalTowerSumEt)/pt<0.1"),
+      ## valent to inclusive electron multiplicity plot                                                    
+      isolation  = cms.string(ElelooseIsoCut),                                                   
     ),
     ## [optional] : when omitted all monitoring plots for jets
     ## will be filled w/o extras
     jetExtras = cms.PSet(
       ## when omitted monitor plots for pt will be filled from uncorrected
       ## jets
-      jetCorrector = cms.string("ak4PFL2L3"),
+      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
       ## when omitted monitor plots will be filled w/o additional cut on
-      ## jetID
+      ## jetID                                                   
       #jetID  = cms.PSet(
-        #label  = cms.InputTag("ak4JetID"),
+        #label  = cms.InputTag("ak5JetID"),
         #select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
     #  ),
       ## when omitted no extra selection will be applied on jets before
       ## filling the monitor histograms; if jetCorrector is present the
       ## selection will be applied to corrected jets
-      #select = cms.string("pt>30 & abs(eta)<2.5 & emEnergyFraction>0.01"),
+      #select = cms.string("pt>30 & abs(eta)<2.5 & emEnergyFraction>0.01"), 
       select = cms.string("pt>30 & abs(eta)<2.5 "),
-      ## when omitted monitor histograms for b-tagging will not be filled
+      ## when omitted monitor histograms for b-tagging will not be filled                                                   
       jetBTaggers  = cms.PSet(
         trackCountingEff = cms.PSet(
           label = cms.InputTag("trackCountingHighEffBJetTags" ),
@@ -568,7 +590,7 @@ topSingleElectronLooseDQM = cms.EDAnalyzer("TopSingleLeptonDQM",
         ),
         cvsVertex = cms.PSet(
           label = cms.InputTag("combinedSecondaryVertexBJetTags"),
-          workingPoint = cms.double(0.898)
+          workingPoint = cms.double(0.898) 
           # CSV Tight from https://twiki.cern.ch/twiki/bin/viewauth/CMS/BTagPerformanceOP#B_tagging_Operating_Points_for_5
         )
       ),
@@ -616,55 +638,55 @@ topSingleElectronLooseDQM = cms.EDAnalyzer("TopSingleLeptonDQM",
   selection = cms.VPSet(
     cms.PSet(
       label  = cms.string("elecs:step0"),
-      src    = cms.InputTag("gedGsfElectrons"),
-      #electronId = cms.PSet( src = cms.InputTag("simpleEleId70cIso"), pattern = cms.int32(1) ),
-      select = cms.string("pt>15 & abs(eta)<2.5"),
+      src    = cms.InputTag("pfIsolatedElectronsEI"),
+      #electronId = cms.PSet( src = cms.InputTag("mvaTrigV0"), cutValue = cms.double(0.0) ),
+      select = cms.string("pt>20 & abs(eta)<2.5 && "+ElelooseIsoCut),
       min    = cms.int32(1),
     ),
     cms.PSet(
       label  = cms.string("jets/pf:step1"),
       src    = cms.InputTag("ak4PFJetsCHS"),
-      jetCorrector = cms.string("ak4PFL2L3"),
+      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
       #select = cms.string("pt>30 & abs(eta)<2.5 & emEnergyFraction>0.01"),
       select = cms.string("pt>30 & abs(eta)<2.5 "),
       #jetID  = cms.PSet(
-        #label  = cms.InputTag("ak4JetID"),
+        #label  = cms.InputTag("ak5JetID"),
         #select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
      # ),
-      min = cms.int32(1),
-    ),
+      min = cms.int32(1),                                                   
+    ), 
     cms.PSet(
       label  = cms.string("jets/pf:step2"),
       src    = cms.InputTag("ak4PFJetsCHS"),
-      jetCorrector = cms.string("ak4PFL2L3"),
+      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
       #select = cms.string("pt>30 & abs(eta)<2.5 & emEnergyFraction>0.01"),
       select = cms.string("pt>30 & abs(eta)<2.5 "),
       #jetID  = cms.PSet(
-        #label  = cms.InputTag("ak4JetID"),
+        #label  = cms.InputTag("ak5JetID"),
         #select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
 #      ),
       min = cms.int32(2),
-    ),
+    ), 
     cms.PSet(
       label  = cms.string("jets/pf:step3"),
       src    = cms.InputTag("ak4PFJetsCHS"),
-      jetCorrector = cms.string("ak4PFL2L3"),
+      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
       #select = cms.string("pt>30 & abs(eta)<2.5 & emEnergyFraction>0.01"),
       select = cms.string("pt>30 & abs(eta)<2.5 "),
       #jetID  = cms.PSet(
-        #label  = cms.InputTag("ak4JetID"),
+        #label  = cms.InputTag("ak5JetID"),
         #select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
  #     ),
       min = cms.int32(3),
-    ),
+    ), 
     cms.PSet(
       label  = cms.string("jets/pf:step4"),
       src    = cms.InputTag("ak4PFJetsCHS"),
-      jetCorrector = cms.string("ak4PFL2L3"),
+      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
       #select = cms.string("pt>30 & abs(eta)<2.5 & emEnergyFraction>0.01"),
       select = cms.string("pt>30 & abs(eta)<2.5 "),
       #jetID  = cms.PSet(
-        #label  = cms.InputTag("ak4JetID"),
+        #label  = cms.InputTag("ak5JetID"),
         #select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
   #    ),
       min = cms.int32(4),
@@ -686,8 +708,8 @@ topSingleElectronMediumDQM = cms.EDAnalyzer("TopSingleLeptonDQM",
     directory = cms.string("Physics/Top/TopSingleElectronMediumDQM/"),
     ## [mandatory]
     sources = cms.PSet(
-      muons = cms.InputTag("muons"),
-      elecs = cms.InputTag("gedGsfElectrons"),
+      muons = cms.InputTag("pfIsolatedMuonsEI"),
+      elecs = cms.InputTag("pfIsolatedElectronsEI"),
       jets  = cms.InputTag("ak4PFJetsCHS"),
       mets  = cms.VInputTag("met", "tcMet", "pfMet"),
       pvs   = cms.InputTag("offlinePrimaryVertices")
@@ -701,36 +723,36 @@ topSingleElectronMediumDQM = cms.EDAnalyzer("TopSingleLeptonDQM",
     ## will be filled w/o extras
     pvExtras = cms.PSet(
       ## when omitted electron plots will be filled w/o additional pre-
-      ## selection of the primary vertex candidates
+      ## selection of the primary vertex candidates                                                                                            
       select = cms.string("abs(x)<1. & abs(y)<1. & abs(z)<20. & tracksSize>3 & !isFake")
     ),
     ## [optional] : when omitted all monitoring plots for electrons
     ## will be filled w/o extras
     elecExtras = cms.PSet(
       ## when omitted electron plots will be filled w/o cut on electronId
-      #electronId = cms.PSet( src = cms.InputTag("simpleEleId70cIso"), pattern = cms.int32(1) ),
+      #electronId = cms.PSet( src = cms.InputTag("mvaTrigV0"), cutValue = cms.double(0.0) ),
       ## when omitted electron plots will be filled w/o additional pre-
       ## selection of the electron candidates
-      select     = cms.string("pt>25 & abs(eta)<2.5 & (dr03TkSumPt+dr03EcalRecHitSumEt+dr03HcalTowerSumEt)/pt<0.1"),
+      select     = cms.string("pt>20 & abs(eta)<2.5"),
       ## when omitted isolated electron multiplicity plot will be equi-
-      ## valent to inclusive electron multiplicity plot
-      isolation  = cms.string("(dr03TkSumPt+dr03EcalRecHitSumEt+dr03HcalTowerSumEt)/pt<0.1"),
+      ## valent to inclusive electron multiplicity plot 
+      isolation  = cms.string(ElelooseIsoCut),
     ),
     ## [optional] : when omitted all monitoring plots for jets
     ## will be filled w/o extras
     jetExtras = cms.PSet(
       ## when omitted monitor plots for pt will be filled from uncorrected
       ## jets
-      jetCorrector = cms.string("ak4PFL2L3"),
+      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
       ## when omitted monitor plots will be filled w/o additional cut on
       ## jetID
       #jetID  = cms.PSet(
-        #label  = cms.InputTag("ak4JetID"),
+        #label  = cms.InputTag("ak5JetID"),
         #select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
    #   ),
       ## when omitted no extra selection will be applied on jets before
       ## filling the monitor histograms; if jetCorrector is present the
-      ## selection will be applied to corrected jets
+      ## selection will be applied to corrected jets 
       #select = cms.string("pt>30 & abs(eta)<2.5 & emEnergyFraction>0.01"),
       select = cms.string("pt>30 & abs(eta)<2.5 "),
       ## when omitted monitor histograms for b-tagging will not be filled
@@ -749,7 +771,7 @@ topSingleElectronMediumDQM = cms.EDAnalyzer("TopSingleLeptonDQM",
         ),
         cvsVertex = cms.PSet(
           label = cms.InputTag("combinedSecondaryVertexBJetTags"),
-          workingPoint = cms.double(0.898)
+          workingPoint = cms.double(0.898) 
           # CSV Tight from https://twiki.cern.ch/twiki/bin/viewauth/CMS/BTagPerformanceOP#B_tagging_Operating_Points_for_5
         )
       ),
@@ -762,10 +784,10 @@ topSingleElectronMediumDQM = cms.EDAnalyzer("TopSingleLeptonDQM",
     ),
     ## [optional] : when omitted the monitoring plots for triggering
     ## will be empty
-    triggerExtras = cms.PSet(
-      src   = cms.InputTag("TriggerResults","","HLT"),
-      paths = cms.vstring([ 'HLT_Ele15_LW_L1R:HLT_QuadJetU15'])
-    )
+    #triggerExtras = cms.PSet(
+    #  src   = cms.InputTag("TriggerResults","","HLT"),
+    #  paths = cms.vstring([ 'HLT_Ele15_LW_L1R:HLT_QuadJetU15'])
+    #)
   ),
   ## ------------------------------------------------------
   ## PRESELECTION
@@ -797,56 +819,57 @@ topSingleElectronMediumDQM = cms.EDAnalyzer("TopSingleLeptonDQM",
   selection = cms.VPSet(
     cms.PSet(
       label = cms.string("elecs:step0"),
-      src   = cms.InputTag("gedGsfElectrons"),
-      #electronId = cms.PSet( src = cms.InputTag("simpleEleId70cIso"), pattern = cms.int32(1) ),
-      select = cms.string("pt>25 & abs(eta)<2.5 & (dr03TkSumPt+dr03EcalRecHitSumEt+dr03HcalTowerSumEt)/pt<0.1"),
+      src   = cms.InputTag("pfIsolatedElectronsEI"),
+      #electronId = cms.PSet( src = cms.InputTag("mvaTrigV0"), cutValue = cms.double(0.5) ),
+#      select = cms.string("pt>25 & abs(eta)<2.5 & (dr03TkSumPt+dr03EcalRecHitSumEt+dr03HcalTowerSumEt)/pt<0.1"),
+      select = cms.string("pt>30 & abs(eta)<2.5 & abs(gsfElectronRef.gsfTrack.d0)<0.02 & gsfElectronRef.gsfTrack.trackerExpectedHitsInner.numberOfHits <= 0 & (abs(gsfElectronRef.superCluster.eta) <= 1.4442 || abs(gsfElectronRef.superCluster.eta) >= 1.5660) & " + EletightIsoCut),
       min = cms.int32(1),
       max = cms.int32(1),
     ),
     cms.PSet(
       label = cms.string("jets/pf:step1"),
       src   = cms.InputTag("ak4PFJetsCHS"),
-      jetCorrector = cms.string("ak4PFL2L3"),
+      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
 #      select = cms.string("pt>30 & abs(eta)<2.5 & emEnergyFraction>0.01"),
       select = cms.string("pt>30 & abs(eta)<2.5 "),
       #jetID  = cms.PSet(
-        #label  = cms.InputTag("ak4JetID"),
+        #label  = cms.InputTag("ak5JetID"),
         #select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
 #      ),
       min = cms.int32(1),
-    ),
+    ), 
     cms.PSet(
       label  = cms.string("jets/pf:step2"),
       src    = cms.InputTag("ak4PFJetsCHS"),
-      jetCorrector = cms.string("ak4PFL2L3"),
+      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
       #select = cms.string("pt>30 & abs(eta)<2.5 & emEnergyFraction>0.01"),
       select = cms.string("pt>30 & abs(eta)<2.5 "),
       #jetID  = cms.PSet(
-        #label  = cms.InputTag("ak4JetID"),
+        #label  = cms.InputTag("ak5JetID"),
         #select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
  #     ),
       min = cms.int32(2),
-    ),
+    ), 
     cms.PSet(
       label  = cms.string("jets/pf:step3"),
       src    = cms.InputTag("ak4PFJetsCHS"),
-      jetCorrector = cms.string("ak4PFL2L3"),
+      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
 #      select = cms.string("pt>30 & abs(eta)<2.5 & emEnergyFraction>0.01"),
       select = cms.string("pt>30 & abs(eta)<2.5 "),
       #jetID  = cms.PSet(
-        #label  = cms.InputTag("ak4JetID"),
+        #label  = cms.InputTag("ak5JetID"),
         #select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
   #    ),
       min = cms.int32(3),
-    ),
+    ), 
     cms.PSet(
       label  = cms.string("jets/pf:step4"),
       src    = cms.InputTag("ak4PFJetsCHS"),
-      jetCorrector = cms.string("ak4PFL2L3"),
+      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
       #select = cms.string("pt>30 & abs(eta)<2.5 & emEnergyFraction>0.01"),
       select = cms.string("pt>30 & abs(eta)<2.5 "),
       #jetID  = cms.PSet(
-        #label  = cms.InputTag("ak4JetID"),
+        #label  = cms.InputTag("ak5JetID"),
         #select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
    #   ),
       min = cms.int32(4),

--- a/DQM/Physics/src/SingleTopTChannelLeptonDQM.h
+++ b/DQM/Physics/src/SingleTopTChannelLeptonDQM.h
@@ -13,6 +13,7 @@
 #include "DataFormats/MuonReco/interface/Muon.h"
 #include "DataFormats/Common/interface/ValueMap.h"
 #include "DataFormats/METReco/interface/CaloMET.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "JetMETCorrections/Objects/interface/JetCorrector.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
@@ -116,7 +117,9 @@ namespace SingleTopTChannelLepton {
     ///  6: passes conversion rejection and Isolation
     ///  7: passes the whole selection
     /// As described on https://twiki.cern.ch/twiki/bin/view/CMS/SimpleCutBasedEleID
-    int eidPattern_;
+    //int eidPattern_;
+    //the cut for the MVA Id                                                                                                                               
+    double eidCutValue_;
     /// extra isolation criterion on electron
     //    StringCutObjectSelector<reco::GsfElectron>* elecIso_;
     std::string elecIso_;

--- a/DQM/Physics/src/TopDiLeptonDQM.cc
+++ b/DQM/Physics/src/TopDiLeptonDQM.cc
@@ -19,22 +19,22 @@ TopDiLeptonDQM::TopDiLeptonDQM( const edm::ParameterSet& ps ) {
   moduleName_      = ps.getUntrackedParameter<string>("moduleName");
   fileOutput_      = ps.getParameter<bool>("fileOutput");
   outputFile_      = ps.getUntrackedParameter<string>("outputFile");
-  triggerResults_  = consumes<TriggerResults>(ps.getParameter<edm::InputTag>("TriggerResults"));
+  triggerResults_  = ps.getParameter<edm::InputTag>("TriggerResults");
   hltPaths_        = ps.getParameter<vector<string> >("hltPaths");
   hltPaths_sig_    = ps.getParameter<vector<string> >("hltPaths_sig");
   hltPaths_trig_   = ps.getParameter<vector<string> >("hltPaths_trig");
 
-  vertex_          = consumes<reco::VertexCollection>(ps.getParameter<edm::InputTag>("vertexCollection"));
+  vertex_          = ps.getParameter<edm::InputTag>("vertexCollection");
   vertex_X_cut_    = ps.getParameter<double>("vertex_X_cut");
   vertex_Y_cut_    = ps.getParameter<double>("vertex_Y_cut");
   vertex_Z_cut_    = ps.getParameter<double>("vertex_Z_cut");
 
-  muons_           = consumes<reco::MuonCollection>(ps.getParameter<edm::InputTag>("muonCollection"));
+  muons_           = ps.getParameter<edm::InputTag>("muonCollection");
   muon_pT_cut_     = ps.getParameter<double>("muon_pT_cut");
   muon_eta_cut_    = ps.getParameter<double>("muon_eta_cut");
   muon_iso_cut_    = ps.getParameter<double>("muon_iso_cut");
 
-  elecs_           = consumes<reco::GsfElectronCollection>(ps.getParameter<edm::InputTag>("elecCollection"));
+  elecs_           = ps.getParameter<edm::InputTag>("elecCollection");
   elec_pT_cut_     = ps.getParameter<double>("elec_pT_cut");
   elec_eta_cut_    = ps.getParameter<double>("elec_eta_cut");
   elec_iso_cut_    = ps.getParameter<double>("elec_iso_cut");
@@ -228,7 +228,7 @@ void TopDiLeptonDQM::analyze(const edm::Event& evt, const edm::EventSetup& conte
   // ------------------------
 
   edm::Handle<reco::VertexCollection> vertexs;
-  evt.getByToken(vertex_, vertexs);
+  evt.getByLabel(vertex_, vertexs);
 
   if( vertexs.failedToGet() ) {
 
@@ -263,7 +263,7 @@ void TopDiLeptonDQM::analyze(const edm::Event& evt, const edm::EventSetup& conte
   // -------------------------
 
   edm::Handle<TriggerResults> trigResults;
-  evt.getByToken(triggerResults_, trigResults);
+  evt.getByLabel(triggerResults_, trigResults);
 
   if( trigResults.failedToGet() ) {
 
@@ -321,7 +321,7 @@ void TopDiLeptonDQM::analyze(const edm::Event& evt, const edm::EventSetup& conte
   // ------------------------
 
   edm::Handle<reco::MuonCollection> muons;
-  evt.getByToken(muons_, muons);
+  evt.getByLabel(muons_, muons);
 
   reco::MuonCollection::const_iterator muon;
 
@@ -400,7 +400,7 @@ void TopDiLeptonDQM::analyze(const edm::Event& evt, const edm::EventSetup& conte
   // ----------------------------
 
   edm::Handle<reco::GsfElectronCollection> elecs;
-  evt.getByToken(elecs_, elecs);
+  evt.getByLabel(elecs_, elecs);
 
   reco::GsfElectronCollection::const_iterator elec;
 

--- a/DQM/Physics/src/TopDiLeptonDQM.h
+++ b/DQM/Physics/src/TopDiLeptonDQM.h
@@ -33,9 +33,6 @@
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 
-using namespace std;
-using namespace edm;
-
 class TH1F;
 class TH2F;
 class TopDiLeptonDQM : public edm::EDAnalyzer {
@@ -62,7 +59,7 @@ class TopDiLeptonDQM : public edm::EDAnalyzer {
 
     std::string moduleName_;
     std::string outputFile_;
-    edm::EDGetTokenT<TriggerResults> triggerResults_;
+    edm::InputTag triggerResults_;
     std::vector<std::string> hltPaths_;
     std::vector<std::string> hltPaths_sig_;
     std::vector<std::string> hltPaths_trig_;
@@ -77,17 +74,17 @@ class TopDiLeptonDQM : public edm::EDAnalyzer {
     int N_muel;
     int N_elel;
 
-    edm::EDGetTokenT<reco::VertexCollection> vertex_;
+    edm::InputTag vertex_;
     double vertex_X_cut_;
     double vertex_Y_cut_;
     double vertex_Z_cut_;
 
-    edm::EDGetTokenT<reco::MuonCollection> muons_;
+    edm::InputTag muons_;
     double muon_pT_cut_;
     double muon_eta_cut_;
     double muon_iso_cut_;
 
-    edm::EDGetTokenT<reco::GsfElectronCollection> elecs_;
+    edm::InputTag elecs_;
     double elec_pT_cut_;
     double elec_eta_cut_;
     double elec_iso_cut_;

--- a/DQM/Physics/src/TopDiLeptonOfflineDQM.cc
+++ b/DQM/Physics/src/TopDiLeptonOfflineDQM.cc
@@ -8,19 +8,20 @@
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/EDConsumerBase.h"
+
 namespace TopDiLeptonOffline {
 
-  MonitorEnsemble::MonitorEnsemble(const char* label, const edm::ParameterSet& cfg, edm::ConsumesCollector && iC):
-   label_(label), eidPattern_(0), elecIso_(0), elecSelect_(0), muonIso_(0), muonSelect_(0), jetIDSelect_(0),
+  MonitorEnsemble::MonitorEnsemble(const char* label, const edm::ParameterSet& cfg, edm::ConsumesCollector && iC): 
+   label_(label), eidCutValue_(0.), elecIso_(0), elecSelect_(0), muonIso_(0), muonSelect_(0), jetIDSelect_(0), 
    lowerEdge_(-1.), upperEdge_(-1.), elecMuLogged_(0), diMuonLogged_(0), diElecLogged_(0)
   {
     // sources have to be given; this PSet is not optional
     edm::ParameterSet sources=cfg.getParameter<edm::ParameterSet>("sources");
-    muons_ = iC.consumes<edm::View<reco::Muon> >(sources.getParameter<edm::InputTag>("muons"));
-    elecs_ = iC.consumes<edm::View<reco::GsfElectron> >(sources.getParameter<edm::InputTag>("elecs"));
+    muons_ = iC.consumes<edm::View<reco::PFCandidate> >(sources.getParameter<edm::InputTag>("muons"));    
+    elecs_ = iC.consumes<edm::View<reco::PFCandidate> >(sources.getParameter<edm::InputTag>("elecs"));
     jets_ = iC.consumes<edm::View<reco::Jet> >(sources.getParameter<edm::InputTag>("jets"));
     for (edm::InputTag const & tag : sources.getParameter<std::vector<edm::InputTag> >("mets"))
-	mets_.push_back( iC.consumes<edm::View<reco::MET> >(tag) );
+	mets_.push_back( iC.consumes<edm::View<reco::MET> >(tag) );  
 
     // elecExtras are optional; they may be omitted or empty
     if( cfg.existsAs<edm::ParameterSet>("elecExtras") ){
@@ -28,19 +29,20 @@ namespace TopDiLeptonOffline {
       // select is optional; in case it's not found no
       // selection will be applied
       if( elecExtras.existsAs<std::string>("select") ){
-	elecSelect_= new StringCutObjectSelector<reco::GsfElectron>(elecExtras.getParameter<std::string>("select"));
+	elecSelect_= new StringCutObjectSelector<reco::PFCandidate>(elecExtras.getParameter<std::string>("select"));
       }
       // isolation is optional; in case it's not found no
       // isolation will be applied
       if( elecExtras.existsAs<std::string>("isolation") ){
-	elecIso_= new StringCutObjectSelector<reco::GsfElectron>(elecExtras.getParameter<std::string>("isolation"));
+	elecIso_= new StringCutObjectSelector<reco::PFCandidate>(elecExtras.getParameter<std::string>("isolation"));
       }
-      // electronId is optional; in case it's not found the
+      // electronId is optional; in case it's not found the 
       // InputTag will remain empty
       if( elecExtras.existsAs<edm::ParameterSet>("electronId") ){
 	edm::ParameterSet elecId=elecExtras.getParameter<edm::ParameterSet>("electronId");
         electronId_= iC.consumes<edm::ValueMap<float> >(elecId.getParameter<edm::InputTag>("src"));
-	eidPattern_= elecId.getParameter<int>("pattern");
+	eidCutValue_= elecId.getParameter<double>("cutValue");
+	//	eidPattern_= elecId.getParameter<int>("pattern");
       }
     }
     // muonExtras are optional; they may be omitted or empty
@@ -49,18 +51,18 @@ namespace TopDiLeptonOffline {
       // select is optional; in case it's not found no
       // selection will be applied
       if( muonExtras.existsAs<std::string>("select") ){
-	muonSelect_= new StringCutObjectSelector<reco::Muon>(muonExtras.getParameter<std::string>("select"));
+	muonSelect_= new StringCutObjectSelector<reco::PFCandidate, true >(muonExtras.getParameter<std::string>("select"));
       }
       // isolation is optional; in case it's not found no
       // isolation will be applied
       if( muonExtras.existsAs<std::string>("isolation") ){
-	muonIso_= new StringCutObjectSelector<reco::Muon>(muonExtras.getParameter<std::string>("isolation"));
+	muonIso_= new StringCutObjectSelector<reco::PFCandidate, true >(muonExtras.getParameter<std::string>("isolation"));
       }
     }
     // jetExtras are optional; they may be omitted or empty
     if( cfg.existsAs<edm::ParameterSet>("jetExtras") ){
       edm::ParameterSet jetExtras=cfg.getParameter<edm::ParameterSet>("jetExtras");
-      // jetCorrector is optional; in case it's not found
+      // jetCorrector is optional; in case it's not found 
       // the InputTag will remain empty
       if( jetExtras.existsAs<std::string>("jetCorrector") ){
 	jetCorrector_= jetExtras.getParameter<std::string>("jetCorrector");
@@ -72,7 +74,7 @@ namespace TopDiLeptonOffline {
 	jetIDSelect_= new StringCutObjectSelector<reco::JetID>(jetID.getParameter<std::string>("select"));
       }
       // select is optional; in case it's not found no
-      // selection will be applied (only implemented for
+      // selection will be applied (only implemented for 
       // CaloJets at the moment)
       if( jetExtras.existsAs<std::string>("select") ){
 	jetSelect_= jetExtras.getParameter<std::string>("select");
@@ -95,7 +97,7 @@ namespace TopDiLeptonOffline {
     }
 
     // setup the verbosity level for booking histograms;
-    // per default the verbosity level will be set to
+    // per default the verbosity level will be set to 
     // STANDARD. This will also be the chosen level in
     // the case when the monitoring PSet is not found
     verbosity_=STANDARD;
@@ -112,7 +114,7 @@ namespace TopDiLeptonOffline {
     book(cfg.getParameter<std::string>("directory"));
   }
 
-  void
+  void 
   MonitorEnsemble::book(std::string directory)
   {
     //set up the current directory path
@@ -135,7 +137,7 @@ namespace TopDiLeptonOffline {
     hists_["invMassWC_"   ] = store_->book1D("InvMassWC"   , "M_{WC}(L1, L2)"          ,       80,   0.,     320.);
     // invariant mass of same charge lepton pair (log10 for low mass region, only filled for same flavor)
     hists_["invMassWCLog_"] = store_->book1D("InvMassLogWC", "log_{10}(M_{WC})"        ,       80,   .1,      2.5);
-    // decay channel [1]: muon/muon, [2]:elec/elec, [3]:elec/muon
+    // decay channel [1]: muon/muon, [2]:elec/elec, [3]:elec/muon 
     hists_["decayChannel_"] = store_->book1D("DecayChannel", "Decay Channel"           ,        3,    0,        3);
     // trigger efficiency estimates for the electron muon channel
     hists_["elecMuEff_"   ] = store_->book1D("ElecMuEff"   , "Eff(e/#mu paths)"        ,  nElecMu,   0.,  nElecMu);
@@ -150,7 +152,7 @@ namespace TopDiLeptonOffline {
     // pt of the 2. leading lepton
     hists_["lep2Pt_"      ] = store_->book1D("Lep2Pt"      , "pt(lep2)"                ,       50,   0.,     200.);
     // multiplicity of jets with pt>30 (corrected to L2+L3)
-    hists_["jetMult_"     ] = store_->book1D("JetMult"     , "N_{30}(jet)"             ,       21, -0.5,      20.5);
+    hists_["jetMult_"     ] = store_->book1D("JetMult"     , "N_{30}(jet)"             ,       21, -0.5,      20.5); 
     // MET (calo)
     hists_["metCalo_"     ] = store_->book1D("METCalo"     , "MET_{Calo}"              ,       50,   0.,     200.);
 
@@ -166,7 +168,7 @@ namespace TopDiLeptonOffline {
 
     // --- [VERBOSE] --- //
     // mean eta of the candidate leptons
-    hists_["sumEtaL1L2_"  ] = store_->book1D("SumEtaL1L2"  , "<#eta>(lep1, lep2)"      ,       100,  -5.,       5.);
+    hists_["sumEtaL1L2_"  ] = store_->book1D("SumEtaL1L2"  , "<#eta>(lep1, lep2)"      ,       100,  -5.,       5.); 
     // deltaEta between the 2 candidate leptons
     hists_["dEtaL1L2_"    ] = store_->book1D("DEtaL1L2"    , "#Delta#eta(lep1,lep2)"   ,       80,  -4.,       4.);
     // deltaPhi between the 2 candidate leptons
@@ -178,9 +180,9 @@ namespace TopDiLeptonOffline {
     // pt of the canddiate muon (depending on the decay channel)
     hists_["muonPt_"      ] = store_->book1D("MuonPt"      , "pt(#mu)"                 ,       50,   0.,     200.);
     // relative isolation of the candidate muon (depending on the decay channel)
-    hists_["muonRelIso_"  ] = store_->book1D("MuonRelIso"  , "Iso_{Rel}(#mu)"          ,       50,   0.,       1.);
+    hists_["muonRelIso_"  ] = store_->book1D("MuonRelIso"  , "Iso_{Rel}(#mu) (#Delta#beta Corrected)" , 50, 0.,1.);
     // pt of the 1. leading jet (corrected to L2+L3)
-    hists_["jet1Pt_"      ] = store_->book1D("Jet1Pt"      , "pt_{L2L3}(jet1)"         ,       60,   0.,     300.);
+    hists_["jet1Pt_"      ] = store_->book1D("Jet1Pt"      , "pt_{L2L3}(jet1)"         ,       60,   0.,     300.);   
     // pt of the 2. leading jet (corrected to L2+L3)
     hists_["jet2Pt_"      ] = store_->book1D("Jet2Pt"      , "pt_{L2L3}(jet2)"         ,       60,   0.,     300.);
     // MET (PF)
@@ -206,21 +208,29 @@ namespace TopDiLeptonOffline {
     hists_["elecMultIso_" ] = store_->book1D("ElecMultIso" , "N_{Iso}(e)"              ,       11, -0.5,     10.5);
     // muon multiplicity after std isolation
     hists_["muonMultIso_" ] = store_->book1D("MuonMultIso" , "N_{Iso}(#mu)"            ,       11, -0.5,     10.5);
-    // calo isolation of the candidate muon (depending on the decay channel)
-    hists_["muonCalIso_"  ] = store_->book1D("MuonCalIso"  , "Iso_{Cal}(#mu)"          ,       50,   0.,       1.);
-    // track isolation of the candidate muon (depending on the decay channel)
-    hists_["muonTrkIso_"  ] = store_->book1D("MuonTrkIso"  , "Iso_{Trk}(#mu)"          ,       50,   0.,       1.);
+    // charged hadron isolation component of the candidate muon (depending on the decay channel)
+    hists_["muonChHadIso_"] = store_->book1D("MuonChHadIsoComp"  , "ChHad_{IsoComponent}(#mu)" ,       50, 0., 5.);
+    // neutral hadron isolation component of the candidate muon (depending on the decay channel)
+    hists_["muonNeHadIso_"] = store_->book1D("MuonNeHadIsoComp"  , "NeHad_{IsoComponent}(#mu)" ,       50, 0., 5.);
+    // photon isolation component of the candidate muon (depending on the decay channel)
+    hists_["muonPhIso_"   ] = store_->book1D("MuonPhIsoComp"  , "Photon_{IsoComponent}(#mu)"   ,       50, 0., 5.);
+    // charged hadron isolation component of the candidate electron (depending on the decay channel)
+    hists_["elecChHadIso_"] = store_->book1D("ElectronChHadIsoComp"  , "ChHad_{IsoComponent}(e)" ,       50, 0., 5.);
+    // neutral hadron isolation component of the candidate electron (depending on the decay channel)
+    hists_["elecNeHadIso_"] = store_->book1D("ElectronNeHadIsoComp"  , "NeHad_{IsoComponent}(e)" ,       50, 0., 5.);
+    // photon isolation component of the candidate electron (depending on the decay channel)
+    hists_["elecPhIso_"   ] = store_->book1D("ElectronPhIsoComp"  , "Photon_{IsoComponent}(e)"   ,       50, 0., 5.);
     // calo isolation of the candidate electron (depending on the decay channel)
-    hists_["elecCalIso_"  ] = store_->book1D("ElecCalIso"  , "Iso_{Cal}(e)"            ,       50,   0.,       1.);
+    //hists_["elecCalIso_"  ] = store_->book1D("ElecCalIso"  , "Iso_{Cal}(e)"            ,       50,   0.,       1.);
     // track isolation of the candidate electron (depending on the decay channel)
-    hists_["elecTrkIso_"  ] = store_->book1D("ElecTrkIso"  , "Iso_{Trk}(e)"            ,       50,   0.,       1.);
+    //hists_["elecTrkIso_"  ] = store_->book1D("ElecTrkIso"  , "Iso_{Trk}(e)"            ,       50,   0.,       1.);
     // eta of the leading jet
-    hists_["jet1Eta_"     ] = store_->book1D("Jet1Eta"     , "#eta(jet1)"              ,       30,  -5.,       5.);
+    hists_["jet1Eta_"     ] = store_->book1D("Jet1Eta"     , "#eta(jet1)"              ,       30,  -5.,       5.); 
     // eta of the 2. leading jet
     hists_["jet2Eta_"     ] = store_->book1D("Jet2Eta"     , "#eta(jet2)"              ,       30,  -5.,       5.);
     // pt of the 1. leading jet (not corrected)
-    hists_["jet1PtRaw_"   ] = store_->book1D("Jet1PtRaw"   , "pt_{Raw}(jet1)"          ,       60,   0.,     300.);
-    // pt of the 2. leading jet (not corrected)
+    hists_["jet1PtRaw_"   ] = store_->book1D("Jet1PtRaw"   , "pt_{Raw}(jet1)"          ,       60,   0.,     300.);   
+    // pt of the 2. leading jet (not corrected)     
     hists_["jet2PtRaw_"   ] = store_->book1D("Jet2PtRaw"   , "pt_{Raw}(jet2)"          ,       60,   0.,     300.);
     // deltaEta between the 2 leading jets
     hists_["dEtaJet1Jet2_"] = store_->book1D("DEtaJet1Jet2", "#Delta#eta(jet1,jet2)"   ,       80,  -4.,       4.);
@@ -246,35 +256,35 @@ namespace TopDiLeptonOffline {
     hists_["elecMuLogger_"] = store_->book2D("ElecMuLogger", "Logged ElecMu Events"    ,        8,   0.,       8.,   10,   0.,   10.);
 
     // set bin labels for trigger monitoring
-    loggerBinLabels(std::string("diMuonLogger_"));
-    loggerBinLabels(std::string("diElecLogger_"));
+    loggerBinLabels(std::string("diMuonLogger_")); 
+    loggerBinLabels(std::string("diElecLogger_")); 
     loggerBinLabels(std::string("elecMuLogger_"));
     return;
   }
 
-  void
+  void 
   MonitorEnsemble::fill(const edm::Event& event, const edm::EventSetup& setup)
   {
-    // fetch trigger event if configured such
+    // fetch trigger event if configured such 
     edm::Handle<edm::TriggerResults> triggerTable;
     if(!triggerTable_.isUninitialized()) {
 	if( !event.getByToken(triggerTable_, triggerTable) ) return;
      }
     /*
     ------------------------------------------------------------
-
+    
     Run and Inst. Luminosity information (Inst. Lumi. filled now with a dummy value=5.0)
-
+    
     ------------------------------------------------------------
     */
-
+    
     if (!event.eventAuxiliary().run()) return;
-    fill("RunNumb_", event.eventAuxiliary().run());
-
+    fill("RunNumb_", event.eventAuxiliary().run());   
+    
     double dummy=5.; fill("InstLumi_", dummy);
-
-
-    /*
+     
+    
+    /* 
     ------------------------------------------------------------
 
     Muon Selection
@@ -282,30 +292,47 @@ namespace TopDiLeptonOffline {
     ------------------------------------------------------------
     */
 
-    // buffer isolated muons
-    std::vector<const reco::Muon*> isoMuons;
+    std::vector<const reco::PFCandidate*> isoMuons;
 
-    edm::Handle<edm::View<reco::Muon> > muons;
-    if( !event.getByToken(muons_, muons) ) return;
+    edm::Handle<edm::View<reco::PFCandidate> > muons;
+    edm::View<reco::PFCandidate>::const_iterator muonit;
+    
+    if( !event.getByToken(muons_, muons )) return;
 
-    for(edm::View<reco::Muon>::const_iterator muon=muons->begin(); muon!=muons->end(); ++muon){
-      // restrict to globalMuons
+    for(edm::View<reco::PFCandidate>::const_iterator muonit = muons->begin(); muonit != muons->end(); ++muonit){ 
+      
+      if(muonit->muonRef().isNull()) continue ;
+      reco::MuonRef muon = muonit->muonRef();
+
+      if(muon->innerTrack().isNull()) continue ;
+
       if( muon->isGlobalMuon() ){
-	fill("muonDelZ_" , muon->globalTrack()->vz());
-	fill("muonDelXY_", muon->globalTrack()->vx(), muon->globalTrack()->vy());
-	// apply preselection
-	if(!muonSelect_ || (*muonSelect_)(*muon)){
-	  double isolationTrk = muon->pt()/(muon->pt()+muon->isolationR03().sumPt);
-	  double isolationCal = muon->pt()/(muon->pt()+muon->isolationR03().emEt+muon->isolationR03().hadEt);
-	  double isolationRel = (muon->isolationR03().sumPt+muon->isolationR03().emEt+muon->isolationR03().hadEt)/muon->pt();
-	  fill("muonTrkIso_" , isolationTrk); fill("muonCalIso_" , isolationCal); fill("muonRelIso_" , isolationRel);
-	  if(!muonIso_ || (*muonIso_)(*muon)) isoMuons.push_back(&(*muon));
-	}
+        fill("muonDelZ_" , muon->innerTrack()->vz());                           // CB using inner track!
+        fill("muonDelXY_", muon->innerTrack()->vx(), muon->innerTrack()->vy());
+
+        // apply selection
+        if( !muonSelect_ || (*muonSelect_)(*muonit)) {
+
+	  double chHadPt = muon->pfIsolationR04().sumChargedHadronPt; 
+	  double neHadEt = muon->pfIsolationR04().sumNeutralHadronEt;
+	  double phoEt   = muon->pfIsolationR04().sumPhotonEt; 
+
+	  double pfRelIso = (chHadPt + max(0.,neHadEt + phoEt - 0.5*muon->pfIsolationR04().sumPUPt) ) / muon->pt();    // CB dBeta corrected iso!  										
+
+          fill("muonRelIso_" , pfRelIso);
+
+	  fill("muonChHadIso_",chHadPt);
+	  fill("muonNeHadIso_",neHadEt);
+	  fill("muonPhIso_"   ,phoEt);
+
+          if( !muonIso_ || (*muonIso_)(*muonit)) isoMuons.push_back(&(*muonit)); 
+        }
       }
     }
-    fill("muonMultIso_", isoMuons.size());
 
-    /*
+    fill("muonMultIso_", isoMuons.size());    
+
+    /* 
     ------------------------------------------------------------
 
     Electron Selection
@@ -314,31 +341,42 @@ namespace TopDiLeptonOffline {
     */
 
     // buffer isolated electronss
-    std::vector<const reco::GsfElectron*> isoElecs;
-    edm::Handle<edm::ValueMap<float> > electronId;
+    std::vector<const reco::PFCandidate*> isoElecs;
+    edm::Handle<edm::ValueMap<float> > electronId; 
     if(!electronId_.isUninitialized()) {
 	if( !event.getByToken(electronId_, electronId) ) return;
     }
-    edm::Handle<edm::View<reco::GsfElectron> > elecs;
+    edm::Handle<edm::View<reco::PFCandidate> > elecs;
     if( !event.getByToken(elecs_, elecs) ) return;
 
-    for(edm::View<reco::GsfElectron>::const_iterator elec=elecs->begin(); elec!=elecs->end(); ++elec){
+    for(edm::View<reco::PFCandidate>::const_iterator elec=elecs->begin(); elec!=elecs->end(); ++elec){
+      if(elec->gsfElectronRef().isNull()){ continue ;}
+      reco::GsfElectronRef gsf_el = elec->gsfElectronRef();
       // restrict to electrons with good electronId
-      int idx = elec-elecs->begin();
-      if( electronId_.isUninitialized() ? true : ((int)(*electronId)[elecs->refAt(idx)] & eidPattern_) ){
+      //int idx = elec-elecs->begin();
+      if( electronId_.isUninitialized() ? true : ((double)(*electronId)[gsf_el] >= eidCutValue_) ){
+	//      if( electronId_.isUninitialized() ? true : ((int)(*electronId)[elecs->refAt(idx)] & eidPattern_) ){
 	// apply preselection
 	if(!elecSelect_ || (*elecSelect_)(*elec)){
-	  double isolationTrk = elec->pt()/(elec->pt()+elec->dr03TkSumPt());
-	  double isolationCal = elec->pt()/(elec->pt()+elec->dr03EcalRecHitSumEt()+elec->dr03HcalTowerSumEt());
-	  double isolationRel = (elec->dr03TkSumPt()+elec->dr03EcalRecHitSumEt()+elec->dr03HcalTowerSumEt())/elec->pt();
-	  fill("elecTrkIso_" , isolationTrk); fill("elecCalIso_" , isolationCal); fill("elecRelIso_" , isolationRel);
+	  //double isolationTrk = elec->pt()/(elec->pt()+elec->dr03TkSumPt());
+	  //double isolationCal = elec->pt()/(elec->pt()+elec->dr03EcalRecHitSumEt()+elec->dr03HcalTowerSumEt());
+	  //double isolationRel = (elec->dr03TkSumPt()+elec->dr03EcalRecHitSumEt()+elec->dr03HcalTowerSumEt())/elec->pt();
+	  //fill("elecTrkIso_" , isolationTrk); fill("elecCalIso_" , isolationCal); fill("elecRelIso_" , isolationRel);
+	  double el_ChHadIso = gsf_el->pfIsolationVariables().sumChargedHadronPt;
+          double el_NeHadIso = gsf_el->pfIsolationVariables().sumNeutralHadronEt;
+          double el_PhIso = gsf_el->pfIsolationVariables().sumPhotonEt;
+          double el_pfRelIso = (el_ChHadIso + max(0.,el_NeHadIso + el_PhIso - 0.5*gsf_el->pfIsolationVariables().sumPUPt) ) / gsf_el->pt();
+	  fill("elecRelIso_" , el_pfRelIso );
+	  fill("elecChHadIso_" , el_ChHadIso );
+	  fill("elecNeHadIso_" , el_NeHadIso );
+	  fill("elecPhIso_" , el_PhIso );
 	  if(!elecIso_ || (*elecIso_)(*elec)) isoElecs.push_back(&(*elec));
 	}
       }
     }
     fill("elecMultIso_", isoElecs.size());
 
-    /*
+    /* 
     ------------------------------------------------------------
 
     Jet Selection
@@ -353,16 +391,16 @@ namespace TopDiLeptonOffline {
 	corrector = JetCorrector::getJetCorrector(jetCorrector_, setup);
       }
       else{
-	edm::LogVerbatim( "TopDiLeptonOfflineDQM" )
+	edm::LogVerbatim( "TopDiLeptonOfflineDQM" ) 
 	  << "\n"
 	  << "------------------------------------------------------------------------------------- \n"
-	  << " No JetCorrectionsRecord available from EventSetup:                                   \n"
+	  << " No JetCorrectionsRecord available from EventSetup:                                   \n" 
 	  << "  - Jets will not be corrected.                                                       \n"
 	  << "  - If you want to change this add the following lines to your cfg file:              \n"
 	  << "                                                                                      \n"
 	  << "  ## load jet corrections                                                             \n"
 	  << "  process.load(\"JetMETCorrections.Configuration.JetCorrectionServicesAllAlgos_cff\") \n"
-	  << "  process.prefer(\"ak4CaloL2L3\")                                                     \n"
+	  << "  process.prefer(\"ak5CaloL2L3\")                                                     \n"
 	  << "                                                                                      \n"
 	  << "------------------------------------------------------------------------------------- \n";
       }
@@ -371,11 +409,11 @@ namespace TopDiLeptonOffline {
     unsigned int mult=0;
     // buffer leadingJets
     std::vector<reco::Jet> leadingJets;
-    edm::Handle<edm::View<reco::Jet> > jets;
+    edm::Handle<edm::View<reco::Jet> > jets; 
     if( !event.getByToken(jets_, jets) ) return;
 
     edm::Handle<reco::JetIDValueMap> jetID;
-    if(jetIDSelect_){
+    if(jetIDSelect_){ 
       if( !event.getByToken(jetIDLabel_, jetID) ) return;
     }
 
@@ -392,14 +430,14 @@ namespace TopDiLeptonOffline {
       else if(dynamic_cast<const reco::PFJet*>(&*jet)){
 	reco::PFJet sel= dynamic_cast<const reco::PFJet&>(*jet); sel.scaleEnergy(corrector ? corrector->correction(*jet) : 1.);
 	StringCutObjectSelector<reco::PFJet> jetSelect(jetSelect_); if(!jetSelect(sel)) continue;
-      }
+      } 
       else{
 	reco::Jet sel = *jet; sel.scaleEnergy(corrector ? corrector->correction(*jet) : 1.);
 	StringCutObjectSelector<reco::Jet> jetSelect(jetSelect_); if(!jetSelect(sel)) continue;
       }
       // check for overlaps
       bool overlap=false;
-      for(std::vector<const reco::GsfElectron*>::const_iterator elec=isoElecs.begin(); elec!=isoElecs.end(); ++elec){
+      for(std::vector<const reco::PFCandidate*>::const_iterator elec=isoElecs.begin(); elec!=isoElecs.end(); ++elec){
 	if(reco::deltaR((*elec)->eta(), (*elec)->phi(), jet->eta(), jet->phi())<0.4){overlap=true; break;}
       } if(overlap){continue;}
       // prepare jet to fill monitor histograms
@@ -425,7 +463,7 @@ namespace TopDiLeptonOffline {
 	if( isoElecs.empty() || isoMuons[0]->pt()>isoElecs[0]->pt() ){
 	  fill("dEtaJet1Lep1_" , isoMuons[0]->eta()-leadingJets[0].eta());
 	  fill("dPhiJet1Lep1_" , reco::deltaPhi(isoMuons[0]->phi() , leadingJets[0].phi()));
-	}
+	} 
       }
       if( !isoElecs.empty() ){
 	if( isoMuons.empty() || isoElecs[0]->pt()>isoMuons[0]->pt() ){
@@ -435,8 +473,8 @@ namespace TopDiLeptonOffline {
       }
     }
     fill("jetMult_", mult);
-
-    /*
+    
+    /* 
     ------------------------------------------------------------
 
     MET Selection
@@ -444,7 +482,7 @@ namespace TopDiLeptonOffline {
     ------------------------------------------------------------
     */
 
-    // buffer for event logging
+    // buffer for event logging 
     reco::MET caloMET;
     //for(std::vector<edm::InputTag>::const_iterator met_=mets_.begin(); met_!=mets_.end(); ++met_){
     for(std::vector<edm::EDGetTokenT<edm::View<reco::MET> > >::const_iterator met_=mets_.begin(); met_!=mets_.end(); ++met_){
@@ -455,7 +493,7 @@ namespace TopDiLeptonOffline {
       if(met->begin()!=met->end()){
 	unsigned int idx=met_-mets_.begin();
 	if(idx==0){
-	  caloMET=*met->begin();
+	  caloMET=*met->begin(); 
 	  fill("metCalo_", met->begin()->et());
 	  if(!leadingJets.empty()){
 	    fill("dEtaJet1MET_" , leadingJets[0].eta()-met->begin()->eta());
@@ -465,7 +503,7 @@ namespace TopDiLeptonOffline {
 	    if( isoElecs.empty() || isoMuons[0]->pt()>isoElecs[0]->pt() ){
 	      fill("dEtaLep1MET_" , isoMuons[0]->eta()-met->begin()->eta());
 	      fill("dPhiLep1MET_" , reco::deltaPhi(isoMuons[0]->phi(), met->begin()->phi()));
-	    }
+	    } 
 	  }
 	  if( !isoElecs.empty() ){
 	    if( isoMuons.empty() || isoElecs[0]->pt()>isoMuons[0]->pt() ){
@@ -480,7 +518,7 @@ namespace TopDiLeptonOffline {
     }
 
 
-    /*
+    /* 
     ------------------------------------------------------------
 
     Event Monitoring
@@ -495,11 +533,11 @@ namespace TopDiLeptonOffline {
       fill("decayChannel_", 0.5);
       double mass = (isoElecs[0]->p4()+isoMuons[0]->p4()).mass();
       if( (lowerEdge_==-1. && upperEdge_==-1.) || (lowerEdge_<mass && mass<upperEdge_) ){
-
-	fill("dEtaL1L2_"  , isoElecs[0]->eta()-isoMuons[0]->eta());
-	fill("sumEtaL1L2_", (isoElecs[0]->eta()+isoMuons[0]->eta())/2);
-	fill("dPhiL1L2_"  , reco::deltaPhi(isoElecs[0]->phi(), isoMuons[0]->eta()));
-	fill("elecPt_", isoElecs[0]->pt()); fill("muonPt_", isoMuons[0]->pt());
+        
+	fill("dEtaL1L2_"  , isoElecs[0]->eta()-isoMuons[0]->eta()); 
+	fill("sumEtaL1L2_", (isoElecs[0]->eta()+isoMuons[0]->eta())/2); 
+	fill("dPhiL1L2_"  , reco::deltaPhi(isoElecs[0]->phi(), isoMuons[0]->eta())); 
+	fill("elecPt_", isoElecs[0]->pt()); fill("muonPt_", isoMuons[0]->pt()); 
 	fill("lep1Pt_", isoElecs[0]->pt()>isoMuons[0]->pt() ? isoElecs[0]->pt() : isoMuons[0]->pt());
 	fill("lep2Pt_", isoElecs[0]->pt()>isoMuons[0]->pt() ? isoMuons[0]->pt() : isoElecs[0]->pt());
 	// fill plots for trigger monitoring
@@ -507,15 +545,15 @@ namespace TopDiLeptonOffline {
 	if(elecMuLogged_<=hists_.find("elecMuLogger_")->second->getNbinsY()){
 	  // log runnumber, lumi block, event number & some
 	  // more pysics infomation for interesting events
-	  fill("elecMuLogger_", 0.5, elecMuLogged_+0.5, event.eventAuxiliary().run());
-	  fill("elecMuLogger_", 1.5, elecMuLogged_+0.5, event.eventAuxiliary().luminosityBlock());
-	  fill("elecMuLogger_", 2.5, elecMuLogged_+0.5, event.eventAuxiliary().event());
-	  fill("elecMuLogger_", 3.5, elecMuLogged_+0.5, isoMuons[0]->pt());
-	  fill("elecMuLogger_", 4.5, elecMuLogged_+0.5, isoElecs[0]->pt());
-	  if(leadingJets.size()>0) fill("elecMuLogger_", 5.5, elecMuLogged_+0.5, leadingJets[0].pt());
-	  if(leadingJets.size()>1) fill("elecMuLogger_", 6.5, elecMuLogged_+0.5, leadingJets[1].pt());
-	  fill("elecMuLogger_", 7.5, elecMuLogged_+0.5, caloMET.et());
-	  ++elecMuLogged_;
+	  fill("elecMuLogger_", 0.5, elecMuLogged_+0.5, event.eventAuxiliary().run()); 
+	  fill("elecMuLogger_", 1.5, elecMuLogged_+0.5, event.eventAuxiliary().luminosityBlock()); 
+	  fill("elecMuLogger_", 2.5, elecMuLogged_+0.5, event.eventAuxiliary().event()); 
+	  fill("elecMuLogger_", 3.5, elecMuLogged_+0.5, isoMuons[0]->pt()); 
+	  fill("elecMuLogger_", 4.5, elecMuLogged_+0.5, isoElecs[0]->pt()); 
+	  if(leadingJets.size()>0) fill("elecMuLogger_", 5.5, elecMuLogged_+0.5, leadingJets[0].pt()); 
+	  if(leadingJets.size()>1) fill("elecMuLogger_", 6.5, elecMuLogged_+0.5, leadingJets[1].pt()); 
+	  fill("elecMuLogger_", 7.5, elecMuLogged_+0.5, caloMET.et()); 
+	  ++elecMuLogged_; 
 	}
       }
     }
@@ -525,29 +563,29 @@ namespace TopDiLeptonOffline {
       fill("decayChannel_", 1.5);
       int charge = isoMuons[0]->charge()*isoMuons[1]->charge();
       double mass = (isoMuons[0]->p4()+isoMuons[1]->p4()).mass();
-
+      
       fill(charge<0 ? "invMass_"    : "invMassWC_"    , mass       );
       fill(charge<0 ? "invMassLog_" : "invMassWCLog_" , log10(mass));
       if((lowerEdge_==-1. && upperEdge_==-1.) || (lowerEdge_<mass && mass<upperEdge_) ){
         fill("dEtaL1L2_"  , isoMuons[0]->eta()-isoMuons[1]->eta() );
 	fill("sumEtaL1L2_", (isoMuons[0]->eta()+isoMuons[1]->eta())/2);
 	fill("dPhiL1L2_", reco::deltaPhi(isoMuons[0]->phi(),isoMuons[1]->phi()) );
-	fill("muonPt_", isoMuons[0]->pt()); fill("muonPt_", isoMuons[1]->pt());
-	fill("lep1Pt_", isoMuons[0]->pt()); fill("lep2Pt_", isoMuons[1]->pt());
+	fill("muonPt_", isoMuons[0]->pt()); fill("muonPt_", isoMuons[1]->pt()); 
+	fill("lep1Pt_", isoMuons[0]->pt()); fill("lep2Pt_", isoMuons[1]->pt()); 
 	// fill plots for trigger monitoring
 	if(!triggerTable_.isUninitialized()) fill(event, *triggerTable, "diMuon", diMuonPaths_);
 	if(diMuonLogged_<=hists_.find("diMuonLogger_")->second->getNbinsY()){
 	  // log runnumber, lumi block, event number & some
 	  // more pysics infomation for interesting events
-	  fill("diMuonLogger_", 0.5, diMuonLogged_+0.5, event.eventAuxiliary().run());
-	  fill("diMuonLogger_", 1.5, diMuonLogged_+0.5, event.eventAuxiliary().luminosityBlock());
-	  fill("diMuonLogger_", 2.5, diMuonLogged_+0.5, event.eventAuxiliary().event());
-	  fill("diMuonLogger_", 3.5, diMuonLogged_+0.5, isoMuons[0]->pt());
-	  fill("diMuonLogger_", 4.5, diMuonLogged_+0.5, isoMuons[1]->pt());
-	  if(leadingJets.size()>0) fill("diMuonLogger_", 5.5, diMuonLogged_+0.5, leadingJets[0].pt());
-	  if(leadingJets.size()>1) fill("diMuonLogger_", 6.5, diMuonLogged_+0.5, leadingJets[1].pt());
-	  fill("diMuonLogger_", 7.5, diMuonLogged_+0.5, caloMET.et());
-	  ++diMuonLogged_;
+	  fill("diMuonLogger_", 0.5, diMuonLogged_+0.5, event.eventAuxiliary().run()); 
+	  fill("diMuonLogger_", 1.5, diMuonLogged_+0.5, event.eventAuxiliary().luminosityBlock()); 
+	  fill("diMuonLogger_", 2.5, diMuonLogged_+0.5, event.eventAuxiliary().event()); 
+	  fill("diMuonLogger_", 3.5, diMuonLogged_+0.5, isoMuons[0]->pt()); 
+	  fill("diMuonLogger_", 4.5, diMuonLogged_+0.5, isoMuons[1]->pt()); 
+	  if(leadingJets.size()>0) fill("diMuonLogger_", 5.5, diMuonLogged_+0.5, leadingJets[0].pt()); 
+	  if(leadingJets.size()>1) fill("diMuonLogger_", 6.5, diMuonLogged_+0.5, leadingJets[1].pt()); 
+	  fill("diMuonLogger_", 7.5, diMuonLogged_+0.5, caloMET.et()); 
+	  ++diMuonLogged_; 
 	}
       }
     }
@@ -563,25 +601,25 @@ namespace TopDiLeptonOffline {
 	fill("dEtaL1L2_"  , isoElecs[0]->eta()-isoElecs[1]->eta() );
 	fill("sumEtaL1L2_", (isoElecs[0]->eta()+isoElecs[1]->eta())/2);
 	fill("dPhiL1L2_"  , reco::deltaPhi(isoElecs[0]->phi(),isoElecs[1]->phi()) );
-	fill("elecPt_", isoElecs[0]->pt()); fill("elecPt_", isoElecs[1]->pt());
-	fill("lep1Pt_", isoElecs[0]->pt()); fill("lep2Pt_", isoElecs[1]->pt());
+	fill("elecPt_", isoElecs[0]->pt()); fill("elecPt_", isoElecs[1]->pt()); 
+	fill("lep1Pt_", isoElecs[0]->pt()); fill("lep2Pt_", isoElecs[1]->pt()); 
 	if(diElecLogged_<=hists_.find("diElecLogger_")->second->getNbinsY()){
 	  // log runnumber, lumi block, event number & some
 	  // more pysics infomation for interesting events
-	  fill("diElecLogger_", 0.5, diElecLogged_+0.5, event.eventAuxiliary().run());
-	  fill("diElecLogger_", 1.5, diElecLogged_+0.5, event.eventAuxiliary().luminosityBlock());
-	  fill("diElecLogger_", 2.5, diElecLogged_+0.5, event.eventAuxiliary().event());
-	  fill("diElecLogger_", 3.5, diElecLogged_+0.5, isoElecs[0]->pt());
-	  fill("diElecLogger_", 4.5, diElecLogged_+0.5, isoElecs[1]->pt());
-	  if(leadingJets.size()>0) fill("diElecLogger_", 5.5, diElecLogged_+0.5, leadingJets[0].pt());
-	  if(leadingJets.size()>1) fill("diElecLogger_", 6.5, diElecLogged_+0.5, leadingJets[1].pt());
-	  fill("diElecLogger_", 7.5, diElecLogged_+0.5, caloMET.et());
-	  ++diElecLogged_;
+	  fill("diElecLogger_", 0.5, diElecLogged_+0.5, event.eventAuxiliary().run()); 
+	  fill("diElecLogger_", 1.5, diElecLogged_+0.5, event.eventAuxiliary().luminosityBlock()); 
+	  fill("diElecLogger_", 2.5, diElecLogged_+0.5, event.eventAuxiliary().event()); 
+	  fill("diElecLogger_", 3.5, diElecLogged_+0.5, isoElecs[0]->pt()); 
+	  fill("diElecLogger_", 4.5, diElecLogged_+0.5, isoElecs[1]->pt()); 
+	  if(leadingJets.size()>0) fill("diElecLogger_", 5.5, diElecLogged_+0.5, leadingJets[0].pt()); 
+	  if(leadingJets.size()>1) fill("diElecLogger_", 6.5, diElecLogged_+0.5, leadingJets[1].pt()); 
+	  fill("diElecLogger_", 7.5, diElecLogged_+0.5, caloMET.et()); 
+	  ++diElecLogged_; 
 	}
       }
    }
   }
-
+  
 }
 
 TopDiLeptonOfflineDQM::TopDiLeptonOfflineDQM(const edm::ParameterSet& cfg): vertexSelect_(0), beamspotSelect_(0), MuonStep(0), ElectronStep(0), PvStep(0), METStep(0)
@@ -594,9 +632,9 @@ TopDiLeptonOfflineDQM::TopDiLeptonOfflineDQM(const edm::ParameterSet& cfg): vert
   if( presel.existsAs<edm::ParameterSet>("trigger") ){
     edm::ParameterSet trigger=presel.getParameter<edm::ParameterSet>("trigger");
 //    triggerTable_=trigger.getParameter<edm::InputTag>("src");
-    triggerTable_ = consumes<edm::TriggerResults>(trigger.getParameter<edm::InputTag>("src"));
+    triggerTable_ = consumes<edm::TriggerResults>(trigger.getParameter<edm::InputTag>("src"));    
     triggerPaths_=trigger.getParameter<std::vector<std::string> >("select");
-  }
+  } 
   if( presel.existsAs<edm::ParameterSet>("vertex" ) ){
     edm::ParameterSet vertex=presel.getParameter<edm::ParameterSet>("vertex");
     vertex_= consumes<std::vector<reco::Vertex> >(vertex.getParameter<edm::InputTag>("src"));
@@ -618,10 +656,10 @@ TopDiLeptonOfflineDQM::TopDiLeptonOfflineDQM(const edm::ParameterSet& cfg): vert
     std::string key = selectionStep(*selIt), type = objectType(*selIt);
     if(selection_.find(key)!=selection_.end()){
       if(type=="muons"){
-    MuonStep = new SelectionStep<reco::Muon>(selection_[key].first, consumesCollector());
-      }
+    MuonStep = new SelectionStep<reco::PFCandidate>(selection_[key].first, consumesCollector());
+      } 
       if(type=="elecs"){
-          ElectronStep = new SelectionStep<reco::GsfElectron>(selection_[key].first, consumesCollector());
+          ElectronStep = new SelectionStep<reco::PFCandidate>(selection_[key].first, consumesCollector());
       }
       if(type=="pvs"){
           PvStep = new SelectionStep<reco::Vertex>(selection_[key].first, consumesCollector());
@@ -637,14 +675,14 @@ TopDiLeptonOfflineDQM::TopDiLeptonOfflineDQM(const edm::ParameterSet& cfg): vert
       }
       if(type=="met"){
     METStep = new SelectionStep<reco::MET>(selection_[key].first, consumesCollector());
-      }
+      } 
     }
    }
 }
 
-void
+void 
 TopDiLeptonOfflineDQM::analyze(const edm::Event& event, const edm::EventSetup& setup)
-{
+{ 
   if(!triggerTable_.isUninitialized()){
     edm::Handle<edm::TriggerResults> triggerTable;
     if( !event.getByToken(triggerTable_, triggerTable) ) return;
@@ -675,14 +713,13 @@ TopDiLeptonOfflineDQM::analyze(const edm::Event& event, const edm::EventSetup& s
 	selection_[key].second->fill(event, setup);
       }
       if(type=="muons" && MuonStep != 0){
-//	SelectionStep<reco::Muon> step(selection_[key].first, consumesCollector());
 	if(MuonStep->select(event)){++passed;
 	  selection_[key].second->fill(event, setup);
 	} else break;
       }
       if(type=="elecs" && ElectronStep != 0){
-//	SelectionStep<reco::GsfElectron> step(selection_[key].first, consumesCollector());
-        if(ElectronStep->select(event)){ ++passed;
+//	SelectionStep<reco::PFCandidate> step(selection_[key].first, consumesCollector());
+        if(ElectronStep->select(event,"electron")){++passed;
 	  selection_[key].second->fill(event, setup);
 	} else break;
       }

--- a/DQM/Physics/src/TopDiLeptonOfflineDQM.h
+++ b/DQM/Physics/src/TopDiLeptonOfflineDQM.h
@@ -11,9 +11,9 @@
 #include "DataFormats/Math/interface/deltaR.h"
 #include "DataFormats/JetReco/interface/Jet.h"
 #include "DQM/Physics/interface/TopDQMHelpers.h"
-#include "DataFormats/MuonReco/interface/Muon.h"
 #include "DataFormats/Common/interface/ValueMap.h"
 #include "DataFormats/METReco/interface/CaloMET.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "JetMETCorrections/Objects/interface/JetCorrector.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
@@ -68,7 +68,7 @@ namespace TopDiLeptonOffline {
     /// expected to be of type 'selectionPath:monitorPath' 
     std::string selectionPath(const std::string& label) const { return label.substr(0, label.find(':')); };  
     /// determine dileptonic decay channel 
-    DecayChannel decayChannel(const std::vector<const reco::Muon*>& muons, const std::vector<const reco::GsfElectron*>& elecs) const;
+    DecayChannel decayChannel(const std::vector<const reco::PFCandidate*>& muons, const std::vector<const reco::PFCandidate*>& elecs) const;
 
     /// set labels for event logging histograms
     void loggerBinLabels(std::string hist);
@@ -94,8 +94,8 @@ namespace TopDiLeptonOffline {
     /// input sources for monitoring
     //edm::InputTag elecs_, muons_, jets_; 
     edm::EDGetTokenT<edm::View<reco::Jet> >  jets_; 
-    edm::EDGetTokenT<edm::View<reco::Muon> > muons_;
-    edm::EDGetTokenT<edm::View<reco::GsfElectron> > elecs_;
+    edm::EDGetTokenT<edm::View<reco::PFCandidate> > muons_;
+    edm::EDGetTokenT<edm::View<reco::PFCandidate> > elecs_;
 
     /// considers a vector of METs
     //std::vector<edm::InputTag> mets_;
@@ -123,16 +123,19 @@ namespace TopDiLeptonOffline {
     ///  6: passes conversion rejection and Isolation
     ///  7: passes the whole selection
     /// As described on https://twiki.cern.ch/twiki/bin/view/CMS/SimpleCutBasedEleID
-    int eidPattern_;
+    //int eidPattern_;
+    //the cut for the MVA Id                                                                                                                                
+    double eidCutValue_;
     /// extra isolation criterion on electron
-    StringCutObjectSelector<reco::GsfElectron>* elecIso_;
+    StringCutObjectSelector<reco::PFCandidate>* elecIso_;
     /// extra selection on electrons
-    StringCutObjectSelector<reco::GsfElectron>* elecSelect_;
+    StringCutObjectSelector<reco::PFCandidate>* elecSelect_;
 
     /// extra isolation criterion on muon
-    StringCutObjectSelector<reco::Muon>* muonIso_;
+    StringCutObjectSelector<reco::PFCandidate, true>* muonIso_;
+    
     /// extra selection on muons
-    StringCutObjectSelector<reco::Muon>* muonSelect_;
+    StringCutObjectSelector<reco::PFCandidate, true>* muonSelect_;
 
     /// jetCorrector
     std::string jetCorrector_;
@@ -206,7 +209,7 @@ namespace TopDiLeptonOffline {
   }
   
   inline MonitorEnsemble::DecayChannel
-  MonitorEnsemble::decayChannel(const std::vector<const reco::Muon*>& muons, const std::vector<const reco::GsfElectron*>& elecs) const 
+  MonitorEnsemble::decayChannel(const std::vector<const reco::PFCandidate*>&  muons, const std::vector<const reco::PFCandidate*>& elecs) const   
   {
     DecayChannel type=NONE;
     if( muons.size()>1 ){ type=DIMUON; } else if( elecs.size()>1 ){ type=DIELEC; } else if( !elecs.empty() && !muons.empty() ){ type=ELECMU; }
@@ -242,8 +245,8 @@ namespace TopDiLeptonOffline {
    MonitorEnsemble class. The following objects are supported for selection:
 
     - jets  : of type reco::Jet
-    - elecs : of type reco::GsfElectron
-    - muons : of type reco::Muon
+    - elecs : of type reco::PFCandidate
+    - muons : of type reco::PFCandidate
     - met   : of type reco::MET
 
    These types have to be present as prefix of the selection step paramter _label_ separated 
@@ -322,8 +325,8 @@ class TopDiLeptonOfflineDQM : public edm::EDAnalyzer  {
   /// MonitoringEnsemble keeps an instance of the MonitorEnsemble class to 
   /// be filled _after_ each selection step
   std::map<std::string, std::pair<edm::ParameterSet, TopDiLeptonOffline::MonitorEnsemble*> > selection_;
-  SelectionStep<reco::Muon> * MuonStep;
-  SelectionStep<reco::GsfElectron> * ElectronStep;
+  SelectionStep<reco::PFCandidate> * MuonStep;
+  SelectionStep<reco::PFCandidate> * ElectronStep;
   SelectionStep<reco::Vertex> * PvStep;
   SelectionStep<reco::MET> * METStep;
   std::vector<SelectionStep<reco::Jet> * > JetSteps;

--- a/DQM/Physics/src/TopSingleLeptonDQM.cc
+++ b/DQM/Physics/src/TopSingleLeptonDQM.cc
@@ -8,6 +8,7 @@
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/EDConsumerBase.h"
+
 using namespace std;
 namespace TopSingleLepton {
 
@@ -18,37 +19,41 @@ namespace TopSingleLepton {
   // be used for the top mass estimate
   static const double WMASS = 80.4;
 
-  MonitorEnsemble::MonitorEnsemble(const char* label, const edm::ParameterSet& cfg, edm::ConsumesCollector && iC) :
+  MonitorEnsemble::MonitorEnsemble(const char* label, const edm::ParameterSet& cfg, edm::ConsumesCollector && iC) : 
     label_(label), elecIso_(0), elecSelect_(0), pvSelect_(0), muonIso_(0), muonSelect_(0), jetIDSelect_(0), includeBTag_(false), lowerEdge_(-1.), upperEdge_(-1.), logged_(0)
   {
+
     // sources have to be given; this PSet is not optional
     edm::ParameterSet sources=cfg.getParameter<edm::ParameterSet>("sources");
-    muons_ = iC.consumes<edm::View<reco::Muon> >(sources.getParameter<edm::InputTag>("muons"));
-    elecs_ = iC.consumes<edm::View<reco::GsfElectron> >(sources.getParameter<edm::InputTag>("elecs"));
+    muons_ = iC.consumes<edm::View<reco::PFCandidate> >(sources.getParameter<edm::InputTag>("muons"));    
+    elecs_ = iC.consumes<edm::View<reco::PFCandidate> >(sources.getParameter<edm::InputTag>("elecs"));
     pvs_ = iC.consumes<edm::View<reco::Vertex> >(sources.getParameter<edm::InputTag>("pvs"));
     jets_ = iC.consumes<edm::View<reco::Jet> >(sources.getParameter<edm::InputTag>("jets"));
     for (edm::InputTag const & tag : sources.getParameter<std::vector<edm::InputTag> >("mets"))
-	    mets_.push_back( iC.consumes<edm::View<reco::MET> >(tag) );
-    // electronExtras are optional; they may be omitted or
+	    mets_.push_back( iC.consumes<edm::View<reco::MET> >(tag) );	
+    // electronExtras are optional; they may be omitted or 
     // empty
     if( cfg.existsAs<edm::ParameterSet>("elecExtras") ){
+      //rho for PF isolation with EA corrections
+      // eventrhoToken_ = iC.consumes<double>(edm::InputTag("fixedGridRhoFastjetAll"));
+
       edm::ParameterSet elecExtras=cfg.getParameter<edm::ParameterSet>("elecExtras");
       // select is optional; in case it's not found no
       // selection will be applied
       if( elecExtras.existsAs<std::string>("select") ){
-		elecSelect_= new StringCutObjectSelector<reco::GsfElectron>(elecExtras.getParameter<std::string>("select"));
+		elecSelect_= new StringCutObjectSelector<reco::PFCandidate>(elecExtras.getParameter<std::string>("select"));
       }
       // isolation is optional; in case it's not found no
       // isolation will be applied
       if( elecExtras.existsAs<std::string>("isolation") ){
-		elecIso_= new StringCutObjectSelector<reco::GsfElectron>(elecExtras.getParameter<std::string>("isolation"));
+		elecIso_= new StringCutObjectSelector<reco::PFCandidate>(elecExtras.getParameter<std::string>("isolation"));
       }
       // electronId is optional; in case it's not found the
       // InputTag will remain empty
       if( elecExtras.existsAs<edm::ParameterSet>("electronId") ){
 		edm::ParameterSet elecId=elecExtras.getParameter<edm::ParameterSet>("electronId");
 		electronId_= iC.consumes<edm::ValueMap<float> >(elecId.getParameter<edm::InputTag>("src"));
-		eidPattern_= elecId.getParameter<int>("pattern");
+		eidCutValue_= elecId.getParameter<double>("cutValue");
       }
     }
     // pvExtras are opetional; they may be omitted or empty
@@ -66,12 +71,12 @@ namespace TopSingleLepton {
       // select is optional; in case it's not found no
       // selection will be applied
       if( muonExtras.existsAs<std::string>("select") ){
-	muonSelect_= new StringCutObjectSelector<reco::Muon>(muonExtras.getParameter<std::string>("select"));
+	muonSelect_= new StringCutObjectSelector<reco::PFCandidate>(muonExtras.getParameter<std::string>("select"));
       }
       // isolation is optional; in case it's not found no
       // isolation will be applied
       if( muonExtras.existsAs<std::string>("isolation") ){
-	muonIso_= new StringCutObjectSelector<reco::Muon>(muonExtras.getParameter<std::string>("isolation"));
+	muonIso_= new StringCutObjectSelector<reco::PFCandidate>(muonExtras.getParameter<std::string>("isolation"));
       }
     }
 
@@ -188,7 +193,7 @@ namespace TopSingleLepton {
     // W mass estimate
     hists_["massW_"      ] = store_->book1D("MassW"      , "M(W)"             ,     60,     0.,    300.);
     // Top mass estimate
-    hists_["massTop_"    ] = store_->book1D("MassTop"    , "M(Top)"           ,     50,     0.,    500.);
+    hists_["massTop_"    ] = store_->book1D("MassTop"    , "M(Top)"           ,     50,     0.,    500.);   
     // b-tagged Top mass
     hists_["massBTop_"   ] = store_->book1D("MassBTop"   , "M(Top, 1 b-tag)"  ,     50,     0.,    500.);
     // set bin labels for trigger monitoring
@@ -199,30 +204,30 @@ namespace TopSingleLepton {
     // --- [VERBOSE] --- //
     // eta of the leading muon
     hists_["muonEta_"    ] = store_->book1D("MuonEta"    , "#eta(#mu)"        ,     30,    -3.,      3.);
-    // std isolation variable of the leading muon
-    hists_["muonRelIso_" ] = store_->book1D("MuonRelIso" , "Iso_{Rel}(#mu)"   ,     50,     0.,      1.);
+    // relative isolation of the candidate muon (depending on the decay channel)
+    hists_["muonRelIso_"  ] = store_->book1D("MuonRelIso"  , "Iso_{Rel}(#mu) (#Delta#beta Corrected)" , 50, 0.,1.);
     // eta of the leading electron
     hists_["elecEta_"    ] = store_->book1D("ElecEta"    , "#eta(e)"          ,     30,    -3.,      3.);
     // std isolation variable of the leading electron
     hists_["elecRelIso_" ] = store_->book1D("ElecRelIso" , "Iso_{Rel}(e)"     ,     50,     0.,      1.);
     // multiplicity of btagged jets (for track counting high efficiency) with pt(L2L3)>30
-    hists_["jetMultBEff_"] = store_->book1D("JetMultBEff", "N_{30}(TCHE)"    ,     10,     0.,     10.);
+    hists_["jetMultBEff_"] = store_->book1D("JetMultBEff", "N_{30}(TCHE)"    ,     10,     0.,     10.);   
     // btag discriminator for track counting high efficiency for jets with pt(L2L3)>30
-    hists_["jetBDiscEff_"] = store_->book1D("JetBDiscEff", "Disc_{TCHE}(jet)",     100,     0.,    10.);
+    hists_["jetBDiscEff_"] = store_->book1D("JetBDiscEff", "Disc_{TCHE}(jet)",     100,     0.,    10.);   
     // eta of the 1. leading jet (corrected to L2+L3)
-    hists_["jet1Eta_"    ] = store_->book1D("Jet1Eta"    , "#eta_{L2L3}(jet1)",     60,     -3.,     3.);
+    hists_["jet1Eta_"    ] = store_->book1D("Jet1Eta"    , "#eta_{L2L3}(jet1)",     60,     -3.,     3.);   
     // pt of the 1. leading jet (corrected to L2+L3)
-    hists_["jet1Pt_"     ] = store_->book1D("Jet1Pt"     , "pt_{L2L3}(jet1)"  ,     60,     0.,    300.);
-   // eta of the 2. leading jet (corrected to L2+L3)
-    hists_["jet2Eta_"    ] = store_->book1D("Jet2Eta"    , "#eta_{L2L3}(jet2)",     60,     -3.,     3.);
+    hists_["jet1Pt_"     ] = store_->book1D("Jet1Pt"     , "pt_{L2L3}(jet1)"  ,     60,     0.,    300.);   
+    // eta of the 2. leading jet (corrected to L2+L3)
+    hists_["jet2Eta_"    ] = store_->book1D("Jet2Eta"    , "#eta_{L2L3}(jet2)",     60,     -3.,     3.);   
     // pt of the 2. leading jet (corrected to L2+L3)
-    hists_["jet2Pt_"     ] = store_->book1D("Jet2Pt"     , "pt_{L2L3}(jet2)"  ,     60,     0.,    300.);
-   // eta of the 3. leading jet (corrected to L2+L3)
-    hists_["jet3Eta_"    ] = store_->book1D("Jet3Eta"    , "#eta_{L2L3}(jet3)",     60,     -3.,     3.);
+    hists_["jet2Pt_"     ] = store_->book1D("Jet2Pt"     , "pt_{L2L3}(jet2)"  ,     60,     0.,    300.);   
+    // eta of the 3. leading jet (corrected to L2+L3)
+    hists_["jet3Eta_"    ] = store_->book1D("Jet3Eta"    , "#eta_{L2L3}(jet3)",     60,     -3.,     3.);   
     // pt of the 3. leading jet (corrected to L2+L3)
-    hists_["jet3Pt_"     ] = store_->book1D("Jet3Pt"     , "pt_{L2L3}(jet3)"  ,     60,     0.,    300.);
-   // eta of the 4. leading jet (corrected to L2+L3)
-    hists_["jet4Eta_"    ] = store_->book1D("Jet4Eta"    , "#eta_{L2L3}(jet4)",     60,     -3.,     3.);
+    hists_["jet3Pt_"     ] = store_->book1D("Jet3Pt"     , "pt_{L2L3}(jet3)"  ,     60,     0.,    300.);   
+    // eta of the 4. leading jet (corrected to L2+L3)
+    hists_["jet4Eta_"    ] = store_->book1D("Jet4Eta"    , "#eta_{L2L3}(jet4)",     60,     -3.,     3.);   
     // pt of the 4. leading jet (corrected to L2+L3)
     hists_["jet4Pt_"     ] = store_->book1D("Jet4Pt"     , "pt_{L2L3}(jet4)"  ,     60,     0.,    300.);
     // MET (tc)
@@ -240,22 +245,30 @@ namespace TopSingleLepton {
     if( verbosity_==VERBOSE) return;
 
     // --- [DEBUG] --- //
-    // relative muon isolation in tracker for the leading muon
-    hists_["muonTrkIso_" ] = store_->book1D("MuonTrkIso" , "Iso_{Trk}(#mu)"   ,     50,     0.,      1.);
-    // relative muon isolation in ecal+hcal for the leading muon
-    hists_["muonCalIso_" ] = store_->book1D("MuonCalIso" , "Iso_{Ecal}(#mu)"  ,     50,     0.,      1.);
+    // charged hadron isolation component of the candidate muon (depending on the decay channel)
+    hists_["muonChHadIso_"] = store_->book1D("MuonChHadIsoComp"  , "ChHad_{IsoComponent}(#mu)" ,       50, 0., 5.);
+    // neutral hadron isolation component of the candidate muon (depending on the decay channel)
+    hists_["muonNeHadIso_"] = store_->book1D("MuonNeHadIsoComp"  , "NeHad_{IsoComponent}(#mu)" ,       50, 0., 5.);
+    // photon isolation component of the candidate muon (depending on the decay channel)
+    hists_["muonPhIso_"   ] = store_->book1D("MuonPhIsoComp"  , "Photon_{IsoComponent}(#mu)"   ,       50, 0., 5.);
+    // charged hadron isolation component of the candidate electron (depending on the decay channel)
+    hists_["elecChHadIso_"] = store_->book1D("ElectronChHadIsoComp"  , "ChHad_{IsoComponent}(e)" ,       50, 0., 5.);
+    // neutral hadron isolation component of the candidate electron (depending on the decay channel)
+    hists_["elecNeHadIso_"] = store_->book1D("ElectronNeHadIsoComp"  , "NeHad_{IsoComponent}(e)" ,       50, 0., 5.);
+    // photon isolation component of the candidate electron (depending on the decay channel)
+    hists_["elecPhIso_"   ] = store_->book1D("ElectronPhIsoComp"  , "Photon_{IsoComponent}(e)"   ,       50, 0., 5.);
     // relative electron isolation in tracker for the leading electron
-    hists_["elecTrkIso_" ] = store_->book1D("ElecTrkIso" , "Iso_{Trk}(e)"     ,     50,     0.,      1.);
+    //hists_["elecTrkIso_" ] = store_->book1D("ElecTrkIso" , "Iso_{Trk}(e)"     ,     50,     0.,      1.);
     // relative electron isolation in ecal+hcal for the leading electron
-    hists_["elecCalIso_" ] = store_->book1D("ElecCalIso" , "Iso_{Ecal}(e)"    ,     50,     0.,      1.);
+    //hists_["elecCalIso_" ] = store_->book1D("ElecCalIso" , "Iso_{Ecal}(e)"    ,     50,     0.,      1.);
     // multiplicity of btagged jets (for track counting high purity) with pt(L2L3)>30
-    hists_["jetMultBPur_"] = store_->book1D("JetMultBPur", "N_{30}(TCHP)"    ,     10,     0.,     10.);
+    hists_["jetMultBPur_"] = store_->book1D("JetMultBPur", "N_{30}(TCHP)"    ,     10,     0.,     10.);   
     // btag discriminator for track counting high purity
-    hists_["jetBDiscPur_"] = store_->book1D("JetBDiscPur", "Disc_{TCHP}(Jet)",    100,     0.,    10.);
+    hists_["jetBDiscPur_"] = store_->book1D("JetBDiscPur", "Disc_{TCHP}(Jet)",    100,     0.,    10.);   
     // multiplicity of btagged jets (for simple secondary vertex) with pt(L2L3)>30
-    hists_["jetMultBVtx_"] = store_->book1D("JetMultBVtx", "N_{30}(SSVHE)"    ,    10,     0.,     10.);
+    hists_["jetMultBVtx_"] = store_->book1D("JetMultBVtx", "N_{30}(SSVHE)"    ,    10,     0.,     10.);   
     // btag discriminator for simple secondary vertex
-    hists_["jetBDiscVtx_"] = store_->book1D("JetBDiscVtx", "Disc_{SSVHE}(Jet)",    35,    -1.,      6.);
+    hists_["jetBDiscVtx_"] = store_->book1D("JetBDiscVtx", "Disc_{SSVHE}(Jet)",    35,    -1.,      6.);   
     // multiplicity for combined secondary vertex
     hists_["jetMultCSVtx_"]= store_->book1D("JetMultCSV" , "N_{30}(CSV)"     ,      10,     0.,     10.);
     // btag discriminator for combined secondary vertex
@@ -291,7 +304,7 @@ namespace TopSingleLepton {
   {
     // fetch trigger event if configured such
     edm::Handle<edm::TriggerResults> triggerTable;
-
+     
     if(!triggerTable_.isUninitialized()) {
             if( !event.getByToken(triggerTable_, triggerTable) ) return;
     }
@@ -316,18 +329,18 @@ namespace TopSingleLepton {
 
     /*
     ------------------------------------------------------------
-
+    
     Run and Inst. Luminosity information (Inst. Lumi. filled now with a dummy value=5.0)
-
+    
     ------------------------------------------------------------
     */
     if (!event.eventAuxiliary().run()) return;
-    fill("RunNumb_", event.eventAuxiliary().run());
-
+    fill("RunNumb_", event.eventAuxiliary().run());   
+    
     double dummy=5.; fill("InstLumi_", dummy);
+     
 
-
-    /*
+    /* 
     ------------------------------------------------------------
 
     Electron Monitoring
@@ -335,37 +348,50 @@ namespace TopSingleLepton {
     ------------------------------------------------------------
     */
 
+    //fill rho for EA corrections
+    //edm::Handle<double> rho_;
+    //if( !event.getByToken(eventrhoToken_,rho_) ) return;
+    //double rho = *(rho_.product()); 
+
     // fill monitoring plots for electrons
-    edm::Handle<edm::View<reco::GsfElectron> > elecs;
+    edm::Handle<edm::View<reco::PFCandidate> > elecs;
     if( !event.getByToken(elecs_, elecs) ) return;
 
     // check availability of electron id
-    edm::Handle<edm::ValueMap<float> > electronId;
+    edm::Handle<edm::ValueMap<float> > electronId; 
     if(!electronId_.isUninitialized()) {
       if( !event.getByToken(electronId_, electronId) ) return;
     }
 
     // loop electron collection
     unsigned int eMult=0, eMultIso=0;
-    std::vector<const reco::GsfElectron*> isoElecs;
-    for(edm::View<reco::GsfElectron>::const_iterator elec=elecs->begin(); elec!=elecs->end(); ++elec){
-      unsigned int idx = elec-elecs->begin();
+    std::vector<const reco::PFCandidate*> isoElecs;
+    for(edm::View<reco::PFCandidate>::const_iterator elec=elecs->begin(); elec!=elecs->end(); ++elec){
+      if(elec->gsfElectronRef().isNull()){ continue ;}
+      reco::GsfElectronRef gsf_el = elec->gsfElectronRef();
       // restrict to electrons with good electronId
-      if( electronId_.isUninitialized() ? true : ((int)(*electronId)[elecs->refAt(idx)] & eidPattern_) ){
+      if( electronId_.isUninitialized() ? true : ((double)(*electronId)[gsf_el] >= eidCutValue_) ){
 	if(!elecSelect_ || (*elecSelect_)(*elec)){
-	  double isolationTrk = elec->pt()/(elec->pt()+elec->dr03TkSumPt());
-	  double isolationCal = elec->pt()/(elec->pt()+elec->dr03EcalRecHitSumEt()+elec->dr03HcalTowerSumEt());
-	  double isolationRel = (elec->dr03TkSumPt()+elec->dr03EcalRecHitSumEt()+elec->dr03HcalTowerSumEt())/elec->pt();
+
+	  //	  double isolationTrk = elec->pt()/(elec->pt()+elec->dr03TkSumPt());
+	  //	  double isolationCal = elec->pt()/(elec->pt()+elec->dr03EcalRecHitSumEt()+elec->dr03HcalTowerSumEt());
+	  //	  double isolationRel = (elec->dr03TkSumPt()+elec->dr03EcalRecHitSumEt()+elec->dr03HcalTowerSumEt())/elec->pt();
+	  double el_ChHadIso = gsf_el->pfIsolationVariables().sumChargedHadronPt;
+	  double el_NeHadIso = gsf_el->pfIsolationVariables().sumNeutralHadronEt;
+	  double el_PhIso = gsf_el->pfIsolationVariables().sumPhotonEt;
+	  double el_pfRelIso = (el_ChHadIso + max(0.,el_NeHadIso + el_PhIso - 0.5*gsf_el->pfIsolationVariables().sumPUPt) ) / gsf_el->pt();
 	  if( eMult==0 ){
 	    // restrict to the leading electron
 	    fill("elecPt_" , elec->pt() );
 	    fill("elecEta_", elec->eta());
-	    fill("elecRelIso_" , isolationRel );
-	    fill("elecTrkIso_" , isolationTrk );
-	    fill("elecCalIso_" , isolationCal );
+	    fill("elecRelIso_" , el_pfRelIso );
+	    fill("elecChHadIso_" , el_ChHadIso );
+	    fill("elecNeHadIso_" , el_NeHadIso );
+	    fill("elecPhIso_" , el_PhIso );
 	  }
 	  // in addition to the multiplicity counter buffer the iso
 	  // electron candidates for later overlap check with jets
+	  //  double Aeff = 1.;
 	  ++eMult; if(!elecIso_ || (*elecIso_)(*elec)){ isoElecs.push_back(&(*elec)); ++eMultIso;}
 	}
       }
@@ -384,28 +410,42 @@ namespace TopSingleLepton {
     // fill monitoring plots for muons
     unsigned int mMult=0, mMultIso=0;
 
-    edm::Handle<edm::View<reco::Muon> > muons;
-    if( !event.getByToken(muons_, muons) ) return;
+    edm::Handle<edm::View<reco::PFCandidate> > muons;
+    edm::View<reco::PFCandidate>::const_iterator muonit;
 
-    for(edm::View<reco::Muon>::const_iterator muon=muons->begin(); muon!=muons->end(); ++muon){
+    if( !event.getByToken(muons_, muons )) return;
+
+    for(edm::View<reco::PFCandidate>::const_iterator muonit = muons->begin(); muonit != muons->end(); ++muonit){ 
+      
+      if(muonit->muonRef().isNull()) continue ;
+      reco::MuonRef muon = muonit->muonRef();
+
       // restrict to globalMuons
       if( muon->isGlobalMuon() ){
-	fill("muonDelZ_" , muon->globalTrack()->vz());
-	fill("muonDelXY_", muon->globalTrack()->vx(), muon->globalTrack()->vy());
-	// apply preselection
-	if(!muonSelect_ || (*muonSelect_)(*muon)){
-	  double isolationTrk = muon->pt()/(muon->pt()+muon->isolationR03().sumPt);
-	  double isolationCal = muon->pt()/(muon->pt()+muon->isolationR03().emEt+muon->isolationR03().hadEt);
-	  double isolationRel = (muon->isolationR03().sumPt+muon->isolationR03().emEt+muon->isolationR03().hadEt)/muon->pt();
+	fill("muonDelZ_" , muon->innerTrack()->vz());                            // CB using inner track!
+	fill("muonDelXY_", muon->innerTrack()->vx(), muon->innerTrack()->vy());
+
+ 	// apply preselection
+	if(!muonSelect_ || (*muonSelect_)(*muonit)){
+
+	  double chHadPt = muon->pfIsolationR04().sumChargedHadronPt; 
+	  double neHadEt = muon->pfIsolationR04().sumNeutralHadronEt;
+	  double phoEt   = muon->pfIsolationR04().sumPhotonEt; 
+
+	  double pfRelIso = (chHadPt + max(0.,neHadEt + phoEt - 0.5*muon->pfIsolationR04().sumPUPt) ) / muon->pt();      // CB dBeta corrected iso!
+
 	  if( mMult==0 ){
 	    // restrict to leading muon
 	    fill("muonPt_"     , muon->pt() );
 	    fill("muonEta_"    , muon->eta());
-	    fill("muonRelIso_" , isolationRel );
-	    fill("muonTrkIso_" , isolationTrk );
-	    fill("muonCalIso_" , isolationCal );
+
+	    fill("muonRelIso_" , pfRelIso);
+	    
+	    fill("muonChHadIso_",chHadPt);
+	    fill("muonNeHadIso_",neHadEt);
+	    fill("muonPhIso_"   ,phoEt);
 	  }
-	   ++mMult; if(!muonIso_ || (*muonIso_)(*muon)) ++mMultIso;
+	   ++mMult; if(!muonIso_ || (*muonIso_)(*muonit)) ++mMultIso;
 	}
       }
     }
@@ -422,7 +462,7 @@ namespace TopSingleLepton {
 
     // check availability of the btaggers
     edm::Handle<reco::JetTagCollection> btagEff, btagPur, btagVtx, btagCSV;
-    if( includeBTag_ ){
+    if( includeBTag_ ){ 
       if( !event.getByToken(btagEff_, btagEff) ) return;
       if( !event.getByToken(btagPur_, btagPur) ) return;
       if( !event.getByToken(btagVtx_, btagVtx) ) return;
@@ -445,7 +485,7 @@ namespace TopSingleLepton {
 	  << "                                                                                      \n"
 	  << "  ## load jet corrections                                                             \n"
 	  << "  process.load(\"JetMETCorrections.Configuration.JetCorrectionServicesAllAlgos_cff\") \n"
-	  << "  process.prefer(\"ak4CaloL2L3\")                                                     \n"
+	  << "  process.prefer(\"ak5CaloL2L3\")                                                     \n"
 	  << "                                                                                      \n"
 	  << "------------------------------------------------------------------------------------- \n";
       }
@@ -455,15 +495,15 @@ namespace TopSingleLepton {
     std::vector<reco::Jet> correctedJets;
     std::vector<double> JetTagValues;
     unsigned int mult=0, multBEff=0, multBPur=0, multBVtx=0, multCSV=0;
-
-    edm::Handle<edm::View<reco::Jet> > jets;
+    
+    edm::Handle<edm::View<reco::Jet> > jets; 
     if( !event.getByToken(jets_, jets) ) {
 	//cout<<"event does not contain "<<jets_.label()<<endl;
 	return;
      }
 
-    edm::Handle<reco::JetIDValueMap> jetID;
-    if(jetIDSelect_){
+    edm::Handle<reco::JetIDValueMap> jetID; 
+    if(jetIDSelect_){ 
       if( !event.getByToken(jetIDLabel_, jetID) ) return;
     }
 
@@ -488,7 +528,7 @@ namespace TopSingleLepton {
       }
       // check for overlaps -- comment this to be synchronous with the selection
       //bool overlap=false;
-      //for(std::vector<const reco::GsfElectron*>::const_iterator elec=isoElecs.begin(); elec!=isoElecs.end(); ++elec){
+      //for(std::vector<const reco::PFCandidate*>::const_iterator elec=isoElecs.begin(); elec!=isoElecs.end(); ++elec){
       //  if(reco::deltaR((*elec)->eta(), (*elec)->phi(), jet->eta(), jet->phi())<0.4){overlap=true; break;}
       //} if(overlap){continue;}
 
@@ -499,15 +539,15 @@ namespace TopSingleLepton {
       if( includeBTag_ ){
 	// fill b-discriminators
 	edm::RefToBase<reco::Jet> jetRef = jets->refAt(idx);
-	fill("jetBDiscEff_", (*btagEff)[jetRef]); if( (*btagEff)[jetRef]>btagEffWP_ ) ++multBEff;
-	fill("jetBDiscPur_", (*btagPur)[jetRef]); if( (*btagPur)[jetRef]>btagPurWP_ ) ++multBPur;
-	fill("jetBDiscVtx_", (*btagVtx)[jetRef]); if( (*btagVtx)[jetRef]>btagVtxWP_ ) ++multBVtx;
+	fill("jetBDiscEff_", (*btagEff)[jetRef]); if( (*btagEff)[jetRef]>btagEffWP_ ) ++multBEff; 
+	fill("jetBDiscPur_", (*btagPur)[jetRef]); if( (*btagPur)[jetRef]>btagPurWP_ ) ++multBPur; 
+	fill("jetBDiscVtx_", (*btagVtx)[jetRef]); if( (*btagVtx)[jetRef]>btagVtxWP_ ) ++multBVtx; 
         fill("jetBCVtx_"   , (*btagCSV)[jetRef]); if( (*btagCSV)[jetRef]>btagCSVWP_ ) ++multCSV;
-
+        
         //Fill a vector with Jet b-tag WP for later M3+1tag calculation: CSV tagger
         JetTagValues.push_back( (*btagCSV)[jetRef]);
       }
-      // fill pt (raw or L2L3) for the leading four jets
+      // fill pt (raw or L2L3) for the leading four jets  
       if(idx==0) {fill("jet1Pt_" , monitorJet.pt()); fill("jet1PtRaw_", jet->pt() );
                   fill("jet1Eta_", monitorJet.eta());
 		 };
@@ -526,8 +566,8 @@ namespace TopSingleLepton {
     fill("jetMultBPur_" , multBPur);
     fill("jetMultBVtx_" , multBVtx);
     fill("jetMultCSVtx_", multCSV );
-
-    /*
+    
+    /* 
     ------------------------------------------------------------
 
     MET Monitoring
@@ -556,19 +596,19 @@ namespace TopSingleLepton {
     */
 
     // fill W boson and top mass estimates
-
+    
     Calculate eventKinematics(MAXJETS, WMASS);
     double wMass   = eventKinematics.massWBoson   (correctedJets);
     double topMass = eventKinematics.massTopQuark (correctedJets);
     if(wMass>=0 && topMass>=0 ) {fill("massW_" ,   wMass  );fill("massTop_" , topMass);}
-
+    
     // Fill M3 with Btag (CSV Tight) requirement
-
+    
     if (!includeBTag_) return;
     if (correctedJets.size() != JetTagValues.size()) return;
     double btopMass= eventKinematics.massBTopQuark(correctedJets, JetTagValues, btagCSVWP_);
     if (btopMass>=0) fill("massBTop_", btopMass);
-
+    
     // fill plots for trigger monitoring
     if((lowerEdge_==-1. && upperEdge_==-1.) || (lowerEdge_<wMass && wMass<upperEdge_) ){
       if(!triggerTable_.isUninitialized()) fill(event, *triggerTable, "trigger", triggerPaths_);
@@ -593,7 +633,7 @@ namespace TopSingleLepton {
 
 
 TopSingleLeptonDQM::TopSingleLeptonDQM(const edm::ParameterSet& cfg): vertexSelect_(0), beamspot_(""), beamspotSelect_(0),
-  MuonStep(0), ElectronStep(0), PvStep(0), METStep(0)
+  MuonStep(0), ElectronStep(0), PvStep(0), METStep(0) 
 {
   JetSteps.clear();
   CaloJetSteps.clear();
@@ -604,7 +644,7 @@ TopSingleLeptonDQM::TopSingleLeptonDQM(const edm::ParameterSet& cfg): vertexSele
     edm::ParameterSet trigger=presel.getParameter<edm::ParameterSet>("trigger");
     triggerTable__ = consumes<edm::TriggerResults>(trigger.getParameter<edm::InputTag>("src"));
     triggerPaths_=trigger.getParameter<std::vector<std::string> >("select");
-  }
+  } 
   /*if( presel.existsAs<edm::ParameterSet>("vertex" ) ){
     edm::ParameterSet vertex=presel.getParameter<edm::ParameterSet>("vertex");
     vertex_= vertex.getParameter<edm::InputTag>("src");
@@ -627,10 +667,10 @@ TopSingleLeptonDQM::TopSingleLeptonDQM(const edm::ParameterSet& cfg): vertexSele
     std::string key = selectionStep(*selIt), type = objectType(*selIt);
     if(selection_.find(key)!=selection_.end()){
       if(type=="muons"){
-		MuonStep = new SelectionStep<reco::Muon>(selection_[key].first, consumesCollector());
-      }
+		MuonStep = new SelectionStep<reco::PFCandidate>(selection_[key].first, consumesCollector());
+      } 
       if(type=="elecs"){
-      		ElectronStep = new SelectionStep<reco::GsfElectron>(selection_[key].first, consumesCollector());
+      		ElectronStep = new SelectionStep<reco::PFCandidate>(selection_[key].first, consumesCollector());
       }
       if(type=="pvs"){
       		PvStep = new SelectionStep<reco::Vertex>(selection_[key].first, consumesCollector());
@@ -646,17 +686,18 @@ TopSingleLeptonDQM::TopSingleLeptonDQM(const edm::ParameterSet& cfg): vertexSele
       }
       if(type=="met"){
 		METStep = new SelectionStep<reco::MET>(selection_[key].first, consumesCollector());
-      }
+      } 
     }
   }
 }
 
 void
 TopSingleLeptonDQM::analyze(const edm::Event& event, const edm::EventSetup& setup)
-{
+{ 
+
   if(!triggerTable__.isUninitialized() ){
     edm::Handle<edm::TriggerResults> triggerTable;
-    if(!event.getByToken(triggerTable__, triggerTable)) return;
+    if(!event.getByToken(triggerTable__, triggerTable)) return;	
     if(!accept(event, *triggerTable, triggerPaths_)) return;
   }
   if(!beamspot__.isUninitialized()){
@@ -664,7 +705,7 @@ TopSingleLeptonDQM::analyze(const edm::Event& event, const edm::EventSetup& setu
     if( !event.getByToken(beamspot__, beamspot) ) return;
     if(!(*beamspotSelect_)(*beamspot)) return;
   }
-  //cout<<" apply selection steps"<<endl;
+//  cout<<" apply selection steps"<<endl;
   unsigned int passed=0;
   unsigned int nJetSteps = -1;
   unsigned int nPFJetSteps = -1;
@@ -676,7 +717,6 @@ TopSingleLeptonDQM::analyze(const edm::Event& event, const edm::EventSetup& setu
 	selection_[key].second->fill(event, setup);
       }
       if(type=="muons" && MuonStep != 0){
-//	SelectionStep<reco::Muon> step(selection_[key].first, consumesCollector());
 	if(MuonStep->select(event)){ ++passed;
     //      cout<<"selected event! "<<selection_[key].second<<endl;
 	  selection_[key].second->fill(event, setup);
@@ -684,7 +724,8 @@ TopSingleLeptonDQM::analyze(const edm::Event& event, const edm::EventSetup& setu
       }
       //cout<<" apply selection steps 2"<<endl;
       if(type=="elecs" && ElectronStep != 0){
-	if(ElectronStep->select(event)){ ++passed;
+	//cout<<"In electrons ..."<<endl;
+	if(ElectronStep->select(event,"electron")){ ++passed;
 	  selection_[key].second->fill(event, setup);
 	} else break;
       }

--- a/DQM/Physics/src/TopSingleLeptonDQM.h
+++ b/DQM/Physics/src/TopSingleLeptonDQM.h
@@ -10,9 +10,9 @@
 
 #include "DataFormats/JetReco/interface/Jet.h"
 #include "DQM/Physics/interface/TopDQMHelpers.h"
-#include "DataFormats/MuonReco/interface/Muon.h"
 #include "DataFormats/Common/interface/ValueMap.h"
 #include "DataFormats/METReco/interface/CaloMET.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "JetMETCorrections/Objects/interface/JetCorrector.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
@@ -85,8 +85,8 @@ namespace TopSingleLepton {
     std::vector<edm::EDGetTokenT<edm::View<reco::MET> > > mets_;
     /// input sources for monitoring
     edm::EDGetTokenT<edm::View<reco::Jet> >  jets_; 
-    edm::EDGetTokenT<edm::View<reco::Muon> > muons_;
-    edm::EDGetTokenT<edm::View<reco::GsfElectron> > elecs_;
+    edm::EDGetTokenT<edm::View<reco::PFCandidate> > muons_;
+    edm::EDGetTokenT<edm::View<reco::PFCandidate> > elecs_;
     edm::EDGetTokenT<edm::View<reco::Vertex> > pvs_;
     /// trigger table
     edm::EDGetTokenT<edm::TriggerResults> triggerTable_;
@@ -106,19 +106,24 @@ namespace TopSingleLepton {
     ///  6: passes conversion rejection and Isolation
     ///  7: passes the whole selection
     /// As described on https://twiki.cern.ch/twiki/bin/view/CMS/SimpleCutBasedEleID
-    int eidPattern_;
+    //int eidPattern_;
+    //the cut for the MVA Id
+    double eidCutValue_;
+    //rho for PF Isolation with EA corrections
+    //edm::EDGetTokenT<double> eventrhoToken_;
     /// extra isolation criterion on electron
-    StringCutObjectSelector<reco::GsfElectron>* elecIso_;
+    StringCutObjectSelector<reco::PFCandidate>* elecIso_;
     /// extra selection on electrons
-    StringCutObjectSelector<reco::GsfElectron>* elecSelect_;
+    StringCutObjectSelector<reco::PFCandidate>* elecSelect_;
 
     /// extra selection on primary vertices; meant to investigate the pile-up effect
     StringCutObjectSelector<reco::Vertex>* pvSelect_;
 
     /// extra isolation criterion on muon
-    StringCutObjectSelector<reco::Muon>* muonIso_;
+    StringCutObjectSelector<reco::PFCandidate>* muonIso_;
+    
     /// extra selection on muons
-    StringCutObjectSelector<reco::Muon>* muonSelect_;
+    StringCutObjectSelector<reco::PFCandidate>* muonSelect_;
 
     /// jetCorrector
     std::string jetCorrector_;
@@ -201,8 +206,8 @@ namespace TopSingleLepton {
    MonitorEnsemble class. The following objects are supported for selection:
 
     - jets  : of type reco::Jet (jets), reco::CaloJet (jets/calo) or reco::PFJet (jets/pflow)
-    - elecs : of type reco::GsfElectron
-    - muons : of type reco::Muon
+    - elecs : of type reco::PFCandidate
+    - muons : of type reco::PFCandidate
     - met   : of type reco::MET
 
    These types have to be present as prefix of the selection step paramter _label_ separated
@@ -272,8 +277,8 @@ class TopSingleLeptonDQM : public edm::EDAnalyzer  {
   /// MonitoringEnsemble keeps an instance of the MonitorEnsemble class to
   /// be filled _after_ each selection step
   std::map<std::string, std::pair<edm::ParameterSet, TopSingleLepton::MonitorEnsemble*> > selection_;
-  SelectionStep<reco::Muon> * MuonStep;
-  SelectionStep<reco::GsfElectron> * ElectronStep;
+  SelectionStep<reco::PFCandidate> * MuonStep;
+  SelectionStep<reco::PFCandidate> * ElectronStep;
   SelectionStep<reco::Vertex> * PvStep;
   SelectionStep<reco::MET> * METStep;
   std::vector<SelectionStep<reco::Jet> * > JetSteps;

--- a/DQM/Physics/test/topDQM_production_cfg.py
+++ b/DQM/Physics/test/topDQM_production_cfg.py
@@ -67,8 +67,8 @@ process.output = cms.OutputModule("PoolOutputModule",
 )
 
 ## load jet corrections
-process.load("JetMETCorrections.Configuration.JetCorrectionServicesAllAlgos_cff")
-process.prefer("ak4PFL2L3")
+#process.load("JetMETCorrections.Configuration.JetCorrectionServicesAllAlgos_cff")
+#process.prefer("ak4PFL2L3")
 
 ## check the event content
 process.content = cms.EDAnalyzer("EventContentAnalyzer")


### PR DESCRIPTION
This includes the following:
- move to EI 
- temporary solution for the "algorithm" name for Ak5CHSJets in corrections
- ak5 corrections to be applied to ak4 jets (temporary)
- tests 1,2,11,12,4,9 are checked and they were OK
