### PR TITLE
Fix file creations and permissions for DQM histograms encoded with ProtocolBuffer: second round

### DIFF
--- a/DQMServices/Components/bin/fastHadd.cc
+++ b/DQMServices/Components/bin/fastHadd.cc
@@ -204,7 +204,7 @@ void writeMessage(const dqmstorepb::ROOTFilePB &dqmstore_output_msg,
                       O_WRONLY | O_CREAT | O_TRUNC,
                       S_IRUSR | S_IWUSR |
                       S_IRGRP | S_IWGRP |
-                      S_IROTH | S_IWOTH);
+                      S_IROTH);
   FileOutputStream out_stream(out_fd);
   GzipOutputStream::Options options;
   options.format = GzipOutputStream::GZIP;

--- a/DQMServices/Components/src/DQMFileSaver.cc
+++ b/DQMServices/Components/src/DQMFileSaver.cc
@@ -309,8 +309,6 @@ DQMFileSaver::saveForFilterUnit(const std::string& rewrite, int run, int lumi,  
 
   // create the files names
   if (fakeFilterUnitMode_) {
-    // sets the umask to 0, as done by EvF services
-    umask(0);
     std::string runDir = str(boost::format("%s/run%06d") % dirName_ % run);
     std::string baseName = str(boost::format("%s/run%06d_ls%04d_%s") % runDir % run % lumi % stream_label_ );
 

--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -2462,7 +2462,7 @@ void DQMStore::savePB(const std::string &filename,
                               O_WRONLY | O_CREAT | O_TRUNC,
                               S_IRUSR | S_IWUSR |
                               S_IRGRP | S_IWGRP |
-                              S_IROTH | S_IWOTH);
+                              S_IROTH);
   FileOutputStream file_stream(filedescriptor);
   GzipOutputStream::Options options;
   options.format = GzipOutputStream::GZIP;


### PR DESCRIPTION
Another iteration of the review of file permissions in online DQM, after #4876:
- Do not set `umask` when running DQM modules: this should be set upstream in the process environment;
- in `DQMFileSaver`, save files containing DQM MonitorElement encoded with `ProtocolBuffer` by setting permissions to `0664`: this allows for testing/debugging purposes (files are accessible by all users), and for correctly handling files in DAQ2 (while in the same step, files are handled by the same user, when moved in the data flow chain, files should be handled by users in the same group);
- in `fastHadd`, save files merged and encoded with `ProtocolBuffer` by setting permissions to `0664`: see comment above.

Thanks @rovere for the useful comments, and @smorovic for the discussion on DAQ2 services, and @danduggan for signing again ;-)
