### PR TITLE
Update class checksums for new version of ROOT

### DIFF
--- a/DataFormats/TauReco/src/classes_def_1.xml
+++ b/DataFormats/TauReco/src/classes_def_1.xml
@@ -18,9 +18,10 @@
   <class name="edm::RefProd<std::vector<reco::BaseTauTagInfo> >"/>
   <class name="edm::RefVector<std::vector<reco::BaseTauTagInfo>,reco::BaseTauTagInfo,edm::refhelper::FindUsingAdvance<std::vector<reco::BaseTauTagInfo>,reco::BaseTauTagInfo> >"/>
   
-  <class name="reco::CaloTauTagInfo" ClassVersion="11">
+  <class name="reco::CaloTauTagInfo" ClassVersion="12">
    <version ClassVersion="10" checksum="3077166108"/>
    <version ClassVersion="11" checksum="442155907"/>
+   <version ClassVersion="12" checksum="3608080402"/>
   </class>
   <class name="std::vector<reco::CaloTauTagInfo>"/>
   <class name="edm::Wrapper<std::vector<reco::CaloTauTagInfo> >"/>
@@ -28,7 +29,8 @@
   <class name="edm::RefProd<std::vector<reco::CaloTauTagInfo> >"/>
   <class name="edm::RefVector<std::vector<reco::CaloTauTagInfo>,reco::CaloTauTagInfo,edm::refhelper::FindUsingAdvance<std::vector<reco::CaloTauTagInfo>,reco::CaloTauTagInfo> >"/>
 
-  <class name="reco::PFTauTagInfo" ClassVersion="11">
+  <class name="reco::PFTauTagInfo" ClassVersion="12">
+   <version ClassVersion="12" checksum="3598523528"/>
    <version ClassVersion="11" checksum="2849126593"/>
    <version ClassVersion="10" checksum="2791906466"/>
   </class>
