### PR TITLE
Simple cluster size model 1 simhit-1digi, ME0 sim params changed

### DIFF
--- a/SimMuon/GEMDigitizer/interface/GEMSimpleModel.h
+++ b/SimMuon/GEMDigitizer/interface/GEMSimpleModel.h
@@ -20,7 +20,6 @@ namespace CLHEP
   class RandFlat;
   class RandPoissonQ;
   class RandGaussQ;
-  class RandGamma;
   class RandBinomial;
 }
 
@@ -52,8 +51,7 @@ private:
   double timeResolution_;
   double timeJitter_;
   double averageNoiseRate_;
-// double averageClusterSize_;
-  std::vector<double> clsParametrization_;
+//  std::vector<double> clsParametrization_;
   double signalPropagationSpeed_;
   bool cosmics_;
   int bxwidth_;
@@ -63,7 +61,6 @@ private:
   bool doBkgNoise_;
   bool doNoiseCLS_;
   bool fixedRollRadius_;
-  double minPabsNoiseCLS_;
   bool simulateIntrinsicNoise_;
   bool simulateElectronBkg_;
   bool simulateLowNeutralRate_;
@@ -75,7 +72,6 @@ private:
   CLHEP::RandPoissonQ* poisson_;
   CLHEP::RandGaussQ* gauss1_;
   CLHEP::RandGaussQ* gauss2_;
-  CLHEP::RandGamma* gamma1_;
 
 //parameters from the fit:
 //params for pol3 model of electron bkg for GE1/1:

--- a/SimMuon/GEMDigitizer/python/muonGEMDigis_cfi.py
+++ b/SimMuon/GEMDigitizer/python/muonGEMDigis_cfi.py
@@ -7,7 +7,7 @@ simMuonGEMDigis = cms.EDProducer("GEMDigiProducer",
     timeResolution = cms.double(5),
     timeJitter = cms.double(1.0),
     averageShapingTime = cms.double(50.0),
-    clsParametrization = cms.vdouble(0.455091, 0.865613, 0.945891, 0.973286, 0.986234, 0.991686, 0.996865, 0.998501, 1.),
+#    clsParametrization = cms.vdouble(0.455091, 0.865613, 0.945891, 0.973286, 0.986234, 0.991686, 0.996865, 0.998501, 1.),
     averageEfficiency = cms.double(0.98),
     averageNoiseRate = cms.double(0.001), #intrinsic noise
     bxwidth = cms.int32(25),
@@ -19,7 +19,6 @@ simMuonGEMDigis = cms.EDProducer("GEMDigiProducer",
     doBkgNoise = cms.bool(True), #False == No background simulation
     doNoiseCLS = cms.bool(True),
     fixedRollRadius = cms.bool(True), #Uses fixed radius in the center of the roll
-    minPabsNoiseCLS = cms.double(0.),
     simulateIntrinsicNoise = cms.bool(False),
 
     simulateElectronBkg = cms.bool(True),	#False=simulate only neutral Bkg

--- a/SimMuon/GEMDigitizer/src/ME0PreRecoGaussianModel.cc
+++ b/SimMuon/GEMDigitizer/src/ME0PreRecoGaussianModel.cc
@@ -31,22 +31,23 @@ ME0PreRecoGaussianModel::ME0PreRecoGaussianModel(const edm::ParameterSet& config
 , maxBunch_(config.getParameter<int> ("maxBunch"))
 
 {
-  //params for the simple pol6 model of neutral and electron bkg for ME0:
-  ME0ModNeuBkgParam0 = 5.69e+06;
-  ME0ModNeuBkgParam1 = -293334;
-  ME0ModNeuBkgParam2 = 6279.6;
-  ME0ModNeuBkgParam3 = -71.2928;
-  ME0ModNeuBkgParam4 = 0.452244;
-  ME0ModNeuBkgParam5 = -0.0015191;
-  ME0ModNeuBkgParam6 = 2.1106e-06;
 
-  ME0ModElecBkgParam0 = 3.77712e+06;
-  ME0ModElecBkgParam1 = -199280;
-  ME0ModElecBkgParam2 = 4340.69;
-  ME0ModElecBkgParam3 = -49.922;
-  ME0ModElecBkgParam4 = 0.319699;
-  ME0ModElecBkgParam5 = -0.00108113;
-  ME0ModElecBkgParam6 = 1.50889e-06;
+  //params for the simple pol6 model of neutral and electron bkg for ME0:
+  ME0ModNeuBkgParam0 = 899644;
+  ME0ModNeuBkgParam1 = -30841;
+  ME0ModNeuBkgParam2 = 441.28;
+  ME0ModNeuBkgParam3 = -3.3405;
+  ME0ModNeuBkgParam4 = 0.0140588;
+  ME0ModNeuBkgParam5 = -3.11473e-05;
+  ME0ModNeuBkgParam6 = 2.83736e-08;
+
+  ME0ModElecBkgParam0 = 4.68590e+05;
+  ME0ModElecBkgParam1 = -1.63834e+04;
+  ME0ModElecBkgParam2 = 2.35700e+02;
+  ME0ModElecBkgParam3 = -1.77706e+00;
+  ME0ModElecBkgParam4 = 7.39960e-03;
+  ME0ModElecBkgParam5 = -1.61448e-05;
+  ME0ModElecBkgParam6 = 1.44368e-08;
 
 }
 


### PR DESCRIPTION
The cluster size model is changed with more simple - for every 1 simHit only one strip is fired. The background hits fire one or two strips. The ME0 parameters for pseudo-digis are improved.
