### PR TITLE
Fixing HF cluster dependencies in unit tests

### DIFF
--- a/FastSimulation/ParticleFlow/python/ParticleFlowFastSim_cff.py
+++ b/FastSimulation/ParticleFlow/python/ParticleFlowFastSim_cff.py
@@ -22,16 +22,23 @@ from RecoParticleFlow.PFProducer.particleFlowEGamma_cff import *
 particleFlowSimParticle.sim = 'famosSimHits'
 
 #Deactivate the recovery of dead towers since dead towers are not simulated
-particleFlowRecHitHCAL.ECAL_Compensate = cms.bool(False)
 #Similarly, deactivate HF cleaning for spikes
-particleFlowRecHitHCAL.ShortFibre_Cut = cms.double(1E5)
-particleFlowRecHitHCAL.LongFibre_Cut = cms.double(1E5)
-particleFlowRecHitHCAL.LongShortFibre_Cut = cms.double(1E5)
-particleFlowRecHitHCAL.ApplyLongShortDPG = cms.bool(False)
-particleFlowClusterHFEM.thresh_Clean_Barrel = cms.double(1E5)
-particleFlowClusterHFEM.thresh_Clean_Endcap = cms.double(1E5)
-particleFlowClusterHFHAD.thresh_Clean_Barrel = cms.double(1E5)
-particleFlowClusterHFHAD.thresh_Clean_Endcap = cms.double(1E5)
+particleFlowClusterHF.recHitCleaners = cms.VPSet()
+particleFlowRecHitHF.producers[0].qualityTests =cms.VPSet(
+    cms.PSet(
+        name = cms.string("PFRecHitQTestHCALThresholdVsDepth"),
+        cuts = cms.VPSet(
+            cms.PSet(
+                depth = cms.int32(1),
+                threshold = cms.double(1.2)),
+            cms.PSet(
+                depth = cms.int32(2),
+                threshold = cms.double(1.8))
+            )
+        )   
+
+)
+
 
 #particleFlowBlock.useNuclear = cms.bool(True)
 #particleFlowBlock.useConversions = cms.bool(True)

--- a/RecoHI/Configuration/python/Reconstruction_hiPF_cff.py
+++ b/RecoHI/Configuration/python/Reconstruction_hiPF_cff.py
@@ -45,9 +45,7 @@ particleFlowBlock.elementImporters = cms.VPSet(
     cms.PSet( importerName = cms.string("GenericClusterImporter"),
               source = cms.InputTag("particleFlowClusterHO") ),
     cms.PSet( importerName = cms.string("GenericClusterImporter"),
-              source = cms.InputTag("particleFlowClusterHFEM") ),
-    cms.PSet( importerName = cms.string("GenericClusterImporter"),
-              source = cms.InputTag("particleFlowClusterHFHAD") ),
+              source = cms.InputTag("particleFlowClusterHF") ),
     cms.PSet( importerName = cms.string("GenericClusterImporter"),
               source = cms.InputTag("particleFlowClusterPS") )
     )

--- a/RecoJets/JetProducers/python/PFClustersForJets_cff.py
+++ b/RecoJets/JetProducers/python/PFClustersForJets_cff.py
@@ -12,19 +12,14 @@ pfClusterRefsForJetsECAL = cms.EDProducer("PFClusterRefCandidateProducer",
     particleType = cms.string('pi+')
 )
 
