### PR TITLE
Histograms modifications and enhancement

### DIFF
--- a/DQMOffline/EGamma/interface/ElectronDqmAnalyzerBase.h
+++ b/DQMOffline/EGamma/interface/ElectronDqmAnalyzerBase.h
@@ -76,7 +76,7 @@ class ElectronDqmAnalyzerBase : public edm::EDAnalyzer
     MonitorElement * bookH1andDivide
      ( const std::string & name, MonitorElement * num, MonitorElement * denom,
        const std::string & titleX, const std::string & titleY,
-       const std::string & title ="" ) ;
+       const std::string & title ="", const std::string & setEfficiencyFlag="" ) ;
 
     MonitorElement * bookH2andDivide
      ( const std::string & name, MonitorElement * num, MonitorElement * denom,
@@ -100,7 +100,7 @@ class ElectronDqmAnalyzerBase : public edm::EDAnalyzer
     MonitorElement * bookH1andDivide
      ( const std::string & name, const std::string & num, const std::string & denom,
        const std::string & titleX, const std::string & titleY,
-       const std::string & title ="" ) ;
+       const std::string & title ="", const std::string & setEfficiencyFlag="" ) ;
 
     MonitorElement * bookH2andDivide
      ( const std::string & name, const std::string & num, const std::string & denom,

--- a/DQMOffline/EGamma/scripts/electronCompare.py
+++ b/DQMOffline/EGamma/scripts/electronCompare.py
@@ -133,6 +133,8 @@ if __name__ == "__main__":
   if options.title=='' :
     options.title = red_long_name+' vs '+blue_long_name
          
+  (red_hd, red_release) = os.path.split(red_head)
+  (blue_hd, blue_release) = os.path.split(blue_head)
          
   #============================================
   # final commands
@@ -150,6 +152,8 @@ if __name__ == "__main__":
   os.environ['CMP_RED_COMMENT'] = red_file+'.comment'
   os.environ['CMP_BLUE_COMMENT'] = blue_file+'.comment'
   os.environ['CMP_CONFIG'] = options.config
+  os.environ['CMP_RED_RELEASE'] = red_release
+  os.environ['CMP_BLUE_RELEASE'] = blue_release
   
   mysystem('root -b -l -q electronCompare.C')
   

--- a/DQMOffline/EGamma/src/ElectronDqmAnalyzerBase.cc
+++ b/DQMOffline/EGamma/src/ElectronDqmAnalyzerBase.cc
@@ -201,8 +201,8 @@ void ElectronDqmAnalyzerBase::remove_other_dirs()
 MonitorElement * ElectronDqmAnalyzerBase::bookH1andDivide
  ( const std::string & name, const std::string & num, const std::string & denom,
    const std::string & titleX, const std::string & titleY,
-   const std::string & title )
- { return bookH1andDivide(name,get(num),get(denom),titleX,titleY,title) ;  }
+   const std::string & title, const std::string & setEfficiencyFlag )
+ { return bookH1andDivide(name,get(num),get(denom),titleX,titleY,title,setEfficiencyFlag) ;  }
 
 MonitorElement * ElectronDqmAnalyzerBase::bookH2andDivide
  ( const std::string & name, const std::string & num, const std::string & denom,
@@ -299,7 +299,7 @@ MonitorElement * ElectronDqmAnalyzerBase::bookP1
 MonitorElement * ElectronDqmAnalyzerBase::bookH1andDivide
  ( const std::string & name, MonitorElement * num, MonitorElement * denom,
    const std::string & titleX, const std::string & titleY,
-   const std::string & title )
+   const std::string & title,const std::string & setEfficiencyFlag )
  {
   if ((!num)||(!denom)) return 0 ;
   std::string name2 = newName(name) ;

--- a/DQMOffline/EGamma/src/ElectronDqmAnalyzerBase.cc
+++ b/DQMOffline/EGamma/src/ElectronDqmAnalyzerBase.cc
@@ -311,7 +311,8 @@ MonitorElement * ElectronDqmAnalyzerBase::bookH1andDivide
   if (title!="") { h_temp->SetTitle(title.c_str()) ; }
   if (verbosity_>0) { h_temp->Print() ; }
   MonitorElement * me = store_->book1D(name2,h_temp) ;
-  delete h_temp ;
+  if (setEfficiencyFlag == "true") { me->setEfficiencyFlag(); }
+ delete h_temp ;
   return me ;
  }
 

--- a/DQMOffline/EGamma/src/ElectronDqmAnalyzerBase.cc
+++ b/DQMOffline/EGamma/src/ElectronDqmAnalyzerBase.cc
@@ -312,7 +312,7 @@ MonitorElement * ElectronDqmAnalyzerBase::bookH1andDivide
   if (verbosity_>0) { h_temp->Print() ; }
   MonitorElement * me = store_->book1D(name2,h_temp) ;
   if (setEfficiencyFlag == "true") { me->setEfficiencyFlag(); }
- delete h_temp ;
+  delete h_temp ;
   return me ;
  }
 

--- a/Validation/RecoEgamma/plugins/ElectronMcFakePostValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcFakePostValidator.cc
@@ -18,28 +18,28 @@ void ElectronMcFakePostValidator::finalize()
   setBookPrefix("h_ele") ;
 
   edm::LogInfo("ElectronMcFakePostValidator::finalize") << "efficiency calculation " ;
-  bookH1andDivide("etaEff","matchingObjectEta_matched","matchingObject_eta","#eta","Efficiency");
-  bookH1andDivide("zEff","matchingObjectZ_matched","matchingObject_z","z (cm)","Efficiency");
-  bookH1andDivide("absetaEff","matchingObjectAbsEta_matched","matchingObject_abseta","|#eta|","Efficiency");
-  bookH1andDivide("ptEff","matchingObjectPt_matched","matchingObject_Pt","p_{T} (GeV/c)","Efficiency");
-  bookH1andDivide("phiEff","matchingObjectPhi_matched","matchingObject_phi","#phi (rad)","Efficiency");
-//    bookH2andDivide("ptEtaEff","matchingObjectPtEta_matched","matchingObjectPtEta","#eta","p_{T} (GeV/c)");
+  bookH1andDivide("etaEff","matchingObjectEta_matched","matchingObject_eta","#eta","Efficiency","", "true");
+  bookH1andDivide("zEff","matchingObjectZ_matched","matchingObject_z","z (cm)","Efficiency","", "true");
+  bookH1andDivide("absetaEff","matchingObjectAbsEta_matched","matchingObject_abseta","|#eta|","Efficiency","", "true");
+  bookH1andDivide("ptEff","matchingObjectPt_matched","matchingObject_Pt","p_{T} (GeV/c)","Efficiency","", "true");
+  bookH1andDivide("phiEff","matchingObjectPhi_matched","matchingObject_phi","#phi (rad)","Efficiency","", "true");
+//    bookH2andDivide("ptEtaEff","matchingObjectPtEta_matched","matchingObjectPtEta","#eta","p_{T} (GeV/c)","");
 //
 //    std::cout << "[ElectronMcFakePostValidator] q-misid calculation " << std::endl;
-//    bookH1andDivide("etaQmisid","matchingObjectEta_matched_qmisid","h_simEta","#eta","q misId","",true);
-//    bookH1andDivide("zQmisid","matchingObjectZ_matched_qmisid","h_simZ","z (cm)","q misId","",true);
-//    bookH1andDivide("absetaQmisid","matchingObjectAbsEta_matched_qmisid","h_simAbsEta","|#eta|","q misId");
-//    bookH1andDivide("ptQmisid","matchingObjectPt_matched_qmisid","h_simPt","p_{T} (GeV/c)","q misId");
+//    bookH1andDivide("etaQmisid","matchingObjectEta_matched_qmisid","h_simEta","#eta","q misId","","");
+//    bookH1andDivide("zQmisid","matchingObjectZ_matched_qmisid","h_simZ","z (cm)","q misId","","");
+//    bookH1andDivide("absetaQmisid","matchingObjectAbsEta_matched_qmisid","h_simAbsEta","|#eta|","q misId","","");
+//    bookH1andDivide("ptQmisid","matchingObjectPt_matched_qmisid","h_simPt","p_{T} (GeV/c)","q misId","","");
 
   edm::LogInfo("ElectronMcFakePostValidator::finalize") << "all reco electrons " ;
-  bookH1andDivide("etaEff_all","vertexEta_all","matchingObject_eta","#eta","N_{rec}/N_{gen}");
-  bookH1andDivide("ptEff_all", "vertexPt_all","matchingObject_Pt","p_{T} (GeV/c)","N_{rec}/N_{gen}");
+  bookH1andDivide("etaEff_all","vertexEta_all","matchingObject_eta","#eta","N_{rec}/N_{gen}","","");
+  bookH1andDivide("ptEff_all", "vertexPt_all","matchingObject_Pt","p_{T} (GeV/c)","N_{rec}/N_{gen}","","");
 
   edm::LogInfo("ElectronMcFakePostValidator::finalize") << "classes" ;
-  bookH1andDivide("eta_goldenFrac","eta_golden","h_ele_eta","|#eta|","Fraction of electrons","fraction of golden electrons vs eta");
-  bookH1andDivide("eta_bbremFrac" ,"eta_bbrem", "h_ele_eta","|#eta|","Fraction of electrons","fraction of big brem electrons vs eta");
-//  bookH1andDivide("eta_narrowFrac","eta_narrow","h_ele_eta","|#eta|","Fraction of electrons","fraction of narrow electrons vs eta");
-  bookH1andDivide("eta_showerFrac","eta_shower","h_ele_eta","|#eta|","Fraction of electrons","fraction of showering electrons vs eta");
+  bookH1andDivide("eta_goldenFrac","eta_golden","h_ele_eta","|#eta|","Fraction of electrons","fraction of golden electrons vs eta","");
+  bookH1andDivide("eta_bbremFrac" ,"eta_bbrem", "h_ele_eta","|#eta|","Fraction of electrons","fraction of big brem electrons vs eta","");
+//  bookH1andDivide("eta_narrowFrac","eta_narrow","h_ele_eta","|#eta|","Fraction of electrons","fraction of narrow electrons vs eta","");
+  bookH1andDivide("eta_showerFrac","eta_shower","h_ele_eta","|#eta|","Fraction of electrons","fraction of showering electrons vs eta","");
 
   // fbrem
   MonitorElement * p1_ele_fbremVsEta_mean = get("fbremvsEtamean") ;

--- a/Validation/RecoEgamma/plugins/ElectronMcSignalPostValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcSignalPostValidator.cc
@@ -18,27 +18,27 @@ void ElectronMcSignalPostValidator::finalize()
   setBookPrefix("h_ele") ;
 
   edm::LogInfo("ElectronMcSignalPostValidator::finalize") << "efficiency calculation" ;
