### PR TITLE
Fix Customisation to pick up default GT config in cmsDriver-generated workflows

### DIFF
--- a/HLTrigger/Configuration/python/CustomConfigs.py
+++ b/HLTrigger/Configuration/python/CustomConfigs.py
@@ -24,11 +24,13 @@ def Base(process):
     process.MessageLogger.categories.append('L1GtTrigReport')
     process.MessageLogger.categories.append('HLTrigReport')
 
-# override the GlobalTag, connection string and pfnPrefix
-    if 'GlobalTag' in process.__dict__:
-        process.GlobalTag.connect   = 'frontier://FrontierProd/CMS_CONDITIONS'
-        process.GlobalTag.pfnPrefix = cms.untracked.string('frontier://FrontierProd/')
-        
+#
+# No longer override - instead use GT config as provided via cmsDriver
+## override the GlobalTag, connection string and pfnPrefix
+#    if 'GlobalTag' in process.__dict__:
+#        process.GlobalTag.connect   = 'frontier://FrontierProd/CMS_CONDITIONS'
+#        process.GlobalTag.pfnPrefix = cms.untracked.string('frontier://Frontie#rProd/')
+#        
     process=ProcessName(process)
 
     return(process)


### PR DESCRIPTION
Fix Customisation to pick up default GT config in cmsDriver-generated workflows
