### PR TITLE
Bug fix to an "OR" logic in tau discrimination

### DIFF
--- a/RecoTauTag/RecoTau/src/TauDiscriminationProducerBase.cc
+++ b/RecoTauTag/RecoTau/src/TauDiscriminationProducerBase.cc
@@ -109,7 +109,7 @@ void TauDiscriminationProducerBase<TauType, TauDiscriminator>::produce(edm::Even
       // get reference to tau
       TauRef tauRef(taus, iTau);
 
-      bool passesPrediscriminants = true;
+      bool passesPrediscriminants = ( andPrediscriminants_ ? 1 : 0 );
       // check tau passes prediscriminants
       for( size_t iDisc = 0; iDisc < nPrediscriminants; ++iDisc )
       {


### PR DESCRIPTION
Fix to an initialization of passesPrediscriminants variable to make OR logic working properly. In current implementation True is always when mode with logical OR is selected.
It is an urgent bug fix required for new HLT paths with taus. The OR logic is not used in default reco sequences.

@jpavel
