### PR TITLE
add triple electron path in the Higgs/Hzz directory 

### DIFF
--- a/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
+++ b/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
@@ -108,6 +108,7 @@ hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
 	    hltPathsToCheck = cms.vstring(
 		    "HLT_Mu17_TkMu8_v",
 		    "HLT_Ele17_CaloIdT_CaloIsoVL_TrkIdVL_TrkIsoVL_Ele8_CaloIdT_CaloIsoVL_TrkIdVL_TrkIsoVL_v",
+            "HLT_Ele17_Ele12_Ele10_CaloId_TrackId_v"
 		    ),
 	    recMuonLabel  = cms.string("muons"),
 	    recElecLabel  = cms.string("gedGsfElectrons"),

--- a/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
+++ b/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
@@ -94,7 +94,7 @@ hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
 		    "HLT_Mu8_Ele17_CaloIdT_CaloIsoVL_TrkIdVL_TrkIsoVL_v",
 		    "HLT_Ele17_CaloIdT_CaloIsoVL_TrkIdVL_TrkIsoVL_Ele8_CaloIdT_CaloIsoVL_TrkIdVL_TrkIsoVL_v",
 		    "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_v",
-                    "HLT_Mu17_TrkIsoVVL_kMu8_TrkIsoVVL_v",
+                    "HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_v",
                     "HLT_Mu23_TrkIsoVVL_Ele12_Gsf_CaloId_TrackId_Iso_MediumWP_v",
                     "HLT_Mu8_TrkIsoVVL_Ele23_Gsf_CaloId_TrackId_Iso_MediumWP_v",
                     "HLT_Ele23_Ele12_CaloId_TrackId_Iso_v"


### PR DESCRIPTION
addition of the template menu's path HLT_Ele17_Ele12_Ele10_CaloId_TrackId in the list of path monitored in the Hzz directory of the Higgs HLT validation DQM.
