### PR TITLE
Migration of L1T condition data to conddbv2

### DIFF
--- a/CondCore/CondDB/interface/Session.h
+++ b/CondCore/CondDB/interface/Session.h
@@ -161,6 +161,16 @@ namespace cond {
 			       const std::string& sourceTag, 
 			       cond::MigrationStatus status);
 
+      bool lookupMigratedPayload( const std::string& sourceAccount, 
+				  const std::string& sourceToken, 
+				  std::string& payloadId );
+      void addMigratedPayload( const std::string& sourceAccount, 
+			       const std::string& sourceToken, 
+			       const std::string& payloadId );
+      void updateMigratedPayload( const std::string& sourceAccount, 
+				  const std::string& sourceToken, 
+				  const std::string& payloadId );
+      std::string parsePoolToken( const std::string& poolToken );
 
       std::string connectionString();
 

--- a/CondCore/CondDB/src/IDbSchema.h
+++ b/CondCore/CondDB/src/IDbSchema.h
@@ -75,6 +75,18 @@ namespace cond {
       virtual void updateValidationCode( const std::string& sourceAccount, const std::string& sourceTag, int statusCode ) = 0;
     };
     
+    class IPayloadMigrationTable {
+    public:
+      virtual ~IPayloadMigrationTable(){}
+      virtual bool exists() = 0;
+      virtual void create() = 0;
+      virtual bool select( const std::string& sourceAccount, const std::string& sourceToken, std::string& payloadId ) = 0;
+      virtual void insert( const std::string& sourceAccount, const std::string& sourceToken, const std::string& payloadId, 
+			   const boost::posix_time::ptime& insertionTime ) = 0;
+      virtual void update( const std::string& sourceAccount, const std::string& sourceToken, const std::string& payloadId, 
+			   const boost::posix_time::ptime& insertionTime ) = 0;
+    };
+
     class IIOVSchema {
     public: 
       virtual ~IIOVSchema(){}
@@ -84,6 +96,8 @@ namespace cond {
       virtual IIOVTable& iovTable() = 0;
       virtual IPayloadTable& payloadTable() = 0;
       virtual ITagMigrationTable& tagMigrationTable() = 0;
+      virtual IPayloadMigrationTable& payloadMigrationTable() = 0;
+      virtual std::string parsePoolToken( const std::string& poolToken ) = 0;
     };
 
     class IGTTable {

--- a/CondCore/CondDB/src/IOVSchema.h
+++ b/CondCore/CondDB/src/IOVSchema.h
@@ -159,6 +159,30 @@ namespace cond {
 	coral::ISchema& m_schema;
       };
     }
+
+    // temporary... to be removed after the changeover.
+    table( PAYLOAD_MIGRATION ) {
+      
+      column( SOURCE_ACCOUNT, std::string );
+      column( SOURCE_TOKEN, std::string );
+      column( PAYLOAD_HASH, std::string );
+      column( INSERTION_TIME, boost::posix_time::ptime );
+      
+      class Table : public IPayloadMigrationTable {
+      public:
+	explicit Table( coral::ISchema& schema );
+	virtual ~Table(){}
+	bool exists();
+	void create();
+	bool select( const std::string& sourceAccount, const std::string& sourceToken, std::string& payloadId );
+	void insert( const std::string& sourceAccount, const std::string& sourceToken, const std::string& payloadId, 
+		     const boost::posix_time::ptime& insertionTime);
+	void update( const std::string& sourceAccount, const std::string& sourceToken, const std::string& payloadId, 
+		     const boost::posix_time::ptime& insertionTime);
+      private:
+	coral::ISchema& m_schema;
+      };
+    } 
     
     class IOVSchema : public IIOVSchema {
     public: 
@@ -170,11 +194,14 @@ namespace cond {
       IIOVTable& iovTable();
       IPayloadTable& payloadTable();
       ITagMigrationTable& tagMigrationTable();
+      IPayloadMigrationTable& payloadMigrationTable();
+      std::string parsePoolToken( const std::string& );
     private:
       TAG::Table m_tagTable;
       IOV::Table m_iovTable;
       PAYLOAD::Table m_payloadTable;
       TAG_MIGRATION::Table m_tagMigrationTable;
+      PAYLOAD_MIGRATION::Table m_payloadMigrationTable;
     };
   }
 }

