### PR TITLE
remove beginJob in SiPixelMonitorCluster

### DIFF
--- a/DQM/SiPixelMonitorCluster/interface/SiPixelClusterSource.h
+++ b/DQM/SiPixelMonitorCluster/interface/SiPixelClusterSource.h
@@ -65,7 +65,6 @@
        typedef edmNew::DetSet<SiPixelCluster>::const_iterator    ClusterIterator;
        
        virtual void analyze(const edm::Event&, const edm::EventSetup&);
-       virtual void beginJob() ;
        virtual void dqmBeginRun(const edm::Run&, edm::EventSetup const&) ;
        virtual void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 

--- a/DQM/SiPixelMonitorCluster/src/SiPixelClusterSource.cc
+++ b/DQM/SiPixelMonitorCluster/src/SiPixelClusterSource.cc
@@ -66,6 +66,7 @@ SiPixelClusterSource::SiPixelClusterSource(const edm::ParameterSet& iConfig) :
 
    //set Token(-s)
    srcToken_ = consumes<edmNew::DetSetVector<SiPixelCluster> >(conf_.getParameter<edm::InputTag>("src"));
+   firstRun = true;
 }
 
 
@@ -83,9 +84,6 @@ SiPixelClusterSource::~SiPixelClusterSource()
 }
 
 
-void SiPixelClusterSource::beginJob(){
-  firstRun = true;
-}
 
 void SiPixelClusterSource::dqmBeginRun(const edm::Run& r, const edm::EventSetup& iSetup){
   LogInfo ("PixelDQM") << " SiPixelClusterSource::beginJob - Initialisation ... " << std::endl;


### PR DESCRIPTION
move initialization out of beginJob which is not called and into the constructor
