### PR TITLE
Add a few new strip recHit validation histograms

### DIFF
--- a/Validation/TrackerRecHits/interface/SiStripRecHitsValid.h
+++ b/Validation/TrackerRecHits/interface/SiStripRecHitsValid.h
@@ -61,8 +61,14 @@ class SiStripRecHitsValid : public DQMEDAnalyzer {
  
   struct SubDetMEs{ // MEs for Subdetector Level
     MonitorElement*  meNumrphi;
+    MonitorElement*  meBunchrphi;
+    MonitorElement*  meEventrphi;
     MonitorElement*  meNumStereo;
+    MonitorElement*  meBunchStereo;
+    MonitorElement*  meEventStereo;
     MonitorElement*  meNumMatched;
+    MonitorElement*  meBunchMatched;
+    MonitorElement*  meEventMatched;
   };
 
   struct LayerMEs{ // MEs for Layer Level
@@ -74,6 +80,7 @@ class SiStripRecHitsValid : public DQMEDAnalyzer {
     MonitorElement* mePullLFrphi;
     MonitorElement* mePullMFrphi;
     MonitorElement* meChi2rphi;
+    MonitorElement* meNsimHitrphi;
     
   };
 
@@ -86,6 +93,7 @@ class SiStripRecHitsValid : public DQMEDAnalyzer {
     MonitorElement* mePullLFStereo;
     MonitorElement* mePullMFStereo;
     MonitorElement* meChi2Stereo;
+    MonitorElement* meNsimHitStereo;
     MonitorElement* mePosxMatched;
     MonitorElement* mePosyMatched;
     MonitorElement* meResolxMatched;
@@ -93,6 +101,7 @@ class SiStripRecHitsValid : public DQMEDAnalyzer {
     MonitorElement* meResxMatched;
     MonitorElement* meResyMatched;
     MonitorElement* meChi2Matched;
+    MonitorElement* meNsimHitMatched;
 
   };
 
@@ -109,6 +118,9 @@ class SiStripRecHitsValid : public DQMEDAnalyzer {
     int clusiz;
     float cluchg;
     float chi2;
+    int NsimHit;
+    int bunch;
+    int event;
   };
 
 
@@ -128,8 +140,14 @@ class SiStripRecHitsValid : public DQMEDAnalyzer {
 
 
   bool switchNumrphi;
+  bool switchBunchrphi;
+  bool switchEventrphi;
   bool switchNumStereo;
+  bool switchBunchStereo;
+  bool switchEventStereo;
   bool switchNumMatched;
+  bool switchBunchMatched;
+  bool switchEventMatched;
 
 
   bool switchWclusrphi;
@@ -140,6 +158,7 @@ class SiStripRecHitsValid : public DQMEDAnalyzer {
   bool switchPullLFrphi;
   bool switchPullMFrphi;
   bool switchChi2rphi;
+  bool switchNsimHitrphi;
   bool switchWclusStereo;
   bool switchAdcStereo;
   bool switchPosxStereo;
@@ -148,6 +167,7 @@ class SiStripRecHitsValid : public DQMEDAnalyzer {
   bool switchPullLFStereo;
   bool switchPullMFStereo;
   bool switchChi2Stereo;
+  bool switchNsimHitStereo;
   bool switchPosxMatched;
   bool switchPosyMatched;
   bool switchResolxMatched;
@@ -155,6 +175,7 @@ class SiStripRecHitsValid : public DQMEDAnalyzer {
   bool switchResxMatched;
   bool switchResyMatched;
   bool switchChi2Matched;
+  bool switchNsimHitMatched;
   
   std::string topFolderName_;
   std::vector<std::string> SubDetList_;

--- a/Validation/TrackerRecHits/python/SiStripRecHitsValid_cfi.py
+++ b/Validation/TrackerRecHits/python/SiStripRecHitsValid_cfi.py
@@ -33,6 +33,20 @@ stripRecHitsValid = cms.EDAnalyzer("SiStripRecHitsValid",
 
     ),
 
+  TH1Bunchrphi = cms.PSet( 
+        Nbinx          = cms.int32(20),
+        xmin           = cms.double(-10.),
+        xmax           = cms.double(10.),
+        switchon  = cms.bool(True)
+    ),
+
+  TH1Eventrphi = cms.PSet( 
+        Nbinx          = cms.int32(100),
+        xmin           = cms.double(0.),
+        xmax           = cms.double(100.),
+        switchon  = cms.bool(True)
+    ),
+
   TH1NumStereo = cms.PSet(
         Nbinx          = cms.int32(100),
         xmin           = cms.double(0.),
@@ -41,12 +55,40 @@ stripRecHitsValid = cms.EDAnalyzer("SiStripRecHitsValid",
 
     ),
 
+    TH1BunchStereo = cms.PSet( 
+        Nbinx          = cms.int32(20),
+        xmin           = cms.double(-10.),
+        xmax           = cms.double(10.),
+        switchon  = cms.bool(True)
+    ),
+
+    TH1EventStereo = cms.PSet( 
+        Nbinx          = cms.int32(100),
+        xmin           = cms.double(0.),
+        xmax           = cms.double(100.),
+        switchon  = cms.bool(True)
+    ),
+
   TH1NumMatched = cms.PSet(
         Nbinx          = cms.int32(100),
         xmin           = cms.double(0.),
         xmax           = cms.double(5000.),
         switchon  = cms.bool(True)
 
+    ),
+
+    TH1BunchMatched = cms.PSet( 
+        Nbinx          = cms.int32(20),
+        xmin           = cms.double(-10.),
+        xmax           = cms.double(10.),
+        switchon  = cms.bool(True)
+    ),
+
+    TH1EventMatched = cms.PSet( 
+        Nbinx          = cms.int32(100),
+        xmin           = cms.double(0.),
+        xmax           = cms.double(100.),
+        switchon  = cms.bool(True)
     ),
 
     TH1Wclusrphi = cms.PSet(
@@ -102,6 +144,13 @@ stripRecHitsValid = cms.EDAnalyzer("SiStripRecHitsValid",
         Nbinx          = cms.int32(100),
         xmin           = cms.double(0.),
         xmax           = cms.double(50.),
+        switchon  = cms.bool(True)
+    ),
+
+    TH1NsimHitrphi = cms.PSet( 
+        Nbinx          = cms.int32(30),
+        xmin           = cms.double(0.),
+        xmax           = cms.double(30.),
         switchon  = cms.bool(True)
     ),
 
@@ -161,6 +210,13 @@ stripRecHitsValid = cms.EDAnalyzer("SiStripRecHitsValid",
         switchon  = cms.bool(True)
     ),
 
+    TH1NsimHitStereo = cms.PSet( 
+        Nbinx          = cms.int32(30),
+        xmin           = cms.double(0.),
+        xmax           = cms.double(30.),
+        switchon  = cms.bool(True)
+    ),
+
    TH1PosxMatched = cms.PSet( 
         Nbinx          = cms.int32(100),
         xmin           = cms.double(-10.0),#-6.0
@@ -207,6 +263,13 @@ stripRecHitsValid = cms.EDAnalyzer("SiStripRecHitsValid",
         Nbinx          = cms.int32(100),
         xmin           = cms.double(0.),
         xmax           = cms.double(50.),
+        switchon  = cms.bool(True)
+    ),
+
+    TH1NsimHitMatched = cms.PSet( 
+        Nbinx          = cms.int32(30),
+        xmin           = cms.double(0.),
+        xmax           = cms.double(30.),
         switchon  = cms.bool(True)
     ),
 

--- a/Validation/TrackerRecHits/src/SiStripRecHitsValid.cc
+++ b/Validation/TrackerRecHits/src/SiStripRecHitsValid.cc
@@ -77,11 +77,29 @@ SiStripRecHitsValid::SiStripRecHitsValid(const ParameterSet& ps) :
   edm::ParameterSet ParametersNumrphi =  conf_.getParameter<edm::ParameterSet>("TH1Numrphi");
   switchNumrphi = ParametersNumrphi.getParameter<bool>("switchon");
 
+  edm::ParameterSet ParametersBunchrphi =  conf_.getParameter<edm::ParameterSet>("TH1Bunchrphi");
+  switchBunchrphi = ParametersBunchrphi.getParameter<bool>("switchon");
+
+  edm::ParameterSet ParametersEventrphi =  conf_.getParameter<edm::ParameterSet>("TH1Eventrphi");
+  switchEventrphi = ParametersEventrphi.getParameter<bool>("switchon");
+
   edm::ParameterSet ParametersNumStereo =  conf_.getParameter<edm::ParameterSet>("TH1NumStereo");
   switchNumStereo = ParametersNumStereo.getParameter<bool>("switchon");
 
+  edm::ParameterSet ParametersBunchStereo =  conf_.getParameter<edm::ParameterSet>("TH1BunchStereo");
+  switchBunchStereo = ParametersBunchStereo.getParameter<bool>("switchon");
+
+  edm::ParameterSet ParametersEventStereo =  conf_.getParameter<edm::ParameterSet>("TH1EventStereo");
+  switchEventStereo = ParametersEventStereo.getParameter<bool>("switchon");
+
   edm::ParameterSet ParametersNumMatched =  conf_.getParameter<edm::ParameterSet>("TH1NumMatched");
   switchNumMatched = ParametersNumMatched.getParameter<bool>("switchon");
+
+  edm::ParameterSet ParametersBunchMatched =  conf_.getParameter<edm::ParameterSet>("TH1BunchMatched");
+  switchBunchMatched = ParametersBunchMatched.getParameter<bool>("switchon");
+
+  edm::ParameterSet ParametersEventMatched =  conf_.getParameter<edm::ParameterSet>("TH1EventMatched");
+  switchEventMatched = ParametersEventMatched.getParameter<bool>("switchon");
 
   edm::ParameterSet ParametersWclusrphi =  conf_.getParameter<edm::ParameterSet>("TH1Wclusrphi");
   switchWclusrphi = ParametersWclusrphi.getParameter<bool>("switchon");
@@ -107,6 +125,9 @@ SiStripRecHitsValid::SiStripRecHitsValid(const ParameterSet& ps) :
   edm::ParameterSet ParametersChi2rphi =  conf_.getParameter<edm::ParameterSet>("TH1Chi2rphi");
   switchChi2rphi = ParametersChi2rphi.getParameter<bool>("switchon");
 
+  edm::ParameterSet ParametersNsimHitrphi =  conf_.getParameter<edm::ParameterSet>("TH1NsimHitrphi");
+  switchNsimHitrphi = ParametersNsimHitrphi.getParameter<bool>("switchon");
+
   edm::ParameterSet ParametersWclusStereo =  conf_.getParameter<edm::ParameterSet>("TH1WclusStereo");
   switchWclusStereo = ParametersWclusStereo.getParameter<bool>("switchon");
 
@@ -131,6 +152,9 @@ SiStripRecHitsValid::SiStripRecHitsValid(const ParameterSet& ps) :
   edm::ParameterSet ParametersChi2Stereo =  conf_.getParameter<edm::ParameterSet>("TH1Chi2Stereo");
   switchChi2Stereo = ParametersChi2Stereo.getParameter<bool>("switchon");
 
+  edm::ParameterSet ParametersNsimHitStereo =  conf_.getParameter<edm::ParameterSet>("TH1NsimHitStereo");
+  switchNsimHitStereo = ParametersNsimHitStereo.getParameter<bool>("switchon");
+
   edm::ParameterSet ParametersPosxMatched =  conf_.getParameter<edm::ParameterSet>("TH1PosxMatched");
   switchPosxMatched = ParametersPosxMatched.getParameter<bool>("switchon");
 
@@ -151,6 +175,9 @@ SiStripRecHitsValid::SiStripRecHitsValid(const ParameterSet& ps) :
 
   edm::ParameterSet ParametersChi2Matched =  conf_.getParameter<edm::ParameterSet>("TH1Chi2Matched");
   switchChi2Matched = ParametersChi2Matched.getParameter<bool>("switchon");
+
+  edm::ParameterSet ParametersNsimHitMatched =  conf_.getParameter<edm::ParameterSet>("TH1NsimHitMatched");
+  switchNsimHitMatched = ParametersNsimHitMatched.getParameter<bool>("switchon");
 
 }
 
@@ -310,6 +337,12 @@ void SiStripRecHitsValid::analyze(const edm::Event& e, const edm::EventSetup& es
 	  fillME(iLayerME->second.meAdcrphi,(*irh).cluchg);
 	  fillME(iLayerME->second.mePosxrphi,(*irh).x);
 	  fillME(iLayerME->second.meResolxrphi,(*irh).resolxx);
+	  fillME(iLayerME->second.meNsimHitrphi,(*irh).NsimHit);
+	  if ((*irh).NsimHit > 0) {
+	    std::map<std::string, SubDetMEs>::iterator iSubDetME = SubDetMEsMap.find(det_lay_pair.first);
+	    fillME(iSubDetME->second.meBunchrphi, (*irh).bunch);
+	    if ((*irh).bunch == 0) fillME(iSubDetME->second.meEventrphi, (*irh).event);
+	  }
 	  if ( (*irh).resx != -999999. || (*irh).pullMF != -999999. || (*irh).chi2 != -999999. ){
 	    fillME(iLayerME->second.meResrphi,(*irh).resx);
 	    fillME(iLayerME->second.mePullLFrphi,(*irh).resx/sqrt((*irh).resolxx));
@@ -326,6 +359,12 @@ void SiStripRecHitsValid::analyze(const edm::Event& e, const edm::EventSetup& es
 	  fillME(iStereoAndMatchedME->second.meAdcStereo,(*irh).cluchg);
 	  fillME(iStereoAndMatchedME->second.mePosxStereo,(*irh).x);
 	  fillME(iStereoAndMatchedME->second.meResolxStereo,sqrt((*irh).resolxx));
+	  fillME(iStereoAndMatchedME->second.meNsimHitStereo,(*irh).NsimHit);
+	  if ((*irh).NsimHit > 0) {
+	    std::map<std::string, SubDetMEs>::iterator iSubDetME = SubDetMEsMap.find(det_lay_pair.first);
+	    fillME(iSubDetME->second.meBunchStereo, (*irh).bunch);
+	    if ((*irh).bunch == 0) fillME(iSubDetME->second.meEventStereo, (*irh).event);
+	  }
 	  if ( (*irh).resx != -999999. || (*irh).pullMF != -999999. || (*irh).chi2 != -999999. ){
 	    fillME(iStereoAndMatchedME->second.meResStereo,(*irh).resx);
 	    fillME(iStereoAndMatchedME->second.mePullLFStereo,(*irh).resx/sqrt((*irh).resolxx));
@@ -341,6 +380,12 @@ void SiStripRecHitsValid::analyze(const edm::Event& e, const edm::EventSetup& es
 	  fillME(iStereoAndMatchedME->second.mePosyMatched,(*irh).y);
 	  fillME(iStereoAndMatchedME->second.meResolxMatched,sqrt((*irh).resolxx));
 	  fillME(iStereoAndMatchedME->second.meResolyMatched,sqrt((*irh).resolyy));
+	  fillME(iStereoAndMatchedME->second.meNsimHitMatched,(*irh).NsimHit);
+	  if ((*irh).NsimHit > 0) {
+	    std::map<std::string, SubDetMEs>::iterator iSubDetME = SubDetMEsMap.find(det_lay_pair.first);
+	    fillME(iSubDetME->second.meBunchMatched, (*irh).bunch);
+	    if ((*irh).bunch == 0) fillME(iSubDetME->second.meEventMatched, (*irh).event);
+	  }
 	  if ( (*irh).resx != -999999. || (*irh).resy != -999999. || (*irh).chi2 != -999999. ){
 	    fillME(iStereoAndMatchedME->second.meResxMatched,(*irh).resx);
 	    fillME(iStereoAndMatchedME->second.meResyMatched,(*irh).resy);
@@ -404,7 +449,8 @@ void SiStripRecHitsValid::rechitanalysis(SiStripRecHit2D const rechit,const Stri
   
   rechitpro.x = -999999.; rechitpro.y = -999999.; rechitpro.z = -999999.; rechitpro.resolxx = -999999.; rechitpro.resolxy = -999999.; 
   rechitpro.resolyy = -999999.; rechitpro.resx = -999999.; rechitpro.resy = -999999.;rechitpro.pullMF = -999999.; 
-  rechitpro.clusiz = -999999.; rechitpro.cluchg = -999999.; rechitpro.chi2 = -999999.;
+  rechitpro.clusiz = -999999.; rechitpro.cluchg = -999999.; rechitpro.chi2 = -999999.; rechitpro.NsimHit = -999999.;
+  rechitpro.bunch = -999999.; rechitpro.event = -999999.;
 
   LocalPoint position=rechit.localPosition();
   LocalError error=rechit.localPositionError();
@@ -432,6 +478,7 @@ void SiStripRecHitsValid::rechitanalysis(SiStripRecHit2D const rechit,const Stri
 
   matched.clear();
   matched = associate.associateHit(rechit);
+  rechitpro.NsimHit = matched.size();
 
   double mindist = 999999;
   double dist = 999999;
@@ -446,6 +493,8 @@ void SiStripRecHitsValid::rechitanalysis(SiStripRecHit2D const rechit,const Stri
 	closest = (*m);
       }
     }  
+    rechitpro.bunch = closest.eventId().bunchCrossing();
+    rechitpro.event = closest.eventId().event();
     rechitpro.resx = rechitpro.x - closest.localPosition().x();
     rechitpro.pullMF = (Mposition.x() - (topol.measurementPosition(closest.localPosition())).x())/sqrt(Merror.uu());
     
@@ -482,7 +531,8 @@ void SiStripRecHitsValid::rechitanalysis_matched(SiStripMatchedRecHit2D const re
   
   rechitpro.x = -999999.; rechitpro.y = -999999.; rechitpro.z = -999999.; rechitpro.resolxx = -999999.; rechitpro.resolxy = -999999.; 
   rechitpro.resolyy = -999999.; rechitpro.resx = -999999.; rechitpro.resy = -999999.;rechitpro.pullMF = -999999.; 
-  rechitpro.clusiz = -999999.; rechitpro.cluchg = -999999.; rechitpro.chi2 = -999999.;
+  rechitpro.clusiz = -999999.; rechitpro.cluchg = -999999.; rechitpro.chi2 = -999999.; rechitpro.NsimHit = -999999.;
+  rechitpro.bunch = -999999.; rechitpro.event = -999999.;
 
   LocalPoint position=rechit.localPosition();
   LocalError error=rechit.localPositionError();
@@ -496,11 +546,13 @@ void SiStripRecHitsValid::rechitanalysis_matched(SiStripMatchedRecHit2D const re
 
   matched.clear();
   matched = associate.associateHit(rechit);
+  rechitpro.NsimHit = matched.size();
 
   double mindist = 999999;
   double dist = 999999;
   double distx = 999999;
   double disty = 999999;
+  PSimHit closest;
   std::pair<LocalPoint,LocalVector> closestPair;
 
   if(!matched.empty()){
@@ -522,9 +574,12 @@ void SiStripRecHitsValid::rechitanalysis_matched(SiStripMatchedRecHit2D const re
 	if(dist<mindist){
 	  mindist = dist;
 	  closestPair = hitPair;
+	  closest = (*m);
 	}
       }
     }  
+    rechitpro.bunch = closest.eventId().bunchCrossing();
+    rechitpro.event = closest.eventId().event();
     rechitpro.resx = rechitpro.x - closestPair.first.x();
     rechitpro.resy = rechitpro.y - closestPair.first.y();
     //std::cout << " Closest position x = " << closestPair.first.x() 
@@ -691,7 +746,7 @@ void SiStripRecHitsValid::createTotalMEs(DQMStore::IBooker & ibooker)
 
   //NumTotrphi
   if(switchNumTotrphi) {
-    totalMEs.meNumTotrphi = bookME1D(ibooker,"TH1NumTotrphi", "TH1NumTotrphi" ,"Num of RecHits");
+    totalMEs.meNumTotrphi = bookME1D(ibooker,"TH1NumTotrphi", "TH1NumTotrphi" ,"Num of RecHits rphi");
     totalMEs.meNumTotrphi->setAxisTitle("Total number of RecHits");
   }
   //NumTotStereo
@@ -701,7 +756,7 @@ void SiStripRecHitsValid::createTotalMEs(DQMStore::IBooker & ibooker)
   }
   //NumTotMatched
   if(switchNumTotMatched) {
-    totalMEs.meNumTotMatched = bookME1D(ibooker,"TH1NumTotMatched","TH1NumTotMatched","Num of RecHits rmatched"); 
+    totalMEs.meNumTotMatched = bookME1D(ibooker,"TH1NumTotMatched","TH1NumTotMatched","Num of RecHits matched"); 
     totalMEs.meNumTotMatched->setAxisTitle("Total number of matched RecHits");
   }
        
@@ -720,6 +775,7 @@ void SiStripRecHitsValid::createLayerMEs(DQMStore::IBooker & ibooker,std::string
   layerMEs.mePullLFrphi = 0;
   layerMEs.mePullMFrphi = 0;
   layerMEs.meChi2rphi = 0;
+  layerMEs.meNsimHitrphi = 0;
 
   //Wclusrphi
   if(switchWclusrphi) {
@@ -761,6 +817,11 @@ void SiStripRecHitsValid::createLayerMEs(DQMStore::IBooker & ibooker,std::string
     layerMEs.meChi2rphi = bookME1D(ibooker,"TH1Chi2rphi", hidmanager.createHistoLayer("Chi2_rphi","layer",label,"").c_str() ,"RecHit Chi2 test"); 
     layerMEs.meChi2rphi->setAxisTitle(("RecHit Chi2 test in " + label).c_str()); 
   }
+  //NsimHitrphi
+  if(switchNsimHitrphi) {
+    layerMEs.meNsimHitrphi = bookME1D(ibooker,"TH1NsimHitrphi", hidmanager.createHistoLayer("NsimHit_rphi","layer",label,"").c_str() ,"No. of assoc. simHits"); 
+    layerMEs.meNsimHitrphi->setAxisTitle(("Number of assoc. simHits in " + label).c_str()); 
+  }
 
   LayerMEsMap[label]=layerMEs;
  
@@ -779,6 +840,7 @@ void SiStripRecHitsValid::createStereoAndMatchedMEs(DQMStore::IBooker & ibooker,
   stereoandmatchedMEs.mePullLFStereo = 0;
   stereoandmatchedMEs.mePullMFStereo = 0;
   stereoandmatchedMEs.meChi2Stereo = 0;
+  stereoandmatchedMEs.meNsimHitStereo = 0;
   stereoandmatchedMEs.mePosxMatched = 0;
   stereoandmatchedMEs.mePosyMatched = 0;
   stereoandmatchedMEs.meResolxMatched = 0;
@@ -786,6 +848,7 @@ void SiStripRecHitsValid::createStereoAndMatchedMEs(DQMStore::IBooker & ibooker,
   stereoandmatchedMEs.meResxMatched = 0;
   stereoandmatchedMEs.meResyMatched = 0;
   stereoandmatchedMEs.meChi2Matched = 0;
+  stereoandmatchedMEs.meNsimHitMatched = 0;
 
   //WclusStereo
   if(switchWclusStereo) {
@@ -827,6 +890,11 @@ void SiStripRecHitsValid::createStereoAndMatchedMEs(DQMStore::IBooker & ibooker,
     stereoandmatchedMEs.meChi2Stereo = bookME1D(ibooker,"TH1Chi2Stereo", hidmanager.createHistoLayer("Chi2_stereo","layer",label,"").c_str() ,"RecHit Chi2 test");  
     stereoandmatchedMEs.meChi2Stereo->setAxisTitle(("RecHit Chi2 test in stereo modules in " + label).c_str()); 
   }
+  //NsimHitStereo
+  if(switchNsimHitStereo) {
+    stereoandmatchedMEs.meNsimHitStereo = bookME1D(ibooker,"TH1NsimHitStereo", hidmanager.createHistoLayer("NsimHit_stereo","layer",label,"").c_str() ,"No. of assoc. simHits");  
+    stereoandmatchedMEs.meNsimHitStereo->setAxisTitle(("Number of assoc. simHits in stereo modules in " + label).c_str()); 
+  }
   //PosxMatched
   if(switchPosxMatched) {
     stereoandmatchedMEs.mePosxMatched = bookME1D(ibooker,"TH1PosxMatched", hidmanager.createHistoLayer("Posx_matched","layer",label,"").c_str() ,"RecHit x coord.");  
@@ -862,6 +930,11 @@ void SiStripRecHitsValid::createStereoAndMatchedMEs(DQMStore::IBooker & ibooker,
     stereoandmatchedMEs.meChi2Matched = bookME1D(ibooker,"TH1Chi2Matched", hidmanager.createHistoLayer("Chi2_matched","layer",label,"").c_str() ,"RecHit Chi2 test"); 
     stereoandmatchedMEs.meChi2Matched->setAxisTitle(("Matched RecHit Chi2 test in " + label).c_str()); 
   }
+  //NsimHitMatched
+  if(switchNsimHitMatched) {
+    stereoandmatchedMEs.meNsimHitMatched = bookME1D(ibooker,"TH1NsimHitMatched", hidmanager.createHistoLayer("NsimHit_matched","layer",label,"").c_str() ,"No. of assoc. simHits"); 
+    stereoandmatchedMEs.meNsimHitMatched->setAxisTitle(("Number of assoc. simHits in " + label).c_str()); 
+  }
 
   StereoAndMatchedMEsMap[label]=stereoandmatchedMEs;
  
@@ -871,8 +944,14 @@ void SiStripRecHitsValid::createSubDetMEs(DQMStore::IBooker & ibooker,std::strin
 
   SubDetMEs subdetMEs;
   subdetMEs.meNumrphi = 0;
+  subdetMEs.meBunchrphi = 0;
+  subdetMEs.meEventrphi = 0;
   subdetMEs.meNumStereo = 0;
+  subdetMEs.meBunchStereo = 0;
+  subdetMEs.meEventStereo = 0;
   subdetMEs.meNumMatched = 0;
+  subdetMEs.meBunchMatched = 0;
+  subdetMEs.meEventMatched = 0;
 
   std::string HistoName;
   //Numrphi
@@ -881,18 +960,54 @@ void SiStripRecHitsValid::createSubDetMEs(DQMStore::IBooker & ibooker,std::strin
     subdetMEs.meNumrphi = bookME1D(ibooker,"TH1Numrphi",HistoName.c_str(),"Num of RecHits");
     subdetMEs.meNumrphi->setAxisTitle(("Total number of RecHits in "+ label).c_str());
   }  
+  //Bunchrphi
+  if(switchBunchrphi) {
+    HistoName = "TH1Bunchrphi__" + label;
+    subdetMEs.meBunchrphi = bookME1D(ibooker,"TH1Bunchrphi",HistoName.c_str(),"Bunch Crossing");
+    subdetMEs.meBunchrphi->setAxisTitle(("Bunch crossing in " + label).c_str()); 
+  }
+  //Eventrphi
+  if(switchEventrphi) {
+    HistoName = "TH1Eventrphi__" + label;
+    subdetMEs.meEventrphi = bookME1D(ibooker,"TH1Eventrphi",HistoName.c_str(),"Event (in-time bunch)");
+    subdetMEs.meEventrphi->setAxisTitle(("Event (in-time bunch) in " + label).c_str()); 
+  }
   //NumStereo
   if (switchNumStereo){
     HistoName = "TH1NumStereo__" + label;
     subdetMEs.meNumStereo = bookME1D(ibooker,"TH1NumStereo",HistoName.c_str(),"Num of RecHits in stereo modules");
-    subdetMEs.meNumStereo->setAxisTitle(("Total number of RecHits in stereo modules in "+ label).c_str());
+    subdetMEs.meNumStereo->setAxisTitle(("Total number of RecHits, stereo modules in "+ label).c_str());
   }  
+  //BunchStereo
+  if(switchBunchStereo) {
+    HistoName = "TH1BunchStereo__" + label;
+    subdetMEs.meBunchStereo = bookME1D(ibooker,"TH1BunchStereo",HistoName.c_str(),"Bunch Crossing");
+    subdetMEs.meBunchStereo->setAxisTitle(("Bunch crossing, stereo modules in " + label).c_str()); 
+  }
+  //EventStereo
+  if(switchEventStereo) {
+    HistoName = "TH1EventStereo__" + label;
+    subdetMEs.meEventStereo = bookME1D(ibooker,"TH1EventStereo",HistoName.c_str(),"Event (in-time bunch)");
+    subdetMEs.meEventStereo->setAxisTitle(("Event (in-time bunch), stereo modules in " + label).c_str()); 
+  }
   //NumMatched
   if (switchNumMatched){
     HistoName = "TH1NumMatched__" + label;
     subdetMEs.meNumMatched = bookME1D(ibooker,"TH1NumMatched",HistoName.c_str(),"Num of matched RecHits" );
     subdetMEs.meNumMatched->setAxisTitle(("Total number of matched RecHits in "+ label).c_str());
   }  
+  //BunchMatched
+  if(switchBunchMatched) {
+    HistoName = "TH1BunchMatched__" + label;
+    subdetMEs.meBunchMatched = bookME1D(ibooker,"TH1BunchMatched",HistoName.c_str(),"Bunch Crossing");
+    subdetMEs.meBunchMatched->setAxisTitle(("Bunch crossing, matched RecHits in " + label).c_str()); 
+  }
+  //EventMatched
+  if(switchEventMatched) {
+    HistoName = "TH1EventMatched__" + label;
+    subdetMEs.meEventMatched = bookME1D(ibooker,"TH1EventMatched",HistoName.c_str(),"Event (in-time bunch)");
+    subdetMEs.meEventMatched->setAxisTitle(("Event (in-time bunch), matched RecHits in " + label).c_str()); 
+  }
 
   SubDetMEsMap[label]=subdetMEs;
 }


### PR DESCRIPTION
New histograms for  pileup bunch number, event number for in-time bunch (by subDet), and number of simHits associated with a given recHit (by subDet and layer).  Discussed at Tracker DPG meeting of Aug. 15, 2014:  https://indico.cern.ch/event/322710/
This PR is for the strips.
