### PR TITLE
T rugg ribbon

### DIFF
--- a/Geometry/TrackerCommonData/data/flat10percent/tibtidcommonmaterial.xml
+++ b/Geometry/TrackerCommonData/data/flat10percent/tibtidcommonmaterial.xml
@@ -67,7 +67,7 @@
         <rMaterial name="materials:Polyethylene" />
       </MaterialFraction>
     </CompositeMaterial>
-    <CompositeMaterial name="T_RuggRibbon" density="0.926332*g/cm3" method="mixture by weight" pork="true" symbol=" ">
+    <CompositeMaterial name="TIBTID_T_RuggRibbon" density="0.926332*g/cm3" method="mixture by weight" pork="true" symbol=" ">
       <MaterialFraction fraction="0.67168">
         <rMaterial name="materials:Polyethylene" />
       </MaterialFraction>
@@ -239,7 +239,7 @@
     </CompositeMaterial>
     <CompositeMaterial name="TIBTID_OptoPanelFront" density="0.061248*g/cm3" method="mixture by weight" pork="true" symbol=" ">
       <MaterialFraction fraction="0.8808">
-        <rMaterial name="tibtidcommonmaterial:T_RuggRibbon" />
+        <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon" />
       </MaterialFraction>
       <MaterialFraction fraction="0.08973">
         <rMaterial name="trackermaterial:T_Aluminium" />
@@ -284,7 +284,7 @@
         <rMaterial name="trackermaterial:T_FR4" />
       </MaterialFraction>
       <MaterialFraction fraction="0.20893">
-        <rMaterial name="tibtidcommonmaterial:T_RuggRibbon" />
+        <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon" />
       </MaterialFraction>
       <MaterialFraction fraction="0.58144">
         <rMaterial name="tibtidcommonmaterial:T_FiberPigtail" />
@@ -362,7 +362,7 @@
         <rMaterial name="tibtidcommonmaterial:T_Cu10mmPipe" />
       </MaterialFraction>
       <MaterialFraction fraction="0.0472998518237542">
-        <rMaterial name="tibtidcommonmaterial:T_RuggRibbon" />
+        <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon" />
       </MaterialFraction>
       <MaterialFraction fraction="0.00355998884762293">
         <rMaterial name="trackermaterial:T_Copper" />
@@ -382,7 +382,7 @@
         <rMaterial name="tibtidcommonmaterial:T_Cu10mmPipe" />
       </MaterialFraction>
       <MaterialFraction fraction="0.0572197614737023">
-        <rMaterial name="tibtidcommonmaterial:T_RuggRibbon" />
+        <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon" />
       </MaterialFraction>
     </CompositeMaterial>
     <CompositeMaterial name="TIBTID_PA" density="3.024758*g/cm3" method="mixture by weight" pork="true" symbol=" ">

--- a/Geometry/TrackerCommonData/data/flat10services30percent/tibtidcommonmaterial.xml
+++ b/Geometry/TrackerCommonData/data/flat10services30percent/tibtidcommonmaterial.xml
@@ -67,7 +67,7 @@
         <rMaterial name="materials:Polyethylene" />
       </MaterialFraction>
     </CompositeMaterial>
-    <CompositeMaterial name="T_RuggRibbon" density="0.926332*g/cm3" method="mixture by weight" pork="true" symbol=" ">
+    <CompositeMaterial name="TIBTID_T_RuggRibbon" density="0.926332*g/cm3" method="mixture by weight" pork="true" symbol=" ">
       <MaterialFraction fraction="0.67168">
         <rMaterial name="materials:Polyethylene" />
       </MaterialFraction>
@@ -239,7 +239,7 @@
     </CompositeMaterial>
     <CompositeMaterial name="TIBTID_OptoPanelFront" density="0.0723951360000001*g/cm3" method="mixture by weight" pork="true" symbol=" ">
       <MaterialFraction fraction="0.8808">
-        <rMaterial name="tibtidcommonmaterial:T_RuggRibbon" />
+        <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon" />
       </MaterialFraction>
       <MaterialFraction fraction="0.08973">
         <rMaterial name="trackermaterial:T_Aluminium" />
@@ -284,7 +284,7 @@
         <rMaterial name="trackermaterial:T_FR4" />
       </MaterialFraction>
       <MaterialFraction fraction="0.20893">
-        <rMaterial name="tibtidcommonmaterial:T_RuggRibbon" />
+        <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon" />
       </MaterialFraction>
       <MaterialFraction fraction="0.58144">
         <rMaterial name="tibtidcommonmaterial:T_FiberPigtail" />
@@ -362,7 +362,7 @@
         <rMaterial name="tibtidcommonmaterial:T_Cu10mmPipe" />
       </MaterialFraction>
       <MaterialFraction fraction="0.0472998518237542">
-        <rMaterial name="tibtidcommonmaterial:T_RuggRibbon" />
+        <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon" />
       </MaterialFraction>
       <MaterialFraction fraction="0.00355998884762293">
         <rMaterial name="trackermaterial:T_Copper" />
@@ -382,7 +382,7 @@
         <rMaterial name="tibtidcommonmaterial:T_Cu10mmPipe" />
       </MaterialFraction>
       <MaterialFraction fraction="0.0572197614737023">
