### PR TITLE
explicitly convert Time_t to RunNumber to avoid compiler warning

### DIFF
--- a/Alignment/MillePedeAlignmentAlgorithm/src/PedeLabelerBase.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/PedeLabelerBase.cc
@@ -24,8 +24,8 @@ const unsigned int PedeLabelerBase::theMinLabel = 1; // must be > 0
 
 PedeLabelerBase::PedeLabelerBase(const TopLevelAlignables &alignables,
 				 const edm::ParameterSet &config)
-  :theOpenRunRange(std::make_pair<RunNumber,RunNumber>(cond::timeTypeSpecs[cond::runnumber].beginValue,
-						       cond::timeTypeSpecs[cond::runnumber].endValue))
+  :theOpenRunRange(std::make_pair<RunNumber,RunNumber>( RunNumber( cond::timeTypeSpecs[cond::runnumber].beginValue) ,  // since we know we have a runnumber here, we can
+						        RunNumber( cond::timeTypeSpecs[cond::runnumber].endValue  ) )) // simply convert the Time_t to make the compiler happy
 {
   
 }


### PR DESCRIPTION
explicitly convert Time_t to RunNumber for run numbers when creating a pair to make the compiler happy. 
