### PR TITLE
New GTs for Run1 simulations, Run2 simulations, and data.

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,19 +2,19 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector                                                                                                                              
     'mc'                :   'MC_71_V8::All',
     # GlobalTag for MC production with realistic alignment and calibrations
-    'startup'           :   'START71_V7::All',
+    'startup'           :   'START71_V8::All',
     # GlobalTag for MC production of Heavy Ions events with realistic alignment and calibrations
-    'starthi'           :   'STARTHI71_V13::All',
+    'starthi'           :   'STARTHI71_V15::All',
     # GlobalTag for MC production of p-Pb events with realistic alignment and calibrations
-    'startpa'           :   'STARTHI71_V14::All',
+    'startpa'           :   'STARTHI71_V16::All',
     # GlobalTag for data reprocessing: this should always be the GR_R tag
-    'com10'             :   'GR_R_71_V6::All',
+    'com10'             :   'GR_R_71_V7::All',
     # GlobalTag for running HLT on recent data: this should be the GR_P (prompt reco) global tag until a compatible GR_H tag is available, 
     # then it should point to the GR_H tag and override the connection string and pfnPrefix for use offline
     'hltonline'         :   'GR_H_V37::All,frontier://FrontierProd/CMS_COND_31X_GLOBALTAG,frontier://FrontierProd/',
     # GlobalTag for POSTLS1 upgrade studies:
-    'upgradePLS1'       :   'POSTLS171_V15::All',
-    'upgradePLS150ns'   :   'POSTLS171_V16::All',
+    'upgradePLS1'       :   'POSTLS171_V17::All',
+    'upgradePLS150ns'   :   'POSTLS171_V18::All',
     'upgrade2017'       :   'DES17_70_V2::All', # placeholder (GT not meant for standard RelVal)
     'upgrade2019'       :   'DES19_70_V2::All', # placeholder (GT not meant for standard RelVal)
     'upgradePLS3'       :   'POSTLS262_V1::All', # placeholder (GT not meant for standard RelVal)
@@ -23,21 +23,21 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
     'run1_design'       :   'MC_71_V8::All',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   'START71_V7::All',
+    'run1_mc'           :   'START71_V8::All',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   'STARTHI71_V13::All',
+    'run1_mc_hi'        :   'STARTHI71_V15::All',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pPb'       :   'STARTHI71_V14::All',
+    'run1_mc_pPb'       :   'STARTHI71_V16::All',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   'DESIGN71_V5::All',
+    'run2_design'       :   'DESIGN71_V6::All',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   'POSTLS171_V16::All',
+    'run2_mc_50ns'      :   'POSTLS171_V18::All',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   'POSTLS171_V15::All',
+    'run2_mc'           :   'POSTLS171_V17::All',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   'GR_R_71_V6::All',
+    'run1_data'         :   'GR_R_71_V7::All',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   'GR_R_71_V6::All',
+    'run2_data'         :   'GR_R_71_V7::All',
     # GlobalTag for Run2 HLT: it points to the online GT and overrides the connection string and pfnPrefix for use offline
     'run2_hlt'          :   'GR_H_V37::All,frontier://FrontierProd/CMS_COND_31X_GLOBALTAG,frontier://FrontierProd/',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017


### PR DESCRIPTION
New set of GTs with the following additions:
- Run1 MC GTs (pp, PbPb, pPb):
  - adding simulated geometry with more realistic material budget description
- Run1 data GT:
  - adding AK4PF and AK4PFchs JEC
- Run2 design GT:
  - adding AK4PF and AK4PFchs JEC
- Run2 MC GTs (both 50 and 25 ns):
  - adding AK4PF and AK4PFchs JEC
- Run2 data GT:
  - adding AK4PF and AK4PFchs JEC