-        <rMaterial name="tibtidcommonmaterial:T_RuggRibbon" />
+        <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon" />
       </MaterialFraction>
     </CompositeMaterial>
     <CompositeMaterial name="TIBTID_PA" density="3.024758*g/cm3" method="mixture by weight" pork="true" symbol=" ">

--- a/Geometry/TrackerCommonData/data/flat20percent/tibtidcommonmaterial.xml
+++ b/Geometry/TrackerCommonData/data/flat20percent/tibtidcommonmaterial.xml
@@ -67,7 +67,7 @@
         <rMaterial name="materials:Polyethylene" />
       </MaterialFraction>
     </CompositeMaterial>
-    <CompositeMaterial name="T_RuggRibbon" density="1.010544*g/cm3" method="mixture by weight" pork="true" symbol=" ">
+    <CompositeMaterial name="TIBTID_T_RuggRibbon" density="1.010544*g/cm3" method="mixture by weight" pork="true" symbol=" ">
       <MaterialFraction fraction="0.67168">
         <rMaterial name="materials:Polyethylene" />
       </MaterialFraction>
@@ -239,7 +239,7 @@
     </CompositeMaterial>
     <CompositeMaterial name="TIBTID_OptoPanelFront" density="0.066816*g/cm3" method="mixture by weight" pork="true" symbol=" ">
       <MaterialFraction fraction="0.8808">
-        <rMaterial name="tibtidcommonmaterial:T_RuggRibbon" />
+        <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon" />
       </MaterialFraction>
       <MaterialFraction fraction="0.08973">
         <rMaterial name="trackermaterial:T_Aluminium" />
@@ -284,7 +284,7 @@
         <rMaterial name="trackermaterial:T_FR4" />
       </MaterialFraction>
       <MaterialFraction fraction="0.20893">
-        <rMaterial name="tibtidcommonmaterial:T_RuggRibbon" />
+        <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon" />
       </MaterialFraction>
       <MaterialFraction fraction="0.58144">
         <rMaterial name="tibtidcommonmaterial:T_FiberPigtail" />
@@ -362,7 +362,7 @@
         <rMaterial name="tibtidcommonmaterial:T_Cu10mmPipe" />
       </MaterialFraction>
       <MaterialFraction fraction="0.0472998518237542">
-        <rMaterial name="tibtidcommonmaterial:T_RuggRibbon" />
+        <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon" />
       </MaterialFraction>
       <MaterialFraction fraction="0.00355998884762294">
         <rMaterial name="trackermaterial:T_Copper" />
@@ -382,7 +382,7 @@
         <rMaterial name="tibtidcommonmaterial:T_Cu10mmPipe" />
       </MaterialFraction>
       <MaterialFraction fraction="0.0572197614737023">
-        <rMaterial name="tibtidcommonmaterial:T_RuggRibbon" />
+        <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon" />
       </MaterialFraction>
     </CompositeMaterial>
     <CompositeMaterial name="TIBTID_PA" density="3.299736*g/cm3" method="mixture by weight" pork="true" symbol=" ">

--- a/Geometry/TrackerCommonData/data/flat20services30percent/tibtidcommonmaterial.xml
+++ b/Geometry/TrackerCommonData/data/flat20services30percent/tibtidcommonmaterial.xml
@@ -67,7 +67,7 @@
         <rMaterial name="materials:Polyethylene" />
       </MaterialFraction>
     </CompositeMaterial>
-    <CompositeMaterial name="T_RuggRibbon" density="1.010544*g/cm3" method="mixture by weight" pork="true" symbol=" ">
+    <CompositeMaterial name="TIBTID_T_RuggRibbon" density="1.010544*g/cm3" method="mixture by weight" pork="true" symbol=" ">
       <MaterialFraction fraction="0.67168">
         <rMaterial name="materials:Polyethylene" />
       </MaterialFraction>
@@ -239,7 +239,7 @@
     </CompositeMaterial>
     <CompositeMaterial name="TIBTID_OptoPanelFront" density="0.0723617279999999*g/cm3" method="mixture by weight" pork="true" symbol=" ">
       <MaterialFraction fraction="0.8808">
-        <rMaterial name="tibtidcommonmaterial:T_RuggRibbon" />
+        <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon" />
       </MaterialFraction>
       <MaterialFraction fraction="0.08973">
         <rMaterial name="trackermaterial:T_Aluminium" />
@@ -284,7 +284,7 @@
         <rMaterial name="trackermaterial:T_FR4" />
       </MaterialFraction>
       <MaterialFraction fraction="0.20893">
-        <rMaterial name="tibtidcommonmaterial:T_RuggRibbon" />
+        <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon" />
       </MaterialFraction>
       <MaterialFraction fraction="0.58144">
         <rMaterial name="tibtidcommonmaterial:T_FiberPigtail" />
@@ -362,7 +362,7 @@
         <rMaterial name="tibtidcommonmaterial:T_Cu10mmPipe" />
       </MaterialFraction>
       <MaterialFraction fraction="0.0472998518237542">
-        <rMaterial name="tibtidcommonmaterial:T_RuggRibbon" />
+        <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon" />
       </MaterialFraction>
       <MaterialFraction fraction="0.00355998884762294">
         <rMaterial name="trackermaterial:T_Copper" />
