### PR TITLE
Avoid direct use of TType in ObjectWithDIct

### DIFF
--- a/FWCore/Services/src/InitRootHandlers.cc
+++ b/FWCore/Services/src/InitRootHandlers.cc
@@ -19,6 +19,7 @@
 #include "TROOT.h"
 #include "TError.h"
 #include "TFile.h"
+#include "TInterpreter.h"
 #include "TH1.h"
 #include "TSystem.h"
 #include "TUnixSystem.h"

--- a/FWCore/Utilities/interface/ObjectWithDict.h
+++ b/FWCore/Utilities/interface/ObjectWithDict.h
@@ -7,18 +7,16 @@ ObjectWithDict:  A holder for an object and its type information.
 
 ----------------------------------------------------------------------*/
 
-#include "TInterpreter.h"
-
 #include <string>
 #include <typeinfo>
 
-namespace edm {
+#include "FWCore/Utilities/interface/TypeWithDict.h"
 
-class TypeWithDict;
+namespace edm {
 
 class ObjectWithDict {
 private:
-  TType* type_;
+  TypeWithDict type_;
   void* address_;
 public:
   static ObjectWithDict byType(TypeWithDict const&);
@@ -43,6 +41,5 @@ public:
 
 } // namespace edm
 
-#include "FWCore/Utilities/interface/TypeWithDict.h"
 
 #endif // FWCore_Utilities_ObjectWithDict_h

--- a/FWCore/Utilities/src/ObjectWithDict.cc
+++ b/FWCore/Utilities/src/ObjectWithDict.cc
@@ -14,21 +14,21 @@ namespace edm {
     return obj;
   }
 
-  ObjectWithDict::ObjectWithDict() : type_(nullptr), address_(nullptr) {
+  ObjectWithDict::ObjectWithDict() : type_(), address_(nullptr) {
   }
 
   ObjectWithDict::ObjectWithDict(TypeWithDict const& type, void* address) :
-    type_(static_cast<TType*>(type.ttype())),
+    type_(type),
     address_(address) {
   }
 
   ObjectWithDict::ObjectWithDict(std::type_info const& ti, void* address) :
-    type_(static_cast<TType*>(TypeWithDict(ti).ttype())),
+    type_(TypeWithDict(ti)),
     address_(address) {
   }
 
   ObjectWithDict::operator bool() const {
-    return gInterpreter->Type_Bool(type_) && (address_ != nullptr);
+    return bool(type_) && (address_ != nullptr);
   }
 
   void*
@@ -38,7 +38,7 @@ namespace edm {
 
   TypeWithDict
   ObjectWithDict::typeOf() const {
-    return TypeWithDict(type_);
+    return type_;
   }
 
   class DummyVT {
@@ -51,8 +51,8 @@ namespace edm {
 
   TypeWithDict
   ObjectWithDict::dynamicType() const {
-    if (!gInterpreter->Type_IsVirtual(type_)) {
-      return TypeWithDict(type_);
+    if (!type_.isVirtual()) {
+      return type_;
     }
     // Use a dirty trick, force the typeid() operator
     // to consult the virtual table stored at address_.
@@ -61,7 +61,7 @@ namespace edm {
 
   ObjectWithDict
   ObjectWithDict::get(std::string const& memberName) const {
-    return TypeWithDict(type_).dataMemberByName(memberName).get(*this);
+    return type_.dataMemberByName(memberName).get(*this);
   }
 
   ObjectWithDict
@@ -101,8 +101,7 @@ namespace edm {
 
   void
   ObjectWithDict::destruct(bool dealloc) const {
-    TypeWithDict ty(type_);
-    TClass* cl = ty.getClass();
+    TClass* cl = type_.getClass();
     if (cl != nullptr) {
       cl->Destructor(address_, !dealloc);
       //if (dealloc) {


### PR DESCRIPTION
In order to reduce header parsing, which will save memory, we are eliminating unnecessary uses of the TType class.  This pull request removes the direct use of TType in class ObjectWithDict.  After this pull request is merged, the use of TType will be confined to class TypeWithDict.
Please merge this pull request as soon as convenient.
