### PR TITLE
fix OutputMagneticFieldDDToDDL (wasn't compiled by default)

### DIFF
--- a/DetectorDescription/OfflineDBLoader/bin/BuildFile.xml
+++ b/DetectorDescription/OfflineDBLoader/bin/BuildFile.xml
@@ -1,4 +1,4 @@
-<library   name="OutputDDToDDL" file="stubs/OutputDDToDDL.cc">
+<library   name="OutputDDToDDL" file="stubs/Output*.cc">
   <flags   EDM_PLUGIN="1"/>
   <use   name="CondCore/DBOutputService"/>
   <use   name="DetectorDescription/Core"/>
@@ -7,4 +7,5 @@
   <use   name="FWCore/ParameterSet"/>
   <use   name="FWCore/ServiceRegistry"/>
   <use   name="Geometry/Records"/>
+  <use   name="MagneticField/Records"/>
 </library>

--- a/DetectorDescription/OfflineDBLoader/bin/stubs/OutputDDToDDL.h
+++ b/DetectorDescription/OfflineDBLoader/bin/stubs/OutputDDToDDL.h
@@ -13,10 +13,12 @@
 
 class DDPartSelection;
 
+namespace {
 /// is sv1 < sv2 
 struct ddsvaluesCmp {
   bool operator() ( const  DDsvalues_type& sv1, const DDsvalues_type& sv2 );
 };
+}
 
 class OutputDDToDDL : public edm::EDAnalyzer {
 

--- a/DetectorDescription/OfflineDBLoader/bin/stubs/OutputMagneticFieldDDToDDL.cc
+++ b/DetectorDescription/OfflineDBLoader/bin/stubs/OutputMagneticFieldDDToDDL.cc
@@ -73,7 +73,7 @@ OutputMagneticFieldDDToDDL::beginRun( const edm::Run&, edm::EventSetup const& es
   std::set<DDMaterial> matStore;
   std::set<DDSolid> solStore;
   
-  std::map<DDsvalues_type, std::set<DDPartSelection*>, ddsvaluesCmp > specStore;
+  std::map<const DDsvalues_type, std::set<const DDPartSelection*>, ddsvaluesCmp > specStore;
   std::set<DDRotation> rotStore;
 
   DDCoreToDDXMLOutput out;
@@ -191,7 +191,7 @@ OutputMagneticFieldDDToDDL::beginRun( const edm::Run&, edm::EventSetup const& es
   ( *m_xos ) << "</LogicalPartSection>\n";
 
   ( *m_xos ) << std::fixed << std::setprecision( 18 );
-  std::map<DDsvalues_type, std::set<DDPartSelection*> >::const_iterator mit( specStore.begin()), mend( specStore.end());
+  std::map<DDsvalues_type, std::set<const DDPartSelection*> >::const_iterator mit( specStore.begin()), mend( specStore.end());
   ( *m_xos ) << "<SpecParSection label=\"" << ns_ << "\">\n";
   for( ; mit != mend; ++mit )
   {
@@ -239,9 +239,9 @@ OutputMagneticFieldDDToDDL::addToSolStore( const DDSolid& sol, std::set<DDSolid>
 }
 
 void
-OutputMagneticFieldDDToDDL::addToSpecStore( const DDLogicalPart& lp, std::map<DDsvalues_type, std::set<DDPartSelection*>, ddsvaluesCmp > & specStore )
+OutputMagneticFieldDDToDDL::addToSpecStore( const DDLogicalPart& lp, std::map<const DDsvalues_type, std::set<const DDPartSelection*>, ddsvaluesCmp > & specStore )
 {
-  std::vector<std::pair<DDPartSelection*, DDsvalues_type*> >::const_iterator spit( lp.attachedSpecifics().begin()), spend( lp.attachedSpecifics().end());
+  std::vector<std::pair<const DDPartSelection*, const DDsvalues_type*> >::const_iterator spit( lp.attachedSpecifics().begin()), spend( lp.attachedSpecifics().end());
   for( ; spit != spend; ++spit )
   {
     specStore[ *spit->second ].insert( spit->first );

--- a/DetectorDescription/OfflineDBLoader/bin/stubs/OutputMagneticFieldDDToDDL.h
+++ b/DetectorDescription/OfflineDBLoader/bin/stubs/OutputMagneticFieldDDToDDL.h
@@ -13,11 +13,12 @@
 
 class DDPartSelection;
 
+namespace {
 /// is sv1 < sv2 
-struct ddsvaluesCmp
-{
+struct ddsvaluesCmp {
   bool operator() ( const  DDsvalues_type& sv1, const DDsvalues_type& sv2 );
 };
+}
 
 class OutputMagneticFieldDDToDDL : public edm::EDAnalyzer
 {
@@ -32,11 +33,11 @@ public:
 private:
   void addToMatStore( const DDMaterial& mat, std::set<DDMaterial> & matStore );
   void addToSolStore( const DDSolid& sol, std::set<DDSolid> & solStore, std::set<DDRotation>& rotStore );
-  void addToSpecStore( const DDLogicalPart& lp, std::map<DDsvalues_type, std::set<DDPartSelection*>, ddsvaluesCmp > & specStore );
+  void addToSpecStore( const DDLogicalPart& lp, std::map<const DDsvalues_type, std::set<const DDPartSelection*>, ddsvaluesCmp > & specStore );
 
+  int m_rotNumSeed;
   std::string m_fname;
   std::ostream* m_xos;
-  int m_rotNumSeed;
   int m_specNameCount;
 };
 


### PR DESCRIPTION
Let bin/stubs/OutputMagneticFieldDDToDDL.cc be compiled by default (code was there, but wasn't included in the BuildFile). Also, update so that it compiles in 72X (was not updated since 71X).

This is a very minor fix that does not affect any functionality except this small module that is used to dump the MF geometry to a DB.
