### PR TITLE
restoring GE11 rotation bug for back compatibility

### DIFF
--- a/DQMServices/ClientConfig/plugins/DQMGenericClient.cc
+++ b/DQMServices/ClientConfig/plugins/DQMGenericClient.cc
@@ -754,6 +754,7 @@ void DQMGenericClient::limitedFit(MonitorElement * srcME, MonitorElement * meanM
     TH1 *histoY =  histo->ProjectionY(" ", i, i);
     double cont = histoY->GetEntries();
     double rms = histoY->GetRMS();
+    double rmsErr = histoY->GetRMSError();
 
     if (cont >= cont_min) {
       float minfit = histoY->GetMean() - histoY->GetRMS();
@@ -780,6 +781,7 @@ void DQMGenericClient::limitedFit(MonitorElement * srcME, MonitorElement * meanM
 //       sigmaME->setBinError(i,sqrt(err[2]*err[2]+par[2]*par[2]));
 
       rmsME->setBinContent(i, rms);
+      rmsME->setBinError(i, rmsErr);
 
       if(fitFcn) delete fitFcn;
       if(histoY) delete histoY;

--- a/DQMServices/ClientConfig/src/FitSlicesYTool.cc
+++ b/DQMServices/ClientConfig/src/FitSlicesYTool.cc
@@ -88,8 +88,10 @@ void FitSlicesYTool::getRMS(MonitorElement * me){
     for (int bin=1;bin!=h2D->GetNbinsX();bin++){
       TH1D * tmp = h2D->ProjectionY(" ", bin, bin);
       double rms = tmp->GetRMS();
+      double rmsErr = tmp->GetRMSError();
       tmp->Delete();
       me->setBinContent(bin,rms);
+      me->setBinError(bin,rmsErr);
     }
   } else {
     throw cms::Exception("FitSlicesYTool") << "Different number of bins!";

--- a/Geometry/MuonCommonData/data/v4/gem11.xml
+++ b/Geometry/MuonCommonData/data/v4/gem11.xml
@@ -1507,7 +1507,7 @@
     <Numeric name="incrCopyNo"  value="2"/>
     <Numeric name="invert"      value="1"/>
     <Numeric name="stepAngle"   value="20*deg"/>
-    <Numeric name="startAngle"  value="10*deg"/>
+    <Numeric name="startAngle"  value="0*deg"/>
     <Numeric name="rPosition"   value="[rPosL]"/>
     <Numeric name="zoffset"     value="+28.70*mm"/>
 </Algorithm>
@@ -1516,26 +1516,13 @@
     <String name="ChildName" value="GEMBox11L"/>
     <String name="RotNameSpace" value="gemf"/>
     <Numeric name="n" value="18"/>
-    <Numeric name="startCopyNo" value="52"/>
+    <Numeric name="startCopyNo" value="1"/>
     <Numeric name="incrCopyNo"  value="2"/>
     <Numeric name="invert"      value="1"/>
     <Numeric name="stepAngle"   value="20*deg"/>
-    <Numeric name="startAngle"  value="10*deg"/>
+    <Numeric name="startAngle"  value="0*deg"/>
     <Numeric name="rPosition"   value="[rPosL]"/>
     <Numeric name="zoffset"     value=" -9.70*mm"/>
-</Algorithm>
-<Algorithm name="muon:DDGEMAngular">
-    <rParent name="gem11:GEMDisk11P"/>
-    <String name="ChildName" value="GEMBox11S"/>
-    <String name="RotNameSpace" value="gemf"/>
-    <Numeric name="n" value="18"/>
-    <Numeric name="startCopyNo" value="1"/>
-    <Numeric name="incrCopyNo"  value="2"/>
-    <Numeric name="invert"      value="0"/>
-    <Numeric name="stepAngle"   value="20*deg"/>
-    <Numeric name="startAngle"  value="0*deg"/>
-    <Numeric name="rPosition"   value="[rPosS]"/>
-    <Numeric name="zoffset"     value=" +9.50*mm"/>
 </Algorithm>
 <Algorithm name="muon:DDGEMAngular">
     <rParent name="gem11:GEMDisk11P"/>
@@ -1546,9 +1533,22 @@
     <Numeric name="incrCopyNo"  value="2"/>
     <Numeric name="invert"      value="0"/>
     <Numeric name="stepAngle"   value="20*deg"/>
-    <Numeric name="startAngle"  value="0*deg"/>
+    <Numeric name="startAngle"  value="10*deg"/>
     <Numeric name="rPosition"   value="[rPosS]"/>
-    <Numeric name="zoffset"     value="-28.90*mm"/>
+    <Numeric name="zoffset"     value=" +9.50*mm"/>
+</Algorithm>
+<Algorithm name="muon:DDGEMAngular">
+    <rParent name="gem11:GEMDisk11P"/>
+    <String name="ChildName" value="GEMBox11S"/>
+    <String name="RotNameSpace" value="gemf"/>
+    <Numeric name="n" value="18"/>
+    <Numeric name="startCopyNo" value="52"/>
+    <Numeric name="incrCopyNo"  value="2"/>
+    <Numeric name="invert"      value="0"/>
+    <Numeric name="stepAngle"   value="20*deg"/>
+    <Numeric name="startAngle"  value="10*deg"/>
+    <Numeric name="rPosition"   value="[rPosS]"/>
+    <Numeric name="zoffset"     value="-27.90*mm"/>
 </Algorithm>
 <Algorithm name="muon:DDGEMAngular">
     <rParent name="gem11:GEMDisk11N"/>
@@ -1559,7 +1559,7 @@
     <Numeric name="incrCopyNo"  value="2"/>
     <Numeric name="invert"      value="1"/>
     <Numeric name="stepAngle"   value="-20*deg"/>
-    <Numeric name="startAngle"  value="170*deg"/>
+    <Numeric name="startAngle"  value="180*deg"/>
     <Numeric name="rPosition"   value="[rPosL]"/>
     <Numeric name="zoffset"     value="+28.70*mm"/>
 </Algorithm>
@@ -1568,26 +1568,13 @@
     <String name="ChildName" value="GEMBox11L"/>
     <String name="RotNameSpace" value="gemf"/>
     <Numeric name="n" value="18"/>
-    <Numeric name="startCopyNo" value="52"/>
+    <Numeric name="startCopyNo" value="1"/>
     <Numeric name="incrCopyNo"  value="2"/>
     <Numeric name="invert"      value="1"/>
     <Numeric name="stepAngle"   value="-20*deg"/>
-    <Numeric name="startAngle"  value="170*deg"/>
+    <Numeric name="startAngle"  value="180*deg"/>
     <Numeric name="rPosition"   value="[rPosL]"/>
     <Numeric name="zoffset"     value=" -9.70*mm"/>
-</Algorithm>
-<Algorithm name="muon:DDGEMAngular">
-    <rParent name="gem11:GEMDisk11N"/>
-    <String name="ChildName" value="GEMBox11S"/>
-    <String name="RotNameSpace" value="gemf"/>
-    <Numeric name="n" value="18"/>
-    <Numeric name="startCopyNo" value="1"/>
-    <Numeric name="incrCopyNo"  value="2"/>
-    <Numeric name="invert"      value="0"/>
-    <Numeric name="stepAngle"   value="-20*deg"/>
-    <Numeric name="startAngle"  value="180*deg"/>
-    <Numeric name="rPosition"   value="[rPosS]"/>
-    <Numeric name="zoffset"     value=" +9.50*mm"/>
 </Algorithm>
 <Algorithm name="muon:DDGEMAngular">
     <rParent name="gem11:GEMDisk11N"/>
@@ -1598,10 +1585,24 @@
     <Numeric name="incrCopyNo"  value="2"/>
     <Numeric name="invert"      value="0"/>
     <Numeric name="stepAngle"   value="-20*deg"/>
-    <Numeric name="startAngle"  value="180*deg"/>
+    <Numeric name="startAngle"  value="170*deg"/>
     <Numeric name="rPosition"   value="[rPosS]"/>
-    <Numeric name="zoffset"     value="-28.90*mm"/>
+    <Numeric name="zoffset"     value=" +9.50*mm"/>
+</Algorithm>
+<Algorithm name="muon:DDGEMAngular">
+    <rParent name="gem11:GEMDisk11N"/>
+    <String name="ChildName" value="GEMBox11S"/>
+    <String name="RotNameSpace" value="gemf"/>
+    <Numeric name="n" value="18"/>
+    <Numeric name="startCopyNo" value="52"/>
+    <Numeric name="incrCopyNo"  value="2"/>
+    <Numeric name="invert"      value="0"/>
+    <Numeric name="stepAngle"   value="-20*deg"/>
+    <Numeric name="startAngle"  value="170*deg"/>
+    <Numeric name="rPosition"   value="[rPosS]"/>
+    <Numeric name="zoffset"     value="-27.90*mm"/>
 </Algorithm>
 
 </DDDefinition>
+
 


### PR DESCRIPTION
Bug: GEM chambers in SLHC11,12,13,14 were rotated by 10°. A partial fix was sent and included in SLHC15 that breaks the back compatibility. This PR restores the GE11 rotation bug to mantain the back compatibility with SLHC11,12,13 that are used for the GEN-SIM sample production (phase1 or phase2). Added also a small bug fix for the dqm tools.
