### PR TITLE
Strip writing of root file from Validation/TrackerRecHits classes

### DIFF
--- a/Validation/TrackerRecHits/interface/SiPixelRecHitsValid.h
+++ b/Validation/TrackerRecHits/interface/SiPixelRecHitsValid.h
@@ -38,16 +38,12 @@ class SiPixelRecHitsValid : public DQMEDAnalyzer {
 	virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
 	void beginJob();
 	void bookHistograms(DQMStore::IBooker & ibooker,const edm::Run& run, const edm::EventSetup& es);
-	void endJob();
 
    private:
 	void fillBarrel(const SiPixelRecHit &,const PSimHit &, DetId, const PixelGeomDetUnit *,	
 			 const TrackerTopology *tTopo);
 	void fillForward(const SiPixelRecHit &, const PSimHit &, DetId, const PixelGeomDetUnit *,
 			 const TrackerTopology *tTopo);
-
-	std::string outputFile_;
-	bool runStandalone;
 
 	//Clusters BPIX
 	MonitorElement* clustYSizeModule[8];
@@ -109,8 +105,6 @@ class SiPixelRecHitsValid : public DQMEDAnalyzer {
 	MonitorElement* recHitXPullDisk2Plaquettes[7];
 	MonitorElement* recHitYPullDisk1Plaquettes[7];
 	MonitorElement* recHitYPullDisk2Plaquettes[7];
-
-        DQMStore* dbe_;
 
         edm::ParameterSet conf_;
         edm::EDGetTokenT<SiPixelRecHitCollection> siPixelRecHitCollectionToken_;

--- a/Validation/TrackerRecHits/interface/SiStripRecHitsValid.h
+++ b/Validation/TrackerRecHits/interface/SiStripRecHitsValid.h
@@ -117,14 +117,8 @@ class SiStripRecHitsValid : public DQMEDAnalyzer {
   virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
   void bookHistograms(DQMStore::IBooker & ibooker,const edm::Run& run, const edm::EventSetup& es);
   void beginJob(const edm::EventSetup& es);
-  void endJob();
 
  private: 
-  //Back-End Interface
-  DQMStore* dbe_;
-  bool outputMEsInRootFile;
-  bool runStandalone;
-  std::string outputFileName;
 
   TotalMEs totalMEs;
 

--- a/Validation/TrackerRecHits/python/SiPixelRecHitsValid_cfi.py
+++ b/Validation/TrackerRecHits/python/SiPixelRecHitsValid_cfi.py
@@ -2,8 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 pixRecHitsValid = cms.EDAnalyzer("SiPixelRecHitsValid",
     src = cms.InputTag("siPixelRecHits"),
-    outputFile = cms.untracked.string(''),
-    runStandalone = cms.bool(False),
     associatePixel = cms.bool(True),
     ROUList = cms.vstring('g4SimHitsTrackerHitsPixelBarrelLowTof', 
         'g4SimHitsTrackerHitsPixelBarrelHighTof', 

--- a/Validation/TrackerRecHits/python/SiStripRecHitsValid_cfi.py
+++ b/Validation/TrackerRecHits/python/SiStripRecHitsValid_cfi.py
@@ -1,10 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
 stripRecHitsValid = cms.EDAnalyzer("SiStripRecHitsValid",
-#    outputFile = cms.untracked.string('sistriprechitshisto.root'),
-    outputFile = cms.string('striptrackingrechitshisto.root'),
-    runStandalone = cms.bool(False),
-    OutputMEsInRootFile = cms.bool(False),
     TopFolderName = cms.string('SiStrip/RecHitsValidation/StiffTrackingRecHits'),
 
     TH1NumTotrphi = cms.PSet(

--- a/Validation/TrackerRecHits/src/SiPixelRecHitsValid.cc
+++ b/Validation/TrackerRecHits/src/SiPixelRecHitsValid.cc
@@ -49,10 +49,7 @@
 #include <math.h>
 
 SiPixelRecHitsValid::SiPixelRecHitsValid(const edm::ParameterSet& ps)
-  : outputFile_( ps.getUntrackedParameter<std::string>( "outputFile", "pixelrechitshisto.root" ) )
-  , runStandalone ( ps.getParameter<bool>("runStandalone")  ) 
-  , dbe_(0) 
-  , conf_(ps)
+  : conf_(ps)
   , siPixelRecHitCollectionToken_( consumes<SiPixelRecHitCollection>( ps.getParameter<edm::InputTag>( "src" ) ) ) {
 
 }
@@ -64,8 +61,6 @@ void SiPixelRecHitsValid::beginJob() {
 }
 
 void SiPixelRecHitsValid::bookHistograms(DQMStore::IBooker & ibooker,const edm::Run& run, const edm::EventSetup& es){
-  dbe_ = edm::Service<DQMStore>().operator->();
-  //dbe_->showDirStructure();
   ibooker.setCurrentFolder("TrackerRecHitsV/TrackerRecHits/Pixel/clustBPIX");
   
   Char_t histo[200];
@@ -262,11 +257,6 @@ void SiPixelRecHitsValid::bookHistograms(DQMStore::IBooker & ibooker,const edm::
       sprintf(histo, "RecHit_YPull_Disk2_Plaquette%d", i+1);
       recHitYPullDisk2Plaquettes[i] = ibooker.book1D(histo, "RecHit YPull Disk2 by plaquette", 100, -10.0, 10.0);
     }
-}
-
-void SiPixelRecHitsValid::endJob() {
-  //Save histos in local root file only in standalone mode
-  if (  runStandalone && outputFile_.size() != 0 && dbe_ ){ dbe_->save(outputFile_);}
 }
 
 void SiPixelRecHitsValid::analyze(const edm::Event& e, const edm::EventSetup& es) 

--- a/Validation/TrackerRecHits/src/SiStripRecHitsValid.cc
+++ b/Validation/TrackerRecHits/src/SiStripRecHitsValid.cc
@@ -49,7 +49,6 @@ namespace helper {
 
 //Constructor
 SiStripRecHitsValid::SiStripRecHitsValid(const ParameterSet& ps) :
-  dbe_(edm::Service<DQMStore>().operator->()),
   conf_(ps),
   m_cacheID_(0)
   // matchedRecHits_( ps.getParameter<edm::InputTag>("matchedRecHits") ),
@@ -65,12 +64,6 @@ SiStripRecHitsValid::SiStripRecHitsValid(const ParameterSet& ps) :
   topFolderName_ = conf_.getParameter<std::string>("TopFolderName");
 
   SubDetList_ = conf_.getParameter<std::vector<std::string> >("SubDetList");
-  
-  outputMEsInRootFile = conf_.getParameter<bool>("OutputMEsInRootFile");
-  
-  outputFileName = conf_.getParameter<std::string>("outputFile");
-
-  runStandalone = conf_.getParameter<bool>("runStandalone");
 
   edm::ParameterSet ParametersNumTotrphi =  conf_.getParameter<edm::ParameterSet>("TH1NumTotrphi");
   switchNumTotrphi = ParametersNumTotrphi.getParameter<bool>("switchon");
@@ -179,13 +172,6 @@ void SiStripRecHitsValid::bookHistograms(DQMStore::IBooker & ibooker,const edm::
 
 void SiStripRecHitsValid::beginJob(const edm::EventSetup& es){
 }
-
-void SiStripRecHitsValid::endJob() {
-  //Only in standalone mode save local root file 
-  if(runStandalone && outputMEsInRootFile){dbe_->save(outputFileName);}
-  
-}
-
 
 void SiStripRecHitsValid::analyze(const edm::Event& e, const edm::EventSetup& es) {
 


### PR DESCRIPTION
Since these are now a DQMEDAnalyzers, output of root file is the responsibility of DQMFileSaver, so we remove the code (no longer called) that used to do this.
This replaces previous PR #4683.
