### PR TITLE
TLRs for run2 data processing configurations (start from CSC)

### DIFF
--- a/Configuration/DataProcessing/python/Impl/cosmicsRun2.py
+++ b/Configuration/DataProcessing/python/Impl/cosmicsRun2.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+"""
+_cosmicsRun2_
+
+Scenario supporting cosmic data taking
+
+"""
+
+import os
+import sys
+
+from Configuration.DataProcessing.Reco import Reco
+from Configuration.DataProcessing.RecoTLR import customiseCosmicDataRun2
+
+class cosmicsRun2(Reco):
+    def __init__(self):
+        self.recoSeq=''
+        self.cbSc='cosmics'
+    """
+    _cosmicsRun2_
+
+    Implement configuration building for data processing for cosmic
+    data taking in Run2
+
+    """
+
+
+    def promptReco(self, globalTag, **args):
+        """
+        _promptReco_
+
+        Cosmic data taking prompt reco
+
+        """
+        if not 'skims' in args:
+            args['skims']= ['@allForPromptCosmics']
+        process = Reco.promptReco(self,globalTag, **args)
+
+        customiseCosmicDataRun2(process)  
+        return process
+
+
+    def expressProcessing(self, globalTag, **args):
+        """
+        _expressProcessing_
+
+        Cosmic data taking express processing
+
+        """
+
+        if not 'skims' in args:
+            args['skims']= ['@allForExpressCosmics']
+        process = Reco.expressProcessing(self,globalTag, **args)
+
+        customiseCosmicDataRun2(process)  
+        return process
+
+
+    def alcaHarvesting(self, globalTag, datasetName, **args):
+        """
+        _alcaHarvesting_
+
+        Proton collisions data taking AlCa Harvesting
+
+        """
+        if not 'skims' in args:
+            args['skims']=['SiStripQuality']
+            
+        return Reco.alcaHarvesting(self, globalTag, datasetName, **args)

--- a/Configuration/DataProcessing/python/Impl/ppRun2.py
+++ b/Configuration/DataProcessing/python/Impl/ppRun2.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+"""
+_ppRun2_
+
+Scenario supporting proton collisions
+
+"""
+
+import os
+import sys
+
+from Configuration.DataProcessing.Reco import Reco
+import FWCore.ParameterSet.Config as cms
+from Configuration.DataProcessing.RecoTLR import customisePromptRun2,customiseExpressRun2
+
+class ppRun2(Reco):
+    def __init__(self):
+        self.recoSeq=''
+        self.cbSc='pp'
+    """
+    _ppRun2_
+
+    Implement configuration building for data processing for proton
+    collision data taking for Run2
+
+    """
+
+
+    def promptReco(self, globalTag, **args):
+        """
+        _promptReco_
+
+        Proton collision data taking prompt reco
+
+        """
+        if not 'skims' in args:
+            args['skims']=['@allForPrompt']
+        process = Reco.promptReco(self,globalTag, **args)
+
+        #add the former top level patches here
+        customisePromptRun2(process)
+        
+        return process
+
+
+    def expressProcessing(self, globalTag, **args):
+        """
+        _expressProcessing_
+
+        Proton collision data taking express processing
+
+        """
+        if not 'skims' in args:
+            args['skims']=['@allForExpress']
+        process = Reco.expressProcessing(self,globalTag, **args)
+        
+        customiseExpressRun2(process)
+                
+        return process
+
+
+    def alcaHarvesting(self, globalTag, datasetName, **args):
+        """
+        _alcaHarvesting_
+
+        Proton collisions data taking AlCa Harvesting
+
+        """
+        if not 'skims' in args:
+            args['skims']=['BeamSpotByRun',
+                           'BeamSpotByLumi',
+                           'SiStripQuality']
+            
+        return Reco.alcaHarvesting(self, globalTag, datasetName, **args)
+

--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -24,6 +24,30 @@ def customiseCosmicData(process):
 
     return process
 
