### PR TITLE
High Granularity Optimization

### DIFF
--- a/Geometry/CommonTopologies/BuildFile.xml
+++ b/Geometry/CommonTopologies/BuildFile.xml
@@ -1,7 +1,8 @@
+<flags   CXXFLAGS="-Ofast -mrecip"/>
+
 <use   name="FWCore/MessageLogger"/>
 <use   name="Utilities/General"/>
 <use   name="vdt_headers"/>
 <export>
   <lib   name="1"/>
 </export>
-# <flags   CXXFLAGS="-O3 -ffast-math -funsafe-loop-optimizations"/>

--- a/RecoEgamma/EgammaPhotonAlgos/BuildFile.xml
+++ b/RecoEgamma/EgammaPhotonAlgos/BuildFile.xml
@@ -1,3 +1,4 @@
+<flags   CXXFLAGS="-Ofast -mrecip"/>
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="Geometry/CaloGeometry"/>

--- a/RecoLocalTracker/SiPixelRecHits/BuildFile.xml
+++ b/RecoLocalTracker/SiPixelRecHits/BuildFile.xml
@@ -1,7 +1,7 @@
+<flags   CXXFLAGS="-Ofast"/>
+
 <use   name="FWCore/Framework"/>
-
 <use   name="FWCore/ParameterSet"/>
-
 <use   name="CondFormats/SiPixelObjects"/>
 <use   name="CalibTracker/SiPixelESProducers"/>
 <use   name="DataFormats/SiPixelCluster"/>

--- a/RecoLocalTracker/SiPixelRecHits/plugins/BuildFile.xml
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/BuildFile.xml
@@ -1,3 +1,4 @@
+<flags   CXXFLAGS="-Ofast"/>
 <use   name="RecoLocalTracker/ClusterParameterEstimator"/>
 <use   name="RecoLocalTracker/Records"/>
 <use   name="RecoLocalTracker/SiPixelRecHits"/>

--- a/RecoLocalTracker/SiStripRecHitConverter/BuildFile.xml
+++ b/RecoLocalTracker/SiStripRecHitConverter/BuildFile.xml
@@ -1,3 +1,5 @@
+<flags   CXXFLAGS="-Ofast"/>
+
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="DataFormats/Common"/>

--- a/RecoLocalTracker/SiStripRecHitConverter/plugins/BuildFile.xml
+++ b/RecoLocalTracker/SiStripRecHitConverter/plugins/BuildFile.xml
@@ -1,3 +1,5 @@
+<flags   CXXFLAGS="-Ofast"/>
+
 <use   name="MagneticField/Engine"/>
 <use   name="RecoLocalTracker/SiStripRecHitConverter"/>
 <use   name="CalibTracker/Records"/>

--- a/RecoTracker/MeasurementDet/plugins/BuildFile.xml
+++ b/RecoTracker/MeasurementDet/plugins/BuildFile.xml
@@ -1,3 +1,4 @@
+<flags   CXXFLAGS="-Ofast"/>
 <use   name="RecoTracker/MeasurementDet"/>
 <use   name="CalibFormats/SiStripObjects"/>
 <use   name="CalibTracker/Records"/>

--- a/RecoVertex/AdaptiveVertexFinder/BuildFile.xml
+++ b/RecoVertex/AdaptiveVertexFinder/BuildFile.xml
@@ -1,3 +1,4 @@
+<flags   CXXFLAGS="-Ofast -mrecip"/>
 <use   name="RecoVertex/KalmanVertexFit"/>
 <use   name="RecoVertex/AdaptiveVertexFit"/>
 <use   name="RecoVertex/VertexPrimitives"/>

--- a/RecoVertex/AdaptiveVertexFinder/plugins/BuildFile.xml
+++ b/RecoVertex/AdaptiveVertexFinder/plugins/BuildFile.xml
@@ -1,3 +1,4 @@
+<flags   CXXFLAGS="-Ofast -mrecip"/>
 <use   name="FWCore/Framework"/>
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/VertexReco"/>

--- a/RecoVertex/AdaptiveVertexFit/BuildFile.xml
+++ b/RecoVertex/AdaptiveVertexFit/BuildFile.xml
@@ -1,3 +1,4 @@
+<flags   CXXFLAGS="-Ofast -mrecip"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="DataFormats/GeometryCommonDetAlgo"/>
 <use   name="DataFormats/GeometryVector"/>

--- a/RecoVertex/ConfigurableVertexReco/BuildFile.xml
+++ b/RecoVertex/ConfigurableVertexReco/BuildFile.xml
@@ -1,3 +1,4 @@
+<flags   CXXFLAGS="-Ofast -mrecip"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/RecoVertex/KalmanVertexFit/BuildFile.xml
+++ b/RecoVertex/KalmanVertexFit/BuildFile.xml
@@ -1,3 +1,4 @@
+<flags   CXXFLAGS="-Ofast -mrecip"/>
 <use   name="CommonTools/Statistics"/>
 <use   name="DataFormats/CLHEP"/>
 <use   name="DataFormats/GeometryCommonDetAlgo"/>

--- a/RecoVertex/KinematicFit/BuildFile.xml
+++ b/RecoVertex/KinematicFit/BuildFile.xml
@@ -1,3 +1,4 @@
+<flags   CXXFLAGS="-Ofast -mrecip"/>
 <use   name="RecoVertex/KalmanVertexFit"/>
 <export>
   <lib   name="1"/>

--- a/RecoVertex/KinematicFitPrimitives/BuildFile.xml
+++ b/RecoVertex/KinematicFitPrimitives/BuildFile.xml
@@ -1,3 +1,4 @@
+<flags   CXXFLAGS="-Ofast -mrecip"/>
 <use   name="TrackingTools/TransientTrack"/>
 <use   name="TrackingTools/GeomPropagators"/>
 <export>

--- a/RecoVertex/MultiVertexFit/BuildFile.xml
+++ b/RecoVertex/MultiVertexFit/BuildFile.xml
@@ -1,3 +1,4 @@
+<flags   CXXFLAGS="-Ofast -mrecip"/>
 <use   name="CommonTools/Clustering1D"/>
 <use   name="DataFormats/GeometryCommonDetAlgo"/>
 <use   name="DataFormats/GeometryVector"/>

--- a/RecoVertex/PrimaryVertexProducer/BuildFile.xml
+++ b/RecoVertex/PrimaryVertexProducer/BuildFile.xml
@@ -1,3 +1,4 @@
+<flags   CXXFLAGS="-Ofast -mrecip"/>
 <use   name="DataFormats/BeamSpot"/>
 <use   name="DataFormats/VertexReco"/>
 <use   name="FWCore/Framework"/>

--- a/RecoVertex/PrimaryVertexProducer/BuildFile.xml
+++ b/RecoVertex/PrimaryVertexProducer/BuildFile.xml
@@ -1,4 +1,4 @@
-<flags   CXXFLAGS="-O3 -mrecip"/>
+<flags   CXXFLAGS="-Ofast -mrecip"/>
 <use   name="DataFormats/BeamSpot"/>
 <use   name="DataFormats/VertexReco"/>
 <use   name="FWCore/Framework"/>

--- a/RecoVertex/PrimaryVertexProducer/BuildFile.xml
+++ b/RecoVertex/PrimaryVertexProducer/BuildFile.xml
@@ -1,4 +1,4 @@
-<flags   CXXFLAGS="-Ofast -mrecip"/>
+<flags   CXXFLAGS="-O3 -mrecip"/>
 <use   name="DataFormats/BeamSpot"/>
 <use   name="DataFormats/VertexReco"/>
 <use   name="FWCore/Framework"/>

--- a/RecoVertex/PrimaryVertexProducer/interface/DAClusterizerInZ_vect.h
+++ b/RecoVertex/PrimaryVertexProducer/interface/DAClusterizerInZ_vect.h
@@ -18,197 +18,193 @@
 #include "RecoVertex/VertexPrimitives/interface/TransientVertex.h"
 
 
