### PR TITLE
Removed old Timing plugin declaration

### DIFF
--- a/FWCore/Services/plugins/Module.cc
+++ b/FWCore/Services/plugins/Module.cc
@@ -26,7 +26,6 @@ using edm::service::UnixSignalService;
 using edm::PrintEventSetupDataRetrieval;
 
 DEFINE_FWK_SERVICE(Tracer);
-DEFINE_FWK_SERVICE(Timing);
 DEFINE_FWK_SERVICE(CPU);
 DEFINE_FWK_SERVICE(PrintEventSetupDataRetrieval);
 


### PR DESCRIPTION
In the recent change that added a base class to the Timing Service, the old plugin declaration was not removed. This caused two plugin declarations for the same Service to appear and confuses the PluginManager when attempting to load the requested Service.
