### PR TITLE
revert back to CondDB v1

### DIFF
--- a/CondCore/CondDB/src/SessionImpl.cc
+++ b/CondCore/CondDB/src/SessionImpl.cc
@@ -74,9 +74,9 @@ namespace cond {
 	  ret = COND_DB;
 	}
       } else {
-	edm::LogWarning("CondDB") << "You are using conditions from the old database via: " 
-				  << connectionString 
-				  << std::endl;
+	//	edm::LogWarning("CondDB") << "You are using conditions from the old database via: " 
+	//			  << connectionString 
+	//			  << std::endl;
 	ret = ORA_DB;
       }
       oraSession.transaction().commit();

--- a/Configuration/Applications/python/Options.py
+++ b/Configuration/Applications/python/Options.py
@@ -34,10 +34,10 @@ parser.add_option("--conditions",
                   default=None,
                   dest="conditions")
 
-parser.add_option("--useCondDBv1",
+parser.add_option("--useCondDBv2",
                   help="use conditions DB V1",
-                  action="store_true",
-                  default=False,
+                  action="store_false",
+                  default=True,
                   dest="useCondDBv1")
 
 parser.add_option("--eventcontent",


### PR DESCRIPTION
in hopes of getting a working gcc490 build to allow us to kick out pre2, reverting the default to CondDB v1
