### PR TITLE
Fix clang compiler errors and warnings in DQMServices/Core

### DIFF
--- a/DQMServices/Core/interface/Standalone.h
+++ b/DQMServices/Core/interface/Standalone.h
@@ -18,8 +18,9 @@ namespace edm
   std::string getReleaseVersion(void)
   { return "CMSSW_STANDALONE"; }
 
-  struct ParameterSet
+  class ParameterSet
   {
+    public:
     template <class T> static const T &
     getUntrackedParameter(const char * /* key */, const T &value)
     { return value; }
@@ -30,8 +31,9 @@ namespace edm
     ServiceToken(int) {}
   };
 
-  struct ServiceRegistry
+  class ServiceRegistry
   {
+  public:
     struct Operate
     {
       Operate(const ServiceToken &) {}
@@ -41,8 +43,9 @@ namespace edm
   };
 
   template <class T>
-  struct Service
+  class  Service
   {
+  public:
     bool isAvailable(void) { return false; }
     T *operator->(void)
     {
@@ -62,8 +65,9 @@ namespace edm
     void connect( T&& ) {};
   };
 
-  struct ActivityRegistry
+  class ActivityRegistry
   {
+  public:
     template <typename T>
     void watchPostSourceRun(void*, T) {}
 
@@ -74,8 +78,9 @@ namespace edm
   };
   
   
-  struct JobReport
+  class JobReport
   {
+  public:
     JobReport(const edm::ParameterSet &) {}
     void reportAnalysisFile(const std::string &, const std::map<std::string, std::string> &) {}
   };

--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -784,7 +784,7 @@ DQMStore::book(const std::string &dir, const std::string &name,
     refdir += '/';
     refdir += dir;
 
-    if (MonitorElement *refme = findObject(refdir, name))
+    if (findObject(refdir, name))
     {
       me->data_.flags |= DQMNet::DQM_PROP_HAS_REFERENCE;
     }


### PR DESCRIPTION
clang was failing to compile becuase of unused variable errors in
DQMStore. Also fixed warnings about forward declarations not being
the same type as struct/class declarations.
