### PR TITLE
strip digitizer stores tofBin, hitAssociator uses CFpos

### DIFF
--- a/SimDataFormats/TrackerDigiSimLink/interface/StripDigiSimLink.h
+++ b/SimDataFormats/TrackerDigiSimLink/interface/StripDigiSimLink.h
@@ -6,11 +6,16 @@
 
 class StripDigiSimLink {
  public:
-  StripDigiSimLink(unsigned int ch, unsigned int tkId, unsigned int counter, EncodedEventId e,float a ):
-    chan(ch),simTkId(tkId), CFpos(counter), eId(e) , fract(a) {;}
+  enum {LowTof, HighTof};
 
-  StripDigiSimLink(unsigned int ch, unsigned int tkId, EncodedEventId e,float a ):
-    chan(ch),simTkId(tkId), CFpos(0), eId(e) , fract(a) {;}
+  StripDigiSimLink(unsigned int ch, unsigned int tkId, unsigned int counter, unsigned int tofBin, EncodedEventId e, float a ):
+    chan(ch),simTkId(tkId), CFpos(tofBin == LowTof ? counter & 0x7FFFFFFF : (counter & 0x7FFFFFFF) | 0x80000000), eId(e), fract(a) {;}
+
+  StripDigiSimLink(unsigned int ch, unsigned int tkId, unsigned int counter, EncodedEventId e, float a ):
+    chan(ch),simTkId(tkId), CFpos(counter & 0x7FFFFFFF), eId(e), fract(a) {;}
+
+  StripDigiSimLink(unsigned int ch, unsigned int tkId, EncodedEventId e, float a ):
+    chan(ch),simTkId(tkId), CFpos(0), eId(e), fract(a) {;}
 
     StripDigiSimLink():chan(0),simTkId(0),CFpos(0),eId(0), fract(0) {;}
 
@@ -18,7 +23,8 @@ class StripDigiSimLink {
 
   unsigned int   channel()     const {return chan;}
   unsigned int   SimTrackId()  const {return simTkId;}
-  unsigned int   CFposition()  const {return CFpos;}
+  unsigned int   CFposition()  const {return CFpos & 0x7FFFFFFF;}
+  unsigned int   TofBin()      const {return (CFpos & 0x80000000) == 0 ? LowTof : HighTof;}
   EncodedEventId eventId()     const {return eId;}
   float          fraction()    const {return fract;}
 
@@ -27,7 +33,8 @@ class StripDigiSimLink {
  private:
   unsigned int chan;
   unsigned int simTkId;
-  unsigned int CFpos; //position of the PSimHit in the CrossingFrame vector
+  uint32_t CFpos; // position of the PSimHit in the CrossingFrame vector
+             // for the subdetector collection; bit 31 set if from the HighTof collection
   EncodedEventId eId;
   float    fract;
 };

--- a/SimDataFormats/TrackerDigiSimLink/src/classes_def.xml
+++ b/SimDataFormats/TrackerDigiSimLink/src/classes_def.xml
@@ -11,7 +11,8 @@
  <class name="edm::Wrapper< std::vector<edm::DetSet<PixelDigiSimLink> > >" splitLevel="0" />
  <class name="edm::Wrapper< edm::DetSetVector<PixelDigiSimLink> >" splitLevel="0" />
 
- <class name="StripDigiSimLink" ClassVersion="10">
+ <class name="StripDigiSimLink" ClassVersion="11">
+  <version ClassVersion="11" checksum="2019711893"/>
   <version ClassVersion="10" checksum="2019711893"/>
  </class>
  <class name="edm::DetSet<StripDigiSimLink>"/>

--- a/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.cc
+++ b/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.cc
@@ -96,7 +96,7 @@ SiStripDigitizer::~SiStripDigitizer() {
 }  
 
 void SiStripDigitizer::accumulateStripHits(edm::Handle<std::vector<PSimHit> > hSimHits,
-					   const TrackerTopology *tTopo, size_t globalSimHitIndex, CLHEP::HepRandomEngine* engine ) {
+					   const TrackerTopology *tTopo, size_t globalSimHitIndex, const unsigned int tofBin, CLHEP::HepRandomEngine* engine ) {
   // globalSimHitIndex is the index the sim hit will have when it is put in a collection
   // of sim hits for all crossings. This is only used when creating digi-sim links if
   // configured to do so.
@@ -115,7 +115,7 @@ void SiStripDigitizer::accumulateStripHits(edm::Handle<std::vector<PSimHit> > hS
 	  GlobalVector bfield = pSetup->inTesla(stripdet->surface().position());
 	  LogDebug ("Digitizer ") << "B-field(T) at " << stripdet->surface().position() << "(cm): "
 				  << pSetup->inTesla(stripdet->surface().position());
-	  theDigiAlgo->accumulateSimHits(it, itEnd, globalSimHitIndex, stripdet, bfield, tTopo, engine);
+	  theDigiAlgo->accumulateSimHits(it, itEnd, globalSimHitIndex, tofBin, stripdet, bfield, tTopo, engine);
 	}
       }
     } // end of loop over sim hits
@@ -134,9 +134,11 @@ void SiStripDigitizer::accumulateStripHits(edm::Handle<std::vector<PSimHit> > hS
     for(auto const& trackerContainer : trackerContainers) {
       edm::Handle<std::vector<PSimHit> > simHits;
       edm::InputTag tag(hitsProducer, trackerContainer);
+      unsigned int tofBin = StripDigiSimLink::LowTof;
+      if (trackerContainer.find(std::string("HighTof")) != std::string::npos) tofBin = StripDigiSimLink::HighTof;
 
       iEvent.getByLabel(tag, simHits);
-      accumulateStripHits(simHits,tTopo,crossingSimHitIndexOffset_[tag.encode()], randomEngine(iEvent.streamID()));
+      accumulateStripHits(simHits,tTopo,crossingSimHitIndexOffset_[tag.encode()], tofBin, randomEngine(iEvent.streamID()));
       // Now that the hits have been processed, I'll add the amount of hits in this crossing on to
       // the global counter. Next time accumulateStripHits() is called it will count the sim hits
       // as though they were on the end of this collection.
@@ -156,9 +158,11 @@ void SiStripDigitizer::accumulateStripHits(edm::Handle<std::vector<PSimHit> > hS
     for(auto const& trackerContainer : trackerContainers) {
       edm::Handle<std::vector<PSimHit> > simHits;
       edm::InputTag tag(hitsProducer, trackerContainer);
+      unsigned int tofBin = StripDigiSimLink::LowTof;
+      if (trackerContainer.find(std::string("HighTof")) != std::string::npos) tofBin = StripDigiSimLink::HighTof; 
 
       iEvent.getByLabel(tag, simHits);
-      accumulateStripHits(simHits,tTopo,crossingSimHitIndexOffset_[tag.encode()], randomEngine(streamID));
+      accumulateStripHits(simHits,tTopo,crossingSimHitIndexOffset_[tag.encode()], tofBin, randomEngine(streamID));
       // Now that the hits have been processed, I'll add the amount of hits in this crossing on to
       // the global counter. Next time accumulateStripHits() is called it will count the sim hits
       // as though they were on the end of this collection.

--- a/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.h
+++ b/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.h
@@ -54,7 +54,7 @@ public:
   virtual void finalizeEvent(edm::Event& e, edm::EventSetup const& c) override;
   
 private:
-  void accumulateStripHits(edm::Handle<std::vector<PSimHit> >, const TrackerTopology *tTopo, size_t globalSimHitIndex, CLHEP::HepRandomEngine*);
+  void accumulateStripHits(edm::Handle<std::vector<PSimHit> >, const TrackerTopology *tTopo, size_t globalSimHitIndex, const unsigned int tofBin, CLHEP::HepRandomEngine*);
   CLHEP::HepRandomEngine* randomEngine(edm::StreamID const& streamID);
 
   typedef std::vector<std::string> vstring;

--- a/SimTracker/SiStripDigitizer/plugins/SiStripDigitizerAlgorithm.cc
+++ b/SimTracker/SiStripDigitizer/plugins/SiStripDigitizerAlgorithm.cc
@@ -108,6 +108,7 @@ void
 SiStripDigitizerAlgorithm::accumulateSimHits(std::vector<PSimHit>::const_iterator inputBegin,
                                              std::vector<PSimHit>::const_iterator inputEnd,
                                              size_t inputBeginGlobalIndex,
+					     unsigned int tofBin,
                                              const StripGeomDetUnit* det,
                                              const GlobalVector& bfield,
 					     const TrackerTopology *tTopo,
@@ -118,7 +119,7 @@ SiStripDigitizerAlgorithm::accumulateSimHits(std::vector<PSimHit>::const_iterato
 
   std::vector<bool>& badChannels = allBadChannels[detID];
   size_t thisFirstChannelWithSignal = numStrips;
-  size_t thisLastChannelWithSignal = numStrips;
+  size_t thisLastChannelWithSignal = 0;
 
   float langle = (lorentzAngleHandle.isValid()) ? lorentzAngleHandle->getLorentzAngle(detID) : 0.;
 
@@ -195,7 +196,7 @@ SiStripDigitizerAlgorithm::accumulateSimHits(std::vector<PSimHit>::const_iterato
                 }
               } // end of loop over associationVector
               // If the hit wasn't already in create a new association info structure.
-              if( addNewEntry ) associationVector.push_back( AssociationInfo{ simHitIter->trackId(), simHitIter->eventId(), signalFromThisSimHit, simHitGlobalIndex } );
+              if( addNewEntry ) associationVector.push_back( AssociationInfo{ simHitIter->trackId(), simHitIter->eventId(), signalFromThisSimHit, simHitGlobalIndex, tofBin } );
             } // end of "if( signalFromThisSimHit!=0 )"
           } // end of loop over locAmpl strips
         } // end of "if( makeDigiSimLinks_ )"
@@ -272,9 +273,9 @@ SiStripDigitizerAlgorithm::digitize(
         for( const auto& iAssociationInfo : associationInfo ) totalSimADC+=iAssociationInfo.contributionToADC;
         // Now I know that I can loop again and create the links
         for( const auto& iAssociationInfo : associationInfo ) {
-          // Note simHitGlobalIndex has +1 because TrackerHitAssociator (the only place I can find this value being used)
-          // expects counting to start at 1, not 0.
-          outLink.push_back( StripDigiSimLink( iDigi.channel(), iAssociationInfo.trackID, iAssociationInfo.simHitGlobalIndex+1, iAssociationInfo.eventID, iAssociationInfo.contributionToADC/totalSimADC ) );
+          // Note simHitGlobalIndex used to have +1 because TrackerHitAssociator (the only place I can find this value being used)
+          // expected counting to start at 1, not 0.  Now changed.
+          outLink.push_back( StripDigiSimLink( iDigi.channel(), iAssociationInfo.trackID, iAssociationInfo.simHitGlobalIndex, iAssociationInfo.tofBin, iAssociationInfo.eventID, iAssociationInfo.contributionToADC/totalSimADC ) );
         } // end of loop over associationInfo
       } // end of loop over the digis
     } // end of check that iAssociationInfoByChannel is a valid iterator
@@ -397,9 +398,9 @@ SiStripDigitizerAlgorithm::digitize(
         for( const auto& iAssociationInfo : associationInfo ) totalSimADC+=iAssociationInfo.contributionToADC;
         // Now I know that I can loop again and create the links
         for( const auto& iAssociationInfo : associationInfo ) {
-          // Note simHitGlobalIndex has +1 because TrackerHitAssociator (the only place I can find this value being used)
-          // expects counting to start at 1, not 0.
-          outLink.push_back( StripDigiSimLink( channel, iAssociationInfo.trackID, iAssociationInfo.simHitGlobalIndex+1, iAssociationInfo.eventID, iAssociationInfo.contributionToADC/totalSimADC ) );
+          // Note simHitGlobalIndex used to have +1 because TrackerHitAssociator (the only place I can find this value being used)
+          // expected counting to start at 1, not 0.  Now changed.
+          outLink.push_back( StripDigiSimLink( channel, iAssociationInfo.trackID, iAssociationInfo.simHitGlobalIndex, iAssociationInfo.tofBin, iAssociationInfo.eventID, iAssociationInfo.contributionToADC/totalSimADC ) );
         } // end of loop over associationInfo
       } // end of loop over the digis
     } // end of check that iAssociationInfoByChannel is a valid iterator

--- a/SimTracker/SiStripDigitizer/plugins/SiStripDigitizerAlgorithm.h
+++ b/SimTracker/SiStripDigitizer/plugins/SiStripDigitizerAlgorithm.h
@@ -68,6 +68,7 @@ class SiStripDigitizerAlgorithm {
   void accumulateSimHits(const std::vector<PSimHit>::const_iterator inputBegin,
                          const std::vector<PSimHit>::const_iterator inputEnd,
                          size_t inputBeginGlobalIndex,
+			 unsigned int tofBin,
                          const StripGeomDetUnit *stripdet,
                          const GlobalVector& bfield,
 			 const TrackerTopology *tTopo,
@@ -143,6 +144,7 @@ class SiStripDigitizerAlgorithm {
     EncodedEventId eventID;
     float contributionToADC;
     size_t simHitGlobalIndex; ///< The array index of the sim hit, but in the array for all crossings
+    unsigned int tofBin;  // Needed along with subDet to determine which PSimHit collection simHitGlobalIndex indexes
   };
 
   typedef std::map<int, std::vector<AssociationInfo> >  AssociationInfoForChannel;

--- a/SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h
+++ b/SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h
@@ -62,26 +62,31 @@ class TrackerHitAssociator {
   // Destructor
   virtual ~TrackerHitAssociator(){}
   
+  typedef std::pair<unsigned int, unsigned int> simHitCollectionID;
+  typedef std::pair<simHitCollectionID, unsigned int> simhitAddr;
+
   std::vector<PSimHit> associateHit(const TrackingRecHit & thit) const;
   //for PU events
   std::vector<SimHitIdpr> associateHitId(const TrackingRecHit & thit) const;
-  void associateHitId(const TrackingRecHit & thit,std::vector<SimHitIdpr> &simhitid) const;
+  void associateHitId(const TrackingRecHit & thit,std::vector<SimHitIdpr> &simhitid, std::vector<simhitAddr>* simhitCFPos=0) const;
   template<typename T>
-    void associateSiStripRecHit(const T *simplerechit, std::vector<SimHitIdpr>& simtrackid) const;
+    void associateSiStripRecHit(const T *simplerechit, std::vector<SimHitIdpr>& simtrackid, std::vector<simhitAddr>* simhitCFPos=0) const;
   void associateSimpleRecHitCluster(const SiStripCluster* clust,
-				    const uint32_t& detID,
-				    std::vector<SimHitIdpr>& simtrackid) const;
+				    const DetId& detid,
+				    std::vector<SimHitIdpr>& simtrackid, std::vector<simhitAddr>* simhitCFPos=0) const;
 
-  std::vector<SimHitIdpr> associateMatchedRecHit(const SiStripMatchedRecHit2D * matchedrechit) const;
-  std::vector<SimHitIdpr> associateProjectedRecHit(const ProjectedSiStripRecHit2D * projectedrechit) const;
+  std::vector<SimHitIdpr> associateMatchedRecHit(const SiStripMatchedRecHit2D * matchedrechit, std::vector<simhitAddr>* simhitCFPos=0) const;
+  std::vector<SimHitIdpr> associateProjectedRecHit(const ProjectedSiStripRecHit2D * projectedrechit, std::vector<simhitAddr>* simhitCFPos=0) const;
   void associatePixelRecHit(const SiPixelRecHit * pixelrechit, std::vector<SimHitIdpr> & simhitid) const;
   std::vector<SimHitIdpr> associateGSRecHit(const SiTrackerGSRecHit2D * gsrechit) const;
-  std::vector<SimHitIdpr> associateMultiRecHitId(const SiTrackerMultiRecHit * multirechit) const;
+  std::vector<SimHitIdpr> associateMultiRecHitId(const SiTrackerMultiRecHit * multirechit, std::vector<simhitAddr>* simhitCFPos=0) const;
   std::vector<PSimHit>    associateMultiRecHit(const SiTrackerMultiRecHit * multirechit) const;
   std::vector<SimHitIdpr> associateGSMatchedRecHit(const SiTrackerGSMatchedRecHit2D * gsmrechit) const;
   
   typedef std::map<unsigned int, std::vector<PSimHit> > simhit_map;
   simhit_map SimHitMap;
+  typedef std::map<simHitCollectionID, std::vector<PSimHit> > simhit_collectionMap;
+  simhit_collectionMap SimHitCollMap;
  
  private:
   const edm::Event& myEvent_;

--- a/SimTracker/TrackerHitAssociation/src/TrackerHitAssociator.cc
+++ b/SimTracker/TrackerHitAssociation/src/TrackerHitAssociator.cc
@@ -57,13 +57,29 @@ TrackerHitAssociator::TrackerHitAssociator(const edm::Event& e)  :
     if (e.getByLabel(tag_cf, cf_simhit)) {
       std::auto_ptr<MixCollection<PSimHit> > thisContainerHits(new MixCollection<PSimHit>(cf_simhit.product()));
       for (MixCollection<PSimHit>::iterator isim = thisContainerHits->begin();
-	   isim != thisContainerHits->end(); isim++)
+	   isim != thisContainerHits->end(); isim++) {
 	SimHitMap[(*isim).detUnitId()].push_back((*isim));
+
+	DetId theDet((*isim).detUnitId());
+	unsigned int tofBin = StripDigiSimLink::LowTof;
+	if (trackerContainer.find(std::string("HighTof")) != std::string::npos) tofBin = StripDigiSimLink::HighTof;
+	simHitCollectionID theSimHitCollID = std::make_pair(theDet.subdetId(), tofBin);
+	SimHitCollMap[theSimHitCollID].push_back((*isim));
+
+      }
     } else {
       e.getByLabel(tag_hits, simHits);
       for (std::vector<PSimHit>::const_iterator isim = simHits->begin();
-	   isim != simHits->end(); isim++)
+	   isim != simHits->end(); isim++) {
 	SimHitMap[(*isim).detUnitId()].push_back((*isim));
+
+	DetId theDet((*isim).detUnitId());
+	unsigned int tofBin = StripDigiSimLink::LowTof;
+	if (trackerContainer.find(std::string("HighTof")) != std::string::npos) tofBin = StripDigiSimLink::HighTof;
+	simHitCollectionID theSimHitCollID = std::make_pair(theDet.subdetId(), tofBin);
+	SimHitCollMap[theSimHitCollID].push_back((*isim));
+
+      }
     }
   }
   
