### PR TITLE
uTCA Unpacker for HCAL

### DIFF
--- a/CalibCalorimetry/HcalAlgos/src/HcalDbASCIIIO.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalDbASCIIIO.cc
@@ -1327,7 +1327,12 @@ bool HcalDbASCIIIO::getObject (std::istream& fInput, HcalElectronicsMap* fObject
     int dcc = atoi (items [4].c_str());
     int spigot = atoi (items [5].c_str());
     HcalElectronicsId elId;
-    if (items[8] == "HT" || items[8] == "NT") {
+    if (items[3][0] == 'u') { // uTCA!
+      int fiber = atoi (items [6].c_str());
+      int fiberCh = atoi (items [7].c_str());
+      bool isTrig=(items[8] == "HT" || items[8] == "NT");
+      elId=HcalElectronicsId(crate, slot, fiber, fiberCh,isTrig);
+    } else if (items[8] == "HT" || items[8] == "NT") {
       int slb = atoi (items [6].c_str());
       int slbCh = atoi (items [7].c_str());
       elId=HcalElectronicsId(slbCh, slb, spigot, dcc,crate,slot,top);
@@ -1399,14 +1404,23 @@ bool HcalDbASCIIIO::dumpObject (std::ostream& fOutput, const HcalElectronicsMap&
       DetId channel = fObject.lookup (eid);
       if (channel.rawId()) {
 	HcalText2DetIdConverter converter (channel);
-	// changes by Jared, 6.03.09/(included 25.03.09)
-	//	sprintf (buf, " %10X %6d %6d %6c %6d %6d %6d %6d %15s %15s %15s %15s",
-	sprintf (buf, " %7X %3d %3d %3c %4d %7d %10d %14d %7s %5s %5s %6s",
-		 //		 i,
-		 converter.getId().rawId(),
-		 eid.readoutVMECrateId(), eid.htrSlot(), eid.htrTopBottom()>0?'t':'b', eid.dccid(), eid.spigot(), eid.fiberIndex(), eid.fiberChanId(),
-		 converter.getFlavor ().c_str (), converter.getField1 ().c_str (), converter.getField2 ().c_str (), converter.getField3 ().c_str ()
-	       );
+	if (eid.isVMEid()) {
+	  // changes by Jared, 6.03.09/(included 25.03.09)
+	  //	sprintf (buf, " %10X %6d %6d %6c %6d %6d %6d %6d %15s %15s %15s %15s",
+	  sprintf (buf, " %7X %3d %3d %3c %4d %7d %10d %14d %7s %5s %5s %6s",
+		   //		 i,
+		   converter.getId().rawId(),
+		   eid.readoutVMECrateId(), eid.htrSlot(), eid.htrTopBottom()>0?'t':'b', eid.dccid(), eid.spigot(), eid.fiberIndex(), eid.fiberChanId(),
+		   converter.getFlavor ().c_str (), converter.getField1 ().c_str (), converter.getField2 ().c_str (), converter.getField3 ().c_str ()
+		   );
+	} else {
+	  sprintf (buf, " %7X %3d %3d u %4d %7d %10d %14d %7s %5s %5s %6s",
+		   //		 i,
+		   converter.getId().rawId(),
+		   eid.crateId(), eid.slot(), 0, eid.slot(), eid.fiberIndex(), eid.fiberChanId(),
+		   converter.getFlavor ().c_str (), converter.getField1 ().c_str (), converter.getField2 ().c_str (), converter.getField3 ().c_str ()
+		   );
+	}
 	fOutput << buf << std::endl;
       }
     }

--- a/DataFormats/HcalDetId/interface/HcalElectronicsId.h
+++ b/DataFormats/HcalDetId/interface/HcalElectronicsId.h
@@ -6,7 +6,11 @@
 #include <stdint.h>
 
 /** \brief Readout chain identification for Hcal
-    [31:26] Unused (so far)
+
+    [31:27] Unused (so far)
+    [26] VME (0), uTCA (1)
+
+    For VME Electronics:
     [25]    Trigger-chain id flag
     [24:20] Readout Crate Id
     [19] HTR FPGA selector [t/b]
@@ -15,6 +19,24 @@
     [8:5]   Spigot
     [4:2]   FiberIndex or SLB site
     [1:0]   FiberChanId or SLB channel
+
+    For uTCA Electronics:
+
+     [25:21] Subtype
+     [17:13] Readout Crate Id
+     [12:9] Slot
+     [8:4]   Fiber
+     [3:0]   FiberChanId
+
+     Subtypes:
+        0x01 = 1.6 Gbps precision (3 channel)
+        0x02 = 4.8 Gbps 6 channel ADC+RETDC
+        0x03 = 4.8 Gbps 12 channel FETDC
+        0x04 = 4.8 Gbps 4 channel ADC+RETDC+FETDC
+        0x11 = optical RCT trigger
+        0x12 = 6.4 Gbps HF trigger
+        0x13 = 4.8 Gbps HB/HE trigger
+        0x14 = 6.4 Gbps HB/HE trigger
  */
 class HcalElectronicsId {
 public:
@@ -22,47 +44,59 @@ public:
   HcalElectronicsId();
   /** from raw */
   HcalElectronicsId(uint32_t);
-  /** Constructor from fiberchan,fiber index,spigot,dccid */
+  /** VME Constructor from fiberchan,fiber index,spigot,dccid */
   HcalElectronicsId(int fiberChan, int fiberIndex, int spigot, int dccid);
-  /** Constructor from slb channel,slb site,spigot,dccid */
+  /** VME Constructor from slb channel,slb site,spigot,dccid */
   HcalElectronicsId(int slbChan, int slbSite, int spigot, int dccid, int crate, int slot, int tb);
+  /** uTCA constructor */
+  HcalElectronicsId(int subtype, int crate, int slot, int fiber, int fiberchan);
+
   uint32_t operator()() { return hcalElectronicsId_; }
 
   uint32_t rawId() const { return hcalElectronicsId_; }
 
+  bool isVMEid() const { return (hcalElectronicsId_&0x04000000)==0; }
+  bool isUTCAid() const { return (hcalElectronicsId_&0x04000000)!=0; }
   bool isTriggerChainId() const { return (hcalElectronicsId_&0x02000000)!=0; }
 
-  /** Set the htr-related information 1=top, 0=bottom*/
+  /** Set the VME htr-related information 1=top, 0=bottom*/
   void setHTR(int crate, int slot, int tb);
 
-  /// get the fiber channel id (which of three channels on a readout fiber) (valid only for non-trigger-chain ids)
-  int fiberChanId() const { return hcalElectronicsId_&0x3; }
-  /// get the fiber index [1-8] (which of eight fibers carried by a spigot) (valid only for non-trigger-chain ids)
-  int fiberIndex() const { return ((hcalElectronicsId_>>2)&0x7)+1; }
-  /// get the SLB channel index  (valid only for trigger-chain ids)
+  /// get subtype for this channel (valid for uTCA only)
+  int subtype() const { return (isUTCAid())?((hcalElectronicsId_>>21)&0x1F):(-1); }
+  /// get the fiber channel id (which of channels on a fiber) 
+  int fiberChanId() const { return (isVMEid())?(hcalElectronicsId_&0x3):(hcalElectronicsId_&0xF); }
+  /// get the fiber index.  For VME 1-8 (which of eight fibers carried by a spigot), for uTCA fibers are zero-based
+  int fiberIndex() const { return (isVMEid())?(((hcalElectronicsId_>>2)&0x7)+1):((hcalElectronicsId_>>4)&0x1F); }
+  /// get the SLB channel index  (valid only for VME trigger-chain ids)
   int slbChannelIndex() const { return hcalElectronicsId_&0x3; }
-  /// get the SLB site number (valid only for trigger-chain ids)
+  /// get the SLB site number (valid only for VME trigger-chain ids)
   int slbSiteNumber() const { return ((hcalElectronicsId_>>2)&0x7); }
+ 
+  /// get the HTR channel id (1-24)
+  int htrChanId() const { return isVMEid()?((fiberChanId()+1)+((fiberIndex()-1)*3)):(0); }
 
   /// get the HTR-wide slb channel code (letter plus number)
   std::string slbChannelCode() const;
 
-  /// get the HTR channel id (1-24)
-  int htrChanId() const { return (fiberChanId()+1)+((fiberIndex()-1)*3); }
-  /// get the spigot (input number on DCC)
-  int spigot() const { return (hcalElectronicsId_>>5)&0xF; }
-  /// get the (Hcal local) DCC id
-  int dccid() const { return (hcalElectronicsId_>>9)&0x1F; }
+  /// get the spigot (input number on DCC, AMC card number for uTCA)
+  int spigot() const { return (isVMEid())?((hcalElectronicsId_>>5)&0xF):slot(); }
+  /// get the (Hcal local) DCC id for VME, crate number for uTCA
+  int dccid() const { return (isVMEid())?((hcalElectronicsId_>>9)&0x1F):crateId(); }
   /// get the htr slot
-  int htrSlot() const { return (hcalElectronicsId_>>14)&0x1F; }
-  /// get the htr top/bottom (1=top/0=bottom)
-  int htrTopBottom() const { return (hcalElectronicsId_>>19)&0x1; }
+  int htrSlot() const { return slot(); }
+  /// get the htr or uHTR slot
+  int slot() const { return (isVMEid())?((hcalElectronicsId_>>14)&0x1F):((hcalElectronicsId_>>9)&0xF); }
+  /// get the htr top/bottom (1=top/0=bottom), valid for VME
+  int htrTopBottom() const { return (isVMEid())?((hcalElectronicsId_>>19)&0x1):(-1); }
   /// get the readout VME crate number
-  int readoutVMECrateId() const { return (hcalElectronicsId_>>20)&0x1F; }
+  int readoutVMECrateId() const { return crateId(); }
+  /// get the readout VME crate number
+  int crateId() const { return (isVMEid())?((hcalElectronicsId_>>20)&0x1F):((hcalElectronicsId_>>13)&0x1F); }
   /// get a fast, compact, unique index for linear lookups (maximum value = 16384)
-  int linearIndex() const { return (hcalElectronicsId_)&0x3FFF; }
+  int linearIndex() const { return (isVMEid())?((hcalElectronicsId_)&0x3FFF):((hcalElectronicsId_)&0x3FFFF); }
 
-  static const int maxLinearIndex = 0x3FFF;
+  static const int maxLinearIndex = 0x3FFFF; // 
   static const int maxDCCId = 31;
   
   /** Equality operator */
@@ -71,6 +105,15 @@ public:
   int operator!=(const HcalElectronicsId& id) const { return id.hcalElectronicsId_!=hcalElectronicsId_; }
   /// Compare the id to another id for use in a map
   int operator<(const HcalElectronicsId& id) const { return hcalElectronicsId_<id.hcalElectronicsId_; }
+
+  static const int st_PRECISION_1_6              = 0x01;
+  static const int st_PRECISION_4_8_6CHAN        = 0x02;
+  static const int st_PRECISION_4_8_12CHAN_TDC   = 0x03;
+  static const int st_PRECISION_4_8_4CHAN        = 0x04;
+  static const int st_TRIGGER_RCT                = 0x11;
+  static const int st_TRIGGER_HF_6_4             = 0x12;
+  static const int st_TRIGGER_HBHE_4_8           = 0x13;
+  static const int st_TRIGGER_HBHE_6_4           = 0x14;
 
 private:
   uint32_t hcalElectronicsId_;

--- a/DataFormats/HcalDetId/interface/HcalElectronicsId.h
+++ b/DataFormats/HcalDetId/interface/HcalElectronicsId.h
@@ -22,21 +22,12 @@
 
     For uTCA Electronics:
 
-     [25:21] Subtype
-     [17:13] Readout Crate Id
+     [25]    Is Trigger Id
+     [18:13] Readout Crate Id
      [12:9] Slot
      [8:4]   Fiber
      [3:0]   FiberChanId
 
-     Subtypes:
-        0x01 = 1.6 Gbps precision (3 channel)
-        0x02 = 4.8 Gbps 6 channel ADC+RETDC
-        0x03 = 4.8 Gbps 12 channel FETDC
-        0x04 = 4.8 Gbps 4 channel ADC+RETDC+FETDC
-        0x11 = optical RCT trigger
-        0x12 = 6.4 Gbps HF trigger
-        0x13 = 4.8 Gbps HB/HE trigger
-        0x14 = 6.4 Gbps HB/HE trigger
  */
 class HcalElectronicsId {
 public:
@@ -49,7 +40,7 @@ public:
   /** VME Constructor from slb channel,slb site,spigot,dccid */
   HcalElectronicsId(int slbChan, int slbSite, int spigot, int dccid, int crate, int slot, int tb);
   /** uTCA constructor */
-  HcalElectronicsId(int subtype, int crate, int slot, int fiber, int fiberchan);
+  HcalElectronicsId(int crate, int slot, int fiber, int fiberchan, bool isTrigger);
 
   uint32_t operator()() { return hcalElectronicsId_; }
 
@@ -92,11 +83,11 @@ public:
   /// get the readout VME crate number
   int readoutVMECrateId() const { return crateId(); }
   /// get the readout VME crate number
-  int crateId() const { return (isVMEid())?((hcalElectronicsId_>>20)&0x1F):((hcalElectronicsId_>>13)&0x1F); }
-  /// get a fast, compact, unique index for linear lookups (maximum value = 16384)
-  int linearIndex() const { return (isVMEid())?((hcalElectronicsId_)&0x3FFF):((hcalElectronicsId_)&0x3FFFF); }
+  int crateId() const { return (isVMEid())?((hcalElectronicsId_>>20)&0x1F):((hcalElectronicsId_>>13)&0x3F); }
+  /// get a fast, compact, unique index for linear lookups 
+  int linearIndex() const { return (isVMEid())?((hcalElectronicsId_)&0x3FFF):((hcalElectronicsId_)&0x7FFFF); }
 
-  static const int maxLinearIndex = 0x3FFFF; // 
+  static const int maxLinearIndex = 0x7FFFF; // 
   static const int maxDCCId = 31;
   
   /** Equality operator */
@@ -105,15 +96,6 @@ public:
   int operator!=(const HcalElectronicsId& id) const { return id.hcalElectronicsId_!=hcalElectronicsId_; }
   /// Compare the id to another id for use in a map
   int operator<(const HcalElectronicsId& id) const { return hcalElectronicsId_<id.hcalElectronicsId_; }
-
-  static const int st_PRECISION_1_6              = 0x01;
-  static const int st_PRECISION_4_8_6CHAN        = 0x02;
-  static const int st_PRECISION_4_8_12CHAN_TDC   = 0x03;
-  static const int st_PRECISION_4_8_4CHAN        = 0x04;
-  static const int st_TRIGGER_RCT                = 0x11;
-  static const int st_TRIGGER_HF_6_4             = 0x12;
-  static const int st_TRIGGER_HBHE_4_8           = 0x13;
-  static const int st_TRIGGER_HBHE_6_4           = 0x14;
 
 private:
   uint32_t hcalElectronicsId_;

--- a/DataFormats/HcalDetId/src/HcalElectronicsId.cc
+++ b/DataFormats/HcalDetId/src/HcalElectronicsId.cc
@@ -21,9 +21,17 @@ HcalElectronicsId::HcalElectronicsId(int slbChan, int slbSite, int spigot, int d
   hcalElectronicsId_|=0x02000000;
 }
 
+HcalElectronicsId::HcalElectronicsId(int subtype, int crate, int slot, int fiber, int fc) {
+  hcalElectronicsId_=(fc&0xF) | (((fiber)&0x1F)<<4) |
+    ((slot&0xF)<<9) | ((crate&0x1F)<<13) | ((subtype&0x1F)<<21);
+  hcalElectronicsId_|=0x04000000;
+}
+
+
+
 std::string HcalElectronicsId::slbChannelCode() const {
   std::string retval;
-  if (isTriggerChainId()) {
+  if (isTriggerChainId() && isVMEid()) {
     if (htrTopBottom()) { // top
       switch (slbChannelIndex()) {
       case (0): retval="A0"; break;
@@ -44,18 +52,34 @@ std::string HcalElectronicsId::slbChannelCode() const {
 }
 
 void HcalElectronicsId::setHTR(int crate, int slot, int tb) {
+  if (isUTCAid()) return; // cannot do this for uTCA
   hcalElectronicsId_&=0x3FFF; // keep the readout chain info
   hcalElectronicsId_|=((tb&0x1)<<19) | ((slot&0x1f)<<14) | ((crate&0x3f)<<20);
 }
 
 std::ostream& operator<<(std::ostream& os,const HcalElectronicsId& id) {
-  if (id.isTriggerChainId()) {
-    return os << id.dccid() << ',' << id.spigot() << ",SLB" << id.slbSiteNumber() << ',' << id.slbChannelIndex() << " (HTR "
-	      << id.readoutVMECrateId() << ":" << id.htrSlot() << ((id.htrTopBottom()==1)?('t'):('b')) << ')'; 
-    
+  if (id.isUTCAid()) {
+    switch (id.subtype()) {
+    case HcalElectronicsId::st_PRECISION_1_6 : os << "PREC_1.6:"; break;
+    case HcalElectronicsId::st_PRECISION_4_8_6CHAN : os << "PREC_4.8(6 CHAN):"; break;
+    case HcalElectronicsId::st_PRECISION_4_8_12CHAN_TDC : os << "PREC_4.8(12 TDC):"; break;
+    case HcalElectronicsId::st_PRECISION_4_8_4CHAN : os << "PREC_4.8(4 CHAN):"; break;
+    case HcalElectronicsId::st_TRIGGER_RCT : os << "TRIG_RCT:"; break;
+    case HcalElectronicsId::st_TRIGGER_HF_6_4 : os << "TRIG_HF_6_4:"; break;
+    case HcalElectronicsId::st_TRIGGER_HBHE_4_8 : os << "TRIG_HBHE_4_8:"; break;
+    case HcalElectronicsId::st_TRIGGER_HBHE_6_4 : os << "TRIG_HBHE_6_4:"; break;
+    default: break;
+    }
+    return os << id.crateId() << ',' << id.slot() << ',' << id.fiberIndex() << ',' << id.fiberChanId();
   } else {
-    return os << id.dccid() << ',' << id.spigot() << ',' << id.fiberIndex() << ',' << id.fiberChanId() << " (HTR "
-	      << id.readoutVMECrateId() << ":" << id.htrSlot() << ((id.htrTopBottom()==1)?('t'):('b')) << ')'; 
+    if (id.isTriggerChainId()) {
+      return os << id.dccid() << ',' << id.spigot() << ",SLB" << id.slbSiteNumber() << ',' << id.slbChannelIndex() << " (HTR "
+		<< id.readoutVMECrateId() << ":" << id.htrSlot() << ((id.htrTopBottom()==1)?('t'):('b')) << ')'; 
+      
+    } else {
+      return os << id.dccid() << ',' << id.spigot() << ',' << id.fiberIndex() << ',' << id.fiberChanId() << " (HTR "
+		<< id.readoutVMECrateId() << ":" << id.htrSlot() << ((id.htrTopBottom()==1)?('t'):('b')) << ')'; 
+    }
   }
 }
 

--- a/DataFormats/HcalDetId/src/HcalElectronicsId.cc
+++ b/DataFormats/HcalDetId/src/HcalElectronicsId.cc
@@ -1,6 +1,5 @@
 #include "DataFormats/HcalDetId/interface/HcalElectronicsId.h"
 
-
 HcalElectronicsId::HcalElectronicsId() {
   hcalElectronicsId_=0xffffffffu;
 }
@@ -21,13 +20,12 @@ HcalElectronicsId::HcalElectronicsId(int slbChan, int slbSite, int spigot, int d
   hcalElectronicsId_|=0x02000000;
 }
 
-HcalElectronicsId::HcalElectronicsId(int subtype, int crate, int slot, int fiber, int fc) {
+HcalElectronicsId::HcalElectronicsId(int crate, int slot, int fiber, int fc, bool isTrigger) {
   hcalElectronicsId_=(fc&0xF) | (((fiber)&0x1F)<<4) |
-    ((slot&0xF)<<9) | ((crate&0x1F)<<13) | ((subtype&0x1F)<<21);
+    ((slot&0xF)<<9) | ((crate&0x3F)<<13);
+  if (isTrigger)   hcalElectronicsId_|=0x02000000;
   hcalElectronicsId_|=0x04000000;
 }
-
-
 
 std::string HcalElectronicsId::slbChannelCode() const {
   std::string retval;
@@ -59,17 +57,8 @@ void HcalElectronicsId::setHTR(int crate, int slot, int tb) {
 
 std::ostream& operator<<(std::ostream& os,const HcalElectronicsId& id) {
   if (id.isUTCAid()) {
-    switch (id.subtype()) {
-    case HcalElectronicsId::st_PRECISION_1_6 : os << "PREC_1.6:"; break;
-    case HcalElectronicsId::st_PRECISION_4_8_6CHAN : os << "PREC_4.8(6 CHAN):"; break;
-    case HcalElectronicsId::st_PRECISION_4_8_12CHAN_TDC : os << "PREC_4.8(12 TDC):"; break;
-    case HcalElectronicsId::st_PRECISION_4_8_4CHAN : os << "PREC_4.8(4 CHAN):"; break;
-    case HcalElectronicsId::st_TRIGGER_RCT : os << "TRIG_RCT:"; break;
-    case HcalElectronicsId::st_TRIGGER_HF_6_4 : os << "TRIG_HF_6_4:"; break;
-    case HcalElectronicsId::st_TRIGGER_HBHE_4_8 : os << "TRIG_HBHE_4_8:"; break;
-    case HcalElectronicsId::st_TRIGGER_HBHE_6_4 : os << "TRIG_HBHE_6_4:"; break;
-    default: break;
-    }
+    if (id.isTriggerChainId()) os << "UTCA(trigger): ";
+    else os << "UTCA: ";
     return os << id.crateId() << ',' << id.slot() << ',' << id.fiberIndex() << ',' << id.fiberChanId();
   } else {
     if (id.isTriggerChainId()) {

--- a/DataFormats/HcalDigi/interface/HcalTriggerPrimitiveSample.h
+++ b/DataFormats/HcalDigi/interface/HcalTriggerPrimitiveSample.h
@@ -13,19 +13,14 @@ public:
   HcalTriggerPrimitiveSample();
   HcalTriggerPrimitiveSample(uint16_t data);
   HcalTriggerPrimitiveSample(int encodedEt, bool finegrain, int slb, int slbchan);
+  HcalTriggerPrimitiveSample(int encodedEt, int finegrainExtended);
   
   /// get the raw word
   uint16_t raw() const { return theSample; }
   /// get the encoded/compressed Et
   int compressedEt() const { return theSample&0xFF; }
-  /// get the fine-grain bit
-  bool fineGrain() const { return (theSample&0x100)!=0; }
-  /// get the slb site number
-  int slb() const { return ((theSample>>13)&0x7); }
-  /// get the slb channel number
-  int slbChan() const { return (theSample>>11)&0x3; }
-  /// get the id channel
-  int slbAndChan() const { return (theSample>>11)&0x1F; }
+  /// get fine-grain bit (traditional)
+  bool fineGrain(int i=0) const { return (((theSample)>>(i+8))&0x1)!=0; }
   
 private:
   uint16_t theSample;

--- a/DataFormats/HcalDigi/src/HcalTriggerPrimitiveSample.cc
+++ b/DataFormats/HcalDigi/src/HcalTriggerPrimitiveSample.cc
@@ -9,6 +9,10 @@ HcalTriggerPrimitiveSample::HcalTriggerPrimitiveSample(int encodedEt, bool fineG
     ((fineGrain)?(0x100):(0));
 }
 
+HcalTriggerPrimitiveSample::HcalTriggerPrimitiveSample(int encodedEt, int fineGrainExt) {
+  theSample=(encodedEt&0xFF)|((fineGrainExt&0x3F)<<8);
+}
+
 std::ostream& operator<<(std::ostream& s, const HcalTriggerPrimitiveSample& samp) {
   return s << "Value=" << samp.compressedEt() << ", FG=" << samp.fineGrain();
 }

--- a/DataFormats/HcalDigi/test/HcalDigiDump.cc
+++ b/DataFormats/HcalDigi/test/HcalDigiDump.cc
@@ -20,6 +20,18 @@ public:
 
 
 HcalDigiDump::HcalDigiDump(edm::ParameterSet const& conf) {
+  consumesMany<HBHEDigiCollection>();
+  consumesMany<HODigiCollection>();
+  consumesMany<HFDigiCollection>();
+  consumesMany<ZDCDigiCollection>();
+  consumesMany<CastorDigiCollection>();
+  consumesMany<CastorTrigPrimDigiCollection>();
+  consumesMany<HcalCalibDigiCollection>();
+  consumesMany<HcalTrigPrimDigiCollection>();
+  consumesMany<HOTrigPrimDigiCollection>();
+  consumesMany<HcalHistogramDigiCollection>();
+  consumesMany<HcalTTPDigiCollection>();
+  consumesMany<HcalUpgradeDigiCollection>();
 }
 
 void HcalDigiDump::analyze(edm::Event const& e, edm::EventSetup const& c) {

--- a/EventFilter/CastorRawToDigi/src/CastorUnpacker.cc
+++ b/EventFilter/CastorRawToDigi/src/CastorUnpacker.cc
@@ -62,6 +62,11 @@ CastorUnpacker::CastorUnpacker(int sourceIdOffset, int beg, int end) : sourceIdO
  }
 }
 
+static int slb(const HcalTriggerPrimitiveSample& theSample) { return ((theSample.raw()>>13)&0x7); }
+static int slbChan(const HcalTriggerPrimitiveSample& theSample) { return (theSample.raw()>>11)&0x3; }
+static int slbAndChan(const HcalTriggerPrimitiveSample& theSample) { return (theSample.raw()>>11)&0x1F; }
+
+
 
 void CastorUnpacker::unpack(const FEDRawData& raw, const CastorElectronicsMap& emap,
 			  CastorRawCollections& colls, HcalUnpackerReport& report, bool silent) {
@@ -165,9 +170,9 @@ void CastorUnpacker::unpack(const FEDRawData& raw, const CastorElectronicsMap& e
       for (tp_work=tp_begin; tp_work!=tp_end; tp_work++) {
 	//	  std::cout << "raw=0x"<<std::hex<< tp_work->raw()<<std::dec <<std::endl;
 	if (tp_work->raw()==0xFFFF) continue; // filler word
-	if (tp_work->slbAndChan()!=currFiberChan) { // start new set
+	if (slbAndChan(*tp_work)!=currFiberChan) { // start new set
 	  npre=0;
-	  currFiberChan=tp_work->slbAndChan();
+	  currFiberChan=slbAndChan(*tp_work);
 	  
 		// std::cout<< " NEW SET "<<std::endl;
 	  //HcalElectronicsId eid(tp_work->slbChan(),tp_work->slb(),spigot,dccid,htr_cr,htr_slot,htr_tb);
@@ -190,7 +195,7 @@ void CastorUnpacker::unpack(const FEDRawData& raw, const CastorElectronicsMap& e
 	  colls.tpCont->push_back(CastorTriggerPrimitiveDigi(id));
 	  // set the various bits
 	  if (!tpgSOIbitInUse) colls.tpCont->back().setPresamples(nps);
-	  colls.tpCont->back().setZSInfo(htr.isUnsuppressed(),htr.wasMarkAndPassZSTP(tp_work->slb(),tp_work->slbChan()));
+	  colls.tpCont->back().setZSInfo(htr.isUnsuppressed(),htr.wasMarkAndPassZSTP(slb(*tp_work),slbChan(*tp_work)));
 
 	  // no hits recorded for current
 	  ncurr=0;

--- a/EventFilter/HcalRawToDigi/interface/AMC13Header.h
+++ b/EventFilter/HcalRawToDigi/interface/AMC13Header.h
@@ -1,0 +1,64 @@
+/* -*- C++ -*- */
+#ifndef AMC13Header_H_included
+#define AMC13Header_H_included
+
+#include <stdint.h>
+
+namespace hcal {
+  /** \class AMC13Header
+   *
+   *  Interpretive class for the AMC13XG common data format
+   */
+  class AMC13Header {
+  public:
+    /** get the source id from the CDF header */
+    inline int sourceId() const { return int(cdfHeader>>8)&0xFFF; }
+    /** get the bunch id from the CDF header */
+    inline int bunchId() const { return int(cdfHeader>>20)&0xFFF; }
+    /** get the Event Number from the CDF header */
+    inline int l1aNumber() const { return int((cdfHeader>>32) & 0x00FFFFFF); }
+    /** Get the Event Type value (2007.11.03 - Not defined, but should stay consistent among events.) */
+    inline int CDFEventType() const { return ( int(cdfHeader>>56) & 0x0F ); }  
+    /** Get the Orbit Number from the CDF. */
+    inline unsigned int orbitNumber() const { return (unsigned int)((amc13Header>>4)&0xFFFFFFFFu); }
+    /** Get the number of modules in the payload */
+    inline int NAMC() const { return int((amc13Header>>52)&0xF); }
+    /** Get the format version number */
+    inline int AMC13FormatVersion() const { return int((amc13Header>>60)&0xF); }
+    
+    // Per-AMC items
+    /** Get the board identifier for the given module (sequential) */
+    inline uint16_t AMCId(int i) const { return uint16_t(modulesHeaders[i]&0xFFFF); }
+    /** Get the slot for the given module (sequential) */
+    inline int AMCSlot(int i) const { return int((modulesHeaders[i]>>16)&0xF); }
+    /** Get the block number */
+    inline int AMCBlockNumber(int i) const { return int((modulesHeaders[i]>>20)&0xFF); }
+    /** Get the size */
+    inline int AMCSize(int i) const { return int((modulesHeaders[i]>>32)&0xFFFFFF); }
+    /** More blocks? */
+    inline bool AMCMore(int i) const { return ((modulesHeaders[i]>>61)&0x1)!=0; }
+    /** Segmented data? */
+    inline bool AMCSegmented(int i) const { return ((modulesHeaders[i]>>60)&0x1)!=0; }
+    /** Was the length as expected? */
+    inline bool AMCLengthOk(int i) const { return ((modulesHeaders[i]>>62)&0x1)!=0; }
+    /** Was the CRC correct as received by the AMC13? */
+    inline bool AMCCRCOk(int i) const { return ((modulesHeaders[i]>>56)&0x1)!=0; }
+    /** Is there data for this AMC? */
+    inline bool AMCDataPresent(int i) const { return ((modulesHeaders[i]>>58)&0x1)!=0; }
+    /** Does the EvN and BCN match for this AMC? */
+    inline bool AMCDataValid(int i) const { return ((modulesHeaders[i]>>57)&0x1)!=0; }
+    /** Is this AMC input enabled? */
+    inline bool AMCEnabled(int i) const { return ((modulesHeaders[i]>>59)&0x1)!=0; }
+
+    /** Get the pointer to the beginning of the data for the given AMC */
+    const uint64_t* AMCPayload(int i) const;
+
+
+  private:
+    uint64_t cdfHeader;
+    uint64_t amc13Header;
+    uint64_t modulesHeaders[12];
+  };
+}
+
+#endif // AMC13Header_H_included

--- a/EventFilter/HcalRawToDigi/interface/HcalDCCHeader.h
+++ b/EventFilter/HcalRawToDigi/interface/HcalDCCHeader.h
@@ -43,7 +43,7 @@ class HcalDCCHeader {
   /** Check the third bit of second Slink64 CDF word */
   inline bool thereIsAThirdCDFHeaderWord() const {return ((commondataformat2>>3) & 0x0001); }
   /** Get the Orbit Number from the CDF. */
-  inline unsigned int getOrbitNumber() const { return ( ((commondataformat3 & 0xF) << 28) + ( commondataformat2>>4) ); }
+  inline unsigned int getOrbitNumber() const { return ( ((commondataformat3 && 0xF) << 28) + ( commondataformat2>>4) ); }
   /** get the (undefined) 'Reserved' part of the second Slink64 CDF word */
   inline unsigned int getSlink64ReservedBits() const { return (  (commondataformat3>>4)&0x00FFFFFF ); }
   /** Get the Beginning Of Event bits.  If it's not the first or last CDF Slink64 word, the high 4 bits must be zero.*/
@@ -128,13 +128,13 @@ class HcalDCCHeader {
 
  private:
   // CURRENTLY VALID FOR LITTLE-ENDIAN (LINUX/x86) ONLY
-  unsigned int commondataformat0;
-  unsigned int commondataformat1;
-  unsigned int commondataformat2;
-  unsigned int commondataformat3;
-  unsigned int dcch0;
-  unsigned int dcch1;
-  unsigned int spigotInfo[18];   //The last three of these 32bit words should always be zero!
+  uint32_t commondataformat0;
+  uint32_t commondataformat1;
+  uint32_t commondataformat2;
+  uint32_t commondataformat3;
+  uint32_t dcch0;
+  uint32_t dcch1;
+  uint32_t spigotInfo[18];   //The last three of these 32bit words should always be zero!
 
 };
 

--- a/EventFilter/HcalRawToDigi/interface/HcalUHTRData.h
+++ b/EventFilter/HcalRawToDigi/interface/HcalUHTRData.h
@@ -39,7 +39,7 @@ class HcalUHTRData {
   
   class const_iterator {
   public:
-    const_iterator(const uint16_t* ptr);
+    const_iterator(const uint16_t* ptr, const uint16_t* limit=0);
     
     bool isHeader() const { return ((*m_ptr)&0x8000)!=0; }    
     int flavor() const { return ((*m_ptr)>>12)&0x7; }    
@@ -64,7 +64,7 @@ class HcalUHTRData {
 
   private:
     void determineMode();
-    const uint16_t* m_ptr;
+    const uint16_t* m_ptr, *m_limit;
     int m_microstep;
     int m_stepclass;
     int m_flavor;

--- a/EventFilter/HcalRawToDigi/interface/HcalUHTRData.h
+++ b/EventFilter/HcalRawToDigi/interface/HcalUHTRData.h
@@ -1,0 +1,132 @@
+/* -*- C++ -*- */
+#ifndef HcalUHTRData_H
+#define HcalUHTRData_H
+
+#include <stdint.h>
+
+/**  \class HcalUHTRData
+ *
+ *  Interpretive class for HcalUHTRData
+ *  Since this class requires external specification of the length of the data, it is implemented
+ *  as an interpreter, rather than a cast-able header class.
+ *
+ *  \author J. Mans - UMN
+ */
+
+class HcalUHTRData {
+ public:
+  static const int FIBERS_PER_UHTR             = 24;
+  static const int CHANNELS_PER_FIBER_HF       = 4;
+  static const int CHANNELS_PER_FIBER_HBHE     = 6;
+  static const int CHANNELS_PER_FIBER_MAX      = 8;
+  
+  HcalUHTRData();
+  ~HcalUHTRData() { if (m_ownData!=0) delete [] m_ownData; }
+  HcalUHTRData(int version_to_create);
+  HcalUHTRData(const uint64_t* data, int length_words);
+  HcalUHTRData(const HcalUHTRData&);
+  
+  HcalUHTRData& operator=(const HcalUHTRData&);
+  
+  /** \brief Get the version number of this event */
+  inline int getFormatVersion() const { return m_formatVersion; }
+  
+  /** \brief Get a pointer to the raw data */
+  inline const unsigned short* getRawData16() const { return m_raw16; }
+  
+  /** \brief Get the length of the raw data */
+  inline const int getRawLengthBytes() const { return m_rawLength64*sizeof(uint64_t); }
+  
+  class const_iterator {
+  public:
+    const_iterator(const uint16_t* ptr);
+    
+    bool isHeader() const { return ((*m_ptr)&0x8000)!=0; }    
+    int flavor() const { return ((*m_ptr)>>12)&0x7; }    
+    int errFlags() const { return ((*m_ptr)>>10)&0x3; }    
+    int capid0() const { return ((*m_ptr)>>8)&0x3; }    
+    int channelid() const { return ((*m_ptr))&0xFF; }    
+
+    uint16_t value() const { return *m_ptr; }
+
+    uint8_t adc() const;
+    uint8_t re_tdc() const;
+    uint8_t fe_tdc() const;
+    bool soi() const;
+
+    uint16_t operator*() const { return *m_ptr; }
+
+    /** Increment operator is "magic" and adjusts steps to match channel requirements. */
+    const_iterator& operator++();
+
+    bool operator==(const const_iterator& i) { return m_ptr==i.m_ptr; }
+    bool operator!=(const const_iterator& i) { return m_ptr!=i.m_ptr; }
+
+  private:
+    void determineMode();
+    const uint16_t* m_ptr;
+    int m_microstep;
+    int m_stepclass;
+    int m_flavor;
+  };    
+
+  const_iterator begin() const;
+  const_iterator end() const;
+
+  class packer {
+  public:
+    packer(uint16_t* baseptr);
+    void addHeader(int flavor, int errf, int cap0, int channelid);
+    void addSample(int adc, bool soi=false, int retdc=0, int fetdc=0, int tdcstat=0);
+    void addTP(int tpword, bool soi=false);
+  private:
+    uint16_t* m_baseptr;
+    int m_ptr;
+    int m_flavor;
+    int m_ministep;
+  };
+
+  packer pack();
+
+
+  /** \brief pack header and trailer (call _after_ pack)*/
+  void packHeaderTrailer(int L1Anumber, int bcn, int submodule, int
+			 orbitn, int pipeline, int ndd, int nps, int firmwareRev=0);
+
+  /** \brief pack trailer with Mark and Pass bits */
+  void packUnsuppressed(const bool* mp);
+    
+  /** \brief Get the HTR event number */
+  inline uint32_t l1ANumber() const {  return uint32_t(m_raw64[0]>>32)&0xFFFFFF; }
+  /** \brief Get the HTR bunch number */
+  inline uint32_t bunchNumber() const { return uint32_t(m_raw64[0]>>20)&0xFFF; }
+  /** \brief Get the HTR orbit number */
+  inline uint32_t orbitNumber() const { return uint32_t(m_raw64[1]>>16)&0xFFFF; }
+  /** \brief Get the raw board id */
+  inline uint32_t boardId() const { return uint32_t(m_raw64[1])&0xFFFF; }
+  /** \brief Get the board crate */
+  inline uint32_t crateId() const { return uint32_t(m_raw64[1])&0xFF; }
+  /** \brief Get the board slot */
+  inline uint32_t slot() const { return uint32_t(m_raw64[1]>>8)&0xF; }
+
+  /** \brief Was this channel passed as part of Mark&Pass ZS?*/
+  bool wasMarkAndPassZS(int fiber, int fiberchan) const;
+  /** \brief Was this channel passed as part of Mark&Pass ZS?*/
+  bool wasMarkAndPassZSTP(int slb, int slbchan) const;
+  
+  /** \brief Get the HTR firmware version */
+  unsigned int getFirmwareRevision() const { return uint32_t(m_raw64[1]>>48)&0xFFFF; }
+  /** \brief Get the HTR firmware flavor */
+  int getFirmwareFlavor() const { return uint32_t(m_raw64[1]>>32)&0xFF; }
+
+
+protected:
+  int m_formatVersion;
+  int m_rawLength64;
+  const uint64_t* m_raw64;
+  const uint16_t* m_raw16;
+  uint64_t* m_ownData;
+};
+
+#endif
+

--- a/EventFilter/HcalRawToDigi/interface/HcalUnpacker.h
+++ b/EventFilter/HcalRawToDigi/interface/HcalUnpacker.h
@@ -38,14 +38,12 @@ public:
   void setExpectedOrbitMessageTime(int time) { expectedOrbitMessageTime_=time; }
   void unpack(const FEDRawData& raw, const HcalElectronicsMap& emap, std::vector<HcalHistogramDigi>& histoDigis);
   void unpack(const FEDRawData& raw, const HcalElectronicsMap& emap, Collections& conts, HcalUnpackerReport& report, bool silent=false);
-  // Old -- deprecated
-  void unpack(const FEDRawData& raw, const HcalElectronicsMap& emap, std::vector<HBHEDataFrame>& precision, std::vector<HcalTriggerPrimitiveDigi>& tp);
-  // Old -- deprecated
-  void unpack(const FEDRawData& raw, const HcalElectronicsMap& emap, std::vector<HODataFrame>& precision, std::vector<HcalTriggerPrimitiveDigi>& tp);
-  // Old -- deprecated
-  void unpack(const FEDRawData& raw, const HcalElectronicsMap& emap, std::vector<HFDataFrame>& precision, std::vector<HcalTriggerPrimitiveDigi>& tp);
   void setMode(int mode) { mode_=mode; }
 private:
+  void unpackVME(const FEDRawData& raw, const HcalElectronicsMap& emap, Collections& conts, HcalUnpackerReport& report, bool silent=false);
+  void unpackUTCA(const FEDRawData& raw, const HcalElectronicsMap& emap, Collections& conts, HcalUnpackerReport& report, bool silent=false);
+
+
   int sourceIdOffset_; ///< number to subtract from the source id to get the dcc id
   int startSample_; ///< first sample from fed raw data to copy 
   int endSample_; ///< last sample from fed raw data to copy (if present)

--- a/EventFilter/HcalRawToDigi/plugins/HcalRawToDigi.cc
+++ b/EventFilter/HcalRawToDigi/plugins/HcalRawToDigi.cc
@@ -105,6 +105,7 @@ void HcalRawToDigi::produce(edm::Event& e, const edm::EventSetup& es)
   // Step C: unpack all requested FEDs
   for (std::vector<int>::const_iterator i=fedUnpackList_.begin(); i!=fedUnpackList_.end(); i++) {
     const FEDRawData& fed = rawraw->FEDData(*i);
+    std::cout << "FED " << *i << " size=" << fed.size() << std::endl;
     if (fed.size()==0) {
       if (complainEmptyData_) {
 	if (!silent_) edm::LogWarning("EmptyData") << "No data for FED " << *i;

--- a/EventFilter/HcalRawToDigi/plugins/HcalRawToDigi.cc
+++ b/EventFilter/HcalRawToDigi/plugins/HcalRawToDigi.cc
@@ -105,7 +105,6 @@ void HcalRawToDigi::produce(edm::Event& e, const edm::EventSetup& es)
   // Step C: unpack all requested FEDs
   for (std::vector<int>::const_iterator i=fedUnpackList_.begin(); i!=fedUnpackList_.end(); i++) {
     const FEDRawData& fed = rawraw->FEDData(*i);
-    std::cout << "FED " << *i << " size=" << fed.size() << std::endl;
     if (fed.size()==0) {
       if (complainEmptyData_) {
 	if (!silent_) edm::LogWarning("EmptyData") << "No data for FED " << *i;

--- a/EventFilter/HcalRawToDigi/src/AMC13Header.cc
+++ b/EventFilter/HcalRawToDigi/src/AMC13Header.cc
@@ -1,0 +1,10 @@
+#include "EventFilter/HcalRawToDigi/interface/AMC13Header.h"
+
+namespace hcal {
+  const uint64_t* AMC13Header::AMCPayload(int i) const {
+    const uint64_t* ptr=(&cdfHeader)+14;
+    for (int j=0; j<i; j++)
+      ptr+=AMCSize(j);
+    return ptr;
+  }
+}

--- a/EventFilter/HcalRawToDigi/src/AMC13Header.cc
+++ b/EventFilter/HcalRawToDigi/src/AMC13Header.cc
@@ -2,7 +2,7 @@
 
 namespace hcal {
   const uint64_t* AMC13Header::AMCPayload(int i) const {
-    const uint64_t* ptr=(&cdfHeader)+14;
+    const uint64_t* ptr=(&cdfHeader)+2+NAMC();
     for (int j=0; j<i; j++)
       ptr+=AMCSize(j);
     return ptr;

--- a/EventFilter/HcalRawToDigi/src/HcalUHTRData.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalUHTRData.cc
@@ -3,11 +3,12 @@
 
 static const int HEADER_LENGTH_16BIT=2*sizeof(uint64_t)/sizeof(uint16_t);
 
-HcalUHTRData::const_iterator::const_iterator(const uint16_t* ptr) : m_ptr(ptr) {
+HcalUHTRData::const_iterator::const_iterator(const uint16_t* ptr, const uint16_t* limit) : m_ptr(ptr), m_limit(limit) {
   if (isHeader()) determineMode();
 }
 
 HcalUHTRData::const_iterator& HcalUHTRData::const_iterator::operator++() {
+  if (m_ptr==m_limit) return *this;
   if (m_stepclass==0) m_ptr++;
   else if (m_stepclass==1) {
     if (m_microstep==0) { m_ptr++; m_microstep++; }
@@ -51,11 +52,11 @@ uint8_t HcalUHTRData::const_iterator::fe_tdc() const {
 
 
 HcalUHTRData::const_iterator HcalUHTRData::begin() const {
-  return HcalUHTRData::const_iterator(m_raw16+HEADER_LENGTH_16BIT);
+  return HcalUHTRData::const_iterator(m_raw16+HEADER_LENGTH_16BIT,m_raw16+(m_rawLength64-1)*sizeof(uint64_t)/sizeof(uint16_t));
 }
 
 HcalUHTRData::const_iterator HcalUHTRData::end() const {
-  return HcalUHTRData::const_iterator(m_raw16+(m_rawLength64-1)*sizeof(uint64_t)/sizeof(uint16_t));
+  return HcalUHTRData::const_iterator(m_raw16+(m_rawLength64-1)*sizeof(uint64_t)/sizeof(uint16_t),m_raw16+(m_rawLength64-1)*sizeof(uint64_t)/sizeof(uint16_t));
 }
 
 HcalUHTRData::packer::packer(uint16_t* baseptr) : m_baseptr(baseptr),m_ptr(0),m_flavor(0),m_ministep(0) {

--- a/EventFilter/HcalRawToDigi/src/HcalUHTRData.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalUHTRData.cc
@@ -1,0 +1,130 @@
+#include "EventFilter/HcalRawToDigi/interface/HcalUHTRData.h"
+#include <string.h>
+
+static const int HEADER_LENGTH_16BIT=2*sizeof(uint64_t)/sizeof(uint16_t);
+
+HcalUHTRData::const_iterator::const_iterator(const uint16_t* ptr) : m_ptr(ptr) {
+  if (isHeader()) determineMode();
+}
+
+HcalUHTRData::const_iterator& HcalUHTRData::const_iterator::operator++() {
+  if (m_stepclass==0) m_ptr++;
+  else if (m_stepclass==1) {
+    if (m_microstep==0) { m_ptr++; m_microstep++; }
+    else { m_microstep--; }
+  } 
+  else if (m_stepclass==2) m_ptr+=2;
+
+  if (isHeader()) determineMode();
+  return *this;
+}
+
+void HcalUHTRData::const_iterator::determineMode() {
+  if (!isHeader()) return;
+  m_flavor=flavor();
+  m_stepclass=0;
+  if (m_flavor==5) { m_stepclass=1; m_microstep=0; }
+  else if ((m_flavor&0x6)==0x2) { m_stepclass=2; }
+}
+
+uint8_t HcalUHTRData::const_iterator::adc() const {
+  if (m_flavor==0x5 && m_microstep==0) return ((*m_ptr)>>8)&0x7F;
+  else return (*m_ptr)&0xFF;
+}
+
+uint8_t HcalUHTRData::const_iterator::re_tdc() const {
+  if (m_flavor==0x5) return 0x80;
+  else if ((m_flavor&0x6)==0x2) return (m_ptr[1]&0x3F);
+  else return (((*m_ptr)&0x3F00)>>8);
+}
+
+bool HcalUHTRData::const_iterator::soi() const {
+  if (m_flavor==0x5) return false;
+  else if ((m_flavor&0x6)==0x2) return (m_ptr[0]&0x2000);
+  else return (((*m_ptr)&0x4000));
+}
+
+uint8_t HcalUHTRData::const_iterator::fe_tdc() const {
+  if (m_flavor==0x5 || (m_flavor&0x6)==0x0) return 0x80;
+  else return ((m_ptr[1]>>6)&0xF);
+}
+
+
+HcalUHTRData::const_iterator HcalUHTRData::begin() const {
+  return HcalUHTRData::const_iterator(m_raw16+HEADER_LENGTH_16BIT);
+}
+
+HcalUHTRData::const_iterator HcalUHTRData::end() const {
+  return HcalUHTRData::const_iterator(m_raw16+(m_rawLength64-1)*sizeof(uint64_t)/sizeof(uint16_t));
+}
+
+HcalUHTRData::packer::packer(uint16_t* baseptr) : m_baseptr(baseptr),m_ptr(0),m_flavor(0),m_ministep(0) {
+}
+
+void HcalUHTRData::packer::addHeader(int flavor, int errf, int cap0, int channelid) {
+  m_baseptr[m_ptr]=0x8000 | 
+    ((flavor&0x7)<<12) |
+    ((errf&0x3)<<10) |
+    ((cap0&0x3)<<8) | 
+    (channelid&0xFF);
+  m_flavor=flavor; 
+  m_ministep=0;
+  m_ptr++;
+}
+
+void HcalUHTRData::packer::addSample(int adc, bool soi, int retdc, int fetdc, int tdcstat) {
+  if (m_flavor==0x5) {
+    if (m_ministep==0) m_baseptr[m_ptr]=adc&0x7F;
+    else m_baseptr[m_ptr]|=((adc&0x7f)<<8);
+    if (m_ministep==1) m_ptr++;
+    m_ministep=(m_ministep+1)%2;
+  } else if ((m_flavor&0x6)==0x0) {
+    m_baseptr[m_ptr]=(adc&0xFF) | ((retdc&0x3F)<<8);
+    if (soi) m_baseptr[m_ptr]|=0x4000;
+    m_ptr++;
+  } else if ((m_flavor&0x6)==0x1) {
+    m_baseptr[m_ptr]=(adc&0xFF);
+    m_baseptr[m_ptr+1]=0x4000| ((tdcstat&0x3)<<10) | ((fetdc&0xF)<<6) | ((retdc)<<8);    
+    if (soi) m_baseptr[m_ptr]|=0x2000;
+    m_ptr+=2;
+  }
+}
+
+void HcalUHTRData::packer::addTP(int tpword, bool soi) {
+  if (m_flavor==0x4) {
+    m_baseptr[m_ptr]=tpword&0xFFF;
+    if (soi) m_baseptr[m_ptr]|=0x4000;
+    m_ptr++;
+  }
+}
+
+HcalUHTRData::HcalUHTRData() : m_formatVersion(-2), m_rawLength64(0), m_raw64(0), m_raw16(0), m_ownData(0) { }
+
+HcalUHTRData::HcalUHTRData(const uint64_t* data, int length) : m_rawLength64(length),m_raw64(data),m_raw16((const uint16_t*)(data)),m_ownData(0) {
+  m_formatVersion=(m_raw16[6]>>12)&0xF;
+}
+
+HcalUHTRData::HcalUHTRData(const HcalUHTRData& hd) : m_formatVersion(hd.m_formatVersion), m_rawLength64(hd.m_rawLength64), m_raw64(hd.m_raw64), m_raw16(hd.m_raw16), m_ownData(0) { }
+
+HcalUHTRData::HcalUHTRData(int version_to_create) : m_formatVersion(version_to_create) {
+
+  // the needed space is for the biggest possible event...
+  // fibers*maxsamples/fiber
+  const int needed=(0x20+FIBERS_PER_UHTR*CHANNELS_PER_FIBER_MAX*(10+1))*sizeof(uint16_t)/sizeof(uint64_t);
+
+  m_ownData=new uint64_t[needed];
+  memset(m_ownData,0,sizeof(uint64_t)*needed);
+  m_rawLength64=0;
+  m_raw64=m_ownData;
+  m_raw16=(const uint16_t*)m_raw64;
+}
+
+HcalUHTRData& HcalUHTRData::operator=(const HcalUHTRData& hd) {
+  if (m_ownData==0) {
+    m_formatVersion=hd.m_formatVersion;
+    m_rawLength64=hd.m_rawLength64;
+    m_raw64=hd.m_raw64;
+    m_raw16=hd.m_raw16;
+  }
+  return (*this);
+}

--- a/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
@@ -177,6 +177,11 @@ void HcalUnpacker::unpack(const FEDRawData& raw, const HcalElectronicsMap& emap,
   else unpackUTCA(raw,emap,colls,report,silent);
 }
 
+static int slb(uint16_t theSample) { return ((theSample>>13)&0x7); }
+static int slbChan(uint16_t theSample) { return (theSample>>11)&0x3; }
+static int slbAndChan(uint16_t theSample) { return (theSample>>11)&0x1F; }
+
+
 void HcalUnpacker::unpackVME(const FEDRawData& raw, const HcalElectronicsMap& emap,
 			  Collections& colls, HcalUnpackerReport& report, bool silent) {
 
@@ -301,7 +306,7 @@ void HcalUnpacker::unpackVME(const FEDRawData& raw, const HcalElectronicsMap& em
       HOUnrolledTP unrolled[24];
       for (tp_work=tp_begin; tp_work!=tp_end; tp_work++) {
 	if (tp_work->raw()==0xFFFF) continue; // filler word
-	int sector=tp_work->slbChan();
+	int sector=slbChan(tp_work->raw());
 	if (sector>2) continue;
 
 	for (int ibit=0; ibit<8; ibit++) {
@@ -344,11 +349,11 @@ void HcalUnpacker::unpackVME(const FEDRawData& raw, const HcalElectronicsMap& em
     } else { // regular TPs (not HO)
       for (tp_work=tp_begin; tp_work!=tp_end; tp_work++) {
 	if (tp_work->raw()==0xFFFF) continue; // filler word
-	if (tp_work->slbAndChan()!=currFiberChan) { // start new set
+	if (slbAndChan(tp_work->raw())!=currFiberChan) { // start new set
 	  npre=0;
-	  currFiberChan=tp_work->slbAndChan();
+	  currFiberChan=slbAndChan(tp_work->raw());
 	  // lookup the right channel
-	  HcalElectronicsId eid(tp_work->slbChan(),tp_work->slb(),spigot,dccid,htr_cr,htr_slot,htr_tb);
+	  HcalElectronicsId eid(slbChan(tp_work->raw()),slb(tp_work->raw()),spigot,dccid,htr_cr,htr_slot,htr_tb);
 	  DetId did=emap.lookupTrigger(eid);
 	  if (did.null()) {
 	    report.countUnmappedTPDigi(eid);
@@ -368,7 +373,7 @@ void HcalUnpacker::unpackVME(const FEDRawData& raw, const HcalElectronicsMap& em
 	  colls.tpCont->push_back(HcalTriggerPrimitiveDigi(id));
 	  // set the various bits
 	  if (!tpgSOIbitInUse) colls.tpCont->back().setPresamples(nps);
-	  colls.tpCont->back().setZSInfo(htr.isUnsuppressed(),htr.wasMarkAndPassZSTP(tp_work->slb(),tp_work->slbChan()));
+	  colls.tpCont->back().setZSInfo(htr.isUnsuppressed(),htr.wasMarkAndPassZSTP(slb(tp_work->raw()),slbChan(tp_work->raw())));
 
 	  // no hits recorded for current
 	  ncurr=0;
@@ -557,7 +562,7 @@ void HcalUnpacker::unpackUTCA(const FEDRawData& raw, const HcalElectronicsMap& e
       if (!silent) 
 	edm::LogWarning("Invalid Data") << "CRC Error on uHTR data observed on iamc " << iamc << " of AMC13 with source id " << amc13->sourceId();
       report.countSpigotFormatError();
-      continue;
+      //      continue;
     }
     // this unpacker cannot handle segmented data!
     if (amc13->AMCSegmented(iamc)) {
@@ -576,14 +581,16 @@ void HcalUnpacker::unpackUTCA(const FEDRawData& raw, const HcalElectronicsMap& e
     HcalUHTRData uhtr(amc13->AMCPayload(iamc),amc13->AMCSize(iamc));
     HcalUHTRData::const_iterator i=uhtr.begin(), iend=uhtr.end();
     while (i!=iend) {
+      ///      std::cout << i.isHeader() << " " << i.flavor() << std::endl;
+
       if (!i.isHeader()) {
 	++i;
 	continue;
       }
       if (i.flavor()==0x5) { // Old-style digis
-	int ifiber=((i.channelid()>>2)&0x7)+1;
+	int ifiber=((i.channelid()>>2)&0x1F);
 	int ichan=(i.channelid()&0x3);
-	HcalElectronicsId eid(0x01,crate,slot,ifiber,ichan);
+	HcalElectronicsId eid(crate,slot,ifiber,ichan, false);
 	DetId did=emap.lookup(eid);
 	
 	if (!did.null()) { // unpack and store...
@@ -632,7 +639,39 @@ void HcalUnpacker::unpackUTCA(const FEDRawData& raw, const HcalElectronicsMap& e
 	       ++i);
 	}
       } else if (i.flavor()==0x4) { // TP digis
-	
+	int ilink=((i.channelid()>>4)&0x7);
+	int itower=(i.channelid()&0xF);
+	HcalElectronicsId eid(crate,slot,ilink,itower,true);
+	DetId did=emap.lookupTrigger(eid);
+	std::cout << "Unpacking " << eid << " " << i.channelid() << std::endl;
+	if (did.null()) {
+	  report.countUnmappedTPDigi(eid);
+	  if (unknownIdsTrig_.find(eid)==unknownIdsTrig_.end()) {
+	    if (!silent) edm::LogWarning("HCAL") << "HcalUnpacker: No trigger primitive match found for electronics id :" << eid;
+	    unknownIdsTrig_.insert(eid);
+	  }
+	  // Skip it
+	  for (++i; i!=iend && !i.isHeader(); ++i);	
+	} else if (did==HcalTrigTowerDetId::Undefined || 
+		   (did.det()==DetId::Hcal && did.subdetId()==0)) {
+	  for (++i; i!=iend && !i.isHeader(); ++i);	
+	} else {
+	  HcalTrigTowerDetId id(did);
+	  std::cout << "Unpacking " << id << std::endl;
+	  colls.tpCont->push_back(HcalTriggerPrimitiveDigi(id));
+	  int j=0;
+	  for (++i; i!=iend && !i.isHeader(); ++i) {
+	    colls.tpCont->back().setSample(j,i.value());
+	    if (i.soi()) colls.tpCont->back().setPresamples(j);
+	    j++;
+	  }
+	  colls.tpCont->back().setSize(j);
+	}      
+      } else {
+	// consume any not-understood channel data
+	  for (++i;
+	       i!=iend && !i.isHeader();
+	       ++i);	
       }
     }
   }

--- a/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
@@ -643,7 +643,7 @@ void HcalUnpacker::unpackUTCA(const FEDRawData& raw, const HcalElectronicsMap& e
 	int itower=(i.channelid()&0xF);
 	HcalElectronicsId eid(crate,slot,ilink,itower,true);
 	DetId did=emap.lookupTrigger(eid);
-	std::cout << "Unpacking " << eid << " " << i.channelid() << std::endl;
+	//std::cout << "Unpacking " << eid << " " << i.channelid() << std::endl;
 	if (did.null()) {
 	  report.countUnmappedTPDigi(eid);
 	  if (unknownIdsTrig_.find(eid)==unknownIdsTrig_.end()) {
@@ -657,7 +657,7 @@ void HcalUnpacker::unpackUTCA(const FEDRawData& raw, const HcalElectronicsMap& e
 	  for (++i; i!=iend && !i.isHeader(); ++i);	
 	} else {
 	  HcalTrigTowerDetId id(did);
-	  std::cout << "Unpacking " << id << std::endl;
+	  //std::cout << "Unpacking " << id << std::endl;
 	  colls.tpCont->push_back(HcalTriggerPrimitiveDigi(id));
 	  int j=0;
 	  for (++i; i!=iend && !i.isHeader(); ++i) {


### PR DESCRIPTION
Updates to the data formats and unpacker to support the new uTCA FEDs in HCAL.  Tested with readout of both VME and uTCA data taken at P5.  Backward compatible with older data formats.
