### PR TITLE
backport of TauolaInterface for Tauola 1.1.4 from 7_2_X to 5_3_X

### DIFF
--- a/GeneratorInterface/ExternalDecays/src/ExternalDecayDriver.cc
+++ b/GeneratorInterface/ExternalDecays/src/ExternalDecayDriver.cc
@@ -47,8 +47,8 @@ ExternalDecayDriver::ExternalDecayDriver( const ParameterSet& pset )
       fTauolaInterface = (TauolaInterfaceBase*)(TauolaFactory::get()->create("Tauola271215", pset.getUntrackedParameter< ParameterSet >(curSet)));
       fTauolaInterface->SetDecayRandomEngine(decayRandomEngine);
     }
-    if(curSet =="Tauolapp111a"){
-      fTauolaInterface = (TauolaInterfaceBase*)(TauolaFactory::get()->create("Tauolapp111a", pset.getUntrackedParameter< ParameterSet >(curSet)));
+    if(curSet =="Tauolapp114"){
+      fTauolaInterface = (TauolaInterfaceBase*)(TauolaFactory::get()->create("Tauolapp114", pset.getUntrackedParameter< ParameterSet >(curSet)));
       fPhotosInterface = (PhotosInterfaceBase*)(PhotosFactory::get()->create("Photos2155", pset.getUntrackedParameter< ParameterSet >(curSet)));
       fPhotosInterface->SetDecayRandomEngine(decayRandomEngine);
       fPhotosInterface->configureOnlyFor(15); 

--- a/GeneratorInterface/TauolaInterface/interface/TauolappInterface.h
+++ b/GeneratorInterface/TauolaInterface/interface/TauolappInterface.h
@@ -54,12 +54,11 @@ namespace gen {
       //TauolappInterface();
       
       // member function(s)
-      float flat();
       void decodeMDTAU( int );
       void selectDecayByMDTAU();
       int selectLeptonic();
       int selectHadronic();
-      
+      double flat();
       
       //
       CLHEP::HepRandomEngine*                  fRandomEngine;            

--- a/GeneratorInterface/TauolaInterface/plugins/BuildFile.xml
+++ b/GeneratorInterface/TauolaInterface/plugins/BuildFile.xml
@@ -36,6 +36,8 @@
   <use name="tauolapp"/>
   <use name="lhapdf"/>
   <use name="root"/>
+  <use name="rootmath"/>
   <use name="clhep"/>
   <flags   EDM_PLUGIN="1"/>
 </library>
+

--- a/GeneratorInterface/TauolaInterface/plugins/TauSpinner/TauSpinnerCMS.cc
+++ b/GeneratorInterface/TauolaInterface/plugins/TauSpinner/TauSpinnerCMS.cc
@@ -70,6 +70,9 @@ void TauSpinnerCMS::beginJob()
 }
 
 void TauSpinnerCMS::produce( edm::Event& e, const edm::EventSetup& iSetup){
+
+  Tauolapp::Tauola::setRandomGenerator(TauSpinnerCMS::flat); // rest tauola++ random number incase other modules use tauola++
+  Tauolapp::jaki_.ktom = 1; // rest for when you run after tauola
   double WT=1.0;
   double WTFlip=1.0;
   double polSM=-999; //range [-1,1]
@@ -84,35 +87,35 @@ void TauSpinnerCMS::produce( edm::Event& e, const edm::EventSetup& iSetup){
     e.getByLabel( "generator", EvtHandle ) ;
     const HepMC::GenEvent* Evt = EvtHandle->GetEvent() ;
     stat=readParticlesFromHepMC(Evt,X,tau,tau2,tau_daughters,tau_daughters2);
-  }  
+  }
   if(MotherPDGID_<0 || abs(X.pdgid())==MotherPDGID_){
     if(stat!=1){
-      // Determine the weight      
-      if( abs(X.pdgid())==24 ||  abs(X.pdgid())==37 ){
+      // Determine the weight
+      if( abs(X.pdgid())==24 || abs(X.pdgid())==37 ){
         TLorentzVector tau_1r(0,0,0,0);
         TLorentzVector tau_1(tau.px(),tau.py(),tau.pz(),tau.e());
         for(unsigned int i=0; i<tau_daughters.size();i++){
           tau_1r+=TLorentzVector(tau_daughters.at(i).px(),tau_daughters.at(i).py(),tau_daughters.at(i).pz(),tau_daughters.at(i).e());
         }
-	if(fabs(tau_1r.M()-tau_1.M())<roundOff_){
-	  WT = TauSpinner::calculateWeightFromParticlesWorHpn(X, tau, tau2, tau_daughters); // note that tau2 is tau neutrino
-	  polSM=getTauSpin();
-	  WTFlip=(2.0-WT)/WT;
-	}
+        if(fabs(tau_1r.M()-tau_1.M())<roundOff_){
+          WT = TauSpinner::calculateWeightFromParticlesWorHpn(X, tau, tau2, tau_daughters); // note that tau2 is tau neutrino
+          polSM=getTauSpin();
+          WTFlip=(2.0-WT)/WT;
+        }
       }
       else if( X.pdgid()==25 || X.pdgid()==36 || X.pdgid()==22 || X.pdgid()==23 ){
-	TLorentzVector tau_1r(0,0,0,0), tau_2r(0,0,0,0);
-	TLorentzVector tau_1(tau.px(),tau.py(),tau.pz(),tau.e()), tau_2(tau2.px(),tau2.py(),tau2.pz(),tau2.e());
-	for(unsigned int i=0; i<tau_daughters.size();i++){
-	  tau_1r+=TLorentzVector(tau_daughters.at(i).px(),tau_daughters.at(i).py(),tau_daughters.at(i).pz(),tau_daughters.at(i).e());
-	}
-	for(unsigned int i=0; i<tau_daughters2.size();i++){
-	  tau_2r+=TLorentzVector(tau_daughters2.at(i).px(),tau_daughters2.at(i).py(),tau_daughters2.at(i).pz(),tau_daughters2.at(i).e());
-	}
+        TLorentzVector tau_1r(0,0,0,0), tau_2r(0,0,0,0);
+        TLorentzVector tau_1(tau.px(),tau.py(),tau.pz(),tau.e()), tau_2(tau2.px(),tau2.py(),tau2.pz(),tau2.e());
+        for(unsigned int i=0; i<tau_daughters.size();i++){
+          tau_1r+=TLorentzVector(tau_daughters.at(i).px(),tau_daughters.at(i).py(),tau_daughters.at(i).pz(),tau_daughters.at(i).e());
+        }
+        for(unsigned int i=0; i<tau_daughters2.size();i++){
+          tau_2r+=TLorentzVector(tau_daughters2.at(i).px(),tau_daughters2.at(i).py(),tau_daughters2.at(i).pz(),tau_daughters2.at(i).e());
+        }
 
         if(fabs(tau_1r.M()-tau_1.M())<roundOff_ && fabs(tau_2r.M()-tau_2.M())<roundOff_){
           WT = TauSpinner::calculateWeightFromParticlesH(X, tau, tau2, tau_daughters,tau_daughters2);
-	  //std::cout << "WT " << WT << std::endl;
+          //std::cout << "WT " << WT << std::endl;
           polSM=getTauSpin();
           if(X.pdgid()==25 || X.pdgid()==22 || X.pdgid()==23 ){
             if(X.pdgid()==25) X.setPdgid(23);
@@ -124,7 +127,7 @@ void TauSpinnerCMS::produce( edm::Event& e, const edm::EventSetup& iSetup){
         }
       }
       else{
-	cout<<"TauSpinner: WARNING: Unexpected PDG for tau mother: "<<X.pdgid()<<endl;
+        cout<<"TauSpinner: WARNING: Unexpected PDG for tau mother: "<<X.pdgid()<<endl;
       }
     }
   }
@@ -136,17 +139,17 @@ void TauSpinnerCMS::produce( edm::Event& e, const edm::EventSetup& iSetup){
 
   // regular weight
   std::auto_ptr<double> TauSpinnerWeight(new double);
-  *TauSpinnerWeight =WT;    
-  e.put(TauSpinnerWeight,"TauSpinnerWT");  
-  
+  *TauSpinnerWeight =WT;
+  e.put(TauSpinnerWeight,"TauSpinnerWT");
+
   // flipped weight (ie Z->H or H->Z)
   std::auto_ptr<double> TauSpinnerWeightFlip(new double);
   *TauSpinnerWeightFlip =WTFlip;
   e.put(TauSpinnerWeightFlip,"TauSpinnerWTFlip");
-  
+
   // h+ polarization
   double WThplus=WT;
-  if(polSM<0.0 && polSM!=-999 && isValid) WThplus=0; 
+  if(polSM<0.0 && polSM!=-999 && isValid) WThplus=0;
   std::auto_ptr<double> TauSpinnerWeighthplus(new double);
   *TauSpinnerWeighthplus = WThplus;
   e.put(TauSpinnerWeighthplus,"TauSpinnerWThplus");
@@ -157,7 +160,6 @@ void TauSpinnerCMS::produce( edm::Event& e, const edm::EventSetup& iSetup){
   std::auto_ptr<double> TauSpinnerWeighthminus(new double);
   *TauSpinnerWeighthminus = WThminus;
   e.put(TauSpinnerWeighthminus,"TauSpinnerWThminus");
-  
   return ;
 }  
 

--- a/GeneratorInterface/TauolaInterface/plugins/Tauolapp/module.cc
+++ b/GeneratorInterface/TauolaInterface/plugins/Tauolapp/module.cc
@@ -3,4 +3,4 @@
 #include "GeneratorInterface/TauolaInterface/interface/TauolaFactory.h"
 #include "GeneratorInterface/TauolaInterface/interface/TauolappInterface.h"
 
-DEFINE_EDM_PLUGIN(TauolaFactory, gen::TauolappInterface, "Tauolapp111a");
+DEFINE_EDM_PLUGIN(TauolaFactory, gen::TauolappInterface, "Tauolapp114");

--- a/GeneratorInterface/TauolaInterface/test/DYToLL_M_50_TuneZ2star_8TeV_Tauola_TauSpinner_Example_cfi.py
+++ b/GeneratorInterface/TauolaInterface/test/DYToLL_M_50_TuneZ2star_8TeV_Tauola_TauSpinner_Example_cfi.py
@@ -25,47 +25,47 @@ process.load("GeneratorInterface.TauolaInterface.TauSpinner_cfi")
 process.load("GeneratorInterface.TauolaInterface.TauSpinnerFilter_cfi")
 
 process.maxEvents = cms.untracked.PSet(
-        input = cms.untracked.int32(10000)
-        )
+    input = cms.untracked.int32(10000)
+)
 
 # Input source
 process.source = cms.Source("EmptySource")
 
 process.options = cms.untracked.PSet(
 
-    )
+)
 
 # Production Info
 process.configurationMetadata = cms.untracked.PSet(
-        version = cms.untracked.string('$Revision: 1.381.2.28 $'),
-            annotation = cms.untracked.string('DYToLL_M_50_TuneZ2star_8TeV_pythia6_tauola_cff nevts:1000'),
-            name = cms.untracked.string('PyReleaseValidation')
-        )
+    version = cms.untracked.string('$Revision: 1.381.2.28 $'),
+    annotation = cms.untracked.string('DYToLL_M_50_TuneZ2star_8TeV_pythia6_tauola_cff nevts:1000'),
+    name = cms.untracked.string('PyReleaseValidation')
+)
 
 # Output definition
 
 process.RAWSIMoutput = cms.OutputModule("PoolOutputModule",
-                                            splitLevel = cms.untracked.int32(0),
-                                            eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
-                                            outputCommands = process.RAWSIMEventContent.outputCommands,
-                                            fileName = cms.untracked.string('DYToLL_M_50_TuneZ2star_8TeV_pythia6_tauola_cff_GEN_VALIDATION.root'),
-                                            dataset = cms.untracked.PSet(
-            filterName = cms.untracked.string(''),
-                    dataTier = cms.untracked.string('GEN')
-                ),
-                                            SelectEvents = cms.untracked.PSet(
-            SelectEvents = cms.vstring('generation_step')
-                )
-                                        )
+    splitLevel = cms.untracked.int32(0),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
+    outputCommands = process.RAWSIMEventContent.outputCommands,
+    fileName = cms.untracked.string('file:step1.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('GEN')
+    ),
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('generation_step')
+    )
+)
 
 # Additional output definition
 
 process.RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService",
-                                                   generator = cms.PSet(initialSeed = cms.untracked.uint32(12345)),
-                                                   TauSpinnerGen = cms.PSet(initialSeed = cms.untracked.uint32(12345)),
-                                                   TauSpinnerZHFilter = cms.PSet(initialSeed = cms.untracked.uint32(429842)),
-                                                   VtxSmeared = cms.PSet(initialSeed = cms.untracked.uint32(275744))
-                                                   )
+generator = cms.PSet(initialSeed = cms.untracked.uint32(12345)),
+TauSpinnerGen = cms.PSet(initialSeed = cms.untracked.uint32(12345)),
+TauSpinnerZHFilter = cms.PSet(initialSeed = cms.untracked.uint32(429842)),
+VtxSmeared = cms.PSet(initialSeed = cms.untracked.uint32(275744))
+)
 
 
 # Other statements