+
+
+##############################################################################
+# this is supposed to be added on top of other (Run1) data customs
+def customiseDataRun2Common(process):
+    process.CSCGeometryESModule.useGangedStripsInME1a = cms.bool(False)
+    process.CSCIndexerESProducer.AlgoName=cms.string("CSCIndexerPostls1")
+    process.CSCChannelMapperESProducer.AlgoName=cms.string("CSCChannelMapperPostls1")
+    process.csc2DRecHits.readBadChannels = cms.bool(False)
+    process.csc2DRecHits.CSCUseGasGainCorrections = cms.bool(False)
+    if hasattr(process,'valCscTriggerPrimitiveDigis'):
+        #this is not doing anything at the moment
+        process.valCscTriggerPrimitiveDigis.commonParam.gangedME1a = cms.untracked.bool(False)
+    if hasattr(process,'valCsctfTrackDigis'):
+        process.valCsctfTrackDigis.gangedME1a = cms.untracked.bool(False)
+    return process
+
+##############################################################################
+def customiseCosmicDataRun2(process):
+    process = customiseCosmicData(process)
+    process = customiseDataRun2Common(process)
+    return process
+
+
 ##############################################################################
 def customiseCosmicMC(process):
     
@@ -46,6 +70,12 @@ def customiseExpress(process):
     return process
 
 ##############################################################################
+def customiseExpressRun2(process):
+    process = customiseExpress(process)
+    process = customiseDataRun2Common(process)
+    return process
+
+##############################################################################
 def customisePrompt(process):
     process= customisePPData(process)
 
@@ -54,6 +84,11 @@ def customisePrompt(process):
     return process
 
 ##############################################################################
+def customisePromptRun2(process):
+    process = customisePrompt(process)
+    process = customiseDataRun2Common(process)
+    return process
+
 ##############################################################################
 
 #gone with the fact that there is no difference between production and development sequence

