### PR TITLE
CMSSW_7_1_6 fix crash at cmsShow startup 

### DIFF
--- a/Fireworks/Core/src/FWRPZViewGeometry.cc
+++ b/Fireworks/Core/src/FWRPZViewGeometry.cc
@@ -60,7 +60,8 @@ FWRPZViewGeometry::FWRPZViewGeometry(const fireworks::Context& context):
    m_pixelEndcapElements(0),
    m_trackerBarrelElements(0),
    m_trackerEndcapElements(0),
-   m_rpcEndcapElements(0)
+   m_rpcEndcapElements(0),
+   m_GEMElements(0)
 {
    SetElementName("RPZGeomShared");
 }


### PR DESCRIPTION
The change has missing initalisation of a variable which cause cmsShow to crash at startup.
