### PR TITLE
Dictionaries needed for ROOT 6

### DIFF
--- a/CondCore/ORA/src/classes.h
+++ b/CondCore/ORA/src/classes.h
@@ -1,0 +1,2 @@
+#include "CondCore/ORA/interface/Reference.h"
+#include "CondCore/ORA/interface/NamedRef.h"

--- a/CondCore/ORA/src/classes_def.xml
+++ b/CondCore/ORA/src/classes_def.xml
@@ -1,0 +1,4 @@
+<lcgdict>
+  <class name="ora::Reference"/>
+  <class name="ora::NamedReference"/>
+</lcgdict>

--- a/CondCore/ORA/test/classes_def.xml
+++ b/CondCore/ORA/test/classes_def.xml
@@ -32,7 +32,6 @@
   <class name="testORA::SiStripNoises">
      <field name="v_noises" mapping="blob"/>
   </class>
-  <class name="ora::Reference"/>
   <class name="testORA::RefBase">
   </class>
   <class name="testORA::Ref<testORA::SimpleClass>"/>
@@ -60,6 +59,5 @@
   <class name="ora::PVector<ora::OId>"/>
   <class name="testORA::IOV"/>
   <class name="testORA::SH"/>
-  <class name="ora::NamedReference"/>
   <class name="ora::NamedRef<testORA::SimpleClass>"/>
 </lcgdict>


### PR DESCRIPTION
In ROOT6, dictionaries are needed for classes ora::Reference and ora::NamedReference, even though these classes are not persisted.  The absence of these dictionaries causes step 4 of relval test 1001 to fail.
This pull request adds these dictionaries to CondCore/ORA.  Note that these dictionaries were also needed in ROOT 5, but only for the CondCore/ORA unit tests.  Since these dictionaries will now be in CondCore/ORA itself, they no longer are needed in CondCore/ORA/test, as these would be duplicate definitions.
Note that this pull request is not sufficient to make step 4 of relval 1001 run successfully , because with this pull request, the test fails later for a different reason. Please merge promptly.
