### PR TITLE
Pf2 stream

### DIFF
--- a/CalibFormats/HcalObjects/interface/HcalDbService.h
+++ b/CalibFormats/HcalObjects/interface/HcalDbService.h
@@ -89,8 +89,8 @@ class HcalDbService {
   const HcalPFCorrs* mPFCorrs;
   const HcalLutMetadata* mLutMetadata;
   //  bool mPedestalInADC;
-  mutable std::atomic<HcalCalibrationsSet*> mCalibSet;
-  mutable std::atomic<HcalCalibrationWidthsSet*> mCalibWidthSet;
+  mutable std::atomic<HcalCalibrationsSet const *> mCalibSet;
+  mutable std::atomic<HcalCalibrationWidthsSet const *> mCalibWidthSet;
 };
 
 #endif

--- a/CalibFormats/HcalObjects/src/HcalDbService.cc
+++ b/CalibFormats/HcalObjects/src/HcalDbService.cc
@@ -71,9 +71,9 @@ void HcalDbService::buildCalibrations() const {
         //    std::cout << "Hcal calibrations built... detid no. " << HcalGenericDetId(*id) << std::endl;
       }
       ptr->sort();
-
-      HcalCalibrationsSet* expect = nullptr;
-      bool exchanged = mCalibSet.compare_exchange_strong(expect, ptr, std::memory_order_acq_rel);
+      HcalCalibrationsSet const * cptr = ptr;
+      HcalCalibrationsSet const * expect = nullptr;
+      bool exchanged = mCalibSet.compare_exchange_strong(expect, cptr, std::memory_order_acq_rel);
       if(!exchanged) {
           delete ptr;
       }
@@ -103,8 +103,9 @@ void HcalDbService::buildCalibWidths() const {
       }
       ptr->sort();
 
-      HcalCalibrationWidthsSet* expect = nullptr;
-      bool exchanged = mCalibWidthSet.compare_exchange_strong(expect, ptr, std::memory_order_acq_rel);
+      HcalCalibrationWidthsSet const *  cptr =	ptr;
+      HcalCalibrationWidthsSet const * expect = nullptr;
+      bool exchanged = mCalibWidthSet.compare_exchange_strong(expect, cptr, std::memory_order_acq_rel);
       if(!exchanged) {
           delete ptr;
       }

--- a/CondFormats/HcalObjects/interface/HcalCondObjectContainer.h
+++ b/CondFormats/HcalObjects/interface/HcalCondObjectContainer.h
@@ -9,6 +9,9 @@
 #include "DataFormats/HcalDetId/interface/HcalCastorDetId.h"
 #include "DataFormats/HcalDetId/interface/HcalZDCDetId.h"
 #include "FWCore/Utilities/interface/Exception.h"
+#ifndef __GCCXML__
+#include<atomic>
+#endif
 
 class HcalTopology;
 
@@ -19,8 +22,14 @@ public:
   const HcalTopology* topo() const { return topo_; }
   int getCreatorPackedIndexVersion() const { return packedIndexVersion_; }
   void setTopo(const HcalTopology* topo) const;
-  void setTopo(const HcalTopology* topo);
 protected:
+  HcalCondObjectContainerBase(HcalCondObjectContainerBase const & o) : packedIndexVersion_(o.packedIndexVersion_), topo_(o.topo()) {}
+  HcalCondObjectContainerBase & operator = (HcalCondObjectContainerBase const & o) {  topo_=o.topo();	packedIndexVersion_=o.packedIndexVersion_; return *this;}
+#ifndef __GCCXML__
+  HcalCondObjectContainerBase(HcalCondObjectContainerBase &&) = default;
+  HcalCondObjectContainerBase & operator = (HcalCondObjectContainerBase &&) = default;
+#endif
+
   HcalCondObjectContainerBase(const HcalTopology*);
   unsigned int indexFor(DetId) const;
   unsigned int sizeFor(DetId) const;
@@ -28,7 +37,11 @@ protected:
   inline HcalOtherSubdetector extractOther(const DetId& id) const { return HcalOtherSubdetector((id.rawId()>>20)&0x1F); }
   std::string textForId(const DetId& id) const;
 private:
+#ifndef __GCCXML__
+  mutable std::atomic<const HcalTopology*> topo_ COND_TRANSIENT;
+#else
   mutable const HcalTopology* topo_ COND_TRANSIENT;
+#endif
 
   COND_SERIALIZABLE;
 };
@@ -85,9 +98,6 @@ public:
   std::vector<Item> CALIBcontainer;
   std::vector<Item> CASTORcontainer;
   
-  //volatile const HcalTopology* topo_; // This needs to not be in the DB
-
-
 
  COND_SERIALIZABLE;
 };

--- a/CondFormats/HcalObjects/src/HcalCondObjectContainerBase.cc
+++ b/CondFormats/HcalObjects/src/HcalCondObjectContainerBase.cc
@@ -9,7 +9,7 @@
 #include "FWCore/Utilities/interface/Exception.h"
 
 HcalCondObjectContainerBase::HcalCondObjectContainerBase(const HcalTopology* topo) : packedIndexVersion_(0), topo_(topo) { 
-  if (topo_) packedIndexVersion_=topo_->topoVersion();
+  if (topo) packedIndexVersion_=topo->topoVersion();
 }
 
 void HcalCondObjectContainerBase::setTopo(const HcalTopology* topo) const {
@@ -18,16 +18,10 @@ void HcalCondObjectContainerBase::setTopo(const HcalTopology* topo) const {
   }
   topo_=topo;
 }
