### PR TITLE
Moving to the previos digi model used for phase 1 MC

### DIFF
--- a/SimMuon/GEMDigitizer/interface/GEMSimpleModel.h
+++ b/SimMuon/GEMDigitizer/interface/GEMSimpleModel.h
@@ -1,14 +1,14 @@
 #ifndef GEMDigitizer_GEMSimpleModel_h
 #define GEMDigitizer_GEMSimpleModel_h
 
-/**
-* \class GEMSimpleModel
-*
-* Class for the GEM strip response simulation based on a very simple model
-*
-* \author Sven Dildick
-* \modified by Roumyana Hadjiiska
-*/
+/** 
+ * \class GEMSimpleModel
+ *
+ * Class for the GEM strip response simulation based on a very simple model
+ *
+ * \author Sven Dildick
+ * \modified by Roumyana Hadjiiska
+ */
 
 #include "SimMuon/GEMDigitizer/interface/GEMDigiModel.h"
 
@@ -21,7 +21,6 @@ namespace CLHEP
   class RandPoissonQ;
   class RandGaussQ;
   class RandGamma;
-  class RandBinomial;
 }
 
 class GEMSimpleModel: public GEMDigiModel
@@ -42,7 +41,7 @@ public:
 
   void simulateNoise(const GEMEtaPartition*);
 
-  std::vector<std::pair<int,int> >
+  std::vector<std::pair<int,int> > 
     simulateClustering(const GEMEtaPartition*, const PSimHit*, const int);
 
 private:
@@ -52,7 +51,7 @@ private:
   double timeResolution_;
   double timeJitter_;
   double averageNoiseRate_;
-// double averageClusterSize_;
+//  double averageClusterSize_;
   std::vector<double> clsParametrization_;
   double signalPropagationSpeed_;
   bool cosmics_;
@@ -65,8 +64,13 @@ private:
   bool fixedRollRadius_;
   double minPabsNoiseCLS_;
   bool simulateIntrinsicNoise_;
+  double scaleLumi_;
   bool simulateElectronBkg_;
-  bool simulateLowNeutralRate_;
+  double constNeuGE11_;
+  double slopeNeuGE11_;
+  std::vector<double> GE21NeuBkgParams_;
+  std::vector<double> GE11ElecBkgParams_;
+  std::vector<double> GE21ElecBkgParams_;
 
   CLHEP::RandFlat* flat1_;
   CLHEP::RandFlat* flat2_;
@@ -77,42 +81,9 @@ private:
   CLHEP::RandGaussQ* gauss2_;
   CLHEP::RandGamma* gamma1_;
 
-//parameters from the fit:
-//params for pol3 model of electron bkg for GE1/1:
-  double GE11ElecBkgParam0;
-  double GE11ElecBkgParam1;
-  double GE11ElecBkgParam2;
-  double GE11ElecBkgParam3;
-//params for expo of electron bkg for GE2/1:
-  double constElecGE21;
-  double slopeElecGE21;
-
-//Neutral Bkg
-//Low Rate model L=10^{34}cm^{-2}s^{-1}
-//const and slope for expo model of neutral bkg for GE1/1:
-  double constNeuGE11;
-  double slopeNeuGE11;
-//params for pol5 model of neutral bkg for GE2/1:
-  double GE21NeuBkgParam0;
-  double GE21NeuBkgParam1;
-  double GE21NeuBkgParam2;
-  double GE21NeuBkgParam3;
-  double GE21NeuBkgParam4;
-  double GE21NeuBkgParam5;
-
-//High Rate model L=5x10^{34}cm^{-2}s^{-1}
-//params for expo model of neutral bkg for GE1/1:
-  double constNeuGE11_highRate;
-  double slopeNeuGE11_highRate;
-//params for pol5 model of neutral bkg for GE2/1:
-  double GE21ModNeuBkgParam0;
-  double GE21ModNeuBkgParam1;
-  double GE21ModNeuBkgParam2;
-  double GE21ModNeuBkgParam3;
-  double GE21ModNeuBkgParam4;
-  double GE21ModNeuBkgParam5;
-
 };
 #endif
+
+
 
 

