### PR TITLE
Fixed bug in BoostedJetMerger and made it a edm::stream::Producer

### DIFF
--- a/PhysicsTools/PatUtils/interface/BoostedJetMerger.h
+++ b/PhysicsTools/PatUtils/interface/BoostedJetMerger.h
@@ -18,7 +18,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -54,15 +54,13 @@ struct FindCorrectedSubjet {
   edm::Ptr<reco::Candidate> da_;
 };
 
-class BoostedJetMerger : public edm::EDProducer {
+class BoostedJetMerger : public edm::stream::EDProducer<> {
    public:
       explicit BoostedJetMerger(const edm::ParameterSet&);
       ~BoostedJetMerger();
 
    private:
-      virtual void beginJob(const edm::EventSetup&) ;
-      virtual void produce(edm::Event&, const edm::EventSetup&);
-      virtual void endJob() ;
+      virtual void produce(edm::Event&, const edm::EventSetup&) override;
       
       // ----------member data ---------------------------
 

--- a/PhysicsTools/PatUtils/plugins/BoostedJetMerger.cc
+++ b/PhysicsTools/PatUtils/plugins/BoostedJetMerger.cc
@@ -17,7 +17,7 @@ BoostedJetMerger::~BoostedJetMerger()
 
 // ------------ method called to produce the data  ------------
 void
-BoostedJetMerger::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
+BoostedJetMerger::produce(edm::Event& iEvent, const edm::EventSetup&)
 {  
 
   std::auto_ptr< std::vector<pat::Jet> > outputs( new std::vector<pat::Jet> );
@@ -55,17 +55,6 @@ BoostedJetMerger::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
   iEvent.put(outputs);
 
-}
-
-// ------------ method called once each job just before starting event loop  ------------
-void 
-BoostedJetMerger::beginJob(const edm::EventSetup&)
-{
-}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void 
-BoostedJetMerger::endJob() {
 }
 
 //define this as a plug-in


### PR DESCRIPTION
BoostedJetMerger had the wrong signature for beginJob and therefore
that function was never called (caught by clang). However, neither
beginJob nor endJob did anything so those methods were removed.
In addition, it was safe to change BoostedJetMerger to an
edm::stream::Producer and therefore become efficient when running
with multiple threads.
