### PR TITLE
disable running of testUtilitiesStorageFactory and testUtilitiesRFIOAdaptor via scram unittests/runtests

### DIFF
--- a/Utilities/RFIOAdaptor/test/BuildFile.xml
+++ b/Utilities/RFIOAdaptor/test/BuildFile.xml
@@ -1,4 +1,5 @@
 <bin   file="RunUtilitiesRFIOAdaptor.cpp" name="testUtilitiesRFIOAdaptor">
+  <flags NO_TESTRUN="1"/>
   <flags   TEST_RUNNER_ARGS=" /bin/bash Utilities/RFIOAdaptor/test run_RFIOAdaptorTests.sh"/>
   <use   name="FWCore/Utilities"/>
 </bin>

--- a/Utilities/StorageFactory/test/BuildFile.xml
+++ b/Utilities/StorageFactory/test/BuildFile.xml
@@ -1,6 +1,7 @@
 <use   name="Utilities/StorageFactory"/>
 <use   name="FWCore/ParameterSet"/>
 <bin   file="RunUtilitiesStorageFactory.cpp" name="testUtilitiesStorageFactory">
+  <flags NO_TESTRUN="1"/>
   <flags   TEST_RUNNER_ARGS=" /bin/bash Utilities/StorageFactory/test run_StorageFactoryTests.sh"/>
   <use   name="FWCore/Utilities"/>
 </bin>


### PR DESCRIPTION
this just disables the two unit tests which try to access non-existing path /castor/cern.ch/cms
