### PR TITLE
Pythia8 interface fix which is really working this time

### DIFF
--- a/GeneratorInterface/Pythia8Interface/BuildFile.xml
+++ b/GeneratorInterface/Pythia8Interface/BuildFile.xml
@@ -6,10 +6,5 @@
 <use name="GeneratorInterface/ExternalDecays"/>
 <use name="boost"/>
 <use name="clhep"/>
-<use name="hepmc"/>
-<use name="lhapdf"/>
 <use name="pythia8"/>
 <flags EDM_PLUGIN="1"/>
-<export>
-	<lib name="GeneratorInterfacePythia8Interface"/>
-</export>

--- a/GeneratorInterface/Pythia8Interface/BuildFile.xml
+++ b/GeneratorInterface/Pythia8Interface/BuildFile.xml
@@ -6,5 +6,11 @@
 <use name="GeneratorInterface/ExternalDecays"/>
 <use name="boost"/>
 <use name="clhep"/>
+<use name="hepmc"/>
+<use name="lhapdf"/>
 <use name="pythia8"/>
 <flags EDM_PLUGIN="1"/>
+<export>
+       <lib name="GeneratorInterfacePythia8Interface"/>
+</export>
+

--- a/GeneratorInterface/Pythia8Interface/src/Pythia8Hadronizer.cc
+++ b/GeneratorInterface/Pythia8Interface/src/Pythia8Hadronizer.cc
@@ -41,7 +41,6 @@ class Pythia8Hadronizer : public BaseHadronizer {
 	Pythia8Hadronizer(const edm::ParameterSet &params);
 	~Pythia8Hadronizer();
  
-	bool readSettings( int );
 	bool initializeForInternalPartons();
         bool initializeForExternalPartons();
 	
@@ -70,111 +69,59 @@ class Pythia8Hadronizer : public BaseHadronizer {
 	/// Events to print if verbosity
 	unsigned int		maxEventsToPrint;
 
-	string LHEInputFileName;
+    string LHEInputFileName;
 
-	/// Switch User Hook flag
-	bool            useUserHook;
+    /// Switch User Hook flag
+    bool            useUserHook;
 
-	std::auto_ptr<LHAupLesHouches>      lhaUP;
+    std::auto_ptr<LHAupLesHouches>      lhaUP;
 
 	std::auto_ptr<Pythia>	pythia;
-	std::auto_ptr<Pythia>   decayer;
-	Event*			pythiaEvent;
+	Event			*pythiaEvent;
 	HepMC::I_Pythia8	toHepMC;   
 
-	enum { PP, PPbar, ElectronPositron };
-	int    fInitialState ; // pp, ppbar, or e-e+
-
-	double fBeam1PZ;
-	double fBeam2PZ;
-
         UserHooks* UserHookPointer;
-
 };
 
 
 Pythia8Hadronizer::Pythia8Hadronizer(const edm::ParameterSet &params) :
-    BaseHadronizer(params),
-    parameters(params.getParameter<edm::ParameterSet>("PythiaParameters")),
-    comEnergy(params.getParameter<double>("comEnergy")),
-    pythiaPylistVerbosity(params.getUntrackedParameter<int>("pythiaPylistVerbosity", 0)),
-    pythiaHepMCVerbosity(params.getUntrackedParameter<bool>("pythiaHepMCVerbosity", false)),
-    maxEventsToPrint(params.getUntrackedParameter<int>("maxEventsToPrint", 0)),
+        BaseHadronizer(params),
+	parameters(params.getParameter<edm::ParameterSet>("PythiaParameters")),
+	comEnergy(params.getParameter<double>("comEnergy")),
+	pythiaPylistVerbosity(params.getUntrackedParameter<int>("pythiaPylistVerbosity", 0)),
+	pythiaHepMCVerbosity(params.getUntrackedParameter<bool>("pythiaHepMCVerbosity", false)),
+	maxEventsToPrint(params.getUntrackedParameter<int>("maxEventsToPrint", 0)),
     LHEInputFileName(params.getUntrackedParameter<string>("LHEInputFileName","")),
     useUserHook(false),
-    fInitialState(PP),
     UserHookPointer(0)
 {
     if( params.exists( "useUserHook" ) )
       useUserHook = params.getParameter<bool>("useUserHook");
     randomEngine = &getEngineReference();
-
-    //Old code that used Pythia8 own random engine
-    //edm::Service<edm::RandomNumberGenerator> rng;
-    //uint32_t seed = rng->mySeed();
-    //Pythia8::Rndm::init(seed);
-
-    RandomP8* RP8 = new RandomP8();
-
-    // J.Y.: the following 3 parameters are hacked "for a reason"
-    //
-    if ( params.exists( "PPbarInitialState" ) )
-    {
-      if ( fInitialState == PP )
-      {
-        fInitialState = PPbar;
-        edm::LogInfo("GeneratorInterface|Pythia6Interface")
-        << "Pythia6 will be initialized for PROTON-ANTIPROTON INITIAL STATE. "
-        << "This is a user-request change from the DEFAULT PROTON-PROTON initial state." << std::endl;
-        std::cout << "Pythia6 will be initialized for PROTON-ANTIPROTON INITIAL STATE." << std::endl;
-        std::cout << "This is a user-request change from the DEFAULT PROTON-PROTON initial state." << std::endl;
-      }
-      else
-      {   
-        // probably need to throw on attempt to override ?
-      }
-    }   
-    else if ( params.exists( "ElectronPositronInitialState" ) )
-    {
-      if ( fInitialState == PP )
-      {
-        fInitialState = ElectronPositron;
-        edm::LogInfo("GeneratorInterface|Pythia6Interface")
-        << "Pythia6 will be initialized for ELECTRON-POSITRON INITIAL STATE. "
-        << "This is a user-request change from the DEFAULT PROTON-PROTON initial state." << std::endl;
-        std::cout << "Pythia6 will be initialized for ELECTRON-POSITRON INITIAL STATE." << std::endl; 
-        std::cout << "This is a user-request change from the DEFAULT PROTON-PROTON initial state." << std::endl;
-      }
-      else
-      {   
-         // probably need to throw on attempt to override ?
-      }
-    }
-    else if ( params.exists( "ElectronProtonInitialState" ) || params.exists( "PositronProtonInitialState" ) )
-    {
-      // throw on unknown initial state !
-      throw edm::Exception(edm::errors::Configuration,"Pythia6Interface")
-        <<" UNKNOWN INITIAL STATE. \n The allowed initial states are: PP, PPbar, ElectronPositron \n";
-    }
-
-    pythia.reset(new Pythia);
-    decayer.reset(new Pythia);
-
-    pythia->setRndmEnginePtr(RP8);
-    decayer->setRndmEnginePtr(RP8);
-
 }
 
 Pythia8Hadronizer::~Pythia8Hadronizer()
 {
 }
 
-bool Pythia8Hadronizer::readSettings( int )
+bool Pythia8Hadronizer::initializeForInternalPartons()
 {
-    if(useUserHook) {
+	//Old code that used Pythia8 own random engine
+	//edm::Service<edm::RandomNumberGenerator> rng;
+	//uint32_t seed = rng->mySeed();
+	//Pythia8::Rndm::init(seed);
+
+    RandomP8* RP8 = new RandomP8();
+
+	pythia.reset(new Pythia);
+
+    pythia->setRndmEnginePtr(RP8);
+    if(useUserHook){
       UserHookPointer = new PtHatReweightUserHook();
       pythia->setUserHooksPtr(UserHookPointer);
     }
+
+	pythiaEvent = &pythia->event;
 
 	for(ParameterCollector::const_iterator line = parameters.begin();
 	    line != parameters.end(); ++line) {
@@ -198,39 +145,11 @@ bool Pythia8Hadronizer::readSettings( int )
         pythia->particleData.listAll();
     }
 
-   return true;
+	pythia->init(2212, 2212, comEnergy);
 
-}
+	pythia->settings.listChanged();
 
-bool Pythia8Hadronizer::initializeForInternalPartons()
-{
-
-    pythiaEvent = &pythia->event;
-
-    //pythia->init(2212, 2212, comEnergy);
-
-    if ( fInitialState == PP ) // default
-    {
-      pythia->init(2212, 2212, comEnergy);
-    }
-    else if ( fInitialState == PPbar )
-    {
-      pythia->init(2212, -2212, comEnergy);
-    }
-    else if ( fInitialState == ElectronPositron )
-    {
-      pythia->init(11, -11, comEnergy);
-    }    
-    else 
-    {
-      // throw on unknown initial state !
-      throw edm::Exception(edm::errors::Configuration,"Pythia8Interface")
-             <<" UNKNOWN INITIAL STATE. \n The allowed initial states are: PP, PPbar, ElectronPositron \n";
-    }
-
-    pythia->settings.listChanged();
-
-    return true;
+	return true;
 }
 
 
@@ -239,17 +158,14 @@ bool Pythia8Hadronizer::initializeForExternalPartons()
 
     std::cout << "Initializing for external partons" << std::endl;
 
-//    RandomP8* RP8 = new RandomP8();
+    RandomP8* RP8 = new RandomP8();
 
-//    pythia.reset(new Pythia);
+    pythia.reset(new Pythia);
 
-//    pythia->setRndmEnginePtr(RP8);
+    pythia->setRndmEnginePtr(RP8);
 
     pythiaEvent = &pythia->event;
-    
-    // readSettings();
 
-/*
     for(ParameterCollector::const_iterator line = parameters.begin();
         line != parameters.end(); ++line) {
         if (line->find("Random:") != std::string::npos)
@@ -271,7 +187,7 @@ bool Pythia8Hadronizer::initializeForExternalPartons()
       if(pythiaPylistVerbosity == 12 || pythiaPylistVerbosity == 13)
         pythia->particleData.listAll();
     }
-*/
+
     if(LHEInputFileName != string()) {
 
       cout << endl;
@@ -313,10 +229,7 @@ bool Pythia8Hadronizer::declareStableParticles(const std::vector<int> &pdgIds)
       // FIXME: need to double check if PID's are the same in Py6 & Py8,
       //        because the HepPDT translation tool is actually for **Py6** 
       // 
-      // well, actually it looks like Py8 operates in PDT id's rather than Py6's
-      //
-      // int PyID = HepPID::translatePDTtoPythia( pdgIds[i] ); 
-      int PyID = pdgIds[i]; 
+      int PyID = HepPID::translatePDTtoPythia( pdgIds[i] ); 
       std::ostringstream pyCard ;
       pyCard << PyID <<":mayDecay=false";
       pythia->readString( pyCard.str() );
@@ -325,22 +238,12 @@ bool Pythia8Hadronizer::declareStableParticles(const std::vector<int> &pdgIds)
       // - this way Py8 will NOT print warnings about unknown particle code(s)
       // pythia->readString( pyCard.str(), false )
    }
-      
-   // init decayer
-   decayer->readString("ProcessLevel:all = off"); // The trick!
-   decayer->init();
    
    return true;
 
 }
-bool Pythia8Hadronizer::declareSpecialSettings( const std::vector<std::string> settings )
+bool Pythia8Hadronizer::declareSpecialSettings( const std::vector<std::string> )
 {
-   for ( unsigned int iss=0; iss<settings.size(); iss++ )
-   {
-      if ( settings[iss].find("QED-brem-off") == std::string::npos ) continue;      
-      pythia->readString( "TimeShower:QEDshowerByL=off" );
-   }
-
    return true;
 }
 
@@ -388,79 +291,12 @@ bool Pythia8Hadronizer::hadronize()
 
 bool Pythia8Hadronizer::decay()
 {
-   return true;
+	return true;
 }
 
 bool Pythia8Hadronizer::residualDecay()
 {
-
-   int NPartsBeforeDecays = pythiaEvent->size();
-   int NPartsAfterDecays = event().get()->particles_size();
-   int NewBarcode = NPartsAfterDecays;
-   
-   for ( int ipart=NPartsAfterDecays; ipart>NPartsBeforeDecays; ipart-- )
-   {
-
-      HepMC::GenParticle* part = event().get()->barcode_to_particle( ipart );
-
-      if ( part->status() == 1 )
-      {
-
-	    decayer->event.reset();
-	    Particle py8part(  part->pdg_id(), 93, 0, 0, 0, 0, 0, 0,
-	                            part->momentum().x(),
-	                            part->momentum().y(),
-	                            part->momentum().z(),
-				    part->momentum().t(),
-				    part->generated_mass() );
-            HepMC::GenVertex* ProdVtx = part->production_vertex();
-	    py8part.vProd( ProdVtx->position().x(), ProdVtx->position().y(), ProdVtx->position().z(), ProdVtx->position().t() );
-	    py8part.tau( (decayer->particleData).tau0( part->pdg_id() ) );
-	    decayer->event.append( py8part );
-	    int nentries = decayer->event.size();
-	    if ( !decayer->event[nentries-1].mayDecay() ) continue;
-	    decayer->next();
-	    int nentries1 = decayer->event.size();
-	    // --> decayer->event.list(std::cout);
-	    if ( nentries1 <= nentries ) continue; // same number of paericles, no decays...
-	    
-	    part->set_status(2);
-	    
-	    Particle& py8daughter = decayer->event[nentries]; // the 1st daughter
-	    HepMC::GenVertex* DecVtx = new HepMC::GenVertex( HepMC::FourVector(py8daughter.xProd(),
-	                                                                       py8daughter.yProd(),
-					 		                       py8daughter.zProd(),
-									       py8daughter.tProd()) );	       
-
-	    DecVtx->add_particle_in( part ); // this will cleanup end_vertex if exists, replace with the new one
-				             // I presume (vtx) barcode will be given automatically
-	    
-	    HepMC::FourVector pmom( py8daughter.px(), py8daughter.py(), py8daughter.pz(), py8daughter.e() );
-	    
-	    HepMC::GenParticle* daughter = new HepMC::GenParticle( pmom, 
-	                                                           py8daughter.id(), 1 );
-	    
-	    NewBarcode++;
-	    daughter->suggest_barcode( NewBarcode );
-	    DecVtx->add_particle_out( daughter );
-	    	    
-	    for ( ipart=nentries+1; ipart<nentries1; ipart++ )
-	    {
-	       py8daughter = decayer->event[ipart];
-	       HepMC::FourVector pmomN( py8daughter.px(), py8daughter.py(), py8daughter.pz(), py8daughter.e() );	    
-	       HepMC::GenParticle* daughterN = new HepMC::GenParticle( pmomN, 
-	                                                               py8daughter.id(), 1 );
-	       NewBarcode++;
-	       daughterN->suggest_barcode( NewBarcode );
-	       DecVtx->add_particle_out( daughterN );
-	    }
-	    
-	    event().get()->add_vertex( DecVtx );
-
-      }
-   } 
-   
-   return true;
+	return true;
 }
 
 void Pythia8Hadronizer::finalizeEvent()


### PR DESCRIPTION
When the bug in Pythia8 flat QCD weights was found, it was suggested to copy the Pythia8Interface from CMSSW_4_4_7 to fix it (https://github.com/cms-sw/cmssw/pull/3853). Even though it compiled nicely, the fix introduced some pythia8 initialization problems, probably due to name changes of functions in GeneratorInterface/Core, I think.

Therefore I made this new fix where I revert Pythia8Hadronizer.cc back to the former version and only updated the sections which deal with the weights. So this is a more minimal fix, as was actually suggested by Josh before. I have tested it with our generator fragments, and it is really working this time.
