### PR TITLE
speed up DA clusterizer allowing more vectorization

### DIFF
--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
@@ -63,7 +63,6 @@
 #include "RecoVertex/PrimaryVertexProducer/interface/TrackFilterForPVFinding.h"
 #include "RecoVertex/PrimaryVertexProducer/interface/TrackClusterizerInZ.h"
 #include "RecoVertex/PrimaryVertexProducer/interface/PrimaryVertexProducerAlgorithm.h"
-
 #include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
 
 // system include files

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
@@ -63,6 +63,7 @@
 #include "RecoVertex/PrimaryVertexProducer/interface/TrackFilterForPVFinding.h"
 #include "RecoVertex/PrimaryVertexProducer/interface/TrackClusterizerInZ.h"
 #include "RecoVertex/PrimaryVertexProducer/interface/PrimaryVertexProducerAlgorithm.h"
+
 #include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
 
 // system include files

--- a/RecoVertex/PrimaryVertexProducer/BuildFile.xml
+++ b/RecoVertex/PrimaryVertexProducer/BuildFile.xml
@@ -1,3 +1,4 @@
+<flags   CXXFLAGS="-Ofast -mrecip"/>
 <use   name="DataFormats/BeamSpot"/>
 <use   name="DataFormats/VertexReco"/>
 <use   name="FWCore/Framework"/>

--- a/RecoVertex/PrimaryVertexProducer/interface/DAClusterizerInZ_vect.h
+++ b/RecoVertex/PrimaryVertexProducer/interface/DAClusterizerInZ_vect.h
@@ -18,197 +18,192 @@
 #include "RecoVertex/VertexPrimitives/interface/TransientVertex.h"
 
 
