### PR TITLE
Including module necessary for standalone PFTau execution

### DIFF
--- a/RecoTauTag/Configuration/python/RecoPFTauTag_cff.py
+++ b/RecoTauTag/Configuration/python/RecoPFTauTag_cff.py
@@ -1,6 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
 from RecoTauTag.RecoTau.PFRecoTauPFJetInputs_cfi import PFRecoTauPFJetInputs
+# to be able to run PFTau sequence standalone on AOD
+from TrackingTools.TransientTrack.TransientTrackBuilder_cfi import TransientTrackBuilderESProducer
 
 #-------------------------------------------------------------------------------
 #------------------ Jet Production and Preselection-----------------------------


### PR DESCRIPTION
TransientTrackBuilderESProducer is necessary for the tau reconstruction. When PFTau is executed during RECO sequence, it is already loaded. Also this module is loaded with patCandidates_cff.py. However, when trying to execute PFTau only without loading the full PAT creating config, the code crashed due to this missing module.

This PR should allow simple and more intuitive re-running of PFTau. It should have no effect neither on timing or output content or size.
