### PR TITLE
fix the fbin bug in template errors

### DIFF
--- a/EventFilter/SiPixelRawToDigi/test/SiPixelRawDumper.cc
+++ b/EventFilter/SiPixelRawToDigi/test/SiPixelRawDumper.cc
@@ -3,7 +3,7 @@
  *  for pixel subdetector
  *  Added class to interpret the data d.k. 30/10/08
  *  Add histograms. Add pix 0 detection.
- * Works with v7x
+ * Works with v7x, comment out the digis access.
  */
 
 #include "FWCore/Framework/interface/EDAnalyzer.h"
@@ -989,8 +989,8 @@ void SiPixelRawDumper::analyze(const  edm::Event& ev, const edm::EventSetup& es)
 
   std::pair<int,int> fedIds(FEDNumbering::MINSiPixelFEDID, FEDNumbering::MAXSiPixelFEDID);
 
-  PixelDataFormatter formatter(0);
-  bool dummyErrorBool;
+  //PixelDataFormatter formatter(0);  // only for digis
+  //bool dummyErrorBool;
 
   //typedef unsigned int Word32;
   //typedef long long Word64;
@@ -1017,7 +1017,7 @@ void SiPixelRawDumper::analyze(const  edm::Event& ev, const edm::EventSetup& es)
     //LogDebug("SiPixelRawDumper")<< " GET DATA FOR FED: " <<  fedId ;
     if(printHeaders) cout<<"Get data For FED = "<<fedId<<endl;
 
-    edm::DetSetVector<PixelDigi> collection;
+    //edm::DetSetVector<PixelDigi> collection;
     PixelDataFormatter::Errors errors;
 
     //get event data for this fed
@@ -1270,7 +1270,7 @@ void SiPixelRawDumper::analyze(const  edm::Event& ev, const edm::EventSetup& es)
     countErrorsPerEvent2 += countErrorsInFed2;
 
     //convert data to digi (dummy for the moment)
