### PR TITLE
Hideous kludge to partially work around ROOT6 bug with enums

### DIFF
--- a/CommonTools/Utils/interface/StringToEnumValue.h
+++ b/CommonTools/Utils/interface/StringToEnumValue.h
@@ -23,6 +23,16 @@
 
 template <class MyType> 
 int StringToEnumValue(const std::string & enumMemberName){
+  //KLUDGE workaround for ROOT6 bug
+  if(enumMemberName[0] == 'k') {
+    if(enumMemberName == "kGood") return 0;
+    if(enumMemberName == "kProblematic") return 1;
+    if(enumMemberName == "kRecovered") return 2;
+    if(enumMemberName == "kTime") return 3;
+    if(enumMemberName == "kWeird") return 4;
+    if(enumMemberName == "kBad") return 5;
+  }
+  // END KLUDGE
   edm::TypeWithDict dataType(typeid(MyType), kIsEnum);
   return dataType.stringToEnumValue(enumMemberName);
 }


### PR DESCRIPTION
This pull request is a hideous temporary workaround for a new bug in ROOT6 that prevents handling of enumerations.  It does not work around all the effects of this bug, but it does work around the most common effect of this bug.  With this workaround, many release validation tests will actually pass, while many others will fail for other reasons, which can now be investigated.
Please merge this request promptly.
