### PR TITLE
CSC DDU IDs fix for post-LS1 configuration

### DIFF
--- a/DQM/CSCMonitorModule/plugins/CSCDQM_EventProcessor_processDDU.cc
+++ b/DQM/CSCMonitorModule/plugins/CSCDQM_EventProcessor_processDDU.cc
@@ -40,7 +40,12 @@ void EventProcessor::processDDU(const CSCDDUEventData& dduData, const CSCDCCExam
 
   if ( (dduID >= FEDNumbering::MINCSCDDUFEDID) && (dduID <= FEDNumbering::MAXCSCDDUFEDID) )   /// New CSC readout without DCCs. CMS CSC DDU ID range 830-869
     {
-      dduID -= (FEDNumbering::MINCSCDDUFEDID - 1); /// TODO: Can require DDU-RUI remapping for actual system
+      // dduID -= (FEDNumbering::MINCSCDDUFEDID - 1); /// TODO: Can require DDU-RUI remapping for actual system
+      dduID = cscdqm::Utility::getRUIfromDDUId(dduHeader.source_id());
+      if (dduID < 0) {
+	   LOG_WARN <<  "DDU source ID (" << dduHeader.source_id() << ") is out of valid range. Remapping to DDU ID 1.";
+	   dduID = 1;
+        }
     }
   else
     {

--- a/DQM/CSCMonitorModule/plugins/CSCDQM_EventProcessor_processExaminer.cc
+++ b/DQM/CSCMonitorModule/plugins/CSCDQM_EventProcessor_processExaminer.cc
@@ -43,7 +43,12 @@ bool EventProcessor::processExaminer(const CSCDCCExaminer& binChecker, const CSC
           int dduID = (*ddu_itr)&0xFF;
           if ( ((*ddu_itr) >= FEDNumbering::MINCSCDDUFEDID) && ((*ddu_itr) <= FEDNumbering::MAXCSCDDUFEDID) )   /// New CSC readout without DCCs. CMS CSC DDU ID range 830-869
             {
-              dduID = (*ddu_itr) - FEDNumbering::MINCSCDDUFEDID + 1; /// TODO: Can require DDU-RUI remapping for actual system
+              // dduID = (*ddu_itr) - FEDNumbering::MINCSCDDUFEDID + 1; /// TODO: Can require DDU-RUI remapping for actual system
+	      dduID = cscdqm::Utility::getRUIfromDDUId((*ddu_itr));
+	      if (dduID < 0) {
+                  LOG_WARN <<  "DDU source ID (" << (*ddu_itr) << ") is out of valid range. Remapping to DDU ID 1.";
+                  dduID = 1;
+                }
             }
           if (errs != 0)
             {

--- a/DQM/CSCMonitorModule/plugins/CSCDQM_Utility.cc
+++ b/DQM/CSCMonitorModule/plugins/CSCDQM_Utility.cc
@@ -357,4 +357,28 @@ namespace cscdqm {
     return sqrt(2.0 * (no * (log(no / ne) - 1) + ne));
   }
 
+  /**
+   * @brief Get RUI Number from DDU source ID for post LS1 configuration
+   * @param ddu_id DDI Source ID
+   */
+  int Utility::getRUIfromDDUId(unsigned ddu_id) {
+    int rui = -1;
+    const unsigned postLS1_map [] = { 841, 842, 843, 844, 845, 846, 847, 848, 849,
+                                     831, 832, 833, 834, 835, 836, 837, 838, 839,
+                                     861, 862, 863, 864, 865, 866, 867, 868, 869,
+                                     851, 852, 853, 854, 855, 856, 857, 858, 859 };
+    if ( (ddu_id >= FEDNumbering::MINCSCDDUFEDID) && (ddu_id <= FEDNumbering::MAXCSCDDUFEDID) )
+      {
+        for ( int i = 0; i < 36; i++)
+        {
+          if (ddu_id == postLS1_map[i]) { rui = i+1; return rui;}
+        }
+      } else {
+        rui = ddu_id & 0xFF;
+      }
+    return rui;
+  }
+
+ 
+
 }

--- a/DQM/CSCMonitorModule/plugins/CSCDQM_Utility.h
+++ b/DQM/CSCMonitorModule/plugins/CSCDQM_Utility.h
@@ -34,6 +34,8 @@
 #include <TString.h>
 #include <TPRegexp.h>
 
+#include "DataFormats/FEDRawData/interface/FEDNumbering.h"
+
 namespace cscdqm {
 
   /**
@@ -89,6 +91,8 @@ namespace cscdqm {
       static bool   checkError(const unsigned int N, const unsigned int n, const double threshold, const double sigfail);
       static double SignificanceLevelLow(const unsigned int N, const unsigned int n, const double eps);
       static double SignificanceLevelHigh(const unsigned int N, const unsigned int n);
+
+      static int getRUIfromDDUId(unsigned ddu_id);
 
   };
 

--- a/EventFilter/CSCRawToDigi/src/CSCDigiToRaw.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCDigiToRaw.cc
@@ -404,13 +404,16 @@ void CSCDigiToRaw::createFedBuffers(const CSCStripDigiCollection& stripDigis,
 
       std::map<int, CSCDDUEventData> dduMap;
       unsigned int ddu_fmt_version = 0x7; /// 2013 Format
+      const unsigned postLS1_map [] = { 841, 842, 843, 844, 845, 846, 847, 848, 849,
+                                     831, 832, 833, 834, 835, 836, 837, 838, 839,
+                                     861, 862, 863, 864, 865, 866, 867, 868, 869,
+                                     851, 852, 853, 854, 855, 856, 857, 858, 859 };
 
 
-      /// Create dummy DDu buffers
-      for (unsigned int iddu=FEDNumbering::MINCSCDDUFEDID;
-	//           iddu<=FEDNumbering::MAXCSCDDUFEDID; ++iddu)   // loop over DDUs
-	  iddu<FEDNumbering::MINCSCDDUFEDID+36; ++iddu)
+      /// Create dummy DDU buffers
+      for (unsigned int i = 0; i < 36; i++)
         {
+	  unsigned int iddu = postLS1_map[i];
           // make a new one
           CSCDDUHeader newDDUHeader(bx,l1a, iddu, ddu_fmt_version);
 
@@ -418,11 +421,10 @@ void CSCDigiToRaw::createFedBuffers(const CSCStripDigiCollection& stripDigis,
         }
 
 
-       // Loop over post-LS1 DDU FEDs
-      for (unsigned int iddu=FEDNumbering::MINCSCDDUFEDID;
-          //  iddu<=FEDNumbering::MAXCSCDDUFEDID; ++iddu)   
-	  iddu<FEDNumbering::MINCSCDDUFEDID+36; ++iddu)
+      /// Loop over post-LS1 DDU FEDs
+      for (unsigned int i = 0; i < 36; i++)
         {
+	  unsigned int iddu = postLS1_map[i];
           // for every chamber with data, add to a DDU in this DCC Event
           for (map<CSCDetId, CSCEventData>::iterator chamberItr = theChamberDataMap.begin();
                chamberItr != theChamberDataMap.end(); ++chamberItr)
@@ -434,15 +436,15 @@ void CSCDigiToRaw::createFedBuffers(const CSCStripDigiCollection& stripDigis,
                 {
 
                   int dduID    = mapping->ddu(chamberItr->first); // try to switch to DDU ID mapping
-                  if ((dduID >= FEDNumbering::MINCSCDDUFEDID) && (dduID <= FEDNumbering::MAXCSCDDUFEDID) ) // DDU ID is in expected FED ID range
+                  if ((dduID >= FEDNumbering::MINCSCDDUFEDID) && (dduID <= FEDNumbering::MAXCSCDDUFEDID) ) // DDU ID is in expectedi post-LS1 FED ID range
                     {
                       indexDDU = dduID;
                     }
                   else // Messy
                     {
-                      // Lets try to change 1-36 ID range to MINCSCDDUFEDID+id range
+                      // Lets try to change pre-LS1 1-36 ID range to post-LS1 MINCSCDDUFEDID - MAXCSCDDUFEDID range
                       dduID &= 0xFF;
-                      if ((dduID <= 36) && (dduID > 0)) indexDDU = FEDNumbering::MINCSCDDUFEDID + dduID-1;
+                      if ((dduID <= 36) && (dduID > 0)) indexDDU = postLS1_map[dduID -1]; // indexDDU = FEDNumbering::MINCSCDDUFEDID + dduID-1;
                     }
 
                 }


### PR DESCRIPTION
CSC DDU IDs fix for post-LS1 configuration (adjusted for expected CSC DDUs IDs mapping for final readout)
- the CSC Packer for post-LS1 data is affected
- the CSC DQM DDU plots for post-LS1 are affected
- the CSC Unpacker is NOT affected 
