### PR TITLE
Revert "strip digitizer stores tofBin, hitAssociator uses CFpos"

### DIFF
--- a/SimDataFormats/TrackerDigiSimLink/interface/StripDigiSimLink.h
+++ b/SimDataFormats/TrackerDigiSimLink/interface/StripDigiSimLink.h
@@ -6,16 +6,11 @@
 
 class StripDigiSimLink {
  public:
-  enum {LowTof, HighTof};
+  StripDigiSimLink(unsigned int ch, unsigned int tkId, unsigned int counter, EncodedEventId e,float a ):
+    chan(ch),simTkId(tkId), CFpos(counter), eId(e) , fract(a) {;}
 
-  StripDigiSimLink(unsigned int ch, unsigned int tkId, unsigned int counter, unsigned int tofBin, EncodedEventId e, float a ):
-    chan(ch),simTkId(tkId), CFpos(tofBin == LowTof ? counter & 0x7FFFFFFF : (counter & 0x7FFFFFFF) | 0x80000000), eId(e), fract(a) {;}
-
-  StripDigiSimLink(unsigned int ch, unsigned int tkId, unsigned int counter, EncodedEventId e, float a ):
-    chan(ch),simTkId(tkId), CFpos(counter & 0x7FFFFFFF), eId(e), fract(a) {;}
-
-  StripDigiSimLink(unsigned int ch, unsigned int tkId, EncodedEventId e, float a ):
-    chan(ch),simTkId(tkId), CFpos(0), eId(e), fract(a) {;}
+  StripDigiSimLink(unsigned int ch, unsigned int tkId, EncodedEventId e,float a ):
+    chan(ch),simTkId(tkId), CFpos(0), eId(e) , fract(a) {;}
 
     StripDigiSimLink():chan(0),simTkId(0),CFpos(0),eId(0), fract(0) {;}
 
@@ -23,8 +18,7 @@ class StripDigiSimLink {
 
   unsigned int   channel()     const {return chan;}
   unsigned int   SimTrackId()  const {return simTkId;}
-  unsigned int   CFposition()  const {return CFpos & 0x7FFFFFFF;}
-  unsigned int   TofBin()      const {return (CFpos & 0x80000000) == 0 ? LowTof : HighTof;}
+  unsigned int   CFposition()  const {return CFpos;}
   EncodedEventId eventId()     const {return eId;}
   float          fraction()    const {return fract;}
 
@@ -33,8 +27,7 @@ class StripDigiSimLink {
  private:
   unsigned int chan;
   unsigned int simTkId;
-  uint32_t CFpos; // position of the PSimHit in the CrossingFrame vector
-             // for the subdetector collection; bit 31 set if from the HighTof collection
+  unsigned int CFpos; //position of the PSimHit in the CrossingFrame vector
   EncodedEventId eId;
   float    fract;
 };

--- a/SimDataFormats/TrackerDigiSimLink/src/classes_def.xml
+++ b/SimDataFormats/TrackerDigiSimLink/src/classes_def.xml
@@ -11,8 +11,7 @@
  <class name="edm::Wrapper< std::vector<edm::DetSet<PixelDigiSimLink> > >" splitLevel="0" />
  <class name="edm::Wrapper< edm::DetSetVector<PixelDigiSimLink> >" splitLevel="0" />
 
- <class name="StripDigiSimLink" ClassVersion="11">
-  <version ClassVersion="11" checksum="2019711893"/>
+ <class name="StripDigiSimLink" ClassVersion="10">
   <version ClassVersion="10" checksum="2019711893"/>
  </class>
  <class name="edm::DetSet<StripDigiSimLink>"/>

--- a/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.cc
+++ b/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.cc
@@ -96,7 +96,7 @@ SiStripDigitizer::~SiStripDigitizer() {
 }  
 
 void SiStripDigitizer::accumulateStripHits(edm::Handle<std::vector<PSimHit> > hSimHits,
-					   const TrackerTopology *tTopo, size_t globalSimHitIndex, const unsigned int tofBin, CLHEP::HepRandomEngine* engine ) {
+					   const TrackerTopology *tTopo, size_t globalSimHitIndex, CLHEP::HepRandomEngine* engine ) {
   // globalSimHitIndex is the index the sim hit will have when it is put in a collection
   // of sim hits for all crossings. This is only used when creating digi-sim links if
   // configured to do so.
@@ -115,7 +115,7 @@ void SiStripDigitizer::accumulateStripHits(edm::Handle<std::vector<PSimHit> > hS
 	  GlobalVector bfield = pSetup->inTesla(stripdet->surface().position());
 	  LogDebug ("Digitizer ") << "B-field(T) at " << stripdet->surface().position() << "(cm): "
 				  << pSetup->inTesla(stripdet->surface().position());
-	  theDigiAlgo->accumulateSimHits(it, itEnd, globalSimHitIndex, tofBin, stripdet, bfield, tTopo, engine);
+	  theDigiAlgo->accumulateSimHits(it, itEnd, globalSimHitIndex, stripdet, bfield, tTopo, engine);
 	}
       }
     } // end of loop over sim hits
@@ -134,11 +134,9 @@ void SiStripDigitizer::accumulateStripHits(edm::Handle<std::vector<PSimHit> > hS
     for(auto const& trackerContainer : trackerContainers) {
       edm::Handle<std::vector<PSimHit> > simHits;
       edm::InputTag tag(hitsProducer, trackerContainer);
-      unsigned int tofBin = StripDigiSimLink::LowTof;
-      if (trackerContainer.find(std::string("HighTof")) != std::string::npos) tofBin = StripDigiSimLink::HighTof;
 
       iEvent.getByLabel(tag, simHits);
-      accumulateStripHits(simHits,tTopo,crossingSimHitIndexOffset_[tag.encode()], tofBin, randomEngine(iEvent.streamID()));
+      accumulateStripHits(simHits,tTopo,crossingSimHitIndexOffset_[tag.encode()], randomEngine(iEvent.streamID()));
       // Now that the hits have been processed, I'll add the amount of hits in this crossing on to
       // the global counter. Next time accumulateStripHits() is called it will count the sim hits
       // as though they were on the end of this collection.
@@ -158,11 +156,9 @@ void SiStripDigitizer::accumulateStripHits(edm::Handle<std::vector<PSimHit> > hS
     for(auto const& trackerContainer : trackerContainers) {
       edm::Handle<std::vector<PSimHit> > simHits;
       edm::InputTag tag(hitsProducer, trackerContainer);
-      unsigned int tofBin = StripDigiSimLink::LowTof;
-      if (trackerContainer.find(std::string("HighTof")) != std::string::npos) tofBin = StripDigiSimLink::HighTof; 
 
       iEvent.getByLabel(tag, simHits);
-      accumulateStripHits(simHits,tTopo,crossingSimHitIndexOffset_[tag.encode()], tofBin, randomEngine(streamID));
+      accumulateStripHits(simHits,tTopo,crossingSimHitIndexOffset_[tag.encode()], randomEngine(streamID));
       // Now that the hits have been processed, I'll add the amount of hits in this crossing on to
       // the global counter. Next time accumulateStripHits() is called it will count the sim hits
       // as though they were on the end of this collection.

--- a/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.h
+++ b/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.h
@@ -54,7 +54,7 @@ public:
   virtual void finalizeEvent(edm::Event& e, edm::EventSetup const& c) override;
   
 private:
-  void accumulateStripHits(edm::Handle<std::vector<PSimHit> >, const TrackerTopology *tTopo, size_t globalSimHitIndex, const unsigned int tofBin, CLHEP::HepRandomEngine*);
+  void accumulateStripHits(edm::Handle<std::vector<PSimHit> >, const TrackerTopology *tTopo, size_t globalSimHitIndex, CLHEP::HepRandomEngine*);
   CLHEP::HepRandomEngine* randomEngine(edm::StreamID const& streamID);
 
   typedef std::vector<std::string> vstring;

--- a/SimTracker/SiStripDigitizer/plugins/SiStripDigitizerAlgorithm.cc
+++ b/SimTracker/SiStripDigitizer/plugins/SiStripDigitizerAlgorithm.cc
@@ -108,7 +108,6 @@ void
 SiStripDigitizerAlgorithm::accumulateSimHits(std::vector<PSimHit>::const_iterator inputBegin,
                                              std::vector<PSimHit>::const_iterator inputEnd,
                                              size_t inputBeginGlobalIndex,
-					     unsigned int tofBin,
                                              const StripGeomDetUnit* det,
                                              const GlobalVector& bfield,
 					     const TrackerTopology *tTopo,
@@ -119,7 +118,7 @@ SiStripDigitizerAlgorithm::accumulateSimHits(std::vector<PSimHit>::const_iterato
 
   std::vector<bool>& badChannels = allBadChannels[detID];
   size_t thisFirstChannelWithSignal = numStrips;
-  size_t thisLastChannelWithSignal = 0;
+  size_t thisLastChannelWithSignal = numStrips;
 
   float langle = (lorentzAngleHandle.isValid()) ? lorentzAngleHandle->getLorentzAngle(detID) : 0.;
 
@@ -196,7 +195,7 @@ SiStripDigitizerAlgorithm::accumulateSimHits(std::vector<PSimHit>::const_iterato
                 }
               } // end of loop over associationVector
               // If the hit wasn't already in create a new association info structure.
-              if( addNewEntry ) associationVector.push_back( AssociationInfo{ simHitIter->trackId(), simHitIter->eventId(), signalFromThisSimHit, simHitGlobalIndex, tofBin } );
+              if( addNewEntry ) associationVector.push_back( AssociationInfo{ simHitIter->trackId(), simHitIter->eventId(), signalFromThisSimHit, simHitGlobalIndex } );
             } // end of "if( signalFromThisSimHit!=0 )"
           } // end of loop over locAmpl strips
         } // end of "if( makeDigiSimLinks_ )"
@@ -273,9 +272,9 @@ SiStripDigitizerAlgorithm::digitize(
         for( const auto& iAssociationInfo : associationInfo ) totalSimADC+=iAssociationInfo.contributionToADC;
         // Now I know that I can loop again and create the links
         for( const auto& iAssociationInfo : associationInfo ) {
-          // Note simHitGlobalIndex used to have +1 because TrackerHitAssociator (the only place I can find this value being used)
-          // expected counting to start at 1, not 0.  Now changed.
-          outLink.push_back( StripDigiSimLink( iDigi.channel(), iAssociationInfo.trackID, iAssociationInfo.simHitGlobalIndex, iAssociationInfo.tofBin, iAssociationInfo.eventID, iAssociationInfo.contributionToADC/totalSimADC ) );
+          // Note simHitGlobalIndex has +1 because TrackerHitAssociator (the only place I can find this value being used)
+          // expects counting to start at 1, not 0.
+          outLink.push_back( StripDigiSimLink( iDigi.channel(), iAssociationInfo.trackID, iAssociationInfo.simHitGlobalIndex+1, iAssociationInfo.eventID, iAssociationInfo.contributionToADC/totalSimADC ) );
         } // end of loop over associationInfo
       } // end of loop over the digis
     } // end of check that iAssociationInfoByChannel is a valid iterator
@@ -398,9 +397,9 @@ SiStripDigitizerAlgorithm::digitize(
         for( const auto& iAssociationInfo : associationInfo ) totalSimADC+=iAssociationInfo.contributionToADC;
         // Now I know that I can loop again and create the links
         for( const auto& iAssociationInfo : associationInfo ) {
-          // Note simHitGlobalIndex used to have +1 because TrackerHitAssociator (the only place I can find this value being used)
-          // expected counting to start at 1, not 0.  Now changed.
-          outLink.push_back( StripDigiSimLink( channel, iAssociationInfo.trackID, iAssociationInfo.simHitGlobalIndex, iAssociationInfo.tofBin, iAssociationInfo.eventID, iAssociationInfo.contributionToADC/totalSimADC ) );
+          // Note simHitGlobalIndex has +1 because TrackerHitAssociator (the only place I can find this value being used)
+          // expects counting to start at 1, not 0.
+          outLink.push_back( StripDigiSimLink( channel, iAssociationInfo.trackID, iAssociationInfo.simHitGlobalIndex+1, iAssociationInfo.eventID, iAssociationInfo.contributionToADC/totalSimADC ) );
         } // end of loop over associationInfo
       } // end of loop over the digis
     } // end of check that iAssociationInfoByChannel is a valid iterator

--- a/SimTracker/SiStripDigitizer/plugins/SiStripDigitizerAlgorithm.h
+++ b/SimTracker/SiStripDigitizer/plugins/SiStripDigitizerAlgorithm.h
@@ -68,7 +68,6 @@ class SiStripDigitizerAlgorithm {
   void accumulateSimHits(const std::vector<PSimHit>::const_iterator inputBegin,
                          const std::vector<PSimHit>::const_iterator inputEnd,
                          size_t inputBeginGlobalIndex,
-			 unsigned int tofBin,
                          const StripGeomDetUnit *stripdet,
                          const GlobalVector& bfield,
 			 const TrackerTopology *tTopo,
@@ -144,7 +143,6 @@ class SiStripDigitizerAlgorithm {
     EncodedEventId eventID;
     float contributionToADC;
     size_t simHitGlobalIndex; ///< The array index of the sim hit, but in the array for all crossings
-    unsigned int tofBin;  // Needed along with subDet to determine which PSimHit collection simHitGlobalIndex indexes
   };
 
   typedef std::map<int, std::vector<AssociationInfo> >  AssociationInfoForChannel;

--- a/SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h
+++ b/SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h
@@ -62,31 +62,26 @@ class TrackerHitAssociator {
   // Destructor
   virtual ~TrackerHitAssociator(){}
   
-  typedef std::pair<unsigned int, unsigned int> simHitCollectionID;
-  typedef std::pair<simHitCollectionID, unsigned int> simhitAddr;
-
   std::vector<PSimHit> associateHit(const TrackingRecHit & thit) const;
   //for PU events
   std::vector<SimHitIdpr> associateHitId(const TrackingRecHit & thit) const;
-  void associateHitId(const TrackingRecHit & thit,std::vector<SimHitIdpr> &simhitid, std::vector<simhitAddr>* simhitCFPos=0) const;
+  void associateHitId(const TrackingRecHit & thit,std::vector<SimHitIdpr> &simhitid) const;
   template<typename T>
-    void associateSiStripRecHit(const T *simplerechit, std::vector<SimHitIdpr>& simtrackid, std::vector<simhitAddr>* simhitCFPos=0) const;
+    void associateSiStripRecHit(const T *simplerechit, std::vector<SimHitIdpr>& simtrackid) const;
   void associateSimpleRecHitCluster(const SiStripCluster* clust,
-				    const DetId& detid,
-				    std::vector<SimHitIdpr>& simtrackid, std::vector<simhitAddr>* simhitCFPos=0) const;
+				    const uint32_t& detID,
+				    std::vector<SimHitIdpr>& simtrackid) const;
 
-  std::vector<SimHitIdpr> associateMatchedRecHit(const SiStripMatchedRecHit2D * matchedrechit, std::vector<simhitAddr>* simhitCFPos=0) const;
-  std::vector<SimHitIdpr> associateProjectedRecHit(const ProjectedSiStripRecHit2D * projectedrechit, std::vector<simhitAddr>* simhitCFPos=0) const;
+  std::vector<SimHitIdpr> associateMatchedRecHit(const SiStripMatchedRecHit2D * matchedrechit) const;
+  std::vector<SimHitIdpr> associateProjectedRecHit(const ProjectedSiStripRecHit2D * projectedrechit) const;
   void associatePixelRecHit(const SiPixelRecHit * pixelrechit, std::vector<SimHitIdpr> & simhitid) const;
   std::vector<SimHitIdpr> associateGSRecHit(const SiTrackerGSRecHit2D * gsrechit) const;
-  std::vector<SimHitIdpr> associateMultiRecHitId(const SiTrackerMultiRecHit * multirechit, std::vector<simhitAddr>* simhitCFPos=0) const;
+  std::vector<SimHitIdpr> associateMultiRecHitId(const SiTrackerMultiRecHit * multirechit) const;
   std::vector<PSimHit>    associateMultiRecHit(const SiTrackerMultiRecHit * multirechit) const;
   std::vector<SimHitIdpr> associateGSMatchedRecHit(const SiTrackerGSMatchedRecHit2D * gsmrechit) const;
   
   typedef std::map<unsigned int, std::vector<PSimHit> > simhit_map;
   simhit_map SimHitMap;
-  typedef std::map<simHitCollectionID, std::vector<PSimHit> > simhit_collectionMap;
-  simhit_collectionMap SimHitCollMap;
  
  private:
   const edm::Event& myEvent_;


### PR DESCRIPTION
Reverts cms-sw/cmssw#4520 as it seems to introduce huge performance regression with PU deco.
