### PR TITLE
Fix two compilation errors in ROOT6 IB

### DIFF
--- a/EventFilter/Utilities/plugins/FRDStreamSource.cc
+++ b/EventFilter/Utilities/plugins/FRDStreamSource.cc
@@ -1,4 +1,5 @@
 #include <zlib.h>
+#include <iostream>
 
 #include "IOPool/Streamer/interface/FRDEventMessage.h"
 

--- a/GeneratorInterface/EvtGenInterface/plugins/DataCardFileWriter.cc
+++ b/GeneratorInterface/EvtGenInterface/plugins/DataCardFileWriter.cc
@@ -15,7 +15,7 @@ DataCardFileWriter::DataCardFileWriter(const edm::ParameterSet& pset){
   std::string Base= getenv ("CMSSW_BASE");
   Base+="/src/";
   std::cout << "Writting file:" << Base+FileName << std::endl;
-  ofstream outputFile(Base+FileName);
+  std::ofstream outputFile(Base+FileName);
   std::vector<std::string> FileContent= pset.getParameter<std::vector<std::string> >("FileContent") ;
   for(unsigned int i=0; i<FileContent.size();i++){
     outputFile << FileContent.at(i) << std::endl;


### PR DESCRIPTION
This pull request adds a missing std:: qualifier and a missing include of "iostream" to fix two of the four fatal compilation errors in the latest ROOT6 IB.
This is totally technical and trivial.  Please merge as soon as convenient.
