### PR TITLE
cleanup user actions and MC truth

### DIFF
--- a/SimG4Core/Application/interface/StackingAction.h
+++ b/SimG4Core/Application/interface/StackingAction.h
@@ -12,11 +12,12 @@
 #include <vector>
 
 class NewTrackAction;
+class TrackingAction;
 
 class StackingAction : public G4UserStackingAction {
 
 public:
-  StackingAction(const edm::ParameterSet & ps);
+  StackingAction(const TrackingAction*, const edm::ParameterSet & ps);
   virtual ~StackingAction();
 
   virtual G4ClassificationOfNewTrack ClassifyNewTrack(const G4Track * aTrack);
@@ -65,6 +66,7 @@ private:
   std::vector<const G4Region*>  lowdensRegions;
   std::vector<const G4Region*>  deadRegions;
 
+  const TrackingAction*         trackAction;
   NewTrackAction*               newTA;
 
   // Russian roulette regions

--- a/SimG4Core/Application/interface/TrackingAction.h
+++ b/SimG4Core/Application/interface/TrackingAction.h
@@ -22,6 +22,7 @@ public:
     virtual void PostUserTrackingAction(const G4Track * aTrack);
 
     TrackWithHistory * currentTrackWithHistory() { return currentTrack_; }
+    const G4Track * geant4Track() const { return g4Track_; }
     G4TrackingManager * getTrackManager();
 
     SimActivityRegistry::BeginOfTrackSignal m_beginOfTrackSignal;
@@ -30,6 +31,7 @@ public:
 private:
     EventAction * eventAction_;
     TrackWithHistory * currentTrack_;
+    const G4Track * g4Track_;
     G4VSolid * worldSolid;
     bool detailedTiming;
     bool checkTrack;

--- a/SimG4Core/Application/src/ActionInitialization.cc
+++ b/SimG4Core/Application/src/ActionInitialization.cc
@@ -73,7 +73,7 @@ void ActionInitialization::Build() const
   SetUserAction(stepAction);
   interface->Connect(stepAction);
 
-  SetUserAction(new StackingAction(m_pStackingAction));
+  SetUserAction(new StackingAction(trackAction, m_pStackingAction));
 }  
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......

--- a/SimG4Core/Application/src/RunManager.cc
+++ b/SimG4Core/Application/src/RunManager.cc
@@ -441,7 +441,8 @@ void RunManager::initializeUserActions()
     Connect(userSteppingAction);
     eventManager->SetUserAction(userSteppingAction);
 
