### PR TITLE
Fixed neutron background simulation

### DIFF
--- a/SimG4Core/Application/python/NeutronBGforMuonsHP_cff.py
+++ b/SimG4Core/Application/python/NeutronBGforMuonsHP_cff.py
@@ -5,7 +5,7 @@ def customise(process):
     # fragment allowing to simulate neutron background in muon system
 
   if hasattr(process,'g4SimHits'):
-    # time window 10 millisecond
+    # time window 100 millisecond
     process.common_maximum_time.MaxTrackTime = cms.double(100000000.0)
     process.common_maximum_time.MaxTimeNames = cms.vstring('ZDCRegion')
     process.common_maximum_time.MaxTrackTimes = cms.vdouble(2000)
@@ -13,6 +13,7 @@ def customise(process):
     process.g4SimHits.Physics.type = cms.string('SimG4Core/Physics/FTFP_BERT_HP_EML')
     process.g4SimHits.Physics.CutsOnProton  = cms.untracked.bool(False)
     process.g4SimHits.Physics.FlagFluo    = cms.bool(True)
+    process.g4SimHits.Physics.TrackingCut = cms.bool(False)
     process.g4SimHits.Physics.RusRoGammaEnergyLimit = cms.double(0.0)
     # Eta cut
     process.g4SimHits.Generator.MinEtaCut = cms.double(-7.0)

--- a/SimG4Core/Application/python/NeutronBGforMuonsXS_cff.py
+++ b/SimG4Core/Application/python/NeutronBGforMuonsXS_cff.py
@@ -5,7 +5,7 @@ def customise(process):
     # fragment allowing to simulate neutron background in muon system
 
   if hasattr(process,'g4SimHits'):
-    # time window 10 millisecond
+    # time window 100 millisecond
     process.common_maximum_time.MaxTrackTime = cms.double(100000000.0)
     process.common_maximum_time.MaxTimeNames = cms.vstring('ZDCRegion')
     process.common_maximum_time.MaxTrackTimes = cms.vdouble(2000)
@@ -13,6 +13,7 @@ def customise(process):
     process.g4SimHits.Physics.type = cms.string('SimG4Core/Physics/FTFP_BERT_XS_EML')
     process.g4SimHits.Physics.CutsOnProton  = cms.untracked.bool(False)
     process.g4SimHits.Physics.FlagFluo    = cms.bool(True)
+    process.g4SimHits.Physics.TrackingCut = cms.bool(False)
     process.g4SimHits.Physics.RusRoGammaEnergyLimit = cms.double(0.0)
     # Eta cut
     process.g4SimHits.Generator.MinEtaCut = cms.double(-7.0)


### PR DESCRIPTION
Neutron background simulation is fine in 7_1_X but not in 6_2_X_SLHC due to forgotten option to disable Geant4 tracking cut for neutrons in corresponding custom fragments.

This PR  does not affect mainstream production.
