### PR TITLE
reading event id from EVM FED

### DIFF
--- a/EventFilter/Utilities/plugins/DaqFakeReader.h
+++ b/EventFilter/Utilities/plugins/DaqFakeReader.h
@@ -48,8 +48,10 @@ private:
 		FEDRawDataCollection& data,
 		float meansize,
 		float width);
+  void fillGTPFED(edm::EventID& eID,
+		   FEDRawDataCollection& data,timeval * now);
   void fillFED1023(edm::EventID& eID,
-		   FEDRawDataCollection& data);
+		   FEDRawDataCollection& data,timeval * now);
   virtual void beginLuminosityBlock(edm::LuminosityBlock const& iL, edm::EventSetup const& iE);
  private:
   //
@@ -62,6 +64,7 @@ private:
   unsigned int        width;
   unsigned int        injected_errors_per_million_events;
   unsigned int        modulo_error_events;
+  unsigned int        fakeLs_=0;
   evf::EvffedFillerRB frb;
 };
 

--- a/EventFilter/Utilities/plugins/FRDStreamSource.cc
+++ b/EventFilter/Utilities/plugins/FRDStreamSource.cc
@@ -16,7 +16,8 @@
 FRDStreamSource::FRDStreamSource(edm::ParameterSet const& pset,
                                           edm::InputSourceDescription const& desc)
   : ProducerSourceFromFiles(pset,desc,true),
