### PR TITLE
Add Shashlik to METAlgorithm for Phase2

### DIFF
--- a/RecoMET/METAlgorithms/interface/SignAlgoResolutions.h
+++ b/RecoMET/METAlgorithms/interface/SignAlgoResolutions.h
@@ -38,7 +38,7 @@
 
 namespace metsig {
 
-  enum resolutionType { caloEE, caloEB, caloHE, caloHO, caloHF, caloHB, jet, electron, tau, muon,PFtype1,PFtype2, PFtype3, PFtype4, PFtype5, PFtype6, PFtype7 };
+  enum resolutionType { caloEE, caloEB, caloHE, caloHO, caloHF, caloHB, jet, electron, tau, muon,PFtype1,PFtype2, PFtype3, PFtype4, PFtype5, PFtype6, PFtype7, caloEK};
   enum resolutionFunc { ET, PHI,TRACKP,CONSTPHI };
 
   class SignAlgoResolutions{

--- a/RecoMET/METAlgorithms/src/SignCaloSpecificAlgo.cc
+++ b/RecoMET/METAlgorithms/src/SignCaloSpecificAlgo.cc
@@ -130,6 +130,12 @@ SignCaloSpecificAlgo::makeVectorOutOfCaloTowers(edm::Handle<edm::View<reco::Cand
 		  sign_tower_sigma_phi = resolutions.eval(metsig::caloEE,metsig::PHI,sign_tower_et,calotower->phi(),calotower->eta());
 		    
 		}
+		else if(subdet == EcalShashlik ){
+		  sign_tower_type = "emcalotower";
+		  sign_tower_et = calotower->emEt();
+		  sign_tower_sigma_et = resolutions.eval(metsig::caloEK,metsig::ET,sign_tower_et,calotower->phi(),calotower->eta());
+		  sign_tower_sigma_phi = resolutions.eval(metsig::caloEK,metsig::PHI,sign_tower_et,calotower->phi(),calotower->eta());
+		}
 		else{
 		  edm::LogWarning("SignCaloSpecificAlgo") << " ECAL tower cell not assigned to an ECAL subdetector!!!" << std::endl;
 		}


### PR DESCRIPTION
For Phase2 SHCAL, the reco step will have the following warning:
%MSG-w SignCaloSpecificAlgo:  METProducer:metNoHF 30-Jul-2014 14:46:45 CDT  Run: 1 Event: 1665
 ECAL tower cell not assigned to an ECAL subdetector!!!
%MSG

This is a quick fix, which will simply suppress the above warning.
However, it won't provide a correct MET significance calculation
as we don't have the resolution per Shashlik tower.
