### PR TITLE
Fix -mrecip errors in clang.

### DIFF
--- a/RecoEgamma/EgammaPhotonAlgos/BuildFile.xml
+++ b/RecoEgamma/EgammaPhotonAlgos/BuildFile.xml
@@ -1,4 +1,7 @@
-<flags   CXXFLAGS="-Ofast -mrecip"/>
+<flags   CXXFLAGS="-Ofast"/>
+<compiler name="gcc">
+  <flags   CXXFLAGS="-mrecip"/>
+</compiler>
 
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/ParameterSet"/>

--- a/RecoVertex/PrimaryVertexProducer/BuildFile.xml
+++ b/RecoVertex/PrimaryVertexProducer/BuildFile.xml
@@ -1,4 +1,7 @@
-<flags   CXXFLAGS="-Ofast -mrecip"/>
+<flags   CXXFLAGS="-Ofast"/>
+<compiler name="gcc">
+<flags   CXXFLAGS="-mrecip"/>
+</compiler>
 <use   name="DataFormats/BeamSpot"/>
 <use   name="DataFormats/VertexReco"/>
 <use   name="FWCore/Framework"/>

--- a/TrackingTools/GsfTools/BuildFile.xml
+++ b/TrackingTools/GsfTools/BuildFile.xml
@@ -1,4 +1,7 @@
-<flags   CXXFLAGS="-Ofast -mrecip"/>
+<flags   CXXFLAGS="-Ofast"/>
+<compiler name="gcc">
+  <flags   CXXFLAGS="-mrecip"/>
+</compiler>
 
 <use   name="boost"/>
 <use   name="CLHEP"/>

--- a/TrackingTools/GsfTracking/BuildFile.xml
+++ b/TrackingTools/GsfTracking/BuildFile.xml
@@ -1,4 +1,7 @@
-<flags   CXXFLAGS="-Ofast -mrecip"/>
+<flags   CXXFLAGS="-Ofast"/>
+<compiler name="gcc">
+<flags   CXXFLAGS="-mrecip"/>
+</compiler>
 
 <use   name="boost"/>
 <use   name="CLHEP"/>

--- a/TrackingTools/KalmanUpdators/BuildFile.xml
+++ b/TrackingTools/KalmanUpdators/BuildFile.xml
@@ -1,4 +1,8 @@
-#<flags   CXXFLAGS="-Ofast -mrecip -funroll-all-loops"/>
+<flags   CXXFLAGS="-Ofast -funroll-all-loops"/>
+<compiler name="gcc">
+ <flags   CXXFLAGS="-mrecip"/>
+</compiler>
+
 <flags   CXXFLAGS="-O3"/>
 <use   name="boost"/>
 <use   name="clhep"/>

--- a/TrackingTools/TrackFitters/BuildFile.xml
+++ b/TrackingTools/TrackFitters/BuildFile.xml
@@ -1,4 +1,7 @@
-<flags   CXXFLAGS="-Ofast -mrecip"/>
+<flags   CXXFLAGS="-Ofast"/>
+<compiler name="gcc">
+  <flags   CXXFLAGS="-mrecip"/>
+</compiler>
 
 <use   name="boost"/>
 <use   name="CLHEP"/>

--- a/TrackingTools/TrajectoryState/BuildFile.xml
+++ b/TrackingTools/TrajectoryState/BuildFile.xml
@@ -1,4 +1,7 @@
-<flags   CXXFLAGS="-Ofast -mrecip"/>
+<flags   CXXFLAGS="-Ofast"/>
+<compiler name="gcc">
+  <flags   CXXFLAGS="-mrecip"/>
+</compiler>
 
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/GeometrySurface"/>


### PR DESCRIPTION
Notice that currently "#" comment is parsed correctly by scram for some reason so the flags in KalmanUpdators actually are in the build.
