### PR TITLE
Made staic debug controls std::atomics

### DIFF
--- a/EventFilter/CSCRawToDigi/interface/CSCDDUEventData.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCDDUEventData.h
@@ -61,10 +61,11 @@ public:
 
 #ifdef LOCAL_UNPACK
   static bool debug;
+  static unsigned int errMask;
 #else
   static std::atomic<bool> debug;
+  static std::atomic<unsigned int> errMask;
 #endif
-  static unsigned int errMask;
 
   /// a good test routine would be to unpack data, then pack it again.
 protected:

--- a/EventFilter/CSCRawToDigi/interface/CSCEventData.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCEventData.h
@@ -20,6 +20,9 @@ class CSCStripDigi;
 class CSCComparatorOutput;
 #include <map>
 #include <vector>
+#ifndef LOCAL_UNPACK
+#include <atomic>
+#endif
 #include "EventFilter/CSCRawToDigi/interface/CSCDMBHeader.h"
 #include "EventFilter/CSCRawToDigi/interface/CSCDMBTrailer.h"
 #include "EventFilter/CSCRawToDigi/interface/CSCDMBHeader.h"
@@ -142,7 +145,11 @@ class CSCEventData {
   unsigned int calcALCTcrc(std::vector< std::pair<unsigned int, unsigned short*> > &vec);
 
 
+#ifdef LOCAL_UNPACK
   static bool debug;
+#else
+  static std::atomic<bool> debug;
+#endif
   //uint16_t dataPresent; // 7 bit word which will tell if alct, clct, and 5 cfebs are present
   static void selfTest();
 

--- a/EventFilter/CSCRawToDigi/interface/CSCRPCData.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCRPCData.h
@@ -2,6 +2,9 @@
 #define CSCRPCData_h
 
 #include <vector>
+#ifndef LOCAL_UNPACK
+#include <atomic>
+#endif
 
 class CSCRPCDigi;
 
@@ -24,7 +27,11 @@ public:
   static void setDebug(bool debugValue) {debug = debugValue;}
   
 private:
+#ifdef LOCAL_UNPACK
   static bool debug;
+#else
+  static std::atomic<bool> debug;
+#endif
   int ntbins_;
   int size_;
   unsigned short theData[2*4*32+2];

--- a/EventFilter/CSCRawToDigi/interface/CSCTMBData.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCTMBData.h
@@ -17,6 +17,9 @@
 #include "EventFilter/CSCRawToDigi/interface/CSCRPCData.h"
 #include <bitset>
 #include <boost/dynamic_bitset.hpp>
+#ifndef LOCAL_UNPACK
+#include <atomic>
+#endif
 
 
 class CSCTMBData {
@@ -91,7 +94,11 @@ class CSCTMBData {
   CSCTMBBlockedCFEB * theTMBBlockedCFEB;
 
   CSCTMBTrailer theTMBTrailer;
+#ifdef LOCAL_UNPACK
   static bool debug;
+#else
+  static std::atomic<bool> debug;
+#endif
   unsigned short size_;
   unsigned short cWordCnt;
   bool theRPCDataIsPresent;

--- a/EventFilter/CSCRawToDigi/interface/CSCTMBHeader.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCTMBHeader.h
@@ -12,6 +12,9 @@
 #include "EventFilter/CSCRawToDigi/interface/CSCVTMBHeaderFormat.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include <boost/shared_ptr.hpp>
+#ifndef LOCAL_UNPACK
+#include <atomic>
+#endif
 class CSCDMBHeader;
 class CSCTMBHeader2006;
 class CSCTMBHeader2007;
@@ -143,7 +146,11 @@ private:
 
   //void swapCLCTs(CSCCLCTDigi& digi1, CSCCLCTDigi& digi2);
 
+#ifdef LOCAL_UNPACK
   static bool debug;
+#else
+  static std::atomic<bool> debug;
+#endif
 
   boost::shared_ptr<CSCVTMBHeaderFormat> theHeaderFormat;
   int theFirmwareVersion;

--- a/EventFilter/CSCRawToDigi/interface/CSCTMBScope.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCTMBScope.h
@@ -8,6 +8,10 @@
 #ifndef CSCTMBScope_h
 #define CSCTMBScope_h
 
+#ifndef LOCAL_UNPACK
+#include <atomic>
+#endif
+
 class CSCTMBScope {
 
 public:
@@ -26,7 +30,11 @@ private:
 
   unsigned int scope_ram[256][6];   //stores all scope data
   unsigned short size_;
+#ifdef LOCAL_UNPACK
   static bool debug;
+#else
+  static std::atomic<bool> debug;
+#endif
 
 };
 

--- a/EventFilter/CSCRawToDigi/src/CSCDDUEventData.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCDDUEventData.cc
@@ -14,12 +14,13 @@
 
 #ifdef LOCAL_UNPACK
 bool CSCDDUEventData::debug = false;
+uint32_t CSCDDUEventData::errMask = 0xFFFFFFFF;
 #else
 #include <atomic>
 std::atomic<bool> CSCDDUEventData::debug{false};
+std::atomic<uint32_t> CSCDDUEventData::errMask{0xFFFFFFFF};
 #endif
 
-uint32_t CSCDDUEventData::errMask = 0xFFFFFFFF;
 
 
 CSCDDUEventData::CSCDDUEventData(const CSCDDUHeader & header) 

--- a/EventFilter/CSCRawToDigi/src/CSCEventData.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCEventData.cc
@@ -9,7 +9,11 @@
 #include "FWCore/Utilities/interface/Exception.h"
 
 
+#ifdef LOCAL_UNPACK
 bool CSCEventData::debug = false;
+#else
+std::atomic<bool> CSCEventData::debug{false};
+#endif
 
 CSCEventData::CSCEventData(int chamberType, uint16_t format_version) :
     theDMBHeader(format_version),

--- a/EventFilter/CSCRawToDigi/src/CSCRPCData.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCRPCData.cc
@@ -16,7 +16,11 @@
   RPC3  BXN     Pads[15:8]
 */
 
+#ifdef LOCAL_UNPACK
 bool CSCRPCData::debug = false;
+#else
+std::atomic<bool> CSCRPCData::debug{false};
+#endif
 
 CSCRPCData::CSCRPCData(int ntbins) 
   : ntbins_(ntbins), size_( 0 )

--- a/EventFilter/CSCRawToDigi/src/CSCTMBData.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCTMBData.cc
@@ -12,7 +12,11 @@
 #include "EventFilter/CSCRawToDigi/src/bitset_append.h"
 #include "EventFilter/CSCRawToDigi/src/cscPackerCompare.h"
 
+#ifdef LOCAL_UNPACK
 bool CSCTMBData::debug =false;
+#else
+std::atomic<bool> CSCTMBData::debug{false};
+#endif
 
 CSCTMBData::CSCTMBData() 
   : theOriginalBuffer(0), 

--- a/EventFilter/CSCRawToDigi/src/CSCTMBHeader.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCTMBHeader.cc
@@ -11,7 +11,11 @@
 #include <math.h>
 #include <string.h> // memcpy
 
+#ifdef LOCAL_UNPACK
 bool CSCTMBHeader::debug = false;
+#else
+std::atomic<bool> CSCTMBHeader::debug{false};
+#endif
 
 CSCTMBHeader::CSCTMBHeader(int firmwareVersion, int firmwareRevision):
   theHeaderFormat(),

--- a/EventFilter/CSCRawToDigi/src/CSCTMBScope.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCTMBScope.cc
@@ -8,7 +8,11 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <iostream>
 
+#ifdef LOCAL_UNPACK
 bool CSCTMBScope::debug = false;
+#else
+std::atomic<bool> CSCTMBScope::debug{false};
+#endif
 
 CSCTMBScope::CSCTMBScope(unsigned short *buf,int b05Line,int e05Line) {
 


### PR DESCRIPTION
To avoid race conditions when changing the debug conditions, switched
all the variables to be std::atomics following similar code use in
other classes of this package.
These statics were found by the static analyzer.