-pfClusterRefsForJetsHFEM = cms.EDProducer("PFClusterRefCandidateProducer",
-    src          = cms.InputTag('particleFlowClusterHFEM'),
-    particleType = cms.string('pi+')
-)
-
-pfClusterRefsForJetsHFHAD = cms.EDProducer("PFClusterRefCandidateProducer",
-    src          = cms.InputTag('particleFlowClusterHFHAD'),
+pfClusterRefsForJetsHF = cms.EDProducer("PFClusterRefCandidateProducer",
+    src          = cms.InputTag('particleFlowClusterHF'),
     particleType = cms.string('pi+')
 )
 
 pfClusterRefsForJets = cms.EDProducer("PFClusterRefCandidateMerger",
     src = cms.VInputTag("pfClusterRefsForJetsHCAL", "pfClusterRefsForJetsECAL")
-#    src = cms.VInputTag("pfClusterRefsForJetsHCAL", "pfClusterRefsForJetsECAL","pfClusterRefsForJetsHFEM","pfClusterRefsForJetsHFHAD")
+#    src = cms.VInputTag("pfClusterRefsForJetsHCAL", "pfClusterRefsForJetsECAL","pfClusterRefsForJetsHF")
 )
 
 

--- a/RecoMET/METAlgorithms/interface/TCMETAlgo.h
+++ b/RecoMET/METAlgorithms/interface/TCMETAlgo.h
@@ -105,8 +105,7 @@ private:
   edm::EDGetTokenT<reco::VertexCollection> vertexToken_;
   edm::EDGetTokenT<reco::PFClusterCollection> clustersECALToken_;
   edm::EDGetTokenT<reco::PFClusterCollection> clustersHCALToken_;
-  edm::EDGetTokenT<reco::PFClusterCollection> clustersHFEMToken_;
-  edm::EDGetTokenT<reco::PFClusterCollection> clustersHFHADToken_;
+  edm::EDGetTokenT<reco::PFClusterCollection> clustersHFToken_;
   edm::EDGetTokenT<edm::ValueMap<reco::MuonMETCorrectionData> > muonDepValueMapToken_;
   edm::EDGetTokenT<edm::ValueMap<reco::MuonMETCorrectionData> > tcmetDepValueMapToken_;
 

--- a/RecoMET/METAlgorithms/src/TCMETAlgo.cc
+++ b/RecoMET/METAlgorithms/src/TCMETAlgo.cc
@@ -78,8 +78,8 @@ void TCMETAlgo::configure(const edm::ParameterSet& iConfig, edm::ConsumesCollect
     {
       clustersECALToken_ = iConsumesCollector.consumes<reco::PFClusterCollection>(iConfig.getParameter<edm::InputTag>("PFClustersECAL"));
       clustersHCALToken_ = iConsumesCollector.consumes<reco::PFClusterCollection>(iConfig.getParameter<edm::InputTag>("PFClustersHCAL"));
-      clustersHFEMToken_ = iConsumesCollector.consumes<reco::PFClusterCollection>(iConfig.getParameter<edm::InputTag>("PFClustersHFEM"));
-      clustersHFHADToken_ = iConsumesCollector.consumes<reco::PFClusterCollection>(iConfig.getParameter<edm::InputTag>("PFClustersHFHAD"));
+      clustersHFToken_ = iConsumesCollector.consumes<reco::PFClusterCollection>(iConfig.getParameter<edm::InputTag>("PFClustersHF"));
+
     }
 
   muonDepValueMapToken_ = iConsumesCollector.consumes<edm::ValueMap<reco::MuonMETCorrectionData> >(iConfig.getParameter<edm::InputTag>("muonDepValueMap"));
@@ -227,20 +227,9 @@ void TCMETAlgo::initialize_MET_with_PFClusters(edm::Event& event)
       pfcsumet += et;
     }
 
-  edm::Handle< reco::PFClusterCollection > clustersHFHAD;
-  event.getByToken(clustersHFHADToken_, clustersHFHAD);
-  for (reco::PFClusterCollection::const_iterator it = clustersHFHAD->begin(); it != clustersHFHAD->end(); it++)
-    {
-      const math::XYZPoint& cluster_pos = it->position();
-      double et = it->energy()/cosh(cluster_pos.eta());
-      pfcmet_x -= et*cos(cluster_pos.phi());
-      pfcmet_y -= et*sin(cluster_pos.phi());
-      pfcsumet += et;
-    }
-
-  edm::Handle< reco::PFClusterCollection > clustersHFEM;
-  event.getByToken(clustersHFEMToken_, clustersHFEM);
-  for (reco::PFClusterCollection::const_iterator it = clustersHFEM->begin(); it != clustersHFEM->end(); it++)
+  edm::Handle< reco::PFClusterCollection > clustersHF;
+  event.getByToken(clustersHFToken_, clustersHF);
+  for (reco::PFClusterCollection::const_iterator it = clustersHF->begin(); it != clustersHF->end(); it++)
     {
       const math::XYZPoint& cluster_pos = it->position();
       double et = it->energy()/cosh(cluster_pos.eta());

--- a/RecoMET/METProducers/python/TCMET_cfi.py
+++ b/RecoMET/METProducers/python/TCMET_cfi.py
@@ -58,8 +58,7 @@ tcMet = cms.EDProducer(
     dupDCotTh = cms.double(0.0006),
     PFClustersECAL = cms.InputTag("particleFlowClusterECAL"),
     PFClustersHCAL = cms.InputTag("particleFlowClusterHCAL"),
-    PFClustersHFEM = cms.InputTag("particleFlowClusterHFEM"),
-    PFClustersHFHAD = cms.InputTag("particleFlowClusterHFHAD"),
+    PFClustersHF = cms.InputTag("particleFlowClusterHF"),
     usePFClusters = cms.bool(False)
     )
 

--- a/RecoParticleFlow/PFProducer/python/particleFlowEGamma_cfi.py
+++ b/RecoParticleFlow/PFProducer/python/particleFlowEGamma_cfi.py
@@ -167,8 +167,7 @@ particleFlowEGamma = cms.EDProducer("PFEGammaProducer",
     # Check HF cleaning
     cleanedHF = cms.VInputTag(
                 cms.InputTag("particleFlowRecHitHCAL","Cleaned"),
-                cms.InputTag("particleFlowClusterHFHAD","Cleaned"),
-                cms.InputTag("particleFlowClusterHFEM","Cleaned")
+                cms.InputTag("particleFlowClusterHF","Cleaned")
                 ),
     
     # number of sigmas for neutral energy detection


### PR DESCRIPTION
Since now [and this is not going to change even when we have the new HCAL reco]  we have a single
HF cluster collection , change dependencies to take it into account .
This is what escaped the matrix 
