### PR TITLE
7 2 x lifetime patch

### DIFF
--- a/GeneratorInterface/TauolaInterface/interface/TauolappInterface.h
+++ b/GeneratorInterface/TauolaInterface/interface/TauolappInterface.h
@@ -47,7 +47,9 @@ namespace gen {
       void selectDecayByMDTAU();
       int selectLeptonic();
       int selectHadronic();
-      
+      bool isLastTauInChain(const HepMC::GenParticle* tau);
+      void setLifeTimeInDecays(HepMC::GenParticle* p,double vx, double vy, double vz, double vt);
+
       //
       static CLHEP::HepRandomEngine*           fRandomEngine;            
       std::vector<int>                         fPDGs;

--- a/GeneratorInterface/TauolaInterface/interface/TauolappInterface.h
+++ b/GeneratorInterface/TauolaInterface/interface/TauolappInterface.h
@@ -62,7 +62,7 @@ namespace gen {
       std::vector<int>                         fHadronModes;
       std::vector<double>                      fScaledLeptonBrRatios;
       std::vector<double>                      fScaledHadronBrRatios;
-      
+      double lifetime;
    };
 
 }

--- a/GeneratorInterface/TauolaInterface/plugins/Tauolapp/TauolappInterface.cc
+++ b/GeneratorInterface/TauolaInterface/plugins/Tauolapp/TauolappInterface.cc
@@ -89,10 +89,9 @@ void TauolappInterface::init( const edm::EventSetup& es ){
    // some more options, copied over from an example 
    // Default values
    //Tauola::setEtaK0sPi(0,0,0); // switches to decay eta K0_S and pi0 1/0 on/off. 
- 
+   Tauolapp::Tauola::setTauLifetime(0.0);
    const HepPDT::ParticleData* PData = fPDGTable->particle(HepPDT::ParticleID( abs(Tauolapp::Tauola::getDecayingParticle()) )) ;
    lifetime = PData->lifetime().value();
-   Tauolapp::Tauola::setTauLifetime(0.0);
    //std::cout << "Setting lifetime: ctau=" << lifetime << "m or tau=" << lifetime/(299792458.0*1000.0) << "s" << std::endl;
 
    fPDGs.push_back( Tauolapp::Tauola::getDecayingParticle() );
@@ -215,30 +214,21 @@ HepMC::GenEvent* TauolappInterface::decay( HepMC::GenEvent* evt ){
     // NOTE: the procedure ASSYMES that vertex barcoding is COUNTIUOUS/SEQUENTIAL,
     // and that the abs(barcode) corresponds to vertex "plain indexing"
     //
-    for ( int iv=NVtxBefore+1; iv<=evt->vertices_size(); iv++ )
-    {
+    // manually add lifetimes
+    for(HepMC::GenEvent::particle_const_iterator iter = evt->particles_begin(); iter != evt->particles_end(); iter++){
+      if(abs((*iter)->pdg_id())==15 && isLastTauInChain(*iter)){
+	HepMC::FourVector PMom = (*iter)->momentum();
+	double mass = (*iter)->generated_mass();
+	float prob = 0.;
+	int length=1;
+	ranmar_(&prob,&length);
+	double ct = -lifetime * std::log(prob);
+	// d*gamma=t*v*gamma=t*c*beta*gamma=ct*(P/E)*(E/m)=ct*(P/m)
+	setLifeTimeInDecays((*iter),ct*(PMom.px()/mass),ct*(PMom.py()/mass),ct*(PMom.pz()/mass),ct*(PMom.e()/mass));
+      }
+    }
+    for ( int iv=NVtxBefore+1; iv<=evt->vertices_size(); iv++ ){
        HepMC::GenVertex* GenVtx = evt->barcode_to_vertex(-iv);
-       HepMC::GenParticle* GenPart = *(GenVtx->particles_in_const_begin());
-       HepMC::GenVertex* ProdVtx = GenPart->production_vertex();
-       HepMC::FourVector PMom = GenPart->momentum();
-       double mass = GenPart->generated_mass();
-       float prob = 0.;
-       int length=1;
-       ranmar_(&prob,&length);
-       double ct = -lifetime * std::log(prob);
-       double VxDec = GenVtx->position().x();
-       VxDec += ct * (PMom.px()/mass);
-       VxDec += ProdVtx->position().x();
-       double VyDec = GenVtx->position().y();
-       VyDec += ct * (PMom.py()/mass);
-       VyDec += ProdVtx->position().y();
-       double VzDec = GenVtx->position().z();
-       VzDec += ct * (PMom.pz()/mass);
-       VzDec += ProdVtx->position().z();
-       double VtDec = GenVtx->position().t();
-       VtDec += ct * (PMom.e()/mass);
-       VtDec += ProdVtx->position().t();
-       GenVtx->set_position( HepMC::FourVector(VxDec,VyDec,VzDec,VtDec) ); 
        //
        // now find decay products with funky barcode, weed out and replace with clones of sensible barcode
        // we can NOT change the barcode while iterating, because iterators do depend on the barcoding
@@ -620,4 +610,31 @@ int TauolappInterface::selectHadronic()
 
 }
 
+bool TauolappInterface::isLastTauInChain(const HepMC::GenParticle* tau){
+  if ( tau->end_vertex() ) {
+    HepMC::GenVertex::particle_iterator dau;
+    for (dau = tau->end_vertex()->particles_begin(HepMC::children); dau!= tau->end_vertex()->particles_end(HepMC::children); dau++ ) {
+      int dau_pid = (*dau)->pdg_id();
+      if(dau_pid == tau->pdg_id()) return false;
+    }
+  }
+  return true;
+}
 
+void TauolappInterface::setLifeTimeInDecays(HepMC::GenParticle* p,double vx, double vy, double vz, double vt){
+  if(p->end_vertex()){
+    HepMC::GenVertex* GenVtx=p->end_vertex();
+    double VxDec = GenVtx->position().x();
+    VxDec += vx;
+    double VyDec = GenVtx->position().y();
+    VyDec += vy;
+    double VzDec = GenVtx->position().z();
+    VzDec += vz;
+    double VtDec = GenVtx->position().t();
+    VtDec += vt;
+    GenVtx->set_position( HepMC::FourVector(VxDec,VyDec,VzDec,VtDec) );
+    for(HepMC::GenVertex::particle_iterator dau=p->end_vertex()->particles_begin(HepMC::children); dau!=p->end_vertex()->particles_end(HepMC::children); dau++){
+      setLifeTimeInDecays((*dau),vx,vy,vz,vt); //recursively modify everything in the decay chain
+    }
+  }
+} 

--- a/GeneratorInterface/TauolaInterface/plugins/Tauolapp/TauolappInterface.cc
+++ b/GeneratorInterface/TauolaInterface/plugins/Tauolapp/TauolappInterface.cc
@@ -91,8 +91,8 @@ void TauolappInterface::init( const edm::EventSetup& es ){
    //Tauola::setEtaK0sPi(0,0,0); // switches to decay eta K0_S and pi0 1/0 on/off. 
  
    const HepPDT::ParticleData* PData = fPDGTable->particle(HepPDT::ParticleID( abs(Tauolapp::Tauola::getDecayingParticle()) )) ;
-   double lifetime = PData->lifetime().value();
-   Tauolapp::Tauola::setTauLifetime( lifetime );
+   lifetime = PData->lifetime().value();
+   Tauolapp::Tauola::setTauLifetime(0.0);
    //std::cout << "Setting lifetime: ctau=" << lifetime << "m or tau=" << lifetime/(299792458.0*1000.0) << "s" << std::endl;
 
    fPDGs.push_back( Tauolapp::Tauola::getDecayingParticle() );
@@ -218,6 +218,27 @@ HepMC::GenEvent* TauolappInterface::decay( HepMC::GenEvent* evt ){
     for ( int iv=NVtxBefore+1; iv<=evt->vertices_size(); iv++ )
     {
        HepMC::GenVertex* GenVtx = evt->barcode_to_vertex(-iv);
+       HepMC::GenParticle* GenPart = *(GenVtx->particles_in_const_begin());
+       HepMC::GenVertex* ProdVtx = GenPart->production_vertex();
+       HepMC::FourVector PMom = GenPart->momentum();
+       double mass = GenPart->generated_mass();
+       float prob = 0.;
+       int length=1;
+       ranmar_(&prob,&length);
+       double ct = -lifetime * std::log(prob);
+       double VxDec = GenVtx->position().x();
+       VxDec += ct * (PMom.px()/mass);
+       VxDec += ProdVtx->position().x();
+       double VyDec = GenVtx->position().y();
+       VyDec += ct * (PMom.py()/mass);
+       VyDec += ProdVtx->position().y();
+       double VzDec = GenVtx->position().z();
+       VzDec += ct * (PMom.pz()/mass);
+       VzDec += ProdVtx->position().z();
+       double VtDec = GenVtx->position().t();
+       VtDec += ct * (PMom.e()/mass);
+       VtDec += ProdVtx->position().t();
+       GenVtx->set_position( HepMC::FourVector(VxDec,VyDec,VzDec,VtDec) ); 
        //
        // now find decay products with funky barcode, weed out and replace with clones of sensible barcode
        // we can NOT change the barcode while iterating, because iterators do depend on the barcoding


### PR DESCRIPTION
Pull request to fix: hypernews posting - Urgent issue with pythia6 + Tauola++ in 71x and 72x (was Fwd: 720pre3 standard relval samples). 
In the hypernews, it was reported that undecayed taus were causing aborts in on an insert statement. There was only one line that could cause this problem (ie setting the tau lifetime for tauola to a non-zero value). This has been changed back and a substitute calculation of the tau decay length has been added with code to propagate it to the full decay chain.
This code has been tested both on default test configurations (see test dir) and on the relval sample that crashed(however, since the generator depends on random seeds, only a limited test could be performed).  
