### PR TITLE
add support for post LS1 photon path validation for Egamma HLT RelVal

### DIFF
--- a/HLTriggerOffline/Egamma/src/EmDQM.cc
+++ b/HLTriggerOffline/Egamma/src/EmDQM.cc
@@ -1451,6 +1451,9 @@ EmDQM::makePSetForEgammaGenericQuadraticFilter(const std::string& moduleName)
       inputType == "EgammaHLTClusterShapeProducer" ||                  // cluster shape
       inputType == "EgammaHLTEcalRecIsolationProducer" ||              // ecal isolation
       inputType == "EgammaHLTHcalIsolationProducersRegional" ||        // HCAL isolation and HE
+      inputType == "EgammaHLTBcHcalIsolationProducersRegional" ||      // HCAL isolation and HE
+      inputType == "EgammaHLTEcalPFClusterIsolationProducer" ||        // ECAL PF isolation filter
+      inputType == "EgammaHLTHcalPFClusterIsolationProducer" ||        // HCAL PF isolation filter
       inputType == "EgammaHLTPhotonTrackIsolationProducersRegional"    // Photon track isolation
      ) {
     retPSet.addParameter<std::vector<double> >("PlotBounds", std::vector<double>(2, 0.0));

--- a/HLTriggerOffline/Egamma/test/testEmDQM_cfg.py
+++ b/HLTriggerOffline/Egamma/test/testEmDQM_cfg.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("emdqm")
 
 process.load('Configuration/StandardSequences/FrontierConditions_GlobalTag_cff')
-process.GlobalTag.globaltag = 'PRE_LS171_V7::All'
+process.GlobalTag.globaltag = 'START72_V1::All'
 
 process.load("FWCore.MessageService.MessageLogger_cfi")
 # suppress printout of error messages on every event when a collection is missing in the event
@@ -15,7 +15,7 @@ process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
 
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring(
-        '/store/relval/CMSSW_7_1_0_pre7/RelValZEE_13/GEN-SIM-DIGI-RAW-HLTDEBUG/PRE_LS171_V7-v1/00000/06D540C7-B1D0-E311-A86E-02163E00E81C.root',
+        'file:../../../HLTrigger/Configuration/test/outputAForPP.root',
 #        '/store/relval/CMSSW_7_1_0_pre7/RelValH130GGgluonfusion_13/GEN-SIM-DIGI-RAW-HLTDEBUG/PRE_LS171_V7-v1/00000/C87CDC3A-B1D0-E311-8890-02163E00E6DE.root',
 #        '/store/relval/CMSSW_7_1_0_pre7/RelValWE_13/GEN-SIM-DIGI-RAW-HLTDEBUG/PRE_LS171_V7-v1/00000/665BE840-B4D0-E311-BBA6-02163E00E694.root',
 #        '/store/relval/CMSSW_7_1_0_pre7/RelValPhotonJets_Pt_10_13/GEN-SIM-DIGI-RAW-HLTDEBUG/PRE_LS171_V7-v1/00000/C0AB31B9-A2D0-E311-A15D-02163E00E725.root',
@@ -32,6 +32,8 @@ process.emdqm.mcMatchedOnly = cms.untracked.bool(False)
 process.emdqm.noPhiPlots = cms.untracked.bool(False)
 # switch for 2D isolation plots
 process.emdqm.noIsolationPlots = cms.untracked.bool(False)
+# which trigger object and process should we run on?
+#process.emdqm.triggerobject = cms.InputTag("hltTriggerSummaryRAW","","HLTTEST")
 
 process.p = cms.Path(
                      # require generated particles in fiducial volume


### PR DESCRIPTION
The photon paths in the new HLT menu were not validated properly so far due to a filter using a collection from an unknown producer. Made the the producer type known to the validation tool to fix this.
