### PR TITLE
Add explicit header that is no longer brought in by default.

### DIFF
--- a/Utilities/XrdAdaptor/src/XrdFile.cc
+++ b/Utilities/XrdAdaptor/src/XrdFile.cc
@@ -7,6 +7,8 @@
 #include <vector>
 #include <sstream>
 
+#include "XrdClient/XrdClientConn.hh"
+
 XrdFile::XrdFile (void)
   : m_client (0),
     m_offset (0),

--- a/Utilities/XrdAdaptor/src/XrdReadv.cc
+++ b/Utilities/XrdAdaptor/src/XrdReadv.cc
@@ -16,6 +16,7 @@
 
 #include "Utilities/XrdAdaptor/src/XrdFile.h"
 #include "XProtocol/XProtocol.hh"
+#include "XrdClient/XrdClientConn.hh"
 #include "XrdClient/XrdClientProtocol.hh"
 #include "XrdClient/XrdClientConst.hh"
 #include "XrdClient/XrdClientSid.hh"


### PR DESCRIPTION
Xrootd 4.0.2 re-arranged some headers; one of the ones we use (XrdClient/XrdClientConn.hh) is now marked as private and no longer implicitly dragged in as part of the XrdClient.hh.  Hence, we must explicitly include it.

This is part of the transition-to-Xrootd-4.0.2 work.  We'll need to use the private headers for awhile to rebase to the latest external (prior to converting the new client).
