### PR TITLE
Make lookup for LHE headers case-insentive

### DIFF
--- a/GeneratorInterface/LHEInterface/src/LHERunInfo.cc
+++ b/GeneratorInterface/LHEInterface/src/LHERunInfo.cc
@@ -9,6 +9,7 @@
 #include <cstring>
 
 #include <boost/bind.hpp>
+#include <boost/algorithm/string.hpp>
 
 #include <xercesc/dom/DOM.hpp>
 #include <xercesc/parsers/XercesDOMParser.hpp>
@@ -392,10 +393,10 @@ std::vector<std::string> LHERunInfo::findHeader(const std::string &tag) const
 	const LHERunInfo::Header *header = 0;
 	for(std::vector<Header>::const_iterator iter = headers.begin();
 	    iter != headers.end(); ++iter) {
-		if (iter->tag() == tag)
+		if (boost::iequals(iter->tag(), tag))
 			return std::vector<std::string>(iter->begin(),
 			                                iter->end());
-		if (iter->tag() == "header")
+		if (boost::iequals(iter->tag(), "header"))
 			header = &*iter;
 	}
 
@@ -410,7 +411,7 @@ std::vector<std::string> LHERunInfo::findHeader(const std::string &tag) const
 	    iter; iter = iter->getNextSibling()) {
 		if (iter->getNodeType() != DOMNode::ELEMENT_NODE)
 			continue;
-		if (tag == (const char*)XMLSimpleStr(iter->getNodeName()))
+		if (boost::iequals(tag, (std::string) XMLSimpleStr(iter->getNodeName())))
 			return domToLines(iter);
 	}
 


### PR DESCRIPTION
For the moment, LHE headers are retrieved using case-sensitive string comparison. It makes all LHE file processed by MadSpin invalid, because until today, MadSpin converted all headers to lowercase (MGProcCard to mgproccard, etc.) (see https://bugs.launchpad.net/mg5amcnlo/+bug/1325955 )

This PR change the way we look for LHE headers for case-insensitive string comparisons.

It'd be great if you could also cherry-pick this on other CMSSW release, as I don't have much time to do it.
