### PR TITLE
Fix Multi5x5ClusterProducer for Shashlik

### DIFF
--- a/RecoEcal/EgammaClusterProducers/src/Multi5x5ClusterProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/Multi5x5ClusterProducer.cc
@@ -146,7 +146,7 @@ void Multi5x5ClusterProducer::clusterizeECALPart(edm::Event &evt, const edm::Eve
     geometry_p = shgeo.product();
     edm::ESHandle<ShashlikTopology> topo;
     es.get<ShashlikNumberingRecord>().get(topo);
-    topology_p = (CaloSubdetectorTopology *)(topo.product());
+    topology_p = new ShashlikTopology(*topo.product());
   } else {
     geometry_p = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalEndcap);
     topology_p = new EcalEndcapTopology(geoHandle); 

--- a/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
@@ -225,11 +225,10 @@ def cust_2023SHCal(process):
         process.photons.isolationSumsCalculatorSet.endcapEcalRecHitCollection = cms.InputTag("ecalRecHit","EcalRecHitsEK")
         process.uncleanedOnlyConversionTrackCandidates.endcapEcalRecHitCollection = cms.InputTag("ecalRecHit","EcalRecHitsEK")
         process.uncleanedOnlyGsfElectrons.endcapRecHitCollectionTag = cms.InputTag("ecalRecHit","EcalRecHitsEK")
-        ## The following ones don't work out of the box, so until they're fixed let them use the wrong collection
-        #process.multi5x5BasicClustersCleaned.endcapHitCollection = cms.string('EcalRecHitsEK')
-        #process.multi5x5BasicClustersUncleaned.endcapHitCollection = cms.string('EcalRecHitsEK')
-        #process.correctedMulti5x5SuperClustersWithPreshower.recHitProducer = cms.InputTag("ecalRecHit","EcalRecHitsEK")
-        #process.uncleanedOnlyCorrectedMulti5x5SuperClustersWithPreshower.recHitProducer = cms.InputTag("ecalRecHit","EcalRecHitsEK")
+        process.multi5x5BasicClustersCleaned.endcapHitCollection = cms.string('EcalRecHitsEK')
+        process.multi5x5BasicClustersUncleaned.endcapHitCollection = cms.string('EcalRecHitsEK')
+        process.correctedMulti5x5SuperClustersWithPreshower.recHitProducer = cms.InputTag("ecalRecHit","EcalRecHitsEK")
+        process.uncleanedOnlyCorrectedMulti5x5SuperClustersWithPreshower.recHitProducer = cms.InputTag("ecalRecHit","EcalRecHitsEK")
 
     if hasattr(process,'validation_step'):
         process.ecalEndcapClusterTaskExtras.EcalRecHitCollection = cms.InputTag("ecalRecHit","EcalRecHitsEK")


### PR DESCRIPTION
Multi5x5ClusterProducer used to crash when given the correct Shashlik hit collection.  It was previously "disabled" for Shashlik because the customisation didn't change to the correct hit collection.
This fixes the crash and changes the customisation so that the correct hit collection is used.

@bsunanda, I had to change to create a copy of ShashlikTopology because the method deletes the object at the end ([line 171](https://github.com/cms-sw/cmssw/blob/CMSSW_6_2_X_SLHC/RecoEcal/EgammaClusterProducers/src/Multi5x5ClusterProducer.cc#L171)).  Previously the function would run correctly once, then crash the next time (or anything else that tried to use ShashlikTopology from the EventSetup).
