### PR TITLE
Adding Hadronic-path HLT DQM for B2G PAG

### DIFF
--- a/HLTriggerOffline/B2G/interface/B2GHadronicHLTValidation.h
+++ b/HLTriggerOffline/B2G/interface/B2GHadronicHLTValidation.h
@@ -1,0 +1,143 @@
+// -*- C++ -*-
+//
+// Package:    HLTriggerOffline/B2G
+// Class:      B2GHadronicHLTValidation
+// 
+/**\class B2GHadronicHLTValidation B2GHadronicHLTValidation.h HLTriggerOffline/B2G/interface/B2GHadronicHLTValidation.h
+
+ Description: compute efficiencies of trigger paths on offline reco selection with respect to pt and eta
+
+ Implementation:
+     harvesting
+*/
+//
+// Original Author:  Elvire Bouvier
+//         Created:  Thu, 16 Jan 2014 16:27:35 GMT
+//
+//
+#ifndef B2GHADRONICHLTVALIDATION
+#define B2GHADRONICHLTVALIDATION
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+
+#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
+#include "DataFormats/MuonReco/interface/Muon.h"
+#include "DataFormats/JetReco/interface/Jet.h"
+#include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
+#include "DataFormats/Common/interface/TriggerResults.h"
+
+//
+// class declaration
+//
+
+class B2GHadronicHLTValidation : public DQMEDAnalyzer {
+   public:
+      explicit B2GHadronicHLTValidation(const edm::ParameterSet&);
+      ~B2GHadronicHLTValidation();
+
+      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+
+   private:
+      virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+      void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
+      /// deduce monitorPath from label, the label is expected
+      /// to be of type 'selectionPath:monitorPath'
+      std::string monitorPath(const std::string& label) const { return label.substr(label.find(':')+1); };  
+      /// set configurable labels for trigger monitoring histograms
+      void triggerBinLabels(const std::vector<std::string>& labels);
+
+      // ----------member data ---------------------------
+      // DQM
+      std::string sDir_;
+      MonitorElement* hNumJetPt;
+      MonitorElement* hDenJetPt;
+      MonitorElement* hNumJetEta;
+      MonitorElement* hDenJetEta;
+      MonitorElement* hNumTriggerMon;
+      MonitorElement* hDenTriggerMon;
+      // Jets
+      edm::Ptr<reco::Jet> jet_;
+      std::string sJets_;
+      edm::EDGetTokenT< edm::View<reco::Jet> > tokJets_;
+      double ptJets_;
+      double ptJets0_;
+      double ptJets1_;
+      double etaJets_;
+      unsigned int minJets_;
+      double htMin_;
+      // Trigger
+      std::string sTrigger_;
+      edm::EDGetTokenT<edm::TriggerResults> tokTrigger_;
+      std::vector<std::string> vsPaths_;
+      // Flags
+      bool isAll_ = false;
+      bool isSel_ = false;
+
+};
+
+inline void B2GHadronicHLTValidation::triggerBinLabels(const std::vector<std::string>& labels)
+{
+  for(unsigned int idx=0; idx<labels.size(); ++idx){
+    hNumTriggerMon->setBinLabel( idx+1, "["+monitorPath(labels[idx])+"]", 1);
+    hDenTriggerMon->setBinLabel( idx+1, "["+monitorPath(labels[idx])+"]", 1);
+  }
+}
+
+//
+// constants, enums and typedefs
+//
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+B2GHadronicHLTValidation::B2GHadronicHLTValidation(const edm::ParameterSet& iConfig) :
+  sDir_(iConfig.getUntrackedParameter<std::string>("sDir","HLTValidation/B2G/Efficiencies/")),
+  sJets_(iConfig.getUntrackedParameter<std::string>("sJets","ak5PFJets")),
+  ptJets_(iConfig.getUntrackedParameter<double>("ptJets",0.)),
+  ptJets0_(iConfig.getUntrackedParameter<double>("ptJets0",0.)),
+  ptJets1_(iConfig.getUntrackedParameter<double>("ptJets1",0.)),
+  etaJets_(iConfig.getUntrackedParameter<double>("etaJets",0.)),
+  minJets_(iConfig.getUntrackedParameter<unsigned int>("minJets",0)),
+  htMin_(iConfig.getUntrackedParameter<double>("htMin",0.0)),
+  sTrigger_(iConfig.getUntrackedParameter<std::string>("sTrigger","TriggerResults")),
+  vsPaths_(iConfig.getUntrackedParameter< std::vector<std::string> >("vsPaths"))
+
+{
+  // Jets
+  tokJets_ = consumes< edm::View<reco::Jet> >(edm::InputTag(sJets_));
+  // Trigger
+  tokTrigger_ = consumes<edm::TriggerResults>(edm::InputTag(sTrigger_, "", "HLT"));
+}
+
+
+B2GHadronicHLTValidation::~B2GHadronicHLTValidation()
+{
+ 
+   // do anything here that needs to be done at desctruction time
+   // (e.g. close files, deallocate resources etc.)
+
+}
+#endif
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(B2GHadronicHLTValidation);

