### PR TITLE
Creating new package for JSON monitoring

### DIFF
--- a/HLTrigger/JSONMonitoring/interface/TriggerJSONMonitoring.h
+++ b/HLTrigger/JSONMonitoring/interface/TriggerJSONMonitoring.h
@@ -1,0 +1,67 @@
+#ifndef HLTcore_TriggerJSONMonitoring_h
+#define HLTcore_TriggerJSONMonitoring_h
+
+/** \class TriggerJSONMonitoring
+ *
+ *  
+ *  Description: This class prints JSON files with trigger info. 
+ *
+ *  Created:  Wed, 09 Jul 2014 
+ *
+ *  \author Aram Avetisyan
+ *  \author Daniel Salerno
+ *
+ */
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+
+#include "EventFilter/Utilities/interface/JsonMonitorable.h"
+#include "EventFilter/Utilities/interface/FastMonitor.h"
+#include "EventFilter/Utilities/interface/JSONSerializer.h"
+#include "EventFilter/Utilities/interface/FastMonitoringService.h"
+#include "EventFilter/Utilities/interface/EvFDaqDirector.h"
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Common/interface/TriggerResults.h"
+
+#include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
+
+//
+// class declaration
+//
+class TriggerJSONMonitoring : public edm::EDAnalyzer {
+  
+ public:
+  explicit TriggerJSONMonitoring(const edm::ParameterSet&);
+  ~TriggerJSONMonitoring();
+  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  virtual void beginRun(edm::Run const&, edm::EventSetup const&);
+  virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
+  virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
+
+  void reset(bool changed = false);       // reset all counters
+
+ private:
+  boost::shared_ptr<jsoncollector::FastMonitor> jsonMonitor_;
+  DataPointDefinition outJson_;
+  IntJ processed_; 
+
+  std::string baseRunDir;
+
+  std::vector<std::string>  hltNames_;  // name of each HLT algorithm
+  std::vector<IntJ> hltPaths_;          // stores name and # of event accepted by HLT paths
+
+  std::string jsonDefinitionFile;       // JSON definition file name
+
+  edm::InputTag triggerResults_;                               // Input tag for TriggerResults
+  edm::EDGetTokenT<edm::TriggerResults> triggerResultsToken_;  // Token for TriggerResults
+      
+  HLTConfigProvider hltConfig_;         // to get configuration for HLT
+
+};
+#endif

--- a/HLTrigger/JSONMonitoring/plugins/BuildFile.xml
+++ b/HLTrigger/JSONMonitoring/plugins/BuildFile.xml
@@ -1,0 +1,8 @@
+<library   file="*.cc" name="HLTriggerJSONMonitoringPlugins">
+  <use   name="FWCore/PrescaleService"/>
+  <use   name="FWCore/ServiceRegistry"/>
+  <use   name="FWCore/Utilities"/>
+  <use   name="HLTrigger/HLTcore"/>
+  <use   name="EventFilter/Utilities"/>
+  <flags   EDM_PLUGIN="1"/>
+</library>

--- a/HLTrigger/JSONMonitoring/plugins/SealModule.cc
+++ b/HLTrigger/JSONMonitoring/plugins/SealModule.cc
@@ -1,0 +1,5 @@
+#include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "HLTrigger/JSONMonitoring/interface/TriggerJSONMonitoring.h"
+
+DEFINE_FWK_MODULE(TriggerJSONMonitoring);

