### PR TITLE
GlobalTag*.py: sort the additional payloads

### DIFF
--- a/Configuration/AlCa/python/GlobalTag.py
+++ b/Configuration/AlCa/python/GlobalTag.py
@@ -118,7 +118,7 @@ def GlobalTag(essource = None, globaltag = None, conditions = None):
 
     # explicit payloads toGet from DB
     if custom_conditions:
-        for ( (record, label), (tag, connection) ) in custom_conditions.iteritems():
+        for ( (record, label), (tag, connection) ) in sorted(custom_conditions.iteritems()):
             payload = cms.PSet()
             payload.record = cms.string( record )
             if label:

--- a/Configuration/AlCa/python/GlobalTag_condDBv2.py
+++ b/Configuration/AlCa/python/GlobalTag_condDBv2.py
@@ -119,7 +119,7 @@ def GlobalTag(essource = None, globaltag = None, conditions = None):
 
     # explicit payloads toGet from DB
     if custom_conditions:
-        for ( (record, label), (tag, connection) ) in custom_conditions.iteritems():
+        for ( (record, label), (tag, connection) ) in sorted(custom_conditions.iteritems()):
             payload = cms.PSet()
             payload.record = cms.string( record )
             if label:


### PR DESCRIPTION
Sort the additional payloads from release-level or user-level customisations to the global tags,
to ensure a consistent hash of the process configuration.
