### PR TITLE
Bug fix: changing a module did not set getByToken code

### DIFF
--- a/FWCore/Framework/interface/ModuleChanger.h
+++ b/FWCore/Framework/interface/ModuleChanger.h
@@ -29,11 +29,12 @@
 namespace edm {
    class ParameterSet;
    class Schedule;
-   
+   class ProductRegistry;
+
    class ModuleChanger {
 
    public:
-      ModuleChanger(Schedule*);
+      ModuleChanger(Schedule*, ProductRegistry const* iReg);
       virtual ~ModuleChanger();
 
       // ---------- const member functions ---------------------
@@ -45,12 +46,13 @@ namespace edm {
       // ---------- member functions ---------------------------
 
    private:
-      ModuleChanger(const ModuleChanger&); // stop default
+      ModuleChanger(const ModuleChanger&) = delete; // stop default
 
-      const ModuleChanger& operator=(const ModuleChanger&); // stop default
+      const ModuleChanger& operator=(const ModuleChanger&) = delete; // stop default
 
       // ---------- member data --------------------------------
       Schedule* schedule_;
+      ProductRegistry const* registry_;
    };
 }
 #endif

--- a/FWCore/Framework/interface/Schedule.h
+++ b/FWCore/Framework/interface/Schedule.h
@@ -228,7 +228,7 @@ namespace edm {
 
     /// clone the type of module with label iLabel but configure with iPSet.
     /// Returns true if successful.
-    bool changeModule(std::string const& iLabel, ParameterSet const& iPSet);
+    bool changeModule(std::string const& iLabel, ParameterSet const& iPSet, const ProductRegistry& iRegistry);
 
     /// returns the collection of pointers to workers
     AllWorkers const& allWorkers() const;

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -1496,7 +1496,7 @@ namespace edm {
 
   bool EventProcessor::endOfLoop() {
     if(looper_) {
-      ModuleChanger changer(schedule_.get());
+      ModuleChanger changer(schedule_.get(),preg_.get());
       looper_->setModuleChanger(&changer);
       EDLooperBase::Status status = looper_->doEndOfLoop(esp_->eventSetup());
       looper_->setModuleChanger(nullptr);

--- a/FWCore/Framework/src/ModuleChanger.cc
+++ b/FWCore/Framework/src/ModuleChanger.cc
@@ -28,8 +28,9 @@ using namespace edm;
 //
 // constructors and destructor
 //
-ModuleChanger::ModuleChanger(Schedule* iSchedule):
-schedule_(iSchedule)
+ModuleChanger::ModuleChanger(Schedule* iSchedule, ProductRegistry const* iRegistry):
+schedule_(iSchedule),
+registry_(iRegistry)
 {
 }
 
@@ -65,7 +66,7 @@ bool
 ModuleChanger::changeModule(const std::string& iLabel,
                             const ParameterSet& iPSet) const
 {
-   return schedule_->changeModule(iLabel,iPSet);
+   return schedule_->changeModule(iLabel,iPSet, *registry_);
 }
 
 //


### PR DESCRIPTION
When an EDLooper changed a module, the infrastructure used to properly setup getByToken was not called.

This functionality is only used by fireworks. It needs to be back ported since fireworks is being actively used in 7_1_X.