--- a/Configuration/DataProcessing/test/cosmicsRun2_t.py
+++ b/Configuration/DataProcessing/test/cosmicsRun2_t.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+"""
+_cosmicsRun2_
+
+Test for CosmicsRun2 Scenario implementation
+
+"""
+
+
+import unittest
+import FWCore.ParameterSet.Config as cms
+from Configuration.DataProcessing.GetScenario import getScenario
+
+
+
+def writePSetFile(name, process):
+    """
+    _writePSetFile_
+
+    Util to dump the process to a file
+
+    """
+    handle = open(name, 'w')
+    handle.write(process.dumpPython())
+    handle.close()
+
+
+class cosmicsRun2ScenarioTest(unittest.TestCase):
+    """
+    unittest for cosmicsRun2 scenario
+
+    """
+
+    def testA(self):
+        """get the scenario"""
+        try:
+            scenario = getScenario("cosmicsRun2")
+        except Exception, ex:
+            msg = "Failed to get cosmicsRun2 scenario\n"
+            msg += str(ex)
+            self.fail(msg)
+
+
+    def testPromptReco(self):
+        """test promptReco method"""
+        scenario = getScenario("cosmicsRun2")
+        try:
+            process = scenario.promptReco("GLOBALTAG::ALL")
+            writePSetFile("testPromptReco.py", process)
+        except Exception, ex:
+            msg = "Failed to create Prompt Reco configuration\n"
+            msg += "for cosmicsRun2 Scenario\n"
+            msg += str(ex)
+            self.fail(msg)
+
+
+    def testExpressProcessing(self):
+        """ test expressProcessing method"""
+        scenario = getScenario("cosmicsRun2")
+        try:
+            process = scenario.expressProcessing("GLOBALTAG::ALL")
+            writePSetFile("testExpressProcessing.py", process)
+        except Exception, ex:
+            msg = "Failed to create Express Processing configuration\n"
+            msg += "for cosmicsRun2 Scenario\n"
+            msg += str(ex)
+            self.fail(msg)
+
+
+    def testAlcaSkim(self):
+        """ test alcaSkim method"""
+        scenario = getScenario("cosmicsRun2")
+        try:
+            process = scenario.alcaSkim(["MuAlCalIsolatedMu"])
+            writePSetFile("testAlcaReco.py", process)
+        except Exception, ex:
+           msg = "Failed to create Alca Skimming configuration\n"
+           msg += "for cosmicsRun2 Scenario\n"
+           msg += str(ex)
+           self.fail(msg)
+
+
+    def testDQMHarvesting(self):
+        """test dqmHarvesting  method"""
+        scenario = getScenario("cosmicsRun2")
+        try:
+            process = scenario.dqmHarvesting("dataset", 123456,
+                                             "GLOBALTAG::ALL")
+            writePSetFile("testDQMHarvesting.py", process)
+        except Exception, ex:
+            msg = "Failed to create DQM Harvesting configuration "
+            msg += "for cosmicsRun2 scenario:\n"
+            msg += str(ex)
+            self.fail(msg)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Configuration/DataProcessing/test/ppRun2_t.py
+++ b/Configuration/DataProcessing/test/ppRun2_t.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+"""
+_ppRun2_
+
+Test for Collision Scenario implementation
+
+"""
+
+
+import unittest
+import FWCore.ParameterSet.Config as cms
+from Configuration.DataProcessing.GetScenario import getScenario
+
+
+
+def writePSetFile(name, process):
+    """
+    _writePSetFile_
+
+    Util to dump the process to a file
+
+    """
+    handle = open(name, 'w')
+    handle.write(process.dumpPython())
+    handle.close()
+
+
+class ppRun2ScenarioTest(unittest.TestCase):
+    """
+    unittest for ppRun2 collisions scenario
+
+    """
+
+    def testA(self):
+        """get the scenario"""
+        try:
+            scenario = getScenario("ppRun2")
+        except Exception, ex:
+            msg = "Failed to get ppRun2 scenario\n"
+            msg += str(ex)
+            self.fail(msg)
+
+
+    def testPromptReco(self):
+        """test promptReco method"""
+        scenario = getScenario("ppRun2")
+        try:
+            process = scenario.promptReco("GLOBALTAG::ALL")
+            writePSetFile("testPromptReco.py", process)
+        except Exception, ex:
+            msg = "Failed to create Prompt Reco configuration\n"
+            msg += "for ppRun2 Scenario\n"
+            msg += str(ex)
+            self.fail(msg)
+
+
+    def testExpressProcessing(self):
+        """ test expressProcessing method"""
+        scenario = getScenario("ppRun2")
+        try:
+            process = scenario.expressProcessing("GLOBALTAG::ALL")
+            writePSetFile("testExpressProcessing.py", process)
+        except Exception, ex:
+            msg = "Failed to create Express Processing configuration\n"
+            msg += "for ppRun2 Scenario\n"
+            msg += str(ex)
+            self.fail(msg)
+
+
+    def testAlcaSkim(self):
+        """ test alcaSkim method"""
+        scenario = getScenario("ppRun2")
+        try:
+            process = scenario.alcaSkim(["MuAlCalIsolatedMu"])
+            writePSetFile("testAlcaReco.py", process)
+        except Exception, ex:
+           msg = "Failed to create Alca Skimming configuration\n"
+           msg += "for ppRun2 Scenario\n"
+           msg += str(ex)
+           self.fail(msg)
+
+
+    def testDQMHarvesting(self):
+        """test dqmHarvesting  method"""
+        scenario = getScenario("ppRun2")
+        try:
+            process = scenario.dqmHarvesting("dataset", 123456,
+                                             "GLOBALTAG::ALL")
+            writePSetFile("testDQMHarvesting.py", process)
+        except Exception, ex:
+            msg = "Failed to create DQM Harvesting configuration "
+            msg += "for ppRun2 scenario:\n"
+            msg += str(ex)
+            self.fail(msg)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Configuration/DataProcessing/test/run_CfgTest.sh
+++ b/Configuration/DataProcessing/test/run_CfgTest.sh
@@ -15,6 +15,8 @@ INPUT=${LOCAL_TEST_DIR}/RunExpressProcessing.py
 
 runTest "${INPUT} --scenario cosmics --global-tag GLOBALTAG::ALL --lfn /store/whatever --fevt --alca --dqm"
 runTest "${INPUT} --scenario pp --global-tag GLOBALTAG::ALL --lfn /store/whatever --fevt --alca --dqm"
