### PR TITLE
Use conditions DB v2 (72x)

### DIFF
--- a/CondCore/CSCPlugins/src/plugin.cc
+++ b/CondCore/CSCPlugins/src/plugin.cc
@@ -59,18 +59,26 @@
 //
 #include "CondCore/CondDB/interface/Serialization.h"
 
-namespace cond {
-  template <> CSCReadoutMapping* createPayload<CSCReadoutMapping>( const std::string& payloadTypeName ){
-    if( payloadTypeName == "CSCReadoutMappingFromFile" ) return new CSCReadoutMappingFromFile;
-    throwException(std::string("Type mismatch, target object is type \"")+payloadTypeName+"\"",
-		   "createPayload" );
-  }
-  template <> CSCReadoutMappingForSliceTest* createPayload<CSCReadoutMappingForSliceTest>( const std::string& payloadTypeName ){
-    if( payloadTypeName == "CSCReadoutMappingFromFile" ) return new CSCReadoutMappingFromFile;
-    throwException(std::string("Type mismatch, target object is type \"")+payloadTypeName+"\"",
-		   "createPayload" );
-  }
 
+namespace cond {
+  template <> boost::shared_ptr<CSCReadoutMapping> deserialize<CSCReadoutMapping>( const std::string& payloadType,
+                                                                                     const Binary& payloadData,
+                                                                                     const Binary& streamerInfoData,
+                                                                                     bool unpackingOnly ){
+    // DESERIALIZE_BASE_CASE( CSCReadoutMapping ); abstract
+    DESERIALIZE_POLIMORPHIC_CASE( CSCReadoutMapping, CSCReadoutMappingFromFile );
+    // here we come if none of the deserializations above match the payload type:
+    throwException(std::string("Type mismatch, target object is type \"")+payloadType+"\"", "deserialize<>" );
+  }
+  template <> boost::shared_ptr<CSCReadoutMappingForSliceTest> deserialize<CSCReadoutMappingForSliceTest>( const std::string& payloadType,
+                                                                                     const Binary& payloadData,
+                                                                                     const Binary& streamerInfoData,
+                                                                                     bool unpackingOnly ){
+    // DESERIALIZE_BASE_CASE( CSCReadoutMappingForSliceTest ); abstract
+    DESERIALIZE_POLIMORPHIC_CASE( CSCReadoutMappingForSliceTest, CSCReadoutMappingFromFile );
+    // here we come if none of the deserializations above match the payload type:
+    throwException(std::string("Type mismatch, target object is type \"")+payloadType+"\"", "deserialize<>" );
+  }
 }
 
 

--- a/CondCore/CalibPlugins/src/plugin.cc
+++ b/CondCore/CalibPlugins/src/plugin.cc
@@ -13,7 +13,6 @@
 #include "CondFormats/Calibration/interface/mySiStripNoises.h"
 #include "CondFormats/DataRecord/interface/mySiStripNoisesRcd.h"
 #include "CondFormats/Calibration/interface/Efficiency.h"
-#include "CondFormats/Calibration/interface/EfficiencyPayloads.h"
 #include "CondFormats/DataRecord/interface/ExEfficiency.h"
 #include "CondFormats/Common/interface/BaseKeyed.h"
 #include "CondCore/CondDB/interface/KeyListProxy.h"
@@ -21,15 +20,36 @@
 //
 #include "CondCore/CondDB/interface/Serialization.h"
 
-namespace cond {
 
-  template <> BaseKeyed* createPayload<BaseKeyed>( const std::string& payloadTypeName ){
-    if( payloadTypeName == "condex::ConfI" ) return new condex::ConfI;
-    if( payloadTypeName == "condex::ConfF" ) return new condex::ConfF;
-    throwException(std::string("Type mismatch, target object is type \"")+payloadTypeName+"\"",
-		   "createPayload" );
+namespace cond {
+  template <> boost::shared_ptr<condex::Efficiency> deserialize<condex::Efficiency>( const std::string& payloadType,
+                                                                                     const Binary& payloadData,
+                                                                                     const Binary& streamerInfoData,
+                                                                                     bool unpackingOnly ){
+    // DESERIALIZE_BASE_CASE( condex::Efficiency ); abstract 
+    DESERIALIZE_POLIMORPHIC_CASE( condex::Efficiency, condex::ParametricEfficiencyInPt );
+    DESERIALIZE_POLIMORPHIC_CASE( condex::Efficiency, condex::ParametricEfficiencyInEta );
+
+    // here we come if none of the deserializations above match the payload type:
+    throwException(std::string("Type mismatch, target object is type \"")+payloadType+"\"", "deserialize<>" );
   }
 }
+
+
+namespace cond {
+  template <> boost::shared_ptr<BaseKeyed> deserialize<BaseKeyed>( const std::string& payloadType,
+						 const Binary& payloadData,
+						 const Binary& streamerInfoData,
+						 bool unpackingOnly ){
+    DESERIALIZE_BASE_CASE( BaseKeyed );
+    DESERIALIZE_POLIMORPHIC_CASE( BaseKeyed, condex::ConfI );
+    DESERIALIZE_POLIMORPHIC_CASE( BaseKeyed, condex::ConfI );
+
+    // here we come if none of the deserializations above match the payload type:                                                                                                                                                                                             
+    throwException(std::string("Type mismatch, target object is type \"")+payloadType+"\"", "deserialize<>" );
+  }
+}
+
 
 namespace {
   struct InitEfficiency {void operator()(condex::Efficiency& e){ e.initialize();}};

--- a/CondCore/CondDB/src/ConnectionPool.cc
+++ b/CondCore/CondDB/src/ConnectionPool.cc
@@ -124,8 +124,6 @@ namespace cond {
           coral::Context::instance().loadComponent( authServiceName, m_pluginManager );
       }
       
-      std::cout << "==> using " << servName << " for auth, sys " << authSys << std::endl;
-      
       coralConfig.setAuthenticationService( authServiceName );
     }
     

--- a/CondCore/CondDB/src/SessionImpl.cc
+++ b/CondCore/CondDB/src/SessionImpl.cc
@@ -5,6 +5,9 @@
 #include "OraDbSchema.h"
 #include "CondCore/DBCommon/interface/DbConnection.h"
 #include "CondCore/DBCommon/interface/DbTransaction.h"
+//-ap: also to be removed when ORA goes:
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+//
 //
 #include "RelationalAccess/ISessionProxy.h"
 #include "RelationalAccess/ITransaction.h"
@@ -71,6 +74,9 @@ namespace cond {
 	  ret = COND_DB;
 	}
       } else {
+	edm::LogWarning("CondDB") << "You are using conditions from the old database via: " 
+				  << connectionString 
+				  << std::endl;
 	ret = ORA_DB;
       }
       oraSession.transaction().commit();

--- a/CondCore/DTPlugins/src/plugin.cc
+++ b/CondCore/DTPlugins/src/plugin.cc
@@ -45,15 +45,20 @@
 #include "CondCore/CondDB/interface/Serialization.h"
 #include "CondFormats/External/interface/DetID.h"
 
+
 namespace cond {
+  template <> boost::shared_ptr<BaseKeyed> deserialize<BaseKeyed>( const std::string& payloadType,
+						 const Binary& payloadData,
+						 const Binary& streamerInfoData,
+						 bool unpackingOnly ){
+    DESERIALIZE_BASE_CASE( BaseKeyed );                                                                                                                                                                                                             
+    DESERIALIZE_POLIMORPHIC_CASE( BaseKeyed, DTKeyedConfig );
 
-  template <> BaseKeyed* createPayload<BaseKeyed>( const std::string& payloadTypeName ){
-    if( payloadTypeName == "DTKeyedConfig" ) return new DTKeyedConfig;
-    throwException(std::string("Type mismatch, target object is type \"")+payloadTypeName+"\"",
-		   "createPayload" );
+    // here we come if none of the deserializations above match the payload type:                                                                                                                                                                                             
+    throwException(std::string("Type mismatch, target object is type \"")+payloadType+"\"", "deserialize<>" );
   }
-
 }
+
 
 namespace {
   struct InitDTCCBConfig {void operator()(DTCCBConfig& e){ e.initialize();}};

--- a/CondCore/HcalPlugins/src/plugin.cc
+++ b/CondCore/HcalPlugins/src/plugin.cc
@@ -16,6 +16,7 @@
 //
 #include "CondCore/CondDB/interface/Serialization.h"
 
+
 // required for compiling ( the only available constructor in this class ). Can't be used in persistency without this...
 namespace cond {
   template <> HcalCalibrationQIEData* createPayload<HcalCalibrationQIEData>( const std::string& payloadTypeName ){

--- a/CondCore/PhysicsToolsPlugins/src/PerformanceRecordPlugin.cc
+++ b/CondCore/PhysicsToolsPlugins/src/PerformanceRecordPlugin.cc
@@ -11,12 +11,19 @@
 #include "CondFormats/PhysicsToolsObjects/interface/PerformancePayloadFromTFormula.h"
 #include "CondFormats/PhysicsToolsObjects/interface/PerformancePayloadFromTable.h"
 
+#include "CondCore/CondDB/interface/Serialization.h"
+
 namespace cond {
-  template <> PerformancePayload* createPayload<PerformancePayload>( const std::string& payloadTypeName ){
-    if( payloadTypeName == "PerformancePayloadFromTFormula" ) return new PerformancePayloadFromTFormula;
-    if( payloadTypeName == "PerformancePayloadFromBinnedTFormula" ) return new PerformancePayloadFromBinnedTFormula;
-    if( payloadTypeName == "PerformancePayloadFromTable" ) return new PerformancePayloadFromTable;
-    throwException(std::string("Type mismatch, target object is type \"")+payloadTypeName+"\"",
+  template <> boost::shared_ptr<PerformancePayload> deserialize<PerformancePayload>( const std::string& payloadType, 
+										     const Binary& payloadData, 
+										     const Binary& streamerInfoData, 
+										     bool unpackingOnly ){
+    // DESERIALIZE_BASE_CASE( PerformancePayload );  abstract 
+    DESERIALIZE_POLIMORPHIC_CASE( PerformancePayload, PerformancePayloadFromTFormula ); 
+    DESERIALIZE_POLIMORPHIC_CASE( PerformancePayload, PerformancePayloadFromBinnedTFormula ); 
+    DESERIALIZE_POLIMORPHIC_CASE( PerformancePayload, PerformancePayloadFromTable ); 
+    // here we come if none of the deserializations above match the payload type:
+    throwException(std::string("Type mismatch, target object is type \"")+payloadType+"\"",
 		   "createPayload" );
   }
 }

--- a/CondCore/PopCon/test/stubs/EffSourceHandler.cc
+++ b/CondCore/PopCon/test/stubs/EffSourceHandler.cc
@@ -1,5 +1,4 @@
 #include "EffSourceHandler.h"
-#include "CondFormats/Calibration/interface/EfficiencyPayloads.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -12,6 +11,20 @@
 #include <typeinfo>
 
 #include "CondCore/CondDB/interface/Serialization.h"
+
+namespace cond {
+  template <> boost::shared_ptr<condex::Efficiency> deserialize<condex::Efficiency>( const std::string& payloadType,
+                                                                                     const Binary& payloadData,
+                                                                                     const Binary& streamerInfoData,
+                                                                                     bool unpackingOnly ){
+    // DESERIALIZE_BASE_CASE( condex::Efficiency );  abstract
+    DESERIALIZE_POLIMORPHIC_CASE( condex::Efficiency, condex::ParametricEfficiencyInPt );
+    DESERIALIZE_POLIMORPHIC_CASE( condex::Efficiency, condex::ParametricEfficiencyInEta );
+
+    // here we come if none of the deserializations above match the payload type:
+    throwException(std::string("Type mismatch, target object is type \"")+payloadType+"\"", "deserialize<>" );
+  }
+}
 
 popcon::ExEffSource::ExEffSource(const edm::ParameterSet& pset) :
   m_name(pset.getUntrackedParameter<std::string>("name","ExEffSource")),

--- a/CondCore/Utilities/python/conddblib.py
+++ b/CondCore/Utilities/python/conddblib.py
@@ -97,13 +97,15 @@ database_help = '''
       arc           Archive      Frontier       read-only
       int           Integration  Frontier       read-only
       dev           Development  Frontier       read-only
-      boost         Development  Frontier       read-only
+      boost         Production   Frontier       read-only
+      boostprep     Development  Frontier       read-only
 
       orapro        Production   Oracle (ADG)   read-only   Password required.
       oraarc        Archive      Oracle         read-only   Password required.
       oraint        Integration  Oracle         read-write  Password required.
       oradev        Development  Oracle         read-write  Password required.
-      oraboost      Development  Oracle         read-write  Password required.
+      oraboost      Production   Oracle (ADG)   read-write  Password required.
+      oraboostprep  Development  Oracle         read-write  Password required.
 
       onlineorapro  Production   Oracle         read-write  Password required. Online only.
       onlineoraint  Online Int   Oracle         read-write  Password required. Online only.
@@ -362,13 +364,15 @@ def connect(database='pro', init=False, verbose=0):
         'arc':           lambda: _getCMSFrontierSQLAlchemyConnectionString('FrontierArc'),
         'int':           lambda: _getCMSFrontierSQLAlchemyConnectionString('FrontierInt'),
         'dev':           lambda: _getCMSFrontierSQLAlchemyConnectionString('FrontierPrep'),
-        'boost':         lambda: _getCMSFrontierSQLAlchemyConnectionString('FrontierPrep', 'cms_test_conditions'),
+        'boost':         lambda: _getCMSFrontierSQLAlchemyConnectionString('FrontierProd', 'cms_conditions'),
+        'boostprep':     lambda: _getCMSFrontierSQLAlchemyConnectionString('FrontierPrep', 'cms_conditions'),
 
         'orapro':        lambda: _getCMSOracleSQLAlchemyConnectionString('cms_orcon_adg'),
         'oraarc':        lambda: _getCMSOracleSQLAlchemyConnectionString('cmsarc_lb'),
         'oraint':        lambda: _getCMSOracleSQLAlchemyConnectionString('cms_orcoff_int'),
         'oradev':        lambda: _getCMSOracleSQLAlchemyConnectionString('cms_orcoff_prep'),
-        'oraboost':      lambda: _getCMSOracleSQLAlchemyConnectionString('cms_orcoff_prep', 'cms_test_conditions'),
+        'oraboost':      lambda: _getCMSOracleSQLAlchemyConnectionString('cms_orcon_adg'  , 'cms_conditions'),
+        'oraboostprep':  lambda: _getCMSOracleSQLAlchemyConnectionString('cms_orcoff_prep', 'cms_conditions'),
 
         'onlineorapro':  lambda: _getCMSOracleSQLAlchemyConnectionString('cms_orcon_prod'),
         'onlineoraint':  lambda: _getCMSOracleSQLAlchemyConnectionString('cmsintr_lb'),

--- a/CondFormats/Calibration/interface/EfficiencyPayloads.h
+++ b/CondFormats/Calibration/interface/EfficiencyPayloads.h
@@ -1,13 +1,2 @@
-#include "CondFormats/Calibration/interface/Efficiency.h"
-#include "CondCore/CondDB/interface/Serialization.h"
 
-namespace cond {
-  // payload factory specializations
-  template <> condex::Efficiency* createPayload<condex::Efficiency>( const std::string& payloadTypeName ){
-    if( payloadTypeName == "condex::ParametricEfficiencyInPt" ) return new condex::ParametricEfficiencyInPt;
-    if( payloadTypeName == "condex::ParametricEfficiencyInEta" ) return new condex::ParametricEfficiencyInEta;
-    throwException(std::string("Type mismatch, target object is type \"")+payloadTypeName+"\"",
-		   "createPayload" );
-  }
-}
-
+#error "this file is obsolete"

--- a/CondFormats/PhysicsToolsObjects/src/SerializationManual.h
+++ b/CondFormats/PhysicsToolsObjects/src/SerializationManual.h
@@ -1,6 +1,8 @@
 
 #include "boost/serialization/assume_abstract.hpp"
 
+// take care of instantiating the concrete templates:
+
 COND_SERIALIZATION_INSTANTIATE(PhysicsTools::Calibration::Histogram<double, double>);
 COND_SERIALIZATION_INSTANTIATE(PhysicsTools::Calibration::Histogram<float, float>);
 
@@ -13,7 +15,15 @@ COND_SERIALIZATION_INSTANTIATE(PhysicsTools::Calibration::Histogram3D<float, flo
 COND_SERIALIZATION_INSTANTIATE(PhysicsTools::Calibration::Range<double>);
 COND_SERIALIZATION_INSTANTIATE(PhysicsTools::Calibration::Range<float>);
 
-//-ap not really sure that one is needed:
+// take care of inhertitance chains:
+
+BOOST_SERIALIZATION_ASSUME_ABSTRACT(PerformancePayload);
+
+COND_SERIALIZABLE_POLYMORPHIC(PerformancePayloadFromTable)
+COND_SERIALIZABLE_POLYMORPHIC(PerformancePayloadFromTFormula)
+COND_SERIALIZABLE_POLYMORPHIC(PerformancePayloadFromBinnedTFormula)
+
+
 BOOST_SERIALIZATION_ASSUME_ABSTRACT(PhysicsTools::Calibration::VarProcessor); 
 
 COND_SERIALIZABLE_POLYMORPHIC(PhysicsTools::Calibration::VarProcessor)

--- a/Configuration/AlCa/python/GlobalTag_condDBv2.py
+++ b/Configuration/AlCa/python/GlobalTag_condDBv2.py
@@ -1,0 +1,132 @@
+import FWCore.ParameterSet.Config as cms
+
+def checkPrefix(mainList, inputGTParams):
+    """ Compares two input GTs to see if they have the same prefix. Returns the index in the internal list of GTs of the match
+    or -1 in case of no match. """
+    if inputGTParams.find("_") == -1:
+        raise Exception("Invalid GT name. It does not contain an _, it cannot be used for replacements.")
+    prefix = inputGTParams.split("_")[0]
+    for i in range(0, len(mainList)):
+        if mainList[i].split("_")[0] == prefix:
+            return i
+    return -1
+
+
+from Configuration.AlCa.autoCond_condDBv2 import aliases
+def combineGTs(globaltag):
+    gtList = globaltag.split("+")
+    main = gtList[0]
+    # Alias expansion
+    if main in aliases:
+        main = aliases[main]
+    mainList = main.split("|")
+    # Do any requested replacement
+    if len(gtList) > 1:
+        for gt in gtList[1:]:
+            index = checkPrefix(mainList, gt)
+            if index != -1:
+                mainList[index] = gt
+            else:
+                exceptionString = "Error: replacement of GT "+gt+" not allowed. No matching prefix found in existing GT components. Available components are:\n"
+                for comp in mainList:
+                    exceptionString += comp + "\n"
+                raise Exception(exceptionString)
+        mainGT = mainList[0]
+        if len(mainList) > 1:
+            for mainPart in mainList[1:]:
+                mainGT += mainPart
+        return mainGT
+    else:
+        # Nothing to do, return the input globaltag
+        return main
+    
+
+def GlobalTag(essource = None, globaltag = None, conditions = None):
+    """Modify the GlobalTag module configuration, allowing to use the extended
+    Configuration/AlCa/python/autoCond_condDBv2.py functionality of specifying symbolic
+    globaltags (i.e., actual global tags, plus additional payloads to get from
+    the DB as customisations).
+    The actual code is taken from cmsDriver's ConfigBuilder.py, adapted here to
+    apply the changes directly to the process object and its module GlobalTag."""
+
+    # custom conditions: 
+    #  - start from an empty map
+    #  - add any conditions coming from autoCond_condDBv2.py
+    #  - then add and override them with any conditions explicitly requested
+    custom_conditions = {}
+
+    # if no GlobalTag ESSource module is given, load a "default" configuration
+    if essource is None:
+        from Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cfi import GlobalTag as essource
+
+    # if a Global Tag is given, check for an "auto" tag, and look it up in autoCond_condDBv2.py
+    # if a match is found, load the actual Global Tag and optional conditions
+    if globaltag is not None:
+        if globaltag.startswith('auto:'):
+            from Configuration.AlCa.autoCond_condDBv2 import autoCond
+            globaltag = globaltag[5:]
+            if globaltag not in autoCond:
+                raise Exception('no correspondence for '+globaltag+'\navailable keys are\n'+','.join(autoCond.keys()))
+
+            autoKey = autoCond[globaltag]
+            if isinstance(autoKey, tuple) or isinstance(autoKey, list):
+                globaltag = autoKey[0]
+                # TODO backward compatible code: to be removed after migrating autoCond.py to use a map for custom conditions
+                map = {}
+                for entry in autoKey[1:]:
+                  entry = entry.split(',')
+                  record     = entry[1]
+                  label      = len(entry) > 3 and entry[3] or None
+                  tag        = entry[0]
+                  connection = len(entry) > 2 and entry[2] or None
+                  map[ (record, label) ] = (tag, connection)
+                custom_conditions.update( map )
+            else:
+                globaltag = autoKey
+
+        # if a GlobalTag globaltag is given or loaded from autoCond_condDBv2.py, check for optional connection string and pfn prefix
+        globaltag = globaltag.split(',')
+        if len(globaltag) > 0 :
+            # Perform any alias expansion and consistency check.
+            # We are assuming the same connection and pfnPrefix/Postfix will be used for all GTs.
+            globaltag[0] = combineGTs(globaltag[0])
+            print "globaltag =", globaltag[0]
+            essource.globaltag = cms.string( str(globaltag[0]) )
+        if len(globaltag) > 1:
+            essource.connect   = cms.string( str(globaltag[1]) )
+        if len(globaltag) > 2:
+            essource.pfnPrefix = cms.untracked.string( str(globaltag[2]) )
+
+
+    # add any explicitly requested conditions, possibly overriding those from autoCond_condDBv2.py
+    if conditions is not None:
+        # TODO backward compatible code: to be removed after migrating ConfigBuilder.py and confdb.py to use a map for custom conditions
+        if isinstance(conditions, basestring): 
+          if conditions:
+            map = {}
+            for entry in conditions.split('+'):
+                entry = entry.split(',')
+                record     = entry[1]
+                label      = len(entry) > 3 and entry[3] or None
+                tag        = entry[0]
+                connection = len(entry) > 2 and entry[2] or None
+                map[ (record, label) ] = (tag, connection)
+            custom_conditions.update( map )
+        elif isinstance(conditions, dict):
+          custom_conditions.update( conditions )
+        else:
+          raise TypeError, "the 'conditions' argument should be either a string or a dictionary"
+
+    # explicit payloads toGet from DB
+    if custom_conditions:
+        for ( (record, label), (tag, connection) ) in custom_conditions.iteritems():
+            payload = cms.PSet()
+            payload.record = cms.string( record )
+            if label:
+                payload.label = cms.untracked.string( label )
+            payload.tag = cms.string( tag )
+            if connection:
+                payload.connect = cms.untracked.string( connection )
+            essource.toGet.append( payload )
+
+    return essource

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -1,43 +1,43 @@
 autoCond = { 
     # GlobalTag for MC production with perfectly aligned and calibrated detector                                                                                                                              
-    'mc'                :   'MC_71_V6::All',
+    'mc'                :   'MC_72_V1::All',
     # GlobalTag for MC production with realistic alignment and calibrations
-    'startup'           :   'START71_V5::All',
+    'startup'           :   'START72_V1::All',
     # GlobalTag for MC production of Heavy Ions events with realistic alignment and calibrations
-    'starthi'           :   'STARTHI71_V9::All',
+    'starthi'           :   'STARTHI72_V1::All',
     # GlobalTag for MC production of p-Pb events with realistic alignment and calibrations
-    'startpa'           :   'STARTHI71_V10::All',
+    'startpa'           :   'STARTHI72_V2::All',
     # GlobalTag for data reprocessing: this should always be the GR_R tag
-    'com10'             :   'GR_R_71_V4::All',
+    'com10'             :   'GR_R_72_V1::All',
     # GlobalTag for running HLT on recent data: this should be the GR_P (prompt reco) global tag until a compatible GR_H tag is available, 
     # then it should point to the GR_H tag and override the connection string and pfnPrefix for use offline
     'hltonline'         :   'GR_H_V37::All,frontier://FrontierProd/CMS_COND_31X_GLOBALTAG,frontier://FrontierProd/',
     # GlobalTag for POSTLS1 upgrade studies:
-    'upgradePLS1'       :   'POSTLS171_V11::All',
-    'upgradePLS150ns'   :   'POSTLS171_V12::All',
+    'upgradePLS1'       :   'POSTLS172_V1::All',
+    'upgradePLS150ns'   :   'POSTLS172_V2::All',
     'upgrade2017'       :   'DES17_70_V2::All', # placeholder (GT not meant for standard RelVal)
     'upgrade2019'       :   'DES19_70_V2::All', # placeholder (GT not meant for standard RelVal)
     'upgradePLS3'       :   'POSTLS262_V1::All', # placeholder (GT not meant for standard RelVal)
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   'MC_71_V6::All',
+    'run1_design'       :   'MC_72_V1::All',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   'START71_V5::All',
+    'run1_mc'           :   'START72_V1::All',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   'STARTHI71_V9::All',
+    'run1_mc_hi'        :   'STARTHI72_V1::All',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pPb'       :   'STARTHI71_V10::All',
+    'run1_mc_pPb'       :   'STARTHI72_V2::All',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   'DESIGN71_V3::All',
+    'run2_design'       :   'DESIGN72_V1::All',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   'POSTLS171_V12::All',
+    'run2_mc_50ns'      :   'POSTLS172_V2::All',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   'POSTLS171_V11::All',
+    'run2_mc'           :   'POSTLS172_V1::All',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   'GR_R_71_V4::All',
+    'run1_data'         :   'GR_R_72_V1::All',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   'GR_R_71_V4::All',
+    'run2_data'         :   'GR_R_72_V1::All',
     # GlobalTag for Run2 HLT: it points to the online GT and overrides the connection string and pfnPrefix for use offline
     'run2_hlt'          :   'GR_H_V37::All,frontier://FrontierProd/CMS_COND_31X_GLOBALTAG,frontier://FrontierProd/',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017

--- a/Configuration/AlCa/python/autoCond_condDBv2.py
+++ b/Configuration/AlCa/python/autoCond_condDBv2.py
@@ -1,43 +1,43 @@
 autoCond = { 
     # GlobalTag for MC production with perfectly aligned and calibrated detector                                                                                                                              
-    'mc'                :   'MC_71_V6',
+    'mc'                :   'MC_72_V1',
     # GlobalTag for MC production with realistic alignment and calibrations
-    'startup'           :   'START71_V5',
+    'startup'           :   'START72_V1',
     # GlobalTag for MC production of Heavy Ions events with realistic alignment and calibrations
-    'starthi'           :   'STARTHI71_V9',
+    'starthi'           :   'STARTHI72_V1',
     # GlobalTag for MC production of p-Pb events with realistic alignment and calibrations
-    'startpa'           :   'STARTHI71_V10',
+    'startpa'           :   'STARTHI72_V2',
     # GlobalTag for data reprocessing: this should always be the GR_R tag
-    'com10'             :   'GR_R_71_V4',
+    'com10'             :   'GR_R_72_V1',
     # GlobalTag for running HLT on recent data: this should be the GR_P (prompt reco) global tag until a compatible GR_H tag is available, 
     # then it should point to the GR_H tag and override the connection string and pfnPrefix for use offline
     'hltonline'         :   'GR_H_V37,frontier://FrontierProd/CMS_CONDITIONS,frontier://FrontierProd/',
     # GlobalTag for POSTLS1 upgrade studies:
-    'upgradePLS1'       :   'POSTLS171_V11',
-    'upgradePLS150ns'   :   'POSTLS171_V12',
+    'upgradePLS1'       :   'POSTLS172_V1',
+    'upgradePLS150ns'   :   'POSTLS172_V2',
     'upgrade2017'       :   'DES17_70_V2', # placeholder (GT not meant for standard RelVal)
     'upgrade2019'       :   'DES19_70_V2', # placeholder (GT not meant for standard RelVal)
     'upgradePLS3'       :   'POSTLS262_V1', # placeholder (GT not meant for standard RelVal)
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   'MC_71_V6',
+    'run1_design'       :   'MC_72_V1',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   'START71_V5',
+    'run1_mc'           :   'START72_V1',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   'STARTHI71_V9',
+    'run1_mc_hi'        :   'STARTHI72_V1',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pPb'       :   'STARTHI71_V10',
+    'run1_mc_pPb'       :   'STARTHI72_V2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   'DESIGN71_V3',
+    'run2_design'       :   'DESIGN72_V1',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   'POSTLS171_V12',
+    'run2_mc_50ns'      :   'POSTLS172_V2',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   'POSTLS171_V11',
+    'run2_mc'           :   'POSTLS172_V1',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   'GR_R_71_V4',
+    'run1_data'         :   'GR_R_72_V1',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   'GR_R_71_V4',
+    'run2_data'         :   'GR_R_72_V1',
     # GlobalTag for Run2 HLT: it points to the online GT and overrides the connection string and pfnPrefix for use offline
     'run2_hlt'          :   'GR_H_V37,frontier://FrontierProd/CMS_CONDITIONS,frontier://FrontierProd/',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017

--- a/Configuration/AlCa/python/autoCond_condDBv2.py
+++ b/Configuration/AlCa/python/autoCond_condDBv2.py
@@ -1,0 +1,157 @@
+autoCond = { 
+    # GlobalTag for MC production with perfectly aligned and calibrated detector                                                                                                                              
+    'mc'                :   'MC_71_V6',
+    # GlobalTag for MC production with realistic alignment and calibrations
+    'startup'           :   'START71_V5',
+    # GlobalTag for MC production of Heavy Ions events with realistic alignment and calibrations
+    'starthi'           :   'STARTHI71_V9',
+    # GlobalTag for MC production of p-Pb events with realistic alignment and calibrations
+    'startpa'           :   'STARTHI71_V10',
+    # GlobalTag for data reprocessing: this should always be the GR_R tag
+    'com10'             :   'GR_R_71_V4',
+    # GlobalTag for running HLT on recent data: this should be the GR_P (prompt reco) global tag until a compatible GR_H tag is available, 
+    # then it should point to the GR_H tag and override the connection string and pfnPrefix for use offline
+    'hltonline'         :   'GR_H_V37,frontier://FrontierProd/CMS_CONDITIONS,frontier://FrontierProd/',
+    # GlobalTag for POSTLS1 upgrade studies:
+    'upgradePLS1'       :   'POSTLS171_V11',
+    'upgradePLS150ns'   :   'POSTLS171_V12',
+    'upgrade2017'       :   'DES17_70_V2', # placeholder (GT not meant for standard RelVal)
+    'upgrade2019'       :   'DES19_70_V2', # placeholder (GT not meant for standard RelVal)
+    'upgradePLS3'       :   'POSTLS262_V1', # placeholder (GT not meant for standard RelVal)
+
+    ### NEW KEYS ###
+    # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
+    'run1_design'       :   'MC_71_V6',
+    # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
+    'run1_mc'           :   'START71_V5',
+    # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
+    'run1_mc_hi'        :   'STARTHI71_V9',
+    # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
+    'run1_mc_pPb'       :   'STARTHI71_V10',
+    # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
+    'run2_design'       :   'DESIGN71_V3',
+    # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
+    'run2_mc_50ns'      :   'POSTLS171_V12',
+    #GlobalTag for MC production with optimistic alignment and calibrations for Run2
+    'run2_mc'           :   'POSTLS171_V11',
+    # GlobalTag for Run1 data reprocessing
+    'run1_data'         :   'GR_R_71_V4',
+    # GlobalTag for Run2 data reprocessing
+    'run2_data'         :   'GR_R_71_V4',
+    # GlobalTag for Run2 HLT: it points to the online GT and overrides the connection string and pfnPrefix for use offline
+    'run2_hlt'          :   'GR_H_V37,frontier://FrontierProd/CMS_CONDITIONS,frontier://FrontierProd/',
+    # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
+    'phase1_2017_design' :  'DES17_70_V2', # placeholder (GT not meant for standard RelVal)
+    # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
+    'phase1_2019_design' :  'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
+    # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase2
+    'phase2_design'     :   'POSTLS262_V1', # placeholder (GT not meant for standard RelVal)
+}
+
+aliases = {
+    'MAINGT' : 'FT_P_V42D|AN_V4',
+    'BASEGT' : 'BASE1_V1|BASE2_V1'
+}
+
+# L1 configuration used during Run2012D
+conditions_L1_Run2012D = (
+    # L1 GT menu 2012 v3, used during Run2012D
+    'L1GtTriggerMenu_L1Menu_Collisions2012_v3_mc,L1GtTriggerMenuRcd,frontier://FrontierProd/CMS_COND_31X_L1T',
+    # L1 GCT configuration with 5 GeV jet seed threshold, used since Run2012C
+    'L1GctJetFinderParams_GCTPhysics_2012_04_27_JetSeedThresh5GeV_mc,L1GctJetFinderParamsRcd,frontier://FrontierProd/CMS_COND_31X_L1T',
+    'L1HfRingEtScale_GCTPhysics_2012_04_27_JetSeedThresh5GeV_mc,L1HfRingEtScaleRcd,frontier://FrontierProd/CMS_COND_31X_L1T',
+    'L1HtMissScale_GCTPhysics_2012_04_27_JetSeedThresh5GeV_mc,L1HtMissScaleRcd,frontier://FrontierProd/CMS_COND_31X_L1T',
+    'L1JetEtScale_GCTPhysics_2012_04_27_JetSeedThresh5GeV_mc,L1JetEtScaleRcd,frontier://FrontierProd/CMS_COND_31X_L1T',
+    # L1 CSCTF configuration used since Run2012B
+    'L1MuCSCPtLut_key-11_mc,L1MuCSCPtLutRcd,frontier://FrontierProd/CMS_COND_31X_L1T',
+    # L1 DTTF settings used since Run2012C
+    'L1MuDTTFParameters_dttf12_TSC_03_csc_col_mc,L1MuDTTFParametersRcd,frontier://FrontierProd/CMS_COND_31X_L1T',
+)
+
+# L1 configuration used during HIRun2011
+conditions_L1_HIRun2011 = (
+    # L1 heavy ions menu 2011 v0
+    'L1GtTriggerMenu_L1Menu_CollisionsHeavyIons2011_v0_mc,L1GtTriggerMenuRcd,frontier://FrontierProd/CMS_COND_31X_L1T',
+)
+
+# L1 configuration used during PARun2013
+conditions_L1_PARun2013 = (
+    # L1 GT menu HI 2013 v0, used for the p-Pb run 2013
+    'L1GtTriggerMenu_L1Menu_CollisionsHeavyIons2013_v0_mc,L1GtTriggerMenuRcd,frontier://FrontierProd/CMS_COND_31X_L1T',
+    # L1 GCT configuration without jet seed threshold (same as 2012B)
+    'L1GctJetFinderParams_GCTPhysics_2011_09_01_B_mc,L1GctJetFinderParamsRcd,frontier://FrontierProd/CMS_COND_31X_L1T',
+    'L1HfRingEtScale_GCTPhysics_2011_09_01_B_mc,L1HfRingEtScaleRcd,frontier://FrontierProd/CMS_COND_31X_L1T',
+    'L1HtMissScale_GCTPhysics_2011_09_01_B_mc,L1HtMissScaleRcd,frontier://FrontierProd/CMS_COND_31X_L1T',
+    'L1JetEtScale_GCTPhysics_2011_09_01_B_mc,L1JetEtScaleRcd,frontier://FrontierProd/CMS_COND_31X_L1T',
+    # L1 CSCTF configuration used since Run2012B
+    'L1MuCSCPtLut_key-11_mc,L1MuCSCPtLutRcd,frontier://FrontierProd/CMS_COND_31X_L1T',
+    # L1 DTTF settings used since Run2012C
+    'L1MuDTTFParameters_dttf12_TSC_03_csc_col_mc,L1MuDTTFParametersRcd,frontier://FrontierProd/CMS_COND_31X_L1T',
+)
+
+# HLT Jet Energy Corrections
+conditions_HLT_JECs = (
+    # HLT 2012 jet energy corrections
+    'JetCorrectorParametersCollection_Jec11_V12_AK5CaloHLT,JetCorrectionsRecord,frontier://FrontierProd/CMS_COND_31X_PHYSICSTOOLS,AK5CaloHLT',
+    'JetCorrectorParametersCollection_AK5PF_2012_V8_hlt_mc,JetCorrectionsRecord,frontier://FrontierProd/CMS_COND_31X_PHYSICSTOOLS,AK5PFHLT',
+    'JetCorrectorParametersCollection_AK5PFchs_2012_V8_hlt_mc,JetCorrectionsRecord,frontier://FrontierProd/CMS_COND_31X_PHYSICSTOOLS,AK5PFchsHLT',
+)
+
+
+# dedicated GlobalTags for MC production with the frozen HLT menus
+autoCond['startup_8E33v2']   = ( autoCond['startup'], ) \
+                             + conditions_L1_Run2012D
+
+autoCond['startup_2013']     = ( autoCond['startup'], ) \
+                             + conditions_L1_Run2012D
+
+autoCond['startup_2014']     = ( autoCond['startup'], ) \
+                             + conditions_L1_Run2012D
+
+autoCond['startup_GRun']     = ( autoCond['startup'], ) \
+                             + conditions_L1_Run2012D
+
+autoCond['starthi_HIon']     = ( autoCond['starthi'], ) \
+                             + conditions_L1_HIRun2011 \
+                             + conditions_HLT_JECs
+
+autoCond['startup_PIon']     = ( autoCond['startpa'], ) \
+                             + conditions_L1_PARun2013
+
+# dedicated GlobalTags for running the frozen HLT menus on data
+autoCond['hltonline_8E33v2'] = ( autoCond['hltonline'], ) \
+                             + conditions_L1_Run2012D
+
+autoCond['hltonline_2013']   = ( autoCond['hltonline'], ) \
+                             + conditions_L1_Run2012D
+
+autoCond['hltonline_2014']   = ( autoCond['hltonline'], ) \
+                             + conditions_L1_Run2012D
+
+autoCond['hltonline_GRun']   = ( autoCond['hltonline'], ) \
+                             + conditions_L1_Run2012D
+
+autoCond['hltonline_HIon']   = ( autoCond['hltonline'], ) \
+                             + conditions_L1_HIRun2011
+
+autoCond['hltonline_PIon']   = ( autoCond['hltonline'], ) \
+                             + conditions_L1_PARun2013
+
+# dedicated GlobalTags for running RECO and the frozen HLT menus on data
+autoCond['com10_8E33v2']     = ( autoCond['com10'], ) \
+                             + conditions_L1_Run2012D
+
+autoCond['com10_2013']       = ( autoCond['com10'], ) \
+                             + conditions_L1_Run2012D
+
+autoCond['com10_2014']       = ( autoCond['com10'], ) \
+                             + conditions_L1_Run2012D
+
+autoCond['com10_GRun']       = ( autoCond['com10'], ) \
+                             + conditions_L1_Run2012D
+
+autoCond['com10_HIon']       = ( autoCond['com10'], ) \
+                             + conditions_L1_HIRun2011
+
+autoCond['com10_PIon']       = ( autoCond['com10'], ) \
+                             + conditions_L1_PARun2013

--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -23,6 +23,7 @@ defaultOptions.geometry = 'SimDB'
 defaultOptions.geometryExtendedOptions = ['ExtendedGFlash','Extended','NoCastor']
 defaultOptions.magField = '38T'
 defaultOptions.conditions = None
+defaultOptions.useCondDBv2 = False
 defaultOptions.scenarioOptions=['pp','cosmics','nocoll','HeavyIons']
 defaultOptions.harvesting= 'AtRunEnd'
 defaultOptions.gflash = False
@@ -740,9 +741,18 @@ class ConfigBuilder(object):
 						
         self.loadAndRemember(self.ConditionsDefaultCFF)
 
-        from Configuration.AlCa.GlobalTag import GlobalTag
+	if self._options.useCondDBv2:
+		from Configuration.AlCa.GlobalTag_condDBv2 import GlobalTag
+	else:
+		from Configuration.AlCa.GlobalTag import GlobalTag
+
         self.process.GlobalTag = GlobalTag(self.process.GlobalTag, self._options.conditions, self._options.custom_conditions)
-        self.additionalCommands.append('from Configuration.AlCa.GlobalTag import GlobalTag')
+
+	if self._options.useCondDBv2:
+	        self.additionalCommands.append('from Configuration.AlCa.GlobalTag_condDBv2 import GlobalTag')
+	else:
+	        self.additionalCommands.append('from Configuration.AlCa.GlobalTag import GlobalTag')
+
         self.additionalCommands.append('process.GlobalTag = GlobalTag(process.GlobalTag, %s, %s)' % (repr(self._options.conditions), repr(self._options.custom_conditions)))
 
 	if self._options.slhc:
@@ -864,7 +874,10 @@ class ConfigBuilder(object):
         self.HARVESTINGDefaultCFF="Configuration/StandardSequences/Harvesting_cff"
         self.ALCAHARVESTDefaultCFF="Configuration/StandardSequences/AlCaHarvesting_cff"
         self.ENDJOBDefaultCFF="Configuration/StandardSequences/EndOfProcess_cff"
-        self.ConditionsDefaultCFF = "Configuration/StandardSequences/FrontierConditions_GlobalTag_cff"
+        if self._options.useCondDBv2:
+           self.ConditionsDefaultCFF = "Configuration/StandardSequences/FrontierConditions_GlobalTag_condDBv2_cff"
+	else:
+	    self.ConditionsDefaultCFF = "Configuration/StandardSequences/FrontierConditions_GlobalTag_cff"
         self.CFWRITERDefaultCFF = "Configuration/StandardSequences/CrossingFrameWriter_cff"
         self.REPACKDefaultCFF="Configuration/StandardSequences/DigiToRaw_Repack_cff"
 

--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -23,7 +23,7 @@ defaultOptions.geometry = 'SimDB'
 defaultOptions.geometryExtendedOptions = ['ExtendedGFlash','Extended','NoCastor']
 defaultOptions.magField = '38T'
 defaultOptions.conditions = None
-defaultOptions.useCondDBv2 = False
+defaultOptions.useCondDBv1 = False
 defaultOptions.scenarioOptions=['pp','cosmics','nocoll','HeavyIons']
 defaultOptions.harvesting= 'AtRunEnd'
 defaultOptions.gflash = False
@@ -741,17 +741,17 @@ class ConfigBuilder(object):
 						
         self.loadAndRemember(self.ConditionsDefaultCFF)
 
-	if self._options.useCondDBv2:
-		from Configuration.AlCa.GlobalTag_condDBv2 import GlobalTag
-	else:
+	if self._options.useCondDBv1:
 		from Configuration.AlCa.GlobalTag import GlobalTag
+	else:
+		from Configuration.AlCa.GlobalTag_condDBv2 import GlobalTag
 
         self.process.GlobalTag = GlobalTag(self.process.GlobalTag, self._options.conditions, self._options.custom_conditions)
 
-	if self._options.useCondDBv2:
-	        self.additionalCommands.append('from Configuration.AlCa.GlobalTag_condDBv2 import GlobalTag')
-	else:
+	if self._options.useCondDBv1:
 	        self.additionalCommands.append('from Configuration.AlCa.GlobalTag import GlobalTag')
+	else:
+	        self.additionalCommands.append('from Configuration.AlCa.GlobalTag_condDBv2 import GlobalTag')
 
         self.additionalCommands.append('process.GlobalTag = GlobalTag(process.GlobalTag, %s, %s)' % (repr(self._options.conditions), repr(self._options.custom_conditions)))
 
@@ -874,10 +874,10 @@ class ConfigBuilder(object):
         self.HARVESTINGDefaultCFF="Configuration/StandardSequences/Harvesting_cff"
         self.ALCAHARVESTDefaultCFF="Configuration/StandardSequences/AlCaHarvesting_cff"
         self.ENDJOBDefaultCFF="Configuration/StandardSequences/EndOfProcess_cff"
-        if self._options.useCondDBv2:
-           self.ConditionsDefaultCFF = "Configuration/StandardSequences/FrontierConditions_GlobalTag_condDBv2_cff"
-	else:
+        if self._options.useCondDBv1:
 	    self.ConditionsDefaultCFF = "Configuration/StandardSequences/FrontierConditions_GlobalTag_cff"
+	else:
+            self.ConditionsDefaultCFF = "Configuration/StandardSequences/FrontierConditions_GlobalTag_condDBv2_cff"
         self.CFWRITERDefaultCFF = "Configuration/StandardSequences/CrossingFrameWriter_cff"
         self.REPACKDefaultCFF="Configuration/StandardSequences/DigiToRaw_Repack_cff"
 

--- a/Configuration/Applications/python/Options.py
+++ b/Configuration/Applications/python/Options.py
@@ -34,6 +34,12 @@ parser.add_option("--conditions",
                   default=None,
                   dest="conditions")
 
+parser.add_option("--useCondDBv2",
+                  help="use conditions DB v2 (with boost-blobified payloads and single account)",
+                  action="store_true",
+                  default=False,
+                  dest="useCondDBv2")
+
 parser.add_option("--eventcontent",
                   help="What event content to write out. Default=FEVTDEBUG, or FEVT (for cosmics)",
                   default='RECOSIM',

--- a/Configuration/Applications/python/Options.py
+++ b/Configuration/Applications/python/Options.py
@@ -34,11 +34,11 @@ parser.add_option("--conditions",
                   default=None,
                   dest="conditions")
 
-parser.add_option("--useCondDBv2",
-                  help="use conditions DB v2 (with boost-blobified payloads and single account)",
+parser.add_option("--useCondDBv1",
+                  help="use conditions DB V1",
                   action="store_true",
                   default=False,
-                  dest="useCondDBv2")
+                  dest="useCondDBv1")
 
 parser.add_option("--eventcontent",
                   help="What event content to write out. Default=FEVTDEBUG, or FEVT (for cosmics)",

--- a/Configuration/PyReleaseValidation/python/MatrixReader.py
+++ b/Configuration/PyReleaseValidation/python/MatrixReader.py
@@ -240,7 +240,6 @@ class MatrixReader(object):
                         cmd  = 'cmsDriver.py '+cfg+' '+opts
                     else:
                         cmd  = 'cmsDriver.py step'+str(stepIndex+1)+' '+opts
-                    cmd += ' --useCondDBv2 '  # set the default to use the conditionsDB v2
                     if self.wm:
                         cmd+=' --io %s.io --python %s.py'%(stepName,stepName)
                     if self.addCommand:

--- a/Configuration/PyReleaseValidation/python/MatrixReader.py
+++ b/Configuration/PyReleaseValidation/python/MatrixReader.py
@@ -240,6 +240,7 @@ class MatrixReader(object):
                         cmd  = 'cmsDriver.py '+cfg+' '+opts
                     else:
                         cmd  = 'cmsDriver.py step'+str(stepIndex+1)+' '+opts
+                    cmd += ' --useCondDBv2 '  # set the default to use the conditionsDB v2
                     if self.wm:
                         cmd+=' --io %s.io --python %s.py'%(stepName,stepName)
                     if self.addCommand:

--- a/Configuration/StandardSequences/python/FrontierConditions_GlobalTag_condDBv2_cff.py
+++ b/Configuration/StandardSequences/python/FrontierConditions_GlobalTag_condDBv2_cff.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cfi import *
+
+# the following are needed for non PoolDBESSources
+from CalibCalorimetry.EcalLaserCorrection.ecalLaserCorrectionService_cfi import *
+from CalibCalorimetry.HcalPlugins.Hcal_Conditions_forGlobalTag_cff import *
+from CalibTracker.Configuration.Tracker_DependentRecords_forGlobalTag_nofakes_cff import *
+# FIXME: should be moved to a cfi in a castor package
+CastorDbProducer = cms.ESProducer("CastorDbProducer")

--- a/Configuration/StandardSequences/python/FrontierConditions_GlobalTag_condDBv2_cfi.py
+++ b/Configuration/StandardSequences/python/FrontierConditions_GlobalTag_condDBv2_cfi.py
@@ -1,0 +1,12 @@
+import FWCore.ParameterSet.Config as cms
+
+from CondCore.DBCommon.CondDBSetup_cfi import *
+
+print '# Conditions read from  CMS_CONDITIONS  via FrontierProd '
+
+GlobalTag = cms.ESSource("PoolDBESSource",
+    CondDBSetup,
+    connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
+    globaltag = cms.string('UNSPECIFIED::All'),
+    toGet = cms.VPSet( ),   # hook to override or add single payloads
+)


### PR DESCRIPTION
As requested, here is the PR with more meaningful names for the new conditions DB ("condDBv2"). 
Added is also the change in runTheMatrix to use the condDBv2 files by default (via the new '--useCondDBv2' option of cmsDriver)
