### PR TITLE
EvF lumiblock consistency cross-check (backport of #4399)

### DIFF
--- a/EventFilter/Utilities/plugins/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/plugins/FedRawDataInputSource.cc
@@ -825,6 +825,11 @@ void FedRawDataInputSource::readSupervisor()
 	fileQueue_.push(new InputFile(evf::EvFDaqDirector::newLumi, currentLumiSection));
       }
 
+      if( getLSFromFilename_ && currentLumiSection>0 && ls < currentLumiSection) {
+          edm::LogError("FedRawDataInputSource") << "Got old LS ("<<ls<<") file from EvFDAQDirector! Expected LS:" << currentLumiSection<<". Aborting execution."<<std::endl;
+          _exit(-1);
+      }
+
       int dbgcount=0;
       if (status == evf::EvFDaqDirector::noFile) {
 	dbgcount++;

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -404,8 +404,10 @@ namespace evf {
 	if (testModeNoBuilderUnit_)
 	  fscanf(fu_rw_lock_stream, "%u %u %u %u", &readLs, &readIndex,
 		 &jumpLs, &jumpIndex);
-	else
+	else {
 	  fscanf(fu_rw_lock_stream, "%u %u", &readLs, &readIndex);
+	  edm::LogInfo("EvFDaqDirector") << "Read fu.lock file file -: " << readLs << ":" << readIndex;
+        }
 
 	// try to bump
 	bool bumpedOk = bumpFile(readLs, readIndex, nextFile, fsize);
@@ -517,16 +519,14 @@ namespace evf {
       bool eolFound = (stat(getEoLSFilePathOnBU(ls).c_str(), &buf) == 0);
       unsigned int startingLumi = ls;
       while (eolFound) {
-        //DEBUG!
-        //remove this for testing (might not be necessary after all..)
-        /*
+
         // recheck that no raw file appeared in the meantime
         if (stat(nextFile.c_str(), &buf) == 0) {
           previousFileSize_ = buf.st_size;
           fsize = buf.st_size;
           return true;
         }
-        */
+
 	// this lumi ended, check for files
 	++ls;
 	nextFile = getInputJsonFilePath(ls,0);


### PR DESCRIPTION
Hi,
this resolves a very recently found issue in DAQ where there is a problem in input discovery that might cause events being processed assuming wrong lumisection number. I am also posting to  cms-release-dataops egroup to inform about this. Please merge for 7_1_1 if possible.

*revert removing check for json file after EoLS has appeared
*check that LS is consistent with the one coming from information shared among multiple CMSSW processes
*add several info logs to verify what was written in the lock file
