### PR TITLE
fix cmsShowFF crash -- root 5.34.18 & new ServiRegistry interface

### DIFF
--- a/Fireworks/Eve/interface/EveService.h
+++ b/Fireworks/Eve/interface/EveService.h
@@ -27,7 +27,9 @@ namespace edm
    class ActivityRegistry;
    class Run;
    class Event;
-   class EventSetup;
+   class EventSetup; 
+   class StreamContext;
+   class GlobalContext;
 }
 
 class TEveManager;
@@ -54,9 +56,9 @@ public:
    void postBeginJob();
    void postEndJob();
 
-   void postBeginRun(const edm::Run&, const edm::EventSetup&);
+   void postGlobalBeginRun(edm::GlobalContext const&);
 
-   void postProcessEvent(const edm::Event&, const edm::EventSetup&);
+   void postEvent(edm::StreamContext const&);
 
    void display(const std::string& info="");
 

--- a/Fireworks/FWInterface/src/FWFFHelper.cc
+++ b/Fireworks/FWInterface/src/FWFFHelper.cc
@@ -64,15 +64,17 @@ FWFFHelper::FWFFHelper(const edm::ParameterSet &ps, const edm::ActivityRegistry 
       std::cerr <<"Insufficient GL support. " << iException.what() << std::endl;
       throw;
    }
+
+// AMT workaround for an agressive clenup in 5.43.18
 #if ROOT_VERSION_CODE >= ROOT_VERSION(5,34,18)
-   // AMT workaround for an agressive clenup in 5.43.18
    if (!gStyle) {
       TColor::fgInitDone=false;
       TColor::InitializeColors();
       TStyle::BuildStyles();
       gROOT->SetStyle(gEnv->GetValue("Canvas.Style", "Modern"));
       gStyle = gROOT->GetStyle("Classic");
-      TEveManager::Create(kFALSE, "FIV");
    }
 #endif
+
+    TEveManager::Create(kFALSE, "FIV");
 }

--- a/Fireworks/FWInterface/src/FWFFHelper.cc
+++ b/Fireworks/FWInterface/src/FWFFHelper.cc
@@ -2,9 +2,12 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
 
+#define private public
 #include "TROOT.h"
 #include "TSystem.h"
-#define private public
+#include "TColor.h"
+#include "TStyle.h"
+#include "TEnv.h"
 #include "TRint.h"
 #include "TEveManager.h"
 #include "TEveEventManager.h"
@@ -61,7 +64,15 @@ FWFFHelper::FWFFHelper(const edm::ParameterSet &ps, const edm::ActivityRegistry 
       std::cerr <<"Insufficient GL support. " << iException.what() << std::endl;
       throw;
    }
-   
-
-   TEveManager::Create(kFALSE, "FIV");
+#if ROOT_VERSION_CODE >= ROOT_VERSION(5,34,18)
+   // AMT workaround for an agressive clenup in 5.43.18
+   if (!gStyle) {
+      TColor::fgInitDone=false;
+      TColor::InitializeColors();
+      TStyle::BuildStyles();
+      gROOT->SetStyle(gEnv->GetValue("Canvas.Style", "Modern"));
+      gStyle = gROOT->GetStyle("Classic");
+      TEveManager::Create(kFALSE, "FIV");
+   }
+#endif
 }

--- a/Fireworks/FWInterface/src/FWFFLooper.cc
+++ b/Fireworks/FWInterface/src/FWFFLooper.cc
@@ -47,6 +47,12 @@
 #include "TGeoManager.h"
 
 
