### PR TITLE
Don't hide C++11 constructs from ROOT 6

### DIFF
--- a/DataFormats/TrackerRecHit2D/interface/ProjectedSiStripRecHit2D.h
+++ b/DataFormats/TrackerRecHit2D/interface/ProjectedSiStripRecHit2D.h
@@ -74,7 +74,7 @@ private:
   virtual ProjectedSiStripRecHit2D * clone(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const {
     return cloner(*this,tsos);
   }
-#ifdef NO_DICT
+#ifndef __GCCXML__
   virtual  ConstRecHitPointer cloneSH(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const {
     return cloner.makeShared(*this,tsos);
   }

--- a/DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h
+++ b/DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h
@@ -41,7 +41,7 @@ public:
 
   
   virtual SiPixelRecHit * clone() const {return new SiPixelRecHit( * this); }
-#ifdef NO_DICT
+#ifndef __GCCXML__
   virtual RecHitPointer cloneSH() const { return std::make_shared<SiPixelRecHit>(*this);}
 #endif
 
@@ -60,7 +60,7 @@ private:
   virtual SiPixelRecHit * clone(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const {
     return cloner(*this,tsos);
   }
-#ifdef NO_DICT
+#ifndef __GCCXML__
   virtual  RecHitPointer cloneSH(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const {
     return cloner.makeShared(*this,tsos);
   }

--- a/DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2D.h
+++ b/DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2D.h
@@ -42,7 +42,7 @@ class SiStripMatchedRecHit2D GCC11_FINAL : public BaseTrackerRecHit {
 
 
   virtual SiStripMatchedRecHit2D * clone() const {return new SiStripMatchedRecHit2D( * this);}
-#ifdef NO_DICT
+#ifndef __GCCXML__
   virtual RecHitPointer cloneSH() const { return std::make_shared<SiStripMatchedRecHit2D>(*this);}
 #endif
 
@@ -66,7 +66,7 @@ private:
   virtual SiStripMatchedRecHit2D * clone(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const {
     return cloner(*this,tsos);
   }
-#ifdef NO_DICT
+#ifndef __GCCXML__
   virtual  RecHitPointer cloneSH(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const {
     return cloner.makeShared(*this,tsos);
   }

--- a/DataFormats/TrackerRecHit2D/interface/SiStripRecHit1D.h
+++ b/DataFormats/TrackerRecHit2D/interface/SiStripRecHit1D.h
@@ -30,7 +30,7 @@ public:
 
 
   virtual SiStripRecHit1D * clone() const GCC11_OVERRIDE {return new SiStripRecHit1D( * this); }
-#ifdef NO_DICT
+#ifndef __GCCXML__
   virtual RecHitPointer cloneSH() const { return std::make_shared<SiStripRecHit1D>(*this);}
 #endif
   
@@ -44,7 +44,7 @@ private:
   virtual SiStripRecHit1D * clone(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const GCC11_OVERRIDE {
     return cloner(*this,tsos);
   }
-#ifdef NO_DICT
+#ifndef __GCCXML__
   virtual  RecHitPointer cloneSH(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const GCC11_OVERRIDE {
     return cloner.makeShared(*this,tsos);
   }

--- a/DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h
+++ b/DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h
@@ -30,7 +30,7 @@ public:
   void setClusterRef(ClusterRef const & ref)  {setClusterStripRef(ref);}
 
   virtual SiStripRecHit2D * clone() const GCC11_OVERRIDE {return new SiStripRecHit2D( * this); }
-#ifdef NO_DICT
+#ifndef __GCCXML__
   virtual RecHitPointer cloneSH() const { return std::make_shared<SiStripRecHit2D>(*this);}
 #endif
   
@@ -43,7 +43,7 @@ private:
   virtual SiStripRecHit2D * clone(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const GCC11_OVERRIDE {
     return cloner(*this,tsos);
   }
-#ifdef NO_DICT
+#ifndef __GCCXML__
   virtual  RecHitPointer cloneSH(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const GCC11_OVERRIDE {
     return cloner.makeShared(*this,tsos);
   }

--- a/DataFormats/TrackerRecHit2D/interface/TkCloner.h
+++ b/DataFormats/TrackerRecHit2D/interface/TkCloner.h
@@ -16,7 +16,7 @@ public:
     return hit.clone(*this, tsos);
   }
 
-#ifdef NO_DICT
+#ifndef __GCCXML__
   TrackingRecHit::ConstRecHitPointer makeShared(TrackingRecHit::ConstRecHitPointer const & hit, TrajectoryStateOnSurface const& tsos) const {
     return hit->canImproveWithTrack() ?  hit->cloneSH(*this, tsos) : hit;
     // return  hit->cloneSH(*this, tsos);
@@ -29,7 +29,7 @@ public:
   virtual SiStripMatchedRecHit2D * operator()(SiStripMatchedRecHit2D const & hit, TrajectoryStateOnSurface const& tsos) const=0;
   virtual ProjectedSiStripRecHit2D * operator()(ProjectedSiStripRecHit2D const & hit, TrajectoryStateOnSurface const& tsos) const=0;
 
-#ifdef NO_DICT
+#ifndef __GCCXML__
   virtual TrackingRecHit::ConstRecHitPointer makeShared(SiPixelRecHit const & hit, TrajectoryStateOnSurface const& tsos) const=0;
   virtual TrackingRecHit::ConstRecHitPointer makeShared(SiStripRecHit2D const & hit, TrajectoryStateOnSurface const& tsos) const=0;
   virtual TrackingRecHit::ConstRecHitPointer makeShared(SiStripRecHit1D const & hit, TrajectoryStateOnSurface const& tsos) const=0;

--- a/DataFormats/TrackingRecHit/interface/InvalidTrackingRecHit.h
+++ b/DataFormats/TrackingRecHit/interface/InvalidTrackingRecHit.h
@@ -17,7 +17,7 @@ public:
   virtual ~InvalidTrackingRecHit() {}
 
   virtual InvalidTrackingRecHit * clone() const GCC11_OVERRIDE {return new InvalidTrackingRecHit(*this);}
-#ifdef NO_DICT
+#ifndef __GCCXML__
   virtual RecHitPointer cloneSH() const { return RecHitPointer(clone());}
 #endif
 

--- a/DataFormats/TrackingRecHit/interface/TrackingRecHit.h
+++ b/DataFormats/TrackingRecHit/interface/TrackingRecHit.h
@@ -12,9 +12,6 @@
 
 
 #include "FWCore/Utilities/interface/GCC11Compatibility.h"
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
-#define NO_DICT
-#endif
 
 #include<vector>
 #include<memory>
@@ -28,7 +25,7 @@ class KfComponentsHolder;
 class TrackingRecHit {
 public:
 
-#ifdef NO_DICT
+#ifndef __GCCXML__
    using      RecHitPointer = std::shared_ptr<TrackingRecHit const>;  // requires to much editing
    using ConstRecHitPointer = std::shared_ptr<TrackingRecHit const>;   
 #else
@@ -77,7 +74,7 @@ public:
 
   
   virtual TrackingRecHit * clone() const = 0;
-#ifdef NO_DICT
+#ifndef __GCCXML__
   virtual RecHitPointer cloneSH() const { return RecHitPointer(clone());}
   // clone and add the geom (ready for refit)
   RecHitPointer cloneForFit(const GeomDet & idet) const {
@@ -106,7 +103,7 @@ public:
   virtual std::vector<TrackingRecHit*> recHits() = 0;
   virtual void recHitsV(std::vector<TrackingRecHit*> & );
 
-#ifdef NO_DICT
+#ifndef __GCCXML__
   virtual ConstRecHitContainer transientHits() const {
     ConstRecHitContainer result;
     std::vector<const TrackingRecHit*> hits;
@@ -175,7 +172,7 @@ private:
     assert("clone"==nullptr);
     return clone(); // default
   }
-#ifdef NO_DICT
+#ifndef __GCCXML__
   virtual  RecHitPointer cloneSH(TkCloner const&, TrajectoryStateOnSurface const&) const {
     assert("cloneSH"==nullptr);
     return cloneSH(); // default


### PR DESCRIPTION
In CMSSW header files exposed to CINT in ROOT 5, C++11 constructs are must be hidden from CINT, Usually with preprocessor symbols (e.g **GCCXML**, _MAKECINT__).  In ROOT 6, this hiding is not
necessary.  Unfortunately, there is no consistency in the symbols used.  Some are defined in ROOT 6,
some are not.
I have discovered one case, in TrackingRecHits.h, where the current use of such a preprocessor symbol
causes a run time JIT compilation error in ROOT6.  This is because this class contains a data member
that is a std::shared_ptr, but due to conditional compilation, the JIT compiler sees it as a bare pointer.
This leads to a JIT compilation error because, while std::shared_ptr<T>::element is defined, "element"
is not defined for a bare pointer.  The fix is to use a preprocessor symbol, **GCCXML** that is defined only for ROOT 5, so that the JIT compilation sees the shared_ptr.  For consistency. this change is made in two closely related packages.
This pull request is a no-op for ROOT 5, and is being requested for code commonality between the 7_2_X branch and the 7_2_ROOT6_X branch.
