### PR TITLE
Fix a few minor bugs in Online DQM monitoring

### DIFF
--- a/DQMServices/StreamerIO/plugins/DQMFileIterator.cc
+++ b/DQMServices/StreamerIO/plugins/DQMFileIterator.cc
@@ -69,6 +69,7 @@ DQMFileIterator::DQMFileIterator(edm::ParameterSet const& pset)
   nextLumiTimeoutMillis_ =
       pset.getUntrackedParameter<int32_t>("nextLumiTimeoutMillis");
 
+  forceFileCheckTimeoutMillis_ = 5015;
   reset();
 }
 
@@ -158,20 +159,20 @@ void DQMFileIterator::collect(bool ignoreTimers) {
   // don't refresh if it's too soon
   if ((!ignoreTimers) && (last_ms < 100)) {
     return;
-  } else {
-    runPathLastCollect_ = now;
   }
 
   // check if directory changed
   std::time_t t = boost::filesystem::last_write_time(runPath_);
 
-  if ((!ignoreTimers) && (t <= runPathMTime_)) {
+  if ((!ignoreTimers) && (last_ms < forceFileCheckTimeoutMillis_) && (t == runPathMTime_)) {
     //logFileAction("Directory hasn't changed.");
     return;
   } else {
     //logFileAction("Directory changed, updating.");
-    runPathMTime_ = t;
   }
+
+  runPathMTime_ = t;
+  runPathLastCollect_ = now;
 
   using boost::filesystem::directory_iterator;
   using boost::filesystem::directory_entry;

--- a/DQMServices/StreamerIO/plugins/DQMFileIterator.h
+++ b/DQMServices/StreamerIO/plugins/DQMFileIterator.h
@@ -86,6 +86,7 @@ class DQMFileIterator {
   std::string streamLabel_;
   unsigned long delayMillis_;
   long nextLumiTimeoutMillis_;
+  long forceFileCheckTimeoutMillis_;
 
   // file name position in the json file
   unsigned int datafnPosition_;

--- a/DQMServices/StreamerIO/plugins/DQMMonitoringService.cc
+++ b/DQMServices/StreamerIO/plugins/DQMMonitoringService.cc
@@ -60,6 +60,7 @@ void DQMMonitoringService::reportEvents(int nevts) {
 void DQMMonitoringService::reportLumiSectionUnsafe(int run, int lumi) {
   using std::chrono::duration_cast;
   using std::chrono::milliseconds;
+  using std::chrono::seconds;
 
   int pid = getpid();
   ++fseq_;
@@ -89,8 +90,7 @@ void DQMMonitoringService::reportLumiSectionUnsafe(int run, int lumi) {
   std::string final_path = (json_path_ / path_id).string();
 
   float rate = (nevents_ - last_report_nevents_);
-  rate = rate / duration_cast<milliseconds>(now - last_report_time_).count();
-  rate = rate / 100;
+  rate = rate / duration_cast<seconds>(now - last_report_time_).count();
 
   ptree pt;
   pt.put("_id", id);
@@ -104,6 +104,8 @@ void DQMMonitoringService::reportLumiSectionUnsafe(int run, int lumi) {
 
   pt.put("events_total", nevents_);
   pt.put("events_rate", rate);
+  
+  pt.put("report_timestamp", std::time(NULL));
 
   // add some additional per-lumi information
   std::string log = hackoutTheStdErr();

--- a/DQMServices/StreamerIO/plugins/DQMMonitoringService.cc
+++ b/DQMServices/StreamerIO/plugins/DQMMonitoringService.cc
@@ -27,6 +27,9 @@ DQMMonitoringService::DQMMonitoringService(const edm::ParameterSet &pset, edm::A
   hostname_ = host;
   fseq_ = 0;
   tag_ = "";
+  nevents_ = 0;
+  last_report_nevents_ = 0;
+  last_report_time_ = std::chrono::high_resolution_clock::now();
 
   try {
     fillProcessInfoCmdline();
@@ -150,6 +153,11 @@ void DQMMonitoringService::fillProcessInfoCmdline() {
         tag_ = token;
         boost::replace_last(tag_, ".py", "");
         boost::replace_last(tag_, "_cfg", "");
+
+        size_t pos = tag_.rfind("/");
+        if (pos != std::string::npos) {
+          tag_ = tag_.substr(pos + 1);
+        }
       }
 
       while (*p++); // skip until start of next 0-terminated section


### PR DESCRIPTION
This PR implements/fixes:
1. event rate calculation in dqm online monitoring;
2. modifies time-to-live in dqm online monitoring output schema;
3. implements a playback mode in dqm online monitoring file monitoring daemon (yes, DQ(M)^3).
