### PR TITLE
add gen card for radiative decays of Z boson

### DIFF
--- a/Configuration/Generator/python/ZMMgamma_8TeV_cfi.py
+++ b/Configuration/Generator/python/ZMMgamma_8TeV_cfi.py
@@ -1,0 +1,43 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.PythiaUEZ2starSettings_cfi import *
+generator = cms.EDFilter("Pythia6GeneratorFilter",
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    maxEventsToPrint = cms.untracked.int32(0),
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    filterEfficiency = cms.untracked.double(1.0),
+    comEnergy = cms.double(8000.0),
+    PythiaParameters = cms.PSet(
+        pythiaUESettingsBlock,
+        processParameters = cms.vstring('MSEL         = 11 ', 
+            'MDME( 174,1) = 0    !Z decay into d dbar', 
+            'MDME( 175,1) = 0    !Z decay into u ubar', 
+            'MDME( 176,1) = 0    !Z decay into s sbar', 
+            'MDME( 177,1) = 0    !Z decay into c cbar', 
+            'MDME( 178,1) = 0    !Z decay into b bbar', 
+            'MDME( 179,1) = 0    !Z decay into t tbar', 
+            'MDME( 182,1) = 0    !Z decay into e- e+', 
+            'MDME( 183,1) = 0    !Z decay into nu_e nu_ebar', 
+            'MDME( 184,1) = 1    !Z decay into mu- mu+', 
+            'MDME( 185,1) = 0    !Z decay into nu_mu nu_mubar', 
+            'MDME( 186,1) = 0    !Z decay into tau- tau+', 
+            'MDME( 187,1) = 0    !Z decay into nu_tau nu_taubar', 
+            'CKIN( 1)     = 40.  !(D=2. GeV)', 
+            'CKIN( 2)     = -1.  !(D=-1. GeV)'),
+        # This is a vector of ParameterSet names to be read, in this order
+        parameterSets = cms.vstring('pythiaUESettings', 
+            'processParameters')
+    )
+)
+
+mumugenfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(2.5, 2.5),
+    MaxEta = cms.untracked.vdouble(2.5, 2.5),
+    MinEta = cms.untracked.vdouble(-2.5, -2.5),
+    ParticleCharge = cms.untracked.int32(-1),
+    ParticleID1 = cms.untracked.vint32(13),
+    ParticleID2 = cms.untracked.vint32(13)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*mumugenfilter)


### PR DESCRIPTION
- add gen card for radiative decays of Z boson
- requires #4433  (which in turn is a fw-port of an already integrated PR #1101), where the filter to select only radiative decays is developed
- it would be very handy and helpful having this gen card in the release, in order to generate relval samples w/o inclusion of local cards; it's the case for the d.v.mc exercise
