### PR TITLE
Replace boost:: with std:: where feasible in framework

### DIFF
--- a/AnalysisAlgos/SiStripClusterInfoProducer/plugins/SiStripProcessedRawDigiProducer.cc
+++ b/AnalysisAlgos/SiStripClusterInfoProducer/plugins/SiStripProcessedRawDigiProducer.cc
@@ -13,6 +13,8 @@
 #include "DataFormats/SiStripDigi/interface/SiStripRawDigi.h"
 #include "DataFormats/SiStripDigi/interface/SiStripProcessedRawDigi.h"
 
+#include "boost/bind.hpp"
+
 #include <functional>
 
 SiStripProcessedRawDigiProducer::SiStripProcessedRawDigiProducer(edm::ParameterSet const& conf)

--- a/DQM/SiStripMonitorHardware/src/SiStripFEDEmulator.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripFEDEmulator.cc
@@ -2,6 +2,8 @@
 #include "DQM/SiStripMonitorHardware/interface/SiStripFEDEmulator.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
+#include "boost/bind.hpp"
+
 using edm::LogError;
 using edm::LogInfo;
 using edm::LogWarning;

--- a/DataFormats/Common/interface/DetSetAlgorithm.h
+++ b/DataFormats/Common/interface/DetSetAlgorithm.h
@@ -2,9 +2,8 @@
 #define DataFormats_Common_DetSetAlgorithm_h
 
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
-#include <boost/ref.hpp>
-#include <boost/function.hpp>
 #include <algorithm>
