### PR TITLE
Add ability to account for additional CPU time per event

### DIFF
--- a/FWCore/Services/interface/Timing.h
+++ b/FWCore/Services/interface/Timing.h
@@ -9,6 +9,7 @@
 //
 
 #include "DataFormats/Provenance/interface/ProvenanceFwd.h"
+#include "FWCore/Utilities/interface/TimingServiceBase.h"
 #include <atomic>
 
 namespace edm {
@@ -21,12 +22,14 @@ namespace edm {
   class ModuleCallingContext;
 
   namespace service {
-    class Timing {
+    class Timing : public TimingServiceBase {
     public:
       Timing(ParameterSet const&,ActivityRegistry&);
       ~Timing();
 
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+
+      virtual void addToCPUTime(StreamID id, double iTime) override;
 
     private:
       

--- a/FWCore/Services/plugins/Module.cc
+++ b/FWCore/Services/plugins/Module.cc
@@ -45,3 +45,5 @@ DEFINE_FWK_SERVICE_MAKER(EnableFloatingPointExceptions,edm::serviceregistry::All
 DEFINE_FWK_SERVICE_MAKER(LoadAllDictionaries,edm::serviceregistry::ParameterSetMaker<LoadAllDictionaries>);
 typedef edm::serviceregistry::AllArgsMaker<edm::JobReport,JobReportService> JobReportMaker;
 DEFINE_FWK_SERVICE_MAKER(JobReportService, JobReportMaker);
+typedef edm::serviceregistry::AllArgsMaker<edm::TimingServiceBase,Timing> TimingMaker;
+DEFINE_FWK_SERVICE_MAKER(Timing, TimingMaker);

--- a/FWCore/Services/src/Timing.cc
+++ b/FWCore/Services/src/Timing.cc
@@ -103,6 +103,12 @@ namespace edm {
 
     Timing::~Timing() {
     }
+    
+    void Timing::addToCPUTime(StreamID id, double iTime) {
+      //For accounting purposes we effectively can saw we started earlier
+      curr_events_cpu_[id.value()] -= iTime;
+    }
+
 
     void Timing::fillDescriptions(ConfigurationDescriptions& descriptions) {
       ParameterSetDescription desc;

--- a/FWCore/Utilities/interface/TimingServiceBase.h
+++ b/FWCore/Utilities/interface/TimingServiceBase.h
@@ -1,0 +1,49 @@
+#ifndef FWCore_Utilities_TimingServiceBase_h
+#define FWCore_Utilities_TimingServiceBase_h
+// -*- C++ -*-
+//
+// Package:     FWCore/Utilities
+// Class  :     TimingServiceBase
+// 
+/**\class TimingServiceBase TimingServiceBase.h "TimingServiceBase.h"
+
+ Description: Base class for Timing Services
+
+ Usage:
+    Provides an interface to allow
+
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  Wed, 11 Jun 2014 14:50:33 GMT
+//
+
+// system include files
+
+// user include files
+#include "FWCore/Utilities/interface/StreamID.h"
+
+// forward declarations
+namespace edm {
+  class TimingServiceBase
+  {
+    
+  public:
+    TimingServiceBase();
+    virtual ~TimingServiceBase();
+    
+    // ---------- member functions ---------------------------
+    ///Extra CPU time used by a job but not seen by cmsRun
+    /// The value should be in seconds.
+    /// This function is safe to call from multiple threads
+    virtual void addToCPUTime(StreamID id, double iTime) = 0;
+    
+  private:
+    TimingServiceBase(const TimingServiceBase&) =delete; // stop default
+    
+    const TimingServiceBase& operator=(const TimingServiceBase&) =delete; // stop default
+  };
+}
+
+
+#endif

--- a/FWCore/Utilities/src/TimingServiceBase.cc
+++ b/FWCore/Utilities/src/TimingServiceBase.cc
@@ -1,0 +1,32 @@
+// -*- C++ -*-
+//
+// Package:     Subsystem/Package
+// Class  :     TimingServiceBase
+// 
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Chris Jones
+//         Created:  Wed, 11 Jun 2014 15:08:00 GMT
+//
+
+// system include files
+
+// user include files
+#include "FWCore/Utilities/interface/TimingServiceBase.h"
+
+using namespace edm;
+//
+// constants, enums and typedefs
+//
+
+//
+// constructors and destructor
+//
+TimingServiceBase::TimingServiceBase()
+{
+}
+
+TimingServiceBase::~TimingServiceBase()
+{
+}


### PR DESCRIPTION
Created a new base class for the Timing Service so other modules can report additional CPU time spent by a job external to cmsRun.
