### PR TITLE
Correct the geometry for HGCal v4 in runTheMatrix (148xx workflows)

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1145,7 +1145,7 @@ upgradeGeoms={ '2017' : 'Extended2017',
                'Extended2023SHCalNoTaper4Eta' : 'Extended2023SHCalNoTaper4Eta,Extended2023SHCalNoTaper4EtaReco',
                'Extended2023HGCal' : 'Extended2023HGCal,Extended2023HGCalReco',
                'Extended2023HGCalMuon4Eta' : 'Extended2023HGCalMuon4Eta,Extended2023HGCalMuon4EtaReco',
-               'Extended2023HGCalV4' : 'Extended2023HGCalV4,Extended2023HGCalMuonReco'
+               'Extended2023HGCalV4' : 'Extended2023HGCalV4Muon,Extended2023HGCalV4MuonReco'
                }
 upgradeGTs={ '2017' : 'auto:upgrade2017',
              '2019' : 'auto:upgrade2019',


### PR DESCRIPTION
@bsunanda, @vandreev11

Note that as well as changing the reco geometry to V4, the sim geometry also has "Muon" appended to match the command given in @vandreev's email on the 08/Jul/2014.  If this is not what you want let me know.

Workflow 14800 (4 muons) runs through to the end, I'll do more tests once the pull request is in the queue.
