### PR TITLE
Allow postLS1 customisation for reduced geometries 

### DIFF
--- a/SLHCUpgradeSimulations/Configuration/python/muonCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/muonCustoms.py
@@ -5,10 +5,8 @@ def unganged_me1a_geometry(process):
     """Customise digi/reco geometry to use unganged ME1/a channels
     """
     if hasattr(process,"CSCGeometryESModule"):
-        print "do csc geom custom"
         process.CSCGeometryESModule.useGangedStripsInME1a = False
     if hasattr(process,"idealForDigiCSCGeometry"):
-        print "do csc digi custom"
         process.idealForDigiCSCGeometry.useGangedStripsInME1a = False
     return process
 

--- a/SLHCUpgradeSimulations/Configuration/python/muonCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/muonCustoms.py
@@ -4,8 +4,12 @@ import FWCore.ParameterSet.Config as cms
 def unganged_me1a_geometry(process):
     """Customise digi/reco geometry to use unganged ME1/a channels
     """
-    process.CSCGeometryESModule.useGangedStripsInME1a = False
-    process.idealForDigiCSCGeometry.useGangedStripsInME1a = False
+    if hasattr(process,"CSCGeometryESModule"):
+        print "do csc geom custom"
+        process.CSCGeometryESModule.useGangedStripsInME1a = False
+    if hasattr(process,"idealForDigiCSCGeometry"):
+        print "do csc digi custom"
+        process.idealForDigiCSCGeometry.useGangedStripsInME1a = False
     return process
 
 


### PR DESCRIPTION
avoid python errors when running cmsDriver with options

--customise SLHCUpgradeSimulations/Configuration/postLS1Customs.customisePostLS1

in combination with geomegtries that don't include CSCs, e.g.

--geometry HCal
--geometry ECALHCAL

tests:
- python runs,
- checked with prints that customisation is completed with full geometry
