### PR TITLE
HGCAL recogeometry fix for local (thus also global)  x and y coordinates

### DIFF
--- a/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
+++ b/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
@@ -102,7 +102,7 @@ std::pair<int,int> HGCalDDDConstants::findCell(int cell, float h, float bl,
   int   ky(0), testCell(0);
   for (int iky=0; iky<kymax; ++iky) {
     int deltay(floor((iky*cellSize+b)/(a*cellSize)));
-    if (testCell+deltay > cell) break;
+    if (testCell+deltay >= cell) break;
     testCell += deltay;
     ky++;
   }


### PR DESCRIPTION
@bsunanda, @pfs, @lgray The fix in recogeometry for the correspondence between cell number and the local
xy coordinates. Solves "jumping muon" problem.
