### PR TITLE
Mask warning in the Higgs HLT DQM

### DIFF
--- a/HLTriggerOffline/Higgs/src/HLTHiggsSubAnalysis.cc
+++ b/HLTriggerOffline/Higgs/src/HLTHiggsSubAnalysis.cc
@@ -160,7 +160,7 @@ void HLTHiggsSubAnalysis::beginRun(const edm::Run & iRun, const edm::EventSetup 
 		}
 		if( ! found )
 		{
-			edm::LogWarning("HiggsValidations") << "HLTHiggsSubAnalysis::beginRun, In "
+			LogDebug("HiggsValidations") << "HLTHiggsSubAnalysis::beginRun, In "
 				<< _analysisname << " subfolder NOT found the path: '" 
 				<< _hltPathsToCheck[i] << "*'" ;
 		}


### PR DESCRIPTION
Small change to mask a warning coming from the fact that some paths monitored in the Higgs DQM are not anymore in the HLT menu. It is done one purpose to be able to monitor the 2012 menu in case it is needed. 

When menu will be stable, we will clean the list of paths and unmask the warning
