### PR TITLE
Fixig HLT process name

### DIFF
--- a/HLTriggerOffline/Top/interface/TopDiLeptonHLTValidation.h
+++ b/HLTriggerOffline/Top/interface/TopDiLeptonHLTValidation.h
@@ -104,7 +104,7 @@ class TopDiLeptonHLTValidation : public DQMEDAnalyzer {
       double etaJets_;
       unsigned int minJets_;
       // Trigger
-      std::string sTrigger_;
+      edm::InputTag iTrigger_;
       edm::EDGetTokenT<edm::TriggerResults> tokTrigger_;
       std::vector<std::string> vsPaths_;
       // Flags
@@ -147,7 +147,7 @@ TopDiLeptonHLTValidation::TopDiLeptonHLTValidation(const edm::ParameterSet& iCon
   ptJets_(iConfig.getUntrackedParameter<double>("ptJets",0.)),
   etaJets_(iConfig.getUntrackedParameter<double>("etaJets",0.)),
   minJets_(iConfig.getUntrackedParameter<unsigned int>("minJets",0)),
-  sTrigger_(iConfig.getUntrackedParameter<std::string>("sTrigger","TriggerResults")),
+  iTrigger_(iConfig.getUntrackedParameter<edm::InputTag>("iTrigger")),
   vsPaths_(iConfig.getUntrackedParameter< std::vector<std::string> >("vsPaths"))
 
 {
@@ -158,7 +158,7 @@ TopDiLeptonHLTValidation::TopDiLeptonHLTValidation(const edm::ParameterSet& iCon
   // Jets
   tokJets_ = consumes< edm::View<reco::Jet> >(edm::InputTag(sJets_));
   // Trigger
-  tokTrigger_ = consumes<edm::TriggerResults>(edm::InputTag(sTrigger_, "", "")); 
+  tokTrigger_ = consumes<edm::TriggerResults>(iTrigger_); 
 }
 
 

--- a/HLTriggerOffline/Top/interface/TopSingleLeptonHLTValidation.h
+++ b/HLTriggerOffline/Top/interface/TopSingleLeptonHLTValidation.h
@@ -99,7 +99,7 @@ class TopSingleLeptonHLTValidation : public DQMEDAnalyzer {
       double etaJets_;
       unsigned int minJets_;
       // Trigger
-      std::string sTrigger_;
+      edm::InputTag iTrigger_;
       edm::EDGetTokenT<edm::TriggerResults> tokTrigger_;
       std::vector<std::string> vsPaths_;
       // Flags
@@ -143,7 +143,7 @@ TopSingleLeptonHLTValidation::TopSingleLeptonHLTValidation(const edm::ParameterS
   ptJets_(iConfig.getUntrackedParameter<double>("ptJets",0.)),
   etaJets_(iConfig.getUntrackedParameter<double>("etaJets",0.)),
   minJets_(iConfig.getUntrackedParameter<unsigned int>("minJets",0)),
-  sTrigger_(iConfig.getUntrackedParameter<std::string>("sTrigger","TriggerResults")),
+  iTrigger_(iConfig.getUntrackedParameter<edm::InputTag>("iTrigger")),
   vsPaths_(iConfig.getUntrackedParameter< std::vector<std::string> >("vsPaths"))
 
 {
@@ -154,7 +154,7 @@ TopSingleLeptonHLTValidation::TopSingleLeptonHLTValidation(const edm::ParameterS
   // Jets
   tokJets_ = consumes< edm::View<reco::Jet> >(edm::InputTag(sJets_));
   // Trigger
-  tokTrigger_ = consumes<edm::TriggerResults>(edm::InputTag(sTrigger_, "", "")); 
+  tokTrigger_ = consumes<edm::TriggerResults>(iTrigger_); 
 }
 
 

--- a/HLTriggerOffline/Top/python/singletopHLTEventValidation_cfi.py
+++ b/HLTriggerOffline/Top/python/singletopHLTEventValidation_cfi.py
@@ -22,7 +22,7 @@ SingleTopSingleMuonHLTValidation = cms.EDAnalyzer('TopSingleLeptonHLTValidation'
         etaJets      = cms.untracked.double(5.),
         minJets      = cms.untracked.uint32(2),
         # Trigger
-        sTrigger     = cms.untracked.string("TriggerResults"),
+        iTrigger     = cms.untracked.InputTag("TriggerResults","","HLT"),
         vsPaths      = cms.untracked.vstring(['HLT_IsoMu24_IterTrk02_v', 'HLT_IsoMu24_IterTrk02_TriCentralPFJet60_50_35_v', 'HLT_IsoMu24_IterTrk02_TriCentralPFJet40_v', 'HLT_IsoMu24_IterTrk02_CentralPFJet30_BTagCSV_v']),
 )
 
@@ -48,6 +48,6 @@ SingleTopSingleElectronHLTValidation = cms.EDAnalyzer('TopSingleLeptonHLTValidat
         etaJets      = cms.untracked.double(5.),
         minJets      = cms.untracked.uint32(2),
         # Trigger
-        sTrigger     = cms.untracked.string("TriggerResults"),
+        iTrigger     = cms.untracked.InputTag("TriggerResults","","HLT"),
         vsPaths      = cms.untracked.vstring(['HLT_Ele27_WP85_Gsf_v', 'HLT_Ele27_WP85_Gsf_TriCentralPFJet40_v', 'HLT_Ele27_WP85_Gsf_TriCentralPFJet60_50_35_v', 'HLT_Ele27_WP85_Gsf_CentralPFJet30_BTagCSV_v']),
 )

--- a/HLTriggerOffline/Top/python/topDiLeptonHLTEventValidation_cfi.py
+++ b/HLTriggerOffline/Top/python/topDiLeptonHLTEventValidation_cfi.py
@@ -22,7 +22,7 @@ DiMuonHLTValidation = cms.EDAnalyzer('TopDiLeptonHLTValidation',
         etaJets      = cms.untracked.double(2.5),
         minJets      = cms.untracked.uint32(2),
         # Trigger
-        sTrigger     = cms.untracked.string("TriggerResults"),
+        iTrigger     = cms.untracked.InputTag("TriggerResults","","HLT"),
         vsPaths      = cms.untracked.vstring(['HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_v','HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_v','HLT_Mu17_TkMu8_v']),
 )
 
@@ -48,7 +48,7 @@ DiElectronHLTValidation = cms.EDAnalyzer('TopDiLeptonHLTValidation',
         etaJets      = cms.untracked.double(2.5),
         minJets      = cms.untracked.uint32(2),
         # Trigger
-        sTrigger     = cms.untracked.string("TriggerResults"),
+        iTrigger     = cms.untracked.InputTag("TriggerResults","","HLT"),
         vsPaths      = cms.untracked.vstring(['HLT_Ele23_Ele12_CaloId_TrackId_iso_v']),
 )
 
@@ -74,6 +74,6 @@ ElecMuonHLTValidation = cms.EDAnalyzer('TopDiLeptonHLTValidation',
         etaJets      = cms.untracked.double(2.5),
         minJets      = cms.untracked.uint32(2),
         # Trigger
-        sTrigger     = cms.untracked.string("TriggerResults"),
+        iTrigger     = cms.untracked.InputTag("TriggerResults","","HLT"),
         vsPaths      = cms.untracked.vstring(['HLT_Mu23_TrkIsoVVL_Ele12_Gsf_CaloId_TrackId_Iso_MediumWP_v','HLT_Mu8_TrkIsoVVL_Ele23_Gsf_CaloId_TrackId_Iso_MediumWP_v']),
 )

--- a/HLTriggerOffline/Top/python/topSingleLeptonHLTEventValidation_cfi.py
+++ b/HLTriggerOffline/Top/python/topSingleLeptonHLTEventValidation_cfi.py
@@ -22,7 +22,7 @@ topSingleMuonHLTValidation = cms.EDAnalyzer('TopSingleLeptonHLTValidation',
         etaJets      = cms.untracked.double(2.5),
         minJets      = cms.untracked.uint32(4),
         # Trigger
-        sTrigger     = cms.untracked.string("TriggerResults"),
+        iTrigger     = cms.untracked.InputTag("TriggerResults","","HLT"),
         vsPaths      = cms.untracked.vstring(['HLT_IsoMu24_IterTrk02_v', 'HLT_IsoMu24_IterTrk02_TriCentralPFJet60_50_35_v', 'HLT_IsoMu24_IterTrk02_TriCentralPFJet40_v', 'HLT_IsoMu24_IterTrk02_CentralPFJet30_BTagCSV_v']),
 )
 
@@ -48,6 +48,6 @@ topSingleElectronHLTValidation = cms.EDAnalyzer('TopSingleLeptonHLTValidation',
         etaJets      = cms.untracked.double(2.5),
         minJets      = cms.untracked.uint32(4),
         # Trigger
-        sTrigger     = cms.untracked.string("TriggerResults"),
+        iTrigger     = cms.untracked.InputTag("TriggerResults","","HLT"),
         vsPaths      = cms.untracked.vstring(['HLT_Ele27_WP85_Gsf_v', 'HLT_Ele27_WP85_Gsf_TriCentralPFJet40_v', 'HLT_Ele27_WP85_Gsf_TriCentralPFJet60_50_35_v', 'HLT_Ele27_WP85_Gsf_CentralPFJet30_BTagCSV_v']),
 )


### PR DESCRIPTION
The HLT process name being now in the python files, the flag "--hltProcess" should be able to change of input tags for HLT to whatever new value HLT is, e.g. "reHLT".
