### PR TITLE
Shm stream consumer typedef (71X backport of #4805)

### DIFF
--- a/EventFilter/Utilities/plugins/SealModule.cc
+++ b/EventFilter/Utilities/plugins/SealModule.cc
@@ -21,6 +21,9 @@ typedef edm::serviceregistry::AllArgsMaker<MicroStateService, FastMonitoringServ
 typedef RawEventOutputModuleForBU<RawEventFileWriterForBU> RawStreamFileWriterForBU;
 typedef RecoEventOutputModuleForFU<RecoEventWriterForFU> EvFOutputModule;
 
+//legacy name for ConfDB compatibility
+typedef EvFOutputModule ShmStreamConsumer;
+
 //DEFINE_FWK_SERVICE_MAKER(MicroStateService, MicroStateServiceMaker);
 
 DEFINE_FWK_SERVICE_MAKER(FastMonitoringService, FastMonitoringServiceMaker);
@@ -31,4 +34,5 @@ DEFINE_FWK_MODULE(EvFRecordInserter);
 DEFINE_FWK_MODULE(EvFRecordUnpacker);
 DEFINE_FWK_MODULE(RawStreamFileWriterForBU);
 DEFINE_FWK_MODULE(EvFOutputModule);
+DEFINE_FWK_MODULE(ShmStreamConsumer);
 DEFINE_FWK_MODULE(DaqFakeReader);

--- a/EventFilter/Utilities/python/ShmStreamConsumer_cfi.py
+++ b/EventFilter/Utilities/python/ShmStreamConsumer_cfi.py
@@ -1,10 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 
-process.ShmStreamConsumer = cms.Service("ShmStreamConsumer",
+shmStreamConsumer = cms.OutputModule("ShmStreamConsumer",
     fileName = cms.untracked.string(""),
     SelectEvents = cms.untracked.PSet(
         SelectEvents = cms.vstring(),
         outputCommands = cms.untracked.vstring()
     )
 )
-

--- a/EventFilter/Utilities/python/ShmStreamConsumer_cfi.py
+++ b/EventFilter/Utilities/python/ShmStreamConsumer_cfi.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+
+process.ShmStreamConsumer = cms.Service("ShmStreamConsumer",
+    fileName = cms.untracked.string(""),
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring(),
+        outputCommands = cms.untracked.vstring()
+    )
+)
+


### PR DESCRIPTION
Typedef for the old HLT output module name, requested by TSG for ConfDB compatibility (backport of #4805)
