### PR TITLE
Simplification of the tau quality cuts

### DIFF
--- a/RecoTauTag/RecoTau/interface/RecoTauQualityCuts.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauQualityCuts.h
@@ -54,10 +54,6 @@ class RecoTauQualityCuts
   /// If null, this will set the lead track ref null.
   void setLeadTrack(const reco::PFCandidateRef& leadCand) const;
 
-  /// Get the predicate used to filter.
-  const TrackQCutFunc& trackPredicate() const { return trackPredicate_; }  
-  const CandQCutFunc& candPredicate() const { return candPredicate_; }
-
   /// Filter a single Track
   bool filterTrack(const reco::TrackBaseRef& track) const;
   bool filterTrack(const reco::TrackRef& track) const { return filterTrack(reco::TrackBaseRef(track)); }
@@ -92,17 +88,26 @@ class RecoTauQualityCuts
   }
 
  private:
+  bool filterGammaCand(const reco::PFCandidate& cand) const;
+  bool filterNeutralHadronCand(const reco::PFCandidate& cand) const;
+  bool filterCandByType(const reco::PFCandidate& cand) const;
+
   // The current primary vertex
   mutable reco::VertexRef pv_;
   // The current lead track references
   mutable reco::TrackBaseRef leadTrack_;
-  // Set of track quality cuts
-  TrackQCutFuncCollection trackQCuts_;
-  // A mapping from particle type to a set of QCuts
-  CandQCutFuncMap candQCuts_;
-  // Our entire predicate function
-  TrackQCutFunc trackPredicate_;
-  CandQCutFunc candPredicate_;
+
+  double minTrackPt_;
+  double maxTrackChi2_;
+  int minTrackPixelHits_;
+  int minTrackHits_;
+  double maxTransverseImpactParameter_;
+  double maxDeltaZ_;
+  double maxDeltaZToLeadTrack_;
+  double minTrackVertexWeight_;
+  double minGammaEt_;
+  double minNeutralHadronEt_;
+
 };
 
 // Split an input set of quality cuts into those that need to be inverted

--- a/RecoTauTag/RecoTau/interface/RecoTauQualityCuts.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauQualityCuts.h
@@ -56,7 +56,7 @@ class RecoTauQualityCuts
 
   /// Filter a single Track
   bool filterTrack(const reco::TrackBaseRef& track) const;
-  bool filterTrack(const reco::TrackRef& track) const { return filterTrack(reco::TrackBaseRef(track)); }
+  bool filterTrack(const reco::TrackRef& track) const;
 
   /// Filter a collection of Tracks
   template<typename Coll> 
@@ -88,6 +88,7 @@ class RecoTauQualityCuts
   }
 
  private:
+  template <typename T> bool filterTrack_(const T& trackRef) const;
   bool filterGammaCand(const reco::PFCandidate& cand) const;
   bool filterNeutralHadronCand(const reco::PFCandidate& cand) const;
   bool filterCandByType(const reco::PFCandidate& cand) const;
@@ -107,7 +108,8 @@ class RecoTauQualityCuts
   double minTrackVertexWeight_;
   double minGammaEt_;
   double minNeutralHadronEt_;
-
+  bool checkHitPattern_;
+  bool checkPV_;
 };
 
 // Split an input set of quality cuts into those that need to be inverted

--- a/RecoTauTag/RecoTau/src/RecoTauQualityCuts.cc
+++ b/RecoTauTag/RecoTau/src/RecoTauQualityCuts.cc
@@ -232,70 +232,40 @@ RecoTauQualityCuts::RecoTauQualityCuts(const edm::ParameterSet &qcuts)
     passedOptionSet.insert(option);
   }
 
+  unsigned int nCuts = 0;
+  auto getDouble = [&qcuts, &passedOptionSet, &nCuts](const std::string& name) {
+    if(qcuts.exists(name)) {
+      ++nCuts;
+      passedOptionSet.erase(name);
+      return qcuts.getParameter<double>(name);
+    }
+    return -1.0;
+  };
+  auto getUint = [&qcuts, &passedOptionSet, &nCuts](const std::string& name) -> unsigned int {
+    if(qcuts.exists(name)) {
+      ++nCuts;
+      passedOptionSet.erase(name);
+      return qcuts.getParameter<unsigned int>(name);
+    }
+    return 0;
+  };
+
   // Build all the QCuts for tracks
