### PR TITLE
Added OOT PU for HCAL, and updated JEC for Reco and HLT in GTs for pre6

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,27 +2,27 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   'MC_72_V2::All',
+    'run1_design'       :   'MC_72_V3::All',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   'START72_V2::All',
+    'run1_mc'           :   'START72_V3::All',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   'STARTHI72_V3::All',
+    'run1_mc_hi'        :   'STARTHI72_V5::All',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   'STARTHI72_V4::All',
+    'run1_mc_pa'        :   'STARTHI72_V6::All',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   'DESIGN72_V4::All',
+    'run2_design'       :   'DESIGN72_V5::All',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   'POSTLS172_V8::All',
+    'run2_mc_50ns'      :   'POSTLS172_V10::All',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   'POSTLS172_V7::All',
+    'run2_mc'           :   'POSTLS172_V9::All',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   'GR_R_72_V3::All',
+    'run1_data'         :   'GR_R_72_V4A::All',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   'GR_R_72_V3::All',
+    'run2_data'         :   'GR_R_72_V5A::All',
     # GlobalTag for Run1 HLT: it points to the online GT and overrides the connection string and pfnPrefix for use offline
-    'run1_hlt'          :   'GR_H_V37::All,frontier://FrontierProd/CMS_COND_31X_GLOBALTAG,frontier://FrontierProd/',
+    'run1_hlt'          :   'GR_H_V38A::All,frontier://FrontierProd/CMS_COND_31X_GLOBALTAG,frontier://FrontierProd/',
     # GlobalTag for Run2 HLT: it points to the online GT and overrides the connection string and pfnPrefix for use offline
-    'run2_hlt'          :   'GR_H_V39::All,frontier://FrontierProd/CMS_COND_31X_GLOBALTAG,frontier://FrontierProd/',
+    'run2_hlt'          :   'GR_H_V40A::All,frontier://FrontierProd/CMS_COND_31X_GLOBALTAG,frontier://FrontierProd/',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
     'phase1_2017_design' :  'DES17_70_V2::All', # placeholder (GT not meant for standard RelVal)
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
@@ -62,33 +62,33 @@ conditions_HLT_JECs = (
     'JetCorrectorParametersCollection_HLT_trk1B_V1_AK4PF,JetCorrectionsRecord,frontier://FrontierPrep/CMS_COND_PHYSICSTOOLS,AK4PFHLT',
 )
 
-autoCond['run1_mc']          = ( autoCond['run1_mc'], ) \
-                             + conditions_L1_Run2012D \
-                             + conditions_HLT_JECs
+autoCond['run1_mc']          = ( autoCond['run1_mc'], ) 
+                             #+ conditions_L1_Run2012D 
+                             #+ conditions_HLT_JECs
  
-autoCond['run1_mc_hi']       = ( autoCond['run1_mc_hi'], ) \
-                             + conditions_L1_Run2012D \
-                             + conditions_HLT_JECs
+autoCond['run1_mc_hi']       = ( autoCond['run1_mc_hi'], ) 
+                             #+ conditions_L1_Run2012D 
+                             #+ conditions_HLT_JECs
  
-autoCond['run1_mc_pa']       = ( autoCond['run1_mc_pa'], ) \
-                             + conditions_L1_Run2012D \
-                             + conditions_HLT_JECs
+autoCond['run1_mc_pa']       = ( autoCond['run1_mc_pa'], ) 
+                             #+ conditions_L1_Run2012D 
+                             #+ conditions_HLT_JECs
  
-autoCond['run1_hlt']         = ( autoCond['run1_hlt'], ) \
-                             + conditions_L1_Run2012D \
-                             + conditions_HLT_JECs
+autoCond['run1_hlt']         = ( autoCond['run1_hlt'], ) 
+                             #+ conditions_L1_Run2012D 
+                             #+ conditions_HLT_JECs
  
-autoCond['run1_data']        = ( autoCond['run1_data'], ) \
-                             + conditions_L1_Run2012D \
-                             + conditions_HLT_JECs
+autoCond['run1_data']        = ( autoCond['run1_data'], ) 
+                             #+ conditions_L1_Run2012D 
+                             #+ conditions_HLT_JECs
  
