### PR TITLE
New fastsim event content for pileup

### DIFF
--- a/FastSimulation/Configuration/python/CommonInputs_cff.py
+++ b/FastSimulation/Configuration/python/CommonInputs_cff.py
@@ -30,9 +30,9 @@ from RecoLocalCalo.EcalRecAlgos.EcalSeverityLevelESProducer_cfi import *
 
 # CaloMode is defined here
 # 0: custom local reco bypassing digis, ECAL and HCAL; default before 61x
-# 1: as 0, but full digi + std local reco in ECAL <---- DEFAULT
+# 1: as 0, but full digi + std local reco in ECAL 
 # 2: as 0, but full digi + std local reco in HCAL
-# 3: full digi + std local reco in ECAL and HCAL; planned to become default soon
+# 3: full digi + std local reco in ECAL and HCAL <---- DEFAULT
 
 CaloMode = 3
 

--- a/FastSimulation/Configuration/python/EventContent_cff.py
+++ b/FastSimulation/Configuration/python/EventContent_cff.py
@@ -246,3 +246,16 @@ FEVTDEBUGHLTEventContent.outputCommands.extend(FastSimRecoLocalTrackerFEVT.outpu
 FEVTDEBUGHLTEventContent.outputCommands.extend(FastSimRecoLocalCaloFEVT.outputCommands)
 FEVTDEBUGHLTEventContent.outputCommands.extend(FastSimRecoTrackerFEVT.outputCommands)
 FEVTDEBUGHLTEventContent.outputCommands.extend(FastSimParticleFlowFEVT.outputCommands) 
+
+#####################################################################
+#
+# To be used only to create the MinBias sample for "new mixing" (--eventcontent=FASTPU)
+#
+#####################################################################
+FASTPUEventContent = cms.PSet(
+    outputCommands = cms.untracked.vstring('drop *', 
+                                           'keep *_famosSimHits_*_*',
+                                           'keep *_MuonSimHits_*_*',
+                                           'keep Traj*_*_*_*',
+                                           'keep *_generalTracks_*_*')
+    )


### PR DESCRIPTION
This PR introduces a new event content for FastSim, called FASTPU, to be used with the new pileup scheme.
More information in this PPD talk (slide 16 is related to the event content):
https://indico.cern.ch/event/317624/contribution/1/material/slides/0.pdf

This new event content should be used in a dedicated MinBias workflow like that:

<pre>
cmsDriver.py MinBias_13TeV_cfi -s GEN,SIM,RECO --conditions auto:startup_GRun --eventcontent=FASTPU --fast -n 100
</pre>


(I suppose that creating a new workflow should be done by the specific experts, but if you think that I should do that, please tell me which files to modify, and which numbering convention I should follow.)

Given that the modification is really minimal, I suggest to merge this in 71x already, in order to allow PdmV to start the production of this sample, and gain time. The next step from my side, once this MinBias sample will have been created, will be to make use of the new mixing scheme in a workflow to be used for validation, as agreed during a PPD meeting.
