### PR TITLE
Add check that the event number is valid

### DIFF
--- a/DataFormats/Provenance/interface/EventID.h
+++ b/DataFormats/Provenance/interface/EventID.h
@@ -5,7 +5,7 @@
 // Package:     DataFormats/Provenance
 // Class  :     EventID
 //
-/**\class EventID EventID.h DataFormats/Provenance/interface/EventID.h
+/**\class edm::EventID
 
  Description: Holds run, lumi, and event numbers.
 
@@ -23,23 +23,15 @@
 
 // user include files
 #include "DataFormats/Provenance/interface/RunID.h"
+#include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
 
 // forward declarations
 namespace edm {
 
-   typedef unsigned int EventNumber_t;
-   typedef unsigned int LuminosityBlockNumber_t;
-
-
   class EventID {
 
     public:
-
-      static RunNumber_t const invalidRun;
-      static LuminosityBlockNumber_t const invalidLumi;
-      static EventNumber_t const invalidEvent;
-
-      EventID() : run_(0), luminosityBlock_(0), event_(0) {}
+      EventID() : run_(invalidRunNumber), luminosityBlock_(invalidLuminosityBlockNumber), event_(invalidEventNumber) {}
       EventID(RunNumber_t iRun, LuminosityBlockNumber_t iLumi, EventNumber_t iEvent) :
         run_(iRun), luminosityBlock_(iLumi), event_(iEvent) {}
 

--- a/DataFormats/Provenance/interface/EventID.h
+++ b/DataFormats/Provenance/interface/EventID.h
@@ -34,6 +34,11 @@ namespace edm {
   class EventID {
 
     public:
+
+      static RunNumber_t const invalidRun;
+      static LuminosityBlockNumber_t const invalidLumi;
+      static EventNumber_t const invalidEvent;
+
       EventID() : run_(0), luminosityBlock_(0), event_(0) {}
       EventID(RunNumber_t iRun, LuminosityBlockNumber_t iLumi, EventNumber_t iEvent) :
         run_(iRun), luminosityBlock_(iLumi), event_(iEvent) {}

--- a/DataFormats/Provenance/interface/LuminosityBlockID.h
+++ b/DataFormats/Provenance/interface/LuminosityBlockID.h
@@ -5,7 +5,7 @@
 // Package:     DataFormats/Provenance
 // Class  :     LuminosityBlockID
 //
-/**\class LuminosityBlockID LuminosityBlockID.h DataFormats/Provenance/interface/LuminosityBlockID.h
+/**\class edm::LuminosityBlockID
 
  Description: Holds run and luminosityBlock number.
 
@@ -23,15 +23,14 @@
 
 // user include files
 #include "DataFormats/Provenance/interface/RunID.h"
+#include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
 
 // forward declarations
 namespace edm {
 
-   typedef unsigned int LuminosityBlockNumber_t;
-
   class LuminosityBlockID {
    public:
-      LuminosityBlockID() : run_(0), luminosityBlock_(0) {}
+      LuminosityBlockID() : run_(invalidRunNumber), luminosityBlock_(invalidLuminosityBlockNumber) {}
       explicit LuminosityBlockID(boost::uint64_t id);
       LuminosityBlockID(RunNumber_t iRun, LuminosityBlockNumber_t iLuminosityBlock) :
         run_(iRun), luminosityBlock_(iLuminosityBlock) {}

--- a/DataFormats/Provenance/interface/RunID.h
+++ b/DataFormats/Provenance/interface/RunID.h
@@ -5,9 +5,9 @@
 // Package:     DataFormats/Provenance
 // Class  :     RunID
 // 
-/**\class RunID RunID.h DataFormats/Provenance/interface/RunID.h
+/**\class edm::RunID
 
- Description: Holds run and luminosityBlock number.
+ Description: Holds run number
 
  Usage:
     <usage>
@@ -20,20 +20,16 @@
 #include <iosfwd>
 
 // user include files
+#include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
 
 // forward declarations
 namespace edm {
 
-   typedef unsigned int RunNumber_t;
-
-   
 class RunID
 {
-
    public:
-   
-   
-      RunID() : run_(0) {}
+
+      RunID() : run_(invalidRunNumber) {}
       explicit RunID(RunNumber_t iRun) :
 	run_(iRun) {}
       

--- a/DataFormats/Provenance/interface/RunLumiEventNumber.h
+++ b/DataFormats/Provenance/interface/RunLumiEventNumber.h
@@ -1,0 +1,20 @@
+#ifndef DataFormats_Provenance_RunLumiEventNumber_h
+#define DataFormats_Provenance_RunLumiEventNumber_h
+
+/**
+
+\author W. David Dagenhart, created 1 August, 2014
+
+*/
+
+namespace edm {
+
+   typedef unsigned int EventNumber_t;
+   typedef unsigned int LuminosityBlockNumber_t;
+   typedef unsigned int RunNumber_t;
+
+   EventNumber_t const invalidEventNumber = 0U;
+   LuminosityBlockNumber_t const invalidLuminosityBlockNumber = 0U;
+   RunNumber_t const invalidRunNumber = 0U;
+}
+#endif

--- a/DataFormats/Provenance/src/EventID.cc
+++ b/DataFormats/Provenance/src/EventID.cc
@@ -1,7 +1,13 @@
 #include "DataFormats/Provenance/interface/EventID.h"
 #include <ostream>
 
