### PR TITLE
Change tracker eta boundary for PF linking

### DIFF
--- a/SLHCUpgradeSimulations/Configuration/python/phase2TkCustomsBE5DPixel10D.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase2TkCustomsBE5DPixel10D.py
@@ -206,7 +206,7 @@ def customise_Reco(process,pileup):
     # Particle flow needs to know that the eta range has increased, for
     # when linking tracks to HF clusters
     for link in process.particleFlowBlock.linkDefinitions:
-        if hasattr(link,'trackerEtaBoundary') : link.trackerEtaBoundary = cms.double(3.8)
+        if hasattr(link,'trackerEtaBoundary') : link.trackerEtaBoundary = cms.double(3.0)
     for importer in process.particleFlowBlock.elementImporters :
     	if importer.source.value()=="particleFlowClusterHFEM" : importer.importerName = cms.string("ClusterImporterForForwardTracker")
     	if importer.source.value()=="particleFlowClusterHFHAD" : importer.importerName = cms.string("ClusterImporterForForwardTracker")


### PR DESCRIPTION
Changes the tracker eta boundary used by particle flow from 3.8 to 3.0.

Private correspondence from Michalis Bachtis 05/Jun/2014:

> Physics Justification: Nominally inside the tracker coverage we call ECAL clusters photons but outside we do not do it because most of the ECAL contribution comes from charged hadrons without tracker tracks. If you change this 3.8 to 3 we allow photons up to eta 3 but in the HF we make neutral hadrons which are much close to the jets in the HF than photons.