-    formatter.interpretRawData( dummyErrorBool, fedId, rawData, collection, errors);
+    //formatter.interpretRawData( dummyErrorBool, fedId, rawData, collection, errors);
     //cout<<dummyErrorBool<<" "<<digis.size()<<" "<<errors.size()<<endl;
 
     if(countPixelsInFed>0)  {

--- a/EventFilter/SiPixelRawToDigi/test/findHotPixels.cc
+++ b/EventFilter/SiPixelRawToDigi/test/findHotPixels.cc
@@ -470,11 +470,9 @@ void findHotPixels::analyze(const  edm::Event& ev, const edm::EventSetup& es) {
 
   std::pair<int,int> fedIds(FEDNumbering::MINSiPixelFEDID, FEDNumbering::MAXSiPixelFEDID);
   
-  PixelDataFormatter formatter(0);
-  bool dummyErrorBool;
+  //PixelDataFormatter formatter(0); // to get digis
+  //bool dummyErrorBool;
   
-  //typedef unsigned int Word32;
-  //typedef long long Word64;
   typedef uint32_t Word32;
   typedef uint64_t Word64;
   int status=0;
@@ -486,7 +484,7 @@ void findHotPixels::analyze(const  edm::Event& ev, const edm::EventSetup& es) {
   countAllEvents++;
   if(printHeaders) cout<<" Event = "<<countEvents<<endl;
   
-  edm::DetSetVector<PixelDigi> collection;
+  //edm::DetSetVector<PixelDigi> collection; // for digis only
 
 
   // Loop over FEDs
@@ -537,7 +535,7 @@ void findHotPixels::analyze(const  edm::Event& ev, const edm::EventSetup& es) {
     countErrors += countErrorsInFed;
     
     //convert data to digi (dummy for the moment)
-    formatter.interpretRawData( dummyErrorBool, fedId, rawData,  collection, errors);
+    //formatter.interpretRawData( dummyErrorBool, fedId, rawData,  collection, errors);
     //cout<<dummyErrorBool<<" "<<digis.size()<<" "<<errors.size()<<endl;
     
     if(countPixelsInFed>0)  {

--- a/EventFilter/SiPixelRawToDigi/test/runFedErrorDumper.py
+++ b/EventFilter/SiPixelRawToDigi/test/runFedErrorDumper.py
@@ -3,30 +3,6 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("i")
 
-## import HLTrigger.HLTfilters.hltHighLevel_cfi as hlt
-## # accept if 'path_1' succeeds
-## process.hltfilter = hlt.hltHighLevel.clone(
-## # Min-Bias
-## #    HLTPaths = ['HLT_Physics_v1'],
-## #    HLTPaths = ['HLT_L1Tech_BSC_minBias_threshold1_v1'],
-## #    HLTPaths = ['HLT_Random_v1'],
-## #    HLTPaths = ['HLT_ZeroBias_v*'],
-## # old
-## #    HLTPaths = ['HLT_L1_BPTX_MinusOnly','HLT_L1_BPTX_PlusOnly'],
-## #    HLTPaths = ['HLT_L1Tech_BSC_minBias'],
-## #    HLTPaths = ['HLT_L1Tech_BSC_minBias_OR'],
-## # Commissioning:
-## #    HLTPaths = ['HLT_L1_Interbunch_BSC_v1'],
-## #    HLTPaths = ['HLT_L1_PreCollisions_v1'],
-## #    HLTPaths = ['HLT_BeamGas_BSC_v1'],
-## #    HLTPaths = ['HLT_BeamGas_HF_v1'],
-## # old
-## #    HLTPaths = ['HLT_L1_BPTX','HLT_ZeroBias','HLT_L1_BPTX_MinusOnly','HLT_L1_BPTX_PlusOnly'],
-## #    HLTPaths = ['p*'],
-## #    HLTPaths = ['path_?'],
-##     andOr = True,  # False = and, True=or
-##     throw = False
-##     )
 
 process.MessageLogger = cms.Service("MessageLogger",
      debugModules = cms.untracked.vstring('dumper'),
@@ -45,29 +21,24 @@ process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(-1)
 )
 
-process.TFileService = cms.Service("TFileService",
-    fileName = cms.string('histo.root')
-)
 
 process.source = cms.Source("PoolSource",
-#    fileNames = cms.untracked.vstring('file:/afs/cern.ch/work/d/dkotlins/public/test.root'))
-    fileNames = cms.untracked.vstring('file:/afs/cern.ch/work/d/dkotlins/public/digis.root'))
-#    fileNames = cms.untracked.vstring('file:/tmp/dkotlins/digis.root'))
+#    fileNames = cms.untracked.vstring('file:/afs/cern.ch/work/d/dkotlins/public/digis.root'))
+    fileNames = cms.untracked.vstring('file:digis.root'))
 
 #process.out = cms.OutputModule("PoolOutputModule",
 #    fileName =  cms.untracked.string('file:histos.root')
 #)
 
-process.dumper = cms.EDAnalyzer("FedErrorDumper", 
-#    Timing = cms.untracked.bool(False),
-    Verbosity = cms.untracked.bool(True),
-#    IncludeErrors = cms.untracked.bool(True),
-#    InputLabel = cms.untracked.string('source'),
-    InputLabel = cms.untracked.string('siPixelDigis'),
-#    CheckPixelOrder = cms.untracked.bool(False)
+process.TFileService = cms.Service("TFileService",
+    fileName = cms.string('histo.root')
 )
 
-# process.p = cms.Path(process.hltfilter*process.dumper)
+process.dumper = cms.EDAnalyzer("FedErrorDumper", 
+    Verbosity = cms.untracked.bool(True),
+    InputLabel = cms.untracked.string('siPixelDigis'),
+)
+
 process.p = cms.Path(process.dumper)
 
 # process.ep = cms.EndPath(process.out)

--- a/EventFilter/SiPixelRawToDigi/test/runHotPixels_cfg.py
+++ b/EventFilter/SiPixelRawToDigi/test/runHotPixels_cfg.py
@@ -42,68 +42,13 @@ process.MessageLogger = cms.Service("MessageLogger",
 #process.MessageLogger.cerr.threshold = 'Debug'
 
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(-1)
+    input = cms.untracked.int32(10)
 )
 
 process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring(                          
-# "/store/data/Commissioning11/Cosmics/RAW/v1/000/157/884/FE867543-D938-E011-B9C4-001D09F2983F.root",
-# 186160
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/Cosmics/RAW/v1/000/186/160/0224F8A5-6A61-E111-BCC5-BCAEC5329708.root"
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/Commissioning/RAW/v1/000/186/160/04D2072A-8161-E111-9058-BCAEC518FF5A.root"
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/186/160/60406E4F-8A61-E111-9CF3-BCAEC53296F8.root",
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/186/160/62193B74-6D61-E111-8044-BCAEC518FF7A.root",
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/186/160/847DCF6E-8061-E111-9638-BCAEC5329708.root",
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/186/160/9C639109-9E61-E111-BC15-E0CB4E55365C.root",
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/186/160/A4420D9C-7661-E111-8763-5404A63886BD.root",
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/186/160/EC5A04E5-9461-E111-8600-BCAEC53296F5.root",
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/186/160/F2915E5C-A461-E111-8FBF-BCAEC532970D.root"
-# 185984
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/Commissioning/RAW/v1/000/185/984/00DB308B-775E-E111-94B1-BCAEC532972E.root"
-# 185250
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/Commissioning/RAW/v1/000/185/250/0286CCB5-7858-E111-B19E-BCAEC5329708.root"
-
-# 186822
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/186/822/06D621F9-1C68-E111-817A-001D09F2906A.root",
-    
-# 186996
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/186/996/1A8BFCC6-BE68-E111-B0F5-0019B9F72F97.root",
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/186/996/1E2C2DC4-B468-E111-B1C6-001D09F25267.root",
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/186/996/1ECD78E8-D068-E111-9B5F-001D09F29321.root",
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/186/996/2A2E8E83-A968-E111-97A0-001D09F24399.root",
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/186/996/523DC559-EC68-E111-9534-0019B9F4A1D7.root",
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/186/996/5E323AB2-E668-E111-B4FA-001D09F295FB.root",
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/186/996/62F17EC4-C768-E111-A53F-001D09F23D1D.root",
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/186/996/7A1B5B90-DD68-E111-AB69-001D09F2983F.root",
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/186/996/A045EE58-A068-E111-8DCF-001D09F27003.root",
-
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/Cosmics/RAW/v1/000/186/996/007B8341-C468-E111-9909-001D09F2906A.root",
-
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/Commissioning/RAW/v1/000/186/996/006860ED-D068-E111-8327-001D09F24303.root",
-
-# 187361
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/187/361/483A4D50-566A-E111-AE98-001D09F2AF96.root",
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/187/361/5630B3CF-6C6A-E111-BA18-001D09F28F25.root",
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/187/361/6CD5D083-806A-E111-BEDD-001D09F2906A.root",
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/187/361/70C71F71-856A-E111-839E-001D09F2983F.root",
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/187/361/A6868F2F-676A-E111-AD64-001D09F2305C.root",
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/187/361/B465D505-5E6A-E111-952C-001D09F29114.root",
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/187/361/F6994FC3-786A-E111-99FA-001D09F25267.root",
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/187/361/F6BA5695-746A-E111-B8EF-001D09F2910A.root",
-
-# 187446
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/187/446/02CC6857-376B-E111-ADC2-001D09F28E80.root",
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/187/446/0438B1B9-826B-E111-919B-001D09F24D8A.root",
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/187/446/065A1CA7-3D6B-E111-81A4-001D09F24FEC.root",
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/187/446/088CEEC5-2C6B-E111-9C1D-001D09F24D67.root",
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/187/446/12549E7F-916B-E111-8972-001D09F2B30B.root",
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/187/446/146B7135-546B-E111-8E3E-0019B9F72F97.root",
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/187/446/1630241C-A36B-E111-ADC0-003048D374F2.root",
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/187/446/16B7554B-436B-E111-BAEC-001D09F251FE.root",
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/187/446/1883852F-4D6B-E111-ACF5-001D09F241F0.root",
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/187/446/24FCE29B-1C6B-E111-928D-001D09F2910A.root",
+    fileNames = cms.untracked.vstring(                         
  
-  "rfio:/castor/cern.ch/cms/store/data/Run2012D/MinimumBias/RAW/v1/000/205/217/2EF61B7D-F216-E211-98C3-001D09F28D54.root",
+#  "rfio:/castor/cern.ch/cms/store/data/Run2012D/MinimumBias/RAW/v1/000/205/217/2EF61B7D-F216-E211-98C3-001D09F28D54.root",
 #  "rfio:/castor/cern.ch/cms/store/data/Run2012D/MinimumBias/RAW/v1/000/205/217/6825CA93-0017-E211-8B46-001D09F25267.root",
 #  "rfio:/castor/cern.ch/cms/store/data/Run2012D/MinimumBias/RAW/v1/000/205/217/6C8D4EB2-F116-E211-A7CD-0019B9F70468.root",
 #  "rfio:/castor/cern.ch/cms/store/data/Run2012D/MinimumBias/RAW/v1/000/205/217/96B95E6C-FE16-E211-823E-001D09F295FB.root",
@@ -113,12 +58,13 @@ process.source = cms.Source("PoolSource",
 #  "rfio:/castor/cern.ch/cms/store/data/Run2012D/MinimumBias/RAW/v1/000/205/217/F859580F-F116-E211-B759-485B39897227.root",
 #  "rfio:/castor/cern.ch/cms/store/data/Run2012D/MinimumBias/RAW/v1/000/205/217/FC46615A-F716-E211-924F-001D09F276CF.root",
 
+  "rfio:/castor/cern.ch/cms/store/data/Run2012D/MinimumBias/RAW/v1/000/208/686/A88F66A0-393F-E211-9287-002481E0D524.root",
 
     )
 
 )
 
-process.source.lumisToProcess = cms.untracked.VLuminosityBlockRange('205217:0-205217:323')
+#process.source.lumisToProcess = cms.untracked.VLuminosityBlockRange('205217:0-205217:323')
 #process.source.lumisToProcess = cms.untracked.VLuminosityBlockRange('205718:49-205718:734')
 
 

--- a/EventFilter/SiPixelRawToDigi/test/runRawDumper_cfg.py
+++ b/EventFilter/SiPixelRawToDigi/test/runRawDumper_cfg.py
@@ -41,7 +41,6 @@ process.MessageLogger = cms.Service("MessageLogger",
 #        threshold = cms.untracked.string('DEBUG')
 #    )
 )
-
 #process.MessageLogger.cerr.FwkReport.reportEvery = 1
 #process.MessageLogger.cerr.threshold = 'Debug'
 
@@ -55,69 +54,6 @@ process.TFileService = cms.Service("TFileService",
 
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring(                          
-# 186160 - cosmics
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/Cosmics/RAW/v1/000/186/160/0224F8A5-6A61-E111-BCC5-BCAEC5329708.root"
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/Commissioning/RAW/v1/000/186/160/04D2072A-8161-E111-9058-BCAEC518FF5A.root"
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/186/160/60406E4F-8A61-E111-9CF3-BCAEC53296F8.root",
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/186/160/62193B74-6D61-E111-8044-BCAEC518FF7A.root",
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/186/160/847DCF6E-8061-E111-9638-BCAEC5329708.root",
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/186/160/9C639109-9E61-E111-BC15-E0CB4E55365C.root",
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/186/160/A4420D9C-7661-E111-8763-5404A63886BD.root",
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/186/160/EC5A04E5-9461-E111-8600-BCAEC53296F5.root",
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/186/160/F2915E5C-A461-E111-8FBF-BCAEC532970D.root"
-# 186996
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/186/996/1A8BFCC6-BE68-E111-B0F5-0019B9F72F97.root",
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/186/996/1E2C2DC4-B468-E111-B1C6-001D09F25267.root",
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/186/996/1ECD78E8-D068-E111-9B5F-001D09F29321.root",
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/186/996/2A2E8E83-A968-E111-97A0-001D09F24399.root",
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/186/996/523DC559-EC68-E111-9534-0019B9F4A1D7.root",
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/186/996/5E323AB2-E668-E111-B4FA-001D09F295FB.root",
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/186/996/62F17EC4-C768-E111-A53F-001D09F23D1D.root",
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/186/996/7A1B5B90-DD68-E111-AB69-001D09F2983F.root",
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/186/996/A045EE58-A068-E111-8DCF-001D09F27003.root",
-
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/Cosmics/RAW/v1/000/186/996/007B8341-C468-E111-9909-001D09F2906A.root",
-
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/Commissioning/RAW/v1/000/186/996/006860ED-D068-E111-8327-001D09F24303.root",
-
-# 187446
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/187/446/02CC6857-376B-E111-ADC2-001D09F28E80.root",
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/187/446/0438B1B9-826B-E111-919B-001D09F24D8A.root",
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/187/446/065A1CA7-3D6B-E111-81A4-001D09F24FEC.root",
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/187/446/088CEEC5-2C6B-E111-9C1D-001D09F24D67.root",
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/187/446/12549E7F-916B-E111-8972-001D09F2B30B.root",
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/187/446/146B7135-546B-E111-8E3E-0019B9F72F97.root",
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/187/446/1630241C-A36B-E111-ADC0-003048D374F2.root",
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/187/446/16B7554B-436B-E111-BAEC-001D09F251FE.root",
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/187/446/1883852F-4D6B-E111-ACF5-001D09F241F0.root",
-# "rfio:/castor/cern.ch/cms/store/data/Commissioning12/MinimumBias/RAW/v1/000/187/446/24FCE29B-1C6B-E111-928D-001D09F2910A.root",
-
-# "/store/data/Commissioning12/ZeroBias1/RAW/v1/000/190/411/0002E75F-F57E-E111-BB83-001D09F2447F.root",
-
-# "/store/data/Commissioning12/AlCaLumiPixels/RAW/v1/000/190/411/48147BFB-017F-E111-8B8B-0015C5FDE067.root",
-
-# 191271, fill 2516, 1092bx
-##  "/store/data/Run2012A/MinimumBias/RAW/v1/000/191/271/02F00BC8-1587-E111-8712-BCAEC5364CFB.root",
-##  "/store/data/Run2012A/MinimumBias/RAW/v1/000/191/271/0C1B8DA5-1387-E111-9863-003048D2BA82.root",
-##  "/store/data/Run2012A/MinimumBias/RAW/v1/000/191/271/1808F52A-1487-E111-80A7-001D09F2A49C.root",
-##  "/store/data/Run2012A/MinimumBias/RAW/v1/000/191/271/38E460A5-1387-E111-A9B3-5404A63886C0.root",
-##  "/store/data/Run2012A/MinimumBias/RAW/v1/000/191/271/74542A54-0D87-E111-9414-003048CF9B28.root",
-##  "/store/data/Run2012A/MinimumBias/RAW/v1/000/191/271/8ADB56CB-0D87-E111-BC3D-00215AEDFCCC.root",
-##  "/store/data/Run2012A/MinimumBias/RAW/v1/000/191/271/8E1E30A5-1387-E111-9D57-5404A63886A2.root",
-##  "/store/data/Run2012A/MinimumBias/RAW/v1/000/191/271/B46133EF-1187-E111-B777-0015C5FDE067.root",
-##  "/store/data/Run2012A/MinimumBias/RAW/v1/000/191/271/BCFA4704-1087-E111-BD87-003048F11CF0.root",
-##  "/store/data/Run2012A/MinimumBias/RAW/v1/000/191/271/CE7A0CB8-1987-E111-AE46-003048D3C944.root",
-##  "/store/data/Run2012A/MinimumBias/RAW/v1/000/191/271/D2E5C62A-1487-E111-B079-001D09F290BF.root",
-##  "/store/data/Run2012A/MinimumBias/RAW/v1/000/191/271/E09510CA-0D87-E111-B157-001D09F2A690.root",
-
-# 191718, fill 2534, 1380bc
-#   "/store/data/Run2012A/MinimumBias/RAW/v1/000/191/718/18F61765-DF89-E111-941C-5404A63886EC.root",
-#   "/store/data/Run2012A/MinimumBias/RAW/v1/000/191/718/2C57FC68-DC89-E111-B99C-5404A63886CF.root",
-#   "/store/data/Run2012A/MinimumBias/RAW/v1/000/191/718/525E87E6-DD89-E111-AB92-0025901D631E.root",
-#   "/store/data/Run2012A/MinimumBias/RAW/v1/000/191/718/66EB03A0-E389-E111-BA35-001D09F2B2CF.root",
-#   "/store/data/Run2012A/MinimumBias/RAW/v1/000/191/718/A633C8FE-E289-E111-B56A-003048F11114.root",
-#   "/store/data/Run2012A/MinimumBias/RAW/v1/000/191/718/D06E1F3B-E089-E111-B8A6-001D09F2910A.root",
-#   "/store/data/Run2012A/MinimumBias/RAW/v1/000/191/718/FA809C22-DB89-E111-809C-001D09F29619.root",
 
 ##  "/store/data/Run2012A/AlCaLumiPixels/RAW/v1/000/191/271/00016516-0587-E111-9884-003048D2BBF0.root",
 ##  "/store/data/Run2012A/AlCaLumiPixels/RAW/v1/000/191/271/022D9994-1087-E111-8772-001D09F28D4A.root",
@@ -301,7 +237,7 @@ process.source = cms.Source("PoolSource",
 #  "rfio:/castor/cern.ch/cms/store/data/Run2012C/MinimumBias/RAW/v1/000/201/657/96B51DAE-3EEE-E111-95ED-0019B9F72CE5.root",
 #  "rfio:/castor/cern.ch/cms/store/data/Run2012C/MinimumBias/RAW/v1/000/201/657/E2C43972-3AEE-E111-9D26-003048F024FE.root",
 
-  "rfio:/castor/cern.ch/cms/store/data/Run2012D/MinimumBias/RAW/v1/000/205/217/2EF61B7D-F216-E211-98C3-001D09F28D54.root",
+#  "rfio:/castor/cern.ch/cms/store/data/Run2012D/MinimumBias/RAW/v1/000/205/217/2EF61B7D-F216-E211-98C3-001D09F28D54.root",
 #  "rfio:/castor/cern.ch/cms/store/data/Run2012D/MinimumBias/RAW/v1/000/205/217/6825CA93-0017-E211-8B46-001D09F25267.root",
 #  "rfio:/castor/cern.ch/cms/store/data/Run2012D/MinimumBias/RAW/v1/000/205/217/6C8D4EB2-F116-E211-A7CD-0019B9F70468.root",
 #  "rfio:/castor/cern.ch/cms/store/data/Run2012D/MinimumBias/RAW/v1/000/205/217/96B95E6C-FE16-E211-823E-001D09F295FB.root",
@@ -317,41 +253,7 @@ process.source = cms.Source("PoolSource",
 #  "rfio:/castor/cern.ch/cms/store/data/Run2012D/MinimumBias/RAW/v1/000/205/718/1285A278-E41B-E211-BD9A-0019B9F72F97.root",
 #  "rfio:/castor/cern.ch/cms/store/data/Run2012D/MinimumBias/RAW/v1/000/205/718/1289B6A0-F91B-E211-BC25-001D09F24682.root",
 
-# does not work
-##"/store/data/Run2012D/MinimumBias/RAW/v1/000/205/718/FA450605-001C-E211-850C-003048D2BEA8.root",
-## /store/data/Run2012D/MinimumBias/RAW/v1/000/205/718/F657AB55-F21B-E211-9386-003048F024C2.root
-## /store/data/Run2012D/MinimumBias/RAW/v1/000/205/718/F29D0DA2-F71B-E211-8CA3-001D09F29169.root
-## /store/data/Run2012D/MinimumBias/RAW/v1/000/205/718/EE5A3BA2-ED1B-E211-A298-003048CF99BA.root
-## /store/data/Run2012D/MinimumBias/RAW/v1/000/205/718/E68CD0EB-F81B-E211-8BFA-0030486780B4.root
-## /store/data/Run2012D/MinimumBias/RAW/v1/000/205/718/E25312CE-071C-E211-8D6C-5404A63886B1.root
-## /store/data/Run2012D/MinimumBias/RAW/v1/000/205/718/DA50B038-F61B-E211-ACA4-0025B32034EA.root
-## /store/data/Run2012D/MinimumBias/RAW/v1/000/205/718/C0E0D89B-FE1B-E211-8D00-001D09F34488.root
-## /store/data/Run2012D/MinimumBias/RAW/v1/000/205/718/C014AF3A-EC1B-E211-A56F-001D09F2983F.root
-## /store/data/Run2012D/MinimumBias/RAW/v1/000/205/718/B817D0D9-E51B-E211-BC08-5404A63886EC.root
-## /store/data/Run2012D/MinimumBias/RAW/v1/000/205/718/9EC9D9E5-051C-E211-9870-003048D2C16E.root
-## /store/data/Run2012D/MinimumBias/RAW/v1/000/205/718/9E38AA8A-031C-E211-90BB-0025901D5DEE.root
-## /store/data/Run2012D/MinimumBias/RAW/v1/000/205/718/962974EB-F41B-E211-8CEA-001D09F29169.root
-## /store/data/Run2012D/MinimumBias/RAW/v1/000/205/718/92DDE660-E91B-E211-AC1D-002481E0D524.root
-## /store/data/Run2012D/MinimumBias/RAW/v1/000/205/718/8E378B22-F11B-E211-8B63-BCAEC518FF30.root
-## /store/data/Run2012D/MinimumBias/RAW/v1/000/205/718/86F15B1A-EA1B-E211-8EBE-003048D3756A.root
-## /store/data/Run2012D/MinimumBias/RAW/v1/000/205/718/86509EC6-FB1B-E211-8E64-E0CB4E5536AE.root
-## /store/data/Run2012D/MinimumBias/RAW/v1/000/205/718/7E532F1D-FB1B-E211-A38F-003048D2BB58.root
-## /store/data/Run2012D/MinimumBias/RAW/v1/000/205/718/7A5BCC57-F21B-E211-B943-5404A63886B1.root
-## /store/data/Run2012D/MinimumBias/RAW/v1/000/205/718/76DA051D-FB1B-E211-82D6-003048678098.root
-## /store/data/Run2012D/MinimumBias/RAW/v1/000/205/718/6487640E-ED1B-E211-A111-5404A640A643.root
-## /store/data/Run2012D/MinimumBias/RAW/v1/000/205/718/5E976B97-F31B-E211-8E55-0025901D5D9A.root
-## /store/data/Run2012D/MinimumBias/RAW/v1/000/205/718/48ED4539-F61B-E211-BE6B-00237DDBE0E2.root
-## /store/data/Run2012D/MinimumBias/RAW/v1/000/205/718/429632A8-E81B-E211-83E3-002481E0D90C.root
-## /store/data/Run2012D/MinimumBias/RAW/v1/000/205/718/3A43546E-011C-E211-B54D-003048D375AA.root
-## /store/data/Run2012D/MinimumBias/RAW/v1/000/205/718/3425D3A3-021C-E211-B79E-003048D2C01A.root
-## /store/data/Run2012D/MinimumBias/RAW/v1/000/205/718/1AAD934A-E71B-E211-8C1E-0025901D624A.root
-## /store/data/Run2012D/MinimumBias/RAW/v1/000/205/718/1A00BEAD-F21B-E211-8B1C-001D09F24D8A.root
-## /store/data/Run2012D/MinimumBias/RAW/v1/000/205/718/1289B6A0-F91B-E211-BC25-001D09F24682.root
-## /store/data/Run2012D/MinimumBias/RAW/v1/000/205/718/1285A278-E41B-E211-BD9A-0019B9F72F97.root
-## /store/data/Run2012D/MinimumBias/RAW/v1/000/205/718/08787828-EE1B-E211-B680-0025901D5D78.root
-## /store/data/Run2012D/MinimumBias/RAW/v1/000/205/718/02285033-FD1B-E211-8F74-001D09F295FB.root
-
-#"/store/caf/user/venturia/logerrevent_HI2013_express_v1_210634_210635_v14.root"
+  "rfio:/castor/cern.ch/cms/store/data/Run2012D/MinimumBias/RAW/v1/000/208/686/A88F66A0-393F-E211-9287-002481E0D524.root",
 
   
     )
@@ -368,12 +270,8 @@ process.source = cms.Source("PoolSource",
 # 195774 OK from LS=0
 #process.source.lumisToProcess = cms.untracked.VLuminosityBlockRange('198609:47-198609:112')
 #process.source.lumisToProcess = cms.untracked.VLuminosityBlockRange('201657:77-201657:9999')
-process.source.lumisToProcess = cms.untracked.VLuminosityBlockRange('205217:0-205217:323')
+#process.source.lumisToProcess = cms.untracked.VLuminosityBlockRange('205217:0-205217:323')
 #process.source.lumisToProcess = cms.untracked.VLuminosityBlockRange('205718:49-205718:734')
-
-#process.out = cms.OutputModule("PoolOutputModule",
-#    fileName =  cms.untracked.string('file:histos.root')
-#)
 
 process.d = cms.EDAnalyzer("SiPixelRawDumper", 
     Timing = cms.untracked.bool(False),

--- a/EventFilter/SiPixelRawToDigi/test/runRawToClus_cfg.py
+++ b/EventFilter/SiPixelRawToDigi/test/runRawToClus_cfg.py
@@ -3,50 +3,32 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("MyRawToClus")
 
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
-#process.load("Configuration.Geometry.GeometryIdeal_cff")
 process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
 #process.load("Configuration.StandardSequences.MagneticField_38T_cff")
 process.load('Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff')
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 process.load("Configuration.StandardSequences.Services_cff")
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
 
 # for strips 
 #process.load("CalibTracker.SiStripESProducers.SiStripGainSimESProducer_cfi")
 
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1000))
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(100))
 
 process.source = cms.Source("PoolSource",
-# fileNames =  cms.untracked.vstring('file:rawdata.root')
 fileNames =  cms.untracked.vstring(
 #  "rfio:/castor/cern.ch/cms/store/data/Run2012D/MinimumBias/RAW/v1/000/205/217/2EF61B7D-F216-E211-98C3-001D09F28D54.root",
   "rfio:/castor/cern.ch/cms/store/data/Run2012D/MinimumBias/RAW/v1/000/208/686/A88F66A0-393F-E211-9287-002481E0D524.root",
  )
 )
 
-#process.load("Geometry.TrackerSimData.trackerSimGeometryXML_cfi")
-#process.load("Geometry.TrackerGeometryBuilder.trackerGeometry_cfi")
-#process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
-#process.load("Configuration.StandardSequences.MagneticField_cff")
-
-# Cabling
-#  include "CalibTracker/Configuration/data/Tracker_FakeConditions.cff"
-#process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-#process.GlobalTag.connect = "frontier://FrontierProd/CMS_COND_21X_GLOBALTAG"
-#process.GlobalTag.globaltag = "CRAFT_V3P::All"
-#process.es_prefer_GlobalTag = cms.ESPrefer('PoolDBESSource','GlobalTag')
-
-#process.load("CalibTracker.Configuration.SiPixel_FakeConditions_cff")
-#process.load("CalibTracker.Configuration.SiPixelCabling.SiPixelCabling_SQLite_cff")
-#process.siPixelCabling.connect = 'sqlite_file:cabling.db'
-#process.siPixelCabling.toGet = cms.VPSet(cms.PSet(
-#    record = cms.string('SiPixelFedCablingMapRcd'),
-#    tag = cms.string('SiPixelFedCablingMap_v14')
-#))
-
 
 # Choose the global tag here:
 #process.GlobalTag.globaltag = "GR_P_V40::All"
-process.GlobalTag.globaltag = "GR_R_62_V1::All"
+#process.GlobalTag.globaltag = "GR_R_62_V1::All"
+# for data in V7
+process.GlobalTag.globaltag = "GR_R_71_V1::All"
 
 # process.load("EventFilter.SiPixelRawToDigi.SiPixelRawToDigi_cfi")
 process.load('Configuration.StandardSequences.RawToDigi_cff')
@@ -60,7 +42,6 @@ process.load("RecoLocalTracker.Configuration.RecoLocalTracker_cff")
 # for Raw2digi for data
 process.siPixelDigis.InputLabel = 'rawDataCollector'
 process.siStripDigis.ProductLabel = 'rawDataCollector'
-
 
 # for digi to clu
 #process.siPixelClusters.src = 'siPixelDigis'
@@ -79,12 +60,10 @@ process.MessageLogger = cms.Service("MessageLogger",
 #    )
 )
 
-process.load('Configuration.EventContent.EventContent_cff')
-process.load('Configuration.StandardSequences.EndOfProcess_cff')
 
 process.out = cms.OutputModule("PoolOutputModule",
-#    fileName =  cms.untracked.string('file:digis.root'),
-    fileName =  cms.untracked.string('file:/afs/cern.ch/work/d/dkotlins/public/data/clus/clus_1k.root'),
+    fileName =  cms.untracked.string('file:clus.root'),
+#    fileName =  cms.untracked.string('file:/afs/cern.ch/work/d/dkotlins/public/data/clus/clus_1k.root'),
 
     #outputCommands = cms.untracked.vstring("drop *","keep *_*_*_MyRawToClus") # 13.1MB per 10 events
     splitLevel = cms.untracked.int32(0),
@@ -94,8 +73,32 @@ process.out = cms.OutputModule("PoolOutputModule",
         filterName = cms.untracked.string(''),
         dataTier = cms.untracked.string('RECO')
     )
-
 )
+
+# pixel local reco (RecHits) needs the GenError object,
+# not yet in GT, add here:
+# DB stuff 
+useLocalDBError = True
+if useLocalDBError :
+    process.DBReaderFrontier = cms.ESSource("PoolDBESSource",
+     DBParameters = cms.PSet(
+         messageLevel = cms.untracked.int32(0),
+         authenticationPath = cms.untracked.string('')
+     ),
+     toGet = cms.VPSet(
+       cms.PSet(
+         record = cms.string('SiPixelGenErrorDBObjectRcd'),
+# 	 tag = cms.string("SiPixelGenErrorDBObject38Tv1")
+#        tag = cms.string('SiPixelGenErrorDBObject_38T_2012_IOV7_v1')
+         tag = cms.string('SiPixelGenErrorDBObject_38T_v1_offline')
+ 	 ),
+       ),
+#     connect = cms.string('sqlite_file:siPixelGenErrors38T_2012_IOV7_v1.db')
+#     connect = cms.string('frontier://FrontierProd/CMS_COND_31X_PIXEL')
+#     connect = cms.string('frontier://FrontierPrep/CMS_COND_PIXEL')
+     connect = cms.string('frontier://FrontierProd/CMS_COND_PIXEL_000')
+    ) # end process
+process.myprefer = cms.ESPrefer("PoolDBESSource","DBReaderFrontier")
 
 #process.p = cms.Path(process.siPixelDigis)
 #process.p = cms.Path(process.siPixelDigis*process.siPixelClusters)
@@ -103,6 +106,7 @@ process.out = cms.OutputModule("PoolOutputModule",
 
 #process.p1 = cms.Path(process.siPixelDigis*process.siStripDigis)
 # crash on strip clusters, calibration records missing? works with the 620 tag
+
 process.p1 = cms.Path(process.siPixelDigis*process.siStripDigis*process.trackerlocalreco)
 
 process.ep = cms.EndPath(process.out)

--- a/EventFilter/SiPixelRawToDigi/test/runRawToDigi_cfg.py
+++ b/EventFilter/SiPixelRawToDigi/test/runRawToDigi_cfg.py
@@ -3,15 +3,13 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("MyRawToDigi")
 
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
-#process.load("Configuration.Geometry.GeometryIdeal_cff")
 process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
 #process.load("Configuration.StandardSequences.MagneticField_38T_cff")
 process.load('Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff')
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 process.load("Configuration.StandardSequences.Services_cff")
-process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1000))
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(100))
 
 process.source = cms.Source("PoolSource",
 # fileNames =  cms.untracked.vstring('file:rawdata.root')
@@ -23,13 +21,11 @@ fileNames =  cms.untracked.vstring(
 
 # Cabling
 #  include "CalibTracker/Configuration/data/Tracker_FakeConditions.cff"
-#process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+#process.load("CalibTracker.Configuration.SiPixel_FakeConditions_cff")
+#process.load("CalibTracker.Configuration.SiPixelCabling.SiPixelCabling_SQLite_cff")
 #process.GlobalTag.connect = "frontier://FrontierProd/CMS_COND_21X_GLOBALTAG"
 #process.GlobalTag.globaltag = "CRAFT_V3P::All"
 #process.es_prefer_GlobalTag = cms.ESPrefer('PoolDBESSource','GlobalTag')
-
-#process.load("CalibTracker.Configuration.SiPixel_FakeConditions_cff")
-#process.load("CalibTracker.Configuration.SiPixelCabling.SiPixelCabling_SQLite_cff")
 #process.siPixelCabling.connect = 'sqlite_file:cabling.db'
 #process.siPixelCabling.toGet = cms.VPSet(cms.PSet(
 #    record = cms.string('SiPixelFedCablingMapRcd'),
@@ -38,7 +34,9 @@ fileNames =  cms.untracked.vstring(
 
 
 # Choose the global tag here:
-process.GlobalTag.globaltag = "GR_P_V40::All"
+#process.GlobalTag.globaltag = "GR_P_V40::All"
+# for data in V7
+process.GlobalTag.globaltag = "GR_R_71_V1::All"
 
 
 process.load("EventFilter.SiPixelRawToDigi.SiPixelRawToDigi_cfi")
@@ -49,7 +47,7 @@ process.load("EventFilter.SiPixelRawToDigi.SiPixelRawToDigi_cfi")
 process.siPixelDigis.InputLabel = 'rawDataCollector'
 process.siPixelDigis.IncludeErrors = True
 process.siPixelDigis.Timing = False 
-process.siPixelDigis.UseCablingTree = True 
+#process.siPixelDigis.UseCablingTree = True 
 
 process.MessageLogger = cms.Service("MessageLogger",
     debugModules = cms.untracked.vstring('siPixelDigis'),
@@ -58,8 +56,8 @@ process.MessageLogger = cms.Service("MessageLogger",
 )
 
 process.out = cms.OutputModule("PoolOutputModule",
-#    fileName =  cms.untracked.string('file:digis.root'),
-    fileName =  cms.untracked.string('file:/afs/cern.ch/work/d/dkotlins/public/data/digis/digis_1k.root'),
+    fileName =  cms.untracked.string('file:digis.root'),
+#    fileName =  cms.untracked.string('file:/afs/cern.ch/work/d/dkotlins/public/data/digis/digis_1k.root'),
     outputCommands = cms.untracked.vstring("drop *","keep *_siPixelDigis_*_*")
 )
 

--- a/RecoLocalTracker/SiPixelClusterizer/test/TestClusters.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/test/TestClusters.cc
@@ -101,9 +101,9 @@ using namespace std;
 //#define L1
 //#define HLT
 //#define HI
-#define ROC_EFF
-#define Lumi
-#define USE_RESYNCS  // get theinfo about recyncs 
+//#define ROC_EFF
+//#define Lumi
+//#define USE_RESYNCS  // get theinfo about recyncs 
 
 // special hitos with parameters normalized to intlumi (usually disabled)
 //#define INSTLUMI_STUDIES
@@ -1067,11 +1067,11 @@ void TestClusters::beginJob() {
   hpixPerLink3 = fs->make<TH1D>( "hpixPerLink3", "Pix per link l3",
 			    sizeH, lowH, highH);
 
-  sizeH=3000;
+  sizeH=5000;
 #ifdef HI
   highH = 19999.5;
 #else
-  highH = 2999.5;
+  highH = 4999.5;
 #endif
 
   hclusPerLay1 = fs->make<TH1D>( "hclusPerLay1", "Clus per layer l1",
@@ -1082,11 +1082,11 @@ void TestClusters::beginJob() {
 			    sizeH, lowH, highH);
 
   hclus = fs->make<TH1D>( "hclus", "Clus per event",
-			    sizeH, lowH, 4.*highH);
+			    sizeH, lowH, 5.*highH);
   hclusBPix = fs->make<TH1D>( "hclusBPix", "Bpix Clus per event",
-			    sizeH, lowH, 3.*highH);
+			    sizeH, lowH, 4.*highH);
   hclusFPix = fs->make<TH1D>( "hclusFPix", "Fpix Clus per event",
-			    sizeH, lowH, highH);
+			    sizeH, lowH, 2.*highH);
 
 #ifdef HI
   highH = 3999.5;
@@ -1123,7 +1123,7 @@ void TestClusters::beginJob() {
 #ifdef HI
   highH = 99999.5;
 #else
-  highH = 14999.5;
+  highH = 19999.5;
 #endif
 
   hpixPerLay1 = fs->make<TH1D>( "hpixPerLay1", "Pix per layer l1",
@@ -1134,11 +1134,11 @@ void TestClusters::beginJob() {
 				 sizeH, lowH, highH);
 
   hdigis = fs->make<TH1D>( "hdigis", "All Digis in clus per event",
-				 sizeH, lowH, 4.*highH);
+				 sizeH, lowH, 5.*highH);
   hdigisB = fs->make<TH1D>( "hdigisB", "BPix Digis in clus per event",
-				 sizeH, lowH, 3.*highH);
+				 sizeH, lowH, 4.*highH);
   hdigisF = fs->make<TH1D>( "hdigisF", "FPix Digis in clus per event",
-				 sizeH, lowH, highH);
+				 sizeH, lowH, 2.*highH);
   hdigis2 = fs->make<TH1D>( "hdigis2", "Digis per event - zoomed",1000, -0.5, 999.5);
 
   //#ifdef BX
@@ -1162,12 +1162,11 @@ void TestClusters::beginJob() {
 #ifdef HI
   highH = 19999.5;
 #else
-  highH = 2999.5;
+  highH = 4999.5;
 #endif
 
 
   hclus2 = fs->make<TH1D>( "hclus2", "Clus per event - zoomed",1000, -0.5, 999.5);
-
   //hclus3 = fs->make<TH1D>( "hclus3", "Clus per event",sizeH, lowH, highH);
   //hclus4 = fs->make<TH1D>( "hclus4", "Clus per event",sizeH, lowH, highH);
   hclus5 = fs->make<TH1D>( "hclus5", "Clus per event",sizeH, lowH, highH);
@@ -1736,7 +1735,10 @@ void TestClusters::beginJob() {
 // ------------ method called to at the end of the job  ------------
 void TestClusters::endJob(){
   double norm = 1;
+#ifdef ROC_EFF
   double totClusters = sumClusters; // save the total cluster number
+#endif
+
   if(countEvents>0) {
     sumClusters = sumClusters/float(countEvents);
     sumPixels = sumPixels/float(countEvents);
@@ -1775,10 +1777,7 @@ void TestClusters::endJob(){
   hcluDetMap2->Scale(norm);
   hcluDetMap3->Scale(norm);
 
-
-
 #ifdef ROC_EFF
-
   // Do this only if there is enough statistics
   double clusPerROC = totClusters/15000.;
   if( clusPerROC < 1000.) {

--- a/RecoLocalTracker/SiPixelClusterizer/test/TestWithTracks.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/test/TestWithTracks.cc
@@ -178,6 +178,17 @@ class TestWithTracks : public edm::EDAnalyzer {
 
   TH1D *hlumi, *hlumi0, *hbx, *hbx0;
 
+  TH1D *recHitXError1,*recHitXError2,*recHitXError3; 
+  TH1D *recHitYError1,*recHitYError2,*recHitYError3; 
+  TH1D *recHitXAlignError1,*recHitXAlignError2,*recHitXAlignError3; 
+  TH1D *recHitYAlignError1,*recHitYAlignError2,*recHitYAlignError3; 
+  TH1D *recHitXError4,*recHitXError5,*recHitXError6,*recHitXError7; 
+  TH1D *recHitYError4,*recHitYError5,*recHitYError6,*recHitYError7; 
+  TH1D *recHitXAlignError4,*recHitXAlignError5,*recHitXAlignError6,*recHitXAlignError7; 
+  TH1D *recHitYAlignError4,*recHitYAlignError5,*recHitYAlignError6,*recHitYAlignError7; 
+  TProfile *hErrorXB,*hErrorYB,*hErrorXF,*hErrorYF; 
+  TProfile *hAErrorXB,*hAErrorYB,*hAErrorXF,*hAErrorYF; 
+
 #ifdef VDM_STUDIES
   TProfile *hcharCluls, *hcharPixls, *hsizeCluls, *hsizeXCluls;
   TProfile *hcharCluls1, *hcharPixls1, *hsizeCluls1, *hsizeXCluls1;
@@ -394,6 +405,50 @@ void TestWithTracks::beginJob() {
    hclusMap1 = fs->make<TH2F>("hclusMap1","clus - lay1",260,-26.,26.,350,-3.5,3.5);
    hclusMap2 = fs->make<TH2F>("hclusMap2","clus - lay2",260,-26.,26.,350,-3.5,3.5);
    hclusMap3 = fs->make<TH2F>("hclusMap3","clus - lay3",260,-26.,26.,350,-3.5,3.5);
+
+
+
+   // RecHit errors
+   // alignment errors
+   recHitXAlignError1 = fs->make<TH1D>("recHitXAlignError1","RecHit X Alignment errors bpix 1", 100, 0., 100.);
+   recHitYAlignError1 = fs->make<TH1D>("recHitYAlignError1","RecHit Y Alignment errors bpix 1", 100, 0., 100.);
+   recHitXAlignError2 = fs->make<TH1D>("recHitXAlignError2","RecHit X Alignment errors bpix 2", 100, 0., 100.);
+   recHitYAlignError2 = fs->make<TH1D>("recHitYAlignError2","RecHit Y Alignment errors bpix 2", 100, 0., 100.);
+   recHitXAlignError3 = fs->make<TH1D>("recHitXAlignError3","RecHit X Alignment errors bpix 3", 100, 0., 100.);
+   recHitYAlignError3 = fs->make<TH1D>("recHitYAlignError3","RecHit Y Alignment errors bpix 3", 100, 0., 100.);
+   recHitXAlignError4 = fs->make<TH1D>("recHitXAlignError4","RecHit X Alignment errors fpix -d2", 100, 0., 100.);
+   recHitYAlignError4 = fs->make<TH1D>("recHitYAlignError4","RecHit Y Alignment errors fpix -d2", 100, 0., 100.);
+   recHitXAlignError5 = fs->make<TH1D>("recHitXAlignError5","RecHit X Alignment errors fpix -d1", 100, 0., 100.);
+   recHitYAlignError5 = fs->make<TH1D>("recHitYAlignError5","RecHit Y Alignment errors fpix -d1", 100, 0., 100.);
+   recHitXAlignError6 = fs->make<TH1D>("recHitXAlignError6","RecHit X Alignment errors fpix +d1", 100, 0., 100.);
+   recHitYAlignError6 = fs->make<TH1D>("recHitYAlignError6","RecHit Y Alignment errors fpix +d1", 100, 0., 100.);
+   recHitXAlignError7 = fs->make<TH1D>("recHitXAlignError7","RecHit X Alignment errors fpix +d2", 100, 0., 100.);
+   recHitYAlignError7 = fs->make<TH1D>("recHitYAlignError7","RecHit Y Alignment errors fpix +d2", 100, 0., 100.);
+
+   recHitXError1 = fs->make<TH1D>("recHitXError1","RecHit X errors bpix 1", 100, 0., 100.);
+   recHitYError1 = fs->make<TH1D>("recHitYError1","RecHit Y errors bpix 1", 100, 0., 100.);
+   recHitXError2 = fs->make<TH1D>("recHitXError2","RecHit X errors bpix 2", 100, 0., 100.);
+   recHitYError2 = fs->make<TH1D>("recHitYError2","RecHit Y errors bpix 2", 100, 0., 100.);
+   recHitXError3 = fs->make<TH1D>("recHitXError3","RecHit X errors bpix 3", 100, 0., 100.);
+   recHitYError3 = fs->make<TH1D>("recHitYError3","RecHit Y errors bpix 3", 100, 0., 100.);
+   recHitXError4 = fs->make<TH1D>("recHitXError4","RecHit X errors fpix -d2", 100, 0., 100.);
+   recHitYError4 = fs->make<TH1D>("recHitYError4","RecHit Y errors fpix -d2", 100, 0., 100.);
+   recHitXError5 = fs->make<TH1D>("recHitXError5","RecHit X errors fpix -d1", 100, 0., 100.);
+   recHitYError5 = fs->make<TH1D>("recHitYError5","RecHit Y errors fpix -d1", 100, 0., 100.);
+   recHitXError6 = fs->make<TH1D>("recHitXError6","RecHit X errors fpix +d1", 100, 0., 100.);
+   recHitYError6 = fs->make<TH1D>("recHitYError6","RecHit Y errors fpix +d1", 100, 0., 100.);
+   recHitXError7 = fs->make<TH1D>("recHitXError7","RecHit X errors fpix +d2", 100, 0., 100.);
+   recHitYError7 = fs->make<TH1D>("recHitYError7","RecHit Y errors fpix +d2", 100, 0., 100.);
+
+  hErrorXB = fs->make<TProfile>("hErrorXB","bpix x errors per ladder",220,0.,220.,0.0,1000.);
+  hErrorXF = fs->make<TProfile>("hErrorXF","fpix x errors per ladder",100,0.,100.,0.0,1000.);
+  hErrorYB = fs->make<TProfile>("hErrorYB","bpix y errors per ladder",220,0.,220.,0.0,1000.);
+  hErrorYF = fs->make<TProfile>("hErrorYF","fpix y errors per ladder",100,0.,100.,0.0,1000.);
+
+  hAErrorXB = fs->make<TProfile>("hAErrorXB","bpix x errors per ladder",220,0.,220.,0.0,1000.);
+  hAErrorXF = fs->make<TProfile>("hAErrorXF","fpix x errors per ladder",100,0.,100.,0.0,1000.);
+  hAErrorYB = fs->make<TProfile>("hAErrorYB","bpix y errors per ladder",220,0.,220.,0.0,1000.);
+  hAErrorYF = fs->make<TProfile>("hAErrorYF","fpix y errors per ladder",100,0.,100.,0.0,1000.);
 
 
 #ifdef VDM_STUDIES
@@ -645,6 +700,8 @@ void TestWithTracks::analyze(const edm::Event& e,
 
   if(PRINT) cout<<" Not fake PVs = "<<pvNotFake<<" good position "<<pvsTrue<<endl;
    
+  // -- Tracks
+  // ----------------------------------------------------------------------
   Handle<reco::TrackCollection> recTracks;
   // e.getByLabel("generalTracks", recTracks);
   // e.getByLabel("ctfWithMaterialTracksP5", recTracks);
@@ -732,7 +789,8 @@ void TestWithTracks::analyze(const edm::Event& e,
 	ladder=pdetId.ladder();
 	// Barrel Z-index=1,8
 	zindex=pdetId.module();
-	
+	if(zindex<5) side=1; else side=2;
+
 	// Convert to online 
 	PixelBarrelName pbn(pdetId);
 	// Shell { mO = 1, mI = 2 , pO =3 , pI =4 };
@@ -784,11 +842,111 @@ void TestWithTracks::analyze(const edm::Event& e,
 
       if(hit) {
 
-	// RecHit (recthits are transient, so not available without ttrack refit)
- 	//double xloc = hit->localPosition().x();// 1st meas coord
- 	//double yloc = hit->localPosition().y();// 2nd meas coord or zero
- 	//double zloc = hit->localPosition().z();// up, always zero
-	//cout<<" rechit loc "<<xloc<<" "<<yloc<<endl;
+	if(pt>1.) { // eliminate low pt tracks
+	  // RecHit (recthits are transient, so not available without track refit)
+	  double xloc = hit->localPosition().x();// 1st meas coord
+	  double yloc = hit->localPosition().y();// 2nd meas coord or zero
+	  //double zloc = hit->localPosition().z();// up, always zero
+	  LocalError lerr = hit->localPositionError();
+	  float lerr_x = sqrt(lerr.xx())*1E4;
+	  float lerr_y = sqrt(lerr.yy())*1E4;
+	  
+	  if( layer == 1) 
+	    {recHitXError1->Fill(lerr_x); recHitYError1->Fill(lerr_y);
+	      hErrorXB->Fill(float(ladder+(110*(side-1))),lerr_x);
+	      hErrorYB->Fill(float(ladder+(110*(side-1))),lerr_y);
+	    }
+	  else if( layer == 2) 
+	    {recHitXError2->Fill(lerr_x); recHitYError2->Fill(lerr_y);
+	      hErrorXB->Fill(float(ladder+25+(110*(side-1))),lerr_x);
+	      hErrorYB->Fill(float(ladder+25+(110*(side-1))),lerr_y);
+
+	    }
+	  else if( layer == 3) 
+	    {recHitXError3->Fill(lerr_x); recHitYError3->Fill(lerr_y);
+	      hErrorXB->Fill(float(ladder+60+(110*(side-1))),lerr_x);
+	      hErrorYB->Fill(float(ladder+60+(110*(side-1))),lerr_y);
+	    }
+	  else if( (disk == 2) && (side==1) ) 
+	    {recHitXError4->Fill(lerr_x); recHitYError4->Fill(lerr_y);
+	      hErrorXF->Fill(float(blade),lerr_x);
+	      hErrorYF->Fill(float(blade),lerr_y);
+
+	    }
+	  else if( (disk == 1) && (side==1) ) 
+	    {recHitXError5->Fill(lerr_x); recHitYError5->Fill(lerr_y);
+	      hErrorXF->Fill(float(blade+25),lerr_x);
+	      hErrorYF->Fill(float(blade+25),lerr_y);
+
+	    }
+	  else if( (disk == 1) && (side==2) ) 
+	    {recHitXError6->Fill(lerr_x); recHitYError6->Fill(lerr_y);
+	      hErrorXF->Fill(float(blade+50),lerr_x);
+	      hErrorYF->Fill(float(blade+50),lerr_y);
+	    }
+	  else if( (disk == 2) && (side==2) ) 
+	    {recHitXError7->Fill(lerr_x); recHitYError7->Fill(lerr_y);
+	      hErrorXF->Fill(float(blade+75),lerr_x);
+	      hErrorYF->Fill(float(blade+75),lerr_y);
+	    }
+	  
+	  LocalError lape = theGeomDet->localAlignmentError();
+	  if (lape.valid()) {
+	    float tmp11= 0.;
+	    if(lape.xx()>0.) tmp11= sqrt(lape.xx())*1E4;
+	    //float tmp12= sqrt(lape.xy())*1E4;
+	    float tmp13= 0.;
+	    if(lape.yy()>0.) tmp13= sqrt(lape.yy())*1E4;
+	    //bool tmp14=tmp2<tmp1;
+	    if( layer == 1) 
+	      {recHitXAlignError1->Fill(tmp11); recHitYAlignError1->Fill(tmp13);
+		hAErrorXB->Fill(float(ladder+(110*(side-1))),tmp11);
+		hAErrorYB->Fill(float(ladder+(110*(side-1))),tmp13);
+	      }
+	    else if( layer == 2) 
+	      {recHitXAlignError2->Fill(tmp11); recHitYAlignError2->Fill(tmp13);
+		hAErrorXB->Fill(float(ladder+25+(110*(side-1))),tmp11);
+		hAErrorYB->Fill(float(ladder+25+(110*(side-1))),tmp13);
+	      }
+	    else if( layer == 3) 
+	      {recHitXAlignError3->Fill(tmp11); recHitYAlignError3->Fill(tmp13);
+		hAErrorXB->Fill(float(ladder+60+(110*(side-1))),tmp11);
+		hAErrorYB->Fill(float(ladder+60+(110*(side-1))),tmp13);
+
+	      }
+	    else if( (disk == 2) && (side==1) ) 
+	      {recHitXAlignError4->Fill(tmp11); recHitYAlignError4->Fill(tmp13);
+		hAErrorXF->Fill(float(blade),tmp11);
+		hAErrorYF->Fill(float(blade),tmp13);
+
+	      }
+	    else if( (disk == 1) && (side==1) ) 
+	      {recHitXAlignError5->Fill(tmp11); recHitYAlignError5->Fill(tmp13);
+		hAErrorXF->Fill(float(blade+25),tmp11);
+		hAErrorYF->Fill(float(blade+25),tmp13);
+	      }
+	    else if( (disk == 1) && (side==2) ) 
+	      {recHitXAlignError6->Fill(tmp11); recHitYAlignError6->Fill(tmp13);
+		hAErrorXF->Fill(float(blade+50),tmp11);
+		hAErrorYF->Fill(float(blade+50),tmp13);
+	      }
+	    else if( (disk == 2) && (side==2) ) 
+	      {recHitXAlignError7->Fill(tmp11); recHitYAlignError7->Fill(tmp13);
+		hAErrorXF->Fill(float(blade+75),tmp11);
+		hAErrorYF->Fill(float(blade+75),tmp13);
+	      }
+	    
+	    
+	    //cout<<tTopo->pxbLayer(detId)<<" "<<tTopo->pxbModule(detId)<<" "<<rows<<" "<<tmp14<<" "
+	    if(PRINT) cout<<" align error "<<layer<<tmp11<<" "<<tmp13<<endl;
+	  } else {
+	    cout<<" lape = 0"<<endl;
+	  }  // if lape
+	  
+	  if(PRINT) cout<<" rechit loc "<<xloc<<" "<<yloc<<" "<<lerr_x<<" "
+			<<lerr_y<<endl;
+	} // limit pt
+       
 	
 	edm::Ref<edmNew::DetSetVector<SiPixelCluster>, SiPixelCluster> const& clust = hit->cluster();
 	//  check if the ref is not null
@@ -1130,12 +1288,10 @@ void TestWithTracks::analyze(const edm::Event& e,
   return;
 
 
-
-
-
 #ifdef USE_TRAJ
+  // Not used 
 
-  //------------------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
   // Use Trajectories
 
   edm::Handle<TrajTrackAssociationCollection> trajTrackCollectionHandle;

--- a/RecoLocalTracker/SiPixelClusterizer/test/readClusters_cfg.py
+++ b/RecoLocalTracker/SiPixelClusterizer/test/readClusters_cfg.py
@@ -6,6 +6,9 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("cluTest")
 
+process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.MagneticField_38T_cff")
+
 
 import HLTrigger.HLTfilters.hltHighLevel_cfi as hlt
 # accept if 'path_1' succeeds
@@ -40,7 +43,8 @@ process.MessageLogger = cms.Service("MessageLogger",
     destinations = cms.untracked.vstring('cout'),
 #    destinations = cms.untracked.vstring("log","cout"),
     cout = cms.untracked.PSet(
-        threshold = cms.untracked.string('ERROR')
+        threshold = cms.untracked.string('WARNING')
+#        threshold = cms.untracked.string('ERROR')
     )
 #    log = cms.untracked.PSet(
 #        threshold = cms.untracked.string('DEBUG')
@@ -52,10 +56,12 @@ process.source = cms.Source("PoolSource",
 # fill 3273 run 206940
 #  "/store/data/Run2012D/MinimumBias/RECO/PromptReco-v1/000/206/940/FA55823C-312C-E211-94AB-001D09F29533.root",
 # for MC 
-#  'file:/afs/cern.ch/work/d/dkotlins/public/MC/mu/pt100_pre10/clus/clus1.root'
+  'file:clus.root'
 #  'file:/afs/cern.ch/work/d/dkotlins/public/MC/mu/pt100/clus/clus1.root'
 #  'file:/afs/cern.ch/work/d/dkotlins/public/MC/mu/pt100/rechits/rechits1.root'
-  'file:../../../../../CMSSW_7_0_0_pre8/src/EventFilter/SiPixelRawToDigi/test/digis.root'
+#  'file:../../../../../CMSSW_7_0_0_pre8/src/EventFilter/SiPixelRawToDigi/test/digis.root'
+#   'file:/afs/cern.ch/work/d/dkotlins/public/MC/mu/pt100_71_pre7/rechits/rechits2_postls171.root'
+#   'file:/afs/cern.ch/work/d/dkotlins/public/MC/mu/pt100_71_pre7/rechits/rechits2_mc71.root'
 
   )
 )
@@ -67,14 +73,16 @@ process.TFileService = cms.Service("TFileService",
     fileName = cms.string('histo.root')
 )
 
-process.load("Configuration.StandardSequences.Geometry_cff")
-process.load("Configuration.StandardSequences.MagneticField_38T_cff")
-
-process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")# Choose the global tag here:
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+# Choose the global tag here:
 # 2012
 #process.GlobalTag.globaltag = 'GR_P_V40::All'
-# MC 2913
-process.GlobalTag.globaltag = 'MC_70_V1::All'
+# MC 2013
+# process.GlobalTag.globaltag = 'MC_70_V1::All'
+# DATA 2014
+process.GlobalTag.globaltag = 'PRE_R_71_V3::All'
+# MC 2014
+#process.GlobalTag.globaltag = 'PRE_STA71_V4::All'
 
 process.analysis = cms.EDAnalyzer("ReadPixClusters",
     Verbosity = cms.untracked.bool(True),

--- a/RecoLocalTracker/SiPixelClusterizer/test/runClusToTracks.py
+++ b/RecoLocalTracker/SiPixelClusterizer/test/runClusToTracks.py
@@ -6,7 +6,7 @@
 
 import FWCore.ParameterSet.Config as cms
 
-process = cms.Process("TrackTest")
+process = cms.Process("CluToTrack")
 
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
 process.load("Configuration.Geometry.GeometryIdeal_cff")
@@ -15,6 +15,10 @@ process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 process.load("Configuration.StandardSequences.Services_cff")
 process.load('Configuration.EventContent.EventContent_cff')
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
+
+# for data?
+#process.load('Configuration.StandardSequences.Reconstruction_Data_cff')
+
 
 # clusterizer 
 process.load("RecoLocalTracker.Configuration.RecoLocalTracker_cff")
@@ -29,8 +33,11 @@ process.load('Configuration.StandardSequences.RawToDigi_cff')
 process.load("Configuration.StandardSequences.Reconstruction_cff")
 #process.load("RecoTracker.Configuration.RecoTracker_cff")
 
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(10)
+    input = cms.untracked.int32(1000)
 )
 
 process.MessageLogger = cms.Service("MessageLogger",
@@ -40,8 +47,8 @@ process.MessageLogger = cms.Service("MessageLogger",
 #    destinations = cms.untracked.vstring("log","cout"),
     cout = cms.untracked.PSet(
 #       threshold = cms.untracked.string('INFO')
-#       threshold = cms.untracked.string('ERROR')
-        threshold = cms.untracked.string('WARNING')
+       threshold = cms.untracked.string('ERROR')
+#        threshold = cms.untracked.string('WARNING')
 #        threshold = cms.untracked.string('DEBUG')
     )
 #    log = cms.untracked.PSet(
@@ -51,22 +58,46 @@ process.MessageLogger = cms.Service("MessageLogger",
 # get the files from DBS:
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring(
-    'file:/afs/cern.ch/work/d/dkotlins/public/MC/mu/pt100_71_pre7/digis_trk/digis2_mc71.root'
-#    'file:/afs/cern.ch/work/d/dkotlins/public/MC/mu/pt100/digis_trk/digis1.root'
+#    'file:/afs/cern.ch/work/d/dkotlins/public/MC/mu/pt100_71_pre7/tracks/tracks2_mc71.root'
+#    'file:/afs/cern.ch/work/d/dkotlins/public/MC/mu/pt100_71_pre7/tracks/tracks2_postls171.root'
+
+ "/store/data/Run2012D/MinimumBias/RECO/PromptReco-v1/000/208/686/F60495B3-1E41-E211-BB7C-003048D3756A.root",
+
     )
 )
 
+process.source.lumisToProcess = cms.untracked.VLuminosityBlockRange('208686:73-208686:463')
 # Choose the global tag here:
-process.GlobalTag.globaltag = 'PRE_STA71_V4::All'
-#process.GlobalTag.globaltag = 'MC_71_V1::All'
+# process.GlobalTag.globaltag = 'MC_71_V1::All'
 # process.GlobalTag.globaltag = 'POSTLS171_V1::All'
 # process.GlobalTag.globaltag = 'PRE_MC_71_V2::All'
+# data 
+#process.GlobalTag.globaltag = "GR_R_71_V1::All"
+process.GlobalTag.globaltag = "PRE_R_71_V3::All"
+
+#process.PoolDBESSource = cms.ESSource("PoolDBESSource",
+#    BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
+#    DBParameters = cms.PSet(
+#        messageLevel = cms.untracked.int32(0),
+#        authenticationPath = cms.untracked.string('')
+#    ),
+#    timetype = cms.string('runnumber'),
+#    toGet = cms.VPSet(cms.PSet(
+#        record = cms.string('SiPixelQualityRcd'),
+#        tag = cms.string('SiPixelBadModule_test')
+#    )),
+#    connect = cms.string('sqlite_file:test.db')
+#)
+#
+# To use a test DB instead of the official pixel object DB tag: 
+#process.customDead = cms.ESSource("PoolDBESSource", process.CondDBSetup, connect = cms.string('sqlite_file:/afs/cern.ch/user/v/vesna/Digitizer/dead_20100901.db'), toGet = cms.VPSet(cms.PSet(record = cms.string('SiPixelQualityRcd'), tag = cms.string('dead_20100901'))))
+#process.es_prefer_customDead = cms.ESPrefer("PoolDBESSource","customDead")
 
 
 process.o1 = cms.OutputModule("PoolOutputModule",
-#        outputCommands = cms.untracked.vstring('drop *','keep *_*_*_TrackTest'),
+#        outputCommands = cms.untracked.vstring('drop *','keep *_*_*_CluToTrack'),
         fileName = cms.untracked.string('file:tracks.root'),
-#       fileName = cms.untracked.string('file:/afs/cern.ch/work/d/dkotlins/public/MC/mu/pt100_71_pre7/tracks/tracks_test.root'),
+#       fileName = cms.untracked.string('file:/afs/cern.ch/work/d/dkotlins/public/MC/mu/pt100_71_pre7/tracks/tracks2_postls171.root'),
 #    splitLevel = cms.untracked.int32(0),
 #    eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
     outputCommands = process.RECOSIMEventContent.outputCommands,
@@ -77,30 +108,61 @@ process.o1 = cms.OutputModule("PoolOutputModule",
 
 )
 
-# pixel local reco (RecHits) needs the GenError object,
-# not yet in GT, add here:
 # DB stuff 
-useLocalDBError = True
-if useLocalDBError :
+useLocalDB = False
+if useLocalDB :
+# Frontier LA 
     process.DBReaderFrontier = cms.ESSource("PoolDBESSource",
      DBParameters = cms.PSet(
          messageLevel = cms.untracked.int32(0),
          authenticationPath = cms.untracked.string('')
      ),
      toGet = cms.VPSet(
-       cms.PSet(
-         record = cms.string('SiPixelGenErrorDBObjectRcd'),
-# 	 tag = cms.string("SiPixelGenErrorDBObject38Tv1")
-#        tag = cms.string('SiPixelGenErrorDBObject_38T_2012_IOV7_v1')
-         tag = cms.string('SiPixelGenErrorDBObject_38T_v1_offline')
- 	 ),
-       ),
-#     connect = cms.string('sqlite_file:siPixelGenErrors38T_2012_IOV7_v1.db')
+ 	 cms.PSet(
+# GenError
+          record = cms.string('SiPixelGenErrorDBObjectRcd'),
+#          tag = cms.string('SiPixelGenErrorDBObject38Tv1')
+#          tag = cms.string('SiPixelGenErrorDBObject38TV10')
+#          tag = cms.string('SiPixelGenErrorDBObject38T_v0_mc1')
+          tag = cms.string('SiPixelGenErrorDBObject_38T_v1_mc')
+# LA
+# 			record = cms.string("SiPixelLorentzAngleRcd"),
+# 			label = cms.untracked.string("fromAlignment"),
+# 			label = cms.untracked.string("forWidth"),
+# 			tag = cms.string("SiPixelLorentzAngle_v02_mc")
+# 			tag = cms.string("SiPixelLorentzAngle_fromAlignment_v0_mc")
+# 			tag = cms.string("SiPixelLorentzAngle_forWidth_v0_mc")
+ 		),
+# 		cms.PSet(
+# 			record = cms.string("SiPixelLorentzAngleSimRcd"),
+# 			tag = cms.string("test_LorentzAngle_Sim")
+# 		)
+ 	),
 #     connect = cms.string('frontier://FrontierProd/CMS_COND_31X_PIXEL')
-#     connect = cms.string('frontier://FrontierPrep/CMS_COND_PIXEL')
-     connect = cms.string('frontier://FrontierProd/CMS_COND_PIXEL_000')
+     connect = cms.string('frontier://FrontierPrep/CMS_COND_PIXEL')
     ) # end process
-process.myprefer = cms.ESPrefer("PoolDBESSource","DBReaderFrontier")
+
+# SQ_LITE GenError
+    process.DBReaderFrontier2 = cms.ESSource("PoolDBESSource",
+     DBParameters = cms.PSet(
+         messageLevel = cms.untracked.int32(0),
+         authenticationPath = cms.untracked.string('')
+     ),
+     toGet = cms.VPSet(
+ 		cms.PSet(
+ 			record = cms.string("SiPixelGenErrorDBObjectRcd"),
+# 			label = cms.untracked.string("fromAlignment"),
+# 			tag = cms.string("SiPixelGenErrorDBObject38Tv1")
+ 			tag = cms.string("SiPixelGenErrorDBObject38TV10")
+ 		),
+ 	),
+#     connect = cms.string('sqlite_file:siPixelGenErrors38T.db_old')
+     connect = cms.string('sqlite_file:siPixelGenErrors38T.db')
+   ) # end process
+# endif
+ 
+#process.myprefer = cms.ESPrefer("PoolDBESSource","DBReaderFrontier")
+#process.myprefer2 = cms.ESPrefer("PoolDBESSource","DBReaderFrontier2")
 
 
 #process.Timing = cms.Service("Timing")
@@ -121,11 +183,7 @@ process.myprefer = cms.ESPrefer("PoolDBESSource","DBReaderFrontier")
 #process.p1 = cms.Path(process.pixeltrackerlocalreco)
 
 # clusterize through raw (OK)
-# for digi to raw 
-# my old
-#process.siPixelRawData.InputLabel = 'mix'
-#process.SiStripDigiToRaw.InputModuleLabel = 'mix'
-# my new 
+# for digi to raw
 process.siPixelRawData.InputLabel = 'simSiPixelDigis'
 process.SiStripDigiToRaw.InputModuleLabel = 'simSiPixelDigis'
 # for Raw2digi for simulations 
@@ -144,16 +202,29 @@ process.siPixelClusters.src = 'siPixelDigis'
 #process.p1 = cms.Path(process.siPixelRawData*process.SiStripDigiToRaw*process.siPixelDigis*process.siStripDigis)
 
 # runs ok
-#process.p1 = cms.Path(process.siPixelRawData*process.SiStripDigiToRaw*process.siPixelDigis*process.siStripDigis*process.trackerlocalreco)
+#process.p1 = cms.Path(process.trackerlocalreco)
 
 # runs ok
-#process.p1 = cms.Path(process.siPixelRawData*process.SiStripDigiToRaw*process.siPixelDigis*process.siStripDigis*process.trackerlocalreco*process.offlineBeamSpot)
+#process.p1 = cms.Path(process.offlineBeamSpot)
 
 # runs ok
 #process.p1 = cms.Path(process.siPixelRawData*process.SiStripDigiToRaw*process.siPixelDigis*process.siStripDigis*process.trackerlocalreco*process.offlineBeamSpot*process.MeasurementTrackerEvent)
 
 # runs ok
 #process.p1 = cms.Path(process.siPixelRawData*process.SiStripDigiToRaw*process.siPixelDigis*process.siStripDigis*process.trackerlocalreco*process.offlineBeamSpot*process.MeasurementTrackerEvent*process.siPixelClusterShapeCache*process.recopixelvertexing)
+
+process.d = cms.EDAnalyzer("TestWithTracks",
+    Verbosity = cms.untracked.bool(False),
+    src = cms.InputTag("generalTracks"),
+#     PrimaryVertexLabel = cms.untracked.InputTag("offlinePrimaryVertices"),                             
+#     trajectoryInput = cms.string("TrackRefitterP5")
+#     trajectoryInput = cms.string('cosmictrackfinderP5')
+)
+
+process.TFileService = cms.Service("TFileService",
+    fileName = cms.string('histo_tracks.root')
+)
+
 
 process.load("RecoTracker.IterativeTracking.iterativeTk_cff")
 
@@ -177,15 +248,8 @@ process.myTracking = cms.Sequence(process.InitialStep*
 # run full tracking
 # trackingGlobalReco does not work, needs EarlyMuons for muon seeding.
 # ckftracks & iterTracking does not work as well  (same problem).
-process.p1 = cms.Path(process.siPixelRawData*process.SiStripDigiToRaw*process.siPixelDigis*process.siStripDigis*process.trackerlocalreco*process.offlineBeamSpot*process.siPixelClusterShapeCache*process.recopixelvertexing*process.MeasurementTrackerEvent*process.myTracking*process.vertexreco)
+process.p1 = cms.Path(process.siPixelRecHits*process.siStripMatchedRecHits*process.offlineBeamSpot*process.siPixelClusterShapeCache*process.recopixelvertexing*process.MeasurementTrackerEvent*process.myTracking*process.vertexreco*process.d)
 
-# unused 
-# Path and EndPath definitions
-#process.raw2digi_step = cms.Path(process.RawToDigi)
-#process.reconstruction_step = cms.Path(process.reconstruction)
-#process.endjob_step = cms.EndPath(process.endOfProcess)
-#process.RECOSIMoutput_step = cms.EndPath(process.RECOSIMoutput)
-# Schedule definition
-#process.schedule = cms.Schedule(process.raw2digi_step,process.reconstruction_step,process.endjob_step,process.RECOSIMoutput_step)
+#process.p1 = cms.Path(process.siPixelRawData*process.SiStripDigiToRaw*process.siPixelDigis*process.siStripDigis*process.trackerlocalreco*process.offlineBeamSpot*process.siPixelClusterShapeCache*process.recopixelvertexing*process.MeasurementTrackerEvent*process.myTracking*process.vertexreco)
 
-process.outpath = cms.EndPath(process.o1)
+#process.outpath = cms.EndPath(process.o1)

--- a/RecoLocalTracker/SiPixelClusterizer/test/runPixelRawToRecHitsAna.py
+++ b/RecoLocalTracker/SiPixelClusterizer/test/runPixelRawToRecHitsAna.py
@@ -52,21 +52,40 @@ process.source = cms.Source("PoolSource",
   fileNames = cms.untracked.vstring(
 #    'file:/afs/cern.ch/work/d/dkotlins/public/MC/mu/pt100/digis/digis1.root'
 #    'file:/afs/cern.ch/work/d/dkotlins/public/MC/mu/pt100_71_pre7/digis/digis2_postls171.root'
-    'file:/afs/cern.ch/work/d/dkotlins/public/MC/mu/pt100_71_pre7/digis/digis2_mc71.root'
+#    'file:/afs/cern.ch/work/d/dkotlins/public/MC/mu/pt100_71_pre7/digis/digis2_mc71.root'
+
+#  '/store/relval/CMSSW_7_1_0_pre8/RelValTTbar/GEN-SIM-DIGI-RAW-HLTDEBUG/PU_PRE_STA71_V4-v1/00000/06397C95-91E2-E311-963D-02163E00B776.root',
+
+ '/store/relval/CMSSW_7_1_0_pre8/RelValSingleMuPt100_UP15/GEN-SIM-DIGI-RAW-HLTDEBUG/PRE_LS171_V9-v1/00000/5AAEC7CC-D7E1-E311-83DD-0025905A6094.root',
+
+# 25ns flat pu=20-50
+#   /store/mc/Spring14dr/TT_Tune4C_13TeV-pythia8-tauola/GEN-SIM-RAW/Flat20to50_POSTLS170_V5-v1/00000/006EBBE4-98DC-E311-B64F-0025905A611E.root
+
+# 50ns poisson pu=50
+#   '/store/mc/Fall13dr/TT_Tune4C_13TeV-pythia8-tauola/GEN-SIM-RAW/tsg_PU40bx50_POSTLS162_V2-v1/00000/00E707E5-0D75-E311-B109-003048678BAE.root',
+
+# 25ns poisson pu=50
+#   /store/mc/Fall13dr/TT_Tune4C_13TeV-pythia8-tauola/GEN-SIM-RAW/tsg_PU40bx25_POSTLS162_V2-v1/00000/00309507-AB75-E311-AB10-0025905A60B2.root
+
+# 25ns poisson pu=20
+#   /store/mc/Fall13dr/TT_Tune4C_13TeV-pythia8-tauola/GEN-SIM-RAW/tsg_PU20bx25_POSTLS162_V2-v1/00000/001E7210-126D-E311-8D68-003048679182.root
+
+
   )
 )
 
 # Choose the global tag here:
+#process.GlobalTag.globaltag = "POSTLS162_V2::All"
 #process.GlobalTag.globaltag = "MC_70_V1::All"
 #process.GlobalTag.globaltag = "START70_V1::All"
-#process.GlobalTag.globaltag = "START71_V1::All"
-process.GlobalTag.globaltag = "MC_71_V1::All"
+process.GlobalTag.globaltag = "START71_V1::All"
+#process.GlobalTag.globaltag = "MC_71_V1::All"
 #process.GlobalTag.globaltag = "POSTLS171_V1::All"
 #process.GlobalTag.globaltag = "PRE_MC_71_V2::All"
 
 
 # DB stuff 
-useLocalDB = True
+useLocalDB = False
 if useLocalDB :
 # Frontier LA 
     process.DBReaderFrontier = cms.ESSource("PoolDBESSource",
@@ -118,7 +137,7 @@ if useLocalDB :
    ) # end process
 # endif
  
-process.myprefer = cms.ESPrefer("PoolDBESSource","DBReaderFrontier")
+#process.myprefer = cms.ESPrefer("PoolDBESSource","DBReaderFrontier")
 #process.myprefer2 = cms.ESPrefer("PoolDBESSource","DBReaderFrontier2")
 
 
@@ -142,9 +161,27 @@ process.myprefer = cms.ESPrefer("PoolDBESSource","DBReaderFrontier")
 
 
 process.o1 = cms.OutputModule("PoolOutputModule",
-                              outputCommands = cms.untracked.vstring('drop *','keep *_*_*_ClusTest'),
-#            fileName = cms.untracked.string('file:clus.root')
-            fileName = cms.untracked.string('file:/afs/cern.ch/work/d/dkotlins/public/MC/mu/pt100_71_pre7/rechits/rechits2_mc71.root')
+            outputCommands = cms.untracked.vstring('drop *','keep *_*_*_ClusTest'),
+            fileName = cms.untracked.string('file:clus.root')
+#            fileName = cms.untracked.string('file:/afs/cern.ch/work/d/dkotlins/public/MC/mu/pt100_71_pre7/rechits/rechits2_mc71.root')
+
+)
+
+process.analysis = cms.EDAnalyzer("ReadPixClusters",
+    Verbosity = cms.untracked.bool(False),
+    src = cms.InputTag("siPixelClusters"),
+)
+
+process.d = cms.EDAnalyzer("TestClusters",
+    Verbosity = cms.untracked.bool(False),
+    src = cms.InputTag("siPixelClusters"),
+    Select1 = cms.untracked.int32(1),  # cut on the num of dets <4 skip, 0 means 4 default 
+    Select2 = cms.untracked.int32(0),  # 6 no bptx, 0 no selection                               
+)
+
+
+process.TFileService = cms.Service("TFileService",
+    fileName = cms.string('histo.root')
 )
 
 #process.Timing = cms.Service("Timing")
@@ -154,26 +191,16 @@ process.o1 = cms.OutputModule("PoolOutputModule",
 # modify clusterie parameters
 #process.siPixelClusters.ClusterThreshold = 4000.0
 
-# DIRECT
-# direct clusterization (no raw step)
-# label of digis 
-process.siPixelClusters.src = 'simSiPixelDigis'
-
-# plus pixel clusters  (OK)
-#process.p1 = cms.Path(process.siPixelClusters)
-# plus pixel rechits (OK)
-process.p1 = cms.Path(process.pixeltrackerlocalreco)
-
 # RAW
 # clusterize through raw (OK)
 # for Raw2digi for simulations 
-#process.siPixelRawData.InputLabel = 'mix'
 #process.siPixelDigis.InputLabel = 'siPixelRawData'
-# process.siStripDigis.ProductLabel = 'SiStripDigiToRaw'
-#process.siPixelClusters.src = 'siPixelDigis'
+process.siPixelDigis.InputLabel = 'rawDataCollector'
+#process.siPixelDigis.InputLabel = 'source'
 
-#process.p1 = cms.Path(process.siPixelRawData)
-#process.p1 = cms.Path(process.siPixelRawData*process.siPixelDigis)
-#process.p1 = cms.Path(process.siPixelRawData*process.siPixelDigis*process.pixeltrackerlocalreco)
+process.siPixelClusters.src = 'siPixelDigis'
 
-process.outpath = cms.EndPath(process.o1)
+#process.p1 = cms.Path(process.siPixelDigis*process.pixeltrackerlocalreco)
+process.p1 = cms.Path(process.siPixelDigis*process.pixeltrackerlocalreco*process.d)
+
+#process.outpath = cms.EndPath(process.o1)

--- a/RecoLocalTracker/SiPixelClusterizer/test/testTracks_cfg.py
+++ b/RecoLocalTracker/SiPixelClusterizer/test/testTracks_cfg.py
@@ -3,8 +3,11 @@
 #
 #
 import FWCore.ParameterSet.Config as cms
-
 process = cms.Process("T")
+
+process.load("Configuration.Geometry.GeometryIdeal_cff")
+process.load("Configuration.StandardSequences.MagneticField_38T_cff")
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(-1)
@@ -51,8 +54,10 @@ process.hltPhysicsDeclared.L1GtReadoutRecordTag = 'gtDigis'
 
 process.source = cms.Source("PoolSource",
  fileNames =  cms.untracked.vstring(
-#    'file:../../../SimTracker/SiPixelDigitizer/test/tracks.root'
-    'file:/afs/cern.ch/work/d/dkotlins/public/MC/mu/pt100/tracks/tracks1.root'
+    'file:tracks.root'
+#    'file:/afs/cern.ch/work/d/dkotlins/public/MC/mu/pt100/tracks/tracks1.root'
+#    'file:/afs/cern.ch/work/d/dkotlins/public/MC/mu/pt100_71_pre7/tracks/tracks2_mc71.root'
+#    'file:/afs/cern.ch/work/d/dkotlins/public/MC/mu/pt100_71_pre7/tracks/tracks2_postls171.root'
     )
 )
 
@@ -61,14 +66,14 @@ process.TFileService = cms.Service("TFileService",
     fileName = cms.string('histo_tracks.root')
 )
 
-process.load("Configuration.Geometry.GeometryIdeal_cff")
-process.load("Configuration.StandardSequences.MagneticField_38T_cff")
 
-# needed for global transformation
-# process.load("Configuration.StandardSequences.FakeConditions_cff")
-
-process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")# Choose the global tag here:
-process.GlobalTag.globaltag = "MC_70_V1::All"
+# Choose the global tag here:
+# DATA 2014
+process.GlobalTag.globaltag = 'PRE_R_71_V3::All'
+# MC 2014
+#process.GlobalTag.globaltag = 'PRE_STA71_V4::All'
+# 2013 MC
+#process.GlobalTag.globaltag = "MC_70_V1::All"
 # 2012
 #process.GlobalTag.globaltag = "GR_P_V40::All"
 #process.GlobalTag.globaltag = "GR_P_V28::All" # A&B
@@ -83,7 +88,7 @@ process.GlobalTag.globaltag = "MC_70_V1::All"
 # process.GlobalTag.globaltag = 'CRAFT09_R_V4::All'
 
 process.d = cms.EDAnalyzer("TestWithTracks",
-    Verbosity = cms.untracked.bool(False),
+    Verbosity = cms.untracked.bool(True),
     src = cms.InputTag("generalTracks"),
 #     PrimaryVertexLabel = cms.untracked.InputTag("offlinePrimaryVertices"),                             
 #     trajectoryInput = cms.string("TrackRefitterP5")

--- a/RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplate.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplate.h
@@ -486,7 +486,7 @@ class SiPixelTemplate {
      return chi2xminc2m_[i];} //!< 1st pass chi2 min search: minimum x-chisq for merged clusters 
    float fbin(int i) {
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
-      if(i < 0 || i > 2) {throw cms::Exception("DataCorrupt") << "SiPixelTemplate::chi2xminc2m called with illegal index = " << i << std::endl;}
+      if(i < 0 || i > 2) {throw cms::Exception("DataCorrupt") << "SiPixelTemplate::fbin called with illegal index = " << i << std::endl;}
 #else
       assert(i>=0 && i<3);
 #endif

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc
@@ -48,9 +48,9 @@ PixelCPEGeneric::PixelCPEGeneric(edm::ParameterSet const & conf,
 #endif
   
   if (theVerboseLevel > 0) 
-    edm::LogWarning("PixelCPEGeneric") 
-      << " constructing a generic algorithm for ideal pixel detector.\n"
-      << " CPEGeneric:: VerboseLevel = " << theVerboseLevel;
+    cout<<"PixelCPEGeneric:" 
+	<< " constructing a generic algorithm for ideal pixel detector.\n"
+	<< " CPEGeneric:: VerboseLevel = " << theVerboseLevel;
 
   // Externally settable cuts  
   the_eff_charge_cut_lowX = conf.getParameter<double>("eff_charge_cut_lowX");

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc
@@ -18,7 +18,7 @@
 #include <iostream>
 using namespace std;
 
-//#define NEW_CPEERROR // must be constistent with base.cc, generic cc/h and genericProducer.cc 
+#define NEW_CPEERROR // must be constistent with base.cc, generic cc/h and genericProducer.cc 
 
 namespace {
   constexpr float micronsToCm = 1.0e-4;
@@ -46,11 +46,11 @@ PixelCPEGeneric::PixelCPEGeneric(edm::ParameterSet const & conf,
 				 const SiPixelLorentzAngle * lorentzAngleWidth=0) 
   : PixelCPEBase(conf, mag, geom, lorentzAngle, genErrorDBObject, templateDBobject,lorentzAngleWidth,0) {
 #endif
-  
+
   if (theVerboseLevel > 0) 
-    cout<<"PixelCPEGeneric:" 
-	<< " constructing a generic algorithm for ideal pixel detector.\n"
-	<< " CPEGeneric:: VerboseLevel = " << theVerboseLevel;
+    LogDebug("PixelCPEGeneric") 
+      << " constructing a generic algorithm for ideal pixel detector.\n"
+      << " CPEGeneric:: VerboseLevel = " << theVerboseLevel;
 
   // Externally settable cuts  
   the_eff_charge_cut_lowX = conf.getParameter<double>("eff_charge_cut_lowX");
@@ -247,7 +247,7 @@ PixelCPEGeneric::localPosition(DetParam const & theDetParam, ClusterParam & theC
       if(useLAWidthFromGenError) {
 	chargeWidthX = (-micronsToCm*gtempl.lorxwidth());
 	chargeWidthY = (-micronsToCm*gtempl.lorywidth());
-	//cout<< " redefine la width (gen-error) "<< chargeWidthX<<" "<< chargeWidthY <<endl;
+	if(MYDEBUG) cout<< " redefine la width (gen-error) "<< chargeWidthX<<" "<< chargeWidthY <<endl;
       }
       if(MYDEBUG) cout<<" GenError: "<<gtemplID_<<endl;
       
@@ -636,8 +636,10 @@ PixelCPEGeneric::localError(DetParam const & theDetParam,  ClusterParam & theClu
 
   unsigned int sizex = theClusterParam.theCluster->sizeX();
   unsigned int sizey = theClusterParam.theCluster->sizeY();
-  if( int(sizex) != (maxPixelRow - minPixelRow+1) ) cout<<" wrong x"<<endl;
-  if( int(sizey) != (maxPixelCol - minPixelCol+1) ) cout<<" wrong y"<<endl;
+  if(MYDEBUG) {
+    if( int(sizex) != (maxPixelRow - minPixelRow+1) ) cout<<" wrong x"<<endl;
+    if( int(sizey) != (maxPixelCol - minPixelCol+1) ) cout<<" wrong y"<<endl;
+  }
 
   // Find if cluster contains double (big) pixels. 
   bool bigInX = theDetParam.theRecTopol->containsBigPixelInX( minPixelRow, maxPixelRow ); 	 

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc
@@ -18,7 +18,7 @@
 #include <iostream>
 using namespace std;
 
-#define NEW_CPEERROR // must be constistent with base.cc, generic cc/h and genericProducer.cc 
+//#define NEW_CPEERROR // must be constistent with base.cc, generic cc/h and genericProducer.cc 
 
 namespace {
   constexpr float micronsToCm = 1.0e-4;

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc
@@ -22,10 +22,6 @@ using namespace std;
 
 namespace {
   constexpr float micronsToCm = 1.0e-4;
-#ifndef NEW_CPEERROR
-  //const bool useNewSimplerErrors = true; // must be the same as in base
-  const bool useNewSimplerErrors = false; // must be the same as in base
-#endif
   const bool MYDEBUG = false;
 }
 
@@ -52,7 +48,7 @@ PixelCPEGeneric::PixelCPEGeneric(edm::ParameterSet const & conf,
 #endif
   
   if (theVerboseLevel > 0) 
-    LogDebug("PixelCPEGeneric") 
+    edm::LogWarning("PixelCPEGeneric") 
       << " constructing a generic algorithm for ideal pixel detector.\n"
       << " CPEGeneric:: VerboseLevel = " << theVerboseLevel;
 
@@ -119,7 +115,7 @@ PixelCPEGeneric::PixelCPEGeneric(edm::ParameterSet const & conf,
       << "\n\n";
   }
 
-  // Use errors from templates 
+  // Use errors from templates or from GenError
   if ( UseErrorsFromTemplates_ ) {
 
 #ifdef NEW_CPEERROR
@@ -127,32 +123,16 @@ PixelCPEGeneric::PixelCPEGeneric(edm::ParameterSet const & conf,
       if ( LoadTemplatesFromDB_ )  {  // From DB
 	if ( !SiPixelGenError::pushfile( *genErrorDBObject_, thePixelGenError_) )
           throw cms::Exception("InvalidCalibrationLoaded") 
-            << "ERROR: Templates not filled correctly. Check the sqlite file. Using SiPixelTemplateDBObject version " 
+            << "ERROR: GenErrors not filled correctly. Check the sqlite file. Using SiPixelTemplateDBObject version " 
             << ( *genErrorDBObject_ ).version();
+	if(MYDEBUG) cout<<"Loaded genErrorDBObject v"<<( *genErrorDBObject_ ).version()<<endl;
       } else  { // From file      
         if ( !SiPixelGenError::pushfile( -999, thePixelGenError_ ) )
           throw cms::Exception("InvalidCalibrationLoaded") 
-            << "ERROR: Templates not loaded correctly from text file. Reconstruction will fail.";
+            << "ERROR: GenErrors not loaded correctly from text file. Reconstruction will fail.";
       } // if load from DB
 
 #else 
-
-    if(useNewSimplerErrors) {  // use new errors from mini templates 
-
-      //cout<<" load errors "<<LoadTemplatesFromDB_<<endl;
-
-      if ( LoadTemplatesFromDB_ )  {  // From DB
-	if ( !SiPixelGenError::pushfile( *genErrorDBObject_, thePixelGenError_) )
-          throw cms::Exception("InvalidCalibrationLoaded") 
-            << "ERROR: Templates not filled correctly. Check the sqlite file. Using SiPixelTemplateDBObject version " 
-            << ( *genErrorDBObject_ ).version();
-      } else  { // From file      
-        if ( !SiPixelGenError::pushfile( -999, thePixelGenError_ ) )
-          throw cms::Exception("InvalidCalibrationLoaded") 
-            << "ERROR: Templates not loaded correctly from text file. Reconstruction will fail.";
-      } // if load from DB
-
-    } else {  // use old errors from full templates
 
       if ( LoadTemplatesFromDB_ ) {
 	// Initialize template store to the selected ID [Morris, 6/25/08]  
@@ -160,25 +140,26 @@ PixelCPEGeneric::PixelCPEGeneric(edm::ParameterSet const & conf,
 	  throw cms::Exception("InvalidCalibrationLoaded") 
 	    << "ERROR: Templates not filled correctly. Check the sqlite file. Using SiPixelTemplateDBObject version " 
 	    << ( *templateDBobject_ ).version();
+	if(MYDEBUG) cout<<"Loaded templateDBobject "<<( *templateDBobject_ ).version()<<endl;
+
       } else {
 	if ( !SiPixelTemplate::pushfile( -999, thePixelTemp_ ) )
 	  throw cms::Exception("InvalidCalibrationLoaded") 
 	    << "ERROR: Templates not loaded correctly from text file. Reconstruction will fail.";
       } // if load from DB
 
-    } // if useNewSimpleErrors 
 #endif // NEW_CPEERROR
 
   } // if ( UseErrorsFromTemplates_ )
   
-  //cout << endl;
-  //cout << "From PixelCPEGeneric::PixelCPEGeneric(...)" << endl;
-  //cout << "(int)UseErrorsFromTemplates_ = " << (int)UseErrorsFromTemplates_    << endl;
-  //cout << "TruncatePixelCharge_         = " << (int)TruncatePixelCharge_       << endl;      
-  //cout << "IrradiationBiasCorrection_   = " << (int)IrradiationBiasCorrection_ << endl;
-  //cout << "(int)DoCosmics_              = " << (int)DoCosmics_                 << endl;
-  //cout << "(int)LoadTemplatesFromDB_    = " << (int)LoadTemplatesFromDB_       << endl;
-  //cout << endl;
+  if(MYDEBUG) {
+    cout << "From PixelCPEGeneric::PixelCPEGeneric(...)" << endl;
+    cout << "(int)UseErrorsFromTemplates_ = " << (int)UseErrorsFromTemplates_    << endl;
+    cout << "TruncatePixelCharge_         = " << (int)TruncatePixelCharge_       << endl;      
+    cout << "IrradiationBiasCorrection_   = " << (int)IrradiationBiasCorrection_ << endl;
+    cout << "(int)DoCosmics_              = " << (int)DoCosmics_                 << endl;
+    cout << "(int)LoadTemplatesFromDB_    = " << (int)LoadTemplatesFromDB_       << endl;
+  }
 
 
   // Default case for rechit errors in case other, more correct, errors are not vailable
@@ -248,70 +229,43 @@ PixelCPEGeneric::localPosition(DetParam const & theDetParam, ClusterParam & theC
 
 #ifdef NEW_CPEERROR
 
-        SiPixelGenError gtempl(thePixelGenError_);
-	int gtemplID_ = theDetParam.detTemplateId;
+      SiPixelGenError gtempl(thePixelGenError_);
+      int gtemplID_ = theDetParam.detTemplateId;
 
-	//int gtemplID0 = genErrorDBObject_->getGenErrorID(theDetParam.theDet->geographicalId().rawId());
-	//if(gtemplID0!=gtemplID_) cout<<" different id "<< gtemplID_<<" "<<gtemplID0<<endl;
+      //int gtemplID0 = genErrorDBObject_->getGenErrorID(theDetParam.theDet->geographicalId().rawId());
+      //if(gtemplID0!=gtemplID_) cout<<" different id "<< gtemplID_<<" "<<gtemplID0<<endl;
 
-	theClusterParam.qBin_ = gtempl.qbin( gtemplID_, theClusterParam.cotalpha, theClusterParam.cotbeta, locBz, qclus,  
-			      theClusterParam.pixmx, theClusterParam.sigmay, theClusterParam.deltay, 
-			      theClusterParam.sigmax, theClusterParam.deltax, theClusterParam.sy1, 
-                              theClusterParam.dy1, theClusterParam.sy2, theClusterParam.dy2, theClusterParam.sx1, 
-                              theClusterParam.dx1, theClusterParam.sx2, theClusterParam.dx2 );  
-	
-	// now use the charge widths stored in the new generic template headers (change to the
-	// incorrect sign convention of the base class)       
-	bool useLAWidthFromGenError = false;
-	if(useLAWidthFromGenError) {
-	  chargeWidthX = (-micronsToCm*gtempl.lorxwidth());
-	  chargeWidthY = (-micronsToCm*gtempl.lorywidth());
-	  //cout<< " redefine la width (gen-error) "<< chargeWidthX<<" "<< chargeWidthY <<endl;
-	}
-	if(MYDEBUG) cout<<" new errors "<<gtemplID_<<" "<<theClusterParam.sy1<<endl;
+      theClusterParam.qBin_ = gtempl.qbin( gtemplID_, theClusterParam.cotalpha, theClusterParam.cotbeta, locBz, qclus,  
+					   theClusterParam.pixmx, theClusterParam.sigmay, theClusterParam.deltay, 
+					   theClusterParam.sigmax, theClusterParam.deltax, theClusterParam.sy1, 
+					   theClusterParam.dy1, theClusterParam.sy2, theClusterParam.dy2, theClusterParam.sx1, 
+					   theClusterParam.dx1, theClusterParam.sx2, theClusterParam.dx2 );  
+      
+      // now use the charge widths stored in the new generic template headers (change to the
+      // incorrect sign convention of the base class)       
+      bool useLAWidthFromGenError = false;
+      if(useLAWidthFromGenError) {
+	chargeWidthX = (-micronsToCm*gtempl.lorxwidth());
+	chargeWidthY = (-micronsToCm*gtempl.lorywidth());
+	//cout<< " redefine la width (gen-error) "<< chargeWidthX<<" "<< chargeWidthY <<endl;
+      }
+      if(MYDEBUG) cout<<" GenError: "<<gtemplID_<<endl;
+      
+#else // select templates
 
-#else // select which one 
-
-      if(useNewSimplerErrors) { // errors from new light templates
-
-        SiPixelGenError gtempl(thePixelGenError_);
-	int gtemplID_ = theDetParam.detTemplateId;
-
-	//int gtemplID0 = genErrorDBObject_->getGenErrorID(theDetParam.theDet->geographicalId().rawId());
-	//if(gtemplID0!=gtemplID_) cout<<" different id "<< gtemplID_<<" "<<gtemplID0<<endl;
-
-	theClusterParam.qBin_ = gtempl.qbin( gtemplID_, theClusterParam.cotalpha, theClusterParam.cotbeta, locBz, qclus,  // inputs
-			      theClusterParam.pixmx,                                       // returned by reference
-			      theClusterParam.sigmay, theClusterParam.deltay, theClusterParam.sigmax, theClusterParam.deltax,              // returned by reference
-			      theClusterParam.sy1, theClusterParam.dy1, theClusterParam.sy2, theClusterParam.dy2, theClusterParam.sx1, theClusterParam.dx1, theClusterParam.sx2, theClusterParam.dx2 );    // returned by reference
-	
-
-	// OK, now use the charge widths stored in the new generic template headers (change to the
-	// incorrect sign convention of the base class)       
-	bool useLAWidthFromGenError = false;
-	if(useLAWidthFromGenError) {
-	  chargeWidthX = (-micronsToCm*gtempl.lorxwidth());
-	  chargeWidthY = (-micronsToCm*gtempl.lorywidth());
-	  //cout<< " redefine la width (gen-error) "<< chargeWidthX<<" "<< chargeWidthY <<endl;
-	}
-	if(MYDEBUG) cout<<" new errors "<<gtemplID_<<" "<<theClusterParam.sy1<<endl;
-
-
-      } else { // errors from full templates 
-
-        SiPixelTemplate templ(thePixelTemp_);
-	//int templID0 = templateDBobject_->getTemplateID(theDetParam.theDet->geographicalId().rawId());
-	int templID_ = theDetParam.detTemplateId;
-	//if(templID0!=templID_) cout<<" different id"<< templID_<<" "<<templID0<<endl;
-
-	theClusterParam.qBin_ = templ.qbin( templID_, theClusterParam.cotalpha, theClusterParam.cotbeta, locBz, qclus,  // inputs
-			     theClusterParam.pixmx,                                       // returned by reference
-			     theClusterParam.sigmay, theClusterParam.deltay, theClusterParam.sigmax, theClusterParam.deltax,              // returned by reference
-			     theClusterParam.sy1, theClusterParam.dy1, theClusterParam.sy2, theClusterParam.dy2, theClusterParam.sx1, theClusterParam.dx1, theClusterParam.sx2, theClusterParam.dx2 );    // returned by reference
-
-	if(MYDEBUG) cout<<" errors "<<templID_<<" "<<theClusterParam.sy1<<endl;
-
-      }  // if iseNewSimplerErrors
+      SiPixelTemplate templ(thePixelTemp_);
+      int templID_ = theDetParam.detTemplateId;
+      
+      theClusterParam.qBin_ = templ.qbin( templID_, theClusterParam.cotalpha, theClusterParam.cotbeta, locBz, qclus,  // inputs
+					  theClusterParam.pixmx,                                       // returned by reference
+					  theClusterParam.sigmay, theClusterParam.deltay, theClusterParam.sigmax, theClusterParam.deltax,              // returned by reference
+					  theClusterParam.sy1, theClusterParam.dy1, theClusterParam.sy2, theClusterParam.dy2, theClusterParam.sx1, theClusterParam.dx1, theClusterParam.sx2, theClusterParam.dx2 );    // returned by reference
+      
+      //if(MYDEBUG) {
+      //cout<<" errors "<<templID_<<" "<<theClusterParam.qBin_<<" "<<theClusterParam.sigmax<<" "<<theClusterParam.sigmay<<endl;
+      //int templID0 = templateDBobject_->getTemplateID(theDetParam.theDet->geographicalId().rawId());
+      //if(templID0!=templID_) cout<<" different id"<< templID_<<" "<<templID0<<endl;
+      //}
 
 #endif // NEW_CPEERROR
 
@@ -443,15 +397,18 @@ PixelCPEGeneric::localPosition(DetParam const & theDetParam, ClusterParam & theC
   if ( IrradiationBiasCorrection_ ) {
     if ( theClusterParam.theCluster->sizeX() == 1 ) {  // size=1	  
       // ggiurgiu@jhu.edu, 02/03/09 : for size = 1, the Lorentz shift is already accounted by the irradiation correction
+      //float tmp1 =  (0.5 * theDetParam.lorentzShiftInCmX);
+      //cout << "Apply correction correction_dx1 = " << theClusterParam.dx1 << " to xPos = " << xPos;
       xPos = xPos - (0.5 * theDetParam.lorentzShiftInCmX);
       // Find if pixel is double (big). 
       bool bigInX = theDetParam.theRecTopol->isItBigPixelInX( theClusterParam.theCluster->maxPixelRow() );	  
       if ( !bigInX ) xPos -= theClusterParam.dx1;	   
       else           xPos -= theClusterParam.dx2;
-	  
+      //cout<<" to "<<xPos<<" "<<(tmp1+theClusterParam.dx1)<<endl;
     } else { // size>1
-      //cout << "Apply correction correction_deltax = " << deltax << " to xPos = " << xPos << endl;
+      //cout << "Apply correction correction_deltax = " << theClusterParam.deltax << " to xPos = " << xPos;
       xPos -= theClusterParam.deltax;
+      //cout<<" to "<<xPos<<endl;
     }
     
     if ( theClusterParam.theCluster->sizeY() == 1 ) {
@@ -464,6 +421,7 @@ PixelCPEGeneric::localPosition(DetParam const & theDetParam, ClusterParam & theC
       else           yPos -= theClusterParam.dy2;
       
     } else { 
+      //cout << "Apply correction correction_deltay = " << theClusterParam.deltay << " to yPos = " << yPos << endl;
       yPos -= theClusterParam.deltay; 
     }
  
@@ -693,7 +651,6 @@ PixelCPEGeneric::localError(DetParam const & theDetParam,  ClusterParam & theClu
    if(theClusterParam.qBin_ == 0) 
      cout<<" qbin 0! "<<edgex<<" "<<edgey<<" "<<bigInX<<" "<<bigInY<<" "
 	<<sizex<<" "<<sizey<<endl;
-   if(sizex==2 && sizey==2) cout<<" size 2*2 "<<theClusterParam.qBin_<<endl;
   }
 
   //if likely(UseErrorsFromTemplates_ && (qBin_!= 0) ) {
@@ -796,10 +753,10 @@ PixelCPEGeneric::localError(DetParam const & theDetParam,  ClusterParam & theClu
       << "\nERROR: Negative pixel error yerr = " << yerr << "\n\n";
 #endif
  
-  if(localPrint) {
-    cout<<" errors  "<<xerr<<" "<<yerr<<endl;  //dk
-    if(theClusterParam.qBin_ == 0) cout<<" qbin 0 "<<xerr<<" "<<yerr<<endl;
-  }
+  //if(localPrint) {
+  //cout<<" errors  "<<xerr<<" "<<yerr<<endl;  //dk
+  //if(theClusterParam.qBin_ == 0) cout<<" qbin 0 "<<xerr<<" "<<yerr<<endl;
+  //}
 
   auto xerr_sq = xerr*xerr; 
   auto yerr_sq = yerr*yerr;

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPETemplateReco.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPETemplateReco.cc
@@ -420,14 +420,22 @@ PixelCPETemplateReco::localPosition(DetParam const & theDetParam, ClusterParam &
 	  // the LA width/shift returned by templates use (+)
 	  // the LA width/shift produced by PixelCPEBase for positive LA is (-)
 	  // correct this by iserting (-)
-	  //float templateLorbiasCmX = -micronsToCm*templ.lorxwidth();  // old
-	  //float templateLorbiasCmY = -micronsToCm*templ.lorywidth();
+	  //float temp1 = -micronsToCm*templ.lorxwidth();  // old
+	  //float temp2 = -micronsToCm*templ.lorywidth();  // does not incl 1/2
 	  float templateLorbiasCmX = -micronsToCm*templ.lorxbias();  // new 
-	  float templateLorbiasCmY = -micronsToCm*templ.lorybias();
+	  float templateLorbiasCmY = -micronsToCm*templ.lorybias(); //incl. 1/2
 	  // now, correctly, we can use the difference of shifts  
-	  theClusterParam.templXrec_ += 0.5*(theDetParam.lorentzShiftInCmX - templateLorbiasCmX);
-	  theClusterParam.templYrec_ += 0.5*(theDetParam.lorentzShiftInCmY - templateLorbiasCmY);
-	  //cout << "Templates: la lorentz offset = " <<(0.5*(lorentzShiftInCmX_-templateLorwidthCmX))<< endl; //dk
+	  //theClusterParam.templXrec_ += 0.5*(theDetParam.lorentzShiftInCmX - templateLorbiasCmX);
+	  //theClusterParam.templYrec_ += 0.5*(theDetParam.lorentzShiftInCmY - templateLorbiasCmY);
+	  theClusterParam.templXrec_ += (0.5*(theDetParam.lorentzShiftInCmX) - templateLorbiasCmX);
+	  theClusterParam.templYrec_ += (0.5*(theDetParam.lorentzShiftInCmY) - templateLorbiasCmY);
+	  //cout << "Templates: la lorentz offset = " 
+	  //   <<(0.5*(theDetParam.lorentzShiftInCmX)-templateLorbiasCmX)
+	  //   <<" "<<templateLorbiasCmX<<" "<<templateLorbiasCmY
+	  //   <<" "<<temp1<<" "<<temp2
+	  //   <<" "<<theDetParam.lorentzShiftInCmX
+	  //   <<" "<<theDetParam.lorentzShiftInCmY
+	  //   << endl; //dk
 	} //else {cout<<" LA is 0, disable offset corrections "<<endl;} //dk
       } //else {cout<<" Do not do LA offset correction "<<endl;} //dk
 

--- a/RecoLocalTracker/SiPixelRecHits/src/SiPixelGenError.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/SiPixelGenError.cc
@@ -2,9 +2,9 @@
 //  SiPixelGenError.cc  Version 1.00
 //
 //  Object stores Lorentz widths, bias corrections, and errors for the Generic Algorithm
-//
+//  
 //  Created by Morris Swartz on 10/27/06.
-//
+//  Add some debugging messages. d.k. 5/14
 //
 
 //#include <stdlib.h>
@@ -30,6 +30,7 @@
 #include "FWCore/ParameterSet/interface/FileInPath.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #define LOGERROR(x) LogError(x)
+#define LOGWARNING(x) LogWarning(x)
 #define LOGINFO(x) LogInfo(x)
 #define ENDL " "
 #include "FWCore/Utilities/interface/Exception.h"
@@ -236,155 +237,159 @@ bool SiPixelGenError::pushfile(int filenum, std::vector< SiPixelGenErrorStore > 
 //! SiPixelGenErrorDBObject
 //! \param dbobject - db storing multiple generic calibrations
 //**************************************************************** 
-bool SiPixelGenError::pushfile(const SiPixelGenErrorDBObject& dbobject, std::vector< SiPixelGenErrorStore > & thePixelTemp_)
-{
-	// Add GenError stored in external dbobject to theGenErrorStore
+bool SiPixelGenError::pushfile(const SiPixelGenErrorDBObject& dbobject, 
+			       std::vector< SiPixelGenErrorStore > & thePixelTemp_) {
+  // Add GenError stored in external dbobject to theGenErrorStore
     
-	// Local variables 
-	int i, j, k;
-	float costrk[3]={0,0,0};
-	//	const char *tempfile;
-	const int code_version={1};
-	
-	// We must create a new object because dbobject must be a const and our stream must not be
-	SiPixelGenErrorDBObject db = dbobject;
-	
-	// Create a local GenError storage entry
-	SiPixelGenErrorStore theCurrentTemp;
-	
-	// Fill the GenError storage for each GenError calibration stored in the db
-	for(int m=0; m<db.numOfTempl(); ++m)
-	{
+  // Local variables 
+  int i, j, k;
+  float costrk[3]={0,0,0};
+  //	const char *tempfile;
+  const int code_version={1};
+  
+  // We must create a new object because dbobject must be a const and our stream must not be
+  SiPixelGenErrorDBObject db = dbobject;
+  
+  // Create a local GenError storage entry
+  SiPixelGenErrorStore theCurrentTemp;
+  
+  // Fill the GenError storage for each GenError calibration stored in the db
+  for(int m=0; m<db.numOfTempl(); ++m) {
 		
-		// Read-in a header string first and print it    
+    // Read-in a header string first and print it    
+    
+    SiPixelGenErrorDBObject::char2float temp;
+    for (i=0; i<20; ++i) {
+      temp.f = db.sVector()[db.index()];
+      theCurrentTemp.head.title[4*i] = temp.c[0];
+      theCurrentTemp.head.title[4*i+1] = temp.c[1];
+      theCurrentTemp.head.title[4*i+2] = temp.c[2];
+      theCurrentTemp.head.title[4*i+3] = temp.c[3];
+      db.incrementIndex(1);
+    }
+
+    theCurrentTemp.head.title[79] = '\0';
+    LOGINFO("SiPixelGenError") << "Loading Pixel GenError File - " 
+			       << theCurrentTemp.head.title << ENDL;
+    
+    // next, the header information     
 		
-		SiPixelGenErrorDBObject::char2float temp;
-		for (i=0; i<20; ++i) {
-			temp.f = db.sVector()[db.index()];
-			theCurrentTemp.head.title[4*i] = temp.c[0];
-			theCurrentTemp.head.title[4*i+1] = temp.c[1];
-			theCurrentTemp.head.title[4*i+2] = temp.c[2];
-			theCurrentTemp.head.title[4*i+3] = temp.c[3];
-			db.incrementIndex(1);
-		}
-		theCurrentTemp.head.title[79] = '\0';
-		LOGINFO("SiPixelGenError") << "Loading Pixel GenError File - " << theCurrentTemp.head.title << ENDL;
-		
-		// next, the header information     
-		
-		
-		db >> theCurrentTemp.head.ID  >> theCurrentTemp.head.templ_version >> theCurrentTemp.head.Bfield >> theCurrentTemp.head.NTy >> theCurrentTemp.head.NTyx >> theCurrentTemp.head.NTxx >> theCurrentTemp.head.Dtype >> theCurrentTemp.head.Vbias >>
-          theCurrentTemp.head.temperature >> theCurrentTemp.head.fluence >> theCurrentTemp.head.qscale >> theCurrentTemp.head.s50 >>
-          theCurrentTemp.head.lorywidth >> theCurrentTemp.head.lorxwidth >> theCurrentTemp.head.ysize >> theCurrentTemp.head.xsize >>
-          theCurrentTemp.head.zsize >> theCurrentTemp.head.ss50 >> theCurrentTemp.head.lorybias >> theCurrentTemp.head.lorxbias >>
-          theCurrentTemp.head.fbin[0] >> theCurrentTemp.head.fbin[1] >> theCurrentTemp.head.fbin[2];
-		
-		if(db.fail()) {LOGERROR("SiPixelGenError") << "Error reading file, no GenError load" << ENDL; return false;}
+    db >> theCurrentTemp.head.ID  >> theCurrentTemp.head.templ_version >> theCurrentTemp.head.Bfield >> theCurrentTemp.head.NTy >> theCurrentTemp.head.NTyx >> theCurrentTemp.head.NTxx >> theCurrentTemp.head.Dtype >> theCurrentTemp.head.Vbias >>
+      theCurrentTemp.head.temperature >> theCurrentTemp.head.fluence >> theCurrentTemp.head.qscale >> theCurrentTemp.head.s50 >>
+      theCurrentTemp.head.lorywidth >> theCurrentTemp.head.lorxwidth >> theCurrentTemp.head.ysize >> theCurrentTemp.head.xsize >>
+      theCurrentTemp.head.zsize >> theCurrentTemp.head.ss50 >> theCurrentTemp.head.lorybias >> theCurrentTemp.head.lorxbias >>
+      theCurrentTemp.head.fbin[0] >> theCurrentTemp.head.fbin[1] >> theCurrentTemp.head.fbin[2];
+    
+    if(db.fail()) {LOGERROR("SiPixelGenError") 
+	<< "Error reading file, no GenError load" << ENDL; return false;}
       
-		LOGINFO("SiPixelGenError") << "GenError ID = " << theCurrentTemp.head.ID << ", GenError Version " << theCurrentTemp.head.templ_version << ", Bfield = " << theCurrentTemp.head.Bfield
-		<< ", NTy = " << theCurrentTemp.head.NTy << ", NTyx = " << theCurrentTemp.head.NTyx<< ", NTxx = " << theCurrentTemp.head.NTxx << ", Dtype = " << theCurrentTemp.head.Dtype
-		<< ", Bias voltage " << theCurrentTemp.head.Vbias << ", temperature "
-		<< theCurrentTemp.head.temperature << ", fluence " << theCurrentTemp.head.fluence << ", Q-scaling factor " << theCurrentTemp.head.qscale
-		<< ", 1/2 multi dcol threshold " << theCurrentTemp.head.s50 << ", 1/2 single dcol threshold " << theCurrentTemp.head.ss50
-      << ", y Lorentz Width " << theCurrentTemp.head.lorywidth << ", y Lorentz Bias " << theCurrentTemp.head.lorybias
-      << ", x Lorentz width " << theCurrentTemp.head.lorxwidth << ", x Lorentz Bias " << theCurrentTemp.head.lorxbias
-      << ", Q/Q_avg fractions for Qbin defs " << theCurrentTemp.head.fbin[0] << ", " << theCurrentTemp.head.fbin[1]
-      << ", " << theCurrentTemp.head.fbin[2]
-		<< ", pixel x-size " << theCurrentTemp.head.xsize << ", y-size " << theCurrentTemp.head.ysize << ", zsize " << theCurrentTemp.head.zsize << ENDL;
-		
-		if(theCurrentTemp.head.templ_version < code_version) {LOGERROR("SiPixelGenError") << "code expects version " << code_version << ", no GenError load" << ENDL; return false;}
-		
-		
+    LOGINFO("SiPixelGenError") << "GenError ID = " << theCurrentTemp.head.ID << ", GenError Version " << theCurrentTemp.head.templ_version << ", Bfield = " << theCurrentTemp.head.Bfield
+			       << ", NTy = " << theCurrentTemp.head.NTy << ", NTyx = " << theCurrentTemp.head.NTyx<< ", NTxx = " << theCurrentTemp.head.NTxx << ", Dtype = " << theCurrentTemp.head.Dtype
+			       << ", Bias voltage " << theCurrentTemp.head.Vbias << ", temperature "
+			       << theCurrentTemp.head.temperature << ", fluence " << theCurrentTemp.head.fluence << ", Q-scaling factor " << theCurrentTemp.head.qscale
+			       << ", 1/2 multi dcol threshold " << theCurrentTemp.head.s50 << ", 1/2 single dcol threshold " << theCurrentTemp.head.ss50
+			       << ", y Lorentz Width " << theCurrentTemp.head.lorywidth << ", y Lorentz Bias " << theCurrentTemp.head.lorybias
+			       << ", x Lorentz width " << theCurrentTemp.head.lorxwidth << ", x Lorentz Bias " << theCurrentTemp.head.lorxbias
+			       << ", Q/Q_avg fractions for Qbin defs " << theCurrentTemp.head.fbin[0] << ", " << theCurrentTemp.head.fbin[1]
+			       << ", " << theCurrentTemp.head.fbin[2]
+			       << ", pixel x-size " << theCurrentTemp.head.xsize << ", y-size " << theCurrentTemp.head.ysize << ", zsize " << theCurrentTemp.head.zsize << ENDL;
+    
+    LOGWARNING("SiPixelGenError") << "Loading Pixel GenError - " 
+				  << theCurrentTemp.head.title << " version "
+				  <<theCurrentTemp.head.templ_version <<" code v."
+				  <<code_version<<ENDL;
+    if(theCurrentTemp.head.templ_version < code_version) {
+      LOGERROR("SiPixelGenError") << "code expects version " << code_version 
+				  << ", no GenError load" << ENDL; return false;}
+    		
 #ifdef SI_PIXEL_TEMPLATE_USE_BOOST 
 		
 // next, layout the 1-d/2-d structures needed to store GenError
 		
-		theCurrentTemp.enty.resize(boost::extents[theCurrentTemp.head.NTy]);
-		
-		theCurrentTemp.entx.resize(boost::extents[theCurrentTemp.head.NTyx][theCurrentTemp.head.NTxx]);
-		
+    theCurrentTemp.enty.resize(boost::extents[theCurrentTemp.head.NTy]);
+    
+    theCurrentTemp.entx.resize(boost::extents[theCurrentTemp.head.NTyx][theCurrentTemp.head.NTxx]);
+    
 #endif
-				
-// next, loop over all barrel y-angle entries   
-		
-		for (i=0; i < theCurrentTemp.head.NTy; ++i) {     
-			
-			db >> theCurrentTemp.enty[i].runnum >> costrk[0] >> costrk[1] >> costrk[2];
-			
-			if(db.fail()) {LOGERROR("SiPixelGenError") << "Error reading file 1, no GenError load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-			
-// Calculate the alpha, beta, and cot(beta) for this entry 
-			
-			theCurrentTemp.enty[i].cotalpha = costrk[0]/costrk[2];
-			
-			theCurrentTemp.enty[i].cotbeta = costrk[1]/costrk[2];
-			
-			db >> theCurrentTemp.enty[i].qavg >> theCurrentTemp.enty[i].pixmax >> theCurrentTemp.enty[i].dyone
-			>> theCurrentTemp.enty[i].syone >> theCurrentTemp.enty[i].dxone >> theCurrentTemp.enty[i].sxone;
-			
-			if(db.fail()) {LOGERROR("SiPixelGenError") << "Error reading file 2, no GenError load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-			
-			db >> theCurrentTemp.enty[i].dytwo >> theCurrentTemp.enty[i].sytwo >> theCurrentTemp.enty[i].dxtwo 
-			>> theCurrentTemp.enty[i].sxtwo >> theCurrentTemp.enty[i].qmin >> theCurrentTemp.enty[i].qmin2;
-			
-			for (j=0; j<4; ++j) {
-				
-            db >> theCurrentTemp.enty[i].yavggen[j] >> theCurrentTemp.enty[i].yrmsgen[j] >> theCurrentTemp.enty[i].xavggen[j] >> theCurrentTemp.enty[i].xrmsgen[j];
-				
-				if(db.fail()) {LOGERROR("SiPixelGenError") << "Error reading file 14a, no GenError load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-			}
-						
-		}
-		
-		// next, loop over all barrel x-angle entries   
-		
-		for (k=0; k < theCurrentTemp.head.NTyx; ++k) { 
-			
-			for (i=0; i < theCurrentTemp.head.NTxx; ++i) { 
-				
-				db >> theCurrentTemp.entx[k][i].runnum >> costrk[0] >> costrk[1] >> costrk[2];
-				
-				if(db.fail()) {LOGERROR("SiPixelGenError") << "Error reading file 17, no GenError load, run # " << theCurrentTemp.entx[k][i].runnum << ENDL; return false;}
-				
-				// Calculate the alpha, beta, and cot(beta) for this entry 
-				
-				theCurrentTemp.entx[k][i].cotalpha = costrk[0]/costrk[2];
-				
-				theCurrentTemp.entx[k][i].cotbeta = costrk[1]/costrk[2];
-				
-				db >> theCurrentTemp.entx[k][i].qavg >> theCurrentTemp.entx[k][i].pixmax >> theCurrentTemp.entx[k][i].dyone
-				>> theCurrentTemp.entx[k][i].syone >> theCurrentTemp.entx[k][i].dxone >> theCurrentTemp.entx[k][i].sxone;
-				
-				if(db.fail()) {LOGERROR("SiPixelGenError") << "Error reading file 18, no GenError load, run # " << theCurrentTemp.entx[k][i].runnum << ENDL; return false;}
-				
-				db >> theCurrentTemp.entx[k][i].dytwo >> theCurrentTemp.entx[k][i].sytwo >> theCurrentTemp.entx[k][i].dxtwo 
-				>> theCurrentTemp.entx[k][i].sxtwo >> theCurrentTemp.entx[k][i].qmin >> theCurrentTemp.entx[k][i].qmin2;
-				
-				for (j=0; j<4; ++j) {
-					
-					db >> theCurrentTemp.entx[k][i].yavggen[j] >> theCurrentTemp.entx[k][i].yrmsgen[j] >> theCurrentTemp.entx[k][i].xavggen[j] >> theCurrentTemp.entx[k][i].xrmsgen[j];
-					
-					if(db.fail()) {LOGERROR("SiPixelGenError") << "Error reading file 30a, no GenError load, run # " << theCurrentTemp.entx[k][i].runnum << ENDL; return false;}
-				}
-								
-			}
-		}	
-		
-		
-		// Add this GenError to the store
-		
-		thePixelTemp_.push_back(theCurrentTemp);
+    
+    // next, loop over all barrel y-angle entries   
+    
+    for (i=0; i < theCurrentTemp.head.NTy; ++i) {     
       
-		postInit(thePixelTemp_);
-		
-	}
-	return true;
+      db >> theCurrentTemp.enty[i].runnum >> costrk[0] >> costrk[1] >> costrk[2];
+      
+      if(db.fail()) {LOGERROR("SiPixelGenError") << "Error reading file 1, no GenError load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
+      
+      // Calculate the alpha, beta, and cot(beta) for this entry 
+      
+      theCurrentTemp.enty[i].cotalpha = costrk[0]/costrk[2];
+      
+      theCurrentTemp.enty[i].cotbeta = costrk[1]/costrk[2];
+      
+      db >> theCurrentTemp.enty[i].qavg >> theCurrentTemp.enty[i].pixmax >> theCurrentTemp.enty[i].dyone
+	 >> theCurrentTemp.enty[i].syone >> theCurrentTemp.enty[i].dxone >> theCurrentTemp.enty[i].sxone;
+      
+      if(db.fail()) {LOGERROR("SiPixelGenError") << "Error reading file 2, no GenError load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
+      
+      db >> theCurrentTemp.enty[i].dytwo >> theCurrentTemp.enty[i].sytwo >> theCurrentTemp.enty[i].dxtwo 
+	 >> theCurrentTemp.enty[i].sxtwo >> theCurrentTemp.enty[i].qmin >> theCurrentTemp.enty[i].qmin2;
+      
+      for (j=0; j<4; ++j) {
 	
+	db >> theCurrentTemp.enty[i].yavggen[j] >> theCurrentTemp.enty[i].yrmsgen[j] >> theCurrentTemp.enty[i].xavggen[j] >> theCurrentTemp.enty[i].xrmsgen[j];
+	
+	if(db.fail()) {LOGERROR("SiPixelGenError") << "Error reading file 14a, no GenError load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
+      }
+      
+    }
+    
+    // next, loop over all barrel x-angle entries   
+    
+    for (k=0; k < theCurrentTemp.head.NTyx; ++k) { 
+      
+      for (i=0; i < theCurrentTemp.head.NTxx; ++i) { 
+	
+	db >> theCurrentTemp.entx[k][i].runnum >> costrk[0] >> costrk[1] >> costrk[2];
+	
+	if(db.fail()) {LOGERROR("SiPixelGenError") << "Error reading file 17, no GenError load, run # " << theCurrentTemp.entx[k][i].runnum << ENDL; return false;}
+	
+	// Calculate the alpha, beta, and cot(beta) for this entry 
+	
+	theCurrentTemp.entx[k][i].cotalpha = costrk[0]/costrk[2];
+	
+	theCurrentTemp.entx[k][i].cotbeta = costrk[1]/costrk[2];
+	
+	db >> theCurrentTemp.entx[k][i].qavg >> theCurrentTemp.entx[k][i].pixmax >> theCurrentTemp.entx[k][i].dyone
+	   >> theCurrentTemp.entx[k][i].syone >> theCurrentTemp.entx[k][i].dxone >> theCurrentTemp.entx[k][i].sxone;
+	
+	if(db.fail()) {LOGERROR("SiPixelGenError") << "Error reading file 18, no GenError load, run # " << theCurrentTemp.entx[k][i].runnum << ENDL; return false;}
+	
+	db >> theCurrentTemp.entx[k][i].dytwo >> theCurrentTemp.entx[k][i].sytwo >> theCurrentTemp.entx[k][i].dxtwo 
+	   >> theCurrentTemp.entx[k][i].sxtwo >> theCurrentTemp.entx[k][i].qmin >> theCurrentTemp.entx[k][i].qmin2;
+	
+	for (j=0; j<4; ++j) {
+	  
+	  db >> theCurrentTemp.entx[k][i].yavggen[j] >> theCurrentTemp.entx[k][i].yrmsgen[j] >> theCurrentTemp.entx[k][i].xavggen[j] >> theCurrentTemp.entx[k][i].xrmsgen[j];
+	  
+	  if(db.fail()) {LOGERROR("SiPixelGenError") << "Error reading file 30a, no GenError load, run # " << theCurrentTemp.entx[k][i].runnum << ENDL; return false;}
+	}
+	
+      }
+    }	
+    
+		
+    // Add this GenError to the store
+		
+    thePixelTemp_.push_back(theCurrentTemp);
+      
+    postInit(thePixelTemp_);
+    
+  }
+  return true;
+  
 } // TempInit 
 
 #endif
-
-
 
 void SiPixelGenError::postInit(std::vector< SiPixelGenErrorStore > & thePixelTemp_) {
    

--- a/RecoLocalTracker/SiPixelRecHits/src/SiPixelGenError.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/SiPixelGenError.cc
@@ -39,6 +39,7 @@ using namespace edm;
 #include "SiPixelGenError.h"
 #define LOGERROR(x) std::cout << x << ": "
 #define LOGINFO(x) std::cout << x << ": "
+#define LOGWARNING(x) std::cout << x << ": "
 #define ENDL std::endl
 #endif
 
@@ -294,7 +295,7 @@ bool SiPixelGenError::pushfile(const SiPixelGenErrorDBObject& dbobject,
 			       << ", " << theCurrentTemp.head.fbin[2]
 			       << ", pixel x-size " << theCurrentTemp.head.xsize << ", y-size " << theCurrentTemp.head.ysize << ", zsize " << theCurrentTemp.head.zsize << ENDL;
     
-    LOGWARNING("SiPixelGenError") << "Loading Pixel GenError - " 
+    LOGINFO("SiPixelGenError") << "Loading Pixel GenError - " 
 				  << theCurrentTemp.head.title << " version "
 				  <<theCurrentTemp.head.templ_version <<" code v."
 				  <<code_version<<ENDL;

--- a/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplate.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplate.cc
@@ -1,5 +1,5 @@
 //
-//  SiPixelTemplate.cc  Version 8.30 
+//  SiPixelTemplate.cc  Version 9.00 
 //
 //  Add goodness-of-fit info and spare entries to templates, version number in template header, more error checking
 //  Add correction for (Q_F-Q_L)/(Q_F+Q_L) bias
@@ -65,7 +65,13 @@
 //  V8.25 - Incorporate VI's speed changes into the current version
 //  V8.26 - Modify the Vavilov lookups to work better with the FPix (offset y-templates)
 //  V8.30 - Change the splitting template generation and access to improve speed and eliminate triple index boost::multiarray
-
+//  V8.31 - Add correction factor: measured/true charge
+//  V8.31 - Fix version number bug in db object I/O (pushfile)
+//  V8.32 - Check for illegal qmin during loading
+//  V8.33 - Fix small type conversion warnings
+//  V8.40 - Incorporate V.I. optimizations
+//  V9.00 - Expand header to include multi and single dcol thresholds, LA biases, and (variable) Qbin definitions
+// Due to a bug I have to fix fbin to 1.5,1.0,0.85. Delete version testing. d.k. 5/14
 //  Created by Morris Swartz on 10/27/06.
 //
 //
@@ -93,6 +99,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #define LOGERROR(x) LogError(x)
 #define LOGINFO(x) LogInfo(x)
+#define LOGWARNING(x) LogWarning(x)
 #define ENDL " "
 #include "FWCore/Utilities/interface/Exception.h"
 using namespace edm;
@@ -148,35 +155,56 @@ bool SiPixelTemplate::pushfile(int filenum, std::vector< SiPixelTemplateStore > 
 	
 	if(in_file.is_open()) {
 		
-		// Create a local template storage entry
+	  // Create a local template storage entry
 		
-		SiPixelTemplateStore theCurrentTemp;
+	  SiPixelTemplateStore theCurrentTemp;
+	  
+	  // Read-in a header string first and print it    
+	  
+	  for (i=0; (c=in_file.get()) != '\n'; ++i) {
+	    if(i < 79) {theCurrentTemp.head.title[i] = c;}
+	  }
+	  if(i > 78) {i=78;}
+	  theCurrentTemp.head.title[i+1] ='\0';
+	  LOGINFO("SiPixelTemplate") << "Loading Pixel Template File - " << theCurrentTemp.head.title << ENDL;
+	  
+	  // next, the header information     
+	  
+	  in_file >> theCurrentTemp.head.ID  >> theCurrentTemp.head.templ_version >> theCurrentTemp.head.Bfield >> theCurrentTemp.head.NTy >> theCurrentTemp.head.NTyx >> theCurrentTemp.head.NTxx
+		  >> theCurrentTemp.head.Dtype >> theCurrentTemp.head.Vbias >> theCurrentTemp.head.temperature >> theCurrentTemp.head.fluence >> theCurrentTemp.head.qscale
+		  >> theCurrentTemp.head.s50 >> theCurrentTemp.head.lorywidth >> theCurrentTemp.head.lorxwidth >> theCurrentTemp.head.ysize >> theCurrentTemp.head.xsize >> theCurrentTemp.head.zsize;
+	  
+	  if(in_file.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 0A, no template load" << ENDL; return false;}
+	  
+	  if(theCurrentTemp.head.templ_version > 17) {
+	    in_file >> theCurrentTemp.head.ss50 >> theCurrentTemp.head.lorybias 
+		    >> theCurrentTemp.head.lorxbias >> theCurrentTemp.head.fbin[0] 
+		    >> theCurrentTemp.head.fbin[1] >> theCurrentTemp.head.fbin[2];
+	    
+	    if(in_file.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 0B, no template load" 
+							    << ENDL; return false;}
+	  } else {
+	    theCurrentTemp.head.ss50 = theCurrentTemp.head.s50;
+	    theCurrentTemp.head.lorybias = theCurrentTemp.head.lorywidth/2.f;
+	    theCurrentTemp.head.lorxbias = theCurrentTemp.head.lorxwidth/2.f;
+	    theCurrentTemp.head.fbin[0] = 1.50f;
+	    theCurrentTemp.head.fbin[1] = 1.00f;
+	    theCurrentTemp.head.fbin[2] = 0.85f;
+	  }
 		
-		// Read-in a header string first and print it    
-		
-		for (i=0; (c=in_file.get()) != '\n'; ++i) {
-			if(i < 79) {theCurrentTemp.head.title[i] = c;}
-		}
-		if(i > 78) {i=78;}
-		theCurrentTemp.head.title[i+1] ='\0';
-		LOGINFO("SiPixelTemplate") << "Loading Pixel Template File - " << theCurrentTemp.head.title << ENDL;
-		
-		// next, the header information     
-		
-		in_file >> theCurrentTemp.head.ID  >> theCurrentTemp.head.templ_version >> theCurrentTemp.head.Bfield >> theCurrentTemp.head.NTy >> theCurrentTemp.head.NTyx >> theCurrentTemp.head.NTxx
-		>> theCurrentTemp.head.Dtype >> theCurrentTemp.head.Vbias >> theCurrentTemp.head.temperature >> theCurrentTemp.head.fluence >> theCurrentTemp.head.qscale
-		>> theCurrentTemp.head.s50 >> theCurrentTemp.head.lorywidth >> theCurrentTemp.head.lorxwidth >> theCurrentTemp.head.ysize >> theCurrentTemp.head.xsize >> theCurrentTemp.head.zsize;
-		
-		if(in_file.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file, no template load" << ENDL; return false;}
-		
-		LOGINFO("SiPixelTemplate") << "Template ID = " << theCurrentTemp.head.ID << ", Template Version " << theCurrentTemp.head.templ_version << ", Bfield = " << theCurrentTemp.head.Bfield 
-		<< ", NTy = " << theCurrentTemp.head.NTy << ", NTyx = " << theCurrentTemp.head.NTyx<< ", NTxx = " << theCurrentTemp.head.NTxx << ", Dtype = " << theCurrentTemp.head.Dtype
+	  LOGINFO("SiPixelTemplate") << "Template ID = " << theCurrentTemp.head.ID << ", Template Version " << theCurrentTemp.head.templ_version << ", Bfield = " << theCurrentTemp.head.Bfield 
+				     << ", NTy = " << theCurrentTemp.head.NTy << ", NTyx = " << theCurrentTemp.head.NTyx<< ", NTxx = " << theCurrentTemp.head.NTxx << ", Dtype = " << theCurrentTemp.head.Dtype
 		<< ", Bias voltage " << theCurrentTemp.head.Vbias << ", temperature "
 		<< theCurrentTemp.head.temperature << ", fluence " << theCurrentTemp.head.fluence << ", Q-scaling factor " << theCurrentTemp.head.qscale
-		<< ", 1/2 threshold " << theCurrentTemp.head.s50 << ", y Lorentz Width " << theCurrentTemp.head.lorywidth << ", x Lorentz width " << theCurrentTemp.head.lorxwidth    
+		<< ", 1/2 multi dcol threshold " << theCurrentTemp.head.s50 << ", 1/2 single dcol threshold " << theCurrentTemp.head.ss50
+      << ", y Lorentz Width " << theCurrentTemp.head.lorywidth << ", y Lorentz Bias " << theCurrentTemp.head.lorybias
+      << ", x Lorentz width " << theCurrentTemp.head.lorxwidth << ", x Lorentz Bias " << theCurrentTemp.head.lorxbias
+      << ", Q/Q_avg fractions for Qbin defs " << theCurrentTemp.head.fbin[0] << ", " << theCurrentTemp.head.fbin[1]
+      << ", " << theCurrentTemp.head.fbin[2]
 		<< ", pixel x-size " << theCurrentTemp.head.xsize << ", y-size " << theCurrentTemp.head.ysize << ", zsize " << theCurrentTemp.head.zsize << ENDL;
 		
-		if(theCurrentTemp.head.templ_version < code_version) {LOGERROR("SiPixelTemplate") << "code expects version " << code_version << ", no template load" << ENDL; return false;}
+
+	  if(theCurrentTemp.head.templ_version < code_version) {LOGERROR("SiPixelTemplate") << "code expects version " << code_version << " finds "<< theCurrentTemp.head.templ_version <<", no template load" << ENDL; return false;}
 		
 #ifdef SI_PIXEL_TEMPLATE_USE_BOOST 
 		
@@ -216,6 +244,10 @@ bool SiPixelTemplate::pushfile(int filenum, std::vector< SiPixelTemplateStore > 
 			>> theCurrentTemp.enty[i].sxtwo >> theCurrentTemp.enty[i].qmin >> theCurrentTemp.enty[i].clsleny >> theCurrentTemp.enty[i].clslenx;
 			
 			if(in_file.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 3, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
+
+         
+         if(theCurrentTemp.enty[i].qmin <= 0.) {LOGERROR("SiPixelTemplate") << "Error in template ID " << theCurrentTemp.head.ID << " qmin = " << theCurrentTemp.enty[i].qmin << ", run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
+
 			
 			for (j=0; j<2; ++j) {
 				
@@ -317,7 +349,7 @@ bool SiPixelTemplate::pushfile(int filenum, std::vector< SiPixelTemplateStore > 
 			} 
 			
 			in_file >> theCurrentTemp.enty[i].chi2yavgone >> theCurrentTemp.enty[i].chi2yminone >> theCurrentTemp.enty[i].chi2xavgone >> theCurrentTemp.enty[i].chi2xminone >> theCurrentTemp.enty[i].qmin2
-			>> theCurrentTemp.enty[i].mpvvav >> theCurrentTemp.enty[i].sigmavav >> theCurrentTemp.enty[i].kappavav >> theCurrentTemp.enty[i].qavg_spare >> theCurrentTemp.enty[i].spare[0];
+			>> theCurrentTemp.enty[i].mpvvav >> theCurrentTemp.enty[i].sigmavav >> theCurrentTemp.enty[i].kappavav >> theCurrentTemp.enty[i].r_qMeas_qTrue >> theCurrentTemp.enty[i].spare[0];
 			
 			if(in_file.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 15, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
 			
@@ -460,7 +492,7 @@ bool SiPixelTemplate::pushfile(int filenum, std::vector< SiPixelTemplateStore > 
 				}
 				
 				in_file >> theCurrentTemp.entx[k][i].chi2yavgone >> theCurrentTemp.entx[k][i].chi2yminone >> theCurrentTemp.entx[k][i].chi2xavgone >> theCurrentTemp.entx[k][i].chi2xminone >> theCurrentTemp.entx[k][i].qmin2
-				>> theCurrentTemp.entx[k][i].mpvvav >> theCurrentTemp.entx[k][i].sigmavav >> theCurrentTemp.entx[k][i].kappavav >> theCurrentTemp.entx[k][i].qavg_spare >> theCurrentTemp.entx[k][i].spare[0];
+				>> theCurrentTemp.entx[k][i].mpvvav >> theCurrentTemp.entx[k][i].sigmavav >> theCurrentTemp.entx[k][i].kappavav >> theCurrentTemp.entx[k][i].r_qMeas_qTrue >> theCurrentTemp.entx[k][i].spare[0];
 				
 				if(in_file.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 31, no template load, run # " << theCurrentTemp.entx[k][i].runnum << ENDL; return false;}
 				
@@ -511,7 +543,7 @@ bool SiPixelTemplate::pushfile(const SiPixelTemplateDBObject& dbobject, std::vec
 	int i, j, k, l;
 	float qavg_avg;
 	//	const char *tempfile;
-	const int code_version={16};
+	const int code_version={17};
 	
 	// We must create a new object because dbobject must be a const and our stream must not be
 	SiPixelTemplateDBObject db = dbobject;
@@ -521,195 +553,231 @@ bool SiPixelTemplate::pushfile(const SiPixelTemplateDBObject& dbobject, std::vec
 	SiPixelTemplateStore theCurrentTemp;
 	
 	// Fill the template storage for each template calibration stored in the db
-	for(int m=0; m<db.numOfTempl(); ++m)
-	{
+	for(int m=0; m<db.numOfTempl(); ++m) {
 		
-		// Read-in a header string first and print it    
+	  // Read-in a header string first and print it    
+	  
+	  SiPixelTemplateDBObject::char2float temp;
+	  for (i=0; i<20; ++i) {
+	    temp.f = db.sVector()[db.index()];
+	    theCurrentTemp.head.title[4*i] = temp.c[0];
+	    theCurrentTemp.head.title[4*i+1] = temp.c[1];
+	    theCurrentTemp.head.title[4*i+2] = temp.c[2];
+	    theCurrentTemp.head.title[4*i+3] = temp.c[3];
+	    db.incrementIndex(1);
+	  }
+	  theCurrentTemp.head.title[79] = '\0';
+	  LOGINFO("SiPixelTemplate") << "Loading Pixel Template File - " << theCurrentTemp.head.title << ENDL;
+	  	  
+	  // next, the header information     
+	  
+	  db >> theCurrentTemp.head.ID  >> theCurrentTemp.head.templ_version >> theCurrentTemp.head.Bfield >> theCurrentTemp.head.NTy >> theCurrentTemp.head.NTyx >> theCurrentTemp.head.NTxx
+	     >> theCurrentTemp.head.Dtype >> theCurrentTemp.head.Vbias >> theCurrentTemp.head.temperature >> theCurrentTemp.head.fluence >> theCurrentTemp.head.qscale
+	     >> theCurrentTemp.head.s50 >> theCurrentTemp.head.lorywidth >> theCurrentTemp.head.lorxwidth >> theCurrentTemp.head.ysize >> theCurrentTemp.head.xsize >> theCurrentTemp.head.zsize;
+	  
+	  if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 0A, no template load" << ENDL; return false;}
+	  
+	  LOGWARNING("SiPixelTemplate") << "Loading Pixel Template File - " << theCurrentTemp.head.title 
+					<<" code version = "<<code_version
+					<<" object version "<<theCurrentTemp.head.templ_version
+					<< ENDL;
+	  
+	  if(theCurrentTemp.head.templ_version > 17) {
+	    db >> theCurrentTemp.head.ss50 >> theCurrentTemp.head.lorybias >> theCurrentTemp.head.lorxbias >> theCurrentTemp.head.fbin[0] >> theCurrentTemp.head.fbin[1] >> theCurrentTemp.head.fbin[2];
+	    
+	    if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 0B, no template load" 
+						       << ENDL; return false;}
+	  } else {
+	    theCurrentTemp.head.ss50 = theCurrentTemp.head.s50;
+	    theCurrentTemp.head.lorybias = theCurrentTemp.head.lorywidth/2.f;
+	    theCurrentTemp.head.lorxbias = theCurrentTemp.head.lorxwidth/2.f;
+	    theCurrentTemp.head.fbin[0] = 1.50f;
+	    theCurrentTemp.head.fbin[1] = 1.00f;
+	    theCurrentTemp.head.fbin[2] = 0.85f;
+	    //std::cout<<" set fbin  "<< theCurrentTemp.head.fbin[0]<<" "<<theCurrentTemp.head.fbin[1]<<" "
+	    //	     <<theCurrentTemp.head.fbin[2]<<std::endl;
+	  }
+				
+	  LOGINFO("SiPixelTemplate") 
+	    << "Template ID = " << theCurrentTemp.head.ID << ", Template Version " 
+	    << theCurrentTemp.head.templ_version << ", Bfield = " 
+	    << theCurrentTemp.head.Bfield<< ", NTy = " << theCurrentTemp.head.NTy << ", NTyx = " 
+	    << theCurrentTemp.head.NTyx<< ", NTxx = " << theCurrentTemp.head.NTxx << ", Dtype = " 
+	    << theCurrentTemp.head.Dtype<< ", Bias voltage " << theCurrentTemp.head.Vbias << ", temperature "
+	    << theCurrentTemp.head.temperature << ", fluence " << theCurrentTemp.head.fluence 
+	    << ", Q-scaling factor " << theCurrentTemp.head.qscale
+	    << ", 1/2 multi dcol threshold " << theCurrentTemp.head.s50 << ", 1/2 single dcol threshold " 
+	    << theCurrentTemp.head.ss50<< ", y Lorentz Width " << theCurrentTemp.head.lorywidth 
+	    << ", y Lorentz Bias " << theCurrentTemp.head.lorybias
+	    << ", x Lorentz width " << theCurrentTemp.head.lorxwidth 
+	    << ", x Lorentz Bias " << theCurrentTemp.head.lorxbias
+	    << ", Q/Q_avg fractions for Qbin defs " << theCurrentTemp.head.fbin[0] 
+	    << ", " << theCurrentTemp.head.fbin[1]
+	    << ", " << theCurrentTemp.head.fbin[2]
+	    << ", pixel x-size " << theCurrentTemp.head.xsize 
+	    << ", y-size " << theCurrentTemp.head.ysize << ", zsize " << theCurrentTemp.head.zsize << ENDL;
 		
-		SiPixelTemplateDBObject::char2float temp;
-		for (i=0; i<20; ++i) {
-			temp.f = db.sVector()[db.index()];
-			theCurrentTemp.head.title[4*i] = temp.c[0];
-			theCurrentTemp.head.title[4*i+1] = temp.c[1];
-			theCurrentTemp.head.title[4*i+2] = temp.c[2];
-			theCurrentTemp.head.title[4*i+3] = temp.c[3];
-			db.incrementIndex(1);
-		}
-		theCurrentTemp.head.title[79] = '\0';
-		LOGINFO("SiPixelTemplate") << "Loading Pixel Template File - " << theCurrentTemp.head.title << ENDL;
-		
-		// next, the header information     
-		
-		db >> theCurrentTemp.head.ID  >> theCurrentTemp.head.templ_version >> theCurrentTemp.head.Bfield >> theCurrentTemp.head.NTy >> theCurrentTemp.head.NTyx >> theCurrentTemp.head.NTxx
-		>> theCurrentTemp.head.Dtype >> theCurrentTemp.head.Vbias >> theCurrentTemp.head.temperature >> theCurrentTemp.head.fluence >> theCurrentTemp.head.qscale
-		>> theCurrentTemp.head.s50 >> theCurrentTemp.head.lorywidth >> theCurrentTemp.head.lorxwidth >> theCurrentTemp.head.ysize >> theCurrentTemp.head.xsize >> theCurrentTemp.head.zsize;
-		
-		if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file, no template load" << ENDL; return false;}
-		
-		LOGINFO("SiPixelTemplate") << "Template ID = " << theCurrentTemp.head.ID << ", Template Version " << theCurrentTemp.head.templ_version << ", Bfield = " << theCurrentTemp.head.Bfield 
-		<< ", NTy = " << theCurrentTemp.head.NTy << ", NTyx = " << theCurrentTemp.head.NTyx<< ", NTxx = " << theCurrentTemp.head.NTxx << ", Dtype = " << theCurrentTemp.head.Dtype
-		<< ", Bias voltage " << theCurrentTemp.head.Vbias << ", temperature "
-		<< theCurrentTemp.head.temperature << ", fluence " << theCurrentTemp.head.fluence << ", Q-scaling factor " << theCurrentTemp.head.qscale
-		<< ", 1/2 threshold " << theCurrentTemp.head.s50 << ", y Lorentz Width " << theCurrentTemp.head.lorywidth << ", x Lorentz width " << theCurrentTemp.head.lorxwidth    
-		<< ", pixel x-size " << theCurrentTemp.head.xsize << ", y-size " << theCurrentTemp.head.ysize << ", zsize " << theCurrentTemp.head.zsize << ENDL;
-		
-		if(theCurrentTemp.head.templ_version < code_version) {LOGERROR("SiPixelTemplate") << "code expects version " << code_version << ", no template load" << ENDL; return false;}
+	  if(theCurrentTemp.head.templ_version < code_version) {
+	    LOGERROR("SiPixelTemplate") << "code expects version "<< code_version << " finds "
+					<< theCurrentTemp.head.templ_version <<", load anyway " << ENDL; 
+	    //return false; // dk
+	  }
 		
 		
 #ifdef SI_PIXEL_TEMPLATE_USE_BOOST 
 		
-// next, layout the 1-d/2-d structures needed to store template
-		
-		theCurrentTemp.enty.resize(boost::extents[theCurrentTemp.head.NTy]);
-		
-		theCurrentTemp.entx.resize(boost::extents[theCurrentTemp.head.NTyx][theCurrentTemp.head.NTxx]);
+	  // next, layout the 1-d/2-d structures needed to store template
+	  theCurrentTemp.enty.resize(boost::extents[theCurrentTemp.head.NTy]);	
+	  theCurrentTemp.entx.resize(boost::extents[theCurrentTemp.head.NTyx][theCurrentTemp.head.NTxx]);
 		
 #endif
 				
-// next, loop over all barrel y-angle entries   
+	  // next, loop over all barrel y-angle entries   
 		
-		for (i=0; i < theCurrentTemp.head.NTy; ++i) {     
+	  for (i=0; i < theCurrentTemp.head.NTy; ++i) {     
+	    
+	    db >> theCurrentTemp.enty[i].runnum >> theCurrentTemp.enty[i].costrk[0] 
+	       >> theCurrentTemp.enty[i].costrk[1] >> theCurrentTemp.enty[i].costrk[2]; 
+	    
+	    if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 1, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
 			
-			db >> theCurrentTemp.enty[i].runnum >> theCurrentTemp.enty[i].costrk[0] 
-			>> theCurrentTemp.enty[i].costrk[1] >> theCurrentTemp.enty[i].costrk[2]; 
-			
-			if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 1, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-			
-// Calculate the alpha, beta, and cot(beta) for this entry 
-			
-			theCurrentTemp.enty[i].alpha = static_cast<float>(atan2((double)theCurrentTemp.enty[i].costrk[2], (double)theCurrentTemp.enty[i].costrk[0]));
-			
-			theCurrentTemp.enty[i].cotalpha = theCurrentTemp.enty[i].costrk[0]/theCurrentTemp.enty[i].costrk[2];
-			
-			theCurrentTemp.enty[i].beta = static_cast<float>(atan2((double)theCurrentTemp.enty[i].costrk[2], (double)theCurrentTemp.enty[i].costrk[1]));
-			
-			theCurrentTemp.enty[i].cotbeta = theCurrentTemp.enty[i].costrk[1]/theCurrentTemp.enty[i].costrk[2];
-			
-			db >> theCurrentTemp.enty[i].qavg >> theCurrentTemp.enty[i].pixmax >> theCurrentTemp.enty[i].symax >> theCurrentTemp.enty[i].dyone
-			>> theCurrentTemp.enty[i].syone >> theCurrentTemp.enty[i].sxmax >> theCurrentTemp.enty[i].dxone >> theCurrentTemp.enty[i].sxone;
-			
-			if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 2, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-			
-			db >> theCurrentTemp.enty[i].dytwo >> theCurrentTemp.enty[i].sytwo >> theCurrentTemp.enty[i].dxtwo 
-			>> theCurrentTemp.enty[i].sxtwo >> theCurrentTemp.enty[i].qmin >> theCurrentTemp.enty[i].clsleny >> theCurrentTemp.enty[i].clslenx;
-			//			     >> theCurrentTemp.enty[i].mpvvav >> theCurrentTemp.enty[i].sigmavav >> theCurrentTemp.enty[i].kappavav;
-			
-			if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 3, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-			
-			for (j=0; j<2; ++j) {
-				
-				db >> theCurrentTemp.enty[i].ypar[j][0] >> theCurrentTemp.enty[i].ypar[j][1] 
-				>> theCurrentTemp.enty[i].ypar[j][2] >> theCurrentTemp.enty[i].ypar[j][3] >> theCurrentTemp.enty[i].ypar[j][4];
-				
-				if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 4, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-				
-			}
-			
-			for (j=0; j<9; ++j) {
-				
-				for (k=0; k<TYSIZE; ++k) {db >> theCurrentTemp.enty[i].ytemp[j][k];}
-				
-				if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 5, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-			}
-			
-			for (j=0; j<2; ++j) {
-				
-				db >> theCurrentTemp.enty[i].xpar[j][0] >> theCurrentTemp.enty[i].xpar[j][1] 
-				>> theCurrentTemp.enty[i].xpar[j][2] >> theCurrentTemp.enty[i].xpar[j][3] >> theCurrentTemp.enty[i].xpar[j][4];
-				
-				if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 6, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-				
-			}
-			
-			qavg_avg = 0.f;
-			for (j=0; j<9; ++j) {
-				
-				for (k=0; k<TXSIZE; ++k) {db >> theCurrentTemp.enty[i].xtemp[j][k]; qavg_avg += theCurrentTemp.enty[i].xtemp[j][k];} 
-				
-				if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 7, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-			}
-			theCurrentTemp.enty[i].qavg_avg = qavg_avg/9.;
-			
-			for (j=0; j<4; ++j) {
-				
-				db >> theCurrentTemp.enty[i].yavg[j] >> theCurrentTemp.enty[i].yrms[j] >> theCurrentTemp.enty[i].ygx0[j] >> theCurrentTemp.enty[i].ygsig[j];
-				
-				if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 8, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-			}
-			
-			for (j=0; j<4; ++j) {
-				
-				db >> theCurrentTemp.enty[i].yflpar[j][0] >> theCurrentTemp.enty[i].yflpar[j][1] >> theCurrentTemp.enty[i].yflpar[j][2] 
-				>> theCurrentTemp.enty[i].yflpar[j][3] >> theCurrentTemp.enty[i].yflpar[j][4] >> theCurrentTemp.enty[i].yflpar[j][5];
-				
-				if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 9, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-			}
-			
-			for (j=0; j<4; ++j) {
-				
-				db >> theCurrentTemp.enty[i].xavg[j] >> theCurrentTemp.enty[i].xrms[j] >> theCurrentTemp.enty[i].xgx0[j] >> theCurrentTemp.enty[i].xgsig[j];
-				
-				if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 10, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-			}
-			
-			for (j=0; j<4; ++j) {
-				
-				db >> theCurrentTemp.enty[i].xflpar[j][0] >> theCurrentTemp.enty[i].xflpar[j][1] >> theCurrentTemp.enty[i].xflpar[j][2] 
-				>> theCurrentTemp.enty[i].xflpar[j][3] >> theCurrentTemp.enty[i].xflpar[j][4] >> theCurrentTemp.enty[i].xflpar[j][5];
-				
-				if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 11, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-			}
-			
-			for (j=0; j<4; ++j) {
-				
-				db >> theCurrentTemp.enty[i].chi2yavg[j] >> theCurrentTemp.enty[i].chi2ymin[j] >> theCurrentTemp.enty[i].chi2xavg[j] >> theCurrentTemp.enty[i].chi2xmin[j];
-				
-				if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 12, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-			}
-			
-			for (j=0; j<4; ++j) {
-				
-				db >> theCurrentTemp.enty[i].yavgc2m[j] >> theCurrentTemp.enty[i].yrmsc2m[j] >> theCurrentTemp.enty[i].chi2yavgc2m[j] >> theCurrentTemp.enty[i].chi2yminc2m[j];
-				
-				if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 13, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-			}
-			
-			for (j=0; j<4; ++j) {
-				
-				db >> theCurrentTemp.enty[i].xavgc2m[j] >> theCurrentTemp.enty[i].xrmsc2m[j] >> theCurrentTemp.enty[i].chi2xavgc2m[j] >> theCurrentTemp.enty[i].chi2xminc2m[j];
-				
-				if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 14, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-			} 
-			
-			for (j=0; j<4; ++j) {
-				
-				db >> theCurrentTemp.enty[i].yavggen[j] >> theCurrentTemp.enty[i].yrmsgen[j] >> theCurrentTemp.enty[i].ygx0gen[j] >> theCurrentTemp.enty[i].ygsiggen[j];
-				
-				if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 14a, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-			}
-			
-			for (j=0; j<4; ++j) {
-				
-				db >> theCurrentTemp.enty[i].xavggen[j] >> theCurrentTemp.enty[i].xrmsgen[j] >> theCurrentTemp.enty[i].xgx0gen[j] >> theCurrentTemp.enty[i].xgsiggen[j];
-				
-				if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 14b, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-			} 
-			
-			
-			db >> theCurrentTemp.enty[i].chi2yavgone >> theCurrentTemp.enty[i].chi2yminone >> theCurrentTemp.enty[i].chi2xavgone >> theCurrentTemp.enty[i].chi2xminone >> theCurrentTemp.enty[i].qmin2
-			>> theCurrentTemp.enty[i].mpvvav >> theCurrentTemp.enty[i].sigmavav >> theCurrentTemp.enty[i].kappavav >> theCurrentTemp.enty[i].qavg_spare >> theCurrentTemp.enty[i].spare[0];
-			
-			if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 15, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-			
-			db >> theCurrentTemp.enty[i].mpvvav2 >> theCurrentTemp.enty[i].sigmavav2 >> theCurrentTemp.enty[i].kappavav2 >> theCurrentTemp.enty[i].qbfrac[0] >> theCurrentTemp.enty[i].qbfrac[1]
-			>> theCurrentTemp.enty[i].qbfrac[2] >> theCurrentTemp.enty[i].fracyone >> theCurrentTemp.enty[i].fracxone >> theCurrentTemp.enty[i].fracytwo >> theCurrentTemp.enty[i].fracxtwo;
-			//			theCurrentTemp.enty[i].qbfrac[3] = 1. - theCurrentTemp.enty[i].qbfrac[0] - theCurrentTemp.enty[i].qbfrac[1] - theCurrentTemp.enty[i].qbfrac[2];
-			
-			if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 16, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-			
-		}
+	    // Calculate the alpha, beta, and cot(beta) for this entry 
+	    
+	    theCurrentTemp.enty[i].alpha = static_cast<float>(atan2((double)theCurrentTemp.enty[i].costrk[2], (double)theCurrentTemp.enty[i].costrk[0]));
+	    
+	    theCurrentTemp.enty[i].cotalpha = theCurrentTemp.enty[i].costrk[0]/theCurrentTemp.enty[i].costrk[2];
+	    
+	    theCurrentTemp.enty[i].beta = static_cast<float>(atan2((double)theCurrentTemp.enty[i].costrk[2], (double)theCurrentTemp.enty[i].costrk[1]));
+	    
+	    theCurrentTemp.enty[i].cotbeta = theCurrentTemp.enty[i].costrk[1]/theCurrentTemp.enty[i].costrk[2];
+	    
+	    db >> theCurrentTemp.enty[i].qavg >> theCurrentTemp.enty[i].pixmax >> theCurrentTemp.enty[i].symax >> theCurrentTemp.enty[i].dyone
+	       >> theCurrentTemp.enty[i].syone >> theCurrentTemp.enty[i].sxmax >> theCurrentTemp.enty[i].dxone >> theCurrentTemp.enty[i].sxone;
+	    
+	    if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 2, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
+	    
+	    db >> theCurrentTemp.enty[i].dytwo >> theCurrentTemp.enty[i].sytwo >> theCurrentTemp.enty[i].dxtwo 
+	       >> theCurrentTemp.enty[i].sxtwo >> theCurrentTemp.enty[i].qmin >> theCurrentTemp.enty[i].clsleny >> theCurrentTemp.enty[i].clslenx;
+	    //			     >> theCurrentTemp.enty[i].mpvvav >> theCurrentTemp.enty[i].sigmavav >> theCurrentTemp.enty[i].kappavav;
+	    
+	    if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 3, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
+	    
+	    if(theCurrentTemp.enty[i].qmin <= 0.) {LOGERROR("SiPixelTemplate") << "Error in template ID " << theCurrentTemp.head.ID << " qmin = " << theCurrentTemp.enty[i].qmin << ", run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
+	    
+	    for (j=0; j<2; ++j) {
+	      
+	      db >> theCurrentTemp.enty[i].ypar[j][0] >> theCurrentTemp.enty[i].ypar[j][1] 
+		 >> theCurrentTemp.enty[i].ypar[j][2] >> theCurrentTemp.enty[i].ypar[j][3] >> theCurrentTemp.enty[i].ypar[j][4];
+	      
+	      if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 4, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
+	      
+	    }
+	    
+	    for (j=0; j<9; ++j) {
+	      
+	      for (k=0; k<TYSIZE; ++k) {db >> theCurrentTemp.enty[i].ytemp[j][k];}
+	      
+	      if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 5, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
+	    }
+	    
+	    for (j=0; j<2; ++j) {
+	      
+	      db >> theCurrentTemp.enty[i].xpar[j][0] >> theCurrentTemp.enty[i].xpar[j][1] 
+		 >> theCurrentTemp.enty[i].xpar[j][2] >> theCurrentTemp.enty[i].xpar[j][3] >> theCurrentTemp.enty[i].xpar[j][4];
+	      
+	      if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 6, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
+	      
+	    }
+	    
+	    qavg_avg = 0.f;
+	    for (j=0; j<9; ++j) {
+	      
+	      for (k=0; k<TXSIZE; ++k) {db >> theCurrentTemp.enty[i].xtemp[j][k]; qavg_avg += theCurrentTemp.enty[i].xtemp[j][k];} 
+	      
+	      if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 7, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
+	    }
+	    theCurrentTemp.enty[i].qavg_avg = qavg_avg/9.;
+	    
+	    for (j=0; j<4; ++j) {
+	      
+	      db >> theCurrentTemp.enty[i].yavg[j] >> theCurrentTemp.enty[i].yrms[j] >> theCurrentTemp.enty[i].ygx0[j] >> theCurrentTemp.enty[i].ygsig[j];
+	      
+	      if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 8, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
+	    }
+	    
+	    for (j=0; j<4; ++j) {
+	      
+	      db >> theCurrentTemp.enty[i].yflpar[j][0] >> theCurrentTemp.enty[i].yflpar[j][1] >> theCurrentTemp.enty[i].yflpar[j][2] 
+		 >> theCurrentTemp.enty[i].yflpar[j][3] >> theCurrentTemp.enty[i].yflpar[j][4] >> theCurrentTemp.enty[i].yflpar[j][5];
+	      
+	      if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 9, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
+	    }
+	    
+	    for (j=0; j<4; ++j) {
+	      
+	      db >> theCurrentTemp.enty[i].xavg[j] >> theCurrentTemp.enty[i].xrms[j] >> theCurrentTemp.enty[i].xgx0[j] >> theCurrentTemp.enty[i].xgsig[j];
+	      
+	      if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 10, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
+	    }
+	    
+	    for (j=0; j<4; ++j) {
+	      
+	      db >> theCurrentTemp.enty[i].xflpar[j][0] >> theCurrentTemp.enty[i].xflpar[j][1] >> theCurrentTemp.enty[i].xflpar[j][2] 
+		 >> theCurrentTemp.enty[i].xflpar[j][3] >> theCurrentTemp.enty[i].xflpar[j][4] >> theCurrentTemp.enty[i].xflpar[j][5];
+	      
+	      if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 11, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
+	    }
+	    
+	    for (j=0; j<4; ++j) {
+	      
+	      db >> theCurrentTemp.enty[i].chi2yavg[j] >> theCurrentTemp.enty[i].chi2ymin[j] >> theCurrentTemp.enty[i].chi2xavg[j] >> theCurrentTemp.enty[i].chi2xmin[j];
+	      
+	      if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 12, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
+	    }
+	    
+	    for (j=0; j<4; ++j) {
+	      
+	      db >> theCurrentTemp.enty[i].yavgc2m[j] >> theCurrentTemp.enty[i].yrmsc2m[j] >> theCurrentTemp.enty[i].chi2yavgc2m[j] >> theCurrentTemp.enty[i].chi2yminc2m[j];
+	      
+	      if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 13, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
+	    }
+	    
+	    for (j=0; j<4; ++j) {
+	      
+	      db >> theCurrentTemp.enty[i].xavgc2m[j] >> theCurrentTemp.enty[i].xrmsc2m[j] >> theCurrentTemp.enty[i].chi2xavgc2m[j] >> theCurrentTemp.enty[i].chi2xminc2m[j];
+	      
+	      if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 14, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
+	    } 
+	    
+	    for (j=0; j<4; ++j) {
+	      
+	      db >> theCurrentTemp.enty[i].yavggen[j] >> theCurrentTemp.enty[i].yrmsgen[j] >> theCurrentTemp.enty[i].ygx0gen[j] >> theCurrentTemp.enty[i].ygsiggen[j];
+	      
+	      if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 14a, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
+	    }
+	    
+	    for (j=0; j<4; ++j) {
+	      
+	      db >> theCurrentTemp.enty[i].xavggen[j] >> theCurrentTemp.enty[i].xrmsgen[j] >> theCurrentTemp.enty[i].xgx0gen[j] >> theCurrentTemp.enty[i].xgsiggen[j];
+	      
+	      if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 14b, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
+	    } 
+	    
+	    
+	    db >> theCurrentTemp.enty[i].chi2yavgone >> theCurrentTemp.enty[i].chi2yminone >> theCurrentTemp.enty[i].chi2xavgone >> theCurrentTemp.enty[i].chi2xminone >> theCurrentTemp.enty[i].qmin2
+	       >> theCurrentTemp.enty[i].mpvvav >> theCurrentTemp.enty[i].sigmavav >> theCurrentTemp.enty[i].kappavav >> theCurrentTemp.enty[i].r_qMeas_qTrue >> theCurrentTemp.enty[i].spare[0];
+	    
+	    if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 15, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
+	    
+	    db >> theCurrentTemp.enty[i].mpvvav2 >> theCurrentTemp.enty[i].sigmavav2 >> theCurrentTemp.enty[i].kappavav2 >> theCurrentTemp.enty[i].qbfrac[0] >> theCurrentTemp.enty[i].qbfrac[1]
+	       >> theCurrentTemp.enty[i].qbfrac[2] >> theCurrentTemp.enty[i].fracyone >> theCurrentTemp.enty[i].fracxone >> theCurrentTemp.enty[i].fracytwo >> theCurrentTemp.enty[i].fracxtwo;
+	    //			theCurrentTemp.enty[i].qbfrac[3] = 1. - theCurrentTemp.enty[i].qbfrac[0] - theCurrentTemp.enty[i].qbfrac[1] - theCurrentTemp.enty[i].qbfrac[2];
+	    
+	    if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 16, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
+	    
+	  }
 		
-		// next, loop over all barrel x-angle entries   
+	  // next, loop over all barrel x-angle entries   
 		
 		for (k=0; k < theCurrentTemp.head.NTyx; ++k) { 
 			
@@ -755,6 +823,8 @@ bool SiPixelTemplate::pushfile(const SiPixelTemplateDBObject& dbobject, std::vec
 					
 					if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 21, no template load, run # " << theCurrentTemp.entx[k][i].runnum << ENDL; return false;}
 				}
+
+
 				
 				for (j=0; j<2; ++j) {
 					
@@ -841,7 +911,7 @@ bool SiPixelTemplate::pushfile(const SiPixelTemplateDBObject& dbobject, std::vec
 				
 				
 				db >> theCurrentTemp.entx[k][i].chi2yavgone >> theCurrentTemp.entx[k][i].chi2yminone >> theCurrentTemp.entx[k][i].chi2xavgone >> theCurrentTemp.entx[k][i].chi2xminone >> theCurrentTemp.entx[k][i].qmin2
-				>> theCurrentTemp.entx[k][i].mpvvav >> theCurrentTemp.entx[k][i].sigmavav >> theCurrentTemp.entx[k][i].kappavav >> theCurrentTemp.entx[k][i].qavg_spare >> theCurrentTemp.entx[k][i].spare[0];
+				>> theCurrentTemp.entx[k][i].mpvvav >> theCurrentTemp.entx[k][i].sigmavav >> theCurrentTemp.entx[k][i].kappavav >> theCurrentTemp.entx[k][i].r_qMeas_qTrue >> theCurrentTemp.entx[k][i].spare[0];
 				
 				if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 31, no template load, run # " << theCurrentTemp.entx[k][i].runnum << ENDL; return false;}
 				
@@ -909,50 +979,56 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
     // Interpolate for a new set of track angles 
     
     // Local variables 
-    int i, j;
-	int ilow, ihigh, iylow, iyhigh, Ny, Nxx, Nyx, imidy, imaxx;
-	float yratio, yxratio, xxratio, sxmax, qcorrect, qxtempcor, symax, chi2xavgone, chi2xminone, cotb, cotalpha0, cotbeta0;
-	bool flip_y;
-//	std::vector <float> xrms(4), xgsig(4), xrmsc2m(4);
-	float chi2xavg[4], chi2xmin[4], chi2xavgc2m[4], chi2xminc2m[4];
+  int i, j;
+  int ilow, ihigh, iylow, iyhigh, Ny, Nxx, Nyx, imidy, imaxx;
+  float yratio, yxratio, xxratio, sxmax, qcorrect, qxtempcor, symax, chi2xavgone, chi2xminone, cotb, cotalpha0, cotbeta0;
+  bool flip_y;
+  //	std::vector <float> xrms(4), xgsig(4), xrmsc2m(4);
+  float chi2xavg[4], chi2xmin[4], chi2xavgc2m[4], chi2xminc2m[4];
 
-
-// Check to see if interpolation is valid     
-
-if(id != id_current_ || cotalpha != cota_current_ || cotbeta != cotb_current_) {
-
-	cota_current_ = cotalpha; cotb_current_ = cotbeta; success_ = true;
+  
+  // Check to see if interpolation is valid     
+  if(id != id_current_ || cotalpha != cota_current_ || cotbeta != cotb_current_) {
+    
+    cota_current_ = cotalpha; cotb_current_ = cotbeta; success_ = true;
+    
+    if(id != id_current_) {
+      
+      // Find the index corresponding to id
+      
+      index_id_ = -1;
+      for(i=0; i<(int)thePixelTemp_.size(); ++i) {
 	
-	if(id != id_current_) {
+	//std::cout<<i<<" "<<id<<" "<<thePixelTemp_[i].head.ID<<std::endl;
 
-// Find the index corresponding to id
-
-       index_id_ = -1;
-       for(i=0; i<(int)thePixelTemp_.size(); ++i) {
-	
-	      if(id == thePixelTemp_[i].head.ID) {
-	   
-	         index_id_ = i;
-		      id_current_ = id;
-				
-// Copy the charge scaling factor to the private variable     
-				
-				qscale_ = thePixelTemp_[index_id_].head.qscale;
-				
-// Copy the pseudopixel signal size to the private variable     
-				
-				s50_ = thePixelTemp_[index_id_].head.s50;
-			
-// Pixel sizes to the private variables     
-				
-				xsize_ = thePixelTemp_[index_id_].head.xsize;
-				ysize_ = thePixelTemp_[index_id_].head.ysize;
-				zsize_ = thePixelTemp_[index_id_].head.zsize;
-				
-				break;
-          }
-	    }
-     }
+	if(id == thePixelTemp_[i].head.ID) {
+	  
+	  index_id_ = i;
+	  id_current_ = id;
+	  
+	  // Copy the charge scaling factor to the private variable     
+	  
+	  qscale_ = thePixelTemp_[index_id_].head.qscale;
+	  
+	  // Copy the pseudopixel signal size to the private variable     
+	  
+	  s50_ = thePixelTemp_[index_id_].head.s50;
+          
+	  // Copy Qbinning info to private variables
+	  
+	  for(j=0; j<3; ++j) {fbin_[j] = thePixelTemp_[index_id_].head.fbin[j];}
+	  //std::cout<<" set fbin  "<< fbin_[0]<<" "<<fbin_[1]<<" "<<fbin_[2]<<std::endl;
+	  
+	  // Pixel sizes to the private variables     
+	  
+	  xsize_ = thePixelTemp_[index_id_].head.xsize;
+	  ysize_ = thePixelTemp_[index_id_].head.ysize;
+	  zsize_ = thePixelTemp_[index_id_].head.zsize;
+	  
+	  break;
+	}
+      }
+    }
 	 
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
     if(index_id_ < 0 || index_id_ >= (int)thePixelTemp_.size()) {
@@ -1217,7 +1293,12 @@ if(id != id_current_ || cotalpha != cota_current_ || cotbeta != cotb_current_) {
 
 	pixmax_=(1.f - yxratio)*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iylow][ilow].pixmax + xxratio*thePixelTemp_[index_id_].entx[iylow][ihigh].pixmax)
 			+yxratio*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iyhigh][ilow].pixmax + xxratio*thePixelTemp_[index_id_].entx[iyhigh][ihigh].pixmax);
-			  
+	
+   
+   r_qMeas_qTrue_=(1.f - yxratio)*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iylow][ilow].r_qMeas_qTrue + xxratio*thePixelTemp_[index_id_].entx[iylow][ihigh].r_qMeas_qTrue)
+   +yxratio*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iyhigh][ilow].r_qMeas_qTrue + xxratio*thePixelTemp_[index_id_].entx[iyhigh][ihigh].r_qMeas_qTrue);
+			
+		  
 	for(i=0; i<4; ++i) {
 		xavg_[i]=(1.f - yxratio)*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iylow][ilow].xavg[i] + xxratio*thePixelTemp_[index_id_].entx[iylow][ihigh].xavg[i])
 				+yxratio*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iyhigh][ilow].xavg[i] + xxratio*thePixelTemp_[index_id_].entx[iyhigh][ihigh].xavg[i]);
@@ -1304,8 +1385,11 @@ if(id != id_current_ || cotalpha != cota_current_ || cotbeta != cotb_current_) {
 	}
 	
 	lorywidth_ = thePixelTemp_[index_id_].head.lorywidth;
-	if(locBz > 0.f) {lorywidth_ = -lorywidth_;}
 	lorxwidth_ = thePixelTemp_[index_id_].head.lorxwidth;
+   lorybias_ = thePixelTemp_[index_id_].head.lorybias;
+   lorxbias_ = thePixelTemp_[index_id_].head.lorxbias;
+   if(locBz > 0.f) {lorywidth_ = -lorywidth_; lorybias_ = -lorybias_;}
+	
 	
   }
 	
@@ -1328,8 +1412,8 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta)
     
     // Local variables 
     float locBz;
-	locBz = -1.f;
-	if(cotbeta < 0.f) {locBz = -locBz;}
+    locBz = -1.f;
+    if(cotbeta < 0.f) {locBz = -locBz;}
     return SiPixelTemplate::interpolate(id, cotalpha, cotbeta, locBz);
 }
 
@@ -2075,7 +2159,7 @@ void SiPixelTemplate::ytemp3d(int i, int j, std::vector<float>& ytemplate)
 	
 // Calculate the size of the shift in pixels needed to span the entire cluster
 
-    float diff = fabsf(nxpix - clslenx_)/2. + 1.f;
+    float diff = fabsf(nxpix - clslenx_)/2.f + 1.f;
 	int nshift = (int)diff;
 	if((diff - nshift) > 0.5f) {++nshift;}
 
@@ -2177,9 +2261,9 @@ void SiPixelTemplate::xtemp3d(int i, int j, std::vector<float>& xtemplate)
 //! \param lorywidth - (output) the estimated y Lorentz width
 //! \param lorxwidth - (output) the estimated x Lorentz width
 // ************************************************************************************************************ 
-int SiPixelTemplate::qbin(int id, float cotalpha, float cotbeta, float locBz, float qclus, float& pixmx, float& sigmay, float& deltay, float& sigmax, float& deltax, 
-                          float& sy1, float& dy1, float& sy2, float& dy2, float& sx1, float& dx1, float& sx2, float& dx2) // float& lorywidth, float& lorxwidth)
-		 
+int SiPixelTemplate::qbin(int id, float cotalpha, float cotbeta, float locBz, float qclus, float& pixmx, 
+    float& sigmay, float& deltay, float& sigmax, float& deltax,float& sy1, float& dy1, float& sy2, 
+    float& dy2, float& sx1, float& dx1, float& sx2, float& dx2) // float& lorywidth, float& lorxwidth)		 
 {
     // Interpolate for a new set of track angles 
     
@@ -2305,17 +2389,21 @@ int SiPixelTemplate::qbin(int id, float cotalpha, float cotbeta, float locBz, fl
     
     auto qtotal = qscale*qclus;
     
-    // uncertainty and final corrections depend upon total charge bin 	   
-    
+    // uncertainty and final corrections depend upon total charge bin 	       
     auto fq = qtotal/qavg;
     int  binq;
-    if(fq > 1.5f) {
+    // since fbin is undefined I define it here d.k. 6/14
+    fbin_[0]=1.5; fbin_[1]=1.0; fbin_[2]=0.85; 
+
+    if(fq > fbin_[0]) {
       binq=0;
+      //std::cout<<" fq "<<fq<<" "<<qtotal<<" "<<qavg<<" "<<qclus<<" "<<qscale<<" "
+      //       <<fbin_[0]<<" "<<fbin_[1]<<" "<<fbin_[2]<<std::endl;
     } else {
-      if(fq > 1.0f) {
+      if(fq > fbin_[1]) {
 	binq=1;
       } else {
-	if(fq > 0.85f) {
+	if(fq > fbin_[2]) {
 	  binq=2;
 	} else {
 	  binq=3;

--- a/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplate.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplate.cc
@@ -111,6 +111,10 @@ using namespace edm;
 #define ENDL std::endl
 #endif
 
+namespace {
+  const float fbin0=1.50f, fbin1=1.00f, fbin2=0.85f;
+}
+
 //**************************************************************** 
 //! This routine initializes the global template structures from 
 //! an external file template_summary_zpNNNN where NNNN are four  
@@ -187,9 +191,9 @@ bool SiPixelTemplate::pushfile(int filenum, std::vector< SiPixelTemplateStore > 
 	    theCurrentTemp.head.ss50 = theCurrentTemp.head.s50;
 	    theCurrentTemp.head.lorybias = theCurrentTemp.head.lorywidth/2.f;
 	    theCurrentTemp.head.lorxbias = theCurrentTemp.head.lorxwidth/2.f;
-	    theCurrentTemp.head.fbin[0] = 1.50f;
-	    theCurrentTemp.head.fbin[1] = 1.00f;
-	    theCurrentTemp.head.fbin[2] = 0.85f;
+	    theCurrentTemp.head.fbin[0] = fbin0;
+	    theCurrentTemp.head.fbin[1] = fbin1;
+	    theCurrentTemp.head.fbin[2] = fbin2;
 	  }
 		
 	  LOGINFO("SiPixelTemplate") << "Template ID = " << theCurrentTemp.head.ID << ", Template Version " << theCurrentTemp.head.templ_version << ", Bfield = " << theCurrentTemp.head.Bfield 
@@ -591,9 +595,9 @@ bool SiPixelTemplate::pushfile(const SiPixelTemplateDBObject& dbobject, std::vec
 	    theCurrentTemp.head.ss50 = theCurrentTemp.head.s50;
 	    theCurrentTemp.head.lorybias = theCurrentTemp.head.lorywidth/2.f;
 	    theCurrentTemp.head.lorxbias = theCurrentTemp.head.lorxwidth/2.f;
-	    theCurrentTemp.head.fbin[0] = 1.50f;
-	    theCurrentTemp.head.fbin[1] = 1.00f;
-	    theCurrentTemp.head.fbin[2] = 0.85f;
+	    theCurrentTemp.head.fbin[0] = fbin0;
+	    theCurrentTemp.head.fbin[1] = fbin1;
+	    theCurrentTemp.head.fbin[2] = fbin2;
 	    //std::cout<<" set fbin  "<< theCurrentTemp.head.fbin[0]<<" "<<theCurrentTemp.head.fbin[1]<<" "
 	    //	     <<theCurrentTemp.head.fbin[2]<<std::endl;
 	  }
@@ -2393,7 +2397,7 @@ int SiPixelTemplate::qbin(int id, float cotalpha, float cotbeta, float locBz, fl
     auto fq = qtotal/qavg;
     int  binq;
     // since fbin is undefined I define it here d.k. 6/14
-    fbin_[0]=1.5; fbin_[1]=1.0; fbin_[2]=0.85; 
+    fbin_[0]=fbin0; fbin_[1]=fbin1; fbin_[2]=fbin2; 
 
     if(fq > fbin_[0]) {
       binq=0;

--- a/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplate.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplate.cc
@@ -618,7 +618,7 @@ bool SiPixelTemplate::pushfile(const SiPixelTemplateDBObject& dbobject, std::vec
 	    << ", y-size " << theCurrentTemp.head.ysize << ", zsize " << theCurrentTemp.head.zsize << ENDL;
 		
 	  if(theCurrentTemp.head.templ_version < code_version) {
-	    LOGWARNING("SiPixelTemplate") << "code expects version "<< code_version << " finds "
+	    LOGINFO("SiPixelTemplate") << "code expects version "<< code_version << " finds "
 					<< theCurrentTemp.head.templ_version <<", load anyway " << ENDL; 
 	    //return false; // dk
 	  }

--- a/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplate.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplate.cc
@@ -577,7 +577,7 @@ bool SiPixelTemplate::pushfile(const SiPixelTemplateDBObject& dbobject, std::vec
 	  
 	  if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 0A, no template load" << ENDL; return false;}
 	  
-	  LOGWARNING("SiPixelTemplate") << "Loading Pixel Template File - " << theCurrentTemp.head.title 
+	  LOGINFO("SiPixelTemplate") << "Loading Pixel Template File - " << theCurrentTemp.head.title 
 					<<" code version = "<<code_version
 					<<" object version "<<theCurrentTemp.head.templ_version
 					<< ENDL;
@@ -618,7 +618,7 @@ bool SiPixelTemplate::pushfile(const SiPixelTemplateDBObject& dbobject, std::vec
 	    << ", y-size " << theCurrentTemp.head.ysize << ", zsize " << theCurrentTemp.head.zsize << ENDL;
 		
 	  if(theCurrentTemp.head.templ_version < code_version) {
-	    LOGERROR("SiPixelTemplate") << "code expects version "<< code_version << " finds "
+	    LOGWARNING("SiPixelTemplate") << "code expects version "<< code_version << " finds "
 					<< theCurrentTemp.head.templ_version <<", load anyway " << ENDL; 
 	    //return false; // dk
 	  }

--- a/RecoLocalTracker/SiPixelRecHits/test/ReadPixelRecHit.cc
+++ b/RecoLocalTracker/SiPixelRecHits/test/ReadPixelRecHit.cc
@@ -48,6 +48,8 @@ ReadPixelRecHit::ReadPixelRecHit(edm::ParameterSet const& conf) :
   conf_(conf),
   src_( conf.getParameter<edm::InputTag>( "src" ) ) { 
     print = conf.getUntrackedParameter<bool>("Verbosity",false);
+
+    cout<<" Verbosity "<<print<<endl;
 }
 //----------------------------------------------------------------------
 // Virtual destructor needed.
@@ -119,6 +121,37 @@ void ReadPixelRecHit::beginJob() {
   hsize1 = fs->make<TH1F>( "hsize1", "layer 1 clu size",100,-0.5,99.5);
   hsize2 = fs->make<TH1F>( "hsize2", "layer 2 clu size",100,-0.5,99.5);
   hsize3 = fs->make<TH1F>( "hsize3", "layer 3 clu size",100,-0.5,99.5);
+
+  hAlignErrorX1 = fs->make<TH1F>( "hAlignErrorX1", "Align error Layer 1 X", 100,0.0,100.);
+  hAlignErrorY1 = fs->make<TH1F>( "hAlignErrorY1", "Align error Layer 1 Y", 100,0.0,100.);
+  hAlignErrorX2 = fs->make<TH1F>( "hAlignErrorX2", "Align error Layer 2 X", 100,0.0,100.);
+  hAlignErrorY2 = fs->make<TH1F>( "hAlignErrorY2", "Align error Layer 2 Y", 100,0.0,100.);
+  hAlignErrorX3 = fs->make<TH1F>( "hAlignErrorX3", "Align error Layer 3 X", 100,0.0,100.);
+  hAlignErrorY3 = fs->make<TH1F>( "hAlignErrorY3", "Align error Layer 3 Y", 100,0.0,100.);
+  hAlignErrorX4 = fs->make<TH1F>( "hAlignErrorX4", "Align error Disk -1 X", 100,0.0,100.);
+  hAlignErrorY4 = fs->make<TH1F>( "hAlignErrorY4", "Align error Disk -1 Y", 100,0.0,100.);
+  hAlignErrorX5 = fs->make<TH1F>( "hAlignErrorX5", "Align error Disk -2 X", 100,0.0,100.);
+  hAlignErrorY5 = fs->make<TH1F>( "hAlignErrorY5", "Align error Disk -2 Y", 100,0.0,100.);
+  hAlignErrorX6 = fs->make<TH1F>( "hAlignErrorX6", "Align error Disk +1 X", 100,0.0,100.);
+  hAlignErrorY6 = fs->make<TH1F>( "hAlignErrorY6", "Align error Disk +1 Y", 100,0.0,100.);
+  hAlignErrorX7 = fs->make<TH1F>( "hAlignErrorX7", "Align error Disk +2 X", 100,0.0,100.);
+  hAlignErrorY7 = fs->make<TH1F>( "hAlignErrorY7", "Align error Disk +2 Y", 100,0.0,100.);
+
+  hErrorX1 = fs->make<TH1F>( "hErrorX1", "Error Layer 1 X", 100,0.0,100.);
+  hErrorY1 = fs->make<TH1F>( "hErrorY1", "Error Layer 1 Y", 100,0.0,100.);
+  hErrorX2 = fs->make<TH1F>( "hErrorX2", "Error Layer 2 X", 100,0.0,100.);
+  hErrorY2 = fs->make<TH1F>( "hErrorY2", "Error Layer 2 Y", 100,0.0,100.);
+  hErrorX3 = fs->make<TH1F>( "hErrorX3", "Error Layer 3 X", 100,0.0,100.);
+  hErrorY3 = fs->make<TH1F>( "hErrorY3", "Error Layer 3 Y", 100,0.0,100.);
+  hErrorX4 = fs->make<TH1F>( "hErrorX4", "Error Disk -1 X", 100,0.0,100.);
+  hErrorY4 = fs->make<TH1F>( "hErrorY4", "Error Disk -1 Y", 100,0.0,100.);
+  hErrorX5 = fs->make<TH1F>( "hErrorX5", "Error Disk -2 X", 100,0.0,100.);
+  hErrorY5 = fs->make<TH1F>( "hErrorY5", "Error Disk -2 Y", 100,0.0,100.);
+  hErrorX6 = fs->make<TH1F>( "hErrorX6", "Error Disk +1 X", 100,0.0,100.);
+  hErrorY6 = fs->make<TH1F>( "hErrorY6", "Error Disk +1 Y", 100,0.0,100.);
+  hErrorX7 = fs->make<TH1F>( "hErrorX7", "Error Disk +2 X", 100,0.0,100.);
+  hErrorY7 = fs->make<TH1F>( "hErrorY7", "Error Disk +2 Y", 100,0.0,100.);
+
   hsizex1 = fs->make<TH1F>( "hsizex1", "lay1 clu size in x",
                       10,-0.5,9.5);
   hsizex2 = fs->make<TH1F>( "hsizex2", "lay2 clu size in x",
@@ -177,6 +210,17 @@ void ReadPixelRecHit::beginJob() {
   hdetsPerLay2F = fs->make<TH1F>( "hdetsPerLay2F", "Full dets per layer l2",
                            257, -0.5, 256.5);
 
+  hErrorXB = fs->make<TProfile>("hErrorXB","bpix x errors per ladder",220,0.,220.,0.0,1000.);
+  hErrorXF = fs->make<TProfile>("hErrorXF","fpix x errors per ladder",100,0.,100.,0.0,1000.);
+  hErrorYB = fs->make<TProfile>("hErrorYB","bpix y errors per ladder",220,0.,220.,0.0,1000.);
+  hErrorYF = fs->make<TProfile>("hErrorYF","fpix y errors per ladder",100,0.,100.,0.0,1000.);
+
+  hAErrorXB = fs->make<TProfile>("hAErrorXB","bpix x errors per ladder",220,0.,220.,0.0,1000.);
+  hAErrorXF = fs->make<TProfile>("hAErrorXF","fpix x errors per ladder",100,0.,100.,0.0,1000.);
+  hAErrorYB = fs->make<TProfile>("hAErrorYB","bpix y errors per ladder",220,0.,220.,0.0,1000.);
+  hAErrorYF = fs->make<TProfile>("hAErrorYF","fpix y errors per ladder",100,0.,100.,0.0,1000.);
+
+
   cout<<" book histos "<<endl;
 
 #endif
@@ -190,8 +234,8 @@ void ReadPixelRecHit::endJob(){
 void ReadPixelRecHit::analyze(const edm::Event& e, 
 			      const edm::EventSetup& es) {
   using namespace edm;
-  //const bool localPrint = false;
-  const bool localPrint = true;
+  const bool localPrint = false;
+  //const bool localPrint = true;
 
   // Get event setup (to get global transformation)
   edm::ESHandle<TrackerGeometry> geom;
@@ -264,7 +308,18 @@ void ReadPixelRecHit::analyze(const edm::Event& e,
     //int cols = theGeomDet->specificTopology().ncolumns(); UNUSED
     //int rows = theGeomDet->specificTopology().nrows();
 
-    unsigned int layer=0, disk=0, ladder=0, zindex=0, blade=0, panel=0;
+    float alignErrorX= 0., alignErrorY=0.;
+    LocalError lape = theGeomDet->localAlignmentError();
+    //cout<<lape.valid()<<endl;
+    if (lape.valid()) {
+      if(lape.xx()>0.) alignErrorX = sqrt(lape.xx())*1E4;
+      //float tmp12= sqrt(lape.xy())*1E4;
+      if(lape.yy()>0.) alignErrorY = sqrt(lape.yy())*1E4;
+      if(print) cout<<" Alignment errors "<<alignErrorX<<" "<<alignErrorY<<endl;
+      //cout<<" Alignment errors "<<alignErrorX<<" "<<alignErrorY<<endl;
+    }
+
+    unsigned int layer=0, disk=0, ladder=0, zindex=0, blade=0, panel=0, side=0;
     if(subid==1) {  // Subdet it, pix barrel=1 
       ++numberOfDetUnits;
       
@@ -277,6 +332,8 @@ void ReadPixelRecHit::analyze(const edm::Event& e,
       ladder=pdetId.ladder();
       // Barrel Z-index=1,8
       zindex=pdetId.module();
+      if(zindex<5) side=1; else side=2;
+
       if(localPrint)
 	cout<<" Layer "<<layer<<" ladder "<<ladder<<" z "<<zindex<<endl;
       //<<pdetId.rawId()<<" "<<pdetId.null()<<detTypeP<<" "<<subidP<<" "<<endl;
@@ -298,7 +355,7 @@ void ReadPixelRecHit::analyze(const edm::Event& e,
       PXFDetId pdetId = PXFDetId(detId.rawId());
       disk=pdetId.disk(); //1,2,3
       blade=pdetId.blade(); //1-24
-      unsigned int side=pdetId.side(); //size=1 for -z, 2 for +z
+      side=pdetId.side(); //size=1 for -z, 2 for +z
       panel=pdetId.panel(); //panel=1,2
       unsigned int module=pdetId.module(); // plaquette
 
@@ -321,24 +378,62 @@ void ReadPixelRecHit::analyze(const edm::Event& e,
     if(layer==1) {
       hladder1id->Fill(float(ladder));
       hz1id->Fill(float(zindex));
+      hAlignErrorX1->Fill(alignErrorX);
+      hAlignErrorY1->Fill(alignErrorY);
+      hAErrorXB->Fill(float(ladder+(110*(side-1))),alignErrorX);
+      hAErrorYB->Fill(float(ladder+(110*(side-1))),alignErrorY);
       ++numberOfDetUnits1;
       numOfRecHitsPerDet1=0; 
+
     } else if(layer==2) {
       hladder2id->Fill(float(ladder));
       hz2id->Fill(float(zindex));
+      hAlignErrorX2->Fill(alignErrorX);
+      hAlignErrorY2->Fill(alignErrorY);
+      hAErrorXB->Fill(float(ladder+25+(110*(side-1))),alignErrorX);
+      hAErrorYB->Fill(float(ladder+25+(110*(side-1))),alignErrorY);
       ++numberOfDetUnits2;
       numOfRecHitsPerDet2=0;
+
     } else if(layer==3) {
       hladder3id->Fill(float(ladder));
       hz3id->Fill(float(zindex));
+      hAlignErrorX3->Fill(alignErrorX);
+      hAlignErrorY3->Fill(alignErrorY);
+      hAErrorXB->Fill(float(ladder+60+(110*(side-1))),alignErrorX);
+      hAErrorYB->Fill(float(ladder+60+(110*(side-1))),alignErrorY);
       ++numberOfDetUnits3;
       numOfRecHitsPerDet3=0;
+
     } else if(disk==1) {
       ++numberOfDetUnits1F;
       numOfRecHitsPerDet1F=0;
+      if(side==1) {
+	hAlignErrorX4->Fill(alignErrorX);
+	hAlignErrorY4->Fill(alignErrorY);
+	hAErrorXF->Fill(float(blade+25),alignErrorX);
+	hAErrorYF->Fill(float(blade+25),alignErrorY);
+      } else {
+	hAlignErrorX6->Fill(alignErrorX);
+	hAlignErrorY6->Fill(alignErrorY);
+	hAErrorXF->Fill(float(blade+50),alignErrorX);
+	hAErrorYF->Fill(float(blade+50),alignErrorY);
+      }
+
     } else if(disk==2) {
       ++numberOfDetUnits2F;
       numOfRecHitsPerDet2F=0;
+      if(side==1) {
+	hAlignErrorX5->Fill(alignErrorX);
+	hAlignErrorY5->Fill(alignErrorY);
+	hAErrorXF->Fill(float(blade),alignErrorX);
+	hAErrorYF->Fill(float(blade),alignErrorY);
+      } else {
+	hAlignErrorX7->Fill(alignErrorX);
+	hAlignErrorY7->Fill(alignErrorY);
+	hAErrorXF->Fill(float(blade+75),alignErrorX);
+	hAErrorYF->Fill(float(blade+75),alignErrorY);
+      }
     }
 #endif  
    
@@ -347,18 +442,17 @@ void ReadPixelRecHit::analyze(const edm::Event& e,
     SiPixelRecHitCollection::DetSet::const_iterator rechitRangeIteratorEnd   = detset.end();
     for(;pixeliter!=rechitRangeIteratorEnd;++pixeliter) { //loop on the rechit
 
-      if(print) cout <<" No Position " << endl;
-
       numOfRecHits++;
 
       // RecHit local position is now transient, 
-      // one needs to run tracking to get position 
-      //LocalPoint lp = pixeliter->localPosition();
-      //LocalError le = pixeliter->localPositionError(); UNUSED
-      //float xRecHit = lp.x();
-      //float yRecHit = lp.y();
-      //if(localPrint) cout<<" RecHit: "<<numOfRecHits<<" "<<xRecHit<<" "
-      //		 <<yRecHit<<endl;
+      // one needs to run tracking to get position OR rerun localreco 
+      LocalPoint lp = pixeliter->localPosition();
+      LocalError le = pixeliter->localPositionError();
+      float xRecHit = lp.x();
+      float yRecHit = lp.y();
+      float xerror = sqrt(le.xx())*1E4;
+      float yerror = sqrt(le.yy())*1E4;
+      if(print) cout<<" RecHit: "<<numOfRecHits<<" x/y "<<xRecHit<<" "<<yRecHit<<" errors x/y "<<xerror<<" "<<yerror<<endl;
       
       //MeasurementPoint mp = topol->measurementPosition(xRecHit,yRecHit);
       //GlobalPoint GP = PixGeom->surface().toGlobal(Local3DPoint(lp));
@@ -386,10 +480,12 @@ void ReadPixelRecHit::analyze(const edm::Event& e,
       bool edgeHitY = (topol->isItEdgePixelInY(minPixelCol)) ||
         (topol->isItEdgePixelInY(maxPixelCol));
 
-      if(localPrint) 
+      if(print) 
 	cout<<"Clu: charge "<<ch<<" size "<<size<<" size x/y "<<sizeX<<" "
 	    <<sizeY<<" meas. "<<xClu<<" "<<yClu<<" edge "<<edgeHitX<<" "<<edgeHitY<<endl;
       
+      if(print) cout<<" pixels:"<<endl;
+
       // Get the pixels in the Cluster
       const vector<SiPixelCluster::Pixel>& pixelsVec = clust->pixels();
       //if(localPrint) cout<<" Pixels in this cluster "<<endl;
@@ -402,18 +498,15 @@ void ReadPixelRecHit::analyze(const edm::Event& e,
 
 	// OLD way
 	//int chan = PixelChannelIdentifier::pixelToChannel(int(pixx),int(pixy));
-	//if(RectangularPixelTopology::isItBigPixelInX(int(pixx))) bigInX=true;
-	//if(RectangularPixelTopology::isItBigPixelInY(int(pixy))) bigInY=true; 
-	
-	//bool bigInX = (PixelTopology::isItBigPixelInX(int(pixx)));
-	//bool bigInY = (PixelTopology::isItBigPixelInY(int(pixy)));
+	bool bigInX = topol->isItBigPixelInX(int(pixx));
+	bool bigInY = topol->isItBigPixelInY(int(pixy));
 	
 	bool edgeInX = topol->isItEdgePixelInX(int(pixx));
 	bool edgeInY = topol->isItEdgePixelInY(int(pixy));
 	  
-	if(localPrint)
-	  cout<<i<<" "<<pixx<<" "<<pixy<<" "<<adc<<" "
-	      <<edgeInX<<" "<<edgeInY<<endl;
+	if(print)
+	  cout<<i<<" index "<<pixx<<" "<<pixy<<" adc "<<adc<<" edge "
+	      <<edgeInX<<" "<<edgeInY<<" big "<<bigInX<<" "<<bigInY<<endl;
 	
 
 	//if(print && sizeX==1 && bigInX) 
@@ -439,54 +532,90 @@ void ReadPixelRecHit::analyze(const edm::Event& e,
 #ifdef DO_HISTO
       if(layer==1) {
 	hcharge1->Fill(ch);
-	//hxpos1->Fill(yRecHit);
-	//hypos1->Fill(xRecHit);
+	hxpos1->Fill(yRecHit);
+	hypos1->Fill(xRecHit);
 	hsize1->Fill(float(size));
 	hsizex1->Fill(float(sizeX));
 	hsizey1->Fill(float(sizeY));
 	numOfRecHitsPerDet1++;
 	numOfRecHitsPerLay1++;
+	hErrorX1->Fill(xerror);
+	hErrorY1->Fill(yerror);
+	hErrorXB->Fill(float(ladder+(110*(side-1))),xerror);
+	hErrorYB->Fill(float(ladder+(110*(side-1))),yerror);
+
       } else if(layer==2) {  // layer 2
 	
 	hcharge2->Fill(ch);
-	//hxpos2->Fill(yRecHit);
-	//hypos2->Fill(xRecHit);
+	hxpos2->Fill(yRecHit);
+	hypos2->Fill(xRecHit);
 	hsize2->Fill(float(size));
 	hsizex2->Fill(float(sizeX));
 	hsizey2->Fill(float(sizeY));
 	numOfRecHitsPerDet2++;
 	numOfRecHitsPerLay2++;
+	hErrorX2->Fill(xerror);
+	hErrorY2->Fill(yerror);
+	hErrorXB->Fill(float(ladder+25+(110*(side-1))),xerror);
+	hErrorYB->Fill(float(ladder+25+(110*(side-1))),yerror);
+
       } else if(layer==3) {  // Layer 3
 	
 	hcharge3->Fill(ch);
-	//hxpos3->Fill(yRecHit);
-	//hypos3->Fill(xRecHit);
+	hxpos3->Fill(yRecHit);
+	hypos3->Fill(xRecHit);
 	hsize3->Fill(float(size));
 	hsizex3->Fill(float(sizeX));
 	hsizey3->Fill(float(sizeY));
 	numOfRecHitsPerDet3++;
 	numOfRecHitsPerLay3++;
+	hErrorX3->Fill(xerror);
+	hErrorY3->Fill(yerror);
+	hErrorXB->Fill(float(ladder+60+(110*(side-1))),xerror);
+	hErrorYB->Fill(float(ladder+60+(110*(side-1))),yerror);
+
       } else if(disk==1) {
 	
 	hcharge1F->Fill(ch);
-	//hxpos1F->Fill(yRecHit);
-	//hypos1F->Fill(xRecHit);
+	hxpos1F->Fill(yRecHit);
+	hypos1F->Fill(xRecHit);
 	hsize1F->Fill(float(size));
 	hsizex1F->Fill(float(sizeX));
 	hsizey1F->Fill(float(sizeY));
-	
+	if(side==1) { // -z
+	  hErrorX4->Fill(xerror);
+	  hErrorY4->Fill(yerror);
+	  hErrorXF->Fill(float(blade+25),xerror);
+	  hErrorYF->Fill(float(blade+25),yerror);
+	} else { // +z
+	  hErrorX6->Fill(xerror);
+	  hErrorY6->Fill(yerror);
+	  hErrorXF->Fill(float(blade+50),xerror);
+	  hErrorYF->Fill(float(blade+50),yerror);
+	}
 	numOfRecHitsPerDet1F++;
 	numOfRecHitsPerLay1F++;
       } else if(disk==2) {  // disk 2
 	
 	hcharge2F->Fill(ch);
-	//hxpos2F->Fill(yRecHit);
-	//hypos2F->Fill(xRecHit);
+	hxpos2F->Fill(yRecHit);
+	hypos2F->Fill(xRecHit);
 	hsize2F->Fill(float(size));
 	hsizex2F->Fill(float(sizeX));
 	hsizey2F->Fill(float(sizeY));
 	numOfRecHitsPerDet2F++;
 	numOfRecHitsPerLay2F++;
+	if(side==1) { // -z
+	  hErrorX5->Fill(xerror);
+	  hErrorY5->Fill(yerror);
+	  hErrorXF->Fill(float(blade),xerror);
+	  hErrorYF->Fill(float(blade),yerror);
+	} else { // +z
+	  hErrorX7->Fill(xerror);
+	  hErrorY7->Fill(yerror);
+	  hErrorXF->Fill(float(blade+75),xerror);
+	  hErrorYF->Fill(float(blade+75),yerror);
+	}
       }
 #endif  
       

--- a/RecoLocalTracker/SiPixelRecHits/test/ReadPixelRecHit.h
+++ b/RecoLocalTracker/SiPixelRecHits/test/ReadPixelRecHit.h
@@ -28,6 +28,7 @@
 #include <TF1.h>
 #include <TH2F.h>
 #include <TH1F.h>
+#include <TProfile.h>
 #endif
 
 class ReadPixelRecHit : public edm::EDAnalyzer
@@ -80,6 +81,14 @@ class ReadPixelRecHit : public edm::EDAnalyzer
   TH1F *hrecHitsPerLay1F,*hrecHitsPerLay2F;
   TH1F *hdetsPerLay1F,*hdetsPerLay2F;
 
+  TH1F *hAlignErrorX1,*hAlignErrorX2,*hAlignErrorX3;
+  TH1F *hAlignErrorX4,*hAlignErrorX5,*hAlignErrorX6,*hAlignErrorX7;
+  TH1F *hAlignErrorY1,*hAlignErrorY2,*hAlignErrorY3;
+  TH1F *hAlignErrorY4,*hAlignErrorY5,*hAlignErrorY6,*hAlignErrorY7;
+  TH1F *hErrorX1,*hErrorX2,*hErrorX3,*hErrorX4,*hErrorX5,*hErrorX6,*hErrorX7;
+  TH1F *hErrorY1,*hErrorY2,*hErrorY3,*hErrorY4,*hErrorY5,*hErrorY6,*hErrorY7;
+  TProfile *hErrorXB, *hErrorXF, *hErrorYB, *hErrorYF;
+  TProfile *hAErrorXB, *hAErrorXF, *hAErrorYB, *hAErrorYF;
 
 #endif
 

--- a/RecoLocalTracker/SiPixelRecHits/test/readRecHits_cfg.py
+++ b/RecoLocalTracker/SiPixelRecHits/test/readRecHits_cfg.py
@@ -7,7 +7,7 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("recHitsTest")
 
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(10)
+    input = cms.untracked.int32(100)
 )
 
 process.MessageLogger = cms.Service("MessageLogger",
@@ -25,7 +25,7 @@ process.MessageLogger = cms.Service("MessageLogger",
 process.source = cms.Source("PoolSource",
 #    fileNames =  cms.untracked.vstring('file:/scratch/dkotlins/digis.root')
    fileNames =  cms.untracked.vstring(
-    'file:/afs/cern.ch/work/d/dkotlins/public/MC/mu/pt100/rechits/rechits1.root'
+    'file:/afs/cern.ch/work/d/dkotlins/public/MC/mu/pt100_71_pre7/rechits/rechits2_postls171.root'
    )
 )
 
@@ -42,7 +42,7 @@ process.load("Configuration.StandardSequences.MagneticField_38T_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")# Choose the global tag here:
 # 2012
 #process.GlobalTag.globaltag = 'GR_P_V40::All'
-# MC 2913
+# MC 2014
 process.GlobalTag.globaltag = 'MC_70_V1::All'
 
 # read rechits
@@ -50,17 +50,18 @@ process.analysis = cms.EDAnalyzer("ReadPixelRecHit",
     Verbosity = cms.untracked.bool(True),
     src = cms.InputTag("siPixelRecHits"),
 )
-# test the DB object, works
-process.load("RecoLocalTracker.SiPixelRecHits.PixelCPEESProducers_cff")
-#process.load("RecoLocalTracker.SiPixelRecHits.SiPixelRecHits_cfi")
-#process.load("CalibTracker.SiPixelESProducers.SiPixelFakeTemplateDBObjectESSource_cfi"
-#process.load("CalibTracker.SiPixelESProducers.SiPixelFakeCPEGenericErrorParmESSource_cfi"
-process.test = cms.EDAnalyzer("CPEAccessTester",
-#    PixelCPE = cms.string('PixelCPEGeneric'),
-    PixelCPE = cms.string('PixelCPETemplateReco'),
-)
 
 process.p = cms.Path(process.analysis)
+
+# test the DB object, works
+#process.load("RecoLocalTracker.SiPixelRecHits.PixelCPEESProducers_cff")
+##process.load("RecoLocalTracker.SiPixelRecHits.SiPixelRecHits_cfi")
+##process.load("CalibTracker.SiPixelESProducers.SiPixelFakeTemplateDBObjectESSource_cfi"
+##process.load("CalibTracker.SiPixelESProducers.SiPixelFakeCPEGenericErrorParmESSource_cfi"
+#process.test = cms.EDAnalyzer("CPEAccessTester",
+##    PixelCPE = cms.string('PixelCPEGeneric'),
+#    PixelCPE = cms.string('PixelCPETemplateReco'),
+#)
 #process.p = cms.Path(process.test)
 
 

--- a/RecoLocalTracker/SiPixelRecHits/test/runClusToRecHits.py
+++ b/RecoLocalTracker/SiPixelRecHits/test/runClusToRecHits.py
@@ -6,7 +6,7 @@
 
 import FWCore.ParameterSet.Config as cms
 
-process = cms.Process("ClusTest")
+process = cms.Process("RecHitTest")
 
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
 process.load("Configuration.Geometry.GeometryIdeal_cff")
@@ -40,8 +40,8 @@ process.MessageLogger = cms.Service("MessageLogger",
 #    destinations = cms.untracked.vstring("log","cout"),
     cout = cms.untracked.PSet(
 #       threshold = cms.untracked.string('INFO')
-#       threshold = cms.untracked.string('ERROR')
         threshold = cms.untracked.string('WARNING')
+#       threshold = cms.untracked.string('ERROR')
     )
 #    log = cms.untracked.PSet(
 #        threshold = cms.untracked.string('DEBUG')
@@ -50,25 +50,57 @@ process.MessageLogger = cms.Service("MessageLogger",
 # get the files from DBS:
 process.source = cms.Source("PoolSource",
   fileNames = cms.untracked.vstring(
-#    'file:/afs/cern.ch/work/d/dkotlins/public/MC/mu/pt100/digis/digis1.root'
-#    'file:/afs/cern.ch/work/d/dkotlins/public/MC/mu/pt100_71_pre7/digis/digis2_postls171.root'
-    'file:/afs/cern.ch/work/d/dkotlins/public/MC/mu/pt100_71_pre7/digis/digis2_mc71.root'
+#    'file:/afs/cern.ch/work/d/dkotlins/public/MC/mu/pt100/clus/clus1.root'
+    'file:/afs/cern.ch/work/d/dkotlins/public/MC/mu/pt100_71_pre7/rechits/rechits2_mc71.root'
+#    '/store/relval/CMSSW_7_1_0_pre7/RelValProdMinBias/GEN-SIM-RECO/PRE_STA71_V3-v1/00000/9E55469D-B2D1-E311-BEA8-02163E00B4B7.root'
+
+#"/store/data/Run2012D/MinimumBias/RECO/PromptReco-v1/000/208/686/F60495B3-1E41-E211-BB7C-003048D3756A.root",
+
+##"/store/data/Run2012D/MinimumBias/RECO/PromptReco-v1/000/208/686/F2BA6B22-2C41-E211-9D7A-003048D2BED6.root",
+## "/store/data/Run2012D/MinimumBias/RECO/PromptReco-v1/000/208/686/E4E6B318-2041-E211-B351-001D09F29114.root",
+## "/store/data/Run2012D/MinimumBias/RECO/PromptReco-v1/000/208/686/B27AC385-3241-E211-AD10-0019B9F4A1D7.root",
+## "/store/data/Run2012D/MinimumBias/RECO/PromptReco-v1/000/208/686/AC6EF0B7-4941-E211-9EFB-003048D374F2.root",
+## "/store/data/Run2012D/MinimumBias/RECO/PromptReco-v1/000/208/686/AA4018D3-2C41-E211-8279-00215AEDFD98.root",
+## "/store/data/Run2012D/MinimumBias/RECO/PromptReco-v1/000/208/686/A8CF653C-4D41-E211-811E-003048673374.root",
+## "/store/data/Run2012D/MinimumBias/RECO/PromptReco-v1/000/208/686/98EEEB5E-4A41-E211-A591-001D09F25460.root",
+## "/store/data/Run2012D/MinimumBias/RECO/PromptReco-v1/000/208/686/96BE2949-2241-E211-9993-001D09F23F2A.root",
+## "/store/data/Run2012D/MinimumBias/RECO/PromptReco-v1/000/208/686/90F6F479-2641-E211-99E5-001D09F29524.root",
+## "/store/data/Run2012D/MinimumBias/RECO/PromptReco-v1/000/208/686/8AAFC294-2141-E211-89E8-003048F1182E.root",
+## "/store/data/Run2012D/MinimumBias/RECO/PromptReco-v1/000/208/686/82B885ED-2241-E211-9877-001D09F252E9.root",
+## "/store/data/Run2012D/MinimumBias/RECO/PromptReco-v1/000/208/686/6440884D-2941-E211-BBA9-0025901D6288.root",
+## "/store/data/Run2012D/MinimumBias/RECO/PromptReco-v1/000/208/686/604E8D2C-2741-E211-B542-003048F11C28.root",
+## "/store/data/Run2012D/MinimumBias/RECO/PromptReco-v1/000/208/686/4EB6D745-2241-E211-9738-001D09F24D8A.root",
+## "/store/data/Run2012D/MinimumBias/RECO/PromptReco-v1/000/208/686/3E863C44-2241-E211-9255-001D09F25041.root",
+## "/store/data/Run2012D/MinimumBias/RECO/PromptReco-v1/000/208/686/3E76F7E8-2741-E211-8249-003048D37666.root",
+## "/store/data/Run2012D/MinimumBias/RECO/PromptReco-v1/000/208/686/3C1D83B8-3641-E211-8C66-0025B32035A2.root",
+## "/store/data/Run2012D/MinimumBias/RECO/PromptReco-v1/000/208/686/2A12A045-2241-E211-8BF5-001D09F2915A.root",
+## "/store/data/Run2012D/MinimumBias/RECO/PromptReco-v1/000/208/686/1661335F-3041-E211-9B96-00237DDBE0E2.root",
+
   )
+)
+
+#process.source.lumisToProcess = cms.untracked.VLuminosityBlockRange('208686:73-208686:463')
+
+# a service to use root histos
+process.TFileService = cms.Service("TFileService",
+    fileName = cms.string('histo.root')
 )
 
 # Choose the global tag here:
 #process.GlobalTag.globaltag = "MC_70_V1::All"
 #process.GlobalTag.globaltag = "START70_V1::All"
-#process.GlobalTag.globaltag = "START71_V1::All"
-process.GlobalTag.globaltag = "MC_71_V1::All"
+#process.GlobalTag.globaltag = "POSTLS170_V5::All"
+process.GlobalTag.globaltag = "START71_V1::All"
+#process.GlobalTag.globaltag = "MC_71_V1::All"
 #process.GlobalTag.globaltag = "POSTLS171_V1::All"
 #process.GlobalTag.globaltag = "PRE_MC_71_V2::All"
-
+# for data
+#process.GlobalTag.globaltag = "GR_R_71_V1::All"
 
 # DB stuff 
+# GenError
 useLocalDB = True
 if useLocalDB :
-# Frontier LA 
     process.DBReaderFrontier = cms.ESSource("PoolDBESSource",
      DBParameters = cms.PSet(
          messageLevel = cms.untracked.int32(0),
@@ -76,30 +108,19 @@ if useLocalDB :
      ),
      toGet = cms.VPSet(
  	 cms.PSet(
-# GenError
           record = cms.string('SiPixelGenErrorDBObjectRcd'),
-#          tag = cms.string('SiPixelGenErrorDBObject38Tv1')
 #          tag = cms.string('SiPixelGenErrorDBObject38TV10')
-#          tag = cms.string('SiPixelGenErrorDBObject38T_v0_mc1')
           tag = cms.string('SiPixelGenErrorDBObject_38T_v1_mc')
-# LA
-# 			record = cms.string("SiPixelLorentzAngleRcd"),
-# 			label = cms.untracked.string("fromAlignment"),
-# 			label = cms.untracked.string("forWidth"),
-# 			tag = cms.string("SiPixelLorentzAngle_v02_mc")
-# 			tag = cms.string("SiPixelLorentzAngle_fromAlignment_v0_mc")
-# 			tag = cms.string("SiPixelLorentzAngle_forWidth_v0_mc")
- 		),
-# 		cms.PSet(
-# 			record = cms.string("SiPixelLorentzAngleSimRcd"),
-# 			tag = cms.string("test_LorentzAngle_Sim")
-# 		)
+ 	 ),
  	),
-#     connect = cms.string('frontier://FrontierProd/CMS_COND_31X_PIXEL')
+#     connect = cms.string('sqlite_file:siPixelGenErrors38T.db')
+#     connect = cms.string('frontier://FrontierProd/CMS_COND_PIXEL_000')
      connect = cms.string('frontier://FrontierPrep/CMS_COND_PIXEL')
     ) # end process
+# endif
 
-# SQ_LITE GenError
+useLocalDB2 = False
+if useLocalDB2 :
     process.DBReaderFrontier2 = cms.ESSource("PoolDBESSource",
      DBParameters = cms.PSet(
          messageLevel = cms.untracked.int32(0),
@@ -107,14 +128,14 @@ if useLocalDB :
      ),
      toGet = cms.VPSet(
  		cms.PSet(
- 			record = cms.string("SiPixelGenErrorDBObjectRcd"),
-# 			label = cms.untracked.string("fromAlignment"),
-# 			tag = cms.string("SiPixelGenErrorDBObject38Tv1")
- 			tag = cms.string("SiPixelGenErrorDBObject38TV10")
+ 			record = cms.string("SiPixelTemplateDBObjectRcd"),
+ 			tag = cms.string("SiPixelTemplateDBObject38TV10")
+# 			tag = cms.string("SiPixelTemplateDBObject38Tv21")
  		),
  	),
-#     connect = cms.string('sqlite_file:siPixelGenErrors38T.db_old')
-     connect = cms.string('sqlite_file:siPixelGenErrors38T.db')
+     connect = cms.string('sqlite_file:siPixelTemplates38T.db')
+#     connect = cms.string('frontier://FrontierPrep/CMS_COND_PIXEL')
+#     connect = cms.string('frontier://FrontierProd/CMS_COND_31X_PIXEL')
    ) # end process
 # endif
  
@@ -142,9 +163,9 @@ process.myprefer = cms.ESPrefer("PoolDBESSource","DBReaderFrontier")
 
 
 process.o1 = cms.OutputModule("PoolOutputModule",
-                              outputCommands = cms.untracked.vstring('drop *','keep *_*_*_ClusTest'),
-#            fileName = cms.untracked.string('file:clus.root')
-            fileName = cms.untracked.string('file:/afs/cern.ch/work/d/dkotlins/public/MC/mu/pt100_71_pre7/rechits/rechits2_mc71.root')
+                              outputCommands = cms.untracked.vstring('drop *','keep *_*_*_RecHitTest'),
+            fileName = cms.untracked.string('file:clus.root')
+#            fileName = cms.untracked.string('file:/afs/cern.ch/work/d/dkotlins/public/MC/mu/pt100_71_pre7/rechits/rechits2_mc71.root')
 )
 
 #process.Timing = cms.Service("Timing")
@@ -159,10 +180,18 @@ process.o1 = cms.OutputModule("PoolOutputModule",
 # label of digis 
 process.siPixelClusters.src = 'simSiPixelDigis'
 
+# read rechits
+process.analysis = cms.EDAnalyzer("ReadPixelRecHit",
+    Verbosity = cms.untracked.bool(False),
+    src = cms.InputTag("siPixelRecHits"),
+)
+
 # plus pixel clusters  (OK)
 #process.p1 = cms.Path(process.siPixelClusters)
 # plus pixel rechits (OK)
-process.p1 = cms.Path(process.pixeltrackerlocalreco)
+#process.p1 = cms.Path(process.pixeltrackerlocalreco*process.analysis)
+# only rechits
+process.p1 = cms.Path(process.siPixelRecHits*process.analysis)
 
 # RAW
 # clusterize through raw (OK)
@@ -176,4 +205,5 @@ process.p1 = cms.Path(process.pixeltrackerlocalreco)
 #process.p1 = cms.Path(process.siPixelRawData*process.siPixelDigis)
 #process.p1 = cms.Path(process.siPixelRawData*process.siPixelDigis*process.pixeltrackerlocalreco)
 
-process.outpath = cms.EndPath(process.o1)
+# save output 
+#process.outpath = cms.EndPath(process.o1)

--- a/SimTracker/SiPixelDigitizer/test/Digitze_Pixels_And_Strips.py
+++ b/SimTracker/SiPixelDigitizer/test/Digitze_Pixels_And_Strips.py
@@ -28,7 +28,7 @@ from SimGeneral.MixingModule.stripDigitizer_cfi import *
 from SimGeneral.MixingModule.trackingTruthProducer_cfi import *
 
 
-process.mix = cms.EDProducer("MixingModule",
+process.simSiPixelDigis = cms.EDProducer("MixingModule",
 #    digitizers = cms.PSet(theDigitizers),
 #    digitizers = cms.PSet(
 #      mergedtruth = cms.PSet(
@@ -132,7 +132,7 @@ process.RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService
 #        initialSeed = cms.untracked.uint32(1234567),
 #        engineName = cms.untracked.string('TRandom3')
 #    ),
-     mix = cms.PSet(
+     simSiPixelDigis = cms.PSet(
         initialSeed = cms.untracked.uint32(1234567),
         engineName = cms.untracked.string('TRandom3')
    )
@@ -144,19 +144,28 @@ process.maxEvents = cms.untracked.PSet(
 )
 
 process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring(
-       'file:/afs/cern.ch/work/d/dkotlins/public//MC/mu/pt100/simhits/simHits1.root'
+#       'file:/afs/cern.ch/work/d/dkotlins/public//MC/mu/pt100_71_pre5/simhits/simHits2.root'
+       'file:/afs/cern.ch/work/d/dkotlins/public//MC/mu/pt100_71_pre5/simhits/simHits1.root'
+#       'file:/afs/cern.ch/work/d/dkotlins/public//MC/mu/pt100_71_pre5/simhits/simHits3.root'
+#       'file:/afs/cern.ch/work/d/dkotlins/public//MC/mu/pt100_71_pre5/simhits/simHits4.root'
   )
 )
 
 # Choose the global tag here:
 # for v7.0
 #process.GlobalTag.globaltag = 'MC_70_V1::All'
-process.GlobalTag.globaltag = 'START70_V1::All'
+#process.GlobalTag.globaltag = 'START70_V1::All'
 #process.GlobalTag.globaltag = 'DESIGN70_V1::All'
+#process.GlobalTag.globaltag = "START71_V1::All"
+#process.GlobalTag.globaltag = 'MC_71_V1::All'
+#process.GlobalTag.globaltag = 'POSTLS171_V1::All'
+#process.GlobalTag.globaltag = "PRE_MC_71_V2::All"
+process.GlobalTag.globaltag = "PRE_STA71_V4::All"
+
 
 process.o1 = cms.OutputModule("PoolOutputModule",
       outputCommands = cms.untracked.vstring('drop *','keep *_*_*_Test'),
-      fileName = cms.untracked.string('file:/afs/cern.ch/work/d/dkotlins/public/MC/mu/pt100/digis_trk/digis1.root')
+      fileName = cms.untracked.string('file:/afs/cern.ch/work/d/dkotlins/public/MC/mu/pt100_71_pre7/digis_trk/digis1_presta71.root')
 #      fileName = cms.untracked.string('file:dummy.root')
 )
 
@@ -166,7 +175,7 @@ process.g4SimHits.Generator.HepMCProductLabel = 'source'
 #process.mix.digitizers.pixel.ThresholdInElectrons_BPix = 3500.0 
 
 #This process is to run the digitizer:
-process.p1 = cms.Path(process.mix)
+process.p1 = cms.Path(process.simSiPixelDigis)
 
 process.outpath = cms.EndPath(process.o1)
 

--- a/SimTracker/SiPixelDigitizer/test/testPixelDigitizer.py
+++ b/SimTracker/SiPixelDigitizer/test/testPixelDigitizer.py
@@ -25,7 +25,7 @@ from SimGeneral.MixingModule.pixelDigitizer_cfi import *
 from SimGeneral.MixingModule.stripDigitizer_cfi import *
 from SimGeneral.MixingModule.trackingTruthProducer_cfi import *
 
-process.mix = cms.EDProducer("MixingModule",
+process.simSiPixelDigis = cms.EDProducer("MixingModule",
 #    digitizers = cms.PSet(theDigitizers),
 #    digitizers = cms.PSet(
 #      mergedtruth = cms.PSet(
@@ -128,7 +128,7 @@ process.RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService
 #        initialSeed = cms.untracked.uint32(1234567),
 #        engineName = cms.untracked.string('TRandom3')
 #    ),
-     mix = cms.PSet(
+     simSiPixelDigis = cms.PSet(
         initialSeed = cms.untracked.uint32(1234567),
         engineName = cms.untracked.string('TRandom3')
    )
@@ -140,28 +140,34 @@ process.maxEvents = cms.untracked.PSet(
 )
 
 process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring(
-       'file:/afs/cern.ch/work/d/dkotlins/public//MC/mu/pt100/simhits/simHits1.root'
+       'file:/afs/cern.ch/work/d/dkotlins/public//MC/mu/pt100_71_pre5/simhits/simHits2.root'
   )
 )
 
 # Choose the global tag here:
 # for v7.0
-process.GlobalTag.globaltag = 'MC_70_V1::All'
+#process.GlobalTag.globaltag = 'MC_70_V1::All'
+#process.GlobalTag.globaltag = "START70_V1::All"
+#process.GlobalTag.globaltag = "START71_V1::All"
+#process.GlobalTag.globaltag = 'MC_71_V1::All'
+process.GlobalTag.globaltag = 'POSTLS171_V1::All'
+#process.GlobalTag.globaltag = "PRE_MC_71_V2::All"
 
 process.o1 = cms.OutputModule("PoolOutputModule",
             outputCommands = cms.untracked.vstring('drop *','keep *_*_*_Test'),
-      fileName = cms.untracked.string('file:/afs/cern.ch/work/d/dkotlins/public/MC/mu/pt100/digis/digis1.root')
+      fileName = cms.untracked.string('file:/afs/cern.ch/work/d/dkotlins/public/MC/mu/pt100_71_pre7/digis/digis2_postls171.root')
 #      fileName = cms.untracked.string('file:dummy.root')
 )
 
 process.g4SimHits.Generator.HepMCProductLabel = 'source'
+process.simSiPixelDigis.digitizers.pixel.AddPixelInefficiencyFromPython = cms.bool(False)
 
 # modify digitizer parameters
 #process.simSiPixelDigis.ThresholdInElectrons_BPix = 3500.0 
-process.mix.digitizers.pixel.ThresholdInElectrons_BPix = 3500.0 
+#process.mix.digitizers.pixel.ThresholdInElectrons_BPix = 3500.0 
 
 #This process is to run the digitizer, pixel gitizer is now clled by the mix module
-process.p1 = cms.Path(process.mix)
+process.p1 = cms.Path(process.simSiPixelDigis)
 
 process.outpath = cms.EndPath(process.o1)
 

--- a/SimTracker/SiPixelDigitizer/test/testPxdigi_cfg.py
+++ b/SimTracker/SiPixelDigitizer/test/testPxdigi_cfg.py
@@ -3,6 +3,12 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("digiTest")
 
+process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.MagneticField_38T_cff")
+# process.load("Configuration.StandardSequences.Services_cff")
+
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(-1)
 )
@@ -21,8 +27,8 @@ process.MessageLogger = cms.Service("MessageLogger",
 
 process.source = cms.Source("PoolSource",
     fileNames =  cms.untracked.vstring(
-    'file:/afs/cern.ch/work/d/dkotlins/public/MC/mu/pt100/digis/digis1.root'
-#    'file:dummy_100.root'
+#    'file:/afs/cern.ch/work/d/dkotlins/public/MC/mu/pt100_71_pre7/digis/digis2_postls171.root'
+    'file:digis.root'
     )
 )
 
@@ -31,40 +37,25 @@ process.TFileService = cms.Service("TFileService",
     fileName = cms.string('histo.root')
 )
 
-#process.load("Geometry.TrackerSimData.trackerSimGeometryXML_cfi")
-#process.load("Geometry.CMSCommonData.cmsSimIdealGeometryXML_cfi")
-
-process.load("Configuration.StandardSequences.Geometry_cff")
-process.load("Configuration.StandardSequences.MagneticField_38T_cff")
-# what is this?
-# process.load("Configuration.StandardSequences.Services_cff")
-
-# what is this?
-#process.load("SimTracker.Configuration.SimTracker_cff")
-
-# needed for global transformation
-# this crashes
-# process.load("Configuration.StandardSequences.FakeConditions_cff")
-
-process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")# Choose the global tag here:
 #process.GlobalTag.globaltag = 'MC_31X_V9::All'
 #process.GlobalTag.globaltag = 'CRAFT09_R_V4::All'
 # 2012
 # process.GlobalTag.globaltag = 'GR_P_V40::All'
 # 2013 MC
-process.GlobalTag.globaltag = 'MC_70_V1::All'
+#process.GlobalTag.globaltag = 'MC_70_V1::All'
+# 2014 data
+process.GlobalTag.globaltag = 'PRE_R_71_V3::All'
+# 2014 mc
+#process.GlobalTag.globaltag = 'PRE_STA71_V4::All'
 
-#process.load("Geometry.TrackerGeometryBuilder.trackerGeometry_cfi")
-#process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
-#process.load("Configuration.StandardSequences.MagneticField_cff")
-# include "MagneticField/Engine/data/volumeBasedMagneticField.cfi"
   
 process.analysis = cms.EDAnalyzer("PixelDigisTest",
-    Verbosity = cms.untracked.bool(False),
-# sim in V7
-    src = cms.InputTag("mix"),
+    Verbosity = cms.untracked.bool(True),
+# my sim in V7
+#    src = cms.InputTag("simSiPixelDigis"),
+#    src = cms.InputTag("mix"),
 # old default
-#    src = cms.InputTag("siPixelDigis"),
+    src = cms.InputTag("siPixelDigis"),
 )
 
 process.p = cms.Path(process.analysis)


### PR DESCRIPTION
A new version of RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplate.cc.
The rest are small printout changes, mostly in test files and some in the GenericCPE code.
The default generic-error is still from template objects since we are still waiting for the right GT.
For version 72X.
