### PR TITLE
Extra cuts for lumi monitor simulations

### DIFF
--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -137,6 +137,7 @@ g4SimHits = cms.EDProducer("OscarProducer",
         ApplyPhiCuts = cms.bool(False),
         MinPhiCut = cms.double(-3.14159265359), ## (radians)
         MaxPhiCut = cms.double(3.14159265359), ## according to CMS conventions
+        ApplyLumiMonitorCuts = cms.bool(False), ## primary for lumi monitors
         Verbosity = cms.untracked.int32(0)
     ),
     RunAction = cms.PSet(

--- a/SimG4Core/Generators/interface/Generator.h
+++ b/SimG4Core/Generators/interface/Generator.h
@@ -14,6 +14,7 @@
     
 class G4Event;
 class G4PrimaryParticle;
+class LumiMonitorFilter;
 
 class Generator
 {
@@ -53,6 +54,7 @@ private:
   double theEtaCutForHector; 
   double theDecLenCut;
   int verbose;
+  LumiMonitorFilter* fLumiFilter; 
   HepMC::GenEvent*  evt_;
   math::XYZTLorentzVector* vtx_;
   double weight_;    

--- a/SimG4Core/Generators/interface/LumiMonitorFilter.h
+++ b/SimG4Core/Generators/interface/LumiMonitorFilter.h
@@ -1,0 +1,19 @@
+#ifndef SimG4Core_LumiMonitorFilter_H
+#define SimG4Core_LumiMonitorFilter_H
+
+class GenParticle;
+
+class LumiMonitorFilter
+{
+public:
+  LumiMonitorFilter();
+  virtual ~LumiMonitorFilter();
+
+  void Describe() const; 
+  bool isGoodForLumiMonitor(const GenParticle*) const;
+
+private:
+
+};
+
+#endif

--- a/SimG4Core/Generators/interface/LumiMonitorFilter.h
+++ b/SimG4Core/Generators/interface/LumiMonitorFilter.h
@@ -1,7 +1,7 @@
 #ifndef SimG4Core_LumiMonitorFilter_H
 #define SimG4Core_LumiMonitorFilter_H
 
-class GenParticle;
+#include "HepMC/GenParticle.h"
 
 class LumiMonitorFilter
 {
@@ -10,7 +10,7 @@ public:
   virtual ~LumiMonitorFilter();
 
   void Describe() const; 
-  bool isGoodForLumiMonitor(const GenParticle*) const;
+  bool isGoodForLumiMonitor(const HepMC::GenParticle*) const;
 
 private:
 

--- a/SimG4Core/Generators/src/Generator.cc
+++ b/SimG4Core/Generators/src/Generator.cc
@@ -87,7 +87,7 @@ Generator::Generator(const ParameterSet & p) :
     << " cm;  Z_hector = " << Z_hector << " cm\n"
     << "ApplyPCuts: " << fPCuts << "  ApplyPtransCut: " << fPtransCut
     << "  ApplyEtaCuts: " << fEtaCuts 
-    << "  ApplyPhiCuts: " << fPhiCuts;
+    << "  ApplyPhiCuts: " << fPhiCuts
     << "  ApplyLumiMonitorCuts: " << lumi;
   if(lumi) { fLumiFilter->Describe(); }
 }
@@ -311,7 +311,8 @@ void Generator::HepMC2G4(const HepMC::GenEvent * evt, G4Event * g4evt)
 	      continue;
 	    }
 	  }
-	  if(fLumiFilter && !IsGoodForLumiMonitors(*pitr)) { continue; }
+	  if(fLumiFilter && !fLumiFilter->isGoodForLumiMonitor(*pitr)) 
+	    { continue; }
 	  toBeAdded = true;
 	  if ( verbose > 2 ) LogDebug("SimG4CoreGenerator") 
 	    << "GenParticle barcode = " << (*pitr)->barcode() 

--- a/SimG4Core/Generators/src/Generator.cc
+++ b/SimG4Core/Generators/src/Generator.cc
@@ -1,5 +1,6 @@
 #include "SimG4Core/Generators/interface/Generator.h"
 #include "SimG4Core/Generators/interface/HepMCParticle.h"
+#include "SimG4Core/Generators/interface/LumiMonitorFilter.h"
 
 #include "SimG4Core/Notification/interface/SimG4Exception.h"
 
@@ -31,6 +32,7 @@ Generator::Generator(const ParameterSet & p) :
   theMaxPCut(p.getParameter<double>("MaxPCut")),   
   theEtaCutForHector(p.getParameter<double>("EtaCutForHector")),
   verbose(p.getUntrackedParameter<int>("Verbosity",0)),
