### PR TITLE
hash function for pileup summary info

### DIFF
--- a/SimDataFormats/PileupSummaryInfo/interface/PSIHash.h
+++ b/SimDataFormats/PileupSummaryInfo/interface/PSIHash.h
@@ -1,0 +1,20 @@
+#ifndef PSIHash_h
+#define PSIHash_h
+
+#include "PileupSummaryInfo.h"
+#include <vector>
+#include <string>
+
+namespace sim{
+size_t PSIHash(const std::vector<PileupSummaryInfo> &psi ) {
+  
+  std::hash<std::string> str_hash;
+
+  std::stringstream result;
+  for ( unsigned int i=0; i<psi.size(); i++)
+    result << psi[i].getPU_NumInteractions() << " ";
+  
+  return str_hash(result.str());
+}
+}
+#endif


### PR DESCRIPTION
All that is available without tracking particles is the # of pileup vertices per bx. At 40 PU and with 16bx, this is plenty of information to make a reliable hash to use to check for duplicates in RECO samples where premixing was used.
