### PR TITLE
Set Vx3DHLTAnalyzer to thread_unsafe::DQMEDAnalyzer

### DIFF
--- a/DQM/BeamMonitor/plugins/Vx3DHLTAnalyzer.h
+++ b/DQM/BeamMonitor/plugins/Vx3DHLTAnalyzer.h
@@ -24,7 +24,7 @@
 #include "FWCore/Utilities/interface/InputTag.h"
 
 #include "DQMServices/Core/interface/MonitorElement.h"
-#include <DQMServices/Core/interface/DQMEDAnalyzer.h>
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
@@ -62,7 +62,7 @@ double pi;
 double VxErrCorr;       // Coefficient to compensate the under-estimation of the vertex errors
 
 
-class Vx3DHLTAnalyzer : public DQMEDAnalyzer {
+class Vx3DHLTAnalyzer : public thread_unsafe::DQMEDAnalyzer {
    public:
       explicit Vx3DHLTAnalyzer(const edm::ParameterSet&);
       ~Vx3DHLTAnalyzer();


### PR DESCRIPTION
The Vx3DHLTAnalyzer uses a global std::vector to hold all Vertices
it has seen. Filling this on different threads will lead to crashes
of cmsRun. Therefore changed it to inherit from thread_unsafe::DQMEDAnalyzer.
