### PR TITLE
Backport eta range calo jet selector to71X

### DIFF
--- a/CommonTools/RecoAlgos/plugins/EtaRangeCaloJetSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/EtaRangeCaloJetSelector.cc
@@ -1,0 +1,18 @@
+/* \class EtaRangeCaloJetSelector
+ *
+ * selects calo-jet in the eta range
+ *
+ * \author: Silvio Donato
+ *
+ */
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "CommonTools/UtilAlgos/interface/EtaRangeSelector.h"
+#include "CommonTools/UtilAlgos/interface/SingleObjectSelector.h"
+#include "DataFormats/JetReco/interface/CaloJet.h"
+
+ typedef SingleObjectSelector<
+           reco::CaloJetCollection, 
+           EtaRangeSelector
+         > EtaRangeCaloJetSelector;
+
+DEFINE_FWK_MODULE( EtaRangeCaloJetSelector );

--- a/CommonTools/RecoAlgos/python/etaRangeCaloJetSelector_cfi.py
+++ b/CommonTools/RecoAlgos/python/etaRangeCaloJetSelector_cfi.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+
+etaRangeCaloJetSelector = cms.EDFilter( "EtaRangeCaloJetSelector",
+   src = cms.InputTag("hltCaloJetL1FastJetCorrected"),
+   etaMin = cms.double( -99.9 ), #2.4
+   etaMax = cms.double( +99.9 ), #2.4
+)
+


### PR DESCRIPTION
Backport EtaRangeCaloJetSelector (PR #4332 from @silviodonato) from 72X to 71X
It can be used for ConfDB parsing in the forthcoming possible 711
Since it is just the definition of a new module, with its python steering configuration, used nowhere in the current workflows, there is no need to wait for possible relvals in 720pre1