-  bookH1andDivide("etaEff","mc_Eta_matched","mc_Eta","#eta","Efficiency","");
-  bookH1andDivide("zEff","mc_Z_matched","mc_Z","z (cm)","Efficiency","");
-  bookH1andDivide("absetaEff","mc_AbsEta_matched","mc_AbsEta","|#eta|","Efficiency");
-  bookH1andDivide("ptEff","mc_Pt_matched","mc_Pt","p_{T} (GeV/c)","Efficiency");
-  bookH1andDivide("phiEff","mc_Phi_matched","mc_Phi","#phi (rad)","Efficiency");
-  bookH2andDivide("ptEtaEff","mc_PtEta_matched","mc_PtEta","#eta","p_{T} (GeV/c)");
+  bookH1andDivide("etaEff","mc_Eta_matched","mc_Eta","#eta","Efficiency",,"","true");
+  bookH1andDivide("zEff","mc_Z_matched","mc_Z","z (cm)","Efficiency","","true");
+  bookH1andDivide("absetaEff","mc_AbsEta_matched","mc_AbsEta","|#eta|","Efficiency","","true");
+  bookH1andDivide("ptEff","mc_Pt_matched","mc_Pt","p_{T} (GeV/c)","Efficiency","","true");
+  bookH1andDivide("phiEff","mc_Phi_matched","mc_Phi","#phi (rad)","Efficiency","","true");
+  bookH2andDivide("ptEtaEff","mc_PtEta_matched","mc_PtEta","#eta","p_{T} (GeV/c)","");
 
   edm::LogInfo("ElectronMcSignalPostValidator::finalize") << "q-misid calculation" ;
-  bookH1andDivide("etaQmisid","mc_Eta_matched_qmisid","mc_Eta","#eta","q misId","");
-  bookH1andDivide("zQmisid","mc_Z_matched_qmisid","mc_Z","z (cm)","q misId","");
-  bookH1andDivide("absetaQmisid","mc_AbsEta_matched_qmisid","mc_AbsEta","|#eta|","q misId");
-  bookH1andDivide("ptQmisid","mc_Pt_matched_qmisid","mc_Pt","p_{T} (GeV/c)","q misId");
+  bookH1andDivide("etaQmisid","mc_Eta_matched_qmisid","mc_Eta","#eta","q misId","","");
+  bookH1andDivide("zQmisid","mc_Z_matched_qmisid","mc_Z","z (cm)","q misId","","");
+  bookH1andDivide("absetaQmisid","mc_AbsEta_matched_qmisid","mc_AbsEta","|#eta|","q misId","","");
+  bookH1andDivide("ptQmisid","mc_Pt_matched_qmisid","mc_Pt","p_{T} (GeV/c)","q misId","","");
 
   edm::LogInfo("ElectronMcSignalPostValidator::finalize") << "all reco electrons" ;
-  bookH1andDivide("etaEff_all","vertexEta_all","h_mc_Eta","#eta","N_{rec}/N_{gen}","");
-  bookH1andDivide("ptEff_all","vertexPt_all","h_mc_Pt","p_{T} (GeV/c)","N_{rec}/N_{gen}","");
+  bookH1andDivide("etaEff_all","vertexEta_all","h_mc_Eta","#eta","N_{rec}/N_{gen}","","");
+  bookH1andDivide("ptEff_all","vertexPt_all","h_mc_Pt","p_{T} (GeV/c)","N_{rec}/N_{gen}","","");
 
   edm::LogInfo("ElectronMcSignalPostValidator::finalize") << "classes" ;
-  bookH1andDivide("eta_goldenFrac","eta_golden","h_ele_eta","|#eta|","Fraction of electrons","fraction of golden electrons vs eta");
-  bookH1andDivide("eta_bbremFrac" ,"eta_bbrem","h_ele_eta","|#eta|","Fraction of electrons","fraction of big brem electrons vs eta");
-  bookH1andDivide("eta_showerFrac","eta_shower","h_ele_eta","|#eta|","Fraction of electrons","fraction of showering electrons vs eta");
+  bookH1andDivide("eta_goldenFrac","eta_golden","h_ele_eta","|#eta|","Fraction of electrons","fraction of golden electrons vs eta","");
+  bookH1andDivide("eta_bbremFrac" ,"eta_bbrem","h_ele_eta","|#eta|","Fraction of electrons","fraction of big brem electrons vs eta","");
+  bookH1andDivide("eta_showerFrac","eta_shower","h_ele_eta","|#eta|","Fraction of electrons","fraction of showering electrons vs eta","");
 
   // fbrem
   MonitorElement * p1_ele_fbremVsEta_mean = get("fbremvsEtamean") ;

--- a/Validation/RecoEgamma/plugins/ElectronMcSignalPostValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcSignalPostValidator.cc
@@ -18,7 +18,7 @@ void ElectronMcSignalPostValidator::finalize()
   setBookPrefix("h_ele") ;
 
   edm::LogInfo("ElectronMcSignalPostValidator::finalize") << "efficiency calculation" ;
-  bookH1andDivide("etaEff","mc_Eta_matched","mc_Eta","#eta","Efficiency",,"","true");
+  bookH1andDivide("etaEff","mc_Eta_matched","mc_Eta","#eta","Efficiency","","true");
   bookH1andDivide("zEff","mc_Z_matched","mc_Z","z (cm)","Efficiency","","true");
   bookH1andDivide("absetaEff","mc_AbsEta_matched","mc_AbsEta","|#eta|","Efficiency","","true");
   bookH1andDivide("ptEff","mc_Pt_matched","mc_Pt","p_{T} (GeV/c)","Efficiency","","true");

--- a/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
@@ -705,12 +705,12 @@ void ElectronMcSignalValidator::book()
   h2_ele_PhiMnPhiTrueVsEta = bookH2("PhiMnPhiTrueVsEta","ele momentum  phi - gen  phi vs eta",eta2D_nbin,eta_min,eta_max,dphi_nbin/2,dphi_min,dphi_max);
   h2_ele_PhiMnPhiTrueVsPhi = bookH2("PhiMnPhiTrueVsPhi","ele momentum  phi - gen  phi vs phi",phi2D_nbin,phi_min,phi_max,dphi_nbin/2,dphi_min,dphi_max);
   h2_ele_PhiMnPhiTrueVsPt = bookH2("PhiMnPhiTrueVsPt","ele momentum  phi - gen  phi vs pt",pt2D_nbin,0.,pt_max,dphi_nbin/2,dphi_min,dphi_max);
-  h1_ele_ecalEnergyError = bookH1withSumw2("ecalEnergyError","",error_nbin,0,enerror_max);
-  h1_ele_ecalEnergyError_barrel = bookH1withSumw2("ecalEnergyError_barrel","",30,0,30);
-  h1_ele_ecalEnergyError_endcaps = bookH1withSumw2("ecalEnergyError_endcaps","",error_nbin,0,enerror_max);
-  h1_ele_combinedP4Error = bookH1withSumw2("combinedP4Error","",error_nbin,0,enerror_max);
-  h1_ele_combinedP4Error_barrel = bookH1withSumw2("combinedP4Error_barrel","",30,0,30);
-  h1_ele_combinedP4Error_endcaps = bookH1withSumw2("combinedP4Error_endcaps","",error_nbin,0,enerror_max);
+  h1_ele_ecalEnergyError = bookH1withSumw2("ecalEnergyError","Regression estimate of the ECAL energy error",error_nbin,0,enerror_max);
+  h1_ele_ecalEnergyError_barrel = bookH1withSumw2("ecalEnergyError_barrel","Regression estimate of the ECAL energy error - barrel",30,0,30);
+  h1_ele_ecalEnergyError_endcaps = bookH1withSumw2("ecalEnergyError_endcaps","Regression estimate of the ECAL energy error - endcaps",error_nbin,0,enerror_max);
+  h1_ele_combinedP4Error = bookH1withSumw2("combinedP4Error","Estimated error on the combined momentum",error_nbin,0,enerror_max);
+  h1_ele_combinedP4Error_barrel = bookH1withSumw2("combinedP4Error_barrel","Estimated error on the combined momentum - barrel",30,0,30);
+  h1_ele_combinedP4Error_endcaps = bookH1withSumw2("combinedP4Error_endcaps","Estimated error on the combined momentum - endcaps",error_nbin,0,enerror_max);
 
   // matched electron, superclusters
   setBookPrefix("h_scl") ;

--- a/Validation/RecoEgamma/test/ElectronMcFakeValidation_cfg.py
+++ b/Validation/RecoEgamma/test/ElectronMcFakeValidation_cfg.py
@@ -29,6 +29,7 @@ process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
 from Configuration.AlCa.autoCond import autoCond
 process.GlobalTag.globaltag = autoCond[os.environ['TEST_GLOBAL_AUTOCOND']]
+# next line is for old releases, prior to 7XX
 #process.GlobalTag.globaltag = os.environ['TEST_GLOBAL_TAG']+'::All'
 
 process.load("Validation.RecoEgamma.electronIsoFromDeps_cff")

--- a/Validation/RecoEgamma/test/ElectronMcFakeValidation_gedGsfElectrons_cfg.py
+++ b/Validation/RecoEgamma/test/ElectronMcFakeValidation_gedGsfElectrons_cfg.py
@@ -29,6 +29,7 @@ process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
 from Configuration.AlCa.autoCond import autoCond
 process.GlobalTag.globaltag = autoCond[os.environ['TEST_GLOBAL_AUTOCOND']]
+# next line is for old releases, prior to 7XX
 #process.GlobalTag.globaltag = os.environ['TEST_GLOBAL_TAG']+'::All'
 
 process.load("Validation.RecoEgamma.electronIsoFromDeps_cff")

--- a/Validation/RecoEgamma/test/ElectronMcSignalHistos.txt
+++ b/Validation/RecoEgamma/test/ElectronMcSignalHistos.txt
@@ -5,9 +5,9 @@ ElectronMcSignalValidator/h_recEleNum                       1 1 1 0
 ElectronMcSignalValidator/h_recCoreNum                      1 1 1 0
 ElectronMcSignalValidator/h_recTrackNum                     1 1 1 0
 ElectronMcSignalValidator/h_recSeedNum                      1 1 1 1
-        
-Basic electron quantities       
-        
+
+Basic electron quantities
+
 ElectronMcSignalValidator/h_ele_charge                      1 1 1 0
 ElectronMcSignalValidator/h_ele_vertexPt                    1 1 1 0
 ElectronMcSignalValidator/h_ele_vertexEta                   1 1 1 0

--- a/Validation/RecoEgamma/test/ElectronMcSignalValidation_cfg.py
+++ b/Validation/RecoEgamma/test/ElectronMcSignalValidation_cfg.py
@@ -29,6 +29,7 @@ process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
 from Configuration.AlCa.autoCond import autoCond
 process.GlobalTag.globaltag = autoCond[os.environ['TEST_GLOBAL_AUTOCOND']]
+# next line is for old releases, prior to 7XX
 #process.GlobalTag.globaltag = os.environ['TEST_GLOBAL_TAG']+'::All'
 
 # FOR DATA REDONE FROM RAW, ONE MUST HIDE IsoFromDeps

--- a/Validation/RecoEgamma/test/ElectronMcSignalValidation_gedGsfElectrons_cfg.py
+++ b/Validation/RecoEgamma/test/ElectronMcSignalValidation_gedGsfElectrons_cfg.py
@@ -29,6 +29,7 @@ process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
 from Configuration.AlCa.autoCond import autoCond
 process.GlobalTag.globaltag = autoCond[os.environ['TEST_GLOBAL_AUTOCOND']]
