### PR TITLE
Fix RPC noise in PreMixing

### DIFF
--- a/Configuration/StandardSequences/python/Digi_PreMix_cff.py
+++ b/Configuration/StandardSequences/python/Digi_PreMix_cff.py
@@ -9,7 +9,8 @@ from Configuration.StandardSequences.DigiNZS_cff import *
 #simMuonCSCDigis.strips.doNoise = False
 #simMuonCSCDigis.wires.doNoise = False
 #simMuonDTDigis.onlyMuHits = True
-#simMuonRPCDigis.Noise = False
+
+simMuonRPCDigis.doBkgNoise = False
 
 # Note: the other noise is turned of in the DigitizersNoNoise sequence defined in the MixingModule
 # because the MM holds/controls all of the other digitizers.

--- a/SimMuon/RPCDigitizer/python/muonRPCDigis_cfi.py
+++ b/SimMuon/RPCDigitizer/python/muonRPCDigis_cfi.py
@@ -19,6 +19,7 @@ simMuonRPCDigis = cms.EDProducer("RPCDigiProducer",
         Nbxing = cms.int32(9),
         timeJitter = cms.double(1.0)
     ),
+    doBkgNoise = cms.bool(True), #False - no noise and bkg simulation
     Signal = cms.bool(True),
     mixLabel = cms.string('mix'),                                 
     InputCollection = cms.string('g4SimHitsMuonRPCHits'),

--- a/SimMuon/RPCDigitizer/src/RPCDigitizer.cc
+++ b/SimMuon/RPCDigitizer/src/RPCDigitizer.cc
@@ -13,6 +13,7 @@ RPCDigitizer::RPCDigitizer(const edm::ParameterSet& config, CLHEP::HepRandomEngi
   theName = config.getParameter<std::string>("digiModel");
   theRPCSim = RPCSimFactory::get()->create(theName,config.getParameter<edm::ParameterSet>("digiModelConfig"));
   theRPCSim->setRandomEngine(eng);
+  theNoise=config.getParameter<bool>("doBkgNoise");
 }
 
 RPCDigitizer::~RPCDigitizer() {
@@ -52,7 +53,9 @@ void RPCDigitizer::doAction(MixCollection<PSimHit> & simHits,
 //			     <<" hit(s) in the rpc roll";  
     
     theRPCSim->simulate(*r,rollSimHits);
-    theRPCSim->simulateNoise(*r);
+    if(theNoise){
+      theRPCSim->simulateNoise(*r);
+    }
     theRPCSim->fillDigis((*r)->id(),rpcDigis);
     rpcDigiSimLink.insert(theRPCSim->rpcDigiSimLinks());
   }

--- a/SimMuon/RPCDigitizer/src/RPCDigitizer.h
+++ b/SimMuon/RPCDigitizer/src/RPCDigitizer.h
@@ -55,7 +55,7 @@ private:
   RPCSim* theRPCSim;
   RPCSimSetUp * theSimSetUp;
   std::string theName;
-
+  bool theNoise;
 };
 
 #endif


### PR DESCRIPTION
Backport the addition of a "turn off noise flag" for RPCs (SimMuon/RPCDigitizer) to 70X, proper settings to do this in the PreMixing stage in Configuration/StandardSequences.
