### PR TITLE
demote message status of gap-region linking bug

### DIFF
--- a/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
@@ -1097,7 +1097,7 @@ initializeProtoCands(std::list<PFEGammaAlgo::ProtoEGObject>& egobjs) {
 	 // link tests in the gap region can current split a gap electron
 	 // HEY THIS IS A WORK AROUND FOR A KNOWN BUG IN PFBLOCKALGO
 	 // MAYBE WE SHOULD FIX IT??????????????????????????????????
-	 LOGERR("PFEGammaAlgo")
+	 LOGDRESSED("PFEGammaAlgo")
 	   << "Encountered the known GSF-SC splitting bug "
 	   << " in PFBlockAlgo! We should really fix this!" << std::endl; 
        } else { // SC was not in a earlier proto-object	


### PR DESCRIPTION
Gap region linking bug will no longer be noisy.
