### PR TITLE
Remove workaround for ROOT6 bug

### DIFF
--- a/CommonTools/Utils/interface/StringToEnumValue.h
+++ b/CommonTools/Utils/interface/StringToEnumValue.h
@@ -23,16 +23,6 @@
 
 template <class MyType> 
 int StringToEnumValue(const std::string & enumMemberName){
-  //KLUDGE workaround for ROOT6 bug
-  if(enumMemberName[0] == 'k') {
-    if(enumMemberName == "kGood") return 0;
-    if(enumMemberName == "kProblematic") return 1;
-    if(enumMemberName == "kRecovered") return 2;
-    if(enumMemberName == "kTime") return 3;
-    if(enumMemberName == "kWeird") return 4;
-    if(enumMemberName == "kBad") return 5;
-  }
-  // END KLUDGE
   edm::TypeWithDict dataType(typeid(MyType), kIsEnum);
   return dataType.stringToEnumValue(enumMemberName);
 }


### PR DESCRIPTION
Remove the hideous partial workaround for a ROOT6 bug.  The bug, which is due to on demand header parsing, was backed out of the IB in the latestROOT6  patch.  This workaround is not needed now, and causes other problems.  Please merge promptly.
