### PR TITLE
Remove line breaks. They cause problems

### DIFF
--- a/DataFormats/EgammaReco/src/classes_def.xml
+++ b/DataFormats/EgammaReco/src/classes_def.xml
@@ -4,32 +4,10 @@
   <class name="edm::reftobase::BaseHolder<reco::CaloCluster>"/>
   <class name="edm::reftobase::IndirectHolder<reco::CaloCluster>" />
 
-  <class name="edm::reftobase::Holder<
-    reco::CaloCluster,
-    edm::Ref<
-      std::vector<reco::SuperCluster>, reco::SuperCluster,
-      edm::refhelper::FindUsingAdvance<std::vector<reco::SuperCluster>,reco::SuperCluster>
-    >
-  >"/>
-  <class name="edm::reftobase::RefHolder<
-    edm::Ref<
-      std::vector<reco::SuperCluster>, reco::SuperCluster,
-      edm::refhelper::FindUsingAdvance<std::vector<reco::SuperCluster>,reco::SuperCluster>
-    >
-  >"/>
-  <class name="edm::reftobase::Holder<
-    reco::CaloCluster,
-    edm::Ref<
-      std::vector<reco::BasicCluster>, reco::BasicCluster,
-      edm::refhelper::FindUsingAdvance<std::vector<reco::BasicCluster>,reco::BasicCluster>
-    >
-  >"/>
-  <class name="edm::reftobase::RefHolder<
-    edm::Ref<
-      std::vector<reco::BasicCluster>, reco::BasicCluster,
-      edm::refhelper::FindUsingAdvance<std::vector<reco::BasicCluster>,reco::BasicCluster>
-    >
-  >"/>
+  <class name="edm::reftobase::Holder<reco::CaloCluster, edm::Ref<std::vector<reco::SuperCluster>, reco::SuperCluster, edm::refhelper::FindUsingAdvance<std::vector<reco::SuperCluster>,reco::SuperCluster> > >"/>
+  <class name="edm::reftobase::RefHolder<edm::Ref<std::vector<reco::SuperCluster>, reco::SuperCluster, edm::refhelper::FindUsingAdvance<std::vector<reco::SuperCluster>,reco::SuperCluster> > >"/>
+  <class name="edm::reftobase::Holder<reco::CaloCluster, edm::Ref<std::vector<reco::BasicCluster>, reco::BasicCluster, edm::refhelper::FindUsingAdvance<std::vector<reco::BasicCluster>,reco::BasicCluster> > >"/>
+  <class name="edm::reftobase::RefHolder<edm::Ref<std::vector<reco::BasicCluster>, reco::BasicCluster, edm::refhelper::FindUsingAdvance<std::vector<reco::BasicCluster>,reco::BasicCluster> > >"/>
 
   <class name="std::vector<reco::BasicCluster>"/>
   <class name="edm::Wrapper<std::vector<reco::BasicCluster> >"/>


### PR DESCRIPTION
Totally technical and trivial. Please bypass signatures if not signed promptly, and please merge as soon as convenient.
Line breaks in this classes_def.xml file now cause fatal problems in ROOT6. The dictionary is generated successfully, but the line breaks remain in the generated dictionary file, which now causes fatal compilation errors when the dictionary is compiled. Arguably, the dictionary generation by ROOT should remove the line breaks that cause problems, but the easiest and quickest way to fix this is to remove the line breaks in the xml file. 
