### PR TITLE
Switch on BTag from candidates in reco and provide corresponding PAT tools

### DIFF
--- a/DataFormats/PatCandidates/interface/PackedCandidate.h
+++ b/DataFormats/PatCandidates/interface/PackedCandidate.h
@@ -233,7 +233,7 @@ namespace pat {
 
     /// return a pointer to the track if present. otherwise, return a null pointer
     virtual const reco::Track * bestTrack() const {
-      if (normalizedChi2_!=0) {
+      if (packedHits_!=0) {
         if (!unpackedTrk_) unpackTrk();
         return &track_;
       }

--- a/PhysicsTools/PatAlgos/python/recoLayer0/bTagging_cff.py
+++ b/PhysicsTools/PatAlgos/python/recoLayer0/bTagging_cff.py
@@ -9,6 +9,8 @@ from RecoBTag.SecondaryVertex.simpleSecondaryVertex2TrkES_cfi import *
 ## list of all available btagInfos
 supportedBtagInfos = [
     'None'
+  , 'pfImpactParameterTagInfos'
+  , 'pfSecondaryVertexTagInfos'
   , 'impactParameterTagInfos'
   , 'secondaryVertexTagInfos'
   , 'secondaryVertexNegativeTagInfos'
@@ -37,6 +39,7 @@ supportedBtagDiscr = {
   , 'simpleSecondaryVertexHighPurBJetTags'                  : ['secondaryVertexTagInfos']
   , 'simpleSecondaryVertexNegativeHighEffBJetTags'          : ['secondaryVertexNegativeTagInfos']
   , 'simpleSecondaryVertexNegativeHighPurBJetTags'          : ['secondaryVertexNegativeTagInfos']
+  , 'pfCombinedSecondaryVertexBJetTags'                     : ['pfImpactParameterTagInfos', 'pfSecondaryVertexTagInfos']
   , 'combinedSecondaryVertexBJetTags'                       : ['impactParameterTagInfos', 'secondaryVertexTagInfos']
   , 'combinedSecondaryVertexPositiveBJetTags'               : ['impactParameterTagInfos', 'secondaryVertexTagInfos']
   #, 'combinedSecondaryVertexV1BJetTags'                     : ['impactParameterTagInfos', 'secondaryVertexTagInfos']

--- a/PhysicsTools/PatAlgos/python/slimming/prunedGenParticles_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/prunedGenParticles_cfi.py
@@ -16,7 +16,7 @@ prunedGenParticles = cms.EDProducer("GenParticlePruner",
         "keep abs(pdgId) == 23 || abs(pdgId) == 24 || abs(pdgId) == 25 || abs(pdgId) == 6 || abs(pdgId) == 37 ",   # keep VIP(articles)s
         "keep abs(pdgId) == 310 && abs(eta) < 2.5 && pt > 1 ",                                                     # keep K0
 # keep heavy flavour quarks for parton-based jet flavour
-	"keep (4 <= abs(pdgId) = 5) & (status = 2 || status = 11 || status = 71 || status = 72)",
+	"keep (4 <= abs(pdgId) <= 5) & (status = 2 || status = 11 || status = 71 || status = 72)",
 # keep light-flavour quarks and gluons for parton-based jet flavour
 	"keep (1 <= abs(pdgId) <= 3 || pdgId = 21) & (status = 2 || status = 11 || status = 71 || status = 72) && pt>5", 
 # keep b and c hadrons for hadron-based jet flavour

--- a/PhysicsTools/PatAlgos/python/tools/jetTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/jetTools.py
@@ -31,6 +31,7 @@ class AddJetCollection(ConfigToolBase):
         self.addParameter(self._defaultParameters,'labelName', 'UNDEFINED', "Label name of the new patJet collection.", str)
         self.addParameter(self._defaultParameters,'postfix','', "Postfix from usePF2PAT.", str)
         self.addParameter(self._defaultParameters,'jetSource','', "Label of the input collection from which the new patJet collection should be created", cms.InputTag)
+        self.addParameter(self._defaultParameters,'pfCandidates',cms.InputTag('particleFlow'), "Label of the input collection for candidatecandidatese used in b-tagging", cms.InputTag)
         self.addParameter(self._defaultParameters,'trackSource',cms.InputTag('generalTracks'), "Label of the input collection for tracks to be used in b-tagging", cms.InputTag)
         self.addParameter(self._defaultParameters,'pvSource',cms.InputTag('offlinePrimaryVertices'), "Label of the input collection for primary vertices used in b-tagging", cms.InputTag)
         self.addParameter(self._defaultParameters,'svSource',cms.InputTag('inclusiveSecondaryVertices'), "Label of the input collection for IVF vertices used in b-tagging", cms.InputTag)
@@ -73,7 +74,7 @@ class AddJetCollection(ConfigToolBase):
         """
         return self._defaultParameters
 
-    def __call__(self,process,labelName=None,postfix=None,jetSource=None,trackSource=None,pvSource=None,svSource=None,algo=None,rParam=None,getJetMCFlavour=None,genJetCollection=None,jetCorrections=None,btagDiscriminators=None,btagInfos=None,jetTrackAssociation=None,outputModules=None):
+    def __call__(self,process,labelName=None,postfix=None,jetSource=None,trackSource=None,pfCandidates=None,pvSource=None,svSource=None,algo=None,rParam=None,getJetMCFlavour=None,genJetCollection=None,jetCorrections=None,btagDiscriminators=None,btagInfos=None,jetTrackAssociation=None,outputModules=None):
         """
         Function call wrapper. This will check the parameters and call the actual implementation that
         can be found in toolCode via the base class function apply.
@@ -90,6 +91,9 @@ class AddJetCollection(ConfigToolBase):
         if svSource is None:
             svSource=self._defaultParameters['svSource'].value
         self.setParameter('svSource', svSource)
+        if pfCandidates is None:
+            pfCandidates=self._defaultParameters['pfCandidates'].value
+        self.setParameter('pfCandidates', pfCandidates)
         if trackSource is None:
             trackSource=self._defaultParameters['trackSource'].value
         self.setParameter('trackSource', trackSource)
@@ -137,6 +141,7 @@ class AddJetCollection(ConfigToolBase):
         postfix=self._parameters['postfix'].value
         jetSource=self._parameters['jetSource'].value
         trackSource=self._parameters['trackSource'].value
+        pfCandidates=self._parameters['pfCandidates'].value
         pvSource=self._parameters['pvSource'].value
         svSource=self._parameters['svSource'].value
         algo=self._parameters['algo'].value
@@ -339,6 +344,10 @@ class AddJetCollection(ConfigToolBase):
             acceptedTagInfos = list()
             for btagInfo in requiredTagInfos:
                 if hasattr(btag,btagInfo):
+                    if btagInfo == 'pfImpactParameterTagInfos':
+                        setattr(process, btagInfo+_labelName+postfix, btag.pfImpactParameterTagInfos.clone(jets = jetSource,primaryVertex=pvSource,candidates=pfCandidates))
+                    if btagInfo == 'pfSecondaryVertexTagInfos':
+                        setattr(process, btagInfo+_labelName+postfix, btag.secondaryVertexTagInfos.clone(trackIPTagInfos = cms.InputTag('pfImpactParameterTagInfos'+_labelName+postfix)))
                     if btagInfo == 'impactParameterTagInfos':
                         setattr(process, btagInfo+_labelName+postfix, btag.impactParameterTagInfos.clone(jetTracks = cms.InputTag('jetTracksAssociatorAtVertex'+_labelName+postfix),primaryVertex=pvSource))
                     if btagInfo == 'secondaryVertexTagInfos':
@@ -550,6 +559,7 @@ class SwitchJetCollection(ConfigToolBase):
         ## add all parameters that should be known to the class
         self.addParameter(self._defaultParameters,'postfix','', "postfix from usePF2PAT")
         self.addParameter(self._defaultParameters,'jetSource','', "Label of the input collection from which the new patJet collection should be created", cms.InputTag)
+        self.addParameter(self._defaultParameters,'pfCandidates',cms.InputTag('particleFlow'), "Label of the input collection for candidatecandidatese used in b-tagging", cms.InputTag)
         self.addParameter(self._defaultParameters,'trackSource',cms.InputTag('generalTracks'), "Label of the input collection for tracks to be used in b-tagging", cms.InputTag)
         self.addParameter(self._defaultParameters,'pvSource',cms.InputTag('offlinePrimaryVertices'), "Label of the input collection for primary vertices used in b-tagging", cms.InputTag)
         self.addParameter(self._defaultParameters,'svSource',cms.InputTag('inclusiveSecondaryVertices'), "Label of the input collection for IVF vertices used in b-tagging", cms.InputTag)
@@ -589,7 +599,7 @@ class SwitchJetCollection(ConfigToolBase):
         """
         return self._defaultParameters
 
-    def __call__(self,process,postfix=None,jetSource=None,trackSource=None,pvSource=None,svSource=None,algo=None,rParam=None,getJetMCFlavour=None,genJetCollection=None,jetCorrections=None,btagDiscriminators=None,btagInfos=None,jetTrackAssociation=None,outputModules=None):
+    def __call__(self,process,postfix=None,jetSource=None,trackSource=None,pfCandidates=None,pvSource=None,svSource=None,algo=None,rParam=None,getJetMCFlavour=None,genJetCollection=None,jetCorrections=None,btagDiscriminators=None,btagInfos=None,jetTrackAssociation=None,outputModules=None):
         """
         Function call wrapper. This will check the parameters and call the actual implementation that
         can be found in toolCode via the base class function apply.
@@ -600,6 +610,9 @@ class SwitchJetCollection(ConfigToolBase):
         if jetSource is None:
             jetSource=self._defaultParameters['jetSource'].value
         self.setParameter('jetSource', jetSource)
+        if pfCandidates is None:
+            pfCandidates=self._defaultParameters['pfCandidates'].value
+        self.setParameter('pfCandidates', pfCandidates)
         if trackSource is None:
             trackSource=self._defaultParameters['trackSource'].value
         self.setParameter('trackSource', trackSource)
@@ -645,6 +658,7 @@ class SwitchJetCollection(ConfigToolBase):
         ## initialize parameters
         postfix=self._parameters['postfix'].value
         jetSource=self._parameters['jetSource'].value
+        pfCandidates=self._parameters['pfCandidates'].value
         trackSource=self._parameters['trackSource'].value
         pvSource=self._parameters['pvSource'].value
         svSource=self._parameters['svSource'].value
@@ -665,6 +679,7 @@ class SwitchJetCollection(ConfigToolBase):
             postfix=postfix,
             jetSource=jetSource,
             trackSource=trackSource,
+            pfCandidates=pfCandidates,
             pvSource=pvSource,
             svSource=svSource,
             algo=algo,

--- a/PhysicsTools/PatAlgos/python/tools/jetTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/jetTools.py
@@ -315,8 +315,6 @@ class AddJetCollection(ConfigToolBase):
             ## expand tagInfos to what is explicitely required by user + implicit
             ## requirements that come in from one or the other discriminator
             requiredTagInfos = list(btagInfos)
-            if len(requiredTagInfos) > 0 :
-                _newPatJets.addTagInfos = True
             for btagDiscr in btagDiscriminators :
                 for requiredTagInfo in supportedBtagDiscr[btagDiscr] :
                     tagInfoCovered = False
@@ -347,7 +345,7 @@ class AddJetCollection(ConfigToolBase):
                     if btagInfo == 'pfImpactParameterTagInfos':
                         setattr(process, btagInfo+_labelName+postfix, btag.pfImpactParameterTagInfos.clone(jets = jetSource,primaryVertex=pvSource,candidates=pfCandidates))
                     if btagInfo == 'pfSecondaryVertexTagInfos':
-                        setattr(process, btagInfo+_labelName+postfix, btag.secondaryVertexTagInfos.clone(trackIPTagInfos = cms.InputTag('pfImpactParameterTagInfos'+_labelName+postfix)))
+                        setattr(process, btagInfo+_labelName+postfix, btag.pfSecondaryVertexTagInfos.clone(trackIPTagInfos = cms.InputTag('pfImpactParameterTagInfos'+_labelName+postfix)))
                     if btagInfo == 'impactParameterTagInfos':
                         setattr(process, btagInfo+_labelName+postfix, btag.impactParameterTagInfos.clone(jetTracks = cms.InputTag('jetTracksAssociatorAtVertex'+_labelName+postfix),primaryVertex=pvSource))
                     if btagInfo == 'secondaryVertexTagInfos':
@@ -380,6 +378,8 @@ class AddJetCollection(ConfigToolBase):
             ## replace corresponding tags for pat jet production
             _newPatJets.tagInfoSources = cms.VInputTag( *[ cms.InputTag(x+_labelName+postfix) for x in acceptedTagInfos ] )
             _newPatJets.discriminatorSources = cms.VInputTag( *[ cms.InputTag(x+_labelName+postfix) for x in acceptedBtagDiscriminators ] )
+            if len(acceptedBtagDiscriminators) > 0 :
+                _newPatJets.addBTagInfo = True
             if 'inclusiveSecondaryVertexFinderTagInfos' in acceptedTagInfos:
                 if not hasattr( process, 'inclusiveVertexing' ):
                     process.load( 'RecoVertex.AdaptiveVertexFinder.inclusiveVertexing_cff' )
@@ -391,10 +391,12 @@ class AddJetCollection(ConfigToolBase):
                 if not hasattr( process, 'bToCharmDecayVertexMerged' ):
                     process.load( 'RecoBTag.SecondaryVertex.bToCharmDecayVertexMerger_cfi' )
             if 'caTopTagInfos' in acceptedTagInfos :
+                _newPatJets.addTagInfos = True
                 if not hasattr( process, 'caTopTagInfos' ):
                     process.load( 'RecoJets.JetProducers.CATopTagInfos_cff' )
         else:
             _newPatJets.addBTagInfo = False
+            _newPatJets.addTagInfos = False
             ## adjust output module; these collections will be empty anyhow, but we do it to stay clean
             for outputModule in outputModules:
                     if hasattr(process,outputModule):

--- a/PhysicsTools/PatAlgos/test/miniAOD/example_ei.py
+++ b/PhysicsTools/PatAlgos/test/miniAOD/example_ei.py
@@ -6,8 +6,8 @@ process.source = cms.Source("PoolSource",
 )
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(100) )
 
-from RecoJets.JetProducers.ak5PFJets_cfi import ak5PFJets
-from RecoJets.JetProducers.ak5GenJets_cfi import ak5GenJets
+from RecoJets.JetProducers.ak4PFJets_cfi import ak4PFJets
+from RecoJets.JetProducers.ak4GenJets_cfi import ak4GenJets
 from RecoMET.METProducers.PFMET_cfi import pfMet
 
 #select isolated collections
@@ -35,9 +35,9 @@ process.pfNoElectrons = cms.EDProducer("CandPtrProjector", src = cms.InputTag("p
 
 
 
-process.ak5PFJets = ak5PFJets.clone(src = 'pfNoElectrons', doAreaFastjet = True) # no idea while doArea is false by default, but it's True in RECO so we have to set it
-process.ak5PFJetsCHS = ak5PFJets.clone(src = 'pfNoElectronsCHS', doAreaFastjet = True) # no idea while doArea is false by default, but it's True in RECO so we have to set it
-process.ak5GenJets = ak5GenJets.clone(src = 'packedGenParticles')
+process.ak4PFJets = ak4PFJets.clone(src = 'pfNoElectrons', doAreaFastjet = True) # no idea while doArea is false by default, but it's True in RECO so we have to set it
+process.ak4PFJetsCHS = ak4PFJets.clone(src = 'pfNoElectronsCHS', doAreaFastjet = True) # no idea while doArea is false by default, but it's True in RECO so we have to set it
+process.ak4GenJets = ak4GenJets.clone(src = 'packedGenParticles')
 
 
 # The following is make patJets, but EI is done with the above
@@ -54,23 +54,25 @@ addJetCollection(
    process,
    postfix   = "",
    labelName = 'AK4PFCHS',
-   jetSource = cms.InputTag('ak5PFJetsCHS'),
+   jetSource = cms.InputTag('ak4PFJetsCHS'),
    trackSource = cms.InputTag('unpackedTracksAndVertices'), 
    pfCandidates = cms.InputTag('packedPFCandidates'), 
    pvSource = cms.InputTag('unpackedTracksAndVertices'), 
    jetCorrections = ('AK4PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'Type-2'),
-   btagDiscriminators = [      'pfCombinedSecondaryVertexBJetTags'     ]
+   btagDiscriminators = [      'pfCombinedSecondaryVertexBJetTags'     ],
+   genJetCollection=cms.InputTag('ak4GenJets')
    )
 addJetCollection(
    process,
    postfix   = "",
    labelName = 'AK4PF',
-   jetSource = cms.InputTag('ak5PFJets'),
+   jetSource = cms.InputTag('ak4PFJets'),
    trackSource = cms.InputTag('unpackedTracksAndVertices'),
    pfCandidates = cms.InputTag('packedPFCandidates'), 
    pvSource = cms.InputTag('unpackedTracksAndVertices'), 
    jetCorrections = ('AK4PF', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'Type-2'),
-   btagDiscriminators = [      'pfCombinedSecondaryVertexBJetTags'     ]
+   btagDiscriminators = [      'pfCombinedSecondaryVertexBJetTags'     ],
+   genJetCollection=cms.InputTag('ak4GenJets')
    )
 
 #adjust MC matching

--- a/PhysicsTools/PatAlgos/test/miniAOD/example_ei.py
+++ b/PhysicsTools/PatAlgos/test/miniAOD/example_ei.py
@@ -46,41 +46,45 @@ process.load("Configuration.EventContent.EventContent_cff")
 process.load('Configuration.StandardSequences.Geometry_cff')
 process.load('Configuration.StandardSequences.MagneticField_38T_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
-process.GlobalTag.globaltag = 'START70_V6::All'
+process.GlobalTag.globaltag =  'POSTLS172_V3::All'
 
 
 from PhysicsTools.PatAlgos.tools.jetTools import addJetCollection
 addJetCollection(
    process,
    postfix   = "",
-   labelName = 'AK5PFCHS',
+   labelName = 'AK4PFCHS',
    jetSource = cms.InputTag('ak5PFJetsCHS'),
    trackSource = cms.InputTag('unpackedTracksAndVertices'), 
+   pfCandidates = cms.InputTag('packedPFCandidates'), 
    pvSource = cms.InputTag('unpackedTracksAndVertices'), 
-   jetCorrections = ('AK5PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'Type-2'),
-   btagDiscriminators = [      'combinedSecondaryVertexBJetTags'     ]
+   jetCorrections = ('AK4PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'Type-2'),
+   btagDiscriminators = [      'pfCombinedSecondaryVertexBJetTags'     ]
    )
 addJetCollection(
    process,
    postfix   = "",
-   labelName = 'AK5PF',
+   labelName = 'AK4PF',
    jetSource = cms.InputTag('ak5PFJets'),
    trackSource = cms.InputTag('unpackedTracksAndVertices'),
+   pfCandidates = cms.InputTag('packedPFCandidates'), 
    pvSource = cms.InputTag('unpackedTracksAndVertices'), 
-   jetCorrections = ('AK5PF', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'Type-2'),
-   btagDiscriminators = [      'combinedSecondaryVertexBJetTags'     ]
+   jetCorrections = ('AK4PF', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'Type-2'),
+   btagDiscriminators = [      'pfCombinedSecondaryVertexBJetTags'     ]
    )
 
 #adjust MC matching
-process.patJetPartonMatchPatJetsAK5PFCHS.matched = "prunedGenParticles"
-process.patJetPartonMatchPatJetsAK5PF.matched = "prunedGenParticles"
-process.patJetPartons.src = "prunedGenParticles"
+process.patJetGenJetMatchAK4PF.matched = "slimmedGenJets"
+process.patJetGenJetMatchAK4PFCHS.matched = "slimmedGenJets"
+process.patJetPartonMatchAK4PFCHS.matched = "prunedGenParticles"
+process.patJetPartonMatchAK4PF.matched = "prunedGenParticles"
+process.patJetPartons.particles  = "prunedGenParticles"
 process.patJetPartons.skipFirstN = cms.uint32(0) # do not skip first 6 particles, we already pruned some!
 process.patJetPartons.acceptNoDaughters = cms.bool(True) # as we drop intermediate stuff, we need to accept quarks with no siblings
 
 #adjust PV
-process.patJetCorrFactorsPatJetsAK5PFCHS.primaryVertices = "offlineSlimmedPrimaryVertices"
-process.patJetCorrFactorsPatJetsAK5PF.primaryVertices = "offlineSlimmedPrimaryVertices"
+process.patJetCorrFactorsAK4PFCHS.primaryVertices = "offlineSlimmedPrimaryVertices"
+process.patJetCorrFactorsAK4PF.primaryVertices = "offlineSlimmedPrimaryVertices"
 
 #recreate tracks and pv for btagging
 process.load('PhysicsTools.PatAlgos.slimming.unpackedTracksAndVertices_cfi')
@@ -95,7 +99,7 @@ process.options.allowUnscheduled = cms.untracked.bool(True)
 
 process.OUT = cms.OutputModule("PoolOutputModule",
     fileName = cms.untracked.string('test.root'),
-    outputCommands = cms.untracked.vstring(['drop *','keep patJets_patJetsAK5PF_*_*','keep patJets_patJetsAK5PFCHS_*_*','keep *_*_*_PAT'])
+    outputCommands = cms.untracked.vstring(['drop *','keep patJets_patJetsAK4PF_*_*','keep patJets_patJetsAK4PFCHS_*_*','keep *_*_*_PAT'])
 )
 process.endpath= cms.EndPath(process.OUT)
 

--- a/RecoBTag/Configuration/python/RecoBTag_EventContent_cff.py
+++ b/RecoBTag/Configuration/python/RecoBTag_EventContent_cff.py
@@ -24,6 +24,9 @@ RecoBTagFEVT = cms.PSet(
         'keep *_softMuonBJetTags_*_*',
         'keep *_softMuonByIP3dBJetTags_*_*',
         'keep *_softMuonByPtBJetTags_*_*',
+	'keep *_pfImpactParameterTagInfos_*_*',
+	'keep *_pfSecondaryVertexTagInfos_*_*',
+	'keep *_pfCombinedSecondaryVertexBJetTags_*_*'
     )
 )
 #RECO content
@@ -50,6 +53,9 @@ RecoBTagRECO = cms.PSet(
         'keep *_softMuonBJetTags_*_*',
         'keep *_softMuonByIP3dBJetTags_*_*',
         'keep *_softMuonByPtBJetTags_*_*',
+	'keep *_pfImpactParameterTagInfos_*_*',
+	'keep *_pfSecondaryVertexTagInfos_*_*',
+	'keep *_pfCombinedSecondaryVertexBJetTags_*_*'
     )
 )
 #AOD content
@@ -78,5 +84,6 @@ RecoBTagAOD = cms.PSet(
         'keep *_softMuonBJetTags_*_*',
         'keep *_softMuonByIP3dBJetTags_*_*',
         'keep *_softMuonByPtBJetTags_*_*',
+	'keep *_pfCombinedSecondaryVertexBJetTags_*_*'
     )
 )

--- a/RecoBTag/Configuration/python/RecoBTag_cff.py
+++ b/RecoBTag/Configuration/python/RecoBTag_cff.py
@@ -31,8 +31,13 @@ btagging = cms.Sequence(
 	softPFMuonBJetTags *
 	softPFElectronsTagInfos*
 	softPFElectronBJetTags
-        
+        *
 
+#new candidate model, with PF inputs	
+	pfImpactParameterTagInfos *
+	pfSecondaryVertexTagInfos *
+	pfCombinedSecondaryVertexBJetTags
+	
     )
 
     # overall combined taggers

--- a/RecoBTag/ImpactParameter/plugins/IPProducer.h
+++ b/RecoBTag/ImpactParameter/plugins/IPProducer.h
@@ -106,7 +106,7 @@ namespace IPProducerHelpers {
                                       bases.push_back(jRef);
 				      //FIXME: add deltaR or any other requirement here
 				      for(size_t j=0;j<cands->size();j++) {
-					      if((*cands)[j].bestTrack()!=0 &&  ROOT::Math::VectorUtil::DeltaR((*cands)[j].p4(),(*jets)[i].p4()) < maxDeltaR){
+					      if((*cands)[j].bestTrack()!=0 &&  ROOT::Math::VectorUtil::DeltaR((*cands)[j].p4(),(*jets)[i].p4()) < maxDeltaR && (*cands)[j].charge() !=0 ){
 						      m_map[i].push_back(cands->ptrAt(j));	
 					      }
 				      }

--- a/RecoBTag/ImpactParameter/python/impactParameter_cff.py
+++ b/RecoBTag/ImpactParameter/python/impactParameter_cff.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from TrackingTools.TransientTrack.TransientTrackBuilder_cfi import *
 from RecoBTag.ImpactParameter.impactParameter_cfi import *
+from RecoBTag.ImpactParameter.pfImpactParameter_cfi import *
 #tmp fix, use fake/frontier
 #include "RecoBTag/Configuration/data/RecoBTag_FakeConditions.cff"
 from RecoBTau.JetTagComputer.jetTagRecord_cfi import *

--- a/RecoBTag/ImpactParameter/python/pfImpactParameter_cfi.py
+++ b/RecoBTag/ImpactParameter/python/pfImpactParameter_cfi.py
@@ -1,0 +1,21 @@
+import FWCore.ParameterSet.Config as cms
+pfImpactParameterTagInfos = cms.EDProducer("CandIPProducer",
+    maximumTransverseImpactParameter = cms.double(0.2),
+    minimumNumberOfHits = cms.int32(8),
+    minimumTransverseMomentum = cms.double(1.0),
+    primaryVertex = cms.InputTag("offlinePrimaryVertices"),
+    maximumLongitudinalImpactParameter = cms.double(17.0),
+    computeProbabilities = cms.bool(True),
+    ghostTrackPriorDeltaR = cms.double(0.03),
+    maxDeltaR= cms.double(0.5),
+    jetDirectionUsingGhostTrack = cms.bool(False),
+    minimumNumberOfPixelHits = cms.int32(2),
+    jetDirectionUsingTracks = cms.bool(False),
+    computeGhostTrack = cms.bool(True),
+    useTrackQuality = cms.bool(False),
+    maximumChiSquared = cms.double(5.0),
+#this is candidate specific
+    jets = cms.InputTag("ak4PFJets"),
+    candidates = cms.InputTag("particleFlow"),
+
+)

--- a/RecoBTag/ImpactParameter/python/pfImpactParameter_cfi.py
+++ b/RecoBTag/ImpactParameter/python/pfImpactParameter_cfi.py
@@ -7,7 +7,6 @@ pfImpactParameterTagInfos = cms.EDProducer("CandIPProducer",
     maximumLongitudinalImpactParameter = cms.double(17.0),
     computeProbabilities = cms.bool(True),
     ghostTrackPriorDeltaR = cms.double(0.03),
-    maxDeltaR= cms.double(0.5),
     jetDirectionUsingGhostTrack = cms.bool(False),
     minimumNumberOfPixelHits = cms.int32(2),
     jetDirectionUsingTracks = cms.bool(False),
@@ -17,5 +16,6 @@ pfImpactParameterTagInfos = cms.EDProducer("CandIPProducer",
 #this is candidate specific
     jets = cms.InputTag("ak4PFJets"),
     candidates = cms.InputTag("particleFlow"),
+    maxDeltaR= cms.double(0.4),
 
 )

--- a/RecoBTag/SecondaryVertex/python/candidateCombinedSecondaryVertexES_cfi.py
+++ b/RecoBTag/SecondaryVertex/python/candidateCombinedSecondaryVertexES_cfi.py
@@ -1,0 +1,33 @@
+import FWCore.ParameterSet.Config as cms
+
+from RecoBTag.SecondaryVertex.combinedSecondaryVertexCommon_cfi import *
+candidateCombinedSecondaryVertex = cms.ESProducer("CandidateCombinedSecondaryVertexESProducer",
+        combinedSecondaryVertexCommon,
+        useCategories = cms.bool(True),
+        calibrationRecords = cms.vstring(
+                'CombinedSVRecoVertex',
+                'CombinedSVPseudoVertex',
+                'CombinedSVNoVertex'),
+        categoryVariableName = cms.string('vertexCategory')
+)
+
+
+#combinedSecondaryVertexV1 = cms.ESProducer("CombinedSecondaryVertexESProducer",
+#	combinedSecondaryVertexCommon,
+#	useCategories = cms.bool(True),
+#	calibrationRecords = cms.vstring(
+#		'CombinedSVRetrainRecoVertex', 
+#		'CombinedSVRetrainPseudoVertex', 
+#		'CombinedSVRetrainNoVertex'),
+#	categoryVariableName = cms.string('vertexCategory')
+#)
+
+#combinedSecondaryVertexV2 = cms.ESProducer("CombinedSecondaryVertexESProducerV2",
+#	combinedSecondaryVertexCommon,
+#	useCategories = cms.bool(True),
+#	calibrationRecords = cms.vstring(
+#		'CombinedSVIVFV2RecoVertex', 
+#		'CombinedSVIVFV2PseudoVertex', 
+#		'CombinedSVIVFV2NoVertex'),
+#	categoryVariableName = cms.string('vertexCategory')
+#)

--- a/RecoBTag/SecondaryVertex/python/pfCombinedSecondaryVertexBJetTags_cfi.py
+++ b/RecoBTag/SecondaryVertex/python/pfCombinedSecondaryVertexBJetTags_cfi.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+from RecoBTag.SecondaryVertex.combinedSecondaryVertexBJetTags_cfi import *
+pfCombinedSecondaryVertexBJetTags = combinedSecondaryVertexBJetTags.clone(
+    jetTagComputer = cms.string('candidateCombinedSecondaryVertex'),
+    tagInfos = cms.VInputTag(cms.InputTag("pfImpactParameterTagInfos"), cms.InputTag("pfSecondaryVertexTagInfos"))
+)
+
+#add V1 and V2

--- a/RecoBTag/SecondaryVertex/python/pfSecondaryVertexTagInfos_cfi.py
+++ b/RecoBTag/SecondaryVertex/python/pfSecondaryVertexTagInfos_cfi.py
@@ -1,0 +1,23 @@
+import FWCore.ParameterSet.Config as cms
+
+from RecoBTag.SecondaryVertex.vertexTrackSelection_cfi import *
+from RecoBTag.SecondaryVertex.vertexReco_cfi import *
+from RecoBTag.SecondaryVertex.vertexCuts_cfi import *
+from RecoBTag.SecondaryVertex.vertexSelection_cfi import *
+
+pfSecondaryVertexTagInfos = cms.EDProducer("CandSecondaryVertexProducer",
+	vertexTrackSelectionBlock,
+	vertexSelectionBlock,
+	vertexCutsBlock,
+	vertexRecoBlock,
+	constraint = cms.string("BeamSpot"),
+	trackIPTagInfos = cms.InputTag("pfImpactParameterTagInfos"),
+	minimumTrackWeight = cms.double(0.5),
+	usePVError = cms.bool(True),
+	trackSort = cms.string('sip3dSig'),
+        beamSpotTag = cms.InputTag('offlineBeamSpot'),                                        
+        useExternalSV       = cms.bool(False),
+        extSVCollection     = cms.InputTag('secondaryVertices'),
+        extSVDeltaRToJet    = cms.double(0.3)
+
+)

--- a/RecoBTag/SecondaryVertex/python/secondaryVertex_cff.py
+++ b/RecoBTag/SecondaryVertex/python/secondaryVertex_cff.py
@@ -43,6 +43,12 @@ from RecoBTag.SecondaryVertex.combinedSecondaryVertexPositiveES_cfi import *
 from RecoBTag.SecondaryVertex.combinedSecondaryVertexPositiveBJetTags_cfi import *
 from RecoBTag.SecondaryVertex.combinedInclusiveSecondaryVertexPositiveBJetTags_cfi import *
 
+
+# New candidate based fwk
+from RecoBTag.SecondaryVertex.candidateCombinedSecondaryVertexES_cfi import *
+from RecoBTag.SecondaryVertex.pfSecondaryVertexTagInfos_cfi import *
+from RecoBTag.SecondaryVertex.pfCombinedSecondaryVertexBJetTags_cfi import *
+
 # Backwards compatibility
 
 simpleSecondaryVertexBJetTags = simpleSecondaryVertexHighEffBJetTags.clone()

--- a/RecoBTag/SecondaryVertex/src/VertexFilter.cc
+++ b/RecoBTag/SecondaryVertex/src/VertexFilter.cc
@@ -49,8 +49,12 @@ computeSharedTracks(const Vertex &pv, const std::vector<CandidatePtr> &svTracks,
         unsigned int count = 0;
         for(std::vector<CandidatePtr>::const_iterator iter = svTracks.begin();
             iter != svTracks.end(); iter++)
-                count += pvTracks.count((*iter)->bestTrack());
-
+               {
+			if( std::abs((*iter)->bestTrack()->dz()-pv.z())/(*iter)->bestTrack()->dzError() < 2.0 &&
+			    std::abs((*iter)->bestTrack()->dxy(pv.position())/(*iter)->bestTrack()->dxyError() < 2.0 )
+				count++;
+			  )  
+		}
         return count;
 }
 

--- a/RecoBTag/SecondaryVertex/src/VertexFilter.cc
+++ b/RecoBTag/SecondaryVertex/src/VertexFilter.cc
@@ -40,11 +40,11 @@ static unsigned int
 computeSharedTracks(const Vertex &pv, const std::vector<CandidatePtr> &svTracks,
                     double minTrackWeight)
 {
-        std::set<const Track *> pvTracks;
-        for(std::vector<TrackBaseRef>::const_iterator iter = pv.tracks_begin();
-            iter != pv.tracks_end(); iter++)
-                if (pv.trackWeight(*iter) >= minTrackWeight)
-                        pvTracks.insert(iter->get());
+//         std::set<const Track *> pvTracks;
+//         for(std::vector<TrackBaseRef>::const_iterator iter = pv.tracks_begin();
+//             iter != pv.tracks_end(); iter++)
+//                 if (pv.trackWeight(*iter) >= minTrackWeight)
+//                         pvTracks.insert(iter->get());
 
         unsigned int count = 0;
         for(std::vector<CandidatePtr>::const_iterator iter = svTracks.begin();

--- a/RecoBTag/SecondaryVertex/src/VertexFilter.cc
+++ b/RecoBTag/SecondaryVertex/src/VertexFilter.cc
@@ -52,8 +52,8 @@ computeSharedTracks(const Vertex &pv, const std::vector<CandidatePtr> &svTracks,
                {
 			if( std::abs((*iter)->bestTrack()->dz()-pv.z())/(*iter)->bestTrack()->dzError() < 2.0 &&
 			    std::abs((*iter)->bestTrack()->dxy(pv.position())/(*iter)->bestTrack()->dxyError() < 2.0 )
-				count++;
 			  )  
+				count++;
 		}
         return count;
 }


### PR DESCRIPTION
This PR runs one candidate based tagging (exploiting the new fwk) in RECO.
The corresponding code in jetTools.py (and related PAT stuff) is also added.

@ferencek @pvmulder