@@ -382,7 +382,7 @@
         <rMaterial name="tibtidcommonmaterial:T_Cu10mmPipe" />
       </MaterialFraction>
       <MaterialFraction fraction="0.0572197614737023">
-        <rMaterial name="tibtidcommonmaterial:T_RuggRibbon" />
+        <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon" />
       </MaterialFraction>
     </CompositeMaterial>
     <CompositeMaterial name="TIBTID_PA" density="3.299736*g/cm3" method="mixture by weight" pork="true" symbol=" ">

--- a/Geometry/TrackerCommonData/data/flat30percent/tibtidcommonmaterial.xml
+++ b/Geometry/TrackerCommonData/data/flat30percent/tibtidcommonmaterial.xml
@@ -67,7 +67,7 @@
         <rMaterial name="materials:Polyethylene" />
       </MaterialFraction>
     </CompositeMaterial>
-    <CompositeMaterial name="T_RuggRibbon" density="1.094756*g/cm3" method="mixture by weight" pork="true" symbol=" ">
+    <CompositeMaterial name="TIBTID_T_RuggRibbon" density="1.094756*g/cm3" method="mixture by weight" pork="true" symbol=" ">
       <MaterialFraction fraction="0.67168">
         <rMaterial name="materials:Polyethylene" />
       </MaterialFraction>
@@ -239,7 +239,7 @@
     </CompositeMaterial>
     <CompositeMaterial name="TIBTID_OptoPanelFront" density="0.072384*g/cm3" method="mixture by weight" pork="true" symbol=" ">
       <MaterialFraction fraction="0.8808">
-        <rMaterial name="tibtidcommonmaterial:T_RuggRibbon" />
+        <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon" />
       </MaterialFraction>
       <MaterialFraction fraction="0.08973">
         <rMaterial name="trackermaterial:T_Aluminium" />
@@ -284,7 +284,7 @@
         <rMaterial name="trackermaterial:T_FR4" />
       </MaterialFraction>
       <MaterialFraction fraction="0.20893">
-        <rMaterial name="tibtidcommonmaterial:T_RuggRibbon" />
+        <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon" />
       </MaterialFraction>
       <MaterialFraction fraction="0.58144">
         <rMaterial name="tibtidcommonmaterial:T_FiberPigtail" />
@@ -362,7 +362,7 @@
         <rMaterial name="tibtidcommonmaterial:T_Cu10mmPipe" />
       </MaterialFraction>
       <MaterialFraction fraction="0.0472998518237542">
-        <rMaterial name="tibtidcommonmaterial:T_RuggRibbon" />
+        <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon" />
       </MaterialFraction>
       <MaterialFraction fraction="0.00355998884762294">
         <rMaterial name="trackermaterial:T_Copper" />
@@ -382,7 +382,7 @@
         <rMaterial name="tibtidcommonmaterial:T_Cu10mmPipe" />
       </MaterialFraction>
       <MaterialFraction fraction="0.0572197614737023">
-        <rMaterial name="tibtidcommonmaterial:T_RuggRibbon" />
+        <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon" />
       </MaterialFraction>
     </CompositeMaterial>
     <CompositeMaterial name="TIBTID_PA" density="3.574714*g/cm3" method="mixture by weight" pork="true" symbol=" ">

--- a/Geometry/TrackerCommonData/data/limax/tibtidcommonmaterial.xml
+++ b/Geometry/TrackerCommonData/data/limax/tibtidcommonmaterial.xml
@@ -67,7 +67,7 @@
         <rMaterial name="materials:Polyethylene"/>
       </MaterialFraction>
     </CompositeMaterial>
-    <CompositeMaterial name="T_RuggRibbon" density="0.963862088344*g/cm3" method="mixture by weight" pork="true" symbol=" ">
+    <CompositeMaterial name="TIBTID_T_RuggRibbon" density="0.963862088344*g/cm3" method="mixture by weight" pork="true" symbol=" ">
       <MaterialFraction fraction="0.674868784348166">
         <rMaterial name="materials:Polyethylene"/>
       </MaterialFraction>
@@ -239,7 +239,7 @@
     </CompositeMaterial>
     <CompositeMaterial name="TIBTID_OptoPanelFront" density="0.0626842326908928*g/cm3" method="mixture by weight" pork="true" symbol=" ">
       <MaterialFraction fraction="0.89548669005321">
-        <rMaterial name="tibtidcommonmaterial:T_RuggRibbon"/>
+        <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon"/>
       </MaterialFraction>
       <MaterialFraction fraction="0.0757185320175353">
         <rMaterial name="trackermaterial:T_Aluminium"/>
@@ -284,7 +284,7 @@
         <rMaterial name="trackermaterial:T_FR4"/>
       </MaterialFraction>
       <MaterialFraction fraction="0.210476612923447">
-        <rMaterial name="tibtidcommonmaterial:T_RuggRibbon"/>
+        <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon"/>
       </MaterialFraction>
       <MaterialFraction fraction="0.586564419589588">
         <rMaterial name="tibtidcommonmaterial:T_FiberPigtail"/>