+runTest "${INPUT} --scenario cosmicsRun2 --global-tag GLOBALTAG::ALL --lfn /store/whatever --fevt --alca --dqm"
+runTest "${INPUT} --scenario ppRun2 --global-tag GLOBALTAG::ALL --lfn /store/whatever --fevt --alca --dqm"
 runTest "${INPUT} --scenario HeavyIons --global-tag GLOBALTAG::ALL --lfn /store/whatever --fevt --alca --dqm"
 
 
@@ -27,6 +29,8 @@ INPUT=${LOCAL_TEST_DIR}/RunPromptReco.py
 
 runTest "${INPUT} --scenario=cosmics --reco --aod --alcareco --dqm --global-tag GLOBALTAG::ALL --lfn=/store/whatever"
 runTest "${INPUT} --scenario=pp --reco --aod --alcareco --dqm --global-tag GLOBALTAG::ALL --lfn=/store/whatever"
+runTest "${INPUT} --scenario=cosmicsRun2 --reco --aod --alcareco --dqm --global-tag GLOBALTAG::ALL --lfn=/store/whatever"
+runTest "${INPUT} --scenario=ppRun2 --reco --aod --alcareco --dqm --global-tag GLOBALTAG::ALL --lfn=/store/whatever"
 runTest "${INPUT} --scenario=HeavyIons --reco --aod --alcareco --dqm --global-tag GLOBALTAG::ALL --lfn=/store/whatever"
 runTest "${INPUT} --scenario=AlCaLumiPixels --reco --aod --alcareco --dqm --global-tag GLOBALTAG::ALL --lfn=/store/whatever"
 #runTest "${INPUT} --scenario=AlCaP0 --reco --aod --alcareco --dqm --global-tag GLOBALTAG::ALL --lfn=/store/whatever"
@@ -38,6 +42,8 @@ INPUT=${LOCAL_TEST_DIR}/RunAlcaSkimming.py
 
 runTest "${INPUT} --scenario pp --lfn=/store/whatever --global-tag GLOBALTAG::ALL --skims SiStripCalZeroBias,SiStripCalMinBias,TkAlMinBias,PromptCalibProd"
 runTest "${INPUT} --scenario cosmics --lfn /store/whatever --global-tag GLOBALTAG::ALL --skims SiStripCalZeroBias,SiStripPCLHistos"
+runTest "${INPUT} --scenario ppRun2 --lfn=/store/whatever --global-tag GLOBALTAG::ALL --skims SiStripCalZeroBias,SiStripCalMinBias,TkAlMinBias,PromptCalibProd"
+runTest "${INPUT} --scenario cosmicsRun2 --lfn /store/whatever --global-tag GLOBALTAG::ALL --skims SiStripCalZeroBias,SiStripPCLHistos"
 runTest "${INPUT} --scenario HeavyIons --lfn=/store/whatever --global-tag GLOBALTAG::ALL --skims SiStripCalZeroBias,SiStripCalMinBias,TkAlMinBiasHI,PromptCalibProd"
 runTest "${INPUT} --scenario AlCaLumiPixels --lfn /store/whatever --global-tag GLOBALTAG::ALL --skims LumiPixels"
 #runTest "${INPUT} --scenario AlCaP0 --lfn /store/whatever --global-tag GLOBALTAG::ALL --skims EcalCalPi0Calib"
