### PR TITLE
Update Shashlik customs

### DIFF
--- a/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
@@ -114,7 +114,8 @@ def cust_2023SHCal(process):
     if hasattr(process,'L1simulation_step'):
         process.simEcalTriggerPrimitiveDigis.BarrelOnly = cms.bool(True)
     if hasattr(process,'digitisation_step'):
-    	process.mix.digitizers.ecal.accumulatorType = cms.string('EcalPhaseIIDigiProducer')
+        process.mix.digitizers.ecal.accumulatorType = cms.string('EcalPhaseIIDigiProducer')
+        process.mix.mixObjects.mixCH.input.append( cms.InputTag("g4SimHits","EcalHitsEK") )
         process.simEcalUnsuppressedDigis = cms.EDAlias(
             mix = cms.VPSet(
             cms.PSet(type = cms.string('EBDigiCollection')),

--- a/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
@@ -215,11 +215,10 @@ def cust_2023SHCal(process):
         process.uncleanedOnlyGsfElectrons.endcapRecHitCollectionTag = cms.InputTag("ecalRecHit","EcalRecHitsEK")
         process.ecalEndcapClusterTaskExtras.EcalRecHitCollection = cms.InputTag("ecalRecHit","EcalRecHitsEK")
         process.ecalEndcapRecoSummary.recHitCollection_EE = cms.InputTag("ecalRecHit","EcalRecHitsEK")
-        ## The following ones don't work out of the box, so until they're fixed let them use the wrong collection
-        #process.multi5x5BasicClustersCleaned.endcapHitCollection = cms.string('EcalRecHitsEK')
-        #process.multi5x5BasicClustersUncleaned.endcapHitCollection = cms.string('EcalRecHitsEK')
-        #process.correctedMulti5x5SuperClustersWithPreshower.recHitProducer = cms.InputTag("ecalRecHit","EcalRecHitsEK")
-        #process.uncleanedOnlyCorrectedMulti5x5SuperClustersWithPreshower.recHitProducer = cms.InputTag("ecalRecHit","EcalRecHitsEK")
+        process.multi5x5BasicClustersCleaned.endcapHitCollection = cms.string('EcalRecHitsEK')
+        process.multi5x5BasicClustersUncleaned.endcapHitCollection = cms.string('EcalRecHitsEK')
+        process.correctedMulti5x5SuperClustersWithPreshower.recHitProducer = cms.InputTag("ecalRecHit","EcalRecHitsEK")
+        process.uncleanedOnlyCorrectedMulti5x5SuperClustersWithPreshower.recHitProducer = cms.InputTag("ecalRecHit","EcalRecHitsEK")
 
 
     return process


### PR DESCRIPTION
@bsunanda fixed loads of modules to work with the Shashlik geometry, so this updates the last of the modules to use the correct Shashlik EcalRecHitsEK collection.

Also, EcalHitsEK wasn't in the mixObjects for the mixing module.  The mixing module has this odd behaviour where all collections in the signal sample are available to the accumulators, but for the pileup events only the collections in mixObjects are available.  Before this fix I'm pretty sure EcalHitsEK were only being digitised for the signal event.
