### PR TITLE
Workaround for ROOT 6 problem with forward declarations

### DIFF
--- a/TrackingTools/PatternTools/src/classes_def.xml
+++ b/TrackingTools/PatternTools/src/classes_def.xml
@@ -63,4 +63,6 @@
   <class name="std::vector<TrajAnnealing>" persistent="false"/>
   <class name="edm::Wrapper<std::vector<TrajAnnealing> >" persistent="false"/>
 
+  <!-- This next spec should not really be here, but it is a workaround for a ROOT6 problem (Danilo Piparo).-->
+  <class name="GlobalErrorBase<double,ErrorMatrixTag>" />
 </lcgdict>


### PR DESCRIPTION
This is a workaround for a ROOT 6 problem.  This workaround was requested by Danilo Piparo.
Danilo's explanation follows:
One of the ingredients needed to enable delayed  payload parsing is the forward declaration of classes, functions and typedefs. ROOT automatically produces them, transparently for the user.
I found a case in CMS where this "automatic forward declaration" does not work.
It is in the TrackingTools/PatternTools package and I worked it around adding an entry to the selection file (src/classes_sel.xml):
       class name="GlobalErrorBase&ltdouble,ErrorMatrixTag&gt" /
[More detail omitted for brevity]
Now, I [Danilo] am _sure_ I can debug this with some time at disposal, say one morning, but unfortunately tomorrow I will leave for a 2 weeks vacation.
I proposed to add the selection because it will make the cms jobs succeed and is relatively cheap to add.

Please merge this as soon as convenient.
