### PR TITLE
add delayedStandAloneMuons to SA muon reco

### DIFF
--- a/RecoMuon/Configuration/python/RecoMuonPPonly_cff.py
+++ b/RecoMuon/Configuration/python/RecoMuonPPonly_cff.py
@@ -10,6 +10,15 @@ from RecoMuon.StandAloneMuonProducer.standAloneMuons_cff import *
 refittedStandAloneMuons = standAloneMuons.clone()
 refittedStandAloneMuons.STATrajBuilderParameters.DoRefit = True
 
+# Delayed SA muons
+from RecoMuon.MuonSeedGenerator.CosmicMuonSeedProducer_cfi import *
+delayedMuonSeeds = CosmicMuonSeed.clone()
+delayedMuonSeeds.ForcePointDown = False
+
+delayedStandAloneMuons = standAloneMuons.clone()
+delayedStandAloneMuons.InputObjects = cms.InputTag("delayedMuonSeeds")
+delayedStandAloneMuons.MuonTrajectoryBuilder = cms.string("StandAloneMuonTrajectoryBuilder")
+
 # Global muon track producer
 from RecoMuon.GlobalMuonProducer.GlobalMuonProducer_cff import *
 
@@ -34,7 +43,7 @@ from RecoMuon.MuonIsolationProducers.muIsolation_cff import *
 # ---------------------------------------------------- #
 
 # Muon Tracking sequence
-standalonemuontracking = cms.Sequence(standAloneMuonSeeds*standAloneMuons*refittedStandAloneMuons)
+standalonemuontracking = cms.Sequence(standAloneMuonSeeds*standAloneMuons*refittedStandAloneMuons*delayedMuonSeeds*delayedStandAloneMuons)
 globalmuontracking = cms.Sequence(globalMuons*tevMuons)
 muontracking = cms.Sequence(standalonemuontracking*globalmuontracking)
 

--- a/RecoMuon/Configuration/python/RecoMuonPPonly_cff.py
+++ b/RecoMuon/Configuration/python/RecoMuonPPonly_cff.py
@@ -10,14 +10,14 @@ from RecoMuon.StandAloneMuonProducer.standAloneMuons_cff import *
 refittedStandAloneMuons = standAloneMuons.clone()
 refittedStandAloneMuons.STATrajBuilderParameters.DoRefit = True
 
-# Delayed SA muons
+# Displaced SA muons
 from RecoMuon.MuonSeedGenerator.CosmicMuonSeedProducer_cfi import *
-delayedMuonSeeds = CosmicMuonSeed.clone()
-delayedMuonSeeds.ForcePointDown = False
+displacedMuonSeeds = CosmicMuonSeed.clone()
+displacedMuonSeeds.ForcePointDown = False
 
-delayedStandAloneMuons = standAloneMuons.clone()
-delayedStandAloneMuons.InputObjects = cms.InputTag("delayedMuonSeeds")
-delayedStandAloneMuons.MuonTrajectoryBuilder = cms.string("StandAloneMuonTrajectoryBuilder")
+displacedStandAloneMuons = standAloneMuons.clone()
+displacedStandAloneMuons.InputObjects = cms.InputTag("displacedMuonSeeds")
+displacedStandAloneMuons.MuonTrajectoryBuilder = cms.string("StandAloneMuonTrajectoryBuilder")
 
 # Global muon track producer
 from RecoMuon.GlobalMuonProducer.GlobalMuonProducer_cff import *
@@ -43,7 +43,7 @@ from RecoMuon.MuonIsolationProducers.muIsolation_cff import *
 # ---------------------------------------------------- #
 
 # Muon Tracking sequence
-standalonemuontracking = cms.Sequence(standAloneMuonSeeds*standAloneMuons*refittedStandAloneMuons*delayedMuonSeeds*delayedStandAloneMuons)
+standalonemuontracking = cms.Sequence(standAloneMuonSeeds*standAloneMuons*refittedStandAloneMuons*displacedMuonSeeds*displacedStandAloneMuons)
 globalmuontracking = cms.Sequence(globalMuons*tevMuons)
 muontracking = cms.Sequence(standalonemuontracking*globalmuontracking)
 

