### PR TITLE
Fix compilation errors

### DIFF
--- a/FWCore/TFWLiteSelectorTest/src/ThingsTSelector2.h
+++ b/FWCore/TFWLiteSelectorTest/src/ThingsTSelector2.h
@@ -34,5 +34,4 @@ private:
     ClassDef(ThingsTSelector2,2)
   };
 }
-template<> atomic_TClass_ptr TFWLiteSelector<tfwliteselectortest::ThingsWorker>::fgIsA;
 #endif

--- a/PhysicsTools/ParallelAnalysis/interface/TrackAnalysisAlgorithm.h
+++ b/PhysicsTools/ParallelAnalysis/interface/TrackAnalysisAlgorithm.h
@@ -37,5 +37,4 @@ namespace examples {
 
 }
 
-template<> atomic_TClass_ptr TFWLiteSelector<examples::TrackAnalysisAlgorithm>::fgIsA;
 #endif


### PR DESCRIPTION
Code ported from 7_2_X broke compilation, probably because atomic_TClass_ptr is not found anywhere in ROOT6.
This fixes the compilation errors.
Please merge promptly.
