### PR TITLE
Coalesce thread_local statics in RunManagerMTWorker into one struct, and change boost::shared_ptr to std:: in SimG4Core

### DIFF
--- a/SimG4Core/Application/interface/OscarMTProducer.h
+++ b/SimG4Core/Application/interface/OscarMTProducer.h
@@ -23,7 +23,7 @@ class OscarMTProducer : public edm::stream::EDProducer<
 >
 {
 public:
-  typedef std::vector<boost::shared_ptr<SimProducer> > Producers;
+  typedef std::vector<std::shared_ptr<SimProducer> > Producers;
 
   explicit OscarMTProducer(edm::ParameterSet const & p, const OscarMTMasterThread *);
   virtual ~OscarMTProducer();

--- a/SimG4Core/Application/interface/OscarProducer.h
+++ b/SimG4Core/Application/interface/OscarProducer.h
@@ -18,7 +18,7 @@
 class OscarProducer : public edm::one::EDProducer<edm::one::SharedResources, edm::one::WatchRuns>
 {
 public:
-  typedef std::vector<boost::shared_ptr<SimProducer> > Producers;
+  typedef std::vector<std::shared_ptr<SimProducer> > Producers;
 
   explicit OscarProducer(edm::ParameterSet const & p);
   virtual ~OscarProducer();

--- a/SimG4Core/Application/interface/RunManager.h
+++ b/SimG4Core/Application/interface/RunManager.h
@@ -17,7 +17,6 @@
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
@@ -85,7 +84,7 @@ public:
   std::vector<SensitiveCaloDetector*>& sensCaloDetectors() { 
     return m_sensCaloDets; 
   }
-  std::vector<boost::shared_ptr<SimProducer> > producers() const {
+  std::vector<std::shared_ptr<SimProducer> > producers() const {
     return m_producers;
   }
 
@@ -149,8 +148,8 @@ private:
   std::vector<SensitiveCaloDetector*> m_sensCaloDets;
 
   SimActivityRegistry m_registry;
-  std::vector<boost::shared_ptr<SimWatcher> > m_watchers;
-  std::vector<boost::shared_ptr<SimProducer> > m_producers;
+  std::vector<std::shared_ptr<SimWatcher> > m_watchers;
+  std::vector<std::shared_ptr<SimProducer> > m_producers;
     
   std::auto_ptr<SimTrackManager> m_trackManager;
   sim::FieldBuilder             *m_fieldBuilder;

--- a/SimG4Core/Application/interface/RunManagerMTWorker.h
+++ b/SimG4Core/Application/interface/RunManagerMTWorker.h
@@ -8,7 +8,6 @@
 #include "SimDataFormats/Forward/interface/LHCTransportLinkContainer.h"
 
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 namespace edm {
   class ParameterSet;
@@ -58,7 +57,7 @@ public:
   SimTrackManager* GetSimTrackManager();
   std::vector<SensitiveTkDetector*>& sensTkDetectors();
   std::vector<SensitiveCaloDetector*>& sensCaloDetectors();
-  std::vector<boost::shared_ptr<SimProducer> > producers();
+  std::vector<std::shared_ptr<SimProducer> > producers();
 
 private:
   void initializeTLS();

--- a/SimG4Core/Application/interface/RunManagerMTWorker.h
+++ b/SimG4Core/Application/interface/RunManagerMTWorker.h
@@ -115,8 +115,8 @@ private:
   std::unique_ptr<G4Event> m_currentEvent;
   std::unique_ptr<G4SimEvent> m_simEvent;
 
-  std::vector<boost::shared_ptr<SimWatcher> > m_watchers;
-  std::vector<boost::shared_ptr<SimProducer> > m_producers;
+  static thread_local std::vector<boost::shared_ptr<SimWatcher> > m_watchers;
+  static thread_local std::vector<boost::shared_ptr<SimProducer> > m_producers;
 };
 
 #endif

--- a/SimG4Core/Application/interface/RunManagerMTWorker.h
+++ b/SimG4Core/Application/interface/RunManagerMTWorker.h
@@ -5,7 +5,6 @@
 #include "DataFormats/Provenance/interface/RunID.h"
 
 #include "SimG4Core/Generators/interface/Generator.h"
-#include "SimG4Core/Notification/interface/SimActivityRegistry.h"
 #include "SimDataFormats/Forward/interface/LHCTransportLinkContainer.h"
 
 #include <memory>
@@ -18,10 +17,6 @@ namespace edm {
   class ConsumesCollector;
   class HepMCProduct;
 }
-namespace sim {
-  class FieldBuilder;
-}
-class CustomUIsession;
 class Generator;
 class RunManagerMT;
 
@@ -34,8 +29,6 @@ class RunAction;
 class EventAction;
 class TrackingAction;
 class SteppingAction;
-
-class SimRunInterface;
 
 class SensitiveTkDetector;
 class SensitiveCaloDetector;
@@ -57,23 +50,18 @@ public:
   void abortRun(bool softAbort=false);
 
   G4SimEvent * simEvent() { return m_simEvent.get(); }
-  SimTrackManager* GetSimTrackManager() { return m_trackManager; }
   void             Connect(RunAction*);
   void             Connect(EventAction*);
   void             Connect(TrackingAction*);
   void             Connect(SteppingAction*);
 
-  std::vector<SensitiveTkDetector*>& sensTkDetectors() {
-    return m_sensTkDets; 
-  }
-  std::vector<SensitiveCaloDetector*>& sensCaloDetectors() {
-    return m_sensCaloDets; 
-  }
-  std::vector<boost::shared_ptr<SimProducer> > producers() {
-    return m_producers;
-  }
+  SimTrackManager* GetSimTrackManager();
+  std::vector<SensitiveTkDetector*>& sensTkDetectors();
+  std::vector<SensitiveCaloDetector*>& sensCaloDetectors();
+  std::vector<boost::shared_ptr<SimProducer> > producers();
 
 private:
+  void initializeTLS();
   void initializeThread(const RunManagerMT& runManagerMaster, const edm::EventSetup& es);
   void initializeUserActions();
 
@@ -82,10 +70,6 @@ private:
 
   G4Event *generateEvent(const edm::Event& inpevt);
   void resetGenParticleId(const edm::Event& inpevt);
-
-  static thread_local bool m_threadInitialized;
-  static thread_local bool m_runTerminated;
-  static thread_local edm::RunNumber_t m_currentRunNumber;
 
   Generator m_generator;
   edm::EDGetTokenT<edm::HepMCProduct> m_InToken;
@@ -101,22 +85,11 @@ private:
   edm::ParameterSet m_pSteppingAction;
   edm::ParameterSet m_p;
 
-  static thread_local std::unique_ptr<CustomUIsession> m_UIsession;
-  static thread_local RunAction *m_userRunAction;
-  static thread_local SimRunInterface *m_runInterface;
-  static thread_local SimActivityRegistry m_registry;
-  static thread_local SimTrackManager *m_trackManager;
-  static thread_local std::vector<SensitiveTkDetector*> m_sensTkDets;
-  static thread_local std::vector<SensitiveCaloDetector*> m_sensCaloDets;
-  static thread_local sim::FieldBuilder *m_fieldBuilder;
-
-  static thread_local G4Run *m_currentRun;
+  struct TLSData;
+  static thread_local TLSData *m_tls;
 
   std::unique_ptr<G4Event> m_currentEvent;
   std::unique_ptr<G4SimEvent> m_simEvent;
-
-  static thread_local std::vector<boost::shared_ptr<SimWatcher> > m_watchers;
-  static thread_local std::vector<boost::shared_ptr<SimProducer> > m_producers;
 };
 
 #endif

--- a/SimG4Core/Application/src/RunManager.cc
+++ b/SimG4Core/Application/src/RunManager.cc
@@ -75,8 +75,8 @@
 static
 void createWatchers(const edm::ParameterSet& iP,
 		    SimActivityRegistry& iReg,
-		    std::vector<boost::shared_ptr<SimWatcher> >& oWatchers,
-		    std::vector<boost::shared_ptr<SimProducer> >& oProds
+		    std::vector<std::shared_ptr<SimWatcher> >& oWatchers,
+		    std::vector<std::shared_ptr<SimProducer> >& oProds
    )
 {
   using namespace std;
@@ -97,8 +97,8 @@ void createWatchers(const edm::ParameterSet& iP,
       throw SimG4Exception("Unable to find the requested Watcher");
     }
     
-    boost::shared_ptr<SimWatcher> watcherTemp;
-    boost::shared_ptr<SimProducer> producerTemp;
+    std::shared_ptr<SimWatcher> watcherTemp;
+    std::shared_ptr<SimProducer> producerTemp;
     maker->make(*itWatcher,iReg,watcherTemp,producerTemp);
     oWatchers.push_back(watcherTemp);
     if(producerTemp) {

--- a/SimG4Core/Application/src/RunManagerMTWorker.cc
+++ b/SimG4Core/Application/src/RunManagerMTWorker.cc
@@ -112,6 +112,8 @@ thread_local std::vector<SensitiveTkDetector*> RunManagerMTWorker::m_sensTkDets;
 thread_local std::vector<SensitiveCaloDetector*> RunManagerMTWorker::m_sensCaloDets;
 thread_local sim::FieldBuilder *RunManagerMTWorker::m_fieldBuilder;
 thread_local G4Run *RunManagerMTWorker::m_currentRun = nullptr;
+thread_local std::vector<boost::shared_ptr<SimWatcher> > RunManagerMTWorker::m_watchers;
+thread_local std::vector<boost::shared_ptr<SimProducer> > RunManagerMTWorker::m_producers;
 
 RunManagerMTWorker::RunManagerMTWorker(const edm::ParameterSet& iConfig, edm::ConsumesCollector&& iC):
   m_generator(iConfig.getParameter<edm::ParameterSet>("Generator")),

--- a/SimG4Core/Application/src/RunManagerMTWorker.cc
+++ b/SimG4Core/Application/src/RunManagerMTWorker.cc
@@ -100,20 +100,24 @@ namespace {
   }
 }
 
-thread_local bool RunManagerMTWorker::m_threadInitialized = false;
-thread_local bool RunManagerMTWorker::m_runTerminated = false;
-thread_local edm::RunNumber_t RunManagerMTWorker::m_currentRunNumber = 0;
-thread_local std::unique_ptr<CustomUIsession> RunManagerMTWorker::m_UIsession;
-thread_local RunAction *RunManagerMTWorker::m_userRunAction = nullptr;
-thread_local SimRunInterface *RunManagerMTWorker::m_runInterface = nullptr;
-thread_local SimActivityRegistry RunManagerMTWorker::m_registry;
-thread_local SimTrackManager *RunManagerMTWorker::m_trackManager = nullptr;
-thread_local std::vector<SensitiveTkDetector*> RunManagerMTWorker::m_sensTkDets;
-thread_local std::vector<SensitiveCaloDetector*> RunManagerMTWorker::m_sensCaloDets;
-thread_local sim::FieldBuilder *RunManagerMTWorker::m_fieldBuilder;
-thread_local G4Run *RunManagerMTWorker::m_currentRun = nullptr;
-thread_local std::vector<boost::shared_ptr<SimWatcher> > RunManagerMTWorker::m_watchers;
-thread_local std::vector<boost::shared_ptr<SimProducer> > RunManagerMTWorker::m_producers;
+struct RunManagerMTWorker::TLSData {
+  std::unique_ptr<CustomUIsession> UIsession;
+  std::unique_ptr<RunAction> userRunAction;
+  std::unique_ptr<SimRunInterface> runInterface;
+  SimActivityRegistry registry;
+  std::unique_ptr<SimTrackManager> trackManager;
+  std::vector<SensitiveTkDetector*> sensTkDets;
+  std::vector<SensitiveCaloDetector*> sensCaloDets;
+  std::vector<boost::shared_ptr<SimWatcher> > watchers;
+  std::vector<boost::shared_ptr<SimProducer> > producers;
+  std::unique_ptr<sim::FieldBuilder> fieldBuilder;
+  std::unique_ptr<G4Run> currentRun;
+  edm::RunNumber_t currentRunNumber = 0;
+  bool threadInitialized = false;
+  bool runTerminated = false;
+};
+
+thread_local RunManagerMTWorker::TLSData *RunManagerMTWorker::m_tls = nullptr;
 
 RunManagerMTWorker::RunManagerMTWorker(const edm::ParameterSet& iConfig, edm::ConsumesCollector&& iC):
   m_generator(iConfig.getParameter<edm::ParameterSet>("Generator")),
@@ -130,18 +134,11 @@ RunManagerMTWorker::RunManagerMTWorker(const edm::ParameterSet& iConfig, edm::Co
   m_pSteppingAction(iConfig.getParameter<edm::ParameterSet>("SteppingAction")),
   m_p(iConfig)
 {
-  edm::Service<SimActivityRegistry> otherRegistry;
-  //Look for an outside SimActivityRegistry
-  // this is used by the visualization code
-  if(otherRegistry){
-    m_registry.connect(*otherRegistry);
-  }
-
-  createWatchers(m_p, m_registry, m_watchers, m_producers);
+  initializeTLS();
 }
 
 RunManagerMTWorker::~RunManagerMTWorker() {
-  if(!m_runTerminated) { terminateRun(); }
+  if(!(m_tls && m_tls->runTerminated)) { terminateRun(); }
   // RunManagerMT has 'delete m_runInterface' in the destructor, but
   // doesn't make much sense here because it is thread_local and we're
   // not guaranteed to run the destructor on each of the threads.
@@ -151,15 +148,31 @@ void RunManagerMTWorker::endRun() {
   terminateRun();
 }
 
+void RunManagerMTWorker::initializeTLS() {
+  if(m_tls)
+    return;
+  m_tls = new TLSData;
+
+  edm::Service<SimActivityRegistry> otherRegistry;
+  //Look for an outside SimActivityRegistry
+  // this is used by the visualization code
+  if(otherRegistry){
+    m_tls->registry.connect(*otherRegistry);
+  }
+
+  createWatchers(m_p, m_tls->registry, m_tls->watchers, m_tls->producers);
+}
+
 void RunManagerMTWorker::initializeThread(const RunManagerMT& runManagerMaster, const edm::EventSetup& es) {
   // I guess everything initialized here should be in thread_local storage
+  initializeTLS();
 
   int thisID = getThreadIndex();
 
   // Initialize per-thread output
   G4Threading::G4SetThreadId( thisID );
   G4UImanager::GetUIpointer()->SetUpForAThread( thisID );
-  m_UIsession.reset(new CustomUIsession());
+  m_tls->UIsession.reset(new CustomUIsession());
 
   // Initialize worker part of shared resources (geometry, physics)
   G4WorkerThread::BuildGeometryAndPhysicsVector();
@@ -172,7 +185,7 @@ void RunManagerMTWorker::initializeThread(const RunManagerMT& runManagerMaster, 
   DDDWorld::WorkerSetAsWorld(runManagerMaster.world().GetWorldVolumeForWorker());
 
   // we need the track manager now
-  m_trackManager = new SimTrackManager();
+  m_tls->trackManager.reset(new SimTrackManager());
 
   // Get DDCompactView, or would it be better to get the object from
   // runManagerMaster instead of EventSetup in here?
@@ -187,11 +200,11 @@ void RunManagerMTWorker::initializeThread(const RunManagerMT& runManagerMaster, 
       edm::ESHandle<MagneticField> pMF;
       es.get<IdealMagneticFieldRecord>().get(pMF);
 
-      m_fieldBuilder = new sim::FieldBuilder(pMF.product(), m_pField);
+      m_tls->fieldBuilder.reset(new sim::FieldBuilder(pMF.product(), m_pField));
       G4TransportationManager * tM =
 	G4TransportationManager::GetTransportationManager();
-      m_fieldBuilder->build( tM->GetFieldManager(),
-			     tM->GetPropagatorInField());
+      m_tls->fieldBuilder->build( tM->GetFieldManager(),
+                                  tM->GetPropagatorInField());
     }
 
 
@@ -203,18 +216,18 @@ void RunManagerMTWorker::initializeThread(const RunManagerMT& runManagerMaster, 
                   (*pDD),
                   runManagerMaster.catalog(),
                   m_p,
-                  m_trackManager,
-                  m_registry);
+                  m_tls->trackManager.get(),
+                  m_tls->registry);
 
-  m_sensTkDets.swap(sensDets.first);
-  m_sensCaloDets.swap(sensDets.second);
+  m_tls->sensTkDets.swap(sensDets.first);
+  m_tls->sensCaloDets.swap(sensDets.second);
 
   edm::LogInfo("SimG4CoreApplication")
     << " RunManagerMTWorker: Sensitive Detector "
     << "building finished; found "
-    << m_sensTkDets.size()
+    << m_tls->sensTkDets.size()
     << " Tk type Producers, and "
-    << m_sensCaloDets.size()
+    << m_tls->sensCaloDets.size()
     << " Calo type producers ";
 
   // Set the physics list for the worker, share from master
@@ -229,7 +242,7 @@ void RunManagerMTWorker::initializeThread(const RunManagerMT& runManagerMaster, 
 
   //tell all interesting parties that we are beginning the job
   BeginOfJob aBeginOfJob(&es);
-  m_registry.beginOfJobSignal_(&aBeginOfJob);
+  m_tls->registry.beginOfJobSignal_(&aBeginOfJob);
 
   initializeUserActions();
 
@@ -241,18 +254,18 @@ void RunManagerMTWorker::initializeThread(const RunManagerMT& runManagerMaster, 
 }
 
 void RunManagerMTWorker::initializeUserActions() {
-  m_runInterface = new SimRunInterface(this, false);
+  m_tls->runInterface.reset(new SimRunInterface(this, false));
 
-  m_userRunAction = new RunAction(m_pRunAction, m_runInterface);
-  m_userRunAction->SetMaster(false);
-  Connect(m_userRunAction);
+  m_tls->userRunAction.reset(new RunAction(m_pRunAction, m_tls->runInterface.get()));
+  m_tls->userRunAction->SetMaster(false);
+  Connect(m_tls->userRunAction.get());
 
   G4RunManagerKernel *kernel = G4WorkerRunManagerKernel::GetRunManagerKernel();
   G4EventManager * eventManager = kernel->GetEventManager();
   eventManager->SetVerboseLevel(m_EvtMgrVerbosity);
 
   EventAction * userEventAction =
-    new EventAction(m_pEventAction, m_runInterface, m_trackManager);
+    new EventAction(m_pEventAction, m_tls->runInterface.get(), m_tls->trackManager.get());
   Connect(userEventAction);
   eventManager->SetUserAction(userEventAction);
 
@@ -273,46 +286,63 @@ void RunManagerMTWorker::initializeUserActions() {
 
 void  RunManagerMTWorker::Connect(RunAction* runAction)
 {
-  runAction->m_beginOfRunSignal.connect(m_registry.beginOfRunSignal_);
-  runAction->m_endOfRunSignal.connect(m_registry.endOfRunSignal_);
+  runAction->m_beginOfRunSignal.connect(m_tls->registry.beginOfRunSignal_);
+  runAction->m_endOfRunSignal.connect(m_tls->registry.endOfRunSignal_);
 }
 
 void  RunManagerMTWorker::Connect(EventAction* eventAction)
 {
-  eventAction->m_beginOfEventSignal.connect(m_registry.beginOfEventSignal_);
-  eventAction->m_endOfEventSignal.connect(m_registry.endOfEventSignal_);
+  eventAction->m_beginOfEventSignal.connect(m_tls->registry.beginOfEventSignal_);
+  eventAction->m_endOfEventSignal.connect(m_tls->registry.endOfEventSignal_);
 }
 
 void  RunManagerMTWorker::Connect(TrackingAction* trackingAction)
 {
-  trackingAction->m_beginOfTrackSignal.connect(m_registry.beginOfTrackSignal_);
-  trackingAction->m_endOfTrackSignal.connect(m_registry.endOfTrackSignal_);
+  trackingAction->m_beginOfTrackSignal.connect(m_tls->registry.beginOfTrackSignal_);
+  trackingAction->m_endOfTrackSignal.connect(m_tls->registry.endOfTrackSignal_);
 }
 
 void  RunManagerMTWorker::Connect(SteppingAction* steppingAction)
 {
-  steppingAction->m_g4StepSignal.connect(m_registry.g4StepSignal_);
+  steppingAction->m_g4StepSignal.connect(m_tls->registry.g4StepSignal_);
 }
 
+SimTrackManager* RunManagerMTWorker::GetSimTrackManager() {
+  initializeTLS();
+  return m_tls->trackManager.get();
+}
+std::vector<SensitiveTkDetector*>& RunManagerMTWorker::sensTkDetectors() {
+  initializeTLS();
+  return m_tls->sensTkDets; 
+}
+std::vector<SensitiveCaloDetector*>& RunManagerMTWorker::sensCaloDetectors() {
+  initializeTLS();
+  return m_tls->sensCaloDets; 
+}
+std::vector<boost::shared_ptr<SimProducer> > RunManagerMTWorker::producers() {
+  initializeTLS();
+  return m_tls->producers;
+}
+
+
 void RunManagerMTWorker::initializeRun() {
-  m_currentRun = new G4Run();
+  m_tls->currentRun.reset(new G4Run());
   G4StateManager::GetStateManager()->SetNewState(G4State_GeomClosed);
-  if (m_userRunAction!=0) { m_userRunAction->BeginOfRunAction(m_currentRun); }
+  if (m_tls->userRunAction) { m_tls->userRunAction->BeginOfRunAction(m_tls->currentRun.get()); }
 }
 
 void RunManagerMTWorker::terminateRun() {
-  if(m_userRunAction) {
-    m_userRunAction->EndOfRunAction(m_currentRun);
-    delete m_userRunAction;
-    m_userRunAction = nullptr;
+  if(m_tls->userRunAction) {
+    m_tls->userRunAction->EndOfRunAction(m_tls->currentRun.get());
+    m_tls->userRunAction.reset();
   }
 
   G4RunManagerKernel *kernel = G4WorkerRunManagerKernel::GetRunManagerKernel();
-  if(!kernel && !m_runTerminated) {
+  if(!kernel && !m_tls->runTerminated) {
     m_currentEvent.reset();
     m_simEvent.reset();
     kernel->RunTermination();
-    m_runTerminated = true;
+    m_tls->runTerminated = true;
   }
 }
 
@@ -325,21 +355,21 @@ void RunManagerMTWorker::produce(const edm::Event& inpevt, const edm::EventSetup
   //
   // We have to do the per-thread initialization, and per-thread
   // per-run initialization here by ourselves. 
-  if(!m_threadInitialized) {
+  if(!(m_tls && m_tls->threadInitialized)) {
     LogDebug("SimG4CoreApplication") << "RunManagerMTWorker::produce(): stream " << inpevt.streamID() << " thread " << getThreadIndex() << " initializing";
     initializeThread(runManagerMaster, es);
-    m_threadInitialized = true;
+    m_tls->threadInitialized = true;
   }
   // Initialize run
-  if(inpevt.id().run() != m_currentRunNumber) {
-    if(m_currentRunNumber != 0 && !m_runTerminated) {
+  if(inpevt.id().run() != m_tls->currentRunNumber) {
+    if(m_tls->currentRunNumber != 0 && !m_tls->runTerminated) {
       // If previous run in this thread was not terminated via endRun() call, terminate it now
       terminateRun();
     }
     initializeRun();
-    m_currentRunNumber = inpevt.id().run();
+    m_tls->currentRunNumber = inpevt.id().run();
   }
-  m_runInterface->setRunManagerMTWorker(this); // For UserActions
+  m_tls->runInterface->setRunManagerMTWorker(this); // For UserActions
 
 
   m_currentEvent.reset(generateEvent(inpevt));
@@ -382,7 +412,7 @@ void RunManagerMTWorker::produce(const edm::Event& inpevt, const edm::EventSetup
 }
 
 void RunManagerMTWorker::abortEvent() {
-  if(m_runTerminated) { return; }
+  if(m_tls->runTerminated) { return; }
   G4RunManagerKernel *kernel = G4WorkerRunManagerKernel::GetRunManagerKernel();
   G4Track* t = kernel->GetEventManager()->GetTrackingManager()->GetTrack();
   t->SetTrackStatus(fStopAndKill) ;
@@ -415,8 +445,7 @@ void RunManagerMTWorker::abortEvent() {
 
 void RunManagerMTWorker::abortRun(bool softAbort) {
   if (!softAbort) { abortEvent(); }
-  delete m_currentRun;
-  m_currentRun = nullptr;
+  m_tls->currentRun.reset();
   terminateRun();
 }
 
@@ -453,6 +482,6 @@ void RunManagerMTWorker::resetGenParticleId(const edm::Event& inpevt)
   edm::Handle<edm::LHCTransportLinkContainer> theLHCTlink;
   inpevt.getByToken( m_theLHCTlinkToken, theLHCTlink );
   if ( theLHCTlink.isValid() ) {
-    m_trackManager->setLHCTransportLink( theLHCTlink.product() );
+    m_tls->trackManager->setLHCTransportLink( theLHCTlink.product() );
   }
 }

--- a/SimG4Core/Application/src/RunManagerMTWorker.cc
+++ b/SimG4Core/Application/src/RunManagerMTWorker.cc
@@ -68,8 +68,8 @@ namespace {
 
   void createWatchers(const edm::ParameterSet& iP,
                       SimActivityRegistry& iReg,
-                      std::vector<boost::shared_ptr<SimWatcher> >& oWatchers,
-                      std::vector<boost::shared_ptr<SimProducer> >& oProds
+                      std::vector<std::shared_ptr<SimWatcher> >& oWatchers,
+                      std::vector<std::shared_ptr<SimProducer> >& oProds
                       )
   {
     using namespace std;
@@ -89,8 +89,8 @@ namespace {
         throw SimG4Exception("Unable to find the requested Watcher");
       }
 
-      boost::shared_ptr<SimWatcher> watcherTemp;
-      boost::shared_ptr<SimProducer> producerTemp;
+      std::shared_ptr<SimWatcher> watcherTemp;
+      std::shared_ptr<SimProducer> producerTemp;
       maker->make(*itWatcher,iReg,watcherTemp,producerTemp);
       oWatchers.push_back(watcherTemp);
       if(producerTemp) {
@@ -108,8 +108,8 @@ struct RunManagerMTWorker::TLSData {
   std::unique_ptr<SimTrackManager> trackManager;
   std::vector<SensitiveTkDetector*> sensTkDets;
   std::vector<SensitiveCaloDetector*> sensCaloDets;
-  std::vector<boost::shared_ptr<SimWatcher> > watchers;
-  std::vector<boost::shared_ptr<SimProducer> > producers;
+  std::vector<std::shared_ptr<SimWatcher> > watchers;
+  std::vector<std::shared_ptr<SimProducer> > producers;
   std::unique_ptr<sim::FieldBuilder> fieldBuilder;
   std::unique_ptr<G4Run> currentRun;
   edm::RunNumber_t currentRunNumber = 0;
@@ -319,7 +319,7 @@ std::vector<SensitiveCaloDetector*>& RunManagerMTWorker::sensCaloDetectors() {
   initializeTLS();
   return m_tls->sensCaloDets; 
 }
-std::vector<boost::shared_ptr<SimProducer> > RunManagerMTWorker::producers() {
+std::vector<std::shared_ptr<SimProducer> > RunManagerMTWorker::producers() {
   initializeTLS();
   return m_tls->producers;
 }

--- a/SimG4Core/GeometryProducer/interface/GeometryProducer.h
+++ b/SimG4Core/GeometryProducer/interface/GeometryProducer.h
@@ -17,7 +17,6 @@
 #include "SimG4Core/SensitiveDetector/interface/SensitiveCaloDetector.h"
 
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 namespace sim { class FieldBuilder; }
 class SimWatcher;
@@ -29,13 +28,13 @@ class SimTrackManager;
 class GeometryProducer : public edm::EDProducer
 {
 public:
-    typedef std::vector<boost::shared_ptr<SimProducer> > Producers;
+    typedef std::vector<std::shared_ptr<SimProducer> > Producers;
     explicit GeometryProducer(edm::ParameterSet const & p);
     virtual ~GeometryProducer();
     virtual void beginJob();
     virtual void endJob();
     virtual void produce(edm::Event & e, const edm::EventSetup & c);
-    std::vector<boost::shared_ptr<SimProducer> > producers() const
+    std::vector<std::shared_ptr<SimProducer> > producers() const
     { return m_producers; }
     std::vector<SensitiveTkDetector*>& sensTkDetectors() { return m_sensTkDets; }
     std::vector<SensitiveCaloDetector*>& sensCaloDetectors() { return m_sensCaloDets; }
@@ -45,8 +44,8 @@ private:
     edm::ParameterSet m_pField;
     bool m_pUseSensitiveDetectors;
     SimActivityRegistry m_registry;
-    std::vector<boost::shared_ptr<SimWatcher> > m_watchers;
-    std::vector<boost::shared_ptr<SimProducer> > m_producers;    
+    std::vector<std::shared_ptr<SimWatcher> > m_watchers;
+    std::vector<std::shared_ptr<SimProducer> > m_producers;
     std::auto_ptr<sim::FieldBuilder> m_fieldBuilder;
     std::auto_ptr<SimTrackManager> m_trackManager;
     AttachSD * m_attach;

--- a/SimG4Core/GeometryProducer/src/GeometryProducer.cc
+++ b/SimG4Core/GeometryProducer/src/GeometryProducer.cc
@@ -30,8 +30,8 @@
 
 static
 void createWatchers(const edm::ParameterSet& iP, SimActivityRegistry& iReg,
-		    std::vector<boost::shared_ptr<SimWatcher> >& oWatchers,
-		    std::vector<boost::shared_ptr<SimProducer> >& oProds)
+		    std::vector<std::shared_ptr<SimWatcher> >& oWatchers,
+		    std::vector<std::shared_ptr<SimProducer> >& oProds)
 {
     using namespace std;
     using namespace edm;
@@ -46,8 +46,8 @@ void createWatchers(const edm::ParameterSet& iP, SimActivityRegistry& iReg,
 	    maker(SimWatcherFactory::get()->create(itWatcher->getParameter<std::string> ("type")));
 	if(maker.get()==0) { throw SimG4Exception("Unable to find the requested Watcher"); }
     
-	boost::shared_ptr<SimWatcher> watcherTemp;
-	boost::shared_ptr<SimProducer> producerTemp;
+	std::shared_ptr<SimWatcher> watcherTemp;
+	std::shared_ptr<SimProducer> producerTemp;
 	maker->make(*itWatcher,iReg,watcherTemp,producerTemp);
 	oWatchers.push_back(watcherTemp);
 	if(producerTemp) oProds.push_back(producerTemp);

--- a/SimG4Core/Watcher/interface/SimProducer.h
+++ b/SimG4Core/Watcher/interface/SimProducer.h
@@ -22,8 +22,8 @@
 #include <algorithm>
 #include <string>
 #include <vector>
-#include "boost/bind.hpp"
-#include "boost/shared_ptr.hpp"
+#include <functional>
+#include <memory>
 
 // user include files
 #include "SimG4Core/Watcher/interface/SimWatcher.h"
@@ -79,7 +79,7 @@ class SimProducer : public SimWatcher
       
       void registerProducts(edm::ProducerBase& iProd) {
 	 std::for_each(m_info.begin(), m_info.end(),
-		       boost::bind(&simproducer::ProductInfoBase::registerProduct,_1, &iProd));
+                       std::bind(&simproducer::ProductInfoBase::registerProduct, std::placeholders::_1, &iProd));
       }
    protected:
       template<class T>
@@ -90,7 +90,7 @@ class SimProducer : public SimWatcher
       template<class T>
       void produces(const std::string& instanceName) {
 	 m_info.push_back( 
-			  boost::shared_ptr<simproducer::ProductInfo<T> >(new simproducer::ProductInfo<T>(instanceName) ));
+			  std::make_shared<simproducer::ProductInfo<T> >(instanceName) );
       }
 
    private:
@@ -99,7 +99,7 @@ class SimProducer : public SimWatcher
       const SimProducer& operator=(const SimProducer&); // stop default
 
       // ---------- member data --------------------------------
-      std::vector<boost::shared_ptr< simproducer::ProductInfoBase> > m_info;
+      std::vector<std::shared_ptr< simproducer::ProductInfoBase> > m_info;
 };
 
 

--- a/SimG4Core/Watcher/interface/SimWatcherMaker.h
+++ b/SimG4Core/Watcher/interface/SimWatcherMaker.h
@@ -37,11 +37,11 @@ class SimWatcherMaker : public SimWatcherMakerBase
       // ---------- const member functions ---------------------
       virtual void make(const edm::ParameterSet& p,
 			SimActivityRegistry& reg,
-			boost::shared_ptr<SimWatcher>& oWatcher,
-			boost::shared_ptr<SimProducer>& oProd
+			std::shared_ptr<SimWatcher>& oWatcher,
+			std::shared_ptr<SimProducer>& oProd
 	 ) const
       {
-	boost::shared_ptr<T> returnValue(new T(p));
+	std::shared_ptr<T> returnValue(new T(p));
 	SimActivityRegistryEnroller::enroll(reg, returnValue.get());
 	oWatcher = returnValue;
 
@@ -50,13 +50,13 @@ class SimWatcherMaker : public SimWatcherMakerBase
       }
 
    private:
-      boost::shared_ptr<SimProducer>
-      getSimProducer(SimProducer*, boost::shared_ptr<T>& iProd) const{
-	 return boost::shared_ptr<SimProducer>(iProd);
+      std::shared_ptr<SimProducer>
+      getSimProducer(SimProducer*, std::shared_ptr<T>& iProd) const{
+	 return std::shared_ptr<SimProducer>(iProd);
       }
-      boost::shared_ptr<SimProducer>
-      getSimProducer(void*, boost::shared_ptr<T>& iProd) const{
-	 return boost::shared_ptr<SimProducer>();
+      std::shared_ptr<SimProducer>
+      getSimProducer(void*, std::shared_ptr<T>& iProd) const{
+	 return std::shared_ptr<SimProducer>();
       }
 
 };

--- a/SimG4Core/Watcher/interface/SimWatcherMakerBase.h
+++ b/SimG4Core/Watcher/interface/SimWatcherMakerBase.h
@@ -20,7 +20,7 @@
 //
 
 // system include files
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 // user include files
 
@@ -41,8 +41,8 @@ class SimWatcherMakerBase
       // ---------- const member functions ---------------------
       virtual void make(const edm::ParameterSet&,
 			SimActivityRegistry&,
-			boost::shared_ptr<SimWatcher>&,
-			boost::shared_ptr<SimProducer>&
+			std::shared_ptr<SimWatcher>&,
+			std::shared_ptr<SimProducer>&
 	 ) const = 0;
 };
 


### PR DESCRIPTION
Coalesce the many thread_local statics in RunManagerMTWorker into a single thread_local struct.

In addition, change all boost::shared_ptr's to std::shared_ptr in SimG4Core.

No changes in physics is expected. Tested in CMSSW_7_2_GEANT10_X_2014-08-03-1400 with 100 TTBar events (wf 1302.0 step1), SIM-step gives identical results (runEdmFileComparison.py) before and after this PR for both OscarProducer and OscarMTProducer with 1 thread.
