### PR TITLE
Put starting capId back to random to fix drop in number of digis in Hcal

### DIFF
--- a/SimCalorimetry/HcalSimAlgos/src/HcalElectronicsSim.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalElectronicsSim.cc
@@ -14,7 +14,7 @@ HcalElectronicsSim::HcalElectronicsSim(HcalAmplifier * amplifier, const HcalCode
     theCoderFactory(coderFactory),
     theRandFlat(0),
     theStartingCapId(0),
-    theStartingCapIdIsRandom(false),
+    theStartingCapIdIsRandom(true),
     PreMixDigis(PreMixing)
 {
 }


### PR DESCRIPTION
Fix for Hcal.  Fixes discrepancy of Hcal Digis.