-autoCond['run2_mc']          = ( autoCond['run2_mc'], ) \
-                             + conditions_L1_Run2012D \
-                             + conditions_HLT_JECs
+autoCond['run2_mc']          = ( autoCond['run2_mc'], )
+                             #+ conditions_L1_Run2012D 
+                             #+ conditions_HLT_JECs
  
-autoCond['run2_mc_50ns']     = ( autoCond['run2_mc_50ns'], ) \
-                             + conditions_L1_Run2012D \
-                             + conditions_HLT_JECs
+autoCond['run2_mc_50ns']     = ( autoCond['run2_mc_50ns'], )
+                             #+ conditions_L1_Run2012D 
+                             #+ conditions_HLT_JECs
  
 # dedicated GlobalTags for MC production with the fixed HLT menus
 autoCond['startup_2014']     = ( autoCond['run1_mc'] )

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,23 +2,23 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   'MC_72_V3::All',
+    'run1_design'       :   'PRE_MC_72_V4::All',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   'START72_V3::All',
+    'run1_mc'           :   'PRE_STA72_V4::All',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   'STARTHI72_V5::All',
+    'run1_mc_hi'        :   'PRE_SHI72_V7::All',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   'STARTHI72_V6::All',
+    'run1_mc_pa'        :   'PRE_SHI72_V8::All',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   'DESIGN72_V5::All',
+    'run2_design'       :   'PRE_DES72_V6::All',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   'POSTLS172_V10::All',
+    'run2_mc_50ns'      :   'PRE_LS172_V12::All',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   'POSTLS172_V9::All',
+    'run2_mc'           :   'PRE_LS172_V11::All',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   'GR_R_72_V4A::All',
+    'run1_data'         :   'PRE_R_72_V6A::All',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   'GR_R_72_V5A::All',
+    'run2_data'         :   'PRE_R_72_V7A::All',
     # GlobalTag for Run1 HLT: it points to the online GT and overrides the connection string and pfnPrefix for use offline
     'run1_hlt'          :   'GR_H_V38A::All,frontier://FrontierProd/CMS_COND_31X_GLOBALTAG,frontier://FrontierProd/',
     # GlobalTag for Run2 HLT: it points to the online GT and overrides the connection string and pfnPrefix for use offline
@@ -36,60 +36,6 @@ aliases = {
     'BASEGT' : 'BASE1_V1::All|BASE2_V1::All'
 }
 
