### PR TITLE
Fix clang compiler error by explicitly calling default constructor

### DIFF
--- a/Geometry/CommonDetUnit/src/GeomDet.cc
+++ b/Geometry/CommonDetUnit/src/GeomDet.cc
@@ -73,13 +73,13 @@ struct DummyTopology final : public Topology {
   measurementError( const LocalPoint&, const LocalError& ) const { return MeasurementError();}
   virtual int channel( const LocalPoint& p) const { return -1;}
 };
-const DummyTopology dummyTopology;
+  const DummyTopology dummyTopology{};
 
 struct DummyGeomDetType final : public GeomDetType {
    DummyGeomDetType() : GeomDetType("", GeomDetEnumerators::invalidDet){}
    const Topology& topology() const { return dummyTopology;}
 };
-const DummyGeomDetType dummyGeomDetType;
+  const DummyGeomDetType dummyGeomDetType{};
 }
 
 


### PR DESCRIPTION
The clang compiler wanted an explicit call to the default constructor
for the file scoped statics.