--- a/HLTriggerOffline/B2G/python/b2gHLTValidationHarvest_cff.py
+++ b/HLTriggerOffline/B2G/python/b2gHLTValidationHarvest_cff.py
@@ -25,9 +25,20 @@ b2gSingleElectronHLTValidationHarvest = cms.EDAnalyzer("DQMGenericClient",
         resolution = cms.vstring(""),
         )
 
+b2gSingleJetHLTValidationHarvest = cms.EDAnalyzer("DQMGenericClient",
+        subDirs = cms.untracked.vstring("HLT/B2GHLTValidation/B2G/SingleJet"),
+        efficiency = cms.vstring(
+            "hEffLastJetEta 'Efficiency vs Eta Last Jet' EtaLastJetSel EtaLastJetAll",
+            "hEffLastJetPt 'Efficiency vs Pt Last Jet' PtLastJetSel PtLastJetAll",
+            "hTriggerMon 'Efficiency per trigger bit' TriggerMonSel TriggerMonAll"
+            ),
+        resolution = cms.vstring(""),
+        )
+
 
 b2gHLTriggerValidationHarvest = cms.Sequence(  
     b2gSingleMuonHLTValidationHarvest
     *b2gSingleElectronHLTValidationHarvest
+    *b2gSingleJetHLTValidationHarvest
     )
 

--- a/HLTriggerOffline/B2G/python/b2gHLTValidation_cff.py
+++ b/HLTriggerOffline/B2G/python/b2gHLTValidation_cff.py
@@ -1,10 +1,12 @@
 import FWCore.ParameterSet.Config as cms
 
 from HLTriggerOffline.B2G.b2gSingleLeptonHLTEventValidation_cfi import *
+from HLTriggerOffline.B2G.b2gHadronicHLTEventValidation_cfi import *
 
 
 b2gHLTriggerValidation = cms.Sequence(  
     b2gSingleMuonHLTValidation*
-    b2gSingleElectronHLTValidation
+    b2gSingleElectronHLTValidation*
+    b2gSingleJetHLTValidation
     )
 

