### PR TITLE
FastTimerService: remove obsolete parameters

### DIFF
--- a/HLTrigger/Timer/src/FastTimerService.cc
+++ b/HLTrigger/Timer/src/FastTimerService.cc
@@ -1407,7 +1407,6 @@ void FastTimerService::fillDescriptions(edm::ConfigurationDescriptions & descrip
   desc.addUntracked<bool>(   "enableDQMbyModule",        false);
   desc.addUntracked<bool>(   "enableDQMbyModuleType",    false);
   desc.addUntracked<bool>(   "enableDQMSummary",         false);
-  desc.addUntracked<bool>(   "enableDQMbyLuminosity",    false)->setComment("deprecated: this parameter is ignored");
   desc.addUntracked<bool>(   "enableDQMbyLumiSection",   false);
   desc.addUntracked<bool>(   "enableDQMbyProcesses",     false);
   desc.addUntracked<double>( "dqmTimeRange",             1000. );   // ms
@@ -1416,12 +1415,8 @@ void FastTimerService::fillDescriptions(edm::ConfigurationDescriptions & descrip
   desc.addUntracked<double>( "dqmPathTimeResolution",       0.5);   // ms
   desc.addUntracked<double>( "dqmModuleTimeRange",         40. );   // ms
   desc.addUntracked<double>( "dqmModuleTimeResolution",     0.2);   // ms
-  desc.addUntracked<double>( "dqmLuminosityRange",      1.e34  )->setComment("deprecated: this parameter is ignored");
-  desc.addUntracked<double>( "dqmLuminosityResolution", 1.e31  )->setComment("deprecated: this parameter is ignored");
   desc.addUntracked<uint32_t>( "dqmLumiSectionsRange",   2500  );   // ~ 16 hours
   desc.addUntracked<std::string>(   "dqmPath",           "HLT/TimerService");
-  desc.addUntracked<edm::InputTag>( "luminosityProduct", edm::InputTag("hltScalersRawToDigi"))->setComment("deprecated: this parameter is ignored");
-  desc.addUntracked<std::vector<unsigned int> >("supportedProcesses", std::vector<unsigned int> { })->setComment("deprecated: this parameter is ignored");
   descriptions.add("FastTimerService", desc);
 }
 

--- a/HLTrigger/Timer/test/chrono.cc
+++ b/HLTrigger/Timer/test/chrono.cc
@@ -62,10 +62,18 @@ void init_timers(std::vector<BenchmarkBase *> & timers)
   if (clock_gettime_realtime::is_available)
     timers.push_back(new Benchmark<clock_gettime_realtime>("clock_gettime(CLOCK_REALTIME)"));
 #endif // HAVE_POSIX_CLOCK_REALTIME
+#ifdef HAVE_POSIX_CLOCK_REALTIME_COARSE
+  if (clock_gettime_realtime_coarse::is_available)
+    timers.push_back(new Benchmark<clock_gettime_realtime_coarse>("clock_gettime(CLOCK_REALTIME_COARSE)"));
+#endif // HAVE_POSIX_CLOCK_REALTIME_COARSE
 #ifdef HAVE_POSIX_CLOCK_MONOTONIC
   if (clock_gettime_monotonic::is_available)
     timers.push_back(new Benchmark<clock_gettime_monotonic>("clock_gettime(CLOCK_MONOTONIC)"));
 #endif // HAVE_POSIX_CLOCK_MONOTONIC
+#ifdef HAVE_POSIX_CLOCK_MONOTONIC_COARSE
+  if (clock_gettime_monotonic_coarse::is_available)
+    timers.push_back(new Benchmark<clock_gettime_monotonic_coarse>("clock_gettime(CLOCK_MONOTONIC_COARSE)"));
+#endif // HAVE_POSIX_CLOCK_MONOTONIC_COARSE
 #ifdef HAVE_POSIX_CLOCK_MONOTONIC_RAW
   if (clock_gettime_monotonic_raw::is_available)
     timers.push_back(new Benchmark<clock_gettime_monotonic_raw>("clock_gettime(CLOCK_MONOTONIC_RAW)"));

--- a/HLTrigger/Timer/test/posix_clock_gettime.cc
+++ b/HLTrigger/Timer/test/posix_clock_gettime.cc
@@ -7,9 +7,19 @@ const bool clock_gettime_realtime::is_available = (sysconf(_SC_TIMERS) > 0);
 #endif // HAVE_POSIX_CLOCK_REALTIME
 
 
+#ifdef HAVE_POSIX_CLOCK_REALTIME_COARSE
+const bool clock_gettime_realtime_coarse::is_available = true;
+#endif // HAVE_POSIX_CLOCK_REALTIME_COARSE
+
+
 #ifdef HAVE_POSIX_CLOCK_MONOTONIC
 const bool clock_gettime_monotonic::is_available = (sysconf(_SC_MONOTONIC_CLOCK) > 0);
 #endif // HAVE_POSIX_CLOCK_MONOTONIC
+
+
+#ifdef HAVE_POSIX_CLOCK_MONOTONIC_COARSE
+const bool clock_gettime_monotonic_coarse::is_available = true;
+#endif // HAVE_POSIX_CLOCK_MONOTONIC_COARSE
 
 
 #ifdef HAVE_POSIX_CLOCK_MONOTONIC_RAW

--- a/HLTrigger/Timer/test/posix_clock_gettime.h
+++ b/HLTrigger/Timer/test/posix_clock_gettime.h
@@ -30,6 +30,10 @@
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 28)
 #define HAVE_POSIX_CLOCK_MONOTONIC_RAW
 #endif // LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 28)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 32)
