### PR TITLE
Fix compilation error

### DIFF
--- a/FWCore/TFWLiteSelector/src/TFWLiteSelectorBasic.cc
+++ b/FWCore/TFWLiteSelector/src/TFWLiteSelectorBasic.cc
@@ -50,7 +50,6 @@
 #include "TChain.h"
 #include "TFile.h"
 #include "TTree.h"
-#include "Reflex/Type.h"
 
 #include <iostream>
 #include <memory>
@@ -99,8 +98,8 @@ namespace edm {
       }
       //find the class type
       std::string const fullName = wrappedClassName(bDesc.className());
-      Reflex::Type classType = Reflex::Type::ByName(fullName);
-      if(classType == Reflex::Type()) {
+      TypeWithDict classType = TypeWithDict::byName(fullName);
+      if(!bool(classType)) {
         throw cms::Exception("MissingDictionary")
         << "could not find dictionary for type '" << fullName << "'"
         << "\n Please make sure all the necessary libraries are available.";


### PR DESCRIPTION
FIx compilation error caused by carry forward from 7_2_X branch, which reintroduced use of Reflex.
Please merge as soon as convenient.
