### PR TITLE
Dt dqm online cfg fix 140628

### DIFF
--- a/DQM/DTMonitorModule/python/dt_dqm_sourceclient_common_cff.py
+++ b/DQM/DTMonitorModule/python/dt_dqm_sourceclient_common_cff.py
@@ -45,6 +45,9 @@ from Configuration.StandardSequences.FrontierConditions_GlobalTag_cff import *
 from DQM.DTMonitorModule.dtDataIntegrityTask_cfi import *
 from DQM.DTMonitorClient.dtDataIntegrityTest_cfi import *
 from DQM.DTMonitorClient.dtBlockedROChannelsTest_cfi import *
+DTDataIntegrityTask.processingMode = 'Online'
+DTDataIntegrityTask.dtDDULabel     = 'dtunpacker'
+DTDataIntegrityTask.dtROS25Label   = 'dtunpacker'
 
 
 # Digi task
@@ -105,7 +108,7 @@ unpackers = cms.Sequence(dtunpacker + dttfunpacker + scalersRawToDigi)
 reco = cms.Sequence(dt1DRecHits + dt4DSegments)
 
 # sequence of DQM tasks to be run on physics events only
-dtDQMTask = cms.Sequence(dtDigiMonitor + dtSegmentAnalysisMonitor + dtTriggerBaseMonitor + dtTriggerLutMonitor + dtNoiseMonitor + dtResolutionAnalysisMonitor)
+dtDQMTask = cms.Sequence(DTDataIntegrityTask + dtDigiMonitor + dtSegmentAnalysisMonitor + dtTriggerBaseMonitor + dtTriggerLutMonitor + dtNoiseMonitor + dtResolutionAnalysisMonitor)
 
 # DQM clients to be run on physics event only
 dtDQMTest = cms.Sequence(dataIntegrityTest + blockedROChannelTest + triggerLutTest + triggerTest + dtOccupancyTest + segmentTest + dtNoiseAnalysisMonitor + dtSummaryClients + dtqTester)

--- a/DQM/DTMonitorModule/python/dt_dqm_sourceclient_common_cff.py
+++ b/DQM/DTMonitorModule/python/dt_dqm_sourceclient_common_cff.py
@@ -49,7 +49,6 @@ DTDataIntegrityTask.processingMode = 'Online'
 DTDataIntegrityTask.dtDDULabel     = 'dtunpacker'
 DTDataIntegrityTask.dtROS25Label   = 'dtunpacker'
 
-
 # Digi task
 from DQM.DTMonitorModule.dtDigiTask_cfi import *
 from DQM.DTMonitorClient.dtOccupancyTest_cfi import *


### PR DESCRIPTION
This commit adds the DTDataIntegrityTask to the online sequence, and sets up the correct processing mode and input tags. Needed to have a working DT data integrity monitoring in the upcoming Global Runs.
