### PR TITLE
database compatibility additions for boost I/O so that records intended ...

### DIFF
--- a/CondCore/HcalPlugins/src/plugin.cc
+++ b/CondCore/HcalPlugins/src/plugin.cc
@@ -13,6 +13,9 @@
 #include "CondFormats/DataRecord/interface/HcalOOTPileupCorrectionRcd.h"
 #include "CondFormats/HcalObjects/interface/OOTPileupCorrectionColl.h"
 
+#include "CondFormats/DataRecord/interface/HcalOOTPileupCompatibilityRcd.h"
+#include "CondFormats/HcalObjects/interface/OOTPileupCorrectionBuffer.h"
+
 //
 #include "CondCore/CondDB/interface/Serialization.h"
 
@@ -53,3 +56,5 @@ REGISTER_PLUGIN(HcalMCParamsRcd,HcalMCParams);
 REGISTER_PLUGIN(HcalFlagHFDigiTimeParamsRcd,HcalFlagHFDigiTimeParams);
 REGISTER_PLUGIN(HcalTimingParamsRcd,HcalTimingParams);
 REGISTER_PLUGIN(HcalOOTPileupCorrectionRcd,OOTPileupCorrectionColl);
+REGISTER_PLUGIN(HcalOOTPileupCompatibilityRcd,OOTPileupCorrectionBuffer);
+

--- a/CondFormats/DataRecord/interface/HcalOOTPileupCompatibilityRcd.h
+++ b/CondFormats/DataRecord/interface/HcalOOTPileupCompatibilityRcd.h
@@ -1,0 +1,26 @@
+#ifndef CondFormats_HcalOOTPileupCompatibilityRcd_h
+#define CondFormats_HcalOOTPileupCompatibilityRcd_h
+// -*- C++ -*-
+//
+// Package:     CondFormats/DataRecord
+// Class  :     HcalOOTPileupCompatibilityRcd
+// 
+/**\class HcalOOTPileupCompatibilityRcd HcalOOTPileupCompatibilityRcd.h CondFormats/DataRecord/interface/HcalOOTPileupCompatibilityRcd.h
+
+ Description: record for storing OOT pileup mitigation parameters
+
+ Usage:
+    <usage>
+
+*/
+//
+// Author:      Igor Volobouev
+// Created:     Fri Aug 29 18:43:00 CDT 2014
+//
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+
+class HcalOOTPileupCompatibilityRcd : public edm::eventsetup::EventSetupRecordImplementation<HcalOOTPileupCompatibilityRcd> {};
+
+#endif // CondFormats_HcalOOTPileupCompatibilityRcd_h
+

--- a/CondFormats/DataRecord/src/HcalOOTPileupCompatibilityRcd.cc
+++ b/CondFormats/DataRecord/src/HcalOOTPileupCompatibilityRcd.cc
@@ -1,0 +1,15 @@
+// -*- C++ -*-
+//
+// Package:     CondFormats/DataRecord
+// Class  :     HcalOOTPileupCompatibilityRcd
+// 
+// Implementation:
+//     [Notes on implementation]
+//
+// Author:      Igor Volobouev
+// Created:     Fri Aug 29 18:43:57 CDT 2014
+
+#include "CondFormats/DataRecord/interface/HcalOOTPileupCompatibilityRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+
+EVENTSETUP_RECORD_REG(HcalOOTPileupCompatibilityRcd);

--- a/CondFormats/HcalObjects/interface/AllObjects.h
+++ b/CondFormats/HcalObjects/interface/AllObjects.h
@@ -30,4 +30,5 @@
 #include "CondFormats/HcalObjects/interface/HcalMCParams.h"
 #include "CondFormats/HcalObjects/interface/HcalFlagHFDigiTimeParams.h"
 #include "CondFormats/HcalObjects/interface/HcalTimingParams.h"
+#include "CondFormats/HcalObjects/interface/OOTPileupCorrectionBuffer.h"
 #endif

