### PR TITLE
Marked debugging static as thread safe in KinematicConstrainedVertexupdatorT

### DIFF
--- a/RecoVertex/KinematicFit/interface/KinematicConstrainedVertexUpdatorT.h
+++ b/RecoVertex/KinematicFit/interface/KinematicConstrainedVertexUpdatorT.h
@@ -18,7 +18,7 @@ namespace KineDebug3 {
 
   };
   inline void count() {
-    static Count c;
+    [[cms::thread_safe]] static Count c;
     ++c.n;
   }
 


### PR DESCRIPTION
A static instance of a class which only has a std::atomic member data was being
falsely accused of being thread unsafe by the static analyzer. Given the rare
case this represents, it was easier to just mark the static as thread safe using
our C++11 attribute.
