### PR TITLE
Update code to match new Wrapper constructor API

### DIFF
--- a/EventFilter/Utilities/plugins/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/plugins/FedRawDataInputSource.cc
@@ -565,8 +565,8 @@ void FedRawDataInputSource::deleteFile(std::string const& fileName)
 
 void FedRawDataInputSource::read(edm::EventPrincipal& eventPrincipal)
 {
-  std::auto_ptr<FEDRawDataCollection> rawData(new FEDRawDataCollection);
-  edm::Timestamp tstamp = fillFEDRawDataCollection(rawData);
+  std::unique_ptr<FEDRawDataCollection> rawData(new FEDRawDataCollection);
+  edm::Timestamp tstamp = fillFEDRawDataCollection(*rawData);
 
   if (useL1EventID_)
     eventID_ = edm::EventID(eventRunNumber_, currentLumiSection_, L1EventID_); 
@@ -580,7 +580,7 @@ void FedRawDataInputSource::read(edm::EventPrincipal& eventPrincipal)
   aux.setProcessHistoryID(processHistoryID_);
   makeEvent(eventPrincipal, aux);
 
-  std::unique_ptr<edm::WrapperBase> edp(new edm::Wrapper<FEDRawDataCollection>(rawData));
+  std::unique_ptr<edm::WrapperBase> edp(new edm::Wrapper<FEDRawDataCollection>(std::move(rawData)));
 
   //FWCore/Sources DaqProvenanceHelper before 7_1_0_pre3
   //eventPrincipal.put(daqProvenanceHelper_.constBranchDescription_, edp,
@@ -618,7 +618,7 @@ void FedRawDataInputSource::read(edm::EventPrincipal& eventPrincipal)
   return;
 }
 
-edm::Timestamp FedRawDataInputSource::fillFEDRawDataCollection(std::auto_ptr<FEDRawDataCollection>& rawData)
+edm::Timestamp FedRawDataInputSource::fillFEDRawDataCollection(FEDRawDataCollection& rawData)
 {
   edm::Timestamp tstamp;
   uint32_t eventSize = event_->eventSize();
@@ -648,7 +648,7 @@ edm::Timestamp FedRawDataInputSource::fillFEDRawDataCollection(std::auto_ptr<FED
         GTPEventID_ = evf::evtn::gtpe_get((unsigned char*) fedHeader);
       }
     }
-    FEDRawData& fedData = rawData->FEDData(fedId);
+    FEDRawData& fedData = rawData.FEDData(fedId);
     fedData.resize(fedSize);
     memcpy(fedData.data(), event + eventSize, fedSize);
   }

--- a/EventFilter/Utilities/plugins/FedRawDataInputSource.h
+++ b/EventFilter/Utilities/plugins/FedRawDataInputSource.h
@@ -57,7 +57,7 @@ private:
   void maybeOpenNewLumiSection(const uint32_t lumiSection);
   evf::EvFDaqDirector::FileStatus nextEvent();
   evf::EvFDaqDirector::FileStatus getNextEvent();
-  edm::Timestamp fillFEDRawDataCollection(std::auto_ptr<FEDRawDataCollection>&);
+  edm::Timestamp fillFEDRawDataCollection(FEDRawDataCollection&);
   void deleteFile(std::string const&);
   int grabNextJsonFile(boost::filesystem::path const&);
   void renameToNextFree(std::string const& fileName) const;

--- a/GeneratorInterface/LHEInterface/plugins/LHESource.cc
+++ b/GeneratorInterface/LHEInterface/plugins/LHESource.cc
@@ -127,7 +127,7 @@ void LHESource::beginRun(edm::Run&)
 	if (runInfoLast) {
 		runInfo = runInfoLast;
 
-		std::auto_ptr<LHERunInfoProduct> product(
+		std::unique_ptr<LHERunInfoProduct> product(
 				new LHERunInfoProduct(*runInfo->getHEPRUP()));
 		std::for_each(runInfo->getHeaders().begin(),
 		              runInfo->getHeaders().end(),
@@ -143,7 +143,7 @@ void LHESource::beginRun(edm::Run&)
 		runInfoProducts.push_back(new LHERunInfoProduct(*product));
 		wasMerged = false;
 
-                std::unique_ptr<edm::WrapperBase> rdp(new edm::Wrapper<LHERunInfoProduct>(product));
+                std::unique_ptr<edm::WrapperBase> rdp(new edm::Wrapper<LHERunInfoProduct>(std::move(product)));
 		runPrincipal_->put(lheProvenanceHelper_.runProductBranchDescription_, std::move(rdp));
 
 		runInfo.reset();
@@ -153,9 +153,9 @@ void LHESource::beginRun(edm::Run&)
 void LHESource::endRun(edm::Run&)
 {
 	if (!runInfoProducts.empty()) {
-		std::auto_ptr<LHERunInfoProduct> product(
+		std::unique_ptr<LHERunInfoProduct> product(
 					runInfoProducts.pop_front().release());
-                std::unique_ptr<edm::WrapperBase> rdp(new edm::Wrapper<LHERunInfoProduct>(product));
+                std::unique_ptr<edm::WrapperBase> rdp(new edm::Wrapper<LHERunInfoProduct>(std::move(product)));
 		runPrincipal_->put(lheProvenanceHelper_.runProductBranchDescription_, std::move(rdp));
 	}
 	runPrincipal_ = nullptr;
@@ -182,7 +182,7 @@ LHESource::readEvent_(edm::EventPrincipal& eventPrincipal) {
 	aux.setProcessHistoryID(phid_);
 	eventPrincipal.fillEventPrincipal(aux, processHistoryRegistryForUpdate());
 
-	std::auto_ptr<LHEEventProduct> product(
+	std::unique_ptr<LHEEventProduct> product(
 		     new LHEEventProduct(*partonLevel->getHEPEUP(),
 					 partonLevel->originalXWGTUP())
 		     );
@@ -201,7 +201,7 @@ LHESource::readEvent_(edm::EventPrincipal& eventPrincipal) {
 	              boost::bind(&LHEEventProduct::addComment,
 	                          product.get(), _1));
 
-	std::unique_ptr<edm::WrapperBase> edp(new edm::Wrapper<LHEEventProduct>(product));
+	std::unique_ptr<edm::WrapperBase> edp(new edm::Wrapper<LHEEventProduct>(std::move(product)));
 	eventPrincipal.put(lheProvenanceHelper_.eventProductBranchDescription_, std::move(edp), lheProvenanceHelper_.eventProductProvenance_);
 
 	partonLevel.reset();


### PR DESCRIPTION
The Wrapper class switch from using a std::auto_ptr to a std::unique_ptr.
This code was missed in the first pass of updating all code to use the
new API.
