### PR TITLE
Fix memory leak in ME0SegmentMatcher

### DIFF
--- a/RecoMuon/MuonIdentification/plugins/ME0SegmentMatcher.cc
+++ b/RecoMuon/MuonIdentification/plugins/ME0SegmentMatcher.cc
@@ -66,7 +66,7 @@ void ME0SegmentMatcher::produce(edm::Event& ev, const edm::EventSetup& setup) {
       //Initializing our plane
       float zSign  = thisTrack->pz()/fabs(thisTrack->pz());
       float zValue = 560. * zSign;
-      Plane *plane = new Plane(Surface::PositionType(0,0,zValue),Surface::RotationType());
+      Plane plane(Surface::PositionType(0,0,zValue),Surface::RotationType());
       //Getting the initial variables for propagation
       int chargeReco = thisTrack->charge(); 
       GlobalVector p3reco, r3reco;
@@ -88,7 +88,7 @@ void ME0SegmentMatcher::produce(edm::Event& ev, const edm::EventSetup& setup) {
       const SteppingHelixPropagator* ThisshProp = 
 	dynamic_cast<const SteppingHelixPropagator*>(&*shProp);
 	
-      lastrecostate = ThisshProp->propagate(startrecostate, *plane);
+      lastrecostate = ThisshProp->propagate(startrecostate, plane);
 	
       FreeTrajectoryState finalrecostate;
       lastrecostate.getFreeState(finalrecostate);


### PR DESCRIPTION
Fixes a small memory leak in ME0SegmentMatcher that looks to be proportional to the number of tracks.  At 140 pileup this is about half a Mb per event.
Plot of retained memory before an after below.

Leak pointed out by David Lange.

![me0segmentmatcher](https://cloud.githubusercontent.com/assets/6480160/4182520/bdc7b9ba-372f-11e4-9a30-49720ca44527.png)

(**EDIT** - I've just realised I labelled the series incorrectly. "After" is of course the line with flat memory use)
