### PR TITLE
fixing bug which causes filter to auto accept

### DIFF
--- a/HLTrigger/Egamma/src/HLTElectronPixelMatchFilter.cc
+++ b/HLTrigger/Egamma/src/HLTElectronPixelMatchFilter.cc
@@ -204,7 +204,6 @@ bool HLTElectronPixelMatchFilter::hltFilter(edm::Event& iEvent, const edm::Event
   
   // filter decision
   bool accept(n>=ncandcut_);
-  accept = true ;
   
   return accept;
 }


### PR DESCRIPTION
This one line fix stops the HLT pixel match filter auto accepting events, a bug introduced in the last commit. 
