### PR TITLE
separate token for the view

### DIFF
--- a/CommonTools/ParticleFlow/plugins/PFPileUp.cc
+++ b/CommonTools/ParticleFlow/plugins/PFPileUp.cc
@@ -19,6 +19,8 @@ PFPileUp::PFPileUp(const edm::ParameterSet& iConfig) {
 
   tokenPFCandidates_
     = consumes<PFCollection>(iConfig.getParameter<InputTag>("PFCandidates"));
+  tokenPFCandidatesView_
+    = mayConsume<PFView>(iConfig.getParameter<InputTag>("PFCandidates"));
 
   tokenVertices_
     = consumes<VertexCollection>(iConfig.getParameter<InputTag>("Vertices"));
@@ -87,7 +89,7 @@ void PFPileUp::produce(Event& iEvent,
     // then we can pass it to the PFPileupAlgo.
     else {
       Handle<PFView> pfView;
-      bool getFromView = iEvent.getByToken( tokenPFCandidates_, pfView );
+      bool getFromView = iEvent.getByToken( tokenPFCandidatesView_, pfView );
       if ( ! getFromView ) {
 	throw cms::Exception("PFPileUp is misconfigured. This needs to be either vector<FwdPtr<PFCandidate> >, or View<PFCandidate>");
       }

--- a/CommonTools/ParticleFlow/plugins/PFPileUp.h
+++ b/CommonTools/ParticleFlow/plugins/PFPileUp.h
@@ -50,6 +50,8 @@ class PFPileUp : public edm::stream::EDProducer<> {
 
   /// PFCandidates to be analyzed
   edm::EDGetTokenT<PFCollection>   tokenPFCandidates_;
+  /// fall-back token
+  edm::EDGetTokenT<PFView>   tokenPFCandidatesView_;
 
   /// vertices
   edm::EDGetTokenT<reco::VertexCollection>   tokenVertices_;


### PR DESCRIPTION
use a token with correct type for the fall-back case of using a candidate view as an input.