@@ -362,7 +362,7 @@
         <rMaterial name="tibtidcommonmaterial:T_Cu10mmPipe"/>
       </MaterialFraction>
       <MaterialFraction fraction="0.0540088286254318">
-        <rMaterial name="tibtidcommonmaterial:T_RuggRibbon"/>
+        <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon"/>
       </MaterialFraction>
       <MaterialFraction fraction="0.00337393183417733">
         <rMaterial name="trackermaterial:T_Copper"/>
@@ -382,7 +382,7 @@
         <rMaterial name="tibtidcommonmaterial:T_Cu10mmPipe"/>
       </MaterialFraction>
       <MaterialFraction fraction="0.0640894098420788">
-        <rMaterial name="tibtidcommonmaterial:T_RuggRibbon"/>
+        <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon"/>
       </MaterialFraction>
     </CompositeMaterial>
     <CompositeMaterial name="TIBTID_PA" density="2.9139124158562*g/cm3" method="mixture by weight" pork="true" symbol=" ">

--- a/Geometry/TrackerCommonData/data/limin/tibtidcommonmaterial.xml
+++ b/Geometry/TrackerCommonData/data/limin/tibtidcommonmaterial.xml
@@ -67,7 +67,7 @@
         <rMaterial name="materials:Polyethylene"/>
       </MaterialFraction>
     </CompositeMaterial>
-    <CompositeMaterial name="T_RuggRibbon" density="0.9639073944*g/cm3" method="mixture by weight" pork="true" symbol=" ">
+    <CompositeMaterial name="TIBTID_T_RuggRibbon" density="0.9639073944*g/cm3" method="mixture by weight" pork="true" symbol=" ">
       <MaterialFraction fraction="0.674837063829043">
         <rMaterial name="materials:Polyethylene"/>
       </MaterialFraction>
@@ -239,7 +239,7 @@
     </CompositeMaterial>
     <CompositeMaterial name="TIBTID_OptoPanelFront" density="0.06304373044608*g/cm3" method="mixture by weight" pork="true" symbol=" ">
       <MaterialFraction fraction="0.890422158779001">
-        <rMaterial name="tibtidcommonmaterial:T_RuggRibbon"/>
+        <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon"/>
       </MaterialFraction>
       <MaterialFraction fraction="0.0832116799383688">
         <rMaterial name="trackermaterial:T_Aluminium"/>
@@ -284,7 +284,7 @@
         <rMaterial name="trackermaterial:T_FR4"/>
       </MaterialFraction>
       <MaterialFraction fraction="0.213914030453495">
-        <rMaterial name="tibtidcommonmaterial:T_RuggRibbon"/>
+        <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon"/>
       </MaterialFraction>
       <MaterialFraction fraction="0.596135655513996">
         <rMaterial name="tibtidcommonmaterial:T_FiberPigtail"/>
@@ -362,7 +362,7 @@
         <rMaterial name="tibtidcommonmaterial:T_Cu10mmPipe"/>
       </MaterialFraction>
       <MaterialFraction fraction="0.0503834065478672">
-        <rMaterial name="tibtidcommonmaterial:T_RuggRibbon"/>
+        <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon"/>
       </MaterialFraction>
       <MaterialFraction fraction="0.00347859889052292">
         <rMaterial name="trackermaterial:T_Copper"/>
@@ -382,7 +382,7 @@
         <rMaterial name="tibtidcommonmaterial:T_Cu10mmPipe"/>
       </MaterialFraction>
       <MaterialFraction fraction="0.0604617512505906">
-        <rMaterial name="tibtidcommonmaterial:T_RuggRibbon"/>
+        <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon"/>
       </MaterialFraction>
     </CompositeMaterial>
     <CompositeMaterial name="TIBTID_PA" density="2.83860476845*g/cm3" method="mixture by weight" pork="true" symbol=" ">

--- a/Geometry/TrackerCommonData/data/services30percent/tibtidcommonmaterial.xml
+++ b/Geometry/TrackerCommonData/data/services30percent/tibtidcommonmaterial.xml
@@ -67,7 +67,7 @@
         <rMaterial name="materials:Polyethylene" />
       </MaterialFraction>
     </CompositeMaterial>
-    <CompositeMaterial name="T_RuggRibbon" density="0.84212*g/cm3" method="mixture by weight" symbol=" ">
+    <CompositeMaterial name="TIBTID_T_RuggRibbon" density="0.84212*g/cm3" method="mixture by weight" symbol=" ">
       <MaterialFraction fraction="0.67168">
         <rMaterial name="materials:Polyethylene" />
       </MaterialFraction>
@@ -239,7 +239,7 @@
     </CompositeMaterial>
     <CompositeMaterial name="TIBTID_OptoPanelFront" density="0.072384*g/cm3" method="mixture by weight" pork="true" symbol=" ">
       <MaterialFraction fraction="0.8808">
-        <rMaterial name="tibtidcommonmaterial:T_RuggRibbon" />
+        <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon" />
       </MaterialFraction>
       <MaterialFraction fraction="0.08973">
         <rMaterial name="trackermaterial:T_Aluminium" />
@@ -284,7 +284,7 @@
         <rMaterial name="trackermaterial:T_FR4" />
       </MaterialFraction>
       <MaterialFraction fraction="0.20893">
