### PR TITLE
import radiativeZ filter

### DIFF
--- a/GeneratorInterface/GenFilters/interface/ZgammaMassFilter.h
+++ b/GeneratorInterface/GenFilters/interface/ZgammaMassFilter.h
@@ -1,0 +1,68 @@
+#ifndef ZgammaMassFilter_h
+#define ZgammaMassFilter_h
+// -*- C++ -*-
+//
+// Package:    ZgammaMassFilter
+// Class:      ZgammaMassFilter
+// 
+/* 
+
+ Description: filter events based on the Pythia particle information
+
+ Implementation: inherits from generic EDFilter
+     
+*/
+//
+// Original Author:  Alexey Ferapontov
+//         Created:  Thu July 26 11:57:54 CDT 2012
+// $Id: ZgammaMassFilter.h,v 1.1 2012/08/10 12:46:29 lenzip Exp $
+//
+//
+
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDFilter.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+
+//
+// class decleration
+//
+
+class ZgammaMassFilter : public edm::EDFilter {
+   public:
+      explicit ZgammaMassFilter(const edm::ParameterSet&);
+      ~ZgammaMassFilter();
+
+
+      virtual bool filter(edm::Event&, const edm::EventSetup&);
+   private:
+      // ----------memeber function----------------------
+       int charge(const int& Id);
+
+      // ----------member data ---------------------------
+      
+       std::string label_;
+
+       double minPhotonPt;
+       double minLeptonPt;
+
+       double minPhotonEta;
+       double minLeptonEta;
+
+       double maxPhotonEta;
+       double maxLeptonEta;
+
+       double minDileptonMass;
+       double minZgMass;
+
+};
+#endif

--- a/GeneratorInterface/GenFilters/python/ZgammaFilter_cfi.py
+++ b/GeneratorInterface/GenFilters/python/ZgammaFilter_cfi.py
@@ -1,0 +1,24 @@
+import FWCore.ParameterSet.Config as cms
+
+# values tuned also according to slide 3 of :
+# https://indico.cern.ch/getFile.py/access?contribId=23&sessionId=2&resId=0&materialId=slides&confId=271548
+# selection efficiency of approx 6% for ZMM_8TeV
+
+myZgammaFilter = cms.EDFilter('ZgammaMassFilter',
+
+  HepMCProduct             = cms.string("generator"),
+
+  minPhotonPt              = cms.double(7.),
+  minLeptonPt              = cms.double(7.),
+
+  minPhotonEta             = cms.double(-3),
+  minLeptonEta             = cms.double(-3),
+
+  maxPhotonEta             = cms.double(3),
+  maxLeptonEta             = cms.double(3),
+
+  minDileptonMass          = cms.double(30.),
+  minZgMass                = cms.double(40.)
+ )
+
+ZgammaFilter = cms.Sequence( myZgammaFilter )

--- a/GeneratorInterface/GenFilters/src/SealModule.cc
+++ b/GeneratorInterface/GenFilters/src/SealModule.cc
@@ -14,7 +14,6 @@
 #include "GeneratorInterface/GenFilters/interface/MCDijetResonance.h"
 #include "GeneratorInterface/GenFilters/interface/MCProcessFilter.h"
 #include "GeneratorInterface/GenFilters/interface/MCProcessRangeFilter.h"
-#include "GeneratorInterface/GenFilters/interface/MCPdgIndexFilter.h"
 #include "GeneratorInterface/GenFilters/interface/MCSingleParticleFilter.h"
 #include "GeneratorInterface/GenFilters/interface/MCSmartSingleParticleFilter.h"
 #include "GeneratorInterface/GenFilters/interface/MCZll.h"
@@ -42,6 +41,7 @@
 #include "GeneratorInterface/GenFilters/interface/LHEDYdecayFilter.h"
 #include "GeneratorInterface/GenFilters/interface/Zto2lFilter.h"
 #include "GeneratorInterface/GenFilters/interface/ZgMassFilter.h"
+#include "GeneratorInterface/GenFilters/interface/ZgammaMassFilter.h"
 
 
   using cms::BHFilter;
@@ -60,7 +60,6 @@
   DEFINE_FWK_MODULE(MCDijetResonance);
   DEFINE_FWK_MODULE(MCProcessFilter);
   DEFINE_FWK_MODULE(MCProcessRangeFilter);
-  DEFINE_FWK_MODULE(MCPdgIndexFilter);
   DEFINE_FWK_MODULE(MCSingleParticleFilter);
   DEFINE_FWK_MODULE(MCSmartSingleParticleFilter);
   DEFINE_FWK_MODULE(MCZll);
@@ -87,3 +86,4 @@
   DEFINE_FWK_MODULE(LHEDYdecayFilter);
   DEFINE_FWK_MODULE(Zto2lFilter);
   DEFINE_FWK_MODULE(ZgMassFilter);
+  DEFINE_FWK_MODULE(ZgammaMassFilter);

