### PR TITLE
Fix warning in RecoParticleFlow/PFClusterProducer: Removed sortByDepth since it was not being used

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/src/PFMultiDepthClusterizer.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/PFMultiDepthClusterizer.cc
@@ -10,13 +10,6 @@
 #include <iterator>
 
 
-namespace {
-  bool sortByDepth(const reco::PFCluster& a,
-		   const reco::PFCluster& b) {
-    return a.depth() < b.depth();
-  }
-}
-
 
 PFMultiDepthClusterizer::
 PFMultiDepthClusterizer(const edm::ParameterSet& conf) :


### PR DESCRIPTION
This fixes the the warning that can be seen here: https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc6_amd64_gcc491/CMSSW_7_2_X_2014-08-12-0200/RecoParticleFlow/PFClusterProducer
