### PR TITLE
Use std::shared_ptr, not boost::shared_ptr

### DIFF
--- a/DQM/SiStripMonitorHardware/interface/SiStripSpyEventMatcher.h
+++ b/DQM/SiStripMonitorHardware/interface/SiStripSpyEventMatcher.h
@@ -174,7 +174,7 @@ namespace sistrip {
     // as long as unscheduled execution of an EDProducer cannot occur
     // as a result of this function call (and with the current implementation
     // of SpyEventMatcher unscheduled execution never happens).
-    const boost::shared_ptr< const edm::Wrapper<T> > productWrapper = edm::getProductByTag<T>(event,tag,nullptr);
+    const std::shared_ptr< const edm::Wrapper<T> > productWrapper = edm::getProductByTag<T>(event,tag,nullptr);
     if (productWrapper) {
       return productWrapper->product();
     } else {

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyEventMatcher.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyEventMatcher.cc
@@ -21,9 +21,9 @@
 #include "FWCore/Version/interface/GetReleaseVersion.h"
 #include "DQM/SiStripMonitorHardware/interface/SiStripSpyUtilities.h"
 #include "boost/bind.hpp"
-#include "boost/shared_ptr.hpp"
 #include <algorithm>
 #include <limits>
+#include <memory>
 
 using edm::LogInfo;
 using edm::LogWarning;
@@ -74,8 +74,8 @@ namespace sistrip {
     const edm::VectorInputSourceFactory* sourceFactory = edm::VectorInputSourceFactory::get();
     edm::InputSourceDescription description(edm::ModuleDescription(),
                                             *productRegistry_,
-                                            boost::shared_ptr<edm::BranchIDListHelper>(new edm::BranchIDListHelper),
-                                            boost::shared_ptr<edm::ActivityRegistry>(new edm::ActivityRegistry),
+                                            std::make_shared<edm::BranchIDListHelper>(),
+                                            std::make_shared<edm::ActivityRegistry>(),
                                             -1, -1,
                                             edm::PreallocationConfiguration());
     return sourceFactory->makeVectorInputSource(sourceConfig, description);

--- a/DQMServices/FwkIO/plugins/DQMRootSource.cc
+++ b/DQMServices/FwkIO/plugins/DQMRootSource.cc
@@ -386,8 +386,8 @@ class DQMRootSource : public edm::InputSource
 
       virtual edm::InputSource::ItemType getNextItemType() override;
       //NOTE: the following is really read next run auxiliary
-      virtual boost::shared_ptr<edm::RunAuxiliary> readRunAuxiliary_() override ;
-      virtual boost::shared_ptr<edm::LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary_() override ;
+      virtual std::shared_ptr<edm::RunAuxiliary> readRunAuxiliary_() override ;
+      virtual std::shared_ptr<edm::LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary_() override ;
       virtual void readRun_(edm::RunPrincipal& rpCache) override;
       virtual void readLuminosityBlock_(edm::LuminosityBlockPrincipal& lbCache) override;
       virtual void readEvent_(edm::EventPrincipal&) override ;
@@ -549,7 +549,7 @@ edm::InputSource::ItemType DQMRootSource::getNextItemType()
   return m_nextItemType;
 }
 
-boost::shared_ptr<edm::RunAuxiliary> DQMRootSource::readRunAuxiliary_()
+std::shared_ptr<edm::RunAuxiliary> DQMRootSource::readRunAuxiliary_()
 {
   //std::cout <<"readRunAuxiliary_"<<std::endl;
   assert(m_nextIndexItr != m_orderedIndices.end());
@@ -561,10 +561,10 @@ boost::shared_ptr<edm::RunAuxiliary> DQMRootSource::readRunAuxiliary_()
   assert(m_historyIDs.size() > runLumiRange.m_historyIDIndex);
   //std::cout <<"readRunAuxiliary_ "<<m_historyIDs[runLumiRange.m_historyIDIndex]<<std::endl;
   m_runAux.setProcessHistoryID(m_historyIDs[runLumiRange.m_historyIDIndex]);    
-  return boost::shared_ptr<edm::RunAuxiliary>( new edm::RunAuxiliary(m_runAux) );
+  return std::make_shared<edm::RunAuxiliary>(m_runAux);
 }
 
-boost::shared_ptr<edm::LuminosityBlockAuxiliary>
+std::shared_ptr<edm::LuminosityBlockAuxiliary>
 DQMRootSource::readLuminosityBlockAuxiliary_()
 {
   //std::cout <<"readLuminosityBlockAuxiliary_"<<std::endl;
@@ -577,7 +577,7 @@ DQMRootSource::readLuminosityBlockAuxiliary_()
   //std::cout <<"lumi "<<m_lumiAux.beginTime().value()<<" "<<runLumiRange.m_beginTime<<std::endl;
   m_lumiAux.setProcessHistoryID(m_historyIDs[runLumiRange.m_historyIDIndex]);    
 
-  return boost::shared_ptr<edm::LuminosityBlockAuxiliary>(new edm::LuminosityBlockAuxiliary(m_lumiAux));
+  return std::make_shared<edm::LuminosityBlockAuxiliary>(m_lumiAux);
 }
 
 void

--- a/DQMServices/StreamerIO/plugins/DQMStreamerReader.h
+++ b/DQMServices/StreamerIO/plugins/DQMStreamerReader.h
@@ -6,7 +6,6 @@
 
 #include "DQMFileIterator.h"
 
-#include "boost/shared_ptr.hpp"
 #include "boost/filesystem.hpp"
 
 #include <memory>
@@ -71,7 +70,7 @@ class DQMStreamerReader : public StreamerInputSource {
   bool flagDeleteDatFiles_;
 
   std::unique_ptr<StreamerInputFile> streamReader_;
-  boost::shared_ptr<EventSkipperByID> eventSkipperByID_;
+  std::shared_ptr<EventSkipperByID> eventSkipperByID_;
 
   DQMFileIterator fiterator_;
 };

--- a/DataFormats/Common/interface/BasicHandle.h
+++ b/DataFormats/Common/interface/BasicHandle.h
@@ -35,7 +35,7 @@ If failedToGet() returns false but isValid() is also false then no attempt
 
 
 #include <memory>
-#include "DataFormats/Common/interface/HideStdSharedPtrFromRoot.h"
+#include "FWCore/Utilities/interface/HideStdSharedPtrFromRoot.h"
 
 namespace cms {
   class Exception;

--- a/DataFormats/Common/interface/DetSetLazyVector.h
+++ b/DataFormats/Common/interface/DetSetLazyVector.h
@@ -30,12 +30,13 @@ to be returned, *not* the ordinal number of the T to be returned.
 
 #include "boost/concept_check.hpp"
 #include "boost/iterator/transform_iterator.hpp"
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 #include "DataFormats/Common/interface/traits.h"
 #include "DataFormats/Common/interface/DetSet.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "DataFormats/Common/interface/Ref.h"
+#include "FWCore/Utilities/interface/HideStdSharedPtrFromRoot.h"
 
 namespace edm {
 
@@ -67,7 +68,7 @@ public:
     };
     template<typename T>
       struct LazyAdapter : public std::unary_function<const DetSet<T>&, const DetSet<T>&> {
-        LazyAdapter(boost::shared_ptr<LazyGetter<T> > iGetter): getter_(iGetter) {}
+        LazyAdapter(std::shared_ptr<LazyGetter<T> > iGetter): getter_(iGetter) {}
         const DetSet<T>& operator()(const DetSet<T>& iUpdate) const {
           if(iUpdate.data.empty() && getter_) {
             //NOTE: because this is 'updating a cache' we need to cast away the const
@@ -78,7 +79,7 @@ public:
           return iUpdate;
         }
 private:
-        boost::shared_ptr<LazyGetter<T> > getter_;
+        std::shared_ptr<LazyGetter<T> > getter_;
       };
   }
   //------------------------------------------------------------
@@ -120,7 +121,7 @@ private:
 
     DetSetLazyVector() {}
     
-    DetSetLazyVector(boost::shared_ptr<dslv::LazyGetter<T> > iGetter, const std::vector<det_id_type>& iDets) :
+    DetSetLazyVector(std::shared_ptr<dslv::LazyGetter<T> > iGetter, const std::vector<det_id_type>& iDets) :
     sets_(),
     getter_(iGetter) {
         sets_.reserve(iDets.size());
@@ -169,7 +170,7 @@ private:
 
   private:
     collection_type   sets_;
-    boost::shared_ptr<dslv::LazyGetter<T> > getter_;
+    std::shared_ptr<dslv::LazyGetter<T> > getter_;
   };
 
   template <class T>

--- a/DataFormats/Common/interface/DetSetVectorNew.h
+++ b/DataFormats/Common/interface/DetSetVectorNew.h
@@ -10,8 +10,9 @@
 #include <boost/iterator/transform_iterator.hpp>
 #include <boost/iterator/counting_iterator.hpp>
 #include <boost/any.hpp>
-#include "boost/shared_ptr.hpp"
+#include <memory>
 #include "FWCore/Utilities/interface/GCC11Compatibility.h"
+#include "FWCore/Utilities/interface/HideStdSharedPtrFromRoot.h"
 
 
 #include<vector>
@@ -200,7 +201,7 @@ namespace edmNew {
     explicit DetSetVector(int isubdet=0) :
       m_subdetId(isubdet) {}
 
-    DetSetVector(boost::shared_ptr<dslv::LazyGetter<T> > iGetter, const std::vector<det_id_type>& iDets,
+    DetSetVector(std::shared_ptr<dslv::LazyGetter<T> > iGetter, const std::vector<det_id_type>& iDets,
 		 int isubdet=0);
 
 
@@ -413,7 +414,7 @@ namespace edmNew {
     
 
   template<typename T>
-  inline DetSetVector<T>::DetSetVector(boost::shared_ptr<Getter> iGetter, 
+  inline DetSetVector<T>::DetSetVector(std::shared_ptr<Getter> iGetter, 
 				       const std::vector<det_id_type>& iDets,
 				       int isubdet):  
     m_subdetId(isubdet) {
@@ -437,7 +438,7 @@ namespace edmNew {
     if (item.offset!=-1 || getter.empty() ) return;
     item.offset = int(m_data.size());
     FastFiller ff(*this,item,true);
-    (*boost::any_cast<boost::shared_ptr<Getter> >(&getter))->fill(ff);
+    (*boost::any_cast<std::shared_ptr<Getter> >(&getter))->fill(ff);
   }
 
 

--- a/DataFormats/Common/interface/EDProductfwd.h
+++ b/DataFormats/Common/interface/EDProductfwd.h
@@ -6,7 +6,9 @@
 Forward declarations of types in the EDM.
 
 ----------------------------------------------------------------------*/
-#include "boost/shared_ptr.hpp"
+#include <memory>
+
+#include "FWCore/Utilities/interface/HideStdSharedPtrFromRoot.h"
 
 namespace edm 
 {
@@ -41,9 +43,9 @@ namespace edm
     template <class T> class BaseVectorHolder;
     template <class T, class REFVECTOR> class VectorHolder;
   }
-  typedef boost::shared_ptr<reftobase::RefHolderBase> helper_ptr;
+  typedef std::shared_ptr<reftobase::RefHolderBase> helper_ptr;
   typedef reftobase::RefVectorHolderBase helper_vector;
-  typedef boost::shared_ptr<reftobase::RefVectorHolderBase> helper_vector_ptr;
+  typedef std::shared_ptr<reftobase::RefVectorHolderBase> helper_vector_ptr;
 }
 
 #endif

--- a/DataFormats/Common/interface/HandleBase.h
+++ b/DataFormats/Common/interface/HandleBase.h
@@ -33,7 +33,7 @@ If failedToGet() returns false but isValid() is also false then no attempt
 
 
 #include <memory>
-#include "DataFormats/Common/interface/HideStdSharedPtrFromRoot.h"
+#include "FWCore/Utilities/interface/HideStdSharedPtrFromRoot.h"
 
 namespace cms {
   class Exception;

--- a/DataFormats/Common/interface/HandleExceptionFactory.h
+++ b/DataFormats/Common/interface/HandleExceptionFactory.h
@@ -26,7 +26,7 @@
 
 // system include files
 #include <memory>
-#include "DataFormats/Common/interface/HideStdSharedPtrFromRoot.h"
+#include "FWCore/Utilities/interface/HideStdSharedPtrFromRoot.h"
 
 // user include files
 

--- a/DataFormats/Common/interface/IndirectHolder.h
+++ b/DataFormats/Common/interface/IndirectHolder.h
@@ -4,8 +4,8 @@
 #include "DataFormats/Common/interface/BaseHolder.h"
 #include "DataFormats/Common/interface/RefHolderBase.h"
 #include "DataFormats/Provenance/interface/ProductID.h"
+#include "FWCore/Utilities/interface/HideStdSharedPtrFromRoot.h"
 
-#include "boost/shared_ptr.hpp"
 #include <memory>
 
 namespace edm {
@@ -28,7 +28,7 @@ namespace edm {
       // this constructor, so that the cloning can be avoided. I'm not
       // sure if use of auto_ptr here causes any troubles elsewhere.
       IndirectHolder() : BaseHolder<T>(), helper_( 0 ) { }
-      IndirectHolder(boost::shared_ptr<RefHolderBase> p);
+      IndirectHolder(std::shared_ptr<RefHolderBase> p);
       IndirectHolder(IndirectHolder const& other);
       IndirectHolder& operator= (IndirectHolder const& rhs);
       void swap(IndirectHolder& other);
@@ -64,10 +64,9 @@ namespace edm {
     //------------------------------------------------------------------
     // Implementation of IndirectHolder<T>
     //------------------------------------------------------------------
-
     template <typename T>
     inline
-    IndirectHolder<T>::IndirectHolder(boost::shared_ptr<RefHolderBase> p) :
+    IndirectHolder<T>::IndirectHolder(std::shared_ptr<RefHolderBase> p) :
       BaseHolder<T>(), helper_(p->clone()) 
     { }
 
@@ -188,7 +187,7 @@ namespace edm {
     template <typename T>
     std::auto_ptr<BaseVectorHolder<T> > IndirectHolder<T>::makeVectorHolder() const {
       std::auto_ptr<RefVectorHolderBase> p = helper_->makeVectorHolder();
-      boost::shared_ptr<RefVectorHolderBase> sp( p );
+      std::shared_ptr<RefVectorHolderBase> sp( p.release() );
       return std::auto_ptr<BaseVectorHolder<T> >( new IndirectVectorHolder<T>( sp ) );
     }
 

--- a/DataFormats/Common/interface/IndirectVectorHolder.h
+++ b/DataFormats/Common/interface/IndirectVectorHolder.h
@@ -5,6 +5,7 @@
 #include "DataFormats/Common/interface/RefVectorHolderBase.h"
 #include "DataFormats/Common/interface/IndirectHolder.h"
 #include <memory>
+#include "FWCore/Utilities/interface/HideStdSharedPtrFromRoot.h"
 
 namespace edm {
   namespace reftobase {
@@ -20,7 +21,7 @@ namespace edm {
 
       IndirectVectorHolder();
       IndirectVectorHolder( const IndirectVectorHolder & other);
-      IndirectVectorHolder(boost::shared_ptr<RefVectorHolderBase> p);
+      IndirectVectorHolder(std::shared_ptr<RefVectorHolderBase> p);
       IndirectVectorHolder(RefVectorHolderBase * p);
       virtual ~IndirectVectorHolder();
       IndirectVectorHolder& operator= (IndirectVectorHolder const& rhs);
@@ -105,7 +106,7 @@ namespace edm {
     IndirectVectorHolder<T>::IndirectVectorHolder() : BaseVectorHolder<T>(), helper_( 0 ) { }
 
     template <typename T>
-    IndirectVectorHolder<T>::IndirectVectorHolder(boost::shared_ptr<RefVectorHolderBase> p) :
+    IndirectVectorHolder<T>::IndirectVectorHolder(std::shared_ptr<RefVectorHolderBase> p) :
       BaseVectorHolder<T>(), helper_(p->clone()) { }
 
     template <typename T>

--- a/DataFormats/Common/interface/LazyGetter.h
+++ b/DataFormats/Common/interface/LazyGetter.h
@@ -5,7 +5,7 @@
 #include <vector>
 #include "boost/concept_check.hpp"
 #include "boost/iterator/transform_iterator.hpp"
-#include "boost/shared_ptr.hpp"
+#include <memory>
 #include "DataFormats/Common/interface/CMS_CLASS_VERSION.h"
 #include "DataFormats/Common/interface/traits.h"
 #include "DataFormats/Common/interface/Ref.h"
@@ -322,7 +322,7 @@ namespace edm {
     LazyGetter();
 
     /// Constructor with unpacker.
-    LazyGetter(uint32_t, const boost::shared_ptr< LazyUnpacker<T> >&);
+    LazyGetter(uint32_t, const std::shared_ptr< LazyUnpacker<T> >&);
 
     /// Returns the size of LazyUnpacker::register_.
     uint32_t regions() const;
@@ -375,7 +375,7 @@ namespace edm {
 
   private:
 
-    boost::shared_ptr< LazyUnpacker<T> > unpacker_;
+    std::shared_ptr< LazyUnpacker<T> > unpacker_;
     std::vector<T> record_;
     std::vector< RegionIndex<T> > register_;
   };
@@ -387,7 +387,7 @@ namespace edm {
 
   template <class T>
     inline
-    LazyGetter<T>::LazyGetter(uint32_t nregions,const boost::shared_ptr< LazyUnpacker<T> > & unpacker) : unpacker_(unpacker), record_(), register_()
+    LazyGetter<T>::LazyGetter(uint32_t nregions,const std::shared_ptr< LazyUnpacker<T> > & unpacker) : unpacker_(unpacker), record_(), register_()
     {
       //Reserve 100,000 to absorb event-by-event fluctuations.
       record_.reserve(100000);

--- a/DataFormats/Common/interface/MultiAssociation.h
+++ b/DataFormats/Common/interface/MultiAssociation.h
@@ -50,12 +50,13 @@
 
 #include <vector>
 #include <map>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <boost/utility.hpp>
 #include <boost/range.hpp>
 #include "DataFormats/Common/interface/CMS_CLASS_VERSION.h"
 #include "DataFormats/Provenance/interface/ProductID.h"
 #include "FWCore/Utilities/interface/GCC11Compatibility.h"
+#include "FWCore/Utilities/interface/HideStdSharedPtrFromRoot.h"
 
 namespace edm {
   namespace helper {
@@ -225,7 +226,7 @@ namespace edm {
         private:
             MultiAssociation &  assoc_;
             typedef edm::helper::IndexRangeAssociation::FastFiller IndexFiller;
-            boost::shared_ptr<IndexFiller> indexFiller_;
+            std::shared_ptr<IndexFiller> indexFiller_;
 
     }; // FastFiller
     friend class FastFiller;
@@ -269,7 +270,7 @@ namespace edm {
             MultiAssociation & assoc_;
             ProductID id_; 
             unsigned int size_;
-            boost::shared_ptr<TempValues> tempValues_;
+            std::shared_ptr<TempValues> tempValues_;
             bool fillOnExit_;
     }; // LazyFiller
     friend class LazyFiller;

--- a/DataFormats/Common/interface/OutputHandle.h
+++ b/DataFormats/Common/interface/OutputHandle.h
@@ -27,7 +27,7 @@ If failedToGet() returns false but isValid() is also false then no attempt
 #include "DataFormats/Common/interface/WrapperHolder.h"
 #include "DataFormats/Provenance/interface/ProductProvenance.h"
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 namespace cms {
   class Exception;
@@ -55,7 +55,7 @@ namespace edm {
       productProvenance_(productProvenance) {}
 
     ///Used when the attempt to get the data failed
-    OutputHandle(boost::shared_ptr<cms::Exception> const& iWhyFailed):
+    OutputHandle(std::shared_ptr<cms::Exception> const& iWhyFailed):
       product_(),
       desc_(0),
       productProvenance_(0),
@@ -94,7 +94,7 @@ namespace edm {
       return product_;
     }
 
-    boost::shared_ptr<cms::Exception> whyFailed() const {
+    std::shared_ptr<cms::Exception> whyFailed() const {
       return whyFailed_;
     }
 
@@ -110,7 +110,7 @@ namespace edm {
     WrapperHolder product_;
     BranchDescription const* desc_;
     ProductProvenance* productProvenance_;
-    boost::shared_ptr<cms::Exception> whyFailed_;
+    std::shared_ptr<cms::Exception> whyFailed_;
   };
 
   // Free swap function

--- a/DataFormats/Common/interface/ProductData.h
+++ b/DataFormats/Common/interface/ProductData.h
@@ -9,7 +9,7 @@ is the storage unit of such information.
 ----------------------------------------------------------------------*/
 
 #include "DataFormats/Provenance/interface/Provenance.h"
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 namespace edm {
   class BranchDescription;
@@ -17,7 +17,7 @@ namespace edm {
   struct ProductData {
     ProductData();
 
-    explicit ProductData(boost::shared_ptr<BranchDescription const> bd);
+    explicit ProductData(std::shared_ptr<BranchDescription const> bd);
 
     // For use by FWLite
     ProductData(void const* product, Provenance const& prov);
@@ -26,7 +26,7 @@ namespace edm {
       return prov_.product().getInterface();
     }
 
-    boost::shared_ptr<BranchDescription const> const& branchDescription() const {
+    std::shared_ptr<BranchDescription const> const& branchDescription() const {
       return prov_.constBranchDescriptionPtr();
     }
 
@@ -35,7 +35,7 @@ namespace edm {
        prov_.swap(other.prov_);
     }
 
-    void resetBranchDescription(boost::shared_ptr<BranchDescription const> bd);
+    void resetBranchDescription(std::shared_ptr<BranchDescription const> bd);
 
     void resetProductData() {
       wrapper_.reset();
@@ -47,7 +47,7 @@ namespace edm {
     // the effort to make the Framework multithread capable ...
 
     // "non-const data" (updated every event)
-    mutable boost::shared_ptr<void const> wrapper_;
+    mutable std::shared_ptr<void const> wrapper_;
     mutable Provenance prov_;
   };
 

--- a/DataFormats/Common/interface/RefToBase.h
+++ b/DataFormats/Common/interface/RefToBase.h
@@ -34,7 +34,7 @@ reference type.
 
 // user include files
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 #include "boost/static_assert.hpp"
 #include "boost/type_traits/is_base_of.hpp"
 
@@ -46,6 +46,7 @@ reference type.
 #include "DataFormats/Common/interface/Holder.h"
 #include "DataFormats/Common/interface/IndirectHolder.h"
 #include "DataFormats/Common/interface/RefHolder.h"
+#include "FWCore/Utilities/interface/HideStdSharedPtrFromRoot.h"
 
 namespace edm {
   //--------------------------------------------------------------------
@@ -78,7 +79,7 @@ namespace edm {
     RefToBase(Handle<View<T> > const& handle, size_t i);
     template <typename T1>
     explicit RefToBase(RefToBase<T1> const & r );
-    RefToBase(boost::shared_ptr<reftobase::RefHolderBase> p);
+    RefToBase(std::shared_ptr<reftobase::RefHolderBase> p);
     ~RefToBase();
 
     RefToBase& operator= (RefToBase const& rhs);
@@ -156,7 +157,7 @@ namespace edm {
   inline
   RefToBase<T>::RefToBase(RefToBase<T1> const& iRef) :
         holder_(new reftobase::IndirectHolder<T> (
-             boost::shared_ptr< edm::reftobase::RefHolderBase>(iRef.holder().release())
+             std::shared_ptr< edm::reftobase::RefHolderBase>(iRef.holder().release())
         ) )
   {
     // OUT: holder_( new reftobase::Holder<T,RefToBase<T1> >(iRef ) )  {
@@ -169,7 +170,7 @@ namespace edm {
 
   template <class T>
   inline
-  RefToBase<T>::RefToBase(boost::shared_ptr<reftobase::RefHolderBase> p) :
+  RefToBase<T>::RefToBase(std::shared_ptr<reftobase::RefHolderBase> p) :
     holder_(new reftobase::IndirectHolder<T>(p))
   { }
 

--- a/DataFormats/Common/interface/RefToBaseProd.h
+++ b/DataFormats/Common/interface/RefToBaseProd.h
@@ -13,6 +13,7 @@
 #include "DataFormats/Common/interface/RefCore.h"
 #include "DataFormats/Provenance/interface/ProductID.h"
 #include "DataFormats/Common/interface/ConstPtrCache.h"
+#include "DataFormats/Common/interface/FillView.h"
 
 namespace edm {
   template<typename T> class View;
@@ -234,7 +235,9 @@ namespace edm {
     typedef typename refhelper::RefToBaseProdTrait<C>::ref_vector_type ref_vector;
     typedef reftobase::RefVectorHolder<ref_vector> holder_type;
     helper_vector_ptr helpers(new holder_type);
+#ifndef __GCCXML__
     detail::reallyFillView(* ref.product(), ref.id(), pointers, * helpers);
+#endif
     product_.setProductPtr(new View<T>(pointers, helpers));
   }
 

--- a/DataFormats/Common/interface/RefToBaseVector.h
+++ b/DataFormats/Common/interface/RefToBaseVector.h
@@ -7,8 +7,9 @@
  */
 #include "DataFormats/Common/interface/CMS_CLASS_VERSION.h"
 #include "DataFormats/Provenance/interface/ProductID.h"
-#include "boost/shared_ptr.hpp"
+#include <memory>
 #include <vector>
+#include "FWCore/Utilities/interface/HideStdSharedPtrFromRoot.h"
 
 namespace edm {
   template<typename T> class RefToBase;
@@ -37,7 +38,7 @@ namespace edm {
     explicit RefToBaseVector(Handle<C> const& );
     template<typename T1>
     explicit RefToBaseVector(Handle<View<T1> > const& );
-    RefToBaseVector(boost::shared_ptr<reftobase::RefVectorHolderBase> p);
+    RefToBaseVector(std::shared_ptr<reftobase::RefVectorHolderBase> p);
     RefToBaseVector& operator=(RefToBaseVector const& iRHS);
     void swap(RefToBaseVector& other);
 
@@ -127,7 +128,7 @@ namespace edm {
 
   template <class T>
   inline
-  RefToBaseVector<T>::RefToBaseVector(boost::shared_ptr<reftobase::RefVectorHolderBase> p) : 
+  RefToBaseVector<T>::RefToBaseVector(std::shared_ptr<reftobase::RefVectorHolderBase> p) : 
     holder_(new reftobase::IndirectVectorHolder<T>(p)) {
   }
 

--- a/DataFormats/Common/interface/RefVectorHolder.h
+++ b/DataFormats/Common/interface/RefVectorHolder.h
@@ -5,6 +5,7 @@
 #include "DataFormats/Common/interface/RefVectorHolderBase.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "DataFormats/Provenance/interface/ProductID.h"
+#include "FWCore/Utilities/interface/HideStdSharedPtrFromRoot.h"
 
 namespace edm {
   namespace reftobase {
@@ -56,7 +57,7 @@ namespace edm {
 	bool equal_to(const_iterator_imp const* o) const { return i == dc(o); }
 	bool less_than(const_iterator_imp const* o) const { return i < dc(o); }
 	void assign(const_iterator_imp const* o) { i = dc(o); }
-	boost::shared_ptr<RefHolderBase> deref() const;
+	std::shared_ptr<RefHolderBase> deref() const;
 	difference_type difference(const_iterator_imp const* o) const { return i - dc(o); }
       private:
 	typename REFV::const_iterator const& dc(const_iterator_imp const* o) const {
@@ -91,7 +92,7 @@ namespace edm {
       virtual bool isAvailable() const { return refs_.isAvailable(); }
 
     private:
-      virtual boost::shared_ptr<reftobase::RefHolderBase> refBase(size_t idx) const;
+      virtual std::shared_ptr<reftobase::RefHolderBase> refBase(size_t idx) const;
       REFV refs_;
     };
 
@@ -205,16 +206,24 @@ namespace edm {
     }
 
     template <typename REFV>
-    boost::shared_ptr<RefHolderBase>
+    std::shared_ptr<RefHolderBase>
     RefVectorHolder<REFV>::refBase(size_t idx) const {
-      return boost::shared_ptr<RefHolderBase>(new RefHolder<typename REFV::value_type>(refs_[idx]));
+#ifdef __GCCXML__
+      return std::shared_ptr<RefHolderBase>(new RefHolder<typename REFV::value_type>(refs_[idx]));
+#else
+      return std::shared_ptr<RefHolderBase>(std::make_shared<RefHolder<typename REFV::value_type> >(refs_[idx]));
+#endif
     }
 
     template<typename REFV>
-    boost::shared_ptr<RefHolderBase> RefVectorHolder<REFV>::const_iterator_imp_specific::deref() const {
-      return boost::shared_ptr<RefHolderBase>(new RefHolder<typename REFV::value_type>(*i));
+    std::shared_ptr<RefHolderBase>
+    RefVectorHolder<REFV>::const_iterator_imp_specific::deref() const {
+#ifdef __GCCXML__
+      return std::shared_ptr<RefHolderBase>(new RefHolder<typename REFV::value_type>(*i));
+#else
+      return std::shared_ptr<RefHolderBase>(std::make_shared<RefHolder<typename REFV::value_type> >(*i));
+#endif
     }
-
   }
 }
 

--- a/DataFormats/Common/interface/RefVectorHolderBase.h
+++ b/DataFormats/Common/interface/RefVectorHolderBase.h
@@ -3,8 +3,9 @@
 
 #include "DataFormats/Common/interface/RefHolderBase.h"
 #include "FWCore/Utilities/interface/EDMException.h"
+#include "FWCore/Utilities/interface/HideStdSharedPtrFromRoot.h"
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 namespace edm {
   template<typename T> class RefToBase;
@@ -39,12 +40,12 @@ namespace edm {
         virtual bool equal_to(const_iterator_imp const*) const = 0;
         virtual bool less_than(const_iterator_imp const*) const = 0;
         virtual void assign(const_iterator_imp const*) = 0;
-        virtual boost::shared_ptr<RefHolderBase> deref() const = 0;
+        virtual std::shared_ptr<RefHolderBase> deref() const = 0;
         virtual difference_type difference(const_iterator_imp const*) const = 0;
       };
 
       struct const_iterator : public std::iterator <std::random_access_iterator_tag, void*>{
-        typedef boost::shared_ptr<RefHolderBase> value_type;
+        typedef std::shared_ptr<RefHolderBase> value_type;
         typedef std::ptrdiff_t difference_type;
         const_iterator() : i(0) { }
         const_iterator(const_iterator_imp* it) : i(it) { }
@@ -164,12 +165,12 @@ namespace edm {
       virtual bool isAvailable() const = 0;
 
     private:
-      virtual boost::shared_ptr<reftobase::RefHolderBase> refBase(size_t idx) const = 0;
+      virtual std::shared_ptr<reftobase::RefHolderBase> refBase(size_t idx) const = 0;
     };
 
     template<typename T>
     RefToBase<T> RefVectorHolderBase::getRef(size_t idx) const {
-      boost::shared_ptr<reftobase::RefHolderBase> rb = refBase(idx);
+      std::shared_ptr<reftobase::RefHolderBase> rb = refBase(idx);
       return RefToBase<T>(rb);
     }
 

--- a/DataFormats/Common/interface/Wrapper.h
+++ b/DataFormats/Common/interface/Wrapper.h
@@ -383,7 +383,7 @@ namespace edm {
           pointers.reserve(h->size());
           // NOTE: the following implementation has unusual signature!
           fillView(obj, pointers);
-          helpers = helper_vector_ptr(h);
+          helpers = helper_vector_ptr(h.release());
         }
       }
     };
@@ -399,7 +399,7 @@ namespace edm {
           pointers.reserve(obj.size());
           // NOTE: the following implementation has unusual signature!
           fillView(obj, pointers);
-          helpers = helper_vector_ptr(h);
+          helpers = helper_vector_ptr(h.release());
         }
       }
     };

--- a/DataFormats/Common/interface/WrapperOwningHolder.h
+++ b/DataFormats/Common/interface/WrapperOwningHolder.h
@@ -7,7 +7,8 @@
 
 #include "DataFormats/Common/interface/WrapperHolder.h"
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
+#include "FWCore/Utilities/interface/HideStdSharedPtrFromRoot.h"
 
 namespace edm {
   class WrapperOwningHolder : private WrapperHolder {
@@ -22,9 +23,9 @@ namespace edm {
 
     WrapperOwningHolder(void const* wrapper, WrapperInterfaceBase const* interface);
 
-    WrapperOwningHolder(boost::shared_ptr<void const> wrapper, WrapperInterfaceBase const* interface);
+    WrapperOwningHolder(std::shared_ptr<void const> wrapper, WrapperInterfaceBase const* interface);
 
-    boost::shared_ptr<void const> makeWrapper(void const* wrapper, WrapperInterfaceBase const* interface);
+    std::shared_ptr<void const> makeWrapper(void const* wrapper, WrapperInterfaceBase const* interface);
 
     using WrapperHolder::dynamicTypeInfo;
     using WrapperHolder::fillPtrVector;
@@ -40,7 +41,7 @@ namespace edm {
     using WrapperHolder::wrappedTypeInfo;
     using WrapperHolder::wrapper;
 
-    boost::shared_ptr<void const> product() const {
+    std::shared_ptr<void const> product() const {
       return wrapperOwner_;
     }
 
@@ -50,7 +51,7 @@ namespace edm {
     }
 
   private:  
-    boost::shared_ptr<void const> wrapperOwner_;
+    std::shared_ptr<void const> wrapperOwner_;
   };
 
 }

--- a/DataFormats/Common/src/ProductData.cc
+++ b/DataFormats/Common/src/ProductData.cc
@@ -11,7 +11,7 @@ namespace edm {
     prov_() {
   }
 
-  ProductData::ProductData(boost::shared_ptr<BranchDescription const> bd) :
+  ProductData::ProductData(std::shared_ptr<BranchDescription const> bd) :
     wrapper_(),
     prov_(bd, ProductID()) {
   }
@@ -23,7 +23,7 @@ namespace edm {
   }
 
   void
-  ProductData::resetBranchDescription(boost::shared_ptr<BranchDescription const> bd) {
+  ProductData::resetBranchDescription(std::shared_ptr<BranchDescription const> bd) {
     prov_.setBranchDescription(bd);
   }
 }

--- a/DataFormats/Common/src/WrapperOwningHolder.cc
+++ b/DataFormats/Common/src/WrapperOwningHolder.cc
@@ -10,7 +10,7 @@ namespace edm {
 
   WrapperOwningHolder::WrapperOwningHolder() : WrapperHolder(), wrapperOwner_() {}
 
-  WrapperOwningHolder::WrapperOwningHolder(boost::shared_ptr<void const> wrapper, WrapperInterfaceBase const* interface) :
+  WrapperOwningHolder::WrapperOwningHolder(std::shared_ptr<void const> wrapper, WrapperInterfaceBase const* interface) :
       WrapperHolder(wrapper.get(), interface), wrapperOwner_(wrapper) {
   }
 
@@ -19,9 +19,9 @@ namespace edm {
       wrapperOwner_(makeWrapper(wrapper, interface)) {
   }
 
-  boost::shared_ptr<void const>
+  std::shared_ptr<void const>
   WrapperOwningHolder::makeWrapper(void const* wrapper, WrapperInterfaceBase const* interface) {
-     return(boost::shared_ptr<void const>(wrapper, EDProductDeleter(interface)));
+     return(std::shared_ptr<void const>(wrapper, EDProductDeleter(interface)));
   }
 
 }

--- a/DataFormats/Common/test/DetSetLazyVector_t.cppunit.cc
+++ b/DataFormats/Common/test/DetSetLazyVector_t.cppunit.cc
@@ -79,7 +79,7 @@ testDetSetLazyVector::checkConstruction()
   c.insert(d1);
   c.post_insert();
 
-  boost::shared_ptr<edm::dslv::LazyGetter<Value> > getter(new TestGetter(c));
+  std::shared_ptr<edm::dslv::LazyGetter<Value> > getter = std::make_shared<TestGetter>(c);
   {
     std::vector<edm::det_id_type> ids;
     ids.push_back(1);
@@ -137,8 +137,7 @@ testDetSetLazyVector::checkFind()
   c.insert(d1);
   c.post_insert();
 
-  boost::shared_ptr<edm::dslv::LazyGetter<Value> > getter(new TestGetter(c));
-
+  std::shared_ptr<edm::dslv::LazyGetter<Value> > getter = std::make_shared<TestGetter>(c);
   {
     std::vector<edm::det_id_type> ids;
     ids.push_back(1);

--- a/DataFormats/Common/test/DetSetNew_t.cpp
+++ b/DataFormats/Common/test/DetSetNew_t.cpp
@@ -414,7 +414,7 @@ void TestDetSet::algorithm() {
 using namespace boost::assign;
 
 void TestDetSet::onDemand() {
-  boost::shared_ptr<Getter> pg(new Getter(this));
+  auto pg = std::make_shared<Getter>(this);
   Getter & g = *pg;
   std::vector<unsigned int> v; v+= 21,23,25,27;
   DSTV detsets(pg,v,2);

--- a/DataFormats/Common/test/SimpleEDProductGetter.h
+++ b/DataFormats/Common/test/SimpleEDProductGetter.h
@@ -1,8 +1,6 @@
 #ifndef DataFormats_Common_SimpleEDProductGetter_h
 #define DataFormats_Common_SimpleEDProductGetter_h
 
-#include "boost/shared_ptr.hpp"
-
 #include "DataFormats/Common/interface/WrapperHolder.h"
 #include "DataFormats/Common/interface/WrapperOwningHolder.h"
 #include "DataFormats/Common/interface/EDProductGetter.h"

--- a/DataFormats/FWLite/interface/ChainEvent.h
+++ b/DataFormats/FWLite/interface/ChainEvent.h
@@ -19,14 +19,15 @@
 //
 #if !defined(__CINT__) && !defined(__MAKECINT__)
 // system include files
+#include <memory>
 #include <string>
 #include <typeinfo>
 #include <vector>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "DataFormats/FWLite/interface/Event.h"
 #include "DataFormats/FWLite/interface/EventBase.h"
+#include "FWCore/Utilities/interface/HideStdSharedPtrFromRoot.h"
 
 // forward declarations
 namespace edm {
@@ -100,7 +101,7 @@ namespace fwlite {
       Long64_t eventIndex() const { return eventIndex_; }
       virtual Long64_t fileIndex() const { return eventIndex_; }
 
-      void setGetter(boost::shared_ptr<edm::EDProductGetter> getter){
+      void setGetter(std::shared_ptr<edm::EDProductGetter> getter){
          event_->setGetter(getter);
       }
 
@@ -131,11 +132,11 @@ namespace fwlite {
       void switchToFile(Long64_t);
       // ---------- member data --------------------------------
       std::vector<std::string> fileNames_;
-      boost::shared_ptr<TFile> file_;
-      boost::shared_ptr<Event> event_;
+      std::shared_ptr<TFile> file_;
+      std::shared_ptr<Event> event_;
       Long64_t eventIndex_;
       std::vector<Long64_t> accumulatedSize_;
-      boost::shared_ptr<edm::EDProductGetter> getter_;
+      std::shared_ptr<edm::EDProductGetter> getter_;
 
 };
 

--- a/DataFormats/FWLite/interface/DataGetterHelper.h
+++ b/DataFormats/FWLite/interface/DataGetterHelper.h
@@ -27,13 +27,13 @@
 #include "FWCore/FWLite/interface/BranchMapReader.h"
 
 // system include files
-#include "boost/shared_ptr.hpp"
-
 #include <cstring>
 #include <map>
 #include <memory>
 #include <typeinfo>
 #include <vector>
+
+#include "FWCore/Utilities/interface/HideStdSharedPtrFromRoot.h"
 
 // forward declarations
 class TTreeCache;
@@ -45,9 +45,9 @@ namespace fwlite {
         public:
 //            DataGetterHelper() {};
             DataGetterHelper(TTree* tree,
-                             boost::shared_ptr<HistoryGetterBase> historyGetter,
-                             boost::shared_ptr<BranchMapReader> branchMap = boost::shared_ptr<BranchMapReader>(),
-                             boost::shared_ptr<edm::EDProductGetter> getter = boost::shared_ptr<edm::EDProductGetter>(),
+                             std::shared_ptr<HistoryGetterBase> historyGetter,
+                             std::shared_ptr<BranchMapReader> branchMap = std::shared_ptr<BranchMapReader>(),
+                             std::shared_ptr<edm::EDProductGetter> getter = std::shared_ptr<edm::EDProductGetter>(),
                              bool useCache = false);
             virtual ~DataGetterHelper();
 
@@ -67,7 +67,7 @@ namespace fwlite {
 
             // ---------- member functions ---------------------------
 
-            void setGetter(boost::shared_ptr<edm::EDProductGetter> getter) {
+            void setGetter(std::shared_ptr<edm::EDProductGetter> getter) {
                 getter_ = getter;
             }
 
@@ -84,15 +84,15 @@ namespace fwlite {
 
             // ---------- member data --------------------------------
             TTree* tree_;
-            mutable boost::shared_ptr<BranchMapReader> branchMap_;
-            typedef std::map<internal::DataKey, boost::shared_ptr<internal::Data> > KeyToDataMap;
+            mutable std::shared_ptr<BranchMapReader> branchMap_;
+            typedef std::map<internal::DataKey, std::shared_ptr<internal::Data> > KeyToDataMap;
             mutable KeyToDataMap data_;
             mutable std::vector<char const*> labels_;
             const edm::ProcessHistory& history() const;
 
-            mutable std::map<std::pair<edm::ProductID, edm::BranchListIndex>,boost::shared_ptr<internal::Data> > idToData_;
-            boost::shared_ptr<fwlite::HistoryGetterBase> historyGetter_;
-            boost::shared_ptr<edm::EDProductGetter> getter_;
+            mutable std::map<std::pair<edm::ProductID, edm::BranchListIndex>,std::shared_ptr<internal::Data> > idToData_;
+            std::shared_ptr<fwlite::HistoryGetterBase> historyGetter_;
+            std::shared_ptr<edm::EDProductGetter> getter_;
             mutable bool tcTrained_;
     };
 

--- a/DataFormats/FWLite/interface/ESHandle.h
+++ b/DataFormats/FWLite/interface/ESHandle.h
@@ -19,18 +19,19 @@
 //
 
 // system include files
+#include <memory>
 #include <typeinfo>
 #include <vector>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/HideStdSharedPtrFromRoot.h"
 
 // forward declarations
 namespace fwlite {
    class Record;
    
-   boost::shared_ptr<cms::Exception> eshandle_not_set_exception();
+   std::shared_ptr<cms::Exception> eshandle_not_set_exception();
    
 template <class T>
 class ESHandle
@@ -77,7 +78,7 @@ class ESHandle
 
       // ---------- member data --------------------------------
       const T* m_data;
-      boost::shared_ptr<cms::Exception> m_exception;
+      std::shared_ptr<cms::Exception> m_exception;
 };
 
 }

--- a/DataFormats/FWLite/interface/Event.h
+++ b/DataFormats/FWLite/interface/Event.h
@@ -49,7 +49,6 @@
 #include <memory>
 #include <cstring>
 #include <string>
-#include "boost/shared_ptr.hpp"
 
 #include "Rtypes.h"
 
@@ -63,6 +62,7 @@
 #include "DataFormats/Provenance/interface/EventProcessHistoryID.h"
 #include "DataFormats/Provenance/interface/EventAuxiliary.h"
 #include "DataFormats/Provenance/interface/EventID.h"
+#include "FWCore/Utilities/interface/HideStdSharedPtrFromRoot.h"
 
 // forward declarations
 namespace edm {
@@ -172,15 +172,15 @@ namespace fwlite {
          edm::ProcessHistory const& history() const;
          void updateAux(Long_t eventIndex) const;
          void fillParameterSetRegistry() const;
-         void setGetter(boost::shared_ptr<edm::EDProductGetter> getter) { return dataHelper_.setGetter(getter);}
+         void setGetter(std::shared_ptr<edm::EDProductGetter> getter) { return dataHelper_.setGetter(getter);}
 
          // ---------- member data --------------------------------
          TFile* file_;
          // TTree* eventTree_;
          TTree* eventHistoryTree_;
          // Long64_t eventIndex_;
-         mutable boost::shared_ptr<fwlite::LuminosityBlock>  lumi_;
-         mutable boost::shared_ptr<fwlite::Run>  run_;
+         mutable std::shared_ptr<fwlite::LuminosityBlock>  lumi_;
+         mutable std::shared_ptr<fwlite::Run>  run_;
          mutable fwlite::BranchMapReader branchMap_;
 
          //takes ownership of the strings used by the DataKey keys in data_
@@ -197,7 +197,7 @@ namespace fwlite {
          mutable bool parameterSetRegistryFilled_;
 
          fwlite::DataGetterHelper dataHelper_;
-         mutable boost::shared_ptr<RunFactory> runFactory_;
+         mutable std::shared_ptr<RunFactory> runFactory_;
    };
 
 }

--- a/DataFormats/FWLite/interface/LuminosityBlock.h
+++ b/DataFormats/FWLite/interface/LuminosityBlock.h
@@ -24,7 +24,6 @@
 #include <vector>
 #include <memory>
 #include <cstring>
-#include "boost/shared_ptr.hpp"
 
 #include "Rtypes.h"
 
@@ -35,6 +34,7 @@
 #include "DataFormats/FWLite/interface/EntryFinder.h"
 #include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
 #include "DataFormats/Provenance/interface/LuminosityBlockAuxiliary.h"
+#include "FWCore/Utilities/interface/HideStdSharedPtrFromRoot.h"
 
 // forward declarations
 namespace edm {
@@ -62,7 +62,7 @@ namespace fwlite {
          // NOTE: Does NOT take ownership so iFile must remain around
          // at least as long as LuminosityBlock
          LuminosityBlock(TFile* iFile);
-         LuminosityBlock(boost::shared_ptr<BranchMapReader> branchMap,  boost::shared_ptr<RunFactory> runFactory);
+         LuminosityBlock(std::shared_ptr<BranchMapReader> branchMap,  std::shared_ptr<RunFactory> runFactory);
          virtual ~LuminosityBlock();
 
          const LuminosityBlock& operator++();
@@ -120,9 +120,9 @@ namespace fwlite {
 
 
          // ---------- member data --------------------------------
-         mutable boost::shared_ptr<BranchMapReader> branchMap_;
+         mutable std::shared_ptr<BranchMapReader> branchMap_;
 
-         mutable boost::shared_ptr<fwlite::Run>  run_;
+         mutable std::shared_ptr<fwlite::Run>  run_;
 
          //takes ownership of the strings used by the DataKey keys in data_
          mutable std::vector<char const*> labels_;
@@ -136,7 +136,7 @@ namespace fwlite {
          int fileVersion_;
 
          DataGetterHelper dataHelper_;
-         mutable boost::shared_ptr<RunFactory> runFactory_;
+         mutable std::shared_ptr<RunFactory> runFactory_;
    };
 
 }

--- a/DataFormats/FWLite/interface/MultiChainEvent.h
+++ b/DataFormats/FWLite/interface/MultiChainEvent.h
@@ -19,14 +19,15 @@
 //
 #if !defined(__CINT__) && !defined(__MAKECINT__)
 // system include files
+#include <memory>
 #include <string>
 #include <typeinfo>
 #include <vector>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "DataFormats/FWLite/interface/EventBase.h"
 #include "DataFormats/FWLite/interface/ChainEvent.h"
+#include "FWCore/Utilities/interface/HideStdSharedPtrFromRoot.h"
 
 // forward declarations
 namespace edm {
@@ -153,9 +154,9 @@ class MultiChainEvent: public EventBase
 
       // ---------- member data --------------------------------
 
-      boost::shared_ptr<ChainEvent> event1_;  // primary files
-      boost::shared_ptr<ChainEvent> event2_;  // secondary files
-      boost::shared_ptr<internal::MultiProductGetter> getter_;
+      std::shared_ptr<ChainEvent> event1_;  // primary files
+      std::shared_ptr<ChainEvent> event2_;  // secondary files
+      std::shared_ptr<internal::MultiProductGetter> getter_;
 
       // speed up secondary file access with a (run range)_1 ---> index_2 map,
       // when the files are sorted by run,event within the file.

--- a/DataFormats/FWLite/interface/Run.h
+++ b/DataFormats/FWLite/interface/Run.h
@@ -24,7 +24,6 @@
 #include <vector>
 #include <memory>
 #include <cstring>
-#include "boost/shared_ptr.hpp"
 
 #include "Rtypes.h"
 
@@ -37,6 +36,7 @@
 #include "DataFormats/Provenance/interface/RunID.h"
 #include "FWCore/FWLite/interface/BranchMapReader.h"
 #include "DataFormats/FWLite/interface/DataGetterHelper.h"
+#include "FWCore/Utilities/interface/HideStdSharedPtrFromRoot.h"
 
 // forward declarations
 namespace edm {
@@ -59,7 +59,7 @@ namespace fwlite {
          // NOTE: Does NOT take ownership so iFile must remain around
          // at least as long as Run
          Run(TFile* iFile);
-         Run(boost::shared_ptr<BranchMapReader> branchMap);
+         Run(std::shared_ptr<BranchMapReader> branchMap);
          virtual ~Run();
 
          const Run& operator++();
@@ -115,7 +115,7 @@ namespace fwlite {
          void updateAux(Long_t runIndex) const;
 
          // ---------- member data --------------------------------
-         mutable boost::shared_ptr<BranchMapReader> branchMap_;
+         mutable std::shared_ptr<BranchMapReader> branchMap_;
 
          //takes ownership of the strings used by the DataKey keys in data_
          mutable std::vector<char const*> labels_;

--- a/DataFormats/FWLite/interface/RunFactory.h
+++ b/DataFormats/FWLite/interface/RunFactory.h
@@ -17,11 +17,13 @@
 // Original Author:
 //         Created:  Wed Feb 10 11:15:16 CST 2010
 //
+
 #if !defined(__CINT__) && !defined(__MAKECINT__)
 
-#include "DataFormats/FWLite/interface/Run.h"
+#include <memory>
 
-#include "boost/shared_ptr.hpp"
+#include "DataFormats/FWLite/interface/Run.h"
+#include "FWCore/Utilities/interface/HideStdSharedPtrFromRoot.h"
 
 namespace fwlite {
     class RunFactory {
@@ -30,13 +32,13 @@ namespace fwlite {
             virtual ~RunFactory();
 
             // ---------- const member functions ---------------------
-            boost::shared_ptr<fwlite::Run> makeRun(boost::shared_ptr<BranchMapReader> branchMap) const;
+            std::shared_ptr<fwlite::Run> makeRun(std::shared_ptr<BranchMapReader> branchMap) const;
 
         private:
             RunFactory(const RunFactory&); // stop default
 
             const RunFactory& operator=(const RunFactory&); // stop default
-            mutable boost::shared_ptr<fwlite::Run> run_;
+            mutable std::shared_ptr<fwlite::Run> run_;
 
 
             // ---------- member data --------------------------------

--- a/DataFormats/FWLite/src/ChainEvent.cc
+++ b/DataFormats/FWLite/src/ChainEvent.cc
@@ -47,7 +47,7 @@ ChainEvent::ChainEvent(std::vector<std::string> const& iFileNames):
       it!=itEnd;
       ++it) {
     TFile *tfilePtr = TFile::Open(it->c_str());
-    file_ = boost::shared_ptr<TFile>(tfilePtr);
+    file_ = std::shared_ptr<TFile>(tfilePtr);
     gROOT->GetListOfFiles()->Remove(tfilePtr);
     TTree* tree = dynamic_cast<TTree*>(file_->Get(edm::poolNames::eventTreeName().c_str()));
     if (0 == tree) {
@@ -212,9 +212,9 @@ ChainEvent::switchToFile(Long64_t iIndex)
 {
   eventIndex_= iIndex;
   TFile *tfilePtr = TFile::Open(fileNames_[iIndex].c_str());
-  file_ = boost::shared_ptr<TFile>(tfilePtr);
+  file_ = std::shared_ptr<TFile>(tfilePtr);
   gROOT->GetListOfFiles()->Remove(tfilePtr);
-  event_ = boost::shared_ptr<Event>(new Event(file_.get()));
+  event_ = std::shared_ptr<Event>(new Event(file_.get()));
 }
 
 //

--- a/DataFormats/FWLite/src/DataGetterHelper.cc
+++ b/DataFormats/FWLite/src/DataGetterHelper.cc
@@ -37,7 +37,7 @@ namespace fwlite {
     //
     // static data member definitions
     //
-    typedef std::map<internal::DataKey, boost::shared_ptr<internal::Data> > DataMap;
+    typedef std::map<internal::DataKey, std::shared_ptr<internal::Data> > DataMap;
     // empty object used to signal that the branch requested was not found
     static internal::Data branchNotFound;
 
@@ -45,9 +45,9 @@ namespace fwlite {
     // constructors and destructor
     //
     DataGetterHelper::DataGetterHelper(TTree* tree,
-                                       boost::shared_ptr<HistoryGetterBase> historyGetter,
-                                       boost::shared_ptr<BranchMapReader> branchMap,
-                                       boost::shared_ptr<edm::EDProductGetter> getter,
+                                       std::shared_ptr<HistoryGetterBase> historyGetter,
+                                       std::shared_ptr<BranchMapReader> branchMap,
+                                       std::shared_ptr<edm::EDProductGetter> getter,
                                        bool useCache):
         branchMap_(branchMap),
         historyGetter_(historyGetter),
@@ -154,7 +154,7 @@ namespace fwlite {
         edm::TypeID type(iInfo);
         internal::DataKey key(type, iModuleLabel, iProductInstanceLabel, iProcessLabel);
 
-        boost::shared_ptr<internal::Data> theData;
+        std::shared_ptr<internal::Data> theData;
         DataMap::iterator itFind = data_.find(key);
         if(itFind == data_.end()) {
             //see if such a branch actually exists
@@ -242,7 +242,7 @@ namespace fwlite {
                 if(obj.address() == 0) {
                     throw cms::Exception("ConstructionFailed") << "failed to construct an instance of " << type.name();
                 }
-                boost::shared_ptr<internal::Data> newData(new internal::Data());
+                std::shared_ptr<internal::Data> newData(new internal::Data());
                 newData->branch_ = branch;
                 newData->obj_ = obj;
                 newData->lastProduct_=-1;
@@ -337,7 +337,7 @@ namespace fwlite {
     {
         typedef std::pair<edm::ProductID,edm::BranchListIndex> IDPair;
         IDPair theID = std::make_pair(iID, branchMap_->branchListIndexes()[iID.processIndex()-1]);
-        std::map<IDPair,boost::shared_ptr<internal::Data> >::const_iterator itFound = idToData_.find(theID);
+        std::map<IDPair,std::shared_ptr<internal::Data> >::const_iterator itFound = idToData_.find(theID);
 
         if(itFound == idToData_.end()) {
             edm::BranchDescription const& bDesc = branchMap_->productToBranch(iID);

--- a/DataFormats/FWLite/src/ESHandle.cc
+++ b/DataFormats/FWLite/src/ESHandle.cc
@@ -25,7 +25,7 @@ static cms::Exception s_exc("ESHandleUnset", "The ESHandle is being accessed wit
 static void doNotDelete(cms::Exception*) {}
 
 namespace fwlite {
-   boost::shared_ptr<cms::Exception> eshandle_not_set_exception() {
-      return boost::shared_ptr<cms::Exception>(&s_exc, doNotDelete);
+   std::shared_ptr<cms::Exception> eshandle_not_set_exception() {
+      return std::shared_ptr<cms::Exception>(&s_exc, doNotDelete);
    }   
 }

--- a/DataFormats/FWLite/src/EntryFinder.cc
+++ b/DataFormats/FWLite/src/EntryFinder.cc
@@ -126,7 +126,7 @@ namespace fwlite {
         }
 
         indexIntoFile_.setNumberOfEvents(auxBranch->GetEntries());
-        indexIntoFile_.setEventFinder(boost::shared_ptr<edm::IndexIntoFile::EventFinder>(new FWLiteEventFinder(auxBranch)));
+        indexIntoFile_.setEventFinder(std::shared_ptr<edm::IndexIntoFile::EventFinder>(std::make_shared<FWLiteEventFinder>(auxBranch)));
 
       } else if (meta->FindBranch(edm::poolNames::fileIndexBranchName().c_str()) != 0) {
         edm::FileIndex* findexPtr = &fileIndex_;

--- a/DataFormats/FWLite/src/Event.cc
+++ b/DataFormats/FWLite/src/Event.cc
@@ -90,9 +90,9 @@ namespace fwlite {
   fileVersion_(-1),
   parameterSetRegistryFilled_(false),
   dataHelper_(branchMap_.getEventTree(),
-              boost::shared_ptr<HistoryGetterBase>(new EventHistoryGetter(this)),
-              boost::shared_ptr<BranchMapReader>(&branchMap_,NoDelete()),
-              boost::shared_ptr<edm::EDProductGetter>(new internal::ProductGetter(this)),
+              std::shared_ptr<HistoryGetterBase>(new EventHistoryGetter(this)),
+              std::shared_ptr<BranchMapReader>(&branchMap_,NoDelete()),
+              std::shared_ptr<edm::EDProductGetter>(new internal::ProductGetter(this)),
               true) {
     if(0 == iFile) {
       throw cms::Exception("NoFile") << "The TFile pointer passed to the constructor was null";
@@ -130,7 +130,7 @@ namespace fwlite {
     if(fileVersion_ >= 7 && fileVersion_ < 17) {
       eventHistoryTree_ = dynamic_cast<TTree*>(iFile->Get(edm::poolNames::eventHistoryTreeName().c_str()));
     }
-    runFactory_ =  boost::shared_ptr<RunFactory>(new RunFactory());
+    runFactory_ =  std::shared_ptr<RunFactory>(new RunFactory());
 
 }
 
@@ -500,8 +500,8 @@ Event::throwProductNotFoundException(std::type_info const& iType, char const* iM
 fwlite::LuminosityBlock const& Event::getLuminosityBlock() const {
   if (not lumi_) {
     // Branch map pointer not really being shared, owned by event, have to trick Lumi
-    lumi_ = boost::shared_ptr<fwlite::LuminosityBlock> (
-             new fwlite::LuminosityBlock(boost::shared_ptr<BranchMapReader>(&branchMap_,NoDelete()),
+    lumi_ = std::shared_ptr<fwlite::LuminosityBlock> (
+             new fwlite::LuminosityBlock(std::shared_ptr<BranchMapReader>(&branchMap_,NoDelete()),
              runFactory_)
           );
   }
@@ -512,7 +512,7 @@ fwlite::LuminosityBlock const& Event::getLuminosityBlock() const {
 }
 
 fwlite::Run const& Event::getRun() const {
-  run_ = runFactory_->makeRun(boost::shared_ptr<BranchMapReader>(&branchMap_,NoDelete()));
+  run_ = runFactory_->makeRun(std::shared_ptr<BranchMapReader>(&branchMap_,NoDelete()));
   edm::RunNumber_t run = eventAuxiliary().run();
   run_->to(run);
   return *run_;

--- a/DataFormats/FWLite/src/EventBase.cc
+++ b/DataFormats/FWLite/src/EventBase.cc
@@ -23,7 +23,7 @@
 
 static const edm::ProductID s_id;
 static edm::BranchDescription const s_branch = edm::BranchDescription(edm::BranchDescription());
-static const edm::Provenance s_prov(boost::shared_ptr<edm::BranchDescription const>(&s_branch, edm::do_nothing_deleter()), s_id);
+static const edm::Provenance s_prov(std::shared_ptr<edm::BranchDescription const>(&s_branch, edm::do_nothing_deleter()), s_id);
 
 namespace fwlite
 {

--- a/DataFormats/FWLite/src/LuminosityBlock.cc
+++ b/DataFormats/FWLite/src/LuminosityBlock.cc
@@ -48,7 +48,7 @@ namespace fwlite {
     pOldAux_(0),
     fileVersion_(-1),
     dataHelper_(branchMap_->getLuminosityBlockTree(),
-                boost::shared_ptr<HistoryGetterBase>(new LumiHistoryGetter(this)),
+                std::shared_ptr<HistoryGetterBase>(new LumiHistoryGetter(this)),
                 branchMap_)
   {
     if(0==iFile) {
@@ -85,16 +85,16 @@ namespace fwlite {
 //       auxBranch_->SetAddress(&pOldAux_);
     }
     branchMap_->updateLuminosityBlock(0);
-    runFactory_ =  boost::shared_ptr<RunFactory>(new RunFactory());
+    runFactory_ =  std::shared_ptr<RunFactory>(new RunFactory());
 }
 
-  LuminosityBlock::LuminosityBlock(boost::shared_ptr<BranchMapReader> branchMap, boost::shared_ptr<RunFactory> runFactory):
+  LuminosityBlock::LuminosityBlock(std::shared_ptr<BranchMapReader> branchMap, std::shared_ptr<RunFactory> runFactory):
     branchMap_(branchMap),
     pAux_(&aux_),
     pOldAux_(0),
     fileVersion_(-1),
     dataHelper_(branchMap_->getLuminosityBlockTree(),
-                boost::shared_ptr<HistoryGetterBase>(new LumiHistoryGetter(this)),
+                std::shared_ptr<HistoryGetterBase>(new LumiHistoryGetter(this)),
                 branchMap_),
     runFactory_(runFactory)
   {
@@ -356,7 +356,7 @@ namespace {
 }
 
 fwlite::Run const& LuminosityBlock::getRun() const {
-  run_ = runFactory_->makeRun(boost::shared_ptr<BranchMapReader>(&*branchMap_,NoDelete()));
+  run_ = runFactory_->makeRun(std::shared_ptr<BranchMapReader>(&*branchMap_,NoDelete()));
   edm::RunNumber_t run = luminosityBlockAuxiliary().run();
   run_->to(run);
   return *run_;

--- a/DataFormats/FWLite/src/LuminosityBlockBase.cc
+++ b/DataFormats/FWLite/src/LuminosityBlockBase.cc
@@ -28,7 +28,7 @@
 
 static const edm::ProductID s_id;
 static edm::BranchDescription const s_branch = edm::BranchDescription(edm::BranchDescription());
-static const edm::Provenance s_prov(boost::shared_ptr<edm::BranchDescription const>(&s_branch, edm::do_nothing_deleter()), s_id);
+static const edm::Provenance s_prov(std::shared_ptr<edm::BranchDescription const>(&s_branch, edm::do_nothing_deleter()), s_id);
 
 namespace fwlite
 {

--- a/DataFormats/FWLite/src/MultiChainEvent.cc
+++ b/DataFormats/FWLite/src/MultiChainEvent.cc
@@ -59,10 +59,10 @@ private:
 				   std::vector<std::string> const& iFileNames2,
 				   bool useSecFileMapSorted)
 {
-  event1_ = boost::shared_ptr<ChainEvent> (new ChainEvent(iFileNames1));
-  event2_ = boost::shared_ptr<ChainEvent> (new ChainEvent(iFileNames2));
+  event1_ = std::shared_ptr<ChainEvent> (new ChainEvent(iFileNames1));
+  event2_ = std::shared_ptr<ChainEvent> (new ChainEvent(iFileNames2));
 
-  getter_ = boost::shared_ptr<internal::MultiProductGetter>(new internal::MultiProductGetter(this));
+  getter_ = std::shared_ptr<internal::MultiProductGetter>(new internal::MultiProductGetter(this));
 
   event1_->setGetter(getter_);
   event2_->setGetter(getter_);

--- a/DataFormats/FWLite/src/Run.cc
+++ b/DataFormats/FWLite/src/Run.cc
@@ -47,7 +47,7 @@ namespace fwlite {
     pOldAux_(0),
     fileVersion_(-1),
     dataHelper_(branchMap_->getRunTree(),
-                boost::shared_ptr<HistoryGetterBase>(new RunHistoryGetter(this)),
+                std::shared_ptr<HistoryGetterBase>(new RunHistoryGetter(this)),
                 branchMap_)
   {
     if(0==iFile) {
@@ -84,16 +84,16 @@ namespace fwlite {
 //       auxBranch_->SetAddress(&pOldAux_);
     }
     branchMap_->updateRun(0);
-//     getter_ = boost::shared_ptr<edm::EDProductGetter>(new ProductGetter(this));
+//     getter_ = std::shared_ptr<edm::EDProductGetter>(new ProductGetter(this));
 }
 
-  Run::Run(boost::shared_ptr<BranchMapReader> branchMap):
+  Run::Run(std::shared_ptr<BranchMapReader> branchMap):
     branchMap_(branchMap),
     pAux_(&aux_),
     pOldAux_(0),
     fileVersion_(-1),
     dataHelper_(branchMap_->getRunTree(),
-                boost::shared_ptr<HistoryGetterBase>(new RunHistoryGetter(this)),
+                std::shared_ptr<HistoryGetterBase>(new RunHistoryGetter(this)),
                 branchMap_)
   {
     if(0==branchMap_->getRunTree()) {
@@ -129,7 +129,7 @@ namespace fwlite {
 //       eventHistoryTree_ = dynamic_cast<TTree*>(iFile->Get(edm::poolNames::eventHistoryTreeName().c_str()));
 //     }
 
-//     getter_ = boost::shared_ptr<edm::EDProductGetter>(new ProductGetter(this));
+//     getter_ = std::shared_ptr<edm::EDProductGetter>(new ProductGetter(this));
 }
 
 Run::~Run()

--- a/DataFormats/FWLite/src/RunBase.cc
+++ b/DataFormats/FWLite/src/RunBase.cc
@@ -28,7 +28,7 @@
 
 static const edm::ProductID s_id;
 static edm::BranchDescription const s_branch = edm::BranchDescription(edm::BranchDescription());
-static const edm::Provenance s_prov(boost::shared_ptr<edm::BranchDescription const>(&s_branch, edm::do_nothing_deleter()), s_id);
+static const edm::Provenance s_prov(std::shared_ptr<edm::BranchDescription const>(&s_branch, edm::do_nothing_deleter()), s_id);
 
 namespace fwlite
 {

--- a/DataFormats/FWLite/src/RunFactory.cc
+++ b/DataFormats/FWLite/src/RunFactory.cc
@@ -23,9 +23,9 @@ namespace fwlite {
     RunFactory::RunFactory() {}
     RunFactory::~RunFactory() {}
 
-    boost::shared_ptr<fwlite::Run> RunFactory::makeRun(boost::shared_ptr<BranchMapReader> branchMap) const {
+    std::shared_ptr<fwlite::Run> RunFactory::makeRun(std::shared_ptr<BranchMapReader> branchMap) const {
         if (not run_) {
-            run_ = boost::shared_ptr<fwlite::Run>(new fwlite::Run(branchMap));
+            run_ = std::shared_ptr<fwlite::Run>(new fwlite::Run(branchMap));
         }
         return run_;
     }

--- a/DataFormats/FWLite/src/classes_def.xml
+++ b/DataFormats/FWLite/src/classes_def.xml
@@ -2,28 +2,18 @@
   <class name="fwlite::EventBase" ClassVersion="10">
    <version ClassVersion="10" checksum="446550501"/>
   </class>
-  <class name="fwlite::Event" ClassVersion="10">
-   <version ClassVersion="10" checksum="4235158529"/>
-  </class>
-  <class name="fwlite::ChainEvent" ClassVersion="10">
-   <version ClassVersion="10" checksum="3186044134"/>
-  </class>
-  <class name="fwlite::MultiChainEvent" ClassVersion="10">
-   <version ClassVersion="10" checksum="1750442807"/>
-  </class>
+  <class name="fwlite::Event" ClassVersion="0"/>
+  <class name="fwlite::ChainEvent" ClassVersion="0"/>
+  <class name="fwlite::MultiChainEvent" ClassVersion="0"/>
   <class name="fwlite::ErrorThrower" ClassVersion="10">
    <version ClassVersion="10" checksum="730281206"/>
   </class>
   <class name="fwlite::LuminosityBlockBase" ClassVersion="10">
    <version ClassVersion="10" checksum="3045691697"/>
   </class>
-  <class name="fwlite::LuminosityBlock" ClassVersion="10">
-   <version ClassVersion="10" checksum="2000450836"/>
-  </class>
+  <class name="fwlite::LuminosityBlock" ClassVersion="0"/>
   <class name="fwlite::RunBase" ClassVersion="10">
    <version ClassVersion="10" checksum="3966228119"/>
   </class>
-  <class name="fwlite::Run" ClassVersion="10">
-   <version ClassVersion="10" checksum="1215046249"/>
-  </class>
+  <class name="fwlite::Run" ClassVersion="0"/>
 </lcgdict>

--- a/DataFormats/Provenance/interface/IndexIntoFile.h
+++ b/DataFormats/Provenance/interface/IndexIntoFile.h
@@ -170,13 +170,15 @@ The interface is too complex for general use.
 #include "DataFormats/Provenance/interface/RunID.h"
 #include "FWCore/Utilities/interface/value_ptr.h"
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 #include <cassert>
 #include <iosfwd>
 #include <map>
 #include <set>
 #include <vector>
+
+#include "FWCore/Utilities/interface/HideStdSharedPtrFromRoot.h"
 
 namespace edm {
 
@@ -920,7 +922,7 @@ namespace edm {
       /// This implies the client needs to define a class that inherits from
       /// EventFinder and then create one.  This function is used to pass in a
       /// pointer to its base class.
-      void setEventFinder(boost::shared_ptr<EventFinder> ptr) const {transient_.eventFinder_ = ptr;}
+      void setEventFinder(std::shared_ptr<EventFinder> ptr) const {transient_.eventFinder_ = ptr;}
 
       /// Fills a vector of 4 byte event numbers.
       /// Not filling it reduces the memory used by IndexIntoFile.
@@ -1009,7 +1011,7 @@ namespace edm {
         RunNumber_t currentRun_;
         LuminosityBlockNumber_t currentLumi_;
         EntryNumber_t numberOfEvents_;
-        boost::shared_ptr<EventFinder> eventFinder_;
+        std::shared_ptr<EventFinder> eventFinder_;
         std::vector<RunOrLumiIndexes> runOrLumiIndexes_;
         std::vector<EventNumber_t> eventNumbers_;
         std::vector<EventEntry> eventEntries_;

--- a/DataFormats/Provenance/interface/ProductProvenance.h
+++ b/DataFormats/Provenance/interface/ProductProvenance.h
@@ -10,8 +10,9 @@ and how it came into existence.
 #include "DataFormats/Provenance/interface/BranchID.h"
 #include "DataFormats/Provenance/interface/ParentageID.h"
 #include "DataFormats/Provenance/interface/ProvenanceFwd.h"
+#include "FWCore/Utilities/interface/HideStdSharedPtrFromRoot.h"
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 #include <iosfwd>
 #include <vector>
@@ -26,7 +27,7 @@ namespace edm {
     ProductProvenance();
     explicit ProductProvenance(BranchID const& bid);
     ProductProvenance(BranchID const& bid,
-                      boost::shared_ptr<Parentage> parentagePtr);
+                      std::shared_ptr<Parentage> parentagePtr);
     ProductProvenance(BranchID const& bid,
                       ParentageID const& id);
 
@@ -50,13 +51,13 @@ namespace edm {
     struct Transients {
       Transients();
       void reset();
-      boost::shared_ptr<Parentage> parentagePtr_;
+      std::shared_ptr<Parentage> parentagePtr_;
       bool noParentage_;
     };
 
   private:
 
-    boost::shared_ptr<Parentage>& parentagePtr() const {return transient_.parentagePtr_;}
+    std::shared_ptr<Parentage>& parentagePtr() const {return transient_.parentagePtr_;}
 
     BranchID branchID_;
     ParentageID parentageID_;

--- a/DataFormats/Provenance/interface/ProductProvenanceRetriever.h
+++ b/DataFormats/Provenance/interface/ProductProvenanceRetriever.h
@@ -11,12 +11,12 @@ ProductProvenanceRetriever: Manages the per event/lumi/run per product provenanc
 #include "DataFormats/Provenance/interface/ProcessHistoryID.h"
 
 #include "boost/scoped_ptr.hpp"
-#include "boost/shared_ptr.hpp"
 #include "boost/utility.hpp"
 
 #include <iosfwd>
 #include <memory>
 #include <set>
+#include "FWCore/Utilities/interface/HideStdSharedPtrFromRoot.h"
 
 /*
   ProductProvenanceRetriever
@@ -38,7 +38,7 @@ namespace edm {
 
     void insertIntoSet(ProductProvenance const& provenanceProduct) const;
 
-    void mergeProvenanceRetrievers(boost::shared_ptr<ProductProvenanceRetriever> other);
+    void mergeProvenanceRetrievers(std::shared_ptr<ProductProvenanceRetriever> other);
 
     void deepSwap(ProductProvenanceRetriever&);
     
@@ -52,8 +52,8 @@ namespace edm {
     typedef std::set<ProductProvenance> eiSet;
 
     mutable eiSet entryInfoSet_;
-    boost::shared_ptr<ProductProvenanceRetriever> nextRetriever_;
-    mutable boost::shared_ptr<ProvenanceReaderBase> provenanceReader_;
+    std::shared_ptr<ProductProvenanceRetriever> nextRetriever_;
+    mutable std::shared_ptr<ProvenanceReaderBase> provenanceReader_;
     unsigned int transitionIndex_;
     mutable bool delayedRead_;
   };

--- a/DataFormats/Provenance/interface/ProductRegistry.h
+++ b/DataFormats/Provenance/interface/ProductRegistry.h
@@ -15,12 +15,13 @@
 #include "FWCore/Utilities/interface/ProductHolderIndex.h"
 
 #include "boost/array.hpp"
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 #include <iosfwd>
 #include <map>
 #include <string>
 #include <vector>
+#include "FWCore/Utilities/interface/HideStdSharedPtrFromRoot.h"
 
 namespace edm {
   class ProductHolderIndexHelper;
@@ -101,7 +102,7 @@ namespace edm {
        return transient_.constProductList_;
     }
 
-    boost::shared_ptr<ProductHolderIndexHelper> const& productLookup(BranchType branchType) const;
+    std::shared_ptr<ProductHolderIndexHelper> const& productLookup(BranchType branchType) const;
 
     // returns the appropriate ProductHolderIndex else ProductHolderIndexInvalid if no BranchID is available
     ProductHolderIndex indexFrom(BranchID const& iID) const;
@@ -132,9 +133,9 @@ namespace edm {
       boost::array<bool, NumBranchTypes> productProduced_;
       bool anyProductProduced_;
 
-      boost::shared_ptr<ProductHolderIndexHelper> eventProductLookup_;
-      boost::shared_ptr<ProductHolderIndexHelper> lumiProductLookup_;
-      boost::shared_ptr<ProductHolderIndexHelper> runProductLookup_;
+      std::shared_ptr<ProductHolderIndexHelper> eventProductLookup_;
+      std::shared_ptr<ProductHolderIndexHelper> lumiProductLookup_;
+      std::shared_ptr<ProductHolderIndexHelper> runProductLookup_;
 
       ProductHolderIndex eventNextIndexValue_;
       ProductHolderIndex lumiNextIndexValue_;

--- a/DataFormats/Provenance/interface/Provenance.h
+++ b/DataFormats/Provenance/interface/Provenance.h
@@ -16,9 +16,10 @@ existence.
 #include "DataFormats/Provenance/interface/ProductID.h"
 #include "DataFormats/Provenance/interface/ReleaseVersion.h"
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 #include <iosfwd>
+#include "FWCore/Utilities/interface/HideStdSharedPtrFromRoot.h"
 /*
   Provenance
 
@@ -36,14 +37,14 @@ namespace edm {
   public:
     Provenance();
 
-    Provenance(boost::shared_ptr<BranchDescription const> const& p, ProductID const& pid);
+    Provenance(std::shared_ptr<BranchDescription const> const& p, ProductID const& pid);
 
     Parentage const& event() const {return parentage();}
     BranchDescription const& product() const {return *branchDescription_;}
 
     BranchDescription const& branchDescription() const {return *branchDescription_;}
     BranchDescription const& constBranchDescription() const {return *branchDescription_;}
-    boost::shared_ptr<BranchDescription const> const& constBranchDescriptionPtr() const {return branchDescription_;}
+    std::shared_ptr<BranchDescription const> const& constBranchDescriptionPtr() const {return branchDescription_;}
 
     ProductProvenance* resolve() const;
     ProductProvenance* productProvenance() const {
@@ -61,7 +62,7 @@ namespace edm {
     std::string const& processName() const {return product().processName();}
     std::string const& productInstanceName() const {return product().productInstanceName();}
     std::string const& friendlyClassName() const {return product().friendlyClassName();}
-    boost::shared_ptr<ProductProvenanceRetriever> const& store() const {return store_;}
+    std::shared_ptr<ProductProvenanceRetriever> const& store() const {return store_;}
     ProcessHistory const& processHistory() const {return *processHistory_;}
     bool getProcessConfiguration(ProcessConfiguration& pc) const;
     ReleaseVersion releaseVersion() const;
@@ -71,7 +72,7 @@ namespace edm {
 
     void write(std::ostream& os) const;
 
-    void setStore(boost::shared_ptr<ProductProvenanceRetriever> store) const {store_ = store;}
+    void setStore(std::shared_ptr<ProductProvenanceRetriever> store) const {store_ = store;}
 
     void setProcessHistory(ProcessHistory const& ph) {processHistory_ = &ph;}
 
@@ -83,7 +84,7 @@ namespace edm {
       productID_ = pid;
     }
 
-    void setBranchDescription(boost::shared_ptr<BranchDescription const> const& p) {
+    void setBranchDescription(std::shared_ptr<BranchDescription const> const& p) {
       branchDescription_ = p;
     }
 
@@ -92,12 +93,12 @@ namespace edm {
     void swap(Provenance&);
 
   private:
-    boost::shared_ptr<BranchDescription const> branchDescription_;
+    std::shared_ptr<BranchDescription const> branchDescription_;
     ProductID productID_;
     ProcessHistory const* processHistory_; // We don't own this
     mutable bool productProvenanceValid_;
-    mutable boost::shared_ptr<ProductProvenance> productProvenancePtr_;
-    mutable boost::shared_ptr<ProductProvenanceRetriever> store_;
+    mutable std::shared_ptr<ProductProvenance> productProvenancePtr_;
+    mutable std::shared_ptr<ProductProvenanceRetriever> store_;
   };
 
   inline

--- a/DataFormats/Provenance/interface/WrapperInterfaceBase.h
+++ b/DataFormats/Provenance/interface/WrapperInterfaceBase.h
@@ -6,17 +6,17 @@
 WrapperInterfaceBase: The base class of all things that will be inserted into the Event.
 /
 ----------------------------------------------------------------------*/
-#include "boost/shared_ptr.hpp"
-
+#include <memory>
 #include <typeinfo>
 #include <vector>
+#include "FWCore/Utilities/interface/HideStdSharedPtrFromRoot.h"
 
 namespace edm {
   class ProductID;
   namespace reftobase {
     class RefVectorHolderBase;
   }
-  typedef boost::shared_ptr<reftobase::RefVectorHolderBase> helper_vector_ptr;
+  typedef std::shared_ptr<reftobase::RefVectorHolderBase> helper_vector_ptr;
   class WrapperInterfaceBase {
   public:
     WrapperInterfaceBase();

--- a/DataFormats/Provenance/src/ProductProvenance.cc
+++ b/DataFormats/Provenance/src/ProductProvenance.cc
@@ -40,7 +40,7 @@ namespace edm {
   {}
 
    ProductProvenance::ProductProvenance(BranchID const& bid,
-				    boost::shared_ptr<Parentage> pPtr) :
+				    std::shared_ptr<Parentage> pPtr) :
     branchID_(bid),
     parentageID_(pPtr->id()),
     transient_() {
@@ -53,7 +53,7 @@ namespace edm {
     branchID_(bid),
     parentageID_(),
     transient_() {
-      parentagePtr() = boost::shared_ptr<Parentage>(new Parentage);
+      parentagePtr() = std::make_shared<Parentage>();
       parentagePtr()->setParents(parents);
       parentageID_ = parentagePtr()->id();
       ParentageRegistry::instance()->insertMapped(*parentagePtr());

--- a/DataFormats/Provenance/src/ProductProvenanceRetriever.cc
+++ b/DataFormats/Provenance/src/ProductProvenanceRetriever.cc
@@ -72,7 +72,7 @@ namespace edm {
   }
  
   void
-  ProductProvenanceRetriever::mergeProvenanceRetrievers(boost::shared_ptr<ProductProvenanceRetriever> other) {
+  ProductProvenanceRetriever::mergeProvenanceRetrievers(std::shared_ptr<ProductProvenanceRetriever> other) {
     nextRetriever_ = other;
   }
 

--- a/DataFormats/Provenance/src/ProductRegistry.cc
+++ b/DataFormats/Provenance/src/ProductRegistry.cc
@@ -137,7 +137,7 @@ namespace edm {
     return false;
   }
 
-  boost::shared_ptr<ProductHolderIndexHelper> const&
+  std::shared_ptr<ProductHolderIndexHelper> const&
   ProductRegistry::productLookup(BranchType branchType) const {
     if (branchType == InEvent) return transient_.eventProductLookup_;
     if (branchType == InLumi) return transient_.lumiProductLookup_;

--- a/DataFormats/Provenance/src/Provenance.cc
+++ b/DataFormats/Provenance/src/Provenance.cc
@@ -14,10 +14,10 @@
 
 namespace edm {
 
-  Provenance::Provenance() : Provenance{boost::shared_ptr<BranchDescription const>(), ProductID()} {
+  Provenance::Provenance() : Provenance{std::shared_ptr<BranchDescription const>(), ProductID()} {
   }
 
-  Provenance::Provenance(boost::shared_ptr<BranchDescription const> const& p, ProductID const& pid) :
+  Provenance::Provenance(std::shared_ptr<BranchDescription const> const& p, ProductID const& pid) :
     branchDescription_(p),
     productID_(pid),
     processHistory_(),

--- a/DataFormats/Provenance/test/indexIntoFile2_t.cppunit.cc
+++ b/DataFormats/Provenance/test/indexIntoFile2_t.cppunit.cc
@@ -346,7 +346,7 @@ void TestIndexIntoFile2::testAddEntryAndFixAndSort() {
   ptr->push_back(4);
   ptr->push_back(8);
 
-  boost::shared_ptr<IndexIntoFile::EventFinder> shptr(ptr);
+  std::shared_ptr<IndexIntoFile::EventFinder> shptr(ptr);
   indexIntoFile.setEventFinder(shptr);
 
   indexIntoFile.fillEventNumbers();

--- a/DataFormats/Provenance/test/indexIntoFile4_t.cppunit.cc
+++ b/DataFormats/Provenance/test/indexIntoFile4_t.cppunit.cc
@@ -235,7 +235,7 @@ void TestIndexIntoFile4::testFind() {
     ptr->push_back(4);
     ptr->push_back(7);
     ptr->push_back(6);
-    boost::shared_ptr<IndexIntoFile::EventFinder> shptr(ptr);
+    std::shared_ptr<IndexIntoFile::EventFinder> shptr(ptr);
     indexIntoFile.setEventFinder(shptr);
 
     edm::IndexIntoFile::IndexIntoFileItr iter = indexIntoFile.findPosition(1000, 0, 0);

--- a/DataFormats/Provenance/test/indexIntoFile5_t.cppunit.cc
+++ b/DataFormats/Provenance/test/indexIntoFile5_t.cppunit.cc
@@ -260,7 +260,7 @@ void TestIndexIntoFile5::testDuplicateCheckerFunctions() {
     ptr11->push_back(1);
     ptr11->push_back(2);
 
-    boost::shared_ptr<IndexIntoFile::EventFinder> shptr11(ptr11);
+    std::shared_ptr<IndexIntoFile::EventFinder> shptr11(ptr11);
     indexIntoFile11.setEventFinder(shptr11);
 
     TestEventFinder* ptr12(new TestEventFinder);
@@ -273,7 +273,7 @@ void TestIndexIntoFile5::testDuplicateCheckerFunctions() {
     ptr12->push_back(1);
     ptr12->push_back(4);
 
-    boost::shared_ptr<IndexIntoFile::EventFinder> shptr12(ptr12);
+    std::shared_ptr<IndexIntoFile::EventFinder> shptr12(ptr12);
     indexIntoFile12.setEventFinder(shptr12);
 
     TestEventFinder* ptr22(new TestEventFinder);
@@ -286,7 +286,7 @@ void TestIndexIntoFile5::testDuplicateCheckerFunctions() {
     ptr22->push_back(1);
     ptr22->push_back(4);
 
-    boost::shared_ptr<IndexIntoFile::EventFinder> shptr22(ptr22);
+    std::shared_ptr<IndexIntoFile::EventFinder> shptr22(ptr22);
     indexIntoFile22.setEventFinder(shptr22);
 
     if (j == 0) {

--- a/DataFormats/TestObjects/test/BuildFile.xml
+++ b/DataFormats/TestObjects/test/BuildFile.xml
@@ -1,4 +1,3 @@
-<use   name="boost"/>
 <use   name="cppunit"/>
 <use   name="DataFormats/TestObjects"/>
 <bin   file="Enum_t.cpp">

--- a/EventFilter/Utilities/plugins/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/plugins/FedRawDataInputSource.cc
@@ -1,6 +1,7 @@
 #include <fcntl.h>
 #include <iomanip>
 #include <iostream>
+#include <memory>
 #include <sstream>
 #include <sys/types.h>
 #include <sys/file.h>
@@ -745,7 +746,7 @@ void FedRawDataInputSource::renameToNextFree(std::string const& fileName) const
 void FedRawDataInputSource::preForkReleaseResources()
 {}
 
-void FedRawDataInputSource::postForkReacquireResources(boost::shared_ptr<edm::multicore::MessageReceiverForSource>)
+void FedRawDataInputSource::postForkReacquireResources(std::shared_ptr<edm::multicore::MessageReceiverForSource>)
 {
   InputSource::rewind();
   setRunAuxiliary(

--- a/EventFilter/Utilities/plugins/FedRawDataInputSource.h
+++ b/EventFilter/Utilities/plugins/FedRawDataInputSource.h
@@ -47,7 +47,7 @@ protected:
 
 private:
   virtual void preForkReleaseResources() override;
-  virtual void postForkReacquireResources(boost::shared_ptr<edm::multicore::MessageReceiverForSource>) override;
+  virtual void postForkReacquireResources(std::shared_ptr<edm::multicore::MessageReceiverForSource>) override;
   virtual void rewind_() override;
 
   void maybeOpenNewLumiSection(const uint32_t lumiSection);

--- a/FWCore/Common/interface/LuminosityBlockBase.h
+++ b/FWCore/Common/interface/LuminosityBlockBase.h
@@ -140,7 +140,7 @@ namespace edm {
     PrincipalGetAdapter provRecorder_;
     ProductPtrVec putProducts_;
     LuminosityBlockAuxiliary const& aux_;
-    boost::shared_ptr<Run const> const run_;
+    std::shared_ptr<Run const> const run_;
 */
     virtual BasicHandle getByLabelImpl(std::type_info const& iWrapperType, std::type_info const& iProductType, const InputTag& iTag) const = 0;
 

--- a/FWCore/Framework/bin/cmsRun.cpp
+++ b/FWCore/Framework/bin/cmsRun.cpp
@@ -25,7 +25,6 @@ PSet script.   See notes in EventProcessor.cpp for details about it.
 #include "TError.h"
 
 #include "boost/program_options.hpp"
-#include "boost/shared_ptr.hpp"
 #include "tbb/task_scheduler_init.h"
 
 #include <cstring>
@@ -123,9 +122,9 @@ int main(int argc, char* argv[]) {
   // may be using TBB.
   bool setNThreadsOnCommandLine = false;
   std::unique_ptr<tbb::task_scheduler_init> tsiPtr{new tbb::task_scheduler_init{1}};
-  boost::shared_ptr<edm::Presence> theMessageServicePresence;
+  std::shared_ptr<edm::Presence> theMessageServicePresence;
   std::unique_ptr<std::ofstream> jobReportStreamPtr;
-  boost::shared_ptr<edm::serviceregistry::ServiceWrapper<edm::JobReport> > jobRep;
+  std::shared_ptr<edm::serviceregistry::ServiceWrapper<edm::JobReport> > jobRep;
   EventProcessorWithSentry proc;
 
   try {
@@ -165,11 +164,11 @@ int main(int argc, char* argv[]) {
       // Load the message service plug-in
 
       if(multiThreadML) {
-        theMessageServicePresence = boost::shared_ptr<edm::Presence>(edm::PresenceFactory::get()->
+        theMessageServicePresence = std::shared_ptr<edm::Presence>(edm::PresenceFactory::get()->
           makePresence("MessageServicePresence").release());
       }
       else {
-        theMessageServicePresence = boost::shared_ptr<edm::Presence>(edm::PresenceFactory::get()->
+        theMessageServicePresence = std::shared_ptr<edm::Presence>(edm::PresenceFactory::get()->
           makePresence("SingleThreadMSPresence").release());
       }
 
@@ -274,9 +273,9 @@ int main(int argc, char* argv[]) {
 
       context = "Processing the python configuration file named ";
       context += fileName;
-      boost::shared_ptr<edm::ProcessDesc> processDesc;
+      std::shared_ptr<edm::ProcessDesc> processDesc;
       try {
-        boost::shared_ptr<edm::ParameterSet> parameterSet = edm::readConfig(fileName, argc, argv);
+        std::shared_ptr<edm::ParameterSet> parameterSet = edm::readConfig(fileName, argc, argv);
         processDesc.reset(new edm::ProcessDesc(parameterSet));
       }
       catch(cms::Exception& iException) {
@@ -289,7 +288,7 @@ int main(int argc, char* argv[]) {
       context = "Setting up number of threads";
       {
         if(not setNThreadsOnCommandLine) {
-          boost::shared_ptr<edm::ParameterSet> pset = processDesc->getProcessPSet();
+          std::shared_ptr<edm::ParameterSet> pset = processDesc->getProcessPSet();
           if(pset->existsAs<edm::ParameterSet>("options",false)) {
             auto const& ops = pset->getUntrackedParameterSet("options");
             if(ops.existsAs<unsigned int>("numberOfThreads",false)) {
@@ -304,7 +303,7 @@ int main(int argc, char* argv[]) {
         } else {
           //inject it into the top level ParameterSet
           edm::ParameterSet newOp;
-          boost::shared_ptr<edm::ParameterSet> pset = processDesc->getProcessPSet();
+          std::shared_ptr<edm::ParameterSet> pset = processDesc->getProcessPSet();
           if(pset->existsAs<edm::ParameterSet>("options",false)) {
             newOp = pset->getUntrackedParameterSet("options");
           }

--- a/FWCore/Framework/interface/Event.h
+++ b/FWCore/Framework/interface/Event.h
@@ -38,8 +38,6 @@ For its usage, see "FWCore/Framework/interface/PrincipalGetAdapter.h"
 #include "FWCore/Utilities/interface/ProductKindOfType.h"
 #include "FWCore/Utilities/interface/StreamID.h"
 
-#include "boost/shared_ptr.hpp"
-
 #include <memory>
 #include <string>
 #include <set>
@@ -258,7 +256,7 @@ namespace edm {
     ProductPtrVec putProductsWithoutParents_; // ... but not for these
 
     EventAuxiliary const& aux_;
-    boost::shared_ptr<LuminosityBlock const> const luminosityBlock_;
+    std::shared_ptr<LuminosityBlock const> const luminosityBlock_;
 
     // gotBranchIDs_ must be mutable because it records all 'gets',
     // which do not logically modify the PrincipalGetAdapter. gotBranchIDs_ is
@@ -269,7 +267,7 @@ namespace edm {
     void addToGotBranchIDs(Provenance const& prov) const;
 
     // We own the retrieved Views, and have to destroy them.
-    mutable std::vector<boost::shared_ptr<ViewBase> > gotViews_;
+    mutable std::vector<std::shared_ptr<ViewBase> > gotViews_;
     
     StreamID streamID_;
     ModuleCallingContext const* moduleCallingContext_;
@@ -325,7 +323,7 @@ namespace edm {
 
       if(bh.failedToGet()) {
           Handle<View<ELEMENT> > temp(makeHandleExceptionFactory([oid]()->std::shared_ptr<cms::Exception> {
-            std::shared_ptr<cms::Exception> whyFailed(new edm::Exception(edm::errors::ProductNotFound));
+            std::shared_ptr<cms::Exception> whyFailed = std::make_shared<edm::Exception>(edm::errors::ProductNotFound);
             *whyFailed
             << "get View by ID failed: no product with ID = " << oid <<"\n";
             return whyFailed;
@@ -532,8 +530,7 @@ namespace edm {
     //  shared pointer and fill the helper vector
     bh.interface()->fillView(bh.wrapper(), bh.id(), pointersToElements, helpers);
 
-    boost::shared_ptr<View<ELEMENT> >
-      newview(new View<ELEMENT>(pointersToElements, helpers));
+    auto newview = std::make_shared<View<ELEMENT> >(pointersToElements, helpers);
 
     addToGotBranchIDs(*bh.provenance());
     gotViews_.push_back(newview);

--- a/FWCore/Framework/interface/EventPrincipal.h
+++ b/FWCore/Framework/interface/EventPrincipal.h
@@ -22,8 +22,6 @@ is the DataBlock.
 #include "FWCore/Utilities/interface/Signal.h"
 #include "FWCore/Framework/interface/Principal.h"
 
-#include "boost/shared_ptr.hpp"
-
 #include <map>
 #include <memory>
 #include <string>
@@ -51,8 +49,8 @@ namespace edm {
     static int const invalidBunchXing = EventAuxiliary::invalidBunchXing;
     static int const invalidStoreNumber = EventAuxiliary::invalidStoreNumber;
     EventPrincipal(
-        boost::shared_ptr<ProductRegistry const> reg,
-        boost::shared_ptr<BranchIDListHelper const> branchIDListHelper,
+        std::shared_ptr<ProductRegistry const> reg,
+        std::shared_ptr<BranchIDListHelper const> branchIDListHelper,
         ProcessConfiguration const& pc,
         HistoryAppender* historyAppender,
         unsigned int streamIndex = 0);
@@ -88,7 +86,7 @@ namespace edm {
       return (luminosityBlockPrincipal_) ? true : false;
     }
 
-    void setLuminosityBlockPrincipal(boost::shared_ptr<LuminosityBlockPrincipal> const& lbp);
+    void setLuminosityBlockPrincipal(std::shared_ptr<LuminosityBlockPrincipal> const& lbp);
 
     void setRunAndLumiNumber(RunNumber_t run, LuminosityBlockNumber_t lumi);
 
@@ -132,10 +130,10 @@ namespace edm {
 
     RunPrincipal const& runPrincipal() const;
 
-    boost::shared_ptr<ProductProvenanceRetriever> productProvenanceRetrieverPtr() const {return provRetrieverPtr_;}
+    std::shared_ptr<ProductProvenanceRetriever> productProvenanceRetrieverPtr() const {return provRetrieverPtr_;}
 
-    void setUnscheduledHandler(boost::shared_ptr<UnscheduledHandler> iHandler);
-    boost::shared_ptr<UnscheduledHandler> unscheduledHandler() const;
+    void setUnscheduledHandler(std::shared_ptr<UnscheduledHandler> iHandler);
+    std::shared_ptr<UnscheduledHandler> unscheduledHandler() const;
 
     EventSelectionIDVector const& eventSelectionIDs() const;
 
@@ -199,19 +197,19 @@ namespace edm {
 
     EventAuxiliary aux_;
 
-    boost::shared_ptr<LuminosityBlockPrincipal> luminosityBlockPrincipal_;
+    std::shared_ptr<LuminosityBlockPrincipal> luminosityBlockPrincipal_;
 
     // Pointer to the 'retriever' that will get provenance information from the persistent store.
-    boost::shared_ptr<ProductProvenanceRetriever> provRetrieverPtr_;
+    std::shared_ptr<ProductProvenanceRetriever> provRetrieverPtr_;
 
     // Handler for unscheduled modules
-    boost::shared_ptr<UnscheduledHandler> unscheduledHandler_;
+    std::shared_ptr<UnscheduledHandler> unscheduledHandler_;
 
     mutable std::vector<std::string> moduleLabelsRunning_;
 
     EventSelectionIDVector eventSelectionIDs_;
 
-    boost::shared_ptr<BranchIDListHelper const> branchIDListHelper_;
+    std::shared_ptr<BranchIDListHelper const> branchIDListHelper_;
 
     BranchListIndexes branchListIndexes_;
 

--- a/FWCore/Framework/interface/EventProcessor.h
+++ b/FWCore/Framework/interface/EventProcessor.h
@@ -75,7 +75,7 @@ namespace edm {
                    std::vector<std::string> const& defaultServices,
                    std::vector<std::string> const& forcedServices = std::vector<std::string>());
 
-    EventProcessor(boost::shared_ptr<ProcessDesc>& processDesc,
+    EventProcessor(std::shared_ptr<ProcessDesc>& processDesc,
                    ServiceToken const& token,
                    serviceregistry::ServiceLegacy legacy);
 
@@ -217,7 +217,7 @@ namespace edm {
     //
     // Now private functions.
     // init() is used by only by constructors
-    void init(boost::shared_ptr<ProcessDesc>& processDesc,
+    void init(std::shared_ptr<ProcessDesc>& processDesc,
               ServiceToken const& token,
               serviceregistry::ServiceLegacy);
 
@@ -252,15 +252,15 @@ namespace edm {
     // only during construction, and never again. If they aren't
     // really needed, we should remove them.
 
-    boost::shared_ptr<ActivityRegistry>           actReg_;
-    boost::shared_ptr<ProductRegistry const>      preg_;
-    boost::shared_ptr<BranchIDListHelper>         branchIDListHelper_;
+    std::shared_ptr<ActivityRegistry>           actReg_;
+    std::shared_ptr<ProductRegistry const>      preg_;
+    std::shared_ptr<BranchIDListHelper>         branchIDListHelper_;
     ServiceToken                                  serviceToken_;
     std::unique_ptr<InputSource>                  input_;
     std::unique_ptr<eventsetup::EventSetupsController> espController_;
     boost::shared_ptr<eventsetup::EventSetupProvider> esp_;
     std::unique_ptr<ExceptionToActionTable const>          act_table_;
-    boost::shared_ptr<ProcessConfiguration const>       processConfiguration_;
+    std::shared_ptr<ProcessConfiguration const>       processConfiguration_;
     ProcessContext                                processContext_;
     std::auto_ptr<Schedule>                       schedule_;
     std::auto_ptr<SubProcess>                     subProcess_;

--- a/FWCore/Framework/interface/EventSelector.h
+++ b/FWCore/Framework/interface/EventSelector.h
@@ -19,7 +19,7 @@
 #include "DataFormats/Common/interface/TriggerResults.h"
 #include "DataFormats/Provenance/interface/ParameterSetID.h"
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 #include <vector>
 #include <string>
@@ -64,7 +64,7 @@ namespace edm
       testSelectionOverlap(Strings const& pathspec1,
                            Strings const& pathspec2,
                            Strings const& fullTriggerList);
-    boost::shared_ptr<TriggerResults>
+    std::shared_ptr<TriggerResults>
       maskTriggerResults(TriggerResults const& inputResults);
     static std::vector<std::string>
       getEventSelectionVString(edm::ParameterSet const& pset);

--- a/FWCore/Framework/interface/FileBlock.h
+++ b/FWCore/Framework/interface/FileBlock.h
@@ -11,7 +11,7 @@ FileBlock: Properties of an input file.
 #include "DataFormats/Provenance/interface/BranchChildren.h"
 #include "FWCore/Utilities/interface/BranchType.h"
 class TTree;
-#include "boost/shared_ptr.hpp"
+#include <memory>
 #include <array>
 #include <string>
 
@@ -76,7 +76,7 @@ namespace edm {
               std::string const& fileName,
               bool branchListIndexesUnchanged,
               bool modifiedIDs,
-              boost::shared_ptr<BranchChildren> branchChildren) :
+              std::shared_ptr<BranchChildren> branchChildren) :
       fileFormatVersion_(version),
       tree_(const_cast<TTree*>(ev)),
       metaTree_(const_cast<TTree*>(meta)),
@@ -127,7 +127,7 @@ namespace edm {
     std::string fileName_;
     bool branchListIndexesUnchanged_;
     bool modifiedIDs_;
-    boost::shared_ptr<BranchChildren> branchChildren_;
+    std::shared_ptr<BranchChildren> branchChildren_;
   };
 }
 #endif

--- a/FWCore/Framework/interface/HistoryAppender.h
+++ b/FWCore/Framework/interface/HistoryAppender.h
@@ -4,7 +4,7 @@
 #include "DataFormats/Provenance/interface/ProcessHistory.h"
 #include "DataFormats/Provenance/interface/ProcessHistoryID.h"
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 namespace edm {
 
@@ -19,7 +19,7 @@ namespace edm {
     // Used to append the current process to the process history
     // when necessary. Optimized to cache the results so it
     // does not need to repeat the same calculations many times.
-    boost::shared_ptr<ProcessHistory const>
+    std::shared_ptr<ProcessHistory const>
     appendToProcessHistory(ProcessHistoryID const& inputPHID,
                            ProcessHistory const* inputProcessHistory,
                            ProcessConfiguration const& pc);
@@ -34,7 +34,7 @@ namespace edm {
                              ProcessConfiguration const& pc) const;
 
     ProcessHistoryID m_cachedInputPHID;
-    boost::shared_ptr<ProcessHistory const> m_cachedHistory;
+    std::shared_ptr<ProcessHistory const> m_cachedHistory;
   };
 }
 #endif

--- a/FWCore/Framework/interface/InputSource.h
+++ b/FWCore/Framework/interface/InputSource.h
@@ -50,7 +50,6 @@ Some examples of InputSource subclasses may be:
 #include "FWCore/Framework/interface/ProcessingController.h"
 #include "FWCore/Framework/interface/ProductRegistryHelper.h"
 
-#include "boost/shared_ptr.hpp"
 #include "FWCore/Utilities/interface/Signal.h"
 
 #include <memory>
@@ -116,10 +115,10 @@ namespace edm {
     bool readEvent(EventPrincipal& ep, EventID const&, StreamContext &);
 
     /// Read next luminosity block Auxilary
-    boost::shared_ptr<LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary();
+    std::shared_ptr<LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary();
 
     /// Read next run Auxiliary
-    boost::shared_ptr<RunAuxiliary> readRunAuxiliary();
+    std::shared_ptr<RunAuxiliary> readRunAuxiliary();
 
     /// Read next run (new run)
     void readRun(RunPrincipal& runPrincipal, HistoryAppender& historyAppender);
@@ -165,7 +164,7 @@ namespace edm {
     void registerProducts();
 
     /// Accessor for product registry.
-    boost::shared_ptr<ProductRegistry const> productRegistry() const {return productRegistry_;}
+    std::shared_ptr<ProductRegistry const> productRegistry() const {return productRegistry_;}
 
     /// Const accessor for process history registry.
     ProcessHistoryRegistry const& processHistoryRegistry() const {return *processHistoryRegistry_;}
@@ -174,7 +173,7 @@ namespace edm {
     ProcessHistoryRegistry& processHistoryRegistryForUpdate() {return *processHistoryRegistry_;}
 
     /// Accessor for branchIDListHelper
-    boost::shared_ptr<BranchIDListHelper> branchIDListHelper() const {return branchIDListHelper_;}
+    std::shared_ptr<BranchIDListHelper> branchIDListHelper() const {return branchIDListHelper_;}
 
     /// Reset the remaining number of events/lumis to the maximum number.
     void repeat() {
@@ -233,7 +232,7 @@ namespace edm {
 
     /// Called by the framework before forking the process
     void doPreForkReleaseResources();
-    void doPostForkReacquireResources(boost::shared_ptr<multicore::MessageReceiverForSource>);
+    void doPostForkReacquireResources(std::shared_ptr<multicore::MessageReceiverForSource>);
 
     /// Accessor for the current time, as seen by the input source
     Timestamp const& timestamp() const {return time_;}
@@ -253,13 +252,13 @@ namespace edm {
     ProcessingMode processingMode() const {return processingMode_;}
 
     /// Accessor for Activity Registry
-    boost::shared_ptr<ActivityRegistry> actReg() const {return actReg_;}
+    std::shared_ptr<ActivityRegistry> actReg() const {return actReg_;}
 
     /// Called by the framework to merge or insert run in principal cache.
-    boost::shared_ptr<RunAuxiliary> runAuxiliary() const {return runAuxiliary_;}
+    std::shared_ptr<RunAuxiliary> runAuxiliary() const {return runAuxiliary_;}
 
     /// Called by the framework to merge or insert lumi in principal cache.
-    boost::shared_ptr<LuminosityBlockAuxiliary> luminosityBlockAuxiliary() const {return lumiAuxiliary_;}
+    std::shared_ptr<LuminosityBlockAuxiliary> luminosityBlockAuxiliary() const {return lumiAuxiliary_;}
 
     bool randomAccess() const;
     ProcessingController::ForwardState forwardState() const;
@@ -368,8 +367,8 @@ namespace edm {
       resetRunAuxiliary();
       state_ = IsInvalid;
     }
-    boost::shared_ptr<LuminosityBlockPrincipal> const luminosityBlockPrincipal() const;
-    boost::shared_ptr<RunPrincipal> const runPrincipal() const;
+    std::shared_ptr<LuminosityBlockPrincipal> const luminosityBlockPrincipal() const;
+    std::shared_ptr<RunPrincipal> const runPrincipal() const;
     bool newRun() const {return newRun_;}
     void setNewRun() {newRun_ = true;}
     void resetNewRun() {newRun_ = false;}
@@ -391,8 +390,8 @@ namespace edm {
     bool limitReached() const {return eventLimitReached() || lumiLimitReached();}
     virtual ItemType getNextItemType() = 0;
     ItemType nextItemType_();
-    virtual boost::shared_ptr<RunAuxiliary> readRunAuxiliary_() = 0;
-    virtual boost::shared_ptr<LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary_() = 0;
+    virtual std::shared_ptr<RunAuxiliary> readRunAuxiliary_() = 0;
+    virtual std::shared_ptr<LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary_() = 0;
     virtual void readRun_(RunPrincipal& runPrincipal);
     virtual void readLuminosityBlock_(LuminosityBlockPrincipal& lumiPrincipal);
     virtual void readEvent_(EventPrincipal& eventPrincipal) = 0;
@@ -412,14 +411,14 @@ namespace edm {
     virtual SharedResourcesAcquirer* resourceSharedWithDelayedReader_() const;
 
     virtual void preForkReleaseResources();
-    virtual void postForkReacquireResources(boost::shared_ptr<multicore::MessageReceiverForSource>);
+    virtual void postForkReacquireResources(std::shared_ptr<multicore::MessageReceiverForSource>);
     virtual bool randomAccess_() const;
     virtual ProcessingController::ForwardState forwardState_() const;
     virtual ProcessingController::ReverseState reverseState_() const;
 
   private:
 
-    boost::shared_ptr<ActivityRegistry> actReg_;
+    std::shared_ptr<ActivityRegistry> actReg_;
     int maxEvents_;
     int remainingEvents_;
     int maxLumis_;
@@ -427,9 +426,9 @@ namespace edm {
     int readCount_;
     ProcessingMode processingMode_;
     ModuleDescription const moduleDescription_;
-    boost::shared_ptr<ProductRegistry> productRegistry_;
+    std::shared_ptr<ProductRegistry> productRegistry_;
     std::unique_ptr<ProcessHistoryRegistry> processHistoryRegistry_;
-    boost::shared_ptr<BranchIDListHelper> branchIDListHelper_;
+    std::shared_ptr<BranchIDListHelper> branchIDListHelper_;
     bool const primary_;
     std::string processGUID_;
     Timestamp time_;
@@ -437,12 +436,12 @@ namespace edm {
     mutable bool newLumi_;
     bool eventCached_;
     mutable ItemType state_;
-    mutable boost::shared_ptr<RunAuxiliary> runAuxiliary_;
-    mutable boost::shared_ptr<LuminosityBlockAuxiliary>  lumiAuxiliary_;
+    mutable std::shared_ptr<RunAuxiliary> runAuxiliary_;
+    mutable std::shared_ptr<LuminosityBlockAuxiliary>  lumiAuxiliary_;
     std::string statusFileName_;
 
     //used when process has been forked
-    boost::shared_ptr<edm::multicore::MessageReceiverForSource> receiver_;
+    std::shared_ptr<edm::multicore::MessageReceiverForSource> receiver_;
     unsigned int numberOfEventsBeforeBigSkip_;
   };
 }

--- a/FWCore/Framework/interface/InputSourceDescription.h
+++ b/FWCore/Framework/interface/InputSourceDescription.h
@@ -6,7 +6,7 @@
 InputSourceDescription : the stuff that is needed to configure an
 input source that does not come in through the ParameterSet  
 ----------------------------------------------------------------------*/
-#include "boost/shared_ptr.hpp"
+#include <memory>
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
 #include "FWCore/Framework/src/PreallocationConfiguration.h"
 
@@ -28,8 +28,8 @@ namespace edm {
 
     InputSourceDescription(ModuleDescription const& md,
                            ProductRegistry& preg,
-                           boost::shared_ptr<BranchIDListHelper> branchIDListHelper,
-                           boost::shared_ptr<ActivityRegistry> areg,
+                           std::shared_ptr<BranchIDListHelper> branchIDListHelper,
+                           std::shared_ptr<ActivityRegistry> areg,
                            int maxEvents,
                            int maxLumis,
                            PreallocationConfiguration const& allocations) :
@@ -44,8 +44,8 @@ namespace edm {
 
     ModuleDescription moduleDescription_;
     ProductRegistry* productRegistry_;
-    boost::shared_ptr<BranchIDListHelper> branchIDListHelper_;
-    boost::shared_ptr<ActivityRegistry> actReg_;
+    std::shared_ptr<BranchIDListHelper> branchIDListHelper_;
+    std::shared_ptr<ActivityRegistry> actReg_;
     int maxEvents_;
     int maxLumis_;
     PreallocationConfiguration const* allocations_;

--- a/FWCore/Framework/interface/LuminosityBlock.h
+++ b/FWCore/Framework/interface/LuminosityBlock.h
@@ -27,9 +27,6 @@ For its usage, see "FWCore/Framework/interface/PrincipalGetAdapter.h"
 #include "FWCore/Utilities/interface/ProductKindOfType.h"
 #include "FWCore/Utilities/interface/LuminosityBlockIndex.h"
 
-
-#include "boost/shared_ptr.hpp"
-
 #include <memory>
 #include <set>
 #include <string>
@@ -155,7 +152,7 @@ namespace edm {
     PrincipalGetAdapter provRecorder_;
     ProductPtrVec putProducts_;
     LuminosityBlockAuxiliary const& aux_;
-    boost::shared_ptr<Run const> const run_;
+    std::shared_ptr<Run const> const run_;
     typedef std::set<BranchID> BranchIDSet;
     mutable BranchIDSet gotBranchIDs_;
     ModuleCallingContext const* moduleCallingContext_;

--- a/FWCore/Framework/interface/LuminosityBlockPrincipal.h
+++ b/FWCore/Framework/interface/LuminosityBlockPrincipal.h
@@ -18,7 +18,7 @@ is the DataBlock.
 #include "FWCore/Utilities/interface/LuminosityBlockIndex.h"
 #include "FWCore/Framework/interface/Principal.h"
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 #include <vector>
 
@@ -35,8 +35,8 @@ namespace edm {
     typedef LuminosityBlockAuxiliary Auxiliary;
     typedef Principal Base;
     LuminosityBlockPrincipal(
-        boost::shared_ptr<LuminosityBlockAuxiliary> aux,
-        boost::shared_ptr<ProductRegistry const> reg,
+        std::shared_ptr<LuminosityBlockAuxiliary> aux,
+        std::shared_ptr<ProductRegistry const> reg,
         ProcessConfiguration const& pc,
         HistoryAppender* historyAppender,
         unsigned int index);
@@ -53,7 +53,7 @@ namespace edm {
       return *runPrincipal_;
     }
 
-    void setRunPrincipal(boost::shared_ptr<RunPrincipal> rp) {
+    void setRunPrincipal(std::shared_ptr<RunPrincipal> rp) {
       runPrincipal_ = rp;
     }
 
@@ -93,7 +93,7 @@ namespace edm {
       return aux_->mergeAuxiliary(aux);
     }
 
-    void setUnscheduledHandler(boost::shared_ptr<UnscheduledHandler>) {}
+    void setUnscheduledHandler(std::shared_ptr<UnscheduledHandler>) {}
 
     void put(
         BranchDescription const& bd,
@@ -116,9 +116,9 @@ namespace edm {
 
     void resolveProductImmediate(ProductHolderBase const& phb) const;
 
-    boost::shared_ptr<RunPrincipal> runPrincipal_;
+    std::shared_ptr<RunPrincipal> runPrincipal_;
 
-    boost::shared_ptr<LuminosityBlockAuxiliary> aux_;
+    std::shared_ptr<LuminosityBlockAuxiliary> aux_;
 
     LuminosityBlockIndex index_;
     

--- a/FWCore/Framework/interface/Principal.h
+++ b/FWCore/Framework/interface/Principal.h
@@ -32,7 +32,6 @@ pointer to a ProductHolder, when queried.
 #include "FWCore/Utilities/interface/ProductKindOfType.h"
 
 #include "boost/iterator/filter_iterator.hpp"
-#include "boost/shared_ptr.hpp"
 
 #include <map>
 #include <memory>
@@ -49,23 +48,23 @@ namespace edm {
   class EDConsumerBase;
 
   struct FilledProductPtr {
-    bool operator()(boost::shared_ptr<ProductHolderBase> const& iObj) { return bool(iObj);}
+    bool operator()(std::shared_ptr<ProductHolderBase> const& iObj) { return bool(iObj);}
   };
 
   class Principal : public EDProductGetter {
   public:
-    typedef std::vector<boost::shared_ptr<ProductHolderBase> > ProductHolderCollection;
+    typedef std::vector<std::shared_ptr<ProductHolderBase> > ProductHolderCollection;
     typedef boost::filter_iterator<FilledProductPtr, ProductHolderCollection::const_iterator> const_iterator;
     typedef ProcessHistory::const_iterator ProcessNameConstIterator;
     typedef ProductHolderBase const* ConstProductHolderPtr;
     typedef std::vector<BasicHandle> BasicHandleVec;
     typedef ProductHolderCollection::size_type size_type;
 
-    typedef boost::shared_ptr<ProductHolderBase> SharedProductPtr;
+    typedef std::shared_ptr<ProductHolderBase> SharedProductPtr;
     typedef std::string ProcessName;
 
-    Principal(boost::shared_ptr<ProductRegistry const> reg,
-              boost::shared_ptr<ProductHolderIndexHelper const> productLookup,
+    Principal(std::shared_ptr<ProductRegistry const> reg,
+              std::shared_ptr<ProductHolderIndexHelper const> productLookup,
               ProcessConfiguration const& pc,
               BranchType bt,
               HistoryAppender* historyAppender);
@@ -76,15 +75,15 @@ namespace edm {
 
     void adjustIndexesAfterProductRegistryAddition();
 
-    void addScheduledProduct(boost::shared_ptr<BranchDescription const> bd);
+    void addScheduledProduct(std::shared_ptr<BranchDescription const> bd);
 
-    void addSourceProduct(boost::shared_ptr<BranchDescription const> bd);
+    void addSourceProduct(std::shared_ptr<BranchDescription const> bd);
 
-    void addInputProduct(boost::shared_ptr<BranchDescription const> bd);
+    void addInputProduct(std::shared_ptr<BranchDescription const> bd);
 
-    void addUnscheduledProduct(boost::shared_ptr<BranchDescription const> bd);
+    void addUnscheduledProduct(std::shared_ptr<BranchDescription const> bd);
 
-    void addAliasedProduct(boost::shared_ptr<BranchDescription const> bd);
+    void addAliasedProduct(std::shared_ptr<BranchDescription const> bd);
 
     void fillPrincipal(ProcessHistoryID const& hist, ProcessHistoryRegistry const& phr, DelayedReader* reader);
 
@@ -237,7 +236,7 @@ namespace edm {
 
     virtual bool isComplete_() const {return true;}
 
-    boost::shared_ptr<ProcessHistory const> processHistoryPtr_;
+    std::shared_ptr<ProcessHistory const> processHistoryPtr_;
 
     ProcessHistoryID processHistoryID_;
 
@@ -248,8 +247,8 @@ namespace edm {
 
     // Pointer to the product registry. There is one entry in the registry
     // for each EDProduct in the event.
-    boost::shared_ptr<ProductRegistry const> preg_;
-    boost::shared_ptr<ProductHolderIndexHelper const> productLookup_;
+    std::shared_ptr<ProductRegistry const> preg_;
+    std::shared_ptr<ProductHolderIndexHelper const> productLookup_;
 
     std::vector<unsigned int> lookupProcessOrder_;
     ProcessHistoryID orderProcessHistoryID_;
@@ -274,19 +273,19 @@ namespace edm {
 
   template <typename PROD>
   inline
-  boost::shared_ptr<Wrapper<PROD> const>
+  std::shared_ptr<Wrapper<PROD> const>
     getProductByTag(Principal const& ep, InputTag const& tag, ModuleCallingContext const* mcc) {
     TypeID tid = TypeID(typeid(PROD));
     ProductData const* result = ep.findProductByTag(tid, tag, mcc);
     if(result == nullptr) {
-      return boost::shared_ptr<Wrapper<PROD> const>(); 
+      return std::shared_ptr<Wrapper<PROD> const>(); 
     }
 
     if(result->getInterface() &&
        (!(result->getInterface()->dynamicTypeInfo() == typeid(PROD)))) {
       handleimpl::throwConvertTypeError(typeid(PROD), result->getInterface()->dynamicTypeInfo());
     }
-    return boost::static_pointer_cast<Wrapper<PROD> const>(result->wrapper_);
+    return std::static_pointer_cast<Wrapper<PROD> const>(result->wrapper_);
   }
 }
 #endif

--- a/FWCore/Framework/interface/ProductHolder.h
+++ b/FWCore/Framework/interface/ProductHolder.h
@@ -17,7 +17,7 @@ a set of related EDProducts. This is the storage unit of such information.
 #include "FWCore/Utilities/interface/ProductHolderIndex.h"
 #include "FWCore/Utilities/interface/TypeID.h"
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 #include <string>
 
@@ -80,7 +80,7 @@ namespace edm {
     bool productWasDeleted() const {return productWasDeleted_();}
 
     // Retrieves a shared pointer to the wrapped product.
-    boost::shared_ptr<void const> product() const { return getProductData().wrapper_; }
+    std::shared_ptr<void const> product() const { return getProductData().wrapper_; }
 
     // Retrieves the wrapped product and type. (non-owning);
     WrapperHolder wrapper() const { return WrapperHolder(getProductData().wrapper_.get(), getProductData().getInterface()); }
@@ -100,7 +100,7 @@ namespace edm {
     void setPrincipal(Principal* principal) { setPrincipal_(principal); }
 
     // Sets the pointer to the event independent provenance.
-    void resetBranchDescription(boost::shared_ptr<BranchDescription const> bd) {resetBranchDescription_(bd);}
+    void resetBranchDescription(std::shared_ptr<BranchDescription const> bd) {resetBranchDescription_(bd);}
 
     // Retrieves a reference to the module label.
     std::string const& moduleLabel() const {return branchDescription().moduleLabel();}
@@ -120,7 +120,7 @@ namespace edm {
     Provenance* provenance() const;
 
     // Initializes the event independent portion of the provenance, plus the process history ID, the product ID, and the provRetriever.
-    void setProvenance(boost::shared_ptr<ProductProvenanceRetriever> provRetriever, ProcessHistory const& ph, ProductID const& pid) { setProvenance_(provRetriever, ph, pid); }
+    void setProvenance(std::shared_ptr<ProductProvenanceRetriever> provRetriever, ProcessHistory const& ph, ProductID const& pid) { setProvenance_(provRetriever, ph, pid); }
 
     // Initializes the process history.
     void setProcessHistory(ProcessHistory const& ph) { setProcessHistory_(ph); }
@@ -191,9 +191,9 @@ namespace edm {
     virtual void resetStatus_() = 0;
     virtual void setProductDeleted_() = 0;
     virtual BranchDescription const& branchDescription_() const = 0;
-    virtual void resetBranchDescription_(boost::shared_ptr<BranchDescription const> bd) = 0;
+    virtual void resetBranchDescription_(std::shared_ptr<BranchDescription const> bd) = 0;
     virtual std::string const& resolvedModuleLabel_() const = 0;
-    virtual void setProvenance_(boost::shared_ptr<ProductProvenanceRetriever> provRetriever, ProcessHistory const& ph, ProductID const& pid) = 0;
+    virtual void setProvenance_(std::shared_ptr<ProductProvenanceRetriever> provRetriever, ProcessHistory const& ph, ProductID const& pid) = 0;
     virtual void setProcessHistory_(ProcessHistory const& ph) = 0;
     virtual ProductProvenance* productProvenancePtr_() const = 0;
     virtual void resetProductData_() = 0;
@@ -210,7 +210,7 @@ namespace edm {
 
   class InputProductHolder : public ProductHolderBase {
     public:
-    explicit InputProductHolder(boost::shared_ptr<BranchDescription const> bd, Principal* principal) :
+    explicit InputProductHolder(std::shared_ptr<BranchDescription const> bd, Principal* principal) :
         ProductHolderBase(), productData_(bd), productIsUnavailable_(false),
         productHasBeenDeleted_(false), principal_(principal) {}
       virtual ~InputProductHolder();
@@ -245,9 +245,9 @@ namespace edm {
       virtual ProductData& getProductData() {return productData_;}
       virtual void setProductDeleted_() {productHasBeenDeleted_ = true;}
       virtual BranchDescription const& branchDescription_() const {return *productData().branchDescription();}
-      virtual void resetBranchDescription_(boost::shared_ptr<BranchDescription const> bd) {productData().resetBranchDescription(bd);}
+      virtual void resetBranchDescription_(std::shared_ptr<BranchDescription const> bd) {productData().resetBranchDescription(bd);}
       virtual std::string const& resolvedModuleLabel_() const {return moduleLabel();}
-      virtual void setProvenance_(boost::shared_ptr<ProductProvenanceRetriever> provRetriever, ProcessHistory const& ph, ProductID const& pid);
+      virtual void setProvenance_(std::shared_ptr<ProductProvenanceRetriever> provRetriever, ProcessHistory const& ph, ProductID const& pid);
       virtual void setProcessHistory_(ProcessHistory const& ph);
       virtual ProductProvenance* productProvenancePtr_() const;
       virtual void resetProductData_();
@@ -295,9 +295,9 @@ namespace edm {
       virtual bool productWasDeleted_() const;
       virtual void setProductDeleted_();
       virtual BranchDescription const& branchDescription_() const {return *productData().branchDescription();}
-      virtual void resetBranchDescription_(boost::shared_ptr<BranchDescription const> bd) {productData().resetBranchDescription(bd);}
+      virtual void resetBranchDescription_(std::shared_ptr<BranchDescription const> bd) {productData().resetBranchDescription(bd);}
       virtual std::string const& resolvedModuleLabel_() const {return moduleLabel();}
-      virtual void setProvenance_(boost::shared_ptr<ProductProvenanceRetriever> provRetriever, ProcessHistory const& ph, ProductID const& pid);
+      virtual void setProvenance_(std::shared_ptr<ProductProvenanceRetriever> provRetriever, ProcessHistory const& ph, ProductID const& pid);
       virtual void setProcessHistory_(ProcessHistory const& ph);
       virtual ProductProvenance* productProvenancePtr_() const;
       virtual void resetProductData_();
@@ -307,7 +307,7 @@ namespace edm {
 
   class ScheduledProductHolder : public ProducedProductHolder {
     public:
-      explicit ScheduledProductHolder(boost::shared_ptr<BranchDescription const> bd) : ProducedProductHolder(), productData_(bd), theStatus_(NotRun) {}
+      explicit ScheduledProductHolder(std::shared_ptr<BranchDescription const> bd) : ProducedProductHolder(), productData_(bd), theStatus_(NotRun) {}
       virtual ~ScheduledProductHolder();
     private:
       virtual void swap_(ProductHolderBase& rhs) {
@@ -334,7 +334,7 @@ namespace edm {
 
   class UnscheduledProductHolder : public ProducedProductHolder {
     public:
-      explicit UnscheduledProductHolder(boost::shared_ptr<BranchDescription const> bd, Principal* principal) :
+      explicit UnscheduledProductHolder(std::shared_ptr<BranchDescription const> bd, Principal* principal) :
         ProducedProductHolder(), productData_(bd), theStatus_(UnscheduledNotRun), principal_(principal) {}
       virtual ~UnscheduledProductHolder();
     private:
@@ -363,7 +363,7 @@ namespace edm {
 
   class SourceProductHolder : public ProducedProductHolder {
     public:
-      explicit SourceProductHolder(boost::shared_ptr<BranchDescription const> bd) : ProducedProductHolder(), productData_(bd), theStatus_(NotPut) {}
+      explicit SourceProductHolder(std::shared_ptr<BranchDescription const> bd) : ProducedProductHolder(), productData_(bd), theStatus_(NotPut) {}
       virtual ~SourceProductHolder();
     private:
       virtual void swap_(ProductHolderBase& rhs) {
@@ -386,7 +386,7 @@ namespace edm {
   class AliasProductHolder : public ProductHolderBase {
     public:
       typedef ProducedProductHolder::ProductStatus ProductStatus;
-      explicit AliasProductHolder(boost::shared_ptr<BranchDescription const> bd, ProducedProductHolder& realProduct) : ProductHolderBase(), realProduct_(realProduct), bd_(bd) {}
+      explicit AliasProductHolder(std::shared_ptr<BranchDescription const> bd, ProducedProductHolder& realProduct) : ProductHolderBase(), realProduct_(realProduct), bd_(bd) {}
       virtual ~AliasProductHolder();
     private:
       virtual void swap_(ProductHolderBase& rhs) {
@@ -421,9 +421,9 @@ namespace edm {
         return realProduct_.putOrMergeProduct();
       }
       virtual BranchDescription const& branchDescription_() const {return *bd_;}
-      virtual void resetBranchDescription_(boost::shared_ptr<BranchDescription const> bd) {bd_ = bd;}
+      virtual void resetBranchDescription_(std::shared_ptr<BranchDescription const> bd) {bd_ = bd;}
       virtual std::string const& resolvedModuleLabel_() const {return realProduct_.moduleLabel();}
-      virtual void setProvenance_(boost::shared_ptr<ProductProvenanceRetriever> provRetriever, ProcessHistory const& ph, ProductID const& pid);
+      virtual void setProvenance_(std::shared_ptr<ProductProvenanceRetriever> provRetriever, ProcessHistory const& ph, ProductID const& pid);
       virtual void setProcessHistory_(ProcessHistory const& ph);
       virtual ProductProvenance* productProvenancePtr_() const;
       virtual void resetProductData_();
@@ -431,7 +431,7 @@ namespace edm {
       virtual void setPrincipal_(Principal* principal);
 
       ProducedProductHolder& realProduct_;
-      boost::shared_ptr<BranchDescription const> bd_;
+      std::shared_ptr<BranchDescription const> bd_;
   };
 
   class NoProcessProductHolder : public ProductHolderBase {
@@ -459,9 +459,9 @@ namespace edm {
       virtual void resetStatus_();
       virtual void setProductDeleted_();
       virtual BranchDescription const& branchDescription_() const;
-      virtual void resetBranchDescription_(boost::shared_ptr<BranchDescription const> bd);
+      virtual void resetBranchDescription_(std::shared_ptr<BranchDescription const> bd);
       virtual std::string const& resolvedModuleLabel_() const {return moduleLabel();}
-      virtual void setProvenance_(boost::shared_ptr<ProductProvenanceRetriever> provRetriever, ProcessHistory const& ph, ProductID const& pid);
+      virtual void setProvenance_(std::shared_ptr<ProductProvenanceRetriever> provRetriever, ProcessHistory const& ph, ProductID const& pid);
       virtual void setProcessHistory_(ProcessHistory const& ph);
       virtual ProductProvenance* productProvenancePtr_() const;
       virtual void resetProductData_();

--- a/FWCore/Framework/interface/RunPrincipal.h
+++ b/FWCore/Framework/interface/RunPrincipal.h
@@ -15,7 +15,7 @@ is the DataBlock.
 #include <string>
 #include <vector>
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 #include "DataFormats/Provenance/interface/RunAuxiliary.h"
 #include "DataFormats/Provenance/interface/ProcessHistoryID.h"
@@ -34,8 +34,8 @@ namespace edm {
     typedef Principal Base;
 
     RunPrincipal(
-        boost::shared_ptr<RunAuxiliary> aux,
-        boost::shared_ptr<ProductRegistry const> reg,
+        std::shared_ptr<RunAuxiliary> aux,
+        std::shared_ptr<ProductRegistry const> reg,
         ProcessConfiguration const& pc,
         HistoryAppender* historyAppender,
         unsigned int iRunIndex);
@@ -86,7 +86,7 @@ namespace edm {
       return aux_->mergeAuxiliary(aux);
     }
 
-    void setUnscheduledHandler(boost::shared_ptr<UnscheduledHandler>) {}
+    void setUnscheduledHandler(std::shared_ptr<UnscheduledHandler>) {}
 
     void put(
         BranchDescription const& bd,
@@ -109,7 +109,7 @@ namespace edm {
 
     void resolveProductImmediate(ProductHolderBase const& phb) const;
 
-    boost::shared_ptr<RunAuxiliary> aux_;
+    std::shared_ptr<RunAuxiliary> aux_;
     ProcessHistoryID m_reducedHistoryID;
     RunIndex index_;
 

--- a/FWCore/Framework/interface/Schedule.h
+++ b/FWCore/Framework/interface/Schedule.h
@@ -109,9 +109,9 @@ namespace edm {
   class Schedule {
   public:
     typedef std::vector<std::string> vstring;
-    typedef boost::shared_ptr<Worker> WorkerPtr;
+    typedef std::shared_ptr<Worker> WorkerPtr;
     typedef std::vector<Worker*> AllWorkers;
-    typedef std::vector<boost::shared_ptr<OutputModuleCommunicator>> AllOutputModuleCommunicators;
+    typedef std::vector<boost::shared_ptr<OutputModuleCommunicator> > AllOutputModuleCommunicators;
 
     typedef std::vector<Worker*> Workers;
 
@@ -120,8 +120,8 @@ namespace edm {
              ProductRegistry& pregistry,
              BranchIDListHelper& branchIDListHelper,
              ExceptionToActionTable const& actions,
-             boost::shared_ptr<ActivityRegistry> areg,
-             boost::shared_ptr<ProcessConfiguration> processConfiguration,
+             std::shared_ptr<ActivityRegistry> areg,
+             std::shared_ptr<ProcessConfiguration> processConfiguration,
              const ParameterSet* subProcPSet,
              PreallocationConfiguration const& config,
              ProcessContext const* processContext);
@@ -241,7 +241,7 @@ namespace edm {
     void limitOutput(ParameterSet const& proc_pset, BranchIDLists const& branchIDLists);
 
     std::shared_ptr<TriggerResultInserter> resultsInserter_;
-    boost::shared_ptr<ModuleRegistry> moduleRegistry_;
+    std::shared_ptr<ModuleRegistry> moduleRegistry_;
     std::vector<std::shared_ptr<StreamSchedule>> streamSchedules_;
     //In the future, we will have one GlobalSchedule per simultaneous transition
     std::unique_ptr<GlobalSchedule> globalSchedule_;

--- a/FWCore/Framework/interface/ScheduleItems.h
+++ b/FWCore/Framework/interface/ScheduleItems.h
@@ -4,8 +4,6 @@
 #include "FWCore/ServiceRegistry/interface/ServiceLegacy.h"
 #include "FWCore/ServiceRegistry/interface/ServiceToken.h"
 
-#include "boost/shared_ptr.hpp"
-
 #include <memory>
 #include <vector>
 
@@ -42,7 +40,7 @@ namespace edm {
     ServiceToken
     addCPRandTNS(ParameterSet const& parameterSet, ServiceToken const& token);
 
-    boost::shared_ptr<CommonParams>
+    std::shared_ptr<CommonParams>
     initMisc(ParameterSet& parameterSet);
 
     std::auto_ptr<Schedule>
@@ -54,11 +52,11 @@ namespace edm {
     void
     clear();
 
-    boost::shared_ptr<ActivityRegistry>           actReg_;
+    std::shared_ptr<ActivityRegistry>           actReg_;
     std::unique_ptr<SignallingProductRegistry>    preg_;
-    boost::shared_ptr<BranchIDListHelper>         branchIDListHelper_;
+    std::shared_ptr<BranchIDListHelper>         branchIDListHelper_;
     std::unique_ptr<ExceptionToActionTable const>            act_table_;
-    boost::shared_ptr<ProcessConfiguration>       processConfiguration_;
+    std::shared_ptr<ProcessConfiguration>       processConfiguration_;
   };
 }
 

--- a/FWCore/Framework/interface/SubProcess.h
+++ b/FWCore/Framework/interface/SubProcess.h
@@ -22,7 +22,6 @@
 
 namespace edm {
   class BranchIDListHelper;
-  class EDLooperBase;
   class HistoryAppender;
   class IOVSyncValue;
   class ParameterSet;
@@ -36,8 +35,8 @@ namespace edm {
   public:
     SubProcess(ParameterSet& parameterSet,
                ParameterSet const& topLevelParameterSet,
-               boost::shared_ptr<ProductRegistry const> parentProductRegistry,
-               boost::shared_ptr<BranchIDListHelper const> parentBranchIDListHelper,
+               std::shared_ptr<ProductRegistry const> parentProductRegistry,
+               std::shared_ptr<BranchIDListHelper const> parentBranchIDListHelper,
                eventsetup::EventSetupsController& esController,
                ActivityRegistry& parentActReg,
                ServiceToken const& token,
@@ -220,11 +219,11 @@ namespace edm {
 
     
     ServiceToken                                  serviceToken_;
-    boost::shared_ptr<ProductRegistry const>      parentPreg_;
-    boost::shared_ptr<ProductRegistry const>	    preg_;
-    boost::shared_ptr<BranchIDListHelper>         branchIDListHelper_;
+    std::shared_ptr<ProductRegistry const>      parentPreg_;
+    std::shared_ptr<ProductRegistry const>	    preg_;
+    std::shared_ptr<BranchIDListHelper>         branchIDListHelper_;
     std::unique_ptr<ExceptionToActionTable const> act_table_;
-    boost::shared_ptr<ProcessConfiguration const> processConfiguration_;
+    std::shared_ptr<ProcessConfiguration const> processConfiguration_;
     ProcessContext                                processContext_;
     //We require 1 history for each Run, Lumi and Stream
     // The vectors first hold Stream info, then Lumi then Run

--- a/FWCore/Framework/interface/WorkerManager.h
+++ b/FWCore/Framework/interface/WorkerManager.h
@@ -13,7 +13,7 @@
 #include "FWCore/Utilities/interface/ConvertException.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 #include <set>
 #include <string>
@@ -30,15 +30,15 @@ namespace edm {
   public:
     typedef std::vector<Worker*> AllWorkers;
 
-    WorkerManager(boost::shared_ptr<ActivityRegistry> actReg, ExceptionToActionTable const& actions);
+    WorkerManager(std::shared_ptr<ActivityRegistry> actReg, ExceptionToActionTable const& actions);
 
-    WorkerManager(boost::shared_ptr<ModuleRegistry> modReg,
-                  boost::shared_ptr<ActivityRegistry> actReg,
+    WorkerManager(std::shared_ptr<ModuleRegistry> modReg,
+                  std::shared_ptr<ActivityRegistry> actReg,
                   ExceptionToActionTable const& actions);
     void addToUnscheduledWorkers(ParameterSet& pset,
                                  ProductRegistry& preg,
                                  PreallocationConfiguration const* prealloc,
-                                 boost::shared_ptr<ProcessConfiguration> processConfiguration,
+                                 std::shared_ptr<ProcessConfiguration> processConfiguration,
                                  std::string label,
                                  bool useStopwatch,
                                  std::set<std::string>& unscheduledLabels,
@@ -70,7 +70,7 @@ namespace edm {
     Worker* getWorker(ParameterSet& pset,
                       ProductRegistry& preg,
                       PreallocationConfiguration const* prealloc,
-                      boost::shared_ptr<ProcessConfiguration const> processConfiguration,
+                      std::shared_ptr<ProcessConfiguration const> processConfiguration,
                       std::string const& label);
 
   private:
@@ -84,7 +84,7 @@ namespace edm {
 
     AllWorkers          allWorkers_;
 
-    boost::shared_ptr<UnscheduledCallProducer> unscheduled_;
+    std::shared_ptr<UnscheduledCallProducer> unscheduled_;
   };
 
   template <typename T, typename U>

--- a/FWCore/Framework/src/EventPrincipal.cc
+++ b/FWCore/Framework/src/EventPrincipal.cc
@@ -22,8 +22,8 @@
 
 namespace edm {
   EventPrincipal::EventPrincipal(
-        boost::shared_ptr<ProductRegistry const> reg,
-        boost::shared_ptr<BranchIDListHelper const> branchIDListHelper,
+        std::shared_ptr<ProductRegistry const> reg,
+        std::shared_ptr<BranchIDListHelper const> branchIDListHelper,
         ProcessConfiguration const& pc,
         HistoryAppender* historyAppender,
         unsigned int streamIndex) :
@@ -111,7 +111,7 @@ namespace edm {
   }
 
   void
-  EventPrincipal::setLuminosityBlockPrincipal(boost::shared_ptr<LuminosityBlockPrincipal> const& lbp) {
+  EventPrincipal::setLuminosityBlockPrincipal(std::shared_ptr<LuminosityBlockPrincipal> const& lbp) {
     luminosityBlockPrincipal_ = lbp;
   }
 
@@ -286,11 +286,11 @@ namespace edm {
   }
 
   void
-  EventPrincipal::setUnscheduledHandler(boost::shared_ptr<UnscheduledHandler> iHandler) {
+  EventPrincipal::setUnscheduledHandler(std::shared_ptr<UnscheduledHandler> iHandler) {
     unscheduledHandler_ = iHandler;
   }
 
-  boost::shared_ptr<UnscheduledHandler>
+  std::shared_ptr<UnscheduledHandler>
   EventPrincipal::unscheduledHandler() const {
      return unscheduledHandler_;
   }

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -97,9 +97,9 @@ namespace edm {
   makeInput(ParameterSet& params,
             CommonParams const& common,
             ProductRegistry& preg,
-            boost::shared_ptr<BranchIDListHelper> branchIDListHelper,
-            boost::shared_ptr<ActivityRegistry> areg,
-            boost::shared_ptr<ProcessConfiguration const> processConfiguration,
+            std::shared_ptr<BranchIDListHelper> branchIDListHelper,
+            std::shared_ptr<ActivityRegistry> areg,
+            std::shared_ptr<ProcessConfiguration const> processConfiguration,
             PreallocationConfiguration const& allocations) {
     ParameterSet* main_input = params.getPSetForUpdate("@main_input");
     if(main_input == 0) {
@@ -227,8 +227,8 @@ namespace edm {
     numberOfSequentialEventsPerChild_(1),
     setCpuAffinity_(false),
     eventSetupDataToExcludeFromPrefetching_() {
-    boost::shared_ptr<ParameterSet> parameterSet = PythonProcessDesc(config).parameterSet();
-    boost::shared_ptr<ProcessDesc> processDesc(new ProcessDesc(parameterSet));
+    std::shared_ptr<ParameterSet> parameterSet = PythonProcessDesc(config).parameterSet();
+    auto processDesc = std::make_shared<ProcessDesc>(parameterSet);
     processDesc->addServices(defaultServices, forcedServices);
     init(processDesc, iToken, iLegacy);
   }
@@ -271,13 +271,13 @@ namespace edm {
   nextItemTypeFromProcessingEvents_(InputSource::IsEvent),
     eventSetupDataToExcludeFromPrefetching_()
   {
-    boost::shared_ptr<ParameterSet> parameterSet = PythonProcessDesc(config).parameterSet();
-    boost::shared_ptr<ProcessDesc> processDesc(new ProcessDesc(parameterSet));
+    std::shared_ptr<ParameterSet> parameterSet = PythonProcessDesc(config).parameterSet();
+    auto processDesc = std::make_shared<ProcessDesc>(parameterSet);
     processDesc->addServices(defaultServices, forcedServices);
     init(processDesc, ServiceToken(), serviceregistry::kOverlapIsError);
   }
 
-  EventProcessor::EventProcessor(boost::shared_ptr<ProcessDesc>& processDesc,
+  EventProcessor::EventProcessor(std::shared_ptr<ProcessDesc>& processDesc,
                  ServiceToken const& token,
                  serviceregistry::ServiceLegacy legacy) :
     actReg_(),
@@ -356,18 +356,18 @@ namespace edm {
     eventSetupDataToExcludeFromPrefetching_()
 {
     if(isPython) {
-      boost::shared_ptr<ParameterSet> parameterSet = PythonProcessDesc(config).parameterSet();
-      boost::shared_ptr<ProcessDesc> processDesc(new ProcessDesc(parameterSet));
+      std::shared_ptr<ParameterSet> parameterSet = PythonProcessDesc(config).parameterSet();
+      auto processDesc = std::make_shared<ProcessDesc>(parameterSet);
       init(processDesc, ServiceToken(), serviceregistry::kOverlapIsError);
     }
     else {
-      boost::shared_ptr<ProcessDesc> processDesc(new ProcessDesc(config));
+      auto processDesc = std::make_shared<ProcessDesc>(config);
       init(processDesc, ServiceToken(), serviceregistry::kOverlapIsError);
     }
   }
 
   void
-  EventProcessor::init(boost::shared_ptr<ProcessDesc>& processDesc,
+  EventProcessor::init(std::shared_ptr<ProcessDesc>& processDesc,
                         ServiceToken const& iToken,
                         serviceregistry::ServiceLegacy iLegacy) {
 
@@ -381,11 +381,11 @@ namespace edm {
     // register the empty parameter set, once and for all.
     ParameterSet().registerIt();
 
-    boost::shared_ptr<ParameterSet> parameterSet = processDesc->getProcessPSet();
+    std::shared_ptr<ParameterSet> parameterSet = processDesc->getProcessPSet();
     //std::cerr << parameterSet->dump() << std::endl;
 
     // If there is a subprocess, pop the subprocess parameter set out of the process parameter set
-    boost::shared_ptr<ParameterSet> subProcessParameterSet(popSubProcessParameterSet(*parameterSet).release());
+    std::shared_ptr<ParameterSet> subProcessParameterSet(popSubProcessParameterSet(*parameterSet).release());
 
     // Now set some parameters specific to the main process.
     ParameterSet const& optionsPset(parameterSet->getUntrackedParameterSet("options", ParameterSet()));
@@ -459,7 +459,7 @@ namespace edm {
     ScheduleItems items;
 
     //initialize the services
-    boost::shared_ptr<std::vector<ParameterSet> > pServiceSets = processDesc->getServicesPSets();
+    std::shared_ptr<std::vector<ParameterSet> > pServiceSets = processDesc->getServicesPSets();
     ServiceToken token = items.initServices(*pServiceSets, *parameterSet, iToken, iLegacy, true);
     serviceToken_ = items.addCPRandTNS(*parameterSet, token);
 
@@ -472,7 +472,7 @@ namespace edm {
     }
 
     // intialize miscellaneous items
-    boost::shared_ptr<CommonParams> common(items.initMisc(*parameterSet));
+    std::shared_ptr<CommonParams> common(items.initMisc(*parameterSet));
 
     // intialize the event setup provider
     esp_ = espController_->makeProvider(*parameterSet);
@@ -511,11 +511,7 @@ namespace edm {
     principalCache_.setNumberOfConcurrentPrincipals(preallocations_);
     for(unsigned int index = 0; index<preallocations_.numberOfStreams(); ++index ) {
       // Reusable event principal
-      boost::shared_ptr<EventPrincipal> ep(new EventPrincipal(preg_,
-                                                              branchIDListHelper_,
-                                                              *processConfiguration_,
-                                                              historyAppender_.get(),
-                                                              index));
+      auto ep = std::make_shared<EventPrincipal>(preg_, branchIDListHelper_, *processConfiguration_, historyAppender_.get(), index);
       ep->preModuleDelayedGetSignal_.connect(std::cref(actReg_->preModuleEventDelayedGetSignal_));
       ep->postModuleDelayedGetSignal_.connect(std::cref(actReg_->postModuleEventDelayedGetSignal_));
       principalCache_.insert(ep);
@@ -1069,7 +1065,7 @@ namespace edm {
         jobReport->childAfterFork(jobReportFile, childIndex, kMaxChildren);
         actReg_->postForkReacquireResourcesSignal_(childIndex, kMaxChildren);
 
-        boost::shared_ptr<multicore::MessageReceiverForSource> receiver(new multicore::MessageReceiverForSource(sockets[1], pipes[1]));
+        auto receiver = std::make_shared<multicore::MessageReceiverForSource>(sockets[1], pipes[1]);
         input_->doPostForkReacquireResources(receiver);
         schedule_->postForkReacquireResources(childIndex, kMaxChildren);
         //NOTE: sources have to reset themselves by listening to the post fork message
@@ -1692,11 +1688,7 @@ namespace edm {
         << "Illegal attempt to insert run into cache\n"
         << "Contact a Framework Developer\n";
     }
-    boost::shared_ptr<RunPrincipal> rp(new RunPrincipal(input_->runAuxiliary(),
-                                                        preg_,
-                                                        *processConfiguration_,
-                                                        historyAppender_.get(),
-                                                        0));
+    auto rp = std::make_shared<RunPrincipal>(input_->runAuxiliary(), preg_, *processConfiguration_, historyAppender_.get(), 0);
     input_->readRun(*rp, *historyAppender_);
     assert(input_->reducedProcessHistoryID() == rp->reducedProcessHistoryID());
     principalCache_.insert(rp);
@@ -1725,11 +1717,7 @@ namespace edm {
         << "Run is invalid\n"
         << "Contact a Framework Developer\n";
     }
-    boost::shared_ptr<LuminosityBlockPrincipal> lbp(new LuminosityBlockPrincipal(input_->luminosityBlockAuxiliary(),
-                                                                                 preg_,
-                                                                                 *processConfiguration_,
-                                                                                 historyAppender_.get(),
-                                                                                 0));
+    auto lbp = std::make_shared<LuminosityBlockPrincipal>(input_->luminosityBlockAuxiliary(), preg_, *processConfiguration_, historyAppender_.get(), 0);
     input_->readLuminosityBlock(*lbp, *historyAppender_);
     lbp->setRunPrincipal(principalCache_.runPrincipalPtr());
     principalCache_.insert(lbp);

--- a/FWCore/Framework/src/EventSelector.cc
+++ b/FWCore/Framework/src/EventSelector.cc
@@ -768,7 +768,7 @@ namespace edm
    *         if the trigger selection is invalid in the context of the
    *         full trigger list.
    */
-  boost::shared_ptr<TriggerResults>
+  std::shared_ptr<TriggerResults>
   EventSelector::maskTriggerResults(TriggerResults const& inputResults)
   {
     // fetch and validate the total number of paths
@@ -853,8 +853,7 @@ namespace edm
  
     // Based on the global status for the mask, create and return a 
     // TriggerResults
-    boost::shared_ptr<TriggerResults>
-      maskedResults(new TriggerResults(mask, inputResults.parameterSetID()));
+    auto maskedResults = std::make_shared<TriggerResults>(mask, inputResults.parameterSetID());
     return maskedResults;
   }  // maskTriggerResults
 
@@ -881,7 +880,7 @@ namespace edm
    *         if the trigger selection is invalid in the context of the
    *         full trigger list.
    */
-  boost::shared_ptr<TriggerResults>
+  std::shared_ptr<TriggerResults>
   EventSelector::maskTriggerResults(Strings const& pathspecs,
                                     TriggerResults const& inputResults,
                                     Strings const& fullTriggerList)
@@ -899,8 +898,7 @@ namespace edm
 
     // create a working copy of the TriggerResults object
     HLTGlobalStatus hltGS(fullTriggerCount);
-    boost::shared_ptr<TriggerResults>
-      maskedResults(new TriggerResults(hltGS, inputResults.parameterSetID()));
+    auto maskedResults = std::make_shared<TriggerResults>(hltGS, inputResults.parameterSetID());
     for (unsigned int iPath = 0; iPath < fullTriggerCount; iPath++)
     {
       (*maskedResults)[iPath] = inputResults[iPath];

--- a/FWCore/Framework/src/GlobalSchedule.cc
+++ b/FWCore/Framework/src/GlobalSchedule.cc
@@ -17,14 +17,14 @@
 
 namespace edm {
   GlobalSchedule::GlobalSchedule(TriggerResultInserter* inserter,
-                                 boost::shared_ptr<ModuleRegistry> modReg,
+                                 std::shared_ptr<ModuleRegistry> modReg,
                                  std::vector<std::string> const& iModulesToUse,
                                  ParameterSet& proc_pset,
                                  ProductRegistry& pregistry,
                                  PreallocationConfiguration const& prealloc,
                                  ExceptionToActionTable const& actions,
-                                 boost::shared_ptr<ActivityRegistry> areg,
-                                 boost::shared_ptr<ProcessConfiguration> processConfiguration,
+                                 std::shared_ptr<ActivityRegistry> areg,
+                                 std::shared_ptr<ProcessConfiguration> processConfiguration,
                                  ProcessContext const* processContext) :
     workerManager_(modReg,areg,actions),
     actReg_(areg),

--- a/FWCore/Framework/src/GlobalSchedule.h
+++ b/FWCore/Framework/src/GlobalSchedule.h
@@ -20,8 +20,6 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/StreamID.h"
 
-#include "boost/shared_ptr.hpp"
-
 #include <map>
 #include <memory>
 #include <set>
@@ -72,18 +70,18 @@ namespace edm {
   public:
     typedef std::vector<std::string> vstring;
     typedef std::vector<Worker*> AllWorkers;
-    typedef boost::shared_ptr<Worker> WorkerPtr;
+    typedef std::shared_ptr<Worker> WorkerPtr;
     typedef std::vector<Worker*> Workers;
 
     GlobalSchedule(TriggerResultInserter* inserter,
-                   boost::shared_ptr<ModuleRegistry> modReg,
+                   std::shared_ptr<ModuleRegistry> modReg,
                    std::vector<std::string> const& modulesToUse,
                    ParameterSet& proc_pset,
                    ProductRegistry& pregistry,
                    PreallocationConfiguration const& prealloc,
                    ExceptionToActionTable const& actions,
-                   boost::shared_ptr<ActivityRegistry> areg,
-                   boost::shared_ptr<ProcessConfiguration> processConfiguration,
+                   std::shared_ptr<ActivityRegistry> areg,
+                   std::shared_ptr<ProcessConfiguration> processConfiguration,
                    ProcessContext const* processContext);
     GlobalSchedule(GlobalSchedule const&) = delete;
 
@@ -132,7 +130,7 @@ namespace edm {
     void addToAllWorkers(Worker* w);
     
     WorkerManager                         workerManager_;
-    boost::shared_ptr<ActivityRegistry>   actReg_;
+    std::shared_ptr<ActivityRegistry>   actReg_;
     WorkerPtr                             results_inserter_;
 
 

--- a/FWCore/Framework/src/HistoryAppender.cc
+++ b/FWCore/Framework/src/HistoryAppender.cc
@@ -14,7 +14,7 @@ namespace edm {
   {
   }
 
-  boost::shared_ptr<ProcessHistory const>
+  std::shared_ptr<ProcessHistory const>
   HistoryAppender::appendToProcessHistory(ProcessHistoryID const& inputPHID,
                                           ProcessHistory const* iInputProcessHistory,
                                           ProcessConfiguration const& pc)  {
@@ -34,7 +34,7 @@ namespace edm {
       }
     }
 
-    boost::shared_ptr<ProcessHistory> newProcessHistory(new ProcessHistory);
+    auto newProcessHistory = std::make_shared<ProcessHistory>();
     *newProcessHistory = *inputProcessHistory;
     checkProcessHistory(*newProcessHistory, pc);
     newProcessHistory->push_back(pc);

--- a/FWCore/Framework/src/InputSource.cc
+++ b/FWCore/Framework/src/InputSource.cc
@@ -44,8 +44,8 @@ namespace edm {
           return (lastDigit == 1 ? st : (lastDigit == 2 ? nd : rd));
         }
         template <typename T>
-        boost::shared_ptr<T> createSharedPtrToStatic(T* ptr) {
-          return boost::shared_ptr<T>(ptr, do_nothing_deleter());
+        std::shared_ptr<T> createSharedPtrToStatic(T* ptr) {
+          return std::shared_ptr<T>(ptr, do_nothing_deleter());
         }
   }
 
@@ -228,15 +228,15 @@ namespace edm {
     return state_;
   }
 
-  boost::shared_ptr<LuminosityBlockAuxiliary>
+  std::shared_ptr<LuminosityBlockAuxiliary>
   InputSource::readLuminosityBlockAuxiliary() {
-    return callWithTryCatchAndPrint<boost::shared_ptr<LuminosityBlockAuxiliary> >( [this](){ return readLuminosityBlockAuxiliary_(); },
+    return callWithTryCatchAndPrint<std::shared_ptr<LuminosityBlockAuxiliary> >( [this](){ return readLuminosityBlockAuxiliary_(); },
                                                                                    "Calling InputSource::readLuminosityBlockAuxiliary_" );
   }
 
-  boost::shared_ptr<RunAuxiliary>
+  std::shared_ptr<RunAuxiliary>
   InputSource::readRunAuxiliary() {
-    return callWithTryCatchAndPrint<boost::shared_ptr<RunAuxiliary> >( [this](){ return readRunAuxiliary_(); },
+    return callWithTryCatchAndPrint<std::shared_ptr<RunAuxiliary> >( [this](){ return readRunAuxiliary_(); },
                                                                        "Calling InputSource::readRunAuxiliary_" );
   }
 
@@ -518,7 +518,7 @@ namespace edm {
   }
 
   void
-  InputSource::doPostForkReacquireResources(boost::shared_ptr<multicore::MessageReceiverForSource> iReceiver) {
+  InputSource::doPostForkReacquireResources(std::shared_ptr<multicore::MessageReceiverForSource> iReceiver) {
     callWithTryCatchAndPrint<void>( [this, &iReceiver](){ postForkReacquireResources(iReceiver); },
                                     "Calling InputSource::postForkReacquireResources" );
   }
@@ -563,7 +563,7 @@ namespace edm {
   InputSource::preForkReleaseResources() {}
 
   void
-  InputSource::postForkReacquireResources(boost::shared_ptr<multicore::MessageReceiverForSource> iReceiver) {
+  InputSource::postForkReacquireResources(std::shared_ptr<multicore::MessageReceiverForSource> iReceiver) {
     receiver_ = iReceiver;
     receiver_->receive();
     numberOfEventsBeforeBigSkip_ = receiver_->numberOfConsecutiveIndices();

--- a/FWCore/Framework/src/LuminosityBlockPrincipal.cc
+++ b/FWCore/Framework/src/LuminosityBlockPrincipal.cc
@@ -9,8 +9,8 @@
 namespace edm {
 
   LuminosityBlockPrincipal::LuminosityBlockPrincipal(
-      boost::shared_ptr<LuminosityBlockAuxiliary> aux,
-      boost::shared_ptr<ProductRegistry const> reg,
+      std::shared_ptr<LuminosityBlockAuxiliary> aux,
+      std::shared_ptr<ProductRegistry const> reg,
       ProcessConfiguration const& pc,
       HistoryAppender* historyAppender,
       unsigned int index) :

--- a/FWCore/Framework/src/MakeModuleParams.h
+++ b/FWCore/Framework/src/MakeModuleParams.h
@@ -9,7 +9,7 @@ This struct is used to communication parameters into the module factory.
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 #include <string>
 
@@ -26,7 +26,7 @@ namespace edm {
     MakeModuleParams(ParameterSet* pset,
                      ProductRegistry& reg,
                      PreallocationConfiguration const* prealloc,
-                     boost::shared_ptr<ProcessConfiguration const> processConfiguration) :
+                     std::shared_ptr<ProcessConfiguration const> processConfiguration) :
       pset_(pset),
       reg_(&reg),
       preallocate_(prealloc),
@@ -35,7 +35,7 @@ namespace edm {
     ParameterSet* pset_;
     ProductRegistry* reg_;
     PreallocationConfiguration const* preallocate_;
-    boost::shared_ptr<ProcessConfiguration const> processConfiguration_;
+    std::shared_ptr<ProcessConfiguration const> processConfiguration_;
   };
 }
 

--- a/FWCore/Framework/src/Path.cc
+++ b/FWCore/Framework/src/Path.cc
@@ -14,7 +14,7 @@ namespace edm {
              WorkersInPath const& workers,
              TrigResPtr trptr,
              ExceptionToActionTable const& actions,
-             boost::shared_ptr<ActivityRegistry> areg,
+             std::shared_ptr<ActivityRegistry> areg,
              StreamContext const* streamContext,
              PathContext::PathType pathType) :
     stopwatch_(),

--- a/FWCore/Framework/src/Path.h
+++ b/FWCore/Framework/src/Path.h
@@ -20,7 +20,7 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/ConvertException.h"
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 #include <string>
 #include <vector>
@@ -45,13 +45,13 @@ namespace edm {
 
     typedef std::vector<WorkerInPath> WorkersInPath;
     typedef WorkersInPath::size_type        size_type;
-    typedef boost::shared_ptr<HLTGlobalStatus> TrigResPtr;
+    typedef std::shared_ptr<HLTGlobalStatus> TrigResPtr;
 
     Path(int bitpos, std::string const& path_name,
          WorkersInPath const& workers,
          TrigResPtr trptr,
          ExceptionToActionTable const& actions,
-         boost::shared_ptr<ActivityRegistry> reg,
+         std::shared_ptr<ActivityRegistry> reg,
          StreamContext const* streamContext,
          PathContext::PathType pathType);
 
@@ -110,7 +110,7 @@ namespace edm {
 
     int bitpos_;
     TrigResPtr trptr_;
-    boost::shared_ptr<ActivityRegistry> actReg_;
+    std::shared_ptr<ActivityRegistry> actReg_;
     ExceptionToActionTable const* act_table_;
 
     WorkersInPath workers_;

--- a/FWCore/Framework/src/Principal.cc
+++ b/FWCore/Framework/src/Principal.cc
@@ -60,7 +60,7 @@ namespace edm {
   std::shared_ptr<cms::Exception>
   makeNotFoundException(char const* where, KindOfType kindOfType,
                         TypeID const& productType, std::string const& label, std::string const& instance, std::string const& process) {
-    std::shared_ptr<cms::Exception> exception(new Exception(errors::ProductNotFound));
+    std::shared_ptr<cms::Exception> exception = std::make_shared<Exception>(errors::ProductNotFound);
     if (kindOfType == PRODUCT_TYPE) {
       *exception << "Principal::" << where << ": Found zero products matching all criteria\nLooking for type: " << productType << "\n"
                  << "Looking for module label: " << label << "\n" << "Looking for productInstanceName: " << instance << "\n"
@@ -122,8 +122,8 @@ namespace edm {
     return s_nextIdentifier.fetch_add(1,std::memory_order_acq_rel);
   }
   
-  Principal::Principal(boost::shared_ptr<ProductRegistry const> reg,
-                       boost::shared_ptr<ProductHolderIndexHelper const> productLookup,
+  Principal::Principal(std::shared_ptr<ProductRegistry const> reg,
+                       std::shared_ptr<ProductHolderIndexHelper const> productLookup,
                        ProcessConfiguration const& pc,
                        BranchType bt,
                        HistoryAppender* historyAppender) :
@@ -155,7 +155,7 @@ namespace edm {
         if(bd.isAlias()) {
           hasAliases = true;
         } else {
-          boost::shared_ptr<BranchDescription const> cbd(new BranchDescription const(bd));
+          auto cbd = std::make_shared<BranchDescription const>(bd);
           if(bd.produced()) {
             if(bd.moduleLabel() == source) {
               addSourceProduct(cbd);
@@ -176,7 +176,7 @@ namespace edm {
       for(auto const& prod : prodsList) {
         BranchDescription const& bd = prod.second;
         if(bd.isAlias() && bd.branchType() == branchType_) {
-          boost::shared_ptr<BranchDescription const> cbd(new BranchDescription const(bd));
+          auto cbd = std::make_shared<BranchDescription const>(bd);
           addAliasedProduct(cbd);
         }
       }
@@ -202,7 +202,7 @@ namespace edm {
           ProductHolderIndexHelper::IndexAndNames const& product = indexAndNames.at(i);
           if (product.startInProcessNames() == 0) {
             if (productHolderIndex != ProductHolderIndexInvalid) {
-              boost::shared_ptr<ProductHolderBase> newHolder(new NoProcessProductHolder(matchingHolders, ambiguous, this));
+              std::shared_ptr<ProductHolderBase> newHolder = std::make_shared<NoProcessProductHolder>(matchingHolders, ambiguous, this);
               productHolders_.at(productHolderIndex) = newHolder;
               matchingHolders.assign(lookupProcessNames.size(), ProductHolderIndexInvalid);
               ambiguous.assign(lookupProcessNames.size(), false);
@@ -223,7 +223,7 @@ namespace edm {
           }
         }
       }
-      boost::shared_ptr<ProductHolderBase> newHolder(new NoProcessProductHolder(matchingHolders, ambiguous, this));
+      std::shared_ptr<ProductHolderBase> newHolder = std::make_shared<NoProcessProductHolder>(matchingHolders, ambiguous, this);
       productHolders_.at(productHolderIndex) = newHolder;
     }
   }
@@ -255,7 +255,7 @@ namespace edm {
     for(auto const& prod : prodsList) {
       BranchDescription const& bd = prod.second;
       if(!bd.produced() && (bd.branchType() == branchType_)) {
-        boost::shared_ptr<BranchDescription const> cbd(new BranchDescription const(bd));
+        auto cbd = std::make_shared<BranchDescription const>(bd);
         ProductHolderBase* phb = getExistingProduct(cbd->branchID());
         if(phb == nullptr || phb->branchDescription().branchName() != cbd->branchName()) {
             return false;
@@ -267,31 +267,31 @@ namespace edm {
   }
 
   void
-  Principal::addScheduledProduct(boost::shared_ptr<BranchDescription const> bd) {
+  Principal::addScheduledProduct(std::shared_ptr<BranchDescription const> bd) {
     std::auto_ptr<ProductHolderBase> phb(new ScheduledProductHolder(bd));
     addProductOrThrow(phb);
   }
 
   void
-  Principal::addSourceProduct(boost::shared_ptr<BranchDescription const> bd) {
+  Principal::addSourceProduct(std::shared_ptr<BranchDescription const> bd) {
     std::auto_ptr<ProductHolderBase> phb(new SourceProductHolder(bd));
     addProductOrThrow(phb);
   }
 
   void
-  Principal::addInputProduct(boost::shared_ptr<BranchDescription const> bd) {
+  Principal::addInputProduct(std::shared_ptr<BranchDescription const> bd) {
     std::auto_ptr<ProductHolderBase> phb(new InputProductHolder(bd, this));
     addProductOrThrow(phb);
   }
 
   void
-  Principal::addUnscheduledProduct(boost::shared_ptr<BranchDescription const> bd) {
+  Principal::addUnscheduledProduct(std::shared_ptr<BranchDescription const> bd) {
     std::auto_ptr<ProductHolderBase> phb(new UnscheduledProductHolder(bd, this));
     addProductOrThrow(phb);
   }
 
   void
-  Principal::addAliasedProduct(boost::shared_ptr<BranchDescription const> bd) {
+  Principal::addAliasedProduct(std::shared_ptr<BranchDescription const> bd) {
     ProductHolderIndex index = preg_->indexFrom(bd->originalBranchID());
     assert(index != ProductHolderIndexInvalid);
 
@@ -341,12 +341,12 @@ namespace edm {
       processHistoryID_ = processHistoryPtr_->id();
     }
     else {
-      boost::shared_ptr<ProcessHistory const> inputProcessHistory;
+      std::shared_ptr<ProcessHistory const> inputProcessHistory;
       if (hist.isValid()) {
         //does not own the pointer
         auto noDel =[](void const*){};
         inputProcessHistory =
-        boost::shared_ptr<ProcessHistory const>(processHistoryRegistry.getMapped(hist),noDel);
+        std::shared_ptr<ProcessHistory const>(processHistoryRegistry.getMapped(hist),noDel);
         if (inputProcessHistory.get() == nullptr) {
           throw Exception(errors::LogicError)
             << "Principal::fillPrincipal\n"
@@ -355,7 +355,7 @@ namespace edm {
         }
       } else {
         //Since this is static we don't want it deleted
-        inputProcessHistory = boost::shared_ptr<ProcessHistory const>(&s_emptyProcessHistory,[](void const*){});
+        inputProcessHistory = std::shared_ptr<ProcessHistory const>(&s_emptyProcessHistory,[](void const*){});
       }
       processHistoryID_ = hist;
       processHistoryPtr_ = inputProcessHistory;        
@@ -401,7 +401,7 @@ namespace edm {
     assert (!bd.friendlyClassName().empty());
     assert (!bd.moduleLabel().empty());
     assert (!bd.processName().empty());
-    SharedProductPtr phb(productHolder);
+    SharedProductPtr phb(productHolder.release());
 
     ProductHolderIndex index = preg_->indexFrom(bd.branchID());
     assert(index != ProductHolderIndexInvalid);
@@ -483,7 +483,7 @@ namespace edm {
                         bool& ambiguous,
                         ModuleCallingContext const* mcc) const {
     assert(index !=ProductHolderIndexInvalid);
-    boost::shared_ptr<ProductHolderBase> const& productHolder = productHolders_[index];
+    std::shared_ptr<ProductHolderBase> const& productHolder = productHolders_[index];
     assert(0!=productHolder.get());
     ProductHolderBase::ResolveStatus resolveStatus;
     ProductData const* productData = productHolder->resolveProduct(resolveStatus, skipCurrentProcess, mcc);
@@ -501,7 +501,7 @@ namespace edm {
   Principal::prefetch(ProductHolderIndex index,
                       bool skipCurrentProcess,
                       ModuleCallingContext const* mcc) const {
-    boost::shared_ptr<ProductHolderBase> const& productHolder = productHolders_.at(index);
+    std::shared_ptr<ProductHolderBase> const& productHolder = productHolders_.at(index);
     assert(0!=productHolder.get());
     ProductHolderBase::ResolveStatus resolveStatus;
     productHolder->resolveProduct(resolveStatus, skipCurrentProcess, mcc);
@@ -650,7 +650,7 @@ namespace edm {
     }
 
     
-    boost::shared_ptr<ProductHolderBase> const& productHolder = productHolders_[index];
+    std::shared_ptr<ProductHolderBase> const& productHolder = productHolders_[index];
 
     ProductHolderBase::ResolveStatus resolveStatus;
     ProductData const* productData = productHolder->resolveProduct(resolveStatus, skipCurrentProcess, mcc);
@@ -691,7 +691,7 @@ namespace edm {
       failedToRegisterConsumes(kindOfType,typeID,label,instance,process);
     }
     
-    boost::shared_ptr<ProductHolderBase> const& productHolder = productHolders_[index];
+    std::shared_ptr<ProductHolderBase> const& productHolder = productHolders_[index];
 
     ProductHolderBase::ResolveStatus resolveStatus;
     ProductData const* productData = productHolder->resolveProduct(resolveStatus, false, mcc);
@@ -839,7 +839,7 @@ namespace edm {
           if(!productHolders_[index]) {
             // no product holder.  Must add one. The new entry must be an input product holder.
             assert(!bd.produced());
-            boost::shared_ptr<BranchDescription const> cbd(new BranchDescription const(bd));
+            auto cbd = std::make_shared<BranchDescription const>(bd);
             addInputProduct(cbd);
           }
         }

--- a/FWCore/Framework/src/PrincipalCache.cc
+++ b/FWCore/Framework/src/PrincipalCache.cc
@@ -32,7 +32,7 @@ namespace edm {
     return *runPrincipal_.get();
   }
 
-  boost::shared_ptr<RunPrincipal> const&
+  std::shared_ptr<RunPrincipal> const&
   PrincipalCache::runPrincipalPtr(ProcessHistoryID const& phid, RunNumber_t run) const {
     if (phid != reducedInputProcessHistoryID_ ||
         run != run_ ||
@@ -50,7 +50,7 @@ namespace edm {
     return *runPrincipal_.get();
   }
 
-  boost::shared_ptr<RunPrincipal> const&
+  std::shared_ptr<RunPrincipal> const&
   PrincipalCache::runPrincipalPtr() const {
     if (runPrincipal_.get() == 0) {
       throwRunMissing();
@@ -69,7 +69,7 @@ namespace edm {
     return *lumiPrincipal_.get();
   }
 
-  boost::shared_ptr<LuminosityBlockPrincipal> const&
+  std::shared_ptr<LuminosityBlockPrincipal> const&
   PrincipalCache::lumiPrincipalPtr(ProcessHistoryID const& phid, RunNumber_t run, LuminosityBlockNumber_t lumi) const {
     if (phid != reducedInputProcessHistoryID_ ||
         run != run_ ||
@@ -88,7 +88,7 @@ namespace edm {
     return *lumiPrincipal_.get();
   }
 
-  boost::shared_ptr<LuminosityBlockPrincipal> const&
+  std::shared_ptr<LuminosityBlockPrincipal> const&
   PrincipalCache::lumiPrincipalPtr() const {
     if (lumiPrincipal_.get() == 0) {
       throwLumiMissing();
@@ -96,7 +96,7 @@ namespace edm {
     return lumiPrincipal_;
   }
 
-  void PrincipalCache::merge(boost::shared_ptr<RunAuxiliary> aux, boost::shared_ptr<ProductRegistry const> reg) {
+  void PrincipalCache::merge(std::shared_ptr<RunAuxiliary> aux, std::shared_ptr<ProductRegistry const> reg) {
     if (runPrincipal_.get() == 0) {
       throw edm::Exception(edm::errors::LogicError)
         << "PrincipalCache::merge\n"
@@ -126,7 +126,7 @@ namespace edm {
     runPrincipal_->mergeAuxiliary(*aux);
   }
 
-  void PrincipalCache::merge(boost::shared_ptr<LuminosityBlockAuxiliary> aux, boost::shared_ptr<ProductRegistry const> reg) {
+  void PrincipalCache::merge(std::shared_ptr<LuminosityBlockAuxiliary> aux, std::shared_ptr<ProductRegistry const> reg) {
     if (lumiPrincipal_.get() == 0) {
       throw edm::Exception(edm::errors::LogicError)
         << "PrincipalCache::merge\n"
@@ -157,7 +157,7 @@ namespace edm {
     lumiPrincipal_->mergeAuxiliary(*aux);
   }
 
-  void PrincipalCache::insert(boost::shared_ptr<RunPrincipal> rp) {
+  void PrincipalCache::insert(std::shared_ptr<RunPrincipal> rp) {
     if (runPrincipal_.get() != 0) {
       throw edm::Exception(edm::errors::LogicError)
         << "PrincipalCache::insert\n"
@@ -172,7 +172,7 @@ namespace edm {
     runPrincipal_ = rp; 
   }
 
-  void PrincipalCache::insert(boost::shared_ptr<LuminosityBlockPrincipal> lbp) {
+  void PrincipalCache::insert(std::shared_ptr<LuminosityBlockPrincipal> lbp) {
     if (lumiPrincipal_.get() != 0) {
       throw edm::Exception(edm::errors::LogicError)
         << "PrincipalCache::insert\n"
@@ -207,7 +207,7 @@ namespace edm {
     lumiPrincipal_ = lbp; 
   }
 
-  void PrincipalCache::insert(boost::shared_ptr<EventPrincipal> ep) {
+  void PrincipalCache::insert(std::shared_ptr<EventPrincipal> ep) {
     unsigned int iStreamIndex = ep->streamID().value();
     assert(iStreamIndex < eventPrincipals_.size());
     eventPrincipals_[iStreamIndex] = ep;
@@ -252,7 +252,7 @@ namespace edm {
     lumiPrincipal_.reset();
   }
 
-  void PrincipalCache::adjustEventsToNewProductRegistry(boost::shared_ptr<ProductRegistry const> reg) {
+  void PrincipalCache::adjustEventsToNewProductRegistry(std::shared_ptr<ProductRegistry const> reg) {
     for(auto &eventPrincipal : eventPrincipals_) {
       if (eventPrincipal) {
         eventPrincipal->adjustIndexesAfterProductRegistryAddition();

--- a/FWCore/Framework/src/PrincipalCache.h
+++ b/FWCore/Framework/src/PrincipalCache.h
@@ -28,7 +28,7 @@ Original Author: W. David Dagenhart
 #include "DataFormats/Provenance/interface/RunID.h"
 #include "DataFormats/Provenance/interface/LuminosityBlockID.h"
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 #include <vector>
 #include <cassert>
 
@@ -49,31 +49,31 @@ namespace edm {
     ~PrincipalCache();
 
     RunPrincipal& runPrincipal(ProcessHistoryID const& phid, RunNumber_t run) const;
-    boost::shared_ptr<RunPrincipal> const& runPrincipalPtr(ProcessHistoryID const& phid, RunNumber_t run) const;
+    std::shared_ptr<RunPrincipal> const& runPrincipalPtr(ProcessHistoryID const& phid, RunNumber_t run) const;
     RunPrincipal& runPrincipal() const;
-    boost::shared_ptr<RunPrincipal> const& runPrincipalPtr() const;
-    bool hasRunPrincipal() const {return runPrincipal_;}
+    std::shared_ptr<RunPrincipal> const& runPrincipalPtr() const;
+    bool hasRunPrincipal() const {return bool(runPrincipal_);}
 
     LuminosityBlockPrincipal& lumiPrincipal(ProcessHistoryID const& phid, RunNumber_t run, LuminosityBlockNumber_t lumi) const;
-    boost::shared_ptr<LuminosityBlockPrincipal> const& lumiPrincipalPtr(ProcessHistoryID const& phid, RunNumber_t run, LuminosityBlockNumber_t lumi) const;
+    std::shared_ptr<LuminosityBlockPrincipal> const& lumiPrincipalPtr(ProcessHistoryID const& phid, RunNumber_t run, LuminosityBlockNumber_t lumi) const;
     LuminosityBlockPrincipal& lumiPrincipal() const;
-    boost::shared_ptr<LuminosityBlockPrincipal> const& lumiPrincipalPtr() const;
-    bool hasLumiPrincipal() const {return lumiPrincipal_;}
+    std::shared_ptr<LuminosityBlockPrincipal> const& lumiPrincipalPtr() const;
+    bool hasLumiPrincipal() const {return bool(lumiPrincipal_);}
 
     EventPrincipal& eventPrincipal(unsigned int iStreamIndex) const { return *(eventPrincipals_[iStreamIndex]); }
 
-    void merge(boost::shared_ptr<RunAuxiliary> aux, boost::shared_ptr<ProductRegistry const> reg);
-    void merge(boost::shared_ptr<LuminosityBlockAuxiliary> aux, boost::shared_ptr<ProductRegistry const> reg);
+    void merge(std::shared_ptr<RunAuxiliary> aux, std::shared_ptr<ProductRegistry const> reg);
+    void merge(std::shared_ptr<LuminosityBlockAuxiliary> aux, std::shared_ptr<ProductRegistry const> reg);
 
     void setNumberOfConcurrentPrincipals(PreallocationConfiguration const&);
-    void insert(boost::shared_ptr<RunPrincipal> rp);
-    void insert(boost::shared_ptr<LuminosityBlockPrincipal> lbp);
-    void insert(boost::shared_ptr<EventPrincipal> ep);
+    void insert(std::shared_ptr<RunPrincipal> rp);
+    void insert(std::shared_ptr<LuminosityBlockPrincipal> lbp);
+    void insert(std::shared_ptr<EventPrincipal> ep);
 
     void deleteRun(ProcessHistoryID const& phid, RunNumber_t run);
     void deleteLumi(ProcessHistoryID const& phid, RunNumber_t run, LuminosityBlockNumber_t lumi);
 
-    void adjustEventsToNewProductRegistry(boost::shared_ptr<ProductRegistry const> reg);
+    void adjustEventsToNewProductRegistry(std::shared_ptr<ProductRegistry const> reg);
 
     void adjustIndexesAfterProductRegistryAddition();
 
@@ -86,9 +86,9 @@ namespace edm {
 
     // These are explicitly cleared when finished with the run,
     // lumi, or event
-    boost::shared_ptr<RunPrincipal> runPrincipal_;
-    boost::shared_ptr<LuminosityBlockPrincipal> lumiPrincipal_;
-    std::vector<boost::shared_ptr<EventPrincipal>> eventPrincipals_;
+    std::shared_ptr<RunPrincipal> runPrincipal_;
+    std::shared_ptr<LuminosityBlockPrincipal> lumiPrincipal_;
+    std::vector<std::shared_ptr<EventPrincipal>> eventPrincipals_;
 
     // This is just an accessor to the registry owned by the input source. 
     ProcessHistoryRegistry const* processHistoryRegistry_; // We don't own this

--- a/FWCore/Framework/src/ProductHolder.cc
+++ b/FWCore/Framework/src/ProductHolder.cc
@@ -239,7 +239,7 @@ namespace edm {
     productData().wrapper_ = prod.product();
   }
 
-  void InputProductHolder::setProvenance_(boost::shared_ptr<ProductProvenanceRetriever> provRetriever, ProcessHistory const& ph, ProductID const& pid) {
+  void InputProductHolder::setProvenance_(std::shared_ptr<ProductProvenanceRetriever> provRetriever, ProcessHistory const& ph, ProductID const& pid) {
     productData().prov_.setProductID(pid);
     productData().prov_.setStore(provRetriever);
     productData().prov_.setProcessHistory(ph);
@@ -313,7 +313,7 @@ namespace edm {
     status() = ProductDeleted;
   }
 
-  void ProducedProductHolder::setProvenance_(boost::shared_ptr<ProductProvenanceRetriever> provRetriever, ProcessHistory const& ph, ProductID const& pid) {
+  void ProducedProductHolder::setProvenance_(std::shared_ptr<ProductProvenanceRetriever> provRetriever, ProcessHistory const& ph, ProductID const& pid) {
     productData().prov_.setProductID(pid);
     productData().prov_.setStore(provRetriever);
     productData().prov_.setProcessHistory(ph);
@@ -428,7 +428,7 @@ namespace edm {
     return nullptr;
   }
 
-  void AliasProductHolder::setProvenance_(boost::shared_ptr<ProductProvenanceRetriever> provRetriever, ProcessHistory const& ph, ProductID const& pid) {
+  void AliasProductHolder::setProvenance_(std::shared_ptr<ProductProvenanceRetriever> provRetriever, ProcessHistory const& ph, ProductID const& pid) {
     productData().prov_.setProductID(pid);
     productData().prov_.setStore(provRetriever);
     productData().prov_.setProcessHistory(ph);
@@ -464,7 +464,7 @@ namespace edm {
   void NoProcessProductHolder::resetStatus_() {
   }
 
-  void NoProcessProductHolder::setProvenance_(boost::shared_ptr<ProductProvenanceRetriever> provRetriever, ProcessHistory const& ph, ProductID const& pid) {
+  void NoProcessProductHolder::setProvenance_(std::shared_ptr<ProductProvenanceRetriever> provRetriever, ProcessHistory const& ph, ProductID const& pid) {
   }
 
   void NoProcessProductHolder::setProcessHistory_(ProcessHistory const& ph) {
@@ -553,7 +553,7 @@ namespace edm {
       << "Contact a Framework developer\n";
   }
 
-  void NoProcessProductHolder::resetBranchDescription_(boost::shared_ptr<BranchDescription const> bd) {
+  void NoProcessProductHolder::resetBranchDescription_(std::shared_ptr<BranchDescription const> bd) {
     throw Exception(errors::LogicError)
       << "NoProcessProductHolder::resetBranchDescription_() not implemented and should never be called.\n"
       << "Contact a Framework developer\n";

--- a/FWCore/Framework/src/RunPrincipal.cc
+++ b/FWCore/Framework/src/RunPrincipal.cc
@@ -9,8 +9,8 @@
 
 namespace edm {
   RunPrincipal::RunPrincipal(
-    boost::shared_ptr<RunAuxiliary> aux,
-    boost::shared_ptr<ProductRegistry const> reg,
+    std::shared_ptr<RunAuxiliary> aux,
+    std::shared_ptr<ProductRegistry const> reg,
     ProcessConfiguration const& pc,
     HistoryAppender* historyAppender,
     unsigned int iRunIndex) :

--- a/FWCore/Framework/src/RunStopwatch.h
+++ b/FWCore/Framework/src/RunStopwatch.h
@@ -11,7 +11,7 @@ calls the destructor which stops the clock.
 
 ----------------------------------------------------------------------*/
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 #include "FWCore/Utilities/interface/CPUTimer.h"
 
 namespace edm {
@@ -19,7 +19,7 @@ namespace edm {
   class RunStopwatch {
 
   public:
-    typedef boost::shared_ptr<CPUTimer> StopwatchPointer;
+    typedef std::shared_ptr<CPUTimer> StopwatchPointer;
 
     RunStopwatch(const StopwatchPointer& ptr): stopwatch_(ptr) {
       if(stopwatch_) {
@@ -41,7 +41,7 @@ namespace edm {
   class RunDualStopwatches {
     
   public:
-    typedef boost::shared_ptr<CPUTimer> StopwatchPointer;
+    typedef std::shared_ptr<CPUTimer> StopwatchPointer;
     
     RunDualStopwatches(const StopwatchPointer& ptr1, CPUTimer* const ptr2): stopwatch1_(ptr1),stopwatch2_(ptr2) {
       if(stopwatch1_ && 0 != stopwatch2_) {

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -55,8 +55,8 @@ namespace edm {
                  PreallocationConfiguration const& iPrealloc,
                  ProductRegistry& preg,
                  ExceptionToActionTable const& actions,
-                 boost::shared_ptr<ActivityRegistry> areg,
-                 boost::shared_ptr<ProcessConfiguration> processConfiguration) {
+                 std::shared_ptr<ActivityRegistry> areg,
+                 std::shared_ptr<ProcessConfiguration> processConfiguration) {
       
       ParameterSet* trig_pset = proc_pset.getPSetForUpdate("@trigger_paths");
       trig_pset->registerIt();
@@ -360,8 +360,8 @@ namespace edm {
                      ProductRegistry& preg,
                      BranchIDListHelper& branchIDListHelper,
                      ExceptionToActionTable const& actions,
-                     boost::shared_ptr<ActivityRegistry> areg,
-                     boost::shared_ptr<ProcessConfiguration> processConfiguration,
+                     std::shared_ptr<ActivityRegistry> areg,
+                     std::shared_ptr<ProcessConfiguration> processConfiguration,
                      const ParameterSet* subProcPSet,
                      PreallocationConfiguration const& prealloc,
                      ProcessContext const* processContext) :
@@ -376,7 +376,7 @@ namespace edm {
     assert(0<prealloc.numberOfStreams());
     streamSchedules_.reserve(prealloc.numberOfStreams());
     for(unsigned int i=0; i<prealloc.numberOfStreams();++i) {
-      streamSchedules_.emplace_back(std::shared_ptr<StreamSchedule>{new StreamSchedule{resultsInserter_.get(),moduleRegistry_,proc_pset,tns,prealloc, preg,branchIDListHelper,actions,areg,processConfiguration,nullptr==subProcPSet,StreamID{i},processContext}});
+      streamSchedules_.emplace_back(std::make_shared<StreamSchedule>(resultsInserter_.get(),moduleRegistry_,proc_pset,tns,prealloc,preg,branchIDListHelper,actions,areg,processConfiguration,nullptr==subProcPSet,StreamID{i},processContext));
     }
     
     //TriggerResults are injected automatically by StreamSchedules and are

--- a/FWCore/Framework/src/ScheduleItems.cc
+++ b/FWCore/Framework/src/ScheduleItems.cc
@@ -91,8 +91,7 @@ namespace edm {
 
     //add the ProductRegistry as a service ONLY for the construction phase
     typedef serviceregistry::ServiceWrapper<ConstProductRegistry> w_CPR;
-    boost::shared_ptr<w_CPR>
-      reg(new w_CPR(std::auto_ptr<ConstProductRegistry>(new ConstProductRegistry(*preg_))));
+    auto reg = std::make_shared<w_CPR>(std::auto_ptr<ConstProductRegistry>(new ConstProductRegistry(*preg_)));
     ServiceToken tempToken(ServiceRegistry::createContaining(reg,
                                                              token,
                                                              serviceregistry::kOverlapIsError));
@@ -103,24 +102,23 @@ namespace edm {
     typedef service::TriggerNamesService TNS;
     typedef serviceregistry::ServiceWrapper<TNS> w_TNS;
 
-    boost::shared_ptr<w_TNS> tnsptr
-      (new w_TNS(std::auto_ptr<TNS>(new TNS(parameterSet))));
+    auto tnsptr = std::make_shared<w_TNS>(std::auto_ptr<TNS>(new TNS(parameterSet)));
 
     return ServiceRegistry::createContaining(tnsptr,
                                              tempToken,
                                              serviceregistry::kOverlapIsError);
   }
 
-  boost::shared_ptr<CommonParams>
+  std::shared_ptr<CommonParams>
   ScheduleItems::initMisc(ParameterSet& parameterSet) {
     act_table_.reset(new ExceptionToActionTable(parameterSet));
     std::string processName = parameterSet.getParameter<std::string>("@process_name");
     processConfiguration_.reset(new ProcessConfiguration(processName, getReleaseVersion(), getPassID()));
-    boost::shared_ptr<CommonParams>
-        common(new CommonParams(parameterSet.getUntrackedParameterSet(
+    auto common = std::make_shared<CommonParams>(
+                                parameterSet.getUntrackedParameterSet(
                                    "maxEvents", ParameterSet()).getUntrackedParameter<int>("input", -1),
                                 parameterSet.getUntrackedParameterSet(
-                                   "maxLuminosityBlocks", ParameterSet()).getUntrackedParameter<int>("input", -1)));
+                                   "maxLuminosityBlocks", ParameterSet()).getUntrackedParameter<int>("input", -1));
     return common;
   }
 

--- a/FWCore/Framework/src/StreamSchedule.cc
+++ b/FWCore/Framework/src/StreamSchedule.cc
@@ -74,7 +74,7 @@ namespace edm {
 
     StreamSchedule::WorkerPtr
     makeInserter(ExceptionToActionTable const& actions,
-                 boost::shared_ptr<ActivityRegistry> areg,
+                 std::shared_ptr<ActivityRegistry> areg,
                  TriggerResultInserter* inserter) {
       StreamSchedule::WorkerPtr ptr(new edm::WorkerT<TriggerResultInserter::ModuleType>(inserter, inserter->moduleDescription(), &actions));
       ptr->setActivityRegistry(areg);
@@ -134,15 +134,15 @@ namespace edm {
   // -----------------------------
 
   StreamSchedule::StreamSchedule(TriggerResultInserter* inserter,
-                                 boost::shared_ptr<ModuleRegistry> modReg,
+                                 std::shared_ptr<ModuleRegistry> modReg,
                                  ParameterSet& proc_pset,
                                  service::TriggerNamesService& tns,
                                  PreallocationConfiguration const& prealloc,
                                  ProductRegistry& preg,
                                  BranchIDListHelper& branchIDListHelper,
                                  ExceptionToActionTable const& actions,
-                                 boost::shared_ptr<ActivityRegistry> areg,
-                                 boost::shared_ptr<ProcessConfiguration> processConfiguration,
+                                 std::shared_ptr<ActivityRegistry> areg,
+                                 std::shared_ptr<ProcessConfiguration> processConfiguration,
                                  bool allowEarlyDelete,
                                  StreamID streamID,
                                  ProcessContext const* processContext) :
@@ -407,7 +407,7 @@ namespace edm {
   void StreamSchedule::fillWorkers(ParameterSet& proc_pset,
                                    ProductRegistry& preg,
                                    PreallocationConfiguration const* prealloc,
-                                   boost::shared_ptr<ProcessConfiguration const> processConfiguration,
+                                   std::shared_ptr<ProcessConfiguration const> processConfiguration,
                                    std::string const& name,
                                    bool ignoreFilters,
                                    PathWorkers& out,
@@ -466,7 +466,7 @@ namespace edm {
   void StreamSchedule::fillTrigPath(ParameterSet& proc_pset,
                                     ProductRegistry& preg,
                                     PreallocationConfiguration const* prealloc,
-                                    boost::shared_ptr<ProcessConfiguration const> processConfiguration,
+                                    std::shared_ptr<ProcessConfiguration const> processConfiguration,
                                     int bitpos, std::string const& name, TrigResPtr trptr,
                                     vstring* labelsOnTriggerPaths) {
     PathWorkers tmpworkers;
@@ -494,7 +494,7 @@ namespace edm {
   void StreamSchedule::fillEndPath(ParameterSet& proc_pset,
                                    ProductRegistry& preg,
                                    PreallocationConfiguration const* prealloc,
-                                   boost::shared_ptr<ProcessConfiguration const> processConfiguration,
+                                   std::shared_ptr<ProcessConfiguration const> processConfiguration,
                                    int bitpos, std::string const& name) {
     PathWorkers tmpworkers;
     fillWorkers(proc_pset, preg, prealloc, processConfiguration, name, true, tmpworkers, 0);

--- a/FWCore/Framework/src/StreamSchedule.h
+++ b/FWCore/Framework/src/StreamSchedule.h
@@ -145,8 +145,8 @@ namespace edm {
     typedef std::vector<std::string> vstring;
     typedef std::vector<Path> TrigPaths;
     typedef std::vector<Path> NonTrigPaths;
-    typedef boost::shared_ptr<HLTGlobalStatus> TrigResPtr;
-    typedef boost::shared_ptr<Worker> WorkerPtr;
+    typedef std::shared_ptr<HLTGlobalStatus> TrigResPtr;
+    typedef std::shared_ptr<Worker> WorkerPtr;
     typedef std::vector<Worker*> AllWorkers;
     typedef std::vector<boost::shared_ptr<OutputModuleCommunicator>> AllOutputModuleCommunicators;
 
@@ -155,15 +155,15 @@ namespace edm {
     typedef std::vector<WorkerInPath> PathWorkers;
 
     StreamSchedule(TriggerResultInserter* inserter,
-                   boost::shared_ptr<ModuleRegistry>,
+                   std::shared_ptr<ModuleRegistry>,
                    ParameterSet& proc_pset,
                    service::TriggerNamesService& tns,
                    PreallocationConfiguration const& prealloc,
                    ProductRegistry& pregistry,
                    BranchIDListHelper& branchIDListHelper,
                    ExceptionToActionTable const& actions,
-                   boost::shared_ptr<ActivityRegistry> areg,
-                   boost::shared_ptr<ProcessConfiguration> processConfiguration,
+                   std::shared_ptr<ActivityRegistry> areg,
+                   std::shared_ptr<ProcessConfiguration> processConfiguration,
                    bool allowEarlyDelete,
                    StreamID streamID,
                    ProcessContext const* processContext);
@@ -274,19 +274,19 @@ namespace edm {
     void fillWorkers(ParameterSet& proc_pset,
                      ProductRegistry& preg,
                      PreallocationConfiguration const* prealloc,
-                     boost::shared_ptr<ProcessConfiguration const> processConfiguration,
+                     std::shared_ptr<ProcessConfiguration const> processConfiguration,
                      std::string const& name, bool ignoreFilters, PathWorkers& out,
                      vstring* labelsOnPaths);
     void fillTrigPath(ParameterSet& proc_pset,
                       ProductRegistry& preg,
                       PreallocationConfiguration const* prealloc,
-                      boost::shared_ptr<ProcessConfiguration const> processConfiguration,
+                      std::shared_ptr<ProcessConfiguration const> processConfiguration,
                       int bitpos, std::string const& name, TrigResPtr,
                       vstring* labelsOnTriggerPaths);
     void fillEndPath(ParameterSet& proc_pset,
                      ProductRegistry& preg,
                      PreallocationConfiguration const* prealloc,
-                     boost::shared_ptr<ProcessConfiguration const> processConfiguration,
+                     std::shared_ptr<ProcessConfiguration const> processConfiguration,
                      int bitpos, std::string const& name);
 
     void addToAllWorkers(Worker* w);
@@ -298,7 +298,7 @@ namespace edm {
                                bool allowEarlyDelete);
 
     WorkerManager            workerManager_;
-    boost::shared_ptr<ActivityRegistry>           actReg_;
+    std::shared_ptr<ActivityRegistry>           actReg_;
 
     vstring                  trig_name_list_;
     vstring                  end_path_name_list_;

--- a/FWCore/Framework/src/SubProcess.cc
+++ b/FWCore/Framework/src/SubProcess.cc
@@ -34,8 +34,8 @@ namespace edm {
 
   SubProcess::SubProcess(ParameterSet& parameterSet,
                          ParameterSet const& topLevelParameterSet,
-                         boost::shared_ptr<ProductRegistry const> parentProductRegistry,
-                         boost::shared_ptr<BranchIDListHelper const> parentBranchIDListHelper,
+                         std::shared_ptr<ProductRegistry const> parentProductRegistry,
+                         std::shared_ptr<BranchIDListHelper const> parentBranchIDListHelper,
                          eventsetup::EventSetupsController& esController,
                          ActivityRegistry& parentActReg,
                          ServiceToken const& token,
@@ -103,7 +103,7 @@ namespace edm {
 
     // If this process has a subprocess, pop the subprocess parameter set out of the process parameter set
 
-    boost::shared_ptr<ParameterSet> subProcessParameterSet(popSubProcessParameterSet(*processParameterSet_).release());
+    std::shared_ptr<ParameterSet> subProcessParameterSet(popSubProcessParameterSet(*processParameterSet_).release());
   
     ScheduleItems items(*parentProductRegistry, *this);
 
@@ -151,11 +151,7 @@ namespace edm {
 
     principalCache_.setNumberOfConcurrentPrincipals(preallocConfig);
     for(unsigned int index = 0; index < preallocConfig.numberOfStreams(); ++index) {
-      boost::shared_ptr<EventPrincipal> ep(new EventPrincipal(preg_,
-                                                              branchIDListHelper_,
-                                                              *processConfiguration_,
-                                                              &(historyAppenders_[index]),
-                                                              index));
+      auto ep = std::make_shared<EventPrincipal>(preg_, branchIDListHelper_, *processConfiguration_, &(historyAppenders_[index]), index);
       ep->preModuleDelayedGetSignal_.connect(std::cref(items.actReg_->preModuleEventDelayedGetSignal_));
       ep->postModuleDelayedGetSignal_.connect(std::cref(items.actReg_->postModuleEventDelayedGetSignal_));
       principalCache_.insert(ep);
@@ -333,9 +329,9 @@ namespace edm {
 
   void
   SubProcess::beginRun(RunPrincipal const& principal, IOVSyncValue const& ts) {
-    boost::shared_ptr<RunAuxiliary> aux(new RunAuxiliary(principal.aux()));
+    auto aux = std::make_shared<RunAuxiliary>(principal.aux());
     aux->setProcessHistoryID(principal.processHistoryID());
-    boost::shared_ptr<RunPrincipal> rpp(new RunPrincipal(aux, preg_, *processConfiguration_, &(historyAppenders_[historyRunOffset_+principal.index()]),principal.index()));
+    auto rpp = std::make_shared<RunPrincipal>(aux, preg_, *processConfiguration_, &(historyAppenders_[historyRunOffset_+principal.index()]),principal.index());
     auto & processHistoryRegistry = processHistoryRegistries_[historyRunOffset_+principal.index()];
     processHistoryRegistry.registerProcessHistory(principal.processHistory());
     rpp->fillRunPrincipal(processHistoryRegistry, principal.reader());
@@ -393,9 +389,9 @@ namespace edm {
 
   void
   SubProcess::beginLuminosityBlock(LuminosityBlockPrincipal const& principal, IOVSyncValue const& ts) {
-    boost::shared_ptr<LuminosityBlockAuxiliary> aux(new LuminosityBlockAuxiliary(principal.aux()));
+    auto aux = std::make_shared<LuminosityBlockAuxiliary>(principal.aux());
     aux->setProcessHistoryID(principal.processHistoryID());
-    boost::shared_ptr<LuminosityBlockPrincipal> lbpp(new LuminosityBlockPrincipal(aux, preg_, *processConfiguration_, &(historyAppenders_[historyLumiOffset_+principal.index()]),principal.index()));
+    auto lbpp = std::make_shared<LuminosityBlockPrincipal>(aux, preg_, *processConfiguration_, &(historyAppenders_[historyLumiOffset_+principal.index()]),principal.index());
     auto & processHistoryRegistry = processHistoryRegistries_[historyLumiOffset_+principal.index()];
     processHistoryRegistry.registerProcessHistory(principal.processHistory());
     lbpp->fillLuminosityBlockPrincipal(processHistoryRegistry, principal.reader());

--- a/FWCore/Framework/src/TriggerResultInserter.h
+++ b/FWCore/Framework/src/TriggerResultInserter.h
@@ -17,7 +17,7 @@
 #include "FWCore/Framework/interface/global/EDProducer.h"
 #include "DataFormats/Provenance/interface/ParameterSetID.h"
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 namespace edm
 {
@@ -30,7 +30,7 @@ namespace edm
   {
   public:
 
-    typedef boost::shared_ptr<HLTGlobalStatus> TrigResPtr;
+    typedef std::shared_ptr<HLTGlobalStatus> TrigResPtr;
 
     // standard constructor not supported for this module
     explicit TriggerResultInserter(edm::ParameterSet const& ps);

--- a/FWCore/Framework/src/Worker.cc
+++ b/FWCore/Framework/src/Worker.cc
@@ -88,7 +88,7 @@ private:
   Worker::~Worker() {
   }
 
-  void Worker::setActivityRegistry(boost::shared_ptr<ActivityRegistry> areg) {
+  void Worker::setActivityRegistry(std::shared_ptr<ActivityRegistry> areg) {
     actReg_ = areg;
   }
 

--- a/FWCore/Framework/src/Worker.h
+++ b/FWCore/Framework/src/Worker.h
@@ -41,8 +41,6 @@ the worker is reset().
 #include "FWCore/Utilities/interface/ProductHolderIndex.h"
 #include "FWCore/Utilities/interface/StreamID.h"
 
-#include "boost/shared_ptr.hpp"
-
 #include "FWCore/Framework/src/RunStopwatch.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 
@@ -98,7 +96,7 @@ namespace edm {
     ModuleDescription const* descPtr() const {return moduleCallingContext_.moduleDescription(); }
     ///The signals are required to live longer than the last call to 'doWork'
     /// this was done to improve performance based on profiling
-    void setActivityRegistry(boost::shared_ptr<ActivityRegistry> areg);
+    void setActivityRegistry(std::shared_ptr<ActivityRegistry> areg);
     
     void setEarlyDeleteHelper(EarlyDeleteHelper* iHelper);
     
@@ -184,9 +182,9 @@ namespace edm {
     ModuleCallingContext moduleCallingContext_;
 
     ExceptionToActionTable const* actions_; // memory assumed to be managed elsewhere
-    boost::shared_ptr<cms::Exception> cached_exception_; // if state is 'exception'
+    std::shared_ptr<cms::Exception> cached_exception_; // if state is 'exception'
 
-    boost::shared_ptr<ActivityRegistry> actReg_;
+    std::shared_ptr<ActivityRegistry> actReg_;
     
     EarlyDeleteHelper* earlyDeleteHelper_;
   };

--- a/FWCore/Framework/src/WorkerMaker.h
+++ b/FWCore/Framework/src/WorkerMaker.h
@@ -82,9 +82,7 @@ protected:
     typedef typename UserType::ModuleType ModuleType;
     typedef MakeModuleHelper<ModuleType> MakerHelperType;
     
-    
-    
-    return std::shared_ptr<maker::ModuleHolder>(new maker::ModuleHolderT<ModuleType>{MakerHelperType::template makeModule<UserType>(p).release(),this});
+    return std::shared_ptr<maker::ModuleHolder>(std::make_shared<maker::ModuleHolderT<ModuleType> >(MakerHelperType::template makeModule<UserType>(p).release(),this));
   }
   
   template <class T>

--- a/FWCore/Framework/src/WorkerManager.cc
+++ b/FWCore/Framework/src/WorkerManager.cc
@@ -12,15 +12,15 @@ static const std::string kProducerType("EDProducer");
 namespace edm {
   // -----------------------------
 
-  WorkerManager::WorkerManager(boost::shared_ptr<ActivityRegistry> areg, ExceptionToActionTable const& actions) :
+  WorkerManager::WorkerManager(std::shared_ptr<ActivityRegistry> areg, ExceptionToActionTable const& actions) :
     workerReg_(areg),
     actionTable_(&actions),
     allWorkers_(),
     unscheduled_(new UnscheduledCallProducer) {
   } // WorkerManager::WorkerManager
 
-  WorkerManager::WorkerManager(boost::shared_ptr<ModuleRegistry> modReg,
-                               boost::shared_ptr<ActivityRegistry> areg,
+  WorkerManager::WorkerManager(std::shared_ptr<ModuleRegistry> modReg,
+                               std::shared_ptr<ActivityRegistry> areg,
                                ExceptionToActionTable const& actions) :
   workerReg_(areg,modReg),
   actionTable_(&actions),
@@ -31,7 +31,7 @@ namespace edm {
   Worker* WorkerManager::getWorker(ParameterSet& pset,
                                    ProductRegistry& preg,
                                    PreallocationConfiguration const* prealloc,
-                                   boost::shared_ptr<ProcessConfiguration const> processConfiguration,
+                                   std::shared_ptr<ProcessConfiguration const> processConfiguration,
                                    std::string const & label) {
     WorkerParams params(&pset, preg, prealloc, processConfiguration, *actionTable_);
     return workerReg_.getWorker(params, label);
@@ -40,7 +40,7 @@ namespace edm {
   void WorkerManager::addToUnscheduledWorkers(ParameterSet& pset,
                                               ProductRegistry& preg,
                                               PreallocationConfiguration const* prealloc,
-                                              boost::shared_ptr<ProcessConfiguration> processConfiguration,
+                                              std::shared_ptr<ProcessConfiguration> processConfiguration,
                                               std::string label,
                                               bool useStopwatch,
                                               std::set<std::string>& unscheduledLabels,

--- a/FWCore/Framework/src/WorkerParams.h
+++ b/FWCore/Framework/src/WorkerParams.h
@@ -9,7 +9,7 @@ This struct is used to communication parameters into the worker factory.
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 #include <string>
 
@@ -27,7 +27,7 @@ namespace edm {
     WorkerParams(ParameterSet* pset,
                  ProductRegistry& reg,
                  PreallocationConfiguration const* prealloc,
-                 boost::shared_ptr<ProcessConfiguration const> processConfiguration,
+                 std::shared_ptr<ProcessConfiguration const> processConfiguration,
                  ExceptionToActionTable const& actions) :
       pset_(pset),
       reg_(&reg),
@@ -38,7 +38,7 @@ namespace edm {
     ParameterSet* pset_;
     ProductRegistry* reg_;
     PreallocationConfiguration const* preallocate_;
-    boost::shared_ptr<ProcessConfiguration const> processConfiguration_;
+    std::shared_ptr<ProcessConfiguration const> processConfiguration_;
     ExceptionToActionTable const* actions_;
   };
 }

--- a/FWCore/Framework/src/WorkerRegistry.cc
+++ b/FWCore/Framework/src/WorkerRegistry.cc
@@ -15,15 +15,15 @@
 
 namespace edm {
   
-  WorkerRegistry::WorkerRegistry(boost::shared_ptr<ActivityRegistry> areg) :
+  WorkerRegistry::WorkerRegistry(std::shared_ptr<ActivityRegistry> areg) :
     modRegistry_(new ModuleRegistry),
     m_workerMap(),
     actReg_(areg)
   {
   }
   
-  WorkerRegistry::WorkerRegistry(boost::shared_ptr<ActivityRegistry> areg,
-                                 boost::shared_ptr<ModuleRegistry> modReg):
+  WorkerRegistry::WorkerRegistry(std::shared_ptr<ActivityRegistry> areg,
+                                 std::shared_ptr<ModuleRegistry> modReg):
   modRegistry_(modReg),
   m_workerMap(),
   actReg_(areg)

--- a/FWCore/Framework/src/WorkerRegistry.h
+++ b/FWCore/Framework/src/WorkerRegistry.h
@@ -9,7 +9,7 @@
    \date 18 May 2005
 */
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 #include <map>
 #include <string>
@@ -38,9 +38,9 @@ namespace edm {
 
   public:
 
-    explicit WorkerRegistry(boost::shared_ptr<ActivityRegistry> areg);
-    WorkerRegistry(boost::shared_ptr<ActivityRegistry> areg,
-                   boost::shared_ptr<ModuleRegistry> iModReg);
+    explicit WorkerRegistry(std::shared_ptr<ActivityRegistry> areg);
+    WorkerRegistry(std::shared_ptr<ActivityRegistry> areg,
+                   std::shared_ptr<ModuleRegistry> iModReg);
     ~WorkerRegistry();
         
     WorkerRegistry(WorkerRegistry const&) = delete; // Disallow copying and moving
@@ -55,13 +55,13 @@ namespace edm {
     
   private:
     /// the container of workers
-    typedef std::map<std::string, boost::shared_ptr<Worker> > WorkerMap;
+    typedef std::map<std::string, std::shared_ptr<Worker> > WorkerMap;
 
-    boost::shared_ptr<ModuleRegistry> modRegistry_;
+    std::shared_ptr<ModuleRegistry> modRegistry_;
     
     /// internal map of registered workers (owned).
     WorkerMap m_workerMap;
-    boost::shared_ptr<ActivityRegistry> actReg_;
+    std::shared_ptr<ActivityRegistry> actReg_;
      
   }; // WorkerRegistry
 

--- a/FWCore/Framework/src/WorkerT.cc
+++ b/FWCore/Framework/src/WorkerT.cc
@@ -115,7 +115,7 @@ namespace edm{
   inline
   bool
   WorkerT<T>::implDo(EventPrincipal& ep, EventSetup const& c, ModuleCallingContext const* mcc) {
-    boost::shared_ptr<Worker> sentry(this,[&ep](Worker* obj) {obj->postDoEvent(ep);});
+    std::shared_ptr<Worker> sentry(this,[&ep](Worker* obj) {obj->postDoEvent(ep);});
     return module_->doEvent(ep, c, activityRegistry(), mcc);
   }
   

--- a/FWCore/Framework/test/EventSelExc_t.cpp
+++ b/FWCore/Framework/test/EventSelExc_t.cpp
@@ -24,8 +24,6 @@
 #include "FWCore/ServiceRegistry/interface/ServiceToken.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-#include "boost/shared_ptr.hpp"
-
 #include <array>
 #include <vector>
 #include <string>
@@ -268,8 +266,7 @@ try {
   typedef edm::service::TriggerNamesService TNS;
   typedef serviceregistry::ServiceWrapper<TNS> w_TNS;
 
-  boost::shared_ptr<w_TNS> tnsptr
-    (new w_TNS(std::auto_ptr<TNS>(new TNS(proc_pset))));
+  auto tnsptr = std::make_shared<w_TNS>(std::auto_ptr<TNS>(new TNS(proc_pset)));
 
   ServiceToken serviceToken_ = ServiceRegistry::createContaining(tnsptr);
 

--- a/FWCore/Framework/test/EventSelOverlap_t.cpp
+++ b/FWCore/Framework/test/EventSelOverlap_t.cpp
@@ -13,8 +13,6 @@
 #include "FWCore/ServiceRegistry/interface/ServiceToken.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-#include "boost/shared_ptr.hpp"
-
 #include <array>
 #include <vector>
 #include <string>
@@ -161,7 +159,7 @@ void maskTest ( PathSpecifiers const & ps,
   // obtain the answer from maskTriggerResults
    
   EventSelector selector (ps.path, trigger_path_names);
-  boost::shared_ptr<TriggerResults> sptr =
+  std::shared_ptr<TriggerResults> sptr =
     selector.maskTriggerResults (results);
   TriggerResults maskTR = *sptr;
   
@@ -226,8 +224,7 @@ try {
   typedef edm::service::TriggerNamesService TNS;
   typedef serviceregistry::ServiceWrapper<TNS> w_TNS;
 
-  boost::shared_ptr<w_TNS> tnsptr
-    (new w_TNS(std::auto_ptr<TNS>(new TNS(proc_pset))));
+  auto tnsptr = std::make_shared<w_TNS>(std::auto_ptr<TNS>(new TNS(proc_pset)));
 
   ServiceToken serviceToken_ = ServiceRegistry::createContaining(tnsptr);
 

--- a/FWCore/Framework/test/EventSelWildcard_t.cpp
+++ b/FWCore/Framework/test/EventSelWildcard_t.cpp
@@ -8,8 +8,6 @@
 #include "FWCore/ServiceRegistry/interface/ServiceToken.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-#include "boost/shared_ptr.hpp"
-
 #include <array>
 #include <vector>
 #include <string>
@@ -450,8 +448,7 @@ try {
   typedef edm::service::TriggerNamesService TNS;
   typedef serviceregistry::ServiceWrapper<TNS> w_TNS;
 
-  boost::shared_ptr<w_TNS> tnsptr
-    (new w_TNS(std::auto_ptr<TNS>(new TNS(proc_pset))));
+  auto tnsptr = std::make_shared<w_TNS>(std::auto_ptr<TNS>(new TNS(proc_pset)));
 
   ServiceToken serviceToken_ = ServiceRegistry::createContaining(tnsptr);
 

--- a/FWCore/Framework/test/EventSelector_t.cpp
+++ b/FWCore/Framework/test/EventSelector_t.cpp
@@ -8,8 +8,6 @@
 #include "FWCore/ServiceRegistry/interface/ServiceToken.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-#include "boost/shared_ptr.hpp"
-
 #include <array>
 #include <vector>
 #include <string>
@@ -266,8 +264,7 @@ try {
   typedef edm::service::TriggerNamesService TNS;
   typedef serviceregistry::ServiceWrapper<TNS> w_TNS;
 
-  boost::shared_ptr<w_TNS> tnsptr
-    (new w_TNS(std::auto_ptr<TNS>(new TNS(proc_pset))));
+  auto tnsptr = std::make_shared<w_TNS>(std::auto_ptr<TNS>(new TNS(proc_pset)));
 
   ServiceToken serviceToken_ = ServiceRegistry::createContaining(tnsptr);
 

--- a/FWCore/Framework/test/Event_t.cpp
+++ b/FWCore/Framework/test/Event_t.cpp
@@ -44,8 +44,6 @@ Test program for edm::Event.
 
 #include "Cintex/Cintex.h"
 
-#include "boost/shared_ptr.hpp"
-
 #include <algorithm>
 #include <fstream>
 #include <iterator>
@@ -150,17 +148,17 @@ class testEvent: public CppUnit::TestFixture {
                        std::string const& tag,
                        std::string const& productLabel = std::string());
 
-  boost::shared_ptr<ProductRegistry>   availableProducts_;
-  boost::shared_ptr<BranchIDListHelper> branchIDListHelper_;
-  boost::shared_ptr<EventPrincipal>    principal_;
-  boost::shared_ptr<Event>             currentEvent_;
-  boost::shared_ptr<ModuleDescription> currentModuleDescription_;
+  std::shared_ptr<ProductRegistry>   availableProducts_;
+  std::shared_ptr<BranchIDListHelper> branchIDListHelper_;
+  std::shared_ptr<EventPrincipal>    principal_;
+  std::shared_ptr<Event>             currentEvent_;
+  std::shared_ptr<ModuleDescription> currentModuleDescription_;
   typedef std::map<std::string, ModuleDescription> modCache_t;
   typedef modCache_t::iterator iterator_t;
 
   modCache_t moduleDescriptions_;
   ProcessHistoryRegistry processHistoryRegistry_;
-  std::vector<boost::shared_ptr<ProcessConfiguration> > processConfigurations_;
+  std::vector<std::shared_ptr<ProcessConfiguration> > processConfigurations_;
   HistoryAppender historyAppender_;
 };
 
@@ -192,7 +190,7 @@ testEvent::registerProduct(std::string const& tag,
 
   ProcessConfiguration process(processName, processParams.id(), getReleaseVersion(), getPassID());
 
-  boost::shared_ptr<ProcessConfiguration> processX(new ProcessConfiguration(process));
+  auto processX = std::make_shared<ProcessConfiguration>(process);
   processConfigurations_.push_back(processX);
 
   TypeWithDict product_type(typeid(T));
@@ -275,7 +273,7 @@ testEvent::testEvent() :
 
   TypeWithDict product_type(typeid(prod_t));
 
-  boost::shared_ptr<ProcessConfiguration> processX(new ProcessConfiguration(process));
+  auto processX = std::make_shared<ProcessConfiguration>(process);
   processConfigurations_.push_back(processX);
     currentModuleDescription_.reset(new ModuleDescription(moduleParams.id(), moduleClassName, moduleLabel, processX.get(),ModuleDescription::getUniqueID()));
 
@@ -363,15 +361,15 @@ void testEvent::setUp() {
   // and that is used to create the product holder in the principal used to
   // look up the object.
 
-  boost::shared_ptr<ProductRegistry const> preg(availableProducts_);
+  std::shared_ptr<ProductRegistry const> preg(availableProducts_);
   std::string uuid = createGlobalIdentifier();
   Timestamp time = make_timestamp();
   EventID id = make_id();
   ProcessConfiguration const& pc = currentModuleDescription_->processConfiguration();
-  boost::shared_ptr<RunAuxiliary> runAux(new RunAuxiliary(id.run(), time, time));
-  boost::shared_ptr<RunPrincipal> rp(new RunPrincipal(runAux, preg, pc, &historyAppender_,0));
-  boost::shared_ptr<LuminosityBlockAuxiliary> lumiAux(new LuminosityBlockAuxiliary(rp->run(), 1, time, time));
-  boost::shared_ptr<LuminosityBlockPrincipal>lbp(new LuminosityBlockPrincipal(lumiAux, preg, pc, &historyAppender_,0));
+  auto runAux = std::make_shared<RunAuxiliary>(id.run(), time, time);
+  auto rp = std::make_shared<RunPrincipal>(runAux, preg, pc, &historyAppender_,0);
+  auto lumiAux = std::make_shared<LuminosityBlockAuxiliary>(rp->run(), 1, time, time);
+  auto lbp = std::make_shared<LuminosityBlockPrincipal>(lumiAux, preg, pc, &historyAppender_,0);
   lbp->setRunPrincipal(rp);
   EventAuxiliary eventAux(id, uuid, time, true);
   const_cast<ProcessHistoryID &>(eventAux.processHistoryID()) = processHistoryID;
@@ -584,7 +582,7 @@ void testEvent::getByLabel() {
   BasicHandle bh2(principal_->getByLabel(PRODUCT_TYPE, TypeID(typeid(edmtest::IntProduct)), "modMulti", "int1", "nomatch",nullptr, nullptr));
   CPPUNIT_ASSERT(!bh2.isValid());
 
-  boost::shared_ptr<Wrapper<edmtest::IntProduct> const> ptr = getProductByTag<edmtest::IntProduct>(*principal_, inputTag, nullptr);
+  std::shared_ptr<Wrapper<edmtest::IntProduct> const> ptr = getProductByTag<edmtest::IntProduct>(*principal_, inputTag, nullptr);
   CPPUNIT_ASSERT(ptr->product()->value == 200);
 }
 

--- a/FWCore/Framework/test/ProductSelector_t.cpp
+++ b/FWCore/Framework/test/ProductSelector_t.cpp
@@ -3,7 +3,7 @@
 #include <string>
 #include <vector>
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 #include "FWCore/Framework/interface/ProductSelectorRules.h"
 #include "FWCore/Framework/interface/ProductSelector.h"
@@ -52,8 +52,7 @@ int doTest(edm::ParameterSet const& params,
 int work() {
   edm::ParameterSet dummyProcessPset;
   dummyProcessPset.registerIt();
-  boost::shared_ptr<edm::ProcessConfiguration> processConfiguration(
-    new edm::ProcessConfiguration());
+  auto processConfiguration = std::make_shared<edm::ProcessConfiguration>();
   processConfiguration->setParameterSetID(dummyProcessPset.id());
 
   edm::ParameterSet pset;

--- a/FWCore/Framework/test/edproducer_productregistry_callback.cc
+++ b/FWCore/Framework/test/edproducer_productregistry_callback.cc
@@ -9,7 +9,7 @@
 
 #include <iostream>
 #include "cppunit/extensions/HelperMacros.h"
-#include "boost/shared_ptr.hpp"
+#include <memory>
 #include "FWCore/Utilities/interface/GetPassID.h"
 #include "FWCore/Version/interface/GetReleaseVersion.h"
 
@@ -143,7 +143,7 @@ void  testEDProducerProductRegistryCallback::testCircularRef() {
   
    edm::ParameterSet dummyProcessPset;
    dummyProcessPset.registerIt();
-   boost::shared_ptr<ProcessConfiguration> pc(new ProcessConfiguration("PROD", dummyProcessPset.id(), edm::getReleaseVersion(), edm::getPassID()));
+   auto pc = std::make_shared<ProcessConfiguration>("PROD", dummyProcessPset.id(), edm::getReleaseVersion(), edm::getPassID());
 
    edm::MakeModuleParams params1(&p1, preg, &prealloc, pc);
    edm::MakeModuleParams params2(&p2, preg, &prealloc, pc);
@@ -219,7 +219,7 @@ void  testEDProducerProductRegistryCallback::testCircularRef2() {
   
    edm::ParameterSet dummyProcessPset;
    dummyProcessPset.registerIt();
-   boost::shared_ptr<ProcessConfiguration> pc(new ProcessConfiguration("PROD", dummyProcessPset.id(), edm::getReleaseVersion(), edm::getPassID()));
+   auto pc = std::make_shared<ProcessConfiguration>("PROD", dummyProcessPset.id(), edm::getReleaseVersion(), edm::getPassID());
 
    edm::MakeModuleParams params1(&p1, preg, &prealloc, pc);
    edm::MakeModuleParams params2(&p2, preg, &prealloc, pc);
@@ -294,7 +294,7 @@ void  testEDProducerProductRegistryCallback::testTwoListeners(){
   
    edm::ParameterSet dummyProcessPset;
    dummyProcessPset.registerIt();
-   boost::shared_ptr<ProcessConfiguration> pc(new ProcessConfiguration("PROD", dummyProcessPset.id(), edm::getReleaseVersion(), edm::getPassID()));
+   auto pc = std::make_shared<ProcessConfiguration>("PROD", dummyProcessPset.id(), edm::getReleaseVersion(), edm::getPassID());
 
    edm::MakeModuleParams params1(&p1, preg, &prealloc, pc);
    edm::MakeModuleParams params2(&p2, preg, &prealloc, pc);

--- a/FWCore/Framework/test/event_getrefbeforeput_t.cppunit.cc
+++ b/FWCore/Framework/test/event_getrefbeforeput_t.cppunit.cc
@@ -29,8 +29,6 @@ Test of the EventPrincipal class.
 
 #include "cppunit/extensions/HelperMacros.h"
 
-#include "boost/shared_ptr.hpp"
-
 #include <cassert>
 #include <iostream>
 #include <memory>
@@ -66,17 +64,17 @@ void testEventGetRefBeforePut::failGetProductNotRegisteredTest() {
 
   std::auto_ptr<edm::ProductRegistry> preg(new edm::ProductRegistry);
   preg->setFrozen();
-  boost::shared_ptr<edm::BranchIDListHelper> branchIDListHelper(new edm::BranchIDListHelper());
+  auto branchIDListHelper = std::make_shared<edm::BranchIDListHelper>();
   branchIDListHelper->updateFromRegistry(*preg);
   edm::EventID col(1L, 1L, 1L);
   std::string uuid = edm::createGlobalIdentifier();
   edm::Timestamp fakeTime;
   edm::ProcessConfiguration pc("PROD", edm::ParameterSetID(), edm::getReleaseVersion(), edm::getPassID());
-  boost::shared_ptr<edm::ProductRegistry const> pregc(preg.release());
-  boost::shared_ptr<edm::RunAuxiliary> runAux(new edm::RunAuxiliary(col.run(), fakeTime, fakeTime));
-  boost::shared_ptr<edm::RunPrincipal> rp(new edm::RunPrincipal(runAux, pregc, pc, &historyAppender_,0));
-  boost::shared_ptr<edm::LuminosityBlockAuxiliary> lumiAux(new edm::LuminosityBlockAuxiliary(rp->run(), 1, fakeTime, fakeTime));
-  boost::shared_ptr<edm::LuminosityBlockPrincipal>lbp(new edm::LuminosityBlockPrincipal(lumiAux, pregc, pc, &historyAppender_,0));
+  std::shared_ptr<edm::ProductRegistry const> pregc(preg.release());
+  auto runAux = std::make_shared<edm::RunAuxiliary>(col.run(), fakeTime, fakeTime);
+  auto rp = std::make_shared<edm::RunPrincipal>(runAux, pregc, pc, &historyAppender_,0);
+  auto lumiAux = std::make_shared<edm::LuminosityBlockAuxiliary>(rp->run(), 1, fakeTime, fakeTime);
+  auto lbp = std::make_shared<edm::LuminosityBlockPrincipal>(lumiAux, pregc, pc, &historyAppender_,0);
   lbp->setRunPrincipal(rp);
   edm::EventAuxiliary eventAux(col, uuid, fakeTime, true);
   edm::EventPrincipal ep(pregc, branchIDListHelper, pc, &historyAppender_,edm::StreamID::invalidStreamID());
@@ -86,8 +84,7 @@ void testEventGetRefBeforePut::failGetProductNotRegisteredTest() {
   try {
      edm::ParameterSet pset;
      pset.registerIt();
-     boost::shared_ptr<edm::ProcessConfiguration> processConfiguration(
-      new edm::ProcessConfiguration());
+     auto processConfiguration = std::make_shared<edm::ProcessConfiguration>();
      edm::ModuleDescription modDesc(pset.id(), "Blah", "blahs", processConfiguration.get(), edm::ModuleDescription::getUniqueID());
      edm::Event event(ep, modDesc, nullptr);
 
@@ -115,8 +112,7 @@ void testEventGetRefBeforePut::getRefTest() {
 
   edm::ParameterSet dummyProcessPset;
   dummyProcessPset.registerIt();
-  boost::shared_ptr<edm::ProcessConfiguration> processConfiguration(
-    new edm::ProcessConfiguration());
+  auto processConfiguration = std::make_shared<edm::ProcessConfiguration>();
   processConfiguration->setParameterSetID(dummyProcessPset.id());
 
   edm::ParameterSet pset;
@@ -138,18 +134,18 @@ void testEventGetRefBeforePut::getRefTest() {
   std::auto_ptr<edm::ProductRegistry> preg(new edm::ProductRegistry);
   preg->addProduct(product);
   preg->setFrozen();
-  boost::shared_ptr<edm::BranchIDListHelper> branchIDListHelper(new edm::BranchIDListHelper());
+  auto branchIDListHelper = std::make_shared<edm::BranchIDListHelper>();
   branchIDListHelper->updateFromRegistry(*preg);
   edm::EventID col(1L, 1L, 1L);
   std::string uuid = edm::createGlobalIdentifier();
   edm::Timestamp fakeTime;
-  boost::shared_ptr<edm::ProcessConfiguration> pcPtr(new edm::ProcessConfiguration(processName, dummyProcessPset.id(), edm::getReleaseVersion(), edm::getPassID()));
+  auto pcPtr = std::make_shared<edm::ProcessConfiguration>(processName, dummyProcessPset.id(), edm::getReleaseVersion(), edm::getPassID());
   edm::ProcessConfiguration& pc = *pcPtr;
-  boost::shared_ptr<edm::ProductRegistry const> pregc(preg.release());
-  boost::shared_ptr<edm::RunAuxiliary> runAux(new edm::RunAuxiliary(col.run(), fakeTime, fakeTime));
-  boost::shared_ptr<edm::RunPrincipal> rp(new edm::RunPrincipal(runAux, pregc, pc, &historyAppender_,0));
-  boost::shared_ptr<edm::LuminosityBlockAuxiliary> lumiAux(new edm::LuminosityBlockAuxiliary(rp->run(), 1, fakeTime, fakeTime));
-  boost::shared_ptr<edm::LuminosityBlockPrincipal>lbp(new edm::LuminosityBlockPrincipal(lumiAux, pregc, pc, &historyAppender_,0));
+  std::shared_ptr<edm::ProductRegistry const> pregc(preg.release());
+  auto runAux = std::make_shared<edm::RunAuxiliary>(col.run(), fakeTime, fakeTime);
+  auto rp = std::make_shared<edm::RunPrincipal>(runAux, pregc, pc, &historyAppender_,0);
+  auto lumiAux = std::make_shared<edm::LuminosityBlockAuxiliary>(rp->run(), 1, fakeTime, fakeTime);
+  auto lbp = std::make_shared<edm::LuminosityBlockPrincipal>(lumiAux, pregc, pc, &historyAppender_,0);
   lbp->setRunPrincipal(rp);
   edm::EventAuxiliary eventAux(col, uuid, fakeTime, true);
   edm::EventPrincipal ep(pregc, branchIDListHelper, pc, &historyAppender_,edm::StreamID::invalidStreamID());

--- a/FWCore/Framework/test/eventprincipal_t.cppunit.cc
+++ b/FWCore/Framework/test/eventprincipal_t.cppunit.cc
@@ -37,8 +37,6 @@ Test of the EventPrincipal class.
 
 #include "cppunit/extensions/HelperMacros.h"
 
-#include "boost/shared_ptr.hpp"
-
 #include <map>
 #include <memory>
 #include <stdexcept>
@@ -64,22 +62,22 @@ public:
 
 private:
 
-  boost::shared_ptr<edm::ProcessConfiguration>
+  std::shared_ptr<edm::ProcessConfiguration>
   fake_single_module_process(std::string const& tag,
                              std::string const& processName,
                              edm::ParameterSet const& moduleParams,
                              std::string const& release = edm::getReleaseVersion(),
                              std::string const& pass = edm::getPassID());
-  boost::shared_ptr<edm::BranchDescription>
+  std::shared_ptr<edm::BranchDescription>
   fake_single_process_branch(std::string const& tag,
                              std::string const& processName,
                              std::string const& productInstanceName = std::string());
 
-  std::map<std::string, boost::shared_ptr<edm::BranchDescription> >    branchDescriptions_;
-  std::map<std::string, boost::shared_ptr<edm::ProcessConfiguration> > processConfigurations_;
+  std::map<std::string, std::shared_ptr<edm::BranchDescription> >    branchDescriptions_;
+  std::map<std::string, std::shared_ptr<edm::ProcessConfiguration> > processConfigurations_;
 
-  boost::shared_ptr<edm::ProductRegistry>   pProductRegistry_;
-  boost::shared_ptr<edm::EventPrincipal>    pEvent_;
+  std::shared_ptr<edm::ProductRegistry>   pProductRegistry_;
+  std::shared_ptr<edm::EventPrincipal>    pEvent_;
 
   edm::EventID               eventID_;
 
@@ -93,7 +91,7 @@ CPPUNIT_TEST_SUITE_REGISTRATION(test_ep);
 
 //----------------------------------------------------------------------
 
-boost::shared_ptr<edm::ProcessConfiguration>
+std::shared_ptr<edm::ProcessConfiguration>
 test_ep::fake_single_module_process(std::string const& tag,
                                     std::string const& processName,
                                     edm::ParameterSet const& moduleParams,
@@ -105,13 +103,12 @@ test_ep::fake_single_module_process(std::string const& tag,
                                           processName);
 
   processParams.registerIt();
-  boost::shared_ptr<edm::ProcessConfiguration> result(
-    new edm::ProcessConfiguration(processName, processParams.id(), release, pass));
+  auto result = std::make_shared<edm::ProcessConfiguration>(processName, processParams.id(), release, pass);
   processConfigurations_[tag] = result;
   return result;
 }
 
-boost::shared_ptr<edm::BranchDescription>
+std::shared_ptr<edm::BranchDescription>
 test_ep::fake_single_process_branch(std::string const& tag,
                                     std::string const& processName,
                                     std::string const& productInstanceName) {
@@ -124,10 +121,10 @@ test_ep::fake_single_process_branch(std::string const& tag,
   modParams.addParameter<std::string>("@module_type", moduleClass);
   modParams.addParameter<std::string>("@module_label", moduleLabel);
   modParams.registerIt();
-  boost::shared_ptr<edm::ProcessConfiguration> process(fake_single_module_process(tag, processName, modParams));
+  std::shared_ptr<edm::ProcessConfiguration> process(fake_single_module_process(tag, processName, modParams));
 
-  boost::shared_ptr<edm::BranchDescription> result(
-    new edm::BranchDescription(edm::InEvent,
+  auto result = std::make_shared<edm::BranchDescription>(
+                               edm::InEvent,
                                moduleLabel,
                                processName,
                                productClassName,
@@ -135,7 +132,7 @@ test_ep::fake_single_process_branch(std::string const& tag,
                                productInstanceName,
                                moduleClass,
                                modParams.id(),
-                               dummyType));
+                               dummyType);
   branchDescriptions_[tag] = result;
   return result;
 }
@@ -156,7 +153,7 @@ void test_ep::setUp() {
   pProductRegistry_->addProduct(*fake_single_process_branch("user", "USER"));
   pProductRegistry_->addProduct(*fake_single_process_branch("rick", "USER2", "rick"));
   pProductRegistry_->setFrozen();
-  boost::shared_ptr<edm::BranchIDListHelper> branchIDListHelper(new edm::BranchIDListHelper());
+  auto branchIDListHelper = std::make_shared<edm::BranchIDListHelper>();
   branchIDListHelper->updateFromRegistry(*pProductRegistry_);
 
   // Put products we'll look for into the EventPrincipal.
@@ -179,17 +176,17 @@ void test_ep::setUp() {
 
     edm::BranchDescription const branchFromRegistry(it->second);
 
-    boost::shared_ptr<edm::Parentage> entryDescriptionPtr(new edm::Parentage);
+    auto entryDescriptionPtr = std::make_shared<edm::Parentage>();
     edm::ProductProvenance prov(branchFromRegistry.branchID(), entryDescriptionPtr);
 
-    boost::shared_ptr<edm::ProcessConfiguration> process(processConfigurations_[tag]);
+    std::shared_ptr<edm::ProcessConfiguration> process(processConfigurations_[tag]);
     assert(process);
     std::string uuid = edm::createGlobalIdentifier();
     edm::Timestamp now(1234567UL);
-    boost::shared_ptr<edm::RunAuxiliary> runAux(new edm::RunAuxiliary(eventID_.run(), now, now));
-    boost::shared_ptr<edm::RunPrincipal> rp(new edm::RunPrincipal(runAux, pProductRegistry_, *process, &historyAppender_,0));
-    boost::shared_ptr<edm::LuminosityBlockAuxiliary> lumiAux(new edm::LuminosityBlockAuxiliary(rp->run(), 1, now, now));
-    boost::shared_ptr<edm::LuminosityBlockPrincipal>lbp(new edm::LuminosityBlockPrincipal(lumiAux, pProductRegistry_, *process, &historyAppender_,0));
+    auto runAux = std::make_shared<edm::RunAuxiliary>(eventID_.run(), now, now);
+    auto rp = std::make_shared<edm::RunPrincipal>(runAux, pProductRegistry_, *process, &historyAppender_,0);
+    auto lumiAux = std::make_shared<edm::LuminosityBlockAuxiliary>(rp->run(), 1, now, now);
+    auto lbp = std::make_shared<edm::LuminosityBlockPrincipal>(lumiAux, pProductRegistry_, *process, &historyAppender_,0);
     lbp->setRunPrincipal(rp);
     edm::EventAuxiliary eventAux(eventID_, uuid, now, true);
     pEvent_.reset(new edm::EventPrincipal(pProductRegistry_, branchIDListHelper, *process, &historyAppender_,edm::StreamID::invalidStreamID()));

--- a/FWCore/Framework/test/eventprocessor_t.cppunit.cc
+++ b/FWCore/Framework/test/eventprocessor_t.cppunit.cc
@@ -410,8 +410,8 @@ testeventprocessor::activityRegistryTest() {
       "   ivalue = cms.int32(-3))\n"
       "process.p1 = cms.Path(process.m1)\n");
 
-  boost::shared_ptr<edm::ParameterSet> parameterSet = PythonProcessDesc(configuration).parameterSet();
-  boost::shared_ptr<edm::ProcessDesc> processDesc(new edm::ProcessDesc(parameterSet));
+  std::shared_ptr<edm::ParameterSet> parameterSet = PythonProcessDesc(configuration).parameterSet();
+  auto processDesc = std::make_shared<edm::ProcessDesc>(parameterSet);
 
   //We don't want any services, we just want an ActivityRegistry to be created
   // We then use this ActivityRegistry to 'spy on' the signals being produced

--- a/FWCore/Framework/test/generichandle_t.cppunit.cc
+++ b/FWCore/Framework/test/generichandle_t.cppunit.cc
@@ -83,14 +83,14 @@ void testGenericHandle::failgetbyLabelTest() {
   edm::Timestamp time;
   std::string uuid = edm::createGlobalIdentifier();
   edm::ProcessConfiguration pc("PROD", edm::ParameterSetID(), edm::getReleaseVersion(), edm::getPassID());
-  boost::shared_ptr<edm::ProductRegistry> preg(new edm::ProductRegistry);
+  auto preg = std::make_shared<edm::ProductRegistry>();
   preg->setFrozen();
-  boost::shared_ptr<edm::RunAuxiliary> runAux(new edm::RunAuxiliary(id.run(), time, time));
-  boost::shared_ptr<edm::RunPrincipal> rp(new edm::RunPrincipal(runAux, preg, pc, &historyAppender_,0));
-  boost::shared_ptr<edm::LuminosityBlockAuxiliary> lumiAux(new edm::LuminosityBlockAuxiliary(rp->run(), 1, time, time));
-  boost::shared_ptr<edm::LuminosityBlockPrincipal>lbp(new edm::LuminosityBlockPrincipal(lumiAux, preg, pc, &historyAppender_,0));
+  auto runAux = std::make_shared<edm::RunAuxiliary>(id.run(), time, time);
+  auto rp = std::make_shared<edm::RunPrincipal>(runAux, preg, pc, &historyAppender_,0);
+  auto lumiAux = std::make_shared<edm::LuminosityBlockAuxiliary>(rp->run(), 1, time, time);
+  auto lbp = std::make_shared<edm::LuminosityBlockPrincipal>(lumiAux, preg, pc, &historyAppender_,0);
   lbp->setRunPrincipal(rp);
-  boost::shared_ptr<edm::BranchIDListHelper> branchIDListHelper(new edm::BranchIDListHelper());
+  auto branchIDListHelper = std::make_shared<edm::BranchIDListHelper>();
   branchIDListHelper->updateFromRegistry(*preg);
   edm::EventAuxiliary eventAux(id, uuid, time, true);
   edm::EventPrincipal ep(preg, branchIDListHelper, pc, &historyAppender_,edm::StreamID::invalidStreamID());
@@ -142,8 +142,7 @@ void testGenericHandle::getbyLabelTest() {
 
   edm::ParameterSet dummyProcessPset;
   dummyProcessPset.registerIt();
-  boost::shared_ptr<edm::ProcessConfiguration> processConfiguration(
-    new edm::ProcessConfiguration());
+  auto processConfiguration = std::make_shared<edm::ProcessConfiguration>();
   processConfiguration->setParameterSetID(dummyProcessPset.id());
 
   edm::ParameterSet pset;
@@ -165,7 +164,7 @@ void testGenericHandle::getbyLabelTest() {
   std::unique_ptr<edm::ProductRegistry> preg(new edm::ProductRegistry);
   preg->addProduct(product);
   preg->setFrozen();
-  boost::shared_ptr<edm::BranchIDListHelper> branchIDListHelper(new edm::BranchIDListHelper());
+  auto branchIDListHelper = std::make_shared<edm::BranchIDListHelper>();
   branchIDListHelper->updateFromRegistry(*preg);
 
   edm::ProductRegistry::ProductList const& pl = preg->productList();
@@ -176,11 +175,11 @@ void testGenericHandle::getbyLabelTest() {
   edm::Timestamp fakeTime;
   std::string uuid = edm::createGlobalIdentifier();
   edm::ProcessConfiguration pc("PROD", dummyProcessPset.id(), edm::getReleaseVersion(), edm::getPassID());
-  boost::shared_ptr<edm::ProductRegistry const> pregc(preg.release());
-  boost::shared_ptr<edm::RunAuxiliary> runAux(new edm::RunAuxiliary(col.run(), fakeTime, fakeTime));
-  boost::shared_ptr<edm::RunPrincipal> rp(new edm::RunPrincipal(runAux, pregc, pc, &historyAppender_,0));
-  boost::shared_ptr<edm::LuminosityBlockAuxiliary> lumiAux(new edm::LuminosityBlockAuxiliary(rp->run(), 1, fakeTime, fakeTime));
-  boost::shared_ptr<edm::LuminosityBlockPrincipal>lbp(new edm::LuminosityBlockPrincipal(lumiAux, pregc, pc, &historyAppender_,0));
+  std::shared_ptr<edm::ProductRegistry const> pregc(preg.release());
+  auto runAux = std::make_shared<edm::RunAuxiliary>(col.run(), fakeTime, fakeTime);
+  auto rp = std::make_shared<edm::RunPrincipal>(runAux, pregc, pc, &historyAppender_,0);
+  auto lumiAux = std::make_shared<edm::LuminosityBlockAuxiliary>(rp->run(), 1, fakeTime, fakeTime);
+  auto lbp = std::make_shared<edm::LuminosityBlockPrincipal>(lumiAux, pregc, pc, &historyAppender_,0);
   lbp->setRunPrincipal(rp);
   edm::EventAuxiliary eventAux(col, uuid, fakeTime, true);
   edm::EventPrincipal ep(pregc, branchIDListHelper, pc, &historyAppender_,edm::StreamID::invalidStreamID());
@@ -188,7 +187,7 @@ void testGenericHandle::getbyLabelTest() {
   ep.fillEventPrincipal(eventAux, phr);
   ep.setLuminosityBlockPrincipal(lbp);
   edm::BranchDescription const& branchFromRegistry = it->second;
-  boost::shared_ptr<edm::Parentage> entryDescriptionPtr(new edm::Parentage);
+  auto entryDescriptionPtr = std::make_shared<edm::Parentage>();
   edm::ProductProvenance prov(branchFromRegistry.branchID(), entryDescriptionPtr);
   edm::BranchDescription const desc(branchFromRegistry);
   ep.put(desc, pprod, prov);
@@ -197,8 +196,7 @@ void testGenericHandle::getbyLabelTest() {
   try {
     edm::ParameterSet dummyProcessPset;
     dummyProcessPset.registerIt();
-    boost::shared_ptr<edm::ProcessConfiguration> processConfiguration(
-      new edm::ProcessConfiguration());
+    auto processConfiguration = std::make_shared<edm::ProcessConfiguration>();
     processConfiguration->setParameterSetID(dummyProcessPset.id());
 
     edm::ParameterSet pset;

--- a/FWCore/Framework/test/global_module_t.cppunit.cc
+++ b/FWCore/Framework/test/global_module_t.cppunit.cc
@@ -90,13 +90,13 @@ private:
   std::map<Trans,std::function<void(edm::Worker*)>> m_transToFunc;
   
   edm::ProcessConfiguration m_procConfig;
-  boost::shared_ptr<edm::ProductRegistry> m_prodReg;
-  boost::shared_ptr<edm::BranchIDListHelper> m_idHelper;
+  std::shared_ptr<edm::ProductRegistry> m_prodReg;
+  std::shared_ptr<edm::BranchIDListHelper> m_idHelper;
   std::unique_ptr<edm::EventPrincipal> m_ep;
   edm::HistoryAppender historyAppender_;
-  boost::shared_ptr<edm::LuminosityBlockPrincipal> m_lbp;
-  boost::shared_ptr<edm::RunPrincipal> m_rp;
-  boost::shared_ptr<edm::ActivityRegistry> m_actReg;
+  std::shared_ptr<edm::LuminosityBlockPrincipal> m_lbp;
+  std::shared_ptr<edm::RunPrincipal> m_rp;
+  std::shared_ptr<edm::ActivityRegistry> m_actReg;
   edm::EventSetup* m_es = nullptr;
   edm::ModuleDescription m_desc = {"Dummy","dummy"};
   edm::CPUTimer* m_timer = nullptr;
@@ -353,9 +353,9 @@ m_ep()
   
   std::string uuid = edm::createGlobalIdentifier();
   edm::Timestamp now(1234567UL);
-  boost::shared_ptr<edm::RunAuxiliary> runAux(new edm::RunAuxiliary(eventID.run(), now, now));
+  auto runAux = std::make_shared<edm::RunAuxiliary>(eventID.run(), now, now);
   m_rp.reset(new edm::RunPrincipal(runAux, m_prodReg, m_procConfig, &historyAppender_,0));
-  boost::shared_ptr<edm::LuminosityBlockAuxiliary> lumiAux(new edm::LuminosityBlockAuxiliary(m_rp->run(), 1, now, now));
+  auto lumiAux = std::make_shared<edm::LuminosityBlockAuxiliary>(m_rp->run(), 1, now, now);
   m_lbp.reset(new edm::LuminosityBlockPrincipal(lumiAux, m_prodReg, m_procConfig, &historyAppender_,0));
   m_lbp->setRunPrincipal(m_rp);
   edm::EventAuxiliary eventAux(eventID, uuid, now, true);

--- a/FWCore/Framework/test/maker2_t.cppunit.cc
+++ b/FWCore/Framework/test/maker2_t.cppunit.cc
@@ -1,7 +1,7 @@
 
 #include <iostream>
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 #include "FWCore/Utilities/interface/GetPassID.h"
 #include "FWCore/Version/interface/GetReleaseVersion.h"
@@ -71,7 +71,7 @@ void testmaker2::maker2Test()
 
   edm::ProductRegistry preg;
   edm::PreallocationConfiguration prealloc;
-  boost::shared_ptr<ProcessConfiguration> pc(new ProcessConfiguration("PROD", edm::ParameterSetID(), edm::getReleaseVersion(), edm::getPassID()));
+  auto pc = std::make_shared<ProcessConfiguration>("PROD", edm::ParameterSetID(), edm::getReleaseVersion(), edm::getPassID());
   edm::MakeModuleParams params1(&p1, preg, &prealloc, pc);
   edm::MakeModuleParams params2(&p2, preg, &prealloc, pc);
 

--- a/FWCore/Framework/test/maker_t.cppunit.cc
+++ b/FWCore/Framework/test/maker_t.cppunit.cc
@@ -41,8 +41,8 @@ void testmaker::makerTest()
     //std::cout << (*ib)->name() << std::endl;
     // }
 
-    boost::shared_ptr<ParameterSet> p1 = makePSet(*edm::pset::parse(param1.c_str()));;
-    boost::shared_ptr<ParameterSet> p2 = makePSet(*edm::pset::parse(param2.c_str()));;
+    std::shared_ptr<ParameterSet> p1 = makePSet(*edm::pset::parse(param1.c_str()));;
+    std::shared_ptr<ParameterSet> p2 = makePSet(*edm::pset::parse(param2.c_str()));;
 
     std::cerr << p1->getParameter<std::string>("@module_type");
 

--- a/FWCore/Framework/test/one_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/one_outputmodule_t.cppunit.cc
@@ -77,13 +77,13 @@ private:
   std::map<Trans,std::function<void(edm::Worker*,edm::OutputModuleCommunicator*)>> m_transToFunc;
   
   edm::ProcessConfiguration m_procConfig;
-  boost::shared_ptr<edm::ProductRegistry> m_prodReg;
-  boost::shared_ptr<edm::BranchIDListHelper> m_idHelper;
+  std::shared_ptr<edm::ProductRegistry> m_prodReg;
+  std::shared_ptr<edm::BranchIDListHelper> m_idHelper;
   std::unique_ptr<edm::EventPrincipal> m_ep;
   edm::HistoryAppender historyAppender_;
-  boost::shared_ptr<edm::LuminosityBlockPrincipal> m_lbp;
-  boost::shared_ptr<edm::RunPrincipal> m_rp;
-  boost::shared_ptr<edm::ActivityRegistry> m_actReg;
+  std::shared_ptr<edm::LuminosityBlockPrincipal> m_lbp;
+  std::shared_ptr<edm::RunPrincipal> m_rp;
+  std::shared_ptr<edm::ActivityRegistry> m_actReg;
   edm::EventSetup* m_es = nullptr;
   edm::ModuleDescription m_desc = {"Dummy","dummy"};
   edm::CPUTimer* m_timer = nullptr;
@@ -91,7 +91,7 @@ private:
   
   typedef edm::service::TriggerNamesService TNS;
   typedef edm::serviceregistry::ServiceWrapper<TNS> w_TNS;
-  boost::shared_ptr<w_TNS> tnsptr_;
+  std::shared_ptr<w_TNS> tnsptr_;
   edm::ServiceToken serviceToken_;
   
   template<typename T>
@@ -240,9 +240,9 @@ m_ep()
   
   std::string uuid = edm::createGlobalIdentifier();
   edm::Timestamp now(1234567UL);
-  boost::shared_ptr<edm::RunAuxiliary> runAux(new edm::RunAuxiliary(eventID.run(), now, now));
+  auto runAux = std::make_shared<edm::RunAuxiliary>(eventID.run(), now, now);
   m_rp.reset(new edm::RunPrincipal(runAux, m_prodReg, m_procConfig, &historyAppender_,0));
-  boost::shared_ptr<edm::LuminosityBlockAuxiliary> lumiAux(new edm::LuminosityBlockAuxiliary(m_rp->run(), 1, now, now));
+  auto lumiAux = std::make_shared<edm::LuminosityBlockAuxiliary>(m_rp->run(), 1, now, now);
   m_lbp.reset(new edm::LuminosityBlockPrincipal(lumiAux, m_prodReg, m_procConfig, &historyAppender_,0));
   m_lbp->setRunPrincipal(m_rp);
   edm::EventAuxiliary eventAux(eventID, uuid, now, true);

--- a/FWCore/Framework/test/productregistry.cppunit.cc
+++ b/FWCore/Framework/test/productregistry.cppunit.cc
@@ -20,7 +20,7 @@
 
 #include "cppunit/extensions/HelperMacros.h"
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 #include <iostream>
 
@@ -45,8 +45,8 @@ public:
   void testProductRegistration();
 
  private:
-  boost::shared_ptr<edm::BranchDescription> intBranch_;
-  boost::shared_ptr<edm::BranchDescription> floatBranch_;
+  std::shared_ptr<edm::BranchDescription> intBranch_;
+  std::shared_ptr<edm::BranchDescription> floatBranch_;
 };
 
 ///registration of the test so that the runner can find it
@@ -72,8 +72,7 @@ namespace {
       void respond(edm::BranchDescription const& iDesc) {
          edm::ParameterSet dummyProcessPset;
          dummyProcessPset.registerIt();
-         boost::shared_ptr<edm::ProcessConfiguration> pc(
-           new edm::ProcessConfiguration());
+         auto pc = std::make_shared<edm::ProcessConfiguration>();
          pc->setParameterSetID(dummyProcessPset.id());
 
          edm::BranchDescription prod(iDesc.branchType(),
@@ -101,8 +100,7 @@ void testProductRegistry::setUp() {
   edm::RootAutoLibraryLoader::enable();
   edm::ParameterSet dummyProcessPset;
   dummyProcessPset.registerIt();
-  boost::shared_ptr<edm::ProcessConfiguration> processConfiguration(
-    new edm::ProcessConfiguration());
+  auto processConfiguration = std::make_shared<edm::ProcessConfiguration>();
   processConfiguration->setParameterSetID(dummyProcessPset.id());
 
   edm::ParameterSet pset;
@@ -120,7 +118,7 @@ void testProductRegistry::setUp() {
 }
 
 namespace {
-  template <class T> void kill_and_clear(boost::shared_ptr<T>& p) { p.reset(); }
+  template <class T> void kill_and_clear(std::shared_ptr<T>& p) { p.reset(); }
 }
 
 void testProductRegistry::tearDown() {

--- a/FWCore/Framework/test/stream_module_t.cppunit.cc
+++ b/FWCore/Framework/test/stream_module_t.cppunit.cc
@@ -89,13 +89,13 @@ private:
   std::map<Trans,std::function<void(edm::Worker*)>> m_transToFunc;
   
   edm::ProcessConfiguration m_procConfig;
-  boost::shared_ptr<edm::ProductRegistry> m_prodReg;
-  boost::shared_ptr<edm::BranchIDListHelper> m_idHelper;
+  std::shared_ptr<edm::ProductRegistry> m_prodReg;
+  std::shared_ptr<edm::BranchIDListHelper> m_idHelper;
   std::unique_ptr<edm::EventPrincipal> m_ep;
   edm::HistoryAppender historyAppender_;
-  boost::shared_ptr<edm::LuminosityBlockPrincipal> m_lbp;
-  boost::shared_ptr<edm::RunPrincipal> m_rp;
-  boost::shared_ptr<edm::ActivityRegistry> m_actReg;
+  std::shared_ptr<edm::LuminosityBlockPrincipal> m_lbp;
+  std::shared_ptr<edm::RunPrincipal> m_rp;
+  std::shared_ptr<edm::ActivityRegistry> m_actReg;
   edm::EventSetup* m_es = nullptr;
   edm::ModuleDescription m_desc = {"Dummy","dummy"};
   edm::CPUTimer* m_timer = nullptr;
@@ -376,9 +376,9 @@ m_ep()
   
   std::string uuid = edm::createGlobalIdentifier();
   edm::Timestamp now(1234567UL);
-  boost::shared_ptr<edm::RunAuxiliary> runAux(new edm::RunAuxiliary(eventID.run(), now, now));
+  auto runAux = std::make_shared<edm::RunAuxiliary>(eventID.run(), now, now);
   m_rp.reset(new edm::RunPrincipal(runAux, m_prodReg, m_procConfig, &historyAppender_,0));
-  boost::shared_ptr<edm::LuminosityBlockAuxiliary> lumiAux(new edm::LuminosityBlockAuxiliary(m_rp->run(), 1, now, now));
+  auto lumiAux = std::make_shared<edm::LuminosityBlockAuxiliary>(m_rp->run(), 1, now, now);
   m_lbp.reset(new edm::LuminosityBlockPrincipal(lumiAux, m_prodReg, m_procConfig, &historyAppender_,0));
   m_lbp->setRunPrincipal(m_rp);
   edm::EventAuxiliary eventAux(eventID, uuid, now, true);

--- a/FWCore/Framework/test/stubs/TestGlobalAnalyzers.cc
+++ b/FWCore/Framework/test/stubs/TestGlobalAnalyzers.cc
@@ -129,7 +129,7 @@ struct UnsafeCache {
     
     std::shared_ptr<Cache> globalBeginRun(edm::Run const&, edm::EventSetup const&) const override {
       ++m_count;
-      return std::shared_ptr<Cache>(new Cache);
+      return std::make_shared<Cache>();
     }
 
     void analyze(edm::StreamID iID, const edm::Event& iEvent, const edm::EventSetup&) const override {
@@ -169,7 +169,7 @@ struct UnsafeCache {
    
     std::shared_ptr<Cache> globalBeginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) const override {
       ++m_count;
-      return std::shared_ptr<Cache>(new Cache);
+      return std::make_shared<Cache>();
     }
 
     void analyze(edm::StreamID, const edm::Event& iEvent, const edm::EventSetup&) const override {
@@ -213,7 +213,7 @@ struct UnsafeCache {
 
     std::shared_ptr<UnsafeCache> globalBeginRunSummary(edm::Run const&, edm::EventSetup const&) const override {
       ++m_count;
-      return std::shared_ptr<UnsafeCache>(new UnsafeCache);
+      return std::make_shared<UnsafeCache>();
     }
   
     void analyze(edm::StreamID iID, const edm::Event&, const edm::EventSetup&) const override {
@@ -263,7 +263,7 @@ struct UnsafeCache {
 
     std::shared_ptr<UnsafeCache> globalBeginLuminosityBlockSummary(edm::LuminosityBlock const&, edm::EventSetup const&) const override {
       ++m_count;
-      return std::shared_ptr<UnsafeCache>(new UnsafeCache);
+      return std::make_shared<UnsafeCache>();
     }
     
     void analyze(edm::StreamID iID, const edm::Event& iEvent, const edm::EventSetup&) const override {

--- a/FWCore/Framework/test/stubs/TestGlobalFilters.cc
+++ b/FWCore/Framework/test/stubs/TestGlobalFilters.cc
@@ -179,7 +179,7 @@ struct UnsafeCache {
     
     std::shared_ptr<Cache> globalBeginRun(edm::Run const&, edm::EventSetup const&) const override {
       ++m_count;
-      std::shared_ptr<Cache> rCache(new Cache);
+      auto rCache = std::make_shared<Cache>();
       ++(rCache->run);
       return rCache;
     }
@@ -248,7 +248,7 @@ struct UnsafeCache {
     
     std::shared_ptr<Cache> globalBeginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) const override {
       ++m_count;
-      std::shared_ptr<Cache> lCache(new Cache);
+      auto lCache = std::make_shared<Cache>();
       ++(lCache->lumi);  
       return lCache;
     }
@@ -325,7 +325,7 @@ struct UnsafeCache {
     
     std::shared_ptr<UnsafeCache> globalBeginRunSummary(edm::Run const&, edm::EventSetup const&) const override {
       ++m_count;
-      std::shared_ptr<UnsafeCache> gCache(new UnsafeCache);
+      auto gCache = std::make_shared<UnsafeCache>();
       ++(gCache->run);
       return gCache;
     }
@@ -387,7 +387,7 @@ struct UnsafeCache {
   
     std::shared_ptr<UnsafeCache> globalBeginLuminosityBlockSummary(edm::LuminosityBlock const&, edm::EventSetup const&) const override {
       ++m_count;
-      std::shared_ptr<UnsafeCache> gCache(new UnsafeCache);
+      auto gCache = std::make_shared<UnsafeCache>();
       ++(gCache->lumi);
       return gCache;
     }

--- a/FWCore/Framework/test/stubs/TestGlobalProducers.cc
+++ b/FWCore/Framework/test/stubs/TestGlobalProducers.cc
@@ -160,7 +160,7 @@ struct UnsafeCache {
 
     std::shared_ptr<Cache> globalBeginRun(edm::Run const& iRun, edm::EventSetup const&) const override {
       ++m_count;
-      std::shared_ptr<Cache> rCache(new Cache);
+      auto rCache = std::make_shared<Cache>();
       ++(rCache->run);
       return rCache;
     }
@@ -228,7 +228,7 @@ struct UnsafeCache {
     
     std::shared_ptr<Cache> globalBeginLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&) const override {
       ++m_count;
-      std::shared_ptr<Cache> lCache(new Cache);
+      auto lCache = std::make_shared<Cache>();
       ++(lCache->lumi);  
       return lCache;
     }
@@ -304,7 +304,7 @@ struct UnsafeCache {
 
     std::shared_ptr<UnsafeCache> globalBeginRunSummary(edm::Run const& iRun, edm::EventSetup const&) const override {
       ++m_count;
-      std::shared_ptr<UnsafeCache> gCache(new UnsafeCache);
+      auto gCache = std::make_shared<UnsafeCache>();
       ++(gCache->run);
       return gCache;
     }
@@ -365,7 +365,7 @@ struct UnsafeCache {
 
     std::shared_ptr<UnsafeCache> globalBeginLuminosityBlockSummary(edm::LuminosityBlock const& iLB, edm::EventSetup const&) const override {
       ++m_count;
-      std::shared_ptr<UnsafeCache> gCache(new UnsafeCache);
+      auto gCache = std::make_shared<UnsafeCache>();
       ++(gCache->lumi);
        return gCache;
     }

--- a/FWCore/Framework/test/stubs/TestStreamAnalyzers.cc
+++ b/FWCore/Framework/test/stubs/TestStreamAnalyzers.cc
@@ -106,7 +106,7 @@ struct Cache {
       ++m_count;
       gbr = true;
       ger = false;
-      std::shared_ptr<Cache> pCache{ new Cache };
+      auto pCache = std::make_shared<Cache>();
       ++(pCache->run);
       return pCache;
     }
@@ -181,7 +181,7 @@ struct Cache {
       ++m_count;
       gbl = true;
       gel = false;
-      std::shared_ptr<Cache> pCache{ new Cache };
+      auto pCache = std::make_shared<Cache>();
       ++(pCache->lumi);
       return pCache;
    }
@@ -263,7 +263,7 @@ struct Cache {
       ++m_count;
       gbr=true;
       ger=false;
-      std::shared_ptr<Cache> pCache{ new Cache };
+      auto pCache = std::make_shared<Cache>();
       ++(pCache->run);
       return pCache;
    }
@@ -278,7 +278,7 @@ struct Cache {
         throw cms::Exception("begin out of sequence")
           << "globalBeginRunSummary seen before globalBeginRun";
       }
-      return std::shared_ptr<Cache>{ new Cache };
+      return std::make_shared<Cache>();
     }
 
    void endRunSummary(edm::Run const&, edm::EventSetup const&, Cache* gCache) const override {
@@ -367,7 +367,7 @@ struct Cache {
       ++m_count;
       gbl = true;
       gel = false;
-      std::shared_ptr<Cache> pCache{ new Cache };
+      auto pCache = std::make_shared<Cache>();
       ++(pCache->lumi);
       return pCache;
     }
@@ -383,7 +383,7 @@ struct Cache {
        throw cms::Exception("begin out of sequence")
          << "globalBeginLuminosityBlockSummary seen before globalBeginLuminosityBlock";
       }
-      return std::shared_ptr<Cache>{ new Cache };
+      return std::make_shared<Cache>();
    }
    
    

--- a/FWCore/Framework/test/stubs/TestStreamFilters.cc
+++ b/FWCore/Framework/test/stubs/TestStreamFilters.cc
@@ -110,7 +110,7 @@ struct Cache {
       ++m_count;
       gbr = true;
       ger = false;
-      std::shared_ptr<Cache> pCache{ new Cache };
+      auto pCache = std::make_shared<Cache>();
       ++(pCache->run);
       return pCache;
    }
@@ -168,7 +168,7 @@ struct Cache {
       ++m_count;
       gbl = true;
       gel = false;
-      std::shared_ptr<Cache> pCache{ new Cache };
+      auto pCache = std::make_shared<Cache>();
       ++(pCache->lumi);
       return pCache;
    }
@@ -247,7 +247,7 @@ struct Cache {
       ++m_count;
       gbr=true;
       ger=false;
-      std::shared_ptr<Cache> pCache {new Cache };
+      auto pCache = std::make_shared<Cache>();
       ++(pCache->run);
       return pCache;
    }
@@ -262,7 +262,7 @@ struct Cache {
         throw cms::Exception("begin out of sequence")
           << "globalBeginRunSummary seen before globalBeginRun";
       }
-      return std::shared_ptr<Cache>{ new Cache };
+      return std::make_shared<Cache>();
    }
     
     void endRunSummary(edm::Run const&, edm::EventSetup const&, Cache* gCache) const override {
@@ -353,7 +353,7 @@ struct Cache {
       ++m_count;
       gbl = true;
       gel = false;
-      std::shared_ptr<Cache> pCache{ new Cache };
+      auto pCache = std::make_shared<Cache>();
       ++(pCache->lumi);
       return pCache;
     }
@@ -369,7 +369,7 @@ struct Cache {
        throw cms::Exception("begin out of sequence")
          << "globalBeginLuminosityBlockSummary seen before globalBeginLuminosityBlock";
       }
-      return std::shared_ptr<Cache>{ new Cache };
+      return std::make_shared<Cache>();
     }
     
     void endLuminosityBlockSummary(edm::LuminosityBlock const&, edm::EventSetup const&, Cache* gCache) const override {
@@ -446,7 +446,7 @@ struct Cache {
      ++m_count;
       gbr=true;
       ger=false;
-      std::shared_ptr<Cache> pCache{ new Cache };
+      auto pCache = std::make_shared<Cache>();
       ++(pCache->run);
       return pCache;
    }
@@ -495,7 +495,7 @@ struct Cache {
      ++m_count;
       gbr=true;
       ger=false;
-      std::shared_ptr<Cache> pCache{ new Cache };
+      auto pCache = std::make_shared<Cache>();
       ++(pCache->run);
       return pCache;
    }
@@ -575,7 +575,7 @@ struct Cache {
       ++m_count;
       gbl = true;
       gel = false;
-      std::shared_ptr<Cache> pCache{ new Cache };
+      auto pCache = std::make_shared<Cache>();
       ++(pCache->lumi);
       return pCache;
    }
@@ -625,7 +625,7 @@ struct Cache {
       ++m_count;
       gbl = true;
       gel = false;
-      std::shared_ptr<Cache> pCache{ new Cache };
+      auto pCache = std::make_shared<Cache>();
       ++(pCache->lumi);
       return pCache;
    }

--- a/FWCore/Framework/test/stubs/TestStreamProducers.cc
+++ b/FWCore/Framework/test/stubs/TestStreamProducers.cc
@@ -113,7 +113,7 @@ struct UnsafeCache {
       ++m_count;
       gbr = true;
       ger = false;
-      std::shared_ptr<Cache> pCache{ new Cache };
+      auto pCache = std::make_shared<Cache>();
       ++(pCache->run);
       return pCache;
     }
@@ -188,7 +188,7 @@ struct UnsafeCache {
       ++m_count;
       gbl = true;
       gel = false;
-      std::shared_ptr<Cache> pCache{ new Cache };
+      auto pCache = std::make_shared<Cache>();
       ++(pCache->lumi);
       return pCache;
     }
@@ -271,7 +271,7 @@ struct UnsafeCache {
       ++m_count;
       gbr=true;
       ger=false;
-      std::shared_ptr<Cache> pCache{ new Cache };
+      auto pCache = std::make_shared<Cache>();
       ++(pCache->run);
       return pCache;
  
@@ -287,7 +287,7 @@ struct UnsafeCache {
         throw cms::Exception("begin out of sequence")
           << "globalBeginRunSummary seen before globalBeginRun";
       }
-      return std::shared_ptr<UnsafeCache>{ new UnsafeCache };
+      return std::make_shared<UnsafeCache>();
     }
     
     void endRunSummary(edm::Run const&, edm::EventSetup const&, UnsafeCache* gCache) const override {
@@ -375,7 +375,7 @@ struct UnsafeCache {
       ++m_count;
       gbl = true;
       gel = false;
-      std::shared_ptr<Cache> pCache{ new Cache };
+      auto pCache = std::make_shared<Cache>();
       ++(pCache->lumi);
       return pCache;
     }
@@ -391,7 +391,7 @@ struct UnsafeCache {
        throw cms::Exception("begin out of sequence")
          << "globalBeginLuminosityBlockSummary seen before globalBeginLuminosityBlock";
       }
-      return std::shared_ptr<UnsafeCache>{ new UnsafeCache };
+      return std::make_shared<UnsafeCache>();
     }
     
 

--- a/FWCore/Integration/test/ThrowingSource.cc
+++ b/FWCore/Integration/test/ThrowingSource.cc
@@ -20,8 +20,8 @@ namespace edm {
     virtual void endRun(edm::Run&);
     virtual std::unique_ptr<edm::FileBlock> readFile_();
     virtual void closeFile_();
-    virtual boost::shared_ptr<edm::RunAuxiliary> readRunAuxiliary_();
-    virtual boost::shared_ptr<edm::LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary_();
+    virtual std::shared_ptr<edm::RunAuxiliary> readRunAuxiliary_();
+    virtual std::shared_ptr<edm::LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary_();
     virtual void readEvent_(edm::EventPrincipal&);
   private:
     enum {
@@ -109,21 +109,21 @@ namespace edm {
     if (whenToThrow_ == kCloseFile) throw cms::Exception("TestThrow") << "ThrowingSource::closeFile_";
   }
 
-  boost::shared_ptr<RunAuxiliary>
+  std::shared_ptr<RunAuxiliary>
   ThrowingSource::readRunAuxiliary_() {
     if (whenToThrow_ == kReadRunAuxiliary) throw cms::Exception("TestThrow") << "ThrowingSource::readRunAuxiliary_";
     Timestamp ts = Timestamp(presentTime());
     resetNewRun();
-    return boost::shared_ptr<RunAuxiliary>(new RunAuxiliary(eventID().run(), ts, Timestamp::invalidTimestamp()));
+    return std::make_shared<RunAuxiliary>(eventID().run(), ts, Timestamp::invalidTimestamp());
   }
 
-  boost::shared_ptr<LuminosityBlockAuxiliary>
+  std::shared_ptr<LuminosityBlockAuxiliary>
   ThrowingSource::readLuminosityBlockAuxiliary_() {
     if (whenToThrow_ == kReadLuminosityBlockAuxiliary) throw cms::Exception("TestThrow") << "ThrowingSource::readLuminosityBlockAuxiliary_";
-    if (processingMode() == Runs) return boost::shared_ptr<LuminosityBlockAuxiliary>();
+    if (processingMode() == Runs) return std::shared_ptr<LuminosityBlockAuxiliary>();
     Timestamp ts = Timestamp(presentTime());
     resetNewLumi();
-    return boost::shared_ptr<LuminosityBlockAuxiliary>(new LuminosityBlockAuxiliary(eventID().run(), eventID().luminosityBlock(), ts, Timestamp::invalidTimestamp()));
+    return std::make_shared<LuminosityBlockAuxiliary>(eventID().run(), eventID().luminosityBlock(), ts, Timestamp::invalidTimestamp());
   }
 
   void

--- a/FWCore/MessageLogger/interface/ConfigurationHandshake.h
+++ b/FWCore/MessageLogger/interface/ConfigurationHandshake.h
@@ -9,8 +9,8 @@
 namespace edm {
   class ParameterSet;
 
-  typedef boost::shared_ptr<edm::Exception> Pointer_to_new_exception_on_heap;
-  typedef boost::shared_ptr<Pointer_to_new_exception_on_heap> Place_for_passing_exception_ptr;
+  typedef std::shared_ptr<edm::Exception> Pointer_to_new_exception_on_heap;
+  typedef std::shared_ptr<Pointer_to_new_exception_on_heap> Place_for_passing_exception_ptr;
 
   struct ConfigurationHandshake {
     void* p;

--- a/FWCore/MessageLogger/interface/MessageLoggerQ.h
+++ b/FWCore/MessageLogger/interface/MessageLoggerQ.h
@@ -3,7 +3,7 @@
 
 #include "FWCore/MessageLogger/interface/ELseverityLevel.h"
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 #include <string>
 #include <map>
@@ -56,7 +56,7 @@ public:
 
   // ---  bookkeeping for single-thread mode
   static  void  setMLscribe_ptr
-     (boost::shared_ptr<edm::service::AbstractMLscribe>  m);
+     (std::shared_ptr<edm::service::AbstractMLscribe>  m);
 
   // ---  helper for scribes
   static bool handshaked ( const OpCode & op );
@@ -83,7 +83,7 @@ private:
   void  operator = ( MessageLoggerQ const & );
 
   // --- data:
-  [[cms::thread_safe]] static  boost::shared_ptr<edm::service::AbstractMLscribe> mlscribe_ptr;
+  [[cms::thread_safe]] static  std::shared_ptr<edm::service::AbstractMLscribe> mlscribe_ptr;
   [[cms::thread_safe]] static  edm::ELseverityLevel threshold;
   [[cms::thread_safe]] static  std::set<std::string> squelchSet;
   

--- a/FWCore/MessageLogger/interface/MessageSender.h
+++ b/FWCore/MessageLogger/interface/MessageSender.h
@@ -5,9 +5,10 @@
 #include "FWCore/MessageLogger/interface/ELseverityLevel.h"
 #include "FWCore/MessageLogger/interface/ErrorObj.h"
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 #include <map>
+#include "FWCore/Utilities/interface/HideStdSharedPtrFromRoot.h"
 
 // Change log
 //
@@ -44,7 +45,9 @@ public:
     MessageSender &
     operator<< ( T const & t )
   {
+#ifndef __GCCXML__
     if (valid()) (*errorobj_p) << t;
+#endif
     return *this;
   }
 
@@ -54,7 +57,7 @@ public:
   
 private:
   // data:
-  boost::shared_ptr<ErrorObj> errorobj_p;
+  std::shared_ptr<ErrorObj> errorobj_p;
 
 };  // MessageSender
 

--- a/FWCore/MessageLogger/src/MessageLoggerQ.cc
+++ b/FWCore/MessageLogger/src/MessageLoggerQ.cc
@@ -107,16 +107,15 @@ namespace {
    }   
 
   // Changelog 14
-  boost::shared_ptr<StandAloneScribe> obtainStandAloneScribePtr() {   
-    static boost::shared_ptr<StandAloneScribe> 
-      standAloneScribe_ptr( new StandAloneScribe );
+  std::shared_ptr<StandAloneScribe> obtainStandAloneScribePtr() {   
+    static auto standAloneScribe_ptr = std::make_shared<StandAloneScribe>();
     return standAloneScribe_ptr;
   }
 
 
 } // end of anonymous namespace
 
-boost::shared_ptr<edm::service::AbstractMLscribe>  
+std::shared_ptr<edm::service::AbstractMLscribe>  
   MessageLoggerQ::mlscribe_ptr = obtainStandAloneScribePtr();  
   				// changeLog 8, 11, 14
 
@@ -137,7 +136,7 @@ MessageLoggerQ *
 
 void
   MessageLoggerQ::setMLscribe_ptr
-  	(boost::shared_ptr<edm::service::AbstractMLscribe> m) // changeLog 8, 14
+  	(std::shared_ptr<edm::service::AbstractMLscribe> m) // changeLog 8, 14
 {
   if (!m) { 
     mlscribe_ptr = obtainStandAloneScribePtr();

--- a/FWCore/MessageLogger/src/MessageSender.cc
+++ b/FWCore/MessageLogger/src/MessageSender.cc
@@ -4,6 +4,7 @@
 
 #include "FWCore/MessageLogger/interface/ErrorSummaryEntry.h"
 
+#include <algorithm>
 #include <cassert>
 #include <vector>
 #include <limits>

--- a/FWCore/MessageService/bin/Standalone.cpp
+++ b/FWCore/MessageService/bin/Standalone.cpp
@@ -71,8 +71,8 @@ int main(int, char* argv[]) {
 //     In particular, the job hangs as soon as the output buffer fills up.
 //     That's because, without the message service, there is no mechanism for
 //     emptying the buffers.
-    boost::shared_ptr<edm::Presence> theMessageServicePresence;
-    theMessageServicePresence = boost::shared_ptr<edm::Presence>(edm::PresenceFactory::get()->
+    std::shared_ptr<edm::Presence> theMessageServicePresence;
+    theMessageServicePresence = std::shared_ptr<edm::Presence>(edm::PresenceFactory::get()->
       makePresence("MessageServicePresence").release());
 
 // C.  Manufacture a configuration and establish it.

--- a/FWCore/MessageService/interface/ELadministrator.h
+++ b/FWCore/MessageService/interface/ELadministrator.h
@@ -56,7 +56,7 @@
 #include "FWCore/MessageLogger/interface/ELseverityLevel.h"
 #include "FWCore/MessageLogger/interface/ErrorObj.h"
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 namespace edm {       
 namespace service {       
@@ -124,7 +124,7 @@ protected:
   //
   const ELseverityLevel       & abortThreshold() const;
   const ELseverityLevel       &  exitThreshold() const;
-  std::list<boost::shared_ptr<ELdestination> >  & sinks();
+  std::list<std::shared_ptr<ELdestination> >  & sinks();
   const ELseverityLevel       & highSeverity() const;
   int                           severityCounts( int lev ) const;
 
@@ -137,11 +137,11 @@ private:
 
   // ---  traditional member data:
   //
-  std::list<boost::shared_ptr<ELdestination> > sinks_;		
+  std::list<std::shared_ptr<ELdestination> > sinks_;		
   ELseverityLevel            highSeverity_;
   int                        severityCounts_[ ELseverityLevel::nLevels ];
 
-  std::map < ELstring, boost::shared_ptr<ELdestination> > attachedDestinations_;
+  std::map < ELstring, std::shared_ptr<ELdestination> > attachedDestinations_;
 
 };  // ELadministrator
 

--- a/FWCore/MessageService/interface/ELdestControl.h
+++ b/FWCore/MessageService/interface/ELdestControl.h
@@ -34,7 +34,7 @@
 #include "FWCore/MessageLogger/interface/ELseverityLevel.h"
 #include "FWCore/MessageLogger/interface/ErrorObj.h"
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 
 namespace edm {       
@@ -53,7 +53,7 @@ class ELdestination;
 class ELdestControl  {
 
 public:
-  ELdestControl( boost::shared_ptr<ELdestination> dest );
+  ELdestControl( std::shared_ptr<ELdestination> dest );
   ELdestControl();
   ~ELdestControl();
 
@@ -124,7 +124,7 @@ public:
   // -----  Data implementing the trivial handle pattern:
   //
 private:
-  boost::shared_ptr<ELdestination> d;
+  std::shared_ptr<ELdestination> d;
 
 };  // ELdestControl
 

--- a/FWCore/MessageService/interface/ELoutput.h
+++ b/FWCore/MessageService/interface/ELoutput.h
@@ -27,7 +27,7 @@
 #include "FWCore/MessageLogger/interface/ELstring.h"
 #include "FWCore/MessageLogger/interface/ELextendedID.h"
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 namespace edm {       
 
@@ -110,7 +110,7 @@ protected:
 protected:
   // --- member data:
   //
-  boost::shared_ptr<std::ostream> os;
+  std::shared_ptr<std::ostream> os;
   int                             charsOnLine;
   edm::ELextendedID               xid;
 

--- a/FWCore/MessageService/interface/MainThreadMLscribe.h
+++ b/FWCore/MessageService/interface/MainThreadMLscribe.h
@@ -6,7 +6,7 @@
 
 // I believe the below are not needed:
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 #include <iosfwd>
 #include <vector>
@@ -39,7 +39,7 @@ class MainThreadMLscribe : public AbstractMLscribe
 {
 public:
   // ---  birth/death:
-  MainThreadMLscribe(boost::shared_ptr<ThreadQueue> tqp);
+  MainThreadMLscribe(std::shared_ptr<ThreadQueue> tqp);
   virtual ~MainThreadMLscribe();
 
   // --- receive and act on messages:
@@ -49,7 +49,7 @@ public:
 
 private:
 
-   boost::shared_ptr<ThreadQueue>   m_queue;
+   std::shared_ptr<ThreadQueue>   m_queue;
 };  // MainThreadMLscribe
 
 

--- a/FWCore/MessageService/interface/MessageLoggerScribe.h
+++ b/FWCore/MessageService/interface/MessageLoggerScribe.h
@@ -10,7 +10,7 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 #include <iosfwd>
 #include <vector>
@@ -88,7 +88,7 @@ public:
   
   // ChangeLog 12
   /// --- If queue is NULL, this sets singleThread true 
-  explicit MessageLoggerScribe(boost::shared_ptr<ThreadQueue> queue);
+  explicit MessageLoggerScribe(std::shared_ptr<ThreadQueue> queue);
   
   virtual ~MessageLoggerScribe();
 
@@ -217,10 +217,10 @@ private:
   void parseCategories (std::string const & s, std::vector<std::string> & cats);
   
   // --- data:
-  boost::shared_ptr<ELadministrator>  admin_p;
+  std::shared_ptr<ELadministrator>  admin_p;
   ELdestControl                       early_dest;
-  std::vector<boost::shared_ptr<std::ofstream> > file_ps;
-  boost::shared_ptr<PSet>             job_pset_p;
+  std::vector<std::shared_ptr<std::ofstream> > file_ps;
+  std::shared_ptr<PSet>             job_pset_p;
   std::vector<NamedDestination     *> extern_dests;
   std::map<String,std::ostream     *> stream_ps;
   std::vector<String> 	  	      ordinary_destination_filenames;
@@ -233,7 +233,7 @@ private:
   bool 				      done;			// changeLog 9
   bool 				      purge_mode;		// changeLog 9
   int				      count;			// changeLog 9
-  boost::shared_ptr<ThreadQueue>      m_queue;			// changeLog 12
+  std::shared_ptr<ThreadQueue>      m_queue;			// changeLog 12
       
 };  // MessageLoggerScribe
 

--- a/FWCore/MessageService/interface/MessageServicePresence.h
+++ b/FWCore/MessageService/interface/MessageServicePresence.h
@@ -5,7 +5,7 @@
 
 #include "boost/thread/thread.hpp"
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 
 namespace edm  {
@@ -26,7 +26,7 @@ private:
   void  operator = (MessageServicePresence const &);
 
   // --- data:
-  boost::shared_ptr<ThreadQueue> m_queue;
+  std::shared_ptr<ThreadQueue> m_queue;
   boost::thread  m_scribeThread;
 
 };  // MessageServicePresence

--- a/FWCore/MessageService/interface/ThreadSafeLogMessageLoggerScribe.h
+++ b/FWCore/MessageService/interface/ThreadSafeLogMessageLoggerScribe.h
@@ -10,7 +10,7 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 #include <iosfwd>
 #include <vector>
@@ -94,10 +94,10 @@ private:
   void parseCategories (std::string const & s, std::vector<std::string> & cats);
   
   // --- data:
-  boost::shared_ptr<ELadministrator>  admin_p;
+  std::shared_ptr<ELadministrator>  admin_p;
   ELdestControl                       early_dest;
-  std::vector<boost::shared_ptr<std::ofstream> > file_ps;
-  boost::shared_ptr<PSet>             job_pset_p;
+  std::vector<std::shared_ptr<std::ofstream> > file_ps;
+  std::shared_ptr<PSet>             job_pset_p;
   std::vector<NamedDestination     *> extern_dests;
   std::map<String,std::ostream     *> stream_ps;
   std::vector<String> 	  	      ordinary_destination_filenames;

--- a/FWCore/MessageService/src/ELadministrator.cc
+++ b/FWCore/MessageService/src/ELadministrator.cc
@@ -111,7 +111,7 @@ void ELadministrator::log(edm::ErrorObj & msg) {
     << std::endl;
     attach(ELoutput(std::cerr));
   }
-  std::list<boost::shared_ptr<ELdestination> >::iterator d;
+  std::list<std::shared_ptr<ELdestination> >::iterator d;
   for ( d = sinks().begin();  d != sinks().end();  ++d )
     if (  (*d)->log( msg )  )
       msg.setReactedTo ( true );
@@ -127,7 +127,7 @@ void ELadministrator::log(edm::ErrorObj & msg) {
 
 ELdestControl ELadministrator::attach( const ELdestination & sink )  {
 
-  boost::shared_ptr<ELdestination> dest(sink.clone());
+  std::shared_ptr<ELdestination> dest(sink.clone());
   sinks().push_back( dest );
   return ELdestControl( dest );
 
@@ -135,7 +135,7 @@ ELdestControl ELadministrator::attach( const ELdestination & sink )  {
 
 ELdestControl ELadministrator::attach(  const ELdestination & sink,
                                         const ELstring & name )     {
-  boost::shared_ptr<ELdestination> dest(sink.clone());
+  std::shared_ptr<ELdestination> dest(sink.clone());
   attachedDestinations_[name] = dest;
   sinks().push_back( dest );
   return ELdestControl( dest );
@@ -201,7 +201,7 @@ void ELadministrator::resetSeverityCount()  {
 // Accessors:
 // ----------------------------------------------------------------------
 
-std::list<boost::shared_ptr<ELdestination> > & ELadministrator::sinks()  { return sinks_; }
+std::list<std::shared_ptr<ELdestination> > & ELadministrator::sinks()  { return sinks_; }
 
 
 const ELseverityLevel & ELadministrator::highSeverity() const  {
@@ -225,7 +225,7 @@ int ELadministrator::severityCounts( const int lev ) const  {
 
 void ELadministrator::setThresholds( const ELseverityLevel & sev )  {
 
-  std::list<boost::shared_ptr<ELdestination> >::iterator d;
+  std::list<std::shared_ptr<ELdestination> >::iterator d;
   for ( d = sinks().begin();  d != sinks().end();  ++d )
     (*d)->threshold = sev;
 
@@ -234,7 +234,7 @@ void ELadministrator::setThresholds( const ELseverityLevel & sev )  {
 
 void ELadministrator::setLimits( const ELstring & id, int limit )  {
 
-  std::list<boost::shared_ptr<ELdestination> >::iterator d;
+  std::list<std::shared_ptr<ELdestination> >::iterator d;
   for ( d = sinks().begin();  d != sinks().end();  ++d )
     (*d)->limits.setLimit( id, limit );
 
@@ -244,7 +244,7 @@ void ELadministrator::setLimits( const ELstring & id, int limit )  {
 void ELadministrator::setIntervals
 			( const ELseverityLevel & sev, int interval )  {
 
-  std::list<boost::shared_ptr<ELdestination> >::iterator d;
+  std::list<std::shared_ptr<ELdestination> >::iterator d;
   for ( d = sinks().begin();  d != sinks().end();  ++d )
     (*d)->limits.setInterval( sev, interval );
 
@@ -252,7 +252,7 @@ void ELadministrator::setIntervals
 
 void ELadministrator::setIntervals( const ELstring & id, int interval )  {
 
-  std::list<boost::shared_ptr<ELdestination> >::iterator d;
+  std::list<std::shared_ptr<ELdestination> >::iterator d;
   for ( d = sinks().begin();  d != sinks().end();  ++d )
     (*d)->limits.setInterval( id, interval );
 
@@ -261,7 +261,7 @@ void ELadministrator::setIntervals( const ELstring & id, int interval )  {
 
 void ELadministrator::setLimits( const ELseverityLevel & sev, int limit )  {
 
-  std::list<boost::shared_ptr<ELdestination> >::iterator d;
+  std::list<std::shared_ptr<ELdestination> >::iterator d;
   for ( d = sinks().begin();  d != sinks().end();  ++d )
     (*d)->limits.setLimit( sev, limit );
 
@@ -270,7 +270,7 @@ void ELadministrator::setLimits( const ELseverityLevel & sev, int limit )  {
 
 void ELadministrator::setTimespans( const ELstring & id, int seconds )  {
 
-  std::list<boost::shared_ptr<ELdestination> >::iterator d;
+  std::list<std::shared_ptr<ELdestination> >::iterator d;
   for ( d = sinks().begin();  d != sinks().end();  ++d )
     (*d)->limits.setTimespan( id, seconds );
 
@@ -279,7 +279,7 @@ void ELadministrator::setTimespans( const ELstring & id, int seconds )  {
 
 void ELadministrator::setTimespans( const ELseverityLevel & sev, int seconds )  {
 
-  std::list<boost::shared_ptr<ELdestination> >::iterator d;
+  std::list<std::shared_ptr<ELdestination> >::iterator d;
   for ( d = sinks().begin();  d != sinks().end();  ++d )
     (*d)->limits.setTimespan( sev, seconds );
 
@@ -288,7 +288,7 @@ void ELadministrator::setTimespans( const ELseverityLevel & sev, int seconds )  
 
 void ELadministrator::wipe()  {
 
-  std::list<boost::shared_ptr<ELdestination> >::iterator d;
+  std::list<std::shared_ptr<ELdestination> >::iterator d;
   for ( d = sinks().begin();  d != sinks().end();  ++d )
     (*d)->limits.wipe();
 
@@ -296,7 +296,7 @@ void ELadministrator::wipe()  {
 
 void ELadministrator::finish()  {
 
-  std::list<boost::shared_ptr<ELdestination> >::iterator d;
+  std::list<std::shared_ptr<ELdestination> >::iterator d;
   for ( d = sinks().begin();  d != sinks().end();  ++d )
     (*d)->finish();
 

--- a/FWCore/MessageService/src/ELdestControl.cc
+++ b/FWCore/MessageService/src/ELdestControl.cc
@@ -41,7 +41,7 @@ namespace service {
 // ----------------------------------------------------------------------
 
 
-ELdestControl::ELdestControl( boost::shared_ptr<ELdestination> dest )
+ELdestControl::ELdestControl( std::shared_ptr<ELdestination> dest )
 : d ( dest )
 {
   #ifdef ELdestinationCONSTRUCTOR_TRACE

--- a/FWCore/MessageService/src/MainThreadMLscribe.cc
+++ b/FWCore/MessageService/src/MainThreadMLscribe.cc
@@ -13,7 +13,7 @@
 namespace edm {
 namespace service {
 
-MainThreadMLscribe::MainThreadMLscribe(boost::shared_ptr<ThreadQueue> tqp) 
+MainThreadMLscribe::MainThreadMLscribe(std::shared_ptr<ThreadQueue> tqp) 
   : m_queue(tqp) 
 {
 }

--- a/FWCore/MessageService/src/MessageLoggerScribe.cc
+++ b/FWCore/MessageService/src/MessageLoggerScribe.cc
@@ -211,7 +211,7 @@ namespace edm {
 namespace service {
 
 
-MessageLoggerScribe::MessageLoggerScribe(boost::shared_ptr<ThreadQueue> queue)
+MessageLoggerScribe::MessageLoggerScribe(std::shared_ptr<ThreadQueue> queue)
 : admin_p   ( new ELadministrator() )
 , early_dest( admin_p->attach(ELoutput(std::cerr, false)) )
 , file_ps   ( )
@@ -317,7 +317,7 @@ void
 	  {
 	    Place_for_passing_exception_ptr epp = h_p->epp;
 	    if (!(*epp)) { 
-	      *epp = boost::shared_ptr<edm::Exception>(new edm::Exception(e));
+	      *epp = std::make_shared<edm::Exception>(e);
 	    } else {
 	      Pointer_to_new_exception_on_heap ep = *epp;
 	      (*ep) << "\n and another exception: \n" << e.what();
@@ -844,7 +844,7 @@ void
       stream_ps["cerr"] = &std::cerr;
     }
     else  {
-      boost::shared_ptr<std::ofstream> os_sp(new std::ofstream(actual_filename.c_str()));
+      auto os_sp = std::make_shared<std::ofstream>(actual_filename.c_str());
       file_ps.push_back(os_sp);
       dest_ctrl = admin_p->attach( ELoutput(*os_sp) );
       stream_ps[actual_filename] = os_sp.get();
@@ -969,7 +969,7 @@ void
       } else if ( actual_filename == "cerr" ) {
         os_p = &std::cerr;
       } else {
-        boost::shared_ptr<std::ofstream> os_sp(new std::ofstream(actual_filename.c_str()));
+        auto os_sp = std::make_shared<std::ofstream>(actual_filename.c_str());
 	file_ps.push_back(os_sp);
         os_p = os_sp.get();
       }

--- a/FWCore/MessageService/src/MessageServicePresence.cc
+++ b/FWCore/MessageService/src/MessageServicePresence.cc
@@ -32,7 +32,7 @@ using namespace edm::service;
 
 namespace  {
 void
-  runMessageLoggerScribe(boost::shared_ptr<ThreadQueue> queue)
+  runMessageLoggerScribe(std::shared_ptr<ThreadQueue> queue)
 {
   sigset_t oldset;
   edm::disableAllSigs(&oldset);
@@ -67,8 +67,7 @@ MessageServicePresence::MessageServicePresence()
 	  // first executing the before-the-comma statement. 
 {
   MessageLoggerQ::setMLscribe_ptr(
-    boost::shared_ptr<edm::service::AbstractMLscribe>
-        (new MainThreadMLscribe(m_queue))); 
+    std::shared_ptr<edm::service::AbstractMLscribe>(std::make_shared<MainThreadMLscribe>(m_queue)));
     								// change log 3
   //std::cout << "MessageServicePresence ctor\n";
 }
@@ -79,7 +78,7 @@ MessageServicePresence::~MessageServicePresence()
   MessageLoggerQ::MLqEND();
   m_scribeThread.join();
   MessageLoggerQ::setMLscribe_ptr
-    (boost::shared_ptr<edm::service::AbstractMLscribe>());   // change log 3
+    (std::shared_ptr<edm::service::AbstractMLscribe>());   // change log 3
 }
 
 } // end of namespace service  

--- a/FWCore/MessageService/src/SingleThreadMSPresence.cc
+++ b/FWCore/MessageService/src/SingleThreadMSPresence.cc
@@ -12,7 +12,7 @@
 #include "FWCore/MessageLogger/interface/MessageLoggerQ.h"
 #include "FWCore/MessageLogger/interface/MessageDrop.h"
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 
 namespace edm {
@@ -23,9 +23,7 @@ SingleThreadMSPresence::SingleThreadMSPresence()
   : Presence()
 {
   //std::cout << "SingleThreadMSPresence ctor\n";
-  MessageLoggerQ::setMLscribe_ptr(
-     boost::shared_ptr<edm::service::AbstractMLscribe> 
-     (new ThreadSafeLogMessageLoggerScribe()));
+  MessageLoggerQ::setMLscribe_ptr(std::shared_ptr<edm::service::AbstractMLscribe>(std::make_shared<ThreadSafeLogMessageLoggerScribe>()));
   MessageDrop::instance()->messageLoggerScribeIsRunning = 
   				MLSCRIBE_RUNNING_INDICATOR;
 }
@@ -35,7 +33,7 @@ SingleThreadMSPresence::~SingleThreadMSPresence()
 {
   MessageLoggerQ::MLqEND();
   MessageLoggerQ::setMLscribe_ptr
-    (boost::shared_ptr<edm::service::AbstractMLscribe>());
+    (std::shared_ptr<edm::service::AbstractMLscribe>());
 }
 
 } // end of namespace service  

--- a/FWCore/MessageService/src/ThreadSafeLogMessageLoggerScribe.cc
+++ b/FWCore/MessageService/src/ThreadSafeLogMessageLoggerScribe.cc
@@ -622,7 +622,7 @@ namespace edm {
           stream_ps["cerr"] = &std::cerr;
         }
         else  {
-          boost::shared_ptr<std::ofstream> os_sp(new std::ofstream(actual_filename.c_str()));
+          auto os_sp = std::make_shared<std::ofstream>(actual_filename.c_str());
           file_ps.push_back(os_sp);
           dest_ctrl = admin_p->attach( ELoutput(*os_sp) );
           stream_ps[actual_filename] = os_sp.get();
@@ -747,7 +747,7 @@ namespace edm {
           } else if ( actual_filename == "cerr" ) {
             os_p = &std::cerr;
           } else {
-            boost::shared_ptr<std::ofstream> os_sp(new std::ofstream(actual_filename.c_str()));
+            auto os_sp = std::make_shared<std::ofstream>(actual_filename.c_str());
             file_ps.push_back(os_sp);
             os_p = os_sp.get();
           }

--- a/FWCore/Modules/src/MulticoreRunLumiEventChecker.cc
+++ b/FWCore/Modules/src/MulticoreRunLumiEventChecker.cc
@@ -29,8 +29,6 @@
 #include "FWCore/Utilities/interface/UnixSignalHandlers.h"
 
 // system include files
-#include <boost/shared_ptr.hpp>
-
 #include <algorithm>
 #include <map>
 #include <memory>
@@ -80,7 +78,7 @@ private:
    unsigned int numberOfEventsLeftBeforeSearch_;
    bool mustSearch_;
    
-   boost::shared_ptr<boost::thread> listenerThread_;
+   std::shared_ptr<boost::thread> listenerThread_;
    int messageQueue_;
 };
 
@@ -306,7 +304,7 @@ MulticoreRunLumiEventChecker::postForkReacquireResources(unsigned int iChildInde
       edm::disableAllSigs(&oldset);
       
       Listener listener(&seenIDs_, messageQueue_, iNumberOfChildren);
-      listenerThread_ = boost::shared_ptr<boost::thread>(new boost::thread(listener)) ;
+      listenerThread_ = std::make_shared<boost::thread>(listener) ;
       edm::reenableSigs(&oldset);
    }
 }

--- a/FWCore/Modules/src/ProvenanceCheckerOutputModule.cc
+++ b/FWCore/Modules/src/ProvenanceCheckerOutputModule.cc
@@ -106,13 +106,13 @@ namespace edm {
    void
    ProvenanceCheckerOutputModule::write(EventPrincipal const& e, ModuleCallingContext const* mcc) {
       //check ProductProvenance's parents to see if they are in the ProductProvenance list
-      boost::shared_ptr<ProductProvenanceRetriever> mapperPtr = e.productProvenanceRetrieverPtr();
+      std::shared_ptr<ProductProvenanceRetriever> mapperPtr = e.productProvenanceRetrieverPtr();
 
       std::map<BranchID, bool> seenParentInPrincipal;
       std::set<BranchID> missingFromMapper;
       std::set<BranchID> missingProductProvenance;
 
-      std::map<BranchID, boost::shared_ptr<ProductHolderBase> > idToProductHolder;
+      std::map<BranchID, std::shared_ptr<ProductHolderBase> > idToProductHolder;
       for(EventPrincipal::const_iterator it = e.begin(), itEnd = e.end();
           it != itEnd;
           ++it) {

--- a/FWCore/ParameterSet/interface/ProcessDesc.h
+++ b/FWCore/ParameterSet/interface/ProcessDesc.h
@@ -1,7 +1,7 @@
 #ifndef FWCore_ParameterSet_ProcessDesc_h
 #define FWCore_ParameterSet_ProcessDesc_h
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -12,7 +12,7 @@ namespace edm {
   class ProcessDesc {
 
   public:
-    explicit ProcessDesc(boost::shared_ptr<ParameterSet> pset);
+    explicit ProcessDesc(std::shared_ptr<ParameterSet> pset);
 
     /// construct from the configuration language string
     explicit ProcessDesc(std::string const& config);
@@ -20,10 +20,10 @@ namespace edm {
     ~ProcessDesc();
 
     /// get the parameter set
-    boost::shared_ptr<ParameterSet> getProcessPSet() const;
+    std::shared_ptr<ParameterSet> getProcessPSet() const;
 
     /// get the descriptions of the services
-    boost::shared_ptr<std::vector<ParameterSet> > getServicesPSets() const;
+    std::shared_ptr<std::vector<ParameterSet> > getServicesPSets() const;
 
     void addService(ParameterSet& pset);
     /// add a service as an empty pset
@@ -38,8 +38,8 @@ namespace edm {
 
     std::string dump() const;
   private:
-    boost::shared_ptr<ParameterSet> pset_;
-    boost::shared_ptr<std::vector<ParameterSet> > services_;
+    std::shared_ptr<ParameterSet> pset_;
+    std::shared_ptr<std::vector<ParameterSet> > services_;
   };
 }
 

--- a/FWCore/ParameterSet/src/ProcessDesc.cc
+++ b/FWCore/ParameterSet/src/ProcessDesc.cc
@@ -5,7 +5,7 @@
 
 namespace edm {
 
-  ProcessDesc::ProcessDesc(boost::shared_ptr<ParameterSet> pset) :
+  ProcessDesc::ProcessDesc(std::shared_ptr<ParameterSet> pset) :
       pset_(pset), services_(pset_->popVParameterSet(std::string("services")).release()) {
   }
 
@@ -18,12 +18,12 @@ namespace edm {
   ProcessDesc::~ProcessDesc() {
   }
 
-  boost::shared_ptr<ParameterSet>
+  std::shared_ptr<ParameterSet>
   ProcessDesc::getProcessPSet() const {
     return pset_;
   }
 
-  boost::shared_ptr<std::vector<ParameterSet> >
+  std::shared_ptr<std::vector<ParameterSet> >
   ProcessDesc::getServicesPSets() const {
     return services_;
   }

--- a/FWCore/PluginManager/interface/PluginManager.h
+++ b/FWCore/PluginManager/interface/PluginManager.h
@@ -25,7 +25,7 @@
 #include <mutex>
 
 #include <boost/filesystem/path.hpp>
-#include "boost/shared_ptr.hpp"
+#include <memory>
 #include "tbb/concurrent_unordered_map.h"
 
 // user include files
@@ -122,7 +122,7 @@ class PluginManager
                                                   bool& ioThrowIfFailElseSucceedStatus);
       // ---------- member data --------------------------------
       SearchPath searchPath_;
-      tbb::concurrent_unordered_map<boost::filesystem::path, boost::shared_ptr<SharedLibrary>, PluginManagerPathHasher > loadables_;
+      tbb::concurrent_unordered_map<boost::filesystem::path, std::shared_ptr<SharedLibrary>, PluginManagerPathHasher > loadables_;
       
       CategoryToInfos categoryToInfos_;
       std::recursive_mutex pluginLoadMutex_;

--- a/FWCore/PluginManager/src/PluginManager.cc
+++ b/FWCore/PluginManager/src/PluginManager.cc
@@ -245,7 +245,7 @@ PluginManager::load(const std::string& iCategory,
       goingToLoad_(p);
       Sentry s(loadingLibraryNamed_(), p.string());
       //boost::filesystem::path native(p.string());
-      boost::shared_ptr<SharedLibrary> ptr;
+      std::shared_ptr<SharedLibrary> ptr;
       {
 	//TEMPORARY: to avoid possible deadlocks from ROOT, we must
 	// take the lock ourselves
@@ -285,7 +285,7 @@ PluginManager::tryToLoad(const std::string& iCategory,
       goingToLoad_(p);
       Sentry s(loadingLibraryNamed_(), p.string());
       //boost::filesystem::path native(p.string());
-      boost::shared_ptr<SharedLibrary> ptr;
+      std::shared_ptr<SharedLibrary> ptr;
       {
 	//TEMPORARY: to avoid possible deadlocks from ROOT, we must
 	// take the lock ourselves

--- a/FWCore/PythonParameterSet/bin/edmConfigHash.cpp
+++ b/FWCore/PythonParameterSet/bin/edmConfigHash.cpp
@@ -9,7 +9,7 @@
 #include "FWCore/PythonParameterSet/interface/MakeParameterSets.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 #include <iostream>
 #include <string>
@@ -29,7 +29,7 @@ int main(int argc, char **argv) try {
     config = std::string(argv[1]);
   }
 
-  boost::shared_ptr<edm::ParameterSet> parameterSet = edm::readConfig(config);
+  std::shared_ptr<edm::ParameterSet> parameterSet = edm::readConfig(config);
   parameterSet->registerIt();
   std::cout << parameterSet->id() << std::endl;
   return 0;

--- a/FWCore/PythonParameterSet/bin/edmParameterSetDump.cpp
+++ b/FWCore/PythonParameterSet/bin/edmParameterSetDump.cpp
@@ -14,7 +14,7 @@
 #include "FWCore/PythonParameterSet/interface/MakeParameterSets.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 #include <iostream>
 #include <string>
 
@@ -23,7 +23,7 @@ int main (int argc, char **argv) try {
     std::cout << "Usage: edmParameterSetDump <cfgfile>" << std::endl;
   }
   std::string fileName(argv[1]);
-  boost::shared_ptr<edm::ParameterSet> parameterSet = edm::readConfig(fileName);
+  std::shared_ptr<edm::ParameterSet> parameterSet = edm::readConfig(fileName);
   std::cout << "====Main Process====" << std::endl;
   std::cout << parameterSet->dump() << std::endl;
   return 0;

--- a/FWCore/PythonParameterSet/interface/MakeParameterSets.h
+++ b/FWCore/PythonParameterSet/interface/MakeParameterSets.h
@@ -5,7 +5,7 @@
 // Declare functions used to create ParameterSets.
 //----------------------------------------------------------------------
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 #include <string>
 #include <vector>
@@ -14,21 +14,21 @@ namespace edm {
   class ParameterSet;
 
   // input can either be a python file name or a python config string
-  boost::shared_ptr<ParameterSet>
+  std::shared_ptr<ParameterSet>
   readConfig(std::string const& config);
 
   /// same, but with arguments
-  boost::shared_ptr<ParameterSet>
+  std::shared_ptr<ParameterSet>
   readConfig(std::string const& config, int argc, char* argv[]);
 
   /// essentially the same as the previous method
   void
   makeParameterSets(std::string const& configtext,
-                    boost::shared_ptr<ParameterSet>& main);
+                    std::shared_ptr<ParameterSet>& main);
 
   /**finds all the PSets used in the top level module referred as a file or as a string containing
    python commands. These PSets are bundled into a top level PSet from which they can be retrieved
    */
-  boost::shared_ptr<ParameterSet> readPSetsFrom(std::string const& fileOrString);
+  std::shared_ptr<ParameterSet> readPSetsFrom(std::string const& fileOrString);
 } // namespace edm
 #endif

--- a/FWCore/PythonParameterSet/interface/PythonProcessDesc.h
+++ b/FWCore/PythonParameterSet/interface/PythonProcessDesc.h
@@ -4,7 +4,7 @@
 #include "FWCore/PythonParameterSet/interface/BoostPython.h"
 #include "FWCore/PythonParameterSet/interface/PythonParameterSet.h"
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 #include <string>
 #include <vector>
@@ -33,11 +33,11 @@ public:
   std::string dump() const;
 
   // makes a new (copy) of the ParameterSet
-  boost::shared_ptr<edm::ParameterSet> parameterSet();
+  std::shared_ptr<edm::ParameterSet> parameterSet();
 
   // makes a new (copy) of a ProcessDesc
   // For backward compatibility only.  Remove when no longer needed.
-  boost::shared_ptr<edm::ProcessDesc> processDesc();
+  std::shared_ptr<edm::ProcessDesc> processDesc();
 
 private:
   void prepareToRead();

--- a/FWCore/PythonParameterSet/src/MakeParameterSets.cc
+++ b/FWCore/PythonParameterSet/src/MakeParameterSets.cc
@@ -38,13 +38,13 @@ makePSetsFromString(std::string const& module, boost::python::object& mainNamesp
 
 namespace edm {
 
-  boost::shared_ptr<ParameterSet>
+  std::shared_ptr<ParameterSet>
   readConfig(std::string const& config) {
     PythonProcessDesc pythonProcessDesc(config);
     return pythonProcessDesc.parameterSet();
   }
 
-  boost::shared_ptr<ParameterSet>
+  std::shared_ptr<ParameterSet>
   readConfig(std::string const& config, int argc, char* argv[]) {
     PythonProcessDesc pythonProcessDesc(config, argc, argv);
     return pythonProcessDesc.parameterSet();
@@ -52,12 +52,12 @@ namespace edm {
 
   void
   makeParameterSets(std::string const& configtext,
-                  boost::shared_ptr<ParameterSet>& main) {
+                  std::shared_ptr<ParameterSet>& main) {
     PythonProcessDesc pythonProcessDesc(configtext);
     main = pythonProcessDesc.parameterSet();
   }
 
-  boost::shared_ptr<ParameterSet>
+  std::shared_ptr<ParameterSet>
   readPSetsFrom(std::string const& module) {
     python::initializeModule();
 
@@ -79,7 +79,7 @@ namespace edm {
       pythonToCppException("Configuration");
       Py_Finalize();
     }
-    boost::shared_ptr<ParameterSet> returnValue(new ParameterSet);
+    auto returnValue = std::make_shared<ParameterSet>();
     theProcessPSet.pset().swap(*returnValue);
     return returnValue;
   }

--- a/FWCore/PythonParameterSet/src/PythonProcessDesc.cc
+++ b/FWCore/PythonParameterSet/src/PythonProcessDesc.cc
@@ -83,9 +83,8 @@ void PythonProcessDesc::readString(std::string const& pyConfig) {
                         theMainNamespace.ptr()));
 }
 
-boost::shared_ptr<edm::ParameterSet> PythonProcessDesc::parameterSet() {
-  boost::shared_ptr<edm::ParameterSet> result(new edm::ParameterSet(theProcessPSet.pset()));
-  return result;
+std::shared_ptr<edm::ParameterSet> PythonProcessDesc::parameterSet() {
+  return std::make_shared<edm::ParameterSet>(theProcessPSet.pset());
 }
 
 std::string PythonProcessDesc::dump() const {
@@ -95,7 +94,6 @@ std::string PythonProcessDesc::dump() const {
 }
 
 // For backward compatibility only.  Remove when no longer used.
-boost::shared_ptr<edm::ProcessDesc> PythonProcessDesc::processDesc() {
-  boost::shared_ptr<edm::ProcessDesc> result(new edm::ProcessDesc(parameterSet()));
-  return result;
+std::shared_ptr<edm::ProcessDesc> PythonProcessDesc::processDesc() {
+  return std::make_shared<edm::ProcessDesc>(parameterSet());
 }

--- a/FWCore/PythonParameterSet/test/makeprocess_t.cppunit.cc
+++ b/FWCore/PythonParameterSet/test/makeprocess_t.cppunit.cc
@@ -11,7 +11,7 @@
 
 #include <cppunit/extensions/HelperMacros.h>
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 #include <iostream>
 #include <sstream>
@@ -40,7 +40,7 @@ public:
   //void windowsLineEndingTest();
 private:
 
-  typedef boost::shared_ptr<edm::ParameterSet> ParameterSetPtr;
+  typedef std::shared_ptr<edm::ParameterSet> ParameterSetPtr;
   ParameterSetPtr pSet(char const* c) {
 
     //ParameterSetPtr result( new edm::ProcessDesc(std::string(c)) );

--- a/FWCore/PythonParameterSet/test/makepset_t.cppunit.cc
+++ b/FWCore/PythonParameterSet/test/makepset_t.cppunit.cc
@@ -12,7 +12,7 @@
 
 #include "cppunit/extensions/HelperMacros.h"
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 #include <algorithm>
 #include <iostream>
@@ -93,7 +93,7 @@ void testmakepset::secsourceAux() {
 
   // Create the ParameterSet object from this configuration string.
   PythonProcessDesc builder(config);
-  boost::shared_ptr<edm::ParameterSet> ps = builder.parameterSet();
+  std::shared_ptr<edm::ParameterSet> ps = builder.parameterSet();
 
   CPPUNIT_ASSERT(0 != ps.get());
 
@@ -147,7 +147,7 @@ void testmakepset::usingBlockAux() {
   std::string config(kTest);
   // Create the ParameterSet object from this configuration string.
   PythonProcessDesc builder(config);
-  boost::shared_ptr<edm::ParameterSet> ps = builder.parameterSet();
+  std::shared_ptr<edm::ParameterSet> ps = builder.parameterSet();
 
   CPPUNIT_ASSERT(0 != ps.get());
 
@@ -196,7 +196,7 @@ void testmakepset::fileinpathAux() {
 
   // Create the ParameterSet object from this configuration string.
   PythonProcessDesc builder(config);
-  boost::shared_ptr<edm::ParameterSet> ps = builder.parameterSet();
+  std::shared_ptr<edm::ParameterSet> ps = builder.parameterSet();
   CPPUNIT_ASSERT(0 != ps.get());
 
   edm::ParameterSet const& innerps = ps->getParameterSet("main");
@@ -254,7 +254,7 @@ void testmakepset::fileinpathAux() {
   // Create the ParameterSet object from this configuration string.
   PythonProcessDesc builder2(config2);
   unlink(tmpout.c_str());
-  boost::shared_ptr<edm::ParameterSet> ps2 = builder2.parameterSet();
+  std::shared_ptr<edm::ParameterSet> ps2 = builder2.parameterSet();
 
   CPPUNIT_ASSERT(0 != ps2.get());
 
@@ -332,7 +332,7 @@ void testmakepset::typesTest() {
    std::string config2(kTest);
    // Create the ParameterSet object from this configuration string.
    PythonProcessDesc builder2(config2);
-   boost::shared_ptr<edm::ParameterSet> ps2 = builder2.parameterSet();
+   std::shared_ptr<edm::ParameterSet> ps2 = builder2.parameterSet();
    edm::ParameterSet const& test = ps2->getParameterSet("p");
 
    CPPUNIT_ASSERT(1 == test.getParameter<int>("i"));

--- a/FWCore/PythonParameterSet/test/processbuilder_t.cppunit.cpp
+++ b/FWCore/PythonParameterSet/test/processbuilder_t.cppunit.cpp
@@ -12,7 +12,7 @@
 #include <FWCore/PythonParameterSet/interface/PythonProcessDesc.h>
 #include "FWCore/Utilities/interface/EDMException.h"
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 #include <vector>
 #include <string>
@@ -66,7 +66,7 @@ void testProcessDesc::trivialPathTest() {
   "process.c = cms.EDProducer('C')\n"
   "process.p = cms.Path(process.a*process.b*process.c)\n";
 
-  boost::shared_ptr<edm::ParameterSet> test = PythonProcessDesc(str).parameterSet();
+  std::shared_ptr<edm::ParameterSet> test = PythonProcessDesc(str).parameterSet();
 
   typedef std::vector<std::string> Strs;
 
@@ -91,7 +91,7 @@ void testProcessDesc::simplePathTest() {
   ")\n"
   "process.p = cms.Path(process.a*process.b*process.c)\n";
 
-  boost::shared_ptr<edm::ParameterSet> test = PythonProcessDesc(str).parameterSet();
+  std::shared_ptr<edm::ParameterSet> test = PythonProcessDesc(str).parameterSet();
 
   typedef std::vector<std::string> Strs;
 
@@ -132,7 +132,7 @@ void testProcessDesc:: attriggertest () {
   "process.epath = cms.EndPath(process.output)\n";
 
   try {
-  boost::shared_ptr<edm::ParameterSet> test = PythonProcessDesc(str).parameterSet();
+  std::shared_ptr<edm::ParameterSet> test = PythonProcessDesc(str).parameterSet();
 
   typedef std::vector<std::string> Strs;
 
@@ -190,7 +190,7 @@ void testProcessDesc:: sequenceSubstitutionTest () {
   "process.jets = cms.Sequence(process.somejet1*process.somejet2)\n"
   "process.path1 = cms.Path(process.cones*process.jets*process.jtanalyzer)\n";
 
-  boost::shared_ptr<edm::ParameterSet> test = PythonProcessDesc(str).parameterSet();
+  std::shared_ptr<edm::ParameterSet> test = PythonProcessDesc(str).parameterSet();
 
   typedef std::vector<std::string> Strs;
 
@@ -219,7 +219,7 @@ void testProcessDesc::nestedSequenceSubstitutionTest() {
    "process.s1 = cms.Sequence( process.a+ process.b)\n"
    "process.s2 = cms.Sequence(process.s1+ process.c)\n"
    "process.path1 = cms.Path(process.s2+process.d)\n";
-  boost::shared_ptr<edm::ParameterSet> test = PythonProcessDesc(str).parameterSet();
+  std::shared_ptr<edm::ParameterSet> test = PythonProcessDesc(str).parameterSet();
 
   typedef std::vector<std::string> Strs;
 
@@ -249,7 +249,7 @@ void testProcessDesc::sequenceSubstitutionTest2() {
    "process.jets = cms.Sequence(process.somejet1+ process.somejet2)\n"
    "process.path1 = cms.Path(process.cones+process.jets+ process.jtanalyzer)\n";
 
-  boost::shared_ptr<edm::ParameterSet> test = PythonProcessDesc(str).parameterSet();
+  std::shared_ptr<edm::ParameterSet> test = PythonProcessDesc(str).parameterSet();
 
   typedef std::vector<std::string> Strs;
 
@@ -292,7 +292,7 @@ void testProcessDesc::sequenceSubstitutionTest3() {
    "process.s3 = cms.Sequence(process.aaa*process.bbb*~process.ccc*process.ddd*process.eee)\n"
    "process.path1 = cms.Path(process.s1+process.s3+process.s2+process.last)\n";
 
-  boost::shared_ptr<edm::ParameterSet> test = PythonProcessDesc(str).parameterSet();
+  std::shared_ptr<edm::ParameterSet> test = PythonProcessDesc(str).parameterSet();
 
   typedef std::vector<std::string> Strs;
 
@@ -344,7 +344,7 @@ void testProcessDesc::multiplePathsTest() {
     "process.path2 = cms.Path(process.jets+ process.anotherjtanalyzer)\n"
     "process.schedule = cms.Schedule(process.path2, process.path1)\n";
 
-  boost::shared_ptr<edm::ParameterSet> test = PythonProcessDesc(str).parameterSet();
+  std::shared_ptr<edm::ParameterSet> test = PythonProcessDesc(str).parameterSet();
 
   typedef std::vector<std::string> Strs;
 
@@ -383,7 +383,7 @@ void testProcessDesc::inconsistentPathTest() {
    "process.b = cms.EDProducer('PhonyConeJet', i = cms.int32(7))\n"
    "process.c = cms.EDProducer('PhonyJet', i = cms.int32(7))\n"
    "process.path1 = cms.Path((process.a*process.b)+ (process.c*process.b))\n";
-  boost::shared_ptr<edm::ParameterSet> test = PythonProcessDesc(str).parameterSet();
+  std::shared_ptr<edm::ParameterSet> test = PythonProcessDesc(str).parameterSet();
 }
 
 void testProcessDesc::inconsistentMultiplePathTest() {
@@ -400,7 +400,7 @@ void testProcessDesc::inconsistentMultiplePathTest() {
    "process.path1 = cms.Path(process.cones*process.jtanalyzer)\n"
    "process.path2 = cms.Path(process.jets*process.jtanalyzer)\n";
 
-  boost::shared_ptr<edm::ParameterSet> test = PythonProcessDesc(str).parameterSet();
+  std::shared_ptr<edm::ParameterSet> test = PythonProcessDesc(str).parameterSet();
 }
 
 #include <Utilities/Testing/interface/CppUnit_testdriver.icpp>

--- a/FWCore/PythonParameterSet/test/readpsetsfrom_t.cppunit.cc
+++ b/FWCore/PythonParameterSet/test/readpsetsfrom_t.cppunit.cc
@@ -13,7 +13,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/PythonParameterSet/interface/MakeParameterSets.h"
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 #include <iostream>
 #include <sstream>
@@ -45,7 +45,7 @@ void testreadpsetsfrom::simpleTest()
                       "dummy =  cms.PSet(b = cms.bool(True))\n"
                       "foo = cms.PSet(a = cms.string('blah'))\n"
    ;
-   boost::shared_ptr<edm::ParameterSet> test = edm::readPSetsFrom(kTest);
+   std::shared_ptr<edm::ParameterSet> test = edm::readPSetsFrom(kTest);
    
    CPPUNIT_ASSERT(test->getParameterSet("dummy").getParameter<bool>("b")==true);
    CPPUNIT_ASSERT(test->getParameterSet("foo").getParameter<std::string>("a")==std::string("blah"));

--- a/FWCore/ServiceRegistry/interface/ServiceMaker.h
+++ b/FWCore/ServiceRegistry/interface/ServiceMaker.h
@@ -83,7 +83,7 @@ public:
                            ServicesManager& oSM) const {
             TMaker maker;
             std::auto_ptr<T> pService(maker.make(iPS, iAR));
-            boost::shared_ptr<ServiceWrapper<T> > ptr(new ServiceWrapper<T>(pService));
+            auto ptr = std::make_shared<ServiceWrapper<T> >(pService);
             return oSM.put(ptr);
          }
 

--- a/FWCore/ServiceRegistry/interface/ServiceRegistry.h
+++ b/FWCore/ServiceRegistry/interface/ServiceRegistry.h
@@ -99,9 +99,8 @@ namespace edm {
       template<typename T>
       static ServiceToken createContaining(std::auto_ptr<T> iService){
          std::vector<edm::ParameterSet> config;
-         boost::shared_ptr<serviceregistry::ServicesManager> manager(new serviceregistry::ServicesManager(config));
-         boost::shared_ptr<serviceregistry::ServiceWrapper<T> >
-            wrapper(new serviceregistry::ServiceWrapper<T>(iService));
+         auto manager = std::make_shared<serviceregistry::ServicesManager>(config);
+         auto wrapper = std::make_shared<serviceregistry::ServiceWrapper<T> >(iService);
          manager->put(wrapper);
          return manager;
       }
@@ -110,30 +109,25 @@ namespace edm {
                                            ServiceToken iToken,
                                            serviceregistry::ServiceLegacy iLegacy){
          std::vector<edm::ParameterSet> config;
-         boost::shared_ptr<serviceregistry::ServicesManager> manager(new serviceregistry::ServicesManager(iToken,
-                                                                                                          iLegacy,
-                                                                                                          config));
-         boost::shared_ptr<serviceregistry::ServiceWrapper<T> >
-         wrapper(new serviceregistry::ServiceWrapper<T>(iService));
+         auto manager = std::make_shared<serviceregistry::ServicesManager>(iToken, iLegacy, config);
+         auto wrapper = std::make_shared<serviceregistry::ServiceWrapper<T> >(iService);
          manager->put(wrapper);
          return manager;
       }
       /// create a service token that holds the service held by iWrapper
       template<typename T>
-      static ServiceToken createContaining(boost::shared_ptr<serviceregistry::ServiceWrapper<T> > iWrapper) {
+      static ServiceToken createContaining(std::shared_ptr<serviceregistry::ServiceWrapper<T> > iWrapper) {
          std::vector<edm::ParameterSet> config;
-         boost::shared_ptr<serviceregistry::ServicesManager> manager(new serviceregistry::ServicesManager(config));
+         auto manager = std::make_shared<serviceregistry::ServicesManager>(config);
          manager->put(iWrapper);
          return manager;
       }
       template<typename T>
-      static ServiceToken createContaining(boost::shared_ptr<serviceregistry::ServiceWrapper<T> > iWrapper,
+      static ServiceToken createContaining(std::shared_ptr<serviceregistry::ServiceWrapper<T> > iWrapper,
                                            ServiceToken iToken,
                                            serviceregistry::ServiceLegacy iLegacy){
          std::vector<edm::ParameterSet> config;
-         boost::shared_ptr<serviceregistry::ServicesManager> manager(new serviceregistry::ServicesManager(iToken,
-                                                                                                          iLegacy,
-                                                                                                          config));
+         auto manager = std::make_shared<serviceregistry::ServicesManager>(iToken, iLegacy, config);
          manager->put(iWrapper);
          return manager;
       }
@@ -149,7 +143,7 @@ private:
       ServiceRegistry const& operator=(ServiceRegistry const&); // stop default
 
       // ---------- member data --------------------------------
-      boost::shared_ptr<serviceregistry::ServicesManager> manager_;
+      std::shared_ptr<serviceregistry::ServicesManager> manager_;
    };
 }
 

--- a/FWCore/ServiceRegistry/interface/ServiceToken.h
+++ b/FWCore/ServiceRegistry/interface/ServiceToken.h
@@ -21,7 +21,7 @@
 //
 
 // system include files
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 // user include files
 
@@ -59,7 +59,7 @@ namespace edm {
       void copySlotsFrom(ActivityRegistry&);
       
     private:
-      ServiceToken(boost::shared_ptr<edm::serviceregistry::ServicesManager>  iManager):
+      ServiceToken(std::shared_ptr<edm::serviceregistry::ServicesManager>  iManager):
       manager_(iManager) {}
       
       //ServiceToken(const ServiceToken&); // stop default
@@ -67,7 +67,7 @@ namespace edm {
       //const ServiceToken& operator=(const ServiceToken&); // stop default
 
       // ---------- member data --------------------------------
-      boost::shared_ptr<edm::serviceregistry::ServicesManager> manager_;
+      std::shared_ptr<edm::serviceregistry::ServicesManager> manager_;
    };
 }
 

--- a/FWCore/ServiceRegistry/interface/ServicesManager.h
+++ b/FWCore/ServiceRegistry/interface/ServicesManager.h
@@ -27,7 +27,7 @@
 #include "FWCore/Utilities/interface/TypeIDBase.h"
 
 // system include files
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 #include <cassert>
 #include <vector>
@@ -42,17 +42,17 @@ namespace edm {
       class ServicesManager {
 public:
          struct MakerHolder {
-            MakerHolder(boost::shared_ptr<ServiceMakerBase> iMaker,
+            MakerHolder(std::shared_ptr<ServiceMakerBase> iMaker,
                         ParameterSet& iPSet,
                         ActivityRegistry&) ;
             bool add(ServicesManager&) const;
 
-            boost::shared_ptr<ServiceMakerBase> maker_;
+            std::shared_ptr<ServiceMakerBase> maker_;
             ParameterSet* pset_;
             ActivityRegistry* registry_;
             mutable bool wasAdded_;
          };
-         typedef std::map<TypeIDBase, boost::shared_ptr<ServiceWrapperBase> > Type2Service;
+         typedef std::map<TypeIDBase, std::shared_ptr<ServiceWrapperBase> > Type2Service;
          typedef std::map<TypeIDBase, MakerHolder> Type2Maker;
 
          ServicesManager(std::vector<ParameterSet>& iConfiguration);
@@ -89,7 +89,7 @@ public:
                }
             }
             //convert it to its actual type
-            boost::shared_ptr<ServiceWrapper<T> > ptr(boost::dynamic_pointer_cast<ServiceWrapper<T> >(itFound->second));
+            std::shared_ptr<ServiceWrapper<T> > ptr(std::dynamic_pointer_cast<ServiceWrapper<T> >(itFound->second));
             assert(0 != ptr.get());
             return ptr->get();
          }
@@ -121,7 +121,7 @@ public:
          // ---------- member functions ---------------------------
          ///returns false if put fails because a service of this type already exists
          template<typename T>
-         bool put(boost::shared_ptr<ServiceWrapper<T> > iPtr) {
+         bool put(std::shared_ptr<ServiceWrapper<T> > iPtr) {
             Type2Service::const_iterator itFound = type2Service_.find(TypeIDBase(typeid(T)));
             if(itFound != type2Service_.end()) {
                return false;
@@ -155,7 +155,7 @@ private:
          // the ActivityRegistry of that Manager does not go out of scope
          // This must be first to get the Service destructors called in
          // the correct order.
-         boost::shared_ptr<ServicesManager> associatedManager_;
+         std::shared_ptr<ServicesManager> associatedManager_;
 
          ActivityRegistry registry_;
          Type2Service type2Service_;

--- a/FWCore/ServiceRegistry/src/ServiceRegistry.cc
+++ b/FWCore/ServiceRegistry/src/ServiceRegistry.cc
@@ -78,7 +78,7 @@ namespace edm {
 
    ServiceToken
    ServiceRegistry::createServicesFromConfig(std::string const& config) {
-      boost::shared_ptr<ParameterSet> params;
+      std::shared_ptr<ParameterSet> params;
       makeParameterSets(config, params);
 
       std::auto_ptr<std::vector<ParameterSet> > serviceSets = params->popVParameterSet(std::string("services"));
@@ -89,7 +89,7 @@ namespace edm {
    ServiceToken 
    ServiceRegistry::createSet(std::vector<ParameterSet>& iPS) {
       using namespace serviceregistry;
-      boost::shared_ptr<ServicesManager> returnValue(new ServicesManager(iPS));
+      auto returnValue = std::make_shared<ServicesManager>(iPS);
       return ServiceToken(returnValue);
    }
 
@@ -99,7 +99,7 @@ namespace edm {
                                    serviceregistry::ServiceLegacy iLegacy,
                                    bool associate) {
       using namespace serviceregistry;
-      boost::shared_ptr<ServicesManager> returnValue(new ServicesManager(iToken, iLegacy, iPS, associate));
+      auto returnValue = std::make_shared<ServicesManager>(iToken, iLegacy, iPS, associate);
       return ServiceToken(returnValue);
    }
 

--- a/FWCore/ServiceRegistry/src/ServicesManager.cc
+++ b/FWCore/ServiceRegistry/src/ServicesManager.cc
@@ -40,7 +40,7 @@
 namespace edm {
    namespace serviceregistry {
 
-      ServicesManager::MakerHolder::MakerHolder(boost::shared_ptr<ServiceMakerBase> iMaker,
+      ServicesManager::MakerHolder::MakerHolder(std::shared_ptr<ServiceMakerBase> iMaker,
                                                 ParameterSet& iPSet,
                                                 ActivityRegistry& iRegistry) :
       maker_(iMaker),
@@ -78,7 +78,7 @@ namespace edm {
                                        ServiceLegacy iLegacy,
                                        std::vector<ParameterSet>& iConfiguration,
                                        bool associate) :
-            associatedManager_(associate ? iToken.manager_ : boost::shared_ptr<ServicesManager>()),
+            associatedManager_(associate ? iToken.manager_ : std::shared_ptr<ServicesManager>()),
             type2Maker_(new Type2Maker) {
          fillListOfMakers(iConfiguration);
 
@@ -237,7 +237,7 @@ namespace edm {
               itParamEnd = iConfiguration.end();
               itParam != itParamEnd;
               ++itParam) {
-            boost::shared_ptr<ServiceMakerBase> base(ServicePluginFactory::get()->create(itParam->getParameter<std::string>("@service_type")));
+            std::shared_ptr<ServiceMakerBase> base(ServicePluginFactory::get()->create(itParam->getParameter<std::string>("@service_type")));
 
             if(0 == base.get()) {
                throw Exception(errors::Configuration, "Service")
@@ -271,7 +271,7 @@ namespace edm {
       ServicesManager::createServices() {
 
          //create a shared_ptr of 'this' that will not delete us
-         boost::shared_ptr<ServicesManager> shareThis(this, NoOp());
+         std::shared_ptr<ServicesManager> shareThis(this, NoOp());
 
          ServiceToken token(shareThis);
 

--- a/FWCore/ServiceRegistry/test/serviceregistry_t.cppunit.cpp
+++ b/FWCore/ServiceRegistry/test/serviceregistry_t.cppunit.cpp
@@ -115,8 +115,7 @@ testServiceRegistry::externalServiceTest()
 
    {
       std::auto_ptr<DummyService> dummyPtr(new DummyService);
-      boost::shared_ptr<edm::serviceregistry::ServiceWrapper<DummyService> >
-	  wrapper(new edm::serviceregistry::ServiceWrapper<DummyService>(dummyPtr));
+      auto wrapper = std::make_shared<edm::serviceregistry::ServiceWrapper<DummyService> >(dummyPtr);
       edm::ServiceToken token(edm::ServiceRegistry::createContaining(wrapper));
 
       wrapper->get().value_ = 2;

--- a/FWCore/ServiceRegistry/test/servicesmanager_order.cpp
+++ b/FWCore/ServiceRegistry/test/servicesmanager_order.cpp
@@ -12,8 +12,6 @@
 #include "FWCore/ServiceRegistry/interface/ServiceToken.h"
 #undef private
 
-#include "boost/shared_ptr.hpp"
-
 #include <cstdlib>
 #include <vector>
 #include <memory>
@@ -41,13 +39,12 @@ int main() try {
   // demand is also tested.
 
   std::vector<edm::ParameterSet> vps;
-  boost::shared_ptr<ServicesManager> legacy(new ServicesManager(vps));
+  auto legacy = std::make_shared<ServicesManager>(vps);
 
   edm::ActivityRegistry ar;
   edm::ParameterSet pset;
   std::auto_ptr<Service0> s0(new Service0(pset, ar));  
-  boost::shared_ptr<ServiceWrapper<Service0> > 
-      wrapper (new ServiceWrapper<Service0>(s0));
+  auto wrapper = std::make_shared<ServiceWrapper<Service0> >(s0);
   legacy->put(wrapper);
   legacy->copySlotsFrom(ar);
   edm::ServiceToken legacyToken(legacy);
@@ -74,9 +71,7 @@ int main() try {
   ps2.addParameter("@service_type", typeName2);
   vps1.push_back(ps2);
 
-  boost::shared_ptr<ServicesManager> legacy2(new ServicesManager(legacyToken,
-                                                                 kTokenOverrides,
-                                                                 vps1));
+  auto legacy2 = std::make_shared<ServicesManager>(legacyToken, kTokenOverrides, vps1);
   edm::ServiceToken legacyToken2(legacy2);
 
 
@@ -85,8 +80,7 @@ int main() try {
   edm::ActivityRegistry ar4;
   edm::ParameterSet pset4;
   std::auto_ptr<Service4> s4(new Service4(pset4, ar4));  
-  boost::shared_ptr<ServiceWrapper<Service4> > 
-      wrapper4 (new ServiceWrapper<Service4>(s4));
+  auto wrapper4 = std::make_shared<ServiceWrapper<Service4> >(s4);
   sm.put(wrapper4);
   sm.copySlotsFrom(ar4);
 

--- a/FWCore/ServiceRegistry/test/servicesmanager_t.cppunit.cc
+++ b/FWCore/ServiceRegistry/test/servicesmanager_t.cppunit.cc
@@ -76,8 +76,7 @@ testServicesManager::putGetTest()
    CPPUNIT_ASSERT(exceptionThrown);
    
    std::auto_ptr< DummyService > pService(new DummyService);
-   boost::shared_ptr< ServiceWrapper<DummyService> > 
-      ptrWrapper (new ServiceWrapper<DummyService>(pService));
+   auto ptrWrapper = std::make_shared<ServiceWrapper<DummyService> >(pService);
 
    CPPUNIT_ASSERT(sm.put(ptrWrapper));
 
@@ -171,7 +170,7 @@ testServicesManager::legacyTest()
    ps.addParameter("value", value);
    pss.push_back(ps);
    
-   boost::shared_ptr<ServicesManager>  legacy(new ServicesManager(pss));
+   auto legacy = std::make_shared<ServicesManager>(pss);
    CPPUNIT_ASSERT(1 == legacy->get<TestService>().value());
    
    edm::ServiceToken legacyToken(legacy);

--- a/FWCore/Services/bin/cmsGetFnConnect.cc
+++ b/FWCore/Services/bin/cmsGetFnConnect.cc
@@ -30,7 +30,7 @@ main(int argc, char* argv[])
 
     try {
       std::auto_ptr<edm::SiteLocalConfig> slcptr(new edm::service::SiteLocalConfigService(edm::ParameterSet()));
-      boost::shared_ptr<edm::serviceregistry::ServiceWrapper<edm::SiteLocalConfig> > slc(new edm::serviceregistry::ServiceWrapper<edm::SiteLocalConfig>(slcptr));
+      auto slc = std::make_shared<edm::serviceregistry::ServiceWrapper<edm::SiteLocalConfig> >(slcptr);
       edm::ServiceToken slcToken = edm::ServiceRegistry::createContaining(slc);
       edm::ServiceRegistry::Operate operate(slcToken);
 

--- a/FWCore/Skeletons/scripts/mkTemplates/EDLooper/EDLooper.cc
+++ b/FWCore/Skeletons/scripts/mkTemplates/EDLooper/EDLooper.cc
@@ -19,7 +19,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/LooperFactory.h"
@@ -46,7 +45,7 @@ class __class__ : public edm::ESProducerLooper {
             datatypes.append("boost::auto_ptr<%s>" % dtype)
         print "      typedef edm::ESProducts<%s> ReturnType;" % ','.join(datatypes)
     elif len(__datatypes__) == 1:
-        print "      typedef boost::shared_ptr<%s> ReturnType;" % __datatypes__[0]
+        print "      typedef std::shared_ptr<%s> ReturnType;" % __datatypes__[0]
 #python_end
 
       ReturnType produce(const recordname&);

--- a/FWCore/Skeletons/scripts/mkTemplates/ESProducer/ESProducer.cc
+++ b/FWCore/Skeletons/scripts/mkTemplates/ESProducer/ESProducer.cc
@@ -19,7 +19,6 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"
@@ -43,10 +42,10 @@ class __class__ : public edm::ESProducer {
     if  len(__datatypes__) > 1:
         datatypes = []
         for dtype in __datatypes__:
-            datatypes.append("boost::shared_ptr<%s>" % dtype)
+            datatypes.append("std::shared_ptr<%s>" % dtype)
         print "      typedef edm::ESProducts<%s> ReturnType;" % ','.join(datatypes)
     elif len(__datatypes__) == 1:
-        print "      typedef boost::shared_ptr<%s> ReturnType;" % __datatypes__[0]
+        print "      typedef std::shared_ptr<%s> ReturnType;" % __datatypes__[0]
 #python_end
 
       ReturnType produce(const __record__&);
@@ -97,7 +96,7 @@ __class__::produce(const __record__& iRecord)
     out1 = []
     out2 = []
     for dtype in __datatypes__:
-        out1.append("   boost::shared_ptr<%s> p%s;" % (dtype, dtype))
+        out1.append("   std::shared_ptr<%s> p%s;" % (dtype, dtype))
         out2.append("p%s" % dtype)
     output  = '\n'.join(out1)
     output += "\n   return products(%s);" % ','.join(out2)

--- a/FWCore/Sources/BuildFile.xml
+++ b/FWCore/Sources/BuildFile.xml
@@ -5,7 +5,6 @@
 <use   name="FWCore/ParameterSet"/>
 <use   name="FWCore/PluginManager"/>
 <use   name="FWCore/Utilities"/>
-<use   name="boost"/>
 <use   name="tbb"/>
 <export>
   <lib   name="1"/>

--- a/FWCore/Sources/interface/ProducerSourceBase.h
+++ b/FWCore/Sources/interface/ProducerSourceBase.h
@@ -11,7 +11,7 @@
 #include "DataFormats/Provenance/interface/Timestamp.h"
 #include "DataFormats/Provenance/interface/RunID.h"
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 namespace edm {
   class ParameterSet;
@@ -50,8 +50,8 @@ namespace edm {
     virtual void beginLuminosityBlock(LuminosityBlock&) override;
     virtual void endLuminosityBlock(LuminosityBlock&) override;
     virtual void readEvent_(EventPrincipal& eventPrincipal) override;
-    virtual boost::shared_ptr<LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary_() override;
-    virtual boost::shared_ptr<RunAuxiliary> readRunAuxiliary_() override;
+    virtual std::shared_ptr<LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary_() override;
+    virtual std::shared_ptr<RunAuxiliary> readRunAuxiliary_() override;
     virtual void skip(int offset) override;
     virtual void rewind_() override;
 

--- a/FWCore/Sources/interface/RawInputSource.h
+++ b/FWCore/Sources/interface/RawInputSource.h
@@ -7,8 +7,6 @@
 #include <memory>
 #include <utility>
 
-#include "boost/shared_ptr.hpp"
-
 #include "DataFormats/Provenance/interface/EventID.h"
 #include "FWCore/Framework/interface/InputSource.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
@@ -30,8 +28,8 @@ namespace edm {
 
   private:
     virtual void readEvent_(EventPrincipal& eventPrincipal) override;
-    virtual boost::shared_ptr<LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary_() override;
-    virtual boost::shared_ptr<RunAuxiliary> readRunAuxiliary_() override;
+    virtual std::shared_ptr<LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary_() override;
+    virtual std::shared_ptr<RunAuxiliary> readRunAuxiliary_() override;
     virtual void reset_();
     virtual void rewind_() override;
     virtual ItemType getNextItemType() override;

--- a/FWCore/Sources/src/ProducerSourceBase.cc
+++ b/FWCore/Sources/src/ProducerSourceBase.cc
@@ -41,19 +41,19 @@ namespace edm {
   ProducerSourceBase::~ProducerSourceBase() {
   }
 
-  boost::shared_ptr<RunAuxiliary>
+  std::shared_ptr<RunAuxiliary>
   ProducerSourceBase::readRunAuxiliary_() {
     Timestamp ts = Timestamp(presentTime_);
     resetNewRun();
-    return boost::shared_ptr<RunAuxiliary>(new RunAuxiliary(eventID_.run(), ts, Timestamp::invalidTimestamp()));
+    return std::make_shared<RunAuxiliary>(eventID_.run(), ts, Timestamp::invalidTimestamp());
   }
 
-  boost::shared_ptr<LuminosityBlockAuxiliary>
+  std::shared_ptr<LuminosityBlockAuxiliary>
   ProducerSourceBase::readLuminosityBlockAuxiliary_() {
-    if (processingMode() == Runs) return boost::shared_ptr<LuminosityBlockAuxiliary>();
+    if (processingMode() == Runs) return std::shared_ptr<LuminosityBlockAuxiliary>();
     Timestamp ts = Timestamp(presentTime_);
     resetNewLumi();
-    return boost::shared_ptr<LuminosityBlockAuxiliary>(new LuminosityBlockAuxiliary(eventID_.run(), eventID_.luminosityBlock(), ts, Timestamp::invalidTimestamp()));
+    return std::make_shared<LuminosityBlockAuxiliary>(eventID_.run(), eventID_.luminosityBlock(), ts, Timestamp::invalidTimestamp());
   }
 
   void

--- a/FWCore/Sources/src/RawInputSource.cc
+++ b/FWCore/Sources/src/RawInputSource.cc
@@ -23,7 +23,7 @@ namespace edm {
   RawInputSource::~RawInputSource() {
   }
 
-  boost::shared_ptr<RunAuxiliary>
+  std::shared_ptr<RunAuxiliary>
   RawInputSource::readRunAuxiliary_() {
     assert(newRun());
     assert(runAuxiliary());
@@ -31,7 +31,7 @@ namespace edm {
     return runAuxiliary();
   }
 
-  boost::shared_ptr<LuminosityBlockAuxiliary>
+  std::shared_ptr<LuminosityBlockAuxiliary>
   RawInputSource::readLuminosityBlockAuxiliary_() {
     assert(!newRun());
     assert(newLumi());

--- a/FWCore/TFWLiteSelector/interface/TFWLiteSelector.h
+++ b/FWCore/TFWLiteSelector/interface/TFWLiteSelector.h
@@ -43,13 +43,14 @@
 //
 
 // system include files
+#include <memory>
+
 class TList;
 
 // user include files
 
-#include "boost/shared_ptr.hpp"
-
 #include "FWCore/TFWLiteSelector/interface/TFWLiteSelectorBasic.h"
+#include "FWCore/Utilities/interface/HideStdSharedPtrFromRoot.h"
 
 // forward declarations
 template <class TWorker>
@@ -82,7 +83,7 @@ class TFWLiteSelector : public TFWLiteSelectorBasic
       }
       
       // ---------- member data --------------------------------
-      boost::shared_ptr<TWorker> worker_;
+      std::shared_ptr<TWorker> worker_;
       ClassDef(TFWLiteSelector,2)
 };
 

--- a/FWCore/TFWLiteSelector/interface/TFWLiteSelectorBasic.h
+++ b/FWCore/TFWLiteSelector/interface/TFWLiteSelectorBasic.h
@@ -20,10 +20,12 @@ allows you to access data using an edm::Event.
 //
 
 // system include files
+#include <memory>
 #include "TSelector.h"
 
 // user include files
-#include "boost/shared_ptr.hpp"
+
+#include "FWCore/Utilities/interface/HideStdSharedPtrFromRoot.h"
 
 // forward declarations
 class TFile;
@@ -96,7 +98,7 @@ class TFWLiteSelectorBasic : public TSelector
       
       void setupNewFile(TFile&);
       // ---------- member data --------------------------------
-      boost::shared_ptr<edm::root::TFWLiteSelectorMembers> m_;
+      std::shared_ptr<edm::root::TFWLiteSelectorMembers> m_;
       bool everythingOK_;
   
   ClassDef(TFWLiteSelectorBasic,2)

--- a/FWCore/TFWLiteSelector/src/TFWLiteSelectorBasic.cc
+++ b/FWCore/TFWLiteSelector/src/TFWLiteSelectorBasic.cc
@@ -59,7 +59,7 @@ namespace edm {
       FWLiteDelayedReader() : entry_(-1), eventTree_(nullptr), reg_() {}
       void setEntry(Long64_t iEntry) { entry_ = iEntry; }
       void setTree(TTree* iTree) {eventTree_ = iTree;}
-      void set(boost::shared_ptr<ProductRegistry const> iReg) { reg_ = iReg;}
+      void set(std::shared_ptr<ProductRegistry const> iReg) { reg_ = iReg;}
      private:
       WrapperOwningHolder getTheProduct(BranchKey const& k) const;
       virtual WrapperOwningHolder getProduct_(BranchKey const& k, WrapperInterfaceBase const* interface, EDProductGetter const* ep) const override;
@@ -70,7 +70,7 @@ namespace edm {
       virtual void reset_() override {}
       Long64_t entry_;
       TTree* eventTree_;
-      boost::shared_ptr<ProductRegistry const>(reg_);
+      std::shared_ptr<ProductRegistry const>(reg_);
     };
 
     WrapperOwningHolder
@@ -130,18 +130,18 @@ namespace edm {
         reader_->setTree(iTree);
       }
       TTree* tree_;
-      boost::shared_ptr<ProductRegistry> reg_;
-      boost::shared_ptr<ProcessHistoryRegistry> phreg_;
-      boost::shared_ptr<BranchIDListHelper> branchIDListHelper_;
+      std::shared_ptr<ProductRegistry> reg_;
+      std::shared_ptr<ProcessHistoryRegistry> phreg_;
+      std::shared_ptr<BranchIDListHelper> branchIDListHelper_;
       ProcessHistory processNames_;
-      boost::shared_ptr<FWLiteDelayedReader> reader_;
+      std::shared_ptr<FWLiteDelayedReader> reader_;
       std::vector<EventEntryDescription> prov_;
       std::vector<EventEntryDescription*> pointerToBranchBuffer_;
       FileFormatVersion fileFormatVersion_;
 
-      boost::shared_ptr<edm::ProductProvenanceRetriever> provRetriever_;
+      std::shared_ptr<edm::ProductProvenanceRetriever> provRetriever_;
       edm::ProcessConfiguration pc_;
-      boost::shared_ptr<edm::EventPrincipal> ep_;
+      std::shared_ptr<edm::EventPrincipal> ep_;
       edm::ModuleDescription md_;
     };
   }
@@ -285,12 +285,10 @@ TFWLiteSelectorBasic::Process(Long64_t iEntry) {
 
       try {
          m_->reader_->setEntry(iEntry);
-         boost::shared_ptr<edm::RunAuxiliary> runAux(new edm::RunAuxiliary(aux.run(), aux.time(), aux.time()));
-         boost::shared_ptr<edm::RunPrincipal> rp(new edm::RunPrincipal(runAux, m_->reg_, m_->pc_, nullptr, 0));
-         boost::shared_ptr<edm::LuminosityBlockAuxiliary> lumiAux(
-                new edm::LuminosityBlockAuxiliary(rp->run(), 1, aux.time(), aux.time()));
-         boost::shared_ptr<edm::LuminosityBlockPrincipal>lbp(
-                new edm::LuminosityBlockPrincipal(lumiAux, m_->reg_, m_->pc_, nullptr, 0));
+         auto runAux = std::make_shared<edm::RunAuxiliary>(aux.run(), aux.time(), aux.time());
+         auto rp = std::make_shared<edm::RunPrincipal>(runAux, m_->reg_, m_->pc_, nullptr, 0);
+         auto lumiAux = std::make_shared<edm::LuminosityBlockAuxiliary>(rp->run(), 1, aux.time(), aux.time());
+         auto lbp = std::make_shared<edm::LuminosityBlockPrincipal>(lumiAux, m_->reg_, m_->pc_, nullptr, 0);
         m_->ep_->fillEventPrincipal(*eaux,
                                     *m_->phreg_,
                                     std::move(eventSelectionIDs),
@@ -381,7 +379,7 @@ TFWLiteSelectorBasic::setupNewFile(TFile& iFile) {
      metaDataTree->SetBranchAddress(edm::poolNames::processConfigurationBranchName().c_str(), &procConfigVectorPtr);
   }
 
-  boost::shared_ptr<edm::BranchIDListHelper> branchIDListsHelper(new edm::BranchIDListHelper);
+  auto branchIDListsHelper = std::make_shared<edm::BranchIDListHelper>();
   edm::BranchIDLists const* branchIDListsPtr = &branchIDListsHelper->branchIDLists();
   if(metaDataTree->FindBranch(edm::poolNames::branchIDListBranchName().c_str()) != nullptr) {
     metaDataTree->SetBranchAddress(edm::poolNames::branchIDListBranchName().c_str(), &branchIDListsPtr);

--- a/FWCore/Utilities/interface/ExtensionCord.h
+++ b/FWCore/Utilities/interface/ExtensionCord.h
@@ -19,7 +19,7 @@
 //
 
 // system include files
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 // user include files
 #include "FWCore/Utilities/interface/ECGetterBase.h"
@@ -80,7 +80,7 @@ namespace edm {
         holder_->getter_ = iGetter;
       }
       // ---------- member data --------------------------------
-      boost::shared_ptr< Holder > holder_;
+      std::shared_ptr< Holder > holder_;
       
   };
 }

--- a/FWCore/Utilities/interface/HideStdSharedPtrFromRoot.h
+++ b/FWCore/Utilities/interface/HideStdSharedPtrFromRoot.h
@@ -1,9 +1,9 @@
-#ifndef DataFormats_Common_HideStdSharedPtrFromRoot_h
-#define DataFormats_Common_HideStdSharedPtrFromRoot_h
-#if defined(__CINT__) || defined(__MAKECINT__) || defined(__REFLEX__)
+#ifndef FWCore_Utilities_HideStdSharedPtrFromRoot_h
+#define FWCore_Utilities_HideStdSharedPtrFromRoot_h
+#if defined(__GCCXML__)
 // -*- C++ -*-
 //
-// Package:     DataFormats/Common
+// Package:     FWCore/Utilities
 // Class  :     HideStdSharedPtrFromRoot
 // 
 /**
@@ -33,12 +33,16 @@ namespace std {
     void* data_;
     unsigned long count_;
   public:
+    shared_ptr();
+    shared_ptr(T*);
     void reset(T* iValue=0);
     T* get();
     T const* get() const;
     
     T* operator->();
     T const* operator->() const;
+
+    T operator*() const;
     
     operator bool() const;
   };

--- a/FWCore/Utilities/interface/do_nothing_deleter.h
+++ b/FWCore/Utilities/interface/do_nothing_deleter.h
@@ -5,7 +5,7 @@
 //
 // do_nothing_deleter.h
 //
-// Purpose: do_nothing_deleter provides a way to use boost::shared_ptr
+// Purpose: do_nothing_deleter provides a way to use std::shared_ptr
 // or boost::shared_array for those cases where the object or array
 // may be either in dynamic (heap) storage, or in static storage,
 // as long as which of these applies is known when the shared_ptr or shared_array
@@ -14,10 +14,10 @@
 // For objects:
 //
 // If the object is allocated in dynamic storage, use
-// boost::shared_ptr<T> (new T(...));
+// std::shared_ptr<T> (new T(...));
 
 // If the object "t" is in static storage, use
-// boost::shared_ptr<T> (&t, do_nothing_deleter());
+// std::shared_ptr<T> (&t, do_nothing_deleter());
 //
 // For arrays:
 //

--- a/Fireworks/Core/bin/cmsShow.cc
+++ b/Fireworks/Core/bin/cmsShow.cc
@@ -91,7 +91,7 @@ void signal_handler_wrapper(int sid, siginfo_t* sinfo, void* sctx)
 void run_app(TApplication &app, int argc, char **argv)
 {
    //Remove when FWLite handles the MessageLogger
-   edm::MessageLoggerQ::setMLscribe_ptr(boost::shared_ptr<edm::service::AbstractMLscribe>(new SilentMLscribe));
+   edm::MessageLoggerQ::setMLscribe_ptr(std::shared_ptr<edm::service::AbstractMLscribe>(std::make_shared<SilentMLscribe>()));
    edm::MessageDrop::instance()->messageLoggerScribeIsRunning = edm::MLSCRIBE_RUNNING_INDICATOR;
    //---------------------
    std::auto_ptr<CmsShowMain> pMain( new CmsShowMain(argc,argv) );

--- a/GeneratorInterface/SherpaInterface/BuildFile.xml
+++ b/GeneratorInterface/SherpaInterface/BuildFile.xml
@@ -5,7 +5,6 @@
 <use name="GeneratorInterface/Core"/>
 <use name="GeneratorInterface/ExternalDecays"/>
 <use name="GeneratorInterface/Pythia6Interface"/>
-<use name="boost"/>
 <use name="clhep"/>
 <use name="sherpa"/>
 <use name="frontier_client"/>

--- a/GeneratorInterface/SherpaInterface/src/SherpackFetcher.cc
+++ b/GeneratorInterface/SherpaInterface/src/SherpackFetcher.cc
@@ -7,6 +7,7 @@
 //~ #include "SherpackFetcher.h"
 #include "GeneratorInterface/SherpaInterface/interface/SherpackFetcher.h"
 
+#include <memory>
 
 //~ #include <libtar.h>
 namespace spf {
@@ -101,7 +102,7 @@ int SherpackFetcher::FnFileGet(std::string pathstring)
   std::string connectstr="";
   try {
 	  std::auto_ptr<edm::SiteLocalConfig> slcptr(new edm::service::SiteLocalConfigService(edm::ParameterSet()));
-	  boost::shared_ptr<edm::serviceregistry::ServiceWrapper<edm::SiteLocalConfig> > slc(new edm::serviceregistry::ServiceWrapper<edm::SiteLocalConfig>(slcptr));
+	  auto slc = std::make_shared<edm::serviceregistry::ServiceWrapper<edm::SiteLocalConfig> >(slcptr);
 	  edm::ServiceToken slcToken = edm::ServiceRegistry::createContaining(slc);
 	  edm::ServiceRegistry::Operate operate(slcToken);
 

--- a/Geometry/HcalTowerAlgo/test/BuildFile.xml
+++ b/Geometry/HcalTowerAlgo/test/BuildFile.xml
@@ -1,5 +1,4 @@
 <use   name="Geometry/HcalTowerAlgo"/>
-<use   name="boost"/>
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="FWCore/PythonParameterSet"/>

--- a/Geometry/HcalTowerAlgo/test/HcalGeometryTest.cpp
+++ b/Geometry/HcalTowerAlgo/test/HcalGeometryTest.cpp
@@ -8,7 +8,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/FileInPath.h"
 #include "FWCore/PythonParameterSet/interface/MakeParameterSets.h"
-#include "boost/shared_ptr.hpp"
+#include <memory>
 #include <string>
 #include <iostream>
 
@@ -69,7 +69,7 @@ testClosestCells( HcalTopology& topology )
 {
   edm::FileInPath fp("Geometry/HcalTowerAlgo/test/runHcalGeometryAnalyzer_cfg.py");
   std::string fname  = fp.fullPath();
-  boost::shared_ptr<edm::ParameterSet> pS = edm::readConfig(fname);
+  std::shared_ptr<edm::ParameterSet> pS = edm::readConfig(fname);
   //  std::cout << pS->dump() << std::endl;
 
   edm::ParameterSet const& pModule =
@@ -124,7 +124,7 @@ testFlexiValidDetIds( HcalTopology& topology, DetId::Detector det, int subdet, c
 
   edm::FileInPath fp("Geometry/HcalTowerAlgo/test/runHcalGeometryAnalyzer_cfg.py");
   std::string fname  = fp.fullPath();
-  boost::shared_ptr<edm::ParameterSet> pS = edm::readConfig(fname);
+  std::shared_ptr<edm::ParameterSet> pS = edm::readConfig(fname);
   //  std::cout << pS->dump() << std::endl;
 
   edm::ParameterSet const& pModule =

--- a/IOMC/RandomEngine/src/RandomNumberGeneratorService.cc
+++ b/IOMC/RandomEngine/src/RandomNumberGeneratorService.cc
@@ -1200,7 +1200,7 @@ namespace edm {
           VUint32 const& seeds = i.second.seeds();
 
           if(name == "RanecuEngine") {
-            std::shared_ptr<CLHEP::HepRandomEngine> engine(new CLHEP::RanecuEngine());
+            std::shared_ptr<CLHEP::HepRandomEngine> engine = std::make_shared<CLHEP::RanecuEngine>();
             engines.emplace_back(label, seeds, engine);
             resetEngineSeeds(engines.back(), name, seeds, seedOffset, eventSeedOffset);
           }
@@ -1209,7 +1209,7 @@ namespace edm {
             long int seedL = static_cast<long int>(seeds[0]);
 
             if(name == "HepJamesRandom") {
-              std::shared_ptr<CLHEP::HepRandomEngine> engine(new CLHEP::HepJamesRandom(seedL));
+              std::shared_ptr<CLHEP::HepRandomEngine> engine = std::make_shared<CLHEP::HepJamesRandom>(seedL);
               engines.emplace_back(label, seeds, engine);
               if(seedOffset != 0 || eventSeedOffset != 0) {
                 resetEngineSeeds(engines.back(), name, seeds, seedOffset, eventSeedOffset);
@@ -1226,7 +1226,7 @@ namespace edm {
               std::uint32_t seedu32 = static_cast<std::uint32_t>(seedL);
               assert(seeds[0] == seedu32);
 
-              std::shared_ptr<CLHEP::HepRandomEngine> engine(new TRandomAdaptor(seedL));
+              std::shared_ptr<CLHEP::HepRandomEngine> engine = std::make_shared<TRandomAdaptor>(seedL);
               engines.emplace_back(label, seeds, engine);
               if(seedOffset != 0 || eventSeedOffset != 0) {
                 resetEngineSeeds(engines.back(), name, seeds, seedOffset, eventSeedOffset);

--- a/IOMC/RandomEngine/test/TestRandomNumberServiceGlobal.cc
+++ b/IOMC/RandomEngine/test/TestRandomNumberServiceGlobal.cc
@@ -306,7 +306,7 @@ TestRandomNumberServiceGlobal::globalBeginLuminosityBlock(edm::LuminosityBlock c
     std::cout << rng->getEngine(lumi.index()).name() << "\n";
   }
 
-  std::shared_ptr<TestRandomNumberServiceLumiCache> lumiCache(new TestRandomNumberServiceLumiCache);
+  auto lumiCache = std::make_shared<TestRandomNumberServiceLumiCache>();
 
   unsigned int seed0 = seeds_.at(0) + nStreams_;
   if(lumi.luminosityBlockAuxiliary().luminosityBlock() < seedByLumi_.size()) {

--- a/IOPool/Common/bin/EdmFileUtil.cpp
+++ b/IOPool/Common/bin/EdmFileUtil.cpp
@@ -82,7 +82,7 @@ int main(int argc, char* argv[]) {
   int rc = 0;
   try {
     std::auto_ptr<edm::SiteLocalConfig> slcptr(new edm::service::SiteLocalConfigService(edm::ParameterSet()));
-    boost::shared_ptr<edm::serviceregistry::ServiceWrapper<edm::SiteLocalConfig> > slc(new edm::serviceregistry::ServiceWrapper<edm::SiteLocalConfig>(slcptr));
+    auto slc = std::make_shared<edm::serviceregistry::ServiceWrapper<edm::SiteLocalConfig> >(slcptr);
     edm::ServiceToken slcToken = edm::ServiceRegistry::createContaining(slc);
     edm::ServiceRegistry::Operate operate(slcToken);
 

--- a/IOPool/Common/bin/EdmProvDump.cc
+++ b/IOPool/Common/bin/EdmProvDump.cc
@@ -375,7 +375,7 @@ namespace {
   makeTFileWithLookup(std::string const& filename) {
     // See if it is a logical file name.
     std::auto_ptr<edm::SiteLocalConfig> slcptr(new edm::service::SiteLocalConfigService(edm::ParameterSet()));
-    boost::shared_ptr<edm::serviceregistry::ServiceWrapper<edm::SiteLocalConfig> > slc(new edm::serviceregistry::ServiceWrapper<edm::SiteLocalConfig>(slcptr));
+    auto slc = std::make_shared<edm::serviceregistry::ServiceWrapper<edm::SiteLocalConfig> >(slcptr);
     edm::ServiceToken slcToken = edm::ServiceRegistry::createContaining(slc);
     edm::ServiceRegistry::Operate operate(slcToken);
     std::string override;

--- a/IOPool/Input/BuildFile.xml
+++ b/IOPool/Input/BuildFile.xml
@@ -9,7 +9,6 @@
 <use   name="FWCore/Utilities"/>
 <use   name="IOPool/Common"/>
 <use   name="Utilities/StorageFactory"/>
-<use   name="boost"/>
 <use   name="clhep"/>
 <use   name="rootcore"/>
 <flags   EDM_PLUGIN="1"/>

--- a/IOPool/Input/src/DuplicateChecker.cc
+++ b/IOPool/Input/src/DuplicateChecker.cc
@@ -47,8 +47,8 @@ namespace edm {
   void DuplicateChecker::inputFileOpened(
       bool realData,
       IndexIntoFile const& indexIntoFile,
-      std::vector<boost::shared_ptr<IndexIntoFile> > const& indexesIntoFiles,
-      std::vector<boost::shared_ptr<IndexIntoFile> >::size_type currentIndexIntoFile) {
+      std::vector<std::shared_ptr<IndexIntoFile> > const& indexesIntoFiles,
+      std::vector<std::shared_ptr<IndexIntoFile> >::size_type currentIndexIntoFile) {
 
     dataType_ = realData ? isRealData : isSimulation;
     if (checkDisabled()) return;
@@ -60,7 +60,7 @@ namespace edm {
 
       // Compares the current IndexIntoFile to all the previous ones and saves any duplicates.
       // One unintended thing, it also saves the duplicate runs and lumis.
-      for(std::vector<boost::shared_ptr<IndexIntoFile> >::size_type i = 0; i < currentIndexIntoFile; ++i) {
+      for(std::vector<std::shared_ptr<IndexIntoFile> >::size_type i = 0; i < currentIndexIntoFile; ++i) {
         if (indexesIntoFiles[i].get() != 0) {
 
           indexIntoFile.set_intersection(*indexesIntoFiles[i], relevantPreviousEvents_);

--- a/IOPool/Input/src/DuplicateChecker.h
+++ b/IOPool/Input/src/DuplicateChecker.h
@@ -39,8 +39,8 @@ namespace edm {
     void inputFileOpened(
       bool realData,
       IndexIntoFile const& indexIntoFile,
-      std::vector<boost::shared_ptr<IndexIntoFile> > const& indexesIntoFiles,
-      std::vector<boost::shared_ptr<IndexIntoFile> >::size_type currentIndexIntoFile);
+      std::vector<std::shared_ptr<IndexIntoFile> > const& indexesIntoFiles,
+      std::vector<std::shared_ptr<IndexIntoFile> >::size_type currentIndexIntoFile);
 
     void inputFileClosed();
 

--- a/IOPool/Input/src/PoolSource.cc
+++ b/IOPool/Input/src/PoolSource.cc
@@ -137,12 +137,12 @@ namespace edm {
     primaryFileSequence_->closeFile_();
   }
 
-  boost::shared_ptr<RunAuxiliary>
+  std::shared_ptr<RunAuxiliary>
   PoolSource::readRunAuxiliary_() {
     return primaryFileSequence_->readRunAuxiliary_();
   }
 
-  boost::shared_ptr<LuminosityBlockAuxiliary>
+  std::shared_ptr<LuminosityBlockAuxiliary>
   PoolSource::readLuminosityBlockAuxiliary_() {
     return primaryFileSequence_->readLuminosityBlockAuxiliary_();
   }
@@ -153,7 +153,7 @@ namespace edm {
     if(secondaryFileSequence_ && !branchIDsToReplace_[InRun].empty()) {
       bool found = secondaryFileSequence_->skipToItem(runPrincipal.run(), 0U, 0U);
       if(found) {
-        boost::shared_ptr<RunAuxiliary> secondaryAuxiliary = secondaryFileSequence_->readRunAuxiliary_();
+        std::shared_ptr<RunAuxiliary> secondaryAuxiliary = secondaryFileSequence_->readRunAuxiliary_();
         checkConsistency(runPrincipal.aux(), *secondaryAuxiliary);
         secondaryRunPrincipal_.reset(new RunPrincipal(secondaryAuxiliary,
                                                       secondaryFileSequence_->fileProductRegistry(),
@@ -177,7 +177,7 @@ namespace edm {
     if(secondaryFileSequence_ && !branchIDsToReplace_[InLumi].empty()) {
       bool found = secondaryFileSequence_->skipToItem(lumiPrincipal.run(), lumiPrincipal.luminosityBlock(), 0U);
       if(found) {
-        boost::shared_ptr<LuminosityBlockAuxiliary> secondaryAuxiliary = secondaryFileSequence_->readLuminosityBlockAuxiliary_();
+        std::shared_ptr<LuminosityBlockAuxiliary> secondaryAuxiliary = secondaryFileSequence_->readLuminosityBlockAuxiliary_();
         checkConsistency(lumiPrincipal.aux(), *secondaryAuxiliary);
         secondaryLumiPrincipal_.reset(new LuminosityBlockPrincipal(secondaryAuxiliary,
                                                                    secondaryFileSequence_->fileProductRegistry(),

--- a/IOPool/Input/src/PoolSource.h
+++ b/IOPool/Input/src/PoolSource.h
@@ -13,8 +13,6 @@ PoolSource: This is an InputSource
 #include "FWCore/Sources/interface/VectorInputSource.h"
 #include "IOPool/Common/interface/RootServiceChecker.h"
 
-#include "boost/shared_ptr.hpp"
-
 #include <array>
 #include <memory>
 #include <string>
@@ -41,9 +39,9 @@ namespace edm {
 
   private:
     virtual void readEvent_(EventPrincipal& eventPrincipal);
-    virtual boost::shared_ptr<LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary_();
+    virtual std::shared_ptr<LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary_();
     virtual void readLuminosityBlock_(LuminosityBlockPrincipal& lumiPrincipal);
-    virtual boost::shared_ptr<RunAuxiliary> readRunAuxiliary_();
+    virtual std::shared_ptr<RunAuxiliary> readRunAuxiliary_();
     virtual void readRun_(RunPrincipal& runPrincipal);
     virtual std::unique_ptr<FileBlock> readFile_();
     virtual void closeFile_();
@@ -70,8 +68,8 @@ namespace edm {
     RootServiceChecker rootServiceChecker_;
     std::unique_ptr<RootInputFileSequence> primaryFileSequence_;
     std::unique_ptr<RootInputFileSequence> secondaryFileSequence_;
-    boost::shared_ptr<RunPrincipal> secondaryRunPrincipal_;
-    boost::shared_ptr<LuminosityBlockPrincipal> secondaryLumiPrincipal_;
+    std::shared_ptr<RunPrincipal> secondaryRunPrincipal_;
+    std::shared_ptr<LuminosityBlockPrincipal> secondaryLumiPrincipal_;
     std::vector<std::unique_ptr<EventPrincipal>> secondaryEventPrincipals_;
     std::array<std::vector<BranchID>, NumBranchTypes>  branchIDsToReplace_;
     

--- a/IOPool/Input/src/ProvenanceAdaptor.cc
+++ b/IOPool/Input/src/ProvenanceAdaptor.cc
@@ -91,7 +91,7 @@ namespace edm {
     void
     fillListsAndIndexes(ProductRegistry& productRegistry,
 			ProcessHistoryMap const& pHistMap,
-			boost::shared_ptr<BranchIDLists const>& branchIDLists,
+			std::shared_ptr<BranchIDLists const>& branchIDLists,
 			std::vector<BranchListIndex>& branchListIndexes) {
       OrderedProducts orderedProducts;
       std::set<std::string> processNamesThatProduced;
@@ -183,7 +183,7 @@ namespace edm {
     return it->second; 
   }
 
-  boost::shared_ptr<BranchIDLists const>
+  std::shared_ptr<BranchIDLists const>
   ProvenanceAdaptor::branchIDLists() const {
     return branchIDLists_;
   }

--- a/IOPool/Input/src/ProvenanceAdaptor.h
+++ b/IOPool/Input/src/ProvenanceAdaptor.h
@@ -10,8 +10,6 @@ ProvenanceAdaptor.h
 #include <memory>
 #include <vector>
 
-#include "boost/shared_ptr.hpp"
-
 #include "DataFormats/Provenance/interface/BranchIDList.h"
 #include "DataFormats/Provenance/interface/BranchListIndex.h"
 #include "DataFormats/Provenance/interface/ParameterSetID.h"
@@ -41,7 +39,7 @@ namespace edm {
     ProvenanceAdaptor(ProvenanceAdaptor const&) = delete; // Disallow copying and moving
     ProvenanceAdaptor& operator=(ProvenanceAdaptor const&) = delete; // Disallow copying and moving
 
-    boost::shared_ptr<BranchIDLists const> branchIDLists() const;
+    std::shared_ptr<BranchIDLists const> branchIDLists() const;
 
     void branchListIndexes(BranchListIndexes & indexes) const;
 
@@ -57,7 +55,7 @@ namespace edm {
 
     ParameterSetIdConverter parameterSetIdConverter_;
     ProcessHistoryIdConverter processHistoryIdConverter_;
-    boost::shared_ptr<BranchIDLists const> branchIDLists_;
+    std::shared_ptr<BranchIDLists const> branchIDLists_;
     std::vector<BranchListIndex> branchListIndexes_;
   }; // class ProvenanceAdaptor
 }

--- a/IOPool/Input/src/RootDelayedReader.cc
+++ b/IOPool/Input/src/RootDelayedReader.cc
@@ -20,7 +20,7 @@ namespace edm {
 
   RootDelayedReader::RootDelayedReader(
       RootTree const& tree,
-      boost::shared_ptr<InputFile> filePtr,
+      std::shared_ptr<InputFile> filePtr,
       InputType inputType) :
    tree_(tree),
    filePtr_(filePtr),

--- a/IOPool/Input/src/RootDelayedReader.h
+++ b/IOPool/Input/src/RootDelayedReader.h
@@ -33,7 +33,7 @@ namespace edm {
     typedef roottree::EntryNumber EntryNumber;
     RootDelayedReader(
       RootTree const& tree,
-      boost::shared_ptr<InputFile> filePtr,
+      std::shared_ptr<InputFile> filePtr,
       InputType inputType);
 
     virtual ~RootDelayedReader();
@@ -56,7 +56,7 @@ namespace edm {
     // NOTE: filePtr_ appears to be unused, but is needed to prevent
     // the file containing the branch from being reclaimed.
     RootTree const& tree_;
-    boost::shared_ptr<InputFile> filePtr_;
+    std::shared_ptr<InputFile> filePtr_;
     DelayedReader* nextReader_;
     std::unique_ptr<SharedResourcesAcquirer> resourceAcquirer_;
     InputType inputType_;

--- a/IOPool/Input/src/RootFile.cc
+++ b/IOPool/Input/src/RootFile.cc
@@ -138,8 +138,8 @@ namespace edm {
   RootFile::RootFile(std::string const& fileName,
                      ProcessConfiguration const& processConfiguration,
                      std::string const& logicalFileName,
-                     boost::shared_ptr<InputFile> filePtr,
-                     boost::shared_ptr<EventSkipperByID> eventSkipperByID,
+                     std::shared_ptr<InputFile> filePtr,
+                     std::shared_ptr<EventSkipperByID> eventSkipperByID,
                      bool skipAnyEvents,
                      int remainingEvents,
                      int remainingLumis,
@@ -151,12 +151,12 @@ namespace edm {
                      bool noEventSort,
                      ProductSelectorRules const& productSelectorRules,
                      InputType inputType,
-                     boost::shared_ptr<BranchIDListHelper> branchIDListHelper,
-                     boost::shared_ptr<DuplicateChecker> duplicateChecker,
+                     std::shared_ptr<BranchIDListHelper> branchIDListHelper,
+                     std::shared_ptr<DuplicateChecker> duplicateChecker,
                      bool dropDescendants,
                      ProcessHistoryRegistry& processHistoryRegistry,
-                     std::vector<boost::shared_ptr<IndexIntoFile> > const& indexesIntoFiles,
-                     std::vector<boost::shared_ptr<IndexIntoFile> >::size_type currentIndexIntoFile,
+                     std::vector<std::shared_ptr<IndexIntoFile> > const& indexesIntoFiles,
+                     std::vector<std::shared_ptr<IndexIntoFile> >::size_type currentIndexIntoFile,
                      std::vector<ProcessHistoryID>& orderedProcessHistoryIDs,
                      bool labelRawDataLikeMC,
                      bool usingGoToEvent,
@@ -935,7 +935,7 @@ namespace edm {
       while(runTree_.next()) {
         // Note: adjacent duplicates will be skipped without an explicit check.
 
-        boost::shared_ptr<RunAuxiliary> runAux = fillRunAuxiliary();
+        std::shared_ptr<RunAuxiliary> runAux = fillRunAuxiliary();
         ProcessHistoryID reducedPHID = processHistoryRegistry_->reducedProcessHistoryID(runAux->processHistoryID());
 
         if(runSet.insert(runAux->run()).second) { // (check 4, insert 4)
@@ -974,7 +974,7 @@ namespace edm {
     if(lumiTree_.isValid()) {
       while(lumiTree_.next()) {
         // Note: adjacent duplicates will be skipped without an explicit check.
-        boost::shared_ptr<LuminosityBlockAuxiliary> lumiAux = fillLumiAuxiliary();
+        std::shared_ptr<LuminosityBlockAuxiliary> lumiAux = fillLumiAuxiliary();
         LuminosityBlockID lumiID = LuminosityBlockID(lumiAux->run(), lumiAux->luminosityBlock());
         if(runLumiSet.insert(lumiID).second) { // (check 2, insert 2)
           // This lumi was not associated with any events.
@@ -1096,7 +1096,7 @@ namespace edm {
 
     indexIntoFile_.fixIndexes(orderedProcessHistoryIDs_);
     indexIntoFile_.setNumberOfEvents(eventTree_.entries());
-    indexIntoFile_.setEventFinder(boost::shared_ptr<IndexIntoFile::EventFinder>(new RootFileEventFinder(eventTree_)));
+    indexIntoFile_.setEventFinder(std::shared_ptr<IndexIntoFile::EventFinder>(std::make_shared<RootFileEventFinder>(eventTree_)));
     // We fill the event numbers explicitly if we need to find events in closed files,
     // such as for secondary files (or secondary sources) or if duplicate checking across files.
     bool needEventNumbers = false;
@@ -1223,9 +1223,9 @@ namespace edm {
     branchIDListHelper_->fixBranchListIndexes(branchListIndexes_);
   }
 
-  boost::shared_ptr<LuminosityBlockAuxiliary>
+  std::shared_ptr<LuminosityBlockAuxiliary>
   RootFile::fillLumiAuxiliary() {
-    boost::shared_ptr<LuminosityBlockAuxiliary> lumiAuxiliary(new LuminosityBlockAuxiliary);
+    auto lumiAuxiliary = std::make_shared<LuminosityBlockAuxiliary>();
     if(fileFormatVersion().newAuxiliary()) {
       LuminosityBlockAuxiliary *pLumiAux = lumiAuxiliary.get();
       lumiTree_.fillAux<LuminosityBlockAuxiliary>(pLumiAux);
@@ -1247,9 +1247,9 @@ namespace edm {
     return lumiAuxiliary;
   }
 
-  boost::shared_ptr<RunAuxiliary>
+  std::shared_ptr<RunAuxiliary>
   RootFile::fillRunAuxiliary() {
-    boost::shared_ptr<RunAuxiliary> runAuxiliary(new RunAuxiliary);
+    auto runAuxiliary = std::make_shared<RunAuxiliary>();
     if(fileFormatVersion().newAuxiliary()) {
       RunAuxiliary *pRunAux = runAuxiliary.get();
       runTree_.fillAux<RunAuxiliary>(pRunAux);
@@ -1426,7 +1426,7 @@ namespace edm {
     eventTree_.setEntryNumber(entry);
   }
 
-  boost::shared_ptr<RunAuxiliary>
+  std::shared_ptr<RunAuxiliary>
   RootFile::readRunAuxiliary_() {
     assert(indexIntoFileIter_ != indexIntoFileEnd_);
     assert(indexIntoFileIter_.getEntryType() == IndexIntoFile::kRun);
@@ -1443,11 +1443,11 @@ namespace edm {
 
       RunID run = RunID(indexIntoFileIter_.run());
       overrideRunNumber(run);
-      return boost::shared_ptr<RunAuxiliary>(new RunAuxiliary(run.run(), eventAux().time(), Timestamp::invalidTimestamp()));
+      return std::make_shared<RunAuxiliary>(run.run(), eventAux().time(), Timestamp::invalidTimestamp());
     }
     // End code for backward compatibility before the existence of run trees.
     runTree_.setEntryNumber(indexIntoFileIter_.entry());
-    boost::shared_ptr<RunAuxiliary> runAuxiliary = fillRunAuxiliary();
+    std::shared_ptr<RunAuxiliary> runAuxiliary = fillRunAuxiliary();
     assert(runAuxiliary->run() == indexIntoFileIter_.run());
     overrideRunNumber(runAuxiliary->id());
     filePtr_->reportInputRunNumber(runAuxiliary->run());
@@ -1507,7 +1507,7 @@ namespace edm {
     ++indexIntoFileIter_;
   }
 
-  boost::shared_ptr<LuminosityBlockAuxiliary>
+  std::shared_ptr<LuminosityBlockAuxiliary>
   RootFile::readLuminosityBlockAuxiliary_() {
     assert(indexIntoFileIter_ != indexIntoFileEnd_);
     assert(indexIntoFileIter_.getEntryType() == IndexIntoFile::kLumi);
@@ -1520,11 +1520,11 @@ namespace edm {
 
       LuminosityBlockID lumi = LuminosityBlockID(indexIntoFileIter_.run(), indexIntoFileIter_.lumi());
       overrideRunNumber(lumi);
-      return boost::shared_ptr<LuminosityBlockAuxiliary>(new LuminosityBlockAuxiliary(lumi.run(), lumi.luminosityBlock(), eventAux().time(), Timestamp::invalidTimestamp()));
+      return std::make_shared<LuminosityBlockAuxiliary>(lumi.run(), lumi.luminosityBlock(), eventAux().time(), Timestamp::invalidTimestamp());
     }
     // End code for backward compatibility before the existence of lumi trees.
     lumiTree_.setEntryNumber(indexIntoFileIter_.entry());
-    boost::shared_ptr<LuminosityBlockAuxiliary> lumiAuxiliary = fillLumiAuxiliary();
+    std::shared_ptr<LuminosityBlockAuxiliary> lumiAuxiliary = fillLumiAuxiliary();
     assert(lumiAuxiliary->run() == indexIntoFileIter_.run());
     assert(lumiAuxiliary->luminosityBlock() == indexIntoFileIter_.lumi());
     overrideRunNumber(lumiAuxiliary->id());
@@ -1646,8 +1646,8 @@ namespace edm {
 
   void
   RootFile::initializeDuplicateChecker(
-    std::vector<boost::shared_ptr<IndexIntoFile> > const& indexesIntoFiles,
-    std::vector<boost::shared_ptr<IndexIntoFile> >::size_type currentIndexIntoFile) {
+    std::vector<std::shared_ptr<IndexIntoFile> > const& indexesIntoFiles,
+    std::vector<std::shared_ptr<IndexIntoFile> >::size_type currentIndexIntoFile) {
     if(duplicateChecker_) {
       if(eventTree_.next()) {
         fillThisEventAuxiliary();
@@ -1741,7 +1741,7 @@ namespace edm {
     }
   }
 
-  boost::shared_ptr<ProductProvenanceRetriever>
+  std::shared_ptr<ProductProvenanceRetriever>
   RootFile::makeProductProvenanceRetriever(unsigned int iStreamID) {
     if(eventProductProvenanceRetrievers_.size()<=iStreamID) {
       eventProductProvenanceRetrievers_.resize(iStreamID+1);

--- a/IOPool/Input/src/RootFile.h
+++ b/IOPool/Input/src/RootFile.h
@@ -58,8 +58,8 @@ namespace edm {
     RootFile(std::string const& fileName,
              ProcessConfiguration const& processConfiguration,
              std::string const& logicalFileName,
-             boost::shared_ptr<InputFile> filePtr,
-             boost::shared_ptr<EventSkipperByID> eventSkipperByID,
+             std::shared_ptr<InputFile> filePtr,
+             std::shared_ptr<EventSkipperByID> eventSkipperByID,
              bool skipAnyEvents,
              int remainingEvents,
              int remainingLumis,
@@ -71,12 +71,12 @@ namespace edm {
              bool noEventSort,
              ProductSelectorRules const& productSelectorRules,
              InputType inputType,
-             boost::shared_ptr<BranchIDListHelper> branchIDListHelper,
-             boost::shared_ptr<DuplicateChecker> duplicateChecker,
+             std::shared_ptr<BranchIDListHelper> branchIDListHelper,
+             std::shared_ptr<DuplicateChecker> duplicateChecker,
              bool dropDescendantsOfDroppedProducts,
              ProcessHistoryRegistry& processHistoryRegistry,
-             std::vector<boost::shared_ptr<IndexIntoFile> > const& indexesIntoFiles,
-             std::vector<boost::shared_ptr<IndexIntoFile> >::size_type currentIndexIntoFile,
+             std::vector<std::shared_ptr<IndexIntoFile> > const& indexesIntoFiles,
+             std::vector<std::shared_ptr<IndexIntoFile> >::size_type currentIndexIntoFile,
              std::vector<ProcessHistoryID>& orderedProcessHistoryIDs,
              bool labelRawDataLikeMC,
              bool usingGoToEvent,
@@ -91,13 +91,13 @@ namespace edm {
     bool readCurrentEvent(EventPrincipal& cache);
     void readEvent(EventPrincipal& cache);
 
-    boost::shared_ptr<LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary_();
-    boost::shared_ptr<RunAuxiliary> readRunAuxiliary_();
+    std::shared_ptr<LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary_();
+    std::shared_ptr<RunAuxiliary> readRunAuxiliary_();
     void readRun_(RunPrincipal& runPrincipal);
     void readLuminosityBlock_(LuminosityBlockPrincipal& lumiPrincipal);
     std::string const& file() const {return file_;}
-    boost::shared_ptr<ProductRegistry const> productRegistry() const {return productRegistry_;}
-    boost::shared_ptr<BranchIDListHelper const> branchIDListHelper() const {return branchIDListHelper_;}
+    std::shared_ptr<ProductRegistry const> productRegistry() const {return productRegistry_;}
+    std::shared_ptr<BranchIDListHelper const> branchIDListHelper() const {return branchIDListHelper_;}
     BranchIDLists const& branchIDLists() {return *branchIDLists_;}
     EventAuxiliary const& eventAux() const {return eventAux_;}
     // IndexIntoFile::EntryNumber_t const& entryNumber() const {return indexIntoFileIter().entry();}
@@ -137,7 +137,7 @@ namespace edm {
     bool goToEvent(EventID const& eventID);
     bool nextEventEntry() {return eventTree_.next();}
     IndexIntoFile::EntryType getNextItemType(RunNumber_t& run, LuminosityBlockNumber_t& lumi, EventNumber_t& event);
-    boost::shared_ptr<IndexIntoFile> indexIntoFileSharedPtr() const {
+    std::shared_ptr<IndexIntoFile> indexIntoFileSharedPtr() const {
       return indexIntoFileSharedPtr_;
     }
     bool wasLastEventJustRead() const;
@@ -154,8 +154,8 @@ namespace edm {
     bool fillEventAuxiliary(IndexIntoFile::EntryNumber_t entry);
     void fillThisEventAuxiliary();
     void fillEventHistory();
-    boost::shared_ptr<LuminosityBlockAuxiliary> fillLumiAuxiliary();
-    boost::shared_ptr<RunAuxiliary> fillRunAuxiliary();
+    std::shared_ptr<LuminosityBlockAuxiliary> fillLumiAuxiliary();
+    std::shared_ptr<RunAuxiliary> fillRunAuxiliary();
     void overrideRunNumber(RunID& id);
     void overrideRunNumber(LuminosityBlockID& id);
     void overrideRunNumber(EventID& id, bool isRealData);
@@ -166,21 +166,21 @@ namespace edm {
     void readEventHistoryTree();
     bool isDuplicateEvent();
 
-    void initializeDuplicateChecker(std::vector<boost::shared_ptr<IndexIntoFile> > const& indexesIntoFiles,
-                                    std::vector<boost::shared_ptr<IndexIntoFile> >::size_type currentIndexIntoFile);
+    void initializeDuplicateChecker(std::vector<std::shared_ptr<IndexIntoFile> > const& indexesIntoFiles,
+                                    std::vector<std::shared_ptr<IndexIntoFile> >::size_type currentIndexIntoFile);
 
     std::unique_ptr<MakeProvenanceReader> makeProvenanceReaderMaker(InputType inputType);
-    boost::shared_ptr<ProductProvenanceRetriever> makeProductProvenanceRetriever(unsigned int iStreamIndex);
+    std::shared_ptr<ProductProvenanceRetriever> makeProductProvenanceRetriever(unsigned int iStreamIndex);
 
     std::string const file_;
     std::string const logicalFile_;
     ProcessConfiguration const& processConfiguration_;
     ProcessHistoryRegistry* processHistoryRegistry_;  // We don't own this
-    boost::shared_ptr<InputFile> filePtr_;
-    boost::shared_ptr<EventSkipperByID> eventSkipperByID_;
+    std::shared_ptr<InputFile> filePtr_;
+    std::shared_ptr<EventSkipperByID> eventSkipperByID_;
     FileFormatVersion fileFormatVersion_;
     FileID fid_;
-    boost::shared_ptr<IndexIntoFile> indexIntoFileSharedPtr_;
+    std::shared_ptr<IndexIntoFile> indexIntoFileSharedPtr_;
     IndexIntoFile& indexIntoFile_;
     std::vector<ProcessHistoryID>& orderedProcessHistoryIDs_;
     IndexIntoFile::IndexIntoFileItr indexIntoFileBegin_;
@@ -188,7 +188,7 @@ namespace edm {
     IndexIntoFile::IndexIntoFileItr indexIntoFileIter_;
     std::vector<EventProcessHistoryID> eventProcessHistoryIDs_;  // backward compatibility
     std::vector<EventProcessHistoryID>::const_iterator eventProcessHistoryIter_; // backward compatibility
-    boost::shared_ptr<RunAuxiliary> savedRunAuxiliary_; // backward compatibility
+    std::shared_ptr<RunAuxiliary> savedRunAuxiliary_; // backward compatibility
     bool skipAnyEvents_;
     bool noEventSort_;
     int whyNotFastClonable_;
@@ -200,9 +200,9 @@ namespace edm {
     RootTree runTree_;
     RootTreePtrArray treePointers_;
     IndexIntoFile::EntryNumber_t lastEventEntryNumberRead_;
-    boost::shared_ptr<ProductRegistry const> productRegistry_;
-    boost::shared_ptr<BranchIDLists const> branchIDLists_;
-    boost::shared_ptr<BranchIDListHelper> branchIDListHelper_;
+    std::shared_ptr<ProductRegistry const> productRegistry_;
+    std::shared_ptr<BranchIDLists const> branchIDLists_;
+    std::shared_ptr<BranchIDListHelper> branchIDListHelper_;
     InputSource::ProcessingMode processingMode_;
     int forcedRunOffset_;
     std::map<std::string, std::string> newBranchToOldBranch_;
@@ -210,11 +210,11 @@ namespace edm {
     EventSelectionIDVector eventSelectionIDs_;
     BranchListIndexes branchListIndexes_;
     std::unique_ptr<History> history_; // backward compatibility
-    boost::shared_ptr<BranchChildren> branchChildren_;
-    boost::shared_ptr<DuplicateChecker> duplicateChecker_;
+    std::shared_ptr<BranchChildren> branchChildren_;
+    std::shared_ptr<DuplicateChecker> duplicateChecker_;
     std::unique_ptr<ProvenanceAdaptor> provenanceAdaptor_; // backward comatibility
     std::unique_ptr<MakeProvenanceReader> provenanceReaderMaker_;
-    mutable std::vector<boost::shared_ptr<ProductProvenanceRetriever>> eventProductProvenanceRetrievers_;
+    mutable std::vector<std::shared_ptr<ProductProvenanceRetriever>> eventProductProvenanceRetrievers_;
     std::vector<ParentageID> parentageIDLookup_;
     std::unique_ptr<DaqProvenanceHelper> daqProvenanceHelper_;
   }; // class RootFile

--- a/IOPool/Input/src/RootInputFileSequence.cc
+++ b/IOPool/Input/src/RootInputFileSequence.cc
@@ -194,7 +194,7 @@ namespace edm {
     std::string fallbackName = fileIter_->fallbackFileName();
     bool hasFallbackUrl = !fallbackName.empty() && fallbackName != fileIter_->fileName();
 
-    boost::shared_ptr<InputFile> filePtr;
+    std::shared_ptr<InputFile> filePtr;
     try {
       std::unique_ptr<InputSource::FileOpenSentry>
         sentry(inputType_ == InputType::Primary ? new InputSource::FileOpenSentry(input_, lfn_, usedFallback_) : 0);
@@ -239,7 +239,7 @@ namespace edm {
       }
     }
     if(filePtr) {
-      std::vector<boost::shared_ptr<IndexIntoFile> >::size_type currentIndexIntoFile = fileIter_ - fileIterBegin_;
+      std::vector<std::shared_ptr<IndexIntoFile> >::size_type currentIndexIntoFile = fileIter_ - fileIterBegin_;
       rootFile_ = RootFileSharedPtr(new RootFile(
           fileIter_->fileName(),
           processConfiguration(),
@@ -257,7 +257,7 @@ namespace edm {
           noEventSort_,
           productSelectorRules_,
           inputType_,
-          (inputType_ == InputType::SecondarySource ?  boost::shared_ptr<BranchIDListHelper>(new BranchIDListHelper()) :  input_.branchIDListHelper()),
+          (inputType_ == InputType::SecondarySource ?  std::make_shared<BranchIDListHelper>() :  input_.branchIDListHelper()),
           duplicateChecker_,
           dropDescendants_,
           processHistoryRegistryForUpdate(),
@@ -288,13 +288,13 @@ namespace edm {
     }
   }
 
-  boost::shared_ptr<ProductRegistry const>
+  std::shared_ptr<ProductRegistry const>
   RootInputFileSequence::fileProductRegistry() const {
     assert(rootFile_);
     return rootFile_->productRegistry();
   }
 
-  boost::shared_ptr<BranchIDListHelper const>
+  std::shared_ptr<BranchIDListHelper const>
   RootInputFileSequence::fileBranchIDListHelper() const {
     assert(rootFile_);
     return rootFile_->branchIDListHelper();
@@ -352,13 +352,13 @@ namespace edm {
   RootInputFileSequence::~RootInputFileSequence() {
   }
 
-  boost::shared_ptr<RunAuxiliary>
+  std::shared_ptr<RunAuxiliary>
   RootInputFileSequence::readRunAuxiliary_() {
     assert(rootFile_);
     return rootFile_->readRunAuxiliary_();
   }
 
-  boost::shared_ptr<LuminosityBlockAuxiliary>
+  std::shared_ptr<LuminosityBlockAuxiliary>
   RootInputFileSequence::readLuminosityBlockAuxiliary_() {
     assert(rootFile_);
     return rootFile_->readLuminosityBlockAuxiliary_();
@@ -490,7 +490,7 @@ namespace edm {
       IndexIntoFile::IndexIntoFileItr originalPosition = rootFile_->indexIntoFileIter();
 
       // Look for item (run/lumi/event) in files previously opened without reopening unnecessary files.
-      typedef std::vector<boost::shared_ptr<IndexIntoFile> >::const_iterator Iter;
+      typedef std::vector<std::shared_ptr<IndexIntoFile> >::const_iterator Iter;
       for(Iter it = indexesIntoFiles_.begin(), itEnd = indexesIntoFiles_.end(); it != itEnd; ++it) {
         if(*it && (*it)->containsItem(eventID.run(), eventID.luminosityBlock(), eventID.event())) {
           // We found it. Close the currently open file, and open the correct one.
@@ -530,7 +530,7 @@ namespace edm {
   bool
   RootInputFileSequence::skipToItemInNewFile(RunNumber_t run, LuminosityBlockNumber_t lumi, EventNumber_t event) {
     // Look for item in files not yet opened.
-    typedef std::vector<boost::shared_ptr<IndexIntoFile> >::const_iterator Iter;
+    typedef std::vector<std::shared_ptr<IndexIntoFile> >::const_iterator Iter;
     for(Iter it = indexesIntoFiles_.begin(), itEnd = indexesIntoFiles_.end(); it != itEnd; ++it) {
       if(!*it) {
         fileIter_ = fileIterBegin_ + (it - indexesIntoFiles_.begin());
@@ -556,7 +556,7 @@ namespace edm {
         return false;
       }
       // Look for item (run/lumi/event) in files previously opened without reopening unnecessary files.
-      typedef std::vector<boost::shared_ptr<IndexIntoFile> >::const_iterator Iter;
+      typedef std::vector<std::shared_ptr<IndexIntoFile> >::const_iterator Iter;
       for(Iter it = indexesIntoFiles_.begin(), itEnd = indexesIntoFiles_.end(); it != itEnd; ++it) {
         if(*it && (*it)->containsItem(run, lumi, event)) {
           // We found it. Close the currently open file, and open the correct one.
@@ -608,7 +608,7 @@ namespace edm {
     return input_.productRegistryUpdate();
   }
 
-  boost::shared_ptr<ProductRegistry const>
+  std::shared_ptr<ProductRegistry const>
   RootInputFileSequence::productRegistry() const{
     return input_.productRegistry();
   }

--- a/IOPool/Input/src/RootInputFileSequence.h
+++ b/IOPool/Input/src/RootInputFileSequence.h
@@ -46,11 +46,11 @@ namespace edm {
     RootInputFileSequence(RootInputFileSequence const&) = delete; // Disallow copying and moving
     RootInputFileSequence& operator=(RootInputFileSequence const&) = delete; // Disallow copying and moving
 
-    typedef boost::shared_ptr<RootFile> RootFileSharedPtr;
+    typedef std::shared_ptr<RootFile> RootFileSharedPtr;
     void readEvent(EventPrincipal& cache);
-    boost::shared_ptr<LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary_();
+    std::shared_ptr<LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary_();
     void readLuminosityBlock_(LuminosityBlockPrincipal& lumiPrincipal);
-    boost::shared_ptr<RunAuxiliary> readRunAuxiliary_();
+    std::shared_ptr<RunAuxiliary> readRunAuxiliary_();
     void readRun_(RunPrincipal& runPrincipal);
     std::unique_ptr<FileBlock> readFile_();
     void closeFile_();
@@ -69,8 +69,8 @@ namespace edm {
     void readOneSpecified(EventPrincipal& cache, EventID const& id);
 
     void dropUnwantedBranches_(std::vector<std::string> const& wantedBranches);
-    boost::shared_ptr<ProductRegistry const> fileProductRegistry() const;
-    boost::shared_ptr<BranchIDListHelper const> fileBranchIDListHelper() const;
+    std::shared_ptr<ProductRegistry const> fileProductRegistry() const;
+    std::shared_ptr<BranchIDListHelper const> fileBranchIDListHelper() const;
     ProcessHistoryRegistry const& processHistoryRegistry() const;
     ProcessHistoryRegistry& processHistoryRegistryForUpdate();
     static void fillDescription(ParameterSetDescription & desc);
@@ -83,7 +83,7 @@ namespace edm {
     void rewindFile();
     std::vector<FileCatalogItem> const& fileCatalogItems() const;
 
-    boost::shared_ptr<ProductRegistry const> productRegistry() const;
+    std::shared_ptr<ProductRegistry const> productRegistry() const;
     ProcessConfiguration const& processConfiguration() const;
     ProductRegistry & productRegistryUpdate() const;
     int remainingEvents() const;
@@ -101,11 +101,11 @@ namespace edm {
     RootFileSharedPtr rootFile_;
     BranchDescription::MatchMode branchesMustMatch_;
 
-    std::vector<boost::shared_ptr<IndexIntoFile> > indexesIntoFiles_;
+    std::vector<std::shared_ptr<IndexIntoFile> > indexesIntoFiles_;
     std::vector<ProcessHistoryID> orderedProcessHistoryIDs_;
 
     unsigned int nStreams_; 
-    boost::shared_ptr<EventSkipperByID> eventSkipperByID_;
+    std::shared_ptr<EventSkipperByID> eventSkipperByID_;
     int eventsRemainingInFile_;
     int initialNumberOfEventsToSkip_;
     bool noEventSort_;
@@ -114,7 +114,7 @@ namespace edm {
     int const treeMaxVirtualSize_;
     RunNumber_t setRun_;
     ProductSelectorRules productSelectorRules_;
-    boost::shared_ptr<DuplicateChecker> duplicateChecker_;
+    std::shared_ptr<DuplicateChecker> duplicateChecker_;
     bool dropDescendants_;
     bool labelRawDataLikeMC_;
     bool usingGoToEvent_;

--- a/IOPool/Input/src/RootTree.cc
+++ b/IOPool/Input/src/RootTree.cc
@@ -25,7 +25,7 @@ namespace edm {
       return branch;
     }
   }
-  RootTree::RootTree(boost::shared_ptr<InputFile> filePtr,
+  RootTree::RootTree(std::shared_ptr<InputFile> filePtr,
                      BranchType const& branchType,
                      unsigned int nIndexes,
                      unsigned int maxVirtualSize,

--- a/IOPool/Input/src/RootTree.h
+++ b/IOPool/Input/src/RootTree.h
@@ -60,7 +60,7 @@ namespace edm {
   public:
     typedef roottree::BranchMap BranchMap;
     typedef roottree::EntryNumber EntryNumber;
-    RootTree(boost::shared_ptr<InputFile> filePtr,
+    RootTree(std::shared_ptr<InputFile> filePtr,
              BranchType const& branchType,
              unsigned int nIndexes,
              unsigned int maxVirtualSize,
@@ -155,7 +155,7 @@ namespace edm {
     void startTraining();
     void stopTraining();
 
-    boost::shared_ptr<InputFile> filePtr_;
+    std::shared_ptr<InputFile> filePtr_;
 // We use bare pointers for pointers to some ROOT entities.
 // Root owns them and uses bare pointers internally.
 // Therefore,using smart pointers here will do no good.
@@ -166,17 +166,17 @@ namespace edm {
 // We use a smart pointer to own the TTreeCache.
 // Unfortunately, ROOT owns it when attached to a TFile, but not after it is detached.
 // So, we make sure to it is detached before closing the TFile so there is no double delete.
-    boost::shared_ptr<TTreeCache> treeCache_;
-    boost::shared_ptr<TTreeCache> rawTreeCache_;
-    mutable boost::shared_ptr<TTreeCache> triggerTreeCache_;
-    mutable boost::shared_ptr<TTreeCache> rawTriggerTreeCache_;
+    std::shared_ptr<TTreeCache> treeCache_;
+    std::shared_ptr<TTreeCache> rawTreeCache_;
+    mutable std::shared_ptr<TTreeCache> triggerTreeCache_;
+    mutable std::shared_ptr<TTreeCache> rawTriggerTreeCache_;
     mutable std::unordered_set<TBranch*> trainedSet_;
     mutable std::unordered_set<TBranch*> triggerSet_;
     EntryNumber entries_;
     EntryNumber entryNumber_;
     std::unique_ptr<std::vector<EntryNumber> > entryNumberForIndex_;
     std::vector<std::string> branchNames_;
-    boost::shared_ptr<BranchMap> branches_;
+    std::shared_ptr<BranchMap> branches_;
     bool trainNow_;
     EntryNumber switchOverEntry_;
     mutable EntryNumber rawTriggerSwitchOverEntry_;

--- a/IOPool/Output/interface/PoolOutputModule.h
+++ b/IOPool/Output/interface/PoolOutputModule.h
@@ -13,7 +13,6 @@
 #include <array>
 #include <memory>
 #include <string>
-#include "boost/shared_ptr.hpp"
 
 #include "IOPool/Common/interface/RootServiceChecker.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
@@ -71,7 +70,7 @@ namespace edm {
         explicit Sorter(TTree* tree);
         bool operator() (OutputItem const& lh, OutputItem const& rh) const;
       private:
-        boost::shared_ptr<std::map<std::string, int> > treeMap_;
+        std::shared_ptr<std::map<std::string, int> > treeMap_;
       };
 
       OutputItem();

--- a/IOPool/Output/src/RootOutputFile.h
+++ b/IOPool/Output/src/RootOutputFile.h
@@ -14,7 +14,7 @@
 #include <string>
 #include <vector>
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/MessageLogger/interface/JobReport.h"
@@ -102,7 +102,7 @@ namespace edm {
     PoolOutputModule const* om_;
     int whyNotFastClonable_;
     bool canFastCloneAux_;
-    boost::shared_ptr<TFile> filePtr_;
+    std::shared_ptr<TFile> filePtr_;
     FileID fid_;
     IndexIntoFile::EntryNumber_t eventEntryNumber_;
     IndexIntoFile::EntryNumber_t lumiEntryNumber_;

--- a/IOPool/Output/src/RootOutputTree.cc
+++ b/IOPool/Output/src/RootOutputTree.cc
@@ -25,7 +25,7 @@
 namespace edm {
 
     RootOutputTree::RootOutputTree(
-                   boost::shared_ptr<TFile> filePtr,
+                   std::shared_ptr<TFile> filePtr,
                    BranchType const& branchType,
                    int splitLevel,
                    int treeMaxVirtualSize) :

--- a/IOPool/Output/src/RootOutputTree.h
+++ b/IOPool/Output/src/RootOutputTree.h
@@ -10,7 +10,7 @@ RootOutputTree.h // used by ROOT output modules
 #include <string>
 #include <vector>
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 #include "FWCore/Framework/interface/RunPrincipal.h"
 #include "FWCore/Utilities/interface/BranchType.h"
@@ -24,7 +24,7 @@ namespace edm {
   class WrapperInterfaceBase;
   class RootOutputTree {
   public:
-    RootOutputTree(boost::shared_ptr<TFile> filePtr,
+    RootOutputTree(std::shared_ptr<TFile> filePtr,
                    BranchType const& branchType,
                    int splitLevel,
                    int treeMaxVirtualSize);
@@ -111,7 +111,7 @@ namespace edm {
 // We use bare pointers for pointers to some ROOT entities.
 // Root owns them and uses bare pointers internally.
 // Therefore, using smart pointers here will do no good.
-    boost::shared_ptr<TFile> filePtr_;
+    std::shared_ptr<TFile> filePtr_;
     TTree* tree_;
     std::vector<TBranch*> producedBranches_; // does not include cloned branches
     std::vector<TBranch*> readBranches_;

--- a/IOPool/SecondaryInput/test/SecondaryProducer.cc
+++ b/IOPool/SecondaryInput/test/SecondaryProducer.cc
@@ -170,15 +170,15 @@ namespace edm {
     ++expectedEventNumber_;
   }
 
-  boost::shared_ptr<VectorInputSource> SecondaryProducer::makeSecInput(ParameterSet const& ps) {
+  std::shared_ptr<VectorInputSource> SecondaryProducer::makeSecInput(ParameterSet const& ps) {
     ParameterSet const& sec_input = ps.getParameterSet("input");
     PreallocationConfiguration dummy;
     InputSourceDescription desc(ModuleDescription(),
                                 *productRegistry_,
-				boost::shared_ptr<BranchIDListHelper>(new BranchIDListHelper),
-				boost::shared_ptr<ActivityRegistry>(new ActivityRegistry),
+				std::make_shared<BranchIDListHelper>(),
+				std::make_shared<ActivityRegistry>(),
 				-1, -1, dummy);
-    boost::shared_ptr<VectorInputSource> input_(static_cast<VectorInputSource *>
+    std::shared_ptr<VectorInputSource> input_(static_cast<VectorInputSource *>
       (VectorInputSourceFactory::get()->makeVectorInputSource(sec_input,
       desc).release()));
     return input_;

--- a/IOPool/SecondaryInput/test/SecondaryProducer.h
+++ b/IOPool/SecondaryInput/test/SecondaryProducer.h
@@ -13,8 +13,6 @@
 
 #include <memory>
 
-#include "boost/shared_ptr.hpp"
-
 namespace edm {
   class EventPrincipal;
   class ProcessConfiguration;
@@ -42,11 +40,11 @@ namespace edm {
 
     virtual void endJob();
 
-    boost::shared_ptr<VectorInputSource> makeSecInput(ParameterSet const& ps);
+    std::shared_ptr<VectorInputSource> makeSecInput(ParameterSet const& ps);
 
     std::unique_ptr<ProductRegistry> productRegistry_;
 
-    boost::shared_ptr<VectorInputSource> const secInput_;
+    std::shared_ptr<VectorInputSource> const secInput_;
 
     std::unique_ptr<ProcessConfiguration> processConfiguration_;
 

--- a/IOPool/Streamer/interface/DQMEventMessage.h
+++ b/IOPool/Streamer/interface/DQMEventMessage.h
@@ -40,7 +40,7 @@
 
 #include "IOPool/Streamer/interface/MsgTools.h"
 #include "IOPool/Streamer/interface/MsgHeader.h"
-#include "boost/shared_ptr.hpp"
+#include <memory>
 #include "TObject.h"
 #include <map>
 
@@ -103,7 +103,7 @@ class DQMEventMsgView
   std::string topFolderName() const { return folderName_; }
 
   uint32 subFolderCount() const { return subFolderCount_; }
-  boost::shared_ptr< std::vector<std::string> > subFolderNames() const;
+  std::shared_ptr< std::vector<std::string> > subFolderNames() const;
 
   std::string subFolderName(uint32 const subFolderIndex) const;
   uint32 meCount(std::string const& subFolderName) const;
@@ -121,7 +121,7 @@ class DQMEventMsgView
   uint32 host_name_len_;
   uint32 subFolderCount_;
   std::map<std::string, uint32> subFolderIndexTable_;
-  boost::shared_ptr< std::vector<std::string> > nameListPtr_;
+  std::shared_ptr< std::vector<std::string> > nameListPtr_;
   std::vector<uint32> meCountList_;
 };
 

--- a/IOPool/Streamer/interface/StreamDQMInputFile.h
+++ b/IOPool/Streamer/interface/StreamDQMInputFile.h
@@ -3,7 +3,7 @@
 
 #include "IOPool/Streamer/interface/DQMEventMessage.h"
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 #include<string>
 #include<vector>
@@ -27,7 +27,7 @@
 
     int readDQMEventMessage();
 
-    boost::shared_ptr<DQMEventMsgView> currentEvMsg_;
+    std::shared_ptr<DQMEventMsgView> currentEvMsg_;
     std::auto_ptr<std::ifstream> ist_;
     std::vector<char> eventBuf_;  /** Buffer to store Event Data */
   };

--- a/IOPool/Streamer/interface/StreamDQMOutputFile.h
+++ b/IOPool/Streamer/interface/StreamDQMOutputFile.h
@@ -10,7 +10,7 @@
 
 #include "IOPool/Streamer/interface/StreamerFileIO.h"
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 #include <exception>
 #include <fstream>
@@ -43,7 +43,7 @@ class StreamDQMOutputFile
   private:
      void writeDQMEventHeader(const DQMEventMsgView& inview);
      void writeDQMEventHeader(const DQMEventMsgBuilder& inview);
-     boost::shared_ptr<OutputFile> dqmstreamfile_;
+     std::shared_ptr<OutputFile> dqmstreamfile_;
 };
 
 #endif

--- a/IOPool/Streamer/interface/StreamerFileIO.h
+++ b/IOPool/Streamer/interface/StreamerFileIO.h
@@ -7,7 +7,7 @@ Class representing Output (Streamer) file.
 */
 
 #include "IOPool/Streamer/interface/MsgTools.h"
-#include "boost/shared_ptr.hpp"
+#include <memory>
 #include <iosfwd>
 #include <string>
 
@@ -54,7 +54,7 @@ class OutputFile
      uint32 adlera_;
      uint32 adlerb_;
 
-     boost::shared_ptr<std::ofstream> ost_;
+     std::shared_ptr<std::ofstream> ost_;
      std::string filename_; 
   };
 

--- a/IOPool/Streamer/interface/StreamerInputFile.h
+++ b/IOPool/Streamer/interface/StreamerInputFile.h
@@ -7,7 +7,7 @@
 #include "Utilities/StorageFactory/interface/IOTypes.h"
 #include "Utilities/StorageFactory/interface/Storage.h"
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include<string>
 #include<vector>
@@ -19,11 +19,11 @@ namespace edm {
 
     /**Reads a Streamer file */
     explicit StreamerInputFile(std::string const& name,
-      boost::shared_ptr<EventSkipperByID> eventSkipperByID = boost::shared_ptr<EventSkipperByID>());
+      std::shared_ptr<EventSkipperByID> eventSkipperByID = std::shared_ptr<EventSkipperByID>());
 
     /** Multiple Streamer files */
     explicit StreamerInputFile(std::vector<std::string> const& names,
-      boost::shared_ptr<EventSkipperByID> eventSkipperByID = boost::shared_ptr<EventSkipperByID>());
+      std::shared_ptr<EventSkipperByID> eventSkipperByID = std::shared_ptr<EventSkipperByID>());
 
     ~StreamerInputFile();
 
@@ -56,8 +56,8 @@ namespace edm {
 
     void logFileAction(char const* msg);
 
-    boost::shared_ptr<InitMsgView> startMsg_;
-    boost::shared_ptr<EventMsgView> currentEvMsg_;
+    std::shared_ptr<InitMsgView> startMsg_;
+    std::shared_ptr<EventMsgView> currentEvMsg_;
 
     std::vector<char> headerBuf_; /** Buffer to store file Header */
     std::vector<char> eventBuf_;  /** Buffer to store Event Data */
@@ -68,14 +68,14 @@ namespace edm {
     std::string currentFileName_;
     bool currentFileOpen_;
 
-    boost::shared_ptr<EventSkipperByID> eventSkipperByID_;
+    std::shared_ptr<EventSkipperByID> eventSkipperByID_;
 
     uint32 currRun_;
     uint32 currProto_;
 
     bool newHeader_;
 
-    boost::shared_ptr<Storage> storage_;
+    std::shared_ptr<Storage> storage_;
 
     bool endOfFile_;
   };

--- a/IOPool/Streamer/interface/StreamerOutputFile.h
+++ b/IOPool/Streamer/interface/StreamerOutputFile.h
@@ -12,7 +12,7 @@
 #include "IOPool/Streamer/interface/EventMessage.h"
 
 #include "IOPool/Streamer/interface/StreamerFileIO.h"
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 #include <exception>
 #include <fstream>
@@ -59,7 +59,7 @@ class StreamerOutputFile
      void writeStart(const InitMsgView& inview);
 
   private:
-     boost::shared_ptr<OutputFile> streamerfile_;
+     std::shared_ptr<OutputFile> streamerfile_;
 };
 
 #endif

--- a/IOPool/Streamer/src/DQMEventMessage.cc
+++ b/IOPool/Streamer/src/DQMEventMessage.cc
@@ -111,7 +111,7 @@ DQMEventMsgView::DQMEventMsgView(void* buf):
 /**
  * Returns a shared pointer to the list of subfolder names.
  */
-boost::shared_ptr< std::vector<std::string> >
+std::shared_ptr< std::vector<std::string> >
     DQMEventMsgView::subFolderNames() const
 {
   return nameListPtr_;

--- a/IOPool/Streamer/src/DumpTools.cc
+++ b/IOPool/Streamer/src/DumpTools.cc
@@ -231,7 +231,7 @@ void dumpDQMEventView(const DQMEventMsgView* dview)
   std::cout << "\n>>>>> DQMEvent Message Dump (begin) >>>>>" << std::endl;
   dumpDQMEventHeader(dview);
 
-  boost::shared_ptr< std::vector<std::string> > subFolders =
+  std::shared_ptr< std::vector<std::string> > subFolders =
     dview->subFolderNames();
   for (uint32 idx = 0; idx < subFolders->size(); idx++) {
     std::string name = subFolders->at(idx);

--- a/IOPool/Streamer/src/StreamerFileReader.h
+++ b/IOPool/Streamer/src/StreamerFileReader.h
@@ -3,8 +3,6 @@
 
 #include "IOPool/Streamer/interface/StreamerInputSource.h"
 
-#include "boost/shared_ptr.hpp"
-
 #include <memory>
 #include <string>
 #include <vector>
@@ -37,7 +35,7 @@ namespace edm {
 
     std::vector<std::string> streamerNames_; // names of Streamer files
     std::unique_ptr<StreamerInputFile> streamReader_;
-    boost::shared_ptr<EventSkipperByID> eventSkipperByID_;
+    std::shared_ptr<EventSkipperByID> eventSkipperByID_;
     int initialNumberOfEventsToSkip_;
   };
 } //end-of-namespace-def

--- a/IOPool/Streamer/src/StreamerInputFile.cc
+++ b/IOPool/Streamer/src/StreamerInputFile.cc
@@ -20,7 +20,7 @@ namespace edm {
   }
 
   StreamerInputFile::StreamerInputFile(std::string const& name,
-                                       boost::shared_ptr<EventSkipperByID> eventSkipperByID) :
+                                       std::shared_ptr<EventSkipperByID> eventSkipperByID) :
     startMsg_(),
     currentEvMsg_(),
     headerBuf_(1000*1000),
@@ -41,7 +41,7 @@ namespace edm {
   }
 
   StreamerInputFile::StreamerInputFile(std::vector<std::string> const& names,
-                                       boost::shared_ptr<EventSkipperByID> eventSkipperByID) :
+                                       std::shared_ptr<EventSkipperByID> eventSkipperByID) :
     startMsg_(),
     currentEvMsg_(),
     headerBuf_(1000*1000),

--- a/IOPool/Streamer/src/TestConsumer.cc
+++ b/IOPool/Streamer/src/TestConsumer.cc
@@ -12,7 +12,7 @@ using namespace edm;
 
 namespace edmtest
 {
-  typedef boost::shared_ptr<std::ofstream> OutPtr;
+  typedef std::shared_ptr<std::ofstream> OutPtr;
   typedef std::vector<char> SaveArea;
 
   std::string makeFileName(const std::string& base, int num)

--- a/IOPool/Streamer/src/TestConsumer.h
+++ b/IOPool/Streamer/src/TestConsumer.h
@@ -4,7 +4,7 @@
 #include "IOPool/Streamer/interface/EventBuffer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 namespace edmtest
 {
@@ -23,7 +23,7 @@ namespace edmtest
     void sendRegistry(void* buf, int len);
 
   private:
-    boost::shared_ptr<Worker> worker_;
+    std::shared_ptr<Worker> worker_;
     edm::EventBuffer* bufs_; //does not own the buffer
   };
 }

--- a/IOPool/Streamer/test/ParamSetWalker_t.cpp
+++ b/IOPool/Streamer/test/ParamSetWalker_t.cpp
@@ -1,6 +1,6 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/ParameterSet/interface/ProcessDesc.h"
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 #include <vector>
 #include <map>
@@ -19,7 +19,7 @@ class ParamSetWalker {
     
       ProcessDesc  pdesc(config.c_str()); 
       
-      boost::shared_ptr<ParameterSet> procPset = pdesc.getProcessPSet();
+      std::shared_ptr<ParameterSet> procPset = pdesc.getProcessPSet();
       std::cout<< "Process PSet:" << procPset->toString() << std::endl;           
       
       //std::cout << "Module Label: " << procPset->getParameter<std::string>("@module_label")

--- a/IOPool/TFileAdaptor/src/TFileAdaptor.cc
+++ b/IOPool/TFileAdaptor/src/TFileAdaptor.cc
@@ -15,7 +15,7 @@
 #include <TFile.h>
 #include <TPluginManager.h>
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include <algorithm>
 #include <sstream>

--- a/Mixing/Base/interface/PileUp.h
+++ b/Mixing/Base/interface/PileUp.h
@@ -11,8 +11,6 @@
 #include "FWCore/Framework/interface/EventPrincipal.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#include "boost/shared_ptr.hpp"
-
 #include "TRandom.h"
 #include "TFile.h"
 #include "TH1F.h"
@@ -95,12 +93,12 @@ namespace edm {
     int  intFixed_OOT_;
     int  intFixed_ITPU_;
 
-    boost::shared_ptr<ProductRegistry> productRegistry_;
+    std::shared_ptr<ProductRegistry> productRegistry_;
     std::unique_ptr<VectorInputSource> const input_;
-    boost::shared_ptr<ProcessConfiguration> processConfiguration_;
+    std::shared_ptr<ProcessConfiguration> processConfiguration_;
     std::unique_ptr<EventPrincipal> eventPrincipal_;
-    boost::shared_ptr<LuminosityBlockPrincipal> lumiPrincipal_;
-    boost::shared_ptr<RunPrincipal> runPrincipal_;
+    std::shared_ptr<LuminosityBlockPrincipal> lumiPrincipal_;
+    std::shared_ptr<RunPrincipal> runPrincipal_;
     std::unique_ptr<SecondaryEventProvider> provider_;
     std::vector<std::unique_ptr<CLHEP::RandPoissonQ> > vPoissonDistribution_;
     std::vector<std::unique_ptr<CLHEP::RandPoisson> > vPoissonDistr_OOT_;

--- a/Mixing/Base/src/PileUp.cc
+++ b/Mixing/Base/src/PileUp.cc
@@ -25,9 +25,8 @@
 #include "CLHEP/Random/RandPoissonQ.h"
 #include "CLHEP/Random/RandPoisson.h"
 
-#include "boost/shared_ptr.hpp"
-
 #include <algorithm>
+#include <memory>
 
 namespace edm {
   PileUp::PileUp(ParameterSet const& pset, double averageNumber, TH1F * const histo, const bool playback) :
@@ -44,8 +43,8 @@ namespace edm {
     input_(VectorInputSourceFactory::get()->makeVectorInputSource(pset, InputSourceDescription(
                                                                    ModuleDescription(),
                                                                    *productRegistry_,
-                                                                   boost::shared_ptr<BranchIDListHelper>(new BranchIDListHelper),
-                                                                   boost::shared_ptr<ActivityRegistry>(new ActivityRegistry),
+                                                                   std::make_shared<BranchIDListHelper>(),
+                                                                   std::make_shared<ActivityRegistry>(),
                                                                    -1, -1,
                                                                    PreallocationConfiguration()
                                                                    )).release()),
@@ -178,14 +177,14 @@ namespace edm {
 
   void PileUp::beginRun(const edm::Run& run, const edm::EventSetup& setup) {
     if (provider_.get() != nullptr) {
-      boost::shared_ptr<RunAuxiliary> aux(new RunAuxiliary(run.runAuxiliary()));
+      auto aux = std::make_shared<RunAuxiliary>(run.runAuxiliary());
       runPrincipal_.reset(new RunPrincipal(aux, productRegistry_, *processConfiguration_, nullptr, 0));
       provider_->beginRun(*runPrincipal_, setup, run.moduleCallingContext());
     }
   }
   void PileUp::beginLuminosityBlock(const edm::LuminosityBlock& lumi, const edm::EventSetup& setup) {
     if (provider_.get() != nullptr) {
-      boost::shared_ptr<LuminosityBlockAuxiliary> aux(new LuminosityBlockAuxiliary(lumi.luminosityBlockAuxiliary()));
+      auto aux = std::make_shared<LuminosityBlockAuxiliary>(lumi.luminosityBlockAuxiliary());
       lumiPrincipal_.reset(new LuminosityBlockPrincipal(aux, productRegistry_, *processConfiguration_, nullptr, 0));
       lumiPrincipal_->setRunPrincipal(runPrincipal_);
       provider_->beginLuminosityBlock(*lumiPrincipal_, setup, lumi.moduleCallingContext());

--- a/Mixing/Base/src/SecondaryEventProvider.cc
+++ b/Mixing/Base/src/SecondaryEventProvider.cc
@@ -7,9 +7,9 @@
 namespace edm {
   SecondaryEventProvider::SecondaryEventProvider(std::vector<ParameterSet>& psets,
                      ProductRegistry& preg,
-                     boost::shared_ptr<ProcessConfiguration> processConfiguration) :
+                     std::shared_ptr<ProcessConfiguration> processConfiguration) :
     exceptionToActionTable_(new ExceptionToActionTable),
-    workerManager_(boost::shared_ptr<ActivityRegistry>(new ActivityRegistry), *exceptionToActionTable_) {
+    workerManager_(std::make_shared<ActivityRegistry>(), *exceptionToActionTable_) {
     std::vector<std::string> shouldBeUsedLabels;
     std::set<std::string> unscheduledLabels;
     const PreallocationConfiguration preallocConfig;

--- a/Mixing/Base/src/SecondaryEventProvider.h
+++ b/Mixing/Base/src/SecondaryEventProvider.h
@@ -4,8 +4,6 @@
 #include "FWCore/Framework/interface/WorkerManager.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 
-#include "boost/shared_ptr.hpp"
-
 #include <memory>
 #include <string>
 #include <vector>
@@ -17,7 +15,7 @@ namespace edm {
   public:
     SecondaryEventProvider(std::vector<ParameterSet>& psets,
              ProductRegistry& pregistry,
-             boost::shared_ptr<ProcessConfiguration> processConfiguration);
+             std::shared_ptr<ProcessConfiguration> processConfiguration);
 
     void beginRun(RunPrincipal& run, const edm::EventSetup& setup, ModuleCallingContext const*);
     void beginLuminosityBlock(LuminosityBlockPrincipal& lumi, const edm::EventSetup& setup, ModuleCallingContext const*);

--- a/PhysicsTools/PatExamples/bin/BuildFile.xml
+++ b/PhysicsTools/PatExamples/bin/BuildFile.xml
@@ -1,5 +1,4 @@
 <use   name="root"/>
-<use   name="boost"/>
 <use   name="rootcintex"/>
 <use   name="FWCore/FWLite"/>
 <use   name="DataFormats/FWLite"/>

--- a/PhysicsTools/PatExamples/bin/PatBasicFWLiteJetAnalyzer_Selector.cc
+++ b/PhysicsTools/PatExamples/bin/PatBasicFWLiteJetAnalyzer_Selector.cc
@@ -30,6 +30,7 @@ This example creates a histogram of Jet Pt, using Jets with Pt above 30 and ETA 
 
 
 #include <iostream>
+#include <memory>
 #include <cmath>      //necessary for absolute function fabs()
 
 using namespace std;
@@ -172,8 +173,8 @@ public:
     return false;
   }// end of method
 
-  boost::shared_ptr<JetIDSelectionFunctor> const &   jetSel()     const { return jetSel_;}
-  boost::shared_ptr<PFJetIDSelectionFunctor> const & pfJetSel()   const { return pfJetSel_;}
+  std::shared_ptr<JetIDSelectionFunctor> const &   jetSel()     const { return jetSel_;}
+  std::shared_ptr<PFJetIDSelectionFunctor> const & pfJetSel()   const { return pfJetSel_;}
 
   vector<pat::Jet>            const &   allCaloJets () const { return *h_jets_; }
   vector<pat::Jet>            const &   allPFJets   () const { return *h_pfjets_; }
@@ -197,8 +198,8 @@ public:
 
 
 protected:
-  boost::shared_ptr<JetIDSelectionFunctor>   jetSel_;
-  boost::shared_ptr<PFJetIDSelectionFunctor> pfJetSel_;
+  std::shared_ptr<JetIDSelectionFunctor>   jetSel_;
+  std::shared_ptr<PFJetIDSelectionFunctor> pfJetSel_;
   edm::InputTag                              jetSrc_;
   edm::InputTag                              pfJetSrc_;
   
@@ -249,8 +250,8 @@ int main (int argc, char* argv[])
   cout << "Getting parameters" << endl;
   // Get the python configuration
   PythonProcessDesc builder(argv[1]);
-  boost::shared_ptr<edm::ProcessDesc> b = builder.processDesc();
-  boost::shared_ptr<edm::ParameterSet> parameters = b->getProcessPSet();
+  std::shared_ptr<edm::ProcessDesc> b = builder.processDesc();
+  std::shared_ptr<edm::ParameterSet> parameters = b->getProcessPSet();
   parameters->registerIt(); 
 
   edm::ParameterSet const& jetStudiesParams    = parameters->getParameter<edm::ParameterSet>("jetStudies");

--- a/RecoLocalTracker/SiStripClusterizer/interface/SiStripClusterInfo.h
+++ b/RecoLocalTracker/SiStripClusterizer/interface/SiStripClusterInfo.h
@@ -4,6 +4,7 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
+#include <algorithm>
 #include <numeric>
 
 class SiStripNoises;
@@ -36,8 +37,8 @@ class SiStripClusterInfo {
   std::vector<bool>           stripQualitiesBad() const;
 
   uint16_t charge() const    {return   accumulate( stripCharges().begin(), stripCharges().end(), uint16_t(0));}
-  uint8_t  maxCharge() const {return * max_element(stripCharges().begin(), stripCharges().end());}
-  uint16_t maxIndex() const  {return   max_element(stripCharges().begin(), stripCharges().end()) - stripCharges().begin();}
+  uint8_t  maxCharge() const {return * std::max_element(stripCharges().begin(), stripCharges().end());}
+  uint16_t maxIndex() const  {return   std::max_element(stripCharges().begin(), stripCharges().end()) - stripCharges().begin();}
   std::pair<uint16_t,uint16_t> chargeLR() const;
   
   float noise() const               { return calculate_noise(stripNoises());}

--- a/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
@@ -207,7 +207,7 @@ class SiStripClusterizerFromRaw final : public edm::stream::EDProducer<>  {
     
     std::auto_ptr< edmNew::DetSetVector<SiStripCluster> > 
       output( onDemand ?
-	      new edmNew::DetSetVector<SiStripCluster>(boost::shared_ptr<edmNew::DetSetVector<SiStripCluster>::Getter>(new ClusterFiller(*rawData, *clusterizer_, 
+	      new edmNew::DetSetVector<SiStripCluster>(std::shared_ptr<edmNew::DetSetVector<SiStripCluster>::Getter>(std::make_shared<ClusterFiller>(*rawData, *clusterizer_, 
 																	 *rawAlgos_, doAPVEmulatorCheck_)
 														       ), 
 						       clusterizer_->allDetIds())

--- a/SimCalorimetry/EcalSimAlgos/interface/EcalSignalGenerator.h
+++ b/SimCalorimetry/EcalSimAlgos/interface/EcalSignalGenerator.h
@@ -36,6 +36,7 @@
  */
 
 #include <iostream>
+#include <memory>
 
 namespace edm {
   class ModuleCallingContext;
@@ -146,7 +147,7 @@ public:
     }
     else if(theEventPrincipal)
     {
-       boost::shared_ptr<edm::Wrapper<COLLECTION>  const> digisPTR =
+       std::shared_ptr<edm::Wrapper<COLLECTION>  const> digisPTR =
           edm::getProductByTag<COLLECTION>(*theEventPrincipal, theInputTag, mcc );
        if(digisPTR) {
           digis = digisPTR->product();

--- a/SimCalorimetry/HcalSimAlgos/interface/HcalSignalGenerator.h
+++ b/SimCalorimetry/HcalSimAlgos/interface/HcalSignalGenerator.h
@@ -19,6 +19,7 @@
  */
 
 #include <iostream>
+#include <memory>
 
 namespace edm {
   class ModuleCallingContext;
@@ -75,7 +76,7 @@ public:
     }
     else if(theEventPrincipal)
     {
-       boost::shared_ptr<edm::Wrapper<COLLECTION>  const> digisPTR =
+       std::shared_ptr<edm::Wrapper<COLLECTION>  const> digisPTR =
           edm::getProductByTag<COLLECTION>(*theEventPrincipal, theInputTag, mcc );
        if(digisPTR) {
           digis = digisPTR->product();

--- a/SimDataFormats/CrossingFrame/interface/CrossingFrame.h
+++ b/SimDataFormats/CrossingFrame/interface/CrossingFrame.h
@@ -27,12 +27,12 @@
 template <class T>
 class PCrossingFrame;
 
-#include "boost/shared_ptr.hpp"
 #include <vector>
 #include <string>
 #include <iostream>
 #include <utility>
 #include <algorithm>
+#include <memory>
 
 
 template <class T> 
@@ -66,12 +66,12 @@ class CrossingFrame
 
   // we keep the shared pointer in the object that will be only destroyed at the end of the event (transient object!)
   // because of HepMCProduct, we need 2 versions...
-/*   void setPileupPtr(boost::shared_ptr<edm::Wrapper<std::vector<T> > const> shPtr) {shPtrPileups_=shPtr;} */
-/*   void setPileupPtr(boost::shared_ptr<edm::Wrapper<T> const> shPtr) {shPtrPileups2_=shPtr;} */
-  void setPileupPtr(boost::shared_ptr<edm::Wrapper<std::vector<T> > const> shPtr) {shPtrPileups_.push_back( shPtr );}
-  void setPileupPtr(boost::shared_ptr<edm::Wrapper<T> const> shPtr) {shPtrPileups2_.push_back( shPtr );}
+/*   void setPileupPtr(std::shared_ptr<edm::Wrapper<std::vector<T> > const> shPtr) {shPtrPileups_=shPtr;} */
+/*   void setPileupPtr(std::shared_ptr<edm::Wrapper<T> const> shPtr) {shPtrPileups2_=shPtr;} */
+  void setPileupPtr(std::shared_ptr<edm::Wrapper<std::vector<T> > const> shPtr) {shPtrPileups_.push_back( shPtr );}
+  void setPileupPtr(std::shared_ptr<edm::Wrapper<T> const> shPtr) {shPtrPileups2_.push_back( shPtr );}
   // used in the Step2 to set the PCrossingFrame
-  void setPileupPtr(boost::shared_ptr<edm::Wrapper<PCrossingFrame<T> > const> shPtr);
+  void setPileupPtr(std::shared_ptr<edm::Wrapper<PCrossingFrame<T> > const> shPtr);
   
   void print(int level=0) const ;
 
@@ -159,12 +159,12 @@ class CrossingFrame
 
   //pileup
   std::vector<const T *>  pileups_; 
-  std::vector< boost::shared_ptr<edm::Wrapper<std::vector<T> > const> > shPtrPileups_; 
-  std::vector< boost::shared_ptr<edm::Wrapper<T> const> > shPtrPileups2_;   // fore HepMCProduct
-/*   boost::shared_ptr<edm::Wrapper<std::vector<T> > const> shPtrPileups_;  */
-/*   boost::shared_ptr<edm::Wrapper<T> const> shPtrPileups2_;   // fore HepMCProduct */
-  boost::shared_ptr<edm::Wrapper<PCrossingFrame<T> > const> shPtrPileupsPCF_;
-//  boost::shared_ptr<edm::Wrapper<PCrossingFrame<edm::HepMCProduct> const> shPtrPileupsHepMCProductPCF_;
+  std::vector< std::shared_ptr<edm::Wrapper<std::vector<T> > const> > shPtrPileups_; 
+  std::vector< std::shared_ptr<edm::Wrapper<T> const> > shPtrPileups2_;   // fore HepMCProduct
+/*   std::shared_ptr<edm::Wrapper<std::vector<T> > const> shPtrPileups_;  */
+/*   std::shared_ptr<edm::Wrapper<T> const> shPtrPileups2_;   // fore HepMCProduct */
+  std::shared_ptr<edm::Wrapper<PCrossingFrame<T> > const> shPtrPileupsPCF_;
+//  std::shared_ptr<edm::Wrapper<PCrossingFrame<edm::HepMCProduct> const> shPtrPileupsHepMCProductPCF_;
   
   // these are informations stored in order to be able to have information
   // as a function of the position of an object in the pileups_ vector
@@ -278,7 +278,7 @@ std::ostream &operator<<(std::ostream& o, const CrossingFrame<T>& cf)
 
 #include "SimDataFormats/CrossingFrame/interface/PCrossingFrame.h"
 template <class T>
-void CrossingFrame<T>::setPileupPtr(boost::shared_ptr<edm::Wrapper<PCrossingFrame<T> > const> shPtr) {shPtrPileupsPCF_=shPtr;}
+void CrossingFrame<T>::setPileupPtr(std::shared_ptr<edm::Wrapper<PCrossingFrame<T> > const> shPtr) {shPtrPileupsPCF_=shPtr;}
 
 
 template <class T>

--- a/SimGeneral/DataMixingModule/plugins/DataMixingEMDigiWorker.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingEMDigiWorker.cc
@@ -5,6 +5,7 @@
 //--------------------------------------------
 
 #include <map>
+#include <memory>
 #include <cmath>
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/EDMException.h"
@@ -183,7 +184,7 @@ namespace edm
 
     // EB first
 
-    boost::shared_ptr<Wrapper<EBDigiCollection>  const> EBDigisPTR = 
+    std::shared_ptr<Wrapper<EBDigiCollection>  const> EBDigisPTR = 
       getProductByTag<EBDigiCollection>(*ep, EBPileInputTag_, mcc);
  
    if(EBDigisPTR ) {
@@ -209,7 +210,7 @@ namespace edm
 
     // EE Next
 
-    boost::shared_ptr<Wrapper<EEDigiCollection>  const> EEDigisPTR =
+    std::shared_ptr<Wrapper<EEDigiCollection>  const> EEDigisPTR =
       getProductByTag<EEDigiCollection>(*ep, EEPileInputTag_, mcc);
 
     if(EEDigisPTR ) {
@@ -233,7 +234,7 @@ namespace edm
    }
     // ES Next
 
-    boost::shared_ptr<Wrapper<ESDigiCollection>  const> ESDigisPTR =
+    std::shared_ptr<Wrapper<ESDigiCollection>  const> ESDigisPTR =
       getProductByTag<ESDigiCollection>(*ep, ESPileInputTag_, mcc);
 
     if(ESDigisPTR ) {

--- a/SimGeneral/DataMixingModule/plugins/DataMixingEMWorker.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingEMWorker.cc
@@ -5,6 +5,7 @@
 //--------------------------------------------
 
 #include <map>
+#include <memory>
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Framework/interface/ConstProductRegistry.h"
@@ -173,7 +174,7 @@ namespace edm
 
     // EB first
 
-    boost::shared_ptr<Wrapper<EBRecHitCollection>  const> EBRecHitsPTR =
+    std::shared_ptr<Wrapper<EBRecHitCollection>  const> EBRecHitsPTR =
       getProductByTag<EBRecHitCollection>(*ep, EBPileRecHitInputTag_, mcc);
 
     if(EBRecHitsPTR ) {
@@ -198,7 +199,7 @@ namespace edm
 
     // EE Next
 
-    boost::shared_ptr<Wrapper<EERecHitCollection>  const> EERecHitsPTR =
+    std::shared_ptr<Wrapper<EERecHitCollection>  const> EERecHitsPTR =
       getProductByTag<EERecHitCollection>(*ep, EEPileRecHitInputTag_, mcc);
 
     if(EERecHitsPTR ) {
@@ -223,7 +224,7 @@ namespace edm
 
     // ES Next
 
-    boost::shared_ptr<Wrapper<ESRecHitCollection>  const> ESRecHitsPTR =
+    std::shared_ptr<Wrapper<ESRecHitCollection>  const> ESRecHitsPTR =
       getProductByTag<ESRecHitCollection>(*ep, ESPileRecHitInputTag_, mcc);
 
     if(ESRecHitsPTR ) {

--- a/SimGeneral/DataMixingModule/plugins/DataMixingGeneralTrackWorker.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingGeneralTrackWorker.cc
@@ -5,6 +5,7 @@
 //--------------------------------------------
 
 #include <map>
+#include <memory>
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Framework/interface/ConstProductRegistry.h"
@@ -82,7 +83,7 @@ namespace edm
     LogDebug("DataMixingGeneralTrackWorker") <<"\n===============> adding pileups from event  "<<ep->id()<<" for bunchcrossing "<<bcr;
 
 
-    boost::shared_ptr<Wrapper<reco::TrackCollection >  const> inputPTR =
+    std::shared_ptr<Wrapper<reco::TrackCollection >  const> inputPTR =
       getProductByTag<reco::TrackCollection >(*ep, GeneralTrackPileInputTag_, mcc);
 
     if(inputPTR ) {

--- a/SimGeneral/DataMixingModule/plugins/DataMixingHcalDigiWorker.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingHcalDigiWorker.cc
@@ -5,6 +5,7 @@
 //--------------------------------------------
 
 #include <map>
+#include <memory>
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Framework/interface/ConstProductRegistry.h"
@@ -291,7 +292,7 @@ namespace edm
     // HBHE first
 
 
-    boost::shared_ptr<Wrapper<HBHEDigiCollection>  const> HBHEDigisPTR = 
+    std::shared_ptr<Wrapper<HBHEDigiCollection>  const> HBHEDigisPTR = 
       getProductByTag<HBHEDigiCollection>(*ep, HBHEPileInputTag_, mcc);
  
     if(HBHEDigisPTR ) {
@@ -327,7 +328,7 @@ namespace edm
     //else {std::cout << "NO HBHE Digis!!!!" << std::endl;}
     // HO Next
 
-    boost::shared_ptr<Wrapper<HODigiCollection>  const> HODigisPTR = 
+    std::shared_ptr<Wrapper<HODigiCollection>  const> HODigisPTR = 
       getProductByTag<HODigiCollection>(*ep, HOPileInputTag_, mcc);
  
     if(HODigisPTR ) {
@@ -364,7 +365,7 @@ namespace edm
 
     // HF Next
 
-    boost::shared_ptr<Wrapper<HFDigiCollection>  const> HFDigisPTR = 
+    std::shared_ptr<Wrapper<HFDigiCollection>  const> HFDigisPTR = 
       getProductByTag<HFDigiCollection>(*ep, HFPileInputTag_, mcc);
  
     if(HFDigisPTR ) {
@@ -404,7 +405,7 @@ namespace edm
     if(DoZDC_) {
 
 
-      boost::shared_ptr<Wrapper<ZDCDigiCollection>  const> ZDCDigisPTR = 
+      std::shared_ptr<Wrapper<ZDCDigiCollection>  const> ZDCDigisPTR = 
 	getProductByTag<ZDCDigiCollection>(*ep, ZDCPileInputTag_, mcc);
  
       if(ZDCDigisPTR ) {

--- a/SimGeneral/DataMixingModule/plugins/DataMixingHcalWorker.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingHcalWorker.cc
@@ -5,6 +5,7 @@
 //--------------------------------------------
 
 #include <map>
+#include <memory>
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Framework/interface/ConstProductRegistry.h"
@@ -210,7 +211,7 @@ namespace edm
 
     // HBHE first
 
-    boost::shared_ptr<Wrapper<HBHERecHitCollection>  const> HBHERecHitsPTR =
+    std::shared_ptr<Wrapper<HBHERecHitCollection>  const> HBHERecHitsPTR =
       getProductByTag<HBHERecHitCollection>(*ep, HBHEPileRecHitInputTag_, mcc);
 
     if(HBHERecHitsPTR ) {
@@ -235,7 +236,7 @@ namespace edm
 
     // HO Next
 
-    boost::shared_ptr<Wrapper<HORecHitCollection>  const> HORecHitsPTR =
+    std::shared_ptr<Wrapper<HORecHitCollection>  const> HORecHitsPTR =
       getProductByTag<HORecHitCollection>(*ep, HOPileRecHitInputTag_, mcc);
 
     if(HORecHitsPTR ) {
@@ -260,7 +261,7 @@ namespace edm
 
     // HF Next
 
-    boost::shared_ptr<Wrapper<HFRecHitCollection>  const> HFRecHitsPTR =
+    std::shared_ptr<Wrapper<HFRecHitCollection>  const> HFRecHitsPTR =
       getProductByTag<HFRecHitCollection>(*ep, HFPileRecHitInputTag_, mcc);
 
     if(HFRecHitsPTR ) {
@@ -285,7 +286,7 @@ namespace edm
 
     // ZDC Next
 
-    boost::shared_ptr<Wrapper<ZDCRecHitCollection>  const> ZDCRecHitsPTR =
+    std::shared_ptr<Wrapper<ZDCRecHitCollection>  const> ZDCRecHitsPTR =
       getProductByTag<ZDCRecHitCollection>(*ep, ZDCPileRecHitInputTag_, mcc);
 
     if(ZDCRecHitsPTR ) {

--- a/SimGeneral/DataMixingModule/plugins/DataMixingMuonWorker.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingMuonWorker.cc
@@ -5,6 +5,7 @@
 //--------------------------------------------
 
 #include <map>
+#include <memory>
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Framework/interface/ConstProductRegistry.h"
@@ -244,7 +245,7 @@ namespace edm
     // 
     // Get the digis from the event
 
-   boost::shared_ptr<Wrapper<DTDigiCollection>  const> DTDigisPTR = 
+   std::shared_ptr<Wrapper<DTDigiCollection>  const> DTDigisPTR = 
      getProductByTag<DTDigiCollection>(*ep, DTPileInputTag_, mcc);
  
    if(DTDigisPTR ) {
@@ -270,7 +271,7 @@ namespace edm
     // Get the digis from the event
 
 
-   boost::shared_ptr<Wrapper<RPCDigiCollection>  const> RPCDigisPTR = 
+   std::shared_ptr<Wrapper<RPCDigiCollection>  const> RPCDigisPTR = 
      getProductByTag<RPCDigiCollection>(*ep, RPCPileInputTag_, mcc);
  
    if(RPCDigisPTR ) {
@@ -295,7 +296,7 @@ namespace edm
 
     // Get the digis from the event
 
-   boost::shared_ptr<Wrapper<CSCStripDigiCollection>  const> CSCStripDigisPTR = 
+   std::shared_ptr<Wrapper<CSCStripDigiCollection>  const> CSCStripDigisPTR = 
      getProductByTag<CSCStripDigiCollection>(*ep, CSCStripPileInputTag_, mcc);
  
    if(CSCStripDigisPTR ) {
@@ -326,7 +327,7 @@ namespace edm
 
     // Get the digis from the event
 
-   boost::shared_ptr<Wrapper<CSCWireDigiCollection>  const> CSCWireDigisPTR = 
+   std::shared_ptr<Wrapper<CSCWireDigiCollection>  const> CSCWireDigisPTR = 
      getProductByTag<CSCWireDigiCollection>(*ep, CSCWirePileInputTag_, mcc);
  
    if(CSCWireDigisPTR ) {
@@ -351,7 +352,7 @@ namespace edm
 
    // Get the digis from the event
 
-   boost::shared_ptr<Wrapper<CSCComparatorDigiCollection>  const> CSCComparatorDigisPTR =
+   std::shared_ptr<Wrapper<CSCComparatorDigiCollection>  const> CSCComparatorDigisPTR =
      getProductByTag<CSCComparatorDigiCollection>(*ep, CSCCompPileInputTag_, mcc);
 
    if(CSCComparatorDigisPTR ) {

--- a/SimGeneral/DataMixingModule/plugins/DataMixingPileupCopy.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingPileupCopy.cc
@@ -5,6 +5,7 @@
 //--------------------------------------------
 
 #include <map>
+#include <memory>
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Framework/interface/ConstProductRegistry.h"
@@ -55,7 +56,7 @@ namespace edm
 
     // Pileup info first
 
-    boost::shared_ptr<Wrapper< std::vector<PileupSummaryInfo> >  const> PileupInfoPTR =
+    std::shared_ptr<Wrapper< std::vector<PileupSummaryInfo> >  const> PileupInfoPTR =
       getProductByTag<std::vector<PileupSummaryInfo>>(*ep,PileupInfoInputTag_, mcc);
 
     if(PileupInfoPTR ) {
@@ -68,7 +69,7 @@ namespace edm
 
     // Playback
 
-    boost::shared_ptr<Wrapper<CrossingFramePlaybackInfoExtended>  const> PlaybackPTR =
+    std::shared_ptr<Wrapper<CrossingFramePlaybackInfoExtended>  const> PlaybackPTR =
       getProductByTag<CrossingFramePlaybackInfoExtended>(*ep,CFPlaybackInputTag_, mcc);
 
     FoundPlayback_ = false;

--- a/SimGeneral/DataMixingModule/plugins/DataMixingSiPixelWorker.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingSiPixelWorker.cc
@@ -5,6 +5,7 @@
 //--------------------------------------------
 
 #include <map>
+#include <memory>
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Framework/interface/ConstProductRegistry.h"
@@ -100,7 +101,7 @@ namespace edm
 
     // fill in maps of hits; same code as addSignals, except now applied to the pileup events
 
-    boost::shared_ptr<Wrapper<edm::DetSetVector<PixelDigi> >  const> inputPTR =
+    std::shared_ptr<Wrapper<edm::DetSetVector<PixelDigi> >  const> inputPTR =
       getProductByTag<edm::DetSetVector<PixelDigi> >(*ep, pixeldigi_collectionPile_, mcc);
 
     if(inputPTR ) {

--- a/SimGeneral/DataMixingModule/plugins/DataMixingSiStripMCDigiWorker.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingSiStripMCDigiWorker.cc
@@ -5,6 +5,7 @@
 //--------------------------------------------
 
 #include <map>
+#include <memory>
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Framework/interface/ConstProductRegistry.h"
@@ -155,7 +156,7 @@ namespace edm
 
     // fill in maps of hits; same code as addSignals, except now applied to the pileup events
 
-    boost::shared_ptr<Wrapper<edm::DetSetVector<SiStripDigi> >  const> inputPTR =
+    std::shared_ptr<Wrapper<edm::DetSetVector<SiStripDigi> >  const> inputPTR =
       getProductByTag<edm::DetSetVector<SiStripDigi> >(*ep, SiStripPileInputTag_, mcc);
 
     if(inputPTR ) {

--- a/SimGeneral/DataMixingModule/plugins/DataMixingSiStripRawWorker.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingSiStripRawWorker.cc
@@ -5,6 +5,7 @@
 //--------------------------------------------
 
 #include <map>
+#include <memory>
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Framework/interface/ConstProductRegistry.h"
@@ -90,8 +91,8 @@ namespace edm
     LogDebug("DataMixingSiStripRawWorker") << "\n===============> adding pileups from event  "
 					   << ep->id() << " for bunchcrossing " << bcr;
 
-    boost::shared_ptr<Wrapper<edm::DetSetVector<SiStripDigi> > const>    pSSD;
-    boost::shared_ptr<Wrapper<edm::DetSetVector<SiStripRawDigi> > const> pSSRD;
+    std::shared_ptr<Wrapper<edm::DetSetVector<SiStripDigi> > const>    pSSD;
+    std::shared_ptr<Wrapper<edm::DetSetVector<SiStripRawDigi> > const> pSSRD;
     
     if (SiStripRawDigiSource_=="SIGNAL") {
       pSSD = getProductByTag<edm::DetSetVector<SiStripDigi> >(*ep, SiStripPileInputTag_, mcc);

--- a/SimGeneral/DataMixingModule/plugins/DataMixingSiStripWorker.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingSiStripWorker.cc
@@ -5,6 +5,7 @@
 //--------------------------------------------
 
 #include <map>
+#include <memory>
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Framework/interface/ConstProductRegistry.h"
@@ -92,7 +93,7 @@ namespace edm
 
     // fill in maps of hits; same code as addSignals, except now applied to the pileup events
 
-    boost::shared_ptr<Wrapper<edm::DetSetVector<SiStripDigi> >  const> inputPTR =
+    std::shared_ptr<Wrapper<edm::DetSetVector<SiStripDigi> >  const> inputPTR =
       getProductByTag<edm::DetSetVector<SiStripDigi> >(*ep, SiStripPileInputTag_, mcc);
 
     if(inputPTR ) {

--- a/SimGeneral/MixingModule/plugins/Adjuster.h
+++ b/SimGeneral/MixingModule/plugins/Adjuster.h
@@ -10,8 +10,7 @@
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 #include "SimDataFormats/Vertex/interface/SimVertexContainer.h"
 
-#include "boost/shared_ptr.hpp"
-
+#include <memory>
 #include <vector>
 
 namespace edm {
@@ -58,7 +57,7 @@ namespace edm {
 
   template<typename T>
   void  Adjuster<T>::doOffset(int bunchspace, int bcr, const EventPrincipal &ep, ModuleCallingContext const* mcc, unsigned int eventNr, int vertexOffset) {
-    boost::shared_ptr<Wrapper<std::vector<T> > const> shPtr = getProductByTag<std::vector<T> >(ep, tag_, mcc);
+    std::shared_ptr<Wrapper<std::vector<T> > const> shPtr = getProductByTag<std::vector<T> >(ep, tag_, mcc);
     if (shPtr) {
       std::vector<T>& product = const_cast<std::vector<T>&>(*shPtr->product());
       detail::doTheOffset(bunchspace, bcr, product, eventNr, vertexOffset);

--- a/SimGeneral/MixingModule/plugins/MixingWorker.cc
+++ b/SimGeneral/MixingModule/plugins/MixingWorker.cc
@@ -5,13 +5,13 @@
 #include "SimDataFormats/CrossingFrame/interface/PCrossingFrame.h"
 #include "MixingWorker.h"
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 namespace edm {
   template <>
   void MixingWorker<HepMCProduct>::addPileups(const EventPrincipal& ep, ModuleCallingContext const* mcc, unsigned int eventNr) {
     // HepMCProduct does not come as a vector....
-    boost::shared_ptr<Wrapper<HepMCProduct> const> shPtr = getProductByTag<HepMCProduct>(ep, tag_, mcc);
+    std::shared_ptr<Wrapper<HepMCProduct> const> shPtr = getProductByTag<HepMCProduct>(ep, tag_, mcc);
     if (shPtr) {
       LogDebug("MixingModule") <<"HepMC pileup objects  added, eventNr "<<eventNr << " Tag " << tag_ << std::endl;
       crFrame_->setPileupPtr(shPtr);

--- a/SimGeneral/MixingModule/plugins/MixingWorker.h
+++ b/SimGeneral/MixingModule/plugins/MixingWorker.h
@@ -27,6 +27,7 @@
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 #include "FWCore/Utilities/interface/InputTag.h" 
 
+#include <memory>
 #include <vector>
 #include <string>
 #include <typeinfo>
@@ -152,7 +153,7 @@ namespace edm
 
   template <typename T>
   void  MixingWorker<T>::addPileups(const EventPrincipal &ep, ModuleCallingContext const* mcc, unsigned int eventNr) {
-    boost::shared_ptr<Wrapper<std::vector<T> > const> shPtr = getProductByTag<std::vector<T> >(ep, tag_, mcc);
+    std::shared_ptr<Wrapper<std::vector<T> > const> shPtr = getProductByTag<std::vector<T> >(ep, tag_, mcc);
     if (shPtr) {
       LogDebug("MixingModule") << shPtr->product()->size() << "  pileup objects  added, eventNr " << eventNr;
       crFrame_->setPileupPtr(shPtr);

--- a/SimGeneral/MixingModule/plugins/MixingWorkerBase.cc
+++ b/SimGeneral/MixingModule/plugins/MixingWorkerBase.cc
@@ -12,7 +12,6 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
 #include "MixingWorkerBase.h"
-#include "boost/shared_ptr.hpp"
 
 namespace edm
 {

--- a/SimGeneral/MixingModule/plugins/SecSourceAnalyzer.cc
+++ b/SimGeneral/MixingModule/plugins/SecSourceAnalyzer.cc
@@ -143,7 +143,7 @@ void  SecSourceAnalyzer::getBranches(EventPrincipal const &ep,
         // Get the SimTrack collection
         
 	// default version changed to transmit vertexoffset
-        boost::shared_ptr<Wrapper<std::vector<SimTrack> > const> shPtr =
+        std::shared_ptr<Wrapper<std::vector<SimTrack> > const> shPtr =
           getProductByTag<std::vector<SimTrack> >(ep, tag_, &moduleCallingContext);
     
         if (shPtr) 
@@ -157,7 +157,7 @@ void  SecSourceAnalyzer::getBranches(EventPrincipal const &ep,
     
         // default version changed to transmit vertexoffset
 	tag_ = InputTag("CFwriter","g4SimHits");
-        boost::shared_ptr<Wrapper<PCrossingFrame<SimTrack> > const> shPtr =
+        std::shared_ptr<Wrapper<PCrossingFrame<SimTrack> > const> shPtr =
           getProductByTag<PCrossingFrame<SimTrack> >(ep, tag_, &moduleCallingContext);
         
 	if (shPtr) 

--- a/SimGeneral/MixingModule/plugins/SecSourceAnalyzer.h
+++ b/SimGeneral/MixingModule/plugins/SecSourceAnalyzer.h
@@ -17,8 +17,6 @@
 // system include files
 #include <memory>
 
-#include "boost/shared_ptr.hpp"
-
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
@@ -64,7 +62,7 @@ namespace edm {
       
     std::vector<std::vector<edm::EventID> > vectorEventIDs_;
 
-    boost::shared_ptr<PileUp> input_;
+    std::shared_ptr<PileUp> input_;
     std::vector< float > TrueNumInteractions_[5];
 
     InputTag tag_;


### PR DESCRIPTION
ROOT6 cannot handle boost::shared_ptr due to the assembler code used in boost. Use std::shared_ptr instead. Use also with ROOT5 for commonality.
Most instances in the framework were modified, except for those in the event setup system, none of which are exposed to ROOT.  The changes outside the framework are the necessary adaptation to the framework changes.
Also, std::make_shared<> is used wherever possible, to reduce memory allocations.