-# L1 configuration used during Run2012D
-conditions_L1_Run2012D = (
-    # L1 GT menu 2012 v3, used during Run2012D
-    'L1GtTriggerMenu_L1Menu_Collisions2012_v3_mc,L1GtTriggerMenuRcd,frontier://FrontierProd/CMS_COND_31X_L1T',
-    # L1 GCT configuration with 5 GeV jet seed threshold, used since Run2012C
-    'L1GctJetFinderParams_GCTPhysics_2012_04_27_JetSeedThresh5GeV_mc,L1GctJetFinderParamsRcd,frontier://FrontierProd/CMS_COND_31X_L1T',
-    'L1HfRingEtScale_GCTPhysics_2012_04_27_JetSeedThresh5GeV_mc,L1HfRingEtScaleRcd,frontier://FrontierProd/CMS_COND_31X_L1T',
-    'L1HtMissScale_GCTPhysics_2012_04_27_JetSeedThresh5GeV_mc,L1HtMissScaleRcd,frontier://FrontierProd/CMS_COND_31X_L1T',
-    'L1JetEtScale_GCTPhysics_2012_04_27_JetSeedThresh5GeV_mc,L1JetEtScaleRcd,frontier://FrontierProd/CMS_COND_31X_L1T',
-    # L1 CSCTF configuration used since Run2012B
-    'L1MuCSCPtLut_key-11_mc,L1MuCSCPtLutRcd,frontier://FrontierProd/CMS_COND_31X_L1T',
-    # L1 DTTF settings used since Run2012C
-    'L1MuDTTFParameters_dttf12_TSC_03_csc_col_mc,L1MuDTTFParametersRcd,frontier://FrontierProd/CMS_COND_31X_L1T',
-)
-
-# HLT Jet Energy Corrections
-conditions_HLT_JECs = (
-    # HLT 2012 jet energy corrections
-    'JetCorrectorParametersCollection_Jec11_V12_AK5CaloHLT,JetCorrectionsRecord,frontier://FrontierProd/CMS_COND_31X_PHYSICSTOOLS,AK5CaloHLT',
-    'JetCorrectorParametersCollection_AK5PF_2012_V8_hlt_mc,JetCorrectionsRecord,frontier://FrontierProd/CMS_COND_31X_PHYSICSTOOLS,AK5PFHLT',
-    'JetCorrectorParametersCollection_AK5PFchs_2012_V8_hlt_mc,JetCorrectionsRecord,frontier://FrontierProd/CMS_COND_31X_PHYSICSTOOLS,AK5PFchsHLT',
-    # HLT 2014 jet energy corrections - tk1B scenario
-    'JetCorrectorParametersCollection_HLT_V1_AK4Calo,JetCorrectionsRecord,frontier://FrontierPrep/CMS_COND_PHYSICSTOOLS,AK4CaloHLT',
-    'JetCorrectorParametersCollection_HLT_trk1B_V1_AK4PF,JetCorrectionsRecord,frontier://FrontierPrep/CMS_COND_PHYSICSTOOLS,AK4PFHLT',
-)
-
-autoCond['run1_mc']          = ( autoCond['run1_mc'], ) 
-                             #+ conditions_L1_Run2012D 
-                             #+ conditions_HLT_JECs
- 
-autoCond['run1_mc_hi']       = ( autoCond['run1_mc_hi'], ) 
-                             #+ conditions_L1_Run2012D 
-                             #+ conditions_HLT_JECs
- 
-autoCond['run1_mc_pa']       = ( autoCond['run1_mc_pa'], ) 
-                             #+ conditions_L1_Run2012D 
-                             #+ conditions_HLT_JECs
- 
-autoCond['run1_hlt']         = ( autoCond['run1_hlt'], ) 
-                             #+ conditions_L1_Run2012D 
-                             #+ conditions_HLT_JECs
- 
-autoCond['run1_data']        = ( autoCond['run1_data'], ) 
-                             #+ conditions_L1_Run2012D 
-                             #+ conditions_HLT_JECs
- 
-autoCond['run2_mc']          = ( autoCond['run2_mc'], )
-                             #+ conditions_L1_Run2012D 
-                             #+ conditions_HLT_JECs
- 
-autoCond['run2_mc_50ns']     = ( autoCond['run2_mc_50ns'], )
-                             #+ conditions_L1_Run2012D 
-                             #+ conditions_HLT_JECs
- 
 # dedicated GlobalTags for MC production with the fixed HLT menus
 autoCond['startup_2014']     = ( autoCond['run1_mc'] )
 

--- a/Configuration/AlCa/python/autoCond_condDBv2.py
+++ b/Configuration/AlCa/python/autoCond_condDBv2.py
@@ -2,23 +2,23 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   'MC_72_V3',
+    'run1_design'       :   'PRE_MC_72_V4',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   'START72_V3',
+    'run1_mc'           :   'PRE_STA72_V4',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   'STARTHI72_V5',
+    'run1_mc_hi'        :   'PRE_SHI72_V7',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   'STARTHI72_V6',
+    'run1_mc_pa'        :   'PRE_SHI72_V8',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   'DESIGN72_V5',
+    'run2_design'       :   'PRE_DES72_V6',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   'POSTLS172_V10',
+    'run2_mc_50ns'      :   'PRE_LS172_V12',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   'POSTLS172_V9',
+    'run2_mc'           :   'PRE_LS172_V11',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   'GR_R_72_V4A',
+    'run1_data'         :   'PRE_R_72_V6A',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   'GR_R_72_V5A',
+    'run2_data'         :   'PRE_R_72_V7A',
     # GlobalTag for Run1 HLT: it points to the online GT and overrides the connection string and pfnPrefix for use offline
     'run1_hlt'          :   'GR_H_V38A,frontier://FrontierProd/CMS_CONDITIONS,frontier://FrontierProd/',
     # GlobalTag for Run2 HLT: it points to the online GT and overrides the connection string and pfnPrefix for use offline
