### PR TITLE
Protect Electron DQM code from missing MonitorElements

### DIFF
--- a/DQMOffline/EGamma/src/ElectronDqmAnalyzerBase.cc
+++ b/DQMOffline/EGamma/src/ElectronDqmAnalyzerBase.cc
@@ -151,7 +151,7 @@ MonitorElement * ElectronDqmAnalyzerBase::get( const std::string & name )
   if (fullName)
    { return store_->get(inputInternalPath_+"/"+*fullName) ; }
   else
-  { return 0 ; }
+  { return nullptr ; }
  }
 
 void ElectronDqmAnalyzerBase::remove( const std::string & name )
@@ -301,7 +301,7 @@ MonitorElement * ElectronDqmAnalyzerBase::bookH1andDivide
    const std::string & titleX, const std::string & titleY,
    const std::string & title,const std::string & setEfficiencyFlag )
  {
-  if ((!num)||(!denom)) return 0 ;
+  if ((!num)||(!denom)) return nullptr ;
   std::string name2 = newName(name) ;
   TH1F * h_temp = (TH1F *)num->getTH1F()->Clone(name2.c_str()) ;
   h_temp->Reset() ;
@@ -321,7 +321,7 @@ MonitorElement * ElectronDqmAnalyzerBase::bookH2andDivide
    const std::string & titleX, const std::string & titleY,
    const std::string & title )
  {
-  if ((!num)||(!denom)) return 0 ;
+  if ((!num)||(!denom)) return nullptr ;
   std::string name2 = newName(name) ;
   TH2F * h_temp = (TH2F *)num->getTH2F()->Clone(name2.c_str()) ;
   h_temp->Reset() ;
@@ -339,7 +339,7 @@ MonitorElement * ElectronDqmAnalyzerBase::cloneH1
  ( const std::string & name, MonitorElement * original,
    const std::string & title )
  {
-  if (!original) return 0 ;
+  if (!original) return nullptr ;
   std::string name2 = newName(name) ;
   TH1F * h_temp = (TH1F *)original->getTH1F()->Clone(name2.c_str()) ;
   h_temp->Reset() ;
@@ -354,6 +354,7 @@ MonitorElement * ElectronDqmAnalyzerBase::profileX
    const std::string & title, const std::string & titleX, const std::string & titleY,
    Double_t minimum, Double_t maximum )
  {
+  if(!me2d) { return nullptr;}
   std::string name2 = me2d->getName()+"_pfx" ;
   TProfile * p1_temp = me2d->getTH2F()->ProfileX() ;
   if (title!="") { p1_temp->SetTitle(title.c_str()) ; }
@@ -371,6 +372,7 @@ MonitorElement * ElectronDqmAnalyzerBase::profileY
    const std::string & title, const std::string & titleX, const std::string & titleY,
    Double_t minimum, Double_t maximum )
  {
+  if(!me2d) { return nullptr;}
   std::string name2 = me2d->getName()+"_pfy" ;
   TProfile * p1_temp = me2d->getTH2F()->ProfileY() ;
   if (title!="") { p1_temp->SetTitle(title.c_str()) ; }

--- a/Validation/RecoEgamma/plugins/ElectronMcFakePostValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcFakePostValidator.cc
@@ -43,15 +43,17 @@ void ElectronMcFakePostValidator::finalize()
 
   // fbrem
   MonitorElement * p1_ele_fbremVsEta_mean = get("fbremvsEtamean") ;
-  TAxis * etaAxis = p1_ele_fbremVsEta_mean->getTProfile()->GetXaxis() ;
-  MonitorElement * h1_ele_xOverX0VsEta = bookH1withSumw2("xOverx0VsEta","mean X/X_0 vs eta",etaAxis->GetNbins(),etaAxis->GetXmin(),etaAxis->GetXmax());
-  for (int ibin=1;ibin<etaAxis->GetNbins()+1;ibin++) {
-    double xOverX0 = 0.;
-    if (p1_ele_fbremVsEta_mean->getBinContent(ibin)>0.)
-     { xOverX0 = -log(p1_ele_fbremVsEta_mean->getBinContent(ibin)) ; }
-    h1_ele_xOverX0VsEta->setBinContent(ibin,xOverX0) ;
+  if( p1_ele_fbremVsEta_mean ) {
+    TAxis * etaAxis = p1_ele_fbremVsEta_mean->getTProfile()->GetXaxis() ;
+    MonitorElement * h1_ele_xOverX0VsEta = bookH1withSumw2("xOverx0VsEta","mean X/X_0 vs eta",etaAxis->GetNbins(),etaAxis->GetXmin(),etaAxis->GetXmax());
+    for (int ibin=1;ibin<etaAxis->GetNbins()+1;ibin++) {
+      double xOverX0 = 0.;
+      if (p1_ele_fbremVsEta_mean->getBinContent(ibin)>0.)
+	{ xOverX0 = -log(p1_ele_fbremVsEta_mean->getBinContent(ibin)) ; }
+      h1_ele_xOverX0VsEta->setBinContent(ibin,xOverX0) ;
+    }
   }
-
+    
   // profiles from 2D histos
   profileX("PoPmatchingObjectVsEta","","#eta","<P/P_{gen}>");
   profileX("PoPmatchingObjectVsPhi","","#phi (rad)","<P/P_{gen}>");

--- a/Validation/RecoEgamma/plugins/ElectronMcSignalPostValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcSignalPostValidator.cc
@@ -42,13 +42,15 @@ void ElectronMcSignalPostValidator::finalize()
 
   // fbrem
   MonitorElement * p1_ele_fbremVsEta_mean = get("fbremvsEtamean") ;
-  TAxis * etaAxis = p1_ele_fbremVsEta_mean->getTProfile()->GetXaxis() ;
-  MonitorElement * h1_ele_xOverX0VsEta = bookH1withSumw2("xOverx0VsEta","mean X/X_0 vs eta",etaAxis->GetNbins(),etaAxis->GetXmin(),etaAxis->GetXmax());
-  for (int ibin=1;ibin<etaAxis->GetNbins()+1;ibin++) {
-    double xOverX0 = 0.;
-    if (p1_ele_fbremVsEta_mean->getBinContent(ibin)>0.)
-     { xOverX0 = -log(p1_ele_fbremVsEta_mean->getBinContent(ibin)) ; }
-    h1_ele_xOverX0VsEta->setBinContent(ibin,xOverX0) ;
+  if( p1_ele_fbremVsEta_mean ) {
+    TAxis * etaAxis = p1_ele_fbremVsEta_mean->getTProfile()->GetXaxis() ;
+    MonitorElement * h1_ele_xOverX0VsEta = bookH1withSumw2("xOverx0VsEta","mean X/X_0 vs eta",etaAxis->GetNbins(),etaAxis->GetXmin(),etaAxis->GetXmax());
+    for (int ibin=1;ibin<etaAxis->GetNbins()+1;ibin++) {
+      double xOverX0 = 0.;
+      if (p1_ele_fbremVsEta_mean->getBinContent(ibin)>0.)
+	{ xOverX0 = -log(p1_ele_fbremVsEta_mean->getBinContent(ibin)) ; }
+      h1_ele_xOverX0VsEta->setBinContent(ibin,xOverX0) ;
+    }
   }
 
   // profiles from 2D histos


### PR DESCRIPTION
Added needed additional protection for case where a MonitorElement
is missing from the DQMStore.
This fixes a crash seen in the threaded IB RelVals.
