### PR TITLE
addition of soft electron mva, after fixing #4565 merge conflicts

### DIFF
--- a/Configuration/Skimming/src/LeptonRecoSkim.cc
+++ b/Configuration/Skimming/src/LeptonRecoSkim.cc
@@ -115,7 +115,7 @@ LeptonRecoSkim::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
 	if(elpt>ptElecMin)  {
 	  NtotalElectrons++;
 	  nElecPassingCut++;
-	  if(electron.mva()>-0.1) NmvaElectrons++;
+	  if(electron.mva_e_pi()>-0.1) NmvaElectrons++;
 	}
 	LogDebug("LeptonRecoSkim") << "elpt = " << elpt << endl;
 	// } // closes if (electron.ecalDrivenSeed()) {

--- a/DQMOffline/EGamma/plugins/ElectronAnalyzer.cc
+++ b/DQMOffline/EGamma/plugins/ElectronAnalyzer.cc
@@ -469,7 +469,7 @@ void ElectronAnalyzer::analyze( const edm::Event& iEvent, const edm::EventSetup 
 
 
     // pflow
-    h1_mva->Fill(gsfIter->mva()) ;
+    h1_mva->Fill(gsfIter->mva_e_pi()) ;
     if (gsfIter->ecalDrivenSeed()) h1_provenance->Fill(1.) ;
     if (gsfIter->trackerDrivenSeed()) h1_provenance->Fill(-1.) ;
     if (gsfIter->trackerDrivenSeed()||gsfIter->ecalDrivenSeed()) h1_provenance->Fill(0.);

--- a/DQMOffline/EGamma/plugins/ElectronTagProbeAnalyzer.cc
+++ b/DQMOffline/EGamma/plugins/ElectronTagProbeAnalyzer.cc
@@ -439,7 +439,7 @@ void ElectronTagProbeAnalyzer::analyze( const edm::Event& iEvent, const edm::Eve
         h1_classes->Fill(eleClass);
 
         // pflow
-        h1_mva->Fill(bestGsfElectron.mva()) ;
+        h1_mva->Fill(bestGsfElectron.mva_e_pi()) ;
         if (bestGsfElectron.ecalDrivenSeed()) h1_provenance->Fill(1.) ;
         if (bestGsfElectron.trackerDrivenSeed()) h1_provenance->Fill(-1.) ;
         if (bestGsfElectron.trackerDrivenSeed()||bestGsfElectron.ecalDrivenSeed()) h1_provenance->Fill(0.);

--- a/DataFormats/EgammaCandidates/interface/GsfElectron.h
+++ b/DataFormats/EgammaCandidates/interface/GsfElectron.h
@@ -589,10 +589,11 @@ class GsfElectron : public RecoCandidate
     struct MvaOutput
      {
       int status ; // see PFCandidateElectronExtra::StatusFlag
-      float mva ;
+      float mva_Isolated ;
+      float mva_e_pi ;
       float mvaByPassForIsolated ; // complementary MVA used in preselection
       MvaOutput()
-       : status(-1), mva(-999999999.), mvaByPassForIsolated(-999999999.)
+       : status(-1), mva_Isolated(-999999999.),mva_e_pi(-999999999.), mvaByPassForIsolated(-999999999.)
        {}
      } ;
 
@@ -609,7 +610,8 @@ class GsfElectron : public RecoCandidate
     void setMvaOutput( const MvaOutput & mo ) { mvaOutput_ = mo ; }
 
     // for backward compatibility
-    float mva() const { return mvaOutput_.mva ; }
+    float mva_Isolated() const { return mvaOutput_.mva_Isolated ; }
+    float mva_e_pi() const { return mvaOutput_.mva_e_pi ; }
 
   private:
 

--- a/DataFormats/EgammaCandidates/src/classes_def.xml
+++ b/DataFormats/EgammaCandidates/src/classes_def.xml
@@ -193,7 +193,8 @@
    <version ClassVersion="11" checksum="2106253688"/>
    <version ClassVersion="10" checksum="2786166332"/>
   </class>
-  <class name="reco::GsfElectron::MvaOutput" ClassVersion="12">
+  <class name="reco::GsfElectron::MvaOutput" ClassVersion="13">
+   <version ClassVersion="13" checksum="632217271"/>
    <version ClassVersion="12" checksum="3102257169"/>
    <version ClassVersion="11" checksum="1838996036"/>
    <version ClassVersion="10" checksum="2145829729"/>

--- a/DataFormats/EgammaCandidates/src/classes_def.xml
+++ b/DataFormats/EgammaCandidates/src/classes_def.xml
@@ -199,6 +199,10 @@
    <version ClassVersion="11" checksum="1838996036"/>
    <version ClassVersion="10" checksum="2145829729"/>
   </class>
+  <ioread sourceClass="reco::GsfElectron::MvaOutput" version="[1-12]" targetClass="reco::GsfElectron::MvaOutput" source="float mva;" target="mva_e_pi">
+    <![CDATA[mva_e_pi = onfile.mva;]]>
+  </ioread>
+
   <class name="reco::GsfElectron::ClassificationVariables" ClassVersion="11">
    <version ClassVersion="11" checksum="2094185381"/>
   </class>

--- a/DataFormats/ParticleFlowCandidate/interface/PFCandidate.h
+++ b/DataFormats/ParticleFlowCandidate/interface/PFCandidate.h
@@ -287,12 +287,13 @@ namespace reco {
     ///   to 1 otherwise
     /// For neutral particles, it is set to the default value
 
+    void set_mva_Isolated( float mvaI ){ mva_Isolated_=mvaI;}
+    // mva for isolated electrons
+    float mva_Isolated() const { return mva_Isolated_;}
 
-    void set_mva_e_pi( float mva ){ mva_e_pi_=mva;}
-    
+    void set_mva_e_pi( float mvaNI ){ mva_e_pi_=mvaNI;}
     /// mva for electron-pion discrimination
     float mva_e_pi() const { return mva_e_pi_;}
-
     
     /// set mva for electron-muon discrimination
     void set_mva_e_mu( float mva ) { mva_e_mu_=mva;}
@@ -453,6 +454,9 @@ namespace reco {
     float      deltaP_;
 
     PFVertexType vertexType_;
+
+    // mva for isolated electrons
+    float       mva_Isolated_;
 
     /// mva for electron-pion discrimination
     float       mva_e_pi_;

--- a/DataFormats/ParticleFlowCandidate/src/PFCandidate.cc
+++ b/DataFormats/ParticleFlowCandidate/src/PFCandidate.cc
@@ -41,6 +41,7 @@ PFCandidate::PFCandidate() :
   flags_(0), 
   deltaP_(0.), 
   vertexType_(kCandVertex),
+  mva_Isolated_(bigMva_),
   mva_e_pi_(bigMva_),
   mva_e_mu_(bigMva_),
   mva_pi_mu_(bigMva_),
@@ -81,6 +82,7 @@ PFCandidate::PFCandidate( Charge charge,
   flags_(0),
   deltaP_(0.),
   vertexType_(kCandVertex),
+  mva_Isolated_(bigMva_),
   mva_e_pi_(bigMva_),
   mva_e_mu_(bigMva_),
   mva_pi_mu_(bigMva_),
@@ -139,6 +141,7 @@ PFCandidate::PFCandidate( PFCandidate const& iOther) :
   flags_(iOther.flags_), 
   deltaP_(iOther.deltaP_), 
   vertexType_(iOther.vertexType_),
+  mva_Isolated_(iOther.mva_Isolated_),
   mva_e_pi_(iOther.mva_e_pi_),
   mva_e_mu_(iOther.mva_e_mu_),
   mva_pi_mu_(iOther.mva_pi_mu_),
@@ -180,6 +183,7 @@ PFCandidate& PFCandidate::operator=(PFCandidate const& iOther) {
   flags_=iOther.flags_; 
   deltaP_=iOther.deltaP_; 
   vertexType_=iOther.vertexType_;
+  mva_Isolated_=iOther.mva_Isolated_;
   mva_e_pi_=iOther.mva_e_pi_;
   mva_e_mu_=iOther.mva_e_mu_;
   mva_pi_mu_=iOther.mva_pi_mu_;

--- a/DataFormats/ParticleFlowCandidate/src/classes_def.xml
+++ b/DataFormats/ParticleFlowCandidate/src/classes_def.xml
@@ -1,10 +1,11 @@
 <lcgdict>
 
-   <class name="reco::PFCandidate" ClassVersion="13">
+   <class name="reco::PFCandidate" ClassVersion="14">
     <version ClassVersion="10" checksum="536762407"/>
     <version ClassVersion="11" checksum="2503588164"/>
     <version ClassVersion="12" checksum="2782366916"/>
     <version ClassVersion="13" checksum="3911979988"/>
+    <version ClassVersion="14" checksum="3379420193"/>
      <field name="elementsInBlocks_" transient="true"/>
      <field name="getter_" transient="true"/>
      <field name="refsCollectionCache_" transient="true"/>

--- a/PhysicsTools/SelectorUtils/interface/PFElectronSelector.h
+++ b/PhysicsTools/SelectorUtils/interface/PFElectronSelector.h
@@ -114,7 +114,7 @@ class PFElectronSelector : public Selector<pat::Electron> {
 
     ret.set(false);
 
-    double mva = electron.mva();
+    double mva = electron.mva_e_pi();
     double missingHits = electron.gsfTrack()->trackerExpectedHitsInner().numberOfHits() ;
     double corr_d0 = electron.dB();
 

--- a/RecoBTag/SoftLepton/plugins/SoftLepton.cc
+++ b/RecoBTag/SoftLepton/plugins/SoftLepton.cc
@@ -165,7 +165,7 @@ SoftLepton::produce(edm::Event & event, const edm::EventSetup & setup) {
       leptonId = SoftLeptonProperties::Quality::egammaElectronId;
       for (GsfElectronView::const_iterator electron = h_electrons->begin(); electron != h_electrons->end(); ++electron) {
         LeptonIds &id = leptons[reco::TrackBaseRef(electron->gsfTrack())];
-        id[SoftLeptonProperties::Quality::pfElectronId] = electron->mva();
+        id[SoftLeptonProperties::Quality::pfElectronId] = electron->mva_e_pi();
         if (haveLeptonCands)
           id[SoftLeptonProperties::Quality::btagElectronCands] = (*h_leptonCands)[h_electrons->refAt(electron - h_electrons->begin())];
       }

--- a/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h
@@ -48,7 +48,7 @@ class EcalClusterFunctionBaseClass ;
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgoRcd.h"
 
 #include "RecoEgamma/ElectronIdentification/interface/SoftElectronMVAEstimator.h"
-
+#include "RecoEgamma/ElectronIdentification/interface/ElectronMVAEstimator.h"
 
 #include <list>
 #include <string>
@@ -204,7 +204,8 @@ class GsfElectronAlgo {
       const EcalRecHitsConfiguration &,
       EcalClusterFunctionBaseClass * superClusterErrorFunction,
       EcalClusterFunctionBaseClass * crackCorrectionFunction,
-      const SoftElectronMVAEstimator::Configuration & mvaCfg,	
+      const SoftElectronMVAEstimator::Configuration & mva_NIso_Cfg,
+      const ElectronMVAEstimator::Configuration & mva_Iso_Cfg,	
       const RegressionHelper::Configuration & regCfg
       ) ;
 

--- a/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
@@ -70,7 +70,8 @@ struct GsfElectronAlgo::GeneralData
      const EcalRecHitsConfiguration &,
      EcalClusterFunctionBaseClass * superClusterErrorFunction,
      EcalClusterFunctionBaseClass * crackCorrectionFunction,
-     const SoftElectronMVAEstimator::Configuration & mvaCfg ,
+     const SoftElectronMVAEstimator::Configuration & mva_NIso_Cfg ,
+     const ElectronMVAEstimator::Configuration & mva_Iso_Cfg ,
      const RegressionHelper::Configuration &) ;
   ~GeneralData() ;
 
@@ -87,6 +88,7 @@ struct GsfElectronAlgo::GeneralData
   EcalClusterFunctionBaseClass * superClusterErrorFunction ;
   EcalClusterFunctionBaseClass * crackCorrectionFunction ;
   SoftElectronMVAEstimator *sElectronMVAEstimator;
+  ElectronMVAEstimator *iElectronMVAEstimator;
   const RegressionHelper::Configuration regCfg;
   RegressionHelper * regHelper;
  } ;
@@ -102,7 +104,9 @@ struct GsfElectronAlgo::GeneralData
    const EcalRecHitsConfiguration & recHitsConfig,
    EcalClusterFunctionBaseClass * superClusterErrorFunc,
    EcalClusterFunctionBaseClass * crackCorrectionFunc,
-   const SoftElectronMVAEstimator::Configuration & mvaConfig,
+   const SoftElectronMVAEstimator::Configuration & mva_NIso_Config,
+   const ElectronMVAEstimator::Configuration & mva_Iso_Config,
+
    const RegressionHelper::Configuration & regConfig
    )
  : inputCfg(inputConfig),
@@ -115,7 +119,8 @@ struct GsfElectronAlgo::GeneralData
    hcalHelperPflow(new ElectronHcalHelper(hcalConfigPflow)),
    superClusterErrorFunction(superClusterErrorFunc),
    crackCorrectionFunction(crackCorrectionFunc),
-   sElectronMVAEstimator(new SoftElectronMVAEstimator(mvaConfig)),
+   sElectronMVAEstimator(new SoftElectronMVAEstimator(mva_NIso_Config)),
+   iElectronMVAEstimator(new ElectronMVAEstimator(mva_Iso_Config)),
    regCfg(regConfig),
    regHelper(new RegressionHelper(regConfig))
   {}
@@ -125,6 +130,7 @@ GsfElectronAlgo::GeneralData::~GeneralData()
   delete hcalHelper ;
   delete hcalHelperPflow ;
   delete sElectronMVAEstimator;
+  delete iElectronMVAEstimator;
   delete regHelper;
  }
 
@@ -646,10 +652,11 @@ GsfElectronAlgo::GsfElectronAlgo
    const EcalRecHitsConfiguration & recHitsCfg,
    EcalClusterFunctionBaseClass * superClusterErrorFunction,
    EcalClusterFunctionBaseClass * crackCorrectionFunction,
-   const SoftElectronMVAEstimator::Configuration & mvaCfg,
+   const SoftElectronMVAEstimator::Configuration & mva_NIso_Cfg,
+   const ElectronMVAEstimator::Configuration & mva_Iso_Cfg,
    const RegressionHelper::Configuration & regCfg
  )
-   : generalData_(new GeneralData(inputCfg,strategyCfg,cutsCfg,cutsCfgPflow,hcalCfg,hcalCfgPflow,isoCfg,recHitsCfg,superClusterErrorFunction,crackCorrectionFunction,mvaCfg,regCfg)),
+   : generalData_(new GeneralData(inputCfg,strategyCfg,cutsCfg,cutsCfgPflow,hcalCfg,hcalCfgPflow,isoCfg,recHitsCfg,superClusterErrorFunction,crackCorrectionFunction,mva_NIso_Cfg,mva_Iso_Cfg,regCfg)),
    eventSetupData_(new EventSetupData),
    eventData_(0), electronData_(0)
  {}
@@ -984,7 +991,7 @@ void GsfElectronAlgo::addPflowInfo()
           else
            { (*el)->setP4(GsfElectron::P4_PFLOW_COMBINATION,pfElectron->p4(GsfElectron::P4_PFLOW_COMBINATION),pfElectron->p4Error(GsfElectron::P4_PFLOW_COMBINATION),true) ; }
           double noCutMin = -999999999. ;
-          if ((*el)->mva()<noCutMin) { throw cms::Exception("GsfElectronAlgo|UnexpectedMvaValue")<<"unexpected MVA value: "<<(*el)->mva() ; }
+          if ((*el)->mva_e_pi()<noCutMin) { throw cms::Exception("GsfElectronAlgo|UnexpectedMvaValue")<<"unexpected MVA value: "<<(*el)->mva_e_pi() ; }
          }
        }
      }