--- a/GeneratorInterface/GenFilters/src/ZgammaMassFilter.cc
+++ b/GeneratorInterface/GenFilters/src/ZgammaMassFilter.cc
@@ -1,0 +1,118 @@
+#include "GeneratorInterface/GenFilters/interface/ZgammaMassFilter.h"
+#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
+#include <iostream>
+#include "TLorentzVector.h"
+
+// order std::vector of TLorentzVector elements
+class orderByPt {
+public:
+  bool operator()(TLorentzVector const & a, TLorentzVector  const & b) {
+    if (a.Pt()  == b.Pt()  ) {
+      return a.Pt() < b.Pt();
+    } else {
+      return a.Pt()  > b.Pt() ;
+    }
+  }
+};
+
+
+using namespace edm;
+using namespace std;
+
+ZgammaMassFilter::ZgammaMassFilter(const edm::ParameterSet& iConfig)
+{
+  label_          =iConfig.getParameter<string>("HepMCProduct");
+  minPhotonPt     =iConfig.getParameter<double>("minPhotonPt");
+  minLeptonPt     =iConfig.getParameter<double>("minLeptonPt");
+  minPhotonEta    =iConfig.getParameter<double>("minPhotonEta");
+  minLeptonEta    =iConfig.getParameter<double>("minLeptonEta");
+  maxPhotonEta    =iConfig.getParameter<double>("maxPhotonEta");
+  maxLeptonEta    =iConfig.getParameter<double>("maxLeptonEta");
+  minDileptonMass =iConfig.getParameter<double>("minDileptonMass");
+  minZgMass       =iConfig.getParameter<double>("minZgMass");
+}
+
+ZgammaMassFilter::~ZgammaMassFilter()
+{
+}
+
+// ------------ method called to skim the data  ------------
+bool ZgammaMassFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+  using namespace edm;
+  
+  bool accepted = false;
+  Handle<HepMCProduct> evt;
+  iEvent.getByLabel(label_, evt);
+  const HepMC::GenEvent * myGenEvent = evt->GetEvent();
+  
+  vector<TLorentzVector> Lepton; Lepton.clear();
+  vector<TLorentzVector> Photon; Photon.clear();   
+  vector<float> Charge; Charge.clear();
+  
+  for ( HepMC::GenEvent::particle_const_iterator p = myGenEvent->particles_begin();
+	p != myGenEvent->particles_end(); ++p ) 
+    {
+      if ((*p)->status() == 1 && (abs((*p)->pdg_id()) == 11 || abs((*p)->pdg_id()) == 13 || abs((*p)->pdg_id()) == 15)) { 
+	TLorentzVector LeptP((*p)->momentum().px(), (*p)->momentum().py(), (*p)->momentum().pz(), (*p)->momentum().e()); 
+	if (LeptP.Pt() > minLeptonPt) { 
+	  Lepton.push_back(LeptP);
+	} // if pt
+      }// if lepton       
+      
+      if ( abs((*p)->pdg_id()) == 22 && (*p)->status() == 1) {
+      TLorentzVector PhotP((*p)->momentum().px(), (*p)->momentum().py(), (*p)->momentum().pz(), (*p)->momentum().e()); 
+      if (PhotP.Pt() > minPhotonPt) {
+      Photon.push_back(PhotP);
+      }// if pt
+     }// if photon
+
+    }// loop over particles  
+  
+  
+  // std::cout << "\n" << "Photon size: " << Photon.size() << std::endl;
+  // for (unsigned int u=0; u<Photon.size(); u++){
+  //   std::cout << "BEF photon PT: " << Photon[u].Pt() << std::endl;
+  // }
+  // std::cout << "\n" << "Lepton size: " << Lepton.size() << std::endl;
+  // for (unsigned int u=0; u<Lepton.size(); u++){
+  //   std::cout << "BEF lepton PT: " << Lepton[u].Pt() << std::endl;
+  // }
+
+  // order Lepton and Photon according to Pt
+  std::stable_sort(Photon.begin(), Photon.end(), orderByPt());
+  std::stable_sort(Lepton.begin(), Lepton.end(), orderByPt());
+
+  //  std::cout << "\n" << std::endl;
+  //  std::cout << "\n" << "Photon size: " << Photon.size() << std::endl;
+  //  for (unsigned int u=0; u<Photon.size(); u++){
+  //    std::cout << "AFT photon PT: " << Photon[u].Pt() << std::endl;
+  //  }
+  //  std::cout << "\n" << "Lepton size: " << Lepton.size() << std::endl;
+  //  for (unsigned int u=0; u<Lepton.size(); u++){
+  //    std::cout << "AFT lepton PT: " << Lepton[u].Pt() << std::endl;
+  //  }
+  //  std::cout << "\n" << std::endl;
+  
+  if (
+      Photon.size() > 0 && Lepton.size() > 1 &&  
+      Photon[0].Pt()  > minPhotonPt  && 
+      Lepton[0].Pt()  > minLeptonPt  && 
+      Lepton[1].Pt()  > minLeptonPt  &&  
+      Photon[0].Eta() > minPhotonEta && 
+      Lepton[0].Eta() > minLeptonEta && 
+      Lepton[1].Eta() > minLeptonEta &&  
+      Photon[0].Eta() < maxPhotonEta && 
+      Lepton[0].Eta() < maxLeptonEta && 
+      Lepton[1].Eta() < maxLeptonEta &&  
+      (Lepton[0]+Lepton[1]).M()           > minDileptonMass  &&
+      (Lepton[0]+Lepton[1]+Photon[0]).M() > minZgMass 
+      )
+    { // satisfy molteplicity, kinematics, and ll llg minimum mass
+      accepted = true; 
+    }
+
+  //  std::cout << "++ returning: " << accepted << "\n" << std::endl;
+
+  return accepted;    
+}


### PR DESCRIPTION
- clone of PR #4433
- purely the forward port of #1101 , which enter 62x and was not fw-ported to 70-71x
- import radiative z filter approx 6% selection efficiency on ZMM_8TeV
- needed (also) for d.v.mc exercise, to economize GEN-SIM production of z mu mu gamma events
