### PR TITLE
Rpc noise configurable

### DIFF
--- a/SimMuon/RPCDigitizer/python/muonRPCDigis_cfi.py
+++ b/SimMuon/RPCDigitizer/python/muonRPCDigis_cfi.py
@@ -18,6 +18,7 @@ simMuonRPCDigis = cms.EDProducer("RPCDigiProducer",
         averageEfficiency = cms.double(0.95),
         Nbxing = cms.int32(9),
         timeJitter = cms.double(1.0)
+        doBkgNoise = cms.bool(True) #False - no noise and bkg simulation
     ),
     Signal = cms.bool(True),
     mixLabel = cms.string('mix'),                                 

--- a/SimMuon/RPCDigitizer/python/muonRPCDigis_cfi.py
+++ b/SimMuon/RPCDigitizer/python/muonRPCDigis_cfi.py
@@ -17,9 +17,9 @@ simMuonRPCDigis = cms.EDProducer("RPCDigiProducer",
         Gate = cms.double(25.0),
         averageEfficiency = cms.double(0.95),
         Nbxing = cms.int32(9),
-        timeJitter = cms.double(1.0),
-        doBkgNoise = cms.bool(True) #False - no noise and bkg simulation
+        timeJitter = cms.double(1.0)
     ),
+    doBkgNoise = cms.bool(True), #False - no noise and bkg simulation
     Signal = cms.bool(True),
     mixLabel = cms.string('mix'),                                 
     InputCollection = cms.string('g4SimHitsMuonRPCHits'),

--- a/SimMuon/RPCDigitizer/python/muonRPCDigis_cfi.py
+++ b/SimMuon/RPCDigitizer/python/muonRPCDigis_cfi.py
@@ -17,7 +17,7 @@ simMuonRPCDigis = cms.EDProducer("RPCDigiProducer",
         Gate = cms.double(25.0),
         averageEfficiency = cms.double(0.95),
         Nbxing = cms.int32(9),
-        timeJitter = cms.double(1.0)
+        timeJitter = cms.double(1.0),
         doBkgNoise = cms.bool(True) #False - no noise and bkg simulation
     ),
     Signal = cms.bool(True),

--- a/SimMuon/RPCDigitizer/src/RPCDigitizer.cc
+++ b/SimMuon/RPCDigitizer/src/RPCDigitizer.cc
@@ -12,6 +12,7 @@
 RPCDigitizer::RPCDigitizer(const edm::ParameterSet& config) {
   theName = config.getParameter<std::string>("digiModel");
   theRPCSim = RPCSimFactory::get()->create(theName,config.getParameter<edm::ParameterSet>("digiModelConfig"));
+  theNoise=config.getParameter<bool>("doBkgNoise");
 }
 
 RPCDigitizer::~RPCDigitizer() {
@@ -52,7 +53,9 @@ void RPCDigitizer::doAction(MixCollection<PSimHit> & simHits,
 //			     <<" hit(s) in the rpc roll";  
     
     theRPCSim->simulate(*r, rollSimHits, engine);
-    theRPCSim->simulateNoise(*r, engine);
+    if(theNoise){
+        theRPCSim->simulateNoise(*r, engine);
+    }
     theRPCSim->fillDigis((*r)->id(),rpcDigis);
     rpcDigiSimLink.insert(theRPCSim->rpcDigiSimLinks());
   }

--- a/SimMuon/RPCDigitizer/src/RPCDigitizer.h
+++ b/SimMuon/RPCDigitizer/src/RPCDigitizer.h
@@ -61,7 +61,7 @@ private:
   RPCSim* theRPCSim;
   RPCSimSetUp * theSimSetUp;
   std::string theName;
-
+  bool theNoise;
 };
 
 #endif


### PR DESCRIPTION
Some analysis demanded RPC to be switched off from a config fail. The code implements that feature, by  doBkgNoise flag in the config file (SimMuon/RPCDigitizer/python/muonRPCDigis_cfi.py)
