### PR TITLE
Protections to dtScalerInfo module to run online in MWGR

### DIFF
--- a/DQM/DTMonitorModule/src/DTScalerInfoTask.cc
+++ b/DQM/DTMonitorModule/src/DTScalerInfoTask.cc
@@ -102,9 +102,20 @@ void DTScalerInfoTask::analyze(const edm::Event& e, const edm::EventSetup& c){
 
   //retrieve the luminosity
   edm::Handle<LumiScalersCollection> lumiScalers;
-  e.getByToken(scalerToken_, lumiScalers);
-  LumiScalersCollection::const_iterator lumiIt = lumiScalers->begin();
-  trendHistos["AvgLumivsLumiSec"]->accumulateValueTimeSlot(lumiIt->instantLumi());
+  if (e.getByToken(scalerToken_, lumiScalers)) {
+    if (lumiScalers->begin() != lumiScalers->end()) {
+      LumiScalersCollection::const_iterator lumiIt = lumiScalers->begin();
+      trendHistos["AvgLumivsLumiSec"]->accumulateValueTimeSlot(lumiIt->instantLumi());
+    }
+    else {
+      LogVerbatim("DTDQM|DTMonitorModule|DTScalerInfoTask")
+	<< "[DTScalerInfoTask]: LumiScalersCollection size == 0" << endl;
+    }
+  }
+  else {
+    LogVerbatim("DTDQM|DTMonitorModule|DTScalerInfoTask")
+      << "[DTScalerInfoTask]: LumiScalersCollection getByToken call failed" << endl;
+  }
 
 }
 


### PR DESCRIPTION
Validity of the getByToken from the dtScalerInfo module is checked as well as the size of the LumiScalersCollection before accesing information.
This fix affects only Online DQM (the module is not run in any offline DQM workflow) and is needed to properly run Online DT DQM during MWGR.
