### PR TITLE
Bugfix plus filter update for missing hits, backport of #4391 to 71X

### DIFF
--- a/HLTrigger/Egamma/src/HLTElectronMissingHitsFilter.cc
+++ b/HLTrigger/Egamma/src/HLTElectronMissingHitsFilter.cc
@@ -73,7 +73,7 @@ bool HLTElectronMissingHitsFilter::hltFilter(edm::Event& iEvent, const edm::Even
 	int missinghits = 0;
 	if (electronref->gsfTrack().isNonnull())
 	  missinghits = electronref->gsfTrack()->trackerExpectedHitsInner().numberOfLostHits();
-	else if (electronref->gsfTrack().isNonnull())
+	else if (electronref->track().isNonnull())
 	  missinghits = electronref->track()->trackerExpectedHitsInner().numberOfLostHits();
 	else
 	  std::cerr << "Electron without track..." << std::endl;

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTGsfTrackVarProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTGsfTrackVarProducer.cc
@@ -44,7 +44,7 @@ EgammaHLTGsfTrackVarProducer::EgammaHLTGsfTrackVarProducer(const edm::ParameterS
   produces < reco::RecoEcalCandidateIsolationMap >( "Dphi" ).setBranchAlias( "dphi" );
   produces < reco::RecoEcalCandidateIsolationMap >( "OneOESuperMinusOneOP" );
   produces < reco::RecoEcalCandidateIsolationMap >( "OneOESeedMinusOneOP" );
-  
+  produces < reco::RecoEcalCandidateIsolationMap >( "MissingHits" ).setBranchAlias( "missinghits" );
 }
 
 EgammaHLTGsfTrackVarProducer::~EgammaHLTGsfTrackVarProducer()
@@ -143,9 +143,13 @@ void EgammaHLTGsfTrackVarProducer::produce(edm::Event& iEvent, const edm::EventS
 	if(scRef->seed().isNonnull() && scRef->seed()->energy()!=0 && trkP!=0){
 	  if(fabs(1/scRef->seed()->energy() - 1/trkP)<oneOverESeedMinusOneOverPValue) oneOverESeedMinusOneOverPValue =fabs(1/scRef->seed()->energy() - 1/trkP);
 	}
-	
-	if(fabs(scAtVtx.dEta())<dEtaInValue) dEtaInValue=fabs(scAtVtx.dEta()); //we are allowing them to come from different tracks
-	if(fabs(scAtVtx.dPhi())<dPhiInValue) dPhiInValue=fabs(scAtVtx.dPhi());//we are allowing them to come from different tracks
+
+	if (gsfTracks[trkNr]->trackerExpectedHitsInner().numberOfLostHits() < missingHitsValue) 
+	  missingHitsValue = gsfTracks[trkNr]->trackerExpectedHitsInner().numberOfLostHits();
+	if (fabs(scAtVtx.dEta())<dEtaInValue) 
+	  dEtaInValue=fabs(scAtVtx.dEta()); //we are allowing them to come from different tracks
+	if (fabs(scAtVtx.dPhi())<dPhiInValue) 
+	  dPhiInValue=fabs(scAtVtx.dPhi());//we are allowing them to come from different tracks
       }	
     }
    

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTGsfTrackVarProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTGsfTrackVarProducer.cc
@@ -86,6 +86,7 @@ void EgammaHLTGsfTrackVarProducer::produce(edm::Event& iEvent, const edm::EventS
   reco::RecoEcalCandidateIsolationMap dPhiMap;
   reco::RecoEcalCandidateIsolationMap oneOverESuperMinusOneOverPMap;
   reco::RecoEcalCandidateIsolationMap oneOverESeedMinusOneOverPMap;
+  reco::RecoEcalCandidateIsolationMap missingHitsMap;
 
   for(reco::RecoEcalCandidateCollection::const_iterator iRecoEcalCand = recoEcalCandHandle->begin(); iRecoEcalCand != recoEcalCandHandle->end(); iRecoEcalCand++){
     reco::RecoEcalCandidateRef recoEcalCandRef(recoEcalCandHandle,iRecoEcalCand-recoEcalCandHandle->begin());
@@ -112,6 +113,8 @@ void EgammaHLTGsfTrackVarProducer::produce(edm::Event& iEvent, const edm::EventS
       }
       
     }
+
+    float missingHitsValue = 9999999;
     float dEtaInValue=999999;
     float dPhiInValue=999999;
     float oneOverESuperMinusOneOverPValue=999999;
@@ -120,9 +123,11 @@ void EgammaHLTGsfTrackVarProducer::produce(edm::Event& iEvent, const edm::EventS
     if(static_cast<int>(gsfTracks.size())>=upperTrackNrToRemoveCut_){
       dEtaInValue=0;
       dPhiInValue=0;
+      missingHitsValue = 0;
     }else if(static_cast<int>(gsfTracks.size())<=lowerTrackNrToRemoveCut_){
       dEtaInValue=0;
       dPhiInValue=0;
+      missingHitsValue = 0;
     }else{
       for(size_t trkNr=0;trkNr<gsfTracks.size();trkNr++){
       
@@ -148,18 +153,20 @@ void EgammaHLTGsfTrackVarProducer::produce(edm::Event& iEvent, const edm::EventS
     dPhiMap.insert(recoEcalCandRef, dPhiInValue);
     oneOverESuperMinusOneOverPMap.insert(recoEcalCandRef,oneOverESuperMinusOneOverPValue);   
     oneOverESeedMinusOneOverPMap.insert(recoEcalCandRef,oneOverESeedMinusOneOverPValue);
+    missingHitsMap.insert(recoEcalCandRef, missingHitsValue);
   }
 
   std::auto_ptr<reco::RecoEcalCandidateIsolationMap> dEtaMapForEvent(new reco::RecoEcalCandidateIsolationMap(dEtaMap));
   std::auto_ptr<reco::RecoEcalCandidateIsolationMap> dPhiMapForEvent(new reco::RecoEcalCandidateIsolationMap(dPhiMap));
   std::auto_ptr<reco::RecoEcalCandidateIsolationMap> oneOverESuperMinusOneOverPMapForEvent(new reco::RecoEcalCandidateIsolationMap(oneOverESuperMinusOneOverPMap));
   std::auto_ptr<reco::RecoEcalCandidateIsolationMap> oneOverESeedMinusOneOverPMapForEvent(new reco::RecoEcalCandidateIsolationMap(oneOverESeedMinusOneOverPMap));
+  std::auto_ptr<reco::RecoEcalCandidateIsolationMap> missingHitsForEvent(new reco::RecoEcalCandidateIsolationMap(missingHitsMap));
   iEvent.put(dEtaMapForEvent, "Deta" );
   iEvent.put(dPhiMapForEvent, "Dphi" );
   iEvent.put(oneOverESuperMinusOneOverPMapForEvent,"OneOESuperMinusOneOP");
   iEvent.put(oneOverESeedMinusOneOverPMapForEvent,"OneOESeedMinusOneOP");
+  iEvent.put(missingHitsForEvent, "MissingHits");
 }
-
 
 
 EgammaHLTGsfTrackVarProducer::TrackExtrapolator::TrackExtrapolator(const EgammaHLTGsfTrackVarProducer::TrackExtrapolator& rhs):


### PR DESCRIPTION
I just realized that #4391 from @matteosan1 was not backported yet to 71X.
It may be needed, however, for trigger developments and studies of the developing Run2 HLT menu, which have to be done in 71X
