### PR TITLE
Improve vertex validation

### DIFF
--- a/Validation/RecoVertex/interface/PrimaryVertexAnalyzer4PUSlimmed.h
+++ b/Validation/RecoVertex/interface/PrimaryVertexAnalyzer4PUSlimmed.h
@@ -147,8 +147,6 @@ class PrimaryVertexAnalyzer4PUSlimmed : public DQMEDAnalyzer {
   // re-run the associator(s)
   const TrackAssociatorBase * associatorByHits_;
 
-  std::string recoTrackProducer_;
-
   edm::EDGetTokenT< std::vector<PileupSummaryInfo> > vecPileupSummaryInfoToken_;
   std::vector<edm::EDGetTokenT<reco::VertexCollection> > reco_vertex_collection_tokens_;
   std::vector<edm::InputTag > reco_vertex_collections_;

--- a/Validation/RecoVertex/python/PrimaryVertexAnalyzer4PUSlimmed_Client_cfi.py
+++ b/Validation/RecoVertex/python/PrimaryVertexAnalyzer4PUSlimmed_Client_cfi.py
@@ -33,3 +33,5 @@ postProcessorVertex = cms.EDAnalyzer("DQMGenericClient",
                                      outputFileName = cms.untracked.string(""),
                                      verbose = cms.untracked.uint32(5)
 )
+
+postProcessorVertexStandAlone = cms.Sequence(postProcessorVertex)

--- a/Validation/RecoVertex/src/PrimaryVertexAnalyzer4PUSlimmed.cc
+++ b/Validation/RecoVertex/src/PrimaryVertexAnalyzer4PUSlimmed.cc
@@ -794,18 +794,17 @@ void PrimaryVertexAnalyzer4PUSlimmed::analyze(const edm::Event& iEvent,
           // recontructed at all.
 
           auto iv = (*recVtxs.product()).begin();
-	  if ( iv != (*recVtxs.product()).end() ) {
-	    int pv_position_in_reco_collection = 0;
-	    while (++iv != (*recVtxs.product()).end()) {
-	      pv_position_in_reco_collection++;
-	      if (std::find(v.rec_vertices.begin(), v.rec_vertices.end(),
-			    &(*iv)) != v.rec_vertices.end()) {
-		mes_[label]["TruePVLocationIndex"]
+          int pv_position_in_reco_collection = 0;
+          for (; iv != (*recVtxs.product()).end(); ++iv) {
+            pv_position_in_reco_collection++;
+            if (std::find(v.rec_vertices.begin(), v.rec_vertices.end(),
+                          &(*iv)) != v.rec_vertices.end()) {
+              mes_[label]["TruePVLocationIndex"]
                   ->Fill(pv_position_in_reco_collection);
-		break;
-	      }
-	    }
-	  }
+              break;
+            }
+          }
+
           // If we reached the end, it means that the Simulated PV has not
           // been associated to any recontructed vertex: mark it as
           // missing in the reconstructed vertex collection using the fake

--- a/Validation/RecoVertex/src/PrimaryVertexAnalyzer4PUSlimmed.cc
+++ b/Validation/RecoVertex/src/PrimaryVertexAnalyzer4PUSlimmed.cc
@@ -29,8 +29,6 @@ PrimaryVertexAnalyzer4PUSlimmed::PrimaryVertexAnalyzer4PUSlimmed(
           iConfig.getUntrackedParameter<bool>("use_TP_associator", false)),
       sigma_z_match_(
           iConfig.getUntrackedParameter<double>("sigma_z_match", 3.0)),
-      recoTrackProducer_(
-          iConfig.getUntrackedParameter<std::string>("recoTrackProducer")),
       vecPileupSummaryInfoToken_(consumes<std::vector<PileupSummaryInfo> >(
           edm::InputTag(std::string("addPileupInfo")))),
       recoTrackCollectionToken_(consumes<reco::TrackCollection>(edm::InputTag(
@@ -753,11 +751,14 @@ void PrimaryVertexAnalyzer4PUSlimmed::analyze(const edm::Event& iEvent,
     }
   }
 
+  std::vector<simPrimaryVertex> simpv;  // a list of simulated primary
+                                        // MC vertices
+  // TODO(rovere) use move semantic?
+  simpv = getSimPVs(TVCollectionH);
+  mes_["root_folder"]["GenAllV_NumVertices"]->Fill(simpv.size());
+
   int label_index = -1;
   for (auto const& vertex_token : reco_vertex_collection_tokens_) {
-    std::vector<simPrimaryVertex> simpv;  // a list of simulatedprimary
-                                          // MC vertices
-
     std::vector<recoPrimaryVertex> recopv;  // a list of recontructed
                                             // primary MC vertices
     std::string label = reco_vertex_collections_[++label_index].label();
@@ -769,8 +770,6 @@ void PrimaryVertexAnalyzer4PUSlimmed::analyze(const edm::Event& iEvent,
       continue;
     }
     if (gotTV) {
-      // TODO(rovere) use move semantic?
-      simpv = getSimPVs(TVCollectionH);
       matchSim2RecoVertices(simpv, *recVtxs.product());
       recopv = getRecoPVs(recVtxs);
       matchReco2SimVertices(recopv, *TVCollectionH.product());
@@ -788,31 +787,32 @@ void PrimaryVertexAnalyzer4PUSlimmed::analyze(const edm::Event& iEvent,
           mes_[label]["MisTagRate"]->Fill(1.);
         } else {
           mes_[label]["MisTagRate"]->Fill(0.0);
-          // Now check at which location the Simulated PV has been
-          // reconstructed in the primvary vertex collection
-          // at-hand. Mark it with fake index -1 if it was not
-          // recontructed at all.
-
-          auto iv = (*recVtxs.product()).begin();
-          int pv_position_in_reco_collection = 0;
-          for (; iv != (*recVtxs.product()).end(); ++iv) {
-            pv_position_in_reco_collection++;
-            if (std::find(v.rec_vertices.begin(), v.rec_vertices.end(),
-                          &(*iv)) != v.rec_vertices.end()) {
-              mes_[label]["TruePVLocationIndex"]
-                  ->Fill(pv_position_in_reco_collection);
-              break;
-            }
-          }
-
-          // If we reached the end, it means that the Simulated PV has not
-          // been associated to any recontructed vertex: mark it as
-          // missing in the reconstructed vertex collection using the fake
-          // index -1.
-          if (iv == (*recVtxs.product()).end())
-            mes_[label]["TruePVLocationIndex"]->Fill(-1.);
         }
+        // Now check at which location the Simulated PV has been
+        // reconstructed in the primvary vertex collection
+        // at-hand. Mark it with fake index -1 if it was not
+        // recontructed at all.
+
+        auto iv = (*recVtxs.product()).begin();
+        for (int pv_position_in_reco_collection = 0;
+             iv != (*recVtxs.product()).end();
+             ++pv_position_in_reco_collection, ++iv) {
+          if (std::find(v.rec_vertices.begin(), v.rec_vertices.end(),
+                        &(*iv)) != v.rec_vertices.end()) {
+            mes_[label]["TruePVLocationIndex"]
+                ->Fill(pv_position_in_reco_collection);
+            break;
+          }
+        }
+
+        // If we reached the end, it means that the Simulated PV has not
+        // been associated to any recontructed vertex: mark it as
+        // missing in the reconstructed vertex collection using the fake
+        // index -1.
+        if (iv == (*recVtxs.product()).end())
+          mes_[label]["TruePVLocationIndex"]->Fill(-1.);
       }
+
       if (v.rec_vertices.size()) num_total_gen_vertices_assoc2reco++;
       if (v.rec_vertices.size() > 1) num_total_gen_vertices_multiassoc2reco++;
       // No need to N-tplicate the Gen-related cumulative histograms:

--- a/Validation/RecoVertex/test/README_VertexValidationSlimmed.txt
+++ b/Validation/RecoVertex/test/README_VertexValidationSlimmed.txt
@@ -1,0 +1,117 @@
+* INTRODUCTION
+
+This small README file is here to guide you in the process of running
+the Vertex Validation, slimmed version, on RelVal samples, in case you
+want to perform test on tracking and vertexing. The idea here is not
+to give you pre-cooked python configuration files, but to teach you
+how you could use the most common tool available in CMS to perform the
+same. We will mainly use cmsDriver and its powerful option to create
+the python cfg that we will run, and das_client to explore and find
+suitable samples to run upon. Let start with order.
+
+** PREREQUISITES
+
+We assume that from this point onward, you have setup a proper CMSSW
+area and that you have source its environments, since all the script
+that we will be using are available to you only after you performed
+such actions.
+
+** FIND PROPER SAMPLES
+
+The first thing that we need to do is to find appropriate samples to
+run upon. Our suggestion is to start from the RelVal samples that are
+regularly produced for every release and pre-release, since this will
+avoid all the burden of properly selecting the PU and generation
+snippet. In case you want to use anything other than what is available
+as RelVal, we assume you are familiar enough with the production
+mechanism that you can take care of it alone: no instructions will be
+given here.
+
+*** FIND GEN-SIM-DIGI-RAW-HLTDEBUG samples FOR A SPECIFIC RELEASE
+
+In order to check what samples are available for, e.g. the CMSSW_7_2
+release cycle, issue the command
+
+```
+das_client.py --query='dataset=/RelValTTbar*/*7_2_0*/*GEN-SIM-DIGI-RAW-HLTDEBUG' --format=plain
+```
+
+and pick up the proper dataset among the ones printed directly on the
+screen. Here we picked up
+/RelValTTbar_13/CMSSW_7_2_0_pre1-PU25ns_POSTLS172_V1-v1/GEN-SIM-DIGI-RAW-HLTDEBUG.
+
+*** FIND ALL FILES BELONGING TO A SPECIFIC DATASET
+
+In order to discover which files belong to the selected dataset, you
+have to issue the following command (of course you have to change the
+dataset name in the query, using the one you discovered in the
+previous point...)
+
+```
+das_client.py --limit 0 --query='file dataset=/RelValTTbar_13/CMSSW_7_2_0_pre1-PU25ns_POSTLS172_V1-v1/GEN-SIM-DIGI-RAW-HLTDEBUG' --format=plain | sort -u > gen_sim_digi_raw_files.txt 2>&1
+```
+
+This will write the discovered files directly into the ASCII file
+gen_sim_digi_raw_files.txt, that will be used as input to the
+following cmsDriver commands.
+
+*** RUN RECO AND VERTEX VALIDATION
+
+Inn order to run the vertex validation starting from RAW file, you
+need to create a proper python cfg. As said, instead of preparing a
+pre-cooked one, we think its more useful to give you the cmsDriver
+command that will dynamically prepare it for you. To obtain such a cfg
+file, issue the following command:
+
+```
+cmsDriver.py step3  --conditions auto:run2_mc -n 100 --eventcontent DQM -s RAW2DIGI,RECO,VALIDATION:vertexAnalysisSequence --datatier DQMIO --filein filelist:gen_sim_digi_raw_files.txt --fileout step3_VertexValidation.root --customise SLHCUpgradeSimulations/Configuration/postLS1Customs.customisePostLS1 --magField 38T_PostLS1
+```
+
+This will create the python configuration file **and will
+automatically run cmsRun on it. If instead you want to just produce
+the configuration, e.g. for inspection and further customization, you
+can add the option:
+
+```
+--no_exec
+```
+
+to the previous command, This command will produce and output file
+named step3_VertexValidation,root that will contain all the histograms
+produce by the Vertex Validation package. The internal format of the
+ROOT file follows the DQMIO rules, to have better performance while
+running,
+
+*** RUN FINAL HARVESTING TO PRODUCE EFFICIENCY, FAKE, MERGE AND DUPLICATE RATE PLOTS
+
+The outcome of the previous step is not yet suitable to be browsed
+using plain ROOT. Moreover all the important plots have not yet been
+produce. You need to finalize the processing running the harvesting
+sequence. Again, we think it is better to provide you with the
+cmsDriver command to do that:
+
+```
+cmsDriver.py step4  --scenario pp --filetype DQM --conditions auto:run1_mc --mc  -s HARVESTING:postProcessorVertexStandAlone -n -1 --filein file:step3_VertexValidation.root
+```
+This command will create a final, plain, ROOT file named:
+DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO.root that will contain
+all the folders and plots produced by the Vertex Validation package.
+
+
+*** FURTHER CUSTOMIZATION
+
+If you want to customize the default vertex validation sequence, both
+the first one and the ones used in harvesting, you need to manually
+edit the configuration files produce by the previous cmsDriver
+commands. To ease this operation, you can point your browser here:
+
+https://github.com/cms-sw/cmssw/blob/CMSSW_7_2_X/Validation/RecoVertex/python/PrimaryVertexAnalyzer4PUSlimmed_cfi.py
+
+for the first default, and here:
+
+https://github.com/cms-sw/cmssw/blob/CMSSW_7_2_X/Validation/RecoVertex/python/PrimaryVertexAnalyzer4PUSlimmed_Client_cfi.py
+
+for the default used in the harvesting step.
+
+Enjoy.
+

--- a/Validation/RecoVertex/test/README_VertexValidationSlimmed.txt
+++ b/Validation/RecoVertex/test/README_VertexValidationSlimmed.txt
@@ -9,14 +9,14 @@ same. We will mainly use cmsDriver and its powerful option to create
 the python cfg that we will run, and das_client to explore and find
 suitable samples to run upon. Let start with order.
 
-** PREREQUISITES
+* PREREQUISITES
 
 We assume that from this point onward, you have setup a proper CMSSW
 area and that you have source its environments, since all the script
 that we will be using are available to you only after you performed
 such actions.
 
-** FIND PROPER SAMPLES
+* FIND PROPER SAMPLES
 
 The first thing that we need to do is to find appropriate samples to
 run upon. Our suggestion is to start from the RelVal samples that are
@@ -27,7 +27,7 @@ as RelVal, we assume you are familiar enough with the production
 mechanism that you can take care of it alone: no instructions will be
 given here.
 
-*** FIND GEN-SIM-DIGI-RAW-HLTDEBUG samples FOR A SPECIFIC RELEASE
+** FIND GEN-SIM-DIGI-RAW-HLTDEBUG samples FOR A SPECIFIC RELEASE
 
 In order to check what samples are available for, e.g. the CMSSW_7_2
 release cycle, issue the command
@@ -55,7 +55,7 @@ This will write the discovered files directly into the ASCII file
 gen_sim_digi_raw_files.txt, that will be used as input to the
 following cmsDriver commands.
 
-*** RUN RECO AND VERTEX VALIDATION
+* RUN RECO AND VERTEX VALIDATION
 
 Inn order to run the vertex validation starting from RAW file, you
 need to create a proper python cfg. As said, instead of preparing a
@@ -82,7 +82,7 @@ produce by the Vertex Validation package. The internal format of the
 ROOT file follows the DQMIO rules, to have better performance while
 running,
 
-*** RUN FINAL HARVESTING TO PRODUCE EFFICIENCY, FAKE, MERGE AND DUPLICATE RATE PLOTS
+* RUN FINAL HARVESTING TO PRODUCE EFFICIENCY, FAKE, MERGE AND DUPLICATE RATE PLOTS
 
 The outcome of the previous step is not yet suitable to be browsed
 using plain ROOT. Moreover all the important plots have not yet been
@@ -98,7 +98,7 @@ DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO.root that will contain
 all the folders and plots produced by the Vertex Validation package.
 
 
-*** FURTHER CUSTOMIZATION
+* FURTHER CUSTOMIZATION
 
 If you want to customize the default vertex validation sequence, both
 the first one and the ones used in harvesting, you need to manually


### PR DESCRIPTION
This PR will fix an offset-by-one bug that was present in the old version while computing mistag and add a rather comprehensive documentation on how to run and use this validation package.

Further code improvements, mainly related to logic and speed, have been included.
