### PR TITLE
New config parameter "doBkgNoise", turn on-off the noise simulation

### DIFF
--- a/SimMuon/RPCDigitizer/python/muonRPCDigis_cfi.py
+++ b/SimMuon/RPCDigitizer/python/muonRPCDigis_cfi.py
@@ -17,7 +17,9 @@ simMuonRPCDigis = cms.EDProducer("RPCDigiProducer",
         Gate = cms.double(25.0),
         averageEfficiency = cms.double(0.95),
         Nbxing = cms.int32(9),
-        timeJitter = cms.double(1.0)
+        timeJitter = cms.double(1.0),
+        doBkgNoise = cms.bool(True) #False - no noise and bkg simulation
+
     ),
     Signal = cms.bool(True),
     mixLabel = cms.string('mix'),                                 

--- a/SimMuon/RPCDigitizer/src/RPCSimAsymmetricCls.cc
+++ b/SimMuon/RPCDigitizer/src/RPCSimAsymmetricCls.cc
@@ -56,6 +56,8 @@ RPCSimAsymmetricCls::RPCSimAsymmetricCls(const edm::ParameterSet& config) :
   nbxing=config.getParameter<int>("Nbxing");
   gate=config.getParameter<double>("Gate");
   frate=config.getParameter<double>("Frate");
+  doBkgNoise_=config.getParameter<bool>("doBkgNoise");
+
 
   if (rpcdigiprint) {
     std::cout <<"Average Efficiency        = "<<aveEff<<std::endl;
@@ -298,6 +300,8 @@ RPCSimAsymmetricCls::simulate(const RPCRoll* roll,
 void RPCSimAsymmetricCls::simulateNoise(const RPCRoll* roll,
 					CLHEP::HepRandomEngine* engine)
 {
+  if(!doBkgNoise_)
+    return;
 
   RPCDetId rpcId = roll->id();
 

--- a/SimMuon/RPCDigitizer/src/RPCSimAsymmetricCls.h
+++ b/SimMuon/RPCDigitizer/src/RPCSimAsymmetricCls.h
@@ -66,6 +66,8 @@ class RPCSimAsymmetricCls : public RPCSim
   std::vector<double> sum_clsize;
   std::vector<double> clsForDetId;
   std::ifstream *infile;
+
+  bool doBkgNoise_;
  
   RPCSynchronizer* _rpcSync;
 };

--- a/SimMuon/RPCDigitizer/src/RPCSimAverageNoiseEffCls.cc
+++ b/SimMuon/RPCDigitizer/src/RPCSimAverageNoiseEffCls.cc
@@ -56,6 +56,7 @@ RPCSimAverageNoiseEffCls::RPCSimAverageNoiseEffCls(const edm::ParameterSet& conf
   nbxing=config.getParameter<int>("Nbxing");
   gate=config.getParameter<double>("Gate");
   frate=config.getParameter<double>("Frate");
+  doBkgNoise_=config.getParameter<bool>("doBkgNoise");
 
   if (rpcdigiprint) {
     std::cout <<"Average Efficiency        = "<<aveEff<<std::endl;
@@ -271,6 +272,8 @@ RPCSimAverageNoiseEffCls::simulate(const RPCRoll* roll,
 void RPCSimAverageNoiseEffCls::simulateNoise(const RPCRoll* roll,
                                              CLHEP::HepRandomEngine* engine)
 {
+  if(!doBkgNoise_)
+    return;
 
   RPCDetId rpcId = roll->id();
 

--- a/SimMuon/RPCDigitizer/src/RPCSimAverageNoiseEffCls.h
+++ b/SimMuon/RPCDigitizer/src/RPCSimAverageNoiseEffCls.h
@@ -66,6 +66,8 @@ class RPCSimAverageNoiseEffCls : public RPCSim
   std::vector<double> clsForDetId;
   std::ifstream *infile;
 
+  bool doBkgNoise_;
+
   RPCSynchronizer* _rpcSync;
 };
 #endif


### PR DESCRIPTION
A new config parameter is added in order to turn on or off the noise simulation in the RPC digitizer.