+# next line is for old releases, prior to 7XX
 #process.GlobalTag.globaltag = os.environ['TEST_GLOBAL_TAG']+'::All'
 
 # FOR DATA REDONE FROM RAW, ONE MUST HIDE IsoFromDeps

--- a/Validation/RecoEgamma/test/OvalFile
+++ b/Validation/RecoEgamma/test/OvalFile
@@ -1,13 +1,12 @@
 <var name="TEST_COMMENT" value="">
-<var name="TEST_NEW" value="7_0_0_pre6">
-<var name="TEST_REF" value="7_0_0_pre5">
+<var name="TEST_NEW" value="7_2_0_pre1_std">
+<var name="TEST_REF" value="7_1_0_std">
 
-<var name="TAG_STARTUP" value="PRE_ST62_V8">
-<var name="TAG_IDEAL" value="PRE_ST62_V8">
+<var name="TAG_STARTUP" value="POSTLS172_V1">
 <var name="DATA_VERSION" value="v1">
 
 TAG for the REFERENCE DATA, USED ONLY FOR INFORMATION ON WEB PAGE
-<var name="DD_COND_REF" value="PRE_ST62_V8-v1">
+<var name="DD_COND_REF" value="POSTLS171_V15_FastSim-v1">
 
 <var name="DD_RELEASE" value="${CMSSW_VERSION}">
 
@@ -23,6 +22,7 @@ The value of OVAL_ENVNAME is automatically set by Oval to the name
 of the current environment, before running any executable. Using it below,
 we have an output file name which is unique for each execution.
 
+<!--var name="TEST_HISTOS_FILE" value="electronHistos.${OVAL_ENVNAME}.root"-->
 <var name="TEST_HISTOS_FILE" value="electronHistos.${OVAL_ENVNAME}.root">
 <var name="TEST_OUTPUT_LOGS" value="*.${OVAL_ENVNAME}.olog">
 <!--var name="TEST_HISTOS_FILE" value="DQM_V0001_R000000001__${DD_SAMPLE}__${DD_RELEASE}-${DD_COND}__DQM.root"-->
@@ -65,6 +65,7 @@ The file defined below is used by the script electronDataDiscovery.py when we wa
 some RelVal reco files which have been regenerated locally.
 
 <var name="TEST_AFS_DIR" value="/afs/cern.ch/cms/CAF/CMSPHYS/PHYS_EGAMMA/electrons/chamont/ReleaseValidationTmp/SeedsRemaker3">
+<!--var name="TEST_AFS_DIR" value="/afs/cern.ch/user/a/archiron/private/Root_Regress"-->
 <file name="electronInputDataFiles.txt">
 file:${TEST_AFS_DIR}/RelValSingleElectronPt10-STARTUP-RECO.root
 file:${TEST_AFS_DIR}/RelValSingleElectronPt35-STARTUP-RECO.root
@@ -73,407 +74,6 @@ file:${TEST_AFS_DIR}/RelValZEE-STARTUP-RECO.root
 file:${TEST_AFS_DIR}/RelValQCD_Pt_80_120-STARTUP-RECO.root
 </file>
   
-Here comes the concrete executables to run. They are split among few different
-environments, each one defining the relevant variales for a given scenario and/or
-data sample. Running electronDataDiscovery.py is only usefull to check the correctness
-of the list of input data files returned by the data discovery web server. We guess
-that from time to time we will have to upgrade the values DD_* variable so to keep in
-touch with changes in data catalog structure.
-
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-================================================================================
-FullSim
-================================================================================
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-<environment name="FullStdStats">
-
-  This set of targets is currently used for the validation of electrons.
-
-  Used if DD_SOURCE=das
-  <!--var name="DD_TIER" value="*RECO*"-->
-
-  Used if DD_source=/eos/...
-  <var name="DD_TIER" value="GEN-SIM-RECO">
-  
-  <var name="VAL_HISTOS" value="ElectronMcSignalHistos.txt">
-  <var name="VAL_ANALYZER" value="ElectronMcSignalValidator">
-  <var name="VAL_POST_ANALYZER" value="ElectronMcSignalPostValidator">
-  <var name="VAL_CONFIGURATION" value="ElectronMcSignalValidation_cfg">
-  <var name="VAL_CONFIGURATION_gedGsfE" value="ElectronMcSignalValidation_gedGsfElectrons_cfg">
-  <var name="VAL_POST_CONFIGURATION" value="ElectronMcSignalPostValidation_cfg">
-      
-  <environment name="ValFullStdStatsStartup">
-  
-    <var name="TEST_GLOBAL_TAG" value="${TAG_STARTUP}">
-    <var name="TEST_GLOBAL_AUTOCOND" value="startup">
-       
-    <var name="DD_COND" value="${TEST_GLOBAL_TAG}-${DATA_VERSION}">    
-    
-    <environment name="ValFullPt10Startup">
-    
-      <var name="DD_SAMPLE" value="RelValSingleElectronPt10">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <target name="dqm" cmd="electronDataDiscovery.py castor">
-      <target name="wget" cmd="electronWget.py castor">
-      
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION}.py">
-      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-      
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/Full_${DD_SAMPLE}_Startup'>
-  
-    </environment>
-
-    <environment name="ValFullPt35Startup">
-  
-      <var name="DD_SAMPLE" value="RelValSingleElectronPt35">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <target name="dqm" cmd="electronDataDiscovery.py castor">
-      <target name="wget" cmd="electronWget.py castor">
-      
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION}.py">
-      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-      
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/Full_${DD_SAMPLE}_Startup'>
-            
-    </environment>
-
-    <environment name="ValFullPt1000Startup">
-    
-      <var name="DD_SAMPLE" value="RelValSingleElectronPt1000">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <target name="dqm" cmd="electronDataDiscovery.py castor">
-      <target name="wget" cmd="electronWget.py castor">
-      
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="analyze" cmd="cmsRun ElectronMcSignalPt1000Validation_cfg.py">
-      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-      
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/Full_${DD_SAMPLE}_Startup'>
-  
-    </environment>
-
-    <environment name="ValFullTTbarStartup">
-  
-      <var name="DD_SAMPLE" value="RelValTTbar">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <target name="dqm" cmd="electronDataDiscovery.py castor">
-      <target name="wget" cmd="electronWget.py castor">
-      
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION}.py">
-      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-      
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/Full_${DD_SAMPLE}_Startup'>
-  
-    </environment>
-
-    <environment name="ValFullZEEStartup">
-    
-      <var name="DD_SAMPLE" value="RelValZEE">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <target name="dqm" cmd="electronDataDiscovery.py castor">
-      <target name="wget" cmd="electronWget.py castor">
-      
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION}.py">
-      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-      
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/Full_${DD_SAMPLE}_Startup'>
-  
-    </environment>
-
-    <environment name="ValFullQcdPt80Pt120Startup">
-    
-      <var name="DD_SAMPLE" value="RelValQCD_Pt_80_120">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <var name="VAL_HISTOS" value="ElectronMcFakeHistos.txt">
-      <var name="VAL_ANALYZER" value="ElectronMcFakeValidator">
-      <var name="VAL_POST_ANALYZER" value="ElectronMcFakePostValidator">
-      <var name="VAL_CONFIGURATION" value="ElectronMcFakeValidation_cfg">
-      <var name="VAL_POST_CONFIGURATION" value="ElectronMcFakePostValidation_cfg">
-      
-      <target name="dqm" cmd="electronDataDiscovery.py castor">
-      <target name="wget" cmd="electronWget.py castor">
-      
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION}.py">
-      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-      
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/Full_${DD_SAMPLE}_Startup'>
-  
-    </environment>
-
-    <environment name="ValFullPt10Startup_gedGsfE">
-    
-      <var name="DD_SAMPLE" value="RelValSingleElectronPt10">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <var name="BLUE_FILE" value="electronHistos.ValFullPt10Startup.root">
-      <var name="RED_FILE" value="electronHistos.ValFullPt10Startup_gedGsfE.root">
-
-      <target name="dqm" cmd="electronDataDiscovery.py castor">
-      <target name="wget" cmd="electronWget.py castor">
-      
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
-      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-      
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs
-      ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GfsVsGedGsf/Full_${DD_SAMPLE}_gedGsfE_Startup'>
-
-    </environment>
-
-    <environment name="ValFullPt35Startup_gedGsfE">
-  
-      <var name="DD_SAMPLE" value="RelValSingleElectronPt35">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <var name="BLUE_FILE" value="electronHistos.ValFullPt35Startup.root">
-      <var name="RED_FILE" value="electronHistos.ValFullPt35Startup_gedGsfE.root">
-
-      <target name="dqm" cmd="electronDataDiscovery.py castor">
-      <target name="wget" cmd="electronWget.py castor">
-      
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
-      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-      
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs
-      ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GfsVsGedGsf/Full_${DD_SAMPLE}_gedGsfE_Startup'>
-      
-    </environment>
-    
-    <environment name="ValFullPt1000Startup_gedGsfE">
-    
-      <var name="DD_SAMPLE" value="RelValSingleElectronPt1000">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <var name="BLUE_FILE" value="electronHistos.ValFullPt1000Startup.root">
-      <var name="RED_FILE" value="electronHistos.ValFullPt1000Startup_gedGsfE.root">
-
-      <target name="dqm" cmd="electronDataDiscovery.py castor">
-      <target name="wget" cmd="electronWget.py castor">
-      
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="analyze" cmd="cmsRun ElectronMcSignalPt1000Validation_gedGsfElectrons_cfg.py">
-      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-      
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs
-      ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GfsVsGedGsf/Full_${DD_SAMPLE}_gedGsfE_Startup'>
-
-    </environment>
-
-    <environment name="ValFullTTbarStartup_gedGsfE">
-  
-      <var name="DD_SAMPLE" value="RelValTTbar">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <var name="BLUE_FILE" value="electronHistos.ValFullTTbarStartup.root">
-      <var name="RED_FILE" value="electronHistos.ValFullTTbarStartup_gedGsfE.root">
-
-      <target name="dqm" cmd="electronDataDiscovery.py castor">
-      <target name="wget" cmd="electronWget.py castor">
-      
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
-      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-      
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs
-      ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GfsVsGedGsf/Full_${DD_SAMPLE}_gedGsfE_Startup'>
-
-    </environment>
-  
-
-    <environment name="ValFullZEEStartup_gedGsfE">
-    
-      <var name="DD_SAMPLE" value="RelValZEE">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <var name="BLUE_FILE" value="electronHistos.ValFullZEEStartup.root">
-      <var name="RED_FILE" value="electronHistos.ValFullZEEStartup_gedGsfE.root">
-
-      <target name="dqm" cmd="electronDataDiscovery.py castor">
-      <target name="wget" cmd="electronWget.py castor">
-      
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
-      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-      
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs
-      ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GfsVsGedGsf/Full_${DD_SAMPLE}_gedGsfE_Startup'>
-  
-    </environment>
-
-    <environment name="ValFullQcdPt80Pt120Startup_gedGsfE">
-    
-      <var name="DD_SAMPLE" value="RelValQCD_Pt_80_120">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <var name="BLUE_FILE" value="electronHistos.ValFullQcdPt80Pt120Startup.root">
-      <var name="RED_FILE" value="electronHistos.ValFullQcdPt80Pt120Startup_gedGsfE.root">
-
-      <var name="VAL_HISTOS" value="ElectronMcFakeHistos.txt">
-      <var name="VAL_ANALYZER" value="ElectronMcFakeValidator">
-      <var name="VAL_POST_ANALYZER" value="ElectronMcFakePostValidator">
-      <var name="VAL_CONFIGURATION" value="ElectronMcFakeValidation_gedGsfElectrons_cfg">
-      <var name="VAL_POST_CONFIGURATION" value="ElectronMcFakePostValidation_cfg">
-      
-      <target name="dqm" cmd="electronDataDiscovery.py castor">
-      <target name="wget" cmd="electronWget.py castor">
-      
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION}.py">
-      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-      
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs
-      ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GfsVsGedGsf/Full_${DD_SAMPLE}_gedGsfE_Startup'>
-
-    </environment>  
-  
-  </environment>
-
-  <environment name="ValPileUpStartup">
-    
-    <var name="TAG_STARTUP" value="PU_${TAG_STARTUP}">
-    <var name="TEST_GLOBAL_TAG" value="${TAG_STARTUP}">
-    <var name="TEST_GLOBAL_AUTOCOND" value="startup">
-    <var name="DD_COND" value="${TEST_GLOBAL_TAG}-${DATA_VERSION}">
-
-      <environment name="ValPileUpTTbarStartup">
-        
-        <var name="DD_SAMPLE" value="RelValTTbar">
-        <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-        <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-
-        <target name="dqm" cmd="electronDataDiscovery.py castor">
-        <target name="wget" cmd="electronWget.py castor">
-      
-        <target name="dd" cmd="electronDataDiscovery.py">
-        <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION}.py">
-        <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-      
-        <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-        <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-        <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/PileUp_${DD_SAMPLE}_Startup'>
-  
-      </environment>
-
-    <environment name="ValPileUpZEEStartup">
-    
-      <var name="DD_SAMPLE" value="RelValZEE">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <target name="dqm" cmd="electronDataDiscovery.py castor">
-      <target name="wget" cmd="electronWget.py castor">
-      
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION}.py">
-      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-      
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} /${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/PileUp_${DD_SAMPLE}_Startup'>
-  
-    </environment>
-
-      <environment name="ValPileUpTTbarStartup_gedGsfE">
-        
-        <var name="DD_SAMPLE" value="RelValTTbar">
-        <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-        <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-	
-	<var name="BLUE_FILE" value="electronHistos.ValPileUpTTbarStartup.root">
-        <var name="RED_FILE" value="electronHistos.ValPileUpTTbarStartup_gedGsfE.root">
- 
-        <target name="dqm" cmd="electronDataDiscovery.py castor">
-        <target name="wget" cmd="electronWget.py castor">
-      
-        <target name="dd" cmd="electronDataDiscovery.py">
-        <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
-        <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-      
-        <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-        <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-	<target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs
-      ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GfsVsGedGsf/PileUp_${DD_SAMPLE}_gedGsfE_Startup'>
-
-      </environment>
-
-    <environment name="ValPileUpZEEStartup_gedGsfE">
-    
-      <var name="DD_SAMPLE" value="RelValZEE">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-     
-      <var name="BLUE_FILE" value="electronHistos.ValPileUpZEEStartup.root">
-      <var name="RED_FILE" value="electronHistos.ValPileUpZEEStartup_gedGsfE.root">
-
-      <target name="dqm" cmd="electronDataDiscovery.py castor">
-      <target name="wget" cmd="electronWget.py castor">
-      
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
-      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-      
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs
-      ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GfsVsGedGsf/PileUp_${DD_SAMPLE}_gedGsfE_Startup'>
-
-    </environment>
-  
-  </environment>
-    
-</environment>
-
-
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 ================================================================================
 FastSim
@@ -487,6 +87,7 @@ FastSim
   <var name="VAL_ANALYZER" value="ElectronMcSignalValidator">
   <var name="VAL_POST_ANALYZER" value="ElectronMcSignalPostValidator">
   <var name="VAL_CONFIGURATION" value="ElectronMcSignalValidation_cfg">
+  <var name="VAL_CONFIGURATION_gedGsfE" value="ElectronMcSignalValidation_gedGsfElectrons_cfg">
   <var name="VAL_POST_CONFIGURATION" value="ElectronMcSignalPostValidation_cfg">
   <var name="VAL_HISTOS" value="ElectronMcSignalHistos.txt">
  
@@ -534,6 +135,44 @@ FastSim
         
       </environment>
     
+      <environment name="ValFastTTbarStartup_gedGsfE">
+      
+        <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
+        <!--var name="DD_SAMPLE" value="RelValTTbar"-->
+        <var name="DD_SAMPLE" value="RelValTTbar_13">
+	<var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}">
+	
+        <target name="dqm" cmd="electronDataDiscovery.py castor">
+        <target name="wget" cmd="electronWget.py castor">
+        
+        <target name="dd" cmd="electronDataDiscovery.py">
+        <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
+        <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
+        
+        <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+        <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+        
+      </environment>
+    
+      <environment name="ValFastZEEStartup_gedGsfE">
+      
+        <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
+        <!--var name="DD_SAMPLE" value="RelValZEE"-->
+        <var name="DD_SAMPLE" value="RelValZEE_13">
+	<var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}">
+	
+        <target name="dqm" cmd="electronDataDiscovery.py castor">
+        <target name="wget" cmd="electronWget.py castor">
+        
+        <target name="dd" cmd="electronDataDiscovery.py">
+        <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
+        <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
+        
+        <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+        <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+        
+      </environment>
+    
     </environment>
     
   </environment>
