### PR TITLE
selective imports in vtx smearing cfg files

### DIFF
--- a/IOMC/EventVertexGenerators/python/BeamSpotFilterParameters_cfi.py
+++ b/IOMC/EventVertexGenerators/python/BeamSpotFilterParameters_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import *
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import Realistic8TeVCollisionVtxSmearingParameters,Realistic8TeV2012CollisionVtxSmearingParameters
 
 baseVtx = Realistic8TeVCollisionVtxSmearingParameters.clone()
 newVtx = Realistic8TeV2012CollisionVtxSmearingParameters.clone()

--- a/IOMC/EventVertexGenerators/python/GaussianZBeamSpotFilter_cfi.py
+++ b/IOMC/EventVertexGenerators/python/GaussianZBeamSpotFilter_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-from IOMC.EventVertexGenerators.BeamSpotFilterParameters_cfi import *
+from IOMC.EventVertexGenerators.BeamSpotFilterParameters_cfi import baseVtx,newVtx
 simBeamSpotFilter = cms.EDFilter("GaussianZBeamSpotFilter",
     src = cms.InputTag("generator"),
     baseSZ = baseVtx.SigmaZ,

--- a/IOMC/EventVertexGenerators/python/VtxSmearedBeamProfile_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedBeamProfile_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import *
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import VtxSmearedCommon
 
 # default definition of common parameters
 

--- a/IOMC/EventVertexGenerators/python/VtxSmearedBetafuncEarlyCollision_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedBetafuncEarlyCollision_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import *
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import VtxSmearedCommon,EarlyCollisionVtxSmearingParameters
 VtxSmeared = cms.EDProducer("BetafuncEvtVtxGenerator",
     VtxSmearedCommon,
     EarlyCollisionVtxSmearingParameters

--- a/IOMC/EventVertexGenerators/python/VtxSmearedBetafuncNominalCollision_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedBetafuncNominalCollision_cfi.py
@@ -1,10 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import *
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import VtxSmearedCommon,NominalCollisionVtxSmearingParameters
 VtxSmeared = cms.EDProducer("BetafuncEvtVtxGenerator",
     VtxSmearedCommon,
     NominalCollisionVtxSmearingParameters
 )
-
-
-

--- a/IOMC/EventVertexGenerators/python/VtxSmearedCentered7TeV2011Collision_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedCentered7TeV2011Collision_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import *
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import Centered7TeV2011CollisionVtxSmearingParameters,VtxSmearedCommon
 VtxSmeared = cms.EDProducer("BetafuncEvtVtxGenerator",
     Centered7TeV2011CollisionVtxSmearingParameters,
     VtxSmearedCommon

--- a/IOMC/EventVertexGenerators/python/VtxSmearedEarly10TeVCollision_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedEarly10TeVCollision_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import *
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import Early10TeVCollisionVtxSmearingParameters,VtxSmearedCommon
 VtxSmeared = cms.EDProducer("BetafuncEvtVtxGenerator",
     Early10TeVCollisionVtxSmearingParameters,
     VtxSmearedCommon

--- a/IOMC/EventVertexGenerators/python/VtxSmearedEarly10TeVX322Y10000_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedEarly10TeVX322Y10000_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import *
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import Early10TeVX322Y10000VtxSmearingParameters,VtxSmearedCommon
 VtxSmeared = cms.EDProducer("BetafuncEvtVtxGenerator",
     Early10TeVX322Y10000VtxSmearingParameters,
     VtxSmearedCommon

--- a/IOMC/EventVertexGenerators/python/VtxSmearedEarly10TeVX322Y1000_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedEarly10TeVX322Y1000_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import *
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import Early10TeVX322Y1000VtxSmearingParameters,VtxSmearedCommon
 VtxSmeared = cms.EDProducer("BetafuncEvtVtxGenerator",
     Early10TeVX322Y1000VtxSmearingParameters,
     VtxSmearedCommon

--- a/IOMC/EventVertexGenerators/python/VtxSmearedEarly10TeVX322Y100_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedEarly10TeVX322Y100_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import *
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import Early10TeVX322Y100VtxSmearingParameters,VtxSmearedCommon
 VtxSmeared = cms.EDProducer("BetafuncEvtVtxGenerator",
     Early10TeVX322Y100VtxSmearingParameters,
     VtxSmearedCommon

--- a/IOMC/EventVertexGenerators/python/VtxSmearedEarly10TeVX322Y250_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedEarly10TeVX322Y250_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import *
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import Early10TeVX322Y250VtxSmearingParameters,VtxSmearedCommon
 VtxSmeared = cms.EDProducer("BetafuncEvtVtxGenerator",
     Early10TeVX322Y250VtxSmearingParameters,
     VtxSmearedCommon

--- a/IOMC/EventVertexGenerators/python/VtxSmearedEarly10TeVX322Y5000_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedEarly10TeVX322Y5000_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import *
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import Early10TeVX322Y5000VtxSmearingParameters,VtxSmearedCommon
 VtxSmeared = cms.EDProducer("BetafuncEvtVtxGenerator",
     Early10TeVX322Y5000VtxSmearingParameters,
     VtxSmearedCommon

--- a/IOMC/EventVertexGenerators/python/VtxSmearedEarly10TeVX322Y500_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedEarly10TeVX322Y500_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import *
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import Early10TeVX322Y500VtxSmearingParameters,VtxSmearedCommon
 VtxSmeared = cms.EDProducer("BetafuncEvtVtxGenerator",
     Early10TeVX322Y500VtxSmearingParameters,
     VtxSmearedCommon

--- a/IOMC/EventVertexGenerators/python/VtxSmearedEarly2p2TeVCollision_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedEarly2p2TeVCollision_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import *
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import Early2p2TeVCollisionVtxSmearingParameters,VtxSmearedCommon
 VtxSmeared = cms.EDProducer("BetafuncEvtVtxGenerator",
     Early2p2TeVCollisionVtxSmearingParameters,
     VtxSmearedCommon

--- a/IOMC/EventVertexGenerators/python/VtxSmearedEarly7TeVCollision_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedEarly7TeVCollision_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import *
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import Early7TeVCollisionVtxSmearingParameters,VtxSmearedCommon
 VtxSmeared = cms.EDProducer("BetafuncEvtVtxGenerator",
     Early7TeVCollisionVtxSmearingParameters,
     VtxSmearedCommon

--- a/IOMC/EventVertexGenerators/python/VtxSmearedEarly900GeVCollision_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedEarly900GeVCollision_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import *
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import Early900GeVCollisionVtxSmearingParameters,VtxSmearedCommon
 VtxSmeared = cms.EDProducer("BetafuncEvtVtxGenerator",
     Early900GeVCollisionVtxSmearingParameters,
     VtxSmearedCommon

--- a/IOMC/EventVertexGenerators/python/VtxSmearedFlat_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedFlat_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import *
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import FlatVtxSmearingParameters,VtxSmearedCommon
 VtxSmeared = cms.EDProducer("FlatEvtVtxGenerator",
     FlatVtxSmearingParameters,
     VtxSmearedCommon

--- a/IOMC/EventVertexGenerators/python/VtxSmearedGauss_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedGauss_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import *
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import GaussVtxSmearingParameters,VtxSmearedCommon
 VtxSmeared = cms.EDProducer("GaussEvtVtxGenerator",
     GaussVtxSmearingParameters,
     VtxSmearedCommon

--- a/IOMC/EventVertexGenerators/python/VtxSmearedNominalCollision1_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedNominalCollision1_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import *
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import NominalCollision1VtxSmearingParameters,VtxSmearedCommon
 VtxSmeared = cms.EDProducer("BetafuncEvtVtxGenerator",
     NominalCollision1VtxSmearingParameters,
     VtxSmearedCommon

--- a/IOMC/EventVertexGenerators/python/VtxSmearedNominalCollision2_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedNominalCollision2_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import *
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import VtxSmearedCommon,NominalCollision2VtxSmearingParameters
 VtxSmeared = cms.EDProducer("BetafuncEvtVtxGenerator",
     VtxSmearedCommon,
     NominalCollision2VtxSmearingParameters

--- a/IOMC/EventVertexGenerators/python/VtxSmearedNominalCollision3_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedNominalCollision3_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import *
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import NominalCollision3VtxSmearingParameters,VtxSmearedCommon
 VtxSmeared = cms.EDProducer("BetafuncEvtVtxGenerator",
     NominalCollision3VtxSmearingParameters,
     VtxSmearedCommon

--- a/IOMC/EventVertexGenerators/python/VtxSmearedNominalCollision4_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedNominalCollision4_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import *
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import NominalCollision4VtxSmearingParameters,VtxSmearedCommon
 VtxSmeared = cms.EDProducer("BetafuncEvtVtxGenerator",
     NominalCollision4VtxSmearingParameters,
     VtxSmearedCommon

--- a/IOMC/EventVertexGenerators/python/VtxSmearedRealistic2p76TeV2011Collision_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedRealistic2p76TeV2011Collision_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import *
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import Realistic2p76TeV2011CollisionVtxSmearingParameters,VtxSmearedCommon
 VtxSmeared = cms.EDProducer("BetafuncEvtVtxGenerator",
     Realistic2p76TeV2011CollisionVtxSmearingParameters,
     VtxSmearedCommon

--- a/IOMC/EventVertexGenerators/python/VtxSmearedRealistic2p76TeV2013Collision_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedRealistic2p76TeV2013Collision_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import *
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import Realistic2p76TeV2013CollisionVtxSmearingParameters,VtxSmearedCommon
 VtxSmeared = cms.EDProducer("BetafuncEvtVtxGenerator",
     Realistic2p76TeV2013CollisionVtxSmearingParameters,
     VtxSmearedCommon

--- a/IOMC/EventVertexGenerators/python/VtxSmearedRealistic7TeV2011Collision_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedRealistic7TeV2011Collision_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import *
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import Realistic7TeV2011CollisionVtxSmearingParameters,VtxSmearedCommon
 VtxSmeared = cms.EDProducer("BetafuncEvtVtxGenerator",
     Realistic7TeV2011CollisionVtxSmearingParameters,
     VtxSmearedCommon

--- a/IOMC/EventVertexGenerators/python/VtxSmearedRealistic7TeVCollision2010B_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedRealistic7TeVCollision2010B_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import *
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import Realistic7TeVCollision2010BVtxSmearingParameters,VtxSmearedCommon
 VtxSmeared = cms.EDProducer("BetafuncEvtVtxGenerator",
     Realistic7TeVCollision2010BVtxSmearingParameters,
     VtxSmearedCommon

--- a/IOMC/EventVertexGenerators/python/VtxSmearedRealistic7TeVCollisionComm10_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedRealistic7TeVCollisionComm10_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import *
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import Realistic7TeVCollisionComm10VtxSmearingParameters,VtxSmearedCommon
 VtxSmeared = cms.EDProducer("BetafuncEvtVtxGenerator",
     Realistic7TeVCollisionComm10VtxSmearingParameters,
     VtxSmearedCommon

--- a/IOMC/EventVertexGenerators/python/VtxSmearedRealistic7TeVCollision_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedRealistic7TeVCollision_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import *
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import Realistic7TeVCollisionVtxSmearingParameters,VtxSmearedCommon
 VtxSmeared = cms.EDProducer("BetafuncEvtVtxGenerator",
     Realistic7TeVCollisionVtxSmearingParameters,
     VtxSmearedCommon

--- a/IOMC/EventVertexGenerators/python/VtxSmearedRealistic8TeV2012Collision_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedRealistic8TeV2012Collision_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import *
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import Realistic8TeV2012CollisionVtxSmearingParameters,VtxSmearedCommon
 VtxSmeared = cms.EDProducer("BetafuncEvtVtxGenerator",
     Realistic8TeV2012CollisionVtxSmearingParameters,
     VtxSmearedCommon

--- a/IOMC/EventVertexGenerators/python/VtxSmearedRealistic8TeVCollision_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedRealistic8TeVCollision_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import *
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import Realistic8TeVCollisionVtxSmearingParameters,VtxSmearedCommon
 VtxSmeared = cms.EDProducer("BetafuncEvtVtxGenerator",
     Realistic8TeVCollisionVtxSmearingParameters,
     VtxSmearedCommon

--- a/IOMC/EventVertexGenerators/python/VtxSmearedRealistic900GeVCollision_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedRealistic900GeVCollision_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import *
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import Realistic900GeVCollisionVtxSmearingParameters,VtxSmearedCommon
 VtxSmeared = cms.EDProducer("BetafuncEvtVtxGenerator",
     Realistic900GeVCollisionVtxSmearingParameters,
     VtxSmearedCommon

--- a/IOMC/EventVertexGenerators/python/VtxSmearedRealisticHI2011Collision_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedRealisticHI2011Collision_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import *
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import RealisticHI2011CollisionVtxSmearingParameters,VtxSmearedCommon
 VtxSmeared = cms.EDProducer("BetafuncEvtVtxGenerator",
     RealisticHI2011CollisionVtxSmearingParameters,
     VtxSmearedCommon

--- a/IOMC/EventVertexGenerators/python/VtxSmearedRealisticHIpPb2013Collision_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedRealisticHIpPb2013Collision_cfi.py
@@ -1,10 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import *
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import RealisticHIpPb2013CollisionVtxSmearingParameters,VtxSmearedCommon
 VtxSmeared = cms.EDProducer("BetafuncEvtVtxGenerator",
     RealisticHIpPb2013CollisionVtxSmearingParameters,
     VtxSmearedCommon
 )
-
-
-


### PR DESCRIPTION
make selective imports in vtx smearing cfg files
small step towards smaller dumps of simulation cfg files

test: all changed python files run

expect 0 regression
