### PR TITLE
initialize members of struct to avoid problems with serialisation

### DIFF
--- a/CondFormats/L1TObjects/interface/L1GtEnergySumTemplate.h
+++ b/CondFormats/L1TObjects/interface/L1GtEnergySumTemplate.h
@@ -61,14 +61,17 @@ public:
     /// typedef for a single object template
     struct ObjectParameter
     {
-        unsigned int etThreshold;
-        bool energyOverflow;
+      unsigned int etThreshold;
+      bool energyOverflow;
 
-        // two words used only for ETM (ETM phi has 72 bins - two 64-bits words)
-        // one word used for HTM
-        unsigned long long phiRange0Word;
-        unsigned long long phiRange1Word;
-    
+      // two words used only for ETM (ETM phi has 72 bins - two 64-bits words)
+      // one word used for HTM
+      unsigned long long phiRange0Word;
+      unsigned long long phiRange1Word;
+
+      // make sure all objects (esp. the bool) are properly initialised to avoid problems with serialisation:
+      ObjectParameter() : etThreshold(0), energyOverflow(0), phiRange0Word(0), phiRange1Word(0) { /*nop*/;};
+
     COND_SERIALIZABLE;
 };
 


### PR DESCRIPTION
This PR fixes a problem in the serialisatoin unit test seen in the gcc490 builds, where a 
non-initialised boolean variable causing problems as it's value was -1 (oxff) while the 
C++ standard allows only 0 (false) and 1 (true), and the serialisation code (the EOS 
portable binary archive) expects only the standard values. 