--- a/CondFormats/HcalObjects/interface/OOTPileupCorrectionBuffer.h
+++ b/CondFormats/HcalObjects/interface/OOTPileupCorrectionBuffer.h
@@ -1,0 +1,44 @@
+#ifndef CondFormats_HcalObjects_OOTPileupCorrectionBuffer_h
+#define CondFormats_HcalObjects_OOTPileupCorrectionBuffer_h
+
+//
+// A simple storage buffer for Hcal OOT pileup corrections.
+//
+// I. Volobouev, 08/29/2014
+//
+
+#include "CondFormats/Serialization/interface/Serializable.h"
+
+#include <string>
+
+class OOTPileupCorrectionBuffer
+{
+public:
+    // Constructors
+    inline OOTPileupCorrectionBuffer() {}
+    inline explicit OOTPileupCorrectionBuffer(const std::string& s) 
+        : m_buffer(s) {}
+    inline OOTPileupCorrectionBuffer(const char* c, std::size_t len)
+        : m_buffer(c, len) {}
+    inline explicit OOTPileupCorrectionBuffer(std::size_t len) 
+        : m_buffer(len, '\0') {}
+
+    // Inspectors
+    inline const std::string& str() const {return m_buffer;}
+    inline std::size_t length() const {return m_buffer.size();}
+    inline bool empty() const {return m_buffer.empty();}
+    inline const char* getBuffer() const
+        {return m_buffer.empty() ? static_cast<const char*>(0) : &m_buffer[0];}
+
+    // Modifiers
+    inline char* getBuffer() 
+        {return m_buffer.empty() ? static_cast<char*>(0) : &m_buffer[0];}
+    inline void setStr(const std::string& s) {m_buffer = s;}
+
+private:
+    std::string m_buffer;
+
+    COND_SERIALIZABLE;
+};
+
+#endif // CondFormats_HcalObjects_OOTPileupCorrectionBuffer_h

--- a/CondFormats/HcalObjects/src/T_EventSetup_OOTPileupCorrectionBuffer.cc
+++ b/CondFormats/HcalObjects/src/T_EventSetup_OOTPileupCorrectionBuffer.cc
@@ -1,0 +1,4 @@
+#include "CondFormats/HcalObjects/interface/OOTPileupCorrectionBuffer.h"
+#include "FWCore/Utilities/interface/typelookup.h"
+
+TYPELOOKUP_DATA_REG(OOTPileupCorrectionBuffer);

--- a/CondFormats/HcalObjects/src/classes.h
+++ b/CondFormats/HcalObjects/src/classes.h
@@ -82,6 +82,8 @@ namespace CondFormats_HcalObjects {
 
     HcalTimingParams myTimingParams;
     std::vector<HcalTimingParam> myTimingParamVec;
+
+    OOTPileupCorrectionBuffer myOOTPileupCorrectionBuffer;
   };
 }
 

--- a/CondFormats/HcalObjects/src/classes_def.xml
+++ b/CondFormats/HcalObjects/src/classes_def.xml
@@ -376,4 +376,8 @@
  </class> 
  <class name="HcalFlagHFDigiTimeParams" class_version="0"/>
 
+ <class name="OOTPileupCorrectionBuffer">
+  <field name="m_buffer" mapping="blob" />
+ </class>
+
 </lcgdict>   

--- a/CondTools/Hcal/interface/BoostIODBReader.h
+++ b/CondTools/Hcal/interface/BoostIODBReader.h
@@ -1,12 +1,12 @@
-#ifndef RecoLocalCalo_HcalRecAlgos_BoostIODBReader_h
-#define RecoLocalCalo_HcalRecAlgos_BoostIODBReader_h
+#ifndef CondTools_Hcal_BoostIODBReader_h
+#define CondTools_Hcal_BoostIODBReader_h
 
 // -*- C++ -*-
 //
-// Package:    RecoLocalCalo/HcalRecAlgos
+// Package:    CondTools/Hcal
 // Class:      BoostIODBReader
 // 
