### PR TITLE
Add missing include of header GenLumiInfoProduct.h

### DIFF
--- a/SimDataFormats/GeneratorProducts/src/classes.h
+++ b/SimDataFormats/GeneratorProducts/src/classes.h
@@ -30,6 +30,7 @@
 #include "SimDataFormats/GeneratorProducts/interface/GenRunInfoProduct.h"
 #include "SimDataFormats/GeneratorProducts/interface/GenFilterInfo.h"
 #include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenLumiInfoProduct.h"
 
 #include "HepMC/GenRanges.h"
 


### PR DESCRIPTION
The package SimDataFormats/GeneratorProducts now does not build due to a missing #include of the header file GenLumiInfoProduct.h.  This pull request adds the missing include.
Please merge this trivial pull request as soon as convenient.
