### PR TITLE
CPUTimer: switch to clock_gettime

### DIFF
--- a/FWCore/Utilities/interface/CPUTimer.h
+++ b/FWCore/Utilities/interface/CPUTimer.h
@@ -20,10 +20,8 @@
 
 // system include files
 #ifdef __linux__
-//NOTE: clock_gettime is not available on OS X and is slower
-// than getrusage and gettimeofday on linux but gives greater
-// timing accuracy so we may want to revisit this in the future
-//#define USE_CLOCK_GETTIME
+//clock_gettime is not available on OS X
+#define USE_CLOCK_GETTIME
 #endif
 
 #ifdef USE_CLOCK_GETTIME

--- a/FWCore/Utilities/src/CPUTimer.cc
+++ b/FWCore/Utilities/src/CPUTimer.cc
@@ -74,7 +74,7 @@ void
 CPUTimer::start() {
   if(kStopped == state_) {
 #ifdef USE_CLOCK_GETTIME
-    clock_gettime(CLOCK_REALTIME, &startRealTime_);
+    clock_gettime(CLOCK_MONOTONIC, &startRealTime_);
     clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &startCPUTime_);
 #else
     gettimeofday(&startRealTime_, 0);
@@ -83,8 +83,8 @@ CPUTimer::start() {
     if(0 != getrusage(RUSAGE_SELF, &theUsage)) {
       throw cms::Exception("CPUTimerFailed")<<errno;
     }
-    startCPUTime_.tv_sec =theUsage.ru_stime.tv_sec+theUsage.ru_utime.tv_sec;
-    startCPUTime_.tv_usec =theUsage.ru_stime.tv_usec+theUsage.ru_utime.tv_usec;
+    startCPUTime_.tv_sec  = theUsage.ru_stime.tv_sec  + theUsage.ru_utime.tv_sec;
+    startCPUTime_.tv_usec = theUsage.ru_stime.tv_usec + theUsage.ru_utime.tv_usec;
 #endif
     state_ = kRunning;
   }
@@ -125,7 +125,7 @@ CPUTimer::calculateDeltaTime() const {
   clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &tp);
   returnValue.cpu_ = tp.tv_sec - startCPUTime_.tv_sec + nanosecToSec * (tp.tv_nsec - startCPUTime_.tv_nsec);
 
-  clock_gettime(CLOCK_REALTIME, &tp);
+  clock_gettime(CLOCK_MONOTONIC, &tp);
   returnValue.real_ = tp.tv_sec - startRealTime_.tv_sec + nanosecToSec * (tp.tv_nsec - startRealTime_.tv_nsec);
 #else
   rusage theUsage;


### PR DESCRIPTION
- switch from `gettimeofday`/`getrusage` to `clock_gettime`, with the same speed but better accuracy (at least on x86_64 Linux)
- switch from `clock_gettime(CLOCK_REALTIME)` to `clock_gettime(CLOCK_MONOTONIC)`, with a very similar performance, but conceptually more sound
