### PR TITLE
Fix HLT process name in Top PAG validation code

### DIFF
--- a/HLTriggerOffline/Top/interface/TopDiLeptonHLTValidation.h
+++ b/HLTriggerOffline/Top/interface/TopDiLeptonHLTValidation.h
@@ -158,7 +158,7 @@ TopDiLeptonHLTValidation::TopDiLeptonHLTValidation(const edm::ParameterSet& iCon
   // Jets
   tokJets_ = consumes< edm::View<reco::Jet> >(edm::InputTag(sJets_));
   // Trigger
-  tokTrigger_ = consumes<edm::TriggerResults>(edm::InputTag(sTrigger_, "", "HLT"));
+  tokTrigger_ = consumes<edm::TriggerResults>(edm::InputTag(sTrigger_, "", "")); 
 }
 
 

--- a/HLTriggerOffline/Top/interface/TopSingleLeptonHLTValidation.h
+++ b/HLTriggerOffline/Top/interface/TopSingleLeptonHLTValidation.h
@@ -154,7 +154,7 @@ TopSingleLeptonHLTValidation::TopSingleLeptonHLTValidation(const edm::ParameterS
   // Jets
   tokJets_ = consumes< edm::View<reco::Jet> >(edm::InputTag(sJets_));
   // Trigger
-  tokTrigger_ = consumes<edm::TriggerResults>(edm::InputTag(sTrigger_, "", "HLT"));
+  tokTrigger_ = consumes<edm::TriggerResults>(edm::InputTag(sTrigger_, "", "")); 
 }
 
 


### PR DESCRIPTION
The InputTag used to be hardcoded which is not convenient for testing development menus.
