### PR TITLE
Dictionary (classes*h) must have unique namespace or/and struct name

### DIFF
--- a/CondFormats/RunInfo/src/classes.h
+++ b/CondFormats/RunInfo/src/classes.h
@@ -1,6 +1,6 @@
 #include "CondFormats/RunInfo/src/headers.h"
 
-namespace {
+namespace CondFormats_RunInfo {
   struct dictionary {
     std::vector<runinfo_test::RunNumber::Item>::iterator tmp0;
     std::vector<L1TriggerScaler::Lumi>::iterator tmp1;

--- a/DataFormats/L1TCalorimeter/src/classes.h
+++ b/DataFormats/L1TCalorimeter/src/classes.h
@@ -12,7 +12,7 @@
 #include "DataFormats/L1TCalorimeter/interface/CaloTower.h"
 #include "DataFormats/L1TCalorimeter/interface/CaloCluster.h"
 
-namespace {
+namespace DataFormats_L1TCalorimeter {
   struct dictionary {
 
     l1t::CaloRegionBxCollection  caloRegionBxColl;

--- a/DataFormats/L1TGlobal/src/classes.h
+++ b/DataFormats/L1TGlobal/src/classes.h
@@ -2,7 +2,7 @@
 #include "DataFormats/L1TGlobal/interface/GlobalAlgBlk.h"
 #include "DataFormats/L1TGlobal/interface/GlobalExtBlk.h"
 
-namespace DataFormats_L1Trigger {
+namespace DataFormats_L1TGlobal {
   struct dictionary {
 
     GlobalAlgBlkBxCollection    uGtAlgBxColl;


### PR DESCRIPTION
This pull request creates or corrects unique namespaces based on package name.  This fix is needed for ROOT6 as classes*h files becomes a payload embedded into ROOT6 dictionary, which is executed in an interpreter (Cling) during dictionary loading procedure.
This fix is purely technical, so signatures should be bypassed if not signed in a reasonable amount of time.
