### PR TITLE
Also add EcalHitsEK to subdets, so that pileup is digitised

### DIFF
--- a/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
@@ -116,6 +116,7 @@ def cust_2023SHCal(process):
     if hasattr(process,'digitisation_step'):
         process.mix.digitizers.ecal.accumulatorType = cms.string('EcalPhaseIIDigiProducer')
         process.mix.mixObjects.mixCH.input.append( cms.InputTag("g4SimHits","EcalHitsEK") )
+        process.mix.mixObjects.mixCH.subdets.append( "EcalHitsEK" )
         process.simEcalUnsuppressedDigis = cms.EDAlias(
             mix = cms.VPSet(
             cms.PSet(type = cms.string('EBDigiCollection')),


### PR DESCRIPTION
When I created #4860 I forgot until @kpedro88 pointed out that the mixing module configuration needs to be changed in two places for it to take effect.  No idea why.  This makes the second change that was missing from #4860.
The following plot shows the calo tower electromagnetic energy as a function of eta for 50 events of QCD in Shashlik at 140 pileup.  SLHC16_patch1 (i.e. only the change in #4860) is in blue, and after applying this pull request is in black.

![fixedshashlikee](https://cloud.githubusercontent.com/assets/6480160/3789063/0d669170-1a8a-11e4-8af9-e9da6200c69f.png)
