### PR TITLE
710 pr9with consumes for di lepton3

### DIFF
--- a/DQM/Physics/interface/TopDQMHelpers.h
+++ b/DQM/Physics/interface/TopDQMHelpers.h
@@ -204,6 +204,8 @@ private:
   /// As described on https://twiki.cern.ch/twiki/bin/view/CMS/SimpleCutBasedEleID
   //int eidPattern_;
   double eidCutValue_;
+  //rho for Effective Area corrections
+  //edm::EDGetTokenT<double> eventrhoToken_;
   /// jet corrector as extra selection type
   std::string jetCorrector_;
   /// choice for b-tag as extra selection type

--- a/DQM/Physics/interface/TopDQMHelpers.h
+++ b/DQM/Physics/interface/TopDQMHelpers.h
@@ -202,10 +202,7 @@ private:
   ///  6: passes conversion rejection and Isolation
   ///  7: passes the whole selection
   /// As described on https://twiki.cern.ch/twiki/bin/view/CMS/SimpleCutBasedEleID
-  //int eidPattern_;
   double eidCutValue_;
-  //rho for Effective Area corrections
-  //edm::EDGetTokenT<double> eventrhoToken_;
   /// jet corrector as extra selection type
   std::string jetCorrector_;
   /// choice for b-tag as extra selection type

--- a/DQM/Physics/python/topDiLeptonOfflineDQM_cfi.py
+++ b/DQM/Physics/python/topDiLeptonOfflineDQM_cfi.py
@@ -419,7 +419,7 @@ DiElectronDQM = cms.EDAnalyzer("TopDiLeptonOfflineDQM",
       label = cms.string("elecs:step0"),
       src   = cms.InputTag("pfIsolatedElectronsEI"),
       ##electronId = cms.PSet( src = cms.InputTag("mvaTrigV0"), cutValue = cms.double(0.5) ),      
-      select = cms.string("pt>20 & abs(eta)<2.5 && gsfElectronRef.gsfTrack.trackerExpectedHitsInner.numberOfHits <= 0 && " + ElelooseIsoCut),
+      select = cms.string("pt>20 & abs(eta)<2.5 && gsfElectronRef.gsfTrack.hitPattern().numberOfHits('MISSING_INNER_HITS') <= 0 && " + ElelooseIsoCut),
       #abs(gsfElectronRef.gsfTrack.d0)<0.04
       min = cms.int32(2),
       max = cms.int32(2),

--- a/DQM/Physics/python/topSingleLeptonDQM_cfi.py
+++ b/DQM/Physics/python/topSingleLeptonDQM_cfi.py
@@ -795,7 +795,7 @@ topSingleElectronMediumDQM = cms.EDAnalyzer("TopSingleLeptonDQM",
     cms.PSet(
       label = cms.string("elecs:step0"),
       src   = cms.InputTag("pfIsolatedElectronsEI"),
-      select = cms.string("pt>30 & abs(eta)<2.5 & abs(gsfElectronRef.gsfTrack.d0)<0.02 & gsfElectronRef.gsfTrack.trackerExpectedHitsInner.numberOfHits <= 0 & (abs(gsfElectronRef.superCluster.eta) <= 1.4442 || abs(gsfElectronRef.superCluster.eta) >= 1.5660) & " + EletightIsoCut),
+      select = cms.string("pt>30 & abs(eta)<2.5 & abs(gsfElectronRef.gsfTrack.d0)<0.02 & gsfElectronRef.gsfTrack.hitPattern().numberOfHits('MISSING_INNER_HITS') <= 0 & (abs(gsfElectronRef.superCluster.eta) <= 1.4442 || abs(gsfElectronRef.superCluster.eta) >= 1.5660) & " + EletightIsoCut),
       min = cms.int32(1),
       max = cms.int32(1),
     ),


### PR DESCRIPTION
The pull request is updated with the new definition of missing hits.
That was the reason for the last failures
trackerExpectedHitsInner.numberOfHits ----> hitPattern().numberOfHits('MISSING_INNER_HITS')
