### PR TITLE
Move from ak5 to ak4 jets in the metUncertainty tool

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -108,8 +108,8 @@ def miniAOD_customizeCommon(process):
     # apply type I/type I + II PFMEt corrections to pat::MET object
     # and estimate systematic uncertainties on MET
     from PhysicsTools.PatUtils.tools.metUncertaintyTools import runMEtUncertainties
-    addJetCollection(process, postfix   = "ForMetUnc", labelName = 'AK5PF', jetSource = cms.InputTag('ak5PFJets'), jetCorrections = ('AK5PF', ['L1FastJet', 'L2Relative', 'L3Absolute'], ''))
-    runMEtUncertainties(process,jetCollection="selectedPatJetsAK5PFForMetUnc", outputModule=None)
+    addJetCollection(process, postfix   = "ForMetUnc", labelName = 'AK4PF', jetSource = cms.InputTag('ak4PFJets'), jetCorrections = ('AK4PF', ['L1FastJet', 'L2Relative', 'L3Absolute'], ''))
+    runMEtUncertainties(process,jetCollection="selectedPatJetsAK4PFForMetUnc", outputModule=None)
 
     #keep this after all addJetCollections otherwise it will attempt computing them also for stuf with no taginfos
     #Some useful BTAG vars

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -111,7 +111,7 @@ def miniAOD_customizeCommon(process):
    # from RecoJets.JetProducers.ak4PFJets_cfi import ak4PFJets
     process.load("RecoJets.JetProducers.ak4PFJets_cfi")
     from PhysicsTools.PatUtils.tools.metUncertaintyTools import runMEtUncertainties
-    addJetCollection(process, postfix   = "ForMetUnc", labelName = 'AK4PF', jetSource = cms.InputTag('ak4PFJets'), jetCorrections = ('AK4PF', ['L1FastJet', 'L2Relative', 'L3Absolute'], ''))
+    addJetCollection(process, postfix   = "ForMetUnc", labelName = 'AK4PF', jetSource = cms.InputTag('ak4PFJets'), jetCorrections = ('AK4PF', ['L1FastJet', 'L2Relative', 'L3Absolute'], ''), rParam = 0.4 )
     runMEtUncertainties(process,jetCollection="selectedPatJetsAK4PFForMetUnc", outputModule=None)
 
     #keep this after all addJetCollections otherwise it will attempt computing them also for stuf with no taginfos

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -111,7 +111,7 @@ def miniAOD_customizeCommon(process):
    # from RecoJets.JetProducers.ak4PFJets_cfi import ak4PFJets
     process.load("RecoJets.JetProducers.ak4PFJets_cfi")
     from PhysicsTools.PatUtils.tools.metUncertaintyTools import runMEtUncertainties
-    addJetCollection(process, postfix   = "ForMetUnc", labelName = 'AK4PF', jetSource = cms.InputTag('ak4PFJets'), jetCorrections = ('AK4PF', ['L1FastJet', 'L2Relative', 'L3Absolute'], ''), rParam = 0.4 )
+    addJetCollection(process, postfix   = "ForMetUnc", labelName = 'AK4PF', jetSource = cms.InputTag('ak4PFJets'), jetCorrections = ('AK4PF', ['L1FastJet', 'L2Relative', 'L3Absolute'], ''), rParam = 0.4, genJetCollection=cms.InputTag('ak4GenJets') )
     runMEtUncertainties(process,jetCollection="selectedPatJetsAK4PFForMetUnc", outputModule=None)
 
     #keep this after all addJetCollections otherwise it will attempt computing them also for stuf with no taginfos

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -107,6 +107,9 @@ def miniAOD_customizeCommon(process):
     #
     # apply type I/type I + II PFMEt corrections to pat::MET object
     # and estimate systematic uncertainties on MET
+    # reclustering of ak4 jets needed in 70X
+   # from RecoJets.JetProducers.ak4PFJets_cfi import ak4PFJets
+    process.load("RecoJets.JetProducers.ak4PFJets_cfi")
     from PhysicsTools.PatUtils.tools.metUncertaintyTools import runMEtUncertainties
     addJetCollection(process, postfix   = "ForMetUnc", labelName = 'AK4PF', jetSource = cms.InputTag('ak4PFJets'), jetCorrections = ('AK4PF', ['L1FastJet', 'L2Relative', 'L3Absolute'], ''))
     runMEtUncertainties(process,jetCollection="selectedPatJetsAK4PFForMetUnc", outputModule=None)

--- a/RecoJets/Configuration/python/RecoPFJets_cff.py
+++ b/RecoJets/Configuration/python/RecoPFJets_cff.py
@@ -160,7 +160,6 @@ recoPFJets   =cms.Sequence(#kt4PFJets+kt6PFJets+
                            fixedGridRhoFastjetAll+
                            fixedGridRhoFastjetCentralChargedPileUp+
                            fixedGridRhoFastjetCentralNeutral+
-                           ak4PFJets+
                            ak5PFJets+ak8PFJets+
                            pfNoPileUpJMESequence+
                            ak5PFJetsCHS+

--- a/RecoJets/Configuration/python/RecoPFJets_cff.py
+++ b/RecoJets/Configuration/python/RecoPFJets_cff.py
@@ -160,6 +160,7 @@ recoPFJets   =cms.Sequence(#kt4PFJets+kt6PFJets+
                            fixedGridRhoFastjetAll+
                            fixedGridRhoFastjetCentralChargedPileUp+
                            fixedGridRhoFastjetCentralNeutral+
+                           ak4PFJets+
                            ak5PFJets+ak8PFJets+
                            pfNoPileUpJMESequence+
                            ak5PFJetsCHS+


### PR DESCRIPTION
The AK5 jets has been switched to ak4 jets inthe MET uncertainty tool called in the miniAOD configuration for consistency with the other jets in the CMSSW_7_0_X release

Two files modified with the following change :
-miniAOD configuration changed
-recoPFJet sequence with now the build of ak4Jets
