### PR TITLE
Removing EE FEDs for RAW2DIGI process in Shashlik geometry

### DIFF
--- a/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
@@ -124,6 +124,25 @@ def cust_2023SHCal(process):
             )
             )
         
+    if hasattr(process,'raw2digi_step'):
+        process.ecalDigis.FEDs = cms.vint32(
+            # EE-:
+            #601, 602, 603, 604, 605,
+            #606, 607, 608, 609,
+            # EB-:
+            610, 611, 612, 613, 614, 615,
+            616, 617, 618, 619, 620, 621,
+            622, 623, 624, 625, 626, 627,
+            # EB+:
+            628, 629, 630, 631, 632, 633,
+            634, 635, 636, 637, 638, 639,
+            640, 641, 642, 643, 644, 645,
+            # EE+:
+            #646, 647, 648, 649, 650,
+            #651, 652, 653, 654
+            )
+        print "RAW2DIGI only for EB FEDs"
+
     if hasattr(process,'reconstruction_step'):
     	process.ecalRecHit.EEuncalibRecHitCollection = cms.InputTag("","")
         #remove the old EE pfrechit producer


### PR DESCRIPTION
Fixing crashes in reconstruction for Shashlik geometry.
I don't understand why it happens only for few events, but running on the entire file:
 root://cmsxrootd-site.fnal.gov//store/relval/CMSSW_6_2_0_SLHC14/RelValSingleGammaPt35/GEN-SIM-DIGI-RAW/DES23_62_V1_UPG2023SHNoTaper-v1/00000/94D0E325-20F5-E311-9DF5-0026189438F5.root
there was not crash any more removing the RAW2DIGI process for EE FEDs

@boudoul @davidlange6 @kknb1056 
