### PR TITLE
Fastsim data.vs.mc pu

### DIFF
--- a/Configuration/StandardSequences/python/Mixing.py
+++ b/Configuration/StandardSequences/python/Mixing.py
@@ -117,6 +117,10 @@ addMixingScenario("FS_mix_2012_Summer_inTimeOnly",{'file': 'FastSimulation.PileU
 addMixingScenario("FS_CSA14_inTimeOnly",{'file': 'FastSimulation.PileUpProducer.PileUpSimulator_CSA14_inTimeOnly_cff'})
 addMixingScenario("FS_E13TeV_AVE_10_inTimeOnly",{'file': 'FastSimulation.PileUpProducer.PileUpSimulator_E13TeV_AVE_10_inTimeOnly_cff'})
 addMixingScenario("FS_E13TeV_AVE_20_inTimeOnly",{'file': 'FastSimulation.PileUpProducer.PileUpSimulator_E13TeV_AVE_20_inTimeOnly_cff'})
+addMixingScenario("FS_E8TeV_2012_run198588",{'file': 'FastSimulation.PileUpProducer.PileUpSimulator_E8TeV_run198588_cff'})
+addMixingScenario("FS_E8TeV_2012_run203002",{'file': 'FastSimulation.PileUpProducer.PileUpSimulator_E8TeV_run203002_cff'})
+addMixingScenario("FS_E8TeV_2012_run209148",{'file': 'FastSimulation.PileUpProducer.PileUpSimulator_E8TeV_run209148_cff'})
+addMixingScenario("FS_E8TeV_2012_ZmumugSkim",{'file': 'FastSimulation.PileUpProducer.PileUpSimulator_E8TeV_zmmg_skim_cff'})
 
 #scenarios for L1 tdr work
 addMixingScenario("AVE_10_BX_25ns",{'file': 'SimGeneral.MixingModule.mix_POISSON_average_cfi','BX':25, 'B': (-12,3), 'N': 10})

--- a/FastSimulation/PileUpProducer/python/PileUpSimulator_E8TeV_run198588_cff.py
+++ b/FastSimulation/PileUpProducer/python/PileUpSimulator_E8TeV_run198588_cff.py
@@ -1,0 +1,58 @@
+from FastSimulation.PileUpProducer.PileUpSimulator8TeV_cfi import PileUpSimulatorBlock as _block8TeV
+from FastSimulation.Configuration.MixingFamos_cff import *
+
+#define the PU scenario itself
+famosPileUp.PileUpSimulator = _block8TeV.PileUpSimulator
+famosPileUp.PileUpSimulator.usePoisson = False
+
+famosPileUp.PileUpSimulator.probFunctionVariable = cms.vint32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45)
+famosPileUp.PileUpSimulator.probValue = cms.vdouble(
+                           0,
+                           0,
+                           0,
+                           0,
+                           0,
+                           0,
+                           0,
+                           0,
+                           0,
+                           0,
+                           0,
+                           0,
+                           0,
+                           0,
+                           0,
+                           0,
+                           0,
+                           0,
+                           0,
+                           0,
+                           0,
+                           0,
+                           0,
+                           0,
+                           0,
+                           0,
+                           0,
+                           0,
+                           0,
+                           0,
+                           0,
+                           0,
+                           0,
+                           0,
+                           0,
+                           0,
+                           0,
+                           0,
+                           0,
+                           0,
+                           0.0397281,
+                           0.294024,
+                           0.301409,
+                           0.226158,
+                           0.138681,
+                           0)
+
+#also import the "no PU" option with the MixingModule:
+from FastSimulation.PileUpProducer.mix_NoPileUp_cfi import *

--- a/FastSimulation/PileUpProducer/python/PileUpSimulator_E8TeV_run203002_cff.py
+++ b/FastSimulation/PileUpProducer/python/PileUpSimulator_E8TeV_run203002_cff.py
@@ -1,0 +1,57 @@
+from FastSimulation.PileUpProducer.PileUpSimulator8TeV_cfi import PileUpSimulatorBlock as _block8TeV
+from FastSimulation.Configuration.MixingFamos_cff import *
+
+#define the PU scenario itself
+famosPileUp.PileUpSimulator = _block8TeV.PileUpSimulator
+famosPileUp.PileUpSimulator.usePoisson = False
+
+famosPileUp.PileUpSimulator.probFunctionVariable = cms.vint32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45)
+famosPileUp.PileUpSimulator.probValue = cms.vdouble(
+                               0,
+                               0,
+                               0,
+                               0,
+                               0,
+                               9.66474e-17,
+                               1.21114e-12,
+                               2.94126e-09,
+                               1.44281e-06,
+                               0.000151792,
+                               0.00376088,
+                               0.0254935,
+                               0.0610745,
+                               0.0769054,
+                               0.076596,
+                               0.0737104,
+                               0.0720484,
+                               0.0702428,
+                               0.065689,
+                               0.0601684,
+                               0.05682,
+                               0.0557221,
+                               0.0551615,
+                               0.0541009,
+                               0.051686,
+                               0.0460924,
+                               0.0368461,
+                               0.0261355,
+                               0.0164099,
+                               0.0089456,
+                               0.00410306,
+                               0.00153858,
+                               0.000462258,
+                               0.000109812,
+                               2.04474e-05,
+                               2.96742e-06,
+                               3.34444e-07,
+                               2.9214e-08,
+                               1.97586e-09,
+                               1.03436e-10,
+                               4.19123e-12,
+                               1.31456e-13,
+                               3.19116e-15,
+                               5.99601e-17,
+                               8.75296e-19,
+                               0)
+#also import the "no PU" option with the MixingModule:
+from FastSimulation.PileUpProducer.mix_NoPileUp_cfi import *

