### PR TITLE
From cmssw 7 1 0 pre8 fix ex4

### DIFF
--- a/PhysicsTools/PatExamples/test/analyzePatMuons_edm_cfg.py
+++ b/PhysicsTools/PatExamples/test/analyzePatMuons_edm_cfg.py
@@ -4,7 +4,7 @@ process = cms.Process("Test")
 
 process.source = cms.Source("PoolSource",
   fileNames = cms.untracked.vstring(
-    "file:patTuple.root"
+    "file:patTuple_standard.root"
   )
 )
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(100) )
@@ -19,7 +19,7 @@ process.MessageLogger = cms.Service("MessageLogger")
 ## PatMuonAnalyzer class in PhysicsTools/PatExamples/interface/PatMuonAnlyzer.h. You will also find
 ## back the input parameters to the module.
 process.patMuonAnalyzer = cms.EDAnalyzer("PatMuonEDAnalyzer",
-  muons = cms.InputTag("cleanPatMuons"),                                             
+  muons = cms.InputTag("selectedPatMuons"),                                             
 )
 
 process.TFileService = cms.Service("TFileService",

--- a/PhysicsTools/PatExamples/test/analyzePatMuons_fwlite_cfg.py
+++ b/PhysicsTools/PatExamples/test/analyzePatMuons_fwlite_cfg.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 process = cms.PSet()
 
 process.fwliteInput = cms.PSet(
-    fileNames   = cms.vstring('file:patTuple.root'),         ## mandatory
+    fileNames   = cms.vstring('file:patTuple_standard.root'),         ## mandatory
     maxEvents   = cms.int32(100),                            ## optional
     outputEvery = cms.uint32(10),                            ## optional
 )
@@ -14,5 +14,5 @@ process.fwliteOutput = cms.PSet(
 
 process.patMuonAnalyzer = cms.PSet(
     ## input specific for this analyzer
-    muons = cms.InputTag('cleanPatMuons')
+    muons = cms.InputTag('selectedPatMuons')
 )

--- a/PhysicsTools/PatExamples/test/analyzePatMuons_tuple1_cfg.py
+++ b/PhysicsTools/PatExamples/test/analyzePatMuons_tuple1_cfg.py
@@ -4,7 +4,7 @@ process = cms.Process("Test")
 
 process.source = cms.Source("PoolSource",
   fileNames = cms.untracked.vstring(
-    "file:patTuple.root"
+    "file:patTuple_standard.root"
   )
 )
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(100) )
@@ -15,7 +15,7 @@ process.MessageLogger = cms.Service("MessageLogger")
 ## This is an example of the use of the plain edm::Tuple dumper to analyze pat::Muons
 process.patMuonAnalyzer = cms.EDProducer(
     "CandViewNtpProducer", 
-    src = cms.InputTag("cleanPatMuons"),
+    src = cms.InputTag("selectedPatMuons"),
     lazyParser = cms.untracked.bool(True),
     prefix = cms.untracked.string(""),
     eventInfo = cms.untracked.bool(True),


### PR DESCRIPTION
Updated some PatExample/test files so that they run with CMSSW 7.
Updated collection and File names to be coherent with PhysicsTools/PatAlgos/test/patTuple_standard_cfg.py.
Used for the PAT Tutorial June 2014.
