### PR TITLE
Wait longer for job timeout when testing multi-threaded

### DIFF
--- a/FWCore/Concurrency/python/dropNonMTSafe.py
+++ b/FWCore/Concurrency/python/dropNonMTSafe.py
@@ -13,7 +13,7 @@ def dropNonMTSafe(process):
                                        numberOfStreams = cms.untracked.uint32(0))
   if not hasattr(process,"ZombieKillerService"):
     process.add_(cms.Service("ZombieKillerService",
-                             secondsBetweenChecks = cms.untracked.uint32(60),
+                             secondsBetweenChecks = cms.untracked.uint32(120),
                              numberOfAllowedFailedChecksInARow = cms.untracked.uint32(4)))
 
   return process


### PR DESCRIPTION
The previous timeout for a ‘zombie’ process was 5 minutes. Based on experience with actual jobs, 5 minutes was deemed to short a time. We are now going to try 10 minutes.