+namespace edm
+{
+   class StreamContext;
+   class ModuleCallingContext;
+}
+
 namespace
 {
    class CmsEveMagField : public TEveMagField
@@ -189,9 +195,10 @@ FWFFLooper::attachTo(edm::ActivityRegistry &ar)
 {
    m_pathsGUI = new FWPathsPopup(this, guiManager());
 
-   ar.watchPostProcessEvent(m_pathsGUI, &FWPathsPopup::postProcessEvent);
-   ar.watchPostModule(m_pathsGUI, &FWPathsPopup::postModule);
-   ar.watchPreModule(m_pathsGUI, &FWPathsPopup::preModule);
+   // ar.watchPostEvent(m_pathsGUI, &FWPathsPopup::postEvent);
+
+   ar.watchPostModuleEvent(m_pathsGUI, &FWPathsPopup::postModuleEvent);
+   ar.watchPreModuleEvent(m_pathsGUI, &FWPathsPopup::preModuleEvent);
    ar.watchPostEndJob(this, &FWFFLooper::postEndJob);
 }
 
@@ -232,8 +239,8 @@ FWFFLooper::startingNewLoop(unsigned int count)
 void 
 FWFFLooper::postEndJob()
 {
-//   printf("FWFFLooper::postEndJob\n");
-//   TEveManager::Terminate();
+   printf("FWFFLooper::postEndJob\n");
+   TEveManager::Terminate();
 }
 
 void
@@ -386,6 +393,11 @@ FWFFLooper::duringLoop(const edm::Event &event,
       m_geomWatcher.check(es);
    } catch (...) {}
    
+
+   m_pathsGUI->setEvent(&event);
+   // AMT Should this call should be done through ServiceRegistry ?
+   edm::StreamContext* x = 0;
+   m_pathsGUI->postEvent(*x);
 
    m_isLastEvent = controller.forwardState() == edm::ProcessingController::kAtLastEvent;
    m_isFirstEvent = controller.reverseState() == edm::ProcessingController::kAtFirstEvent;

--- a/Fireworks/FWInterface/src/FWFFLooper.cc
+++ b/Fireworks/FWInterface/src/FWFFLooper.cc
@@ -195,8 +195,6 @@ FWFFLooper::attachTo(edm::ActivityRegistry &ar)
 {
    m_pathsGUI = new FWPathsPopup(this, guiManager());
 
-   // ar.watchPostEvent(m_pathsGUI, &FWPathsPopup::postEvent);
-
    ar.watchPostModuleEvent(m_pathsGUI, &FWPathsPopup::postModuleEvent);
    ar.watchPreModuleEvent(m_pathsGUI, &FWPathsPopup::preModuleEvent);
    ar.watchPostEndJob(this, &FWFFLooper::postEndJob);
@@ -394,10 +392,7 @@ FWFFLooper::duringLoop(const edm::Event &event,
    } catch (...) {}
    
 
-   m_pathsGUI->setEvent(&event);
-   // AMT Should this call should be done through ServiceRegistry ?
-   edm::StreamContext* x = 0;
-   m_pathsGUI->postEvent(*x);
+   m_pathsGUI->postEvent(event);
 
    m_isLastEvent = controller.forwardState() == edm::ProcessingController::kAtLastEvent;
    m_isFirstEvent = controller.reverseState() == edm::ProcessingController::kAtFirstEvent;

--- a/Fireworks/FWInterface/src/FWPathsPopup.cc
+++ b/Fireworks/FWInterface/src/FWPathsPopup.cc
@@ -39,7 +39,6 @@ FWPathsPopup::windowIsClosing()
 FWPathsPopup::FWPathsPopup(FWFFLooper *looper, FWGUIManager *guiManager)
    : TGMainFrame(gClient->GetRoot(), 400, 600),
      m_info(0),
-     m_event(0),
      m_looper(looper),
      m_hasChanges(false),
      m_moduleLabel(0),
@@ -86,13 +85,6 @@ FWPathsPopup::FWPathsPopup(FWFFLooper *looper, FWGUIManager *guiManager)
    editor->UnmapWindow();
 
    Layout();
-}
-
-
-void
-FWPathsPopup::setEvent(const edm::Event* x)
-{
-   m_event= x;
 }
 
 
@@ -189,7 +181,7 @@ FWPathsPopup::preModuleEvent(edm::StreamContext const &s, edm::ModuleCallingCont
 
 
 void
-FWPathsPopup::postEvent(edm::StreamContext const&)
+FWPathsPopup::postEvent(edm::Event const &event)
 {
    m_guiManager->updateStatus("Done processing.");
    gSystem->ProcessEvents();
@@ -197,23 +189,23 @@ FWPathsPopup::postEvent(edm::StreamContext const&)
    // Get the last process name from the process history:
    // this should be the one specified in the cfg file
  
-   if (m_event->processHistory().empty()) {
+   if (event.processHistory().empty()) {
       fwLog(fwlog::kInfo) << "Path GUI:: no process history available.\n";
       return;
    }
-   edm::ProcessHistory::const_iterator pi = m_event->processHistory().end() - 1;
+   edm::ProcessHistory::const_iterator pi = event.processHistory().end() - 1;
    std::string processName = pi->processName();
    
    // It's called TriggerResults but actually contains info on all paths
    edm::InputTag tag("TriggerResults", "", processName);
    edm::Handle<edm::TriggerResults> triggerResults;
-   m_event->getByLabel(tag, triggerResults);
+   event.getByLabel(tag, triggerResults);
 
    std::vector<FWPSetTableManager::PathUpdate> pathUpdates;
 
    if (triggerResults.isValid())
    {
-      edm::TriggerNames triggerNames = m_event->triggerNames(*triggerResults);
+      edm::TriggerNames triggerNames = event.triggerNames(*triggerResults);
      
       for (size_t i = 0, e = triggerResults->size(); i != e; ++i)
       {

--- a/Fireworks/FWInterface/src/FWPathsPopup.h
+++ b/Fireworks/FWInterface/src/FWPathsPopup.h
@@ -30,7 +30,7 @@ class FWPathsPopup : public TGMainFrame
 public:
    FWPathsPopup(FWFFLooper *, FWGUIManager *);
 
-   void postEvent(edm::StreamContext const&);
+   void postEvent(edm::Event const &event);
    void postModuleEvent(edm::StreamContext const&, edm::ModuleCallingContext const&);
    void preModuleEvent(edm::StreamContext const&, edm::ModuleCallingContext const&);
    void scheduleReloadEvent();
@@ -43,12 +43,8 @@ public:
 
    virtual Bool_t HandleKey(Event_t* event);
 
-   void setEvent(const edm::Event* x);
-
 private:
    const edm::ScheduleInfo  *m_info;
-
-   const edm::Event         *m_event;
 
 #ifndef __CINT__
    FWFFLooper               *m_looper;

--- a/Fireworks/FWInterface/src/FWPathsPopup.h
+++ b/Fireworks/FWInterface/src/FWPathsPopup.h
@@ -10,6 +10,8 @@ namespace edm
    class ModuleDescription;
    class Event;
    class EventSetup;
+   class StreamContext;
+   class ModuleCallingContext;
 }
 
 class FWFFLooper;
@@ -28,9 +30,9 @@ class FWPathsPopup : public TGMainFrame
 public:
    FWPathsPopup(FWFFLooper *, FWGUIManager *);
 
-   void postProcessEvent(edm::Event const&, edm::EventSetup const&);
-   void postModule(edm::ModuleDescription const&);
-   void preModule(edm::ModuleDescription const &);
+   void postEvent(edm::StreamContext const&);
+   void postModuleEvent(edm::StreamContext const&, edm::ModuleCallingContext const&);
+   void preModuleEvent(edm::StreamContext const&, edm::ModuleCallingContext const&);
    void scheduleReloadEvent();
    bool &hasChanges() { return m_hasChanges; }
    void setup(const edm::ScheduleInfo *info);
@@ -41,8 +43,12 @@ public:
 
    virtual Bool_t HandleKey(Event_t* event);
 
+   void setEvent(const edm::Event* x);
+
 private:
    const edm::ScheduleInfo  *m_info;
+
+   const edm::Event         *m_event;
 
 #ifndef __CINT__
    FWFFLooper               *m_looper;
@@ -57,6 +63,7 @@ private:
    FWTableWidget            *m_tableWidget;
    TGTextEntry              *m_search;
    FWGUIManager             *m_guiManager;
+   
 
    ClassDef(FWPathsPopup, 0);
 };

--- a/Fireworks/Geometry/plugins/EveDisplayPlugin.cc
+++ b/Fireworks/Geometry/plugins/EveDisplayPlugin.cc
@@ -15,6 +15,12 @@
 //         Created:  Wed Sep 26 08:27:23 EDT 2007
 //
 //
+#define private public // workaround for bug in 5.34.18
+#include "TROOT.h"
+#include "TSystem.h"
+#include "TColor.h"
+#include "TStyle.h"
+#include "TEnv.h"
 
 // system include files
 #include <memory>
@@ -91,6 +97,18 @@ EveDisplayPlugin::run(const edm::EventSetup& iSetup)
    ESHandle<TGeoManager> geom;
    iSetup.get<DisplayGeomRecord>().get(geom);
 
+
+
+// AMT workaround for an agressive clenup in 5.43.18
+#if ROOT_VERSION_CODE >= ROOT_VERSION(5,34,18)
+   if (!gStyle) {
+      TColor::fgInitDone=false;
+      TColor::InitializeColors();
+      TStyle::BuildStyles();
+      gROOT->SetStyle(gEnv->GetValue("Canvas.Style", "Modern"));
+      gStyle = gROOT->GetStyle("Classic");
+   }
+#endif
 
    TEveManager::Create();
 


### PR DESCRIPTION
In root 5.34.18 gStyle has been auto-destructed due to aggressive clean-up in ~TApplication. This change contains a workaround for  this problem.

ServiceRegistry interface has been changed and this PR also contains adaptation to it.
