### PR TITLE
Fixing an issue in HCAL configuration

### DIFF
--- a/DQM/Integration/python/test/hcal_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/test/hcal_dqm_sourceclient-live_cfg.py
@@ -8,6 +8,15 @@ process = cms.Process("HCALDQM")
 subsystem="Hcal" # specify subsystem name here
 
 #----------------------------
+# Event Source
+#-----------------------------
+# for live online DQM in P5
+process.load("DQM.Integration.test.inputsource_cfi")
+
+# for testing in lxplus
+#process.load("DQM.Integration.test.fileinputsource_cfi")
+
+#----------------------------
 # DQM Environment
 #-----------------------------
 process.load("DQMServices.Components.DQMEnvironment_cfi")
@@ -15,7 +24,6 @@ process.load("DQMServices.Components.DQMEnvironment_cfi")
 process.load("DQM.Integration.test.environment_cfi")
 process.dqmEnv.subSystemFolder = subsystem
 process.DQMStore.referenceFileName = '/dqmdata/dqm/reference/hcal_reference.root'
-process.dqmSaver.dirName = '.'
 
 print "Running with run type = ", process.runType.getRunType()
 
@@ -35,15 +43,6 @@ HcalCalibPlaybackHost='dqm-c2d07-16'.lower()
 playbackHCAL=False
 if (host==HcalPlaybackHost):
     playbackHCAL=True
-
-#----------------------------
-# Event Source
-#-----------------------------
-# for live online DQM in P5
-process.load("DQM.Integration.test.inputsource_cfi")
-
-# for testing in lxplus
-#process.load("DQM.Integration.test.fileinputsource_cfi")
 
 #-----------------------------
 # Hcal Conditions: from Global Conditions Tag 


### PR DESCRIPTION
Hcal configuration file was crashing during MWGR2 since the parameter runType was used before its definiton. Now the configuration file is fixed.
