### PR TITLE
Migrate DQMFileSaver to use LogAbsolute instead of std::cout.

### DIFF
--- a/DQMServices/Components/src/DQMFileSaver.cc
+++ b/DQMServices/Components/src/DQMFileSaver.cc
@@ -112,13 +112,14 @@ DQMFileSaver::saveForOffline(const std::string &workflow, int run, int lumi) con
   {
     std::vector<std::string> systems = (dbe_->cd(), dbe_->getSubdirs());
 
-    edm::LogAbsolute("fileAction") << " DQMFileSaver: storing EventInfo folders for Run: "
+    edm::LogAbsolute msg("fileAction");
+    msg << "DQMFileSaver: storing EventInfo folders for Run: "
               << run << ", Lumi Section: " << lumi << ", Subsystems: " ;
 
     for (size_t i = 0, e = systems.size(); i != e; ++i) {
       if (systems[i] != "Reference") {
         dbe_->cd();
-        edm::LogAbsolute("fileAction") << systems[i] << "  " ;
+        msg << systems[i] << "  " ;
 
         dbe_->save(filename,
                    systems[i]+"/EventInfo", "^(Reference/)?([^/]+)",
@@ -128,8 +129,9 @@ DQMFileSaver::saveForOffline(const std::string &workflow, int run, int lumi) con
                    DQMStore::SaveWithoutReference,
                    dqm::qstatus::STATUS_OK,
                    fileUpdate_ ? "UPDATE" : "RECREATE");
-	// from now on update newly created file
-	if (fileUpdate_.load() == 0) fileUpdate_ = 1;
+
+        // from now on update newly created file
+        if (fileUpdate_.load() == 0) fileUpdate_ = 1;
       }
     }
   }

--- a/DQMServices/Components/src/DQMFileSaver.cc
+++ b/DQMServices/Components/src/DQMFileSaver.cc
@@ -112,13 +112,14 @@ DQMFileSaver::saveForOffline(const std::string &workflow, int run, int lumi) con
   {
     std::vector<std::string> systems = (dbe_->cd(), dbe_->getSubdirs());
 
-    std::cout << " DQMFileSaver: storing EventInfo folders for Run: "
+    edm::LogAbsolute("fileAction") << " DQMFileSaver: storing EventInfo folders for Run: "
               << run << ", Lumi Section: " << lumi << ", Subsystems: " ;
 
     for (size_t i = 0, e = systems.size(); i != e; ++i) {
       if (systems[i] != "Reference") {
         dbe_->cd();
-	std::cout << systems[i] << "  " ;
+        edm::LogAbsolute("fileAction") << systems[i] << "  " ;
+
         dbe_->save(filename,
                    systems[i]+"/EventInfo", "^(Reference/)?([^/]+)",
                    rewrite,


### PR DESCRIPTION
This should not produce garbled up messages when running multithread.
