### PR TITLE
Avoid clang error in rootcling

### DIFF
--- a/PhysicsTools/SelectorUtils/interface/VersionedSelector.h
+++ b/PhysicsTools/SelectorUtils/interface/VersionedSelector.h
@@ -100,7 +100,9 @@ class VersionedSelector : public Selector<T> {
     return this->operator()(ref, ret);
   }
   
+#ifndef __ROOTCLING__
   using typename Selector<T>::operator();
+#endif
   
   const unsigned char* md55Raw() const { return id_md5_; } 
   bool operator==(const VersionedSelector& other) const {


### PR DESCRIPTION
A recent carry forward from the 7_2_X branch introduced a header for dictionary processing that clang cannot parse.  This pull request hides the offending line of code from rootcling (genreflex),, thereby fixing the fatal build error in the ROOT6 IB.
Note: the same header fails to compile in the CLANG IB.
Please merge this trivial request as soon as convenient.
