### PR TITLE
Allow std::unique_ptr when calling Run/Lumi/Event::put

### DIFF
--- a/DataFormats/Common/interface/Wrapper.h
+++ b/DataFormats/Common/interface/Wrapper.h
@@ -17,7 +17,6 @@ Wrapper: A template wrapper around EDProducts to hold the product ID.
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Utilities/interface/GCC11Compatibility.h"
 #include "FWCore/Utilities/interface/Visibility.h"
-
 #include "boost/mpl/if.hpp"
 
 #include <algorithm>
@@ -32,7 +31,9 @@ namespace edm {
     typedef T value_type;
     typedef T wrapped_type;  // used with the dictionary to identify Wrappers
     Wrapper() : WrapperBase(), present(false), obj() {}
-    explicit Wrapper(std::auto_ptr<T> ptr);
+#ifndef __GCCXML__
+    explicit Wrapper(std::unique_ptr<T> ptr);
+#endif
     virtual ~Wrapper() {}
     T const* product() const {return (present ? &obj : 0);}
     T const* operator->() const {return product();}
@@ -275,8 +276,9 @@ namespace edm {
 #endif
   }
 
+#ifndef __GCCXML__
   template <typename T>
-  Wrapper<T>::Wrapper(std::auto_ptr<T> ptr) :
+  Wrapper<T>::Wrapper(std::unique_ptr<T> ptr) :
     WrapperBase(),
     present(ptr.get() != 0),
     obj() {
@@ -295,7 +297,7 @@ namespace edm {
   WrapperBase(),
   present(ptr != 0),
   obj() {
-     std::auto_ptr<T> temp(ptr);
+     std::unique_ptr<T> temp(ptr);
      if (present) {
         // The following will call swap if T has such a function,
         // and use assignment if T has no such function.
@@ -306,6 +308,7 @@ namespace edm {
      }
 
   }
+#endif
 
 #ifndef __GCCXML__
   template <typename T>

--- a/DataFormats/Common/test/DetSetVector_t.cpp
+++ b/DataFormats/Common/test/DetSetVector_t.cpp
@@ -193,8 +193,8 @@ void refTest() {
   c.insert(d1);
   c.post_insert();
 
-  std::auto_ptr<coll_type> pC(new coll_type(c));
-  edm::Wrapper<coll_type> wrapper(pC);
+  std::unique_ptr<coll_type> pC(new coll_type(c));
+  edm::Wrapper<coll_type> wrapper(std::move(pC));
   DSVGetter<coll_type> theGetter;
   theGetter.prod_ = &wrapper;
 

--- a/DataFormats/Common/test/Ref_t.cpp
+++ b/DataFormats/Common/test/Ref_t.cpp
@@ -71,10 +71,10 @@ void TestRef::nondefault_ctor() {
   edm::ProductID id(1, 201U);
   CPPUNIT_ASSERT(id.isValid());
 
-  std::auto_ptr<product1_t> prod(new product1_t);
+  std::unique_ptr<product1_t> prod(new product1_t);
   prod->push_back(1);
   prod->push_back(2);
-  getter.addProduct(id, prod);
+  getter.addProduct(id, std::move(prod));
 
   ref1_t ref0(id, 0, &getter);
   CPPUNIT_ASSERT(ref0.isNull()==false);
@@ -127,10 +127,10 @@ void TestRef::using_wrong_productid() {
   edm::ProductID id(1, 1U);
   CPPUNIT_ASSERT(id.isValid());
 
-  std::auto_ptr<product1_t> prod(new product1_t);
+  std::unique_ptr<product1_t> prod(new product1_t);
   prod->push_back(1);
   prod->push_back(2);
-  getter.addProduct(id, prod);
+  getter.addProduct(id, std::move(prod));
 
   edm::ProductID wrong_id(1, 100U);
   CPPUNIT_ASSERT(wrong_id.isValid()); // its valid, but not used.

--- a/DataFormats/Common/test/SimpleEDProductGetter.h
+++ b/DataFormats/Common/test/SimpleEDProductGetter.h
@@ -14,9 +14,9 @@ public:
 
   template<typename T>
   void
-  addProduct(edm::ProductID const& id, std::auto_ptr<T> p) {
+  addProduct(edm::ProductID const& id, std::unique_ptr<T> p) {
     typedef edm::Wrapper<T> wrapper_t;
-    std::shared_ptr<wrapper_t> product = std::make_shared<wrapper_t>(p);
+    std::shared_ptr<wrapper_t> product = std::make_shared<wrapper_t>(std::move(p));
     database[id] = product;
   }
 

--- a/DataFormats/Common/test/Wrapper_t.cpp
+++ b/DataFormats/Common/test/Wrapper_t.cpp
@@ -31,18 +31,18 @@ class SwappyNoCopy
 
 void work()
 {
-  std::auto_ptr<CopyNoSwappy> thing(new CopyNoSwappy);
-  edm::Wrapper<CopyNoSwappy> wrap(thing);
+  std::unique_ptr<CopyNoSwappy> thing(new CopyNoSwappy);
+  edm::Wrapper<CopyNoSwappy> wrap(std::move(thing));
 
-  std::auto_ptr<SwappyNoCopy> thing2(new SwappyNoCopy);
-  edm::Wrapper<SwappyNoCopy> wrap2(thing2);
+  std::unique_ptr<SwappyNoCopy> thing2(new SwappyNoCopy);
+  edm::Wrapper<SwappyNoCopy> wrap2(std::move(thing2));
 
 
-  std::auto_ptr<std::vector<double> >
+  std::unique_ptr<std::vector<double> >
     thing3(new std::vector<double>(10,2.2));
   assert(thing3->size() == 10);
 
-  edm::Wrapper<std::vector<double> > wrap3(thing3);
+  edm::Wrapper<std::vector<double> > wrap3(std::move(thing3));
   assert(wrap3->size() == 10);
   assert(thing3.get() == 0);
 }

--- a/DataFormats/Common/test/ptr_t.cppunit.cc
+++ b/DataFormats/Common/test/ptr_t.cppunit.cc
@@ -301,12 +301,12 @@ namespace {
 
 void testPtr::getTest() {
    typedef std::vector<IntValue> IntCollection;
-   std::auto_ptr<IntCollection> ptr(new IntCollection);
+   std::unique_ptr<IntCollection> ptr(new IntCollection);
 
    ptr->push_back(0);
    ptr->push_back(1);
 
-   edm::Wrapper<IntCollection> wrapper(ptr);
+   edm::Wrapper<IntCollection> wrapper(std::move(ptr));
    TestGetter tester;
    tester.hold_ = &wrapper;
 
@@ -332,14 +332,14 @@ void testPtr::getTest() {
 
    {
      typedef std::vector<IntValue2> SDCollection;
-     std::auto_ptr<SDCollection> ptr(new SDCollection);
+     std::unique_ptr<SDCollection> ptr(new SDCollection);
      
      ptr->push_back(IntValue2(0));
      ptr->back().value_ = 0;
      ptr->push_back(IntValue2(1));
      ptr->back().value_ = 1;
      
-     edm::Wrapper<SDCollection> wrapper(ptr);
+     edm::Wrapper<SDCollection> wrapper(std::move(ptr));
      TestGetter tester;
      tester.hold_ = &wrapper;
      

--- a/DataFormats/Common/test/ptrvector_t.cppunit.cc
+++ b/DataFormats/Common/test/ptrvector_t.cppunit.cc
@@ -143,14 +143,14 @@ void
 testPtrVector::get() {
   using namespace test_with_dictionaries;
   typedef std::vector<IntValue> IntCollection;
-  std::auto_ptr<IntCollection> ptr(new IntCollection);
+  std::unique_ptr<IntCollection> ptr(new IntCollection);
 
   ptr->push_back(0);
   ptr->push_back(1);
   ptr->push_back(2);
   ptr->push_back(3);
 
-  edm::Wrapper<IntCollection> wrapper(ptr);
+  edm::Wrapper<IntCollection> wrapper(std::move(ptr));
   TestGetter tester;
   tester.hold_ = &wrapper;
 

--- a/DataFormats/Common/test/ref_t.cppunit.cc
+++ b/DataFormats/Common/test/ref_t.cppunit.cc
@@ -176,12 +176,12 @@ namespace {
 
 void testRef::getTest() {
    typedef std::vector<IntValue> IntCollection;
-   std::auto_ptr<IntCollection> ptr(new IntCollection);
+   std::unique_ptr<IntCollection> ptr(new IntCollection);
 
    ptr->push_back(0);
    ptr->push_back(1);
 
-   edm::Wrapper<IntCollection> wrapper(ptr);
+   edm::Wrapper<IntCollection> wrapper(std::move(ptr));
    TestGetter tester;
    tester.hold_ = &wrapper;
 

--- a/DataFormats/Common/test/reftobaseprod_t.cppunit.cc
+++ b/DataFormats/Common/test/reftobaseprod_t.cppunit.cc
@@ -188,12 +188,12 @@ namespace {
 
 void testRefToBaseProd::getTest() {
    typedef std::vector<IntValue> IntCollection;
-   std::auto_ptr<IntCollection> ptr(new IntCollection);
+   std::unique_ptr<IntCollection> ptr(new IntCollection);
 
    ptr->push_back(0);
    ptr->push_back(1);
 
-   edm::Wrapper<IntCollection> wrapper(ptr);
+   edm::Wrapper<IntCollection> wrapper(std::move(ptr));
    TestGetter tester;
    tester.hold_ = &wrapper;
 
@@ -228,14 +228,14 @@ void testRefToBaseProd::getTest() {
 
    {
       typedef std::vector<IntValue2> SDCollection;
-      std::auto_ptr<SDCollection> ptr(new SDCollection);
+      std::unique_ptr<SDCollection> ptr(new SDCollection);
 
       ptr->push_back(IntValue2(0));
       ptr->back().value_ = 0;
       ptr->push_back(IntValue2(1));
       ptr->back().value_ = 1;
 
-      edm::Wrapper<SDCollection> wrapper(ptr);
+      edm::Wrapper<SDCollection> wrapper(std::move(ptr));
       TestGetter tester;
       tester.hold_ = &wrapper;
 

--- a/FWCore/Framework/interface/LuminosityBlock.h
+++ b/FWCore/Framework/interface/LuminosityBlock.h
@@ -103,10 +103,18 @@ namespace edm {
     void
     put(std::auto_ptr<PROD> product) {put<PROD>(product, std::string());}
 
+    template <typename PROD>
+    void
+    put(std::unique_ptr<PROD> product) {put<PROD>(product, std::string());}
+
     ///Put a new product with a 'product instance name'
     template <typename PROD>
     void
     put(std::auto_ptr<PROD> product, std::string const& productInstanceName);
+
+    template <typename PROD>
+    void
+    put(std::unique_ptr<PROD> product, std::string const& productInstanceName);
 
     Provenance
     getProvenance(BranchID const& theID) const;
@@ -162,6 +170,12 @@ namespace edm {
   template <typename PROD>
   void
   LuminosityBlock::put(std::auto_ptr<PROD> product, std::string const& productInstanceName) {
+    put(std::unique_ptr<PROD>(product.release()),productInstanceName);
+  }
+
+  template <typename PROD>
+  void
+  LuminosityBlock::put(std::unique_ptr<PROD> product, std::string const& productInstanceName) {
     if(product.get() == 0) {                // null pointer is illegal
       TypeID typeID(typeid(PROD));
       principal_get_adapter_detail::throwOnPutOfNullProduct("LuminosityBlock", typeID, productInstanceName);
@@ -177,7 +191,7 @@ namespace edm {
     BranchDescription const& desc =
       provRecorder_.getBranchDescription(TypeID(*product), productInstanceName);
 
-    std::unique_ptr<Wrapper<PROD> > wp(new Wrapper<PROD>(product));
+    std::unique_ptr<Wrapper<PROD> > wp(new Wrapper<PROD>(std::move(product)));
     putProducts().emplace_back(std::move(wp), &desc);
 
     // product.release(); // The object has been copied into the Wrapper.

--- a/FWCore/Framework/interface/PrincipalGetAdapter.h
+++ b/FWCore/Framework/interface/PrincipalGetAdapter.h
@@ -41,19 +41,19 @@ event.getByLabel("market", "apple", fruits);
 Putting Data
 
 \code
-std::auto_ptr<AppleCollection> pApples(new AppleCollection);
+std::unique_ptr<AppleCollection> pApples(new AppleCollection);
   
 //fill the collection
 ...
-event.put(pApples);
+event.put(std::move(pApples));
 \endcode
 
 \code
-std::auto_ptr<FruitCollection> pFruits(new FruitCollection);
+std::unique_ptr<FruitCollection> pFruits(new FruitCollection);
 
 //fill the collection
 ...
-event.put("apple", pFruits);
+event.put("apple", std::move(pFruits));
 \endcode
 
 
@@ -63,7 +63,7 @@ NOTE: The edm::RefProd returned will not work until after the
 edm::PrincipalGetAdapter has been committed (which happens after the
 EDProducer::produce method has ended)
 \code
-std::auto_ptr<AppleCollection> pApples(new AppleCollection);
+std::unique_ptr<AppleCollection> pApples(new AppleCollection);
 
 edm::RefProd<AppleCollection> refApples = event.getRefBeforePut<AppleCollection>();
 

--- a/FWCore/Framework/src/TriggerResultInserter.cc
+++ b/FWCore/Framework/src/TriggerResultInserter.cc
@@ -22,9 +22,9 @@ namespace edm
 
   void TriggerResultInserter::produce(StreamID id, edm::Event& e, edm::EventSetup const&) const
   {
-    std::auto_ptr<TriggerResults>
+    std::unique_ptr<TriggerResults>
       results(new TriggerResults(*resultsPerStream_[id.value()], pset_id_));
 
-    e.put(results);
+    e.put(std::move(results));
   }
 }

--- a/FWCore/Framework/test/Event_t.cpp
+++ b/FWCore/Framework/test/Event_t.cpp
@@ -144,7 +144,7 @@ class testEvent: public CppUnit::TestFixture {
   }
 
   template <class T>
-  ProductID addProduct(std::auto_ptr<T> product,
+  ProductID addProduct(std::unique_ptr<T> product,
                        std::string const& tag,
                        std::string const& productLabel = std::string());
 
@@ -214,7 +214,7 @@ testEvent::registerProduct(std::string const& tag,
 // as if it came from the module specified by the given tag.
 template <class T>
 ProductID
-testEvent::addProduct(std::auto_ptr<T> product,
+testEvent::addProduct(std::unique_ptr<T> product,
                       std::string const& tag,
                       std::string const& productLabel) {
   iterator_t description = moduleDescriptions_.find(tag);
@@ -225,7 +225,7 @@ testEvent::addProduct(std::auto_ptr<T> product,
 
   ModuleCallingContext mcc(&description->second);
   Event temporaryEvent(*principal_, description->second, &mcc);
-  OrphanHandle<T> h = temporaryEvent.put(product, productLabel);
+  OrphanHandle<T> h = temporaryEvent.put(std::move(product), productLabel);
   ProductID id = h.id();
   ProducerBase::commitEvent(temporaryEvent);
   return id;
@@ -444,19 +444,19 @@ void testEvent::putAndGetAnIntProduct() {
 void testEvent::getByProductID() {
 
   typedef edmtest::IntProduct product_t;
-  typedef std::auto_ptr<product_t> ap_t;
+  typedef std::unique_ptr<product_t> ap_t;
   typedef Handle<product_t>  handle_t;
 
   ProductID wanted;
 
   {
     ap_t one(new product_t(1));
-    ProductID id1 = addProduct(one, "int1_tag", "int1");
+    ProductID id1 = addProduct(std::move(one), "int1_tag", "int1");
     CPPUNIT_ASSERT(id1 != ProductID());
     wanted = id1;
 
     ap_t two(new product_t(2));
-    ProductID id2 = addProduct(two, "int2_tag", "int2");
+    ProductID id2 = addProduct(std::move(two), "int2_tag", "int2");
     CPPUNIT_ASSERT(id2 != ProductID());
     CPPUNIT_ASSERT(id2 != id1);
 
@@ -502,7 +502,7 @@ void testEvent::transaction() {
 
 void testEvent::getByLabel() {
   typedef edmtest::IntProduct product_t;
-  typedef std::auto_ptr<product_t> ap_t;
+  typedef std::unique_ptr<product_t> ap_t;
   typedef Handle<product_t> handle_t;
   typedef std::vector<handle_t> handle_vec;
 
@@ -510,19 +510,19 @@ void testEvent::getByLabel() {
   ap_t two(new product_t(2));
   ap_t three(new product_t(3));
   ap_t four(new product_t(4));
-  addProduct(one,   "int1_tag", "int1");
-  addProduct(two,   "int2_tag", "int2");
-  addProduct(three, "int3_tag");
-  addProduct(four,  "nolabel_tag");
+  addProduct(std::move(one),   "int1_tag", "int1");
+  addProduct(std::move(two),   "int2_tag", "int2");
+  addProduct(std::move(three), "int3_tag");
+  addProduct(std::move(four),  "nolabel_tag");
 
-  std::auto_ptr<std::vector<edmtest::Thing> > ap_vthing(new std::vector<edmtest::Thing>);
-  addProduct(ap_vthing, "thing", "");
+  std::unique_ptr<std::vector<edmtest::Thing> > ap_vthing(new std::vector<edmtest::Thing>);
+  addProduct(std::move(ap_vthing), "thing", "");
 
   ap_t oneHundred(new product_t(100));
-  addProduct(oneHundred, "int1_tag_late", "int1");
+  addProduct(std::move(oneHundred), "int1_tag_late", "int1");
 
-  std::auto_ptr<edmtest::IntProduct> twoHundred(new edmtest::IntProduct(200));
-  currentEvent_->put(twoHundred, "int1");
+  std::unique_ptr<edmtest::IntProduct> twoHundred(new edmtest::IntProduct(200));
+  currentEvent_->put(std::move(twoHundred), "int1");
   ProducerBase::commitEvent(*currentEvent_);
 
   CPPUNIT_ASSERT(currentEvent_->size() == 7);
@@ -588,7 +588,7 @@ void testEvent::getByLabel() {
 
 void testEvent::getByToken() {
   typedef edmtest::IntProduct product_t;
-  typedef std::auto_ptr<product_t> ap_t;
+  typedef std::unique_ptr<product_t> ap_t;
   typedef Handle<product_t> handle_t;
   typedef std::vector<handle_t> handle_vec;
   
@@ -596,19 +596,19 @@ void testEvent::getByToken() {
   ap_t two(new product_t(2));
   ap_t three(new product_t(3));
   ap_t four(new product_t(4));
-  addProduct(one,   "int1_tag", "int1");
-  addProduct(two,   "int2_tag", "int2");
-  addProduct(three, "int3_tag");
-  addProduct(four,  "nolabel_tag");
+  addProduct(std::move(one),   "int1_tag", "int1");
+  addProduct(std::move(two),   "int2_tag", "int2");
+  addProduct(std::move(three), "int3_tag");
+  addProduct(std::move(four),  "nolabel_tag");
   
-  std::auto_ptr<std::vector<edmtest::Thing> > ap_vthing(new std::vector<edmtest::Thing>);
-  addProduct(ap_vthing, "thing", "");
+  std::unique_ptr<std::vector<edmtest::Thing> > ap_vthing(new std::vector<edmtest::Thing>);
+  addProduct(std::move(ap_vthing), "thing", "");
   
   ap_t oneHundred(new product_t(100));
-  addProduct(oneHundred, "int1_tag_late", "int1");
+  addProduct(std::move(oneHundred), "int1_tag_late", "int1");
   
-  std::auto_ptr<edmtest::IntProduct> twoHundred(new edmtest::IntProduct(200));
-  currentEvent_->put(twoHundred, "int1");
+  std::unique_ptr<edmtest::IntProduct> twoHundred(new edmtest::IntProduct(200));
+  currentEvent_->put(std::move(twoHundred), "int1");
   ProducerBase::commitEvent(*currentEvent_);
   
   CPPUNIT_ASSERT(currentEvent_->size() == 7);
@@ -669,7 +669,7 @@ void testEvent::getByToken() {
 
 void testEvent::getManyByType() {
   typedef edmtest::IntProduct product_t;
-  typedef std::auto_ptr<product_t> ap_t;
+  typedef std::unique_ptr<product_t> ap_t;
   typedef Handle<product_t> handle_t;
   typedef std::vector<handle_t> handle_vec;
 
@@ -677,19 +677,19 @@ void testEvent::getManyByType() {
   ap_t two(new product_t(2));
   ap_t three(new product_t(3));
   ap_t four(new product_t(4));
-  addProduct(one,   "int1_tag", "int1");
-  addProduct(two,   "int2_tag", "int2");
-  addProduct(three, "int3_tag");
-  addProduct(four,  "nolabel_tag");
+  addProduct(std::move(one),   "int1_tag", "int1");
+  addProduct(std::move(two),   "int2_tag", "int2");
+  addProduct(std::move(three), "int3_tag");
+  addProduct(std::move(four),  "nolabel_tag");
 
-  std::auto_ptr<std::vector<edmtest::Thing> > ap_vthing(new std::vector<edmtest::Thing>);
-  addProduct(ap_vthing, "thing", "");
+  std::unique_ptr<std::vector<edmtest::Thing> > ap_vthing(new std::vector<edmtest::Thing>);
+  addProduct(std::move(ap_vthing), "thing", "");
 
-  std::auto_ptr<std::vector<edmtest::Thing> > ap_vthing2(new std::vector<edmtest::Thing>);
-  addProduct(ap_vthing2, "thing2", "inst2");
+  std::unique_ptr<std::vector<edmtest::Thing> > ap_vthing2(new std::vector<edmtest::Thing>);
+  addProduct(std::move(ap_vthing2), "thing2", "inst2");
 
   ap_t oneHundred(new product_t(100));
-  addProduct(oneHundred, "int1_tag_late", "int1");
+  addProduct(std::move(oneHundred), "int1_tag_late", "int1");
 
   std::auto_ptr<edmtest::IntProduct> twoHundred(new edmtest::IntProduct(200));
   currentEvent_->put(twoHundred, "int1");
@@ -715,11 +715,11 @@ void testEvent::printHistory() {
 void testEvent::deleteProduct() {
   
   typedef edmtest::IntProduct product_t;
-  typedef std::auto_ptr<product_t> ap_t;
+  typedef std::unique_ptr<product_t> ap_t;
   typedef Handle<product_t> handle_t;
   
   ap_t one(new product_t(1));
-  addProduct(one,   "int1_tag", "int1");
+  addProduct(std::move(one),   "int1_tag", "int1");
   
   BranchID id;
   

--- a/FWCore/Framework/test/event_getrefbeforeput_t.cppunit.cc
+++ b/FWCore/Framework/test/event_getrefbeforeput_t.cppunit.cc
@@ -158,11 +158,11 @@ void testEventGetRefBeforePut::getRefTest() {
     edm::ModuleDescription modDesc("Blah", label, pcPtr.get());
 
     edm::Event event(ep, modDesc, nullptr);
-    std::auto_ptr<edmtest::IntProduct> pr(new edmtest::IntProduct);
+    std::unique_ptr<edmtest::IntProduct> pr(new edmtest::IntProduct);
     pr->value = 10;
 
     refToProd = event.getRefBeforePut<edmtest::IntProduct>(productInstanceName);
-    event.put(pr,productInstanceName);
+    event.put(std::move(pr),productInstanceName);
     event.commit_();
   }
   catch (cms::Exception& x) {

--- a/FWCore/Framework/test/generichandle_t.cppunit.cc
+++ b/FWCore/Framework/test/generichandle_t.cppunit.cc
@@ -130,8 +130,8 @@ void testGenericHandle::getbyLabelTest() {
   typedef edmtest::DummyProduct DP;
   typedef edm::Wrapper<DP> WDP;
 
-  std::auto_ptr<DP> pr(new DP);
-  std::unique_ptr<edm::WrapperBase> pprod(new WDP(pr));
+  std::unique_ptr<DP> pr(new DP);
+  std::unique_ptr<edm::WrapperBase> pprod(new WDP(std::move(pr)));
   std::string label("fred");
   std::string productInstanceName("Rick");
 

--- a/FWCore/Framework/test/stubs/DeleteEarlyModules.cc
+++ b/FWCore/Framework/test/stubs/DeleteEarlyModules.cc
@@ -33,8 +33,8 @@ namespace edmtest {
     }
     
     virtual void produce(edm::Event& e, edm::EventSetup const& ){
-      std::auto_ptr<DeleteEarly> p(new DeleteEarly);
-      e.put(p);
+      std::unique_ptr<DeleteEarly> p(new DeleteEarly);
+      e.put(std::move(p));
     }
 
   };

--- a/FWCore/Framework/test/stubs/TestMergeResults.cc
+++ b/FWCore/Framework/test/stubs/TestMergeResults.cc
@@ -164,18 +164,18 @@ namespace edmtest {
     processHistoryIndex_(0),
     testAlias_(ps.getUntrackedParameter<bool>("testAlias", false)) {
 
-    std::auto_ptr<edmtest::Thing> ap_thing(new edmtest::Thing);
-    edm::Wrapper<edmtest::Thing> w_thing(ap_thing);
+    std::unique_ptr<edmtest::Thing> ap_thing(new edmtest::Thing);
+    edm::Wrapper<edmtest::Thing> w_thing(std::move(ap_thing));
     assert(!w_thing.isMergeable());
     assert(!w_thing.hasIsProductEqual());
 
-    std::auto_ptr<edmtest::ThingWithMerge> ap_thingwithmerge(new edmtest::ThingWithMerge);
-    edm::Wrapper<edmtest::ThingWithMerge> w_thingWithMerge(ap_thingwithmerge);
+    std::unique_ptr<edmtest::ThingWithMerge> ap_thingwithmerge(new edmtest::ThingWithMerge);
+    edm::Wrapper<edmtest::ThingWithMerge> w_thingWithMerge(std::move(ap_thingwithmerge));
     assert(w_thingWithMerge.isMergeable());
     assert(!w_thingWithMerge.hasIsProductEqual());
 
-    std::auto_ptr<edmtest::ThingWithIsEqual> ap_thingwithisequal(new edmtest::ThingWithIsEqual);
-    edm::Wrapper<edmtest::ThingWithIsEqual> w_thingWithIsEqual(ap_thingwithisequal);
+    std::unique_ptr<edmtest::ThingWithIsEqual> ap_thingwithisequal(new edmtest::ThingWithIsEqual);
+    edm::Wrapper<edmtest::ThingWithIsEqual> w_thingWithIsEqual(std::move(ap_thingwithisequal));
     assert(!w_thingWithIsEqual.isMergeable());
     assert(w_thingWithIsEqual.hasIsProductEqual());
     

--- a/FWCore/Framework/test/stubs/TestPRegisterModule1.cc
+++ b/FWCore/Framework/test/stubs/TestPRegisterModule1.cc
@@ -25,6 +25,6 @@ void TestPRegisterModule1::produce(Event& e, EventSetup const&)
 {
   
   std::string myname = pset_.getParameter<std::string>("@module_label");
-  std::auto_ptr<edmtest::StringProduct> product(new edmtest::StringProduct(myname)); 
-  e.put(product);
+  std::unique_ptr<edmtest::StringProduct> product(new edmtest::StringProduct(myname));
+  e.put(std::move(product));
 }

--- a/FWCore/Framework/test/stubs/TestPRegisterModule2.cc
+++ b/FWCore/Framework/test/stubs/TestPRegisterModule2.cc
@@ -56,6 +56,6 @@ TestPRegisterModule2::TestPRegisterModule2(edm::ParameterSet const&){
      e.getByLabel("m2",stringp);
      CPPUNIT_ASSERT(stringp->name_=="m1");
 
-     std::auto_ptr<edmtest::DoubleProduct> product(new edmtest::DoubleProduct);
-     e.put(product);
+     std::unique_ptr<edmtest::DoubleProduct> product(new edmtest::DoubleProduct);
+     e.put(std::move(product));
   }

--- a/FWCore/Framework/test/stubs/TestSchedulerModule1.cc
+++ b/FWCore/Framework/test/stubs/TestSchedulerModule1.cc
@@ -36,8 +36,8 @@ private:
 void TestSchedulerModule1::produce(Event& e, EventSetup const&)
 {
   std::string myname = pset_.getParameter<std::string>("module_name");
-  std::auto_ptr<edmtest::StringProduct> product(new edmtest::StringProduct(myname)); 
-  e.put(product);
+  std::unique_ptr<edmtest::StringProduct> product(new edmtest::StringProduct(myname));
+  e.put(std::move(product));
 }
 
 DEFINE_FWK_MODULE(TestSchedulerModule1);

--- a/FWCore/Framework/test/stubs/TestSchedulerModule2.cc
+++ b/FWCore/Framework/test/stubs/TestSchedulerModule2.cc
@@ -37,8 +37,8 @@ namespace edm{
   {
 
     std::string myname = pset_.getParameter<std::string>("module_name");
-    std::auto_ptr<edmtest::StringProduct> product(new edmtest::StringProduct(myname));
-    e.put(product);
+    std::unique_ptr<edmtest::StringProduct> product(new edmtest::StringProduct(myname));
+    e.put(std::move(product));
     
   }
 }//namespace  

--- a/FWCore/Framework/test/stubs/ToyDoubleProducers.cc
+++ b/FWCore/Framework/test/stubs/ToyDoubleProducers.cc
@@ -48,8 +48,8 @@ namespace edmtest {
   ToyDoubleProducer::produce(edm::Event& e, edm::EventSetup const&) {
 
     // Make output
-    std::auto_ptr<DoubleProduct> p(new DoubleProduct(value_));
-    e.put(p);
+    std::unique_ptr<DoubleProduct> p(new DoubleProduct(value_));
+    e.put(std::move(p));
   }
 
 }

--- a/FWCore/Framework/test/stubs/ToyIntProducers.cc
+++ b/FWCore/Framework/test/stubs/ToyIntProducers.cc
@@ -90,8 +90,8 @@ namespace edmtest {
   void
   IntProducer::produce(edm::Event& e, edm::EventSetup const&) {
     // EventSetup is not used.
-    std::auto_ptr<IntProduct> p(new IntProduct(value_));
-    e.put(p);
+    std::unique_ptr<IntProduct> p(new IntProduct(value_));
+    e.put(std::move(p));
   }
 
   //--------------------------------------------------------------------
@@ -116,8 +116,8 @@ namespace edmtest {
   void
   EventNumberIntProducer::produce(edm::Event& e, edm::EventSetup const&) {
     // EventSetup is not used.
-    std::auto_ptr<IntProduct> p(new IntProduct(e.id().event()));
-    e.put(p);
+    std::unique_ptr<IntProduct> p(new IntProduct(e.id().event()));
+    e.put(std::move(p));
   }
 
 
@@ -144,8 +144,8 @@ namespace edmtest {
   void
   TransientIntProducer::produce(edm::Event& e, edm::EventSetup const&) {
     // EventSetup is not used.
-    std::auto_ptr<TransientIntProduct> p(new TransientIntProduct(value_));
-    e.put(p);
+    std::unique_ptr<TransientIntProduct> p(new TransientIntProduct(value_));
+    e.put(std::move(p));
   }
 
   //--------------------------------------------------------------------
@@ -173,8 +173,8 @@ namespace edmtest {
     edm::Handle<TransientIntProduct> result;
     bool ok = e.getByLabel("TransientThing", result);
     assert(ok);
-    std::auto_ptr<IntProduct> p(new IntProduct(result.product()->value));
-    e.put(p);
+    std::unique_ptr<IntProduct> p(new IntProduct(result.product()->value));
+    e.put(std::move(p));
   }
 
   //--------------------------------------------------------------------
@@ -200,8 +200,8 @@ namespace edmtest {
   void
   Int16_tProducer::produce(edm::Event& e, edm::EventSetup const&) {
     // EventSetup is not used.
-    std::auto_ptr<Int16_tProduct> p(new Int16_tProduct(value_));
-    e.put(p);
+    std::unique_ptr<Int16_tProduct> p(new Int16_tProduct(value_));
+    e.put(std::move(p));
   }
 
   //
@@ -233,8 +233,8 @@ namespace edmtest {
       e.getByLabel(*itLabel, anInt);
       value += anInt->value;
     }
-    std::auto_ptr<IntProduct> p(new IntProduct(value));
-    e.put(p);
+    std::unique_ptr<IntProduct> p(new IntProduct(value));
+    e.put(std::move(p));
   }
 
 }

--- a/FWCore/Framework/test/stubs/ToyModules.cc
+++ b/FWCore/Framework/test/stubs/ToyModules.cc
@@ -69,10 +69,10 @@ namespace edmtest {
         assert(guts[i-1].id() > guts[i].id());
     }
 
-    std::auto_ptr<SCSimpleProduct> p(new SCSimpleProduct(guts));
+    std::unique_ptr<SCSimpleProduct> p(new SCSimpleProduct(guts));
 
     // Put the product into the Event, thus sorting it.
-    e.put(p);
+    e.put(std::move(p));
   }
 
   //--------------------------------------------------------------------
@@ -105,7 +105,7 @@ namespace edmtest {
   OVSimpleProducer::produce(edm::Event& e,
                             edm::EventSetup const& /* unused */) {
     // Fill up a collection
-    std::auto_ptr<OVSimpleProduct> p(new OVSimpleProduct());
+    std::unique_ptr<OVSimpleProduct> p(new OVSimpleProduct());
 
     for(int i = 0; i < size_; ++i) {
         std::auto_ptr<Simple> simple(new Simple());
@@ -115,10 +115,10 @@ namespace edmtest {
     }
 
     // Put the product into the Event
-    e.put(p);
+    e.put(std::move(p));
 
     // Fill up a collection of SimpleDerived objects
-    std::auto_ptr<OVSimpleDerivedProduct> pd(new OVSimpleDerivedProduct());
+    std::unique_ptr<OVSimpleDerivedProduct> pd(new OVSimpleDerivedProduct());
 
     for(int i = 0; i < size_; ++i) {
         std::auto_ptr<SimpleDerived> simpleDerived(new SimpleDerived());
@@ -129,7 +129,7 @@ namespace edmtest {
     }
 
     // Put the product into the Event
-    e.put(pd, "derived");
+    e.put(std::move(pd), "derived");
   }
 
   //--------------------------------------------------------------------
@@ -160,7 +160,7 @@ namespace edmtest {
   VSimpleProducer::produce(edm::Event& e,
                            edm::EventSetup const& /* unused */) {
     // Fill up a collection
-    std::auto_ptr<VSimpleProduct> p(new VSimpleProduct());
+    std::unique_ptr<VSimpleProduct> p(new VSimpleProduct());
 
     for(int i = 0; i < size_; ++i) {
         Simple simple;
@@ -170,7 +170,7 @@ namespace edmtest {
     }
 
     // Put the product into the Event
-    e.put(p);
+    e.put(std::move(p));
   }
 
   //--------------------------------------------------------------------
@@ -200,7 +200,7 @@ namespace edmtest {
     edm::Handle<std::vector<edmtest::Simple> > vs;
     e.getByLabel(src_, vs);
     // Fill up a collection
-    std::auto_ptr<AVSimpleProduct> p(new AVSimpleProduct(edm::RefProd<std::vector<edmtest::Simple> >(vs)));
+    std::unique_ptr<AVSimpleProduct> p(new AVSimpleProduct(edm::RefProd<std::vector<edmtest::Simple> >(vs)));
 
     for(unsigned int i = 0; i < vs->size(); ++i) {
         edmtest::Simple simple;
@@ -209,7 +209,7 @@ namespace edmtest {
     }
 
     // Put the product into the Event
-    e.put(p);
+    e.put(std::move(p));
   }
 
   //--------------------------------------------------------------------
@@ -268,7 +268,7 @@ namespace edmtest {
       assert(guts[i-1].data > guts[i].data);
     }
 
-    std::auto_ptr<product_type> p(new product_type());
+    std::unique_ptr<product_type> p(new product_type());
     int n = 0;
     for(int id = 1; id<size_; ++id) {
       ++n;
@@ -279,7 +279,7 @@ namespace edmtest {
 
     // Put the product into the Event, thus sorting it ... or not,
     // depending upon the product type.
-    e.put(p);
+    e.put(std::move(p));
   }
 
   //--------------------------------------------------------------------
@@ -342,7 +342,7 @@ namespace edmtest {
     typedef typename detset::value_type       value_type;
     typedef typename detset::id_type       id_type;
 
-    std::auto_ptr<product_type> p(new product_type());
+    std::unique_ptr<product_type> p(new product_type());
     product_type& v = *p;
 
     unsigned int n = 0;
@@ -356,7 +356,7 @@ namespace edmtest {
 
     // Put the product into the Event, thus sorting is not done by magic,
     // up to one user-line
-    e.put(p);
+    e.put(std::move(p));
   }
 
   //--------------------------------------------------------------------
@@ -386,8 +386,8 @@ namespace edmtest {
     edm::Handle<IntProduct> parent;
     e.getByLabel(label_, parent);
 
-    std::auto_ptr<Prodigal> p(new Prodigal(parent->value));
-    e.put(p);
+    std::unique_ptr<Prodigal> p(new Prodigal(parent->value));
+    e.put(std::move(p));
   }
 
 }

--- a/FWCore/Framework/test/stubs/ToyRefProducers.cc
+++ b/FWCore/Framework/test/stubs/ToyRefProducers.cc
@@ -60,13 +60,13 @@ namespace edmtest {
     e.getByLabel(target_, input);
     assert(input.isValid());
 
-    std::auto_ptr<product_type> prod(new product_type());
+    std::unique_ptr<product_type> prod(new product_type());
 
     typedef product_type::value_type ref;
     for(size_t i = 0, sz = input->size(); i != sz; ++i)
       prod->push_back(ref(input, i));
 
-    e.put(prod);
+    e.put(std::move(prod));
   }
 
   //--------------------------------------------------------------------
@@ -98,8 +98,8 @@ namespace edmtest {
     e.getByLabel(target_, input);
     assert(input.isValid());
 
-    std::auto_ptr<product_type> prod(new product_type(input->refVector()));
-    e.put(prod);
+    std::unique_ptr<product_type> prod(new product_type(input->refVector()));
+    e.put(std::move(prod));
   }
 
   //--------------------------------------------------------------------
@@ -131,13 +131,13 @@ namespace edmtest {
     e.getByLabel(target_, input);
     assert(input.isValid());
 
-    std::auto_ptr<product_type> prod(new product_type());
+    std::unique_ptr<product_type> prod(new product_type());
 
     typedef product_type::value_type ref;
     for(size_t i = 0, sz = input->size(); i != sz; ++i)
       prod->push_back(ref(input, i));
 
-    e.put(prod);
+    e.put(std::move(prod));
   }
 
 }

--- a/FWCore/Framework/test/stubs/ToySTLProducers.cc
+++ b/FWCore/Framework/test/stubs/ToySTLProducers.cc
@@ -46,8 +46,8 @@ namespace edmtest {
   void
   IntVectorProducer::produce(edm::Event& e, edm::EventSetup const&) {
     // EventSetup is not used.
-    std::auto_ptr<std::vector<int> > p(new std::vector<int>(count_, value_));
-    e.put(p);
+    std::unique_ptr<std::vector<int> > p(new std::vector<int>(count_, value_));
+    e.put(std::move(p));
   }
 
   //--------------------------------------------------------------------
@@ -68,11 +68,11 @@ namespace edmtest {
   void
   IntVectorSetProducer::produce(edm::Event& e, edm::EventSetup const&) {
     // EventSetup is not used.
-    std::auto_ptr<std::vector<int> > p(new std::vector<int>(1,11));
-    e.put(p);
+    std::unique_ptr<std::vector<int> > p(new std::vector<int>(1,11));
+    e.put(std::move(p));
 
-    std::auto_ptr<std::set<int> > apset(new std::set<int>);
-    e.put(apset);
+    std::unique_ptr<std::set<int> > apset(new std::set<int>);
+    e.put(std::move(apset));
   }
 
   //--------------------------------------------------------------------
@@ -96,8 +96,8 @@ namespace edmtest {
   void
   IntListProducer::produce(edm::Event& e, edm::EventSetup const&) {
     // EventSetup is not used.
-    std::auto_ptr<std::list<int> > p(new std::list<int>(count_, value_));
-    e.put(p);
+    std::unique_ptr<std::list<int> > p(new std::list<int>(count_, value_));
+    e.put(std::move(p));
   }
 
   //--------------------------------------------------------------------
@@ -121,8 +121,8 @@ namespace edmtest {
   void
   IntDequeProducer::produce(edm::Event& e, edm::EventSetup const&) {
     // EventSetup is not used.
-    std::auto_ptr<std::deque<int> > p(new std::deque<int>(count_, value_));
-    e.put(p);
+    std::unique_ptr<std::deque<int> > p(new std::deque<int>(count_, value_));
+    e.put(std::move(p));
   }
 
   //--------------------------------------------------------------------
@@ -146,9 +146,9 @@ namespace edmtest {
   void
   IntSetProducer::produce(edm::Event& e, edm::EventSetup const&) {
     // EventSetup is not used.
-    std::auto_ptr<std::set<int> > p(new std::set<int>());
+    std::unique_ptr<std::set<int> > p(new std::set<int>());
     for(int i = start_; i < stop_; ++i) p->insert(i);
-    e.put(p);
+    e.put(std::move(p));
   }
 
 }

--- a/FWCore/Integration/test/HistProducer.cc
+++ b/FWCore/Integration/test/HistProducer.cc
@@ -16,8 +16,8 @@ namespace edmtest {
   // Functions that gets called by framework every event
   void HistProducer::produce(edm::Event& e, edm::EventSetup const&) {
 
-    std::auto_ptr<TH1F> result(new TH1F);  //Empty
-    e.put(result);
+    std::unique_ptr<TH1F> result(new TH1F);  //Empty
+    e.put(std::move(result));
     //std::auto_ptr<ThingWithHist> result2(new ThingWithHist);  //Empty
     //e.put(result2);
   }

--- a/FWCore/Integration/test/IntSource.cc
+++ b/FWCore/Integration/test/IntSource.cc
@@ -35,8 +35,8 @@ namespace edm {
 
   void
   IntSource::produce(edm::Event& e) {
-    std::auto_ptr<edmtest::IntProduct> p(new edmtest::IntProduct(4));
-    e.put(p);
+    std::unique_ptr<edmtest::IntProduct> p(new edmtest::IntProduct(4));
+    e.put(std::move(p));
   }
 
   void

--- a/FWCore/Integration/test/ManyProductProducer.cc
+++ b/FWCore/Integration/test/ManyProductProducer.cc
@@ -48,8 +48,8 @@ namespace edmtest {
   void ManyProductProducer::produce(edm::Event& e, edm::EventSetup const&) {
     for(unsigned int i = 0; i < nProducts_; ++i) {
     
-      std::auto_ptr<IntProduct> p(new IntProduct(1));
-      e.put(p, instanceNames_[i]);
+      std::unique_ptr<IntProduct> p(new IntProduct(1));
+      e.put(std::move(p), instanceNames_[i]);
     }
   }
 

--- a/FWCore/Integration/test/OtherThingProducer.cc
+++ b/FWCore/Integration/test/OtherThingProducer.cc
@@ -47,7 +47,7 @@ namespace edmtest {
     // Step A: Get Inputs 
 
     // Step B: Create empty output 
-    std::auto_ptr<OtherThingCollection> result(new OtherThingCollection);  //Empty
+    std::unique_ptr<OtherThingCollection> result(new OtherThingCollection);  //Empty
 
     // Step C: Get data for algorithm
     edm::Handle<ThingCollection> parentHandle;
@@ -62,7 +62,7 @@ namespace edmtest {
     alg_.run(parentHandle, *result, useRefs_, refsAreTransient_);
 
     // Step E: Put outputs into event
-    e.put(result, std::string("testUserTag"));
+    e.put(std::move(result), std::string("testUserTag"));
   }
   
   void OtherThingProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/FWCore/Integration/test/ProducerWithPSetDesc.cc
+++ b/FWCore/Integration/test/ProducerWithPSetDesc.cc
@@ -429,8 +429,8 @@ namespace edmtest {
     // This serves no purpose, I just put it here so the module does something
     // Probably could just make this method do nothing and it would not
     // affect the test.
-    std::auto_ptr<ThingCollection> result(new ThingCollection);  //Empty
-    e.put(result);
+    std::unique_ptr<ThingCollection> result(new ThingCollection);  //Empty
+    e.put(std::move(result));
   }
 
   void

--- a/FWCore/Integration/test/ThingExtSource.cc
+++ b/FWCore/Integration/test/ThingExtSource.cc
@@ -30,13 +30,13 @@ namespace edmtest {
     // Step A: Get Inputs 
 
     // Step B: Create empty output 
-    std::auto_ptr<ThingCollection> result(new ThingCollection);  //Empty
+    std::unique_ptr<ThingCollection> result(new ThingCollection);  //Empty
 
     // Step C: Invoke the algorithm, passing in inputs (NONE) and getting back outputs.
     alg_.run(*result);
 
     // Step D: Put outputs into event
-    e.put(result);
+    e.put(std::move(result));
   }
 
   // Functions that gets called by framework every luminosity block
@@ -44,26 +44,26 @@ namespace edmtest {
     // Step A: Get Inputs 
 
     // Step B: Create empty output 
-    std::auto_ptr<ThingCollection> result(new ThingCollection);  //Empty
+    std::unique_ptr<ThingCollection> result(new ThingCollection);  //Empty
 
     // Step C: Invoke the algorithm, passing in inputs (NONE) and getting back outputs.
     alg_.run(*result);
 
     // Step D: Put outputs into lumi block
-    lb.put(result, "beginLumi");
+    lb.put(std::move(result), "beginLumi");
   }
 
   void ThingExtSource::endLuminosityBlock(edm::LuminosityBlock& lb) {
     // Step A: Get Inputs 
 
     // Step B: Create empty output 
-    std::auto_ptr<ThingCollection> result(new ThingCollection);  //Empty
+    std::unique_ptr<ThingCollection> result(new ThingCollection);  //Empty
 
     // Step C: Invoke the algorithm, passing in inputs (NONE) and getting back outputs.
     alg_.run(*result);
 
     // Step D: Put outputs into lumi block
-    lb.put(result, "endLumi");
+    lb.put(std::move(result), "endLumi");
   }
 
   // Functions that gets called by framework every run
@@ -71,26 +71,26 @@ namespace edmtest {
     // Step A: Get Inputs 
 
     // Step B: Create empty output 
-    std::auto_ptr<ThingCollection> result(new ThingCollection);  //Empty
+    std::unique_ptr<ThingCollection> result(new ThingCollection);  //Empty
 
     // Step C: Invoke the algorithm, passing in inputs (NONE) and getting back outputs.
     alg_.run(*result);
 
     // Step D: Put outputs into event
-    r.put(result, "beginRun");
+    r.put(std::move(result), "beginRun");
   }
 
   void ThingExtSource::endRun(edm::Run& r) {
     // Step A: Get Inputs 
 
     // Step B: Create empty output 
-    std::auto_ptr<ThingCollection> result(new ThingCollection);  //Empty
+    std::unique_ptr<ThingCollection> result(new ThingCollection);  //Empty
 
     // Step C: Invoke the algorithm, passing in inputs (NONE) and getting back outputs.
     alg_.run(*result);
 
     // Step D: Put outputs into event
-    r.put(result, "endRun");
+    r.put(std::move(result), "endRun");
   }
 
 }

--- a/FWCore/Integration/test/ThingProducer.cc
+++ b/FWCore/Integration/test/ThingProducer.cc
@@ -25,13 +25,13 @@ namespace edmtest {
     // Step A: Get Inputs 
 
     // Step B: Create empty output 
-    std::auto_ptr<ThingCollection> result(new ThingCollection);  //Empty
+    std::unique_ptr<ThingCollection> result(new ThingCollection);  //Empty
 
     // Step C: Invoke the algorithm, passing in inputs (NONE) and getting back outputs.
     alg_.run(*result);
 
     // Step D: Put outputs into event
-    if (!noPut_) e.put(result);
+    if (!noPut_) e.put(std::move(result));
   }
 
   // Functions that gets called by framework every luminosity block
@@ -39,26 +39,26 @@ namespace edmtest {
     // Step A: Get Inputs 
 
     // Step B: Create empty output 
-    std::auto_ptr<ThingCollection> result(new ThingCollection);  //Empty
+    std::unique_ptr<ThingCollection> result(new ThingCollection);  //Empty
 
     // Step C: Invoke the algorithm, passing in inputs (NONE) and getting back outputs.
     alg_.run(*result);
 
     // Step D: Put outputs into lumi block
-    if (!noPut_) lb.put(result, "beginLumi");
+    if (!noPut_) lb.put(std::move(result), "beginLumi");
   }
 
   void ThingProducer::endLuminosityBlockProduce(edm::LuminosityBlock& lb, edm::EventSetup const&) {
     // Step A: Get Inputs 
 
     // Step B: Create empty output 
-    std::auto_ptr<ThingCollection> result(new ThingCollection);  //Empty
+    std::unique_ptr<ThingCollection> result(new ThingCollection);  //Empty
 
     // Step C: Invoke the algorithm, passing in inputs (NONE) and getting back outputs.
     alg_.run(*result);
 
     // Step D: Put outputs into lumi block
-    if (!noPut_) lb.put(result, "endLumi");
+    if (!noPut_) lb.put(std::move(result), "endLumi");
   }
 
   // Functions that gets called by framework every run
@@ -66,26 +66,26 @@ namespace edmtest {
     // Step A: Get Inputs 
 
     // Step B: Create empty output 
-    std::auto_ptr<ThingCollection> result(new ThingCollection);  //Empty
+    std::unique_ptr<ThingCollection> result(new ThingCollection);  //Empty
 
     // Step C: Invoke the algorithm, passing in inputs (NONE) and getting back outputs.
     alg_.run(*result);
 
     // Step D: Put outputs into event
-    if (!noPut_) r.put(result, "beginRun");
+    if (!noPut_) r.put(std::move(result), "beginRun");
   }
 
   void ThingProducer::endRunProduce(edm::Run& r, edm::EventSetup const&) {
     // Step A: Get Inputs 
 
     // Step B: Create empty output 
-    std::auto_ptr<ThingCollection> result(new ThingCollection);  //Empty
+    std::unique_ptr<ThingCollection> result(new ThingCollection);  //Empty
 
     // Step C: Invoke the algorithm, passing in inputs (NONE) and getting back outputs.
     alg_.run(*result);
 
     // Step D: Put outputs into event
-    if (!noPut_) r.put(result, "endRun");
+    if (!noPut_) r.put(std::move(result), "endRun");
   }
 
   void ThingProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/FWCore/Integration/test/ThingSource.cc
+++ b/FWCore/Integration/test/ThingSource.cc
@@ -23,13 +23,13 @@ namespace edmtest {
     // Step A: Get Inputs 
 
     // Step B: Create empty output 
-    std::auto_ptr<ThingCollection> result(new ThingCollection);  //Empty
+    std::unique_ptr<ThingCollection> result(new ThingCollection);  //Empty
 
     // Step C: Invoke the algorithm, passing in inputs (NONE) and getting back outputs.
     alg_.run(*result);
 
     // Step D: Put outputs into event
-    e.put(result);
+    e.put(std::move(result));
   }
 
   // Functions that gets called by framework every luminosity block
@@ -37,26 +37,26 @@ namespace edmtest {
     // Step A: Get Inputs 
 
     // Step B: Create empty output 
-    std::auto_ptr<ThingCollection> result(new ThingCollection);  //Empty
+    std::unique_ptr<ThingCollection> result(new ThingCollection);  //Empty
 
     // Step C: Invoke the algorithm, passing in inputs (NONE) and getting back outputs.
     alg_.run(*result);
 
     // Step D: Put outputs into lumi block
-    lb.put(result, "beginLumi");
+    lb.put(std::move(result), "beginLumi");
   }
 
   void ThingSource::endLuminosityBlock(edm::LuminosityBlock& lb) {
     // Step A: Get Inputs 
 
     // Step B: Create empty output 
-    std::auto_ptr<ThingCollection> result(new ThingCollection);  //Empty
+    std::unique_ptr<ThingCollection> result(new ThingCollection);  //Empty
 
     // Step C: Invoke the algorithm, passing in inputs (NONE) and getting back outputs.
     alg_.run(*result);
 
     // Step D: Put outputs into lumi block
-    lb.put(result, "endLumi");
+    lb.put(std::move(result), "endLumi");
   }
 
   // Functions that gets called by framework every run
@@ -64,26 +64,26 @@ namespace edmtest {
     // Step A: Get Inputs 
 
     // Step B: Create empty output 
-    std::auto_ptr<ThingCollection> result(new ThingCollection);  //Empty
+    std::unique_ptr<ThingCollection> result(new ThingCollection);  //Empty
 
     // Step C: Invoke the algorithm, passing in inputs (NONE) and getting back outputs.
     alg_.run(*result);
 
     // Step D: Put outputs into event
-    r.put(result, "beginRun");
+    r.put(std::move(result), "beginRun");
   }
 
   void ThingSource::endRun(edm::Run& r) {
     // Step A: Get Inputs 
 
     // Step B: Create empty output 
-    std::auto_ptr<ThingCollection> result(new ThingCollection);  //Empty
+    std::unique_ptr<ThingCollection> result(new ThingCollection);  //Empty
 
     // Step C: Invoke the algorithm, passing in inputs (NONE) and getting back outputs.
     alg_.run(*result);
 
     // Step D: Put outputs into event
-    r.put(result, "endRun");
+    r.put(std::move(result), "endRun");
   }
 }
 using edmtest::ThingSource;

--- a/FWCore/Integration/test/ThingWithMergeProducer.cc
+++ b/FWCore/Integration/test/ThingWithMergeProducer.cc
@@ -66,83 +66,83 @@ namespace edmtest {
       e.getByLabel(tag, h);
     }
 
-    std::auto_ptr<Thing> result(new Thing);
+    std::unique_ptr<Thing> result(new Thing);
     result->a = 11;
-    if (!noPut_) e.put(result, std::string("event"));
+    if (!noPut_) e.put(std::move(result), std::string("event"));
 
-    std::auto_ptr<ThingWithMerge> result2(new ThingWithMerge);
+    std::unique_ptr<ThingWithMerge> result2(new ThingWithMerge);
     result2->a = 12;
-    if (!noPut_) e.put(result2, std::string("event"));
+    if (!noPut_) e.put(std::move(result2), std::string("event"));
 
-    std::auto_ptr<ThingWithIsEqual> result3(new ThingWithIsEqual);
+    std::unique_ptr<ThingWithIsEqual> result3(new ThingWithIsEqual);
     result3->a = 13;
     if (changeIsEqualValue_) result3->a = 14;
-    if (!noPut_) e.put(result3, std::string("event"));
+    if (!noPut_) e.put(std::move(result3), std::string("event"));
   }
 
   void ThingWithMergeProducer::beginLuminosityBlockProduce(edm::LuminosityBlock& lb, edm::EventSetup const&) {
 
-    std::auto_ptr<Thing> result(new Thing);
+    std::unique_ptr<Thing> result(new Thing);
     result->a = 101;
-    if (!noPut_) lb.put(result, "beginLumi");
+    if (!noPut_) lb.put(std::move(result), "beginLumi");
 
-    std::auto_ptr<ThingWithMerge> result2(new ThingWithMerge);
+    std::unique_ptr<ThingWithMerge> result2(new ThingWithMerge);
     result2->a = 102;
-    if (!noPut_) lb.put(result2, "beginLumi");
+    if (!noPut_) lb.put(std::move(result2), "beginLumi");
 
-    std::auto_ptr<ThingWithIsEqual> result3(new ThingWithIsEqual);
+    std::unique_ptr<ThingWithIsEqual> result3(new ThingWithIsEqual);
     result3->a = 103;
     if (changeIsEqualValue_) result3->a = 104;
-    if (!noPut_) lb.put(result3, "beginLumi");
+    if (!noPut_) lb.put(std::move(result3), "beginLumi");
   }
 
   void ThingWithMergeProducer::endLuminosityBlockProduce(edm::LuminosityBlock& lb, edm::EventSetup const&) {
 
-    std::auto_ptr<Thing> result(new Thing);
+    std::unique_ptr<Thing> result(new Thing);
     result->a = 1001;
-    if (!noPut_) lb.put(result, "endLumi");
+    if (!noPut_) lb.put(std::move(result), "endLumi");
 
-    std::auto_ptr<ThingWithMerge> result2(new ThingWithMerge);
+    std::unique_ptr<ThingWithMerge> result2(new ThingWithMerge);
     result2->a = 1002;
-    if (!noPut_) lb.put(result2, "endLumi");
+    if (!noPut_) lb.put(std::move(result2), "endLumi");
 
-    std::auto_ptr<ThingWithIsEqual> result3(new ThingWithIsEqual);
+    std::unique_ptr<ThingWithIsEqual> result3(new ThingWithIsEqual);
     result3->a = 1003;
     if (changeIsEqualValue_) result3->a = 1004;
-    if (!noPut_) lb.put(result3, "endLumi");
+    if (!noPut_) lb.put(std::move(result3), "endLumi");
   }
 
   // Functions that gets called by framework every run
   void ThingWithMergeProducer::beginRunProduce(edm::Run& r, edm::EventSetup const&) {
 
-    std::auto_ptr<Thing> result(new Thing);
+    std::unique_ptr<Thing> result(new Thing);
     result->a = 10001;
-    if (!noPut_) r.put(result, "beginRun");
+    if (!noPut_) r.put(std::move(result), "beginRun");
 
-    std::auto_ptr<ThingWithMerge> result2(new ThingWithMerge);
+    std::unique_ptr<ThingWithMerge> result2(new ThingWithMerge);
     result2->a = 10002;
-    if (!noPut_) r.put(result2, "beginRun");
+    if (!noPut_) r.put(std::move(result2), "beginRun");
 
-    std::auto_ptr<ThingWithIsEqual> result3(new ThingWithIsEqual);
+    std::unique_ptr<ThingWithIsEqual> result3(new ThingWithIsEqual);
     result3->a = 10003;
     if (changeIsEqualValue_) result3->a = 10004;
-    if (!noPut_) r.put(result3, "beginRun");
+    if (!noPut_) r.put(std::move(result3), "beginRun");
   }
 
   void ThingWithMergeProducer::endRunProduce(edm::Run& r, edm::EventSetup const&) {
 
-    std::auto_ptr<Thing> result(new Thing);
+    std::unique_ptr<Thing> result(new Thing);
     result->a = 100001;
-    if (!noPut_) r.put(result, "endRun");
+    if (!noPut_) r.put(std::move(result), "endRun");
 
-    std::auto_ptr<ThingWithMerge> result2(new ThingWithMerge);
+    std::unique_ptr<ThingWithMerge> result2(new ThingWithMerge);
     result2->a = 100002;
-    if (!noPut_) r.put(result2, "endRun");
+    if (!noPut_) r.put(std::move(result2), "endRun");
 
-    std::auto_ptr<ThingWithIsEqual> result3(new ThingWithIsEqual);
+    std::unique_ptr<ThingWithIsEqual> result3(new ThingWithIsEqual);
     result3->a = 100003;
     if (changeIsEqualValue_) result3->a = 100004;
-    if (!noPut_) r.put(result3, "endRun");
+    if (!noPut_) r.put(std::move(result3), "endRun");
   }
 
   void ThingWithMergeProducer::beginLuminosityBlock(edm::LuminosityBlock const& lb, edm::EventSetup const&) {

--- a/FWCore/Modules/src/EventAuxiliaryHistoryProducer.cc
+++ b/FWCore/Modules/src/EventAuxiliaryHistoryProducer.cc
@@ -44,11 +44,11 @@ namespace edm {
     history_.push_back(aux);
 
     //Serialize into std::vector 
-    std::auto_ptr<std::vector<EventAuxiliary > > result(new std::vector<EventAuxiliary>);
+    std::unique_ptr<std::vector<EventAuxiliary > > result(new std::vector<EventAuxiliary>);
     for(size_t j = 0; j < history_.size(); ++j) { 
       result->push_back(history_[j]);
     }
-    e.put(result);
+    e.put(std::move(result));
   }
 
   void EventAuxiliaryHistoryProducer::endJob() {

--- a/FWCore/Modules/src/LogErrorHarvester.cc
+++ b/FWCore/Modules/src/LogErrorHarvester.cc
@@ -55,11 +55,11 @@ namespace edm {
   LogErrorHarvester::produce(Event& iEvent, EventSetup const&) {
     const auto index = iEvent.streamID().value();
     if(!FreshErrorsExist(index)) {
-      std::auto_ptr<std::vector<ErrorSummaryEntry> > errors(new std::vector<ErrorSummaryEntry>());
-      iEvent.put(errors);
+      std::unique_ptr<std::vector<ErrorSummaryEntry> > errors(new std::vector<ErrorSummaryEntry>());
+      iEvent.put(std::move(errors));
     } else {
-      std::auto_ptr<std::vector<ErrorSummaryEntry> > errors(new std::vector<ErrorSummaryEntry>(LoggedErrorsSummary(index)));
-      iEvent.put(errors);
+      std::unique_ptr<std::vector<ErrorSummaryEntry> > errors(new std::vector<ErrorSummaryEntry>(LoggedErrorsSummary(index)));
+      iEvent.put(std::move(errors));
     }
   }
 

--- a/FWCore/Skeletons/scripts/mkTemplates/EDProducer/EDProducer.cc
+++ b/FWCore/Skeletons/scripts/mkTemplates/EDProducer/EDProducer.cc
@@ -123,8 +123,8 @@ __class__::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
    //Use the ExampleData to create an ExampleData2 which 
    // is put into the Event
-   std::auto_ptr<ExampleData2> pOut(new ExampleData2(*pIn));
-   iEvent.put(pOut);
+   std::unique_ptr<ExampleData2> pOut(new ExampleData2(*pIn));
+   iEvent.put(std::move(pOut));
 */
 
 /* this is an EventSetup example
@@ -140,7 +140,7 @@ __class__::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 @example_myparticle    iEvent.getByLabel( electronTags_, electrons );
 @example_myparticle    
 @example_myparticle    // create a new collection of Particle objects
-@example_myparticle    auto_ptr<MyParticleCollection> newParticles( new MyParticleCollection );      
+@example_myparticle    unique_ptr<MyParticleCollection> newParticles( new MyParticleCollection );
 @example_myparticle 
 @example_myparticle    // if the number of electrons or muons is 4 (or 2 and 2), costruct a new particle
 @example_myparticle    if( muons->size() == 4 || electrons->size() == 4 || ( muons->size() == 2 && electrons->size() == 2 ) ) {
@@ -170,7 +170,7 @@ __class__::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 @example_myparticle    }
 @example_myparticle    
 @example_myparticle    // save the vector
-@example_myparticle    iEvent.put( newParticles, "particles" );
+@example_myparticle    iEvent.put( move(newParticles), "particles" );
 }
 
 // ------------ method called once each job just before starting event loop  ------------

--- a/IOPool/SecondaryInput/test/SecondaryProducer.cc
+++ b/IOPool/SecondaryInput/test/SecondaryProducer.cc
@@ -146,10 +146,10 @@ namespace edm {
     WTC const* wtp = static_cast<WTC const*>(ep);
     assert(wtp);
     TC const* tp = wtp->product();
-    std::auto_ptr<TC> thing(new TC(*tp));
+    std::unique_ptr<TC> thing(new TC(*tp));
 
     // Put output into event
-    e.put(thing);
+    e.put(std::move(thing));
 
     if(!sequential_ && !specified_ && firstLoop_ && en == 1) {
       expectedEventNumber_ = 1;

--- a/IOPool/Streamer/test/StreamThingProducer.cc
+++ b/IOPool/Streamer/test/StreamThingProducer.cc
@@ -50,7 +50,7 @@ namespace edmtest_thing
   void StreamThingProducer::produce(edm::Event& e, edm::EventSetup const&)
   {
     for(int i = 0; i < inst_count_; ++i) {
-	std::auto_ptr<WriteThis> result(new WriteThis(size_));
+      std::unique_ptr<WriteThis> result(new WriteThis(size_));
 
         // The purpose of this masking is to allow
         // some limited control of how much smaller these
@@ -62,7 +62,7 @@ namespace edmtest_thing
           }
         }
 
-	e.put(result,names_[i]);
+      e.put(std::move(result),names_[i]);
     }
 
     //std::auto_ptr<TestDbl> d(new TestDbl);


### PR DESCRIPTION
Given that the C++ standard has deprecated the use of std::auto_ptr, we want to encourage the use of std::unique_ptr. To that end, the framework now supports its use in the various 'put' functions along with the put using the legacy std::auto_ptr.