@@ -51,44 +51,26 @@ conditions_L1_Run2012D = (
     'L1MuDTTFParameters_dttf12_TSC_03_csc_col_mc,L1MuDTTFParametersRcd,frontier://FrontierProd/CMS_COND_31X_L1T',
 )
 
-# HLT Jet Energy Corrections
-conditions_HLT_JECs = (
-    # HLT 2012 jet energy corrections
-    'JetCorrectorParametersCollection_Jec11_V12_AK5CaloHLT,JetCorrectionsRecord,frontier://FrontierProd/CMS_COND_31X_PHYSICSTOOLS,AK5CaloHLT',
-    'JetCorrectorParametersCollection_AK5PF_2012_V8_hlt_mc,JetCorrectionsRecord,frontier://FrontierProd/CMS_COND_31X_PHYSICSTOOLS,AK5PFHLT',
-    'JetCorrectorParametersCollection_AK5PFchs_2012_V8_hlt_mc,JetCorrectionsRecord,frontier://FrontierProd/CMS_COND_31X_PHYSICSTOOLS,AK5PFchsHLT',
-    # HLT 2014 jet energy corrections - tk1B scenario
-    'JetCorrectorParametersCollection_HLT_V1_AK4Calo,JetCorrectionsRecord,frontier://FrontierPrep/CMS_COND_PHYSICSTOOLS,AK4CaloHLT',
-    'JetCorrectorParametersCollection_HLT_trk1B_V1_AK4PF,JetCorrectionsRecord,frontier://FrontierPrep/CMS_COND_PHYSICSTOOLS,AK4PFHLT',
-)
-
 autoCond['run1_mc']          = ( autoCond['run1_mc'], ) \
                              + conditions_L1_Run2012D 
-                             #+ conditions_HLT_JECs
  
 autoCond['run1_mc_hi']       = ( autoCond['run1_mc_hi'], ) \
                              + conditions_L1_Run2012D 
-                             #+ conditions_HLT_JECs
  
 autoCond['run1_mc_pa']       = ( autoCond['run1_mc_pa'], ) \
                              + conditions_L1_Run2012D 
-                             #+ conditions_HLT_JECs
  
 autoCond['run1_hlt']         = ( autoCond['run1_hlt'], ) \
                              + conditions_L1_Run2012D 
-                             #+ conditions_HLT_JECs
  
 autoCond['run1_data']        = ( autoCond['run1_data'], ) \
                              + conditions_L1_Run2012D 
-                             #+ conditions_HLT_JECs
  
 autoCond['run2_mc']          = ( autoCond['run2_mc'], ) \
                              + conditions_L1_Run2012D 
-                             #+ conditions_HLT_JECs
  
 autoCond['run2_mc_50ns']     = ( autoCond['run2_mc_50ns'], ) \
                              + conditions_L1_Run2012D 
-                             #+ conditions_HLT_JECs
  
 # dedicated GlobalTags for MC production with the fixed HLT menus
 autoCond['startup_2014']     = ( autoCond['run1_mc'] )

--- a/Configuration/AlCa/python/autoCond_condDBv2.py
+++ b/Configuration/AlCa/python/autoCond_condDBv2.py
@@ -2,27 +2,27 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   'MC_72_V2',
+    'run1_design'       :   'MC_72_V3',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   'START72_V2',
+    'run1_mc'           :   'START72_V3',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   'STARTHI72_V3',
+    'run1_mc_hi'        :   'STARTHI72_V5',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   'STARTHI72_V4',
+    'run1_mc_pa'        :   'STARTHI72_V6',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   'DESIGN72_V4',
+    'run2_design'       :   'DESIGN72_V5',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   'POSTLS172_V8',
+    'run2_mc_50ns'      :   'POSTLS172_V10',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   'POSTLS172_V7',
+    'run2_mc'           :   'POSTLS172_V9',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   'GR_R_72_V3',
+    'run1_data'         :   'GR_R_72_V4A',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   'GR_R_72_V3',
+    'run2_data'         :   'GR_R_72_V5A',
     # GlobalTag for Run1 HLT: it points to the online GT and overrides the connection string and pfnPrefix for use offline