--- a/SimMuon/GEMDigitizer/python/muonGEMDigis_cfi.py
+++ b/SimMuon/GEMDigitizer/python/muonGEMDigis_cfi.py
@@ -7,7 +7,11 @@ simMuonGEMDigis = cms.EDProducer("GEMDigiProducer",
     timeResolution = cms.double(5),
     timeJitter = cms.double(1.0),
     averageShapingTime = cms.double(50.0),
+#    averageClusterSize = cms.double(1.5),#1.5
+#cumulative cls distribution at 771 mkA; experimental results from test pion beam
     clsParametrization = cms.vdouble(0.455091, 0.865613, 0.945891, 0.973286, 0.986234, 0.991686, 0.996865, 0.998501, 1.),
+#cumulative cls distribution at 752 mkA; experimental results from test pion beam
+#    clsParametrization = cms.vdouble(0.663634, 0.928571, 0.967544, 0.982665, 0.990288, 0.994222, 0.997541, 0.999016, 1.),
     averageEfficiency = cms.double(0.98),
     averageNoiseRate = cms.double(0.001), #intrinsic noise
     bxwidth = cms.int32(25),
@@ -15,14 +19,24 @@ simMuonGEMDigis = cms.EDProducer("GEMDigiProducer",
     maxBunch = cms.int32(3),
     inputCollection = cms.string('g4SimHitsMuonGEMHits'),
     digiModelString = cms.string('Simple'),
-    digitizeOnlyMuons = cms.bool(False),
+    digitizeOnlyMuons = cms.bool(True),
     doBkgNoise = cms.bool(True), #False == No background simulation
     doNoiseCLS = cms.bool(True),
     fixedRollRadius = cms.bool(True), #Uses fixed radius in the center of the roll
     minPabsNoiseCLS = cms.double(0.),
     simulateIntrinsicNoise = cms.bool(False),
-
-    simulateElectronBkg = cms.bool(True),	#False=simulate only neutral Bkg
-    simulateLowNeutralRate = cms.bool(False)	#True=neutral_Bkg at L=1x10^{34}, False at L=5x10^{34}cm^{-2}s^{-1}
+    scaleLumi = cms.double(1.),
+#Parameters for background model
+    simulateElectronBkg = cms.bool(False),	#False=simulate only neutral Bkg
+#const and slope for the expo model of neutral bkg for GE1/1:
+    constNeuGE11 = cms.double(807.1),
+    slopeNeuGE11 = cms.double(-0.01443),
+#params for the simple pol5 model of neutral bkg for GE2/1:
+    GE21NeuBkgParams = cms.vdouble(2954.04, -58.7558, 0.473481, -0.00188292, 3.67041e-06, -2.80261e-09),
+#params for the simple pol3 model of electron bkg for GE1/1:
+    GE11ElecBkgParams = cms.vdouble(2135.93, -33.1251, 0.177738, -0.000319334),
+#params for the simple pol6 model of electron bkg for GE2/1:
+    GE21ElecBkgParams = cms.vdouble(-43642.2, 1335.98, -16.476, 0.105281, -0.000368758, 6.72937e-07, -5.00872e-10)
 
 )
+

--- a/SimMuon/GEMDigitizer/python/muonME0DigisPreReco_cfi.py
+++ b/SimMuon/GEMDigitizer/python/muonME0DigisPreReco_cfi.py
@@ -10,10 +10,10 @@ simMuonME0Digis = cms.EDProducer("ME0DigiPreRecoProducer",
     useCorrelation  = cms.bool(False),
     useEtaProjectiveGEO  = cms.bool(False),
     averageEfficiency = cms.double(0.98),
-    doBkgNoise = cms.bool(True), #False == No background simulation
+    doBkgNoise = cms.bool(False), #False == No background simulation
     digitizeOnlyMuons = cms.bool(False),
     simulateIntrinsicNoise = cms.bool(False),
-    simulateElectronBkg = cms.bool(True), #True - will simulate electron background
+    simulateElectronBkg = cms.bool(False), #True - will simulate electron background
 
     averageNoiseRate = cms.double(0.001), #intrinsic noise
     bxwidth = cms.int32(25),

--- a/SimMuon/GEMDigitizer/src/GEMSimpleModel.cc
+++ b/SimMuon/GEMDigitizer/src/GEMSimpleModel.cc
@@ -17,7 +17,8 @@
 #include <utility>
 #include <map>
 
-#include "TMath.h" /* exp */
+#include "TMath.h"       /* exp */
+
 
 namespace
 {
@@ -43,47 +44,15 @@ GEMDigiModel(config)
 , doBkgNoise_(config.getParameter<bool> ("doBkgNoise"))
 , doNoiseCLS_(config.getParameter<bool> ("doNoiseCLS"))
 , fixedRollRadius_(config.getParameter<bool> ("fixedRollRadius"))
+, scaleLumi_(config.getParameter<double> ("scaleLumi"))
 , simulateElectronBkg_(config.getParameter<bool> ("simulateElectronBkg"))
-, simulateLowNeutralRate_(config.getParameter<bool> ("simulateLowNeutralRate"))
+, constNeuGE11_(config.getParameter<double> ("constNeuGE11"))
+, slopeNeuGE11_(config.getParameter<double> ("slopeNeuGE11"))
+, GE21NeuBkgParams_(config.getParameter<std::vector<double>>("GE21NeuBkgParams"))
+, GE11ElecBkgParams_(config.getParameter<std::vector<double>>("GE11ElecBkgParams"))
+, GE21ElecBkgParams_(config.getParameter<std::vector<double>>("GE21ElecBkgParams"))
 
 {
-//initialise parameters from the fit:
-//params for pol3 model of electron bkg for GE1/1:
-  GE11ElecBkgParam0 = 735.304;
-  GE11ElecBkgParam1 = 0.228203;
-  GE11ElecBkgParam2 = -0.042479;
-  GE11ElecBkgParam3 = 0.000125032;
-
-//params for expo model of electron bkg for GE2/1:
-  constElecGE21 = 9.74156e+02;
-  slopeElecGE21 = -1.18398e-02;
-
-//Neutral Bkg
-//Low Rate model L=10^{34}cm^{-2}s^{-1}
-//const and slope for the expo model of neutral bkg for GE1/1:
-    constNeuGE11 = 807.;
-    slopeNeuGE11 = -0.01443;
-//params for the simple pol5 model of neutral bkg for GE2/1:
-  GE21NeuBkgParam0 = 2954.04;
-  GE21NeuBkgParam1 = -58.7558;
-  GE21NeuBkgParam2 = 0.473481;
-  GE21NeuBkgParam3 = -0.00188292;
-  GE21NeuBkgParam4 = 3.67041e-06;
-  GE21NeuBkgParam5 = -2.80261e-09;
-
-
-//High Rate model L=5x10^{34}cm^{-2}s^{-1}
-//params for expo model of neutral bkg for GE1/1:
-    constNeuGE11_highRate = 1.02603e+04;
-    slopeNeuGE11_highRate = -1.62806e-02;
-
-//params for pol5 model of neutral bkg for GE2/1:
-  GE21ModNeuBkgParam0 = 21583.2;
-  GE21ModNeuBkgParam1 = -476.59;
-  GE21ModNeuBkgParam2 = 4.24037;
-  GE21ModNeuBkgParam3 = -0.0185558;
-  GE21ModNeuBkgParam4 = 3.97809e-05;
-  GE21ModNeuBkgParam5 = -3.34575e-08;
 
 }
 
@@ -140,7 +109,7 @@ void GEMSimpleModel::simulateSignal(const GEMEtaPartition* roll, const edm::PSim
       continue;
     const int bx(getSimHitBx(&(*hit)));
     const std::vector<std::pair<int, int> > cluster(simulateClustering(roll, &(*hit), bx));
-    for (auto & digi : cluster)
+    for  (auto & digi : cluster)
     {
       detectorHitMap_.insert(DetectorHitMap::value_type(digi,&*(hit)));
       strips_.insert(digi);
@@ -171,7 +140,7 @@ int GEMSimpleModel::getSimHitBx(const PSimHit* simhit)
   }
 
   // signal propagation speed in vacuum in [m/s]
-  const double cspeed = 299792458; //
+  const double cspeed = 299792458; 
   const int nstrips = roll->nstrips();
   float middleStrip = nstrips/2.;
   LocalPoint middleOfRoll = roll->centreOfStrip(middleStrip);
@@ -204,8 +173,8 @@ int GEMSimpleModel::getSimHitBx(const PSimHit* simhit)
   const bool debug(false);
   if (debug)
   {
-    std::cout << "checktime " << "bx = " << bx << "\tdeltaT = " << timeDifference << "\tsimT = " << simhitTime
-        << "\trefT = " << referenceTime << "\ttof = " << tof << "\tavePropT = " << averagePropagationTime
+    std::cout << "checktime " << "bx = " << bx << "\tdeltaT = " << timeDifference << "\tsimT =  " << simhitTime
+        << "\trefT =  " << referenceTime << "\ttof = " << tof << "\tavePropT =  " << averagePropagationTime
         << "\taveRefPropT = " << halfStripLength / signalPropagationSpeedTrue << std::endl;
   }
   return bx;
@@ -251,17 +220,15 @@ void GEMSimpleModel::simulateNoise(const GEMEtaPartition* roll)
   if(gemId.station() == 1)
   {
 //simulate neutral background for GE1/1
-    if(simulateLowNeutralRate_)
-      averageNeutralNoiseRatePerRoll = constNeuGE11 * TMath::Exp(slopeNeuGE11*rollRadius);
-    else
-      averageNeutralNoiseRatePerRoll = constNeuGE11_highRate * TMath::Exp(slopeNeuGE11_highRate*rollRadius);
+    averageNeutralNoiseRatePerRoll = constNeuGE11_ * TMath::Exp(slopeNeuGE11_*rollRadius);
 
-//simulate electron background for GE1/1
+//simulate eletron background for GE1/1
+//the product is faster than Power or pow:
     if(simulateElectronBkg_)
-    averageNoiseElectronRatePerRoll = GE11ElecBkgParam0
-                                    + GE11ElecBkgParam1*rollRadius
-                                    + GE11ElecBkgParam2*rollRadius*rollRadius
-                                    + GE11ElecBkgParam3*rollRadius*rollRadius*rollRadius;
+    averageNoiseElectronRatePerRoll = GE11ElecBkgParams_[0]
+                                    + GE11ElecBkgParams_[1]*rollRadius
+                                    + GE11ElecBkgParams_[2]*rollRadius*rollRadius
+                                    + GE11ElecBkgParams_[3]*rollRadius*rollRadius*rollRadius;
 
     averageNoiseRatePerRoll = averageNeutralNoiseRatePerRoll + averageNoiseElectronRatePerRoll;
   }
@@ -269,29 +236,26 @@ void GEMSimpleModel::simulateNoise(const GEMEtaPartition* roll)
   if(gemId.station() == 2 || gemId.station() == 3)
   {
 //simulate neutral background for GE2/1
-    if(simulateLowNeutralRate_)
-      averageNeutralNoiseRatePerRoll = GE21NeuBkgParam0
-                                     + GE21NeuBkgParam1*rollRadius
-                                     + GE21NeuBkgParam2*rollRadius*rollRadius
-                                     + GE21NeuBkgParam3*rollRadius*rollRadius*rollRadius
-                                     + GE21NeuBkgParam4*rollRadius*rollRadius*rollRadius*rollRadius
-                                     + GE21NeuBkgParam5*rollRadius*rollRadius*rollRadius*rollRadius*rollRadius;
-
-   else
-     averageNeutralNoiseRatePerRoll = GE21ModNeuBkgParam0
-                                    + GE21ModNeuBkgParam1*rollRadius
-                                    + GE21ModNeuBkgParam2*rollRadius*rollRadius
-                                    + GE21ModNeuBkgParam3*rollRadius*rollRadius*rollRadius
-                                    + GE21ModNeuBkgParam4*rollRadius*rollRadius*rollRadius*rollRadius
-                                    + GE21ModNeuBkgParam5*rollRadius*rollRadius*rollRadius*rollRadius*rollRadius;
+    averageNeutralNoiseRatePerRoll = GE21NeuBkgParams_[0]
+                                   + GE21NeuBkgParams_[1]*rollRadius
+                                   + GE21NeuBkgParams_[2]*rollRadius*rollRadius
+                                   + GE21NeuBkgParams_[3]*rollRadius*rollRadius*rollRadius
+                                   + GE21NeuBkgParams_[4]*rollRadius*rollRadius*rollRadius*rollRadius
+                                   + GE21NeuBkgParams_[5]*rollRadius*rollRadius*rollRadius*rollRadius*rollRadius;
 
 
-//simulate electron background for GE2/1
+//simulate eletron background for GE2/1
     if(simulateElectronBkg_)
-      averageNoiseElectronRatePerRoll = constElecGE21* TMath::Exp(slopeElecGE21*rollRadius);
-      averageNoiseRatePerRoll = averageNeutralNoiseRatePerRoll + averageNoiseElectronRatePerRoll;
-  }
+    averageNoiseElectronRatePerRoll = GE21ElecBkgParams_[0]
+                                    + GE21ElecBkgParams_[1]*rollRadius
+                                    + GE21ElecBkgParams_[2]*rollRadius*rollRadius
+                                    + GE21ElecBkgParams_[3]*rollRadius*rollRadius*rollRadius
+                                    + GE21ElecBkgParams_[4]*rollRadius*rollRadius*rollRadius*rollRadius
+                                    + GE21ElecBkgParams_[5]*rollRadius*rollRadius*rollRadius*rollRadius*rollRadius
+                                    + GE21ElecBkgParams_[6]*rollRadius*rollRadius*rollRadius*rollRadius*rollRadius*rollRadius;
 
+    averageNoiseRatePerRoll = averageNeutralNoiseRatePerRoll + averageNoiseElectronRatePerRoll;
+  }
 
   //simulate intrinsic noise
   if(simulateIntrinsicNoise_)
@@ -300,6 +264,7 @@ void GEMSimpleModel::simulateNoise(const GEMEtaPartition* roll)
     for(int j = 0; j < nstrips; ++j)
     {
       const int n_intrHits = poisson_->fire(aveIntrinsicNoisPerStrip);
+    
       for (int k = 0; k < n_intrHits; k++ )
       {
         const int time_hit(static_cast<int> (flat2_->fire(nBxing)) + minBunch_);
@@ -310,7 +275,7 @@ void GEMSimpleModel::simulateNoise(const GEMEtaPartition* roll)
   }//end simulate intrinsic noise
 
   //simulate bkg contribution
-  const double averageNoise(averageNoiseRatePerRoll * nBxing * bxwidth_ * trArea * 1.0e-9);
+  const double averageNoise(averageNoiseRatePerRoll * nBxing * bxwidth_ * trArea * 1.0e-9 * scaleLumi_);
   const int n_hits(poisson_->fire(averageNoise));
 
   for (int i = 0; i < n_hits; ++i)
@@ -346,7 +311,7 @@ void GEMSimpleModel::simulateNoise(const GEMEtaPartition* roll)
       else if(randForCls <= clsParametrization_[8] && randForCls > clsParametrization_[7])
         clusterSize = 9;
 
-//odd cls
+      //odd cls
       if (clusterSize % 2 != 0)
       {
         int clsR = (clusterSize - 1) / 2;
@@ -358,7 +323,7 @@ void GEMSimpleModel::simulateNoise(const GEMEtaPartition* roll)
             cluster_.push_back(std::pair<int, int>(centralStrip + i, time_hit));
         }
       }
-//even cls
+      //even cls
       if (clusterSize % 2 == 0)
       {
         int clsR = (clusterSize - 2) / 2;
@@ -405,13 +370,13 @@ void GEMSimpleModel::simulateNoise(const GEMEtaPartition* roll)
 std::vector<std::pair<int, int> > GEMSimpleModel::simulateClustering(const GEMEtaPartition* roll,
     const PSimHit* simHit, const int bx)
 {
-  // const Topology& topology(roll->specs()->topology());
+  //  const Topology& topology(roll->specs()->topology());
   const StripTopology& topology = roll->specificTopology();
-  // const LocalPoint& entry(simHit->entryPoint());
+  //  const LocalPoint& entry(simHit->entryPoint());
   const LocalPoint& hit_position(simHit->localPosition());
   const int nstrips(roll->nstrips());
-  int centralStrip = 0;
 
+  int centralStrip = 0;
   if (!(topology.channel(hit_position) + 1 > nstrips))
     centralStrip = topology.channel(hit_position) + 1;
   else
@@ -494,4 +459,7 @@ std::vector<std::pair<int, int> > GEMSimpleModel::simulateClustering(const GEMEt
     }
   }
   return cluster_;
+
 }
+
+


### PR DESCRIPTION
The GEM digitization model used for phase 1 MC has been restored.  The ME0 background model has been switched off. 