-class DAClusterizerInZ_vect: public TrackClusterizerInZ {
+class DAClusterizerInZ_vect  final : public TrackClusterizerInZ {
 
 public:
-	// Internal data structure to 
-	struct track_t {
+  // Internal data structure to 
+  struct track_t {
+    
+    void AddItem( double new_z, double new_dz2, const reco::TransientTrack* new_tt, double new_pi   )
+    {
+      z.push_back( new_z );
+      dz2.push_back( new_dz2 );
+      tt.push_back( new_tt );
+      
+      pi.push_back( new_pi ); // track weight
+      Z_sum.push_back( 1.0); // Z[i]   for DA clustering, initial value as done in ::fill
+    }
 
-		void AddItem( double new_z, double new_dz2, const reco::TransientTrack* new_tt, double new_pi   )
-		{
-			z.push_back( new_z );
-			dz2.push_back( new_dz2 );
-			tt.push_back( new_tt );
-
-			pi.push_back( new_pi ); // track weight
-			Z_sum.push_back( 1.0); // Z[i]   for DA clustering, initial value as done in ::fill
-		}
-
-
-
-		unsigned int GetSize() const
-		{
-			return z.size();
-		}
-
-
-		// has to be called everytime the items are modified
-		void ExtractRaw()
-		{
-			_z = &z.front();
-			_dz2 = &dz2.front();
-			_Z_sum = &Z_sum.front();
-			_pi = &pi.front();
-		}
-
-		double * __restrict__ _z; // z-coordinate at point of closest approach to the beamline
-		double * __restrict__  _dz2; // square of the error of z(pca)
-
-		double * __restrict__  _Z_sum; // Z[i]   for DA clustering
-		double * __restrict__  _pi; // track weight
-
-		std::vector<double> z; // z-coordinate at point of closest approach to the beamline
-		std::vector<double> dz2; // square of the error of z(pca)
-		std::vector< const reco::TransientTrack* > tt; // a pointer to the Transient Track
-
-		std::vector<double> Z_sum; // Z[i]   for DA clustering
-		std::vector<double> pi; // track weight
-	};
-
-	struct vertex_t {
-		std::vector<double> z; //           z coordinate
-		std::vector<double> pk; //           vertex weight for "constrained" clustering
-
-		// --- temporary numbers, used during update
-		std::vector<double> ei_cache;
-		std::vector<double> ei;
-		std::vector<double> sw;
-		std::vector<double> swz;
-		std::vector<double> se;
-		std::vector<double> swE;
-
-
-		unsigned int GetSize() const
-		{
-			return z.size();
-		}
-
-		void AddItem( double new_z, double new_pk   )
-		{
-			z.push_back( new_z);
-			pk.push_back( new_pk);
-
-			ei_cache.push_back( 0.0 );
-			ei.push_back( 0.0 );
-			sw.push_back( 0.0 );
-			swz.push_back( 0.0);
-			se.push_back( 0.0);
-			swE.push_back( 0.0);
-
-			ExtractRaw();
-		}
-
-	        void InsertItem( unsigned int i, double new_z, double new_pk   )
-		{
-		        z.insert(z.begin() + i, new_z);
-			pk.insert(pk.begin() + i, new_pk);
-
-			ei_cache.insert(ei_cache.begin() + i, 0.0 );
-			ei.insert( ei.begin()  + i, 0.0 );
-			sw.insert( sw.begin()  + i, 0.0 );
-			swz.insert(swz.begin() + i, 0.0 );
-			se.insert( se.begin()  + i, 0.0 );
-			swE.insert(swE.begin() + i, 0.0 );
-
-			ExtractRaw();
-		}
-
-		void RemoveItem( unsigned int i )
-		{
-			z.erase( z.begin() + i );
-			pk.erase( pk.begin() + i );
-
-			ei_cache.erase( ei_cache.begin() + i);
-			ei.erase( ei.begin() + i);
-			sw.erase( sw.begin() + i);
-			swz.erase( swz.begin() + i);
-			se.erase(se.begin() + i);
-			swE.erase(swE.begin() + i);
-
-			ExtractRaw();
-		}
-
-		void DebugOut()
-		{
-			std::cout <<  "vertex_t size: " << GetSize() << std::endl;
-
-			for ( unsigned int i =0; i < GetSize(); ++ i)
-			{
-				std::cout << " z = " << _z[i] << " pk = " << _pk[i] << std::endl;
-			}
-		}
-
-		// has to be called everytime the items are modified
-		void ExtractRaw()
-		{
-			_z = &z.front();
-			_pk = &pk.front();
-
-			_ei = &ei.front();
-			_sw = &sw.front();
-			_swz = &swz.front();
-			_se = &se.front();
-			_swE = &swE.front();
-			_ei_cache = &ei_cache.front();
-
-		}
-
-		double * __restrict__ _z;
-		double * __restrict__ _pk;
-
-		double * __restrict__ _ei_cache;
-		double * __restrict__ _ei;
-		double * __restrict__ _sw;
-		double * __restrict__ _swz;
-		double * __restrict__ _se;
-		double * __restrict__ _swE;
-
-	};
-
-	DAClusterizerInZ_vect(const edm::ParameterSet& conf);
-
-
-	std::vector<std::vector<reco::TransientTrack> >
-	clusterize(const std::vector<reco::TransientTrack> & tracks) const;
-
-
-	std::vector<TransientVertex>
-	vertices(const std::vector<reco::TransientTrack> & tracks,
-			const int verbosity = 0) const ;
-
-	track_t	fill(const std::vector<reco::TransientTrack> & tracks) const;
-
-	double update(double beta, track_t & gtracks,
-			vertex_t & gvertices, bool useRho0, double & rho0) const;
-
-	void dump(const double beta, const vertex_t & y,
-			const track_t & tks, const int verbosity = 0) const;
-	bool merge(vertex_t &) const;
-	bool merge(vertex_t & y, double & beta)const;
-	bool purge(vertex_t &, track_t &, double &,
-			const double) const;
-
-	void splitAll( vertex_t & y) const;
-	bool split(const double beta,  track_t &t, vertex_t & y ) const;
-
-	double beta0(const double betamax, track_t & tks, vertex_t & y) const;
-
-	double Eik( double const& t_z, double const& k_z, double const& t_dz2) const;
-
-	inline double local_exp( double const& inp) const;
-	inline void local_exp_list( double* arg_inp, double* arg_out,const int arg_arr_size) const;
-
+    
+    
+    unsigned int GetSize() const
+    {
+      return z.size();
+    }
+    
+    
+    // has to be called everytime the items are modified
+    void ExtractRaw()
+    {
+      _z = &z.front();
+      _dz2 = &dz2.front();
+      _Z_sum = &Z_sum.front();
+      _pi = &pi.front();
+    }
+    
+    double * __restrict__ _z; // z-coordinate at point of closest approach to the beamline
+    double * __restrict__  _dz2; // square of the error of z(pca)
+    
+    double * __restrict__  _Z_sum; // Z[i]   for DA clustering
+    double * __restrict__  _pi; // track weight
+    
+    std::vector<double> z; // z-coordinate at point of closest approach to the beamline
+    std::vector<double> dz2; // square of the error of z(pca)
+    std::vector< const reco::TransientTrack* > tt; // a pointer to the Transient Track
+    
+    std::vector<double> Z_sum; // Z[i]   for DA clustering
+    std::vector<double> pi; // track weight
+  };
+  
+  struct vertex_t {
+    std::vector<double> z; //           z coordinate
+    std::vector<double> pk; //           vertex weight for "constrained" clustering
+    
+    // --- temporary numbers, used during update
+    std::vector<double> ei_cache;
+    std::vector<double> ei;
+    std::vector<double> sw;
+    std::vector<double> swz;
+    std::vector<double> se;
+    std::vector<double> swE;
+    
+    
+    unsigned int GetSize() const
+    {
+      return z.size();
+    }
+    
+    void AddItem( double new_z, double new_pk   )
+    {
+      z.push_back( new_z);
+      pk.push_back( new_pk);
+      
+      ei_cache.push_back( 0.0 );
+      ei.push_back( 0.0 );
+      sw.push_back( 0.0 );
+      swz.push_back( 0.0);
+      se.push_back( 0.0);
+      swE.push_back( 0.0);
+      
+      ExtractRaw();
+    }
+    
+    void InsertItem( unsigned int i, double new_z, double new_pk   )
+    {
+      z.insert(z.begin() + i, new_z);
+      pk.insert(pk.begin() + i, new_pk);
+      
+      ei_cache.insert(ei_cache.begin() + i, 0.0 );
+      ei.insert( ei.begin()  + i, 0.0 );
+      sw.insert( sw.begin()  + i, 0.0 );
+      swz.insert(swz.begin() + i, 0.0 );
+      se.insert( se.begin()  + i, 0.0 );
+      swE.insert(swE.begin() + i, 0.0 );
+      
+      ExtractRaw();
+    }
+    
+    void RemoveItem( unsigned int i )
+    {
+      z.erase( z.begin() + i );
+      pk.erase( pk.begin() + i );
+      
+      ei_cache.erase( ei_cache.begin() + i);
+      ei.erase( ei.begin() + i);
+      sw.erase( sw.begin() + i);
+      swz.erase( swz.begin() + i);
+      se.erase(se.begin() + i);
+      swE.erase(swE.begin() + i);
+      
+      ExtractRaw();
+    }
+    
+    void DebugOut()
+    {
+      std::cout <<  "vertex_t size: " << GetSize() << std::endl;
+      
+      for ( unsigned int i =0; i < GetSize(); ++ i)
+	{
+	  std::cout << " z = " << _z[i] << " pk = " << _pk[i] << std::endl;
+	}
+    }
+    
+    // has to be called everytime the items are modified
+    void ExtractRaw()
+    {
+      _z = &z.front();
+      _pk = &pk.front();
+      
+      _ei = &ei.front();
+      _sw = &sw.front();
+      _swz = &swz.front();
+      _se = &se.front();
+      _swE = &swE.front();
+      _ei_cache = &ei_cache.front();
+      
+    }
+    
+    double * __restrict__ _z;
+    double * __restrict__ _pk;
+    
+    double * __restrict__ _ei_cache;
+    double * __restrict__ _ei;
+    double * __restrict__ _sw;
+    double * __restrict__ _swz;
+    double * __restrict__ _se;
+    double * __restrict__ _swE;
+    
+  };
+  
+  DAClusterizerInZ_vect(const edm::ParameterSet& conf);
+  
+  
+  std::vector<std::vector<reco::TransientTrack> >
+  clusterize(const std::vector<reco::TransientTrack> & tracks) const;
+  
+  
+  std::vector<TransientVertex>
+  vertices(const std::vector<reco::TransientTrack> & tracks,
+	   const int verbosity = 0) const ;
+  
+  track_t	fill(const std::vector<reco::TransientTrack> & tracks) const;
+  
+  double update(double beta, track_t & gtracks,
+		vertex_t & gvertices, bool useRho0, double & rho0) const;
+  
+  void dump(const double beta, const vertex_t & y,
+	    const track_t & tks, const int verbosity = 0) const;
+  bool merge(vertex_t &) const;
+  bool merge(vertex_t & y, double & beta)const;
+  bool purge(vertex_t &, track_t &, double &,
+	     const double) const;
+  
+  void splitAll( vertex_t & y) const;
+  bool split(const double beta,  track_t &t, vertex_t & y ) const;
+  
+  double beta0(const double betamax, track_t const & tks, vertex_t const & y) const;
+    
+  
 private:
-	bool verbose_;
-	float vertexSize_;
-	int maxIterations_;
-	double coolingFactor_;
-	float betamax_;
-	float betastop_;
-	double dzCutOff_;
-	double d0CutOff_;
-	bool use_vdt_;
-	bool useTc_;
+  bool verbose_;
+  float vertexSize_;
+  int maxIterations_;
+  double coolingFactor_;
+  float betamax_;
+  float betastop_;
+  double dzCutOff_;
+  double d0CutOff_;
+  bool use_vdt_;
+  bool useTc_;
 };
 
 

--- a/RecoVertex/PrimaryVertexProducer/interface/DAClusterizerInZ_vect.h
+++ b/RecoVertex/PrimaryVertexProducer/interface/DAClusterizerInZ_vect.h
@@ -203,7 +203,6 @@ private:
   float betastop_;
   double dzCutOff_;
   double d0CutOff_;
-  bool use_vdt_;
   bool useTc_;
 };
 

