### PR TITLE
post ls1 customs: fix

### DIFF
--- a/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py
+++ b/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py
@@ -1,7 +1,7 @@
 
 import FWCore.ParameterSet.Config as cms
 
-from muonCustoms import customise_csc_PostLS1,customise_csc_hlt
+from SLHCUpgradeSimulations.Configuration.muonCustoms import customise_csc_PostLS1,customise_csc_hlt
 
 
 def customisePostLS1(process):


### PR DESCRIPTION
- full path for muonCustoms; required to be able to inline this customise function
- necessary for the production of MC samples EXO-Fall13-00199 ---> EXO-Fall13-00236, see https://hypernews.cern.ch/HyperNews/CMS/get/prep-ops/1174/1/1/1/1/1/1/1/1/1.html
