### PR TITLE
Update the list of the muon path monitored according of the new HLT template menu

### DIFF
--- a/DQMOffline/Trigger/python/HLTMuonOfflineAnalyzer_cfi.py
+++ b/DQMOffline/Trigger/python/HLTMuonOfflineAnalyzer_cfi.py
@@ -10,36 +10,14 @@ hltMuonOfflineAnalyzer = cms.EDAnalyzer("HLTMuonOfflineAnalyzer",
 
     ## HLT paths passing any one of these regular expressions will be included
     hltPathsToCheck = cms.vstring(
-      "HLT_IsoMu20_eta2p1_v",
-      "HLT_IsoMu24_eta2p1_v",
-      "HLT_IsoMu24_v",
-      "HLT_IsoMu30_eta2p1_v",
-      "HLT_IsoMu30_v",
-      "HLT_IsoMu34_eta2p1_v",
-      "HLT_IsoMu40_eta2p1_v",
-      "HLT_L1SingleMu12_v",
-      "HLT_Mu12_v",
-      "HLT_Mu15_eta2p1_v",
-      "HLT_Mu17_v",
-      "HLT_Mu24_eta2p1_v",
-      "HLT_Mu30_eta2p1_v",
+      "HLT_Mu17_NoFilters_v",
       "HLT_Mu40_v",
-      "HLT_Mu40_eta2p1_v",
-      "HLT_Mu50_eta2p1_v",
-      "HLT_Mu5_v",
-      "HLT_Mu8_v", 
-      "HLT_RelIso1p0Mu17_v",
-      "HLT_RelIso1p0Mu5_v",
-      "HLT_DoubleMu5_IsoMu5_v",
-      "HLT_Mu13_Mu8_v",
+      "HLT_IsoMu24_IterTrk02_v",
+      "HLT_IsoTkMu24_IterTrk02_v",
       "HLT_Mu17_Mu8_v",
       "HLT_Mu17_TkMu8_v",
-      "HLT_Mu22_TkMu22_v",
-      "HLT_Mu22_TkMu8_v",
-      "HLT_TripleMu5_v",
-      "HLT_DoubleMu11_Acoplanarity03_v", #Added for forward physics
-      "HLT_Mu40_eta2p1_Track50_dEdx3p6_v", #Exotica
-      "HLT_Mu40_eta2p1_Track60_dEdx3p7_v"
+      "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_v",
+      "HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_v"
     ),
 
 #HLT_Mu15_eta2p1_TriCentral_40_20_20_BTagIP3D1stTrack_v3 matches HLT_Mu15_eta2p1_v

--- a/DQMOffline/Trigger/python/HLTMuonOfflineAnalyzer_cfi.py
+++ b/DQMOffline/Trigger/python/HLTMuonOfflineAnalyzer_cfi.py
@@ -10,6 +10,33 @@ hltMuonOfflineAnalyzer = cms.EDAnalyzer("HLTMuonOfflineAnalyzer",
 
     ## HLT paths passing any one of these regular expressions will be included
     hltPathsToCheck = cms.vstring(
+      "HLT_IsoMu20_eta2p1_v",
+      "HLT_IsoMu24_eta2p1_v",
+      "HLT_IsoMu24_v",
+      "HLT_IsoMu30_eta2p1_v",
+      "HLT_IsoMu30_v",
+      "HLT_IsoMu34_eta2p1_v",
+      "HLT_IsoMu40_eta2p1_v",
+      "HLT_L1SingleMu12_v",
+      "HLT_Mu12_v",
+      "HLT_Mu15_eta2p1_v",
+      "HLT_Mu17_v",
+      "HLT_Mu24_eta2p1_v",
+      "HLT_Mu30_eta2p1_v",
+      "HLT_Mu40_eta2p1_v",
+      "HLT_Mu50_eta2p1_v",
+      "HLT_Mu5_v",
+      "HLT_Mu8_v",
+      "HLT_RelIso1p0Mu17_v",
+      "HLT_RelIso1p0Mu5_v",
+      "HLT_DoubleMu5_IsoMu5_v",
+      "HLT_Mu13_Mu8_v",
+      "HLT_Mu22_TkMu22_v",
+      "HLT_Mu22_TkMu8_v",
+      "HLT_TripleMu5_v",
+      "HLT_DoubleMu11_Acoplanarity03_v", #Added for forward physics
+      "HLT_Mu40_eta2p1_Track50_dEdx3p6_v", #Exotica
+      "HLT_Mu40_eta2p1_Track60_dEdx3p7_v"
       "HLT_Mu17_NoFilters_v",
       "HLT_Mu40_v",
       "HLT_IsoMu24_IterTrk02_v",

--- a/HLTriggerOffline/Muon/python/hltMuonValidator_cfi.py
+++ b/HLTriggerOffline/Muon/python/hltMuonValidator_cfi.py
@@ -4,8 +4,7 @@ hltMuonValidator = cms.EDAnalyzer("HLTMuonValidator",
 
     hltProcessName = cms.string("HLT"),
     hltPathsToCheck = cms.vstring(
-        "HLT_(L[12])?(Double)?(Iso)?Mu[0-9]*(Open)?(_NoVertex)?(_IterTrk02)?(_eta2p1)?(_v[0-9]*)?$",
-        "HLT_IsoTkMu24_IterTrk02?(_v[0-9]*)?$",
+        "HLT_(L[12])?(Double)?(Iso)?(Tk)?Mu[0-9]*(Open)?(_NoVertex)?(_IterTrk02)?(_eta2p1)?(_v[0-9]*)?$",
         "HLT_Mu17_NoFilters?(_v[0-9]*)?$",
         "HLT_Dimuon0_Jpsi_v10",
         "HLT_Dimuon13_Jpsi_Barrel_v5",

--- a/HLTriggerOffline/Muon/python/hltMuonValidator_cfi.py
+++ b/HLTriggerOffline/Muon/python/hltMuonValidator_cfi.py
@@ -4,7 +4,9 @@ hltMuonValidator = cms.EDAnalyzer("HLTMuonValidator",
 
     hltProcessName = cms.string("HLT"),
     hltPathsToCheck = cms.vstring(
-        "HLT_(L[12])?(Double)?(Iso)?Mu[0-9]*(Open)?(_NoVertex)?(_eta2p1)?(_v[0-9]*)?$",
+        "HLT_(L[12])?(Double)?(Iso)?Mu[0-9]*(Open)?(_NoVertex)?(_IterTrk02)?(_eta2p1)?(_v[0-9]*)?$",
+        "HLT_IsoTkMu24_IterTrk02?(_v[0-9]*)?$",
+        "HLT_Mu17_NoFilters?(_v[0-9]*)?$",
         "HLT_Dimuon0_Jpsi_v10",
         "HLT_Dimuon13_Jpsi_Barrel_v5",
         ),

--- a/HLTriggerOffline/Muon/src/HLTMuonPlotter.cc
+++ b/HLTriggerOffline/Muon/src/HLTMuonPlotter.cc
@@ -226,7 +226,7 @@ HLTMuonPlotter::analyze(const Event & iEvent, const EventSetup & iSetup)
       
       const size_t hltStep = (step >= 2) ? step - 2 : 0;
       size_t level = 0;
-      if (stepLabels_[step].find("L3") != string::npos) level = 3;
+      if ((stepLabels_[step].find("L3") != string::npos)||(stepLabels_[step].find("Tk") != string::npos)) level = 3;
       else if (stepLabels_[step].find("L2") != string::npos) level = 2;
       else if (stepLabels_[step].find("L1") != string::npos) level = 1;
       

--- a/HLTriggerOffline/Muon/src/HLTMuonValidator.cc
+++ b/HLTriggerOffline/Muon/src/HLTMuonValidator.cc
@@ -131,6 +131,10 @@ HLTMuonValidator::stepLabels(const vector<string>& modules) {
       else
         steps.push_back("L2Iso");
     }
+    else if (modules[i].find("IsoRhoFiltered") != string::npos) {
+	if (modules[i].find("L3") != string::npos)
+        steps.push_back("L3Iso");
+    }
     else if (modules[i].find("L3") != string::npos)
       steps.push_back("L3");
     else if (modules[i].find("L2") != string::npos)

--- a/HLTriggerOffline/Muon/src/HLTMuonValidator.cc
+++ b/HLTriggerOffline/Muon/src/HLTMuonValidator.cc
@@ -188,7 +188,7 @@ HLTMuonValidator::dqmBeginRun(const edm::Run & iRun,
     
     vector<string> labels = moduleLabels(path);
     vector<string> steps = stepLabels(labels);
-   
+
     if (labels.size() > 0 && steps.size() > 0) {
       HLTMuonPlotter analyzer(pset_, shortpath, labels, steps, myTokens_);
       analyzers_.push_back(analyzer);

--- a/HLTriggerOffline/Muon/src/HLTMuonValidator.cc
+++ b/HLTriggerOffline/Muon/src/HLTMuonValidator.cc
@@ -134,7 +134,11 @@ HLTMuonValidator::stepLabels(const vector<string>& modules) {
     else if (modules[i].find("IsoRhoFiltered") != string::npos) {
 	if (modules[i].find("L3") != string::npos)
         steps.push_back("L3Iso");
+	if (modules[i].find("TkFiltered") != string::npos)
+        steps.push_back("TkIso");
     }
+    else if (modules[i].find("TkFiltered") != string::npos)
+      steps.push_back("Tk");
     else if (modules[i].find("L3") != string::npos)
       steps.push_back("L3");
     else if (modules[i].find("L2") != string::npos)
@@ -144,7 +148,7 @@ HLTMuonValidator::stepLabels(const vector<string>& modules) {
     else
       return vector<string>();
   }
-  if (steps.size() < 2 || steps[1] != "L1")
+  if (steps.size() < 2 || ((steps[1] != "L1")&&(steps[1] != "Tk")))
     return vector<string>();
   return steps;
 
@@ -184,7 +188,7 @@ HLTMuonValidator::dqmBeginRun(const edm::Run & iRun,
     
     vector<string> labels = moduleLabels(path);
     vector<string> steps = stepLabels(labels);
-    
+   
     if (labels.size() > 0 && steps.size() > 0) {
       HLTMuonPlotter analyzer(pset_, shortpath, labels, steps, myTokens_);
       analyzers_.push_back(analyzer);


### PR DESCRIPTION
- The main part of this PR is the update of the list of paths to be monitored in the python configuration files
- In addition, some small changes in the c++ code have been performed to allow the single tracker muon path to be monitored

_The DQM file produced after including this PR can be found here:_

```
/afs/cern.ch/user/h/hbrun/public/DQMtests/DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO.root
```
