### PR TITLE
Enable new pixel cluster position features

### DIFF
--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGeneric.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGeneric.h
@@ -43,7 +43,7 @@
 #include <utility>
 #include <vector>
 
-//#define NEW_CPEERROR // must be constistent with base.cc, generic cc/h and genericProducer.cc 
+#define NEW_CPEERROR // must be constistent with base.cc, generic cc/h and genericProducer.cc 
 
 #if 0
 /** \class PixelCPEGeneric

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEGenericESProducer.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEGenericESProducer.cc
@@ -17,7 +17,7 @@
 #include <string>
 #include <memory>
 
-//#define NEW_CPEERROR // must be constistent with base.cc, generic cc/h and genericProducer.cc 
+#define NEW_CPEERROR // must be constistent with base.cc, generic cc/h and genericProducer.cc 
 
 using namespace edm;
 

--- a/RecoLocalTracker/SiPixelRecHits/python/PixelCPEGeneric_cfi.py
+++ b/RecoLocalTracker/SiPixelRecHits/python/PixelCPEGeneric_cfi.py
@@ -49,8 +49,8 @@ PixelCPEGenericESProducer = cms.ESProducer("PixelCPEGenericESProducer",
     #lAWidthFPix = cms.double(0.0),
 
     # Flag to select the source of LA-Width
-    # Normal = True, use LA from DB, not ready yet
-    useLAWidthFromDB = cms.bool(False),                             
+    # Normal = True, use LA from DB
+    useLAWidthFromDB = cms.bool(True),                             
     # if lAWith=0 and useLAWidthFromDB=false than width is calculated from lAOffset.         
     # Use the LA-Offsets from Alignment instead of our calibration
     useLAAlignmentOffsets = cms.bool(False),                             

--- a/RecoLocalTracker/SiPixelRecHits/python/PixelCPETemplateReco_cfi.py
+++ b/RecoLocalTracker/SiPixelRecHits/python/PixelCPETemplateReco_cfi.py
@@ -12,8 +12,8 @@ templates = cms.ESProducer("PixelCPETemplateRecoESProducer",
     # gavril
     DoCosmics = cms.bool(False), 
     # The flag to regulate if the LA offset is taken from Alignment 
-    # Will be True in the future for offline RECO. kevin 
-    DoLorentz = cms.bool(False),
+    # True in Run II for offline RECO
+    DoLorentz = cms.bool(True),
  
     LoadTemplatesFromDB = cms.bool(True)
 

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEBase.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEBase.cc
@@ -28,7 +28,7 @@
 
 using namespace std;
 
-//#define NEW_CPEERROR // must be constistent with base.cc, generic cc/h and genericProducer.cc 
+#define NEW_CPEERROR // must be constistent with base.cc, generic cc/h and genericProducer.cc 
 
 namespace {
 #ifndef NEW_CPEERROR  

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc
@@ -18,7 +18,7 @@
 #include <iostream>
 using namespace std;
 
-//#define NEW_CPEERROR // must be constistent with base.cc, generic cc/h and genericProducer.cc 
+#define NEW_CPEERROR // must be constistent with base.cc, generic cc/h and genericProducer.cc 
 
 namespace {
   constexpr float micronsToCm = 1.0e-4;


### PR DESCRIPTION
Three new features for pixel cluster position estimation (CPE) were included in 7_1_0, but not yet activated since they rely on global tag information, available since MC_72_V2 and GR_R_72_V3.
Here these features are activated.
1. Enable GenErrors database object for generic CPE, which are faster than the full template database objects previously used.
2. Enable to take the lorentz angle width from database (instead of configuration)
3. Enable lorentz angle estimate from alignment from database. Currently database entries are 0 such that this has no effect until alignment input.
It was checked that none of these features changes pixel cluster position resolution within 1% of the resolution.
