### PR TITLE
Fix PixelTrackCleanerWrapper for quadruplet SeedingHitSet

### DIFF
--- a/RecoPixelVertexing/PixelTrackFitting/interface/PixelTrackCleanerWrapper.h
+++ b/RecoPixelVertexing/PixelTrackFitting/interface/PixelTrackCleanerWrapper.h
@@ -36,7 +36,10 @@ public:
        const std::vector<const TrackingRecHit *> & trhs = it->second;
        assert(!(trhs.size()<2));
        if (trhs.size()<2) continue;
-       SeedingHitSet ttrhs( hitMap[trhs[0]], hitMap[trhs[1]], trhs.size()>2 ? hitMap[trhs[2]] : SeedingHitSet::nullPtr()); 
+       SeedingHitSet ttrhs( hitMap[trhs[0]], hitMap[trhs[1]], 
+               trhs.size()>2 ? hitMap[trhs[2]] : SeedingHitSet::nullPtr(),
+               trhs.size()>3 ? hitMap[trhs[3]] : SeedingHitSet::nullPtr() ); 
+
        finalT_TTRHs.push_back( pixeltrackfitting::TrackWithTTRHs(it->first, ttrhs));
     }
     return finalT_TTRHs;


### PR DESCRIPTION
PixelTrackCleanerWrapper assumed SeeingHitSets have 2 or 3 hits, resulting in pixel tracks that have 3 hits although they were reconstructed from quadruplets. Fixed by storing also the 4th hit if there is one.

Should not affect on pt/eta/etc of pixel tracks because the cleaning is done after the fit, but distributions sensitive to the number of hits may be affected.

FYI @thokc @cerati @rovere @VinInn
