### PR TITLE
Remove obsolete workaround

### DIFF
--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -87,9 +87,6 @@
 #include <sched.h>
 #endif
 
-//FIXME: Needed for temporary workaround for checksum problem in conditions
-#include "TFile.h"
-
 namespace edm {
 
   // ---------------------------------------------------------------
@@ -471,12 +468,6 @@ namespace edm {
 
     // intialize miscellaneous items
     std::shared_ptr<CommonParams> common(items.initMisc(*parameterSet));
-
-    // FIXME: BEGIN temporary workaround for checksum problems in conditions
-    edm::FileInPath condfile("FWCore/Framework/data/cond_dump.root");
-    TFile* fptr = TFile::Open(condfile.fullPath().c_str());
-    fptr->Close();
-    // END temporary workaround for checksum problems in conditions
 
     // intialize the event setup provider
     esp_ = espController_->makeProvider(*parameterSet);


### PR DESCRIPTION
Checksum bugs in ROOT 6 caused fatal errors when reading version 1 of the Conditions database, due to the fact that the version 1 database did not have streamer information.  To work around this problem, cmsRun, at the beginning of the job, opened and closed a dummy conditions database that contained streamer information.  Now that we have moved to version 2 of the conditions database, this ROOT6 bug no longer affects us. Therefore, this pull request removes the workaround.
