### PR TITLE
Add defaulted template parameter to work around ROOT6 issue

### DIFF
--- a/DataFormats/Math/interface/Point3D.h
+++ b/DataFormats/Math/interface/Point3D.h
@@ -5,9 +5,9 @@
 
 namespace math {
   /// point in space with cartesian internal representation
-  typedef ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<double> > XYZPointD;
+  typedef ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<double>, ROOT::Math::DefaultCoordinateSystemTag> XYZPointD;
   /// point in space with cartesian internal representation
-  typedef ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<float> > XYZPointF;
+  typedef ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<float>, ROOT::Math::DefaultCoordinateSystemTag> XYZPointF;
   /// point in space with cartesian internal representation
   typedef XYZPointD XYZPoint;
 


### PR DESCRIPTION
RTOOT6 currently has a problem with defaulted template parameters.  This is causing many relval tests to fail.  This pull request avoids the problem by explicitly specifying the default values.
This change can be removed when and if the problem is fixed in ROOT6.
Please merge this as soon as convenient.