-    'run1_hlt'          :   'GR_H_V37,frontier://FrontierProd/CMS_CONDITIONS,frontier://FrontierProd/',
+    'run1_hlt'          :   'GR_H_V38A,frontier://FrontierProd/CMS_CONDITIONS,frontier://FrontierProd/',
     # GlobalTag for Run2 HLT: it points to the online GT and overrides the connection string and pfnPrefix for use offline
-    'run2_hlt'          :   'GR_H_V39,frontier://FrontierProd/CMS_CONDITIONS,frontier://FrontierProd/',
+    'run2_hlt'          :   'GR_H_V40A,frontier://FrontierProd/CMS_CONDITIONS,frontier://FrontierProd/',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
     'phase1_2017_design' :  'DES17_70_V2', # placeholder (GT not meant for standard RelVal)
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
@@ -63,32 +63,32 @@ conditions_HLT_JECs = (
 )
 
 autoCond['run1_mc']          = ( autoCond['run1_mc'], ) \
-                             + conditions_L1_Run2012D \
-                             + conditions_HLT_JECs
+                             + conditions_L1_Run2012D 
+                             #+ conditions_HLT_JECs
  
 autoCond['run1_mc_hi']       = ( autoCond['run1_mc_hi'], ) \
-                             + conditions_L1_Run2012D \
-                             + conditions_HLT_JECs
+                             + conditions_L1_Run2012D 
+                             #+ conditions_HLT_JECs
  
 autoCond['run1_mc_pa']       = ( autoCond['run1_mc_pa'], ) \
-                             + conditions_L1_Run2012D \
-                             + conditions_HLT_JECs
+                             + conditions_L1_Run2012D 
+                             #+ conditions_HLT_JECs
  
 autoCond['run1_hlt']         = ( autoCond['run1_hlt'], ) \
-                             + conditions_L1_Run2012D \
-                             + conditions_HLT_JECs
+                             + conditions_L1_Run2012D 
+                             #+ conditions_HLT_JECs
  
 autoCond['run1_data']        = ( autoCond['run1_data'], ) \
-                             + conditions_L1_Run2012D \
-                             + conditions_HLT_JECs
+                             + conditions_L1_Run2012D 
+                             #+ conditions_HLT_JECs
  
 autoCond['run2_mc']          = ( autoCond['run2_mc'], ) \
-                             + conditions_L1_Run2012D \
-                             + conditions_HLT_JECs
+                             + conditions_L1_Run2012D 
+                             #+ conditions_HLT_JECs
  
 autoCond['run2_mc_50ns']     = ( autoCond['run2_mc_50ns'], ) \
-                             + conditions_L1_Run2012D \
-                             + conditions_HLT_JECs
+                             + conditions_L1_Run2012D 
+                             #+ conditions_HLT_JECs
  
 # dedicated GlobalTags for MC production with the fixed HLT menus
 autoCond['startup_2014']     = ( autoCond['run1_mc'] )


### PR DESCRIPTION
New Global Tags containing:
- New OOT PU subtraction for HCAL for Run1 and Run2 simulation (both ideal and realistic) and data GT (actually disabled via dummy payload in Run1 simulation and data);
- Updated Jet energy corrections for Reconstruction (Run2 simulation and data GT) and HLT (Run1 and Run2 simulation and data GT), see: https://indico.cern.ch/event/294025/contribution/5/material/slides/0.pdf
- Updated ECAL weights for Run2 for simulation Global Tags
- Updated simulation geometry for Run1 (`ExtendedTest2014` scenario) for material budget studies.
