### PR TITLE
Pixel Phase1 xmls for 72X

### DIFF
--- a/Geometry/TrackerCommonData/data/PhaseI/pixbar.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbar.xml
@@ -1023,9 +1023,6 @@
  <PosPart copyNumber="2">
    <rParent name="pixbar:PixelBarrel"/>
    <rChild name="pixbar:PixelBarrelSupTubCables"/>
-<!--  
-<rRotation name="pixbar:180D"/>
--->
   <Translation x="[zero]" y="[zero]" z="-[ServCablZ]" />
  </PosPart>
 

--- a/Geometry/TrackerCommonData/data/PhaseI/pixbar.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbar.xml
@@ -355,11 +355,11 @@
  <Tubs name="PixelBarrelConnToST"   rMin="[ConnToSTRin]" rMax="[ConnToSTRout]"
        dz="[ConnToSTT]/2"           startPhi="0*deg"        deltaPhi="360*deg"/>
  <Tubs name="PixelBarrelConn3"   rMin="[Conn3Rin]"           rMax="[Conn3Rout]"
-       dz="[Conn3T]/2"           startPhi="285*deg"        deltaPhi="150*deg"/>
+       dz="[Conn3T]/2"           startPhi="0*deg"        deltaPhi="360*deg"/>
  <Tubs name="PixelBarrelConn4"   rMin="[Conn4Rin]"           rMax="[Conn3Rout]"
-       dz="[Conn4T]/2"           startPhi="285*deg"        deltaPhi="150*deg"/>
+       dz="[Conn4T]/2"           startPhi="0*deg"        deltaPhi="360*deg"/>
  <Tubs name="PixelBarrelService" rMin="[ServiceRin]"           rMax="[ServiceRout]"
-       dz="[ServT]/2"            startPhi="293*deg"        deltaPhi="134*deg"/>
+       dz="[ServT]/2"            startPhi="0*deg"        deltaPhi="360*deg"/>
  <Tubs name="PixelBarrelSupTubCables" rMin="[RinSupTubCab]" rMax="[Conn3Rout]"
        dz="[ServCablT]/2"            startPhi="0*deg"        deltaPhi="360*deg"/>
 </SolidSection>
@@ -539,19 +539,19 @@
  </LogicalPart>
  <LogicalPart name="PixelBarrelConn3" category="unspecified">
   <rSolid name="PixelBarrelConn3"/>
-  <rMaterial name="pixbarmaterial:SupplyTubeConn3"/>
+  <rMaterial name="pixbarmaterial:SupplyTubeConn3_3Disks"/>
  </LogicalPart>
  <LogicalPart name="PixelBarrelConn4" category="unspecified">
   <rSolid name="PixelBarrelConn4"/>
-  <rMaterial name="pixbarmaterial:SectorC"/>
+  <rMaterial name="pixbarmaterial:SectorC_3Disks"/>
  </LogicalPart>
  <LogicalPart name="PixelBarrelService" category="unspecified">
   <rSolid name="PixelBarrelService"/>
-  <rMaterial name="pixbarmaterial:SectorA"/>
+  <rMaterial name="pixbarmaterial:SectorA_3Disks"/>
  </LogicalPart>
  <LogicalPart name="PixelBarrelSupTubCables" category="unspecified">
   <rSolid name="PixelBarrelSupTubCables"/>
-  <rMaterial name="pixbarmaterial:PixelBarrelSupTubCables2"/>
+  <rMaterial name="pixbarmaterial:PixelBarrelSupTubCables2_3Disks"/>
  </LogicalPart>
 </LogicalPartSection>
 
@@ -990,18 +990,6 @@
  <PosPart copyNumber="2">
    <rParent name="pixbar:PixelBarrel"/>
    <rChild name="pixbar:PixelBarrelConn3"/>
-  <rRotation name="pixbar:180D"/>
-  <Translation x="[zero]" y="[zero]" z="[Conn3Z]" />
- </PosPart>
- <PosPart copyNumber="3">
-   <rParent name="pixbar:PixelBarrel"/>
-   <rChild name="pixbar:PixelBarrelConn3"/>
-  <Translation x="[zero]" y="[zero]" z="-[Conn3Z]" />
- </PosPart>
- <PosPart copyNumber="4">
-   <rParent name="pixbar:PixelBarrel"/>
-   <rChild name="pixbar:PixelBarrelConn3"/>
-  <rRotation name="pixbar:180D"/>
   <Translation x="[zero]" y="[zero]" z="-[Conn3Z]" />
  </PosPart>
 
