### PR TITLE
fixes to pythia8 pt gun

### DIFF
--- a/GeneratorInterface/Pythia8Interface/plugins/Py8PtGun.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Py8PtGun.cc
@@ -88,21 +88,17 @@ bool Py8PtGun::generatePartonsAndHadronize()
       {
 	if( 1 <= fabs(particleID) && fabs(particleID) <= 6){ // quarks
 	  (fMasterGen->event).append( -particleID, 23, 0, 101, -px, -py, -pz, ee, mass );
-	  std::cout << "1" << std::endl;
 	}
 	else if (fabs(particleID) == 21){                   // gluons
 	  (fMasterGen->event).append( 21, 23, 102, 101, -px, -py, -pz, ee, mass );
-	  std::cout << "2" << std::endl;
 	}
 	else if ( (fMasterGen->particleData).isParticle( -particleID ) )
 	  {
 	    (fMasterGen->event).append( -particleID, 1, 0, 0, -px, -py, -pz, ee, mass );
-	    std::cout << "3" << std::endl;
 	  }
 	else
 	  {
 	    (fMasterGen->event).append( particleID, 1, 0, 0, -px, -py, -pz, ee, mass );
-	    std::cout << "4" << std::endl;
 	  }
       }
 
@@ -110,7 +106,6 @@ bool Py8PtGun::generatePartonsAndHadronize()
 
    
    if ( !fMasterGen->next() ) return false;
-   (fMasterGen->event).list();
    
    event().reset(new HepMC::GenEvent);
    return toHepMC.fill_next_event( fMasterGen->event, event().get() );

--- a/GeneratorInterface/Pythia8Interface/plugins/Py8PtGun.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Py8PtGun.cc
@@ -73,27 +73,44 @@ bool Py8PtGun::generatePartonsAndHadronize()
       {
          particleID = std::fabs(particleID) ;
       }
-      (fMasterGen->event).append( particleID, 1, 0, 0, px, py, pz, ee, mass ); 
-
+      if( 1<= fabs(particleID) && fabs(particleID) <= 6) // quarks
+	(fMasterGen->event).append( particleID, 23, 101, 0, px, py, pz, ee, mass ); 
+      else if (fabs(particleID) == 21)                   // gluons
+	(fMasterGen->event).append( 21, 23, 101, 102, px, py, pz, ee, mass );
+      else                                               // other
+	(fMasterGen->event).append( particleID, 1, 0, 0, px, py, pz, ee, mass ); 
+      
 // Here also need to add anti-particle (if any)
 // otherwise just add a 2nd particle of the same type 
 // (for example, gamma)
 //
       if ( fAddAntiParticle )
       {
-         if ( (fMasterGen->particleData).isParticle( -particleID ) )
-	 {
-	    (fMasterGen->event).append( -particleID, 1, 0, 0, px, py, pz, ee, mass );
-	 }
-	 else
-	 {
-	    (fMasterGen->event).append( particleID, 1, 0, 0, px, py, pz, ee, mass );
-	 }
+	if( 1 <= fabs(particleID) && fabs(particleID) <= 6){ // quarks
+	  (fMasterGen->event).append( -particleID, 23, 0, 101, -px, -py, -pz, ee, mass );
+	  std::cout << "1" << std::endl;
+	}
+	else if (fabs(particleID) == 21){                   // gluons
+	  (fMasterGen->event).append( 21, 23, 102, 101, -px, -py, -pz, ee, mass );
+	  std::cout << "2" << std::endl;
+	}
+	else if ( (fMasterGen->particleData).isParticle( -particleID ) )
+	  {
+	    (fMasterGen->event).append( -particleID, 1, 0, 0, -px, -py, -pz, ee, mass );
+	    std::cout << "3" << std::endl;
+	  }
+	else
+	  {
+	    (fMasterGen->event).append( particleID, 1, 0, 0, -px, -py, -pz, ee, mass );
+	    std::cout << "4" << std::endl;
+	  }
       }
 
    }
+
    
    if ( !fMasterGen->next() ) return false;
+   (fMasterGen->event).list();
    
    event().reset(new HepMC::GenEvent);
    return toHepMC.fill_next_event( fMasterGen->event, event().get() );

--- a/GeneratorInterface/Pythia8Interface/python/Py8PtGun_bb_cfi.py
+++ b/GeneratorInterface/Pythia8Interface/python/Py8PtGun_bb_cfi.py
@@ -1,0 +1,22 @@
+import FWCore.ParameterSet.Config as cms
+
+generator = cms.EDFilter(
+    "Pythia8PtGun",
+
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(True),
+    
+    PGunParameters = cms.PSet(
+        ParticleID = cms.vint32(5),
+        AddAntiParticle = cms.bool(True),
+        MinPhi = cms.double(-3.14159265359),
+        MaxPhi = cms.double(3.14159265359),
+        MinPt = cms.double(100.0),
+        MaxPt = cms.double(200.0),
+        MinEta = cms.double(0.0),
+        MaxEta = cms.double(2.4)
+        ),
+    
+    PythiaParameters = cms.PSet(parameterSets = cms.vstring())       
+)


### PR DESCRIPTION
made anti-particles back-to-back to particles.

made quark + anti-quark and gluon pairs colourless states.
code stolen from pythia8.185 examples/main21.cc

tests:
- generated 10 events for each id [1,5,6,21,22,23]
- checked logs for pythia errors
- visual inspection of events with cmsShow

test outcome:
- all ok
