### PR TITLE
Check if globalrechitsanalyze is in the sequence before modifying it

### DIFF
--- a/SLHCUpgradeSimulations/Configuration/python/phase2TkCustomsBE5DPixel10D.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase2TkCustomsBE5DPixel10D.py
@@ -279,11 +279,12 @@ def customise_DQM(process,pileup):
     process=customise_trackMon_IterativeTracking_PHASE1PU140(process)
     process.dqmoffline_step.remove(process.Phase1Pu70TrackMonStep2)
     process.dqmoffline_step.remove(process.Phase1Pu70TrackMonStep4)
-    process.globalrechitsanalyze.ROUList = cms.vstring(
-       'g4SimHitsTrackerHitsPixelBarrelLowTof', 
-       'g4SimHitsTrackerHitsPixelBarrelHighTof', 
-       'g4SimHitsTrackerHitsPixelEndcapLowTof', 
-       'g4SimHitsTrackerHitsPixelEndcapHighTof')
+    if hasattr(process,"globalrechitsanalyze") : # Validation takes this out if pileup is more than 30
+       process.globalrechitsanalyze.ROUList = cms.vstring(
+          'g4SimHitsTrackerHitsPixelBarrelLowTof', 
+          'g4SimHitsTrackerHitsPixelBarrelHighTof', 
+          'g4SimHitsTrackerHitsPixelEndcapLowTof', 
+          'g4SimHitsTrackerHitsPixelEndcapHighTof')
     return process
 
 def customise_Validation(process,pileup):


### PR DESCRIPTION
If validation is configured it deletes globalrechitsanalyze if the pileup is greater than 30.  If DQM is also run it tries to modify globalrechitsanalyze and hence throws an exception.  This just adds a check to see if globalrechitsanalyze exists before modifying it.
