### PR TITLE
Feature/add simple hlt jet mass filter

### DIFF
--- a/HLTrigger/JetMET/interface/HLTJetMassFilter.h
+++ b/HLTrigger/JetMET/interface/HLTJetMassFilter.h
@@ -1,0 +1,45 @@
+#ifndef HLTJetMassFilter_h
+#define HLTJetMassFilter_h
+
+//system includ files
+#include <memory>
+#include <vector>
+#include <sstream>
+
+// user include files
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/PluginManager/interface/ModuleDef.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "DataFormats/JetReco/interface/CATopJetTagInfo.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "DataFormats/Math/interface/deltaR.h"
+#include "DataFormats/JetReco/interface/BasicJet.h"
+#include "DataFormats/Candidate/interface/CompositeCandidate.h"
+#include "PhysicsTools/CandUtils/interface/AddFourMomenta.h"
+#include "DataFormats/Candidate/interface/CandMatchMap.h"
+#include "DataFormats/HLTReco/interface/TriggerTypeDefs.h"
+#include "HLTrigger/HLTcore/interface/HLTFilter.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include <Math/VectorUtil.h>
+
+
+//class declaration
+
+class HLTJetMassFilter : public HLTFilter {
+ public:
+  explicit HLTJetMassFilter(const edm::ParameterSet&);
+  ~HLTJetMassFilter();
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  virtual bool hltFilter( edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs& filterobject) const override;
+
+ private:
+
+  edm::InputTag src_;
+  const edm::EDGetTokenT<reco::PFJetCollection> inputPFToken_;
+  double minJetMass_;
+
+};
+
+#endif

--- a/HLTrigger/JetMET/src/HLTJetMassFilter.cc
+++ b/HLTrigger/JetMET/src/HLTJetMassFilter.cc
@@ -1,0 +1,88 @@
+// -*- C++ -*-
+//
+// Package:    HLTCATopTagFilter
+// Class:      HLTCATopTagFilter
+// 
+/**\class HLTCATopTagFilter HLTCATopTagFilter.cc UserCode/HLTCATopTagFilter/plugins/HLTCATopTagFilter.cc
+
+ Description: [one line class summary]
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author:  clint richardson
+//         Created:  Sat, 5 Jul 2014 20:23:57 GMT
+// $Id$
+//
+//
+
+#include "HLTrigger/JetMET/interface/HLTJetMassFilter.h"
+#include <typeinfo>
+
+using namespace std;
+using namespace reco;
+using namespace edm;
+
+//
+// constructors and destructor
+//
+
+HLTJetMassFilter::HLTJetMassFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig),
+								       src_ (iConfig.getParameter<edm::InputTag>("src")),
+								       inputPFToken_ (consumes<reco::PFJetCollection>(src_))
+{
+  minJetMass_ = iConfig.getParameter<double>("minJetMass");
+
+}
+
+HLTJetMassFilter::~HLTJetMassFilter(){}
+
+void HLTJetMassFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions){
+  edm::ParameterSetDescription desc;
+  makeHLTFilterDescription(desc);
+  desc.add<edm::InputTag>("src",edm::InputTag("selectedPFJets"));
+  desc.add<double>("minJetMass",30.);
+  desc.add<int>("triggerType",trigger::TriggerJet);
+  descriptions.add("hltJetMassFilter",desc);
+}
+
+
+bool HLTJetMassFilter::hltFilter( edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs& filterobject) const
+{
+
+  //read in jet collection
+  Handle<reco::PFJetCollection> Jets;
+  iEvent.getByToken(inputPFToken_, Jets);
+
+  //add filter object
+  if(saveTags()){
+    filterobject.addCollectionTag(src_);
+  }
+
+  //iterate over jets in event and return pass if at least one passes jet mass cut
+  reco::PFJetCollection::const_iterator iJet = Jets->begin(), iEndJet = Jets->end();
+  bool pass = false;
+
+  for( ; iJet != iEndJet; ++iJet){
+    
+    float mass = iJet->mass();
+
+    if(mass>minJetMass_){
+      //update pass info
+      pass=true;
+      //get ref to jet and add
+      reco::PFJetRef ref = reco::PFJetRef(Jets,distance(Jets->begin(),iJet));
+      filterobject.addObject(trigger::TriggerJet,ref);
+    }
+
+  }
+
+  return pass;
+
+}
+
+
+
+//define as plugin
+DEFINE_FWK_MODULE(HLTJetMassFilter);


### PR DESCRIPTION
added an HLT filter to cut on the jetmass of PFJets. This is needed for the B2G trigger studies where we don't want to have to deal with making a FatJet first but are testing our own jet clustering algorithms at HLT and want to cut on the masses of our jets.
