### PR TITLE
Fix bug in cleaning of HLT jets against electrons

### DIFF
--- a/HLTrigger/JetMET/src/HLTJetCollForElePlusJets.cc
+++ b/HLTrigger/JetMET/src/HLTJetCollForElePlusJets.cc
@@ -76,11 +76,15 @@ HLTJetCollForElePlusJets<T>::produce(edm::Event& iEvent, const edm::EventSetup& 
   iEvent.getByToken(m_theElectronToken,PrevFilterOutput);
  
   //its easier on the if statement flow if I try everything at once, shouldnt add to timing
+  // Electrons can be stored as objects of types TriggerCluster, TriggerElectron, or TriggerPhoton
   std::vector<edm::Ref<reco::RecoEcalCandidateCollection> > clusCands;
   PrevFilterOutput->getObjects(trigger::TriggerCluster,clusCands);
 
   std::vector<edm::Ref<reco::ElectronCollection> > eleCands;
   PrevFilterOutput->getObjects(trigger::TriggerElectron,eleCands);
+  
+  trigger::VRphoton photonCands;
+  PrevFilterOutput->getObjects(trigger::TriggerPhoton, photonCands);
   
   //prepare the collection of 3-D vector for electron momenta
   std::vector<TVector3> ElePs;
@@ -99,6 +103,15 @@ HLTJetCollForElePlusJets<T>::produce(edm::Event& iEvent, const edm::EventSetup& 
 			      eleCands[candNr]->superCluster()->position().x(),
 			      eleCands[candNr]->superCluster()->position().y(),
 			      eleCands[candNr]->superCluster()->position().z());
+      ElePs.push_back(positionVector);
+    }
+  }
+  else if(!photonCands.empty()){ // try trigger photons
+    for(size_t candNr=0;candNr<photonCands.size();candNr++){
+      TVector3 positionVector(
+                  photonCands[candNr]->superCluster()->position().x(),
+                  photonCands[candNr]->superCluster()->position().y(),
+                  photonCands[candNr]->superCluster()->position().z());
       ElePs.push_back(positionVector);
     }
   }

--- a/HLTrigger/JetMET/src/HLTJetCollectionsForElePlusJets.cc
+++ b/HLTrigger/JetMET/src/HLTJetCollectionsForElePlusJets.cc
@@ -82,11 +82,15 @@ HLTJetCollectionsForElePlusJets<T>::produce(edm::Event& iEvent, const edm::Event
   iEvent.getByToken(m_theElectronToken,PrevFilterOutput);
  
   //its easier on the if statement flow if I try everything at once, shouldnt add to timing
+  // Electrons can be stored as objects of types TriggerCluster, TriggerElectron, or TriggerPhoton
   std::vector<edm::Ref<reco::RecoEcalCandidateCollection> > clusCands;
   PrevFilterOutput->getObjects(trigger::TriggerCluster,clusCands);
 
   std::vector<edm::Ref<reco::ElectronCollection> > eleCands;
   PrevFilterOutput->getObjects(trigger::TriggerElectron,eleCands);
+  
+  trigger::VRphoton photonCands;
+  PrevFilterOutput->getObjects(trigger::TriggerPhoton, photonCands);
   
   //prepare the collection of 3-D vector for electron momenta
   std::vector<TVector3> ElePs;
@@ -105,6 +109,15 @@ HLTJetCollectionsForElePlusJets<T>::produce(edm::Event& iEvent, const edm::Event
                   eleCands[candNr]->superCluster()->position().x(),
                   eleCands[candNr]->superCluster()->position().y(),
                   eleCands[candNr]->superCluster()->position().z());
+      ElePs.push_back(positionVector);
+    }
+  }
+  else if(!photonCands.empty()){ // try trigger photons
+    for(size_t candNr=0;candNr<photonCands.size();candNr++){
+      TVector3 positionVector(
+                  photonCands[candNr]->superCluster()->position().x(),
+                  photonCands[candNr]->superCluster()->position().y(),
+                  photonCands[candNr]->superCluster()->position().z());
       ElePs.push_back(positionVector);
     }
   }

