### PR TITLE
Fix two parameters in two Egamma filters in di-photon paths for HIG

### DIFF
--- a/HLTrigger/Configuration/python/HLT_FULL_Famos_cff.py
+++ b/HLTrigger/Configuration/python/HLT_FULL_Famos_cff.py
@@ -1,11 +1,11 @@
-# /dev/CMSSW_7_1_1/HLT/V142 (CMSSW_7_1_6)
+# /dev/CMSSW_7_1_1/HLT/V143 (CMSSW_7_1_6)
 
 import FWCore.ParameterSet.Config as cms
 from FastSimulation.HighLevelTrigger.HLTSetup_cff import *
 
 
 HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_7_1_1/HLT/V142')
+  tableName = cms.string('/dev/CMSSW_7_1_1/HLT/V143')
 )
 
 HLTIter4PSetTrajectoryFilterIT = cms.PSet( 
@@ -8065,11 +8065,11 @@ hltEG18Iso50T80LCaloId24b40eHE10R9Id65HcalIsoUnseededFilter = cms.EDFilter( "HLT
     L1NonIsoCand = cms.InputTag( "" ),
     saveTags = cms.bool( False ),
     thrOverE2EB = cms.double( 0.0 ),
-    thrRegularEE = cms.double( 5.0 ),
+    thrRegularEE = cms.double( 8.0 ),
     thrOverEEE = cms.double( 0.005 ),
     L1IsoCand = cms.InputTag( "hltEgammaCandidatesUnseeded" ),
     thrOverEEB = cms.double( 0.005 ),
-    thrRegularEB = cms.double( 5.0 ),
+    thrRegularEB = cms.double( 8.0 ),
     lessThan = cms.bool( True ),
     useEt = cms.bool( True ),
     ncandcut = cms.int32( 1 ),
@@ -8365,11 +8365,11 @@ hltEG22Iso50T80LCaloId24b40eHE10R9Id65HcalIsoUnseededFilter = cms.EDFilter( "HLT
     L1NonIsoCand = cms.InputTag( "" ),
     saveTags = cms.bool( False ),
     thrOverE2EB = cms.double( 0.0 ),
-    thrRegularEE = cms.double( 5.0 ),
+    thrRegularEE = cms.double( 8.0 ),
     thrOverEEE = cms.double( 0.005 ),
     L1IsoCand = cms.InputTag( "hltEgammaCandidatesUnseeded" ),
     thrOverEEB = cms.double( 0.005 ),
-    thrRegularEB = cms.double( 5.0 ),
+    thrRegularEB = cms.double( 8.0 ),
     lessThan = cms.bool( True ),
     useEt = cms.bool( True ),
     ncandcut = cms.int32( 1 ),

--- a/HLTrigger/Configuration/python/HLT_FULL_cff.py
+++ b/HLTrigger/Configuration/python/HLT_FULL_cff.py
@@ -1,10 +1,10 @@
-# /dev/CMSSW_7_1_1/HLT/V142 (CMSSW_7_1_6)
+# /dev/CMSSW_7_1_1/HLT/V143 (CMSSW_7_1_6)
 
 import FWCore.ParameterSet.Config as cms
 
 
 HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_7_1_1/HLT/V142')
+  tableName = cms.string('/dev/CMSSW_7_1_1/HLT/V143')
 )
 
 HLTIter4PSetTrajectoryFilterIT = cms.PSet( 
@@ -14279,11 +14279,11 @@ hltEG18Iso50T80LCaloId24b40eHE10R9Id65HcalIsoUnseededFilter = cms.EDFilter( "HLT
     L1NonIsoCand = cms.InputTag( "" ),
     saveTags = cms.bool( False ),
     thrOverE2EB = cms.double( 0.0 ),
-    thrRegularEE = cms.double( 5.0 ),
+    thrRegularEE = cms.double( 8.0 ),
     thrOverEEE = cms.double( 0.005 ),
     L1IsoCand = cms.InputTag( "hltEgammaCandidatesUnseeded" ),
     thrOverEEB = cms.double( 0.005 ),
-    thrRegularEB = cms.double( 5.0 ),
+    thrRegularEB = cms.double( 8.0 ),
     lessThan = cms.bool( True ),
     useEt = cms.bool( True ),
     ncandcut = cms.int32( 1 ),
@@ -14579,11 +14579,11 @@ hltEG22Iso50T80LCaloId24b40eHE10R9Id65HcalIsoUnseededFilter = cms.EDFilter( "HLT
     L1NonIsoCand = cms.InputTag( "" ),
     saveTags = cms.bool( False ),
     thrOverE2EB = cms.double( 0.0 ),
-    thrRegularEE = cms.double( 5.0 ),
+    thrRegularEE = cms.double( 8.0 ),
     thrOverEEE = cms.double( 0.005 ),
     L1IsoCand = cms.InputTag( "hltEgammaCandidatesUnseeded" ),
     thrOverEEB = cms.double( 0.005 ),
-    thrRegularEB = cms.double( 5.0 ),
+    thrRegularEB = cms.double( 8.0 ),
     lessThan = cms.bool( True ),
     useEt = cms.bool( True ),
     ncandcut = cms.int32( 1 ),

--- a/HLTrigger/Configuration/python/HLT_GRun_Famos_cff.py
+++ b/HLTrigger/Configuration/python/HLT_GRun_Famos_cff.py
@@ -1,11 +1,11 @@
-# /dev/CMSSW_7_1_1/GRun/V81 (CMSSW_7_1_6)
+# /dev/CMSSW_7_1_1/GRun/V82 (CMSSW_7_1_6)
 
 import FWCore.ParameterSet.Config as cms
 from FastSimulation.HighLevelTrigger.HLTSetup_cff import *
 
 
 HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_7_1_1/GRun/V81')
+  tableName = cms.string('/dev/CMSSW_7_1_1/GRun/V82')
 )
 
 HLTIter4PSetTrajectoryFilterIT = cms.PSet( 

--- a/HLTrigger/Configuration/python/HLT_GRun_cff.py
+++ b/HLTrigger/Configuration/python/HLT_GRun_cff.py
@@ -1,10 +1,10 @@
-# /dev/CMSSW_7_1_1/GRun/V81 (CMSSW_7_1_6)
+# /dev/CMSSW_7_1_1/GRun/V82 (CMSSW_7_1_6)
 
 import FWCore.ParameterSet.Config as cms
 
 
 HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_7_1_1/GRun/V81')
+  tableName = cms.string('/dev/CMSSW_7_1_1/GRun/V82')
 )
 
 HLTIter4PSetTrajectoryFilterIT = cms.PSet( 

--- a/HLTrigger/Configuration/python/HLT_HIon_cff.py
+++ b/HLTrigger/Configuration/python/HLT_HIon_cff.py
@@ -1,10 +1,10 @@
-# /dev/CMSSW_7_1_1/HIon/V81 (CMSSW_7_1_6)
+# /dev/CMSSW_7_1_1/HIon/V82 (CMSSW_7_1_6)
 
 import FWCore.ParameterSet.Config as cms
 
 
 HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_7_1_1/HIon/V81')
+  tableName = cms.string('/dev/CMSSW_7_1_1/HIon/V82')
 )
 
 HLTIter4PSetTrajectoryFilterIT = cms.PSet( 

--- a/HLTrigger/Configuration/python/HLT_PIon_cff.py
+++ b/HLTrigger/Configuration/python/HLT_PIon_cff.py
@@ -1,10 +1,10 @@
-# /dev/CMSSW_7_1_1/PIon/V81 (CMSSW_7_1_6)
+# /dev/CMSSW_7_1_1/PIon/V82 (CMSSW_7_1_6)
 
 import FWCore.ParameterSet.Config as cms
 
 
 HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_7_1_1/PIon/V81')
+  tableName = cms.string('/dev/CMSSW_7_1_1/PIon/V82')
 )
 
 HLTIter4PSetTrajectoryFilterIT = cms.PSet( 

--- a/HLTrigger/Configuration/test/OnData_HLT_FULL.py
+++ b/HLTrigger/Configuration/test/OnData_HLT_FULL.py
@@ -1,11 +1,11 @@
-# /dev/CMSSW_7_1_1/HLT/V142 (CMSSW_7_1_6)
+# /dev/CMSSW_7_1_1/HLT/V143 (CMSSW_7_1_6)
 
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process( "HLTFULL" )
 
 process.HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_7_1_1/HLT/V142')
+  tableName = cms.string('/dev/CMSSW_7_1_1/HLT/V143')
 )
 
 process.HLTIter4PSetTrajectoryFilterIT = cms.PSet( 
@@ -14801,11 +14801,11 @@ process.hltEG18Iso50T80LCaloId24b40eHE10R9Id65HcalIsoUnseededFilter = cms.EDFilt
     L1NonIsoCand = cms.InputTag( "" ),
     saveTags = cms.bool( False ),
     thrOverE2EB = cms.double( 0.0 ),
-    thrRegularEE = cms.double( 5.0 ),
+    thrRegularEE = cms.double( 8.0 ),
     thrOverEEE = cms.double( 0.005 ),
     L1IsoCand = cms.InputTag( "hltEgammaCandidatesUnseeded" ),
     thrOverEEB = cms.double( 0.005 ),
-    thrRegularEB = cms.double( 5.0 ),
+    thrRegularEB = cms.double( 8.0 ),
     lessThan = cms.bool( True ),
     useEt = cms.bool( True ),
     ncandcut = cms.int32( 1 ),
@@ -15101,11 +15101,11 @@ process.hltEG22Iso50T80LCaloId24b40eHE10R9Id65HcalIsoUnseededFilter = cms.EDFilt
     L1NonIsoCand = cms.InputTag( "" ),
     saveTags = cms.bool( False ),
     thrOverE2EB = cms.double( 0.0 ),
-    thrRegularEE = cms.double( 5.0 ),
+    thrRegularEE = cms.double( 8.0 ),
     thrOverEEE = cms.double( 0.005 ),
     L1IsoCand = cms.InputTag( "hltEgammaCandidatesUnseeded" ),
     thrOverEEB = cms.double( 0.005 ),
-    thrRegularEB = cms.double( 5.0 ),
+    thrRegularEB = cms.double( 8.0 ),
     lessThan = cms.bool( True ),
     useEt = cms.bool( True ),
     ncandcut = cms.int32( 1 ),

--- a/HLTrigger/Configuration/test/OnData_HLT_GRun.py
+++ b/HLTrigger/Configuration/test/OnData_HLT_GRun.py
@@ -1,11 +1,11 @@
-# /dev/CMSSW_7_1_1/GRun/V81 (CMSSW_7_1_6)
+# /dev/CMSSW_7_1_1/GRun/V82 (CMSSW_7_1_6)
 
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process( "HLTGRun" )
 
 process.HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_7_1_1/GRun/V81')
+  tableName = cms.string('/dev/CMSSW_7_1_1/GRun/V82')
 )
 
 process.HLTIter4PSetTrajectoryFilterIT = cms.PSet( 

--- a/HLTrigger/Configuration/test/OnData_HLT_HIon.py
+++ b/HLTrigger/Configuration/test/OnData_HLT_HIon.py
@@ -1,11 +1,11 @@
-# /dev/CMSSW_7_1_1/HIon/V81 (CMSSW_7_1_6)
+# /dev/CMSSW_7_1_1/HIon/V82 (CMSSW_7_1_6)
 
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process( "HLTHIon" )
 
 process.HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_7_1_1/HIon/V81')
+  tableName = cms.string('/dev/CMSSW_7_1_1/HIon/V82')
 )
 
 process.HLTIter4PSetTrajectoryFilterIT = cms.PSet( 

--- a/HLTrigger/Configuration/test/OnData_HLT_PIon.py
+++ b/HLTrigger/Configuration/test/OnData_HLT_PIon.py
@@ -1,11 +1,11 @@
-# /dev/CMSSW_7_1_1/PIon/V81 (CMSSW_7_1_6)
+# /dev/CMSSW_7_1_1/PIon/V82 (CMSSW_7_1_6)
 
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process( "HLTPIon" )
 
 process.HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_7_1_1/PIon/V81')
+  tableName = cms.string('/dev/CMSSW_7_1_1/PIon/V82')
 )
 
 process.HLTIter4PSetTrajectoryFilterIT = cms.PSet( 

--- a/HLTrigger/Configuration/test/OnLine_HLT_FULL.py
+++ b/HLTrigger/Configuration/test/OnLine_HLT_FULL.py
@@ -1,11 +1,11 @@
-# /dev/CMSSW_7_1_1/HLT/V142 (CMSSW_7_1_6)
+# /dev/CMSSW_7_1_1/HLT/V143 (CMSSW_7_1_6)
 
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process( "HLTFULL" )
 
 process.HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_7_1_1/HLT/V142')
+  tableName = cms.string('/dev/CMSSW_7_1_1/HLT/V143')
 )
 
 process.HLTIter4PSetTrajectoryFilterIT = cms.PSet( 
@@ -14801,11 +14801,11 @@ process.hltEG18Iso50T80LCaloId24b40eHE10R9Id65HcalIsoUnseededFilter = cms.EDFilt
     L1NonIsoCand = cms.InputTag( "" ),
     saveTags = cms.bool( False ),
     thrOverE2EB = cms.double( 0.0 ),
-    thrRegularEE = cms.double( 5.0 ),
+    thrRegularEE = cms.double( 8.0 ),
     thrOverEEE = cms.double( 0.005 ),
     L1IsoCand = cms.InputTag( "hltEgammaCandidatesUnseeded" ),
     thrOverEEB = cms.double( 0.005 ),
-    thrRegularEB = cms.double( 5.0 ),
+    thrRegularEB = cms.double( 8.0 ),
     lessThan = cms.bool( True ),
     useEt = cms.bool( True ),
     ncandcut = cms.int32( 1 ),
@@ -15101,11 +15101,11 @@ process.hltEG22Iso50T80LCaloId24b40eHE10R9Id65HcalIsoUnseededFilter = cms.EDFilt
     L1NonIsoCand = cms.InputTag( "" ),
     saveTags = cms.bool( False ),
     thrOverE2EB = cms.double( 0.0 ),
-    thrRegularEE = cms.double( 5.0 ),
+    thrRegularEE = cms.double( 8.0 ),
     thrOverEEE = cms.double( 0.005 ),
     L1IsoCand = cms.InputTag( "hltEgammaCandidatesUnseeded" ),
     thrOverEEB = cms.double( 0.005 ),
-    thrRegularEB = cms.double( 5.0 ),
+    thrRegularEB = cms.double( 8.0 ),
     lessThan = cms.bool( True ),
     useEt = cms.bool( True ),
     ncandcut = cms.int32( 1 ),

--- a/HLTrigger/Configuration/test/OnLine_HLT_GRun.py
+++ b/HLTrigger/Configuration/test/OnLine_HLT_GRun.py
@@ -1,11 +1,11 @@
-# /dev/CMSSW_7_1_1/GRun/V81 (CMSSW_7_1_6)
+# /dev/CMSSW_7_1_1/GRun/V82 (CMSSW_7_1_6)
 
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process( "HLTGRun" )
 
 process.HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_7_1_1/GRun/V81')
+  tableName = cms.string('/dev/CMSSW_7_1_1/GRun/V82')
 )
 
 process.HLTIter4PSetTrajectoryFilterIT = cms.PSet( 

--- a/HLTrigger/Configuration/test/OnLine_HLT_HIon.py
+++ b/HLTrigger/Configuration/test/OnLine_HLT_HIon.py
@@ -1,11 +1,11 @@
-# /dev/CMSSW_7_1_1/HIon/V81 (CMSSW_7_1_6)
+# /dev/CMSSW_7_1_1/HIon/V82 (CMSSW_7_1_6)
 
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process( "HLTHIon" )
 
 process.HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_7_1_1/HIon/V81')
+  tableName = cms.string('/dev/CMSSW_7_1_1/HIon/V82')
 )
 
 process.HLTIter4PSetTrajectoryFilterIT = cms.PSet( 

--- a/HLTrigger/Configuration/test/OnLine_HLT_PIon.py
+++ b/HLTrigger/Configuration/test/OnLine_HLT_PIon.py
@@ -1,11 +1,11 @@
-# /dev/CMSSW_7_1_1/PIon/V81 (CMSSW_7_1_6)
+# /dev/CMSSW_7_1_1/PIon/V82 (CMSSW_7_1_6)
 
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process( "HLTPIon" )
 
 process.HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_7_1_1/PIon/V81')
+  tableName = cms.string('/dev/CMSSW_7_1_1/PIon/V82')
 )
 
 process.HLTIter4PSetTrajectoryFilterIT = cms.PSet( 


### PR DESCRIPTION
Chris Tully identified two incorrectly set parameters in the hltEG22Iso50T80LCaloId24b40eHE10R9Id65HcalIsoUnseededFilter and
hltEG18Iso50T80LCaloId24b40eHE10R9Id65HcalIsoUnseededFilter filters.
Fixed here
