### PR TITLE
fix geometry for PAT

### DIFF
--- a/Geometry/CommonDetUnit/python/globalTrackingGeometry_cfi.py
+++ b/Geometry/CommonDetUnit/python/globalTrackingGeometry_cfi.py
@@ -7,8 +7,6 @@ import FWCore.ParameterSet.Config as cms
 from Geometry.CSCGeometry.cscGeometry_cfi import *
 from Geometry.RPCGeometry.rpcGeometry_cfi import *
 from Geometry.DTGeometry.dtGeometry_cfi import *
-from Geometry.GEMGeometry.gemGeometry_cfi import *
-from Geometry.GEMGeometry.me0Geometry_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
 from Geometry.TrackerGeometryBuilder.trackerGeometry_cfi import *
 from Geometry.CommonDetUnit.bareGlobalTrackingGeometry_cfi import *


### PR DESCRIPTION
It affects PAT. the gem and me0 geometry should have been removed as well.
These two files were deleted already a way ago. 
