### PR TITLE
Revert classversion.

### DIFF
--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -109,7 +109,7 @@
     <version ClassVersion="10" checksum="1628501942" />
   </class>
   <class name="std::vector<pat::tau::TauPFEssential>" />
-  <class name="pat::Photon"  ClassVersion="13">
+  <class name="pat::Photon"  ClassVersion="12">
    <field name="superClusterRelinked_" transient="true"/>
    <version ClassVersion="13" checksum="3948496360"/>
    <version ClassVersion="12" checksum="2518470540"/>


### PR DESCRIPTION
The forward port from CMSSW_7_0_X to CMSSW_7_1_X did not (by choice) include the changes to pat::Photon, hence the forward port must retain the old checksum. This should fix the issue.
