### PR TITLE
avoid a copy of SiPixelTemplateDBObject

### DIFF
--- a/CondFormats/SiPixelObjects/interface/SiPixelTemplateDBObject.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelTemplateDBObject.h
@@ -15,6 +15,55 @@
 
 class SiPixelTemplateDBObject {
 public:
+       struct Reader {
+           explicit Reader(SiPixelTemplateDBObject const & idb) : index_(0), isInvalid_(false), db(idb){}
+
+        //- Fills integer from dbobject
+        Reader & operator>>( int& i)
+                {
+                        isInvalid_ = false;
+                        if(index_<=db.maxIndex()) {
+                                i = (int) db.sVector()[index_];
+                                index_++;
+                        }
+                        else
+                           setInvalid();
+                        return *this;
+                }
+        //- Fills float from dbobject
+        Reader & operator>>( float& f)
+                {
+                        isInvalid_ = false;
+                        if(index_<=db.maxIndex()) {
+                                f = db.sVector()[index_];
+                                index_++;
+                        }
+                        else
+                           setInvalid();
+                        return *this;
+                }
+
+
+
+        //- Functions to monitor integrity of dbobject
+        void setInvalid() {isInvalid_ = true;}
+        bool fail() {return isInvalid_;}
+        int index() const {return index_;}
+        int numOfTempl() const {return db.numOfTempl();}
+        float version() const {return db.version();}
+        std::vector<float> const & sVector() const {return db.sVector();}
+
+
+        //- Able to set the index for template header
+        void incrementIndex(int i) {index_+=i;}
+
+        int  index_;
+        bool isInvalid_;
+        SiPixelTemplateDBObject const & db;
+       };
+
+       Reader reader() const { return Reader(*this);}
+
 	SiPixelTemplateDBObject():index_(0),maxIndex_(0),numOfTempl_(1),version_(-99.9),isInvalid_(false),sVector_(0) {
 		sVector_.reserve(1000000);
 	}
@@ -64,7 +113,7 @@ public:
 	int maxIndex() const {return maxIndex_;}
 	int numOfTempl() const {return numOfTempl_;}
 	float version() const {return version_;}
-	std::vector<float> sVector() const {return sVector_;}
+	std::vector<float> const & sVector() const {return sVector_;}
 
 	//- Able to set the index for template header 
 	void incrementIndex(int i) {index_+=i;}

--- a/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplate.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplate.cc
@@ -550,8 +550,7 @@ bool SiPixelTemplate::pushfile(const SiPixelTemplateDBObject& dbobject, std::vec
 	const int code_version={17};
 	
 	// We must create a new object because dbobject must be a const and our stream must not be
-	SiPixelTemplateDBObject db = dbobject;
-	//	SiPixelTemplateDBObject & db = const_cast<SiPixelTemplateDBObject&>(dbobject);
+	auto db(dbobject.reader());
 	
 	// Create a local template storage entry
 	SiPixelTemplateStore theCurrentTemp;


### PR DESCRIPTION
speed up Reco initialization by 14 seconds or so (on a fast machine!)
next should be CaloGeometry (10 seconds) 

SiPixelTemplateDBObject should be cleanedup. We are saying this since ages.
This workaround is better than nothing.