@@ -75,66 +75,67 @@ from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:startup', '')
 
 process.generator = cms.EDFilter("Pythia6GeneratorFilter",
-                                     ExternalDecays = cms.PSet(
-            Tauola = cms.untracked.PSet(
-                UseTauolaPolarization = cms.bool(False),
-                            InputCards = cms.PSet(
-                    mdtau = cms.int32(0),
-                                    pjak2 = cms.int32(3),
-                                    pjak1 = cms.int32(3)
-                                )
-                        ),
-                    parameterSets = cms.vstring('Tauola')
-                ),
-                                     maxEventsToPrint = cms.untracked.int32(0),
-                                     pythiaPylistVerbosity = cms.untracked.int32(1),
-                                     filterEfficiency = cms.untracked.double(1.0),
-                                     pythiaHepMCVerbosity = cms.untracked.bool(False),
-                                     comEnergy = cms.double(8000.0),
-                                     crossSection = cms.untracked.double(762.0),
-                                     UseExternalGenerators = cms.untracked.bool(True),
-                                     PythiaParameters = cms.PSet(
-            pythiaUESettings = cms.vstring('MSTU(21)=1 ! Check on possible errors during program execution',
-                                                       'MSTJ(22)=2 ! Decay those unstable particles',
-                                                       'PARJ(71)=10 . ! for which ctau 10 mm',
-                                                       'MSTP(33)=0 ! no K factors in hard cross sections',
-                                                       'MSTP(2)=1 ! which order running alphaS',
-                                                       'MSTP(51)=10042 ! structure function chosen (external PDF CTEQ6L1)',
-                                                       'MSTP(52)=2 ! work with LHAPDF',
-                                                       'PARP(82)=1.921 ! pt cutoff for multiparton interactions',
-                                                       'PARP(89)=1800. ! sqrts for which PARP82 is set',
-                                                       'PARP(90)=0.227 ! Multiple interactions: rescaling power',
-                                                       'MSTP(95)=6 ! CR (color reconnection parameters)',
-                                                       'PARP(77)=1.016 ! CR',
-                                                       'PARP(78)=0.538 ! CR',
-                                                       'PARP(80)=0.1 ! Prob. colored parton from BBR',
-                                                       'PARP(83)=0.356 ! Multiple interactions: matter distribution parameter',
-                                                       'PARP(84)=0.651 ! Multiple interactions: matter distribution parameter',
-                                                       'PARP(62)=1.025 ! ISR cutoff',
-                                                       'MSTP(91)=1 ! Gaussian primordial kT',
-                                                       'PARP(93)=10.0 ! primordial kT-max',
-                                                       'MSTP(81)=21 ! multiple parton interactions 1 is Pythia default',
-                                                       'MSTP(82)=4 ! Defines the multi-parton model'),
-                    processParameters = cms.vstring('MSEL=0 !User defined processes',
-                                                                'MSUB(1)=1 !Incl Z0/gamma* production',
-                                                                'MSTP(43)=3 !Both Z0 and gamma*',
-                                                                'MDME(174,1)=0 !Z decay into d dbar',
-                                                                'MDME(175,1)=0 !Z decay into u ubar',
-                                                                'MDME(176,1)=0 !Z decay into s sbar',
-                                                                'MDME(177,1)=0 !Z decay into c cbar',
-                                                                'MDME(178,1)=0 !Z decay into b bbar',
-                                                                'MDME(179,1)=0 !Z decay into t tbar',
-                                                                'MDME(182,1)=1 !Z decay into e- e+',
-                                                                'MDME(183,1)=0 !Z decay into nu_e nu_ebar',
-                                                                'MDME(184,1)=1 !Z decay into mu- mu+',
-                                                                'MDME(185,1)=0 !Z decay into nu_mu nu_mubar',
-                                                                'MDME(186,1)=1 !Z decay into tau- tau+',
-                                                                'MDME(187,1)=0 !Z decay into nu_tau nu_taubar',
-                                                                'CKIN(1)=50. !Minimum sqrt(s_hat) value (=Z mass)'),
-                    parameterSets = cms.vstring('pythiaUESettings',
-                                                            'processParameters')
-                )
-                                 )
+    ExternalDecays = cms.PSet(
+        Tauolapp114 = cms.untracked.PSet(
+            UseTauolaPolarization = cms.bool(False),
+parameterSets = cms.vstring(),
+            InputCards = cms.PSet(
+                mdtau = cms.int32(0),
+                pjak2 = cms.int32(3),
+                pjak1 = cms.int32(3)
+            )
+        ),
+        parameterSets = cms.vstring('Tauolapp114')
+    ),
+    maxEventsToPrint = cms.untracked.int32(0),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    filterEfficiency = cms.untracked.double(1.0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(13000.0),
+    crossSection = cms.untracked.double(762.0),
+    UseExternalGenerators = cms.untracked.bool(True),
+    PythiaParameters = cms.PSet(
+        pythiaUESettings = cms.vstring('MSTU(21)=1 ! Check on possible errors during program execution',
+            'MSTJ(22)=2 ! Decay those unstable particles',
+            'PARJ(71)=10 . ! for which ctau 10 mm',
+            'MSTP(33)=0 ! no K factors in hard cross sections',
+            'MSTP(2)=1 ! which order running alphaS',
+            'MSTP(51)=10042 ! structure function chosen (external PDF CTEQ6L1)',
+            'MSTP(52)=2 ! work with LHAPDF',
+            'PARP(82)=1.921 ! pt cutoff for multiparton interactions',
+            'PARP(89)=1800. ! sqrts for which PARP82 is set',
+            'PARP(90)=0.227 ! Multiple interactions: rescaling power',
+            'MSTP(95)=6 ! CR (color reconnection parameters)',
+            'PARP(77)=1.016 ! CR',
+            'PARP(78)=0.538 ! CR',
+            'PARP(80)=0.1 ! Prob. colored parton from BBR',
+            'PARP(83)=0.356 ! Multiple interactions: matter distribution parameter',
+            'PARP(84)=0.651 ! Multiple interactions: matter distribution parameter',
+            'PARP(62)=1.025 ! ISR cutoff',
+            'MSTP(91)=1 ! Gaussian primordial kT',
+            'PARP(93)=10.0 ! primordial kT-max',
+            'MSTP(81)=21 ! multiple parton interactions 1 is Pythia default',
+            'MSTP(82)=4 ! Defines the multi-parton model'),
+        processParameters = cms.vstring('MSEL=0 !User defined processes',
+            'MSUB(1)=1 !Incl Z0/gamma* production',
+            'MSTP(43)=3 !Both Z0 and gamma*',
+            'MDME(174,1)=0 !Z decay into d dbar',
+            'MDME(175,1)=0 !Z decay into u ubar',
+            'MDME(176,1)=0 !Z decay into s sbar',
+            'MDME(177,1)=0 !Z decay into c cbar',
+            'MDME(178,1)=0 !Z decay into b bbar',
+            'MDME(179,1)=0 !Z decay into t tbar',
+            'MDME(182,1)=1 !Z decay into e- e+',
+            'MDME(183,1)=0 !Z decay into nu_e nu_ebar',
+            'MDME(184,1)=1 !Z decay into mu- mu+',
+            'MDME(185,1)=0 !Z decay into nu_mu nu_mubar',
+            'MDME(186,1)=1 !Z decay into tau- tau+',
+            'MDME(187,1)=0 !Z decay into nu_tau nu_taubar',
+            'CKIN(1)=50. !Minimum sqrt(s_hat) value (=Z mass)'),
+        parameterSets = cms.vstring('pythiaUESettings',
+            'processParameters')
+    )
+)
 
 
 process.ProductionFilterSequence = cms.Sequence(process.generator)

