### PR TITLE
RPCMuon bugfix in MuonIdProducer

### DIFF
--- a/DQMOffline/Muon/src/MuonEnergyDepositAnalyzer.cc
+++ b/DQMOffline/Muon/src/MuonEnergyDepositAnalyzer.cc
@@ -202,7 +202,7 @@ void MuonEnergyDepositAnalyzer::analyze(const edm::Event& iEvent, const edm::Eve
 	hoS9PointingMuDepEnergy_Glb->Fill(muEnergy.hoS9);
       }
       // TK muon
-      if((recoMu->isTrackerMuon()||recoMu->isRPCMuon()) && !(recoMu->isGlobalMuon())){
+      if(recoMu->isTrackerMuon() && !(recoMu->isGlobalMuon())){
 	ecalS9PointingMuDepEnergy_Tk->Fill(muEnergy.emS9);
 	hcalS9PointingMuDepEnergy_Tk->Fill(muEnergy.hadS9);
 	hoS9PointingMuDepEnergy_Tk->Fill(muEnergy.hoS9);

--- a/DQMOffline/Muon/src/MuonEnergyDepositAnalyzer.cc
+++ b/DQMOffline/Muon/src/MuonEnergyDepositAnalyzer.cc
@@ -186,7 +186,7 @@ void MuonEnergyDepositAnalyzer::analyze(const edm::Event& iEvent, const edm::Eve
   
     if(recoMu->isGlobalMuon())
       TransTrack = theB->build(recoMu->globalTrack());
-    if(recoMu->isTrackerMuon() && !(recoMu->isGlobalMuon()))
+    if((recoMu->isTrackerMuon() || recoMu->isRPCMuon()) && !(recoMu->isGlobalMuon()))
       TransTrack = theB->build(recoMu->innerTrack());
     if(recoMu->isStandAloneMuon() && !(recoMu->isGlobalMuon()))
       TransTrack = theB->build(recoMu->outerTrack());
@@ -202,7 +202,7 @@ void MuonEnergyDepositAnalyzer::analyze(const edm::Event& iEvent, const edm::Eve
 	hoS9PointingMuDepEnergy_Glb->Fill(muEnergy.hoS9);
       }
       // TK muon
-      if(recoMu->isTrackerMuon() && !(recoMu->isGlobalMuon())){
+      if((recoMu->isTrackerMuon()||recoMu->isRPCMuon()) && !(recoMu->isGlobalMuon())){
 	ecalS9PointingMuDepEnergy_Tk->Fill(muEnergy.emS9);
 	hcalS9PointingMuDepEnergy_Tk->Fill(muEnergy.hadS9);
 	hoS9PointingMuDepEnergy_Tk->Fill(muEnergy.hoS9);

--- a/RecoMET/METAlgorithms/src/MuonMETAlgo.cc
+++ b/RecoMET/METAlgorithms/src/MuonMETAlgo.cc
@@ -128,7 +128,7 @@ void MuonMETAlgo::GetMuDepDeltas(const reco::Muon* inputMuon,
   TrackRef mu_track;
   if(inputMuon->isGlobalMuon()) {
     mu_track = inputMuon->globalTrack();
-  } else if(inputMuon->isTrackerMuon()) {
+  } else if(inputMuon->isTrackerMuon() || inputMuon->isRPCMuon()) {
     mu_track = inputMuon->innerTrack();
   } else 
     mu_track = inputMuon->outerTrack();
@@ -174,7 +174,7 @@ void MuonMETAlgo::GetMuDepDeltas(const reco::Muon* inputMuon,
       mup4 = LorentzVector(inputMuon->globalTrack()->px(), inputMuon->globalTrack()->py(),
 			   inputMuon->globalTrack()->pz(), inputMuon->globalTrack()->p());
     }	
-  } else if(inputMuon->isTrackerMuon()) {
+  } else if(inputMuon->isTrackerMuon() || inputMuon->isRPCMuon()) {
     mup4 = LorentzVector(inputMuon->innerTrack()->px(), inputMuon->innerTrack()->py(),
 			 inputMuon->innerTrack()->pz(), inputMuon->innerTrack()->p());
   } else 

--- a/RecoMET/METProducers/src/MuonMETValueMapProducer.cc
+++ b/RecoMET/METProducers/src/MuonMETValueMapProducer.cc
@@ -152,7 +152,7 @@ reco::MuonMETCorrectionData::Type MuonMETValueMapProducer::decide_correction_typ
 bool MuonMETValueMapProducer::should_type_MuonCandidateValuesUsed(const reco::Muon& muon, const math::XYZPoint &beamSpotPosition)
 {
   if(!muon.isGlobalMuon()) return false;
-  if(!(muon.isTrackerMuon()||muon.isRPCMuon()) && isAlsoTkMu_) return false;
+  if(!muon.isTrackerMuon() && isAlsoTkMu_) return false;
   reco::TrackRef globTk = muon.globalTrack();
   reco::TrackRef siTk   = muon.innerTrack();
 

--- a/RecoMET/METProducers/src/MuonMETValueMapProducer.cc
+++ b/RecoMET/METProducers/src/MuonMETValueMapProducer.cc
@@ -124,7 +124,7 @@ void MuonMETValueMapProducer::determine_deltax_deltay(double& deltax, double& de
 {
   reco::TrackRef mu_track;
   if(muon.isGlobalMuon()) mu_track = muon.globalTrack();
-  else if(muon.isTrackerMuon()) mu_track = muon.innerTrack();
+  else if(muon.isTrackerMuon()||muon.isRPCMuon()) mu_track = muon.innerTrack();
   else mu_track = muon.outerTrack();
 
   TrackDetMatchInfo info = trackAssociator_.associate(iEvent, iSetup,
@@ -152,9 +152,10 @@ reco::MuonMETCorrectionData::Type MuonMETValueMapProducer::decide_correction_typ
 bool MuonMETValueMapProducer::should_type_MuonCandidateValuesUsed(const reco::Muon& muon, const math::XYZPoint &beamSpotPosition)
 {
   if(!muon.isGlobalMuon()) return false;
-  if(!muon.isTrackerMuon() && isAlsoTkMu_) return false;
+  if(!(muon.isTrackerMuon()||muon.isRPCMuon()) && isAlsoTkMu_) return false;
   reco::TrackRef globTk = muon.globalTrack();
   reco::TrackRef siTk   = muon.innerTrack();
+
   if(muon.pt() < minPt_ || fabs(muon.eta()) > maxEta_) return false;
   if(globTk->chi2()/globTk->ndof() > maxNormChi2_) return false;
   if(fabs(globTk->dxy(beamSpotPosition)) > fabs(maxd0_)) return false;

--- a/RecoMET/METProducers/src/MuonTCMETValueMapProducer.cc
+++ b/RecoMET/METProducers/src/MuonTCMETValueMapProducer.cc
@@ -146,7 +146,7 @@ void MuonTCMETValueMapProducer::produce(edm::Event& iEvent, const edm::EventSetu
     reco::MuonMETCorrectionData muMETCorrData(reco::MuonMETCorrectionData::NotUsed, deltax, deltay);
     
     reco::TrackRef mu_track;
-    if( mu->isGlobalMuon() || mu->isTrackerMuon() || mu->isRPCMuon() || mu->isCaloMuon() )
+    if( mu->isGlobalMuon() || mu->isTrackerMuon() || mu->isCaloMuon() )
       mu_track = mu->innerTrack();
     else {
       v_muCorrData.push_back( muMETCorrData );

--- a/RecoMET/METProducers/src/MuonTCMETValueMapProducer.cc
+++ b/RecoMET/METProducers/src/MuonTCMETValueMapProducer.cc
@@ -146,7 +146,7 @@ void MuonTCMETValueMapProducer::produce(edm::Event& iEvent, const edm::EventSetu
     reco::MuonMETCorrectionData muMETCorrData(reco::MuonMETCorrectionData::NotUsed, deltax, deltay);
     
     reco::TrackRef mu_track;
-    if( mu->isGlobalMuon() || mu->isTrackerMuon() || mu->isCaloMuon() )
+    if( mu->isGlobalMuon() || mu->isTrackerMuon() || mu->isRPCMuon() || mu->isCaloMuon() )
       mu_track = mu->innerTrack();
     else {
       v_muCorrData.push_back( muMETCorrData );

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
@@ -621,7 +621,7 @@ void MuonIdProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 		  }
 		if ( newMuon ) {
 		   if ( goodTrackerMuon || goodRPCMuon ){
-		      if ( goodRPCMuon ) trackerMuon->setType( trackerMuon->type() | reco::Muon::RPCMuon );
+		      if ( goodRPCMuon ) trackerMuon.setType( trackerMuon.type() | reco::Muon::RPCMuon );
 		      outputMuons->push_back( trackerMuon );
 		   } else {
 		      LogTrace("MuonIdentification") << "track failed minimal number of muon matches requirement";

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
@@ -601,8 +601,8 @@ void MuonIdProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 		bool newMuon = true;
 		bool goodTrackerMuon = isGoodTrackerMuon( trackerMuon );
 		bool goodRPCMuon = isGoodRPCMuon( trackerMuon );
-		if ( goodTrackerMuon ) trackerMuon.setType( reco::Muon::TrackerMuon );
-		if ( goodRPCMuon ) trackerMuon.setType( reco::Muon::RPCMuon );
+		if ( goodTrackerMuon ) trackerMuon.setType( trackerMuon.type() | reco::Muon::TrackerMuon );
+		if ( goodRPCMuon ) trackerMuon.setType( trackerMuon.type() | reco::Muon::RPCMuon );
 		for ( reco::MuonCollection::iterator muon = outputMuons->begin();
 		      muon !=  outputMuons->end(); ++muon )
 		  {

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
@@ -587,7 +587,7 @@ void MuonIdProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 	     {
 		// make muon
 	       reco::Muon trackerMuon( makeMuon(iEvent, iSetup, reco::TrackRef( innerTrackCollectionHandle_, i ), reco::Muon::InnerTrack ) );
-		trackerMuon.setType( reco::Muon::TrackerMuon | reco::Muon::RPCMuon );
+		trackerMuon.setType( reco::Muon::TrackerMuon );
 		fillMuonId(iEvent, iSetup, trackerMuon, *direction);
 
 		if ( debugWithTruthMatching_ ) {
@@ -621,6 +621,7 @@ void MuonIdProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 		  }
 		if ( newMuon ) {
 		   if ( goodTrackerMuon || goodRPCMuon ){
+		      if ( goodRPCMuon ) trackerMuon->setType( trackerMuon->type() | reco::Muon::RPCMuon );
 		      outputMuons->push_back( trackerMuon );
 		   } else {
 		      LogTrace("MuonIdentification") << "track failed minimal number of muon matches requirement";

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
@@ -620,7 +620,7 @@ void MuonIdProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 		       }
 		  }
 		if ( newMuon ) {
-		   if ( goodTrackerMuon ){
+		   if ( goodTrackerMuon || goodRPCMuon ){
 		      outputMuons->push_back( trackerMuon );
 		   } else {
 		      LogTrace("MuonIdentification") << "track failed minimal number of muon matches requirement";

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
@@ -587,7 +587,6 @@ void MuonIdProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 	     {
 		// make muon
 	       reco::Muon trackerMuon( makeMuon(iEvent, iSetup, reco::TrackRef( innerTrackCollectionHandle_, i ), reco::Muon::InnerTrack ) );
-		trackerMuon.setType( reco::Muon::TrackerMuon );
 		fillMuonId(iEvent, iSetup, trackerMuon, *direction);
 
 		if ( debugWithTruthMatching_ ) {
@@ -602,6 +601,8 @@ void MuonIdProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 		bool newMuon = true;
 		bool goodTrackerMuon = isGoodTrackerMuon( trackerMuon );
 		bool goodRPCMuon = isGoodRPCMuon( trackerMuon );
+		if ( goodTrackerMuon ) trackerMuon.setType( reco::Muon::TrackerMuon );
+		if ( goodRPCMuon ) trackerMuon.setType( reco::Muon::RPCMuon );
 		for ( reco::MuonCollection::iterator muon = outputMuons->begin();
 		      muon !=  outputMuons->end(); ++muon )
 		  {
@@ -621,7 +622,6 @@ void MuonIdProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 		  }
 		if ( newMuon ) {
 		   if ( goodTrackerMuon || goodRPCMuon ){
-		      if ( goodRPCMuon ) trackerMuon.setType( trackerMuon.type() | reco::Muon::RPCMuon );
 		      outputMuons->push_back( trackerMuon );
 		   } else {
 		      LogTrace("MuonIdentification") << "track failed minimal number of muon matches requirement";

--- a/RecoMuon/MuonIdentification/src/MuonCosmicCompatibilityFiller.cc
+++ b/RecoMuon/MuonIdentification/src/MuonCosmicCompatibilityFiller.cc
@@ -228,8 +228,8 @@ MuonCosmicCompatibilityFiller::backToBack2LegCosmic(const edm::Event& iEvent, co
   unsigned int result = 0; //no partners - collision
   reco::TrackRef track;
   if ( muon.isGlobalMuon()  )            track = muon.innerTrack();
-  else if ( muon.isTrackerMuon() || muon.isRPCMuon() )       track = muon.track();
-  else if ( muon.isStandAloneMuon() )    return false;
+  else if ( muon.isTrackerMuon() )       track = muon.track();
+  else if ( muon.isStandAloneMuon() || muon.isRPCMuon() )    return false;
 
   for (unsigned int iColl = 0; iColl<trackTokens_.size(); ++iColl){
     edm::Handle<reco::TrackCollection> trackHandle;

--- a/RecoMuon/MuonIdentification/src/MuonCosmicCompatibilityFiller.cc
+++ b/RecoMuon/MuonIdentification/src/MuonCosmicCompatibilityFiller.cc
@@ -228,7 +228,7 @@ MuonCosmicCompatibilityFiller::backToBack2LegCosmic(const edm::Event& iEvent, co
   unsigned int result = 0; //no partners - collision
   reco::TrackRef track;
   if ( muon.isGlobalMuon()  )            track = muon.innerTrack();
-  else if ( muon.isTrackerMuon() )       track = muon.track();
+  else if ( muon.isTrackerMuon() || muon.isRPCMuon() )       track = muon.track();
   else if ( muon.isStandAloneMuon() )    return false;
 
   for (unsigned int iColl = 0; iColl<trackTokens_.size(); ++iColl){
@@ -405,7 +405,7 @@ MuonCosmicCompatibilityFiller::pvMatches(const edm::Event& iEvent, const reco::M
 
   reco::TrackRef track;
   if ( muon.isGlobalMuon() )          track = muon.innerTrack();
-  else if ( muon.isTrackerMuon() )    track = muon.track();
+  else if ( muon.isTrackerMuon() || muon.isRPCMuon() )    track = muon.track();
   else if ( muon.isStandAloneMuon())  track = muon.standAloneMuon();
   
   bool multipleMu = false;


### PR DESCRIPTION
The RPCMuon is mis-implemented as a subset of TrackerMuons.
Originally it is designed to be a complementary ones to the TM's.
