### PR TITLE
Second bunch of miniAOD 70X changes post CSA14

### DIFF
--- a/DataFormats/PatCandidates/src/PackedGenParticle.cc
+++ b/DataFormats/PatCandidates/src/PackedGenParticle.cc
@@ -79,7 +79,8 @@ size_t pat::PackedGenParticle::numberOfDaughters() const {
 }
 
 size_t pat::PackedGenParticle::numberOfMothers() const { 
-  return 1; 
+  if(mother_.isNonnull())   return 1; 
+  return 0;
 }
 
 bool pat::PackedGenParticle::overlap( const reco::Candidate & o ) const { 

--- a/DataFormats/PatCandidates/src/PackedGenParticle.cc
+++ b/DataFormats/PatCandidates/src/PackedGenParticle.cc
@@ -79,7 +79,7 @@ size_t pat::PackedGenParticle::numberOfDaughters() const {
 }
 
 size_t pat::PackedGenParticle::numberOfMothers() const { 
-  return 0; 
+  return 1; 
 }
 
 bool pat::PackedGenParticle::overlap( const reco::Candidate & o ) const { 

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -348,6 +348,10 @@
   <class name="edm::Association<pat::PackedCandidateCollection>" />
   <class name="edm::Wrapper<edm::Association<pat::PackedCandidateCollection> >" />
 
+  <class name="edm::RefProd<std::vector<pat::PackedGenParticle> >" />
+  <class name="edm::Association<std::vector<pat::PackedGenParticle> >" />
+  <class name="edm::Wrapper<edm::Association<std::vector<pat::PackedGenParticle> > >"/>
+
   </selection>
  <exclusion>
  </exclusion>

--- a/DataFormats/PatCandidates/src/classes_objects.h
+++ b/DataFormats/PatCandidates/src/classes_objects.h
@@ -167,6 +167,8 @@ namespace DataFormats_PatCandidates {
 
   edm::Wrapper<edm::Association<pat::PackedCandidateCollection > > w_asso_pc;
   edm::Wrapper<edm::Association<reco::PFCandidateCollection > >    w_asso_pfc;
+  edm::Wrapper<edm::Association<std::vector<pat::PackedGenParticle> > > asso_pgp;
+
 
   };
 

--- a/PhysicsTools/PatAlgos/plugins/PATGenJetSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATGenJetSlimmer.cc
@@ -15,7 +15,9 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
-
+#include "DataFormats/Common/interface/Association.h"
+#include "DataFormats/Common/interface/RefToPtr.h"
+#include "DataFormats/PatCandidates/interface/PackedGenParticle.h"
 #include "DataFormats/JetReco/interface/GenJet.h"
 
 namespace pat {
@@ -29,6 +31,8 @@ namespace pat {
 
     private:
       edm::EDGetTokenT<edm::View<reco::GenJet> > src_;
+      edm::EDGetTokenT<edm::Association<std::vector<pat::PackedGenParticle> > > gp2pgp_;
+
       StringCutObjectSelector<reco::GenJet> cut_;
       
       /// reset daughters to an empty vector
@@ -41,6 +45,7 @@ namespace pat {
 
 pat::PATGenJetSlimmer::PATGenJetSlimmer(const edm::ParameterSet & iConfig) :
     src_(consumes<edm::View<reco::GenJet> >(iConfig.getParameter<edm::InputTag>("src"))),
+    gp2pgp_(consumes<edm::Association<std::vector<pat::PackedGenParticle> > >(iConfig.getParameter<edm::InputTag>("packedGenParticles"))),
     cut_(iConfig.getParameter<std::string>("cut")),
     clearDaughters_(iConfig.getParameter<bool>("clearDaughters")),
     dropSpecific_(iConfig.getParameter<bool>("dropSpecific"))
@@ -59,6 +64,10 @@ pat::PATGenJetSlimmer::produce(edm::Event & iEvent, const edm::EventSetup & iSet
     auto_ptr<vector<reco::GenJet> >  out(new vector<reco::GenJet>());
     out->reserve(src->size());
 
+    Handle<edm::Association<std::vector<pat::PackedGenParticle> > > gp2pgp;
+    iEvent.getByToken(gp2pgp_,gp2pgp);
+	
+
     for (View<reco::GenJet>::const_iterator it = src->begin(), ed = src->end(); it != ed; ++it) {
         if (!cut_(*it)) continue;
 
@@ -68,6 +77,26 @@ pat::PATGenJetSlimmer::produce(edm::Event & iEvent, const edm::EventSetup & iSet
         if (clearDaughters_) {
             jet.clearDaughters();
         }
+	else // rekey
+	{
+                //copy old 
+		reco::CompositePtrCandidate::daughters old = jet.daughterPtrVector();
+		jet.clearDaughters();
+		std::map<unsigned int,reco::CandidatePtr> ptrs;
+		for(unsigned int  i=0;i<old.size();i++)
+		{
+//	if(! ((*gp2pgp)[old[i]]).isNonnull())	{
+//		std::cout << "Missing ref for key"  <<  old[i].key() << " pdgid " << old[i]->pdgId() << " st "<<   old[i]->status() <<  " pt " << old[i]->pt() << " eta " << old[i]->eta() << std::endl;
+//	}
+			ptrs[((*gp2pgp)[old[i]]).key()]=refToPtr((*gp2pgp)[old[i]]);
+		}
+		for(std::map<unsigned int,reco::CandidatePtr>::iterator itp=ptrs.begin();itp!=ptrs.end();itp++) //iterate on sorted items
+		{
+			jet.addDaughter(itp->second);
+		}
+
+
+	}
         if (dropSpecific_) {
             jet.setSpecific( reco::GenJet::Specific() );
         }

--- a/PhysicsTools/PatAlgos/python/slimming/genParticles_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/genParticles_cff.py
@@ -6,5 +6,7 @@ prunedGenParticlesWithStatusOne = prunedGenParticles.clone()
 prunedGenParticlesWithStatusOne.select.append( "keep    status == 1")
 
 prunedGenParticles.src =  cms.InputTag("prunedGenParticlesWithStatusOne")
+
 packedGenParticles.inputCollection = cms.InputTag("prunedGenParticlesWithStatusOne")
-packedGenParticles.map = cms.InputTag("prunedGenParticles")
+packedGenParticles.map = cms.InputTag("prunedGenParticles") # map with rekey association from prunedGenParticlesWithStatusOne to prunedGenParticles, used to relink our refs to prunedGen
+packedGenParticles.inputOriginal = cms.InputTag("genParticles")

--- a/PhysicsTools/PatAlgos/python/slimming/packedGenParticles_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/packedGenParticles_cfi.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 packedGenParticles = cms.EDProducer("PATPackedGenParticleProducer",
     inputCollection = cms.InputTag("genParticles"),
     map = cms.InputTag("genParticles"),
+    inputOriginal = cms.InputTag("genParticles"),
     inputVertices = cms.InputTag("offlineSlimmedPrimaryVertices"),
-    maxEta = cms.double(5)
+    maxEta = cms.double(6)
 )

--- a/PhysicsTools/PatAlgos/python/slimming/prunedGenParticles_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/prunedGenParticles_cfi.py
@@ -4,7 +4,6 @@ prunedGenParticles = cms.EDProducer("GenParticlePruner",
     src = cms.InputTag("genParticles"),
     select = cms.vstring(
         "drop  *", # this is the default
-        "keep status == 3 || status == 22 || status == 23",  #keep event summary status3 (for pythia), 22,23 (pythia8)
         "++keep abs(pdgId) == 11 || abs(pdgId) == 13 || abs(pdgId) == 15", # keep leptons, with history
         "keep abs(pdgId) == 12 || abs(pdgId) == 14 || abs(pdgId) == 16",   # keep neutrinos
         "drop   status == 2",                                              # drop the shower part of the history
@@ -26,8 +25,9 @@ prunedGenParticles = cms.EDProducer("GenParticlePruner",
 	"keep abs(pdgId) = 10411 || abs(pdgId) = 10421 || abs(pdgId) = 10413 || abs(pdgId) = 10423 || abs(pdgId) = 20413 || abs(pdgId) = 20423 || abs(pdgId) = 10431 || abs(pdgId) = 10433 || abs(pdgId) = 20433", 
 # additional b hadrons for jet fragmentation studies
 	"keep abs(pdgId) = 10511 || abs(pdgId) = 10521 || abs(pdgId) = 10513 || abs(pdgId) = 10523 || abs(pdgId) = 20513 || abs(pdgId) = 20523 || abs(pdgId) = 10531 || abs(pdgId) = 10533 || abs(pdgId) = 20533 || abs(pdgId) = 10541 || abs(pdgId) = 10543 || abs(pdgId) = 20543", 
-# keep protons and first children
-        "keep+ pdgId = 2212",
+# keep protons 
+        "keep pdgId = 2212",
+        "keep status == 3 || status == 22 || status == 23 || ( 11 <= status <= 19)",  #keep event summary status3 (for pythia), 22,23 (pythia8)
 
     )
 )

--- a/PhysicsTools/PatAlgos/python/slimming/prunedGenParticles_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/prunedGenParticles_cfi.py
@@ -7,8 +7,9 @@ prunedGenParticles = cms.EDProducer("GenParticlePruner",
         "keep status == 3 || status == 22 || status == 23",  #keep event summary status3 (for pythia), 22,23 (pythia8)
         "++keep abs(pdgId) == 11 || abs(pdgId) == 13 || abs(pdgId) == 15", # keep leptons, with history
         "keep abs(pdgId) == 12 || abs(pdgId) == 14 || abs(pdgId) == 16",   # keep neutrinos
-        "+keep pdgId == 22 && status == 1 && pt > 10",                     # keep gamma above 10 GeV
         "drop   status == 2",                                              # drop the shower part of the history
+        "+keep pdgId == 22 && status == 1 && pt > 10",                     # keep gamma above 10 GeV and its first parent
+        "+keep pdgId == 11 && status == 1 && pt > 3",                     # keep first parent of electrons above 10 GeV
         "keep++ abs(pdgId) == 15",                                         # but keep keep taus with decays
 	"drop  status > 30 && status < 70 ", 				   #remove pythia8 garbage
 	"drop  pdgId == 21 && pt < 5",                                    #remove pythia8 garbage

--- a/PhysicsTools/PatAlgos/python/slimming/prunedGenParticles_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/prunedGenParticles_cfi.py
@@ -16,7 +16,7 @@ prunedGenParticles = cms.EDProducer("GenParticlePruner",
         "keep abs(pdgId) == 23 || abs(pdgId) == 24 || abs(pdgId) == 25 || abs(pdgId) == 6 || abs(pdgId) == 37 ",   # keep VIP(articles)s
         "keep abs(pdgId) == 310 && abs(eta) < 2.5 && pt > 1 ",                                                     # keep K0
 # keep heavy flavour quarks for parton-based jet flavour
-	"keep (4 <= abs(pdgId) = 5) & (status = 2 || status = 11 || status = 71 || status = 72)",
+	"keep (4 <= abs(pdgId) <= 5) & (status = 2 || status = 11 || status = 71 || status = 72)",
 # keep light-flavour quarks and gluons for parton-based jet flavour
 	"keep (1 <= abs(pdgId) <= 3 || pdgId = 21) & (status = 2 || status = 11 || status = 71 || status = 72) && pt>5", 
 # keep b and c hadrons for hadron-based jet flavour

--- a/PhysicsTools/PatAlgos/python/slimming/slimmedGenJets_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimmedGenJets_cfi.py
@@ -2,7 +2,8 @@ import FWCore.ParameterSet.Config as cms
 
 slimmedGenJets = cms.EDProducer("PATGenJetSlimmer",
     src = cms.InputTag("ak5GenJets"),
+    packedGenParticles = cms.InputTag("packedGenParticles"),
     cut = cms.string("pt > 8"),
-    clearDaughters = cms.bool(True),
+    clearDaughters = cms.bool(False), #False means rekeying
     dropSpecific = cms.bool(False),
 )

--- a/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
@@ -61,7 +61,7 @@ MicroEventContentMC = cms.PSet(
 )
 MicroEventContentMC.outputCommands += [
         'keep *_slimmedGenJets_*_*',
-        'keep *_packedGenParticles_*_*',
+        'keep patPackedGenParticles_packedGenParticles_*_*',
         'keep recoGenParticles_prunedGenParticles_*_*',
         'keep LHEEventProduct_*_*_*',
         'keep PileupSummaryInfos_*_*_*',


### PR DESCRIPTION
This PR implements another bunch of items from
https://twiki.cern.ch/twiki/bin/view/CMS/MiniAODCSA14FollowUp
- Fix heavy flavour selection in pruned gen parts 
- Add photons first mother for pt > 10 (needed for pi0 decays)
- Add first mother for electrons with pt >3 (needed for pi0 decys)
- GenJet constituents rekeying (needed to enlarge the maxEta of packed candidates for fwd jets)

@gpetruc 