--- a/GeneratorInterface/TauolaInterface/test/DYToLLtaupinu_Hadronizer_MgmMatchTune4C_13TeV_madgraph_pythia8_Tauola_taupinu_cff_GEN_VALIDATION.py
+++ b/GeneratorInterface/TauolaInterface/test/DYToLLtaupinu_Hadronizer_MgmMatchTune4C_13TeV_madgraph_pythia8_Tauola_taupinu_cff_GEN_VALIDATION.py
@@ -1,0 +1,151 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.19 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
+# with command line options: Hadronizer_MgmMatchTune4C_13TeV_madgraph_pythia8_Tauola_taupinu_cff --conditions auto:run1_mc --filein das:/DYJetsToLL_M-50_13TeV-madgraph_v2/Fall13wmLHE-START62_V1-v1/GEN -s GEN,VALIDATION:genvalid_all --datatier GEN --relval 1000000,20000 -n 10 --eventcontent RAWSIM -n 10 --fileout file:step1.root
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('VALIDATION')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_38T_cff')
+process.load('Configuration.StandardSequences.Generator_cff')
+process.load('IOMC.EventVertexGenerators.VtxSmearedRealistic8TeVCollision_cfi')
+process.load('GeneratorInterface.Core.genFilterSummary_cff')
+process.load('Configuration.StandardSequences.Validation_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(10000)
+)
+
+# Input source
+process.source = cms.Source("LHESource",
+			    fileNames = cms.untracked.vstring( ('/store/lhe/5591/DYJetsToLL_M-50_8TeV-madgraph-tarball_10001.lhe',
+								'/store/lhe/5591/DYJetsToLL_M-50_8TeV-madgraph-tarball_10002.lhe',
+								'/store/lhe/5591/DYJetsToLL_M-50_8TeV-madgraph-tarball_10003.lhe',
+								'/store/lhe/5591/DYJetsToLL_M-50_8TeV-madgraph-tarball_10004.lhe',
+								'/store/lhe/5591/DYJetsToLL_M-50_8TeV-madgraph-tarball_10005.lhe',
+								'/store/lhe/5591/DYJetsToLL_M-50_8TeV-madgraph-tarball_10006.lhe',
+								'/store/lhe/5591/DYJetsToLL_M-50_8TeV-madgraph-tarball_10007.lhe',
+								'/store/lhe/5591/DYJetsToLL_M-50_8TeV-madgraph-tarball_10008.lhe',
+								'/store/lhe/5591/DYJetsToLL_M-50_8TeV-madgraph-tarball_10009.lhe',
+								'/store/lhe/5591/DYJetsToLL_M-50_8TeV-madgraph-tarball_10010.lhe',
+								'/store/lhe/5591/DYJetsToLL_M-50_8TeV-madgraph-tarball_10011.lhe',
+								'/store/lhe/5591/DYJetsToLL_M-50_8TeV-madgraph-tarball_10012.lhe',
+								'/store/lhe/5591/DYJetsToLL_M-50_8TeV-madgraph-tarball_10013.lhe',
+								'/store/lhe/5591/DYJetsToLL_M-50_8TeV-madgraph-tarball_10014.lhe',
+								'/store/lhe/5591/DYJetsToLL_M-50_8TeV-madgraph-tarball_10015.lhe',
+								'/store/lhe/5591/DYJetsToLL_M-50_8TeV-madgraph-tarball_10016.lhe',
+								'/store/lhe/5591/DYJetsToLL_M-50_8TeV-madgraph-tarball_10017.lhe',
+								'/store/lhe/5591/DYJetsToLL_M-50_8TeV-madgraph-tarball_10018.lhe',
+								'/store/lhe/5591/DYJetsToLL_M-50_8TeV-madgraph-tarball_10019.lhe',
+								'/store/lhe/5591/DYJetsToLL_M-50_8TeV-madgraph-tarball_10020.lhe',
+								'/store/lhe/5591/DYJetsToLL_M-50_8TeV-madgraph-tarball_10021.lhe',
+								'/store/lhe/5591/DYJetsToLL_M-50_8TeV-madgraph-tarball_10022.lhe',
+								'/store/lhe/5591/DYJetsToLL_M-50_8TeV-madgraph-tarball_10023.lhe',
+								'/store/lhe/5591/DYJetsToLL_M-50_8TeV-madgraph-tarball_10024.lhe',
+								'/store/lhe/5591/DYJetsToLL_M-50_8TeV-madgraph-tarball_10025.lhe'
+								)
+							       )
+			    )			    
+process.options = cms.untracked.PSet(
+
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('$Revision: 1.19 $'),
+    annotation = cms.untracked.string('Hadronizer_MgmMatchTune4C_13TeV_madgraph_pythia8_Tauola_taupinu_cff nevts:10'),
+    name = cms.untracked.string('Applications')
+)
+
+# Output definition
+
+process.RAWSIMoutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
+    outputCommands = process.RAWSIMEventContent.outputCommands,
+    fileName = cms.untracked.string('file:step1.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('GEN')
+    ),
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('generation_step')
+    )
+)
+
+# Additional output definition
+
+# Other statements
+process.genstepfilter.triggerConditions=cms.vstring("generation_step")
+process.mix.playback = True
+process.mix.digitizers = cms.PSet()
+
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:startup', '')
+
+process.generator = cms.EDFilter("Pythia8HadronizerFilter",
+				 ExternalDecays = cms.PSet(
+        Tauolapp114 = cms.untracked.PSet(
+	UseTauolaPolarization = cms.bool(True),
+	InputCards = cms.PSet(
+	mdtau = cms.int32(0),
+	pjak2 = cms.int32(3),
+	pjak1 = cms.int32(3)
+	)
+        ),
+        parameterSets = cms.vstring('Tauolapp114')
+	),
+				 maxEventsToPrint = cms.untracked.int32(1),
+				 pythiaPylistVerbosity = cms.untracked.int32(1),
+				 filterEfficiency = cms.untracked.double(1.0),
+				 pythiaHepMCVerbosity = cms.untracked.bool(False),
+				 comEnergy = cms.double(13000.0),
+				 UseExternalGenerators = cms.untracked.bool(True),
+				 jetMatching = cms.untracked.PSet(
+        MEMAIN_nqmatch = cms.int32(5),
+        MEMAIN_showerkt = cms.double(0),
+        MEMAIN_minjets = cms.int32(-1),
+        MEMAIN_qcut = cms.double(-1),
+        MEMAIN_excres = cms.string(''),
+        MEMAIN_etaclmax = cms.double(-1),
+        outTree_flag = cms.int32(0),
+        scheme = cms.string('Madgraph'),
+        MEMAIN_maxjets = cms.int32(-1),
+        mode = cms.string('auto')
+	),
+				 PythiaParameters = cms.PSet(
+        processParameters = cms.vstring('Main:timesAllowErrors = 10000', 
+					'ParticleDecays:limitTau0 = on', 
+					'ParticleDecays:tauMax = 10', 
+					'Tune:ee 3', 
+					'Tune:pp 5'),
+        parameterSets = cms.vstring('processParameters')
+	)
+				 )
+
+
+process.ProductionFilterSequence = cms.Sequence(process.generator)
+
+# Path and EndPath definitions
+process.generation_step = cms.Path(process.pgen)
+process.genfiltersummary_step = cms.EndPath(process.genFilterSummary)
+process.validation_step = cms.EndPath(process.genstepfilter+process.genvalid_all)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.RAWSIMoutput_step = cms.EndPath(process.RAWSIMoutput)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.generation_step,process.genfiltersummary_step,process.validation_step,process.endjob_step,process.RAWSIMoutput_step)
+# filter all path with the production filter sequence
+for path in process.paths:
+	getattr(process,path)._seq = process.ProductionFilterSequence * getattr(process,path)._seq 
+

