### PR TITLE
Restore ROOT6 workaround for conditions DB V1

### DIFF
--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -86,6 +86,9 @@
 #include <sched.h>
 #endif
 
+//FIXME: Needed for temporary workaround for checksum problem in conditions
+#include "TFile.h"
+
 namespace edm {
 
   // ---------------------------------------------------------------
@@ -467,6 +470,12 @@ namespace edm {
 
     // intialize miscellaneous items
     std::shared_ptr<CommonParams> common(items.initMisc(*parameterSet));
+
+    // FIXME: BEGIN temporary workaround for checksum problems in conditions
+    edm::FileInPath condfile("FWCore/Framework/data/cond_dump.root");
+    TFile* fptr = TFile::Open(condfile.fullPath().c_str());
+    fptr->Close();
+    // END temporary workaround for checksum problems in conditions
 
     // intialize the event setup provider
     esp_ = espController_->makeProvider(*parameterSet);


### PR DESCRIPTION
The ROOT6 workaround for reading V1 of the conditions database was removed when we went to V2.  Now that we reverted to V1, the workaround is again needed.
Please merge promptly.