-        <rMaterial name="tibtidcommonmaterial:T_RuggRibbon" />
+        <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon" />
       </MaterialFraction>
       <MaterialFraction fraction="0.58144">
         <rMaterial name="tibtidcommonmaterial:T_FiberPigtail" />
@@ -362,7 +362,7 @@
         <rMaterial name="tibtidcommonmaterial:T_Cu10mmPipe" />
       </MaterialFraction>
       <MaterialFraction fraction="0.0473">
-        <rMaterial name="tibtidcommonmaterial:T_RuggRibbon" />
+        <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon" />
       </MaterialFraction>
       <MaterialFraction fraction="0.00356">
         <rMaterial name="trackermaterial:T_Copper" />
@@ -382,7 +382,7 @@
         <rMaterial name="tibtidcommonmaterial:T_Cu10mmPipe" />
       </MaterialFraction>
       <MaterialFraction fraction="0.05722">
-        <rMaterial name="tibtidcommonmaterial:T_RuggRibbon" />
+        <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon" />
       </MaterialFraction>
     </CompositeMaterial>
     <CompositeMaterial name="TIBTID_PA" density="2.74978*g/cm3" method="mixture by weight" symbol=" ">

--- a/Geometry/TrackerCommonData/data/specialTestGeometries/mod_10_TIBTIDMargherita/tibtidcommonmaterial.xml
+++ b/Geometry/TrackerCommonData/data/specialTestGeometries/mod_10_TIBTIDMargherita/tibtidcommonmaterial.xml
@@ -67,7 +67,7 @@
     <rMaterial name="materials:Polyethylene"/>
    </MaterialFraction>
   </CompositeMaterial>
-  <CompositeMaterial name="T_RuggRibbon" density="0.84212*g/cm3" symbol=" " method="mixture by weight">
+  <CompositeMaterial name="TIBTID_T_RuggRibbon" density="0.84212*g/cm3" symbol=" " method="mixture by weight">
    <MaterialFraction fraction="0.67168">
     <rMaterial name="materials:Polyethylene"/>
    </MaterialFraction>
@@ -239,7 +239,7 @@
   </CompositeMaterial>
   <CompositeMaterial name="TIBTID_OptoPanelFront" density="0.05568*g/cm3" symbol=" " method="mixture by weight">
    <MaterialFraction fraction="0.8808">
-    <rMaterial name="tibtidcommonmaterial:T_RuggRibbon"/>
+    <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon"/>
    </MaterialFraction>
    <MaterialFraction fraction="0.08973">
     <rMaterial name="trackermaterial:T_Aluminium"/>
@@ -284,7 +284,7 @@
     <rMaterial name="trackermaterial:T_FR4"/>
    </MaterialFraction>
    <MaterialFraction fraction="0.20893">
-    <rMaterial name="tibtidcommonmaterial:T_RuggRibbon"/>
+    <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon"/>
    </MaterialFraction>
    <MaterialFraction fraction="0.58144">
     <rMaterial name="tibtidcommonmaterial:T_FiberPigtail"/>
@@ -362,7 +362,7 @@
     <rMaterial name="tibtidcommonmaterial:T_Cu10mmPipe"/>
    </MaterialFraction>
    <MaterialFraction fraction="0.0473">
-    <rMaterial name="tibtidcommonmaterial:T_RuggRibbon"/>
+    <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon"/>
    </MaterialFraction>
    <MaterialFraction fraction="0.00356">
     <rMaterial name="trackermaterial:T_Copper"/>
@@ -382,7 +382,7 @@
     <rMaterial name="tibtidcommonmaterial:T_Cu10mmPipe"/>
    </MaterialFraction>
    <MaterialFraction fraction="0.05722">
-    <rMaterial name="tibtidcommonmaterial:T_RuggRibbon"/>
+    <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon"/>
    </MaterialFraction>
   </CompositeMaterial>
   <CompositeMaterial name="TIBTID_PA" density="2.74978*g/cm3" symbol=" " method="mixture by weight">

--- a/Geometry/TrackerCommonData/data/specialTestGeometries/mod_10_TIBTIDServiceCylinder/tibtidcommonmaterial.xml
+++ b/Geometry/TrackerCommonData/data/specialTestGeometries/mod_10_TIBTIDServiceCylinder/tibtidcommonmaterial.xml
@@ -67,7 +67,7 @@
     <rMaterial name="materials:Polyethylene"/>
    </MaterialFraction>
   </CompositeMaterial>
-  <CompositeMaterial name="T_RuggRibbon" density="0.84212*g/cm3" symbol=" " method="mixture by weight">
+  <CompositeMaterial name="TIBTID_T_RuggRibbon" density="0.84212*g/cm3" symbol=" " method="mixture by weight">
    <MaterialFraction fraction="0.67168">
     <rMaterial name="materials:Polyethylene"/>
    </MaterialFraction>
@@ -239,7 +239,7 @@
   </CompositeMaterial>
   <CompositeMaterial name="TIBTID_OptoPanelFront" density="0.05568*g/cm3" symbol=" " method="mixture by weight">
    <MaterialFraction fraction="0.8808">
