### PR TITLE
Removed use of thread local from CondFormats/EcalObjects

### DIFF
--- a/CondFormats/EcalObjects/interface/EcalCondObjectContainer.h
+++ b/CondFormats/EcalObjects/interface/EcalCondObjectContainer.h
@@ -7,6 +7,8 @@
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
 #include "DataFormats/EcalDetId/interface/EEDetId.h"
 
+#include "CondFormats/EcalObjects/interface/throwInvalidRawIdException.h"
+
 template < typename T >
 class EcalCondObjectContainer {
         public:
@@ -51,7 +53,7 @@ class EcalCondObjectContainer {
                                         }
                                         break;
                                 default:
-                                        // FIXME (add throw)
+    				        ecalobjects::throwInvalidRawIdException("EcalCondObjectContainer<T>::insert",a.first);
                                         return;
                         }
                 }
@@ -76,7 +78,6 @@ class EcalCondObjectContainer {
                                         }
                                         break;
                                 default:
-                                        // FIXME (add throw)
                                         return ee_.end();
                         }
                 }
@@ -124,9 +125,12 @@ class EcalCondObjectContainer {
                                         }
                                         break;
                                 default:
-                                        // FIXME (add throw)
-                                        thread_local static Item dummy;
-                                        return dummy;
+				        {
+					        ecalobjects::throwInvalidRawIdException("EcalCondObjectContainer<T>::operator[]",rawId);
+						static T dummy;
+						return dummy;
+					}
+
                         }
                 }
 #else
@@ -148,9 +152,9 @@ class EcalCondObjectContainer {
                                         }
                                         break;
                                 default:
-                                        // FIXME (add throw)
-                                        // sizeof(Item) <= sizeof(int64_t) for all Items.
-                                        return Item();
+					        ecalobjects::throwInvalidRawIdException("EcalCondObjectContainer<T>::operator[]",rawId);
+						// sizeof(Item) <= sizeof(int64_t) for all Items.
+						return Item();
                         }
                 }
                 

--- a/CondFormats/EcalObjects/interface/EcalCondTowerObjectContainer.h
+++ b/CondFormats/EcalObjects/interface/EcalCondTowerObjectContainer.h
@@ -6,7 +6,7 @@
 #include "DataFormats/EcalDetId/interface/EcalContainer.h"
 #include "DataFormats/EcalDetId/interface/EcalTrigTowerDetId.h"
 #include "DataFormats/EcalDetId/interface/EcalScDetId.h"
-
+#include "CondFormats/EcalObjects/interface/throwInvalidRawIdException.h"
 
 // #include <cstdio>
 
@@ -109,7 +109,8 @@ class EcalCondTowerObjectContainer {
 			} else if(  id.subdetId() == EcalEndcap  ) { 
 			  return ee_[rawId];
 			} else {
-                          thread_local static Item dummy;
+			  ecalobjects::throwInvalidRawIdException("EcalCondTowerObjectContainer<T>::operator[]",rawId);
+			  static T dummy;
 			  return dummy;
                         }
                 }

--- a/CondFormats/EcalObjects/interface/throwInvalidRawIdException.h
+++ b/CondFormats/EcalObjects/interface/throwInvalidRawIdException.h
@@ -1,0 +1,30 @@
+#ifndef CondFormats_EcalObjects_throwInvalidRawIdException_h
+#define CondFormats_EcalObjects_throwInvalidRawIdException_h
+// -*- C++ -*-
+//
+// Package:     CondFormats/EcalObjects
+// Class  :     throwInvalidRawIdException
+// 
+/**\function ecalobjects::throwInvalidRawIdException throwInvalidRawIdException.h "CondFormats/EcalObjects/interface/throwInvalidRawIdException.h"
+
+ Description: Function to throw an invalid index exception
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Christopher Jones
+//         Created:  Wed, 11 Jun 2014 20:37:28 GMT
+//
+
+// system include files
+
+// user include files
+
+// forward declarations
+namespace ecalobjects {
+  void throwInvalidRawIdException(const char* iAction, uint32_t iBadID);
+}
+
+#endif

--- a/CondFormats/EcalObjects/src/throwInvalidRawIdException.cc
+++ b/CondFormats/EcalObjects/src/throwInvalidRawIdException.cc
@@ -1,0 +1,23 @@
+// -*- C++ -*-
+//
+// Package:     CondFormats/EcalObjects
+// Class  :     throwInvalidIndexException
+// 
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Christopher Jones
+//         Created:  Wed, 11 Jun 2014 20:37:36 GMT
+//
+
+// system include files
+
+// user include files
+#include "FWCore/Utilities/interface/Exception.h"
+#include "CondFormats/EcalObjects/interface/throwInvalidRawIdException.h"
+
+namespace ecalobjects {
+  void throwInvalidRawIdException(const char* iAction, uint32_t iBadID) {
+    throw cms::Exception("InvalidRawId")<<iAction<<" used invalid rawid "<<iBadID;
+  }
+}


### PR DESCRIPTION
The std::thread_local was being used to return dummy values in the
case where an invalid id was requested. Comments in the code said
that should be fixed and replaced with an exception. This change
does exactly that.
This is needed to reduce our use of thread local in order to get
under the system limit for thread locals in shared libraries.
