### PR TITLE
Modernized the code for GoodSeedProducer

### DIFF
--- a/RecoParticleFlow/PFTracking/plugins/GoodSeedProducer.h
+++ b/RecoParticleFlow/PFTracking/plugins/GoodSeedProducer.h
@@ -53,12 +53,10 @@ class GoodSeedProducer : public edm::EDProducer {
   typedef TrajectoryStateOnSurface TSOS;
    public:
       explicit GoodSeedProducer(const edm::ParameterSet&);
-      ~GoodSeedProducer();
   
    private:
       virtual void beginRun(const edm::Run & run,const edm::EventSetup&) override;
       virtual void produce(edm::Event&, const edm::EventSetup&) override;
-      virtual void endRun(const edm::Run & run,const edm::EventSetup&) override;
  
       ///Find the bin in pt and eta
       int getBin(float,float);
@@ -67,10 +65,6 @@ class GoodSeedProducer : public edm::EDProducer {
 				 const edm::OrphanHandle<reco::PreIdCollection>&,
 				 edm::ValueMap<reco::PreIdRef>::Filler & filler);
       // ----------member data ---------------------------
-
-      ///Vector of clusters of the PreShower
-      std::vector<reco::PFCluster const *> ps1Clus;
-      std::vector<reco::PFCluster const *> ps2Clus;
 
       ///Name of the Seed(Ckf) Collection
       std::string preidckf_;
@@ -91,7 +85,7 @@ class GoodSeedProducer : public edm::EDProducer {
       TkClonerImpl hitCloner;
 
       ///PFTrackTransformer
-      PFTrackTransformer *pfTransformer_;
+      std::unique_ptr<PFTrackTransformer> pfTransformer_;
 
       ///Number of hits in the seed;
       int nHitsInSeed_;
@@ -143,15 +137,15 @@ class GoodSeedProducer : public edm::EDProducer {
       std::string smootherName_;
       std::string propagatorName_;
 
-      PFResolutionMap* resMapEtaECAL_;
-      PFResolutionMap* resMapPhiECAL_;
+      std::unique_ptr<PFResolutionMap> resMapEtaECAL_;
+      std::unique_ptr<PFResolutionMap> resMapPhiECAL_;
 
       ///TRACK QUALITY
       bool useQuality_;
       reco::TrackBase::TrackQuality trackQuality_;
 	
       ///READER FOR TMVA
-      TMVA::Reader *reader[9]{};
+      std::array<std::unique_ptr<TMVA::Reader>,9> reader{};
 
       ///VARIABLES NEEDED FOR TMVA
       float eP,eta,pt,nhit,dpt,chired,chiRatio;

--- a/RecoParticleFlow/PFTracking/plugins/modules.cc
+++ b/RecoParticleFlow/PFTracking/plugins/modules.cc
@@ -1,5 +1,4 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "RecoParticleFlow/PFTracking/interface/GoodSeedProducer.h"
 #include "RecoParticleFlow/PFTracking/interface/PFElecTkProducer.h"
 #include "RecoParticleFlow/PFTracking/interface/LightPFTrackProducer.h"
 #include "RecoParticleFlow/PFTracking/interface/PFNuclearProducer.h"
@@ -13,7 +12,6 @@
 #include "RecoParticleFlow/PFTracking/plugins/PFDisplacedVertexSelector.cc"
 #include "RecoParticleFlow/PFTracking/plugins/SimVertexSelector.cc"
 
-DEFINE_FWK_MODULE(GoodSeedProducer);
 DEFINE_FWK_MODULE(PFElecTkProducer);
 DEFINE_FWK_MODULE(LightPFTrackProducer);
 DEFINE_FWK_MODULE(PFNuclearProducer);


### PR DESCRIPTION
The reader arguments were being leaked if more than one Run is processed
in the job. Switching all pointer ownership to std::unique_ptr simplified
all memory handling in the class.
Removed to unused member variables: ps1Clus, ps2Clus.
Moved header into plugin directory.
Declare plugin directly in .cc file.
NOTE: The .h and .cc file can now be merged into 1 file, but I didn't
do this to avoid making code diffs more difficult.