-  if ( qcuts.exists("minTrackPt") ) {
-    trackQCuts_.push_back(boost::bind(qcuts::ptMin, _1, qcuts.getParameter<double>("minTrackPt")));
-    passedOptionSet.erase("minTrackPt");
-  }
-
-  if ( qcuts.exists("maxTrackChi2") ) {
-    trackQCuts_.push_back(boost::bind(qcuts::trkChi2, _1, qcuts.getParameter<double>("maxTrackChi2")));
-    passedOptionSet.erase("maxTrackChi2");
-  }
-
-  if ( qcuts.exists("minTrackPixelHits") ) {
-    uint32_t minTrackPixelHits = qcuts.getParameter<uint32_t>("minTrackPixelHits");
-    if ( minTrackPixelHits >= 1 ) {
-      trackQCuts_.push_back(boost::bind(qcuts::trkPixelHits, _1, minTrackPixelHits));
-    }
-    passedOptionSet.erase("minTrackPixelHits");
-  }
-
-  if ( qcuts.exists("minTrackHits") ) {
-    uint32_t minTrackHits = qcuts.getParameter<uint32_t>("minTrackHits");
-    if ( minTrackHits >= 1 ) {
-      trackQCuts_.push_back(boost::bind(qcuts::trkTrackerHits, _1, minTrackHits));
-    }
-    passedOptionSet.erase("minTrackHits");
-  }
-
-  // The impact parameter functions are bound to our member PV, since they
-  // need it to compute the discriminant value.
-  if ( qcuts.exists("maxTransverseImpactParameter") ) {
-    trackQCuts_.push_back(boost::bind(qcuts::trkTransverseImpactParameter, _1, &pv_, qcuts.getParameter<double>("maxTransverseImpactParameter")));
-    passedOptionSet.erase("maxTransverseImpactParameter");
-  }
-
-  if ( qcuts.exists("maxDeltaZ") ) {
-    trackQCuts_.push_back(boost::bind(qcuts::trkLongitudinalImpactParameter, _1, &pv_, qcuts.getParameter<double>("maxDeltaZ")));
-    passedOptionSet.erase("maxDeltaZ");
-  }
-
-  if ( qcuts.exists("maxDeltaZToLeadTrack") ) {
-    trackQCuts_.push_back(boost::bind(qcuts::trkLongitudinalImpactParameterWrtTrack, _1, &leadTrack_, &pv_, qcuts.getParameter<double>("maxDeltaZToLeadTrack")));
-    passedOptionSet.erase("maxDeltaZToLeadTrack");
-  }
-
+  minTrackPt_ = getDouble("minTrackPt");
+  maxTrackChi2_ = getDouble("maxTrackChi2");
+  minTrackPixelHits_ = getUint("minTrackPixelHits");
+  minTrackHits_ = getUint("minTrackHits");
+  maxTransverseImpactParameter_ = getDouble("maxTransverseImpactParameter");
+  maxDeltaZ_ = getDouble("maxDeltaZ");
+  maxDeltaZToLeadTrack_ = getDouble("maxDeltaZToLeadTrack");
   // Require tracks to contribute a minimum weight to the associated vertex.
-  if ( qcuts.exists("minTrackVertexWeight") ) {
-    double minTrackVertexWeight = qcuts.getParameter<double>("minTrackVertexWeight");
-    if ( minTrackVertexWeight > -1. ) {
-      trackQCuts_.push_back(boost::bind(qcuts::minTrackVertexWeight, _1, &pv_, minTrackVertexWeight));
-    }
-    passedOptionSet.erase("minTrackVertexWeight");
-  }
-
+  minTrackVertexWeight_ = getDouble("minTrackVertexWeight");
+  
   // Build the QCuts for gammas
