### PR TITLE
clear map before each event is processed in PhotonMCTruthFinder

### DIFF
--- a/RecoEgamma/EgammaMCTools/interface/PhotonMCTruthFinder.h
+++ b/RecoEgamma/EgammaMCTools/interface/PhotonMCTruthFinder.h
@@ -28,6 +28,7 @@ public:
  
  std::vector<PhotonMCTruth> find( const std::vector<SimTrack>& simTracks, const std::vector<SimVertex>& simVertices);  
 
+ void clear() {geantToIndex_.clear();}
      
 
  private:

--- a/Validation/RecoEgamma/plugins/PhotonValidator.cc
+++ b/Validation/RecoEgamma/plugins/PhotonValidator.cc
@@ -1637,7 +1637,7 @@ void  PhotonValidator::endRun (edm::Run& r, edm::EventSetup const & theEventSetu
 
 void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup ) {
 
-
+  thePhotonMCTruthFinder_->clear();
   using namespace edm;
   //  const float etaPhiDistance=0.01;
   // Fiducial region

--- a/Validation/RecoEgamma/plugins/TkConvValidator.cc
+++ b/Validation/RecoEgamma/plugins/TkConvValidator.cc
@@ -809,7 +809,7 @@ void  TkConvValidator::endRun (edm::Run& r, edm::EventSetup const & theEventSetu
 
 
 void TkConvValidator::analyze( const edm::Event& e, const edm::EventSetup& esup ) {
-
+  thePhotonMCTruthFinder_->clear();
   using namespace edm;
   //  const float etaPhiDistance=0.01;
   // Fiducial region


### PR DESCRIPTION
geantToIndex_ variable in PhotonMCTruthFinder seems to keep its entries until deleted. Adding a clear function as PhotonValidator 
