### PR TITLE
fixHLT tracking validation

### DIFF
--- a/SimTracker/TrackAssociation/src/QuickTrackAssociatorByHits.cc
+++ b/SimTracker/TrackAssociation/src/QuickTrackAssociatorByHits.cc
@@ -198,11 +198,9 @@ reco::RecoToSimCollection QuickTrackAssociatorByHits::associateRecoToSimImplemen
 
 	size_t collectionSize=::collectionSize(trackCollection); // Delegate away type specific part
 
-	//std::cout << "#reco Tracks = " << collectionSize << std::endl;
 	for( size_t i=0; i < collectionSize; ++i )
 	{
 		const reco::Track* pTrack=::getTrackAt(trackCollection,i); // Get a normal pointer for ease of use. This part is type specific so delegate.
-		//    std::cout << ">>> recoTrack #index = " << i << " pt = " << pTrack->pt() << std::endl;
 
 		// The return of this function has first as the index and second as the number of associated hits
 		std::vector < std::pair<edm::Ref<TrackingParticleCollection>,size_t> > trackingParticleQualityPairs=associateTrack( hitOrClusterAssociator, trackingParticleCollection, pTrack->recHitsBegin(), pTrack->recHitsEnd() );
@@ -216,7 +214,6 @@ reco::RecoToSimCollection QuickTrackAssociatorByHits::associateRecoToSimImplemen
 			size_t numberOfSharedHits=iTrackingParticleQualityPair->second;
 			size_t numberOfValidTrackHits=pTrack->found();
 
-			//std::cout << ">>> reco2sim. numberOfSharedHits = " << nt++ << ", " << numberOfSharedHits << std::endl;
 			if( numberOfSharedHits == 0 ) continue; // No point in continuing if there was no association
 
 			//if electron subtract double counting
@@ -263,7 +260,6 @@ reco::SimToRecoCollection QuickTrackAssociatorByHits::associateSimToRecoImplemen
 			size_t numberOfValidTrackHits=pTrack->found();
 			size_t numberOfSimulatedHits=0; // Set a few lines below, but only if required.
 
-			//std::cout << ">>> sim2reco. numberOfSharedHits = " << nt++ << ", " << numberOfSharedHits << std::endl;
 			if( numberOfSharedHits==0 ) continue; // No point in continuing if there was no association
 
 			if( simToRecoDenominator_==denomsim || (numberOfSharedHits<3 && threeHitTracksAreSpecial_) ) // the numberOfSimulatedHits is not always required, so can skip counting in some circumstances
@@ -443,7 +439,6 @@ template<typename iter> std::vector<OmniClusterRef> QuickTrackAssociatorByHits::
       else if (subdetid==SiStripDetId::TIB||subdetid==SiStripDetId::TOB||subdetid==SiStripDetId::TID||subdetid==SiStripDetId::TEC) {
 	const std::type_info &tid = typeid(*rhit);
 	if (tid == typeid(SiStripMatchedRecHit2D)) {
-	  //		      std::cout << "SiStripMatchedRecHit2D" << std::endl;
 	  const SiStripMatchedRecHit2D* sMatchedRHit = dynamic_cast<const SiStripMatchedRecHit2D*>(rhit);
 	  if (!sMatchedRHit->monoHit().cluster().isNonnull() || !sMatchedRHit->stereoHit().cluster().isNonnull())
 	    edm::LogError("TrackAssociator") << ">>> RecHit does not have an associated cluster!" << " file: " << __FILE__ << " line: " << __LINE__;
@@ -451,14 +446,12 @@ template<typename iter> std::vector<OmniClusterRef> QuickTrackAssociatorByHits::
 	  returnValue.push_back(sMatchedRHit->stereoClusterRef());
 	}
 	else if (tid == typeid(SiStripRecHit2D)) {
-	  //		      std::cout << "SiStripRecHit2D" << std::endl;
 	  const SiStripRecHit2D* sRHit = dynamic_cast<const SiStripRecHit2D*>(rhit);
 	  if (!sRHit->cluster().isNonnull())
 	    edm::LogError("TrackAssociator") << ">>> RecHit does not have an associated cluster!" << " file: " << __FILE__ << " line: " << __LINE__;
 	  returnValue.push_back(sRHit->omniClusterRef());
 	}
 	else if (tid == typeid(SiStripRecHit1D)) {
-	  //		      std::cout << "SiStripRecHit1D" << std::endl;
 	  const SiStripRecHit1D* sRHit = dynamic_cast<const SiStripRecHit1D*>(rhit);
 	  if (!sRHit->cluster().isNonnull())
 	    edm::LogError("TrackAssociator") << ">>> RecHit does not have an associated cluster!" << " file: " << __FILE__ << " line: " << __LINE__;
@@ -468,13 +461,11 @@ template<typename iter> std::vector<OmniClusterRef> QuickTrackAssociatorByHits::
 	  auto const & thit = static_cast<BaseTrackerRecHit const&>(*rhit);
 	  if ( thit.isProjected() ) {
 	  } else {
-	    //	    std::cout << "WHICH CLUSTER ?!?!" << std::endl;
 	    edm::LogError("TrackAssociator") << ">>> getMatchedClusters: TrackingRecHit not associated to any SiStripCluster! subdetid = " << subdetid;
 	  }
 	}
       }
       else {
-	//		    std::cout << "WHICH CLUSTER and WHICH DET ?!?!" << std::endl;
 	edm::LogError("TrackAssociator") << ">>> getMatchedClusters: TrackingRecHit not associated to any cluster! subdetid = " << subdetid;
       }
     }

