### PR TITLE
Temporarily assign number of strips and pads to -999

### DIFF
--- a/Geometry/GEMGeometryBuilder/src/ME0GeometryBuilderFromDDD.cc
+++ b/Geometry/GEMGeometryBuilder/src/ME0GeometryBuilderFromDDD.cc
@@ -109,9 +109,11 @@ ME0Geometry* ME0GeometryBuilderFromDDD::buildGeometry(DDFilteredView& fview, con
     std::vector<float> pars;
     pars.push_back(be); 
     pars.push_back(te); 
-    pars.push_back(ap); 
-    //    pars.push_back(nStrips);
-    // pars.push_back(nPads);
+    pars.push_back(ap);
+    float nStrips = -999.;
+    float nPads = -999.;
+    pars.push_back(nStrips);
+    pars.push_back(nPads);
 
     LogDebug("ME0GeometryBuilderFromDDD") 
       << "ME0 " << name << " par " << be << " " << te << " " << ap << " " << dpar[0];


### PR DESCRIPTION
ME0 strips or pads are not used anywhere in the DIGI or RECO steps. Temporarily assign them to -999 and fix them later when ME0 readout is defined. This is just to prevent the ME0GeometryBuilder from crashing sporadically. 
