### PR TITLE
Configure SiStrip noise the same in production and validation modes! Sup...

### DIFF
--- a/SimCalorimetry/HcalSimAlgos/interface/HcalSignalGenerator.h
+++ b/SimCalorimetry/HcalSimAlgos/interface/HcalSignalGenerator.h
@@ -153,11 +153,7 @@ private:
       }
       result.setPresamples(digi.presamples());
     }
-
-    std::cout << " HcalSignalGenerator: noise input ADC " << digi << std::endl;
-
-    std::cout << " HcalSignalGenerator: noise input in fC " << result << std::endl;
-
+    
     // translation done in fC, convert to pe:
 
     fC2pe(result);

--- a/SimGeneral/MixingModule/python/digi_MixPreMix_cfi.py
+++ b/SimGeneral/MixingModule/python/digi_MixPreMix_cfi.py
@@ -40,4 +40,5 @@ theDigitizersMixPreMixValid = cms.PSet(
 #theDigitizersNoNoise.pixel.AddNoise = cms.bool(True)
 #theDigitizersNoNoise.pixel.addNoisyPixels = cms.bool(False)
 theDigitizersMixPreMix.strip.Noise = cms.bool(False) # will be added in DataMixer
+theDigitizersMixPreMixValid.strip.Noise = cms.bool(False) # will be added in DataMixer
 


### PR DESCRIPTION
Fix configuration of SiStrip noise in PreMixing so that the "validation" and "production" modes have the same settings.  (doh).  (The "production" mode was correct, btw.)  Found and suppressed a bunch of Hcal printout that should have been removed earlier.