--- a/HLTriggerOffline/B2G/python/b2gHadronicHLTEventValidation_cfi.py
+++ b/HLTriggerOffline/B2G/python/b2gHadronicHLTEventValidation_cfi.py
@@ -1,0 +1,63 @@
+import FWCore.ParameterSet.Config as cms
+
+# ttbar semi muonique
+b2gSingleMuonHLTValidation = cms.EDAnalyzer('B2GSingleLeptonHLTValidation',
+        # Directory
+        sDir         = cms.untracked.string('HLT/B2GHLTValidation/B2G/SemiMuonic/'),
+        # Electrons
+        sElectrons   = cms.untracked.string('gedGsfElectrons'),
+        ptElectrons  = cms.untracked.double(30.),
+        etaElectrons = cms.untracked.double(2.5),
+        minElectrons = cms.untracked.uint32(0),
+        # Muons
+        sMuons       = cms.untracked.string('muons'),
+        ptMuons      = cms.untracked.double(40.),
+        etaMuons     = cms.untracked.double(2.1),
+        minMuons     = cms.untracked.uint32(1),
+        # Jets
+        sJets        = cms.untracked.string('ak4PFJetsCHS'),
+        minJets      = cms.untracked.uint32(0),
+        # Trigger
+        sTrigger     = cms.untracked.string("TriggerResults"),
+        vsPaths      = cms.untracked.vstring(['HLT_Mu40_eta2p1']),
+)
+
+# ttbar semi electronique
+b2gSingleElectronHLTValidation = cms.EDAnalyzer('B2GSingleLeptonHLTValidation',
+        # Directory
+        sDir         = cms.untracked.string('HLT/B2GHLTValidation/B2G/SemiElectronic/'),
+        # Electrons
+        sElectrons   = cms.untracked.string('gedGsfElectrons'),
+        ptElectrons  = cms.untracked.double(30.),
+        etaElectrons = cms.untracked.double(2.5),
+        minElectrons = cms.untracked.uint32(1),
+        # Muons
+        sMuons       = cms.untracked.string('muons'),
+        ptMuons      = cms.untracked.double(26.),
+        etaMuons     = cms.untracked.double(2.1),
+        minMuons     = cms.untracked.uint32(0),
+        # Jets
+        sJets        = cms.untracked.string('ak4PFJetsCHS'),
+        ptJets0      = cms.untracked.double(150.),
+        ptJets1      = cms.untracked.double(25.),
+        etaJets      = cms.untracked.double(2.5),
+        minJets      = cms.untracked.uint32(2),
+        # Trigger
+        sTrigger     = cms.untracked.string("TriggerResults"),
+        vsPaths      = cms.untracked.vstring(['HLT_Ele30_CaloIdVT_TrkIdT_PFNoPUJet150_PFNoPUJet25']),
+)
+
+
+# single jet validation
+b2gSingleJetHLTValidation = cms.EDAnalyzer('B2GHadronicHLTValidation',
+        # Directory
+        sDir         = cms.untracked.string('HLT/B2GHLTValidation/B2G/SingleJet/'),
+        # Jets
+        sJets        = cms.untracked.string('ak4PFJetsCHS'),
+        ptJets0      = cms.untracked.double(325.),
+        etaJets      = cms.untracked.double(2.5),
+        minJets      = cms.untracked.uint32(1),
+        # Trigger
+        sTrigger     = cms.untracked.string("TriggerResults"),
+        vsPaths      = cms.untracked.vstring(['HLT_PFJet325']),
+)

