### PR TITLE
removed unnecessary mutables from CondFormats/L1TObjects

### DIFF
--- a/CondFormats/L1TObjects/interface/L1GtTriggerMenu.h
+++ b/CondFormats/L1TObjects/interface/L1GtTriggerMenu.h
@@ -272,7 +272,7 @@ public:
 private:
 
     /// map containing the conditions (per condition chip) - transient
-    mutable std::vector<ConditionMap> m_conditionMap COND_TRANSIENT;
+    std::vector<ConditionMap> m_conditionMap COND_TRANSIENT;
 
 private:
 

--- a/L1Trigger/L1TGlobal/interface/TriggerMenu.h
+++ b/L1Trigger/L1TGlobal/interface/TriggerMenu.h
@@ -270,7 +270,7 @@ public:
 private:
 
     /// map containing the conditions (per condition chip) - transient
-    mutable std::vector<l1t::ConditionMap> m_conditionMap;
+    std::vector<l1t::ConditionMap> m_conditionMap;
 
 private:
 


### PR DESCRIPTION
The mutables were being flagged by the static analyzer as thread
safety issues. Turns out the mutables were not needed since no
const member functions ever modified the values.