@@ -548,13 +187,33 @@ FastSim
 
       <environment name="ValFastVsFastTTbarStartup">
         <var name="DD_SAMPLE" value="RelValTTbar">
-        <var name="TEST_HISTOS_FILE" value="electronHistos.ValFastTTbarStartup.root">
+	<var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}">
+        <!--var name="TEST_HISTOS_FILE" value="electronHistos.ValFastTTbarStartup.root"-->
+        <var name="TEST_HISTOS_FILE" value="electronHistos.ValFastTTbarStartup_gedGsfE.root">
         <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/Fast_${DD_SAMPLE}_Startup'>
       </environment>
       
       <environment name="ValFastVsFastZEEStartup">
         <var name="DD_SAMPLE" value="RelValZEE">
-        <var name="TEST_HISTOS_FILE" value="electronHistos.ValFastZEEStartup.root">
+	<var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}">
+        <!--var name="TEST_HISTOS_FILE" value="electronHistos.ValFastZEEStartup.root"-->
+        <var name="TEST_HISTOS_FILE" value="electronHistos.ValFastZEEStartup_gedGsfE.root">
+        <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/Fast_${DD_SAMPLE}_Startup'>
+      </environment>
+        
+      <environment name="ValFastVsFastTTbarStartup_gedGsfE">
+        <var name="DD_SAMPLE" value="RelValTTbar_13">
+	<var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}">
+        <!--var name="TEST_HISTOS_FILE" value="electronHistos.ValFastTTbarStartup.root"-->
+        <var name="TEST_HISTOS_FILE" value="electronHistos.ValFastTTbarStartup_gedGsfE.root">
+        <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/Fast_${DD_SAMPLE}_Startup'>
+      </environment>
+      
+      <environment name="ValFastVsFastZEEStartup_gedGsfE">
+        <var name="DD_SAMPLE" value="RelValZEE_13">
+	<var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}">
+        <!--var name="TEST_HISTOS_FILE" value="electronHistos.ValFastZEEStartup.root"-->
+        <var name="TEST_HISTOS_FILE" value="electronHistos.ValFastZEEStartup_gedGsfE.root">
         <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/Fast_${DD_SAMPLE}_Startup'>
       </environment>
         
@@ -570,235 +229,24 @@ FastSim
       <var name="TEST_GLOBAL_AUTOCOND" value="startup">
       <var name="DD_COND" value="-${TEST_GLOBAL_TAG}-${DATA_VERSION}">
 
-      <environment name="ValFastVsFullTTbarStartup">
-        <var name="DD_SAMPLE" value="RelValTTbar">
-        <var name="BLUE_FILE" value="electronHistos.ValFullTTbarStartup.root">
-        <var name="RED_FILE" value="electronHistos.ValFastTTbarStartup.root">
-        <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r FastSim -b FullSim -t "Fast vs Full / ${DD_SAMPLE} / ${DD_COND}" ${STORE_DIR}/${RED_FILE} ${STORE_DIR}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/FastVsFull/${DD_SAMPLE}_Startup'>
+      <environment name="ValFastVsFullTTbarStartup_gedGsfE">
+        <var name="DD_SAMPLE" value="RelValTTbar_13">
+ 	<var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}">
+       <var name="BLUE_FILE" value="electronHistos.ValFullTTbarStartup_13_gedGsfE.root">
+        <var name="RED_FILE" value="electronHistos.ValFastTTbarStartup_gedGsfE.root">
+        <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_NEW} -t "Fast vs Full / ${DD_SAMPLE} / ${DD_COND}" ${STORE_DIR}/${RED_FILE} ${STORE_DIR}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/FastVsFull/${DD_SAMPLE}_Startup'>
       </environment>
       
-      <environment name="ValFastVsFullZEEStartup">
-        <var name="DD_SAMPLE" value="RelValZEE">
-        <var name="BLUE_FILE" value="electronHistos.ValFullZEEStartup.root">
-        <var name="RED_FILE" value="electronHistos.ValFastZEEStartup.root">
-        <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r FastSim -b FullSim -t "Fast vs Full / ${DD_SAMPLE} / ${DD_COND}" ${STORE_DIR}/${RED_FILE} ${STORE_DIR}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/FastVsFull/${DD_SAMPLE}_Startup'>
+      <environment name="ValFastVsFullZEEStartup_gedGsfE">
+        <var name="DD_SAMPLE" value="RelValZEE_13">
+	<var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}">
+        <var name="BLUE_FILE" value="electronHistos.ValFullZEEStartup_13_gedGsfE.root">
+        <var name="RED_FILE" value="electronHistos.ValFastZEEStartup_gedGsfE.root">
+        <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_NEW} -t "Fast vs Full / ${DD_SAMPLE} / ${DD_COND}" ${STORE_DIR}/${RED_FILE} ${STORE_DIR}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/FastVsFull/${DD_SAMPLE}_Startup'>
       </environment>
       
     </environment>
         
