### PR TITLE
Allow option of reading of files with prior releases (for 5_3_X)

### DIFF
--- a/IOPool/Input/src/RootFile.cc
+++ b/IOPool/Input/src/RootFile.cc
@@ -139,6 +139,7 @@ namespace edm {
                      std::vector<boost::shared_ptr<IndexIntoFile> > const& indexesIntoFiles,
                      std::vector<boost::shared_ptr<IndexIntoFile> >::size_type currentIndexIntoFile,
                      std::vector<ProcessHistoryID>& orderedProcessHistoryIDs,
+                     bool bypassVersionCheck,
                      bool labelRawDataLikeMC,
                      bool usingGoToEvent) :
       file_(fileName),
@@ -304,7 +305,9 @@ namespace edm {
     // Here we read the metadata tree
     roottree::getEntry(metaDataTree.get(), 0);
 
-    checkReleaseVersion();
+    if(!bypassVersionCheck) {
+      checkReleaseVersion();
+    }
 
     eventProcessHistoryIter_ = eventProcessHistoryIDs_.begin();
 

--- a/IOPool/Input/src/RootFile.h
+++ b/IOPool/Input/src/RootFile.h
@@ -70,6 +70,7 @@ namespace edm {
              std::vector<boost::shared_ptr<IndexIntoFile> > const& indexesIntoFiles,
              std::vector<boost::shared_ptr<IndexIntoFile> >::size_type currentIndexIntoFile,
              std::vector<ProcessHistoryID>& orderedProcessHistoryIDs,
+             bool bypassVersionCheck,
              bool labelRawDataLikeMC,
              bool usingGoToEvent);
     ~RootFile();

--- a/IOPool/Input/src/RootInputFileSequence.cc
+++ b/IOPool/Input/src/RootInputFileSequence.cc
@@ -55,6 +55,7 @@ namespace edm {
     numberOfEventsToSkip_(inputType == InputType::Primary ? pset.getUntrackedParameter<unsigned int>("skipEvents", 0U) : 0U),
     noEventSort_(inputType == InputType::Primary ? pset.getUntrackedParameter<bool>("noEventSort", true) : false),
     skipBadFiles_(pset.getUntrackedParameter<bool>("skipBadFiles", false)),
+    bypassVersionCheck_(pset.getUntrackedParameter<bool>("bypassVersionCheck", false)),
     treeCacheSize_(noEventSort_ ? pset.getUntrackedParameter<unsigned int>("cacheSize", roottree::defaultCacheSize) : 0U),
     treeMaxVirtualSize_(pset.getUntrackedParameter<int>("treeMaxVirtualSize", -1)),
     setRun_(pset.getUntrackedParameter<unsigned int>("setRunNumber", 0U)),
@@ -245,6 +246,7 @@ namespace edm {
           indexesIntoFiles_,
           currentIndexIntoFile,
           orderedProcessHistoryIDs_,
+          bypassVersionCheck_,
           labelRawDataLikeMC_,
           usingGoToEvent_));
 
@@ -757,6 +759,9 @@ namespace edm {
     desc.addUntracked<bool>("skipBadFiles", false)
         ->setComment("True:  Ignore any missing or unopenable input file.\n"
                      "False: Throw exception if missing or unopenable input file.");
+    desc.addUntracked<bool>("bypassVersionCheck", false)
+        ->setComment("True:  Bypass release version check.\n"
+                     "False: Throw exception if reading file in a release prior to the release in which the file was written.");
     desc.addUntracked<unsigned int>("cacheSize", roottree::defaultCacheSize)
         ->setComment("Size of ROOT TTree prefetch cache.  Affects performance.");
     desc.addUntracked<int>("treeMaxVirtualSize", -1)

--- a/IOPool/Input/src/RootInputFileSequence.h
+++ b/IOPool/Input/src/RootInputFileSequence.h
@@ -104,6 +104,7 @@ namespace edm {
     int numberOfEventsToSkip_;
     bool noEventSort_;
     bool skipBadFiles_;
+    bool bypassVersionCheck_;
     unsigned int treeCacheSize_;
     int const treeMaxVirtualSize_;
     RunNumber_t setRun_;


### PR DESCRIPTION
Offline has committed to allowing HLT jobs running in an earlier release to read raw data files written in a later release. This is currently prevented by a defensive check that disallows reading products in a release prior to the release in which the product was created. This pull request adds a configurable option "bypassVersionCheck" to bypass this check. See
https://indico.cern.ch/event/299538/material/slides/1.pdf
for the XEB report in which this commitment is documented.
This pull request is for 5_3_X only. It needs to be customized for other release cycles.
