### PR TITLE
Remove CMSSW duplicates of dictionaries defined in ROOT

### DIFF
--- a/DataFormats/StdDictionaries/src/classes_def_vector.xml
+++ b/DataFormats/StdDictionaries/src/classes_def_vector.xml
@@ -10,8 +10,6 @@
  <class name="std::vector<long long>"/>
  <class name="std::vector<short>"/>
  <class name="std::vector<std::basic_string<char> >"/>
- <class name="std::vector<std::basic_string<char> >::const_iterator"/>
- <class name="std::vector<std::basic_string<char> >::iterator"/>
  <class name="std::vector<std::map<short,short> >"/>
  <class name="std::vector<std::pair<double,double> >"/>
  <class name="std::vector<std::pair<double,std::vector<double> > >"/>

--- a/DataFormats/StdDictionaries/src/classes_vector.h
+++ b/DataFormats/StdDictionaries/src/classes_vector.h
@@ -44,7 +44,6 @@ namespace DataFormats_StdDictionaries {
   std::vector<std::pair<unsigned int,unsigned int> > dummyvpuu;
   std::vector<std::pair<unsigned long long,std::basic_string<char> > > v_ull_s;
   std::vector<std::string> dummy5;
-  std::vector<std::string>::iterator itstring;
   std::vector<std::vector<double> > v_v_d;
   std::vector<std::vector<float> > v_v_f;
   std::vector<std::vector<int> > v_v_i;


### PR DESCRIPTION
In ROOT 6, many dictionaries for iterators are defined internally in ROOT libraries.  Two of these are also
defined in CMSSW.  This results in ubiquitous warning messages.
This pull request removes the duplicate definitions for these iterators, and eliminates the warnings.
Please merge promptly.
