### PR TITLE
Added an early termination signal for Services

### DIFF
--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -89,6 +89,30 @@
 //Needed for introspection
 #include "Cintex/Cintex.h"
 
+
+namespace {
+  //Sentry class to only send a signal if an
+  // exception occurs. An exception is identified
+  // by the destructor being called without first
+  // calling completedSuccessfully().
+  class SendSourceTerminationSignalIfException {
+  public:
+    SendSourceTerminationSignalIfException(edm::ActivityRegistry* iReg):
+    reg_(iReg) {}
+    ~SendSourceTerminationSignalIfException() {
+      if(reg_) {
+        reg_->preSourceEarlyTerminationSignal_(edm::TerminationOrigin::ExceptionFromThisContext);
+      }
+    }
+    void completedSuccessfully() {
+      reg_ = nullptr;
+    }
+  private:
+    edm::ActivityRegistry* reg_;
+    
+  };
+}
+
 namespace edm {
 
   // ---------------------------------------------------------------
@@ -1270,19 +1294,28 @@ namespace edm {
             bool more = true;
             if(numberOfForkedChildren_ > 0) {
               size_t size = preg_->size();
-              more = input_->skipForForking();
+              {
+                SendSourceTerminationSignalIfException sentry(actReg_.get());
+                more = input_->skipForForking();
+                sentry.completedSuccessfully();
+              }
               if(more) {
                 if(size < preg_->size()) {
                   principalCache_.adjustIndexesAfterProductRegistryAddition();
                 }
                 principalCache_.adjustEventsToNewProductRegistry(preg_);
               }
-            } 
-            itemType = (more ? input_->nextItemType() : InputSource::IsStop);
+            }
+            {
+              SendSourceTerminationSignalIfException sentry(actReg_.get());
+              itemType = (more ? input_->nextItemType() : InputSource::IsStop);
+              sentry.completedSuccessfully();
+            }
             
             FDEBUG(1) << "itemType = " << itemType << "\n";
             
             if(checkForAsyncStopRequest(returnCode)) {
+              actReg_->preSourceEarlyTerminationSignal_(TerminationOrigin::ExternalSignal);
               forceLooperToEnd_ = true;
               machine->process_event(statemachine::Stop());
               forceLooperToEnd_ = false;
@@ -1425,6 +1458,8 @@ namespace edm {
   void EventProcessor::readFile() {
     FDEBUG(1) << " \treadFile\n";
     size_t size = preg_->size();
+    SendSourceTerminationSignalIfException sentry(actReg_.get());
+
     fb_ = input_->readFile();
     if(size < preg_->size()) {
       principalCache_.adjustIndexesAfterProductRegistryAddition();
@@ -1435,11 +1470,14 @@ namespace edm {
         preallocations_.numberOfThreads()>1)) {
         fb_->setNotFastClonable(FileBlock::ParallelProcesses);
     }
+    sentry.completedSuccessfully();
   }
 
   void EventProcessor::closeInputFile(bool cleaningUpAfterException) {
     if (fb_.get() != nullptr) {
+      SendSourceTerminationSignalIfException sentry(actReg_.get());
       input_->closeFile(fb_.get(), cleaningUpAfterException);
+      sentry.completedSuccessfully();
     }
     FDEBUG(1) << "\tcloseInputFile\n";
   }
@@ -1531,13 +1569,23 @@ namespace edm {
 
   void EventProcessor::beginRun(statemachine::Run const& run) {
     RunPrincipal& runPrincipal = principalCache_.runPrincipal(run.processHistoryID(), run.runNumber());
-    input_->doBeginRun(runPrincipal, &processContext_);
+    {
+      SendSourceTerminationSignalIfException sentry(actReg_.get());
+
+      input_->doBeginRun(runPrincipal, &processContext_);
+      sentry.completedSuccessfully();
+    }
+
     IOVSyncValue ts(EventID(runPrincipal.run(), 0, 0),
                     runPrincipal.beginTime());
     if(forceESCacheClearOnNewRun_){
       espController_->forceCacheClear();
     }
-    espController_->eventSetupForInstance(ts);
+    {
+      SendSourceTerminationSignalIfException sentry(actReg_.get());
+      espController_->eventSetupForInstance(ts);
+      sentry.completedSuccessfully();
+    }
     EventSetup const& es = esp_->eventSetup();
     if(looper_ && looperBeginJobRun_== false) {
       looper_->copyInfo(ScheduleInfo(schedule_.get()));
@@ -1573,10 +1621,20 @@ namespace edm {
 
   void EventProcessor::endRun(statemachine::Run const& run, bool cleaningUpAfterException) {
     RunPrincipal& runPrincipal = principalCache_.runPrincipal(run.processHistoryID(), run.runNumber());
-    input_->doEndRun(runPrincipal, cleaningUpAfterException, &processContext_);
+    {
+      SendSourceTerminationSignalIfException sentry(actReg_.get());
+
+      input_->doEndRun(runPrincipal, cleaningUpAfterException, &processContext_);
+      sentry.completedSuccessfully();
+    }
+
     IOVSyncValue ts(EventID(runPrincipal.run(), LuminosityBlockID::maxLuminosityBlockNumber(), EventID::maxEventNumber()),
                     runPrincipal.endTime());
-    espController_->eventSetupForInstance(ts);
+    {
+      SendSourceTerminationSignalIfException sentry(actReg_.get());
+      espController_->eventSetupForInstance(ts);
+      sentry.completedSuccessfully();
+    }
     EventSetup const& es = esp_->eventSetup();
     {
       for(unsigned int i=0; i<preallocations_.numberOfStreams();++i) {
@@ -1606,7 +1664,12 @@ namespace edm {
 
   void EventProcessor::beginLumi(ProcessHistoryID const& phid, RunNumber_t run, LuminosityBlockNumber_t lumi) {
     LuminosityBlockPrincipal& lumiPrincipal = principalCache_.lumiPrincipal(phid, run, lumi);
-    input_->doBeginLumi(lumiPrincipal, &processContext_);
+    {
+      SendSourceTerminationSignalIfException sentry(actReg_.get());
+
+      input_->doBeginLumi(lumiPrincipal, &processContext_);
+      sentry.completedSuccessfully();
+    }
 
     Service<RandomNumberGenerator> rng;
     if(rng.isAvailable()) {
@@ -1617,7 +1680,11 @@ namespace edm {
     // NOTE: Using 0 as the event number for the begin of a lumi block is a bad idea
     // lumi blocks know their start and end times why not also start and end events?
     IOVSyncValue ts(EventID(lumiPrincipal.run(), lumiPrincipal.luminosityBlock(), 0), lumiPrincipal.beginTime());
-    espController_->eventSetupForInstance(ts);
+    {
+      SendSourceTerminationSignalIfException sentry(actReg_.get());
+      espController_->eventSetupForInstance(ts);
+      sentry.completedSuccessfully();
+    }
     EventSetup const& es = esp_->eventSetup();
     {
       typedef OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalBegin> Traits;
@@ -1647,12 +1714,21 @@ namespace edm {
 
   void EventProcessor::endLumi(ProcessHistoryID const& phid, RunNumber_t run, LuminosityBlockNumber_t lumi, bool cleaningUpAfterException) {
     LuminosityBlockPrincipal& lumiPrincipal = principalCache_.lumiPrincipal(phid, run, lumi);
-    input_->doEndLumi(lumiPrincipal, cleaningUpAfterException, &processContext_);
+    {
+      SendSourceTerminationSignalIfException sentry(actReg_.get());
+
+      input_->doEndLumi(lumiPrincipal, cleaningUpAfterException, &processContext_);
+      sentry.completedSuccessfully();
+    }
     //NOTE: Using the max event number for the end of a lumi block is a bad idea
     // lumi blocks know their start and end times why not also start and end events?
     IOVSyncValue ts(EventID(lumiPrincipal.run(), lumiPrincipal.luminosityBlock(), EventID::maxEventNumber()),
                     lumiPrincipal.endTime());
-    espController_->eventSetupForInstance(ts);
+    {
+      SendSourceTerminationSignalIfException sentry(actReg_.get());
+      espController_->eventSetupForInstance(ts);
+      sentry.completedSuccessfully();
+    }
     EventSetup const& es = esp_->eventSetup();
     {
       for(unsigned int i=0; i<preallocations_.numberOfStreams();++i) {
@@ -1688,7 +1764,11 @@ namespace edm {
         << "Contact a Framework Developer\n";
     }
     auto rp = std::make_shared<RunPrincipal>(input_->runAuxiliary(), preg_, *processConfiguration_, historyAppender_.get(), 0);
-    input_->readRun(*rp, *historyAppender_);
+    {
+      SendSourceTerminationSignalIfException sentry(actReg_.get());
+      input_->readRun(*rp, *historyAppender_);
+      sentry.completedSuccessfully();
+    }
     assert(input_->reducedProcessHistoryID() == rp->reducedProcessHistoryID());
     principalCache_.insert(rp);
     return statemachine::Run(rp->reducedProcessHistoryID(), input_->run());
@@ -1697,7 +1777,11 @@ namespace edm {
   statemachine::Run EventProcessor::readAndMergeRun() {
     principalCache_.merge(input_->runAuxiliary(), preg_);
     auto runPrincipal =principalCache_.runPrincipalPtr();
-    input_->readAndMergeRun(*runPrincipal);
+    {
+      SendSourceTerminationSignalIfException sentry(actReg_.get());
+      input_->readAndMergeRun(*runPrincipal);
+      sentry.completedSuccessfully();
+    }
     assert(input_->reducedProcessHistoryID() == runPrincipal->reducedProcessHistoryID());
     return statemachine::Run(runPrincipal->reducedProcessHistoryID(), input_->run());
   }
@@ -1717,7 +1801,11 @@ namespace edm {
         << "Contact a Framework Developer\n";
     }
     auto lbp = std::make_shared<LuminosityBlockPrincipal>(input_->luminosityBlockAuxiliary(), preg_, *processConfiguration_, historyAppender_.get(), 0);
-    input_->readLuminosityBlock(*lbp, *historyAppender_);
+    {
+      SendSourceTerminationSignalIfException sentry(actReg_.get());
+      input_->readLuminosityBlock(*lbp, *historyAppender_);
+      sentry.completedSuccessfully();
+    }
     lbp->setRunPrincipal(principalCache_.runPrincipalPtr());
     principalCache_.insert(lbp);
     return input_->luminosityBlock();
@@ -1725,7 +1813,11 @@ namespace edm {
 
   int EventProcessor::readAndMergeLumi() {
     principalCache_.merge(input_->luminosityBlockAuxiliary(), preg_);
-    input_->readAndMergeLumi(*principalCache_.lumiPrincipalPtr());
+    {
+      SendSourceTerminationSignalIfException sentry(actReg_.get());
+      input_->readAndMergeLumi(*principalCache_.lumiPrincipalPtr());
+      sentry.completedSuccessfully();
+    }
     return input_->luminosityBlock();
   }
 
@@ -1816,7 +1908,6 @@ namespace edm {
             if(sr) {
               delayedReaderGuard = std::unique_lock<SharedResourcesAcquirer>(*sr);
             }
-            
             InputSource::ItemType itemType = input_->nextItemType();
             if (InputSource::IsEvent !=itemType) {
               nextItemTypeFromProcessingEvents_ = itemType;
@@ -1826,6 +1917,7 @@ namespace edm {
             }
             if((asyncStopRequestedWhileProcessingEvents_=checkForAsyncStopRequest(asyncStopStatusCodeFromProcessingEvents_))) {
               //std::cerr<<"task told to async stop\n";
+              actReg_->preSourceEarlyTerminationSignal_(TerminationOrigin::ExternalSignal);
               break;
             }
             readEvent(iStreamIndex);
@@ -1834,6 +1926,8 @@ namespace edm {
         if(deferredExceptionPtrIsSet_.load(std::memory_order_acquire)) {
           //another thread hit an exception
           //std::cerr<<"another thread saw an exception\n";
+          actReg_->preSourceEarlyTerminationSignal_(TerminationOrigin::ExceptionFromAnotherContext);
+
           break;
         }
         processEvent(iStreamIndex);
@@ -1885,7 +1979,11 @@ namespace edm {
     //TODO this will have to become per stream
     auto& event = principalCache_.eventPrincipal(iStreamIndex);
     StreamContext streamContext(event.streamID(), &processContext_);
+    
+    SendSourceTerminationSignalIfException sentry(actReg_.get());
     input_->readEvent(event, streamContext);
+    sentry.completedSuccessfully();
+    
     FDEBUG(1) << "\treadEvent\n";
   }
   void EventProcessor::processEvent(unsigned int iStreamIndex) {

--- a/FWCore/Framework/src/GlobalSchedule.h
+++ b/FWCore/Framework/src/GlobalSchedule.h
@@ -117,6 +117,28 @@ namespace edm {
     }
 
   private:
+    //Sentry class to only send a signal if an
+    // exception occurs. An exception is identified
+    // by the destructor being called without first
+    // calling completedSuccessfully().
+    class SendTerminationSignalIfException {
+    public:
+      SendTerminationSignalIfException(edm::ActivityRegistry* iReg, edm::GlobalContext const* iContext):
+      reg_(iReg),
+      context_(iContext){}
+      ~SendTerminationSignalIfException() {
+        if(reg_) {
+          reg_->preGlobalEarlyTerminationSignal_(*context_,TerminationOrigin::ExceptionFromThisContext);
+        }
+      }
+      void completedSuccessfully() {
+        reg_ = nullptr;
+      }
+    private:
+      edm::ActivityRegistry* reg_;
+      GlobalContext const* context_;
+    };
+
     
     template<typename T>
     void runNow(typename T::MyPrincipal& p, EventSetup const& es,
@@ -146,6 +168,8 @@ namespace edm {
     GlobalContext globalContext = T::makeGlobalContext(ep, processContext_);
 
     GlobalScheduleSignalSentry<T> sentry(actReg_.get(), &globalContext);
+    
+    SendTerminationSignalIfException terminationSentry(actReg_.get(), &globalContext);
 
     // This call takes care of the unscheduled processing.
     workerManager_.processOneOccurrence<T>(ep, es, StreamID::invalidStreamID(), &globalContext, &globalContext, cleaningUpAfterException);
@@ -163,6 +187,8 @@ namespace edm {
       }
       throw;
     }
+    terminationSentry.completedSuccessfully();
+    
     //If we got here no other exception has happened so we can propogate any Service related exceptions
     sentry.allowThrow();
   }

--- a/FWCore/Framework/src/StreamSchedule.h
+++ b/FWCore/Framework/src/StreamSchedule.h
@@ -242,6 +242,28 @@ namespace edm {
     }
     
   private:
+    //Sentry class to only send a signal if an
+    // exception occurs. An exception is identified
+    // by the destructor being called without first
+    // calling completedSuccessfully().
+    class SendTerminationSignalIfException {
+    public:
+      SendTerminationSignalIfException(edm::ActivityRegistry* iReg, edm::StreamContext const* iContext):
+      reg_(iReg),
+      context_(iContext){}
+      ~SendTerminationSignalIfException() {
+        if(reg_) {
+          reg_->preStreamEarlyTerminationSignal_(*context_,TerminationOrigin::ExceptionFromThisContext);
+        }
+      }
+      void completedSuccessfully() {
+        reg_ = nullptr;
+      }
+    private:
+      edm::ActivityRegistry* reg_;
+      StreamContext const* context_;
+    };
+
     /// returns the action table
     ExceptionToActionTable const& actionTable() const {
       return workerManager_.actionTable();
@@ -341,6 +363,7 @@ namespace edm {
     T::setStreamContext(streamContext_, ep);
     StreamScheduleSignalSentry<T> sentry(actReg_.get(), &streamContext_);
 
+    SendTerminationSignalIfException terminationSentry(actReg_.get(), &streamContext_);
     // This call takes care of the unscheduled processing.
     workerManager_.processOneOccurrence<T>(ep, es, streamID_, &streamContext_, &streamContext_, cleaningUpAfterException);
 
@@ -389,6 +412,8 @@ namespace edm {
       }
       throw;
     }
+    terminationSentry.completedSuccessfully();
+    
     //If we got here no other exception has happened so we can propogate any Service related exceptions
     sentry.allowThrow();
   }
@@ -401,6 +426,8 @@ namespace edm {
 
     T::setStreamContext(streamContext_, ep);
     StreamScheduleSignalSentry<T> sentry(actReg_.get(), &streamContext_);
+
+    SendTerminationSignalIfException terminationSentry(actReg_.get(), &streamContext_);
 
     // This call takes care of the unscheduled processing.
     workerManager_.processOneOccurrence<T>(ep, es, streamID_, &streamContext_, &streamContext_, cleaningUpAfterException);
@@ -420,6 +447,8 @@ namespace edm {
       }
       throw;
     }
+    terminationSentry.completedSuccessfully();
+
     //If we got here no other exception has happened so we can propogate any Service related exceptions
     sentry.allowThrow();
   }

--- a/FWCore/Framework/test/BuildFile.xml
+++ b/FWCore/Framework/test/BuildFile.xml
@@ -301,3 +301,7 @@
   <flags   TEST_RUNNER_ARGS=" /bin/bash FWCore/Framework/test test_deleteEarly.sh"/>
   <use   name="FWCore/Utilities"/>
 </bin>
+<bin   name="TestFWCoreFrameworkEarlyTerminationSignal" file="TestDriver.cpp">
+  <flags TEST_RUNNER_ARGS=" /bin/bash FWCore/Framework/test test_earlyTerminationSignal.sh"/>
+  <use name="FWCore/Utilities"/>
+</bin>

--- a/FWCore/Framework/test/testEarlyTerminationSignal_cfg.py
+++ b/FWCore/Framework/test/testEarlyTerminationSignal_cfg.py
@@ -1,0 +1,13 @@
+import FWCore.ParameterSet.Config as cms
+
+process =cms.Process("TEST")
+
+process.source = cms.Source("EmptySource")
+
+process.tester = cms.EDAnalyzer("AbortOnEventIDAnalyzer",
+                                eventsToAbort = cms.untracked.VEventID( cms.EventID(1,10) ),
+                                throwExceptionInsteadOfAbort = cms.untracked.bool(True))
+
+process.p = cms.Path(process.tester)
+
+process.add_(cms.Service("Tracer"))

--- a/FWCore/Framework/test/test_earlyTerminationSignal.sh
+++ b/FWCore/Framework/test/test_earlyTerminationSignal.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Pass in name and status
+
+function die { echo $1: status $2 ;  exit $2; }
+
+(cmsRun ${LOCAL_TEST_DIR}/testEarlyTerminationSignal_cfg.py 2>&1 | grep -q 'early termination of event: stream = 0 run = 1 lumi = 1 event = 10 : time = 50000001') || die "Early termination signal failed" $?

--- a/FWCore/ServiceRegistry/interface/ActivityRegistry.h
+++ b/FWCore/ServiceRegistry/interface/ActivityRegistry.h
@@ -33,6 +33,7 @@ unscheduled execution. The tests are in FWCore/Integration/test:
 #include <functional>
 #include "FWCore/Utilities/interface/Signal.h"
 #include "FWCore/Utilities/interface/StreamID.h"
+#include "FWCore/ServiceRegistry/interface/TerminationOrigin.h"
 
 // user include files
 
@@ -379,6 +380,30 @@ namespace edm {
          postPathEventSignal_.connect_front(iSlot);
       }
       AR_WATCH_USING_METHOD_3(watchPostPathEvent)
+      
+      /// signal is emitted when began processing a stream transition and
+      ///  then we began terminating the application
+      typedef signalslot::Signal<void(StreamContext const&, TerminationOrigin)> PreStreamEarlyTermination;
+      PreStreamEarlyTermination preStreamEarlyTerminationSignal_;
+      void watchPreStreamEarlyTermination(PreStreamEarlyTermination::slot_type const& iSlot) {
+         preStreamEarlyTerminationSignal_.connect(iSlot);
+      }
+
+      /// signal is emitted if a began processing a global transition and
+      ///  then we began terminating the application
+      typedef signalslot::Signal<void(GlobalContext const&, TerminationOrigin)> PreGlobalEarlyTermination;
+      PreGlobalEarlyTermination preGlobalEarlyTerminationSignal_;
+      void watchPreGlobalEarlyTermination(PreGlobalEarlyTermination::slot_type const& iSlot) {
+         preGlobalEarlyTerminationSignal_.connect(iSlot);
+      }
+
+      /// signal is emitted if while communicating with a source we began terminating
+      ///  the application
+      typedef signalslot::Signal<void(TerminationOrigin)> PreSourceEarlyTermination;
+      PreSourceEarlyTermination preSourceEarlyTerminationSignal_;
+      void watchPreSourceEarlyTermination(PreSourceEarlyTermination::slot_type const& iSlot) {
+         preSourceEarlyTerminationSignal_.connect(iSlot);
+      }
 
       // OLD DELETE THIS
       typedef signalslot::ObsoleteSignal<void(EventID const&, Timestamp const&)> PreProcessEvent;

--- a/FWCore/ServiceRegistry/interface/TerminationOrigin.h
+++ b/FWCore/ServiceRegistry/interface/TerminationOrigin.h
@@ -1,0 +1,35 @@
+#ifndef FWCore_ServiceRegistry_TerminationOrigin_h
+#define FWCore_ServiceRegistry_TerminationOrigin_h
+// -*- C++ -*-
+//
+// Package:     FWCore/ServiceRegistry
+// Class  :     edm::TerminationOrigin
+// 
+/**\class edm::TerminationOrigin TerminationOrigin.h "TerminationOrigin.h"
+
+ Description: Enum for different possible origins of a job termination 'signal'
+
+ Usage:
+    These values are used to denote exactly why a job is terminating prematurely.
+
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  Tue, 02 Sep 2014 20:22:02 GMT
+//
+
+// system include files
+
+// user include files
+
+// forward declarations
+
+namespace edm {
+  enum class TerminationOrigin {
+    ExceptionFromThisContext,
+    ExceptionFromAnotherContext,
+    ExternalSignal
+  };
+}
+
+#endif

--- a/FWCore/ServiceRegistry/src/ActivityRegistry.cc
+++ b/FWCore/ServiceRegistry/src/ActivityRegistry.cc
@@ -120,6 +120,11 @@ namespace edm {
 
      preForkReleaseResourcesSignal_.connect(std::cref(iOther.preForkReleaseResourcesSignal_));
      postForkReacquireResourcesSignal_.connect(std::cref(iOther.postForkReacquireResourcesSignal_));
+    
+    preStreamEarlyTerminationSignal_.connect(std::cref(iOther.preStreamEarlyTerminationSignal_));
+    preGlobalEarlyTerminationSignal_.connect(std::cref(iOther.preGlobalEarlyTerminationSignal_));
+    preSourceEarlyTerminationSignal_.connect(std::cref(iOther.preSourceEarlyTerminationSignal_));
+
   }
 
   void
@@ -317,6 +322,10 @@ namespace edm {
 
     copySlotsToFrom(prePathEventSignal_, iOther.prePathEventSignal_);
     copySlotsToFromReverse(postPathEventSignal_, iOther.postPathEventSignal_);
+
+    copySlotsToFrom(preStreamEarlyTerminationSignal_, iOther.preStreamEarlyTerminationSignal_);
+    copySlotsToFrom(preGlobalEarlyTerminationSignal_, iOther.preGlobalEarlyTerminationSignal_);
+    copySlotsToFrom(preSourceEarlyTerminationSignal_, iOther.preSourceEarlyTerminationSignal_);
 
     /*
     copySlotsToFrom(preProcessEventSignal_, iOther.preProcessEventSignal_);

--- a/FWCore/Services/src/Tracer.cc
+++ b/FWCore/Services/src/Tracer.cc
@@ -157,6 +157,46 @@ Tracer::Tracer(ParameterSet const& iPS, ActivityRegistry&iRegistry) :
 
   iRegistry.watchPreSourceConstruction(this, &Tracer::preSourceConstruction);
   iRegistry.watchPostSourceConstruction(this, &Tracer::postSourceConstruction);
+  
+  iRegistry.preSourceEarlyTerminationSignal_.connect([this](edm::TerminationOrigin iOrigin) {
+    LogAbsolute out("Tracer");
+    out << TimeStamper(printTimestamps_);
+    out << indention_ << indention_ << " early termination before processing transition";
+  });
+  iRegistry.preStreamEarlyTerminationSignal_.connect([this](edm::StreamContext const& iContext, edm::TerminationOrigin iOrigin) {
+    LogAbsolute out("Tracer");
+    out << TimeStamper(printTimestamps_);
+    if(iContext.eventID().luminosityBlock() ==0) {
+      out << indention_ << indention_ << " early termination of run: stream = " << iContext.streamID()
+      <<" run = " << iContext.eventID().run();
+    }else {
+      if(iContext.eventID().event() == 0) {
+        out << indention_ << indention_ << " early termination of stream lumi: stream = " << iContext.streamID()
+        <<" run = " << iContext.eventID().run()
+        << " lumi = " << iContext.eventID().luminosityBlock() ;
+      } else {
+        out << indention_ << indention_ << " early termination of event: stream = " << iContext.streamID()
+        <<" run = " << iContext.eventID().run()
+        << " lumi = " << iContext.eventID().luminosityBlock()
+        << " event = "<< iContext.eventID().event();
+        
+      }
+    }
+    out<< " : time = " << iContext.timestamp().value();
+    
+  });
+  iRegistry.preGlobalEarlyTerminationSignal_.connect([this](edm::GlobalContext const& iContext, edm::TerminationOrigin iOrigin) {
+    LogAbsolute out("Tracer");
+    out << TimeStamper(printTimestamps_);
+    if(iContext.luminosityBlockID().value() ==0) {
+      out << indention_ << indention_ << " early termination of global run " << iContext.luminosityBlockID().run();
+    }else {
+      out << indention_ << indention_ << " early termination of global lumi run = " << iContext.luminosityBlockID().run()
+          << " lumi = " << iContext.luminosityBlockID().luminosityBlock() ;
+      
+    }
+    out<< " : time = " << iContext.timestamp().value();
+  });
 }
 
 void


### PR DESCRIPTION
Services can now listen for a signal which is sent whenever a job is ending because of an early termination. The early termination can be caused by either an external signal or a fatal exception. The signal gives the context, if known, under which the termination was causes. The context includes such information as the run, lumi and event number for the transition which either saw the termination or which is being terminated because another transition caused the termination.
