### PR TITLE
Add csa_assert macro.

### DIFF
--- a/FWCore/Utilities/interface/csa_assert.h
+++ b/FWCore/Utilities/interface/csa_assert.h
@@ -1,0 +1,12 @@
+#ifndef __FWCore_Utilities_interface_csa_assert_h__
+#define __FWCore_Utilities_interface_csa_assert_h__
+
+#include <cassert>
+
+#ifdef __clang_analyzer__
+#define csa_assert(CONDITION) assert(CONDITION)
+#else
+#define csa_assert(CONDITION) (void)0
+#endif
+
+#endif // __FWCore_Utilities_interface_csa_assert_h__


### PR DESCRIPTION
Just like the normal assert, however it's only enabled when running
in the clang static analyzer. Can be used to guide static analysis
in case of false positives.
