### PR TITLE
Fix clang problems in DataFormats/PatCandidates

### DIFF
--- a/DataFormats/PatCandidates/interface/EventHypothesis.h
+++ b/DataFormats/PatCandidates/interface/EventHypothesis.h
@@ -8,7 +8,7 @@
 
 namespace pat {
    // forward declaration
-   namespace eventhypothesis { template<typename T> struct Looper; }
+   namespace eventhypothesis { template<typename T> class Looper; }
    // real declarations
    namespace eventhypothesis { 
         // typedef for the Ref

--- a/DataFormats/PatCandidates/interface/TriggerEvent.h
+++ b/DataFormats/PatCandidates/interface/TriggerEvent.h
@@ -118,7 +118,7 @@ namespace pat {
       /// Set the success flag
       void setAccept( bool accept ) { accept_ = accept; };
       /// Set the error flag
-      void setError( bool error ) { error = error; };
+      void setError( bool error ) { error_ = error; };
       /// Set the PhysicsDeclared GT bit
       void setPhysDecl( bool physDecl ) { physDecl_ = physDecl; };
       /// Set the LHC fill number


### PR DESCRIPTION
Clang found one actual bug and complained about inconsistencies with a forward declaration. With the inclusion of some clang fixes in other packages, this package now builds cleanly.
