### PR TITLE
Added callbacks to new module types for forking support

### DIFF
--- a/FWCore/Framework/interface/global/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/global/EDAnalyzerBase.h
@@ -95,11 +95,12 @@ namespace edm {
       void doEndLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
                                 ModuleCallingContext const*);
       
+      void doPreForkReleaseResources();
+      void doPostForkReacquireResources(unsigned int iChildIndex, unsigned int iNumberOfChildren);
+
       //For now, the following are just dummy implemenations with no ability for users to override
       void doRespondToOpenInputFile(FileBlock const& fb);
       void doRespondToCloseInputFile(FileBlock const& fb);
-      void doPreForkReleaseResources();
-      void doPostForkReacquireResources(unsigned int iChildIndex, unsigned int iNumberOfChildren);
       
       
       void registerProductsAndCallbacks(EDAnalyzerBase* module, ProductRegistry* reg);
@@ -108,6 +109,10 @@ namespace edm {
       virtual void analyze(StreamID, Event const& , EventSetup const&) const= 0;
       virtual void beginJob() {}
       virtual void endJob(){}
+      
+      virtual void preForkReleaseResources() {}
+      virtual void postForkReacquireResources(unsigned int /*iChildIndex*/, unsigned int /*iNumberOfChildren*/) {}
+
 
       virtual void preallocStreams(unsigned int);
       virtual void doBeginStream_(StreamID id);

--- a/FWCore/Framework/interface/global/EDFilterBase.h
+++ b/FWCore/Framework/interface/global/EDFilterBase.h
@@ -97,11 +97,12 @@ namespace edm {
       void doEndLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
                                 ModuleCallingContext const*);
       
+      void doPreForkReleaseResources();
+      void doPostForkReacquireResources(unsigned int iChildIndex, unsigned int iNumberOfChildren);
+
       //For now, the following are just dummy implemenations with no ability for users to override
       void doRespondToOpenInputFile(FileBlock const& fb);
       void doRespondToCloseInputFile(FileBlock const& fb);
-      void doPreForkReleaseResources();
-      void doPostForkReacquireResources(unsigned int iChildIndex, unsigned int iNumberOfChildren);
       
       
       void registerProductsAndCallbacks(EDFilterBase* module, ProductRegistry* reg) {
@@ -113,6 +114,9 @@ namespace edm {
       virtual void beginJob() {}
       virtual void endJob(){}
 
+      virtual void preForkReleaseResources() {}
+      virtual void postForkReacquireResources(unsigned int /*iChildIndex*/, unsigned int /*iNumberOfChildren*/) {}
+      
       virtual void preallocStreams(unsigned int);
       virtual void doBeginStream_(StreamID id);
       virtual void doEndStream_(StreamID id);

--- a/FWCore/Framework/interface/global/EDProducerBase.h
+++ b/FWCore/Framework/interface/global/EDProducerBase.h
@@ -100,11 +100,12 @@ namespace edm {
       void doEndLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
                                 ModuleCallingContext const*);
       
+      void doPreForkReleaseResources();
+      void doPostForkReacquireResources(unsigned int iChildIndex, unsigned int iNumberOfChildren);
+
       //For now, the following are just dummy implemenations with no ability for users to override
       void doRespondToOpenInputFile(FileBlock const& fb);
       void doRespondToCloseInputFile(FileBlock const& fb);
-      void doPreForkReleaseResources();
-      void doPostForkReacquireResources(unsigned int iChildIndex, unsigned int iNumberOfChildren);
       
       
       void registerProductsAndCallbacks(EDProducerBase* module, ProductRegistry* reg) {
@@ -116,6 +117,9 @@ namespace edm {
       virtual void beginJob() {}
       virtual void endJob(){}
 
+      virtual void preForkReleaseResources() {}
+      virtual void postForkReacquireResources(unsigned int /*iChildIndex*/, unsigned int /*iNumberOfChildren*/) {}
+      
       virtual void preallocStreams(unsigned int);
       virtual void doBeginStream_(StreamID id);
       virtual void doEndStream_(StreamID id);

--- a/FWCore/Framework/interface/one/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/one/EDAnalyzerBase.h
@@ -82,11 +82,12 @@ namespace edm {
       void doEndLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
                                 ModuleCallingContext const*);
       
+      void doPreForkReleaseResources();
+      void doPostForkReacquireResources(unsigned int iChildIndex, unsigned int iNumberOfChildren);
+
       //For now, the following are just dummy implemenations with no ability for users to override
       void doRespondToOpenInputFile(FileBlock const& fb);
       void doRespondToCloseInputFile(FileBlock const& fb);
-      void doPreForkReleaseResources();
-      void doPostForkReacquireResources(unsigned int iChildIndex, unsigned int iNumberOfChildren);
 
       
       void registerProductsAndCallbacks(EDAnalyzerBase const* module, ProductRegistry* reg);
@@ -95,6 +96,10 @@ namespace edm {
       virtual void analyze(Event const&, EventSetup const&) = 0;
       virtual void beginJob() {}
       virtual void endJob(){}
+      
+      virtual void preForkReleaseResources() {}
+      virtual void postForkReacquireResources(unsigned int /*iChildIndex*/, unsigned int /*iNumberOfChildren*/) {}
+
 
       virtual void doBeginRun_(Run const& rp, EventSetup const& c);
       virtual void doEndRun_(Run const& rp, EventSetup const& c);

--- a/FWCore/Framework/interface/one/EDFilterBase.h
+++ b/FWCore/Framework/interface/one/EDFilterBase.h
@@ -78,11 +78,12 @@ namespace edm {
       void doEndLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
                                 ModuleCallingContext const*);
       
+      void doPreForkReleaseResources();
+      void doPostForkReacquireResources(unsigned int iChildIndex, unsigned int iNumberOfChildren);
+
       //For now, the following are just dummy implemenations with no ability for users to override
       void doRespondToOpenInputFile(FileBlock const& fb);
       void doRespondToCloseInputFile(FileBlock const& fb);
-      void doPreForkReleaseResources();
-      void doPostForkReacquireResources(unsigned int iChildIndex, unsigned int iNumberOfChildren);
 
       
       void registerProductsAndCallbacks(EDFilterBase* module, ProductRegistry* reg) {
@@ -93,6 +94,9 @@ namespace edm {
       virtual bool filter(Event&, EventSetup const&) = 0;
       virtual void beginJob() {}
       virtual void endJob(){}
+
+      virtual void preForkReleaseResources() {}
+      virtual void postForkReacquireResources(unsigned int /*iChildIndex*/, unsigned int /*iNumberOfChildren*/) {}
 
       virtual void doBeginRun_(Run const& rp, EventSetup const& c);
       virtual void doEndRun_(Run const& rp, EventSetup const& c);

--- a/FWCore/Framework/interface/one/EDProducerBase.h
+++ b/FWCore/Framework/interface/one/EDProducerBase.h
@@ -77,11 +77,12 @@ namespace edm {
       void doEndLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
                                 ModuleCallingContext const*);
 
+      void doPreForkReleaseResources();
+      void doPostForkReacquireResources(unsigned int iChildIndex, unsigned int iNumberOfChildren);
+
       //For now, the following are just dummy implemenations with no ability for users to override
       void doRespondToOpenInputFile(FileBlock const& fb);
       void doRespondToCloseInputFile(FileBlock const& fb);
-      void doPreForkReleaseResources();
-      void doPostForkReacquireResources(unsigned int iChildIndex, unsigned int iNumberOfChildren);
 
       
       void registerProductsAndCallbacks(EDProducerBase* module, ProductRegistry* reg) {
@@ -92,6 +93,9 @@ namespace edm {
       virtual void produce(Event&, EventSetup const&) = 0;
       virtual void beginJob() {}
       virtual void endJob(){}
+
+      virtual void preForkReleaseResources() {}
+      virtual void postForkReacquireResources(unsigned int /*iChildIndex*/, unsigned int /*iNumberOfChildren*/) {}
 
       virtual void doBeginRun_(Run const& rp, EventSetup const& c);
       virtual void doEndRun_(Run const& rp, EventSetup const& c);

--- a/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
@@ -135,11 +135,12 @@ namespace edm {
       virtual void doEndLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
                                         ModuleCallingContext const*)=0;
 
+      void doPreForkReleaseResources();
+      void doPostForkReacquireResources(unsigned int iChildIndex, unsigned int iNumberOfChildren);
+
       //For now, the following are just dummy implemenations with no ability for users to override
       void doRespondToOpenInputFile(FileBlock const& fb);
       void doRespondToCloseInputFile(FileBlock const& fb);
-      void doPreForkReleaseResources();
-      void doPostForkReacquireResources(unsigned int iChildIndex, unsigned int iNumberOfChildren);
 
       // ---------- member data --------------------------------
       void setModuleDescription(ModuleDescription const& md) {

--- a/FWCore/Framework/interface/stream/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerBase.h
@@ -70,6 +70,10 @@ namespace edm {
       virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {}
       virtual void endRun(edm::Run const&, edm::EventSetup const&) {}
       virtual void endStream(){}
+      
+      virtual void preForkReleaseResources() {}
+      virtual void postForkReacquireResources(unsigned int /*iChildIndex*/, unsigned int /*iNumberOfChildren*/) {}
+
 
       void setModuleDescriptionPtr(ModuleDescription const* iDesc) {
         moduleDescriptionPtr_ = iDesc;

--- a/FWCore/Framework/interface/stream/EDFilterBase.h
+++ b/FWCore/Framework/interface/stream/EDFilterBase.h
@@ -68,6 +68,9 @@ namespace edm {
       virtual void endRun(edm::Run const&, edm::EventSetup const&) {}
       virtual void endStream(){}
 
+      virtual void preForkReleaseResources() {}
+      virtual void postForkReacquireResources(unsigned int /*iChildIndex*/, unsigned int /*iNumberOfChildren*/) {}
+
       void setModuleDescriptionPtr(ModuleDescription const* iDesc) {
         moduleDescriptionPtr_ = iDesc;
       }

--- a/FWCore/Framework/interface/stream/EDProducerBase.h
+++ b/FWCore/Framework/interface/stream/EDProducerBase.h
@@ -68,6 +68,9 @@ namespace edm {
       virtual void endRun(edm::Run const&, edm::EventSetup const&) {}
       virtual void endStream(){}
 
+      virtual void preForkReleaseResources() {}
+      virtual void postForkReacquireResources(unsigned int /*iChildIndex*/, unsigned int /*iNumberOfChildren*/) {}
+
       void setModuleDescriptionPtr(ModuleDescription const* iDesc) {
         moduleDescriptionPtr_ = iDesc;
       }

--- a/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
@@ -148,11 +148,12 @@ namespace edm {
                                         EventSetup const& c,
                                         ModuleCallingContext const*)=0;
       
+      void doPreForkReleaseResources();
+      void doPostForkReacquireResources(unsigned int iChildIndex, unsigned int iNumberOfChildren);
+
       //For now, the following are just dummy implemenations with no ability for users to override
       void doRespondToOpenInputFile(FileBlock const& fb);
       void doRespondToCloseInputFile(FileBlock const& fb);
-      void doPreForkReleaseResources();
-      void doPostForkReacquireResources(unsigned int iChildIndex, unsigned int iNumberOfChildren);
 
       // ---------- member data --------------------------------
       void setModuleDescription(ModuleDescription const& md) {

--- a/FWCore/Framework/src/global/EDAnalyzerBase.cc
+++ b/FWCore/Framework/src/global/EDAnalyzerBase.cc
@@ -180,12 +180,12 @@ namespace edm {
     
     void
     EDAnalyzerBase::doPreForkReleaseResources() {
-      //preForkReleaseResources();
+      preForkReleaseResources();
     }
     
     void
     EDAnalyzerBase::doPostForkReacquireResources(unsigned int iChildIndex, unsigned int iNumberOfChildren) {
-      //postForkReacquireResources(iChildIndex, iNumberOfChildren);
+      postForkReacquireResources(iChildIndex, iNumberOfChildren);
     }
     
     void EDAnalyzerBase::preallocStreams(unsigned int) {}

--- a/FWCore/Framework/src/global/EDFilterBase.cc
+++ b/FWCore/Framework/src/global/EDFilterBase.cc
@@ -189,12 +189,12 @@ namespace edm {
     
     void
     EDFilterBase::doPreForkReleaseResources() {
-      //preForkReleaseResources();
+      preForkReleaseResources();
     }
     
     void
     EDFilterBase::doPostForkReacquireResources(unsigned int iChildIndex, unsigned int iNumberOfChildren) {
-      //postForkReacquireResources(iChildIndex, iNumberOfChildren);
+      postForkReacquireResources(iChildIndex, iNumberOfChildren);
     }
     
     void EDFilterBase::preallocStreams(unsigned int) {}

--- a/FWCore/Framework/src/global/EDProducerBase.cc
+++ b/FWCore/Framework/src/global/EDProducerBase.cc
@@ -189,12 +189,12 @@ namespace edm {
     
     void
     EDProducerBase::doPreForkReleaseResources() {
-      //preForkReleaseResources();
+      preForkReleaseResources();
     }
     
     void
     EDProducerBase::doPostForkReacquireResources(unsigned int iChildIndex, unsigned int iNumberOfChildren) {
-      //postForkReacquireResources(iChildIndex, iNumberOfChildren);
+      postForkReacquireResources(iChildIndex, iNumberOfChildren);
     }
     
     void EDProducerBase::preallocStreams(unsigned int) {}

--- a/FWCore/Framework/src/one/EDAnalyzerBase.cc
+++ b/FWCore/Framework/src/one/EDAnalyzerBase.cc
@@ -125,12 +125,12 @@ namespace edm {
     
     void
     EDAnalyzerBase::doPreForkReleaseResources() {
-      //preForkReleaseResources();
+      preForkReleaseResources();
     }
     
     void
     EDAnalyzerBase::doPostForkReacquireResources(unsigned int iChildIndex, unsigned int iNumberOfChildren) {
-      //postForkReacquireResources(iChildIndex, iNumberOfChildren);
+      postForkReacquireResources(iChildIndex, iNumberOfChildren);
     }
     
     void EDAnalyzerBase::doBeginRun_(Run const& rp, EventSetup const& c) {}

--- a/FWCore/Framework/src/one/EDFilterBase.cc
+++ b/FWCore/Framework/src/one/EDFilterBase.cc
@@ -139,12 +139,12 @@ namespace edm {
     
     void
     EDFilterBase::doPreForkReleaseResources() {
-      //preForkReleaseResources();
+      preForkReleaseResources();
     }
     
     void
     EDFilterBase::doPostForkReacquireResources(unsigned int iChildIndex, unsigned int iNumberOfChildren) {
-      //postForkReacquireResources(iChildIndex, iNumberOfChildren);
+      postForkReacquireResources(iChildIndex, iNumberOfChildren);
     }
     
     void EDFilterBase::doBeginRun_(Run const& rp, EventSetup const& c) {}

--- a/FWCore/Framework/src/one/EDProducerBase.cc
+++ b/FWCore/Framework/src/one/EDProducerBase.cc
@@ -137,12 +137,12 @@ namespace edm {
     
     void
     EDProducerBase::doPreForkReleaseResources() {
-      //preForkReleaseResources();
+      preForkReleaseResources();
     }
     
     void
     EDProducerBase::doPostForkReacquireResources(unsigned int iChildIndex, unsigned int iNumberOfChildren) {
-      //postForkReacquireResources(iChildIndex, iNumberOfChildren);
+      postForkReacquireResources(iChildIndex, iNumberOfChildren);
     }
     
     void EDProducerBase::doBeginRun_(Run const& rp, EventSetup const& c) {}

--- a/FWCore/Framework/src/stream/EDAnalyzerAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/EDAnalyzerAdaptorBase.cc
@@ -204,6 +204,16 @@ EDAnalyzerAdaptorBase::doRespondToOpenInputFile(FileBlock const& fb){}
 void
 EDAnalyzerAdaptorBase::doRespondToCloseInputFile(FileBlock const& fb){}
 void
-EDAnalyzerAdaptorBase::doPreForkReleaseResources(){}
+EDAnalyzerAdaptorBase::doPreForkReleaseResources()
+{
+  for(auto mod: m_streamModules) {
+    mod->preForkReleaseResources();
+  }
+}
 void
-EDAnalyzerAdaptorBase::doPostForkReacquireResources(unsigned int iChildIndex, unsigned int iNumberOfChildren){}
+EDAnalyzerAdaptorBase::doPostForkReacquireResources(unsigned int iChildIndex, unsigned int iNumberOfChildren)
+{
+  for(auto mod: m_streamModules) {
+    mod->postForkReacquireResources(iChildIndex,iNumberOfChildren);
+  }
+}

--- a/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
@@ -202,9 +202,17 @@ namespace edm {
     ProducingModuleAdaptorBase<T>::doRespondToCloseInputFile(FileBlock const& fb){}
     template< typename T>
     void
-    ProducingModuleAdaptorBase<T>::doPreForkReleaseResources(){}
+    ProducingModuleAdaptorBase<T>::doPreForkReleaseResources(){
+      for(auto m: m_streamModules) {
+        m->preForkReleaseResources();
+      }
+    }
     template< typename T>
     void
-    ProducingModuleAdaptorBase<T>::doPostForkReacquireResources(unsigned int iChildIndex, unsigned int iNumberOfChildren){}
+    ProducingModuleAdaptorBase<T>::doPostForkReacquireResources(unsigned int iChildIndex, unsigned int iNumberOfChildren){
+      for(auto m: m_streamModules) {
+        m->postForkReacquireResources(iChildIndex,iNumberOfChildren);
+      }
+    }
   }
 }


### PR DESCRIPTION
On request from HLT, I added the callbacks used by the forking mechanism.
NOTE: forking and threading should not be used together in the same job.