+#define HAVE_POSIX_CLOCK_REALTIME_COARSE
+#define HAVE_POSIX_CLOCK_MONOTONIC_COARSE
+#endif // LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 32)
 #endif // __linux__
 
 #endif // _POSIX_TIMERS
@@ -58,6 +62,30 @@ struct clock_gettime_realtime
 #endif // HAVE_POSIX_CLOCK_REALTIME
 
 
+#ifdef HAVE_POSIX_CLOCK_REALTIME_COARSE
+// based on clock_gettime(CLOCK_REALTIME_COARSE, ...)
+struct clock_gettime_realtime_coarse
+{
+  typedef std::chrono::nanoseconds                                          duration;
+  typedef duration::rep                                                     rep;
+  typedef duration::period                                                  period;
+  typedef std::chrono::time_point<clock_gettime_realtime_coarse, duration>  time_point;
+
+  static constexpr bool is_steady = false;
+  static const     bool is_available;
+
+  static time_point now() noexcept
+  {
+    timespec t;
+    clock_gettime(CLOCK_REALTIME_COARSE, &t);
+
+    return time_point( std::chrono::seconds(t.tv_sec) + std::chrono::nanoseconds(t.tv_nsec) );
+  }
+
+};
+#endif // HAVE_POSIX_CLOCK_REALTIME_COARSE
+
+
 #ifdef HAVE_POSIX_CLOCK_MONOTONIC
 // based on clock_gettime(CLOCK_MONOTONIC, ...)
 struct clock_gettime_monotonic
@@ -80,6 +108,30 @@ struct clock_gettime_monotonic
 
 };
 #endif // HAVE_POSIX_CLOCK_MONOTONIC
+
+
+#ifdef HAVE_POSIX_CLOCK_MONOTONIC_COARSE
+// based on clock_gettime(CLOCK_MONOTONIC_COARSE, ...)
+struct clock_gettime_monotonic_coarse
+{
+  typedef std::chrono::nanoseconds                                          duration;
+  typedef duration::rep                                                     rep;
+  typedef duration::period                                                  period;
+  typedef std::chrono::time_point<clock_gettime_monotonic_coarse, duration> time_point;
+
+  static constexpr bool is_steady = true;
+  static const     bool is_available;
+
+  static time_point now() noexcept
+  {
+    timespec t;
+    clock_gettime(CLOCK_MONOTONIC_COARSE, &t);
+
+    return time_point( std::chrono::seconds(t.tv_sec) + std::chrono::nanoseconds(t.tv_nsec) );
+  }
+
+};
+#endif // HAVE_POSIX_CLOCK_MONOTONIC_COARSE
 
 
 #ifdef HAVE_POSIX_CLOCK_MONOTONIC_RAW


### PR DESCRIPTION
Also, add some more clock_gettime-based timers under test
