### PR TITLE
KfComponentsHolder cleanup

### DIFF
--- a/Alignment/ReferenceTrajectories/src/ReferenceTrajectory.cc
+++ b/Alignment/ReferenceTrajectories/src/ReferenceTrajectory.cc
@@ -955,18 +955,17 @@ ReferenceTrajectory::getHitProjectionMatrixT
 {
   // define variables that will be used to setup the KfComponentsHolder
   // (their allocated memory is needed by 'hitPtr->getKfComponents(..)'
-  // ProjectMatrix<double,5,N>  pf; // not needed
-  typename AlgebraicROOTObject<N,5>::Matrix H; 
+
+  ProjectMatrix<double,5,N>  pf; 
   typename AlgebraicROOTObject<N>::Vector r, rMeas; 
   typename AlgebraicROOTObject<N,N>::SymMatrix V, VMeas;
   // input for the holder - but dummy is OK here to just get the projection matrix:
   const AlgebraicVector5 dummyPars;
   const AlgebraicSymMatrix55 dummyErr;
-  ProjectMatrix<double,5,N> dummyProjFunc;
 
   // setup the holder with the correct dimensions and get the values
   KfComponentsHolder holder;
-  holder.setup<N>(&r, &V, &H, &dummyProjFunc, &rMeas, &VMeas, dummyPars, dummyErr);
+  holder.setup<N>(&r, &V, &pf, &rMeas, &VMeas, dummyPars, dummyErr);
   hitPtr->getKfComponents(holder);
 
   return asHepMatrix<N,5>(holder.projection<N>());

--- a/DataFormats/Math/interface/ProjectMatrix.h
+++ b/DataFormats/Math/interface/ProjectMatrix.h
@@ -11,11 +11,30 @@ struct ProjectMatrix{
   typedef  ROOT::Math::SMatrix<T,D,D,ROOT::Math::MatRepSym<T,D> > SMatDD;
   typedef  ROOT::Math::SMatrix<T,N,N > SMatNN;
   typedef  ROOT::Math::SMatrix<T,N,D > SMatND;
+  typedef  ROOT::Math::SMatrix<T,D,N > SMatDN;
   
+
   // no constructor
   
+  // H
+  SMatDN matrix() const {
+    SMatDN r;
+    for (unsigned int i=0; i<D; i++)
+        r(i,index[i]) = T(1.);
+    return r;
+  }
+
+  // constuct given H
+  void fromH(SMatDN const & H) {
+    for (unsigned int i=0; i<D; i++) {
+      index[i]=N;
+      for (unsigned int j=0; j<N; j++)
+        if ( H(i,j)>0 ) { index[i]=j; break;}
+   }
+  }
+
   // H*S
-  SMatND project(SMatDD const & s) {
+  SMatND project(SMatDD const & s) const {
     SMatND r;
     for (unsigned int i=0; i<D; i++)
       for (unsigned int j=0; j<D; j++)
@@ -24,7 +43,7 @@ struct ProjectMatrix{
   }
   
   // K*H
-  SMatNN project(SMatND const & k) {
+  SMatNN project(SMatND const & k) const {
     SMatNN s;
     for (unsigned int i=0; i<N; i++)
       for (unsigned int j=0; j<D; j++)
@@ -33,13 +52,13 @@ struct ProjectMatrix{
   }
 
   // S-K*H
-  void projectAndSubtractFrom(SMatNN & __restrict__ s, SMatND const & __restrict__ k) {
+  void projectAndSubtractFrom(SMatNN & __restrict__ s, SMatND const & __restrict__ k) const {
     for (unsigned int i=0; i<N; i++)
       for (unsigned int j=0; j<D; j++)
 	s(i,index[j]) -= k(i,j);
   }
 
-  // only H(i,index(i))=1.
+  // only H(i,index[i])=1.
   unsigned int index[D];
 
 };

--- a/DataFormats/Math/test/ProjectMatrix_t.cpp
+++ b/DataFormats/Math/test/ProjectMatrix_t.cpp
@@ -37,6 +37,7 @@ int main() {
   SMatDD S(v,3);
 
   std::cout << S << std::endl;
+  std::cout << std::endl;
   
 
   {
@@ -45,8 +46,10 @@ int main() {
   
     SMatNN V = K*H; 
     
+    std::cout << H << std::endl;
     std::cout << K << std::endl;
     std::cout << V << std::endl;
+    std::cout << std::endl;
 
   }
   {
@@ -55,13 +58,28 @@ int main() {
     SMatND K = H.project(S);  
   
     SMatNN V = H.project(K); 
-    
+
+    std::cout << H.matrix() << std::endl;
     std::cout << K << std::endl;
     std::cout << V << std::endl;
+    std::cout << std::endl;
 
   }
 
+  {
 
+    SMatDN HH; HH(0,3)=1; HH(1,4)=1;
+    ProjectMatrix<double,5,2> H; H.fromH(HH);
+    SMatND K = H.project(S);                                                         
+
+    SMatNN V = H.project(K);
+
+    std::cout << H.matrix() << std::endl;
+    std::cout << K << std::endl;
+    std::cout << V << std::endl;
+    std::cout << std::endl;
+
+  }
 
 
   return 0;

--- a/DataFormats/TrackerRecHit2D/src/BaseTrackerRecHit.cc
+++ b/DataFormats/TrackerRecHit2D/src/BaseTrackerRecHit.cc
@@ -48,8 +48,8 @@ BaseTrackerRecHit::getKfComponents1D( KfComponentsHolder & holder ) const
   AlgebraicMatrix15 & proj = holder.projection<1>();
   proj(0,3) = 1;
   
-   holder.measuredParams<1>() = AlgebraicVector1( holder.tsosLocalParameters().At(3) );
-   holder.measuredErrors<1>() = holder.tsosLocalErrors().Sub<AlgebraicSymMatrix11>( 3, 3 );
+  holder.measuredParams<1>() = AlgebraicVector1( holder.tsosLocalParameters().At(3) );
+  holder.measuredErrors<1>() = holder.tsosLocalErrors().Sub<AlgebraicSymMatrix11>( 3, 3 );
 }
 
 void

--- a/DataFormats/TrackerRecHit2D/src/BaseTrackerRecHit.cc
+++ b/DataFormats/TrackerRecHit2D/src/BaseTrackerRecHit.cc
@@ -45,11 +45,6 @@ BaseTrackerRecHit::getKfComponents1D( KfComponentsHolder & holder ) const
   AlgebraicSymMatrix11 & errs = holder.errors<1>();
   errs(0,0) = err_.xx();
   
-  /*
-  AlgebraicMatrix15 & proj = holder.projection<1>();
-  proj(0,3) = 1;
-  */
-
   ProjectMatrix<double,5,1>  & pf = holder.projFunc<1>();
   pf.index[0] = 3;
   holder.doUseProjFunc();
@@ -72,12 +67,6 @@ BaseTrackerRecHit::getKfComponents2D( KfComponentsHolder & holder ) const
    errs(0,0) = err_.xx();
    errs(0,1) = err_.xy();
    errs(1,1) = err_.yy();
-
-   /*
-   AlgebraicMatrix25 & proj = holder.projection<2>();
-   proj(0,3) = 1;
-   proj(1,4) = 1;
-   */
 
    ProjectMatrix<double,5,2>  & pf = holder.projFunc<2>();
    pf.index[0] = 3;

--- a/DataFormats/TrackerRecHit2D/src/BaseTrackerRecHit.cc
+++ b/DataFormats/TrackerRecHit2D/src/BaseTrackerRecHit.cc
@@ -47,9 +47,6 @@ BaseTrackerRecHit::getKfComponents1D( KfComponentsHolder & holder ) const
   
   ProjectMatrix<double,5,1>  & pf = holder.projFunc<1>();
   pf.index[0] = 3;
-  holder.doUseProjFunc();
-
-
 
   holder.measuredParams<1>() = AlgebraicVector1( holder.tsosLocalParameters().At(3) );
   holder.measuredErrors<1>() = holder.tsosLocalErrors().Sub<AlgebraicSymMatrix11>( 3, 3 );
@@ -71,7 +68,6 @@ BaseTrackerRecHit::getKfComponents2D( KfComponentsHolder & holder ) const
    ProjectMatrix<double,5,2>  & pf = holder.projFunc<2>();
    pf.index[0] = 3;
    pf.index[1] = 4;
-   holder.doUseProjFunc();
 
    holder.measuredParams<2>() = AlgebraicVector2( & holder.tsosLocalParameters().At(3), 2 );
    holder.measuredErrors<2>() = holder.tsosLocalErrors().Sub<AlgebraicSymMatrix22>( 3, 3 );

--- a/DataFormats/TrackerRecHit2D/src/BaseTrackerRecHit.cc
+++ b/DataFormats/TrackerRecHit2D/src/BaseTrackerRecHit.cc
@@ -45,9 +45,17 @@ BaseTrackerRecHit::getKfComponents1D( KfComponentsHolder & holder ) const
   AlgebraicSymMatrix11 & errs = holder.errors<1>();
   errs(0,0) = err_.xx();
   
+  /*
   AlgebraicMatrix15 & proj = holder.projection<1>();
   proj(0,3) = 1;
-  
+  */
+
+  ProjectMatrix<double,5,1>  & pf = holder.projFunc<1>();
+  pf.index[0] = 3;
+  holder.doUseProjFunc();
+
+
+
   holder.measuredParams<1>() = AlgebraicVector1( holder.tsosLocalParameters().At(3) );
   holder.measuredErrors<1>() = holder.tsosLocalErrors().Sub<AlgebraicSymMatrix11>( 3, 3 );
 }
@@ -65,10 +73,11 @@ BaseTrackerRecHit::getKfComponents2D( KfComponentsHolder & holder ) const
    errs(0,1) = err_.xy();
    errs(1,1) = err_.yy();
 
-   
+   /*
    AlgebraicMatrix25 & proj = holder.projection<2>();
    proj(0,3) = 1;
    proj(1,4) = 1;
+   */
 
    ProjectMatrix<double,5,2>  & pf = holder.projFunc<2>();
    pf.index[0] = 3;

--- a/DataFormats/TrackingRecHit/interface/KfComponentsHolder.h
+++ b/DataFormats/TrackingRecHit/interface/KfComponentsHolder.h
@@ -4,11 +4,11 @@
 
 #include "DataFormats/CLHEP/interface/AlgebraicObjects.h"
 #include "DataFormats/Math/interface/ProjectMatrix.h"
-#include <stdint.h>
+#include <cstdint>
 
 class TrackingRecHit;
 
-#define Debug_KfComponentsHolder
+// #define Debug_KfComponentsHolder
 
 class KfComponentsHolder {
     public:
@@ -31,7 +31,7 @@ class KfComponentsHolder {
             const AlgebraicSymMatrix55 & tsosLocalErrors 
         ) ;
 
-
+/*
   // backward compatible call
         template <unsigned int D>
         void setup(
@@ -44,6 +44,7 @@ class KfComponentsHolder {
             const AlgebraicSymMatrix55 & tsosLocalErrors 
         ) ;
 
+*/
 
         template <unsigned int D>
         typename AlgebraicROOTObject<D>::Vector & params() { 

--- a/DataFormats/TrackingRecHit/interface/KfComponentsHolder.h
+++ b/DataFormats/TrackingRecHit/interface/KfComponentsHolder.h
@@ -48,6 +48,7 @@ class KfComponentsHolder {
             return  * reinterpret_cast<typename AlgebraicROOTObject<D,D>::SymMatrix *>(errors_);
         }
 
+
         template <unsigned int D>
         typename AlgebraicROOTObject<D,5>::Matrix & projection() { 
 #ifdef Debug_KfComponentsHolder
@@ -55,6 +56,8 @@ class KfComponentsHolder {
 #endif
             return  * reinterpret_cast<typename AlgebraicROOTObject<D,5>::Matrix *>(projection_);
         }
+
+
 
         template <unsigned int D>
         ProjectMatrix<double,5,D> & projFunc() { 

--- a/DataFormats/TrackingRecHit/interface/KfComponentsHolder.h
+++ b/DataFormats/TrackingRecHit/interface/KfComponentsHolder.h
@@ -31,20 +31,6 @@ class KfComponentsHolder {
             const AlgebraicSymMatrix55 & tsosLocalErrors 
         ) ;
 
-/*
-  // backward compatible call
-        template <unsigned int D>
-        void setup(
-            typename AlgebraicROOTObject<D>::Vector       *params,
-            typename AlgebraicROOTObject<D,D>::SymMatrix  *errors,
-            typename AlgebraicROOTObject<D,5>::Matrix     *projection,
-            typename AlgebraicROOTObject<D>::Vector       *measuredParams,
-            typename AlgebraicROOTObject<D,D>::SymMatrix  *measuredErrors,
-            const AlgebraicVector5 & tsosLocalParameters, 
-            const AlgebraicSymMatrix55 & tsosLocalErrors 
-        ) ;
-
-*/
 
         template <unsigned int D>
         typename AlgebraicROOTObject<D>::Vector & params() { 

--- a/DataFormats/TrackingRecHit/interface/KfComponentsHolder.h
+++ b/DataFormats/TrackingRecHit/interface/KfComponentsHolder.h
@@ -50,11 +50,12 @@ class KfComponentsHolder {
 
 
         template <unsigned int D>
-        typename AlgebraicROOTObject<D,5>::Matrix & projection() { 
+        typename AlgebraicROOTObject<D,5>::Matrix  projection() { 
 #ifdef Debug_KfComponentsHolder
             assert(size_ == D);
 #endif
-            return  * reinterpret_cast<typename AlgebraicROOTObject<D,5>::Matrix *>(projection_);
+            return this->projFunc<D>().matrix();
+            //return  * reinterpret_cast<typename AlgebraicROOTObject<D,5>::Matrix *>(projection_);
         }
 
 
@@ -153,3 +154,4 @@ void KfComponentsHolder::dump() {
 #endif 
 
 #endif
+

--- a/DataFormats/TrackingRecHit/interface/KfComponentsHolder.h
+++ b/DataFormats/TrackingRecHit/interface/KfComponentsHolder.h
@@ -12,18 +12,16 @@ class TrackingRecHit;
 
 class KfComponentsHolder {
     public:
-  KfComponentsHolder() : params_(0), errors_(0), projection_(0), useProjFunc_(false)
-        {
+  KfComponentsHolder(){
 #ifdef Debug_KfComponentsHolder
-            size_ = 0;
+   size_ == 0;
 #endif
-        }
+}
 
         template <unsigned int D>
         void setup(
             typename AlgebraicROOTObject<D>::Vector       *params,
             typename AlgebraicROOTObject<D,D>::SymMatrix  *errors,
-            typename AlgebraicROOTObject<D,5>::Matrix     *projection,
 	    ProjectMatrix<double,5,D>                     *projFunc, 
             typename AlgebraicROOTObject<D>::Vector       *measuredParams,
             typename AlgebraicROOTObject<D,D>::SymMatrix  *measuredErrors,
@@ -90,23 +88,18 @@ class KfComponentsHolder {
         const AlgebraicVector5     & tsosLocalParameters() const { return *tsosLocalParameters_; }
         const AlgebraicSymMatrix55 & tsosLocalErrors()     const { return *tsosLocalErrors_;     }
 
-        bool useProjFunc() const { return useProjFunc_;}
-        void doUseProjFunc() {  useProjFunc_ = true; }
 
         template<unsigned int D> void dump() ;
     private:
 #ifdef Debug_KfComponentsHolder
         uint16_t size_;
 #endif
-  void *params_, *errors_, *projection_, *projFunc_, *measuredParams_, *measuredErrors_;
+  void *params_, *errors_, *projFunc_, *measuredParams_, *measuredErrors_;
   const AlgebraicVector5 * tsosLocalParameters_;
   const AlgebraicSymMatrix55 * tsosLocalErrors_;
 
-  bool useProjFunc_;
-
   template<unsigned int D>
   void genericFill_(const TrackingRecHit &hit);
-
         
 };
 
@@ -115,7 +108,6 @@ template<unsigned int D>
 void KfComponentsHolder::setup(
         typename AlgebraicROOTObject<D>::Vector       *params,
         typename AlgebraicROOTObject<D,D>::SymMatrix  *errors,
-        typename AlgebraicROOTObject<D,5>::Matrix     *projection,
 	ProjectMatrix<double,5,D>                     *projFunc, 
         typename AlgebraicROOTObject<D>::Vector       *measuredParams,
         typename AlgebraicROOTObject<D,D>::SymMatrix  *measuredErrors,
@@ -128,7 +120,6 @@ void KfComponentsHolder::setup(
 #endif
     params_     = params;
     errors_     = errors;
-    projection_ = projection;
     projFunc_ = projFunc;
     measuredParams_ = measuredParams;
     measuredErrors_ = measuredErrors;

--- a/DataFormats/TrackingRecHit/interface/KfComponentsHolder.h
+++ b/DataFormats/TrackingRecHit/interface/KfComponentsHolder.h
@@ -14,7 +14,7 @@ class KfComponentsHolder {
     public:
   KfComponentsHolder(){
 #ifdef Debug_KfComponentsHolder
-   size_ == 0;
+   size_ = 0;
 #endif
 }
 

--- a/DataFormats/TrackingRecHit/src/KfComponentsHolder.cc
+++ b/DataFormats/TrackingRecHit/src/KfComponentsHolder.cc
@@ -11,12 +11,9 @@ void KfComponentsHolder::genericFill_(const TrackingRecHit &hit) {
 
    params<D>()     = asSVector<D>(hit.parameters());
    errors<D>()     = asSMatrix<D>(hit.parametersError());
-   // projection<D>() = asSMatrix<D,5>(hit.projectionMatrix());
 
    MatD5 && H = asSMatrix<D,5>(hit.projectionMatrix());
-  
    projFunc<D>().fromH(H);
-   doUseProjFunc();
 
    measuredParams<D>() = H * (*tsosLocalParameters_);
    measuredErrors<D>() = ROOT::Math::Similarity(H, (*tsosLocalErrors_));

--- a/DataFormats/TrackingRecHit/src/KfComponentsHolder.cc
+++ b/DataFormats/TrackingRecHit/src/KfComponentsHolder.cc
@@ -11,9 +11,12 @@ void KfComponentsHolder::genericFill_(const TrackingRecHit &hit) {
 
    params<D>()     = asSVector<D>(hit.parameters());
    errors<D>()     = asSMatrix<D>(hit.parametersError());
-   projection<D>() = asSMatrix<D,5>(hit.projectionMatrix());
+   // projection<D>() = asSMatrix<D,5>(hit.projectionMatrix());
 
-   const MatD5 & H = projection<D>();
+   MatD5 && H = asSMatrix<D,5>(hit.projectionMatrix());
+  
+   projFunc<D>().fromH(H);
+   doUseProjFunc();
 
    measuredParams<D>() = H * (*tsosLocalParameters_);
    measuredErrors<D>() = ROOT::Math::Similarity(H, (*tsosLocalErrors_));

--- a/RecoTracker/SiTrackerMRHTools/src/SiTrackerMultiRecHitUpdator.cc
+++ b/RecoTracker/SiTrackerMRHTools/src/SiTrackerMultiRecHitUpdator.cc
@@ -192,7 +192,6 @@ double SiTrackerMultiRecHitUpdator::ComputeWeight(const TrajectoryStateOnSurface
 
   // define variables that will be used to setup the KfComponentsHolder
   ProjectMatrix<double,5,N>  pf;
-  typename AlgebraicROOTObject<N,5>::Matrix H;
   typename AlgebraicROOTObject<N>::Vector r, rMeas;
   typename AlgebraicROOTObject<N,N>::SymMatrix V, VMeas, W;
   AlgebraicVector5 x = tsos.localParameters().vector();
@@ -200,7 +199,7 @@ double SiTrackerMultiRecHitUpdator::ComputeWeight(const TrajectoryStateOnSurface
 
   // setup the holder with the correct dimensions and get the values
   KfComponentsHolder holder;
-  holder.template setup<N>(&r, &V, &H, &pf, &rMeas, &VMeas, x, C);
+  holder.template setup<N>(&r, &V,  &pf, &rMeas, &VMeas, x, C);
   aRecHit.getKfComponents(holder);
 
   typename AlgebraicROOTObject<N>::Vector diff;
@@ -289,7 +288,6 @@ std::pair<AlgebraicVector2,AlgebraicSymMatrix22> SiTrackerMultiRecHitUpdator::Co
 
   // define variables that will be used to setup the KfComponentsHolder
   ProjectMatrix<double,5,N>  pf;
-  typename AlgebraicROOTObject<N,5>::Matrix H;
   typename AlgebraicROOTObject<N>::Vector r, rMeas;
   typename AlgebraicROOTObject<N,N>::SymMatrix V, VMeas, Wtemp;
   AlgebraicVector5 x = tsos.localParameters().vector();
@@ -297,7 +295,7 @@ std::pair<AlgebraicVector2,AlgebraicSymMatrix22> SiTrackerMultiRecHitUpdator::Co
 
   // setup the holder with the correct dimensions and get the values
   KfComponentsHolder holder;
-  holder.template setup<N>(&r, &V, &H, &pf, &rMeas, &VMeas, x, C);
+  holder.template setup<N>(&r, &V, &pf, &rMeas, &VMeas, x, C);
   aRecHit.getKfComponents(holder);
 
   Wtemp = V;

--- a/TrackingTools/GsfTracking/src/PosteriorWeightsCalculator.cc
+++ b/TrackingTools/GsfTracking/src/PosteriorWeightsCalculator.cc
@@ -23,7 +23,8 @@ std::vector<double> PosteriorWeightsCalculator::weights(const TrackingRecHit& re
   typedef typename AlgebraicROOTObject<5,D>::Matrix Mat5D;
   typedef typename AlgebraicROOTObject<D,D>::SymMatrix SMatDD;
   typedef typename AlgebraicROOTObject<D>::Vector VecD;
-  
+  using ROOT::Math::SMatrixNoInit;
+
   std::vector<double> weights;
   if ( predictedComponents.empty() )  {
     edm::LogError("EmptyPredictedComponents")<<"a multi state is empty. cannot compute any weight.";
@@ -36,9 +37,8 @@ std::vector<double> PosteriorWeightsCalculator::weights(const TrackingRecHit& re
   std::vector<double> chi2s;
   chi2s.reserve(predictedComponents.size());
 
-  MatD5 H; 
   VecD r, rMeas; 
-  SMatDD V, R;
+  SMatDD V(SMatrixNoInit{}), R(SMatrixNoInit{});
   AlgebraicVector5 x;
   ProjectMatrix<double,5,D> p;
   //
@@ -47,18 +47,10 @@ std::vector<double> PosteriorWeightsCalculator::weights(const TrackingRecHit& re
   //  
   double chi2Min(DBL_MAX);
   for ( unsigned int i=0; i<predictedComponents.size(); i++ ) {
-//     MeasurementExtractor me(predictedComponents[i]);
-//     // Residuals of aPredictedState w.r.t. aRecHit, 
-//     //!!!     AlgebraicVector r(recHit.parameters(predictedComponents[i]) - me.measuredParameters(recHit));
-//     VecD r = asSVector<D>(recHit.parameters()) - me.measuredParameters<D>(recHit);
-//     // and covariance matrix of residuals
-//     //!!!     AlgebraicSymMatrix V(recHit.parametersError(predictedComponents[i]));
-//     SMatDD V = asSMatrix<D>(recHit.parametersError());
-//     SMatDD R = V + me.measuredError<D>(recHit);
 
     KfComponentsHolder holder; 
     x = predictedComponents[i].localParameters().vector();
-    holder.template setup<D>(&r, &V, &H, &p, &rMeas, &R, 
+    holder.template setup<D>(&r, &V, &p, &rMeas, &R, 
 			     x, predictedComponents[i].localError().matrix());
     recHit.getKfComponents(holder);
 

--- a/TrackingTools/KalmanUpdators/BuildFile.xml
+++ b/TrackingTools/KalmanUpdators/BuildFile.xml
@@ -1,3 +1,4 @@
+#<flags   CXXFLAGS="-Ofast -mrecip -funroll-all-loops"/>
 <flags   CXXFLAGS="-O3"/>
 <use   name="boost"/>
 <use   name="clhep"/>

--- a/TrackingTools/KalmanUpdators/interface/Chi2MeasurementEstimator.h
+++ b/TrackingTools/KalmanUpdators/interface/Chi2MeasurementEstimator.h
@@ -25,8 +25,6 @@ public:
 
   virtual std::pair<bool,double> estimate(const TrajectoryStateOnSurface&,
 				     const TrackingRecHit&) const;
-  template <unsigned int D> std::pair<bool,double> estimate(const TrajectoryStateOnSurface&,
-				     const TrackingRecHit&) const;
 
   virtual Chi2MeasurementEstimator* clone() const {
     return new Chi2MeasurementEstimator(*this);

--- a/TrackingTools/KalmanUpdators/interface/KFUpdator.h
+++ b/TrackingTools/KalmanUpdators/interface/KFUpdator.h
@@ -40,8 +40,6 @@ public:
   TrajectoryStateOnSurface update(const TrajectoryStateOnSurface&,
                                   const TrackingRecHit&) const;
 
-  template <unsigned int D> TrajectoryStateOnSurface update(const TrajectoryStateOnSurface&,
-                                  const TrackingRecHit&) const;
 
   virtual KFUpdator * clone() const {
     return new KFUpdator(*this);

--- a/TrackingTools/KalmanUpdators/src/Chi2MeasurementEstimator.cc
+++ b/TrackingTools/KalmanUpdators/src/Chi2MeasurementEstimator.cc
@@ -18,12 +18,11 @@ namespace {
     using ROOT::Math::SMatrixNoInit;
     
     VecD r, rMeas; SMatDD R(SMatrixNoInit{}), RMeas(SMatrixNoInit{});
-    MatD5 dummyProjMatrix=SMatrixNoInit{};
     ProjectMatrix<double,5,D> dummyProjFunc;
     auto && v = tsos.localParameters().vector();
     auto && m = tsos.localError().matrix();
     KfComponentsHolder holder;
-    holder.template setup<D>(&r, &R, &dummyProjMatrix, &dummyProjFunc, &rMeas, &RMeas, v, m);
+    holder.template setup<D>(&r, &R, &dummyProjFunc, &rMeas, &RMeas, v, m);
     aRecHit.getKfComponents(holder);
     
     R += RMeas;

--- a/TrackingTools/KalmanUpdators/src/Chi2MeasurementEstimator.cc
+++ b/TrackingTools/KalmanUpdators/src/Chi2MeasurementEstimator.cc
@@ -17,7 +17,7 @@ namespace {
     typedef typename AlgebraicROOTObject<D>::Vector VecD;
     using ROOT::Math::SMatrixNoInit;
     
-    VecD r, rMeas; SMatDD R, RMeas;
+    VecD r, rMeas; SMatDD R(SMatrixNoInit{}), RMeas(SMatrixNoInit{});
     MatD5 dummyProjMatrix=SMatrixNoInit{};
     ProjectMatrix<double,5,D> dummyProjFunc;
     auto && v = tsos.localParameters().vector();

--- a/TrackingTools/KalmanUpdators/src/Chi2MeasurementEstimator.cc
+++ b/TrackingTools/KalmanUpdators/src/Chi2MeasurementEstimator.cc
@@ -5,40 +5,42 @@
 #include "DataFormats/GeometrySurface/interface/Plane.h"
 #include "DataFormats/Math/interface/invertPosDefMatrix.h"
 
-std::pair<bool,double> 
-Chi2MeasurementEstimator::estimate(const TrajectoryStateOnSurface& tsos,
-				   const TrackingRecHit& aRecHit) const {
-    switch (aRecHit.dimension()) {
-        case 1: return estimate<1>(tsos,aRecHit);
-        case 2: return estimate<2>(tsos,aRecHit);
-        case 3: return estimate<3>(tsos,aRecHit);
-        case 4: return estimate<4>(tsos,aRecHit);
-        case 5: return estimate<5>(tsos,aRecHit);
-    }
-    throw cms::Exception("RecHit of invalid size (not 1,2,3,4,5)");
+
+namespace {
+  template <unsigned int D> 
+  double
+  lestimate(const TrajectoryStateOnSurface& tsos,
+	    const TrackingRecHit& aRecHit) {
+    typedef typename AlgebraicROOTObject<D,5>::Matrix MatD5;
+    typedef typename AlgebraicROOTObject<5,D>::Matrix Mat5D;
+    typedef typename AlgebraicROOTObject<D,D>::SymMatrix SMatDD;
+    typedef typename AlgebraicROOTObject<D>::Vector VecD;
+    using ROOT::Math::SMatrixNoInit;
+    
+    VecD r, rMeas; SMatDD R, RMeas;
+    MatD5 dummyProjMatrix=SMatrixNoInit{};
+    ProjectMatrix<double,5,D> dummyProjFunc;
+    auto && v = tsos.localParameters().vector();
+    auto && m = tsos.localError().matrix();
+    KfComponentsHolder holder;
+    holder.template setup<D>(&r, &R, &dummyProjMatrix, &dummyProjFunc, &rMeas, &RMeas, v, m);
+    aRecHit.getKfComponents(holder);
+    
+    R += RMeas;
+    invertPosDefMatrix(R);
+    return ROOT::Math::Similarity(r - rMeas, R);
+  }
 }
 
-template <unsigned int D> std::pair<bool,double> 
+std::pair<bool,double>
 Chi2MeasurementEstimator::estimate(const TrajectoryStateOnSurface& tsos,
-				   const TrackingRecHit& aRecHit) const {
-
-  typedef typename AlgebraicROOTObject<D,5>::Matrix MatD5;
-  typedef typename AlgebraicROOTObject<5,D>::Matrix Mat5D;
-  typedef typename AlgebraicROOTObject<D,D>::SymMatrix SMatDD;
-  typedef typename AlgebraicROOTObject<D>::Vector VecD;
-
-  VecD r, rMeas; SMatDD R, RMeas; 
-  MatD5 dummyProjMatrix;
-  ProjectMatrix<double,5,D> dummyProjFunc;
-  auto && v = tsos.localParameters().vector();
-  auto && m = tsos.localError().matrix();
-  KfComponentsHolder holder;
-  holder.template setup<D>(&r, &R, &dummyProjMatrix, &dummyProjFunc, &rMeas, &RMeas, v, m);
-  aRecHit.getKfComponents(holder);
- 
-  R += RMeas;
-  invertPosDefMatrix(R);
-  double est = ROOT::Math::Similarity(r - rMeas, R);
-
-  return returnIt(est);
+                                   const TrackingRecHit& aRecHit) const {
+    switch (aRecHit.dimension()) {
+        case 1: return returnIt(lestimate<1>(tsos,aRecHit));
+        case 2: return returnIt(lestimate<2>(tsos,aRecHit));
+        case 3: return returnIt(lestimate<3>(tsos,aRecHit));
+        case 4: return returnIt(lestimate<4>(tsos,aRecHit));
+        case 5: return returnIt(lestimate<5>(tsos,aRecHit));
+    }
+    throw cms::Exception("RecHit of invalid size (not 1,2,3,4,5)");
 }

--- a/TrackingTools/KalmanUpdators/src/KFUpdator.cc
+++ b/TrackingTools/KalmanUpdators/src/KFUpdator.cc
@@ -7,65 +7,46 @@
 #include "DataFormats/Math/interface/invertPosDefMatrix.h"
 #include "DataFormats/Math/interface/ProjectMatrix.h"
 
-TrajectoryStateOnSurface KFUpdator::update(const TrajectoryStateOnSurface& tsos,
-				           const TrackingRecHit& aRecHit) const {
-    switch (aRecHit.dimension()) {
-        case 1: return update<1>(tsos,aRecHit);
-        case 2: return update<2>(tsos,aRecHit);
-        case 3: return update<3>(tsos,aRecHit);
-        case 4: return update<4>(tsos,aRecHit);
-        case 5: return update<5>(tsos,aRecHit);
-    }
-    throw cms::Exception("Rec hit of invalid dimension (not 1,2,3,4,5)") <<
-         "The value was " << aRecHit.dimension() << 
-        ", type is " << typeid(aRecHit).name() << "\n";
-}
+namespace {
 
-#define NEW
-#ifdef NEW
 template <unsigned int D>
-TrajectoryStateOnSurface KFUpdator::update(const TrajectoryStateOnSurface& tsos,
-				           const TrackingRecHit& aRecHit) const {
+TrajectoryStateOnSurface lupdate(const TrajectoryStateOnSurface& tsos,
+				           const TrackingRecHit& aRecHit) {
 
   typedef typename AlgebraicROOTObject<D,5>::Matrix MatD5;
   typedef typename AlgebraicROOTObject<5,D>::Matrix Mat5D;
   typedef typename AlgebraicROOTObject<D,D>::SymMatrix SMatDD;
   typedef typename AlgebraicROOTObject<D>::Vector VecD;
+  using ROOT::Math::SMatrixNoInit;
   double pzSign = tsos.localParameters().pzSign();
 
   //MeasurementExtractor me(tsos);
 
   auto && x = tsos.localParameters().vector();
   auto && C = tsos.localError().matrix();
-  // Measurement matrix
+
+  // projection matrix (should be zeroed)
   ProjectMatrix<double,5,D>  pf;
-  MatD5 H; 
+  MatD5 H;
+ 
+  // Measurement matrix
   VecD r, rMeas; 
-  SMatDD V, VMeas;
+  SMatDD V(SMatrixNoInit{}), VMeas(SMatrixNoInit{});
 
   KfComponentsHolder holder; 
   holder.template setup<D>(&r, &V, &H, &pf, &rMeas, &VMeas, x, C);
   aRecHit.getKfComponents(holder);
   
-  //MatD5 H = asSMatrix<D,5>(aRecHit.projectionMatrix());
-
-  // Residuals of aPredictedState w.r.t. aRecHit, 
-  //VecD r = asSVector<D>(aRecHit.parameters()) - me.measuredParameters<D>(aRecHit);
-  //r -= me.measuredParameters<D>(aRecHit);
   r -= rMeas;
 
   // and covariance matrix of residuals
-  //SMatDD V = asSMatrix<D>(aRecHit.parametersError());
-  //SMatDD R = V + me.measuredError<D>(aRecHit);
   SMatDD R = V + VMeas;
   bool ok = invertPosDefMatrix(R);
-  // error check moved at the end
-  //R.Invert();
 
   // Compute Kalman gain matrix
-  Mat5D K;
+  Mat5D K(SMatrixNoInit{});
   AlgebraicMatrix55 M = AlgebraicMatrixID();
-  if (holder.useProjFunc() ) {
+  if likely(holder.useProjFunc() ) {
     K = C*pf.project(R);
     pf.projectAndSubtractFrom(M,K);
   }
@@ -98,47 +79,19 @@ TrajectoryStateOnSurface KFUpdator::update(const TrajectoryStateOnSurface& tsos,
   }
 
 }
-#endif
-
-#ifndef NEW
-template <unsigned int D>
-TrajectoryStateOnSurface KFUpdator::update(const TrajectoryStateOnSurface& tsos,
-				           const TransientTrackingRecHit& aRecHit) const {
-
-  typedef typename AlgebraicROOTObject<D,5>::Matrix MatD5;
-  typedef typename AlgebraicROOTObject<5,D>::Matrix Mat5D;
-  typedef typename AlgebraicROOTObject<D,D>::SymMatrix SMatDD;
-  typedef typename AlgebraicROOTObject<D>::Vector VecD;
-  double pzSign = tsos.localParameters().pzSign();
-
-  MeasurementExtractor me(tsos);
-
-  AlgebraicVector5 x = tsos.localParameters().vector();
-  const AlgebraicSymMatrix55 &C = (tsos.localError().matrix());
-  // Measurement matrix
-  MatD5 H = asSMatrix<D,5>(aRecHit.projectionMatrix());
-
-  // Residuals of aPredictedState w.r.t. aRecHit, 
-  VecD r = asSVector<D>(aRecHit.parameters()) - me.measuredParameters<D>(aRecHit);
-
-  // and covariance matrix of residuals
-  SMatDD V = asSMatrix<D>(aRecHit.parametersError());
-  SMatDD R = V + me.measuredError<D>(aRecHit);
-  int ierr = !  invertPosDefMatrix(R);; // if (ierr != 0) throw exception;
-  //R.Invert();
-
-  // Compute Kalman gain matrix
-  Mat5D K = C * ROOT::Math::Transpose(H) * R;
-
-  // Compute local filtered state vector
-  AlgebraicVector5 fsv = x + K * r;
-
-  // Compute covariance matrix of local filtered state vector
-  AlgebraicMatrix55 I = AlgebraicMatrixID();
-  AlgebraicMatrix55 M = I - K * H;
-  AlgebraicSymMatrix55 fse = ROOT::Math::Similarity(M, C) + ROOT::Math::Similarity(K, V);
-
-  return TrajectoryStateOnSurface( LocalTrajectoryParameters(fsv, pzSign),
-				   LocalTrajectoryError(fse), tsos.surface(),&(tsos.globalParameters().magneticField()), tsos.surfaceSide() );
 }
-#endif
+
+TrajectoryStateOnSurface KFUpdator::update(const TrajectoryStateOnSurface& tsos,
+                                           const TrackingRecHit& aRecHit) const {
+    switch (aRecHit.dimension()) {
+        case 1: return lupdate<1>(tsos,aRecHit);
+        case 2: return lupdate<2>(tsos,aRecHit);
+        case 3: return lupdate<3>(tsos,aRecHit);
+        case 4: return lupdate<4>(tsos,aRecHit);
+        case 5: return lupdate<5>(tsos,aRecHit);
+    }
+    throw cms::Exception("Rec hit of invalid dimension (not 1,2,3,4,5)") <<
+         "The value was " << aRecHit.dimension() <<
+        ", type is " << typeid(aRecHit).name() << "\n";
+}
+

--- a/TrackingTools/KalmanUpdators/src/KFUpdator.cc
+++ b/TrackingTools/KalmanUpdators/src/KFUpdator.cc
@@ -20,8 +20,6 @@ TrajectoryStateOnSurface lupdate(const TrajectoryStateOnSurface& tsos,
   using ROOT::Math::SMatrixNoInit;
   double pzSign = tsos.localParameters().pzSign();
 
-  //MeasurementExtractor me(tsos);
-
   auto && x = tsos.localParameters().vector();
   auto && C = tsos.localError().matrix();
 

--- a/TrackingTools/KalmanUpdators/src/MRHChi2MeasurementEstimator.cc
+++ b/TrackingTools/KalmanUpdators/src/MRHChi2MeasurementEstimator.cc
@@ -45,7 +45,6 @@ std::pair<bool, double> MRHChi2MeasurementEstimator::estimate(const TrajectorySt
 
     // define variables that will be used to setup the KfComponentsHolder
     ProjectMatrix<double,5,N>  pf;
-    typename AlgebraicROOTObject<N,5>::Matrix H;
     typename AlgebraicROOTObject<N>::Vector r, rMeas;
     typename AlgebraicROOTObject<N,N>::SymMatrix V, VMeas;
     AlgebraicVector5 x = tsos.localParameters().vector();
@@ -53,7 +52,7 @@ std::pair<bool, double> MRHChi2MeasurementEstimator::estimate(const TrajectorySt
 
     // setup the holder with the correct dimensions and get the values
     KfComponentsHolder holder;
-    holder.template setup<N>(&r, &V, &H, &pf, &rMeas, &VMeas, x, C);
+    holder.template setup<N>(&r, &V, &pf, &rMeas, &VMeas, x, C);
     (**iter).getKfComponents(holder);
 
     r -= rMeas;


### PR DESCRIPTION
Cleanup of KfComponentsHolder.
It became a bit more urgent due to changes introduced by thread-safety.
Restore the timing performance of the Chi2MeasurementEstimator (still pretty deceiving though).

No regression expected, no regression observed
