### PR TITLE
update test input files for MET packages

### DIFF
--- a/JetMETCorrections/Type1MET/python/testInputFiles_cff.py
+++ b/JetMETCorrections/Type1MET/python/testInputFiles_cff.py
@@ -4,15 +4,15 @@ import FWCore.ParameterSet.Config as cms
 from PhysicsTools.PatAlgos.tools.cmsswVersionTools import pickRelValInputFiles
 corrMETtestInputFiles = pickRelValInputFiles(
     useDAS = True,
-    cmsswVersion = 'CMSSW_7_1_0_pre8',
+    cmsswVersion = 'CMSSW_7_2_0_pre1',
     dataTier = 'GEN-SIM-RECO',
     relVal = 'RelValTTbar_13',
-    globalTag = 'PU50ns_PRE_LS171_V10',
+    globalTag = 'PU50ns_POSTLS172_V2',
     maxVersions = 2
     )
 
 # corrMETtestInputFiles = [
-#     '/store/relval/CMSSW_7_1_0_pre8/RelValTTbar_13/GEN-SIM-RECO/PU50ns_PRE_LS171_V10-v1/00000/342381E4-6BE7-E311-AEF0-0025905A60AA.root',
+#     '/store/relval/CMSSW_7_2_0_pre1/RelValTTbar_13/GEN-SIM-RECO/PU50ns_POSTLS172_V2-v1/00000/0AA51FF6-8EFD-E311-B591-0025905A6068.root',
 #     ]
 
 ##____________________________________________________________________________||

--- a/RecoMET/METProducers/python/testInputFiles_cff.py
+++ b/RecoMET/METProducers/python/testInputFiles_cff.py
@@ -4,14 +4,14 @@ import FWCore.ParameterSet.Config as cms
 from PhysicsTools.PatAlgos.tools.cmsswVersionTools import pickRelValInputFiles
 recoMETtestInputFiles = pickRelValInputFiles(
     useDAS = True,
-    cmsswVersion = 'CMSSW_7_1_0_pre4_AK4',
+    cmsswVersion = 'CMSSW_7_2_0_pre1',
     dataTier = 'GEN-SIM-RECO',
     relVal = 'RelValTTbar_13',
-    globalTag = 'PU50ns_POSTLS171_V2',
+    globalTag = 'PU50ns_POSTLS172_V2',
     maxVersions = 2
     )
 
 # recoMETtestInputFiles = [
-#     '/store/relval/CMSSW_7_1_0_pre4_AK4/RelValTTbar_13/GEN-SIM-RECO/PU50ns_POSTLS171_V2-v2/00000/1487CD0E-A4B3-E311-96D2-0025904C678A.root',
+#     '/store/relval/CMSSW_7_2_0_pre1/RelValTTbar_13/GEN-SIM-RECO/PU50ns_POSTLS172_V2-v1/00000/0AA51FF6-8EFD-E311-B591-0025905A6068.root',
 #     ]
 ##____________________________________________________________________________||

--- a/RecoMET/METProducers/test/recoMET_tcMet_cfg.py
+++ b/RecoMET/METProducers/test/recoMET_tcMet_cfg.py
@@ -58,7 +58,7 @@ process.tcMetVedu.vetoDuplicates = cms.bool(True)
 ##____________________________________________________________________________||
 process.p = cms.Path(
     process.particleFlowCluster *
-    process.caloMet *
+    process.muonTCMETValueMapProducer *
     process.tcMet *
     process.tcMetCST *
     process.tcMetRft2 *


### PR DESCRIPTION
This PR updates the test input files in RecoMET/METProducers and JetMETCorrections/Type1MET.

The previous updates were made at https://github.com/cms-sw/cmssw/pull/3965 for RecoMET/METProducers  and at https://github.com/cms-sw/cmssw/pull/4283 for JetMETCorrections/Type1MET.
