### PR TITLE
fix label collection for HI MTV

### DIFF
--- a/Validation/RecoHI/python/TrackValidationHeavyIons_cff.py
+++ b/Validation/RecoHI/python/TrackValidationHeavyIons_cff.py
@@ -26,6 +26,7 @@ from Validation.RecoTrack.MultiTrackValidator_cff import *
 hiTrackValidator = multiTrackValidator.clone(
     label_tp_effic = cms.InputTag("primaryChgSimTracks"),
     label_tp_fake  = cms.InputTag("cutsTPFake"),
+    trackCollectionForDrCalculation = cms.InputTag("cutsRecoTracks"),
     signalOnlyTP = cms.bool(False),
     skipHistoFit = cms.untracked.bool(True), # done in post-processing
     minpT = cms.double(1.0),


### PR DESCRIPTION
Fix a recent problem as discussed in #4669 due to a wrong collection name used in MTV with HI scenario.
We think that the problem should have beed introduced by #4239.
