### PR TITLE
Run dir check fix 72X

### DIFF
--- a/EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h
+++ b/EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h
@@ -81,6 +81,11 @@ namespace evf {
     // create open dir if not already there
     edm::Service<evf::EvFDaqDirector>()->createRunOpendirMaybe();
 
+    //replace hltOutoputA with stream if the HLT menu uses this convention
+    std::string testPrefix="hltOutput";
+    if (stream_label_.find(testPrefix)==0) 
+            stream_label_=std::string("stream")+stream_label_.substr(testPrefix.size());
+
     fms_ = (evf::FastMonitoringService *)(edm::Service<evf::MicroStateService>().operator->());
     
     processed_.setName("Processed");

--- a/EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h
+++ b/EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h
@@ -203,6 +203,7 @@ namespace evf {
           fread(outBuf_,toRead,1,src);
           fwrite(outBuf_,toRead,1,des);
           readInput+=toRead;
+          filesize+=toRead;
       }
 
       //if(des != 0 && src !=0){


### PR DESCRIPTION
Hi,
This contains fixes for detecting early run dir deletion (debugged in MWGR #2).
Also included is the parsing of hltOutput\* module label used in HLT menus, to construct the correct output file name.
