### PR TITLE
Add CFPosition to pixelDigSimLinks; use in hitAssociator

### DIFF
--- a/SimDataFormats/TrackerDigiSimLink/interface/PixelDigiSimLink.h
+++ b/SimDataFormats/TrackerDigiSimLink/interface/PixelDigiSimLink.h
@@ -7,20 +7,33 @@
 //typedef std::pair<unsigned int ,unsigned int > PixelDigiSimLink;
 class PixelDigiSimLink {
 public:
+  enum {LowTof, HighTof};
+
+  PixelDigiSimLink(unsigned int ch, unsigned int tkId, unsigned int counter, unsigned int tofBin, EncodedEventId e, float a ){
+    chan=ch;
+    simTkId=tkId;
+    CFpos = tofBin == LowTof ? counter & 0x7FFFFFFF : (counter & 0x7FFFFFFF) | 0x80000000;
+    fract=a;
+    eId=e;
+  };
   PixelDigiSimLink(unsigned int ch, unsigned int tkId, EncodedEventId e, float a ){
     chan=ch;
     simTkId=tkId;
+    CFpos = 0;
     fract=a;
     eId=e;
   };
   PixelDigiSimLink():eId(0){
     chan=0;
     simTkId=0;
+    CFpos = 0;
     fract=0;
   };
   ~PixelDigiSimLink(){};
   unsigned int channel() const{return chan;};
   unsigned int SimTrackId() const{return simTkId;};
+  unsigned int CFposition()  const {return CFpos & 0x7FFFFFFF;}
+  unsigned int TofBin()      const {return (CFpos & 0x80000000) == 0 ? LowTof : HighTof;}
   EncodedEventId eventId() const{return eId;}
   float fraction() const{return fract;};
 
@@ -30,6 +43,8 @@ public:
  private:
   unsigned int chan;
   unsigned int simTkId;
+  uint32_t CFpos; // position of the PSimHit in the CrossingFrame vector
+             // for the subdetector collection; bit 31 set if from the HighTof collection
   EncodedEventId eId;
   float fract;
   };

--- a/SimDataFormats/TrackerDigiSimLink/src/classes_def.xml
+++ b/SimDataFormats/TrackerDigiSimLink/src/classes_def.xml
@@ -1,7 +1,8 @@
 <lcgdict>
 
-  <class name="PixelDigiSimLink" ClassVersion="10">
+  <class name="PixelDigiSimLink" ClassVersion="11">
    <version ClassVersion="10" checksum="408436386"/>
+   <version ClassVersion="11" checksum="3298015919"/>
   </class>
  <class name="edm::DetSet<PixelDigiSimLink>"/>
  <class name="std::vector<PixelDigiSimLink>"/>

--- a/SimTracker/Common/interface/SimHitInfoForLinks.h
+++ b/SimTracker/Common/interface/SimHitInfoForLinks.h
@@ -6,11 +6,15 @@
 
 // A stripped down version of PSimHit used to save memory.
 // Contains only the information needed to be make DigiSimLinks.
