### PR TITLE
Add eta-dependent pt threshold to shashlik clusters

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterShashlik_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterShashlik_cfi.py
@@ -25,7 +25,7 @@ _topoClusterizer_EK = cms.PSet(
     thresholdsByDetector = cms.VPSet(   
     cms.PSet( detector = cms.string("ECAL_ENDCAP"),
               gatheringThreshold = cms.double(0.08),
-              gatheringThresholdPt = cms.double(0.0)
+              gatheringThresholdPt = cms.double(0.03)
               )
     ),
     useCornerCells = cms.bool(True)


### PR DESCRIPTION
New eta-dependent gathering threshold for shashlik clustering. 300 MeV at eta == 3.0.
Should control topo cluster size at high eta.
