### PR TITLE
fixing bug which causes filter to auto accept

### DIFF
--- a/HLTrigger/Egamma/src/HLTElectronPixelMatchFilter.cc
+++ b/HLTrigger/Egamma/src/HLTElectronPixelMatchFilter.cc
@@ -204,7 +204,6 @@ bool HLTElectronPixelMatchFilter::hltFilter(edm::Event& iEvent, const edm::Event
   
   // filter decision
   bool accept(n>=ncandcut_);
-  accept = true ;
   
   return accept;
 }


### PR DESCRIPTION
back porting https://github.com/cms-sw/cmssw/pull/4758#issuecomment-49867506 to 71X.

One line bug fix removing a bug introduced in last commit which means HLT pixelmatching filter auto accepts
