### PR TITLE
Add missing dictionary

### DIFF
--- a/SimDataFormats/GeneratorProducts/src/classes_def.xml
+++ b/SimDataFormats/GeneratorProducts/src/classes_def.xml
@@ -145,6 +145,9 @@
 	<class name="GenLumiInfoProduct::ProcessInfo" ClassVersion="10">
 	  <version ClassVersion="10" checksum="621228037"/>
 	</class>
+	<class name="std::vector<GenLumiInfoProduct::ProcessInfo>" ClassVersion="10">
+	  <version ClassVersion="10" checksum="999999999"/>
+	</class>
 	<class name="edm::Wrapper&lt;GenLumiInfoProduct&gt;"/>
 
 	<!-- GenEventInfoProduct -->


### PR DESCRIPTION
Add a missing dictionary for std::vectorGenLumiInfoProduct::ProcessInfo.  This fixes many failing relval tests.  The checksum is a placeholder, as edmCheckClassVersion is temporarily disabled in ROOT6.
Please merge as soon as convenient.
