### PR TITLE
Disable noise for pre-mixing for RPC and SiStrips

### DIFF
--- a/Configuration/StandardSequences/python/Digi_PreMix_cff.py
+++ b/Configuration/StandardSequences/python/Digi_PreMix_cff.py
@@ -9,7 +9,7 @@ from Configuration.StandardSequences.DigiNZS_cff import *
 #simMuonCSCDigis.strips.doNoise = False
 #simMuonCSCDigis.wires.doNoise = False
 #simMuonDTDigis.onlyMuHits = True
-#simMuonRPCDigis.Noise = False
+simMuonRPCDigis.doBkgNoise = False
 
 # Note: the other noise is turned of in the DigitizersNoNoise sequence defined in the MixingModule
 # because the MM holds/controls all of the other digitizers.

--- a/SimGeneral/MixingModule/python/digi_MixPreMix_cfi.py
+++ b/SimGeneral/MixingModule/python/digi_MixPreMix_cfi.py
@@ -40,4 +40,5 @@ theDigitizersMixPreMixValid = cms.PSet(
 #theDigitizersNoNoise.pixel.AddNoise = cms.bool(True)
 #theDigitizersNoNoise.pixel.addNoisyPixels = cms.bool(False)
 theDigitizersMixPreMix.strip.Noise = cms.bool(False) # will be added in DataMixer
+theDigitizersMixPreMixValid.strip.Noise = cms.bool(False) # will be added in DataMixer
 


### PR DESCRIPTION
This is the sum of Mike PR 4547, 4550 for 7_2_X, which complete pre-mixing fixes.
