### PR TITLE
Enable using our on loader only for selected executables.

### DIFF
--- a/FWCore/Framework/bin/BuildFile.xml
+++ b/FWCore/Framework/bin/BuildFile.xml
@@ -1,3 +1,6 @@
+<architecture name="slc[6-9]_amd64">
+  <flags LDFLAGS="-Wl,-dynamic-linker,$(GLIBC_BASE)/lib64/ld.so"/>
+</architecture>
 <bin   name="cmsRunGlibC" file="cmsRun.cpp">
   <use   name="roothistmatrix"/>
   <use   name="tbb"/>

--- a/FWCore/PluginManager/bin/BuildFile.xml
+++ b/FWCore/PluginManager/bin/BuildFile.xml
@@ -2,9 +2,15 @@
   <use   name="boost"/>
   <use   name="boost_program_options"/>
   <use   name="FWCore/PluginManager"/>
+<architecture name="slc[6-9]_amd64">
+  <flags LDFLAGS="-Wl,-dynamic-linker,$(GLIBC_BASE)/lib64/ld.so"/>
+</architecture>
 </bin>
 <bin   name="edmPluginRefresh" file="refresh.cc">
   <use   name="boost"/>
   <use   name="boost_program_options"/>
   <use   name="FWCore/PluginManager"/>
+<architecture name="slc[6-9]_amd64">
+  <flags LDFLAGS="-Wl,-dynamic-linker,$(GLIBC_BASE)/lib64/ld.so"/>
+</architecture>
 </bin>


### PR DESCRIPTION
This is necessary to keep cmsShow standalone tarballs into account. It however has the advantage that the relocation process is not executed unless requested which should simplify eventual back-ports.
