### PR TITLE
Marked statics as thread-safe since update only at library load

### DIFF
--- a/RecoVertex/ConfigurableVertexReco/src/VertexFitterManager.cc
+++ b/RecoVertex/ConfigurableVertexReco/src/VertexFitterManager.cc
@@ -53,7 +53,10 @@ VertexFitterManager::VertexFitterManager ( const VertexFitterManager & o )
 
 VertexFitterManager & VertexFitterManager::Instance()
 {
-  static VertexFitterManager singleton;
+  //The singleton's internal structure only changes while
+  // this library is being loaded. All other methods are const.
+  
+  [[cms::thread_safe]] static VertexFitterManager singleton;
   return singleton;
 }
 

--- a/RecoVertex/ConfigurableVertexReco/src/VertexRecoManager.cc
+++ b/RecoVertex/ConfigurableVertexReco/src/VertexRecoManager.cc
@@ -44,7 +44,9 @@ VertexRecoManager::VertexRecoManager ( const VertexRecoManager & o )
 
 VertexRecoManager & VertexRecoManager::Instance()
 {
-  static VertexRecoManager singleton;
+  //The singleton's internal structure only changes while
+  // this library is being loaded. All other methods are const.
+  [[cms::thread_safe]] static VertexRecoManager singleton;
   return singleton;
 }
 


### PR DESCRIPTION
The singletons VertexRecoManager and VertexFitterManager are only
updated while the library in which they are embedded is loaded.
Therefore access to these singletons is thread-safe. By marking them
with our C++11 attribute, the static analyzer will no longer complain
about them.
