### PR TITLE
Avoid dereference of null TClass pointer

### DIFF
--- a/CondCore/ORA/src/RflxPropList.h
+++ b/CondCore/ORA/src/RflxPropList.h
@@ -15,8 +15,11 @@ namespace Reflex {
           PropertyList(const edm::TypeWithDict   &dict) { 
               m_wp = dict.getClass()->GetAttributeMap();
           }
-          PropertyList(const edm::MemberWithDict &dict) { 
-              m_wp = dict.typeOf().getClass()->GetAttributeMap();
+          PropertyList(const edm::MemberWithDict &dict) : m_wp(0) {
+              TClass* cl = dict.typeOf().getClass();
+              if(cl) {
+                m_wp = cl->GetAttributeMap();
+              }
           }
 
           PropertyList() : m_wp(0) { /* NOOP */ }


### PR DESCRIPTION
This pull request simply avoids a segfault if the property list is checked for a non-class data type.
This is a ROOT6 specific trivial bug fix.
Please merge promptly unless there are issues.
