### PR TITLE
GEN relvals 1M -> 250k

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -904,7 +904,7 @@ steps['TTbarFS_ID']=identityFS(steps['TTbarFS'])
 #    return c
  
 step1GenDefaults=merge([{'-s':'GEN,VALIDATION:genvalid',
-                         '--relval':'1000000,20000',
+                         '--relval':'250000,20000',
                          '--eventcontent':'RAWSIM',
                          '--datatier':'GEN'},
                         step1Defaults])


### PR DESCRIPTION
- affects only relval production, not usage in IB
- as agreed with @inugent in https://github.com/cms-sw/cmssw/pull/5149
