### PR TITLE
introduce repacking step in post-LS1 CSC simulation

### DIFF
--- a/EventFilter/CSCRawToDigi/plugins/CSCDigiToRawModule.cc
+++ b/EventFilter/CSCRawToDigi/plugins/CSCDigiToRawModule.cc
@@ -21,6 +21,8 @@ CSCDigiToRawModule::CSCDigiToRawModule(const edm::ParameterSet & pset):
   
   theFormatVersion =  pset.getParameter<unsigned int>("useFormatVersion"); 	// pre-LS1 - '2005'. post-LS1 - '2013'
   usePreTriggers = pset.getParameter<bool>("usePreTriggers"); 			// disable checking CLCT PreTriggers digis
+  packEverything_ = pset.getParameter<bool>("packEverything");                  // don't check for consistency with trig primitives
+                                                                                // overrides usePreTriggers
 
   wd_token = consumes<CSCWireDigiCollection>( pset.getParameter<edm::InputTag>("wireDigiTag") );
   sd_token = consumes<CSCStripDigiCollection>( pset.getParameter<edm::InputTag>("stripDigiTag") );
@@ -63,6 +65,8 @@ void CSCDigiToRawModule::fillDescriptions(edm::ConfigurationDescriptions & descr
   setComment("Set to 2005 for pre-LS1 CSC data format, 2013 - new post-LS1 CSC data format");
   desc.add<bool>("usePreTriggers", true)->
   setComment("Set to false if CSCCLCTPreTrigger digis are not available");
+  desc.add<bool>("packEverything", false)->
+  setComment("Set to true to disable trigger-related constraints on readout data");
 
   desc.add<edm::InputTag>("wireDigiTag", edm::InputTag("simMuonCSCDigis","MuonCSCWireDigi"));
   desc.add<edm::InputTag>("stripDigiTag",edm::InputTag("simMuonCSCDigis","MuonCSCStripDigi"));
@@ -115,7 +119,8 @@ void CSCDigiToRawModule::produce( edm::Event & e, const edm::EventSetup& c ){
   // Create the packed data
   packer->createFedBuffers(*stripDigis, *wireDigis, *comparatorDigis, 
                            *alctDigis, *clctDigis, *preTriggers, *correlatedLCTDigis,
-                           *(fed_buffers.get()), theMapping, e, theFormatVersion, usePreTriggers);
+                           *(fed_buffers.get()), theMapping, e, theFormatVersion, usePreTriggers,
+			   packEverything_);
   
   // put the raw data to the event
   e.put(fed_buffers, "CSCRawData");

--- a/EventFilter/CSCRawToDigi/src/CSCDigiToRaw.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCDigiToRaw.cc
@@ -93,8 +93,8 @@ CSCDigiToRaw::CSCDigiToRaw(const edm::ParameterSet & pset)
     clctWindowMax_(pset.getParameter<int>("clctWindowMax")),
     preTriggerWindowMin_(pset.getParameter<int>("preTriggerWindowMin")),
     preTriggerWindowMax_(pset.getParameter<int>("preTriggerWindowMax")),
-    theFormatVersion(2005),
-    usePreTriggers(true)
+    formatVersion_(2005),
+    usePreTriggers_(true)
 {}
 
 void CSCDigiToRaw::beginEvent(const CSCChamberMap* electronicsMap)
@@ -113,12 +113,12 @@ CSCEventData & CSCDigiToRaw::findEventData(const CSCDetId & cscDetId)
     {
       // make an entry, telling it the correct chamberType
       int chamberType = chamberId.iChamberType();
-      chamberMapItr = theChamberDataMap.insert(pair<CSCDetId, CSCEventData>(chamberId, CSCEventData(chamberType, theFormatVersion))).first;
+      chamberMapItr = theChamberDataMap.insert(pair<CSCDetId, CSCEventData>(chamberId, CSCEventData(chamberType, formatVersion_))).first;
     }
   CSCEventData & cscData = chamberMapItr->second;
   cscData.dmbHeader()->setCrateAddress(theElectronicsMap->crate(cscDetId), theElectronicsMap->dmb(cscDetId));
 
-  if (theFormatVersion == 2013)
+  if (formatVersion_ == 2013)
     {
       // Set DMB version field to distinguish between ME11s and other chambers (ME11 - 2, others - 1)
       bool me11 = ((chamberId.station()==1) && (chamberId.ring()==4)) || ((chamberId.station()==1) && (chamberId.ring()==1));
@@ -146,8 +146,8 @@ void CSCDigiToRaw::add(const CSCStripDigiCollection& stripDigis,
       // only digitize if there are pre-triggers
       
       /* !!! Testing. Uncomment for production */
-     if (!usePreTriggers || 
-	(usePreTriggers && cscd2r::accept(cscDetId, preTriggers, preTriggerWindowMin_, preTriggerWindowMax_)) )
+     if (!usePreTriggers_ || packEverything_ ||
+	(usePreTriggers_ && cscd2r::accept(cscDetId, preTriggers, preTriggerWindowMin_, preTriggerWindowMax_)) )
         {
           bool me1a = (cscDetId.station()==1) && (cscDetId.ring()==4);
           bool zplus = (cscDetId.endcap() == 1);
@@ -161,7 +161,7 @@ void CSCDigiToRaw::add(const CSCStripDigiCollection& stripDigis,
             {
               CSCStripDigi digi = *digiItr;
               int strip = digi.getStrip();
-              if (theFormatVersion == 2013)
+              if (formatVersion_ == 2013)
                 {
                   if ( me1a && zplus )
                     {
@@ -208,7 +208,7 @@ void CSCDigiToRaw::add(const CSCWireDigiCollection& wireDigis,
   for (CSCWireDigiCollection::DigiRangeIterator j=wireDigis.begin(); j!=wireDigis.end(); ++j)
     {
       CSCDetId cscDetId=(*j).first;
-      if (cscd2r::accept(cscDetId, alctDigis, alctWindowMin_, alctWindowMax_))
+      if (packEverything_ || cscd2r::accept(cscDetId, alctDigis, alctWindowMin_, alctWindowMax_))
         {
           CSCEventData & cscData = findEventData(cscDetId);
           std::vector<CSCWireDigi>::const_iterator digiItr = (*j).second.first;
@@ -230,14 +230,14 @@ void CSCDigiToRaw::add(const CSCComparatorDigiCollection & comparatorDigis,
     {
       CSCDetId cscDetId=(*j).first;
       CSCEventData & cscData = findEventData(cscDetId);
-      if (cscd2r::accept(cscDetId, clctDigis, clctWindowMin_, clctWindowMax_))
+      if (packEverything_ || cscd2r::accept(cscDetId, clctDigis, clctWindowMin_, clctWindowMax_))
         {
           bool me1a = (cscDetId.station()==1) && (cscDetId.ring()==4);
 	  
 
-          BOOST_FOREACH(CSCComparatorDigi digi, (*j).second)
+	  BOOST_FOREACH(CSCComparatorDigi digi, (*j).second)
           {
-            if (theFormatVersion == 2013)
+            if (formatVersion_ == 2013)
               {
                 // Move ME1/A comparators from CFEB=0 to CFEB=4 if this has not
                 // been done already.
@@ -320,11 +320,13 @@ void CSCDigiToRaw::createFedBuffers(const CSCStripDigiCollection& stripDigis,
                                     const CSCCorrelatedLCTDigiCollection& correlatedLCTDigis,
                                     FEDRawDataCollection& fed_buffers,
                                     const CSCChamberMap* mapping,
-                                    Event & e, uint16_t format_version, bool use_pre_triggers)
+                                    Event & e, uint16_t format_version, bool use_pre_triggers,
+				    bool packEverything)
 {
 
-  theFormatVersion = format_version;
-  usePreTriggers = use_pre_triggers;
+  formatVersion_ = format_version;
+  usePreTriggers_ = use_pre_triggers;
+  packEverything_ = packEverything;
   //bits of code from ORCA/Muon/METBFormatter - thanks, Rick:)!
 
   //get fed object from fed_buffers
@@ -339,7 +341,7 @@ void CSCDigiToRaw::createFedBuffers(const CSCStripDigiCollection& stripDigis,
   int bx = l1a;//same as above
   //int startingFED = FEDNumbering::MINCSCFEDID;
 
-  if (theFormatVersion == 2005) /// Handle pre-LS1 format data
+  if (formatVersion_ == 2005) /// Handle pre-LS1 format data
     {
       std::map<int, CSCDCCEventData> dccMap;
       for (int idcc=FEDNumbering::MINCSCFEDID;
@@ -378,7 +380,7 @@ void CSCDigiToRaw::createFedBuffers(const CSCStripDigiCollection& stripDigis,
                   int dduSlot  = mapping->dduSlot(chamberItr->first);
                   int dduInput = mapping->dduInput(chamberItr->first);
                   int dmbId    = mapping->dmb(chamberItr->first);
-                  dccMapItr->second.addChamber(chamberItr->second, dduId, dduSlot, dduInput, dmbId, theFormatVersion);
+                  dccMapItr->second.addChamber(chamberItr->second, dduId, dduSlot, dduInput, dmbId, formatVersion_);
                 }
             }
         }
@@ -399,7 +401,7 @@ void CSCDigiToRaw::createFedBuffers(const CSCStripDigiCollection& stripDigis,
         }
 
     }
-  else if (theFormatVersion == 2013) /// Handle post-LS1 format data
+  else if (formatVersion_ == 2013) /// Handle post-LS1 format data
     {
 
       std::map<int, CSCDDUEventData> dduMap;
@@ -461,7 +463,7 @@ void CSCDigiToRaw::createFedBuffers(const CSCStripDigiCollection& stripDigis,
                   int dduInput = mapping->dduInput(chamberItr->first);
                   int dmbId    = mapping->dmb(chamberItr->first);
 		  // int crateId  = mapping->crate(chamberItr->first);
-                  dduMapItr->second.add( chamberItr->second, dmbId, dduInput, theFormatVersion );
+                  dduMapItr->second.add( chamberItr->second, dmbId, dduInput, formatVersion_ );
                 }
             }
         }

--- a/EventFilter/CSCRawToDigi/src/CSCDigiToRaw.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCDigiToRaw.cc
@@ -87,14 +87,15 @@ bool accept(const CSCDetId & cscId, const CSCCLCTPreTriggerCollection & lcts,
 
 
 CSCDigiToRaw::CSCDigiToRaw(const edm::ParameterSet & pset)
-    : alctWindowMin_(pset.getParameter<int>("alctWindowMin")),
+  : alctWindowMin_(pset.getParameter<int>("alctWindowMin")),
     alctWindowMax_(pset.getParameter<int>("alctWindowMax")),
     clctWindowMin_(pset.getParameter<int>("clctWindowMin")),
     clctWindowMax_(pset.getParameter<int>("clctWindowMax")),
     preTriggerWindowMin_(pset.getParameter<int>("preTriggerWindowMin")),
     preTriggerWindowMax_(pset.getParameter<int>("preTriggerWindowMax")),
     formatVersion_(2005),
-    usePreTriggers_(true)
+    usePreTriggers_(true),
+    packEverything_(false)
 {}
 
 void CSCDigiToRaw::beginEvent(const CSCChamberMap* electronicsMap)

--- a/EventFilter/CSCRawToDigi/src/CSCDigiToRaw.h
+++ b/EventFilter/CSCRawToDigi/src/CSCDigiToRaw.h
@@ -37,7 +37,8 @@ public:
 		        const CSCChamberMap* theMapping, 
 			edm::Event & e, 
 			uint16_t theFormatVersion = 2005, 
-			bool usePreTriggers = true);
+			bool usePreTriggers = true,
+			bool packEverything = false);
 
 private:
   void beginEvent(const CSCChamberMap* electronicsMap);
@@ -64,9 +65,9 @@ private:
   int clctWindowMax_;
   int preTriggerWindowMin_;
   int preTriggerWindowMax_;
-  uint16_t theFormatVersion;
-  bool usePreTriggers;
-
+  uint16_t formatVersion_;
+  bool usePreTriggers_;
+  bool packEverything_;
 };
 
 

--- a/EventFilter/CSCRawToDigi/src/CSCDigiToRawModule.h
+++ b/EventFilter/CSCRawToDigi/src/CSCDigiToRawModule.h
@@ -44,6 +44,7 @@ class CSCDigiToRawModule : public edm::EDProducer {
 
   unsigned int 	theFormatVersion; // Select which version of data format to use Pre-LS1: 2005, Post-LS1: 2013
   bool		usePreTriggers;   // Select if to use Pre-Triigers CLCT digis
+  bool		packEverything_;   // bypass all cuts and (pre)trigger requirements
 
   CSCDigiToRaw * packer;
 

--- a/SLHCUpgradeSimulations/Configuration/python/muonCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/muonCustoms.py
@@ -165,6 +165,7 @@ def customise_csc_Packer(process):
     """Use 2013 a.k.a. post-LS1 version
     """
     process.cscpacker.useFormatVersion = cms.uint32(2013)
+    process.cscpacker.usePreTriggers = cms.bool(False)
     return process
 
 

--- a/SLHCUpgradeSimulations/Configuration/python/muonCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/muonCustoms.py
@@ -211,7 +211,7 @@ def customise_csc_LocalReco(process):
 
     # Turn off some flags for CSCRecHitD that are turned ON in default config
     process.csc2DRecHits.readBadChannels = cms.bool(False)
-    process.csc2DRecHits.CSCUseGasGainCorrection = cms.bool(False)
+    process.csc2DRecHits.CSCUseGasGainCorrections = cms.bool(False)
 
     # Switch input for CSCRecHitD to  s i m u l a t e d  digis
     process.csc2DRecHits.wireDigiTag  = cms.InputTag("simMuonCSCDigis", "MuonCSCWireDigi")

--- a/SLHCUpgradeSimulations/Configuration/python/muonCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/muonCustoms.py
@@ -165,16 +165,13 @@ def customise_csc_L1Emulator(process):
 def customise_csc_Packer(process):
     """Get rid of process.cscpacker and process.csctfpacker in all the paths
     """
-    process = remove_from_all_paths(process, 'cscpacker')
-    process = remove_from_all_paths(process, 'csctfpacker')
+    process.cscpacker.useFormatVersion = cms.uint32(2013)
     return process
 
 
 def customise_csc_Unpacker(process):
     """Get rid of process.muonCSCDigis and process.csctfDigis in all the paths
     """
-    process = remove_from_all_paths(process, 'muonCSCDigis')
-    process = remove_from_all_paths(process, 'csctfDigis')
     return process
 
 

--- a/SLHCUpgradeSimulations/Configuration/python/muonCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/muonCustoms.py
@@ -166,6 +166,7 @@ def customise_csc_Packer(process):
     """
     process.cscpacker.useFormatVersion = cms.uint32(2013)
     process.cscpacker.usePreTriggers = cms.bool(False)
+    process.cscpacker.packEverything = cms.bool(True)
     return process
 
 

--- a/SLHCUpgradeSimulations/Configuration/python/muonCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/muonCustoms.py
@@ -127,7 +127,7 @@ def customise_csc_Digitizer(process):
     return process
 
 
-def customise_csc_L1Stubs(process):
+def customise_csc_L1Stubs_sim(process):
     """Configure the local CSC trigger stubs emulator with the upgrade 
     algorithm version that efficiently uses unganged ME1a
     """
@@ -142,10 +142,9 @@ def customise_csc_L1Stubs(process):
     return process
 
 
-def customise_csc_L1TrackFinder(process):
+def customise_csc_L1TrackFinder_sim(process):
     """Regular CSCTF configuration adapted to deal with unganged ME1a
     """
-
     from L1Trigger.CSCTrackFinder.csctfTrackDigisUngangedME1a_cfi import csctfTrackDigisUngangedME1a
     process.simCsctfTrackDigis = csctfTrackDigisUngangedME1a
     process.simCsctfTrackDigis.DTproducer = cms.untracked.InputTag("simDtTriggerPrimitiveDigis")
@@ -154,23 +153,23 @@ def customise_csc_L1TrackFinder(process):
     return process
 
 
-def customise_csc_L1Emulator(process):
+def customise_csc_L1Emulator_sim(process):
     """Customise both stubs and TF emulators
     """
-    process = customise_csc_L1Stubs(process)
-    process = customise_csc_L1TrackFinder(process)
+    process = customise_csc_L1Stubs_sim(process)
+    process = customise_csc_L1TrackFinder_sim(process)
     return process
 
 
 def customise_csc_Packer(process):
-    """Get rid of process.cscpacker and process.csctfpacker in all the paths
+    """Use 2013 a.k.a. post-LS1 version
     """
     process.cscpacker.useFormatVersion = cms.uint32(2013)
     return process
 
 
 def customise_csc_Unpacker(process):
-    """Get rid of process.muonCSCDigis and process.csctfDigis in all the paths
+    """Do nothing at the moment
     """
     return process
 
@@ -210,35 +209,18 @@ def customise_csc_LocalReco(process):
     process.csc2DRecHits.readBadChannels = cms.bool(False)
     process.csc2DRecHits.CSCUseGasGainCorrections = cms.bool(False)
 
-    # Switch input for CSCRecHitD to  s i m u l a t e d  digis
-    process.csc2DRecHits.wireDigiTag  = cms.InputTag("simMuonCSCDigis", "MuonCSCWireDigi")
-    process.csc2DRecHits.stripDigiTag = cms.InputTag("simMuonCSCDigis", "MuonCSCStripDigi")
-
     return process
 
 
 def customise_csc_DQM(process):
-    """At this point: get rid of process.muonAnalyzer, adjust cscMonitor's input
+    """Do nothing special. May need some adjustments for unganged ME11
     """
-    process = remove_from_all_paths(process, 'muonAnalyzer')
-
-    process.cscMonitor.clctDigiTag = cms.InputTag("simCscTriggerPrimitiveDigis")
-    process.cscMonitor.stripDigiTag = cms.InputTag("simMuonCSCDigis", "MuonCSCStripDigi")
-    process.cscMonitor.wireDigiTag = cms.InputTag("simMuonCSCDigis", "MuonCSCWireDigi")
-    process.cscMonitor.alctDigiTag = cms.InputTag("simCscTriggerPrimitiveDigis")
-
-    process.l1tCsctf.statusProducer=cms.InputTag("null")
-    process.l1tCsctf.lctProducer=cms.InputTag("null")
-    process.l1tCsctf.trackProducer=cms.InputTag("null")
-    process.l1tCsctf.mbProducer=cms.InputTag("null")
-
     return process
 
 
 def customise_csc_Validation(process):
-    """At this point, just get rid of process.relvalMuonBits
+    """Nothing for now
     """
-    process = remove_from_all_paths(process, 'relvalMuonBits')
     return process
 
 
@@ -261,11 +243,11 @@ def customise_csc_PostLS1(process):
 
     # L1 stub emulator upgrade algorithm
     if hasattr(process, 'simCscTriggerPrimitiveDigis'):
-        process = customise_csc_L1Stubs(process)
+        process = customise_csc_L1Stubs_sim(process)
 
     # CSCTF that can deal with unganged ME1a
     if hasattr(process, 'simCsctfTrackDigis'):
-        process = customise_csc_L1TrackFinder(process)
+        process = customise_csc_L1TrackFinder_sim(process)
 
     # packer - simply get rid of it
     if hasattr(process, 'cscpacker') or hasattr(process, 'csctfpacker'):
@@ -298,9 +280,4 @@ def customise_csc_hlt(process):
     
     process = customise_csc_Indexing(process)
 
-    # Switch input for CSCRecHitD to  s i m u l a t e d  digis
-    
-    process.hltCsc2DRecHits.wireDigiTag  = cms.InputTag("simMuonCSCDigis","MuonCSCWireDigi")
-    process.hltCsc2DRecHits.stripDigiTag = cms.InputTag("simMuonCSCDigis","MuonCSCStripDigi")
-    
     return process

--- a/SLHCUpgradeSimulations/Configuration/python/muonCustomsPreMixing.py
+++ b/SLHCUpgradeSimulations/Configuration/python/muonCustomsPreMixing.py
@@ -167,6 +167,7 @@ def customise_csc_Packer(process):
     """
     process.cscpacker.useFormatVersion = cms.uint32(2013)
     process.cscpacker.usePreTriggers = cms.bool(False)
+    process.cscpacker.packEverything = cms.bool(True)
     return process
 
 

--- a/SLHCUpgradeSimulations/Configuration/python/muonCustomsPreMixing.py
+++ b/SLHCUpgradeSimulations/Configuration/python/muonCustomsPreMixing.py
@@ -127,7 +127,7 @@ def customise_csc_Digitizer(process):
     return process
 
 
-def customise_csc_L1Stubs(process):
+def customise_csc_L1Stubs_sim(process):
     """Configure the local CSC trigger stubs emulator with the upgrade 
     algorithm version that efficiently uses unganged ME1a
     """
@@ -142,7 +142,7 @@ def customise_csc_L1Stubs(process):
     return process
 
 
-def customise_csc_L1TrackFinder(process):
+def customise_csc_L1TrackFinder_sim(process):
     """Regular CSCTF configuration adapted to deal with unganged ME1a
     """
 
@@ -154,23 +154,23 @@ def customise_csc_L1TrackFinder(process):
     return process
 
 
-def customise_csc_L1Emulator(process):
+def customise_csc_L1Emulator_sim(process):
     """Customise both stubs and TF emulators
     """
-    process = customise_csc_L1Stubs(process)
-    process = customise_csc_L1TrackFinder(process)
+    process = customise_csc_L1Stubs_sim(process)
+    process = customise_csc_L1TrackFinder_sim(process)
     return process
 
 
 def customise_csc_Packer(process):
-    """Get rid of process.cscpacker and process.csctfpacker in all the paths
+    """Use 2013 a.k.a. post-LS1 version 
     """
     process.cscpacker.useFormatVersion = cms.uint32(2013)
     return process
 
 
 def customise_csc_Unpacker(process):
-    """Get rid of process.muonCSCDigis and process.csctfDigis in all the paths
+    """Do nothing at the moment
     """
     return process
 
@@ -210,35 +210,18 @@ def customise_csc_LocalReco(process):
     process.csc2DRecHits.readBadChannels = cms.bool(False)
     process.csc2DRecHits.CSCUseGasGainCorrections = cms.bool(False)
 
-    # Switch input for CSCRecHitD to  s i m u l a t e d (and Mixed!)  digis
-    process.csc2DRecHits.wireDigiTag  = cms.InputTag("mixData", "MuonCSCWireDigisDM")
-    process.csc2DRecHits.stripDigiTag = cms.InputTag("mixData", "MuonCSCStripDigisDM")
-
     return process
 
 
 def customise_csc_DQM(process):
-    """At this point: get rid of process.muonAnalyzer, adjust cscMonitor's input
+    """Runs after RAW2DIGI, so, should use defaults
     """
-    process = remove_from_all_paths(process, 'muonAnalyzer')
-
-    process.cscMonitor.clctDigiTag = cms.InputTag("simCscTriggerPrimitiveDigis")
-    process.cscMonitor.stripDigiTag = cms.InputTag("mixData", "MuonCSCStripDigisDM")
-    process.cscMonitor.wireDigiTag = cms.InputTag("mixData", "MuonCSCWireDigisDM")
-    process.cscMonitor.alctDigiTag = cms.InputTag("simCscTriggerPrimitiveDigis")
-
-    process.l1tCsctf.statusProducer=cms.InputTag("null")
-    process.l1tCsctf.lctProducer=cms.InputTag("null")
-    process.l1tCsctf.trackProducer=cms.InputTag("null")
-    process.l1tCsctf.mbProducer=cms.InputTag("null")
-
     return process
 
 
 def customise_csc_Validation(process):
-    """At this point, just get rid of process.relvalMuonBits
+    """Nothing for now
     """
-    process = remove_from_all_paths(process, 'relvalMuonBits')
     return process
 
 
@@ -261,11 +244,11 @@ def customise_csc_PostLS1(process):
 
     # L1 stub emulator upgrade algorithm
     if hasattr(process, 'simCscTriggerPrimitiveDigis'):
-        process = customise_csc_L1Stubs(process)
+        process = customise_csc_L1Stubs_sim(process)
 
     # CSCTF that can deal with unganged ME1a
     if hasattr(process, 'simCsctfTrackDigis'):
-        process = customise_csc_L1TrackFinder(process)
+        process = customise_csc_L1TrackFinder_sim(process)
 
     # packer - simply get rid of it
     if hasattr(process, 'cscpacker') or hasattr(process, 'csctfpacker'):
@@ -296,9 +279,6 @@ def customise_csc_hlt(process):
     process.hltCsc2DRecHits.readBadChannels = cms.bool(False)
     process.hltCsc2DRecHits.CSCUseGasGainCorrections = cms.bool(False)
     
-    # Switch input for CSCRecHitD to  s i m u l a t e d (and Mixed!) digis
-    
-    process.hltCsc2DRecHits.wireDigiTag  = cms.InputTag("mixData","MuonCSCWireDigisDM")
-    process.hltCsc2DRecHits.stripDigiTag = cms.InputTag("mixData","MuonCSCStripDigisDM")
+    process = customise_csc_Indexing(process)
     
     return process

--- a/SLHCUpgradeSimulations/Configuration/python/muonCustomsPreMixing.py
+++ b/SLHCUpgradeSimulations/Configuration/python/muonCustomsPreMixing.py
@@ -165,16 +165,13 @@ def customise_csc_L1Emulator(process):
 def customise_csc_Packer(process):
     """Get rid of process.cscpacker and process.csctfpacker in all the paths
     """
-    process = remove_from_all_paths(process, 'cscpacker')
-    process = remove_from_all_paths(process, 'csctfpacker')
+    process.cscpacker.useFormatVersion = cms.uint32(2013)
     return process
 
 
 def customise_csc_Unpacker(process):
     """Get rid of process.muonCSCDigis and process.csctfDigis in all the paths
     """
-    process = remove_from_all_paths(process, 'muonCSCDigis')
-    process = remove_from_all_paths(process, 'csctfDigis')
     return process
 
 

--- a/SLHCUpgradeSimulations/Configuration/python/muonCustomsPreMixing.py
+++ b/SLHCUpgradeSimulations/Configuration/python/muonCustomsPreMixing.py
@@ -166,6 +166,7 @@ def customise_csc_Packer(process):
     """Use 2013 a.k.a. post-LS1 version 
     """
     process.cscpacker.useFormatVersion = cms.uint32(2013)
+    process.cscpacker.usePreTriggers = cms.bool(False)
     return process
 
 

--- a/SLHCUpgradeSimulations/Configuration/python/muonCustomsPreMixing.py
+++ b/SLHCUpgradeSimulations/Configuration/python/muonCustomsPreMixing.py
@@ -211,7 +211,7 @@ def customise_csc_LocalReco(process):
 
     # Turn off some flags for CSCRecHitD that are turned ON in default config
     process.csc2DRecHits.readBadChannels = cms.bool(False)
-    process.csc2DRecHits.CSCUseGasGainCorrection = cms.bool(False)
+    process.csc2DRecHits.CSCUseGasGainCorrections = cms.bool(False)
 
     # Switch input for CSCRecHitD to  s i m u l a t e d (and Mixed!)  digis
     process.csc2DRecHits.wireDigiTag  = cms.InputTag("mixData", "MuonCSCWireDigisDM")
@@ -297,7 +297,7 @@ def customise_csc_hlt(process):
     process.CSCGeometryESModule.useGangedStripsInME1a = False
     
     process.hltCsc2DRecHits.readBadChannels = cms.bool(False)
-    process.hltCsc2DRecHits.CSCUseGasGainCorrection = cms.bool(False)
+    process.hltCsc2DRecHits.CSCUseGasGainCorrections = cms.bool(False)
     
     # Switch input for CSCRecHitD to  s i m u l a t e d (and Mixed!) digis
     


### PR DESCRIPTION
Enable proper digi2raw -> raw2digi for CSC in post-LS1/Run2.
Quite a few of the customizations still remain, they are specific to new settings needed in ME1/1 and are now essentially the same as changes added in the Run2 data processing scenarios.

Differences come out as expected:
- monitoring and validation plots are now filled (were disabled earlier)
- minor changes in muon parameters/distributions (<1%) 
  - changes in muon distributions are minimal and can be traced back to changes in the CSC wire digis in ME1/1 chambers:
  - in simulation these are coming separately for ME11a and ME11b and occasionally the same wire could have separate hits in ME11a and ME11b (there is only one actual electronic readout channel), while after repacking wire digis of the same wire-group from A and B are merged into one digi. 
  - So, the number of hits is generally expected to reduce (~0.5% rate)
  - The downstream reconstruction can be affected in a minor way. The effect decreases going from hits to segments to standalone muons to global/tracker muons.