@@ -104,6 +120,13 @@ TrackerHitAssociator::TrackerHitAssociator(const edm::Event& e, const edm::Param
 	for (MixCollection<PSimHit>::iterator isim = thisContainerHits->begin();
 	     isim != thisContainerHits->end(); isim++) {
 	  SimHitMap[(*isim).detUnitId()].push_back((*isim));
+
+	  DetId theDet((*isim).detUnitId());
+	  unsigned int tofBin = StripDigiSimLink::LowTof;
+	  if (trackerContainer.find(std::string("HighTof")) != std::string::npos) tofBin = StripDigiSimLink::HighTof;
+	  simHitCollectionID theSimHitCollID = std::make_pair(theDet.subdetId(), tofBin);
+	  SimHitCollMap[theSimHitCollID].push_back((*isim));
+
 	  Nhits++;
 	}
 // 	std::cout << "simHits from crossing frames; map size = " << SimHitMap.size() << ", Hit count = " << Nhits << std::endl;
@@ -112,6 +135,13 @@ TrackerHitAssociator::TrackerHitAssociator(const edm::Event& e, const edm::Param
 	for (std::vector<PSimHit>::const_iterator isim = simHits->begin();
 	     isim != simHits->end(); isim++) {
 	  SimHitMap[(*isim).detUnitId()].push_back((*isim));
+
+	  DetId theDet((*isim).detUnitId());
+	  unsigned int tofBin = StripDigiSimLink::LowTof;
+	  if (trackerContainer.find(std::string("HighTof")) != std::string::npos) tofBin = StripDigiSimLink::HighTof;
+	  simHitCollectionID theSimHitCollID = std::make_pair(theDet.subdetId(), tofBin);
+	  SimHitCollMap[theSimHitCollID].push_back((*isim));
+
 	  Nhits++;
 	}
 // 	std::cout << "simHits from prompt collection; map size = " << SimHitMap.size() << ", Hit count = " << Nhits << std::endl;
@@ -126,28 +156,59 @@ TrackerHitAssociator::TrackerHitAssociator(const edm::Event& e, const edm::Param
 std::vector<PSimHit> TrackerHitAssociator::associateHit(const TrackingRecHit & thit) const
 {
 
+  if (const SiTrackerMultiRecHit * rechit = dynamic_cast<const SiTrackerMultiRecHit *>(&thit)){
+    return associateMultiRecHit(rechit);
+  }
+
   //vector with the matched SimHit
   std::vector<PSimHit> result;
 
   if(doTrackAssoc_) return result;
 
-  //initialize vectors!
+  // Vectors to contain lists of matched simTracks, simHits
   std::vector<SimHitIdpr> simtrackid;
+  std::vector<simhitAddr> simhitCFPos;
   
   //get the Detector type of the rechit
   DetId detid=  thit.geographicalId();
   uint32_t detID = detid.rawId();
 
-  // Get the vector of simtrackIDs associated with this rechit
-  simtrackid = associateHitId(thit);
-  
-  //
-  //Save the SimHits in a vector. for the matched hits both the rphi and stereo simhits are saved. 
-  //
-    //now get the SimHit from the trackid
-  vector<PSimHit> simHit;
+  // Get the vectors of simtrackIDs and simHit indices associated with this rechit
+  associateHitId(thit, simtrackid, &simhitCFPos);
+//   std::cout << "recHit subdet, detID = " << detid.subdetId() << ", " << detID << ", (bnch, evt, trk) = ";
+//   for (size_t i=0; i<simtrackid.size(); ++i)
+//     std::cout << ", (" << simtrackid[i].second.bunchCrossing() << ", "
+// 	      << simtrackid[i].second.event() << ", " << simtrackid[i].first << ")";
+//   std::cout << std::endl; 
+
+  // Get the vector of simHits associated with this rechit
+  std::vector<PSimHit> simHit;
+
+  if (simhitCFPos.size() > 0) {
+    // For the strips we can make use of the indices to the simHit collections taken
+    //  from the DigiSimLinks and returned in simhitCFPos.
+    //  simhitCFPos[i] contains the full address of the ith simhit:
+    //   <collection, index> = <<subdet, tofBin>, index>
+    for(size_t i=0; i<simhitCFPos.size(); i++) {
+      simhitAddr theSimHitAddr = simhitCFPos[i];
+      simHitCollectionID theSimHitCollID = theSimHitAddr.first;
+      simhit_collectionMap::const_iterator it = SimHitCollMap.find(theSimHitCollID);
+      if (it!= SimHitCollMap.end()) {
+	simHit = it->second;
+	PSimHit theSimHit = simHit[theSimHitAddr.second];
+        result.push_back(theSimHit);
+
+// 	std::cout << "by CFpos, simHit detId = " << theSimHit.detUnitId() << " address = (" << (theSimHitAddr.first).first
+// 		  << ", " << (theSimHitAddr.first).second << ", " << theSimHitAddr.second
+// 		  << "), process = " << theSimHit.processType() << " (" << theSimHit.eventId().bunchCrossing()
+// 		  << ", " << theSimHit.eventId().event() << ", " << theSimHit.trackId() << ")" << std::endl;
+      }
+    }
+    return result;
+  }
+
+  // Here get the SimHit from the trackid, for pixels.
   std::map<unsigned int, std::vector<PSimHit> >::const_iterator it = SimHitMap.find(detID);
-  simHit.clear();
   if (it!= SimHitMap.end()) {
     simHit = it->second;
     vector<PSimHit>::const_iterator simHitIter = simHit.begin();
@@ -156,20 +217,27 @@ std::vector<PSimHit> TrackerHitAssociator::associateHit(const TrackingRecHit & t
       const PSimHit ihit = *simHitIter;
       unsigned int simHitid = ihit.trackId();
       EncodedEventId simHiteid = ihit.eventId();
+//       std::cout << "simHit, process = " << ihit.processType() << " (" << ihit.eventId().bunchCrossing()
+// 		<< ", " << ihit.eventId().event() << ", " << ihit.trackId() << ")";
 	
       for(size_t i=0; i<simtrackid.size();i++) {
 	if(simHitid == simtrackid[i].first && simHiteid == simtrackid[i].second) {
+//      In replay mode the MixingModule doesn't seem to save the eventId.event(); test on bunchCrossing only.
+// 	if(simHitid == simtrackid[i].first && simHiteid.bunchCrossing() == simtrackid[i].second.bunchCrossing()) {
 // 	    	cout << "Associator ---> ID" << ihit.trackId() << " Simhit x= " << ihit.localPosition().x() 
-// 	    	     << " y= " <<  ihit.localPosition().y() << " z= " <<  ihit.localPosition().x() << endl; 
+//                   << " y= " <<  ihit.localPosition().y() << " z= " <<  ihit.localPosition().x() << endl;
+// 	  std::cout << " matches";
 	  result.push_back(ihit);
 	  break;
 	}
       }
+//       std::cout << std::endl;
     }
 
   }else{
 
-    /// Check if it's the gluedDet   
+    /// Check if it's the gluedDet.
+    //  (We don't expect to get here because strips are handled by direct simHit matching above.)   
     std::map<unsigned int, std::vector<PSimHit> >::const_iterator itrphi =
       SimHitMap.find(detID+2);  //iterator to the simhit in the rphi module
     std::map<unsigned int, std::vector<PSimHit> >::const_iterator itster = 
@@ -184,9 +252,10 @@ std::vector<PSimHit> TrackerHitAssociator::associateHit(const TrackingRecHit & t
 	unsigned int simHitid = ihit.trackId();
 	EncodedEventId simHiteid = ihit.eventId();
 	for(size_t i=0; i<simtrackid.size();i++) {
-	  if(simHitid == simtrackid[i].first && simHiteid == simtrackid[i].second) {
+	  if(simHitid == simtrackid[i].first && simHiteid == simtrackid[i].second) { 
+// 	  if(simHitid == simtrackid[i].first && simHiteid.bunchCrossing() == simtrackid[i].second.bunchCrossing()) {
 	    //	  cout << "GluedDet Associator ---> ID" << ihit.trackId() << " Simhit x= " << ihit.localPosition().x() 
-	    //	       << " y= " <<  ihit.localPosition().y() << " z= " <<  ihit.localPosition().x() << endl; 
+            //         << " y= " <<  ihit.localPosition().y() << " z= " <<  ihit.localPosition().x() << endl; 
 	    result.push_back(ihit);
 	    break;
 	  }
@@ -205,15 +274,16 @@ std::vector< SimHitIdpr > TrackerHitAssociator::associateHitId(const TrackingRec
   return simhitid;
 }
 
-void TrackerHitAssociator::associateHitId(const TrackingRecHit & thit, std::vector< SimHitIdpr > & simtkid) const
+void TrackerHitAssociator::associateHitId(const TrackingRecHit & thit, std::vector< SimHitIdpr > & simtkid,
+                                          std::vector<simhitAddr>* simhitCFPos) const
 {
-  
+
     simtkid.clear();
     
   //get the Detector type of the rechit
     DetId detid=  thit.geographicalId();
     if (const SiTrackerMultiRecHit * rechit = dynamic_cast<const SiTrackerMultiRecHit *>(&thit)){
-       simtkid=associateMultiRecHitId(rechit);
+       simtkid=associateMultiRecHitId(rechit, simhitCFPos);
     }
     
   //cout << "Associator ---> get Detid " << detID << endl;
@@ -227,25 +297,25 @@ void TrackerHitAssociator::associateHitId(const TrackingRecHit & thit, std::vect
 	if(const SiStripRecHit2D * rechit = 
 	   dynamic_cast<const SiStripRecHit2D *>(&thit))
 	  {	  
-	    associateSiStripRecHit(rechit, simtkid);
+	    associateSiStripRecHit(rechit, simtkid, simhitCFPos);
 	  }
-	//check if it is a matched SiStripMatchedRecHit2D
+	//check if it is a SiStripRecHit1D
 	else  if(const SiStripRecHit1D * rechit = 
 		 dynamic_cast<const SiStripRecHit1D *>(&thit))
 	  {	  
-	    associateSiStripRecHit(rechit,simtkid);
+	    associateSiStripRecHit(rechit, simtkid, simhitCFPos);
 	  }
-	//check if it is a matched SiStripMatchedRecHit2D
+	//check if it is a SiStripMatchedRecHit2D
 	else  if(const SiStripMatchedRecHit2D * rechit = 
 		 dynamic_cast<const SiStripMatchedRecHit2D *>(&thit))
 	  {	  
-	    simtkid = associateMatchedRecHit(rechit);
+	    simtkid = associateMatchedRecHit(rechit, simhitCFPos);
 	  }
 	//check if it is a  ProjectedSiStripRecHit2D
 	else if(const ProjectedSiStripRecHit2D * rechit = 
 		dynamic_cast<const ProjectedSiStripRecHit2D *>(&thit))
 	  {	  
-	    simtkid = associateProjectedRecHit(rechit);
+	    simtkid = associateProjectedRecHit(rechit, simhitCFPos);
 	  }
 	else{
 	  //std::cout << "associate to invalid" << std::endl;
@@ -274,24 +344,18 @@ void TrackerHitAssociator::associateHitId(const TrackingRecHit & thit, std::vect
 }
 
 template<typename T>
-void TrackerHitAssociator::associateSiStripRecHit(const T *simplerechit, std::vector<SimHitIdpr>& simtrackid) const
+void TrackerHitAssociator::associateSiStripRecHit(const T *simplerechit, std::vector<SimHitIdpr>& simtrackid, std::vector<simhitAddr>* simhitCFPos) const
 {
   const SiStripCluster* clust = &(*simplerechit->cluster());
-  associateSimpleRecHitCluster(clust,simplerechit->geographicalId(),simtrackid);
+  associateSimpleRecHitCluster(clust, simplerechit->geographicalId(), simtrackid, simhitCFPos);
 }
 
 void TrackerHitAssociator::associateSimpleRecHitCluster(const SiStripCluster* clust,
-							const uint32_t& detID,
-							std::vector<SimHitIdpr>& simtrackid) const{
-  //  std::cout <<"ASSOCIATE SIMPLE RECHIT" << std::endl;	    
+							const DetId& detid,
+							std::vector<SimHitIdpr>& simtrackid,
+							std::vector<simhitAddr>* simhitCFPos) const {
   
-  //to store temporary charge information
-  std::vector<SimHitIdpr> cache_simtrackid; 
-  cache_simtrackid.clear();
-  
-  std::map<SimHitIdpr, vector<float> > temp_simtrackid;
-  temp_simtrackid.clear();
-  
+  uint32_t detID = detid.rawId();
   edm::DetSetVector<StripDigiSimLink>::const_iterator isearch = stripdigisimlink->find(detID); 
   if(isearch != stripdigisimlink->end()) {  //if it is not empty
     edm::DetSet<StripDigiSimLink> link_detset = (*isearch);
@@ -305,20 +369,17 @@ void TrackerHitAssociator::associateSimpleRecHitCluster(const SiStripCluster* cl
 //       std::cout << " detID = " << detID << " DETSET size = " << link_detset.data.size() << std::endl;
       //use a vector
       std::vector<SimHitIdpr> idcachev;
+      std::vector<simhitAddr> CFposcachev;
       for(edm::DetSet<StripDigiSimLink>::const_iterator linkiter = link_detset.data.begin(); linkiter != link_detset.data.end(); linkiter++){
-	//StripDigiSimLink link = *linkiter;
-	
 	if( (int)(linkiter->channel()) >= first  && (int)(linkiter->channel()) < last ){
 	  
 	  //check this digisimlink
 // 	  printf("%s%4d%s%8d%s%3d%s%8.4f\n", "CHANNEL = ", linkiter->channel(), " TrackID = ", linkiter->SimTrackId(),
-// 		 " Process = ", TrackerHits.getObject(linkiter->CFposition()-1).processType(), " fraction = ", linkiter->fraction());
+// 		 " tofBin = ", linkiter->TofBin(), " fraction = ", linkiter->fraction());
 	  /*
 	    std::cout << "CHECKING CHANNEL  = " << linkiter->channel()   << std::endl;
 	    std::cout << "TrackID  = " << linkiter->SimTrackId()  << std::endl;
 	    std::cout << "Position = " << linkiter->CFposition()  << std::endl;
-	    std::cout << " POS -1 = " << TrackerHits.getObject(linkiter->CFposition()-1).localPosition() << std::endl;
-	    std::cout << " Process = " << TrackerHits.getObject(linkiter->CFposition()-1).processType() << std::endl;
 	    std::cout << " fraction = " << linkiter->fraction() << std::endl;
 	  */
 	  
@@ -337,6 +398,28 @@ void TrackerHitAssociator::associateSimpleRecHitCluster(const SiStripCluster* cl
 	    idcachev.push_back(currentId);
 	    simtrackid.push_back(currentId);
 	  }
+	  	  
+	  if (simhitCFPos != 0) {
+	  //create a vector that contains all the position (in the MixCollection) of the SimHits that contributed to the RecHit
+	  //write position only once
+	    unsigned int currentCFPos = linkiter->CFposition();
+	    unsigned int tofBin = linkiter->TofBin();
+	    simHitCollectionID theSimHitCollID = std::make_pair(detid.subdetId(), tofBin);
+	    simhitAddr currentAddr = std::make_pair(theSimHitCollID, currentCFPos);
+
+	    if(find(CFposcachev.begin(), CFposcachev.end(), currentAddr ) == CFposcachev.end()) {
+//   	      std::cout << "CHECKING CHANNEL  = " << linkiter->channel()   << std::endl;
+// 	      std::cout << "\tTrackID  = " << linkiter->SimTrackId()  << "\tCFPos = " << currentCFPos <<"\ttofBin = " << tofBin << std::endl;
+// 	      simhit_collectionMap::const_iterator it = SimHitCollMap.find(theSimHitCollID);
+// 	      if (it!= SimHitCollMap.end()) {
+// 		PSimHit theSimHit = it->second[currentCFPos];
+// 		std::cout << "\tLocal Pos = " << theSimHit.localPosition()
+// 			  << "\tProcess = " << theSimHit.processType() << std::endl;
+// 	      }
+	      CFposcachev.push_back(currentAddr);
+	      simhitCFPos->push_back(currentAddr);
+	    }
+	  }
 	}
       }    
     }
@@ -346,18 +429,16 @@ void TrackerHitAssociator::associateSimpleRecHitCluster(const SiStripCluster* cl
   }
 }
 
-std::vector<SimHitIdpr>  TrackerHitAssociator::associateMatchedRecHit(const SiStripMatchedRecHit2D * matchedrechit) const
+std::vector<SimHitIdpr>  TrackerHitAssociator::associateMatchedRecHit(const SiStripMatchedRecHit2D* matchedrechit, std::vector<simhitAddr>* simhitCFPos) const
 {
-  vector<SimHitIdpr> matched_mono;
-  vector<SimHitIdpr> matched_st;
-  matched_mono.clear();
-  matched_st.clear();
+  std::vector<SimHitIdpr> matched_mono;
+  std::vector<SimHitIdpr> matched_st;
 
   const SiStripRecHit2D mono = matchedrechit->monoHit();
   const SiStripRecHit2D st = matchedrechit->stereoHit();
   //associate the two simple hits separately
-  associateSiStripRecHit(&mono,matched_mono );
-  associateSiStripRecHit(&st, matched_st );
+  associateSiStripRecHit(&mono, matched_mono, simhitCFPos);
+  associateSiStripRecHit(&st, matched_st, simhitCFPos);
   
   //save in a vector all the simtrack-id's that are common to mono and stereo hits
   std::vector<SimHitIdpr> simtrackid;
@@ -365,29 +446,29 @@ std::vector<SimHitIdpr>  TrackerHitAssociator::associateMatchedRecHit(const SiSt
     std::vector<SimHitIdpr> idcachev;
     for(vector<SimHitIdpr>::iterator mhit=matched_mono.begin(); mhit != matched_mono.end(); mhit++){
       //save only once the ID
-      if(find(idcachev.begin(), idcachev.end(),(*mhit)) == idcachev.end()) {
+      if(find(idcachev.begin(), idcachev.end(), (*mhit)) == idcachev.end()) {
 	idcachev.push_back(*mhit);
 	//save if the stereoID matched the monoID
-	if(find(matched_st.begin(), matched_st.end(),(*mhit))!=matched_st.end()){
+	if(find(matched_st.begin(), matched_st.end(), (*mhit)) != matched_st.end()) {
 	  simtrackid.push_back(*mhit);
-	  //std::cout << "matched case: saved ID " << (*mhit) << std::endl; 
 	}
       }
     }
   }
+  
   return simtrackid;
 }
 
 
-std::vector<SimHitIdpr>  TrackerHitAssociator::associateProjectedRecHit(const ProjectedSiStripRecHit2D * projectedrechit) const
+std::vector<SimHitIdpr>  TrackerHitAssociator::associateProjectedRecHit(const ProjectedSiStripRecHit2D * projectedrechit,
+									std::vector<simhitAddr>* simhitCFPos) const
 {
   //projectedRecHit is a "matched" rechit with only one component
 
-  vector<SimHitIdpr> matched_mono;
-  matched_mono.clear();
+  std::vector<SimHitIdpr> matched_mono;
  
   const SiStripRecHit2D mono = projectedrechit->originalHit();
-  associateSiStripRecHit(&mono, matched_mono);
+  associateSiStripRecHit(&mono, matched_mono, simhitCFPos);
   return matched_mono;
 }
 
@@ -467,7 +548,7 @@ std::vector<PSimHit> TrackerHitAssociator::associateMultiRecHit(const SiTrackerM
   return associateHit(*componenthits[idmostprobable]);
 }
 
-std::vector<SimHitIdpr> TrackerHitAssociator::associateMultiRecHitId(const SiTrackerMultiRecHit * multirechit) const{
+std::vector<SimHitIdpr> TrackerHitAssociator::associateMultiRecHitId(const SiTrackerMultiRecHit * multirechit, std::vector<simhitAddr>* simhitCFPos) const{
   std::vector<const TrackingRecHit*> componenthits = multirechit->recHits();
   int size=multirechit->weights().size(), idmostprobable=0;
   
@@ -475,7 +556,9 @@ std::vector<SimHitIdpr> TrackerHitAssociator::associateMultiRecHitId(const SiTra
     if(multirechit->weight(i)>multirechit->weight(idmostprobable)) idmostprobable=i;
   }
   
-  return associateHitId(*componenthits[idmostprobable]);
+  std::vector< SimHitIdpr > simhitid;
+  associateHitId(*componenthits[idmostprobable], simhitid, simhitCFPos);
+  return simhitid;
 }
 
 std::vector<SimHitIdpr>  TrackerHitAssociator::associateGSMatchedRecHit(const SiTrackerGSMatchedRecHit2D * gsmrechit) const

--- a/SimTracker/TrackerHitAssociation/src/TrackerHitAssociator.cc
+++ b/SimTracker/TrackerHitAssociation/src/TrackerHitAssociator.cc
@@ -195,13 +195,16 @@ std::vector<PSimHit> TrackerHitAssociator::associateHit(const TrackingRecHit & t
       simhit_collectionMap::const_iterator it = SimHitCollMap.find(theSimHitCollID);
       if (it!= SimHitCollMap.end()) {
 	simHit = it->second;
-	PSimHit theSimHit = simHit[theSimHitAddr.second];
-        result.push_back(theSimHit);
+	unsigned int theSimHitIndex = theSimHitAddr.second;
+	if (theSimHitIndex < simHit.size()) {
+	  PSimHit theSimHit = simHit[theSimHitIndex];
+	  result.push_back(theSimHit);
 
-// 	std::cout << "by CFpos, simHit detId = " << theSimHit.detUnitId() << " address = (" << (theSimHitAddr.first).first
-// 		  << ", " << (theSimHitAddr.first).second << ", " << theSimHitAddr.second
-// 		  << "), process = " << theSimHit.processType() << " (" << theSimHit.eventId().bunchCrossing()
-// 		  << ", " << theSimHit.eventId().event() << ", " << theSimHit.trackId() << ")" << std::endl;
+//           std::cout << "by CFpos, simHit detId =  " << theSimHit.detUnitId() << " address = (" << (theSimHitAddr.first).first
+// 		    << ", " << (theSimHitAddr.first).second << ", " << theSimHitIndex
+// 		    << "), process = " << theSimHit.processType() << " (" << theSimHit.eventId().bunchCrossing()
+// 		    << ", " << theSimHit.eventId().event() << ", " << theSimHit.trackId() << ")" << std::endl;
+	}
       }
     }
     return result;


### PR DESCRIPTION
With this PR we fully restore the hit association functionality to what it was before CMSSW_6_2_0_pre8.  That is, for the strip tracker we follow the digiSimLink directly back to the simHit.  This is in contrast to the previous fix (PRs 2279, 2285, 3021, 3637), where the match was indirect through the simTrack, and is sometimes ambiguous.
Here we add a bit to the stripDigiSimLink to specify the Low- vs High-Tof collection, which in combination with the detID.subDet allows the collection-relative pointers to be used.  The digitizer supplies this information on creation of the digiSimLink.  The hitAssociator now uses this information.  I hope I've implemented this in a way that preserves the thread-safe behavior of the hitAssociator.
