### PR TITLE
prepared to use new conditions DB with cmsDriver flag

### DIFF
--- a/CondCore/CondDB/src/ConnectionPool.cc
+++ b/CondCore/CondDB/src/ConnectionPool.cc
@@ -124,8 +124,6 @@ namespace cond {
           coral::Context::instance().loadComponent( authServiceName, m_pluginManager );
       }
       
-      std::cout << "==> using " << servName << " for auth, sys " << authSys << std::endl;
-      
       coralConfig.setAuthenticationService( authServiceName );
     }
     

--- a/CondCore/CondDB/src/SessionImpl.cc
+++ b/CondCore/CondDB/src/SessionImpl.cc
@@ -5,6 +5,9 @@
 #include "OraDbSchema.h"
 #include "CondCore/DBCommon/interface/DbConnection.h"
 #include "CondCore/DBCommon/interface/DbTransaction.h"
+//-ap: also to be removed when ORA goes:
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+//
 //
 #include "RelationalAccess/ISessionProxy.h"
 #include "RelationalAccess/ITransaction.h"
@@ -71,6 +74,9 @@ namespace cond {
 	  ret = COND_DB;
 	}
       } else {
+	edm::LogWarning("CondDB") << "You are using conditions from the old database via: " 
+				  << connectionString 
+				  << std::endl;
 	ret = ORA_DB;
       }
       oraSession.transaction().commit();

--- a/Configuration/AlCa/python/GlobalTag_newDB.py
+++ b/Configuration/AlCa/python/GlobalTag_newDB.py
@@ -1,0 +1,132 @@
+import FWCore.ParameterSet.Config as cms
+
+def checkPrefix(mainList, inputGTParams):
+    """ Compares two input GTs to see if they have the same prefix. Returns the index in the internal list of GTs of the match
+    or -1 in case of no match. """
+    if inputGTParams.find("_") == -1:
+        raise Exception("Invalid GT name. It does not contain an _, it cannot be used for replacements.")
+    prefix = inputGTParams.split("_")[0]
+    for i in range(0, len(mainList)):
+        if mainList[i].split("_")[0] == prefix:
+            return i
+    return -1
+
+
+from Configuration.AlCa.autoCond_newDB import aliases
+def combineGTs(globaltag):
+    gtList = globaltag.split("+")
+    main = gtList[0]
+    # Alias expansion
+    if main in aliases:
+        main = aliases[main]
+    mainList = main.split("|")
+    # Do any requested replacement
+    if len(gtList) > 1:
+        for gt in gtList[1:]:
+            index = checkPrefix(mainList, gt)
+            if index != -1:
+                mainList[index] = gt
+            else:
+                exceptionString = "Error: replacement of GT "+gt+" not allowed. No matching prefix found in existing GT components. Available components are:\n"
+                for comp in mainList:
+                    exceptionString += comp + "\n"
+                raise Exception(exceptionString)
+        mainGT = mainList[0]
+        if len(mainList) > 1:
+            for mainPart in mainList[1:]:
+                mainGT += mainPart
+        return mainGT
+    else:
+        # Nothing to do, return the input globaltag
+        return main
+    
+
+def GlobalTag(essource = None, globaltag = None, conditions = None):
+    """Modify the GlobalTag module configuration, allowing to use the extended
+    Configuration/AlCa/python/autoCond_newDB.py functionality of specifying symbolic
+    globaltags (i.e., actual global tags, plus additional payloads to get from
+    the DB as customisations).
+    The actual code is taken from cmsDriver's ConfigBuilder.py, adapted here to
+    apply the changes directly to the process object and its module GlobalTag."""
+
+    # custom conditions: 
+    #  - start from an empty map
+    #  - add any conditions coming from autoCond_newDB.py
+    #  - then add and override them with any conditions explicitly requested
+    custom_conditions = {}
+
+    # if no GlobalTag ESSource module is given, load a "default" configuration
+    if essource is None:
+        from Configuration.StandardSequences.FrontierConditions_GlobalTag_newDB_cfi import GlobalTag as essource
+
+    # if a Global Tag is given, check for an "auto" tag, and look it up in autoCond_newDB.py
+    # if a match is found, load the actual Global Tag and optional conditions
+    if globaltag is not None:
+        if globaltag.startswith('auto:'):
+            from Configuration.AlCa.autoCond_newDB import autoCond
+            globaltag = globaltag[5:]
+            if globaltag not in autoCond:
+                raise Exception('no correspondence for '+globaltag+'\navailable keys are\n'+','.join(autoCond.keys()))
+
+            autoKey = autoCond[globaltag]
+            if isinstance(autoKey, tuple) or isinstance(autoKey, list):
+                globaltag = autoKey[0]
+                # TODO backward compatible code: to be removed after migrating autoCond.py to use a map for custom conditions
+                map = {}
+                for entry in autoKey[1:]:
+                  entry = entry.split(',')
+                  record     = entry[1]
+                  label      = len(entry) > 3 and entry[3] or None
+                  tag        = entry[0]
+                  connection = len(entry) > 2 and entry[2] or None
+                  map[ (record, label) ] = (tag, connection)
+                custom_conditions.update( map )
+            else:
+                globaltag = autoKey
+
+        # if a GlobalTag globaltag is given or loaded from autoCond_newDB.py, check for optional connection string and pfn prefix
+        globaltag = globaltag.split(',')
+        if len(globaltag) > 0 :
+            # Perform any alias expansion and consistency check.
+            # We are assuming the same connection and pfnPrefix/Postfix will be used for all GTs.
+            globaltag[0] = combineGTs(globaltag[0])
+            print "globaltag =", globaltag[0]
+            essource.globaltag = cms.string( str(globaltag[0]) )
+        if len(globaltag) > 1:
+            essource.connect   = cms.string( str(globaltag[1]) )
+        if len(globaltag) > 2:
+            essource.pfnPrefix = cms.untracked.string( str(globaltag[2]) )
+
+
+    # add any explicitly requested conditions, possibly overriding those from autoCond_newDB.py
+    if conditions is not None:
+        # TODO backward compatible code: to be removed after migrating ConfigBuilder.py and confdb.py to use a map for custom conditions
+        if isinstance(conditions, basestring): 
+          if conditions:
+            map = {}
+            for entry in conditions.split('+'):
+                entry = entry.split(',')
+                record     = entry[1]
+                label      = len(entry) > 3 and entry[3] or None
+                tag        = entry[0]
+                connection = len(entry) > 2 and entry[2] or None
+                map[ (record, label) ] = (tag, connection)
+            custom_conditions.update( map )
+        elif isinstance(conditions, dict):
+          custom_conditions.update( conditions )
+        else:
+          raise TypeError, "the 'conditions' argument should be either a string or a dictionary"
+
+    # explicit payloads toGet from DB
+    if custom_conditions:
+        for ( (record, label), (tag, connection) ) in custom_conditions.iteritems():
+            payload = cms.PSet()
+            payload.record = cms.string( record )
+            if label:
+                payload.label = cms.untracked.string( label )
+            payload.tag = cms.string( tag )
+            if connection:
+                payload.connect = cms.untracked.string( connection )
+            essource.toGet.append( payload )
+
+    return essource

