### PR TITLE
Removed unnecessary mutable from GlobalTriggerMenu

### DIFF
--- a/CondFormats/L1TObjects/interface/GlobalTriggerMenu.h
+++ b/CondFormats/L1TObjects/interface/GlobalTriggerMenu.h
@@ -270,7 +270,7 @@ public:
 private:
 
     /// map containing the conditions (per condition chip) - transient
-    mutable std::vector<l1t::ConditionMap> m_conditionMap;
+    std::vector<l1t::ConditionMap> m_conditionMap;
 
 private:
 


### PR DESCRIPTION
The static analyzer was complaining about a mutable in GlobalTriggerMenu.
The mutable keyword was actually unnecessary so was removed.