@@ -1013,18 +1001,6 @@
  <PosPart copyNumber="2">
    <rParent name="pixbar:PixelBarrel"/>
    <rChild name="pixbar:PixelBarrelConn4"/>
-  <rRotation name="pixbar:180D"/>
-  <Translation x="[zero]" y="[zero]" z="[Conn4Z]" />
- </PosPart>
- <PosPart copyNumber="3">
-   <rParent name="pixbar:PixelBarrel"/>
-   <rChild name="pixbar:PixelBarrelConn4"/>
-  <Translation x="[zero]" y="[zero]" z="-[Conn4Z]" />
- </PosPart>
- <PosPart copyNumber="4">
-   <rParent name="pixbar:PixelBarrel"/>
-   <rChild name="pixbar:PixelBarrelConn4"/>
-  <rRotation name="pixbar:180D"/>
   <Translation x="[zero]" y="[zero]" z="-[Conn4Z]" />
  </PosPart>
 
@@ -1036,18 +1012,6 @@
  <PosPart copyNumber="2">
    <rParent name="pixbar:PixelBarrel"/>
    <rChild name="pixbar:PixelBarrelService"/>
-  <rRotation name="pixbar:180D"/>
-  <Translation x="[zero]" y="[zero]" z="[ServZ]" />
- </PosPart>
- <PosPart copyNumber="3">
-   <rParent name="pixbar:PixelBarrel"/>
-   <rChild name="pixbar:PixelBarrelService"/>
-  <Translation x="[zero]" y="[zero]" z="-[ServZ]" />
- </PosPart>
- <PosPart copyNumber="4">
-   <rParent name="pixbar:PixelBarrel"/>
-   <rChild name="pixbar:PixelBarrelService"/>
-  <rRotation name="pixbar:180D"/>
   <Translation x="[zero]" y="[zero]" z="-[ServZ]" />
  </PosPart>
 
@@ -1059,7 +1023,9 @@
  <PosPart copyNumber="2">
    <rParent name="pixbar:PixelBarrel"/>
    <rChild name="pixbar:PixelBarrelSupTubCables"/>
-  <rRotation name="pixbar:180D"/>
+<!--  
+<rRotation name="pixbar:180D"/>
+-->
   <Translation x="[zero]" y="[zero]" z="-[ServCablZ]" />
  </PosPart>
 

--- a/Geometry/TrackerCommonData/data/PhaseI/pixbarmaterial.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbarmaterial.xml
@@ -4,7 +4,7 @@
 <MaterialSection label="pixbarmaterial.xml">
 
 <!-- New materials -->
-  <CompositeMaterial name="SupplyTubeConn3" density="0.3556*g/cm3" symbol=" " method="mixture by weight">   <!--Supply tube material in Conn3 volume-->
+  <CompositeMaterial name="SupplyTubeConn3" density="0.3556*g/cm3" symbol=" " method="mixture by weight">   <!--Supply tube material in Conn3 volume (no fpix contribution and 150/180 deg sectors)-->
      <MaterialFraction fraction="0.027795">
       <rMaterial name="materials:Bpix_Pipe_Steel"/>
      </MaterialFraction>
@@ -30,6 +30,17 @@
       <rMaterial name="materials:T_Kapton"/>
     </MaterialFraction>
    </CompositeMaterial>
+   
+  <CompositeMaterial name="SupplyTubeConn3_3Disks" density="0.4646*g/cm3" symbol=" " method="mixture by weight"> <!-- fpix 3 disks service material added -->
+    <MaterialFraction fraction="1.00000000">
+      <rMaterial name="SupplyTubeConn3"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="SupplyTubeConn3_10Disks" density="0.7908*g/cm3" symbol=" " method="mixture by weight"> <!-- fpix 10 disks service material added -->
+    <MaterialFraction fraction="1.00000000">
+      <rMaterial name="SupplyTubeConn3"/>
+    </MaterialFraction>
+  </CompositeMaterial>
 
   <CompositeMaterial name="SupplyTubeEpoxy" density="1.05*g/cm3" symbol=" " method="mixture by weight">
     <MaterialFraction fraction="0.5999">