-    <rMaterial name="tibtidcommonmaterial:T_RuggRibbon"/>
+    <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon"/>
    </MaterialFraction>
    <MaterialFraction fraction="0.08973">
     <rMaterial name="trackermaterial:T_Aluminium"/>
@@ -284,7 +284,7 @@
     <rMaterial name="trackermaterial:T_FR4"/>
    </MaterialFraction>
    <MaterialFraction fraction="0.20893">
-    <rMaterial name="tibtidcommonmaterial:T_RuggRibbon"/>
+    <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon"/>
    </MaterialFraction>
    <MaterialFraction fraction="0.58144">
     <rMaterial name="tibtidcommonmaterial:T_FiberPigtail"/>
@@ -362,7 +362,7 @@
     <rMaterial name="tibtidcommonmaterial:T_Cu10mmPipe"/>
    </MaterialFraction>
    <MaterialFraction fraction="0.0473">
-    <rMaterial name="tibtidcommonmaterial:T_RuggRibbon"/>
+    <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon"/>
    </MaterialFraction>
    <MaterialFraction fraction="0.00356">
     <rMaterial name="trackermaterial:T_Copper"/>
@@ -382,7 +382,7 @@
     <rMaterial name="tibtidcommonmaterial:T_Cu10mmPipe"/>
    </MaterialFraction>
    <MaterialFraction fraction="0.05722">
-    <rMaterial name="tibtidcommonmaterial:T_RuggRibbon"/>
+    <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon"/>
    </MaterialFraction>
   </CompositeMaterial>
   <CompositeMaterial name="TIBTID_PA" density="2.74978*g/cm3" symbol=" " method="mixture by weight">

--- a/Geometry/TrackerCommonData/data/test2014/tibtidcommonmaterial.xml
+++ b/Geometry/TrackerCommonData/data/test2014/tibtidcommonmaterial.xml
@@ -67,7 +67,7 @@
         <rMaterial name="materials:Polyethylene" />
       </MaterialFraction>
     </CompositeMaterial>
-    <CompositeMaterial name="T_RuggRibbon" density="0.84212*g/cm3" method="mixture by weight" symbol=" ">
+    <CompositeMaterial name="TIBTID_T_RuggRibbon" density="0.84212*g/cm3" method="mixture by weight" symbol=" ">
       <MaterialFraction fraction="0.67168">
         <rMaterial name="materials:Polyethylene" />
       </MaterialFraction>
@@ -265,7 +265,7 @@
     </CompositeMaterial>
     <CompositeMaterial name="TIBTID_OptoPanelFront" density="0.077952*g/cm3" method="mixture by weight"  symbol=" ">
       <MaterialFraction fraction="0.8808">
-        <rMaterial name="tibtidcommonmaterial:T_RuggRibbon" />
+        <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon" />
       </MaterialFraction>
       <MaterialFraction fraction="0.08973">
         <rMaterial name="trackermaterial:T_Aluminium" />
@@ -310,7 +310,7 @@
         <rMaterial name="trackermaterial:T_FR4" />
       </MaterialFraction>
       <MaterialFraction fraction="0.20893">
-        <rMaterial name="tibtidcommonmaterial:T_RuggRibbon" />
+        <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon" />
       </MaterialFraction>
       <MaterialFraction fraction="0.58144">
         <rMaterial name="tibtidcommonmaterial:T_FiberPigtail" />
@@ -388,7 +388,7 @@
         <rMaterial name="tibtidcommonmaterial:T_Cu10mmPipe" />
       </MaterialFraction>
       <MaterialFraction fraction="0.0473">
-        <rMaterial name="tibtidcommonmaterial:T_RuggRibbon" />
+        <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon" />
       </MaterialFraction>
       <MaterialFraction fraction="0.00356">
         <rMaterial name="trackermaterial:T_Copper" />
@@ -408,7 +408,7 @@
         <rMaterial name="tibtidcommonmaterial:T_Cu10mmPipe" />
       </MaterialFraction>
       <MaterialFraction fraction="0.05722">
-        <rMaterial name="tibtidcommonmaterial:T_RuggRibbon" />
+        <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon" />
       </MaterialFraction>
     </CompositeMaterial>
     <CompositeMaterial name="TIBTID_PA" density="2.74978*g/cm3" method="mixture by weight" symbol=" ">

--- a/Geometry/TrackerCommonData/data/tibtidcommonmaterial.xml
+++ b/Geometry/TrackerCommonData/data/tibtidcommonmaterial.xml
@@ -67,7 +67,7 @@
         <rMaterial name="materials:Polyethylene" />
       </MaterialFraction>
     </CompositeMaterial>
-    <CompositeMaterial name="T_RuggRibbon" density="0.84212*g/cm3" method="mixture by weight" symbol=" ">
+    <CompositeMaterial name="TIBTID_T_RuggRibbon" density="0.84212*g/cm3" method="mixture by weight" symbol=" ">
       <MaterialFraction fraction="0.67168">
         <rMaterial name="materials:Polyethylene" />
       </MaterialFraction>
@@ -265,7 +265,7 @@
     </CompositeMaterial>
     <CompositeMaterial name="TIBTID_OptoPanelFront" density="0.077952*g/cm3" method="mixture by weight"  symbol=" ">
       <MaterialFraction fraction="0.8808">
