### PR TITLE
fix pat::Electron source PFCand accessor in miniAOD

### DIFF
--- a/DataFormats/PatCandidates/src/Electron.cc
+++ b/DataFormats/PatCandidates/src/Electron.cc
@@ -395,7 +395,7 @@ reco::CandidatePtr Electron::sourceCandidatePtr( size_type i ) const {
     if (i >= associatedPackedFCandidateIndices_.size()) {
         return reco::CandidatePtr();
     } else {
-        return reco::CandidatePtr(edm::refToPtr(edm::Ref<pat::PackedCandidateCollection>(packedPFCandidates_, i)));
+        return reco::CandidatePtr(edm::refToPtr(edm::Ref<pat::PackedCandidateCollection>(packedPFCandidates_, associatedPackedFCandidateIndices_[i])));
     }
 }
 

--- a/DataFormats/PatCandidates/src/Photon.cc
+++ b/DataFormats/PatCandidates/src/Photon.cc
@@ -215,7 +215,7 @@ reco::CandidatePtr Photon::sourceCandidatePtr( size_type i ) const {
     if (i >= associatedPackedFCandidateIndices_.size()) {
         return reco::CandidatePtr();
     } else {
-        return reco::CandidatePtr(edm::refToPtr(edm::Ref<pat::PackedCandidateCollection>(packedPFCandidates_, i)));
+        return reco::CandidatePtr(edm::refToPtr(edm::Ref<pat::PackedCandidateCollection>(packedPFCandidates_, associatedPackedFCandidateIndices_[i])));
     }
 }
 


### PR DESCRIPTION
References from pat::Electron to packed PFCandidates are correctly stored in the miniAODs, but the accessor that returns them had a bug.
This commit fixes the problem in the accessor. 
It does not need to reproduce the miniAODs, it does not change the persistent dataformat, and in general it doesn't affect miniAOD production in any way.
It also doesn't need to recompile any dependency for it to work, since the fix is localized in a cc file.

@arizzi @bendavid 
