### PR TITLE
Do not throw an exception when ROOT reports a missing dictionary problem

### DIFF
--- a/DataFormats/Provenance/src/BranchDescription.cc
+++ b/DataFormats/Provenance/src/BranchDescription.cc
@@ -162,22 +162,28 @@ namespace edm {
 
     throwIfInvalid_();
 
-    setWrappedName(wrappedClassName(fullClassName()));
+    try {
+      setWrappedName(wrappedClassName(fullClassName()));
+      
+      // unwrapped type.
+      setUnwrappedType(TypeWithDict::byName(fullClassName()));
+      if(!bool(unwrappedType())) {
+	setSplitLevel(invalidSplitLevel);
+	setBasketSize(invalidBasketSize);
+	setTransient(false);
+	return;
+      }
 
-    // unwrapped type.
-    setUnwrappedType(TypeWithDict::byName(fullClassName()));
-    if(!bool(unwrappedType())) {
-      setSplitLevel(invalidSplitLevel);
-      setBasketSize(invalidBasketSize);
-      setTransient(false);
-      return;
-    }
 
-    setWrappedType(TypeWithDict::byName(wrappedName()));
-    if(!bool(wrappedType())) {
-      setSplitLevel(invalidSplitLevel);
-      setBasketSize(invalidBasketSize);
-      return;
+      setWrappedType(TypeWithDict::byName(wrappedName()));
+      if(!bool(wrappedType())) {
+	setSplitLevel(invalidSplitLevel);
+	setBasketSize(invalidBasketSize);
+	return;
+      }
+    } catch( edm::Exception& caughtException) {
+      caughtException.addContext(std::string{"While initializing meta data for branch: "}+branchName());
+      throw;
     }
     wrappedType().invokeByName(wrapperInterfaceBase(), "getInterface");
     assert(wrapperInterfaceBase() != 0);

--- a/FWCore/Services/src/InitRootHandlers.cc
+++ b/FWCore/Services/src/InitRootHandlers.cc
@@ -124,6 +124,9 @@ namespace {
           (el_message.find("already in TClassTable") != std::string::npos) ||
           (el_message.find("matrix not positive definite") != std::string::npos) ||
           (el_message.find("not a TStreamerInfo object") != std::string::npos) ||
+	  //This deals with a missing dictionary problem
+	  ( (el_message.find("Collection proxy for") !=std::string::npos && 
+	     el_message.find("was not properly initialized!") != std::string::npos)) ||
           (el_location.find("Fit") != std::string::npos) ||
           (el_location.find("TDecompChol::Solve") != std::string::npos) ||
           (el_location.find("THistPainter::PaintInit") != std::string::npos) ||


### PR DESCRIPTION
In the case where ROOT prints an error message  about a missing collection proxy we no longer throw an exception. This was  needed to handle the case of reading an old file using a release for which a class in that
file no longer exists. The framework doesn't need the exception since it has other ways of detecting the missing dictionary and then take appropriate action.
