### PR TITLE
Forward port HCAL fix of pre-mixing

### DIFF
--- a/EventFilter/HcalRawToDigi/src/HcalHTRData.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalHTRData.cc
@@ -248,7 +248,7 @@ void HcalHTRData::pack(unsigned char* daq_lengths, unsigned short* daq_samples,
   for (ichan=0; ichan<24; ichan++) {
     unsigned short chanid=((ichan%3)+((ichan/3)<<2))<<11;
     for (isample=0; isample<daq_lengths[ichan] && isample<MAXIMUM_SAMPLES_PER_CHANNEL; isample++) {
-      unsigned short basedata=daq_samples[ichan*MAXIMUM_SAMPLES_PER_CHANNEL+isample]&0x3FF;
+      unsigned short basedata=daq_samples[ichan*MAXIMUM_SAMPLES_PER_CHANNEL+isample]&0x7FF;
       if (do_capid) basedata=(basedata&0x7F)|(0x200)|((isample%4)<<7);
       ptr[daq_words_total]=chanid|basedata;
       daq_words_total++;

--- a/SimCalorimetry/HcalSimAlgos/interface/HcalElectronicsSim.h
+++ b/SimCalorimetry/HcalSimAlgos/interface/HcalElectronicsSim.h
@@ -24,7 +24,7 @@ namespace CLHEP {
 class HcalElectronicsSim {
 public:
   HcalElectronicsSim(HcalAmplifier * amplifier, 
-                     const HcalCoderFactory * coderFactory);
+                     const HcalCoderFactory * coderFactory, bool PreMix);
   ~HcalElectronicsSim();
 
   void setDbService(const HcalDbService * service);
@@ -48,5 +48,6 @@ private:
 
   int theStartingCapId;
   bool theStartingCapIdIsRandom;
+  bool PreMixDigis;
 };
 #endif

--- a/SimCalorimetry/HcalSimAlgos/interface/HcalSignalGenerator.h
+++ b/SimCalorimetry/HcalSimAlgos/interface/HcalSignalGenerator.h
@@ -13,13 +13,13 @@
 #include "SimCalorimetry/HcalSimAlgos/interface/HcalElectronicsSim.h"
 #include "SimCalorimetry/HcalSimAlgos/interface/HcalDigitizerTraits.h"
 #include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
 
 /** Converts digis back into analog signals, to be used
  *  as noise 
  */
 
 #include <iostream>
-#include <memory>
 
 namespace edm {
   class ModuleCallingContext;
@@ -77,7 +77,7 @@ public:
     else if(theEventPrincipal)
     {
        std::shared_ptr<edm::Wrapper<COLLECTION>  const> digisPTR =
-          edm::getProductByTag<COLLECTION>(*theEventPrincipal, theInputTag, mcc );
+	 edm::getProductByTag<COLLECTION>(*theEventPrincipal, theInputTag, mcc );
        if(digisPTR) {
           digis = digisPTR->product();
        }
@@ -134,13 +134,43 @@ private:
     HcalCoderDb coder (*channelCoder, *channelShape);
     CaloSamples result;
     coder.adc2fC(digi, result);
-    fC2pe(result);
 
-    //    std::cout << " HcalSignalGenerator: noise input " << digi << std::endl;
+    // first, check if there was an overflow in this fake digi:
+    bool overflow = false;
+    // find and list them
+
+    for(int isample=0; isample<digi.size(); ++isample) {
+      if(digi[isample].er()) overflow = true; 
+    }
+ 
+    if(overflow) {  // do full conversion, go back and overwrite fake entries
+ 
+      const HcalQIECoder* channelCoder = theConditions->getHcalCoder (cell);
+      const HcalQIEShape* channelShape = theConditions->getHcalShape (cell);
+      HcalCoderDb coder (*channelCoder, *channelShape);
+      coder.adc2fC(digi, result);
+ 
+      // overwrite with coded information
+      for(int isample=0; isample<digi.size(); ++isample) {
+	if(!digi[isample].er()) result[isample] = float(digi[isample].adc())/10.;
+      }
+    }
+    else {  // saves creating the coder, etc., every time
+      // use coded information
+      for(int isample=0; isample<digi.size(); ++isample) {
+	result[isample] = float(digi[isample].adc())/10.;
+      }
+      result.setPresamples(digi.presamples());
+    }
+ 
+    // std::cout << " HcalSignalGenerator: noise input ADC " << digi << std::endl;
+    // std::cout << " HcalSignalGenerator: noise input in fC " << result << std::endl;
+ 
+    // translation done in fC, convert to pe: 
+    fC2pe(result);
 
     return result;
   }
-
     
   /// these fields are set in initializeEvent()
   const edm::Event * theEvent;

--- a/SimCalorimetry/HcalSimAlgos/src/HcalElectronicsSim.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalElectronicsSim.cc
@@ -8,13 +8,14 @@
 #include "DataFormats/HcalDigi/interface/HcalUpgradeDataFrame.h"
 
 #include "CLHEP/Random/RandFlat.h"
+#include <math.h>
 
-
-HcalElectronicsSim::HcalElectronicsSim(HcalAmplifier * amplifier, const HcalCoderFactory * coderFactory)
+HcalElectronicsSim::HcalElectronicsSim(HcalAmplifier * amplifier, const HcalCoderFactory * coderFactory, bool PreMixing)
   : theAmplifier(amplifier),
     theCoderFactory(coderFactory),
     theStartingCapId(0),
-    theStartingCapIdIsRandom(true)
+    theStartingCapIdIsRandom(true),
+    PreMixDigis(PreMixing)
 {
 }
 
@@ -38,20 +39,84 @@ void HcalElectronicsSim::convert(CaloSamples & frame, Digi & result, CLHEP::HepR
 
 void HcalElectronicsSim::analogToDigital(CLHEP::HepRandomEngine* engine, CaloSamples & lf, HBHEDataFrame & result) {
   convert<HBHEDataFrame>(lf, result, engine);
+  if(PreMixDigis) {
+    for(int isample = 0; isample !=lf.size(); ++isample) {
+      uint16_t theADC = round(10.0*lf[isample]);
+      unsigned capId = result[isample].capid();
+
+      if(theADC > 126) {
+	uint16_t keepADC = result[isample].adc();
+	HcalQIESample mysamp(keepADC, capId, 0, 0, true, true); // set error bit as a flag
+	result.setSample(isample, HcalQIESample(keepADC, capId, 0, 0, true, true) );
+      }
+      else {
+	result.setSample(isample, HcalQIESample(theADC, capId, 0, 0) ); // preserve fC, no noise
+	HcalQIESample mysamp(theADC, capId, 0, 0);
+      }
+    }
+  }
 }
 
 
 void HcalElectronicsSim::analogToDigital(CLHEP::HepRandomEngine* engine, CaloSamples & lf, HODataFrame & result) {
   convert<HODataFrame>(lf, result, engine);
+  if(PreMixDigis) {
+    for(int isample = 0; isample !=lf.size(); ++isample) {
+      uint16_t theADC = round(10.0*lf[isample]);
+      unsigned capId = result[isample].capid();
+
+      if(theADC > 126) {
+	uint16_t keepADC = result[isample].adc();
+	HcalQIESample mysamp(keepADC, capId, 0, 0, true, true);// set error bit as a flag
+	result.setSample(isample, HcalQIESample(keepADC, capId, 0, 0, true, true) );
+      }
+      else {
+	result.setSample(isample, HcalQIESample(theADC, capId, 0, 0) ); // preserve fC, no noise
+	HcalQIESample mysamp(theADC, capId, 0, 0);
+      }
+    }
+  }
 }
 
 
 void HcalElectronicsSim::analogToDigital(CLHEP::HepRandomEngine* engine, CaloSamples & lf, HFDataFrame & result) {
   convert<HFDataFrame>(lf, result, engine);
+  if(PreMixDigis) {
+    for(int isample = 0; isample !=lf.size(); ++isample) {
+      uint16_t theADC = round(10.0*lf[isample]);
+      unsigned capId = result[isample].capid();
+
+      if(theADC > 126) {
+	uint16_t keepADC = result[isample].adc();
+	HcalQIESample mysamp(keepADC, capId, 0, 0, true, true);// set error bit as a flag
+	result.setSample(isample, HcalQIESample(keepADC, capId, 0, 0, true, true) );
+      }
+      else {
+	result.setSample(isample, HcalQIESample(theADC, capId, 0, 0)  );  // preserve fC, no noise
+	HcalQIESample mysamp(theADC, capId, 0, 0);
+      }
+    }
+  }
 }
 
 void HcalElectronicsSim::analogToDigital(CLHEP::HepRandomEngine* engine, CaloSamples & lf, ZDCDataFrame & result) {
   convert<ZDCDataFrame>(lf, result, engine);
+  if(PreMixDigis) {
+    for(int isample = 0; isample !=lf.size(); ++isample) {
+      uint16_t theADC = round(10.0*lf[isample]);
+      unsigned capId = result[isample].capid();
+
+      if(theADC > 126) {
+	uint16_t keepADC = result[isample].adc();
+	HcalQIESample mysamp(keepADC, capId, 0, 0, true, true);//set error bit as a flag
+	result.setSample(isample, HcalQIESample(keepADC, capId, 0, 0, true, true) );
+      }
+      else {
+	result.setSample(isample, HcalQIESample(theADC, capId, 0, 0)  );  // preserve fC, no noise
+	HcalQIESample mysamp(theADC, capId, 0, 0);
+      }
+    }
+  }
 }
 
 

--- a/SimCalorimetry/HcalSimAlgos/test/HcalDigitizerTest.cpp
+++ b/SimCalorimetry/HcalSimAlgos/test/HcalDigitizerTest.cpp
@@ -218,7 +218,7 @@ int main() {
   bool PM2 = false;
   HcalAmplifier amplifier(&parameterMap, addNoise, PM1, PM2);
   HcalCoderFactory coderFactory(HcalCoderFactory::NOMINAL);
-  HcalElectronicsSim electronicsSim(&amplifier, &coderFactory);
+  HcalElectronicsSim electronicsSim(&amplifier, &coderFactory, PM1);
   amplifier.setDbService(&calibratorHandle);
   parameterMap.setDbService(&calibratorHandle);
   siPMParameterMap.setDbService(&calibratorHandle);

--- a/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
+++ b/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
@@ -182,12 +182,12 @@ HcalDigitizer::HcalDigitizer(const edm::ParameterSet& ps, edm::ConsumesCollector
 
   //  std::cout << "HcalDigitizer: theUpgradeCoderFactory created" << std::endl;
 
-  theHBHEElectronicsSim = new HcalElectronicsSim(theHBHEAmplifier, theCoderFactory);
-  theHFElectronicsSim = new HcalElectronicsSim(theHFAmplifier, theCoderFactory);
-  theHOElectronicsSim = new HcalElectronicsSim(theHOAmplifier, theCoderFactory);
-  theZDCElectronicsSim = new HcalElectronicsSim(theZDCAmplifier, theCoderFactory);
-  theUpgradeHBHEElectronicsSim = new HcalElectronicsSim(theHBHEAmplifier, theUpgradeCoderFactory);
-  theUpgradeHFElectronicsSim = new HcalElectronicsSim(theHFAmplifier, theUpgradeCoderFactory);
+  theHBHEElectronicsSim = new HcalElectronicsSim(theHBHEAmplifier, theCoderFactory, PreMix1);
+  theHFElectronicsSim = new HcalElectronicsSim(theHFAmplifier, theCoderFactory, PreMix1);
+  theHOElectronicsSim = new HcalElectronicsSim(theHOAmplifier, theCoderFactory, PreMix1);
+  theZDCElectronicsSim = new HcalElectronicsSim(theZDCAmplifier, theCoderFactory, PreMix1);
+  theUpgradeHBHEElectronicsSim = new HcalElectronicsSim(theHBHEAmplifier, theUpgradeCoderFactory, PreMix1);
+  theUpgradeHFElectronicsSim = new HcalElectronicsSim(theHFAmplifier, theUpgradeCoderFactory, PreMix1);
 
   //  std::cout << "HcalDigitizer: theUpgradeElectronicsSim created" <<  std::endl; 
 

--- a/SimCalorimetry/HcalTestBeam/src/HcalTBDigiProducer.cc
+++ b/SimCalorimetry/HcalTestBeam/src/HcalTBDigiProducer.cc
@@ -51,7 +51,7 @@ HcalTBDigiProducer::HcalTBDigiProducer(const edm::ParameterSet& ps, edm::one::ED
   bool dummy2 = false;  // extra arguments for premixing
   theAmplifier = new HcalAmplifier(theParameterMap, doNoise, dummy1, dummy2);
   theCoderFactory = new HcalCoderFactory(HcalCoderFactory::DB);
-  theElectronicsSim = new HcalElectronicsSim(theAmplifier, theCoderFactory);
+  theElectronicsSim = new HcalElectronicsSim(theAmplifier, theCoderFactory, dummy1);
 
   theHBHEDigitizer = new HBHEDigitizer(theHBHEResponse, theElectronicsSim, doNoise);
   theHODigitizer = new HODigitizer(theHOResponse, theElectronicsSim, doNoise);

--- a/SimGeneral/DataMixingModule/python/mixOne_simraw_on_sim_cfi.py
+++ b/SimGeneral/DataMixingModule/python/mixOne_simraw_on_sim_cfi.py
@@ -54,6 +54,7 @@ muonDTDigis.inputLabel = 'rawDataCollector'
 #muonRPCDigis.InputLabel = 'rawDataCollector'
 #castorDigis.InputLabel = 'rawDataCollector'
 
+hcalDigis.FilterDataQuality = cms.bool(False)
 hcalSimBlock.HcalPreMixStage2 = cms.bool(True)
 
 mixData = cms.EDProducer("DataMixingModule",


### PR DESCRIPTION
This is forward port of HCAL pre-mixing fix 7_0_X (PR 4325) -> 7_1_X (PR 4379) -> 7_2_X .

This cannot be done automatically, because in 7_2_X boost::shared_ptr is substituted by std::shared_ptr.
