### PR TITLE
Use dynamic loader from CMSSW to load cmsRun

### DIFF
--- a/FWCore/Framework/bin/BuildFile.xml
+++ b/FWCore/Framework/bin/BuildFile.xml
@@ -1,4 +1,4 @@
-<bin   name="cmsRunGlibC" file="cmsRun.cpp">
+<bin   name="cmsRunGlibCImpl" file="cmsRun.cpp">
   <use   name="roothistmatrix"/>
   <use   name="tbb"/>
   <use   name="boost"/>
@@ -12,7 +12,7 @@
   <use   name="FWCore/ParameterSet"/>
   <use   name="FWCore/PythonParameterSet"/>
 </bin>
-<bin   name="cmsRunTC" file="cmsRun.cpp">
+<bin   name="cmsRunTCImpl" file="cmsRun.cpp">
   <use   name="tbb"/>
   <use   name="boost"/>
   <use   name="boost_program_options"/>
@@ -26,7 +26,7 @@
   <use   name="FWCore/ParameterSet"/>
   <use   name="FWCore/PythonParameterSet"/>
 </bin>
-<bin   name="cmsRun" file="cmsRun.cpp">
+<bin   name="cmsRunImpl" file="cmsRun.cpp">
   <use   name="tbb"/>
   <use   name="boost"/>
   <use   name="boost_program_options"/>
@@ -40,7 +40,7 @@
   <use   name="FWCore/ParameterSet"/>
   <use   name="FWCore/PythonParameterSet"/>
 </bin>
-<bin   name="cmsRunVDT" file="cmsRun.cpp">
+<bin   name="cmsRunVDTImpl" file="cmsRun.cpp">
   <use   name="vdt"/>
   <use   name="tbb"/>
   <use   name="boost"/>

--- a/FWCore/Framework/scripts/cmsRun
+++ b/FWCore/Framework/scripts/cmsRun
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+exec ${GLIBC_ROOT}/lib/ld-2.12.2.so --library-path \
+${LD_LIBRARY_PATH}:\
+${GLIBC_ROOT}/lib:\
+/lib64:\
+/usr/lib64 \
+$(which ${0}Impl) "$@"

--- a/FWCore/Framework/scripts/cmsRunGlibC
+++ b/FWCore/Framework/scripts/cmsRunGlibC
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+exec ${GLIBC_ROOT}/lib/ld-2.12.2.so --library-path \
+${LD_LIBRARY_PATH}:\
+${GLIBC_ROOT}/lib:\
+/lib64:\
+/usr/lib64 \
+$(which ${0}Impl) "$@"

--- a/FWCore/Framework/scripts/cmsRunTC
+++ b/FWCore/Framework/scripts/cmsRunTC
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+exec ${GLIBC_ROOT}/lib/ld-2.12.2.so --library-path \
+${LD_LIBRARY_PATH}:\
+${GLIBC_ROOT}/lib:\
+/lib64:\
+/usr/lib64 \
+$(which ${0}Impl) "$@"

--- a/FWCore/Framework/scripts/cmsRunVDT
+++ b/FWCore/Framework/scripts/cmsRunVDT
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+exec ${GLIBC_ROOT}/lib/ld-2.12.2.so --library-path \
+${LD_LIBRARY_PATH}:\
+${GLIBC_ROOT}/lib:\
+/lib64:\
+/usr/lib64 \
+$(which ${0}Impl) "$@"


### PR DESCRIPTION
This uses dynamic loader from CMSDIST glibc package. Package includes
TLS/thread-safety patches.

This is experimental and currently is only available in DEVEL, glibc package is also available in THREADED, but changes in CMSSW were not present. The following adds identical changes as in DEVEL.

`cmsRun*` currently becomes **bash** wrappers, thus be careful if you need to run `valgrind`. `gdb`, or similar.

Alternative and best option is to post-install ELF patch and rewrite `.interp` section of selection executable binaries. You can find the instructions on the HN.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
