### PR TITLE
MiniAOD 7.0.X fixes from CSA14 feedback

### DIFF
--- a/DataFormats/PatCandidates/interface/MET.h
+++ b/DataFormats/PatCandidates/interface/MET.h
@@ -168,7 +168,7 @@ namespace pat {
       enum METUncertainty {
         JetEnUp=0, JetEnDown=1, JetResUp=2, JetResDown=3,
         MuonEnUp=4, MuonEnDown=5, ElectronEnUp=6, ElectronEnDown=7, TauEnUp=8,TauEnDown=9,
-        UnclusteredEnUp=10,UnclusteredEnDown=11, METUncertaintySize=12
+        UnclusteredEnUp=10,UnclusteredEnDown=11, NoShift=12, METUncertaintySize=13
       };
       enum METUncertaintyLevel {
         Raw=0, Type1=1, Type1p2=2

--- a/DataFormats/PatCandidates/interface/PackedGenParticle.h
+++ b/DataFormats/PatCandidates/interface/PackedGenParticle.h
@@ -56,6 +56,9 @@ namespace pat {
     virtual size_t numberOfMothers() const;
     /// return mother at a given position (throws an exception)
     virtual const reco::Candidate * mother( size_type ) const;
+    /// direct access to the mother reference (may be null)
+    const reco::GenParticleRef & motherRef() const { return mother_; }
+
     /// return daughter at a given position (throws an exception)
     virtual reco::Candidate * daughter( size_type );
     /// return daughter with a specified role name

--- a/JetMETCorrections/Type1MET/plugins/CorrectedPFMETProducer.cc
+++ b/JetMETCorrections/Type1MET/plugins/CorrectedPFMETProducer.cc
@@ -28,10 +28,12 @@ namespace CorrectedMETProducer_namespace
 
     reco::PFMET operator()(const reco::PFMET& rawMEt, const CorrMETData& correction) const
     {
-      return reco::PFMET(rawMEt.getSpecific(), 
+      reco::PFMET ret(rawMEt.getSpecific(), 
 			 correctedSumEt(rawMEt, correction), 
 			 correctedP4(rawMEt, correction), 
 			 rawMEt.vertex());
+      ret.setSignificanceMatrix(rawMEt.getSignificanceMatrix()); 
+      return ret;
     }
   };
 }

--- a/PhysicsTools/PatAlgos/plugins/PATMETSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMETSlimmer.cc
@@ -54,6 +54,7 @@ void pat::PATMETSlimmer::maybeReadShifts(const edm::ParameterSet &basePSet, cons
         throw cms::Exception("Unsupported", "Reading PSets not supported, for now just use input tag");
     } else if (basePSet.existsAs<edm::InputTag>(name)) {
         const edm::InputTag & baseTag = basePSet.getParameter<edm::InputTag>(name);
+        shifts_.push_back(OneMETShift(pat::MET::NoShift,   level, baseTag, consumesCollector()));
         shifts_.push_back(OneMETShift(pat::MET::JetEnUp,   level, baseTag, consumesCollector()));
         shifts_.push_back(OneMETShift(pat::MET::JetEnDown, level, baseTag, consumesCollector()));
         shifts_.push_back(OneMETShift(pat::MET::JetResUp,   level, baseTag, consumesCollector()));
@@ -75,6 +76,7 @@ pat::PATMETSlimmer::OneMETShift::OneMETShift(pat::MET::METUncertainty shift_, pa
     std::string baseTagStr = baseTag.encode();
     char buff[1024];
     switch (shift) {
+        case pat::MET::NoShift  : snprintf(buff, 1023, baseTagStr.c_str(), "OriginalReserved");   break;
         case pat::MET::JetEnUp  : snprintf(buff, 1023, baseTagStr.c_str(), "JetEnUp");   break;
         case pat::MET::JetEnDown: snprintf(buff, 1023, baseTagStr.c_str(), "JetEnDown"); break;
         case pat::MET::JetResUp  : snprintf(buff, 1023, baseTagStr.c_str(), "JetResUp");   break;

--- a/PhysicsTools/PatAlgos/plugins/PATPackedGenParticleProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPackedGenParticleProducer.cc
@@ -88,7 +88,7 @@ void pat::PATPackedGenParticleProducer::produce(edm::Event& iEvent, const edm::E
 
     for(unsigned int ic=0, nc = cands->size(); ic < nc; ++ic) {
         const reco::GenParticle &cand=(*cands)[ic];
-	if(cand.status() ==1 && std::abs(cand.eta() < maxEta_))
+	if(cand.status() ==1 && std::abs(cand.eta()) < maxEta_)
         {
 		if(cand.numberOfMothers() > 0) {
 			edm::Ref<reco::GenParticleCollection> newRef=(*asso)[cand.motherRef(0)];

--- a/PhysicsTools/PatAlgos/python/slimming/prunedGenParticles_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/prunedGenParticles_cfi.py
@@ -25,6 +25,8 @@ prunedGenParticles = cms.EDProducer("GenParticlePruner",
 	"keep abs(pdgId) = 10411 || abs(pdgId) = 10421 || abs(pdgId) = 10413 || abs(pdgId) = 10423 || abs(pdgId) = 20413 || abs(pdgId) = 20423 || abs(pdgId) = 10431 || abs(pdgId) = 10433 || abs(pdgId) = 20433", 
 # additional b hadrons for jet fragmentation studies
 	"keep abs(pdgId) = 10511 || abs(pdgId) = 10521 || abs(pdgId) = 10513 || abs(pdgId) = 10523 || abs(pdgId) = 20513 || abs(pdgId) = 20523 || abs(pdgId) = 10531 || abs(pdgId) = 10533 || abs(pdgId) = 20533 || abs(pdgId) = 10541 || abs(pdgId) = 10543 || abs(pdgId) = 20543", 
+# keep protons and first children
+        "keep+ pdgId = 2212",
 
     )
 )

--- a/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
@@ -46,13 +46,13 @@ MicroEventContent = cms.PSet(
 
         'keep double_fixedGridRho*__*', 
 
-        'keep *_selectedPatTrigger_*_PAT',
-        'keep patPackedTriggerPrescales_patTrigger__PAT',
-        'keep *_l1extraParticles_*_HLT',
-        'keep L1GlobalTriggerReadoutRecord_gtDigis_*_HLT',
+        'keep *_selectedPatTrigger_*_*',
+        'keep patPackedTriggerPrescales_patTrigger__*',
+        'keep *_l1extraParticles_*_*',
+        'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*',
         'keep *_TriggerResults_*_HLT',
         'keep *_TriggerResults_*_PAT', # for MET filters
-	'keep patPackedCandidates_lostTracks_*_PAT',
+	'keep patPackedCandidates_lostTracks_*_*',
         'keep HcalNoiseSummary_hcalnoise__*',
     )
 )


### PR DESCRIPTION
This set of small commits fixes individual issues that had been pointed out during CSA14 (mostly from https://twiki.cern.ch/twiki/bin/viewauth/CMS/MiniAODCSA14FollowUp)

While there's no change in the dataformats, these fixes really enter the miniAOD production step (unlike e.g. #4862 which was only affecting analysis on top of miniAODs), so to benefit from the fix one has to reproduce the miniAODs.
For the last commit, related to MET corrections, if somebody wants to implement something better feel free to leave it out. In the next two weeks I'll be at a conference and then on holidays, so I will be able to follow up on this PR only intermittently.

@arizzi