--- a/RecoMuon/Configuration/python/RecoMuonPPonly_cff.py
+++ b/RecoMuon/Configuration/python/RecoMuonPPonly_cff.py
@@ -18,6 +18,7 @@ displacedMuonSeeds.ForcePointDown = False
 displacedStandAloneMuons = standAloneMuons.clone()
 displacedStandAloneMuons.InputObjects = cms.InputTag("displacedMuonSeeds")
 displacedStandAloneMuons.MuonTrajectoryBuilder = cms.string("StandAloneMuonTrajectoryBuilder")
+displacedStandAloneMuons.TrackLoaderParameters.VertexConstraint = cms.bool(False) 
 
 # Global muon track producer
 from RecoMuon.GlobalMuonProducer.GlobalMuonProducer_cff import *

--- a/RecoMuon/Configuration/python/RecoMuon_EventContent_cff.py
+++ b/RecoMuon/Configuration/python/RecoMuon_EventContent_cff.py
@@ -49,7 +49,7 @@ RecoMuonAOD = cms.PSet(
                                            'keep recoTracks_refittedStandAloneMuons_*_*', 
                                            'keep recoTrackExtras_refittedStandAloneMuons_*_*', 
                                            'keep TrackingRecHitsOwned_refittedStandAloneMuons_*_*',
-                                           'keep recoTracks_displacedStandAloneMuons_*_*',
+                                           'keep recoTracks_displacedStandAloneMuons__*',
                                            'keep recoTrackExtras_displacedStandAloneMuons_*_*',
                                            'keep TrackingRecHitsOwned_displacedStandAloneMuons_*_*'
                                            )