-/**\class BoostIODBReader BoostIODBReader.h RecoLocalCalo/HcalRecAlgos/interface/BoostIODBReader.h
+/**\class BoostIODBReader BoostIODBReader.h CondTools/Hcal/interface/BoostIODBReader.h
 
  Description: reads an object from a database and puts it into a file using boost I/O
 
@@ -77,4 +77,4 @@ void BoostIODBReader<DataType,RecordType>::analyze(const edm::Event& iEvent,
     ar & *p;
 }
 
-#endif // RecoLocalCalo_HcalRecAlgos_BoostIODBReader_h
+#endif // CondTools_Hcal_BoostIODBReader_h

--- a/CondTools/Hcal/interface/BoostIODBWriter.h
+++ b/CondTools/Hcal/interface/BoostIODBWriter.h
@@ -1,12 +1,12 @@
-#ifndef RecoLocalCalo_HcalRecAlgos_BoostIODBWriter_h
-#define RecoLocalCalo_HcalRecAlgos_BoostIODBWriter_h
+#ifndef CondTools_Hcal_BoostIODBWriter_h
+#define CondTools_Hcal_BoostIODBWriter_h
 
 // -*- C++ -*-
 //
-// Package:    RecoLocalCalo/HcalRecAlgos
+// Package:    CondTools/Hcal
 // Class:      BoostIODBWriter
 // 
-/**\class BoostIODBWriter BoostIODBWriter.h RecoLocalCalo/HcalRecAlgos/interface/BoostIODBWriter.h
+/**\class BoostIODBWriter BoostIODBWriter.h CondTools/Hcal/interface/BoostIODBWriter.h
 
  Description: writes a boost I/O blob from a file into a database
 
@@ -87,4 +87,4 @@ void BoostIODBWriter<DataType>::analyze(const edm::Event& iEvent,
             << "please configure it properly" << std::endl;
 }
 
-#endif // RecoLocalCalo_HcalRecAlgos_BoostIODBWriter_h
+#endif // CondTools_Hcal_BoostIODBWriter_h

--- a/CondTools/Hcal/interface/BufferedBoostIOESProducer.h
+++ b/CondTools/Hcal/interface/BufferedBoostIOESProducer.h
@@ -1,0 +1,60 @@
+#ifndef CondTools_Hcal_BufferedBoostIOESProducer_h
+#define CondTools_Hcal_BufferedBoostIOESProducer_h
+
+// -*- C++ -*-
+//
+// Package:    CondTools/Hcal
+// Class:      BufferedBoostIOESProducer
+//
+/**\class BufferedBoostIOESProducer BufferedBoostIOESProducer.h CondTools/Hcal/interface/BufferedBoostIOESProducer.h
+
+ Description: reads objects serialized by boost from simple string buffers
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author:  Igor Volobouev
+//         Created:  Sun Aug 31 22:18:44 CDT 2014
+// $Id: BufferedBoostIOESProducer.h,v 1.0 2014/08/31 22:18:44 igv Exp $
+//
+//
+
+#include <sstream>
+#include "boost/shared_ptr.hpp"
+
+#include "FWCore/Framework/interface/ModuleFactory.h"
+#include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "CondFormats/Serialization/interface/eos/portable_iarchive.hpp"
+#include "CondFormats/HcalObjects/interface/OOTPileupCorrectionBuffer.h"
+
+template<class DataType, class MyRecord>
+class BufferedBoostIOESProducer : public edm::ESProducer
+{
+public:
+    typedef boost::shared_ptr<DataType> ReturnType;
+
+    inline BufferedBoostIOESProducer(const edm::ParameterSet&)
+        {setWhatProduced(this);}
+
+    inline virtual ~BufferedBoostIOESProducer() {}
+
+    ReturnType produce(const MyRecord&);
+};
+
+template<class DataType, class MyRecord>
+typename BufferedBoostIOESProducer<DataType,MyRecord>::ReturnType
+BufferedBoostIOESProducer<DataType,MyRecord>::produce(const MyRecord& iRecord)
+{
+    edm::ESHandle<OOTPileupCorrectionBuffer> handle;
+    iRecord.get(handle);
+    std::istringstream is(handle->str());
+    eos::portable_iarchive ar(is);
+    ReturnType ret(new DataType());
+    ar & *ret;
+    return ret;
+}
+
+#endif // CondTools_Hcal_BufferedBoostIOESProducer_h

--- a/CondTools/Hcal/plugins/BufferedBoostIODBWriter.cc
+++ b/CondTools/Hcal/plugins/BufferedBoostIODBWriter.cc
@@ -1,0 +1,84 @@
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <cassert>
+#include <fstream>
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "CondFormats/HcalObjects/interface/OOTPileupCorrectionBuffer.h"
+#include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
+
+//
+// class declaration
+//
+class BufferedBoostIODBWriter : public edm::EDAnalyzer
+{
+public:
+    explicit BufferedBoostIODBWriter(const edm::ParameterSet&);
+    virtual ~BufferedBoostIODBWriter() {}
+
+private:
+    BufferedBoostIODBWriter();
+    BufferedBoostIODBWriter(const BufferedBoostIODBWriter&);
+    BufferedBoostIODBWriter& operator=(const BufferedBoostIODBWriter&);
+
+    virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+
+    std::string inputFile;
+    std::string record;
+};
+
+BufferedBoostIODBWriter::BufferedBoostIODBWriter(const edm::ParameterSet& ps)
+    : inputFile(ps.getParameter<std::string>("inputFile")),
+      record(ps.getParameter<std::string>("record"))
+{
+}
+
+void BufferedBoostIODBWriter::analyze(const edm::Event& iEvent,
+                                      const edm::EventSetup& iSetup)
+{
+    std::auto_ptr<OOTPileupCorrectionBuffer> fcp;
+
+    {
+        std::ifstream input(inputFile.c_str(), std::ios_base::binary);
+        if (!input.is_open())
+            throw cms::Exception("InvalidArgument")
+                << "Failed to open file \"" << inputFile << '"' << std::endl;
+
+        struct stat st;
+        if (stat(inputFile.c_str(), &st))
+            throw cms::Exception("SystemError")
+                << "Failed to stat file \"" << inputFile << '"' << std::endl;
+
+        const std::size_t len = st.st_size;
+        fcp = std::auto_ptr<OOTPileupCorrectionBuffer>(
+            new OOTPileupCorrectionBuffer(len));
+        assert(fcp->length() == len);
+        if (len)
+            input.read(fcp->getBuffer(), len);
+        if (input.fail())
+            throw cms::Exception("SystemError")
+                << "Input stream failure while reading file \""
+                << inputFile << '"' << std::endl;
+    }
+
+    edm::Service<cond::service::PoolDBOutputService> poolDbService;
+    if (poolDbService.isAvailable())
+        poolDbService->writeOne(fcp.release(),
+                                poolDbService->currentTime(),
+                                record);
+    else
+        throw cms::Exception("ConfigurationError")
+            << "PoolDBOutputService is not available, "
+            << "please configure it properly" << std::endl;
+}
+
+DEFINE_FWK_MODULE(BufferedBoostIODBWriter);

--- a/CondTools/Hcal/plugins/OOTPileupCompatibilityModules.cc
+++ b/CondTools/Hcal/plugins/OOTPileupCompatibilityModules.cc
@@ -1,0 +1,7 @@
+#include "CondTools/Hcal/interface/BufferedBoostIOESProducer.h"
+#include "CondFormats/DataRecord/interface/HcalOOTPileupCompatibilityRcd.h"
+#include "CondFormats/HcalObjects/interface/OOTPileupCorrectionColl.h"
+
+typedef BufferedBoostIOESProducer<OOTPileupCorrectionColl,HcalOOTPileupCompatibilityRcd> OOTPileupDBCompatibilityESProducer;
+
+DEFINE_FWK_EVENTSETUP_MODULE(OOTPileupDBCompatibilityESProducer);

--- a/CondTools/Hcal/plugins/OOTPileupCorrectionDBModules.cc
+++ b/CondTools/Hcal/plugins/OOTPileupCorrectionDBModules.cc
@@ -1,5 +1,6 @@
 #include "CondFormats/HcalObjects/interface/OOTPileupCorrectionColl.h"
 #include "CondFormats/DataRecord/interface/HcalOOTPileupCorrectionRcd.h"
+#include "CondFormats/DataRecord/interface/HcalOOTPileupCompatibilityRcd.h"
 
 #include "CondTools/Hcal/interface/BoostIODBWriter.h"
 #include "CondTools/Hcal/interface/BoostIODBReader.h"
@@ -8,6 +9,9 @@
 
 typedef BoostIODBWriter<OOTPileupCorrectionColl> OOTPileupCorrectionDBWriter;
 typedef BoostIODBReader<OOTPileupCorrectionColl,HcalOOTPileupCorrectionRcd> OOTPileupCorrectionDBReader;
+typedef BoostIODBReader<OOTPileupCorrectionColl,HcalOOTPileupCompatibilityRcd> OOTPileupCompatibilityDBReader;
 
 DEFINE_FWK_MODULE(OOTPileupCorrectionDBWriter);
 DEFINE_FWK_MODULE(OOTPileupCorrectionDBReader);
+DEFINE_FWK_MODULE(OOTPileupCompatibilityDBReader);
+

--- a/CondTools/Hcal/test/OOTPileupCompatibilityDBReader_cfg.py
+++ b/CondTools/Hcal/test/OOTPileupCompatibilityDBReader_cfg.py
@@ -1,0 +1,32 @@
+database = "sqlite_file:compatOOTPileupCorrection.db"
+tag = "test"
+outputfile = "testOOTPileupCorrection_dbread.bbin"
+
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('OOTPileupCompatibilityDBRead')
+
+process.source = cms.Source('EmptySource') 
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(1)) 
+
+process.load("CondCore.CondDB.CondDB_cfi")
+process.CondDB.connect = database
+
+process.PoolDBESSource = cms.ESSource("PoolDBESSource",
+    process.CondDB,
+    toGet = cms.VPSet(cms.PSet(
+        record = cms.string("HcalOOTPileupCompatibilityRcd"),
+        tag = cms.string(tag)
+    ))
+)
+
+process.ootpileupesproducer = cms.ESProducer(
+    'OOTPileupDBCompatibilityESProducer'
+)
+
+process.dumper = cms.EDAnalyzer(
+    'OOTPileupCompatibilityDBReader',
+    outputFile = cms.string(outputfile)
+)
+
+process.p = cms.Path(process.dumper)

--- a/CondTools/Hcal/test/OOTPileupCompatibilityDBWriter_cfg.py
+++ b/CondTools/Hcal/test/OOTPileupCompatibilityDBWriter_cfg.py
@@ -1,0 +1,45 @@
+database = "sqlite_file:compatOOTPileupCorrection.db"
+tag = "test"
+inputfile = "../data/testOOTPileupCorrection.bbin"
+
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('OOTPileupCompatibilityDBWrite') 
+
+process.source = cms.Source('EmptySource') 
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(1)) 
+
+process.load("CondCore.CondDB.CondDB_cfi")
+process.CondDB.connect = database
+
+# Data is tagged in the database by the "tag" parameter specified in the
+# PoolDBOutputService configuration. We then check if the tag already exists.
+#
+# -- If the tag does not exist, a new interval of validity (IOV) for this tag
+#    is created, valid till "end of time".
+#
+# -- If the tag already exists: the IOV of the previous data is stopped at
+#    "current time" and we register new data valid from now on (currentTime
+#    is the time of the current event!). 
+#
+# The "record" parameter should be the same in the PoolDBOutputService
+# configuration and in the module which writes the object. It is basically
+# used in order to just associate the record with the tag.
+#
+process.PoolDBOutputService = cms.Service(
+    "PoolDBOutputService",
+    process.CondDB,
+    timetype = cms.untracked.string('runnumber'),
+    toPut = cms.VPSet(cms.PSet(
+        record = cms.string("HcalOOTPileupCompatibilityRcd"),
+        tag = cms.string(tag)
+    ))
+)
+
+process.filereader = cms.EDAnalyzer(
+    'BufferedBoostIODBWriter',
+    inputFile = cms.string(inputfile),
+    record = cms.string("HcalOOTPileupCompatibilityRcd")
+)
+
+process.p = cms.Path(process.filereader)


### PR DESCRIPTION
This includes a number of changes intended for storing conditions
objects serialized with boost.serialization into v1 database in case
genreflex/root I/O can not process the data structures. The idea
is to make a simple string buffer and use it for boost I/O. What
stored in the database is the blob representation of this buffer.