--- a/HLTrigger/JetMET/src/HLTJetCollectionsForLeptonPlusJets.cc
+++ b/HLTrigger/JetMET/src/HLTJetCollectionsForLeptonPlusJets.cc
@@ -72,11 +72,15 @@ HLTJetCollectionsForLeptonPlusJets<jetType>::produce(edm::Event& iEvent, const e
   iEvent.getByToken(m_theLeptonToken,PrevFilterOutput);
  
   //its easier on the if statement flow if I try everything at once, shouldnt add to timing
+  // Electrons can be stored as objects of types TriggerCluster, TriggerElectron, or TriggerPhoton
   vector<Ref<reco::RecoEcalCandidateCollection> > clusCands;
   PrevFilterOutput->getObjects(trigger::TriggerCluster,clusCands);
 
   vector<Ref<reco::ElectronCollection> > eleCands;
   PrevFilterOutput->getObjects(trigger::TriggerElectron,eleCands);
+  
+  trigger::VRphoton photonCands;
+  PrevFilterOutput->getObjects(trigger::TriggerPhoton, photonCands);
   
   vector<reco::RecoChargedCandidateRef> muonCands;
   PrevFilterOutput->getObjects(trigger::TriggerMuon,muonCands);
@@ -88,7 +92,7 @@ HLTJetCollectionsForLeptonPlusJets<jetType>::produce(edm::Event& iEvent, const e
   
   auto_ptr < JetCollectionVector > allSelections(new JetCollectionVector());
   
- if(!clusCands.empty()){ //try trigger cluster
+ if(!clusCands.empty()){ // try trigger clusters
     for(size_t candNr=0;candNr<clusCands.size();candNr++){  
         JetRefVector refVector;
         for (unsigned int j = 0; j < theJetCollection.size(); j++) {
@@ -98,7 +102,7 @@ HLTJetCollectionsForLeptonPlusJets<jetType>::produce(edm::Event& iEvent, const e
     }
  }
 
- if(!eleCands.empty()){ //try trigger cluster
+ if(!eleCands.empty()){ // try electrons
     for(size_t candNr=0;candNr<eleCands.size();candNr++){  
         JetRefVector refVector;
         for (unsigned int j = 0; j < theJetCollection.size(); j++) {
@@ -107,8 +111,18 @@ HLTJetCollectionsForLeptonPlusJets<jetType>::produce(edm::Event& iEvent, const e
     allSelections->push_back(refVector);
     }
  }
+ 
+ if(!photonCands.empty()){ // try photons
+    for(size_t candNr=0;candNr<photonCands.size();candNr++){  
+        JetRefVector refVector;
+        for (unsigned int j = 0; j < theJetCollection.size(); j++) {
+          if (deltaR(photonCands[candNr]->superCluster()->position(),theJetCollection[j]) > minDeltaR_) refVector.push_back(JetRef(theJetCollectionHandle, j));
+        }
+    allSelections->push_back(refVector);
+    }
+ }
 
- if(!muonCands.empty()){ //try trigger cluster
+ if(!muonCands.empty()){ // muons
     for(size_t candNr=0;candNr<muonCands.size();candNr++){  
         JetRefVector refVector;
         for (unsigned int j = 0; j < theJetCollection.size(); j++) {


### PR DESCRIPTION
Several plugins for jet-lepton cleaning at HLT access electrons as records of type `trigger::TriggerElectron` or `trigger::TriggerCluster`. However, they might be stored as `trigger::TriggerPhoton` as well as mentioned [here](https://hypernews.cern.ch/HyperNews/CMS/get/egamma-hlt/201/1.html). The pull request extends the plugins to deal with `trigger::TriggerPhoton` as well.

Further details and a validation of the changes are described in [these slides](https://indico.cern.ch/event/325987/contribution/5/material/slides/0.pdf).
