### PR TITLE
Restore means of passing eventID to Mixed SimHits

### DIFF
--- a/Mixing/Base/interface/PileUp.h
+++ b/Mixing/Base/interface/PileUp.h
@@ -140,6 +140,21 @@ namespace edm {
   };
 
 
+  template<typename T>
+  class PassEventID
+  {
+  private:
+    T& eventOperator_;
+    int eventCount ;
+  public:
+    PassEventID(T& eventOperator)
+      : eventOperator_(eventOperator), eventCount( 0 ) {}
+    void operator()(EventPrincipal const& eventPrincipal) {
+      eventOperator_(eventPrincipal, ++eventCount);
+    }
+  };
+
+
   /*! Generates events from a VectorInputSource.
    *  This function decides which method of VectorInputSource 
    *  to call: sequential, random, or pre-specified.
@@ -196,7 +211,8 @@ namespace edm {
   void
     PileUp::playPileUp(const std::vector<edm::EventID> &ids, T eventOperator) {
     //TrueNumInteractions.push_back( ids.size() ) ;
-    input_->loopSpecified(*eventPrincipal_,ids,eventOperator);
+    PassEventID<T> recorder(eventOperator);
+    input_->loopSpecified(*eventPrincipal_,ids,recorder);
   }
 
 

--- a/SimGeneral/MixingModule/plugins/MixingModule.cc
+++ b/SimGeneral/MixingModule/plugins/MixingModule.cc
@@ -394,8 +394,7 @@ namespace edm {
           playbackInfo_->setStartEventId(recordEventID, readSrcIdx, bunchIdx, KeepTrackOfPileup);
           KeepTrackOfPileup+=NumPU_Events;
         } else {
-          int dummyId = 0;
-          const std::vector<edm::EventID>& playEventID =
+	  const std::vector<edm::EventID>& playEventID =
             playbackInfo_H->getStartEventId(readSrcIdx, bunchIdx);
           if(readSrcIdx == 0) {
             PileupList.push_back(playEventID.size());
@@ -404,7 +403,7 @@ namespace edm {
           inputSources_[readSrcIdx]->playPileUp(
             playEventID,
             boost::bind(&MixingModule::pileAllWorkers, boost::ref(*this), _1, mcc, bunchIdx,
-                        dummyId, vertexOffset, boost::ref(setup), boost::cref(e.streamID()))
+                        _2, vertexOffset, boost::ref(setup), boost::cref(e.streamID()))
             );
         }
       }


### PR DESCRIPTION
Fix bug in passing eventIDs to mixed SimHits that has been there since the MixingModule was partially re-written in the 5X(?) series.  Spotted by Bill Ford during validation tests. 
