### PR TITLE
For new phase2digitizers (Reverting the DetId renumbering fix)

### DIFF
--- a/SimTracker/SiPhase2Digitizer/BuildFile.xml
+++ b/SimTracker/SiPhase2Digitizer/BuildFile.xml
@@ -16,7 +16,6 @@
 <use   name="clhep"/>
 <use   name="root"/>
 <use   name="rootflx"/>
-<use name="SimTracker/SiPixelDigitizer"/>
 <library   file="*.cc" name="SimTrackerSiPhase2DigitizerPlugins">
   <flags   EDM_PLUGIN="1"/>
 </library>

--- a/SimTracker/SiPhase2Digitizer/plugins/SiPhase2Digitizer.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/SiPhase2Digitizer.cc
@@ -176,12 +176,8 @@ namespace cms
       edm::Handle<std::vector<PSimHit> > simHits;
       edm::InputTag tag(hitsProducer, *i);
 
-      // MODIFIED Mark Grimes 05/Jul/2014 - There was a problem reading back production samples made with
-      // SLHC11 because the DetId numbering changed in SLHC13. This is a horrible temporary hack to allow
-      // those samples to be read in newer versions of CMSSW. As soon as this ability is no longer required
-      // the next (i.e. original) line should be uncommented and the one after removed. Forever.
-      //iEvent.getByLabel(tag, simHits);
-      detIdRemapService_->getByLabel( iEvent, tag, simHits );
+      // MODIFIED G. Boudoul 08/Sept/2014 - Removing Mark's hack, this package will not use old GENSIM.
+      iEvent.getByLabel(tag, simHits);
       unsigned int tofBin = PixelDigiSimLink::LowTof;
       if ((*i).find(std::string("HighTof")) != std::string::npos) tofBin = PixelDigiSimLink::HighTof;
       accumulatePixelHits(simHits, crossingSimHitIndexOffset_[tag.encode()], tofBin);
@@ -200,12 +196,8 @@ namespace cms
       edm::Handle<std::vector<PSimHit> > simHits;
       edm::InputTag tag(hitsProducer, *i);
 
-      // MODIFIED Mark Grimes 05/Jul/2014 - There was a problem reading back production samples made with
-      // SLHC11 because the DetId numbering changed in SLHC13. This is a horrible temporary hack to allow
-      // those samples to be read in newer versions of CMSSW. As soon as this ability is no longer required
-      // the next (i.e. original) line should be uncommented and the one after removed. Forever.
-      //iEvent.getByLabel(tag, simHits);
-      detIdRemapService_->getByLabel( iEvent, tag, simHits );
+      // MODIFIED G. Boudoul 08/Sept/2014 - Removing Mark's hack, this package will not use old GENSIM.
+      iEvent.getByLabel(tag, simHits);
       unsigned int tofBin = PixelDigiSimLink::LowTof;
       if ((*i).find(std::string("HighTof")) != std::string::npos) tofBin = PixelDigiSimLink::HighTof;
       accumulatePixelHits(simHits, crossingSimHitIndexOffset_[tag.encode()], tofBin);

--- a/SimTracker/SiPhase2Digitizer/plugins/SiPhase2Digitizer.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/SiPhase2Digitizer.h
@@ -21,10 +21,6 @@
 #include "SimGeneral/MixingModule/interface/DigiAccumulatorMixMod.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 
-// Take these next two lines out as soon as SLHC11 samples no longer need to be processed
-#include <FWCore/ServiceRegistry/interface/Service.h>
-#include <SimTracker/SiPixelDigitizer/interface/RemapDetIdService.h>
-
 namespace CLHEP {
   class HepRandomEngine;
 }
@@ -83,8 +79,6 @@ namespace cms {
     std::map<unsigned int, PixelGeomDetUnit*> detectorUnits;
     CLHEP::HepRandomEngine* rndEngine;
 
-    // Take this member out as soon as SLHC11 files no longer need to be processed
-    edm::Service<simtracker::services::RemapDetIdService> detIdRemapService_;
     // infrastructure to reject dead pixels as defined in db (added by F.Blekman)
   };
 }


### PR DESCRIPTION
This package for phase2 digitizer  is intended to be tested and used whith fresh GENSIM, so no need for the backward compatibility introduced in PR #4740  
As a consequence the PR #4725 will have to be updated too.
