### PR TITLE
Revert broken tau fixes (71x)

### DIFF
--- a/GeneratorInterface/TauolaInterface/interface/TauolappInterface.h
+++ b/GeneratorInterface/TauolaInterface/interface/TauolappInterface.h
@@ -47,9 +47,7 @@ namespace gen {
       void selectDecayByMDTAU();
       int selectLeptonic();
       int selectHadronic();
-      bool isLastTauInChain(const HepMC::GenParticle* tau);
-      void setLifeTimeInDecays(HepMC::GenParticle* p,double vx, double vy, double vz, double vt);
-
+      
       //
       static CLHEP::HepRandomEngine*           fRandomEngine;            
       std::vector<int>                         fPDGs;
@@ -64,7 +62,7 @@ namespace gen {
       std::vector<int>                         fHadronModes;
       std::vector<double>                      fScaledLeptonBrRatios;
       std::vector<double>                      fScaledHadronBrRatios;
-      double lifetime;
+      
    };
 
 }

--- a/GeneratorInterface/TauolaInterface/plugins/Tauolapp/TauolappInterface.cc
+++ b/GeneratorInterface/TauolaInterface/plugins/Tauolapp/TauolappInterface.cc
@@ -84,16 +84,20 @@ void TauolappInterface::init( const edm::EventSetup& es ){
       Tauolapp::Tauola::setOppositeParticleDecayMode( cards.getParameter< int >( "pjak2" ) ) ;
    }
 
+   Tauolapp::Tauola::setTauLifetime(0.0);
    Tauolapp::Tauola::spin_correlation.setAll(fPolarization);
 
    // some more options, copied over from an example 
-   // Default values
+   // - maybe will use later...
+   //
    //Tauola::setEtaK0sPi(0,0,0); // switches to decay eta K0_S and pi0 1/0 on/off. 
- 
-   const HepPDT::ParticleData* PData = fPDGTable->particle(HepPDT::ParticleID( abs(Tauolapp::Tauola::getDecayingParticle()) )) ;
-   double lifetime = PData->lifetime().value();
-   Tauolapp::Tauola::setTauLifetime( lifetime );
-   //std::cout << "Setting lifetime: ctau=" << lifetime << "m or tau=" << lifetime/(299792458.0*1000.0) << "s" << std::endl;
+   //
+
+//
+//   const HepPDT::ParticleData* 
+//         PData = fPDGTable->particle(HepPDT::ParticleID( abs(Tauola::getDecayingParticle()) )) ;
+//   double lifetime = PData->lifetime().value();
+//   Tauola::setTauLifetime( lifetime );
 
    fPDGs.push_back( Tauolapp::Tauola::getDecayingParticle() );
 
