### PR TITLE
Comment Out "cout"

### DIFF
--- a/L1Trigger/RegionalCaloTrigger/src/L1RCTLookupTables.cc
+++ b/L1Trigger/RegionalCaloTrigger/src/L1RCTLookupTables.cc
@@ -194,7 +194,7 @@ unsigned int L1RCTLookupTables::lookup(unsigned short hfInput,
       et = 0;
     }
 
-  cout << (int) rctParameters_->jetMETHCalScaleFactors()[iAbsEta-1] << endl;
+  //cout << (int) rctParameters_->jetMETHCalScaleFactors()[iAbsEta-1] << endl;
 
   float scalehf = 1.;
   if(rctParameters_->jetMETHCalScaleFactors().size()==32){


### PR DESCRIPTION
I recently submitted PR #5047. There was a request made by @ktf to get rid of a `cout`. The line was commented out so that it could be easily added back if needed for debugging.
