### PR TITLE
FastSim : PileUpProducer : fix to number of interactions

### DIFF
--- a/FastSimulation/PileUpProducer/plugins/PileUpProducer.cc
+++ b/FastSimulation/PileUpProducer/plugins/PileUpProducer.cc
@@ -249,7 +249,7 @@ void PileUpProducer::produce(edm::Event & iEvent, const edm::EventSetup & es)
     // other modules using it also declare the same shared resource.
     // This also breaks replay.
     float d = (float) hprob->GetRandom();
-    PUevts = (int) d;
+    PUevts = (int) random.poissonShoot(d);
     truePUevts = d;
   }
   //  std::cout << "PUevts = " << PUevts << std::endl;


### PR DESCRIPTION
The distribution of the number of PU interactions can be provided by the user as a histogram in txt format. In FullSim it is assumed that the distribution of true number of interactions is provided, while in FastSim it is assumed the distribution of actual number of pu interactions is provided.

With this fix, FastSim moves to the FullSim assumption.
