### PR TITLE
EventFilter/Utilities fixes (Jul MWGR)

### DIFF
--- a/EventFilter/Utilities/plugins/FRDStreamSource.h
+++ b/EventFilter/Utilities/plugins/FRDStreamSource.h
@@ -46,6 +46,7 @@ private:
   std::auto_ptr<FEDRawDataCollection> rawData_;
   std::vector<char> buffer_;
   const bool verifyAdler32_;
+  unsigned int detectedFRDversion_=0;
 };
 
 #endif // EventFilter_Utilities_FRDStreamSource_h

--- a/EventFilter/Utilities/plugins/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/plugins/FedRawDataInputSource.cc
@@ -407,14 +407,16 @@ inline evf::EvFDaqDirector::FileStatus FedRawDataInputSource::getNextEvent()
 
     unsigned char *dataPosition = currentFile_->chunks_[0]->buf_+ currentFile_->chunkPosition_;
 
-    if (detectedFRDversion_==0) {
-      detectedFRDversion_=*((uint32*)dataPosition);
-      assert(detectedFRDversion_>=1 && detectedFRDversion_<=3);
-    }
- 
-    if (bufferInputRead_ < headerSize[detectedFRDversion_])
+
+    if (!bufferInputRead_ || bufferInputRead_ < headerSize[detectedFRDversion_])
     {
       readNextChunkIntoBuffer(currentFile_);
+
+      if (detectedFRDversion_==0) {
+        detectedFRDversion_=*((uint32*)dataPosition);
+        assert(detectedFRDversion_>=1 && detectedFRDversion_<=3);
+      }
+
       //recalculate chunk position
       dataPosition = currentFile_->chunks_[0]->buf_+ currentFile_->chunkPosition_;
       if ( bufferInputRead_ < headerSize[detectedFRDversion_])

--- a/EventFilter/Utilities/plugins/FedRawDataInputSource.h
+++ b/EventFilter/Utilities/plugins/FedRawDataInputSource.h
@@ -112,6 +112,7 @@ private:
 
   typedef std::pair<InputFile*,InputChunk*> ReaderInfo;
 
+  uint32 detectedFRDversion_=0;
   InputFile *currentFile_ = nullptr;
   bool chunkIsFree_=false;
 

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -480,7 +480,7 @@ namespace evf {
     if ( fileStatus == noFile ) {
       struct stat buf;
       //edm::LogInfo("EvFDaqDirector") << " looking for EoR file: " << getEoRFilePath().c_str();
-      if ( stat(getEoRFilePath().c_str(), &buf) == 0 )
+      if ( stat(getEoRFilePath().c_str(), &buf) == 0 || stat(bu_run_dir_.c_str(), &buf)!=0)
         fileStatus = runEnded;
     }
     return fileStatus;

--- a/EventFilter/Utilities/test/startBU.py
+++ b/EventFilter/Utilities/test/startBU.py
@@ -86,6 +86,7 @@ process.out = cms.OutputModule("RawStreamFileWriterForBU",
     numEventsPerFile= cms.untracked.uint32(20),
     jsonDefLocation = cms.untracked.string(cmsswbase+"/src/EventFilter/Utilities/plugins/budef.jsd"),
     jsonEoLDefLocation = cms.untracked.string(cmsswbase+"/src/EventFilter/Utilities/plugins/eols.jsd"),
+    frdVersion=cms.untracked.uint32(3),
     debug = cms.untracked.bool(True))
 
 process.p = cms.Path(process.s+process.a)

--- a/EventFilter/Utilities/test/startFU.py
+++ b/EventFilter/Utilities/test/startFU.py
@@ -87,6 +87,7 @@ process.source = cms.Source("FedRawDataInputSource",
     runNumber = cms.untracked.uint32(options.runNumber),
     getLSFromFilename = cms.untracked.bool(True),
     testModeNoBuilderUnit = cms.untracked.bool(False),
+    verifyAdler32 = cms.untracked.bool(True),
     eventChunkSize = cms.untracked.uint32(16),
     numBuffers = cms.untracked.uint32(2),
     eventChunkBlock = cms.untracked.uint32(1)


### PR DESCRIPTION
This pull request contains:
- improvment of FRD header handling between different versions (survive events smaller than v2 header)
- input source exit on deleted run directory
- micro-merging uses fwrite and fread instead of getc/putc