--- a/HLTrigger/JSONMonitoring/plugins/TriggerJSONMonitoring.cc
+++ b/HLTrigger/JSONMonitoring/plugins/TriggerJSONMonitoring.cc
@@ -1,0 +1,199 @@
+/** \class TriggerJSONMonitoring
+ *
+ * See header file for documentation
+ *
+ *
+ *  \author Aram Avetisyan
+ *  \author Daniel Salerno
+ *
+ */
+
+#include "HLTrigger/JSONMonitoring/interface/TriggerJSONMonitoring.h"
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Common/interface/TriggerResults.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include <fstream>
+
+TriggerJSONMonitoring::TriggerJSONMonitoring(const edm::ParameterSet& ps)
+{
+  if (ps.exists("triggerResults")) triggerResults_ = ps.getParameter<edm::InputTag> ("triggerResults");
+  else                             triggerResults_ = edm::InputTag("TriggerResults","","HLT");
+  
+  triggerResultsToken_ = consumes<edm::TriggerResults>(triggerResults_);
+}
+
+TriggerJSONMonitoring::~TriggerJSONMonitoring()
+{
+}
+
+void
+TriggerJSONMonitoring::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("triggerResults",edm::InputTag("TriggerResults","","HLT"));
+  descriptions.add("triggerJSONMonitoring", desc);
+}
+
+void
+TriggerJSONMonitoring::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+
+  using namespace std;
+  using namespace edm;
+
+  processed_.value()++;
+
+  //Get hold of TriggerResults
+  Handle<TriggerResults> HLTR;
+  iEvent.getByToken(triggerResultsToken_, HLTR);
+  if (!HLTR.isValid()) {
+    LogDebug("TriggerJSONMonitoring") << "HLT TriggerResults with label ["+triggerResults_.encode()+"] not found!" << std::endl;
+    return;
+  }
+  
+  // decision for each HLT path
+  const unsigned int n(hltNames_.size());
+  for (unsigned int i=0; i<n; i++) {
+    if (HLTR->accept(i)){
+      hltPaths_[i].value()++;
+    }
+  }
+
+}
+
+void 
+TriggerJSONMonitoring::reset(bool changed ){
+
+  processed_.value() = 0;
+
+  // update trigger names
+  if (changed) hltNames_ = hltConfig_.triggerNames();
+
+  const unsigned int n = hltNames_.size();
+
+  if (changed) {
+    // resize per-path counter
+    hltPaths_.resize(n);
+  }
+
+  // reset per-path counter
+  for (unsigned int i = 0; i < n; i++) {
+    hltPaths_[i].value() = 0;
+  }
+
+}
+
+
+void 
+TriggerJSONMonitoring::beginRun(edm::Run const& iRun, edm::EventSetup const& iSetup)
+{
+
+   //Get the run directory from the EvFDaqDirector
+   baseRunDir = edm::Service<evf::EvFDaqDirector>()->baseRunDir();
+  
+   // initialize hltConfig_
+   bool changed = true;
+   if (hltConfig_.init(iRun, iSetup, triggerResults_.process(), changed)) {
+     reset(true);
+   }
+
+   // set up JSON
+   processed_.setName("Processed");
+
+   DataPointDefinition outJsonTemp_;
+
+   outJsonTemp_.setDefaultGroup("data");
+   outJsonTemp_.addLegendItem("Processed","integer",DataPointDefinition::SUM);
+
+   const unsigned int n = hltNames_.size();
+
+   for(unsigned int i =0; i<n; i++){
+     hltPaths_[i].setName( hltNames_[i] );
+     outJsonTemp_.addLegendItem(hltNames_[i],"integer",DataPointDefinition::SUM);
+   }
+
+   outJson_ = outJsonTemp_;
+
+   // create JSON definition file
+   unsigned int nRun = iRun.run();
+
+   std::stringstream sjsd;
+   sjsd << baseRunDir << "/mon/HLTRates_run"<< nRun; 
+   sjsd << "_pid" << std::setfill('0') << std::setw(5) << getpid() << ".jsd";
+   jsonDefinitionFile = sjsd.str();
+   
+   std::ofstream outfile( jsonDefinitionFile );
+   outfile << "{" << std::endl;
+   outfile << "   \"data\" : [" << std::endl;
+   outfile << "      {" << std::endl;
+   outfile << "         \"name\" : \"Processed\"," << std::endl;
+   outfile << "         \"operation\" : \"sum\"," << std::endl;
+   outfile << "         \"type\" : \"integer\"" << std::endl;
+   
+   for(unsigned int j =0; j<n; j++){
+     outfile << "      }," << std::endl;
+     outfile << "      {" << std::endl;
+     outfile << "         \"name\" : \"" << hltNames_[j] << "\"," << std::endl;
+     outfile << "         \"operation\" : \"sum\"," << std::endl;
+     outfile << "         \"type\" : \"integer\"" << std::endl;
+   } 
+   
+   outfile << "      }" << std::endl;
+   outfile << "   ]" << std::endl;
+   outfile << "}" << std::endl;
+   
+   outfile.close();
+
+   //std::cout << "CurrentRunDir is " << RunDir << std::endl;  //***
+}
+
+void 
+TriggerJSONMonitoring::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
+{
+
+  std::string outJsonDefName = jsonDefinitionFile;
+
+  jsonMonitor_.reset(new jsoncollector::FastMonitor(&outJson_, false));
+  jsonMonitor_->setDefPath(outJsonDefName);
+  jsonMonitor_->registerGlobalMonitorable(&processed_,false);
+
+  for(unsigned int i = 0; i < hltPaths_.size(); i++){
+    jsonMonitor_->registerGlobalMonitorable(&hltPaths_[i], false);
+  }
+
+  jsonMonitor_->commit(nullptr);
+
+  reset();
+}
+
+void 
+TriggerJSONMonitoring::endLuminosityBlock(edm::LuminosityBlock const& ls, edm::EventSetup const&)
+{
+
+  unsigned int uiLS  = ls.luminosityBlock();
+  unsigned int uiRun = ls.run();
+
+  jsonMonitor_->snap(uiLS);
+
+  std::stringstream ss;
+  ss << baseRunDir << "/mon/" << "HLTRates";
+  ss << "_run" << uiRun << "_ls" << std::setfill('0') << std::setw(4) << uiLS;
+  ss << "_pid" << std::setfill('0') << std::setw(5) << getpid() << ".jsn";
+  std::string outputJsonNameStream = ss.str();
+  
+  jsonMonitor_->outputFullJSON(outputJsonNameStream, uiLS);
+
+  // Debug output
+  LogDebug("TriggerJSONMonitoring") << "i hltNames #Accepted" << std::endl;
+  const unsigned int size = hltNames_.size();
+  for (unsigned int i = 0; i < size; i++) {
+    LogDebug("TriggerJSONMonitoring") << i                    << " "
+				      << hltNames_[i]         << " "
+				      << hltPaths_[i].value() << std::endl;
+  }
+
+}

