### PR TITLE
Fix Shashlik reco customisation when validation not present

### DIFF
--- a/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
@@ -225,14 +225,15 @@ def cust_2023SHCal(process):
         process.photons.isolationSumsCalculatorSet.endcapEcalRecHitCollection = cms.InputTag("ecalRecHit","EcalRecHitsEK")
         process.uncleanedOnlyConversionTrackCandidates.endcapEcalRecHitCollection = cms.InputTag("ecalRecHit","EcalRecHitsEK")
         process.uncleanedOnlyGsfElectrons.endcapRecHitCollectionTag = cms.InputTag("ecalRecHit","EcalRecHitsEK")
-        process.ecalEndcapClusterTaskExtras.EcalRecHitCollection = cms.InputTag("ecalRecHit","EcalRecHitsEK")
-        process.ecalEndcapRecoSummary.recHitCollection_EE = cms.InputTag("ecalRecHit","EcalRecHitsEK")
         ## The following ones don't work out of the box, so until they're fixed let them use the wrong collection
         #process.multi5x5BasicClustersCleaned.endcapHitCollection = cms.string('EcalRecHitsEK')
         #process.multi5x5BasicClustersUncleaned.endcapHitCollection = cms.string('EcalRecHitsEK')
         #process.correctedMulti5x5SuperClustersWithPreshower.recHitProducer = cms.InputTag("ecalRecHit","EcalRecHitsEK")
         #process.uncleanedOnlyCorrectedMulti5x5SuperClustersWithPreshower.recHitProducer = cms.InputTag("ecalRecHit","EcalRecHitsEK")
 
+    if hasattr(process,'validation_step'):
+        process.ecalEndcapClusterTaskExtras.EcalRecHitCollection = cms.InputTag("ecalRecHit","EcalRecHitsEK")
+        process.ecalEndcapRecoSummary.recHitCollection_EE = cms.InputTag("ecalRecHit","EcalRecHitsEK")
 
     return process
 


### PR DESCRIPTION
Move two lines that are specific to validation out of "hasattr reconstruction_step" and into "hasattr validation_step".  Previously cmsDriver would fail when customising reco for Shashlik if validation was not also being done.