--- a/GeneratorInterface/TauolaInterface/test/DYToLLtaurhonu_Hadronizer_MgmMatchTune4C_13TeV_madgraph_pythia8_Tauola_taurhonu_cff_GEN_VALIDATION.py
+++ b/GeneratorInterface/TauolaInterface/test/DYToLLtaurhonu_Hadronizer_MgmMatchTune4C_13TeV_madgraph_pythia8_Tauola_taurhonu_cff_GEN_VALIDATION.py
@@ -1,0 +1,151 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.19 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
+# with command line options: Hadronizer_MgmMatchTune4C_13TeV_madgraph_pythia8_Tauola_taupinu_cff --conditions auto:run1_mc --filein das:/DYJetsToLL_M-50_13TeV-madgraph_v2/Fall13wmLHE-START62_V1-v1/GEN -s GEN,VALIDATION:genvalid_all --datatier GEN --relval 1000000,20000 -n 10 --eventcontent RAWSIM -n 10 --fileout file:step1.root
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('VALIDATION')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_38T_cff')
+process.load('Configuration.StandardSequences.Generator_cff')
+process.load('IOMC.EventVertexGenerators.VtxSmearedRealistic8TeVCollision_cfi')
+process.load('GeneratorInterface.Core.genFilterSummary_cff')
+process.load('Configuration.StandardSequences.Validation_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(10000)
+)
+
+# Input source
+process.source = cms.Source("LHESource",
+			    fileNames = cms.untracked.vstring( ('/store/lhe/5591/DYJetsToLL_M-50_8TeV-madgraph-tarball_10001.lhe',
+								'/store/lhe/5591/DYJetsToLL_M-50_8TeV-madgraph-tarball_10002.lhe',
+								'/store/lhe/5591/DYJetsToLL_M-50_8TeV-madgraph-tarball_10003.lhe',
+								'/store/lhe/5591/DYJetsToLL_M-50_8TeV-madgraph-tarball_10004.lhe',
+								'/store/lhe/5591/DYJetsToLL_M-50_8TeV-madgraph-tarball_10005.lhe',
+								'/store/lhe/5591/DYJetsToLL_M-50_8TeV-madgraph-tarball_10006.lhe',
+								'/store/lhe/5591/DYJetsToLL_M-50_8TeV-madgraph-tarball_10007.lhe',
+								'/store/lhe/5591/DYJetsToLL_M-50_8TeV-madgraph-tarball_10008.lhe',
+								'/store/lhe/5591/DYJetsToLL_M-50_8TeV-madgraph-tarball_10009.lhe',
+								'/store/lhe/5591/DYJetsToLL_M-50_8TeV-madgraph-tarball_10010.lhe',
+								'/store/lhe/5591/DYJetsToLL_M-50_8TeV-madgraph-tarball_10011.lhe',
+								'/store/lhe/5591/DYJetsToLL_M-50_8TeV-madgraph-tarball_10012.lhe',
+								'/store/lhe/5591/DYJetsToLL_M-50_8TeV-madgraph-tarball_10013.lhe',
+								'/store/lhe/5591/DYJetsToLL_M-50_8TeV-madgraph-tarball_10014.lhe',
+								'/store/lhe/5591/DYJetsToLL_M-50_8TeV-madgraph-tarball_10015.lhe',
+								'/store/lhe/5591/DYJetsToLL_M-50_8TeV-madgraph-tarball_10016.lhe',
+								'/store/lhe/5591/DYJetsToLL_M-50_8TeV-madgraph-tarball_10017.lhe',
+								'/store/lhe/5591/DYJetsToLL_M-50_8TeV-madgraph-tarball_10018.lhe',
+								'/store/lhe/5591/DYJetsToLL_M-50_8TeV-madgraph-tarball_10019.lhe',
+								'/store/lhe/5591/DYJetsToLL_M-50_8TeV-madgraph-tarball_10020.lhe',
+								'/store/lhe/5591/DYJetsToLL_M-50_8TeV-madgraph-tarball_10021.lhe',
+								'/store/lhe/5591/DYJetsToLL_M-50_8TeV-madgraph-tarball_10022.lhe',
+								'/store/lhe/5591/DYJetsToLL_M-50_8TeV-madgraph-tarball_10023.lhe',
+								'/store/lhe/5591/DYJetsToLL_M-50_8TeV-madgraph-tarball_10024.lhe',
+								'/store/lhe/5591/DYJetsToLL_M-50_8TeV-madgraph-tarball_10025.lhe'
+								)
+							       )
+			    )			    
+process.options = cms.untracked.PSet(
+
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('$Revision: 1.19 $'),
+    annotation = cms.untracked.string('Hadronizer_MgmMatchTune4C_13TeV_madgraph_pythia8_Tauola_taupinu_cff nevts:10'),
+    name = cms.untracked.string('Applications')
+)
+
+# Output definition
+
+process.RAWSIMoutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
+    outputCommands = process.RAWSIMEventContent.outputCommands,
+    fileName = cms.untracked.string('file:step1.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('GEN')
+    ),
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('generation_step')
+    )
+)
+
+# Additional output definition
+
+# Other statements
+process.genstepfilter.triggerConditions=cms.vstring("generation_step")
+process.mix.playback = True
+process.mix.digitizers = cms.PSet()
+
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:startup', '')
+
+process.generator = cms.EDFilter("Pythia8HadronizerFilter",
+				 ExternalDecays = cms.PSet(
+        Tauolapp114 = cms.untracked.PSet(
+	UseTauolaPolarization = cms.bool(True),
+	InputCards = cms.PSet(
+	mdtau = cms.int32(0),
+	pjak2 = cms.int32(4),
+	pjak1 = cms.int32(4)
+	)
+        ),
+        parameterSets = cms.vstring('Tauolapp114')
+	),
+				 maxEventsToPrint = cms.untracked.int32(1),
+				 pythiaPylistVerbosity = cms.untracked.int32(1),
+				 filterEfficiency = cms.untracked.double(1.0),
+				 pythiaHepMCVerbosity = cms.untracked.bool(False),
+				 comEnergy = cms.double(13000.0),
+				 UseExternalGenerators = cms.untracked.bool(True),
+				 jetMatching = cms.untracked.PSet(
+        MEMAIN_nqmatch = cms.int32(5),
+        MEMAIN_showerkt = cms.double(0),
+        MEMAIN_minjets = cms.int32(-1),
+        MEMAIN_qcut = cms.double(-1),
+        MEMAIN_excres = cms.string(''),
+        MEMAIN_etaclmax = cms.double(-1),
+        outTree_flag = cms.int32(0),
+        scheme = cms.string('Madgraph'),
+        MEMAIN_maxjets = cms.int32(-1),
+        mode = cms.string('auto')
+	),
+				 PythiaParameters = cms.PSet(
+        processParameters = cms.vstring('Main:timesAllowErrors = 10000', 
+					'ParticleDecays:limitTau0 = on', 
+					'ParticleDecays:tauMax = 10', 
+					'Tune:ee 3', 
+					'Tune:pp 5'),
+        parameterSets = cms.vstring('processParameters')
+	)
+				 )
+
+
+process.ProductionFilterSequence = cms.Sequence(process.generator)
+
+# Path and EndPath definitions
+process.generation_step = cms.Path(process.pgen)
+process.genfiltersummary_step = cms.EndPath(process.genFilterSummary)
+process.validation_step = cms.EndPath(process.genstepfilter+process.genvalid_all)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.RAWSIMoutput_step = cms.EndPath(process.RAWSIMoutput)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.generation_step,process.genfiltersummary_step,process.validation_step,process.endjob_step,process.RAWSIMoutput_step)
+# filter all path with the production filter sequence
+for path in process.paths:
+	getattr(process,path)._seq = process.ProductionFilterSequence * getattr(process,path)._seq 
+