-    verifyAdler32_(pset.getUntrackedParameter<bool> ("verifyAdler32", true))
+    verifyAdler32_(pset.getUntrackedParameter<bool> ("verifyAdler32", true)),
+    useL1EventID_(pset.getUntrackedParameter<bool> ("useL1EventID", false))
 {
   itFileName_=fileNames().begin();
   openFile(*itFileName_);
@@ -55,7 +56,8 @@ bool FRDStreamSource::setRunAndEventInfo(edm::EventID& id, edm::TimeValue_t& the
   }
 
   std::unique_ptr<FRDEventMsgView> frdEventMsg(new FRDEventMsgView(&buffer_[0]));
-  id = edm::EventID(frdEventMsg->run(), frdEventMsg->lumi(), frdEventMsg->event());
+  if (useL1EventID_)
+    id = edm::EventID(frdEventMsg->run(), frdEventMsg->lumi(), frdEventMsg->event());
 
   const uint32_t totalSize = frdEventMsg->size();
   if ( totalSize > buffer_.size() ) {
@@ -86,6 +88,7 @@ bool FRDStreamSource::setRunAndEventInfo(edm::EventID& id, edm::TimeValue_t& the
 
   uint32_t eventSize = frdEventMsg->eventSize();
   char* event = (char*)frdEventMsg->payload();
+  bool foundGTPFED=false;
 
   while (eventSize > 0) {
     eventSize -= sizeof(fedt_t);
@@ -95,10 +98,24 @@ bool FRDStreamSource::setRunAndEventInfo(edm::EventID& id, edm::TimeValue_t& the
     const fedh_t* fedHeader = (fedh_t *) (event + eventSize);
     const uint16_t fedId = FED_SOID_EXTRACT(fedHeader->sourceid);
     if (fedId == FEDNumbering::MINTriggerGTPFEDID) {
-      evf::evtn::evm_board_setformat(fedSize);
+      foundGTPFED=true;
+      const bool GTPEvmBoardSense=evf::evtn::evm_board_sense((unsigned char*) fedHeader,fedSize);
+      if (!useL1EventID_) {
+        if (GTPEvmBoardSense)
+          id = edm::EventID(frdEventMsg->run(), frdEventMsg->lumi(), evf::evtn::get((unsigned char*) fedHeader,true));
+        else
+          id = edm::EventID(frdEventMsg->run(), frdEventMsg->lumi(), evf::evtn::get((unsigned char*) fedHeader,false));
+      }
+      //evf::evtn::evm_board_setformat(fedSize);
       const uint64_t gpsl = evf::evtn::getgpslow((unsigned char*) fedHeader);
       const uint64_t gpsh = evf::evtn::getgpshigh((unsigned char*) fedHeader);
       theTime = static_cast<edm::TimeValue_t>((gpsh << 32) + gpsl);
+    }
+    //take event ID from GTPE FED
+    if (fedId == FEDNumbering::MINTriggerEGTPFEDID && !foundGTPFED && !useL1EventID_) {
+      if (evf::evtn::gtpe_board_sense((unsigned char*)fedHeader)) {
+        id = edm::EventID(frdEventMsg->run(), frdEventMsg->lumi(), evf::evtn::gtpe_get((unsigned char*) fedHeader));
+      }
     }
     FEDRawData& fedData = rawData_->FEDData(fedId);
     fedData.resize(fedSize);

--- a/EventFilter/Utilities/plugins/FRDStreamSource.h
+++ b/EventFilter/Utilities/plugins/FRDStreamSource.h
@@ -46,6 +46,7 @@ private:
   std::auto_ptr<FEDRawDataCollection> rawData_;
   std::vector<char> buffer_;
   const bool verifyAdler32_;
+  const bool useL1EventID_;
   unsigned int detectedFRDversion_=0;
 };
 

--- a/EventFilter/Utilities/plugins/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/plugins/FedRawDataInputSource.cc
@@ -229,7 +229,7 @@ bool FedRawDataInputSource::checkNextEvent()
           maybeOpenNewLumiSection( event_->lumi() );
 	}
       }
-      eventID_ = edm::EventID(event_->run(), currentLumiSection_, event_->event());
+      eventRunNumber_=event_->run();
 
       setEventCached();
 
@@ -407,8 +407,9 @@ inline evf::EvFDaqDirector::FileStatus FedRawDataInputSource::getNextEvent()
 
     unsigned char *dataPosition = currentFile_->chunks_[0]->buf_+ currentFile_->chunkPosition_;
 
-
-    if (!bufferInputRead_ || bufferInputRead_ < headerSize[detectedFRDversion_])
+    //conditions when read amount is not sufficient for the header to fit
+    if (!bufferInputRead_ || bufferInputRead_ < headerSize[detectedFRDversion_] 
+       ||  eventChunkSize_ - currentFile_->chunkPosition_ < headerSize[detectedFRDversion_])
     {
       readNextChunkIntoBuffer(currentFile_);
 
@@ -559,10 +560,13 @@ void FedRawDataInputSource::deleteFile(std::string const& fileName)
   }
 }
 
+
 void FedRawDataInputSource::read(edm::EventPrincipal& eventPrincipal)
 {
   std::auto_ptr<FEDRawDataCollection> rawData(new FEDRawDataCollection);
   edm::Timestamp tstamp = fillFEDRawDataCollection(rawData);
+
+  eventID_ = edm::EventID(eventRunNumber_, currentLumiSection_, GTEventID_);
 
   edm::EventAuxiliary aux(eventID_, processGUID(), tstamp, true,
                           edm::EventAuxiliary::PhysicsTrigger);
@@ -608,11 +612,12 @@ void FedRawDataInputSource::read(edm::EventPrincipal& eventPrincipal)
   return;
 }
 
-edm::Timestamp FedRawDataInputSource::fillFEDRawDataCollection(std::auto_ptr<FEDRawDataCollection>& rawData) const
+edm::Timestamp FedRawDataInputSource::fillFEDRawDataCollection(std::auto_ptr<FEDRawDataCollection>& rawData)
 {
   edm::Timestamp tstamp;
   uint32_t eventSize = event_->eventSize();
   char* event = (char*)event_->payload();
+  GTEventID_=0;
 
   while (eventSize > 0) {
     eventSize -= sizeof(fedt_t);
@@ -622,10 +627,20 @@ edm::Timestamp FedRawDataInputSource::fillFEDRawDataCollection(std::auto_ptr<FED
     const fedh_t* fedHeader = (fedh_t *) (event + eventSize);
     const uint16_t fedId = FED_SOID_EXTRACT(fedHeader->sourceid);
     if (fedId == FEDNumbering::MINTriggerGTPFEDID) {
-      evf::evtn::evm_board_setformat(fedSize);
+      if (evf::evtn::evm_board_sense((unsigned char*) fedHeader,fedSize))
+          GTEventID_ = evf::evtn::get((unsigned char*) fedHeader,true);
+      else
+          GTEventID_ = evf::evtn::get((unsigned char*) fedHeader,false);
+      //evf::evtn::evm_board_setformat(fedSize);
       const uint64_t gpsl = evf::evtn::getgpslow((unsigned char*) fedHeader);
       const uint64_t gpsh = evf::evtn::getgpshigh((unsigned char*) fedHeader);
       tstamp = edm::Timestamp(static_cast<edm::TimeValue_t> ((gpsh << 32) + gpsl));
+    }
+    //take event ID from GTPE FED
+    if (fedId == FEDNumbering::MINTriggerEGTPFEDID && GTEventID_==0) {
+      if (evf::evtn::gtpe_board_sense((unsigned char*)fedHeader)) {
+        GTEventID_ = evf::evtn::gtpe_get((unsigned char*) fedHeader);
+      }
     }
     FEDRawData& fedData = rawData->FEDData(fedId);
     fedData.resize(fedSize);

--- a/EventFilter/Utilities/plugins/FedRawDataInputSource.h
+++ b/EventFilter/Utilities/plugins/FedRawDataInputSource.h
@@ -85,6 +85,7 @@ private:
   // get LS from filename instead of event header
   const bool getLSFromFilename_;
   const bool verifyAdler32_;
+  const bool useL1EventID_;
   const bool testModeNoBuilderUnit_;
 
   const edm::RunNumber_t runNumber_;
@@ -100,7 +101,8 @@ private:
 
   unsigned int currentLumiSection_;
   uint32_t eventRunNumber_=0;
-  uint32_t GTEventID_ = 0;
+  uint32_t GTPEventID_ = 0;
+  uint32_t L1EventID_ = 0;
   unsigned int eventsThisLumi_;
   unsigned long eventsThisRun_ = 0;
 

--- a/EventFilter/Utilities/plugins/FedRawDataInputSource.h
+++ b/EventFilter/Utilities/plugins/FedRawDataInputSource.h
@@ -57,7 +57,7 @@ private:
   void maybeOpenNewLumiSection(const uint32_t lumiSection);
   evf::EvFDaqDirector::FileStatus nextEvent();
   evf::EvFDaqDirector::FileStatus getNextEvent();
-  edm::Timestamp fillFEDRawDataCollection(std::auto_ptr<FEDRawDataCollection>&) const;
+  edm::Timestamp fillFEDRawDataCollection(std::auto_ptr<FEDRawDataCollection>&);
   void deleteFile(std::string const&);
   int grabNextJsonFile(boost::filesystem::path const&);
   void renameToNextFree(std::string const& fileName) const;
@@ -99,6 +99,8 @@ private:
   edm::ProcessHistoryID processHistoryID_;
 
   unsigned int currentLumiSection_;
+  uint32_t eventRunNumber_=0;
+  uint32_t GTEventID_ = 0;
   unsigned int eventsThisLumi_;
   unsigned long eventsThisRun_ = 0;
 

--- a/EventFilter/Utilities/python/FedRawDataInputSource_cfi.py
+++ b/EventFilter/Utilities/python/FedRawDataInputSource_cfi.py
@@ -2,9 +2,9 @@ import FWCore.ParameterSet.Config as cms
 
 source = cms.Source("FedRawDataInputSource",
     getLSFromFilename = cms.untracked.bool(True),
-    eventChunkSize = cms.untracked.uint32(128),
-    eventChunkBlock = cms.untracked.uint32(128),
-    numBuffers = cms.untracked.uint32(1),
+    eventChunkSize = cms.untracked.uint32(32),
+    eventChunkBlock = cms.untracked.uint32(32),
+    numBuffers = cms.untracked.uint32(2),
     verifyAdler32 = cms.untracked.bool(True)
     )
 

--- a/EventFilter/Utilities/python/FedRawDataInputSource_cfi.py
+++ b/EventFilter/Utilities/python/FedRawDataInputSource_cfi.py
@@ -5,6 +5,7 @@ source = cms.Source("FedRawDataInputSource",
     eventChunkSize = cms.untracked.uint32(32),
     eventChunkBlock = cms.untracked.uint32(32),
     numBuffers = cms.untracked.uint32(2),
-    verifyAdler32 = cms.untracked.bool(True)
+    verifyAdler32 = cms.untracked.bool(True),
+    useL1EventID = cms.untracked.bool(False)
     )
 

--- a/EventFilter/Utilities/test/startFU.py
+++ b/EventFilter/Utilities/test/startFU.py
@@ -88,6 +88,7 @@ process.source = cms.Source("FedRawDataInputSource",
     getLSFromFilename = cms.untracked.bool(True),
     testModeNoBuilderUnit = cms.untracked.bool(False),
     verifyAdler32 = cms.untracked.bool(True),
+    useL1EventID = cms.untracked.bool(False),
     eventChunkSize = cms.untracked.uint32(16),
     numBuffers = cms.untracked.uint32(2),
     eventChunkBlock = cms.untracked.uint32(1)


### PR DESCRIPTION
Hi,
These are changes/bugfixes from MWGR3:
- reading 32 bit event ID from GTP (EVM) FED. useL1EventID parameter is provided for switching back to 24-bit ID (if there are problems with runs where TCDS is used)
- added generation of this FED & event ID to Fake BU generator source
- fix for buffering code when using single input buffer in input source
