### PR TITLE
Cannot yet use SMatrixNoInit in ROOT 6

### DIFF
--- a/TrackingTools/GsfTracking/src/PosteriorWeightsCalculator.cc
+++ b/TrackingTools/GsfTracking/src/PosteriorWeightsCalculator.cc
@@ -23,7 +23,7 @@ std::vector<double> PosteriorWeightsCalculator::weights(const TrackingRecHit& re
   typedef typename AlgebraicROOTObject<5,D>::Matrix Mat5D;
   typedef typename AlgebraicROOTObject<D,D>::SymMatrix SMatDD;
   typedef typename AlgebraicROOTObject<D>::Vector VecD;
-  using ROOT::Math::SMatrixNoInit;
+  using ROOT::Math::SMatrixIdentity;
 
   std::vector<double> weights;
   if ( predictedComponents.empty() )  {
@@ -38,7 +38,7 @@ std::vector<double> PosteriorWeightsCalculator::weights(const TrackingRecHit& re
   chi2s.reserve(predictedComponents.size());
 
   VecD r, rMeas; 
-  SMatDD V(SMatrixNoInit{}), R(SMatrixNoInit{});
+  SMatDD V(SMatrixIdentity{}), R(SMatrixIdentity{});
   AlgebraicVector5 x;
   ProjectMatrix<double,5,D> p;
   //

--- a/TrackingTools/KalmanUpdators/src/Chi2MeasurementEstimator.cc
+++ b/TrackingTools/KalmanUpdators/src/Chi2MeasurementEstimator.cc
@@ -15,9 +15,9 @@ namespace {
     typedef typename AlgebraicROOTObject<5,D>::Matrix Mat5D;
     typedef typename AlgebraicROOTObject<D,D>::SymMatrix SMatDD;
     typedef typename AlgebraicROOTObject<D>::Vector VecD;
-    using ROOT::Math::SMatrixNoInit;
+    using ROOT::Math::SMatrixIdentity;
     
-    VecD r, rMeas; SMatDD R(SMatrixNoInit{}), RMeas(SMatrixNoInit{});
+    VecD r, rMeas; SMatDD R(SMatrixIdentity{}), RMeas(SMatrixIdentity{});
     ProjectMatrix<double,5,D> dummyProjFunc;
     auto && v = tsos.localParameters().vector();
     auto && m = tsos.localError().matrix();

--- a/TrackingTools/KalmanUpdators/src/KFUpdator.cc
+++ b/TrackingTools/KalmanUpdators/src/KFUpdator.cc
@@ -17,7 +17,7 @@ TrajectoryStateOnSurface lupdate(const TrajectoryStateOnSurface& tsos,
   typedef typename AlgebraicROOTObject<5,D>::Matrix Mat5D;
   typedef typename AlgebraicROOTObject<D,D>::SymMatrix SMatDD;
   typedef typename AlgebraicROOTObject<D>::Vector VecD;
-  using ROOT::Math::SMatrixNoInit;
+  using ROOT::Math::SMatrixIdentity;
   double pzSign = tsos.localParameters().pzSign();
 
   auto && x = tsos.localParameters().vector();
@@ -28,7 +28,7 @@ TrajectoryStateOnSurface lupdate(const TrajectoryStateOnSurface& tsos,
  
   // Measurement matrix
   VecD r, rMeas; 
-  SMatDD V(SMatrixNoInit{}), VMeas(SMatrixNoInit{});
+  SMatDD V(SMatrixIdentity{}), VMeas(SMatrixIdentity{});
 
   KfComponentsHolder holder; 
   holder.template setup<D>(&r, &V, &pf, &rMeas, &VMeas, x, C);


### PR DESCRIPTION
The class SMatrixNoInit was added to ROOT in a CMS specific patch.  Unfortunately, for reasons not yet investigated, the patch is not compatible with ROOT 6, so it is not present in ROOT 6.  Therefore, for the time being, CMSSW code must use class SMatrixIdentity instead of SMatrixNoInit.
This pull request removes the remaining two compilation errors in the latest CMSSW build in the ROOT6 branch.
Please merge as soon as convenient.
