### PR TITLE
Various fixes for big plugins.

### DIFF
--- a/BigProducts/Simulation/BuildFile.xml
+++ b/BigProducts/Simulation/BuildFile.xml
@@ -14,6 +14,9 @@
 <use name="SimG4Core/PhysicsLists"/>
 <use name="SimG4Core/SensitiveDetector"/>
 <use name="SimRomanPot/SimFP420"/>
+<use name="Validation/HcalHits"/>
+<use name="Validation/EcalHits"/>
+<use name="SimDataFormats/ValidationFormats"/>
 <use name="geant4static"/>
 <flags DROP_DEP="geant4core"/>
 # Hack needed to avoid undefined variable in CLHEP.

--- a/BigProducts/Simulation/BuildFile.xml
+++ b/BigProducts/Simulation/BuildFile.xml
@@ -16,5 +16,7 @@
 <use name="SimRomanPot/SimFP420"/>
 <use name="geant4static"/>
 <flags DROP_DEP="geant4core"/>
-<flags REM_CXXFLAGS="-Werror=maybe-uninitialized"/>
-<flags REM_CXXFLAGS="-Werror=uninitialized"/>
+# Hack needed to avoid undefined variable in CLHEP.
+<architecture name="slc6_amd64_gcc49">
+  <flags REM_CXXFLAGS="-Werror=unused-variable"/>
+</architecture>

--- a/SimDataFormats/ValidationFormats/src/PValidationFormats.cc
+++ b/SimDataFormats/ValidationFormats/src/PValidationFormats.cc
@@ -1765,4 +1765,3 @@ void PTrackerSimHit::putHits (const std::vector<int>& _sysID, const std::vector<
 
   return;
 }
-

--- a/SimG4CMS/Calo/interface/HFGflash.h
+++ b/SimG4CMS/Calo/interface/HFGflash.h
@@ -36,10 +36,10 @@ public:
   struct Hit {
     Hit() {}
     G4ThreeVector       position;
-    int                 depth;
-    double              time;
-    double              edep;
-    double              pez;
+    int                 depth = 0;
+    double              time = 0.;
+    double              edep = 0.;
+    double              pez = 0.;
   };
 
   std::vector<Hit> gfParameterization(G4Step * aStep, bool & ok, bool onlyLong=false);

--- a/Validation/EcalHits/src/module.cc
+++ b/Validation/EcalHits/src/module.cc
@@ -1,7 +1,5 @@
 #include "SimG4Core/Watcher/interface/SimWatcherFactory.h"
-
 #include "FWCore/PluginManager/interface/ModuleDef.h"
-
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 

--- a/Validation/HcalHits/src/module.cc
+++ b/Validation/HcalHits/src/module.cc
@@ -3,7 +3,6 @@
 #include "FWCore/PluginManager/interface/ModuleDef.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-
 DEFINE_SIMWATCHER (SimG4HcalValidation);
 
 #include "Validation/HcalHits/interface/HcalSimHitStudy.h"


### PR DESCRIPTION
- Cleanup allegedly uninitialised data and do not drop the releted warning flags anymore.
- Add a few more libraries to the bigplugin so that we avoid duplicate loading of geant4 when customising with `Validation.Configuration.ECALHCAL`.