--- a/GeneratorInterface/TauolaInterface/test/GGToHtautau_13TeV_pythia8_Tauola_taupinu_cff_GEN_VALIDATION.py
+++ b/GeneratorInterface/TauolaInterface/test/GGToHtautau_13TeV_pythia8_Tauola_taupinu_cff_GEN_VALIDATION.py
@@ -1,0 +1,116 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.19 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
+# with command line options: GGToHtautau_13TeV_pythia8_Tauola_taupinu_cff --conditions auto:run1_mc -s GEN,VALIDATION:genvalid_all --datatier GEN --relval 1000000,20000 -n 10 --eventcontent RAWSIM -n 10 --fileout file:step1.root
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('VALIDATION')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_38T_cff')
+process.load('Configuration.StandardSequences.Generator_cff')
+process.load('IOMC.EventVertexGenerators.VtxSmearedRealistic8TeVCollision_cfi')
+process.load('GeneratorInterface.Core.genFilterSummary_cff')
+process.load('Configuration.StandardSequences.Validation_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(10000)
+)
+
+# Input source
+process.source = cms.Source("EmptySource")
+
+process.options = cms.untracked.PSet(
+
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('$Revision: 1.19 $'),
+    annotation = cms.untracked.string('GGToHtautau_13TeV_pythia8_Tauola_taupinu_cff nevts:10'),
+    name = cms.untracked.string('Applications')
+)
+
+# Output definition
+
+process.RAWSIMoutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
+    outputCommands = process.RAWSIMEventContent.outputCommands,
+    fileName = cms.untracked.string('file:step1.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('GEN')
+    ),
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('generation_step')
+    )
+)
+
+# Additional output definition
+
+# Other statements
+process.genstepfilter.triggerConditions=cms.vstring("generation_step")
+process.mix.playback = True
+process.mix.digitizers = cms.PSet()
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:startup', '')
+
+process.generator = cms.EDFilter("Pythia8GeneratorFilter",
+    ExternalDecays = cms.PSet(
+        Tauolapp114 = cms.untracked.PSet(
+            UseTauolaPolarization = cms.bool(True),
+            InputCards = cms.PSet(
+                mdtau = cms.int32(0),
+                pjak2 = cms.int32(3),
+                pjak1 = cms.int32(3)
+            )
+        ),
+        parameterSets = cms.vstring('Tauolapp114')
+    ),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    filterEfficiency = cms.untracked.double(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(13000.0),
+    crossSection = cms.untracked.double(6.44),
+    UseExternalGenerators = cms.untracked.bool(True),
+    PythiaParameters = cms.PSet(
+        processParameters = cms.vstring('Main:timesAllowErrors = 10000', 
+            'ParticleDecays:limitTau0 = on', 
+            'ParticleDecays:tauMax = 10', 
+            'Tune:ee 3', 
+            'Tune:pp 5', 
+            'HiggsSM:gg2H = on', 
+            '25:onMode = off', 
+            '25:onIfAny = 15', 
+            '25:mMin = 50.'),
+        parameterSets = cms.vstring('processParameters')
+    )
+)
+
+
+process.ProductionFilterSequence = cms.Sequence(process.generator)
+
+# Path and EndPath definitions
+process.generation_step = cms.Path(process.pgen)
+process.genfiltersummary_step = cms.EndPath(process.genFilterSummary)
+process.validation_step = cms.EndPath(process.genstepfilter+process.genvalid_all)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.RAWSIMoutput_step = cms.EndPath(process.RAWSIMoutput)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.generation_step,process.genfiltersummary_step,process.validation_step,process.endjob_step,process.RAWSIMoutput_step)
+# filter all path with the production filter sequence
+for path in process.paths:
+	getattr(process,path)._seq = process.ProductionFilterSequence * getattr(process,path)._seq 
+

