### PR TITLE
Fix file creations and permissions for DQM histograms encoded with ProtocolBuffer

### DIFF
--- a/DQMServices/Components/bin/fastHadd.cc
+++ b/DQMServices/Components/bin/fastHadd.cc
@@ -201,7 +201,10 @@ void writeMessage(const dqmstorepb::ROOTFilePB &dqmstore_output_msg,
   DEBUG(1, "Writing file" << std::endl);
 
   int out_fd = ::open(output_filename.c_str(),
-                      O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
+                      O_WRONLY | O_CREAT | O_TRUNC,
+                      S_IRUSR | S_IWUSR |
+                      S_IRGRP | S_IWGRP |
+                      S_IROTH | S_IWOTH);
   FileOutputStream out_stream(out_fd);
   GzipOutputStream::Options options;
   options.format = GzipOutputStream::GZIP;

--- a/DQMServices/Components/src/DQMFileSaver.cc
+++ b/DQMServices/Components/src/DQMFileSaver.cc
@@ -309,6 +309,8 @@ DQMFileSaver::saveForFilterUnit(const std::string& rewrite, int run, int lumi,  
 
   // create the files names
   if (fakeFilterUnitMode_) {
+    // sets the umask to 0, as done by EvF services
+    umask(0);
     std::string runDir = str(boost::format("%s/run%06d") % dirName_ % run);
     std::string baseName = str(boost::format("%s/run%06d_ls%04d_%s") % runDir % run % lumi % stream_label_ );
 

--- a/DQMServices/Components/src/DQMFileSaver.cc
+++ b/DQMServices/Components/src/DQMFileSaver.cc
@@ -664,8 +664,15 @@ DQMFileSaver::globalEndLuminosityBlock(const edm::LuminosityBlock & iLS, const e
           << "Internal error, can save files"
           << " only in ROOT or ProtocolBuffer format.";
     }
-    // store at every lumi section end only if some events have been processed
-    if (convention_ == FilterUnit && fms_->getEventsProcessedForLumi(ilumi) > 0)
+    // Store at every lumi section end only if some events have been processed.
+    // Caveat: if faking FilterUnit, i.e. not accessing DAQ2 services,
+    // we cannot ask FastMonitoringService the processed events, so we are forced
+    // to save the file at every lumisection, even with no statistics.
+    // Here, we protect the call to get the processed events in a lumi section
+    // by testing the pointer to FastMonitoringService: if not null, i.e. in real FU mode,
+    // we check that the events are not 0; otherwise, we skip the test, so we store at every lumi transition. 
+    // TODO(diguida): allow fake FU mode to skip file creation at empty lumi sections.
+    if (convention_ == FilterUnit && (fms_ ? (fms_->getEventsProcessedForLumi(ilumi) > 0) : !fms_))
     {
       char rewrite[128];
       sprintf(rewrite, "\\1Run %d/\\2/By Lumi Section %d-%d", irun, ilumi, ilumi);

--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -2459,8 +2459,10 @@ void DQMStore::savePB(const std::string &filename,
   }
 
   int filedescriptor = ::open(filename.c_str(),
-			      O_WRONLY | O_CREAT | O_TRUNC,
-			      S_IRUSR | S_IWUSR);
+                              O_WRONLY | O_CREAT | O_TRUNC,
+                              S_IRUSR | S_IWUSR |
+                              S_IRGRP | S_IWGRP |
+                              S_IROTH | S_IWOTH);
   FileOutputStream file_stream(filedescriptor);
   GzipOutputStream::Options options;
   options.format = GzipOutputStream::GZIP;


### PR DESCRIPTION
Several fixes to the way files containing DQM `MonitorElement` encoded with `ProtocolBuffer` are created and managed:
- in `DQMFileSaver`, protect a function member call for `FastMonitoringService` pointer by testing whether or not is is a `nullptr`; as a consequence, `ProtocolBuffer` encoded files are saved for non-empty lumisections only in real `FilterUnit` mode;
- in `DQMFileSaver`, when faking `FilterUnit` mode, set explicitly `umask` to `0`: this is done in order to reproduce what DAQ2 services do;
- in `DQMFileSaver`, save files containing DQM `MonitorElement` encoded with `ProtocolBuffer` by explicitly setting permissions to `0666`: in principle, this should be handled by the environment or the OS, but `ProtocolBuffer` examples seem to require explicit file permission handling (see discussion in the code);
- in `fastHadd`, save files merged and encoded with `ProtocolBuffer` by explicitly setting permissions to `0666`: see comment above.
