### PR TITLE
B2G HLT DQM bug fix

### DIFF
--- a/HLTriggerOffline/B2G/python/b2gHadronicHLTEventValidation_cfi.py
+++ b/HLTriggerOffline/B2G/python/b2gHadronicHLTEventValidation_cfi.py
@@ -11,5 +11,5 @@ b2gSingleJetHLTValidation = cms.EDAnalyzer('B2GHadronicHLTValidation',
         minJets      = cms.untracked.uint32(1),
         # Trigger
         sTrigger     = cms.untracked.string("TriggerResults"),
-        vsPaths      = cms.untracked.vstring(['HLT_AK8PFJet360TrimMod_Mass30_v1']),
+        vsPaths      = cms.untracked.vstring(['HLT_AK8PFJet360TrimMod_Mass30']),
 )

--- a/HLTriggerOffline/B2G/python/b2gSingleLeptonHLTEventValidation_cfi.py
+++ b/HLTriggerOffline/B2G/python/b2gSingleLeptonHLTEventValidation_cfi.py
@@ -22,7 +22,7 @@ b2gSingleMuonHLTValidation = cms.EDAnalyzer('B2GSingleLeptonHLTValidation',
         minJets      = cms.untracked.uint32(2),
         # Trigger
         sTrigger     = cms.untracked.string("TriggerResults"),
-        vsPaths      = cms.untracked.vstring(['HLT_Mu40_eta2p1_PFJet200_PFJet50_v1']),
+        vsPaths      = cms.untracked.vstring(['HLT_Mu40_eta2p1_PFJet200_PFJet50']),
 )
 
 # ttbar semi electronique
@@ -47,5 +47,5 @@ b2gSingleElectronHLTValidation = cms.EDAnalyzer('B2GSingleLeptonHLTValidation',
         minJets      = cms.untracked.uint32(2),
         # Trigger
         sTrigger     = cms.untracked.string("TriggerResults"),
-        vsPaths      = cms.untracked.vstring(['HLT_Ele45_CaloIdVT_GsfTrkIdT_PFJet200_PFJet50_v1']),
+        vsPaths      = cms.untracked.vstring(['HLT_Ele45_CaloIdVT_GsfTrkIdT_PFJet200_PFJet50']),
 )

--- a/HLTriggerOffline/B2G/src/B2GHadronicHLTValidation.cc
+++ b/HLTriggerOffline/B2G/src/B2GHadronicHLTValidation.cc
@@ -113,6 +113,8 @@ B2GHadronicHLTValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
 
   }
   if (isSel_) {
+    hNumJetPt->Fill(jet_->pt());
+    hNumJetEta->Fill(jet_->eta());
     for (unsigned int i=0; i<triggerNames.triggerNames().size(); ++i) {
       TString name = triggerNames.triggerNames()[i].c_str();
       for (unsigned int j=0; j<vsPaths_.size(); j++) {


### PR DESCRIPTION
Here is a bug fix for the B2G HLT DQM, where the selected histograms were accidentally not being filled.

I also added some future compatibility by removing the explicit "v1" at the end of the triggers. Since the code checks "contains" instead of "equals", this is supported. 