-  </environment>
-  
-</environment>
-
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-================================================================================
-This set of targets is made to redo the electrons
-with the local modified code.
-================================================================================
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-<environment name="Redo">
-
-  <environment name="SeedsRemaker">
-
-    <var name="TEST_GLOBAL_TAG" value="${TAG_STARTUP}">
-    <var name="TEST_GLOBAL_AUTOCOND" value="startup">
-    <var name="DD_COND" value="-${TEST_GLOBAL_TAG}-${DATA_VERSION}">
-    <var name="DD_SAMPLE" value="RelValSingleElectronPt10">
-      
-    <environment name="SeedsRemakerStep1">
-
-      <var name="DD_TIER" value="*RAW*">
-      <var name="TEST_HISTOS_FILE" value="${TEST_AFS_DIR}/${DD_SAMPLE}-STARTUP-FIRST-RECO.root">
-
-      <target name="cfg" cmd="cmsDriver.py step3 -n -1 -s RAW2DIGI,L1Reco,RECO,VALIDATION,DQM --conditions auto:startup --datatier GEN-SIM-RECO,DQM --eventcontent RECOSIM,DQM --filein=Dummy-STARTUP-RAW.root --fileout=Dummy-STARTUP-RECO.root --customise reseed.storeseed --python_filename=ElectronRedoFromRawStartup_driver_cfg.py --no_exec">
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="reco" cmd="cmsRun ElectronRedoFromRawStartup_cfg.py">
-      
-    </environment>
-  
-    <environment name="SeedsRemakerStep2">
-    
-      <var name="DD_TIER" value="*FIRST-RECO*">
-      <var name="DD_SOURCE" value="electronInputDataFiles.txt">
-      <var name="DD_COND" value="STARTUP">
-      <file name="electronInputDataFiles.txt">
-      file:${TEST_AFS_DIR}/RelValSingleElectronPt10-STARTUP-FIRST-RECO.root
-      </file>
-      <var name="TEST_HISTOS_FILE" value="${TEST_AFS_DIR}/${DD_SAMPLE}-STARTUP-RECO.root">
-      
-      <target name="cfg" cmd="cmsDriver.py step3 -n -1 --process reRECO --filtername RECOfromRECO -s RECO:reconstruction_fromRECO_noTrackingTest --conditions auto:startup --datatier GEN-SIM-RECO --eventcontent RECOSIM --filein=Dummy-STARTUP-RECO.root --fileout=Dummy-STARTUP-RECO.root --customise reseed.reseed+regenseed+reconv --python_filename=SeedsRemaker_driver_cfg.py --no_exec">
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="redo" cmd="cmsRun SeedsRemaker_cfg.py">
-      
-    </environment>
-
-  </environment>
-  
-  <environment name="RedoFromTrackSeeds">
-
-    <var name="VAL_CONFIGURATION" value="ElectronRedoFromTrackSeeds_cfg">
-    
-    <environment name="RedoFromTrackSeedsPt35">
-      <var name="DD_SAMPLE" value="RelValSingleElectronPt35">
-      <var name="TEST_HISTOS_FILE" value="${TEST_AFS_DIR}/${DD_SAMPLE}-STARTUP-RECO.root">
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="redo" cmd="cmsRun ${VAL_CONFIGURATION}.py">
-    </environment>
-  
-    <environment name="RedoFromTrackSeedsQcdPt80Pt120">
-      <var name="DD_SAMPLE" value="RelValQCD_Pt_80_120">
-      <var name="TEST_HISTOS_FILE" value="${TEST_AFS_DIR}/${DD_SAMPLE}-STARTUP-RECO.root">
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="redo" cmd="cmsRun ${VAL_CONFIGURATION}.py">
-    </environment>
-  
-    <environment name="RedoFromTrackSeedsPt10">
-      <var name="DD_SAMPLE" value="RelValSingleElectronPt10">
-      <var name="TEST_HISTOS_FILE" value="${TEST_AFS_DIR}/${DD_SAMPLE}-STARTUP-RECO.root">
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="redo" cmd="cmsRun ${VAL_CONFIGURATION}.py">
-    </environment>
-  
-  </environment>
-
-  <environment name="RedoFromCore">
-
-    <environment name="RedoFromCoreStartup">
-  
-      <var name="TEST_GLOBAL_TAG" value="${TAG_STARTUP}">
-      <var name="TEST_GLOBAL_AUTOCOND" value="startup">
-      <var name="DD_COND" value="-${TEST_GLOBAL_TAG}-${DATA_VERSION}">
-
-      <environment name="RedoFromCoreZEEStartup">
-        <var name="DD_SAMPLE" value="RelValZEE">
-        <var name="TEST_HISTOS_FILE" value="${TEST_AFS_DIR}/${DD_SAMPLE}-STARTUP-RECO.root">
-        <executable name="electronDataDiscovery.py">
-        <executable name="cmsRun" args="ElectronRedoFromCore_cfg.py">
-      </environment>
-    
-    </environment>
-        
-  </environment>
-
-  <environment name="RedoFromRaw">
-
-    <var name="DD_TIER" value="*RAW*">
-
-    <!--var name="DD_SOURCE" value="electronInputDataFiles.txt"-->
-    <file name="electronInputDataFiles.txt">
-    ${TEST_AFS_DIR}/RelValSingleElectronPt10-IDEAL-RAW.root
-    ${TEST_AFS_DIR}/RelValSingleElectronPt35-IDEAL-RAW.root
-    ${TEST_AFS_DIR}/RelValTTbar-IDEAL-RAW.root
-    ${TEST_AFS_DIR}/RelValZEE-IDEAL-RAW.root
-    ${TEST_AFS_DIR}/RelValZEE-STARTUP-RAW.root
-    ${TEST_AFS_DIR}/RelValQCD_Pt_80_120-IDEAL-RAW.root
-    </file>
-
-    <environment name="RedoFromRawStartup">
-
-      <var name="TEST_GLOBAL_TAG" value="${TAG_STARTUP}">
-      <var name="TEST_GLOBAL_AUTOCOND" value="startup">
-      <var name="DD_COND" value="-${TEST_GLOBAL_TAG}-${DATA_VERSION}">
-      <!--var name="DD_COND" value="STARTUP"-->
-
-      <target name="cfg" cmd="cmsDriver.py reco -s RAW2DIGI,RECO -n -1 --conditions auto:startup --datatier GEN-SIM-RECO --eventcontent RECOSIM --filein=Dummy-RAW.root --fileout=Dummy-STARTUP-RECO.root --python_filename=ElectronRedoFromRawStartup_driver_cfg.py --no_exec">
-
-      <environment name="RedoFromRawPt35Startup">
-        <var name="DD_SAMPLE" value="RelValSingleElectronPt35">
-        <var name="TEST_HISTOS_FILE" value="${TEST_AFS_DIR}/${DD_SAMPLE}-STARTUP-RECO.root">
-        <target name="dd" cmd="electronDataDiscovery.py">
-        <target name="redo" cmd="cmsRun ElectronRedoFromRawStartup_cfg.py">
-      </environment>
-    
-      <environment name="RedoFromRawQcdPt80Pt120Startup">
-        <var name="DD_SAMPLE" value="RelValQCD_Pt_80_120">
-        <var name="TEST_HISTOS_FILE" value="${TEST_AFS_DIR}/${DD_SAMPLE}-STARTUP-RECO.root">
-        <target name="dd" cmd="electronDataDiscovery.py">
-        <target name="redo" cmd="cmsRun ElectronRedoFromRawStartup_cfg.py">
-      </environment>
-    
-      <environment name="RedoFromRawPt10Startup">
-        <var name="DD_SAMPLE" value="RelValSingleElectronPt10">
-        <var name="TEST_HISTOS_FILE" value="${TEST_AFS_DIR}/${DD_SAMPLE}-STARTUP-RECO.root">
-        <target name="dd" cmd="electronDataDiscovery.py">
-        <target name="redo" cmd="cmsRun ElectronRedoFromRawStartup_cfg.py">
-      </environment>
-  
-      <environment name="RedoFromRawZEEStartup">
-        <var name="DD_SAMPLE" value="RelValZEE">
-        <var name="TEST_HISTOS_FILE" value="${TEST_AFS_DIR}/${DD_SAMPLE}-STARTUP-RECO.root">
-        <target name="dd" cmd="electronDataDiscovery.py">
-        <target name="redo" cmd="cmsRun ElectronRedoFromRawStartup_cfg.py">
-      </environment>
-    
-    </environment>
-    
-  </environment>
-  
-</environment>
-
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-================================================================================
-This set of targets is made to test cmsDriver.py steps
-================================================================================
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-<environment name="Validation">
-
-  <target name="step1" cmd="cmsDriver.py SingleElectronPt35_cfi.py -s GEN,SIM,DIGI,L1,DIGI2RAW,HLT:GRun -n 10 --eventcontent FEVTDEBUGHLT --conditions auto:mc --mc --fileout SingleElectronPt35-10-IDEAL-RAW.root">
-  <target name="step2" cmd="cmsDriver.py step2 -s RAW2DIGI,RECO,VALIDATION,DQM -n 10 --filein file:SingleElectronPt35-10-IDEAL-RAW.root --eventcontent FEVTDEBUGHLT --conditions auto:mc --mc --fileout SingleElectronPt35-10-IDEAL-RECO.root">
-  <target name="step3" cmd="cmsDriver.py step3 -s HARVESTING:validationHarvesting+dqmHarvesting --harvesting AtRunEnd --conditions auto:mc --filein file:SingleElectronPt35-10-IDEAL-RECO.root --mc">
-
-</environment>
-
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-================================================================================
-Process uncleaned superclusters
-================================================================================
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-<environment name="Uncleaned">
-
-  <var name="DD_TIER" value="*RAW*">
-  <var name="DD_SAMPLE" value="RelValSingleElectronPt35">
-  <var name="TEST_HISTOS_FILE" value="${DD_SAMPLE}-IDEAL-UNCLEANED-RECO.root">
-  
-  <target name="dd" cmd="electronDataDiscovery.py">
-  <target name="py" cmd="python ElectronFromUncleanedOnly_cfg.py">
-  <target name="reco" cmd="cmsRun ElectronFromUncleanedOnly_cfg.py">
-  
-</environment>
-
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-================================================================================
-Photons
-================================================================================
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-<environment name="Photons">
-
-  Those few photons datasets are checked so to compare
-  size and performance with electrons.
-
-  <var name="DD_TIER_SECONDARY" value="*RAW*">
-  <!--var name="DD_RELEASE" value="LOCAL"-->
-  <!--var name="DD_COND" value=""-->
-
-  <environment name="PhotonPt35">
-    <var name="DD_SAMPLE" value="RelValSingleGammaPt35">
-    <executable name="electronDataDiscovery.py">
-    <executable name="cmsRun" args="PhotonValidation_cfg.py">
-  </environment>
-  
-  <environment name="PhotonQcdPt80-120">
-    <var name="DD_SAMPLE" value="RelValQCD_Pt_80_120">
-    <executable name="electronDataDiscovery.py">
-    <executable name="cmsRun" args="PhotonValidation_cfg.py">
   </environment>
   
 </environment>

--- a/Validation/RecoEgamma/test/OvalFile.FAST
+++ b/Validation/RecoEgamma/test/OvalFile.FAST
@@ -1,19 +1,19 @@
 <var name="TEST_COMMENT" value="">
-<var name="TEST_NEW" value="7_0_0_std">
-<var name="TEST_REF" value="7_0_0_std">
+<var name="TEST_NEW" value="7_1_0_std">
+<var name="TEST_REF" value="7_1_0_pre9_std">
 
-<var name="TAG_STARTUP" value="POSTLS170_V3">
-<var name="DATA_VERSION" value="v2">
+<var name="TAG_STARTUP" value="POSTLS171_V15">
+<var name="DATA_VERSION" value="v1">
 
 TAG for the REFERENCE DATA, USED ONLY FOR INFORMATION ON WEB PAGE
