### PR TITLE
fixing infinite loop in Validation/RecoVertex

### DIFF
--- a/Validation/RecoVertex/src/PrimaryVertexAnalyzer4PUSlimmed.cc
+++ b/Validation/RecoVertex/src/PrimaryVertexAnalyzer4PUSlimmed.cc
@@ -792,17 +792,20 @@ void PrimaryVertexAnalyzer4PUSlimmed::analyze(const edm::Event& iEvent,
           // reconstructed in the primvary vertex collection
           // at-hand. Mark it with fake index -1 if it was not
           // recontructed at all.
+
           auto iv = (*recVtxs.product()).begin();
-          int pv_position_in_reco_collection = 0;
-          while (++iv != (*recVtxs.product()).end()) {
-            pv_position_in_reco_collection++;
-            if (std::find(v.rec_vertices.begin(), v.rec_vertices.end(),
-                          &(*iv)) != v.rec_vertices.end()) {
-              mes_[label]["TruePVLocationIndex"]
+	  if ( iv != (*recVtxs.product()).end() ) {
+	    int pv_position_in_reco_collection = 0;
+	    while (++iv != (*recVtxs.product()).end()) {
+	      pv_position_in_reco_collection++;
+	      if (std::find(v.rec_vertices.begin(), v.rec_vertices.end(),
+			    &(*iv)) != v.rec_vertices.end()) {
+		mes_[label]["TruePVLocationIndex"]
                   ->Fill(pv_position_in_reco_collection);
-              break;
-            }
-          }
+		break;
+	      }
+	    }
+	  }
           // If we reached the end, it means that the Simulated PV has not
           // been associated to any recontructed vertex: mark it as
           // missing in the reconstructed vertex collection using the fake


### PR DESCRIPTION
fixing infinite loop in case of no vertices - but not sure that loop is actually doing what it should be