-    eventManager->SetUserAction(new StackingAction(m_pStackingAction));
+    eventManager->SetUserAction(new StackingAction(userTrackingAction, 
+						   m_pStackingAction));
 
   } else {
     edm::LogWarning("SimG4CoreApplication") << " RunManager: WARNING : "

--- a/SimG4Core/Application/src/RunManagerMTWorker.cc
+++ b/SimG4Core/Application/src/RunManagerMTWorker.cc
@@ -264,7 +264,8 @@ void RunManagerMTWorker::initializeUserActions() {
   Connect(userSteppingAction);
   eventManager->SetUserAction(userSteppingAction);
 
-  eventManager->SetUserAction(new StackingAction(m_pStackingAction));
+  eventManager->SetUserAction(new StackingAction(userTrackingAction,
+						 m_pStackingAction));
 
 }
 

--- a/SimG4Core/Application/src/StackingAction.cc
+++ b/SimG4Core/Application/src/StackingAction.cc
@@ -1,5 +1,5 @@
 #include "SimG4Core/Application/interface/StackingAction.h"
-#include "SimG4Core/Notification/interface/CurrentG4Track.h"
+#include "SimG4Core/Application/interface/TrackingAction.h"
 #include "SimG4Core/Notification/interface/NewTrackAction.h"
 #include "SimG4Core/Notification/interface/TrackInformation.h"
 #include "SimG4Core/Notification/interface/TrackInformationExtractor.h"
@@ -17,7 +17,8 @@
 
 //#define DebugLog
 
-StackingAction::StackingAction(const edm::ParameterSet & p) 
+StackingAction::StackingAction(const TrackingAction* trka, const edm::ParameterSet & p)
+  : trackAction(trka) 
 {
   trackNeutrino  = p.getParameter<bool>("TrackNeutrino");
   killHeavy      = p.getParameter<bool>("KillHeavy");
@@ -292,7 +293,7 @@ G4ClassificationOfNewTrack StackingAction::ClassifyNewTrack(const G4Track * aTra
 
     // Russian roulette && MC truth
     if(classification != fKill) {
-      const G4Track * mother = CurrentG4Track::track();
+      const G4Track * mother = trackAction->geant4Track();
       int flag = 0;
       if(savePDandCinAll) {
 	flag = isItPrimaryDecayProductOrConversion(aTrack, *mother);

--- a/SimG4Core/Application/src/TrackingAction.cc
+++ b/SimG4Core/Application/src/TrackingAction.cc
@@ -21,7 +21,7 @@
 //using namespace std;
 
 TrackingAction::TrackingAction(EventAction * e, const edm::ParameterSet & p) 
-  : eventAction_(e),currentTrack_(0),
+  : eventAction_(e),currentTrack_(0),g4Track_(0),
   detailedTiming(p.getUntrackedParameter<bool>("DetailedTiming",false)),
   checkTrack(p.getUntrackedParameter<bool>("CheckTrack",false)),
   trackMgrVerbose(p.getUntrackedParameter<int>("G4TrackManagerVerbosity",0)) 
@@ -33,7 +33,7 @@ TrackingAction::~TrackingAction() {}
 
 void TrackingAction::PreUserTrackingAction(const G4Track * aTrack)
 {
-  CurrentG4Track::setTrack(aTrack);
+  g4Track_ = aTrack;
 
   if (currentTrack_ != 0) {
     throw SimG4Exception("TrackingAction: currentTrack is a mess...");
@@ -77,7 +77,6 @@ void TrackingAction::PreUserTrackingAction(const G4Track * aTrack)
 
 void TrackingAction::PostUserTrackingAction(const G4Track * aTrack)
 {
-  CurrentG4Track::postTracking(aTrack);
   if (eventAction_->trackContainer() != 0) {
 
     TrackInformationExtractor extractor;

--- a/SimG4Core/Notification/interface/CurrentG4Track.h
+++ b/SimG4Core/Notification/interface/CurrentG4Track.h
@@ -1,11 +1,7 @@
 #ifndef SimG4Core_CurrentG4Track_H
 #define SimG4Core_CurrentG4Track_H
 
-#include "SimG4Core/Notification/interface/SimG4Exception.h"
-
 #include "G4Track.hh"
-
-class TrackingAction;
 
 /** This class is NOT intended for general use.
  *  It provides immediate access to the currently tracked G4Track
@@ -18,16 +14,10 @@ class TrackingAction;
 class CurrentG4Track 
 {
 public:
-    static int id() { check(); return m_track->GetTrackID(); }
-    static const G4Track * track() { check(); return m_track; }
+    static const G4Track * track();
+    static void setTrack(const G4Track *);
 private:
     static thread_local const G4Track * m_track;
-    static thread_local bool m_tracking;
-    static void setTrack(const G4Track *);
-    static void postTracking(const G4Track *);
-    static void check()	
-    { if (m_track == 0) throw SimG4Exception("CurrentG4Track requested but not set"); }
-    friend class TrackingAction;
 };
 
 #endif

--- a/SimG4Core/Notification/src/CurrentG4Track.cc
+++ b/SimG4Core/Notification/src/CurrentG4Track.cc
@@ -1,22 +1,14 @@
 #include "SimG4Core/Notification/interface/CurrentG4Track.h"
 
 thread_local const G4Track * CurrentG4Track::m_track = 0;
-thread_local bool CurrentG4Track::m_tracking = false;
 
 void CurrentG4Track::setTrack(const G4Track * t)
 {
-    if (m_tracking) 
-	throw SimG4Exception("CurrentG4Track: new track set while previous is being tracked");
-    m_track = t;
-    m_tracking = true;
+  m_track = t;
 }
 
-void CurrentG4Track::postTracking(const G4Track * t) 
+const G4Track * CurrentG4Track::track()
 {
-    if (t != m_track)
-	throw SimG4Exception("CurrentG4Track: tracking finishes for a different track");
-    if (!m_tracking)
-	throw SimG4Exception("CurrentG4Track: tracking finishes without having started");
-    m_tracking = false;
+  return m_track;
 }
 

--- a/SimG4Core/Notification/src/G4TrackToParticleID.cc
+++ b/SimG4Core/Notification/src/G4TrackToParticleID.cc
@@ -7,12 +7,10 @@
 int G4TrackToParticleID::particleID(const G4Track * g4trk)
 {
     int particleID_ = g4trk->GetDefinition()->GetPDGEncoding();
-#ifdef DebugLog
-    if ( particleID_ > 1000000000 ) {
-      LogDebug("SimG4CoreNotification") << "G4TrackToParticleID ion code = " << particleID_ ;
+    if (0 == particleID_) {
+      edm::LogWarning("SimG4CoreNotification") 
+	<< "G4TrackToParticleID: unknown code for track Id = " << g4trk->GetTrackID();
+      particleID_ = -99;
     }
-#endif
-    if (particleID_ != 0) return particleID_;
-    edm::LogWarning("SimG4CoreNotification") << "G4TrackToParticleID: unknown code for track Id = " << g4trk->GetTrackID();
-    return -99;
+    return particleID_;
 }

--- a/SimG4Core/Physics/src/G4ProcessTypeEnumerator.cc
+++ b/SimG4Core/Physics/src/G4ProcessTypeEnumerator.cc
@@ -1,7 +1,7 @@
 #include "SimG4Core/Physics/interface/G4ProcessTypeEnumerator.h"
 
-static const int nprocesses = 47;
-static const std::string g4processes[nprocesses] = { 
+static const int nprocesses = 48;
+static const std::string g4processes[nprocesses] = { "Primary", 
   "Transportation",  "CoupleTrans",  "CoulombScat",  "Ionisation",  "Brems",
   "PairProdCharged",  "Annih",  "AnnihToMuMu",  "AnnihToHad",  "NuclearStopp",
   "Msc",  "Rayleigh",  "PhotoElectric",  "Compton",  "Conv",
@@ -13,6 +13,7 @@ static const std::string g4processes[nprocesses] = {
   "DecayPiWSpin",  "DecayRadio",  "DecayUnKnown",  "DecayExt",  "StepLimiter",
   "UsrSpecCuts", "NeutronKiller"}; 
 static const int g4subtype[nprocesses] = { 
+  0,   // Primary generator
   91,  // Transportation
   92,  // CoupleTrans
   1,   // CoulombScat


### PR DESCRIPTION
Added "primary" to the list of known processes (type=0) in Geant4 process enumerator.
Do not use  CurrentG4Track - because it adds two thread local variables for nothing, instead allow direct interface from StackingAction to TrackingAction. 

Should not affect results. 
