### PR TITLE
Speed up Shashlik reconstruction at high pileup

### DIFF
--- a/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
@@ -1385,7 +1385,7 @@ bool PFEGammaAlgo::EvaluateSingleLegMVA(const reco::PFBlockRef& blockref, const 
   const reco::PFBlock& block = *blockref;  
   const edm::OwnVector< reco::PFBlockElement >& elements = block.elements();  
   //use this to store linkdata in the associatedElements function below  
-  PFBlock::LinkData linkData =  block.linkData();  
+  const PFBlock::LinkData& linkData =  block.linkData();  
   //calculate MVA Variables  
   chi2=elements[track_index].trackRef()->chi2()/elements[track_index].trackRef()->ndof();  
   nlost=elements[track_index].trackRef()->trackerExpectedHitsInner().numberOfLostHits();  

--- a/RecoParticleFlow/PFProducer/src/PFPhotonAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFPhotonAlgo.cc
@@ -1321,7 +1321,7 @@ bool PFPhotonAlgo::EvaluateSingleLegMVA(const reco::PFBlockRef& blockref, const 
   const reco::PFBlock& block = *blockref;  
   const edm::OwnVector< reco::PFBlockElement >& elements = block.elements();  
   //use this to store linkdata in the associatedElements function below  
-  PFBlock::LinkData linkData =  block.linkData();  
+  const PFBlock::LinkData& linkData =  block.linkData();  
   //calculate MVA Variables  
   chi2=elements[track_index].trackRef()->chi2()/elements[track_index].trackRef()->ndof();  
   nlost=elements[track_index].trackRef()->trackerExpectedHitsInner().numberOfLostHits();  


### PR DESCRIPTION
Just converts a copy of an object to a const reference.  In profiling it appears that this copy was accounting for almost 30% of the Shashlik reconstruction runtime at 140 pileup.

No change in results whatsoever is expected, early tests at 140 pileup appear to cut the time spent in PFProducer and PFEGammaProducer by about 3.5 times.  Overall event times appears to have halved from 11.3+/-4 minutes to 5.9+/-1.6 minutes.

**Module times before this fix**
![shashlikrecousertime-beforefix](https://cloud.githubusercontent.com/assets/6480160/3856812/87e6ace8-1efc-11e4-81da-ee58b6a16e44.png)

**Module times after this fix**
![shashlikrecousertime-afterfix](https://cloud.githubusercontent.com/assets/6480160/3856816/9a975068-1efc-11e4-839c-376fc91f5e48.png)

@davidlange6, @lgray, @vininn
