### PR TITLE
Remove unused data member

### DIFF
--- a/FWCore/Utilities/interface/TypeWithDict.h
+++ b/FWCore/Utilities/interface/TypeWithDict.h
@@ -141,7 +141,6 @@ std::ostream& operator<<(std::ostream& os, TypeWithDict const& id);
 
 class TypeBases {
 private:
-  TType* type_;
   TClass* class_;
 public:
   explicit TypeBases(TypeWithDict const&);
@@ -152,7 +151,6 @@ public:
 
 class TypeDataMembers {
 private:
-  TType* type_;
   TClass* class_;
 public:
   explicit TypeDataMembers(TypeWithDict const&);
@@ -163,7 +161,6 @@ public:
 
 class TypeFunctionMembers {
 private:
-  TType* type_;
   TClass* class_;
 public:
   explicit TypeFunctionMembers(TypeWithDict const&);

--- a/FWCore/Utilities/interface/TypeWithDict.h
+++ b/FWCore/Utilities/interface/TypeWithDict.h
@@ -48,7 +48,6 @@ private:
   TDataType* dataType_;
   long property_;
 private:
-  void setProperty();
   void processEnumeration();
 public:
   static TypeWithDict byName(std::string const& name, long property = 0L);

--- a/FWCore/Utilities/src/TypeWithDict.cc
+++ b/FWCore/Utilities/src/TypeWithDict.cc
@@ -831,7 +831,6 @@ namespace edm {
   //
 
   TypeBases::TypeBases(TypeWithDict const& type) :
-    type_(type.type_),
     class_(type.class_) {
   }
 
@@ -861,7 +860,6 @@ namespace edm {
   //
 
   TypeDataMembers::TypeDataMembers(TypeWithDict const& type) :
-    type_(type.type_),
     class_(type.class_) {
   }
 
@@ -891,7 +889,6 @@ namespace edm {
   //
 
   TypeFunctionMembers::TypeFunctionMembers(TypeWithDict const& type) :
-    type_(type.type_),
     class_(type.class_) {
   }
 

--- a/FWCore/Utilities/src/TypeWithDict.cc
+++ b/FWCore/Utilities/src/TypeWithDict.cc
@@ -75,28 +75,6 @@ namespace edm {
     return TypeWithDict(type, property);
   }
 
-  void
-  TypeWithDict::setProperty() {
-    // Note: typeid() ignores const and volatile qualifiers, and
-    //       cannot see references.
-    //       So:
-    //            typeid(int) == typeid(int const)
-    //                        == typeid(int&)
-    //                        == typeid(int const&)
-    //
-    if (type_ == nullptr) {
-      return;
-    }
-    if (gInterpreter->Type_IsConst(type_)) {
-      // Note: This is not possible if created by typeid.
-      property_ |= (long) kIsConstant;
-    }
-    if (gInterpreter->Type_IsReference(type_)) {
-      // Note: This is not possible if created by typeid.
-      property_ |= (long) kIsReference;
-    }
-  }
-
   TypeWithDict::TypeWithDict() :
     ti_(&typeid(void)),
     type_(nullptr),


### PR DESCRIPTION
The type_ data member of classes typeBases, TypeDataMembers, and TypeFunctionMembers is no longer used.  Remove it.
Also, the function TypeWithDict::setProperty() is unused.  Remove it also.
Please merge this techinical trivial ROOT6 specific pull request as soon as convenient.
