### PR TITLE
Allow option of reading of files with prior releases (for 7_1_X)

### DIFF
--- a/IOPool/Input/src/RootFile.cc
+++ b/IOPool/Input/src/RootFile.cc
@@ -158,6 +158,7 @@ namespace edm {
                      std::vector<boost::shared_ptr<IndexIntoFile> > const& indexesIntoFiles,
                      std::vector<boost::shared_ptr<IndexIntoFile> >::size_type currentIndexIntoFile,
                      std::vector<ProcessHistoryID>& orderedProcessHistoryIDs,
+                     bool bypassVersionCheck,
                      bool labelRawDataLikeMC,
                      bool usingGoToEvent,
                      bool enablePrefetching) :
@@ -367,7 +368,9 @@ namespace edm {
       branchIDLists_.reset(branchIDListsAPtr.release());
     }
 
-    checkReleaseVersion(pHistVector, file());
+    if(!bypassVersionCheck) { 
+      checkReleaseVersion(pHistVector, file());
+    }
 
     if(labelRawDataLikeMC) {
       std::string const rawData("FEDRawDataCollection");

--- a/IOPool/Input/src/RootFile.h
+++ b/IOPool/Input/src/RootFile.h
@@ -78,6 +78,7 @@ namespace edm {
              std::vector<boost::shared_ptr<IndexIntoFile> > const& indexesIntoFiles,
              std::vector<boost::shared_ptr<IndexIntoFile> >::size_type currentIndexIntoFile,
              std::vector<ProcessHistoryID>& orderedProcessHistoryIDs,
+             bool bypassVersionCheck,
              bool labelRawDataLikeMC,
              bool usingGoToEvent,
              bool enablePrefetching);

--- a/IOPool/Input/src/RootInputFileSequence.cc
+++ b/IOPool/Input/src/RootInputFileSequence.cc
@@ -56,6 +56,7 @@ namespace edm {
     initialNumberOfEventsToSkip_(inputType == InputType::Primary ? pset.getUntrackedParameter<unsigned int>("skipEvents", 0U) : 0U),
     noEventSort_(inputType == InputType::Primary ? pset.getUntrackedParameter<bool>("noEventSort", true) : false),
     skipBadFiles_(pset.getUntrackedParameter<bool>("skipBadFiles", false)),
+    bypassVersionCheck_(pset.getUntrackedParameter<bool>("bypassVersionCheck", false)),
     treeCacheSize_(noEventSort_ ? pset.getUntrackedParameter<unsigned int>("cacheSize", roottree::defaultCacheSize) : 0U),
     treeMaxVirtualSize_(pset.getUntrackedParameter<int>("treeMaxVirtualSize", -1)),
     setRun_(pset.getUntrackedParameter<unsigned int>("setRunNumber", 0U)),
@@ -264,6 +265,7 @@ namespace edm {
           indexesIntoFiles_,
           currentIndexIntoFile,
           orderedProcessHistoryIDs_,
+          bypassVersionCheck_,
           labelRawDataLikeMC_,
           usingGoToEvent_,
           enablePrefetching_));
@@ -788,6 +790,9 @@ namespace edm {
     desc.addUntracked<bool>("skipBadFiles", false)
         ->setComment("True:  Ignore any missing or unopenable input file.\n"
                      "False: Throw exception if missing or unopenable input file.");
+    desc.addUntracked<bool>("bypassVersionCheck", false)
+        ->setComment("True:  Bypass release version check.\n"
+                     "False: Throw exception if reading file in a release prior to the release in which the file was written.");
     desc.addUntracked<unsigned int>("cacheSize", roottree::defaultCacheSize)
         ->setComment("Size of ROOT TTree prefetch cache.  Affects performance.");
     desc.addUntracked<int>("treeMaxVirtualSize", -1)

--- a/IOPool/Input/src/RootInputFileSequence.h
+++ b/IOPool/Input/src/RootInputFileSequence.h
@@ -110,6 +110,7 @@ namespace edm {
     int initialNumberOfEventsToSkip_;
     bool noEventSort_;
     bool skipBadFiles_;
+    bool bypassVersionCheck_;
     unsigned int treeCacheSize_;
     int const treeMaxVirtualSize_;
     RunNumber_t setRun_;


### PR DESCRIPTION
Offline has committed to allowing HLT jobs running in an earlier release to read raw data files written in a later release. This is currently prevented by a defensive check that disallows reading products in a release prior to the release in which the product was created. This pull request adds a configurable option "bypassVersionCheck" to bypass this check. See
https://indico.cern.ch/event/299538/material/slides/1.pdf
for the XEB report in which this commitment is documented.
This pull request is for 7_1_X only. It needs to be customized for other release cycles.
