### PR TITLE
 updated GTs for 7_2_0_pre1

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -1,43 +1,43 @@
 autoCond = { 
     # GlobalTag for MC production with perfectly aligned and calibrated detector                                                                                                                              
-    'mc'                :   'MC_71_V6::All',
+    'mc'                :   'MC_72_V1::All',
     # GlobalTag for MC production with realistic alignment and calibrations
-    'startup'           :   'START71_V5::All',
+    'startup'           :   'START72_V1::All',
     # GlobalTag for MC production of Heavy Ions events with realistic alignment and calibrations
-    'starthi'           :   'STARTHI71_V9::All',
+    'starthi'           :   'STARTHI72_V1::All',
     # GlobalTag for MC production of p-Pb events with realistic alignment and calibrations
-    'startpa'           :   'STARTHI71_V10::All',
+    'startpa'           :   'STARTHI72_V2::All',
     # GlobalTag for data reprocessing: this should always be the GR_R tag
-    'com10'             :   'GR_R_71_V4::All',
+    'com10'             :   'GR_R_72_V1::All',
     # GlobalTag for running HLT on recent data: this should be the GR_P (prompt reco) global tag until a compatible GR_H tag is available, 
     # then it should point to the GR_H tag and override the connection string and pfnPrefix for use offline
     'hltonline'         :   'GR_H_V37::All,frontier://FrontierProd/CMS_COND_31X_GLOBALTAG,frontier://FrontierProd/',
     # GlobalTag for POSTLS1 upgrade studies:
-    'upgradePLS1'       :   'POSTLS171_V11::All',
-    'upgradePLS150ns'   :   'POSTLS171_V12::All',
+    'upgradePLS1'       :   'POSTLS172_V1::All',
+    'upgradePLS150ns'   :   'POSTLS172_V2::All',
     'upgrade2017'       :   'DES17_70_V2::All', # placeholder (GT not meant for standard RelVal)
     'upgrade2019'       :   'DES19_70_V2::All', # placeholder (GT not meant for standard RelVal)
     'upgradePLS3'       :   'POSTLS262_V1::All', # placeholder (GT not meant for standard RelVal)
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   'MC_71_V6::All',
+    'run1_design'       :   'MC_72_V1::All',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   'START71_V5::All',
+    'run1_mc'           :   'START72_V1::All',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   'STARTHI71_V9::All',
+    'run1_mc_hi'        :   'STARTHI72_V1::All',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pPb'       :   'STARTHI71_V10::All',
+    'run1_mc_pPb'       :   'STARTHI72_V2::All',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   'DESIGN71_V3::All',
+    'run2_design'       :   'DESIGN72_V1::All',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   'POSTLS171_V12::All',
+    'run2_mc_50ns'      :   'POSTLS172_V2::All',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   'POSTLS171_V11::All',
+    'run2_mc'           :   'POSTLS172_V1::All',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   'GR_R_71_V4::All',
+    'run1_data'         :   'GR_R_72_V1::All',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   'GR_R_71_V4::All',
+    'run2_data'         :   'GR_R_72_V1::All',
     # GlobalTag for Run2 HLT: it points to the online GT and overrides the connection string and pfnPrefix for use offline
     'run2_hlt'          :   'GR_H_V37::All,frontier://FrontierProd/CMS_COND_31X_GLOBALTAG,frontier://FrontierProd/',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017


### PR DESCRIPTION
Updating GTs for 7_2_0 cycle:
- new SiPixelGen errors (for data and MC GTs) 
- new RPC digitizer (for MC GTs)
- new MVA trainings of b-tagging algorithm (data and MC GTs)
- XML geometries fix for Run2 MC GTs
- restoring correct 2D b-tag probabilities for MC GTs