@@ -218,6 +222,30 @@ HepMC::GenEvent* TauolappInterface::decay( HepMC::GenEvent* evt ){
     for ( int iv=NVtxBefore+1; iv<=evt->vertices_size(); iv++ )
     {
        HepMC::GenVertex* GenVtx = evt->barcode_to_vertex(-iv);
+       HepMC::GenParticle* GenPart = *(GenVtx->particles_in_const_begin());
+       HepMC::GenVertex* ProdVtx = GenPart->production_vertex();
+       HepMC::FourVector PMom = GenPart->momentum();
+       double mass = GenPart->generated_mass();
+       const HepPDT::ParticleData* 
+             PData = fPDGTable->particle(HepPDT::ParticleID(abs(GenPart->pdg_id()))) ;
+       double lifetime = PData->lifetime().value();
+       float prob = 0.;
+       int length=1;
+       ranmar_(&prob,&length);
+       double ct = -lifetime * std::log(prob);
+       double VxDec = GenVtx->position().x();
+       VxDec += ct * (PMom.px()/mass);
+       VxDec += ProdVtx->position().x();
+       double VyDec = GenVtx->position().y();
+       VyDec += ct * (PMom.py()/mass);
+       VyDec += ProdVtx->position().y();
+       double VzDec = GenVtx->position().z();
+       VzDec += ct * (PMom.pz()/mass);
+       VzDec += ProdVtx->position().z();
+       double VtDec = GenVtx->position().t();
+       VtDec += ct * (PMom.e()/mass);
+       VtDec += ProdVtx->position().t();
+       GenVtx->set_position( HepMC::FourVector(VxDec,VyDec,VzDec,VtDec) ); 
        //
        // now find decay products with funky barcode, weed out and replace with clones of sensible barcode
        // we can NOT change the barcode while iterating, because iterators do depend on the barcoding

--- a/Validation/EventGenerator/plugins/TauValidation.cc
+++ b/Validation/EventGenerator/plugins/TauValidation.cc
@@ -74,8 +74,8 @@ void TauValidation::bookHistograms(DQMStore::IBooker &i, edm::Run const &, edm::
 	TauMothers->setBinLabel(1+A0,"A^{0}");
 	TauMothers->setBinLabel(1+Hpm,"H^{#pm}");
 
-	DecayLength = i.book1D("DecayLength","#tau Decay Length", 100 ,-20,20);  DecayLength->setAxisTitle("L_{#tau} (mm)");
-	LifeTime =  i.book1D("LifeTime","#tau LifeTime ", 500 ,0,1000E-14);     LifeTime->setAxisTitle("#tau_{#tau} (s)");
+	DecayLength = i.book1D("DecayLength","#tau Decay Length", 100 ,0,20);  DecayLength->setAxisTitle("L_{#tau} (mm)");
+	LifeTime =  i.book1D("LifeTime","#tau LifeTime ", 100 ,0,1000E-15);     LifeTime->setAxisTitle("#tau_{#tau}s)");
 
     TauRtauW          = i.book1D("TauRtauW","W->Tau p(leading track)/E(visible tau)", 50 ,0,1);     TauRtauW->setAxisTitle("rtau");
     TauRtauHpm        = i.book1D("TauRtauHpm","Hpm->Tau p(leading track)/E(visible tau)", 50 ,0,1); TauRtauHpm->setAxisTitle("rtau");
@@ -191,7 +191,6 @@ void TauValidation::analyze(const edm::Event& iEvent,const edm::EventSetup& iSet
 	///////////////////////////////////////////////
 	//Adding JAKID and Mass information
 	//
-	TLorentzVector Tau((*iter)->momentum().px(),(*iter)->momentum().py(),(*iter)->momentum().pz(),(*iter)->momentum().e()); 
         TauDecay_CMSSW TD;
         unsigned int jak_id, TauBitMask;
         if(TD.AnalyzeTau((*iter),jak_id,TauBitMask,false,false)){
@@ -212,7 +211,7 @@ void TauValidation::analyze(const edm::Event& iEvent,const edm::EventSetup& iSet
 		 PV=TVector3((*iter)->production_vertex()->point3d().x(),(*iter)->production_vertex()->point3d().y(),(*iter)->production_vertex()->point3d().z());
 		 SV=TVector3(part.at(i)->production_vertex()->point3d().x(),part.at(i)->production_vertex()->point3d().y(),part.at(i)->production_vertex()->point3d().z());
 		 TVector3 DL=SV-PV;
-		 DecayLength->Fill(DL.Dot(Tau.Vect())/Tau.P(),weight);
+		 DecayLength->Fill(DL.Mag(),weight);
 		 double c(2.99792458E8),Ltau(DL.Mag()/1000),beta((*iter)->momentum().rho()/(*iter)->momentum().m());
 		 LifeTime->Fill( Ltau/(c*beta),weight);
 	       }


### PR DESCRIPTION
Reverts recent sets of changes to Tauola++ interface which caused undecayed taus in rare cases and therefore crashes in the validation sequence.

This reverts pull requests:
https://github.com/cms-sw/cmssw/pull/4835 
https://github.com/cms-sw/cmssw/pull/4933

(The equivalent reverts for 72x are in https://github.com/cms-sw/cmssw/pull/4986)
