### PR TITLE
Fix for condtions DB V2

### DIFF
--- a/CondFormats/PhysicsToolsObjects/src/MVAComputer.cc
+++ b/CondFormats/PhysicsToolsObjects/src/MVAComputer.cc
@@ -129,7 +129,7 @@ void MVAComputer::addProcessor(const VarProcessor* proc)
       << std::endl;
   }
   edm::TypeWithDict refType(type, kIsConstant | kIsReference);
-  edm::FunctionWithDict func = type.functionMemberByName(type.name(), refType.name(), false);
+  edm::FunctionWithDict func = type.functionMemberByName(type.unscopedName(), refType.qualifiedName(), false);
   if (!func) {
     throw cms::Exception("MVAComputerCalibration")
       << "Calibration class "


### PR DESCRIPTION
This is a fix for the ROOT 6 specific bug that caused many fatal relval errors using V2 of the configuration database.  The ROOT function TClass::GetMethodWithPrototype() requires its "name" argument to be unscoped, and its "prototype" argument to be fully qualified and scoped.
Please merge this fix promptly.
This pull request does not affect which version of the Conditions DB is used.
