### PR TITLE
Fix hf sl sampling factor

### DIFF
--- a/SLHCUpgradeSimulations/Configuration/python/customise_mixing.py
+++ b/SLHCUpgradeSimulations/Configuration/python/customise_mixing.py
@@ -32,8 +32,8 @@ def customise_NoCrossing(process):
     process.mix.mixObjects.mixTracks.makeCrossingFrame = cms.untracked.bool(False)
     process.mix.mixObjects.mixVertices.makeCrossingFrame = cms.untracked.bool(False)
     process.mix.mixObjects.mixHepMC.makeCrossingFrame = cms.untracked.bool(False)
-    process.digitisation_step.remove(process.simSiStripDigiSimLink)
-    process.digitisation_step.remove(process.mergedtruth)
+    #process.digitisation_step.remove(process.simSiStripDigiSimLink)
+    #process.digitisation_step.remove(process.mergedtruth)
     return (process)
 
 def customise_pixelMixing_PU(process):

--- a/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py
+++ b/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py
@@ -83,9 +83,9 @@ def customise_Digi(process):
             process.mix.digitizers.hcal.ho.pixels = cms.int32(2500)
             process.mix.digitizers.hcal.ho.doSiPMSmearing = cms.bool(False)
         if hasattr(process.mix.digitizers,'hcal') and hasattr(process.mix.digitizers.hcal,'hf1'):
-            process.mix.digitizers.hcal.hf1.samplingFactor = cms.double(0.50)
+            process.mix.digitizers.hcal.hf1.samplingFactor = cms.double(0.60)
         if hasattr(process.mix.digitizers,'hcal') and hasattr(process.mix.digitizers.hcal,'hf2'):
-            process.mix.digitizers.hcal.hf2.samplingFactor = cms.double(0.75)
+            process.mix.digitizers.hcal.hf2.samplingFactor = cms.double(0.60)
     return process
 
 

--- a/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py
+++ b/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py
@@ -37,7 +37,7 @@ def customisePostLS1(process):
 def digiEventContent(process):
     #extend the event content
 
-    alist=['RAWSIM','FEVTDEBUG','FEVTDEBUGHLT','GENRAW','RAWSIMHLT','FEVT']
+    alist=['RAWSIM','RAWDEBUG','FEVTDEBUG','FEVTDEBUGHLT','GENRAW','RAWSIMHLT','FEVT']
     for a in alist:
         b=a+'output'
         if hasattr(process,b):

--- a/SLHCUpgradeSimulations/Configuration/python/postLS1CustomsPreMixing.py
+++ b/SLHCUpgradeSimulations/Configuration/python/postLS1CustomsPreMixing.py
@@ -35,7 +35,7 @@ def customisePostLS1(process):
 def digiEventContent(process):
     #extend the event content
 
-    alist=['RAWSIM','FEVTDEBUG','FEVTDEBUGHLT','GENRAW','RAWSIMHLT','FEVT','PREMIX','PREMIXRAW']
+    alist=['RAWSIM','RAWDEBUG','FEVTDEBUG','FEVTDEBUGHLT','GENRAW','RAWSIMHLT','FEVT','PREMIX','PREMIXRAW']
     for a in alist:
         b=a+'output'
         if hasattr(process,b):

--- a/SLHCUpgradeSimulations/Configuration/python/postLS1CustomsPreMixing.py
+++ b/SLHCUpgradeSimulations/Configuration/python/postLS1CustomsPreMixing.py
@@ -60,9 +60,7 @@ def customise_Validation(process):
     #process.validation_step.remove(process.hltHiggsValidator)
     return process
 
-
 def customise_Digi(process):
-    process=digiEventContent(process)
     process=digiEventContent(process)
     if hasattr(process,'mix') and hasattr(process.mix,'digitizers'):
         if hasattr(process.mix.digitizers,'hcal') and hasattr(process.mix.digitizers.hcal,'ho'):

--- a/SLHCUpgradeSimulations/Configuration/python/postLS1CustomsPreMixing.py
+++ b/SLHCUpgradeSimulations/Configuration/python/postLS1CustomsPreMixing.py
@@ -63,11 +63,17 @@ def customise_Validation(process):
 
 def customise_Digi(process):
     process=digiEventContent(process)
-    if hasattr(process,"mix.digitizers.hcal.ho"):
-        process.mix.digitizers.hcal.ho.photoelectronsToAnalog = cms.vdouble([4.0]*16)
-        process.mix.digitizers.hcal.ho.siPMCode = cms.int32(1)
-        process.mix.digitizers.hcal.ho.pixels = cms.int32(2500)
-        process.mix.digitizers.hcal.ho.doSiPMSmearing = cms.bool(False)
+    process=digiEventContent(process)
+    if hasattr(process,'mix') and hasattr(process.mix,'digitizers'):
+        if hasattr(process.mix.digitizers,'hcal') and hasattr(process.mix.digitizers.hcal,'ho'):
+            process.mix.digitizers.hcal.ho.photoelectronsToAnalog = cms.vdouble([4.0]*16)
+            process.mix.digitizers.hcal.ho.siPMCode = cms.int32(1)
+            process.mix.digitizers.hcal.ho.pixels = cms.int32(2500)
+            process.mix.digitizers.hcal.ho.doSiPMSmearing = cms.bool(False)
+        if hasattr(process.mix.digitizers,'hcal') and hasattr(process.mix.digitizers.hcal,'hf1'):
+            process.mix.digitizers.hcal.hf1.samplingFactor = cms.double(0.60)
+        if hasattr(process.mix.digitizers,'hcal') and hasattr(process.mix.digitizers.hcal,'hf2'):
+            process.mix.digitizers.hcal.hf2.samplingFactor = cms.double(0.60)
     return process
 
 


### PR DESCRIPTION
New HF shower library validation shows a problem which is fixed by the change of samplingFactors for HF. Both factors should be 0.6.

PreMixing digi custom fragment is also changed to be identical for HCAL.

inside customise_mixing fragment 2 obsolete commands are commented out.

It is including also PR 4319 for consistency.
