### PR TITLE
Changed HcalRecHitsAnalyzer to thread_unsafe since it uses HcalChannelQuality

### DIFF
--- a/DQMOffline/Hcal/interface/HcalRecHitsAnalyzer.h
+++ b/DQMOffline/Hcal/interface/HcalRecHitsAnalyzer.h
@@ -53,13 +53,11 @@
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgo.h"
 
 
-class HcalRecHitsAnalyzer : public DQMEDAnalyzer {
+class HcalRecHitsAnalyzer : public thread_unsafe::DQMEDAnalyzer {
  public:
   HcalRecHitsAnalyzer(edm::ParameterSet const& conf);
-  ~HcalRecHitsAnalyzer();
-  virtual void analyze(edm::Event const& ev, edm::EventSetup const& c);
-  virtual void beginJob() ;
-  virtual void endJob() ;
+
+  virtual void analyze(edm::Event const& ev, edm::EventSetup const& c) override;
   virtual void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
  private:
   

--- a/DQMOffline/Hcal/src/HcalRecHitsAnalyzer.cc
+++ b/DQMOffline/Hcal/src/HcalRecHitsAnalyzer.cc
@@ -609,13 +609,6 @@ HcalRecHitsAnalyzer::HcalRecHitsAnalyzer(edm::ParameterSet const& conf) {
 }
 
 
-HcalRecHitsAnalyzer::~HcalRecHitsAnalyzer() { }
-
-void HcalRecHitsAnalyzer::endJob() { }
-
-
-void HcalRecHitsAnalyzer::beginJob(){ }
-
 void HcalRecHitsAnalyzer::analyze(edm::Event const& ev, edm::EventSetup const& c) {
 
   using namespace edm;


### PR DESCRIPTION
Changed HcalRecHitsAnalyzer to inherit from thread_unsafe::DQMEDAnalyzer.
This was needed since the module used HcalChannelQuality with is a thread
unsafe EventSetup product.
This was found by the static analyzer.