+
 namespace edm {
+
+  RunNumber_t const EventID::invalidRun = 0U;
+  LuminosityBlockNumber_t const EventID::invalidLumi = 0U;
+  EventNumber_t const EventID::invalidEvent = 0U;
+
   std::ostream& operator<<(std::ostream& oStream, EventID const& iID) {
     oStream << "run: " << iID.run() << " lumi: " << iID.luminosityBlock() << " event: " << iID.event();
     return oStream;

--- a/DataFormats/Provenance/src/EventID.cc
+++ b/DataFormats/Provenance/src/EventID.cc
@@ -1,13 +1,7 @@
 #include "DataFormats/Provenance/interface/EventID.h"
 #include <ostream>
 
-
 namespace edm {
-
-  RunNumber_t const EventID::invalidRun = 0U;
-  LuminosityBlockNumber_t const EventID::invalidLumi = 0U;
-  EventNumber_t const EventID::invalidEvent = 0U;
-
   std::ostream& operator<<(std::ostream& oStream, EventID const& iID) {
     oStream << "run: " << iID.run() << " lumi: " << iID.luminosityBlock() << " event: " << iID.event();
     return oStream;

--- a/FWCore/Framework/src/EventPrincipal.cc
+++ b/FWCore/Framework/src/EventPrincipal.cc
@@ -5,6 +5,7 @@
 #include "DataFormats/Provenance/interface/BranchIDList.h"
 #include "DataFormats/Provenance/interface/BranchIDListHelper.h"
 #include "DataFormats/Provenance/interface/BranchListIndex.h"
+#include "DataFormats/Provenance/interface/EventID.h"
 #include "DataFormats/Provenance/interface/ProductIDToBranchID.h"
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
 #include "FWCore/Common/interface/Provenance.h"
@@ -85,6 +86,11 @@ namespace edm {
   EventPrincipal::fillEventPrincipal(EventAuxiliary const& aux,
                                      ProcessHistoryRegistry const& processHistoryRegistry,
                                      DelayedReader* reader) {
+    if(aux.event() == EventID::invalidEvent) {
+      throw Exception(errors::LogicError)
+        << "EventPrincipal::fillEventPrincipal, Invalid event number provided in EventAuxiliary, It is illegal for the event number to be 0\n";
+    }
+
     fillPrincipal(aux.processHistoryID(), processHistoryRegistry, reader);
     aux_ = aux;
     aux_.setProcessHistoryID(processHistoryID());

--- a/FWCore/Framework/src/EventPrincipal.cc
+++ b/FWCore/Framework/src/EventPrincipal.cc
@@ -5,7 +5,7 @@
 #include "DataFormats/Provenance/interface/BranchIDList.h"
 #include "DataFormats/Provenance/interface/BranchIDListHelper.h"
 #include "DataFormats/Provenance/interface/BranchListIndex.h"
-#include "DataFormats/Provenance/interface/EventID.h"
+#include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
 #include "DataFormats/Provenance/interface/ProductIDToBranchID.h"
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
 #include "FWCore/Common/interface/Provenance.h"
@@ -86,7 +86,7 @@ namespace edm {
   EventPrincipal::fillEventPrincipal(EventAuxiliary const& aux,
                                      ProcessHistoryRegistry const& processHistoryRegistry,
                                      DelayedReader* reader) {
-    if(aux.event() == EventID::invalidEvent) {
+    if(aux.event() == invalidEventNumber) {
       throw Exception(errors::LogicError)
         << "EventPrincipal::fillEventPrincipal, Invalid event number provided in EventAuxiliary, It is illegal for the event number to be 0\n";
     }

--- a/FWCore/Framework/test/generichandle_t.cppunit.cc
+++ b/FWCore/Framework/test/generichandle_t.cppunit.cc
@@ -79,7 +79,7 @@ void testGenericHandle::failWrongType() {
 }
 void testGenericHandle::failgetbyLabelTest() {
 
-  edm::EventID id;
+  edm::EventID id = edm::EventID::firstValidEvent();
   edm::Timestamp time;
   std::string uuid = edm::createGlobalIdentifier();
   edm::ProcessConfiguration pc("PROD", edm::ParameterSetID(), edm::getReleaseVersion(), edm::getPassID());

--- a/FWCore/Framework/test/global_module_t.cppunit.cc
+++ b/FWCore/Framework/test/global_module_t.cppunit.cc
@@ -348,7 +348,7 @@ m_ep()
   //Setup the principals
   m_prodReg->setFrozen();
   m_idHelper->updateFromRegistry(*m_prodReg);
-  edm::EventID eventID;
+  edm::EventID eventID = edm::EventID::firstValidEvent();
   
   std::string uuid = edm::createGlobalIdentifier();
   edm::Timestamp now(1234567UL);

--- a/FWCore/Framework/test/one_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/one_outputmodule_t.cppunit.cc
@@ -235,7 +235,7 @@ m_ep()
   //Setup the principals
   m_prodReg->setFrozen();
   m_idHelper->updateFromRegistry(*m_prodReg);
-  edm::EventID eventID;
+  edm::EventID eventID = edm::EventID::firstValidEvent();
   
   std::string uuid = edm::createGlobalIdentifier();
   edm::Timestamp now(1234567UL);

--- a/FWCore/Framework/test/stream_module_t.cppunit.cc
+++ b/FWCore/Framework/test/stream_module_t.cppunit.cc
@@ -371,7 +371,7 @@ m_ep()
   //Setup the principals
   m_prodReg->setFrozen();
   m_idHelper->updateFromRegistry(*m_prodReg);
-  edm::EventID eventID;
+  edm::EventID eventID = edm::EventID::firstValidEvent();
   
   std::string uuid = edm::createGlobalIdentifier();
   edm::Timestamp now(1234567UL);


### PR DESCRIPTION
Add check that the event number is valid when filling the EventPrincipal. Also add constants defining invalid event, lumi and run numbers to the EventID class. Fix a few unit tests broken by this.
