### PR TITLE
Adapt to ROOT6 interface changes by adding or removing const qualifiers

### DIFF
--- a/DQM/Physics/src/QcdLowPtDQM.cc
+++ b/DQM/Physics/src/QcdLowPtDQM.cc
@@ -1053,7 +1053,7 @@ void QcdLowPtDQM::fillTracklets(const std::vector<Tracklet> &tracklets,
   }
 
   // fill tracklet based info
-  TAxis *xa = AlphaTracklets->GetXaxis();
+  const TAxis *xa = AlphaTracklets->GetXaxis();
   int ybin  = AlphaTracklets->GetYaxis()->FindFixBin(pixels.size());
   int zbin  = AlphaTracklets->GetZaxis()->FindFixBin(trackletV.z());
   int tbin  = AlphaTracklets->GetBin(0,ybin,zbin);

--- a/ElectroWeakAnalysis/ZMuMu/plugins/ZMuMuIsolationAnalyzer.cc
+++ b/ElectroWeakAnalysis/ZMuMu/plugins/ZMuMuIsolationAnalyzer.cc
@@ -62,7 +62,7 @@ private:
   template<typename T>
   MuTag muTag(const T & mu) const;
   void Deposits(const pat::IsoDeposit* isodep, double dR_max,  TH1F* hist);
-  void histo(const TH1F* hist, const char* cx, const char* cy) const;
+  void histo(TH1F* hist, const char* cx, const char* cy) const;
 };
 
 template<typename T>
@@ -114,7 +114,7 @@ void ZMuMuIsolationAnalyzer::Deposits(const pat::IsoDeposit* isodep,double dR_ma
   }
 }
 
-void ZMuMuIsolationAnalyzer::histo(const TH1F* hist, const char* cx, const char*cy) const{
+void ZMuMuIsolationAnalyzer::histo(TH1F* hist, const char* cx, const char*cy) const{
   hist->GetXaxis()->SetTitle(cx);
   hist->GetYaxis()->SetTitle(cy);
   hist->GetXaxis()->SetTitleOffset(1);

--- a/ElectroWeakAnalysis/ZMuMu/plugins/ZMuMuSaMassHistogram.cc
+++ b/ElectroWeakAnalysis/ZMuMu/plugins/ZMuMuSaMassHistogram.cc
@@ -46,10 +46,10 @@ private:
   double min, max;
   int Nbin;
   TH1F * ZMassSa;
-  void histo(const TH1F* hist, char* cx, char* cy) const;
+  void histo(TH1F* hist, char* cx, char* cy) const;
 };
 
-void ZMuMuSaMassHistogram::histo(const TH1F* hist,char* cx, char*cy) const{
+void ZMuMuSaMassHistogram::histo(TH1F* hist,char* cx, char*cy) const{
   hist->GetXaxis()->SetTitle(cx);
   hist->GetYaxis()->SetTitle(cy);
   hist->GetXaxis()->SetTitleOffset(1);


### PR DESCRIPTION
This pull request fixes the compilation errors in two packages due to a recent change in the ROOT6 API.
All it does is add or remove const qualifiers as needed for the packages to compile.
Please merge as soon as convenient.