@@ -81,8 +83,9 @@ for(auto const& ref : onfile.PFGammaCands_) {
 
 
   
-  <class name="reco::BaseTau" ClassVersion="10">
+  <class name="reco::BaseTau" ClassVersion="11">
    <version ClassVersion="10" checksum="3887454152"/>
+   <version ClassVersion="11" checksum="3609212284"/>
   </class>
   <class name="std::vector<reco::BaseTau>"/>
   <class name="edm::Wrapper<std::vector<reco::BaseTau> >"/>
@@ -91,8 +94,9 @@ for(auto const& ref : onfile.PFGammaCands_) {
   <class name="edm::RefVector<std::vector<reco::BaseTau>,reco::BaseTau,edm::refhelper::FindUsingAdvance<std::vector<reco::BaseTau>,reco::BaseTau> >"/>
   <class name="edm::reftobase::Holder<reco::Candidate, edm::Ref<std::vector<reco::BaseTau>,reco::BaseTau,edm::refhelper::FindUsingAdvance<std::vector<reco::BaseTau>,reco::BaseTau> > >" />
   
-  <class name="reco::CaloTau" ClassVersion="10">
+  <class name="reco::CaloTau" ClassVersion="11">
    <version ClassVersion="10" checksum="1329876375"/>
+   <version ClassVersion="11" checksum="1065337651"/>
   </class>
   <class name="std::vector<reco::CaloTau>"/>
   <class name="edm::Wrapper<std::vector<reco::CaloTau> >"/>

--- a/DataFormats/TauReco/src/classes_def_2.xml
+++ b/DataFormats/TauReco/src/classes_def_2.xml
@@ -1,6 +1,7 @@
 <lcgdict>
   
-  <class name="reco::PFTau" ClassVersion="15">
+  <class name="reco::PFTau" ClassVersion="16">
+    <version ClassVersion="16" checksum="2695990650"/>
     <version ClassVersion="15" checksum="4105994460"/>
     <version ClassVersion="14" checksum="3087106015"/>
     <version ClassVersion="13" checksum="1088944403"/>
@@ -204,7 +205,8 @@ for(auto const& ref : onfile.selectedIsolationPFGammaCands_) {
 <!-- </ioread> -->
 
 
-  <class name="reco::PFTauDecayMode" ClassVersion="10">
+  <class name="reco::PFTauDecayMode" ClassVersion="11">
+   <version ClassVersion="11" checksum="3414615810"/>
    <version ClassVersion="10" checksum="2108215737"/>
   </class>
   <class name="std::vector<reco::PFTauDecayMode>"/>
@@ -218,7 +220,8 @@ for(auto const& ref : onfile.selectedIsolationPFGammaCands_) {
   <class name="edm::Wrapper<edm::Association<std::vector<reco::PFTauDecayMode> > >"/>
   <class name="edm::Wrapper<edm::Association<std::vector<reco::PFTau> > >"/>
 
-  <class name="reco::RecoTauPiZero" ClassVersion="10">
+  <class name="reco::RecoTauPiZero" ClassVersion="11">
+   <version ClassVersion="11" checksum="2458276705"/>
    <version ClassVersion="10" checksum="465425628"/>
   </class>
   <class name="std::vector<reco::RecoTauPiZero>"/>
@@ -229,7 +232,8 @@ for(auto const& ref : onfile.selectedIsolationPFGammaCands_) {
   <class name="edm::RefVector<std::vector<reco::RecoTauPiZero>,reco::RecoTauPiZero,edm::refhelper::FindUsingAdvance<std::vector<reco::RecoTauPiZero>,reco::RecoTauPiZero> >"/>
   <class name="edm::reftobase::Holder<reco::CompositePtrCandidate, edm::Ref<std::vector<reco::RecoTauPiZero>,reco::RecoTauPiZero,edm::refhelper::FindUsingAdvance<std::vector<reco::RecoTauPiZero>,reco::RecoTauPiZero> > >" />
 
-  <class name="reco::PFRecoTauChargedHadron" ClassVersion="11">
+  <class name="reco::PFRecoTauChargedHadron" ClassVersion="12">
+   <version ClassVersion="12" checksum="2480143236" />
    <version ClassVersion="11" checksum="858406271" />
    <version ClassVersion="10" checksum="4027987990"/>
   </class>
@@ -244,7 +248,8 @@ for(auto const& ref : onfile.selectedIsolationPFGammaCands_) {
   <class name="reco::CaloTauDiscriminatorByIsolationBase">
     <field name="transientVector_" transient="true"/>
   </class>
-  <class name="reco::CaloTauDiscriminatorByIsolation" ClassVersion="10">
+  <class name="reco::CaloTauDiscriminatorByIsolation" ClassVersion="11">
+   <version ClassVersion="11" checksum="2337069537"/>
    <version ClassVersion="10" checksum="2968502385"/>
     <!-- <field name="transientVector_" transient="true"/> -->
   </class>
@@ -256,7 +261,8 @@ for(auto const& ref : onfile.selectedIsolationPFGammaCands_) {
   <class name="reco::CaloTauDiscriminatorBase">
     <field name="transientVector_" transient="true"/>
   </class>
-  <class name="reco::CaloTauDiscriminator" ClassVersion="10">
+  <class name="reco::CaloTauDiscriminator" ClassVersion="11">
+   <version ClassVersion="11" checksum="3173873463"/>
    <version ClassVersion="10" checksum="1989330711"/>
     <!-- <field name="transientVector_" transient="true"/> -->
   </class>

--- a/DataFormats/TauReco/src/classes_def_3.xml
+++ b/DataFormats/TauReco/src/classes_def_3.xml
@@ -5,8 +5,9 @@
     <field name="transientVector_" transient="true"/>
   </class>
   -->
-  <class name="reco::CaloTauDiscriminatorAgainstElectron" ClassVersion="10">
+  <class name="reco::CaloTauDiscriminatorAgainstElectron" ClassVersion="11">
    <version ClassVersion="10" checksum="3692008801"/>
+   <version ClassVersion="11" checksum="212621489"/>
     <!-- <field name="transientVector_" transient="true"/> -->
   </class>
   <class name="reco::CaloTauDiscriminatorAgainstElectronRef"/>
@@ -23,8 +24,9 @@
   <class name="reco::PFTauDiscriminatorByIsolationBase">
     <field name="transientVector_" transient="true"/>
   </class>
-  <class name="reco::PFTauDiscriminatorByIsolation" ClassVersion="10">
+  <class name="reco::PFTauDiscriminatorByIsolation" ClassVersion="11">
    <version ClassVersion="10" checksum="1187112623"/>
+   <version ClassVersion="11" checksum="443644863"/>
     <!-- <field name="transientVector_" transient="true"/> -->
   </class>
   <class name="reco::PFTauDiscriminatorByIsolationRef"/>
@@ -42,8 +44,9 @@
     <field name="transientVector_" transient="true"/>
   </class>
 
-  <class name="reco::PFTauDiscriminator" ClassVersion="10">
+  <class name="reco::PFTauDiscriminator" ClassVersion="11">
    <version ClassVersion="10" checksum="4019319043"/>
+   <version ClassVersion="11" checksum="3738212815"/>
     <!-- <field name="transientVector_" transient="true"/> -->
   </class>
   <class name="reco::PFTauDiscriminatorRef"/>
@@ -55,8 +58,9 @@
     <field name="transientVector_" transient="true"/>
   </class>
 
-  <class name="reco::JetPiZeroAssociation" ClassVersion="10">
+  <class name="reco::JetPiZeroAssociation" ClassVersion="11">
    <version ClassVersion="10" checksum="3488813045"/>
+   <version ClassVersion="11" checksum="2107652063"/>
     <!-- <field name="transientVector_" transient="true"/> -->
   </class>
   <class name="reco::JetPiZeroAssociationRef"/>
@@ -71,8 +75,9 @@
     <field name="transientVector_" transient="true"/>
   </class>
 
-  <class name="reco::PFJetChargedHadronAssociation" ClassVersion="10">
+  <class name="reco::PFJetChargedHadronAssociation" ClassVersion="11">
    <version ClassVersion="10" checksum="3498827707"/>
+   <version ClassVersion="11" checksum="269001295"/>
 <!--     <field name="transientVector_" transient="true"/> -->
   </class>
   <class name="reco::PFJetChargedHadronAssociationRef"/>

--- a/DataFormats/TestObjects/src/classes_def.xml
+++ b/DataFormats/TestObjects/src/classes_def.xml
@@ -21,20 +21,23 @@
  <class name="edmtest::StringProduct" ClassVersion="10">
   <version ClassVersion="10" checksum="2737503723"/>
  </class>
- <class name="edmtest::Prodigal" ClassVersion="10">
+ <class name="edmtest::Prodigal" ClassVersion="11">
   <version ClassVersion="10" checksum="3510691703"/>
+  <version ClassVersion="11" checksum="1159264709"/>
  </class>
  <class name="edmtest::Simple" ClassVersion="10">
   <version ClassVersion="10" checksum="2533881336"/>
  </class>
- <class name="edmtest::SimpleDerived" ClassVersion="10">
+ <class name="edmtest::SimpleDerived" ClassVersion="11">
   <version ClassVersion="10" checksum="3753531674"/>
+  <version ClassVersion="11" checksum="802041948"/>
  </class>
  <class name="edmtest::Sortable" ClassVersion="10">
   <version ClassVersion="10" checksum="1166695033"/>
  </class>
- <class name="edmtest::Unsortable" ClassVersion="10">
+ <class name="edmtest::Unsortable" ClassVersion="11">
   <version ClassVersion="10" checksum="2720085305"/>
+  <version ClassVersion="11" checksum="3812549796"/>
  </class>
  <class name="edm::SortedCollection<edmtest::Simple, edm::StrictWeakOrdering<edmtest::Simple> >"/>
  <class name="edm::OwnVector<edmtest::Simple, edm::ClonePolicy<edmtest::Simple> >"/>

--- a/DataFormats/TrackReco/src/classes_def.xml
+++ b/DataFormats/TrackReco/src/classes_def.xml
@@ -332,7 +332,8 @@
    <version ClassVersion="10" checksum="3548207838"/>
   </class>
 
-  <class name="reco::TrackExtra" ClassVersion="10">
+  <class name="reco::TrackExtra" ClassVersion="11">
+   <version ClassVersion="11" checksum="2586227274"/>
    <version ClassVersion="10" checksum="1613098482"/>
     <field name="outerPosition_" iotype="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag>" /> 
     <field name="outerMomentum_" iotype="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag>" /> 
@@ -345,7 +346,8 @@
   <class name="edm::Ref<std::vector<reco::TrackExtra>,reco::TrackExtra,edm::refhelper::FindUsingAdvance<std::vector<reco::TrackExtra>,reco::TrackExtra> >"/>
   <class name="edm::RefVector<std::vector<reco::TrackExtra>,reco::TrackExtra,edm::refhelper::FindUsingAdvance<std::vector<reco::TrackExtra>,reco::TrackExtra> >"/>
 
-  <class name="reco::Track" ClassVersion="12">
+  <class name="reco::Track" ClassVersion="13">
+   <version ClassVersion="13" checksum="36410295"/>
    <version ClassVersion="12" checksum="1190637787"/>
    <version ClassVersion="11" checksum="1190637787"/>
    <version ClassVersion="10" checksum="1190637787"/>

--- a/DataFormats/TrackerRecHit2D/src/classes_def.xml
+++ b/DataFormats/TrackerRecHit2D/src/classes_def.xml
@@ -1,62 +1,73 @@
 <lcgdict>
-  <class name="GSSiTrackerRecHit2DLocalPos" ClassVersion="12">
+  <class name="GSSiTrackerRecHit2DLocalPos" ClassVersion="13">
+   <version ClassVersion="13" checksum="2851199532"/>
    <version ClassVersion="12" checksum="1712216203"/>
    <version ClassVersion="11" checksum="834943006"/>
    <version ClassVersion="10" checksum="2474445311"/>
   </class>
-  <class name="SiTrackerGSRecHit2D" ClassVersion="10">
+  <class name="SiTrackerGSRecHit2D" ClassVersion="11">
+   <version ClassVersion="11" checksum="1613493049"/>
    <version ClassVersion="10" checksum="877294307"/>
   </class>
-  <class name="SiTrackerGSMatchedRecHit2D" ClassVersion="10">
+  <class name="SiTrackerGSMatchedRecHit2D" ClassVersion="11">
+   <version ClassVersion="11" checksum="1553184391"/>
    <version ClassVersion="10" checksum="3741285161"/>
   </class>
 
 
-  <class name="BaseTrackerRecHit" ClassVersion="11">
-    <version ClassVersion="11" checksum="135047806"/>
+  <class name="BaseTrackerRecHit" ClassVersion="12">
+   <version ClassVersion="12" checksum="2900718455"/>
+   <version ClassVersion="11" checksum="135047806"/>
    <version ClassVersion="10" checksum="213945316"/>
      <field name="pos_" transient="true" />	 
      <field name="err_" transient="true" />	 
    </class>	 
-  <class name="TrackerSingleRecHit" ClassVersion="10">
+  <class name="TrackerSingleRecHit" ClassVersion="11">
+   <version ClassVersion="11" checksum="738485235"/>
    <version ClassVersion="10" checksum="3082889606"/>
-   </class>	 
+  </class>	 
 
   <class name="OmniClusterRef"  ClassVersion="10">
    <version ClassVersion="10" checksum="735211426"/>
   </class>
 
-  <class name="SiStripRecHit1D"  ClassVersion="12">
+  <class name="SiStripRecHit1D"  ClassVersion="13">
+   <version ClassVersion="13" checksum="1625079676"/>
    <version ClassVersion="12" checksum="3158843011"/>
    <version ClassVersion="11" checksum="1486832741"/>
    <version ClassVersion="10" checksum="1325274892"/>
   </class> 
 
-  <class name="SiStripRecHit2D"  ClassVersion="12">
+  <class name="SiStripRecHit2D"  ClassVersion="13">
+   <version ClassVersion="13" checksum="3495498287"/>
    <version ClassVersion="12" checksum="2350660116"/>
    <version ClassVersion="11" checksum="2157674799"/>
    <version ClassVersion="10" checksum="4057204970"/>
   </class>
 
 
-  <class name="ProjectedSiStripRecHit2D" ClassVersion="12">
+  <class name="ProjectedSiStripRecHit2D" ClassVersion="13">
+   <version ClassVersion="13" checksum="1225510999"/>
    <version ClassVersion="12" checksum="3025653452"/>
-   <field name="theOriginalDet" transient="true" />
    <version ClassVersion="11" checksum="1187571635"/>
    <version ClassVersion="10" checksum="1058168814"/>
+   <field name="theOriginalDet" transient="true" />
   </class>
-  <class name="SiStripMatchedRecHit2D" ClassVersion="11">
+  <class name="SiStripMatchedRecHit2D" ClassVersion="12">
+   <version ClassVersion="12" checksum="2335359391"/>
    <version ClassVersion="11" checksum="427184586"/>
    <version ClassVersion="10" checksum="1602539953"/>
   </class>
-  <class name="SiTrackerMultiRecHit" ClassVersion="12">
+  <class name="SiTrackerMultiRecHit" ClassVersion="13">
+   <version ClassVersion="13" checksum="461376600"/>
    <version ClassVersion="12" checksum="561999321"/>
    <version ClassVersion="11" checksum="2489323248"/>
    <version ClassVersion="10" checksum="2607997209"/>
   </class>
 
-  <class name="SiPixelRecHit" ClassVersion="13">
-    <version ClassVersion="13" checksum="2432056380"/>
+  <class name="SiPixelRecHit" ClassVersion="14">
+   <version ClassVersion="14" checksum="3739687079"/>
+   <version ClassVersion="13" checksum="2432056380"/>
    <version ClassVersion="12" checksum="1051928582"/>
    <version ClassVersion="11" checksum="790601993"/>
    <version ClassVersion="10" checksum="414205262"/>

--- a/DataFormats/TrackingRecHit/src/classes_def.xml
+++ b/DataFormats/TrackingRecHit/src/classes_def.xml
@@ -5,20 +5,25 @@
    <version ClassVersion="10" checksum="1481465852"/>
    <field name="m_det" transient="true" />
   </class>
-  <class name="RecHit1D" ClassVersion="10">
+  <class name="RecHit1D" ClassVersion="11">
+   <version ClassVersion="11" checksum="312395919"/>
    <version ClassVersion="10" checksum="2579934268"/>
   </class>
-  <class name="InvalidTrackingRecHit" ClassVersion="10">
+  <class name="InvalidTrackingRecHit" ClassVersion="11">
+   <version ClassVersion="11" checksum="2642266668"/>
    <version ClassVersion="10" checksum="3356557851"/>
   </class>
-  <class name="InvalidTrackingRecHitNoDet" ClassVersion="10">
+  <class name="InvalidTrackingRecHitNoDet" ClassVersion="11">
+   <version ClassVersion="11" checksum="3858174036"/>
    <version ClassVersion="10" checksum="405302456"/>
    <field name="m_surface" transient="true" />
   </class>
-  <class name="RecHit2DLocalPos" ClassVersion="10">
+  <class name="RecHit2DLocalPos" ClassVersion="11">
+   <version ClassVersion="11" checksum="373569091"/>
    <version ClassVersion="10" checksum="1168669560"/>
   </class>
-  <class name="RecSegment" ClassVersion="10">
+  <class name="RecSegment" ClassVersion="11">
+   <version ClassVersion="11" checksum="754678582"/>
    <version ClassVersion="10" checksum="1295706057"/>
   </class>
   <class name="std::vector<TrackingRecHit*>"/>

--- a/DataFormats/V0Candidate/src/classes_def.xml
+++ b/DataFormats/V0Candidate/src/classes_def.xml
@@ -1,6 +1,7 @@
 <lcgdict>
 <selection>
-  <class name="reco::V0Candidate" ClassVersion="10">
+  <class name="reco::V0Candidate" ClassVersion="11">
+   <version ClassVersion="11" checksum="3236778854"/>
    <version ClassVersion="10" checksum="1361748283"/>
   </class>
   <class name="std::vector<reco::V0Candidate>" />

--- a/SimDataFormats/GeneratorProducts/src/classes_def.xml
+++ b/SimDataFormats/GeneratorProducts/src/classes_def.xml
@@ -1,151 +1,152 @@
 <lcgdict>
 	<!-- HepMC externals -->
 
-	<class name="HepMC::GenEvent" ClassVersion="10">
+ <class name="HepMC::GenEvent" ClassVersion="10">
   <version ClassVersion="10" checksum="2993730389"/>
  </class>
-	<class name="HepMC::GenVertex" ClassVersion="10">
+ <class name="HepMC::GenVertex" ClassVersion="10">
   <version ClassVersion="10" checksum="1541111972"/>
  </class>
-	<class name="HepMC::GenParticle" ClassVersion="10">
+ <class name="HepMC::GenParticle" ClassVersion="10">
   <version ClassVersion="10" checksum="3138667414"/>
 		<!-- <field name="itsParticleData" transient="true"/> -->
 		<!-- <field name="itsDecayData" transient="true"/> -->
-	</class>
-    <class name="HepMC::GenCrossSection" ClassVersion="10">
-     <version ClassVersion="10" checksum="920043842"/>
-    </class>
-	<class name="HepMC::WeightContainer" ClassVersion="12">
+ </class>
+ <class name="HepMC::GenCrossSection" ClassVersion="10">
+  <version ClassVersion="10" checksum="920043842"/>
+ </class>
+ <class name="HepMC::WeightContainer" ClassVersion="13">
   <version ClassVersion="10" checksum="2163093401"/>
   <version ClassVersion="11" checksum="376377869"/>
   <version ClassVersion="12" checksum="2537869863"/>
-  </class>
-	<class name="HepMC::FourVector" ClassVersion="10">
+  <version ClassVersion="13" checksum="1293886956"/>
+ </class>
+ <class name="HepMC::FourVector" ClassVersion="10">
   <version ClassVersion="10" checksum="3279825169"/>
  </class>
-	<class name="HepMC::HeavyIon" ClassVersion="10">
+ <class name="HepMC::HeavyIon" ClassVersion="10">
   <version ClassVersion="10" checksum="972653740"/>
  </class>
-	<class name="HepMC::PdfInfo" ClassVersion="10">
+ <class name="HepMC::PdfInfo" ClassVersion="10">
   <version ClassVersion="10" checksum="2092965304"/>
  </class>
-	<class name="HepMC::Flow" ClassVersion="10">
+ <class name="HepMC::Flow" ClassVersion="10">
   <version ClassVersion="10" checksum="3390577269"/>
-		<field name="m_particle_owner" transient="true"/>
-	</class>
-	<class name="HepMC::Polarization" ClassVersion="11">
+  <field name="m_particle_owner" transient="true"/>
+ </class>
+ <class name="HepMC::Polarization" ClassVersion="11">
   <version ClassVersion="10" checksum="4158943762"/>
   <version ClassVersion="11" checksum="418544139"/>
  </class>
-	<class name="HepMC::GenEvent::particle_iterator"/>
-	<class name="HepMC::GenEvent::particle_const_iterator"/>
-	<class name="HepMC::GenEvent::vertex_iterator"/>
-	<class name="HepMC::GenEvent::vertex_const_iterator"/>
-	<class name="std::vector&lt;HepMC::GenParticle*&gt;"/>
-	<!-- <class name="std::iterator&lt;std::forward_iterator_tag,HepMC::GenVertex*,int,HepMC::GenVertex**,HepMC::GenVertex*& &gt;"/> -->
-	<class pattern="std::iterator&lt;std::forward_iterator_tag,HepMC::GenVertex*&gt;"/>
-	<!-- <class name="std::iterator&lt;std::forward_iterator_tag,HepMC::GenParticle*,int,HepMC::GenParticle**,HepMC::GenParticle*& &gt;"/> -->
-	<class pattern="std::iterator&lt;std::forward_iterator_tag,HepMC::GenParticle*&gt;"/>
-	<!--
+ <class name="HepMC::GenEvent::particle_iterator"/>
+ <class name="HepMC::GenEvent::particle_const_iterator"/>
+ <class name="HepMC::GenEvent::vertex_iterator"/>
+ <class name="HepMC::GenEvent::vertex_const_iterator"/>
+ <class name="std::vector&lt;HepMC::GenParticle*&gt;"/>
+ <!-- <class name="std::iterator&lt;std::forward_iterator_tag,HepMC::GenVertex*,int,HepMC::GenVertex**,HepMC::GenVertex*& &gt;"/> -->
+ <class pattern="std::iterator&lt;std::forward_iterator_tag,HepMC::GenVertex*&gt;"/>
+ <!-- <class name="std::iterator&lt;std::forward_iterator_tag,HepMC::GenParticle*,int,HepMC::GenParticle**,HepMC::GenParticle*& &gt;"/> -->
+ <class pattern="std::iterator&lt;std::forward_iterator_tag,HepMC::GenParticle*&gt;"/>
+ <!--
 		<class name="HepMC::GenVertex::edge_iterator">
 			<field name="m_set_iter" transient="true"/>
 		</class>
 	-->
-	<!-- <class name="_Rb_tree_iterator&lt;HepMC::GenParticle*,HepMC::GenParticle* const&,HepMC::GenParticle* const*&gt;"/> -->
-	<!-- <class pattern="*iterator&lt;HepMC::GenParticle*&gt;"/> -->
-	<!-- <class name="_Rb_tree_iterator&lt;std::pair&lt;const int,HepMC::GenVertex*&gt;,const std::pair&lt;const int,HepMC::GenVertex*&gt;&,const std::pair&lt;const int,HepMC::GenVertex*&gt;*&gt;"/> -->
-	<!-- <class pattern="*iterator&lt;std::pair&lt;*HepMC::GenVertex*&gt;*&gt;"/> -->
-	<!-- <class pattern="*iterator&lt;std::pair&lt;*HepMC::GenParticle*&gt;*&gt;"/> -->
-	<!-- <class name="HepPDT::ParticleID"/> -->
-	<!-- <class name="HepPDT::Quarks"/> -->
-	<!-- <class name="HepPDT::DecayDataT&lt;HepMCConfig&gt;"/> -->
-	<!-- <class name="HepPDT::ParticleDataT&lt;HepMCConfig&gt;"/> -->
+ <!-- <class name="_Rb_tree_iterator&lt;HepMC::GenParticle*,HepMC::GenParticle* const&,HepMC::GenParticle* const*&gt;"/> -->
+ <!-- <class pattern="*iterator&lt;HepMC::GenParticle*&gt;"/> -->
+ <!-- <class name="_Rb_tree_iterator&lt;std::pair&lt;const int,HepMC::GenVertex*&gt;,const std::pair&lt;const int,HepMC::GenVertex*&gt;&,const std::pair&lt;const int,HepMC::GenVertex*&gt;*&gt;"/> -->
+ <!-- <class pattern="*iterator&lt;std::pair&lt;*HepMC::GenVertex*&gt;*&gt;"/> -->
+ <!-- <class pattern="*iterator&lt;std::pair&lt;*HepMC::GenParticle*&gt;*&gt;"/> -->
+ <!-- <class name="HepPDT::ParticleID"/> -->
+ <!-- <class name="HepPDT::Quarks"/> -->
+ <!-- <class name="HepPDT::DecayDataT&lt;HepMCConfig&gt;"/> -->
+ <!-- <class name="HepPDT::ParticleDataT&lt;HepMCConfig&gt;"/> -->
 
-	<!-- HepMCProduct -->
+ <!-- HepMCProduct -->
 
-	<class name="edm::Wrapper&lt;edm::HepMCProduct&gt;"/>
-	<class name="edm::HepMCProduct" ClassVersion="10">
+ <class name="edm::Wrapper&lt;edm::HepMCProduct&gt;"/>
+ <class name="edm::HepMCProduct" ClassVersion="10">
   <version ClassVersion="10" checksum="3587845075"/>
  </class>
-        <class name="std::vector&lt;const edm::HepMCProduct*&gt;"/>
-	<class name="edm::Ref&lt;edm::HepMCProduct,HepMC::GenVertex,edm::refhelper::FindTrait&lt;edm::HepMCProduct,HepMC::GenVertex&gt;::Find&gt;"/>
-	<class name="edm::Ref&lt;edm::HepMCProduct,HepMC::GenParticle,edm::refhelper::FindTrait&lt;edm::HepMCProduct,HepMC::GenParticle&gt;::Find&gt;"/>
-	<class name="edm::RefVector&lt;edm::HepMCProduct,HepMC::GenVertex,edm::refhelper::FindTrait&lt;edm::HepMCProduct,HepMC::GenVertex&gt;::Find&gt;"/>
-	<class name="edm::RefVector&lt;edm::HepMCProduct,HepMC::GenParticle,edm::refhelper::FindTrait&lt;edm::HepMCProduct,HepMC::GenParticle&gt;::Find&gt;"/>
-	<class name="std::map&lt;int,HepMC::GenVertex*&gt;"/>
-	<class name="std::pair&lt;const int,HepMC::GenVertex*&gt;"/>
-	<class name="std::pair&lt;int,HepMC::GenVertex*&gt;"/>
-	<class name="std::map&lt;int,HepMC::GenParticle*&gt;"/>
-	<class name="std::pair&lt;const int,HepMC::GenParticle*&gt;"/>
-	<class name="std::pair&lt;int,HepMC::GenParticle*&gt;"/>
-	<class name="std::map&lt;int,HepMC::GenVertex*,std::greater&lt;int&gt; &gt;"/>
+ <class name="std::vector&lt;const edm::HepMCProduct*&gt;"/>
+ <class name="edm::Ref&lt;edm::HepMCProduct,HepMC::GenVertex,edm::refhelper::FindTrait&lt;edm::HepMCProduct,HepMC::GenVertex&gt;::Find&gt;"/>
+ <class name="edm::Ref&lt;edm::HepMCProduct,HepMC::GenParticle,edm::refhelper::FindTrait&lt;edm::HepMCProduct,HepMC::GenParticle&gt;::Find&gt;"/>
+ <class name="edm::RefVector&lt;edm::HepMCProduct,HepMC::GenVertex,edm::refhelper::FindTrait&lt;edm::HepMCProduct,HepMC::GenVertex&gt;::Find&gt;"/>
+ <class name="edm::RefVector&lt;edm::HepMCProduct,HepMC::GenParticle,edm::refhelper::FindTrait&lt;edm::HepMCProduct,HepMC::GenParticle&gt;::Find&gt;"/>
+ <class name="std::map&lt;int,HepMC::GenVertex*&gt;"/>
+ <class name="std::pair&lt;const int,HepMC::GenVertex*&gt;"/>
+ <class name="std::pair&lt;int,HepMC::GenVertex*&gt;"/>
+ <class name="std::map&lt;int,HepMC::GenParticle*&gt;"/>
+ <class name="std::pair&lt;const int,HepMC::GenParticle*&gt;"/>
+ <class name="std::pair&lt;int,HepMC::GenParticle*&gt;"/>
+ <class name="std::map&lt;int,HepMC::GenVertex*,std::greater&lt;int&gt; &gt;"/>
 
-	<!-- Classes shared between different kinds of products -->
+ <!-- Classes shared between different kinds of products -->
 
-	<class name="gen::PdfInfo" ClassVersion="10">
+ <class name="gen::PdfInfo" ClassVersion="10">
   <version ClassVersion="10" checksum="876888052"/>
  </class>
-	<class name="std::auto_ptr&lt;gen::PdfInfo&gt;"/>
+ <class name="std::auto_ptr&lt;gen::PdfInfo&gt;"/>
 
-	<!-- GenRunInfoProduct -->
+ <!-- GenRunInfoProduct -->
 
-	<class name="GenRunInfoProduct" ClassVersion="10">
+ <class name="GenRunInfoProduct" ClassVersion="10">
   <version ClassVersion="10" checksum="3638379298"/>
  </class>
-	<class name="GenRunInfoProduct::XSec" ClassVersion="10">
+ <class name="GenRunInfoProduct::XSec" ClassVersion="10">
   <version ClassVersion="10" checksum="658524022"/>
  </class>
-	<class name="edm::Wrapper&lt;GenRunInfoProduct&gt;"/>
+ <class name="edm::Wrapper&lt;GenRunInfoProduct&gt;"/>
 
-	<!-- GenFilterInfo -->
+ <!-- GenFilterInfo -->
 
-	<class name="GenFilterInfo" ClassVersion="11">
+ <class name="GenFilterInfo" ClassVersion="11">
   <version ClassVersion="11" checksum="1506634242"/>
   <version ClassVersion="10" checksum="2060912306"/>
  </class>
-	<ioread sourceClass = "GenFilterInfo" source = "unsigned int numEventsPassed_" version="[-10]" targetClass="GenFilterInfo" target="numPassPositiveEvents_">
-	  <![CDATA[numPassPositiveEvents_ = onfile.numEventsPassed_;]]>
-	</ioread> 
-	<ioread sourceClass = "GenFilterInfo" source = "" version="[-10]" targetClass="GenFilterInfo" target="numPassNegativeEvents_">
-	  <![CDATA[numPassNegativeEvents_ = 0;]]>
-	</ioread> 
-	<ioread sourceClass = "GenFilterInfo" source = "unsigned int numEventsTried_" version="[-10]" targetClass="GenFilterInfo" target="numTotalPositiveEvents_">
-	  <![CDATA[numTotalPositiveEvents_ = onfile.numEventsTried_;]]>
-	</ioread> 
-	<ioread sourceClass = "GenFilterInfo" source = "" version="[-10]" targetClass="GenFilterInfo" target="numTotalNegativeEvents_">
-	  <![CDATA[numTotalNegativeEvents_ = 0;]]>
-	</ioread> 
-	<ioread sourceClass = "GenFilterInfo" source = "unsigned int numEventsPassed_" version="[-10]" targetClass="GenFilterInfo" target="sumPassWeights_">
-	  <![CDATA[sumPassWeights_ = onfile.numEventsPassed_;]]>
-	</ioread> 
-	<ioread sourceClass = "GenFilterInfo" source = "unsigned int numEventsPassed_" version="[-10]" targetClass="GenFilterInfo" target="sumPassWeights2_">
-	  <![CDATA[sumPassWeights2_ = onfile.numEventsPassed_;]]>
-	</ioread> 
-	<ioread sourceClass = "GenFilterInfo" source = "unsigned int numEventsTried_" version="[-10]" targetClass="GenFilterInfo" target="sumTotalWeights_">
-	  <![CDATA[sumTotalWeights_ = onfile.numEventsTried_;]]>
-	</ioread> 
-	<ioread sourceClass = "GenFilterInfo" source = "unsigned int numEventsTried_" version="[-10]" targetClass="GenFilterInfo" target="sumTotalWeights2_">
-	  <![CDATA[sumTotalWeights2_ = onfile.numEventsTried_;]]>
-	</ioread> 
-	<class name="edm::Wrapper&lt;GenFilterInfo&gt;"/>
+ <ioread sourceClass = "GenFilterInfo" source = "unsigned int numEventsPassed_" version="[-10]" targetClass="GenFilterInfo" target="numPassPositiveEvents_">
+  <![CDATA[numPassPositiveEvents_ = onfile.numEventsPassed_;]]>
+ </ioread> 
+ <ioread sourceClass = "GenFilterInfo" source = "" version="[-10]" targetClass="GenFilterInfo" target="numPassNegativeEvents_">
+  <![CDATA[numPassNegativeEvents_ = 0;]]>
+ </ioread> 
+ <ioread sourceClass = "GenFilterInfo" source = "unsigned int numEventsTried_" version="[-10]" targetClass="GenFilterInfo" target="numTotalPositiveEvents_">
+  <![CDATA[numTotalPositiveEvents_ = onfile.numEventsTried_;]]>
+ </ioread> 
+ <ioread sourceClass = "GenFilterInfo" source = "" version="[-10]" targetClass="GenFilterInfo" target="numTotalNegativeEvents_">
+  <![CDATA[numTotalNegativeEvents_ = 0;]]>
+ </ioread> 
+ <ioread sourceClass = "GenFilterInfo" source = "unsigned int numEventsPassed_" version="[-10]" targetClass="GenFilterInfo" target="sumPassWeights_">
+  <![CDATA[sumPassWeights_ = onfile.numEventsPassed_;]]>
+ </ioread> 
+ <ioread sourceClass = "GenFilterInfo" source = "unsigned int numEventsPassed_" version="[-10]" targetClass="GenFilterInfo" target="sumPassWeights2_">
+  <![CDATA[sumPassWeights2_ = onfile.numEventsPassed_;]]>
+ </ioread> 
+ <ioread sourceClass = "GenFilterInfo" source = "unsigned int numEventsTried_" version="[-10]" targetClass="GenFilterInfo" target="sumTotalWeights_">
+  <![CDATA[sumTotalWeights_ = onfile.numEventsTried_;]]>
+ </ioread> 
+ <ioread sourceClass = "GenFilterInfo" source = "unsigned int numEventsTried_" version="[-10]" targetClass="GenFilterInfo" target="sumTotalWeights2_">
+  <![CDATA[sumTotalWeights2_ = onfile.numEventsTried_;]]>
+ </ioread> 
+ <class name="edm::Wrapper&lt;GenFilterInfo&gt;"/>
 
-	<!-- GenLumiInfoProduct -->
+ <!-- GenLumiInfoProduct -->
 
-	<class name="GenLumiInfoProduct" ClassVersion="10">
-	  <version ClassVersion="10" checksum="2365797689"/> 
-	</class>
-	<class name="GenLumiInfoProduct::FinalStat" ClassVersion="10">
-	  <version ClassVersion="10" checksum="1937303025"/>  
-	</class>
-	<class name="GenLumiInfoProduct::XSec" ClassVersion="10">
-	  <version ClassVersion="10" checksum="1482608724"/> 
-	</class>
-	<class name="GenLumiInfoProduct::ProcessInfo" ClassVersion="10">
-	  <version ClassVersion="10" checksum="621228037"/>
-	</class>
-	<class name="edm::Wrapper&lt;GenLumiInfoProduct&gt;"/>
+ <class name="GenLumiInfoProduct" ClassVersion="10">
+  <version ClassVersion="10" checksum="2365797689"/> 
+ </class>
+ <class name="GenLumiInfoProduct::FinalStat" ClassVersion="10">
+  <version ClassVersion="10" checksum="1937303025"/>  
+ </class>
+ <class name="GenLumiInfoProduct::XSec" ClassVersion="10">
+  <version ClassVersion="10" checksum="1482608724"/> 
+ </class>
+ <class name="GenLumiInfoProduct::ProcessInfo" ClassVersion="10">
+  <version ClassVersion="10" checksum="621228037"/>
+ </class>
+ <class name="edm::Wrapper&lt;GenLumiInfoProduct&gt;"/>
 
-	<!-- GenEventInfoProduct -->
+ <!-- GenEventInfoProduct -->
 
  <class name="GenEventInfoProduct" ClassVersion="11">
   <version ClassVersion="11" checksum="4154339631"/>
@@ -157,32 +158,32 @@
  <ioread sourceClass = "GenEventInfoProduct" version="[-10]" targetClass="GenEventInfoProduct" source = "" target="nMEPartonsFiltered_">
     <![CDATA[nMEPartonsFiltered_ = -1;]]>
  </ioread> 
-	<class name="edm::Wrapper&lt;GenEventInfoProduct&gt;"/>
+ <class name="edm::Wrapper&lt;GenEventInfoProduct&gt;"/>
 
-	<!-- LHE products -->
+ <!-- LHE products -->
 
-	<class name="lhef::HEPEUP::FiveVector" ClassVersion="10">
+ <class name="lhef::HEPEUP::FiveVector" ClassVersion="10">
   <version ClassVersion="10" checksum="1667733747"/>
  </class>
-	<class name="std::vector&lt;lhef::HEPEUP::FiveVector&gt;"/>
-	<class name="lhef::HEPRUP" ClassVersion="10">
+ <class name="std::vector&lt;lhef::HEPEUP::FiveVector&gt;"/>
+ <class name="lhef::HEPRUP" ClassVersion="10">
   <version ClassVersion="10" checksum="3719865791"/>
  </class>
-	<class name="lhef::HEPEUP" ClassVersion="10">
+ <class name="lhef::HEPEUP" ClassVersion="10">
   <version ClassVersion="10" checksum="2595629275"/>
  </class>
-	<class name="LHERunInfoProduct::Header" ClassVersion="10">
+ <class name="LHERunInfoProduct::Header" ClassVersion="10">
   <version ClassVersion="10" checksum="1310911082"/>
  </class>
  <class name="LHEXMLStringProduct" ClassVersion="10">
   <version ClassVersion="10" checksum="4158740350"/>
  </class> 
  <class name="edm::Wrapper&lt;LHEXMLStringProduct&gt;"/>
-	<class name="std::vector&lt;LHERunInfoProduct::Header&gt;"/>
-	<class name="LHERunInfoProduct" ClassVersion="10">
+ <class name="std::vector&lt;LHERunInfoProduct::Header&gt;"/>
+ <class name="LHERunInfoProduct" ClassVersion="10">
   <version ClassVersion="10" checksum="2098560362"/>
  </class>
-	<class name="LHEEventProduct" ClassVersion="13">
+ <class name="LHEEventProduct" ClassVersion="13">
   <version ClassVersion="10" checksum="1026978494"/>
   <version ClassVersion="11" checksum="619154414"/>
   <version ClassVersion="12" checksum="259352862"/>
@@ -198,17 +199,17 @@
   <version ClassVersion="10" checksum="2663143460"/>
  </class>
  <class name="std::vector<gen::WeightsInfo>"/>
-	<class name="edm::Wrapper&lt;LHERunInfoProduct&gt;"/>
-	<class name="edm::Wrapper&lt;LHEEventProduct&gt;"/>
+ <class name="edm::Wrapper&lt;LHERunInfoProduct&gt;"/>
+ <class name="edm::Wrapper&lt;LHEEventProduct&gt;"/>
 
-<!--needed for backward compatibility between HepMC 2.06.xx and 2.05.yy-->
-<ioread sourceClass = "HepMC::Polarization" version="[1-10]" targetClass="HepMC::Polarization" source = "" target="m_defined">
+ <!--needed for backward compatibility between HepMC 2.06.xx and 2.05.yy-->
+ <ioread sourceClass = "HepMC::Polarization" version="[1-10]" targetClass="HepMC::Polarization" source = "" target="m_defined">
    <![CDATA[m_defined=true;
    ]]>
-</ioread>
-<ioread sourceClass = "HepMC::WeightContainer" source = "std::vector<double> m_weights" version="[1-10]" targetClass="HepMC::WeightContainer" target="m_names" include="iostream">
+ </ioread>
+ <ioread sourceClass = "HepMC::WeightContainer" source = "std::vector<double> m_weights" version="[1-10]" targetClass="HepMC::WeightContainer" target="m_names" include="iostream">
    <![CDATA[hepmc_rootio::weightcontainer_set_default_names(onfile.m_weights.size(),m_names);
    ]]>
-</ioread>        
+ </ioread>        
 
 </lcgdict>

--- a/SimDataFormats/JetMatching/src/classes_def.xml
+++ b/SimDataFormats/JetMatching/src/classes_def.xml
@@ -8,7 +8,8 @@
   <class name="reco::JetFlavourInfoMatchingCollectionBase">
     <field name="transientVector_" transient="true"/>
   </class>
-  <class name="reco::JetFlavourInfoMatchingCollection" ClassVersion="10">
+  <class name="reco::JetFlavourInfoMatchingCollection" ClassVersion="11">
+   <version ClassVersion="11" checksum="2491721971"/>
    <version ClassVersion="10" checksum="581152871"/>
     <!-- <field name="transientVector_" transient="true"/> -->
     <!-- <field name="fixed_" transient="true"/> -->
@@ -30,7 +31,8 @@
   <class name="reco::JetFlavourMatchingCollectionBase">
     <field name="transientVector_" transient="true"/>
   </class>
-  <class name="reco::JetFlavourMatchingCollection" ClassVersion="10">
+  <class name="reco::JetFlavourMatchingCollection" ClassVersion="11">
+   <version ClassVersion="11" checksum="392469271"/>
    <version ClassVersion="10" checksum="344297371"/>
     <!-- <field name="transientVector_" transient="true"/> -->
     <!-- <field name="fixed_" transient="true"/> -->
@@ -49,7 +51,8 @@
   <class name="reco::JetMatchedPartonsCollectionBase">
     <field name="transientVector_" transient="true"/>  
   </class>
-  <class name="reco::JetMatchedPartonsCollection" ClassVersion="10">
+  <class name="reco::JetMatchedPartonsCollection" ClassVersion="11">
+   <version ClassVersion="11" checksum="3945783503"/>
    <version ClassVersion="10" checksum="1343220703"/>
     <!-- <field name="transientVector_" transient="true"/> -->
     <!-- <field name="fixed_" transient="true"/> -->

--- a/SimDataFormats/Track/src/classes_def.xml
+++ b/SimDataFormats/Track/src/classes_def.xml
@@ -4,7 +4,8 @@
   <class name="CoreSimTrack" ClassVersion="10">
    <version ClassVersion="10" checksum="3936841839"/>
   </class>
-  <class name="SimTrack" ClassVersion="10">
+  <class name="SimTrack" ClassVersion="11">
+   <version ClassVersion="11" checksum="1785575744"/>
    <version ClassVersion="10" checksum="1430205451"/>
   </class>
   <class name="edm::Wrapper<std::vector<SimTrack> >" />

--- a/SimDataFormats/Vertex/src/classes_def.xml
+++ b/SimDataFormats/Vertex/src/classes_def.xml
@@ -3,8 +3,9 @@
   <class name="CoreSimVertex" ClassVersion="10">
    <version ClassVersion="10" checksum="4012086828"/>
   </class>
-  <class name="SimVertex" ClassVersion="11">
+  <class name="SimVertex" ClassVersion="12">
    <version ClassVersion="11" checksum="801220081"/>
+   <version ClassVersion="12" checksum="802888023"/>
   </class>
   <class pattern="edm::Ref<std::vector<SimVertex>,*>" />
   <class name="std::vector<const SimVertex*>"/>


### PR DESCRIPTION
ROOT 5.34.20 changed how the checksums for classes are calculated.
This updates the version number to checksum matching in order to
be compliant with the ROOT change.