--- a/HLTrigger/JSONMonitoring/test/TriggerJSONMonitoring.py
+++ b/HLTrigger/JSONMonitoring/test/TriggerJSONMonitoring.py
@@ -1,0 +1,36 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("HLTM")
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+
+process.EvFDaqDirector = cms.Service( "EvFDaqDirector",
+    buBaseDir = cms.untracked.string( "." ),
+    runNumber = cms.untracked.uint32( 0 ),
+    baseDir = cms.untracked.string( "." )
+)
+process.FastMonitoringService = cms.Service( "FastMonitoringService",
+    slowName = cms.untracked.string( "slowmoni" ),
+    sleepTime = cms.untracked.int32( 1 ),
+    fastMonIntervals = cms.untracked.uint32( 2 ),
+    fastName = cms.untracked.string( "fastmoni" )
+)
+
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring(
+        'file:../../../../../Commissioning2014_Run224380_1000Events.root'
+    )
+)
+
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:hltonline_8E33v2', '')
+
+process.hltm = cms.EDAnalyzer('TriggerJSONMonitoring',
+    triggerResults = cms.InputTag( 'TriggerResults','','HLT')
+)
+
+
+process.p = cms.Path(process.hltm)


### PR DESCRIPTION
Following the discussing in PR#5013, the JSON monitoring code has been moved to its own package (HLTrigger/JSONMonitoring). Aside from the necessary changes in include commands, the build file and the seal module, this code is identical to PR#5013. The description copied from the latter is below.

This is the initial version of the trigger monitoring via JSON files. For now, all it does is print a pair of JSON files per process to the mon subdirectory of the base directory provided by the EvFDaqDirector service. The first file (the definition) has the names of all HLT paths and the second has the counts in each lumi section.
