### PR TITLE
Add new FED IDs for future uTCA FEDs

### DIFF
--- a/DataFormats/FEDRawData/interface/FEDNumbering.h
+++ b/DataFormats/FEDRawData/interface/FEDNumbering.h
@@ -2,15 +2,15 @@
 #define FEDRawData_FEDNumbering_h
 
 /** \class FEDNumbering
- *  
- *  This class holds the fed numbering scheme for the CMS geometry. 
+ *
+ *  This class holds the fed numbering scheme for the CMS geometry.
  *  No two feds should have the same id. Each subdetector has a reserved range.
  *  Gaps between ranges give flexibility to the numbering.
  *
  *  $Log
  *
  *  \author G. Bruno - CERN, EP Division
- */   
+ */
 
 #include <vector>
 #include <string>
@@ -33,7 +33,7 @@ class FEDNumbering {
 
    enum {
      NOT_A_FEDID = -1,
-     MAXFEDID = 1023, // 10 bits
+     MAXFEDID = 1350, // must be larger than largest used FED id
      MINSiPixelFEDID = 0,
      MAXSiPixelFEDID = 39,
      MINSiStripFEDID = 50,
@@ -95,7 +95,13 @@ class FEDNumbering {
      MINDAQeFEDFEDID = 902,
      MAXDAQeFEDFEDID = 931,
      MINDAQmFEDFEDID = 1023,
-     MAXDAQmFEDFEDID = 1023
+     MAXDAQmFEDFEDID = 1023,
+     MINTCDSuTCAFEDID = 1024,
+     MAXTCDSuTCAFEDID = 1099,
+     MINHCALuTCAFEDID = 1100,
+     MAXHCALuTCAFEDID = 1199,
+     MINSiPixeluTCAFEDID = 1200,
+     MAXSiPixeluTCAFEDID = 1349
    };
  private:
   static std::vector<std::string> from_;

--- a/DataFormats/FEDRawData/src/FEDNumbering.cc
+++ b/DataFormats/FEDRawData/src/FEDNumbering.cc
@@ -10,9 +10,9 @@ using namespace std;
 
 
 bool FEDNumbering::init_ = true;
-bool *FEDNumbering::in_ = new bool[1024];
+bool *FEDNumbering::in_ = new bool[MAXFEDID+1];
 
-vector<string> FEDNumbering::from_(1024,"");
+vector<string> FEDNumbering::from_(MAXFEDID+1,"");
 
 int FEDNumbering::lastFEDId(){
   return MAXFEDID;
@@ -126,32 +126,47 @@ void FEDNumbering::init()
   for(i=MINDAQeFEDFEDID; i<=MAXDAQeFEDFEDID; i++)
     {
       in_[i] = true;
-      from_[i] = "DAQeFED";
+      from_[i] = "DAQ";
     }
   for(i=MINDAQmFEDFEDID; i<=MAXDAQmFEDFEDID; i++)
     {
       in_[i] = true;
-      from_[i] = "DAQmFED";
+      from_[i] = "DAQ";
+    }
+  for(i=MINTCDSuTCAFEDID; i<=MAXTCDSuTCAFEDID; i++)
+    {
+      in_[i] = true;
+      from_[i] = "TCDS";
+    }
+  for(i=MINHCALuTCAFEDID; i<=MAXHCALuTCAFEDID; i++)
+    {
+      in_[i] = true;
+      from_[i] = "Hcal";
+    }
+  for(i=MINSiPixeluTCAFEDID; i<=MAXSiPixeluTCAFEDID; i++)
+    {
+      in_[i] = true;
+      from_[i] = "SiPixel";
     }
 
 
   init_ = false;
 }
 
-bool FEDNumbering::inRange(int i) 
+bool FEDNumbering::inRange(int i)
 {
   if(init_) init();
   return in_[i];
 }
-bool FEDNumbering::inRangeNoGT(int i) 
+bool FEDNumbering::inRangeNoGT(int i)
 {
   if(init_) init();
   if((i>=MINTriggerGTPFEDID && i<=MAXTriggerGTPFEDID) || (i>=MINTriggerEGTPFEDID && i<=MAXTriggerEGTPFEDID)) return false;
   return in_[i];
 }
 
-string const &FEDNumbering::fromDet(int i) 
+string const &FEDNumbering::fromDet(int i)
 {
   if(init_) init();
   return from_[i];
-}  
+}


### PR DESCRIPTION
Add new FED ID ranges for the future uTCA FEDs to be added for/during run 2. Increment the maximum number of FED IDs to accommodate those new ranges. I checked as far as I could that this does not break any existing code in CMSSW 7_X_Y.