-<var name="DD_COND_REF" value="POSTLS170_V3-v2">
+<var name="DD_COND_REF" value="POSTLS171_V11_FastSim-v1">
 
 <var name="DD_RELEASE" value="${CMSSW_VERSION}">
 
 <var name="STORE_DIR" value="/afs/cern.ch/cms/Physics/egamma/www/validation/Electrons/Store/${TEST_NEW}">
 <var name="STORE_REF" value="/afs/cern.ch/cms/Physics/egamma/www/validation/Electrons/Store/${TEST_REF}">
 
-<var name="WEB_DIR" value="/afs/cern.ch/cms/Physics/egamma/www/validation/Electrons/Releases">
+<var name="WEB_DIR" value="/afs/cern.ch/cms/Physics/egamma/www/validation/Electrons/Dev">
 
 <!--var name="WEB_DIR" value="/afs/cern.ch/user/c/chamont/www/validation"-->
 <!--var name="WEB_URL" value="https://chamont.web.cern.ch/chamont/validation"-->
@@ -187,6 +187,7 @@ FastSim
 
       <environment name="ValFastVsFastTTbarStartup">
         <var name="DD_SAMPLE" value="RelValTTbar">
+	<var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}">
         <!--var name="TEST_HISTOS_FILE" value="electronHistos.ValFastTTbarStartup.root"-->
         <var name="TEST_HISTOS_FILE" value="electronHistos.ValFastTTbarStartup_gedGsfE.root">
         <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/Fast_${DD_SAMPLE}_Startup'>
@@ -194,20 +195,23 @@ FastSim
       
       <environment name="ValFastVsFastZEEStartup">
         <var name="DD_SAMPLE" value="RelValZEE">
+	<var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}">
         <!--var name="TEST_HISTOS_FILE" value="electronHistos.ValFastZEEStartup.root"-->
         <var name="TEST_HISTOS_FILE" value="electronHistos.ValFastZEEStartup_gedGsfE.root">
         <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/Fast_${DD_SAMPLE}_Startup'>
       </environment>
         
       <environment name="ValFastVsFastTTbarStartup_gedGsfE">
-        <var name="DD_SAMPLE" value="RelValTTbar">
+        <var name="DD_SAMPLE" value="RelValTTbar_13">
+	<var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}">
         <!--var name="TEST_HISTOS_FILE" value="electronHistos.ValFastTTbarStartup.root"-->
         <var name="TEST_HISTOS_FILE" value="electronHistos.ValFastTTbarStartup_gedGsfE.root">
         <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/Fast_${DD_SAMPLE}_Startup'>
       </environment>
       
       <environment name="ValFastVsFastZEEStartup_gedGsfE">
-        <var name="DD_SAMPLE" value="RelValZEE">
+        <var name="DD_SAMPLE" value="RelValZEE_13">
+	<var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}">
         <!--var name="TEST_HISTOS_FILE" value="electronHistos.ValFastZEEStartup.root"-->
         <var name="TEST_HISTOS_FILE" value="electronHistos.ValFastZEEStartup_gedGsfE.root">
         <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/Fast_${DD_SAMPLE}_Startup'>
@@ -227,16 +231,18 @@ FastSim
 
       <environment name="ValFastVsFullTTbarStartup_gedGsfE">
         <var name="DD_SAMPLE" value="RelValTTbar_13">
-        <var name="BLUE_FILE" value="electronHistos.ValFullTTbarStartup_13_gedGsfE.root">
+ 	<var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}">
+       <var name="BLUE_FILE" value="electronHistos.ValFullTTbarStartup_13_gedGsfE.root">
         <var name="RED_FILE" value="electronHistos.ValFastTTbarStartup_gedGsfE.root">
-        <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r FastSim -b FullSim -t "Fast vs Full / ${DD_SAMPLE} / ${DD_COND}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/FastVsFull/${DD_SAMPLE}_Startup'>
+        <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_NEW} -t "Fast vs Full / ${DD_SAMPLE} / ${DD_COND}" ${STORE_DIR}/${RED_FILE} ${STORE_DIR}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/FastVsFull/${DD_SAMPLE}_Startup'>
       </environment>
       
       <environment name="ValFastVsFullZEEStartup_gedGsfE">
         <var name="DD_SAMPLE" value="RelValZEE_13">
+	<var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}">
         <var name="BLUE_FILE" value="electronHistos.ValFullZEEStartup_13_gedGsfE.root">
         <var name="RED_FILE" value="electronHistos.ValFastZEEStartup_gedGsfE.root">
-        <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r FastSim -b FullSim -t "Fast vs Full / ${DD_SAMPLE} / ${DD_COND}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/FastVsFull/${DD_SAMPLE}_Startup'>
+        <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_NEW} -t "Fast vs Full / ${DD_SAMPLE} / ${DD_COND}" ${STORE_DIR}/${RED_FILE} ${STORE_DIR}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/FastVsFull/${DD_SAMPLE}_Startup'>
       </environment>
       
     </environment>

--- a/Validation/RecoEgamma/test/OvalFile.GED
+++ b/Validation/RecoEgamma/test/OvalFile.GED
@@ -1,19 +1,19 @@
 <var name="TEST_COMMENT" value="">
-<var name="TEST_NEW" value="7_0_0_std">
-<var name="TEST_REF" value="7_0_0_pre13_std">
+<var name="TEST_NEW" value="7_1_0_std">
+<var name="TEST_REF" value="7_1_0_pre9_std">
 
-<var name="TAG_STARTUP" value="POSTLS170_V3">
-<var name="DATA_VERSION" value="v2">
+<var name="TAG_STARTUP" value="POSTLS171_V15">
+<var name="DATA_VERSION" value="v1">
 
 TAG for the REFERENCE DATA, USED ONLY FOR INFORMATION ON WEB PAGE
-<var name="DD_COND_REF" value="POSTLS170_V1-v1">
+<var name="DD_COND_REF" value="POSTLS171_V11-v1">
 
 <var name="DD_RELEASE" value="${CMSSW_VERSION}">
 
 <var name="STORE_DIR" value="/afs/cern.ch/cms/Physics/egamma/www/validation/Electrons/Store/${TEST_NEW}">
 <var name="STORE_REF" value="/afs/cern.ch/cms/Physics/egamma/www/validation/Electrons/Store/${TEST_REF}">
 
-<var name="WEB_DIR" value="/afs/cern.ch/cms/Physics/egamma/www/validation/Electrons/Releases">
+<var name="WEB_DIR" value="/afs/cern.ch/cms/Physics/egamma/www/validation/Electrons/Dev">
 
 <!--var name="WEB_DIR" value="/afs/cern.ch/user/c/chamont/www/validation"-->
 <!--var name="WEB_URL" value="https://chamont.web.cern.ch/chamont/validation"-->

--- a/Validation/RecoEgamma/test/OvalFile.PU
+++ b/Validation/RecoEgamma/test/OvalFile.PU
@@ -1,19 +1,19 @@
 <var name="TEST_COMMENT" value="">
-<var name="TEST_NEW" value="7_0_0_std">
-<var name="TEST_REF" value="7_0_0_pre13_std">
+<var name="TEST_NEW" value="7_1_0_std">
+<var name="TEST_REF" value="7_1_0_pre7_std">
 
-<var name="TAG_STARTUP" value="POSTLS170_V3">
-<var name="DATA_VERSION" value="v2">
+<var name="TAG_STARTUP" value="POSTLS171_V16">
+<var name="DATA_VERSION" value="v1">
 
 TAG for the REFERENCE DATA, USED ONLY FOR INFORMATION ON WEB PAGE
-<var name="DD_COND_REF" value="PU25ns_POSTLS170_V3-v1">
+<var name="DD_COND_REF" value="PU50ns_PRE_LS171_V8-v1">
 
 <var name="DD_RELEASE" value="${CMSSW_VERSION}">
 
 <var name="STORE_DIR" value="/afs/cern.ch/cms/Physics/egamma/www/validation/Electrons/Store/${TEST_NEW}">
 <var name="STORE_REF" value="/afs/cern.ch/cms/Physics/egamma/www/validation/Electrons/Store/${TEST_REF}">
 
-<var name="WEB_DIR" value="/afs/cern.ch/cms/Physics/egamma/www/validation/Electrons/Releases">
+<var name="WEB_DIR" value="/afs/cern.ch/cms/Physics/egamma/www/validation/Electrons/Dev">
 
 <!--var name="WEB_DIR" value="/afs/cern.ch/user/c/chamont/www/validation"-->
 <!--var name="WEB_URL" value="https://chamont.web.cern.ch/chamont/validation"-->
@@ -22,7 +22,7 @@ The value of OVAL_ENVNAME is automatically set by Oval to the name
 of the current environment, before running any executable. Using it below,
 we have an output file name which is unique for each execution.
 
-<var name="TEST_HISTOS_FILE" value="electronHistos.PU25ns_${OVAL_ENVNAME}.root">
+<var name="TEST_HISTOS_FILE" value="electronHistos.PU50ns_${OVAL_ENVNAME}.root">
 <var name="TEST_OUTPUT_LOGS" value="*.${OVAL_ENVNAME}.olog">
 <!--var name="TEST_HISTOS_FILE" value="DQM_V0001_R000000001__${DD_SAMPLE}__${DD_RELEASE}-${DD_COND}__DQM.root"-->
 <!--difffile name="electronHistos.root"-->
@@ -106,7 +106,7 @@ FullSim
       
   <environment name="ValPileUpStartup">
     
-    <var name="TAG_STARTUP" value="PU25ns_${TAG_STARTUP}">
+    <var name="TAG_STARTUP" value="PU50ns_${TAG_STARTUP}">
     <var name="TEST_GLOBAL_TAG" value="${TAG_STARTUP}">
     <var name="TEST_GLOBAL_AUTOCOND" value="startup">
     <var name="DD_COND" value="${TEST_GLOBAL_TAG}-${DATA_VERSION}">
@@ -118,7 +118,7 @@ FullSim
         <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
 
 	    <var name="BLUE_FILE" value="electronHistos.ValPileUpTTbarStartup_pu40bx50.root">
-        <var name="RED_FILE" value="electronHistos.PU25ns_ValPileUpTTbarStartup.root">
+        <var name="RED_FILE" value="electronHistos.PU50ns_ValPileUpTTbarStartup.root">
 
         <target name="dqm" cmd="electronDataDiscovery.py castor">
         <target name="wget" cmd="electronWget.py castor">
@@ -129,7 +129,7 @@ FullSim
       
         <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
         <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/PileUp25ns_${DD_SAMPLE}_Startup'>
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/PileUp50ns_${DD_SAMPLE}_Startup'>
   
       </environment>
 
@@ -140,7 +140,7 @@ FullSim
       <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
       
 	    <var name="BLUE_FILE" value="electronHistos.ValPileUpZEEStartup_pu40bx50.root">
-        <var name="RED_FILE" value="electronHistos.PU25ns_ValPileUpZEEStartup.root">
+        <var name="RED_FILE" value="electronHistos.PU50ns_ValPileUpZEEStartup.root">
 
 		<target name="dqm" cmd="electronDataDiscovery.py castor">
       <target name="wget" cmd="electronWget.py castor">
@@ -151,8 +151,8 @@ FullSim
       
       <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
       <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/PileUp25ns_${DD_SAMPLE}_Startup'>
