### PR TITLE
Add missing iterations

### DIFF
--- a/RecoParticleFlow/Configuration/test/PFChargedHadronAnalyzer.cc
+++ b/RecoParticleFlow/Configuration/test/PFChargedHadronAnalyzer.cc
@@ -244,6 +244,9 @@ PFChargedHadronAnalyzer::analyze(const Event& iEvent,
     case TrackBase::iter4:
     case TrackBase::iter5:
     case TrackBase::iter6:
+    case TrackBase::iter7:
+    case TrackBase::iter9:
+    case TrackBase::iter10:
     default:
       break;
     }

--- a/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporter.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporter.cc
@@ -157,6 +157,8 @@ goodPtResolution( const reco::TrackRef& trackref) const {
   case reco::TrackBase::iter1:
   case reco::TrackBase::iter2:
   case reco::TrackBase::iter7:
+  case reco::TrackBase::iter9:
+  case reco::TrackBase::iter10:
     Algo = 0;
     break;
   case reco::TrackBase::iter3:
@@ -180,7 +182,7 @@ goodPtResolution( const reco::TrackRef& trackref) const {
   if ( P < 0.05 ) return false;
 
   // Temporary : Reject all tracking iteration beyond 5th step. 
-  if ( Algo > 4 ) return false;
+//  if ( Algo > 4 ) return false;
  
   if (_debug) std::cout << " PFBlockAlgo: PFrecTrack->Track Pt= "
 		   << Pt << " DPt = " << DPt << std::endl;

--- a/RecoParticleFlow/PFProducer/src/PFAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFAlgo.cc
@@ -1940,6 +1940,8 @@ void PFAlgo::processBlock( const reco::PFBlockRef& blockref,
       case TrackBase::iter3:
       case TrackBase::iter4:
       case TrackBase::iter7:
+      case TrackBase::iter9:
+      case TrackBase::iter10:
 	blowError = 1.;
 	break;
       case TrackBase::iter5:
@@ -2398,6 +2400,8 @@ void PFAlgo::processBlock( const reco::PFBlockRef& blockref,
 	case TrackBase::iter3:
 	case TrackBase::iter4:
 	case TrackBase::iter7:
+	case TrackBase::iter9:
+	case TrackBase::iter10:
 	  break;
 	case TrackBase::iter5:
 	case TrackBase::iter6:

--- a/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
@@ -2520,6 +2520,8 @@ unsigned int PFEGammaAlgo::whichTrackAlgo(const reco::TrackRef& trackRef) {
   case TrackBase::iter1:
   case TrackBase::iter2:
   case TrackBase::iter7:
+  case TrackBase::iter9:
+  case TrackBase::iter10:
     Algo = 0;
     break;
   case TrackBase::iter3:

--- a/RecoParticleFlow/PFProducer/src/PFEGammaFilters.cc
+++ b/RecoParticleFlow/PFProducer/src/PFEGammaFilters.cc
@@ -372,6 +372,8 @@ unsigned int PFEGammaFilters::whichTrackAlgo(const reco::TrackRef& trackRef) {
   case TrackBase::iter1:
   case TrackBase::iter2:
   case TrackBase::iter7:
+  case TrackBase::iter9:
+  case TrackBase::iter10:
     Algo = 0;
     break;
   case TrackBase::iter3:

--- a/RecoParticleFlow/PFProducer/src/PFElectronAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFElectronAlgo.cc
@@ -2669,6 +2669,9 @@ unsigned int PFElectronAlgo::whichTrackAlgo(const reco::TrackRef& trackRef) {
   case TrackBase::iter0:
   case TrackBase::iter1:
   case TrackBase::iter2:
+  case TrackBase::iter7:
+  case TrackBase::iter9:
+  case TrackBase::iter10:
     Algo = 0;
     break;
   case TrackBase::iter3:

--- a/RecoParticleFlow/PFTracking/plugins/PFElecTkProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFElecTkProducer.cc
@@ -501,6 +501,8 @@ bool PFElecTkProducer::isFifthStep(reco::PFRecTrackRef pfKfTrack) {
   case TrackBase::iter1:
   case TrackBase::iter2:
   case TrackBase::iter7:
+  case TrackBase::iter9:
+  case TrackBase::iter10:
     Algo = 0;
     break;
   case TrackBase::iter3:


### PR DESCRIPTION
Request to add the missing track iterations, the new iter7 and also the iter9 and iter10. This is a temporary fix in order not to ignore the tracks. More detailed studies on the performance of track quality cuts per iteration are coming soon.  