--- a/RecoMuon/Configuration/python/RecoMuon_EventContent_cff.py
+++ b/RecoMuon/Configuration/python/RecoMuon_EventContent_cff.py
@@ -48,13 +48,17 @@ RecoMuonAOD = cms.PSet(
                                            # Additional tracks
                                            'keep recoTracks_refittedStandAloneMuons_*_*', 
                                            'keep recoTrackExtras_refittedStandAloneMuons_*_*', 
-                                           'keep TrackingRecHitsOwned_refittedStandAloneMuons_*_*' 
+                                           'keep TrackingRecHitsOwned_refittedStandAloneMuons_*_*',
+                                           'keep recoTracks_delayedStandAloneMuons_*_*',
+                                           'keep recoTrackExtras_delayedStandAloneMuons_*_*',
+                                           'keep TrackingRecHitsOwned_delayedStandAloneMuons_*_*'
                                            )
 )
 # RECO content
 RecoMuonRECO = cms.PSet(
     outputCommands = cms.untracked.vstring('keep *_MuonSeed_*_*',
                                            'keep *_ancientMuonSeed_*_*',
+                                           'keep *_delayedMuonSeed_*_*',
                                            'keep *_mergedStandAloneMuonSeeds_*_*',
                                            'keep TrackingRecHitsOwned_globalMuons_*_*', 
                                            'keep TrackingRecHitsOwned_tevMuons_*_*',

--- a/RecoMuon/Configuration/python/RecoMuon_EventContent_cff.py
+++ b/RecoMuon/Configuration/python/RecoMuon_EventContent_cff.py
@@ -49,16 +49,16 @@ RecoMuonAOD = cms.PSet(
                                            'keep recoTracks_refittedStandAloneMuons_*_*', 
                                            'keep recoTrackExtras_refittedStandAloneMuons_*_*', 
                                            'keep TrackingRecHitsOwned_refittedStandAloneMuons_*_*',
-                                           'keep recoTracks_delayedStandAloneMuons_*_*',
-                                           'keep recoTrackExtras_delayedStandAloneMuons_*_*',
-                                           'keep TrackingRecHitsOwned_delayedStandAloneMuons_*_*'
+                                           'keep recoTracks_displacedStandAloneMuons_*_*',
+                                           'keep recoTrackExtras_displacedStandAloneMuons_*_*',
+                                           'keep TrackingRecHitsOwned_displacedStandAloneMuons_*_*'
                                            )
 )
 # RECO content
 RecoMuonRECO = cms.PSet(
     outputCommands = cms.untracked.vstring('keep *_MuonSeed_*_*',
                                            'keep *_ancientMuonSeed_*_*',
-                                           'keep *_delayedMuonSeed_*_*',
+                                           'keep *_displacedMuonSeeds_*_*',
                                            'keep *_mergedStandAloneMuonSeeds_*_*',
                                            'keep TrackingRecHitsOwned_globalMuons_*_*', 
                                            'keep TrackingRecHitsOwned_tevMuons_*_*',

--- a/RecoMuon/MuonSeedGenerator/plugins/CosmicMuonSeedGenerator.cc
+++ b/RecoMuon/MuonSeedGenerator/plugins/CosmicMuonSeedGenerator.cc
@@ -360,8 +360,11 @@ std::vector<TrajectorySeed> CosmicMuonSeedGenerator::createSeed(const MuonRecHit
   LogTrace(category) << "The RecSegment relies on: ";
   LogTrace(category) << dumper.dumpMuonId(hit->geographicalId());
 
-  result.push_back( tsosToSeed(tsos, hit->geographicalId().rawId()) ); 
-  result.push_back( tsosToSeed(tsos2, hit->geographicalId().rawId()) );
+  edm::OwnVector<TrackingRecHit> container; 
+  container.push_back(hit->hit()->clone());
+
+  result.push_back( tsosToSeed(tsos, hit->geographicalId().rawId(), container) );
+  result.push_back( tsosToSeed(tsos2, hit->geographicalId().rawId(), container) );
 
   return result;
 }
@@ -513,18 +516,25 @@ std::vector<TrajectorySeed> CosmicMuonSeedGenerator::createSeed(const CosmicMuon
   LogTrace(category)<<"pos: " << tsos.globalPosition(); 
   LogTrace(category) << "The RecSegment relies on: ";
   LogTrace(category) << dumper.dumpMuonId(hit->geographicalId());
-
-  result.push_back( tsosToSeed(tsos, hit->geographicalId().rawId()) );
-
-   return result;
+  
+  edm::OwnVector<TrackingRecHit> container; 
+  container.push_back(hitpair.first->hit()->clone()); 
+  container.push_back(hitpair.second->hit()->clone());
+  
+  result.push_back( tsosToSeed(tsos, hit->geographicalId().rawId(), container) );
+  
+  return result;
 }
 
 TrajectorySeed CosmicMuonSeedGenerator::tsosToSeed(const TrajectoryStateOnSurface& tsos, uint32_t id) const {
 
-  PTrajectoryStateOnDet const & seedTSOS = trajectoryStateTransform::persistentState(tsos, id);
-
   edm::OwnVector<TrackingRecHit> container;
+  return tsosToSeed(tsos, id, container); 
+}
+
+TrajectorySeed CosmicMuonSeedGenerator::tsosToSeed(const TrajectoryStateOnSurface& tsos, uint32_t id, edm::OwnVector<TrackingRecHit>& container) const {
+ 
+  PTrajectoryStateOnDet const & seedTSOS = trajectoryStateTransform::persistentState(tsos, id);
   TrajectorySeed seed(seedTSOS,container,alongMomentum);
   return seed;
 }
-

--- a/RecoMuon/MuonSeedGenerator/plugins/CosmicMuonSeedGenerator.cc
+++ b/RecoMuon/MuonSeedGenerator/plugins/CosmicMuonSeedGenerator.cc
@@ -59,6 +59,8 @@ CosmicMuonSeedGenerator::CosmicMuonSeedGenerator(const edm::ParameterSet& pset){
   theMaxDTChi2 = pset.getParameter<double>("MaxDTChi2");
   theMaxCSCChi2 = pset.getParameter<double>("MaxCSCChi2");
 
+  theForcePointDownFlag = pset.getUntrackedParameter<bool>("ForcePointDown",true);
+
   // pre-determined parameters for seed pt calculation ( pt * dphi )
   theParameters["topmb41"] = 0.87;
   theParameters["bottommb41"] = 1.2;
@@ -323,11 +325,12 @@ std::vector<TrajectorySeed> CosmicMuonSeedGenerator::createSeed(const MuonRecHit
                                              hit->globalDirection().phi(),
                                              1.));
   // Force all track downward for cosmic, not beam-halo
-  if (hit->geographicalId().subdetId() == MuonSubdetId::DT && fabs(hit->globalDirection().eta()) < 4.0 && hit->globalDirection().phi() > 0 ) 
-    polar = - polar;
+  if(theForcePointDownFlag){
+    if (hit->geographicalId().subdetId() == MuonSubdetId::DT && fabs(hit->globalDirection().eta()) < 4.0 && hit->globalDirection().phi() > 0 ) 
+      polar = - polar;
 
-  if (hit->geographicalId().subdetId() == MuonSubdetId::CSC && fabs(hit->globalDirection().eta()) > 2.3 ) {
-    polar = - polar;
+    if (hit->geographicalId().subdetId() == MuonSubdetId::CSC && fabs(hit->globalDirection().eta()) > 2.3 ) 
+      polar = - polar;
   }
 
   polar *=fabs(pt)/polar.perp();
@@ -480,11 +483,12 @@ std::vector<TrajectorySeed> CosmicMuonSeedGenerator::createSeed(const CosmicMuon
                                              hit->globalDirection().phi(),
                                              1.));
   // Force all track downward for cosmic, not beam-halo
-  if (hit->geographicalId().subdetId() == MuonSubdetId::DT && fabs(hit->globalDirection().eta()) < 4.0 && hit->globalDirection().phi() > 0 ) 
-    polar = - polar;
+  if(theForcePointDownFlag){
+    if (hit->geographicalId().subdetId() == MuonSubdetId::DT && fabs(hit->globalDirection().eta()) < 4.0 && hit->globalDirection().phi() > 0 ) 
+      polar = - polar;
 
-  if (hit->geographicalId().subdetId() == MuonSubdetId::CSC && fabs(hit->globalDirection().eta()) > 2.3 ) {
-    polar = - polar;
+    if (hit->geographicalId().subdetId() == MuonSubdetId::CSC && fabs(hit->globalDirection().eta()) > 2.3 )
+      polar = - polar;
   }
 
   polar *=fabs(pt)/polar.perp();

--- a/RecoMuon/MuonSeedGenerator/plugins/CosmicMuonSeedGenerator.cc
+++ b/RecoMuon/MuonSeedGenerator/plugins/CosmicMuonSeedGenerator.cc
@@ -59,7 +59,7 @@ CosmicMuonSeedGenerator::CosmicMuonSeedGenerator(const edm::ParameterSet& pset){
   theMaxDTChi2 = pset.getParameter<double>("MaxDTChi2");
   theMaxCSCChi2 = pset.getParameter<double>("MaxCSCChi2");
 
-  theForcePointDownFlag = pset.getUntrackedParameter<bool>("ForcePointDown",true);
+  theForcePointDownFlag = pset.existsAs<bool>("ForcePointDown") ? pset.getParameter<bool>("ForcePointDown") : true;
 
   // pre-determined parameters for seed pt calculation ( pt * dphi )
   theParameters["topmb41"] = 0.87;

--- a/RecoMuon/MuonSeedGenerator/plugins/CosmicMuonSeedGenerator.h
+++ b/RecoMuon/MuonSeedGenerator/plugins/CosmicMuonSeedGenerator.h
@@ -77,6 +77,7 @@ class CosmicMuonSeedGenerator: public edm::stream::EDProducer<> {
                                          const edm::EventSetup&) const;
 
   TrajectorySeed tsosToSeed(const TrajectoryStateOnSurface&, uint32_t) const;
+  TrajectorySeed tsosToSeed(const TrajectoryStateOnSurface&, uint32_t, edm::OwnVector<TrackingRecHit>&) const;
 
   /// check if two rechits are correlated
   bool areCorrelated(const MuonTransientTrackingRecHit::MuonRecHitPointer&,

--- a/RecoMuon/MuonSeedGenerator/plugins/CosmicMuonSeedGenerator.h
+++ b/RecoMuon/MuonSeedGenerator/plugins/CosmicMuonSeedGenerator.h
@@ -112,6 +112,7 @@ class CosmicMuonSeedGenerator: public edm::stream::EDProducer<> {
   /// the maximum chi2 required for dt and csc rechits
   double theMaxDTChi2;
   double theMaxCSCChi2;
+  bool theForcePointDownFlag;
   edm::ESHandle<MuonDetLayerGeometry> theMuonLayers;
   edm::ESHandle<MagneticField> theField;
 

--- a/RecoMuon/MuonSeedGenerator/python/CosmicMuonSeedProducer_cfi.py
+++ b/RecoMuon/MuonSeedGenerator/python/CosmicMuonSeedProducer_cfi.py
@@ -8,7 +8,7 @@ CosmicMuonSeed = cms.EDProducer("CosmicMuonSeedGenerator",
     MaxDTChi2 = cms.double(300.0),
     DTRecSegmentLabel = cms.InputTag("dt4DSegments"),
     EnableCSCMeasurement = cms.bool(True),
-    ForcePointDown = cms.untracked.bool(True)
+    ForcePointDown = cms.bool(True)
 )
 
 

--- a/RecoMuon/MuonSeedGenerator/python/CosmicMuonSeedProducer_cfi.py
+++ b/RecoMuon/MuonSeedGenerator/python/CosmicMuonSeedProducer_cfi.py
@@ -7,7 +7,8 @@ CosmicMuonSeed = cms.EDProducer("CosmicMuonSeedGenerator",
     MaxCSCChi2 = cms.double(300.0),
     MaxDTChi2 = cms.double(300.0),
     DTRecSegmentLabel = cms.InputTag("dt4DSegments"),
-    EnableCSCMeasurement = cms.bool(True)
+    EnableCSCMeasurement = cms.bool(True),
+    ForcePointDown = cms.untracked.bool(True)
 )
 
 

--- a/Validation/RecoMuon/python/associators_cff.py
+++ b/Validation/RecoMuon/python/associators_cff.py
@@ -41,6 +41,10 @@ seedsOfSTAmuons = SimMuon.MCTruth.SeedToTrackProducer_cfi.SeedToTrackProducer.cl
 seedsOfSTAmuons.L2seedsCollection = cms.InputTag("ancientMuonSeed")
 seedsOfSTAmuons_seq = cms.Sequence( seedsOfSTAmuons )
 
+seedsOfDisplacedSTAmuons = SimMuon.MCTruth.SeedToTrackProducer_cfi.SeedToTrackProducer.clone()
+seedsOfDisplacedSTAmuons.L2seedsCollection = cms.InputTag("displacedMuonSeeds")
+seedsOfDisplacedSTAmuons_seq = cms.Sequence( seedsOfDisplacedSTAmuons )
+
 # select probe tracks
 import PhysicsTools.RecoAlgos.recoTrackSelector_cfi
 probeTracks = PhysicsTools.RecoAlgos.recoTrackSelector_cfi.recoTrackSelector.clone()
@@ -163,6 +167,8 @@ tpToStaUpdMuonAssociation = SimMuon.MCTruth.MuonAssociatorByHits_cfi.muonAssocia
 tpToGlbMuonAssociation = SimMuon.MCTruth.MuonAssociatorByHits_cfi.muonAssociatorByHits.clone()
 tpToStaRefitMuonAssociation = SimMuon.MCTruth.MuonAssociatorByHits_cfi.muonAssociatorByHits.clone()
 tpToStaRefitUpdMuonAssociation = SimMuon.MCTruth.MuonAssociatorByHits_cfi.muonAssociatorByHits.clone()
+tpToDisplacedStaSeedAssociation = SimMuon.MCTruth.MuonAssociatorByHits_cfi.muonAssociatorByHits.clone()
+tpToDisplacedStaMuonAssociation = SimMuon.MCTruth.MuonAssociatorByHits_cfi.muonAssociatorByHits.clone()
 tpToStaSETMuonAssociation = SimMuon.MCTruth.MuonAssociatorByHits_cfi.muonAssociatorByHits.clone()
 tpToStaSETUpdMuonAssociation = SimMuon.MCTruth.MuonAssociatorByHits_cfi.muonAssociatorByHits.clone()
 tpToGlbSETMuonAssociation = SimMuon.MCTruth.MuonAssociatorByHits_cfi.muonAssociatorByHits.clone()
@@ -210,6 +216,16 @@ tpToStaRefitUpdMuonAssociation.tpTag = 'mix:MergedTrackTruth'
 tpToStaRefitUpdMuonAssociation.tracksTag = 'refittedStandAloneMuons:UpdatedAtVtx'
 tpToStaRefitUpdMuonAssociation.UseTracker = False
 tpToStaRefitUpdMuonAssociation.UseMuon = True
+
+tpToDisplacedStaSeedAssociation.tpTag = 'mix:MergedTrackTruth'
+tpToDisplacedStaSeedAssociation.tracksTag = 'seedsOfDisplacedSTAmuons'
+tpToDisplacedStaSeedAssociation.UseTracker = False
+tpToDisplacedStaSeedAssociation.UseMuon = True
+
+tpToDisplacedStaMuonAssociation.tpTag = 'mix:MergedTrackTruth'
+tpToDisplacedStaMuonAssociation.tracksTag = 'displacedStandAloneMuons'
+tpToDisplacedStaMuonAssociation.UseTracker = False
+tpToDisplacedStaMuonAssociation.UseMuon = True
 
 tpToStaSETMuonAssociation.tpTag = 'mix:MergedTrackTruth'
 tpToStaSETMuonAssociation.tracksTag = 'standAloneSETMuons'
@@ -329,6 +345,9 @@ muonAssociation_seq = cms.Sequence(
 muonAssociationTEV_seq = cms.Sequence(
     (tpToTevFirstMuonAssociation+tpToTevPickyMuonAssociation+tpToTevDytMuonAssociation)
 #    +(tpToTevFirstTrackAssociation+tpToTevPickyTrackAssociation)
+)
+muonAssociationDisplaced_seq = cms.Sequence(seedsOfDisplacedSTAmuons_seq
+ +(tpToDisplacedStaSeedAssociation+tpToDisplacedStaMuonAssociation)
 )
 muonAssociationRefit_seq = cms.Sequence(
     (tpToStaRefitMuonAssociation+tpToStaRefitUpdMuonAssociation)

--- a/Validation/RecoMuon/python/muonValidation_cff.py
+++ b/Validation/RecoMuon/python/muonValidation_cff.py
@@ -148,6 +148,20 @@ staRefitUpdMuonTrackVMuonAssoc.label = ('refittedStandAloneMuons:UpdatedAtVtx',)
 staRefitUpdMuonTrackVMuonAssoc.usetracker = False
 staRefitUpdMuonTrackVMuonAssoc.usemuon = True
 
+displacedStaSeedTrackVMuonAssoc = Validation.RecoMuon.MuonTrackValidator_cfi.muonTrackValidator.clone()
+displacedStaSeedTrackVMuonAssoc.associatormap = 'tpToDisplacedStaSeedAssociation'
+displacedStaSeedTrackVMuonAssoc.associators = ('MuonAssociationByHits',)
+displacedStaSeedTrackVMuonAssoc.label = ('seedsOfDisplacedSTAmuons',)
+displacedStaSeedTrackVMuonAssoc.usetracker = False
+displacedStaSeedTrackVMuonAssoc.usemuon = True
+
+displacedStaMuonTrackVMuonAssoc = Validation.RecoMuon.MuonTrackValidator_cfi.muonTrackValidator.clone()
+displacedStaMuonTrackVMuonAssoc.associatormap = 'tpToDisplacedStaMuonAssociation'
+displacedStaMuonTrackVMuonAssoc.associators = ('MuonAssociationByHits',)
+displacedStaMuonTrackVMuonAssoc.label = ('displacedStandAloneMuons',)
+displacedStaMuonTrackVMuonAssoc.usetracker = False
+displacedStaMuonTrackVMuonAssoc.usemuon = True
+
 staSETMuonTrackVMuonAssoc = Validation.RecoMuon.MuonTrackValidator_cfi.muonTrackValidator.clone()
 staSETMuonTrackVMuonAssoc.associatormap = 'tpToStaSETMuonAssociation'
 staSETMuonTrackVMuonAssoc.associators = ('MuonAssociationByHits',)
@@ -326,6 +340,9 @@ muonValidationTEV_seq = cms.Sequence(tevMuonFirstTrackVMuonAssoc+tevMuonPickyTra
 
 muonValidationRefit_seq = cms.Sequence(staRefitMuonTrackVMuonAssoc+staRefitUpdMuonTrackVMuonAssoc)
 
+muonValidationDisplaced_seq = cms.Sequence(displacedStaSeedTrackVMuonAssoc+
+ displacedStaMuonTrackVMuonAssoc)
+
 muonValidationSET_seq = cms.Sequence(staSETMuonTrackVMuonAssoc+staSETUpdMuonTrackVMuonAssoc+glbSETMuonTrackVMuonAssoc)
 
 muonValidationCosmic_seq = cms.Sequence(trkCosmicMuonTrackVTrackAssoc
@@ -337,6 +354,7 @@ recoMuonValidation = cms.Sequence((muonAssociation_seq*muonValidation_seq)
                                  +(muonAssociationTEV_seq*muonValidationTEV_seq)
                                  +(muonAssociationSET_seq*muonValidationSET_seq)
                                  +(muonAssociationRefit_seq*muonValidationRefit_seq)
+                                 +(muonAssociationDisplaced_seq*muonValidationDisplaced_seq)
                                  )
 
 recoCosmicMuonValidation = cms.Sequence(muonAssociationCosmic_seq*muonValidationCosmic_seq)


### PR DESCRIPTION
Adds displacedStandAloneMuons collection, intended to improve the pt bias for displaced muons reconstructed in the muon system only. Uses a combination of the cosmic seed and standalone trajectory building.
