### PR TITLE
add Shashlik to CaloTowers

### DIFF
--- a/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreationAlgo.cc
+++ b/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreationAlgo.cc
@@ -551,7 +551,7 @@ void CaloTowersCreationAlgo::assignHit(const CaloRecHit * recHit) {
 	else  passEmThreshold = (energy >= threshold);
 
       }
-      else if (detId.subdetId() == EcalEndcap) {
+      else if (detId.subdetId() == EcalEndcap || detId.subdetId() == EcalShashlik) {
 	if (theUseEtEETresholdFlag) energy /= cosh( (theGeometry->getGeometry(detId)->getPosition()).eta() ) ;
 	if (theUseSymEETresholdFlag) passEmThreshold = (fabs(energy) >= threshold);
 	else  passEmThreshold = (energy >= threshold);
@@ -974,7 +974,7 @@ void CaloTowersCreationAlgo::convert(const CaloTowerDetId& id, const MetaTower& 
       if (ac_it->subdetId() == EcalBarrel && theEbHandle.isValid()) {
 	thisEcalSevLvl = theEcalSevLvlAlgo->severityLevel( *ac_it, *theEbHandle);//, *theEcalChStatus);
       }
-      else if (ac_it->subdetId() == EcalEndcap && theEeHandle.isValid()) {
+      else if ((ac_it->subdetId() == EcalEndcap || ac_it->subdetId() == EcalShashlik) && theEeHandle.isValid()) {
 	thisEcalSevLvl = theEcalSevLvlAlgo->severityLevel( *ac_it, *theEeHandle);//, *theEcalChStatus);
       }
  
@@ -1046,7 +1046,7 @@ void CaloTowersCreationAlgo::getThresholdAndWeight(const DetId & detId, double &
         weight = my.Eval(theEBEScale);
       }
     }
-    else if(subdet == EcalEndcap) {
+    else if(subdet == EcalEndcap || subdet == EcalShashlik) {
       threshold = theEEthreshold;
       weight = theEEweight;
       if (weight <= 0.) {

--- a/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreator.cc
+++ b/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreator.cc
@@ -237,7 +237,7 @@ void CaloTowersCreator::produce(edm::Event& e, const edm::EventSetup& c) {
     if ( (ec_tmp->begin()->detid()).subdetId() == EcalBarrel ) {
       ebHandle = ec_tmp;
     }
-    else if ((ec_tmp->begin()->detid()).subdetId() == EcalEndcap ) {
+    else if ((ec_tmp->begin()->detid()).subdetId() == EcalEndcap || (ec_tmp->begin()->detid()).subdetId() == EcalShashlik) {
       eeHandle = ec_tmp;
     }
 

--- a/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
@@ -161,7 +161,13 @@ def cust_2023SHCal(process):
         process.towerMaker.ecalInputs = cms.VInputTag(cms.InputTag("ecalRecHit","EcalRecHitsEB"), cms.InputTag("ecalRecHit","EcalRecHitsEK"))
         process.towerMakerPF.ecalInputs = cms.VInputTag(cms.InputTag("ecalRecHit","EcalRecHitsEB"), cms.InputTag("ecalRecHit","EcalRecHitsEK"))
         process.towerMakerWithHO.ecalInputs = cms.VInputTag(cms.InputTag("ecalRecHit","EcalRecHitsEB"), cms.InputTag("ecalRecHit","EcalRecHitsEK"))
-       
+        process.towerMaker.EESumThreshold = cms.double(0.1)
+        process.towerMakerPF.EESumThreshold = cms.double(0.1)
+        process.towerMakerWithHO.EESumThreshold = cms.double(0.1)
+        process.towerMaker.EEThreshold = cms.double(0.035)
+        process.towerMakerPF.EEThreshold = cms.double(0.035)
+        process.towerMakerWithHO.EEThreshold = cms.double(0.035)
+
     return process
 
 def cust_2023HGCal(process):

--- a/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
@@ -158,6 +158,9 @@ def cust_2023SHCal(process):
         process.pfClusteringEK += process.particleFlowClusterECAL
         process.particleFlowClusterECAL.inputECAL = cms.InputTag('particleFlowClusterEBEKMerger')
         process.particleFlowCluster += process.pfClusteringEK
+        process.towerMaker.ecalInputs = cms.VInputTag(cms.InputTag("ecalRecHit","EcalRecHitsEB"), cms.InputTag("ecalRecHit","EcalRecHitsEK"))
+        process.towerMakerPF.ecalInputs = cms.VInputTag(cms.InputTag("ecalRecHit","EcalRecHitsEB"), cms.InputTag("ecalRecHit","EcalRecHitsEK"))
+        process.towerMakerWithHO.ecalInputs = cms.VInputTag(cms.InputTag("ecalRecHit","EcalRecHitsEB"), cms.InputTag("ecalRecHit","EcalRecHitsEK"))
        
     return process
 


### PR DESCRIPTION
This commit adds the Shashlik ECAL to the CaloTowers algorithm. It treats the subdet ID EcalShashlik as equivalent to EcalEndcap, passes the EcalRecHitsEK input tag to the algorithm, and specifies some preliminary thresholds equal to 1/2 of the current EB thresholds (based on a suggestion from Shashlik experts).

Validation of the changes, using runTheMatrix 13815 (QCD_Pt_600_800_8TeV with Extended2023SHCalNoTaper), plotting average CaloTower EM energy vs. eta:
old: 
![caloem_old](https://cloud.githubusercontent.com/assets/4672808/3627559/f7982be8-0e8a-11e4-90f9-4dd6f472ffa4.png)

new:
![caloem_new_th](https://cloud.githubusercontent.com/assets/4672808/3627563/fcd17cf4-0e8a-11e4-8922-1595b32234ca.png)
