### PR TITLE
Updating the default preselection cuts and histrogram ranges

### DIFF
--- a/Validation/RecoTau/python/RecoTauValidation_cfi.py
+++ b/Validation/RecoTau/python/RecoTauValidation_cfi.py
@@ -70,7 +70,7 @@ DENOMINATOR
 
 """
 
-kinematicSelectedTauValDenominatorCut = cms.string('pt > 5. && abs(eta) < 2.5')
+kinematicSelectedTauValDenominatorCut = cms.string('pt > 5. && abs(eta) < 5.0')
 denominator = cms.InputTag("kinematicSelectedTauValDenominator")
 
 """

--- a/Validation/RecoTau/src/TauTagValidation.cc
+++ b/Validation/RecoTau/src/TauTagValidation.cc
@@ -327,9 +327,9 @@ void TauTagValidation::beginJob() {
     
     //Histograms settings
     hinfo ptHinfo = (histoSettings_.exists("pt")) ? hinfo(histoSettings_.getParameter<edm::ParameterSet>("pt")) : hinfo(500, 0., 1000.);
-    hinfo etaHinfo = (histoSettings_.exists("eta")) ? hinfo(histoSettings_.getParameter<edm::ParameterSet>("eta")) : hinfo(60, -3.0, 3.0);
+    hinfo etaHinfo = (histoSettings_.exists("eta")) ? hinfo(histoSettings_.getParameter<edm::ParameterSet>("eta")) : hinfo(110, -5.5, 5.5);
     hinfo phiHinfo = (histoSettings_.exists("phi")) ? hinfo(histoSettings_.getParameter<edm::ParameterSet>("phi")) : hinfo(40, -200., 200.);
-    hinfo pileupHinfo = (histoSettings_.exists("pileup")) ? hinfo(histoSettings_.getParameter<edm::ParameterSet>("pileup")) : hinfo(100, 0., 100.);
+    hinfo pileupHinfo = (histoSettings_.exists("pileup")) ? hinfo(histoSettings_.getParameter<edm::ParameterSet>("pileup")) : hinfo(200, 0., 200.);
     //hinfo dRHinfo = (histoSettings_.exists("deltaR")) ? hinfo(histoSettings_.getParameter<edm::ParameterSet>("deltaR")) : hinfo(10, 0., 0.5);
 
     // What kind of Taus do we originally have!


### PR DESCRIPTION
Phase 2 geometry allows taus above |eta|= 2.5. Also, the expected PU is larger than 100. In order to make validation faster (i.e. without re-running on AODs), this PR is changing the default preselection (loosening |eta| cut to 5.0) and extending the histogram ranges in |eta| (to 5.5) and in reconstructed nVx (to 200).

No change in physics expected (only validation sequence affected)
Probably increase in CPU time (more candidates and larger histograms)
