### PR TITLE
GTs in autoCond for 710

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -1,43 +1,43 @@
 autoCond = { 
     # GlobalTag for MC production with perfectly aligned and calibrated detector                                                                                                                              
-    'mc'                :   'MC_71_V7::All',
+    'mc'                :   'MC_71_V8::All',
     # GlobalTag for MC production with realistic alignment and calibrations
-    'startup'           :   'START71_V6::All',
+    'startup'           :   'START71_V7::All',
     # GlobalTag for MC production of Heavy Ions events with realistic alignment and calibrations
-    'starthi'           :   'STARTHI71_V11::All',
+    'starthi'           :   'STARTHI71_V13::All',
     # GlobalTag for MC production of p-Pb events with realistic alignment and calibrations
-    'startpa'           :   'STARTHI71_V12::All',
+    'startpa'           :   'STARTHI71_V14::All',
     # GlobalTag for data reprocessing: this should always be the GR_R tag
-    'com10'             :   'GR_R_71_V5::All',
+    'com10'             :   'GR_R_71_V6::All',
     # GlobalTag for running HLT on recent data: this should be the GR_P (prompt reco) global tag until a compatible GR_H tag is available, 
     # then it should point to the GR_H tag and override the connection string and pfnPrefix for use offline
     'hltonline'         :   'GR_H_V37::All,frontier://FrontierProd/CMS_COND_31X_GLOBALTAG,frontier://FrontierProd/',
     # GlobalTag for POSTLS1 upgrade studies:
-    'upgradePLS1'       :   'POSTLS171_V13::All',
-    'upgradePLS150ns'   :   'POSTLS171_V14::All',
+    'upgradePLS1'       :   'POSTLS171_V15::All',
+    'upgradePLS150ns'   :   'POSTLS171_V16::All',
     'upgrade2017'       :   'DES17_70_V2::All', # placeholder (GT not meant for standard RelVal)
     'upgrade2019'       :   'DES19_70_V2::All', # placeholder (GT not meant for standard RelVal)
     'upgradePLS3'       :   'POSTLS262_V1::All', # placeholder (GT not meant for standard RelVal)
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   'MC_71_V7::All',
+    'run1_design'       :   'MC_71_V8::All',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   'START71_V6::All',
+    'run1_mc'           :   'START71_V7::All',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   'STARTHI71_V11::All',
+    'run1_mc_hi'        :   'STARTHI71_V13::All',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pPb'       :   'STARTHI71_V12::All',
+    'run1_mc_pPb'       :   'STARTHI71_V14::All',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   'DESIGN71_V4::All',
+    'run2_design'       :   'DESIGN71_V5::All',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   'POSTLS171_V14::All',
+    'run2_mc_50ns'      :   'POSTLS171_V16::All',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   'POSTLS171_V13::All',
+    'run2_mc'           :   'POSTLS171_V15::All',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   'GR_R_71_V5::All',
+    'run1_data'         :   'GR_R_71_V6::All',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   'GR_R_71_V5::All',
+    'run2_data'         :   'GR_R_71_V6::All',
     # GlobalTag for Run2 HLT: it points to the online GT and overrides the connection string and pfnPrefix for use offline
     'run2_hlt'          :   'GR_H_V37::All,frontier://FrontierProd/CMS_COND_31X_GLOBALTAG,frontier://FrontierProd/',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -1,43 +1,43 @@
 autoCond = { 
     # GlobalTag for MC production with perfectly aligned and calibrated detector                                                                                                                              
-    'mc'                :   'MC_71_V6::All',
+    'mc'                :   'MC_71_V7::All',
     # GlobalTag for MC production with realistic alignment and calibrations
-    'startup'           :   'START71_V5::All',
+    'startup'           :   'START71_V6::All',
     # GlobalTag for MC production of Heavy Ions events with realistic alignment and calibrations
-    'starthi'           :   'STARTHI71_V9::All',
+    'starthi'           :   'STARTHI71_V11::All',
     # GlobalTag for MC production of p-Pb events with realistic alignment and calibrations
-    'startpa'           :   'STARTHI71_V10::All',
+    'startpa'           :   'STARTHI71_V12::All',
     # GlobalTag for data reprocessing: this should always be the GR_R tag
-    'com10'             :   'GR_R_71_V4::All',
+    'com10'             :   'GR_R_71_V5::All',
     # GlobalTag for running HLT on recent data: this should be the GR_P (prompt reco) global tag until a compatible GR_H tag is available, 
     # then it should point to the GR_H tag and override the connection string and pfnPrefix for use offline
     'hltonline'         :   'GR_H_V37::All,frontier://FrontierProd/CMS_COND_31X_GLOBALTAG,frontier://FrontierProd/',
     # GlobalTag for POSTLS1 upgrade studies:
-    'upgradePLS1'       :   'POSTLS171_V11::All',
-    'upgradePLS150ns'   :   'POSTLS171_V12::All',
+    'upgradePLS1'       :   'POSTLS171_V13::All',
+    'upgradePLS150ns'   :   'POSTLS171_V14::All',
     'upgrade2017'       :   'DES17_70_V2::All', # placeholder (GT not meant for standard RelVal)
     'upgrade2019'       :   'DES19_70_V2::All', # placeholder (GT not meant for standard RelVal)
     'upgradePLS3'       :   'POSTLS262_V1::All', # placeholder (GT not meant for standard RelVal)
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   'MC_71_V6::All',
+    'run1_design'       :   'MC_71_V7::All',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   'START71_V5::All',
+    'run1_mc'           :   'START71_V6::All',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   'STARTHI71_V9::All',
+    'run1_mc_hi'        :   'STARTHI71_V11::All',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pPb'       :   'STARTHI71_V10::All',
+    'run1_mc_pPb'       :   'STARTHI71_V12::All',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   'DESIGN71_V3::All',
+    'run2_design'       :   'DESIGN71_V4::All',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   'POSTLS171_V12::All',
+    'run2_mc_50ns'      :   'POSTLS171_V14::All',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   'POSTLS171_V11::All',
+    'run2_mc'           :   'POSTLS171_V13::All',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   'GR_R_71_V4::All',
+    'run1_data'         :   'GR_R_71_V5::All',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   'GR_R_71_V4::All',
+    'run2_data'         :   'GR_R_71_V5::All',
     # GlobalTag for Run2 HLT: it points to the online GT and overrides the connection string and pfnPrefix for use offline
     'run2_hlt'          :   'GR_H_V37::All,frontier://FrontierProd/CMS_COND_31X_GLOBALTAG,frontier://FrontierProd/',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017


### PR DESCRIPTION
- New Run1 simulation (ideal and realistic for pp, PbPb, and pPb) GTs:
  - updated record for b-tagging calibrations (see validation [here](https://indico.cern.ch/event/294010/contribution/1/material/slides/0.pdf) )
- New Run1 data GT:
  - updated record for b-tagging calibrations (see validation [here](https://indico.cern.ch/event/294010/contribution/1/material/slides/0.pdf) )
- New Run2 simulation (ideal, 25 ns, 50 ns) GTs:
  - fixed simulation geometry records yielding warnings in G4
  - updated record for b-tagging calibrations (see validation [here](https://indico.cern.ch/event/294010/contribution/1/material/slides/0.pdf) )
