### PR TITLE
Special case needed to get template name of std::string

### DIFF
--- a/FWCore/Utilities/src/TypeWithDict.cc
+++ b/FWCore/Utilities/src/TypeWithDict.cc
@@ -584,6 +584,9 @@ namespace edm {
     if (!isTemplateInstance()) {
       return "";
     }
+    if (name() == "std::string") {
+      return std::string("std::basic_string");
+    }
     std::string templateName(name());
     auto begin = templateName.find('<');
     assert(begin != std::string::npos);


### PR DESCRIPTION
Due to the fact that, in ROOT6, the normalized name of std::basic_string<char> is a typedef (std::string),
the function returning the name of a template returns the empty string instead of "std::basic_string".
A special case is needed for std::string to fix this ROOT6 specific problem.
Please merge this request promptly.
