### PR TITLE
Fix typo in parameter name - should be automatically forwarded to 72X as well

### DIFF
--- a/SLHCUpgradeSimulations/Configuration/python/muonCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/muonCustoms.py
@@ -297,7 +297,7 @@ def customise_csc_hlt(process):
     process.CSCGeometryESModule.useGangedStripsInME1a = False
     
     process.hltCsc2DRecHits.readBadChannels = cms.bool(False)
-    process.hltCsc2DRecHits.CSCUseGasGainCorrection = cms.bool(False)
+    process.hltCsc2DRecHits.CSCUseGasGainCorrections = cms.bool(False)
     
     # Switch input for CSCRecHitD to  s i m u l a t e d  digis
     

--- a/SLHCUpgradeSimulations/Configuration/python/muonCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/muonCustoms.py
@@ -299,6 +299,8 @@ def customise_csc_hlt(process):
     process.hltCsc2DRecHits.readBadChannels = cms.bool(False)
     process.hltCsc2DRecHits.CSCUseGasGainCorrections = cms.bool(False)
     
+    process = customise_csc_Indexing(process)
+
     # Switch input for CSCRecHitD to  s i m u l a t e d  digis
     
     process.hltCsc2DRecHits.wireDigiTag  = cms.InputTag("simMuonCSCDigis","MuonCSCWireDigi")


### PR DESCRIPTION
Fix typo in parameter name - should be automatically forwarded to 72X as well