-        <rMaterial name="tibtidcommonmaterial:T_RuggRibbon" />
+        <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon" />
       </MaterialFraction>
       <MaterialFraction fraction="0.08973">
         <rMaterial name="trackermaterial:T_Aluminium" />
@@ -310,7 +310,7 @@
         <rMaterial name="trackermaterial:T_FR4" />
       </MaterialFraction>
       <MaterialFraction fraction="0.20893">
-        <rMaterial name="tibtidcommonmaterial:T_RuggRibbon" />
+        <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon" />
       </MaterialFraction>
       <MaterialFraction fraction="0.58144">
         <rMaterial name="tibtidcommonmaterial:T_FiberPigtail" />
@@ -388,7 +388,7 @@
         <rMaterial name="tibtidcommonmaterial:T_Cu10mmPipe" />
       </MaterialFraction>
       <MaterialFraction fraction="0.0473">
-        <rMaterial name="tibtidcommonmaterial:T_RuggRibbon" />
+        <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon" />
       </MaterialFraction>
       <MaterialFraction fraction="0.00356">
         <rMaterial name="trackermaterial:T_Copper" />
@@ -408,7 +408,7 @@
         <rMaterial name="tibtidcommonmaterial:T_Cu10mmPipe" />
       </MaterialFraction>
       <MaterialFraction fraction="0.05722">
-        <rMaterial name="tibtidcommonmaterial:T_RuggRibbon" />
+        <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon" />
       </MaterialFraction>
     </CompositeMaterial>
     <CompositeMaterial name="TIBTID_PA" density="2.74978*g/cm3" method="mixture by weight" symbol=" ">

--- a/Geometry/TrackerCommonData/data/x0max/tibtidcommonmaterial.xml
+++ b/Geometry/TrackerCommonData/data/x0max/tibtidcommonmaterial.xml
@@ -67,7 +67,7 @@
         <rMaterial name="materials:Polyethylene"/>
       </MaterialFraction>
     </CompositeMaterial>
-    <CompositeMaterial name="T_RuggRibbon" density="0.7248632112*g/cm3" method="mixture by weight" pork="true" symbol=" ">
+    <CompositeMaterial name="TIBTID_T_RuggRibbon" density="0.7248632112*g/cm3" method="mixture by weight" pork="true" symbol=" ">
       <MaterialFraction fraction="0.663283609833171">
         <rMaterial name="materials:Polyethylene"/>
       </MaterialFraction>
@@ -239,7 +239,7 @@
     </CompositeMaterial>
     <CompositeMaterial name="TIBTID_OptoPanelFront" density="0.04926515775744*g/cm3" method="mixture by weight" pork="true" symbol=" ">
       <MaterialFraction fraction="0.856877485002366">
-        <rMaterial name="tibtidcommonmaterial:T_RuggRibbon"/>
+        <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon"/>
       </MaterialFraction>
       <MaterialFraction fraction="0.106484480285821">
         <rMaterial name="trackermaterial:T_Aluminium"/>
@@ -284,7 +284,7 @@
         <rMaterial name="trackermaterial:T_FR4"/>
       </MaterialFraction>
       <MaterialFraction fraction="0.197827780953809">
-        <rMaterial name="tibtidcommonmaterial:T_RuggRibbon"/>
+        <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon"/>
       </MaterialFraction>
       <MaterialFraction fraction="0.548513077784069">
         <rMaterial name="tibtidcommonmaterial:T_FiberPigtail"/>
@@ -362,7 +362,7 @@
         <rMaterial name="tibtidcommonmaterial:T_Cu10mmPipe"/>
       </MaterialFraction>
       <MaterialFraction fraction="0.0398372406205536">
-        <rMaterial name="tibtidcommonmaterial:T_RuggRibbon"/>
+        <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon"/>
       </MaterialFraction>
       <MaterialFraction fraction="0.00365750836641117">
         <rMaterial name="trackermaterial:T_Copper"/>
@@ -382,7 +382,7 @@
         <rMaterial name="tibtidcommonmaterial:T_Cu10mmPipe"/>
       </MaterialFraction>
       <MaterialFraction fraction="0.0485285795170534">
-        <rMaterial name="tibtidcommonmaterial:T_RuggRibbon"/>
+        <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon"/>
       </MaterialFraction>
     </CompositeMaterial>
     <CompositeMaterial name="TIBTID_PA" density="2.91646753893*g/cm3" method="mixture by weight" pork="true" symbol=" ">

--- a/Geometry/TrackerCommonData/data/x0min/tibtidcommonmaterial.xml
+++ b/Geometry/TrackerCommonData/data/x0min/tibtidcommonmaterial.xml
@@ -67,7 +67,7 @@
         <rMaterial name="materials:Polyethylene"/>
       </MaterialFraction>
     </CompositeMaterial>
-    <CompositeMaterial name="T_RuggRibbon" density="0.9593767888*g/cm3" method="mixture by weight" pork="true" symbol=" ">
+    <CompositeMaterial name="TIBTID_T_RuggRibbon" density="0.9593767888*g/cm3" method="mixture by weight" pork="true" symbol=" ">
       <MaterialFraction fraction="0.67802394578842">
         <rMaterial name="materials:Polyethylene"/>
       </MaterialFraction>