@@ -576,6 +587,17 @@
       <rMaterial name="trackermaterial:T_Nomex"/>
     </MaterialFraction>
   </CompositeMaterial>
+  
+ <CompositeMaterial name="SectorA_3Disks" density="0.55812*g/cm3" symbol=" " method="mixture by weight"> <!-- fpix 3 disks service material added -->
+    <MaterialFraction fraction="1.0">
+      <rMaterial name="pixbarmaterial:SectorA"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+ <CompositeMaterial name="SectorA_10Disks" density="0.95001*g/cm3" symbol=" " method="mixture by weight"> <!-- fpix 10 disks service material added -->
+    <MaterialFraction fraction="1.0">
+      <rMaterial name="pixbarmaterial:SectorA"/>
+    </MaterialFraction>
+  </CompositeMaterial>
 
   <CompositeMaterial name="SectorB" density="0.74961*g/cm3" symbol=" " method="mixture by weight">
     <MaterialFraction fraction="0.19011">
@@ -648,6 +670,17 @@
       <rMaterial name="trackermaterial:T_Nomex"/>
     </MaterialFraction>
   </CompositeMaterial>
+  
+ <CompositeMaterial name="SectorC_3Disks" density="1.22394*g/cm3" symbol=" " method="mixture by weight"> <!-- fpix 3 disks service material added -->
+    <MaterialFraction fraction="1.000000">
+      <rMaterial name="pixbarmaterial:SectorC"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+ <CompositeMaterial name="SectorC_10Disks" density="2.18549*g/cm3" symbol=" " method="mixture by weight"> <!-- fpix 10 disks service material added -->
+    <MaterialFraction fraction="1.000000">
+      <rMaterial name="pixbarmaterial:SectorC"/>
+    </MaterialFraction>
+  </CompositeMaterial>
 
   <CompositeMaterial name="SectorC_Upgrade" density="0.19652*g/cm3" symbol=" " method="mixture by weight">
     <MaterialFraction fraction="1.00000000">
@@ -683,6 +716,17 @@
     </MaterialFraction>
     <MaterialFraction fraction="0.4749">
       <rMaterial name="trackermaterial:T_Copper"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+  
+  <CompositeMaterial name="PixelBarrelSupTubCables2_3Disks" density="0.96016*g/cm3" symbol=" " method="mixture by weight"> <!-- fpix 3 disks service material added -->
+    <MaterialFraction fraction="1.00000000">
+      <rMaterial name="PixelBarrelSupTubCables2"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="PixelBarrelSupTubCables2_10Disks" density="1.63436*g/cm3" symbol=" " method="mixture by weight"> <!-- fpix 10 disks service material added -->
+    <MaterialFraction fraction="1.00000000">
+      <rMaterial name="PixelBarrelSupTubCables2"/>
     </MaterialFraction>
   </CompositeMaterial>
 

--- a/Geometry/TrackerCommonData/data/PhaseI/pixfwd.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixfwd.xml
@@ -15,8 +15,8 @@
  <Constant name="RootEndZ"       value="2*[RootHalfLength]"/>
 
  <Constant name="Disk1Z"         value="[pixfwdDisks:DiskHalfWidth]+[RootStartZ]"/> <!-- 35.75*mm-->
- <Constant name="Disk2Z"         value="[Disk1Z]+105.0*mm"/> <!-- +72.5*mm--> <!-- +105.0*mm -->
- <Constant name="Disk3Z"         value="[Disk2Z]+120.0*mm"/> <!-- +120.0*mm-->
+ <Constant name="Disk2Z"         value="[Disk1Z]+75.0*mm"/> <!-- +72.5*mm--> <!-- +105.0*mm -->
+ <Constant name="Disk3Z"         value="[Disk2Z]+95.0*mm"/> <!-- +120.0*mm-->
 
  <Constant name="ZCylinder"      value="[AnchorZ]"/>
 

--- a/Geometry/TrackerCommonData/data/PhaseI/pixfwdDisks.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixfwdDisks.xml
@@ -4,7 +4,7 @@
 <ConstantsSection label="pixfwdDisks.xml" eval="true">
  <Constant name="DiskRmin"         value="37.5*mm"/>
  <Constant name="DiskRmax"         value="166.0*mm"/><!-- 166.00*mm-->