-void HcalCondObjectContainerBase::setTopo(const HcalTopology* topo) {
-  if (topo && !topo->denseIdConsistent(packedIndexVersion_)) {
-    edm::LogError("HCAL") << "Inconsistent dense packing between current topology (" << topo->topoVersion() << ") and calibration object (" << packedIndexVersion_ << ")";
-  }
-  topo_=topo;  
-}
 
 unsigned int HcalCondObjectContainerBase::indexFor(DetId fId) const { 
   unsigned int retval=0xFFFFFFFFu;
-  if (!topo_) {
+  if (!topo()) {
     edm::LogError("HCAL") << "Topology pointer not set, HCAL conditions non-functional";
     throw cms::Exception("Topology pointer not set, HCAL conditions non-functional");
     return retval;
@@ -35,13 +29,13 @@ unsigned int HcalCondObjectContainerBase::indexFor(DetId fId) const {
 
   if (fId.det()==DetId::Hcal) {
     switch (HcalSubdetector(fId.subdetId())) {
-    case(HcalBarrel) : retval=topo_->detId2denseIdHB(fId); break;
-    case(HcalEndcap) : retval=topo_->detId2denseIdHE(fId); break;
-    case(HcalOuter) : retval=topo_->detId2denseIdHO(fId); break;
-    case(HcalForward) : retval=topo_->detId2denseIdHF(fId); break;
-    case(HcalTriggerTower) : retval=topo_->detId2denseIdHT(fId); break;
+    case(HcalBarrel) : retval=topo()->detId2denseIdHB(fId); break;
+    case(HcalEndcap) : retval=topo()->detId2denseIdHE(fId); break;
+    case(HcalOuter) : retval=topo()->detId2denseIdHO(fId); break;
+    case(HcalForward) : retval=topo()->detId2denseIdHF(fId); break;
+    case(HcalTriggerTower) : retval=topo()->detId2denseIdHT(fId); break;
     case(HcalOther) : if (extractOther(fId)==HcalCalibration)
-	retval=topo_->detId2denseIdCALIB(fId);
+	retval=topo()->detId2denseIdCALIB(fId);
       break; 
     default: break;
     }
@@ -71,7 +65,7 @@ unsigned int HcalCondObjectContainerBase::indexFor(DetId fId) const {
 unsigned int HcalCondObjectContainerBase::sizeFor(DetId fId) const {
   unsigned int retval=0;
 
-  if (!topo_) {
+  if (!topo()) {
     edm::LogError("HCAL") << "Topology pointer not set, HCAL conditions non-functional";
     throw cms::Exception("Topology pointer not set, HCAL conditions non-functional");
     return retval;
@@ -79,12 +73,12 @@ unsigned int HcalCondObjectContainerBase::sizeFor(DetId fId) const {
 
   if (fId.det()==DetId::Hcal) {
     switch (HcalSubdetector(fId.subdetId())) {
-    case(HcalBarrel) : retval=topo_->getHBSize(); break;
-    case(HcalEndcap) : retval=topo_->getHESize(); break;
-    case(HcalOuter) : retval=topo_->getHOSize(); break;
-    case(HcalForward) : retval=topo_->getHFSize(); break;
-    case(HcalTriggerTower) : retval=topo_->getHTSize(); break;
-    case(HcalOther) : if (extractOther(fId)==HcalCalibration) retval=topo_->getCALIBSize();
+    case(HcalBarrel) : retval=topo()->getHBSize(); break;
+    case(HcalEndcap) : retval=topo()->getHESize(); break;
+    case(HcalOuter) : retval=topo()->getHOSize(); break;
+    case(HcalForward) : retval=topo()->getHFSize(); break;
+    case(HcalTriggerTower) : retval=topo()->getHTSize(); break;
+    case(HcalOther) : if (extractOther(fId)==HcalCalibration) retval=topo()->getCALIBSize();
       break; 
     default: break;
     }

--- a/CondFormats/JetMETObjects/interface/FactorizedJetCorrector.h
+++ b/CondFormats/JetMETObjects/interface/FactorizedJetCorrector.h
@@ -39,6 +39,7 @@ class FactorizedJetCorrector
     void setLepPy       (float fLepPy);
     void setLepPz       (float fLepPz);
     void setAddLepToJet (bool fAddLepToJet);
+
     float getCorrection();
     std::vector<float> getSubCorrections();
     

--- a/CondFormats/JetMETObjects/src/FactorizedJetCorrectorCalculator.cc
+++ b/CondFormats/JetMETObjects/src/FactorizedJetCorrectorCalculator.cc
@@ -264,8 +264,8 @@ std::string FactorizedJetCorrectorCalculator::removeSpaces(const std::string& ss
 //------------------------------------------------------------------------
 float FactorizedJetCorrectorCalculator::getCorrection(FactorizedJetCorrectorCalculator::VariableValues& iValues) const
 {
-  std::vector<float> vv = getSubCorrections(iValues);
-  return vv[vv.size()-1];
+  std::vector<float> && vv = getSubCorrections(iValues);
+  return vv.back();
 }
 //------------------------------------------------------------------------
 //--- Returns the vector of subcorrections, up to a given level ----------

--- a/JetMETCorrections/TauJet/interface/TCTauCorrector.h
+++ b/JetMETCorrections/TauJet/interface/TCTauCorrector.h
@@ -18,7 +18,7 @@
 /// 16.4.2008/S.Lehti
 
 
-class TCTauCorrector :  public JetCorrector {
+class TCTauCorrector final :  public JetCorrector {
 
     public:
 	TCTauCorrector();
@@ -33,19 +33,18 @@ class TCTauCorrector :  public JetCorrector {
 //        double correction(const reco::CaloJet&) const;
         double correction(const reco::CaloTau&) const;
 
-	void inputConfig(const edm::ParameterSet&, edm::ConsumesCollector&) const;
-	void eventSetup(const edm::Event&, const edm::EventSetup&) const;
+	void inputConfig(const edm::ParameterSet&, edm::ConsumesCollector&);
+	void eventSetup(const edm::Event&, const edm::EventSetup&);
 
 	virtual bool eventRequired() const;
 
-	double efficiency();
-	int    allTauCandidates();
-	int    statistics();
-	int    algoComponent();
+	double efficiency() const ;
+	int    allTauCandidates() const ;
+	int    statistics() const ;
 
     private:
         void init();
 
-	TCTauAlgorithm* tcTauAlgorithm;
+	TCTauAlgorithm tcTauAlgorithm;
 };
 #endif

--- a/JetMETCorrections/TauJet/plugins/TCRecoTauDiscriminationAgainstHadronicJets.cc
+++ b/JetMETCorrections/TauJet/plugins/TCRecoTauDiscriminationAgainstHadronicJets.cc
@@ -17,7 +17,7 @@ class TCRecoTauDiscriminationAgainstHadronicJets final  : public CaloTauDiscrimi
       	}
       	~TCRecoTauDiscriminationAgainstHadronicJets(){} 
 
-      	double discriminate(const CaloTauRef& theCaloTauRef) override;
+      	double discriminate(const CaloTauRef& theCaloTauRef) const override;
 	void beginEvent(const edm::Event&, const edm::EventSetup&) override;
 
     private:
@@ -29,7 +29,7 @@ void TCRecoTauDiscriminationAgainstHadronicJets::beginEvent(const edm::Event& iE
 }
 
 
-double TCRecoTauDiscriminationAgainstHadronicJets::discriminate(const CaloTauRef& theCaloTauRef){
+double TCRecoTauDiscriminationAgainstHadronicJets::discriminate(const CaloTauRef& theCaloTauRef) const {
         auto algoused = TCTauAlgorithm::TCAlgoUndetermined;
 	tcTauAlgorithm.recalculateEnergy(*theCaloTauRef, algoused);
 	return (algoused != TCTauAlgorithm::TCAlgoHadronicJet) ? 1. : 0.;

--- a/JetMETCorrections/TauJet/plugins/TCRecoTauDiscriminationAgainstHadronicJets.cc
+++ b/JetMETCorrections/TauJet/plugins/TCRecoTauDiscriminationAgainstHadronicJets.cc
@@ -10,27 +10,29 @@
 
 using namespace reco;
 
-class TCRecoTauDiscriminationAgainstHadronicJets : public CaloTauDiscriminationProducerBase {
+class TCRecoTauDiscriminationAgainstHadronicJets final  : public CaloTauDiscriminationProducerBase {
     public:
-      	explicit TCRecoTauDiscriminationAgainstHadronicJets(const edm::ParameterSet& iConfig):CaloTauDiscriminationProducerBase(iConfig){   
-	  tcTauAlgorithm = new TCTauAlgorithm(iConfig, consumesCollector());
+      	explicit TCRecoTauDiscriminationAgainstHadronicJets(const edm::ParameterSet& iConfig):CaloTauDiscriminationProducerBase(iConfig),
+	  tcTauAlgorithm(iConfig, consumesCollector()) {
       	}
       	~TCRecoTauDiscriminationAgainstHadronicJets(){} 
+
       	double discriminate(const CaloTauRef& theCaloTauRef) override;
 	void beginEvent(const edm::Event&, const edm::EventSetup&) override;
 
     private:
-	TCTauAlgorithm*  tcTauAlgorithm;
+	TCTauAlgorithm  tcTauAlgorithm;
 };
 
 void TCRecoTauDiscriminationAgainstHadronicJets::beginEvent(const edm::Event& iEvent, const edm::EventSetup& iSetup){
-	tcTauAlgorithm->eventSetup(iEvent,iSetup);
+	tcTauAlgorithm.eventSetup(iEvent,iSetup);
 }
 
 
 double TCRecoTauDiscriminationAgainstHadronicJets::discriminate(const CaloTauRef& theCaloTauRef){
-	tcTauAlgorithm->recalculateEnergy(*theCaloTauRef);
-	return ((tcTauAlgorithm->algoComponent() != TCTauAlgorithm::TCAlgoHadronicJet) ? 1. : 0.);
+        auto algoused = TCTauAlgorithm::TCAlgoUndetermined;
+	tcTauAlgorithm.recalculateEnergy(*theCaloTauRef, algoused);
+	return (algoused != TCTauAlgorithm::TCAlgoHadronicJet) ? 1. : 0.;
 }
 
 DEFINE_FWK_MODULE(TCRecoTauDiscriminationAgainstHadronicJets);

--- a/JetMETCorrections/TauJet/plugins/TCRecoTauDiscriminationAlgoComponent.cc
+++ b/JetMETCorrections/TauJet/plugins/TCRecoTauDiscriminationAlgoComponent.cc
@@ -10,27 +10,30 @@
 
 using namespace reco;
 
-class TCRecoTauDiscriminationAlgoComponent : public CaloTauDiscriminationProducerBase {
+class TCRecoTauDiscriminationAlgoComponent final : public CaloTauDiscriminationProducerBase {
     public:
-      	explicit TCRecoTauDiscriminationAlgoComponent(const edm::ParameterSet& iConfig):CaloTauDiscriminationProducerBase(iConfig){   
-	  tcTauAlgorithm = new TCTauAlgorithm(iConfig, consumesCollector());
+      	explicit TCRecoTauDiscriminationAlgoComponent(const edm::ParameterSet& iConfig):CaloTauDiscriminationProducerBase(iConfig),    
+	  tcTauAlgorithm(iConfig, consumesCollector()) {
       	}
       	~TCRecoTauDiscriminationAlgoComponent(){} 
+
       	double discriminate(const CaloTauRef& theCaloTauRef) override;
+
 	void beginEvent(const edm::Event&, const edm::EventSetup&) override;
 
     private:
-	TCTauAlgorithm*  tcTauAlgorithm;
+	TCTauAlgorithm tcTauAlgorithm;
 };
 
 void TCRecoTauDiscriminationAlgoComponent::beginEvent(const edm::Event& iEvent, const edm::EventSetup& iSetup){
-	tcTauAlgorithm->eventSetup(iEvent,iSetup);
+	tcTauAlgorithm.eventSetup(iEvent,iSetup);
 }
 
 
 double TCRecoTauDiscriminationAlgoComponent::discriminate(const CaloTauRef& theCaloTauRef){
-	tcTauAlgorithm->recalculateEnergy(*theCaloTauRef);
-	return (tcTauAlgorithm->algoComponent());
+        auto algoused = TCTauAlgorithm::TCAlgoUndetermined;
+	tcTauAlgorithm.recalculateEnergy(*theCaloTauRef, algoused);
+	return algoused; // is this correct???  (elsewehre is  ? 1.:0.;)
 }
 
 DEFINE_FWK_MODULE(TCRecoTauDiscriminationAlgoComponent);

--- a/JetMETCorrections/TauJet/plugins/TCRecoTauDiscriminationAlgoComponent.cc
+++ b/JetMETCorrections/TauJet/plugins/TCRecoTauDiscriminationAlgoComponent.cc
@@ -17,7 +17,7 @@ class TCRecoTauDiscriminationAlgoComponent final : public CaloTauDiscriminationP
       	}
       	~TCRecoTauDiscriminationAlgoComponent(){} 
 
-      	double discriminate(const CaloTauRef& theCaloTauRef) override;
+      	double discriminate(const CaloTauRef& theCaloTauRef) const override;
 
 	void beginEvent(const edm::Event&, const edm::EventSetup&) override;
 
@@ -30,7 +30,7 @@ void TCRecoTauDiscriminationAlgoComponent::beginEvent(const edm::Event& iEvent, 
 }
 
 
-double TCRecoTauDiscriminationAlgoComponent::discriminate(const CaloTauRef& theCaloTauRef){
+double TCRecoTauDiscriminationAlgoComponent::discriminate(const CaloTauRef& theCaloTauRef) const {
         auto algoused = TCTauAlgorithm::TCAlgoUndetermined;
 	tcTauAlgorithm.recalculateEnergy(*theCaloTauRef, algoused);
 	return algoused; // is this correct???  (elsewehre is  ? 1.:0.;)

--- a/JetMETCorrections/TauJet/src/TCTauCorrector.cc
+++ b/JetMETCorrections/TauJet/src/TCTauCorrector.cc
@@ -8,24 +8,24 @@ TCTauCorrector::TCTauCorrector(const edm::ParameterSet& iConfig, edm::ConsumesCo
 	inputConfig(iConfig, iC);
 }
 TCTauCorrector::~TCTauCorrector(){
-	delete tcTauAlgorithm;
 }
 
 void TCTauCorrector::init(){
-	tcTauAlgorithm = new TCTauAlgorithm;
 }
 
-void TCTauCorrector::inputConfig(const edm::ParameterSet& iConfig, edm::ConsumesCollector &iC) const {
-        tcTauAlgorithm->inputConfig(iConfig, iC);
+void TCTauCorrector::inputConfig(const edm::ParameterSet& iConfig, edm::ConsumesCollector &iC) {
+        tcTauAlgorithm.inputConfig(iConfig, iC);
 }
 
-void TCTauCorrector::eventSetup(const edm::Event& iEvent, const edm::EventSetup& iSetup) const {
-	tcTauAlgorithm->eventSetup(iEvent,iSetup);
+void TCTauCorrector::eventSetup(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+	tcTauAlgorithm.eventSetup(iEvent,iSetup);
 }
 
 math::XYZTLorentzVector TCTauCorrector::correctedP4(const reco::CaloTau& fJet) const {
-	return tcTauAlgorithm->recalculateEnergy(fJet);
+	return tcTauAlgorithm.recalculateEnergy(fJet);
 }
+
+
 /*
 double TCTauCorrector::correction(const reco::Jet& fJet, const edm::Event& iEvent, const edm::EventSetup& iSetup) const {
 
@@ -33,15 +33,17 @@ double TCTauCorrector::correction(const reco::Jet& fJet, const edm::Event& iEven
 	return correction(fJet);
 }
 */
+
 double TCTauCorrector::correction(const math::XYZTLorentzVector& fJet) const{
 	return 0;
 }
+
 /*
 double TCTauCorrector::correction(const reco::Jet& fJet) const {
 
 	if(fJet.et() == 0) return 0;
 
-        math::XYZTLorentzVector corrected = tcTauAlgorithm->recalculateEnergy(fJet);
+        math::XYZTLorentzVector corrected = tcTauAlgorithm.recalculateEnergy(fJet);
         return corrected.Et()/fJet.et();
 }
 */
@@ -50,15 +52,17 @@ double TCTauCorrector::correction(const reco::CaloJet& fJet) const {
 
         if(fJet.et() == 0) return 0;
 
-        math::XYZTLorentzVector corrected = tcTauAlgorithm->recalculateEnergy(fJet);
+        math::XYZTLorentzVector corrected = tcTauAlgorithm.recalculateEnergy(fJet);
         return corrected.Et()/fJet.et();
 }
 */
+
+
 double TCTauCorrector::correction(const reco::CaloTau& fJet) const {
 
         if(fJet.et() == 0) return 0;
 
-        math::XYZTLorentzVector corrected = tcTauAlgorithm->recalculateEnergy(fJet);
+        math::XYZTLorentzVector corrected = tcTauAlgorithm.recalculateEnergy(fJet);
         return corrected.Et()/fJet.et();
 }
 
@@ -66,18 +70,15 @@ bool TCTauCorrector::eventRequired() const {
 	return true;
 }
 
-double TCTauCorrector::efficiency(){
-	return tcTauAlgorithm->efficiency();
+double TCTauCorrector::efficiency() const {
+	return tcTauAlgorithm.efficiency();
 }
 
-int TCTauCorrector::allTauCandidates(){
-        return tcTauAlgorithm->allTauCandidates();
+int TCTauCorrector::allTauCandidates() const {
+        return tcTauAlgorithm.allTauCandidates();
 }
 
-int TCTauCorrector::statistics(){
-        return tcTauAlgorithm->statistics();
+int TCTauCorrector::statistics() const{
+        return tcTauAlgorithm.statistics();
 }
 
-int TCTauCorrector::algoComponent(){
-        return tcTauAlgorithm->algoComponent();
-}

--- a/JetMETCorrections/Type1MET/interface/CaloJetMETcorrInputProducerT.h
+++ b/JetMETCorrections/Type1MET/interface/CaloJetMETcorrInputProducerT.h
@@ -14,7 +14,7 @@
  *
  */
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -56,7 +56,7 @@ namespace CaloJetMETcorrInputProducer_namespace
 }
 
 template <typename T, typename Textractor>
-class CaloJetMETcorrInputProducerT : public edm::EDProducer  
+class CaloJetMETcorrInputProducerT final : public edm::global::EDProducer<>
 {
  public:
 
@@ -93,7 +93,7 @@ class CaloJetMETcorrInputProducerT : public edm::EDProducer
     
  private:
 
-  void produce(edm::Event& evt, const edm::EventSetup& es)
+  void produce(edm::StreamID, edm::Event& evt, const edm::EventSetup& es) const override
   {
     std::auto_ptr<CorrMETData> type1Correction(new CorrMETData());
     std::auto_ptr<CorrMETData> unclEnergySum(new CorrMETData());
@@ -128,10 +128,10 @@ class CaloJetMETcorrInputProducerT : public edm::EDProducer
     for ( int jetIndex = 0; jetIndex < numJets; ++jetIndex ) {
       const T& rawJet = jets->at(jetIndex);
 
-      static CaloJetMETcorrInputProducer_namespace::InputTypeCheckerT<T> checkInputType;
+      const CaloJetMETcorrInputProducer_namespace::InputTypeCheckerT<T> checkInputType;
       checkInputType(rawJet);
 
-      static CaloJetMETcorrInputProducer_namespace::RawJetExtractorT<T> rawJetExtractor;
+      const CaloJetMETcorrInputProducer_namespace::RawJetExtractorT<T> rawJetExtractor;
       reco::Candidate::LorentzVector rawJetP4 = rawJetExtractor(rawJet);
       
       reco::Candidate::LorentzVector corrJetP4 = jetCorrExtractor_(rawJet, jetCorrLabel_, &evt, &es, jetCorrEtaMax_);

--- a/JetMETCorrections/Type1MET/interface/JetCorrExtractorT.h
+++ b/JetMETCorrections/Type1MET/interface/JetCorrExtractorT.h
@@ -38,6 +38,7 @@ namespace
     return jetCorrector->correction(rawJet, evt, es);
   }
 
+  // never heard of copysign?
   double sign(double x)
   {
     if      ( x > 0. ) return +1.;
@@ -52,9 +53,9 @@ class JetCorrExtractorT
  public:
 
   reco::Candidate::LorentzVector operator()(const T& rawJet, const std::string& jetCorrLabel, 
-					    const edm::Event* evt = 0, const edm::EventSetup* es = 0, 
+					    const edm::Event* evt = nullptr, const edm::EventSetup* es = nullptr, 
 					    double jetCorrEtaMax = 9.9, 
-					    const reco::Candidate::LorentzVector* rawJetP4_specified = 0)
+					    const reco::Candidate::LorentzVector * const rawJetP4_specified = nullptr) const
   {
     // "general" implementation requires access to edm::Event and edm::EventSetup,
     // only specialization for pat::Jets doesn't

--- a/PhysicsTools/PatUtils/interface/PATJetCorrExtractor.h
+++ b/PhysicsTools/PatUtils/interface/PATJetCorrExtractor.h
@@ -53,9 +53,9 @@ class PATJetCorrExtractor
  public:
 
   reco::Candidate::LorentzVector operator()(const pat::Jet& jet, const std::string& jetCorrLabel, 
-					    const edm::Event* evt = 0, const edm::EventSetup* es = 0, 
+					    const edm::Event* evt = nullptr, const edm::EventSetup* es = nullptr, 
 					    double jetCorrEtaMax = 9.9, 
-					    const reco::Candidate::LorentzVector* rawJetP4_specified = 0)
+					    const reco::Candidate::LorentzVector* const rawJetP4_specified = nullptr) const 
   {
     reco::Candidate::LorentzVector corrJetP4;
 

--- a/RecoJets/JetProducers/plugins/VirtualJetProducer.h
+++ b/RecoJets/JetProducers/plugins/VirtualJetProducer.h
@@ -3,7 +3,7 @@
 
 #include "RecoJets/JetProducers/interface/JetSpecific.h"
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/Candidate/interface/CandidateFwd.h"
@@ -27,7 +27,7 @@
 #include <boost/shared_ptr.hpp>
 
 
-class VirtualJetProducer : public edm::EDProducer
+class dso_hidden VirtualJetProducer : public edm::stream::EDProducer<>
 {
 protected:
   //

--- a/RecoLocalCalo/CaloTowersCreator/src/CaloTowerCandidateCreator.h
+++ b/RecoLocalCalo/CaloTowersCreator/src/CaloTowerCandidateCreator.h
@@ -11,13 +11,13 @@
  *
  *
  */
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/CaloTowers/interface/CaloTower.h"
 #include <string>
 
 
-class CaloTowerCandidateCreator : public edm::EDProducer {
+class CaloTowerCandidateCreator : public edm::stream::EDProducer<> {
  public:
   /// constructor from parameter set
   CaloTowerCandidateCreator( const edm::ParameterSet & );

--- a/RecoLocalCalo/HcalRecProducers/src/HcalHitReconstructor.h
+++ b/RecoLocalCalo/HcalRecProducers/src/HcalHitReconstructor.h
@@ -1,7 +1,7 @@
 #ifndef HCALHITRECONSTRUCTOR_H 
 #define HCALHITRECONSTRUCTOR_H 1
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
 
@@ -39,7 +39,7 @@
 
 class HcalTopology;
 
-    class HcalHitReconstructor : public edm::EDProducer {
+    class HcalHitReconstructor : public edm::stream::EDProducer<> {
     public:
       explicit HcalHitReconstructor(const edm::ParameterSet& ps);
       virtual ~HcalHitReconstructor();

--- a/RecoLocalCalo/HcalRecProducers/src/HcalSimpleReconstructor.h
+++ b/RecoLocalCalo/HcalRecProducers/src/HcalSimpleReconstructor.h
@@ -1,7 +1,7 @@
 #ifndef HCALSIMPLERECONSTRUCTOR_H
 #define HCALSIMPLERECONSTRUCTOR_H 1
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "DataFormats/Common/interface/EDProduct.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
@@ -21,7 +21,7 @@
     */
 class HcalTopology;
 
-    class HcalSimpleReconstructor : public edm::EDProducer {
+    class HcalSimpleReconstructor : public edm::stream::EDProducer<> {
     public:
       explicit HcalSimpleReconstructor(const edm::ParameterSet& ps);
       virtual ~HcalSimpleReconstructor();

--- a/RecoLocalCalo/HcalRecProducers/src/ZdcHitReconstructor.h
+++ b/RecoLocalCalo/HcalRecProducers/src/ZdcHitReconstructor.h
@@ -1,7 +1,7 @@
 #ifndef ZDCHITRECONSTRUCTOR_H 
 #define ZDCHITRECONSTRUCTOR_H 1
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
 
@@ -33,7 +33,7 @@ class HcalTopology;
     \author E. Garcia - CSU
     ** Based on HcalSimpleReconstructor.h by J. Mans
     */
-    class ZdcHitReconstructor : public edm::EDProducer {
+    class ZdcHitReconstructor : public edm::stream::EDProducer<> {
     public:
       explicit ZdcHitReconstructor(const edm::ParameterSet& ps);
       virtual ~ZdcHitReconstructor();

--- a/RecoLocalCalo/HcalRecProducers/src/ZdcSimpleReconstructor.h
+++ b/RecoLocalCalo/HcalRecProducers/src/ZdcSimpleReconstructor.h
@@ -1,7 +1,7 @@
 #ifndef ZDCSIMPLERECONSTRUCTOR_H
 #define ZDCSIMPLERECONSTRUCTOR_H 1
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "CondFormats/HcalObjects/interface/HcalLongRecoParams.h"
@@ -19,7 +19,7 @@
     \author E. Garcia - CSU
     ** Based on HcalSimpleReconstructor.h by J. Mans
     */
-     class ZdcSimpleReconstructor : public edm::EDProducer {
+     class ZdcSimpleReconstructor : public edm::stream::EDProducer<> {
     public:
       explicit ZdcSimpleReconstructor(const edm::ParameterSet& ps);
       virtual ~ZdcSimpleReconstructor();

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFCTRecHitProducer.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFCTRecHitProducer.h
@@ -7,7 +7,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -32,7 +32,7 @@ class CaloSubdetectorTopology;
 class CaloSubdetectorGeometry;
 class DetId;
 
-class PFCTRecHitProducer : public edm::EDProducer {
+class dso_hidden PFCTRecHitProducer final : public edm::stream::EDProducer<> {
  public:
   explicit PFCTRecHitProducer(const edm::ParameterSet&);
   ~PFCTRecHitProducer();

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFRecHitProducer.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFRecHitProducer.h
@@ -4,7 +4,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -18,7 +18,7 @@
 // class declaration
 //
 
-class PFRecHitProducer : public edm::EDProducer {
+class PFRecHitProducer final : public edm::stream::EDProducer<> {
    public:
       explicit PFRecHitProducer(const edm::ParameterSet& iConfig);
       ~PFRecHitProducer();

--- a/RecoParticleFlow/PFTracking/interface/PFElecTkProducer.h
+++ b/RecoParticleFlow/PFTracking/interface/PFElecTkProducer.h
@@ -4,7 +4,7 @@
 #include "DataFormats/ParticleFlowReco/interface/PFConversion.h"
 #include "DataFormats/ParticleFlowReco/interface/PFV0.h"
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -41,7 +41,7 @@ class ConvBremPFTrackFinder;
  and transform them in PFGsfRecTracks.
 */
 
-class PFElecTkProducer : public edm::EDProducer {
+class PFElecTkProducer final : public edm::stream::EDProducer<> {
  public:
   
      ///Constructor

--- a/RecoParticleFlow/PFTracking/plugins/GoodSeedProducer.h
+++ b/RecoParticleFlow/PFTracking/plugins/GoodSeedProducer.h
@@ -6,7 +6,7 @@
 // user include files
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -49,7 +49,7 @@ class TrackerGeometry;
 class TrajectoryStateOnSurface;
 
 
-class GoodSeedProducer : public edm::EDProducer {
+class GoodSeedProducer final : public edm::stream::EDProducer<> {
   typedef TrajectoryStateOnSurface TSOS;
    public:
       explicit GoodSeedProducer(const edm::ParameterSet&);

--- a/RecoTauTag/RecoTau/interface/TCTauAlgorithm.h
+++ b/RecoTauTag/RecoTau/interface/TCTauAlgorithm.h
@@ -44,7 +44,7 @@
 
 class TCTauAlgorithm {
     public:
-        enum  {TCAlgoUndetermined,
+        enum  TCAlgo {TCAlgoUndetermined,
 	       TCAlgoMomentum,
 	       TCAlgoTrackProblem,
 	       TCAlgoMomentumECAL,
@@ -56,16 +56,19 @@ class TCTauAlgorithm {
 	TCTauAlgorithm(const edm::ParameterSet&, edm::ConsumesCollector&&);
         ~TCTauAlgorithm();
 
-	math::XYZTLorentzVector recalculateEnergy(const reco::CaloTau&);
-	math::XYZTLorentzVector recalculateEnergy(const reco::CaloJet&,const reco::TrackRef&,const reco::TrackRefVector&);
+	math::XYZTLorentzVector recalculateEnergy(const reco::CaloTau&, TCAlgo&) const ;
+        math::XYZTLorentzVector recalculateEnergy(const reco::CaloTau& tau) const {
+             TCAlgo dummy = TCAlgoUndetermined;
+             return recalculateEnergy(tau,dummy);
+        }
+	math::XYZTLorentzVector recalculateEnergy(const reco::CaloJet&,const reco::TrackRef&,const reco::TrackRefVector&, TCAlgo&) const;
 
 	void inputConfig(const edm::ParameterSet& iConfig, edm::ConsumesCollector &iC);
 	void eventSetup(const edm::Event&,const edm::EventSetup&);
 
-	double efficiency();
-	int    allTauCandidates();
-	int    statistics();
-	int    algoComponent();
+	double efficiency() const;
+	int    allTauCandidates() const;
+	int    statistics() const;
 
     private:
 
@@ -77,16 +80,15 @@ class TCTauAlgorithm {
 
         void init();
 
-	math::XYZVector                 trackEcalHitPoint(const reco::TransientTrack&,const reco::CaloJet&);
-	math::XYZVector		  trackEcalHitPoint(const reco::Track&);
-	std::pair<math::XYZVector,math::XYZVector> getClusterEnergy(const reco::CaloJet&,math::XYZVector&,double);
-	math::XYZVector                 getCellMomentum(const CaloCellGeometry*,double&);
+	math::XYZVector           trackEcalHitPoint(const reco::TransientTrack&,const reco::CaloJet&) const;
+	math::XYZVector		  trackEcalHitPoint(const reco::Track&) const;
+	std::pair<math::XYZVector,math::XYZVector> getClusterEnergy(const reco::CaloJet&,math::XYZVector&,double) const;
+	math::XYZVector                 getCellMomentum(const CaloCellGeometry*,double&) const;
 
 
-        int all,
-            passed;
+      
+        mutable std::atomic<int> all, passed;
 
-	int algoComponentUsed;
 
 	int prongs;
 

--- a/RecoTauTag/RecoTau/interface/TauDiscriminationProducerBase.h
+++ b/RecoTauTag/RecoTau/interface/TauDiscriminationProducerBase.h
@@ -95,6 +95,9 @@ class TauDiscriminationProducerBase : public edm::stream::EDProducer<> {
     std::string moduleLabel_;
     edm::EDGetTokenT<TauCollection> Tau_token;
 
+    // current tau
+    size_t tauIndex_;
+
   private:
     std::vector<TauDiscInfo> prediscriminants_;
     // select boolean operation on prediscriminants (and = 0x01, or = 0x00)

--- a/RecoTauTag/RecoTau/interface/TauDiscriminationProducerBase.h
+++ b/RecoTauTag/RecoTau/interface/TauDiscriminationProducerBase.h
@@ -69,7 +69,7 @@ class TauDiscriminationProducerBase : public edm::stream::EDProducer<> {
                             const edm::EventSetup& evtSetup) {}
 
     // abstract functions implemented in derived classes.
-    virtual double discriminate(const TauRef& tau) = 0;
+    virtual double discriminate(const TauRef& tau) const = 0;
 
     // called at the end of event processing - override if necessary.
     virtual void endEvent(edm::Event& evt) {}

--- a/RecoTauTag/RecoTau/interface/TauDiscriminationProducerBase.h
+++ b/RecoTauTag/RecoTau/interface/TauDiscriminationProducerBase.h
@@ -30,8 +30,8 @@
  * Authors :  Evan Friis (UC Davis), Simone Gennai (SNS)
  */
 
-#include "FWCore/Framework/interface/EDProducer.h"
-//#include "FWCore/Framework/interface/stream/EDProducer.h"
+// #include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -46,7 +46,7 @@
 #include "DataFormats/TauReco/interface/CaloTauDiscriminator.h"
 
 template<class TauType, class TauDiscriminator>
-class TauDiscriminationProducerBase : public edm::EDProducer { // edm::stream::EDProducer<> {
+class TauDiscriminationProducerBase : public edm::stream::EDProducer<> {
   public:
     // setup framework types for this tautype
     typedef std::vector<TauType>        TauCollection;

--- a/RecoTauTag/RecoTau/plugins/CaloRecoTauDiscriminationAgainstElectron.cc
+++ b/RecoTauTag/RecoTau/plugins/CaloRecoTauDiscriminationAgainstElectron.cc
@@ -12,9 +12,10 @@
  *                Evan Friis (UC Davis)
  */
 
-using namespace reco;
 
-class CaloRecoTauDiscriminationAgainstElectron : public  CaloTauDiscriminationProducerBase {
+namespace {
+using namespace reco;
+class CaloRecoTauDiscriminationAgainstElectron final  : public  CaloTauDiscriminationProducerBase {
    public:
       explicit CaloRecoTauDiscriminationAgainstElectron(const edm::ParameterSet& iConfig):CaloTauDiscriminationProducerBase(iConfig){   
          CaloTauProducer_                            = iConfig.getParameter<edm::InputTag>("CaloTauProducer");
@@ -24,7 +25,7 @@ class CaloRecoTauDiscriminationAgainstElectron : public  CaloTauDiscriminationPr
          ApplyCut_leadTrackavoidsECALcrack_          = iConfig.getParameter<bool>("ApplyCut_leadTrackavoidsECALcrack");
       }
       ~CaloRecoTauDiscriminationAgainstElectron(){} 
-      double discriminate(const CaloTauRef& theCaloTauRef) override;
+      double discriminate(const CaloTauRef& theCaloTauRef) const override;
       void beginEvent(const edm::Event& event, const edm::EventSetup& eventSetup) override;
    private:  
       edm::ESHandle<MagneticField> theMagneticField;
@@ -45,7 +46,7 @@ void CaloRecoTauDiscriminationAgainstElectron::beginEvent(const edm::Event& even
 }
 
 
-double CaloRecoTauDiscriminationAgainstElectron::discriminate(const CaloTauRef& theCaloTauRef)
+double CaloRecoTauDiscriminationAgainstElectron::discriminate(const CaloTauRef& theCaloTauRef) const 
 {
    if (ApplyCut_maxleadTrackHCAL3x3hottesthitDEta_){
       // optional selection : ask for small |deta| between direction of propag. leading Track - ECAL inner surf. contact point and direction of highest Et hit among HCAL hits inside a 3x3 calo. tower matrix centered on direction of propag. leading Track - ECAL inner surf. contact point
@@ -122,4 +123,6 @@ void CaloRecoTauDiscriminationAgainstElectron::produce(edm::Event& iEvent,const 
   iEvent.put(theCaloTauDiscriminatorAgainstElectron);
 }
 */
+
+}
 DEFINE_FWK_MODULE(CaloRecoTauDiscriminationAgainstElectron);

--- a/RecoTauTag/RecoTau/plugins/CaloRecoTauDiscriminationAgainstHadronicJets.cc
+++ b/RecoTauTag/RecoTau/plugins/CaloRecoTauDiscriminationAgainstHadronicJets.cc
@@ -11,7 +11,7 @@
 using namespace reco;
 using namespace edm;
 
-class CaloRecoTauDiscriminationAgainstHadronicJets : public CaloTauDiscriminationProducerBase {
+class CaloRecoTauDiscriminationAgainstHadronicJets final : public CaloTauDiscriminationProducerBase {
   public:
     explicit CaloRecoTauDiscriminationAgainstHadronicJets(
         const edm::ParameterSet& iConfig)
@@ -34,9 +34,9 @@ void CaloRecoTauDiscriminationAgainstHadronicJets::beginEvent(
 
 double CaloRecoTauDiscriminationAgainstHadronicJets::discriminate(
     const CaloTauRef& theCaloTauRef){
-  tcTauAlgorithm->recalculateEnergy(*theCaloTauRef);
-  return ((tcTauAlgorithm->algoComponent() !=
-           TCTauAlgorithm::TCAlgoHadronicJet) ? 1. : 0.);
+    auto algoused = TCTauAlgorithm::TCAlgoUndetermined;
+        tcTauAlgorithm->recalculateEnergy(*theCaloTauRef, algoused);
+        return (algoused != TCTauAlgorithm::TCAlgoHadronicJet) ? 1. : 0.;
 }
 
 DEFINE_FWK_MODULE(CaloRecoTauDiscriminationAgainstHadronicJets);

--- a/RecoTauTag/RecoTau/plugins/CaloRecoTauDiscriminationAgainstHadronicJets.cc
+++ b/RecoTauTag/RecoTau/plugins/CaloRecoTauDiscriminationAgainstHadronicJets.cc
@@ -8,6 +8,8 @@
 #include "RecoTauTag/RecoTau/interface/TauDiscriminationProducerBase.h"
 #include "RecoTauTag/RecoTau/interface/TCTauAlgorithm.h"
 
+namespace {
+
 using namespace reco;
 using namespace edm;
 
@@ -15,28 +17,30 @@ class CaloRecoTauDiscriminationAgainstHadronicJets final : public CaloTauDiscrim
   public:
     explicit CaloRecoTauDiscriminationAgainstHadronicJets(
         const edm::ParameterSet& iConfig)
-        :CaloTauDiscriminationProducerBase(iConfig){
-          tcTauAlgorithm = new TCTauAlgorithm(iConfig, consumesCollector());
+        :CaloTauDiscriminationProducerBase(iConfig), 
+          tcTauAlgorithm(iConfig, consumesCollector()) {
         }
     ~CaloRecoTauDiscriminationAgainstHadronicJets(){}
-    double discriminate(const CaloTauRef& theCaloTauRef) override;
+    double discriminate(const CaloTauRef& theCaloTauRef) const override;
     void beginEvent(const edm::Event&, const edm::EventSetup&) override;
 
   private:
-    TCTauAlgorithm*  tcTauAlgorithm;
+    TCTauAlgorithm  tcTauAlgorithm;
 };
 
 void CaloRecoTauDiscriminationAgainstHadronicJets::beginEvent(
     const edm::Event& iEvent, const edm::EventSetup& iSetup){
-  tcTauAlgorithm->eventSetup(iEvent,iSetup);
+  tcTauAlgorithm.eventSetup(iEvent,iSetup);
 }
 
 
 double CaloRecoTauDiscriminationAgainstHadronicJets::discriminate(
-    const CaloTauRef& theCaloTauRef){
+    const CaloTauRef& theCaloTauRef) const {
     auto algoused = TCTauAlgorithm::TCAlgoUndetermined;
-        tcTauAlgorithm->recalculateEnergy(*theCaloTauRef, algoused);
+        tcTauAlgorithm.recalculateEnergy(*theCaloTauRef, algoused);
         return (algoused != TCTauAlgorithm::TCAlgoHadronicJet) ? 1. : 0.;
+}
+
 }
 
 DEFINE_FWK_MODULE(CaloRecoTauDiscriminationAgainstHadronicJets);

--- a/RecoTauTag/RecoTau/plugins/CaloRecoTauDiscriminationByCharge.cc
+++ b/RecoTauTag/RecoTau/plugins/CaloRecoTauDiscriminationByCharge.cc
@@ -8,7 +8,9 @@
  * Authors : S.Lehti, copied from PFRecoTauDiscriminationByCharge
  */
 
-class CaloRecoTauDiscriminationByCharge : public CaloTauDiscriminationProducerBase  {
+namespace {
+
+class CaloRecoTauDiscriminationByCharge final : public CaloTauDiscriminationProducerBase  {
   public:
     explicit CaloRecoTauDiscriminationByCharge(const edm::ParameterSet& iConfig)
         :CaloTauDiscriminationProducerBase(iConfig){
@@ -17,18 +19,20 @@ class CaloRecoTauDiscriminationByCharge : public CaloTauDiscriminationProducerBa
               iConfig.getParameter<bool>("ApplyOneOrThreeProngCut");
         }
     ~CaloRecoTauDiscriminationByCharge(){}
-    double discriminate(const reco::CaloTauRef& pfTau) override;
+    double discriminate(const reco::CaloTauRef& pfTau) const override;
   private:
     uint32_t chargeReq_;
     bool oneOrThreeProng_;
 };
 
 double CaloRecoTauDiscriminationByCharge::discriminate(
-    const reco::CaloTauRef& theTauRef) {
+    const reco::CaloTauRef& theTauRef) const {
   uint16_t nSigTk =  theTauRef->signalTracks().size();
   bool chargeok = (abs(theTauRef->charge()) == int(chargeReq_));
   bool oneOrThreeProngOK =  ( (nSigTk==1) || (nSigTk==3) || !oneOrThreeProng_ );
 
   return ( (chargeok && oneOrThreeProngOK) ? 1. : 0. );
+}
+
 }
 DEFINE_FWK_MODULE(CaloRecoTauDiscriminationByCharge);

--- a/RecoTauTag/RecoTau/plugins/CaloRecoTauDiscriminationByDeltaE.cc
+++ b/RecoTauTag/RecoTau/plugins/CaloRecoTauDiscriminationByDeltaE.cc
@@ -15,7 +15,7 @@ using namespace reco;
 using namespace std;
 using namespace edm;
 
-class CaloRecoTauDiscriminationByDeltaE : public CaloTauDiscriminationProducerBase  {
+class CaloRecoTauDiscriminationByDeltaE final : public CaloTauDiscriminationProducerBase  {
     public:
 	explicit CaloRecoTauDiscriminationByDeltaE(const ParameterSet& iConfig):CaloTauDiscriminationProducerBase(iConfig){
 		deltaEmin		= iConfig.getParameter<double>("deltaEmin");
@@ -27,10 +27,10 @@ class CaloRecoTauDiscriminationByDeltaE : public CaloTauDiscriminationProducerBa
       	~CaloRecoTauDiscriminationByDeltaE(){}
 
 	void beginEvent(const edm::Event&, const edm::EventSetup&) override;
-	double discriminate(const reco::CaloTauRef&) override;
+	double discriminate(const reco::CaloTauRef&) const override;
 
     private:
-	double DeltaE(const CaloTauRef&);
+	double DeltaE(const CaloTauRef&) const ;
 
 	double chargedPionMass;
 
@@ -41,14 +41,14 @@ class CaloRecoTauDiscriminationByDeltaE : public CaloTauDiscriminationProducerBa
 void CaloRecoTauDiscriminationByDeltaE::beginEvent(const Event& iEvent, const EventSetup& iSetup){
 }
 
-double CaloRecoTauDiscriminationByDeltaE::discriminate(const CaloTauRef& tau){
+double CaloRecoTauDiscriminationByDeltaE::discriminate(const CaloTauRef& tau) const {
 
 	double dE = DeltaE(tau);
 	if(booleanOutput) return ( dE > deltaEmin && dE < deltaEmax ? 1. : 0. );
 	return dE;
 }
 
-double CaloRecoTauDiscriminationByDeltaE::DeltaE(const CaloTauRef& tau){
+double CaloRecoTauDiscriminationByDeltaE::DeltaE(const CaloTauRef& tau) const {
 	double tracksE = 0;
 	reco::TrackRefVector signalTracks = tau->signalTracks();
 	for(size_t i = 0; i < signalTracks.size(); ++i){

--- a/RecoTauTag/RecoTau/plugins/CaloRecoTauDiscriminationByFlightPathSignificance.cc
+++ b/RecoTauTag/RecoTau/plugins/CaloRecoTauDiscriminationByFlightPathSignificance.cc
@@ -16,10 +16,12 @@
 
 #include "TLorentzVector.h"
 
+namespace { 
+
 using namespace reco;
 using namespace std;
 
-class CaloRecoTauDiscriminationByFlightPathSignificance : public CaloTauDiscriminationProducerBase  {
+class CaloRecoTauDiscriminationByFlightPathSignificance final : public CaloTauDiscriminationProducerBase  {
   public:
     explicit CaloRecoTauDiscriminationByFlightPathSignificance(
         const edm::ParameterSet& iConfig)
@@ -33,11 +35,11 @@ class CaloRecoTauDiscriminationByFlightPathSignificance : public CaloTauDiscrimi
     }
     ~CaloRecoTauDiscriminationByFlightPathSignificance(){}
     void beginEvent(const edm::Event&, const edm::EventSetup&) override;
-    double discriminate(const reco::CaloTauRef&) override;
+    double discriminate(const reco::CaloTauRef&) const override;
 
   private:
-    double threeProngFlightPathSig(const CaloTauRef&);
-    double vertexSignificance(reco::Vertex&,reco::Vertex&,GlobalVector&);
+    double threeProngFlightPathSig(const CaloTauRef&) const ;
+    double vertexSignificance(reco::Vertex const&,reco::Vertex const &,GlobalVector const &) const ;
 
     double flightPathSig;
     bool withPVError;
@@ -64,7 +66,7 @@ void CaloRecoTauDiscriminationByFlightPathSignificance::beginEvent(
 
 double
 CaloRecoTauDiscriminationByFlightPathSignificance::discriminate(
-    const CaloTauRef& tau){
+    const CaloTauRef& tau) const {
   if(booleanOutput)
     return ( threeProngFlightPathSig(tau) > flightPathSig ? 1. : 0. );
   return threeProngFlightPathSig(tau);
@@ -72,7 +74,7 @@ CaloRecoTauDiscriminationByFlightPathSignificance::discriminate(
 
 double
 CaloRecoTauDiscriminationByFlightPathSignificance::threeProngFlightPathSig(
-    const CaloTauRef& tau){
+    const CaloTauRef& tau) const {
   double flightPathSignificance = 0;
   //Secondary vertex
   reco::TrackRefVector signalTracks = tau->signalTracks();
@@ -96,10 +98,11 @@ CaloRecoTauDiscriminationByFlightPathSignificance::threeProngFlightPathSig(
 
 double
 CaloRecoTauDiscriminationByFlightPathSignificance::vertexSignificance(
-    reco::Vertex& pv, Vertex& sv,GlobalVector& direction){
+    reco::Vertex const & pv, Vertex const & sv,GlobalVector const & direction) const {
   return SecondaryVertex::computeDist3d(
       pv,sv,direction,withPVError).significance();
 }
 
+}
 DEFINE_FWK_MODULE(CaloRecoTauDiscriminationByFlightPathSignificance);
 

--- a/RecoTauTag/RecoTau/plugins/CaloRecoTauDiscriminationByInvMass.cc
+++ b/RecoTauTag/RecoTau/plugins/CaloRecoTauDiscriminationByInvMass.cc
@@ -10,10 +10,12 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "TLorentzVector.h"
 
+namespace {
+
 using namespace reco;
 using namespace std;
 
-class CaloRecoTauDiscriminationByInvMass : public CaloTauDiscriminationProducerBase  {
+class CaloRecoTauDiscriminationByInvMass final : public CaloTauDiscriminationProducerBase  {
   public:
     explicit CaloRecoTauDiscriminationByInvMass(
         const edm::ParameterSet& iConfig)
@@ -26,16 +28,16 @@ class CaloRecoTauDiscriminationByInvMass : public CaloTauDiscriminationProducerB
 
     ~CaloRecoTauDiscriminationByInvMass(){}
 
-    double discriminate(const reco::CaloTauRef&) override;
+    double discriminate(const reco::CaloTauRef&) const override;
 
   private:
-    double threeProngInvMass(const CaloTauRef&);
+    double threeProngInvMass(const CaloTauRef&) const ;
     double chargedPionMass;
     double invMassMin,invMassMax;
     bool booleanOutput;
 };
 
-double CaloRecoTauDiscriminationByInvMass::discriminate(const CaloTauRef& tau){
+double CaloRecoTauDiscriminationByInvMass::discriminate(const CaloTauRef& tau) const {
 
   double invMass = threeProngInvMass(tau);
   if(booleanOutput) return (
@@ -44,7 +46,7 @@ double CaloRecoTauDiscriminationByInvMass::discriminate(const CaloTauRef& tau){
 }
 
 double CaloRecoTauDiscriminationByInvMass::threeProngInvMass(
-    const CaloTauRef& tau){
+    const CaloTauRef& tau) const {
   TLorentzVector sum;
   reco::TrackRefVector signalTracks = tau->signalTracks();
   for(size_t i = 0; i < signalTracks.size(); ++i){
@@ -58,4 +60,5 @@ double CaloRecoTauDiscriminationByInvMass::threeProngInvMass(
   return sum.M();
 }
 
+}
 DEFINE_FWK_MODULE(CaloRecoTauDiscriminationByInvMass);

--- a/RecoTauTag/RecoTau/plugins/CaloRecoTauDiscriminationByIsolation.cc
+++ b/RecoTauTag/RecoTau/plugins/CaloRecoTauDiscriminationByIsolation.cc
@@ -6,9 +6,11 @@
 
 #include "RecoTauTag/RecoTau/interface/TauDiscriminationProducerBase.h"
 
+namespace {
+
 using namespace reco;
 
-class CaloRecoTauDiscriminationByIsolation : public CaloTauDiscriminationProducerBase {
+class CaloRecoTauDiscriminationByIsolation final : public CaloTauDiscriminationProducerBase {
  public:
   explicit CaloRecoTauDiscriminationByIsolation(const edm::ParameterSet& iConfig):CaloTauDiscriminationProducerBase(iConfig){   
     applyDiscriminationByTrackerIsolation_ = iConfig.getParameter<bool>("ApplyDiscriminationByTrackerIsolation");
@@ -18,7 +20,7 @@ class CaloRecoTauDiscriminationByIsolation : public CaloTauDiscriminationProduce
     EcalIsolAnnulus_maximumSumEtCut_       = iConfig.getParameter<double>("ECALisolAnnulus_maximumSumEtCut");   
   }
   ~CaloRecoTauDiscriminationByIsolation(){} 
-  double discriminate(const CaloTauRef&) override;
+  double discriminate(const CaloTauRef&) const override;
  private:  
   bool applyDiscriminationByTrackerIsolation_;
   unsigned TrackerIsolAnnulus_maximumOccupancy_;   
@@ -26,7 +28,7 @@ class CaloRecoTauDiscriminationByIsolation : public CaloTauDiscriminationProduce
   double EcalIsolAnnulus_maximumSumEtCut_;
 };
 
-double CaloRecoTauDiscriminationByIsolation::discriminate(const CaloTauRef& caloTau)
+double CaloRecoTauDiscriminationByIsolation::discriminate(const CaloTauRef& caloTau) const 
 {
   if ( applyDiscriminationByTrackerIsolation_ ){  
     if ( caloTau->isolationTracks().size() > TrackerIsolAnnulus_maximumOccupancy_ ) return 0.;
@@ -38,6 +40,8 @@ double CaloRecoTauDiscriminationByIsolation::discriminate(const CaloTauRef& calo
   
   // N.B. the lead track requirement must be included in the discriminants
   return 1.;
+}
+
 }
 
 DEFINE_FWK_MODULE(CaloRecoTauDiscriminationByIsolation);

--- a/RecoTauTag/RecoTau/plugins/CaloRecoTauDiscriminationByLeadingTrackPtCut.cc
+++ b/RecoTauTag/RecoTau/plugins/CaloRecoTauDiscriminationByLeadingTrackPtCut.cc
@@ -11,19 +11,19 @@
 
 using namespace reco;
 
-class CaloRecoTauDiscriminationByLeadingTrackPtCut : public CaloTauDiscriminationProducerBase {
+class CaloRecoTauDiscriminationByLeadingTrackPtCut final : public CaloTauDiscriminationProducerBase {
    public:
       explicit CaloRecoTauDiscriminationByLeadingTrackPtCut(const edm::ParameterSet& iConfig):CaloTauDiscriminationProducerBase(iConfig){   
          minPtLeadTrack_ = iConfig.getParameter<double>("MinPtLeadingTrack");
       }
       ~CaloRecoTauDiscriminationByLeadingTrackPtCut(){} 
-      double discriminate(const CaloTauRef& theCaloTauRef) override;
+      double discriminate(const CaloTauRef& theCaloTauRef) const override;
 
    private:
       double minPtLeadTrack_;
 };
 
-double CaloRecoTauDiscriminationByLeadingTrackPtCut::discriminate(const CaloTauRef& theCaloTauRef)
+double CaloRecoTauDiscriminationByLeadingTrackPtCut::discriminate(const CaloTauRef& theCaloTauRef) const
 {
    double leadTrackPt_ = -1;
 

--- a/RecoTauTag/RecoTau/plugins/CaloRecoTauDiscriminationByNProngs.cc
+++ b/RecoTauTag/RecoTau/plugins/CaloRecoTauDiscriminationByNProngs.cc
@@ -7,10 +7,12 @@
  * based on H+ tau ID by Lauri Wendland
  */
 
+namespace {
+
 using namespace reco;
 using namespace std;
 
-class CaloRecoTauDiscriminationByNProngs
+class CaloRecoTauDiscriminationByNProngs final 
   : public CaloTauDiscriminationProducerBase  {
   public:
     explicit CaloRecoTauDiscriminationByNProngs(const edm::ParameterSet& iConfig)
@@ -19,7 +21,7 @@ class CaloRecoTauDiscriminationByNProngs
       booleanOutput = iConfig.getParameter<bool>("BooleanOutput");
     }
     ~CaloRecoTauDiscriminationByNProngs(){}
-    double discriminate(const reco::CaloTauRef&) override;
+    double discriminate(const reco::CaloTauRef&) const override;
 
   private:
     uint32_t nprongs;
@@ -27,7 +29,7 @@ class CaloRecoTauDiscriminationByNProngs
 };
 
 
-double CaloRecoTauDiscriminationByNProngs::discriminate(const CaloTauRef& tau){
+double CaloRecoTauDiscriminationByNProngs::discriminate(const CaloTauRef& tau) const {
   bool accepted = false;
   int np = tau->signalTracks().size();
   if((np == 1 && (nprongs == 1 || nprongs == 0)) ||
@@ -37,4 +39,5 @@ double CaloRecoTauDiscriminationByNProngs::discriminate(const CaloTauRef& tau){
   return np;
 }
 
+}
 DEFINE_FWK_MODULE(CaloRecoTauDiscriminationByNProngs);

--- a/RecoTauTag/RecoTau/plugins/CaloRecoTauDiscriminationByTauPolarization.cc
+++ b/RecoTauTag/RecoTau/plugins/CaloRecoTauDiscriminationByTauPolarization.cc
@@ -6,6 +6,8 @@
  * contributors : Sami Lehti (sami.lehti@cern.ch ; HIP, Helsinki)
  */
 
+
+namespace {
 using namespace reco;
 using namespace std;
 
@@ -19,7 +21,7 @@ class CaloRecoTauDiscriminationByTauPolarization : public CaloTauDiscriminationP
         }
 
     ~CaloRecoTauDiscriminationByTauPolarization(){}
-    double discriminate(const CaloTauRef&) override;
+    double discriminate(const CaloTauRef&) const override;
 
   private:
     bool booleanOutput;
@@ -27,12 +29,12 @@ class CaloRecoTauDiscriminationByTauPolarization : public CaloTauDiscriminationP
 };
 
 double
-CaloRecoTauDiscriminationByTauPolarization::discriminate(const CaloTauRef& tau){
+CaloRecoTauDiscriminationByTauPolarization::discriminate(const CaloTauRef& tau) const {
   double rTau = 0;
   if(tau.isNonnull() && tau->p() > 0 && tau->leadTrack().isNonnull())
     rTau = tau->leadTrack()->p()/tau->p();
   if(booleanOutput) return ( rTau > rTauMin ? 1. : 0. );
   return rTau;
 }
-
+}
 DEFINE_FWK_MODULE(CaloRecoTauDiscriminationByTauPolarization);

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauCorrectedInvariantMassProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauCorrectedInvariantMassProducer.cc
@@ -19,6 +19,7 @@
 #include "DataFormats/TauReco/interface/PFTauDecayMode.h"
 #include "DataFormats/TauReco/interface/PFTauDecayModeAssociation.h"
 
+namespace {
 using namespace reco;
 
 class PFRecoTauCorrectedInvariantMassProducer : public PFTauDiscriminationProducerBase  {
@@ -27,7 +28,7 @@ class PFRecoTauCorrectedInvariantMassProducer : public PFTauDiscriminationProduc
          PFTauDecayModeProducer_     = iConfig.getParameter<edm::InputTag>("PFTauDecayModeProducer");
       }
       ~PFRecoTauCorrectedInvariantMassProducer(){} 
-      double discriminate(const PFTauRef& pfTau) override;
+      double discriminate(const PFTauRef& pfTau) const override;
       void beginEvent(const edm::Event& event, const edm::EventSetup& evtSetup) override;
    private:
       edm::InputTag PFTauDecayModeProducer_;
@@ -40,10 +41,10 @@ void PFRecoTauCorrectedInvariantMassProducer::beginEvent(const edm::Event& event
    event.getByLabel(PFTauDecayModeProducer_, theDMAssoc);
 }
 
-double PFRecoTauCorrectedInvariantMassProducer::discriminate(const PFTauRef& thePFTauRef)
+double PFRecoTauCorrectedInvariantMassProducer::discriminate(const PFTauRef& thePFTauRef) const
 {
    const PFTauDecayMode& theDecayMode = (*theDMAssoc)[thePFTauRef];
    return theDecayMode.mass();
 }
-
+}
 DEFINE_FWK_MODULE(PFRecoTauCorrectedInvariantMassProducer);

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDecayModeIndexProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDecayModeIndexProducer.cc
@@ -14,15 +14,17 @@
 #include "DataFormats/TauReco/interface/PFTauDecayMode.h"
 #include "DataFormats/TauReco/interface/PFTauDecayModeAssociation.h"
 
+namespace {
+
 using namespace reco;
 
-class PFRecoTauDecayModeIndexProducer : public PFTauDiscriminationProducerBase {
+class PFRecoTauDecayModeIndexProducer final : public PFTauDiscriminationProducerBase {
    public:
       explicit PFRecoTauDecayModeIndexProducer(const edm::ParameterSet& iConfig):PFTauDiscriminationProducerBase(iConfig) {   
          PFTauDecayModeProducer_     = iConfig.getParameter<edm::InputTag>("PFTauDecayModeProducer");
       }
       ~PFRecoTauDecayModeIndexProducer(){} 
-      double discriminate(const PFTauRef& thePFTauRef);
+      double discriminate(const PFTauRef& thePFTauRef) const ;
       void beginEvent(const edm::Event& evt, const edm::EventSetup& evtSetup);
    private:
       edm::InputTag PFTauDecayModeProducer_;
@@ -36,7 +38,7 @@ void PFRecoTauDecayModeIndexProducer::beginEvent(const edm::Event& event, const 
    event.getByLabel(PFTauDecayModeProducer_, decayModes_);
 }
 
-double PFRecoTauDecayModeIndexProducer::discriminate(const PFTauRef& thePFTauRef)
+double PFRecoTauDecayModeIndexProducer::discriminate(const PFTauRef& thePFTauRef) const
 {
    int theDecayModeIndex = -1;
 
@@ -50,4 +52,6 @@ double PFRecoTauDecayModeIndexProducer::discriminate(const PFTauRef& thePFTauRef
    return theDecayModeIndex;
 }
   
+}
+
 DEFINE_FWK_MODULE(PFRecoTauDecayModeIndexProducer);

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstElectron.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstElectron.cc
@@ -7,9 +7,11 @@
 #include "RecoTauTag/RecoTau/interface/TauDiscriminationProducerBase.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 
+namespace {
+
 using namespace reco;
 
-class PFRecoTauDiscriminationAgainstElectron : public PFTauDiscriminationProducerBase  {
+class PFRecoTauDiscriminationAgainstElectron final : public PFTauDiscriminationProducerBase  {
    public:
       explicit PFRecoTauDiscriminationAgainstElectron(const edm::ParameterSet& iConfig):PFTauDiscriminationProducerBase(iConfig) {
 
@@ -55,7 +57,7 @@ class PFRecoTauDiscriminationAgainstElectron : public PFTauDiscriminationProduce
 
       }
 
-      double discriminate(const PFTauRef& pfTau) override;
+      double discriminate(const PFTauRef& pfTau) const override;
 
       ~PFRecoTauDiscriminationAgainstElectron(){}
 
@@ -100,7 +102,7 @@ class PFRecoTauDiscriminationAgainstElectron : public PFTauDiscriminationProduce
 
 };
 
-double PFRecoTauDiscriminationAgainstElectron::discriminate(const PFTauRef& thePFTauRef)
+double PFRecoTauDiscriminationAgainstElectron::discriminate(const PFTauRef& thePFTauRef) const 
 {
 
 
@@ -237,6 +239,7 @@ PFRecoTauDiscriminationAgainstElectron::isInEcalCrack(double eta) const
 	  (eta>0.770 && eta<0.806) ||
 	  (eta>1.127 && eta<1.163) ||
 	  (eta>1.460 && eta<1.558));
+}
 }
 
 DEFINE_FWK_MODULE(PFRecoTauDiscriminationAgainstElectron);

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstElectron2.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstElectron2.cc
@@ -66,7 +66,7 @@ public:
 
   void beginEvent(const edm::Event&, const edm::EventSetup&);
 
-  double discriminate(const PFTauRef&);
+  double discriminate(const PFTauRef&) const;
   
   ~PFRecoTauDiscriminationAgainstElectron2()
   {  }
@@ -154,7 +154,7 @@ void PFRecoTauDiscriminationAgainstElectron2::beginEvent(const edm::Event& evt, 
 
 }
 
-double PFRecoTauDiscriminationAgainstElectron2::discriminate(const PFTauRef& thePFTauRef)
+double PFRecoTauDiscriminationAgainstElectron2::discriminate(const PFTauRef& thePFTauRef) const
 {
   double discriminator = 0.;
   

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstElectronDeadECAL.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstElectronDeadECAL.cc
@@ -53,7 +53,7 @@ class PFRecoTauDiscriminationAgainstElectronDeadECAL : public PFTauDiscriminatio
     updateBadTowers(es);
   }
 
-  double discriminate(const PFTauRef& pfTau) override
+  double discriminate(const PFTauRef& pfTau) const override
   {
     if ( verbosity_ ) {
       edm::LogPrint("PFTauAgainstEleDeadECAL") << "<PFRecoTauDiscriminationAgainstElectronDeadECAL::discriminate>:" ;

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstElectronMVA5.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstElectronMVA5.cc
@@ -71,7 +71,6 @@ private:
   edm::Handle<TauCollection> taus_;
 
   std::auto_ptr<PFTauDiscriminator> category_output_;
-  mutable size_t tauIndex_;  // FIXME it is thread safe...
 
   int verbosity_;
 };
@@ -82,7 +81,6 @@ void PFRecoTauDiscriminationAgainstElectronMVA5::beginEvent(const edm::Event& ev
 
   evt.getByToken(Tau_token, taus_);
   category_output_.reset(new PFTauDiscriminator(TauRefProd(taus_)));
-  tauIndex_ = 0;
 
   evt.getByToken(GsfElectrons_token, gsfElectrons_);
 }
@@ -141,7 +139,6 @@ double PFRecoTauDiscriminationAgainstElectronMVA5::discriminate(const PFTauRef& 
 	  if ( isInEcalCrack(tauEtaAtEcalEntrance) || isInEcalCrack(leadChargedPFCandEtaAtEcalEntrance) ) {
 	    // add category index
 	    category_output_->setValue(tauIndex_, category);
-	    ++tauIndex_;
 	    // return MVA output value
 	    return -99;
 	  }
@@ -184,7 +181,6 @@ double PFRecoTauDiscriminationAgainstElectronMVA5::discriminate(const PFTauRef& 
       if ( isInEcalCrack(tauEtaAtEcalEntrance) || isInEcalCrack(leadChargedPFCandEtaAtEcalEntrance) ) {
 	// add category index
 	category_output_->setValue(tauIndex_, category);
-	++tauIndex_;
 	// return MVA output value
 	return -99;
       }
@@ -224,7 +220,6 @@ double PFRecoTauDiscriminationAgainstElectronMVA5::discriminate(const PFTauRef& 
 
   // add category index
   category_output_->setValue(tauIndex_, category);
-  ++tauIndex_;
   // return MVA output value
   return mvaValue;
 }

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstElectronMVA5.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstElectronMVA5.cc
@@ -48,7 +48,7 @@ class PFRecoTauDiscriminationAgainstElectronMVA5 : public PFTauDiscriminationPro
 
   void beginEvent(const edm::Event&, const edm::EventSetup&);
 
-  double discriminate(const PFTauRef&);
+  double discriminate(const PFTauRef&) const;
 
   void endEvent(edm::Event&);
 
@@ -69,8 +69,9 @@ private:
   edm::EDGetTokenT<reco::GsfElectronCollection> GsfElectrons_token;
   edm::Handle<reco::GsfElectronCollection> gsfElectrons_;
   edm::Handle<TauCollection> taus_;
+
   std::auto_ptr<PFTauDiscriminator> category_output_;
-  size_t tauIndex_;
+  mutable size_t tauIndex_;  // FIXME it is thread safe...
 
   int verbosity_;
 };
@@ -86,7 +87,7 @@ void PFRecoTauDiscriminationAgainstElectronMVA5::beginEvent(const edm::Event& ev
   evt.getByToken(GsfElectrons_token, gsfElectrons_);
 }
 
-double PFRecoTauDiscriminationAgainstElectronMVA5::discriminate(const PFTauRef& thePFTauRef)
+double PFRecoTauDiscriminationAgainstElectronMVA5::discriminate(const PFTauRef& thePFTauRef) const
 {
   double mvaValue = 1.;
   double category = -1.;

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstMuon.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstMuon.cc
@@ -34,7 +34,7 @@ class PFRecoTauDiscriminationAgainstMuon : public PFTauDiscriminationProducerBas
 
   ~PFRecoTauDiscriminationAgainstMuon() {} 
 
-  double discriminate(const PFTauRef& pfTau) override;
+  double discriminate(const PFTauRef& pfTau) const override;
 
  private:  
   std::string discriminatorOption_;
@@ -46,7 +46,7 @@ class PFRecoTauDiscriminationAgainstMuon : public PFTauDiscriminationProducerBas
   bool checkNumMatches_;
 };
 
-double PFRecoTauDiscriminationAgainstMuon::discriminate(const PFTauRef& thePFTauRef)
+double PFRecoTauDiscriminationAgainstMuon::discriminate(const PFTauRef& thePFTauRef) const
 {
   bool decision = true;
 

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstMuon2.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstMuon2.cc
@@ -25,7 +25,9 @@
 #include <string>
 #include <iostream>
 
-class PFRecoTauDiscriminationAgainstMuon2 : public PFTauDiscriminationProducerBase 
+namespace {
+
+class PFRecoTauDiscriminationAgainstMuon2 final : public PFTauDiscriminationProducerBase
 {
   enum { kLoose, kMedium, kTight, kCustom };
  public:
@@ -66,7 +68,7 @@ class PFRecoTauDiscriminationAgainstMuon2 : public PFTauDiscriminationProducerBa
 
   void beginEvent(const edm::Event&, const edm::EventSetup&) override;
 
-  double discriminate(const reco::PFTauRef&) override;
+  double discriminate(const reco::PFTauRef&) const override;
 
  private:  
   std::string moduleLabel_;
@@ -149,7 +151,7 @@ namespace
   }
 }
 
-double PFRecoTauDiscriminationAgainstMuon2::discriminate(const reco::PFTauRef& pfTau)
+double PFRecoTauDiscriminationAgainstMuon2::discriminate(const reco::PFTauRef& pfTau) const
 {
   if ( verbosity_ ) {
     edm::LogPrint("PFTauAgainstMuon2") << "<PFRecoTauDiscriminationAgainstMuon2::discriminate>:" ;
@@ -275,5 +277,7 @@ double PFRecoTauDiscriminationAgainstMuon2::discriminate(const reco::PFTauRef& p
 
   return discriminatorValue;
 } 
+
+}
 
 DEFINE_FWK_MODULE(PFRecoTauDiscriminationAgainstMuon2);

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstMuonMVA.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstMuonMVA.cc
@@ -60,9 +60,9 @@ namespace
     es.get<GBRWrapperRcd>().get(mvaName, mva);
     return mva.product();
   }
-}
 
-class PFRecoTauDiscriminationAgainstMuonMVA : public PFTauDiscriminationProducerBase  
+
+class PFRecoTauDiscriminationAgainstMuonMVA final : public PFTauDiscriminationProducerBase  
 {
  public:
   explicit PFRecoTauDiscriminationAgainstMuonMVA(const edm::ParameterSet& cfg)
@@ -90,7 +90,7 @@ class PFRecoTauDiscriminationAgainstMuonMVA : public PFTauDiscriminationProducer
 
   void beginEvent(const edm::Event&, const edm::EventSetup&);
 
-  double discriminate(const PFTauRef&);
+  double discriminate(const PFTauRef&) const;
 
   void endEvent(edm::Event&);
 
@@ -121,7 +121,7 @@ class PFRecoTauDiscriminationAgainstMuonMVA : public PFTauDiscriminationProducer
 
   edm::Handle<TauCollection> taus_;
   std::auto_ptr<PFTauDiscriminator> category_output_;
-  size_t tauIndex_;
+  mutable size_t tauIndex_;
 
   std::vector<TFile*> inputFilesToDelete_;
 
@@ -167,7 +167,7 @@ namespace
   }
 }
 
-double PFRecoTauDiscriminationAgainstMuonMVA::discriminate(const PFTauRef& tau)
+double PFRecoTauDiscriminationAgainstMuonMVA::discriminate(const PFTauRef& tau) const
 {
   if ( verbosity_ ) {
     edm::LogPrint("PFTauAgainstMuonMVA") << "<PFRecoTauDiscriminationAgainstMuonMVA::discriminate>:";
@@ -241,6 +241,8 @@ void PFRecoTauDiscriminationAgainstMuonMVA::endEvent(edm::Event& evt)
 {
   // add all category indices to event
   evt.put(category_output_, "category");
+}
+
 }
 
 DEFINE_FWK_MODULE(PFRecoTauDiscriminationAgainstMuonMVA);

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstMuonMVA.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstMuonMVA.cc
@@ -121,7 +121,6 @@ class PFRecoTauDiscriminationAgainstMuonMVA final : public PFTauDiscriminationPr
 
   edm::Handle<TauCollection> taus_;
   std::auto_ptr<PFTauDiscriminator> category_output_;
-  mutable size_t tauIndex_;
 
   std::vector<TFile*> inputFilesToDelete_;
 
@@ -142,7 +141,6 @@ void PFRecoTauDiscriminationAgainstMuonMVA::beginEvent(const edm::Event& evt, co
 
   evt.getByToken(Tau_token, taus_);
   category_output_.reset(new PFTauDiscriminator(TauRefProd(taus_)));
-  tauIndex_ = 0;
 }
 
 namespace
@@ -177,7 +175,6 @@ double PFRecoTauDiscriminationAgainstMuonMVA::discriminate(const PFTauRef& tau) 
   // CV: define dummy category index in order to use RecoTauDiscriminantCutMultiplexer module to appy WP cuts
   double category = 0.; 
   category_output_->setValue(tauIndex_, category);
-  ++tauIndex_;
 
   // CV: computation of anti-muon MVA value requires presence of leading charged hadron
   if ( tau->leadPFChargedHadrCand().isNull() ) return 0.;

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByCharge.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByCharge.cc
@@ -18,13 +18,13 @@ class PFRecoTauDiscriminationByCharge : public PFTauDiscriminationProducerBase  
          oneOrThreeProng_  = iConfig.getParameter<bool>("ApplyOneOrThreeProngCut");
       }
       ~PFRecoTauDiscriminationByCharge(){} 
-      double discriminate(const PFTauRef& pfTau) override;
+      double discriminate(const PFTauRef& pfTau) const override;
    private:
       uint32_t chargeReq_;
       bool oneOrThreeProng_;
 };
 
-double PFRecoTauDiscriminationByCharge::discriminate(const PFTauRef& thePFTauRef)
+double PFRecoTauDiscriminationByCharge::discriminate(const PFTauRef& thePFTauRef) const
 {
    uint16_t nSigTk        =  thePFTauRef->signalPFChargedHadrCands().size();
    bool chargeok          =  (std::abs(thePFTauRef->charge()) == int(chargeReq_));

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByDeltaE.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByDeltaE.cc
@@ -25,10 +25,10 @@ class PFRecoTauDiscriminationByDeltaE : public PFTauDiscriminationProducerBase  
       	~PFRecoTauDiscriminationByDeltaE(){}
 
 	void beginEvent(const edm::Event&, const edm::EventSetup&) override;
-	double discriminate(const reco::PFTauRef&) override;
+	double discriminate(const reco::PFTauRef&) const override;
 
     private:
-	double DeltaE(const PFTauRef&);
+	double DeltaE(const PFTauRef&) const ;
 
 	double chargedPionMass;
 
@@ -39,14 +39,14 @@ class PFRecoTauDiscriminationByDeltaE : public PFTauDiscriminationProducerBase  
 void PFRecoTauDiscriminationByDeltaE::beginEvent(const Event& iEvent, const EventSetup& iSetup){
 }
 
-double PFRecoTauDiscriminationByDeltaE::discriminate(const PFTauRef& tau){
+double PFRecoTauDiscriminationByDeltaE::discriminate(const PFTauRef& tau) const{
 
 	double dE = DeltaE(tau);
 	if(booleanOutput) return ( dE > deltaEmin && dE < deltaEmax ? 1. : 0. );
 	return dE;
 }
 
-double PFRecoTauDiscriminationByDeltaE::DeltaE(const PFTauRef& tau){
+double PFRecoTauDiscriminationByDeltaE::DeltaE(const PFTauRef& tau) const {
 	double tracksE = 0;
 	const std::vector<PFCandidatePtr>& signalTracks = tau->signalPFChargedHadrCands();
 	for(size_t i = 0; i < signalTracks.size(); ++i){

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByFlightPathSignificance.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByFlightPathSignificance.cc
@@ -36,11 +36,11 @@ class PFRecoTauDiscriminationByFlightPathSignificance
     ~PFRecoTauDiscriminationByFlightPathSignificance(){}
 
     void beginEvent(const edm::Event&, const edm::EventSetup&) override;
-    double discriminate(const reco::PFTauRef&) override;
+    double discriminate(const reco::PFTauRef&) const override;
 
   private:
-    double threeProngFlightPathSig(const PFTauRef&);
-    double vertexSignificance(reco::Vertex&,reco::Vertex&,GlobalVector&);
+    double threeProngFlightPathSig(const PFTauRef&) const ;
+    double vertexSignificance(reco::Vertex const&,reco::Vertex const &,GlobalVector const&) const;
 
     reco::tau::RecoTauVertexAssociator* vertexAssociator_;
 
@@ -63,14 +63,14 @@ void PFRecoTauDiscriminationByFlightPathSignificance::beginEvent(
 
 }
 
-double PFRecoTauDiscriminationByFlightPathSignificance::discriminate(const PFTauRef& tau){
+double PFRecoTauDiscriminationByFlightPathSignificance::discriminate(const PFTauRef& tau) const{
 
   if(booleanOutput) return ( threeProngFlightPathSig(tau) > flightPathSig ? 1. : 0. );
   return threeProngFlightPathSig(tau);
 }
 
 double PFRecoTauDiscriminationByFlightPathSignificance::threeProngFlightPathSig(
-    const PFTauRef& tau){
+    const PFTauRef& tau) const {
   double flightPathSignificance = 0;
 
   reco::VertexRef primaryVertex = vertexAssociator_->associatedVertex(*tau);
@@ -110,7 +110,7 @@ double PFRecoTauDiscriminationByFlightPathSignificance::threeProngFlightPathSig(
 }
 
 double PFRecoTauDiscriminationByFlightPathSignificance::vertexSignificance(
-    reco::Vertex& pv, Vertex& sv,GlobalVector& direction){
+    reco::Vertex const & pv, Vertex const & sv,GlobalVector const & direction) const {
   return SecondaryVertex::computeDist3d(pv,sv,direction,withPVError).significance();
 }
 

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByHPSSelection.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByHPSSelection.cc
@@ -23,7 +23,7 @@ class PFRecoTauDiscriminationByHPSSelection : public PFTauDiscriminationProducer
  public:
   explicit PFRecoTauDiscriminationByHPSSelection(const edm::ParameterSet&);
   ~PFRecoTauDiscriminationByHPSSelection();
-  double discriminate(const reco::PFTauRef&) override;
+  double discriminate(const reco::PFTauRef&) const override;
 
  private:
   typedef StringObjectFunction<reco::PFTau> TauFunc;
@@ -116,7 +116,7 @@ PFRecoTauDiscriminationByHPSSelection::~PFRecoTauDiscriminationByHPSSelection()
 }
 
 double
-PFRecoTauDiscriminationByHPSSelection::discriminate(const reco::PFTauRef& tau) 
+PFRecoTauDiscriminationByHPSSelection::discriminate(const reco::PFTauRef& tau) const
 {
   if ( verbosity_ ) {
     edm::LogPrint("PFTauByHPSSelect") << "<PFRecoTauDiscriminationByHPSSelection::discriminate>:" ;

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByInvMass.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByInvMass.cc
@@ -39,7 +39,7 @@ class PFRecoTauDiscriminationByInvMass: public PFTauDiscriminationProducerBase {
       }
     }
     ~PFRecoTauDiscriminationByInvMass(){}
-    double discriminate(const reco::PFTauRef&) override;
+    double discriminate(const reco::PFTauRef&) const override;
 
   private:
     typedef std::pair<unsigned int, unsigned int> IntPair;
@@ -52,7 +52,7 @@ class PFRecoTauDiscriminationByInvMass: public PFTauDiscriminationProducerBase {
 };
 
 double
-PFRecoTauDiscriminationByInvMass::discriminate(const reco::PFTauRef& tau) {
+PFRecoTauDiscriminationByInvMass::discriminate(const reco::PFTauRef& tau) const {
   double mass = tau->mass();
   if (cut_) {
     unsigned int charged = tau->signalPFChargedHadrCands().size();

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByIsolation.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByIsolation.cc
@@ -148,7 +148,7 @@ class PFRecoTauDiscriminationByIsolation : public PFTauDiscriminationProducerBas
   ~PFRecoTauDiscriminationByIsolation(){}
 
   void beginEvent(const edm::Event& evt, const edm::EventSetup& evtSetup) override;
-  double discriminate(const PFTauRef& pfTau) override;
+  double discriminate(const PFTauRef& pfTau) const override;
 
  private:
   std::string moduleLabel_;
@@ -190,9 +190,6 @@ class PFRecoTauDiscriminationByIsolation : public PFTauDiscriminationProducerBas
   edm::InputTag vertexSrc_;
   edm::EDGetTokenT<reco::VertexCollection> vertex_token;
   std::vector<reco::PFCandidatePtr> chargedPFCandidatesInEvent_;
-  std::vector<PFCandidatePtr> isoCharged_;
-  std::vector<PFCandidatePtr> isoNeutral_;
-  std::vector<PFCandidatePtr> isoPU_;
   // Size of cone used to collect PU tracks
   double deltaBetaCollectionCone_;
   std::auto_ptr<TFormula> deltaBetaFormula_;
@@ -251,7 +248,7 @@ void PFRecoTauDiscriminationByIsolation::beginEvent(const edm::Event& event, con
 }
 
 double
-PFRecoTauDiscriminationByIsolation::discriminate(const PFTauRef& pfTau) 
+PFRecoTauDiscriminationByIsolation::discriminate(const PFTauRef& pfTau) const
 {
   if ( verbosity_ ) {
     std::cout << "<PFRecoTauDiscriminationByIsolation::discriminate (moduleLabel = " << moduleLabel_ <<")>:" << std::endl;
@@ -259,11 +256,11 @@ PFRecoTauDiscriminationByIsolation::discriminate(const PFTauRef& pfTau)
   }
 
   // collect the objects we are working with (ie tracks, tracks+gammas, etc)
-  isoCharged_.clear();
+  std::vector<PFCandidatePtr> isoCharged_;
+  std::vector<PFCandidatePtr> isoNeutral_;
+  std::vector<PFCandidatePtr> isoPU_;
   isoCharged_.reserve(pfTau->isolationPFChargedHadrCands().size());
-  isoNeutral_.clear();
   isoNeutral_.reserve(pfTau->isolationPFGammaCands().size());
-  isoPU_.clear();
   isoPU_.reserve(chargedPFCandidatesInEvent_.size());
 
   // Get the primary vertex associated to this tau

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByLeadingObjectPtCut.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByLeadingObjectPtCut.cc
@@ -16,13 +16,13 @@ class PFRecoTauDiscriminationByLeadingObjectPtCut : public PFTauDiscriminationPr
          minPtLeadObject_ = iConfig.getParameter<double>("MinPtLeadingObject");
       }
       ~PFRecoTauDiscriminationByLeadingObjectPtCut(){} 
-      double discriminate(const PFTauRef& pfTau) override;
+      double discriminate(const PFTauRef& pfTau) const override;
    private:
       bool chargedOnly_;
       double minPtLeadObject_;
 };
 
-double PFRecoTauDiscriminationByLeadingObjectPtCut::discriminate(const PFTauRef& thePFTauRef)
+double PFRecoTauDiscriminationByLeadingObjectPtCut::discriminate(const PFTauRef& thePFTauRef) const
 {
    double leadObjectPt = -1.;
    if( chargedOnly_ )

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByMVAIsolation2.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByMVAIsolation2.cc
@@ -142,7 +142,6 @@ class PFRecoTauDiscriminationByIsolationMVA2 : public PFTauDiscriminationProduce
 
   edm::Handle<TauCollection> taus_;
   std::auto_ptr<PFTauDiscriminator> category_output_;
-  mutable size_t tauIndex_;
 
   std::vector<TFile*> inputFilesToDelete_;
 
@@ -167,7 +166,6 @@ void PFRecoTauDiscriminationByIsolationMVA2::beginEvent(const edm::Event& evt, c
 
   evt.getByToken(Tau_token, taus_);
   category_output_.reset(new PFTauDiscriminator(TauRefProd(taus_)));
-  tauIndex_ = 0;
 }
 
 double PFRecoTauDiscriminationByIsolationMVA2::discriminate(const PFTauRef& tau) const
@@ -175,7 +173,6 @@ double PFRecoTauDiscriminationByIsolationMVA2::discriminate(const PFTauRef& tau)
   // CV: define dummy category index in order to use RecoTauDiscriminantCutMultiplexer module to appy WP cuts
   double category = 0.; 
   category_output_->setValue(tauIndex_, category);
-  ++tauIndex_;
 
   // CV: computation of MVA value requires presence of leading charged hadron
   if ( tau->leadPFChargedHadrCand().isNull() ) return 0.;

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByMVAIsolation2.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByMVAIsolation2.cc
@@ -103,7 +103,7 @@ class PFRecoTauDiscriminationByIsolationMVA2 : public PFTauDiscriminationProduce
 
   void beginEvent(const edm::Event&, const edm::EventSetup&);
 
-  double discriminate(const PFTauRef&);
+  double discriminate(const PFTauRef&) const;
 
   void endEvent(edm::Event&);
 
@@ -142,7 +142,7 @@ class PFRecoTauDiscriminationByIsolationMVA2 : public PFTauDiscriminationProduce
 
   edm::Handle<TauCollection> taus_;
   std::auto_ptr<PFTauDiscriminator> category_output_;
-  size_t tauIndex_;
+  mutable size_t tauIndex_;
 
   std::vector<TFile*> inputFilesToDelete_;
 
@@ -170,7 +170,7 @@ void PFRecoTauDiscriminationByIsolationMVA2::beginEvent(const edm::Event& evt, c
   tauIndex_ = 0;
 }
 
-double PFRecoTauDiscriminationByIsolationMVA2::discriminate(const PFTauRef& tau)
+double PFRecoTauDiscriminationByIsolationMVA2::discriminate(const PFTauRef& tau) const
 {
   // CV: define dummy category index in order to use RecoTauDiscriminantCutMultiplexer module to appy WP cuts
   double category = 0.; 

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByNProngs.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByNProngs.cc
@@ -22,7 +22,7 @@ class PFRecoTauDiscriminationByNProngs : public PFTauDiscriminationProducerBase 
       	~PFRecoTauDiscriminationByNProngs(){}
 
 	void beginEvent(const edm::Event&, const edm::EventSetup&) override;
-	double discriminate(const reco::PFTauRef&) override;
+	double discriminate(const reco::PFTauRef&) const override;
 
     private:
 	std::auto_ptr<tau::RecoTauQualityCuts> qcuts_;
@@ -49,7 +49,7 @@ void PFRecoTauDiscriminationByNProngs::beginEvent(const Event& iEvent, const Eve
 	vertexAssociator_->setEvent(iEvent);
 }
 
-double PFRecoTauDiscriminationByNProngs::discriminate(const PFTauRef& tau){
+double PFRecoTauDiscriminationByNProngs::discriminate(const PFTauRef& tau) const{
 
 	reco::VertexRef pv = vertexAssociator_->associatedVertex(*tau);
 	const PFCandidatePtr leadingTrack = tau->leadPFChargedHadrCand();

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByTauPolarization.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByTauPolarization.cc
@@ -22,7 +22,7 @@ class PFRecoTauDiscriminationByTauPolarization :
     ~PFRecoTauDiscriminationByTauPolarization(){}
 
     void beginEvent(const Event&, const EventSetup&) override;
-    double discriminate(const PFTauRef&) override;
+    double discriminate(const PFTauRef&) const override;
 
   private:
     bool booleanOutput;
@@ -33,7 +33,7 @@ void PFRecoTauDiscriminationByTauPolarization::beginEvent(
     const Event& event, const EventSetup& eventSetup){}
 
 double
-PFRecoTauDiscriminationByTauPolarization::discriminate(const PFTauRef& tau){
+PFRecoTauDiscriminationByTauPolarization::discriminate(const PFTauRef& tau) const{
 
   double rTau = 0;
   // rtau for PFTau has to be calculated for leading PF charged hadronic candidate

--- a/RecoTauTag/RecoTau/plugins/PFTauDecayModeCutMultiplexer.cc
+++ b/RecoTauTag/RecoTau/plugins/PFTauDecayModeCutMultiplexer.cc
@@ -40,7 +40,7 @@ class PFTauDecayModeCutMultiplexer : public PFTauDiscriminationProducerBase {
       typedef std::vector<ComputerAndCut>    CutList;
       typedef std::map<int, CutList::iterator> DecayModeToCutMap;
 
-      double discriminate(const PFTauRef& thePFTau) override;
+      double discriminate(const PFTauRef& thePFTau) const override;
       void beginEvent(const edm::Event& event, const edm::EventSetup& eventSetup) override;
 
    private:
@@ -107,7 +107,7 @@ PFTauDecayModeCutMultiplexer::beginEvent(const edm::Event& iEvent, const edm::Ev
    iEvent.getByToken(discriminant_token, targetDiscriminant);
 }
 
-double PFTauDecayModeCutMultiplexer::discriminate(const PFTauRef& pfTau)
+double PFTauDecayModeCutMultiplexer::discriminate(const PFTauRef& pfTau) const
 {
    // get decay mode for current tau
    int decayMode = lrint( (*pfTauDecayModeIndices)[pfTau] ); //convert to int
@@ -116,7 +116,7 @@ double PFTauDecayModeCutMultiplexer::discriminate(const PFTauRef& pfTau)
    float valueToMultiplex = (*targetDiscriminant)[pfTau];
 
    // Get correct cut
-   DecayModeToCutMap::iterator iterToComputer = computerMap_.find(decayMode);
+   auto iterToComputer = computerMap_.find(decayMode);
    if(iterToComputer != computerMap_.end()) //if we don't have a MVA mapped to this decay mode, skip it, it fails.
    {
       // use the supplied cut to make a decision

--- a/RecoTauTag/RecoTau/plugins/PFTauDiscriminatorLogicalAndProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/PFTauDiscriminatorLogicalAndProducer.cc
@@ -20,7 +20,7 @@ class PFTauDiscriminatorLogicalAndProducer : public PFTauDiscriminationProducerB
    public:
       explicit PFTauDiscriminatorLogicalAndProducer(const edm::ParameterSet&);
       ~PFTauDiscriminatorLogicalAndProducer(){};
-      double discriminate(const PFTauRef& pfTau) override;
+      double discriminate(const PFTauRef& pfTau) const override;
    private:
       double passResult_;
 };
@@ -32,7 +32,7 @@ PFTauDiscriminatorLogicalAndProducer::PFTauDiscriminatorLogicalAndProducer(const
 }
 
 double
-PFTauDiscriminatorLogicalAndProducer::discriminate(const PFTauRef& pfTau)
+PFTauDiscriminatorLogicalAndProducer::discriminate(const PFTauRef& pfTau) const 
 {
    // if this function is called on a tau, it is has passed (in the base class)
    // the set of prediscriminants, using the prescribed boolean operation.  thus 

--- a/RecoTauTag/RecoTau/plugins/PFTauPrimaryVertexProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/PFTauPrimaryVertexProducer.cc
@@ -14,7 +14,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/Exception.h"
@@ -56,7 +56,7 @@ using namespace reco;
 using namespace edm;
 using namespace std;
 
-class PFTauPrimaryVertexProducer : public EDProducer {
+class PFTauPrimaryVertexProducer final : public edm::stream::EDProducer<> {
  public:
   enum Alg{useInputPV=0, useFontPV};
 

--- a/RecoTauTag/RecoTau/plugins/RecoTauDecayModeCutMultiplexer.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauDecayModeCutMultiplexer.cc
@@ -7,7 +7,7 @@ class RecoTauDecayModeCutMultiplexer : public PFTauDiscriminationProducerBase {
     explicit RecoTauDecayModeCutMultiplexer(const edm::ParameterSet& pset);
 
     ~RecoTauDecayModeCutMultiplexer() {}
-    double discriminate(const reco::PFTauRef&) override;
+    double discriminate(const reco::PFTauRef&) const override;
     void beginEvent(const edm::Event& event, const edm::EventSetup& eventSetup) override;
 
   private:
@@ -47,7 +47,7 @@ RecoTauDecayModeCutMultiplexer::beginEvent(
 }
 
 double
-RecoTauDecayModeCutMultiplexer::discriminate(const reco::PFTauRef& tau) {
+RecoTauDecayModeCutMultiplexer::discriminate(const reco::PFTauRef& tau) const {
   double disc_result = (*handle_)[tau];
   DecayModeCutMap::const_iterator cutIter =
       decayModeCuts_.find(std::make_pair(tau->signalPFChargedHadrCands().size(),

--- a/RecoTauTag/RecoTau/plugins/RecoTauDiscriminantCutMultiplexer.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauDiscriminantCutMultiplexer.cc
@@ -37,7 +37,7 @@ class RecoTauDiscriminantCutMultiplexer : public PFTauDiscriminationProducerBase
   explicit RecoTauDiscriminantCutMultiplexer(const edm::ParameterSet& pset);
 
   ~RecoTauDiscriminantCutMultiplexer();
-  double discriminate(const reco::PFTauRef&) override;
+  double discriminate(const reco::PFTauRef&) const override;
   void beginEvent(const edm::Event& event, const edm::EventSetup& eventSetup) override;
   
  private:
@@ -233,7 +233,7 @@ void RecoTauDiscriminantCutMultiplexer::beginEvent(const edm::Event& evt, const 
 }
 
 double
-RecoTauDiscriminantCutMultiplexer::discriminate(const reco::PFTauRef& tau) 
+RecoTauDiscriminantCutMultiplexer::discriminate(const reco::PFTauRef& tau) const
 {
   if ( verbosity_ ) {
     std::cout << "<RecoTauDiscriminantCutMultiplexer::discriminate>:" << std::endl;

--- a/RecoTauTag/RecoTau/plugins/RecoTauDiscriminationByFlight.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauDiscriminationByFlight.cc
@@ -16,7 +16,7 @@ class PFRecoTauDiscriminationByFlight : public PFTauDiscriminationProducerBase {
     PFRecoTauDiscriminationByFlight(const edm::ParameterSet& pset);
     virtual ~PFRecoTauDiscriminationByFlight(){}
     void beginEvent(const edm::Event& evt, const edm::EventSetup& es) override;
-    double discriminate(const reco::PFTauRef&) override;
+    double discriminate(const reco::PFTauRef&) const override;
   private:
     edm::InputTag vertexSource_;
     edm::InputTag bsSource_;
@@ -51,7 +51,7 @@ void PFRecoTauDiscriminationByFlight::beginEvent(
 }
 
 double PFRecoTauDiscriminationByFlight::discriminate(
-    const reco::PFTauRef& tau) {
+    const reco::PFTauRef& tau) const {
 
   KalmanVertexFitter kvf(true);
   const std::vector<reco::PFCandidatePtr>& signalTracks =

--- a/RecoTauTag/RecoTau/plugins/RecoTauMVATransform.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauMVATransform.cc
@@ -48,7 +48,7 @@ class RecoTauMVATransform : public PFTauDiscriminationProducerBase {
     ~RecoTauMVATransform() {}
 
     void beginEvent(const edm::Event&, const edm::EventSetup&) override;
-    double discriminate(const reco::PFTauRef&) override;
+    double discriminate(const reco::PFTauRef&) const override;
 
   private:
     // Map a decay mode to a transformation
@@ -95,7 +95,7 @@ RecoTauMVATransform::beginEvent(const edm::Event& evt, const edm::EventSetup&) {
   evt.getByLabel(input_, disc_);
 }
 
-double RecoTauMVATransform::discriminate(const reco::PFTauRef& tau) {
+double RecoTauMVATransform::discriminate(const reco::PFTauRef& tau) const {
   // Check if we support this decay mode:
   TransformMap::const_iterator transformIter =
       transforms_.find(tau->decayMode());

--- a/RecoTauTag/RecoTau/plugins/TauDiscriminationAgainstCaloMuon.cc
+++ b/RecoTauTag/RecoTau/plugins/TauDiscriminationAgainstCaloMuon.cc
@@ -42,6 +42,8 @@
 
 #include <string>
 
+namespace {
+
 using namespace reco;
 
 // define acess to lead. track for CaloTaus
@@ -85,7 +87,7 @@ class TauLeadTrackExtractor<reco::PFTau>
 };
 
 template<class TauType, class TauDiscriminator>
-class TauDiscriminationAgainstCaloMuon : public TauDiscriminationProducerBase<TauType, TauDiscriminator>
+class TauDiscriminationAgainstCaloMuon final : public TauDiscriminationProducerBase<TauType, TauDiscriminator>
 {
  public:
   // setup framework types for this tautype
@@ -98,7 +100,7 @@ class TauDiscriminationAgainstCaloMuon : public TauDiscriminationProducerBase<Ta
   // called at the beginning of every event
   void beginEvent(const edm::Event&, const edm::EventSetup&);
 
-  double discriminate(const TauRef&);
+  double discriminate(const TauRef&) const override;
 
  private:  
   edm::InputTag srcEcalRecHitsBarrel_;
@@ -272,7 +274,7 @@ double compHcalEnergySum(const HBHERecHitCollection& hcalRecHits,
 }
 
 template<class TauType, class TauDiscriminator>
-double TauDiscriminationAgainstCaloMuon<TauType, TauDiscriminator>::discriminate(const TauRef& tau)
+double TauDiscriminationAgainstCaloMuon<TauType, TauDiscriminator>::discriminate(const TauRef& tau) const
 {
   if ( !(trackBuilder_ && caloGeometry_) ) return 0.;
 
@@ -307,6 +309,8 @@ double TauDiscriminationAgainstCaloMuon<TauType, TauDiscriminator>::discriminate
   }
 
   return 1.;
+}
+
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/RecoTauTag/RecoTau/plugins/TauDiscriminationAgainstMuon.cc
+++ b/RecoTauTag/RecoTau/plugins/TauDiscriminationAgainstMuon.cc
@@ -18,10 +18,11 @@
 
 #include <string>
 
+namespace {
 using namespace reco;
 
 template<class TauType, class TauDiscriminator>
-class TauDiscriminationAgainstMuon : public TauDiscriminationProducerBase<TauType, TauDiscriminator>
+class TauDiscriminationAgainstMuon final : public TauDiscriminationProducerBase<TauType, TauDiscriminator>
 {
  public:
   // setup framework types for this tautype
@@ -34,10 +35,10 @@ class TauDiscriminationAgainstMuon : public TauDiscriminationProducerBase<TauTyp
   // called at the beginning of every event
   void beginEvent(const edm::Event&, const edm::EventSetup&);
 
-  double discriminate(const TauRef&);
+  double discriminate(const TauRef&) const override;
 
  private:  
-  bool evaluateMuonVeto(const reco::Muon&);
+  bool evaluateMuonVeto(const reco::Muon&) const;
 
   edm::InputTag muonSource_;
   edm::Handle<reco::MuonCollection> muons_;
@@ -80,7 +81,7 @@ void TauDiscriminationAgainstMuon<TauType, TauDiscriminator>::beginEvent(const e
 }		
 
 template<class TauType, class TauDiscriminator>
-bool TauDiscriminationAgainstMuon<TauType, TauDiscriminator>::evaluateMuonVeto(const reco::Muon& muon)
+bool TauDiscriminationAgainstMuon<TauType, TauDiscriminator>::evaluateMuonVeto(const reco::Muon& muon) const 
 {
   bool decision = true;	
 
@@ -108,7 +109,7 @@ bool TauDiscriminationAgainstMuon<TauType, TauDiscriminator>::evaluateMuonVeto(c
 }
 
 template<class TauType, class TauDiscriminator>
-double TauDiscriminationAgainstMuon<TauType, TauDiscriminator>::discriminate(const TauRef& tau)
+double TauDiscriminationAgainstMuon<TauType, TauDiscriminator>::discriminate(const TauRef& tau) const 
 {
   bool decision = true;	
 
@@ -118,6 +119,7 @@ double TauDiscriminationAgainstMuon<TauType, TauDiscriminator>::discriminate(con
   }
 
   return (decision ? 1. : 0.);
+}
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/RecoTauTag/RecoTau/src/AntiElectronIDMVA5.cc
+++ b/RecoTauTag/RecoTau/src/AntiElectronIDMVA5.cc
@@ -117,19 +117,14 @@ AntiElectronIDMVA5::~AntiElectronIDMVA5()
 
 namespace
 {
-  const GBRForest* loadMVAfromFile(const edm::FileInPath& inputFileName, const std::string& mvaName, std::vector<TFile*>& inputFilesToDelete)
+  const GBRForest* loadMVAfromFile(TFile* inputFile, const std::string& mvaName)
   {
-    if ( inputFileName.location() == edm::FileInPath::Unknown ) throw cms::Exception("PFRecoTauDiscriminationAgainstMuonMVA::loadMVA") 
-      << " Failed to find File = " << inputFileName << " !!\n";
-    TFile* inputFile = new TFile(inputFileName.fullPath().data());
   
     //const GBRForest* mva = dynamic_cast<GBRForest*>(inputFile->Get(mvaName.data())); // CV: dynamic_cast<GBRForest*> fails for some reason ?!
     const GBRForest* mva = (GBRForest*)inputFile->Get(mvaName.data());
     if ( !mva )
       throw cms::Exception("PFRecoTauDiscriminationAgainstMuonMVA::loadMVA")
-        << " Failed to load MVA = " << mvaName.data() << " from file = " << inputFileName.fullPath().data() << " !!\n";
-
-    inputFilesToDelete.push_back(inputFile);
+        << " Failed to load MVA = " << mvaName.data() << " from file " << " !!\n";
 
     return mva;
   }
@@ -163,22 +158,27 @@ void AntiElectronIDMVA5::beginEvent(const edm::Event& evt, const edm::EventSetup
       mva_wGwoGSF_EC_             = loadMVAfromDB(es, mvaName_wGwoGSF_EC_);
       mva_wGwGSF_EC_              = loadMVAfromDB(es, mvaName_wGwGSF_EC_);  
     } else {
-      mva_NoEleMatch_woGwoGSF_BL_ = loadMVAfromFile(inputFileName_, mvaName_NoEleMatch_woGwoGSF_BL_, inputFilesToDelete_);
-      mva_NoEleMatch_woGwGSF_BL_  = loadMVAfromFile(inputFileName_, mvaName_NoEleMatch_woGwGSF_BL_, inputFilesToDelete_);
-      mva_NoEleMatch_wGwoGSF_BL_  = loadMVAfromFile(inputFileName_, mvaName_NoEleMatch_wGwoGSF_BL_, inputFilesToDelete_);
-      mva_NoEleMatch_wGwGSF_BL_   = loadMVAfromFile(inputFileName_, mvaName_NoEleMatch_wGwGSF_BL_, inputFilesToDelete_);
-      mva_woGwoGSF_BL_            = loadMVAfromFile(inputFileName_, mvaName_woGwoGSF_BL_, inputFilesToDelete_);
-      mva_woGwGSF_BL_             = loadMVAfromFile(inputFileName_, mvaName_woGwGSF_BL_, inputFilesToDelete_);
-      mva_wGwoGSF_BL_             = loadMVAfromFile(inputFileName_, mvaName_wGwoGSF_BL_, inputFilesToDelete_);
-      mva_wGwGSF_BL_              = loadMVAfromFile(inputFileName_, mvaName_wGwGSF_BL_, inputFilesToDelete_);
-      mva_NoEleMatch_woGwoGSF_EC_ = loadMVAfromFile(inputFileName_, mvaName_NoEleMatch_woGwoGSF_EC_, inputFilesToDelete_);
-      mva_NoEleMatch_woGwGSF_EC_  = loadMVAfromFile(inputFileName_, mvaName_NoEleMatch_woGwGSF_EC_, inputFilesToDelete_);
-      mva_NoEleMatch_wGwoGSF_EC_  = loadMVAfromFile(inputFileName_, mvaName_NoEleMatch_wGwoGSF_EC_, inputFilesToDelete_);
-      mva_NoEleMatch_wGwGSF_EC_   = loadMVAfromFile(inputFileName_, mvaName_NoEleMatch_wGwGSF_EC_, inputFilesToDelete_);
-      mva_woGwoGSF_EC_            = loadMVAfromFile(inputFileName_, mvaName_woGwoGSF_EC_, inputFilesToDelete_);
-      mva_woGwGSF_EC_             = loadMVAfromFile(inputFileName_, mvaName_woGwGSF_EC_, inputFilesToDelete_);
-      mva_wGwoGSF_EC_             = loadMVAfromFile(inputFileName_, mvaName_wGwoGSF_EC_, inputFilesToDelete_);
-      mva_wGwGSF_EC_              = loadMVAfromFile(inputFileName_, mvaName_wGwGSF_EC_, inputFilesToDelete_);  
+          if ( inputFileName_.location() == edm::FileInPath::Unknown ) throw cms::Exception("PFRecoTauDiscriminationAgainstMuonMVA::loadMVA")
+          << " Failed to find File = " << inputFileName_ << " !!\n";
+          TFile* inputFile = new TFile(inputFileName_.fullPath().data());
+
+      mva_NoEleMatch_woGwoGSF_BL_ = loadMVAfromFile(inputFile, mvaName_NoEleMatch_woGwoGSF_BL_);
+      mva_NoEleMatch_woGwGSF_BL_  = loadMVAfromFile(inputFile, mvaName_NoEleMatch_woGwGSF_BL_);
+      mva_NoEleMatch_wGwoGSF_BL_  = loadMVAfromFile(inputFile, mvaName_NoEleMatch_wGwoGSF_BL_);
+      mva_NoEleMatch_wGwGSF_BL_   = loadMVAfromFile(inputFile, mvaName_NoEleMatch_wGwGSF_BL_);
+      mva_woGwoGSF_BL_            = loadMVAfromFile(inputFile, mvaName_woGwoGSF_BL_);
+      mva_woGwGSF_BL_             = loadMVAfromFile(inputFile, mvaName_woGwGSF_BL_);
+      mva_wGwoGSF_BL_             = loadMVAfromFile(inputFile, mvaName_wGwoGSF_BL_);
+      mva_wGwGSF_BL_              = loadMVAfromFile(inputFile, mvaName_wGwGSF_BL_);
+      mva_NoEleMatch_woGwoGSF_EC_ = loadMVAfromFile(inputFile, mvaName_NoEleMatch_woGwoGSF_EC_);
+      mva_NoEleMatch_woGwGSF_EC_  = loadMVAfromFile(inputFile, mvaName_NoEleMatch_woGwGSF_EC_);
+      mva_NoEleMatch_wGwoGSF_EC_  = loadMVAfromFile(inputFile, mvaName_NoEleMatch_wGwoGSF_EC_);
+      mva_NoEleMatch_wGwGSF_EC_   = loadMVAfromFile(inputFile, mvaName_NoEleMatch_wGwGSF_EC_);
+      mva_woGwoGSF_EC_            = loadMVAfromFile(inputFile, mvaName_woGwoGSF_EC_);
+      mva_woGwGSF_EC_             = loadMVAfromFile(inputFile, mvaName_woGwGSF_EC_);
+      mva_wGwoGSF_EC_             = loadMVAfromFile(inputFile, mvaName_wGwoGSF_EC_);
+      mva_wGwGSF_EC_              = loadMVAfromFile(inputFile, mvaName_wGwGSF_EC_);
+      inputFilesToDelete_.push_back(inputFile);  
     }
     isInitialized_ = true;
   }

--- a/RecoTauTag/RecoTau/src/TCTauAlgorithm.cc
+++ b/RecoTauTag/RecoTau/src/TCTauAlgorithm.cc
@@ -25,8 +25,8 @@ TCTauAlgorithm::~TCTauAlgorithm(){}
 
 void TCTauAlgorithm::init(){
 
-	event = 0;
-	setup = 0;
+	event = nullptr;
+	setup = nullptr;
 
 	trackAssociator = new TrackDetectorAssociator();
   	trackAssociator->useDefaultPropagator();
@@ -34,7 +34,6 @@ void TCTauAlgorithm::init(){
         all    = 0;
         passed = 0;
 	prongs = -1;
-	algoComponentUsed = 0;
 }
 
 void TCTauAlgorithm::inputConfig(const edm::ParameterSet& iConfig, edm::ConsumesCollector &iC){
@@ -61,23 +60,19 @@ void TCTauAlgorithm::inputConfig(const edm::ParameterSet& iConfig, edm::Consumes
 }
 
 
-double TCTauAlgorithm::efficiency(){
+double TCTauAlgorithm::efficiency() const {
 	return double(passed)/all;
 }
 
-int TCTauAlgorithm::statistics(){
+int TCTauAlgorithm::statistics() const {
 	return passed;
 }
 
-int TCTauAlgorithm::allTauCandidates(){
+int TCTauAlgorithm::allTauCandidates() const {
         return all;
 }
 
-int TCTauAlgorithm::algoComponent(){
-        return algoComponentUsed;
-}
-
-void TCTauAlgorithm::eventSetup(const edm::Event& iEvent,const edm::EventSetup& iSetup){
+void TCTauAlgorithm::eventSetup(const edm::Event& iEvent,const edm::EventSetup& iSetup) {
 
 	event = &iEvent;
 	setup = &iSetup;
@@ -108,7 +103,7 @@ void TCTauAlgorithm::eventSetup(const edm::Event& iEvent,const edm::EventSetup& 
 }
 
 
-math::XYZTLorentzVector TCTauAlgorithm::recalculateEnergy(const reco::CaloTau& jet){
+math::XYZTLorentzVector TCTauAlgorithm::recalculateEnergy(const reco::CaloTau& jet, TCAlgo& algoComponentUsed) const {
 
 	const TrackRef& leadTk = jet.leadTrack();
 
@@ -118,10 +113,10 @@ math::XYZTLorentzVector TCTauAlgorithm::recalculateEnergy(const reco::CaloTau& j
 	CaloJet caloJet = *cJet;
 	caloJet.setP4(jet.p4());
 
-	return recalculateEnergy(caloJet,leadTk,associatedTracks);
+	return recalculateEnergy(caloJet,leadTk,associatedTracks,algoComponentUsed);
 }
 
-math::XYZTLorentzVector TCTauAlgorithm::recalculateEnergy(const reco::CaloJet& caloJet,const TrackRef& leadTk,const TrackRefVector& associatedTracks){
+math::XYZTLorentzVector TCTauAlgorithm::recalculateEnergy(const reco::CaloJet& caloJet,const TrackRef& leadTk,const TrackRefVector& associatedTracks, TCAlgo&algoComponentUsed) const {
 
         all++;
 
@@ -212,7 +207,7 @@ math::XYZTLorentzVector TCTauAlgorithm::recalculateEnergy(const reco::CaloJet& c
 }
 
 
-XYZVector TCTauAlgorithm::trackEcalHitPoint(const TransientTrack& transientTrack,const CaloJet& caloJet){
+XYZVector TCTauAlgorithm::trackEcalHitPoint(const TransientTrack& transientTrack,const CaloJet& caloJet) const {
 
 
         GlobalPoint ecalHitPosition(0,0,0);
@@ -239,7 +234,7 @@ XYZVector TCTauAlgorithm::trackEcalHitPoint(const TransientTrack& transientTrack
         return ecalHitPoint;
 }
 
-XYZVector TCTauAlgorithm::trackEcalHitPoint(const Track& track){
+XYZVector TCTauAlgorithm::trackEcalHitPoint(const Track& track) const {
 
       	const FreeTrajectoryState fts = trackAssociator->getFreeTrajectoryState(*setup,track);
       	TrackDetMatchInfo info = trackAssociator->associate(*event, *setup, fts, trackAssociatorParameters);
@@ -249,7 +244,7 @@ XYZVector TCTauAlgorithm::trackEcalHitPoint(const Track& track){
 	return XYZVector(0,0,0);
 }
 
-std::pair<XYZVector,XYZVector> TCTauAlgorithm::getClusterEnergy(const CaloJet& caloJet,XYZVector& trackEcalHitPoint,double cone){
+std::pair<XYZVector,XYZVector> TCTauAlgorithm::getClusterEnergy(const CaloJet& caloJet,XYZVector& trackEcalHitPoint,double cone) const {
 
         XYZVector ecalCluster(0,0,0);
         XYZVector hcalCluster(0,0,0);
@@ -349,7 +344,7 @@ std::pair<XYZVector,XYZVector> TCTauAlgorithm::getClusterEnergy(const CaloJet& c
         return std::pair<XYZVector,XYZVector> (ecalCluster,hcalCluster);
 }
 
-XYZVector TCTauAlgorithm::getCellMomentum(const CaloCellGeometry* cell,double& energy){
+XYZVector TCTauAlgorithm::getCellMomentum(const CaloCellGeometry* cell,double& energy) const {
         XYZVector momentum(0,0,0);
         if(cell){
                 GlobalPoint hitPosition = cell->getPosition();

--- a/RecoTauTag/RecoTau/src/TauDiscriminationProducerBase.cc
+++ b/RecoTauTag/RecoTau/src/TauDiscriminationProducerBase.cc
@@ -69,6 +69,7 @@ TauDiscriminationProducerBase<TauType, TauDiscriminator>::TauDiscriminationProdu
 template<class TauType, class TauDiscriminator>
 void TauDiscriminationProducerBase<TauType, TauDiscriminator>::produce(edm::Event& event, const edm::EventSetup& eventSetup)
 {
+   tauIndex_=0;
    // setup function - does nothing in base, but can be overridden to retrieve PV or other stuff
    beginEvent(event, eventSetup);
 
@@ -143,7 +144,7 @@ void TauDiscriminationProducerBase<TauType, TauDiscriminator>::produce(edm::Even
       if( passesPrediscriminants )
       {
          // this tau passes the prereqs, call our implemented discrimination function
-         result = discriminate(tauRef);
+         result = discriminate(tauRef); ++tauIndex_;
       }
 
       // store the result of this tau into our new discriminator

--- a/RecoTauTag/TauTagTools/interface/ECALBounds.h
+++ b/RecoTauTag/TauTagTools/interface/ECALBounds.h
@@ -13,9 +13,9 @@ class Disk;
 
 class ECALBounds {
 public:
-  static const Surface& barrelBound()    {check(); return *theCylinder;}
-  static const Surface& negativeEndcapDisk() {check(); return *theNegativeDisk;}
-  static const Surface& positiveEndcapDisk() {check(); return *thePositiveDisk;}
+  static const Surface& barrelBound()    { return theCylinder;}
+  static const Surface& negativeEndcapDisk() {return theNegativeDisk;}
+  static const Surface& positiveEndcapDisk() { return thePositiveDisk;}
   /** Hard-wired numbers defining the envelope of the sensitive volumes.
    */
   static float barrel_innerradius()     {return 129.0f;}
@@ -33,12 +33,9 @@ public:
   static std::pair<float,float> crack_absEtaIntervalD() {return std::pair<float,float>(1.127f,1.163f);}
   static std::pair<float,float> crack_absEtaIntervalE() {return std::pair<float,float>(1.460f,1.558f);}
  private:
-  static ReferenceCountingPointer<Surface> theCylinder;
-  static ReferenceCountingPointer<Surface> theNegativeDisk;
-  static ReferenceCountingPointer<Surface> thePositiveDisk;
-  static bool theInit;
-  static void check() {if (!theInit) initialize();}
-  static void initialize();
+  static const BoundCylinder theCylinder;
+  static const BoundDisk theNegativeDisk;
+  static const BoundDisk thePositiveDisk;
 };
 
 #endif

--- a/RecoTauTag/TauTagTools/plugins/RecoTauDiscriminationByGenMatch.cc
+++ b/RecoTauTag/TauTagTools/plugins/RecoTauDiscriminationByGenMatch.cc
@@ -17,7 +17,7 @@ class RecoTauDiscriminationByGenMatch : public PFTauDiscriminationProducerBase  
          matchingSrc_        = pset.getParameter<edm::InputTag>("match");
       }
       ~RecoTauDiscriminationByGenMatch(){}
-      double discriminate(const reco::PFTauRef& pfTau) override;
+      double discriminate(const reco::PFTauRef& pfTau) const override;
       virtual void beginEvent(
           const edm::Event& evt, const edm::EventSetup& es) override;
    private:
@@ -31,7 +31,7 @@ void RecoTauDiscriminationByGenMatch::beginEvent(
 }
 
 double
-RecoTauDiscriminationByGenMatch::discriminate(const reco::PFTauRef& tau) {
+RecoTauDiscriminationByGenMatch::discriminate(const reco::PFTauRef& tau) const {
   reco::GenJetRef genJet = (*matching_)[tau];
   return genJet.isNonnull() ? 1.0 : 0;
 }

--- a/RecoTauTag/TauTagTools/plugins/RecoTauIndexDiscriminatorProducer.cc
+++ b/RecoTauTag/TauTagTools/plugins/RecoTauIndexDiscriminatorProducer.cc
@@ -11,17 +11,21 @@
 
 #include "RecoTauTag/RecoTau/interface/TauDiscriminationProducerBase.h"
 
-class RecoTauIndexDiscriminatorProducer : public PFTauDiscriminationProducerBase {
+namespace {
+
+class RecoTauIndexDiscriminatorProducer final : public PFTauDiscriminationProducerBase {
   public:
       explicit RecoTauIndexDiscriminatorProducer(const edm::ParameterSet& cfg)
         :PFTauDiscriminationProducerBase(cfg) {}
       ~RecoTauIndexDiscriminatorProducer(){}
-      double discriminate(const reco::PFTauRef& thePFTauRef) override;
+      double discriminate(const reco::PFTauRef& thePFTauRef) const override;
       void beginEvent(const edm::Event& evt, const edm::EventSetup& evtSetup) override {};
 };
 
-double RecoTauIndexDiscriminatorProducer::discriminate(const reco::PFTauRef& thePFTauRef) {
+double RecoTauIndexDiscriminatorProducer::discriminate(const reco::PFTauRef& thePFTauRef) const {
   return thePFTauRef.key();
+}
+
 }
 
 DEFINE_FWK_MODULE(RecoTauIndexDiscriminatorProducer);

--- a/RecoTauTag/TauTagTools/plugins/RecoTauRandomDiscriminant.cc
+++ b/RecoTauTag/TauTagTools/plugins/RecoTauRandomDiscriminant.cc
@@ -9,19 +9,20 @@
 #include "RecoTauTag/RecoTau/interface/TauDiscriminationProducerBase.h"
 #include "TRandom3.h"
 
-class PFTauRandomDiscriminator : public PFTauDiscriminationProducerBase {
+namespace { 
+class PFTauRandomDiscriminator final : public PFTauDiscriminationProducerBase {
   public:
     PFTauRandomDiscriminator(const edm::ParameterSet& pset):
       PFTauDiscriminationProducerBase(pset) {
         passRate_ = pset.getParameter<double>("passRate");
       }
 
-    double discriminate(const reco::PFTauRef& tau) override {
+    double discriminate(const reco::PFTauRef& tau) const override {
       return randy_.Rndm() < passRate_;
     }
   private:
-    TRandom3 randy_;
+    mutable TRandom3 randy_;
     double passRate_;
 };
-
+}
 DEFINE_FWK_MODULE(PFTauRandomDiscriminator);

--- a/RecoTauTag/TauTagTools/plugins/TauDiscriminationByStringCut.cc
+++ b/RecoTauTag/TauTagTools/plugins/TauDiscriminationByStringCut.cc
@@ -7,6 +7,7 @@
  * author : Christian Veelken (veelken@fnal.gov ; UC Davis)
  */
 
+namespace {
 template<class TauType, class TauDiscriminator>
 class TauDiscriminationByStringCut :
     public TauDiscriminationProducerBase<TauType, TauDiscriminator> {
@@ -25,7 +26,7 @@ class TauDiscriminationByStringCut :
       typedef std::vector<TauType> TauCollection;
       typedef edm::Ref<TauCollection> TauRef;
 
-      double discriminate(const TauRef& tau) {
+      double discriminate(const TauRef& tau) const {
         // StringCutObjectSelector::operator() returns true if tau passes cut
         return ( (*cut_)(*tau) ) ? cutPassValue_ : cutFailValue_;
       }
@@ -35,6 +36,7 @@ class TauDiscriminationByStringCut :
       double cutFailValue_;
       double cutPassValue_;
 };
+}
 
 typedef TauDiscriminationByStringCut<reco::PFTau, reco::PFTauDiscriminator>
   PFRecoTauDiscriminationByStringCut;

--- a/RecoTauTag/TauTagTools/src/ECALBounds.cc
+++ b/RecoTauTag/TauTagTools/src/ECALBounds.cc
@@ -1,30 +1,19 @@
 #include "RecoTauTag/TauTagTools/interface/ECALBounds.h"
-
-void ECALBounds::initialize(){
-  const float epsilon = 0.001; // should not matter at all
-  Surface::RotationType rot; // unit rotation matrix
-  theCylinder=new BoundCylinder(barrel_innerradius(), Surface::PositionType(0,0,0),rot, 
-				 new SimpleCylinderBounds(barrel_innerradius()-epsilon, 
-						       	  barrel_innerradius()+epsilon, 
-							 -barrel_halfLength(), 
-							  barrel_halfLength()));
-
-
-  theNegativeDisk=new BoundDisk(Surface::PositionType(0,0,-endcap_innerZ()),rot, 
-		   new SimpleDiskBounds(0,endcap_outerradius(),-epsilon,epsilon));
-
-  thePositiveDisk = 
-    new BoundDisk( Surface::PositionType(0,0,endcap_innerZ()),rot, 
-		   new SimpleDiskBounds(0,endcap_outerradius(),-epsilon,epsilon));
-
-
-  theInit = true;
+namespace {
+  constexpr float epsilon = 0.001; // should not matter at all
+  const Surface::RotationType rot; // unit rotation matrix
 }
 
-// static initializers
-ReferenceCountingPointer<Surface> ECALBounds::theCylinder = 0;
-ReferenceCountingPointer<Surface> ECALBounds::theNegativeDisk = 0;
-ReferenceCountingPointer<Surface> ECALBounds::thePositiveDisk = 0;
-bool ECALBounds::theInit = false;
+
+const BoundCylinder  ECALBounds::theCylinder(ECALBounds::barrel_innerradius(), Surface::PositionType(0,0,0),rot, 
+				 new SimpleCylinderBounds(ECALBounds::barrel_innerradius()-epsilon, 
+						       	  ECALBounds::barrel_innerradius()+epsilon, 
+							 -ECALBounds::barrel_halfLength(), 
+							  ECALBounds::barrel_halfLength()));
 
 
+const BoundDisk  ECALBounds::theNegativeDisk(Surface::PositionType(0,0,-ECALBounds::endcap_innerZ()),rot, 
+		   new SimpleDiskBounds(0,ECALBounds::endcap_outerradius(),-epsilon,epsilon));
+
+const BoundDisk  ECALBounds::thePositiveDisk( Surface::PositionType(0,0,ECALBounds::endcap_innerZ()),rot, 
+		   new SimpleDiskBounds(0,ECALBounds::endcap_outerradius(),-epsilon,epsilon));


### PR DESCRIPTION
Solves several potential "race conditions" in code related to HCAL, Jet and Tau.
Introduces more const-correctness
convert to stream several producers (notably Jet, TauDiscriminators and PFRecHits)

The original logic and implementation are always preserved.
Minor modifications to ensure const-correctness in tau-discriminators where the method
"discriminate" has been made constant to ease const-correctness tracking

No regression expected, no regression observed even running with 4 threads.

Now reco (with no output) is 85% efficient with 6 threads and 70% efficient with 12 threads

Because of reading of MVA from files the number of opened file descriptors may easily grow beyond single user limit when running with many threads
This should disappear when MVA will be read from the DB.

In all these Producers memory usage (and more in general usage of common resources) can be optimized using GlobalContexts and RunCaches
