### PR TITLE
Adding offset parameter to the tau isolation

### DIFF
--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByIsolation.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByIsolation.cc
@@ -45,6 +45,8 @@ class PFRecoTauDiscriminationByIsolation : public PFTauDiscriminationProducerBas
       "applyRelativeSumPtCut");
     maximumRelativeSumPt_ = pset.getParameter<double>(
       "relativeSumPtCut");
+    offsetRelativeSumPt_ = pset.getParameter<double>(
+      "relativeSumPtOffset");
 
     storeRawOccupancy_ = pset.exists("storeRawOccupancy") ?
       pset.getParameter<bool>("storeRawOccupancy") : false;
@@ -168,6 +170,7 @@ class PFRecoTauDiscriminationByIsolation : public PFTauDiscriminationProducerBas
   double maximumSumPt_;
   bool applyRelativeSumPtCut_;
   double maximumRelativeSumPt_;
+  double offsetRelativeSumPt_;
   double customIsoCone_;
   
   // Options to store the raw value in the discriminator instead of boolean pass/fail flag
@@ -424,7 +427,7 @@ PFRecoTauDiscriminationByIsolation::discriminate(const PFTauRef& pfTau)
     failsSumPtCut = (totalPt > maximumSumPt_);
 
 //--- Relative Sum PT requirement
-    failsRelativeSumPtCut = (totalPt > (pfTau->pt()*maximumRelativeSumPt_));
+    failsRelativeSumPtCut = (totalPt > ((pfTau->pt() - offsetRelativeSumPt_)*maximumRelativeSumPt_));
   }
 
   bool fails = (applyOccupancyCut_ && failsOccupancyCut) ||

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByIsolation.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByIsolation.cc
@@ -45,8 +45,8 @@ class PFRecoTauDiscriminationByIsolation : public PFTauDiscriminationProducerBas
       "applyRelativeSumPtCut");
     maximumRelativeSumPt_ = pset.getParameter<double>(
       "relativeSumPtCut");
-    offsetRelativeSumPt_ = pset.getParameter<double>(
-      "relativeSumPtOffset");
+    offsetRelativeSumPt_ = pset.exists("relativeSumPtOffset") ?
+      pset.getParameter<double>("relativeSumPtOffset") : 0.0;
 
     storeRawOccupancy_ = pset.exists("storeRawOccupancy") ?
       pset.getParameter<bool>("storeRawOccupancy") : false;

--- a/RecoTauTag/RecoTau/python/PFRecoTauDiscriminationByIsolation_cfi.py
+++ b/RecoTauTag/RecoTau/python/PFRecoTauDiscriminationByIsolation_cfi.py
@@ -23,6 +23,7 @@ pfRecoTauDiscriminationByIsolation = cms.EDProducer("PFRecoTauDiscriminationByIs
 
     applyRelativeSumPtCut = cms.bool(False), # apply a cut on IsoPt/TotalPt
     relativeSumPtCut = cms.double(0.0),
+    relativeSumPtOffset = cms.double(0.0),
 
     qualityCuts = PFTauQualityCuts,# set the standard quality cuts
 


### PR DESCRIPTION
Modification in *byIsolation discriminant. Here offsetRelativeSumPt parameter was introduced to allow better combine absolute and relative isolation. Say, you want to have absolute isolation <3GeV till 60GeV and above it relative <0.1/Pt. To do so, you need move the latter by 30GeV, ie apply cut as <0.1/(Pt-30). It is new configuration possibility which is not being used by any sequence run by default, so no changes are expected.

@veelken, @mbluj
