### PR TITLE
Fix setDet for Projected Hit

### DIFF
--- a/DataFormats/TrackerRecHit2D/interface/ProjectedSiStripRecHit2D.h
+++ b/DataFormats/TrackerRecHit2D/interface/ProjectedSiStripRecHit2D.h
@@ -3,7 +3,7 @@
 
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h"
 
-#include<iostream>
+// #include<iostream>
 
 class ProjectedSiStripRecHit2D GCC11_FINAL  : public TrackerSingleRecHit  {
 public:
@@ -39,6 +39,8 @@ public:
     assert(originalId()==originalDet.geographicalId());
     }
 
+
+  virtual void setDet(const GeomDet & idet);
 
   virtual bool canImproveWithTrack() const {return true;}
 

--- a/DataFormats/TrackerRecHit2D/src/ProjectedSiStripRecHit2D.cc
+++ b/DataFormats/TrackerRecHit2D/src/ProjectedSiStripRecHit2D.cc
@@ -1,0 +1,11 @@
+#include "DataFormats/TrackerRecHit2D/interface/ProjectedSiStripRecHit2D.h"
+#include "Geometry/TrackerGeometryBuilder/interface/GluedGeomDet.h"
+
+// #include<iostream>
+
+void ProjectedSiStripRecHit2D::setDet(const GeomDet & idet) {
+    TrackingRecHit::setDet(idet);
+    const GluedGeomDet& gdet = static_cast<const GluedGeomDet&>(idet);
+    theOriginalDet = trackerHitRTTI::isProjMono(*this) ? gdet.monoDet() : gdet.stereoDet();
+}
+

--- a/DataFormats/TrackingRecHit/interface/TrackingRecHit.h
+++ b/DataFormats/TrackingRecHit/interface/TrackingRecHit.h
@@ -85,8 +85,9 @@ public:
     const_cast<TrackingRecHit&>(*cl).setDet(idet); // const_cast (can be fixed editing some 100 files)
     return cl;  
   }
-  void setDet(const GeomDet & idet) {m_det = &idet;}
 #endif
+  virtual void setDet(const GeomDet & idet) {m_det = &idet;}
+
   
   virtual AlgebraicVector parameters() const = 0;
   


### PR DESCRIPTION
trivial fix
discovered by @mtosi
occurs when refitting tracks issued by HLT.
No standard workflow ever exercise it.

I would like to ask a fast-track for the approval of this PR to allow @mtosi to proceed with her work
w/o being forced to recompile the whole CMSSW.

The fix is trivial. It involves recompiling the whole CMSSW. It cannot affect any usual workflow.
Therefore if compiles and pass tests, should be good enough
