### PR TITLE
Removed depricated KfComponentsHolder::setup function

### DIFF
--- a/Alignment/ReferenceTrajectories/src/ReferenceTrajectory.cc
+++ b/Alignment/ReferenceTrajectories/src/ReferenceTrajectory.cc
@@ -962,10 +962,11 @@ ReferenceTrajectory::getHitProjectionMatrixT
   // input for the holder - but dummy is OK here to just get the projection matrix:
   const AlgebraicVector5 dummyPars;
   const AlgebraicSymMatrix55 dummyErr;
+  ProjectMatrix<double,5,N> dummyProjFunc;
 
   // setup the holder with the correct dimensions and get the values
   KfComponentsHolder holder;
-  holder.setup<N>(&r, &V, &H, /*&pf,*/ &rMeas, &VMeas, dummyPars, dummyErr);
+  holder.setup<N>(&r, &V, &H, &dummyProjFunc, &rMeas, &VMeas, dummyPars, dummyErr);
   hitPtr->getKfComponents(holder);
 
   return asHepMatrix<N,5>(holder.projection<N>());

--- a/DataFormats/TrackingRecHit/interface/KfComponentsHolder.h
+++ b/DataFormats/TrackingRecHit/interface/KfComponentsHolder.h
@@ -145,33 +145,6 @@ void KfComponentsHolder::setup(
     tsosLocalErrors_     = & tsosLocalErrors;
 }
 
-// backward compatible
-template<unsigned int D>
-void KfComponentsHolder::setup(
-        typename AlgebraicROOTObject<D>::Vector       *params,
-        typename AlgebraicROOTObject<D,D>::SymMatrix  *errors,
-        typename AlgebraicROOTObject<D,5>::Matrix     *projection, 
-        typename AlgebraicROOTObject<D>::Vector       *measuredParams,
-        typename AlgebraicROOTObject<D,D>::SymMatrix  *measuredErrors,
-        const AlgebraicVector5     & tsosLocalParameters, 
-        const AlgebraicSymMatrix55 & tsosLocalErrors)
-{
-#ifdef Debug_KfComponentsHolder
-    assert(size_ == 0); // which means it was uninitialized
-    size_ = D;
-#endif
-    static thread_local ProjectMatrix<double,5,D> dummy;
-    params_     = params;
-    errors_     = errors;
-    projection_ = projection;
-    projFunc_ = &dummy;
-    measuredParams_ = measuredParams;
-    measuredErrors_ = measuredErrors;
-    tsosLocalParameters_ = & tsosLocalParameters;
-    tsosLocalErrors_     = & tsosLocalErrors;
-}
-
-
 template<unsigned int D>
 void KfComponentsHolder::dump() {
     using namespace std;

--- a/TrackingTools/KalmanUpdators/src/Chi2MeasurementEstimator.cc
+++ b/TrackingTools/KalmanUpdators/src/Chi2MeasurementEstimator.cc
@@ -28,10 +28,11 @@ Chi2MeasurementEstimator::estimate(const TrajectoryStateOnSurface& tsos,
 
   VecD r, rMeas; SMatDD R, RMeas; 
   MatD5 dummyProjMatrix;
+  ProjectMatrix<double,5,D> dummyProjFunc;
   auto && v = tsos.localParameters().vector();
   auto && m = tsos.localError().matrix();
   KfComponentsHolder holder;
-  holder.template setup<D>(&r, &R, &dummyProjMatrix, &rMeas, &RMeas, v, m);
+  holder.template setup<D>(&r, &R, &dummyProjMatrix, &dummyProjFunc, &rMeas, &RMeas, v, m);
   aRecHit.getKfComponents(holder);
  
   R += RMeas;


### PR DESCRIPTION
The depricated function was using a thread local for temporary
storage while processing. The already existing replacement version
of setup has that passed in as an argument. The change modifies
the last two places still calling the depricated function.
This is needed because of a system limit on the number of allowed
thread locals in an executable.