-class DAClusterizerInZ_vect: public TrackClusterizerInZ {
+class DAClusterizerInZ_vect  final : public TrackClusterizerInZ {
 
 public:
-	// Internal data structure to 
-	struct track_t {
+  // Internal data structure to 
+  struct track_t {
+    
+    void AddItem( double new_z, double new_dz2, const reco::TransientTrack* new_tt, double new_pi   )
+    {
+      z.push_back( new_z );
+      dz2.push_back( new_dz2 );
+      tt.push_back( new_tt );
+      
+      pi.push_back( new_pi ); // track weight
+      Z_sum.push_back( 1.0); // Z[i]   for DA clustering, initial value as done in ::fill
+    }
 
-		void AddItem( double new_z, double new_dz2, const reco::TransientTrack* new_tt, double new_pi   )
-		{
-			z.push_back( new_z );
-			dz2.push_back( new_dz2 );
-			tt.push_back( new_tt );
-
-			pi.push_back( new_pi ); // track weight
-			Z_sum.push_back( 1.0); // Z[i]   for DA clustering, initial value as done in ::fill
-		}
-
-
-
-		unsigned int GetSize() const
-		{
-			return z.size();
-		}
-
-
-		// has to be called everytime the items are modified
-		void ExtractRaw()
-		{
-			_z = &z.front();
-			_dz2 = &dz2.front();
-			_Z_sum = &Z_sum.front();
-			_pi = &pi.front();
-		}
-
-		double * __restrict__ _z; // z-coordinate at point of closest approach to the beamline
-		double * __restrict__  _dz2; // square of the error of z(pca)
-
-		double * __restrict__  _Z_sum; // Z[i]   for DA clustering
-		double * __restrict__  _pi; // track weight
-
-		std::vector<double> z; // z-coordinate at point of closest approach to the beamline
-		std::vector<double> dz2; // square of the error of z(pca)
-		std::vector< const reco::TransientTrack* > tt; // a pointer to the Transient Track
-
-		std::vector<double> Z_sum; // Z[i]   for DA clustering
-		std::vector<double> pi; // track weight
-	};
-
-	struct vertex_t {
-		std::vector<double> z; //           z coordinate
-		std::vector<double> pk; //           vertex weight for "constrained" clustering
-
-		// --- temporary numbers, used during update
-		std::vector<double> ei_cache;
-		std::vector<double> ei;
-		std::vector<double> sw;
-		std::vector<double> swz;
-		std::vector<double> se;
-		std::vector<double> swE;
-
-
-		unsigned int GetSize() const
-		{
-			return z.size();
-		}
-
-		void AddItem( double new_z, double new_pk   )
-		{
-			z.push_back( new_z);
-			pk.push_back( new_pk);
-
-			ei_cache.push_back( 0.0 );
-			ei.push_back( 0.0 );
-			sw.push_back( 0.0 );
-			swz.push_back( 0.0);
-			se.push_back( 0.0);
-			swE.push_back( 0.0);
-
-			ExtractRaw();
-		}
-
-	        void InsertItem( unsigned int i, double new_z, double new_pk   )
-		{
-		        z.insert(z.begin() + i, new_z);
-			pk.insert(pk.begin() + i, new_pk);
-
-			ei_cache.insert(ei_cache.begin() + i, 0.0 );
-			ei.insert( ei.begin()  + i, 0.0 );
-			sw.insert( sw.begin()  + i, 0.0 );
-			swz.insert(swz.begin() + i, 0.0 );
-			se.insert( se.begin()  + i, 0.0 );
-			swE.insert(swE.begin() + i, 0.0 );
-
-			ExtractRaw();
-		}
-
-		void RemoveItem( unsigned int i )
-		{
-			z.erase( z.begin() + i );
-			pk.erase( pk.begin() + i );
-
-			ei_cache.erase( ei_cache.begin() + i);
-			ei.erase( ei.begin() + i);
-			sw.erase( sw.begin() + i);
-			swz.erase( swz.begin() + i);
-			se.erase(se.begin() + i);
-			swE.erase(swE.begin() + i);
-
-			ExtractRaw();
-		}
-
-		void DebugOut()
-		{
-			std::cout <<  "vertex_t size: " << GetSize() << std::endl;
-
-			for ( unsigned int i =0; i < GetSize(); ++ i)
-			{
-				std::cout << " z = " << _z[i] << " pk = " << _pk[i] << std::endl;
-			}
-		}
-
-		// has to be called everytime the items are modified
-		void ExtractRaw()
-		{
-			_z = &z.front();
-			_pk = &pk.front();
-
-			_ei = &ei.front();
-			_sw = &sw.front();
-			_swz = &swz.front();
-			_se = &se.front();
-			_swE = &swE.front();
-			_ei_cache = &ei_cache.front();
-
-		}
-
-		double * __restrict__ _z;
-		double * __restrict__ _pk;
-
-		double * __restrict__ _ei_cache;
-		double * __restrict__ _ei;
-		double * __restrict__ _sw;
-		double * __restrict__ _swz;
-		double * __restrict__ _se;
-		double * __restrict__ _swE;
-
-	};
-
-	DAClusterizerInZ_vect(const edm::ParameterSet& conf);
-
-
-	std::vector<std::vector<reco::TransientTrack> >
-	clusterize(const std::vector<reco::TransientTrack> & tracks) const;
-
-
-	std::vector<TransientVertex>
-	vertices(const std::vector<reco::TransientTrack> & tracks,
-			const int verbosity = 0) const ;
-
-	track_t	fill(const std::vector<reco::TransientTrack> & tracks) const;
-
-	double update(double beta, track_t & gtracks,
-			vertex_t & gvertices, bool useRho0, double & rho0) const;
-
-	void dump(const double beta, const vertex_t & y,
-			const track_t & tks, const int verbosity = 0) const;
-	bool merge(vertex_t &) const;
-	bool merge(vertex_t & y, double & beta)const;
-	bool purge(vertex_t &, track_t &, double &,
-			const double) const;
-
-	void splitAll( vertex_t & y) const;
-	bool split(const double beta,  track_t &t, vertex_t & y ) const;
-
-	double beta0(const double betamax, track_t & tks, vertex_t & y) const;
-
-	double Eik( double const& t_z, double const& k_z, double const& t_dz2) const;
-
-	inline double local_exp( double const& inp) const;
-	inline void local_exp_list( double* arg_inp, double* arg_out,const int arg_arr_size) const;
-
+    
+    
+    unsigned int GetSize() const
+    {
+      return z.size();
+    }
+    
+    
+    // has to be called everytime the items are modified
+    void ExtractRaw()
+    {
+      _z = &z.front();
+      _dz2 = &dz2.front();
+      _Z_sum = &Z_sum.front();
+      _pi = &pi.front();
+    }
+    
+    double * __restrict__ _z; // z-coordinate at point of closest approach to the beamline
+    double * __restrict__  _dz2; // square of the error of z(pca)
+    
+    double * __restrict__  _Z_sum; // Z[i]   for DA clustering
+    double * __restrict__  _pi; // track weight
+    
+    std::vector<double> z; // z-coordinate at point of closest approach to the beamline
+    std::vector<double> dz2; // square of the error of z(pca)
+    std::vector< const reco::TransientTrack* > tt; // a pointer to the Transient Track
+    
+    std::vector<double> Z_sum; // Z[i]   for DA clustering
+    std::vector<double> pi; // track weight
+  };
+  
+  struct vertex_t {
+    std::vector<double> z; //           z coordinate
+    std::vector<double> pk; //           vertex weight for "constrained" clustering
+    
+    // --- temporary numbers, used during update
+    std::vector<double> ei_cache;
+    std::vector<double> ei;
+    std::vector<double> sw;
+    std::vector<double> swz;
+    std::vector<double> se;
+    std::vector<double> swE;
+    
+    
+    unsigned int GetSize() const
+    {
+      return z.size();
+    }
+    
+    void AddItem( double new_z, double new_pk   )
+    {
+      z.push_back( new_z);
+      pk.push_back( new_pk);
+      
+      ei_cache.push_back( 0.0 );
+      ei.push_back( 0.0 );
+      sw.push_back( 0.0 );
+      swz.push_back( 0.0);
+      se.push_back( 0.0);
+      swE.push_back( 0.0);
+      
+      ExtractRaw();
+    }
+    
+    void InsertItem( unsigned int i, double new_z, double new_pk   )
+    {
+      z.insert(z.begin() + i, new_z);
+      pk.insert(pk.begin() + i, new_pk);
+      
+      ei_cache.insert(ei_cache.begin() + i, 0.0 );
+      ei.insert( ei.begin()  + i, 0.0 );
+      sw.insert( sw.begin()  + i, 0.0 );
+      swz.insert(swz.begin() + i, 0.0 );
+      se.insert( se.begin()  + i, 0.0 );
+      swE.insert(swE.begin() + i, 0.0 );
+      
+      ExtractRaw();
+    }
+    
+    void RemoveItem( unsigned int i )
+    {
+      z.erase( z.begin() + i );
+      pk.erase( pk.begin() + i );
+      
+      ei_cache.erase( ei_cache.begin() + i);
+      ei.erase( ei.begin() + i);
+      sw.erase( sw.begin() + i);
+      swz.erase( swz.begin() + i);
+      se.erase(se.begin() + i);
+      swE.erase(swE.begin() + i);
+      
+      ExtractRaw();
+    }
+    
+    void DebugOut()
+    {
+      std::cout <<  "vertex_t size: " << GetSize() << std::endl;
+      
+      for ( unsigned int i =0; i < GetSize(); ++ i)
+	{
+	  std::cout << " z = " << _z[i] << " pk = " << _pk[i] << std::endl;
+	}
+    }
+    
+    // has to be called everytime the items are modified
+    void ExtractRaw()
+    {
+      _z = &z.front();
+      _pk = &pk.front();
+      
+      _ei = &ei.front();
+      _sw = &sw.front();
+      _swz = &swz.front();
+      _se = &se.front();
+      _swE = &swE.front();
+      _ei_cache = &ei_cache.front();
+      
+    }
+    
+    double * __restrict__ _z;
+    double * __restrict__ _pk;
+    
+    double * __restrict__ _ei_cache;
+    double * __restrict__ _ei;
+    double * __restrict__ _sw;
+    double * __restrict__ _swz;
+    double * __restrict__ _se;
+    double * __restrict__ _swE;
+    
+  };
+  
+  DAClusterizerInZ_vect(const edm::ParameterSet& conf);
+  
+  
+  std::vector<std::vector<reco::TransientTrack> >
+  clusterize(const std::vector<reco::TransientTrack> & tracks) const;
+  
+  
+  std::vector<TransientVertex>
+  vertices(const std::vector<reco::TransientTrack> & tracks,
+	   const int verbosity = 0) const ;
+  
+  track_t	fill(const std::vector<reco::TransientTrack> & tracks) const;
+  
+  double update(double beta, track_t & gtracks,
+		vertex_t & gvertices, bool useRho0, double & rho0) const;
+  
+  void dump(const double beta, const vertex_t & y,
+	    const track_t & tks, const int verbosity = 0) const;
+  bool merge(vertex_t &) const;
+  bool merge(vertex_t & y, double & beta)const;
+  bool purge(vertex_t &, track_t &, double &,
+	     const double) const;
+  
+  void splitAll( vertex_t & y) const;
+  bool split(const double beta,  track_t &t, vertex_t & y ) const;
+  
+  double beta0(const double betamax, track_t const & tks, vertex_t const & y) const;
+    
+  
 private:
-	bool verbose_;
-	float vertexSize_;
-	int maxIterations_;
-	double coolingFactor_;
-	float betamax_;
-	float betastop_;
-	double dzCutOff_;
-	double d0CutOff_;
-	bool use_vdt_;
-	bool useTc_;
+  bool verbose_;
+  float vertexSize_;
+  int maxIterations_;
+  double coolingFactor_;
+  float betamax_;
+  float betastop_;
+  double dzCutOff_;
+  double d0CutOff_;
+  bool useTc_;
 };
 
 

--- a/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
@@ -14,246 +14,221 @@ using namespace std;
 
 DAClusterizerInZ_vect::DAClusterizerInZ_vect(const edm::ParameterSet& conf) {
 
-	// some defaults to avoid uninitialized variables
-	verbose_ = conf.getUntrackedParameter<bool> ("verbose", false);
-	use_vdt_ = conf.getUntrackedParameter<bool> ("use_vdt", false);
-
-	betamax_ = 0.1;
-	betastop_ = 1.0;
-	coolingFactor_ = 0.6;
-	maxIterations_ = 100;
-	vertexSize_ = 0.01; // 0.1 mm
-	dzCutOff_ = 4.0;  
-
+  // some defaults to avoid uninitialized variables
+  verbose_ = conf.getUntrackedParameter<bool> ("verbose", false);
+  
+  betamax_ = 0.1;
+  betastop_ = 1.0;
+  /*
+  coolingFactor_ = 0.6;
+  maxIterations_ = 100;
+  vertexSize_ = 0.01; // 0.1 mm
+  dzCutOff_ = 4.0;  
+  */
 	// configure
 
-	double Tmin = conf.getParameter<double> ("Tmin");
-	vertexSize_ = conf.getParameter<double> ("vertexSize");
-	coolingFactor_ = conf.getParameter<double> ("coolingFactor");
-	useTc_=true;
-	if(coolingFactor_<0){
-	  coolingFactor_=-coolingFactor_; 
-	  useTc_=false;
-	}
-	d0CutOff_ = conf.getParameter<double> ("d0CutOff");
-	dzCutOff_ = conf.getParameter<double> ("dzCutOff");
-	maxIterations_ = 100;
-	if (Tmin == 0) {
-		LogDebug("DAClusterizerinZ_vectorized")  << "DAClusterizerInZ: invalid Tmin" << Tmin
-				<< "  reset do default " << 1. / betamax_ << endl;
-	} else {
-		betamax_ = 1. / Tmin;
-	}
+  double Tmin = conf.getParameter<double> ("Tmin");
+  vertexSize_ = conf.getParameter<double> ("vertexSize");
+  coolingFactor_ = conf.getParameter<double> ("coolingFactor");
+  useTc_=true;
+  if(coolingFactor_<0){
+    coolingFactor_=-coolingFactor_; 
+    useTc_=false;
+  }
+  d0CutOff_ = conf.getParameter<double> ("d0CutOff");
+  dzCutOff_ = conf.getParameter<double> ("dzCutOff");
+  maxIterations_ = 100;
+  if (Tmin == 0) {
+    LogDebug("DAClusterizerinZ_vectorized")  << "DAClusterizerInZ: invalid Tmin" << Tmin
+					     << "  reset do default " << 1. / betamax_ << endl;
+  } else {
+    betamax_ = 1. / Tmin;
+  }
 
 }
 
-inline double DAClusterizerInZ_vect::local_exp( double const& inp) const
-		{
-			if ( use_vdt_)
-                          return vdt::fast_exp( inp );
+namespace {
+  inline double local_exp( double const& inp) {
+    return vdt::fast_exp( inp );
+  }
+  
+  inline void local_exp_list( double const * __restrict__ arg_inp, double * __restrict__ arg_out, const int arg_arr_size) {
+    for(int i=0; i!=arg_arr_size; ++i ) arg_out[i]=vdt::fast_exp(arg_inp[i]);
+  }
 
-			return std::exp( inp );
-		}
-
-inline void DAClusterizerInZ_vect::local_exp_list( double* arg_inp, double* arg_out,const int arg_arr_size) const
-		{
-			if ( use_vdt_){
-//                          std::cout << "I use vdt!\n";
-                            for(int i=0; i!=arg_arr_size; ++i ) arg_out[i]=vdt::fast_exp(arg_inp[i]);
-		           // vdt::fast_expv(arg_arr_size, arg_inp, arg_out);
-                        }
-                        else
-                          for(int i=0; i!=arg_arr_size; ++i ) arg_out[i]=std::exp(arg_inp[i]);
-		}
+}
 
 //todo: use r-value possibility of c++11 here
-DAClusterizerInZ_vect::track_t DAClusterizerInZ_vect::fill(const vector<
-		reco::TransientTrack> & tracks) const {
+DAClusterizerInZ_vect::track_t 
+DAClusterizerInZ_vect::fill(const vector<reco::TransientTrack> & tracks) const {
 
-	// prepare track data for clustering
-	track_t tks;
-	for (vector<reco::TransientTrack>::const_iterator it = tracks.begin(); it
-			!= tracks.end(); it++)
-	{
-		double t_pi;
-		double t_z = ((*it).stateAtBeamLine().trackStateAtPCA()).position().z();
-		double phi=((*it).stateAtBeamLine().trackStateAtPCA()).momentum().phi();
-		double tantheta = tan(
-				((*it).stateAtBeamLine().trackStateAtPCA()).momentum().theta());
-		//  get the beam-spot
-		reco::BeamSpot beamspot = (it->stateAtBeamLine()).beamSpot();
- 		double t_dz2 = 
-		      pow((*it).track().dzError(), 2) // track errror
- 		  + (pow(beamspot.BeamWidthX()*cos(phi),2)+pow(beamspot.BeamWidthY()*sin(phi),2))/pow(tantheta,2)  // beam-width
- 		  + pow(vertexSize_, 2); // intrinsic vertex size, safer for outliers and short lived decays
-		if (d0CutOff_ > 0) {
-			Measurement1D IP =
-					(*it).stateAtBeamLine().transverseImpactParameter();// error constains beamspot
-			t_pi = 1. / (1. + local_exp(pow(IP.value() / IP.error(), 2) - pow(
-					d0CutOff_, 2))); // reduce weight for high ip tracks
-		} else {
-			t_pi = 1.;
-		}
-
-		tks.AddItem(t_z, t_dz2, &(*it), t_pi);
-	}
-        tks.ExtractRaw();
-
-	if (verbose_) {
-		LogDebug("DAClusterizerinZ_vectorized") << "Track count " << tks.GetSize() << std::endl;
-	}
-
-	return tks;
+  // prepare track data for clustering
+  track_t tks;
+  for (auto it = tracks.begin(); it!= tracks.end(); it++){
+    double t_pi;
+    double t_z = ((*it).stateAtBeamLine().trackStateAtPCA()).position().z();
+    double phi=((*it).stateAtBeamLine().trackStateAtPCA()).momentum().phi();
+    double tantheta = std::tan( ((*it).stateAtBeamLine().trackStateAtPCA()).momentum().theta());
+    //  get the beam-spot
+    reco::BeamSpot beamspot = (it->stateAtBeamLine()).beamSpot();
+    double t_dz2 = 
+      std::pow((*it).track().dzError(), 2) // track errror
+      + (std::pow(beamspot.BeamWidthX()*cos(phi),2)+std::pow(beamspot.BeamWidthY()*sin(phi),2))/std::pow(tantheta,2)  // beam-width
+      + std::pow(vertexSize_, 2); // intrinsic vertex size, safer for outliers and short lived decays
+    if (d0CutOff_ > 0) {
+      Measurement1D IP =
+	(*it).stateAtBeamLine().transverseImpactParameter();// error constains beamspot
+      t_pi = 1. / (1. + local_exp(std::pow(IP.value() / IP.error(), 2) - std::pow(d0CutOff_, 2))); // reduce weight for high ip tracks
+    } else {
+      t_pi = 1.;
+    }    
+    tks.AddItem(t_z, t_dz2, &(*it), t_pi);
+  }
+  tks.ExtractRaw();
+  
+  if (verbose_) {
+    LogDebug("DAClusterizerinZ_vectorized") << "Track count " << tks.GetSize() << std::endl;
+  }
+  
+  return tks;
 }
 
 
-double DAClusterizerInZ_vect::Eik(double const& t_z, double const& k_z, double const& t_dz2) const
-{
-	return pow(t_z - k_z, 2) / t_dz2;
+namespace {
+  inline
+  double Eik(double t_z, double k_z, double t_dz2) {
+    return std::pow(t_z - k_z, 2) / t_dz2;
+  }
 }
-
 
 double DAClusterizerInZ_vect::update(double beta, track_t & gtracks,
-		vertex_t & gvertices, bool useRho0, double & rho0) const {
+				     vertex_t & gvertices, bool useRho0, double & rho0) const {
 
-	//update weights and vertex positions
-	// mass constrained annealing without noise
-	// returns the squared sum of changes of vertex positions
+  //update weights and vertex positions
+  // mass constrained annealing without noise
+  // returns the squared sum of changes of vertex positions
+  
+  const unsigned int nt = gtracks.GetSize();
+  const unsigned int nv = gvertices.GetSize();
+  
+  //initialize sums
+  double sumpi = 0;
+  
+  // to return how much the prototype moved
+  double delta = 0;
+  
 
-	const unsigned int nt = gtracks.GetSize();
-	const unsigned int nv = gvertices.GetSize();
+  // intial value of a sum
+  double Z_init = 0;
+  
+  // define kernels
+  auto kernel_calc_exp_arg = [ beta, nv ] ( const unsigned int itrack,
+					     track_t const& tracks,
+					     vertex_t const& vertices ) {
+    const double track_z = tracks._z[itrack];
+    const double botrack_dz2 = -beta/tracks._dz2[itrack];
 
-	//initialize sums
-	double sumpi = 0;
+    // auto-vectorized
+    for ( unsigned int ivertex = 0; ivertex < nv; ++ivertex) {
+      auto mult_res =  track_z - vertices._z[ivertex];
+      vertices._ei_cache[ivertex] = botrack_dz2 * ( mult_res * mult_res );
+    }
+  };
+  
+  auto kernel_add_Z = [ nv, Z_init ] (vertex_t const& vertices) -> double
+    {
+      double ZTemp = Z_init;
+      for (unsigned int ivertex = 0; ivertex < nv; ++ivertex) {	
+	ZTemp += vertices._pk[ivertex] * vertices._ei[ivertex];
+      }
+      return ZTemp;
+    };
 
-	// to return how much the prototype moved
-	double delta = 0;
-
-	unsigned int itrack;
-	unsigned int ivertex;
-
-	// intial value of a sum
-	double Z_init = 0;
-
-	// define kernels
-	auto kernel_calc_exp_arg = [ &beta, nv ] (
-			const unsigned int itrack,
-			track_t const& tracks,
-			vertex_t const& vertices )
-	{
-		const double track_z = tracks._z[itrack];
-		const double track_dz2 = tracks._dz2[itrack];
-
-		// auto-vectorized
-		for ( unsigned int ivertex = 0; ivertex < nv; ++ivertex)
-		{
-			double mult_res = ( track_z - vertices._z[ivertex] );
-			vertices._ei_cache[ivertex] = -beta *
-			( mult_res * mult_res ) / track_dz2;
-		}
-	};
-
-	// auto kernel_add_Z = [ nv, &Z_init ] (vertex_t const& vertices) raises a warning
-	// we declare the return type with " -> double"
-	auto kernel_add_Z = [ nv, &Z_init ] (vertex_t const& vertices) -> double
-	{
-		double ZTemp = Z_init;
- 
-		for (unsigned int ivertex = 0; ivertex < nv; ++ivertex) {
-
-			ZTemp += vertices._pk[ivertex] * vertices._ei[ivertex];
-		}
-		return ZTemp;
-	};
-
-	auto kernel_calc_normalization = [ &beta, nv ] (const unsigned int track_num,
-			track_t & tks_vec,
-			vertex_t & y_vec )
-	{
-		double w;
-
-		const double tmp_trk_pi = tks_vec._pi[track_num];
-		const double tmp_trk_Z_sum = tks_vec._Z_sum[track_num];
-		const double tmp_trk_dz2 = tks_vec._dz2[track_num];
-		const double tmp_trk_z = tks_vec._z[track_num];
-
-		// auto-vectorized
-		for (unsigned int k = 0; k < nv; ++k) {
-			y_vec._se[k] += tmp_trk_pi* y_vec._ei[k] / tmp_trk_Z_sum;
-			w = y_vec._pk[k] * tmp_trk_pi * y_vec._ei[k] / tmp_trk_Z_sum / tmp_trk_dz2;
-			y_vec._sw[k]  += w;
-			y_vec._swz[k] += w * tmp_trk_z;
-			y_vec._swE[k] += w * y_vec._ei_cache[k]/(-beta);
-		}
-	};
-
-	// not vectorized
-	for (ivertex = 0; ivertex < nv; ++ivertex) {
-		gvertices._se[ivertex] = 0.0;
-		gvertices._sw[ivertex] = 0.0;
-		gvertices._swz[ivertex] = 0.0;
-		gvertices._swE[ivertex] = 0.0;
+  auto kernel_calc_normalization = [ beta, nv ] (const unsigned int track_num,
+						  track_t & tks_vec,
+						  vertex_t & y_vec ) {
+    auto tmp_trk_pi = tks_vec._pi[track_num];
+    auto o_trk_Z_sum = 1./tks_vec._Z_sum[track_num];
+    auto o_trk_dz2 = 1./tks_vec._dz2[track_num];
+    auto tmp_trk_z = tks_vec._z[track_num];
+    auto obeta =  -1./beta;
+    
+    // auto-vectorized
+    for (unsigned int k = 0; k < nv; ++k) {
+      y_vec._se[k] +=  y_vec._ei[k] * (tmp_trk_pi* o_trk_Z_sum);
+      auto w = y_vec._pk[k] * y_vec._ei[k] * (tmp_trk_pi*o_trk_Z_sum *o_trk_dz2);
+      y_vec._sw[k]  += w;
+      y_vec._swz[k] += w * tmp_trk_z;
+      y_vec._swE[k] += w * y_vec._ei_cache[k]*obeta;
+    }
+  };
+  
+  
+  for (auto ivertex = 0U; ivertex < nv; ++ivertex) {
+    gvertices._se[ivertex] = 0.0;
+    gvertices._sw[ivertex] = 0.0;
+    gvertices._swz[ivertex] = 0.0;
+    gvertices._swE[ivertex] = 0.0;
+  }
+  
+  
+  // independpent of loop
+  if ( useRho0 )
+    {
+      Z_init = rho0 * local_exp(-beta * dzCutOff_ * dzCutOff_); // cut-off
+    }
+  
+  // loop over tracks
+  for (auto itrack = 0U; itrack < nt; ++itrack) {
+    kernel_calc_exp_arg(itrack, gtracks, gvertices);
+    local_exp_list(gvertices._ei_cache, gvertices._ei, nv);
+    
+    gtracks._Z_sum[itrack] = kernel_add_Z(gvertices);
+    
+    // used in the next major loop to follow
+    if (!useRho0)
+      sumpi += gtracks._pi[itrack];
+    
+    if (gtracks._Z_sum[itrack] > 0) {
+      kernel_calc_normalization(itrack, gtracks, gvertices);
+    }
+  }
+  
+  // now update z and pk
+  auto kernel_calc_z = [  sumpi, nv, this, useRho0 ] (vertex_t & vertices ) -> double {
+    
+    double delta=0;
+    // does not vectorizes
+    for (unsigned int ivertex = 0; ivertex < nv; ++ ivertex ) {
+      if (vertices._sw[ivertex] > 0) {
+	auto znew = vertices._swz[ ivertex ] / vertices._sw[ ivertex ];
+	// prevents from vectorizing if 
+	delta += std::pow( vertices._z[ ivertex ] - znew, 2 );
+	vertices._z[ ivertex ] = znew;
+      }
+#ifdef VI_DEBUG
+      else {
+	edm::LogInfo("sumw") << "invalid sum of weights in fit: " << vertices._sw[ivertex] << endl;
+	if (this->verbose_) {
+	  LogDebug("DAClusterizerinZ_vectorized")  << " a cluster melted away ?  pk=" << vertices._pk[ ivertex ] << " sumw="
+						   << vertices._sw[ivertex] << endl;
 	}
-
-
-	// independpent of loop
-	if ( useRho0 )
-	{
-		Z_init = rho0 * local_exp(-beta * dzCutOff_ * dzCutOff_); // cut-off
-	}
-
-	// loop over tracks
-	for (itrack = 0; itrack < nt; ++itrack) {
-		kernel_calc_exp_arg(itrack, gtracks, gvertices);
-		local_exp_list(gvertices._ei_cache, gvertices._ei, nv);
-		//vdt::cephes_single_exp_vect( y_vec._ei, nv );
-
-		gtracks._Z_sum[itrack] = kernel_add_Z(gvertices);
-
-		// used in the next major loop to follow
-		if (!useRho0)
-			sumpi += gtracks._pi[itrack];
-
-		if (gtracks._Z_sum[itrack] > 0) {
-			kernel_calc_normalization(itrack, gtracks, gvertices);
-		}
-	}
-
-	// now update z and pk
-	auto kernel_calc_z = [ &delta, &sumpi, nv, this, useRho0 ] (vertex_t & vertices )
-	{
-		// does not vectorizes
-		for (unsigned int ivertex = 0; ivertex < nv; ++ ivertex )
-		{
-			if (vertices._sw[ivertex] > 0)
-			{
-				double znew = vertices._swz[ ivertex ] / vertices._sw[ ivertex ];
-
-				// prevents from vectorizing
-				delta += pow( vertices._z[ ivertex ] - znew, 2 );
-				vertices._z[ ivertex ] = znew;
-			}
-			else {
-				edm::LogInfo("sumw") << "invalid sum of weights in fit: " << vertices._sw[ivertex]
-				<< endl;
-				if (this->verbose_) {
-					LogDebug("DAClusterizerinZ_vectorized")  << " a cluster melted away ?  pk=" << vertices._pk[ ivertex ] << " sumw="
-					<< vertices._sw[ivertex] << endl;
-				}
-			}
-
-			// dont do, if rho cut
-			if ( ! useRho0 )
-			{
-				vertices._pk[ ivertex ] = vertices._pk[ ivertex ] * vertices._se[ ivertex ] / sumpi;
-			}
-		}
-	};
-
-	kernel_calc_z(gvertices);
-
-	// return how much the prototypes moved
-	return delta;
+      }
+#endif
+    }
+    // dont do, if rho cut
+    if ( ! useRho0 ){
+      auto osumpi = 1./sumpi;
+      for (unsigned int ivertex = 0; ivertex < nv; ++ ivertex )
+	vertices._pk[ ivertex ] = vertices._pk[ ivertex ] * vertices._se[ ivertex ] * osumpi;
+    }
+    return delta;
+  };
+  
+  delta += kernel_calc_z(gvertices);
+  
+  // return how much the prototypes moved
+  return delta;
 }
 
 
@@ -271,7 +246,7 @@ bool DAClusterizerInZ_vect::merge(vertex_t & y, double & beta)const{
   for (unsigned int k = 0; (k + 1) < nv; k++) {
     if (fabs(y._z[k + 1] - y._z[k]) < 2.e-2) {
       double rho=y._pk[k] + y._pk[k+1];
-      double swE=y._swE[k]+y._swE[k+1] - y._pk[k]*y._pk[k+1] /rho *pow(y._z[k+1]-y._z[k],2);
+      double swE=y._swE[k]+y._swE[k+1] - y._pk[k]*y._pk[k+1] /rho *std::pow(y._z[k+1]-y._z[k],2);
       double Tc=2*swE/(y._sw[k]+y._sw[k+1]);
 
       if(Tc*beta<1){
@@ -297,136 +272,133 @@ bool DAClusterizerInZ_vect::merge(vertex_t & y, double & beta)const{
 
 
 bool DAClusterizerInZ_vect::merge(vertex_t & y) const {
-	// merge clusters that collapsed or never separated, return true if vertices were merged, false otherwise
+  // merge clusters that collapsed or never separated, return true if vertices were merged, false otherwise
+  
+  const unsigned int nv = y.GetSize();
+  
+  if (nv < 2) return false;
 
-	const unsigned int nv = y.GetSize();
+  for (unsigned int k = 0; (k + 1) < nv; k++) {
+    //if ((k+1)->z - k->z<1.e-2){  // note, no fabs here, maintains z-ordering  (with split()+merge() at every temperature)
+    if (std::abs(y._z[k + 1] - y._z[k]) < 1.e-2) { // with fabs if only called after freeze-out (splitAll() at highter T)
+      y._pk[k] += y._pk[k + 1];
+      y._z[k] = 0.5 * (y._z[k] + y._z[k + 1]);
+      
+      y.RemoveItem(k + 1);
+      
+      if ( verbose_)
+	{
+	  LogDebug("DAClusterizerinZ_vectorized") << "Merging vertices k = " << k << std::endl;
+	}
+      
+      return true;
+    }
+  }
+  
+  return false;
+}
 
-	if (nv < 2)
-		return false;
+bool 
+DAClusterizerInZ_vect::purge(vertex_t & y, track_t & tks, double & rho0, const double beta) const {
+  // eliminate clusters with only one significant/unique track
+  const unsigned int nv = y.GetSize();
+  const unsigned int nt = tks.GetSize();
 
-	for (unsigned int k = 0; (k + 1) < nv; k++) {
-		//if ((k+1)->z - k->z<1.e-2){  // note, no fabs here, maintains z-ordering  (with split()+merge() at every temperature)
-		if (fabs(y._z[k + 1] - y._z[k]) < 1.e-2) { // with fabs if only called after freeze-out (splitAll() at highter T)
-			y._pk[k] += y._pk[k + 1];
-			y._z[k] = 0.5 * (y._z[k] + y._z[k + 1]);
-
-			y.RemoveItem(k + 1);
-
-			if ( verbose_)
-			{
-				LogDebug("DAClusterizerinZ_vectorized") << "Merging vertices k = " << k << std::endl;
+  if (nv < 2)
+    return false;
+  
+  double sumpmin = nt;
+  unsigned int k0 = nv;
+  
+  for (unsigned int k = 0; k < nv; k++) {
+    
+    int nUnique = 0;
+    double sump = 0;
+    double pmax = y._pk[k] / (y._pk[k] + rho0 * local_exp(-beta * dzCutOff_* dzCutOff_));
+    
+    for (unsigned int i = 0; i < nt; i++) {
+      
+      if (tks._Z_sum[i] > 0) {
+	//double p=pik(beta,tks[i],*k);
+	double p = y._pk[k] * local_exp(-beta * Eik(tks._z[i], y._z[k], tks._dz2[i])) / tks._Z_sum[i];
+	sump += p;
+	if ((p > 0.9 * pmax) && (tks._pi[i] > 0)) {
+	  nUnique++;
+	}
 			}
-
-			return true;
-		}
-	}
-
-	return false;
+    }
+    
+    if ((nUnique < 2) && (sump < sumpmin)) {
+      sumpmin = sump;
+      k0 = k;
+    }
+  }
+  
+  if (k0 != nv) {
+    if (verbose_) {
+      LogDebug("DAClusterizerinZ_vectorized")  << "eliminating prototype at " << y._z[k0] << " with sump="
+					       << sumpmin << endl;
+    }
+    //rho0+=k0->pk;
+    y.RemoveItem(k0);
+    return true;
+  } else {
+    return false;
+  }
 }
 
-bool DAClusterizerInZ_vect::purge(vertex_t & y, track_t & tks, double & rho0,
-		const double beta) const {
-	// eliminate clusters with only one significant/unique track
-	const unsigned int nv = y.GetSize();
-	const unsigned int nt = tks.GetSize();
-
-	if (nv < 2)
-		return false;
-
-	double sumpmin = nt;
-	unsigned int k0 = nv;
-
-	for (unsigned int k = 0; k < nv; k++) {
-
-		int nUnique = 0;
-		double sump = 0;
-		double pmax = y._pk[k] / (y._pk[k] + rho0 * local_exp(-beta * dzCutOff_
-				* dzCutOff_));
-
-		for (unsigned int i = 0; i < nt; i++) {
-
-			if (tks._Z_sum[i] > 0) {
-				//double p=pik(beta,tks[i],*k);
-				double p = y._pk[k] * local_exp(-beta * Eik(tks._z[i], y._z[k],
-						tks._dz2[i])) / tks._Z_sum[i];
-				sump += p;
-				if ((p > 0.9 * pmax) && (tks._pi[i] > 0)) {
-					nUnique++;
-				}
-			}
-		}
-
-		if ((nUnique < 2) && (sump < sumpmin)) {
-			sumpmin = sump;
-			k0 = k;
-		}
-	}
-
-	if (k0 != nv) {
-		if (verbose_) {
-			LogDebug("DAClusterizerinZ_vectorized")  << "eliminating prototype at " << y._z[k0] << " with sump="
-					<< sumpmin << endl;
-		}
-		//rho0+=k0->pk;
-		y.RemoveItem(k0);
-		return true;
-	} else {
-		return false;
-	}
-}
-
-double DAClusterizerInZ_vect::beta0(double betamax, track_t & tks, vertex_t & y) const {
-
-	double T0 = 0; // max Tc for beta=0
-	// estimate critical temperature from beta=0 (T=inf)
-	const unsigned int nt = tks.GetSize();
-	const unsigned int nv = y.GetSize();
-
-	for (unsigned int k = 0; k < nv; k++) {
-
-		// vertex fit at T=inf
-		double sumwz = 0;
-		double sumw = 0;
-		for (unsigned int i = 0; i < nt; i++) {
-			double w = tks._pi[i] / tks._dz2[i];
-			sumwz += w * tks._z[i];
-			sumw += w;
-		}
-		y._z[k] = sumwz / sumw;
-
-		// estimate Tcrit, eventually do this in the same loop
-		double a = 0, b = 0;
-		for (unsigned int i = 0; i < nt; i++) {
-			double dx = tks._z[i] - (y._z[k]);
-			double w = tks._pi[i] / tks._dz2[i];
-			a += w * pow(dx, 2) / tks._dz2[i];
-			b += w;
-		}
-		double Tc = 2. * a / b; // the critical temperature of this vertex
-		if (Tc > T0)
-			T0 = Tc;
-	}// vertex loop (normally there should be only one vertex at beta=0)
-
-	if (T0 > 1. / betamax) {
-		return betamax / pow(coolingFactor_, int(log(T0 * betamax) / log(
-				coolingFactor_)) - 1);
-	} else {
-		// ensure at least one annealing step
-		return betamax / coolingFactor_;
-	}
+double 
+DAClusterizerInZ_vect::beta0(double betamax, track_t const  & tks, vertex_t const & y) const {
+  
+  double T0 = 0; // max Tc for beta=0
+  // estimate critical temperature from beta=0 (T=inf)
+  const unsigned int nt = tks.GetSize();
+  const unsigned int nv = y.GetSize();
+  
+  for (unsigned int k = 0; k < nv; k++) {
+    
+    // vertex fit at T=inf
+    double sumwz = 0;
+    double sumw = 0;
+    for (unsigned int i = 0; i < nt; i++) {
+      double w = tks._pi[i] / tks._dz2[i];
+      sumwz += w * tks._z[i];
+      sumw += w;
+    }
+    y._z[k] = sumwz / sumw;
+    
+    // estimate Tcrit, eventually do this in the same loop
+    double a = 0, b = 0;
+    for (unsigned int i = 0; i < nt; i++) {
+      double dx = tks._z[i] - y._z[k];
+      double w = tks._pi[i] / tks._dz2[i];
+      a += w * std::pow(dx, 2) / tks._dz2[i];
+      b += w;
+    }
+    double Tc = 2. * a / b; // the critical temperature of this vertex
+    if (Tc > T0) T0 = Tc;
+  }// vertex loop (normally there should be only one vertex at beta=0)
+  
+  if (T0 > 1. / betamax) {
+    return betamax / std::pow(coolingFactor_, int(std::log(T0 * betamax) / std::log(coolingFactor_)) - 1);
+  } else {
+    // ensure at least one annealing step
+    return betamax / coolingFactor_;
+  }
 }
 
 
-bool DAClusterizerInZ_vect::split(const double beta,  track_t &tks, vertex_t & y ) const{
+bool 
+DAClusterizerInZ_vect::split(const double beta,  track_t &tks, vertex_t & y ) const{
   // split only critical vertices (Tc >~ T=1/beta   <==>   beta*Tc>~1)
   // an update must have been made just before doing this (same beta, no merging)
   // returns true if at least one cluster was split
-
+  
   double epsilon=1e-3;      // split all single vertices by 10 um
   unsigned int nv = y.GetSize();
-
+  
   // avoid left-right biases by splitting highest Tc first
-
+  
   std::vector<std::pair<double, unsigned int> > critical;
   for(unsigned int k=0; k<nv; k++){
     double Tc= 2*y._swE[k]/y._sw[k];
@@ -435,9 +407,9 @@ bool DAClusterizerInZ_vect::split(const double beta,  track_t &tks, vertex_t & y
     }
   }
   if (critical.size()==0) return false;
-  stable_sort(critical.begin(), critical.end(), std::greater<std::pair<double, unsigned int> >() );
-
-
+  std::stable_sort(critical.begin(), critical.end(), std::greater<std::pair<double, unsigned int> >() );
+  
+  
   bool split=false;
   const unsigned int nt = tks.GetSize();
 
@@ -448,9 +420,7 @@ bool DAClusterizerInZ_vect::split(const double beta,  track_t &tks, vertex_t & y
     double p2=0, z2=0, w2=0;
     for(unsigned int i=0; i<nt; i++){
       if (tks._Z_sum[i] > 0) {
-	double p = y._pk[k] * local_exp(-beta * Eik(tks._z[i], y._z[k],
-						    tks._dz2[i])) / tks._Z_sum[i];
-
+	double p = y._pk[k] * local_exp(-beta * Eik(tks._z[i], y._z[k], tks._dz2[i])) / tks._Z_sum[i];
         double w=p/tks._dz2[i];
         if(tks._z[i]<y._z[k]){
           p1+=p; z1+=w*tks._z[i]; w1+=w;
@@ -489,58 +459,238 @@ bool DAClusterizerInZ_vect::split(const double beta,  track_t &tks, vertex_t & y
 
 void DAClusterizerInZ_vect::splitAll( vertex_t & y) const {
 
-	const unsigned int nv = y.GetSize();
+  const unsigned int nv = y.GetSize();
+  
+  double epsilon = 1e-3; // split all single vertices by 10 um
+  double zsep = 2 * epsilon; // split vertices that are isolated by at least zsep (vertices that haven't collapsed)
+  vertex_t y1;
+  
+  if (verbose_) {
+    LogDebug("DAClusterizerinZ_vectorized") << "Before Split "<< std::endl;
+    y.DebugOut();
+  }
 
-	double epsilon = 1e-3; // split all single vertices by 10 um
-	double zsep = 2 * epsilon; // split vertices that are isolated by at least zsep (vertices that haven't collapsed)
-	vertex_t y1;
+  for (unsigned int k = 0; k < nv; k++) {
+    if (
+	( (k == 0)       	|| ( y._z[k - 1]	< (y._z[k] - zsep)) ) &&
+	( ((k + 1) == nv)	|| ( y._z[k + 1] 	> (y._z[k] + zsep)) )   )
+      {
+	// isolated prototype, split
+	double new_z = y.z[k] - epsilon;
+	y.z[k] = y.z[k] + epsilon;
+	
+	double new_pk = 0.5 * y.pk[k];
+	y.pk[k] = 0.5 * y.pk[k];
+	
+	y1.AddItem(new_z, new_pk);
+	y1.AddItem(y._z[k], y._pk[k]);	
+      }
+    else if ( (y1.GetSize() == 0 ) ||
+	      (y1._z[y1.GetSize() - 1] <  (y._z[k] - zsep)  ))
+      {
+	y1.AddItem(y._z[k], y._pk[k]);
+      }
+    else
+      {
+	y1._z[y1.GetSize() - 1] = y1._z[y1.GetSize() - 1] - epsilon;
+	y._z[k] = y._z[k] + epsilon;
+	y1.AddItem( y._z[k] , y._pk[k]);
+      }
+  }// vertex loop
 
-	if (verbose_)
-	{
-		LogDebug("DAClusterizerinZ_vectorized") << "Before Split "<< std::endl;
-		y.DebugOut();
-	}
-
-	for (unsigned int k = 0; k < nv; k++) {
-
-		if (
-				( (k == 0)       	|| ( y._z[k - 1]	< (y._z[k] - zsep)) ) &&
-		        ( ((k + 1) == nv)	|| ( y._z[k + 1] 	> (y._z[k] + zsep)) )   )
-		{
-			// isolated prototype, split
-			double new_z = y.z[k] - epsilon;
-			y.z[k] = y.z[k] + epsilon;
-
-			double new_pk = 0.5 * y.pk[k];
-			y.pk[k] = 0.5 * y.pk[k];
-
-			y1.AddItem(new_z, new_pk);
-			y1.AddItem(y._z[k], y._pk[k]);
-
-		}
-		else if ( (y1.GetSize() == 0 ) ||
-				(y1._z[y1.GetSize() - 1] <  (y._z[k] - zsep)  ))
-		{
-
-			y1.AddItem(y._z[k], y._pk[k]);
-		}
-		else
-		{
-			y1._z[y1.GetSize() - 1] = y1._z[y1.GetSize() - 1] - epsilon;
-			y._z[k] = y._z[k] + epsilon;
-			y1.AddItem( y._z[k] , y._pk[k]);
-		}
-	}// vertex loop
-
-	y = y1;
-	y.ExtractRaw();
-
-	if (verbose_)
-	{
-		LogDebug("DAClusterizerinZ_vectorized") << "After split " << std::endl;
-		y.DebugOut();
-	}
+  y = y1;
+  y.ExtractRaw();
+  
+  if (verbose_) {
+    LogDebug("DAClusterizerinZ_vectorized") << "After split " << std::endl;
+    y.DebugOut();
+  }
 }
+
+
+
+vector<TransientVertex> 
+DAClusterizerInZ_vect::vertices(const vector<reco::TransientTrack> & tracks, const int verbosity) const {
+  track_t tks = fill(tracks);
+  tks.ExtractRaw();
+  
+  unsigned int nt = tracks.size();
+  double rho0 = 0.0; // start with no outlier rejection
+  
+  vector<TransientVertex> clusters;
+  if (tks.GetSize() == 0) return clusters;
+  
+  vertex_t y; // the vertex prototypes
+  
+  // initialize:single vertex at infinite temperature
+  y.AddItem( 0, 1.0);
+  
+  int niter = 0; // number of iterations
+  
+  
+  // estimate first critical temperature
+  double beta = beta0(betamax_, tks, y);
+  if ( verbose_) LogDebug("DAClusterizerinZ_vectorized") << "Beta0 is " << beta << std::endl;
+  
+  niter = 0;
+  while ((update(beta, tks, y, false, rho0) > 1.e-6) && 
+	 (niter++ < maxIterations_)) {}
+
+  // annealing loop, stop when T<Tmin  (i.e. beta>1/Tmin)
+  while (beta < betamax_) {
+    if(useTc_){
+      update(beta, tks,y, false, rho0);
+      while(merge(y,beta)){update(beta, tks,y, false, rho0);}
+      split(beta, tks,y);
+      beta=beta/coolingFactor_;
+    }else{
+      beta=beta/coolingFactor_;
+      splitAll(y);
+    }
+    
+    // make sure we are not too far from equilibrium before cooling further
+    niter = 0;
+    while ((update(beta, tks, y, false, rho0) > 1.e-6) && 
+	   (niter++ < maxIterations_)) {}
+  }
+  
+
+  if(useTc_){
+    // last round of splitting, make sure no critical clusters are left
+    update(beta, tks,y, false, rho0);// make sure Tc is up-to-date
+    while(merge(y,beta)){update(beta, tks,y, false, rho0);}
+    unsigned int ntry=0;
+    while( split(beta, tks,y) && (ntry++<10) ){
+      niter=0; 
+      while((update(beta, tks,y, false, rho0)>1.e-6)  && (niter++ < maxIterations_)){}
+      merge(y,beta);
+      update(beta, tks,y, false, rho0);
+    }
+  }else{
+    // merge collapsed clusters 
+    while(merge(y,beta)){update(beta, tks,y, false, rho0);}  
+    //while(merge(y)){}   original code
+  }
+  
+  if (verbose_) {
+    LogDebug("DAClusterizerinZ_vectorized")  << "dump after 1st merging " << endl;
+    dump(beta, y, tks, 2);
+  }
+  
+  // switch on outlier rejection
+  rho0 = 1. / nt;
+  
+  // auto-vectorized
+  for (unsigned int k = 0; k < y.GetSize(); k++) y._pk[k] = 1.; // democratic
+  niter = 0;
+  while ((update(beta, tks, y, true, rho0) > 1.e-8) && (niter++ < maxIterations_)) {}
+  if (verbose_) {
+    LogDebug("DAClusterizerinZ_vectorized")  << "rho0=" << rho0 << " niter=" << niter << endl;
+    dump(beta, y, tks, 2);
+  }
+  
+  // merge again  (some cluster split by outliers collapse here)
+  while (merge(y)) {}
+  if (verbose_) {
+    LogDebug("DAClusterizerinZ_vectorized")  << "dump after 2nd merging " << endl;
+    dump(beta, y, tks, 2);
+  }
+
+  // continue from freeze-out to Tstop (=1) without splitting, eliminate insignificant vertices
+  while (beta <= betastop_) {
+    while (purge(y, tks, rho0, beta)) {
+      niter = 0;
+      while ((update(beta, tks, y, true, rho0) > 1.e-6) && (niter++ < maxIterations_)) {}
+    }
+    beta /= coolingFactor_;
+    niter = 0;
+    while ((update(beta, tks, y, true, rho0) > 1.e-6) && (niter++< maxIterations_)) {}
+  }
+
+  if (verbose_) {
+    LogDebug("DAClusterizerinZ_vectorized")  << "Final result, rho0=" << rho0 << endl;
+    dump(beta, y, tks, 2);
+  }
+
+  // select significant tracks and use a TransientVertex as a container
+  GlobalError dummyError;
+  
+  // ensure correct normalization of probabilities, should makes double assginment reasonably impossible
+  const unsigned int nv = y.GetSize();
+  
+  for (unsigned int i = 0; i < nt; i++) {
+    tks._Z_sum[i] = rho0 * local_exp(-beta * dzCutOff_ * dzCutOff_);
+    for (unsigned int k = 0; k < nv; k++) {
+      tks._Z_sum[i] += y._pk[k] * local_exp(-beta * Eik(tks._z[i], y._z[k],tks._dz2[i]));
+    }
+  }
+
+  for (unsigned int k = 0; k < nv; k++) {
+    GlobalPoint pos(0, 0, y._z[k]);
+    
+    vector<reco::TransientTrack> vertexTracks;
+    for (unsigned int i = 0; i < nt; i++) {
+      if (tks._Z_sum[i] > 0) {
+	
+	double p = y._pk[k] * local_exp(-beta * Eik(tks._z[i], y._z[k],
+						    tks._dz2[i])) / tks._Z_sum[i];
+	if ((tks._pi[i] > 0) && (p > 0.5)) {
+	  
+	  vertexTracks.push_back(*(tks.tt[i]));
+	  tks._Z_sum[i] = 0;
+	} // setting Z=0 excludes double assignment
+      }
+    }
+    TransientVertex v(pos, dummyError, vertexTracks, 0);
+    clusters.push_back(v);
+  }
+
+  return clusters;
+
+}
+
+vector<vector<reco::TransientTrack> > DAClusterizerInZ_vect::clusterize(
+		const vector<reco::TransientTrack> & tracks) const {
+  
+  if (verbose_) {
+    std::cout  << "###################################################" << endl;
+    std::cout  << "# vectorized DAClusterizerInZ_vect::clusterize   nt=" << tracks.size() << endl;
+    std::cout  << "###################################################" << endl;
+  }
+  
+  vector<vector<reco::TransientTrack> > clusters;
+  vector<TransientVertex> && pv = vertices(tracks);
+  
+  if (verbose_) {
+    LogDebug("DAClusterizerinZ_vectorized")  << "# DAClusterizerInZ::clusterize   pv.size=" << pv.size()
+					     << endl;
+  }
+  if (pv.size() == 0) {
+    return clusters;
+  }
+  
+  // fill into clusters and merge
+  vector<reco::TransientTrack> aCluster = pv.begin()->originalTracks();
+  
+  for (auto k = pv.begin() + 1; k != pv.end(); k++) {
+    if ( std::abs(k->position().z() - (k - 1)->position().z()) > (2 * vertexSize_)) {
+      // close a cluster
+      clusters.push_back(aCluster);
+      aCluster.clear();
+    }
+    for (unsigned int i = 0; i < k->originalTracks().size(); i++) {
+      aCluster.push_back(k->originalTracks()[i]);
+    }
+    
+  }
+  clusters.emplace_back(std::move(aCluster));
+  
+  return clusters;
+
+}
+
+
+
 
 
 void DAClusterizerInZ_vect::dump(const double beta, const vertex_t & y,
@@ -576,7 +726,7 @@ void DAClusterizerInZ_vect::dump(const double beta, const vertex_t & y,
 		LogDebug("DAClusterizerinZ_vectorized")  << setprecision(4);
 		for (unsigned int i = 0; i < nt; i++) {
 			if (tks._Z_sum[i] > 0) {
-				F -= log(tks._Z_sum[i]) / beta;
+				F -= std::log(tks._Z_sum[i]) / beta;
 			}
 			double tz = tks._z[i];
 			LogDebug("DAClusterizerinZ_vectorized")  << setw(3) << i << ")" << setw(8) << fixed << setprecision(4)
@@ -635,207 +785,3 @@ void DAClusterizerInZ_vect::dump(const double beta, const vertex_t & y,
 			 << "  F= " << F << endl << "----------" << endl;
 	}
 }
-
-vector<TransientVertex> DAClusterizerInZ_vect::vertices(const vector<
-		reco::TransientTrack> & tracks, const int verbosity) const {
-
-
-	track_t tks = fill(tracks);
-	tks.ExtractRaw();
-
-	unsigned int nt = tracks.size();
-	double rho0 = 0.0; // start with no outlier rejection
-
-	vector<TransientVertex> clusters;
-	if (tks.GetSize() == 0)
-		return clusters;
-
-	vertex_t y; // the vertex prototypes
-
-	// initialize:single vertex at infinite temperature
-	y.AddItem( 0, 1.0);
-
-	int niter = 0; // number of iterations
-
-
-	// estimate first critical temperature
-	double beta = beta0(betamax_, tks, y);
-	if ( verbose_)
-	{
-		LogDebug("DAClusterizerinZ_vectorized") << "Beta0 is " << beta << std::endl;
-	}
-
-	niter = 0;
-	while ((update(beta, tks, y, false, rho0) > 1.e-6) && (niter++
-			< maxIterations_)) {
-	}
-
-	// annealing loop, stop when T<Tmin  (i.e. beta>1/Tmin)
-	while (beta < betamax_) {
-
-
-		if(useTc_){
-		  update(beta, tks,y, false, rho0);
-		  while(merge(y,beta)){update(beta, tks,y, false, rho0);}
-		  split(beta, tks,y);
-		  beta=beta/coolingFactor_;
-		}else{
-		  beta=beta/coolingFactor_;
-		  splitAll(y);
-		}
-
-		// make sure we are not too far from equilibrium before cooling further
-		niter = 0;
-		while ((update(beta, tks, y, false, rho0) > 1.e-6) && (niter++
-				< maxIterations_)) {
-		}
-
-	}
-
-
-	if(useTc_){
-	  // last round of splitting, make sure no critical clusters are left
-	  update(beta, tks,y, false, rho0);// make sure Tc is up-to-date
-	  while(merge(y,beta)){update(beta, tks,y, false, rho0);}
-	  unsigned int ntry=0;
-	  while( split(beta, tks,y) && (ntry++<10) ){
-	    niter=0; 
-	    while((update(beta, tks,y, false, rho0)>1.e-6)  && (niter++ < maxIterations_)){}
-	    merge(y,beta);
-	    update(beta, tks,y, false, rho0);
-	  }
-	}else{
-	  // merge collapsed clusters 
-	  while(merge(y,beta)){update(beta, tks,y, false, rho0);}  
-	  //while(merge(y)){}   original code
-	}
- 
-	if (verbose_) {
-		LogDebug("DAClusterizerinZ_vectorized")  << "dump after 1st merging " << endl;
-		dump(beta, y, tks, 2);
-	}
-
-	// switch on outlier rejection
-	rho0 = 1. / nt;
-	
-	// auto-vectorized
-	for (unsigned int k = 0; k < y.GetSize(); k++) {
-		y._pk[k] = 1.;
-	} // democratic
-	niter = 0;
-	while ((update(beta, tks, y, true, rho0) > 1.e-8) && (niter++
-			< maxIterations_)) {
-	}
-	if (verbose_) {
-		LogDebug("DAClusterizerinZ_vectorized")  << "rho0=" << rho0 << " niter=" << niter << endl;
-		dump(beta, y, tks, 2);
-	}
-
-	// merge again  (some cluster split by outliers collapse here)
-	while (merge(y)) {
-	}
-	if (verbose_) {
-		LogDebug("DAClusterizerinZ_vectorized")  << "dump after 2nd merging " << endl;
-		dump(beta, y, tks, 2);
-	}
-
-	// continue from freeze-out to Tstop (=1) without splitting, eliminate insignificant vertices
-	while (beta <= betastop_) {
-		while (purge(y, tks, rho0, beta)) {
-			niter = 0;
-			while ((update(beta, tks, y, true, rho0) > 1.e-6) && (niter++
-					< maxIterations_)) {
-			}
-		}
-		beta /= coolingFactor_;
-		niter = 0;
-		while ((update(beta, tks, y, true, rho0) > 1.e-6) && (niter++
-				< maxIterations_)) {
-		}
-	}
-
-	if (verbose_) {
-		LogDebug("DAClusterizerinZ_vectorized")  << "Final result, rho0=" << rho0 << endl;
-		dump(beta, y, tks, 2);
-	}
-
-	// select significant tracks and use a TransientVertex as a container
-	GlobalError dummyError;
-
-	// ensure correct normalization of probabilities, should makes double assginment reasonably impossible
-	const unsigned int nv = y.GetSize();
-
-	for (unsigned int i = 0; i < nt; i++) {
-		tks._Z_sum[i] = rho0 * local_exp(-beta * dzCutOff_ * dzCutOff_);
-
-		for (unsigned int k = 0; k < nv; k++) {
-			tks._Z_sum[i] += y._pk[k] * local_exp(-beta * Eik(tks._z[i], y._z[k],
-					tks._dz2[i]));
-		}
-	}
-
-	for (unsigned int k = 0; k < nv; k++) {
-
-		GlobalPoint pos(0, 0, y._z[k]);
-
-		vector<reco::TransientTrack> vertexTracks;
-		for (unsigned int i = 0; i < nt; i++) {
-			if (tks._Z_sum[i] > 0) {
-
-				double p = y._pk[k] * local_exp(-beta * Eik(tks._z[i], y._z[k],
-						tks._dz2[i])) / tks._Z_sum[i];
-				if ((tks._pi[i] > 0) && (p > 0.5)) {
-
-					vertexTracks.push_back(*(tks.tt[i]));
-					tks._Z_sum[i] = 0;
-				} // setting Z=0 excludes double assignment
-			}
-		}
-		TransientVertex v(pos, dummyError, vertexTracks, 0);
-		clusters.push_back(v);
-	}
-
-	return clusters;
-
-}
-
-vector<vector<reco::TransientTrack> > DAClusterizerInZ_vect::clusterize(
-		const vector<reco::TransientTrack> & tracks) const {
-                  
-	if (verbose_) {
-		std::cout  << "###################################################" << endl;
-		std::cout  << "# vectorized DAClusterizerInZ_vect::clusterize   nt=" << tracks.size() << endl;
-		std::cout  << "###################################################" << endl;
-	}
-
-	vector<vector<reco::TransientTrack> > clusters;
-	vector<TransientVertex> pv = vertices(tracks);
-
-	if (verbose_) {
-		LogDebug("DAClusterizerinZ_vectorized")  << "# DAClusterizerInZ::clusterize   pv.size=" << pv.size()
-				<< endl;
-	}
-	if (pv.size() == 0) {
-		return clusters;
-	}
-
-	// fill into clusters and merge
-	vector<reco::TransientTrack> aCluster = pv.begin()->originalTracks();
-
-	for (vector<TransientVertex>::iterator k = pv.begin() + 1; k != pv.end(); k++) {
-	        if ( fabs(k->position().z() - (k - 1)->position().z()) > (2 * vertexSize_)) {
-			// close a cluster
-			clusters.push_back(aCluster);
-			aCluster.clear();
-		}
-		for (unsigned int i = 0; i < k->originalTracks().size(); i++) {
-			aCluster.push_back(k->originalTracks().at(i));
-		}
-
-	}
-	clusters.push_back(aCluster);
-
-	return clusters;
-
-}
-


### PR DESCRIPTION
35% speed up in the DA clusterizer itself at low pileup.
small regression observed in primary vertex reconstruction and other products whose producer algorithms depend on primary vertices (detached tracks, conversion)

https://twiki.cern.ch/twiki/bin/viewauth/CMS/HighGranularityCMSSWOptimization
