### PR TITLE
preparing to use HCAL OOT pileup corrections with compatibility db fix

### DIFF
--- a/RecoLocalCalo/Configuration/python/hcalLocalReco_cff.py
+++ b/RecoLocalCalo/Configuration/python/hcalLocalReco_cff.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 from RecoLocalCalo.HcalRecAlgos.hcalRecAlgoESProd_cfi import *
+hcalOOTPileupESProducer = cms.ESProducer('OOTPileupDBCompatibilityESProducer')
 
 from RecoLocalCalo.HcalRecProducers.HcalHitReconstructor_hbhe_cfi import *
 from RecoLocalCalo.HcalRecProducers.HcalHitReconstructor_ho_cfi import *

--- a/RecoLocalCalo/HcalRecProducers/src/HcalHitReconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HcalHitReconstructor.cc
@@ -13,6 +13,7 @@
 #include "Geometry/CaloTopology/interface/HcalTopology.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "CondFormats/DataRecord/interface/HcalOOTPileupCorrectionRcd.h"
+#include "CondFormats/DataRecord/interface/HcalOOTPileupCompatibilityRcd.h"
 #include "CondFormats/HcalObjects/interface/OOTPileupCorrectionColl.h"
 #include <iostream>
 #include <fstream>
@@ -322,7 +323,10 @@ void HcalHitReconstructor::produce(edm::Event& e, const edm::EventSetup& eventSe
       if (!corrName.empty())
       {
           edm::ESHandle<OOTPileupCorrectionColl> pileupCorrections;
-          eventSetup.get<HcalOOTPileupCorrectionRcd>().get(pileupCorrections);
+          if (eventSetup.find(edm::eventsetup::EventSetupRecordKey::makeKey<HcalOOTPileupCorrectionRcd>()))
+              eventSetup.get<HcalOOTPileupCorrectionRcd>().get(pileupCorrections);
+          else
+              eventSetup.get<HcalOOTPileupCompatibilityRcd>().get(pileupCorrections);
           const std::string& cat = isData ? dataOOTCorrectionCategory_ : mcOOTCorrectionCategory_;
           (reco_.*setPileupCorrection_)(pileupCorrections->get(corrName, cat));
       }


### PR DESCRIPTION
Added the ability to read OOTPileupCorrectionColl object
from a different database record and included ESProducer
which adds relevant data to that record.

The corrections themselves are not enabled yet (pending
creation of the corresponding database records in relvals).
Therefore, no change in the output is expected for this PR.
