### PR TITLE
Turn off MET significance calculation in CaloMETs for SLHC

### DIFF
--- a/RecoMET/METAlgorithms/interface/SignAlgoResolutions.h
+++ b/RecoMET/METAlgorithms/interface/SignAlgoResolutions.h
@@ -38,7 +38,7 @@
 
 namespace metsig {
 
-  enum resolutionType { caloEE, caloEB, caloHE, caloHO, caloHF, caloHB, jet, electron, tau, muon,PFtype1,PFtype2, PFtype3, PFtype4, PFtype5, PFtype6, PFtype7, caloEK};
+  enum resolutionType { caloEE, caloEB, caloHE, caloHO, caloHF, caloHB, jet, electron, tau, muon,PFtype1,PFtype2, PFtype3, PFtype4, PFtype5, PFtype6, PFtype7 };
   enum resolutionFunc { ET, PHI,TRACKP,CONSTPHI };
 
   class SignAlgoResolutions{

--- a/RecoMET/METAlgorithms/src/SignCaloSpecificAlgo.cc
+++ b/RecoMET/METAlgorithms/src/SignCaloSpecificAlgo.cc
@@ -130,12 +130,6 @@ SignCaloSpecificAlgo::makeVectorOutOfCaloTowers(edm::Handle<edm::View<reco::Cand
 		  sign_tower_sigma_phi = resolutions.eval(metsig::caloEE,metsig::PHI,sign_tower_et,calotower->phi(),calotower->eta());
 		    
 		}
-		else if(subdet == EcalShashlik ){
-		  sign_tower_type = "emcalotower";
-		  sign_tower_et = calotower->emEt();
-		  sign_tower_sigma_et = resolutions.eval(metsig::caloEK,metsig::ET,sign_tower_et,calotower->phi(),calotower->eta());
-		  sign_tower_sigma_phi = resolutions.eval(metsig::caloEK,metsig::PHI,sign_tower_et,calotower->phi(),calotower->eta());
-		}
 		else{
 		  edm::LogWarning("SignCaloSpecificAlgo") << " ECAL tower cell not assigned to an ECAL subdetector!!!" << std::endl;
 		}

--- a/RecoMET/METProducers/python/CaloMET_cfi.py
+++ b/RecoMET/METProducers/python/CaloMET_cfi.py
@@ -24,7 +24,7 @@ met = cms.EDProducer(
     noHF = cms.bool(False),
     globalThreshold = cms.double(0.3),
     InputType = cms.string('CandidateCollection'),
-    calculateSignificance = cms.bool(True)
+    calculateSignificance = cms.bool(False)
     )
 
 metHO = met.clone()
@@ -40,7 +40,7 @@ metOpt = cms.EDProducer(
     noHF = cms.bool(False),
     globalThreshold = cms.double(0.0),
     InputType = cms.string('CandidateCollection'),
-    calculateSignificance = cms.bool(True)
+    calculateSignificance = cms.bool(False)
     )
 
 metOptHO = metOpt.clone()
@@ -56,7 +56,7 @@ metNoHF = cms.EDProducer(
     noHF = cms.bool(True),
     globalThreshold = cms.double(0.3),
     InputType = cms.string('CandidateCollection'),
-    calculateSignificance = cms.bool(True)
+    calculateSignificance = cms.bool(False)
 )
 
 metNoHFHO = metNoHF.clone()
@@ -72,7 +72,7 @@ metOptNoHF = cms.EDProducer(
     noHF = cms.bool(True),
     globalThreshold = cms.double(0.0),
     InputType = cms.string('CandidateCollection'),
-    calculateSignificance = cms.bool(True)
+    calculateSignificance = cms.bool(False)
     )
 metOptNoHFHO = metOptNoHF.clone()
 metOptNoHFHO.src = "calotoweroptmakerWithHO"


### PR DESCRIPTION
The previous pull request: https://github.com/cms-sw/cmssw/pull/4838
might cause potential problems in future. As suggested by Tai Sakuma, 
we can just turn off MET significance calculation in CaloMETs.

This pull request reverts the previous changes and turns off MET 
significance calculation in RecoMET/METProducers/python/CaloMET_cfi.py.
The MET significance will be set zero in these MET objects.
