### PR TITLE
Make the magnetic field record for the PixelCPEGeneric configurable

### DIFF
--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGenericESProducer.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGenericESProducer.h
@@ -15,7 +15,7 @@ class  PixelCPEGenericESProducer: public edm::ESProducer{
  private:
   boost::shared_ptr<PixelClusterParameterEstimator> cpe_;
   edm::ParameterSet pset_;
-  std::string magname_;
+  edm::ESInputTag magname_;
   bool useLAWidthFromDB_;
   bool useLAAlignmentOffsets_;
 };

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGenericESProducer.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGenericESProducer.h
@@ -15,6 +15,7 @@ class  PixelCPEGenericESProducer: public edm::ESProducer{
  private:
   boost::shared_ptr<PixelClusterParameterEstimator> cpe_;
   edm::ParameterSet pset_;
+  std::string magname_;
   bool useLAWidthFromDB_;
   bool useLAAlignmentOffsets_;
 };

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEGenericESProducer.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEGenericESProducer.cc
@@ -30,6 +30,8 @@ PixelCPEGenericESProducer::PixelCPEGenericESProducer(const edm::ParameterSet & p
   // Use Alignment LA-offset 
   useLAAlignmentOffsets_ = p.existsAs<bool>("useLAAlignmentOffsets")?
     p.getParameter<bool>("useLAAlignmentOffsets"):false;
+  magname_ = p.existsAs<std::string>("MagneticFieldRecord")?
+    p.getParameter<std::string>("MagneticFieldRecord"):"";
 
   pset_ = p;
   setWhatProduced(this,myname);
@@ -44,7 +46,7 @@ boost::shared_ptr<PixelClusterParameterEstimator>
 PixelCPEGenericESProducer::produce(const TkPixelCPERecord & iRecord){ 
 
   ESHandle<MagneticField> magfield;
-  iRecord.getRecord<IdealMagneticFieldRecord>().get( magfield );
+  iRecord.getRecord<IdealMagneticFieldRecord>().get( magname_, magfield );
 
   edm::ESHandle<TrackerGeometry> pDD;
   iRecord.getRecord<TrackerDigiGeometryRecord>().get( pDD );

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEGenericESProducer.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEGenericESProducer.cc
@@ -30,8 +30,8 @@ PixelCPEGenericESProducer::PixelCPEGenericESProducer(const edm::ParameterSet & p
   // Use Alignment LA-offset 
   useLAAlignmentOffsets_ = p.existsAs<bool>("useLAAlignmentOffsets")?
     p.getParameter<bool>("useLAAlignmentOffsets"):false;
-  magname_ = p.existsAs<std::string>("MagneticFieldRecord")?
-    p.getParameter<std::string>("MagneticFieldRecord"):"";
+  magname_ = p.existsAs<edm::ESInputTag>("MagneticFieldRecord")?
+    p.getParameter<edm::ESInputTag>("MagneticFieldRecord"):edm::ESInputTag("");
 
   pset_ = p;
   setWhatProduced(this,myname);

--- a/RecoLocalTracker/SiPixelRecHits/python/PixelCPEGeneric_cfi.py
+++ b/RecoLocalTracker/SiPixelRecHits/python/PixelCPEGeneric_cfi.py
@@ -55,6 +55,8 @@ PixelCPEGenericESProducer = cms.ESProducer("PixelCPEGenericESProducer",
     # Use the LA-Offsets from Alignment instead of our calibration
     useLAAlignmentOffsets = cms.bool(False),                             
                                            
+    #MagneticFieldRecord: e.g. "" or "ParabolicMF"
+    MagneticFieldRecord = cms.string(""),
 )
 
 

--- a/RecoLocalTracker/SiPixelRecHits/python/PixelCPEGeneric_cfi.py
+++ b/RecoLocalTracker/SiPixelRecHits/python/PixelCPEGeneric_cfi.py
@@ -56,7 +56,7 @@ PixelCPEGenericESProducer = cms.ESProducer("PixelCPEGenericESProducer",
     useLAAlignmentOffsets = cms.bool(False),                             
                                            
     #MagneticFieldRecord: e.g. "" or "ParabolicMF"
-    MagneticFieldRecord = cms.string(""),
+    MagneticFieldRecord = cms.ESInputTag(""),
 )
 
 


### PR DESCRIPTION
Make the magnetic field record for the PixelCPEGeneric configurable.
No change in the default. So No change in reconstruction.
(Potentially used in HLT for performance improvement)
