### PR TITLE
fix for number of secondary vertex tracks in case IVF vertices are used

### DIFF
--- a/RecoBTag/SecondaryVertex/src/CombinedSVComputer.cc
+++ b/RecoBTag/SecondaryVertex/src/CombinedSVComputer.cc
@@ -172,10 +172,8 @@ CombinedSVComputer::operator () (const TrackIPTagInfo &ipInfo,
 
 		const Vertex &vertex = svInfo.secondaryVertex(i);
 		bool hasRefittedTracks = vertex.hasRefittedTracks();
-		TrackRefVector tracks = svInfo.vertexTracks(i);
-		for(TrackRefVector::const_iterator track = tracks.begin();
-		    track != tracks.end(); track++) {
-			double w = svInfo.trackWeight(i, *track);
+		for(reco::Vertex::trackRef_iterator track = vertex.tracks_begin(); track != vertex.tracks_end(); track++) {
+			double w = vertex.trackWeight(*track);			
 			if (w < minTrackWeight)
 				continue;
 			if (hasRefittedTracks) {

--- a/RecoBTag/SecondaryVertex/src/CombinedSVComputerV2.cc
+++ b/RecoBTag/SecondaryVertex/src/CombinedSVComputerV2.cc
@@ -184,9 +184,8 @@ CombinedSVComputerV2::operator () (const TrackIPTagInfo &ipInfo,
 			
 		const Vertex &vertex = svInfo.secondaryVertex(i);
 		bool hasRefittedTracks = vertex.hasRefittedTracks();
-		TrackRefVector tracks = svInfo.vertexTracks(i);
-		for(TrackRefVector::const_iterator track = tracks.begin(); track != tracks.end(); track++) {
-			double w = svInfo.trackWeight(i, *track);
+		for(reco::Vertex::trackRef_iterator track = vertex.tracks_begin(); track != vertex.tracks_end(); track++) {
+			double w = vertex.trackWeight(*track);			
 			if (w < minTrackWeight)
 				continue;
 			if (hasRefittedTracks) {

--- a/RecoBTag/SecondaryVertex/src/CombinedSVSoftLeptonComputer.cc
+++ b/RecoBTag/SecondaryVertex/src/CombinedSVSoftLeptonComputer.cc
@@ -190,9 +190,8 @@ CombinedSVSoftLeptonComputer::operator () (const TrackIPTagInfo &ipInfo,
 			
 		const Vertex &vertex = svInfo.secondaryVertex(i);
 		bool hasRefittedTracks = vertex.hasRefittedTracks();
-		TrackRefVector tracks = svInfo.vertexTracks(i);
-		for(TrackRefVector::const_iterator track = tracks.begin(); track != tracks.end(); track++) {
-			double w = svInfo.trackWeight(i, *track);
+		for(reco::Vertex::trackRef_iterator track = vertex.tracks_begin(); track != vertex.tracks_end(); track++) {
+			double w = vertex.trackWeight(*track);			
 			if (w < minTrackWeight)
 				continue;
 			if (hasRefittedTracks) {


### PR DESCRIPTION
This fix does not affect the any b-tagger in the RECO sequence, it only affects the performance when IVF is used and even in that case the performance is very similar, as can be seen in the figure.
![performance_clean](https://cloud.githubusercontent.com/assets/5425769/4075262/2acb4102-2ead-11e4-994f-8a1ee79a0605.png)
