### PR TITLE
Update Shashlik mixObjects for EcalRecHitsEK

### DIFF
--- a/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
@@ -114,7 +114,8 @@ def cust_2023SHCal(process):
     if hasattr(process,'L1simulation_step'):
         process.simEcalTriggerPrimitiveDigis.BarrelOnly = cms.bool(True)
     if hasattr(process,'digitisation_step'):
-    	process.mix.digitizers.ecal.accumulatorType = cms.string('EcalPhaseIIDigiProducer')
+        process.mix.digitizers.ecal.accumulatorType = cms.string('EcalPhaseIIDigiProducer')
+        process.mix.mixObjects.mixCH.input.append( cms.InputTag("g4SimHits","EcalHitsEK") )
         process.simEcalUnsuppressedDigis = cms.EDAlias(
             mix = cms.VPSet(
             cms.PSet(type = cms.string('EBDigiCollection')),


### PR DESCRIPTION
EcalHitsEK wasn't in the mixObjects for the mixing module. The mixing module has this odd behaviour where all collections in the signal sample are available to the accumulators, but for the pileup events only the collections in mixObjects are available. Before this fix I'm pretty sure EcalHitsEK were only being digitised for the signal event.
