### PR TITLE
Use ROOT function GetMissingDictionaries

### DIFF
--- a/DataFormats/Provenance/src/ProductRegistry.cc
+++ b/DataFormats/Provenance/src/ProductRegistry.cc
@@ -28,10 +28,9 @@ namespace edm {
   namespace {
     void checkDicts(BranchDescription const& productDesc) {
       if(productDesc.transient()) {
-        checkDictionaries(productDesc.fullClassName(), true);
-        checkDictionaries(wrappedClassName(productDesc.fullClassName()), true);
+        checkClassDictionaries(wrappedClassName(productDesc.fullClassName()), false);
       } else {
-        checkDictionaries(wrappedClassName(productDesc.fullClassName()), false);
+        checkClassDictionaries(wrappedClassName(productDesc.fullClassName()), true);
       }
     }
   }
@@ -283,11 +282,9 @@ namespace edm {
 
       //only do the following if the data is supposed to be available in the event
       if(desc.present()) {
-        TypeWithDict type(TypeWithDict::byName(desc.className()));
-        TypeWithDict wrappedType(TypeWithDict::byName(wrappedClassName(desc.className())));
-        if(!bool(type) || !bool(wrappedType)) {
-          missingDicts.insert(desc.className());
-        } else {
+        bool hasDict = checkTypeDictionary(desc.className()) && checkClassDictionary(wrappedClassName(desc.className()));
+        if(hasDict) {
+          TypeWithDict type(TypeWithDict::byName(desc.className()));
           ProductHolderIndex index =
             productLookup(desc.branchType())->insert(type,
                                                      desc.moduleLabel().c_str(),

--- a/FWCore/Framework/src/Principal.cc
+++ b/FWCore/Framework/src/Principal.cc
@@ -37,7 +37,11 @@ namespace edm {
   void
   maybeThrowMissingDictionaryException(TypeID const& productType, bool isElement, std::vector<std::string> const& missingDictionaries) {
     if(binary_search_all(missingDictionaries, productType.className())) {
-      checkDictionaries(isElement ? productType.className() : wrappedClassName(productType.className()), false);
+      if(isElement) {
+        checkTypeDictionary(productType.className());
+      } else {
+        checkClassDictionary(wrappedClassName(productType.className()));
+      }
       throwMissingDictionariesException();
     }
   }

--- a/FWCore/Utilities/interface/DictionaryTools.h
+++ b/FWCore/Utilities/interface/DictionaryTools.h
@@ -56,11 +56,13 @@ bool
 is_RefToBaseVector(TypeWithDict const& possible_ref_vector,
                    TypeWithDict& value_type);
 
-void checkDictionaries(std::string const& name, bool noComponents = false);
+bool checkClassDictionary(std::string const& name);
+void checkClassDictionaries(std::string const& name, bool recursive = true);
+bool checkTypeDictionary(std::string const& name);
+void checkTypeDictionaries(std::string const& name, bool recursive = true);
 void throwMissingDictionariesException();
 void loadMissingDictionaries();
 StringSet& missingTypes();
-StringSet& foundTypes();
 
 void public_base_classes(TypeWithDict const& type,
                          std::vector<TypeWithDict>& baseTypes);

--- a/IOPool/Output/src/PoolOutputModule.cc
+++ b/IOPool/Output/src/PoolOutputModule.cc
@@ -94,8 +94,7 @@ namespace edm {
       SelectedProducts const& keptVector = keptProducts()[branchType];
       for(SelectedProducts::const_iterator it = keptVector.begin(), itEnd = keptVector.end(); it != itEnd; ++it) {
         BranchDescription const& prod = **it;
-        checkDictionaries(prod.fullClassName(), true);
-        checkDictionaries(wrappedClassName(prod.fullClassName()), true);
+        checkClassDictionaries(wrappedClassName(prod.fullClassName()), false);
       }
     }
   }

--- a/IOPool/Streamer/src/ClassFiller.cc
+++ b/IOPool/Streamer/src/ClassFiller.cc
@@ -18,7 +18,7 @@ namespace edm {
   void loadCap(std::string const& name) {
     FDEBUG(1) << "Loading dictionary for " << name << "\n";
     edmplugin::PluginCapabilities::get()->load(dictionaryPlugInPrefix() + name);
-    checkDictionaries(name);
+    checkClassDictionaries(name, true);
     if (!missingTypes().empty()) {
       StringSet missing = missingTypes();
       missingTypes().clear();


### PR DESCRIPTION
Use the new ROOT6 function TClass::GetMissingDictionaries to check for missing dictionaries.
Remove the code in CMS that did this, as it is no longer needed.
Please merge this promptly unless there are issues.
