### PR TITLE
JetCorrector in Event

### DIFF
--- a/JetMETCorrections/Algorithms/BuildFile.xml
+++ b/JetMETCorrections/Algorithms/BuildFile.xml
@@ -9,6 +9,7 @@
 <use   name="FWCore/MessageLogger"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="JetMETCorrections/Objects"/>
+<use   name="JetMETCorrections/JetCorrector"/>
 <use   name="boost"/>
 <export>
   <lib   name="1"/>

--- a/JetMETCorrections/Algorithms/interface/JetCorrectorImplMakerBase.h
+++ b/JetMETCorrections/Algorithms/interface/JetCorrectorImplMakerBase.h
@@ -1,0 +1,66 @@
+#ifndef JetMETCorrections_Algorithms_JetCorrectorImplMakerBase_h
+#define JetMETCorrections_Algorithms_JetCorrectorImplMakerBase_h
+// -*- C++ -*-
+//
+// Package:     JetMETCorrections/Algorithms
+// Class  :     JetCorrectorImplMakerBase
+// 
+/**\class JetCorrectorImplMakerBase JetCorrectorImplMakerBase.h "JetMETCorrections/Algorithms/interface/JetCorrectorImplMakerBase.h"
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Christopher Jones
+//         Created:  Fri, 29 Aug 2014 19:52:21 GMT
+//
+
+// system include files
+#include <string>
+#include <memory>
+#include <functional>
+
+// user include files
+#include "CondFormats/JetMETObjects/interface/FactorizedJetCorrectorCalculator.h"
+
+// forward declarations
+namespace edm {
+  class ParameterSet;
+  class EventSetup;
+}
+
+class JetCorrectorImplMakerBase
+{
+  
+ public:
+  JetCorrectorImplMakerBase(edm::ParameterSet const&);
+  virtual ~JetCorrectorImplMakerBase();
+  
+  // ---------- const member functions ---------------------
+  
+  // ---------- static member functions --------------------
+  
+  // ---------- member functions ---------------------------
+
+ protected:
+  std::shared_ptr<FactorizedJetCorrectorCalculator const> getCalculator(edm::EventSetup const&,
+									std::function<void(std::string const&)> levelCheck);
+  
+ private:
+  JetCorrectorImplMakerBase(const JetCorrectorImplMakerBase&); // stop default
+  
+  const JetCorrectorImplMakerBase& operator=(const JetCorrectorImplMakerBase&); // stop default
+  
+  // ---------- member data --------------------------------
+  std::string level_;
+  std::string algo_;
+  std::shared_ptr<FactorizedJetCorrectorCalculator const> corrector_;
+  unsigned long long cacheId_;
+
+};
+
+
+#endif

--- a/JetMETCorrections/Algorithms/interface/JetCorrectorImplMakerBase.h
+++ b/JetMETCorrections/Algorithms/interface/JetCorrectorImplMakerBase.h
@@ -30,6 +30,7 @@
 namespace edm {
   class ParameterSet;
   class EventSetup;
+  class ParameterSetDescription;
 }
 
 class JetCorrectorImplMakerBase
@@ -42,6 +43,7 @@ class JetCorrectorImplMakerBase
   // ---------- const member functions ---------------------
   
   // ---------- static member functions --------------------
+  static void addToDescription(edm::ParameterSetDescription& iDescription);
   
   // ---------- member functions ---------------------------
 

--- a/JetMETCorrections/Algorithms/interface/L1FastjetCorrectorImpl.h
+++ b/JetMETCorrections/Algorithms/interface/L1FastjetCorrectorImpl.h
@@ -1,0 +1,55 @@
+//
+// L1FastjetCorrector
+// ------------------
+//
+// 08/09/2009 Philipp Schieferdecker <philipp.schieferdecker@cern.ch>
+//
+#ifndef JetMETCorrections_JetCorrector_L1FastjetCorrectorImpl_h
+#define JetMETCorrections_JetCorrector_L1FastjetCorrectorImpl_h 1
+
+#include "JetMETCorrections/JetCorrector/interface/JetCorrectorImpl.h"
+#include "JetMETCorrections/Algorithms/interface/JetCorrectorImplMakerBase.h"
+#include "CondFormats/JetMETObjects/interface/FactorizedJetCorrectorCalculator.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+
+namespace edm {
+  class ParameterSet;
+  class Event;
+  class EventSetup;
+  class ConsumesCollector;
+}
+
+class L1FastjetCorrectorImplMaker : public JetCorrectorImplMakerBase {
+ public:
+  L1FastjetCorrectorImplMaker(edm::ParameterSet const&, edm::ConsumesCollector);
+  std::unique_ptr<reco::JetCorrectorImpl> make(edm::Event const&, edm::EventSetup const&);
+ private:
+  edm::EDGetTokenT<double> rhoToken_;
+};
+
+class L1FastjetCorrectorImpl : public reco::JetCorrectorImpl
+{
+public:
+  typedef L1FastjetCorrectorImplMaker Maker;
+
+  // construction / destruction
+  L1FastjetCorrectorImpl(std::shared_ptr<FactorizedJetCorrectorCalculator const> corrector, double rho):
+  rho_(rho),corrector_(corrector) {}
+  
+  //member functions
+  
+  /// apply correction using Jet information only
+  virtual double correction(const LorentzVector& fJet) const;
+  /// apply correction using Jet information only
+  virtual double correction(const reco::Jet& fJet) const;
+
+  //----- if correction needs a jet reference -------------
+  virtual bool refRequired() const { return false; }
+
+private:
+  // member data
+  double rho_;
+  std::shared_ptr<FactorizedJetCorrectorCalculator const> corrector_;
+};
+
+#endif

--- a/JetMETCorrections/Algorithms/interface/L1FastjetCorrectorImpl.h
+++ b/JetMETCorrections/Algorithms/interface/L1FastjetCorrectorImpl.h
@@ -17,12 +17,15 @@ namespace edm {
   class Event;
   class EventSetup;
   class ConsumesCollector;
+  class ConfigurationDescriptions;
 }
 
 class L1FastjetCorrectorImplMaker : public JetCorrectorImplMakerBase {
  public:
   L1FastjetCorrectorImplMaker(edm::ParameterSet const&, edm::ConsumesCollector);
   std::unique_ptr<reco::JetCorrectorImpl> make(edm::Event const&, edm::EventSetup const&);
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& iDescriptions);
  private:
   edm::EDGetTokenT<double> rhoToken_;
 };

--- a/JetMETCorrections/Algorithms/interface/L1JPTOffsetCorrectorImpl.h
+++ b/JetMETCorrections/Algorithms/interface/L1JPTOffsetCorrectorImpl.h
@@ -15,6 +15,7 @@ namespace edm
   class Event;
   class EventSetup;
   class ConsumesCollector;
+  class ConfigurationDescriptions;
 }
 
 namespace reco {
@@ -25,6 +26,8 @@ class L1JPTOffsetCorrectorImplMaker : public JetCorrectorImplMakerBase {
  public:
   L1JPTOffsetCorrectorImplMaker(edm::ParameterSet const&, edm::ConsumesCollector);
   std::unique_ptr<reco::JetCorrectorImpl> make(edm::Event const&, edm::EventSetup const&);
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& iDescriptions);
  private:
   edm::EDGetTokenT<reco::JetCorrector> offsetCorrectorToken_;
   bool useOffset_;

--- a/JetMETCorrections/Algorithms/interface/L1JPTOffsetCorrectorImpl.h
+++ b/JetMETCorrections/Algorithms/interface/L1JPTOffsetCorrectorImpl.h
@@ -1,0 +1,58 @@
+// L1Offset jet corrector class. Inherits from JetCorrector.h
+#ifndef L1JPTOffsetCorrectorImpl_h
+#define L1JPTOffsetCorrectorImpl_h
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "JetMETCorrections/JetCorrector/interface/JetCorrectorImpl.h"
+#include "JetMETCorrections/Algorithms/interface/JetCorrectorImplMakerBase.h"
+#include "CondFormats/JetMETObjects/interface/FactorizedJetCorrectorCalculator.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+
+//----- classes declaration -----------------------------------
+namespace edm 
+{
+  class ParameterSet;
+  class Event;
+  class EventSetup;
+  class ConsumesCollector;
+}
+
+namespace reco {
+  class JetCorrector;
+}
+
+class L1JPTOffsetCorrectorImplMaker : public JetCorrectorImplMakerBase {
+ public:
+  L1JPTOffsetCorrectorImplMaker(edm::ParameterSet const&, edm::ConsumesCollector);
+  std::unique_ptr<reco::JetCorrectorImpl> make(edm::Event const&, edm::EventSetup const&);
+ private:
+  edm::EDGetTokenT<reco::JetCorrector> offsetCorrectorToken_;
+  bool useOffset_;
+};
+
+//----- LXXXCorrector interface -------------------------------
+class L1JPTOffsetCorrectorImpl : public reco::JetCorrectorImpl 
+{
+  public:
+  typedef L1JPTOffsetCorrectorImplMaker Maker;
+
+    //----- constructors---------------------------------------
+  L1JPTOffsetCorrectorImpl(std::shared_ptr<FactorizedJetCorrectorCalculator const> corrector,
+			   const reco::JetCorrector* offsetService);   
+
+    //----- apply correction using Jet information only -------
+    virtual double correction(const LorentzVector& fJet) const override;
+
+    //----- apply correction using Jet information only -------
+    virtual double correction(const reco::Jet& fJet) const override;
+
+    //----- if correction needs event information -------------
+    virtual bool refRequired() const override {return false;}
+
+  private:
+    //----- member data ---------------------------------------
+    const reco::JetCorrector* offsetService_;
+    std::shared_ptr<FactorizedJetCorrectorCalculator const> corrector_;
+};
+
+#endif

--- a/JetMETCorrections/Algorithms/interface/L1OffsetCorrectorImpl.h
+++ b/JetMETCorrections/Algorithms/interface/L1OffsetCorrectorImpl.h
@@ -17,12 +17,15 @@ namespace edm
   class Event;
   class EventSetup;
   class ConsumesCollector;
+  class ConfigurationDescriptions;
 }
 
 class L1OffsetCorrectorImplMaker : public JetCorrectorImplMakerBase {
  public:
   L1OffsetCorrectorImplMaker(edm::ParameterSet const&, edm::ConsumesCollector);
   std::unique_ptr<reco::JetCorrectorImpl> make(edm::Event const&, edm::EventSetup const&);
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& iDescriptions);
  private:
   edm::EDGetTokenT<reco::VertexCollection> verticesToken_;
   int minVtxNdof_;

--- a/JetMETCorrections/Algorithms/interface/L1OffsetCorrectorImpl.h
+++ b/JetMETCorrections/Algorithms/interface/L1OffsetCorrectorImpl.h
@@ -1,0 +1,59 @@
+// L1Offset jet corrector class. Inherits from JetCorrector.h
+#ifndef L1OffsetCorrectorImpl_h
+#define L1OffsetCorrectorImpl_h
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "JetMETCorrections/JetCorrector/interface/JetCorrectorImpl.h"
+#include "JetMETCorrections/Algorithms/interface/JetCorrectorImplMakerBase.h"
+#include "CondFormats/JetMETObjects/interface/FactorizedJetCorrectorCalculator.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+
+//----- classes declaration -----------------------------------
+namespace edm 
+{
+  class ParameterSet;
+  class Event;
+  class EventSetup;
+  class ConsumesCollector;
+}
+
+class L1OffsetCorrectorImplMaker : public JetCorrectorImplMakerBase {
+ public:
+  L1OffsetCorrectorImplMaker(edm::ParameterSet const&, edm::ConsumesCollector);
+  std::unique_ptr<reco::JetCorrectorImpl> make(edm::Event const&, edm::EventSetup const&);
+ private:
+  edm::EDGetTokenT<reco::VertexCollection> verticesToken_;
+  int minVtxNdof_;
+};
+
+//----- LXXXCorrector interface -------------------------------
+class L1OffsetCorrectorImpl : public reco::JetCorrectorImpl 
+{
+  public:
+  typedef L1OffsetCorrectorImplMaker Maker;
+
+    //----- constructors---------------------------------------
+  L1OffsetCorrectorImpl(std::shared_ptr<FactorizedJetCorrectorCalculator const> calculator,
+			int npv);
+
+    //----- destructor ----------------------------------------
+
+    //----- apply correction using Jet information only -------
+    virtual double correction(const LorentzVector& fJet) const override;
+
+    //----- apply correction using Jet information only -------
+    virtual double correction(const reco::Jet& fJet) const override;
+
+    //----- if correction needs a jet reference -------------
+    virtual bool refRequired() const override { return false; } 
+
+  private:
+    //----- member data ---------------------------------------
+    std::shared_ptr<FactorizedJetCorrectorCalculator const> corrector_;
+    int npv_;
+
+};
+
+#endif

--- a/JetMETCorrections/Algorithms/interface/L6SLBCorrectorImpl.h
+++ b/JetMETCorrections/Algorithms/interface/L6SLBCorrectorImpl.h
@@ -1,0 +1,86 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+// Level6 SLB (Semileptonic BJet) Corrector
+// ----------------------------------------
+//
+//           25/10/2009  Hauke Held             <hauke.held@cern.ch>
+//                       Philipp Schieferdecker <philipp.schieferdecker@cern.ch>
+////////////////////////////////////////////////////////////////////////////////
+#ifndef L6SLBCorrectorImpl_h
+#define L6SLBCorrectorImpl_h
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "JetMETCorrections/JetCorrector/interface/JetCorrectorImpl.h"
+#include "JetMETCorrections/Algorithms/interface/JetCorrectorImplMakerBase.h"
+#include "CondFormats/JetMETObjects/interface/FactorizedJetCorrectorCalculator.h"
+#include "DataFormats/BTauReco/interface/SoftLeptonTagInfo.h"
+
+namespace edm 
+{
+  class ParameterSet;
+  class Event;
+  class EventSetup;
+  class ConsumesCollector;
+}
+
+class L6SLBCorrectorImplMaker : public JetCorrectorImplMakerBase {
+ public:
+  L6SLBCorrectorImplMaker(edm::ParameterSet const&, edm::ConsumesCollector);
+  std::unique_ptr<reco::JetCorrectorImpl> make(edm::Event const&, edm::EventSetup const&);
+ private:
+  edm::EDGetTokenT<std::vector<reco::SoftLeptonTagInfo>> elecToken_;
+  edm::EDGetTokenT<std::vector<reco::SoftLeptonTagInfo>> muonToken_;
+  bool                    addMuonToJet_;
+};
+
+class L6SLBCorrectorImpl : public reco::JetCorrectorImpl
+{
+  //
+  // construction / destruction
+  //
+public:
+  typedef L6SLBCorrectorImplMaker Maker;
+
+  L6SLBCorrectorImpl (  std::shared_ptr<FactorizedJetCorrectorCalculator const> corrector,
+			edm::RefProd<std::vector<reco::SoftLeptonTagInfo>> const& bTagInfoMuon,
+			edm::RefProd<std::vector<reco::SoftLeptonTagInfo>> const& bTagInfoElec,
+			bool addMuonToJet);
+
+  //
+  // member functions
+  //
+public:
+  /// apply correction using Jet information only
+  virtual double correction (const LorentzVector& fJet) const override;
+  /// apply correction using Jet information only
+  virtual double correction (const reco::Jet& fJet) const override;
+  /// apply correction using all event information
+  virtual double correction (const reco::Jet& fJet,
+			     const edm::RefToBase<reco::Jet>& refToRawJet) const override;
+  
+  //----- if correction needs a jet reference -------------
+  virtual bool refRequired () const override {return true;} 
+  
+  //
+  // private member functions
+  //
+private:
+  int getBTagInfoIndex(const edm::RefToBase<reco::Jet>& refToRawJet,
+		       const std::vector<reco::SoftLeptonTagInfo>& tags) const;
+  
+  
+  //
+  // member data
+  //
+private:
+  //edm::InputTag           srcBTagInfoElec_;
+  //edm::InputTag           srcBTagInfoMuon_;
+  std::shared_ptr<FactorizedJetCorrectorCalculator const> corrector_;
+  edm::RefProd<std::vector<reco::SoftLeptonTagInfo>> bTagInfoMuon_;
+  edm::RefProd<std::vector<reco::SoftLeptonTagInfo>> bTagInfoElec_;
+  bool                    addMuonToJet_;
+
+};
+
+#endif

--- a/JetMETCorrections/Algorithms/interface/L6SLBCorrectorImpl.h
+++ b/JetMETCorrections/Algorithms/interface/L6SLBCorrectorImpl.h
@@ -22,12 +22,15 @@ namespace edm
   class Event;
   class EventSetup;
   class ConsumesCollector;
+  class ConfigurationDescriptions;
 }
 
 class L6SLBCorrectorImplMaker : public JetCorrectorImplMakerBase {
  public:
   L6SLBCorrectorImplMaker(edm::ParameterSet const&, edm::ConsumesCollector);
   std::unique_ptr<reco::JetCorrectorImpl> make(edm::Event const&, edm::EventSetup const&);
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& iDescriptions);
  private:
   edm::EDGetTokenT<std::vector<reco::SoftLeptonTagInfo>> elecToken_;
   edm::EDGetTokenT<std::vector<reco::SoftLeptonTagInfo>> muonToken_;

--- a/JetMETCorrections/Algorithms/interface/LXXXCorrectorImpl.h
+++ b/JetMETCorrections/Algorithms/interface/LXXXCorrectorImpl.h
@@ -14,6 +14,7 @@ namespace edm
   class Event;
   class EventSetup;
   class ConsumesCollector;
+  class ConfigurationDescriptions;
 }
 class FactorizedJetCorrector;
 
@@ -21,6 +22,8 @@ class LXXXCorrectorImplMaker : public JetCorrectorImplMakerBase {
  public:
   LXXXCorrectorImplMaker(edm::ParameterSet const&, edm::ConsumesCollector);
   std::unique_ptr<reco::JetCorrectorImpl> make(edm::Event const&, edm::EventSetup const&);
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& iDescriptions);
 };
 
 //----- LXXXCorrectorImpl interface -------------------------------

--- a/JetMETCorrections/Algorithms/interface/LXXXCorrectorImpl.h
+++ b/JetMETCorrections/Algorithms/interface/LXXXCorrectorImpl.h
@@ -1,0 +1,50 @@
+// Generic LX jet corrector class. Inherits from JetCorrector.h
+#ifndef LXXXCorrectorImpl_h
+#define LXXXCorrectorImpl_h
+
+#include "JetMETCorrections/JetCorrector/interface/JetCorrectorImpl.h"
+#include "JetMETCorrections/Algorithms/interface/JetCorrectorImplMakerBase.h"
+#include "CondFormats/JetMETObjects/interface/FactorizedJetCorrectorCalculator.h"
+#include "CondFormats/JetMETObjects/interface/JetCorrectorParameters.h"
+
+//----- classes declaration -----------------------------------
+namespace edm 
+{
+  class ParameterSet;
+  class Event;
+  class EventSetup;
+  class ConsumesCollector;
+}
+class FactorizedJetCorrector;
+
+class LXXXCorrectorImplMaker : public JetCorrectorImplMakerBase {
+ public:
+  LXXXCorrectorImplMaker(edm::ParameterSet const&, edm::ConsumesCollector);
+  std::unique_ptr<reco::JetCorrectorImpl> make(edm::Event const&, edm::EventSetup const&);
+};
+
+//----- LXXXCorrectorImpl interface -------------------------------
+class LXXXCorrectorImpl : public reco::JetCorrectorImpl
+{
+  public:
+    typedef LXXXCorrectorImplMaker Maker;
+
+    //----- constructors---------------------------------------
+    LXXXCorrectorImpl(std::shared_ptr<FactorizedJetCorrectorCalculator const> calculator, unsigned int level);
+
+    //----- apply correction using Jet information only -------
+    virtual double correction(const LorentzVector& fJet) const override;
+
+    //----- apply correction using Jet information only -------
+    virtual double correction(const reco::Jet& fJet) const override;
+
+    //----- if correction needs a jet reference -------------
+    virtual bool refRequired() const override { return false; }
+
+  private:
+    //----- member data ---------------------------------------
+    unsigned int mLevel;
+    std::shared_ptr<FactorizedJetCorrectorCalculator const> mCorrector;
+};
+
+#endif

--- a/JetMETCorrections/Algorithms/src/JetCorrectorImplMakerBase.cc
+++ b/JetMETCorrections/Algorithms/src/JetCorrectorImplMakerBase.cc
@@ -1,0 +1,74 @@
+// -*- C++ -*-
+//
+// Package:     JetMETCorrections/Algorithms
+// Class  :     JetCorrectorImplMakerBase
+// 
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Christopher Jones
+//         Created:  Fri, 29 Aug 2014 19:52:26 GMT
+//
+
+// system include files
+#include <vector>
+
+// user include files
+#include "JetMETCorrections/Algorithms/interface/JetCorrectorImplMakerBase.h"
+
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "CondFormats/JetMETObjects/interface/JetCorrectorParameters.h"
+#include "JetMETCorrections/Objects/interface/JetCorrectionsRecord.h"
+
+
+//
+// constants, enums and typedefs
+//
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+JetCorrectorImplMakerBase::JetCorrectorImplMakerBase(edm::ParameterSet const& iPSet):
+  level_(iPSet.getParameter<std::string>("level")),
+  algo_(iPSet.getParameter<std::string>("algorithm")),
+  cacheId_(0)
+{
+}
+
+// JetCorrectorImplMakerBase::JetCorrectorImplMakerBase(const JetCorrectorImplMakerBase& rhs)
+// {
+//    // do actual copying here;
+// }
+
+JetCorrectorImplMakerBase::~JetCorrectorImplMakerBase()
+{
+}
+
+//
+// member functions
+//
+
+std::shared_ptr<FactorizedJetCorrectorCalculator const> 
+JetCorrectorImplMakerBase::getCalculator(edm::EventSetup const& iSetup, std::function<void(std::string const&)> iLevelCheck) {
+  auto const& rec = iSetup.get<JetCorrectionsRecord>();
+  if( cacheId_ != rec.cacheIdentifier()) {
+    edm::ESHandle<JetCorrectorParametersCollection> JetCorParColl;
+    rec.get(algo_,JetCorParColl); 
+    auto const& parameters = ((*JetCorParColl)[level_]);
+
+    iLevelCheck(parameters.definitions().level());
+    std::vector<JetCorrectorParameters> vParam;
+    vParam.push_back(parameters);
+    corrector_ = std::make_shared<FactorizedJetCorrectorCalculator>(vParam);
+
+    cacheId_ = rec.cacheIdentifier();
+  }
+  return corrector_;
+}

--- a/JetMETCorrections/Algorithms/src/JetCorrectorImplMakerBase.cc
+++ b/JetMETCorrections/Algorithms/src/JetCorrectorImplMakerBase.cc
@@ -19,6 +19,7 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
 #include "CondFormats/JetMETObjects/interface/JetCorrectorParameters.h"
 #include "JetMETCorrections/Objects/interface/JetCorrectionsRecord.h"
@@ -71,4 +72,10 @@ JetCorrectorImplMakerBase::getCalculator(edm::EventSetup const& iSetup, std::fun
     cacheId_ = rec.cacheIdentifier();
   }
   return corrector_;
+}
+
+void 
+JetCorrectorImplMakerBase::addToDescription(edm::ParameterSetDescription& iDescription) {
+  iDescription.add<std::string>("level");
+  iDescription.add<std::string>("algorithm");
 }

--- a/JetMETCorrections/Algorithms/src/L1FastjetCorrectorImpl.cc
+++ b/JetMETCorrections/Algorithms/src/L1FastjetCorrectorImpl.cc
@@ -1,0 +1,74 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+// L1FastjetCorrector
+// ------------------
+//
+//            08/09/2009 Philipp Schieferdecker <philipp.schieferdecker@cern.ch>
+////////////////////////////////////////////////////////////////////////////////
+
+#include "JetMETCorrections/Algorithms/interface/L1FastjetCorrectorImpl.h"
+#include "CondFormats/JetMETObjects/interface/JetCorrectorParameters.h"
+#include "JetMETCorrections/Objects/interface/JetCorrectionsRecord.h"
+
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/Common/interface/Handle.h"
+
+using namespace std;
+
+L1FastjetCorrectorImplMaker::L1FastjetCorrectorImplMaker(edm::ParameterSet const& fConfig, 
+							 edm::ConsumesCollector fCollector):
+  JetCorrectorImplMakerBase(fConfig),
+  rhoToken_(fCollector.consumes<double>(fConfig.getParameter<edm::InputTag>("srcRho")))
+{
+}
+
+std::unique_ptr<reco::JetCorrectorImpl>
+L1FastjetCorrectorImplMaker::make(edm::Event const& fEvent, edm::EventSetup const& fSetup) {
+  auto corrector = getCalculator(fSetup, [](const std::string& level) {
+      if(level != "L1FastJet") {
+      throw cms::Exception("L1FastjetCorrector")<<" correction level: "<<level<<" is not L1FastJet";
+      }
+    });
+
+  edm::Handle<double> hRho;
+  fEvent.getByToken(rhoToken_,hRho);
+  return std::unique_ptr<L1FastjetCorrectorImpl>(new L1FastjetCorrectorImpl(corrector, *hRho) );
+}
+
+
+//______________________________________________________________________________
+////////////////////////////////////////////////////////////////////////////////
+// implementation of member functions
+////////////////////////////////////////////////////////////////////////////////
+
+//______________________________________________________________________________
+double L1FastjetCorrectorImpl::correction (const LorentzVector& fJet) const
+{
+  throw cms::Exception("EventRequired")
+    <<"Wrong interface correction(LorentzVector), event required!";
+  return 1.0;
+}
+
+
+//______________________________________________________________________________
+double L1FastjetCorrectorImpl::correction (const reco::Jet& fJet) const
+{
+  FactorizedJetCorrectorCalculator::VariableValues values;
+  values.setJetEta(fJet.eta());
+  values.setJetPt(fJet.pt());
+  values.setJetE(fJet.energy());
+  values.setJetA(fJet.jetArea());
+  values.setRho(rho_);
+  return corrector_->getCorrection(values);  
+}
+
+
+
+

--- a/JetMETCorrections/Algorithms/src/L1FastjetCorrectorImpl.cc
+++ b/JetMETCorrections/Algorithms/src/L1FastjetCorrectorImpl.cc
@@ -18,6 +18,8 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "DataFormats/Common/interface/Handle.h"
 
 using namespace std;
@@ -40,6 +42,15 @@ L1FastjetCorrectorImplMaker::make(edm::Event const& fEvent, edm::EventSetup cons
   edm::Handle<double> hRho;
   fEvent.getByToken(rhoToken_,hRho);
   return std::unique_ptr<L1FastjetCorrectorImpl>(new L1FastjetCorrectorImpl(corrector, *hRho) );
+}
+
+void 
+L1FastjetCorrectorImplMaker::fillDescriptions(edm::ConfigurationDescriptions& iDescriptions)
+{
+  edm::ParameterSetDescription desc;
+  addToDescription(desc);
+  desc.add<edm::InputTag>("srcRho");
+  iDescriptions.addDefault(desc);
 }
 
 

--- a/JetMETCorrections/Algorithms/src/L1JPTOffsetCorrectorImpl.cc
+++ b/JetMETCorrections/Algorithms/src/L1JPTOffsetCorrectorImpl.cc
@@ -7,6 +7,8 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
@@ -22,10 +24,10 @@ L1JPTOffsetCorrectorImplMaker::L1JPTOffsetCorrectorImplMaker(edm::ParameterSet c
   JetCorrectorImplMakerBase(fConfig),
   useOffset_(false)
 {
-  auto const& offsetService = fConfig.getParameter<std::string>("offsetService");
-  if(not offsetService.empty()) {
+  auto const& offsetService = fConfig.getParameter<edm::InputTag>("offsetService");
+  if(not offsetService.label().empty()) {
     useOffset_ =true;
-    offsetCorrectorToken_ = fCollector.consumes<reco::JetCorrector>(edm::InputTag{offsetService});
+    offsetCorrectorToken_ = fCollector.consumes<reco::JetCorrector>(offsetService);
   }
 }
 
@@ -45,6 +47,15 @@ L1JPTOffsetCorrectorImplMaker::make(edm::Event const& fEvent, edm::EventSetup co
       }
     });
   return std::unique_ptr<reco::JetCorrectorImpl>( new L1JPTOffsetCorrectorImpl(calculator,offset) );
+}
+
+void 
+L1JPTOffsetCorrectorImplMaker::fillDescriptions(edm::ConfigurationDescriptions& iDescriptions)
+{
+  edm::ParameterSetDescription desc;
+  addToDescription(desc);
+  desc.add<edm::InputTag>("offsetService");
+  iDescriptions.addDefault(desc);
 }
 
 

--- a/JetMETCorrections/Algorithms/src/L1JPTOffsetCorrectorImpl.cc
+++ b/JetMETCorrections/Algorithms/src/L1JPTOffsetCorrectorImpl.cc
@@ -1,0 +1,96 @@
+// Implementation of class L1JPTOffsetCorrector.
+// L1JPTOffset jet corrector class.
+
+#include "JetMETCorrections/Algorithms/interface/L1JPTOffsetCorrectorImpl.h"
+#include "CondFormats/JetMETObjects/interface/FactorizedJetCorrector.h"
+#include "JetMETCorrections/JetCorrector/interface/JetCorrector.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "DataFormats/JetReco/interface/Jet.h"
+#include "DataFormats/JetReco/interface/CaloJet.h"
+#include "DataFormats/JetReco/interface/JPTJet.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+
+using namespace std;
+
+L1JPTOffsetCorrectorImplMaker::L1JPTOffsetCorrectorImplMaker(edm::ParameterSet const& fConfig, edm::ConsumesCollector fCollector):
+  JetCorrectorImplMakerBase(fConfig),
+  useOffset_(false)
+{
+  auto const& offsetService = fConfig.getParameter<std::string>("offsetService");
+  if(not offsetService.empty()) {
+    useOffset_ =true;
+    offsetCorrectorToken_ = fCollector.consumes<reco::JetCorrector>(edm::InputTag{offsetService});
+  }
+}
+
+std::unique_ptr<reco::JetCorrectorImpl> 
+L1JPTOffsetCorrectorImplMaker::make(edm::Event const& fEvent, edm::EventSetup const& fSetup) {
+  reco::JetCorrector const* offset = nullptr;
+  if(useOffset_) {
+    edm::Handle<reco::JetCorrector> hOffset;
+    fEvent.getByToken(offsetCorrectorToken_,hOffset);
+    offset = &(*hOffset);
+  }
+  auto calculator = getCalculator(fSetup,
+				  [](std::string const& level) 
+    {
+      if ( level != "L1JPTOffset") {
+	throw cms::Exception("L1OffsetCorrector")<<" correction level: "<<level<<" is not L1JPTOffset";
+      }
+    });
+  return std::unique_ptr<reco::JetCorrectorImpl>( new L1JPTOffsetCorrectorImpl(calculator,offset) );
+}
+
+
+//------------------------------------------------------------------------ 
+//--- L1OffsetCorrectorImpl constructor ------------------------------------------
+//------------------------------------------------------------------------
+L1JPTOffsetCorrectorImpl::L1JPTOffsetCorrectorImpl(std::shared_ptr<FactorizedJetCorrectorCalculator const> corrector,
+					   const reco::JetCorrector* offsetService):
+  offsetService_(offsetService),
+  corrector_(corrector)
+{
+}
+//------------------------------------------------------------------------ 
+//--- L1OffsetCorrectorImpl destructor -------------------------------------------
+//------------------------------------------------------------------------
+
+//------------------------------------------------------------------------ 
+//--- Returns correction for a given 4-vector ----------------------------
+//------------------------------------------------------------------------
+double L1JPTOffsetCorrectorImpl::correction(const LorentzVector& fJet) const
+{
+  throw cms::Exception("EventRequired")
+    <<"Wrong interface correction(LorentzVector), event required!";
+  return 1.0;
+}
+//------------------------------------------------------------------------ 
+//--- Returns correction for a given jet ---------------------------------
+//------------------------------------------------------------------------
+double L1JPTOffsetCorrectorImpl::correction(const reco::Jet& fJet) const
+{
+  double result = 1.;
+  const reco::JPTJet& jptjet = dynamic_cast <const reco::JPTJet&> (fJet);
+  edm::RefToBase<reco::Jet> jptjetRef = jptjet.getCaloJetRef();
+  reco::CaloJet const * rawcalojet = dynamic_cast<reco::CaloJet const *>( &* jptjetRef);   
+  //------ access the offset correction service ----------------
+  double offset = 1.0;
+  if (offsetService_) {
+    offset = offsetService_->correction(*rawcalojet); 
+  }
+  //------ calculate the correction for the JPT jet ------------
+  TLorentzVector JPTrawP4(rawcalojet->px(),rawcalojet->py(),rawcalojet->pz(),rawcalojet->energy());
+  FactorizedJetCorrectorCalculator::VariableValues values;
+  values.setJPTrawP4(JPTrawP4);
+  values.setJPTrawOff(offset);
+  values.setJetE(fJet.energy());
+  result = corrector_->getCorrection(values);
+  return result;
+}
+

--- a/JetMETCorrections/Algorithms/src/L1OffsetCorrectorImpl.cc
+++ b/JetMETCorrections/Algorithms/src/L1OffsetCorrectorImpl.cc
@@ -6,7 +6,8 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
@@ -44,6 +45,16 @@ L1OffsetCorrectorImplMaker::make(edm::Event const& fEvent, edm::EventSetup const
       }
     });
   return std::unique_ptr<reco::JetCorrectorImpl>(new L1OffsetCorrectorImpl(calculator,NPV));
+}
+
+void 
+L1OffsetCorrectorImplMaker::fillDescriptions(edm::ConfigurationDescriptions& iDescriptions)
+{
+  edm::ParameterSetDescription desc;
+  addToDescription(desc);
+  desc.add<edm::InputTag>("vertexCollection");
+  desc.add<int>("minVtxNdof");
+  iDescriptions.addDefault(desc);
 }
 
 //------------------------------------------------------------------------ 

--- a/JetMETCorrections/Algorithms/src/L1OffsetCorrectorImpl.cc
+++ b/JetMETCorrections/Algorithms/src/L1OffsetCorrectorImpl.cc
@@ -1,0 +1,84 @@
+// Implementation of class L1OffsetCorrectorImpl.
+// L1Offset jet corrector class.
+
+#include "JetMETCorrections/Algorithms/interface/L1OffsetCorrectorImpl.h"
+#include "CondFormats/JetMETObjects/interface/FactorizedJetCorrector.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "DataFormats/JetReco/interface/Jet.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "CondFormats/JetMETObjects/interface/JetCorrectorParameters.h"
+
+using namespace std;
+
+L1OffsetCorrectorImplMaker::L1OffsetCorrectorImplMaker(edm::ParameterSet const& fConfig, 
+						       edm::ConsumesCollector fCollector) :
+  JetCorrectorImplMakerBase(fConfig),
+  verticesToken_(fCollector.consumes<reco::VertexCollection>(fConfig.getParameter<edm::InputTag>("vertexCollection"))),
+  minVtxNdof_(fConfig.getParameter<int>("minVtxNdof"))
+{
+}
+std::unique_ptr<reco::JetCorrectorImpl> 
+L1OffsetCorrectorImplMaker::make(edm::Event const& fEvent, edm::EventSetup const& fSetup) 
+{
+  edm::Handle<reco::VertexCollection> recVtxs;
+  fEvent.getByToken(verticesToken_,recVtxs);
+  int NPV(0);
+  for(auto const& vertex : *recVtxs) {
+    if ((not vertex.isFake()) and (vertex.ndof() > minVtxNdof_)) {
+      NPV++;
+    }
+  }
+  
+  auto calculator = getCalculator(fSetup,
+				  [](std::string const& level) 
+    {
+      if ( level != "L1Offset") {
+	throw cms::Exception("L1OffsetCorrectorImpl")<<" correction level: "<<level<<" is not L1Offset";
+      }
+    });
+  return std::unique_ptr<reco::JetCorrectorImpl>(new L1OffsetCorrectorImpl(calculator,NPV));
+}
+
+//------------------------------------------------------------------------ 
+//--- L1OffsetCorrectorImpl constructor ------------------------------------------
+//------------------------------------------------------------------------
+L1OffsetCorrectorImpl::L1OffsetCorrectorImpl(std::shared_ptr<FactorizedJetCorrectorCalculator const> calculator,
+					     int npv):
+  corrector_(calculator),
+  npv_(npv)
+{
+}
+
+//------------------------------------------------------------------------ 
+//--- Returns correction for a given 4-vector ----------------------------
+//------------------------------------------------------------------------
+double L1OffsetCorrectorImpl::correction(const LorentzVector& fJet) const
+{
+  throw cms::Exception("EventRequired")
+    <<"Wrong interface correction(LorentzVector), event required!";
+  return 1.0;
+}
+//------------------------------------------------------------------------ 
+//--- Returns correction for a given jet ---------------------------------
+//------------------------------------------------------------------------
+double L1OffsetCorrectorImpl::correction(const reco::Jet& fJet) const
+{
+  double result = 1.;
+  if (npv_ > 0) {
+    FactorizedJetCorrectorCalculator::VariableValues values;
+    values.setJetEta(fJet.eta());
+    values.setJetPt(fJet.pt());
+    values.setJetE(fJet.energy());
+    values.setNPV(npv_);
+    result = corrector_->getCorrection(values);
+  }
+  return result;
+}
+

--- a/JetMETCorrections/Algorithms/src/L6SLBCorrectorImpl.cc
+++ b/JetMETCorrections/Algorithms/src/L6SLBCorrectorImpl.cc
@@ -1,0 +1,140 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+// L6SLBCorrectorImpl
+// --------------
+//
+//           25/10/2009   Hauke Held             <hauke.held@cern.ch>
+//                        Philipp Schieferdecker <philipp.schieferdecker@cern.ch
+////////////////////////////////////////////////////////////////////////////////
+
+#include "JetMETCorrections/Algorithms/interface/L6SLBCorrectorImpl.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+
+#include "DataFormats/TrackReco/interface/Track.h"
+
+
+#include <string>
+
+
+using namespace std;
+
+L6SLBCorrectorImplMaker::L6SLBCorrectorImplMaker(edm::ParameterSet const& fConfig,
+						 edm::ConsumesCollector fCollector)
+  : JetCorrectorImplMakerBase(fConfig)
+  , elecToken_(fCollector.consumes<std::vector<reco::SoftLeptonTagInfo>>(fConfig.getParameter<edm::InputTag>("srcBTagInfoElectron")))
+  , muonToken_(fCollector.consumes<std::vector<reco::SoftLeptonTagInfo>>(fConfig.getParameter<edm::InputTag>("srcBTagInfoMuon")))
+  , addMuonToJet_(fConfig.getParameter<bool>("addMuonToJet"))
+{
+}
+
+std::unique_ptr<reco::JetCorrectorImpl> 
+L6SLBCorrectorImplMaker::make(edm::Event const&fEvent, edm::EventSetup const& fSetup)
+{
+  edm::Handle< std::vector<reco::SoftLeptonTagInfo> > muoninfos;
+  fEvent.getByToken(muonToken_,muoninfos);
+  edm::RefProd<std::vector<reco::SoftLeptonTagInfo>> muonProd(muoninfos);
+
+  edm::Handle< std::vector<reco::SoftLeptonTagInfo> > elecinfos;
+  fEvent.getByToken(elecToken_,elecinfos);
+  edm::RefProd<std::vector<reco::SoftLeptonTagInfo>> elecProd(elecinfos);
+
+  auto calculator = getCalculator(fSetup,
+				  [](std::string const& ) {});
+  return std::unique_ptr<reco::JetCorrectorImpl>(new L6SLBCorrectorImpl(calculator,
+									muonProd,
+									elecProd,
+									addMuonToJet_));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// construction / destruction
+////////////////////////////////////////////////////////////////////////////////
+
+//______________________________________________________________________________
+L6SLBCorrectorImpl::L6SLBCorrectorImpl(std::shared_ptr<FactorizedJetCorrectorCalculator const> corrector,
+				       edm::RefProd<std::vector<reco::SoftLeptonTagInfo>> const& bTagInfoMuon,
+				       edm::RefProd<std::vector<reco::SoftLeptonTagInfo>> const& bTagInfoElec,
+				       bool addMuonToJet):
+	       corrector_(corrector),
+	       bTagInfoMuon_(bTagInfoMuon),
+	       bTagInfoElec_(bTagInfoElec),
+	       addMuonToJet_(addMuonToJet)
+{
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// implementation of member functions
+////////////////////////////////////////////////////////////////////////////////
+
+//______________________________________________________________________________
+double L6SLBCorrectorImpl::correction(const LorentzVector& fJet) const
+{
+  throw cms::Exception("EventRequired")
+    <<"Wrong interface correction(LorentzVector), event required!";
+  return 1.0;
+}
+
+
+//______________________________________________________________________________
+double L6SLBCorrectorImpl::correction(const reco::Jet& fJet) const
+{
+  throw cms::Exception("EventRequired")
+    <<"Wrong interface correction(reco::Jet), event required!";
+  return 1.0;
+}
+
+
+//______________________________________________________________________________
+double L6SLBCorrectorImpl::correction(const reco::Jet& fJet,
+				      const edm::RefToBase<reco::Jet>& refToRawJet) const
+{
+  FactorizedJetCorrectorCalculator::VariableValues values;
+  values.setJetPt(fJet.pt());
+  values.setJetEta(fJet.eta());
+  values.setJetPhi(fJet.phi());
+  values.setJetE(fJet.energy());
+  
+  const reco::SoftLeptonTagInfo& sltMuon =
+    (*bTagInfoMuon_)[getBTagInfoIndex(refToRawJet,*bTagInfoMuon_)];
+  if (sltMuon.leptons()>0) {
+    edm::RefToBase<reco::Track> trackRef = sltMuon.lepton(0);
+    values.setLepPx(trackRef->px());
+    values.setLepPy(trackRef->py());
+    values.setLepPz(trackRef->pz());
+    values.setAddLepToJet(addMuonToJet_);
+    return corrector_->getCorrection(values);
+  }
+  else {
+    const reco::SoftLeptonTagInfo& sltElec =
+      (*bTagInfoElec_)[getBTagInfoIndex(refToRawJet,*bTagInfoElec_)];
+    if (sltElec.leptons()>0) {
+      edm::RefToBase<reco::Track> trackRef = sltElec.lepton(0);
+      values.setLepPx(trackRef->px());
+      values.setLepPy(trackRef->py());
+      values.setLepPz(trackRef->pz());
+      values.setAddLepToJet(false);
+      return corrector_->getCorrection(values);
+    }
+  }
+  return 1.0;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+// implementation of private member functions
+////////////////////////////////////////////////////////////////////////////////
+
+//______________________________________________________________________________
+int L6SLBCorrectorImpl::getBTagInfoIndex(const edm::RefToBase<reco::Jet>& refToRawJet,
+				     const vector<reco::SoftLeptonTagInfo>& tags)
+  const
+{
+  for (unsigned int i=0;i<tags.size();i++)
+    if (tags[i].jet().get()==refToRawJet.get()) return i;
+  return -1;
+}

--- a/JetMETCorrections/Algorithms/src/L6SLBCorrectorImpl.cc
+++ b/JetMETCorrections/Algorithms/src/L6SLBCorrectorImpl.cc
@@ -11,6 +11,8 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/FileInPath.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
@@ -49,6 +51,17 @@ L6SLBCorrectorImplMaker::make(edm::Event const&fEvent, edm::EventSetup const& fS
 									muonProd,
 									elecProd,
 									addMuonToJet_));
+}
+
+void 
+L6SLBCorrectorImplMaker::fillDescriptions(edm::ConfigurationDescriptions& iDescriptions)
+{
+  edm::ParameterSetDescription desc;
+  addToDescription(desc);
+  desc.add<edm::InputTag>("srcBTagInfoElectron");
+  desc.add<edm::InputTag>("srcBTagInfoMuon");
+  desc.add<bool>("addMuonToJet");
+  iDescriptions.addDefault(desc);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/JetMETCorrections/Algorithms/src/LXXXCorrectorImpl.cc
+++ b/JetMETCorrections/Algorithms/src/LXXXCorrectorImpl.cc
@@ -1,0 +1,90 @@
+// Implementation of class LXXXCorrectorImpl.
+// Generic LX jet corrector class.
+
+#include "JetMETCorrections/Algorithms/interface/LXXXCorrectorImpl.h"
+#include "CondFormats/JetMETObjects/interface/FactorizedJetCorrectorCalculator.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/JetReco/interface/Jet.h"
+#include "DataFormats/JetReco/interface/CaloJet.h"
+#include "DataFormats/JetReco/interface/JPTJet.h"
+
+using namespace std;
+
+
+LXXXCorrectorImplMaker::LXXXCorrectorImplMaker(edm::ParameterSet const& fConfig, edm::ConsumesCollector):
+JetCorrectorImplMakerBase(fConfig)
+{
+}
+
+std::unique_ptr<reco::JetCorrectorImpl> 
+LXXXCorrectorImplMaker::make(edm::Event const&, edm::EventSetup const& fSetup)
+{
+  unsigned int level =0;
+  auto calculator = getCalculator(fSetup,
+				  [&level](std::string const& levelName) 
+    {
+      if (levelName == "L2Relative")
+	level = 2;
+      else if (levelName == "L3Absolute")
+	level = 3;  
+      else if (levelName == "L4EMF")
+	level = 4;
+      else if (levelName == "L5Flavor")
+	level = 5;
+      else if (levelName == "L7Parton")
+	level = 7;
+      else
+	throw cms::Exception("LXXXCorrectorImpl")<<" unknown correction level "<<levelName;
+    });
+  return std::unique_ptr<reco::JetCorrectorImpl>(new LXXXCorrectorImpl(calculator,level));
+}
+
+//------------------------------------------------------------------------ 
+//--- LXXXCorrectorImpl constructor ------------------------------------------
+//------------------------------------------------------------------------
+LXXXCorrectorImpl::LXXXCorrectorImpl(std::shared_ptr<FactorizedJetCorrectorCalculator const> calculator, unsigned int level):
+  mLevel(level),
+  mCorrector(calculator)
+{
+}
+//------------------------------------------------------------------------ 
+//--- Returns correction for a given 4-vector ----------------------------
+//------------------------------------------------------------------------
+double LXXXCorrectorImpl::correction(const LorentzVector& fJet) const 
+{
+  // L4 correction requires more information than a simple 4-vector
+  if (mLevel == 4) {
+    throw cms::Exception("Invalid jet type") << "L4EMFCorrection is applicable to CaloJets only";
+    return 1;
+  }
+
+  FactorizedJetCorrectorCalculator::VariableValues values;
+  values.setJetEta(fJet.eta()); 
+  values.setJetE(fJet.energy());
+  values.setJetPt(fJet.pt());
+  values.setJetPhi(fJet.phi());
+
+  return mCorrector->getCorrection(values);
+}
+//------------------------------------------------------------------------ 
+//--- Returns correction for a given jet ---------------------------------
+//------------------------------------------------------------------------
+double LXXXCorrectorImpl::correction(const reco::Jet& fJet) const 
+{
+  double result = 1.;
+  // L4 correction applies to Calojets only
+  if (mLevel == 4) {
+      const reco::CaloJet& caloJet = dynamic_cast <const reco::CaloJet&> (fJet);
+      FactorizedJetCorrectorCalculator::VariableValues values;
+      values.setJetEta(fJet.eta()); 
+      values.setJetPt(fJet.pt());
+      values.setJetEMF(caloJet.emEnergyFraction());
+      result = mCorrector->getCorrection(values);
+  }
+  else
+    result = correction(fJet.p4());
+  return result;
+}

--- a/JetMETCorrections/Algorithms/src/LXXXCorrectorImpl.cc
+++ b/JetMETCorrections/Algorithms/src/LXXXCorrectorImpl.cc
@@ -7,6 +7,8 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "DataFormats/JetReco/interface/Jet.h"
 #include "DataFormats/JetReco/interface/CaloJet.h"
 #include "DataFormats/JetReco/interface/JPTJet.h"
@@ -40,6 +42,15 @@ LXXXCorrectorImplMaker::make(edm::Event const&, edm::EventSetup const& fSetup)
 	throw cms::Exception("LXXXCorrectorImpl")<<" unknown correction level "<<levelName;
     });
   return std::unique_ptr<reco::JetCorrectorImpl>(new LXXXCorrectorImpl(calculator,level));
+}
+
+void 
+LXXXCorrectorImplMaker::fillDescriptions(edm::ConfigurationDescriptions& iDescriptions)
+{
+  edm::ParameterSetDescription desc;
+  addToDescription(desc);
+
+  iDescriptions.addDefault(desc);
 }
 
 //------------------------------------------------------------------------ 

--- a/JetMETCorrections/JetCorrector/BuildFile.xml
+++ b/JetMETCorrections/JetCorrector/BuildFile.xml
@@ -1,0 +1,6 @@
+<use   name="FWCore/MessageLogger"/>
+<use   name="DataFormats/Common"/>
+<use   name="DataFormats/JetReco"/>
+<export>
+  <lib   name="1"/>
+</export>

--- a/JetMETCorrections/JetCorrector/interface/JetCorrector.h
+++ b/JetMETCorrections/JetCorrector/interface/JetCorrector.h
@@ -1,0 +1,102 @@
+#ifndef JetMETCorrections_JetCorrector_JetCorrector_h
+#define JetMETCorrections_JetCorrector_JetCorrector_h
+// -*- C++ -*-
+//
+// Package:     JetMETCorrections/JetCorrector
+// Class  :     reco::JetCorrector
+// 
+/**\class reco::JetCorrector JetCorrector.h "JetMETCorrections/JetCorrector/interface/JetCorrector.h"
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Christopher Jones
+//         Created:  Fri, 29 Aug 2014 15:42:37 GMT
+//
+
+// system include files
+#include <memory>
+
+// user include files
+#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
+#include "JetMETCorrections/JetCorrector/interface/JetCorrectorImpl.h"
+#endif
+#include "DataFormats/Common/interface/RefToBase.h"
+#include "DataFormats/JetReco/interface/Jet.h"
+
+// forward declarations
+
+namespace reco {
+
+  class JetCorrector
+  {
+    
+  public:
+    JetCorrector();
+#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
+    JetCorrector(std::unique_ptr<JetCorrectorImpl const> fImpl):impl_(std::move(fImpl)) {}
+    
+    typedef reco::Particle::LorentzVector LorentzVector;
+
+    // ---------- const member functions ---------------------
+    /// get correction using Jet information only
+    double correction (const LorentzVector& fJet) const {
+      return impl_->correction(fJet);
+    }
+
+    /// apply correction using Jet information only
+    double correction (const reco::Jet& fJet) const {
+      return impl_->correction(fJet);
+    }
+
+    /// apply correction using Ref
+    double correction (const reco::Jet& fJet,
+		       const edm::RefToBase<reco::Jet>& fJetRef) const {
+      return impl_->correction(fJet,fJetRef);
+    }
+
+    /// Apply vectorial correction
+    double correction ( const reco::Jet& fJet, 
+			const edm::RefToBase<reco::Jet>& fJetRef,
+			LorentzVector& corrected ) const {
+      return impl_->correction(fJet,fJetRef,corrected);
+    }
+    
+    /// if correction needs the jet reference
+    bool refRequired () const {
+      return impl_->refRequired();
+    }
+  
+    /// if vectorial correction is provided
+    bool vectorialCorrection () const {
+      return impl_->vectorialCorrection();
+    }
+
+    // ---------- static member functions --------------------
+    
+    // ---------- member functions ---------------------------
+    void swap(JetCorrector& iOther) {
+      std::swap(impl_,iOther.impl_);
+    }
+
+  private:
+    JetCorrector(const JetCorrector&) = delete; 
+    
+    JetCorrector& operator=(const JetCorrector&) = delete; 
+    JetCorrector& operator=(JetCorrector&&) = default;
+    
+    // ---------- member data --------------------------------
+    std::unique_ptr<JetCorrectorImpl const> impl_;
+#else
+  private:
+    JetCorrector(const JetCorrector&);
+    const JetCorrector& operator=(const JetCorrector&);
+#endif
+  };
+}
+
+#endif

--- a/JetMETCorrections/JetCorrector/interface/JetCorrectorImpl.h
+++ b/JetMETCorrections/JetCorrector/interface/JetCorrectorImpl.h
@@ -1,0 +1,76 @@
+#ifndef JetMETCorrections_JetCorrector_JetCorrectorImpl_h
+#define JetMETCorrections_JetCorrector_JetCorrectorImpl_h
+// -*- C++ -*-
+//
+// Package:     JetMETCorrections/JetCorrector
+// Class  :     JetCorrectorImpl
+// 
+/**\class reco::JetCorrectorImpl JetCorrectorImpl.h "JetMETCorrections/JetCorrector/interface/JetCorrectorImpl.h"
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Christopher Jones
+//         Created:  Fri, 29 Aug 2014 15:42:44 GMT
+//
+
+// system include files
+
+// user include files
+#include "DataFormats/Common/interface/RefToBase.h"
+#include "DataFormats/JetReco/interface/Jet.h"
+
+// forward declarations
+
+namespace reco {
+
+  class JetCorrectorImpl
+  {
+    
+  public:
+    JetCorrectorImpl();
+    virtual ~JetCorrectorImpl();
+    
+    typedef reco::Particle::LorentzVector LorentzVector;
+
+    // ---------- const member functions ---------------------
+    /// get correction using Jet information only
+    virtual double correction (const LorentzVector& fJet) const = 0;
+
+    /// apply correction using Jet information only
+    virtual double correction (const reco::Jet& fJet) const = 0;
+
+    /// apply correction using Ref
+    virtual double correction (const reco::Jet& fJet,
+			       const edm::RefToBase<reco::Jet>& fJetRef) const ;
+
+    /// Apply vectorial correction
+    virtual double correction ( const reco::Jet& fJet, 
+				const edm::RefToBase<reco::Jet>& fJetRef,
+				LorentzVector& corrected ) const ;
+    
+    /// if correction needs the jet reference
+    virtual bool refRequired () const = 0;
+  
+    /// if vectorial correction is provided
+    virtual bool vectorialCorrection () const ;
+    
+    // ---------- static member functions --------------------
+    
+    // ---------- member functions ---------------------------
+    
+  private:
+    JetCorrectorImpl(const JetCorrectorImpl&) = delete;
+    
+    const JetCorrectorImpl& operator=(const JetCorrectorImpl&) = delete;
+    
+    // ---------- member data --------------------------------
+    
+  };
+}
+
+#endif

--- a/JetMETCorrections/JetCorrector/src/JetCorrector.cc
+++ b/JetMETCorrections/JetCorrector/src/JetCorrector.cc
@@ -1,0 +1,25 @@
+// -*- C++ -*-
+//
+// Package:     JetMETCorrections/JetCorrector
+// Class  :     JetCorrector
+// 
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Christopher Jones
+//         Created:  Fri, 29 Aug 2014 18:42:41 GMT
+//
+
+// system include files
+
+// user include files
+#include "JetMETCorrections/JetCorrector/interface/JetCorrector.h"
+
+
+//
+// constructors and destructor
+//
+reco::JetCorrector::JetCorrector()
+{
+}
+

--- a/JetMETCorrections/JetCorrector/src/JetCorrectorImpl.cc
+++ b/JetMETCorrections/JetCorrector/src/JetCorrectorImpl.cc
@@ -1,0 +1,84 @@
+// -*- C++ -*-
+//
+// Package:     JetMETCorrections/JetCorrector
+// Class  :     JetCorrectorImpl
+// 
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Christopher Jones
+//         Created:  Fri, 29 Aug 2014 17:58:54 GMT
+//
+
+// system include files
+
+// user include files
+#include "JetMETCorrections/JetCorrector/interface/JetCorrectorImpl.h"
+
+
+//
+// constants, enums and typedefs
+//
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+reco::JetCorrectorImpl::JetCorrectorImpl()
+{
+}
+
+// JetCorrectorImpl::JetCorrectorImpl(const JetCorrectorImpl& rhs)
+// {
+//    // do actual copying here;
+// }
+
+reco::JetCorrectorImpl::~JetCorrectorImpl()
+{
+}
+
+//
+// assignment operators
+//
+// const JetCorrectorImpl& JetCorrectorImpl::operator=(const JetCorrectorImpl& rhs)
+// {
+//   //An exception safe implementation is
+//   JetCorrectorImpl temp(rhs);
+//   swap(rhs);
+//
+//   return *this;
+// }
+
+//
+// member functions
+//
+
+//
+// const member functions
+//
+
+double 
+reco::JetCorrectorImpl::correction (const reco::Jet& fJet,
+				    const edm::RefToBase<reco::Jet>& fJetRef) const  {
+  return correction(fJet);
+}
+
+    /// Apply vectorial correction
+double 
+reco::JetCorrectorImpl::correction ( const reco::Jet& fJet, 
+				     const edm::RefToBase<reco::Jet>& fJetRef,
+				     LorentzVector& corrected ) const {
+  return correction(fJet);
+}
+
+bool
+reco::JetCorrectorImpl::vectorialCorrection() const {
+  return false;
+}
+
+//
+// static member functions
+//

--- a/JetMETCorrections/JetCorrector/src/classes.h
+++ b/JetMETCorrections/JetCorrector/src/classes.h
@@ -1,0 +1,8 @@
+#include "JetMETCorrections/JetCorrector/interface/JetCorrector.h"
+#include "DataFormats/Common/interface/Wrapper.h"
+
+namespace JetMETCorrections_JetCorrector {
+  struct dictionary {
+    edm::Wrapper<reco::JetCorrector> wslsn;
+  };
+}

--- a/JetMETCorrections/JetCorrector/src/classes_def.xml
+++ b/JetMETCorrections/JetCorrector/src/classes_def.xml
@@ -1,0 +1,4 @@
+<lcgdict>
+  <class name="reco::JetCorrector" persistence="false"/>
+  <class name="edm::Wrapper<reco::JetCorrector>" persistent="false"/>
+</lcgdict>

--- a/JetMETCorrections/Modules/BuildFile.xml
+++ b/JetMETCorrections/Modules/BuildFile.xml
@@ -11,6 +11,7 @@
 <use   name="FWCore/ParameterSet"/>
 <use   name="JetMETCorrections/Objects"/>
 <use   name="JetMETCorrections/Algorithms"/>
+<use   name="JetMETCorrections/JetCorrector"/>
 <use   name="boost"/>
 <export>
   <lib   name="1"/>

--- a/JetMETCorrections/Modules/plugins/ChainedJetCorrectorProducer.cc
+++ b/JetMETCorrections/Modules/plugins/ChainedJetCorrectorProducer.cc
@@ -1,0 +1,193 @@
+// -*- C++ -*-
+//
+// Package:    JetMETCorrections/Modules
+// Class:      ChainedJetCorrectorProducer
+// 
+/**\class ChainedJetCorrectorProducer ChainedJetCorrectorProducer.cc JetMETCorrections/Modules/plugins/ChainedJetCorrectorProducer.cc
+
+ Description: [one line class summary]
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author:  Christopher Jones
+//         Created:  Tue, 02 Sep 2014 18:11:02 GMT
+//
+//
+
+
+// system include files
+#include <memory>
+#include <vector>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+#include "DataFormats/Common/interface/Handle.h"
+
+#include "JetMETCorrections/JetCorrector/interface/JetCorrector.h"
+#include "JetMETCorrections/JetCorrector/interface/JetCorrectorImpl.h"
+
+
+//
+// class declaration
+//
+namespace {
+  class ChainedJetCorrectorImpl : public reco::JetCorrectorImpl {
+  public:
+    ChainedJetCorrectorImpl(std::vector<reco::JetCorrector const*> correctors):
+      jetCorrectors_(std::move(correctors)) {}
+
+    virtual double correction (const LorentzVector& fJet) const override;
+
+    /// apply correction using Jet information only
+    virtual double correction (const reco::Jet& fJet) const override;
+
+    /// apply correction using Ref
+    virtual double correction (const reco::Jet& fJet,
+			       const edm::RefToBase<reco::Jet>& fJetRef) const override ;
+
+    /// if correction needs the jet reference
+    virtual bool refRequired () const override;
+  
+  private:
+    std::vector<reco::JetCorrector const*> jetCorrectors_;
+  };
+
+  double ChainedJetCorrectorImpl::correction (const LorentzVector& fJet) const
+  {
+    LorentzVector jet = fJet;
+    double result = 1;
+    for (auto cor: jetCorrectors_) {
+      double scale = cor->correction (jet);
+      jet *= scale;
+      result *= scale;
+    }
+    return result;
+  }
+  
+  /// apply correction using Jet information only
+  double ChainedJetCorrectorImpl::correction (const reco::Jet& fJet) const
+  {
+    std::unique_ptr<reco::Jet> jet (dynamic_cast<reco::Jet*> (fJet.clone ()));
+    double result = 1;
+    for (auto cor: jetCorrectors_) {
+      double scale = cor->correction (*jet);
+      jet->scaleEnergy (scale);
+      result *= scale;
+    }
+    return result;
+  }
+
+  /// apply correction using reference to the raw jet
+  double ChainedJetCorrectorImpl::correction (const reco::Jet& fJet,
+					      const edm::RefToBase<reco::Jet>& fJetRef) const
+  {
+    std::unique_ptr<reco::Jet> jet (dynamic_cast<reco::Jet*> (fJet.clone ()));
+    double result = 1;
+    for (auto cor: jetCorrectors_) {
+      double scale = cor->correction (*jet, fJetRef);
+      jet->scaleEnergy (scale);
+      result *= scale;
+    }
+    return result;
+  }
+
+  /// if correction needs jet reference
+  bool ChainedJetCorrectorImpl::refRequired () const
+  {
+    for (auto cor: jetCorrectors_) {
+      if (cor->refRequired ()) return true;
+    }
+    return false;
+  }
+
+}
+
+
+class ChainedJetCorrectorProducer : public edm::stream::EDProducer<> {
+   public:
+      explicit ChainedJetCorrectorProducer(const edm::ParameterSet&);
+
+      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+   private:
+      virtual void produce(edm::Event&, const edm::EventSetup&) override;
+      
+      // ----------member data ---------------------------
+  std::vector<edm::EDGetTokenT<reco::JetCorrector>> correctorTokens_;
+};
+
+//
+// constants, enums and typedefs
+//
+
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+ChainedJetCorrectorProducer::ChainedJetCorrectorProducer(const edm::ParameterSet& iConfig)
+{
+   //register your products
+  produces<reco::JetCorrector>();
+
+  auto const& tags = iConfig.getParameter<std::vector<edm::InputTag>>("correctors");
+  correctorTokens_.reserve(tags.size());
+
+  for(auto const& tag : tags) {
+    correctorTokens_.emplace_back( consumes<reco::JetCorrector>(tag));
+  }
+}
+
+
+//
+// member functions
+//
+
+// ------------ method called to produce the data  ------------
+void
+ChainedJetCorrectorProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+   using namespace edm;
+
+   std::vector<reco::JetCorrector const*> correctors;
+   correctors.reserve(correctorTokens_.size());
+
+   for(auto const& token: correctorTokens_) {
+     edm::Handle<reco::JetCorrector> hCorrector;
+     iEvent.getByToken(token,hCorrector);
+     correctors.emplace_back(&(*hCorrector));
+   }
+
+   std::auto_ptr<reco::JetCorrector> pCorr( new reco::JetCorrector( std::unique_ptr<reco::JetCorrectorImpl>(new ChainedJetCorrectorImpl(std::move(correctors)) )));
+   iEvent.put(pCorr);
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void
+ChainedJetCorrectorProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.add<std::vector<edm::InputTag>>("correctors");
+  descriptions.addDefault(desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(ChainedJetCorrectorProducer);

--- a/JetMETCorrections/Modules/plugins/JetCorrectorProducer.h
+++ b/JetMETCorrections/Modules/plugins/JetCorrectorProducer.h
@@ -1,0 +1,59 @@
+#ifndef JetMETCorrections_Modules_JetCorrectorProducer_h
+#define JetMETCorrections_Modules_JetCorrectorProducer_h
+// -*- C++ -*-
+//
+// Package:     JetMETCorrections/Modules
+// Class  :     JetCorrectorProducer
+// 
+/**\class JetCorrectorProducer JetCorrectorProducer.h "JetCorrectorProducer.h"
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Christopher Jones
+//         Created:  Sun, 31 Aug 2014 20:40:18 GMT
+//
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "JetMETCorrections/JetCorrector/interface/JetCorrector.h"
+
+// forward declarations
+
+template<typename T>
+class JetCorrectorProducer : public edm::stream::EDProducer<>
+{
+ public:
+ JetCorrectorProducer(edm::ParameterSet const& iPSet):
+  maker_{iPSet,consumesCollector()}
+  {
+    produces<reco::JetCorrector>();
+  }
+  
+  // ---------- member functions ---------------------------
+  void produce(edm::Event& iEvent, edm::EventSetup const& iSetup) override {
+    auto impl =maker_.make(iEvent,iSetup);
+    std::auto_ptr<reco::JetCorrector> corrector{ new reco::JetCorrector{std::move(impl) } };
+    iEvent.put(corrector);
+  }
+  
+ private:
+  JetCorrectorProducer(const JetCorrectorProducer&) = delete; // stop default
+  
+  const JetCorrectorProducer& operator=(const JetCorrectorProducer&) = delete; // stop default
+  
+  // ---------- member data --------------------------------
+  typename T::Maker maker_; 
+};
+
+
+#endif

--- a/JetMETCorrections/Modules/plugins/JetCorrectorProducer.h
+++ b/JetMETCorrections/Modules/plugins/JetCorrectorProducer.h
@@ -26,6 +26,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "JetMETCorrections/JetCorrector/interface/JetCorrector.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 
 // forward declarations
 
@@ -44,6 +45,10 @@ class JetCorrectorProducer : public edm::stream::EDProducer<>
     auto impl =maker_.make(iEvent,iSetup);
     std::auto_ptr<reco::JetCorrector> corrector{ new reco::JetCorrector{std::move(impl) } };
     iEvent.put(corrector);
+  }
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& iDescriptions) {
+    T::Maker::fillDescriptions(iDescriptions);
   }
   
  private:

--- a/JetMETCorrections/Modules/plugins/JetCorrectorProducers.cc
+++ b/JetMETCorrections/Modules/plugins/JetCorrectorProducers.cc
@@ -1,0 +1,37 @@
+// -*- C++ -*-
+//
+// Package:     JetMETCorrections/Modules
+// Class  :     JetCorrectorProducers
+// 
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Christopher Jones
+//         Created:  Sun, 31 Aug 2014 20:58:29 GMT
+//
+
+// system include files
+
+// user include files
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "JetCorrectorProducer.h"
+#include "JetMETCorrections/Algorithms/interface/LXXXCorrectorImpl.h"
+#include "JetMETCorrections/Algorithms/interface/L1OffsetCorrectorImpl.h"
+#include "JetMETCorrections/Algorithms/interface/L1JPTOffsetCorrectorImpl.h"
+#include "JetMETCorrections/Algorithms/interface/L1FastjetCorrectorImpl.h"
+#include "JetMETCorrections/Algorithms/interface/L6SLBCorrectorImpl.h"
+
+typedef JetCorrectorProducer<LXXXCorrectorImpl> LXXXCorrectorProducer;
+DEFINE_FWK_MODULE(LXXXCorrectorProducer);
+
+typedef JetCorrectorProducer<L1OffsetCorrectorImpl> L1OffsetCorrectorProducer;
+DEFINE_FWK_MODULE(L1OffsetCorrectorProducer);
+
+typedef JetCorrectorProducer<L1JPTOffsetCorrectorImpl> L1JPTOffsetCorrectorProducer;
+DEFINE_FWK_MODULE(L1JPTOffsetCorrectorProducer);
+
+typedef JetCorrectorProducer<L1FastjetCorrectorImpl> L1FastjetCorrectorProducer;
+DEFINE_FWK_MODULE(L1FastjetCorrectorProducer);
+
+typedef JetCorrectorProducer<L6SLBCorrectorImpl> L6SLBCorrectorProducer;
+DEFINE_FWK_MODULE(L6SLBCorrectorProducer);


### PR DESCRIPTION
At the request of David Lange @davidlange6 I implemented a solution to the consumes problem with JetCorrector. 

Previously, `JetCorrector` was an EventSetup object yet to do its work it had member functions which took the `edm::Event` as a parameter. Given that the JetCorrector was doing 'hidden' gets from the Event it meant any module using the `JetCorrector` was unable to make all the necessary `consumes` calls.

This implementation avoids the `consumes` problem by having a new `reco::JetCorrector` which is an Event product. Therefore the module which makes the `reco::JetCorrector` can do the needed gets from the Event and knows which `consumes` calls are needed. This also simplifies the use of `reco::JetCorrector` since users no longer have to pass a `edm::Event` and `edm::EventSetup` to the methods of the class.