@@ -48,12 +54,16 @@ INPUT=${LOCAL_TEST_DIR}/RunAlcaHarvesting.py
 
 runTest "${INPUT} --scenario pp --lfn /store/whatever --dataset /A/B/C --global-tag GLOBALTAG::ALL --workflows=BeamSpotByRun,BeamSpotByLumi,SiStripQuality"
 runTest "${INPUT} --scenario cosmics --lfn /store/whatever --dataset /A/B/C --global-tag GLOBALTAG::ALL --workflows=SiStripQuality"
+runTest "${INPUT} --scenario ppRun2 --lfn /store/whatever --dataset /A/B/C --global-tag GLOBALTAG::ALL --workflows=BeamSpotByRun,BeamSpotByLumi,SiStripQuality"
+runTest "${INPUT} --scenario cosmicsRun2 --lfn /store/whatever --dataset /A/B/C --global-tag GLOBALTAG::ALL --workflows=SiStripQuality"
 runTest "${INPUT} --scenario HeavyIons --lfn /store/whatever --dataset /A/B/C --global-tag GLOBALTAG::ALL --workflows=BeamSpotByRun,BeamSpotByLumi,SiStripQuality"
 
 INPUT=${LOCAL_TEST_DIR}/RunDQMHarvesting.py
 
 runTest "${INPUT} --scenario pp --lfn /store/whatever --run 12345 --dataset /A/B/C --global-tag GLOBALTAG::ALL"
 runTest "${INPUT} --scenario cosmics --lfn /store/whatever --run 12345 --dataset /A/B/C --global-tag GLOBALTAG::ALL"
+runTest "${INPUT} --scenario ppRun2 --lfn /store/whatever --run 12345 --dataset /A/B/C --global-tag GLOBALTAG::ALL"
+runTest "${INPUT} --scenario cosmicsRun2 --lfn /store/whatever --run 12345 --dataset /A/B/C --global-tag GLOBALTAG::ALL"
 runTest "${INPUT} --scenario AlCaLumiPixels --lfn /store/whatever --run 12345 --dataset /A/B/C --global-tag GLOBALTAG::ALL"
 #runTest "${INPUT} --scenario AlCaP0 --lfn /store/whatever --run 12345 --dataset /A/B/C --global-tag GLOBALTAG::ALL"
 #runTest "${INPUT} --scenario AlCaPhiSymEcal --lfn /store/whatever --run 12345 --dataset /A/B/C --global-tag GLOBALTAG::ALL"


### PR DESCRIPTION
RecoTLR.py functions to modify the prompt and express processing for run2 detector.
These come with new DataProcessing scenarios (based on config builder pp and cosmics scenarios).
Aiming for July global runs.

Can be tested by calling the regular T0  cmsDriver versions of these (see e.g. 1000.0 or 1001.0)  `Configuration/DataProcessing/RecoTLR.customisePromptRun1` and `Configuration/DataProcessing/RecoTLR.customiseExpressRun2` for pp or `Configuration/DataProcessing/RecoTLR.customiseCosmicDataRun2` for cosmics.

Tested on ~50K events from a local CSC runs.
Taking 221766 as an example, fairly high level reco returns decent results
![all_cscrun2modvscscrun2mod_cp_csc00221766c_recomuons_muonsfromcosmics__rereco_obj_time_timeatipinout](https://cloud.githubusercontent.com/assets/4676718/3393473/dccce802-fcc5-11e3-8dce-9f25012869e2.png)
![all_cscrun2modvscscrun2mod_cp_csc00221766c_recomuons_muonsfromcosmics__rereco_obj_phi](https://cloud.githubusercontent.com/assets/4676718/3393475/e901ced0-fcc5-11e3-9ae3-51c7554b8dc4.png)
![all_cscrun2modvscscrun2mod_cp_csc00221766c_recomuons_muonsfromcosmics__rereco_obj_eta](https://cloud.githubusercontent.com/assets/4676718/3393484/f64bd25c-fcc5-11e3-8689-34cd4568d5e0.png)
