### PR TITLE
DD Read Only View

### DIFF
--- a/DetectorDescription/Core/interface/DDCompactView.h
+++ b/DetectorDescription/Core/interface/DDCompactView.h
@@ -158,11 +158,9 @@ public:
 
   void lockdown();
   
- protected:
-  DDCompactViewImpl* rep_;
-
  private:
-  DDPosData* worldpos_ ;
+  std::unique_ptr<DDCompactViewImpl> rep_;
+  std::unique_ptr<DDPosData> worldpos_ ;
   
     // 2010-01-27 memory patch
     // for copying and protecting DD Store's after parsing is complete.

--- a/DetectorDescription/Core/interface/DDCompactView.h
+++ b/DetectorDescription/Core/interface/DDCompactView.h
@@ -111,6 +111,9 @@ public:
 
   //! returns the DDLogicalPart representing the root of the geometrical hierarchy
   const DDLogicalPart & root() const;
+  
+  //! The absolute position of the world
+  DDPosData * worldPosition() const;
 
   //! Prototype version of calculating the weight of a detector component
   double weight(const DDLogicalPart & p) const;
@@ -159,6 +162,8 @@ public:
   DDCompactViewImpl* rep_;
 
  private:
+  DDPosData* worldpos_ ;
+  
     // 2010-01-27 memory patch
     // for copying and protecting DD Store's after parsing is complete.
     DDI::Store<DDName, DDI::Material*> matStore_;

--- a/DetectorDescription/Core/interface/DDExpandedView.h
+++ b/DetectorDescription/Core/interface/DDExpandedView.h
@@ -135,7 +135,6 @@ protected:
   unsigned int depth_; //!< depth of the scope, 0==unrestricted depth
   DDPosData * worldpos_ ; //!< ???
   std::vector<nav_type> nextBStack_;
-  //std::map<std::string,std::string> dummySpecifics_;    
 };
 
 std::ostream & printNavType(std::ostream &, int const * n, size_t sz);

--- a/DetectorDescription/Core/src/DDCompactView.cc
+++ b/DetectorDescription/Core/src/DDCompactView.cc
@@ -15,8 +15,6 @@
 
 #include <iostream>
 
-//DDCompactViewmpl * DDCompactView::global_ = 0;
-
 /** 
    Compact-views can be created only after an appropriate geometrical hierarchy
    has been defined using DDpos(). 
@@ -45,13 +43,13 @@ DDCompactView::DDCompactView(const DDLogicalPart & rootnodedata)
   DDLogicalPart::StoreT::instance().setReadOnly(false);
   DDSpecifics::StoreT::instance().setReadOnly(false);
   DDRotation::StoreT::instance().setReadOnly(false);
+  worldpos_ = new DDPosData( DDTranslation(), DDRotation(), 0 );
 }
 
 DDCompactView::~DDCompactView() 
 {  
-  if (rep_ != 0) {
-    delete rep_;
-  }
+  delete rep_;
+  delete worldpos_;
 }
 
 /** 
@@ -70,10 +68,14 @@ DDCompactView::graph_type & DDCompactView::writeableGraph()
 }
 
 const DDLogicalPart & DDCompactView::root() const
-{ 
+{
   return rep_->root(); 
 } 
-
+  
+DDPosData* DDCompactView::worldPosition() const
+{
+  return worldpos_;
+}
 
 DDCompactView::walker_type DDCompactView::walker() const
 {

--- a/DetectorDescription/Core/src/DDCompactView.cc
+++ b/DetectorDescription/Core/src/DDCompactView.cc
@@ -44,7 +44,6 @@ DDCompactView::DDCompactView(const DDLogicalPart & rootnodedata)
   DDLogicalPart::StoreT::instance().setReadOnly(false);
   DDSpecifics::StoreT::instance().setReadOnly(false);
   DDRotation::StoreT::instance().setReadOnly(false);
-  //worldpos_ = new DDPosData( DDTranslation(), DDRotation(), 0 );
 }
 
 DDCompactView::~DDCompactView() 
@@ -166,7 +165,10 @@ void DDCompactView::swap( DDCompactView& repToSwap ) {
   rep_->swap ( *(repToSwap.rep_) );
 }
 
-DDCompactView::DDCompactView() : rep_(new DDCompactViewImpl) { }
+DDCompactView::DDCompactView()
+  : rep_(new DDCompactViewImpl),
+    worldpos_( new DDPosData( DDTranslation(), DDRotation(), 0 ))
+{ }
 
 void DDCompactView::lockdown() {
   // at this point we should have a valid store of DDObjects and we will move these

--- a/DetectorDescription/Core/src/DDCompactView.cc
+++ b/DetectorDescription/Core/src/DDCompactView.cc
@@ -33,7 +33,8 @@
 */    
 // 
 DDCompactView::DDCompactView(const DDLogicalPart & rootnodedata)
-  : rep_(new DDCompactViewImpl(rootnodedata))
+  : rep_( new DDCompactViewImpl( rootnodedata )),
+    worldpos_( new DDPosData( DDTranslation(), DDRotation(), 0 ))
 {
   // 2010-01-27 I am leaving this here so that we are sure the global stores
   // are open when a new DDCompactView is being made.  Eventually I want to
@@ -43,14 +44,11 @@ DDCompactView::DDCompactView(const DDLogicalPart & rootnodedata)
   DDLogicalPart::StoreT::instance().setReadOnly(false);
   DDSpecifics::StoreT::instance().setReadOnly(false);
   DDRotation::StoreT::instance().setReadOnly(false);
-  worldpos_ = new DDPosData( DDTranslation(), DDRotation(), 0 );
+  //worldpos_ = new DDPosData( DDTranslation(), DDRotation(), 0 );
 }
 
 DDCompactView::~DDCompactView() 
-{  
-  delete rep_;
-  delete worldpos_;
-}
+{}
 
 /** 
    The compact-view is kept in an acyclic directed multigraph represented
@@ -74,7 +72,7 @@ const DDLogicalPart & DDCompactView::root() const
   
 DDPosData* DDCompactView::worldPosition() const
 {
-  return worldpos_;
+  return worldpos_.get();
 }
 
 DDCompactView::walker_type DDCompactView::walker() const

--- a/DetectorDescription/Core/src/DDCompactViewImpl.cc
+++ b/DetectorDescription/Core/src/DDCompactViewImpl.cc
@@ -33,8 +33,7 @@ DDCompactViewImpl::~DDCompactViewImpl()
 
 graphwalker<DDLogicalPart,DDPosData*> DDCompactViewImpl::walker() const
 {
-   DCOUT('C',"DDCompactView::walker() root_=" << root_);
-   return graphwalker<DDLogicalPart,DDPosData*>(graph_,root_);
+  return graphwalker<DDLogicalPart,DDPosData*>(graph_,root_);
 }
 
 // calculates the weight and caches it in LogicalPartImpl

--- a/DetectorDescription/Core/src/DDExpandedNode.cc
+++ b/DetectorDescription/Core/src/DDExpandedNode.cc
@@ -22,7 +22,8 @@ bool DDExpandedNode::operator==(const DDExpandedNode & n) const {
 
      
 int DDExpandedNode::copyno() const 
-{ 
+{
+  assert( posd_ );
   return posd_->copyno_; 
 }
 


### PR DESCRIPTION
- Move position of the "real" root node of the graph to compact view. 
- It is initialized at construction time in EventSetup.
- Expanded view uses a read-only access to StoreT::instances