+  fLumiFilter(0),
   evt_(0),
   vtx_(0),
   weight_(0),
@@ -40,6 +42,9 @@ Generator::Generator(const ParameterSet & p) :
   pdgFilterSel(false), 
   fPDGFilter(false) 
 {
+  bool lumi = p.getParameter<bool>("ApplyLumiMonitorCuts");
+  if(lumi) { fLumiFilter = new LumiMonitorFilter(); }
+
   double theRDecLenCut = p.getParameter<double>("RDecLenCut")*cm;
   theDecRCut2 = theRDecLenCut*theRDecLenCut;
 
@@ -60,8 +65,8 @@ Generator::Generator(const ParameterSet & p) :
 	  edm::LogWarning("SimG4CoreGenerator") 
 	    << " *** Selecting only PDG ID = " << pdgFilter[ii];
 	} else {
-	  edm::LogWarning("SimG4CoreGenerator") << " *** Filtering out PDG ID = " 
-						<< pdgFilter[ii];
+	  edm::LogWarning("SimG4CoreGenerator") 
+	    << " *** Filtering out PDG ID = " << pdgFilter[ii];
 	}
       }
     }
@@ -83,10 +88,14 @@ Generator::Generator(const ParameterSet & p) :
     << "ApplyPCuts: " << fPCuts << "  ApplyPtransCut: " << fPtransCut
     << "  ApplyEtaCuts: " << fEtaCuts 
     << "  ApplyPhiCuts: " << fPhiCuts;
+    << "  ApplyLumiMonitorCuts: " << lumi;
+  if(lumi) { fLumiFilter->Describe(); }
 }
 
 Generator::~Generator() 
-{}
+{
+  delete fLumiFilter;
+}
 
 void Generator::HepMC2G4(const HepMC::GenEvent * evt, G4Event * g4evt)
 {
@@ -302,6 +311,7 @@ void Generator::HepMC2G4(const HepMC::GenEvent * evt, G4Event * g4evt)
 	      continue;
 	    }
 	  }
+	  if(fLumiFilter && !IsGoodForLumiMonitors(*pitr)) { continue; }
 	  toBeAdded = true;
 	  if ( verbose > 2 ) LogDebug("SimG4CoreGenerator") 
 	    << "GenParticle barcode = " << (*pitr)->barcode() 

--- a/SimG4Core/Generators/src/LumiMonitorFilter.cc
+++ b/SimG4Core/Generators/src/LumiMonitorFilter.cc
@@ -2,10 +2,6 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#include "HepMC/GenParticle.h"
-
-#include "G4Event.hh"
-
 using namespace edm;
 //using std::cout;
 //using std::endl;
@@ -16,13 +12,13 @@ LumiMonitorFilter::LumiMonitorFilter()
 LumiMonitorFilter::~LumiMonitorFilter() 
 {}
 
-void LumiMonitorFilter::Describe() 
+void LumiMonitorFilter::Describe() const
 {
   edm::LogInfo("LumiMonitorFilter") 
     << " is active ";
 }
 
-bool LumiMonitorFilter::isGoodForLumiMonitor(const GenParticle*) const
+bool LumiMonitorFilter::isGoodForLumiMonitor(const HepMC::GenParticle*) const
 {
   return true;
 }

--- a/SimG4Core/Generators/src/LumiMonitorFilter.cc
+++ b/SimG4Core/Generators/src/LumiMonitorFilter.cc
@@ -1,0 +1,28 @@
+#include "SimG4Core/Generators/interface/LumiMonitorFilter.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "HepMC/GenParticle.h"
+
+#include "G4Event.hh"
+
+using namespace edm;
+//using std::cout;
+//using std::endl;
+
+LumiMonitorFilter::LumiMonitorFilter() 
+{} 
+
+LumiMonitorFilter::~LumiMonitorFilter() 
+{}
+
+void LumiMonitorFilter::Describe() 
+{
+  edm::LogInfo("LumiMonitorFilter") 
+    << " is active ";
+}
+
+bool LumiMonitorFilter::isGoodForLumiMonitor(const GenParticle*) const
+{
+  return true;
+}


### PR DESCRIPTION
New lumi monitors have small acceptance, so ordinary simulation is very ineffective. In this PR a new filter allowing selection of primary particles is added. By default this filter is not enabled, so no effect for mainstream production.
