### PR TITLE
binary pixel readout for barrel gt 4 or endcap gt 10

### DIFF
--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
@@ -1144,6 +1144,12 @@ void SiPixelDigitizerAlgorithm::make_digis(float thePixelThresholdInE,
 
     if( signalInElectrons >= thePixelThresholdInE) { // check threshold
 
+      if(DetId(detID).subdetId() == PixelSubdetector::PixelBarrel){ // Barrel modules
+	if (tTopo->pxbLayer(detID) > 4) signalInElectrons = theThresholdInE_BPix*6.0;
+      } else {
+	if (tTopo->pxfDisk(detID) > 10) signalInElectrons = theThresholdInE_FPix*6.0;
+      }
+
       int chan =  (*i).first;  // channel number
       std::pair<int,int> ip = PixelDigi::channelToPixel(chan);
       int adc=0;  // ADC count as integer


### PR DESCRIPTION
In case there will be another SLHC release, this code will emulate binary readout for pixel layers beyond 4 in the barrel or beyond 10 in the endcap.  This corresponds to the phase 2 outer tracker as currently implemented.  This will not be migrated to 7X as the outer tracker will no longer be based on the pixel digitizer.
