### PR TITLE
Allow inheritance check for non-class types

### DIFF
--- a/FWCore/Utilities/src/TypeWithDict.cc
+++ b/FWCore/Utilities/src/TypeWithDict.cc
@@ -652,10 +652,7 @@ namespace edm {
   bool
   TypeWithDict::hasBase(std::string const& basename) const {
     if (class_ == nullptr) {
-      throw Exception(errors::LogicError)
-        << "Function TypeWithDict::hasBase(std::string const&), type\n"
-        << name()
-        << "\nis not a class\n";
+      return false;
     }
     TClass* cl = class_->GetBaseClass(basename.c_str());
     if (cl != nullptr) {
@@ -667,16 +664,10 @@ namespace edm {
   bool
   TypeWithDict::hasBase(TypeWithDict const& basety) const {
     if (class_ == nullptr) {
-      throw Exception(errors::LogicError)
-        << "Function TypeWithDict::hasBase(TypeWithDict const&), type\n"
-        << name()
-        << "\nis not a class\n";
+      return false;
     }
     if (basety.class_ == nullptr) {
-      throw Exception(errors::LogicError)
-        << "Function TypeWithDict::hasBase(TypeWithDict const&), base type\n"
-        << name()
-        << "\nis not a class\n";
+      return false;
     }
     TClass* cl = class_->GetBaseClass(basety.name().c_str());
     if (cl != nullptr) {


### PR DESCRIPTION
The TypeWithDict class (our replacement for Reflex::Type) has checks to see if one type inherits from another type.  Currently, these checks will throw an exception if one or both of the types in question is not a class.  The check should be more general.  This pull request changes the check for inheritance to simply return false if one or both of the types is not a class.
Please merge promptly unless there are issues.
