### PR TITLE
Clear tk geom

### DIFF
--- a/Alignment/ReferenceTrajectories/plugins/TwoBodyDecayTrajectoryFactory.cc
+++ b/Alignment/ReferenceTrajectories/plugins/TwoBodyDecayTrajectoryFactory.cc
@@ -267,11 +267,9 @@ bool TwoBodyDecayTrajectoryFactory::match( const TrajectoryStateOnSurface& state
   double varX = le.xx();
   double varY = le.yy();
 
-  AlignmentPositionError const* gape = recHit->det()->alignmentPositionError();
-  if ( gape )
+  auto const & lape = recHit->det()->localAlignmentError();
+  if ( lape.valid() )
   {
-    ErrorFrameTransformer eft;
-    LocalError lape = eft.transform( gape->globalError(), recHit->det()->surface() );
 
     varX += lape.xx();
     varY += lape.yy();

--- a/FastSimulation/Tracking/BuildFile.xml
+++ b/FastSimulation/Tracking/BuildFile.xml
@@ -5,6 +5,8 @@
 <use   name="DataFormats/TrackingRecHit"/>
 <use   name="DataFormats/TrackerRecHit2D"/>
 <use   name="Geometry/CommonDetUnit"/>
+<use   name="Geometry/TrackerGeometryBuilder"/>
+<use   name="Geometry/Records"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/FastSimulation/TrackingRecHitProducer/src/SiTrackerGaussianSmearingRecHitConverter.cc
+++ b/FastSimulation/TrackingRecHitProducer/src/SiTrackerGaussianSmearingRecHitConverter.cc
@@ -42,8 +42,6 @@
 // Numbering scheme
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
-#include "DataFormats/GeometryCommonDetAlgo/interface/ErrorFrameTransformer.h"
-#include "DataFormats/TrackingRecHit/interface/AlignmentPositionError.h"
 
 //For Pileup events
 #include "SimDataFormats/EncodedEventId/interface/EncodedEventId.h"
@@ -783,15 +781,11 @@ void SiTrackerGaussianSmearingRecHitConverter::smearHits(const edm::PSimHitConta
       // Inflate errors in case of geometry misaligniment  
       // (still needed! what done in constructor of BaseTrackerRecHit is not effective ad geometry is not missaligned)
       const GeomDet* theMADet = misAlignedGeometry->idToDet(det);
-      if ( theMADet->alignmentPositionError() != 0 ) { 
-	LocalError lape = 
-	  ErrorFrameTransformer().transform ( theMADet->alignmentPositionError()->globalError(),
-					      theMADet->surface() );
-        // std::cout << "ori lape " << det.rawId() << ' ' <<  lape << " det lape " << theDetUnit.localAlignmentError() << std::endl;
+      auto const & lape  =  theMADet->localAlignmentError();
+      if ( lape.valid() )
 	error = LocalError ( error.xx()+lape.xx(),
 			     error.xy()+lape.xy(),
 			     error.yy()+lape.yy() );
-      }
 
       float chargeADC = (*isim).energyLoss()/(GevPerElectron * ElectronsPerADC);
 

--- a/Geometry/CommonDetUnit/interface/GeomDet.h
+++ b/Geometry/CommonDetUnit/interface/GeomDet.h
@@ -100,11 +100,11 @@ public:
 
 private:
 
-  ReferenceCountingPointer<Plane>  thePlane;
-  AlignmentPositionError*               theAlignmentPositionError;
-  LocalError                            theLocalAlignmentError;
   DetId m_detId;
   int m_index;
+  ReferenceCountingPointer<Plane>  thePlane;
+  LocalError                            theLocalAlignmentError;
+  AlignmentPositionError*               theAlignmentPositionError;
 
   /// Alignment part of interface, available only to friend 
   friend class DetPositioner;

--- a/Geometry/CommonDetUnit/interface/GeomDet.h
+++ b/Geometry/CommonDetUnit/interface/GeomDet.h
@@ -84,6 +84,9 @@ public:
   // FIXME: must become pure virtual
   virtual const GeomDet* component(DetId /*id*/) const {return 0;}
 
+  /// Return pointer to alignment errors. 
+  AlignmentPositionError const* alignmentPositionError() const { return theAlignmentPositionError;}
+
 
   // specific unix index in a given subdetector (such as Tracker)
   int index() const { return m_index;}
@@ -97,10 +100,11 @@ public:
 
 private:
 
+  ReferenceCountingPointer<Plane>  thePlane;
+  AlignmentPositionError*               theAlignmentPositionError;
+  LocalError                            theLocalAlignmentError;
   DetId m_detId;
   int m_index;
-  ReferenceCountingPointer<Plane>  thePlane;
-  LocalError                            theLocalAlignmentError;
 
   /// Alignment part of interface, available only to friend 
   friend class DetPositioner;

--- a/Geometry/CommonDetUnit/interface/GeomDet.h
+++ b/Geometry/CommonDetUnit/interface/GeomDet.h
@@ -84,9 +84,6 @@ public:
   // FIXME: must become pure virtual
   virtual const GeomDet* component(DetId /*id*/) const {return 0;}
 
-  /// Return pointer to alignment errors. 
-  AlignmentPositionError const* alignmentPositionError() const { return theAlignmentPositionError;}
-
 
   // specific unix index in a given subdetector (such as Tracker)
   int index() const { return m_index;}
@@ -104,7 +101,6 @@ private:
   int m_index;
   ReferenceCountingPointer<Plane>  thePlane;
   LocalError                            theLocalAlignmentError;
-  AlignmentPositionError*               theAlignmentPositionError;
 
   /// Alignment part of interface, available only to friend 
   friend class DetPositioner;

--- a/Geometry/CommonDetUnit/interface/TrackingGeometry.h
+++ b/Geometry/CommonDetUnit/interface/TrackingGeometry.h
@@ -20,8 +20,7 @@
 
 #include "DataFormats/DetId/interface/DetId.h"
 #include <vector>
-// #include <map>
-#include <ext/hash_map>
+#include <unordered_map>
 
 class GeomDetType;
 class GeomDetUnit;
@@ -34,10 +33,8 @@ public:
   typedef std::vector<GeomDet const*>              DetContainer;
   typedef std::vector<GeomDetUnit const*>          DetUnitContainer;
   typedef std::vector<DetId>                 DetIdContainer;
-  //  typedef std::map<DetId,GeomDetUnit const*>       mapIdToDetUnit;
-  // typedef std::map<DetId,GeomDet const*>           mapIdToDet;
-  typedef  __gnu_cxx::hash_map< unsigned int, GeomDetUnit const*> mapIdToDetUnit;
-  typedef  __gnu_cxx::hash_map< unsigned int, GeomDet const*>     mapIdToDet;
+  typedef  std::unordered_map< unsigned int, GeomDetUnit const*> mapIdToDetUnit;
+  typedef  std::unordered_map< unsigned int, GeomDet const*>     mapIdToDet;
 
   // Default constructor
   //  virtual TrackingGeometry() {}

--- a/Geometry/CommonDetUnit/src/GeomDet.cc
+++ b/Geometry/CommonDetUnit/src/GeomDet.cc
@@ -5,9 +5,9 @@
 GeomDet::GeomDet( Plane* plane): GeomDet(ReferenceCountingPointer<Plane>(plane)){}
 
 GeomDet::GeomDet( const ReferenceCountingPointer<Plane>& plane) :
-  m_index(-1), thePlane(plane), theLocalAlignmentError(InvalidError()), theAlignmentPositionError(nullptr)  {}
+  m_index(-1), thePlane(plane), theLocalAlignmentError(InvalidError()) {}
 
-GeomDet::~GeomDet() {delete theAlignmentPositionError;}
+GeomDet::~GeomDet() {}
 
 void GeomDet::move( const GlobalVector& displacement)
 {
@@ -35,11 +35,6 @@ void GeomDet::setPosition( const Surface::PositionType& position,
 #include "DataFormats/GeometryCommonDetAlgo/interface/ErrorFrameTransformer.h"
 bool GeomDet::setAlignmentPositionError (const AlignmentPositionError& ape) 
 {
-  if (!theAlignmentPositionError) {
-    if (ape.valid()) theAlignmentPositionError = new AlignmentPositionError(ape);
-  } 
-  else *theAlignmentPositionError = ape;
-
   theLocalAlignmentError = ape.valid() ?
     ErrorFrameTransformer().transform( ape.globalError(),
                                        surface()

--- a/Geometry/CommonDetUnit/src/GeomDet.cc
+++ b/Geometry/CommonDetUnit/src/GeomDet.cc
@@ -2,12 +2,13 @@
 #include "Geometry/CommonDetUnit/interface/ModifiedSurfaceGenerator.h"
 #include "DataFormats/TrackingRecHit/interface/AlignmentPositionError.h"
 
-GeomDet::GeomDet( Plane* plane): GeomDet(ReferenceCountingPointer<Plane>(plane)){}
+GeomDet::GeomDet( Plane* plane):
+  thePlane(plane), theAlignmentPositionError(0), theLocalAlignmentError(InvalidError()), m_index(-1) {}
 
 GeomDet::GeomDet( const ReferenceCountingPointer<Plane>& plane) :
-  m_index(-1), thePlane(plane), theLocalAlignmentError(InvalidError()) {}
+  thePlane(plane), theAlignmentPositionError(0), theLocalAlignmentError(InvalidError()), m_index(-1) {}
 
-GeomDet::~GeomDet() {}
+GeomDet::~GeomDet() {delete theAlignmentPositionError;}
 
 void GeomDet::move( const GlobalVector& displacement)
 {
@@ -35,6 +36,11 @@ void GeomDet::setPosition( const Surface::PositionType& position,
 #include "DataFormats/GeometryCommonDetAlgo/interface/ErrorFrameTransformer.h"
 bool GeomDet::setAlignmentPositionError (const AlignmentPositionError& ape) 
 {
+  if (!theAlignmentPositionError) {
+    if (ape.valid()) theAlignmentPositionError = new AlignmentPositionError(ape);
+  } 
+  else *theAlignmentPositionError = ape;
+
   theLocalAlignmentError = ape.valid() ?
     ErrorFrameTransformer().transform( ape.globalError(),
                                        surface()

--- a/Geometry/CommonDetUnit/src/GeomDet.cc
+++ b/Geometry/CommonDetUnit/src/GeomDet.cc
@@ -2,11 +2,10 @@
 #include "Geometry/CommonDetUnit/interface/ModifiedSurfaceGenerator.h"
 #include "DataFormats/TrackingRecHit/interface/AlignmentPositionError.h"
 
-GeomDet::GeomDet( Plane* plane):
-  thePlane(plane), theAlignmentPositionError(0), theLocalAlignmentError(InvalidError()), m_index(-1) {}
+GeomDet::GeomDet( Plane* plane): GeomDet(ReferenceCountingPointer<Plane>(plane)){}
 
 GeomDet::GeomDet( const ReferenceCountingPointer<Plane>& plane) :
-  thePlane(plane), theAlignmentPositionError(0), theLocalAlignmentError(InvalidError()), m_index(-1) {}
+  m_index(-1), thePlane(plane), theLocalAlignmentError(InvalidError()), theAlignmentPositionError(nullptr)  {}
 
 GeomDet::~GeomDet() {delete theAlignmentPositionError;}
 

--- a/Geometry/GlobalTrackingGeometryBuilder/test/BuildFile.xml
+++ b/Geometry/GlobalTrackingGeometryBuilder/test/BuildFile.xml
@@ -1,5 +1,5 @@
 <use   name="Geometry/CommonDetUnit"/>
-<use   name="Geometry/TrackingGeometryBuilder"/>
+<use   name="Geometry/TrackerGeometryBuilder"/>
 <use   name="Geometry/Records"/>
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/ParameterSet"/>

--- a/Geometry/GlobalTrackingGeometryBuilder/test/BuildFile.xml
+++ b/Geometry/GlobalTrackingGeometryBuilder/test/BuildFile.xml
@@ -1,4 +1,5 @@
 <use   name="Geometry/CommonDetUnit"/>
+<use   name="Geometry/TrackingGeometryBuilder"/>
 <use   name="Geometry/Records"/>
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/ParameterSet"/>

--- a/Geometry/TrackerGeometryBuilder/BuildFile.xml
+++ b/Geometry/TrackerGeometryBuilder/BuildFile.xml
@@ -3,7 +3,6 @@
 <use   name="DataFormats/SiStripDetId"/>
 <use   name="DetectorDescription/Core"/>
 <use   name="FWCore/MessageLogger"/>
-<use   name="FWCore/ServiceRegistry"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="Geometry/CommonDetUnit"/>
 <use   name="Geometry/CommonTopologies"/>

--- a/Geometry/TrackerGeometryBuilder/interface/GluedGeomDet.h
+++ b/Geometry/TrackerGeometryBuilder/interface/GluedGeomDet.h
@@ -5,7 +5,7 @@
 #include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
 #include "DataFormats/DetId/interface/DetId.h"
 
-class GluedGeomDet : public GeomDet{
+class GluedGeomDet final : public GeomDet{
 public:
 
   GluedGeomDet( BoundPlane* sp, const GeomDetUnit* monoDet,  const GeomDetUnit* stereoDet);
@@ -23,7 +23,6 @@ public:
 private:
   const GeomDetUnit* theMonoDet;
   const GeomDetUnit* theStereoDet;  
-  std::vector<const GeomDet*> child;
 };
 
 #endif

--- a/Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h
+++ b/Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h
@@ -53,7 +53,7 @@ private:
   /// set the SurfaceDeformation for this StripGeomDetUnit to proxy topology.
   virtual void setSurfaceDeformation(const SurfaceDeformation * deformation);
 
-  boost::shared_ptr<ProxyPixelTopology> theTopology;
+  std::unique_ptr<ProxyPixelTopology> theTopology;
 };
 
 #endif // Tracker_PixelGeomDetUnit_H

--- a/Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h
+++ b/Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h
@@ -9,7 +9,6 @@
 
 class PixelGeomDetType;
 class PixelTopology;
-class GeometricDet;
 class SurfaceDeformation;
 /**
  * The base PixelGeomDetUnit. Specialized in SiPixelGeomDetUnit.
@@ -18,7 +17,7 @@ class SurfaceDeformation;
 class PixelGeomDetUnit : public GeomDetUnit {
 public:
 
-  PixelGeomDetUnit(BoundPlane* sp, PixelGeomDetType const * type, GeometricDet const * gd);
+  PixelGeomDetUnit(BoundPlane* sp, PixelGeomDetType const * type, DetId id);
 
   // DetUnit interface
 
@@ -55,7 +54,6 @@ private:
   virtual void setSurfaceDeformation(const SurfaceDeformation * deformation);
 
   boost::shared_ptr<ProxyPixelTopology> theTopology;
-  const GeometricDet* theGD;
 };
 
 #endif // Tracker_PixelGeomDetUnit_H

--- a/Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h
+++ b/Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h
@@ -14,7 +14,7 @@ class SurfaceDeformation;
  * The base PixelGeomDetUnit. Specialized in SiPixelGeomDetUnit.
  */
 
-class PixelGeomDetUnit : public GeomDetUnit {
+class PixelGeomDetUnit final : public GeomDetUnit {
 public:
 
   PixelGeomDetUnit(BoundPlane* sp, PixelGeomDetType const * type, DetId id);

--- a/Geometry/TrackerGeometryBuilder/interface/ProxyPixelTopology.h
+++ b/Geometry/TrackerGeometryBuilder/interface/ProxyPixelTopology.h
@@ -19,8 +19,6 @@
 ///  \author    : Andreas Mussgiller
 ///  date       : December 2010
 
-#include "DataFormats/GeometryCommonDetAlgo/interface/DeepCopyPointerByClone.h"
-
 #include "Geometry/CommonTopologies/interface/SurfaceDeformation.h"
 #include "Geometry/CommonTopologies/interface/PixelTopology.h"
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetType.h"
@@ -120,7 +118,7 @@ private:
   
   PixelGeomDetType const * theType;  
   float theLength, theWidth;
-  DeepCopyPointerByClone<const SurfaceDeformation> theSurfaceDeformation;
+  std::unique_ptr<const SurfaceDeformation> theSurfaceDeformation;
 };
 
 #endif

--- a/Geometry/TrackerGeometryBuilder/interface/ProxyStripTopology.h
+++ b/Geometry/TrackerGeometryBuilder/interface/ProxyStripTopology.h
@@ -24,8 +24,6 @@
 ///  \author    : Andreas Mussgiller
 ///  date       : November 2010
 
-#include "DataFormats/GeometryCommonDetAlgo/interface/DeepCopyPointerByClone.h"
-
 #include "Geometry/CommonTopologies/interface/SurfaceDeformation.h"
 #include "Geometry/CommonTopologies/interface/StripTopology.h"
 #include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetType.h"
@@ -112,7 +110,7 @@ private:
 
   StripGeomDetType const * theType;
   float theLength, theWidth;
-  DeepCopyPointerByClone<const SurfaceDeformation> theSurfaceDeformation;
+  std::unique_ptr<const SurfaceDeformation> theSurfaceDeformation;
 };
 
 #endif

--- a/Geometry/TrackerGeometryBuilder/interface/RectangularPixelTopology.h
+++ b/Geometry/TrackerGeometryBuilder/interface/RectangularPixelTopology.h
@@ -36,10 +36,6 @@
 # include "DataFormats/SiPixelDetId/interface/PixelChannelIdentifier.h"
 # include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-namespace {
-//  const float EPS = 0.001;     // accuray in pixel units, so about 0.1 um
-//  const float EPSCM = 0.00001; // accuray in cm, so about 0.1 um
-}
 
 class RectangularPixelTopology GCC11_FINAL : public PixelTopology
 {

--- a/Geometry/TrackerGeometryBuilder/interface/RectangularPixelTopology.h
+++ b/Geometry/TrackerGeometryBuilder/interface/RectangularPixelTopology.h
@@ -34,12 +34,11 @@
 
 # include "Geometry/CommonTopologies/interface/PixelTopology.h"
 # include "DataFormats/SiPixelDetId/interface/PixelChannelIdentifier.h"
-# include "FWCore/ServiceRegistry/interface/Service.h"
 # include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 namespace {
-  const float EPS = 0.001;     // accuray in pixel units, so about 0.1 um
-  const float EPSCM = 0.00001; // accuray in cm, so about 0.1 um
+//  const float EPS = 0.001;     // accuray in pixel units, so about 0.1 um
+//  const float EPSCM = 0.00001; // accuray in cm, so about 0.1 um
 }
 
 class RectangularPixelTopology GCC11_FINAL : public PixelTopology

--- a/Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h
+++ b/Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h
@@ -53,7 +53,7 @@ private:
   /// set the SurfaceDeformation for this StripGeomDetUnit to proxy topology.
   virtual void setSurfaceDeformation(const SurfaceDeformation * deformation);
 
-  boost::shared_ptr<ProxyStripTopology> theTopology;
+  std::unique_ptr<ProxyStripTopology> theTopology;
 };
 
 #endif // Tracker_StripGeomDetUnit_H

--- a/Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h
+++ b/Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h
@@ -9,7 +9,6 @@
 
 class StripGeomDetType;
 class StripTopology;
-class GeometricDet;
 class SurfaceDeformation;
 /**
  * StripGeomDetUnit is the abstract class for SiStripGeomDetUnit.
@@ -18,7 +17,7 @@ class SurfaceDeformation;
 class StripGeomDetUnit : public GeomDetUnit {
 public:
 
-  StripGeomDetUnit( BoundPlane* sp, StripGeomDetType const * type, GeometricDet const * gd);
+  StripGeomDetUnit( BoundPlane* sp, StripGeomDetType const * type, DetId id);
 
   // Det interface
 
@@ -55,7 +54,6 @@ private:
   virtual void setSurfaceDeformation(const SurfaceDeformation * deformation);
 
   boost::shared_ptr<ProxyStripTopology> theTopology;
-  const GeometricDet* theGD;
 };
 
 #endif // Tracker_StripGeomDetUnit_H

--- a/Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h
+++ b/Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h
@@ -14,7 +14,7 @@ class SurfaceDeformation;
  * StripGeomDetUnit is the abstract class for SiStripGeomDetUnit.
  */
 
-class StripGeomDetUnit : public GeomDetUnit {
+class StripGeomDetUnit final : public GeomDetUnit {
 public:
 
   StripGeomDetUnit( BoundPlane* sp, StripGeomDetType const * type, DetId id);

--- a/Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h
+++ b/Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h
@@ -24,13 +24,24 @@ namespace trackerTrie {
  * A specific Tracker Builder which builds a Tracker from a list of DetUnits. 
  * Pattern recognition is used to discover layers, rings etc.
  */
-class TrackerGeometry : public TrackingGeometry {
-public:
-  typedef GeomDetEnumerators::SubDetector SubDetector;
+class TrackerGeometry final : public TrackingGeometry {
 
   explicit TrackerGeometry(GeometricDet const* gd=0);  
 
+  friend class TrackerGeomBuilderFromGeometricDet;
+
+  void addType(GeomDetType const * p);
+  void addDetUnit(GeomDetUnit const * p);
+  void addDetUnitId(DetId p);
+  void addDet(GeomDet const * p);
+  void addDetId(DetId p);
+  void finalize();
+
+public:
+  typedef GeomDetEnumerators::SubDetector SubDetector;
+
   virtual ~TrackerGeometry() ;
+
 
   virtual const DetTypeContainer&  detTypes()         const;
   virtual const DetUnitContainer&  detUnits()         const;
@@ -41,19 +52,13 @@ public:
   virtual const GeomDet*           idToDet(DetId)     const;
 
 
-  void addType(GeomDetType const * p);
-  void addDetUnit(GeomDetUnit const * p);
-  void addDetUnitId(DetId p);
-  void addDet(GeomDet const * p);
-  void addDetId(DetId p);
-
   unsigned int offsetDU(SubDetector sid) const { return theOffsetDU[sid];}
   unsigned int endsetDU(SubDetector sid) const { return theEndsetDU[sid];}
   // Magic : better be called at the right moment...
   void setOffsetDU(SubDetector sid) { theOffsetDU[sid]=detUnits().size();}
   void setEndsetDU(SubDetector sid) { theEndsetDU[sid]=detUnits().size();}
 
-  GeometricDet const * trackerDet() const; 
+  GeometricDet const * trackerDet() const {return  theTrackerDet;}
 
   const DetContainer& detsPXB() const;
   const DetContainer& detsPXF() const;

--- a/Geometry/TrackerGeometryBuilder/src/GluedGeomDet.cc
+++ b/Geometry/TrackerGeometryBuilder/src/GluedGeomDet.cc
@@ -2,9 +2,7 @@
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 
 GluedGeomDet::GluedGeomDet( BoundPlane* sp,const GeomDetUnit* monoDet, const GeomDetUnit* stereoDet) : 
-  GeomDet(sp),theMonoDet(monoDet),theStereoDet(stereoDet){
-  child.push_back(theMonoDet);
-  child.push_back(theStereoDet);
+  GeomDet(sp),theMonoDet(monoDet),theStereoDet(stereoDet) {
   StripSubdetector subdet(theMonoDet->geographicalId().rawId());
   setDetId(subdet.glued());
 }
@@ -13,5 +11,5 @@ GluedGeomDet::~GluedGeomDet()
 {}
 
 std::vector<const GeomDet*> GluedGeomDet::components() const {
-  return child;
+  return std::vector<const GeomDet*>{theMonoDet,theStereoDet};
 }

--- a/Geometry/TrackerGeometryBuilder/src/PixelGeomDetUnit.cc
+++ b/Geometry/TrackerGeometryBuilder/src/PixelGeomDetUnit.cc
@@ -1,13 +1,12 @@
-#include "Geometry/TrackerNumberingBuilder/interface/GeometricDet.h"
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetType.h"
 
 #include "Geometry/CommonTopologies/interface/SurfaceDeformation.h"
 
-PixelGeomDetUnit::PixelGeomDetUnit( BoundPlane* sp, PixelGeomDetType const * type, const GeometricDet* gd) : 
-  GeomDetUnit(sp), theTopology(new ProxyPixelTopology(type, sp)), theGD(gd)
+PixelGeomDetUnit::PixelGeomDetUnit( BoundPlane* sp, PixelGeomDetType const * type, DetId id) : 
+  GeomDetUnit(sp), theTopology(new ProxyPixelTopology(type, sp))
 {
-  setDetId(theGD->geographicalID());
+  setDetId(id);
 }
 
 const GeomDetType& PixelGeomDetUnit::type() const { return theTopology->type(); }

--- a/Geometry/TrackerGeometryBuilder/src/ProxyPixelTopology.cc
+++ b/Geometry/TrackerGeometryBuilder/src/ProxyPixelTopology.cc
@@ -167,7 +167,7 @@ float ProxyPixelTopology::localY(const float mpY,
 ////////////////////////////////////////////////////////////////////////////////
 void ProxyPixelTopology::setSurfaceDeformation(const SurfaceDeformation * deformation)
 { 
-  theSurfaceDeformation = deformation;
+  theSurfaceDeformation.reset(deformation);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/Geometry/TrackerGeometryBuilder/src/ProxyStripTopology.cc
+++ b/Geometry/TrackerGeometryBuilder/src/ProxyStripTopology.cc
@@ -179,7 +179,7 @@ float ProxyStripTopology::localStripLength( const LocalPoint& lp, const Topology
 ////////////////////////////////////////////////////////////////////////////////
 void ProxyStripTopology::setSurfaceDeformation(const SurfaceDeformation * deformation)
 { 
-  theSurfaceDeformation = deformation;
+  theSurfaceDeformation.reset(deformation);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/Geometry/TrackerGeometryBuilder/src/StripGeomDetUnit.cc
+++ b/Geometry/TrackerGeometryBuilder/src/StripGeomDetUnit.cc
@@ -1,13 +1,12 @@
-#include "Geometry/TrackerNumberingBuilder/interface/GeometricDet.h"
 #include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
 #include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetType.h"
 
 #include "Geometry/CommonTopologies/interface/SurfaceDeformation.h"
 
-StripGeomDetUnit::StripGeomDetUnit( BoundPlane* sp, StripGeomDetType const * type, GeometricDet const * gd) : 
-  GeomDetUnit(sp), theTopology(new ProxyStripTopology(type, sp)), theGD(gd)
+StripGeomDetUnit::StripGeomDetUnit( BoundPlane* sp, StripGeomDetType const * type, DetId id) : 
+  GeomDetUnit(sp), theTopology(new ProxyStripTopology(type, sp))
 {
-  if(theGD) setDetId(theGD->geographicalID());
+  setDetId(id);
 }
 
 const GeomDetType& StripGeomDetUnit::type() const { return theTopology->type(); }

--- a/Geometry/TrackerGeometryBuilder/src/TrackerGeomBuilderFromGeometricDet.cc
+++ b/Geometry/TrackerGeometryBuilder/src/TrackerGeomBuilderFromGeometricDet.cc
@@ -116,7 +116,7 @@ void TrackerGeomBuilderFromGeometricDet::buildPixel(std::vector<const GeometricD
     }
 
     PlaneBuilderFromGeometricDet::ResultType plane = buildPlaneWithMaterial(gdv[i]);
-    GeomDetUnit* temp =  new PixelGeomDetUnit(&(*plane),thePixelDetTypeMap[detName],gdv[i]);
+    GeomDetUnit* temp =  new PixelGeomDetUnit(&(*plane),thePixelDetTypeMap[detName],gdv[i]->geographicalID());
 
     tracker->addDetUnit(temp);
     tracker->addDetUnitId(gdv[i]->geographicalID());
@@ -150,7 +150,7 @@ void TrackerGeomBuilderFromGeometricDet::buildSilicon(std::vector<const Geometri
     double scale  = (sidet.partnerDetId()) ? 0.5 : 1.0 ;	
 
     PlaneBuilderFromGeometricDet::ResultType plane = buildPlaneWithMaterial(gdv[i],scale);  
-    GeomDetUnit* temp = new StripGeomDetUnit(&(*plane), theStripDetTypeMap[detName],gdv[i]);
+    GeomDetUnit* temp = new StripGeomDetUnit(&(*plane), theStripDetTypeMap[detName],gdv[i]->geographicalID());
     
     tracker->addDetUnit(temp);
     tracker->addDetUnitId(gdv[i]->geographicalID());

--- a/Geometry/TrackerGeometryBuilder/src/TrackerGeometry.cc
+++ b/Geometry/TrackerGeometryBuilder/src/TrackerGeometry.cc
@@ -16,12 +16,23 @@
 TrackerGeometry::TrackerGeometry(GeometricDet const* gd) :  theTrackerDet(gd){}
 
 TrackerGeometry::~TrackerGeometry() {
-    for (DetContainer::iterator     it = theDets.begin(),     ed = theDets.end();     it != ed; ++it) delete const_cast<GeomDet*>(*it);
-    for (DetTypeContainer::iterator it = theDetTypes.begin(), ed = theDetTypes.end(); it != ed; ++it) delete const_cast<GeomDetType*>(*it);
+    for (auto d : theDets) delete const_cast<GeomDet*>(d);
+    for (auto d : theDetTypes) delete const_cast<GeomDetType*>(d);
 }
 
-GeometricDet const * TrackerGeometry::trackerDet() const {
-  return  theTrackerDet;
+void TrackerGeometry::finalize() {
+    theDetTypes.shrink_to_fit();  // owns the DetTypes
+    theDetUnits.shrink_to_fit();  // they're all also into 'theDets', so we assume 'theDets' owns them
+    theDets.shrink_to_fit();     // owns *ONLY* the GeomDet * corresponding to GluedDets.
+    theDetUnitIds.shrink_to_fit();
+    theDetIds.shrink_to_fit();
+  
+    thePXBDets.shrink_to_fit(); // not owned: they're also in 'theDets'
+    thePXFDets.shrink_to_fit(); // not owned: they're also in 'theDets'
+    theTIBDets.shrink_to_fit(); // not owned: they're also in 'theDets'
+    theTIDDets.shrink_to_fit(); // not owned: they're also in 'theDets'
+    theTOBDets.shrink_to_fit(); // not owned: they're also in 'theDets'
+    theTECDets.shrink_to_fit(); // not owned: they're also in 'theDets'
 }
 
 

--- a/RecoEgamma/EgammaElectronAlgos/BuildFile.xml
+++ b/RecoEgamma/EgammaElectronAlgos/BuildFile.xml
@@ -18,7 +18,6 @@
 <use   name="RecoTracker/MeasurementDet"/>
 <use   name="RecoTracker/TkSeedGenerator"/>
 <use   name="RecoTracker/TkDetLayers"/>
-<use   name="RecoTracker/TkNavigation"/>
 <use   name="TrackingTools/DetLayers"/>
 <use   name="TrackingTools/GsfTools"/>
 <use   name="TrackingTools/GsfTracking"/>

--- a/RecoEgamma/EgammaHLTAlgos/BuildFile.xml
+++ b/RecoEgamma/EgammaHLTAlgos/BuildFile.xml
@@ -10,7 +10,6 @@
 <use   name="RecoTracker/MeasurementDet"/>
 <use   name="RecoTracker/TkSeedGenerator"/>
 <use   name="RecoTracker/TkDetLayers"/>
-<use   name="RecoTracker/TkNavigation"/>
 <use   name="RecoTracker/CkfPattern"/>
 <use   name="TrackingTools/DetLayers"/>
 <use   name="RecoTracker/TrackProducer"/>

--- a/RecoEgamma/EgammaPhotonAlgos/BuildFile.xml
+++ b/RecoEgamma/EgammaPhotonAlgos/BuildFile.xml
@@ -19,7 +19,6 @@
 <use   name="TrackingTools/DetLayers"/>
 <use   name="TrackingTools/TransientTrack"/>
 <use   name="RecoTracker/MeasurementDet"/>
-<use   name="RecoTracker/TkNavigation"/>
 <use   name="RecoTracker/TkTrackingRegions"/>
 <use   name="RecoTracker/CkfPattern"/>
 <use   name="RecoTracker/TkSeedGenerator"/>

--- a/RecoHI/HiMuonAlgos/plugins/BuildFile.xml
+++ b/RecoHI/HiMuonAlgos/plugins/BuildFile.xml
@@ -16,7 +16,6 @@
 <use   name="DataFormats/TrajectorySeed"/>
 <use   name="TrackingTools/MeasurementDet"/>
 <use   name="RecoTracker/MeasurementDet"/>
-<use   name="RecoTracker/TkNavigation"/>
 <use   name="TrackingTools/TrajectoryFiltering"/>
 <use   name="TrackingTools/TrajectoryCleaning"/>
 <use   name="TrackingTools/MaterialEffects"/>

--- a/RecoLocalTracker/SiPixelClusterizer/test/BuildFile.xml
+++ b/RecoLocalTracker/SiPixelClusterizer/test/BuildFile.xml
@@ -12,7 +12,6 @@
 <use   name="CommonTools/UtilAlgos"/>
 <use   name="Geometry/Records"/>
 <use   name="DataFormats/DetId"/>
-<use   name="RecoLocalTracker/SiPixelClusterizer"/>
 # for tracks
 <use   name="TrackingTools/TrajectoryState"/>
 <use   name="TrackingTools/TrackFitters"/>

--- a/RecoTracker/CkfPattern/BuildFile.xml
+++ b/RecoTracker/CkfPattern/BuildFile.xml
@@ -13,7 +13,6 @@
 <use   name="MagneticField/Records"/>
 <use   name="MagneticField/Engine"/>
 <use   name="TrackingTools/MeasurementDet"/>
-<use   name="RecoTracker/TkNavigation"/>
 <use   name="RecoTracker/MeasurementDet"/>
 <use   name="TrackingTools/PatternTools"/>
 <use   name="TrackingTools/MaterialEffects"/>

--- a/RecoTracker/DebugTools/BuildFile.xml
+++ b/RecoTracker/DebugTools/BuildFile.xml
@@ -11,7 +11,6 @@
 <use name="RecoTracker/Record" />
 <use name="MagneticField/Records" />
 <use name="MagneticField/Engine" />
-<use name="RecoTracker/TkNavigation" />
 <use name="RecoTracker/TkDetLayers" />
 <use name="RecoTracker/MeasurementDet" />
 <use name="DataFormats/TrackerCommon"/>

--- a/RecoTracker/NuclearSeedGenerator/BuildFile.xml
+++ b/RecoTracker/NuclearSeedGenerator/BuildFile.xml
@@ -12,7 +12,6 @@
 <use   name="RecoTracker/MeasurementDet"/>
 <use   name="RecoTracker/Record"/>
 <use   name="RecoTracker/TkDetLayers"/>
-<use   name="RecoTracker/TkNavigation"/>
 <use   name="RecoTracker/TkSeedGenerator"/>
 <use   name="TrackingTools/DetLayers"/>
 <use   name="TrackingTools/GeomPropagators"/>

--- a/RecoTracker/TkNavigation/test/BuildFile.xml
+++ b/RecoTracker/TkNavigation/test/BuildFile.xml
@@ -5,7 +5,6 @@
 <use   name="DataFormats/SiStripDetId"/>
 <use   name="FWCore/MessageLogger"/>
 <use   name="RecoTracker/Record"/>
-<use   name="RecoTracker/TkNavigation"/>
 <use   name="TrackingTools/DetLayers"/>
 <library   file="*.cc" name="RecoTrackerTkNavigationTest">
   <flags   EDM_PLUGIN="1"/>

--- a/RecoTracker/TrackProducer/BuildFile.xml
+++ b/RecoTracker/TrackProducer/BuildFile.xml
@@ -15,7 +15,6 @@
 <use   name="Geometry/TrackerGeometryBuilder"/>
 <use   name="MagneticField/Engine"/>
 <use   name="MagneticField/Records"/>
-<use   name="RecoTracker/TkNavigation"/>
 <use   name="RecoTracker/MeasurementDet"/>
 <use   name="TrackingTools/GeomPropagators"/>
 <use   name="TrackingTools/PatternTools"/>


### PR DESCRIPTION
The initial objective of this PR was to remove all dependencies from DDD from the objects used in Reco
and, at the same time, reduce the memory footprint of the tracker geometry itself.
Unfortunately the two objectives could not be fully achieved because of the implementation of Alignment.
My personal conclusion is that it will be very difficult to optimize the access to geometry information w/o a major reimplementation effort of the Alignment infrastructure. Given the current lack of person-power in that area I do not see how it can ever happen.
