### PR TITLE
do not read biglib/arch/.edmplugincache files for duplicate pluins

### DIFF
--- a/Utilities/ReleaseScripts/scripts/duplicateReflexLibrarySearch.py
+++ b/Utilities/ReleaseScripts/scripts/duplicateReflexLibrarySearch.py
@@ -237,7 +237,9 @@ def searchDuplicatePlugins ():
     edmpluginFile = ''
     libenv = 'LD_LIBRARY_PATH'
     if os.environ.get('SCRAM_ARCH').startswith('osx'): libenv = 'DYLD_FALLBACK_LIBRARY_PATH'
+    biglib = '/biglib/'+os.environ.get('SCRAM_ARCH')
     for libdir in os.environ.get(libenv).split(':'):
+      if libdir.endswith(biglib): continue
       if os.path.exists(libdir+'/.edmplugincache'): edmpluginFile = edmpluginFile + ' ' + libdir+'/.edmplugincache'
     if edmpluginFile == '': edmpluginFile = os.path.join(os.environ.get('CMSSW_BASE'),'lib',os.environ.get('SCRAM_ARCH'),'.edmplugincache')
     cmd = "cat %s | awk '{print $2\" \"$1}' | sort | uniq | awk '{print $1}' | sort | uniq -c | grep '2 ' | awk '{print $2}'" % edmpluginFile


### PR DESCRIPTION
This should fix the following duplicates
https://cmssdt.cern.ch/SDT/cgi-bin/showDupDict.py//slc6_amd64_gcc481/www/thu/7.2-thu-06/CMSSW_7_2_X_2014-07-17-0600/testLogs/dupDict-edmPD.log
