### PR TITLE
Drop -mrecip completely.

### DIFF
--- a/RecoEgamma/EgammaPhotonAlgos/BuildFile.xml
+++ b/RecoEgamma/EgammaPhotonAlgos/BuildFile.xml
@@ -1,7 +1,4 @@
 <flags   CXXFLAGS="-Ofast"/>
-<compiler name="gcc">
-  <flags   CXXFLAGS="-mrecip"/>
-</compiler>
 
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/ParameterSet"/>

--- a/RecoVertex/PrimaryVertexProducer/BuildFile.xml
+++ b/RecoVertex/PrimaryVertexProducer/BuildFile.xml
@@ -1,7 +1,4 @@
 <flags   CXXFLAGS="-Ofast"/>
-<compiler name="gcc">
-<flags   CXXFLAGS="-mrecip"/>
-</compiler>
 <use   name="DataFormats/BeamSpot"/>
 <use   name="DataFormats/VertexReco"/>
 <use   name="FWCore/Framework"/>

--- a/TrackingTools/GsfTools/BuildFile.xml
+++ b/TrackingTools/GsfTools/BuildFile.xml
@@ -1,7 +1,4 @@
 <flags   CXXFLAGS="-Ofast"/>
-<compiler name="gcc">
-  <flags   CXXFLAGS="-mrecip"/>
-</compiler>
 
 <use   name="boost"/>
 <use   name="CLHEP"/>

--- a/TrackingTools/GsfTracking/BuildFile.xml
+++ b/TrackingTools/GsfTracking/BuildFile.xml
@@ -1,7 +1,4 @@
 <flags   CXXFLAGS="-Ofast"/>
-<compiler name="gcc">
-<flags   CXXFLAGS="-mrecip"/>
-</compiler>
 
 <use   name="boost"/>
 <use   name="CLHEP"/>

--- a/TrackingTools/KalmanUpdators/BuildFile.xml
+++ b/TrackingTools/KalmanUpdators/BuildFile.xml
@@ -1,7 +1,4 @@
 <flags   CXXFLAGS="-Ofast -funroll-all-loops"/>
-<compiler name="gcc">
- <flags   CXXFLAGS="-mrecip"/>
-</compiler>
 
 <flags   CXXFLAGS="-O3"/>
 <use   name="boost"/>

--- a/TrackingTools/TrackFitters/BuildFile.xml
+++ b/TrackingTools/TrackFitters/BuildFile.xml
@@ -1,7 +1,4 @@
 <flags   CXXFLAGS="-Ofast"/>
-<compiler name="gcc">
-  <flags   CXXFLAGS="-mrecip"/>
-</compiler>
 
 <use   name="boost"/>
 <use   name="CLHEP"/>

--- a/TrackingTools/TrajectoryState/BuildFile.xml
+++ b/TrackingTools/TrajectoryState/BuildFile.xml
@@ -1,7 +1,4 @@
 <flags   CXXFLAGS="-Ofast"/>
-<compiler name="gcc">
-  <flags   CXXFLAGS="-mrecip"/>
-</compiler>
 
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/GeometrySurface"/>


### PR DESCRIPTION
`-mrecip` optimizes `x/y` to `x * 1/y` which can be convenient on some CPUs at the cost of slightly different results. This was introduced a few weeks ago by @VinInn due to alleged performance improvements that turned out to be not as large when running larger scale tests. Given it is not supported on clang we (@VinInn and myself) agreed to drop it for the moment. Notice also that probably `-freciprocal-math` provides the same level of optimization and it is also available on clang.