--- a/GeneratorInterface/TauolaInterface/test/GGToHtautau_13TeV_pythia8_Tauola_taurhonu_cff_GEN_VALIDATION.py
+++ b/GeneratorInterface/TauolaInterface/test/GGToHtautau_13TeV_pythia8_Tauola_taurhonu_cff_GEN_VALIDATION.py
@@ -1,0 +1,115 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.19 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
+# with command line options: GGToHtautau_13TeV_pythia8_Tauola_taurhonu_cff --conditions auto:run1_mc -s GEN,VALIDATION:genvalid_all --datatier GEN --relval 1000000,20000 -n 10 --eventcontent RAWSIM -n 10 --fileout file:step1.root
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('VALIDATION')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_38T_cff')
+process.load('Configuration.StandardSequences.Generator_cff')
+process.load('IOMC.EventVertexGenerators.VtxSmearedRealistic8TeVCollision_cfi')
+process.load('GeneratorInterface.Core.genFilterSummary_cff')
+process.load('Configuration.StandardSequences.Validation_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(10000)
+)
+
+# Input source
+process.source = cms.Source("EmptySource")
+
+process.options = cms.untracked.PSet(
+
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('$Revision: 1.19 $'),
+    annotation = cms.untracked.string('GGToHtautau_13TeV_pythia8_Tauola_taurhonu_cff nevts:10'),
+    name = cms.untracked.string('Applications')
+)
+
+# Output definition
+
+process.RAWSIMoutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
+    outputCommands = process.RAWSIMEventContent.outputCommands,
+    fileName = cms.untracked.string('file:step1.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('GEN')
+    ),
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('generation_step')
+    )
+)
+
+# Additional output definition
+
+# Other statements
+process.genstepfilter.triggerConditions=cms.vstring("generation_step")
+process.mix.playback = True
+process.mix.digitizers = cms.PSet()
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:startup', '')
+
+process.generator = cms.EDFilter("Pythia8GeneratorFilter",
+    ExternalDecays = cms.PSet(
+        Tauolapp114 = cms.untracked.PSet(
+            UseTauolaPolarization = cms.bool(True),
+            InputCards = cms.PSet(
+                mdtau = cms.int32(0),
+                pjak2 = cms.int32(4),
+                pjak1 = cms.int32(4)
+            )
+        ),
+        parameterSets = cms.vstring('Tauolapp114')
+    ),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    filterEfficiency = cms.untracked.double(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(13000.0),
+    crossSection = cms.untracked.double(6.44),
+    UseExternalGenerators = cms.untracked.bool(True),
+    PythiaParameters = cms.PSet(
+        processParameters = cms.vstring('Main:timesAllowErrors = 10000', 
+            'ParticleDecays:limitTau0 = on', 
+            'ParticleDecays:tauMax = 10', 
+            'Tune:ee 3', 
+            'Tune:pp 5', 
+            'HiggsSM:gg2H = on', 
+            '25:onMode = off', 
+            '25:onIfAny = 15', 
+            '25:mMin = 50.'),
+        parameterSets = cms.vstring('processParameters')
+    )
+)
+
+
+process.ProductionFilterSequence = cms.Sequence(process.generator)
+
+# Path and EndPath definitions
+process.generation_step = cms.Path(process.pgen)
+process.genfiltersummary_step = cms.EndPath(process.genFilterSummary)
+process.validation_step = cms.EndPath(process.genstepfilter+process.genvalid_all)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.RAWSIMoutput_step = cms.EndPath(process.RAWSIMoutput)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.generation_step,process.genfiltersummary_step,process.validation_step,process.endjob_step,process.RAWSIMoutput_step)
+# filter all path with the production filter sequence
+for path in process.paths:
+	getattr(process,path)._seq = process.ProductionFilterSequence * getattr(process,path)._seq 

--- a/GeneratorInterface/TauolaInterface/test/H130GGgluonfusion_8TeV_Tauola_TauSpinner_Example_cfi.py
+++ b/GeneratorInterface/TauolaInterface/test/H130GGgluonfusion_8TeV_Tauola_TauSpinner_Example_cfi.py
@@ -25,7 +25,7 @@ process.load("GeneratorInterface.TauolaInterface.TauSpinner_cfi")
 process.load("GeneratorInterface.TauolaInterface.TauSpinnerFilter_cfi")
 
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(40000)
+    input = cms.untracked.int32(10000)
 )
 
 # Input source
