### PR TITLE
Adding optional PU weighted neutral isolation to tau ID

### DIFF
--- a/RecoTauTag/Configuration/python/HPSPFTaus_cff.py
+++ b/RecoTauTag/Configuration/python/HPSPFTaus_cff.py
@@ -630,6 +630,13 @@ hpsPFTauMVA3IsolationPUcorrPtSum = hpsPFTauMVA3IsolationChargedIsoPtSum.clone(
     storeRawPUsumPt = cms.bool(True),
     verbosity = cms.int32(0)
 )
+hpsPFTauMVA3IsolationNeutralIsoPtSumWeight = hpsPFTauMVA3IsolationChargedIsoPtSum.clone(
+    ApplyDiscriminationByWeightedECALIsolation = cms.bool(True),
+    ApplyDiscriminationByTrackerIsolation = cms.bool(False),
+    UseAllPFCandsForWeights = cms.bool(True),
+    verbosity = cms.int32(0)
+)
+
 hpsPFTauDiscriminationByIsolationMVA3oldDMwoLTraw = discriminationByIsolationMVA2raw.clone(
     PFTauProducer = cms.InputTag('hpsPFTauProducer'),
     Prediscriminants = requireDecayMode.clone(),

--- a/RecoTauTag/Configuration/python/addWeightedIsolation_cfi.py
+++ b/RecoTauTag/Configuration/python/addWeightedIsolation_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+def addWeightedIsolation(process):
+    process.load("RecoTauTag.Configuration.HPSPFTaus_cff")
+    process.hpsPFTauMVAIsolation2Seq+=process.hpsPFTauMVA3IsolationNeutralIsoPtSumWeight
+
+    return process


### PR DESCRIPTION
Adding an option to run weighted neutral isolation for the tau isolation. The very same algorithm has been already implemented by #4131 for general use. As the tau isolation is calculated separately, it was necessary to implement this also within tau ID software.

The default RECO sequence is not affected, no changes expected.

The new option can be utilized via

```
--customise RecoTauTag/Configuration/addWeightedIsolation_cfi.addWeightedIsolation
```

The studies that show that this way of calculating isolation is superior to the previous ways of handling neutral isolation has been presented by Yuta at CPF: https://indico.cern.ch/event/322762/
