### PR TITLE
Mark as thread safe classes from Geometry/EcalAlgo

### DIFF
--- a/Geometry/EcalAlgo/interface/EcalBarrelGeometry.h
+++ b/Geometry/EcalAlgo/interface/EcalBarrelGeometry.h
@@ -12,6 +12,7 @@
 #include "DataFormats/EcalDetId/interface/EEDetId.h"
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
 #include "Geometry/Records/interface/PEcalBarrelRcd.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 #include <vector>
 #include <atomic>
 
@@ -125,8 +126,7 @@ class EcalBarrelGeometry GCC11_FINAL : public CaloSubdetectorGeometry
       mutable std::atomic<EZMgrFL<EEDetId>*>     m_borderMgr ;
 
       mutable std::atomic<VecOrdListEEDetIdPtr*> m_borderPtrVec ;
-
-      mutable CCGFloat m_radius ; // CMS-THREADING protected by m_check
+      CMS_THREAD_GUARD(m_check) mutable CCGFloat m_radius ; 
       mutable std::atomic<bool> m_check;
 
       CellVec m_cellVec ;

--- a/Geometry/EcalAlgo/interface/EcalEndcapGeometry.h
+++ b/Geometry/EcalAlgo/interface/EcalEndcapGeometry.h
@@ -10,6 +10,7 @@
 #include "Geometry/EcalCommonData/interface/EcalEndcapNumberingScheme.h"
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
 #include "Geometry/Records/interface/PEcalEndcapRcd.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 #include <vector>
 #include <map>
 #include <atomic>
@@ -126,7 +127,7 @@ class EcalEndcapGeometry GCC11_FINAL: public CaloSubdetectorGeometry
 
       mutable std::atomic<VecOrdListEBDetIdPtr*> m_borderPtrVec ;
 
-      mutable CCGFloat m_avgZ ; // CMS-THREADING protected by m_check
+      CMS_THREAD_GUARD(m_check) mutable CCGFloat m_avgZ ;
       mutable std::atomic<bool> m_check;
 
       CellVec m_cellVec ;


### PR DESCRIPTION
EcalBarrelGeometry and EcalEndcapGeometry are already thread-safe, however one mutable non-atomic variable which is protected by an atomic variable was causing the static analyzer to complain. Adding the 
proper CMS specific thread-safety annotation should quite the static analyzer.
