### PR TITLE
Revert cmsRun* glibc bash wrappers

### DIFF
--- a/FWCore/Framework/bin/BuildFile.xml
+++ b/FWCore/Framework/bin/BuildFile.xml
@@ -1,4 +1,7 @@
-<bin   name="cmsRunGlibCImpl" file="cmsRun.cpp">
+<architecture name="slc[6-9]_amd64">
+  <flags LDFLAGS="-Wl,-dynamic-linker,$(GLIBC_BASE)/lib64/ld.so"/>
+</architecture>
+<bin   name="cmsRunGlibC" file="cmsRun.cpp">
   <use   name="roothistmatrix"/>
   <use   name="tbb"/>
   <use   name="boost"/>
@@ -12,7 +15,7 @@
   <use   name="FWCore/ParameterSet"/>
   <use   name="FWCore/PythonParameterSet"/>
 </bin>
-<bin   name="cmsRunTCImpl" file="cmsRun.cpp">
+<bin   name="cmsRunTC" file="cmsRun.cpp">
   <use   name="tbb"/>
   <use   name="boost"/>
   <use   name="boost_program_options"/>
@@ -26,7 +29,7 @@
   <use   name="FWCore/ParameterSet"/>
   <use   name="FWCore/PythonParameterSet"/>
 </bin>
-<bin   name="cmsRunImpl" file="cmsRun.cpp">
+<bin   name="cmsRun" file="cmsRun.cpp">
   <use   name="tbb"/>
   <use   name="boost"/>
   <use   name="boost_program_options"/>
@@ -40,7 +43,7 @@
   <use   name="FWCore/ParameterSet"/>
   <use   name="FWCore/PythonParameterSet"/>
 </bin>
-<bin   name="cmsRunVDTImpl" file="cmsRun.cpp">
+<bin   name="cmsRunVDT" file="cmsRun.cpp">
   <use   name="vdt"/>
   <use   name="tbb"/>
   <use   name="boost"/>

--- a/FWCore/Framework/scripts/cmsRun
+++ b/FWCore/Framework/scripts/cmsRun
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-exec ${GLIBC_ROOT}/lib/ld-2.12.2.so --library-path \
-${LD_LIBRARY_PATH}:\
-${GLIBC_ROOT}/lib:\
-/lib64:\
-/usr/lib64 \
-$(which ${0}Impl) "$@"

--- a/FWCore/Framework/scripts/cmsRunGlibC
+++ b/FWCore/Framework/scripts/cmsRunGlibC
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-exec ${GLIBC_ROOT}/lib/ld-2.12.2.so --library-path \
-${LD_LIBRARY_PATH}:\
-${GLIBC_ROOT}/lib:\
-/lib64:\
-/usr/lib64 \
-$(which ${0}Impl) "$@"

--- a/FWCore/Framework/scripts/cmsRunTC
+++ b/FWCore/Framework/scripts/cmsRunTC
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-exec ${GLIBC_ROOT}/lib/ld-2.12.2.so --library-path \
-${LD_LIBRARY_PATH}:\
-${GLIBC_ROOT}/lib:\
-/lib64:\
-/usr/lib64 \
-$(which ${0}Impl) "$@"

--- a/FWCore/Framework/scripts/cmsRunVDT
+++ b/FWCore/Framework/scripts/cmsRunVDT
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-exec ${GLIBC_ROOT}/lib/ld-2.12.2.so --library-path \
-${LD_LIBRARY_PATH}:\
-${GLIBC_ROOT}/lib:\
-/lib64:\
-/usr/lib64 \
-$(which ${0}Impl) "$@"


### PR DESCRIPTION
We are now relocating ELF executable by modifying .interp section.
Glibc bash wrappers are no more needed. Revert wrappers.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
