### PR TITLE
initialize members of struct to avoid problems with serialisation

### DIFF
--- a/CondFormats/RPCObjects/interface/RPCEMap.h
+++ b/CondFormats/RPCObjects/interface/RPCEMap.h
@@ -45,6 +45,8 @@ public:
     int theCode;
     int nFebs;
   
+    lbItem() : theMaster(0), theLinkBoardNumInLink(0), theCode(0), nFebs(0) { /* nop */ };
+
   COND_SERIALIZABLE;
 };
   struct febItem {


### PR DESCRIPTION
This PR fixes a problem in the serialisatoin unit test seen in the CLANG builds, where a 
non-initialised boolean variable causing problems as it's value was -1 (oxff) while the 
C++ standard allows only 0 (false) and 1 (true), and the serialisation code (the EOS 
portable binary archive) expects only the standard values.
