### PR TITLE
HLTrigger/Timer/test: add a thread-based cpu clock for OS X

### DIFF
--- a/HLTrigger/Timer/test/chrono.cc
+++ b/HLTrigger/Timer/test/chrono.cc
@@ -31,6 +31,7 @@
 #include "posix_getrusage.h"
 #include "mach_clock_get_time.h"
 #include "mach_absolute_time.h"
+#include "mach_thread_info.h"
 #include "x86_tsc_clock.h"
 #include "boost_timer.h"
 #include "tbb_tick_count.h"
@@ -120,6 +121,10 @@ void init_timers(std::vector<BenchmarkBase *> & timers)
     timers.push_back(new Benchmark<mach_absolute_time_clock_native>("mach_absolute_time() (native)"));
   }
 #endif // HAVE_MACH_ABSOLUTE_TIME
+#ifdef HAVE_MACH_THREAD_INFO_CLOCK
+  if (mach_thread_info_clock::is_available)
+    timers.push_back(new Benchmark<mach_thread_info_clock>("thread_info(mach_thread_self(), THREAD_BASIC_INFO, ...)"));
+#endif // HAVE_MACH_THREAD_INFO_CLOCK
 
 #if defined __x86_64__ or defined __i386__
 // TSC is only available on x86

--- a/HLTrigger/Timer/test/mach_thread_info.h
+++ b/HLTrigger/Timer/test/mach_thread_info.h
@@ -1,0 +1,45 @@
+#if defined(__APPLE__) || defined(__MACH__)
+
+#ifndef mach_thread_info_h
+#define mach_thread_info_h
+
+#define HAVE_MACH_THREAD_INFO_CLOCK
+
+// Darwin system headers
+#include <mach/kern_return.h>
+#include <mach/mach_init.h>
+#include <mach/thread_info.h>
+
+// C++ standard headers
+#include <chrono>
+
+// based on thread_info(mach_thread_self(), THREAD_BASIC_INFO, ...)
+struct mach_thread_info_clock
+{
+  typedef std::chrono::microseconds                                     duration;
+  typedef duration::rep                                                 rep;
+  typedef duration::period                                              period;
+  typedef std::chrono::time_point<mach_thread_info_clock, duration>     time_point;
+
+  static constexpr bool is_steady    = false;
+  static constexpr bool is_available = true;
+
+  static time_point now() noexcept
+  {
+    thread_local mach_port_t thread_id = mach_thread_self();
+
+    thread_basic_info_data_t basic_info;
+    mach_msg_type_number_t count = THREAD_BASIC_INFO_COUNT;
+    if (KERN_SUCCESS == thread_info(thread_id, THREAD_BASIC_INFO, (thread_info_t) & basic_info, & count)) {
+      return time_point( std::chrono::seconds(basic_info.user_time.seconds + basic_info.system_time.seconds) + 
+                         std::chrono::microseconds(basic_info.user_time.microseconds + basic_info.system_time.microseconds) );
+    } else {
+      return time_point();
+    }
+  }
+
+};
+
+#endif // mach_thread_info_h
+
+#endif // defined(__APPLE__) || defined(__MACH__)


### PR DESCRIPTION
Add a clock to measure the cpu time used by the current thread, with microsecond
granularity, based on thread_info(mach_thread_self(), THREAD_BASIC_INFO, ...)
