### PR TITLE
Cleanup G4 interface to generators

### DIFF
--- a/IOMC/EventVertexGenerators/src/FlatEvtVtxGenerator.cc
+++ b/IOMC/EventVertexGenerators/src/FlatEvtVtxGenerator.cc
@@ -45,15 +45,16 @@ FlatEvtVtxGenerator::~FlatEvtVtxGenerator()
 
 //Hep3Vector * FlatEvtVtxGenerator::newVertex() {
 HepMC::FourVector* FlatEvtVtxGenerator::newVertex(CLHEP::HepRandomEngine* engine) {
-  double aX,aY,aZ;
+  double aX,aY,aZ,aT;
   aX = CLHEP::RandFlat::shoot(engine, fMinX, fMaxX);
   aY = CLHEP::RandFlat::shoot(engine, fMinY, fMaxY);
   aZ = CLHEP::RandFlat::shoot(engine, fMinZ, fMaxZ);
+  aT = CLHEP::RandFlat::shoot(engine, fMinZ, fMaxZ);
 
   //if (fVertex == 0) fVertex = new CLHEP::Hep3Vector;
   //fVertex->set(aX,aY,aZ);
   if ( fVertex == 0 ) fVertex = new HepMC::FourVector() ;
-  fVertex->set(aX,aY,aZ,fTimeOffset);
+  fVertex->set(aX,aY,aZ,aT+fTimeOffset);
 
   return fVertex;
 }

--- a/IOMC/EventVertexGenerators/src/GaussEvtVtxGenerator.cc
+++ b/IOMC/EventVertexGenerators/src/GaussEvtVtxGenerator.cc
@@ -46,14 +46,15 @@ GaussEvtVtxGenerator::~GaussEvtVtxGenerator()
 
 //Hep3Vector* GaussEvtVtxGenerator::newVertex() {
 HepMC::FourVector* GaussEvtVtxGenerator::newVertex(CLHEP::HepRandomEngine* engine) {
-  double X,Y,Z;
+  double X,Y,Z,T;
   X = CLHEP::RandGaussQ::shoot(engine, fMeanX, fSigmaX);
   Y = CLHEP::RandGaussQ::shoot(engine, fMeanY, fSigmaY);
   Z = CLHEP::RandGaussQ::shoot(engine, fMeanZ, fSigmaZ);
+  T = CLHEP::RandGaussQ::shoot(engine, fTimeOffset, fSigmaZ);
 
   //if (fVertex == 0) fVertex = new CLHEP::Hep3Vector;
   if ( fVertex == 0 ) fVertex = new HepMC::FourVector() ;
-  fVertex->set( X, Y, Z, fTimeOffset ) ;
+  fVertex->set( X, Y, Z, T);
 
   return fVertex;
 }


### PR DESCRIPTION
More correct sampling of time of the main vertex in Flat and Gauss generators. These generators are not used by default.

Reduced unwanted new/delete in the generator interface.

Should not affect any result but tiny performance improvement.
