### PR TITLE
Thread safe initialization of dummy PSet static in HLTConfigData

### DIFF
--- a/HLTrigger/HLTcore/src/HLTConfigData.cc
+++ b/HLTrigger/HLTcore/src/HLTConfigData.cc
@@ -12,10 +12,18 @@
 
 #include <iostream>
 
+//Using this function with the 'const static within s_dummyPSet'
+// guarantees that even if multiple threads call s_dummyPSet at the
+// same time, only the 'first' one registers the dummy PSet.
+static const edm::ParameterSet initializeDummyPSet() {
+  edm::ParameterSet dummy;
+  dummy.registerIt();
+  return std::move(dummy);
+}
+
 static const edm::ParameterSet* s_dummyPSet()
 {
-  static edm::ParameterSet dummyPSet;
-  dummyPSet.registerIt();
+  static const edm::ParameterSet dummyPSet{initializeDummyPSet()};
   return &dummyPSet;
 }
 


### PR DESCRIPTION
Modified the code to safely initialize the registration of the dummy
PSet static used in HLTConfigData. Also avoid having the registration
call make each time the function was called.
This was spotted by the static analyzer.