--- a/HLTriggerOffline/B2G/src/B2GHadronicHLTValidation.cc
+++ b/HLTriggerOffline/B2G/src/B2GHadronicHLTValidation.cc
@@ -1,0 +1,156 @@
+// -*- C++ -*-
+//
+// Package:    HLTriggerOffline/B2G
+// Class:      B2GHadronicHLTValidation
+// 
+/**\class B2GHadronicHLTValidation B2GHadronicHLTValidation.cc HLTriggerOffline/B2G/src/B2GHadronicHLTValidation.cc
+
+Description: 
+
+Description: compute efficiencies of trigger paths on offline reco selection with respect to pt and eta
+
+Implementation:
+harvesting
+*/
+//
+// Original Author:  Elvire Bouvier
+//         Created:  Thu, 16 Jan 2014 16:27:35 GMT
+//
+//
+#include "HLTriggerOffline/B2G/interface/B2GHadronicHLTValidation.h"
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
+#include "FWCore/Common/interface/TriggerNames.h"
+#include "TString.h"
+//
+// member functions
+//
+
+// ------------ method called for each event  ------------
+  void
+B2GHadronicHLTValidation::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
+{ 
+  using namespace edm;
+
+  isAll_ = false; isSel_ = false;
+
+  // Jets 
+  Handle< edm::View<reco::Jet> > jets;
+  if (!iEvent.getByToken(tokJets_,jets)) 
+    edm::LogWarning("B2GHadronicHLTValidation") << "Jets collection not found \n";
+  unsigned int nGoodJ = 0;
+  double ht = 0.0;
+  // Check to see if we want asymmetric jet pt cuts
+  if ( ptJets0_ > 0.0 || ptJets1_ > 0.0 )  {
+    if ( ptJets0_ > 0.0 ) {
+      if ( jets->size() > 0 && jets->at(0).pt() > ptJets0_ ) {
+	nGoodJ++;
+	jet_ = jets->ptrAt(0) ;
+      }
+    }
+    if ( ptJets1_ > 0.0 ) {
+      if ( jets->size() > 1 && jets->at(1).pt() > ptJets1_ ) {
+	nGoodJ++;
+	jet_ = jets->ptrAt(1) ;
+      }
+    }
+  } else if (minJets_ > 0 || htMin_ > 0 ) {
+    for(edm::View<reco::Jet>::const_iterator j = jets->begin(); j != jets->end(); ++j){
+      if (j->pt() < ptJets_) continue;
+      if (fabs(j->eta()) > etaJets_) continue;
+      nGoodJ++;
+      ht += j->pt();
+      if (nGoodJ == minJets_) jet_ = jets->ptrAt( j -jets->begin() ); 
+    }
+  } 
+
+  if ( nGoodJ >= minJets_ || ht > htMin_ ) isAll_ = true;
+
+
+  //Trigger
+  Handle<edm::TriggerResults> triggerTable;
+  if (!iEvent.getByToken(tokTrigger_,triggerTable))
+    edm::LogWarning("B2GHadronicHLTValidation") << "Trigger collection not found \n";
+  const edm::TriggerNames& triggerNames = iEvent.triggerNames(*triggerTable);
+  bool isInteresting = false;
+  for (unsigned int i=0; i<triggerNames.triggerNames().size(); ++i) {
+
+    TString name = triggerNames.triggerNames()[i].c_str();
+    for (unsigned int j=0; j<vsPaths_.size(); j++) {
+      if (name.Contains(TString(vsPaths_[j]), TString::kIgnoreCase)) {
+        isInteresting = true; 
+        break;
+      }
+    }
+    if (isInteresting) break;
+  }
+
+  if (isAll_ && isInteresting) isSel_ = true;
+  else isSel_ = false;
+
+  //Histos
+  if (isAll_) {
+    if ( jet_.isNonnull() ) {
+      hDenJetPt->Fill(jet_->pt());
+      hDenJetEta->Fill(jet_->eta());
+    }
+    for(unsigned int idx=0; idx<vsPaths_.size(); ++idx){
+      hDenTriggerMon->Fill(idx+0.5);
+    }
+
+  }
+  if (isSel_) {
+    for (unsigned int i=0; i<triggerNames.triggerNames().size(); ++i) {
+      TString name = triggerNames.triggerNames()[i].c_str();
+      for (unsigned int j=0; j<vsPaths_.size(); j++) {
+        if (name.Contains(TString(vsPaths_[j]), TString::kIgnoreCase)) {
+          hNumTriggerMon->Fill(j+0.5 );
+        }
+      }
+    }
+  }
+}
+
+
+// ------------ booking histograms -----------
+  void
+B2GHadronicHLTValidation::bookHistograms(DQMStore::IBooker & dbe, edm::Run const &, edm::EventSetup const &)
+{
+  dbe.setCurrentFolder(sDir_);
+  hDenJetPt     = dbe.book1D("PtLastJetAll", "PtLastJetAll", 60, 0., 3000.);
+  hDenJetEta    = dbe.book1D("EtaLastJetAll", "EtaLastJetAll", 30, -3., 3.);
+  hNumJetPt     = dbe.book1D("PtLastJetSel", "PtLastJetSel", 60, 0., 3000.);
+  hNumJetEta    = dbe.book1D("EtaLastJetSel", "EtaLastJetSel", 30, -3., 3.);
+  // determine number of bins for trigger monitoring
+  unsigned int nPaths = vsPaths_.size();
+  // monitored trigger occupancy for single lepton triggers
+  hNumTriggerMon    = dbe.book1D("TriggerMonSel" , "TriggerMonSel", nPaths, 0.,  nPaths);
+  hDenTriggerMon    = dbe.book1D("TriggerMonAll" , "TriggerMonAll", nPaths, 0.,  nPaths);
+  // set bin labels for trigger monitoring
+  triggerBinLabels(vsPaths_);
+}
+
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void
+B2GHadronicHLTValidation::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+


### PR DESCRIPTION
I'm adding a module to monitor the hadronic HLT paths for the B2G group that are under development. This module supports several modes : 
- Single jet (pt > X)
- Dijet (pt1 > x1 && pt2 > x2)
- Multijet (count all jets with pt > X, require > N)
- HT (calculate HT all jets with pt > X, require > X)

There will be monitoring elements versus jet mass in the future as well as any other relevant information. 
