### PR TITLE
Trivial Fix for VertexFromTrackProducer

### DIFF
--- a/RecoTauTag/HLTProducers/interface/VertexFromTrackProducer.h
+++ b/RecoTauTag/HLTProducers/interface/VertexFromTrackProducer.h
@@ -52,7 +52,7 @@ public:
   edm::ParameterSet config() const { return theConfig; }
   edm::InputTag trackLabel;
   edm::EDGetTokenT<edm::View<reco::Track> > trackToken;
-  edm::EDGetTokenT<reco::RecoCandidate> candidateToken;
+  edm::EDGetTokenT<edm::View<reco::RecoCandidate> > candidateToken;
   edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> triggerFilterElectronsSrc;
   edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> triggerFilterMuonsSrc;
   edm::EDGetTokenT<edm::View<reco::Vertex> > vertexLabel;

--- a/RecoTauTag/HLTProducers/src/VertexFromTrackProducer.cc
+++ b/RecoTauTag/HLTProducers/src/VertexFromTrackProducer.cc
@@ -32,7 +32,7 @@ VertexFromTrackProducer::VertexFromTrackProducer(const edm::ParameterSet& conf)
   fVerbose = conf.getUntrackedParameter<bool>("verbose", false);
   trackLabel = conf.getParameter<edm::InputTag>("trackLabel");
   trackToken = consumes<edm::View<reco::Track> >(trackLabel);
-  candidateToken = consumes<reco::RecoCandidate>(trackLabel);
+  candidateToken = consumes<edm::View<reco::RecoCandidate> >(trackLabel);
   fIsRecoCandidate = conf.getParameter<bool>("isRecoCandidate");
   fUseBeamSpot = conf.getParameter<bool>("useBeamSpot");
   fUseVertex = conf.getParameter<bool>("useVertex");


### PR DESCRIPTION
This is a trivial fix for a bug introduced during the "consumes migration" of VertexFromTrackProducer.
Basically the bug was affecting the rate reduction power of isolation @ HLT.

Tracks from edm:Vievreco::RecoCandidate > were not properly accessed, preventing from correct generation of vertexes from RecoCandidate tracks.

The net effect in rate reduction for a sample (IsoMu24) path can be summarized as:

Release details / Relative Rate w.r.t. non Iso Path
CMSSW_7_1_0_pre5 (last pre release before the bug was introduced) / relative rate: ~37%
CMSSW_7_1_0_pre9 (before bugfix) / relative rate: ~45%
CMSSW_7_1_0_pre9 (after bugfix) / relative rate: ~37%

@mbluj