+// Include the simHit's index in the source collection, collection name suffix index.
 
   struct SimHitInfoForLinks {
-    explicit SimHitInfoForLinks(PSimHit const* hitp) : eventId_(hitp->eventId()), trackIds_(1, hitp->trackId()) {
+    explicit SimHitInfoForLinks(PSimHit const* hitp, size_t hitindex, unsigned int tofbin) :
+      eventId_(hitp->eventId()), trackIds_(1, hitp->trackId()), hitIndex_(hitindex), tofBin_(tofbin) {
     }
     EncodedEventId eventId_;
     std::vector<unsigned int> trackIds_;
+    size_t hitIndex_;
+    unsigned int tofBin_;
   };
 #endif

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.cc
@@ -122,11 +122,14 @@ namespace cms
   //
 
   void
-  SiPixelDigitizer::accumulatePixelHits(edm::Handle<std::vector<PSimHit> > hSimHits, const TrackerTopology *tTopo) {
+  SiPixelDigitizer::accumulatePixelHits(edm::Handle<std::vector<PSimHit> > hSimHits,
+					size_t globalSimHitIndex,
+					const unsigned int tofBin,
+					const TrackerTopology *tTopo) {
     if(hSimHits.isValid()) {
        std::set<unsigned int> detIds;
        std::vector<PSimHit> const& simHits = *hSimHits.product();
-       for(std::vector<PSimHit>::const_iterator it = simHits.begin(), itEnd = simHits.end(); it != itEnd; ++it) {
+       for(std::vector<PSimHit>::const_iterator it = simHits.begin(), itEnd = simHits.end(); it != itEnd; ++it, ++globalSimHitIndex) {
          unsigned int detId = (*it).detUnitId();
          if(detIds.insert(detId).second) {
            // The insert succeeded, so this detector element has not yet been processed.
@@ -137,8 +140,7 @@ namespace cms
              GlobalVector bfield = pSetup->inTesla(pixdet->surface().position());
              LogDebug ("PixelDigitizer ") << "B-field(T) at " << pixdet->surface().position() << "(cm): " 
                                           << pSetup->inTesla(pixdet->surface().position());
-
-             _pixeldigialgo->accumulateSimHits(it, itEnd, pixdet, bfield, tTopo);
+             _pixeldigialgo->accumulateSimHits(it, itEnd, globalSimHitIndex, tofBin, pixdet, bfield, tTopo);
            }
          }
        }
@@ -151,6 +153,12 @@ namespace cms
       _pixeldigialgo->init(iSetup);
       first = false;
     }
+    // Make sure that the first crossing processed starts indexing the sim hits from zero.
+    // This variable is used so that the sim hits from all crossing frames have sequential
+    // indices used to create the digi-sim link (if configured to do so) rather than starting
+    // from zero for each crossing.
+    crossingSimHitIndexOffset_.clear();
+
     _pixeldigialgo->initializeEvent();
     iSetup.get<TrackerDigiGeometryRecord>().get(geometryType, pDD);
     iSetup.get<IdealMagneticFieldRecord>().get(pSetup);
@@ -184,7 +192,14 @@ namespace cms
       edm::InputTag tag(hitsProducer, *i);
 
       iEvent.getByLabel(tag, simHits);
-      accumulatePixelHits(simHits, tTopo);
+      unsigned int tofBin = PixelDigiSimLink::LowTof;
+      if ((*i).find(std::string("HighTof")) != std::string::npos) tofBin = PixelDigiSimLink::HighTof;
+      accumulatePixelHits(simHits, crossingSimHitIndexOffset_[tag.encode()], tofBin, tTopo);
+      // Now that the hits have been processed, I'll add the amount of hits in this crossing on to
+      // the global counter. Next time accumulateStripHits() is called it will count the sim hits
+      // as though they were on the end of this collection.
+      // Note that this is only used for creating digi-sim links (if configured to do so).
+      if( simHits.isValid() ) crossingSimHitIndexOffset_[tag.encode()]+=simHits->size();
     }
   }
 
@@ -200,7 +215,14 @@ namespace cms
       edm::InputTag tag(hitsProducer, *i);
 
       iEvent.getByLabel(tag, simHits);
-      accumulatePixelHits(simHits,tTopo);
+      unsigned int tofBin = PixelDigiSimLink::LowTof;
+      if ((*i).find(std::string("HighTof")) != std::string::npos) tofBin = PixelDigiSimLink::HighTof;
+      accumulatePixelHits(simHits, crossingSimHitIndexOffset_[tag.encode()], tofBin, tTopo);
+      // Now that the hits have been processed, I'll add the amount of hits in this crossing on to
+      // the global counter. Next time accumulateStripHits() is called it will count the sim hits
+      // as though they were on the end of this collection.
+      // Note that this is only used for creating digi-sim links (if configured to do so).
+      if( simHits.isValid() ) crossingSimHitIndexOffset_[tag.encode()]+=simHits->size();
     }
   }
 

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.h
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.h
@@ -56,9 +56,22 @@ namespace cms {
 
     virtual void beginJob() {}
   private:
-    void accumulatePixelHits(edm::Handle<std::vector<PSimHit> >,const TrackerTopology *tTopo);   
+    void accumulatePixelHits(edm::Handle<std::vector<PSimHit> >,
+			     size_t globalSimHitIndex,
+			     const unsigned int tofBin,
+			     const TrackerTopology *tTopo);
     bool first;
     std::unique_ptr<SiPixelDigitizerAlgorithm>  _pixeldigialgo;
+    /** @brief Offset to add to the index of each sim hit to account for which crossing it's in.
+*
+* I need to know what each sim hit index will be when the hits from all crossing frames are merged into
+* one collection (assuming the MixingModule is configured to create the crossing frame for all sim hits).
+* To do this I'll record how many hits were in each crossing, and then add that on to the index for a given
+* hit in a given crossing. This assumes that the crossings are processed in the same order here as they are
+* put into the crossing frame, which I'm pretty sure is true.<br/>
+* The key is the name of the sim hit collection. */
+ std::map<std::string,size_t> crossingSimHitIndexOffset_;
+
     typedef std::vector<std::string> vstring;
     const std::string hitsProducer;
     const vstring trackerContainers;

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
@@ -485,14 +485,17 @@ SiPixelDigitizerAlgorithm::PixelAging::PixelAging(const edm::ParameterSet& conf,
 //
 void SiPixelDigitizerAlgorithm::accumulateSimHits(std::vector<PSimHit>::const_iterator inputBegin,
                                                   std::vector<PSimHit>::const_iterator inputEnd,
-                                                  const PixelGeomDetUnit* pixdet,
+						  const size_t inputBeginGlobalIndex,
+						  const unsigned int tofBin,
+						  const PixelGeomDetUnit* pixdet,
                                                   const GlobalVector& bfield, 
 						  const TrackerTopology* tTopo) {
     // produce SignalPoint's for all SimHit's in detector
     // Loop over hits
 
     uint32_t detId = pixdet->geographicalId().rawId();
-    for (std::vector<PSimHit>::const_iterator ssbegin = inputBegin; ssbegin != inputEnd; ++ssbegin) {
+    size_t simHitGlobalIndex=inputBeginGlobalIndex; // This needs to stored to create the digi-sim link later
+    for (std::vector<PSimHit>::const_iterator ssbegin = inputBegin; ssbegin != inputEnd; ++ssbegin, ++simHitGlobalIndex) {
       // skip hits not in this detector.
       if((*ssbegin).detUnitId() != detId) {
         continue;
@@ -518,7 +521,7 @@ void SiPixelDigitizerAlgorithm::accumulateSimHits(std::vector<PSimHit>::const_it
 	primary_ionization(*ssbegin, ionization_points); // fills _ionization_points
 	drift(*ssbegin, pixdet, bfield, tTopo, ionization_points, collection_points);  // transforms _ionization_points to collection_points
 	// compute induced signal on readout elements and add to _signal
-	induce_signal(*ssbegin, pixdet, collection_points); // *ihit needed only for SimHit<-->Digi link
+	induce_signal(*ssbegin, simHitGlobalIndex, tofBin, pixdet, collection_points); // 1st 3 args needed only for SimHit<-->Digi link
       } //  end if
     } // end for
 
@@ -881,6 +884,8 @@ void SiPixelDigitizerAlgorithm::drift(const PSimHit& hit,
 //*************************************************************************
 // Induce the signal on the collection plane of the active sensor area.
 void SiPixelDigitizerAlgorithm::induce_signal(const PSimHit& hit,
+					      const size_t hitIndex,
+					      const unsigned int tofBin,
 			                      const PixelGeomDetUnit* pixdet,
                                               const std::vector<SignalPoint>& collection_points) {
 
@@ -1095,7 +1100,7 @@ void SiPixelDigitizerAlgorithm::induce_signal(const PSimHit& hit,
   for ( hit_map_type::const_iterator im = hit_signal.begin();
 	im != hit_signal.end(); ++im) {
     int chan =  (*im).first;
-    theSignal[chan] += (makeDigiSimLinks_ ? Amplitude( (*im).second, &hit, (*im).second) : Amplitude( (*im).second, (*im).second) )  ;
+    theSignal[chan] += (makeDigiSimLinks_ ? Amplitude( (*im).second, &hit, hitIndex, tofBin, (*im).second) : Amplitude( (*im).second, (*im).second) )  ;
 
 #ifdef TP_DEBUG
     std::pair<int,int> ip = PixelDigi::channelToPixel(chan);
@@ -1207,7 +1212,7 @@ void SiPixelDigitizerAlgorithm::make_digis(float thePixelThresholdInE,
 	    }
 	    float fraction=sum_samechannel/(*i).second;
 	    if(fraction>1.) fraction=1.;
-	    simlinks.emplace_back((*i).first, (*simiiter).first, (*i).second.eventId(), fraction);
+	    simlinks.emplace_back((*i).first, (*simiiter).first, (*i).second.hitIndex(), (*i).second.tofBin(), (*i).second.eventId(), fraction);
 	  }
         }
       }

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.h
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.h
@@ -56,6 +56,8 @@ class SiPixelDigitizerAlgorithm  {
   //run the algorithm to digitize a single det
   void accumulateSimHits(const std::vector<PSimHit>::const_iterator inputBegin,
                          const std::vector<PSimHit>::const_iterator inputEnd,
+			 const size_t inputBeginGlobalIndex,
+			 const unsigned int tofBin,
                          const PixelGeomDetUnit *pixdet,
                          const GlobalVector& bfield,
 			 const TrackerTopology *tTopo);
@@ -92,8 +94,8 @@ class SiPixelDigitizerAlgorithm  {
       }
     }
 
-    Amplitude( float amp, const PSimHit* hitp, float frac) :
-      _amp(amp), _frac(1, frac), _hitInfo(new SimHitInfoForLinks(hitp)) {
+    Amplitude( float amp, const PSimHit* hitp, size_t hitIndex, unsigned int tofBin, float frac) :
+      _amp(amp), _frac(1, frac), _hitInfo(new SimHitInfoForLinks(hitp, hitIndex, tofBin) ) {
 
     //in case of digi from noisypixels
       //the MC information are removed 
@@ -131,6 +133,12 @@ class SiPixelDigitizerAlgorithm  {
    }
    const EncodedEventId& eventId() const {
      return _hitInfo->eventId_;
+   }
+   const unsigned int hitIndex() const {
+     return _hitInfo->hitIndex_;
+   }
+   const unsigned int tofBin() const {
+     return _hitInfo->tofBin_;
    }
     void operator+=( const float& amp) {
       _amp += amp;
@@ -371,6 +379,8 @@ class SiPixelDigitizerAlgorithm  {
                const std::vector<EnergyDepositUnit>& ionization_points,
                std::vector<SignalPoint>& collection_points) const;
     void induce_signal(const PSimHit& hit,
+		       const size_t hitIndex,
+		       const unsigned int tofBin,
                        const PixelGeomDetUnit *pixdet,
                        const std::vector<SignalPoint>& collection_points);
     void fluctuateEloss(int particleId, float momentum, float eloss, 

--- a/SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h
+++ b/SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h
@@ -77,7 +77,7 @@ class TrackerHitAssociator {
 
   std::vector<SimHitIdpr> associateMatchedRecHit(const SiStripMatchedRecHit2D * matchedrechit, std::vector<simhitAddr>* simhitCFPos=0) const;
   std::vector<SimHitIdpr> associateProjectedRecHit(const ProjectedSiStripRecHit2D * projectedrechit, std::vector<simhitAddr>* simhitCFPos=0) const;
-  void associatePixelRecHit(const SiPixelRecHit * pixelrechit, std::vector<SimHitIdpr> & simhitid) const;
+  void associatePixelRecHit(const SiPixelRecHit * pixelrechit, std::vector<SimHitIdpr> & simhitid, std::vector<simhitAddr>* simhitCFPos=0) const;
   std::vector<SimHitIdpr> associateGSRecHit(const SiTrackerGSRecHit2D * gsrechit) const;
   std::vector<SimHitIdpr> associateMultiRecHitId(const SiTrackerMultiRecHit * multirechit, std::vector<simhitAddr>* simhitCFPos=0) const;
   std::vector<PSimHit>    associateMultiRecHit(const SiTrackerMultiRecHit * multirechit) const;
@@ -96,7 +96,7 @@ class TrackerHitAssociator {
   edm::Handle< edm::DetSetVector<StripDigiSimLink> >  stripdigisimlink;
   edm::Handle< edm::DetSetVector<PixelDigiSimLink> >  pixeldigisimlink;
   
-  bool doPixel_, doStrip_, doTrackAssoc_;
+  bool doPixel_, doStrip_, doTrackAssoc_, assocHitbySimTrack_;
   
 };  
 

--- a/SimTracker/TrackerHitAssociation/src/TrackerHitAssociator.cc
+++ b/SimTracker/TrackerHitAssociation/src/TrackerHitAssociator.cc
@@ -26,7 +26,8 @@ using namespace edm;
 TrackerHitAssociator::TrackerHitAssociator(const edm::Event& e)  : 
   doPixel_( true ),
   doStrip_( true ), 
-  doTrackAssoc_( false ) {
+  doTrackAssoc_( false ),
+  assocHitbySimTrack_( false ) {
   //
   // Take by default all tracker SimHits
   //
@@ -56,8 +57,8 @@ TrackerHitAssociator::TrackerHitAssociator(const edm::Event& e)  :
 TrackerHitAssociator::TrackerHitAssociator(const edm::Event& e, const edm::ParameterSet& conf)  : 
   doPixel_( conf.getParameter<bool>("associatePixel") ),
   doStrip_( conf.getParameter<bool>("associateStrip") ),
-  doTrackAssoc_( conf.getParameter<bool>("associateRecoTracks") ),
-  assocHitbySimTrack_( conf.getUntrackedParameter<bool>("associateHitbySimTrack", false) ) {
+  doTrackAssoc_( conf.getParameter<bool>("associateRecoTracks") ) {
+  assocHitbySimTrack_ = conf.existsAs<bool>("associateHitbySimTrack") ? conf.getParameter<bool>("associateHitbySimTrack") : false;
   
   //if track association there is no need to access the input collections
   if(!doTrackAssoc_) {
@@ -186,8 +187,6 @@ std::vector<PSimHit> TrackerHitAssociator::associateHit(const TrackingRecHit & t
 	
       for(size_t i=0; i<simtrackid.size();i++) {
 	if(simHitid == simtrackid[i].first && simHiteid == simtrackid[i].second) {
-//      In replay mode the MixingModule doesn't seem to save the eventId.event(); test on bunchCrossing only.
-// 	if(simHitid == simtrackid[i].first && simHiteid.bunchCrossing() == simtrackid[i].second.bunchCrossing()) {
 // 	    	cout << "Associator ---> ID" << ihit.trackId() << " Simhit x= " << ihit.localPosition().x() 
 //                   << " y= " <<  ihit.localPosition().y() << " z= " <<  ihit.localPosition().x() << endl;
 	  // std::cout << " matches";

--- a/SimTracker/TrackerHitAssociation/src/TrackerHitAssociator.cc
+++ b/SimTracker/TrackerHitAssociation/src/TrackerHitAssociator.cc
@@ -56,7 +56,8 @@ TrackerHitAssociator::TrackerHitAssociator(const edm::Event& e)  :
 TrackerHitAssociator::TrackerHitAssociator(const edm::Event& e, const edm::ParameterSet& conf)  : 
   doPixel_( conf.getParameter<bool>("associatePixel") ),
   doStrip_( conf.getParameter<bool>("associateStrip") ),
-  doTrackAssoc_( conf.getParameter<bool>("associateRecoTracks") ) {
+  doTrackAssoc_( conf.getParameter<bool>("associateRecoTracks") ),
+  assocHitbySimTrack_( conf.getUntrackedParameter<bool>("associateHitbySimTrack", false) ) {
   
   //if track association there is no need to access the input collections
   if(!doTrackAssoc_) {
@@ -85,35 +86,33 @@ void TrackerHitAssociator::makeMaps(const edm::Event& theEvent, const vstring tr
       for (MixCollection<PSimHit>::iterator isim = thisContainerHits->begin();
 	   isim != thisContainerHits->end(); isim++) {
 	DetId theDet((*isim).detUnitId());
-	if (theDet.subdetId() == PixelSubdetector::PixelBarrel || theDet.subdetId() == PixelSubdetector::PixelEndcap) {
+	if (assocHitbySimTrack_) {
 	  SimHitMap[theDet].push_back((*isim));
-// 	  std::cout << "simHits from crossing frames; map size = " << SimHitMap.size() << ", Hit count = " << Nhits << std::endl;
 	} else {
 	  unsigned int tofBin = StripDigiSimLink::LowTof;
 	  if (trackerContainer.find(std::string("HighTof")) != std::string::npos) tofBin = StripDigiSimLink::HighTof;
 	  simHitCollectionID theSimHitCollID = std::make_pair(theDet.subdetId(), tofBin);
 	  SimHitCollMap[theSimHitCollID].push_back((*isim));
-// 	  std::cout << "simHits from crossing frames; map size = " << SimHitCollMap.size() << ", Hit count = " << Nhits << std::endl;
 	}
 	Nhits++;
       }
+      // std::cout << "simHits from crossing frames; map size = " << SimHitCollMap.size() << ", Hit count = " << Nhits << std::endl;
     } else {
       theEvent.getByLabel(tag_hits, simHits);
       for (std::vector<PSimHit>::const_iterator isim = simHits->begin();
 	   isim != simHits->end(); isim++) {
 	DetId theDet((*isim).detUnitId());
-	if (theDet.subdetId() == PixelSubdetector::PixelBarrel || theDet.subdetId() == PixelSubdetector::PixelEndcap) {
+	if (assocHitbySimTrack_) {
 	  SimHitMap[theDet].push_back((*isim));
-// 	  std::cout << "simHits from crossing frames; map size = " << SimHitMap.size() << ", Hit count = " << Nhits << std::endl;
 	} else {
 	  unsigned int tofBin = StripDigiSimLink::LowTof;
 	  if (trackerContainer.find(std::string("HighTof")) != std::string::npos) tofBin = StripDigiSimLink::HighTof;
 	  simHitCollectionID theSimHitCollID = std::make_pair(theDet.subdetId(), tofBin);
 	  SimHitCollMap[theSimHitCollID].push_back((*isim));
-// 	  std::cout << "simHits from crossing frames; map size = " << SimHitCollMap.size() << ", Hit count = " << Nhits << std::endl;
 	}
 	Nhits++;
       }
+      // std::cout << "simHits from prompt collections; map size = " << SimHitCollMap.size() << ", Hit count = " << Nhits << std::endl;
     }
   }
 }
@@ -140,16 +139,16 @@ std::vector<PSimHit> TrackerHitAssociator::associateHit(const TrackingRecHit & t
 
   // Get the vectors of simtrackIDs and simHit indices associated with this rechit
   associateHitId(thit, simtrackid, &simhitCFPos);
-//   std::cout << "recHit subdet, detID = " << detid.subdetId() << ", " << detID << ", (bnch, evt, trk) = ";
-//   for (size_t i=0; i<simtrackid.size(); ++i)
-//     std::cout << ", (" << simtrackid[i].second.bunchCrossing() << ", "
-// 	      << simtrackid[i].second.event() << ", " << simtrackid[i].first << ")";
-//   std::cout << std::endl; 
+  // std::cout << "recHit subdet, detID = " << detid.subdetId() << ", " << detID << ", (bnch, evt, trk) = ";
+  // for (size_t i=0; i<simtrackid.size(); ++i)
+  //   std::cout << ", (" << simtrackid[i].second.bunchCrossing() << ", "
+  // 	      << simtrackid[i].second.event() << ", " << simtrackid[i].first << ")";
+  // std::cout << std::endl; 
 
   // Get the vector of simHits associated with this rechit
 
-  if (simhitCFPos.size() > 0) {
-    // For the strips we can make use of the indices to the simHit collections taken
+  if (!assocHitbySimTrack_ && simhitCFPos.size() > 0) {
+    // We use the indices to the simHit collections taken
     //  from the DigiSimLinks and returned in simhitCFPos.
     //  simhitCFPos[i] contains the full address of the ith simhit:
     //   <collection, index> = <<subdet, tofBin>, index>
@@ -163,18 +162,17 @@ std::vector<PSimHit> TrackerHitAssociator::associateHit(const TrackingRecHit & t
 	  const PSimHit& theSimHit = (it->second)[theSimHitIndex];
 	  result.push_back(theSimHit);
 
-//           std::cout << "by CFpos, simHit detId =  " << theSimHit.detUnitId() << " address = (" << (theSimHitAddr.first).first
-// 		    << ", " << (theSimHitAddr.first).second << ", " << theSimHitIndex
-// 		    << "), process = " << theSimHit.processType() << " (" << theSimHit.eventId().bunchCrossing()
-// 		    << ", " << theSimHit.eventId().event() << ", " << theSimHit.trackId() << ")" << std::endl;
+          // std::cout << "by CFpos, simHit detId =  " << theSimHit.detUnitId() << " address = (" << (theSimHitAddr.first).first
+	  // 	    << ", " << (theSimHitAddr.first).second << ", " << theSimHitIndex
+	  // 	    << "), process = " << theSimHit.processType() << " (" << theSimHit.eventId().bunchCrossing()
+	  // 	    << ", " << theSimHit.eventId().event() << ", " << theSimHit.trackId() << ")" << std::endl;
 	}
       }
     }
     return result;
   }
 
-  // Here get the SimHit from the trackid, for pixels.
-//   std::vector<PSimHit> simHitVector;
+  // Get the SimHit from the trackid instead
   std::map<unsigned int, std::vector<PSimHit> >::const_iterator it = SimHitMap.find(detID);
   if (it!= SimHitMap.end()) {
     vector<PSimHit>::const_iterator simHitIter = (it->second).begin();
@@ -183,8 +181,8 @@ std::vector<PSimHit> TrackerHitAssociator::associateHit(const TrackingRecHit & t
       const PSimHit& ihit = *simHitIter;
       unsigned int simHitid = ihit.trackId();
       EncodedEventId simHiteid = ihit.eventId();
-//       std::cout << "simHit, process = " << ihit.processType() << " (" << ihit.eventId().bunchCrossing()
-// 		<< ", " << ihit.eventId().event() << ", " << ihit.trackId() << ")";
+      // std::cout << "by simTk, simHit, process = " << ihit.processType() << " (" << ihit.eventId().bunchCrossing()
+      // 		<< ", " << ihit.eventId().event() << ", " << ihit.trackId() << ")";
 	
       for(size_t i=0; i<simtrackid.size();i++) {
 	if(simHitid == simtrackid[i].first && simHiteid == simtrackid[i].second) {
@@ -192,18 +190,17 @@ std::vector<PSimHit> TrackerHitAssociator::associateHit(const TrackingRecHit & t
 // 	if(simHitid == simtrackid[i].first && simHiteid.bunchCrossing() == simtrackid[i].second.bunchCrossing()) {
 // 	    	cout << "Associator ---> ID" << ihit.trackId() << " Simhit x= " << ihit.localPosition().x() 
 //                   << " y= " <<  ihit.localPosition().y() << " z= " <<  ihit.localPosition().x() << endl;
-// 	  std::cout << " matches";
+	  // std::cout << " matches";
 	  result.push_back(ihit);
 	  break;
 	}
       }
-//       std::cout << std::endl;
+      // std::cout << std::endl;
     }
 
   }else{
 
     /// Check if it's the gluedDet.
-    //  (We don't expect to get here because strips are handled by direct simHit matching above.)   
     std::map<unsigned int, std::vector<PSimHit> >::const_iterator itrphi =
       SimHitMap.find(detID+2);  //iterator to the simhit in the rphi module
     std::map<unsigned int, std::vector<PSimHit> >::const_iterator itster = 
@@ -294,7 +291,7 @@ void TrackerHitAssociator::associateHitId(const TrackingRecHit & thit, std::vect
       {
       if(const SiPixelRecHit * rechit = dynamic_cast<const SiPixelRecHit *>(&thit))
 	{	  
-	  associatePixelRecHit(rechit,simtkid );
+	  associatePixelRecHit(rechit, simtkid, simhitCFPos);
 	}
       }
     //check if these are GSRecHits (from FastSim)
@@ -438,8 +435,9 @@ std::vector<SimHitIdpr>  TrackerHitAssociator::associateProjectedRecHit(const Pr
   return matched_mono;
 }
 
-//std::vector<unsigned int>  TrackerHitAssociator::associatePixelRecHit(const SiPixelRecHit * pixelrechit)
-void  TrackerHitAssociator::associatePixelRecHit(const SiPixelRecHit * pixelrechit, std::vector<SimHitIdpr> & simtrackid) const
+void  TrackerHitAssociator::associatePixelRecHit(const SiPixelRecHit * pixelrechit,
+						 std::vector<SimHitIdpr> & simtrackid,
+						 std::vector<simhitAddr>* simhitCFPos) const
 {
   //
   // Pixel associator
@@ -465,6 +463,7 @@ void  TrackerHitAssociator::associatePixelRecHit(const SiPixelRecHit * pixelrech
       edm::DetSet<PixelDigiSimLink>::const_iterator linkiter = link_detset.data.begin();
       int dsl = 0;
       std::vector<SimHitIdpr> idcachev;
+      std::vector<simhitAddr> CFposcachev;
       for( ; linkiter != link_detset.data.end(); linkiter++) {
 	dsl++;
 	std::pair<int,int> pixel_coord = PixelDigi::channelToPixel(linkiter->channel());
@@ -476,11 +475,25 @@ void  TrackerHitAssociator::associatePixelRecHit(const SiPixelRecHit * pixelrech
 	  //std::cout << "      !-> trackid   " << linkiter->SimTrackId() << endl;
 	  //std::cout << "          fraction  " << linkiter->fraction()   << endl;
 	  SimHitIdpr currentId(linkiter->SimTrackId(), linkiter->eventId());
-	  //	if(find(idcachev.begin(),idcachev.end(),linkiter->SimTrackId()) == idcachev.end()){
 	  if(find(idcachev.begin(),idcachev.end(),currentId) == idcachev.end()){
 	    simtrackid.push_back(currentId);
 	    idcachev.push_back(currentId);
 	  }
+
+	  if (simhitCFPos != 0) {
+	  //create a vector that contains all the position (in the MixCollection) of the SimHits that contributed to the RecHit
+	  //write position only once
+	    unsigned int currentCFPos = linkiter->CFposition();
+	    unsigned int tofBin = linkiter->TofBin();
+	    simHitCollectionID theSimHitCollID = std::make_pair(detid.subdetId(), tofBin);
+	    simhitAddr currentAddr = std::make_pair(theSimHitCollID, currentCFPos);
+
+	    if(find(CFposcachev.begin(), CFposcachev.end(), currentAddr) == CFposcachev.end()) {
+	      CFposcachev.push_back(currentAddr);
+	      simhitCFPos->push_back(currentAddr);
+	    }
+	  }
+
 	} 
       }
     }


### PR DESCRIPTION
Backport PR 4678 to CMSSW_6_2_X_SHLC.  Add for pixels the capability, previously available only for strips, to obtain the simHit index via the pixelDigiSimLink for each channel.
