### PR TITLE
Several fixes for tools

### DIFF
--- a/CondCore/CondDB/interface/IOVEditor.h
+++ b/CondCore/CondDB/interface/IOVEditor.h
@@ -33,8 +33,12 @@ namespace cond {
       explicit IOVEditor( const std::shared_ptr<SessionImpl>& session );
 
       // ctor used after new tag creation. the specified params are assumed and passed directly to the object.
-      IOVEditor( const std::shared_ptr<SessionImpl>& session, const std::string& tag, cond::TimeType timeType, 
-		 const std::string& payloadType, cond::SynchronizationType synchronizationType );
+      IOVEditor( const std::shared_ptr<SessionImpl>& session, 
+		 const std::string& tag, 
+		 cond::TimeType timeType, 
+		 const std::string& payloadType, 
+		 cond::SynchronizationType synchronizationType, 
+		 const boost::posix_time::ptime& creationTime = boost::posix_time::microsec_clock::universal_time() );
 
       //
       IOVEditor( const IOVEditor& rhs );

--- a/CondCore/CondDB/interface/IOVProxy.h
+++ b/CondCore/CondDB/interface/IOVProxy.h
@@ -93,6 +93,8 @@ namespace cond {
       
       cond::Time_t lastValidatedTime() const;
 
+      std::tuple<std::string, boost::posix_time::ptime, boost::posix_time::ptime > getMetadata() const;
+
       // returns true if at least one IOV is in the sequence.
       bool isEmpty() const;
       

--- a/CondCore/CondDB/interface/Session.h
+++ b/CondCore/CondDB/interface/Session.h
@@ -106,6 +106,12 @@ namespace cond {
 			   cond::TimeType timeType,
 			   cond::SynchronizationType synchronizationType=cond::OFFLINE );
 
+      IOVEditor createIov( const std::string& payloadType, 
+			   const std::string& tag, 
+			   cond::TimeType timeType,
+			   cond::SynchronizationType synchronizationType,
+			   const boost::posix_time::ptime& creationTime );
+
       IOVEditor createIovForPayload( const Hash& payloadHash, 
 				     const std::string& tag, cond::TimeType timeType,
 				     cond::SynchronizationType synchronizationType=cond::OFFLINE );

--- a/CondCore/CondDB/src/IOVEditor.cc
+++ b/CondCore/CondDB/src/IOVEditor.cc
@@ -24,6 +24,7 @@ namespace cond {
       std::string description;
       cond::Time_t endOfValidity = cond::time::MAX_VAL;
       cond::Time_t lastValidatedTime = cond::time::MIN_VAL; 
+      boost::posix_time::ptime creationTime;
       bool change = false;
       bool exists = false;
       // buffer for the iov sequence
@@ -45,13 +46,15 @@ namespace cond {
 			  const std::string& tag, 
 			  cond::TimeType timeType, 
 			  const std::string& payloadObjectType,
-			  cond::SynchronizationType synchronizationType  ):
+			  cond::SynchronizationType synchronizationType,
+			  const boost::posix_time::ptime& creationTime ):
       m_data( new IOVEditorData ),
       m_session( session ){
       m_data->tag = tag;
       m_data->timeType = timeType;
       m_data->payloadType = payloadObjectType;
       m_data->synchronizationType = synchronizationType;
+      m_data->creationTime = creationTime;
       m_data->change = true;
     }
 
@@ -153,7 +156,7 @@ namespace cond {
 	if( !m_data->exists ){
 	  m_session->iovSchema().tagTable().insert( m_data->tag, m_data->timeType, m_data->payloadType, 
 						    m_data->synchronizationType, m_data->endOfValidity, 
-						    m_data->description, m_data->lastValidatedTime, operationTime );
+						    m_data->description, m_data->lastValidatedTime, m_data->creationTime );
 	  m_data->exists = true;
 	  ret = true;
 	} else {

--- a/CondCore/CondDB/src/IOVProxy.cc
+++ b/CondCore/CondDB/src/IOVProxy.cc
@@ -183,6 +183,16 @@ namespace cond {
       return m_data.get() ? m_data->lastValidatedTime : cond::time::MIN_VAL;
     }
 
+    std::tuple<std::string, boost::posix_time::ptime, boost::posix_time::ptime > IOVProxy::getMetadata() const {
+      if(!m_data.get()) throwException( "No tag has been loaded.","IOVProxy::getMetadata()");
+      checkTransaction( "IOVProxy::getMetadata" );
+      std::tuple<std::string, boost::posix_time::ptime, boost::posix_time::ptime > ret;
+      if(!m_session->iovSchema().tagTable().getMetadata( m_data->tag, std::get<0>( ret ), std::get<1>( ret ), std::get<2>( ret ) ) ){
+	throwException( "Metadata for tag \""+m_data->tag+"\" have not been found in the database.","IOVProxy::getMetadata()");
+      }
+      return ret;
+    }
+
     bool IOVProxy::isEmpty() const {
       return m_data.get() ? ( m_data->sinceGroups.size()==0 && m_data->iovSequence.size()==0 ) : true; 
     }

--- a/CondCore/CondDB/src/OraDbSchema.cc
+++ b/CondCore/CondDB/src/OraDbSchema.cc
@@ -85,10 +85,11 @@ namespace cond {
     }
 
     bool OraTagTable::getMetadata( const std::string& name, std::string& description, 
-				   boost::posix_time::ptime&, boost::posix_time::ptime& ){
+				   boost::posix_time::ptime&, boost::posix_time::ptime& modificationTime){
       if(!m_cache.load( name )) return false;
       description = m_cache.iovSequence().comment();
-      // TO DO: get insertion / modification time from the Logger?      
+      modificationTime = cond::time::to_boost( m_cache.iovSequence().timestamp() );
+      // TO DO: get insertion time from the Logger?      
       return true;
     }
       

--- a/CondCore/CondDB/src/Session.cc
+++ b/CondCore/CondDB/src/Session.cc
@@ -105,6 +105,18 @@ namespace cond {
       return editor;
     }
 
+    IOVEditor Session::createIov( const std::string& payloadType, 
+				  const std::string& tag, 
+				  cond::TimeType timeType,
+				  cond::SynchronizationType synchronizationType,
+				  const boost::posix_time::ptime& creationTime ){
+      m_session->openIovDb( SessionImpl::CREATE );
+      if( m_session->iovSchema().tagTable().select( tag ) ) 
+	throwException( "The specified tag \""+tag+"\" already exist in the database.","Session::createIov");
+      IOVEditor editor( m_session, tag, timeType, payloadType, synchronizationType, creationTime );
+      return editor;
+    }
+
     IOVEditor Session::createIovForPayload( const Hash& payloadHash, const std::string& tag, cond::TimeType timeType,
 					    cond::SynchronizationType synchronizationType ){
       m_session->openIovDb( SessionImpl::CREATE );

--- a/CondCore/Utilities/bin/conddb_copy_iov.cpp
+++ b/CondCore/Utilities/bin/conddb_copy_iov.cpp
@@ -22,10 +22,13 @@ namespace cond {
 cond::CopyIovUtilities::CopyIovUtilities():Utilities("conddb_copy_iov"){
   addConnectOption("connect","c","target connection string (required)");
   addAuthenticationOptions();
-  addOption<std::string>("inputTag","i","source tag (required)");
-  addOption<std::string>("tag","t","destination tag (required)");
+  addOption<std::string>("inputTag","i","source tag (optional)");
+  addOption<std::string>("tag","t","destination tag (optional)");
   addOption<cond::Time_t>("sourceSince","s","since time of the iov to copy (required)");
   addOption<cond::Time_t>("destSince","d","since time of the destination iov (optional, default=sourceSince)");
+  addOption<std::string>("oraDestAccount","A","ora DB destination account (optional, to be used with -T -I)");
+  addOption<std::string>("oraInputTag","I","ora DB input tag (optional, to be used with -A -T)");
+  addOption<std::string>("oraDestTag","T","ora DB destination tag (optional, to be used with -A -I)");
 }
 
 cond::CopyIovUtilities::~CopyIovUtilities(){
@@ -36,8 +39,21 @@ int cond::CopyIovUtilities::execute(){
   bool debug = hasDebug();
   std::string connect = getOptionValue<std::string>("connect");
 
-  std::string tag = getOptionValue<std::string>("tag");
-  std::string inputTag = getOptionValue<std::string>("inputTag");
+  std::string inputTag("");
+  std::string tag("");
+  std::string oraConn("");
+  std::string oraTag("");
+  std::string oraInputTag("");
+  if( hasOptionValue("tag")) {
+    tag = getOptionValue<std::string>("tag");
+    inputTag = getOptionValue<std::string>("inputTag");
+  } else {
+    if( hasOptionValue("oraDestTag") ){
+      oraTag = getOptionValue<std::string>("oraDestTag");
+    } else throwException("The destination tag is missing and can't be resolved.","CopyIovUtilities::execute");
+    oraInputTag = getOptionValue<std::string>("oraInputTag");
+    oraConn = getOptionValue<std::string>("oraDestAccount");
+  }
 
   cond::Time_t sourceSince = getOptionValue<cond::Time_t>( "sourceSince");
   cond::Time_t destSince = sourceSince;
@@ -50,12 +66,41 @@ int cond::CopyIovUtilities::execute(){
   connPool.configure();
 
   std::cout <<"# Connecting to source database on "<<connect<<std::endl;
-  persistency::Session session = connPool.createSession( connect, true, COND_DB );
+  persistency::Session session = connPool.createSession( connect, true );
 
-  bool imported = copyIov( session, inputTag, tag, sourceSince, destSince, true );
+  bool newTag = false;
+  session.transaction().start( true );
+  if( tag.empty() ){
+    cond::MigrationStatus ms = ERROR;
+    std::cout <<"# checking TAG_MAPPING table to identify the input tag."<<std::endl;
+    session.checkMigrationLog( oraConn, oraInputTag, inputTag, ms );
+    if( ms == ERROR ) throwException("The input Tag is not mapped to any available tag.","CopyIovUtilities::execute");
+    else if( ms == MIGRATED ) std::cout <<"# WARNING: the input tag has not been validated."<<std::endl;
+    std::cout <<"# checking TAG_MAPPING table to identify the destination tag."<<std::endl;
+    if( !session.checkMigrationLog( oraConn, oraTag, tag, ms ) ){
+      tag = oraTag;
+      newTag = true;
+    } else {
+      if( ms == ERROR ) throwException("The destination Tag has not been correctly migrated.","CopyIovUtilities::execute");
+      else if( ms == MIGRATED ) std::cout <<"# WARNING: the destination tag has not been validated."<<std::endl;
+    }
+  }
+  session.transaction().commit();
+
+  std::cout <<"# input tag is "<<inputTag<<std::endl;
+  std::cout <<"# destination tag is "<<tag<<std::endl;
+
+  bool imported = copyIov( session, inputTag, tag, sourceSince, destSince, "", true );
     
-  if( imported ) std::cout <<"# 1 iov copied. "<<std::endl;
-
+  if( imported ) {
+    std::cout <<"# 1 iov copied. "<<std::endl;
+    if( newTag ){
+      std::cout <<"# updating TAG_MAPPING table..."<<std::endl;
+      session.transaction().start( false );
+      session.addToMigrationLog( oraConn, oraTag, tag, VALIDATED );
+      session.transaction().commit();      
+    }
+  }
   return 0;
 }
 

--- a/CondCore/Utilities/bin/conddb_import.cpp
+++ b/CondCore/Utilities/bin/conddb_import.cpp
@@ -27,6 +27,8 @@ cond::ImportUtilities::ImportUtilities():Utilities("conddb_import"){
   addOption<std::string>("tag","t","destination tag (required)");
   addOption<cond::Time_t>("begin","b","lower bound of interval to import (optional, default=1)");
   addOption<cond::Time_t>("end","e","upper bound of interval to import (optional, default=infinity)");
+  addOption<std::string>("oraDestAccount","A","ora DB destination account (optional, to be used with -T)");
+  addOption<std::string>("oraDestTag","T","ora DB destination tag (optional, to be used with -A)");
 }
 
 cond::ImportUtilities::~ImportUtilities(){
@@ -38,10 +40,17 @@ int cond::ImportUtilities::execute(){
   std::string destConnect = getOptionValue<std::string>("connect" );
   std::string sourceConnect = getOptionValue<std::string>("fromConnect");
 
-  std::string tag = getOptionValue<std::string>("tag");
-  std::string inputTag = tag;
-  if( hasOptionValue("inputTag")) {
-    inputTag = getOptionValue<std::string>("inputTag");
+  std::string inputTag = getOptionValue<std::string>("inputTag");;
+  std::string tag(""); 
+  std::string oraConn("");
+  std::string oraTag("");
+  if( hasOptionValue("tag")) {
+    tag = getOptionValue<std::string>("tag");
+  } else {
+    if( hasOptionValue("oraDestTag") ){
+      oraTag = getOptionValue<std::string>("oraDestTag");
+    } else throwException("The destination tag is missing and can't be resolved.","ImportUtilities::execute");; 
+    oraConn = getOptionValue<std::string>("oraDestAccount");
   }
 
   cond::Time_t begin = 1;
@@ -49,7 +58,6 @@ int cond::ImportUtilities::execute(){
   cond::Time_t end = cond::time::MAX_VAL;
   if( hasOptionValue("end") ) end = getOptionValue<cond::Time_t>( "end");
   if( begin > end ) throwException( "Begin time can't be greater than end time.","ImportUtilities::execute");
-
 
   persistency::ConnectionPool connPool;
   if( hasOptionValue("authPath") ){
@@ -60,11 +68,33 @@ int cond::ImportUtilities::execute(){
   persistency::Session sourceSession = connPool.createSession( sourceConnect );
 
   std::cout <<"# Opening session on destination database..."<<std::endl;
-  persistency::Session destSession = connPool.createSession( destConnect, true, COND_DB );
-  
-  size_t nimported = importIovs( inputTag, sourceSession, tag, destSession, begin, end, true );
-    
+  persistency::Session destSession = connPool.createSession( destConnect, true );
+
+  bool newTag = false;
+  destSession.transaction().start( true );
+  if( tag.empty() ){
+    cond::MigrationStatus ms = ERROR;
+    std::cout <<"# checking TAG_MAPPING table to identify destination tag."<<std::endl; 
+    if( !destSession.checkMigrationLog( oraConn, oraTag, tag, ms ) ){
+      tag = oraTag;
+      newTag = true;
+    } else {
+      if( ms == ERROR ) throwException("The destination Tag has not been correctly migrated.","ImportUtilities::execute");
+      else if( ms == MIGRATED ) std::cout <<"# WARNING: the destination tag has not been validated."<<std::endl;
+    }
+  }
+  destSession.transaction().commit();
+
+  std::cout <<"# destination tag is "<<tag<<std::endl;
+
+  size_t nimported = importIovs( inputTag, sourceSession, tag, destSession, begin, end, "", true );
   std::cout <<"# "<<nimported<<" iov(s) imported. "<<std::endl;
+  if( newTag && nimported ){
+    std::cout <<"# updating TAG_MAPPING table..."<<std::endl;
+    destSession.transaction().start( false );
+    destSession.addToMigrationLog( oraConn, oraTag, tag, VALIDATED );
+    destSession.transaction().commit();
+  }
 
   return 0;
 }

--- a/CondCore/Utilities/interface/CondDBTools.h
+++ b/CondCore/Utilities/interface/CondDBTools.h
@@ -2,6 +2,7 @@
 #define Utilities_CondDBTools_h
 
 #include "CondCore/CondDB/interface/Time.h"
+#include "CondCore/DBCommon/interface/DbSession.h"
 //
 #include <string>
 
@@ -19,7 +20,14 @@ namespace cond {
 		    Session& destSession, 
 		    UpdatePolicy policy,
 		    bool log, 
-		    bool forValidation );   
+		    bool forValidation ); 
+  
+    size_t migrateTag( const std::string& sourceTag, 
+		       Session& sourceSession, 
+		       const std::string& destTag, 
+		       Session& destSession,
+		       UpdatePolicy policy,
+		       cond::DbSession& logDbSession);   
 
     size_t importIovs( const std::string& sourceTag, 
 		       Session& sourceSession, 
@@ -27,6 +35,7 @@ namespace cond {
 		       Session& destSession, 
 		       cond::Time_t begin,
 		       cond::Time_t end,
+		       const std::string& description,
 		       bool log );  
 
     bool copyIov( Session& session,
@@ -34,6 +43,7 @@ namespace cond {
 		  const std::string& destTag,
 		  cond::Time_t souceSince,
 		  cond::Time_t destSince,
+		  const std::string& description,
 		  bool log );
  
     bool compareTags( const std::string& firstTag,


### PR DESCRIPTION
Several improvements for the Condition DB command line tools:
- conddb_import:   support look up of TAG_MIGRATION table to remap tag from V1 to V2 DB
- conddb_copy_iov: same as for import
- conddb_migrate: look up into the POPCON LOG, to extract the insertion time to be propagated in the V2 DB.

Packages involved:
CondCore/CondDB
CondCore/Utilities
