### PR TITLE
Shashlik Fixes -> re-add ECAL driven seeding + split off mustache photons

### DIFF
--- a/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
@@ -1036,8 +1036,9 @@ void GsfElectronAlgo::setCutBasedPreselectionFlag( GsfElectron * ele, const reco
   int component = seedCluster.hitsAndFractions()[0].first.det();
   int detector = seedCluster.hitsAndFractions()[0].first.subdetId() ;
   bool HoEveto = false ;
-  if (detector==EcalBarrel && (had<cfg->maxHBarrel || (had/ele->superCluster()->energy())<cfg->maxHOverEBarrel)) HoEveto=true;
-  else if (detector==EcalEndcap && (had<cfg->maxHEndcaps || (had/ele->superCluster()->energy())<cfg->maxHOverEEndcaps)) HoEveto=true;
+  if (component== DetId::Ecal && detector==EcalBarrel && (had<cfg->maxHBarrel || (had/ele->superCluster()->energy())<cfg->maxHOverEBarrel)) HoEveto=true;
+  else if (component== DetId::Ecal && detector==EcalEndcap && (had<cfg->maxHEndcaps || (had/ele->superCluster()->energy())<cfg->maxHOverEEndcaps)) HoEveto=true;
+  else if (component== DetId::Ecal && detector==EcalShashlik && (had<cfg->maxHEndcaps || (had/ele->superCluster()->energy())<cfg->maxHOverEEndcaps)) HoEveto=true;
   else if (component== DetId::Forward && detector==HGCEE && (had<cfg->maxHEndcaps || (had/ele->superCluster()->energy())<cfg->maxHOverEEndcaps)) HoEveto=true;
   if ( !HoEveto ) return ;
   LogTrace("GsfElectronAlgo") << "H/E criteria are satisfied";

--- a/RecoEgamma/EgammaElectronProducers/plugins/ElectronSeedProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/ElectronSeedProducer.cc
@@ -241,19 +241,19 @@ void ElectronSeedProducer::filterClusters
     float sclPt = scl.energy()/cosh(sclEta);
     int detector = scl.seed()->hitsAndFractions()[0].first.subdetId() ;
     //if (scl.energy()/cosh(sclEta)>SCEtCut_)
-    if ((sclPt > SCEtCutBarrel_ and detector == EcalBarrel) or (sclPt > SCEtCutEndcap_ and detector == EcalEndcap))
+    if ((sclPt > SCEtCutBarrel_ && detector == EcalBarrel) || (sclPt > SCEtCutEndcap_ && (detector == EcalEndcap || detector==EcalShashlik || detector == HGCEE) ))
       {
 //      if ((applyHOverECut_==true)&&((hcalHelper_->hcalESum(scl)/scl.energy()) > maxHOverE_))
 //       { continue ; }
 //      sclRefs.push_back(edm::Ref<reco::SuperClusterCollection>(superClusters,i)) ;
-       double had1, had2, had, scle ;
+	double had1(0), had2(0), had(0), scle(0) ;
        bool HoeVeto = false ;
        if (applyHOverECut_)
         {
 	  if (detector==EcalBarrel) {
 	    had1 = hcalHelperBarrel_->hcalESumDepth1(scl);
 	    had2 = hcalHelperBarrel_->hcalESumDepth2(scl);
-	  } else if (detector==EcalEndcap) {
+	  } else if (detector==EcalEndcap || detector==EcalShashlik) {
 	    had1 = hcalHelperEndcap_->hcalESumDepth1(scl);
 	    had2 = hcalHelperEndcap_->hcalESumDepth2(scl);
 	  }
@@ -261,9 +261,9 @@ void ElectronSeedProducer::filterClusters
          scle = scl.energy() ;
 	 int component = scl.seed()->hitsAndFractions()[0].first.det() ;
          //int detector = scl.seed()->hitsAndFractions()[0].first.subdetId() ;
-         if (detector==EcalBarrel && (had<maxHBarrel_ || had/scle<maxHOverEBarrel_)) HoeVeto=true;
-         else if (detector==EcalEndcap && fabs(sclEta) < 2.65 && (had<maxHEndcaps_ || had/scle<maxHOverEEndcaps_)) HoeVeto=true;
-         else if (detector==EcalEndcap && fabs(sclEta) > 2.65 && (had<maxHEndcaps_ || had/scle<maxHOverEOuterEndcaps_)) HoeVeto=true;
+         if (component==DetId::Ecal && detector==EcalBarrel && (had<maxHBarrel_ || had/scle<maxHOverEBarrel_)) HoeVeto=true;
+         else if (component==DetId::Ecal && (detector==EcalEndcap || detector==EcalShashlik ) && fabs(sclEta) < 2.65 && (had<maxHEndcaps_ || had/scle<maxHOverEEndcaps_)) HoeVeto=true;
+         else if (component==DetId::Ecal && (detector==EcalEndcap || detector==EcalShashlik ) && fabs(sclEta) > 2.65 && (had<maxHEndcaps_ || had/scle<maxHOverEOuterEndcaps_)) HoeVeto=true;
 	 else if (component==DetId::Forward && detector==HGCEE && (had<maxHEndcaps_ || had/scle<maxHOverEEndcaps_)) HoeVeto=true;
          if (HoeVeto)
           {

--- a/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
@@ -159,10 +159,19 @@ def cust_2023SHCal(process):
         process.particleFlowClusterECAL.inputECAL = cms.InputTag('particleFlowClusterEBEKMerger')
         process.particleFlowCluster += process.pfClusteringEK
         
-        process.photonCore.scHybridBarrelProducer = cms.InputTag("particleFlowSuperClusterECAL","particleFlowSuperClusterECALBarrel")
-        process.photonCore.scIslandEndcapProducer = cms.InputTag("particleFlowSuperClusterECAL","particleFlowSuperClusterECALEndcapWithPreshower")        
-        process.photons.endcapEcalHits = cms.InputTag("ecalRecHit","EcalRecHitsEK")
+        #clone photons to mustache photons so we can compare back to old reco
+        process.mustachePhotonCore = process.photonCore.clone(scHybridBarrelProducer = cms.InputTag("particleFlowSuperClusterECAL","particleFlowSuperClusterECALBarrel"),scIslandEndcapProducer = cms.InputTag("particleFlowSuperClusterECAL","particleFlowSuperClusterECALEndcapWithPreshower"))
+        process.mustachePhotons = process.photons.clone(photonCoreProducer = cms.InputTag('mustachePhotonCore'), endcapEcalHits = cms.InputTag("ecalRecHit","EcalRecHitsEK"))        
+        process.photonSequence += process.mustachePhotonCore
+        process.photonSequence += process.mustachePhotons
+        #point particle flow at the right photon collection     
+        process.particleFlowBlock.elementImporters[2].source = cms.InputTag('mustachePhotons')
         process.gedPhotons.endcapEcalHits = cms.InputTag("ecalRecHit","EcalRecHitsEK")
+        
+
+        if( hasattr(process,'FEVTDEBUGHLToutput') ):
+            process.FEVTDEBUGHLToutput.outputCommands.append('keep *_mustachePhotonCore_*_*')
+            process.FEVTDEBUGHLToutput.outputCommands.append('keep *_mustachePhotons_*_*')
         
         process.towerMaker.ecalInputs = cms.VInputTag(cms.InputTag("ecalRecHit","EcalRecHitsEB"), cms.InputTag("ecalRecHit","EcalRecHitsEK"))
         process.towerMakerPF.ecalInputs = cms.VInputTag(cms.InputTag("ecalRecHit","EcalRecHitsEB"), cms.InputTag("ecalRecHit","EcalRecHitsEK"))
@@ -209,6 +218,7 @@ def cust_2023SHCal(process):
         process.pfElectronInterestingEcalDetIdEE.recHitsLabel = cms.InputTag("ecalRecHit","EcalRecHitsEK")
         process.pfPhotonInterestingEcalDetIdEE.recHitsLabel = cms.InputTag("ecalRecHit","EcalRecHitsEK")
         process.pfPhotonTranslator.endcapEcalHits = cms.InputTag("ecalRecHit","EcalRecHitsEK")
+        process.pfPhotonTranslator.EGPhotons = cms.string("mustachePhotons")
         process.photons.mipVariableSet.endcapEcalRecHitCollection = cms.InputTag("ecalRecHit","EcalRecHitsEK")
         process.photons.isolationSumsCalculatorSet.endcapEcalRecHitCollection = cms.InputTag("ecalRecHit","EcalRecHitsEK")
         process.uncleanedOnlyConversionTrackCandidates.endcapEcalRecHitCollection = cms.InputTag("ecalRecHit","EcalRecHitsEK")


### PR DESCRIPTION
This PR turns the ECAL driven seeding for Shashlik (and HGCAL) on again. 
It was somehow turned off in a few previous patches.

The photons collection is now split between "photons" (old clusters reco) and "mustachePhotons" which uses the output of the mustache super clustering. Only the latter contains photons in the shashlik device.

This can be put in a patch release since it only edits .cc and python.

@nancymarinelli @dbenedet @matteosan1