-  if ( qcuts.exists("minGammaEt") ) {
-    gammaCuts.push_back(boost::bind(qcuts::etMin_cand, _1, qcuts.getParameter<double>("minGammaEt")));
-    passedOptionSet.erase("minGammaEt");
-  }
+  minGammaEt_ = getDouble("minGammaEt");
 
   // Build QCuts for netural hadrons
-  if ( qcuts.exists("minNeutralHadronEt") ) {
-    neutralHadronCuts.push_back(boost::bind(qcuts::etMin_cand, _1, qcuts.getParameter<double>("minNeutralHadronEt")));
-    passedOptionSet.erase("minNeutralHadronEt");
-  }
+  minNeutralHadronEt_ = getDouble("minNeutralHadronEt");
 
   // Check if there are any remaining unparsed QCuts
   if ( passedOptionSet.size() ) {
@@ -328,25 +298,10 @@ RecoTauQualityCuts::RecoTauQualityCuts(const edm::ParameterSet &qcuts)
   }
 
   // Make sure there are at least some quality cuts
-  size_t nCuts = chargedHadronCuts.size() + gammaCuts.size() + neutralHadronCuts.size() + trackQCuts_.size();
   if ( !nCuts ) {
     throw cms::Exception("BadQualityCutConfig")
       << " No options were passed to the quality cut class!" << std::endl;
   }
-
-  // Build final level predicate that works on Tracks
-  trackPredicate_ = boost::bind(qcuts::AND, _1, boost::cref(trackQCuts_));
-
-  // Map our QCut collections to the particle Ids they are associated to.
-  candQCuts_[PFCandidate::h]     = chargedHadronCuts;
-  candQCuts_[PFCandidate::gamma] = gammaCuts;
-  candQCuts_[PFCandidate::h0]    = neutralHadronCuts;
-  // We use the same qcuts for muons/electrons and charged hadrons.
-  candQCuts_[PFCandidate::e]     = chargedHadronCuts;
-  candQCuts_[PFCandidate::mu]    = chargedHadronCuts;
-
-  // Build a final level predicate that works on any PFCand
-  candPredicate_ = boost::bind(qcuts::mapAndCutByType, _1, boost::cref(candQCuts_));
 }
 
 std::pair<edm::ParameterSet, edm::ParameterSet> factorizePUQCuts(const edm::ParameterSet& input) 
