### PR TITLE
Strip rh valid fix

### DIFF
--- a/SimTracker/TrackerHitAssociation/src/TrackerHitAssociator.cc
+++ b/SimTracker/TrackerHitAssociation/src/TrackerHitAssociator.cc
@@ -153,6 +153,12 @@ std::vector<PSimHit> TrackerHitAssociator::associateHit(const TrackingRecHit & t
     //  from the DigiSimLinks and returned in simhitCFPos.
     //  simhitCFPos[i] contains the full address of the ith simhit:
     //   <collection, index> = <<subdet, tofBin>, index>
+
+    //check if the recHit is a SiStripMatchedRecHit2D
+    bool isMatchedHit = false;
+    if(dynamic_cast<const SiStripMatchedRecHit2D *>(&thit))
+      isMatchedHit = true;
+
     for(size_t i=0; i<simhitCFPos.size(); i++) {
       simhitAddr theSimHitAddr = simhitCFPos[i];
       simHitCollectionID theSimHitCollID = theSimHitAddr.first;
@@ -161,8 +167,18 @@ std::vector<PSimHit> TrackerHitAssociator::associateHit(const TrackingRecHit & t
 	unsigned int theSimHitIndex = theSimHitAddr.second;
 	if (theSimHitIndex < (it->second).size()) {
 	  const PSimHit& theSimHit = (it->second)[theSimHitIndex];
-	  result.push_back(theSimHit);
-
+	  if (isMatchedHit) {
+	    // Try to remove ghosts by requiring a match to the simTrack also
+	    unsigned int simHitid = theSimHit.trackId();
+	    EncodedEventId simHiteid = theSimHit.eventId();
+	    for(size_t i=0; i<simtrackid.size();i++) {
+	      if(simHitid == simtrackid[i].first && simHiteid == simtrackid[i].second) {
+		result.push_back(theSimHit);
+	      }
+	    }
+	  } else {
+	    result.push_back(theSimHit);
+	  }
           // std::cout << "by CFpos, simHit detId =  " << theSimHit.detUnitId() << " address = (" << (theSimHitAddr.first).first
 	  // 	    << ", " << (theSimHitAddr.first).second << ", " << theSimHitIndex
 	  // 	    << "), process = " << theSimHit.processType() << " (" << theSimHit.eventId().bunchCrossing()

--- a/Validation/TrackerRecHits/python/SiStripRecHitsValid_cfi.py
+++ b/Validation/TrackerRecHits/python/SiStripRecHitsValid_cfi.py
@@ -28,7 +28,7 @@ stripRecHitsValid = cms.EDAnalyzer("SiStripRecHitsValid",
   TH1Numrphi = cms.PSet(
         Nbinx          = cms.int32(100),
         xmin           = cms.double(0.),
-        xmax           = cms.double(1000.),
+        xmax           = cms.double(5000.),
         switchon  = cms.bool(True)
 
     ),
@@ -36,7 +36,7 @@ stripRecHitsValid = cms.EDAnalyzer("SiStripRecHitsValid",
   TH1NumStereo = cms.PSet(
         Nbinx          = cms.int32(100),
         xmin           = cms.double(0.),
-        xmax           = cms.double(1000.),
+        xmax           = cms.double(5000.),
         switchon  = cms.bool(True)
 
     ),
@@ -44,7 +44,7 @@ stripRecHitsValid = cms.EDAnalyzer("SiStripRecHitsValid",
   TH1NumMatched = cms.PSet(
         Nbinx          = cms.int32(100),
         xmin           = cms.double(0.),
-        xmax           = cms.double(1000.),
+        xmax           = cms.double(5000.),
         switchon  = cms.bool(True)
 
     ),

--- a/Validation/TrackerRecHits/src/SiStripRecHitsValid.cc
+++ b/Validation/TrackerRecHits/src/SiStripRecHitsValid.cc
@@ -494,14 +494,13 @@ void SiStripRecHitsValid::rechitanalysis_matched(SiStripMatchedRecHit2D const re
   rechitpro.resolxy = error.xy();
   rechitpro.resolyy = error.yy();
 
-  matched.clear();  // Get the simHits that match the stereo recHit
+  matched.clear();
   matched = associate.associateHit(rechit);
 
   double mindist = 999999;
   double dist = 999999;
   double distx = 999999;
   double disty = 999999;
-  PSimHit closest;
   std::pair<LocalPoint,LocalVector> closestPair;
 
   if(!matched.empty()){
@@ -523,7 +522,6 @@ void SiStripRecHitsValid::rechitanalysis_matched(SiStripMatchedRecHit2D const re
 	if(dist<mindist){
 	  mindist = dist;
 	  closestPair = hitPair;
-	  closest = (*m);
 	}
       }
     }  

--- a/Validation/TrackerRecHits/src/SiStripRecHitsValid.cc
+++ b/Validation/TrackerRecHits/src/SiStripRecHitsValid.cc
@@ -495,12 +495,13 @@ void SiStripRecHitsValid::rechitanalysis_matched(SiStripMatchedRecHit2D const re
   rechitpro.resolyy = error.yy();
 
   matched.clear();  // Get the simHits that match the stereo recHit
-  matched = associate.associateHit(rechit.stereoHit());
+  matched = associate.associateHit(rechit);
 
   double mindist = 999999;
   double dist = 999999;
   double distx = 999999;
   double disty = 999999;
+  PSimHit closest;
   std::pair<LocalPoint,LocalVector> closestPair;
 
   if(!matched.empty()){
@@ -510,6 +511,8 @@ void SiStripRecHitsValid::rechitanalysis_matched(SiStripMatchedRecHit2D const re
     
 
     for(vector<PSimHit>::const_iterator m=matched.begin(); m<matched.end(); m++){
+      SiStripDetId hitDetId(m->detUnitId());
+      if (hitDetId.stereo()) {  // project from the stereo sensor
       //project simhit;
 	hitPair= projectHit((*m),partnerstripdet,gluedDet->surface());
 	distx = fabs(rechitpro.x - hitPair.first.x());
@@ -520,7 +523,9 @@ void SiStripRecHitsValid::rechitanalysis_matched(SiStripMatchedRecHit2D const re
 	if(dist<mindist){
 	  mindist = dist;
 	  closestPair = hitPair;
+	  closest = (*m);
 	}
+      }
     }  
     rechitpro.resx = rechitpro.x - closestPair.first.x();
     rechitpro.resy = rechitpro.y - closestPair.first.y();

--- a/Validation/TrackerRecHits/src/SiStripRecHitsValid.cc
+++ b/Validation/TrackerRecHits/src/SiStripRecHitsValid.cc
@@ -355,7 +355,6 @@ void SiStripRecHitsValid::analyze(const edm::Event& e, const edm::EventSetup& es
   
 
   //now fill the cumulative histograms of the hits
-  std::vector<std::string> SubDetList_; 
   for (std::vector<std::string>::iterator iSubdet  = SubDetList_.begin(); iSubdet != SubDetList_.end(); iSubdet++){
     std::map<std::string, SubDetMEs>::iterator iSubDetME  = SubDetMEsMap.find((*iSubdet));
     fillME(iSubDetME->second.meNumrphi,std::accumulate(totnumrechitrphi[(*iSubdet)].rbegin(), totnumrechitrphi[(*iSubdet)].rend(), 0));
@@ -495,8 +494,8 @@ void SiStripRecHitsValid::rechitanalysis_matched(SiStripMatchedRecHit2D const re
   rechitpro.resolxy = error.xy();
   rechitpro.resolyy = error.yy();
 
-  matched.clear();
-  matched = associate.associateHit(rechit);
+  matched.clear();  // Get the simHits that match the stereo recHit
+  matched = associate.associateHit(rechit.stereoHit());
 
   double mindist = 999999;
   double dist = 999999;


### PR DESCRIPTION
SiStripRecHitsValid:  Fix a bug that was disabling filling of histos for no. of recHits by subdet.  Adjust the binning of the now-enabled histograms.
  For matched recHits, limit the simHits projected from the stereo sensor to those actually on the stereo sensor.
TrackerHitAssociator:  For matched recHits, suppress ghost hits by requiring a simTrack association.
