### PR TITLE
71x cmsShow script: fix warning about missing version.txt

### DIFF
--- a/Fireworks/Core/scripts/cmsShow
+++ b/Fireworks/Core/scripts/cmsShow
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# set -x
+#set -x
 
 checkOS()
 {

--- a/Fireworks/Core/scripts/cmsShow
+++ b/Fireworks/Core/scripts/cmsShow
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#set -x
+# set -x
 
 checkOS()
 {
@@ -112,6 +112,8 @@ setupEnv()
      export PATH=${ROOTSYS}/bin:$PATH
      # move cmsShow.exe to libexec
      SHELLDIR=$SHELLDIR/libexec
+   else
+     export FROM_RELEASE=true
    fi
 }
 


### PR DESCRIPTION
FROM_RELEASE variable was not initalised which caused false warning.