@@ -369,14 +324,86 @@ std::pair<edm::ParameterSet, edm::ParameterSet> factorizePUQCuts(const edm::Para
 
 bool RecoTauQualityCuts::filterTrack(const reco::TrackBaseRef& track) const 
 {
-  return trackPredicate_(track);
+  if(minTrackPt_ >= 0 && !(track->pt() > minTrackPt_)) return false;
+  if(maxTrackChi2_ >= 0 && !(track->normalizedChi2() <= maxTrackChi2_)) return false;
+  if(minTrackPixelHits_ > 0 && !(track->hitPattern().numberOfValidPixelHits() >= minTrackPixelHits_)) return false;
+  if(minTrackHits_ > 0 && !(track->hitPattern().numberOfValidHits() >= minTrackHits_)) return false;
+  if(maxTransverseImpactParameter_ >= 0) {
+    if ( pv_.isNull() ) {
+      edm::LogError("QCutsNoPrimaryVertex") << "Primary vertex Ref in " <<
+        "RecoTauQualityCuts is invalid. - trkTransverseImpactParameter";
+      return false;
+    }
+    if(!(std::fabs(track->dxy(pv_->position())) <= maxTransverseImpactParameter_))
+      return false;
+  }
+  if(maxDeltaZ_ >= 0) {
+    if ( pv_.isNull() ) {
+      edm::LogError("QCutsNoPrimaryVertex") << "Primary vertex Ref in " <<
+        "RecoTauQualityCuts is invalid. - trkLongitudinalImpactParameter";
+      return false;
+    }
+    if(!(std::fabs(track->dz(pv_->position())) <= maxDeltaZ_))
+      return false;
+  }
+  if(maxDeltaZToLeadTrack_ >= 0) {
+    if ( leadTrack_.isNull()) {
+      edm::LogError("QCutsNoValidLeadTrack") << "Lead track Ref in " <<
+        "RecoTauQualityCuts is invalid. - trkLongitudinalImpactParameterWrtTrack";
+      return false;
+    }
+    // shouldn't we check for pv_ too?
+
+    if(!(std::fabs(track->dz(pv_->position()) - leadTrack_->dz(pv_->position())) <= maxDeltaZToLeadTrack_))
+      return false;
+  }
+  if(minTrackVertexWeight_ > -1.0) {
+    if ( pv_.isNull() ) {
+      edm::LogError("QCutsNoPrimaryVertex") << "Primary vertex Ref in " <<
+        "RecoTauQualityCuts is invalid. - minTrackVertexWeight";
+      return false;
+    }
+    if(!(pv_->trackWeight(track) >= minTrackVertexWeight_))
+      return false;
+  }
+
+  return true;
+}
+
+bool RecoTauQualityCuts::filterGammaCand(const reco::PFCandidate& cand) const {
+  if(minGammaEt_ >= 0 && !(cand.et() > minGammaEt_)) return false;
+  return true;
+}
+
+bool RecoTauQualityCuts::filterNeutralHadronCand(const reco::PFCandidate& cand) const {
+  if(minNeutralHadronEt_ >= 0 && !(cand.et() > minNeutralHadronEt_)) return false;
+  return true;
+}
+
+bool RecoTauQualityCuts::filterCandByType(const reco::PFCandidate& cand) const {
+  switch(cand.particleId()) {
+  case PFCandidate::gamma:
+    return filterGammaCand(cand);
+  case PFCandidate::h0:
+    return filterNeutralHadronCand(cand);
+  // We use the same qcuts for muons/electrons and charged hadrons.
+  case PFCandidate::h:
+  case PFCandidate::e:
+  case PFCandidate::mu:
+    // no cuts ATM (track cuts applied in filterCand)
+    return true;
+  // Return false if we dont' know how to deal with this particle type
+  default:
+    return false;
+  };
+  return false;
 }
 
 bool RecoTauQualityCuts::filterCand(const reco::PFCandidate& cand) const 
 {
   auto track = getTrackRef(cand);
-  if ( track.isNonnull() ) return (trackPredicate_(track) & candPredicate_(cand));
-  return candPredicate_(cand);
+  if ( track.isNonnull() ) return (filterTrack(track) & filterCandByType(cand));
+  return filterCandByType(cand);
 }
 
 void RecoTauQualityCuts::setLeadTrack(const reco::TrackRef& leadTrack) const 

--- a/RecoTauTag/RecoTau/src/RecoTauQualityCuts.cc
+++ b/RecoTauTag/RecoTau/src/RecoTauQualityCuts.cc
@@ -268,10 +268,10 @@ RecoTauQualityCuts::RecoTauQualityCuts(const edm::ParameterSet &qcuts)
   minTrackVertexWeight_ = getDouble("minTrackVertexWeight");
   
   // Use bit-wise & to avoid conditional code
-  checkHitPattern_ = (minTrackPixelHits_ > 0) & (minTrackHits_ > 0);
-  checkPV_ = (maxTransverseImpactParameter_ >= 0) &
-             (maxDeltaZ_ >= 0) &
-             (maxDeltaZToLeadTrack_ >= 0) &
+  checkHitPattern_ = (minTrackPixelHits_ > 0) || (minTrackHits_ > 0);
+  checkPV_ = (maxTransverseImpactParameter_ >= 0) ||
+             (maxDeltaZ_ >= 0) ||
+             (maxDeltaZToLeadTrack_ >= 0) ||
              (minTrackVertexWeight_ >= 0);
 
   // Build the QCuts for gammas


### PR DESCRIPTION
Simplification of the quality cut class, that gets rid of the "boost" dependence and allows further extension of the interface to accept also packedCandides from miniAOD (not implemented yet, but work-in-progress). No change in physics output expected. The PFTau sequence can be somehow faster.

This change is already implemented in 71x and 72x, so in principle it is a backport. 

The 71x request is #2843. There is no 72x request, as this one was included already in 71x pre-releases. It is not a full backport of that PR, but only the clean-up of quality cuts that is essential for the miniAOD tools development.