--- a/Configuration/AlCa/python/autoCond_newDB.py
+++ b/Configuration/AlCa/python/autoCond_newDB.py
@@ -1,0 +1,148 @@
+autoCond = { 
+    # GlobalTag for MC production with perfectly aligned and calibrated detector                                                                                                                              
+    'mc'                :   'MC_71_V6',
+    # GlobalTag for MC production with realistic alignment and calibrations
+    'startup'           :   'START71_V5',
+    # GlobalTag for MC production of Heavy Ions events with realistic alignment and calibrations
+    'starthi'           :   'STARTHI71_V9',
+    # GlobalTag for MC production of p-Pb events with realistic alignment and calibrations
+    'startpa'           :   'STARTHI71_V10',
+    # GlobalTag for data reprocessing: this should always be the GR_R tag
+    'com10'             :   'GR_R_71_V4',
+    # GlobalTag for running HLT on recent data: this should be the GR_P (prompt reco) global tag until a compatible GR_H tag is available, 
+    # then it should point to the GR_H tag and override the connection string and pfnPrefix for use offline
+    'hltonline'         :   'GR_H_V37,frontier://FrontierProd/CMS_CONDITIONS,frontier://FrontierProd/',
+    # GlobalTag for POSTLS1 upgrade studies:
+    'upgradePLS1'       :   'POSTLS171_V11',
+    'upgradePLS150ns'   :   'POSTLS171_V12',
+    'upgrade2017'       :   'DES17_70_V2', # placeholder (GT not meant for standard RelVal)
+    'upgrade2019'       :   'DES19_70_V2', # placeholder (GT not meant for standard RelVal)
+    'upgradePLS3'       :   'POSTLS262_V1', # placeholder (GT not meant for standard RelVal)
+
+    ### NEW KEYS ###
+    # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
+    'run1_design'       :   'MC_71_V6',
+    # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
+    'run1_mc'           :   'START71_V5',
+    # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
+    'run1_mc_hi'        :   'STARTHI71_V9',
+    # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
+    'run1_mc_pPb'       :   'STARTHI71_V10',
+    # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
+    'run2_design'       :   'DESIGN71_V3',
+    # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
+    'run2_mc_50ns'      :   'POSTLS171_V12',
+    #GlobalTag for MC production with optimistic alignment and calibrations for Run2
+    'run2_mc'           :   'POSTLS171_V11',
+    # GlobalTag for Run1 data reprocessing
+    'run1_data'         :   'GR_R_71_V4',
+    # GlobalTag for Run2 data reprocessing
+    'run2_data'         :   'GR_R_71_V4',
+    # GlobalTag for Run2 HLT: it points to the online GT and overrides the connection string and pfnPrefix for use offline
+    'run2_hlt'          :   'GR_H_V37,frontier://FrontierProd/CMS_CONDITIONS,frontier://FrontierProd/',
+    # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
+    'phase1_2017_design' :  'DES17_70_V2', # placeholder (GT not meant for standard RelVal)
+    # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
+    'phase1_2019_design' :  'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
+    # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase2
+    'phase2_design'     :   'POSTLS262_V1', # placeholder (GT not meant for standard RelVal)
+}
+
+aliases = {
+    'MAINGT' : 'FT_P_V42D|AN_V4',
+    'BASEGT' : 'BASE1_V1|BASE2_V1'
+}
+
+# L1 configuration used during Run2012D
+conditions_L1_Run2012D = (
+    # L1 GT menu 2012 v3, used during Run2012D
+    'L1GtTriggerMenu_L1Menu_Collisions2012_v3_mc,L1GtTriggerMenuRcd,frontier://FrontierProd/CMS_COND_31X_L1T',
+    # L1 GCT configuration with 5 GeV jet seed threshold, used since Run2012C
+    'L1GctJetFinderParams_GCTPhysics_2012_04_27_JetSeedThresh5GeV_mc,L1GctJetFinderParamsRcd,frontier://FrontierProd/CMS_COND_31X_L1T',
+    'L1HfRingEtScale_GCTPhysics_2012_04_27_JetSeedThresh5GeV_mc,L1HfRingEtScaleRcd,frontier://FrontierProd/CMS_COND_31X_L1T',
+    'L1HtMissScale_GCTPhysics_2012_04_27_JetSeedThresh5GeV_mc,L1HtMissScaleRcd,frontier://FrontierProd/CMS_COND_31X_L1T',
+    'L1JetEtScale_GCTPhysics_2012_04_27_JetSeedThresh5GeV_mc,L1JetEtScaleRcd,frontier://FrontierProd/CMS_COND_31X_L1T',
+    # L1 CSCTF configuration used since Run2012B
+    'L1MuCSCPtLut_key-11_mc,L1MuCSCPtLutRcd,frontier://FrontierProd/CMS_COND_31X_L1T',
+    # L1 DTTF settings used since Run2012C
+    'L1MuDTTFParameters_dttf12_TSC_03_csc_col_mc,L1MuDTTFParametersRcd,frontier://FrontierProd/CMS_COND_31X_L1T',
+)
+
+# L1 configuration used during HIRun2011
+conditions_L1_HIRun2011 = (
+    # L1 heavy ions menu 2011 v0
+    'L1GtTriggerMenu_L1Menu_CollisionsHeavyIons2011_v0_mc,L1GtTriggerMenuRcd,frontier://FrontierProd/CMS_COND_31X_L1T',
+)
+
+# L1 configuration used during PARun2013
+conditions_L1_PARun2013 = (
+    # L1 GT menu HI 2013 v0, used for the p-Pb run 2013
+    'L1GtTriggerMenu_L1Menu_CollisionsHeavyIons2013_v0_mc,L1GtTriggerMenuRcd,frontier://FrontierProd/CMS_COND_31X_L1T',
+    # L1 GCT configuration without jet seed threshold (same as 2012B)
+    'L1GctJetFinderParams_GCTPhysics_2011_09_01_B_mc,L1GctJetFinderParamsRcd,frontier://FrontierProd/CMS_COND_31X_L1T',
+    'L1HfRingEtScale_GCTPhysics_2011_09_01_B_mc,L1HfRingEtScaleRcd,frontier://FrontierProd/CMS_COND_31X_L1T',
+    'L1HtMissScale_GCTPhysics_2011_09_01_B_mc,L1HtMissScaleRcd,frontier://FrontierProd/CMS_COND_31X_L1T',
+    'L1JetEtScale_GCTPhysics_2011_09_01_B_mc,L1JetEtScaleRcd,frontier://FrontierProd/CMS_COND_31X_L1T',
+    # L1 CSCTF configuration used since Run2012B
+    'L1MuCSCPtLut_key-11_mc,L1MuCSCPtLutRcd,frontier://FrontierProd/CMS_COND_31X_L1T',
+    # L1 DTTF settings used since Run2012C
+    'L1MuDTTFParameters_dttf12_TSC_03_csc_col_mc,L1MuDTTFParametersRcd,frontier://FrontierProd/CMS_COND_31X_L1T',
+)
+
+# HLT Jet Energy Corrections
+conditions_HLT_JECs = (
+    # HLT 2012 jet energy corrections
+    'JetCorrectorParametersCollection_Jec11_V12_AK5CaloHLT,JetCorrectionsRecord,frontier://FrontierProd/CMS_COND_31X_PHYSICSTOOLS,AK5CaloHLT',
+    'JetCorrectorParametersCollection_AK5PF_2012_V8_hlt_mc,JetCorrectionsRecord,frontier://FrontierProd/CMS_COND_31X_PHYSICSTOOLS,AK5PFHLT',
+    'JetCorrectorParametersCollection_AK5PFchs_2012_V8_hlt_mc,JetCorrectionsRecord,frontier://FrontierProd/CMS_COND_31X_PHYSICSTOOLS,AK5PFchsHLT',
+)
+
+
+# dedicated GlobalTags for MC production with the frozen HLT menus
+autoCond['startup_8E33v2']   = ( autoCond['startup'], ) \
+                             + conditions_L1_Run2012D
+
+autoCond['startup_2013']     = ( autoCond['startup'], ) \
+                             + conditions_L1_Run2012D
+
+autoCond['startup_GRun']     = ( autoCond['startup'], ) \
+                             + conditions_L1_Run2012D
+
+autoCond['starthi_HIon']     = ( autoCond['starthi'], ) \
+                             + conditions_L1_HIRun2011 \
+                             + conditions_HLT_JECs
+
+autoCond['startup_PIon']     = ( autoCond['startpa'], ) \
+                             + conditions_L1_PARun2013
+
+# dedicated GlobalTags for running the frozen HLT menus on data
+autoCond['hltonline_8E33v2'] = ( autoCond['hltonline'], ) \
+                             + conditions_L1_Run2012D
+
+autoCond['hltonline_2013']   = ( autoCond['hltonline'], ) \
+                             + conditions_L1_Run2012D
+
+autoCond['hltonline_GRun']   = ( autoCond['hltonline'], ) \
+                             + conditions_L1_Run2012D
+
+autoCond['hltonline_HIon']   = ( autoCond['hltonline'], ) \
+                             + conditions_L1_HIRun2011
+
+autoCond['hltonline_PIon']   = ( autoCond['hltonline'], ) \
+                             + conditions_L1_PARun2013
+
+# dedicated GlobalTags for running RECO and the frozen HLT menus on data
+autoCond['com10_8E33v2']     = ( autoCond['com10'], ) \
+                             + conditions_L1_Run2012D
+
+autoCond['com10_2013']       = ( autoCond['com10'], ) \
+                             + conditions_L1_Run2012D
+
+autoCond['com10_GRun']       = ( autoCond['com10'], ) \
+                             + conditions_L1_Run2012D
+
+autoCond['com10_HIon']       = ( autoCond['com10'], ) \
+                             + conditions_L1_HIRun2011
+
+autoCond['com10_PIon']       = ( autoCond['com10'], ) \
+                             + conditions_L1_PARun2013