-	  <!--target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/PileUp25ns_${DD_SAMPLE}_gedGsfE_Startup'-->
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/PileUp50ns_${DD_SAMPLE}_Startup'>
+	  <!--target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/PileUp50ns_${DD_SAMPLE}_gedGsfE_Startup'-->
   
     </environment>
 
@@ -162,8 +162,8 @@ FullSim
         <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
         <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
 	
-	    <var name="BLUE_FILE" value="electronHistos.PU25ns_ValPileUpTTbarStartup_gedGsfE.root">
-        <var name="RED_FILE" value="electronHistos.PU25ns_ValPileUpTTbarStartup_gedGsfE.root">
+	    <var name="BLUE_FILE" value="electronHistos.PU50ns_ValPileUpTTbarStartup_gedGsfE.root">
+        <var name="RED_FILE" value="electronHistos.PU50ns_ValPileUpTTbarStartup_gedGsfE.root">
  
         <target name="dqm" cmd="electronDataDiscovery.py castor">
         <target name="wget" cmd="electronWget.py castor">
@@ -174,7 +174,7 @@ FullSim
       
         <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
         <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-	    <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedVsGed/PileUp25ns_${DD_SAMPLE}_gedGsfE_Startup'>
+	    <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedVsGed/PileUp50ns_${DD_SAMPLE}_gedGsfE_Startup'>
 
       </environment>
 
@@ -184,8 +184,8 @@ FullSim
       <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
       <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
      
-      <var name="BLUE_FILE" value="electronHistos.PU25ns_ValPileUpZEEStartup_gedGsfE.root">
-      <var name="RED_FILE" value="electronHistos.PU25ns_ValPileUpZEEStartup_gedGsfE.root">
+      <var name="BLUE_FILE" value="electronHistos.PU50ns_ValPileUpZEEStartup_gedGsfE.root">
+      <var name="RED_FILE" value="electronHistos.PU50ns_ValPileUpZEEStartup_gedGsfE.root">
 
       <target name="dqm" cmd="electronDataDiscovery.py castor">
       <target name="wget" cmd="electronWget.py castor">
@@ -196,7 +196,7 @@ FullSim
       
       <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
       <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedVsGed/PileUp25ns_${DD_SAMPLE}_gedGsfE_Startup'>
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedVsGed/PileUp50ns_${DD_SAMPLE}_gedGsfE_Startup'>
 
     </environment>
   

--- a/Validation/RecoEgamma/test/analyze_gedGsfE.tcsh
+++ b/Validation/RecoEgamma/test/analyze_gedGsfE.tcsh
@@ -13,7 +13,7 @@ if [ "$1" != "i" ]
 then
 	echo "pas d'interaction"
 	echo "defaut = batch"
-	CHOIX_INTERACTION='electronBsub 8nh /afs/cern.ch/cms/utils/oval run analyze.Val'
+	CHOIX_INTERACTION='./electronBsub 8nh /afs/cern.ch/cms/utils/oval run analyze.Val'
 else
 	echo "interaction"
 	CHOIX_INTERACTION='/afs/cern.ch/cms/utils/oval run analyze.Val'
@@ -49,6 +49,7 @@ case $CHOIX_CALCUL in
 Full) echo "Full"
 	echo "--"
 	for i in Pt10Startup_UP15 Pt1000Startup_UP15 Pt35Startup_UP15 TTbarStartup_13 ZEEStartup_13 QcdPt80Pt120Startup_13
+#	for i in Pt1000Startup_UP15 TTbarStartup_13 ZEEStartup_13 QcdPt80Pt120Startup_13
 		do 
 			echo " == ${CHOIX_INTERACTION}${CHOIX_CALCUL}${i}_gedGsfE"
 			${CHOIX_INTERACTION}${CHOIX_CALCUL}${i}_gedGsfE
@@ -65,6 +66,7 @@ PileUp) echo "PileUp"
 Fast) echo "Fast"
 	echo "**"
 	for i in TTbarStartup ZEEStartup
+#	for i in ZEEStartup
 		do 
 			echo " == ${CHOIX_INTERACTION}${CHOIX_CALCUL}${i}_gedGsfE"
 			${CHOIX_INTERACTION}${CHOIX_CALCUL}${i}_gedGsfE

--- a/Validation/RecoEgamma/test/electronCompare.C
+++ b/Validation/RecoEgamma/test/electronCompare.C
@@ -540,10 +540,10 @@ int electronCompare()
 
 
 // ne pas oublier de decommenter les 4 lignes suivantes
-//      std::cout<<histo_name
-//        <<" has "<<histo_new->GetEffectiveEntries()<<" entries"
-//        <<" of mean value "<<histo_new->GetMean()
-//        <<std::endl ;
+      std::cout<<histo_name
+        <<" has "<<histo_new->GetEffectiveEntries()<<" entries"
+        <<" of mean value "<<histo_new->GetMean()
+        <<std::endl ;
       canvas->SaveAs(gif_path.Data()) ;
       web_page<<"<a href=\""<<gif_name<<"\"><img border=\"0\" class=\"image\" width=\"440\" src=\""<<gif_name<<"\"></a><br>" ;
      }

--- a/Validation/RecoEgamma/test/electronCompare.C
+++ b/Validation/RecoEgamma/test/electronCompare.C
@@ -101,6 +101,16 @@ int electronCompare()
   TString CMP_RED_COMMENT  = gSystem->Getenv( "CMP_RED_COMMENT"  ) ;
   TString CMP_BLUE_COMMENT = gSystem->Getenv( "CMP_BLUE_COMMENT" ) ;
   TString CMP_CONFIG       = gSystem->Getenv( "CMP_CONFIG"       ) ;
+  TString CMP_RED_RELEASE  = gSystem->Getenv( "CMP_RED_RELEASE"  ) ;
+  TString CMP_BLUE_RELEASE = gSystem->Getenv( "CMP_BLUE_RELEASE" ) ;
+
+//-----
+// AC
+//  std::cout << "red_file : C : " << CMP_RED_FILE << std::endl;
+//  std::cout << "blue_file : C : " << CMP_BLUE_FILE << std::endl;
+  std::cout << "red_release : C : " << CMP_RED_RELEASE << std::endl;
+  std::cout << "blue_release : C : " << CMP_BLUE_RELEASE << std::endl;
+//-----
 
   // style:
   TStyle *eleStyle = new TStyle("eleStyle","Style for electron validation");
@@ -231,10 +241,17 @@ int electronCompare()
    }
   else
    {
-    web_page
+/*    web_page
      <<"<p>In all plots below"
      <<", the "<<CMP_RED_NAME<<" histograms are in red"
-     <<", and the "<<CMP_BLUE_NAME<<" histograms are in blue." ;
+     <<", and the "<<CMP_BLUE_NAME<<" histograms are in blue." ;*/
+    web_page
+     <<"<p>In all plots below"
+     <<", the "<<CMP_RED_RELEASE<<" histograms are in red"
+     <<", and the "<<CMP_BLUE_RELEASE<<" histograms are in blue." ;
+/*	std::cout <<"<p>In all plots below "
+     <<", the "<<CMP_RED_RELEASE<<" histograms are in red"
+     <<", and the "<<CMP_BLUE_RELEASE<<" histograms are in blue." << std::endl ;*/
    }
 
   std::ifstream red_comment_file(CMP_RED_COMMENT) ;
@@ -391,6 +408,10 @@ int electronCompare()
     canvas = new TCanvas(canvas_name) ;
     canvas->SetFillColor(10) ;
 
+
+
+
+
     web_page<<"<a id=\""<<histo_name<<"\" name=\""<<short_histo_name<<"\"></a>" ;
 
     // search histo_ref
@@ -416,6 +437,7 @@ int electronCompare()
     // search histo_new
     histo_full_path = file_new_dir ; histo_full_path += histo_path.c_str() ;
     histo_new = (TH1 *)file_new->Get(histo_full_path) ;
+
 
     // special treatments
     if ((scaled==1)&&(histo_new!=0)&&(histo_ref!=0)&&(histo_ref->GetEntries()!=0))
@@ -490,6 +512,14 @@ int electronCompare()
         Double_t y2 = st_ref->GetY2NDC() ;
         st_ref->SetY1NDC(2*y1-y2) ;
         st_ref->SetY2NDC(y1) ;
+
+
+
+
+
+
+
+
        }
 
       // Redraws
@@ -502,6 +532,8 @@ int electronCompare()
       // eventual log scale
       //if ( (log==1) && ( (histo_new->GetEntries()>0) || ( (histo_ref!=0) && (histo_ref->GetEntries()!=0) ) ) )
       // { canvas->SetLogy(1) ; }
+
+
 
       std::cout<<histo_name
         <<" has "<<histo_new->GetEffectiveEntries()<<" entries"

--- a/Validation/RecoEgamma/test/electronCompare.C
+++ b/Validation/RecoEgamma/test/electronCompare.C
@@ -111,8 +111,8 @@ int electronCompare()
   std::cout << "red_release : C : " << CMP_RED_RELEASE << std::endl;
   std::cout << "blue_release : C : " << CMP_BLUE_RELEASE << std::endl;
 //-----
-
-  // style:
+  
+// style:
   TStyle *eleStyle = new TStyle("eleStyle","Style for electron validation");
   eleStyle->SetCanvasBorderMode(0);
   eleStyle->SetCanvasColor(kWhite);
@@ -149,6 +149,8 @@ int electronCompare()
   eleStyle->SetPadLeftMargin(0.15);
   eleStyle->SetMarkerStyle(21);
   eleStyle->SetMarkerSize(0.8);
+  //-- AC --
+  eleStyle->SetPadRightMargin(0.2) ; 
 
   eleStyle->cd();
 
@@ -407,10 +409,10 @@ int electronCompare()
     canvas_name = "c" ; canvas_name += histo_name ;
     canvas = new TCanvas(canvas_name) ;
     canvas->SetFillColor(10) ;
-
-
-
-
+	//std::cout << "canvas width " << canvas->GetWindowWidth() << std::endl; // 800 default
+	//std::cout << "canvas height " << canvas->GetWindowHeight() << std::endl; // 600 default
+	//std::cout << "canvas Y real " << canvas->GetYsizeReal() << std::endl;
+	//std::cout << "canvas Y user " << canvas->GetYsizeUser() << std::endl;
 
     web_page<<"<a id=\""<<histo_name<<"\" name=\""<<short_histo_name<<"\"></a>" ;
 
@@ -437,7 +439,7 @@ int electronCompare()
     // search histo_new
     histo_full_path = file_new_dir ; histo_full_path += histo_path.c_str() ;
     histo_new = (TH1 *)file_new->Get(histo_full_path) ;
-
+	//std::cout << "size " << histo_new->GetSize() << std::endl ;
 
     // special treatments
     if ((scaled==1)&&(histo_new!=0)&&(histo_ref!=0)&&(histo_ref->GetEntries()!=0))
@@ -481,6 +483,11 @@ int electronCompare()
       histo_new->SetLineWidth(3) ;
       RenderHisto(histo_new,canvas) ;
       histo_new->Draw(newDrawOptions) ;
