### PR TITLE
speed up Gsf

### DIFF
--- a/TrackingTools/GsfTools/BuildFile.xml
+++ b/TrackingTools/GsfTools/BuildFile.xml
@@ -1,3 +1,5 @@
+<flags   CXXFLAGS="-Ofast -mrecip"/>
+
 <use   name="boost"/>
 <use   name="CLHEP"/>
 <export>

--- a/TrackingTools/GsfTracking/BuildFile.xml
+++ b/TrackingTools/GsfTracking/BuildFile.xml
@@ -1,3 +1,5 @@
+<flags   CXXFLAGS="-Ofast -mrecip"/>
+
 <use   name="boost"/>
 <use   name="CLHEP"/>
 <export>

--- a/TrackingTools/TrajectoryState/BuildFile.xml
+++ b/TrackingTools/TrajectoryState/BuildFile.xml
@@ -1,3 +1,5 @@
+<flags   CXXFLAGS="-Ofast -mrecip"/>
+
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/GeometrySurface"/>
 <use   name="DataFormats/GeometryVector"/>


### PR DESCRIPTION
15% speedup in GsfTrackProducer 
(mostly from a factor 2 in BasicMultiTrajectoryState::combine())
and few percent in tracking in general

a negligible regression can be observed in almost all distributions involving track-parameters

https://twiki.cern.ch/twiki/bin/viewauth/CMS/HighGranularityCMSSWOptimization