--- a/SimTracker/TrackAssociation/src/QuickTrackAssociatorByHits.cc
+++ b/SimTracker/TrackAssociation/src/QuickTrackAssociatorByHits.cc
@@ -429,48 +429,57 @@ template<typename T_TPCollection,typename iter> std::vector< std::pair<edm::Ref<
 
 template<typename iter> std::vector<OmniClusterRef> QuickTrackAssociatorByHits::getMatchedClusters(iter begin, iter end) const
 {
-	std::vector<OmniClusterRef> returnValue;
-	for (iter iRecHit = begin; iRecHit != end; ++iRecHit) {
-		const TrackingRecHit* rhit = getHitFromIter(iRecHit);
-		if (rhit->isValid()) {
-			int subdetid = rhit->geographicalId().subdetId();
-			if (subdetid==PixelSubdetector::PixelBarrel||subdetid==PixelSubdetector::PixelEndcap) {
-				const SiPixelRecHit* pRHit = dynamic_cast<const SiPixelRecHit*>(rhit);
-				if (!pRHit->cluster().isNonnull())
-					edm::LogError("TrackAssociator") << ">>> RecHit does not have an associated cluster!" << " file: " << __FILE__ << " line: " << __LINE__;
-				returnValue.push_back(pRHit->omniClusterRef());
-			}
-			else if (subdetid==SiStripDetId::TIB||subdetid==SiStripDetId::TOB||subdetid==SiStripDetId::TID||subdetid==SiStripDetId::TEC) {
-				const std::type_info &tid = typeid(*rhit);
-				if (tid == typeid(SiStripMatchedRecHit2D)) {
-					const SiStripMatchedRecHit2D* sMatchedRHit = dynamic_cast<const SiStripMatchedRecHit2D*>(rhit);
-					if (!sMatchedRHit->monoHit().cluster().isNonnull() || !sMatchedRHit->stereoHit().cluster().isNonnull())
-						edm::LogError("TrackAssociator") << ">>> RecHit does not have an associated cluster!" << " file: " << __FILE__ << " line: " << __LINE__;
-					returnValue.push_back(sMatchedRHit->monoClusterRef());
-					returnValue.push_back(sMatchedRHit->stereoClusterRef());
-				}
-				else if (tid == typeid(SiStripRecHit2D)) {
-					const SiStripRecHit2D* sRHit = dynamic_cast<const SiStripRecHit2D*>(rhit);
-					if (!sRHit->cluster().isNonnull())
-						edm::LogError("TrackAssociator") << ">>> RecHit does not have an associated cluster!" << " file: " << __FILE__ << " line: " << __LINE__;
-					returnValue.push_back(sRHit->omniClusterRef());
-				}
-				else if (tid == typeid(SiStripRecHit1D)) {
-					const SiStripRecHit1D* sRHit = dynamic_cast<const SiStripRecHit1D*>(rhit);
-					if (!sRHit->cluster().isNonnull())
-						edm::LogError("TrackAssociator") << ">>> RecHit does not have an associated cluster!" << " file: " << __FILE__ << " line: " << __LINE__;
-					returnValue.push_back(sRHit->omniClusterRef());
-				}
-				else {
-					edm::LogError("TrackAssociator") << ">>> getMatchedClusters: TrackingRecHit not associated to any SiStripCluster! subdetid = " << subdetid;
-				}
-			}
-			else {
-				edm::LogError("TrackAssociator") << ">>> getMatchedClusters: TrackingRecHit not associated to any cluster! subdetid = " << subdetid;
-			}
-		}
+  std::vector<OmniClusterRef> returnValue;
+  for (iter iRecHit = begin; iRecHit != end; ++iRecHit) {
+    const TrackingRecHit* rhit = getHitFromIter(iRecHit);
+    if (rhit->isValid()) {
+      int subdetid = rhit->geographicalId().subdetId();
+      if (subdetid==PixelSubdetector::PixelBarrel||subdetid==PixelSubdetector::PixelEndcap) {
+	const SiPixelRecHit* pRHit = dynamic_cast<const SiPixelRecHit*>(rhit);
+	if (!pRHit->cluster().isNonnull())
+	  edm::LogError("TrackAssociator") << ">>> RecHit does not have an associated cluster!" << " file: " << __FILE__ << " line: " << __LINE__;
+	returnValue.push_back(pRHit->omniClusterRef());
+      }
+      else if (subdetid==SiStripDetId::TIB||subdetid==SiStripDetId::TOB||subdetid==SiStripDetId::TID||subdetid==SiStripDetId::TEC) {
+	const std::type_info &tid = typeid(*rhit);
+	if (tid == typeid(SiStripMatchedRecHit2D)) {
+	  //		      std::cout << "SiStripMatchedRecHit2D" << std::endl;
+	  const SiStripMatchedRecHit2D* sMatchedRHit = dynamic_cast<const SiStripMatchedRecHit2D*>(rhit);
+	  if (!sMatchedRHit->monoHit().cluster().isNonnull() || !sMatchedRHit->stereoHit().cluster().isNonnull())
+	    edm::LogError("TrackAssociator") << ">>> RecHit does not have an associated cluster!" << " file: " << __FILE__ << " line: " << __LINE__;
+	  returnValue.push_back(sMatchedRHit->monoClusterRef());
+	  returnValue.push_back(sMatchedRHit->stereoClusterRef());
 	}
-	return returnValue;
+	else if (tid == typeid(SiStripRecHit2D)) {
+	  //		      std::cout << "SiStripRecHit2D" << std::endl;
+	  const SiStripRecHit2D* sRHit = dynamic_cast<const SiStripRecHit2D*>(rhit);
+	  if (!sRHit->cluster().isNonnull())
+	    edm::LogError("TrackAssociator") << ">>> RecHit does not have an associated cluster!" << " file: " << __FILE__ << " line: " << __LINE__;
+	  returnValue.push_back(sRHit->omniClusterRef());
+	}
+	else if (tid == typeid(SiStripRecHit1D)) {
+	  //		      std::cout << "SiStripRecHit1D" << std::endl;
+	  const SiStripRecHit1D* sRHit = dynamic_cast<const SiStripRecHit1D*>(rhit);
+	  if (!sRHit->cluster().isNonnull())
+	    edm::LogError("TrackAssociator") << ">>> RecHit does not have an associated cluster!" << " file: " << __FILE__ << " line: " << __LINE__;
+	  returnValue.push_back(sRHit->omniClusterRef());
+	}
+	else {
+	  auto const & thit = static_cast<BaseTrackerRecHit const&>(*rhit);
+	  if ( thit.isProjected() ) {
+	  } else {
+	    //	    std::cout << "WHICH CLUSTER ?!?!" << std::endl;
+	    edm::LogError("TrackAssociator") << ">>> getMatchedClusters: TrackingRecHit not associated to any SiStripCluster! subdetid = " << subdetid;
+	  }
+	}
+      }
+      else {
+	//		    std::cout << "WHICH CLUSTER and WHICH DET ?!?!" << std::endl;
+	edm::LogError("TrackAssociator") << ">>> getMatchedClusters: TrackingRecHit not associated to any cluster! subdetid = " << subdetid;
+      }
+    }
+  }
+  return returnValue;
 }
 
 template<typename iter> std::vector< std::pair<QuickTrackAssociatorByHits::SimTrackIdentifiers,size_t> > QuickTrackAssociatorByHits::getAllSimTrackIdentifiers( const TrackerHitAssociator& hitAssociator, iter begin, iter end ) const

--- a/Validation/RecoTrack/plugins/MultiTrackValidator.cc
+++ b/Validation/RecoTrack/plugins/MultiTrackValidator.cc
@@ -179,7 +179,6 @@ void MultiTrackValidator::analyze(const edm::Event& event, const edm::EventSetup
 
   edm::Handle<TrackingParticleCollection>  TPCollectionHfake ;
   event.getByToken(label_tp_fake,TPCollectionHfake);
-  //  TrackingParticleCollection const & tPCfake = *(TPCollectionHfake.product());
 
   if(parametersDefiner=="CosmicParametersDefinerForTP") {
     edm::Handle<SimHitTPAssociationProducer::SimHitTPAssociationList> simHitsTPAssoc;

--- a/Validation/RecoTrack/plugins/MultiTrackValidator.cc
+++ b/Validation/RecoTrack/plugins/MultiTrackValidator.cc
@@ -179,8 +179,7 @@ void MultiTrackValidator::analyze(const edm::Event& event, const edm::EventSetup
 
   edm::Handle<TrackingParticleCollection>  TPCollectionHfake ;
   event.getByToken(label_tp_fake,TPCollectionHfake);
-  //  const TrackingParticleCollection tPCfake = *(TPCollectionHfake.product());
-  TrackingParticleCollection const & tPCfake = *(TPCollectionHfake.product());
+  //  TrackingParticleCollection const & tPCfake = *(TPCollectionHfake.product());
 
   if(parametersDefiner=="CosmicParametersDefinerForTP") {
     edm::Handle<SimHitTPAssociationProducer::SimHitTPAssociationList> simHitsTPAssoc;

--- a/Validation/RecoTrack/plugins/MultiTrackValidator.cc
+++ b/Validation/RecoTrack/plugins/MultiTrackValidator.cc
@@ -175,11 +175,12 @@ void MultiTrackValidator::analyze(const edm::Event& event, const edm::EventSetup
 
   edm::Handle<TrackingParticleCollection>  TPCollectionHeff ;
   event.getByToken(label_tp_effic,TPCollectionHeff);
-  const TrackingParticleCollection tPCeff = *(TPCollectionHeff.product());
+  TrackingParticleCollection const & tPCeff = *(TPCollectionHeff.product());
 
   edm::Handle<TrackingParticleCollection>  TPCollectionHfake ;
   event.getByToken(label_tp_fake,TPCollectionHfake);
-  const TrackingParticleCollection tPCfake = *(TPCollectionHfake.product());
+  //  const TrackingParticleCollection tPCfake = *(TPCollectionHfake.product());
+  TrackingParticleCollection const & tPCfake = *(TPCollectionHfake.product());
 
   if(parametersDefiner=="CosmicParametersDefinerForTP") {
     edm::Handle<SimHitTPAssociationProducer::SimHitTPAssociationList> simHitsTPAssoc;

--- a/Validation/RecoTrack/plugins/MultiTrackValidator.cc
+++ b/Validation/RecoTrack/plugins/MultiTrackValidator.cc
@@ -175,11 +175,11 @@ void MultiTrackValidator::analyze(const edm::Event& event, const edm::EventSetup
 
   edm::Handle<TrackingParticleCollection>  TPCollectionHeff ;
   event.getByToken(label_tp_effic,TPCollectionHeff);
-  TrackingParticleCollection const & tPCeff = *(TPCollectionHeff.product());
+  const TrackingParticleCollection tPCeff = *(TPCollectionHeff.product());
 
   edm::Handle<TrackingParticleCollection>  TPCollectionHfake ;
   event.getByToken(label_tp_fake,TPCollectionHfake);
-  const TrackingParticleCollection tPCeff = *(TPCollectionHeff.product());
+  const TrackingParticleCollection tPCfake = *(TPCollectionHfake.product());
 
   if(parametersDefiner=="CosmicParametersDefinerForTP") {
     edm::Handle<SimHitTPAssociationProducer::SimHitTPAssociationList> simHitsTPAssoc;

--- a/Validation/RecoTrack/plugins/MultiTrackValidator.cc
+++ b/Validation/RecoTrack/plugins/MultiTrackValidator.cc
@@ -175,10 +175,12 @@ void MultiTrackValidator::analyze(const edm::Event& event, const edm::EventSetup
   edm::Handle<TrackingParticleCollection>  TPCollectionHeff ;
   event.getByToken(label_tp_effic,TPCollectionHeff);
   const TrackingParticleCollection tPCeff = *(TPCollectionHeff.product());
+  //  std::cout << "[MultiTrackValidator::analyze tPCeff: " << tPCeff.size() << std::endl;
 
   edm::Handle<TrackingParticleCollection>  TPCollectionHfake ;
   event.getByToken(label_tp_fake,TPCollectionHfake);
   const TrackingParticleCollection tPCfake = *(TPCollectionHfake.product());
+  //  std::cout << "[MultiTrackValidator::analyze tPCfake: " << tPCfake.size() << std::endl;
 
   if(parametersDefiner=="CosmicParametersDefinerForTP") {
     edm::Handle<SimHitTPAssociationProducer::SimHitTPAssociationList> simHitsTPAssoc;
@@ -296,6 +298,7 @@ void MultiTrackValidator::analyze(const edm::Event& event, const edm::EventSetup
       int st(0);    	  //This counter counts the number of simulated tracks passing the MTV selection (i.e. tpSelector(tp) )
       unsigned sts(0);   //This counter counts the number of simTracks surviving the bunchcrossing cut
       unsigned asts(0);  //This counter counts the number of simTracks that are "associated" to recoTracks surviving the bunchcrossing cut
+      //      std::cout << "[MultiTrackValidator::analyze] tPCeff.size(): " << tPCeff.size() << std::endl;
       for (TrackingParticleCollection::size_type i=0; i<tPCeff.size(); i++){ //loop over TPs collection for tracking efficiency
 	TrackingParticleRef tpr(TPCollectionHeff, i);
 	TrackingParticle* tp=const_cast<TrackingParticle*>(tpr.get());
@@ -307,9 +310,12 @@ void MultiTrackValidator::analyze(const edm::Event& event, const edm::EventSetup
 
 	//---------- THIS PART HAS TO BE CLEANED UP. THE PARAMETER DEFINER WAS NOT MEANT TO BE USED IN THIS WAY ----------
 	//If the TrackingParticle is collison like, get the momentum and vertex at production state
-	if(parametersDefiner=="LhcParametersDefinerForTP")
+	if(parametersDefiner=="LhcParametersDefinerForTP" || parametersDefiner=="hltLhcParametersDefinerForTP")
 	  {
+	    //	    std::cout << "[MultiTrackValidator::analyze parametersDefiner == LhcParametersDefinerForTP !" << std::endl;
+	    //	    std::cout << "TP is selected ? " << std::endl;
 	    if(! tpSelector(*tp)) continue;
+	    //	    std::cout << "YES!!!!" << std::endl;
 	    momentumTP = tp->momentum();
 	    vertexTP = tp->vertex();
 	    //Calcualte the impact parameters w.r.t. PCA
@@ -339,6 +345,7 @@ void MultiTrackValidator::analyze(const edm::Event& event, const edm::EventSetup
 	// - dxySim
 	// - dzSim
 
+	//	std::cout << "MultiTrackValidator::analyze] filing simTracks w: " << w << std::endl;
 	histoProducerAlgo_->fill_generic_simTrack_histos(w,momentumTP,vertexTP, tp->eventId().bunchCrossing());
 
 
@@ -372,6 +379,7 @@ void MultiTrackValidator::analyze(const edm::Event& event, const edm::EventSetup
 
 
         int nSimHits = tp->numberOfTrackerHits();
+	//	std::cout << "filling fill_recoAssociated_simTrack_histos " << std::endl;
 	histoProducerAlgo_->fill_recoAssociated_simTrack_histos(w,*tp,momentumTP,vertexTP,dxySim,dzSim,nSimHits,matchedTrackPointer,puinfo.getPU_NumInteractions(), dR);
           sts++;
           if (matchedTrackPointer) asts++;

--- a/Validation/RecoTrack/python/HLTmultiTrackValidator_cff.py
+++ b/Validation/RecoTrack/python/HLTmultiTrackValidator_cff.py
@@ -1,115 +1,55 @@
 import FWCore.ParameterSet.Config as cms
 
-from SimTracker.TrackAssociation.LhcParametersDefinerForTP_cfi import *
-hltLhcParametersDefinerForTP = LhcParametersDefinerForTP.clone()
-hltLhcParametersDefinerForTP.ComponentName = cms.string('hltLhcParametersDefinerForTP')
-hltLhcParametersDefinerForTP.beamSpot      = cms.untracked.InputTag('hltOnlineBeamSpot')
+from Validation.RecoTrack.HLTmultiTrackValidator_cfi import *
+hltPixelTracksV = hltMultiTrackValidator.clone()
+hltPixelTracksV.label                           = cms.VInputTag(cms.InputTag("hltPixelTracks"))
+hltPixelTracksV.associatormap                   = cms.InputTag ( "tpToHLTpixelTrackAssociation" ) 
+hltPixelTracksV.trackCollectionForDrCalculation = cms.InputTag("hltPixelTracks") 
 
-from Validation.RecoTrack.MultiTrackValidator_cfi import *
-hltMultiTrackValidator = multiTrackValidator.clone()
-hltMultiTrackValidator.ignoremissingtkcollection = cms.bool(True)
-hltMultiTrackValidator.dirName = cms.string('HLT/Tracking/ValidationWRTtp/')
-hltMultiTrackValidator.label   = cms.VInputTag(
-    cms.InputTag("hltPixelTracks"),
-#    cms.InputTag("hltPFJetCtfWithMaterialTracks"),
-#    cms.InputTag("hltPFlowTrackSelectionHighPurity"), # it is not yet available :(
-#    cms.InputTag("hltIter1PFJetCtfWithMaterialTracks"),
-#    cms.InputTag("hltIter1PFlowTrackSelectionHighPurityLoose"),
-#    cms.InputTag("hltIter1PFlowTrackSelectionHighPurityTight"),
-#    cms.InputTag("hltIter1PFlowTrackSelectionHighPurity"),
-    cms.InputTag("hltIter1Merged"),
-#    cms.InputTag("hltIter2PFJetCtfWithMaterialTracks"),
-#    cms.InputTag("hltIter2PFlowTrackSelectionHighPurity"),
-    cms.InputTag("hltIter2Merged"),
-#    cms.InputTag("hltIter3PFJetCtfWithMaterialTracks"),
-#    cms.InputTag("hltIter3PFlowTrackSelectionHighPurityLoose"),
-#    cms.InputTag("hltIter3PFlowTrackSelectionHighPurityTight"),
-#    cms.InputTag("hltIter3PFlowTrackSelectionHighPurity"),
-    cms.InputTag("hltIter3Merged"),
-#    cms.InputTag("hltIter4PFJetCtfWithMaterialTracks"),
-#    cms.InputTag("hltIter4PFlowTrackSelectionHighPurity"),
-    cms.InputTag("hltIter4Merged"),
-)
-hltMultiTrackValidator.beamSpot = cms.InputTag("hltOnlineBeamSpot")
-hltMultiTrackValidator.ptMinTP  = cms.double( 0.4)
-hltMultiTrackValidator.lipTP    = cms.double(35.0)
-hltMultiTrackValidator.tipTP    = cms.double(70.0)
-hltMultiTrackValidator.histoProducerAlgoBlock.generalTpSelector.ptMin = cms.double( 0.4)
-hltMultiTrackValidator.histoProducerAlgoBlock.generalTpSelector.lip   = cms.double(35.0)
-hltMultiTrackValidator.histoProducerAlgoBlock.generalTpSelector.tip   = cms.double(70.0)
-hltMultiTrackValidator.histoProducerAlgoBlock.TpSelectorForEfficiencyVsEta  = hltMultiTrackValidator.histoProducerAlgoBlock.generalTpSelector.clone()
-hltMultiTrackValidator.histoProducerAlgoBlock.TpSelectorForEfficiencyVsPhi  = hltMultiTrackValidator.histoProducerAlgoBlock.generalTpSelector.clone()
-hltMultiTrackValidator.histoProducerAlgoBlock.TpSelectorForEfficiencyVsPt   = hltMultiTrackValidator.histoProducerAlgoBlock.generalTpSelector.clone()
-hltMultiTrackValidator.histoProducerAlgoBlock.TpSelectorForEfficiencyVsVTXR = hltMultiTrackValidator.histoProducerAlgoBlock.generalTpSelector.clone()
-hltMultiTrackValidator.histoProducerAlgoBlock.TpSelectorForEfficiencyVsVTXZ = hltMultiTrackValidator.histoProducerAlgoBlock.generalTpSelector.clone()
-hltMultiTrackValidator.parametersDefiner = cms.string('hltLhcParametersDefinerForTP')
+hltIter0V = hltMultiTrackValidator.clone()
+hltIter0V.label                           = cms.VInputTag( cms.InputTag("hltIter0PFlowTrackSelectionHighPurity") )
+hltIter0V.associatormap                   = cms.InputTag( "tpToHLTiter0HPtracksAssociation" )
+hltIter0V.trackCollectionForDrCalculation = cms.InputTag("hltIter0PFlowTrackSelectionHighPurity")
 
-from RecoTracker.DeDx.dedxHarmonic2_cfi import *
-hltDedxHarmonic2 = dedxHarmonic2.clone()
-hltDedxHarmonic2.tracks                     = cms.InputTag("hltIter4Merged")
-hltDedxHarmonic2.trajectoryTrackAssociation = cms.InputTag("hltIter4Merged")
+hltIter1V = hltMultiTrackValidator.clone()
+hltIter1V.label                           = cms.VInputTag( cms.InputTag("hltIter1PFlowTrackSelectionHighPurity") )
+hltIter1V.associatormap                   = cms.InputTag ( "tpToHLTiter1HPtracksAssociation" ) 
+hltIter1V.trackCollectionForDrCalculation = cms.InputTag("hltIter1PFlowTrackSelectionHighPurity")
 
-###
-### Principal::getByToken: Found zero products matching all criteria
-### Looking for type: edm::AssociationMap<edm::OneToOne<std::vector<Trajectory>,std::vector<reco::Track>,unsigned short> >
-### Looking for module label: hltIter4Merged
-#hltMultiTrackValidator.dEdx1Tag = cms.InputTag("hltDedxHarmonic2")
+hltIter1MergedV = hltMultiTrackValidator.clone()
+hltIter1MergedV.label                           = cms.VInputTag( cms.InputTag("hltIter1Merged") )
+hltIter1MergedV.associatormap                   = cms.InputTag ( "tpToHLTiter1MergedTracksAssociation" ) 
+hltIter1MergedV.trackCollectionForDrCalculation = cms.InputTag("hltIter1Merged")
 
-from RecoTracker.DeDx.dedxTruncated40_cfi import *
-hltDedxTruncated40 = dedxTruncated40.clone()
-hltDedxTruncated40.tracks                     = cms.InputTag("hltIter4Merged")
-hltDedxTruncated40.trajectoryTrackAssociation = cms.InputTag("hltIter4Merged")
+hltIter2V = hltMultiTrackValidator.clone()
+hltIter2V.label                           = cms.VInputTag( cms.InputTag("hltIter2PFlowTrackSelectionHighPurity") )
+hltIter2V.associatormap                   = cms.InputTag ( "tpToHLTiter2HPtracksAssociation" ) 
+hltIter2V.trackCollectionForDrCalculation = cms.InputTag("hltIter2PFlowTrackSelectionHighPurity")
 
-#hltMultiTrackValidator.dEdx2Tag = cms.InputTag("hltDedxTruncated40")
+hltIter2MergedV = hltMultiTrackValidator.clone()
+hltIter2MergedV.label                           = cms.VInputTag( cms.InputTag("hltIter2Merged") )
+hltIter2MergedV.associatormap                   = cms.InputTag ("tpToHLTiter2MergedTracksAssociation" )  
+hltIter2MergedV.trackCollectionForDrCalculation = cms.InputTag("hltIter2Merged")
 
-hltQuickTrackAssociatorByHits = cms.ESProducer("QuickTrackAssociatorByHitsESProducer",
-    Quality_SimToReco = cms.double(0.5),
-    cluster2TPSrc = cms.InputTag("hltTPClusterProducer"),
-    associatePixel = cms.bool(True),
-    useClusterTPAssociation = cms.bool(False),
-    Purity_SimToReco = cms.double(0.75),
-    ThreeHitTracksAreSpecial = cms.bool(True),
-    AbsoluteNumberOfHits = cms.bool(False),
-    associateStrip = cms.bool(True),
-    Cut_RecoToSim = cms.double(0.75),
-    SimToRecoDenominator = cms.string('sim'),
-    ComponentName = cms.string('hltQuickTrackAssociatorByHits')
-)
+hltIter3V = hltMultiTrackValidator.clone()
+hltIter3V.label                           = cms.VInputTag( cms.InputTag("hltIter3PFlowTrackSelectionHighPurity") )
+hltIter3V.associatormap                   = cms.InputTag( "tpToHLTiter3HPtracksAssociation" )
+hltIter3V.trackCollectionForDrCalculation = cms.InputTag("hltIter3PFlowTrackSelectionHighPurity")
 
-hltTrackingParticleRecoTrackAsssociation = cms.EDProducer("TrackAssociatorEDProducer",
-    label_tr = cms.InputTag("hltIter4Merged"),
-    associator = cms.string('hltQuickTrackAssociatorByHits'),
-    label_tp = cms.InputTag("mix","MergedTrackTruth"),
-    ignoremissingtrackcollection = cms.untracked.bool(True)
-)
+hltIter3MergedV = hltMultiTrackValidator.clone()
+hltIter3MergedV.label                           = cms.VInputTag( cms.InputTag("hltIter3Merged") )
+hltIter3MergedV.associatormap                   = cms.InputTag ( "tpToHLTiter3MergedTracksAssociation" ) 
+hltIter3MergedV.trackCollectionForDrCalculation = cms.InputTag("hltIter3Merged")
 
-hltMultiTrackValidator.associatormap = cms.InputTag("hltTrackingParticleRecoTrackAsssociation")
-hltMultiTrackValidator.ignoremissingtrackcollection = cms.untracked.bool(True)
+hltIter4V = hltMultiTrackValidator.clone()
+hltIter4V.label                           = cms.VInputTag( cms.InputTag("hltIter4PFlowTrackSelectionHighPurity") )
+hltIter4V.associatormap                   = cms.InputTag( "tpToHLTiter4HPtracksAssociation" )
+hltIter4V.trackCollectionForDrCalculation = cms.InputTag("hltIter4PFlowTrackSelectionHighPurity")
 
-hltTPClusterProducer = cms.EDProducer("ClusterTPAssociationProducer",
-    stripSimLinkSrc = cms.InputTag("simSiStripDigis"),
-    verbose = cms.bool(False),
-    pixelClusterSrc = cms.InputTag("hltSiPixelClusters"),
-    pixelSimLinkSrc = cms.InputTag("simSiPixelDigis"),
-    trackingParticleSrc = cms.InputTag("mix","MergedTrackTruth"),
-#    stripClusterSrc = cms.InputTag("hltSiStripClusters"),
-    stripClusterSrc = cms.InputTag("hltSiStripRawToClustersFacility"),                                      
-    simTrackSrc = cms.InputTag("g4SimHits")
-)
-hltTrackAssociatorByHitsRecoDenom = cms.ESProducer("QuickTrackAssociatorByHitsESProducer",
-    Quality_SimToReco = cms.double(0.5),
-    associatePixel = cms.bool(True),
-    useClusterTPAssociation = cms.bool(True),
-    Purity_SimToReco = cms.double(0.75),
-    Cut_RecoToSim = cms.double(0.75),
-    ThreeHitTracksAreSpecial = cms.bool(True),
-    AbsoluteNumberOfHits = cms.bool(False),
-    associateStrip = cms.bool(True),
-    ComponentName = cms.string('hltTrackAssociatorByHitsRecoDenom'),
-    SimToRecoDenominator = cms.string('reco'),
-    cluster2TPSrc = cms.InputTag("hltTPClusterProducer")
-)
-hltMultiTrackValidator.associators = cms.vstring('hltTrackAssociatorByHitsRecoDenom')
+hltIter4MergedV = hltMultiTrackValidator.clone()
+hltIter4MergedV.label                           = cms.VInputTag( cms.InputTag("hltIter4Merged") )
+hltIter4MergedV.associatormap                   = cms.InputTag ( "tpToHLTiter4MergedTracksAssociation" ) 
+hltIter4MergedV.trackCollectionForDrCalculation = cms.InputTag("hltIter4Merged")
 
 from Validation.RecoTrack.cutsTPEffic_cfi import *
 from Validation.RecoTrack.cutsTPFake_cfi import *
@@ -117,13 +57,21 @@ from Validation.RecoTrack.cutsTPFake_cfi import *
 from SimGeneral.TrackingAnalysis.simHitTPAssociation_cfi import *
 
 hltMultiTrackValidation = cms.Sequence(
-#    hltDedxHarmonic2
-#    + hltDedxTruncated40
     simHitTPAssocProducer
     + hltTPClusterProducer
-    + hltTrackingParticleRecoTrackAsssociation
+    + tpToHLTtracksAssociationSequence
     + cutsTPEffic
     + cutsTPFake
-    + hltMultiTrackValidator
+#    + hltMultiTrackValidator
+    + hltPixelTracksV
+    + hltIter0V
+    + hltIter1V
+    + hltIter1MergedV
+    + hltIter2V
+    + hltIter2MergedV
+    + hltIter3V
+    + hltIter3MergedV
+    + hltIter4V
+    + hltIter4MergedV
 )    
 

--- a/Validation/RecoTrack/python/HLTmultiTrackValidator_cfi.py
+++ b/Validation/RecoTrack/python/HLTmultiTrackValidator_cfi.py
@@ -1,0 +1,34 @@
+import FWCore.ParameterSet.Config as cms
+
+from SimTracker.TrackAssociation.LhcParametersDefinerForTP_cfi import *
+hltLhcParametersDefinerForTP = LhcParametersDefinerForTP.clone()
+hltLhcParametersDefinerForTP.ComponentName = cms.string('hltLhcParametersDefinerForTP')
+hltLhcParametersDefinerForTP.beamSpot      = cms.untracked.InputTag('hltOnlineBeamSpot')
+
+from Validation.RecoTrack.associators_cff import *
+
+from Validation.RecoTrack.MultiTrackValidator_cfi import *
+hltMultiTrackValidator = multiTrackValidator.clone()
+hltMultiTrackValidator.ignoremissingtkcollection = cms.bool(True)
+hltMultiTrackValidator.dirName = cms.string('HLT/Tracking/ValidationWRTtp/')
+hltMultiTrackValidator.label   = cms.VInputTag(cms.InputTag("hltPixelTracks"))
+hltMultiTrackValidator.beamSpot = cms.InputTag("hltOnlineBeamSpot")
+hltMultiTrackValidator.ptMinTP  = cms.double( 0.4)
+hltMultiTrackValidator.lipTP    = cms.double(35.0)
+hltMultiTrackValidator.tipTP    = cms.double(70.0)
+hltMultiTrackValidator.histoProducerAlgoBlock.generalTpSelector.ptMin = cms.double( 0.4)
+hltMultiTrackValidator.histoProducerAlgoBlock.generalTpSelector.lip   = cms.double(35.0)
+hltMultiTrackValidator.histoProducerAlgoBlock.generalTpSelector.tip   = cms.double(70.0)
+hltMultiTrackValidator.histoProducerAlgoBlock.TpSelectorForEfficiencyVsEta  = hltMultiTrackValidator.histoProducerAlgoBlock.generalTpSelector.clone()
+hltMultiTrackValidator.histoProducerAlgoBlock.TpSelectorForEfficiencyVsPhi  = hltMultiTrackValidator.histoProducerAlgoBlock.generalTpSelector.clone()
+hltMultiTrackValidator.histoProducerAlgoBlock.TpSelectorForEfficiencyVsPt   = hltMultiTrackValidator.histoProducerAlgoBlock.generalTpSelector.clone()
+hltMultiTrackValidator.histoProducerAlgoBlock.TpSelectorForEfficiencyVsVTXR = hltMultiTrackValidator.histoProducerAlgoBlock.generalTpSelector.clone()
+hltMultiTrackValidator.histoProducerAlgoBlock.TpSelectorForEfficiencyVsVTXZ = hltMultiTrackValidator.histoProducerAlgoBlock.generalTpSelector.clone()
+hltMultiTrackValidator.parametersDefiner = cms.string('hltLhcParametersDefinerForTP')
+#hltMultiTrackValidator.parametersDefiner = cms.string('LhcParametersDefinerForTP')
+### for fake rate vs dR ###
+hltMultiTrackValidator.trackCollectionForDrCalculation = cms.InputTag("hltPixelTracks")
+hltMultiTrackValidator.associatormap = cms.InputTag("tpToHLTpixelTrackAssociation")
+hltMultiTrackValidator.ignoremissingtrackcollection = cms.untracked.bool(True)
+
+hltMultiTrackValidator.associators = cms.vstring('hltTrackAssociatorByHits')

--- a/Validation/RecoTrack/python/associators_cff.py
+++ b/Validation/RecoTrack/python/associators_cff.py
@@ -1,0 +1,156 @@
+import FWCore.ParameterSet.Config as cms
+
+#### TrackAssociation
+from SimTracker.TrackAssociation.TrackAssociatorByChi2_cfi import *
+import SimTracker.TrackAssociation.quickTrackAssociatorByHits_cfi
+import SimTracker.TrackAssociation.TrackAssociatorByPosition_cfi
+
+hltTPClusterProducer = cms.EDProducer("ClusterTPAssociationProducer",
+    stripSimLinkSrc = cms.InputTag("simSiStripDigis"),
+    verbose = cms.bool(False),
+    pixelClusterSrc = cms.InputTag("hltSiPixelClusters"),
+    pixelSimLinkSrc = cms.InputTag("simSiPixelDigis"),
+    trackingParticleSrc = cms.InputTag("mix","MergedTrackTruth"),
+#    stripClusterSrc = cms.InputTag("hltSiStripClusters"),
+    stripClusterSrc = cms.InputTag("hltSiStripRawToClustersFacility"),                                      
+    simTrackSrc = cms.InputTag("g4SimHits")
+)
+
+hltTrackAssociatorByHits = SimTracker.TrackAssociation.quickTrackAssociatorByHits_cfi.quickTrackAssociatorByHits.clone()
+hltTrackAssociatorByHits.ComponentName            = 'hltTrackAssociatorByHits'
+hltTrackAssociatorByHits.cluster2TPSrc            = cms.InputTag("hltTPClusterProducer")
+hltTrackAssociatorByHits.UseGrouped               = cms.bool( False )
+hltTrackAssociatorByHits.UseSplitting             = cms.bool( False )
+hltTrackAssociatorByHits.ThreeHitTracksAreSpecial = cms.bool( False )
+
+hltTrackAssociatorByDeltaR = SimTracker.TrackAssociation.TrackAssociatorByPosition_cfi.TrackAssociatorByPosition.clone()
+hltTrackAssociatorByDeltaR.ComponentName      = 'hltTrackAssociatorByDeltaR'
+hltTrackAssociatorByDeltaR.method             = cms.string('momdr')
+hltTrackAssociatorByDeltaR.QCut               = cms.double(0.5)
+hltTrackAssociatorByDeltaR.ConsiderAllSimHits = cms.bool(True)
+
+
+tpToHLTpixelTrackAssociation = cms.EDProducer("TrackAssociatorEDProducer",
+    label_tr = cms.InputTag("hltPixelTracks"),
+    label_tp = cms.InputTag("mix","MergedTrackTruth"),
+    associator = cms.string('hltTrackAssociatorByHits'),
+    ignoremissingtrackcollection = cms.untracked.bool(True)
+)
+
+tpToHLTiter0tracksAssociation = cms.EDProducer("TrackAssociatorEDProducer",
+    label_tr = cms.InputTag("hltIter0PFlowCtfWithMaterialTracks"),
+    label_tp = cms.InputTag("mix","MergedTrackTruth"),
+#    associator = cms.string('hltTrackAssociatorByHits'),
+    associator = cms.string('hltTrackAssociatorByDeltaR'),
+    ignoremissingtrackcollection = cms.untracked.bool(True)
+)
+
+tpToHLTiter0HPtracksAssociation = cms.EDProducer("TrackAssociatorEDProducer",
+    label_tr = cms.InputTag("hltIter0PFlowTrackSelectionHighPurity"),
+    label_tp = cms.InputTag("mix","MergedTrackTruth"),
+#    associator = cms.string('hltTrackAssociatorByHits'),
+    associator = cms.string('hltTrackAssociatorByDeltaR'),
+    ignoremissingtrackcollection = cms.untracked.bool(True)
+)
+
+tpToHLTiter1tracksAssociation = cms.EDProducer("TrackAssociatorEDProducer",
+    label_tr = cms.InputTag("hltIter1PFlowCtfWithMaterialTracks"),
+    label_tp = cms.InputTag("mix","MergedTrackTruth"),
+    associator = cms.string('hltTrackAssociatorByHits'),
+    ignoremissingtrackcollection = cms.untracked.bool(True)
+)
+
+tpToHLTiter1HPtracksAssociation = cms.EDProducer("TrackAssociatorEDProducer",
+    label_tr = cms.InputTag("hltIter1PFlowTrackSelectionHighPurity"),
+    label_tp = cms.InputTag("mix","MergedTrackTruth"),
+    associator = cms.string('hltTrackAssociatorByHits'),
+    ignoremissingtrackcollection = cms.untracked.bool(True)
+)
+
+tpToHLTiter1MergedTracksAssociation = cms.EDProducer("TrackAssociatorEDProducer",
+    label_tr = cms.InputTag("hltIter1Merged"),
+    label_tp = cms.InputTag("mix","MergedTrackTruth"),
+    associator = cms.string('hltTrackAssociatorByHits'),
+    ignoremissingtrackcollection = cms.untracked.bool(True)
+)
+
+tpToHLTiter2tracksAssociation = cms.EDProducer("TrackAssociatorEDProducer",
+    label_tr = cms.InputTag("hltIter2PFlowCtfWithMaterialTracks"),
+    label_tp = cms.InputTag("mix","MergedTrackTruth"),
+    associator = cms.string('hltTrackAssociatorByHits'),
+    ignoremissingtrackcollection = cms.untracked.bool(True)
+)
+
+tpToHLTiter2HPtracksAssociation = cms.EDProducer("TrackAssociatorEDProducer",
+    label_tr = cms.InputTag("hltIter2PFlowTrackSelectionHighPurity"),
+    label_tp = cms.InputTag("mix","MergedTrackTruth"),
+    associator = cms.string('hltTrackAssociatorByHits'),
+    ignoremissingtrackcollection = cms.untracked.bool(True)
+)
+
+tpToHLTiter2MergedTracksAssociation = cms.EDProducer("TrackAssociatorEDProducer",
+    label_tr = cms.InputTag("hltIter2Merged"),
+    label_tp = cms.InputTag("mix","MergedTrackTruth"),
+    associator = cms.string('hltTrackAssociatorByHits'),
+    ignoremissingtrackcollection = cms.untracked.bool(True)
+)
+
+tpToHLTiter3tracksAssociation = cms.EDProducer("TrackAssociatorEDProducer",
+    label_tr = cms.InputTag("hltIter3PFlowCtfWithMaterialTracks"),
+    label_tp = cms.InputTag("mix","MergedTrackTruth"),
+    associator = cms.string('hltTrackAssociatorByHits'),
+    ignoremissingtrackcollection = cms.untracked.bool(True)
+)
+
+tpToHLTiter3HPtracksAssociation = cms.EDProducer("TrackAssociatorEDProducer",
+    label_tr = cms.InputTag("hltIter3PFlowTrackSelectionHighPurity"),
+    label_tp = cms.InputTag("mix","MergedTrackTruth"),
+    associator = cms.string('hltTrackAssociatorByHits'),
+    ignoremissingtrackcollection = cms.untracked.bool(True)
+)
+
+tpToHLTiter3MergedTracksAssociation = cms.EDProducer("TrackAssociatorEDProducer",
+    label_tr = cms.InputTag("hltIter3Merged"),
+    label_tp = cms.InputTag("mix","MergedTrackTruth"),
+    associator = cms.string('hltTrackAssociatorByHits'),
+    ignoremissingtrackcollection = cms.untracked.bool(True)
+)
+
+tpToHLTiter4tracksAssociation = cms.EDProducer("TrackAssociatorEDProducer",
+    label_tr = cms.InputTag("hltIter4PFlowCtfWithMaterialTracks"),
+    label_tp = cms.InputTag("mix","MergedTrackTruth"),
+    associator = cms.string('hltTrackAssociatorByHits'),
+    ignoremissingtrackcollection = cms.untracked.bool(True)
+)
+
+tpToHLTiter4HPtracksAssociation = cms.EDProducer("TrackAssociatorEDProducer",
+    label_tr = cms.InputTag("hltIter4PFlowTrackSelectionHighPurity"),
+    label_tp = cms.InputTag("mix","MergedTrackTruth"),
+    associator = cms.string('hltTrackAssociatorByHits'),
+    ignoremissingtrackcollection = cms.untracked.bool(True)
+)
+
+tpToHLTiter4MergedTracksAssociation = cms.EDProducer("TrackAssociatorEDProducer",
+    label_tr = cms.InputTag("hltIter4Merged"),
+    label_tp = cms.InputTag("mix","MergedTrackTruth"),
+    associator = cms.string('hltTrackAssociatorByHits'),
+    ignoremissingtrackcollection = cms.untracked.bool(True)
+)
+
+tpToHLTtracksAssociationSequence = cms.Sequence(
+    tpToHLTpixelTrackAssociation +
+#    tpToHLTiter0tracksAssociation +
+    tpToHLTiter0HPtracksAssociation +
+#    tpToHLTiter1tracksAssociation +
+    tpToHLTiter1HPtracksAssociation +
+    tpToHLTiter1MergedTracksAssociation +
+#    tpToHLTiter2tracksAssociation +
+    tpToHLTiter2HPtracksAssociation +
+    tpToHLTiter2MergedTracksAssociation +
+#    tpToHLTiter3tracksAssociation +
+    tpToHLTiter3HPtracksAssociation +
+    tpToHLTiter3MergedTracksAssociation +
+#    tpToHLTiter4tracksAssociation +
+    tpToHLTiter4HPtracksAssociation +
+    tpToHLTiter4MergedTracksAssociation
+)


### PR DESCRIPTION
fix to the WARNING message pointed out in 
https://github.com/cms-sw/cmssw/pull/3011
it was due to a missing case among the different flavour of SiStrip RecHits !

moreover, 
- I added the hltLhcParametersDefinerForTP in MultiTrackValidator
- I re-organized the HLT tracking validation sequence, fixing the association between the different track collections and the TP