- <Constant name="DiskHalfWidth"    value="39.75*mm"/>  <!-- 35.75*mm-->
+ <Constant name="DiskHalfWidth"    value="37.5*mm"/>  <!-- 39.75*mm-->
 </ConstantsSection>
  
 <SolidSection label="pixfwdDisks.xml">

--- a/Geometry/TrackerCommonData/data/PhaseI/pixfwdInnerDisk1.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixfwdInnerDisk1.xml
@@ -94,7 +94,7 @@
   <Numeric name="NumberOfBlades"   value="22"/>
   <Numeric name="BladeAngle"       value="20*deg"/>
   <Numeric name="BladeTilt"        value="12*deg"/>
-  <Numeric name="BladeCommonZ"     value="-18.7*mm"/>
+  <Numeric name="BladeCommonZ"     value="-16.45*mm"/> <!-- -18.7*mm-->
   <Vector name="BladeZShift" type="numeric" nEntries="22">
      7.12*mm,  2.62*mm, -1.88*mm, -6.38*mm, -10.88*mm,      
      11.62*mm,  7.12*mm,  2.62*mm, -1.88*mm, -6.38*mm, -10.88*mm,      

--- a/Geometry/TrackerCommonData/data/PhaseI/pixfwdInnerDisk2.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixfwdInnerDisk2.xml
@@ -94,7 +94,7 @@
   <Numeric name="NumberOfBlades"   value="22"/>
   <Numeric name="BladeAngle"       value="20*deg"/>
   <Numeric name="BladeTilt"        value="12*deg"/>
-  <Numeric name="BladeCommonZ"     value="-18.7*mm"/>
+  <Numeric name="BladeCommonZ"     value="-16.45*mm"/> <!-- -18.7*mm-->
   <Vector name="BladeZShift" type="numeric" nEntries="22">
      7.12*mm,  2.62*mm, -1.88*mm, -6.38*mm, -10.88*mm,      
      11.62*mm,  7.12*mm,  2.62*mm, -1.88*mm, -6.38*mm, -10.88*mm,      

--- a/Geometry/TrackerCommonData/data/PhaseI/pixfwdInnerDisk3.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixfwdInnerDisk3.xml
@@ -94,7 +94,7 @@
   <Numeric name="NumberOfBlades"   value="22"/>
   <Numeric name="BladeAngle"       value="20*deg"/>
   <Numeric name="BladeTilt"        value="12*deg"/>
-  <Numeric name="BladeCommonZ"     value="-18.7*mm"/>
+  <Numeric name="BladeCommonZ"     value="-16.45*mm"/> <!-- -18.7*mm-->
   <Vector name="BladeZShift" type="numeric" nEntries="22">
      7.12*mm,  2.62*mm, -1.88*mm, -6.38*mm, -10.88*mm,      
      11.62*mm,  7.12*mm,  2.62*mm, -1.88*mm, -6.38*mm, -10.88*mm,      

--- a/Geometry/TrackerCommonData/data/PhaseI/pixfwdOuterDisk1.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixfwdOuterDisk1.xml
@@ -10,7 +10,7 @@
 <!--  <Constant name="OuterRingHalfWidth"   value="18.6*mm"/> -->
   <Constant name="OuterRingHalfWidth"   value="18.6*mm"/>
   <Constant name="OuterRingZ"           value="-[pixfwdDisks:DiskHalfWidth]+[OuterRingHalfWidth]"/>
-  <Constant name="InnerRingRMax"      value="89.2"/>
+  <Constant name="InnerRingRMax"      value="89.2*mm"/>
   <Constant name="InnerRingRMin"      value="[InnerRingRMax]-2.0*mm"/>
   <Constant name="InnerRingCFRMax"     value="[InnerRingRMin]"/>
   <Constant name="InnerRingCFRMin"     value="[InnerRingCFRMax]-0.5*mm"/>
@@ -94,7 +94,7 @@
   <Numeric name="NumberOfBlades"   value="34"/>
   <Numeric name="BladeAngle"       value="20*deg"/>
   <Numeric name="BladeTilt"        value="0*deg"/>
