### PR TITLE
Small Shashlik reco speed improvement

### DIFF
--- a/RecoParticleFlow/PFClusterTools/src/ClusterClusterMapping.cc
+++ b/RecoParticleFlow/PFClusterTools/src/ClusterClusterMapping.cc
@@ -16,13 +16,13 @@ bool ClusterClusterMapping::overlap(const reco::CaloCluster & sc1, const reco::C
 	}
       for(unsigned i2=0;i2<nhits2;++i2)
 	{
-	  // consider only with a minimum fraction of minfract (default 1%) of the RecHit
-	  if(hits2[i2].second<minfrac ) {
-	    if(debug) std::cout << " Discarding " << hits2[i2].first << " with " << hits2[i2].second << std::endl;
-	    continue;
-	  }
 	  if(hits1[i1].first==hits2[i2].first)
 	    {
+	      // consider only with a minimum fraction of minfract (default 1%) of the RecHit
+	      if(hits2[i2].second<minfrac ) {
+	        if(debug) std::cout << " Discarding " << hits2[i2].first << " with " << hits2[i2].second << std::endl;
+	        continue;
+	      }
 	      if(debug)
 		{
 		  std::cout << " Matching hits " << hits1[i1].first << " with " <<  hits1[i1].second << " and " <<  hits2[i2].first;


### PR DESCRIPTION
@davidlange6 is this what you meant?

Functionally the same but the order of checks has been changed to improve speed.  There is a minor side effect in that fewer debug printouts will occur when the previously-second "if" evaluates to false, so that the previously-first "if" (which would produce the printout) is skipped.
All plots are ttbar at 140 pileup in Shashlik; "before" plots include #4909.

**Total event times before and after**
![shashlikrecotimer-afterlangesuggestion-eventtotal](https://cloud.githubusercontent.com/assets/6480160/3884299/4a5ea692-21ad-11e4-8df1-31208a665e06.png)
This equates to a drop from 6.1+/-1.7 minutes to 5.9+/-1.8 minutes per event (mean+/-sqrt(variance)). Doesn't sound that impressive when stated like that, but they're the same events not random data.

**User time by module before**
![shashlikrecotimer-beforelangesuggestion](https://cloud.githubusercontent.com/assets/6480160/3884333/e458c354-21ad-11e4-8e8b-9dfb4e4c2b3b.png)

**User time by module after**
![shashlikrecotimer-afterlangesuggestion](https://cloud.githubusercontent.com/assets/6480160/3884337/ed3f8160-21ad-11e4-8d62-9c2fd3c57fcb.png)

Some modules appear to slightly increase in time (e.g. particleFlowTmp, particleFlowEGamma) but others significantly decrease (particleFlowBlock).  I'm not sure how accurate the timing is so I suspect this is just noise.

Updated igprof file at /afs/cern.ch/user/g/grimes/public/SLHC16_patch1Preview/igreport_perf_ShashlikRecoAfterLangeSuggestion_15evt.res
@davidlange6, @lgray
