### PR TITLE
Hgc jumpinghits fix

### DIFF
--- a/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
+++ b/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
@@ -35,19 +35,28 @@ std::pair<int,int> HGCalDDDConstants::assignCell(float x, float y, int lay,
   int i = index.first;
   if (i < 0) return std::pair<int,int>(-1,-1);
   float alpha, h, bl, tl;
-  if (reco) {
-    h    =  moduler_[i].h;
-    bl   =  moduler_[i].bl;
-    tl   =  moduler_[i].tl;
-    alpha=  moduler_[i].alpha;
-    if ((subSec>0 && alpha<0) || (subSec<=0 && alpha>0)) alpha = -alpha;
-  } else {
-    h    =  modules_[i].h;
-    bl   =  modules_[i].bl;
-    tl   =  modules_[i].tl;
-    alpha=  modules_[i].alpha;
-  }
-  return assignCell(x, y, h, bl, tl, alpha, index.second);
+  
+  //set default values
+  std::pair<int,int> cellAssignment( (x>0)?1:0, -1 );
+  if (reco) 
+    {
+      h    =  moduler_[i].h;
+      bl   =  moduler_[i].bl;
+      tl   =  moduler_[i].tl;
+      alpha=  moduler_[i].alpha;
+      if ((subSec>0 && alpha<0) || (subSec<=0 && alpha>0)) alpha = -alpha;
+      cellAssignment=assignCell(x, y, h, bl, tl, alpha, index.second);
+    } 
+  else 
+    {
+      h    =  modules_[i].h;
+      bl   =  modules_[i].bl;
+      tl   =  modules_[i].tl;
+      alpha=  modules_[i].alpha;
+      cellAssignment=assignCell(x, y, h, bl, tl, alpha, index.second);
+    }
+  
+  return cellAssignment;
 }
   
 std::pair<int,int> HGCalDDDConstants::assignCell(float x, float y, float h, 
@@ -56,17 +65,33 @@ std::pair<int,int> HGCalDDDConstants::assignCell(float x, float y, float h,
 
   float a     = (alpha==0) ? (2*h/(tl-bl)) : (h/(tl-bl));
   float b     = 2*h*bl/(tl-bl);
+ 
   float x0(x);
   int phiSector = (x0 > 0) ? 1 : 0;
   if      (alpha < 0) {x0 -= 0.5*(tl+bl); phiSector = 0;}
   else if (alpha > 0) {x0 += 0.5*(tl+bl); phiSector = 1;}
 
-  int kx    = floor(fabs(x0)/cellSize);
+  //determine the i-y
   int ky    = floor((y+h)/cellSize);
-  int icell(kx);
+  int max_ky_allowed=floor(2*h/cellSize);
+  if((y+h)> (max_ky_allowed*cellSize)) return std::pair<int,int>(phiSector,-2);
+
+  //determine the i-x
+  //notice we substitute y by the bottom of the candidate cell
+  int kx    = floor(fabs(x0)/cellSize);
+  int max_kx_allowed=floor( (ky*cellSize+b)/(a*cellSize) );
+  if(fabs(x)>(max_kx_allowed*cellSize)) return std::pair<int,int>(phiSector,-2);
+
+  //count cells summing in rows until required height
+  //notice the bottom of the cell must be used
+  int icell(0);
   for (int iky=0; iky<ky; ++iky) {
-    icell += floor((iky*cellSize+b)/(a*cellSize));
+    int cellsInRow( floor( (iky*cellSize+b)/(a*cellSize) ) );
+    icell += cellsInRow;
   }
+  icell += kx;
+
+  //return result
   return std::pair<int,int>(phiSector,icell);
 }
 
@@ -96,17 +121,28 @@ std::pair<int,int> HGCalDDDConstants::findCell(int cell, float h, float bl,
 					       float tl, float alpha, 
 					       float cellSize) const {
 
+  //check if cell number is meaningful
+  if(cell<0) return std::pair<int,int>(-1,-1);
+
+  //parameterization of the boundary of the trapezoid
   float a     = (alpha==0) ? (2*h/(tl-bl)) : (h/(tl-bl));
   float b     = 2*h*bl/(tl-bl);
-  int   kymax = floor((2*h)/cellSize);
-  int   ky(0), testCell(0);
+
+  int kx(cell), ky(0);
+  int kymax( floor((2*h)/cellSize) );
+  int testCell(0);
   for (int iky=0; iky<kymax; ++iky) {
-    int deltay(floor((iky*cellSize+b)/(a*cellSize)));
-    if (testCell+deltay >= cell) break;
-    testCell += deltay;
+
+    //check if adding all the cells in this row is above the required cell
+    //notice the center of the cell must be used
+    //int cellsInRow( floor( ((iky+0.5)*cellSize+b)/(a*cellSize) ) );
+    int cellsInRow( floor( (iky*cellSize+b)/(a*cellSize) ) );
+    if (testCell+cellsInRow > cell) break;
+    testCell += cellsInRow;
     ky++;
+    kx -= cellsInRow;
   }
-  int kx = (cell-testCell);
+
   return std::pair<int,int>(kx,ky);
 }
 
@@ -115,6 +151,7 @@ bool HGCalDDDConstants::isValid(int lay, int mod, int cell, bool reco) const {
   bool ok = ((lay > 0 && lay <= (int)(layers(reco))) && 
 	     (mod > 0 && mod <= sectors()) &&
 	     (cell >=0 && cell <= maxCells(lay,reco)));
+
 #ifdef DebugLog
   if (!ok) std::cout << "HGCalDDDConstants: Layer " << lay << ":" 
 		     << (lay > 0 && (lay <= (int)(layers(reco)))) << " Module "
@@ -189,11 +226,16 @@ int HGCalDDDConstants::maxCells(float h, float bl, float tl, float alpha,
 
   float a     = (alpha==0) ? (2*h/(tl-bl)) : (h/(tl-bl));
   float b     = 2*h*bl/(tl-bl);
-  int   ncell(0);
+ 
+  int   ncells(0);
   int   kymax = floor((2*h)/cellSize);
   for (int iky=0; iky<=kymax; ++iky)
-    ncell += floor((iky*cellSize+b)/(a*cellSize));
-  return ncell;
+    {
+      int cellsInRow=floor((iky*cellSize+b)/(a*cellSize));
+      ncells += cellsInRow;
+    }
+
+  return ncells;
 }
 
 int HGCalDDDConstants::maxRows(int lay, bool reco) const {

--- a/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
+++ b/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
@@ -229,7 +229,7 @@ int HGCalDDDConstants::maxCells(float h, float bl, float tl, float alpha,
  
   int   ncells(0);
   int   kymax = floor((2*h)/cellSize);
-  for (int iky=0; iky<=kymax; ++iky)
+  for (int iky=0; iky<kymax; ++iky)
     {
       int cellsInRow=floor((iky*cellSize+b)/(a*cellSize));
       ncells += cellsInRow;

--- a/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
+++ b/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
@@ -134,8 +134,7 @@ std::pair<int,int> HGCalDDDConstants::findCell(int cell, float h, float bl,
   for (int iky=0; iky<kymax; ++iky) {
 
     //check if adding all the cells in this row is above the required cell
-    //notice the center of the cell must be used
-    //int cellsInRow( floor( ((iky+0.5)*cellSize+b)/(a*cellSize) ) );
+    //notice the bottom of the cell must be used
     int cellsInRow( floor( (iky*cellSize+b)/(a*cellSize) ) );
     if (testCell+cellsInRow > cell) break;
     testCell += cellsInRow;
@@ -228,6 +227,7 @@ int HGCalDDDConstants::maxCells(float h, float bl, float tl, float alpha,
   float b     = 2*h*bl/(tl-bl);
  
   int   ncells(0);
+  //always use the bottom of the cell...
   int   kymax = floor((2*h)/cellSize);
   for (int iky=0; iky<kymax; ++iky)
     {

--- a/SimG4CMS/Calo/src/HGCNumberingScheme.cc
+++ b/SimG4CMS/Calo/src/HGCNumberingScheme.cc
@@ -35,7 +35,7 @@ uint32_t HGCNumberingScheme::getUnitID(ForwardSubdetector &subdet, int &layer, i
   if ((!HGCalDetId::isValid(subdet,iz,layer,sector,phiSector,icell)) ||
       (!hgcons->isValid(layer,sector,icell,false))) {
     index = 0;
-    if (check_) {
+    if (check_ && icell != -2) {
       edm::LogError("HGCSim") << "[HGCNumberingScheme] ID out of bounds :"
 			      << " Subdet= " << subdet << " Zside= " << iz
 			      << " Layer= " << layer << " Sector= " << sector


### PR DESCRIPTION
This fixes the logic in the HGCalDDDConstants which created jumping hits near the boundaries of the sectors
- moved comparison with the boundary to the bottom of each sim/readout cell
- added a special code for hits in dead zones
  @lgray @bsunanda @vandreev11 please follow this as well