@@ -48,7 +48,7 @@ process.RAWSIMoutput = cms.OutputModule("PoolOutputModule",
     splitLevel = cms.untracked.int32(0),
     eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
     outputCommands = process.RAWSIMEventContent.outputCommands,
-    fileName = cms.untracked.string('H130GGgluonfusion_8TeV_tauola_cfi_py_GEN_VALIDATION.root'),
+    fileName = cms.untracked.string('file:step1.root'),
     dataset = cms.untracked.PSet(
         filterName = cms.untracked.string(''),
         dataTier = cms.untracked.string('GEN')
@@ -90,7 +90,7 @@ process.generator = cms.EDFilter("Pythia6GeneratorFilter",
 				 pythiaPylistVerbosity = cms.untracked.int32(1),
 				 filterEfficiency = cms.untracked.double(1.0),
 				 pythiaHepMCVerbosity = cms.untracked.bool(False),
-				 comEnergy = cms.double(8000.0),
+				 comEnergy = cms.double(13000.0),
 				 crossSection = cms.untracked.double(0.05),
 				 UseExternalGenerators = cms.untracked.bool(True),
 				 PythiaParameters = cms.PSet(
@@ -151,7 +151,6 @@ process.ProductionFilterSequence = cms.Sequence(process.generator)
 
 # Path and EndPath definitions
 process.generation_step = cms.Path(process.pgen+process.TauSpinnerGen+process.TauSpinnerZHFilter)
-#process.genfiltersummary_step = cms.EndPath(process.TauSpinnerGen+process.TauSpinnerZHFilter+process.genFilterSummary)
 process.genfiltersummary_step = cms.EndPath(process.genFilterSummary)
 process.validation_step = cms.EndPath(process.genstepfilter+process.genvalid_all)
 process.endjob_step = cms.EndPath(process.endOfProcess)

--- a/GeneratorInterface/TauolaInterface/test/Test.sh
+++ b/GeneratorInterface/TauolaInterface/test/Test.sh
@@ -1,0 +1,33 @@
+#! /bin/bash
+
+cmsRun DYToLL_M_50_TuneZ2star_8TeV_Tauola_TauSpinner_Example_cfi.py
+cmsDriver.py step3 -s HARVESTING:genHarvesting --harvesting AtJobEnd --conditions auto:mc  --mc --filein file:step1.root
+cp DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO.root DYToLL_M_50_TuneZ2star_8TeV_Tauola_TauSpinner_Example_cfi.root
+
+cmsRun H130GGgluonfusion_8TeV_Tauola_TauSpinner_Example_cfi.py
+cmsDriver.py step3 -s HARVESTING:genHarvesting --harvesting AtJobEnd --conditions auto:mc  --mc --filein file:step1.root
+cp DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO.root  H130GGgluonfusion_8TeV_Tauola_TauSpinner_Example_cfi.root
+
+cmsRun DYToLLtaupinu_Hadronizer_MgmMatchTune4C_13TeV_madgraph_pythia8_Tauola_taupinu_cff_GEN_VALIDATION.py
+cmsDriver.py step3 -s HARVESTING:genHarvesting --harvesting AtJobEnd --conditions auto:mc  --mc --filein file:step1.root
+cp DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO.root  DYToLLtaupinu_Hadronizer_MgmMatchTune4C_13TeV_madgraph_pythia8_Tauola_taupinu_cff_GEN_VALIDATION.root
+
+cmsRun DYToLLtaurhonu_Hadronizer_MgmMatchTune4C_13TeV_madgraph_pythia8_Tauola_taurhonu_cff_GEN_VALIDATION.py
+cmsDriver.py step3 -s HARVESTING:genHarvesting --harvesting AtJobEnd --conditions auto:mc  --mc --filein file:step1.root
+cp DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO.root DYToLLtaurhonu_Hadronizer_MgmMatchTune4C_13TeV_madgraph_pythia8_Tauola_taurhonu_cff_GEN_VALIDATION.root
+
+cmsRun GGToHtautau_13TeV_pythia8_Tauola_taupinu_cff_GEN_VALIDATION.py
+cmsDriver.py step3 -s HARVESTING:genHarvesting --harvesting AtJobEnd --conditions auto:mc  --mc --filein file:step1.root
+cp DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO.root GGToHtautau_13TeV_pythia8_Tauola_taupinu_cff_GEN_VALIDATION.root
+
+cmsRun GGToHtautau_13TeV_pythia8_Tauola_taurhonu_cff_GEN_VALIDATION.py
+cmsDriver.py step3 -s HARVESTING:genHarvesting --harvesting AtJobEnd --conditions auto:mc  --mc --filein file:step1.root
+cp DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO.root GGToHtautau_13TeV_pythia8_Tauola_taurhonu_cff_GEN_VALIDATION.root
+
+cmsRun WToLNutaupinu_Hadronizer_MgmMatchTune4C_13TeV_madgraph_pythia8_Tauola_taupinu_cff_GEN_VALIDATION.py
+cmsDriver.py step3 -s HARVESTING:genHarvesting --harvesting AtJobEnd --conditions auto:mc  --mc --filein file:step1.root
+cp  DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO.root WToLNutaupinu_Hadronizer_MgmMatchTune4C_13TeV_madgraph_pythia8_Tauola_taupinu_cff_GEN_VALIDATION.root
+
+cmsRun WToLNutaurhonu_Hadronizer_MgmMatchTune4C_13TeV_madgraph_pythia8_Tauola_taurhonu_cff_GEN_VALIDATION.py
+cmsDriver.py step3 -s HARVESTING:genHarvesting --harvesting AtJobEnd --conditions auto:mc  --mc --filein file:step1.root
+cp DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO.root WToLNutaurhonu_Hadronizer_MgmMatchTune4C_13TeV_madgraph_pythia8_Tauola_taurhonu_cff_GEN_VALIDATION.root

--- a/GeneratorInterface/TauolaInterface/test/WToLNutaupinu_Hadronizer_MgmMatchTune4C_13TeV_madgraph_pythia8_Tauola_taupinu_cff_GEN_VALIDATION.py
+++ b/GeneratorInterface/TauolaInterface/test/WToLNutaupinu_Hadronizer_MgmMatchTune4C_13TeV_madgraph_pythia8_Tauola_taupinu_cff_GEN_VALIDATION.py
@@ -1,0 +1,163 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.19 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
+# with command line options: Hadronizer_MgmMatchTune4C_13TeV_madgraph_pythia8_Tauola_taupinu_cff --conditions auto:run1_mc --filein das:/WJetsToLNu_13TeV-madgraph/Fall13wmLHE-START62_V1-v1/GEN -s GEN,VALIDATION:genvalid_all --datatier GEN --relval 1000000,20000 -n 10 --eventcontent RAWSIM -n 10 --fileout file:step1.root
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('VALIDATION')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_38T_cff')
+process.load('Configuration.StandardSequences.Generator_cff')
+process.load('IOMC.EventVertexGenerators.VtxSmearedRealistic8TeVCollision_cfi')
+process.load('GeneratorInterface.Core.genFilterSummary_cff')
+process.load('Configuration.StandardSequences.Validation_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(10000)
+)
+
+# Input source
+process.source = cms.Source("LHESource",
+			        fileNames = cms.untracked.vstring( ('/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10001.lhe',
+								            '/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10002.lhe',
+								            '/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10003.lhe',
+								            '/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10004.lhe',
+								            '/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10005.lhe',
+								            '/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10006.lhe',
+								            '/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10007.lhe',
+								            '/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10008.lhe',
+								            '/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10009.lhe',
+								            '/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10010.lhe',
+								            '/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10011.lhe',
+								            '/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10012.lhe',
+								            '/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10013.lhe',
+								            '/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10014.lhe',
+								            '/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10015.lhe',
+								            '/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10016.lhe',
+								            '/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10017.lhe',
+								            '/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10018.lhe',
+								            '/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10019.lhe',
+								            '/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10020.lhe',
+								            '/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10021.lhe',
+								            '/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10022.lhe',
+								            '/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10023.lhe',
+								            '/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10024.lhe',
+								            '/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10025.lhe',
+								            '/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10026.lhe',
+								            '/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10027.lhe',
+								            '/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10028.lhe',
+								            '/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10029.lhe',
+								            '/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10030.lhe',
+								            '/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10031.lhe',
+								            '/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10032.lhe',
+								            '/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10033.lhe',
+								            '/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10034.lhe',
+								            '/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10035.lhe',
+								            '/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10036.lhe',
+								            '/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10037.lhe'
+								    )
+								   )
+			    )
+								    
+process.options = cms.untracked.PSet(
+
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('$Revision: 1.19 $'),
+    annotation = cms.untracked.string('Hadronizer_MgmMatchTune4C_13TeV_madgraph_pythia8_Tauola_taupinu_cff nevts:10'),
+    name = cms.untracked.string('Applications')
+)
+
+# Output definition
+
+process.RAWSIMoutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
+    outputCommands = process.RAWSIMEventContent.outputCommands,
+    fileName = cms.untracked.string('file:step1.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('GEN')
+    ),
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('generation_step')
+    )
+)
+
+# Additional output definition
+
+# Other statements
+process.genstepfilter.triggerConditions=cms.vstring("generation_step")
+process.mix.playback = True
+process.mix.digitizers = cms.PSet()
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:startup', '')
+
+process.generator = cms.EDFilter("Pythia8HadronizerFilter",
+    ExternalDecays = cms.PSet(
+        Tauolapp114 = cms.untracked.PSet(
+            UseTauolaPolarization = cms.bool(True),
+            InputCards = cms.PSet(
+                mdtau = cms.int32(0),
+                pjak2 = cms.int32(3),
+                pjak1 = cms.int32(3)
+            )
+        ),
+        parameterSets = cms.vstring('Tauolapp114')
+    ),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    filterEfficiency = cms.untracked.double(1.0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(13000.0),
+    UseExternalGenerators = cms.untracked.bool(True),
+    jetMatching = cms.untracked.PSet(
+        MEMAIN_nqmatch = cms.int32(5),
+        MEMAIN_showerkt = cms.double(0),
+        MEMAIN_minjets = cms.int32(-1),
+        MEMAIN_qcut = cms.double(-1),
+        MEMAIN_excres = cms.string(''),
+        MEMAIN_etaclmax = cms.double(-1),
+        outTree_flag = cms.int32(0),
+        scheme = cms.string('Madgraph'),
+        MEMAIN_maxjets = cms.int32(-1),
+        mode = cms.string('auto')
+    ),
+    PythiaParameters = cms.PSet(
+        processParameters = cms.vstring('Main:timesAllowErrors = 10000', 
+            'ParticleDecays:limitTau0 = on', 
+            'ParticleDecays:tauMax = 10', 
+            'Tune:ee 3', 
+            'Tune:pp 5'),
+        parameterSets = cms.vstring('processParameters')
+    )
+)
+
+
+process.ProductionFilterSequence = cms.Sequence(process.generator)
+
+# Path and EndPath definitions
+process.generation_step = cms.Path(process.pgen)
+process.genfiltersummary_step = cms.EndPath(process.genFilterSummary)
+process.validation_step = cms.EndPath(process.genstepfilter+process.genvalid_all)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.RAWSIMoutput_step = cms.EndPath(process.RAWSIMoutput)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.generation_step,process.genfiltersummary_step,process.validation_step,process.endjob_step,process.RAWSIMoutput_step)
+# filter all path with the production filter sequence
+for path in process.paths:
+	getattr(process,path)._seq = process.ProductionFilterSequence * getattr(process,path)._seq 
+

--- a/GeneratorInterface/TauolaInterface/test/WToLNutaurhonu_Hadronizer_MgmMatchTune4C_13TeV_madgraph_pythia8_Tauola_taurhonu_cff_GEN_VALIDATION.py
+++ b/GeneratorInterface/TauolaInterface/test/WToLNutaurhonu_Hadronizer_MgmMatchTune4C_13TeV_madgraph_pythia8_Tauola_taurhonu_cff_GEN_VALIDATION.py
@@ -1,0 +1,161 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.19 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
+# with command line options: Hadronizer_MgmMatchTune4C_13TeV_madgraph_pythia8_Tauola_taurhonu_cff --conditions auto:run1_mc --filein das:/WJetsToLNu_13TeV-madgraph/Fall13wmLHE-START62_V1-v1/GEN -s GEN,VALIDATION:genvalid_all --datatier GEN --relval 1000000,20000 -n 10 --eventcontent RAWSIM -n 10 --fileout file:step1.root
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('VALIDATION')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_38T_cff')
+process.load('Configuration.StandardSequences.Generator_cff')
+process.load('IOMC.EventVertexGenerators.VtxSmearedRealistic8TeVCollision_cfi')
+process.load('GeneratorInterface.Core.genFilterSummary_cff')
+process.load('Configuration.StandardSequences.Validation_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+	input = cms.untracked.int32(10000)
+)
+
+# Input source
+process.source = cms.Source("LHESource",
+			    fileNames = cms.untracked.vstring( ('/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10001.lhe',
+								'/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10002.lhe',
+								'/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10003.lhe',
+								'/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10004.lhe',
+								'/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10005.lhe',
+								'/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10006.lhe',
+								'/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10007.lhe',
+								'/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10008.lhe',
+								'/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10009.lhe',
+								'/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10010.lhe',
+								'/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10011.lhe',
+								'/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10012.lhe',
+								'/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10013.lhe',
+								'/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10014.lhe',
+								'/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10015.lhe',
+								'/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10016.lhe',
+								'/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10017.lhe',
+								'/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10018.lhe',
+								'/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10019.lhe',
+								'/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10020.lhe',
+								'/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10021.lhe',
+								'/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10022.lhe',
+								'/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10023.lhe',
+								'/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10024.lhe',
+								'/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10025.lhe',
+								'/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10026.lhe',
+								'/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10027.lhe',
+								'/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10028.lhe',
+								'/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10029.lhe',
+								'/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10030.lhe',
+								'/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10031.lhe',
+								'/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10032.lhe',
+								'/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10033.lhe',
+								'/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10034.lhe',
+								'/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10035.lhe',
+								'/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10036.lhe',
+								'/store/lhe/5607/WJetsToLNu_8TeV-madgraph-tarball_10037.lhe'
+								)
+							       )
+			    )
+
+
+process.options = cms.untracked.PSet(
+
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('$Revision: 1.19 $'),
+    annotation = cms.untracked.string('Hadronizer_MgmMatchTune4C_13TeV_madgraph_pythia8_Tauola_taurhonu_cff nevts:10'),
+    name = cms.untracked.string('Applications')
+)
+
+# Output definition
+
+process.RAWSIMoutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
+    outputCommands = process.RAWSIMEventContent.outputCommands,
+    fileName = cms.untracked.string('file:step1.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('GEN')
+    ),
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('generation_step')
+    )
+)
+
+# Additional output definition
+
+# Other statements
+process.genstepfilter.triggerConditions=cms.vstring("generation_step")
+process.mix.playback = True
+process.mix.digitizers = cms.PSet()
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:startup', '')
+
+process.generator = cms.EDFilter("Pythia8HadronizerFilter",
+    ExternalDecays = cms.PSet(
+        Tauolapp114 = cms.untracked.PSet(
+            UseTauolaPolarization = cms.bool(True),
+            InputCards = cms.PSet(
+                mdtau = cms.int32(0),
+                pjak2 = cms.int32(4),
+                pjak1 = cms.int32(4)
+            )
+        ),
+        parameterSets = cms.vstring('Tauolapp114')
+    ),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    filterEfficiency = cms.untracked.double(1.0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(13000.0),
+    UseExternalGenerators = cms.untracked.bool(True),
+    jetMatching = cms.untracked.PSet(
+        MEMAIN_nqmatch = cms.int32(5),
+        MEMAIN_showerkt = cms.double(0),
+        MEMAIN_minjets = cms.int32(-1),
+        MEMAIN_qcut = cms.double(-1),
+        MEMAIN_excres = cms.string(''),
+        MEMAIN_etaclmax = cms.double(-1),
+        outTree_flag = cms.int32(0),
+        scheme = cms.string('Madgraph'),
+        MEMAIN_maxjets = cms.int32(-1),
+        mode = cms.string('auto')
+    ),
+    PythiaParameters = cms.PSet(
+        processParameters = cms.vstring('Main:timesAllowErrors = 10000', 
+            'ParticleDecays:limitTau0 = on', 
+            'ParticleDecays:tauMax = 10', 
+            'Tune:ee 3', 
+            'Tune:pp 5'),
+        parameterSets = cms.vstring('processParameters')
+    )
+)
+
+
+# Path and EndPath definitions
+process.generation_step = cms.Path(process.pgen)
+process.genfiltersummary_step = cms.EndPath(process.genFilterSummary)
+process.validation_step = cms.EndPath(process.genstepfilter+process.genvalid_all)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.RAWSIMoutput_step = cms.EndPath(process.RAWSIMoutput)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.generation_step,process.genfiltersummary_step,process.validation_step,process.endjob_step,process.RAWSIMoutput_step)
+# filter all path with the production filter sequence
+for path in process.paths:
+	getattr(process,path)._seq = process.generator * getattr(process,path)._seq 


### PR DESCRIPTION
Revert back one commit to version compatible with new 7_1_X and 7_2_X pull requests (ie use Tauola++ to set the decay length). Replaces pull 4956.
Note:
This pull request depends on cmsdist pull #914. This request is being put in before the cmsdist patch at the request of Josh Bendavid Josh.Bendavid@cern.ch and Vitaliano Ciulli vitaliano.ciulli@cern.ch. Before merging please and for any question please contact them. 