+#include <functional>
 
 //FIXME remove New when ready
 namespace edmNew {
@@ -24,7 +23,7 @@ namespace edmNew {
     typename DSTV::Range range = detsetRangeFromPair(v,sel);
     for(typename DSTV::const_iterator id=range.first; id!=range.second; id++)
       std::for_each((*id).begin(), (*id).end(),
-		    boost::function<void(const data_type &)>(boost::ref(f)));
+		    std::function<void(const data_type &)>(std::ref(f)));
   }
 
   namespace dstvdetails {

--- a/DataFormats/Common/interface/DetSetVector.h
+++ b/DataFormats/Common/interface/DetSetVector.h
@@ -41,8 +41,10 @@ behavior (usually a core dump).
 
 #include "boost/concept_check.hpp"
 #include "boost/mpl/if.hpp"
+#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
+#else
 #include "boost/bind.hpp"
-
+#endif
 
 #include "DataFormats/Common/interface/CMS_CLASS_VERSION.h"
 #include "DataFormats/Common/interface/DetSet.h"
@@ -380,7 +382,11 @@ namespace edm {
   {
     std::transform(this->begin(), this->end(),
 		   std::back_inserter(result),
+#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
+		   std::bind(&DetSet<T>::id,std::placeholders::_1));
+#else
 		   boost::bind(&DetSet<T>::id,_1));
+#endif
   }
 
   template <class T>

--- a/DataFormats/Common/interface/OneToManyWithQualityGeneric.h
+++ b/DataFormats/Common/interface/OneToManyWithQualityGeneric.h
@@ -3,10 +3,14 @@
 #include "DataFormats/Common/interface/AssociationMapHelpers.h"
 #include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/Common/interface/RefProd.h"
+#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
+#include <functional>
+#else
+#include "boost/bind.hpp"
+#endif
 #include <map>
 #include <vector>
 #include <algorithm>
-#include <boost/bind.hpp>
 
 #include "DataFormats/Common/interface/MapRefViewTrait.h"
 
@@ -78,13 +82,22 @@ namespace edm {
     static void sort(map_type & m) {
       //      using namespace boost::lambda;
       for(typename map_type::iterator i = m.begin(), iEnd = m.end(); i != iEnd; ++i) {
+#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
+        using std::placeholders::_1;
+        using std::placeholders::_2;
+#endif
 	map_assoc & v = i->second;
 	// Q std::pair<index, Q>::*quality = &std::pair<index, Q>::second;
 	// std::sort(v.begin(), v.end(),
 	// 	  bind(quality, boost::lambda::_2) < bind(quality, boost::lambda::_1));
            std::sort(v.begin(), v.end(), 
+#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
+                  std::bind(std::less<Q>(), 
+                  std::bind(&std::pair<index, Q>::second,_2), std::bind( &std::pair<index, Q>::second,_1)
+#else
                   boost::bind(std::less<Q>(), 
                   boost::bind(&std::pair<index, Q>::second,_2), boost::bind( &std::pair<index, Q>::second,_1)
+#endif
                              )
            );
 

--- a/DataFormats/Common/src/DataFrameContainer.cc
+++ b/DataFormats/Common/src/DataFrameContainer.cc
@@ -35,7 +35,7 @@ namespace edm {
     }
     {
       //      std::transform(indices.begin(),indices.end(),indices.begin(),
-      //	     boost::bind(std::multiplies<int>(),m_stride,_1));
+      //	     std::bind(std::multiplies<int>(),m_stride,std::placeholders::_1));
       DataContainer tmp(m_data.size());
       size_type s = m_stride*sizeof(data_type);
       for(size_type j=0, i=0; i!=indices.size(); ++i, j+=m_stride)

--- a/DataFormats/Common/test/DataFrame_t.cpp
+++ b/DataFormats/Common/test/DataFrame_t.cpp
@@ -8,7 +8,6 @@
 #include <vector>
 #include <algorithm>
 #include <cstdlib>
-#include <boost/bind.hpp>
 #include <numeric>
 #include <cstring>
 
@@ -42,9 +41,10 @@ public:
 CPPUNIT_TEST_SUITE_REGISTRATION(TestDataFrame);
 
 TestDataFrame::TestDataFrame() : sv1(10),sv2(10){ 
+  using std::placeholders::_1;
   edm::DataFrame::data_type v[10] = {0,1,2,3,4,5,6,7,8,9};
   std::copy(v,v+10,sv1.begin());
-  std::transform(sv1.begin(),sv1.end(),sv2.begin(),boost::bind(std::plus<edm::DataFrame::data_type>(),10,_1));
+  std::transform(sv1.begin(),sv1.end(),sv2.begin(),std::bind(std::plus<edm::DataFrame::data_type>(),10,_1));
 } 
 
 

--- a/DataFormats/Common/test/exDSTV.cpp
+++ b/DataFormats/Common/test/exDSTV.cpp
@@ -1,7 +1,7 @@
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include <iostream>
-#include <boost/function.hpp>
+#include <functional>
 
 struct T {
 
@@ -40,7 +40,7 @@ int main()  try {
   DST d2 = dstv.insert(4,3);
   d2[0].v=4.15;
 
-  std::for_each(dstv.begin(),dstv.end(),boost::function<void(DST const&)>(print0));
+  std::for_each(dstv.begin(),dstv.end(),std::function<void(DST const&)>(print0));
 
   return 0;
 } catch(cms::Exception const& e) {

--- a/DataFormats/FWLite/src/EventSetup.cc
+++ b/DataFormats/FWLite/src/EventSetup.cc
@@ -13,7 +13,6 @@
 // system include files
 #include <cassert>
 #include <algorithm>
-#include "boost/bind.hpp"
 #include "TTree.h"
 #include "TFile.h"
 #include "TKey.h"
@@ -71,9 +70,10 @@ EventSetup::~EventSetup()
 //
 void 
 EventSetup::syncTo(const edm::EventID& iID, const edm::Timestamp& iTime) {
+   using std::placeholders::_1;
    std::for_each(m_records.begin(),
                  m_records.end(),
-                 boost::bind(&Record::syncTo,_1,iID,iTime));
+                 std::bind(&Record::syncTo,_1,iID,iTime));
 }
 
 //

--- a/FWCore/Framework/interface/ConstProductRegistry.h
+++ b/FWCore/Framework/interface/ConstProductRegistry.h
@@ -22,8 +22,6 @@ Usage:
 #include <vector>
 #include <string>
 
-#include "boost/bind.hpp"
-
 // user include files
 #include "FWCore/Framework/src/SignallingProductRegistry.h"
 #include "FWCore/ServiceRegistry/interface/connect_but_block_self.h"
@@ -68,8 +66,9 @@ namespace edm {
     template< class T, class TMethod>
     void watchProductAdditions(T const& iObj, TMethod iMethod)
     {
+      using std::placeholders::_1;
       serviceregistry::connect_but_block_self(reg_->productAddedSignal_, 
-					      boost::bind(iMethod, iObj,_1));
+					      std::bind(iMethod, iObj,_1));
     }
      
   private:

--- a/FWCore/Framework/interface/ESWatcher.h
+++ b/FWCore/Framework/interface/ESWatcher.h
@@ -19,8 +19,7 @@
 //
 
 // system include files
-#include <boost/bind.hpp>
-#include <boost/function.hpp>
+#include <functional>
 
 // user include files
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -45,7 +44,7 @@ namespace edm {
     
     template <class TObj, class TMemFunc>
     ESWatcher(TObj const& iObj, TMemFunc iFunc):
-    callback_(boost::bind(iFunc,iObj,_1)),
+    callback_(std::bind(iFunc,iObj,std::placeholders::_1)),
     cacheId_(0)
      {}
       //virtual ~ESWatcher();
@@ -70,7 +69,7 @@ namespace edm {
       const ESWatcher& operator=(const ESWatcher&); // stop default
 
       // ---------- member data --------------------------------
-      boost::function<void (const T&)> callback_;
+      std::function<void (const T&)> callback_;
       unsigned long long cacheId_;
 };
 }

--- a/FWCore/Framework/interface/Schedule.h
+++ b/FWCore/Framework/interface/Schedule.h
@@ -111,7 +111,7 @@ namespace edm {
     typedef std::vector<std::string> vstring;
     typedef std::shared_ptr<Worker> WorkerPtr;
     typedef std::vector<Worker*> AllWorkers;
-    typedef std::vector<boost::shared_ptr<OutputModuleCommunicator> > AllOutputModuleCommunicators;
+    typedef std::vector<std::shared_ptr<OutputModuleCommunicator> > AllOutputModuleCommunicators;
 
     typedef std::vector<Worker*> Workers;
 

--- a/FWCore/Framework/src/EDLooperBase.cc
+++ b/FWCore/Framework/src/EDLooperBase.cc
@@ -26,9 +26,6 @@
 #include "FWCore/ServiceRegistry/interface/ParentContext.h"
 #include "FWCore/ServiceRegistry/interface/StreamContext.h"
 
-#include "boost/bind.hpp"
-
-
 namespace edm {
 
   EDLooperBase::EDLooperBase() : iCounter_(0), act_table_(nullptr), moduleChanger_(nullptr),
@@ -83,8 +80,8 @@ namespace edm {
 
     std::set<edm::eventsetup::EventSetupRecordKey> const& keys = modifyingRecords();
     for_all(keys,
-      boost::bind(&eventsetup::EventSetupProvider::resetRecordPlusDependentRecords,
-                  esp, _1));
+      std::bind(&eventsetup::EventSetupProvider::resetRecordPlusDependentRecords,
+                  esp, std::placeholders::_1));
   }
 
   void EDLooperBase::beginOfJob(const edm::EventSetup&) { beginOfJob();}

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -60,7 +60,6 @@
 #include "MessageForSource.h"
 #include "MessageForParent.h"
 
-#include "boost/bind.hpp"
 #include "boost/thread/xtime.hpp"
 
 #include <exception>
@@ -615,11 +614,11 @@ namespace edm {
     }
     schedule_->endJob(c);
     if(hasSubProcess()) {
-      c.call(boost::bind(&SubProcess::doEndJob, subProcess_.get()));
+      c.call(std::bind(&SubProcess::doEndJob, subProcess_.get()));
     }
-    c.call(boost::bind(&InputSource::doEndJob, input_.get()));
+    c.call(std::bind(&InputSource::doEndJob, input_.get()));
     if(looper_) {
-      c.call(boost::bind(&EDLooperBase::endOfJob, looper_));
+      c.call(std::bind(&EDLooperBase::endOfJob, looper_));
     }
     auto actReg = actReg_.get();
     c.call([actReg](){actReg->postEndJobSignal_();});

--- a/FWCore/Framework/src/EventSetupRecordProvider.cc
+++ b/FWCore/Framework/src/EventSetupRecordProvider.cc
@@ -12,7 +12,6 @@
 
 // system include files
 #include <algorithm>
-#include "boost/bind.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/EventSetupRecordProvider.h"
@@ -108,11 +107,12 @@ EventSetupRecordProvider::setValidityInterval(const ValidityInterval& iInterval)
 void 
 EventSetupRecordProvider::setDependentProviders(const std::vector< boost::shared_ptr<EventSetupRecordProvider> >& iProviders)
 {
+   using std::placeholders::_1;
    boost::shared_ptr< DependentRecordIntervalFinder > newFinder(
                                                                 new DependentRecordIntervalFinder(key()));
    
    boost::shared_ptr<EventSetupRecordIntervalFinder> old = swapFinder(newFinder);
-   for_all(iProviders, boost::bind(std::mem_fun(&DependentRecordIntervalFinder::addProviderWeAreDependentOn), &(*newFinder), _1));
+   for_all(iProviders, std::bind(std::mem_fun(&DependentRecordIntervalFinder::addProviderWeAreDependentOn), &(*newFinder), _1));
    //if a finder was already set, add it as a depedency.  This is done to ensure that the IOVs properly change even if the
    // old finder does not update each time a dependent record does change
    if(old.get() != 0) {
@@ -122,7 +122,8 @@ EventSetupRecordProvider::setDependentProviders(const std::vector< boost::shared
 void 
 EventSetupRecordProvider::usePreferred(const DataToPreferredProviderMap& iMap)
 {
-  for_all(providers_, boost::bind(&EventSetupRecordProvider::addProxiesToRecord,this,_1,iMap));
+  using std::placeholders::_1;
+  for_all(providers_, std::bind(&EventSetupRecordProvider::addProxiesToRecord,this,_1,iMap));
   if (1 < multipleFinders_->size()) {
      
      boost::shared_ptr<IntersectingIOVRecordIntervalFinder> intFinder(new IntersectingIOVRecordIntervalFinder(key_));
@@ -170,8 +171,10 @@ EventSetupRecordProvider::addRecordTo(EventSetupProvider& iEventSetupProvider) {
 void 
 EventSetupRecordProvider::resetTransients()
 {
-   if(checkResetTransients()) {
-      for_all(providers_, boost::bind(&DataProxyProvider::resetProxiesIfTransient,_1,key_)); 
+
+   using std::placeholders::_1;
+   if(checkResetTransients())  {
+      for_all(providers_, std::bind(&DataProxyProvider::resetProxiesIfTransient,_1,key_)); 
    }
 }
 
@@ -227,12 +230,13 @@ EventSetupRecordProvider::setValidityIntervalFor(const IOVSyncValue& iTime)
 void 
 EventSetupRecordProvider::resetProxies()
 {
+   using std::placeholders::_1;
    cacheReset();
-   for_all(providers_, boost::bind(&DataProxyProvider::resetProxies,_1,key_));
+   for_all(providers_, std::bind(&DataProxyProvider::resetProxies,_1,key_));
    //some proxies only clear if they were accessed transiently,
    // since resetProxies resets that flag, calling resetTransients
    // will force a clear
-   for_all(providers_, boost::bind(&DataProxyProvider::resetProxiesIfTransient,_1,key_)); 
+   for_all(providers_, std::bind(&DataProxyProvider::resetProxiesIfTransient,_1,key_)); 
 
 }
 
@@ -248,8 +252,9 @@ EventSetupRecordProvider::fillReferencedDataKeys(std::map<DataKey, ComponentDesc
 
 void
 EventSetupRecordProvider::resetRecordToProxyPointers(DataToPreferredProviderMap const& iMap) {
+   using std::placeholders::_1;
    record().clearProxies();
-   for_all(providers_, boost::bind(&EventSetupRecordProvider::addProxiesToRecord, this, _1, iMap));
+   for_all(providers_, std::bind(&EventSetupRecordProvider::addProxiesToRecord, this, _1, iMap));
 }
 
 void 
@@ -274,20 +279,22 @@ EventSetupRecordProvider::dependentRecords() const
 std::set<ComponentDescription> 
 EventSetupRecordProvider::proxyProviderDescriptions() const
 {
+   using std::placeholders::_1;
    std::set<ComponentDescription> descriptions;
    std::transform(providers_.begin(), providers_.end(),
                   std::inserter(descriptions,descriptions.end()),
-                  boost::bind(&DataProxyProvider::description,_1));
+                  std::bind(&DataProxyProvider::description,_1));
    return descriptions;
 }
 
 boost::shared_ptr<DataProxyProvider> 
 EventSetupRecordProvider::proxyProvider(const ComponentDescription& iDesc) const {
+   using std::placeholders::_1;
    std::vector<boost::shared_ptr<DataProxyProvider> >::const_iterator itFound =
    std::find_if(providers_.begin(),providers_.end(),
-                boost::bind(std::equal_to<ComponentDescription>(), 
+                std::bind(std::equal_to<ComponentDescription>(), 
                             iDesc, 
-                            boost::bind(&DataProxyProvider::description,_1)));
+                            std::bind(&DataProxyProvider::description,_1)));
    if(itFound == providers_.end()){
       return boost::shared_ptr<DataProxyProvider>();
    }

--- a/FWCore/Framework/src/Path.cc
+++ b/FWCore/Framework/src/Path.cc
@@ -7,7 +7,6 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include <algorithm>
-#include "boost/bind.hpp"
 
 namespace edm {
   Path::Path(int bitpos, std::string const& path_name,
@@ -159,8 +158,9 @@ namespace edm {
 
   void
   Path::clearCounters() {
+    using std::placeholders::_1;
     timesRun_ = timesPassed_ = timesFailed_ = timesExcept_ = 0;
-    for_all(workers_, boost::bind(&WorkerInPath::clearCounters, _1));
+    for_all(workers_, std::bind(&WorkerInPath::clearCounters, _1));
   }
 
   void

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -22,9 +22,6 @@
 #include "FWCore/Utilities/interface/ExceptionCollector.h"
 #include "FWCore/Utilities/interface/DictionaryTools.h"
 
-#include "boost/bind.hpp"
-#include "boost/ref.hpp"
-
 #include "boost/graph/graph_traits.hpp"
 #include "boost/graph/adjacency_list.hpp"
 #include "boost/graph/depth_first_search.hpp"
@@ -43,6 +40,8 @@
 
 namespace edm {
   namespace {
+    using std::placeholders::_1;
+
     bool binary_search_string(std::vector<std::string> const& v, std::string const& s) {
       return std::binary_search(v.begin(), v.end(), s);
     }
@@ -295,10 +294,10 @@ namespace edm {
                          labelsToBeDropped.end());
 
       // drop the parameter sets used to configure the modules
-      for_all(labelsToBeDropped, boost::bind(&ParameterSet::eraseOrSetUntrackedParameterSet, boost::ref(proc_pset), _1));
+      for_all(labelsToBeDropped, std::bind(&ParameterSet::eraseOrSetUntrackedParameterSet, std::ref(proc_pset), _1));
       
       // drop the labels from @all_modules
-      vstring::iterator endAfterRemove = std::remove_if(modulesInConfig.begin(), modulesInConfig.end(), boost::bind(binary_search_string, boost::ref(labelsToBeDropped), _1));
+      vstring::iterator endAfterRemove = std::remove_if(modulesInConfig.begin(), modulesInConfig.end(), std::bind(binary_search_string, std::ref(labelsToBeDropped), _1));
       modulesInConfig.erase(endAfterRemove, modulesInConfig.end());
       proc_pset.addParameter<vstring>(std::string("@all_modules"), modulesInConfig);
       
@@ -337,13 +336,13 @@ namespace edm {
       sort_all(endPathsToBeDropped);
       
       // remove empty end paths from @paths
-      endAfterRemove = std::remove_if(scheduledPaths.begin(), scheduledPaths.end(), boost::bind(binary_search_string, boost::ref(endPathsToBeDropped), _1));
+      endAfterRemove = std::remove_if(scheduledPaths.begin(), scheduledPaths.end(), std::bind(binary_search_string, std::ref(endPathsToBeDropped), _1));
       scheduledPaths.erase(endAfterRemove, scheduledPaths.end());
       proc_pset.addParameter<vstring>(std::string("@paths"), scheduledPaths);
       
       // remove empty end paths from @end_paths
       vstring scheduledEndPaths = proc_pset.getParameter<vstring>("@end_paths");
-      endAfterRemove = std::remove_if(scheduledEndPaths.begin(), scheduledEndPaths.end(), boost::bind(binary_search_string, boost::ref(endPathsToBeDropped), _1));
+      endAfterRemove = std::remove_if(scheduledEndPaths.begin(), scheduledEndPaths.end(), std::bind(binary_search_string, std::ref(endPathsToBeDropped), _1));
       scheduledEndPaths.erase(endAfterRemove, scheduledEndPaths.end());
       proc_pset.addParameter<vstring>(std::string("@end_paths"), scheduledEndPaths);
       
@@ -431,7 +430,7 @@ namespace edm {
     moduleRegistry_->forAllModuleHolders([this](maker::ModuleHolder* iHolder){
       auto comm = iHolder->createOutputModuleCommunicator();
       if (comm) {
-        all_output_communicators_.emplace_back(boost::shared_ptr<OutputModuleCommunicator>{comm.release()});
+        all_output_communicators_.emplace_back(std::shared_ptr<OutputModuleCommunicator>{comm.release()});
       }      
     });
     // Now that the output workers are filled in, set any output limits or information.
@@ -860,38 +859,46 @@ namespace edm {
   }
 
   void Schedule::closeOutputFiles() {
-    for_all(all_output_communicators_, boost::bind(&OutputModuleCommunicator::closeFile, _1));
+    using std::placeholders::_1;
+    for_all(all_output_communicators_, std::bind(&OutputModuleCommunicator::closeFile, _1));
   }
 
   void Schedule::openNewOutputFilesIfNeeded() {
-    for_all(all_output_communicators_, boost::bind(&OutputModuleCommunicator::openNewFileIfNeeded, _1));
+    using std::placeholders::_1;
+    for_all(all_output_communicators_, std::bind(&OutputModuleCommunicator::openNewFileIfNeeded, _1));
   }
 
   void Schedule::openOutputFiles(FileBlock& fb) {
-    for_all(all_output_communicators_, boost::bind(&OutputModuleCommunicator::openFile, _1, boost::cref(fb)));
+    using std::placeholders::_1;
+    for_all(all_output_communicators_, std::bind(&OutputModuleCommunicator::openFile, _1, std::cref(fb)));
   }
 
   void Schedule::writeRun(RunPrincipal const& rp, ProcessContext const* processContext) {
-    for_all(all_output_communicators_, boost::bind(&OutputModuleCommunicator::writeRun, _1, boost::cref(rp), processContext));
+    using std::placeholders::_1;
+    for_all(all_output_communicators_, std::bind(&OutputModuleCommunicator::writeRun, _1, std::cref(rp), processContext));
   }
 
   void Schedule::writeLumi(LuminosityBlockPrincipal const& lbp, ProcessContext const* processContext) {
-    for_all(all_output_communicators_, boost::bind(&OutputModuleCommunicator::writeLumi, _1, boost::cref(lbp), processContext));
+    using std::placeholders::_1;
+    for_all(all_output_communicators_, std::bind(&OutputModuleCommunicator::writeLumi, _1, std::cref(lbp), processContext));
   }
 
   bool Schedule::shouldWeCloseOutput() const {
+    using std::placeholders::_1;
     // Return true iff at least one output module returns true.
     return (std::find_if (all_output_communicators_.begin(), all_output_communicators_.end(),
-                     boost::bind(&OutputModuleCommunicator::shouldWeCloseFile, _1))
+                     std::bind(&OutputModuleCommunicator::shouldWeCloseFile, _1))
                      != all_output_communicators_.end());
   }
 
   void Schedule::respondToOpenInputFile(FileBlock const& fb) {
-    for_all(allWorkers(), boost::bind(&Worker::respondToOpenInputFile, _1, boost::cref(fb)));
+    using std::placeholders::_1;
+    for_all(allWorkers(), std::bind(&Worker::respondToOpenInputFile, _1, std::cref(fb)));
   }
 
   void Schedule::respondToCloseInputFile(FileBlock const& fb) {
-    for_all(allWorkers(), boost::bind(&Worker::respondToCloseInputFile, _1, boost::cref(fb)));
+    using std::placeholders::_1;
+    for_all(allWorkers(), std::bind(&Worker::respondToCloseInputFile, _1, std::cref(fb)));
   }
 
   void Schedule::beginJob(ProductRegistry const& iRegistry) {
@@ -911,10 +918,12 @@ namespace edm {
   }
 
   void Schedule::preForkReleaseResources() {
-    for_all(allWorkers(), boost::bind(&Worker::preForkReleaseResources, _1));
+    using std::placeholders::_1;
+    for_all(allWorkers(), std::bind(&Worker::preForkReleaseResources, _1));
   }
   void Schedule::postForkReacquireResources(unsigned int iChildIndex, unsigned int iNumberOfChildren) {
-    for_all(allWorkers(), boost::bind(&Worker::postForkReacquireResources, _1, iChildIndex, iNumberOfChildren));
+    using std::placeholders::_1;
+    for_all(allWorkers(), std::bind(&Worker::postForkReacquireResources, _1, iChildIndex, iNumberOfChildren));
   }
 
   bool Schedule::changeModule(std::string const& iLabel,

--- a/FWCore/Framework/src/ScheduleInfo.cc
+++ b/FWCore/Framework/src/ScheduleInfo.cc
@@ -13,7 +13,6 @@
 // system include files
 #include <algorithm>
 #include <iterator>
-#include <boost/bind.hpp>
 #include <functional>
 
 // user include files
@@ -70,26 +69,28 @@ ScheduleInfo::~ScheduleInfo()
 void 
 ScheduleInfo::availableModuleLabels(std::vector<std::string>& oLabelsToFill) const
 {
+   using std::placeholders::_1;
    std::vector<ModuleDescription const*> desc = schedule_->getAllModuleDescriptions();
    
    oLabelsToFill.reserve(oLabelsToFill.size()+desc.size());
    std::transform(desc.begin(),desc.end(),
                   std::back_inserter(oLabelsToFill),
-                  boost::bind(&ModuleDescription::moduleLabel,_1));
+                  std::bind(&ModuleDescription::moduleLabel,_1));
 }
 
 const ParameterSet*
 ScheduleInfo::parametersForModule(const std::string& iLabel) const 
 {
+   using std::placeholders::_1;
    std::vector<ModuleDescription const*> desc = schedule_->getAllModuleDescriptions();
    
    std::vector<ModuleDescription const*>::iterator itFound = std::find_if(desc.begin(),
                                                                           desc.end(),
-                                                                          boost::bind(std::equal_to<std::string>(),
+                                                                          std::bind(std::equal_to<std::string>(),
                                                                                       iLabel,
-                                                                                      boost::bind(&ModuleDescription::moduleLabel,_1)));
+                                                                                      std::bind(&ModuleDescription::moduleLabel,_1)));
    if (itFound == desc.end()) {
-      return 0;
+      return nullptr;
    }
    return pset::Registry::instance()->getMapped((*itFound)->parameterSetID());
 }

--- a/FWCore/Framework/src/StreamSchedule.cc
+++ b/FWCore/Framework/src/StreamSchedule.cc
@@ -24,9 +24,6 @@
 #include "FWCore/Utilities/interface/ExceptionCollector.h"
 #include "FWCore/Utilities/interface/DictionaryTools.h"
 
-#include "boost/bind.hpp"
-#include "boost/ref.hpp"
-
 #include <algorithm>
 #include <cassert>
 #include <cstdlib>
@@ -469,6 +466,7 @@ namespace edm {
                                     std::shared_ptr<ProcessConfiguration const> processConfiguration,
                                     int bitpos, std::string const& name, TrigResPtr trptr,
                                     vstring* labelsOnTriggerPaths) {
+    using std::placeholders::_1;
     PathWorkers tmpworkers;
     Workers holder;
     fillWorkers(proc_pset, preg, prealloc, processConfiguration, name, false, tmpworkers, labelsOnTriggerPaths);
@@ -488,7 +486,7 @@ namespace edm {
       empty_trig_paths_.push_back(bitpos);
       empty_trig_path_names_.push_back(name);
     }
-    for_all(holder, boost::bind(&StreamSchedule::addToAllWorkers, this, _1));
+    for_all(holder, std::bind(&StreamSchedule::addToAllWorkers, this, _1));
   }
 
   void StreamSchedule::fillEndPath(ParameterSet& proc_pset,
@@ -496,6 +494,7 @@ namespace edm {
                                    PreallocationConfiguration const* prealloc,
                                    std::shared_ptr<ProcessConfiguration const> processConfiguration,
                                    int bitpos, std::string const& name) {
+    using std::placeholders::_1;
     PathWorkers tmpworkers;
     fillWorkers(proc_pset, preg, prealloc, processConfiguration, name, true, tmpworkers, 0);
     Workers holder;
@@ -510,7 +509,7 @@ namespace edm {
         end_paths_.back().useStopwatch();
       }
     }
-    for_all(holder, boost::bind(&StreamSchedule::addToAllWorkers, this, _1));
+    for_all(holder, std::bind(&StreamSchedule::addToAllWorkers, this, _1));
   }
 
   void StreamSchedule::beginStream() {
@@ -556,7 +555,7 @@ namespace edm {
     std::transform(trig_paths_.begin(),
                    trig_paths_.end(),
                    std::back_inserter(oLabelsToFill),
-                   boost::bind(&Path::name, _1));
+                   std::bind(&Path::name, std::placeholders::_1));
   }
 
   void
@@ -565,9 +564,9 @@ namespace edm {
     TrigPaths::const_iterator itFound =
     std::find_if (trig_paths_.begin(),
                  trig_paths_.end(),
-                 boost::bind(std::equal_to<std::string>(),
+                 std::bind(std::equal_to<std::string>(),
                              iPathLabel,
-                             boost::bind(&Path::name, _1)));
+                             std::bind(&Path::name, std::placeholders::_1)));
     if (itFound!=trig_paths_.end()) {
       oLabelsToFill.reserve(itFound->size());
       for (size_t i = 0; i < itFound->size(); ++i) {
@@ -708,10 +707,11 @@ namespace edm {
 
   void
   StreamSchedule::clearCounters() {
+    using std::placeholders::_1;
     total_events_ = total_passed_ = 0;
-    for_all(trig_paths_, boost::bind(&Path::clearCounters, _1));
-    for_all(end_paths_, boost::bind(&Path::clearCounters, _1));
-    for_all(allWorkers(), boost::bind(&Worker::clearCounters, _1));
+    for_all(trig_paths_, std::bind(&Path::clearCounters, _1));
+    for_all(end_paths_, std::bind(&Path::clearCounters, _1));
+    for_all(allWorkers(), std::bind(&Worker::clearCounters, _1));
   }
 
   void

--- a/FWCore/Framework/src/StreamSchedule.h
+++ b/FWCore/Framework/src/StreamSchedule.h
@@ -83,8 +83,6 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/StreamID.h"
 
-#include "boost/shared_ptr.hpp"
-
 #include <map>
 #include <memory>
 #include <set>
@@ -148,7 +146,7 @@ namespace edm {
     typedef std::shared_ptr<HLTGlobalStatus> TrigResPtr;
     typedef std::shared_ptr<Worker> WorkerPtr;
     typedef std::vector<Worker*> AllWorkers;
-    typedef std::vector<boost::shared_ptr<OutputModuleCommunicator>> AllOutputModuleCommunicators;
+    typedef std::vector<std::shared_ptr<OutputModuleCommunicator> > AllOutputModuleCommunicators;
 
     typedef std::vector<Worker*> Workers;
 

--- a/FWCore/Framework/src/TriggerResultsBasedEventSelector.cc
+++ b/FWCore/Framework/src/TriggerResultsBasedEventSelector.cc
@@ -1,7 +1,5 @@
 #include <algorithm>
 
-#include "boost/bind.hpp"
-
 #include "FWCore/Framework/interface/TriggerResultsBasedEventSelector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/Algorithms.h"
@@ -264,7 +262,7 @@ namespace edm
     void
     TriggerResultsBasedEventSelector::clear()
     { 
-      for_all(selectors_, boost::bind(&NamedEventSelector::clear, _1));
+      for_all(selectors_, std::bind(&NamedEventSelector::clear, std::placeholders::_1));
       fillDone_ = false;
       numberFound_ = 0;
     }

--- a/FWCore/Framework/src/WorkerManager.cc
+++ b/FWCore/Framework/src/WorkerManager.cc
@@ -101,7 +101,7 @@ namespace edm {
       worker->updateLookup(InEvent,*eventLookup);
     }
     
-    for_all(allWorkers_, boost::bind(&Worker::beginJob, _1));
+    for_all(allWorkers_, std::bind(&Worker::beginJob, std::placeholders::_1));
     loadMissingDictionaries();
   }
 
@@ -121,7 +121,7 @@ namespace edm {
 
   void
   WorkerManager::resetAll() {
-    for_all(allWorkers_, boost::bind(&Worker::reset, _1));
+    for_all(allWorkers_, std::bind(&Worker::reset, std::placeholders::_1));
   }
 
   void

--- a/FWCore/Integration/test/WhatsItWatcherAnalyzer.cc
+++ b/FWCore/Integration/test/WhatsItWatcherAnalyzer.cc
@@ -71,7 +71,7 @@ class WhatsItWatcherAnalyzer : public edm::EDAnalyzer {
 //
 WhatsItWatcherAnalyzer::WhatsItWatcherAnalyzer(const edm::ParameterSet& /*iConfig*/):
   watch1_(this,&WhatsItWatcherAnalyzer::watch1),
-  watch2_(boost::bind(&WhatsItWatcherAnalyzer::watch2,this,_1)),
+  watch2_(std::bind(&WhatsItWatcherAnalyzer::watch2,this,std::placeholders::_1)),
   watchBool_()
 {
    //now do what ever initialization is needed

--- a/FWCore/MessageService/src/MessageServicePresence.cc
+++ b/FWCore/MessageService/src/MessageServicePresence.cc
@@ -25,8 +25,6 @@
 #include "FWCore/MessageLogger/interface/MessageLoggerQ.h"
 #include "FWCore/Utilities/interface/UnixSignalHandlers.h"
 
-#include <boost/bind.hpp>
-
 using namespace edm::service;
 
 
@@ -54,7 +52,7 @@ MessageServicePresence::MessageServicePresence()
   , m_queue (new ThreadQueue)
   , m_scribeThread
          ( ( (void) MessageLoggerQ::instance() // ensure Q's static data init'd
-            , boost::bind(&runMessageLoggerScribe, m_queue)
+            , std::bind(&runMessageLoggerScribe, m_queue)
 	    			// start a new thread, run rMLS(m_queue)
 				// ChangeLog 2
           ) ) 

--- a/FWCore/ParameterSet/bin/edmPluginHelp.cpp
+++ b/FWCore/ParameterSet/bin/edmPluginHelp.cpp
@@ -21,7 +21,6 @@
 
 #include <boost/filesystem/path.hpp>
 #include <boost/program_options.hpp>
-#include "boost/bind.hpp"
 
 #include <vector>
 #include <string>
@@ -337,12 +336,12 @@ try {
 
     std::string previousName;
 
-    edm::for_all(infos, boost::bind(&getMatchingPlugins,
-                                    _1,
-                                    boost::ref(matchingInfos),
-                                    boost::ref(previousName),
-                                    boost::cref(library),
-                                    boost::cref(plugin)));
+    edm::for_all(infos, std::bind(&getMatchingPlugins,
+                                    std::placeholders::_1,
+                                    std::ref(matchingInfos),
+                                    std::ref(previousName),
+                                    std::cref(library),
+                                    std::cref(plugin)));
   }
   catch(cms::Exception& e) {
     std::cerr << "The executable \"edmPluginHelp\" failed while selecting plugins.\n"
@@ -363,15 +362,15 @@ try {
 
     int iPlugin = 0;
  
-    edm::for_all(matchingInfos, boost::bind(&writeDocForPlugin,
-                                            _1,
+    edm::for_all(matchingInfos, std::bind(&writeDocForPlugin,
+                                            std::placeholders::_1,
                                             factory,
-                                            boost::cref(moduleLabel),
+                                            std::cref(moduleLabel),
                                             brief,
                                             printOnlyLabels,
                                             printOnlyPlugins,
                                             lineWidth,
-                                            boost::ref(iPlugin)));
+                                            std::ref(iPlugin)));
   } catch(cms::Exception& e) {
     std::cerr << "\nThe executable \"edmPluginHelp\" failed. The following problem occurred:\n" 
               << e.what() << std::endl;

--- a/FWCore/ParameterSet/interface/ParameterSwitch.h
+++ b/FWCore/ParameterSet/interface/ParameterSwitch.h
@@ -10,8 +10,6 @@
 #include "FWCore/Utilities/interface/Algorithms.h"
 #include "FWCore/ParameterSet/interface/DocFormatHelper.h"
 
-#include "boost/bind.hpp"
-
 #include <map>
 #include <memory>
 #include <set>
@@ -53,11 +51,11 @@ namespace edm {
       std::set<std::string> caseLabels;
       std::set<ParameterTypes> caseParameterTypes;
       std::set<ParameterTypes> caseWildcardTypes;
-      for_all(cases_, boost::bind(&ParameterSwitch::checkCaseLabels,
-                                  _1,
-                                  boost::ref(caseLabels),
-                                  boost::ref(caseParameterTypes),
-                                  boost::ref(caseWildcardTypes)));
+      for_all(cases_, std::bind(&ParameterSwitch::checkCaseLabels,
+                                  std::placeholders::_1,
+                                  std::ref(caseLabels),
+                                  std::ref(caseParameterTypes),
+                                  std::ref(caseWildcardTypes)));
 
       insertAndCheckLabels(switch_.label(),
                            usedLabels,
@@ -138,12 +136,12 @@ namespace edm {
       printNestedContentBase(os, dfh, new_dfh, switch_.label());
 
       switch_.print(os, optional, true, new_dfh);
-      for_all(cases_, boost::bind(&ParameterSwitchBase::printCaseT<T>,
-                                  _1,
-                                  boost::ref(os),
+      for_all(cases_, std::bind(&ParameterSwitchBase::printCaseT<T>,
+                                  std::placeholders::_1,
+                                  std::ref(os),
                                   optional,
-                                  boost::ref(new_dfh),
-                                  boost::cref(switch_.label())));
+                                  std::ref(new_dfh),
+                                  std::cref(switch_.label())));
 
       new_dfh.setPass(1);
       new_dfh.setCounter(0);
@@ -151,23 +149,23 @@ namespace edm {
       new_dfh.indent(os);
       os << "switch:\n";
       switch_.print(os, optional, true, new_dfh);
-      for_all(cases_, boost::bind(&ParameterSwitchBase::printCaseT<T>,
-                                  _1,
-                                  boost::ref(os),
+      for_all(cases_, std::bind(&ParameterSwitchBase::printCaseT<T>,
+                                  std::placeholders::_1,
+                                  std::ref(os),
                                   optional,
-                                  boost::ref(new_dfh),
-                                  boost::cref(switch_.label())));
+                                  std::ref(new_dfh),
+                                  std::cref(switch_.label())));
 
       new_dfh.setPass(2);
       new_dfh.setCounter(0);
 
       switch_.printNestedContent(os, optional, new_dfh);
-      for_all(cases_, boost::bind(&ParameterSwitchBase::printCaseT<T>,
-                                  _1,
-                                  boost::ref(os),
+      for_all(cases_, std::bind(&ParameterSwitchBase::printCaseT<T>,
+                                  std::placeholders::_1,
+                                  std::ref(os),
                                   optional,
-                                  boost::ref(new_dfh),
-                                  boost::cref(switch_.label())));
+                                  std::ref(new_dfh),
+                                  std::cref(switch_.label())));
     }
 
     virtual bool exists_(ParameterSet const& pset) const { return switch_.exists(pset); }

--- a/FWCore/ParameterSet/src/AllowedLabelsDescriptionBase.cc
+++ b/FWCore/ParameterSet/src/AllowedLabelsDescriptionBase.cc
@@ -5,7 +5,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/ParameterSet/interface/DocFormatHelper.h"
 
-#include "boost/bind.hpp"
+#include "boost/ref.hpp"
 
 #include <iomanip>
 #include <ostream>
@@ -53,11 +53,11 @@ namespace edm {
       else {
         allowedLabels = pset.getUntrackedParameter<std::vector<std::string> >(parameterHoldingLabels_.label());
       }
-      for_all(allowedLabels, boost::bind(&AllowedLabelsDescriptionBase::validateAllowedLabel_,
+      for_all(allowedLabels, std::bind(&AllowedLabelsDescriptionBase::validateAllowedLabel_,
                                          boost::cref(this),
-                                         _1,
-                                         boost::ref(pset),
-                                         boost::ref(validatedLabels)));
+                                         std::placeholders::_1,
+                                         std::ref(pset),
+                                         std::ref(validatedLabels)));
     }
   }
 

--- a/FWCore/ParameterSet/src/ConfigurationDescriptions.cc
+++ b/FWCore/ParameterSet/src/ConfigurationDescriptions.cc
@@ -131,10 +131,10 @@ namespace edm {
                                       std::string const& moduleLabel) const {
     
     ParameterSetDescription const* psetDesc = 0;
-    for_all(descriptions_, boost::bind(&matchLabel,
-                                       _1,
-                                       boost::cref(moduleLabel),
-                                       boost::ref(psetDesc)));
+    for_all(descriptions_, std::bind(&matchLabel,
+                                       std::placeholders::_1,
+                                       std::cref(moduleLabel),
+                                       std::ref(psetDesc)));
 
     // If there is a matching label
     if (psetDesc != 0) {
@@ -156,10 +156,10 @@ namespace edm {
   ConfigurationDescriptions::writeCfis(std::string const& baseType,
                                        std::string const& pluginName) const {
 
-    for_all(descriptions_, boost::bind(&ConfigurationDescriptions::writeCfiForLabel,
-                                       _1,
-                                       boost::cref(baseType),
-                                       boost::cref(pluginName)));
+    for_all(descriptions_, std::bind(&ConfigurationDescriptions::writeCfiForLabel,
+                                       std::placeholders::_1,
+                                       std::cref(baseType),
+                                       std::cref(pluginName)));
   }
 
 
@@ -287,13 +287,13 @@ namespace edm {
     for_all(descriptions_, boost::bind(&ConfigurationDescriptions::printForLabel,
                                        this,
                                        _1,
-                                       boost::ref(os),
-                                       boost::cref(moduleLabel),
+                                       std::ref(os),
+                                       std::cref(moduleLabel),
                                        brief,
                                        printOnlyLabels,
                                        lineWidth,
                                        indentation,
-                                       boost::ref(counter)));
+                                       std::ref(counter)));
 
     if (defaultDescDefined_) {
       printForLabel(os,

--- a/FWCore/ParameterSet/src/ParameterDescription.cc
+++ b/FWCore/ParameterSet/src/ParameterDescription.cc
@@ -14,8 +14,6 @@
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
-#include "boost/bind.hpp"
-
 #include <cassert>
 #include <cstdlib>
 #include <iomanip>
@@ -412,11 +410,11 @@ namespace edm {
   ParameterDescription<std::vector<ParameterSet> >::
   writeCfi_(std::ostream& os, int indentation) const {
     bool nextOneStartsWithAComma = false;
-    for_all(vPset_, boost::bind(&writeOneElementToCfi,
-                                 _1,
-                                 boost::ref(os),
+    for_all(vPset_, std::bind(&writeOneElementToCfi,
+                                 std::placeholders::_1,
+                                 std::ref(os),
                                  indentation,
-                                 boost::ref(nextOneStartsWithAComma)));
+                                 std::ref(nextOneStartsWithAComma)));
     os << "\n";
     printSpaces(os, indentation);
   }
@@ -647,13 +645,13 @@ namespace edm {
         os.fill(' ');
         bool startWithComma = false;
         int i = 0;
-        for_all(value_, boost::bind(&writeValueInVectorWithSpace<T>,
-                                    _1,
-                                    boost::ref(os),
+        for_all(value_, std::bind(&writeValueInVectorWithSpace<T>,
+                                    std::placeholders::_1,
+                                    std::ref(os),
                                     indentation + 2,
-                                    boost::ref(startWithComma),
+                                    std::ref(startWithComma),
                                     format,
-                                    boost::ref(i)));
+                                    std::ref(i)));
         if(format == CFI) os << "\n" << std::setw(indentation) << "";
       }
       os.flags(ff);

--- a/FWCore/ParameterSet/src/ParameterSet.cc
+++ b/FWCore/ParameterSet/src/ParameterSet.cc
@@ -16,8 +16,6 @@
 #include "FWCore/Utilities/interface/Digest.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 
-#include "boost/bind.hpp"
-
 #include <algorithm>
 #include <iostream>
 #include <sstream>
@@ -746,13 +744,14 @@ namespace edm {
 
   std::vector<std::string>
   ParameterSet::getParameterNames() const {
+    using std::placeholders::_1;
     std::vector<std::string> returnValue;
     std::transform(tbl_.begin(), tbl_.end(), back_inserter(returnValue),
-                   boost::bind(&std::pair<std::string const, Entry>::first, _1));
+                   std::bind(&std::pair<std::string const, Entry>::first, _1));
     std::transform(psetTable_.begin(), psetTable_.end(), back_inserter(returnValue),
-                   boost::bind(&std::pair<std::string const, ParameterSetEntry>::first, _1));
+                   std::bind(&std::pair<std::string const, ParameterSetEntry>::first, _1));
     std::transform(vpsetTable_.begin(), vpsetTable_.end(), back_inserter(returnValue),
-                   boost::bind(&std::pair<std::string const, VParameterSetEntry>::first, _1));
+                   std::bind(&std::pair<std::string const, VParameterSetEntry>::first, _1));
     return returnValue;
   }
 
@@ -794,8 +793,9 @@ namespace edm {
   // Comment out unneeded function
   size_t
   ParameterSet::getAllParameterSetNames(std::vector<std::string>& output) const {
+    using std::placeholders::_1;
     std::transform(psetTable_.begin(), psetTable_.end(), back_inserter(output),
-                   boost::bind(&std::pair<std::string const, ParameterSetEntry>::first, _1));
+                   std::bind(&std::pair<std::string const, ParameterSetEntry>::first, _1));
     return output.size();
   }
 */

--- a/FWCore/ParameterSet/src/ParameterSetDescription.cc
+++ b/FWCore/ParameterSet/src/ParameterSetDescription.cc
@@ -19,8 +19,6 @@
 #include "FWCore/Utilities/interface/Algorithms.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 
-#include "boost/bind.hpp"
-
 #include <sstream>
 #include <ostream>
 #include <iomanip>
@@ -105,11 +103,12 @@ namespace edm {
   void
   ParameterSetDescription::validate(ParameterSet & pset) const
   {
+    using std::placeholders::_1;
     if (unknown_) return;
 
     std::set<std::string> validatedLabels;
     for_all(entries_,
-            boost::bind(&ParameterSetDescription::validateNode, _1, boost::ref(pset), boost::ref(validatedLabels)));
+            std::bind(&ParameterSetDescription::validateNode, _1, std::ref(pset), std::ref(validatedLabels)));
 
     std::vector<std::string> parameterNames = pset.getParameterNames();
     if (validatedLabels.size() != parameterNames.size()) {
@@ -153,14 +152,15 @@ namespace edm {
   ParameterSetDescription::writeCfi(std::ostream & os,
                                     bool startWithComma,
                                     int indentation) const {
+    using std::placeholders::_1;
     bool wroteSomething = false;
 
-    for_all(entries_, boost::bind(&ParameterSetDescription::writeNode,
+    for_all(entries_, std::bind(&ParameterSetDescription::writeNode,
                                   _1,
-                                  boost::ref(os),
-                                  boost::ref(startWithComma),
+                                  std::ref(os),
+                                  std::ref(startWithComma),
                                   indentation,
-                                  boost::ref(wroteSomething)));
+                                  std::ref(wroteSomething)));
 
     if (wroteSomething) {
       char oldFill = os.fill();
@@ -178,6 +178,7 @@ namespace edm {
   void ParameterSetDescription::
   print(std::ostream & os, DocFormatHelper & dfh) const {
 
+    using std::placeholders::_1;
     if (isUnknown()) {
       dfh.indent(os);
       os << "Description is unknown.  The configured PSet will not be validated\n";
@@ -204,27 +205,27 @@ namespace edm {
     // Zeroth pass is only to calculate column widths in advance of any printing
     dfh.setPass(0);
     dfh.setCounter(0);
-    for_all(entries_, boost::bind(&ParameterSetDescription::printNode,
+    for_all(entries_, std::bind(&ParameterSetDescription::printNode,
                                   _1,
-                                  boost::ref(os),
-                                  boost::ref(dfh)));
+                                  std::ref(os),
+                                  std::ref(dfh)));
 
     // First pass prints top level parameters and references to structure
     dfh.setPass(1);
     dfh.setCounter(0);
-    for_all(entries_, boost::bind(&ParameterSetDescription::printNode,
+    for_all(entries_, std::bind(&ParameterSetDescription::printNode,
                                   _1,
-                                  boost::ref(os),
-                                  boost::ref(dfh)));
+                                  std::ref(os),
+                                  std::ref(dfh)));
 
     // Second pass prints substructure that goes into different sections of the
     // output document
     dfh.setPass(2);
     dfh.setCounter(0);
-    for_all(entries_, boost::bind(&ParameterSetDescription::printNode,
+    for_all(entries_, std::bind(&ParameterSetDescription::printNode,
                                   _1,
-                                  boost::ref(os),
-                                  boost::ref(dfh)));
+                                  std::ref(os),
+                                  std::ref(dfh)));
   }
 
   bool

--- a/FWCore/ParameterSet/src/ParameterWildcard.cc
+++ b/FWCore/ParameterSet/src/ParameterWildcard.cc
@@ -5,7 +5,7 @@
 #include "FWCore/ParameterSet/interface/VParameterSetEntry.h"
 #include "FWCore/Utilities/interface/Algorithms.h"
 
-#include "boost/bind.hpp"
+#include "boost/ref.hpp"
 
 #include <cassert>
 #include <iomanip>
@@ -63,10 +63,10 @@ namespace edm {
 
     if(psetDesc_) {
       for_all(parameterNames,
-              boost::bind(&ParameterWildcard<ParameterSetDescription>::validateDescription,
+              std::bind(&ParameterWildcard<ParameterSetDescription>::validateDescription,
                           boost::cref(this),
-                          _1,
-                          boost::ref(pset)));
+                          std::placeholders::_1,
+                          std::ref(pset)));
     }
   }
 
@@ -180,10 +180,10 @@ namespace edm {
 
     if(psetDesc_) {
       for_all(parameterNames,
-              boost::bind(&ParameterWildcard<std::vector<ParameterSet> >::validatePSetVector,
+              std::bind(&ParameterWildcard<std::vector<ParameterSet> >::validatePSetVector,
                           boost::cref(this),
-                          _1,
-                          boost::ref(pset)));
+                          std::placeholders::_1,
+                          std::ref(pset)));
     }
   }
 

--- a/FWCore/PluginManager/bin/refresh.cc
+++ b/FWCore/PluginManager/bin/refresh.cc
@@ -8,14 +8,13 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/Algorithms.h"
 
-#include <boost/bind.hpp>
 #include <boost/filesystem/operations.hpp>
-#include <boost/mem_fn.hpp>
 #include <boost/program_options.hpp>
 
 #include <algorithm>
 #include <cstdlib>
 #include <fstream>
+#include <functional>
 #include <iostream>
 #include <set>
 #include <string>
@@ -61,7 +60,9 @@ namespace {
     typedef edmplugin::CacheParser::NameAndTypes NameAndTypes;
 
     void newFactory(edmplugin::PluginFactoryBase const* iBase) {
-      iBase->newPluginAdded_.connect(boost::bind(boost::mem_fn(&Listener::newPlugin), this, _1, _2));
+      using std::placeholders::_1; 
+      using std::placeholders::_2; 
+      iBase->newPluginAdded_.connect(std::bind(std::mem_fn(&Listener::newPlugin), this, _1, _2));
     }
     void newPlugin(std::string const& iCategory, edmplugin::PluginInfo const& iInfo) {
       nameAndTypes_.push_back(NameAndType(iInfo.name_, iCategory));
@@ -72,6 +73,7 @@ namespace {
 }
 int main (int argc, char **argv) try {
   using namespace boost::program_options;
+  using std::placeholders::_1; 
 
   static char const* const kPathsOpt = "paths";
   static char const* const kPathsCommandOpt = "paths,p";
@@ -212,8 +214,8 @@ int main (int argc, char **argv) try {
     //load each file and 'listen' to which plugins are loaded
     Listener listener;
     edmplugin::PluginFactoryManager* pfm =  edmplugin::PluginFactoryManager::get();
-    pfm->newFactory_.connect(boost::bind(boost::mem_fn(&Listener::newFactory), &listener, _1));
-    edm::for_all(*pfm, boost::bind(boost::mem_fn(&Listener::newFactory), &listener, _1));
+    pfm->newFactory_.connect(std::bind(std::mem_fn(&Listener::newFactory), &listener, _1));
+    edm::for_all(*pfm, std::bind(std::mem_fn(&Listener::newFactory), &listener, _1));
 
     // We open the cache file before forking so that all the children will
     // use it.

--- a/FWCore/PluginManager/src/PluginManager.cc
+++ b/FWCore/PluginManager/src/PluginManager.cc
@@ -11,12 +11,10 @@
 //
 
 // system include files
-#include <boost/bind.hpp>
-#include <boost/mem_fn.hpp>
-
 #include <boost/filesystem/operations.hpp>
 
 #include <fstream>
+#include <functional>
 #include <set>
 
 // TEMPORARY
@@ -47,10 +45,11 @@ namespace edmplugin {
 PluginManager::PluginManager(const PluginManager::Config& iConfig) :
   searchPath_( iConfig.searchPath() )
 {
+    using std::placeholders::_1;
     const boost::filesystem::path kCacheFile(standard::cachefileName());
     //NOTE: This may not be needed :/
     PluginFactoryManager* pfm = PluginFactoryManager::get();
-    pfm->newFactory_.connect(boost::bind(boost::mem_fn(&PluginManager::newFactory),this,_1));
+    pfm->newFactory_.connect(std::bind(std::mem_fn(&PluginManager::newFactory),this,_1));
 
     // When building a single big executable the plugins are already registered in the 
     // PluginFactoryManager, we therefore only need to populate the categoryToInfos_ map

--- a/FWCore/PluginManager/test/pluginfactorymanager_t.cc
+++ b/FWCore/PluginManager/test/pluginfactorymanager_t.cc
@@ -13,8 +13,7 @@
 // system include files
 #include <Utilities/Testing/interface/CppUnit_testdriver.icpp>
 #include <cppunit/extensions/HelperMacros.h>
-#include <boost/bind.hpp>
-#include <boost/mem_fn.hpp>
+#include <functional>
 #include <iostream>
 
 // user include files
@@ -59,11 +58,12 @@ void
 TestPluginFactoryManager::test()
 {
   using namespace edmplugin;
+  using std::placeholders::_1;
   PluginFactoryManager& pfm = *(PluginFactoryManager::get());
   CPPUNIT_ASSERT(pfm.begin()==pfm.end());
   
   Catcher catcher;
-  pfm.newFactory_.connect(boost::bind(boost::mem_fn(&Catcher::catchIt),&catcher,_1));
+  pfm.newFactory_.connect(std::bind(std::mem_fn(&Catcher::catchIt),&catcher,_1));
   
   DummyTestPlugin one("one");
   CPPUNIT_ASSERT((pfm.begin()!=pfm.end()));

--- a/FWCore/ServiceRegistry/interface/ActivityRegistry.h
+++ b/FWCore/ServiceRegistry/interface/ActivityRegistry.h
@@ -30,18 +30,16 @@ unscheduled execution. The tests are in FWCore/Integration/test:
 
 // system include files
 //#include "boost/signal.hpp"
+#include <functional>
 #include "FWCore/Utilities/interface/Signal.h"
 #include "FWCore/Utilities/interface/StreamID.h"
-#include "boost/bind.hpp"
-#include "boost/mem_fn.hpp"
-#include "boost/utility.hpp"
 
 // user include files
 
-#define AR_WATCH_USING_METHOD_0(method) template<class TClass, class TMethod> void method (TClass* iObject, TMethod iMethod) { method (boost::bind(boost::mem_fn(iMethod), iObject)); }
-#define AR_WATCH_USING_METHOD_1(method) template<class TClass, class TMethod> void method (TClass* iObject, TMethod iMethod) { method (boost::bind(boost::mem_fn(iMethod), iObject, _1)); }
-#define AR_WATCH_USING_METHOD_2(method) template<class TClass, class TMethod> void method (TClass* iObject, TMethod iMethod) { method (boost::bind(boost::mem_fn(iMethod), iObject, _1, _2)); }
-#define AR_WATCH_USING_METHOD_3(method) template<class TClass, class TMethod> void method (TClass* iObject, TMethod iMethod) { method (boost::bind(boost::mem_fn(iMethod), iObject, _1, _2, _3)); }
+#define AR_WATCH_USING_METHOD_0(method) template<class TClass, class TMethod> void method (TClass* iObject, TMethod iMethod) { method (std::bind(std::mem_fn(iMethod), iObject)); }
+#define AR_WATCH_USING_METHOD_1(method) template<class TClass, class TMethod> void method (TClass* iObject, TMethod iMethod) { method (std::bind(std::mem_fn(iMethod), iObject, std::placeholders::_1)); }
+#define AR_WATCH_USING_METHOD_2(method) template<class TClass, class TMethod> void method (TClass* iObject, TMethod iMethod) { method (std::bind(std::mem_fn(iMethod), iObject, std::placeholders::_1, std::placeholders::_2)); }
+#define AR_WATCH_USING_METHOD_3(method) template<class TClass, class TMethod> void method (TClass* iObject, TMethod iMethod) { method (std::bind(std::mem_fn(iMethod), iObject, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3)); }
 // forward declarations
 namespace edm {
    class EventID;
@@ -84,9 +82,11 @@ namespace edm {
 
       };
    }
-   class ActivityRegistry : private boost::noncopyable {
+   class ActivityRegistry {
    public:
       ActivityRegistry() {}
+      ActivityRegistry(ActivityRegistry const&) = delete; // Disallow copying and moving
+      ActivityRegistry& operator=(ActivityRegistry const&) = delete; // Disallow copying and moving
 
       // ---------- signals ------------------------------------
       typedef signalslot::Signal<void(service::SystemBounds const&)> Preallocate;

--- a/FWCore/Services/src/PrintLoadingPlugins.cc
+++ b/FWCore/Services/src/PrintLoadingPlugins.cc
@@ -20,11 +20,10 @@
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
-#include "boost/bind.hpp"
-#include "boost/mem_fn.hpp"
 #include "FWCore/Utilities/interface/Signal.h"
 
 #include <algorithm>
+#include <functional>
 #include <iostream>
 #include <string>
 #include <map>
@@ -44,11 +43,13 @@ using namespace edmplugin;
 
 PrintLoadingPlugins::PrintLoadingPlugins()
 {   
+   using std::placeholders::_1;
+   using std::placeholders::_2;
    PluginManager *pm = PluginManager::get();
 
-   pm->askedToLoadCategoryWithPlugin_.connect(boost::bind(boost::mem_fn(&PrintLoadingPlugins::askedToLoad),this, _1,_2));
+   pm->askedToLoadCategoryWithPlugin_.connect(std::bind(std::mem_fn(&PrintLoadingPlugins::askedToLoad),this, _1,_2));
    
-   pm->goingToLoad_.connect(boost::bind(boost::mem_fn(&PrintLoadingPlugins::goingToLoad),this, _1));
+   pm->goingToLoad_.connect(std::bind(std::mem_fn(&PrintLoadingPlugins::goingToLoad),this, _1));
 
    
   

--- a/FWCore/Utilities/interface/ExceptionCollector.h
+++ b/FWCore/Utilities/interface/ExceptionCollector.h
@@ -5,24 +5,23 @@
 ExceptionCollector is a utility class that can be used to make sure that
 each function or functor in a sequence of calls is invoked even if 
 a previous function throws.  Each function/functor must take no arguments
-and return a void.  boost::bind can be used to convert a function taking arguments
-into a function taking no arguments.
+and return a void.  std::bind can be used to convert a function
+taking arguments into a function taking no arguments.
 The exception strings are saved in a cms::Exception for optional rethrow.
 
 Here is an example:
 
 ExceptionCollector c("initialMessage");
 
-c.call(boost_bind(&MyClass::myFunction, myClassPtr));
-c.call(boost_bind(&MyClass::myOtherFunction, myClassPtr, myArgPtr));
-c.call(boost_bind(&myFreeFunction, myArgPtr));
+c.call(std::bind(&MyClass::myFunction, myClassPtr));
+c.call(std::bind(&MyClass::myOtherFunction, myClassPtr, myArgPtr));
+c.call(std::bind(&myFreeFunction, myArgPtr));
 if (c.hasThrown()) c.rethrow();
 
 This insures that all three functions will be called before any exception is thrown.
 **/
 
-#include "boost/function.hpp"
-
+#include <functional>
 #include <memory>
 #include <string>
 
@@ -37,7 +36,7 @@ namespace edm {
     ~ExceptionCollector();
     bool hasThrown() const;
     void rethrow() const;
-    void call(boost::function<void(void)>);
+    void call(std::function<void(void)>);
     void addException(cms::Exception const& exception);
 
   private:

--- a/FWCore/Utilities/src/ExceptionCollector.cc
+++ b/FWCore/Utilities/src/ExceptionCollector.cc
@@ -32,7 +32,7 @@ namespace edm {
   }
 
   void
-  ExceptionCollector::call(boost::function<void(void)> f) {
+  ExceptionCollector::call(std::function<void(void)> f) {
     try {
       convertException::wrap([&f]() {
         f();

--- a/Fireworks/FWInterface/src/FWFFLooper.cc
+++ b/Fireworks/FWInterface/src/FWFFLooper.cc
@@ -1,4 +1,5 @@
 #include <iostream>
+#include "boost/bind.hpp"
 #include "Fireworks/FWInterface/interface/FWFFLooper.h"
 #include "Fireworks/FWInterface/src/FWFFNavigator.h"
 #include "Fireworks/FWInterface/src/FWFFMetadataManager.h"

--- a/Fireworks/FWInterface/src/FWFFService.cc
+++ b/Fireworks/FWInterface/src/FWFFService.cc
@@ -1,4 +1,5 @@
 #include <iostream>
+#include "boost/bind.hpp"
 #include "Fireworks/FWInterface/interface/FWFFService.h"
 #include "Fireworks/FWInterface/src/FWFFNavigator.h"
 #include "Fireworks/FWInterface/src/FWFFMetadataManager.h"

--- a/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
+++ b/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
@@ -27,8 +27,9 @@ Implementation:
 #include <fcntl.h>
 #include <sys/wait.h>
 
-#include <boost/shared_ptr.hpp>
-#include <boost/ptr_container/ptr_deque.hpp>
+#include "boost/bind.hpp"
+#include "boost/shared_ptr.hpp"
+#include "boost/ptr_container/ptr_deque.hpp"
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"

--- a/HLTrigger/Timer/src/Timer.cc
+++ b/HLTrigger/Timer/src/Timer.cc
@@ -21,6 +21,9 @@
 #include "HLTrigger/Timer/interface/Timer.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 
+#include "boost/bind.hpp"
+#include "boost/mem_fn.hpp"
+
 #include <iostream>
 
 using edm::ParameterSet; 

--- a/IOPool/Output/src/RootOutputTree.cc
+++ b/IOPool/Output/src/RootOutputTree.cc
@@ -19,7 +19,6 @@
 #include "Rtypes.h"
 #include "RVersion.h"
 
-#include "boost/bind.hpp"
 #include <limits>
 
 namespace edm {
@@ -226,7 +225,7 @@ namespace edm {
 
   void
   RootOutputTree::fillTTree(std::vector<TBranch*> const& branches) {
-    for_all(branches, boost::bind(&TBranch::Fill, _1));
+    for_all(branches, std::bind(&TBranch::Fill, std::placeholders::_1));
   }
 
   void

--- a/IOPool/SecondaryInput/test/SecondaryProducer.cc
+++ b/IOPool/SecondaryInput/test/SecondaryProducer.cc
@@ -35,8 +35,6 @@
 #include "FWCore/Utilities/interface/RandomNumberGenerator.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-#include "boost/bind.hpp"
-
 #include <memory>
 #include <string>
 
@@ -82,18 +80,19 @@ namespace edm {
 
   // Functions that get called by framework every event
   void SecondaryProducer::produce(Event& e, EventSetup const&) {
+    using std::placeholders::_1;
 
     if(sequential_) {
       if(lumiSpecified_) {
         // Just for simplicity, we use the luminosity block ID from the primary to read the secondary.
-        secInput_->loopSequentialWithID(*eventPrincipal_, LuminosityBlockID(e.id().run(), e.id().luminosityBlock()), 1, boost::bind(&SecondaryProducer::processOneEvent, this, _1, boost::ref(e)));
+        secInput_->loopSequentialWithID(*eventPrincipal_, LuminosityBlockID(e.id().run(), e.id().luminosityBlock()), 1, std::bind(&SecondaryProducer::processOneEvent, this, _1, std::ref(e)));
       } else {
-        secInput_->loopSequential(*eventPrincipal_, 1, boost::bind(&SecondaryProducer::processOneEvent, this, _1, boost::ref(e)));
+        secInput_->loopSequential(*eventPrincipal_, 1, std::bind(&SecondaryProducer::processOneEvent, this, _1, std::ref(e)));
       }
     } else if(specified_) {
       // Just for simplicity, we use the event ID from the primary to read the secondary.
       std::vector<EventID> events(1, e.id());
-      secInput_->loopSpecified(*eventPrincipal_, events, boost::bind(&SecondaryProducer::processOneEvent, this, _1, boost::ref(e)));
+      secInput_->loopSpecified(*eventPrincipal_, events, std::bind(&SecondaryProducer::processOneEvent, this, _1, std::ref(e)));
     } else {
 
       edm::Service<edm::RandomNumberGenerator> rng;
@@ -108,10 +107,10 @@ namespace edm {
       if(lumiSpecified_) {
         // Just for simplicity, we use the luminosity block ID from the primary to read the secondary.
         secInput_->loopRandomWithID(*eventPrincipal_, LuminosityBlockID(e.id().run(), e.id().luminosityBlock()), 1,
-                                    boost::bind(&SecondaryProducer::processOneEvent, this, _1, boost::ref(e)),
+                                    std::bind(&SecondaryProducer::processOneEvent, this, _1, std::ref(e)),
                                     engine);
       } else {
-        secInput_->loopRandom(*eventPrincipal_, 1, boost::bind(&SecondaryProducer::processOneEvent, this, _1, boost::ref(e)), engine);
+        secInput_->loopRandom(*eventPrincipal_, 1, std::bind(&SecondaryProducer::processOneEvent, this, _1, std::ref(e)), engine);
       }
     }
   }

--- a/IOPool/Streamer/test/ThreadTest_t.cpp
+++ b/IOPool/Streamer/test/ThreadTest_t.cpp
@@ -1,7 +1,6 @@
 
 #include "IOPool/Streamer/interface/EventBuffer.h"
 #include "boost/thread/thread.hpp"
-#include "boost/bind.hpp"
 #include "boost/signal.hpp"
 
 #include <iostream>
@@ -29,7 +28,7 @@ struct Consumer
 
 Consumer::Consumer(EventBuffer& b, DataSignal& s):
   b_(&b),
-  c_(s.connect(boost::bind(&Consumer::callme,this,_1)))
+  c_(s.connect(std::bind(&Consumer::callme,this,std::placeholders::_1)))
 {
 
 }
@@ -128,9 +127,9 @@ int main(int argc, char* argv[])
   Producer p(buf,total);
   Consumer c(buf,p.sig_),c2(buf,p.sig);
   std::cout << "(2)" << std::endl;
-  boost::thread con(boost::bind(crunner,&c));
-  boost::thread con2(boost::bind(crunner,&c2));
-  boost::thread pro(boost::bind(prunner,&p));
+  boost::thread con(std::bind(crunner,&c));
+  boost::thread con2(std::bind(crunner,&c2));
+  boost::thread pro(std::bind(prunner,&p));
   std::cout << "(3)" << std::endl;
 
   con.join();

--- a/PhysicsTools/TagAndProbe/plugins/ProbeTreeProducer.cc
+++ b/PhysicsTools/TagAndProbe/plugins/ProbeTreeProducer.cc
@@ -13,6 +13,7 @@
 
 #include <memory>
 #include <ctype.h>
+#include "boost/bind.hpp"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"

--- a/RecoBTag/ImpactParameter/plugins/TrackIPProducer.cc
+++ b/RecoBTag/ImpactParameter/plugins/TrackIPProducer.cc
@@ -22,6 +22,8 @@
 #include <iostream>
 #include <algorithm>
 
+#include "boost/bind.hpp"
+
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin.cc
@@ -12,6 +12,8 @@
 #include <algorithm>
 #include <memory>
 
+#include "boost/bind.hpp"
+
 #include "RecoTauTag/RecoTau/interface/RecoTauPiZeroPlugins.h"
 
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin2.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin2.cc
@@ -14,6 +14,8 @@
 #include <algorithm>
 #include <memory>
 
+#include "boost/bind.hpp"
+
 #include "RecoTauTag/RecoTau/interface/RecoTauPiZeroPlugins.h"
 
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"

--- a/RecoTauTag/RecoTau/plugins/RecoTauProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauProducer.cc
@@ -16,6 +16,7 @@
  *          Christian Veelken (LLR)
  *
  */
+#include "boost/bind.hpp"
 #include <boost/ptr_container/ptr_vector.hpp>
 #include <boost/foreach.hpp>
 

--- a/SimGeneral/MixingModule/plugins/MixingModule.cc
+++ b/SimGeneral/MixingModule/plugins/MixingModule.cc
@@ -8,6 +8,8 @@
 #include "MixingWorker.h"
 #include "Adjuster.h"
 
+#include "boost/bind.hpp"
+
 #include "CondFormats/RunInfo/interface/MixingModuleConfig.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/EDMException.h"


### PR DESCRIPTION
This pull request replaces most uses of boost classes or functions with the corresponding C++11 std classes or functions in the framework only.  This was not done outside the framework.  Replaced were boost::bind, boost::cref, boost::ref, boost::function, and boost::mem_fn.  A few uses where the change turned out not to be trivial were left alone for now.  Most uses of boost;;shared_ptr had already been replaced by std::shared_ptr, but I found a few more uses that were easy to replace.
The only changes outside the framework were the necessary addition of missing includes, almost all of boost/bind.hpp, that were exposed when includes of boost headers were removed from framework headers.
No interfaces used outside the framework are affected by this pull request.
This pull request was tested with the FULL relval matrix, and no errors were introduced by this pull request.