--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -23,6 +23,7 @@ defaultOptions.geometry = 'SimDB'
 defaultOptions.geometryExtendedOptions = ['ExtendedGFlash','Extended','NoCastor']
 defaultOptions.magField = '38T'
 defaultOptions.conditions = None
+defaultOptions.useNewDB = False
 defaultOptions.scenarioOptions=['pp','cosmics','nocoll','HeavyIons']
 defaultOptions.harvesting= 'AtRunEnd'
 defaultOptions.gflash = False
@@ -740,9 +741,18 @@ class ConfigBuilder(object):
 						
         self.loadAndRemember(self.ConditionsDefaultCFF)
 
-        from Configuration.AlCa.GlobalTag import GlobalTag
+	if self._options.useNewDB:
+		from Configuration.AlCa.GlobalTag_newDB import GlobalTag
+	else:
+		from Configuration.AlCa.GlobalTag import GlobalTag
+
         self.process.GlobalTag = GlobalTag(self.process.GlobalTag, self._options.conditions, self._options.custom_conditions)
-        self.additionalCommands.append('from Configuration.AlCa.GlobalTag import GlobalTag')
+
+	if self._options.useNewDB:
+	        self.additionalCommands.append('from Configuration.AlCa.GlobalTag_newDB import GlobalTag')
+	else:
+	        self.additionalCommands.append('from Configuration.AlCa.GlobalTag import GlobalTag')
+
         self.additionalCommands.append('process.GlobalTag = GlobalTag(process.GlobalTag, %s, %s)' % (repr(self._options.conditions), repr(self._options.custom_conditions)))
 
 	if self._options.slhc:
@@ -864,7 +874,10 @@ class ConfigBuilder(object):
         self.HARVESTINGDefaultCFF="Configuration/StandardSequences/Harvesting_cff"
         self.ALCAHARVESTDefaultCFF="Configuration/StandardSequences/AlCaHarvesting_cff"
         self.ENDJOBDefaultCFF="Configuration/StandardSequences/EndOfProcess_cff"
-        self.ConditionsDefaultCFF = "Configuration/StandardSequences/FrontierConditions_GlobalTag_cff"
+        if self._options.useNewDB:
+           self.ConditionsDefaultCFF = "Configuration/StandardSequences/FrontierConditions_GlobalTag_newDB_cff"
+	else:
+	    self.ConditionsDefaultCFF = "Configuration/StandardSequences/FrontierConditions_GlobalTag_cff"
         self.CFWRITERDefaultCFF = "Configuration/StandardSequences/CrossingFrameWriter_cff"
         self.REPACKDefaultCFF="Configuration/StandardSequences/DigiToRaw_Repack_cff"
 

--- a/Configuration/Applications/python/Options.py
+++ b/Configuration/Applications/python/Options.py
@@ -34,6 +34,12 @@ parser.add_option("--conditions",
                   default=None,
                   dest="conditions")
 
+parser.add_option("--useNewDB",
+                  help="use new DB (with blobified payloads)",
+                  action="store_true",
+                  default=False,
+                  dest="useNewDB")
+
 parser.add_option("--eventcontent",
                   help="What event content to write out. Default=FEVTDEBUG, or FEVT (for cosmics)",
                   default='RECOSIM',

--- a/Configuration/StandardSequences/python/FrontierConditions_GlobalTag_newDB_cff.py
+++ b/Configuration/StandardSequences/python/FrontierConditions_GlobalTag_newDB_cff.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.StandardSequences.FrontierConditions_GlobalTag_newDB_cfi import *
+
+# the following are needed for non PoolDBESSources
+from CalibCalorimetry.EcalLaserCorrection.ecalLaserCorrectionService_cfi import *
+from CalibCalorimetry.HcalPlugins.Hcal_Conditions_forGlobalTag_cff import *
+from CalibTracker.Configuration.Tracker_DependentRecords_forGlobalTag_nofakes_cff import *
+# FIXME: should be moved to a cfi in a castor package
+CastorDbProducer = cms.ESProducer("CastorDbProducer")

--- a/Configuration/StandardSequences/python/FrontierConditions_GlobalTag_newDB_cfi.py
+++ b/Configuration/StandardSequences/python/FrontierConditions_GlobalTag_newDB_cfi.py
@@ -1,0 +1,12 @@
+import FWCore.ParameterSet.Config as cms
+
+from CondCore.DBCommon.CondDBSetup_cfi import *
+
+print '# Conditions read from new DB via FrontierProd '
+
+GlobalTag = cms.ESSource("PoolDBESSource",
+    CondDBSetup,
+    connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
+    globaltag = cms.string('UNSPECIFIED'),
+    toGet = cms.VPSet( ),   # hook to override or add single payloads
+)


### PR DESCRIPTION
Use new conditions DB via --useNewDB flag for cmsDriver:

```
added new files with *_newDB names to be used when new conditions DB should be selected:
 - Configuration/AlCa/python/GlobalTag_newDB.py
 - Configuration/AlCa/python/autoCond_newDB.py
 - Configuration/StandardSequences/python/FrontierConditions_GlobalTag_newDB_cff.py
 - Configuration/StandardSequences/python/FrontierConditions_GlobalTag_newDB_cfi.py

added new option "--useNewDB" flag for cmsDriver and modified ConfigBuilder to inlcude
the corresponding new files as needed.
```