--- a/RecoVertex/PrimaryVertexProducer/python/OfflinePixel3DPrimaryVertices_cfi.py
+++ b/RecoVertex/PrimaryVertexProducer/python/OfflinePixel3DPrimaryVertices_cfi.py
@@ -8,11 +8,11 @@ pixelVertices = cms.EDProducer("PrimaryVertexProducer",
                                         
     TkFilterParameters = cms.PSet(
         algorithm=cms.string('filter'),
-        maxNormalizedChi2 = cms.double(100.0),
+        maxNormalizedChi2 = cms.double(50.0),
         minPixelLayersWithHits=cms.int32(3),
         minSiliconLayersWithHits = cms.int32(3),
-        maxD0Significance = cms.double(100.0), 
-        minPt = cms.double(0.0),
+        maxD0Significance = cms.double(20.0), 
+        minPt = cms.double(0.3),
         trackQuality = cms.string("any")
     ),
 

--- a/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
@@ -83,14 +83,13 @@ DAClusterizerInZ_vect::track_t DAClusterizerInZ_vect::fill(const vector<
 		//  get the beam-spot
 		reco::BeamSpot beamspot = (it->stateAtBeamLine()).beamSpot();
  		double t_dz2 = 
-		      pow((*it).track().dzError(), 2) // track errror
- 		  + (pow(beamspot.BeamWidthX()*cos(phi),2)+pow(beamspot.BeamWidthY()*sin(phi),2))/pow(tantheta,2)  // beam-width
- 		  + pow(vertexSize_, 2); // intrinsic vertex size, safer for outliers and short lived decays
+		      std::pow((*it).track().dzError(), 2) // track errror
+ 		  + (std::pow(beamspot.BeamWidthX()*cos(phi),2)+std::pow(beamspot.BeamWidthY()*sin(phi),2))/std::pow(tantheta,2)  // beam-width
+ 		  + std::pow(vertexSize_, 2); // intrinsic vertex size, safer for outliers and short lived decays
 		if (d0CutOff_ > 0) {
 			Measurement1D IP =
 					(*it).stateAtBeamLine().transverseImpactParameter();// error constains beamspot
-			t_pi = 1. / (1. + local_exp(pow(IP.value() / IP.error(), 2) - pow(
-					d0CutOff_, 2))); // reduce weight for high ip tracks
+			t_pi = 1. / (1. + local_exp(std::pow(IP.value() / IP.error(), 2) - std::pow(d0CutOff_, 2))); // reduce weight for high ip tracks
 		} else {
 			t_pi = 1.;
 		}
@@ -109,7 +108,7 @@ DAClusterizerInZ_vect::track_t DAClusterizerInZ_vect::fill(const vector<
 
 double DAClusterizerInZ_vect::Eik(double const& t_z, double const& k_z, double const& t_dz2) const
 {
-	return pow(t_z - k_z, 2) / t_dz2;
+	return std::pow(t_z - k_z, 2) / t_dz2;
 }
 
 
@@ -222,26 +221,26 @@ double DAClusterizerInZ_vect::update(double beta, track_t & gtracks,
 	// now update z and pk
 	auto kernel_calc_z = [ &delta, &sumpi, nv, this, useRho0 ] (vertex_t & vertices )
 	{
+
 		// does not vectorizes
 		for (unsigned int ivertex = 0; ivertex < nv; ++ ivertex )
 		{
 			if (vertices._sw[ivertex] > 0)
 			{
 				double znew = vertices._swz[ ivertex ] / vertices._sw[ ivertex ];
-
-				// prevents from vectorizing
-				delta += pow( vertices._z[ ivertex ] - znew, 2 );
+				// prevents from vectorizing if 
+				delta += std::pow( vertices._z[ ivertex ] - znew, 2 );
 				vertices._z[ ivertex ] = znew;
 			}
+#ifdef VI_DEBUG
 			else {
-				edm::LogInfo("sumw") << "invalid sum of weights in fit: " << vertices._sw[ivertex]
-				<< endl;
+				edm::LogInfo("sumw") << "invalid sum of weights in fit: " << vertices._sw[ivertex] << endl;
 				if (this->verbose_) {
 					LogDebug("DAClusterizerinZ_vectorized")  << " a cluster melted away ?  pk=" << vertices._pk[ ivertex ] << " sumw="
 					<< vertices._sw[ivertex] << endl;
 				}
 			}
-
+#endif
 			// dont do, if rho cut
 			if ( ! useRho0 )
 			{
@@ -271,7 +270,7 @@ bool DAClusterizerInZ_vect::merge(vertex_t & y, double & beta)const{
   for (unsigned int k = 0; (k + 1) < nv; k++) {
     if (fabs(y._z[k + 1] - y._z[k]) < 2.e-2) {
       double rho=y._pk[k] + y._pk[k+1];
-      double swE=y._swE[k]+y._swE[k+1] - y._pk[k]*y._pk[k+1] /rho *pow(y._z[k+1]-y._z[k],2);
+      double swE=y._swE[k]+y._swE[k+1] - y._pk[k]*y._pk[k+1] /rho *std::pow(y._z[k+1]-y._z[k],2);
       double Tc=2*swE/(y._sw[k]+y._sw[k+1]);
 
       if(Tc*beta<1){
@@ -399,7 +398,7 @@ double DAClusterizerInZ_vect::beta0(double betamax, track_t & tks, vertex_t & y)
 		for (unsigned int i = 0; i < nt; i++) {
 			double dx = tks._z[i] - (y._z[k]);
 			double w = tks._pi[i] / tks._dz2[i];
-			a += w * pow(dx, 2) / tks._dz2[i];
+			a += w * std::pow(dx, 2) / tks._dz2[i];
 			b += w;
 		}
 		double Tc = 2. * a / b; // the critical temperature of this vertex
@@ -408,7 +407,7 @@ double DAClusterizerInZ_vect::beta0(double betamax, track_t & tks, vertex_t & y)
 	}// vertex loop (normally there should be only one vertex at beta=0)
 
 	if (T0 > 1. / betamax) {
-		return betamax / pow(coolingFactor_, int(log(T0 * betamax) / log(
+		return betamax / std::pow(coolingFactor_, int(std::log(T0 * betamax) / std::log(
 				coolingFactor_)) - 1);
 	} else {
 		// ensure at least one annealing step
@@ -576,7 +575,7 @@ void DAClusterizerInZ_vect::dump(const double beta, const vertex_t & y,
 		LogDebug("DAClusterizerinZ_vectorized")  << setprecision(4);
 		for (unsigned int i = 0; i < nt; i++) {
 			if (tks._Z_sum[i] > 0) {
-				F -= log(tks._Z_sum[i]) / beta;
+				F -= std::log(tks._Z_sum[i]) / beta;
 			}
 			double tz = tks._z[i];
 			LogDebug("DAClusterizerinZ_vectorized")  << setw(3) << i << ")" << setw(8) << fixed << setprecision(4)

--- a/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
@@ -241,12 +241,11 @@ double DAClusterizerInZ_vect::update(double beta, track_t & gtracks,
 				}
 			}
 #endif
+                }
 			// dont do, if rho cut
-			if ( ! useRho0 )
-			{
-				vertices._pk[ ivertex ] = vertices._pk[ ivertex ] * vertices._se[ ivertex ] / sumpi;
-			}
-		}
+		if ( ! useRho0 )
+                for (unsigned int ivertex = 0; ivertex < nv; ++ ivertex )
+                    vertices._pk[ ivertex ] = vertices._pk[ ivertex ] * vertices._se[ ivertex ] / sumpi;
 	};
 
 	kernel_calc_z(gvertices);

--- a/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
@@ -14,242 +14,223 @@ using namespace std;
 
 DAClusterizerInZ_vect::DAClusterizerInZ_vect(const edm::ParameterSet& conf) {
 
-	// some defaults to avoid uninitialized variables
-	verbose_ = conf.getUntrackedParameter<bool> ("verbose", false);
-	use_vdt_ = conf.getUntrackedParameter<bool> ("use_vdt", false);
-
-	betamax_ = 0.1;
-	betastop_ = 1.0;
-	coolingFactor_ = 0.6;
-	maxIterations_ = 100;
-	vertexSize_ = 0.01; // 0.1 mm
-	dzCutOff_ = 4.0;  
-
+  // some defaults to avoid uninitialized variables
+  verbose_ = conf.getUntrackedParameter<bool> ("verbose", false);
+  use_vdt_ = conf.getUntrackedParameter<bool> ("use_vdt", false);
+  
+  betamax_ = 0.1;
+  betastop_ = 1.0;
+  coolingFactor_ = 0.6;
+  maxIterations_ = 100;
+  vertexSize_ = 0.01; // 0.1 mm
+  dzCutOff_ = 4.0;  
+  
 	// configure
 
-	double Tmin = conf.getParameter<double> ("Tmin");
-	vertexSize_ = conf.getParameter<double> ("vertexSize");
-	coolingFactor_ = conf.getParameter<double> ("coolingFactor");
-	useTc_=true;
-	if(coolingFactor_<0){
-	  coolingFactor_=-coolingFactor_; 
-	  useTc_=false;
-	}
-	d0CutOff_ = conf.getParameter<double> ("d0CutOff");
-	dzCutOff_ = conf.getParameter<double> ("dzCutOff");
-	maxIterations_ = 100;
-	if (Tmin == 0) {
-		LogDebug("DAClusterizerinZ_vectorized")  << "DAClusterizerInZ: invalid Tmin" << Tmin
-				<< "  reset do default " << 1. / betamax_ << endl;
-	} else {
-		betamax_ = 1. / Tmin;
-	}
+  double Tmin = conf.getParameter<double> ("Tmin");
+  vertexSize_ = conf.getParameter<double> ("vertexSize");
+  coolingFactor_ = conf.getParameter<double> ("coolingFactor");
+  useTc_=true;
+  if(coolingFactor_<0){
+    coolingFactor_=-coolingFactor_; 
+    useTc_=false;
+  }
+  d0CutOff_ = conf.getParameter<double> ("d0CutOff");
+  dzCutOff_ = conf.getParameter<double> ("dzCutOff");
+  maxIterations_ = 100;
+  if (Tmin == 0) {
+    LogDebug("DAClusterizerinZ_vectorized")  << "DAClusterizerInZ: invalid Tmin" << Tmin
+					     << "  reset do default " << 1. / betamax_ << endl;
+  } else {
+    betamax_ = 1. / Tmin;
+  }
 
 }
 
-inline double DAClusterizerInZ_vect::local_exp( double const& inp) const
-		{
-			if ( use_vdt_)
-                          return vdt::fast_exp( inp );
+namespace {
+  inline double local_exp( double const& inp) {
+    return vdt::fast_exp( inp );
+  }
+  
+  inline void local_exp_list( double const * __restrict__ arg_inp, double * __restrict__ arg_out, const int arg_arr_size) {
+    for(int i=0; i!=arg_arr_size; ++i ) arg_out[i]=vdt::fast_exp(arg_inp[i]);
+  }
 
-			return std::exp( inp );
-		}
-
-inline void DAClusterizerInZ_vect::local_exp_list( double* arg_inp, double* arg_out,const int arg_arr_size) const
-		{
-			if ( use_vdt_){
-//                          std::cout << "I use vdt!\n";
-                            for(int i=0; i!=arg_arr_size; ++i ) arg_out[i]=vdt::fast_exp(arg_inp[i]);
-		           // vdt::fast_expv(arg_arr_size, arg_inp, arg_out);
-                        }
-                        else
-                          for(int i=0; i!=arg_arr_size; ++i ) arg_out[i]=std::exp(arg_inp[i]);
-		}
+}
 
 //todo: use r-value possibility of c++11 here
-DAClusterizerInZ_vect::track_t DAClusterizerInZ_vect::fill(const vector<
-		reco::TransientTrack> & tracks) const {
+DAClusterizerInZ_vect::track_t 
+DAClusterizerInZ_vect::fill(const vector<reco::TransientTrack> & tracks) const {
 
-	// prepare track data for clustering
-	track_t tks;
-	for (vector<reco::TransientTrack>::const_iterator it = tracks.begin(); it
-			!= tracks.end(); it++)
-	{
-		double t_pi;
-		double t_z = ((*it).stateAtBeamLine().trackStateAtPCA()).position().z();
-		double phi=((*it).stateAtBeamLine().trackStateAtPCA()).momentum().phi();
-		double tantheta = tan(
-				((*it).stateAtBeamLine().trackStateAtPCA()).momentum().theta());
-		//  get the beam-spot
-		reco::BeamSpot beamspot = (it->stateAtBeamLine()).beamSpot();
- 		double t_dz2 = 
-		      std::pow((*it).track().dzError(), 2) // track errror
- 		  + (std::pow(beamspot.BeamWidthX()*cos(phi),2)+std::pow(beamspot.BeamWidthY()*sin(phi),2))/std::pow(tantheta,2)  // beam-width
- 		  + std::pow(vertexSize_, 2); // intrinsic vertex size, safer for outliers and short lived decays
-		if (d0CutOff_ > 0) {
-			Measurement1D IP =
-					(*it).stateAtBeamLine().transverseImpactParameter();// error constains beamspot
-			t_pi = 1. / (1. + local_exp(std::pow(IP.value() / IP.error(), 2) - std::pow(d0CutOff_, 2))); // reduce weight for high ip tracks
-		} else {
-			t_pi = 1.;
-		}
-
-		tks.AddItem(t_z, t_dz2, &(*it), t_pi);
-	}
-        tks.ExtractRaw();
-
-	if (verbose_) {
-		LogDebug("DAClusterizerinZ_vectorized") << "Track count " << tks.GetSize() << std::endl;
-	}
-
-	return tks;
+  // prepare track data for clustering
+  track_t tks;
+  for (auto it = tracks.begin(); it!= tracks.end(); it++){
+    double t_pi;
+    double t_z = ((*it).stateAtBeamLine().trackStateAtPCA()).position().z();
+    double phi=((*it).stateAtBeamLine().trackStateAtPCA()).momentum().phi();
+    double tantheta = std::tan( ((*it).stateAtBeamLine().trackStateAtPCA()).momentum().theta());
+    //  get the beam-spot
+    reco::BeamSpot beamspot = (it->stateAtBeamLine()).beamSpot();
+    double t_dz2 = 
+      std::pow((*it).track().dzError(), 2) // track errror
+      + (std::pow(beamspot.BeamWidthX()*cos(phi),2)+std::pow(beamspot.BeamWidthY()*sin(phi),2))/std::pow(tantheta,2)  // beam-width
+      + std::pow(vertexSize_, 2); // intrinsic vertex size, safer for outliers and short lived decays
+    if (d0CutOff_ > 0) {
+      Measurement1D IP =
+	(*it).stateAtBeamLine().transverseImpactParameter();// error constains beamspot
+      t_pi = 1. / (1. + local_exp(std::pow(IP.value() / IP.error(), 2) - std::pow(d0CutOff_, 2))); // reduce weight for high ip tracks
+    } else {
+      t_pi = 1.;
+    }    
+    tks.AddItem(t_z, t_dz2, &(*it), t_pi);
+  }
+  tks.ExtractRaw();
+  
+  if (verbose_) {
+    LogDebug("DAClusterizerinZ_vectorized") << "Track count " << tks.GetSize() << std::endl;
+  }
+  
+  return tks;
 }
 
 
-double DAClusterizerInZ_vect::Eik(double const& t_z, double const& k_z, double const& t_dz2) const
-{
-	return std::pow(t_z - k_z, 2) / t_dz2;
+namespace {
+  inline
+  double Eik(double t_z, double k_z, double t_dz2) {
+    return std::pow(t_z - k_z, 2) / t_dz2;
+  }
 }
-
 
 double DAClusterizerInZ_vect::update(double beta, track_t & gtracks,
 		vertex_t & gvertices, bool useRho0, double & rho0) const {
 
-	//update weights and vertex positions
-	// mass constrained annealing without noise
-	// returns the squared sum of changes of vertex positions
+  //update weights and vertex positions
+  // mass constrained annealing without noise
+  // returns the squared sum of changes of vertex positions
+  
+  const unsigned int nt = gtracks.GetSize();
+  const unsigned int nv = gvertices.GetSize();
+  
+  //initialize sums
+  double sumpi = 0;
+  
+  // to return how much the prototype moved
+  double delta = 0;
+  
+  unsigned int itrack;
+  unsigned int ivertex;
+  
+  // intial value of a sum
+  double Z_init = 0;
+  
+  // define kernels
+  auto kernel_calc_exp_arg = [ &beta, nv ] ( const unsigned int itrack,
+					     track_t const& tracks,
+					     vertex_t const& vertices ) {
+    const double track_z = tracks._z[itrack];
+    const double botrack_dz2 = -beta/tracks._dz2[itrack];
 
-	const unsigned int nt = gtracks.GetSize();
-	const unsigned int nv = gvertices.GetSize();
+    // auto-vectorized
+    for ( unsigned int ivertex = 0; ivertex < nv; ++ivertex) {
+      double mult_res = ( track_z - vertices._z[ivertex] );
+      vertices._ei_cache[ivertex] = botrack_dz2 * ( mult_res * mult_res );
+    }
+  };
+  
+  // auto kernel_add_Z = [ nv, &Z_init ] (vertex_t const& vertices) raises a warning
+  // we declare the return type with " -> double"
+  auto kernel_add_Z = [ nv, &Z_init ] (vertex_t const& vertices) -> double
+    {
+      double ZTemp = Z_init;
+      
+      for (unsigned int ivertex = 0; ivertex < nv; ++ivertex) {	
+	ZTemp += vertices._pk[ivertex] * vertices._ei[ivertex];
+      }
+      return ZTemp;
+    };
 
-	//initialize sums
-	double sumpi = 0;
-
-	// to return how much the prototype moved
-	double delta = 0;
-
-	unsigned int itrack;
-	unsigned int ivertex;
-
-	// intial value of a sum
-	double Z_init = 0;
-
-	// define kernels
-	auto kernel_calc_exp_arg = [ &beta, nv ] (
-			const unsigned int itrack,
-			track_t const& tracks,
-			vertex_t const& vertices )
-	{
-		const double track_z = tracks._z[itrack];
-		const double track_dz2 = tracks._dz2[itrack];
-
-		// auto-vectorized
-		for ( unsigned int ivertex = 0; ivertex < nv; ++ivertex)
-		{
-			double mult_res = ( track_z - vertices._z[ivertex] );
-			vertices._ei_cache[ivertex] = -beta *
-			( mult_res * mult_res ) / track_dz2;
-		}
-	};
-
-	// auto kernel_add_Z = [ nv, &Z_init ] (vertex_t const& vertices) raises a warning
-	// we declare the return type with " -> double"
-	auto kernel_add_Z = [ nv, &Z_init ] (vertex_t const& vertices) -> double
-	{
-		double ZTemp = Z_init;
- 
-		for (unsigned int ivertex = 0; ivertex < nv; ++ivertex) {
-
-			ZTemp += vertices._pk[ivertex] * vertices._ei[ivertex];
-		}
-		return ZTemp;
-	};
-
-	auto kernel_calc_normalization = [ &beta, nv ] (const unsigned int track_num,
-			track_t & tks_vec,
-			vertex_t & y_vec )
-	{
-		double w;
-
-		const double tmp_trk_pi = tks_vec._pi[track_num];
-		const double tmp_trk_Z_sum = tks_vec._Z_sum[track_num];
-		const double tmp_trk_dz2 = tks_vec._dz2[track_num];
-		const double tmp_trk_z = tks_vec._z[track_num];
-
-		// auto-vectorized
-		for (unsigned int k = 0; k < nv; ++k) {
-			y_vec._se[k] += tmp_trk_pi* y_vec._ei[k] / tmp_trk_Z_sum;
-			w = y_vec._pk[k] * tmp_trk_pi * y_vec._ei[k] / tmp_trk_Z_sum / tmp_trk_dz2;
-			y_vec._sw[k]  += w;
-			y_vec._swz[k] += w * tmp_trk_z;
-			y_vec._swE[k] += w * y_vec._ei_cache[k]/(-beta);
-		}
-	};
-
-	// not vectorized
-	for (ivertex = 0; ivertex < nv; ++ivertex) {
-		gvertices._se[ivertex] = 0.0;
-		gvertices._sw[ivertex] = 0.0;
-		gvertices._swz[ivertex] = 0.0;
-		gvertices._swE[ivertex] = 0.0;
-	}
-
-
-	// independpent of loop
-	if ( useRho0 )
-	{
-		Z_init = rho0 * local_exp(-beta * dzCutOff_ * dzCutOff_); // cut-off
-	}
-
-	// loop over tracks
-	for (itrack = 0; itrack < nt; ++itrack) {
-		kernel_calc_exp_arg(itrack, gtracks, gvertices);
-		local_exp_list(gvertices._ei_cache, gvertices._ei, nv);
-		//vdt::cephes_single_exp_vect( y_vec._ei, nv );
-
-		gtracks._Z_sum[itrack] = kernel_add_Z(gvertices);
-
-		// used in the next major loop to follow
-		if (!useRho0)
-			sumpi += gtracks._pi[itrack];
-
-		if (gtracks._Z_sum[itrack] > 0) {
-			kernel_calc_normalization(itrack, gtracks, gvertices);
-		}
-	}
-
-	// now update z and pk
-	auto kernel_calc_z = [ &delta, &sumpi, nv, this, useRho0 ] (vertex_t & vertices )
-	{
-
-		// does not vectorizes
-		for (unsigned int ivertex = 0; ivertex < nv; ++ ivertex )
-		{
-			if (vertices._sw[ivertex] > 0)
-			{
-				double znew = vertices._swz[ ivertex ] / vertices._sw[ ivertex ];
-				// prevents from vectorizing if 
-				delta += std::pow( vertices._z[ ivertex ] - znew, 2 );
-				vertices._z[ ivertex ] = znew;
-			}
+  auto kernel_calc_normalization = [ &beta, nv ] (const unsigned int track_num,
+						  track_t & tks_vec,
+						  vertex_t & y_vec ) {
+    const double tmp_trk_pi = tks_vec._pi[track_num];
+    const double o_trk_Z_sum = 1./tks_vec._Z_sum[track_num];
+    const double o_trk_dz2 = 1./tks_vec._dz2[track_num];
+    const double tmp_trk_z = tks_vec._z[track_num];
+    auto obeta =  -1./beta;
+    
+    // auto-vectorized
+    for (unsigned int k = 0; k < nv; ++k) {
+      y_vec._se[k] +=  y_vec._ei[k] * (tmp_trk_pi* o_trk_Z_sum);
+      auto w = y_vec._pk[k] * y_vec._ei[k] * (tmp_trk_pi*o_trk_Z_sum *o_trk_dz2);
+      y_vec._sw[k]  += w;
+      y_vec._swz[k] += w * tmp_trk_z;
+      y_vec._swE[k] += w * y_vec._ei_cache[k]*obeta;
+    }
+  };
+  
+  // not vectorized
+  for (ivertex = 0; ivertex < nv; ++ivertex) {
+    gvertices._se[ivertex] = 0.0;
+    gvertices._sw[ivertex] = 0.0;
+    gvertices._swz[ivertex] = 0.0;
+    gvertices._swE[ivertex] = 0.0;
+  }
+  
+  
+  // independpent of loop
+  if ( useRho0 )
+    {
+      Z_init = rho0 * local_exp(-beta * dzCutOff_ * dzCutOff_); // cut-off
+    }
+  
+  // loop over tracks
+  for (itrack = 0; itrack < nt; ++itrack) {
+    kernel_calc_exp_arg(itrack, gtracks, gvertices);
+    local_exp_list(gvertices._ei_cache, gvertices._ei, nv);
+    //vdt::cephes_single_exp_vect( y_vec._ei, nv );
+    
+    gtracks._Z_sum[itrack] = kernel_add_Z(gvertices);
+    
+    // used in the next major loop to follow
+    if (!useRho0)
+      sumpi += gtracks._pi[itrack];
+    
+    if (gtracks._Z_sum[itrack] > 0) {
+      kernel_calc_normalization(itrack, gtracks, gvertices);
+    }
+  }
+  
+  // now update z and pk
+  auto kernel_calc_z = [ &delta, &sumpi, nv, this, useRho0 ] (vertex_t & vertices ) {
+    
+    // does not vectorizes
+    for (unsigned int ivertex = 0; ivertex < nv; ++ ivertex ) {
+      if (vertices._sw[ivertex] > 0) {
+	auto znew = vertices._swz[ ivertex ] / vertices._sw[ ivertex ];
+	// prevents from vectorizing if 
+	delta += std::pow( vertices._z[ ivertex ] - znew, 2 );
+	vertices._z[ ivertex ] = znew;
+      }
 #ifdef VI_DEBUG
-			else {
-				edm::LogInfo("sumw") << "invalid sum of weights in fit: " << vertices._sw[ivertex] << endl;
-				if (this->verbose_) {
-					LogDebug("DAClusterizerinZ_vectorized")  << " a cluster melted away ?  pk=" << vertices._pk[ ivertex ] << " sumw="
-					<< vertices._sw[ivertex] << endl;
-				}
-			}
+      else {
+	edm::LogInfo("sumw") << "invalid sum of weights in fit: " << vertices._sw[ivertex] << endl;
+	if (this->verbose_) {
+	  LogDebug("DAClusterizerinZ_vectorized")  << " a cluster melted away ?  pk=" << vertices._pk[ ivertex ] << " sumw="
+						   << vertices._sw[ivertex] << endl;
+	}
+      }
 #endif
-                }
-			// dont do, if rho cut
-		if ( ! useRho0 )
-                for (unsigned int ivertex = 0; ivertex < nv; ++ ivertex )
-                    vertices._pk[ ivertex ] = vertices._pk[ ivertex ] * vertices._se[ ivertex ] / sumpi;
-	};
-
-	kernel_calc_z(gvertices);
-
+    }
+    // dont do, if rho cut
+    if ( ! useRho0 ){
+      auto osumpi = 1./sumpi;
+      for (unsigned int ivertex = 0; ivertex < nv; ++ ivertex )
+	vertices._pk[ ivertex ] = vertices._pk[ ivertex ] * vertices._se[ ivertex ] * osumpi;
+    }
+  };
+  
+  kernel_calc_z(gvertices);
+  
 	// return how much the prototypes moved
 	return delta;
 }
@@ -322,109 +303,110 @@ bool DAClusterizerInZ_vect::merge(vertex_t & y) const {
 	return false;
 }
 
-bool DAClusterizerInZ_vect::purge(vertex_t & y, track_t & tks, double & rho0,
-		const double beta) const {
-	// eliminate clusters with only one significant/unique track
-	const unsigned int nv = y.GetSize();
-	const unsigned int nt = tks.GetSize();
+bool 
+DAClusterizerInZ_vect::purge(vertex_t & y, track_t & tks, double & rho0, const double beta) const {
+  // eliminate clusters with only one significant/unique track
+  const unsigned int nv = y.GetSize();
+  const unsigned int nt = tks.GetSize();
 
-	if (nv < 2)
-		return false;
-
-	double sumpmin = nt;
-	unsigned int k0 = nv;
-
-	for (unsigned int k = 0; k < nv; k++) {
-
-		int nUnique = 0;
-		double sump = 0;
-		double pmax = y._pk[k] / (y._pk[k] + rho0 * local_exp(-beta * dzCutOff_
-				* dzCutOff_));
-
-		for (unsigned int i = 0; i < nt; i++) {
-
-			if (tks._Z_sum[i] > 0) {
-				//double p=pik(beta,tks[i],*k);
-				double p = y._pk[k] * local_exp(-beta * Eik(tks._z[i], y._z[k],
-						tks._dz2[i])) / tks._Z_sum[i];
-				sump += p;
-				if ((p > 0.9 * pmax) && (tks._pi[i] > 0)) {
-					nUnique++;
-				}
+  if (nv < 2)
+    return false;
+  
+  double sumpmin = nt;
+  unsigned int k0 = nv;
+  
+  for (unsigned int k = 0; k < nv; k++) {
+    
+    int nUnique = 0;
+    double sump = 0;
+    double pmax = y._pk[k] / (y._pk[k] + rho0 * local_exp(-beta * dzCutOff_
+							  * dzCutOff_));
+    
+    for (unsigned int i = 0; i < nt; i++) {
+      
+      if (tks._Z_sum[i] > 0) {
+	//double p=pik(beta,tks[i],*k);
+	double p = y._pk[k] * local_exp(-beta * Eik(tks._z[i], y._z[k],
+						    tks._dz2[i])) / tks._Z_sum[i];
+	sump += p;
+	if ((p > 0.9 * pmax) && (tks._pi[i] > 0)) {
+	  nUnique++;
+	}
 			}
-		}
-
-		if ((nUnique < 2) && (sump < sumpmin)) {
-			sumpmin = sump;
-			k0 = k;
-		}
-	}
-
-	if (k0 != nv) {
-		if (verbose_) {
-			LogDebug("DAClusterizerinZ_vectorized")  << "eliminating prototype at " << y._z[k0] << " with sump="
-					<< sumpmin << endl;
-		}
-		//rho0+=k0->pk;
-		y.RemoveItem(k0);
-		return true;
-	} else {
-		return false;
-	}
+    }
+    
+    if ((nUnique < 2) && (sump < sumpmin)) {
+      sumpmin = sump;
+      k0 = k;
+    }
+  }
+  
+  if (k0 != nv) {
+    if (verbose_) {
+      LogDebug("DAClusterizerinZ_vectorized")  << "eliminating prototype at " << y._z[k0] << " with sump="
+					       << sumpmin << endl;
+    }
+    //rho0+=k0->pk;
+    y.RemoveItem(k0);
+    return true;
+  } else {
+    return false;
+  }
 }
 
-double DAClusterizerInZ_vect::beta0(double betamax, track_t & tks, vertex_t & y) const {
-
-	double T0 = 0; // max Tc for beta=0
-	// estimate critical temperature from beta=0 (T=inf)
-	const unsigned int nt = tks.GetSize();
-	const unsigned int nv = y.GetSize();
-
-	for (unsigned int k = 0; k < nv; k++) {
-
-		// vertex fit at T=inf
-		double sumwz = 0;
-		double sumw = 0;
-		for (unsigned int i = 0; i < nt; i++) {
-			double w = tks._pi[i] / tks._dz2[i];
-			sumwz += w * tks._z[i];
-			sumw += w;
-		}
-		y._z[k] = sumwz / sumw;
-
-		// estimate Tcrit, eventually do this in the same loop
-		double a = 0, b = 0;
-		for (unsigned int i = 0; i < nt; i++) {
-			double dx = tks._z[i] - (y._z[k]);
-			double w = tks._pi[i] / tks._dz2[i];
-			a += w * std::pow(dx, 2) / tks._dz2[i];
-			b += w;
-		}
-		double Tc = 2. * a / b; // the critical temperature of this vertex
-		if (Tc > T0)
-			T0 = Tc;
-	}// vertex loop (normally there should be only one vertex at beta=0)
-
-	if (T0 > 1. / betamax) {
-		return betamax / std::pow(coolingFactor_, int(std::log(T0 * betamax) / std::log(
-				coolingFactor_)) - 1);
-	} else {
-		// ensure at least one annealing step
-		return betamax / coolingFactor_;
-	}
+double 
+DAClusterizerInZ_vect::beta0(double betamax, track_t const  & tks, vertex_t const & y) const {
+  
+  double T0 = 0; // max Tc for beta=0
+  // estimate critical temperature from beta=0 (T=inf)
+  const unsigned int nt = tks.GetSize();
+  const unsigned int nv = y.GetSize();
+  
+  for (unsigned int k = 0; k < nv; k++) {
+    
+    // vertex fit at T=inf
+    double sumwz = 0;
+    double sumw = 0;
+    for (unsigned int i = 0; i < nt; i++) {
+      double w = tks._pi[i] / tks._dz2[i];
+      sumwz += w * tks._z[i];
+      sumw += w;
+    }
+    y._z[k] = sumwz / sumw;
+    
+    // estimate Tcrit, eventually do this in the same loop
+    double a = 0, b = 0;
+    for (unsigned int i = 0; i < nt; i++) {
+      double dx = tks._z[i] - (y._z[k]);
+      double w = tks._pi[i] / tks._dz2[i];
+      a += w * std::pow(dx, 2) / tks._dz2[i];
+      b += w;
+    }
+    double Tc = 2. * a / b; // the critical temperature of this vertex
+    if (Tc > T0)
+      T0 = Tc;
+  }// vertex loop (normally there should be only one vertex at beta=0)
+  
+  if (T0 > 1. / betamax) {
+    return betamax / std::pow(coolingFactor_, int(std::log(T0 * betamax) / std::log(coolingFactor_)) - 1);
+  } else {
+    // ensure at least one annealing step
+    return betamax / coolingFactor_;
+  }
 }
 
 
-bool DAClusterizerInZ_vect::split(const double beta,  track_t &tks, vertex_t & y ) const{
+bool 
+DAClusterizerInZ_vect::split(const double beta,  track_t &tks, vertex_t & y ) const{
   // split only critical vertices (Tc >~ T=1/beta   <==>   beta*Tc>~1)
   // an update must have been made just before doing this (same beta, no merging)
   // returns true if at least one cluster was split
-
+  
   double epsilon=1e-3;      // split all single vertices by 10 um
   unsigned int nv = y.GetSize();
-
+  
   // avoid left-right biases by splitting highest Tc first
-
+  
   std::vector<std::pair<double, unsigned int> > critical;
   for(unsigned int k=0; k<nv; k++){
     double Tc= 2*y._swE[k]/y._sw[k];
@@ -434,8 +416,8 @@ bool DAClusterizerInZ_vect::split(const double beta,  track_t &tks, vertex_t & y
   }
   if (critical.size()==0) return false;
   stable_sort(critical.begin(), critical.end(), std::greater<std::pair<double, unsigned int> >() );
-
-
+  
+  
   bool split=false;
   const unsigned int nt = tks.GetSize();
 
@@ -634,8 +616,8 @@ void DAClusterizerInZ_vect::dump(const double beta, const vertex_t & y,
 	}
 }
 
-vector<TransientVertex> DAClusterizerInZ_vect::vertices(const vector<
-		reco::TransientTrack> & tracks, const int verbosity) const {
+vector<TransientVertex> 
+DAClusterizerInZ_vect::vertices(const vector<reco::TransientTrack> & tracks, const int verbosity) const {
 
 
 	track_t tks = fill(tracks);
@@ -799,41 +781,41 @@ vector<TransientVertex> DAClusterizerInZ_vect::vertices(const vector<
 
 vector<vector<reco::TransientTrack> > DAClusterizerInZ_vect::clusterize(
 		const vector<reco::TransientTrack> & tracks) const {
-                  
-	if (verbose_) {
-		std::cout  << "###################################################" << endl;
-		std::cout  << "# vectorized DAClusterizerInZ_vect::clusterize   nt=" << tracks.size() << endl;
-		std::cout  << "###################################################" << endl;
-	}
-
-	vector<vector<reco::TransientTrack> > clusters;
-	vector<TransientVertex> pv = vertices(tracks);
-
-	if (verbose_) {
-		LogDebug("DAClusterizerinZ_vectorized")  << "# DAClusterizerInZ::clusterize   pv.size=" << pv.size()
-				<< endl;
-	}
-	if (pv.size() == 0) {
-		return clusters;
-	}
-
-	// fill into clusters and merge
-	vector<reco::TransientTrack> aCluster = pv.begin()->originalTracks();
-
-	for (vector<TransientVertex>::iterator k = pv.begin() + 1; k != pv.end(); k++) {
-	        if ( fabs(k->position().z() - (k - 1)->position().z()) > (2 * vertexSize_)) {
-			// close a cluster
-			clusters.push_back(aCluster);
-			aCluster.clear();
-		}
-		for (unsigned int i = 0; i < k->originalTracks().size(); i++) {
-			aCluster.push_back(k->originalTracks().at(i));
-		}
-
-	}
-	clusters.push_back(aCluster);
-
-	return clusters;
+  
+  if (verbose_) {
+    std::cout  << "###################################################" << endl;
+    std::cout  << "# vectorized DAClusterizerInZ_vect::clusterize   nt=" << tracks.size() << endl;
+    std::cout  << "###################################################" << endl;
+  }
+  
+  vector<vector<reco::TransientTrack> > clusters;
+  vector<TransientVertex> && pv = vertices(tracks);
+  
+  if (verbose_) {
+    LogDebug("DAClusterizerinZ_vectorized")  << "# DAClusterizerInZ::clusterize   pv.size=" << pv.size()
+					     << endl;
+  }
+  if (pv.size() == 0) {
+    return clusters;
+  }
+  
+  // fill into clusters and merge
+  vector<reco::TransientTrack> aCluster = pv.begin()->originalTracks();
+  
+  for (auto k = pv.begin() + 1; k != pv.end(); k++) {
+    if ( std::abs(k->position().z() - (k - 1)->position().z()) > (2 * vertexSize_)) {
+      // close a cluster
+      clusters.push_back(aCluster);
+      aCluster.clear();
+    }
+    for (unsigned int i = 0; i < k->originalTracks().size(); i++) {
+      aCluster.push_back(k->originalTracks()[i]);
+    }
+    
+  }
+  clusters.emplace_back(std::move(aCluster));
+  
+  return clusters;
 
 }
 

--- a/RecoVertex/TrimmedKalmanVertexFinder/BuildFile.xml
+++ b/RecoVertex/TrimmedKalmanVertexFinder/BuildFile.xml
@@ -1,3 +1,4 @@
+<flags   CXXFLAGS="-Ofast -mrecip"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/RecoVertex/VertexPrimitives/BuildFile.xml
+++ b/RecoVertex/VertexPrimitives/BuildFile.xml
@@ -1,3 +1,4 @@
+<flags   CXXFLAGS="-Ofast -mrecip"/>
 <use   name="DataFormats/BeamSpot"/>
 <use   name="DataFormats/GeometrySurface"/>
 <use   name="DataFormats/GeometryVector"/>

--- a/RecoVertex/VertexTools/BuildFile.xml
+++ b/RecoVertex/VertexTools/BuildFile.xml
@@ -1,3 +1,4 @@
+<flags   CXXFLAGS="-Ofast -mrecip"/>
 <use   name="DataFormats/BeamSpot"/>
 <use   name="DataFormats/CLHEP"/>
 <use   name="DataFormats/GeometryCommonDetAlgo"/>

--- a/RecoVertex/VertexTools/interface/PerigeeLinearizedTrackState.h
+++ b/RecoVertex/VertexTools/interface/PerigeeLinearizedTrackState.h
@@ -153,7 +153,7 @@ private:
   	const TrajectoryStateOnSurface& tsos)
      : theLinPoint(linP), theTrack(track), 
      theTSOS(tsos),  theCharge(theTrack.charge()), jacobiansAvailable(false) {
-     assert(edm::isFinite(linP.x()));
+     // assert(edm::isFinite(linP.x()));
     }
 
   /** Method calculating the track parameters and the Jacobians.

--- a/RecoVertex/VertexTools/interface/PerigeeLinearizedTrackState.h
+++ b/RecoVertex/VertexTools/interface/PerigeeLinearizedTrackState.h
@@ -8,6 +8,7 @@
 #include "Math/SMatrix.h"
 #include "DataFormats/CLHEP/interface/Migration.h"
 
+#include "FWCore/Utilities/interface/isFinite.h"
 #include "FWCore/Utilities/interface/GCC11Compatibility.h"
 
 
@@ -151,7 +152,9 @@ private:
    PerigeeLinearizedTrackState(const GlobalPoint & linP, const reco::TransientTrack & track, 
   	const TrajectoryStateOnSurface& tsos)
      : theLinPoint(linP), theTrack(track), 
-     theTSOS(tsos),  theCharge(theTrack.charge()), jacobiansAvailable(false) {}
+     theTSOS(tsos),  theCharge(theTrack.charge()), jacobiansAvailable(false) {
+     assert(edm::isFinite(linP.x()));
+    }
 
   /** Method calculating the track parameters and the Jacobians.
    */

--- a/TrackingTools/AnalyticalJacobians/BuildFile.xml
+++ b/TrackingTools/AnalyticalJacobians/BuildFile.xml
@@ -1,3 +1,4 @@
+<flags   CXXFLAGS="-O3 -mrecip"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/TrackingTools/GeomPropagators/BuildFile.xml
+++ b/TrackingTools/GeomPropagators/BuildFile.xml
@@ -1,4 +1,4 @@
-<flags   CXXFLAGS="-O3"/>
+<flags   CXXFLAGS="-Ofast -mrecip"/>
 <use   name="FWCore/MessageLogger"/>
 <use   name="FWCore/Utilities"/>
 <use   name="DataFormats/GeometrySurface"/>

--- a/TrackingTools/GeomPropagators/src/HelixBarrelPlaneCrossingByCircle.cc
+++ b/TrackingTools/GeomPropagators/src/HelixBarrelPlaneCrossingByCircle.cc
@@ -7,6 +7,9 @@
 #include <algorithm>
 #include <cfloat>
 
+#include<cassert>
+#include<iostream>
+
 HelixBarrelPlaneCrossingByCircle::
 HelixBarrelPlaneCrossingByCircle( const PositionType& pos,
 				  const DirectionType& dir,
@@ -66,11 +69,14 @@ HelixBarrelPlaneCrossingByCircle::pathLength( const Plane& plane)
   double ny = n.y();  // convert to double
   double distCx = theStartingPos.x() - theXCenter;
   double distCy = theStartingPos.y() - theYCenter;
-
+  
+  if ( (nx==0) & (ny==0) ) { std::cout << "barrel??? " << n << ' ' << plane.rotation() << std::endl; return std::make_pair(false,0.); }
+  // assert(distToPlane!=0);
+ 
   double nfac, dfac;
   double A, B, C;
   bool solveForX;
-  if (fabs(nx) > fabs(ny)) {
+  if (std::abs(nx) > std::abs(ny)) {
     solveForX = false;
     nfac = ny/nx;
     dfac = distToPlane/nx;
@@ -110,7 +116,7 @@ HelixBarrelPlaneCrossingByCircle::pathLength( const Plane& plane)
     // protect asin 
     double sinAlpha = 0.5*theDmag*theRho;
     if ( std::abs(sinAlpha)>1.)  sinAlpha = std::copysign(1.,sinAlpha);
-    theS = theActualDir*2./(theRho*theSinTheta) * asin( sinAlpha);
+    theS = theActualDir*2./(theRho*theSinTheta) * std::asin(sinAlpha);
     return ResultType( true, theS);
   }
   else return ResultType( false, 0.);

--- a/TrackingTools/GeomPropagators/src/RealQuadEquation.h
+++ b/TrackingTools/GeomPropagators/src/RealQuadEquation.h
@@ -15,6 +15,7 @@ struct dso_internal RealQuadEquation {
   bool hasSolution;
 
   RealQuadEquation( double A, double B, double C) {
+    if (A==0) { first=second = -C/B; hasSolution = true; return;}
     double D = B*B - 4*A*C;
     if (D<0) hasSolution = false;
     else {

--- a/TrackingTools/GsfTools/BuildFile.xml
+++ b/TrackingTools/GsfTools/BuildFile.xml
@@ -1,3 +1,4 @@
+<flags   CXXFLAGS="-Ofast -mrecip"/>
 <use   name="boost"/>
 <use   name="CLHEP"/>
 <export>

--- a/TrackingTools/GsfTracking/BuildFile.xml
+++ b/TrackingTools/GsfTracking/BuildFile.xml
@@ -1,3 +1,4 @@
+<flags   CXXFLAGS="-Ofast -mrecip"/>
 <use   name="boost"/>
 <use   name="CLHEP"/>
 <export>

--- a/TrackingTools/KalmanUpdators/BuildFile.xml
+++ b/TrackingTools/KalmanUpdators/BuildFile.xml
@@ -1,4 +1,4 @@
-<flags   CXXFLAGS="-O3"/>
+<flags   CXXFLAGS="-Ofast -mrecip"/>
 <use   name="boost"/>
 <use   name="clhep"/>
 <use   name="RecoTracker/TransientTrackingRecHit"/>

--- a/TrackingTools/MaterialEffects/BuildFile.xml
+++ b/TrackingTools/MaterialEffects/BuildFile.xml
@@ -1,3 +1,4 @@
+<flags   CXXFLAGS="-Ofast -mrecip"/>
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="FWCore/Utilities"/>

--- a/TrackingTools/PatternTools/interface/TrajectoryStateClosestToPointBuilder.h
+++ b/TrackingTools/PatternTools/interface/TrajectoryStateClosestToPointBuilder.h
@@ -27,7 +27,8 @@ public:
     const GlobalPoint& referencePoint) const = 0;
 
   static bool positionEqual(const GlobalPoint& ptB, const GlobalPoint& ptA) {
-    return ptA==ptB;
+    auto d = (ptA-ptB);
+    return std::max(std::max(std::abs(d.x()),std::abs(d.y())),std::abs(d.z())) < 0.1e-3;
   }
 
 protected:

--- a/TrackingTools/PatternTools/src/TSCPBuilderNoMaterial.cc
+++ b/TrackingTools/PatternTools/src/TSCPBuilderNoMaterial.cc
@@ -7,6 +7,8 @@
 #include "TrackingTools/TrajectoryParametrization/interface/TrajectoryStateExceptions.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/isFinite.h"
+
 
 TrajectoryStateClosestToPoint 
 TSCPBuilderNoMaterial::operator() (const FTS& originalFTS, 
@@ -52,7 +54,7 @@ TSCPBuilderNoMaterial::createFTSatTransverseImpactPoint(
   // Straight line approximation? |rho|<1.e-10 equivalent to ~ 1um 
   // difference in transversal position at 10m.
   //
-  if( fabs(originalFTS.transverseCurvature())<1.e-10 ) {
+  if( std::abs(originalFTS.transverseCurvature())<1.e-10 ) {
     return createFTSatTransverseImpactPointNeutral(originalFTS, referencePoint);
   } else {
     return createFTSatTransverseImpactPointCharged(originalFTS, referencePoint);
@@ -75,11 +77,11 @@ TSCPBuilderNoMaterial::createFTSatTransverseImpactPointCharged(
   double zOrig = xvecOrig.z();
 
 //  double fac = 1./originalFTS.charge()/MagneticField::inInverseGeV(referencePoint).z();
-  double fac = 1./originalFTS.charge()/
+  double fac = originalFTS.charge()/
     (originalFTS.parameters().magneticField().inInverseGeV(referencePoint).z());
-  GlobalVectorDouble xOrig2Centre = GlobalVectorDouble(fac * pyOrig, -fac * pxOrig, 0.);
-  GlobalVectorDouble xOrigProj = GlobalVectorDouble(xOrig, yOrig, 0.);
-  GlobalVectorDouble xRefProj = GlobalVectorDouble(referencePoint.x(), referencePoint.y(), 0.);
+  GlobalVectorDouble xOrig2Centre(fac * pyOrig, -fac * pxOrig, 0.);
+  GlobalVectorDouble xOrigProj(xOrig, yOrig, 0.);
+  GlobalVectorDouble xRefProj(referencePoint.x(), referencePoint.y(), 0.);
   GlobalVectorDouble deltax = xRefProj-xOrigProj-xOrig2Centre;
   GlobalVectorDouble ndeltax = deltax.unit();
 
@@ -90,7 +92,7 @@ TSCPBuilderNoMaterial::createFTSatTransverseImpactPointCharged(
   GlobalVector X(ndeltax.x(), ndeltax.y(), ndeltax.z());
   GlobalVector Y(0.,0.,1.);
   Surface::RotationType rot(X,Y);
-  BoundPlane* plane = new BoundPlane(pos,rot);
+  BoundPlane plane(pos,rot);
   // Using Teddy's HelixBarrelPlaneCrossingByCircle for general barrel planes. 
   // A large variety of other,
   // direct solutions turned out to be not so stable numerically.
@@ -98,20 +100,19 @@ TSCPBuilderNoMaterial::createFTSatTransverseImpactPointCharged(
     planeCrossing(HelixPlaneCrossing::PositionType(xOrig, yOrig, zOrig),
 		  HelixPlaneCrossing::DirectionType(pxOrig, pyOrig, pzOrig), 
 		  kappa, direction);
-  std::pair<bool,double> propResult = planeCrossing.pathLength(*plane);
+  std::pair<bool,double> propResult = planeCrossing.pathLength(plane);
   if ( !propResult.first ) {
     edm::LogWarning ("TSCPBuilderNoMaterial") << "Propagation to perigee plane failed!";
     return PairBoolFTS(false, FreeTrajectoryState() );
   }
   double s = propResult.second;
   HelixPlaneCrossing::PositionType xGen = planeCrossing.position(s);
-  GlobalPoint xPerigee = GlobalPoint(xGen.x(),xGen.y(),xGen.z());
+  GlobalPoint xPerigee(xGen.x(),xGen.y(),xGen.z());
   // direction (reconverted to GlobalVector, renormalised)
   HelixPlaneCrossing::DirectionType pGen = planeCrossing.direction(s);
   pGen *= pvecOrig.mag()/pGen.mag();
-  GlobalVector pPerigee = GlobalVector(pGen.x(),pGen.y(),pGen.z());
-  delete plane;
-		  
+  GlobalVector pPerigee(pGen.x(),pGen.y(),pGen.z());
+
   if (originalFTS.hasError()) {
     const AlgebraicSymMatrix55 &errorMatrix = originalFTS.curvilinearError().matrix();
     AnalyticalCurvilinearJacobian curvilinJacobian(originalFTS.parameters(), xPerigee,

--- a/TrackingTools/TrajectoryState/BuildFile.xml
+++ b/TrackingTools/TrajectoryState/BuildFile.xml
@@ -1,3 +1,4 @@
+<flags   CXXFLAGS="-O3 -mrecip"/>
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/GeometrySurface"/>
 <use   name="DataFormats/GeometryVector"/>

--- a/TrackingTools/TrajectoryState/BuildFile.xml
+++ b/TrackingTools/TrajectoryState/BuildFile.xml
@@ -1,4 +1,4 @@
-<flags   CXXFLAGS="-Ofast -mrecip"/>
+<flags   CXXFLAGS="-Ofast"/>
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/GeometrySurface"/>
 <use   name="DataFormats/GeometryVector"/>

--- a/TrackingTools/TrajectoryState/BuildFile.xml
+++ b/TrackingTools/TrajectoryState/BuildFile.xml
@@ -1,4 +1,4 @@
-<flags   CXXFLAGS="-O3 -mrecip"/>
+<flags   CXXFLAGS="-Ofast -mrecip"/>
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/GeometrySurface"/>
 <use   name="DataFormats/GeometryVector"/>

--- a/TrackingTools/TrajectoryState/interface/TrajectoryStateClosestToPoint.h
+++ b/TrackingTools/TrajectoryState/interface/TrajectoryStateClosestToPoint.h
@@ -36,7 +36,7 @@ public:
     theField(field), theRefPoint(referencePoint), 
     theParameters(perigeeParameters), thePt( pt ), 
     valid(true),  theFTSavailable(false), errorIsAvailable(false)
-  {}
+  { assert(pt>0);}
 
   /**
    * Public constructor, which is used to convert perigee 
@@ -48,7 +48,7 @@ public:
 				const MagneticField* field):
     theField(field),  theRefPoint(referencePoint),
     theParameters(perigeeParameters), thePt( pt ), thePerigeeError(perigeeError),
-    valid(true), theFTSavailable(false), errorIsAvailable(true){}
+    valid(true), theFTSavailable(false), errorIsAvailable(true){assert(pt>0);}
 
 
   /**

--- a/TrackingTools/TrajectoryState/src/PerigeeConversions.cc
+++ b/TrackingTools/TrajectoryState/src/PerigeeConversions.cc
@@ -3,6 +3,7 @@
 #include "MagneticField/Engine/interface/MagneticField.h" 
 #include <cmath>
 #include <vdt/vdtMath.h>
+#include <cassert>
 
 PerigeeTrajectoryParameters PerigeeConversions::ftsToPerigeeParameters
   (const FTS& originalFTS, const GlobalPoint& referencePoint, double & pt)
@@ -11,7 +12,7 @@ PerigeeTrajectoryParameters PerigeeConversions::ftsToPerigeeParameters
   GlobalVector impactDistance = originalFTS.position() - referencePoint;
 
   pt = originalFTS.momentum().perp();
-  if (pt==0.) throw cms::Exception("PerigeeConversions", "Track with pt=0");
+  if (pt==0.) assert(pt>0); //  throw cms::Exception("PerigeeConversions", "Track with pt=0");
   
   double theta = originalFTS.momentum().theta();
   double phi = originalFTS.momentum().phi();

--- a/TrackingTools/TrajectoryState/src/TrajectoryStateClosestToPoint.cc
+++ b/TrackingTools/TrajectoryState/src/TrajectoryStateClosestToPoint.cc
@@ -8,11 +8,10 @@ TrajectoryStateClosestToPoint::
 TrajectoryStateClosestToPoint(const FTS& originalFTS, const GlobalPoint& referencePoint) :
   theFTS(originalFTS), theRefPoint(referencePoint),valid(true), theFTSavailable(true) {
   try {
-//    assert(originalFTS.hasError());
-//    assert(originalFTS.momentum().perp2()>0);
-//    assert(originalFTS.position().perp2()>0);
-    if (edm::isNotFinite(originalFTS.momentum().x())) std::cout << "  TSCTS NaN " << originalFTS.momentum() << ' at ' << originalFTS.position() << std::endl;
-    if (originalFTS.momentum().perp()==0) std::cout << "zero pt " << originalFTS.momentum() << std::endl;
+    if (edm::isNotFinite(originalFTS.momentum().x())) 
+       edm::LogWarning("TrajectoryStateClosestToPoint") << "NaN mom " << originalFTS.momentum() << " at " << originalFTS.position();
+    if (edm::isNotFinite(referencePoint.x()))
+       edm::LogWarning("TrajectoryStateClosestToPoint") << "NaN refP " << referencePoint;
     theParameters = PerigeeConversions::ftsToPerigeeParameters(originalFTS, referencePoint, thePt);
     if (theFTS.hasError()) {
       thePerigeeError = PerigeeConversions::ftsToPerigeeError(originalFTS);

--- a/TrackingTools/TrajectoryState/src/TrajectoryStateClosestToPoint.cc
+++ b/TrackingTools/TrajectoryState/src/TrajectoryStateClosestToPoint.cc
@@ -1,5 +1,6 @@
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateClosestToPoint.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/isFinite.h"
 
 // Private constructor
 
@@ -7,6 +8,11 @@ TrajectoryStateClosestToPoint::
 TrajectoryStateClosestToPoint(const FTS& originalFTS, const GlobalPoint& referencePoint) :
   theFTS(originalFTS), theRefPoint(referencePoint),valid(true), theFTSavailable(true) {
   try {
+//    assert(originalFTS.hasError());
+//    assert(originalFTS.momentum().perp2()>0);
+//    assert(originalFTS.position().perp2()>0);
+    if (edm::isNotFinite(originalFTS.momentum().x())) std::cout << "  TSCTS NaN " << originalFTS.momentum() << ' at ' << originalFTS.position() << std::endl;
+    if (originalFTS.momentum().perp()==0) std::cout << "zero pt " << originalFTS.momentum() << std::endl;
     theParameters = PerigeeConversions::ftsToPerigeeParameters(originalFTS, referencePoint, thePt);
     if (theFTS.hasError()) {
       thePerigeeError = PerigeeConversions::ftsToPerigeeError(originalFTS);


### PR DESCRIPTION
speed up various critical packages by using Ofast option
as described in
https://twiki.cern.ch/twiki/bin/view/CMS/HighGranularityCMSSWOptimization
and discussed in April in some Reco/Offline meeting

a small regression is observed in primaryVertices (greatly mitigated w/r/t the very first attempts).
This "cascades" in general tracks and conversions as primaryVertices are used in the seeding