@@ -239,7 +239,7 @@
     </CompositeMaterial>
     <CompositeMaterial name="TIBTID_OptoPanelFront" density="0.06236791700736*g/cm3" method="mixture by weight" pork="true" symbol=" ">
       <MaterialFraction fraction="0.895840140307502">
-        <rMaterial name="tibtidcommonmaterial:T_RuggRibbon"/>
+        <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon"/>
       </MaterialFraction>
       <MaterialFraction fraction="0.0804283886057642">
         <rMaterial name="trackermaterial:T_Aluminium"/>
@@ -284,7 +284,7 @@
         <rMaterial name="trackermaterial:T_FR4"/>
       </MaterialFraction>
       <MaterialFraction fraction="0.21809757401342">
-        <rMaterial name="tibtidcommonmaterial:T_RuggRibbon"/>
+        <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon"/>
       </MaterialFraction>
       <MaterialFraction fraction="0.608643835379782">
         <rMaterial name="tibtidcommonmaterial:T_FiberPigtail"/>
@@ -362,7 +362,7 @@
         <rMaterial name="tibtidcommonmaterial:T_Cu10mmPipe"/>
       </MaterialFraction>
       <MaterialFraction fraction="0.0526334006912297">
-        <rMaterial name="tibtidcommonmaterial:T_RuggRibbon"/>
+        <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon"/>
       </MaterialFraction>
       <MaterialFraction fraction="0.00330338101477055">
         <rMaterial name="trackermaterial:T_Copper"/>
@@ -382,7 +382,7 @@
         <rMaterial name="tibtidcommonmaterial:T_Cu10mmPipe"/>
       </MaterialFraction>
       <MaterialFraction fraction="0.0632512076674401">
-        <rMaterial name="tibtidcommonmaterial:T_RuggRibbon"/>
+        <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon"/>
       </MaterialFraction>
     </CompositeMaterial>
     <CompositeMaterial name="TIBTID_PA" density="2.58309246107*g/cm3" method="mixture by weight" pork="true" symbol=" ">

--- a/Geometry/TrackerCommonData/data/zeroMaterial/tibtidcommonmaterial.xml
+++ b/Geometry/TrackerCommonData/data/zeroMaterial/tibtidcommonmaterial.xml
@@ -67,7 +67,7 @@
         <rMaterial name="materials:Polyethylene" />
       </MaterialFraction>
     </CompositeMaterial>
-    <CompositeMaterial name="T_RuggRibbon" density="8.4212e-06*g/cm3" method="mixture by weight" pork="true" symbol=" ">
+    <CompositeMaterial name="TIBTID_T_RuggRibbon" density="8.4212e-06*g/cm3" method="mixture by weight" pork="true" symbol=" ">
       <MaterialFraction fraction="0.67168">
         <rMaterial name="materials:Polyethylene" />
       </MaterialFraction>
@@ -239,7 +239,7 @@
     </CompositeMaterial>
     <CompositeMaterial name="TIBTID_OptoPanelFront" density="5.56800000000001e-07*g/cm3" method="mixture by weight" pork="true" symbol=" ">
       <MaterialFraction fraction="0.8808">
-        <rMaterial name="tibtidcommonmaterial:T_RuggRibbon" />
+        <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon" />
       </MaterialFraction>
       <MaterialFraction fraction="0.08973">
         <rMaterial name="trackermaterial:T_Aluminium" />
@@ -284,7 +284,7 @@
         <rMaterial name="trackermaterial:T_FR4" />
       </MaterialFraction>
       <MaterialFraction fraction="0.20893">
-        <rMaterial name="tibtidcommonmaterial:T_RuggRibbon" />
+        <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon" />
       </MaterialFraction>
       <MaterialFraction fraction="0.58144">
         <rMaterial name="tibtidcommonmaterial:T_FiberPigtail" />
@@ -362,7 +362,7 @@
         <rMaterial name="tibtidcommonmaterial:T_Cu10mmPipe" />
       </MaterialFraction>
       <MaterialFraction fraction="0.0472998518237542">
-        <rMaterial name="tibtidcommonmaterial:T_RuggRibbon" />
+        <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon" />
       </MaterialFraction>
       <MaterialFraction fraction="0.00355998884762294">
         <rMaterial name="trackermaterial:T_Copper" />
@@ -382,7 +382,7 @@
         <rMaterial name="tibtidcommonmaterial:T_Cu10mmPipe" />
       </MaterialFraction>
       <MaterialFraction fraction="0.0572197614737023">
-        <rMaterial name="tibtidcommonmaterial:T_RuggRibbon" />
+        <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon" />
       </MaterialFraction>
     </CompositeMaterial>
     <CompositeMaterial name="TIBTID_PA" density="2.74977999999999e-05*g/cm3" method="mixture by weight" pork="true" symbol=" ">


### PR DESCRIPTION
Rename tibtidcommonmaterial:T_Rugg_Ribbon by tibtidcommonmaterial:TIBTID_T_RuggRibbon to avoid annoying warning in each simulation run. Should not affect any result.
