### PR TITLE
fix array index out of bounds in mip fraction

### DIFF
--- a/FastSimulation/Calorimetry/src/HCALResponse.cc
+++ b/FastSimulation/Calorimetry/src/HCALResponse.cc
@@ -224,8 +224,8 @@ double HCALResponse::getMIPfraction(double energy, double eta){
   break;
   }
   }
-                                                                                                                                                                         if(ie == -1) return mipfraction [det][maxHDe[det]][deta]; // more than maximal - the last value is used instead of extrapolating
-                                                                                                                                                                         double y1, y2;
+  if(ie == -1) return mipfraction [det][maxHDe[det]-1][deta]; // more than maximal - the last value is used instead of extrapolating
+  double y1, y2;
   double x1 = eGridHD[det][ie];
   double x2 = eGridHD[det][ie+1];
   y1=mipfraction[det][ie][deta];


### PR DESCRIPTION
This fixes a small bug with an out-of-bounds array index when determining the MIP fraction for FastSim hadronic showers. This caused the code to grab values out of neighboring memory. The bug only affects hadrons with energy > 3 TeV, so the effect on simulation results should be small.

Example of buggy behavior (from a few 5 TeV pion events):
Begin processing the 1st record. Run 1, Event 1, LumiSection 1 at 14-Jul-2014 21:06:57.152 CEST
 CalorimetryManager onHcal 6.92421e-310
 CalorimetryManager onHcal 6.92421e-310
Begin processing the 2nd record. Run 1, Event 2, LumiSection 1 at 14-Jul-2014 21:07:02.608 CEST
 CalorimetryManager onHcal 0.99857
 CalorimetryManager onHcal 0.99618

Example of fixed behavior:
Begin processing the 1st record. Run 1, Event 1, LumiSection 1 at 14-Jul-2014 21:31:38.048 CEST
 CalorimetryManager onHcal 0.09604
 CalorimetryManager onHcal 0.09294
Begin processing the 2nd record. Run 1, Event 2, LumiSection 1 at 14-Jul-2014 21:31:42.721 CEST
 CalorimetryManager onHcal 0.01353
 CalorimetryManager onHcal 0.03486
