### PR TITLE
Fix a bunch of clang warnings.

### DIFF
--- a/CommonTools/Utils/interface/OrSelector.h
+++ b/CommonTools/Utils/interface/OrSelector.h
@@ -1,5 +1,5 @@
 #ifndef CommonTools_Utils_OrSelector_h
-#define CommonTools_Utils__OrSelector_h
+#define CommonTools_Utils_OrSelector_h
 /* \class OrSelector
  *
  * \author Luca Lista, INFN

--- a/CommonTools/Utils/src/ExpressionBase.h
+++ b/CommonTools/Utils/src/ExpressionBase.h
@@ -7,8 +7,6 @@
  * \author original version: Chris Jones, Cornell, 
  *         adapted by Luca Lista, INFN
  *
- * \version $Revision: 1.2 $
- *
  */
 #include <boost/shared_ptr.hpp>
 #include <vector>

--- a/CommonTools/Utils/src/ExpressionPtr.h
+++ b/CommonTools/Utils/src/ExpressionPtr.h
@@ -13,7 +13,7 @@
 
 namespace reco {
   namespace parser {
-    class ExpressionBase;
+    struct ExpressionBase;
     typedef boost::shared_ptr<ExpressionBase> ExpressionPtr;
   }
 }


### PR DESCRIPTION
- Using struct consistently for ExpressionBase.
- Correct guard name.
