### PR TITLE
temporary fix to avoid iter7 tracks being discarded

### DIFF
--- a/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporter.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporter.cc
@@ -156,6 +156,7 @@ goodPtResolution( const reco::TrackRef& trackref) const {
   case reco::TrackBase::iter0:
   case reco::TrackBase::iter1:
   case reco::TrackBase::iter2:
+  case reco::TrackBase::iter7:
     Algo = 0;
     break;
   case reco::TrackBase::iter3:


### PR DESCRIPTION
fix to avoid losing tracks that are now recoed as iter7 (jetmet validation reported issue in charged hadron fractions).
This is temporary as PF people are working on simply removing the cuts on iteration number
