### PR TITLE
simplify charge computation

### DIFF
--- a/SimDataFormats/Track/interface/CoreSimTrack.h
+++ b/SimDataFormats/Track/interface/CoreSimTrack.h
@@ -11,12 +11,12 @@ class CoreSimTrack
 public:
 
     /// constructors
-    CoreSimTrack() : thePID(0) {}
+    CoreSimTrack() : tId(0), thePID(0) {}
     CoreSimTrack( int ipart, const math::XYZTLorentzVectorD& p ) :
-       thePID(ipart), theMomentum(p) {}
+      tId(0), thePID(ipart), theMomentum(p) {}
 
     CoreSimTrack( int ipart, math::XYZVectorD& ip, double ie ) :
-       thePID(ipart)
+      tId(0), thePID(ipart)
     { theMomentum.SetXYZT( ip.x(), ip.y(), ip.z(), ie ) ; }
 
     const math::XYZTLorentzVectorD& momentum() const { return theMomentum; }

--- a/SimDataFormats/Track/interface/CoreSimTrack.h
+++ b/SimDataFormats/Track/interface/CoreSimTrack.h
@@ -6,18 +6,12 @@
 
 #include "SimDataFormats/EncodedEventId/interface/EncodedEventId.h"
   
-#include <cmath>
- 
-//class HepParticleData;
- 
-/**  a generic Simulated Track
- */
 class CoreSimTrack 
 { 
 public:
 
     /// constructors
-    CoreSimTrack() {}
+    CoreSimTrack() : thePID(0) {}
     CoreSimTrack( int ipart, const math::XYZTLorentzVectorD& p ) :
        thePID(ipart), theMomentum(p) {}
 
@@ -25,16 +19,7 @@ public:
        thePID(ipart)
     { theMomentum.SetXYZT( ip.x(), ip.y(), ip.z(), ie ) ; }
 
-    /// particle info...
-    //    const HepPDT::ParticleData * particleInfo() const;
-
-    /// four momentum
-//    HepLorentzVector momentum() { return HepLorentzVector( theMomentum.px(),
-//                                                           theMomentum.py(),
-//							   theMomentum.pz(),
-//						           theMomentum.e()  ) ; }
     const math::XYZTLorentzVectorD& momentum() const { return theMomentum; }
-    // math::XYZTLorentzVectorD& momentum() { return theMomentum; }
 
     /// particle type (HEP PDT convension)
     int type() const { return thePID;}
@@ -50,7 +35,6 @@ public:
 
 private:
 
-    int chargeValue(const int&)const;
     EncodedEventId eId;
     unsigned int tId;
     int thePID;

--- a/SimDataFormats/Track/src/CoreSimTrack.cc
+++ b/SimDataFormats/Track/src/CoreSimTrack.cc
@@ -1,88 +1,60 @@
 #include "SimDataFormats/Track/interface/CoreSimTrack.h"
 
-float CoreSimTrack::charge()const { 
-  return float(CoreSimTrack::chargeValue(thePID)/3.);
-}
+const float onethird = 1./3.;
+const float twothird = 2./3.;
+const float chg[109] = {
+ -onethird,twothird,-onethird,twothird,-onethird,twothird,-onethird,twothird,0,0,
+ -1,0,-1,0,-1,0,-1,0,0,0,
+  0,0, 0,1, 0,0, 0,0,0,0,
+  1,0, 1,2, 0,0, 1,2,0,0,
+ -onethird,twothird,-onethird,twothird,-onethird,twothird,0,0,0,0,
+ -1,0,-1,0,-1,0, 0,0,0,0,
+ -onethird,twothird,-onethird,twothird,-onethird,twothird,0,0,0,0,
+ -1,0,-1,0,-1,0, 1,1,0,0,
+  0,0, 0,0, 0,0, 0,0,0,0,
+  0,0, 0,0, 0,0, 0,0,0,0,
+  0,0, 0,0, 0,0, 0,0,0};
 
-
-int CoreSimTrack::chargeValue(const int& Id)const{
-
-  
-  //...Purpose: to give three times the charge for a particle/parton.
-
-  //      ID     = particle ID
-  //      hepchg = particle charge times 3
-
-  int kqa,kq1,kq2,kq3,kqj,irt,kqx,kqn;
-  int hepchg;
-
-
-  int ichg[109]={-1,2,-1,2,-1,2,-1,2,0,0,-3,0,-3,0,-3,0,
--3,0,0,0,0,0,0,3,0,0,0,0,0,0,3,0,3,6,0,0,3,6,0,0,-1,2,-1,2,-1,2,0,0,0,0,
--3,0,-3,0,-3,0,0,0,0,0,-1,2,-1,2,-1,2,0,0,0,0,
--3,0,-3,0,-3,0,3,3,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
-
-
-  //...Initial values. Simple case of direct readout.
-  hepchg=0;
-  kqa=abs(Id);
-  kqn=kqa/1000000000%10;
-  kqx=kqa/1000000%10;
-  kq3=kqa/1000%10;
-  kq2=kqa/100%10;
-  kq1=kqa/10%10;
-  kqj=kqa%10;
-  irt=kqa%10000;
-
-  //...illegal or ion
-  //...set ion charge to zero - not enough information
-  if(kqa==0 || kqa >= 10000000) {
-
-    if(kqn==1) {hepchg=0;}
-  }
-  //... direct translation
-  else if(kqa<=100) {hepchg = ichg[kqa-1];}
-  //... deuteron or tritium
-  else if(kqa==100 || kqa==101) {hepchg = -3;}
-  //... alpha or He3
-  else if(kqa==102 || kqa==104) {hepchg = -6;}
-  //... KS and KL (and undefined)
-  else if(kqj == 0) {hepchg = 0;}
-  //C... direct translation
-  else if(kqx>0 && irt<100)
-    {
-      hepchg = ichg[irt-1];
-      if(kqa==1000017 || kqa==1000018) {hepchg = 0;}
-      if(kqa==1000034 || kqa==1000052) {hepchg = 0;}
-      if(kqa==1000053 || kqa==1000054) {hepchg = 0;}
-      if(kqa==5100061 || kqa==5100062) {hepchg = 6;}
+float CoreSimTrack::charge() const { 
+  float hepchg = 0;
+  if(thePID != 0) {
+    int kqa = std::abs(thePID);
+    if(kqa < 10000000) {
+      //... direct translation
+      if(kqa<=100) {hepchg = chg[kqa-1];}
+      //... deuteron or tritium
+      else if(kqa==100 || kqa==101) {hepchg = -1;}
+      //... alpha or He3
+      else if(kqa==102 || kqa==104) {hepchg = -2;}
+      else if(kqa%10 != 0) {
+	int kqx=kqa/1000000%10;
+	int kq3=kqa/1000%10;
+	int kq2=kqa/100%10;
+	int kq1=kqa/10%10;
+	int irt=kqa%10000;
+	if(kqx>0 && irt<100) {
+	  hepchg = chg[irt-1];
+	  if(kqa==5100061 || kqa==5100062) {hepchg = 2;}
+	} else if(kq3==0) {
+	  //   Construction from quark content for heavy meson, 
+	  //   diquark, baryon, mesons.
+	  hepchg = chg[kq2-1]-chg[kq1-1];
+	  //...Strange or beauty mesons.
+	  if((kq2==3) || (kq2==5)) {hepchg = chg[kq1-1]-chg[kq2-1];}
+	} else if(kq1 == 0) {
+	  //...Diquarks.
+	  hepchg = chg[kq3-1] + chg[kq2-1];
+	} else {
+	  //...Baryons
+	  hepchg = chg[kq3-1]+chg[kq2-1]+chg[kq1-1];
+	}
+      }
+      //... fix sign of charge
+      if(thePID<0) {hepchg = -hepchg;}
     }
-  //...Construction from quark content for heavy meson, diquark, baryon.
-  //...Mesons.
-  else if(kq3==0)
-    {
-      hepchg = ichg[kq2-1]-ichg[kq1-1];
-      //...Strange or beauty mesons.
-      if((kq2==3) || (kq2==5)) {hepchg = ichg[kq1-1]-ichg[kq2-1];}
-    }
-  else if(kq1 == 0) {
-    //...Diquarks.
-    hepchg = ichg[kq3-1] + ichg[kq2-1];
   }
-
-  else{
-    //...Baryons
-    hepchg = ichg[kq3-1]+ichg[kq2-1]+ichg[kq1-1];
-  }
-
-  //... fix sign of charge
-  if(Id<0 && hepchg!=0) {hepchg = -1*hepchg;}
-
-  // cout << hepchg<< endl;
   return hepchg;
 }
-
-
 
 std::ostream & operator <<(std::ostream & o , const CoreSimTrack& t) 
 {

--- a/SimDataFormats/Track/src/SimTrack.cc
+++ b/SimDataFormats/Track/src/SimTrack.cc
@@ -10,7 +10,7 @@ SimTrack::SimTrack(int ipart, const math::XYZTLorentzVectorD& p, int iv, int ig)
 
 SimTrack::SimTrack(int ipart, const math::XYZTLorentzVectorD& p, int iv, int ig,
 		   const math::XYZVectorD&  tkp, const math::XYZTLorentzVectorD& tkm) :
-    Core(ipart, p), ivert(iv), igenpart(ig),tkposition(tkp), tkmomentum(tkm)  {}
+    Core(ipart, p), ivert(iv), igenpart(ig),tkposition(tkp),tkmomentum(tkm)  {}
  
 SimTrack::SimTrack(const CoreSimTrack & t, int iv, int ig) :
     Core(t), ivert(iv), igenpart(ig) {}

--- a/SimDataFormats/Track/src/SimTrack.cc
+++ b/SimDataFormats/Track/src/SimTrack.cc
@@ -1,20 +1,16 @@
 #include "SimDataFormats/Track/interface/SimTrack.h"
 
-SimTrack::SimTrack() {}
+SimTrack::SimTrack() : ivert(-1), igenpart(-1) {}
  
 SimTrack::SimTrack(int ipart, const math::XYZTLorentzVectorD& p) :
-    Core(ipart, p), ivert(-1), igenpart(-1),
-    tkposition(math::XYZVectorD(0.,0.,0.)),
-    tkmomentum(math::XYZTLorentzVectorD(0.,0.,0.,0.)) {}
+    Core(ipart, p), ivert(-1), igenpart(-1) {}
  
 SimTrack::SimTrack(int ipart, const math::XYZTLorentzVectorD& p, int iv, int ig) :
-    Core(ipart, p), ivert(iv), igenpart(ig),
-    tkposition(math::XYZVectorD(0.,0.,0.)),
-    tkmomentum(math::XYZTLorentzVectorD(0.,0.,0.,0.))  {}
+    Core(ipart, p), ivert(iv), igenpart(ig) {}
 
 SimTrack::SimTrack(int ipart, const math::XYZTLorentzVectorD& p, int iv, int ig,
 		   const math::XYZVectorD&  tkp, const math::XYZTLorentzVectorD& tkm) :
-    Core(ipart, p), ivert(iv), igenpart(ig),tkposition(tkp),tkmomentum(tkm)  {}
+    Core(ipart, p), ivert(iv), igenpart(ig),tkposition(tkp), tkmomentum(tkm)  {}
  
 SimTrack::SimTrack(const CoreSimTrack & t, int iv, int ig) :
     Core(t), ivert(iv), igenpart(ig) {}


### PR DESCRIPTION
Method CoreSimTrack::charge() is visible in CPU profiler. Because of that it is re-written, data structure itself is not changed.

Constructors are cleaned up - all members of classes are initialized, unnecessary vectors are not created at construction.
