### PR TITLE
fix filename in jobReport

### DIFF
--- a/DQMServices/Components/src/DQMFileSaver.cc
+++ b/DQMServices/Components/src/DQMFileSaver.cc
@@ -771,7 +771,7 @@ DQMFileSaver::endJob(void)
   // save JobReport once per job
   char suffix[64];
   sprintf(suffix, "R%09d", irun_.load());
-  std::string filename = onlineOfflineFileName(fileBaseName_, suffix, workflow_, child_, PB);
+  std::string filename = onlineOfflineFileName(fileBaseName_, suffix, workflow_, child_, fileFormat_);
   saveJobReport(filename);
 }
 


### PR DESCRIPTION
needed when running the harvesting at the T0. I have checked that the file created matches the name in the FwkJobReport