--- a/CondCore/CondDB/src/OraDbSchema.cc
+++ b/CondCore/CondDB/src/OraDbSchema.cc
@@ -131,7 +131,15 @@ namespace cond {
 				  cond::Binary& payloadData, 
 				  cond::Binary& //streamerInfoData
 				){
-      ora::Object obj = m_session.getObject( payloadHash );
+      ora::Object obj;
+      try {
+	obj = m_session.getObject( payloadHash );
+      } catch( const ora::Exception& e ){
+	// hack to trap the non-existance of the object
+	if( e.explainSelf().find("has not been found in the database. from ReadBuffer::read") != std::string::npos ) {
+	  return false;
+	} else throw;
+      } 
       objectType = obj.typeName();
       payloadData.fromOraObject(obj );
       return true;
@@ -274,7 +282,17 @@ namespace cond {
       
     ITagMigrationTable& OraIOVSchema::tagMigrationTable(){
       throwException("Tag Migration interface is not available in this implementation.",
-		     "OraIOVSchema::tagMigrationTabl");
+		     "OraIOVSchema::tagMigrationTable");
+    }
+
+    IPayloadMigrationTable& OraIOVSchema::payloadMigrationTable(){
+      throwException("Payload Migration interface is not available in this implementation.",
+		     "OraIOVSchema::payloadMigrationTable");
+    }
+
+    std::string OraIOVSchema::parsePoolToken( const std::string& poolToken ){
+      cond::PoolTokenParser parser( m_cache.session().storage() );
+      return parser.parse( poolToken ).toString();
     }
 
     OraGTTable::OraGTTable( DbSession& session ):

--- a/CondCore/CondDB/src/OraDbSchema.h
+++ b/CondCore/CondDB/src/OraDbSchema.h
@@ -122,6 +122,8 @@ namespace cond {
       IIOVTable& iovTable();
       IPayloadTable& payloadTable();
       ITagMigrationTable& tagMigrationTable();
+      IPayloadMigrationTable& payloadMigrationTable();
+      std::string parsePoolToken( const std::string& poolToken );
     private:
       IOVCache m_cache;
       OraTagTable m_tagTable;

--- a/CondCore/CondDB/src/Session.cc
+++ b/CondCore/CondDB/src/Session.cc
@@ -224,6 +224,39 @@ namespace cond {
       m_session->iovSchema().tagMigrationTable().updateValidationCode( sourceAccount, sourceTag, (int)status );
     }
 
+    bool Session::lookupMigratedPayload( const std::string& sourceAccount, 
+					 const std::string& sourceToken, 
+					 std::string& payloadId ){
+      m_session->openIovDb();
+      if(! m_session->iovSchema().payloadMigrationTable().exists() ) return false;
+      return m_session->iovSchema().payloadMigrationTable().select( sourceAccount, sourceToken, payloadId );
+    }
+
+    void Session::addMigratedPayload( const std::string& sourceAccount, 
+				      const std::string& sourceToken, 
+				      const std::string& payloadId ){
+      m_session->openIovDb();
+      if(! m_session->iovSchema().payloadMigrationTable().exists() ) m_session->iovSchema().payloadMigrationTable().create();
+      m_session->iovSchema().payloadMigrationTable().insert( sourceAccount, sourceToken, payloadId,
+							     boost::posix_time::microsec_clock::universal_time() );             
+    }
+
+    void Session::updateMigratedPayload( const std::string& sourceAccount, 
+					 const std::string& sourceToken, 
+					 const std::string& payloadId ){
+      m_session->openIovDb();
+      if(! m_session->iovSchema().payloadMigrationTable().exists() ) 
+	throwException( "Payload Migration Table does not exist in this schema.","Session::updateMigratedPayload");
+      m_session->iovSchema().payloadMigrationTable().update( sourceAccount, sourceToken, payloadId,
+							     boost::posix_time::microsec_clock::universal_time() );             
+    }
+
+    std::string Session::parsePoolToken( const std::string& poolToken ){
+      m_session->openIovDb();
+      //std::cout <<"## parsing pool token="<<poolToken<<std::endl;
+      return m_session->iovSchema().parsePoolToken( poolToken );
+    }
+
     std::string Session::connectionString(){
       return m_session->connectionString;
     }

--- a/CondCore/Utilities/bin/conddb_migrate.cpp
+++ b/CondCore/Utilities/bin/conddb_migrate.cpp
@@ -77,6 +77,10 @@ int cond::MigrateUtilities::execute(){
   cond::DbSession logdb = openDbSession("log", cond::Auth::COND_READER_ROLE, true ); 
 
   persistency::ConnectionPool connPool;
+  if( hasDebug() ) {
+    connPool.setMessageVerbosity( coral::Debug );
+    connPool.configure();
+  }
   persistency::Session sourceSession = connPool.createSession( sourceConnect );
 
   std::cout <<"# Opening session on destination database..."<<std::endl;

--- a/CondCore/Utilities/bin/conddb_validate.cpp
+++ b/CondCore/Utilities/bin/conddb_validate.cpp
@@ -51,7 +51,7 @@ namespace cond {
     writeEditor.setDescription("Validation");
     for( auto iov : p ){
       std::pair<std::string,boost::shared_ptr<void> > readBackPayload = fetch( iov.payloadId, session );
-      cond::Hash ph = import( readBackPayload.first, readBackPayload.second.get(), writeSession );
+      cond::Hash ph = import( session, iov.payloadId, readBackPayload.first, readBackPayload.second.get(), writeSession );
       writeEditor.insert( iov.since, ph );
     }
     writeEditor.flush();

--- a/CondCore/Utilities/interface/CondDBImport.h
+++ b/CondCore/Utilities/interface/CondDBImport.h
@@ -9,7 +9,7 @@ namespace cond {
 
   namespace persistency {
 
-    cond::Hash import( const std::string& inputTypeName, const void* inputPtr, Session& destination );
+    cond::Hash import( Session& source, const cond::Hash& sourcePayloadId, const std::string& inputTypeName, const void* inputPtr, Session& destination );
 
     std::pair<std::string,boost::shared_ptr<void> > fetch( const cond::Hash& payloadId, Session& session );
     std::pair<std::string, boost::shared_ptr<void> > fetchOne( const std::string &payloadTypeName, const cond::Binary &data, const cond::Binary &streamerInfo, boost::shared_ptr<void> payloadPtr, bool is\

--- a/CondCore/Utilities/src/CondDBTools.cc
+++ b/CondCore/Utilities/src/CondDBTools.cc
@@ -82,7 +82,7 @@ namespace cond {
 	// make sure that we import the payload _IN_USE_
 	auto usedIov = p.getInterval( iov.since );
 	std::pair<std::string,boost::shared_ptr<void> > readBackPayload = fetch( usedIov.payloadId, sourceSession );
-	cond::Hash ph = import( readBackPayload.first, readBackPayload.second.get(), destSession );
+	cond::Hash ph = import( sourceSession, usedIov.payloadId, readBackPayload.first, readBackPayload.second.get(), destSession );
 	editor.insert( iov.since, ph );
 	pids.insert( ph );
 	niovs++;
@@ -234,7 +234,7 @@ namespace cond {
 	// make sure that we import the payload _IN_USE_
 	auto usedIov = p.getInterval( iov.since );
 	std::pair<std::string,boost::shared_ptr<void> > readBackPayload = fetch( usedIov.payloadId, sourceSession );
-	cond::Hash ph = import( readBackPayload.first, readBackPayload.second.get(), destSession );
+	cond::Hash ph = import( sourceSession, usedIov.payloadId, readBackPayload.first, readBackPayload.second.get(), destSession );
 	//std::cout <<"## inserting iov "<<iov.since<<" on time "<<insertionTime<<std::endl;
 	editor.insert( iov.since, ph, insertionTime );
 	pids.insert( ph );
@@ -310,7 +310,7 @@ namespace cond {
 	// make sure that we import the payload _IN_USE_
 	auto usedIov = p.getInterval( newSince );
 	std::pair<std::string,boost::shared_ptr<void> > readBackPayload = fetch( usedIov.payloadId, sourceSession );
-	cond::Hash ph = import( readBackPayload.first, readBackPayload.second.get(), destSession );
+	cond::Hash ph = import( sourceSession, usedIov.payloadId, readBackPayload.first, readBackPayload.second.get(), destSession );
 	editor.insert( newSince, ph );
 	pids.insert( ph );
 	niovs++;

--- a/CondTools/L1Trigger/interface/DataWriter.h
+++ b/CondTools/L1Trigger/interface/DataWriter.h
@@ -9,10 +9,6 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
 #include "CondCore/CondDB/interface/Session.h"
-//#include "CondCore/DBCommon/interface/DbSession.h"
-//#include "CondCore/DBCommon/interface/DbScopedTransaction.h"
-
-//#include "CondCore/MetaDataService/interface/MetaData.h"
 
 #include "DataFormats/Provenance/interface/RunID.h"
 

--- a/CondTools/L1Trigger/interface/L1ConfigOnlineProdBase.h
+++ b/CondTools/L1Trigger/interface/L1ConfigOnlineProdBase.h
@@ -44,10 +44,8 @@
 #include "FWCore/Utilities/interface/typelookup.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 
-//#include "CondCore/DBCommon/interface/DbSession.h"
-//#include "CondCore/DBCommon/interface/DbConnection.h"
-//#include "CondCore/DBCommon/interface/DbScopedTransaction.h"
 #include "CondCore/CondDB/interface/Session.h"
+#include "CondCore/CondDB/interface/ConnectionPool.h"
 
 // forward declarations
 
@@ -165,7 +163,7 @@ L1ConfigOnlineProdBase<TRcd, TData>::produce( const TRcd& iRecord )
 	   {
 	     m_dbSession.transaction().start() ; 
 	     pData = m_dbSession.fetchPayload<TData>( payloadToken ) ;
-	     tr.commit ();
+	     m_dbSession.transaction().commit ();
 	   }
        }
      else

--- a/CondTools/L1Trigger/interface/L1ConfigOnlineProdBase.h
+++ b/CondTools/L1Trigger/interface/L1ConfigOnlineProdBase.h
@@ -44,9 +44,10 @@
 #include "FWCore/Utilities/interface/typelookup.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 
-#include "CondCore/DBCommon/interface/DbSession.h"
-#include "CondCore/DBCommon/interface/DbConnection.h"
-#include "CondCore/DBCommon/interface/DbScopedTransaction.h"
+//#include "CondCore/DBCommon/interface/DbSession.h"
+//#include "CondCore/DBCommon/interface/DbConnection.h"
+//#include "CondCore/DBCommon/interface/DbScopedTransaction.h"
+#include "CondCore/CondDB/interface/Session.h"
 
 // forward declarations
 
@@ -77,8 +78,7 @@ class L1ConfigOnlineProdBase : public edm::ESProducer {
                          std::string& objectKey ) ;
 
       // For reading object directly from a CondDB w/o PoolDBOutputService
-      cond::DbConnection m_dbConnection ;
-      cond::DbSession m_dbSession ;
+      cond::persistency::Session m_dbSession ;
       bool m_copyFromCondDB ;
 };
 
@@ -87,7 +87,6 @@ template< class TRcd, class TData >
 L1ConfigOnlineProdBase<TRcd, TData>::L1ConfigOnlineProdBase(const edm::ParameterSet& iConfig)
    : m_omdsReader(),
      m_forceGeneration( iConfig.getParameter< bool >( "forceGeneration" ) ),
-     m_dbConnection(),
      m_dbSession(),
      m_copyFromCondDB( false )
 {
@@ -103,14 +102,12 @@ L1ConfigOnlineProdBase<TRcd, TData>::L1ConfigOnlineProdBase(const edm::Parameter
 
       if( m_copyFromCondDB )
 	{
-	  // Connect DbSession
-	  m_dbConnection.configuration().setAuthenticationPath(
+	  cond::persistency::ConnectionPool connectionPool;
+	  // Connect DB Session
+	  connectionPool.setAuthenticationPath(
 	     iConfig.getParameter< std::string >( "onlineAuthentication" ) ) ;
-	  m_dbConnection.configure() ;
-	  m_dbSession = m_dbConnection.createSession() ;
-	  m_dbSession.open(
-			   iConfig.getParameter< std::string >( "onlineDB" ),
-			   true ); // read-only
+	  connectionPool..configure() ;
+	  m_dbSession = connectionPool.createSession( iConfig.getParameter< std::string >( "onlineDB" ) ) ;
 	}
     }
   else
@@ -166,9 +163,8 @@ L1ConfigOnlineProdBase<TRcd, TData>::produce( const TRcd& iRecord )
 	 // Copied from l1t::DataWriter::readObject()
 	 if( !payloadToken.empty() )
 	   {
-	     cond::DbScopedTransaction tr( m_dbSession ) ;
-	     tr.start( true ) ; 
-	     pData = m_dbSession.getTypedObject<TData>( payloadToken ) ;
+	     m_dbSession.transaction().start() ; 
+	     pData = m_dbSession.fetchPayload<TData>( payloadToken ) ;
 	     tr.commit ();
 	   }
        }


### PR DESCRIPTION
This request contains:
- Changes to the Condition DB tools to perform the specific "translation" of L1T condition data from conddb v1 to conddb v2
- Changes to L1T specific condition code to use the new session, capable to read both conddb v1 and v2.
