### PR TITLE
Upgrade of dyn. ineff. feature to handle cases when PU is 0

### DIFF
--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
@@ -521,12 +521,14 @@ void SiPixelDigitizerAlgorithm::calculateInstlumiFactor(PileupMixingContent* puI
 	  instlumi_pow*=instlumi;
 	}
       }
+      _eventPileUp = TrueInteractionList.at(p);
     }
   } 
   else {
     for (int i=0; i<3;i++) {
       _pu_scale[i] = 1.;
     }
+    _eventPileUp = 0.;
   }
 }
 
@@ -1355,7 +1357,7 @@ void SiPixelDigitizerAlgorithm::pixel_inefficiency(const PixelEfficiencies& eff,
        int module=tTopo->pxbModule(detID);
        if (module<=4) module=5-module;
        else module-=4;
-       
+       if (floor(_eventPileUp) != 0)       
        columnEfficiency *= eff.theLadderEfficiency_BPix[layerIndex-1][ladder-1]*eff.theModuleEfficiency_BPix[layerIndex-1][module-1]*_pu_scale[layerIndex-1];
     }
   } else {                // forward disks

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
@@ -493,7 +493,7 @@ void SiPixelDigitizerAlgorithm::accumulateSimHits(std::vector<PSimHit>::const_it
 //============================================================================
 void SiPixelDigitizerAlgorithm::calculateInstlumiFactor(PileupMixingContent* puInfo){
   //Instlumi scalefactor calculating for dynamic inefficiency
-  
+  _eventPileUp = false;    
   if (puInfo) {
     
     const std::vector<int> bunchCrossing = puInfo->getMix_bunchCrossing();
@@ -511,9 +511,10 @@ void SiPixelDigitizerAlgorithm::calculateInstlumiFactor(PileupMixingContent* puI
       pui++;
     }
     
-    if (pu0!=bunchCrossing.end()) {        
+    if (pu0!=bunchCrossing.end()) {
+      double instlumi = TrueInteractionList[p]*221.95;
+      if (instlumi > 0.) _eventPileUp = true;         
       for (size_t i=0; i<3; i++) {
-	double instlumi = TrueInteractionList.at(p)*221.95;
 	double instlumi_pow=1.;
 	_pu_scale[i] = 0;
 	for  (size_t j=0; j<pixelEfficiencies_.thePUEfficiency_BPix[i].size(); j++){
@@ -521,14 +522,12 @@ void SiPixelDigitizerAlgorithm::calculateInstlumiFactor(PileupMixingContent* puI
 	  instlumi_pow*=instlumi;
 	}
       }
-      _eventPileUp = TrueInteractionList.at(p);
     }
   } 
   else {
     for (int i=0; i<3;i++) {
       _pu_scale[i] = 1.;
     }
-    _eventPileUp = 0.;
   }
 }
 
@@ -1357,7 +1356,7 @@ void SiPixelDigitizerAlgorithm::pixel_inefficiency(const PixelEfficiencies& eff,
        int module=tTopo->pxbModule(detID);
        if (module<=4) module=5-module;
        else module-=4;
-       if (floor(_eventPileUp) != 0)       
+       if (_eventPileUp)       
        columnEfficiency *= eff.theLadderEfficiency_BPix[layerIndex-1][ladder-1]*eff.theModuleEfficiency_BPix[layerIndex-1][module-1]*_pu_scale[layerIndex-1];
     }
   } else {                // forward disks

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.h
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.h
@@ -244,6 +244,7 @@ class SiPixelDigitizerAlgorithm  {
    // Needed by dynamic inefficiency 
    // 0-3 BPix, 4-5 FPix
    double _pu_scale[20];
+   float _eventPileUp;
 
     // Internal typedefs
     typedef std::map<int, Amplitude, std::less<int> > signal_map_type;  // from Digi.Skel.

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.h
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.h
@@ -244,7 +244,7 @@ class SiPixelDigitizerAlgorithm  {
    // Needed by dynamic inefficiency 
    // 0-3 BPix, 4-5 FPix
    double _pu_scale[20];
-   float _eventPileUp;
+   bool _eventPileUp;
 
     // Internal typedefs
     typedef std::map<int, Amplitude, std::less<int> > signal_map_type;  // from Digi.Skel.


### PR DESCRIPTION
A small improvement to pixel digitizer's dynamic inefficiency feature.
It automatically disables dynamic inefficiency simulation in case when there is zero pile-up per event.

Details:
The _eventPileUp variable gets the pile-up number per event from PileupMixinContent's TrueInteractionList (calculateInstlumiFactor () method), then it is used in pixel_inefficiency () method to check whether the actual pile-up is zero. If it is, then the columnEfficiency remains unchanged, i.e. no dynamic inefficiency is used. 
