### PR TITLE
Fix build error in ROOT6 IB

### DIFF
--- a/DataFormats/TrackReco/src/classes_def.xml
+++ b/DataFormats/TrackReco/src/classes_def.xml
@@ -22,16 +22,7 @@
       targetClass="reco::HitPattern"
       target="hitPattern"
       version="[-11]"
-      include="utility;
-        DataFormats/SiPixelDetId/interface/PXBDetId.h;
-        DataFormats/SiPixelDetId/interface/PXFDetId.h;
-        DataFormats/SiStripDetId/interface/TIBDetId.h;
-        DataFormats/SiStripDetId/interface/TIDDetId.h;
-        DataFormats/SiStripDetId/interface/TOBDetId.h;
-        DataFormats/SiStripDetId/interface/TECDetId.h;
-        DataFormats/MuonDetId/interface/DTLayerId.h;
-        DataFormats/MuonDetId/interface/CSCDetId.h;
-        DataFormats/MuonDetId/interface/RPCDetId.h"
+      include="utility,DataFormats/SiPixelDetId/interface/PXBDetId.h,DataFormats/SiPixelDetId/interface/PXFDetId.h,DataFormats/SiStripDetId/interface/TIBDetId.h,DataFormats/SiStripDetId/interface/TIDDetId.h,DataFormats/SiStripDetId/interface/TOBDetId.h,DataFormats/SiStripDetId/interface/TECDetId.h,DataFormats/MuonDetId/interface/DTLayerId.h,DataFormats/MuonDetId/interface/CSCDetId.h,DataFormats/MuonDetId/interface/RPCDetId.h"
       >
       <![CDATA[
             using namespace reco;


### PR DESCRIPTION
This request fixes the compilation error in DataFormats/TrackReco in the ROOT6 IB.
Apparently, the separator character for multiple headers in an IO rule changed from a semicolon in ROOT5 to a comma in ROOT6.Also, in ROOT 6, the names must be on one line, or the dictionary generated does not compile.
Please merge promptly.