--- a/FastSimulation/PileUpProducer/python/PileUpSimulator_E8TeV_run209148_cff.py
+++ b/FastSimulation/PileUpProducer/python/PileUpSimulator_E8TeV_run209148_cff.py
@@ -1,0 +1,33 @@
+from FastSimulation.PileUpProducer.PileUpSimulator8TeV_cfi import PileUpSimulatorBlock as _block8TeV
+from FastSimulation.Configuration.MixingFamos_cff import *
+
+#define the PU scenario itself
+famosPileUp.PileUpSimulator = _block8TeV.PileUpSimulator
+famosPileUp.PileUpSimulator.usePoisson = False
+
+famosPileUp.PileUpSimulator.probFunctionVariable = cms.vint32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,11,12,13,14,15,16,17,18,19,20)
+famosPileUp.PileUpSimulator.probValue = cms.vdouble(
+                    1.92747e-08,
+                    1.62702e-06,
+                    7.42292e-05,
+                    0.0017137,
+                    0.0191414,
+                    0.101638,
+                    0.258023,
+                    0.322184,
+                    0.207559,
+                    0.0730289,
+                    0.0147525,
+                    0.0017561,
+                    0.000123411,
+                    5.07434e-06,
+                    1.20848e-07,
+                    1.6531e-09,
+                    1.29003e-11,
+                    5.7105e-14,
+                    1.42153e-16,
+                    0,
+                    0)
+
+#also import the "no PU" option with the MixingModule:
+from FastSimulation.PileUpProducer.mix_NoPileUp_cfi import *

--- a/FastSimulation/PileUpProducer/python/PileUpSimulator_E8TeV_zmmg_skim_cff.py
+++ b/FastSimulation/PileUpProducer/python/PileUpSimulator_E8TeV_zmmg_skim_cff.py
@@ -1,0 +1,67 @@
+from FastSimulation.PileUpProducer.PileUpSimulator8TeV_cfi import PileUpSimulatorBlock as _block8TeV
+from FastSimulation.Configuration.MixingFamos_cff import *
+
+#define the PU scenario itself
+famosPileUp.PileUpSimulator = _block8TeV.PileUpSimulator
+famosPileUp.PileUpSimulator.usePoisson = False
+
+famosPileUp.PileUpSimulator.probFunctionVariable = cms.vint32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55)
+famosPileUp.PileUpSimulator.probValue = cms.vdouble(
+                       2.22595e-08,
+                       2.00205e-07,
+                       1.64416e-06,
+                       1.14116e-05,
+                       6.40739e-05,
+                       0.000284833,
+                       0.000994025,
+                       0.00272863,
+                       0.00613133,
+                       0.0135242,
+                       0.0322459,
+                       0.0601265,
+                       0.0778966,
+                       0.0818541,
+                       0.0798978,
+                       0.0752475,
+                       0.0687418,
+                       0.0636304,
+                       0.0604193,
+                       0.0571488,
+                       0.0537445,
+                       0.050468,
+                       0.0470076,
+                       0.04297,
+                       0.0377791,
+                       0.0310346,
+                       0.0231801,
+                       0.0154523,
+                       0.00910777,
+                       0.00473839,
+                       0.00218447,
+                       0.000898356,
+                       0.000331497,
+                       0.000110006,
+                       3.27802e-05,
+                       8.75341e-06,
+                       2.1002e-06,
+                       4.58968e-07,
+                       9.41886e-08,
+                       1.90252e-08,
+                       3.95869e-09,
+                       8.60669e-10,
+                       1.91046e-10,
+                       4.18017e-11,
+                       8.78577e-12,
+                       1.74995e-12,
+                       3.28416e-13,
+                       5.79467e-14,
+                       9.60488e-15,
+                       1.49505e-15,
+                       2.18539e-16,
+                       2.99303e-17,
+                       3.87579e-18,
+                       4.53878e-19,
+                       3.6847e-20,
+                       0)
+#also import the "no PU" option with the MixingModule:
+from FastSimulation.PileUpProducer.mix_NoPileUp_cfi import *


### PR DESCRIPTION
fastsim pu scenarios for first data.vs.mc exercise

fastsim equivalent of https://github.com/cms-sw/cmssw/pull/4338/

call pu options in cmsDriver command as follows:
--pileup=E8TeV_2012_ZmumugSkim
--pileup=E8TeV_2012_run209148
--pileup=E8TeV_2012_run203002
--pileup=E8TeV_2012_run198588

these 4 new options were tested, generating 4 events.
true number of pu interactions was inspected visually
