### PR TITLE
GlobalTag_condDBv2.py: remove misleading print out

### DIFF
--- a/Configuration/AlCa/python/GlobalTag_condDBv2.py
+++ b/Configuration/AlCa/python/GlobalTag_condDBv2.py
@@ -90,7 +90,6 @@ def GlobalTag(essource = None, globaltag = None, conditions = None):
             # Perform any alias expansion and consistency check.
             # We are assuming the same connection and pfnPrefix/Postfix will be used for all GTs.
             globaltag[0] = combineGTs(globaltag[0])
-            print "globaltag =", globaltag[0]
             essource.globaltag = cms.string( str(globaltag[0]) )
         if len(globaltag) > 1:
             essource.connect   = cms.string( str(globaltag[1]) )


### PR DESCRIPTION
Do not print the global tag after expanding it.
This was both misleading (users overriding the global tag would still see the wrong print out) and not in line with the CMSSW practices (messages should be printed via the MessageLogger, not directly to the standard output).