+//	  std::cout << "SIZE : " << canvas->GetWw() << std::endl ; // 796 default
+//	  std::cout << "SIZE : " << canvas->GetWh() << std::endl ; // 572 default
+      //canvas->Update() ;
+	  //canvas->SetWindowSize(440, 600);
+	  canvas->SetCanvasSize(960, 600);
       canvas->Update() ;
       st_new = (TPaveStats*)histo_new->FindObject("stats");
       st_new->SetTextColor(kRed) ;
@@ -512,14 +519,12 @@ int electronCompare()
         Double_t y2 = st_ref->GetY2NDC() ;
         st_ref->SetY1NDC(2*y1-y2) ;
         st_ref->SetY2NDC(y1) ;
-
-
-
-
-
-
-
-
+        //Double_t x1 = st_ref->GetX1NDC() ;
+        //Double_t x2 = st_ref->GetX2NDC() ;
+		//std::cout << "position s x1 = " << x1 << std::endl ; // 0.78 par defaut
+		//std::cout << "position s x2 = " << x2 << std::endl ; // 0.98 par defaut
+		//std::cout << "position s y1 = " << y1 << std::endl ; // 0.755 ou 0.835 par defaut
+		//std::cout << "position s y2 = " << y2 << std::endl ; // 0.995 par defaut
        }
 
       // Redraws
@@ -534,11 +539,11 @@ int electronCompare()
       // { canvas->SetLogy(1) ; }
 
 
-
-      std::cout<<histo_name
-        <<" has "<<histo_new->GetEffectiveEntries()<<" entries"
-        <<" of mean value "<<histo_new->GetMean()
-        <<std::endl ;
+// ne pas oublier de decommenter les 4 lignes suivantes
+//      std::cout<<histo_name
+//        <<" has "<<histo_new->GetEffectiveEntries()<<" entries"
+//        <<" of mean value "<<histo_new->GetMean()
+//        <<std::endl ;
       canvas->SaveAs(gif_path.Data()) ;
       web_page<<"<a href=\""<<gif_name<<"\"><img border=\"0\" class=\"image\" width=\"440\" src=\""<<gif_name<<"\"></a><br>" ;
      }

--- a/Validation/RecoEgamma/test/finalize_gedGsfE.tcsh
+++ b/Validation/RecoEgamma/test/finalize_gedGsfE.tcsh
@@ -13,7 +13,7 @@ if [ "$1" != "i" ]
 then
 	echo "pas d'interaction"
 	echo "defaut = batch"
-	CHOIX_INTERACTION='electronBsub 8nh /afs/cern.ch/cms/utils/oval run finalize.Val'
+	CHOIX_INTERACTION='./electronBsub 8nh /afs/cern.ch/cms/utils/oval run finalize.Val'
 else
 	echo "interaction"
 	CHOIX_INTERACTION='/afs/cern.ch/cms/utils/oval run finalize.Val'
@@ -49,6 +49,7 @@ case $CHOIX_CALCUL in
 Full) echo "Full"
 	echo "--"
 	for i in Pt10Startup_UP15 Pt1000Startup_UP15 Pt35Startup_UP15 TTbarStartup_13 ZEEStartup_13 QcdPt80Pt120Startup_13
+#	for i in Pt1000Startup_UP15 TTbarStartup_13 ZEEStartup_13 QcdPt80Pt120Startup_13
 		do 
 			echo " -- ${CHOIX_INTERACTION}${CHOIX_CALCUL}${i}_gedGsfE"
 			${CHOIX_INTERACTION}${CHOIX_CALCUL}${i}_gedGsfE

--- a/Validation/RecoEgamma/test/publish_fast_gedGsfE.tcsh
+++ b/Validation/RecoEgamma/test/publish_fast_gedGsfE.tcsh
@@ -1,5 +1,0 @@
-#!/bin/tcsh
-oval run publish.ValFastVsFullTTbarStartup_gedGsfE
-oval run publish.ValFastVsFullZEEStartup_gedGsfE
-oval run publish.ValFastVsFastTTbarStartup_gedGsfE
-oval run publish.ValFastVsFastZEEStartup_gedGsfE

--- a/Validation/RecoEgamma/test/publish_full_gedGsfE.pu.tcsh
+++ b/Validation/RecoEgamma/test/publish_full_gedGsfE.pu.tcsh
@@ -1,3 +1,0 @@
-#!/bin/tcsh
-oval run publish.ValPileUpTTbarStartup_gedGsfE
-oval run publish.ValPileUpZEEStartup_gedGsfE

--- a/Validation/RecoEgamma/test/publish_fullgedvsged.su.tcsh
+++ b/Validation/RecoEgamma/test/publish_fullgedvsged.su.tcsh
@@ -1,7 +1,0 @@
-#!/bin/tcsh
-oval run publish.ValgedvsgedFullPt10Startup_UP15_gedGsfE
-oval run publish.ValgedvsgedFullPt1000Startup_UP15_gedGsfE
-oval run publish.ValgedvsgedFullPt35Startup_UP15_gedGsfE
-oval run publish.ValgedvsgedFullTTbarStartup_13_gedGsfE
-oval run publish.ValgedvsgedFullZEEStartup_13_gedGsfE
-oval run publish.ValgedvsgedFullQcdPt80Pt120Startup_13_gedGsfE

--- a/Validation/RecoEgamma/test/publish_gedGsfE.tcsh
+++ b/Validation/RecoEgamma/test/publish_gedGsfE.tcsh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+echo $1 $2
+
+if [ "$1" == "?" ] 
+then
+	echo "methode : ./analyze_gedGsfE [i(nteractif),j(ob)] [r(eco),f(ast),p(ileup)]"
+	echo "defaut = j r"
+	exit
+fi
+
+if [ "$1" != "i" ] 
+then
+	echo "pas d'interaction"
+	echo "defaut = batch"
+	CHOIX_INTERACTION='./electronBsub 1nh /afs/cern.ch/cms/utils/oval run publish.Val'
+else
+	echo "interaction"
+	CHOIX_INTERACTION='/afs/cern.ch/cms/utils/oval run publish.Val'
+fi
+
+#echo $1 $CHOIX_INTERACTION
+
+if [ "$2" != "r" ] 
+then
+	if [ "$2" != "f" ] 
+	then
+		if [ "$2" != "p" ] 
+		then
+			echo "pas de choix calcul" 
+			echo "defaut = FULL"
+			CHOIX_CALCUL='Full'
+		else
+			#echo "PILES PileUp"
+			CHOIX_CALCUL='PileUp'
+		fi
+	else
+		#echo "FAST"
+		CHOIX_CALCUL='Fast'
+	fi
+else
+	#echo "FULL"
+	CHOIX_CALCUL='gedvsgedFull'
+fi
+
+#echo $2 $CHOIX_CALCUL
+
+case $CHOIX_CALCUL in
+gedvsgedFull) echo "Full"
+	echo "--"
+	for i in Pt10Startup_UP15 Pt1000Startup_UP15 Pt35Startup_UP15 TTbarStartup_13 ZEEStartup_13 QcdPt80Pt120Startup_13
+#	for i in Pt1000Startup_UP15 TTbarStartup_13 ZEEStartup_13 QcdPt80Pt120Startup_13
+		do 
+			echo " == ${CHOIX_INTERACTION}${CHOIX_CALCUL}${i}_gedGsfE"
+			${CHOIX_INTERACTION}${CHOIX_CALCUL}${i}_gedGsfE
+		done
+	;;
+PileUp) echo "PileUp"
+	echo "++"
+	for i in TTbarStartup ZEEStartup
+		do 
+			echo " == ${CHOIX_INTERACTION}${CHOIX_CALCUL}${i}_gedGsfE"
+			${CHOIX_INTERACTION}${CHOIX_CALCUL}${i}_gedGsfE
+		done
+	;;
+Fast) echo "Fast"
+	echo "**"
+	for j in VsFull VsFast
+		do
+		for i in TTbarStartup ZEEStartup
+#		for i in ZEEStartup
+			do 
+				echo " == ${CHOIX_INTERACTION}${CHOIX_CALCUL}${j}${i}_gedGsfE"
+				${CHOIX_INTERACTION}${CHOIX_CALCUL}${j}${i}_gedGsfE
+			done
+		done
+	;;
+esac
+

--- a/Validation/RecoEgamma/test/store_gedGsfE.tcsh
+++ b/Validation/RecoEgamma/test/store_gedGsfE.tcsh
@@ -13,10 +13,12 @@ if [ "$1" != "i" ]
 then
 	echo "pas d'interaction"
 	echo "defaut = batch"
-	CHOIX_INTERACTION='electronBsub 1nh /afs/cern.ch/cms/utils/oval run store.Val'
+#	CHOIX_INTERACTION='./electronBsub 1nh /afs/cern.ch/cms/utils/oval run force.Val'
+	CHOIX_INTERACTION='./electronBsub 1nh /afs/cern.ch/cms/utils/oval run store.Val'
 else
 	echo "interaction"
 	CHOIX_INTERACTION='/afs/cern.ch/cms/utils/oval run store.Val'
+#	CHOIX_INTERACTION='/afs/cern.ch/cms/utils/oval run force.Val'
 fi
 
 #echo $1 $CHOIX_INTERACTION
@@ -49,6 +51,7 @@ case $CHOIX_CALCUL in
 Full) echo "Full"
 	echo "--"
 	for i in Pt10Startup_UP15 Pt1000Startup_UP15 Pt35Startup_UP15 TTbarStartup_13 ZEEStartup_13 QcdPt80Pt120Startup_13
+#	for i in Pt1000Startup_UP15 TTbarStartup_13 ZEEStartup_13 QcdPt80Pt120Startup_13
 		do 
 			echo " == ${CHOIX_INTERACTION}${CHOIX_CALCUL}${i}_gedGsfE"
 			${CHOIX_INTERACTION}${CHOIX_CALCUL}${i}_gedGsfE
@@ -65,6 +68,7 @@ PileUp) echo "PileUp"
 Fast) echo "Fast"
 	echo "**"
 	for i in TTbarStartup ZEEStartup
+#        for i in ZEEStartup
 		do 
 			echo " == ${CHOIX_INTERACTION}${CHOIX_CALCUL}${i}_gedGsfE"
 			${CHOIX_INTERACTION}${CHOIX_CALCUL}${i}_gedGsfE


### PR DESCRIPTION
Here are the small modifications in the file ElectronMcSignalValidator.cc porting on histos presentations (missing legends).
new publish script instead of the three existing which are deleted.
README updated for use of scripts

DQMOffline/EGamma
/interface/ElectronDqmAnalyzerBase.h and src/ElectronDqmAnalyzerBase.cc have beed modified to take into account the setEfficiencyTag into BookH1andDivide histos. same changes have been introduced into Validation/RecoEgamma/plugins/ElectronMcFakePostValidator.cc and Validation/RecoEgamma/plugins/ElectronMcSignalPostValidator.cc

Validation/RecoEgamma/test
few modifications have been made into scripts analyze_gedGsfE.tcsh, finalize_gedGsfE.tcsh, store_gedGsfE.tcsh, and a new one was added (publish_gedGesfE.tcsh). 
The file ElectronCompare.cc was modified to take into account the releases wich are compared and the stats legend was moved on the right of the pictures (same moficiations are made with DQMOffline/EGamma/scripts/electronCompare.pyà
a modification was made into txt files for web histos presentation (ElectronMcFakeHistos.txt, ElectronMcSignalHistos.txt).
