### PR TITLE
7x Fix crash on save of Fireworks configuration when output file is not  valid

### DIFF
--- a/Fireworks/Core/src/FWConfigurationManager.cc
+++ b/Fireworks/Core/src/FWConfigurationManager.cc
@@ -108,8 +108,7 @@ FWConfigurationManager::writeToFile(const std::string& iName) const
    {
       std::ofstream file(iName.c_str());
       if(not file) {
-         std::string message("unable to open file %s ", iName.c_str());
-         fflush(stdout);
+         std::string message = "unable to open file " + iName;
          message += iName;
          throw std::runtime_error(message.c_str());
       }
@@ -120,7 +119,10 @@ FWConfigurationManager::writeToFile(const std::string& iName) const
 
       streamTo(file, top, "top");
    }
-   catch (std::runtime_error &e) { std::cout << e.what() << std::endl; }
+   catch (std::runtime_error &e)
+   { 
+      fwLog(fwlog::kError) << "FWConfigurationManager::writeToFile() " << e.what() << std::endl;
+   }
 }
 
 void


### PR DESCRIPTION
The crash was in std::string constructor, used as formatted print:
 std::string message("unable to open file %s ", iName.c_str());
