### PR TITLE
Massive HGC Clustering speed/memory improvements

### DIFF
--- a/DataFormats/ParticleFlowCandidate/src/PFCandidate.cc
+++ b/DataFormats/ParticleFlowCandidate/src/PFCandidate.cc
@@ -121,7 +121,7 @@ PFCandidate::PFCandidate( Charge charge,
   setPdgId( translateTypeToPdgId( partId ) );
 }
 
-PFCandidate::~PFCandidate() {}
+PFCandidate::~PFCandidate() { elementsInBlocks_.clear(); }
 
 PFCandidate * PFCandidate::clone() const {
   return new PFCandidate( * this );

--- a/DataFormats/ParticleFlowCandidate/src/PFCandidate.cc
+++ b/DataFormats/ParticleFlowCandidate/src/PFCandidate.cc
@@ -12,6 +12,8 @@
 
 #include "FWCore/Utilities/interface/Exception.h"
 
+#include "DataFormats/ParticleFlowReco/interface/PFBlock.h"
+
 #include <ostream>
 #include <iomanip>
 
@@ -128,6 +130,7 @@ PFCandidate * PFCandidate::clone() const {
 
 void PFCandidate::addElementInBlock( const reco::PFBlockRef& blockref,
                                      unsigned elementIndex ) {
+
   //elementsInBlocks_.push_back( make_pair(blockref.key(), elementIndex) );
   if (blocksStorage_.size()==0)
     blocksStorage_ =Blocks(blockref.id());

--- a/DataFormats/ParticleFlowCandidate/src/classes_def.xml
+++ b/DataFormats/ParticleFlowCandidate/src/classes_def.xml
@@ -9,6 +9,9 @@
      <field name="getter_" transient="true"/>
      <field name="refsCollectionCache_" transient="true"/>
    </class>
+  <ioread sourceClass = "reco::PFCandidate" version="[1-]" targetClass="reco::PFCandidate" source="" target="elementsInBlocks_">
+    <![CDATA[elementsInBlocks_.resize(0);]]>
+  </ioread>
   <ioread sourceClass = "reco::PFCandidate" version="[1-]" targetClass="reco::PFCandidate" source="" target="getter_">
     <![CDATA[edm::EDProductGetter::assignEDProductGetter(getter_); ]]>
   </ioread>

--- a/Fireworks/Calo/plugins/FWCaloClusterProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWCaloClusterProxyBuilder.cc
@@ -4,16 +4,18 @@
 #include "Fireworks/Core/interface/FWGeometry.h"
 #include "Fireworks/Core/interface/BuilderUtils.h"
 #include "DataFormats/CaloRecHit/interface/CaloCluster.h"
+#include "TRandom3.h"
 
 class FWCaloClusterProxyBuilder : public FWSimpleProxyBuilderTemplate<reco::CaloCluster>
 {
 public:
-   FWCaloClusterProxyBuilder( void ) {}  
+  FWCaloClusterProxyBuilder( void ) {myRandom.SetSeed(0);}  
    virtual ~FWCaloClusterProxyBuilder( void ) {}
 
    REGISTER_PROXYBUILDER_METHODS();
 
 private:
+  TRandom3 myRandom;
    FWCaloClusterProxyBuilder( const FWCaloClusterProxyBuilder& ); 			// stop default
    const FWCaloClusterProxyBuilder& operator=( const FWCaloClusterProxyBuilder& ); 	// stop default
 
@@ -29,6 +31,7 @@ FWCaloClusterProxyBuilder::build( const reco::CaloCluster& iData, unsigned int i
    boxset->Reset(TEveBoxSet::kBT_FreeBox, true, 64);
    //boxset->UseSingleColor();
    boxset->SetPickable(1);
+   const unsigned color = (unsigned)myRandom.Uniform(50);
 
    for( std::vector<std::pair<DetId, float> >::iterator it = clusterDetIds.begin(), itEnd = clusterDetIds.end();
         it != itEnd; ++it )
@@ -40,7 +43,7 @@ FWCaloClusterProxyBuilder::build( const reco::CaloCluster& iData, unsigned int i
       std::vector<float> pnts(24);    
       fireworks::energyTower3DCorners(corners, (*it).second, pnts);
       boxset->AddBox( &pnts[0]);
-      boxset->DigitColor( (4*clusterDetIds.size()+3*iIndex)%50 + 50, 50);     
+      boxset->DigitColor( color + 50, 50);     
    }
 
    boxset->RefitPlex();

--- a/Fireworks/ParticleFlow/plugins/FWPFCandidate3DProxyBuilder.cc
+++ b/Fireworks/ParticleFlow/plugins/FWPFCandidate3DProxyBuilder.cc
@@ -67,12 +67,13 @@ void
 FWPFCandidate3DProxyBuilder::build( const reco::PFCandidate& iData, unsigned int iIndex, TEveElement& oItemHolder, const FWViewContext* ) 
 {
   TEveCompound* comp = createCompound();  
+  comp->SetMainColor((unsigned)2.0*myRandom.Uniform(50));
   const reco::PFCandidate::ElementsInBlocks& elems = iData.elementsInBlocks();
   
-  
-
   for( unsigned i = 0 ; i < elems.size(); ++i ) {
+    std::cout << i << ' ' << elems[i].first.isAvailable() << ' ' << elems[i].second << ' ' << elems[i].first->elements().size() << std::endl;
     const reco::PFBlockElement& elem = elems[i].first->elements()[elems[i].second];
+    std::cout << &elem << std::endl;
     switch( elem.type() ) {
     case reco::PFBlockElement::TRACK:
       {
@@ -133,7 +134,7 @@ FWPFCandidate3DProxyBuilder::build( const reco::PFCandidate& iData, unsigned int
       break;
     }
   }
-  comp->SetMainColor((unsigned)myRandom.Uniform(50) + 50);
+  
 
   setupAddElement( comp, &oItemHolder );
 }

--- a/Fireworks/ParticleFlow/plugins/FWPFCandidate3DProxyBuilder.cc
+++ b/Fireworks/ParticleFlow/plugins/FWPFCandidate3DProxyBuilder.cc
@@ -74,6 +74,7 @@ FWPFCandidate3DProxyBuilder::build( const reco::PFCandidate& iData, unsigned int
     std::cout << i << ' ' << elems[i].first.isAvailable() << ' ' << elems[i].second << ' ' << elems[i].first->elements().size() << std::endl;
     const reco::PFBlockElement& elem = elems[i].first->elements()[elems[i].second];
     std::cout << &elem << std::endl;
+    assert( elems[i].second < elems[i].first->elements().size() );
     switch( elem.type() ) {
     case reco::PFBlockElement::TRACK:
       {

--- a/Fireworks/ParticleFlow/plugins/FWPFCandidate3DProxyBuilder.cc
+++ b/Fireworks/ParticleFlow/plugins/FWPFCandidate3DProxyBuilder.cc
@@ -66,15 +66,12 @@ FWPFCandidate3DProxyBuilder::~FWPFCandidate3DProxyBuilder(){}
 void 
 FWPFCandidate3DProxyBuilder::build( const reco::PFCandidate& iData, unsigned int iIndex, TEveElement& oItemHolder, const FWViewContext* ) 
 {
-  TEveCompound* comp = createCompound();  
-  comp->SetMainColor((unsigned)2.0*myRandom.Uniform(50));
+  TEveCompound* comp = createCompound(false,true);  
+  
   const reco::PFCandidate::ElementsInBlocks& elems = iData.elementsInBlocks();
   
   for( unsigned i = 0 ; i < elems.size(); ++i ) {
-    std::cout << i << ' ' << elems[i].first.isAvailable() << ' ' << elems[i].second << ' ' << elems[i].first->elements().size() << std::endl;
     const reco::PFBlockElement& elem = elems[i].first->elements()[elems[i].second];
-    std::cout << &elem << std::endl;
-    assert( elems[i].second < elems[i].first->elements().size() );
     switch( elem.type() ) {
     case reco::PFBlockElement::TRACK:
       {
@@ -86,7 +83,7 @@ FWPFCandidate3DProxyBuilder::build( const reco::PFCandidate& iData, unsigned int
 	TEveTrack* trk = new TEveTrack(&t, context().getTrackPropagator() );      
 	trk->MakeTrack();      
 	fireworks::setTrackTypePF( iData, trk );    
-	setupAddElement( trk, comp );
+	setupAddElement( trk, comp, false );
       }
       break;
     case reco::PFBlockElement::ECAL:
@@ -104,7 +101,7 @@ FWPFCandidate3DProxyBuilder::build( const reco::PFCandidate& iData, unsigned int
 	  TEveTrack* trk = new TEveTrack(&t, context().getTrackPropagator() );      
 	  trk->MakeTrack();      
 	  fireworks::setTrackTypePF( iData, trk );    
-	  setupAddElement( trk, comp );
+	  setupAddElement( trk, comp, false );
 	  continue;
 	}
 	const std::vector<std::pair<DetId, float> >& clusterDetIds = 
@@ -128,7 +125,7 @@ FWPFCandidate3DProxyBuilder::build( const reco::PFCandidate& iData, unsigned int
 	  }
 	
 	boxset->RefitPlex();
-	setupAddElement(boxset,comp);
+	setupAddElement(boxset,comp,false);
       }
       break;
     default:
@@ -136,8 +133,9 @@ FWPFCandidate3DProxyBuilder::build( const reco::PFCandidate& iData, unsigned int
     }
   }
   
+  comp->SetMainColor((unsigned)2.0*myRandom.Uniform(50));
 
-  setupAddElement( comp, &oItemHolder );
+  setupAddElement( comp, &oItemHolder, false );
 }
 
 //______________________________________________________________________________

--- a/Fireworks/ParticleFlow/plugins/FWPFCandidate3DProxyBuilder.cc
+++ b/Fireworks/ParticleFlow/plugins/FWPFCandidate3DProxyBuilder.cc
@@ -14,7 +14,11 @@
 // System include files
 #include "TEveTrack.h"
 #include "TEveTrackPropagator.h"
+#include "TRandom3.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
+#include "DataFormats/ParticleFlowReco/interface/PFBlockElement.h"
+#include "DataFormats/ParticleFlowReco/interface/PFCluster.h"
+#include "DataFormats/ParticleFlowReco/interface/PFBlock.h"
 
 // User include files
 #include "Fireworks/Core/interface/FWSimpleProxyBuilderTemplate.h"
@@ -22,6 +26,10 @@
 #include "Fireworks/Core/src/CmsShowMain.h"
 #include "Fireworks/Core/interface/FWEventItem.h"
 #include "Fireworks/ParticleFlow/interface/setTrackTypePF.h"
+#include "Fireworks/Core/interface/FWGeometry.h"
+#include "Fireworks/Core/interface/BuilderUtils.h"
+#include "TEveCompound.h"
+#include "TEveBoxSet.h"
 
 //-----------------------------------------------------------------------------
 // FWPFCandidate3DProxyBuilder
@@ -32,12 +40,14 @@ class FWPFCandidate3DProxyBuilder : public FWSimpleProxyBuilderTemplate<reco::PF
       
    public:
    // ---------------- Constructor(s)/Destructor ----------------------
-      FWPFCandidate3DProxyBuilder() {}
+  FWPFCandidate3DProxyBuilder() { myRandom.SetSeed(0); }
       virtual ~FWPFCandidate3DProxyBuilder();
    
       REGISTER_PROXYBUILDER_METHODS();
 
    private:
+  TRandom3 myRandom;
+
       FWPFCandidate3DProxyBuilder( const FWPFCandidate3DProxyBuilder& );                    // Stop default
       const FWPFCandidate3DProxyBuilder& operator=( const FWPFCandidate3DProxyBuilder& );   // Stop default
 
@@ -56,17 +66,76 @@ FWPFCandidate3DProxyBuilder::~FWPFCandidate3DProxyBuilder(){}
 void 
 FWPFCandidate3DProxyBuilder::build( const reco::PFCandidate& iData, unsigned int iIndex, TEveElement& oItemHolder, const FWViewContext* ) 
 {
-  TEveRecTrack t;
-  t.fBeta = 1.;
-  t.fP = TEveVector( iData.px(), iData.py(), iData.pz() );
-  t.fV = TEveVector( iData.vertex().x(), iData.vertex().y(), iData.vertex().z() );
-  t.fSign = iData.charge();
-  TEveTrack* trk = new TEveTrack(&t, context().getTrackPropagator() );
+  TEveCompound* comp = createCompound();  
+  const reco::PFCandidate::ElementsInBlocks& elems = iData.elementsInBlocks();
+  
+  
 
-  trk->MakeTrack();
+  for( unsigned i = 0 ; i < elems.size(); ++i ) {
+    const reco::PFBlockElement& elem = elems[i].first->elements()[elems[i].second];
+    switch( elem.type() ) {
+    case reco::PFBlockElement::TRACK:
+      {
+	TEveRecTrack t;
+	t.fBeta = 1.;
+	t.fP = TEveVector( iData.px(), iData.py(), iData.pz() );
+	t.fV = TEveVector( iData.vertex().x(), iData.vertex().y(), iData.vertex().z() );
+	t.fSign = iData.charge();
+	TEveTrack* trk = new TEveTrack(&t, context().getTrackPropagator() );      
+	trk->MakeTrack();      
+	fireworks::setTrackTypePF( iData, trk );    
+	setupAddElement( trk, comp );
+      }
+      break;
+    case reco::PFBlockElement::ECAL:
+    case reco::PFBlockElement::HCAL:
+    case reco::PFBlockElement::HGC_ECAL:
+    case reco::PFBlockElement::HGC_HCALF:
+    case reco::PFBlockElement::HGC_HCALB:
+      {
+	if( elem.clusterRef().isNull() || !elem.clusterRef().isAvailable() ) {
+	  TEveRecTrack t;
+	  t.fBeta = 1.;
+	  t.fP = TEveVector( iData.px(), iData.py(), iData.pz() );
+	  t.fV = TEveVector( iData.vertex().x(), iData.vertex().y(), iData.vertex().z() );
+	  t.fSign = iData.charge();
+	  TEveTrack* trk = new TEveTrack(&t, context().getTrackPropagator() );      
+	  trk->MakeTrack();      
+	  fireworks::setTrackTypePF( iData, trk );    
+	  setupAddElement( trk, comp );
+	  continue;
+	}
+	const std::vector<std::pair<DetId, float> >& clusterDetIds = 
+	  elem.clusterRef()->hitsAndFractions();	
+	TEveBoxSet* boxset = new TEveBoxSet();
+	boxset->Reset(TEveBoxSet::kBT_FreeBox, true, clusterDetIds.size());
+	boxset->UseSingleColor();
+	boxset->SetPickable(1);
+	//const unsigned color = (unsigned)myRandom.Uniform(50);	
+	for( std::vector<std::pair<DetId, float> >::const_iterator it = clusterDetIds.begin(), itEnd = clusterDetIds.end();
+	     it != itEnd; ++it )
+	  {
+	    const float* corners = item()->getGeom()->getCorners( (*it).first );
+	    if( corners == 0 ) {
+	      continue;
+	    }
+	    std::vector<float> pnts(24);    
+	    fireworks::energyTower3DCorners(corners, (*it).second, pnts);
+	    boxset->AddBox( &pnts[0]);
+	    //boxset->DigitColor( color + 50, 50);     
+	  }
+	
+	boxset->RefitPlex();
+	setupAddElement(boxset,comp);
+      }
+      break;
+    default:
+      break;
+    }
+  }
+  comp->SetMainColor((unsigned)myRandom.Uniform(50) + 50);
 
-  fireworks::setTrackTypePF( iData, trk );
-  setupAddElement( trk, &oItemHolder );
+  setupAddElement( comp, &oItemHolder );
 }
 
 //______________________________________________________________________________

--- a/RecoParticleFlow/PFClusterProducer/interface/Arbor.hh
+++ b/RecoParticleFlow/PFClusterProducer/interface/Arbor.hh
@@ -18,7 +18,7 @@ namespace arbor {
   
   void LinkIteration(float Threshold);
   
-  void BranchBuilding();
+  void BranchBuilding(const float distSeedForMerge);
   
   void BushMerging();
   
@@ -26,7 +26,7 @@ namespace arbor {
   
   void MakingCMSCluster();
   
-  branchcoll Arbor( std::vector<TVector3>, float CellSize, float LayerThickness );
+  branchcoll Arbor( std::vector<TVector3>, const float CellSize, const float LayerThickness, const float distSeedForMerge );
 }
 
 #endif

--- a/RecoParticleFlow/PFClusterProducer/interface/Arbor.hh
+++ b/RecoParticleFlow/PFClusterProducer/interface/Arbor.hh
@@ -10,7 +10,7 @@ namespace arbor {
 
   void init(float CellSize, float LayerThickness);
   
-  void HitsCleaning( std::vector<TVector3> inputHits );
+  void HitsCleaning(std::vector<TVector3> inputHits );
   
   void HitsClassification( linkcoll inputLinks );
   

--- a/RecoParticleFlow/PFClusterProducer/interface/ArborTool.hh
+++ b/RecoParticleFlow/PFClusterProducer/interface/ArborTool.hh
@@ -6,8 +6,52 @@
 #include <iostream>
 #include <vector>
 #include <string>
+#include <unordered_map>
 
 namespace arbor{
+
+  class QuickUnion{
+  std::vector<unsigned> _id;
+  std::vector<unsigned> _size;
+  int _count;
+
+  public:
+    QuickUnion(const unsigned NBranches) {
+      _count = NBranches;
+      _id.resize(NBranches);
+      _size.resize(NBranches);
+      for( unsigned i = 0; i < NBranches; ++i ) {
+	_id[i] = i;
+	_size[i] = 1;
+      }
+    }
+    
+    int count() const { return _count; }
+    
+    unsigned find(unsigned p) {
+      while( p != _id[p] ) {
+	_id[p] = _id[_id[p]];
+	p = _id[p];
+      }
+      return p;
+    }
+    
+    bool connected(unsigned p, unsigned q) { return find(p) == find(q); }
+    
+    void unite(unsigned p, unsigned q) {
+      unsigned rootP = find(p);
+      unsigned rootQ = find(q);
+      _id[p] = q;
+      
+      if(_size[rootP] < _size[rootQ] ) { 
+	_id[rootP] = rootQ; _size[rootQ] += _size[rootP]; 
+      } else { 
+	_id[rootQ] = rootP; _size[rootP] += _size[rootQ]; 
+      }
+      --_count;
+    }
+  };
+
   typedef std::vector< std::vector<int> > branchcoll;
   typedef std::vector<int> branch;
   typedef std::vector< std::pair<int, int> > linkcoll;
@@ -24,9 +68,13 @@ namespace arbor{
   
   float DisTPCBoundary( TVector3 Pos );
   
+  std::vector<bool>
+  MatrixSummarize(const std::unordered_multimap<unsigned,unsigned>&, 
+		  const unsigned  NBranches);
+
   TMatrixF MatrixSummarize( TMatrixF inputMatrix );
   
-  std::vector<int>SortMeasure( std::vector<float> Measure, int ControlOrderFlag );
+  std::vector<unsigned> SortMeasure( const std::vector<float>& Measure, int ControlOrderFlag );
   
   float DistanceChargedParticleToCluster(TVector3 CPRefPos, TVector3 CPRefMom, TVector3 CluPosition);
   

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFArborLinker.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFArborLinker.cc
@@ -69,7 +69,7 @@ void PFArborLinker::produce(edm::Event& iEvent,
 	  }
   }
 
-  ArborBranch = arbor::Arbor(ArborIntegralHits, 2, 1);
+  ArborBranch = arbor::Arbor(ArborIntegralHits, 2, 1,20.0);
   int NBranch = ArborBranch.size();
   int BranchSize = 0; 
   // int currhitindex = 0;

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHGCEE_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHGCEE_cfi.py
@@ -28,6 +28,7 @@ _manqiArborClusterizer_HGCEE = cms.PSet(
     # use basic pad sizes in HGCEE
     cellSize = cms.double(10.0),
     layerThickness = cms.double(16.0),
+    distSeedForMerge = cms.double(20.0),
     killNoiseClusters = cms.bool(True),
     maxNoiseClusterSize = cms.uint32(3),
     thresholdsByDetector = cms.VPSet( )

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHGCHEB_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHGCHEB_cfi.py
@@ -25,6 +25,7 @@ _manqiArborClusterizer_HGCHEB = cms.PSet(
     # use basic pad sizes in HGCEE
     cellSize = cms.double(30.0),
     layerThickness = cms.double(55.0),
+    distSeedForMerge = cms.double(20.0),
     killNoiseClusters = cms.bool(True),
     maxNoiseClusterSize = cms.uint32(3),
     thresholdsByDetector = cms.VPSet( )

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHGCHEF_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHGCHEF_cfi.py
@@ -24,7 +24,8 @@ _manqiArborClusterizer_HGCHEF = cms.PSet(
     algoName = cms.string("SimpleArborClusterizer"), 
     # use basic pad sizes in HGCEE
     cellSize = cms.double(10.0),
-    layerThickness = cms.double(55.0),
+    layerThickness = cms.double(45.0),
+    distSeedForMerge = cms.double(20.0),
     killNoiseClusters = cms.bool(True),
     maxNoiseClusterSize = cms.uint32(3),
     thresholdsByDetector = cms.VPSet( )

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHGCHEB_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHGCHEB_cfi.py
@@ -13,7 +13,7 @@ particleFlowRecHitHGCHEB = cms.EDProducer("PFRecHitProducer",
              qualityTests = cms.VPSet( 
                 cms.PSet(
                   name = cms.string("PFRecHitQTestThresholdInMIPs"),
-                  thresholdInMIPs = cms.double(0.8),
+                  thresholdInMIPs = cms.double(1.05),
                   mipValueInkeV = cms.double(1498.4),
                   recHitEnergyIs_keV = cms.bool(False),
                   recHitEnergyMultiplier = cms.double(1.0)

--- a/RecoParticleFlow/PFClusterProducer/src/Arbor.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/Arbor.cc
@@ -426,7 +426,7 @@ void LinkIteration()	//Energy corrections, semi-local correction
 
 }
 
-void BranchBuilding()
+void BranchBuilding(const float distSeedForMerge)
 {
 	edm::LogVerbatim("ArborInfo") <<"Build Branch"<<endl;
 
@@ -566,7 +566,7 @@ void BranchBuilding()
 				FlagSBMerge[i7][j7] = 1.0;
 				FlagSBMerge[j7][i7] = 1.0;
 			}
-			else if( DisSeed.Mag() < 20 )
+			else if( DisSeed.Mag() < distSeedForMerge )
 			{
 				FlagSBMerge[i7][j7] = 2.0;
 				FlagSBMerge[j7][i7] = 2.0;
@@ -626,7 +626,7 @@ void MakingCMSCluster() // edm::Event& Event, const edm::EventSetup& Setup )
 	}
 }	
 
-std::vector< std::vector<int> > Arbor(std::vector<TVector3> inputHits, float CellSize, float LayerThickness )
+  std::vector< std::vector<int> > Arbor(std::vector<TVector3> inputHits, const float CellSize, const float LayerThickness, const float distSeedForMerge )
 {
 	init(CellSize, LayerThickness);
 
@@ -644,7 +644,7 @@ std::vector< std::vector<int> > Arbor(std::vector<TVector3> inputHits, float Cel
 
 	//IterLinks = InitLinks; 
 
-	BranchBuilding();	
+	BranchBuilding(distSeedForMerge);	
 	BushMerging();
 
 	return Trees;

--- a/RecoParticleFlow/PFClusterProducer/src/Arbor.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/Arbor.cc
@@ -62,17 +62,17 @@ void init( float CellSize, float LayerThickness ) {
 
 }
 
-void HitsCleaning( std::vector<TVector3> inputHits )
+void HitsCleaning(std::vector<TVector3> inputHits )
 {
-        cleanedHits = inputHits;        //Cannot Really do much things here. Mapping before calling
-        NHits = cleanedHits.size();
-	/*
-	for(int i = 0; i < NHits; i ++)
-	{
-		if(BarrelFlag(cleanedHits[i]))
-			cout<<cleanedHits[i].Z()<<endl; 
-	}
-	*/
+  cleanedHits = std::move(inputHits);        //Cannot Really do much things here. Mapping before calling
+  NHits = cleanedHits.size();
+  /*
+    for(int i = 0; i < NHits; i ++)
+    {
+    if(BarrelFlag(cleanedHits[i]))
+    cout<<cleanedHits[i].Z()<<endl; 
+    }
+  */
 }
 
 void HitsClassification( linkcoll inputLinks )
@@ -143,7 +143,7 @@ void HitsClassification( linkcoll inputLinks )
 	edm::LogVerbatim("ArborInfo") <<"TotalHits: "<<NHits<<endl; 
 }
 
-linkcoll LinkClean( std::vector<TVector3> allhits, linkcoll alllinks )
+linkcoll LinkClean(const std::vector<TVector3>& allhits, linkcoll alllinks )
 {
 	linkcoll cleanedlinks; 
 
@@ -626,11 +626,11 @@ void MakingCMSCluster() // edm::Event& Event, const edm::EventSetup& Setup )
 	}
 }	
 
-std::vector< std::vector<int> > Arbor( std::vector<TVector3> inputHits, float CellSize, float LayerThickness )
+std::vector< std::vector<int> > Arbor(std::vector<TVector3> inputHits, float CellSize, float LayerThickness )
 {
 	init(CellSize, LayerThickness);
 
-	HitsCleaning(inputHits);
+	HitsCleaning( std::move(inputHits) );
 	BuildInitLink();
 	InitLinks = LinkClean( cleanedHits, Links );
 	

--- a/RecoParticleFlow/PFClusterProducer/src/ArborTool.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/ArborTool.cc
@@ -1,6 +1,8 @@
 #include "RecoParticleFlow/PFClusterProducer/interface/ArborTool.hh"
 #include <TMath.h>
 
+#include <cassert>
+
 namespace arbor {
 using namespace std;
 
@@ -160,131 +162,171 @@ float DisTPCBoundary( TVector3 Pos )
 	return Dis; 
 }
 
-std::vector<int> SortMeasure( std::vector<float> Measure, int ControlOrderFlag )
+std::vector<unsigned> SortMeasure( const std::vector<float>& Measure, int ControlOrderFlag )
 {
-
-	std::vector<int> objindex;
-	int Nobj = Measure.size();
-
-	for(int k = 0; k < Nobj; k++)
+  std::vector<unsigned> objindex;
+  const unsigned Nobj = Measure.size();
+  
+  for(unsigned  k = 0; k < Nobj; k++) {
+    objindex.push_back(k);
+  }
+  
+  std::sort(objindex.begin(),objindex.end(),
+	    [&](const unsigned a,const unsigned b){
+	      return  ( ( Measure[a] < Measure[b] && ControlOrderFlag ) ||
+			( Measure[a] > Measure[b] && !ControlOrderFlag ) );
+	    });
+  /*
+  int FlagSwapOrder = 1;
+  float SwapMeasure = 0;
+  int SwapIndex = 0;
+  
+  for(int i = 0; i < Nobj && FlagSwapOrder; i++)
+    {
+      FlagSwapOrder = 0;
+      for(int j = 0; j < Nobj - 1; j++)
 	{
-		objindex.push_back(k);
+	  if((Measure[j] < Measure[j+1] && ControlOrderFlag) || (Measure[j] > Measure[j+1] && !ControlOrderFlag) )
+	    {
+	      FlagSwapOrder = 1;
+	      SwapMeasure = Measure[j];
+	      Measure[j] = Measure[j+1];
+	      Measure[j+1] = SwapMeasure;
+	      
+	      SwapIndex = objindex[j];
+	      objindex[j] = objindex[j+1];
+	      objindex[j+1] = SwapIndex;
+	    }
 	}
-
-	int FlagSwapOrder = 1;
-	float SwapMeasure = 0;
-	int SwapIndex = 0;
-
-	for(int i = 0; i < Nobj && FlagSwapOrder; i++)
-	{
-		FlagSwapOrder = 0;
-		for(int j = 0; j < Nobj - 1; j++)
-		{
-			if((Measure[j] < Measure[j+1] && ControlOrderFlag) || (Measure[j] > Measure[j+1] && !ControlOrderFlag) )
-			{
-				FlagSwapOrder = 1;
-				SwapMeasure = Measure[j];
-				Measure[j] = Measure[j+1];
-				Measure[j+1] = SwapMeasure;
-
-				SwapIndex = objindex[j];
-				objindex[j] = objindex[j+1];
-				objindex[j+1] = SwapIndex;
-			}
-		}
 	}
+  */
+  return objindex;
+}
 
-	return objindex;
+template< typename Map, typename Range >
+void getIndirectConnections(const unsigned base_index, const Map& directLinks,const Range& range, Map& allLinks) {
+  for( auto itr = range.first; itr != range.second; ++itr ) {
+    if( itr->second <= base_index ) continue;
+    //std::cout << "         adding link: " << base_index << " to " << itr->second << std::endl;    
+    auto alllinksrange = allLinks.equal_range(base_index);
+    if( std::find(alllinksrange.first,alllinksrange.second,typename Map::value_type(base_index,itr->second)) == alllinksrange.second ) {
+      //std::cout << "putting element " << base_index << ' ' << itr->second << std::endl;
+      allLinks.emplace(base_index,itr->second);
+      allLinks.emplace(itr->second,base_index);
+      auto nextRange = directLinks.equal_range(itr->second);
+      getIndirectConnections(base_index,directLinks,nextRange,allLinks);
+    }
+  }
+}
+
+std::vector<bool>
+MatrixSummarize(const std::unordered_multimap<unsigned,unsigned>& directLinks, const unsigned NBranches) {
+  std::vector<bool> allLinks(NBranches*NBranches,false);
+  QuickUnion qu(NBranches);
+
+  for( unsigned p = 0; p < NBranches; ++p ) {
+    auto range = directLinks.equal_range(p);
+    for( auto itr = range.first; itr != range.second; ++itr ) {
+      const unsigned q = itr->second;
+      if( qu.connected(p,q) ) continue;
+      qu.unite(p,q);
+    }
+  }
+
+  std::cout<< "quick union gives : " << qu.count() << " sets!" << std::endl;
+  
+  return allLinks;
 }
 
 TMatrixF MatrixSummarize( TMatrixF inputMatrix )
 {
+  int Nrow = inputMatrix.GetNrows();
+  int Ncol = inputMatrix.GetNcols();
+  
+  assert(Nrow == Ncol && "input matrix is not square!");
 
-	int Nrow = inputMatrix.GetNrows();
-	int Ncol = inputMatrix.GetNcols();
+  TMatrixF tmpMatrix(Nrow, Ncol); 
 
-	TMatrixF tmpMatrix(Nrow, Ncol); 
-
-	for(int i0 = 0; i0 < Nrow; i0 ++)
+  for(int i0 = 0; i0 < Nrow; i0 ++)
+    {
+      for(int j0 = i0; j0 < Ncol; j0 ++)
 	{
-		for(int j0 = i0; j0 < Ncol; j0 ++)
-		{
-			//		if( fabs(inputMatrix(i0, j0) - 2) < 0.2 || fabs(inputMatrix(i0, j0) - 10 ) < 0.2 )	//Case 2, 3: Begin-End connector
-			if(inputMatrix(i0, j0))
-			{
-				tmpMatrix(i0, j0) = 1;
-				tmpMatrix(j0, i0) = 1;
-			}
-			else 
-			{
-				tmpMatrix(i0, j0) = 0;
-				tmpMatrix(j0, i0) = 0;
-			}
-		}
+	  //		if( fabs(inputMatrix(i0, j0) - 2) < 0.2 || fabs(inputMatrix(i0, j0) - 10 ) < 0.2 )	//Case 2, 3: Begin-End connector
+	  if(inputMatrix(i0, j0))
+	    {
+	      tmpMatrix(i0, j0) = 1;
+	      tmpMatrix(j0, i0) = 1;
+	    }
+	  else 
+	    {
+	      tmpMatrix(i0, j0) = 0;
+	      tmpMatrix(j0, i0) = 0;
+	    }
 	}
-
-	int PreviousLinks = -1;
-	int CurrentLinks = 0;
-	int symloopsize = 0;
-	vector <int> Indirectlinks;
-	int tmpI(0);
-	int tmpJ(0);
-
-	// cout<<"Matrix Type: "<<Nrow<<" * "<<Ncol<<endl;
-
-	if( Nrow == Ncol )
+    }
+  
+  int PreviousLinks = -1;
+  int CurrentLinks = 0;
+  int symloopsize = 0;
+  vector <int> Indirectlinks;
+  int tmpI(0);
+  int tmpJ(0);
+  
+  // cout<<"Matrix Type: "<<Nrow<<" * "<<Ncol<<endl;
+  
+  if( Nrow == Ncol )
+    {
+      
+      while( CurrentLinks > PreviousLinks )
 	{
-
-		while( CurrentLinks > PreviousLinks )
+	  PreviousLinks = 0;
+	  CurrentLinks = 0;
+	  
+	  for(int i = 0; i < Nrow; i ++)
+	    {
+	      for(int j = 0; j < Ncol; j ++)
 		{
-			PreviousLinks = 0;
-			CurrentLinks = 0;
-
-			for(int i = 0; i < Nrow; i ++)
-			{
-				for(int j = 0; j < Ncol; j ++)
-				{
-					if( tmpMatrix(i, j) > 0.1 )
-						PreviousLinks ++;
-				}
-			}
-
-			for(int k = 0; k < Nrow; k ++)
-			{
-				for(int l = 0; l < Ncol; l ++)
-				{
-					if( tmpMatrix(k, l) > 0.1) Indirectlinks.push_back(l);
-				}
-				symloopsize = Indirectlinks.size();
-
-				for(int l1(0); l1 < symloopsize; l1 ++)
-				{
-					tmpI = Indirectlinks[l1];
-					for(int m1=l1 + 1; m1 < symloopsize; m1++)
-					{
-						tmpJ = Indirectlinks[m1];
-						tmpMatrix(tmpI, tmpJ) = 1;
-						tmpMatrix(tmpJ, tmpI) = 1;
-					}
-				}
-				Indirectlinks.clear();
-			}
-
-			for(int u = 0; u < Nrow; u++)
-			{
-				for(int v = 0; v < Ncol; v++)
-				{
-					if( tmpMatrix(u, v) > 0.1)
-						CurrentLinks ++;
-				}
-			}
-
-			// cout<<"Link Matrix Symmetrize Loop, PreviousFlag = "<<PreviousLinks<<", CurrentFlag = "<<CurrentLinks<<" of D = "<<Nrow<<" Matrix" <<endl;
-
+		  if( tmpMatrix(i, j) > 0.1 )
+		    PreviousLinks ++;
 		}
+	    }
+	  
+	  for(int k = 0; k < Nrow; k ++)
+	    {
+	      for(int l = 0; l < Ncol; l ++)
+		{
+		  if( tmpMatrix(k, l) > 0.1) Indirectlinks.push_back(l);
+		}
+	      symloopsize = Indirectlinks.size();
+	      
+	      for(int l1(0); l1 < symloopsize; l1 ++)
+		{
+		  tmpI = Indirectlinks[l1];
+		  for(int m1=l1 + 1; m1 < symloopsize; m1++)
+		    {
+		      tmpJ = Indirectlinks[m1];
+		      tmpMatrix(tmpI, tmpJ) = 1;
+		      tmpMatrix(tmpJ, tmpI) = 1;
+		    }
+		}
+	      Indirectlinks.clear();
+	    }
+	  
+	  for(int u = 0; u < Nrow; u++)
+	    {
+	      for(int v = 0; v < Ncol; v++)
+		{
+		  if( tmpMatrix(u, v) > 0.1)
+		    CurrentLinks ++;
+		}
+	    }
+	  
+	  // cout<<"Link Matrix Symmetrize Loop, PreviousFlag = "<<PreviousLinks<<", CurrentFlag = "<<CurrentLinks<<" of D = "<<Nrow<<" Matrix" <<endl;
+	  
 	}
-
-	return tmpMatrix; 
+    }
+  
+  return tmpMatrix; 
 }
 
 
@@ -307,53 +349,53 @@ float DistanceChargedParticleToCluster(TVector3 CPRefPos, TVector3 CPRefMom, TVe
 
 branchcoll ArborBranchMerge(branchcoll inputbranches, TMatrixF ConnectorMatrix)	//ABM
 {
-	branchcoll outputbranches; 
-
-	int NinputBranch = inputbranches.size();
-	int Nrow = ConnectorMatrix.GetNrows();
-	int Ncol = ConnectorMatrix.GetNcols();
-	int FlagBranchTouch[Nrow];
-	int tmpCellID = 0; 
-
-	if(Ncol != NinputBranch || Nrow != Ncol || Nrow != NinputBranch)
+  branchcoll outputbranches; 
+  
+  int NinputBranch = inputbranches.size();
+  int Nrow = ConnectorMatrix.GetNrows();
+  int Ncol = ConnectorMatrix.GetNcols();
+  int FlagBranchTouch[Nrow];
+  int tmpCellID = 0; 
+  
+  if(Ncol != NinputBranch || Nrow != Ncol || Nrow != NinputBranch)
+    {
+      cout<<"Size of Connector Matrix and inputClusterColl is not match"<<endl;
+    }
+  
+  for(int i0 = 0; i0 < Nrow; i0++)
+    {
+      FlagBranchTouch[i0] = 0;
+    }
+  
+  for(int i1 = 0; i1 < Nrow; i1++)
+    {
+      if(FlagBranchTouch[i1] == 0)
 	{
-		cout<<"Size of Connector Matrix and inputClusterColl is not match"<<endl;
-	}
-
-	for(int i0 = 0; i0 < Nrow; i0++)
-	{
-		FlagBranchTouch[i0] = 0;
-	}
-
-	for(int i1 = 0; i1 < Nrow; i1++)
-	{
-		if(FlagBranchTouch[i1] == 0)
+	  branch Mergebranch_A = inputbranches[i1];
+	  branch a_MergedBranch = Mergebranch_A;
+	  FlagBranchTouch[i1] = 1;		
+	  
+	  for(int j1 = i1 + 1; j1 < Nrow; j1++)
+	    {
+	      if(FlagBranchTouch[j1] == 0 && ConnectorMatrix(i1, j1) > 0.1 )
 		{
-			branch Mergebranch_A = inputbranches[i1];
-			branch a_MergedBranch = Mergebranch_A;
-			FlagBranchTouch[i1] = 1;		
-
-			for(int j1 = i1 + 1; j1 < Nrow; j1++)
+		  branch Mergebranch_B = inputbranches[j1];
+		  FlagBranchTouch[j1] = 1;
+		  for(unsigned int k1 = 0; k1 < Mergebranch_B.size(); k1 ++)
+		    {
+		      tmpCellID = Mergebranch_B[k1];
+		      if(find(a_MergedBranch.begin(), a_MergedBranch.end(), tmpCellID) == a_MergedBranch.end())
 			{
-				if(FlagBranchTouch[j1] == 0 && ConnectorMatrix(i1, j1) > 0.1 )
-				{
-					branch Mergebranch_B = inputbranches[j1];
-					FlagBranchTouch[j1] = 1;
-					for(unsigned int k1 = 0; k1 < Mergebranch_B.size(); k1 ++)
-					{
-						tmpCellID = Mergebranch_B[k1];
-						if(find(a_MergedBranch.begin(), a_MergedBranch.end(), tmpCellID) == a_MergedBranch.end())
-						{
-							a_MergedBranch.push_back(tmpCellID);
-						}
-					}					
-				}
+			  a_MergedBranch.push_back(tmpCellID);
 			}
-			outputbranches.push_back(a_MergedBranch);
+		    }					
 		}
-	}	
-
-	return outputbranches; 
+	    }
+	  outputbranches.push_back(a_MergedBranch);
+	}
+    }	
+  
+  return outputbranches; 
 }
 
 }

--- a/RecoParticleFlow/PFClusterProducer/src/ArborTool.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/ArborTool.cc
@@ -160,7 +160,7 @@ float DisTPCBoundary( TVector3 Pos )
 	return Dis; 
 }
 
-std::vector<int>SortMeasure( std::vector<float> Measure, int ControlOrderFlag )
+std::vector<int> SortMeasure( std::vector<float> Measure, int ControlOrderFlag )
 {
 
 	std::vector<int> objindex;

--- a/RecoParticleFlow/PFClusterProducer/src/KDTreeLinkerAlgoT.h
+++ b/RecoParticleFlow/PFClusterProducer/src/KDTreeLinkerAlgoT.h
@@ -1,0 +1,336 @@
+#ifndef KDTreeLinkerAlgoTemplated_h
+#define KDTreeLinkerAlgoTemplated_h
+
+#include "KDTreeLinkerToolsT.h"
+
+#include <cassert>
+#include <vector>
+
+// Class that implements the KDTree partition of 2D space and 
+// a closest point search algorithme.
+
+template <typename DATA, unsigned DIM=2>
+class KDTreeLinkerAlgo
+{
+ public:
+  KDTreeLinkerAlgo();
+  
+  // Dtor calls clear()
+  ~KDTreeLinkerAlgo();
+  
+  // Here we build the KD tree from the "eltList" in the space define by "region".
+ void build(std::vector<KDTreeNodeInfoT<DATA,DIM> > 	&eltList,
+	    const KDTreeBoxT<DIM>	                &region);
+  
+  // Here we search in the KDTree for all points that would be 
+  // contained in the given searchbox. The founded points are stored in resRecHitList.
+  void search(const KDTreeBoxT<DIM>			&searchBox,
+	      std::vector<KDTreeNodeInfoT<DATA,DIM> >	&resRecHitList);
+
+  // This reurns true if the tree is empty
+  bool empty() {return nodePoolPos_ == -1;}
+
+  // This returns the number of nodes + leaves in the tree
+  // (nElements should be (size() +1)/2)
+  int size() { return nodePoolPos_ + 1;}
+
+  // This method clears all allocated structures.
+  void clear();
+  
+ private:
+ // The KDTree root
+ KDTreeNodeT<DATA,DIM>*	root_;
+ 
+ // The node pool allow us to do just 1 call to new for each tree building.
+ KDTreeNodeT<DATA,DIM>*	nodePool_;
+ int		nodePoolSize_;
+ int		nodePoolPos_;
+
+
+  
+ std::vector<KDTreeNodeInfoT<DATA,DIM> >	*closestNeighbour;
+ std::vector<KDTreeNodeInfoT<DATA,DIM> >	*initialEltList;
+  
+ private:
+ 
+  // Get next node from the node pool.
+ KDTreeNodeT<DATA,DIM>* getNextNode();
+
+  //Fast median search with Wirth algorithm in eltList between low and high indexes.
+  int medianSearch(int					low,
+		   int					high,
+		   int					treeDepth);
+
+  // Recursif kdtree builder. Is called by build()
+ KDTreeNodeT<DATA,DIM> *recBuild(int				low,
+				 int				hight,
+				 int				depth,
+				 const KDTreeBoxT<DIM>		&region);
+
+  // Recursif kdtree search. Is called by search()
+ void recSearch(const KDTreeNodeT<DATA,DIM>		*current,
+		const KDTreeBoxT<DIM>			&trackBox);    
+
+  // Add all elements of an subtree to the closest elements. Used during the recSearch().
+ void addSubtree(const KDTreeNodeT<DATA,DIM>		*current);
+ 
+ // This method frees the KDTree.     
+ void clearTree();
+};
+
+
+//Implementation
+
+template < typename DATA, unsigned DIM >
+void
+KDTreeLinkerAlgo<DATA,DIM>::build(std::vector<KDTreeNodeInfoT<DATA,DIM> >  &eltList, 
+				  const KDTreeBoxT<DIM>  		  &region)
+{
+  if (eltList.size()) {
+    initialEltList = &eltList;
+    
+    size_t size = initialEltList->size();
+    nodePoolSize_ = size * 2 - 1;
+    nodePool_ = new KDTreeNodeT<DATA,DIM>[nodePoolSize_];
+    
+    // Here we build the KDTree
+    root_ = recBuild(0, size, 0, region);
+    
+    initialEltList = 0;
+  }
+}
+ 
+//Fast median search with Wirth algorithm in eltList between low and high indexes.
+template < typename DATA, unsigned DIM >
+int
+KDTreeLinkerAlgo<DATA,DIM>::medianSearch(int	low,
+					 int	high,
+					 int	treeDepth)
+{
+  //We should have at least 1 element to calculate the median...
+  //assert(low < high);
+
+  const int nbrElts = high - low;  
+  int median = nbrElts/2 - ( 1 - 1*(nbrElts&1) );
+  median += low;
+
+  int l = low;
+  int m = high - 1;
+  
+  while (l < m) {
+    KDTreeNodeInfoT<DATA,DIM> elt = (*initialEltList)[median];
+    int i = l;
+    int j = m;
+
+    do {
+      // The even depth is associated to dim1 dimension
+      // The odd one to dim2 dimension
+      const unsigned thedim = treeDepth % DIM;
+      while( (*initialEltList)[i].dims[thedim] < elt.dims[thedim] ) ++i;
+      while( (*initialEltList)[j].dims[thedim] > elt.dims[thedim] ) --j;      
+
+      if (i <= j){
+	std::swap((*initialEltList)[i], (*initialEltList)[j]);
+	i++; 
+	j--;
+      }
+    } while (i <= j);
+    if (j < median) l = i;
+    if (i > median) m = j;
+  }
+
+  return median;
+}
+
+
+
+template < typename DATA, unsigned DIM >
+void
+KDTreeLinkerAlgo<DATA,DIM>::search(const KDTreeBoxT<DIM>		  &trackBox,
+				   std::vector<KDTreeNodeInfoT<DATA,DIM> > &recHits)
+{
+  if (root_) {
+    closestNeighbour = &recHits;
+    recSearch(root_, trackBox);
+    closestNeighbour = 0;
+  }
+}
+
+
+template < typename DATA, unsigned DIM >
+void 
+KDTreeLinkerAlgo<DATA,DIM>::recSearch(const KDTreeNodeT<DATA,DIM> *current,
+				      const KDTreeBoxT<DIM>	 &trackBox)
+{
+  /*
+  // By construction, current can't be null
+  assert(current != 0);
+
+  // By Construction, a node can't have just 1 son.
+  assert (!(((current->left == 0) && (current->right != 0)) ||
+	    ((current->left != 0) && (current->right == 0))));
+  */
+    
+  if ((current->left == 0) && (current->right == 0)) {//leaf case
+  
+    // If point inside the rectangle/area
+    bool isInside = true;
+    for( unsigned i = 0; i < DIM; ++i ) {
+      const auto thedim = current->info.dims[i];
+      isInside *= thedim >= trackBox.dimmin[i] && thedim <= trackBox.dimmax[i];
+    }
+    if( isInside ) closestNeighbour->push_back(current->info);
+
+  } else {
+
+    bool isFullyContained = true;
+    bool hasIntersection = true;
+    //if region( v->left ) is fully contained in the rectangle
+    for( unsigned i = 0; i < DIM; ++i ) {
+      const auto regionmin = current->left->region.dimmin[i];
+      const auto regionmax = current->left->region.dimmax[i];
+      isFullyContained *= ( regionmin >= trackBox.dimmin[i] && 
+			    regionmax <= trackBox.dimmax[i]    );
+      hasIntersection *= ( regionmin < trackBox.dimmax[i] && regionmax > trackBox.dimmin[i]);
+    }
+    if( isFullyContained ) {
+      addSubtree(current->left);
+    } else if ( hasIntersection ) {
+      recSearch(current->left, trackBox); 
+    }    
+    // reset flags
+    isFullyContained = true;
+    hasIntersection = true;
+    //if region( v->right ) is fully contained in the rectangle
+    for( unsigned i = 0; i < DIM; ++i ) {
+      const auto regionmin = current->right->region.dimmin[i];
+      const auto regionmax = current->right->region.dimmax[i];
+      isFullyContained *= ( regionmin >= trackBox.dimmin[i] && 
+			    regionmax <= trackBox.dimmax[i]    );
+      hasIntersection *= ( regionmin < trackBox.dimmax[i] && regionmax > trackBox.dimmin[i]);
+    }
+    if( isFullyContained ) {
+      addSubtree(current->right);
+    } else if ( hasIntersection ) {
+      recSearch(current->right, trackBox); 
+    }    
+  }
+}
+
+template < typename DATA, unsigned DIM >
+void
+KDTreeLinkerAlgo<DATA,DIM>::addSubtree(const KDTreeNodeT<DATA,DIM>	*current)
+{
+  // By construction, current can't be null
+  // assert(current != 0);
+
+  if ((current->left == 0) && (current->right == 0)) // leaf
+    closestNeighbour->push_back(current->info);
+  else { // node
+    addSubtree(current->left);
+    addSubtree(current->right);
+  }
+}
+
+
+
+
+template <typename DATA, unsigned DIM>
+KDTreeLinkerAlgo<DATA,DIM>::KDTreeLinkerAlgo()
+  : root_ (0),
+    nodePool_(0),
+    nodePoolSize_(-1),
+    nodePoolPos_(-1)
+{
+}
+
+template <typename DATA, unsigned DIM>
+KDTreeLinkerAlgo<DATA,DIM>::~KDTreeLinkerAlgo()
+{
+  clear();
+}
+
+
+template <typename DATA, unsigned DIM>
+void 
+KDTreeLinkerAlgo<DATA,DIM>::clearTree()
+{
+  delete[] nodePool_;
+  nodePool_ = 0;
+  root_ = 0;
+  nodePoolSize_ = -1;
+  nodePoolPos_ = -1;
+}
+
+template <typename DATA, unsigned DIM>
+void 
+KDTreeLinkerAlgo<DATA,DIM>::clear()
+{
+  if (root_)
+    clearTree();
+}
+
+
+template <typename DATA, unsigned DIM>
+KDTreeNodeT<DATA,DIM>* 
+KDTreeLinkerAlgo<DATA,DIM>::getNextNode()
+{
+  ++nodePoolPos_;
+
+  // The tree size is exactly 2 * nbrElts - 1 and this is the total allocated memory.
+  // If we have used more than that....there is a big problem.
+  // assert(nodePoolPos_ < nodePoolSize_);
+
+  return &(nodePool_[nodePoolPos_]);
+}
+
+
+template <typename DATA, unsigned DIM>
+KDTreeNodeT<DATA,DIM>*
+KDTreeLinkerAlgo<DATA,DIM>::recBuild(int					low, 
+				     int					high, 
+				     int					depth,
+				     const KDTreeBoxT<DIM>&			region)
+{
+  int portionSize = high - low;
+
+  // By construction, portionSize > 0 can't happend.
+  // assert(portionSize > 0);
+
+  if (portionSize == 1) { // Leaf case
+   
+    KDTreeNodeT<DATA,DIM> *leaf = getNextNode();
+    leaf->setAttributs(region, (*initialEltList)[low]);
+    return leaf;
+
+  } else { // Node case
+    
+    // The even depth is associated to dim1 dimension
+    // The odd one to dim2 dimension
+    int medianId = medianSearch(low, high, depth);
+
+    // We create the node
+    KDTreeNodeT<DATA,DIM> *node = getNextNode();
+    node->setAttributs(region);
+
+
+    // Here we split into 2 halfplanes the current plane
+    KDTreeBoxT<DIM> leftRegion = region;
+    KDTreeBoxT<DIM> rightRegion = region;
+    unsigned thedim = depth % DIM;
+    auto medianVal = (*initialEltList)[medianId].dims[thedim];
+    leftRegion.dimmax[thedim] = medianVal;
+    rightRegion.dimmin[thedim] = medianVal;    
+
+    ++depth;
+    ++medianId;
+
+    // We recursively build the son nodes
+    node->left = recBuild(low, medianId, depth, leftRegion);
+    node->right = recBuild(medianId, high, depth, rightRegion);
+
+    return node;
+  }
+}
+
+#endif

--- a/RecoParticleFlow/PFClusterProducer/src/KDTreeLinkerToolsT.h
+++ b/RecoParticleFlow/PFClusterProducer/src/KDTreeLinkerToolsT.h
@@ -1,0 +1,82 @@
+#ifndef KDTreeLinkerToolsTemplated_h
+#define KDTreeLinkerToolsTemplated_h
+
+#include <array>
+
+// Box structure used to define 2D field.
+// It's used in KDTree building step to divide the detector
+// space (ECAL, HCAL...) and in searching step to create a bounding
+// box around the demanded point (Track collision point, PS projection...).
+template<unsigned DIM>
+struct KDTreeBoxT
+{
+  std::array<float,DIM> dimmin, dimmax;
+  
+  template<typename... Ts>
+  KDTreeBoxT(Ts... dimargs) {
+    static_assert(sizeof...(dimargs) == 2*DIM,"Constructor requires 2*DIM args");
+    std::vector<float> dims = {dimargs...};
+    for( unsigned i = 0; i < DIM; ++i ) {
+      dimmin[i] = dims[2*i];
+      dimmax[i] = dims[2*i+1];
+    }
+  }
+
+  KDTreeBoxT() {}
+};
+
+typedef KDTreeBoxT<2> KDTreeBox;
+typedef KDTreeBoxT<3> KDTreeCube;
+
+  
+// Data stored in each KDTree node.
+// The dim1/dim2 fields are usually the duplication of some PFRecHit values
+// (eta/phi or x/y). But in some situations, phi field is shifted by +-2.Pi
+template<typename DATA,unsigned DIM>
+struct KDTreeNodeInfoT 
+{
+  DATA data;
+  std::array<float,DIM> dims;
+
+public:
+  KDTreeNodeInfoT()
+  {}
+  
+  template<typename... Ts>
+  KDTreeNodeInfoT(const DATA& d,Ts... dimargs)
+  : data(d), dims{ {dimargs...} }
+  {}
+};
+
+// KDTree node.
+template <typename DATA, unsigned DIM>
+struct KDTreeNodeT
+{
+  // Data
+  KDTreeNodeInfoT<DATA,DIM> info;
+  
+  // Right/left sons.
+  KDTreeNodeT<DATA,DIM> *left, *right;
+  
+  // Region bounding box.
+  KDTreeBoxT<DIM> region;
+  
+  public:
+  KDTreeNodeT()
+    : left(0), right(0)
+  {}
+  
+  void setAttributs(const KDTreeBoxT<DIM>& regionBox,
+		    const KDTreeNodeInfoT<DATA,DIM>& infoToStore) 
+  {
+    info = infoToStore;
+    region = regionBox;
+  }
+  
+  void setAttributs(const KDTreeBoxT<DIM>&   regionBox) 
+  {
+    region = regionBox;
+  }
+};
+
+#endif

--- a/RecoParticleFlow/PFClusterProducer/src/SimpleArborClusterizer.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/SimpleArborClusterizer.cc
@@ -41,7 +41,7 @@ buildClusters(const edm::Handle<reco::PFRecHitCollection>& input,
     arbor_points.emplace_back(10*pos.x(),10*pos.y(),10*pos.z());
   }
 
-  branches = arbor::Arbor(arbor_points,_cellSize,_layerThickness);
+  branches = arbor::Arbor(arbor_points,_cellSize,_layerThickness,_distSeedForMerge);
   output.reserve(branches.size());
   
   for( auto& branch : branches ) {

--- a/RecoParticleFlow/PFClusterProducer/src/SimpleArborClusterizer.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/SimpleArborClusterizer.cc
@@ -47,16 +47,16 @@ buildClusters(const edm::Handle<reco::PFRecHitCollection>& input,
       arbor_points[1].emplace_back(10*pos.x(),10*pos.y(),10*pos.z());
     }
   }
-  edm::LogError("ArborProgress") 
+  edm::LogInfo("ArborProgress") 
     << "arbor loaded: " << arbor_points[0].size() << " in negative endcap!";
-  edm::LogError("ArborProgress") 
+  edm::LogInfo("ArborProgress") 
     << "arbor loaded: " << arbor_points[1].size() << " in positive endcap!";
   
 
   the_branches[0] = arbor::Arbor(arbor_points[0],_cellSize,_layerThickness,_distSeedForMerge);
-  edm::LogError("ArborProgress") << "arbor clustered negative endcap!";
+  edm::LogInfo("ArborProgress") << "arbor clustered negative endcap!";
   the_branches[1] = arbor::Arbor(arbor_points[1],_cellSize,_layerThickness,_distSeedForMerge);
-  edm::LogError("ArborProgress") << "arbor clustered positive endcap!";
+  edm::LogInfo("ArborProgress") << "arbor clustered positive endcap!";
   output.reserve(the_branches[0].size()+the_branches[1].size());
   
   for( unsigned iside = 0; iside < 2; ++iside ) {
@@ -88,4 +88,5 @@ buildClusters(const edm::Handle<reco::PFRecHitCollection>& input,
 	<< "Made cluster: " << current << std::endl;
     }
   }
+  edm::LogError("ArborInfo") << "Made " << output.size() << " clusters!";
 }

--- a/RecoParticleFlow/PFClusterProducer/src/SimpleArborClusterizer.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/SimpleArborClusterizer.cc
@@ -27,47 +27,65 @@ buildClusters(const edm::Handle<reco::PFRecHitCollection>& input,
 	      const std::vector<bool>& seedable,
 	      reco::PFClusterCollection& output) {  
   const reco::PFRecHitCollection& hits = *input;
-  std::vector<TVector3> arbor_points;
-  std::vector<unsigned> hits_for_arbor;
-  arbor::branchcoll branches;  
+  std::vector<TVector3> arbor_points[2];
+  std::vector<unsigned> hits_for_arbor[2];
+  arbor::branchcoll the_branches[2];  
 
   // get the seeds and sort them descending in energy
-  arbor_points.reserve(hits.size());
-  hits_for_arbor.reserve(hits.size());  
+  arbor_points[0].reserve(hits.size()/2);
+  arbor_points[1].reserve(hits.size()/2);
+  hits_for_arbor[0].reserve(hits.size()/2);  
+  hits_for_arbor[1].reserve(hits.size()/2);
   for( unsigned i = 0; i < hits.size(); ++i ) {
     if( !rechitMask[i] ) continue;
     const math::XYZPoint& pos = hits[i].position();
-    hits_for_arbor.emplace_back(i);
-    arbor_points.emplace_back(10*pos.x(),10*pos.y(),10*pos.z());
+    if( pos.z() < 0 ) {
+      hits_for_arbor[0].emplace_back(i);
+      arbor_points[0].emplace_back(10*pos.x(),10*pos.y(),10*pos.z());
+    } else {
+      hits_for_arbor[1].emplace_back(i);
+      arbor_points[1].emplace_back(10*pos.x(),10*pos.y(),10*pos.z());
+    }
   }
-
-  branches = arbor::Arbor(arbor_points,_cellSize,_layerThickness,_distSeedForMerge);
-  output.reserve(branches.size());
+  edm::LogError("ArborProgress") 
+    << "arbor loaded: " << arbor_points[0].size() << " in negative endcap!";
+  edm::LogError("ArborProgress") 
+    << "arbor loaded: " << arbor_points[1].size() << " in positive endcap!";
   
-  for( auto& branch : branches ) {
-    if( _killNoiseClusters && branch.size() <= _maxNoiseClusterSize ) {
-      continue;
+
+  the_branches[0] = arbor::Arbor(arbor_points[0],_cellSize,_layerThickness,_distSeedForMerge);
+  edm::LogError("ArborProgress") << "arbor clustered negative endcap!";
+  the_branches[1] = arbor::Arbor(arbor_points[1],_cellSize,_layerThickness,_distSeedForMerge);
+  edm::LogError("ArborProgress") << "arbor clustered positive endcap!";
+  output.reserve(the_branches[0].size()+the_branches[1].size());
+  
+  for( unsigned iside = 0; iside < 2; ++iside ) {
+    arbor::branchcoll& branches = the_branches[iside];
+    for( auto& branch : branches ) {
+      if( _killNoiseClusters && branch.size() <= _maxNoiseClusterSize ) {
+	continue;
+      }
+      // sort hits by radius
+      std::sort(branch.begin(),branch.end(),
+		[&](const arbor::branch::value_type& a,
+		    const arbor::branch::value_type& b) {
+		  return ( hits[hits_for_arbor[iside][a]].position().Mag2() <
+			   hits[hits_for_arbor[iside][b]].position().Mag2()   );
+		});
+      const reco::PFRecHit& inner_hit = hits[hits_for_arbor[iside][branch[0]]];
+      PFLayer::Layer inner_layer = inner_hit.layer();
+      const math::XYZPoint& inner_pos = inner_hit.position();    
+      output.emplace_back(inner_layer,branch.size(),
+			  inner_pos.x(),inner_pos.y(),inner_pos.z());
+      reco::PFCluster& current = output.back();
+      current.setSeed(inner_hit.detId());
+      for( const auto& hit : branch ) {
+	const reco::PFRecHitRef& refhit = 
+	  reco::PFRecHitRef(input,hits_for_arbor[iside][hit]);
+	current.addRecHitFraction(reco::PFRecHitFraction(refhit,1.0));
+      }
+      LogDebug("SimpleArborClusterizer")
+	<< "Made cluster: " << current << std::endl;
     }
-    // sort hits by radius
-    std::sort(branch.begin(),branch.end(),
-	      [&](const arbor::branch::value_type& a,
-		  const arbor::branch::value_type& b) {
-		return ( hits[hits_for_arbor[a]].position().Mag2() <
-			 hits[hits_for_arbor[b]].position().Mag2()   );
-	      });
-    const reco::PFRecHit& inner_hit = hits[hits_for_arbor[branch[0]]];
-    PFLayer::Layer inner_layer = inner_hit.layer();
-    const math::XYZPoint& inner_pos = inner_hit.position();    
-    output.emplace_back(inner_layer,branch.size(),
-			inner_pos.x(),inner_pos.y(),inner_pos.z());
-    reco::PFCluster& current = output.back();
-    current.setSeed(inner_hit.detId());
-    for( const auto& hit : branch ) {
-      const reco::PFRecHitRef& refhit = 
-	reco::PFRecHitRef(input,hits_for_arbor[hit]);
-      current.addRecHitFraction(reco::PFRecHitFraction(refhit,1.0));
-    }
-    LogDebug("SimpleArborClusterizer")
-      << "Made cluster: " << current << std::endl;
   }
 }

--- a/RecoParticleFlow/PFClusterProducer/src/SimpleArborClusterizer.h
+++ b/RecoParticleFlow/PFClusterProducer/src/SimpleArborClusterizer.h
@@ -11,6 +11,7 @@ class SimpleArborClusterizer : public InitialClusteringStepBase {
     InitialClusteringStepBase(conf),
       _cellSize(conf.getParameter<double>("cellSize")),
       _layerThickness(conf.getParameter<double>("layerThickness")),
+      _distSeedForMerge(conf.getParameter<double>("distSeedForMerge")),
       _killNoiseClusters(conf.getParameter<bool>("killNoiseClusters")),
       _maxNoiseClusterSize(conf.getParameter<unsigned>("maxNoiseClusterSize")) { }
   virtual ~SimpleArborClusterizer() {}
@@ -23,7 +24,7 @@ class SimpleArborClusterizer : public InitialClusteringStepBase {
 		     reco::PFClusterCollection&);
   
  private:  
-  double _cellSize,_layerThickness;
+  double _cellSize,_layerThickness,_distSeedForMerge;
   bool _killNoiseClusters;
   unsigned _maxNoiseClusterSize;
 };

--- a/RecoParticleFlow/PFClusterProducer/test/hgcal_rechits.fwc
+++ b/RecoParticleFlow/PFClusterProducer/test/hgcal_rechits.fwc
@@ -482,7 +482,7 @@
      <string>1009</string>
    </config>
    <config name="isVisible" version="0">
-     <string>t</string>
+     <string>f</string>
    </config>
    <config name="layer" version="0">
      <string>26</string>
@@ -516,7 +516,7 @@
      <string>1011</string>
    </config>
    <config name="isVisible" version="0">
-     <string>t</string>
+     <string>f</string>
    </config>
    <config name="layer" version="0">
      <string>27</string>
@@ -550,7 +550,7 @@
      <string>1014</string>
    </config>
    <config name="isVisible" version="0">
-     <string>t</string>
+     <string>f</string>
    </config>
    <config name="layer" version="0">
      <string>28</string>
@@ -784,10 +784,10 @@
  <config name="GUI" version="1">
   <config name="main window" version="3">
    <config name="x" version="0">
-     <string>92</string>
+     <string>54</string>
    </config>
    <config name="y" version="0">
-     <string>44</string>
+     <string>31</string>
    </config>
    <config name="width" version="0">
      <string>1263</string>

--- a/RecoParticleFlow/PFClusterProducer/test/run_display.sh
+++ b/RecoParticleFlow/PFClusterProducer/test/run_display.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cmsShow -c ${CMSSW_BASE}/src/RecoParticleFlow/PFClusterProducer/test/hgcal_rechits.fwc -g /afs/cern.ch/user/l/lgray/work/public/xHGCAL/cmsRecoGeom1-HGCAL.root --sim-geom-file /afs/cern.ch/user/l/lgray/work/public/xHGCAL/cmsSimGeom-14-HGCAL.root /afs/cern.ch/user/l/lgray/work/public/CMSSW_6_2_X_SLHC_2014-07-07-0200/src/matrix_tests/simple_jet_gun/step3.root
+cmsShow -c ${CMSSW_BASE}/src/RecoParticleFlow/PFClusterProducer/test/hgcal_rechits.fwc -g /afs/cern.ch/user/l/lgray/work/public/xHGCAL/cmsRecoGeom1-HGCAL.root --sim-geom-file /afs/cern.ch/user/l/lgray/work/public/xHGCAL/cmsSimGeom-14-HGCAL.root /afs/cern.ch/user/l/lgray/work/public/CMSSW_6_2_X_SLHC_2014-07-07-0200/src/matrix_tests/14846_MinBias_TuneZ2star_14TeV+MinBias_TuneZ2star_14TeV_pythia6_Extended2023HGCalV4_GenSimFull+DigiFull_Extended2023HGCalV4+RecoFull_Extended2023HGCalV4+HARVESTFull_Extended2023HGCalV4/step3.root
 
 #12202_SinglePionPt35+SinglePionPt35_Extended2023HGCalMuon_GenSimFull+DigiFull_Extended2023HGCalMuon+RecoFull_Extended2023HGCalMuon+HARVESTFull_Extended2023HGCalMuon
 

--- a/RecoParticleFlow/PFClusterProducer/test/run_display.sh
+++ b/RecoParticleFlow/PFClusterProducer/test/run_display.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cmsShow -c ${CMSSW_BASE}/src/RecoParticleFlow/PFClusterProducer/test/hgcal_rechits.fwc -g /afs/cern.ch/user/l/lgray/work/public/xHGCAL/cmsRecoGeom1-HGCAL.root --sim-geom-file /afs/cern.ch/user/l/lgray/work/public/xHGCAL/cmsSimGeom-14-HGCAL.root /afs/cern.ch/user/l/lgray/work/public/CMSSW_6_2_X_SLHC_2014-07-07-0200/src/matrix_tests/14846_MinBias_TuneZ2star_14TeV+MinBias_TuneZ2star_14TeV_pythia6_Extended2023HGCalV4_GenSimFull+DigiFull_Extended2023HGCalV4+RecoFull_Extended2023HGCalV4+HARVESTFull_Extended2023HGCalV4/step3.root
+cmsShow -c ${CMSSW_BASE}/src/RecoParticleFlow/PFClusterProducer/test/hgcal_rechits.fwc -g /afs/cern.ch/user/l/lgray/work/public/xHGCAL/cmsRecoGeom1-HGCAL.root --sim-geom-file /afs/cern.ch/user/l/lgray/work/public/xHGCAL/cmsSimGeom-14-HGCAL.root /afs/cern.ch/user/l/lgray/work/public/CMSSW_6_2_X_SLHC_2014-07-07-0200/src/matrix_tests/simple_jet_gun/step3.root
 
 #12202_SinglePionPt35+SinglePionPt35_Extended2023HGCalMuon_GenSimFull+DigiFull_Extended2023HGCalMuon+RecoFull_Extended2023HGCalMuon+HARVESTFull_Extended2023HGCalMuon
 

--- a/RecoParticleFlow/PFClusterProducer/test/run_display.sh
+++ b/RecoParticleFlow/PFClusterProducer/test/run_display.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cmsShow -c ${CMSSW_BASE}/src/RecoParticleFlow/PFClusterProducer/test/hgcal_rechits.fwc -g /afs/cern.ch/user/l/lgray/work/public/xHGCAL/cmsRecoGeom1-HGCAL.root --sim-geom-file /afs/cern.ch/user/l/lgray/work/public/xHGCAL/cmsSimGeom-14-HGCAL.root /afs/cern.ch/user/l/lgray/work/public/CMSSW_6_2_X_SLHC_2014-07-07-0200/src/matrix_tests/14800_FourMuPt1_200+FourMuPt_1_200_Extended2023HGCalV4_GenSimFull+DigiFull_Extended2023HGCalV4+RecoFull_Extended2023HGCalV4+HARVESTFull_Extended2023HGCalV4/step3.root
+cmsShow -c ${CMSSW_BASE}/src/RecoParticleFlow/PFClusterProducer/test/hgcal_rechits.fwc -g /afs/cern.ch/user/l/lgray/work/public/xHGCAL/cmsRecoGeom1-HGCAL.root --sim-geom-file /afs/cern.ch/user/l/lgray/work/public/xHGCAL/cmsSimGeom-14-HGCAL.root /afs/cern.ch/user/l/lgray/work/public/CMSSW_6_2_X_SLHC_2014-07-07-0200/src/matrix_tests/simple_jet_gun/step3.root
 
 #12202_SinglePionPt35+SinglePionPt35_Extended2023HGCalMuon_GenSimFull+DigiFull_Extended2023HGCalMuon+RecoFull_Extended2023HGCalMuon+HARVESTFull_Extended2023HGCalMuon
 

--- a/RecoParticleFlow/PFClusterProducer/test/run_display.sh
+++ b/RecoParticleFlow/PFClusterProducer/test/run_display.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cmsShow -c ${CMSSW_BASE}/src/RecoParticleFlow/PFClusterProducer/test/hgcal_rechits.fwc -g /afs/cern.ch/user/l/lgray/work/public/xHGCAL/cmsRecoGeom1-HGCAL.root --sim-geom-file /afs/cern.ch/user/l/lgray/work/public/xHGCAL/cmsSimGeom-14-HGCAL.root /afs/cern.ch/user/l/lgray/work/public/CMSSW_6_2_X_SLHC_2014-07-07-0200/src/matrix_tests/simple_jet_gun/step3.root
+cmsShow -c ${CMSSW_BASE}/src/RecoParticleFlow/PFClusterProducer/test/hgcal_rechits.fwc -g /afs/cern.ch/user/l/lgray/work/public/xHGCAL/cmsRecoGeom1-HGCAL.root --sim-geom-file /afs/cern.ch/user/l/lgray/work/public/xHGCAL/cmsSimGeom-14-HGCAL.root /afs/cern.ch/user/l/lgray/work/public/CMSSW_6_2_X_SLHC_2014-07-07-0200/src/matrix_tests/14800_FourMuPt1_200+FourMuPt_1_200_Extended2023HGCalV4_GenSimFull+DigiFull_Extended2023HGCalV4+RecoFull_Extended2023HGCalV4+HARVESTFull_Extended2023HGCalV4/step3.root
 
 #12202_SinglePionPt35+SinglePionPt35_Extended2023HGCalMuon_GenSimFull+DigiFull_Extended2023HGCalMuon+RecoFull_Extended2023HGCalMuon+HARVESTFull_Extended2023HGCalMuon
 

--- a/RecoParticleFlow/PFClusterProducer/test/run_display.sh
+++ b/RecoParticleFlow/PFClusterProducer/test/run_display.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cmsShow -c ${CMSSW_BASE}/src/RecoParticleFlow/PFClusterProducer/test/hgcal_rechits.fwc -g /afs/cern.ch/user/l/lgray/work/public/xHGCAL/cmsRecoGeom1-HGCAL.root --sim-geom-file /afs/cern.ch/user/l/lgray/work/public/xHGCAL/cmsSimGeom-14-HGCAL.root /afs/cern.ch/user/l/lgray/work/public/CMSSW_6_2_X_SLHC_2014-07-07-0200/src/matrix_tests/simple_jet_gun/step3.root
+cmsShow -c ${CMSSW_BASE}/src/RecoParticleFlow/PFClusterProducer/test/hgcal_rechits.fwc -g /afs/cern.ch/user/l/lgray/work/public/xHGCAL/cmsRecoGeom1-HGCAL.root --sim-geom-file /afs/cern.ch/user/l/lgray/work/public/xHGCAL/cmsSimGeom-14-HGCAL.root /afs/cern.ch/user/l/lgray/work/public/CMSSW_6_2_X_SLHC_2014-07-17-0200/src/matrix_tests/14832_Wjet_Pt_80_120_14TeV+Wjet_Pt_80_120_14TeV_Extended2023HGCalV4_GenSimFull+DigiFull_Extended2023HGCalV4+RecoFull_Extended2023HGCalV4+HARVESTFull_Extended2023HGCalV4/step3.root
 
 #12202_SinglePionPt35+SinglePionPt35_Extended2023HGCalMuon_GenSimFull+DigiFull_Extended2023HGCalMuon+RecoFull_Extended2023HGCalMuon+HARVESTFull_Extended2023HGCalMuon
 

--- a/RecoParticleFlow/PFClusterProducer/test/run_display.sh
+++ b/RecoParticleFlow/PFClusterProducer/test/run_display.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cmsShow -c ${CMSSW_BASE}/src/RecoParticleFlow/PFClusterProducer/test/hgcal_rechits.fwc -g /afs/cern.ch/user/l/lgray/work/public/xHGCAL/cmsRecoGeom1-HGCAL.root --sim-geom-file /afs/cern.ch/user/l/lgray/work/public/xHGCAL/cmsSimGeom-14-HGCAL.root /afs/cern.ch/user/l/lgray/work/public/CMSSW_6_2_X_SLHC_2014-07-17-0200/src/matrix_tests/14832_Wjet_Pt_80_120_14TeV+Wjet_Pt_80_120_14TeV_Extended2023HGCalV4_GenSimFull+DigiFull_Extended2023HGCalV4+RecoFull_Extended2023HGCalV4+HARVESTFull_Extended2023HGCalV4/step3.root
+cmsShow -c ${CMSSW_BASE}/src/RecoParticleFlow/PFClusterProducer/test/hgcal_rechits.fwc -g /afs/cern.ch/user/l/lgray/work/public/xHGCAL/cmsRecoGeom1-HGCAL.root --sim-geom-file /afs/cern.ch/user/l/lgray/work/public/xHGCAL/cmsSimGeom-14-HGCAL.root /afs/cern.ch/user/l/lgray/work/public/CMSSW_6_2_X_SLHC_2014-07-17-0200/src/matrix_tests/simple_jet_gun/step3.root
 
 #12202_SinglePionPt35+SinglePionPt35_Extended2023HGCalMuon_GenSimFull+DigiFull_Extended2023HGCalMuon+RecoFull_Extended2023HGCalMuon+HARVESTFull_Extended2023HGCalMuon
 

--- a/RecoParticleFlow/PFProducer/plugins/importers/ECALClusterImporter.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/ECALClusterImporter.cc
@@ -12,6 +12,7 @@
 // of their own (like electron seeds or photons)
 // otherwise ECAL <-> ECAL linking will not work correctly
 
+template<reco::PFBlockElement::Type the_type> 
 class ECALClusterImporter : public BlockElementImporterBase {
 public:
   ECALClusterImporter(const edm::ParameterSet& conf,
@@ -26,11 +27,10 @@ private:
   edm::EDGetTokenT<reco::PFClusterCollection> _src;
 };
 
-DEFINE_EDM_PLUGIN(BlockElementImporterFactory, 
-		  ECALClusterImporter, 
-		  "ECALClusterImporter");
 
-void ECALClusterImporter::
+
+template<reco::PFBlockElement::Type the_type> 
+void ECALClusterImporter<the_type>::
 importToBlock( const edm::Event& e, 
 	       BlockElementImporterBase::ElementList& elems ) const {
   BlockElementImporterBase::ElementList ecals;
@@ -48,7 +48,7 @@ importToBlock( const edm::Event& e,
   for( auto clus = bclus; clus != eclus; ++clus  ) {    
     reco::PFClusterRef tempref(clusters, std::distance(bclus,clus));
     reco::PFBlockElementCluster* newelem = 
-      new reco::PFBlockElementCluster(tempref,reco::PFBlockElement::ECAL);
+      new reco::PFBlockElementCluster(tempref,the_type);
     for( auto scelem = elems.begin(); scelem != sc_end; ++scelem ) {
       const reco::PFBlockElementSuperCluster* elem_as_sc =
 	static_cast<const reco::PFBlockElementSuperCluster*>(scelem->get());
@@ -67,3 +67,11 @@ importToBlock( const edm::Event& e,
     elems.emplace_back(ecal.release());
   }
 }
+
+DEFINE_EDM_PLUGIN(BlockElementImporterFactory, 
+		  ECALClusterImporter<reco::PFBlockElement::ECAL>, 
+		  "ECALClusterImporter");
+
+DEFINE_EDM_PLUGIN(BlockElementImporterFactory, 
+		  ECALClusterImporter<reco::PFBlockElement::HGC_ECAL>, 
+		  "HGCECALClusterImporter");

--- a/RecoParticleFlow/PFProducer/plugins/kdtrees/KDTreeLinkerTrackHGC.cc
+++ b/RecoParticleFlow/PFProducer/plugins/kdtrees/KDTreeLinkerTrackHGC.cc
@@ -1,8 +1,8 @@
 #include "KDTreeLinkerTrackHGC.h"
 
-typedef KDTreeLinkerTrackHGC<reco::PFTrajectoryPoint::HGC_ECALEntrance> KDTreeTrackAndHGCEELinker;
-typedef KDTreeLinkerTrackHGC<reco::PFTrajectoryPoint::HGC_HCALFEntrance> KDTreeTrackAndHGCHEFLinker;
-typedef KDTreeLinkerTrackHGC<reco::PFTrajectoryPoint::HGC_HCALBEntrance> KDTreeTrackAndHGCHEBLinker;
+typedef KDTreeLinkerTrackHGC<reco::PFTrajectoryPoint::HGC_ECALEntrance,2> KDTreeTrackAndHGCEELinker;
+typedef KDTreeLinkerTrackHGC<reco::PFTrajectoryPoint::HGC_HCALFEntrance,2> KDTreeTrackAndHGCHEFLinker;
+typedef KDTreeLinkerTrackHGC<reco::PFTrajectoryPoint::HGC_HCALBEntrance,2> KDTreeTrackAndHGCHEBLinker;
 
 DEFINE_EDM_PLUGIN(KDTreeLinkerFactory, 
 		  KDTreeTrackAndHGCEELinker, 

--- a/RecoParticleFlow/PFProducer/plugins/kdtrees/KDTreeLinkerTrackHGC.h
+++ b/RecoParticleFlow/PFProducer/plugins/kdtrees/KDTreeLinkerTrackHGC.h
@@ -13,7 +13,7 @@
 // This class is used to find all links between Tracks and ECAL clusters
 // using a KDTree algorithm.
 // It is used in PFBlockAlgo.cc in the function links().
-template<reco::PFTrajectoryPoint::LayerType the_layer>
+template<reco::PFTrajectoryPoint::LayerType the_layer,unsigned RHscaling>
 class KDTreeLinkerTrackHGC : public KDTreeLinkerBase
 {
  public:
@@ -63,30 +63,30 @@ class KDTreeLinkerTrackHGC : public KDTreeLinkerBase
 
 };
 
-template<reco::PFTrajectoryPoint::LayerType the_layer>
-KDTreeLinkerTrackHGC<the_layer>::KDTreeLinkerTrackHGC()
+template<reco::PFTrajectoryPoint::LayerType the_layer,unsigned RHscaling>
+  KDTreeLinkerTrackHGC<the_layer,RHscaling>::KDTreeLinkerTrackHGC()
   : KDTreeLinkerBase()
 {}
 
-template<reco::PFTrajectoryPoint::LayerType the_layer>
-KDTreeLinkerTrackHGC<the_layer>::~KDTreeLinkerTrackHGC()
+template<reco::PFTrajectoryPoint::LayerType the_layer,unsigned RHscaling>
+KDTreeLinkerTrackHGC<the_layer,RHscaling>::~KDTreeLinkerTrackHGC()
 {
   clear();
 }
 
 
-template<reco::PFTrajectoryPoint::LayerType the_layer>
+template<reco::PFTrajectoryPoint::LayerType the_layer,unsigned RHscaling>
 void
-KDTreeLinkerTrackHGC<the_layer>::insertTargetElt(reco::PFBlockElement	*track)
+KDTreeLinkerTrackHGC<the_layer,RHscaling>::insertTargetElt(reco::PFBlockElement	*track)
 {
   if( track->trackRefPF()->extrapolatedPoint( the_layer ).isValid() ) {
     targetSet_.insert(track);
   }
 }
 
-template<reco::PFTrajectoryPoint::LayerType the_layer>
+template<reco::PFTrajectoryPoint::LayerType the_layer,unsigned RHscaling>
 void
-KDTreeLinkerTrackHGC<the_layer>::insertFieldClusterElt(reco::PFBlockElement	*hgcCluster)
+KDTreeLinkerTrackHGC<the_layer,RHscaling>::insertFieldClusterElt(reco::PFBlockElement	*hgcCluster)
 {
   reco::PFClusterRef clusterref = hgcCluster->clusterRef();
 
@@ -151,9 +151,9 @@ KDTreeLinkerTrackHGC<the_layer>::insertFieldClusterElt(reco::PFBlockElement	*hgc
   }
 }
 
-template<reco::PFTrajectoryPoint::LayerType the_layer>
+template<reco::PFTrajectoryPoint::LayerType the_layer,unsigned RHscaling>
 void 
-KDTreeLinkerTrackHGC<the_layer>::buildTree()
+  KDTreeLinkerTrackHGC<the_layer,RHscaling>::buildTree()
 {
   // List of pseudo-rechits that will be used to create the KDTree
   std::vector<KDTreeNodeInfo> eltList;
@@ -193,9 +193,9 @@ KDTreeLinkerTrackHGC<the_layer>::buildTree()
   tree_.build(eltList, region);
 }
 
-template<reco::PFTrajectoryPoint::LayerType the_layer>
+template<reco::PFTrajectoryPoint::LayerType the_layer,unsigned RHscaling>
 void
-KDTreeLinkerTrackHGC<the_layer>::searchLinks()
+  KDTreeLinkerTrackHGC<the_layer,RHscaling>::searchLinks()
 {
   // Must of the code has been taken from LinkByRecHit.cc
   //std::cout << "running searchLinks() for : " << the_layer 
@@ -274,16 +274,16 @@ KDTreeLinkerTrackHGC<the_layer>::searchLinks()
 	
 	reco::PFClusterRef clusterref = (*clusterIt)->clusterRef();
 	//double clusterz = clusterref->position().Z();
-	int fracsNbr = clusterref->recHitFractions().size();
+	//int fracsNbr = clusterref->recHitFractions().size();
 
 	double x[5];
 	double y[5];
 	for ( unsigned jc=0; jc<4; ++jc ) {
 	  math::XYZPoint cornerposxyz = cornersxyz[jc];
 	  x[jc] = cornerposxyz.X() + (cornerposxyz.X()-posxyz.X())
-	    * (1.00+0.50/fracsNbr /std::min(1.,0.5*trackPt));
+	    * (1.00+RHscaling/(0.1*trackPt));
 	  y[jc] = cornerposxyz.Y() + (cornerposxyz.Y()-posxyz.Y())
-	    * (1.00+0.50/fracsNbr /std::min(1.,0.5*trackPt));
+	    * (1.00+RHscaling/(0.1*trackPt));
 	  //std::cout << "hit corner x/y/z: " << cornerposxyz << std::endl;
 	}
 	
@@ -307,9 +307,9 @@ KDTreeLinkerTrackHGC<the_layer>::searchLinks()
 }
 
 
-template<reco::PFTrajectoryPoint::LayerType the_layer>
+template<reco::PFTrajectoryPoint::LayerType the_layer,unsigned RHscaling>
 void
-KDTreeLinkerTrackHGC<the_layer>::updatePFBlockEltWithLinks()
+KDTreeLinkerTrackHGC<the_layer,RHscaling>::updatePFBlockEltWithLinks()
 {
   //TODO YG : Check if cluster positionREP() is valid ?
 
@@ -331,9 +331,9 @@ KDTreeLinkerTrackHGC<the_layer>::updatePFBlockEltWithLinks()
   }
 }
 
-template<reco::PFTrajectoryPoint::LayerType the_layer>
+template<reco::PFTrajectoryPoint::LayerType the_layer,unsigned RHscaling>
 void
-KDTreeLinkerTrackHGC<the_layer>::clear()
+KDTreeLinkerTrackHGC<the_layer,RHscaling>::clear()
 {
   targetSet_.clear();
   fieldClusterSet_.clear();

--- a/RecoParticleFlow/PFProducer/plugins/linkers/SCAndECALLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/linkers/SCAndECALLinker.cc
@@ -31,13 +31,14 @@ double SCAndECALLinker::testLink
   double dist = -1.0;  
   const reco::PFBlockElementCluster* ecalelem(NULL);    
   const reco::PFBlockElementSuperCluster* scelem(NULL); 
-  if( elem1->type() < elem2->type() ) {
-    ecalelem = static_cast<const reco::PFBlockElementCluster*>(elem1);
-    scelem = static_cast<const reco::PFBlockElementSuperCluster*>(elem2);
+  if( elem1->type() == reco::PFBlockElement::ECAL || 
+      elem1->type() == reco::PFBlockElement::HGC_ECAL ) {
+     ecalelem = static_cast<const reco::PFBlockElementCluster*>(elem1);
+     scelem = static_cast<const reco::PFBlockElementSuperCluster*>(elem2);
   } else {
     ecalelem = static_cast<const reco::PFBlockElementCluster*>(elem2);
     scelem = static_cast<const reco::PFBlockElementSuperCluster*>(elem1);
-  }
+  }  
   const reco::PFClusterRef& clus = ecalelem->clusterRef();
   const reco::SuperClusterRef& sclus = scelem->superClusterRef();
   if( sclus.isNull() ) {

--- a/RecoParticleFlow/PFProducer/src/PFBlockAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFBlockAlgo.cc
@@ -129,13 +129,13 @@ PFBlockAlgo::findBlocks() {
     ie = associate(elements_, links, blocks_->back());    
     
     packLinks( blocks_->back(), links );
-    /*
+    
     if( blocks_->back().elements().size() > 1 ) {
       std::cout << blocks_->back() << std::endl;
     }
-    */
+    
   }
-  //std::cout << "(new) Found " << blocks_->size() << " PFBlocks!" << std::endl;
+  std::cout << "(new) Found " << blocks_->size() << " PFBlocks!" << std::endl;
 }
 
 // start from first element in elements_

--- a/RecoParticleFlow/PFProducer/src/PFBlockAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFBlockAlgo.cc
@@ -129,11 +129,11 @@ PFBlockAlgo::findBlocks() {
     ie = associate(elements_, links, blocks_->back());    
     
     packLinks( blocks_->back(), links );
-    
+    /*
     if( blocks_->back().elements().size() > 1 ) {
       std::cout << blocks_->back() << std::endl;
     }
-    
+    */    
   }
   std::cout << "(new) Found " << blocks_->size() << " PFBlocks!" << std::endl;
 }

--- a/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
@@ -177,6 +177,14 @@ def cust_2023HGCal(process):
         process.mix.digitizers.hgceeDigitizer=process.hgceeDigitizer
         process.mix.digitizers.hgchebackDigitizer=process.hgchebackDigitizer
         process.mix.digitizers.hgchefrontDigitizer=process.hgchefrontDigitizer
+        # Also need to tell the MixingModule to make the correct collections available from
+        # the pileup, even if not creating CrossingFrames.
+        process.mix.mixObjects.mixCH.input.append( cms.InputTag("g4SimHits",process.hgceeDigitizer.hitCollection.value()) )
+        process.mix.mixObjects.mixCH.input.append( cms.InputTag("g4SimHits",process.hgchebackDigitizer.hitCollection.value()) )
+        process.mix.mixObjects.mixCH.input.append( cms.InputTag("g4SimHits",process.hgchefrontDigitizer.hitCollection.value()) )
+        process.mix.mixObjects.mixCH.subdets.append( process.hgceeDigitizer.hitCollection.value() )
+        process.mix.mixObjects.mixCH.subdets.append( process.hgchebackDigitizer.hitCollection.value() )
+        process.mix.mixObjects.mixCH.subdets.append( process.hgchefrontDigitizer.hitCollection.value() )
     if hasattr(process,'reconstruction_step'):
         process.particleFlowCluster += process.particleFlowRecHitHGC
         process.particleFlowCluster += process.particleFlowClusterHGC
@@ -232,6 +240,14 @@ def cust_2023HGCalMuon(process):
         process.mix.digitizers.hgceeDigitizer=process.hgceeDigitizer
         process.mix.digitizers.hgchebackDigitizer=process.hgchebackDigitizer
         process.mix.digitizers.hgchefrontDigitizer=process.hgchefrontDigitizer
+        # Also need to tell the MixingModule to make the correct collections available from
+        # the pileup, even if not creating CrossingFrames.
+        process.mix.mixObjects.mixCH.input.append( cms.InputTag("g4SimHits",process.hgceeDigitizer.hitCollection.value()) )
+        process.mix.mixObjects.mixCH.input.append( cms.InputTag("g4SimHits",process.hgchebackDigitizer.hitCollection.value()) )
+        process.mix.mixObjects.mixCH.input.append( cms.InputTag("g4SimHits",process.hgchefrontDigitizer.hitCollection.value()) )
+        process.mix.mixObjects.mixCH.subdets.append( process.hgceeDigitizer.hitCollection.value() )
+        process.mix.mixObjects.mixCH.subdets.append( process.hgchebackDigitizer.hitCollection.value() )
+        process.mix.mixObjects.mixCH.subdets.append( process.hgchefrontDigitizer.hitCollection.value() )
     if hasattr(process,'reconstruction_step'):
         process.particleFlowCluster += process.particleFlowRecHitHGC
         process.particleFlowCluster += process.particleFlowClusterHGC

--- a/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
@@ -189,7 +189,7 @@ def cust_2023HGCal(process):
             if hasattr(process,'ecalDrivenElectronSeeds'):
                 process.ecalDrivenElectronSeeds.endcapSuperClusters = cms.InputTag('particleFlowSuperClusterHGCEE')
         if hasattr(process,'particleFlowBlock'):
-            process.particleFlowBlock.elementImporters.append( cms.PSet( importerName = cms.string('GenericClusterImporter'),
+            process.particleFlowBlock.elementImporters.append( cms.PSet( importerName = cms.string('HGCECALClusterImporter'),
                                                                          source = cms.InputTag('particleFlowClusterHGCEE') ) )
             process.particleFlowBlock.elementImporters.append( cms.PSet( importerName = cms.string('GenericClusterImporter'),
                                                                          source = cms.InputTag('particleFlowClusterHGCHEF') ) )
@@ -204,6 +204,10 @@ def cust_2023HGCal(process):
             process.particleFlowBlock.linkDefinitions.append( cms.PSet( linkerName = cms.string('TrackAndHGCHEBLinker'),
                                                                         linkType = cms.string('TRACK:HGC_HCALB'),
                                                                         useKDTree = cms.bool(True) ) )
+            process.particleFlowBlock.linkDefinitions.append( cms.PSet( linkType = cms.string('SC:HGC_ECAL'),
+                                                                        SuperClusterMatchByRef = cms.bool(True),
+                                                                        useKDTree = cms.bool(False),
+                                                                        linkerName = cms.string('SCAndECALLinker') ) ) 
     #mod event content
     process.load('RecoLocalCalo.Configuration.hgcalLocalReco_EventContent_cff')
     if hasattr(process,'FEVTDEBUGHLTEventContent'):
@@ -240,7 +244,7 @@ def cust_2023HGCalMuon(process):
             if hasattr(process,'ecalDrivenElectronSeeds'):
                 process.ecalDrivenElectronSeeds.endcapSuperClusters = cms.InputTag('particleFlowSuperClusterHGCEE')
         if hasattr(process,'particleFlowBlock'):
-            process.particleFlowBlock.elementImporters.append( cms.PSet( importerName = cms.string('GenericClusterImporter'),
+            process.particleFlowBlock.elementImporters.append( cms.PSet( importerName = cms.string('HGCECALClusterImporter'),
                                                                          source = cms.InputTag('particleFlowClusterHGCEE') ) )
             process.particleFlowBlock.elementImporters.append( cms.PSet( importerName = cms.string('GenericClusterImporter'),
                                                                          source = cms.InputTag('particleFlowClusterHGCHEF') ) )
@@ -255,6 +259,11 @@ def cust_2023HGCalMuon(process):
             process.particleFlowBlock.linkDefinitions.append( cms.PSet( linkerName = cms.string('TrackAndHGCHEBLinker'),
                                                                         linkType = cms.string('TRACK:HGC_HCALB'),
                                                                         useKDTree = cms.bool(True) ) )
+            process.particleFlowBlock.linkDefinitions.append( cms.PSet( linkType = cms.string('SC:HGC_ECAL'),
+                                                                        SuperClusterMatchByRef = cms.bool(True),
+                                                                        useKDTree = cms.bool(False),
+                                                                        linkerName = cms.string('SCAndECALLinker') ) )
+            
     #mod event content
     process.load('RecoLocalCalo.Configuration.hgcalLocalReco_EventContent_cff')
     if hasattr(process,'FEVTDEBUGHLTEventContent'):

--- a/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
@@ -194,8 +194,8 @@ def cust_2023HGCal(process):
             process.particleFlowSuperClusterHGCEE.use_preshower = cms.bool(False)
             process.particleFlowSuperClusterHGCEE.PFSuperClusterCollectionEndcapWithPreshower = cms.string('')
             process.particleFlowCluster += process.particleFlowSuperClusterHGCEE
-            if hasattr(process,'ecalDrivenElectronSeeds'):
-                process.ecalDrivenElectronSeeds.endcapSuperClusters = cms.InputTag('particleFlowSuperClusterHGCEE')
+            #if hasattr(process,'ecalDrivenElectronSeeds'):
+            #    process.ecalDrivenElectronSeeds.endcapSuperClusters = cms.InputTag('particleFlowSuperClusterHGCEE')
         if hasattr(process,'particleFlowBlock'):
             process.particleFlowBlock.elementImporters.append( cms.PSet( importerName = cms.string('HGCECALClusterImporter'),
                                                                          source = cms.InputTag('particleFlowClusterHGCEE') ) )
@@ -257,8 +257,8 @@ def cust_2023HGCalMuon(process):
             process.particleFlowSuperClusterHGCEE.use_preshower = cms.bool(False)
             process.particleFlowSuperClusterHGCEE.PFSuperClusterCollectionEndcapWithPreshower = cms.string('')
             process.particleFlowCluster += process.particleFlowSuperClusterHGCEE
-            if hasattr(process,'ecalDrivenElectronSeeds'):
-                process.ecalDrivenElectronSeeds.endcapSuperClusters = cms.InputTag('particleFlowSuperClusterHGCEE')
+            #if hasattr(process,'ecalDrivenElectronSeeds'):
+            #    process.ecalDrivenElectronSeeds.endcapSuperClusters = cms.InputTag('particleFlowSuperClusterHGCEE')
         if hasattr(process,'particleFlowBlock'):
             process.particleFlowBlock.elementImporters.append( cms.PSet( importerName = cms.string('HGCECALClusterImporter'),
                                                                          source = cms.InputTag('particleFlowClusterHGCEE') ) )


### PR DESCRIPTION
Clustering memory footprint reduced by multiple gigabytes, clustering itself now causes little memory blow-up, O(100 MB) or so, down from 3/4 gigabytes from using a dense matrix.
Clustering timing improved by a factor of ~100, i.e.  hour/event -> 30s/event spent on clustering.
Clustering performance appears the same looking at a limited number of events. EM clusters are formed correctly, charged pions look fine, simple jet gun multi-particle response is as before. 
No changes in energies.

With DQM the event time in TTBar + 140 PU is at ~5 minutes per event. 
Is this OK for now?

NB: I had to turn off the gsf electron tracking since there's no notion of preselection for the HGC clusters. This was causing the electron seeding and track fitting to run very slowly.

@vandreev11 @pfs @amagnan @bsunanda