-  <Numeric name="BladeCommonZ"     value="-3.75*mm"/>
+  <Numeric name="BladeCommonZ"     value="-1.5*mm"/> <!-- -3.75*mm-->
   <Vector  name="BladeZShift" type="numeric" nEntries="34">
    -9.92*mm, -12.42*mm,-14.92*mm,-17.42*mm,-19.92*mm,-22.42*mm,-24.92*mm, -27.42*mm,
    -7.42*mm, -9.92*mm, -12.42*mm,-14.92*mm,-17.42*mm,-19.92*mm,-22.42*mm,-24.92*mm, -27.42*mm,

--- a/Geometry/TrackerCommonData/data/PhaseI/pixfwdOuterDisk2.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixfwdOuterDisk2.xml
@@ -9,7 +9,7 @@
 <!--  <Constant name="OuterRingHalfWidth"   value="18.6*mm"/> -->
   <Constant name="OuterRingHalfWidth"   value="18.6*mm"/>
   <Constant name="OuterRingZ"           value="-[pixfwdDisks:DiskHalfWidth]+[OuterRingHalfWidth]"/>
-  <Constant name="InnerRingRMax"      value="89.2"/>
+  <Constant name="InnerRingRMax"      value="89.2*mm"/>
   <Constant name="InnerRingRMin"      value="[InnerRingRMax]-2.0*mm"/>
   <Constant name="InnerRingCFRMax"     value="[InnerRingRMin]"/>
   <Constant name="InnerRingCFRMin"     value="[InnerRingCFRMax]-0.5*mm"/>
@@ -94,7 +94,7 @@
   <Numeric name="NumberOfBlades"   value="34"/>
   <Numeric name="BladeAngle"       value="20*deg"/>
   <Numeric name="BladeTilt"        value="0*deg"/>
-  <Numeric name="BladeCommonZ"     value="-3.75*mm"/>
+  <Numeric name="BladeCommonZ"     value="-1.5*mm"/> <!-- -3.75*mm-->
   <Vector  name="BladeZShift" type="numeric" nEntries="34">
    -9.92*mm, -12.42*mm,-14.92*mm,-17.42*mm,-19.92*mm,-22.42*mm,-24.92*mm, -27.42*mm,
    -7.42*mm, -9.92*mm, -12.42*mm,-14.92*mm,-17.42*mm,-19.92*mm,-22.42*mm,-24.92*mm, -27.42*mm,

--- a/Geometry/TrackerCommonData/data/PhaseI/pixfwdOuterDisk3.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixfwdOuterDisk3.xml
@@ -10,7 +10,7 @@
 <!--  <Constant name="OuterRingHalfWidth"   value="18.6*mm"/> -->
   <Constant name="OuterRingHalfWidth"   value="18.6*mm"/>
   <Constant name="OuterRingZ"           value="-[pixfwdDisks:DiskHalfWidth]+[OuterRingHalfWidth]"/>
-  <Constant name="InnerRingRMax"      value="89.2"/>
+  <Constant name="InnerRingRMax"      value="89.2*mm"/>
   <Constant name="InnerRingRMin"      value="[InnerRingRMax]-2.0*mm"/>
   <Constant name="InnerRingCFRMax"     value="[InnerRingRMin]"/>
   <Constant name="InnerRingCFRMin"     value="[InnerRingCFRMax]-0.5*mm"/>
@@ -95,7 +95,7 @@
   <Numeric name="NumberOfBlades"   value="34"/>
   <Numeric name="BladeAngle"       value="20*deg"/>
   <Numeric name="BladeTilt"        value="0*deg"/>
-  <Numeric name="BladeCommonZ"     value="-3.75*mm"/>
+  <Numeric name="BladeCommonZ"     value="-1.5*mm"/> <!-- -3.75*mm-->
   <Vector  name="BladeZShift" type="numeric" nEntries="34">
    -9.92*mm, -12.42*mm,-14.92*mm,-17.42*mm,-19.92*mm,-22.42*mm,-24.92*mm, -27.42*mm,
    -7.42*mm, -9.92*mm, -12.42*mm,-14.92*mm,-17.42*mm,-19.92*mm,-22.42*mm,-24.92*mm, -27.42*mm,


### PR DESCRIPTION
First round of XMLs files for 72X :  starting with pixel phase1 synchronized with the latest developments in 62X_SLHC (@mark-grimes & @venturia : FYI, starting to update 72X with the upgrade geometries)
@atricomi : any xml updates should be kept synchronized with 7x from now 
