### PR TITLE
Add missing includes

### DIFF
--- a/DataFormats/Provenance/interface/ModuleDescription.h
+++ b/DataFormats/Provenance/interface/ModuleDescription.h
@@ -9,9 +9,8 @@ ModuleDescription: The description of a producer module.
 #include "DataFormats/Provenance/interface/ParameterSetID.h"
 #include "DataFormats/Provenance/interface/ProcessConfiguration.h"
 
-#include "boost/shared_ptr.hpp"
-
 #include <iosfwd>
+#include <limits>
 #include <string>
 
 namespace edm {

--- a/EventFilter/Utilities/plugins/RecoEventWriterForFU.h
+++ b/EventFilter/Utilities/plugins/RecoEventWriterForFU.h
@@ -10,6 +10,8 @@
 #include "IOPool/Streamer/interface/EventMessage.h"
 #include "IOPool/Streamer/interface/MsgTools.h"
 
+#include "boost/shared_ptr.hpp"
+
 #include <iostream>
 #include <vector>
 #include <memory>

--- a/RecoJets/JetAlgorithms/interface/CATopJetAlgorithm.h
+++ b/RecoJets/JetAlgorithms/interface/CATopJetAlgorithm.h
@@ -19,6 +19,8 @@
 #include <TMath.h>
 #include <iostream>
 
+#include "boost/shared_ptr.hpp"
+
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/CaloTowers/interface/CaloTower.h"
 #include "DataFormats/CaloTowers/interface/CaloTowerFwd.h"

--- a/RecoJets/JetAlgorithms/interface/SubJetAlgorithm.h
+++ b/RecoJets/JetAlgorithms/interface/SubJetAlgorithm.h
@@ -3,6 +3,8 @@
 
 #include <vector>
 
+#include "boost/shared_ptr.hpp"
+
 #include "RecoJets/JetAlgorithms/interface/CompoundPseudoJet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "RecoJets/JetAlgorithms/interface/FastPrunePlugin.hh"

--- a/RecoJets/JetAlgorithms/src/SubJetAlgorithm.cc
+++ b/RecoJets/JetAlgorithms/src/SubJetAlgorithm.cc
@@ -3,6 +3,8 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #include "fastjet/ClusterSequenceArea.hh"
 
+#include "boost/shared_ptr.hpp"
+
 using namespace std;
 using namespace edm;
 

--- a/RecoJets/JetProducers/interface/PileUpSubtractor.h
+++ b/RecoJets/JetProducers/interface/PileUpSubtractor.h
@@ -2,6 +2,7 @@
 #define __PUSubtractor__
 
 #include <vector>
+#include "boost/shared_ptr.hpp"
 #include "fastjet/PseudoJet.hh"
 #include "fastjet/ClusterSequence.hh"
 #include "fastjet/ClusterSequenceArea.hh"

--- a/RecoMuon/MuonIdentification/interface/MuonCaloCompatibility.h
+++ b/RecoMuon/MuonIdentification/interface/MuonCaloCompatibility.h
@@ -21,6 +21,7 @@
 #include "TFile.h"
 #include "DataFormats/MuonReco/interface/Muon.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "boost/shared_ptr.hpp"
 #include <string>
 
 class MuonCaloCompatibility {

--- a/RecoParticleFlow/PFProducer/interface/PFElectronAlgo.h
+++ b/RecoParticleFlow/PFProducer/interface/PFElectronAlgo.h
@@ -12,6 +12,7 @@
 #include "DataFormats/ParticleFlowReco/interface/PFBlockElementGsfTrack.h"
 #include "DataFormats/ParticleFlowReco/interface/PFBlockElementTrack.h"
 #include "TMVA/Reader.h"
+#include "boost/shared_ptr.hpp"
 #include <iostream>
 
 

--- a/RecoTauTag/RecoTau/interface/RecoTauConstructor.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauConstructor.h
@@ -31,6 +31,7 @@
 #include "DataFormats/TauReco/interface/PFRecoTauChargedHadron.h"
 #include "DataFormats/TauReco/interface/RecoTauPiZero.h"
 
+#include "boost/shared_ptr.hpp"
 #include <vector>
 
 namespace reco { namespace tau {


### PR DESCRIPTION
Totally trivial. Please bypass signatures if not signed promptly.

We are in the process of replacing boost::shared_ptr with std::shared_ptr in the framework for ROOT6, and as much as possible in ROOT 5.
This will require adding missing includes of "boost/shared_ptr.hpp" in some files outside the framework that will still use boost::shared_ptr.  This pull request does that.
It also adds one other missing include to ModuleDescription.h, and removes a totally unnecessary #include of "boost/shared_ptr.hpp" from ModuleDescription.h.
