### PR TITLE
Revert broken tau fixes (72x)

### DIFF
--- a/GeneratorInterface/TauolaInterface/interface/TauolappInterface.h
+++ b/GeneratorInterface/TauolaInterface/interface/TauolappInterface.h
@@ -47,9 +47,7 @@ namespace gen {
       void selectDecayByMDTAU();
       int selectLeptonic();
       int selectHadronic();
-      bool isLastTauInChain(const HepMC::GenParticle* tau);
-      void setLifeTimeInDecays(HepMC::GenParticle* p,double vx, double vy, double vz, double vt);
-
+      
       //
       static CLHEP::HepRandomEngine*           fRandomEngine;            
       std::vector<int>                         fPDGs;
@@ -64,7 +62,7 @@ namespace gen {
       std::vector<int>                         fHadronModes;
       std::vector<double>                      fScaledLeptonBrRatios;
       std::vector<double>                      fScaledHadronBrRatios;
-      double lifetime;
+      
    };
 
 }

--- a/GeneratorInterface/TauolaInterface/plugins/Tauolapp/TauolappInterface.cc
+++ b/GeneratorInterface/TauolaInterface/plugins/Tauolapp/TauolappInterface.cc
@@ -84,16 +84,20 @@ void TauolappInterface::init( const edm::EventSetup& es ){
       Tauolapp::Tauola::setOppositeParticleDecayMode( cards.getParameter< int >( "pjak2" ) ) ;
    }
 
+   Tauolapp::Tauola::setTauLifetime(0.0);
    Tauolapp::Tauola::spin_correlation.setAll(fPolarization);
 
    // some more options, copied over from an example 
-   // Default values
+   // - maybe will use later...
+   //
    //Tauola::setEtaK0sPi(0,0,0); // switches to decay eta K0_S and pi0 1/0 on/off. 
- 
-   const HepPDT::ParticleData* PData = fPDGTable->particle(HepPDT::ParticleID( abs(Tauolapp::Tauola::getDecayingParticle()) )) ;
-   double lifetime = PData->lifetime().value();
-   Tauolapp::Tauola::setTauLifetime( lifetime );
-   //std::cout << "Setting lifetime: ctau=" << lifetime << "m or tau=" << lifetime/(299792458.0*1000.0) << "s" << std::endl;
+   //
+
+//
+//   const HepPDT::ParticleData* 
+//         PData = fPDGTable->particle(HepPDT::ParticleID( abs(Tauola::getDecayingParticle()) )) ;
+//   double lifetime = PData->lifetime().value();
+//   Tauola::setTauLifetime( lifetime );
 
    fPDGs.push_back( Tauolapp::Tauola::getDecayingParticle() );
 
@@ -218,6 +222,30 @@ HepMC::GenEvent* TauolappInterface::decay( HepMC::GenEvent* evt ){
     for ( int iv=NVtxBefore+1; iv<=evt->vertices_size(); iv++ )
     {
        HepMC::GenVertex* GenVtx = evt->barcode_to_vertex(-iv);
+       HepMC::GenParticle* GenPart = *(GenVtx->particles_in_const_begin());
+       HepMC::GenVertex* ProdVtx = GenPart->production_vertex();
+       HepMC::FourVector PMom = GenPart->momentum();
+       double mass = GenPart->generated_mass();
+       const HepPDT::ParticleData* 
+             PData = fPDGTable->particle(HepPDT::ParticleID(abs(GenPart->pdg_id()))) ;
+       double lifetime = PData->lifetime().value();
+       float prob = 0.;
+       int length=1;
+       ranmar_(&prob,&length);
+       double ct = -lifetime * std::log(prob);
+       double VxDec = GenVtx->position().x();
+       VxDec += ct * (PMom.px()/mass);
+       VxDec += ProdVtx->position().x();
+       double VyDec = GenVtx->position().y();
+       VyDec += ct * (PMom.py()/mass);
+       VyDec += ProdVtx->position().y();
+       double VzDec = GenVtx->position().z();
+       VzDec += ct * (PMom.pz()/mass);
+       VzDec += ProdVtx->position().z();
+       double VtDec = GenVtx->position().t();
+       VtDec += ct * (PMom.e()/mass);
+       VtDec += ProdVtx->position().t();
+       GenVtx->set_position( HepMC::FourVector(VxDec,VyDec,VzDec,VtDec) ); 
        //
        // now find decay products with funky barcode, weed out and replace with clones of sensible barcode
        // we can NOT change the barcode while iterating, because iterators do depend on the barcoding

--- a/Validation/EventGenerator/plugins/TauValidation.cc
+++ b/Validation/EventGenerator/plugins/TauValidation.cc
@@ -63,6 +63,7 @@ void TauValidation::bookHistograms(DQMStore::IBooker &i, edm::Run const &, edm::
     TauDecayChannels->setBinLabel(1+stable,"Stable");
     
     TauMothers        = i.book1D("TauMothers","Tau mother particles", 10 ,0,10);
+
     TauMothers->setBinLabel(1+other,"?");
     TauMothers->setBinLabel(1+B,"B Decays");
     TauMothers->setBinLabel(1+D,"D Decays");


### PR DESCRIPTION
Reverts recent sets of changes to Tauola++ interface which caused undecayed taus in rare cases and therefore crashes in the validation sequence.

This reverts pull requests:
https://github.com/cms-sw/cmssw/pull/4834
https://github.com/cms-sw/cmssw/pull/4932