@@ -1179,9 +1186,9 @@ void GsfElectronAlgo::setPflowPreselectionFlag( GsfElectron * ele )
   ele->setPassMvaPreselection(false) ;
 
   if (ele->core()->ecalDrivenSeed())
-   { if (ele->mvaOutput().mva>=generalData_->cutsCfg.minMVA) ele->setPassMvaPreselection(true) ; }
+   { if (ele->mvaOutput().mva_e_pi>=generalData_->cutsCfg.minMVA) ele->setPassMvaPreselection(true) ; }
   else
-   { if (ele->mvaOutput().mva>=generalData_->cutsCfgPflow.minMVA) ele->setPassMvaPreselection(true) ; }
+   { if (ele->mvaOutput().mva_e_pi>=generalData_->cutsCfgPflow.minMVA) ele->setPassMvaPreselection(true) ; }
 
   if (ele->passingMvaPreselection())
    { LogTrace("GsfElectronAlgo") << "Main mva criterion is satisfied" ; }
@@ -1227,9 +1234,11 @@ void GsfElectronAlgo::setMVAOutputs(const std::map<reco::GsfTrackRef,reco::GsfEl
       el++ )
     {
 	if(generalData_->strategyCfg.gedElectronMode==true){
-		float mvaValue=generalData_->sElectronMVAEstimator->mva( *(*el),*(eventData_->event));
+		float mva_NIso_Value=	generalData_->sElectronMVAEstimator->mva( *(*el),*(eventData_->event));
+		float mva_Iso_Value =   generalData_->iElectronMVAEstimator->mva( *(*el), eventData_->vertices->size() );
 	        GsfElectron::MvaOutput mvaOutput ;
-	        mvaOutput.mva = mvaValue ;
+	        mvaOutput.mva_e_pi = mva_NIso_Value ;
+		mvaOutput.mva_Isolated = mva_Iso_Value ;
 	        (*el)->setMvaOutput(mvaOutput);
 	}
 	else{

--- a/RecoEgamma/EgammaElectronProducers/plugins/GEDGsfElectronProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GEDGsfElectronProducer.cc
@@ -123,7 +123,6 @@ void GEDGsfElectronProducer::matchWithPFCandidates(edm::Event & event)
     if( it->gsfTrackRef().isNonnull()) {
 
       reco::GsfElectron::MvaOutput myMvaOutput;
-      myMvaOutput.mva = it->mva_e_pi();
       // at the moment, undefined
       myMvaOutput.status = it->egammaExtraRef()->electronStatus() ;
       gsfMVAOutputMap_[it->gsfTrackRef()] = myMvaOutput;

--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronBaseProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronBaseProducer.cc
@@ -365,7 +365,8 @@ GsfElectronBaseProducer::GsfElectronBaseProducer( const edm::ParameterSet& cfg )
    }
 
 
-   mvaCfg_.vweightsfiles=cfg.getParameter<std::vector<std::string>>("SoftElecMVAFilesString");
+   mva_NIso_Cfg_.vweightsfiles=cfg.getParameter<std::vector<std::string>>("SoftElecMVAFilesString");
+   mva_Iso_Cfg_.vweightsfiles=cfg.getParameter<std::vector<std::string>>("ElecMVAFilesString");
   // create algo
   algo_ = new GsfElectronAlgo
    ( inputCfg_, strategyCfg_,
@@ -374,7 +375,8 @@ GsfElectronBaseProducer::GsfElectronBaseProducer( const edm::ParameterSet& cfg )
      isoCfg,recHitsCfg,
      superClusterErrorFunction,
      crackCorrectionFunction,
-     mvaCfg_,
+     mva_NIso_Cfg_,
+     mva_Iso_Cfg_,
      regressionCfg
    ) ;
 

--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronBaseProducer.h
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronBaseProducer.h
@@ -52,7 +52,8 @@ class GsfElectronBaseProducer : public edm::stream::EDProducer<>
     GsfElectronAlgo::CutsConfiguration cutsCfgPflow_ ;
     ElectronHcalHelper::Configuration hcalCfg_ ;
     ElectronHcalHelper::Configuration hcalCfgPflow_ ;
-    SoftElectronMVAEstimator::Configuration mvaCfg_ ;
+    SoftElectronMVAEstimator::Configuration mva_NIso_Cfg_ ;
+    ElectronMVAEstimator::Configuration mva_Iso_Cfg_ ;
   private :
 
     // check expected configuration of previous modules

--- a/RecoEgamma/EgammaElectronProducers/python/gedGsfElectrons_cfi.py
+++ b/RecoEgamma/EgammaElectronProducers/python/gedGsfElectrons_cfi.py
@@ -162,6 +162,9 @@ gedGsfElectronsTmp = cms.EDProducer("GEDGsfElectronProducer",
  SoftElecMVAFilesString = cms.vstring(
     "RecoEgamma/ElectronIdentification/data/TMVA_BDTSoftElectrons_7Feb2014.weights.xml"
                                 ),
+ ElecMVAFilesString = cms.vstring(
+     "RecoEgamma/ElectronIdentification/data/TMVA_BDTSimpleCat_17Feb2011.weights.xml"
+                                 ),
 )
 
 

--- a/RecoEgamma/EgammaElectronProducers/python/gsfElectrons_cfi.py
+++ b/RecoEgamma/EgammaElectronProducers/python/gsfElectrons_cfi.py
@@ -160,6 +160,9 @@ ecalDrivenGsfElectrons = cms.EDProducer("GsfElectronEcalDrivenProducer",
   SoftElecMVAFilesString = cms.vstring(
     "RecoEgamma/ElectronIdentification/data/TMVA_BDTSoftElectrons_9Dec2013.weights.xml"
                                 ),
+  ElecMVAFilesString = cms.vstring(
+     "RecoEgamma/ElectronIdentification/data/TMVA_BDTSimpleCat_17Feb2011.weights.xml"
+                                 ),
 
 )
 
@@ -331,6 +334,9 @@ gsfElectrons = cms.EDProducer("GsfElectronProducer",
    SoftElecMVAFilesString = cms.vstring(
     "RecoEgamma/ElectronIdentification/data/TMVA_BDTSoftElectrons_7Feb2014.weights.xml"
                                 ),
+   ElecMVAFilesString = cms.vstring(
+     "RecoEgamma/ElectronIdentification/data/TMVA_BDTSimpleCat_17Feb2011.weights.xml"
+                                 ),
 )
 
 

--- a/RecoEgamma/ElectronIdentification/interface/ElectronMVAEstimator.h
+++ b/RecoEgamma/ElectronIdentification/interface/ElectronMVAEstimator.h
@@ -7,12 +7,17 @@
 
 class ElectronMVAEstimator {
  public:
+  struct Configuration{
+         std::vector<std::string> vweightsfiles;
+   };
   ElectronMVAEstimator();
   ElectronMVAEstimator(std::string fileName);
+  ElectronMVAEstimator(const Configuration & );
   ~ElectronMVAEstimator() {;}
   double mva(const reco::GsfElectron& myElectron, int nvertices=0);
 
  private:
+  const Configuration cfg_;
   void bindVariables();
   void init(std::string fileName);
 

--- a/RecoEgamma/ElectronIdentification/plugins/ElectronIdMVABased.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/ElectronIdMVABased.cc
@@ -132,13 +132,13 @@ bool ElectronIdMVABased::filter(edm::Event& iEvent, const edm::EventSetup& iSetu
 	  if (eleEta <= 1.485 && mvaVal > thresholdBarrel && isoDr03 < thresholdIsoBarrel) {
 	    mvaElectrons->push_back( *egIter );
 	    reco::GsfElectron::MvaOutput myMvaOutput;
-	    myMvaOutput.mva = mvaVal;
+	    myMvaOutput.mva_Isolated = mvaVal;
 	    mvaElectrons->back().setMvaOutput(myMvaOutput);
 	  }
 	  else if (eleEta > 1.485 && mvaVal > thresholdEndcap  && isoDr03 < thresholdIsoEndcap) {
 	    mvaElectrons->push_back( *egIter );
 	    reco::GsfElectron::MvaOutput myMvaOutput;
-	    myMvaOutput.mva = mvaVal;
+	    myMvaOutput.mva_Isolated = mvaVal;
 	    mvaElectrons->back().setMvaOutput(myMvaOutput);
 	  }
 

--- a/RecoEgamma/ElectronIdentification/src/ElectronMVAEstimator.cc
+++ b/RecoEgamma/ElectronIdentification/src/ElectronMVAEstimator.cc
@@ -8,11 +8,6 @@
 ElectronMVAEstimator::ElectronMVAEstimator(){}
 
 ElectronMVAEstimator::ElectronMVAEstimator(std::string fileName){
-  init(fileName);
-}
-
-
-void ElectronMVAEstimator::init(std::string fileName) {
   tmvaReader_ = new TMVA::Reader("!Color:Silent");
   tmvaReader_->AddVariable("fbrem",&fbrem);
   tmvaReader_->AddVariable("detain", &detain);
@@ -40,7 +35,40 @@ void ElectronMVAEstimator::init(std::string fileName) {
   tmvaReader_->BookMVA("BDTSimpleCat",fileName.c_str());
 }
 
+ElectronMVAEstimator::ElectronMVAEstimator(const Configuration & cfg):cfg_(cfg){
+  std::vector<std::string> weightsfiles;
+  std::string path_mvaWeightFileEleID;
+  for(unsigned ifile=0 ; ifile < cfg_.vweightsfiles.size() ; ++ifile) {
+    path_mvaWeightFileEleID = edm::FileInPath ( cfg_.vweightsfiles[ifile].c_str() ).fullPath();
+    weightsfiles.push_back(path_mvaWeightFileEleID);
+  }
+  tmvaReader_ = new TMVA::Reader("!Color:Silent");
+  tmvaReader_->AddVariable("fbrem",&fbrem);
+  tmvaReader_->AddVariable("detain", &detain);
+  tmvaReader_->AddVariable("dphiin", &dphiin);
+  tmvaReader_->AddVariable("sieie", &sieie);
+  tmvaReader_->AddVariable("hoe", &hoe);
+  tmvaReader_->AddVariable("eop", &eop);
+  tmvaReader_->AddVariable("e1x5e5x5", &e1x5e5x5);
+  tmvaReader_->AddVariable("eleopout", &eleopout);
+  tmvaReader_->AddVariable("detaeleout", &detaeleout);
+  tmvaReader_->AddVariable("kfchi2", &kfchi2);
+  tmvaReader_->AddVariable("kfhits", &mykfhits);
+  tmvaReader_->AddVariable("mishits",&mymishits);
+  tmvaReader_->AddVariable("dist", &absdist);
+  tmvaReader_->AddVariable("dcot", &absdcot);
+  tmvaReader_->AddVariable("nvtx", &myNvtx);
 
+  tmvaReader_->AddSpectator("eta",&eta);
+  tmvaReader_->AddSpectator("pt",&pt);
+  tmvaReader_->AddSpectator("ecalseed",&ecalseed);
+  
+  // Taken from Daniele (his mail from the 30/11)
+  //  tmvaReader_->BookMVA("BDTSimpleCat","../Training/weights_Root527b_3Depth_DanVarConvRej_2PtBins_10Pt_800TPrune5_Min100Events_NoBjets_half/TMVA_BDTSimpleCat.weights.xm");
+  // training of the 7/12 with Nvtx added
+
+  tmvaReader_->BookMVA("BDTSimpleCat",weightsfiles[0]);
+}
 
 double ElectronMVAEstimator::mva(const reco::GsfElectron& myElectron, int nvertices )  {
   fbrem = myElectron.fbrem();

--- a/RecoEgamma/Examples/plugins/DQMAnalyzer.cc
+++ b/RecoEgamma/Examples/plugins/DQMAnalyzer.cc
@@ -768,7 +768,7 @@ DQMAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 
     //fbrem
 
-    h_ele_mva->Fill(gsfIter->mva()) ;
+    h_ele_mva->Fill(gsfIter->mva_e_pi()) ;
     if (gsfIter->ecalDrivenSeed()) h_ele_provenance->Fill(1.) ;
     if (gsfIter->trackerDrivenSeed()) h_ele_provenance->Fill(-1.) ;
     if (gsfIter->trackerDrivenSeed()||gsfIter->ecalDrivenSeed()) h_ele_provenance->Fill(0.);

--- a/RecoEgamma/Examples/plugins/GsfElectronDataAnalyzer.cc
+++ b/RecoEgamma/Examples/plugins/GsfElectronDataAnalyzer.cc
@@ -1113,7 +1113,7 @@ GsfElectronDataAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup
 	if (gsfIter->isEE() && gsfIter->scSigmaIEtaIEta() > sigIetaIetaMaxEndcaps_) continue;
 	if (gsfIter->isEB() && gsfIter->hadronicOverEm() > hadronicOverEmMaxBarrel_) continue;
 	if (gsfIter->isEE() && gsfIter->hadronicOverEm() > hadronicOverEmMaxEndcaps_) continue;
-	if (gsfIter->mva() < mvaMin_) continue;
+	if (gsfIter->mva_e_pi() < mvaMin_) continue;
 
 	double d = (gsfIter->vertex().x()-bs.position().x())
 		  *(gsfIter->vertex().x()-bs.position().x())+
@@ -1314,7 +1314,7 @@ GsfElectronDataAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup
          if (gsfIter->classification() == GsfElectron::SHOWERING)
 	  h_ele_PtinVsPtoutShowering_mean ->  Fill(gsfIter->gsfTrack()->outerMomentum().Rho(), gsfIter->gsfTrack()->innerMomentum().Rho());
 
-        h_ele_mva->Fill(gsfIter->mva());
+        h_ele_mva->Fill(gsfIter->mva_e_pi());
 	if (gsfIter->ecalDrivenSeed()) h_ele_provenance->Fill(1.);
 	if (gsfIter->trackerDrivenSeed()) h_ele_provenance->Fill(-1.);
 	if (gsfIter->trackerDrivenSeed()||gsfIter->ecalDrivenSeed()) h_ele_provenance->Fill(0.);

--- a/RecoEgamma/Examples/plugins/GsfElectronFakeAnalyzer.cc
+++ b/RecoEgamma/Examples/plugins/GsfElectronFakeAnalyzer.cc
@@ -1598,7 +1598,7 @@ GsfElectronFakeAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup
          if (bestGsfElectron.classification() == GsfElectron::SHOWERING)
 	  h_ele_PtinVsPtoutShowering_mean ->  Fill(bestGsfElectron.gsfTrack()->outerMomentum().Rho(), bestGsfElectron.gsfTrack()->innerMomentum().Rho());
 
-        h_ele_mva->Fill(bestGsfElectron.mva());
+        h_ele_mva->Fill(bestGsfElectron.mva_e_pi());
 	if (bestGsfElectron.ecalDrivenSeed()) h_ele_provenance->Fill(1.);
 	if (bestGsfElectron.trackerDrivenSeed()) h_ele_provenance->Fill(-1.);
 	if (bestGsfElectron.trackerDrivenSeed()||bestGsfElectron.ecalDrivenSeed()) h_ele_provenance->Fill(0.);

--- a/RecoEgamma/Examples/plugins/GsfElectronMCAnalyzer.cc
+++ b/RecoEgamma/Examples/plugins/GsfElectronMCAnalyzer.cc
@@ -2284,8 +2284,8 @@ GsfElectronMCAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& 
 	   h_ele_PtinVsPtoutShowering_mean ->  Fill(bestGsfElectron.gsfTrack()->outerMomentum().Rho(), bestGsfElectron.gsfTrack()->innerMomentum().Rho());
         }
 
-        h_ele_mva->Fill(bestGsfElectron.mva());
-        if (bestGsfElectron.ecalDrivenSeed()) h_ele_mva_eg->Fill(bestGsfElectron.mva());
+        h_ele_mva->Fill(bestGsfElectron.mva_e_pi());
+        if (bestGsfElectron.ecalDrivenSeed()) h_ele_mva_eg->Fill(bestGsfElectron.mva_e_pi());
 	if (bestGsfElectron.ecalDrivenSeed()) h_ele_provenance->Fill(1.);
 	if (bestGsfElectron.trackerDrivenSeed()) h_ele_provenance->Fill(-1.);
 	if (bestGsfElectron.trackerDrivenSeed()||bestGsfElectron.ecalDrivenSeed()) h_ele_provenance->Fill(0.);

--- a/RecoEgamma/Examples/plugins/GsfElectronMCFakeAnalyzer.cc
+++ b/RecoEgamma/Examples/plugins/GsfElectronMCFakeAnalyzer.cc
@@ -1602,7 +1602,7 @@ GsfElectronMCFakeAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSet
          if (bestGsfElectron.classification() == GsfElectron::SHOWERING)
 	  h_ele_PtinVsPtoutShowering_mean ->  Fill(bestGsfElectron.gsfTrack()->outerMomentum().Rho(), bestGsfElectron.gsfTrack()->innerMomentum().Rho());
 
-        h_ele_mva->Fill(bestGsfElectron.mva());
+        h_ele_mva->Fill(bestGsfElectron.mva_e_pi());
 	if (bestGsfElectron.ecalDrivenSeed()) h_ele_provenance->Fill(1.);
 	if (bestGsfElectron.trackerDrivenSeed()) h_ele_provenance->Fill(-1.);
 	if (bestGsfElectron.trackerDrivenSeed()||bestGsfElectron.ecalDrivenSeed()) h_ele_provenance->Fill(0.);

--- a/RecoParticleFlow/PFProducer/interface/PFEGammaFilters.h
+++ b/RecoParticleFlow/PFProducer/interface/PFEGammaFilters.h
@@ -34,7 +34,7 @@ class PFEGammaFilters {
 		  const edm::ParameterSet& ele_protectionsForJetMET
 		  );
   
-  ~PFEGammaFilters(){delete ele_iso_mvaID_;};
+  ~PFEGammaFilters(){};
   
   bool passPhotonSelection(const reco::Photon &);
   bool passElectronSelection(const reco::GsfElectron &, 
@@ -71,8 +71,6 @@ class PFEGammaFilters {
   float ele_iso_mva_ee_;
   float ele_iso_combIso_eb_;
   float ele_iso_combIso_ee_;
-  std::string ele_iso_mva_weightFile_;
-  ElectronMVAEstimator *ele_iso_mvaID_;
   float ele_noniso_mva_;
   unsigned int ele_missinghits_;
   //std::vector<double> ele_protectionsForJetMET_; // replacement below

--- a/RecoParticleFlow/PFProducer/plugins/PFElectronTranslator.cc
+++ b/RecoParticleFlow/PFProducer/plugins/PFElectronTranslator.cc
@@ -620,7 +620,7 @@ void PFElectronTranslator::createGsfElectrons(const reco::PFCandidateCollection 
       // MVA output
       reco::GsfElectron::MvaOutput myMvaOutput;
       myMvaOutput.status = pfCandidate.electronExtraRef()->electronStatus();
-      myMvaOutput.mva = pfCandidate.mva_e_pi();
+      myMvaOutput.mva_e_pi = pfCandidate.mva_e_pi();
       myElectron.setMvaOutput(myMvaOutput);
       
       // ambiguous tracks

--- a/RecoParticleFlow/PFProducer/src/PFAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFAlgo.cc
@@ -709,7 +709,8 @@ void PFAlgo::processBlock( const reco::PFBlockRef& blockref,
 	  myPFElectron.setParticleType(particleType);
 	  myPFElectron.setCharge(gedEleRef->charge());
 	  myPFElectron.setP4(gedEleRef->p4());
-	  myPFElectron.set_mva_e_pi(gedEleRef->mva());
+	  myPFElectron.set_mva_e_pi(gedEleRef->mva_e_pi());
+          myPFElectron.set_mva_Isolated(gedEleRef->mva_Isolated());
 
 	  if(egmLocalDebug) {
 	    cout << " PFAlgo: found an electron with NEW EGamma code " << endl;

--- a/RecoParticleFlow/PFProducer/src/PFEGammaFilters.cc
+++ b/RecoParticleFlow/PFProducer/src/PFEGammaFilters.cc
@@ -53,9 +53,6 @@ PFEGammaFilters::PFEGammaFilters(float ph_Et,
   ele_maxEeleOverPout(ele_protectionsForJetMET.getParameter<double>("maxEeleOverPout")), 
   ele_maxDPhiIN(ele_protectionsForJetMET.getParameter<double>("maxDPhiIN"))
 {
-
-  ele_iso_mvaID_= new ElectronMVAEstimator(ele_iso_path_mvaWeightFile);
-
 }
 
 bool PFEGammaFilters::passPhotonSelection(const reco::Photon & photon) {
@@ -101,18 +98,18 @@ bool PFEGammaFilters::passElectronSelection(const reco::GsfElectron & electron,
     double isoDr03 = electron.dr03TkSumPt() + electron.dr03EcalRecHitSumEt() + electron.dr03HcalTowerSumEt();
     double eleEta = fabs(electron.eta());
     if (eleEta <= 1.485 && isoDr03 < ele_iso_combIso_eb_) {
-      if( ele_iso_mvaID_->mva( electron, nVtx ) > ele_iso_mva_eb_ ) 
+      if( electron.mva_Isolated() > ele_iso_mva_eb_ ) 
 	passEleSelection = true;
     }
     else if (eleEta > 1.485  && isoDr03 < ele_iso_combIso_ee_) {
-      if( ele_iso_mvaID_->mva( electron, nVtx ) > ele_iso_mva_ee_ ) 
+      if( electron.mva_Isolated() > ele_iso_mva_ee_ ) 
 	passEleSelection = true;
     }
 
   }
 
   //  cout << " My OLD MVA " << pfcand.mva_e_pi() << " MyNEW MVA " << electron.mva() << endl;
-  if(electron.mva() > ele_noniso_mva_) {
+  if(electron.mva_e_pi() > ele_noniso_mva_) {
     passEleSelection = true; 
   }
   

--- a/RecoParticleFlow/PFProducer/test/GsfGEDElectronAnalyzer.cc
+++ b/RecoParticleFlow/PFProducer/test/GsfGEDElectronAnalyzer.cc
@@ -414,7 +414,7 @@ GsfGEDElectronAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup&
 	float etareco = theGsfEle[j].eta();
 	float phireco = theGsfEle[j].phi();
 
-	float pfmva =  theGsfEle[j].mva();
+	float pfmva =  theGsfEle[j].mva_e_pi();
 
 	reco::GsfTrackRef refGsf =  theGsfEle[j].gsfTrack();
 	//ElectronSeedRef seedRef= refGsf->extra()->seedRef().castTo<ElectronSeedRef>();
@@ -552,7 +552,7 @@ GsfGEDElectronAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup&
 	reco::GsfTrackRef egGsfTrackRef = (theGedEle[j]).gsfTrack();
 	float etareco = theGedEle[j].eta();
 	float phireco = theGedEle[j].phi();	
-	float pfmva =  theGedEle[j].mva();
+	float pfmva =  theGedEle[j].mva_e_pi();
 	
 	reco::GsfTrackRef refGsf =  theGedEle[j].gsfTrack();
 	//ElectronSeedRef seedRef= refGsf->extra()->seedRef().castTo<ElectronSeedRef>();

--- a/RecoParticleFlow/PFProducer/test/PFIsoReader.cc
+++ b/RecoParticleFlow/PFProducer/test/PFIsoReader.cc
@@ -119,7 +119,7 @@ void PFIsoReader::analyze(const edm::Event & iEvent,const edm::EventSetup & c)
   for(unsigned iele=0; iele<nele;++iele) {
     reco::GsfElectronRef myElectronRef(gsfElectronH,iele);
 
-    if(myElectronRef->mva()<-1) continue;
+    if(myElectronRef->mva_e_pi()<-1) continue;
     //const reco::PFCandidatePtr & pfElePtr(myElectronValMap[myElectronRef]);
     const reco::PFCandidatePtr pfElePtr(myElectronValMap[myElectronRef]);
     printIsoDeposits(electronIsoDep,pfElePtr);

--- a/Validation/RecoEgamma/plugins/ElectronMcFakeValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcFakeValidator.cc
@@ -1367,9 +1367,9 @@ void ElectronMcFakeValidator::analyze( const edm::Event & iEvent, const edm::Eve
         if (bestGsfElectron.classification() == GsfElectron::SHOWERING)
           h2_ele_PtinVsPtoutShowering_mean->Fill(bestGsfElectron.gsfTrack()->outerMomentum().Rho(), bestGsfElectron.gsfTrack()->innerMomentum().Rho());
 
-      h1_ele_mva->Fill(bestGsfElectron.mva());
-      if (bestGsfElectron.isEB()) h1_ele_mva_barrel->Fill(bestGsfElectron.mva());
-      if (bestGsfElectron.isEE()) h1_ele_mva_endcaps->Fill(bestGsfElectron.mva());
+      h1_ele_mva->Fill(bestGsfElectron.mva_e_pi());
+      if (bestGsfElectron.isEB()) h1_ele_mva_barrel->Fill(bestGsfElectron.mva_e_pi());
+      if (bestGsfElectron.isEE()) h1_ele_mva_endcaps->Fill(bestGsfElectron.mva_e_pi());
 
       if (bestGsfElectron.ecalDrivenSeed()) h1_ele_provenance->Fill(1.);
       if (bestGsfElectron.trackerDrivenSeed()) h1_ele_provenance->Fill(-1.);

--- a/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
@@ -1737,10 +1737,10 @@ void ElectronMcSignalValidator::analyze( const edm::Event & iEvent, const edm::E
      }
 
     // provenance and pflow data
-    h1_ele_mva->Fill(bestGsfElectron.mva());
-    if (bestGsfElectron.isEB()) h1_ele_mva_barrel->Fill(bestGsfElectron.mva());
-    if (bestGsfElectron.isEE()) h1_ele_mva_endcaps->Fill(bestGsfElectron.mva());
-    if (bestGsfElectron.ecalDrivenSeed()) h1_ele_mva_eg->Fill(bestGsfElectron.mva());
+    h1_ele_mva->Fill(bestGsfElectron.mva_e_pi());
+    if (bestGsfElectron.isEB()) h1_ele_mva_barrel->Fill(bestGsfElectron.mva_e_pi());
+    if (bestGsfElectron.isEE()) h1_ele_mva_endcaps->Fill(bestGsfElectron.mva_e_pi());
+    if (bestGsfElectron.ecalDrivenSeed()) h1_ele_mva_eg->Fill(bestGsfElectron.mva_e_pi());
     if (bestGsfElectron.ecalDrivenSeed()) h1_ele_provenance->Fill(1.);
     if (bestGsfElectron.trackerDrivenSeed()) h1_ele_provenance->Fill(-1.);
     if (bestGsfElectron.trackerDrivenSeed()||bestGsfElectron.ecalDrivenSeed()) h1_ele_provenance->Fill(0.);


### PR DESCRIPTION
Change in GsfElectron data format:
- rename old mva variable with mva_e_pi
- add mva_Isolated

This PR just picks what's in #4565 and adds a fix to merge conflict in merging PhysicsTools/SelectorUtils/interface/PFElectronSelector.h
a3409cd is applied on top of CMSSW_7_2_X_2014-07-30-0200
and only PFElectronSelector was touched
