### PR TITLE
Pull request #4195 also applied to ME0GeometryBuilderFromCondDB

### DIFF
--- a/Geometry/GEMGeometryBuilder/src/ME0GeometryBuilderFromCondDB.cc
+++ b/Geometry/GEMGeometryBuilder/src/ME0GeometryBuilderFromCondDB.cc
@@ -72,8 +72,10 @@ ME0Geometry* ME0GeometryBuilderFromCondDB::build(const RecoIdealGeometry& rgeo)
     pars.push_back(be); //b/2;
     pars.push_back(te); //B/2;
     pars.push_back(ap); //h/2;
-    //    pars.push_back(nstrip);
-    // pars.push_back(npad);
+    float nstrip = -999.;
+    float npad = -999.;
+    pars.push_back(nstrip);
+    pars.push_back(npad);
     
     ME0EtaPartitionSpecs* e_p_specs = new ME0EtaPartitionSpecs(GeomDetEnumerators::ME0, name, pars);
       

--- a/Geometry/GEMGeometryBuilder/src/ME0GeometryBuilderFromDDD.cc
+++ b/Geometry/GEMGeometryBuilder/src/ME0GeometryBuilderFromDDD.cc
@@ -109,9 +109,11 @@ ME0Geometry* ME0GeometryBuilderFromDDD::buildGeometry(DDFilteredView& fview, con
     std::vector<float> pars;
     pars.push_back(be); 
     pars.push_back(te); 
-    pars.push_back(ap); 
-    //    pars.push_back(nStrips);
-    // pars.push_back(nPads);
+    pars.push_back(ap);
+    float nStrips = -999.;
+    float nPads = -999.;
+    pars.push_back(nStrips);
+    pars.push_back(nPads);
 
     LogDebug("ME0GeometryBuilderFromDDD") 
       << "ME0 " << name << " par " << be << " " << te << " " << ap << " " << dpar[0];


### PR DESCRIPTION
@dildick created a fix for an intermittent crash with #4195 which fixes ME0GeometryBuilderFromCondDDD.  This applies the same fix to ME0GeometryBuilderFromCondDB.  I have no idea if this code is ever used but figured it was better to fix it in case it is, since the crash is intermittent and hard to trace.  This also includes #4195.
