### PR TITLE
Global muon refitter and TrackTransformer

### DIFF
--- a/RecoMuon/GlobalTrackingTools/src/GlobalMuonRefitter.cc
+++ b/RecoMuon/GlobalTrackingTools/src/GlobalMuonRefitter.cc
@@ -179,10 +179,12 @@ vector<Trajectory> GlobalMuonRefitter::refit(const reco::Track& globalTrack,
 
   reco::TransientTrack track(globalTrack,&*(theService->magneticField()),theService->trackingGeometry());
   
+  auto tkbuilder = static_cast<TkTransientTrackingRecHitBuilder const *>(theTrackerRecHitBuilder.product());
+
   for (trackingRecHit_iterator hit = track.recHitsBegin(); hit != track.recHitsEnd(); ++hit)
     if ((*hit)->isValid()) {
       if ((*hit)->geographicalId().det() == DetId::Tracker)
-	allRecHitsTemp.push_back(theTrackerRecHitBuilder->build(&**hit));
+	allRecHitsTemp.push_back((**hit).cloneForFit(*tkbuilder->geometry()->idToDet( (**hit).geographicalId() ) ) );
       else if ((*hit)->geographicalId().det() == DetId::Muon) {
 	if ((*hit)->geographicalId().subdetId() == 3 && !theRPCInTheFit) {
 	  LogTrace(theCategory) << "RPC Rec Hit discarged"; 

--- a/TrackingTools/TrackRefitter/src/TrackTransformer.cc
+++ b/TrackingTools/TrackRefitter/src/TrackTransformer.cc
@@ -108,11 +108,13 @@ TransientTrackingRecHit::ConstRecHitContainer
 TrackTransformer::getTransientRecHits(const reco::TransientTrack& track) const {
 
   TransientTrackingRecHit::ConstRecHitContainer result;
+  auto tkbuilder = static_cast<TkTransientTrackingRecHitBuilder const *>(theTrackerRecHitBuilder.product());
+
   
   for (trackingRecHit_iterator hit = track.recHitsBegin(); hit != track.recHitsEnd(); ++hit) {
     if((*hit)->isValid()) {
       if ( (*hit)->geographicalId().det() == DetId::Tracker ) {
-	result.emplace_back((**hit).cloneSH());
+	result.emplace_back((**hit).cloneForFit(*tkbuilder->geometry()->idToDet( (**hit).geographicalId() ) ) );
       } else if ( (*hit)->geographicalId().det() == DetId::Muon ){
 	if( (*hit)->geographicalId().subdetId() == 3 && !theRPCInTheFit){
 	  LogTrace("Reco|TrackingTools|TrackTransformer") << "RPC Rec Hit discarged"; 


### PR DESCRIPTION
as reported by Andrea Giammanco

tested with

cd CMSSW_7_1_0_pre9/src
git cms-addpkg FastSimulation/Configuration
scram b -j 8
edit FastSimulation/Configuration/python/CommonInputs_cff.py and set MixingMode = 'DigiRecoMixing' instead of 'GenMixing'

cmsDriver.py SingleMuPt10_cfi.py -s GEN,SIM,RECO --fast --pileup=mix_2012_Summer_inTimeOnly --conditions auto:startup_GRun --beamspot Realistic8TeVCollision --eventcontent=FEVTDEBUGHLT --datatier GEN-SIM-DIGI-RECO -n 10
