### PR TITLE
Changing input collection for tauGenJets in miniAOD

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -134,6 +134,7 @@ def miniAOD_customizeMC(process):
     process.photonMatch.matched = "prunedGenParticles"
     process.photonMatch.src = cms.InputTag("reducedEgamma","reducedGedPhotons")
     process.tauMatch.matched = "prunedGenParticles"
+    process.tauGenJets.GenParticles = "prunedGenParticles"
     process.patJetPartonMatch.matched = "prunedGenParticles"
     process.patJetPartonMatch.mcStatus = [ 3, 23 ]
     process.patJetGenJetMatch.matched = "slimmedGenJets"


### PR DESCRIPTION
In the default PAT, the tauGenJets are made from genParticles. The miniAOD does not contain genParticles, so the links stored in pat::Tau are broken. The prunedGenParticles contain all particles necessary for tauGenJet building and are contained in miniAOD.

Physics output impact: none expected (however the links genJet constituents will work in miniAOD)

Timing impact: might be slightly faster (using smaller collection for tauGenJet production)
Output size impact: none expected (the references were filled also before, only they were pointing to non-existing objects)

@mbluj @gpetruc @arizzi

Can be forward-ported to 71x and 72x
