### PR TITLE
Added forgotten NeutronKiller process, cleanup comments

### DIFF
--- a/SimG4Core/Physics/interface/G4ProcessTypeEnumerator.h
+++ b/SimG4Core/Physics/interface/G4ProcessTypeEnumerator.h
@@ -25,6 +25,8 @@ public:
 
   std::string processG4Name(int);
 
+  int processId(const std::string& name);
+
 };
 #endif 
 

--- a/SimG4Core/Physics/src/G4ProcessTypeEnumerator.cc
+++ b/SimG4Core/Physics/src/G4ProcessTypeEnumerator.cc
@@ -1,6 +1,6 @@
 #include "SimG4Core/Physics/interface/G4ProcessTypeEnumerator.h"
 
-static const int nprocesses = 46;
+static const int nprocesses = 47;
 static const std::string g4processes[nprocesses] = { 
   "Transportation",  "CoupleTrans",  "CoulombScat",  "Ionisation",  "Brems",
   "PairProdCharged",  "Annih",  "AnnihToMuMu",  "AnnihToHad",  "NuclearStopp",
@@ -8,17 +8,59 @@ static const std::string g4processes[nprocesses] = {
   "ConvToMuMu",  "Cerenkov",  "Scintillation",  "SynchRad",  "TransRad",
   "OpAbsorp",  "OpBoundary",  "OpRayleigh",  "OpWLS",  "OpMieHG",
   "DNAElastic",  "DNAExcit",  "DNAIonisation",  "DNAVibExcit",  "DNAAttachment",
-  "DNAChargeDec",  "DNAChargeInc",  "HadElastic",  "HadInElastic",  "HadCaptue",
+  "DNAChargeDec",  "DNAChargeInc",  "HadElastic",  "HadInelastic",  "HadCapture",
   "HadFission",  "HadAtRest",  "HadCEX",  "Decay",  "DecayWSpin",
   "DecayPiWSpin",  "DecayRadio",  "DecayUnKnown",  "DecayExt",  "StepLimiter",
-  "UsrSpecCuts" }; 
+  "UsrSpecCuts", "NeutronKiller"}; 
 static const int g4subtype[nprocesses] = { 
-  91,  92,  1,  2,  3,  4,  5,  6,  7,  8,
-  10,  11,  12,  13,  14,  15,  21,  22,  23,  24,
-  31,  32,  33,  34,  35,  51,  52,  53,  54,  55,
-  56,  57,  111,  121,  131,  141,  151,  161,  201,  202,
-  203,  210,  211,  231,  401,  402 }; 
-
+  91,  // Transportation
+  92,  // CoupleTrans
+  1,   // CoulombScat
+  2,   // Ionisation
+  3,   // Brems
+  4,   // PairProdCharged
+  5,   // Annih
+  6,   // AnnihToMuMu
+  7,   // AnnihToHad
+  8,   // NuclearStopp
+  10,  // Msc
+  11,  //
+  12,  // PhotoElectric
+  13,  // Compton
+  14,  // Conv
+  15,  // ConvToMuMu
+  21,  
+  22,  
+  23,  
+  24,
+  31,  
+  32,  
+  33,  
+  34,  
+  35,  
+  51,  
+  52,  
+  53,  
+  54,  
+  55,
+  56,  
+  57,  
+  111, // HadElastic 
+  121, // HadInelastic
+  131, // HadCapture 
+  141, // HadFission
+  151, // HadAtRest 
+  161,  
+  201, // Decay 
+  202, // DecayWSpin
+  203, // DecayPiWSpin
+  210, // DecayRadio
+  211, // DecayUnKnown
+  231, // DecayExt
+  401, // StepLimiter
+  402,
+  403  // NeutronKiller
+}; 
 
 G4ProcessTypeEnumerator::G4ProcessTypeEnumerator()
 {}
@@ -38,3 +80,14 @@ std::string G4ProcessTypeEnumerator::processG4Name(int idx)
   return res;
 }
 
+int G4ProcessTypeEnumerator::processId(const std::string& name)
+{
+  int idx = 0;
+  for(int i=0; i<nprocesses; ++i) {
+    if(name == g4processes[i]) {
+      idx = g4subtype[i];
+      break;
+    }
+  }
+  return idx;
+}


### PR DESCRIPTION
Added extra method to access Geant4 process ID. Added forgotten NeutronKiller process to the list of known processes. Clean-up comments.

Back-ported already integrated into 7_2_X PR 4477.
