### PR TITLE
Removed instances of isUpgrade flag, separated standard and Phase1 code

### DIFF
--- a/DQM/SiPixelCommon/interface/SiPixelFolderOrganizerPhase1.h
+++ b/DQM/SiPixelCommon/interface/SiPixelFolderOrganizerPhase1.h
@@ -1,0 +1,50 @@
+#ifndef SiPixelCommon_SiPixelFolderOrganizerPhase1_h
+#define SiPixelCommon_SiPixelFolderOrganizerPhase1_h
+// -*- C++ -*-
+//
+// Package:     SiPixelCommon
+// Class  :     SiPixelFolderOrganizerPhase1
+// 
+/**\class SiPixelFolderOrganizerPhase1 SiPixelFolderOrganizerPhase1.h DQM/SiPixelCommon/interface/SiPixelFolderOrganizerPhase1.h
+   
+Description: <Organizes the folders for the monitoring elements of the Pixel detector. Its methods return strings with names of folders to be created and used.>
+
+Usage:
+<usage>
+
+*/
+//
+// Original Author:  chiochia
+//         Created:  Thu Jan 26 23:49:46 CET 2006
+#include "DQMServices/Core/interface/DQMStore.h"
+#include <boost/cstdint.hpp>
+#include <string>
+
+class SiPixelFolderOrganizerPhase1 {
+  
+ public:
+
+  /// Constructor - getStore should be called false from multi-thread DQM applications
+  SiPixelFolderOrganizerPhase1(bool getStore = true);
+
+  /// Destructor
+  virtual ~SiPixelFolderOrganizerPhase1();
+  
+  /// Set folder name for a module or plaquette
+  //type is: BPIX  mod=0, lad=1, lay=2, phi=3, 
+  //         FPIX  mod=0, blade=4, disc=5, ring=6
+  bool setModuleFolder(const uint32_t& rawdetid=0, int type=0);
+  bool setModuleFolder(DQMStore::IBooker&, const uint32_t& rawdetid=0, int type=0);
+  void getModuleFolder(const uint32_t& rawdetid, std::string& path);
+
+  /// Set folder name for a FED (used in the case of errors without detId)
+  bool setFedFolder(const uint32_t FedId);
+  bool setFedFolder(DQMStore::IBooker&, const uint32_t FedId);
+
+  
+ private:
+
+  std::string rootFolder;
+  DQMStore* dbe_;
+};
+#endif

--- a/DQM/SiPixelCommon/python/SiPixelOfflineDQM_phase1_source_cff.py
+++ b/DQM/SiPixelCommon/python/SiPixelOfflineDQM_phase1_source_cff.py
@@ -1,0 +1,143 @@
+import FWCore.ParameterSet.Config as cms
+
+# Pixel RawDataError Monitoring
+from DQM.SiPixelMonitorRawData.SiPixelMonitorRawData_cfi import * 
+SiPixelRawDataErrorSourcePhase1.saveFile = False
+SiPixelRawDataErrorSourcePhase1.isPIB = False
+SiPixelRawDataErrorSourcePhase1.slowDown = False
+SiPixelRawDataErrorSourcePhase1.reducedSet = False
+
+# Pixel Digi Monitoring
+from DQM.SiPixelMonitorDigi.SiPixelMonitorDigi_cfi import *
+SiPixelDigiSourcePhase1.saveFile = False
+SiPixelDigiSourcePhase1.isPIB = False
+SiPixelDigiSourcePhase1.slowDown = False
+
+# Pixel Cluster Monitoring
+from DQM.SiPixelMonitorCluster.SiPixelMonitorCluster_cfi import *
+SiPixelClusterSourcePhase1.saveFile = False
+
+# Pixel RecHit Monitoring
+from DQM.SiPixelMonitorRecHit.SiPixelMonitorRecHit_cfi import *
+SiPixelRecHitSourcePhase1.saveFile = False
+
+# Pixel Track Monitoring
+from DQM.SiPixelMonitorTrack.SiPixelMonitorTrack_cfi import *
+SiPixelTrackResidualSourcePhase1.saveFile = False
+SiPixelTrackResidualSourcePhase1.TrackCandidateProducer = cms.string('initialStepTrackCandidates')
+SiPixelTrackResidualSourcePhase1.trajectoryInput = cms.InputTag('generalTracks')
+from DQM.SiPixelMonitorTrack.SiPixelMonitorTrack_Cosmics_cfi import *
+SiPixelTrackResidualSource_CosmicsPhase1.saveFile = False
+from DQM.SiPixelMonitorTrack.SiPixelMonitorEfficiency_cfi import *
+SiPixelHitEfficiencySourcePhase1.saveFile = False
+SiPixelHitEfficiencySourcePhase1.trajectoryInput = cms.InputTag('generalTracks') 
+
+##online/offline
+#RawDataErrors
+SiPixelRawDataErrorSourcePhase1.modOn = False
+SiPixelRawDataErrorSourcePhase1.ladOn = True
+SiPixelRawDataErrorSourcePhase1.bladeOn = True
+#Digi
+SiPixelDigiSourcePhase1.modOn = False
+SiPixelDigiSourcePhase1.twoDimOn = False
+SiPixelDigiSourcePhase1.reducedSet = True
+SiPixelDigiSourcePhase1.hiRes = False
+SiPixelDigiSourcePhase1.twoDimModOn = False
+SiPixelDigiSourcePhase1.twoDimOnlyLayDisk = False
+SiPixelDigiSourcePhase1.ladOn = True
+SiPixelDigiSourcePhase1.layOn = True
+SiPixelDigiSourcePhase1.phiOn = False
+SiPixelDigiSourcePhase1.bladeOn = True
+SiPixelDigiSourcePhase1.diskOn = True
+SiPixelDigiSourcePhase1.ringOn = False
+SiPixelDigiSourcePhase1.bigEventSize = 2600
+#Cluster
+SiPixelClusterSourcePhase1.modOn = False
+SiPixelClusterSourcePhase1.twoDimOn = False
+SiPixelClusterSourcePhase1.reducedSet = True
+SiPixelClusterSourcePhase1.ladOn = True
+SiPixelClusterSourcePhase1.layOn = True
+SiPixelClusterSourcePhase1.phiOn = False
+SiPixelClusterSourcePhase1.bladeOn = True
+SiPixelClusterSourcePhase1.diskOn = True
+SiPixelClusterSourcePhase1.ringOn = False
+SiPixelClusterSourcePhase1.bigEventSize = 180
+#RecHit
+SiPixelRecHitSourcePhase1.modOn = False
+SiPixelRecHitSourcePhase1.twoDimOn = False
+SiPixelRecHitSourcePhase1.reducedSet = True
+SiPixelRecHitSourcePhase1.ladOn = True
+SiPixelRecHitSourcePhase1.layOn = True
+SiPixelRecHitSourcePhase1.phiOn = False	
+SiPixelRecHitSourcePhase1.bladeOn = True
+SiPixelRecHitSourcePhase1.diskOn = True
+SiPixelRecHitSourcePhase1.ringOn = False
+
+#Track
+SiPixelTrackResidualSourcePhase1.modOn = False
+SiPixelTrackResidualSourcePhase1.ladOn = True
+SiPixelTrackResidualSourcePhase1.layOn = True
+SiPixelTrackResidualSourcePhase1.phiOn = False	
+SiPixelTrackResidualSourcePhase1.bladeOn = True
+SiPixelTrackResidualSourcePhase1.diskOn = True
+SiPixelTrackResidualSourcePhase1.ringOn = False
+SiPixelTrackResidualSource_CosmicsPhase1.modOn = False
+SiPixelTrackResidualSource_CosmicsPhase1.ladOn = True
+SiPixelTrackResidualSource_CosmicsPhase1.layOn = True
+SiPixelTrackResidualSource_CosmicsPhase1.phiOn = False	
+SiPixelTrackResidualSource_CosmicsPhase1.bladeOn = True
+SiPixelTrackResidualSource_CosmicsPhase1.diskOn = True
+SiPixelTrackResidualSource_CosmicsPhase1.ringOn = False
+SiPixelHitEfficiencySourcePhase1.modOn = False
+SiPixelHitEfficiencySourcePhase1.ladOn = True
+SiPixelHitEfficiencySourcePhase1.layOn = False
+SiPixelHitEfficiencySourcePhase1.phiOn = False
+SiPixelHitEfficiencySourcePhase1.bladeOn = True
+SiPixelHitEfficiencySourcePhase1.diskOn = False
+SiPixelHitEfficiencySourcePhase1.ringOn = False
+
+#HI track modules
+hiTracks = "hiGlobalPrimTracks"
+
+SiPixelTrackResidualSource_HeavyIons = SiPixelTrackResidualSource.clone(
+    TrackCandidateProducer = 'hiPrimTrackCandidates',
+    trajectoryInput = hiTracks
+    )
+
+SiPixelHitEfficiencySource_HeavyIons = SiPixelHitEfficiencySource.clone(
+    trajectoryInput = hiTracks
+    )
+
+
+# Phase1 Upgrade configuration
+SiPixelRawDataErrorSource_phase1 = SiPixelRawDataErrorSourcePhase1.clone(
+    )
+SiPixelDigiSource_phase1 = SiPixelDigiSourcePhase1.clone(
+    )
+SiPixelClusterSource_phase1 = SiPixelClusterSourcePhase1.clone(
+    )
+SiPixelRecHitSource_phase1 = SiPixelRecHitSourcePhase1.clone(
+    )
+SiPixelTrackResidualSource_phase1 = SiPixelTrackResidualSourcePhase1.clone(
+    )
+SiPixelHitEfficiencySource_phase1 = SiPixelHitEfficiencySourcePhase1.clone(
+    )
+
+
+#DQM service
+dqmInfo = cms.EDAnalyzer("DQMEventInfo",
+    subSystemFolder = cms.untracked.string('Pixel')
+)
+
+#FED integrity
+from DQM.SiPixelMonitorRawData.SiPixelMonitorHLT_cfi import *
+
+#siPixelOfflineDQM_source = cms.Sequence(SiPixelHLTSource + SiPixelRawDataErrorSource + SiPixelDigiSource + SiPixelRecHitSource + SiPixelClusterSource + SiPixelTrackResidualSource + SiPixelHitEfficiencySource + dqmInfo)
+
+#siPixelOfflineDQM_cosmics_source = cms.Sequence(SiPixelHLTSource + SiPixelRawDataErrorSource + SiPixelDigiSource + SiPixelRecHitSource + SiPixelClusterSource + SiPixelTrackResidualSource_Cosmics + dqmInfo)
+
+#siPixelOfflineDQM_heavyions_source = cms.Sequence(SiPixelHLTSource + SiPixelRawDataErrorSource + SiPixelDigiSource + SiPixelRecHitSource + SiPixelClusterSource + SiPixelTrackResidualSource_HeavyIons + SiPixelHitEfficiencySource_HeavyIons + dqmInfo)
+
+#siPixelOfflineDQM_source_woTrack = cms.Sequence(SiPixelHLTSource + SiPixelRawDataErrorSource + SiPixelDigiSource + SiPixelRecHitSource + SiPixelClusterSource + dqmInfo)
+
+#siPixelOfflineDQM_phase1_source = cms.Sequence(SiPixelRawDataErrorSource_phase1 + SiPixelDigiSource_phase1 + SiPixelRecHitSource_phase1 + SiPixelClusterSource_phase1 + SiPixelTrackResidualSource_phase1 + SiPixelHitEfficiencySource_phase1 + dqmInfo)

--- a/DQM/SiPixelCommon/python/SiPixelOfflineDQM_source_cff.py
+++ b/DQM/SiPixelCommon/python/SiPixelOfflineDQM_source_cff.py
@@ -32,6 +32,8 @@ from DQM.SiPixelMonitorTrack.SiPixelMonitorEfficiency_cfi import *
 SiPixelHitEfficiencySource.saveFile = False
 SiPixelHitEfficiencySource.trajectoryInput = cms.InputTag('generalTracks') 
 
+from DQM.SiPixelCommon.SiPixelOfflineDQM_phase1_source_cff import *
+
 ##online/offline
 #RawDataErrors
 SiPixelRawDataErrorSource.modOn = False
@@ -110,24 +112,24 @@ SiPixelHitEfficiencySource_HeavyIons = SiPixelHitEfficiencySource.clone(
 
 
 # Phase1 Upgrade configuration
-SiPixelRawDataErrorSource_phase1 = SiPixelRawDataErrorSource.clone(
-    isUpgrade = cms.untracked.bool(True)
-    )
-SiPixelDigiSource_phase1 = SiPixelDigiSource.clone(
-    isUpgrade = cms.untracked.bool(True)
-    )
-SiPixelClusterSource_phase1 = SiPixelClusterSource.clone(
-    isUpgrade = cms.untracked.bool(True)
-    )
-SiPixelRecHitSource_phase1 = SiPixelRecHitSource.clone(
-    isUpgrade = cms.untracked.bool(True)
-    )
-SiPixelTrackResidualSource_phase1 = SiPixelTrackResidualSource.clone(
-    isUpgrade = cms.untracked.bool(True)
-    )
-SiPixelHitEfficiencySource_phase1 = SiPixelHitEfficiencySource.clone(
-    isUpgrade = cms.untracked.bool(True)
-    )
+#SiPixelRawDataErrorSource_phase1 = SiPixelRawDataErrorSource.clone(
+#    isUpgrade = cms.untracked.bool(True)
+#    )
+#SiPixelDigiSource_phase1 = SiPixelDigiSource.clone(
+#    isUpgrade = cms.untracked.bool(True)
+#    )
+#SiPixelClusterSource_phase1 = SiPixelClusterSource.clone(
+#    isUpgrade = cms.untracked.bool(True)
+#    )
+#SiPixelRecHitSource_phase1 = SiPixelRecHitSource.clone(
+#    isUpgrade = cms.untracked.bool(True)
+#    )
+#SiPixelTrackResidualSource_phase1 = SiPixelTrackResidualSource.clone(
+#    isUpgrade = cms.untracked.bool(True)
+#    )
+#SiPixelHitEfficiencySource_phase1 = SiPixelHitEfficiencySource.clone(
+#    isUpgrade = cms.untracked.bool(True)
+#    )
 
 
 #DQM service

--- a/DQM/SiPixelCommon/src/SiPixelFolderOrganizerPhase1.cc
+++ b/DQM/SiPixelCommon/src/SiPixelFolderOrganizerPhase1.cc
@@ -1,0 +1,299 @@
+/// DQM and Framework services
+#include "DQM/SiPixelCommon/interface/SiPixelFolderOrganizerPhase1.h"
+//#include "DQMServices/Core/interface/DQMStore.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/Exception.h"
+/// Data Formats
+#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+#include "DataFormats/SiPixelDetId/interface/PixelBarrelName.h"
+#include "DataFormats/SiPixelDetId/interface/PixelBarrelNameUpgrade.h"
+#include "DataFormats/SiPixelDetId/interface/PixelEndcapName.h"
+#include "DataFormats/SiPixelDetId/interface/PixelEndcapNameUpgrade.h"
+#include <sstream>
+#include <cstdio>
+
+/// Constructor
+SiPixelFolderOrganizerPhase1::SiPixelFolderOrganizerPhase1(bool getStore) :
+  rootFolder("Pixel")
+{  
+  //Not allowed in multithread framework, but can still be called by other modules not from DQM.
+  if (getStore) dbe_ = edm::Service<DQMStore>().operator->();
+}
+
+SiPixelFolderOrganizerPhase1::~SiPixelFolderOrganizerPhase1() {}
+
+//Overloaded function for calling outside of DQM framework
+bool SiPixelFolderOrganizerPhase1::setModuleFolder(const uint32_t& rawdetid, int type) {
+
+  bool flag = false;
+
+   if(rawdetid == 0) {
+     dbe_->setCurrentFolder(rootFolder);
+     flag = true;
+   }
+   ///
+   /// Pixel Barrel
+   ///
+   else if(DetId(rawdetid).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel)) {
+
+     //for endcap types there is nothing to do: 
+     if(type>3 && type!=7) return true;
+     
+     std::string subDetectorFolder = "Barrel";
+     PixelBarrelNameUpgrade::Shell DBshell = PixelBarrelNameUpgrade(DetId(rawdetid)).shell();
+     int DBlayer  = PixelBarrelNameUpgrade(DetId(rawdetid)).layerName();
+     int DBladder = PixelBarrelNameUpgrade(DetId(rawdetid)).ladderName();
+     int DBmodule = PixelBarrelNameUpgrade(DetId(rawdetid)).moduleName();
+     
+     char slayer[80];  sprintf(slayer, "Layer_%i",   DBlayer);
+     char sladder[80]; sprintf(sladder,"Ladder_%02i",DBladder);
+     char smodule[80]; sprintf(smodule,"Module_%i",  DBmodule);
+     
+     std::ostringstream sfolder;
+     
+     sfolder << rootFolder << "/" << subDetectorFolder; 
+     if(type<4){
+       sfolder << "/Shell_" <<DBshell
+               << "/" << slayer;
+     } 
+     if(type<2){
+       sfolder << "/" << sladder;
+       if ( PixelBarrelNameUpgrade(DetId(rawdetid)).isHalfModule() ) sfolder <<"H"; 
+       else sfolder <<"F";
+     }
+     if(type==0) sfolder << "/" <<smodule;
+     //if(type==3) sfolder << "/all_" << smodule;
+     
+     //std::cout<<"set barrel folder: "<<rawdetid<<" : "<<sfolder.str().c_str()<<std::endl;
+     
+     dbe_->setCurrentFolder(sfolder.str().c_str());
+     flag = true;
+   } 
+   
+   ///
+   /// Pixel Endcap
+   ///
+   else if(DetId(rawdetid).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap)) {
+
+     //for barrel types there is nothing to do: 
+     if(type>0 && type < 4) return true;
+     
+     std::string subDetectorFolder = "Endcap";
+     PixelEndcapNameUpgrade::HalfCylinder side = PixelEndcapNameUpgrade(DetId(rawdetid)).halfCylinder();
+     int disk   = PixelEndcapNameUpgrade(DetId(rawdetid)).diskName();
+     int blade  = PixelEndcapNameUpgrade(DetId(rawdetid)).bladeName();
+     int panel  = PixelEndcapNameUpgrade(DetId(rawdetid)).pannelName();
+     int module = PixelEndcapNameUpgrade(DetId(rawdetid)).plaquetteName();
+     
+     
+     char sdisk[80];  sprintf(sdisk,  "Disk_%i",disk);
+     char sblade[80]; sprintf(sblade, "Blade_%02i",blade);
+     char spanel[80]; sprintf(spanel, "Panel_%i",panel);
+     char smodule[80];sprintf(smodule,"Module_%i",module);
+     
+     std::ostringstream sfolder;
+     
+     sfolder <<rootFolder <<"/" << subDetectorFolder << 
+       "/HalfCylinder_" << side << "/" << sdisk; 
+     if(type==0 || type ==4){
+       sfolder << "/" << sblade; 
+     }
+     if(type==0){
+       sfolder << "/" << spanel << "/" << smodule;
+     }
+     //        if(type==6){
+     //          sfolder << "/" << spanel << "_all_" << smodule;
+     //        }
+     
+     //std::cout<<"set endcap folder: "<<rawdetid<<" : "<<sfolder.str().c_str()<<std::endl;
+     
+     dbe_->setCurrentFolder(sfolder.str().c_str());
+     flag = true;
+   } else throw cms::Exception("LogicError")
+	    << "[SiPixelFolderOrganizerPhase1::setModuleFolder] Not a Pixel detector DetId ";
+   
+   return flag;
+
+}
+
+//Overloaded setModuleFolder for multithread safe operation
+bool SiPixelFolderOrganizerPhase1::setModuleFolder(DQMStore::IBooker& iBooker, const uint32_t& rawdetid, int type) {
+
+  bool flag = false;
+
+   if(rawdetid == 0) {
+     iBooker.setCurrentFolder(rootFolder);
+     flag = true;
+   }
+   ///
+   /// Pixel Barrel
+   ///
+   else if(DetId(rawdetid).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel)) {
+
+     //for endcap types there is nothing to do: 
+     if(type>3 && type!=7) return true;
+     
+     std::string subDetectorFolder = "Barrel";
+     PixelBarrelNameUpgrade::Shell DBshell = PixelBarrelNameUpgrade(DetId(rawdetid)).shell();
+     int DBlayer  = PixelBarrelNameUpgrade(DetId(rawdetid)).layerName();
+     int DBladder = PixelBarrelNameUpgrade(DetId(rawdetid)).ladderName();
+     int DBmodule = PixelBarrelNameUpgrade(DetId(rawdetid)).moduleName();
+     
+     char slayer[80];  sprintf(slayer, "Layer_%i",   DBlayer);
+     char sladder[80]; sprintf(sladder,"Ladder_%02i",DBladder);
+     char smodule[80]; sprintf(smodule,"Module_%i",  DBmodule);
+     
+     std::ostringstream sfolder;
+     
+     sfolder << rootFolder << "/" << subDetectorFolder; 
+     if(type<4){
+       sfolder << "/Shell_" <<DBshell
+               << "/" << slayer;
+     } 
+     if(type<2){
+       sfolder << "/" << sladder;
+       if ( PixelBarrelNameUpgrade(DetId(rawdetid)).isHalfModule() ) sfolder <<"H"; 
+       else sfolder <<"F";
+     }
+     if(type==0) sfolder << "/" <<smodule;
+     //if(type==3) sfolder << "/all_" << smodule;
+     
+     //std::cout<<"set barrel folder: "<<rawdetid<<" : "<<sfolder.str().c_str()<<std::endl;
+     
+     iBooker.setCurrentFolder(sfolder.str().c_str());
+     flag = true;
+   } 
+   
+   ///
+   /// Pixel Endcap
+   ///
+   else if(DetId(rawdetid).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap)) {
+
+     //for barrel types there is nothing to do: 
+     if(type>0 && type < 4) return true;
+     
+     std::string subDetectorFolder = "Endcap";
+     PixelEndcapNameUpgrade::HalfCylinder side = PixelEndcapNameUpgrade(DetId(rawdetid)).halfCylinder();
+     int disk   = PixelEndcapNameUpgrade(DetId(rawdetid)).diskName();
+     int blade  = PixelEndcapNameUpgrade(DetId(rawdetid)).bladeName();
+     int panel  = PixelEndcapNameUpgrade(DetId(rawdetid)).pannelName();
+     int module = PixelEndcapNameUpgrade(DetId(rawdetid)).plaquetteName();
+     
+     
+     char sdisk[80];  sprintf(sdisk,  "Disk_%i",disk);
+     char sblade[80]; sprintf(sblade, "Blade_%02i",blade);
+     char spanel[80]; sprintf(spanel, "Panel_%i",panel);
+     char smodule[80];sprintf(smodule,"Module_%i",module);
+     
+     std::ostringstream sfolder;
+     
+     sfolder <<rootFolder <<"/" << subDetectorFolder << 
+       "/HalfCylinder_" << side << "/" << sdisk; 
+     if(type==0 || type ==4){
+       sfolder << "/" << sblade; 
+     }
+     if(type==0){
+       sfolder << "/" << spanel << "/" << smodule;
+     }
+     //        if(type==6){
+     //          sfolder << "/" << spanel << "_all_" << smodule;
+     //        }
+     
+     //std::cout<<"set endcap folder: "<<rawdetid<<" : "<<sfolder.str().c_str()<<std::endl;
+     
+     iBooker.setCurrentFolder(sfolder.str().c_str());
+     flag = true;
+   } else throw cms::Exception("LogicError")
+	    << "[SiPixelFolderOrganizerPhase1::setModuleFolder] Not a Pixel detector DetId ";
+   
+   return flag;
+
+}
+
+//Overloaded setFedFolder for use outside of DQM framework
+bool SiPixelFolderOrganizerPhase1::setFedFolder(const uint32_t FedId) {
+
+  std::string subDetectorFolder = "AdditionalPixelErrors";
+  char sFed[80];  sprintf(sFed,  "FED_%i",FedId);
+  std::ostringstream sfolder;
+  
+  sfolder << rootFolder << "/" << subDetectorFolder << "/" << sFed;
+  dbe_->setCurrentFolder(sfolder.str().c_str());
+  
+  return true;
+
+}
+
+//Overloaded setFedFolder to avoid accessing DQMStore directly.
+bool SiPixelFolderOrganizerPhase1::setFedFolder(DQMStore::IBooker& iBooker, const uint32_t FedId) {
+
+  std::string subDetectorFolder = "AdditionalPixelErrors";
+  char sFed[80];  sprintf(sFed,  "FED_%i",FedId);
+  std::ostringstream sfolder;
+  
+  sfolder << rootFolder << "/" << subDetectorFolder << "/" << sFed;
+  iBooker.setCurrentFolder(sfolder.str().c_str());
+  
+  return true;
+
+}
+
+void SiPixelFolderOrganizerPhase1::getModuleFolder(const uint32_t& rawdetid, 
+                                             std::string& path) {
+
+  path = rootFolder;
+  if(rawdetid == 0) {
+    return;
+  }else if( (DetId(rawdetid).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel)) ) {
+    std::string subDetectorFolder = "Barrel";
+    PixelBarrelNameUpgrade::Shell DBshell = PixelBarrelNameUpgrade(DetId(rawdetid)).shell();
+    int DBlayer  = PixelBarrelNameUpgrade(DetId(rawdetid)).layerName();
+    int DBladder = PixelBarrelNameUpgrade(DetId(rawdetid)).ladderName();
+    int DBmodule = PixelBarrelNameUpgrade(DetId(rawdetid)).moduleName();
+    
+    //char sshell[80];  sprintf(sshell, "Shell_%i",   DBshell);
+    char slayer[80];  sprintf(slayer, "Layer_%i",   DBlayer);
+    char sladder[80]; sprintf(sladder,"Ladder_%02i",DBladder);
+    char smodule[80]; sprintf(smodule,"Module_%i",  DBmodule);
+    
+    std::ostringstream sfolder;
+    sfolder << rootFolder << "/" << subDetectorFolder << "/Shell_" <<DBshell << "/" << slayer << "/" << sladder;
+    if ( PixelBarrelNameUpgrade(DetId(rawdetid)).isHalfModule() ) sfolder <<"H"; 
+    else sfolder <<"F";
+    sfolder << "/" <<smodule;
+    path = sfolder.str().c_str();
+   
+    //path = path + "/" + subDetectorFolder + "/" + sshell + "/" + slayer + "/" + sladder;
+    //if(PixelBarrelNameUpgrade(DetId(rawdetid)).isHalfModule() )
+    //  path = path + "H"; 
+    //else path = path + "F";
+    //path = path + "/" + smodule;
+
+  } else if( (DetId(rawdetid).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap)) ) {
+    std::string subDetectorFolder = "Endcap";
+    PixelEndcapNameUpgrade::HalfCylinder side = PixelEndcapNameUpgrade(DetId(rawdetid)).halfCylinder();
+    int disk   = PixelEndcapNameUpgrade(DetId(rawdetid)).diskName();
+    int blade  = PixelEndcapNameUpgrade(DetId(rawdetid)).bladeName();
+    int panel  = PixelEndcapNameUpgrade(DetId(rawdetid)).pannelName();
+    int module = PixelEndcapNameUpgrade(DetId(rawdetid)).plaquetteName();
+
+    //char shc[80];  sprintf(shc,  "HalfCylinder_%i",side);
+    char sdisk[80];  sprintf(sdisk,  "Disk_%i",disk);
+    char sblade[80]; sprintf(sblade, "Blade_%02i",blade);
+    char spanel[80]; sprintf(spanel, "Panel_%i",panel);
+    char smodule[80];sprintf(smodule,"Module_%i",module);
+
+    std::ostringstream sfolder;
+    sfolder <<rootFolder <<"/" << subDetectorFolder << "/HalfCylinder_" << side << "/" << sdisk << "/" << sblade << "/" << spanel << "/" << smodule;
+    path = sfolder.str().c_str();
+    
+    //path = path + "/" + subDetectorFolder + "/" + shc + "/" + sdisk + "/" + sblade + "/" + spanel + "/" + smodule;
+
+  }else throw cms::Exception("LogicError")
+     << "[SiPixelFolderOrganizerPhase1::getModuleFolder] Not a Pixel detector DetId ";
+     
+  //std::cout<<"resulting final path name: "<<path<<std::endl;   
+     
+  return;
+}

--- a/DQM/SiPixelMonitorClient/interface/SiPixelActionExecutor.h
+++ b/DQM/SiPixelMonitorClient/interface/SiPixelActionExecutor.h
@@ -52,17 +52,12 @@ class SiPixelActionExecutor {
                                     bool                           Tier0Flag);
  ~SiPixelActionExecutor();
 
- void createSummary(    	    DQMStore    		 * bei,
- 				    bool   			   isUpgrade);
- void bookDeviations(               DQMStore                     * bei,
- 				    bool			   isUpgrade);
- void bookEfficiency(    	    DQMStore    		 * bei,
- 				    bool			   isUpgrade);
- void createEfficiency(    	    DQMStore    		 * bei,
- 				    bool			   isUpgrade);
+ void createSummary(    	    DQMStore    		 * bei);
+ void bookDeviations(               DQMStore                     * bei);
+ void bookEfficiency(    	    DQMStore    		 * bei);
+ void createEfficiency(    	    DQMStore    		 * bei);
  void fillEfficiency(    	    DQMStore    		 * bei,
-                                    bool                           isbarrel,
-				    bool			   isUpgrade);
+                                    bool                           isbarrel);
  void bookOccupancyPlots(    	    DQMStore    		 * bei,
                                     bool                           hiRes,
 									bool				isbarrel);
@@ -108,26 +103,22 @@ private:
   
   
   MonitorElement* getSummaryME(     DQMStore     		 * bei, 
-                                    std::string 	     	   me_name,
-				    bool			   isUpgrade);
+                                    std::string 	     	   me_name);
   MonitorElement* getFEDSummaryME(  DQMStore     		 * bei, 
                                     std::string 	     	   me_name);
   void GetBladeSubdirs(DQMStore* bei, std::vector<std::string>& blade_subdirs); 
   void fillSummary(           	    DQMStore     		 * bei, 
                                     std::string 	     	   dir_name,
                                     std::vector<std::string> 	 & me_names,
-				    bool isbarrel,
-				    bool isUpgrade);
+				    bool isbarrel);
   void fillDeviations(              DQMStore     		 * bei);
   void fillFEDErrorSummary(         DQMStore     		 * bei, 
                                     std::string 	     	   dir_name,
                                     std::vector<std::string> 	 & me_names);
   void fillGrandBarrelSummaryHistos(DQMStore     		 * bei, 
-			            std::vector<std::string> 	 & me_names,
-				    bool 			   isUpgrade);
+			            std::vector<std::string> 	 & me_names);
   void fillGrandEndcapSummaryHistos(DQMStore     		 * bei, 
-			            std::vector<std::string> 	 & me_names,
-				    bool			   isUpgrade);
+			            std::vector<std::string> 	 & me_names);
   void getGrandSummaryME(           DQMStore     		 * bei,
                                     int                      	   nbin, 
                                     std::string              	 & me_name, 

--- a/DQM/SiPixelMonitorClient/interface/SiPixelActionExecutorPhase1.h
+++ b/DQM/SiPixelMonitorClient/interface/SiPixelActionExecutorPhase1.h
@@ -1,0 +1,185 @@
+#ifndef _SiPixelActionExecutorPhase1_h_
+#define _SiPixelActionExecutorPhase1_h_
+
+#include "DQMServices/Core/interface/MonitorElement.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQM/SiPixelMonitorClient/interface/SiPixelConfigParser.h"
+#include "DQM/SiPixelMonitorClient/interface/SiPixelConfigWriter.h"
+#include "DQMServices/ClientConfig/interface/QTestHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "CondFormats/DataRecord/interface/SiPixelFedCablingMapRcd.h"
+#include "CondFormats/SiPixelObjects/interface/DetectorIndex.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingMap.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelFrameConverter.h"
+#include <fstream>
+#include <map>
+#include <vector>
+#include <string>
+
+// For Tracker Map
+enum funcType {EachBinContent, Entries, Mean, Sum, WeightedSum};
+#define PI_12 0.261799
+#define PI    3.141592
+#define PI_2  1.570796
+
+#define NLev1		4		// Number of HalfCylinders in Endcap or number of Shells in Barrel, which is bigger
+#define NLev2		3		// Number of Disks in Endcap or number of Layers in Barrel, which is bigger
+#define NLev3		22		// Number of Blades in Endcap or number of Ladders in Barrel, which is bigger
+#define NLev4		7		// Number of Modules - different for Endcap and Barrel, which is bigger
+
+#define NCyl		4
+#define NDisk		2
+#define NBlade		12
+#define NModuleE	7
+
+#define NShell		4
+#define NLayer		3
+//#define NLadders	LayNum * 6 + 4		// where LayNum is number of interesting Layer => 10, 16, 22
+#define NModuleB	4
+
+#define NPoints		5
+
+// End for Tracker Map
+
+class SiPixelActionExecutorPhase1 {
+
+ public:
+
+  SiPixelActionExecutorPhase1(            bool                           offlineXMLfile,
+                                    bool                           Tier0Flag);
+ ~SiPixelActionExecutorPhase1();
+
+ void createSummary(    	    DQMStore    		 * bei);
+ void bookDeviations(               DQMStore                     * bei);
+ void bookEfficiency(    	    DQMStore    		 * bei);
+ void createEfficiency(    	    DQMStore    		 * bei);
+ void fillEfficiency(    	    DQMStore    		 * bei,
+                                    bool                           isbarrel);
+ void bookOccupancyPlots(    	    DQMStore    		 * bei,
+                                    bool                           hiRes,
+									bool				isbarrel);
+ void bookOccupancyPlots(    	    DQMStore    		 * bei,
+                                    bool                           hiRes);
+ void createOccupancy(    	    DQMStore    		 * bei);
+ void setupQTests(      	    DQMStore    		 * bei);
+ void checkQTestResults(	    DQMStore    		 * bei);
+ void createTkMap(      	    DQMStore    		 * bei, 
+                        	    std::string 	    	   mEName,
+				    std::string 	    	   theTKType);
+ bool readConfiguration(	    int 			 & tkmap_freq, 
+                        	    int 			 & sum_barrel_freq, 
+				    int 			 & sum_endcap_freq, 
+				    int 			 & sum_grandbarrel_freq, 
+				    int 			 & sum_grandendcap_freq,
+				    int 			 & message_limit,
+                                    int                          & source_type,
+				    int                          & calib_type);
+ bool readConfiguration(	    int 			 & tkmap_freq, 
+                        	    int 			 & summary_freq);
+ void readConfiguration(	    );
+ void createLayout(     	    DQMStore    		 * bei);
+ void fillLayout(       	    DQMStore    		 * bei);
+ int getTkMapMENames(               std::vector<std::string>	 & names);
+ void dumpModIds(                   DQMStore     		 * bei,
+                                    edm::EventSetup const        & eSetup);
+ void dumpBarrelModIds(             DQMStore     		 * bei,
+                                    edm::EventSetup const        & eSetup);
+ void dumpEndcapModIds(             DQMStore     		 * bei,
+                                    edm::EventSetup const        & eSetup);
+ void dumpRefValues(                   DQMStore     		 * bei,
+                                    edm::EventSetup const        & eSetup);
+ void dumpBarrelRefValues(             DQMStore     		 * bei,
+                                    edm::EventSetup const        & eSetup);
+ void dumpEndcapRefValues(             DQMStore     		 * bei,
+                                    edm::EventSetup const        & eSetup);
+ void createMaps(DQMStore* bei, std::string type, std::string name, funcType ff);
+ void bookTrackerMaps(DQMStore* bei, std::string name);
+
+
+private:
+  
+  
+  MonitorElement* getSummaryME(     DQMStore     		 * bei, 
+                                    std::string 	     	   me_name);
+  MonitorElement* getFEDSummaryME(  DQMStore     		 * bei, 
+                                    std::string 	     	   me_name);
+  void GetBladeSubdirs(DQMStore* bei, std::vector<std::string>& blade_subdirs); 
+  void fillSummary(           	    DQMStore     		 * bei, 
+                                    std::string 	     	   dir_name,
+                                    std::vector<std::string> 	 & me_names,
+				    bool isbarrel);
+  void fillDeviations(              DQMStore     		 * bei);
+  void fillFEDErrorSummary(         DQMStore     		 * bei, 
+                                    std::string 	     	   dir_name,
+                                    std::vector<std::string> 	 & me_names);
+  void fillGrandBarrelSummaryHistos(DQMStore     		 * bei, 
+			            std::vector<std::string> 	 & me_names);
+  void fillGrandEndcapSummaryHistos(DQMStore     		 * bei, 
+			            std::vector<std::string> 	 & me_names);
+  void getGrandSummaryME(           DQMStore     		 * bei,
+                                    int                      	   nbin, 
+                                    std::string              	 & me_name, 
+				    std::vector<MonitorElement*> & mes);
+ 
+  void fillOccupancy(    	    DQMStore    		 * bei,
+				    bool isbarrel);
+
+  SiPixelConfigParser* configParser_;
+  SiPixelConfigWriter* configWriter_;
+  edm::ESHandle<SiPixelFedCablingMap> theCablingMap;
+  
+  std::vector<std::string> summaryMENames;
+  std::vector<std::string> tkMapMENames;
+  
+  int message_limit_;
+  int source_type_;
+  int calib_type_;  
+  int ndet_;
+  bool offlineXMLfile_;
+  bool Tier0Flag_;
+  
+  QTestHandle* qtHandler_;
+  
+  MonitorElement * OccupancyMap;
+  MonitorElement * PixelOccupancyMap;
+  MonitorElement * HitEfficiency_L1;
+  MonitorElement * HitEfficiency_L2;
+  MonitorElement * HitEfficiency_L3;
+  MonitorElement * HitEfficiency_L4;
+  MonitorElement * HitEfficiency_Dp1;
+  MonitorElement * HitEfficiency_Dp2;
+  MonitorElement * HitEfficiency_Dp3;
+  MonitorElement * HitEfficiency_Dm1;
+  MonitorElement * HitEfficiency_Dm2;
+  MonitorElement * HitEfficiency_Dm3;
+  MonitorElement * DEV_adc_Barrel;
+  MonitorElement * DEV_ndigis_Barrel;
+  MonitorElement * DEV_charge_Barrel;
+  MonitorElement * DEV_nclusters_Barrel;
+  MonitorElement * DEV_size_Barrel;
+  MonitorElement * DEV_adc_Endcap;
+  MonitorElement * DEV_ndigis_Endcap;
+  MonitorElement * DEV_charge_Endcap;
+  MonitorElement * DEV_nclusters_Endcap;
+  MonitorElement * DEV_size_Endcap;
+  
+  
+  int createMap(Double_t map[][NLev2][NLev3][NLev4], std::string type, DQMStore* bei, funcType ff, bool isBarrel);
+  void getData(Double_t map[][NLev2][NLev3][NLev4], std::string type, DQMStore* bei, funcType ff, Int_t i, Int_t j, Int_t k, Int_t l);
+  void prephistosB(MonitorElement* me[NCyl], DQMStore *bei, const Double_t map[][NLev2][NLev3][NLev4], std::string name, Double_t min, Double_t max);
+  void prephistosE(MonitorElement* me[NCyl], DQMStore *bei, const Double_t map[][NLev2][NLev3][NLev4], std::string name, Double_t min, Double_t max);
+  Double_t mapMax(const Double_t map[][NLev2][NLev3][NLev4], bool isBarrel); 
+  Double_t mapMin(const Double_t map[][NLev2][NLev3][NLev4], bool isBarrel);
+
+  TH2F * temp_H;
+  TH2F * temp_1x2;
+  TH2F * temp_1x5;
+  TH2F * temp_2x3;
+  TH2F * temp_2x4;
+  TH2F * temp_2x5;
+  
+};
+#endif

--- a/DQM/SiPixelMonitorClient/interface/SiPixelDataQualityPhase1.h
+++ b/DQM/SiPixelMonitorClient/interface/SiPixelDataQualityPhase1.h
@@ -1,0 +1,156 @@
+#ifndef _SiPixelDataQuality_h_
+#define _SiPixelDataQuality_h_
+
+#include "DQMServices/Core/interface/MonitorElement.h"
+
+#include "DQM/SiPixelMonitorClient/interface/SiPixelConfigParser.h"
+#include "DQM/SiPixelMonitorClient/interface/SiPixelConfigWriter.h"
+#include "DQM/SiPixelMonitorClient/interface/SiPixelActionExecutorPhase1.h"
+#include "DQM/SiPixelMonitorClient/interface/SiPixelLayoutParser.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/SiPixelDigi/interface/PixelDigi.h"
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "CondFormats/DataRecord/interface/SiPixelFedCablingMapRcd.h"
+#include "CondFormats/SiPixelObjects/interface/DetectorIndex.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingMap.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelFrameConverter.h"
+
+#include "TCanvas.h"
+#include "TPaveText.h"
+#include "TF1.h"
+#include "TH2F.h"
+#include "TGaxis.h"
+
+#include <fstream>
+#include <sstream>
+#include <map>
+#include <vector>
+#include <string>
+#include <map>
+#include <boost/cstdint.hpp>
+
+class DQMStore;
+class SiPixelEDAClient;
+class SiPixelWebInterface;
+class SiPixelHistoPlotter;
+class SiPixelDataQuality {
+
+ public:
+
+  SiPixelDataQuality(  bool                                      offlineXMLfile);
+ ~SiPixelDataQuality();
+
+  int getDetId(                 MonitorElement                          * mE) ;				
+
+  void bookGlobalQualityFlag    (DQMStore                               * bei,
+				 bool                                     Tier0Flag,
+				 int                                      nFEDs);
+
+  void computeGlobalQualityFlag (DQMStore                               * bei,
+                                 bool                                     init,
+				 int                                      nFEDs,
+				 bool                                     Tier0Flag);
+  
+  void computeGlobalQualityFlagByLumi (DQMStore                         * bei,
+                                       bool                               init,
+				       int                                nFEDs,
+				       bool                               Tier0Flag,
+				       int                                nEvents_lastLS_,
+				       int                                nErrorsBarrel_lastLS_,
+				       int                                nErrorsEndcap_lastLS_);
+  
+  void fillGlobalQualityPlot    (DQMStore                               * bei,
+                                 bool                                     init,
+                                 edm::EventSetup const                  & eSetup,
+				 int                                      nFEDs,
+				 bool                                     Tier0Flag,
+				 int                                      lumisec);
+  
+ private:
+
+  bool  offlineXMLfile_;
+  
+  
+  TH2F * allmodsMap;
+  TH2F * errmodsMap;
+  TH2F * goodmodsMap;
+  TH1D * allmodsVec;
+  TH1D * errmodsVec;
+  TH1D * goodmodsVec;
+  int count;
+  int errcount;
+  bool gotDigis;
+  
+  int objectCount_;
+  bool DONE_;
+  
+  
+  std::ofstream myfile_;  
+  int nevents_;
+  bool endOfModules_;
+  edm::ESHandle<SiPixelFedCablingMap> theCablingMap;
+  
+  // Final combined Data Quality Flags:
+  MonitorElement * SummaryReportMap;
+  MonitorElement * SummaryPixel;
+  MonitorElement * SummaryBarrel;
+  MonitorElement * SummaryEndcap;
+  MonitorElement * ClusterModAll;
+  MonitorElement * ClusterMod1;
+  MonitorElement * ClusterMod2;
+  MonitorElement * ClusterMod3;
+  MonitorElement * ClusterMod4;
+
+  float qflag_;
+  int allMods_, errorMods_, barrelMods_, endcapMods_;
+ 
+  // FEDErrors Cuts:
+  MonitorElement * FEDErrReportMap;
+  MonitorElement * NErrorsBarrel;
+  MonitorElement * NErrorsEndcap;
+  MonitorElement * NErrorsFEDs;
+  int n_errors_barrel_, n_errors_endcap_, n_errors_pixel_;
+  float barrel_error_flag_, endcap_error_flag_, pixel_error_flag_;
+  
+  bool digiStatsBarrel, clusterStatsBarrel, trackStatsBarrel;
+  int digiCounterBarrel, clusterCounterBarrel, trackCounterBarrel;
+  bool digiStatsEndcap, clusterStatsEndcap, trackStatsEndcap;
+  int digiCounterEndcap, clusterCounterEndcap, trackCounterEndcap;
+
+  // Digis Cuts:
+  MonitorElement * NDigisBarrel;
+  MonitorElement * NDigisEndcap;
+  MonitorElement * DigiChargeBarrel;
+  MonitorElement * DigiChargeEndcap;
+  
+  // Cluster Cuts:
+  MonitorElement * ClusterSizeBarrel;
+  MonitorElement * ClusterSizeEndcap;
+  MonitorElement * ClusterChargeBarrel;
+  MonitorElement * ClusterChargeEndcap;
+  MonitorElement * NClustersBarrel;
+  MonitorElement * NClustersEndcap;
+  
+  // Track Cuts:
+  MonitorElement * NPixelTracks;
+    
+  int count1;
+  int count2;
+  int count3;
+  int count4;
+  int count5;
+  int count6;
+  
+  int timeoutCounter_;
+  int modCounter_;
+  int lastLS_;
+  float lasterrmods_[40];
+  float lastallmods_[40];
+
+};
+#endif

--- a/DQM/SiPixelMonitorClient/interface/SiPixelEDAClient.h
+++ b/DQM/SiPixelMonitorClient/interface/SiPixelEDAClient.h
@@ -81,7 +81,6 @@ private:
   bool Tier0Flag_;
   bool firstRun;
   bool doHitEfficiency_;
-  bool isUpgrade_;
   std::string inputSource_;
   
   std::ostringstream html_out_;

--- a/DQM/SiPixelMonitorClient/interface/SiPixelEDAClientPhase1.h
+++ b/DQM/SiPixelMonitorClient/interface/SiPixelEDAClientPhase1.h
@@ -1,0 +1,93 @@
+#ifndef SiPixelEDAClientPhase1_H
+#define SiPixelEDAClientPhase1_H
+
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/Framework/interface/Run.h"
+
+#include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
+
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <vector>
+#include <map>
+
+class DQMStore;
+class SiPixelWebInterface;
+class SiPixelTrackerMapCreator;
+class SiPixelInformationExtractorPhase1;
+class SiPixelDataQuality;
+class SiPixelActionExecutorPhase1;
+ 
+class SiPixelEDAClientPhase1: public edm::EDAnalyzer{
+
+public:
+
+  SiPixelEDAClientPhase1(const edm::ParameterSet& ps);
+  virtual ~SiPixelEDAClientPhase1();
+  
+  //void defaultWebPage(xgi::Input *in, 
+  //xgi::Output *out); 
+  //void publish(xdata::InfoSpace *){};
+
+protected:
+
+  void beginJob();
+  void beginRun(edm::Run const& run, 
+                edm::EventSetup const& eSetup);
+  void analyze(edm::Event const& e, 
+               edm::EventSetup const& eSetup);
+  void beginLuminosityBlock(edm::LuminosityBlock const& lumiSeg, 
+                            edm::EventSetup const& context) ;
+  void endLuminosityBlock(edm::LuminosityBlock const& lumiSeg, 
+                          edm::EventSetup const& c);
+  void endRun(edm::Run const& run, 
+              edm::EventSetup const& eSetup);
+  void endJob();
+
+private:
+
+  unsigned long long m_cacheID_;
+  int nLumiSecs_;
+  int nEvents_;
+  int nEvents_lastLS_;
+  int nErrorsBarrel_lastLS_;
+  int nErrorsEndcap_lastLS_;
+  
+  
+  DQMStore* bei_;  
+
+  SiPixelWebInterface* sipixelWebInterface_;
+  SiPixelInformationExtractorPhase1* sipixelInformationExtractor_;
+  SiPixelDataQuality* sipixelDataQuality_;
+  SiPixelActionExecutorPhase1* sipixelActionExecutor_;
+  SiPixelTrackerMapCreator* trackerMapCreator_;
+
+  int tkMapFrequency_;
+  int summaryFrequency_;
+  unsigned int staticUpdateFrequency_;
+  bool actionOnLumiSec_;
+  bool actionOnRunEnd_;
+  int evtOffsetForInit_;
+  std::string summaryXMLfile_;
+  bool hiRes_;
+  double noiseRate_;
+  int noiseRateDenominator_;
+  bool offlineXMLfile_;
+  int nFEDs_;
+  bool Tier0Flag_;
+  bool firstRun;
+  bool doHitEfficiency_;
+  std::string inputSource_;
+  
+  std::ostringstream html_out_;
+  
+  //define Token(-s)
+  edm::EDGetTokenT<FEDRawDataCollection> inputSourceToken_;
+};
+
+
+#endif

--- a/DQM/SiPixelMonitorClient/interface/SiPixelInformationExtractor.h
+++ b/DQM/SiPixelMonitorClient/interface/SiPixelInformationExtractor.h
@@ -47,15 +47,13 @@ class SiPixelInformationExtractor {
 
  //  void getSingleModuleHistos(   DQMStore                                * bei, 
  //                                const std::multimap<std::string, std::string>& req_map, 
- //				xgi::Output                             * out,
- //				bool					  isUpgrade);
+ //				xgi::Output                             * out);
  //  void getHistosFromPath(       DQMStore                                * bei, 
  //                                const std::multimap<std::string, std::string>& req_map, 
  //				xgi::Output                             * out);
  //  void getTrackerMapHistos(     DQMStore                                * bei, 
  //                                const std::multimap<std::string, std::string>& req_map, 
- //				xgi::Output                             * out,
- //				bool					  isUpgrade);
+ //				xgi::Output                             * out);
 				
  //  void readModuleAndHistoList(	DQMStore				* bei,
  //                              	xgi::Output				* out);

--- a/DQM/SiPixelMonitorClient/interface/SiPixelInformationExtractorPhase1.h
+++ b/DQM/SiPixelMonitorClient/interface/SiPixelInformationExtractorPhase1.h
@@ -1,0 +1,193 @@
+#ifndef _SiPixelInformationExtractorPhase1_h_
+#define _SiPixelInformationExtractorPhase1_h_
+
+#include "DQMServices/Core/interface/MonitorElement.h"
+
+#include "DQM/SiPixelMonitorClient/interface/SiPixelConfigParser.h"
+#include "DQM/SiPixelMonitorClient/interface/SiPixelConfigWriter.h"
+#include "DQM/SiPixelMonitorClient/interface/SiPixelActionExecutorPhase1.h"
+#include "DQM/SiPixelMonitorClient/interface/SiPixelLayoutParser.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/SiPixelDigi/interface/PixelDigi.h"
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "CondFormats/DataRecord/interface/SiPixelFedCablingMapRcd.h"
+#include "CondFormats/SiPixelObjects/interface/DetectorIndex.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingMap.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelFrameConverter.h"
+
+#include "TCanvas.h"
+#include "TPaveText.h"
+#include "TF1.h"
+#include "TH2F.h"
+#include "TGaxis.h"
+
+#include <fstream>
+#include <sstream>
+#include <map>
+#include <vector>
+#include <string>
+#include <map>
+#include <boost/cstdint.hpp>
+
+class DQMStore;
+class SiPixelEDAClientPhase1;
+class SiPixelWebInterface;
+class SiPixelHistoPlotter;
+class SiPixelInformationExtractorPhase1 {
+
+ public:
+
+  SiPixelInformationExtractorPhase1(  bool                                      offlineXMLfile);
+ ~SiPixelInformationExtractorPhase1();
+
+ //  void getSingleModuleHistos(   DQMStore                                * bei, 
+ //                                const std::multimap<std::string, std::string>& req_map, 
+ //				xgi::Output                             * out);
+ //  void getHistosFromPath(       DQMStore                                * bei, 
+ //                                const std::multimap<std::string, std::string>& req_map, 
+ //				xgi::Output                             * out);
+ //  void getTrackerMapHistos(     DQMStore                                * bei, 
+ //                                const std::multimap<std::string, std::string>& req_map, 
+ //				xgi::Output                             * out);
+				
+ //  void readModuleAndHistoList(	DQMStore				* bei,
+ //                              	xgi::Output				* out);
+ //  void readModuleHistoTree(   	DQMStore				* bei, 
+ //                              	std::string				& str_name, 
+ //			      	xgi::Output				* out);
+ //  void readSummaryHistoTree(  	DQMStore				* bei, 
+ //                              	std::string				& str_name, 
+ //			      	xgi::Output				* out);
+ //  void readAlarmTree(         	DQMStore				* bei, 
+ //                              	std::string				& str_name, 
+ //                              	xgi::Output				* out);
+ //  void readStatusMessage(       DQMStore                                * bei, 
+ //                                std::multimap<std::string, std::string>& req_map, 
+ //				xgi::Output * out);
+
+  void computeStatus(           MonitorElement                          * mE,
+                                double                                  & colorValue,
+				std::pair<double,double>                & norm) ;
+  void getNormalization(        MonitorElement                          * mE,
+                                std::pair<double,double>                & norm,
+				std::string                               theMEType) ;
+  void getNormalization2D(      MonitorElement                          * mE,
+                                std::pair<double,double>                & normX,
+                                std::pair<double,double>                & normY,
+				std::string                               theMEType) ;
+
+ //  void sendTkUpdatedStatus(     DQMStore				* bei,
+ //                              	xgi::Output                             * out,
+ //				std::string                             & meName,
+  //				std::string                             & theTKType) ;
+  void selectMEList(            DQMStore                                * bei,  
+                                std::string                             & name, 
+				std::vector<MonitorElement*>            & mes);
+  void getMEList(               DQMStore                                * bei,  
+				std::map<std::string, int>              & mEHash);
+  int getDetId(                 MonitorElement                          * mE) ;				
+  //  void getIMGCImage(            const std::multimap<std::string, std::string>& req_map, 
+  //                                xgi::Output                             * out);
+  //  void getIMGCImage(            std::multimap<std::string, std::string>& req_map, 
+  //                                xgi::Output                             * out);
+  std::string getMEType(        MonitorElement                          * mE) ;
+    
+  void readConfiguration();
+  bool readConfiguration(        std::map<std::string,std::vector< std::string> >   & layoutMap,
+				 std::map<std::string,std::map<std::string,std::string> >                & qtestsMap,
+				 std::map<std::string,std::vector<std::string> >    & meQTestsMap);
+
+  void bookNoisyPixels(          DQMStore                               * bei,
+                                 float                                    noiseRate,
+				 bool                                     Tier0Flag);
+
+  void findNoisyPixels (         DQMStore                               * bei,
+                                 bool                                     init,
+				 float                                    noiseRate,
+				 int                                      noiseRateDenominator,
+                                 edm::EventSetup const                  & eSetup);
+  
+  void createImages             (DQMStore                               * bei);
+  
+ private:
+
+  void fillModuleAndHistoList(	DQMStore				* bei,
+                              	std::vector<std::string>		& modules, 
+			      	std::map<std::string,std::string>	& histos);
+  void getItemList(             const std::multimap<std::string, std::string> & req_map,
+                                std::string                               item_name, 
+				std::vector<std::string>                & items);
+  void printModuleHistoList(    DQMStore 				* bei, 
+                                std::ostringstream                      & str_val);
+  void printSummaryHistoList(   DQMStore 				* bei, 
+                                std::ostringstream                      & str_val);
+  void printAlarmList(          DQMStore 				* bei, 
+                                std::ostringstream                      & str_val);
+  bool goToDir(                 DQMStore                                * bei, 
+                                std::string                             & sname);
+  bool hasItem(                 std::multimap<std::string, std::string> & req_map,
+	                        std::string                               item_name);
+  std::string getItemValue(     const std::multimap<std::string, std::string> & req_map,
+	                        std::string                               item_name);
+  std::string getItemValue(     std::multimap<std::string, std::string> & req_map,
+	                        std::string                               item_name);
+  void createDummiesFromLayout();  
+  void selectImage(            std::string                              & name, 
+                               int                                        status);
+  void selectImage(            std::string                              & name, 
+                               std::vector<QReport*>                    & reports);
+  void selectColor(            std::string                              & col, 
+                               int                                        status);
+  void selectColor(            std::string                              & col, 
+                               std::vector<QReport*>                    & reports);
+  
+  //  void setHTMLHeader(          xgi::Output                              * out);
+  //  void setXMLHeader(           xgi::Output                              * out);
+  //  void setPlainHeader(         xgi::Output                              * out);
+ 
+  int                                    alarmCounter_;
+
+  SiPixelConfigParser   	       * configParser_  ;
+  SiPixelConfigWriter   	       * configWriter_  ;
+  SiPixelActionExecutorPhase1 	       * actionExecutor_;
+  SiPixelLayoutParser                  * layoutParser_  ;
+
+  std::map<std::string, 
+           std::vector< std::string> >  layoutMap;
+  std::map<std::string, 
+           std::map<std::string, 
+                    std::string> >      qtestsMap;
+  std::map<std::string, 
+           std::vector<std::string> >   meQTestsMap;
+
+  
+  bool  readReference_;
+  bool  readQTestMap_;
+  bool  readMeMap_;
+  bool  flagHotModule_;
+  bool  offlineXMLfile_;
+  
+  int count;
+  int errcount;
+  bool gotDigis;
+  
+  std::ofstream myfile_;  
+  int nevents_;
+  std::map< uint32_t , std::vector< std::pair< std::pair<int,int> , float > > >  noisyDetIds_;
+  bool endOfModules_;
+  edm::ESHandle<SiPixelFedCablingMap> theCablingMap;
+  MonitorElement * EventRateBarrelPixels;
+  MonitorElement * EventRateEndcapPixels;
+  
+  MonitorElement * EndcapNdigisFREQProjection;
+  MonitorElement * BarrelNdigisFREQProjection;
+  
+  
+  SiPixelHistoPlotter* histoPlotter_;
+};
+#endif

--- a/DQM/SiPixelMonitorClient/src/SiPixelActionExecutor.cc
+++ b/DQM/SiPixelMonitorClient/src/SiPixelActionExecutor.cc
@@ -170,7 +170,7 @@ void SiPixelActionExecutor::createTkMap(DQMStore* bei,
 }
 
 //=============================================================================================================
-void SiPixelActionExecutor::createSummary(DQMStore* bei, bool isUpgrade) {
+void SiPixelActionExecutor::createSummary(DQMStore* bei) {
   //cout<<"entering SiPixelActionExecutor::createSummary..."<<endl;
   string barrel_structure_name;
   vector<string> barrel_me_names;
@@ -190,7 +190,7 @@ void SiPixelActionExecutor::createSummary(DQMStore* bei, bool isUpgrade) {
 //  cout<<"++++++++++++++++++++++++++SOURCE TYPE= "<<source_type_<<endl;
   bei->setCurrentFolder("Pixel/");
   //bei->cd();
-  fillSummary(bei, barrel_structure_name, barrel_me_names, true, isUpgrade); // Barrel
+  fillSummary(bei, barrel_structure_name, barrel_me_names, true); // Barrel
   bei->setCurrentFolder("Pixel/");
   //bei->cd();
   string endcap_structure_name;
@@ -204,7 +204,7 @@ void SiPixelActionExecutor::createSummary(DQMStore* bei, bool isUpgrade) {
 
   bei->setCurrentFolder("Pixel/");
   //bei->cd();
-  fillSummary(bei, endcap_structure_name, endcap_me_names, false, isUpgrade); // Endcap
+  fillSummary(bei, endcap_structure_name, endcap_me_names, false); // Endcap
   bei->setCurrentFolder("Pixel/");
   //if(!Tier0Flag_) fillDeviations(bei);
   bei->setCurrentFolder("Pixel/");
@@ -231,9 +231,9 @@ void SiPixelActionExecutor::createSummary(DQMStore* bei, bool isUpgrade) {
 }
 
 //=============================================================================================================
-void SiPixelActionExecutor::bookDeviations(DQMStore* bei, bool isUpgrade) {
+void SiPixelActionExecutor::bookDeviations(DQMStore* bei) {
   int nBPixModules;
-  if (isUpgrade) {nBPixModules=1184;} else {nBPixModules=768;} 
+  nBPixModules=768;
   
   bei->cd();
   bei->setCurrentFolder("Pixel/Barrel");
@@ -394,7 +394,7 @@ void SiPixelActionExecutor::GetBladeSubdirs(DQMStore* bei, vector<string>& blade
 
 //=============================================================================================================
 
-void SiPixelActionExecutor::fillSummary(DQMStore* bei, string dir_name, vector<string>& me_names, bool isbarrel, bool isUpgrade)
+void SiPixelActionExecutor::fillSummary(DQMStore* bei, string dir_name, vector<string>& me_names, bool isbarrel)
 {
 	
 
@@ -445,11 +445,11 @@ void SiPixelActionExecutor::fillSummary(DQMStore* bei, string dir_name, vector<s
       if((*iv).find("residual")!=string::npos){                           // track residuals
 	tag = prefix + "_" + (*iv) + "_mean_" 
 	  + currDir.substr(currDir.find(dir_name));
-	temp = getSummaryME(bei, tag, isUpgrade);
+	temp = getSummaryME(bei, tag);
 	sum_mes.push_back(temp);
 	tag = prefix + "_" + (*iv) + "_RMS_" 
 	  + currDir.substr(currDir.find(dir_name));
-	temp = getSummaryME(bei, tag, isUpgrade);
+	temp = getSummaryME(bei, tag);
 	sum_mes.push_back(temp);
       }else if(prefix == "SUMCAL"){                  // calibrations
 	if((*iv)=="Gain1d" || (*iv)=="GainChi2NDF1d" || (*iv)=="GainChi2Prob1d" ||
@@ -461,40 +461,40 @@ void SiPixelActionExecutor::fillSummary(DQMStore* bei, string dir_name, vector<s
 	   (*iv)=="ScurveSigmasSummary" || (*iv)=="ScurveThresholdSummary"){                    
 	  tag = prefix + "_" + (*iv) + "_mean_" 
 	    + currDir.substr(currDir.find(dir_name));
-	  temp = getSummaryME(bei, tag, isUpgrade);
+	  temp = getSummaryME(bei, tag);
 	  sum_mes.push_back(temp);
 	  tag = prefix + "_" + (*iv) + "_RMS_" 
 	    + currDir.substr(currDir.find(dir_name));
-	  temp = getSummaryME(bei, tag, isUpgrade);
+	  temp = getSummaryME(bei, tag);
 	  sum_mes.push_back(temp);
 	}else if((*iv) == "SiPixelErrorsCalibDigis"){
 	  tag = prefix + "_" + (*iv) + "_NCalibErrors_"
 	    + currDir.substr(currDir.find(dir_name));
-	  temp = getSummaryME(bei, tag, isUpgrade);
+	  temp = getSummaryME(bei, tag);
 	  sum_mes.push_back(temp);
 	}else if((*iv)=="GainFitResult2d"){
 	  tag = prefix + "_" + (*iv) + "_NNegativeFits_"
 	    + currDir.substr(currDir.find(dir_name));
-	  temp = getSummaryME(bei, tag, isUpgrade);
+	  temp = getSummaryME(bei, tag);
 	  sum_mes.push_back(temp);
 	}else if((*iv)=="pixelAliveSummary"){
 	  tag = prefix + "_" + (*iv) + "_FracOfPerfectPix_"
 	    + currDir.substr(currDir.find(dir_name));
-	  temp = getSummaryME(bei, tag, isUpgrade);
+	  temp = getSummaryME(bei, tag);
 	  sum_mes.push_back(temp);
 	  tag = prefix + "_" + (*iv) + "_mean_"
 	    + currDir.substr(currDir.find(dir_name));
-	  temp = getSummaryME(bei, tag, isUpgrade);
+	  temp = getSummaryME(bei, tag);
 	  sum_mes.push_back(temp);
 	}
       }else{
 	tag = prefix + "_" + (*iv) + "_" + currDir.substr(currDir.find(dir_name));
-	temp = getSummaryME(bei, tag, isUpgrade);
+	temp = getSummaryME(bei, tag);
 	sum_mes.push_back(temp);
 	if((*iv)=="ndigis"){
 	  tag = prefix + "_" + (*iv) + "FREQ_" 
 	    + currDir.substr(currDir.find(dir_name));
-	  temp = getSummaryME(bei, tag, isUpgrade);
+	  temp = getSummaryME(bei, tag);
 	  sum_mes.push_back(temp);
 	}
 	if(prefix=="SUMDIG" && (*iv)=="adc"){
@@ -696,7 +696,7 @@ void SiPixelActionExecutor::fillSummary(DQMStore* bei, string dir_name, vector<s
 	  bei->cd(*it);
 	  if((*it).find("Endcap")!=string::npos ||
 	     (*it).find("AdditionalPixelErrors")!=string::npos) continue;
-	  fillSummary(bei, dir_name, me_names, true, isUpgrade); // Barrel
+	  fillSummary(bei, dir_name, me_names, true); // Barrel
 	  bei->goUp();
 	}
 	string grandbarrel_structure_name;
@@ -705,7 +705,7 @@ void SiPixelActionExecutor::fillSummary(DQMStore* bei, string dir_name, vector<s
 	  cout << "SiPixelActionExecutor::createSummary: Failed to read Grand Barrel Summary configuration parameters!! ";
 	  return;
 	}
-	fillGrandBarrelSummaryHistos(bei, grandbarrel_me_names, isUpgrade);
+	fillGrandBarrelSummaryHistos(bei, grandbarrel_me_names);
 			
       }
     else // Endcap
@@ -719,7 +719,7 @@ void SiPixelActionExecutor::fillSummary(DQMStore* bei, string dir_name, vector<s
 	  bei->cd((*it));
 	  if ((*it).find("Barrel")!=string::npos ||
 	      (*it).find("AdditionalPixelErrors")!=string::npos) continue;
-	  fillSummary(bei, dir_name, me_names, false, isUpgrade); // Endcap
+	  fillSummary(bei, dir_name, me_names, false); // Endcap
 	  bei->goUp();
 	}
 	string grandendcap_structure_name;
@@ -728,7 +728,7 @@ void SiPixelActionExecutor::fillSummary(DQMStore* bei, string dir_name, vector<s
 	  cout << "SiPixelActionExecutor::createSummary: Failed to read Grand Endcap Summary configuration parameters!! ";
 	  return;
 	}
-	fillGrandEndcapSummaryHistos(bei, grandendcap_me_names, isUpgrade);
+	fillGrandEndcapSummaryHistos(bei, grandendcap_me_names);
 			
 			
       }
@@ -916,8 +916,7 @@ void SiPixelActionExecutor::fillFEDErrorSummary(DQMStore* bei,
 
 //=============================================================================================================
 void SiPixelActionExecutor::fillGrandBarrelSummaryHistos(DQMStore* bei,
-                                                         vector<string>& me_names,
-                                                         bool isUpgrade) {
+                                                         vector<string>& me_names) {
 //  cout<<"Entering SiPixelActionExecutor::fillGrandBarrelSummaryHistos...:"<<me_names.size()<<endl;
   vector<MonitorElement*> gsum_mes;
   string currDir = bei->pwd();
@@ -1018,7 +1017,7 @@ void SiPixelActionExecutor::fillGrandBarrelSummaryHistos(DQMStore* bei,
 	  int wanted_size = me_names.size();
 	  // printing cout << actual_size << "\t" << wanted_size << endl;
 	  if (actual_size !=  wanted_size) { */
-	  if (first_subdir && !isUpgrade){
+	  if (first_subdir){
 //	    bool create_me = true;
 	    nbin = me->getTH1F()->GetNbinsX();        
 	    string me_name = prefix + "_" + (*iv) + "_" + dir_name;
@@ -1028,19 +1027,6 @@ void SiPixelActionExecutor::fillGrandBarrelSummaryHistos(DQMStore* bei,
 	    else if(dir_name=="Barrel") nbin=768;
 	    else if(prefix=="SUMOFF" && dir_name.find("Shell")!=string::npos) nbin=48;
 	    else if(dir_name.find("Shell")!=string::npos) nbin=192;
-	    else nbin=nbin*nDirs;
-
-		getGrandSummaryME(bei, nbin, me_name, gsum_mes);
-	  } else if (first_subdir && isUpgrade){
-//	    bool create_me = true;
-	    nbin = me->getTH1F()->GetNbinsX();        
-	    string me_name = prefix + "_" + (*iv) + "_" + dir_name;
-	    if((*iv)=="adcCOMB"||(*iv)=="chargeCOMB") me_name = "ALLMODS_" + (*iv) + "_" + dir_name;
-	    else if(prefix=="SUMOFF" && dir_name=="Barrel") nbin=296;
-	    else if((*iv)=="adcCOMB") nbin=256;
-	    else if(dir_name=="Barrel") nbin=1184;
-	    else if(prefix=="SUMOFF" && dir_name.find("Shell")!=string::npos) nbin=74;
-	    else if(dir_name.find("Shell")!=string::npos) nbin=296;
 	    else nbin=nbin*nDirs;
 
 		getGrandSummaryME(bei, nbin, me_name, gsum_mes);
@@ -1083,7 +1069,6 @@ void SiPixelActionExecutor::fillGrandBarrelSummaryHistos(DQMStore* bei,
 	      (*igm)->setAxisTitle(title,2);
 		  
 		  // Setting binning
-	      if (!isUpgrade) {
 	      if((*igm)->getName().find("ALLMODS_adcCOMB_")!=string::npos){
 		nbin_subdir=128;
 	      }else if((*igm)->getName().find("ALLMODS_chargeCOMB_")!=string::npos){
@@ -1114,43 +1099,6 @@ void SiPixelActionExecutor::fillGrandBarrelSummaryHistos(DQMStore* bei,
 		  else if(iDir==2){ nbin_i=96; nbin_subdir=48; }
 		  else if(iDir==3){ nbin_i=144; nbin_subdir=48; }
 		}
-	      }
-	      } else if (isUpgrade) {
-	        if((*igm)->getName().find("ALLMODS_adcCOMB_")!=string::npos){
-		  nbin_subdir=128;
-	        }else if((*igm)->getName().find("ALLMODS_chargeCOMB_")!=string::npos){
-		  nbin_subdir=100;
-	        }else if((*igm)->getName().find("Ladder") != string::npos){
-		  nbin_i=0; nbin_subdir=4;
-	        }else if((*igm)->getName().find("Layer") != string::npos){
-		  nbin_i=(cnt-1)*4; nbin_subdir=4;
-	        }else if((*igm)->getName().find("Shell") != string::npos){
-		  if(prefix!="SUMOFF"){
-		   if(iDir==0){ nbin_i=0; nbin_subdir=24; }//40(2*20)-->24(2*12)
-		    else if(iDir==1){ nbin_i=24; nbin_subdir=56; }//64(32*2)-->56(2*28)
-		    else if(iDir==2){ nbin_i=80; nbin_subdir=88; }//88(44*2)-->same88(44*2)
-		    else if(iDir==3){ nbin_i=168; nbin_subdir=128; }
-		  }else{
-		    if(iDir==0){ nbin_i=0; nbin_subdir=6; }//10-->6
-		    else if(iDir==1){ nbin_i=6; nbin_subdir=14; }//16-->14
-		    else if(iDir==2){ nbin_i=20; nbin_subdir=22; }//22-->same22
-		    else if(iDir==3){ nbin_i=42; nbin_subdir=32; }
-		  }
-	        }else if((*igm)->getName().find("Barrel") != string::npos){
-		  if(prefix!="SUMOFF"){
-		    if(iDir==0){ nbin_i=0; nbin_subdir=296; }//192=76 8/4-->296=1184/4
-		    else if(iDir==1){ nbin_i=296; nbin_subdir=296; }//296*2,*3,*4=1184
-		    else if(iDir==2){ nbin_i=592; nbin_subdir=296; }
-		    else if(iDir==3){ nbin_i=888; nbin_subdir=296; }
-		    else if(iDir==4){ nbin_i=1184; nbin_subdir=296; }
-		  }else{
-		    if(iDir==0){ nbin_i=0; nbin_subdir=74; }//48=192/4-->74=296/4
-		    else if(iDir==1){ nbin_i=74; nbin_subdir=74; }//74*2,...*4=296
-		    else if(iDir==2){ nbin_i=148; nbin_subdir=74; }
-		    else if(iDir==3){ nbin_i=222; nbin_subdir=74; }
-		    else if(iDir==4){ nbin_i=296; nbin_subdir=74; }
-		  }
-	        }
 	      }
 
 			if((*igm)->getName().find("ndigisFREQ")==string::npos)
@@ -1193,8 +1141,7 @@ void SiPixelActionExecutor::fillGrandBarrelSummaryHistos(DQMStore* bei,
 
 //=============================================================================================================
 void SiPixelActionExecutor::fillGrandEndcapSummaryHistos(DQMStore* bei,
-                                                         vector<string>& me_names,
-                                                         bool isUpgrade) {
+                                                         vector<string>& me_names) {
   //printing cout<<"Entering SiPixelActionExecutor::fillGrandEndcapSummaryHistos..."<<endl;
   vector<MonitorElement*> gsum_mes;
   string currDir = bei->pwd();
@@ -1285,7 +1232,7 @@ void SiPixelActionExecutor::fillGrandEndcapSummaryHistos(DQMStore* bei,
 	  int actual_size = gsum_mes.size();
 	  int wanted_size = me_names.size();
 	  if (actual_size !=  wanted_size) { */
-	  if (first_subdir && !isUpgrade){
+	  if (first_subdir){
 //	    bool create_me = true;
 	    nbin = me->getTH1F()->GetNbinsX();        
 	    string me_name = prefix + "_" + (*iv) + "_" + dir_name;
@@ -1301,19 +1248,7 @@ void SiPixelActionExecutor::fillGrandEndcapSummaryHistos(DQMStore* bei,
 	    //else if(dir_name.find("Panel_2")!=string::npos) nbin=3;
 		//cout << dir_name.c_str() << "\t" << nbin << endl;
 		getGrandSummaryME(bei, nbin, me_name, gsum_mes);
-	  } else if(first_subdir && isUpgrade){
-            nbin = me->getTH1F()->GetNbinsX();        
-	    string me_name = prefix + "_" + (*iv) + "_" + dir_name;
-	    if((*iv)=="adcCOMB"||(*iv)=="chargeCOMB") me_name = "ALLMODS_" + (*iv) + "_" + dir_name;
-	    else if(prefix=="SUMOFF" && dir_name=="Endcap") nbin=336;
-	    else if(dir_name=="Endcap") nbin=672;
-	    else if(prefix=="SUMOFF" && dir_name.find("HalfCylinder")!=string::npos) nbin=84;
-	    else if(dir_name.find("HalfCylinder")!=string::npos) nbin=168;
-	    else if(prefix=="SUMOFF" && dir_name.find("Disk")!=string::npos) nbin=28;
-	    else if(dir_name.find("Disk")!=string::npos) nbin=56;
-	    else if(dir_name.find("Blade")!=string::npos) nbin=2;
-            getGrandSummaryME(bei, nbin, me_name, gsum_mes);
-          }
+	  }
 	  /*
 
 	    for (vector<MonitorElement*>::const_iterator igm = gsum_mes.begin();
@@ -1345,7 +1280,6 @@ void SiPixelActionExecutor::fillGrandEndcapSummaryHistos(DQMStore* bei,
 	      else title = "mean " + (*iv) + " per Module"; 
 	      (*igm)->setAxisTitle(title,2);
 	      nbin_i=0; 
-	      if (!isUpgrade) {
 	      if((*igm)->getName().find("ALLMODS_adcCOMB_")!=string::npos){
 		nbin_subdir=128;
 	      }else if((*igm)->getName().find("ALLMODS_chargeCOMB_")!=string::npos){
@@ -1382,46 +1316,6 @@ void SiPixelActionExecutor::fillGrandEndcapSummaryHistos(DQMStore* bei,
 		  if((*im).find("_pO") != string::npos) nbin_i=72;
 		}
 	      }
-              } else if (isUpgrade) {
-                if((*igm)->getName().find("ALLMODS_adcCOMB_")!=string::npos){
-		  nbin_subdir=128;
-	        }else if((*igm)->getName().find("ALLMODS_chargeCOMB_")!=string::npos){
-		  nbin_subdir=100;
-	        }else if((*igm)->getName().find("Panel_") != string::npos){
-		  nbin_subdir=2;
-		  //	        }else if((*igm)->getName().find("Panel_1") != string::npos){
-		  //		  nbin_subdir=4;
-		  //	        }else if((*igm)->getName().find("Panel_2") != string::npos){
-		  //		  nbin_subdir=3;
-	        }else if((*igm)->getName().find("Blade") != string::npos){
-		  if((*im).find("_1") != string::npos) nbin_subdir=1;
-		  if((*im).find("_2") != string::npos) {nbin_i=1; nbin_subdir=1;}
-	        }else if((*igm)->getName().find("Disk") != string::npos){
-		  nbin_i=((cnt-1)%28)*2; nbin_subdir=2;
-	        }else if((*igm)->getName().find("HalfCylinder") != string::npos){
-		  if(prefix!="SUMOFF"){
-		    nbin_subdir=56;
-		    if((*im).find("_2") != string::npos) nbin_i=56;
-                    if((*im).find("_3") != string::npos) nbin_i=112;
-		  }else{
-		    nbin_subdir=28;
-		    if((*im).find("_2") != string::npos) nbin_i=28;
-                    if((*im).find("_3") != string::npos) nbin_i=56;
-		  }
-	        }else if((*igm)->getName().find("Endcap") != string::npos){
-		  if(prefix!="SUMOFF"){
-		    nbin_subdir=168;
-		    if((*im).find("_mO") != string::npos) nbin_i=168;
-		    if((*im).find("_pI") != string::npos) nbin_i=336;
-		    if((*im).find("_pO") != string::npos) nbin_i=504;
-		  }else{
-		    nbin_subdir=84;
-		    if((*im).find("_mO") != string::npos) nbin_i=84;
-		    if((*im).find("_pI") != string::npos) nbin_i=168;
-		    if((*im).find("_pO") != string::npos) nbin_i=252;
-		  }
-	        }
-              }
 							
 	      //	       for (int k = 1; k < nbin_subdir+1; k++) {
 	      if((*igm)->getName().find("ndigisFREQ")==string::npos){ 
@@ -1505,8 +1399,7 @@ void SiPixelActionExecutor::getGrandSummaryME(DQMStore* bei,
 // -- Get Summary ME
 //
 MonitorElement* SiPixelActionExecutor::getSummaryME(DQMStore* bei,
-                                                    string me_name,
-                                                    bool isUpgrade) {
+                                                    string me_name) {
   //printing cout<<"Entering SiPixelActionExecutor::getSummaryME for: "<<me_name<<endl;
   MonitorElement* me = 0;
   if((bei->pwd()).find("Pixel")==string::npos) return me;
@@ -1534,7 +1427,6 @@ MonitorElement* SiPixelActionExecutor::getSummaryME(DQMStore* bei,
 //		<< "\t" << ((me_name.find("Layer3_")!=string::npos)?"true":"false")
 //		<< "\t" << ((me_name.find("Disk_")!=string::npos)?"true":"false")
 //		<< endl;
-  if (!isUpgrade) {
   if(me_name.find("SUMOFF")==string::npos){
   	if(me_name.find("Blade_")!=string::npos)me = bei->book1D(me_name.c_str(), me_name.c_str(),7,1.,8.);
 	else me = bei->book1D(me_name.c_str(), me_name.c_str(),4,1.,5.);
@@ -1545,20 +1437,7 @@ MonitorElement* SiPixelActionExecutor::getSummaryME(DQMStore* bei,
   }else if(me_name.find("Layer_3")!=string::npos){ me = bei->book1D(me_name.c_str(), me_name.c_str(),22,1.,23.);
   }else if(me_name.find("Disk_")!=string::npos){ me = bei->book1D(me_name.c_str(), me_name.c_str(),12,1.,13.);
   }
-  }//endifNOTUpgrade
-  else if (isUpgrade) {
-    if(me_name.find("SUMOFF")==string::npos){
-      if(me_name.find("Blade_")!=string::npos)me = bei->book1D(me_name.c_str(), me_name.c_str(),2,1.,3.);
-      else me = bei->book1D(me_name.c_str(), me_name.c_str(),1,1.,2.);
-      //      if(me_name.find("Panel_2")!=string::npos)  me = bei->book1D(me_name.c_str(), me_name.c_str(),3,1.,4.);
-      //      else me = bei->book1D(me_name.c_str(), me_name.c_str(),4,1.,5.);
-    }else if(me_name.find("Layer_1")!=string::npos){ me = bei->book1D(me_name.c_str(), me_name.c_str(),6,1.,7.);
-    }else if(me_name.find("Layer_2")!=string::npos){ me = bei->book1D(me_name.c_str(), me_name.c_str(),14,1.,15.);
-    }else if(me_name.find("Layer_3")!=string::npos){ me = bei->book1D(me_name.c_str(), me_name.c_str(),22,1.,23.);
-    }else if(me_name.find("Layer_4")!=string::npos){ me = bei->book1D(me_name.c_str(), me_name.c_str(),32,1.,33.);
-    }else if(me_name.find("Disk_")!=string::npos){ me = bei->book1D(me_name.c_str(), me_name.c_str(),28,1.,29.);
-    }
-  }//endifUpgrade
+
   
 	
   //  if(me) cout<<"Finally got this ME: "<<me_name<<endl;
@@ -2392,11 +2271,10 @@ void SiPixelActionExecutor::dumpEndcapRefValues(DQMStore * bei, edm::EventSetup 
 
 //=============================================================================================================
 
-void SiPixelActionExecutor::bookEfficiency(DQMStore * bei, bool isUpgrade){
+void SiPixelActionExecutor::bookEfficiency(DQMStore * bei){
   // Barrel
   bei->cd();
   bei->setCurrentFolder("Pixel/Barrel");
-  if (!isUpgrade) {
   if(Tier0Flag_){
     HitEfficiency_L1 = bei->book2D("HitEfficiency_L1","Hit Efficiency in Barrel_Layer1;Module;Ladder",8,-4,4,20,-10.,10.);
     HitEfficiency_L2 = bei->book2D("HitEfficiency_L2","Hit Efficiency in Barrel_Layer2;Module;Ladder",8,-4,4,32,-16.,16.);
@@ -2406,24 +2284,10 @@ void SiPixelActionExecutor::bookEfficiency(DQMStore * bei, bool isUpgrade){
     HitEfficiency_L2 = bei->book2D("HitEfficiency_L2","Hit Efficiency in Barrel_Layer2;Module;Ladder",8,-4.,4.,32,-16.,16.);
     HitEfficiency_L3 = bei->book2D("HitEfficiency_L3","Hit Efficiency in Barrel_Layer3;Module;Ladder",8,-4.,4.,44,-22.,22.);
   }
-  }//endifNOTUpgrade
-  else if (isUpgrade) {
-      if(Tier0Flag_){
-      HitEfficiency_L1 = bei->book2D("HitEfficiency_L1","Hit Efficiency in Barrel_Layer1;z-side;Ladder",2,-1.,1.,12,-6.,6.);
-      HitEfficiency_L2 = bei->book2D("HitEfficiency_L2","Hit Efficiency in Barrel_Layer2;z-side;Ladder",2,-1.,1.,28,-14.,14.);
-      HitEfficiency_L3 = bei->book2D("HitEfficiency_L3","Hit Efficiency in Barrel_Layer3;z-side;Ladder",2,-1.,1.,44,-22.,22.);
-      HitEfficiency_L4 = bei->book2D("HitEfficiency_L4","Hit Efficiency in Barrel_Layer4;z-side;Ladder",2,-1.,1.,64,-32.,32.);
-    }else{
-      HitEfficiency_L1 = bei->book2D("HitEfficiency_L1","Hit Efficiency in Barrel_Layer1;Module;Ladder",8,-4.,4.,12,-6.,6.);
-      HitEfficiency_L2 = bei->book2D("HitEfficiency_L2","Hit Efficiency in Barrel_Layer2;Module;Ladder",8,-4.,4.,28,-14.,14.);
-      HitEfficiency_L3 = bei->book2D("HitEfficiency_L3","Hit Efficiency in Barrel_Layer3;Module;Ladder",8,-4.,4.,44,-22.,22.);
-      HitEfficiency_L4 = bei->book2D("HitEfficiency_L4","Hit Efficiency in Barrel_Layer4;Module;Ladder",8,-4.,4.,64,-32.,32.);
-    }
-  }//endifUpgrade
+
   // Endcap
   bei->cd();
   bei->setCurrentFolder("Pixel/Endcap");
-  if (!isUpgrade) {
   if(Tier0Flag_){
     HitEfficiency_Dp1 = bei->book2D("HitEfficiency_Dp1","Hit Efficiency in Endcap_Disk_p1;Blades;",24,-12.,12.,1,0.,1.);
     HitEfficiency_Dp2 = bei->book2D("HitEfficiency_Dp2","Hit Efficiency in Endcap_Disk_p2;Blades;",24,-12.,12.,1,0.,1.);
@@ -2435,40 +2299,23 @@ void SiPixelActionExecutor::bookEfficiency(DQMStore * bei, bool isUpgrade){
     HitEfficiency_Dm1 = bei->book2D("HitEfficiency_Dm1","Hit Efficiency in Endcap_Disk_m1;Blades;Modules",24,-12.,12.,7,1.,8.);
     HitEfficiency_Dm2 = bei->book2D("HitEfficiency_Dm2","Hit Efficiency in Endcap_Disk_m2;Blades;Modules",24,-12.,12.,7,1.,8.);
   }
-  } else if (isUpgrade) {
-    if(Tier0Flag_){
-      HitEfficiency_Dp1 = bei->book2D("HitEfficiency_Dp1","Hit Efficiency in Endcap_Disk_p1;Blades;",28,-17.,11.,1,0.,1.);
-      HitEfficiency_Dp2 = bei->book2D("HitEfficiency_Dp2","Hit Efficiency in Endcap_Disk_p2;Blades;",28,-17.,11.,1,0.,1.);
-      HitEfficiency_Dp3 = bei->book2D("HitEfficiency_Dp3","Hit Efficiency in Endcap_Disk_p3;Blades;",28,-17.,11.,1,0.,1.);
-      HitEfficiency_Dm1 = bei->book2D("HitEfficiency_Dm1","Hit Efficiency in Endcap_Disk_m1;Blades;",28,-17.,11.,1,0.,1.);
-      HitEfficiency_Dm2 = bei->book2D("HitEfficiency_Dm2","Hit Efficiency in Endcap_Disk_m2;Blades;",28,-17.,11.,1,0.,1.);
-      HitEfficiency_Dm3 = bei->book2D("HitEfficiency_Dm3","Hit Efficiency in Endcap_Disk_m3;Blades;",28,-17.,11.,1,0.,1.);
-    }else{
-      HitEfficiency_Dp1 = bei->book2D("HitEfficiency_Dp1","Hit Efficiency in Endcap_Disk_p1;Blades;Modules",28,-17.,11.,2,1.,3.);
-      HitEfficiency_Dp2 = bei->book2D("HitEfficiency_Dp2","Hit Efficiency in Endcap_Disk_p2;Blades;Modules",28,-17.,11.,2,1.,3.);
-      HitEfficiency_Dp3 = bei->book2D("HitEfficiency_Dp3","Hit Efficiency in Endcap_Disk_p3;Blades;Modules",28,-17.,11.,2,1.,3.);
-      HitEfficiency_Dm1 = bei->book2D("HitEfficiency_Dm1","Hit Efficiency in Endcap_Disk_m1;Blades;Modules",28,-17.,11.,2,1.,3.);
-      HitEfficiency_Dm2 = bei->book2D("HitEfficiency_Dm2","Hit Efficiency in Endcap_Disk_m2;Blades;Modules",28,-17.,11.,2,1.,3.);
-      HitEfficiency_Dm3 = bei->book2D("HitEfficiency_Dm3","Hit Efficiency in Endcap_Disk_m3;Blades;Modules",28,-17.,11.,2,1.,3.);
-    }
-  }//endif(isUpgrade)
 }
 
 //=============================================================================================================
 
-void SiPixelActionExecutor::createEfficiency(DQMStore * bei, bool isUpgrade){
+void SiPixelActionExecutor::createEfficiency(DQMStore * bei){
   //std::cout<<"entering SiPixelActionExecutor::createEfficiency..."<<std::endl;
   bei->cd();
-  fillEfficiency(bei, true, isUpgrade); // Barrel
+  fillEfficiency(bei, true); // Barrel
   bei->cd();
-  fillEfficiency(bei, false, isUpgrade); // Endcap
+  fillEfficiency(bei, false); // Endcap
   bei->cd();
   //std::cout<<"leaving SiPixelActionExecutor::createEfficiency..."<<std::endl;
 }
 
 //=============================================================================================================
 
-void SiPixelActionExecutor::fillEfficiency(DQMStore* bei, bool isbarrel, bool isUpgrade){
+void SiPixelActionExecutor::fillEfficiency(DQMStore* bei, bool isbarrel){
   //cout<<"entering SiPixelActionExecutor::fillEfficiency..."<<std::endl;
   string currDir = bei->pwd();
   string dname = currDir.substr(currDir.find_last_of("/")+1);
@@ -2476,7 +2323,6 @@ void SiPixelActionExecutor::fillEfficiency(DQMStore* bei, bool isbarrel, bool is
   
   if(Tier0Flag_){ // Offline	
     if(isbarrel && dname.find("Ladder_")!=string::npos){ 
-      if (!isUpgrade) {
       vector<string> meVec = bei->getMEs();
       for (vector<string>::const_iterator it = meVec.begin(); it != meVec.end(); it++) {
         string full_path = currDir + "/" + (*it);
@@ -2512,9 +2358,7 @@ void SiPixelActionExecutor::fillEfficiency(DQMStore* bei, bool isbarrel, bool is
 	    else if(currDir.find("Layer_3")!=string::npos){ biny = biny + 22;}
 	    
 	  }
-	  
-	  
-	  
+	  	  
 	  int start=1;
 	  //define start depending on p or m
 	  
@@ -2543,67 +2387,7 @@ void SiPixelActionExecutor::fillEfficiency(DQMStore* bei, bool isbarrel, bool is
 	  
 	}
       }
-      }//endifNOTUpgradeInBPix
-      else if (isUpgrade) {
-        vector<string> meVec = bei->getMEs();
-        for (vector<string>::const_iterator it = meVec.begin(); it != meVec.end(); it++) {
-          string full_path = currDir + "/" + (*it);
-          if(full_path.find("missing_")!=string::npos){ // If we have missing hits ME
-	    MonitorElement * me = bei->get(full_path);
-	    if (!me) continue;
-	    float missingHits = me->getEntries();
-	    //if(currDir.find("Barrel/Shell_mI/Layer_1/Ladder_09F")!=string::npos) cout<<"missingHits= "<<missingHits<<endl;
-	    string new_path = full_path.replace(full_path.find("missing"),7,"valid");
-	    me = bei->get(new_path);
-	    if (!me) continue;
-	    float validHits = me->getEntries();
-	    //if(currDir.find("Barrel/Shell_mI/Layer_1/Ladder_09F")!=string::npos) cout<<"validHits= "<<validHits<<endl;
-	    float hitEfficiency = -1.;
-	    if(validHits + missingHits > 0.) hitEfficiency = validHits / (validHits + missingHits);
-	    //if(currDir.find("Barrel/Shell_mI/Layer_1/Ladder_09F")!=string::npos) cout<<"hitEfficiency= "<<hitEfficiency<<endl;
-	    int binx = 0; int biny = 0;
-	    if(currDir.find("Shell_m")!=string::npos){ binx = 1;}else{ binx = 2;}
-	    if(dname.find("01")!=string::npos){ biny = 1;}else if(dname.find("02")!=string::npos){ biny = 2;}
-	    else if(dname.find("03")!=string::npos){ biny = 3;}else if(dname.find("04")!=string::npos){ biny = 4;}
-	    else if(dname.find("05")!=string::npos){ biny = 5;}else if(dname.find("06")!=string::npos){ biny = 6;}
-	    else if(dname.find("07")!=string::npos){ biny = 7;}else if(dname.find("08")!=string::npos){ biny = 8;}
-	    else if(dname.find("09")!=string::npos){ biny = 9;}else if(dname.find("10")!=string::npos){ biny = 10;}
-	    else if(dname.find("11")!=string::npos){ biny = 11;}else if(dname.find("12")!=string::npos){ biny = 12;}
-	    else if(dname.find("13")!=string::npos){ biny = 13;}else if(dname.find("14")!=string::npos){ biny = 14;}
-	    else if(dname.find("15")!=string::npos){ biny = 15;}else if(dname.find("16")!=string::npos){ biny = 16;}
-	    else if(dname.find("17")!=string::npos){ biny = 17;}else if(dname.find("18")!=string::npos){ biny = 18;}
-	    else if(dname.find("19")!=string::npos){ biny = 19;}else if(dname.find("20")!=string::npos){ biny = 20;}
-	    else if(dname.find("21")!=string::npos){ biny = 21;}else if(dname.find("22")!=string::npos){ biny = 22;}
-	    else if(dname.find("23")!=string::npos){ biny = 23;}else if(dname.find("24")!=string::npos){ biny = 24;}
-	    else if(dname.find("25")!=string::npos){ biny = 25;}else if(dname.find("25")!=string::npos){ biny = 25;}
-	    else if(dname.find("26")!=string::npos){ biny = 26;}else if(dname.find("27")!=string::npos){ biny = 27;}
-	    else if(dname.find("28")!=string::npos){ biny = 28;}else if(dname.find("29")!=string::npos){ biny = 29;}
-	    else if(dname.find("30")!=string::npos){ biny = 30;}else if(dname.find("31")!=string::npos){ biny = 31;}
-	    else if(dname.find("32")!=string::npos){ biny = 32;}
-	    if(currDir.find("Shell_mO")!=string::npos || currDir.find("Shell_pO")!=string::npos){
-	      if(currDir.find("Layer_1")!=string::npos){ biny = biny + 6;}
-	      else if(currDir.find("Layer_2")!=string::npos){ biny = biny + 14;}
-	      else if(currDir.find("Layer_3")!=string::npos){ biny = biny + 22;}
-	      else if(currDir.find("Layer_4")!=string::npos){ biny = biny + 32;}
-	    }
-	    if(currDir.find("Layer_1")!=string::npos){
-	      HitEfficiency_L1 = bei->get("Pixel/Barrel/HitEfficiency_L1");
-	      if(HitEfficiency_L1) HitEfficiency_L1->setBinContent(binx, biny,(float)hitEfficiency);
-	      //if(currDir.find("Barrel/Shell_mI/Layer_1/Ladder_09F")!=string::npos) cout<<"setting bin ("<<binx<<","<<biny<<") with "<<(float)hitEfficiency<<endl;
-	    }else if(currDir.find("Layer_2")!=string::npos){
-	      HitEfficiency_L2 = bei->get("Pixel/Barrel/HitEfficiency_L2");
-	      if(HitEfficiency_L2) HitEfficiency_L2->setBinContent(binx, biny,(float)hitEfficiency);
-	    }else if(currDir.find("Layer_3")!=string::npos){
-	      HitEfficiency_L3 = bei->get("Pixel/Barrel/HitEfficiency_L3");
-	      if(HitEfficiency_L3) HitEfficiency_L3->setBinContent(binx, biny,(float)hitEfficiency);
-	    }else if(currDir.find("Layer_4")!=string::npos){
-	      HitEfficiency_L4 = bei->get("Pixel/Barrel/HitEfficiency_L4");
-	      if(HitEfficiency_L4) HitEfficiency_L4->setBinContent(binx, biny,(float)hitEfficiency);
-	    }
-          }
-        }
-      }//endifUpgradeInBPix
-    }else if(!isbarrel && dname.find("Blade_")!=string::npos && !isUpgrade){ 
+    }else if(!isbarrel && dname.find("Blade_")!=string::npos){ 
       vector<string> meVec = bei->getMEs();
       for (vector<string>::const_iterator it = meVec.begin(); it != meVec.end(); it++) {
         string full_path = currDir + "/" + (*it);
@@ -2654,73 +2438,7 @@ void SiPixelActionExecutor::fillEfficiency(DQMStore* bei, bool isbarrel, bool is
           }
 	  //std::cout<<"EFFI: "<<currDir<<" , x: "<<binx<<" , y: "<<biny<<std::endl;
 	}
-      } 
-    }else if(!isbarrel && dname.find("Blade_")!=string::npos && isUpgrade){ 
-      vector<string> meVec = bei->getMEs();
-      for (vector<string>::const_iterator it = meVec.begin(); it != meVec.end(); it++) {
-        string full_path = currDir + "/" + (*it);
-        if(full_path.find("missing_")!=string::npos){ // If we have missing hits ME
-	  MonitorElement * me = bei->get(full_path);
-	  if (!me) continue;
-	  float missingHits = me->getEntries();
-	  string new_path = full_path.replace(full_path.find("missing"),7,"valid");
-	  me = bei->get(new_path);
-	  if (!me) continue;
-	  float validHits = me->getEntries();
-	  float hitEfficiency = -1.;
-	  if(validHits + missingHits > 0.) hitEfficiency = validHits / (validHits + missingHits);
-	  int binx = 0; int biny = 1;
-	  if(currDir.find("01")!=string::npos){ binx = 1;}else if(currDir.find("02")!=string::npos){ binx = 2;}
-	  else if(currDir.find("03")!=string::npos){ binx = 3;}else if(currDir.find("04")!=string::npos){ binx = 4;}
-	  else if(currDir.find("05")!=string::npos){ binx = 5;}else if(currDir.find("06")!=string::npos){ binx = 6;}
-	  else if(currDir.find("07")!=string::npos){ binx = 7;}else if(currDir.find("08")!=string::npos){ binx = 8;}
-	  else if(currDir.find("09")!=string::npos){ binx = 9;}else if(currDir.find("10")!=string::npos){ binx = 10;}
-	  else if(currDir.find("11")!=string::npos){ binx = 11;}else if(currDir.find("12")!=string::npos){ binx = 12;}
-          else if(currDir.find("13")!=string::npos){ binx = 13;}else if(currDir.find("14")!=string::npos){ binx = 14;}
-          else if(currDir.find("15")!=string::npos){ binx = 15;}else if(currDir.find("16")!=string::npos){ binx = 16;}
-          else if(currDir.find("17")!=string::npos){ binx = 17;}
-	  if(currDir.find("HalfCylinder_mI")!=string::npos || currDir.find("HalfCylinder_pI")!=string::npos){ binx = binx + 12;}
-	  else{ 
-	    if(binx==1) binx = 17;
-	    else if(binx==2) binx = 16;
-	    else if(binx==3) binx = 15;
-	    else if(binx==4) binx = 14;
-	    else if(binx==5) binx = 13;
-	    else if(binx==6) binx = 12;
-	    else if(binx==7) binx = 11;
-	    else if(binx==8) binx = 10;
-	    else if(binx==9) binx = 9;
-	    else if(binx==10) binx = 8;
-	    else if(binx==11) binx = 7;
-	    else if(binx==12) binx = 6;
-            else if(binx==13) binx = 5;
-	    else if(binx==14) binx = 4;
-	    else if(binx==15) binx = 3;
-	    else if(binx==16) binx = 2;
-	    else if(binx==17) binx = 1;
-	  }
-	  if(currDir.find("Disk_1")!=string::npos && currDir.find("HalfCylinder_m")!=string::npos){
-	    HitEfficiency_Dm1 = bei->get("Pixel/Endcap/HitEfficiency_Dm1");
-	    if(HitEfficiency_Dm1) HitEfficiency_Dm1->setBinContent(binx, biny, (float)hitEfficiency);
-	  }else if(currDir.find("Disk_2")!=string::npos && currDir.find("HalfCylinder_m")!=string::npos){
-	    HitEfficiency_Dm2 = bei->get("Pixel/Endcap/HitEfficiency_Dm2");
-	    if(HitEfficiency_Dm2) HitEfficiency_Dm2->setBinContent(binx, biny, (float)hitEfficiency);
-	  }else if(currDir.find("Disk_3")!=string::npos && currDir.find("HalfCylinder_m")!=string::npos){
-	    HitEfficiency_Dm3 = bei->get("Pixel/Endcap/HitEfficiency_Dm3");
-	    if(HitEfficiency_Dm3) HitEfficiency_Dm3->setBinContent(binx, biny, (float)hitEfficiency);
-	  }else if(currDir.find("Disk_1")!=string::npos && currDir.find("HalfCylinder_p")!=string::npos){
-	    HitEfficiency_Dp1 = bei->get("Pixel/Endcap/HitEfficiency_Dp1");
-	    if(HitEfficiency_Dp1) HitEfficiency_Dp1->setBinContent(binx, biny, (float)hitEfficiency);
-	  }else if(currDir.find("Disk_2")!=string::npos && currDir.find("HalfCylinder_p")!=string::npos){
-	    HitEfficiency_Dp2 = bei->get("Pixel/Endcap/HitEfficiency_Dp2");
-	    if(HitEfficiency_Dp2) HitEfficiency_Dp2->setBinContent(binx, biny, (float)hitEfficiency);
-          }else if(currDir.find("Disk_3")!=string::npos && currDir.find("HalfCylinder_p")!=string::npos){
-	    HitEfficiency_Dp3 = bei->get("Pixel/Endcap/HitEfficiency_Dp3");
-	    if(HitEfficiency_Dp3) HitEfficiency_Dp3->setBinContent(binx, biny, (float)hitEfficiency);
-          }
-	  //std::cout<<"EFFI: "<<currDir<<" , x: "<<binx<<" , y: "<<biny<<std::endl;
-	}
-      } 
+      }
     }else{  
       //cout<<"finding subdirs now"<<std::endl;
       vector<string> subdirs = bei->getSubdirs();
@@ -2729,7 +2447,7 @@ void SiPixelActionExecutor::fillEfficiency(DQMStore* bei, bool isbarrel, bool is
         //cout<<"now I am in "<<bei->pwd()<<std::endl;
         if(*it != "Pixel" && ((isbarrel && (*it).find("Barrel")==string::npos) || (!isbarrel && (*it).find("Endcap")==string::npos))) continue;
         //cout<<"calling myself again "<<std::endl;
-        fillEfficiency(bei, isbarrel, isUpgrade);
+        fillEfficiency(bei, isbarrel);
         bei->goUp();
       }
     }
@@ -2757,7 +2475,6 @@ void SiPixelActionExecutor::fillEfficiency(DQMStore* bei, bool isbarrel, bool is
 	      if(currDir.find("Module_1")!=string::npos){ binx = 5;}else if(currDir.find("Module_2")!=string::npos){ binx = 6;}
 	      if(currDir.find("Module_3")!=string::npos){ binx = 7;}else if(currDir.find("Module_4")!=string::npos){ binx = 8;}
 	    }
-	    if (!isUpgrade) {
 	    if(currDir.find("01")!=string::npos){ biny = 1;}else if(currDir.find("02")!=string::npos){ biny = 2;}
 	    else if(currDir.find("03")!=string::npos){ biny = 3;}else if(currDir.find("04")!=string::npos){ biny = 4;}
 	    else if(currDir.find("05")!=string::npos){ biny = 5;}else if(currDir.find("06")!=string::npos){ biny = 6;}
@@ -2774,34 +2491,7 @@ void SiPixelActionExecutor::fillEfficiency(DQMStore* bei, bool isbarrel, bool is
 	      else if(currDir.find("Layer_2")!=string::npos){ biny = biny + 16;}
 	      else if(currDir.find("Layer_3")!=string::npos){ biny = biny + 22;}
 	    }
-	    }
-	    else if (isUpgrade) {
-	      if(currDir.find("01")!=string::npos){ biny = 1;}else if(currDir.find("02")!=string::npos){ biny = 2;}
-	      else if(currDir.find("03")!=string::npos){ biny = 3;}else if(currDir.find("04")!=string::npos){ biny = 4;}
-	      else if(currDir.find("05")!=string::npos){ biny = 5;}else if(currDir.find("06")!=string::npos){ biny = 6;}
-	      else if(currDir.find("07")!=string::npos){ biny = 7;}else if(currDir.find("08")!=string::npos){ biny = 8;}
-	      else if(currDir.find("09")!=string::npos){ biny = 9;}else if(currDir.find("10")!=string::npos){ biny = 10;}
-	      else if(currDir.find("11")!=string::npos){ biny = 11;}else if(currDir.find("12")!=string::npos){ biny = 12;}
-	      else if(currDir.find("13")!=string::npos){ biny = 13;}else if(currDir.find("14")!=string::npos){ biny = 14;}
-	      else if(currDir.find("15")!=string::npos){ biny = 15;}else if(currDir.find("16")!=string::npos){ biny = 16;}
-	      else if(currDir.find("17")!=string::npos){ biny = 17;}else if(currDir.find("18")!=string::npos){ biny = 18;}
-	      else if(currDir.find("19")!=string::npos){ biny = 19;}else if(currDir.find("20")!=string::npos){ biny = 20;}
-	      else if(currDir.find("21")!=string::npos){ biny = 21;}else if(currDir.find("22")!=string::npos){ biny = 22;}
-	      else if(currDir.find("23")!=string::npos){ biny = 23;}else if(currDir.find("24")!=string::npos){ biny = 24;}
-	      else if(currDir.find("25")!=string::npos){ biny = 25;}else if(currDir.find("25")!=string::npos){ biny = 25;}
-	      else if(currDir.find("26")!=string::npos){ biny = 26;}else if(currDir.find("27")!=string::npos){ biny = 27;}
-	      else if(currDir.find("28")!=string::npos){ biny = 28;}else if(currDir.find("29")!=string::npos){ biny = 29;}
-	      else if(currDir.find("30")!=string::npos){ biny = 30;}else if(currDir.find("31")!=string::npos){ biny = 31;}
-	      else if(currDir.find("32")!=string::npos){ biny = 32;}
-	      if(currDir.find("Shell_mO")!=string::npos || currDir.find("Shell_pO")!=string::npos){
-	        if(currDir.find("Layer_1")!=string::npos){ biny = biny + 6;}
-	        else if(currDir.find("Layer_2")!=string::npos){ biny = biny + 14;}
-	        else if(currDir.find("Layer_3")!=string::npos){ biny = biny + 22;}
-	        else if(currDir.find("Layer_4")!=string::npos){ biny = biny + 32;}
-	      }
-	    }
 	  }else{ //endcap
-	    if (!isUpgrade) {
 	    if(currDir.find("01")!=string::npos){ binx = 1;}else if(currDir.find("02")!=string::npos){ binx = 2;}
 	    else if(currDir.find("03")!=string::npos){ binx = 3;}else if(currDir.find("04")!=string::npos){ binx = 4;}
 	    else if(currDir.find("05")!=string::npos){ binx = 5;}else if(currDir.find("06")!=string::npos){ binx = 6;}
@@ -2813,19 +2503,6 @@ void SiPixelActionExecutor::fillEfficiency(DQMStore* bei, bool isbarrel, bool is
 	    else if(currDir.find("Panel_1/Module_2")!=string::npos){ biny = 3;}else if(currDir.find("Panel_2/Module_2")!=string::npos){ biny = 4;}
 	    else if(currDir.find("Panel_1/Module_3")!=string::npos){ biny = 5;}else if(currDir.find("Panel_2/Module_3")!=string::npos){ biny = 6;}
 	    else if(currDir.find("Panel_1/Module_4")!=string::npos){ biny = 7;}
-	    } else if (isUpgrade) {
-	      if(currDir.find("01")!=string::npos){ binx = 1;}else if(currDir.find("02")!=string::npos){ binx = 2;}
-	      else if(currDir.find("03")!=string::npos){ binx = 3;}else if(currDir.find("04")!=string::npos){ binx = 4;}
-	      else if(currDir.find("05")!=string::npos){ binx = 5;}else if(currDir.find("06")!=string::npos){ binx = 6;}
-	      else if(currDir.find("07")!=string::npos){ binx = 7;}else if(currDir.find("08")!=string::npos){ binx = 8;}
-	      else if(currDir.find("09")!=string::npos){ binx = 9;}else if(currDir.find("10")!=string::npos){ binx = 10;}
-	      else if(currDir.find("11")!=string::npos){ binx = 11;}else if(currDir.find("12")!=string::npos){ binx = 12;}
-	      else if(currDir.find("13")!=string::npos){ binx = 13;}else if(currDir.find("14")!=string::npos){ binx = 14;}
-	      else if(currDir.find("15")!=string::npos){ binx = 15;}else if(currDir.find("16")!=string::npos){ binx = 16;}
-	      else if(currDir.find("17")!=string::npos){ binx = 17;}
-	      if(currDir.find("HalfCylinder_mO")!=string::npos || currDir.find("HalfCylinder_pO")!=string::npos){ binx = binx + 17;}
-	      if(currDir.find("Panel_1/Module_1")!=string::npos){ biny = 1;}else if(currDir.find("Panel_2/Module_1")!=string::npos){ biny = 2;}
-	    }//endif(isUpgrade)
 	  }
 	  
 	  if(currDir.find("Layer_1")!=string::npos){
@@ -2837,9 +2514,6 @@ void SiPixelActionExecutor::fillEfficiency(DQMStore* bei, bool isbarrel, bool is
 	  }else if(currDir.find("Layer_3")!=string::npos){
 	    HitEfficiency_L3 = bei->get("Pixel/Barrel/HitEfficiency_L3");
 	    if(HitEfficiency_L3) HitEfficiency_L3->setBinContent(binx, biny,(float)hitEfficiency);
-	  }else if( isUpgrade && (currDir.find("Layer_4")!=string::npos) ){
-	    HitEfficiency_L4 = bei->get("Pixel/Barrel/HitEfficiency_L4");
-	    if(HitEfficiency_L4) HitEfficiency_L4->setBinContent(binx, biny,(float)hitEfficiency);
 	  }else if(currDir.find("Disk_1")!=string::npos && currDir.find("HalfCylinder_m")!=string::npos){
 	    HitEfficiency_Dm1 = bei->get("Pixel/Endcap/HitEfficiency_Dm1");
 	    if(HitEfficiency_Dm1) HitEfficiency_Dm1->setBinContent(binx, biny,(float)hitEfficiency);
@@ -2869,7 +2543,7 @@ void SiPixelActionExecutor::fillEfficiency(DQMStore* bei, bool isbarrel, bool is
         //cout<<"now I am in "<<bei->pwd()<<std::endl;
         if(*it != "Pixel" && ((isbarrel && (*it).find("Barrel")==string::npos) || (!isbarrel && (*it).find("Endcap")==string::npos))) continue;
         //cout<<"calling myself again "<<std::endl;
-        fillEfficiency(bei, isbarrel, isUpgrade);
+        fillEfficiency(bei, isbarrel);
         bei->goUp();
       }
     }

--- a/DQM/SiPixelMonitorClient/src/SiPixelActionExecutorPhase1.cc
+++ b/DQM/SiPixelMonitorClient/src/SiPixelActionExecutorPhase1.cc
@@ -1,0 +1,2580 @@
+#define printing false
+//#define occupancyprinting false
+
+#include "DQM/SiPixelMonitorClient/interface/SiPixelActionExecutorPhase1.h"
+#include "DQM/SiPixelMonitorClient/interface/SiPixelUtility.h"
+#include "DQM/SiPixelMonitorClient/interface/SiPixelInformationExtractorPhase1.h"
+#include "DQM/SiPixelMonitorClient/interface/SiPixelTrackerMapCreator.h"
+#include "DQM/SiPixelMonitorClient/interface/ANSIColors.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+#include "DQM/SiPixelCommon/interface/SiPixelFolderOrganizer.h"
+#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/GeometrySurface/interface/Surface.h"
+#include "DataFormats/SiPixelDetId/interface/PixelBarrelName.h"
+#include "DataFormats/SiPixelDetId/interface/PixelBarrelNameUpgrade.h"
+#include "DataFormats/SiPixelDetId/interface/PixelEndcapName.h"
+#include "DataFormats/SiPixelDetId/interface/PixelEndcapNameUpgrade.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+#include "CondFormats/SiPixelObjects/interface/DetectorIndex.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelFrameConverter.h"
+#include "Geometry/TrackerNumberingBuilder/interface/GeometricDet.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
+#include "Geometry/CommonTopologies/interface/PixelTopology.h"
+
+#include <math.h>
+
+#include <iostream>
+using namespace std;
+//=============================================================================================================
+//
+// -- Constructor
+// 
+SiPixelActionExecutorPhase1::SiPixelActionExecutorPhase1(bool offlineXMLfile, 
+                                             bool Tier0Flag) : 
+  offlineXMLfile_(offlineXMLfile), 
+  Tier0Flag_(Tier0Flag) {
+  edm::LogInfo("SiPixelActionExecutorPhase1") << 
+    " Creating SiPixelActionExecutorPhase1 " << "\n" ;
+  configParser_ = 0;
+  configWriter_ = 0;
+  qtHandler_ = 0;  
+  ndet_ = 0;
+  //collationDone = false;
+}
+//=============================================================================================================
+//
+// --  Destructor
+// 
+SiPixelActionExecutorPhase1::~SiPixelActionExecutorPhase1() {
+  edm::LogInfo("SiPixelActionExecutorPhase1") << 
+    " Deleting SiPixelActionExecutorPhase1 " << "\n" ;
+  if (configParser_) delete configParser_;
+  if (configWriter_) delete configWriter_;  
+  if (qtHandler_) delete qtHandler_;
+}
+//=============================================================================================================
+//
+// -- Read Configuration File
+//
+void SiPixelActionExecutorPhase1::readConfiguration() {
+  string localPath;
+  if(offlineXMLfile_) localPath = string("DQM/SiPixelMonitorClient/test/sipixel_tier0_config.xml");
+  else localPath = string("DQM/SiPixelMonitorClient/test/sipixel_monitorelement_config.xml");
+  if (configParser_ == 0) {
+    configParser_ = new SiPixelConfigParser();
+    configParser_->getDocument(edm::FileInPath(localPath).fullPath());
+  }
+}
+//=============================================================================================================
+//
+// -- Read Configuration File
+//
+bool SiPixelActionExecutorPhase1::readConfiguration(int& tkmap_freq, 
+                                              int& sum_barrel_freq, 
+                                              int& sum_endcap_freq, 
+					      int& sum_grandbarrel_freq, 
+					      int& sum_grandendcap_freq, 
+					      int& message_limit_,
+					      int& source_type_,
+					      int& calib_type_) {
+  //printing cout<<"Entering SiPixelActionExecutorPhase1::readConfiguration..."<<endl;
+  string localPath;
+  if(offlineXMLfile_) localPath = string("DQM/SiPixelMonitorClient/test/sipixel_tier0_config.xml");
+  else localPath = string("DQM/SiPixelMonitorClient/test/sipixel_monitorelement_config.xml");
+  if (configParser_ == 0) {
+    configParser_ = new SiPixelConfigParser();
+    configParser_->getDocument(edm::FileInPath(localPath).fullPath());
+  }
+	
+  if (!configParser_->getFrequencyForTrackerMap(tkmap_freq)){
+    cout << "SiPixelActionExecutorPhase1::readConfiguration: Failed to read TrackerMap configuration parameters!! ";
+    return false;
+  }
+  if (!configParser_->getFrequencyForBarrelSummary(sum_barrel_freq)){
+    edm::LogInfo("SiPixelActionExecutorPhase1") << "Failed to read Barrel Summary configuration parameters!! " << "\n" ;
+    return false;
+  }
+  if (!configParser_->getFrequencyForEndcapSummary(sum_endcap_freq)){
+    edm::LogInfo("SiPixelActionExecutorPhase1")  << "Failed to read Endcap Summary configuration parameters!! " << "\n" ;
+    return false;
+  }
+  if (!configParser_->getFrequencyForGrandBarrelSummary(sum_grandbarrel_freq)){
+    edm::LogInfo("SiPixelActionExecutorPhase1") << "Failed to read Grand Barrel Summary configuration parameters!! " << "\n" ;
+    return false;
+  }
+  if (!configParser_->getFrequencyForGrandEndcapSummary(sum_grandendcap_freq)){
+    edm::LogInfo("SiPixelActionExecutorPhase1")  << "Failed to read Grand Endcap Summary configuration parameters!! " << "\n" ;
+    return false;
+  }
+  if (!configParser_->getMessageLimitForQTests(message_limit_)){
+    edm::LogInfo("SiPixelActionExecutorPhase1")  << "Failed to read QTest Message Limit" << "\n" ;
+    return false;
+  }
+  if (!configParser_->getSourceType(source_type_)){
+    edm::LogInfo("SiPixelActionExecutorPhase1")  << "Failed to read Source Type" << "\n" ;
+    return false;
+  }
+  if (!configParser_->getCalibType(calib_type_)){
+    edm::LogInfo("SiPixelActionExecutorPhase1")  << "Failed to read Calib Type" << "\n" ;
+    return false;
+  }
+  //printing cout<<"...leaving SiPixelActionExecutorPhase1::readConfiguration..."<<endl;
+  return true;
+}
+//=============================================================================================================
+bool SiPixelActionExecutorPhase1::readConfiguration(int& tkmap_freq, int& summary_freq) {
+  //printing cout<<"Entering SiPixelActionExecutorPhase1::readConfiguration..."<<endl;
+  string localPath;
+  if(offlineXMLfile_) localPath = string("DQM/SiPixelMonitorClient/test/sipixel_tier0_config.xml");
+  else localPath = string("DQM/SiPixelMonitorClient/test/sipixel_monitorelement_config.xml");
+  if (configParser_ == 0) {
+    configParser_ = new SiPixelConfigParser();
+    configParser_->getDocument(edm::FileInPath(localPath).fullPath());
+  }
+	
+  if (!configParser_->getFrequencyForTrackerMap(tkmap_freq)){
+    cout << "SiPixelActionExecutorPhase1::readConfiguration: Failed to read TrackerMap configuration parameters!! ";
+    return false;
+  }
+  if (!configParser_->getFrequencyForBarrelSummary(summary_freq)){
+    edm::LogInfo("SiPixelActionExecutorPhase1") << "Failed to read Summary configuration parameters!! " << "\n" ;
+    return false;
+  }
+  //printing cout<<"...leaving SiPixelActionExecutorPhase1::readConfiguration..."<<endl;
+  return true;
+}
+//=============================================================================================================
+// -- Create Tracker Map
+//
+void SiPixelActionExecutorPhase1::createTkMap(DQMStore* bei, 
+                                        string mEName,
+					string theTKType) 
+{
+	
+  SiPixelTrackerMapCreator tkmap_creator(mEName,theTKType,offlineXMLfile_);
+  tkmap_creator.create(bei);
+	
+/*     cout << ACYellow << ACBold 
+  	  << "[SiPixelActionExecutorPhase1::createTkMap()]"
+  	  << ACPlain
+  	  << " Tracker map created (type:" 
+  	  << theTKType
+  	  << ")"
+  	  << endl;
+*/
+}
+
+//=============================================================================================================
+void SiPixelActionExecutorPhase1::createSummary(DQMStore* bei) {
+  //cout<<"entering SiPixelActionExecutorPhase1::createSummary..."<<endl;
+  string barrel_structure_name;
+  vector<string> barrel_me_names;
+  string localPath;
+  if(offlineXMLfile_) localPath = string("DQM/SiPixelMonitorClient/test/sipixel_tier0_config.xml");
+  else localPath = string("DQM/SiPixelMonitorClient/test/sipixel_monitorelement_config.xml");
+//  cout<<"*********************ATTENTION! LOCALPATH= "<<localPath<<endl;
+  if (configParser_ == 0) {
+    configParser_ = new SiPixelConfigParser();
+    configParser_->getDocument(edm::FileInPath(localPath).fullPath());
+  }
+  if (!configParser_->getMENamesForBarrelSummary(barrel_structure_name, barrel_me_names)){
+    cout << "SiPixelActionExecutorPhase1::createSummary: Failed to read Barrel Summary configuration parameters!! ";
+    return;
+  }
+  configParser_->getSourceType(source_type_); 
+//  cout<<"++++++++++++++++++++++++++SOURCE TYPE= "<<source_type_<<endl;
+  bei->setCurrentFolder("Pixel/");
+  //bei->cd();
+  fillSummary(bei, barrel_structure_name, barrel_me_names, true); // Barrel
+  bei->setCurrentFolder("Pixel/");
+  //bei->cd();
+  string endcap_structure_name;
+  vector<string> endcap_me_names;
+  if (!configParser_->getMENamesForEndcapSummary(endcap_structure_name, endcap_me_names)){
+    edm::LogInfo("SiPixelActionExecutorPhase1")  << "Failed to read Endcap Summary configuration parameters!! " << "\n" ;
+    return;
+  }
+
+//  cout << "--- Processing endcap" << endl;
+
+  bei->setCurrentFolder("Pixel/");
+  //bei->cd();
+  fillSummary(bei, endcap_structure_name, endcap_me_names, false); // Endcap
+  bei->setCurrentFolder("Pixel/");
+  //if(!Tier0Flag_) fillDeviations(bei);
+  bei->setCurrentFolder("Pixel/");
+  //bei->cd();
+  if(source_type_==0||source_type_==5 || source_type_ == 20){//do this only if RawData source is present
+    string federror_structure_name;
+    vector<string> federror_me_names;
+    if (!configParser_->getMENamesForFEDErrorSummary(federror_structure_name, federror_me_names)){
+      cout << "SiPixelActionExecutorPhase1::createSummary: Failed to read FED Error Summary configuration parameters!! ";
+      return;
+    }
+    bei->setCurrentFolder("Pixel/");
+    //bei->cd();
+    fillFEDErrorSummary(bei, federror_structure_name, federror_me_names);
+    bei->setCurrentFolder("Pixel/");
+    //bei->cd();
+  }
+  //createLayout(bei);
+  //string fname = "test.xml";
+  // configWriter_->write(fname);
+  if (configWriter_) delete configWriter_;
+  configWriter_ = 0;
+//  cout<<"leaving SiPixelActionExecutorPhase1::createSummary..."<<endl;
+}
+
+//=============================================================================================================
+void SiPixelActionExecutorPhase1::bookDeviations(DQMStore* bei) {
+  int nBPixModules;
+  nBPixModules=1184; 
+  
+  bei->cd();
+  bei->setCurrentFolder("Pixel/Barrel");
+  DEV_adc_Barrel = bei->book1D("DEV_adc_Barrel","Deviation from reference;Module;<adc_ref>-<adc>",nBPixModules,0.,nBPixModules);
+  DEV_ndigis_Barrel = bei->book1D("DEV_ndigis_Barrel","Deviation from reference;Module;<ndigis_ref>-<ndigis>",nBPixModules,0.,nBPixModules);
+  DEV_charge_Barrel = bei->book1D("DEV_charge_Barrel","Deviation from reference;Module;<charge_ref>-<charge>",nBPixModules,0.,nBPixModules);
+  DEV_nclusters_Barrel = bei->book1D("DEV_nclusters_Barrel","Deviation from reference;Module;<nclusters_ref>-<nclusters>",nBPixModules,0.,nBPixModules);
+  DEV_size_Barrel = bei->book1D("DEV_size_Barrel","Deviation from reference;Module;<size_ref>-<size>",nBPixModules,0.,nBPixModules);
+  bei->cd();
+  bei->setCurrentFolder("Pixel/Endcap");
+  DEV_adc_Endcap = bei->book1D("DEV_adc_Endcap","Deviation from reference;Module;<adc_ref>-<adc>",672,0.,672.);
+  DEV_ndigis_Endcap = bei->book1D("DEV_ndigis_Endcap","Deviation from reference;Module;<ndigis_ref>-<ndigis>",672,0.,672.);
+  DEV_charge_Endcap = bei->book1D("DEV_charge_Endcap","Deviation from reference;Module;<charge_ref>-<charge>",672,0.,672.);
+  DEV_nclusters_Endcap = bei->book1D("DEV_nclusters_Endcap","Deviation from reference;Module;<nclusters_ref>-<nclusters>",672,0.,672.);
+  DEV_size_Endcap = bei->book1D("DEV_size_Endcap","Deviation from reference;Module;<size_ref>-<size>",672,0.,672.);  
+  bei->cd();
+}
+
+
+void SiPixelActionExecutorPhase1::fillDeviations(DQMStore* bei) {
+  int n = 768;
+  MonitorElement* me1; MonitorElement* me2; 
+  MonitorElement* me3; MonitorElement* me4; 
+  MonitorElement* me5; 
+  TH1* ref1; TH1* ref2; 
+  TH1* ref3; TH1* ref4; 
+  TH1* ref5; 
+  MonitorElement* dev1; MonitorElement* dev2; 
+  MonitorElement* dev3; MonitorElement* dev4; 
+  MonitorElement* dev5; 
+  me1 = bei->get("Pixel/Barrel/SUMDIG_adc_Barrel");
+  ref1 = me1->getRefTH1();
+  dev1 = bei->get("Pixel/Barrel/DEV_adc_Barrel");
+  me2 = bei->get("Pixel/Barrel/SUMDIG_ndigis_Barrel");
+  ref2 = me2->getRefTH1();
+  dev2 = bei->get("Pixel/Barrel/DEV_ndigis_Barrel");
+  me3 = bei->get("Pixel/Barrel/SUMCLU_charge_Barrel");
+  ref3 = me3->getRefTH1();
+  dev3 = bei->get("Pixel/Barrel/DEV_charge_Barrel");
+  me4 = bei->get("Pixel/Barrel/SUMCLU_nclusters_Barrel");
+  ref4 = me4->getRefTH1();
+  dev4 = bei->get("Pixel/Barrel/DEV_nclusters_Barrel");
+  me5 = bei->get("Pixel/Barrel/SUMCLU_size_Barrel");
+  ref5 = me5->getRefTH1();
+  dev5 = bei->get("Pixel/Barrel/DEV_size_Barrel");
+  for(int i=1; i!=n+1; i++){
+    float ref_value; float new_value;
+    // Barrel adc: 
+    if(me1)if(ref1)if(dev1){
+      new_value = me1->getBinContent(i);
+      ref_value = ref1->GetBinContent(i); 
+      dev1->setBinContent(i,ref_value-new_value);
+    }
+    //Barrel ndigis:
+    if(me2)if(ref2)if(dev2){
+      new_value = me2->getBinContent(i);
+      ref_value = ref2->GetBinContent(i); 
+      dev2->setBinContent(i,ref_value-new_value);
+    }
+    // Barrel cluster charge:
+    if(me3)if(ref3)if(dev3){
+      new_value = me3->getBinContent(i);
+      ref_value = ref3->GetBinContent(i); 
+      dev3->setBinContent(i,ref_value-new_value);
+    }
+    // Barrel nclusters:
+    if(me4)if(ref4)if(dev4){
+      new_value = me4->getBinContent(i);
+      ref_value = ref4->GetBinContent(i); 
+      dev4->setBinContent(i,ref_value-new_value);
+    }
+    // Barrel cluster size:
+    if(me5)if(ref5)if(dev5){
+      new_value = me5->getBinContent(i);
+      ref_value = ref5->GetBinContent(i); 
+      dev5->setBinContent(i,ref_value-new_value);
+    }
+  }
+
+  int nn = 672;
+  MonitorElement* me11; MonitorElement* me12; 
+  MonitorElement* me13; MonitorElement* me14; 
+  MonitorElement* me15; 
+  TH1* ref11; TH1* ref12; 
+  TH1* ref13; TH1* ref14; 
+  TH1* ref15; 
+  MonitorElement* dev11; MonitorElement* dev12; 
+  MonitorElement* dev13; MonitorElement* dev14; 
+  MonitorElement* dev15; 
+  me11 = bei->get("Pixel/Endcap/SUMDIG_adc_Endcap");
+  ref11 = me11->getRefTH1();
+  dev11 = bei->get("Pixel/Endcap/DEV_adc_Endcap");
+  me12 = bei->get("Pixel/Endcap/SUMDIG_ndigis_Endcap");
+  ref12 = me12->getRefTH1();
+  dev12 = bei->get("Pixel/Endcap/DEV_ndigis_Endcap");
+  me13 = bei->get("Pixel/Endcap/SUMCLU_charge_Endcap");
+  ref13 = me13->getRefTH1();
+  dev13 = bei->get("Pixel/Endcap/DEV_charge_Endcap");
+  me14 = bei->get("Pixel/Endcap/SUMCLU_nclusters_Endcap");
+  ref14 = me14->getRefTH1();
+  dev14 = bei->get("Pixel/Endcap/DEV_nclusters_Endcap");
+  me15 = bei->get("Pixel/Endcap/SUMCLU_size_Endcap");
+  ref15 = me15->getRefTH1();
+  dev15 = bei->get("Pixel/Endcap/DEV_size_Endcap");
+  for(int i=1; i!=nn+1; i++){
+    float ref_value; float new_value;
+    // Endcap adc: 
+    if(me11)if(ref11)if(dev11){
+      new_value = me11->getBinContent(i);
+      ref_value = ref11->GetBinContent(i); 
+      dev11->setBinContent(i,ref_value-new_value);
+    }
+    //Endcap ndigis:
+    if(me12)if(ref12)if(dev12){
+      new_value = me12->getBinContent(i);
+      ref_value = ref12->GetBinContent(i); 
+      dev12->setBinContent(i,ref_value-new_value);
+    }
+    // Endcap cluster charge:
+    if(me13)if(ref13)if(dev13){
+      new_value = me13->getBinContent(i);
+      ref_value = ref13->GetBinContent(i); 
+      dev13->setBinContent(i,ref_value-new_value);
+    }
+    // Endcap nclusters:
+    if(me14)if(ref14)if(dev14){
+      new_value = me14->getBinContent(i);
+      ref_value = ref14->GetBinContent(i); 
+      dev14->setBinContent(i,ref_value-new_value);
+    }
+    // Endcap cluster size:
+    if(me15)if(ref15)if(dev15){
+      new_value = me15->getBinContent(i);
+      ref_value = ref15->GetBinContent(i); 
+      dev15->setBinContent(i,ref_value-new_value);
+    }
+  }
+}
+
+//=============================================================================================================
+
+void SiPixelActionExecutorPhase1::GetBladeSubdirs(DQMStore* bei, vector<string>& blade_subdirs) {
+	blade_subdirs.clear();
+//	cout << "BladeSubdirs::" << bei->pwd() << endl;
+	vector<string> panels = bei->getSubdirs();
+	vector<string> modules;
+	for (vector<string>::const_iterator it = panels.begin(); it != panels.end(); it++) {
+		bei->cd(*it);
+		modules = bei->getSubdirs();
+		for (vector<string>::const_iterator m_it = modules.begin(); m_it != modules.end(); m_it++) {
+//			cout << "Would have added " << (*m_it) << "." << endl;
+			blade_subdirs.push_back(*m_it);
+		}
+	}
+//	cout << "Got Blade subdirs" << endl;
+}
+
+
+//=============================================================================================================
+
+void SiPixelActionExecutorPhase1::fillSummary(DQMStore* bei, string dir_name, vector<string>& me_names, bool isbarrel)
+{
+	
+
+  //cout<<"entering SiPixelActionExecutorPhase1::fillSummary..."<<endl;
+  string currDir = bei->pwd();
+  //cout<<"currDir= "<<currDir<<endl;
+  string prefix;
+  if(source_type_==0) prefix="SUMRAW";
+  else if (source_type_==1) prefix="SUMDIG";
+  else if (source_type_==2) prefix="SUMCLU";
+  else if (source_type_==3) prefix="SUMTRK";
+  else if (source_type_==4) prefix="SUMHIT";
+  else if (source_type_>=7 && source_type_<20) prefix="SUMCAL";
+  else if (source_type_==20) prefix="SUMOFF";
+  if (currDir.find(dir_name) != string::npos)  {
+    vector<MonitorElement*> sum_mes;
+    for (vector<string>::const_iterator iv = me_names.begin();
+	 iv != me_names.end(); iv++) {
+      if(source_type_==5||source_type_==6){
+	if((*iv)=="errorType"||(*iv)=="NErrors"||(*iv)=="fullType"||(*iv)=="chanNmbr"||
+	   (*iv)=="TBMType"||(*iv)=="EvtNbr"||(*iv)=="evtSize"||(*iv)=="linkId"||
+	   (*iv)=="ROCId"||(*iv)=="DCOLId"||(*iv)=="PXId"||(*iv)=="ROCNmbr"||
+	   (*iv)=="TBMMessage"||(*iv)=="Type36Hitmap") 
+	  prefix="SUMRAW";
+	else if((*iv)=="ndigis"||(*iv)=="adc")
+	  prefix="SUMDIG";
+	else if((*iv)=="nclusters"||(*iv)=="x"||(*iv)=="y"||(*iv)=="charge"||
+		(*iv)=="size"||(*iv)=="sizeX"||(*iv)=="sizeY"||(*iv)=="minrow"||
+		(*iv)=="maxrow"||(*iv)=="mincol"||(*iv)=="maxcol")
+	  prefix="SUMCLU";
+          if(currDir.find("Track")!=string::npos) prefix="SUMTRK";
+	else if((*iv)=="residualX"||(*iv)=="residualY")
+	  prefix="SUMTRK";
+	else if((*iv)=="ClustX"||(*iv)=="ClustY"||(*iv)=="nRecHits"||(*iv)=="ErrorX"||(*iv)=="ErrorY")
+	  prefix="SUMHIT";
+	else if((*iv)=="Gain1d"||(*iv)=="GainChi2NDF1d"||
+		(*iv)=="GainChi2Prob1d"||(*iv)=="Pedestal1d"||
+		(*iv)=="GainNPoints1d"||(*iv)=="GainHighPoint1d"||
+		(*iv)=="GainLowPoint1d"||(*iv)=="GainEndPoint1d"||
+		(*iv)=="GainFitResult2d"||(*iv)=="GainDynamicRange2d"||
+		(*iv)=="GainSaturate2d"||
+		(*iv)=="ScurveChi2ProbSummary"||(*iv)=="ScurveFitResultSummary"||
+		(*iv)=="ScurveSigmasSummary"||(*iv)=="ScurveThresholdSummary"||
+		(*iv)=="pixelAliveSummary"  || (*iv) == "SiPixelErrorsCalibDigis") 
+	  prefix="SUMCAL"; 
+      }
+      MonitorElement* temp; string tag;
+      if((*iv).find("residual")!=string::npos){                           // track residuals
+	tag = prefix + "_" + (*iv) + "_mean_" 
+	  + currDir.substr(currDir.find(dir_name));
+	temp = getSummaryME(bei, tag);
+	sum_mes.push_back(temp);
+	tag = prefix + "_" + (*iv) + "_RMS_" 
+	  + currDir.substr(currDir.find(dir_name));
+	temp = getSummaryME(bei, tag);
+	sum_mes.push_back(temp);
+      }else if(prefix == "SUMCAL"){                  // calibrations
+	if((*iv)=="Gain1d" || (*iv)=="GainChi2NDF1d" || (*iv)=="GainChi2Prob1d" ||
+	   (*iv)=="GainNPoints1d" || (*iv)=="GainHighPoint1d" ||
+	   (*iv)=="GainLowPoint1d" || (*iv)=="GainEndPoint1d" || 
+	   (*iv)=="GainDynamicRange2d" || (*iv)=="GainSaturate2d" ||
+	   (*iv)=="Pedestal1d" ||
+	   (*iv)=="ScurveChi2ProbSummary" || (*iv)=="ScurveFitResultSummary" ||
+	   (*iv)=="ScurveSigmasSummary" || (*iv)=="ScurveThresholdSummary"){                    
+	  tag = prefix + "_" + (*iv) + "_mean_" 
+	    + currDir.substr(currDir.find(dir_name));
+	  temp = getSummaryME(bei, tag);
+	  sum_mes.push_back(temp);
+	  tag = prefix + "_" + (*iv) + "_RMS_" 
+	    + currDir.substr(currDir.find(dir_name));
+	  temp = getSummaryME(bei, tag);
+	  sum_mes.push_back(temp);
+	}else if((*iv) == "SiPixelErrorsCalibDigis"){
+	  tag = prefix + "_" + (*iv) + "_NCalibErrors_"
+	    + currDir.substr(currDir.find(dir_name));
+	  temp = getSummaryME(bei, tag);
+	  sum_mes.push_back(temp);
+	}else if((*iv)=="GainFitResult2d"){
+	  tag = prefix + "_" + (*iv) + "_NNegativeFits_"
+	    + currDir.substr(currDir.find(dir_name));
+	  temp = getSummaryME(bei, tag);
+	  sum_mes.push_back(temp);
+	}else if((*iv)=="pixelAliveSummary"){
+	  tag = prefix + "_" + (*iv) + "_FracOfPerfectPix_"
+	    + currDir.substr(currDir.find(dir_name));
+	  temp = getSummaryME(bei, tag);
+	  sum_mes.push_back(temp);
+	  tag = prefix + "_" + (*iv) + "_mean_"
+	    + currDir.substr(currDir.find(dir_name));
+	  temp = getSummaryME(bei, tag);
+	  sum_mes.push_back(temp);
+	}
+      }else{
+	tag = prefix + "_" + (*iv) + "_" + currDir.substr(currDir.find(dir_name));
+	temp = getSummaryME(bei, tag);
+	sum_mes.push_back(temp);
+	if((*iv)=="ndigis"){
+	  tag = prefix + "_" + (*iv) + "FREQ_" 
+	    + currDir.substr(currDir.find(dir_name));
+	  temp = getSummaryME(bei, tag);
+	  sum_mes.push_back(temp);
+	}
+	if(prefix=="SUMDIG" && (*iv)=="adc"){
+	  tag = "ALLMODS_" + (*iv) + "COMB_" + currDir.substr(currDir.find(dir_name));
+	  temp = bei->book1D(tag.c_str(), tag.c_str(),128, 0., 256.);
+	  sum_mes.push_back(temp);
+	}
+	if(prefix=="SUMCLU" && (*iv)=="charge"){
+	  tag = "ALLMODS_" + (*iv) + "COMB_" + currDir.substr(currDir.find(dir_name));
+	  temp = bei->book1D(tag.c_str(), tag.c_str(),100, 0., 200.); // To look to get the size automatically	  
+	  sum_mes.push_back(temp);
+	}
+      }
+    }
+    if (sum_mes.size() == 0) {
+      edm::LogInfo("SiPixelActionExecutorPhase1") << " Summary MEs can not be created" << "\n" ;
+      return;
+    }
+    vector<string> subdirs = bei->getSubdirs();
+//Blade
+  if(dir_name.find("Blade_") == 0) GetBladeSubdirs(bei, subdirs);
+	
+    int ndet = 0;
+    for (vector<string>::const_iterator it = subdirs.begin();
+	 it != subdirs.end(); it++) {
+      if (prefix!="SUMOFF" && (*it).find("Module_") == string::npos) continue;
+      if (prefix=="SUMOFF" && (*it).find(isbarrel?"Layer_":"Disk_") == string::npos) continue;
+      bei->cd(*it);
+      ndet++;
+
+      vector<string> contents = bei->getMEs(); 
+			
+			for (vector<MonitorElement*>::const_iterator isum = sum_mes.begin();
+				 isum != sum_mes.end(); isum++) {
+				for (vector<string>::const_iterator im = contents.begin();
+					 im != contents.end(); im++) {
+					string sname = ((*isum)->getName());
+					string tname = " ";
+					tname = sname.substr(7,(sname.find("_",7)-6));
+					if(sname.find("ALLMODS_adcCOMB_")!=string::npos) tname = "adc_";
+					if(sname.find("ALLMODS_chargeCOMB_")!=string::npos) tname = "charge_";
+					if(sname.find("_charge_")!=string::npos && sname.find("Track_")==string::npos) tname = "charge_";
+					if(sname.find("_nclusters_")!=string::npos && sname.find("Track_")==string::npos) tname = "nclusters_";
+					if(sname.find("_size_")!=string::npos && sname.find("Track_")==string::npos) tname = "size_";
+					if(sname.find("_charge_OffTrack_")!=string::npos) tname = "charge_OffTrack_";
+					if(sname.find("_nclusters_OffTrack_")!=string::npos) tname = "nclusters_OffTrack_";
+					if(sname.find("_size_OffTrack_")!=string::npos) tname = "size_OffTrack_";
+					if(sname.find("_sizeX_OffTrack_")!=string::npos) tname = "sizeX_OffTrack_";
+					if(sname.find("_sizeY_OffTrack_")!=string::npos) tname = "sizeY_OffTrack_";
+					if(sname.find("_charge_OnTrack_")!=string::npos) tname = "charge_OnTrack_";
+					if(sname.find("_nclusters_OnTrack_")!=string::npos) tname = "nclusters_OnTrack_";
+					if(sname.find("_size_OnTrack_")!=string::npos) tname = "size_OnTrack_";
+					if(sname.find("_sizeX_OnTrack_")!=string::npos) tname = "sizeX_OnTrack_";
+					if(sname.find("_sizeY_OnTrack_")!=string::npos) tname = "sizeY_OnTrack_";
+					//if(sname.find("ALLMODS")!=string::npos) cout<<"sname and tname= "<<sname<<","<<tname<<endl;
+					if(tname.find("FREQ")!=string::npos) tname = "ndigis_";
+					if (((*im)).find(tname) == 0) {
+						string fullpathname = bei->pwd() + "/" + (*im); 
+					//cout<<"!!!!!!!!!!!!!!!!!!!!!!SNAME= "<<sname<<endl;	
+	    MonitorElement *  me = bei->get(fullpathname);
+
+	    if (me){ 
+	      if(sname.find("_charge")!=string::npos && sname.find("Track_")==string::npos && me->getName().find("Track_")!=string::npos) continue;
+	      if(sname.find("_nclusters_")!=string::npos && sname.find("Track_")==string::npos && me->getName().find("Track_")!=string::npos) continue;
+	      if(sname.find("_size")!=string::npos && sname.find("Track_")==string::npos && me->getName().find("Track_")!=string::npos) continue;
+//cout<<"tell me the sname and me name: "<<sname<<" , "<<me->getName()<<endl;
+	      // fill summary histos:
+	      if (sname.find("_RMS_")!=string::npos && 
+		  sname.find("GainDynamicRange2d")==string::npos && 
+		  sname.find("GainSaturate2d")==string::npos){
+		(*isum)->Fill(ndet, me->getRMS());
+	      }else if (sname.find("GainDynamicRange2d")!=string::npos ||
+			sname.find("GainSaturate2d")!=string::npos){
+		float SumOfEntries=0.; float SumOfSquaredEntries=0.; int SumOfPixels=0;
+		for(int cols=1; cols!=me->getNbinsX()+1; cols++) for(int rows=1; rows!=me->getNbinsY()+1; rows++){
+		  SumOfEntries+=me->getBinContent(cols,rows);
+		  SumOfSquaredEntries+=(me->getBinContent(cols,rows))*(me->getBinContent(cols,rows));
+		  SumOfPixels++;
+		}
+
+		float MeanInZ = SumOfEntries / float(SumOfPixels);
+		float RMSInZ = sqrt(SumOfSquaredEntries/float(SumOfPixels));
+		if(sname.find("_mean_")!=string::npos) (*isum)->Fill(ndet, MeanInZ);
+		if(sname.find("_RMS_")!=string::npos) (*isum)->Fill(ndet, RMSInZ);
+	      }else if (sname.find("_FracOfPerfectPix_")!=string::npos){
+		//printing cout<<"nbins = "<<me->getNbinsX()<<" , "<<me->getBinContent(me->getNbinsX()-1)<<" , "<<me->getBinContent(me->getNbinsX())<<endl;
+		float nlast = me->getBinContent(me->getNbinsX());
+		float nall = (me->getTH1F())->Integral(1,11);
+		//printing cout << nall << endl;
+		(*isum)->Fill(ndet, nlast/nall);
+	      }else if (sname.find("_NCalibErrors_")!=string::npos ||
+			sname.find("FREQ_")!=string::npos){
+		float nall = me->getEntries();
+		(*isum)->Fill(ndet, nall);
+	      }else if (sname.find("GainFitResult2d")!=string::npos){
+		int NegFitPixels=0;
+		for(int cols=1; cols!=me->getNbinsX()+1; cols++) for(int rows=1; rows!=me->getNbinsY()+1; rows++){
+		  if(me->getBinContent(cols,rows)<0.) NegFitPixels++;
+		}
+		(*isum)->Fill(ndet, float(NegFitPixels));
+	      }else if (sname.find("ALLMODS_adcCOMB_")!=string::npos || 
+	                (sname.find("ALLMODS_chargeCOMB_")!=string::npos && me->getName().find("Track_")==string::npos)){
+		(*isum)->getTH1F()->Add(me->getTH1F());
+	      }else if (sname.find("_NErrors_")!=string::npos){
+	        string path1 = fullpathname;
+		path1 = path1.replace(path1.find("NErrors"),7,"errorType");
+		MonitorElement * me1 = bei->get(path1);
+		bool notReset=true;
+	        if(me1){
+	          for(int jj=1; jj<16; jj++){
+	            if(me1->getBinContent(jj)>0.){
+	              if(jj==6){ //errorType=30 (reset)
+	                string path2 = path1;
+			path2 = path2.replace(path2.find("errorType"),9,"TBMMessage");
+	                MonitorElement * me2 = bei->get(path2);
+	                if(me2) if(me2->getBinContent(6)>0. || me2->getBinContent(7)>0.) notReset=false;
+		      }
+		    }
+		  }
+		}
+		if(notReset) (*isum)->Fill(ndet, me1->getEntries());
+	      }else if ((sname.find("_charge_")!=string::npos && sname.find("Track_")==string::npos && 
+	                me->getName().find("Track_")==string::npos) ||
+			(sname.find("_charge_")!=string::npos && sname.find("_OnTrack_")!=string::npos && 
+	                me->getName().find("_OnTrack_")!=string::npos) ||
+			(sname.find("_charge_")!=string::npos && sname.find("_OffTrack_")!=string::npos && 
+	                me->getName().find("_OffTrack_")!=string::npos) ||
+			(sname.find("_nclusters_")!=string::npos && sname.find("Track_")==string::npos && 
+	                me->getName().find("Track_")==string::npos) ||
+			(sname.find("_nclusters_")!=string::npos && sname.find("_OnTrack_")!=string::npos && 
+	                me->getName().find("_OnTrack_")!=string::npos) ||
+			(sname.find("_nclusters_")!=string::npos && sname.find("_OffTrack_")!=string::npos && 
+	                me->getName().find("_OffTrack_")!=string::npos) ||
+			(sname.find("_size")!=string::npos && sname.find("Track_")==string::npos && 
+	                me->getName().find("Track_")==string::npos) ||
+			(sname.find("_size")!=string::npos && sname.find("_OnTrack_")!=string::npos && 
+	                me->getName().find("_OnTrack_")!=string::npos) ||
+			(sname.find("_size")!=string::npos && sname.find("_OffTrack_")!=string::npos && 
+	                me->getName().find("_OffTrack_")!=string::npos)){
+	        (*isum)->Fill(ndet, me->getMean());
+	      }else if(sname.find("_charge_")==string::npos && sname.find("_nclusters_")==string::npos && sname.find("_size")==string::npos){
+		(*isum)->Fill(ndet, me->getMean());
+		//std::cout<<bei->pwd()<<"/"<<(*isum)->getName()<<" , "<<ndet<<" , "<<me->getMean()<<" , "<<(*isum)->getBinContent(ndet)<<std::endl;
+	      }
+	      
+	      // set titles:
+	      if(prefix=="SUMOFF"){
+		(*isum)->setAxisTitle(isbarrel?"Ladders":"Blades",1);
+	      }else if(sname.find("ALLMODS_adcCOMB_")!=string::npos){
+		(*isum)->setAxisTitle("Digi charge [ADC]",1);
+	      }else if(sname.find("ALLMODS_chargeCOMB_")!=string::npos){
+		(*isum)->setAxisTitle("Cluster charge [kilo electrons]",1);
+	      }else{
+		(*isum)->setAxisTitle("Modules",1);
+	      }
+	      string title = " ";
+	      if (sname.find("_RMS_")!=string::npos){
+		title = "RMS of " + sname.substr(7,(sname.find("_",7)-7)) + " per module"; 
+	      }else if (sname.find("_FracOfPerfectPix_")!=string::npos){
+		title = "FracOfPerfectPix " + sname.substr(7,(sname.find("_",7)-7)) + " per module"; 
+	      }else if(sname.find("_NCalibErrors_")!=string::npos){
+		title = "Number of CalibErrors " + sname.substr(7,(sname.find("_",7)-7)) + " per module"; 
+	      }else if(sname.find("_NNegativeFits_")!=string::npos){
+		title = "Number of pixels with neg. fit result " + sname.substr(7,(sname.find("_",7)-7)) + " per module"; 
+	      }else if (sname.find("FREQ_")!=string::npos){
+		title = "NEvents with digis per module"; 
+	      }else if (sname.find("ALLMODS_adcCOMB_")!=string::npos){
+		title = "NDigis";
+	      }else if (sname.find("ALLMODS_chargeCOMB_")!=string::npos){
+		title = "NClusters";
+	      }else if (sname.find("_NErrors_")!=string::npos){
+	        if(prefix=="SUMOFF" && isbarrel) title = "Total number of errors per Ladder";
+		else if(prefix=="SUMOFF" && !isbarrel) title = "Total number of errors per Blade";
+		else title = "Total number of errors per Module";
+	      }else{
+		if(prefix=="SUMOFF") title = "Mean " + sname.substr(7,(sname.find("_",7)-7)) + (isbarrel?" per Ladder":" per Blade"); 
+		else title = "Mean " + sname.substr(7,(sname.find("_",7)-7)) + " per Module"; 
+	      }
+	      (*isum)->setAxisTitle(title,2);
+	    }
+	    break;
+	  }
+	}
+      }
+      bei->goUp();
+	  if(dir_name.find("Blade") == 0) bei->goUp(); // Going up a second time if we are processing the Blade
+    } // end for it (subdirs)
+  } else {  
+    vector<string> subdirs = bei->getSubdirs();
+    // printing cout << "#\t" << bei->pwd() << endl;
+    if(isbarrel)
+      {
+			
+	for (vector<string>::const_iterator it = subdirs.begin();
+	     it != subdirs.end(); it++) {
+	  //				 cout << "##\t" << bei->pwd() << "\t" << (*it) << endl;
+	  if((bei->pwd()).find("Endcap")!=string::npos ||
+	     (bei->pwd()).find("AdditionalPixelErrors")!=string::npos) bei->goUp();
+	  bei->cd(*it);
+	  if((*it).find("Endcap")!=string::npos ||
+	     (*it).find("AdditionalPixelErrors")!=string::npos) continue;
+	  fillSummary(bei, dir_name, me_names, true); // Barrel
+	  bei->goUp();
+	}
+	string grandbarrel_structure_name;
+	vector<string> grandbarrel_me_names;
+	if (!configParser_->getMENamesForGrandBarrelSummary(grandbarrel_structure_name, grandbarrel_me_names)){
+	  cout << "SiPixelActionExecutorPhase1::createSummary: Failed to read Grand Barrel Summary configuration parameters!! ";
+	  return;
+	}
+	fillGrandBarrelSummaryHistos(bei, grandbarrel_me_names);
+			
+      }
+    else // Endcap
+      {
+			
+	for (vector<string>::const_iterator it = subdirs.begin();
+	     it != subdirs.end(); it++) {
+	  //				 cout << "##\t" << bei->pwd() << "\t" << (*it) << endl;
+	  if((bei->pwd()).find("Barrel")!=string::npos ||
+	     (bei->pwd()).find("AdditionalPixelErrors")!=string::npos) bei->goUp();
+	  bei->cd((*it));
+	  if ((*it).find("Barrel")!=string::npos ||
+	      (*it).find("AdditionalPixelErrors")!=string::npos) continue;
+	  fillSummary(bei, dir_name, me_names, false); // Endcap
+	  bei->goUp();
+	}
+	string grandendcap_structure_name;
+	vector<string> grandendcap_me_names;
+	if (!configParser_->getMENamesForGrandEndcapSummary(grandendcap_structure_name, grandendcap_me_names)){
+	  cout << "SiPixelActionExecutorPhase1::createSummary: Failed to read Grand Endcap Summary configuration parameters!! ";
+	  return;
+	}
+	fillGrandEndcapSummaryHistos(bei, grandendcap_me_names);
+			
+			
+      }
+  }
+//  cout<<"...leaving SiPixelActionExecutorPhase1::fillSummary!"<<endl;
+	
+  // End of cleanup
+	
+	
+}
+
+//=============================================================================================================
+void SiPixelActionExecutorPhase1::fillFEDErrorSummary(DQMStore* bei,
+                                                string dir_name,
+						vector<string>& me_names) {
+  //printing cout<<"entering SiPixelActionExecutorPhase1::fillFEDErrorSummary..."<<endl;
+  string currDir = bei->pwd();
+  string prefix;
+  if(source_type_==0) prefix="SUMRAW";
+  else if(source_type_==20) prefix="SUMOFF";
+  
+  if (currDir.find(dir_name) != string::npos)  {
+    vector<MonitorElement*> sum_mes;
+    for (vector<string>::const_iterator iv = me_names.begin();
+	 iv != me_names.end(); iv++) {
+      bool isBooked = false;
+      vector<string> contents = bei->getMEs();
+      for (vector<string>::const_iterator im = contents.begin(); im != contents.end(); im++)
+        if ((*im).find(*iv) != string::npos) isBooked = true;
+      if(source_type_==5||source_type_==6){
+	if((*iv)=="errorType"||(*iv)=="NErrors"||(*iv)=="fullType"||(*iv)=="chanNmbr"||
+	   (*iv)=="TBMType"||(*iv)=="EvtNbr"||(*iv)=="evtSize"||(*iv)=="linkId"||
+	   (*iv)=="ROCId"||(*iv)=="DCOLId"||(*iv)=="PXId"||(*iv)=="ROCNmbr"||
+	   (*iv)=="TBMMessage"||(*iv)=="Type36Hitmap"||
+	   (*iv)=="FedChLErrArray"||(*iv)=="FedChNErrArray"||(*iv)=="FedETypeNErrArray") 
+	  prefix="SUMRAW";
+      }
+      if((*iv)=="errorType"||(*iv)=="NErrors"||(*iv)=="fullType"||(*iv)=="chanNmbr"||
+	 (*iv)=="TBMType"||(*iv)=="EvtNbr"||(*iv)=="evtSize"||(*iv)=="linkId"||
+	 (*iv)=="ROCId"||(*iv)=="DCOLId"||(*iv)=="PXId"||(*iv)=="ROCNmbr"||
+	 (*iv)=="TBMMessage"||(*iv)=="Type36Hitmap"){
+        string tag = prefix + "_" + (*iv) + "_FEDErrors";
+        MonitorElement* temp = getFEDSummaryME(bei, tag);
+        sum_mes.push_back(temp);
+      }else if((*iv)=="FedChLErrArray"||(*iv)=="FedChNErrArray"||(*iv)=="FedETypeNErrArray"){
+        string tag = prefix + "_" + (*iv);
+	MonitorElement* temp;
+	if((*iv)=="FedChLErrArray") {if (!isBooked) temp = bei->book2D("FedChLErrArray","Type of last error",40,-0.5,39.5,37,0.,37.);
+	  else{ 
+	    string fullpathname = bei->pwd() + "/" + (*iv);
+	    temp = bei->get(fullpathname);
+	    temp->Reset();}}  //If I don't reset this one, then I instead start adding error codes..
+	if((*iv)=="FedChNErrArray") {if (!isBooked) temp = bei->book2D("FedChNErrArray","Total number of errors",40,-0.5,39.5,37,0.,37.);
+	  else{ 
+	    string fullpathname = bei->pwd() + "/" + (*iv);
+	    temp = bei->get(fullpathname);
+	    temp->Reset();}}  //If I don't reset this one, then I instead start adding error codes..
+	if((*iv)=="FedETypeNErrArray"){
+	  if(!isBooked){
+	    temp = bei->book2D("FedETypeNErrArray","Number of each error type",40,-0.5,39.5,21,0.,21.);
+	    temp->setBinLabel(1,"ROC of 25",2);
+	    temp->setBinLabel(2,"Gap word",2);
+	    temp->setBinLabel(3,"Dummy word",2);
+	    temp->setBinLabel(4,"FIFO full",2);
+	    temp->setBinLabel(5,"Timeout",2);
+	    temp->setBinLabel(6,"Stack full",2);
+	    temp->setBinLabel(7,"Pre-cal issued",2);
+	    temp->setBinLabel(8,"Trigger clear or sync",2);
+	    temp->setBinLabel(9,"No token bit",2);
+	    temp->setBinLabel(10,"Overflow",2);
+	    temp->setBinLabel(11,"FSM error",2);
+	    temp->setBinLabel(12,"Invalid #ROCs",2);
+	    temp->setBinLabel(13,"Event number",2);
+	    temp->setBinLabel(14,"Slink header",2);
+	    temp->setBinLabel(15,"Slink trailer",2);
+	    temp->setBinLabel(16,"Event size",2);
+	    temp->setBinLabel(17,"Invalid channel#",2);
+	    temp->setBinLabel(18,"ROC value",2);
+	    temp->setBinLabel(19,"Dcol or pixel value",2);
+	    temp->setBinLabel(20,"Readout order",2);
+	    temp->setBinLabel(21,"CRC error",2);
+	  }
+	  else{
+	    string fullpathname = bei->pwd() + "/" + (*iv);
+	    temp = bei->get(fullpathname);
+	    temp->Reset();}  //If I don't reset this one, then I instead start adding error codes..
+	}
+	sum_mes.push_back(temp);
+      }
+    }
+    if (sum_mes.size() == 0) {
+      edm::LogInfo("SiPixelActionExecutorPhase1") << " Summary MEs can not be created" << "\n" ;
+      return;
+    }
+    vector<string> subdirs = bei->getSubdirs();
+    int ndet = 0;
+    for (vector<string>::const_iterator it = subdirs.begin();
+	 it != subdirs.end(); it++) {
+      if ( (*it).find("FED_") == string::npos) continue;
+      bei->cd(*it);
+      string fedid = (*it).substr((*it).find("_")+1);
+      std::istringstream isst;
+      isst.str(fedid);
+      isst>>ndet; ndet++;
+      vector<string> contents = bei->getMEs(); 
+			
+      for (vector<MonitorElement*>::const_iterator isum = sum_mes.begin();
+	   isum != sum_mes.end(); isum++) {
+	for (vector<string>::const_iterator im = contents.begin();
+	     im != contents.end(); im++) {
+	  if(((*im).find("FedChNErrArray_")!=std::string::npos && (*isum)->getName().find("FedChNErrArray")!=std::string::npos) ||
+	     ((*im).find("FedChLErrArray_")!=std::string::npos && (*isum)->getName().find("FedChLErrArray")!=std::string::npos) ||
+	     ((*im).find("FedETypeNErrArray_")!=std::string::npos && (*isum)->getName().find("FedETypeNErrArray")!=std::string::npos)){
+	    string fullpathname = bei->pwd() + "/" + (*im); 
+	    MonitorElement *  me = bei->get(fullpathname);
+	    if(me && me->getIntValue()>0){
+	      for(int i=0; i!=37; i++){
+	        int n = (*im).find("_"); n++;
+	        string channel_str = (*im).substr(n);
+		std::istringstream jsst;
+		jsst.str(channel_str);
+		int channel=-1;
+		jsst>>channel;
+	        if(channel==i){
+		  if((*im).find("FedETypeNErrArray_")!=std::string::npos && i<21) (*isum)->Fill(ndet-1,i,me->getIntValue());
+		  else (*isum)->Fill(ndet-1,i,me->getIntValue());
+		}
+	      }
+	    }
+	  }
+	  string sname = ((*isum)->getName());
+	  string tname = " ";
+	  tname = sname.substr(7,(sname.find("_",7)-6));
+	  if (((*im)).find(tname) == 0) {
+	    string fullpathname = bei->pwd() + "/" + (*im); 
+	    MonitorElement *  me = bei->get(fullpathname);
+						
+	    if (me){ 
+	      if(me->getMean()>0.){
+	        if (sname.find("_NErrors_")!=string::npos){
+	          string path1 = fullpathname;
+		  path1 = path1.replace(path1.find("NErrors"),7,"errorType");
+		  MonitorElement * me1 = bei->get(path1);
+		  bool notReset=true;
+	          if(me1){
+	            for(int jj=1; jj<16; jj++){
+	              if(me1->getBinContent(jj)>0.){
+	                if(jj==6){ //errorType=30 (reset)
+	                  string path2 = path1;
+			  path2 = path2.replace(path2.find("errorType"),9,"TBMMessage");
+	                  MonitorElement * me2 = bei->get(path2);
+	                  if(me2) if(me2->getBinContent(6)>0. || me2->getBinContent(7)>0.) notReset=false; 
+		        }
+		      }
+		    }
+		  }
+		  if(notReset) (*isum)->setBinContent(ndet, (*isum)->getBinContent(ndet) + me1->getEntries());
+	        }else (*isum)->setBinContent(ndet, (*isum)->getBinContent(ndet) + me->getEntries());
+	      }
+	      (*isum)->setAxisTitle("FED #",1);
+	      string title = " ";
+	      title = sname.substr(7,(sname.find("_",7)-7)) + " per FED"; 
+	      (*isum)->setAxisTitle(title,2);
+	    }
+	    break;
+	  }
+	}
+      }
+      bei->goUp();
+    }
+  } else {  
+    vector<string> subdirs = bei->getSubdirs();
+    for (vector<string>::const_iterator it = subdirs.begin();
+	 it != subdirs.end(); it++) {
+      if((*it).find("Endcap")!=string::npos ||
+	 (*it).find("Barrel")!=string::npos) continue;
+      bei->cd(*it);
+      fillFEDErrorSummary(bei, dir_name, me_names);
+      bei->goUp();
+    }
+  }
+  //printing cout<<"...leaving SiPixelActionExecutorPhase1::fillFEDErrorSummary!"<<endl;
+}
+
+
+//=============================================================================================================
+void SiPixelActionExecutorPhase1::fillGrandBarrelSummaryHistos(DQMStore* bei,
+                                                         vector<string>& me_names) {
+//  cout<<"Entering SiPixelActionExecutorPhase1::fillGrandBarrelSummaryHistos...:"<<me_names.size()<<endl;
+  vector<MonitorElement*> gsum_mes;
+  string currDir = bei->pwd();
+  string path_name = bei->pwd();
+  string dir_name =  path_name.substr(path_name.find_last_of("/")+1);
+//  cout<<"I am in "<<path_name<<" now."<<endl;
+  if ((dir_name.find("DQMData") == 0) ||
+      (dir_name.find("Pixel") == 0) ||
+      (dir_name.find("AdditionalPixelErrors") == 0) ||
+      (dir_name.find("Endcap") == 0) ||
+      (dir_name.find("HalfCylinder") == 0) ||
+      (dir_name.find("Disk") == 0) ||
+      (dir_name.find("Blade") == 0) ||
+      (dir_name.find("Panel") == 0) ) return;
+  vector<string> subdirs = bei->getSubdirs();
+  int nDirs = subdirs.size();
+  int iDir =0;
+  int nbin = 0;
+  int nbin_i = 0; 
+  int nbin_subdir = 0; 
+  int cnt=0;
+  bool first_subdir = true;
+  for (vector<string>::const_iterator it = subdirs.begin();
+       it != subdirs.end(); it++) {
+    cnt++;
+    bei->cd(*it);
+//    cout << "--- " << cnt << "\t" << bei->pwd() << endl;
+    vector<string> contents = bei->getMEs();
+		
+    bei->goUp();
+		
+		string prefix;
+		if(source_type_==0) prefix="SUMRAW";
+		else if (source_type_==1) prefix="SUMDIG";
+		else if (source_type_==2) prefix="SUMCLU";
+		else if (source_type_==3) prefix="SUMTRK";
+		else if (source_type_==4) prefix="SUMHIT";
+		else if (source_type_>=7 && source_type_<20) prefix="SUMCAL";
+		else if (source_type_==20) prefix="SUMOFF";
+
+		
+    for (vector<string>::const_iterator im = contents.begin();
+	 im != contents.end(); im++) {
+//      cout<<"A: iterating over "<<(*im)<<" now:"<<endl;
+      for (vector<string>::const_iterator iv = me_names.begin();
+	   iv != me_names.end(); iv++) {
+	string var = "_" + (*iv) + "_";
+//	cout<<"\t B: iterating over "<<(*iv)<<" now, var is set to: "<<var<<endl;
+	if ((*im).find(var) != string::npos) {
+	  if((var=="_charge_" || var=="_nclusters_" || var=="_size_" || var=="_sizeX_" || var=="_sizeY_") && 
+	     (*im).find("Track_")!=string::npos) continue;
+//	  cout << "Looking into " << (*iv) << endl;
+	  string full_path = (*it) + "/" +(*im);
+	  MonitorElement * me = bei->get(full_path.c_str());
+	  if (!me) continue; 
+	  if(source_type_==5||source_type_==6){
+	    if((*iv)=="errorType"||(*iv)=="NErrors"||(*iv)=="fullType"||(*iv)=="chanNmbr"||
+	       (*iv)=="TBMType"||(*iv)=="EvtNbr"||(*iv)=="evtSize"||(*iv)=="linkId"||
+	       (*iv)=="ROCId"||(*iv)=="DCOLId"||(*iv)=="PXId"||(*iv)=="ROCNmbr"||
+	       (*iv)=="TBMMessage"||(*iv)=="Type36Hitmap") 
+	      prefix="SUMRAW";
+	    else if((*iv)=="ndigis"||(*iv)=="adc" ||
+		    (*iv)=="ndigisFREQ" || (*iv)=="adcCOMB")
+	      prefix="SUMDIG";
+	    else if((*iv)=="nclusters"||(*iv)=="x"||(*iv)=="y"||(*iv)=="charge"||(*iv)=="chargeCOMB"||
+		    (*iv)=="size"||(*iv)=="sizeX"||(*iv)=="sizeY"||(*iv)=="minrow"||
+		    (*iv)=="maxrow"||(*iv)=="mincol"||(*iv)=="maxcol")
+	      prefix="SUMCLU";
+	      if(currDir.find("Track")!=string::npos) prefix="SUMTRK";
+	    else if((*iv)=="residualX_mean"||(*iv)=="residualY_mean"||
+		    (*iv)=="residualX_RMS"||(*iv)=="residualY_RMS")
+	      prefix="SUMTRK";
+	    else if((*iv)=="ClustX"||(*iv)=="ClustY"||(*iv)=="nRecHits"||(*iv)=="ErrorX"||(*iv)=="ErrorY")
+	      prefix="SUMHIT";
+	    else if((*iv)=="Gain1d_mean"||(*iv)=="GainChi2NDF1d_mean"||
+		    (*iv)=="GainChi2Prob1d_mean"||(*iv)=="Pedestal1d_mean"||
+		    (*iv)=="ScurveChi2ProbSummary_mean"||(*iv)=="ScurveFitResultSummary_mean"||
+		    (*iv)=="ScurveSigmasSummary_mean"||(*iv)=="ScurveThresholdSummary_mean"||
+		    (*iv)=="Gain1d_RMS"||(*iv)=="GainChi2NDF1d_RMS"||
+		    (*iv)=="GainChi2Prob1d_RMS"||(*iv)=="Pedestal1d_RMS"||
+		    (*iv)=="GainNPoints1d_mean" || (*iv)=="GainNPoints1d_RMS" ||
+		    (*iv)=="GainHighPoint1d_mean" || (*iv)=="GainHighPoint1d_RMS" ||
+		    (*iv)=="GainLowPoint1d_mean" || (*iv)=="GainLowPoint1d_RMS" ||
+		    (*iv)=="GainEndPoint1d_mean" || (*iv)=="GainEndPoint1d_RMS" ||
+		    (*iv)=="GainFitResult2d_mean" || (*iv)=="GainFitResult2d_RMS" ||
+		    (*iv)=="GainDynamicRange2d_mean" || (*iv)=="GainDynamicRange2d_RMS" ||
+		    (*iv)=="GainSaturate2d_mean" || (*iv)=="GainSaturate2d_RMS" ||
+		    (*iv)=="ScurveChi2ProbSummary_RMS"||(*iv)=="ScurveFitResultSummary_RMS"||
+		    (*iv)=="ScurveSigmasSummary_RMS"||(*iv)=="ScurveThresholdSummary_RMS"||
+		    (*iv)=="pixelAliveSummary_mean"||(*iv)=="pixelAliveSummary_FracOfPerfectPix" ||
+		    (*iv)=="SiPixelErrorsCalibDigis_NCalibErrors" )
+	      prefix="SUMCAL";
+	  } // end source_type if
+	  
+	  // bugfix: gsum_mes is filled using the contents of me_names. Proceeding with each entry in me_names.
+      /*
+	  int actual_size = gsum_mes.size();
+	  int wanted_size = me_names.size();
+	  // printing cout << actual_size << "\t" << wanted_size << endl;
+	  if (actual_size !=  wanted_size) { */
+	  if (first_subdir){
+//	    bool create_me = true;
+	    nbin = me->getTH1F()->GetNbinsX();        
+	    string me_name = prefix + "_" + (*iv) + "_" + dir_name;
+	    if((*iv)=="adcCOMB"||(*iv)=="chargeCOMB") me_name = "ALLMODS_" + (*iv) + "_" + dir_name;
+	    else if(prefix=="SUMOFF" && dir_name=="Barrel") nbin=296;
+	    else if((*iv)=="adcCOMB") nbin=256;
+	    else if(dir_name=="Barrel") nbin=1184;
+	    else if(prefix=="SUMOFF" && dir_name.find("Shell")!=string::npos) nbin=74;
+	    else if(dir_name.find("Shell")!=string::npos) nbin=296;
+	    else nbin=nbin*nDirs;
+
+		getGrandSummaryME(bei, nbin, me_name, gsum_mes);
+	  }
+	  /*
+	    for (vector<MonitorElement*>::const_iterator igm = gsum_mes.begin();
+		 igm !=gsum_mes.end(); igm++) { 
+	      // To be further optimized
+	      if( (*iv).find("Clust") != string::npos && (*igm)->getName().find(me_name) != string::npos ) create_me = false; //cout << "Already have it" << endl;
+	    }
+	  
+	    // printing cout<<"me_name to be created= "<<me_name<<endl;
+	    if(create_me) getGrandSummaryME(bei, nbin, me_name, gsum_mes);
+	  }
+	  */
+	  // end bugfix: gsum_mes.
+
+
+	  for (vector<MonitorElement*>::const_iterator igm = gsum_mes.begin();
+	       igm != gsum_mes.end(); igm++) {
+//	    cout<<"\t \t C: iterating over "<<(*igm)->getName()<<" now:"<<endl;
+	    if ((*igm)->getName().find(var) != string::npos) {
+//	      cout<<"\t \t D: Have the correct var now!"<<endl;
+	      if(prefix=="SUMOFF") (*igm)->setAxisTitle("Ladders",1);
+	      else if((*igm)->getName().find("adcCOMB_")!=string::npos) (*igm)->setAxisTitle("Digi charge [ADC]",1);
+	      else if((*igm)->getName().find("chargeCOMB_")!=string::npos) (*igm)->setAxisTitle("Cluster charge [kilo electrons]",1);
+	      else (*igm)->setAxisTitle("Modules",1);
+
+	      // Setting title
+
+		  string title="";
+	      if((*igm)->getName().find("NErrors_") != string::npos && prefix=="SUMOFF") title = "Total number of errors per Ladder";
+	      else if((*igm)->getName().find("NErrors_") != string::npos && prefix=="SUMRAW") title = "Total number of errors per Module";
+	      else if(prefix=="SUMOFF") title = "mean " + (*iv) + " per Ladder"; 
+	      else if((*igm)->getName().find("FREQ_") != string::npos && prefix!="SUMOFF") title = "NEvents with digis per Module"; 
+	      else if((*igm)->getName().find("FREQ_") != string::npos && prefix=="SUMOFF") title = "NEvents with digis per Ladder/Blade"; 
+	      else if((*igm)->getName().find("adcCOMB_") != string::npos) title = "NDigis";
+	      else if((*igm)->getName().find("chargeCOMB_") != string::npos) title = "NClusters";
+	      else title = "mean " + (*iv) + " per Module"; 
+	      (*igm)->setAxisTitle(title,2);
+		  
+	      // Setting binning
+	      if((*igm)->getName().find("ALLMODS_adcCOMB_")!=string::npos){
+		nbin_subdir=128;
+	      }else if((*igm)->getName().find("ALLMODS_chargeCOMB_")!=string::npos){
+		nbin_subdir=100;
+	      }else if((*igm)->getName().find("Ladder") != string::npos){
+		nbin_i=0; nbin_subdir=4;
+	      }else if((*igm)->getName().find("Layer") != string::npos){
+		nbin_i=(cnt-1)*4; nbin_subdir=4;
+	      }else if((*igm)->getName().find("Shell") != string::npos){
+		if(prefix!="SUMOFF"){
+		  if(iDir==0){ nbin_i=0; nbin_subdir=24; }//40(2*20)-->24(2*12)
+		  else if(iDir==1){ nbin_i=24; nbin_subdir=56; }//64(32*2)-->56(2*28)
+		  else if(iDir==2){ nbin_i=80; nbin_subdir=88; }//88(44*2)-->same88(44*2)
+		  else if(iDir==3){ nbin_i=168; nbin_subdir=128; }
+		}else{
+		  if(iDir==0){ nbin_i=0; nbin_subdir=6; }//10-->6
+		  else if(iDir==1){ nbin_i=6; nbin_subdir=14; }//16-->14
+		  else if(iDir==2){ nbin_i=20; nbin_subdir=22; }//22-->same22
+		  else if(iDir==3){ nbin_i=42; nbin_subdir=32; }
+		}
+	      }else if((*igm)->getName().find("Barrel") != string::npos){
+		if(prefix!="SUMOFF"){
+		  if(iDir==0){ nbin_i=0; nbin_subdir=296; }//192=76 8/4-->296=1184/4
+		  else if(iDir==1){ nbin_i=296; nbin_subdir=296; }//296*2,*3,*4=1184
+		  else if(iDir==2){ nbin_i=592; nbin_subdir=296; }
+		  else if(iDir==3){ nbin_i=888; nbin_subdir=296; }
+		  else if(iDir==4){ nbin_i=1184; nbin_subdir=296; }
+		}else{
+		  if(iDir==0){ nbin_i=0; nbin_subdir=74; }//48=192/4-->74=296/4
+		  else if(iDir==1){ nbin_i=74; nbin_subdir=74; }//74*2,...*4=296
+		  else if(iDir==2){ nbin_i=148; nbin_subdir=74; }
+		  else if(iDir==3){ nbin_i=222; nbin_subdir=74; }
+		  else if(iDir==4){ nbin_i=296; nbin_subdir=74; }
+		}
+	      }
+	      
+	      if((*igm)->getName().find("ndigisFREQ")==string::npos)
+		{ 
+		  if(((*igm)->getName().find("adcCOMB")!=string::npos && me->getName().find("adcCOMB")!=string::npos) 
+		     || ((*igm)->getName().find("chargeCOMB")!=string::npos && me->getName().find("chargeCOMB")!=string::npos))
+		    {
+		      (*igm)->getTH1F()->Add(me->getTH1F());
+		    }else if(((*igm)->getName().find("charge_")!=string::npos && (*igm)->getName().find("Track_")==string::npos && 
+			      me->getName().find("charge_")!=string::npos && me->getName().find("Track_")==string::npos) || 
+			     ((*igm)->getName().find("nclusters_")!=string::npos && (*igm)->getName().find("Track_")==string::npos && 
+			      me->getName().find("nclusters_")!=string::npos && me->getName().find("Track_")==string::npos) || 
+			     ((*igm)->getName().find("size_")!=string::npos && (*igm)->getName().find("Track_")==string::npos && 
+			      me->getName().find("size_")!=string::npos && me->getName().find("Track_")==string::npos) || 
+			     ((*igm)->getName().find("charge_OffTrack_")!=string::npos && me->getName().find("charge_OffTrack_")!=string::npos) || 
+			     ((*igm)->getName().find("nclusters_OffTrack_")!=string::npos && me->getName().find("nclusters_OffTrack_")!=string::npos) || 
+			     ((*igm)->getName().find("size_OffTrack_")!=string::npos && me->getName().find("size_OffTrack_")!=string::npos) || 
+			     ((*igm)->getName().find("charge_OnTrack_")!=string::npos && me->getName().find("charge_OnTrack_")!=string::npos) || 
+			     ((*igm)->getName().find("nclusters_OnTrack_")!=string::npos && me->getName().find("nclusters_OnTrack_")!=string::npos) || 
+			     ((*igm)->getName().find("size_OnTrack_")!=string::npos && me->getName().find("size_OnTrack_")!=string::npos) || 
+			     ((*igm)->getName().find("charge_")==string::npos && (*igm)->getName().find("nclusters_")==string::npos && 
+			      (*igm)->getName().find("size_")==string::npos)){
+		    for (int k = 1; k < nbin_subdir+1; k++) if(me->getBinContent(k) > 0) (*igm)->setBinContent(k+nbin_i, me->getBinContent(k));
+		  }
+		}
+	      else if(me->getName().find("ndigisFREQ")!=string::npos)
+		{
+		  for (int k = 1; k < nbin_subdir+1; k++) if(me->getBinContent(k) > 0) (*igm)->setBinContent(k+nbin_i, me->getBinContent(k));
+		}
+	    } // end var in igm (gsum_mes)
+	  } // end igm loop
+	} // end var in im (contents)
+      } // end of iv loop
+    } // end of im loop
+    iDir++;
+    first_subdir = false; // We are done processing the first directory, we don't add any new MEs in the future passes.	
+  } // end of it loop (subdirs)
+  //  cout<<"...leaving SiPixelActionExecutorPhase1::fillGrandBarrelSummaryHistos!"<<endl;
+}
+
+//=============================================================================================================
+void SiPixelActionExecutorPhase1::fillGrandEndcapSummaryHistos(DQMStore* bei,
+                                                         vector<string>& me_names) {
+  //printing cout<<"Entering SiPixelActionExecutorPhase1::fillGrandEndcapSummaryHistos..."<<endl;
+  vector<MonitorElement*> gsum_mes;
+  string currDir = bei->pwd();
+  string path_name = bei->pwd();
+  string dir_name =  path_name.substr(path_name.find_last_of("/")+1);
+  if ((dir_name.find("DQMData") == 0) ||
+      (dir_name.find("Pixel") == 0) ||
+      (dir_name.find("AdditionalPixelErrors") == 0) ||
+      (dir_name.find("Barrel") == 0) ||
+      (dir_name.find("Shell") == 0) ||
+      (dir_name.find("Layer") == 0) ||
+      (dir_name.find("Ladder") == 0) ) return;
+  vector<string> subdirs = bei->getSubdirs();
+  int iDir =0;
+  int nbin = 0;
+  int nbin_i = 0; 
+  int nbin_subdir = 0; 
+  int cnt=0;
+  bool first_subdir = true;  
+  for (vector<string>::const_iterator it = subdirs.begin();
+       it != subdirs.end(); it++) {
+    cnt++;
+    bei->cd(*it);
+    vector<string> contents = bei->getMEs();
+    bei->goUp();
+		
+    string prefix;
+    if(source_type_==0) prefix="SUMRAW";
+    else if (source_type_==1) prefix="SUMDIG";
+    else if (source_type_==2) prefix="SUMCLU";
+    else if (source_type_==3) prefix="SUMTRK";
+    else if (source_type_==4) prefix="SUMHIT";
+    else if (source_type_>=7 && source_type_<20) prefix="SUMCAL";
+    else if (source_type_==20) prefix="SUMOFF";
+		
+    for (vector<string>::const_iterator im = contents.begin();
+	 im != contents.end(); im++) {
+      for (vector<string>::const_iterator iv = me_names.begin();
+	   iv != me_names.end(); iv++) {
+	string var = "_" + (*iv) + "_";
+	if ((*im).find(var) != string::npos) {
+	  if((var=="_charge_" || var=="_nclusters_" || var=="_size_" || var=="_sizeX_" || var=="_sizeY_") && 
+	     (*im).find("Track_")!=string::npos) continue;
+	  string full_path = (*it) + "/" +(*im);
+	  MonitorElement * me = bei->get(full_path.c_str());
+	  if (!me) continue; 
+	  if(source_type_==5||source_type_==6){
+	    if((*iv)=="errorType"||(*iv)=="NErrors"||(*iv)=="fullType"||(*iv)=="chanNmbr"||
+	       (*iv)=="TBMType"||(*iv)=="EvtNbr"||(*iv)=="evtSize"||(*iv)=="linkId"||
+	       (*iv)=="ROCId"||(*iv)=="DCOLId"||(*iv)=="PXId"||(*iv)=="ROCNmbr"||
+	       (*iv)=="TBMMessage"||(*iv)=="Type36Hitmap") 
+	      prefix="SUMRAW";
+	    else if((*iv)=="ndigis"||(*iv)=="adc" ||
+		    (*iv)=="ndigisFREQ"||(*iv)=="adcCOMB")
+	      prefix="SUMDIG";
+	    else if((*iv)=="nclusters"||(*iv)=="x"||(*iv)=="y"||(*iv)=="charge"||(*iv)=="chargeCOMB"||
+		    (*iv)=="size"||(*iv)=="sizeX"||(*iv)=="sizeY"||(*iv)=="minrow"||
+		    (*iv)=="maxrow"||(*iv)=="mincol"||(*iv)=="maxcol")
+	      prefix="SUMCLU";
+	      if(currDir.find("Track")!=string::npos) prefix="SUMTRK";
+	    else if((*iv)=="residualX_mean"||(*iv)=="residualY_mean"||
+		    (*iv)=="residualX_RMS"||(*iv)=="residualY_RMS")
+	      prefix="SUMTRK";
+	    else if((*iv)=="ClustX"||(*iv)=="ClustY"||(*iv)=="nRecHits"||(*iv)=="ErrorX"||(*iv)=="ErrorY")
+	      prefix="SUMHIT";
+	    else if((*iv)=="Gain1d_mean"||(*iv)=="GainChi2NDF1d_mean"||
+		    (*iv)=="GainChi2Prob1d_mean"||(*iv)=="Pedestal1d_mean"||
+		    (*iv)=="ScurveChi2ProbSummary_mean"||(*iv)=="ScurveFitResultSummary_mean"||
+		    (*iv)=="ScurveSigmasSummary_mean"||(*iv)=="ScurveThresholdSummary_mean"||
+		    (*iv)=="Gain1d_RMS"||(*iv)=="GainChi2NDF1d_RMS"||
+		    (*iv)=="GainChi2Prob1d_RMS"||(*iv)=="Pedestal1d_RMS"||
+		    (*iv)=="GainNPoints1d_mean" || (*iv)=="GainNPoints1d_RMS" ||
+		    (*iv)=="GainHighPoint1d_mean" || (*iv)=="GainHighPoint1d_RMS" ||
+		    (*iv)=="GainLowPoint1d_mean" || (*iv)=="GainLowPoint1d_RMS" ||
+		    (*iv)=="GainEndPoint1d_mean" || (*iv)=="GainEndPoint1d_RMS" ||
+		    (*iv)=="GainFitResult2d_mean" || (*iv)=="GainFitResult2d_RMS" ||
+		    (*iv)=="GainDynamicRange2d_mean" || (*iv)=="GainDynamicRange2d_RMS" ||
+		    (*iv)=="GainSaturate2d_mean" || (*iv)=="GainSaturate2d_RMS" ||
+		    (*iv)=="ScurveChi2ProbSummary_RMS"||(*iv)=="ScurveFitResultSummary_RMS"||
+		    (*iv)=="ScurveSigmasSummary_RMS"||(*iv)=="ScurveThresholdSummary_RMS"||
+		    (*iv)=="pixelAliveSummary_mean"||(*iv)=="pixelAliveSummary_FracOfPerfectPix"|| 
+		    (*iv) == "SiPixelErrorsCalibDigis_NCalibErrors")
+	      prefix="SUMCAL"; 
+	  }
+
+	  // bugfix: gsum_mes is filled using the contents of me_names. Proceeding with each entry in me_names.
+	  /*
+	  int actual_size = gsum_mes.size();
+	  int wanted_size = me_names.size();
+	  if (actual_size !=  wanted_size) { */
+	  if(first_subdir){
+            nbin = me->getTH1F()->GetNbinsX();        
+	    string me_name = prefix + "_" + (*iv) + "_" + dir_name;
+	    if((*iv)=="adcCOMB"||(*iv)=="chargeCOMB") me_name = "ALLMODS_" + (*iv) + "_" + dir_name;
+	    else if(prefix=="SUMOFF" && dir_name=="Endcap") nbin=336;
+	    else if(dir_name=="Endcap") nbin=672;
+	    else if(prefix=="SUMOFF" && dir_name.find("HalfCylinder")!=string::npos) nbin=84;
+	    else if(dir_name.find("HalfCylinder")!=string::npos) nbin=168;
+	    else if(prefix=="SUMOFF" && dir_name.find("Disk")!=string::npos) nbin=28;
+	    else if(dir_name.find("Disk")!=string::npos) nbin=56;
+	    else if(dir_name.find("Blade")!=string::npos) nbin=2;
+            getGrandSummaryME(bei, nbin, me_name, gsum_mes);
+          }
+	  /*
+
+	    for (vector<MonitorElement*>::const_iterator igm = gsum_mes.begin();
+		 igm !=gsum_mes.end(); igm++) { 
+	      // To be further optimized
+	      if( (*iv).find("Clust") != string::npos && (*igm)->getName().find(me_name) != string::npos ) create_me = false; //cout << "Already have it" << endl;
+	    }
+
+	    // printing cout<<"me_name to be created= "<<me_name<<endl;
+	    if(create_me) getGrandSummaryME(bei, nbin, me_name, gsum_mes);
+	  }
+	  */
+	  // end bugfix: gsum_mes.
+
+	  for (vector<MonitorElement*>::const_iterator igm = gsum_mes.begin();
+	       igm != gsum_mes.end(); igm++) { 
+	    if ((*igm)->getName().find(var) != string::npos) {
+	      if(prefix=="SUMOFF") (*igm)->setAxisTitle("Blades",1);
+	      else if((*igm)->getName().find("adcCOMB_")!=string::npos) (*igm)->setAxisTitle("Digi charge [ADC]",1);
+	      else if((*igm)->getName().find("chargeCOMB_")!=string::npos) (*igm)->setAxisTitle("Cluster charge [kilo electrons]",1);
+	      else (*igm)->setAxisTitle("Modules",1);
+	      string title="";
+	      if((*igm)->getName().find("NErrors_") != string::npos && prefix=="SUMOFF") title = "Total number of errors per Blade";
+	      else if((*igm)->getName().find("NErrors_") != string::npos && prefix=="SUMRAW") title = "Total number of errors per Module";
+	      else if(prefix=="SUMOFF") title = "mean " + (*iv) + " per Blade"; 
+	      else if((*igm)->getName().find("FREQ_") != string::npos) title = "NEvents with digis per Module"; 
+	      else if((*igm)->getName().find("adcCOMB_")!=string::npos) title = "NDigis";
+	      else if((*igm)->getName().find("chargeCOMB_")!=string::npos) title = "NClusters";
+	      else title = "mean " + (*iv) + " per Module"; 
+	      (*igm)->setAxisTitle(title,2);
+	      nbin_i=0; 
+
+	      if((*igm)->getName().find("ALLMODS_adcCOMB_")!=string::npos){
+		nbin_subdir=128;
+	      }else if((*igm)->getName().find("ALLMODS_chargeCOMB_")!=string::npos){
+		nbin_subdir=100;
+	      }else if((*igm)->getName().find("Panel_") != string::npos){
+		nbin_subdir=2;
+		//	        }else if((*igm)->getName().find("Panel_1") != string::npos){
+		//		  nbin_subdir=4;
+		//	        }else if((*igm)->getName().find("Panel_2") != string::npos){
+		//		  nbin_subdir=3;
+	      }else if((*igm)->getName().find("Blade") != string::npos){
+		if((*im).find("_1") != string::npos) nbin_subdir=1;
+		if((*im).find("_2") != string::npos) {nbin_i=1; nbin_subdir=1;}
+	      }else if((*igm)->getName().find("Disk") != string::npos){
+		nbin_i=((cnt-1)%28)*2; nbin_subdir=2;
+	      }else if((*igm)->getName().find("HalfCylinder") != string::npos){
+		if(prefix!="SUMOFF"){
+		  nbin_subdir=56;
+		  if((*im).find("_2") != string::npos) nbin_i=56;
+		  if((*im).find("_3") != string::npos) nbin_i=112;
+		}else{
+		  nbin_subdir=28;
+		  if((*im).find("_2") != string::npos) nbin_i=28;
+		  if((*im).find("_3") != string::npos) nbin_i=56;
+		}
+	      }else if((*igm)->getName().find("Endcap") != string::npos){
+		if(prefix!="SUMOFF"){
+		  nbin_subdir=168;
+		  if((*im).find("_mO") != string::npos) nbin_i=168;
+		  if((*im).find("_pI") != string::npos) nbin_i=336;
+		  if((*im).find("_pO") != string::npos) nbin_i=504;
+		}else{
+		  nbin_subdir=84;
+		  if((*im).find("_mO") != string::npos) nbin_i=84;
+		  if((*im).find("_pI") != string::npos) nbin_i=168;
+		  if((*im).find("_pO") != string::npos) nbin_i=252;
+		}
+	      }
+              
+	      
+	      //	       for (int k = 1; k < nbin_subdir+1; k++) {
+	      if((*igm)->getName().find("ndigisFREQ")==string::npos){ 
+		if(((*igm)->getName().find("adcCOMB")!=string::npos && me->getName().find("adcCOMB")!=string::npos) || ((*igm)->getName().find("chargeCOMB")!=string::npos && me->getName().find("chargeCOMB")!=string::npos)){
+		  (*igm)->getTH1F()->Add(me->getTH1F());
+		}else if(((*igm)->getName().find("charge_")!=string::npos && (*igm)->getName().find("Track_")==string::npos && 
+			  me->getName().find("charge_")!=string::npos && me->getName().find("Track_")==string::npos) || 
+			 ((*igm)->getName().find("nclusters_")!=string::npos && (*igm)->getName().find("Track_")==string::npos && 
+			  me->getName().find("nclusters_")!=string::npos && me->getName().find("Track_")==string::npos) || 
+			 ((*igm)->getName().find("size_")!=string::npos && (*igm)->getName().find("Track_")==string::npos && 
+			  me->getName().find("size_")!=string::npos && me->getName().find("Track_")==string::npos) || 
+			 ((*igm)->getName().find("charge_OffTrack_")!=string::npos && me->getName().find("charge_OffTrack_")!=string::npos) || 
+			 ((*igm)->getName().find("nclusters_OffTrack_")!=string::npos && me->getName().find("nclusters_OffTrack_")!=string::npos) || 
+			 ((*igm)->getName().find("size_OffTrack_")!=string::npos && me->getName().find("size_OffTrack_")!=string::npos) || 
+			 ((*igm)->getName().find("charge_OnTrack_")!=string::npos && me->getName().find("charge_OnTrack_")!=string::npos) || 
+			 ((*igm)->getName().find("nclusters_OnTrack_")!=string::npos && me->getName().find("nclusters_OnTrack_")!=string::npos) || 
+			 ((*igm)->getName().find("size_OnTrack_")!=string::npos && me->getName().find("size_OnTrack_")!=string::npos) || 
+			 ((*igm)->getName().find("charge_")==string::npos && (*igm)->getName().find("nclusters_")==string::npos && 
+			  (*igm)->getName().find("size_")==string::npos)){
+		  for (int k = 1; k < nbin_subdir+1; k++) if(me->getBinContent(k) > 0) (*igm)->setBinContent(k+nbin_i, me->getBinContent(k));
+		}
+	      }else if(me->getName().find("ndigisFREQ")!=string::npos){
+		for (int k = 1; k < nbin_subdir+1; k++)  if(me->getBinContent(k) > 0) (*igm)->setBinContent(k+nbin_i, me->getBinContent(k));
+	      }
+	      //	       }// for
+	      
+	    }
+	  }
+	}
+      }
+    }
+    
+    iDir++;
+    first_subdir = false; // We are done processing the first directory, we don't add any new MEs in the future passes.	
+  }  // end for it (subdirs)
+}
+//=============================================================================================================
+//
+// -- Get Summary ME
+//
+void SiPixelActionExecutorPhase1::getGrandSummaryME(DQMStore* bei,
+                                              int nbin, 
+					      string& me_name, 
+					      vector<MonitorElement*> & mes) {
+  //printing cout<<"Entering SiPixelActionExecutorPhase1::getGrandSummaryME for: "<<me_name<<endl;
+  if((bei->pwd()).find("Pixel")==string::npos) return; // If one doesn't find pixel
+  vector<string> contents = bei->getMEs();
+	
+  for (vector<string>::const_iterator it = contents.begin();
+       it != contents.end(); it++) {
+    //printing cout<<"in grand summary me: "<<me_name<<","<<(*it)<<endl;
+    if ((*it).find(me_name) == 0) {
+      string fullpathname = bei->pwd() + "/" + me_name;
+      //				cout << "###\t" << fullpathname << endl;
+      MonitorElement* me = bei->get(fullpathname);
+			
+      if (me) {
+	//      cout<<"Found grand ME: "<<fullpathname<<endl;
+	me->Reset();
+	mes.push_back(me);
+	// if printing cout<<"reset and add the following me: "<<me->getName()<<endl;
+	return;
+      }
+    }
+  }
+
+  //  MonitorElement* temp_me = bei->book1D(me_name.c_str(),me_name.c_str(),nbin,1.,nbin+1.);
+  //  if (temp_me) mes.push_back(temp_me);
+  MonitorElement* temp_me(0);
+  if(me_name.find("ALLMODS_adcCOMB_")!=string::npos) temp_me = bei->book1D(me_name.c_str(),me_name.c_str(),128,0,256);
+  else if(me_name.find("ALLMODS_chargeCOMB_")!=string::npos) temp_me = bei->book1D(me_name.c_str(),me_name.c_str(),100,0,200);
+  else temp_me = bei->book1D(me_name.c_str(),me_name.c_str(),nbin,1.,nbin+1.);
+  if (temp_me) mes.push_back(temp_me);
+	
+  //  if(temp_me) cout<<"finally found grand ME: "<<me_name<<endl;
+}
+
+
+//=============================================================================================================
+//
+// -- Get Summary ME
+//
+MonitorElement* SiPixelActionExecutorPhase1::getSummaryME(DQMStore* bei,
+                                                    string me_name) {
+  //printing cout<<"Entering SiPixelActionExecutorPhase1::getSummaryME for: "<<me_name<<endl;
+  MonitorElement* me = 0;
+  if((bei->pwd()).find("Pixel")==string::npos) return me;
+  vector<string> contents = bei->getMEs();    
+	
+  for (vector<string>::const_iterator it = contents.begin();
+       it != contents.end(); it++) {
+    if ((*it).find(me_name) == 0) {
+      string fullpathname = bei->pwd() + "/" + (*it); 
+      me = bei->get(fullpathname);
+			
+      if (me) {
+	//printing cout<<"got this ME: "<<fullpathname<<endl;
+	me->Reset();
+	return me;
+      }
+    }
+  }
+  contents.clear();
+//	cout << me_name.c_str() 
+//		<< "\t" << ((me_name.find("SUMOFF")==string::npos)?"true":"false")
+//		<< "\t" << ((me_name.find("Blade_")!= string::npos)?"true":"false")
+//		<< "\t" << ((me_name.find("Layer1_")!=string::npos)?"true":"false")
+//		<< "\t" << ((me_name.find("Layer2_")!=string::npos)?"true":"false")
+//		<< "\t" << ((me_name.find("Layer3_")!=string::npos)?"true":"false")
+//		<< "\t" << ((me_name.find("Disk_")!=string::npos)?"true":"false")
+//		<< endl;
+  if(me_name.find("SUMOFF")==string::npos){
+    if(me_name.find("Blade_")!=string::npos)me = bei->book1D(me_name.c_str(), me_name.c_str(),2,1.,3.);
+    else me = bei->book1D(me_name.c_str(), me_name.c_str(),1,1.,2.);
+    //      if(me_name.find("Panel_2")!=string::npos)  me = bei->book1D(me_name.c_str(), me_name.c_str(),3,1.,4.);
+    //      else me = bei->book1D(me_name.c_str(), me_name.c_str(),4,1.,5.);
+  }else if(me_name.find("Layer_1")!=string::npos){ me = bei->book1D(me_name.c_str(), me_name.c_str(),6,1.,7.);
+  }else if(me_name.find("Layer_2")!=string::npos){ me = bei->book1D(me_name.c_str(), me_name.c_str(),14,1.,15.);
+  }else if(me_name.find("Layer_3")!=string::npos){ me = bei->book1D(me_name.c_str(), me_name.c_str(),22,1.,23.);
+  }else if(me_name.find("Layer_4")!=string::npos){ me = bei->book1D(me_name.c_str(), me_name.c_str(),32,1.,33.);
+  }else if(me_name.find("Disk_")!=string::npos){ me = bei->book1D(me_name.c_str(), me_name.c_str(),28,1.,29.);
+  }
+  
+	
+  //  if(me) cout<<"Finally got this ME: "<<me_name<<endl;
+  //if(me_name.find("ALLMODS_adc_")!=string::npos) me = bei->book1D(me_name.c_str(), me_name.c_str(),256, 0., 256.);
+	
+  //printing cout<<"...leaving SiPixelActionExecutorPhase1::getSummaryME!"<<endl;
+  return me;
+}
+
+
+//=============================================================================================================
+MonitorElement* SiPixelActionExecutorPhase1::getFEDSummaryME(DQMStore* bei,
+                                                       string me_name) {
+  //printing cout<<"Entering SiPixelActionExecutorPhase1::getFEDSummaryME..."<<endl;
+  MonitorElement* me = 0;
+  if((bei->pwd()).find("Pixel")==string::npos) return me;
+  vector<string> contents = bei->getMEs();
+	
+  for (vector<string>::const_iterator it = contents.begin();
+       it != contents.end(); it++) {
+    if ((*it).find(me_name) == 0) {
+      string fullpathname = bei->pwd() + "/" + (*it); 
+			
+      me = bei->get(fullpathname);
+			
+      if (me) {
+	//printing cout<<"got the ME: "<<fullpathname<<endl;
+	me->Reset();
+	return me;
+      }
+    }
+  }
+  contents.clear();
+  me = bei->book1D(me_name.c_str(), me_name.c_str(),40,-0.5,39.5);
+  //if(me) cout<<"finally got the ME: "<<me_name<<endl;
+  return me;
+  //printing cout<<"...leaving SiPixelActionExecutorPhase1::getFEDSummaryME!"<<endl;
+}
+
+//=============================================================================================================
+void SiPixelActionExecutorPhase1::bookOccupancyPlots(DQMStore* bei, bool hiRes, bool isbarrel) // Polymorphism
+{
+  if(Tier0Flag_) return;
+  vector<string> subdirs = bei->getSubdirs();
+  for (vector<string>::const_iterator it = subdirs.begin(); it != subdirs.end(); it++)
+    {
+      if(isbarrel && (*it).find("Barrel")==string::npos) continue;
+      if(!isbarrel && (*it).find("Endcap")==string::npos) continue;
+		
+      if((*it).find("Module_")!=string::npos) continue;
+      if((*it).find("Panel_")!=string::npos) continue;
+      if((*it).find("Ladder_")!=string::npos) continue;
+      if((*it).find("Blade_")!=string::npos) continue;
+      if((*it).find("Layer_")!=string::npos) continue;
+      if((*it).find("Disk_")!=string::npos) continue;
+      bei->cd(*it);
+      bookOccupancyPlots(bei, hiRes, isbarrel);
+      if(!hiRes){
+	//occupancyprinting cout<<"booking low res barrel occ plot now!"<<endl;
+	OccupancyMap = bei->book2D((isbarrel?"barrelOccupancyMap":"endcapOccupancyMap"),"Barrel Digi Occupancy Map (4 pix per bin)",isbarrel?208:130,0.,isbarrel?416.:260.,80,0.,160.);
+      }else{
+	//occupancyprinting cout<<"booking high res barrel occ plot now!"<<endl;
+	OccupancyMap = bei->book2D((isbarrel?"barrelOccupancyMap":"endcapOccupancyMap"),"Barrel Digi Occupancy Map (1 pix per bin)",isbarrel?416:260,0.,isbarrel?416.:260.,160,0.,160.);
+      }
+      OccupancyMap->setAxisTitle("Columns",1);
+      OccupancyMap->setAxisTitle("Rows",2);
+		
+      bei->goUp();
+		
+    }
+	
+	
+	
+}
+//=============================================================================================================
+void SiPixelActionExecutorPhase1::bookOccupancyPlots(DQMStore* bei, bool hiRes) {
+	
+  if(Tier0Flag_) return;
+  // Barrel
+  bei->cd();
+  bei->setCurrentFolder("Pixel");
+  this->bookOccupancyPlots(bei, hiRes, true);
+	
+  // Endcap
+  bei->cd();
+  bei->setCurrentFolder("Pixel");
+  this->bookOccupancyPlots(bei, hiRes, false);
+	
+}
+
+void SiPixelActionExecutorPhase1::createOccupancy(DQMStore* bei) {
+  //std::cout<<"entering SiPixelActionExecutorPhase1::createOccupancy..."<<std::endl;
+  if(Tier0Flag_) return;
+  bei->cd();
+  fillOccupancy(bei, true);
+  bei->cd();
+  fillOccupancy(bei, false);
+  bei->cd();
+  //std::cout<<"leaving SiPixelActionExecutorPhase1::createOccupancy..."<<std::endl;
+}
+
+//=============================================================================================================
+
+void SiPixelActionExecutorPhase1::fillOccupancy(DQMStore* bei, bool isbarrel)
+{
+  //occupancyprinting cout<<"entering SiPixelActionExecutorPhase1::fillOccupancy..."<<std::endl;
+  if(Tier0Flag_) return;
+  string currDir = bei->pwd();
+  string dname = currDir.substr(currDir.find_last_of("/")+1);
+  //occupancyprinting cout<<"currDir= "<<currDir<< " , dname= "<<dname<<std::endl;
+	
+  if(dname.find("Layer_")!=string::npos || dname.find("Disk_")!=string::npos){ 
+    vector<string> meVec = bei->getMEs();
+    for (vector<string>::const_iterator it = meVec.begin(); it != meVec.end(); it++) {
+      string full_path = currDir + "/" + (*it);
+      if(full_path.find("hitmap_siPixelDigis")!=string::npos){ // If we have the hitmap ME
+	MonitorElement * me = bei->get(full_path);
+	if (!me) continue;
+	//occupancyprinting cout << full_path << endl;
+	string path = full_path;
+	while (path.find_last_of("/") != 5) // Stop before Pixel/
+	  {
+	    path = path.substr(0,path.find_last_of("/"));
+	    //							cout << "\t" << path << endl;
+	    OccupancyMap = bei->get(path + "/" + (isbarrel?"barrel":"endcap") + "OccupancyMap");
+					
+	    if(OccupancyMap){ 
+		for(int i=1; i!=me->getNbinsX()+1; i++) for(int j=1; j!=me->getNbinsY()+1; j++){
+		  float previous = OccupancyMap->getBinContent(i,j);
+		  OccupancyMap->setBinContent(i,j,previous + me->getBinContent(i,j));
+		}
+	      OccupancyMap->getTH2F()->SetEntries(OccupancyMap->getTH2F()->Integral());
+	    }       
+					
+	  }
+      }
+			
+    }
+    //bei->goUp();
+  } else {  
+    //occupancyprinting cout<<"finding subdirs now"<<std::endl;
+    vector<string> subdirs = bei->getSubdirs();
+    for (vector<string>::const_iterator it = subdirs.begin(); it != subdirs.end(); it++) {
+      bei->cd(*it);
+      //occupancyprinting cout<<"now I am in "<<bei->pwd()<<std::endl;
+      if(*it != "Pixel" && ((isbarrel && (*it).find("Barrel")==string::npos) || (!isbarrel && (*it).find("Endcap")==string::npos))) continue;
+      //occupancyprinting cout<<"calling myself again "<<std::endl;
+      fillOccupancy(bei, isbarrel);
+      bei->goUp();
+    }
+  }
+	
+  //occupancyprinting cout<<"leaving SiPixelActionExecutorPhase1::fillOccupancy..."<<std::endl;
+	
+}
+//=============================================================================================================
+
+//
+// -- Tracker Map
+//
+
+void SiPixelActionExecutorPhase1::bookTrackerMaps(DQMStore* bei, std::string name)
+{
+	bei->setCurrentFolder("Pixel/Barrel");
+	std::string partB[] = { "Layer_1", "Layer_2", "Layer_3"};
+	bei->book2D("TRKMAP_" + name + "_" + partB[0], "TRKMAP_" + name + "_" + partB[0], 20, 1., 21., 8, 1., 9.);
+	bei->book2D("TRKMAP_" + name + "_" + partB[1], "TRKMAP_" + name + "_" + partB[1], 32, 1., 33., 8, 1., 9.);
+	bei->book2D("TRKMAP_" + name + "_" + partB[2], "TRKMAP_" + name + "_" + partB[2], 44, 1., 45., 8, 1., 9.);
+		
+	bei->setCurrentFolder("Pixel/Endcap");
+	std::string partE[] = { "Disc_1_M", "Disc_2_M", "Disc_1_P", "Disc_2_P" };
+	for(Int_t p = 0 ; p < NCyl ; p++)
+		bei->book2D("TRKMAP_" + name + "_" + partE[p], "TRKMAP_" + name + "_" + partE[p], 24, 1., 25., 7, 1., 8.);
+}
+
+
+void SiPixelActionExecutorPhase1::createMaps(DQMStore* bei, std::string type, std::string name, funcType ff)
+{
+//	cout << "Starting with SiPixelActionExecutorPhase1::createMaps" << endl;
+
+	Double_t mapB[NLev1][NLev2][NLev3][NLev4];
+	bei->setCurrentFolder("Pixel/Barrel/");
+	createMap(mapB, type, bei, ff, true);
+	Double_t minB = mapMin(mapB, true);
+	Double_t maxB = mapMax(mapB, true);
+	
+	
+	Double_t mapE[NLev1][NLev2][NLev3][NLev4];
+	bei->setCurrentFolder("Pixel/Endcap/");
+	createMap(mapE, type, bei, ff, false);
+	Double_t minE = mapMin(mapE, false);
+	Double_t maxE = mapMax(mapE, false);
+	
+	Double_t min = minE<=minB?minE:minB;
+	Double_t max = maxE>=maxB?maxE:maxB;
+	if(!min)
+		min = -0.01;
+	
+	//	prephistosB(histB, mapB, type, min, max);
+	//	prephistosE(histE, mapE, type, min, max);
+
+
+	MonitorElement* meB[NLayer];
+	//	TH2F* histB[NLayer];
+	MonitorElement* meE[NCyl];
+	//	TH2F* histE[NCyl];
+	bei->setCurrentFolder("Pixel/Barrel");
+	prephistosB(meB, bei, mapB, name, min, max);
+	bei->setCurrentFolder("Pixel/Endcap");
+	prephistosE(meE, bei, mapE, name, min, max);
+
+//	cout << "Done with SiPixelActionExecutorPhase1::createMaps" << endl;
+}
+
+//=============================================================================================================
+
+int SiPixelActionExecutorPhase1::createMap(Double_t map[][NLev2][NLev3][NLev4], std::string type, DQMStore* bei, funcType ff, bool isBarrel)
+{
+	// cout << "Starting with SiPixelActionExecutorPhase1::createMap" << endl;
+	//int createMap(Double_t map[][NLev2][NLev3][NLev4], TString type, TDirectoryFile* dirMain, funcType ff){
+	vector<string> dirLev1 = bei->getSubdirs();
+	Int_t i = 0;
+	for (vector<string>::const_iterator it = dirLev1.begin(); it != dirLev1.end(); it++) // goes over HalfCylinders in Endcap and over Shells in Barrel
+	{
+		//cout << "Current Directory: " << *it << endl;
+		bei->cd(*it);
+		vector<string> dirLev2 = bei->getSubdirs();
+		Int_t j = 0;
+		for (vector<string>::const_iterator it2 = dirLev2.begin(); it2 != dirLev2.end(); it2++) // goes over Disks in Endcap and over Layers in Barrel
+		{
+			//cout << "Current Directory: " << *it2 << endl;
+			bei->cd(*it2);
+			Int_t k = 0;
+			vector<string> dirLev3 = bei->getSubdirs();
+			for (vector<string>::const_iterator it3 = dirLev3.begin(); it3 != dirLev3.end(); it3++) // goes over Blades in Endcap and over Ladders in Barrel
+			{
+				//cout << "Current Directory: " << *it3 << endl;
+				bei->cd(*it3);
+				if(Tier0Flag_)
+					for (Int_t l = 0; l < NLev4; l++)
+						getData(map, type, bei, ff, i, j, k, l);
+				else
+				{
+					Int_t l = 0;
+					vector<string> dirLev4 = bei->getSubdirs();
+					for (vector<string>::const_iterator it4 = dirLev4.begin(); it4 != dirLev4.end(); it4++)
+					{
+						// cout << "Current Directory: " << *it4 << endl;
+						bei->cd(*it4);
+						if (isBarrel)
+							getData(map, type, bei, ff, i, j, k, l++);
+						else
+						{
+							vector<string> dirLev5 = bei->getSubdirs();
+							for (vector<string>::const_iterator it5 = dirLev5.begin(); it5 != dirLev5.end(); it5++)
+							{
+								// cout << "Current Directory: " << *it5 << endl;
+								bei->cd(*it5);
+								getData(map, type, bei, ff, i, j, k, l++);
+							}
+						}
+					}
+				}
+				k++;
+			}
+			j++;
+		}
+		i++;
+	}
+	
+	// cout << "Done with SiPixelActionExecutorPhase1::createMap" << endl;
+	return 0;
+}
+
+//=============================================================================================================
+
+void SiPixelActionExecutorPhase1::getData(Double_t map[][NLev2][NLev3][NLev4], std::string type, DQMStore* bei, funcType ff, Int_t i, Int_t j, Int_t k, Int_t l) {
+	
+//	cout << "Starting with SiPixelActionExecutorPhase1::getData" << endl;
+	vector<string> contents = bei->getMEs();
+	for (vector<string>::const_iterator im = contents.begin(); im != contents.end(); im++)
+	{
+		if((*im).find(type + "_") == string::npos){
+			// cout << "Skip";
+			continue; // Searching for specific type
+		}
+		//cout << "Name: "  << *im << endl;
+		std::string fullpathname = bei->pwd() + "/" + (*im);	
+		MonitorElement*  me = bei->get(fullpathname);
+		
+		if (me) {
+		TH1F* histo = me->getTH1F();
+		
+		Int_t nbins = histo->GetNbinsX();
+		// cout << "# of bins: " << nbins << endl;
+		switch (ff){
+			case EachBinContent:
+				map[i][j][k][l] = histo->GetBinContent(l + 1);
+				break;
+				
+			case Entries:
+				map[i][j][k][l] = histo->GetEntries();
+				break;
+					
+			case Mean:
+				map[i][j][k][l] = histo->GetMean();
+				break;
+							
+			case Sum:
+			{
+				Double_t sum = 0;
+				for(Int_t m = 0; m < nbins; m++)
+					sum += histo->GetBinContent(m + 1);
+				map[i][j][k][l] = sum;
+			}
+				break;
+							
+			case WeightedSum:
+			{
+				Double_t sum = 0;
+				for(Int_t m = 0; m < nbins; m++)
+					sum += histo->GetBinContent(m + 1) * histo->GetBinLowEdge(m + 1);
+				map[i][j][k][l] = sum;
+			}
+				break;
+				
+			default:
+					map[i][j][k][l] = 0;
+		}
+	}}
+//	cout << "Done with SiPixelActionExecutorPhase1::getData" << endl;
+}
+
+//=============================================================================================================
+
+void SiPixelActionExecutorPhase1::prephistosB(MonitorElement* me[NLayer], DQMStore *bei, const Double_t map[][NLev2][NLev3][NLev4],std::string name, Double_t min, Double_t max){
+	// cout << "Starting with SiPixelActionExecutorPhase1::prephistosB" << endl;
+	std::string part[] = { "Layer_1", "Layer_2", "Layer_3"};
+	std::string path = bei->pwd();
+	for (Int_t i = 0; i < NLayer; i++)
+	{
+		std::string fullpath = path + "/" + "TRKMAP_" + name + "_" + part[i];
+		MonitorElement* temp = bei->get(fullpath);
+		if(temp)
+			me[i] = temp;
+		else
+			cout << "Problem: " << fullpath << endl;
+	}
+	
+	for(Int_t p = 0 ; p < NLayer ; p++){
+		for(Int_t b = 0 ; b < (10 + 6 * p); b++)
+			for(Int_t i = 0 ; i < NModuleB ; i++){
+				me[p]->getTH2F()->SetBinContent(b + 1, i + 1, map[0][p][b][i]);
+				me[p]->getTH2F()->SetBinContent(b + 1, i + 1 + NModuleB, map[1][p][b][i]);
+				me[p]->getTH2F()->SetBinContent(b + 1 + 10 + 6 * p, i + 1, map[2][p][b][i]);
+				me[p]->getTH2F()->SetBinContent(b + 1 + 10 + 6 * p, i + 1 + NModuleB, map[3][p][b][i]);
+			}
+		me[p]->getTH2F()->SetMinimum(min);
+		me[p]->getTH2F()->SetMaximum(max);
+	}
+	// cout << "Done with SiPixelActionExecutorPhase1::prephistosB" << endl;
+}
+
+//=============================================================================================================
+
+void SiPixelActionExecutorPhase1::prephistosE(MonitorElement* me[NCyl], DQMStore *bei, const Double_t map[][NLev2][NLev3][NLev4], std::string name, Double_t min, Double_t max){
+	// cout << "Starting with SiPixelActionExecutorPhase1::prephistosE" << endl;
+	std::string part[] = { "Disc_1_M", "Disc_2_M", "Disc_1_P", "Disc_2_P" };
+	std::string path = bei->pwd();
+	for (Int_t i = 0; i < NCyl; i++)
+	{
+		std::string fullpath = path + "/" + "TRKMAP_" + name + "_" + part[i];
+		MonitorElement* temp = bei->get(fullpath);
+		if(temp)
+		{
+			me[i] = temp;
+			me[i]->getTH2F()->SetMinimum(min);
+			me[i]->getTH2F()->SetMaximum(max);
+		}
+		else
+			cout << "Problem: " << fullpath << endl;
+	}
+
+	for(Int_t c = 0 ; c < NCyl ; c += 2)
+		for(Int_t d = 0 ; d < NDisk ; d++)
+			for(Int_t b = 0 ; b < NBlade ; b++){
+				me[c + d]->getTH2F()->SetBinContent(b + 1, 1, map[c][d][b][0]);
+				me[c + d]->getTH2F()->SetBinContent(b + 1, 2, map[c][d][b][4]);
+				me[c + d]->getTH2F()->SetBinContent(b + 1, 3, map[c][d][b][1]);
+				me[c + d]->getTH2F()->SetBinContent(b + 1, 4, map[c][d][b][5]);
+				me[c + d]->getTH2F()->SetBinContent(b + 1, 5, map[c][d][b][2]);
+				me[c + d]->getTH2F()->SetBinContent(b + 1, 6, map[c][d][b][6]);
+				me[c + d]->getTH2F()->SetBinContent(b + 1, 7, map[c][d][b][3]);
+				
+				me[c + d]->getTH2F()->SetBinContent(2 * NBlade - b, 1, map[c + 1][d][b][0]);
+				me[c + d]->getTH2F()->SetBinContent(2 * NBlade - b, 2, map[c + 1][d][b][4]);
+				me[c + d]->getTH2F()->SetBinContent(2 * NBlade - b, 3, map[c + 1][d][b][1]);
+				me[c + d]->getTH2F()->SetBinContent(2 * NBlade - b, 4, map[c + 1][d][b][5]);
+				me[c + d]->getTH2F()->SetBinContent(2 * NBlade - b, 5, map[c + 1][d][b][2]);
+				me[c + d]->getTH2F()->SetBinContent(2 * NBlade - b, 6, map[c + 1][d][b][6]);
+				me[c + d]->getTH2F()->SetBinContent(2 * NBlade - b, 7, map[c + 1][d][b][3]);
+			}
+	// cout << "Done with SiPixelActionExecutorPhase1::prephistosE" << endl;
+}
+
+
+//=============================================================================================================
+Double_t SiPixelActionExecutorPhase1::mapMin(const Double_t map[][NLev2][NLev3][NLev4], bool isBarrel){
+	
+	Double_t min = map[0][0][0][0];
+	
+	for(Int_t p = 0 ; p < NLev1 ; p++)
+		for(Int_t d = 0 ; d < (isBarrel?3:2) ; d++)
+			for(Int_t b = 0 ; b < (isBarrel?(d*6+10):12) ; b++)
+				for(Int_t i = 0 ; i < (isBarrel?4:7); i++){
+					if(map[p][d][b][i] < min)
+						min = map[p][d][b][i];
+				}
+	// cout << "Done with SiPixelActionExecutorPhase1::mapMin" << endl;
+	return min;
+}
+
+//=============================================================================================================
+
+Double_t SiPixelActionExecutorPhase1::mapMax(const Double_t map[][NLev2][NLev3][NLev4], bool isBarrel){
+	
+	Double_t max = map[0][0][0][0];
+	
+	for(Int_t p = 0 ; p < NLev1 ; p++)
+		for(Int_t d = 0 ; d < (isBarrel?3:2); d++)
+			for(Int_t b = 0 ; b < (isBarrel?(d*6+10):12); b++)
+				for(Int_t i = 0 ; i < (isBarrel?4:7); i++)
+					if(map[p][d][b][i] > max)
+						max = map[p][d][b][i];
+	// cout << "Done with SiPixelActionExecutorPhase1::mapMax" << endl;
+	return max;
+}
+
+
+//=============================================================================================================
+
+//
+// -- Setup Quality Tests 
+//
+void SiPixelActionExecutorPhase1::setupQTests(DQMStore * bei) {
+  //printing cout<<"Entering SiPixelActionExecutorPhase1::setupQTests: "<<endl;
+	
+  bei->cd();
+  bei->cd("Pixel");
+	
+  string localPath;
+  if(offlineXMLfile_) localPath = string("DQM/SiPixelMonitorClient/test/sipixel_tier0_qualitytest.xml");
+  else localPath = string("DQM/SiPixelMonitorClient/test/sipixel_qualitytest_config.xml");
+  if(!qtHandler_){
+    qtHandler_ = new QTestHandle();
+  }
+  if(!qtHandler_->configureTests(edm::FileInPath(localPath).fullPath(),bei)){
+    qtHandler_->attachTests(bei,false);
+    bei->cd();
+  }else{
+    cout << " Problem setting up quality tests "<<endl;
+  }
+	
+  //printing cout<<" leaving SiPixelActionExecutorPhase1::setupQTests. "<<endl;
+}
+//=============================================================================================================
+//
+// -- Check Status of Quality Tests
+//
+void SiPixelActionExecutorPhase1::checkQTestResults(DQMStore * bei) {
+  //printing cout<<"Entering SiPixelActionExecutorPhase1::checkQTestResults..."<<endl;
+	
+  int messageCounter=0;
+  string currDir = bei->pwd();
+  vector<string> contentVec;
+  bei->getContents(contentVec);
+  configParser_->getCalibType(calib_type_);
+  //  cout << calib_type_ << endl;
+  configParser_->getMessageLimitForQTests(message_limit_);
+  for (vector<string>::iterator it = contentVec.begin();
+       it != contentVec.end(); it++) {
+    vector<string> contents;
+    int nval = SiPixelUtility::getMEList((*it), contents);
+    if (nval == 0) continue;
+    for (vector<string>::const_iterator im = contents.begin();
+	 im != contents.end(); im++) {
+			
+      MonitorElement * me = bei->get((*im));
+      if (me) {
+	me->runQTests();
+	// get all warnings associated with me
+	vector<QReport*> warnings = me->getQWarnings();
+	for(vector<QReport *>::const_iterator wi = warnings.begin();
+	    wi != warnings.end(); ++wi) {
+	  messageCounter++;
+	  if(messageCounter<message_limit_) {
+	    //edm::LogWarning("SiPixelQualityTester::checkTestResults") << 
+	    //  " *** Warning for " << me->getName() << 
+	    //  "," << (*wi)->getMessage() << "\n";
+						
+	    edm::LogWarning("SiPixelActionExecutorPhase1::checkQTestResults") <<  " *** Warning for " << me->getName() << "," 
+									<< (*wi)->getMessage() << " " << me->getMean() 
+									<< " " << me->getRMS() << me->hasWarning() 
+									<< endl;
+	  }
+	}
+	warnings=vector<QReport*>();
+	// get all errors associated with me
+	vector<QReport *> errors = me->getQErrors();
+	for(vector<QReport *>::const_iterator ei = errors.begin();
+	    ei != errors.end(); ++ei) {
+					
+	  float empty_mean = me->getMean();
+	  float empty_rms = me->getRMS();
+	  if((empty_mean != 0 && empty_rms != 0) || (calib_type_ == 0)){
+	    messageCounter++;
+	    if(messageCounter<=message_limit_) {
+	      //edm::LogError("SiPixelQualityTester::checkTestResults") << 
+	      //  " *** Error for " << me->getName() << 
+	      //  "," << (*ei)->getMessage() << "\n";
+							
+	      edm::LogWarning("SiPixelActionExecutorPhase1::checkQTestResults")  <<   " *** Error for " << me->getName() << ","
+									   << (*ei)->getMessage() << " " << me->getMean() 
+									   << " " << me->getRMS() 
+									   << endl;
+	    }
+	  }
+	}
+	errors=vector<QReport*>();
+      }
+      me=0;
+    }
+    nval=int(); contents=vector<string>();
+  }
+  LogDebug("SiPixelActionExecutorPhase1::checkQTestResults") <<"messageCounter: "<<messageCounter<<" , message_limit: "<<message_limit_<<endl;
+  //  if (messageCounter>=message_limit_)
+  //    edm::LogWarning("SiPixelActionExecutorPhase1::checkQTestResults") << "WARNING: too many QTest failures! Giving up after "<<message_limit_<<" messages."<<endl;
+  contentVec=vector<string>(); currDir=string(); messageCounter=int();
+  //printing cout<<"...leaving SiPixelActionExecutorPhase1::checkQTestResults!"<<endl;
+}
+
+//=============================================================================================================
+void SiPixelActionExecutorPhase1::createLayout(DQMStore * bei){
+  if (configWriter_ == 0) {
+    configWriter_ = new SiPixelConfigWriter();
+    if (!configWriter_->init()) return;
+  }
+  string currDir = bei->pwd();   
+  if (currDir.find("Layer") != string::npos) {
+    string name = "Default";
+    configWriter_->createLayout(name);
+    configWriter_->createRow();
+    fillLayout(bei);
+  } else {
+    vector<string> subdirs = bei->getSubdirs();
+    for (vector<string>::const_iterator it = subdirs.begin();
+	 it != subdirs.end(); it++) {
+      bei->cd(*it);
+      createLayout(bei);
+      bei->goUp();
+    }
+  }  
+}
+
+//=============================================================================================================
+void SiPixelActionExecutorPhase1::fillLayout(DQMStore * bei){
+	
+  static int icount = 0;
+  string currDir = bei->pwd();
+  if (currDir.find("Ladder_") != string::npos) {
+		
+    vector<string> contents = bei->getMEs(); 
+		
+    for (vector<string>::const_iterator im = contents.begin();
+	 im != contents.end(); im++) {
+      if ((*im).find("Clusters") != string::npos) {
+	icount++;
+	if (icount != 0 && icount%6 == 0) {
+	  configWriter_->createRow();
+	}
+	ostringstream full_path;
+	full_path << "test/" << currDir << "/" << *im ;
+	string element = "monitorable";
+	string element_name = full_path.str();     
+	configWriter_->createColumn(element, element_name);
+      }
+    }
+  } else {
+    vector<string> subdirs = bei->getSubdirs();
+    for (vector<string>::const_iterator it = subdirs.begin();
+	 it != subdirs.end(); it++) {
+      bei->cd(*it);
+      fillLayout(bei);
+      bei->goUp();
+    }
+  }
+}
+
+//=============================================================================================================
+//
+// -- Get TkMap ME names
+//
+int SiPixelActionExecutorPhase1::getTkMapMENames(std::vector<std::string>& names) {
+  if (tkMapMENames.size() == 0) return 0;
+  for (vector<string>::iterator it = tkMapMENames.begin();
+       it != tkMapMENames.end(); it++) {
+    names.push_back(*it) ;
+  }
+  return names.size();
+}
+
+//=============================================================================================================
+///// Dump Module paths and IDs on screen:
+void SiPixelActionExecutorPhase1::dumpModIds(DQMStore * bei, edm::EventSetup const& eSetup){
+  //printing cout<<"Going to dump module IDs now!"<<endl;
+  bei->cd();
+  dumpBarrelModIds(bei,eSetup);
+  bei->cd();
+  dumpEndcapModIds(bei,eSetup);
+  bei->cd();
+  //printing cout<<"Done dumping module IDs!"<<endl;
+}
+
+
+//=============================================================================================================
+void SiPixelActionExecutorPhase1::dumpBarrelModIds(DQMStore * bei, edm::EventSetup const& eSetup){
+  string currDir = bei->pwd();
+  string dir_name = "Ladder_";
+  eSetup.get<SiPixelFedCablingMapRcd>().get(theCablingMap);
+  int fedId=-1; int linkId=-1;
+  if (currDir.find(dir_name) != string::npos)  {
+    vector<string> subdirs = bei->getSubdirs();
+    for (vector<string>::const_iterator it = subdirs.begin();
+	 it != subdirs.end(); it++) {
+      if ( (*it).find("Module_") == string::npos) continue;
+      bei->cd(*it);
+      ndet_++;
+      // long version:
+      //cout<<"Ndet: "<<ndet_<<"  ,  Module: "<<bei->pwd();  
+      // short version:
+      cout<<bei->pwd();  
+      vector<string> contents = bei->getMEs(); 
+      bool first_me = false;
+      int detId = -999;
+      for (vector<string>::const_iterator im = contents.begin();
+	   im != contents.end(); im++) {
+	if(first_me) break;
+	string mEName = (*im);
+	string detIdString = mEName.substr((mEName.find_last_of("_"))+1,9);
+	std::istringstream isst;
+	isst.str(detIdString);
+	if(mEName.find("_3")!=string::npos) isst>>detId;
+      }
+      bei->goUp();
+      // long version:
+      //cout<<"  , detector ID: "<<detId;
+      // short version:
+      cout<<" "<<detId;
+      for(int fedid=0; fedid<=40; ++fedid){
+        SiPixelFrameConverter converter(theCablingMap.product(),fedid);
+        uint32_t newDetId = detId;
+        if(converter.hasDetUnit(newDetId)){
+          fedId=fedid;
+          break;   
+        }
+      }
+      if(fedId==-1) continue; 
+      sipixelobjects::ElectronicIndex cabling; 
+      SiPixelFrameConverter formatter(theCablingMap.product(),fedId);
+      assert(detId >= 0);
+      sipixelobjects::DetectorIndex detector = {static_cast<unsigned int>(detId), 1, 1};	   
+      formatter.toCabling(cabling,detector);
+      linkId = cabling.link;
+      // long version:
+      //cout<<"  , FED ID: "<<fedId<<"  , Link ID: "<<linkId<<endl;
+      // short version:
+      cout<<" "<<fedId<<" "<<linkId<<endl;
+    }
+  } else {  
+    vector<string> subdirs = bei->getSubdirs();
+    for (vector<string>::const_iterator it = subdirs.begin();
+	 it != subdirs.end(); it++) {
+      if((*it).find("Endcap")!=string::npos) continue;
+      bei->cd(*it);
+      dumpBarrelModIds(bei,eSetup);
+      bei->goUp();
+    }
+  }
+}
+
+//=============================================================================================================
+void SiPixelActionExecutorPhase1::dumpEndcapModIds(DQMStore * bei, edm::EventSetup const& eSetup){
+  string currDir = bei->pwd();
+  string dir_name = "Panel_";
+  eSetup.get<SiPixelFedCablingMapRcd>().get(theCablingMap);
+  int fedId=-1; int linkId=-1;
+  if (currDir.find(dir_name) != string::npos)  {
+    vector<string> subdirs = bei->getSubdirs();
+    for (vector<string>::const_iterator it = subdirs.begin();
+	 it != subdirs.end(); it++) {
+      if ( (*it).find("Module_") == string::npos) continue;
+      bei->cd(*it);
+      ndet_++;
+      // long version:
+      //cout<<"Ndet: "<<ndet_<<"  ,  Module: "<<bei->pwd();  
+      // short version:
+      cout<<bei->pwd();  
+      vector<string> contents = bei->getMEs(); 
+      bool first_me = false;
+      int detId = -999;
+      for (vector<string>::const_iterator im = contents.begin();
+	   im != contents.end(); im++) {
+	if(first_me) break;
+	string mEName = (*im);
+	string detIdString = mEName.substr((mEName.find_last_of("_"))+1,9);
+	std::istringstream isst;
+	isst.str(detIdString);
+	if(mEName.find("_3")!=string::npos) isst>>detId;
+      }
+      bei->goUp();
+      // long version:
+      //cout<<"  , detector ID: "<<detId;
+      // short version:
+      cout<<" "<<detId;
+      for(int fedid=0; fedid<=40; ++fedid){
+        SiPixelFrameConverter converter(theCablingMap.product(),fedid);
+        uint32_t newDetId = detId;
+        if(converter.hasDetUnit(newDetId)){
+          fedId=fedid;
+          break;   
+        }
+      }
+      if(fedId==-1) continue; 
+      sipixelobjects::ElectronicIndex cabling; 
+      SiPixelFrameConverter formatter(theCablingMap.product(),fedId);
+      assert(detId >= 0);
+      sipixelobjects::DetectorIndex detector = {static_cast<unsigned int>(detId), 1, 1};	   
+      formatter.toCabling(cabling,detector);
+      linkId = cabling.link;
+      // long version:
+      //cout<<"  , FED ID: "<<fedId<<"  , Link ID: "<<linkId<<endl;
+      // short version:
+      cout<<" "<<fedId<<" "<<linkId<<endl;
+    }
+  } else {  
+    vector<string> subdirs = bei->getSubdirs();
+    for (vector<string>::const_iterator it = subdirs.begin();
+	 it != subdirs.end(); it++) {
+      if((bei->pwd()).find("Barrel")!=string::npos) bei->goUp();
+      bei->cd((*it));
+      if((*it).find("Barrel")!=string::npos) continue;
+      dumpEndcapModIds(bei,eSetup);
+      bei->goUp();
+    }
+  }
+	
+}
+
+//=============================================================================================================
+///// Dump Module paths and IDs on screen:
+void SiPixelActionExecutorPhase1::dumpRefValues(DQMStore * bei, edm::EventSetup const& eSetup){
+  //printing cout<<"Going to dump module IDs now!"<<endl;
+  bei->cd();
+  dumpBarrelRefValues(bei,eSetup);
+  bei->cd();
+  dumpEndcapRefValues(bei,eSetup);
+  bei->cd();
+  //printing cout<<"Done dumping module IDs!"<<endl;
+}
+
+
+//=============================================================================================================
+void SiPixelActionExecutorPhase1::dumpBarrelRefValues(DQMStore * bei, edm::EventSetup const& eSetup){
+  MonitorElement* me;
+  me = bei->get("Pixel/Barrel/SUMDIG_adc_Barrel");
+  if(me){
+    std::cout<<"SUMDIG_adc_Barrel: "<<std::endl;
+    for(int i=1; i!=769; i++) std::cout<<i<<" "<<me->getBinContent(i)<<std::endl;
+  }
+  me = bei->get("Pixel/Barrel/SUMDIG_ndigis_Barrel");
+  if(me){
+    std::cout<<"SUMDIG_ndigis_Barrel: "<<std::endl;
+    for(int i=1; i!=769; i++) std::cout<<i<<" "<<me->getBinContent(i)<<std::endl;
+  }
+  me = bei->get("Pixel/Barrel/SUMCLU_charge_Barrel");
+  if(me){
+    std::cout<<"SUMCLU_charge_Barrel: "<<std::endl;
+    for(int i=1; i!=769; i++) std::cout<<i<<" "<<me->getBinContent(i)<<std::endl;
+  }
+  me = bei->get("Pixel/Barrel/SUMCLU_nclusters_Barrel");
+  if(me){
+    std::cout<<"SUMCLU_nclusters_Barrel: "<<std::endl;
+    for(int i=1; i!=769; i++) std::cout<<i<<" "<<me->getBinContent(i)<<std::endl;
+  }
+  me = bei->get("Pixel/Barrel/SUMCLU_size_Barrel");
+  if(me){
+    std::cout<<"SUMCLU_size_Barrel: "<<std::endl;
+    for(int i=1; i!=769; i++) std::cout<<i<<" "<<me->getBinContent(i)<<std::endl;
+  }
+}
+
+//=============================================================================================================
+void SiPixelActionExecutorPhase1::dumpEndcapRefValues(DQMStore * bei, edm::EventSetup const& eSetup){
+  MonitorElement* me;
+  me = bei->get("Pixel/Endcap/SUMDIG_adc_Endcap");
+  if(me){
+    std::cout<<"SUMDIG_adc_Endcap: "<<std::endl;
+    for(int i=1; i!=673; i++) std::cout<<i<<" "<<me->getBinContent(i)<<std::endl;
+  }
+  me = bei->get("Pixel/Endcap/SUMDIG_ndigis_Endcap");
+  if(me){
+    std::cout<<"SUMDIG_ndigis_Endcap: "<<std::endl;
+    for(int i=1; i!=673; i++) std::cout<<i<<" "<<me->getBinContent(i)<<std::endl;
+  }
+  me = bei->get("Pixel/Endcap/SUMCLU_charge_Endcap");
+  if(me){
+    std::cout<<"SUMCLU_charge_Endcap: "<<std::endl;
+    for(int i=1; i!=673; i++) std::cout<<i<<" "<<me->getBinContent(i)<<std::endl;
+  }
+  me = bei->get("Pixel/Endcap/SUMCLU_nclusters_Endcap");
+  if(me){
+    std::cout<<"SUMCLU_nclusters_Endcap: "<<std::endl;
+    for(int i=1; i!=673; i++) std::cout<<i<<" "<<me->getBinContent(i)<<std::endl;
+  }
+  me = bei->get("Pixel/Endcap/SUMCLU_size_Endcap");
+  if(me){
+    std::cout<<"SUMCLU_size_Endcap: "<<std::endl;
+    for(int i=1; i!=673; i++) std::cout<<i<<" "<<me->getBinContent(i)<<std::endl;
+  }
+}
+
+//=============================================================================================================
+
+void SiPixelActionExecutorPhase1::bookEfficiency(DQMStore * bei){
+  // Barrel
+  bei->cd();
+  bei->setCurrentFolder("Pixel/Barrel");
+  if(Tier0Flag_){
+    HitEfficiency_L1 = bei->book2D("HitEfficiency_L1","Hit Efficiency in Barrel_Layer1;z-side;Ladder",2,-1.,1.,12,-6.,6.);
+    HitEfficiency_L2 = bei->book2D("HitEfficiency_L2","Hit Efficiency in Barrel_Layer2;z-side;Ladder",2,-1.,1.,28,-14.,14.);
+    HitEfficiency_L3 = bei->book2D("HitEfficiency_L3","Hit Efficiency in Barrel_Layer3;z-side;Ladder",2,-1.,1.,44,-22.,22.);
+    HitEfficiency_L4 = bei->book2D("HitEfficiency_L4","Hit Efficiency in Barrel_Layer4;z-side;Ladder",2,-1.,1.,64,-32.,32.);
+  }else{
+    HitEfficiency_L1 = bei->book2D("HitEfficiency_L1","Hit Efficiency in Barrel_Layer1;Module;Ladder",8,-4.,4.,12,-6.,6.);
+    HitEfficiency_L2 = bei->book2D("HitEfficiency_L2","Hit Efficiency in Barrel_Layer2;Module;Ladder",8,-4.,4.,28,-14.,14.);
+    HitEfficiency_L3 = bei->book2D("HitEfficiency_L3","Hit Efficiency in Barrel_Layer3;Module;Ladder",8,-4.,4.,44,-22.,22.);
+    HitEfficiency_L4 = bei->book2D("HitEfficiency_L4","Hit Efficiency in Barrel_Layer4;Module;Ladder",8,-4.,4.,64,-32.,32.);
+  }
+  // Endcap
+  bei->cd();
+  bei->setCurrentFolder("Pixel/Endcap");
+  if(Tier0Flag_){
+    HitEfficiency_Dp1 = bei->book2D("HitEfficiency_Dp1","Hit Efficiency in Endcap_Disk_p1;Blades;",28,-17.,11.,1,0.,1.);
+    HitEfficiency_Dp2 = bei->book2D("HitEfficiency_Dp2","Hit Efficiency in Endcap_Disk_p2;Blades;",28,-17.,11.,1,0.,1.);
+    HitEfficiency_Dp3 = bei->book2D("HitEfficiency_Dp3","Hit Efficiency in Endcap_Disk_p3;Blades;",28,-17.,11.,1,0.,1.);
+    HitEfficiency_Dm1 = bei->book2D("HitEfficiency_Dm1","Hit Efficiency in Endcap_Disk_m1;Blades;",28,-17.,11.,1,0.,1.);
+    HitEfficiency_Dm2 = bei->book2D("HitEfficiency_Dm2","Hit Efficiency in Endcap_Disk_m2;Blades;",28,-17.,11.,1,0.,1.);
+    HitEfficiency_Dm3 = bei->book2D("HitEfficiency_Dm3","Hit Efficiency in Endcap_Disk_m3;Blades;",28,-17.,11.,1,0.,1.);
+  }else{
+    HitEfficiency_Dp1 = bei->book2D("HitEfficiency_Dp1","Hit Efficiency in Endcap_Disk_p1;Blades;Modules",28,-17.,11.,2,1.,3.);
+    HitEfficiency_Dp2 = bei->book2D("HitEfficiency_Dp2","Hit Efficiency in Endcap_Disk_p2;Blades;Modules",28,-17.,11.,2,1.,3.);
+    HitEfficiency_Dp3 = bei->book2D("HitEfficiency_Dp3","Hit Efficiency in Endcap_Disk_p3;Blades;Modules",28,-17.,11.,2,1.,3.);
+    HitEfficiency_Dm1 = bei->book2D("HitEfficiency_Dm1","Hit Efficiency in Endcap_Disk_m1;Blades;Modules",28,-17.,11.,2,1.,3.);
+    HitEfficiency_Dm2 = bei->book2D("HitEfficiency_Dm2","Hit Efficiency in Endcap_Disk_m2;Blades;Modules",28,-17.,11.,2,1.,3.);
+    HitEfficiency_Dm3 = bei->book2D("HitEfficiency_Dm3","Hit Efficiency in Endcap_Disk_m3;Blades;Modules",28,-17.,11.,2,1.,3.);
+  }
+}
+
+//=============================================================================================================
+
+void SiPixelActionExecutorPhase1::createEfficiency(DQMStore * bei){
+  //std::cout<<"entering SiPixelActionExecutorPhase1::createEfficiency..."<<std::endl;
+  bei->cd();
+  fillEfficiency(bei, true); // Barrel
+  bei->cd();
+  fillEfficiency(bei, false); // Endcap
+  bei->cd();
+  //std::cout<<"leaving SiPixelActionExecutorPhase1::createEfficiency..."<<std::endl;
+}
+
+//=============================================================================================================
+
+void SiPixelActionExecutorPhase1::fillEfficiency(DQMStore* bei, bool isbarrel){
+  //cout<<"entering SiPixelActionExecutorPhase1::fillEfficiency..."<<std::endl;
+  string currDir = bei->pwd();
+  string dname = currDir.substr(currDir.find_last_of("/")+1);
+  //cout<<"currDir= "<<currDir<< " , dname= "<<dname<<std::endl;
+  
+  if(Tier0Flag_){ // Offline	
+    if(isbarrel && dname.find("Ladder_")!=string::npos){ 
+      vector<string> meVec = bei->getMEs();
+      for (vector<string>::const_iterator it = meVec.begin(); it != meVec.end(); it++) {
+	string full_path = currDir + "/" + (*it);
+	if(full_path.find("missing_")!=string::npos){ // If we have missing hits ME
+	  MonitorElement * me = bei->get(full_path);
+	  if (!me) continue;
+	  float missingHits = me->getEntries();
+	  //if(currDir.find("Barrel/Shell_mI/Layer_1/Ladder_09F")!=string::npos) cout<<"missingHits= "<<missingHits<<endl;
+	  string new_path = full_path.replace(full_path.find("missing"),7,"valid");
+	  me = bei->get(new_path);
+	  if (!me) continue;
+	  float validHits = me->getEntries();
+	  //if(currDir.find("Barrel/Shell_mI/Layer_1/Ladder_09F")!=string::npos) cout<<"validHits= "<<validHits<<endl;
+	  float hitEfficiency = -1.;
+	  if(validHits + missingHits > 0.) hitEfficiency = validHits / (validHits + missingHits);
+	  //if(currDir.find("Barrel/Shell_mI/Layer_1/Ladder_09F")!=string::npos) cout<<"hitEfficiency= "<<hitEfficiency<<endl;
+	  int binx = 0; int biny = 0;
+	  if(currDir.find("Shell_m")!=string::npos){ binx = 1;}else{ binx = 2;}
+	  if(dname.find("01")!=string::npos){ biny = 1;}else if(dname.find("02")!=string::npos){ biny = 2;}
+	  else if(dname.find("03")!=string::npos){ biny = 3;}else if(dname.find("04")!=string::npos){ biny = 4;}
+	  else if(dname.find("05")!=string::npos){ biny = 5;}else if(dname.find("06")!=string::npos){ biny = 6;}
+	  else if(dname.find("07")!=string::npos){ biny = 7;}else if(dname.find("08")!=string::npos){ biny = 8;}
+	  else if(dname.find("09")!=string::npos){ biny = 9;}else if(dname.find("10")!=string::npos){ biny = 10;}
+	  else if(dname.find("11")!=string::npos){ biny = 11;}else if(dname.find("12")!=string::npos){ biny = 12;}
+	  else if(dname.find("13")!=string::npos){ biny = 13;}else if(dname.find("14")!=string::npos){ biny = 14;}
+	  else if(dname.find("15")!=string::npos){ biny = 15;}else if(dname.find("16")!=string::npos){ biny = 16;}
+	  else if(dname.find("17")!=string::npos){ biny = 17;}else if(dname.find("18")!=string::npos){ biny = 18;}
+	  else if(dname.find("19")!=string::npos){ biny = 19;}else if(dname.find("20")!=string::npos){ biny = 20;}
+	  else if(dname.find("21")!=string::npos){ biny = 21;}else if(dname.find("22")!=string::npos){ biny = 22;}
+	  else if(dname.find("23")!=string::npos){ biny = 23;}else if(dname.find("24")!=string::npos){ biny = 24;}
+	  else if(dname.find("25")!=string::npos){ biny = 25;}else if(dname.find("25")!=string::npos){ biny = 25;}
+	  else if(dname.find("26")!=string::npos){ biny = 26;}else if(dname.find("27")!=string::npos){ biny = 27;}
+	  else if(dname.find("28")!=string::npos){ biny = 28;}else if(dname.find("29")!=string::npos){ biny = 29;}
+	  else if(dname.find("30")!=string::npos){ biny = 30;}else if(dname.find("31")!=string::npos){ biny = 31;}
+	  else if(dname.find("32")!=string::npos){ biny = 32;}
+	  if(currDir.find("Shell_mO")!=string::npos || currDir.find("Shell_pO")!=string::npos){
+	    if(currDir.find("Layer_1")!=string::npos){ biny = biny + 6;}
+	    else if(currDir.find("Layer_2")!=string::npos){ biny = biny + 14;}
+	    else if(currDir.find("Layer_3")!=string::npos){ biny = biny + 22;}
+	    else if(currDir.find("Layer_4")!=string::npos){ biny = biny + 32;}
+	  }
+	  if(currDir.find("Layer_1")!=string::npos){
+	    HitEfficiency_L1 = bei->get("Pixel/Barrel/HitEfficiency_L1");
+	    if(HitEfficiency_L1) HitEfficiency_L1->setBinContent(binx, biny,(float)hitEfficiency);
+	    //if(currDir.find("Barrel/Shell_mI/Layer_1/Ladder_09F")!=string::npos) cout<<"setting bin ("<<binx<<","<<biny<<") with "<<(float)hitEfficiency<<endl;
+	  }else if(currDir.find("Layer_2")!=string::npos){
+	    HitEfficiency_L2 = bei->get("Pixel/Barrel/HitEfficiency_L2");
+	    if(HitEfficiency_L2) HitEfficiency_L2->setBinContent(binx, biny,(float)hitEfficiency);
+	  }else if(currDir.find("Layer_3")!=string::npos){
+	    HitEfficiency_L3 = bei->get("Pixel/Barrel/HitEfficiency_L3");
+	    if(HitEfficiency_L3) HitEfficiency_L3->setBinContent(binx, biny,(float)hitEfficiency);
+	  }else if(currDir.find("Layer_4")!=string::npos){
+	    HitEfficiency_L4 = bei->get("Pixel/Barrel/HitEfficiency_L4");
+	    if(HitEfficiency_L4) HitEfficiency_L4->setBinContent(binx, biny,(float)hitEfficiency);
+	  }
+	}
+      }
+    }else if(!isbarrel && dname.find("Blade_")!=string::npos){ 
+      vector<string> meVec = bei->getMEs();
+      for (vector<string>::const_iterator it = meVec.begin(); it != meVec.end(); it++) {
+        string full_path = currDir + "/" + (*it);
+        if(full_path.find("missing_")!=string::npos){ // If we have missing hits ME
+	  MonitorElement * me = bei->get(full_path);
+	  if (!me) continue;
+	  float missingHits = me->getEntries();
+	  string new_path = full_path.replace(full_path.find("missing"),7,"valid");
+	  me = bei->get(new_path);
+	  if (!me) continue;
+	  float validHits = me->getEntries();
+	  float hitEfficiency = -1.;
+	  if(validHits + missingHits > 0.) hitEfficiency = validHits / (validHits + missingHits);
+	  int binx = 0; int biny = 1;
+	  if(currDir.find("01")!=string::npos){ binx = 1;}else if(currDir.find("02")!=string::npos){ binx = 2;}
+	  else if(currDir.find("03")!=string::npos){ binx = 3;}else if(currDir.find("04")!=string::npos){ binx = 4;}
+	  else if(currDir.find("05")!=string::npos){ binx = 5;}else if(currDir.find("06")!=string::npos){ binx = 6;}
+	  else if(currDir.find("07")!=string::npos){ binx = 7;}else if(currDir.find("08")!=string::npos){ binx = 8;}
+	  else if(currDir.find("09")!=string::npos){ binx = 9;}else if(currDir.find("10")!=string::npos){ binx = 10;}
+	  else if(currDir.find("11")!=string::npos){ binx = 11;}else if(currDir.find("12")!=string::npos){ binx = 12;}
+          else if(currDir.find("13")!=string::npos){ binx = 13;}else if(currDir.find("14")!=string::npos){ binx = 14;}
+          else if(currDir.find("15")!=string::npos){ binx = 15;}else if(currDir.find("16")!=string::npos){ binx = 16;}
+          else if(currDir.find("17")!=string::npos){ binx = 17;}
+	  if(currDir.find("HalfCylinder_mI")!=string::npos || currDir.find("HalfCylinder_pI")!=string::npos){ binx = binx + 12;}
+	  else{ 
+	    if(binx==1) binx = 17;
+	    else if(binx==2) binx = 16;
+	    else if(binx==3) binx = 15;
+	    else if(binx==4) binx = 14;
+	    else if(binx==5) binx = 13;
+	    else if(binx==6) binx = 12;
+	    else if(binx==7) binx = 11;
+	    else if(binx==8) binx = 10;
+	    else if(binx==9) binx = 9;
+	    else if(binx==10) binx = 8;
+	    else if(binx==11) binx = 7;
+	    else if(binx==12) binx = 6;
+            else if(binx==13) binx = 5;
+	    else if(binx==14) binx = 4;
+	    else if(binx==15) binx = 3;
+	    else if(binx==16) binx = 2;
+	    else if(binx==17) binx = 1;
+	  }
+	  if(currDir.find("Disk_1")!=string::npos && currDir.find("HalfCylinder_m")!=string::npos){
+	    HitEfficiency_Dm1 = bei->get("Pixel/Endcap/HitEfficiency_Dm1");
+	    if(HitEfficiency_Dm1) HitEfficiency_Dm1->setBinContent(binx, biny, (float)hitEfficiency);
+	  }else if(currDir.find("Disk_2")!=string::npos && currDir.find("HalfCylinder_m")!=string::npos){
+	    HitEfficiency_Dm2 = bei->get("Pixel/Endcap/HitEfficiency_Dm2");
+	    if(HitEfficiency_Dm2) HitEfficiency_Dm2->setBinContent(binx, biny, (float)hitEfficiency);
+	  }else if(currDir.find("Disk_3")!=string::npos && currDir.find("HalfCylinder_m")!=string::npos){
+	    HitEfficiency_Dm3 = bei->get("Pixel/Endcap/HitEfficiency_Dm3");
+	    if(HitEfficiency_Dm3) HitEfficiency_Dm3->setBinContent(binx, biny, (float)hitEfficiency);
+	  }else if(currDir.find("Disk_1")!=string::npos && currDir.find("HalfCylinder_p")!=string::npos){
+	    HitEfficiency_Dp1 = bei->get("Pixel/Endcap/HitEfficiency_Dp1");
+	    if(HitEfficiency_Dp1) HitEfficiency_Dp1->setBinContent(binx, biny, (float)hitEfficiency);
+	  }else if(currDir.find("Disk_2")!=string::npos && currDir.find("HalfCylinder_p")!=string::npos){
+	    HitEfficiency_Dp2 = bei->get("Pixel/Endcap/HitEfficiency_Dp2");
+	    if(HitEfficiency_Dp2) HitEfficiency_Dp2->setBinContent(binx, biny, (float)hitEfficiency);
+          }else if(currDir.find("Disk_3")!=string::npos && currDir.find("HalfCylinder_p")!=string::npos){
+	    HitEfficiency_Dp3 = bei->get("Pixel/Endcap/HitEfficiency_Dp3");
+	    if(HitEfficiency_Dp3) HitEfficiency_Dp3->setBinContent(binx, biny, (float)hitEfficiency);
+          }
+	  //std::cout<<"EFFI: "<<currDir<<" , x: "<<binx<<" , y: "<<biny<<std::endl;
+	}
+      } 
+    }else{  
+      //cout<<"finding subdirs now"<<std::endl;
+      vector<string> subdirs = bei->getSubdirs();
+      for (vector<string>::const_iterator it = subdirs.begin(); it != subdirs.end(); it++) {
+        bei->cd(*it);
+        //cout<<"now I am in "<<bei->pwd()<<std::endl;
+        if(*it != "Pixel" && ((isbarrel && (*it).find("Barrel")==string::npos) || (!isbarrel && (*it).find("Endcap")==string::npos))) continue;
+        //cout<<"calling myself again "<<std::endl;
+        fillEfficiency(bei, isbarrel);
+        bei->goUp();
+      }
+    }
+  }else{ // Online
+    if(dname.find("Module_")!=string::npos){ 
+      vector<string> meVec = bei->getMEs();
+      for (vector<string>::const_iterator it = meVec.begin(); it != meVec.end(); it++) {
+        string full_path = currDir + "/" + (*it);
+        if(full_path.find("missing_")!=string::npos){ // If we have missing hits ME
+	  MonitorElement * me = bei->get(full_path);
+	  if (!me) continue;
+	  float missingHits = me->getEntries();
+	  string new_path = full_path.replace(full_path.find("missing"),7,"valid");
+	  me = bei->get(new_path);
+	  if (!me) continue;
+	  float validHits = me->getEntries();
+	  float hitEfficiency = -1.;
+	  if(validHits + missingHits > 0.) hitEfficiency = validHits / (validHits + missingHits);
+	  int binx = 0; int biny = 0;
+	  if(isbarrel){
+	    if(currDir.find("Shell_m")!=string::npos){
+	      if(currDir.find("Module_4")!=string::npos){ binx = 1;}else if(currDir.find("Module_3")!=string::npos){ binx = 2;}
+	      if(currDir.find("Module_2")!=string::npos){ binx = 3;}else if(currDir.find("Module_1")!=string::npos){ binx = 4;}
+	    }else if(currDir.find("Shell_p")!=string::npos){
+	      if(currDir.find("Module_1")!=string::npos){ binx = 5;}else if(currDir.find("Module_2")!=string::npos){ binx = 6;}
+	      if(currDir.find("Module_3")!=string::npos){ binx = 7;}else if(currDir.find("Module_4")!=string::npos){ binx = 8;}
+	    }
+	    if(currDir.find("01")!=string::npos){ biny = 1;}else if(currDir.find("02")!=string::npos){ biny = 2;}
+	    else if(currDir.find("03")!=string::npos){ biny = 3;}else if(currDir.find("04")!=string::npos){ biny = 4;}
+	    else if(currDir.find("05")!=string::npos){ biny = 5;}else if(currDir.find("06")!=string::npos){ biny = 6;}
+	    else if(currDir.find("07")!=string::npos){ biny = 7;}else if(currDir.find("08")!=string::npos){ biny = 8;}
+	    else if(currDir.find("09")!=string::npos){ biny = 9;}else if(currDir.find("10")!=string::npos){ biny = 10;}
+	    else if(currDir.find("11")!=string::npos){ biny = 11;}else if(currDir.find("12")!=string::npos){ biny = 12;}
+	    else if(currDir.find("13")!=string::npos){ biny = 13;}else if(currDir.find("14")!=string::npos){ biny = 14;}
+	    else if(currDir.find("15")!=string::npos){ biny = 15;}else if(currDir.find("16")!=string::npos){ biny = 16;}
+	    else if(currDir.find("17")!=string::npos){ biny = 17;}else if(currDir.find("18")!=string::npos){ biny = 18;}
+	    else if(currDir.find("19")!=string::npos){ biny = 19;}else if(currDir.find("20")!=string::npos){ biny = 20;}
+	    else if(currDir.find("21")!=string::npos){ biny = 21;}else if(currDir.find("22")!=string::npos){ biny = 22;}
+	    else if(currDir.find("23")!=string::npos){ biny = 23;}else if(currDir.find("24")!=string::npos){ biny = 24;}
+	    else if(currDir.find("25")!=string::npos){ biny = 25;}else if(currDir.find("25")!=string::npos){ biny = 25;}
+	    else if(currDir.find("26")!=string::npos){ biny = 26;}else if(currDir.find("27")!=string::npos){ biny = 27;}
+	    else if(currDir.find("28")!=string::npos){ biny = 28;}else if(currDir.find("29")!=string::npos){ biny = 29;}
+	    else if(currDir.find("30")!=string::npos){ biny = 30;}else if(currDir.find("31")!=string::npos){ biny = 31;}
+	    else if(currDir.find("32")!=string::npos){ biny = 32;}
+	    if(currDir.find("Shell_mO")!=string::npos || currDir.find("Shell_pO")!=string::npos){
+	      if(currDir.find("Layer_1")!=string::npos){ biny = biny + 6;}
+	      else if(currDir.find("Layer_2")!=string::npos){ biny = biny + 14;}
+	      else if(currDir.find("Layer_3")!=string::npos){ biny = biny + 22;}
+	      else if(currDir.find("Layer_4")!=string::npos){ biny = biny + 32;}
+	    }
+	  }else{ //endcap
+	    if(currDir.find("01")!=string::npos){ binx = 1;}else if(currDir.find("02")!=string::npos){ binx = 2;}
+	    else if(currDir.find("03")!=string::npos){ binx = 3;}else if(currDir.find("04")!=string::npos){ binx = 4;}
+	    else if(currDir.find("05")!=string::npos){ binx = 5;}else if(currDir.find("06")!=string::npos){ binx = 6;}
+	    else if(currDir.find("07")!=string::npos){ binx = 7;}else if(currDir.find("08")!=string::npos){ binx = 8;}
+	    else if(currDir.find("09")!=string::npos){ binx = 9;}else if(currDir.find("10")!=string::npos){ binx = 10;}
+	    else if(currDir.find("11")!=string::npos){ binx = 11;}else if(currDir.find("12")!=string::npos){ binx = 12;}
+	    else if(currDir.find("13")!=string::npos){ binx = 13;}else if(currDir.find("14")!=string::npos){ binx = 14;}
+	    else if(currDir.find("15")!=string::npos){ binx = 15;}else if(currDir.find("16")!=string::npos){ binx = 16;}
+	    else if(currDir.find("17")!=string::npos){ binx = 17;}
+	    if(currDir.find("HalfCylinder_mO")!=string::npos || currDir.find("HalfCylinder_pO")!=string::npos){ binx = binx + 17;}
+	    if(currDir.find("Panel_1/Module_1")!=string::npos){ biny = 1;}else if(currDir.find("Panel_2/Module_1")!=string::npos){ biny = 2;}
+	  }
+	  
+	  if(currDir.find("Layer_1")!=string::npos){
+	    HitEfficiency_L1 = bei->get("Pixel/Barrel/HitEfficiency_L1");
+	    if(HitEfficiency_L1) HitEfficiency_L1->setBinContent(binx, biny,(float)hitEfficiency);
+	  }else if(currDir.find("Layer_2")!=string::npos){
+	    HitEfficiency_L2 = bei->get("Pixel/Barrel/HitEfficiency_L2");
+	    if(HitEfficiency_L2) HitEfficiency_L2->setBinContent(binx, biny,(float)hitEfficiency);
+	  }else if(currDir.find("Layer_3")!=string::npos){
+	    HitEfficiency_L3 = bei->get("Pixel/Barrel/HitEfficiency_L3");
+	    if(HitEfficiency_L3) HitEfficiency_L3->setBinContent(binx, biny,(float)hitEfficiency);
+	  }else if(currDir.find("Layer_4")!=string::npos){
+	    HitEfficiency_L4 = bei->get("Pixel/Barrel/HitEfficiency_L4");
+	    if(HitEfficiency_L4) HitEfficiency_L4->setBinContent(binx, biny,(float)hitEfficiency);
+	  }else if(currDir.find("Disk_1")!=string::npos && currDir.find("HalfCylinder_m")!=string::npos){
+	    HitEfficiency_Dm1 = bei->get("Pixel/Endcap/HitEfficiency_Dm1");
+	    if(HitEfficiency_Dm1) HitEfficiency_Dm1->setBinContent(binx, biny,(float)hitEfficiency);
+	  }else if(currDir.find("Disk_2")!=string::npos && currDir.find("HalfCylinder_m")!=string::npos){
+	    HitEfficiency_Dm2 = bei->get("Pixel/Endcap/HitEfficiency_Dm2");
+	    if(HitEfficiency_Dm2) HitEfficiency_Dm2->setBinContent(binx, biny,(float)hitEfficiency);
+	  }else if(currDir.find("Disk_3")!=string::npos && currDir.find("HalfCylinder_m")!=string::npos){
+	    HitEfficiency_Dm3 = bei->get("Pixel/Endcap/HitEfficiency_Dm3");
+	    if(HitEfficiency_Dm3) HitEfficiency_Dm3->setBinContent(binx, biny,(float)hitEfficiency);
+	  }else if(currDir.find("Disk_1")!=string::npos && currDir.find("HalfCylinder_p")!=string::npos){
+	    HitEfficiency_Dp1 = bei->get("Pixel/Endcap/HitEfficiency_Dp1");
+	    if(HitEfficiency_Dp1) HitEfficiency_Dp1->setBinContent(binx, biny,(float)hitEfficiency);
+	  }else if(currDir.find("Disk_2")!=string::npos && currDir.find("HalfCylinder_p")!=string::npos){
+	    HitEfficiency_Dp2 = bei->get("Pixel/Endcap/HitEfficiency_Dp2");
+	    if(HitEfficiency_Dp2) HitEfficiency_Dp2->setBinContent(binx, biny,(float)hitEfficiency);
+	  }else if(currDir.find("Disk_3")!=string::npos && currDir.find("HalfCylinder_p")!=string::npos){
+	    HitEfficiency_Dp3 = bei->get("Pixel/Endcap/HitEfficiency_Dp3");
+	    if(HitEfficiency_Dp3) HitEfficiency_Dp3->setBinContent(binx, biny,(float)hitEfficiency);
+          }
+        }
+      }
+    }else{  
+      //cout<<"finding subdirs now"<<std::endl;
+      vector<string> subdirs = bei->getSubdirs();
+      for (vector<string>::const_iterator it = subdirs.begin(); it != subdirs.end(); it++) {
+        bei->cd(*it);
+        //cout<<"now I am in "<<bei->pwd()<<std::endl;
+        if(*it != "Pixel" && ((isbarrel && (*it).find("Barrel")==string::npos) || (!isbarrel && (*it).find("Endcap")==string::npos))) continue;
+        //cout<<"calling myself again "<<std::endl;
+        fillEfficiency(bei, isbarrel);
+        bei->goUp();
+      }
+    }
+  } // end online/offline
+	
+  //cout<<"leaving SiPixelActionExecutorPhase1::fillEfficiency..."<<std::endl;
+	
+}

--- a/DQM/SiPixelMonitorClient/src/SiPixelEDAClient.cc
+++ b/DQM/SiPixelMonitorClient/src/SiPixelEDAClient.cc
@@ -70,7 +70,6 @@ SiPixelEDAClient::SiPixelEDAClient(const edm::ParameterSet& ps) {
   Tier0Flag_             = ps.getUntrackedParameter<bool>("Tier0Flag",false); //client
   doHitEfficiency_       = ps.getUntrackedParameter<bool>("DoHitEfficiency",true); //client
   inputSource_           = ps.getUntrackedParameter<string>("inputSource",  "source");
-  isUpgrade_             = ps.getUntrackedParameter<bool>("isUpgrade",false); //client
   
   if(!Tier0Flag_){
     string localPath = string("DQM/SiPixelMonitorClient/test/loader.html");
@@ -162,11 +161,11 @@ void SiPixelEDAClient::beginRun(Run const& run, edm::EventSetup const& eSetup) {
   // Setting up QTests:
 //  sipixelActionExecutor_->setupQTests(bei_);
   // Creating Summary Histos:
-  sipixelActionExecutor_->createSummary(bei_, isUpgrade_);
+  sipixelActionExecutor_->createSummary(bei_);
   // Booking Deviation Histos:
-  if(!Tier0Flag_) sipixelActionExecutor_->bookDeviations(bei_, isUpgrade_);
+  if(!Tier0Flag_) sipixelActionExecutor_->bookDeviations(bei_);
   // Booking Efficiency Histos:
-  if(doHitEfficiency_) sipixelActionExecutor_->bookEfficiency(bei_, isUpgrade_);
+  if(doHitEfficiency_) sipixelActionExecutor_->bookEfficiency(bei_);
   // Creating occupancy plots:
   sipixelActionExecutor_->bookOccupancyPlots(bei_, hiRes_);
   // Booking noisy pixel ME's:
@@ -252,7 +251,7 @@ void SiPixelEDAClient::endLuminosityBlock(edm::LuminosityBlock const& lumiSeg, e
     //sipixelWebInterface_->setActionFlag(SiPixelWebInterface::Summary);
     //sipixelWebInterface_->performAction();
      //cout << " Updating efficiency plots" << endl;
-    if(doHitEfficiency_) sipixelActionExecutor_->createEfficiency(bei_, isUpgrade_);
+    if(doHitEfficiency_) sipixelActionExecutor_->createEfficiency(bei_);
     //cout << " Checking QTest results " << endl;
     //sipixelWebInterface_->setActionFlag(SiPixelWebInterface::QTestResult);
     //sipixelWebInterface_->performAction();
@@ -292,9 +291,9 @@ void SiPixelEDAClient::endRun(edm::Run const& run, edm::EventSetup const& eSetup
     //cout << " Updating Summary " << endl;
     //sipixelWebInterface_->setActionFlag(SiPixelWebInterface::Summary);
     //sipixelWebInterface_->performAction();
-    sipixelActionExecutor_->createSummary(bei_, isUpgrade_);
+    sipixelActionExecutor_->createSummary(bei_);
      //cout << " Updating efficiency plots" << endl;
-    if(doHitEfficiency_) sipixelActionExecutor_->createEfficiency(bei_, isUpgrade_);
+    if(doHitEfficiency_) sipixelActionExecutor_->createEfficiency(bei_);
     //cout << " Checking QTest results " << endl;
     //sipixelWebInterface_->setActionFlag(SiPixelWebInterface::QTestResult);
     //sipixelWebInterface_->performAction();

--- a/DQM/SiPixelMonitorClient/src/SiPixelEDAClientPhase1.cc
+++ b/DQM/SiPixelMonitorClient/src/SiPixelEDAClientPhase1.cc
@@ -1,0 +1,363 @@
+#include "DQM/SiPixelMonitorClient/interface/SiPixelEDAClientPhase1.h"
+
+// Framework
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/GeometrySurface/interface/Surface.h"
+#include "DataFormats/SiPixelDetId/interface/PixelBarrelName.h"
+#include "DataFormats/SiPixelDetId/interface/PixelBarrelNameUpgrade.h"
+#include "DataFormats/SiPixelDetId/interface/PixelEndcapName.h"
+#include "DataFormats/SiPixelDetId/interface/PixelEndcapNameUpgrade.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+#include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
+#include "DataFormats/FEDRawData/interface/FEDRawData.h"
+#include "DataFormats/FEDRawData/interface/FEDNumbering.h"
+
+#include "CondFormats/SiPixelObjects/interface/DetectorIndex.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelFrameConverter.h"
+
+#include "Geometry/TrackerNumberingBuilder/interface/GeometricDet.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
+#include "Geometry/CommonTopologies/interface/PixelTopology.h"
+
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+
+#include "DQM/SiPixelMonitorClient/interface/SiPixelActionExecutorPhase1.h"
+#include "DQM/SiPixelMonitorClient/interface/SiPixelInformationExtractorPhase1.h"
+#include "DQM/SiPixelMonitorClient/interface/SiPixelDataQualityPhase1.h"
+#include "DQM/SiPixelMonitorClient/interface/SiPixelUtility.h"
+
+#include <iostream>
+#include <iomanip>
+#include <stdio.h>
+#include <string>
+#include <sstream>
+#include <math.h>
+
+#define BUF_SIZE 256
+
+using namespace edm;
+using namespace std;
+//
+// -- Constructor
+//
+SiPixelEDAClientPhase1::SiPixelEDAClientPhase1(const edm::ParameterSet& ps) {
+// cout<<"Entering  SiPixelEDAClientPhase1::SiPixelEDAClientPhase1: "<<endl;
+ 
+  edm::LogInfo("SiPixelEDAClientPhase1") <<  " Creating SiPixelEDAClientPhase1 " << "\n" ;
+  
+  bei_ = Service<DQMStore>().operator->();
+
+  summaryFrequency_      = ps.getUntrackedParameter<int>("SummaryCreationFrequency",20);
+  tkMapFrequency_        = ps.getUntrackedParameter<int>("TkMapCreationFrequency",50); 
+  staticUpdateFrequency_ = ps.getUntrackedParameter<int>("StaticUpdateFrequency",10);
+  actionOnLumiSec_       = ps.getUntrackedParameter<bool>("ActionOnLumiSection",false); //client
+  actionOnRunEnd_        = ps.getUntrackedParameter<bool>("ActionOnRunEnd",true); //client
+  evtOffsetForInit_      = ps.getUntrackedParameter<int>("EventOffsetForInit",10); //client
+  offlineXMLfile_        = ps.getUntrackedParameter<bool>("UseOfflineXMLFile",false); //client
+  hiRes_                 = ps.getUntrackedParameter<bool>("HighResolutionOccupancy",false); //client
+  noiseRate_             = ps.getUntrackedParameter<double>("NoiseRateCutValue",0.001); //client
+  noiseRateDenominator_  = ps.getUntrackedParameter<int>("NEventsForNoiseCalculation",100000); //client
+  Tier0Flag_             = ps.getUntrackedParameter<bool>("Tier0Flag",false); //client
+  doHitEfficiency_       = ps.getUntrackedParameter<bool>("DoHitEfficiency",true); //client
+  inputSource_           = ps.getUntrackedParameter<string>("inputSource",  "source");
+  
+  if(!Tier0Flag_){
+    string localPath = string("DQM/SiPixelMonitorClient/test/loader.html");
+    std::ifstream fin(edm::FileInPath(localPath).fullPath().c_str(), ios::in);
+    char buf[BUF_SIZE];
+  
+    if (!fin) {
+      cerr << "Input File: loader.html"<< " could not be opened!" << endl;
+      return;
+    }
+
+    while (fin.getline(buf, BUF_SIZE, '\n')) { // pops off the newline character 
+      html_out_ << buf ;
+    }
+    fin.close();
+
+  }
+  
+  // instantiate web interface
+  //sipixelWebInterface_ = new SiPixelWebInterface(bei_,offlineXMLfile_,Tier0Flag_);
+  //instantiate the three work horses of the client:
+  sipixelInformationExtractor_ = new SiPixelInformationExtractorPhase1(offlineXMLfile_);
+  sipixelActionExecutor_ = new SiPixelActionExecutorPhase1(offlineXMLfile_, Tier0Flag_);
+  sipixelDataQuality_ = new SiPixelDataQuality(offlineXMLfile_);
+
+  //set Token(-s)
+  inputSourceToken_ = consumes<FEDRawDataCollection>(ps.getUntrackedParameter<string>("inputSource", "source")); 
+// cout<<"...leaving  SiPixelEDAClientPhase1::SiPixelEDAClientPhase1. "<<endl;
+}
+//
+// -- Destructor
+//
+SiPixelEDAClientPhase1::~SiPixelEDAClientPhase1(){
+//  cout<<"Entering SiPixelEDAClientPhase1::~SiPixelEDAClientPhase1: "<<endl;
+  
+  edm::LogInfo("SiPixelEDAClientPhase1") <<  " Deleting SiPixelEDAClientPhase1 " << "\n" ;
+  /* Removing xdaq deps
+  if (sipixelWebInterface_) {
+     delete sipixelWebInterface_;
+     sipixelWebInterface_ = 0;
+  }
+  */
+  if (sipixelInformationExtractor_) {
+     delete sipixelInformationExtractor_;
+     sipixelInformationExtractor_ = 0;
+  }
+  if (sipixelActionExecutor_) {
+     delete sipixelActionExecutor_;
+     sipixelActionExecutor_ = 0;
+  }
+  if (sipixelDataQuality_) {
+     delete sipixelDataQuality_;
+     sipixelDataQuality_ = 0;
+  }
+
+//  cout<<"...leaving SiPixelEDAClientPhase1::~SiPixelEDAClientPhase1. "<<endl;
+}
+//
+// -- Begin Job
+//
+void SiPixelEDAClientPhase1::beginJob(){
+  firstRun = true;
+}
+//
+// -- Begin Run
+//
+void SiPixelEDAClientPhase1::beginRun(Run const& run, edm::EventSetup const& eSetup) {
+  edm::LogInfo ("SiPixelEDAClientPhase1") <<"[SiPixelEDAClientPhase1]: Begining of Run";
+//  cout<<"Entering SiPixelEDAClientPhase1::beginRun: "<<endl;
+
+  if(firstRun){
+  
+  // Read the summary configuration file
+    //if (!sipixelWebInterface_->readConfiguration(tkMapFrequency_,summaryFrequency_)) {
+    // edm::LogInfo ("SiPixelEDAClientPhase1") <<"[SiPixelEDAClientPhase1]: Error to read configuration file!! Summary will not be produced!!!";
+    //}
+    summaryFrequency_ = -1;
+    tkMapFrequency_ = -1;
+    actionOnLumiSec_ = false;
+    actionOnRunEnd_ = true;
+    evtOffsetForInit_ = -1;
+
+  nLumiSecs_ = 0;
+  nEvents_   = 0;
+  if(Tier0Flag_) nFEDs_ = 40;
+  else nFEDs_ = 0;
+  
+  bei_->setCurrentFolder("Pixel/");
+  // Setting up QTests:
+//  sipixelActionExecutor_->setupQTests(bei_);
+  // Creating Summary Histos:
+  sipixelActionExecutor_->createSummary(bei_);
+  // Booking Deviation Histos:
+  if(!Tier0Flag_) sipixelActionExecutor_->bookDeviations(bei_);
+  // Booking Efficiency Histos:
+  if(doHitEfficiency_) sipixelActionExecutor_->bookEfficiency(bei_);
+  // Creating occupancy plots:
+  sipixelActionExecutor_->bookOccupancyPlots(bei_, hiRes_);
+  // Booking noisy pixel ME's:
+  if(noiseRate_>0.) sipixelInformationExtractor_->bookNoisyPixels(bei_, noiseRate_, Tier0Flag_);
+  // Booking summary report ME's:
+  sipixelDataQuality_->bookGlobalQualityFlag(bei_, Tier0Flag_, nFEDs_);
+  // Booking Static Tracker Maps:
+//  sipixelActionExecutor_->bookTrackerMaps(bei_, "adc");
+//  sipixelActionExecutor_->bookTrackerMaps(bei_, "charge");
+//  sipixelActionExecutor_->bookTrackerMaps(bei_, "ndigis");
+//  sipixelActionExecutor_->bookTrackerMaps(bei_, "NErrors");
+  
+  firstRun = false;
+  }
+
+//  cout<<"...leaving SiPixelEDAClientPhase1::beginRun. "<<endl;
+
+}
+//
+// -- Begin  Luminosity Block
+//
+void SiPixelEDAClientPhase1::beginLuminosityBlock(edm::LuminosityBlock const& lumiSeg, 
+                                            edm::EventSetup const& context) {
+//  cout<<"Entering SiPixelEDAClientPhase1::beginLuminosityBlock: "<<endl;
+  
+  edm::LogInfo ("SiPixelEDAClientPhase1") <<"[SiPixelEDAClientPhase1]: Begin of LS transition";
+
+  nEvents_lastLS_=0; nErrorsBarrel_lastLS_=0; nErrorsEndcap_lastLS_=0;
+  MonitorElement * me = bei_->get("Pixel/AdditionalPixelErrors/byLumiErrors");
+  if(me){
+    nEvents_lastLS_ = int(me->getBinContent(0));
+    nErrorsBarrel_lastLS_ = int(me->getBinContent(1));
+    nErrorsEndcap_lastLS_ = int(me->getBinContent(2));
+    //std::cout<<"Nevts in lastLS in EDAClient: "<<nEvents_lastLS_<<" "<<nErrorsBarrel_lastLS_<<" "<<nErrorsEndcap_lastLS_<<std::endl;
+    me->Reset();
+  }
+//  cout<<"...leaving SiPixelEDAClientPhase1::beginLuminosityBlock. "<<endl;
+}
+//
+//  -- Analyze 
+//
+void SiPixelEDAClientPhase1::analyze(const edm::Event& e, const edm::EventSetup& eSetup){
+//  cout<<"[SiPixelEDAClientPhase1::analyze()] "<<endl;
+  nEvents_++;  
+  if(!Tier0Flag_){
+   
+    if(nEvents_==1){
+      // check if any Pixel FED is in readout:
+      edm::Handle<FEDRawDataCollection> rawDataHandle;
+      e.getByToken(inputSourceToken_, rawDataHandle);
+      if(!rawDataHandle.isValid()){
+        edm::LogInfo("SiPixelEDAClientPhase1") << inputSource_ << " is empty";
+	return;
+      } 
+      const FEDRawDataCollection& rawDataCollection = *rawDataHandle;
+      nFEDs_ = 0;
+      for(int i = 0; i != 40; i++){
+        if(rawDataCollection.FEDData(i).size() && rawDataCollection.FEDData(i).data()) nFEDs_++;
+      }
+    }
+    
+    // This is needed for plotting with the Pixel Expert GUI (interactive client):
+    //sipixelWebInterface_->setActionFlag(SiPixelWebInterface::CreatePlots);
+    //sipixelWebInterface_->performAction();
+  }
+  
+}
+//
+// -- End Luminosity Block
+//
+void SiPixelEDAClientPhase1::endLuminosityBlock(edm::LuminosityBlock const& lumiSeg, edm::EventSetup const& eSetup) {
+  //cout<<"Entering SiPixelEDAClientPhase1::endLuminosityBlock: "<<endl;
+
+  edm::LogInfo ("SiPixelEDAClientPhase1") <<"[SiPixelEDAClientPhase1]: End of LS transition, performing the DQM client operation";
+
+  nLumiSecs_++;
+  //cout << "nLumiSecs_: "<< nLumiSecs_ << endl;
+  
+  edm::LogInfo("SiPixelEDAClientPhase1") << "====================================================== " << endl << " ===> Iteration # " << nLumiSecs_ << " " << lumiSeg.luminosityBlock() << endl  << "====================================================== " << endl;
+  
+  //if(actionOnLumiSec_ && !Tier0Flag_ && nLumiSecs_ % 1 == 0 ){
+  if(actionOnLumiSec_ && nLumiSecs_ % 1 == 0 ){
+    //sipixelWebInterface_->setActionFlag(SiPixelWebInterface::Summary);
+    //sipixelWebInterface_->performAction();
+     //cout << " Updating efficiency plots" << endl;
+    if(doHitEfficiency_) sipixelActionExecutor_->createEfficiency(bei_);
+    //cout << " Checking QTest results " << endl;
+    //sipixelWebInterface_->setActionFlag(SiPixelWebInterface::QTestResult);
+    //sipixelWebInterface_->performAction();
+     //cout << " Updating occupancy plots" << endl;
+    sipixelActionExecutor_->createOccupancy(bei_);
+    //cout  << " Checking Pixel quality flags " << endl;;
+    bei_->cd();
+    bool init=true;
+    //sipixelDataQuality_->computeGlobalQualityFlag(bei_,init,nFEDs_,Tier0Flag_);
+    sipixelDataQuality_->computeGlobalQualityFlagByLumi(bei_,init,nFEDs_,Tier0Flag_,nEvents_lastLS_,nErrorsBarrel_lastLS_,nErrorsEndcap_lastLS_);
+    init=true;
+    bei_->cd();
+    sipixelDataQuality_->fillGlobalQualityPlot(bei_,init,eSetup,nFEDs_,Tier0Flag_,nLumiSecs_);
+    //cout << " Checking for new noisy pixels " << endl;
+    init=true;
+    if(noiseRate_>=0.) sipixelInformationExtractor_->findNoisyPixels(bei_, init, noiseRate_, noiseRateDenominator_, eSetup);
+    // cout << "*** Creating Tracker Map Histos for End Run ***" << endl;
+//    sipixelActionExecutor_->createMaps(bei_, "adc_siPixelDigis", "adc", Mean);
+//    sipixelActionExecutor_->createMaps(bei_, "charge_siPixelClusters", "charge", Mean);
+//    sipixelActionExecutor_->createMaps(bei_, "ndigis_siPixelDigis", "ndigis", WeightedSum);
+//    sipixelActionExecutor_->createMaps(bei_, "NErrors_siPixelDigis", "NErrors", WeightedSum);
+    // cout << "*** Done with Tracker Map Histos for End Run ***" << endl;
+  }   
+         
+  //cout<<"...leaving SiPixelEDAClientPhase1::endLuminosityBlock. "<<endl;
+}
+//
+// -- End Run
+//
+void SiPixelEDAClientPhase1::endRun(edm::Run const& run, edm::EventSetup const& eSetup){
+  //cout<<"Entering SiPixelEDAClientPhase1::endRun: "<<endl;
+
+  //edm::LogVerbatim ("SiPixelEDAClientPhase1") <<"[SiPixelEDAClientPhase1]: End of Run, saving  DQM output ";
+  //int iRun = run.run();
+  
+  if(actionOnRunEnd_){
+    //cout << " Updating Summary " << endl;
+    //sipixelWebInterface_->setActionFlag(SiPixelWebInterface::Summary);
+    //sipixelWebInterface_->performAction();
+    sipixelActionExecutor_->createSummary(bei_);
+     //cout << " Updating efficiency plots" << endl;
+    if(doHitEfficiency_) sipixelActionExecutor_->createEfficiency(bei_);
+    //cout << " Checking QTest results " << endl;
+    //sipixelWebInterface_->setActionFlag(SiPixelWebInterface::QTestResult);
+    //sipixelWebInterface_->performAction();
+    //cout << " Updating occupancy plots" << endl;
+    sipixelActionExecutor_->createOccupancy(bei_);
+    //cout  << " Checking Pixel quality flags " << endl;;
+    bei_->cd();
+    bool init=true;
+    sipixelDataQuality_->computeGlobalQualityFlag(bei_,init,nFEDs_,Tier0Flag_);
+    init=true;
+    bei_->cd();
+    //cout  << " Making run end reportSummaryMap: " <<nFEDs_<< endl;;
+    sipixelDataQuality_->fillGlobalQualityPlot(bei_,init,eSetup,nFEDs_,Tier0Flag_,nLumiSecs_);
+    //cout << " Checking for new noisy pixels " << endl;
+    init=true;
+    if(noiseRate_>=0.) sipixelInformationExtractor_->findNoisyPixels(bei_, init, noiseRate_, noiseRateDenominator_, eSetup);
+    // cout << "*** Creating Tracker Map Histos for End Run ***" << endl;
+//    sipixelActionExecutor_->createMaps(bei_, "adc_siPixelDigis", "adc", Mean);
+//    sipixelActionExecutor_->createMaps(bei_, "charge_siPixelClusters", "charge", Mean);
+//    sipixelActionExecutor_->createMaps(bei_, "ndigis_siPixelDigis", "ndigis", WeightedSum);
+//    sipixelActionExecutor_->createMaps(bei_, "NErrors_siPixelDigis", "NErrors", WeightedSum);
+    // cout << "*** Done with Tracker Map Histos for End Run ***" << endl;
+
+    // On demand, dump module ID's and stuff on the screen:
+    //sipixelActionExecutor_->dumpModIds(bei_,eSetup);
+    // On demand, dump summary histo values for reference on the screen:
+    //sipixelActionExecutor_->dumpRefValues(bei_,eSetup);
+  }
+  
+//  cout<<"...leaving SiPixelEDAClientPhase1::endRun. "<<endl;
+}
+
+//
+// -- End Job
+//
+void SiPixelEDAClientPhase1::endJob(){
+//  cout<<"In SiPixelEDAClientPhase1::endJob "<<endl;
+  edm::LogInfo("SiPixelEDAClientPhase1") <<"[SiPixelEDAClientPhase1]: endjob called!";
+
+}
+//
+// -- Create default web page
+//
+/* removing xdaq deps
+void SiPixelEDAClientPhase1::defaultWebPage(xgi::Input *in, xgi::Output *out)
+{
+//  cout<<"Entering SiPixelEDAClientPhase1::defaultWebPage: "<<endl;
+      
+  bool isRequest = false;
+  cgicc::Cgicc cgi(in);
+  cgicc::CgiEnvironment cgie(in);
+  //  edm::LogInfo("SiPixelEDAClientPhase1") <<"[SiPixelEDAClientPhase1]: defaultWebPage "
+  //             << " query string : " << cgie.getQueryString();
+  //  if ( xgi::Utils::hasFormElement(cgi,"ClientRequest") ) isRequest = true;
+  string q_string = cgie.getQueryString();
+  if (q_string.find("RequestID") != string::npos) isRequest = true;
+  if (!isRequest) {    
+    *out << html_out_.str() << std::endl;
+  }  else {
+    // Handles all HTTP requests of the form
+    int iter = nEvents_/100;
+    sipixelWebInterface_->handleEDARequest(in, out, iter);
+  }
+
+//  cout<<"...leaving SiPixelEDAClientPhase1::defaultWebPage. "<<endl;
+}
+*/

--- a/DQM/SiPixelMonitorClient/src/SiPixelInformationExtractorPhase1.cc
+++ b/DQM/SiPixelMonitorClient/src/SiPixelInformationExtractorPhase1.cc
@@ -1,0 +1,1645 @@
+/*! \file SiPixelInformationExtractorPhase1.cc
+ *  \brief This class represents ...
+ *  
+ *  (Documentation under development)
+ *  
+ */
+#include "DQM/SiPixelMonitorClient/interface/SiPixelInformationExtractorPhase1.h"
+#include "DQM/SiPixelMonitorClient/interface/SiPixelUtility.h"
+#include "DQM/SiPixelMonitorClient/interface/SiPixelEDAClientPhase1.h"
+#include "DQM/SiPixelMonitorClient/interface/ANSIColors.h"
+#include "DQM/SiPixelMonitorClient/interface/SiPixelHistoPlotter.h"
+#include "DQM/SiPixelCommon/interface/SiPixelFolderOrganizerPhase1.h"
+
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/GeometrySurface/interface/Surface.h"
+#include "DataFormats/SiPixelDetId/interface/PixelBarrelName.h"
+#include "DataFormats/SiPixelDetId/interface/PixelBarrelNameUpgrade.h"
+#include "DataFormats/SiPixelDetId/interface/PixelEndcapName.h"
+#include "DataFormats/SiPixelDetId/interface/PixelEndcapNameUpgrade.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+
+#include "CondFormats/SiPixelObjects/interface/DetectorIndex.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelFrameConverter.h"
+
+#include "Geometry/TrackerNumberingBuilder/interface/GeometricDet.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
+#include "Geometry/CommonTopologies/interface/PixelTopology.h"
+
+#include "TClass.h"
+#include "TText.h"
+#include "TROOT.h"
+#include "TPad.h"
+#include "TStyle.h"
+#include "TSystem.h"
+#include "TString.h"
+#include "TImage.h"
+#include "TPaveText.h"
+#include "TImageDump.h"
+#include "TRandom.h"
+#include "TStopwatch.h"
+#include "TAxis.h"
+#include "TPaveLabel.h"
+#include "Rtypes.h"
+#include "TH1F.h"
+#include "TH2F.h"
+#include "TProfile.h"
+
+#include <iostream>
+#include <math.h>
+#include <map>
+
+#include <cstdlib> // for free() - Root can allocate with malloc() - sigh...
+ 
+using namespace std;
+using namespace edm;
+
+//------------------------------------------------------------------------------
+/*! \brief Constructor of the SiPixelInformationExtractorPhase1 class.
+ *  
+ */
+SiPixelInformationExtractorPhase1::SiPixelInformationExtractorPhase1(bool offlineXMLfile) : offlineXMLfile_(offlineXMLfile) {
+  edm::LogInfo("SiPixelInformationExtractorPhase1") << 
+    " Creating SiPixelInformationExtractorPhase1 " << "\n" ;
+  
+  readReference_ = false;
+  histoPlotter_=0;
+  histoPlotter_ = new SiPixelHistoPlotter();
+}
+
+//------------------------------------------------------------------------------
+/*! \brief Destructor of the SiPixelInformationExtractorPhase1 class.
+ *  
+ */
+SiPixelInformationExtractorPhase1::~SiPixelInformationExtractorPhase1() {
+  edm::LogInfo("SiPixelInformationExtractorPhase1") << 
+    " Deleting SiPixelInformationExtractorPhase1 " << "\n" ;
+  
+  if (histoPlotter_) delete histoPlotter_;
+}
+
+//------------------------------------------------------------------------------
+/*! \brief Read Configuration File
+ *
+ */
+void SiPixelInformationExtractorPhase1::readConfiguration() { }
+
+//
+// -- Select Histograms for a given module
+//
+/*Removing xdaq deps
+void SiPixelInformationExtractorPhase1::getSingleModuleHistos(DQMStore * bei, 
+                                                        const multimap<string, string>& req_map, 
+							xgi::Output * out){
+  //cout<<"In SiPixelInformationExtractorPhase1::getSingleModuleHistos: "<<endl;
+  vector<string> hlist;
+  getItemList(req_map,"histo", hlist);
+
+  uint32_t detId = atoi(getItemValue(req_map,"ModId").c_str());
+ 
+  int width  = atoi(getItemValue(req_map, "width").c_str());
+  int height = atoi(getItemValue(req_map, "height").c_str());
+
+  string opt =" ";
+  
+  SiPixelFolderOrganizerPhase1 folder_organizer;
+  string path;
+  folder_organizer.getModuleFolder(detId,path);   
+
+  if((bei->pwd()).find("Module_") == string::npos &&
+     (bei->pwd()).find("FED_") == string::npos){
+    cout<<"This is not a pixel module or FED!"<<endl;
+    return;
+  }
+ 
+  vector<MonitorElement*> all_mes = bei->getContents(path);
+  setHTMLHeader(out);
+  *out << path << " ";
+
+  string theME ;
+  for (vector<string>::const_iterator ih = hlist.begin();
+       ih != hlist.end(); ih++) {
+    for (vector<MonitorElement *>::const_iterator it = all_mes.begin();
+	 it!= all_mes.end(); it++) {
+      MonitorElement * me = (*it);
+      if (!me) continue;
+      theME = me->getName();
+      string temp_s ; 
+      if(theME.find("siPixel")!=string::npos || theME.find("ctfWithMaterialTracks")!=string::npos) { temp_s = theME.substr(0,theME.find_first_of("_")); }
+      //cout<<"should be the variable name: temp_s= "<<temp_s<<endl;
+      if (temp_s == (*ih)) {
+	string full_path = path + "/" + me->getName();
+	histoPlotter_->setNewPlot(full_path, opt, width, height);
+	*out << me->getName() << " " ;
+      }
+    }
+  }
+}
+*/
+//
+// -- Plot Tracker Map MEs
+//
+/* removing xdaq deps
+void SiPixelInformationExtractorPhase1::getTrackerMapHistos(DQMStore* bei, 
+                                                      const std::multimap<std::string, std::string>& req_map, 
+						      xgi::Output * out) {
+
+//  cout << __LINE__ << ACYellow << ACBold 
+//       << "[SiPixelInformationExtractorPhase1::getTrackerMapHistos] " << ACPlain << endl ;
+//  cout<<"I am in this dir: "<<bei->pwd()<<endl;
+  vector<string> hlist;
+  string tkmap_name;
+  SiPixelConfigParser config_parser;
+  string localPath;
+  if(offlineXMLfile_) localPath = string("DQM/SiPixelMonitorClient/test/sipixel_tier0_config.xml");
+  else localPath = string("DQM/SiPixelMonitorClient/test/sipixel_monitorelement_config.xml");
+  config_parser.getDocument(edm::FileInPath(localPath).fullPath());
+//  if (!config_parser.getMENamesForTrackerMap(tkmap_name, hlist)) return;
+//  if (hlist.size() == 0) return;
+  if (!config_parser.getMENamesForTrackerMap(tkmap_name, hlist)) 
+  {
+   cout << __LINE__ << ACYellow << ACBold 
+        << "[SiPixelInformationExtractorPhase1::getTrackerMapHistos] " 
+	<< ACPlain << ACRed << ACPlain 
+	<< "getMENamesForTrackerMap return false " 
+        << ACPlain << endl ; assert(0) ;
+   return;
+  }
+  if (hlist.size() == 0) 
+  {
+   cout << __LINE__ << ACYellow << ACBold 
+        << "[SiPixelInformationExtractorPhase1::getTrackerMapHistos] " 
+	<< ACPlain << ACRed << ACPlain 
+	<< "hlist.size() == 0 " 
+        << ACPlain << endl ;  assert(0) ;
+   return;
+  }
+
+
+  uint32_t detId = atoi(getItemValue(req_map,"ModId").c_str());
+ 
+  int width  = atoi(getItemValue(req_map, "width").c_str());
+  int height = atoi(getItemValue(req_map, "height").c_str());
+
+  string opt =" ";
+  
+  SiPixelFolderOrganizerPhase1 folder_organizer;
+  string path;
+  
+  folder_organizer.getModuleFolder(detId,path);
+  string currDir = bei->pwd();   
+//  cout<<"detId= "<<detId<<" , path= "<<path<<" , and now I am in "<<currDir<<endl;
+  
+
+  if((bei->pwd()).find("Module_") == string::npos &&
+     (bei->pwd()).find("FED_") == string::npos){
+    cout<<"This is not a pixel module or FED!"<<endl;
+   cout << __LINE__ << ACYellow << ACBold 
+        << "[SiPixelInformationExtractorPhase1::getTrackerMapHistos] " 
+	<< ACPlain << ACRed << ACPlain 
+	<< "This is not a pixel module or FED!" 
+        << ACPlain << endl ; assert(0) ;
+    return;
+  }
+
+  vector<MonitorElement*> all_mes = bei->getContents(path);
+  setXMLHeader(out);
+
+  cout << __LINE__ << ACCyan << ACBold 
+       << " [SiPixelInformationExtractorPhase1::getTrackerMapHistos()] path "
+       << ACPlain << path << endl ; 
+  cout << __LINE__ << ACCyan << ACBold 
+       << " [SiPixelInformationExtractorPhase1::getTrackerMapHistos()] all_mes.size() "
+       << ACPlain << all_mes.size() << endl ; 
+
+  string theME ;
+  *out << "<pathList>" << endl ;
+  for (vector<string>::iterator ih = hlist.begin();
+       ih != hlist.end(); ih++) {
+       //cout<<"ih iterator (hlist): "<<(*ih)<<endl;
+    for (vector<MonitorElement *>::const_iterator it = all_mes.begin();
+	 it!= all_mes.end(); it++) {
+      MonitorElement * me = (*it);
+      if (!me) 
+      { 
+       cout << __LINE__ << ACCyan << ACBold 
+            << " [SiPixelInformationExtractorPhase1::getTrackerMapHistos()] skipping "
+        	       << ACPlain << *ih << endl ; 
+       continue;
+      }
+      theME = me->getName();
+      //cout<<"ME iterator (all_mes): "<<theME<<endl; 
+      string temp_s ; 
+      if(theME.find("siPixel")!=string::npos || theME.find("ctfWithMaterialTracks")!=string::npos) { temp_s = theME.substr(0,theME.find_first_of("_")); }
+      //cout << __LINE__ << ACCyan << ACBold 
+      //     << " [SiPixelInformationExtractorPhase1::getTrackerMapHistos()] temp_s "
+      //     << ACPlain << temp_s << " <--> " << *ih << " |" << theME << "|" << endl ; 
+      if (temp_s == (*ih)) {
+	string full_path = path + "/" + me->getName();
+	histoPlotter_->setNewPlot(full_path, opt, width, height);
+//cout << __LINE__ << ACRed << ACBold 
+//     << " [SiPixelInformationExtractorPhase1::getTrackerMapHistos()] fullPath: "
+//     << ACPlain << full_path << endl ; 
+	*out << " <pathElement path='" << full_path << "' />" << endl ;
+      }      
+    }
+  }   
+  *out << "</pathList>" << endl ;
+//cout << __LINE__ << " [SiPixelInformationExtractorPhase1::getTrackerMapHistos()] endlist: " << endl ;
+}
+*/
+//============================================================================================================
+// --  Return type of ME
+//
+std::string  SiPixelInformationExtractorPhase1::getMEType(MonitorElement * theMe)
+{
+  string qtype = theMe->getRootObject()->IsA()->GetName() ;
+  if(         qtype.find("TH1") != string::npos )
+  {
+    return "TH1" ;
+  } else if ( qtype.find("TH2") != string::npos  ) {
+    return "TH2" ;
+  } else if ( qtype.find("TH3") != string::npos ) {
+    return "TH3" ;
+  }
+  return "TH1" ;
+}
+
+//------------------------------------------------------------------------------
+/*! \brief (Documentation under construction).
+ *
+ *  This method 
+ */
+/*removing xdaq deps
+void SiPixelInformationExtractorPhase1::readModuleAndHistoList(DQMStore* bei, 
+                                                         xgi::Output * out) {
+//cout<<"entering SiPixelInformationExtractorPhase1::readModuleAndHistoList"<<endl;
+   bei->cd("Pixel");
+   std::map<std::string,std::string> hnames;
+   std::vector<std::string> mod_names;
+   fillModuleAndHistoList(bei, mod_names, hnames);
+   out->getHTTPResponseHeader().addHeader("Content-Type", "text/xml");
+  *out << "<?xml version=\"1.0\" ?>" << std::endl;
+  *out << "<ModuleAndHistoList>" << endl;
+  *out << "<ModuleList>" << endl;
+   for (std::vector<std::string>::iterator im = mod_names.begin();
+        im != mod_names.end(); im++) {
+     *out << "<ModuleNum>" << *im << "</ModuleNum>" << endl;     
+   }
+   *out << "</ModuleList>" << endl;
+   *out << "<HistoList>" << endl;
+
+   for (std::map<std::string,std::string>::iterator ih = hnames.begin();
+        ih != hnames.end(); ih++) {
+     *out << "<Histo type=\"" 
+          << ih->second
+	  << "\">" 
+	  << ih->first 
+	  << "</Histo>" 
+	  << endl;     
+   }
+   *out << "</HistoList>" << endl;
+   *out << "</ModuleAndHistoList>" << endl;
+//cout<<"leaving SiPixelInformationExtractorPhase1::readModuleAndHistoList"<<endl;
+}
+*/
+
+//------------------------------------------------------------------------------
+/*! \brief (Documentation under construction).
+ *
+ *  This method 
+ */
+void SiPixelInformationExtractorPhase1::fillModuleAndHistoList(DQMStore * bei, 
+                                                         vector<string>        & modules,
+							 map<string,string>    & histos) {
+//cout<<"entering SiPixelInformationExtractorPhase1::fillModuleAndHistoList"<<endl;
+  string currDir = bei->pwd();
+  //cout<<"currDir= "<<currDir<<endl;
+  if(currDir.find("Module_") != string::npos){
+    if(histos.size() == 0){
+      vector<string> contents = bei->getMEs();
+      for (vector<string>::const_iterator it = contents.begin(); it != contents.end(); it++) {
+	string hname          = (*it).substr(0, (*it).find("_siPixel"));
+	if(hname==" ") hname = (*it).substr(0, (*it).find("_generalTracks"));
+        string fullpathname   = bei->pwd() + "/" + (*it); 
+       // cout<<"fullpathname="<<fullpathname<<endl;
+        MonitorElement * me   = bei->get(fullpathname);
+        string htype          = "undefined" ;
+        if(me) htype = me->getRootObject()->IsA()->GetName() ;
+	//cout<<"hname="<<hname<<endl;
+	//if(htype=="TH1F" || htype=="TH1D"){
+        histos[hname] = htype ;
+        string mId=" ";
+	if(hname.find("ndigis") 	       !=string::npos) mId = (*it).substr((*it).find("ndigis_siPixelDigis_")+20, 9);
+	if(mId==" " && hname.find("nclusters") !=string::npos) mId = (*it).substr((*it).find("nclusters_siPixelClusters_")+26, 9);
+        if(mId==" " && hname.find("residualX") !=string::npos) mId = (*it).substr((*it).find("residualX_ctfWithMaterialTracks_")+32, 9);
+        if(mId==" " && hname.find("NErrors") !=string::npos) mId = (*it).substr((*it).find("NErrors_siPixelDigis_")+21, 9);
+        if(mId==" " && hname.find("ClustX") !=string::npos) mId = (*it).substr((*it).find("ClustX_siPixelRecHit_")+21, 9);
+        if(mId==" " && hname.find("pixelAlive") !=string::npos) mId = (*it).substr((*it).find("pixelAlive_siPixelCalibDigis_")+29, 9);
+        if(mId==" " && hname.find("Gain1d") !=string::npos) mId = (*it).substr((*it).find("Gain1d_siPixelCalibDigis_")+25, 9);
+        if(mId!=" ") modules.push_back(mId);
+        //cout<<"mId="<<mId<<endl;
+	//}
+      }    
+    }
+  } else {  
+    vector<string> subdirs = bei->getSubdirs();
+    for (vector<string>::const_iterator it = subdirs.begin(); it != subdirs.end(); it++) {
+      if((bei->pwd()).find("Barrel")==string::npos && (bei->pwd()).find("Endcap")==string::npos) bei->goUp();
+      bei->cd(*it);
+      fillModuleAndHistoList(bei, modules, histos);
+      bei->goUp();
+    }
+  }
+//  fillBarrelList(bei, modules, histos);
+//cout<<"leaving SiPixelInformationExtractorPhase1::fillModuleAndHistoList"<<endl;
+}
+
+//------------------------------------------------------------------------------
+/*! \brief (Documentation under construction).
+ *
+ *  This method 
+ */
+/* removing xdaq deps
+void SiPixelInformationExtractorPhase1::readModuleHistoTree(DQMStore* bei, 
+                                                      string& str_name, 
+						      xgi::Output * out) {
+//cout<<"entering  SiPixelInformationExtractorPhase1::readModuleHistoTree"<<endl;
+  ostringstream modtree;
+  if (goToDir(bei, str_name)) {
+    modtree << "<form name=\"IMGCanvasItemsSelection\" "
+            << "action=\"javascript:void%200\">" 
+	    << endl ;
+    modtree << "<ul id=\"dhtmlgoodies_tree\" class=\"dhtmlgoodies_tree\">" << endl;
+    printModuleHistoList(bei,modtree);
+    modtree <<"</ul>" << endl;   
+    modtree <<"</form>" << endl;   
+  } else {
+    modtree << "Desired Directory does not exist";
+  }
+  cout << ACYellow << ACBold
+       << "[SiPixelInformationExtractorPhase1::readModuleHistoTree()]"
+       << ACPlain << endl ;
+  //     << "html string follows: " << endl ;
+  //cout << modtree.str() << endl ;
+  //cout << ACYellow << ACBold
+  //     << "[SiPixelInformationExtractorPhase1::readModuleHistoTree()]"
+  //     << ACPlain
+  //     << "String complete " << endl ;
+  out->getHTTPResponseHeader().addHeader("Content-Type", "text/plain");
+  *out << modtree.str();
+   bei->cd();
+//cout<<"leaving  SiPixelInformationExtractorPhase1::readModuleHistoTree"<<endl;
+}
+*/
+
+//------------------------------------------------------------------------------
+/*! \brief (Documentation under construction).
+ *
+ *  This method 
+ */
+void SiPixelInformationExtractorPhase1::printModuleHistoList(DQMStore * bei, 
+                                                       ostringstream& str_val){
+//cout<<"entering SiPixelInformationExtractorPhase1::printModuleHistoList"<<endl;
+  string currDir = bei->pwd();
+  string dname = currDir.substr(currDir.find_last_of("/")+1);
+  str_val << " <li>\n"
+	  << "  <a href=\"#\" id=\"" << currDir << "\">\n   " 
+	  <<     dname << "\n"
+	  << "  </a>\n"
+	  << endl << endl;
+
+  vector<string> meVec     = bei->getMEs(); 
+  
+  vector<string> subDirVec = bei->getSubdirs();
+  if ( meVec.size()== 0  && subDirVec.size() == 0 ) {
+    str_val << " </li>" << endl;    
+    return;
+  }
+  str_val << "\n   <ul>" << endl; 
+  for (vector<string>::const_iterator it  = meVec.begin();
+                                      it != meVec.end(); it++) {
+    if ((*it).find("_siPixel")!=string::npos || 
+        (*it).find("_ctfWithMaterialTracks")!=string::npos) {
+      string qit = (*it) ;
+      string temp_s;
+      if(qit.find("siPixel")!=string::npos || qit.find("ctfWithMaterialTracks")!=string::npos) { temp_s = qit.substr(0,qit.find_first_of("_")); }
+      str_val << "    <li class=\"dhtmlgoodies_sheet.gif\">\n"
+	      << "     <input id      = \"selectedME\""
+	      << "            folder  = \"" << currDir << "\""
+	      << "            type    = \"checkbox\""
+	      << "            name    = \"selected\""
+	      << "            class   = \"smallCheckBox\""
+	      << "            value   = \"" << (*it) << "\""
+	      << "            onclick = \"javascript:IMGC.selectedIMGCItems()\" />\n"
+//	      << "     <a href=\"javascript:IMGC.updateIMGC('" << currDir << "')\">\n       " 
+	      << "     <a href=\"javascript:IMGC.plotFromPath('" << currDir << "')\">\n       " 
+//	      <<        temp_s << "\n"
+	      <<        (*it) << "\n"
+	      << "     </a>\n"
+	      << "    </li>" 
+	      << endl;
+    }
+  }
+  for (vector<string>::const_iterator ic  = subDirVec.begin();
+                                      ic != subDirVec.end(); ic++) {
+    bei->cd(*ic);
+    printModuleHistoList(bei, str_val);
+    bei->goUp();
+  }
+  str_val << "   </ul>" << endl;  
+  str_val << "  </li>"  << endl;  
+//cout<<"leaving SiPixelInformationExtractorPhase1::printModuleHistoList"<<endl;
+}
+
+//------------------------------------------------------------------------------
+/*! \brief (Documentation under construction).
+ *
+ *  This method 
+ */
+/* removing xdaq deps
+void SiPixelInformationExtractorPhase1::readSummaryHistoTree(DQMStore* bei, 
+                                                       string& str_name, 
+						       xgi::Output * out) {
+//cout<<"entering  SiPixelInformationExtractorPhase1::readSummaryHistoTree"<<endl;
+  ostringstream sumtree;
+  if (goToDir(bei, str_name)) {
+    sumtree << "<ul id=\"dhtmlgoodies_tree\" class=\"dhtmlgoodies_tree\">" << endl;
+    printSummaryHistoList(bei,sumtree);
+    sumtree <<"</ul>" << endl;   
+  } else {
+    sumtree << "Desired Directory does not exist";
+  }
+  cout << ACYellow << ACBold
+       << "[SiPixelInformationExtractorPhase1::readSummaryHistoTree()]"
+       << ACPlain << endl ;
+  //     << "html string follows: " << endl ;
+  //cout << sumtree.str() << endl ;
+  //cout << ACYellow << ACBold
+  //     << "[SiPixelInformationExtractorPhase1::readSummaryHistoTree()]"
+  //     << ACPlain
+  //     << "String complete " << endl ;
+  out->getHTTPResponseHeader().addHeader("Content-Type", "text/plain");
+  *out << sumtree.str();
+   bei->cd();
+//cout<<"leaving  SiPixelInformationExtractorPhase1::readSummaryHistoTree"<<endl;
+}
+*/
+
+//------------------------------------------------------------------------------
+/*! \brief (Documentation under construction).
+ *
+ *  Returns a stringstream containing an HTML-formatted list of ME in the current
+ *  directory. 
+ *  This is a recursive method.
+ */
+void SiPixelInformationExtractorPhase1::printSummaryHistoList(DQMStore * bei, 
+                                                        ostringstream& str_val){
+//cout<<"entering SiPixelInformationExtractorPhase1::printSummaryHistoList"<<endl;
+  string currDir = bei->pwd();
+  string dname = currDir.substr(currDir.find_last_of("/")+1);
+  if (dname.find("Module_") ==0 || dname.find("FED_")==0) return;
+  str_val << " <li>\n"
+          << "  <a href=\"#\" id=\"" << currDir << "\">\n   " 
+	  <<     dname 
+	  << "  </a>" 
+	  << endl;
+
+  vector<string> meVec     = bei->getMEs(); 
+  
+  vector<string> subDirVec = bei->getSubdirs();
+  if ( meVec.size()== 0  && subDirVec.size() == 0 ) {
+    str_val << " </li> "<< endl;    
+    return;
+  }
+  str_val << "\n   <ul>" << endl;      
+  for (vector<string>::const_iterator it = meVec.begin();
+       it != meVec.end(); it++) {
+    if ((*it).find("SUM") == 0) {
+      str_val << "    <li class=\"dhtmlgoodies_sheet.gif\">\n"
+	      << "     <input id      = \"selectedME\""
+	      << "            folder  = \"" << currDir << "\""
+	      << "            type    = \"checkbox\""
+	      << "            name    = \"selected\""
+	      << "            class   = \"smallCheckBox\""
+	      << "            value   = \"" << (*it) << "\""
+	      << "            onclick = \"javascript:IMGC.selectedIMGCItems()\" />\n"
+//              << "     <a href=\"javascript:IMGC.updateIMGC('" << currDir << "')\">\n       " 
+              << "     <a href=\"javascript:IMGC.plotFromPath('" << currDir << "')\">\n       " 
+	      <<       (*it) << "\n"
+	      << "     </a>\n"
+	      << "    </li>" 
+	      << endl;
+    }
+  }
+
+  for (vector<string>::const_iterator ic = subDirVec.begin();
+       ic != subDirVec.end(); ic++) {
+    bei->cd(*ic);
+    printSummaryHistoList(bei, str_val);
+    bei->goUp();
+  }
+  str_val << "   </ul> "<< endl;  
+  str_val << "  </li> "<< endl;  
+//cout<<"leaving SiPixelInformationExtractorPhase1::printSummaryHistoList"<<endl;
+}
+
+
+//------------------------------------------------------------------------------
+/*! \brief (Documentation under construction).
+ *
+ *  This method 
+ */
+/* removing xdaq deps
+void SiPixelInformationExtractorPhase1::readAlarmTree(DQMStore* bei, 
+                                                string& str_name, 
+						xgi::Output * out){
+//cout<<"entering SiPixelInformationExtractorPhase1::readAlarmTree"<<endl;
+  ostringstream alarmtree;
+  if (goToDir(bei, str_name)) {
+    alarmtree << "<ul id=\"dhtmlgoodies_tree\" class=\"dhtmlgoodies_tree\">" << endl;
+    alarmCounter_=0;
+    printAlarmList(bei,alarmtree);
+    if(alarmCounter_==0) alarmtree <<"<li>No problematic modules found, all ok!</li>" << endl;
+    alarmtree <<"</ul>" << endl; 
+  } else {
+    alarmtree << "Desired Directory does not exist";
+  }
+  cout << ACYellow << ACBold
+       << "[SiPixelInformationExtractorPhase1::readAlarmTree()]"
+       << ACPlain << endl ;
+  //     << "html string follows: " << endl ;
+  //cout << alarmtree.str() << endl ;
+  //cout << ACYellow << ACBold
+  //     << "[SiPixelInformationExtractorPhase1::readAlarmTree()]"
+  //     << ACPlain
+  //     << "String complete " << endl ;
+  out->getHTTPResponseHeader().addHeader("Content-Type", "text/plain");
+ *out << alarmtree.str();
+  bei->cd();
+  cout << ACYellow << ACBold
+       << "[SiPixelInformationExtractorPhase1::readAlarmTree()]"
+       << ACPlain 
+       << " Done!"
+       << endl ;
+//cout<<"leaving SiPixelInformationExtractorPhase1::readAlarmTree"<<endl;
+}
+*/
+//------------------------------------------------------------------------------
+/*! \brief (Documentation under construction).
+ *  
+ *  Returns a stringstream containing an HTML-formatted list of alarms for the current
+ *  directory. 
+ *  This is a recursive method.
+ */
+void SiPixelInformationExtractorPhase1::printAlarmList(DQMStore * bei, 
+                                                 ostringstream& str_val){
+//cout<<"entering SiPixelInformationExtractorPhase1::printAlarmList"<<endl;
+//   cout << ACRed << ACBold
+//        << "[SiPixelInformationExtractorPhase1::printAlarmList()]"
+//        << ACPlain
+//        << " Enter" 
+//        << endl ;
+  string currDir = bei->pwd();
+  string dname = currDir.substr(currDir.find_last_of("/")+1);
+  string image_name;
+  selectImage(image_name,bei->getStatus(currDir));
+  if(image_name!="images/LI_green.gif")
+    str_val << " <li>\n"
+            << "  <a href=\"#\" id=\"" << currDir << "\">\n   " 
+	    <<     dname 
+	    << "  </a>\n"
+	    << "  <img src=\"" 
+            <<     image_name 
+	    << "\">" << endl;
+  vector<string> subDirVec = bei->getSubdirs();
+
+  vector<string> meVec = bei->getMEs();
+   
+  if (subDirVec.size() == 0 && meVec.size() == 0) {
+    str_val <<  "</li> "<< endl;    
+    return;
+  }
+  str_val << "<ul>" << endl;
+  for (vector<string>::const_iterator it = meVec.begin();
+	   it != meVec.end(); it++) {
+    string full_path = currDir + "/" + (*it);
+
+    MonitorElement * me = bei->get(full_path);
+    
+    if (!me) continue;
+    std::vector<QReport *> my_map = me->getQReports();
+    if (my_map.size() > 0) {
+      string image_name1;
+      selectImage(image_name1,my_map);
+      if(image_name1!="images/LI_green.gif") {
+        alarmCounter_++;
+        str_val << "	<li class=\"dhtmlgoodies_sheet.gif\">\n"
+        	<< "	 <input id	= \"selectedME\""
+        	<< "		folder  = \"" << currDir << "\""
+        	<< "		type	= \"checkbox\""
+        	<< "		name	= \"selected\""
+        	<< "		class	= \"smallCheckBox\""
+        	<< "		value	= \"" << (*it) << "\""
+        	<< "		onclick = \"javascript:IMGC.selectedIMGCItems()\" />\n"
+//        	<< "	 <a href=\"javascript:IMGC.updateIMGC('" << currDir << "')\">\n       " 
+        	<< "	 <a href=\"javascript:IMGC.plotFromPath('" << currDir << "')\">\n       " 
+        	<<	  (*it) << "\n"
+        	<< "	 </a>\n"
+		<< "     <img src=\""
+		<<        image_name1 
+		<< "\">"
+        	<< "	</li>" 
+        	<< endl;
+	}	
+    }
+  }
+  for (vector<string>::const_iterator ic = subDirVec.begin();
+       ic != subDirVec.end(); ic++) {
+    bei->cd(*ic);
+    printAlarmList(bei, str_val);
+    bei->goUp();
+  }
+  str_val << "</ul> "<< endl;  
+  str_val << "</li> "<< endl;  
+//   cout << ACGreen << ACBold
+//        << "[SiPixelInformationExtractorPhase1::printAlarmList()]"
+//        << ACPlain
+//        << " Done" 
+//        << endl ;
+//cout<<"leaving SiPixelInformationExtractorPhase1::printAlarmList"<<endl;
+}
+
+
+//------------------------------------------------------------------------------
+/*! \brief (Documentation under construction).
+ *
+ *  This method 
+ */
+void SiPixelInformationExtractorPhase1::getItemList(const multimap<string, string>& req_map, 
+                                              string item_name,
+					      vector<string>& items) {
+//cout<<"entering SiPixelInformationExtractorPhase1::getItemList"<<endl;
+  items.clear();
+  for (multimap<string, string>::const_iterator it = req_map.begin();
+       it != req_map.end(); it++) {
+    if (it->first == item_name) {
+      items.push_back(it->second);
+    }
+  }
+//cout<<"leaving SiPixelInformationExtractorPhase1::getItemList"<<endl;
+}
+
+//------------------------------------------------------------------------------
+/*! \brief (Documentation under construction).
+ *
+ *  This method 
+ */
+bool SiPixelInformationExtractorPhase1::hasItem(multimap<string,string>& req_map,
+					  string item_name){
+//cout<<"entering SiPixelInformationExtractorPhase1::hasItem"<<endl;
+  multimap<string,string>::iterator pos = req_map.find(item_name);
+  if (pos != req_map.end()) return true;
+  return false;  
+//cout<<"leaving SiPixelInformationExtractorPhase1::hasItem"<<endl;
+}
+
+//------------------------------------------------------------------------------
+/*! \brief (Documentation under construction).
+ *
+ *  This method 
+ */
+std::string SiPixelInformationExtractorPhase1::getItemValue(const std::multimap<std::string,std::string>& req_map,
+						 std::string item_name){
+//cout<<"entering SiPixelInformationExtractorPhase1::getItemValue for item: "<<item_name<<endl;
+  std::multimap<std::string,std::string>::const_iterator pos = req_map.find(item_name);
+  std::string value = " ";
+  if (pos != req_map.end()) {
+    value = pos->second;
+  }
+//  cout<<"value = "<<value<<endl;
+  return value;
+//cout<<"leaving SiPixelInformationExtractorPhase1::getItemValue"<<endl;
+}
+std::string SiPixelInformationExtractorPhase1::getItemValue(std::multimap<std::string,std::string>& req_map,
+						 std::string item_name){
+//cout<<"entering SiPixelInformationExtractorPhase1::getItemValue for item: "<<item_name<<endl;
+  std::multimap<std::string,std::string>::iterator pos = req_map.find(item_name);
+  std::string value = " ";
+  if (pos != req_map.end()) {
+//  cout<<"item found!"<<endl;
+    value = pos->second;
+  }
+//  cout<<"value = "<<value<<endl;
+  return value;
+//cout<<"leaving SiPixelInformationExtractorPhase1::getItemValue"<<endl;
+}
+
+//
+// -- Get color  name from status
+//
+void SiPixelInformationExtractorPhase1::selectColor(string& col, int status){
+  if (status == dqm::qstatus::STATUS_OK)    col = "#00ff00";
+  else if (status == dqm::qstatus::WARNING) col = "#ffff00";
+  else if (status == dqm::qstatus::ERROR)   col = "#ff0000";
+  else if (status == dqm::qstatus::OTHER)   col = "#ffa500";
+  else  col = "#0000ff";
+}
+//
+// -- Get Image name from ME
+//
+void SiPixelInformationExtractorPhase1::selectColor(string& col, vector<QReport*>& reports){
+  int istat = 999;
+  int status = 0;
+  for (vector<QReport*>::const_iterator it = reports.begin(); it != reports.end();
+       it++) {
+    status = (*it)->getStatus();
+    if (status > istat) istat = status;
+  }
+  selectColor(col, status);
+}
+//
+// -- Get Image name from status
+//
+void SiPixelInformationExtractorPhase1::selectImage(string& name, int status){
+  if (status == dqm::qstatus::STATUS_OK) name="images/LI_green.gif";
+  else if (status == dqm::qstatus::WARNING) name="images/LI_yellow.gif";
+  else if (status == dqm::qstatus::ERROR) name="images/LI_red.gif";
+  else if (status == dqm::qstatus::OTHER) name="images/LI_orange.gif";
+  else  name="images/LI_blue.gif";
+}
+//
+// -- Get Image name from ME
+//
+void SiPixelInformationExtractorPhase1::selectImage(string& name, vector<QReport*>& reports){
+  int istat = 999;
+  int status = 0;
+  for (vector<QReport*>::const_iterator it = reports.begin(); it != reports.end();
+       it++) {
+    status = (*it)->getStatus();
+    if (status > istat) istat = status;
+  }
+  selectImage(name, status);
+}
+
+//
+// -- Get a tagged image 
+//
+/* removing xdaq deps
+void SiPixelInformationExtractorPhase1::getIMGCImage(const multimap<string, string>& req_map, 
+                                               xgi::Output * out){
+  string path = getItemValue(req_map,"Path");
+  string image;
+  histoPlotter_->getNamedImageBuffer(path, image);
+
+  out->getHTTPResponseHeader().addHeader("Content-Type", "image/png");
+  out->getHTTPResponseHeader().addHeader("Pragma", "no-cache");   
+  out->getHTTPResponseHeader().addHeader("Cache-Control", "no-store, no-cache, must-revalidate,max-age=0");
+  out->getHTTPResponseHeader().addHeader("Expires","Mon, 26 Jul 1997 05:00:00 GMT");
+  *out << image;
+}
+*/
+/* removing xdaq deps
+void SiPixelInformationExtractorPhase1::getIMGCImage(multimap<string, string>& req_map, 
+                                               xgi::Output * out){
+  
+  string path = getItemValue(req_map,"Path");
+  string image;
+  histoPlotter_->getNamedImageBuffer(path, image);
+
+  out->getHTTPResponseHeader().addHeader("Content-Type", "image/png");
+  out->getHTTPResponseHeader().addHeader("Pragma", "no-cache");   
+  out->getHTTPResponseHeader().addHeader("Cache-Control", "no-store, no-cache, must-revalidate,max-age=0");
+  out->getHTTPResponseHeader().addHeader("Expires","Mon, 26 Jul 1997 05:00:00 GMT");
+  *out << image;
+
+}
+*/
+
+//------------------------------------------------------------------------------
+/*! \brief (Documentation under construction).
+ *
+ *  This method 
+ */
+bool SiPixelInformationExtractorPhase1::goToDir(DQMStore* bei, 
+                                          string& sname){ 
+//cout<<"entering SiPixelInformationExtractorPhase1::goToDir"<<endl;
+  bei->cd();
+  //if(flg) bei->cd("Collector/Collated");
+  bei->cd(sname);
+  string dirName = bei->pwd();
+  if (dirName.find(sname) != string::npos) return true;
+  else return false;  
+//cout<<"leaving SiPixelInformationExtractorPhase1::goToDir"<<endl;
+}
+
+//
+// -- Get Warning/Error Messages
+//
+/* removing xdaq deps
+void SiPixelInformationExtractorPhase1::readStatusMessage(DQMStore* bei, 
+                                                    std::multimap<std::string, std::string>& req_map, 
+						    xgi::Output * out){
+
+  string path = getItemValue(req_map,"Path");
+
+  int width  = atoi(getItemValue(req_map, "width").c_str());
+  int height = atoi(getItemValue(req_map, "height").c_str());
+
+  string opt =" ";
+
+  ostringstream test_status;
+  
+  setXMLHeader(out);
+  *out << "<StatusAndPath>" << endl;
+  *out << "<PathList>" << endl;
+  if (path.size() == 0) {
+    *out << "<HPath>" << "NONE" << "</HPath>" << endl;     
+    test_status << " ME Does not exist ! " << endl;
+  } else {
+    vector<MonitorElement*> all_mes = bei->getContents(path);
+    *out << "<HPath>" << path << "</HPath>" << endl;     
+    for(vector<MonitorElement*>::iterator it=all_mes.begin(); it!=all_mes.end(); it++){
+      MonitorElement* me = (*it);
+      if (!me) continue;
+      string name = me->getName();  
+
+      vector<QReport*> q_reports = me->getQReports();
+      if (q_reports.size() == 0) continue;
+      string full_path = path + "/" + name;
+      histoPlotter_->setNewPlot(full_path, opt, width, height);
+
+      if (q_reports.size() != 0) {
+        test_status << " QTest Status for " << name << " : " << endl;
+        test_status << " ======================================================== " << endl; 
+        for (vector<QReport*>::const_iterator it = q_reports.begin(); it != q_reports.end();
+	     it++) {
+	  int status = (*it)->getStatus();
+	  if (status == dqm::qstatus::WARNING) test_status << " Warning ";
+	  else if (status == dqm::qstatus::ERROR) test_status << " Error  ";
+	  else if (status == dqm::qstatus::STATUS_OK) test_status << " Ok  ";
+	  else if (status == dqm::qstatus::OTHER) test_status << " Other(" << status << ") ";
+	  string mess_str = (*it)->getMessage();
+	  test_status <<  "&lt;br/&gt;";
+	  mess_str = mess_str.substr(mess_str.find(" Test")+5);
+	  test_status <<  " QTest Name  : " << mess_str.substr(0, mess_str.find(")")+1) << endl;
+	  test_status << "&lt;br/&gt;";
+	  test_status <<  " QTest Detail  : " << mess_str.substr(mess_str.find(")")+2) << endl;
+	} 
+	test_status << " ======================================================== " << endl;
+      }
+      *out << "<HPath>" << name << "</HPath>" << endl;         
+    }    
+  }
+  *out << "</PathList>" << endl;
+  *out << "<StatusList>" << endl;
+  *out << "<Status>" << test_status.str() << "</Status>" << endl;      
+  *out << "</StatusList>" << endl;
+  *out << "</StatusAndPath>" << endl;
+}
+*/
+
+//------------------------------------------------------------------------------
+/*! \brief (Documentation under construction).
+ *  
+ */
+void SiPixelInformationExtractorPhase1::computeStatus(MonitorElement      * theME,
+                                                double              & colorValue,
+						pair<double,double> & norm) 
+{
+  double normalizationX = 1 ;
+  double normalizationY = 1 ;
+  double meanX          = 0 ;
+  double meanY          = 0 ;
+  
+  colorValue = 0 ;
+
+  pair<double,double> normX ;
+  pair<double,double> normY ;
+
+  string theMEType = getMEType(theME) ;
+
+//   cout << ACRed << ACReverse
+//        << "[SiPixelInformationExtractorPhase1::computeStatus()]"
+//        << ACPlain
+//        << " Computing average for "
+//        << theME->getName()
+//        << endl ;
+
+  if( theMEType.find("TH1") != string::npos)
+  {
+   meanX = (double)theME->getMean();
+   getNormalization(theME, normX, "TH1") ;
+   normalizationX = fabs( normX.second - normX.first) ;
+   if( normalizationX == 0 ) {normalizationX=1.E-20;}
+   colorValue  = meanX / normalizationX ;
+   norm.first  = normX.first ;
+   norm.second = normX.second ;
+  }
+  
+  if( theMEType.find("TH2") != string::npos)
+  {
+   meanX = (double)theME->getMean(1);
+   meanY = (double)theME->getMean(2);
+   getNormalization2D(theME, normX, normY, "TH2") ;
+   normalizationX = fabs( normX.second - normX.first) ;
+   normalizationY = fabs( normY.second - normY.first) ;
+   if( normalizationX == 0 ) {normalizationX=1.E-20;}
+   if( normalizationY == 0 ) {normalizationY=1.E-20;}
+   double cVX = meanX / normalizationX ;
+   double cVY = meanY / normalizationY ;
+   colorValue = sqrt(cVX*cVX + cVY*cVY) ;
+   if( normalizationX >= normalizationY )
+   { 
+    norm.first  = normX.first;
+    norm.second = normX.second ;
+   } else { 
+    norm.first  = normY.first;
+    norm.second = normY.second ;
+   }
+//   cout << ACBlue << ACBold << ACReverse
+//        << "[SiPixelInformationExtractorPhase1::computeStatus()]"
+//	<< ACPlain << "    "
+//	<< theME->getName()
+//	<< " meanX:Y "
+//	<< meanX << ":" << meanY
+//	<< " normX:Y " 
+//	<< norm.first << ":" << norm.second
+//	<< endl ;
+  } 
+ 
+  return ;
+}
+
+//------------------------------------------------------------------------------
+/*! \brief (Documentation under construction).
+ *  
+ */
+void SiPixelInformationExtractorPhase1::getNormalization(MonitorElement     * theME, 
+                                                   pair<double,double>& norm,
+						   std::string          theMEType) 
+{
+  double normLow  = 0 ;
+  double normHigh = 0 ;
+
+  if( theMEType.find("TH1") != string::npos)
+  {
+   normHigh    = (double)theME->getNbinsX() ;
+   norm.first  = normLow  ;
+   norm.second = normHigh ;
+  }
+}
+
+//------------------------------------------------------------------------------
+/*! \brief (Documentation under construction).
+ *  
+ */
+void SiPixelInformationExtractorPhase1::getNormalization2D(MonitorElement     * theME, 
+                                                     pair<double,double>& normX,
+                                                     pair<double,double>& normY,
+						     std::string          theMEType) 
+{
+  double normLow  = 0 ;
+  double normHigh = 0 ;
+
+  if( theMEType.find("TH2") != string::npos )
+  {
+   normHigh    = (double)theME->getNbinsX() ;
+   normX.first  = normLow  ;
+   normX.second = normHigh ;
+   normHigh    = (double)theME->getNbinsY() ;
+   normY.first  = normLow  ;
+   normY.second = normHigh ;
+//   cout << ACCyan << ACBold << ACReverse
+//        << "[SiPixelInformationExtractorPhase1::getNormalization2D()]"
+//	<< ACPlain << " "
+//	<< theME->getName()
+//	<< " normX: " 
+//	<< normX.first << ":" << normX.second
+//	<< " normY: " 
+//	<< normY.first << ":" << normY.second
+//	<< endl ;
+  }
+}
+
+//------------------------------------------------------------------------------
+/*! \brief (Documentation under construction).
+ *
+ *   
+ */
+void SiPixelInformationExtractorPhase1::selectMEList(DQMStore   * bei,  
+					       string	               & theMEName,
+					       vector<MonitorElement*> & mes) 
+{  
+//  cout<<"In SiPixelInformationExtractorPhase1::selectMEList: "<<endl;
+  string currDir = bei->pwd();
+   
+  string theME ;
+   
+  // Get ME from Collector/FU0/Tracker/PixelEndcap/HalfCylinder_pX/Disk_X/Blade_XX/Panel_XX/Module_XX
+  if (currDir.find("Module_") != string::npos ||
+      currDir.find("FED_") != string::npos)  
+  {
+    vector<string> contents = bei->getMEs(); 
+       
+    for (vector<string>::const_iterator it = contents.begin(); it != contents.end(); it++) 
+    {
+      theME = (*it) ;
+      if(theME.find("siPixel")==string::npos && theME.find("ctfWithMaterialTracks")==string::npos) {continue ;} // If the ME is not a siPixel or ctfWithMaterialTrack one, skip
+      string temp_s = theME.substr(0,theME.find_first_of("_"));
+      //cout<<"should be the variable name: temp_s= "<<temp_s<<endl;
+      if (temp_s == theMEName)  
+      {
+        string full_path = currDir + "/" + (*it);
+
+        MonitorElement * me = bei->get(full_path.c_str());
+	
+        if (me) {mes.push_back(me);}
+      }
+    }
+    return;
+  } else {  // If not yet reached the desired level in the directory tree, recursively go down one level more
+    vector<string> subdirs = bei->getSubdirs();
+    for (vector<string>::const_iterator it = subdirs.begin(); it != subdirs.end(); it++) 
+    {
+      bei->cd(*it);
+      selectMEList(bei, theMEName, mes);
+      bei->goUp();
+    }
+  }
+}
+
+//------------------------------------------------------------------------------
+/*! \brief (Documentation under construction).
+ *  
+ */
+/* removing xdaq dependencies
+void SiPixelInformationExtractorPhase1::sendTkUpdatedStatus(DQMStore  * bei, 
+                                                      xgi::Output            * out,
+						      std::string            & theMEName,
+						      std::string            & theTKType) 
+{
+//  cout<<"In SiPixelInformationExtractorPhase1::sendTkUpdatedStatus: "<<endl;
+  int rval, gval, bval;
+  vector<string>          colorMap ;
+  vector<MonitorElement*> me_list;
+  pair<double,double>     norm ;
+  double sts ;
+    
+  bei->cd();
+  selectMEList(bei, theMEName, me_list) ;
+  bei->cd();
+
+  string detId = "undefined";
+
+   cout << ACYellow << ACBold
+	<< "[SiPixelInformationExtractorPhase1::sendTkUpdatedStatus()] "
+	<< ACPlain
+	<< "Preparing color map update for " 
+	<< theMEName
+	<< " type "
+	<< theTKType
+	<< " - List size: "
+	<< me_list.size() 
+	<< endl ;
+  
+  int maxEntries = 0 ;
+  if( theTKType == "Entries") // In this case find the ME with the highest number of entries
+  {			      // first and use that as a vertical scale normalization
+   for(vector<MonitorElement*>::iterator it=me_list.begin(); it!=me_list.end(); it++)
+   {
+    int entries = (int)(*it)->getEntries() ;
+    if( entries > maxEntries ) maxEntries = entries ;
+   }
+  }
+  
+  int entries = 0 ;
+  stringstream jsSnippet ;
+  for(vector<MonitorElement*>::iterator it=me_list.begin(); it!=me_list.end(); it++)
+  {
+    string meName    = (*it)->getName();
+    string theMEType = getMEType(*it);
+    if( meName.find("_3") != string::npos ) 
+    {
+     string detIdString = meName.substr(meName.find_last_of("_")+1,9);
+     std::istringstream isst;
+     isst.str(detIdString);
+     isst>>detId;
+     entries = (int)(*it)->getEntries() ;
+     if( theTKType == "Averages") 
+     {
+      computeStatus(*it, sts, norm) ;
+      SiPixelUtility::getStatusColor(sts, rval, gval, bval);
+     } else if( theTKType == "Entries") {
+      sts = (double)entries / (double)maxEntries ;
+      SiPixelUtility::getStatusColor(sts, rval, gval, bval);
+      if( entries > maxEntries ) maxEntries = entries ;
+      norm.first  = 0 ;
+      norm.second = maxEntries ;
+     } else {
+      int status  =  SiPixelUtility::getStatus((*it));
+      if(        status == dqm::qstatus::ERROR ) 
+      {
+       rval = 255; gval =   0; bval =   0;
+      } else if (status == dqm::qstatus::WARNING )  {
+       rval = 255; gval = 255; bval =   0; 
+      } else if (status == dqm::qstatus::OTHER)     {
+       rval =   0; gval =   0; bval = 255;
+      } else if (status == dqm::qstatus::STATUS_OK) {
+       rval =   0; gval = 255; bval =   0;
+      } else {  
+       rval = 255; gval = 255; bval = 255;
+      }
+     }
+     jsSnippet.str("") ;
+     jsSnippet << " <DetInfo DetId='"
+     	       << detId
+     	       << "' red='"
+     	       << rval
+     	       << "' green='"
+     	       << gval
+     	       << "' blue='"
+     	       << bval
+     	       << "' entries='"
+     	       << entries
+     	       << "'/>" ;
+     colorMap.push_back(jsSnippet.str()) ;
+//      if( it == me_list.begin()) // The first should be equal to all others...
+//      {
+//       getNormalization((*it), norm, theMEType.latin1()) ;
+//      }
+    }
+  }
+
+//  delete random ;
+  
+   cout << ACYellow << ACBold
+	<< "[SiPixelInformationExtractorPhase1::sendTkUpdatedStatus()] "
+	<< ACPlain
+	<< "Color map consists of "
+	<< colorMap.size()
+	<< " snippets: start shipping back"
+	<< endl ;
+
+  out->getHTTPResponseHeader().addHeader("Content-Type", "text/xml");
+  *out << "<?xml version=\"1.0\" ?>" << endl;
+  *out << "<TrackerMapUpdate>"       << endl;
+
+  for(vector<string>::iterator it=colorMap.begin(); it!=colorMap.end(); it++)
+  {
+   *out << *it << endl;
+  }
+ 
+  *out << " <theLimits id=\"normalizationLimits\" normLow=\"" 
+       << norm.first 
+       << "\" normHigh=\""
+       << norm.second 
+       << "\" />"
+       << endl;
+  *out << "</TrackerMapUpdate>"              
+       << endl;
+
+   cout << ACYellow << ACBold
+	<< "[SiPixelInformationExtractorPhase1::sendTkUpdatedStatus()] "
+	<< ACPlain
+	<< "Color map updated within range " 
+	<< norm.first
+	<< "-"
+	<< norm.second
+	<< endl ;
+
+}
+*/
+//------------------------------------------------------------------------------
+/*! \brief (Documentation under construction).
+ *  
+ *  Given a pointer to ME returns the associated detId 
+ */
+int SiPixelInformationExtractorPhase1::getDetId(MonitorElement * mE) 
+{
+//cout<<"In SiPixelInformationExtractorPhase1::getDetId: for ME= "<<mE->getName()<<endl;
+ string mEName = mE->getName();
+
+ int detId = 0;
+ 
+ if( mEName.find("_3") != string::npos )
+ {
+  string detIdString = mEName.substr((mEName.find_last_of("_"))+1,9);
+  //cout<<"string: "<<detIdString<<endl;
+  std::istringstream isst;
+  isst.str(detIdString);
+  isst>>detId;
+// } else {
+//  cout << ACYellow << ACBold
+//       << "[SiPixelInformationExtractorPhase1::getDetId()] "
+//       << ACPlain
+//       << "Could not extract detId from "
+//       << mEName
+//       << endl ;
+ }
+  //cout<<"returning with: "<<detId<<endl;
+  return detId ;
+  
+}
+
+//------------------------------------------------------------------------------
+/*! \brief (Documentation under construction).
+ *  
+ */
+void SiPixelInformationExtractorPhase1::getMEList(DQMStore    * bei,  
+					    map<string, int>         & mEHash)
+{
+  string currDir = bei->pwd();
+   
+//   cout << ACRed << ACBold
+//        << "[SiPixelInformationExtractorPhase1::getMEList()]"
+//        << ACPlain
+//        << " Requesting ME list in " 
+//        << currDir
+//        << endl ;
+       
+  string theME ;
+   
+  // Get ME from Collector/FU0/Tracker/PixelEndcap/HalfCylinder_pX/Disk_X/Blade_XX/Panel_XX/Module_XX
+  if (currDir.find("Module_") != string::npos ||
+      currDir.find("FED_") != string::npos)  
+  {
+    vector<string> contents = bei->getMEs(); 
+       
+    for (vector<string>::const_iterator it = contents.begin(); it != contents.end(); it++) 
+    {
+      theME = (*it) ;
+//       cout << ACRed << ACReverse
+//            << "[SiPixelInformationExtractorPhase1::getMEList()]"
+//            << ACPlain
+//            << " ME: " 
+//            << (*it)
+//            << endl ;
+      if(theME.find("siPixel")==string::npos && theME.find("ctfWithMaterialTracks")==string::npos) 
+      {
+       cout << ACRed << ACBold
+            << "[SiPixelInformationExtractorPhase1::getMEList()]"
+	    << ACPlain
+	    << " ----> Skipping " 
+	    << (*it)
+	    << endl ;
+       continue ;
+      } // If the ME is not a Pixel one, skip
+      string full_path = currDir + "/" + (*it);
+      string mEName = theME.substr(0,theME.find_first_of("_"));
+      mEHash[mEName]++ ;
+    }
+    
+    return;
+  } else {  // If not yet reached the desired level in the directory tree, recursively go down one level more
+    vector<string> subdirs = bei->getSubdirs();
+    for (vector<string>::const_iterator it = subdirs.begin(); it != subdirs.end(); it++) 
+    {
+      bei->cd(*it);
+      getMEList(bei, mEHash);
+      bei->goUp();
+    }
+  }
+}
+
+//
+// -- Get All histograms from a Path
+//
+/* removing xdaq deps
+void SiPixelInformationExtractorPhase1::getHistosFromPath(DQMStore * bei, 
+                                                    const std::multimap<std::string, std::string>& req_map, 
+						    xgi::Output * out){
+//cout<<"Entering SiPixelInformationExtractorPhase1::getHistosFromPath: "<<endl;
+  string path = getItemValue(req_map,"Path");
+//cout<<"Path is: "<<path<<endl;
+  if (path.size() == 0) return;
+
+  int width  = atoi(getItemValue(req_map, "width").c_str());
+  int height = atoi(getItemValue(req_map, "height").c_str());
+
+  string opt =" ";
+
+  setHTMLHeader(out);
+  vector<MonitorElement*> all_mes = bei->getContents(path);
+  *out << path << " " ;
+  for(vector<MonitorElement*>::iterator it=all_mes.begin(); it!=all_mes.end(); it++){
+    MonitorElement* me = (*it);
+    //cout<<"I'm in the loop now..."<<endl;
+    if (!me) continue;
+    string name = me->getName();
+    string full_path = path + "/" + name;
+//cout<<"Calling HP::setNewPlot now for "<<full_path<<endl;
+    histoPlotter_->setNewPlot(full_path, opt, width, height);
+    *out << name << " ";
+  }
+//  cout<<"... leaving SiPixelInformationExtractorPhase1::getHistosFromPath!"<<endl;
+}
+*/
+/////////////////////////////////////////////////////////////////////////////////////////////////////
+
+void SiPixelInformationExtractorPhase1::bookNoisyPixels(DQMStore * bei, float noiseRate_,bool Tier0Flag) {
+//std::cout<<"BOOK NOISY PIXEL MEs!"<<std::endl;
+  bei->cd();
+  if(noiseRate_>=0.){
+    bei->setCurrentFolder("Pixel/Barrel");
+    EventRateBarrelPixels = bei->book1D("barrelEventRate","Digi event rate for all Barrel pixels",1000,0.,0.01);
+    EventRateBarrelPixels->setAxisTitle("Event Rate",1);
+    EventRateBarrelPixels->setAxisTitle("Number of Pixels",2);
+    bei->cd();  
+    bei->setCurrentFolder("Pixel/Endcap");
+    EventRateEndcapPixels = bei->book1D("endcapEventRate","Digi event rate for all Endcap pixels",1000,0.,0.01);
+    EventRateEndcapPixels->setAxisTitle("Event Rate",1);
+    EventRateEndcapPixels->setAxisTitle("Number of Pixels",2);
+  }
+}
+
+          
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+void SiPixelInformationExtractorPhase1::findNoisyPixels(DQMStore * bei, bool init, float noiseRate_, int noiseRateDenominator_, edm::EventSetup const& eSetup)
+{
+//cout<<"Entering SiPixelInformationExtractorPhase1::findNoisyPixels with noiseRate set to "<<noiseRate_<<endl;
+
+  
+  if(init){
+    endOfModules_=false;
+    nevents_=noiseRateDenominator_;
+    if(nevents_ == -1){
+      bei->cd();
+      bei->setCurrentFolder("Pixel/EventInfo");
+      nevents_ = (bei->get("Pixel/EventInfo/processedEvents"))->getIntValue();
+    }
+    bei->cd();  
+    myfile_.open ("NoisyPixelList.txt", ios::app);
+    myfile_ << "Noise summary, ran over " << nevents_ << " events, threshold was set to " << noiseRate_ <<  std::endl;
+  }
+  string currDir = bei->pwd();
+  string dname = currDir.substr(currDir.find_last_of("/")+1);
+
+
+  if(dname.find("Module_")!=string::npos){
+    vector<string> meVec = bei->getMEs();
+    for (vector<string>::const_iterator it = meVec.begin(); it != meVec.end(); it++) {
+      string full_path = currDir + "/" + (*it);
+      if(full_path.find("hitmap_siPixelDigis")!=string::npos){
+        //broken HV bond:
+	//if(currDir.find("HalfCylinder_mI/Disk_1/Blade_01/Panel_2/Module_2")!=string::npos) continue;
+        //?noisy?
+	//if(currDir.find("HalfCylinder_mI/Disk_1/Blade_12/Panel_1/Module_4")!=string::npos) continue;
+        //ROG with HV problem (short?):
+	//if(currDir.find("HalfCylinder_mI/Disk_1/Blade_10/Panel_1/Module_3")!=string::npos) continue;
+	//if(currDir.find("HalfCylinder_mI/Disk_1/Blade_10/Panel_1/Module_4")!=string::npos) continue;
+	//if(currDir.find("HalfCylinder_mI/Disk_1/Blade_10/Panel_2/Module_2")!=string::npos) continue;
+	//if(currDir.find("HalfCylinder_mI/Disk_1/Blade_10/Panel_2/Module_3")!=string::npos) continue;
+	//if(currDir.find("HalfCylinder_mI/Disk_1/Blade_11/Panel_1/Module_3")!=string::npos) continue;
+	//if(currDir.find("HalfCylinder_mI/Disk_1/Blade_11/Panel_1/Module_4")!=string::npos) continue;
+	//if(currDir.find("HalfCylinder_mI/Disk_1/Blade_11/Panel_2/Module_2")!=string::npos) continue;
+	//if(currDir.find("HalfCylinder_mI/Disk_1/Blade_11/Panel_2/Module_3")!=string::npos) continue;
+	//if(currDir.find("HalfCylinder_mI/Disk_1/Blade_12/Panel_1/Module_3")!=string::npos) continue;
+	//if(currDir.find("HalfCylinder_mI/Disk_1/Blade_12/Panel_1/Module_4")!=string::npos) continue;
+	//if(currDir.find("HalfCylinder_mI/Disk_1/Blade_12/Panel_2/Module_2")!=string::npos) continue;
+	//if(currDir.find("HalfCylinder_mI/Disk_1/Blade_12/Panel_2/Module_3")!=string::npos) continue;
+        MonitorElement * me = bei->get(full_path);
+        if (!me) continue;
+	int detid=getDetId(me); int pixcol=-1; int pixrow=-1; 
+
+	//cout<<"detid= "<<detid<<endl;
+	std::vector<std::pair<std::pair<int, int>, float> > noisyPixelsInModule;
+	TH2F * hothisto = me->getTH2F();
+	if(hothisto){
+	  for(int i=1; i!=hothisto->GetNbinsX()+1; i++){
+	    for(int j=1; j!=hothisto->GetNbinsY()+1; j++){
+	      float value = (hothisto->GetBinContent(i,j))/float(nevents_);
+	      if(me->getPathname().find("Barrel")!=string::npos){
+        	EventRateBarrelPixels = bei->get("Pixel/Barrel/barrelEventRate");
+        	if(EventRateBarrelPixels) EventRateBarrelPixels->Fill(value);
+	      }else if(me->getPathname().find("Endcap")!=string::npos){
+        	EventRateEndcapPixels = bei->get("Pixel/Endcap/endcapEventRate");
+        	if(EventRateEndcapPixels) EventRateEndcapPixels->Fill(value);
+	      }
+	      if(value > noiseRate_){
+	        pixcol = i-1;
+	        pixrow = j-1;
+		//cout<<"pixcol= "<<pixcol<<" , pixrow= "<<pixrow<<" , value= "<<value<<endl;
+ 
+	        std::pair<int, int> address(pixcol, pixrow);
+	        std::pair<std::pair<int, int>, float>  PixelStats(address, value);
+	        noisyPixelsInModule.push_back(PixelStats);
+	      }
+            }
+	  }
+	}
+	noisyDetIds_[detid] = noisyPixelsInModule;
+	//if(noisyPixelsInModule.size()>=20) cout<<"This module has 20 or more hot pixels: "<<detid<<","<<bei->pwd()<<","<<noisyPixelsInModule.size()<<endl;
+      }
+    }
+  }
+  vector<string> subDirVec = bei->getSubdirs();  
+  for (vector<string>::const_iterator ic = subDirVec.begin();
+       ic != subDirVec.end(); ic++) {
+    if((*ic).find("AdditionalPixelErrors")!=string::npos) continue;
+    bei->cd(*ic);
+    init=false;
+    findNoisyPixels(bei,init,noiseRate_,noiseRateDenominator_,eSetup);
+    bei->goUp();
+  }
+
+  if(bei->pwd().find("EventInfo")!=string::npos) endOfModules_ = true;
+  
+  if(!endOfModules_) return;
+  // myfile_ <<"am in "<<bei->pwd()<<" now!"<<endl;
+  if(currDir == "Pixel/EventInfo/reportSummaryContents"){
+    eSetup.get<SiPixelFedCablingMapRcd>().get(theCablingMap);
+    std::vector<std::pair<sipixelobjects::DetectorIndex,double> > pixelvec;
+    std::map<uint32_t,int> myfedmap;
+    std::map<uint32_t,std::string> mynamemap;
+    int realfedID = -1;
+    //int Nnoisies = noisyDetIds_.size();
+    //cout<<"Number of noisy modules: "<<Nnoisies<<endl;
+    int counter = 0;
+    int n_noisyrocs_all = 0;
+    int n_noisyrocs_barrel = 0;
+    int n_noisyrocs_endcap = 0;
+    int n_verynoisyrocs_all = 0;
+    int n_verynoisyrocs_barrel = 0;
+    int n_verynoisyrocs_endcap = 0;
+
+    for(int fid = 0; fid < 40; fid++){
+    for(std::map<uint32_t, std::vector< std::pair<std::pair<int, int>, float> > >::const_iterator it = noisyDetIds_.begin(); 
+        it != noisyDetIds_.end(); it++){
+      uint32_t detid = (*it).first;
+      std::vector< std::pair<std::pair<int, int>, float> > noisyPixels = (*it).second;
+      //cout<<noisyPixels.size()<<" noisy pixels in a module: "<<detid<<endl;
+      // now convert into online conventions:
+      for(int fedid=0; fedid<=40; ++fedid){
+	SiPixelFrameConverter converter(theCablingMap.product(),fedid);
+	uint32_t newDetId = detid;
+	if(converter.hasDetUnit(newDetId)){
+	  realfedID=fedid;
+	  break;   
+	}
+      }
+      if(fid == realfedID){
+      //cout<<"FED ID is = "<<realfedID<<endl;
+      if(realfedID==-1) continue; 
+      DetId detId(detid);
+      uint32_t detSubId = detId.subdetId();
+      std::string outputname;
+      bool HalfModule = false;
+      if (detSubId == 2){   //FPIX
+	PixelEndcapName nameworker(detid);
+	outputname = nameworker.name();
+      } else if(detSubId == 1){   //BPIX
+	PixelBarrelName nameworker(detid);
+	outputname = nameworker.name();
+	HalfModule = nameworker.isHalfModule();
+
+      } else{
+	continue;
+      }	
+      std::map<int,int> myrocmap;
+      myfedmap[detid]=realfedID;
+      mynamemap[detid]=outputname;
+      
+      for(std::vector< std::pair< std::pair<int,int>, float> >::const_iterator pxl = noisyPixels.begin(); 
+          pxl != noisyPixels.end(); pxl++){
+        std::pair<int,int> offlineaddress = (*pxl).first;
+	float Noise_frac = (*pxl).second;
+	int offlineColumn = offlineaddress.first;
+        int offlineRow = offlineaddress.second;
+        counter++;
+        //cout<<"noisy pixel counter: "<<counter<<endl;
+
+        sipixelobjects::ElectronicIndex cabling; 
+        SiPixelFrameConverter formatter(theCablingMap.product(),realfedID);
+        sipixelobjects::DetectorIndex detector = {detid, offlineRow, offlineColumn};      
+	formatter.toCabling(cabling,detector);
+        // cabling should now contain cabling.roc and cabling.dcol  and cabling.pxid
+        // however, the coordinates now need to be converted from dcl,pxid to the row,col coordinates used in the calibration info 
+        sipixelobjects::LocalPixel::DcolPxid loc;
+        loc.dcol = cabling.dcol;
+        loc.pxid = cabling.pxid;
+	
+	
+	// OLD version, not 31X compatible:
+//        const sipixelobjects::PixelFEDCabling *theFed= theCablingMap.product()->fed(realfedID);
+//	const sipixelobjects::PixelFEDLink * link = theFed->link(cabling.link);
+//	const sipixelobjects::PixelROC *theRoc = link->roc(cabling.roc);
+//	sipixelobjects::LocalPixel locpixel(loc);
+	
+	
+	// FIX to adhere to new cabling map. To be replaced with CalibTracker/SiPixelTools detid - > hardware id classes ASAP.
+	//        const sipixelobjects::PixelFEDCabling *theFed= theCablingMap.product()->fed(realfedID);
+	//        const sipixelobjects::PixelFEDLink * link = theFed->link(cabling.link);
+	//        const sipixelobjects::PixelROC *theRoc = link->roc(cabling.roc);
+        sipixelobjects::LocalPixel locpixel(loc);
+        assert(realfedID >= 0);
+        assert(cabling.link >= 0);
+        assert(cabling.roc >= 0);
+	sipixelobjects::CablingPathToDetUnit path = {static_cast<unsigned int>(realfedID), 
+                                                     static_cast<unsigned int>(cabling.link),
+                                                     static_cast<unsigned int>(cabling.roc)};  
+	const sipixelobjects::PixelROC *theRoc = theCablingMap->findItem(path);
+	// END of FIX
+	
+        int onlineColumn = locpixel.rocCol();
+        int onlineRow= locpixel.rocRow();
+	myrocmap[(theRoc->idInDetUnit())]++;
+
+	// ROC numbers in the barrel go from 8 to 15 instead of 0 to 7 in half modules.  This is a 
+	// fix to get the roc number, and add 8 to it if:
+	// it's a Barrel module AND on the minus side AND a Half module
+
+	int rocnumber = -1;
+
+	if((detSubId == 1) && (outputname.find("mO")!=string::npos || outputname.find("mI")!=string::npos) && (HalfModule)){
+	  rocnumber = theRoc->idInDetUnit() + 8;
+	}
+	else{
+	  rocnumber = theRoc->idInDetUnit();
+	}
+
+        //cout<<counter<<" : \t detid= "<<detid<<" , OFF col,row= "<<offlineColumn<<","<<offlineRow<<" , ON roc,col,row= "<<theRoc->idInDetUnit()<<","<<onlineColumn<<","<<onlineRow<<endl;
+        myfile_ <<"NAME: "<<outputname<<" , DETID: "<<detid<<" , OFFLINE: col,row: "<<offlineColumn<<","<<offlineRow<<"  \t , ONLINE: roc,col,row: "<<rocnumber<<","<<onlineColumn<<","<<onlineRow<< "  \t , fed,dcol,pixid,link: "<<realfedID<<","<<loc.dcol<<","<<loc.pxid<<","<<cabling.link << ", Noise fraction: " << Noise_frac << std::endl;
+      }
+      for(std::map<int, int>::const_iterator nrc = myrocmap.begin(); nrc != myrocmap.end(); nrc++){
+	if((*nrc).second > 0){
+	  n_noisyrocs_all++;
+	  if(detSubId == 2){
+	    n_noisyrocs_endcap++;
+	  } else if(detSubId == 1){
+	    n_noisyrocs_barrel++;}
+	}
+	if((*nrc).second > 40){
+	  n_verynoisyrocs_all++;
+	  if(detSubId == 2){
+	    n_verynoisyrocs_endcap++;
+	  } else if(detSubId == 1){
+	    n_verynoisyrocs_barrel++;}
+	}
+      }
+      }
+
+    }
+    }
+    myfile_ << "There are " << n_noisyrocs_all << " noisy ROCs (ROCs with at least 1 noisy pixel) in the entire detector. " << n_noisyrocs_endcap << " are in the FPIX and " << n_noisyrocs_barrel << " are in the BPIX. " << endl;
+    myfile_ << "There are " << n_verynoisyrocs_all << " highly noisy ROCs (ROCs with at least 10% of all pixels passing the noise threshold) in the entire detector. " << n_verynoisyrocs_endcap << " are in the FPIX and " << n_verynoisyrocs_barrel << " are in the BPIX. " << endl;
+
+  }
+  myfile_.close();
+//cout<<"...leaving SiPixelInformationExtractorPhase1::findNoisyPixels!"<<endl;
+  return;
+}
+
+
+//
+// -- Create Images 
+//
+void SiPixelInformationExtractorPhase1::createImages(DQMStore* bei){
+  histoPlotter_->createPlots(bei);
+}
+
+//
+// -- Set HTML Header in xgi output
+//
+/* removing xdaq deps
+void SiPixelInformationExtractorPhase1::setHTMLHeader(xgi::Output * out) {
+  out->getHTTPResponseHeader().addHeader("Content-Type", "text/html");
+  out->getHTTPResponseHeader().addHeader("Pragma", "no-cache");   
+  out->getHTTPResponseHeader().addHeader("Cache-Control", "no-store, no-cache, must-revalidate,max-age=0");
+  out->getHTTPResponseHeader().addHeader("Expires","Mon, 26 Jul 1997 05:00:00 GMT");
+}
+*/
+//
+// -- Set XML Header in xgi output
+//
+/* removing xdaq deps
+void SiPixelInformationExtractorPhase1::setXMLHeader(xgi::Output * out) {
+  out->getHTTPResponseHeader().addHeader("Content-Type", "text/xml");
+  out->getHTTPResponseHeader().addHeader("Pragma", "no-cache");   
+  out->getHTTPResponseHeader().addHeader("Cache-Control", "no-store, no-cache, must-revalidate,max-age=0");
+  out->getHTTPResponseHeader().addHeader("Expires","Mon, 26 Jul 1997 05:00:00 GMT");
+  *out << "<?xml version=\"1.0\" ?>" << std::endl;
+
+}
+*/
+//
+// -- Set Plain Header in xgi output
+//
+/* removing xdaq deps
+void SiPixelInformationExtractorPhase1::setPlainHeader(xgi::Output * out) {
+  out->getHTTPResponseHeader().addHeader("Content-Type", "text/plain");
+  out->getHTTPResponseHeader().addHeader("Pragma", "no-cache");   
+  out->getHTTPResponseHeader().addHeader("Cache-Control", "no-store, no-cache, must-revalidate,max-age=0");
+  out->getHTTPResponseHeader().addHeader("Expires","Mon, 26 Jul 1997 05:00:00 GMT");
+
+}
+*/

--- a/DQM/SiPixelMonitorCluster/interface/SiPixelClusterModule.h
+++ b/DQM/SiPixelMonitorCluster/interface/SiPixelClusterModule.h
@@ -52,7 +52,7 @@ class SiPixelClusterModule {
   typedef edmNew::DetSet<SiPixelCluster>::const_iterator    ClusterIterator;
 
   /// Book histograms
-  void book(const edm::ParameterSet& iConfig, DQMStore::IBooker & iBooker, int type=0, bool twoD=true, bool reducedSet=false, bool isUpgrade=false);
+  void book(const edm::ParameterSet& iConfig, DQMStore::IBooker & iBooker, int type=0, bool twoD=true, bool reducedSet=false);
   /// Fill histograms
   int fill(const edmNew::DetSetVector<SiPixelCluster> & input, 
             const TrackerGeometry* tracker,
@@ -75,8 +75,7 @@ class SiPixelClusterModule {
 	    bool ringon=false, 
 	    bool twoD=true,
 	    bool reducedSet=false,
-	    bool smileyon=false,
-	    bool isUpgrade=false);
+	    bool smileyon=false);
   
  private:
 

--- a/DQM/SiPixelMonitorCluster/interface/SiPixelClusterModulePhase1.h
+++ b/DQM/SiPixelMonitorCluster/interface/SiPixelClusterModulePhase1.h
@@ -1,0 +1,203 @@
+#ifndef SiPixelMonitorCluster_SiPixelClusterModulePhase1_h
+#define SiPixelMonitorCluster_SiPixelClusterModulePhase1_h
+// -*- C++ -*-
+//
+// Package:    SiPixelMonitorDigi
+// Class:      SiPixelClusterModulePhase1
+// 
+/*
+
+ Description: Cluster monitoring elements for a Pixel sensor
+
+ Implementation:
+     <Notes on implementation>
+*/
+//
+// Original Author:  Vincenzo Chiochia & Andrew York
+//         Created:  
+//
+//
+//  Updated by: Lukas Wehrli
+//  for pixel offline DQM 
+#include "DQMServices/Core/interface/MonitorElement.h"
+#include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
+#include "DataFormats/Common/interface/DetSetVectorNew.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include <boost/cstdint.hpp>
+
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "Geometry/CommonTopologies/interface/PixelTopology.h"
+#include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDetType.h" 
+#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h" 
+#include "Geometry/TrackerGeometryBuilder/interface/GluedGeomDet.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/TrackerNumberingBuilder/interface/GeometricDet.h"
+#include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetType.h"
+class SiPixelClusterModulePhase1 {        
+
+ public:
+
+  /// Default constructor
+  SiPixelClusterModulePhase1();
+  /// Constructor with raw DetId
+  SiPixelClusterModulePhase1(const uint32_t& id);
+  /// Constructor with raw DetId and sensor size
+  SiPixelClusterModulePhase1(const uint32_t& id, const int& ncols, const int& nrows);
+  /// Destructor
+  ~SiPixelClusterModulePhase1();
+
+  typedef edmNew::DetSet<SiPixelCluster>::const_iterator    ClusterIterator;
+
+  /// Book histograms
+  void book(const edm::ParameterSet& iConfig, DQMStore::IBooker & iBooker, int type=0, bool twoD=true, bool reducedSet=false);
+  /// Fill histograms
+  int fill(const edmNew::DetSetVector<SiPixelCluster> & input, 
+            const TrackerGeometry* tracker,
+	    MonitorElement* layer1,
+	    MonitorElement* layer2,
+	    MonitorElement* layer3,
+	    MonitorElement* layer4,
+	    MonitorElement* disk1pz,
+	    MonitorElement* disk2pz,
+	    MonitorElement* disk3pz,
+	    MonitorElement* disk1mz,
+	    MonitorElement* disk2mz,
+	    MonitorElement* disk3mz,
+            bool modon=true, 
+	    bool ladon=false, 
+	    bool layon=false, 
+	    bool phion=false, 
+	    bool bladeon=false, 
+	    bool diskon=false, 
+	    bool ringon=false, 
+	    bool twoD=true,
+	    bool reducedSet=false,
+	    bool smileyon=false);
+  
+ private:
+
+  uint32_t id_;
+  int ncols_;
+  int nrows_;
+  MonitorElement* meNClusters_;
+  MonitorElement* meY_;
+  MonitorElement* meX_;
+  MonitorElement* meCharge_;
+  MonitorElement* meSize_;
+  MonitorElement* meSizeX_;
+  MonitorElement* meSizeY_;
+  MonitorElement* meMinRow_;
+  MonitorElement* meMaxRow_;
+  MonitorElement* meMinCol_;
+  MonitorElement* meMaxCol_;
+  MonitorElement* mePixClusters_;
+  MonitorElement* mePixClusters_px_;
+  MonitorElement* mePixClusters_py_;
+  //  MonitorElement* meEdgeHitX_;
+  //  MonitorElement* meEdgeHitY_;
+  MonitorElement* meClPosLayer1;
+  MonitorElement* meClPosLayer2;
+  MonitorElement* meClPosLayer3;
+  MonitorElement* meClPosLayer4;
+  MonitorElement* meClPosDisk1pz;
+  MonitorElement* meClPosDisk2pz;
+  MonitorElement* meClPosDisk3pz;
+  MonitorElement* meClPosDisk1mz;
+  MonitorElement* meClPosDisk2mz;
+  MonitorElement* meClPosDisk3mz;
+  
+  //barrel
+  MonitorElement* meNClustersLad_;
+  MonitorElement* meYLad_;
+  MonitorElement* meXLad_;
+  MonitorElement* meChargeLad_;
+  MonitorElement* meSizeLad_;
+  MonitorElement* meSizeXLad_;
+  MonitorElement* meSizeYLad_;
+  MonitorElement* meMinRowLad_;
+  MonitorElement* meMaxRowLad_;
+  MonitorElement* meMinColLad_;
+  MonitorElement* meMaxColLad_;
+  MonitorElement* mePixClustersLad_;
+  MonitorElement* mePixClustersLad_px_;
+  MonitorElement* mePixClustersLad_py_;
+
+  MonitorElement* meSizeYvsEtaBarrel_; 
+
+  MonitorElement* meNClustersLay_;
+  MonitorElement* meYLay_;
+  MonitorElement* meXLay_;
+  MonitorElement* meChargeLay_;
+  MonitorElement* meSizeLay_;
+  MonitorElement* meSizeXLay_;
+  MonitorElement* meSizeYLay_;
+  MonitorElement* meMinRowLay_;
+  MonitorElement* meMaxRowLay_;
+  MonitorElement* meMinColLay_;
+  MonitorElement* meMaxColLay_;
+  MonitorElement* mePixClustersLay_;
+  MonitorElement* mePixClustersLay_px_;
+  MonitorElement* mePixClustersLay_py_;
+
+  MonitorElement* meNClustersPhi_;
+  MonitorElement* meYPhi_;
+  MonitorElement* meXPhi_;
+  MonitorElement* meChargePhi_;
+  MonitorElement* meSizePhi_;
+  MonitorElement* meSizeXPhi_;
+  MonitorElement* meSizeYPhi_;
+  MonitorElement* meMinRowPhi_;
+  MonitorElement* meMaxRowPhi_;
+  MonitorElement* meMinColPhi_;
+  MonitorElement* meMaxColPhi_;
+  MonitorElement* mePixClustersPhi_;
+  MonitorElement* mePixClustersPhi_px_;
+  MonitorElement* mePixClustersPhi_py_;
+
+  //forward
+  MonitorElement* meNClustersBlade_;
+  MonitorElement* meYBlade_;
+  MonitorElement* meXBlade_;
+  MonitorElement* meChargeBlade_;
+  MonitorElement* meSizeBlade_;
+  MonitorElement* meSizeXBlade_;
+  MonitorElement* meSizeYBlade_;
+  MonitorElement* meMinRowBlade_;
+  MonitorElement* meMaxRowBlade_;
+  MonitorElement* meMinColBlade_;
+  MonitorElement* meMaxColBlade_;
+
+
+  MonitorElement* meNClustersDisk_;
+  MonitorElement* meYDisk_;
+  MonitorElement* meXDisk_;
+  MonitorElement* meChargeDisk_;
+  MonitorElement* meSizeDisk_;
+  MonitorElement* meSizeXDisk_;
+  MonitorElement* meSizeYDisk_;
+  MonitorElement* meMinRowDisk_;
+  MonitorElement* meMaxRowDisk_;
+  MonitorElement* meMinColDisk_;
+  MonitorElement* meMaxColDisk_;
+
+
+  MonitorElement* meNClustersRing_;
+  MonitorElement* meYRing_;
+  MonitorElement* meXRing_;
+  MonitorElement* meChargeRing_;
+  MonitorElement* meSizeRing_;
+  MonitorElement* meSizeXRing_;
+  MonitorElement* meSizeYRing_;
+  MonitorElement* meMinRowRing_;
+  MonitorElement* meMaxRowRing_;
+  MonitorElement* meMinColRing_;
+  MonitorElement* meMaxColRing_;
+  MonitorElement* mePixClustersRing_;
+  MonitorElement* mePixClustersRing_px_;
+  MonitorElement* mePixClustersRing_py_;
+
+};
+#endif

--- a/DQM/SiPixelMonitorCluster/interface/SiPixelClusterSource.h
+++ b/DQM/SiPixelMonitorCluster/interface/SiPixelClusterSource.h
@@ -93,7 +93,6 @@
        int nBigEvents;
        MonitorElement* bigFpixClusterEventRate;
        int bigEventSize;
-       bool isUpgrade;
 
   MonitorElement* meClPosLayer1;
   MonitorElement* meClPosLayer2;

--- a/DQM/SiPixelMonitorCluster/interface/SiPixelClusterSourcePhase1.h
+++ b/DQM/SiPixelMonitorCluster/interface/SiPixelClusterSourcePhase1.h
@@ -1,0 +1,112 @@
+#ifndef SiPixelMonitorCluster_SiPixelClusterSourcePhase1_h
+#define SiPixelMonitorCluster_SiPixelClusterSourcePhase1_h
+// -*- C++ -*-
+//
+// Package:     SiPixelMonitorCluster
+// Class  :     SiPixelClusterSourcePhase1
+// 
+/*
+
+ Description: <one line class summary>
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Vincenzo Chiochia & Andrew York
+//
+// Updated by: Lukas Wehrli
+// for pixel offline DQM 
+//         Created:  
+
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+
+#include "DQM/SiPixelMonitorCluster/interface/SiPixelClusterModulePhase1.h"
+
+#include "DataFormats/Common/interface/DetSetVectorNew.h"
+#include "DataFormats/SiPixelDigi/interface/PixelDigi.h"
+#include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
+
+
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include <boost/cstdint.hpp>
+
+#include "Geometry/CommonTopologies/interface/PixelTopology.h"
+#include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDetType.h" 
+#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h" 
+#include "Geometry/TrackerGeometryBuilder/interface/GluedGeomDet.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/TrackerNumberingBuilder/interface/GeometricDet.h"
+#include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetType.h"
+
+ class SiPixelClusterSourcePhase1 : public DQMEDAnalyzer {
+    public:
+       explicit SiPixelClusterSourcePhase1(const edm::ParameterSet& conf);
+       ~SiPixelClusterSourcePhase1();
+
+       typedef edmNew::DetSet<SiPixelCluster>::const_iterator    ClusterIterator;
+       
+       virtual void analyze(const edm::Event&, const edm::EventSetup&);
+       virtual void dqmBeginRun(const edm::Run&, edm::EventSetup const&) ;
+       virtual void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
+
+       virtual void buildStructure(edm::EventSetup const&);
+       virtual void bookMEs(DQMStore::IBooker &);
+
+    private:
+       edm::ParameterSet conf_;
+       edm::InputTag src_;
+       bool saveFile;
+       bool isPIB;
+       bool slowDown;
+       int eventNo;
+       std::map<uint32_t,SiPixelClusterModulePhase1*> thePixelStructure;
+       bool modOn; 
+       bool twoDimOn;
+       bool reducedSet;
+       //barrel:
+       bool ladOn, layOn, phiOn;
+       //forward:
+       bool ringOn, bladeOn, diskOn; 
+       bool smileyOn; //cluster sizeY vs Cluster eta plot 
+       bool firstRun;
+       int lumSec;
+       int nLumiSecs;
+       int nBigEvents;
+       MonitorElement* bigFpixClusterEventRate;
+       int bigEventSize;
+
+  MonitorElement* meClPosLayer1;
+  MonitorElement* meClPosLayer2;
+  MonitorElement* meClPosLayer3;
+  MonitorElement* meClPosLayer4;
+  MonitorElement* meClPosDisk1pz;
+  MonitorElement* meClPosDisk2pz;
+  MonitorElement* meClPosDisk3pz;
+  MonitorElement* meClPosDisk1mz;
+  MonitorElement* meClPosDisk2mz;
+  MonitorElement* meClPosDisk3mz;
+
+  //define Token(-s)
+  edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster> > srcToken_;
+};
+
+#endif

--- a/DQM/SiPixelMonitorCluster/python/SiPixelMonitorCluster_cfi.py
+++ b/DQM/SiPixelMonitorCluster/python/SiPixelMonitorCluster_cfi.py
@@ -19,3 +19,21 @@ SiPixelClusterSource = cms.EDAnalyzer("SiPixelClusterSource",
     bigEventSize = cms.untracked.int32(100)
 )
 
+SiPixelClusterSourcePhase1 = cms.EDAnalyzer("SiPixelClusterSourcePhase1",
+    src = cms.InputTag("siPixelClusters"),
+    outputFile = cms.string('Pixel_DQM_Cluster.root'),
+    saveFile = cms.untracked.bool(False),
+    slowDown = cms.untracked.bool(False),
+    isPIB = cms.untracked.bool(False),
+    modOn = cms.untracked.bool(True),
+    twoDimOn = cms.untracked.bool(True),                            
+    reducedSet = cms.untracked.bool(True),                            
+    ladOn = cms.untracked.bool(False),
+    layOn = cms.untracked.bool(False),
+    phiOn = cms.untracked.bool(False),
+    ringOn = cms.untracked.bool(False),
+    bladeOn = cms.untracked.bool(False),
+    diskOn = cms.untracked.bool(False),
+    smileyOn = cms.untracked.bool(True),
+    bigEventSize = cms.untracked.int32(100)
+)

--- a/DQM/SiPixelMonitorCluster/src/SiPixelClusterModule.cc
+++ b/DQM/SiPixelMonitorCluster/src/SiPixelClusterModule.cc
@@ -63,17 +63,13 @@ SiPixelClusterModule::~SiPixelClusterModule() {}
 //
 // Book histograms
 //
-void SiPixelClusterModule::book(const edm::ParameterSet& iConfig, DQMStore::IBooker & iBooker, int type, bool twoD, bool reducedSet, bool isUpgrade) {
+void SiPixelClusterModule::book(const edm::ParameterSet& iConfig, DQMStore::IBooker & iBooker, int type, bool twoD, bool reducedSet) {
   
   bool barrel = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
   bool endcap = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap);
   bool isHalfModule = false;
   if(barrel){
-    if (!isUpgrade) {
     isHalfModule = PixelBarrelName(DetId(id_)).isHalfModule(); 
-    } else if (isUpgrade) {
-      isHalfModule = PixelBarrelNameUpgrade(DetId(id_)).isHalfModule(); 
-    }
   }
   int nbinx = ncols_/2;
   int nbiny = nrows_/2;
@@ -144,8 +140,7 @@ void SiPixelClusterModule::book(const edm::ParameterSet& iConfig, DQMStore::IBoo
   }
   if(type==1 && barrel){
     uint32_t DBladder;
-    if (!isUpgrade) { DBladder = PixelBarrelName(DetId(id_)).ladderName(); }
-    else { DBladder = PixelBarrelNameUpgrade(DetId(id_)).ladderName(); }
+    DBladder = PixelBarrelName(DetId(id_)).ladderName();
     char sladder[80]; sprintf(sladder,"Ladder_%02i",DBladder);
     hid = src.label() + "_" + sladder;
     if(isHalfModule) hid += "H";
@@ -202,8 +197,7 @@ void SiPixelClusterModule::book(const edm::ParameterSet& iConfig, DQMStore::IBoo
   if(type==2 && barrel){
     
     uint32_t DBlayer;
-    if (!isUpgrade) { DBlayer = PixelBarrelName(DetId(id_)).layerName(); }
-    else { DBlayer = PixelBarrelNameUpgrade(DetId(id_)).layerName(); }
+    DBlayer = PixelBarrelName(DetId(id_)).layerName();
     char slayer[80]; sprintf(slayer,"Layer_%i",DBlayer);
     hid = src.label() + "_" + slayer;
     // Number of clusters
@@ -264,8 +258,7 @@ void SiPixelClusterModule::book(const edm::ParameterSet& iConfig, DQMStore::IBoo
   }
   if(type==3 && barrel){
     uint32_t DBmodule;
-    if (!isUpgrade) { DBmodule = PixelBarrelName(DetId(id_)).moduleName(); }
-    else { DBmodule = PixelBarrelNameUpgrade(DetId(id_)).moduleName(); }
+    DBmodule = PixelBarrelName(DetId(id_)).moduleName();
     char smodule[80]; sprintf(smodule,"Ring_%i",DBmodule);
     hid = src.label() + "_" + smodule;
     // Number of clusters
@@ -327,8 +320,7 @@ void SiPixelClusterModule::book(const edm::ParameterSet& iConfig, DQMStore::IBoo
 
   if(type==4 && endcap){
     uint32_t blade;
-    if (!isUpgrade) { blade = PixelEndcapName(DetId(id_)).bladeName(); }
-    else { blade = PixelEndcapNameUpgrade(DetId(id_)).bladeName(); }
+    blade = PixelEndcapName(DetId(id_)).bladeName();
     
     char sblade[80]; sprintf(sblade, "Blade_%02i",blade);
     hid = src.label() + "_" + sblade;
@@ -370,8 +362,7 @@ void SiPixelClusterModule::book(const edm::ParameterSet& iConfig, DQMStore::IBoo
   }
   if(type==5 && endcap){
     uint32_t disk;
-    if (!isUpgrade) { disk = PixelEndcapName(DetId(id_)).diskName(); }
-    else { disk = PixelEndcapNameUpgrade(DetId(id_)).diskName(); }
+    disk = PixelEndcapName(DetId(id_)).diskName();
     
     char sdisk[80]; sprintf(sdisk, "Disk_%i",disk);
     hid = src.label() + "_" + sdisk;
@@ -415,13 +406,8 @@ void SiPixelClusterModule::book(const edm::ParameterSet& iConfig, DQMStore::IBoo
   if(type==6 && endcap){
     uint32_t panel;
     uint32_t module;
-    if (!isUpgrade) {
-      panel= PixelEndcapName(DetId(id_)).pannelName();
-      module= PixelEndcapName(DetId(id_)).plaquetteName();
-    } else {
-      panel= PixelEndcapNameUpgrade(DetId(id_)).pannelName();
-      module= PixelEndcapNameUpgrade(DetId(id_)).plaquetteName();
-    }
+    panel= PixelEndcapName(DetId(id_)).pannelName();
+    module= PixelEndcapName(DetId(id_)).plaquetteName();
     
     char slab[80]; sprintf(slab, "Panel_%i_Ring_%i",panel, module);
     hid = src.label() + "_" + slab;
@@ -478,7 +464,7 @@ void SiPixelClusterModule::book(const edm::ParameterSet& iConfig, DQMStore::IBoo
 //
 // Fill histograms
 //
-int SiPixelClusterModule::fill(const edmNew::DetSetVector<SiPixelCluster>& input, const TrackerGeometry* tracker,MonitorElement* layer1,MonitorElement* layer2,MonitorElement* layer3,MonitorElement* layer4,MonitorElement* disk1pz,MonitorElement* disk2pz,MonitorElement* disk3pz,MonitorElement* disk1mz,MonitorElement* disk2mz,MonitorElement* disk3mz,bool modon, bool ladon, bool layon, bool phion, bool bladeon, bool diskon, bool ringon, bool twoD, bool reducedSet, bool smileyon, bool isUpgrade) {
+int SiPixelClusterModule::fill(const edmNew::DetSetVector<SiPixelCluster>& input, const TrackerGeometry* tracker,MonitorElement* layer1,MonitorElement* layer2,MonitorElement* layer3,MonitorElement* layer4,MonitorElement* disk1pz,MonitorElement* disk2pz,MonitorElement* disk3pz,MonitorElement* disk1mz,MonitorElement* disk2mz,MonitorElement* disk3mz,bool modon, bool ladon, bool layon, bool phion, bool bladeon, bool diskon, bool ringon, bool twoD, bool reducedSet, bool smileyon) {
   
   bool barrel = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
   bool endcap = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap);
@@ -514,8 +500,7 @@ int SiPixelClusterModule::fill(const edmNew::DetSetVector<SiPixelCluster>& input
 
       if(barrel){
 	uint32_t DBlayer;
-	if (!isUpgrade) { DBlayer = PixelBarrelName(DetId(id_)).layerName(); }
-	else { DBlayer = PixelBarrelNameUpgrade(DetId(id_)).layerName(); }
+	DBlayer = PixelBarrelName(DetId(id_)).layerName();
 	switch(DBlayer){
 	case 1: {
 	  if(layer1) layer1->Fill(clustgp.z(),clustgp.phi());
@@ -527,16 +512,11 @@ int SiPixelClusterModule::fill(const edmNew::DetSetVector<SiPixelCluster>& input
 	  if(layer3) layer3->Fill(clustgp.z(),clustgp.phi());
 	  break;
 	} case 4: {
-	  if (isUpgrade) {
-	    if(layer4) layer4->Fill(clustgp.z(),clustgp.phi());
-	    break;
-	  }
 	  }
 	}
       }else if(endcap){
 	uint32_t DBdisk;
-	if (!isUpgrade) { DBdisk = PixelEndcapName(DetId(id_)).diskName(); }
-	else if (isUpgrade) { DBdisk = PixelEndcapNameUpgrade(DetId(id_)).diskName(); }
+	DBdisk = PixelEndcapName(DetId(id_)).diskName();
 	if(clustgp.z()>0){
 	  switch(DBdisk){
 	  case 1: {
@@ -546,10 +526,6 @@ int SiPixelClusterModule::fill(const edmNew::DetSetVector<SiPixelCluster>& input
 	    if(disk2pz) disk2pz->Fill(clustgp.x(),clustgp.y());
 	    break;
 	  } case 3: {
-	    if (isUpgrade) {
-	      if(disk3pz) disk3pz->Fill(clustgp.x(),clustgp.y());
-	      break;
-	    }
 	    }}
 	}else{
 	  switch(DBdisk){
@@ -560,10 +536,6 @@ int SiPixelClusterModule::fill(const edmNew::DetSetVector<SiPixelCluster>& input
 	    if(disk2mz) disk2mz->Fill(clustgp.x(),clustgp.y());
 	    break;
 	  } case 3: {
-	    if (isUpgrade) {
-	    if(disk3mz) disk3mz->Fill(clustgp.x(),clustgp.y());
-	    break;
-	    }
 	    }
 	  }
 	} 

--- a/DQM/SiPixelMonitorCluster/src/SiPixelClusterModulePhase1.cc
+++ b/DQM/SiPixelMonitorCluster/src/SiPixelClusterModulePhase1.cc
@@ -1,0 +1,700 @@
+// -*- C++ -*-
+//
+// Package:    SiPixelMonitorCluster
+// Class:      SiPixelClusterSource
+// 
+/**\class 
+
+ Description: Pixel DQM source for Clusters
+
+ Implementation:
+     Note that the x- and y-directions referred to in the cluster description refer to local x- and y-values given by the clusterizer.  Local x corresponds to row value and local y corresponds to column value.
+*/
+//
+// Original Author:  Vincenzo Chiochia & Andrew York
+//         Created:  
+//
+//
+// Updated by: Lukas Wehrli
+// for pixel offline DQM 
+#include "DQM/SiPixelMonitorCluster/interface/SiPixelClusterModulePhase1.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQM/SiPixelCommon/interface/SiPixelHistogramId.h"
+/// Framework
+#include "FWCore/ServiceRegistry/interface/Service.h"
+// STL
+#include <vector>
+#include <memory>
+#include <string>
+#include <iostream>
+#include <stdlib.h>
+
+// Data Formats
+#include "DataFormats/SiPixelDetId/interface/PixelBarrelName.h"
+#include "DataFormats/SiPixelDetId/interface/PixelBarrelNameUpgrade.h"
+#include "DataFormats/SiPixelDetId/interface/PixelEndcapName.h"
+#include "DataFormats/SiPixelDetId/interface/PixelEndcapNameUpgrade.h"
+#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+//
+// Constructors
+//
+SiPixelClusterModulePhase1::SiPixelClusterModulePhase1() : id_(0),
+					 ncols_(416),
+					 nrows_(160) { }
+///
+SiPixelClusterModulePhase1::SiPixelClusterModulePhase1(const uint32_t& id) : 
+  id_(id),
+  ncols_(416),
+  nrows_(160)
+{ 
+}
+///
+SiPixelClusterModulePhase1::SiPixelClusterModulePhase1(const uint32_t& id, const int& ncols, const int& nrows) : 
+  id_(id),
+  ncols_(ncols),
+  nrows_(nrows)
+{ 
+}
+//
+// Destructor
+//
+SiPixelClusterModulePhase1::~SiPixelClusterModulePhase1() {}
+//
+// Book histograms
+//
+void SiPixelClusterModulePhase1::book(const edm::ParameterSet& iConfig, DQMStore::IBooker & iBooker, int type, bool twoD, bool reducedSet) {
+  
+  bool barrel = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
+  bool endcap = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap);
+  bool isHalfModule = false;
+  if(barrel){
+    isHalfModule = PixelBarrelNameUpgrade(DetId(id_)).isHalfModule(); 
+  }
+  int nbinx = ncols_/2;
+  int nbiny = nrows_/2;
+
+  std::string hid;
+  // Get collection name and instantiate Histo Id builder
+  edm::InputTag src = iConfig.getParameter<edm::InputTag>( "src" );
+  if(type==0){
+    SiPixelHistogramId* theHistogramId = new SiPixelHistogramId( src.label() );
+    if(!reducedSet){
+      // Lowest cluster row
+      hid = theHistogramId->setHistoId("minrow",id_);
+      meMinRow_ = iBooker.book1D(hid,"Lowest cluster row",200,0.,200.);
+      meMinRow_->setAxisTitle("Lowest cluster row",1);
+      // Highest cluster row
+      hid = theHistogramId->setHistoId("maxrow",id_);
+      meMaxRow_ = iBooker.book1D(hid,"Highest cluster row",200,0.,200.);
+      meMaxRow_->setAxisTitle("Highest cluster row",1);
+      // Lowest cluster column
+      hid = theHistogramId->setHistoId("mincol",id_);
+      meMinCol_ = iBooker.book1D(hid,"Lowest cluster column",500,0.,500.);
+      meMinCol_->setAxisTitle("Lowest cluster column",1);
+      // Highest cluster column
+      hid = theHistogramId->setHistoId("maxcol",id_);
+      meMaxCol_ = iBooker.book1D(hid,"Highest cluster column",500,0.,500.);
+      meMaxCol_->setAxisTitle("Highest cluster column",1);
+      // Cluster barycenter X position
+      hid = theHistogramId->setHistoId("x",id_);
+      meX_ = iBooker.book1D(hid,"Cluster barycenter X (row #)",200,0.,200.);
+      meX_->setAxisTitle("Barycenter x-position [row #]",1);
+      // Cluster barycenter Y position
+      hid = theHistogramId->setHistoId("y",id_);
+      meY_ = iBooker.book1D(hid,"Cluster barycenter Y (column #)",500,0.,500.);
+      meY_->setAxisTitle("Barycenter y-position [column #]",1);
+      // Cluster width on the x-axis
+      hid = theHistogramId->setHistoId("sizeX",id_);
+      meSizeX_ = iBooker.book1D(hid,"Cluster x-width (rows)",10,0.,10.);
+      meSizeX_->setAxisTitle("Cluster x-size [rows]",1);
+      // Cluster width on the y-axis
+      hid = theHistogramId->setHistoId("sizeY",id_);
+      meSizeY_ = iBooker.book1D(hid,"Cluster y-width (columns)",15,0.,15.);
+      meSizeY_->setAxisTitle("Cluster y-size [columns]",1);
+      int nbinx = ncols_/2;
+      int nbiny = nrows_/2;
+      hid = theHistogramId->setHistoId("hitmap",id_);
+      if(twoD){
+        // 2D hit map
+        mePixClusters_ = iBooker.book2D(hid,"Number of Clusters (1bin=four pixels)",nbinx,0.,float(ncols_),nbiny,0.,float(nrows_));
+        mePixClusters_->setAxisTitle("Columns",1);
+        mePixClusters_->setAxisTitle("Rows",2);
+      }else{
+        // projections of hitmap
+        mePixClusters_px_ = iBooker.book1D(hid+"_px","Number of Clusters (1bin=two columns)",nbinx,0.,float(ncols_));
+        mePixClusters_py_ = iBooker.book1D(hid+"_py","Number of Clusters (1bin=two rows)",nbiny,0.,float(nrows_));
+        mePixClusters_px_->setAxisTitle("Columns",1);
+        mePixClusters_py_->setAxisTitle("Rows",1);
+      }
+    }
+    delete theHistogramId;
+  }
+
+  //**
+  if(barrel && type==7){
+    hid = src.label() + "_Barrel";
+    meSizeYvsEtaBarrel_= iBooker.book2D("sizeYvsEta_" + hid,"Cluster size along beamline vs. Cluster position #eta",60,-3.,3.,40,0.,40.);
+    meSizeYvsEtaBarrel_->setAxisTitle("Cluster #eta",1);
+    meSizeYvsEtaBarrel_->setAxisTitle("Cluster size along beamline [number of pixels]",2);
+  }
+  if(type==1 && barrel){
+    uint32_t DBladder;
+    DBladder = PixelBarrelNameUpgrade(DetId(id_)).ladderName();
+    char sladder[80]; sprintf(sladder,"Ladder_%02i",DBladder);
+    hid = src.label() + "_" + sladder;
+    if(isHalfModule) hid += "H";
+    else hid += "F";
+    // Number of clusters
+    meNClustersLad_ = iBooker.book1D("nclusters_" + hid,"Number of Clusters",8,0.,8.);
+    meNClustersLad_->setAxisTitle("Number of Clusters",1);
+    // Total cluster charge in MeV
+    meChargeLad_ = iBooker.book1D("charge_" + hid,"Cluster charge",100,0.,200.);
+    meChargeLad_->setAxisTitle("Charge [kilo electrons]",1);
+    // Total cluster size (in pixels)
+    meSizeLad_ = iBooker.book1D("size_" + hid,"Total cluster size",30,0.,30.);
+    meSizeLad_->setAxisTitle("Cluster size [number of pixels]",1);
+    if(!reducedSet){
+      // Lowest cluster row
+      meMinRowLad_ = iBooker.book1D("minrow_" + hid,"Lowest cluster row",200,0.,200.);
+      meMinRowLad_->setAxisTitle("Lowest cluster row",1);
+      // Highest cluster row
+      meMaxRowLad_ = iBooker.book1D("maxrow_" + hid,"Highest cluster row",200,0.,200.);
+      meMaxRowLad_->setAxisTitle("Highest cluster row",1);
+      // Lowest cluster column
+      meMinColLad_ = iBooker.book1D("mincol_" + hid,"Lowest cluster column",500,0.,500.);
+      meMinColLad_->setAxisTitle("Lowest cluster column",1);
+      // Highest cluster column
+      meMaxColLad_ = iBooker.book1D("maxcol_" + hid,"Highest cluster column",500,0.,500.);
+      meMaxColLad_->setAxisTitle("Highest cluster column",1);
+      // Cluster barycenter X position
+      meXLad_ = iBooker.book1D("x_" + hid,"Cluster barycenter X (row #)",200,0.,200.);
+      meXLad_->setAxisTitle("Barycenter x-position [row #]",1);
+      // Cluster barycenter Y position
+      meYLad_ = iBooker.book1D("y_" + hid,"Cluster barycenter Y (column #)",500,0.,500.);
+      meYLad_->setAxisTitle("Barycenter y-position [column #]",1);
+      // Cluster width on the x-axis
+      meSizeXLad_ = iBooker.book1D("sizeX_" + hid,"Cluster x-width (rows)",10,0.,10.);
+      meSizeXLad_->setAxisTitle("Cluster x-size [rows]",1);
+      // Cluster width on the y-axis
+      meSizeYLad_ = iBooker.book1D("sizeY_" + hid,"Cluster y-width (columns)",15,0.,15.);
+      meSizeYLad_->setAxisTitle("Cluster y-size [columns]",1);
+      if(twoD){
+        // 2D hit map
+        mePixClustersLad_ = iBooker.book2D("hitmap_" + hid,"Number of Clusters (1bin=four pixels)",nbinx,0.,float(ncols_),nbiny,0.,float(nrows_));
+        mePixClustersLad_->setAxisTitle("Columns",1);
+        mePixClustersLad_->setAxisTitle("Rows",2);
+      }else{
+        // projections of hitmap
+        mePixClustersLad_px_ = iBooker.book1D("hitmap_" + hid+"_px","Number of Clusters (1bin=two columns)",nbinx,0.,float(ncols_));
+        mePixClustersLad_py_ = iBooker.book1D("hitmap_" + hid+"_py","Number of Clusters (1bin=two rows)",nbiny,0.,float(nrows_));
+        mePixClustersLad_px_->setAxisTitle("Columns",1);
+        mePixClustersLad_py_->setAxisTitle("Rows",1);
+      }
+    }
+  }
+
+  if(type==2 && barrel){
+    
+    uint32_t DBlayer;
+    DBlayer = PixelBarrelNameUpgrade(DetId(id_)).layerName();
+    char slayer[80]; sprintf(slayer,"Layer_%i",DBlayer);
+    hid = src.label() + "_" + slayer;
+    // Number of clusters
+    meNClustersLay_ = iBooker.book1D("nclusters_" + hid,"Number of Clusters",8,0.,8.);
+    meNClustersLay_->setAxisTitle("Number of Clusters",1);
+    // Total cluster charge in MeV
+    meChargeLay_ = iBooker.book1D("charge_" + hid,"Cluster charge",100,0.,200.);
+    meChargeLay_->setAxisTitle("Charge [kilo electrons]",1);
+    // Total cluster size (in pixels)
+    meSizeLay_ = iBooker.book1D("size_" + hid,"Total cluster size",30,0.,30.);
+    meSizeLay_->setAxisTitle("Cluster size [in pixels]",1);
+    if(!reducedSet){
+      // Lowest cluster row
+      meMinRowLay_ = iBooker.book1D("minrow_" + hid,"Lowest cluster row",200,0.,200.);
+      meMinRowLay_->setAxisTitle("Lowest cluster row",1);
+      // Highest cluster row
+      meMaxRowLay_ = iBooker.book1D("maxrow_" + hid,"Highest cluster row",200,0.,200.);
+      meMaxRowLay_->setAxisTitle("Highest cluster row",1);
+      // Lowest cluster column
+      meMinColLay_ = iBooker.book1D("mincol_" + hid,"Lowest cluster column",500,0.,500.);
+      meMinColLay_->setAxisTitle("Lowest cluster column",1);
+      // Highest cluster column
+      meMaxColLay_ = iBooker.book1D("maxcol_" + hid,"Highest cluster column",500,0.,500.);
+      meMaxColLay_->setAxisTitle("Highest cluster column",1);
+      // Cluster barycenter X position
+      meXLay_ = iBooker.book1D("x_" + hid,"Cluster barycenter X (row #)",200,0.,200.);
+      meXLay_->setAxisTitle("Barycenter x-position [row #]",1);
+      // Cluster barycenter Y position
+      meYLay_ = iBooker.book1D("y_" + hid,"Cluster barycenter Y (column #)",500,0.,500.);
+      meYLay_->setAxisTitle("Barycenter y-position [column #]",1);
+      // Cluster width on the x-axis
+      meSizeXLay_ = iBooker.book1D("sizeX_" + hid,"Cluster x-width (rows)",10,0.,10.);
+      meSizeXLay_->setAxisTitle("Cluster x-size [rows]",1);
+      // Cluster width on the y-axis
+      meSizeYLay_ = iBooker.book1D("sizeY_" + hid,"Cluster y-width (columns)",15,0.,15.);
+      meSizeYLay_->setAxisTitle("Cluster y-size [columns]",1);
+      if(twoD){
+        // 2D hit map
+        if(isHalfModule){
+	  mePixClustersLay_ = iBooker.book2D("hitmap_" + hid,"Number of Clusters (1bin=four pixels)",nbinx,0.,float(ncols_),2*nbiny,0.,float(2*nrows_));
+        }else{
+	  mePixClustersLay_ = iBooker.book2D("hitmap_" + hid,"Number of Clusters (1bin=four pixels)",nbinx,0.,float(ncols_),nbiny,0.,float(nrows_));
+        }
+        mePixClustersLay_->setAxisTitle("Columns",1);
+        mePixClustersLay_->setAxisTitle("Rows",2);
+      }else{
+        // projections of hitmap
+        mePixClustersLay_px_ = iBooker.book1D("hitmap_" + hid+"_px","Number of Clusters (1bin=two columns)",nbinx,0.,float(ncols_));
+        if(isHalfModule){
+	  mePixClustersLay_py_ = iBooker.book1D("hitmap_" + hid+"_py","Number of Clusters (1bin=two rows)",2*nbiny,0.,float(2*nrows_));
+        }else{
+	  mePixClustersLay_py_ = iBooker.book1D("hitmap_" + hid+"_py","Number of Clusters (1bin=two rows)",nbiny,0.,float(nrows_));
+        }
+        mePixClustersLay_px_->setAxisTitle("Columns",1);
+        mePixClustersLay_py_->setAxisTitle("Rows",1);
+      }
+    }
+  }
+  if(type==3 && barrel){
+    uint32_t DBmodule;
+    DBmodule = PixelBarrelNameUpgrade(DetId(id_)).moduleName();
+    char smodule[80]; sprintf(smodule,"Ring_%i",DBmodule);
+    hid = src.label() + "_" + smodule;
+    // Number of clusters
+    meNClustersPhi_ = iBooker.book1D("nclusters_" + hid,"Number of Clusters",8,0.,8.);
+    meNClustersPhi_->setAxisTitle("Number of Clusters",1);
+    // Total cluster charge in MeV
+    meChargePhi_ = iBooker.book1D("charge_" + hid,"Cluster charge",100,0.,200.);
+    meChargePhi_->setAxisTitle("Charge [kilo electrons]",1);
+    // Total cluster size (in pixels)
+    meSizePhi_ = iBooker.book1D("size_" + hid,"Total cluster size",30,0.,30.);
+    meSizePhi_->setAxisTitle("Cluster size [number of pixels]",1);
+    if(!reducedSet){
+      // Lowest cluster row
+      meMinRowPhi_ = iBooker.book1D("minrow_" + hid,"Lowest cluster row",200,0.,200.);
+      meMinRowPhi_->setAxisTitle("Lowest cluster row",1);
+      // Highest cluster row
+      meMaxRowPhi_ = iBooker.book1D("maxrow_" + hid,"Highest cluster row",200,0.,200.);
+      meMaxRowPhi_->setAxisTitle("Highest cluster row",1);
+      // Lowest cluster column
+      meMinColPhi_ = iBooker.book1D("mincol_" + hid,"Lowest cluster column",500,0.,500.);
+      meMinColPhi_->setAxisTitle("Lowest cluster column",1);
+      // Highest cluster column
+      meMaxColPhi_ = iBooker.book1D("maxcol_" + hid,"Highest cluster column",500,0.,500.);
+      meMaxColPhi_->setAxisTitle("Highest cluster column",1);
+      // Cluster barycenter X position
+      meXPhi_ = iBooker.book1D("x_" + hid,"Cluster barycenter X (row #)",200,0.,200.);
+      meXPhi_->setAxisTitle("Barycenter x-position [row #]",1);
+      // Cluster barycenter Y position
+      meYPhi_ = iBooker.book1D("y_" + hid,"Cluster barycenter Y (column #)",500,0.,500.);
+      meYPhi_->setAxisTitle("Barycenter y-position [column #]",1);
+      // Cluster width on the x-axis
+      meSizeXPhi_ = iBooker.book1D("sizeX_" + hid,"Cluster x-width (rows)",10,0.,10.);
+      meSizeXPhi_->setAxisTitle("Cluster x-size [rows]",1);
+      // Cluster width on the y-axis
+      meSizeYPhi_ = iBooker.book1D("sizeY_" + hid,"Cluster y-width (columns)",15,0.,15.);
+      meSizeYPhi_->setAxisTitle("Cluster y-size [columns]",1);
+      if(twoD){
+        // 2D hit map
+        if(isHalfModule){
+	  mePixClustersPhi_ = iBooker.book2D("hitmap_" + hid,"Number of Clusters (1bin=four pixels)",nbinx,0.,float(ncols_),2*nbiny,0.,float(2*nrows_));
+        }else{
+	  mePixClustersPhi_ = iBooker.book2D("hitmap_" + hid,"Number of Clusters (1bin=four pixels)",nbinx,0.,float(ncols_),nbiny,0.,float(nrows_));
+        }
+        mePixClustersPhi_->setAxisTitle("Columns",1);
+        mePixClustersPhi_->setAxisTitle("Rows",2);
+      }else{
+        // projections of hitmap
+        mePixClustersPhi_px_ = iBooker.book1D("hitmap_" + hid+"_px","Number of Clusters (1bin=two columns)",nbinx,0.,float(ncols_));
+        if(isHalfModule){
+	  mePixClustersPhi_py_ = iBooker.book1D("hitmap_" + hid+"_py","Number of Clusters (1bin=two rows)",2*nbiny,0.,float(2*nrows_));
+        }else{
+	  mePixClustersPhi_py_ = iBooker.book1D("hitmap_" + hid+"_py","Number of Clusters (1bin=two rows)",nbiny,0.,float(nrows_));
+        }
+        mePixClustersPhi_px_->setAxisTitle("Columns",1);
+        mePixClustersPhi_py_->setAxisTitle("Rows",1);
+      }
+    }
+  }
+
+  if(type==4 && endcap){
+    uint32_t blade;
+    blade = PixelEndcapNameUpgrade(DetId(id_)).bladeName();
+    
+    char sblade[80]; sprintf(sblade, "Blade_%02i",blade);
+    hid = src.label() + "_" + sblade;
+    // Number of clusters
+    meNClustersBlade_ = iBooker.book1D("nclusters_" + hid,"Number of Clusters",8,0.,8.);
+    meNClustersBlade_->setAxisTitle("Number of Clusters",1);
+    // Total cluster charge in MeV
+    meChargeBlade_ = iBooker.book1D("charge_" + hid,"Cluster charge",100,0.,200.);
+    meChargeBlade_->setAxisTitle("Charge [kilo electrons]",1);
+    // Total cluster size (in pixels)
+    meSizeBlade_ = iBooker.book1D("size_" + hid,"Total cluster size",30,0.,30.);
+    meSizeBlade_->setAxisTitle("Cluster size [number of pixels]",1);
+    if(!reducedSet){
+      // Lowest cluster row
+      meMinRowBlade_ = iBooker.book1D("minrow_" + hid,"Lowest cluster row",200,0.,200.);
+      meMinRowBlade_->setAxisTitle("Lowest cluster row",1);
+      // Highest cluster row
+      meMaxRowBlade_ = iBooker.book1D("maxrow_" + hid,"Highest cluster row",200,0.,200.);
+      meMaxRowBlade_->setAxisTitle("Highest cluster row",1);
+      // Lowest cluster column
+      meMinColBlade_ = iBooker.book1D("mincol_" + hid,"Lowest cluster column",500,0.,500.);
+      meMinColBlade_->setAxisTitle("Lowest cluster column",1);
+      // Highest cluster column
+      meMaxColBlade_ = iBooker.book1D("maxcol_" + hid,"Highest cluster column",500,0.,500.);
+      meMaxColBlade_->setAxisTitle("Highest cluster column",1);
+      // Cluster barycenter X position
+      meXBlade_ = iBooker.book1D("x_" + hid,"Cluster barycenter X (row #)",200,0.,200.);
+      meXBlade_->setAxisTitle("Barycenter x-position [row #]",1);
+      // Cluster barycenter Y position
+      meYBlade_ = iBooker.book1D("y_" + hid,"Cluster barycenter Y (column #)",500,0.,500.);
+      meYBlade_->setAxisTitle("Barycenter y-position [column #]",1);
+      // Cluster width on the x-axis
+      meSizeXBlade_ = iBooker.book1D("sizeX_" + hid,"Cluster x-width (rows)",10,0.,10.);
+      meSizeXBlade_->setAxisTitle("Cluster x-size [rows]",1);
+      // Cluster width on the y-axis
+      meSizeYBlade_ = iBooker.book1D("sizeY_" + hid,"Cluster y-width (columns)",15,0.,15.);
+      meSizeYBlade_->setAxisTitle("Cluster y-size [columns]",1);
+    }
+  }
+  if(type==5 && endcap){
+    uint32_t disk;
+    disk = PixelEndcapNameUpgrade(DetId(id_)).diskName();
+    
+    char sdisk[80]; sprintf(sdisk, "Disk_%i",disk);
+    hid = src.label() + "_" + sdisk;
+    // Number of clusters
+    meNClustersDisk_ = iBooker.book1D("nclusters_" + hid,"Number of Clusters",8,0.,8.);
+    meNClustersDisk_->setAxisTitle("Number of Clusters",1);
+    // Total cluster charge in MeV
+    meChargeDisk_ = iBooker.book1D("charge_" + hid,"Cluster charge",100,0.,200.);
+    meChargeDisk_->setAxisTitle("Charge [kilo electrons]",1);
+    // Total cluster size (in pixels)
+    meSizeDisk_ = iBooker.book1D("size_" + hid,"Total cluster size",30,0.,30.);
+    meSizeDisk_->setAxisTitle("Cluster size [number of pixels]",1);
+    if(!reducedSet){
+      // Lowest cluster row
+      meMinRowDisk_ = iBooker.book1D("minrow_" + hid,"Lowest cluster row",200,0.,200.);
+      meMinRowDisk_->setAxisTitle("Lowest cluster row",1);
+      // Highest cluster row
+      meMaxRowDisk_ = iBooker.book1D("maxrow_" + hid,"Highest cluster row",200,0.,200.);
+      meMaxRowDisk_->setAxisTitle("Highest cluster row",1);
+      // Lowest cluster column
+      meMinColDisk_ = iBooker.book1D("mincol_" + hid,"Lowest cluster column",500,0.,500.);
+      meMinColDisk_->setAxisTitle("Lowest cluster column",1);
+      // Highest cluster column
+      meMaxColDisk_ = iBooker.book1D("maxcol_" + hid,"Highest cluster column",500,0.,500.);
+      meMaxColDisk_->setAxisTitle("Highest cluster column",1);
+      // Cluster barycenter X position
+      meXDisk_ = iBooker.book1D("x_" + hid,"Cluster barycenter X (row #)",200,0.,200.);
+      meXDisk_->setAxisTitle("Barycenter x-position [row #]",1);
+      // Cluster barycenter Y position
+      meYDisk_ = iBooker.book1D("y_" + hid,"Cluster barycenter Y (column #)",500,0.,500.);
+      meYDisk_->setAxisTitle("Barycenter y-position [column #]",1);
+      // Cluster width on the x-axis
+      meSizeXDisk_ = iBooker.book1D("sizeX_" + hid,"Cluster x-width (rows)",10,0.,10.);
+      meSizeXDisk_->setAxisTitle("Cluster x-size [rows]",1);
+      // Cluster width on the y-axis
+      meSizeYDisk_ = iBooker.book1D("sizeY_" + hid,"Cluster y-width (columns)",15,0.,15.);
+      meSizeYDisk_->setAxisTitle("Cluster y-size [columns]",1);
+    }
+  }
+
+  if(type==6 && endcap){
+    uint32_t panel;
+    uint32_t module;
+    panel= PixelEndcapNameUpgrade(DetId(id_)).pannelName();
+    module= PixelEndcapNameUpgrade(DetId(id_)).plaquetteName();
+    
+    
+    char slab[80]; sprintf(slab, "Panel_%i_Ring_%i",panel, module);
+    hid = src.label() + "_" + slab;
+    // Number of clusters
+    meNClustersRing_ = iBooker.book1D("nclusters_" + hid,"Number of Clusters",8,0.,8.);
+    meNClustersRing_->setAxisTitle("Number of Clusters",1);
+    // Total cluster charge in MeV
+    meChargeRing_ = iBooker.book1D("charge_" + hid,"Cluster charge",100,0.,200.);
+    meChargeRing_->setAxisTitle("Charge [kilo electrons]",1);
+    // Total cluster size (in pixels)
+    meSizeRing_ = iBooker.book1D("size_" + hid,"Total cluster size",30,0.,30.);
+    meSizeRing_->setAxisTitle("Cluster size [number of pixels]",1);
+    if(!reducedSet){
+      // Lowest cluster row
+      meMinRowRing_ = iBooker.book1D("minrow_" + hid,"Lowest cluster row",200,0.,200.);
+      meMinRowRing_->setAxisTitle("Lowest cluster row",1);
+      // Highest cluster row
+      meMaxRowRing_ = iBooker.book1D("maxrow_" + hid,"Highest cluster row",200,0.,200.);
+      meMaxRowRing_->setAxisTitle("Highest cluster row",1);
+      // Lowest cluster column
+      meMinColRing_ = iBooker.book1D("mincol_" + hid,"Lowest cluster column",500,0.,500.);
+      meMinColRing_->setAxisTitle("Lowest cluster column",1);
+      // Highest cluster column
+      meMaxColRing_ = iBooker.book1D("maxcol_" + hid,"Highest cluster column",500,0.,500.);
+      meMaxColRing_->setAxisTitle("Highest cluster column",1);
+      // Cluster barycenter X position
+      meXRing_ = iBooker.book1D("x_" + hid,"Cluster barycenter X (row #)",200,0.,200.);
+      meXRing_->setAxisTitle("Barycenter x-position [row #]",1);
+      // Cluster barycenter Y position
+      meYRing_ = iBooker.book1D("y_" + hid,"Cluster barycenter Y (column #)",500,0.,500.);
+      meYRing_->setAxisTitle("Barycenter y-position [column #]",1);
+      // Cluster width on the x-axis
+      meSizeXRing_ = iBooker.book1D("sizeX_" + hid,"Cluster x-width (rows)",10,0.,10.);
+      meSizeXRing_->setAxisTitle("Cluster x-size [rows]",1);
+      // Cluster width on the y-axis
+      meSizeYRing_ = iBooker.book1D("sizeY_" + hid,"Cluster y-width (columns)",15,0.,15.);
+      meSizeYRing_->setAxisTitle("Cluster y-size [columns]",1);
+      if(twoD){
+        // 2D hit map
+        mePixClustersRing_ = iBooker.book2D("hitmap_" + hid,"Number of Clusters (1bin=four pixels)",nbinx,0.,float(ncols_),nbiny,0.,float(nrows_));
+        mePixClustersRing_->setAxisTitle("Columns",1);
+        mePixClustersRing_->setAxisTitle("Rows",2);
+      }else{
+        // projections of hitmap
+        mePixClustersRing_px_ = iBooker.book1D("hitmap_" + hid+"_px","Number of Clusters (1bin=two columns)",nbinx,0.,float(ncols_));
+        mePixClustersRing_py_ = iBooker.book1D("hitmap_" + hid+"_py","Number of Clusters (1bin=two rows)",nbiny,0.,float(nrows_));
+        mePixClustersRing_px_->setAxisTitle("Columns",1);
+        mePixClustersRing_py_->setAxisTitle("Rows",1);
+      }
+    }
+  }
+
+}
+//
+// Fill histograms
+//
+int SiPixelClusterModulePhase1::fill(const edmNew::DetSetVector<SiPixelCluster>& input, const TrackerGeometry* tracker,MonitorElement* layer1,MonitorElement* layer2,MonitorElement* layer3,MonitorElement* layer4,MonitorElement* disk1pz,MonitorElement* disk2pz,MonitorElement* disk3pz,MonitorElement* disk1mz,MonitorElement* disk2mz,MonitorElement* disk3mz,bool modon, bool ladon, bool layon, bool phion, bool bladeon, bool diskon, bool ringon, bool twoD, bool reducedSet, bool smileyon) {
+  
+  bool barrel = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
+  bool endcap = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap);
+  
+  edmNew::DetSetVector<SiPixelCluster>::const_iterator isearch = input.find(id_); // search  clusters of detid
+  unsigned int numberOfClusters = 0;
+  unsigned int numberOfFpixClusters = 0;
+  
+  if( isearch != input.end() ) {  // Not an empty iterator
+
+    
+    // Look at clusters now
+    edmNew::DetSet<SiPixelCluster>::const_iterator  di;
+    for(di = isearch->begin(); di != isearch->end(); di++) {
+      numberOfClusters++;
+      if(endcap) numberOfFpixClusters++;
+      float charge = 0.001*(di->charge()); // total charge of cluster
+      float x = di->x();                   // barycenter x position
+      float y = di->y();                   // barycenter y position
+      int size = di->size();               // total size of cluster (in pixels)
+      int sizeX = di->sizeX();             // size of cluster in x-direction
+      int sizeY = di->sizeY();             // size of cluster in y-direction
+      int minPixelRow = di->minPixelRow(); // min x index
+      int maxPixelRow = di->maxPixelRow(); // max x index
+      int minPixelCol = di->minPixelCol(); // min y index
+      int maxPixelCol = di->maxPixelCol(); // max y index
+
+      const PixelGeomDetUnit* theGeomDet = dynamic_cast<const PixelGeomDetUnit*> ( tracker->idToDet(DetId(id_)) );
+
+      const PixelTopology * topol = &(theGeomDet->specificTopology());
+      LocalPoint clustlp = topol->localPosition( MeasurementPoint(x, y) );
+      GlobalPoint clustgp = theGeomDet->surface().toGlobal( clustlp );
+
+      if(barrel){
+	uint32_t DBlayer;
+	DBlayer = PixelBarrelNameUpgrade(DetId(id_)).layerName();
+	switch(DBlayer){
+	case 1: {
+	  if(layer1) layer1->Fill(clustgp.z(),clustgp.phi());
+	  break;
+	} case 2: {
+	  if(layer2) layer2->Fill(clustgp.z(),clustgp.phi());
+	  break;
+	} case 3: {
+	  if(layer3) layer3->Fill(clustgp.z(),clustgp.phi());
+	  break;
+	} case 4: {
+	    if(layer4) layer4->Fill(clustgp.z(),clustgp.phi());
+	    break;
+	  }
+	}
+      }else if(endcap){
+	uint32_t DBdisk;
+	DBdisk = PixelEndcapNameUpgrade(DetId(id_)).diskName();
+	if(clustgp.z()>0){
+	  switch(DBdisk){
+	  case 1: {
+	    if(disk1pz) disk1pz->Fill(clustgp.x(),clustgp.y());
+	    break;
+	  } case 2: {
+	    if(disk2pz) disk2pz->Fill(clustgp.x(),clustgp.y());
+	    break;
+	  } case 3: {
+	      if(disk3pz) disk3pz->Fill(clustgp.x(),clustgp.y());
+	      break;
+	    }}
+	}else{
+	  switch(DBdisk){
+	  case 1: {
+	    if(disk1mz) disk1mz->Fill(clustgp.x(),clustgp.y());
+	    break;
+	  } case 2: {
+	    if(disk2mz) disk2mz->Fill(clustgp.x(),clustgp.y());
+	    break;
+	  } case 3: {
+	    if(disk3mz) disk3mz->Fill(clustgp.x(),clustgp.y());
+	    break;
+	    }
+	  }
+	} 
+      }
+      if(!reducedSet)
+	{
+	  (meMinRow_)->Fill((int)minPixelRow);
+	  (meMaxRow_)->Fill((int)maxPixelRow);
+	  (meMinCol_)->Fill((int)minPixelCol);
+	  (meMaxCol_)->Fill((int)maxPixelCol);
+	  (meSizeX_)->Fill((int)sizeX);
+	  (meSizeY_)->Fill((int)sizeY);
+ 	  (meX_)->Fill((float)x);
+	  (meY_)->Fill((float)y);
+	  if(twoD)(mePixClusters_)->Fill((float)y,(float)x);
+	  else{
+	  	  (mePixClusters_px_)->Fill((float)y);
+	        (mePixClusters_py_)->Fill((float)x);
+	  }
+	}
+
+      if(barrel && smileyon){
+        (meSizeYvsEtaBarrel_)->Fill(clustgp.eta(),sizeY);
+	//std::cout << "Cluster Global x y z theta eta " << clustgp.x() << " " << clustgp.y() << " " << clustgp.z() << " " << clustgp.theta() << " " << clustgp.eta() << std::endl;
+      }      
+      if(ladon && barrel){
+	(meChargeLad_)->Fill((float)charge);
+	(meSizeLad_)->Fill((int)size);
+	if(!reducedSet)
+	{
+	(meMinRowLad_)->Fill((int)minPixelRow);
+	(meMaxRowLad_)->Fill((int)maxPixelRow);
+	(meMinColLad_)->Fill((int)minPixelCol);
+	(meMaxColLad_)->Fill((int)maxPixelCol);
+	(meXLad_)->Fill((float)x);
+	(meYLad_)->Fill((float)y);
+	(meSizeXLad_)->Fill((int)sizeX);
+	(meSizeYLad_)->Fill((int)sizeY);
+	if(twoD) (mePixClustersLad_)->Fill((float)y,(float)x);
+	else{
+	  (mePixClustersLad_px_)->Fill((float)y);
+	  (mePixClustersLad_py_)->Fill((float)x);
+	}
+	}
+      }
+      if(layon && barrel){
+	(meChargeLay_)->Fill((float)charge);
+	(meSizeLay_)->Fill((int)size);
+	if(!reducedSet)
+	{
+	(meMinRowLay_)->Fill((int)minPixelRow);
+	(meMaxRowLay_)->Fill((int)maxPixelRow);
+	(meMinColLay_)->Fill((int)minPixelCol);
+	(meMaxColLay_)->Fill((int)maxPixelCol);
+	(meXLay_)->Fill((float)x);
+	(meYLay_)->Fill((float)y);
+	(meSizeXLay_)->Fill((int)sizeX);
+	(meSizeYLay_)->Fill((int)sizeY);
+	if(twoD) (mePixClustersLay_)->Fill((float)y,(float)x);
+	else{
+	  (mePixClustersLay_px_)->Fill((float)y);
+	  (mePixClustersLay_py_)->Fill((float)x);
+	}
+	}
+      }
+      if(phion && barrel){
+	(meChargePhi_)->Fill((float)charge);
+	(meSizePhi_)->Fill((int)size);
+	if(!reducedSet)
+	{
+	(meMinRowPhi_)->Fill((int)minPixelRow);
+	(meMaxRowPhi_)->Fill((int)maxPixelRow);
+	(meMinColPhi_)->Fill((int)minPixelCol);
+	(meMaxColPhi_)->Fill((int)maxPixelCol);
+	(meXPhi_)->Fill((float)x);
+	(meYPhi_)->Fill((float)y);
+	(meSizeXPhi_)->Fill((int)sizeX);
+	(meSizeYPhi_)->Fill((int)sizeY);
+	if(twoD) (mePixClustersPhi_)->Fill((float)y,(float)x);
+	else{
+	  (mePixClustersPhi_px_)->Fill((float)y);
+	  (mePixClustersPhi_py_)->Fill((float)x);
+	}
+	}
+      }
+      if(bladeon && endcap){
+	(meChargeBlade_)->Fill((float)charge);
+	(meSizeBlade_)->Fill((int)size);
+	if(!reducedSet)
+	{
+	(meMinRowBlade_)->Fill((int)minPixelRow);
+	(meMaxRowBlade_)->Fill((int)maxPixelRow);
+	(meMinColBlade_)->Fill((int)minPixelCol);
+	(meMaxColBlade_)->Fill((int)maxPixelCol);
+	(meXBlade_)->Fill((float)x);
+	(meYBlade_)->Fill((float)y);
+	(meSizeXBlade_)->Fill((int)sizeX);
+	(meSizeYBlade_)->Fill((int)sizeY);
+	}
+      }
+      if(diskon && endcap){
+	(meChargeDisk_)->Fill((float)charge);
+	(meSizeDisk_)->Fill((int)size);
+	if(!reducedSet)
+	{
+	(meMinRowDisk_)->Fill((int)minPixelRow);
+	(meMaxRowDisk_)->Fill((int)maxPixelRow);
+	(meMinColDisk_)->Fill((int)minPixelCol);
+	(meMaxColDisk_)->Fill((int)maxPixelCol);
+	(meXDisk_)->Fill((float)x);
+	(meYDisk_)->Fill((float)y);
+	(meSizeXDisk_)->Fill((int)sizeX);
+	(meSizeYDisk_)->Fill((int)sizeY);
+	}
+      }
+      
+      if(ringon && endcap){
+	(meChargeRing_)->Fill((float)charge);
+	(meSizeRing_)->Fill((int)size);
+	if(!reducedSet)
+	{
+	(meMinRowRing_)->Fill((int)minPixelRow);
+	(meMaxRowRing_)->Fill((int)maxPixelRow);
+	(meMinColRing_)->Fill((int)minPixelCol);
+	(meMaxColRing_)->Fill((int)maxPixelCol);
+	(meXRing_)->Fill((float)x);
+	(meYRing_)->Fill((float)y);
+	(meSizeXRing_)->Fill((int)sizeX);
+	(meSizeYRing_)->Fill((int)sizeY);
+	if(twoD) (mePixClustersRing_)->Fill((float)y,(float)x);
+	else{
+	  (mePixClustersRing_px_)->Fill((float)y);
+	  (mePixClustersRing_py_)->Fill((float)x);
+	}
+	}
+      }
+    }
+    //if(modon) (meNClusters_)->Fill((float)numberOfClusters);
+    if(ladon && barrel) (meNClustersLad_)->Fill((float)numberOfClusters);
+    if(layon && barrel) (meNClustersLay_)->Fill((float)numberOfClusters);
+    if(phion && barrel) (meNClustersPhi_)->Fill((float)numberOfClusters);
+    if(bladeon && endcap) (meNClustersBlade_)->Fill((float)numberOfClusters);
+    if(diskon && endcap) (meNClustersDisk_)->Fill((float)numberOfClusters);
+    if(ringon && endcap) (meNClustersRing_)->Fill((float)numberOfClusters);
+
+    //std::cout<<"number of clusters="<<numberOfClusters<<std::endl;
+      
+
+  }
+  
+  
+  //std::cout<<"number of detector units="<<numberOfDetUnits<<std::endl;
+  return numberOfFpixClusters;
+  
+}

--- a/DQM/SiPixelMonitorCluster/src/SiPixelClusterSource.cc
+++ b/DQM/SiPixelMonitorCluster/src/SiPixelClusterSource.cc
@@ -59,8 +59,7 @@ SiPixelClusterSource::SiPixelClusterSource(const edm::ParameterSet& iConfig) :
   bladeOn( conf_.getUntrackedParameter<bool>("bladeOn",false) ), 
   diskOn( conf_.getUntrackedParameter<bool>("diskOn",false) ),
   smileyOn(conf_.getUntrackedParameter<bool>("smileyOn",false) ),
-  bigEventSize( conf_.getUntrackedParameter<int>("bigEventSize",100) ), 
-  isUpgrade( conf_.getUntrackedParameter<bool>("isUpgrade",false) )
+  bigEventSize( conf_.getUntrackedParameter<int>("bigEventSize",100) ) 
 {
    LogInfo ("PixelDQM") << "SiPixelClusterSource::SiPixelClusterSource: Got DQM BackEnd interface"<<endl;
 
@@ -114,18 +113,11 @@ void SiPixelClusterSource::bookHistograms(DQMStore::IBooker & iBooker, edm::Run 
   meClPosLayer1 = iBooker.book2D("position_siPixelClusters_Layer_1","Clusters Layer1;Global Z (cm);Global #phi",200,-30.,30.,128,-3.2,3.2);
   meClPosLayer2 = iBooker.book2D("position_siPixelClusters_Layer_2","Clusters Layer2;Global Z (cm);Global #phi",200,-30.,30.,128,-3.2,3.2);
   meClPosLayer3 = iBooker.book2D("position_siPixelClusters_Layer_3","Clusters Layer3;Global Z (cm);Global #phi",200,-30.,30.,128,-3.2,3.2);
-  if (isUpgrade) {
-    meClPosLayer4 = iBooker.book2D("position_siPixelClusters_Layer_4","Clusters Layer4;Global Z (cm);Global #phi",200,-30.,30.,128,-3.2,3.2);
-  }
   //fpix
   meClPosDisk1pz = iBooker.book2D("position_siPixelClusters_pz_Disk_1","Clusters +Z Disk1;Global X (cm);Global Y (cm)",80,-20.,20.,80,-20.,20.);
   meClPosDisk2pz = iBooker.book2D("position_siPixelClusters_pz_Disk_2","Clusters +Z Disk2;Global X (cm);Global Y (cm)",80,-20.,20.,80,-20.,20.);
   meClPosDisk1mz = iBooker.book2D("position_siPixelClusters_mz_Disk_1","Clusters -Z Disk1;Global X (cm);Global Y (cm)",80,-20.,20.,80,-20.,20.);
   meClPosDisk2mz = iBooker.book2D("position_siPixelClusters_mz_Disk_2","Clusters -Z Disk2;Global X (cm);Global Y (cm)",80,-20.,20.,80,-20.,20.);
-  if (isUpgrade) {
-    meClPosDisk3pz = iBooker.book2D("position_siPixelClusters_pz_Disk_3","Clusters +Z Disk3;Global X (cm);Global Y (cm)",80,-20.,20.,80,-20.,20.);
-    meClPosDisk3mz = iBooker.book2D("position_siPixelClusters_mz_Disk_3","Clusters -Z Disk3;Global X (cm);Global Y (cm)",80,-20.,20.,80,-20.,20.);
-  }
 }
 
 //------------------------------------------------------------------
@@ -135,33 +127,16 @@ void SiPixelClusterSource::analyze(const edm::Event& iEvent, const edm::EventSet
 {
   eventNo++;
   
-  //if(modOn && !isUpgrade){
-  if(!isUpgrade){
-    if(meClPosLayer1 && meClPosLayer1->getEntries()>150000){
-      meClPosLayer1->Reset();
-      meClPosLayer2->Reset();
-      meClPosLayer3->Reset();
-      meClPosDisk1mz->Reset();
-      meClPosDisk2mz->Reset();
-      meClPosDisk1pz->Reset();
-      meClPosDisk2pz->Reset();
-    }
-  //}else if(modOn && isUpgrade){
-  }else if(isUpgrade){
-    if(meClPosLayer1 && meClPosLayer1->getEntries()>150000){
-      meClPosLayer1->Reset(); 
-      meClPosLayer2->Reset(); 
-      meClPosLayer3->Reset(); 
-      meClPosLayer4->Reset(); 
-      meClPosDisk1pz->Reset();
-      meClPosDisk2pz->Reset();
-      meClPosDisk3pz->Reset();
-      meClPosDisk1mz->Reset();
-      meClPosDisk2mz->Reset();
-      meClPosDisk3mz->Reset();
-    }
+  if(meClPosLayer1 && meClPosLayer1->getEntries()>150000){
+    meClPosLayer1->Reset();
+    meClPosLayer2->Reset();
+    meClPosLayer3->Reset();
+    meClPosDisk1mz->Reset();
+    meClPosDisk2mz->Reset();
+    meClPosDisk1pz->Reset();
+    meClPosDisk2pz->Reset();
   }
-  
+   
   // get input data
   edm::Handle< edmNew::DetSetVector<SiPixelCluster> >  input;
   iEvent.getByToken(srcToken_, input);
@@ -183,7 +158,7 @@ void SiPixelClusterSource::analyze(const edm::Event& iEvent, const edm::EventSet
 							   meClPosDisk1mz, meClPosDisk2mz, meClPosDisk3mz,
 							   modOn, ladOn, layOn, phiOn, 
                                                            bladeOn, diskOn, ringOn, 
-							   twoDimOn, reducedSet, smileyOn, isUpgrade);
+							   twoDimOn, reducedSet, smileyOn);
     nEventFpixClusters = nEventFpixClusters + numberOfFpixClusters;    
     
   }
@@ -232,7 +207,7 @@ void SiPixelClusterSource::buildStructure(const edm::EventSetup& iSetup){
           if(isPIB) continue;
 	  LogDebug ("PixelDQM") << " ---> Adding Barrel Module " <<  detId.rawId() << endl;
 	  thePixelStructure.insert(pair<uint32_t,SiPixelClusterModule*> (id,theModule));
-        }else if ( (detId.subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap)) && (!isUpgrade) ) {
+        }else if ( detId.subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap) ) {
 	  LogDebug ("PixelDQM") << " ---> Adding Endcap Module " <<  detId.rawId() << endl;
           PixelEndcapName::HalfCylinder side = PixelEndcapName(DetId(id)).halfCylinder();
           int disk   = PixelEndcapName(DetId(id)).diskName();
@@ -254,29 +229,7 @@ void SiPixelClusterSource::buildStructure(const edm::EventSetup& iSetup){
 	  mask = false;
 	  if(isPIB && mask) continue;
 	  thePixelStructure.insert(pair<uint32_t,SiPixelClusterModule*> (id,theModule));
-        } else if ( (detId.subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap)) && (isUpgrade) ) {
-          LogDebug ("PixelDQM") << " ---> Adding Endcap Module " <<  detId.rawId() << endl;
-          PixelEndcapNameUpgrade::HalfCylinder side = PixelEndcapNameUpgrade(DetId(id)).halfCylinder();
-          int disk   = PixelEndcapNameUpgrade(DetId(id)).diskName();
-          int blade  = PixelEndcapNameUpgrade(DetId(id)).bladeName();
-          int panel  = PixelEndcapNameUpgrade(DetId(id)).pannelName();
-          int module = PixelEndcapNameUpgrade(DetId(id)).plaquetteName();
-          char sside[80];  sprintf(sside,  "HalfCylinder_%i",side);
-          char sdisk[80];  sprintf(sdisk,  "Disk_%i",disk);
-          char sblade[80]; sprintf(sblade, "Blade_%02i",blade);
-          char spanel[80]; sprintf(spanel, "Panel_%i",panel);
-          char smodule[80];sprintf(smodule,"Module_%i",module);
-          std::string side_str = sside;
-	  std::string disk_str = sdisk;
-	  bool mask = side_str.find("HalfCylinder_1")!=string::npos||
-	              side_str.find("HalfCylinder_2")!=string::npos||
-		      side_str.find("HalfCylinder_4")!=string::npos||
-		      disk_str.find("Disk_2")!=string::npos;
-	  // clutch to take all of FPIX, but no BPIX:
-	  mask = false;
-	  if(isPIB && mask) continue;
-	  thePixelStructure.insert(pair<uint32_t,SiPixelClusterModule*> (id,theModule));
-        }//endif(Upgrade)
+        }
       }
     }
   }
@@ -301,8 +254,8 @@ void SiPixelClusterSource::bookMEs(DQMStore::IBooker & iBooker){
     
     /// Create folder tree and book histograms 
     if(modOn){
-      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,0,isUpgrade)){
-        (*struct_iter).second->book( conf_,iBooker,0,twoDimOn,reducedSet,isUpgrade);
+      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,0)){
+        (*struct_iter).second->book( conf_,iBooker,0,twoDimOn,reducedSet);
       } else {
         
         if(!isPIB) throw cms::Exception("LogicError")
@@ -310,50 +263,50 @@ void SiPixelClusterSource::bookMEs(DQMStore::IBooker & iBooker){
       }
     }
     if(ladOn){
-      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,1,isUpgrade)){
-	(*struct_iter).second->book( conf_,iBooker,1,twoDimOn,reducedSet,isUpgrade);
+      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,1)){
+	(*struct_iter).second->book( conf_,iBooker,1,twoDimOn,reducedSet);
 	} else {
 	LogDebug ("PixelDQM") << "PROBLEM WITH LADDER-FOLDER\n";
       }
     }
     if(layOn){
-      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,2,isUpgrade)){
-	(*struct_iter).second->book( conf_,iBooker,2,twoDimOn,reducedSet,isUpgrade);
+      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,2)){
+	(*struct_iter).second->book( conf_,iBooker,2,twoDimOn,reducedSet);
 	} else {
 	LogDebug ("PixelDQM") << "PROBLEM WITH LAYER-FOLDER\n";
       }
     }
     if(phiOn){
-      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,3,isUpgrade)){
-	(*struct_iter).second->book( conf_,iBooker,3,twoDimOn,reducedSet,isUpgrade);
+      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,3)){
+	(*struct_iter).second->book( conf_,iBooker,3,twoDimOn,reducedSet);
 	} else {
 	LogDebug ("PixelDQM") << "PROBLEM WITH PHI-FOLDER\n";
       }
     }
     if(bladeOn){
-      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,4,isUpgrade)){
-	(*struct_iter).second->book( conf_,iBooker,4,twoDimOn,reducedSet,isUpgrade);
+      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,4)){
+	(*struct_iter).second->book( conf_,iBooker,4,twoDimOn,reducedSet);
 	} else {
 	LogDebug ("PixelDQM") << "PROBLEM WITH BLADE-FOLDER\n";
       }
     }
     if(diskOn){
-      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,5,isUpgrade)){
-	(*struct_iter).second->book( conf_,iBooker,5,twoDimOn,reducedSet,isUpgrade);
+      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,5)){
+	(*struct_iter).second->book( conf_,iBooker,5,twoDimOn,reducedSet);
 	} else {
 	LogDebug ("PixelDQM") << "PROBLEM WITH DISK-FOLDER\n";
       }
     }
     if(ringOn){
-      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,6,isUpgrade)){
-	(*struct_iter).second->book( conf_,iBooker,6,twoDimOn,reducedSet,isUpgrade);
+      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,6)){
+	(*struct_iter).second->book( conf_,iBooker,6,twoDimOn,reducedSet);
 	} else {
 	LogDebug ("PixelDQM") << "PROBLEM WITH RING-FOLDER\n";
       }
     }
     if(smileyOn){
-      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,7,isUpgrade)){
-        (*struct_iter).second->book( conf_,iBooker,7,twoDimOn,reducedSet,isUpgrade);
+      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,7)){
+        (*struct_iter).second->book( conf_,iBooker,7,twoDimOn,reducedSet);
         } else {
         LogDebug ("PixelDQM") << "PROBLEM WITH BARREL-FOLDER\n";
       }

--- a/DQM/SiPixelMonitorCluster/src/SiPixelClusterSourcePhase1.cc
+++ b/DQM/SiPixelMonitorCluster/src/SiPixelClusterSourcePhase1.cc
@@ -1,0 +1,327 @@
+// -*- C++ -*-
+//
+// Package:    SiPixelMonitorCluster
+// Class:      SiPixelClusterSourcePhase1
+// 
+/**\class 
+
+ Description: Pixel DQM source for Clusters
+
+ Implementation:
+     <Notes on implementation>
+*/
+//
+// Original Author:  Vincenzo Chiochia & Andrew York
+//         Created:  
+//
+//
+// Updated by: Lukas Wehrli
+// for pixel offline DQM 
+#include "DQM/SiPixelMonitorCluster/interface/SiPixelClusterSourcePhase1.h"
+// Framework
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+// DQM Framework
+#include "DQM/SiPixelCommon/interface/SiPixelFolderOrganizer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+// Geometry
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
+#include "Geometry/CommonTopologies/interface/PixelTopology.h"
+// DataFormats
+#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+#include "DataFormats/SiPixelDetId/interface/PixelBarrelName.h"
+#include "DataFormats/SiPixelDetId/interface/PixelBarrelNameUpgrade.h"
+#include "DataFormats/SiPixelDetId/interface/PixelEndcapName.h"
+#include "DataFormats/SiPixelDetId/interface/PixelEndcapNameUpgrade.h"
+//
+#include <string>
+#include <stdlib.h>
+
+using namespace std;
+using namespace edm;
+
+SiPixelClusterSourcePhase1::SiPixelClusterSourcePhase1(const edm::ParameterSet& iConfig) :
+  conf_(iConfig),
+  src_( conf_.getParameter<edm::InputTag>( "src" ) ),
+  saveFile( conf_.getUntrackedParameter<bool>("saveFile",false) ),
+  isPIB( conf_.getUntrackedParameter<bool>("isPIB",false) ),
+  slowDown( conf_.getUntrackedParameter<bool>("slowDown",false) ),
+  modOn( conf_.getUntrackedParameter<bool>("modOn",true) ),
+  twoDimOn( conf_.getUntrackedParameter<bool>("twoDimOn",true) ),
+  reducedSet( conf_.getUntrackedParameter<bool>("reducedSet",false) ),
+  ladOn( conf_.getUntrackedParameter<bool>("ladOn",false) ), 
+  layOn( conf_.getUntrackedParameter<bool>("layOn",false) ), 
+  phiOn( conf_.getUntrackedParameter<bool>("phiOn",false) ), 
+  ringOn( conf_.getUntrackedParameter<bool>("ringOn",false) ), 
+  bladeOn( conf_.getUntrackedParameter<bool>("bladeOn",false) ), 
+  diskOn( conf_.getUntrackedParameter<bool>("diskOn",false) ),
+  smileyOn(conf_.getUntrackedParameter<bool>("smileyOn",false) ),
+  bigEventSize( conf_.getUntrackedParameter<int>("bigEventSize",100) ) 
+{
+   LogInfo ("PixelDQM") << "SiPixelClusterSourcePhase1::SiPixelClusterSourcePhase1: Got DQM BackEnd interface"<<endl;
+
+   //set Token(-s)
+   srcToken_ = consumes<edmNew::DetSetVector<SiPixelCluster> >(conf_.getParameter<edm::InputTag>("src"));
+   firstRun = true;
+}
+
+
+SiPixelClusterSourcePhase1::~SiPixelClusterSourcePhase1()
+{
+   // do anything here that needs to be done at desctruction time
+   // (e.g. close files, deallocate resources etc.)
+  LogInfo ("PixelDQM") << "SiPixelClusterSourcePhase1::~SiPixelClusterSourcePhase1: Destructor"<<endl;
+
+  std::map<uint32_t,SiPixelClusterModulePhase1*>::iterator struct_iter;
+  for (struct_iter = thePixelStructure.begin() ; struct_iter != thePixelStructure.end() ; struct_iter++){
+    delete struct_iter->second;
+    struct_iter->second = 0;
+  }
+}
+
+
+
+void SiPixelClusterSourcePhase1::dqmBeginRun(const edm::Run& r, const edm::EventSetup& iSetup){
+  LogInfo ("PixelDQM") << " SiPixelClusterSourcePhase1::beginJob - Initialisation ... " << std::endl;
+  LogInfo ("PixelDQM") << "Mod/Lad/Lay/Phi " << modOn << "/" << ladOn << "/" 
+	    << layOn << "/" << phiOn << std::endl;
+  LogInfo ("PixelDQM") << "Blade/Disk/Ring" << bladeOn << "/" << diskOn << "/" 
+	    << ringOn << std::endl;
+  LogInfo ("PixelDQM") << "2DIM IS " << twoDimOn << "\n";
+  LogInfo ("PixelDQM") << "Smiley (Cluster sizeY vs. Cluster eta) is " << smileyOn << "\n";
+  
+  if(firstRun){
+    eventNo = 0;
+    lumSec = 0;
+    nLumiSecs = 0;
+    nBigEvents = 0;
+    // Build map
+    buildStructure(iSetup);
+ 
+    firstRun = false;
+  }
+}
+
+void SiPixelClusterSourcePhase1::bookHistograms(DQMStore::IBooker & iBooker, edm::Run const &, edm::EventSetup const &){
+  bookMEs(iBooker);
+  // Book occupancy maps in global coordinates for all clusters:
+  iBooker.setCurrentFolder("Pixel/Clusters/OffTrack");
+  //bpix
+  meClPosLayer1 = iBooker.book2D("position_siPixelClusters_Layer_1","Clusters Layer1;Global Z (cm);Global #phi",200,-30.,30.,128,-3.2,3.2);
+  meClPosLayer2 = iBooker.book2D("position_siPixelClusters_Layer_2","Clusters Layer2;Global Z (cm);Global #phi",200,-30.,30.,128,-3.2,3.2);
+  meClPosLayer3 = iBooker.book2D("position_siPixelClusters_Layer_3","Clusters Layer3;Global Z (cm);Global #phi",200,-30.,30.,128,-3.2,3.2);
+  meClPosLayer4 = iBooker.book2D("position_siPixelClusters_Layer_4","Clusters Layer4;Global Z (cm);Global #phi",200,-30.,30.,128,-3.2,3.2);
+
+  //fpix
+  meClPosDisk1pz = iBooker.book2D("position_siPixelClusters_pz_Disk_1","Clusters +Z Disk1;Global X (cm);Global Y (cm)",80,-20.,20.,80,-20.,20.);
+  meClPosDisk2pz = iBooker.book2D("position_siPixelClusters_pz_Disk_2","Clusters +Z Disk2;Global X (cm);Global Y (cm)",80,-20.,20.,80,-20.,20.);
+  meClPosDisk1mz = iBooker.book2D("position_siPixelClusters_mz_Disk_1","Clusters -Z Disk1;Global X (cm);Global Y (cm)",80,-20.,20.,80,-20.,20.);
+  meClPosDisk2mz = iBooker.book2D("position_siPixelClusters_mz_Disk_2","Clusters -Z Disk2;Global X (cm);Global Y (cm)",80,-20.,20.,80,-20.,20.);
+  meClPosDisk3pz = iBooker.book2D("position_siPixelClusters_pz_Disk_3","Clusters +Z Disk3;Global X (cm);Global Y (cm)",80,-20.,20.,80,-20.,20.);
+  meClPosDisk3mz = iBooker.book2D("position_siPixelClusters_mz_Disk_3","Clusters -Z Disk3;Global X (cm);Global Y (cm)",80,-20.,20.,80,-20.,20.);
+}
+
+//------------------------------------------------------------------
+// Method called for every event
+//------------------------------------------------------------------
+void SiPixelClusterSourcePhase1::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+  eventNo++;
+  
+  if(meClPosLayer1 && meClPosLayer1->getEntries()>150000){
+    meClPosLayer1->Reset(); 
+    meClPosLayer2->Reset(); 
+    meClPosLayer3->Reset(); 
+    meClPosLayer4->Reset(); 
+    meClPosDisk1pz->Reset();
+    meClPosDisk2pz->Reset();
+    meClPosDisk3pz->Reset();
+    meClPosDisk1mz->Reset();
+    meClPosDisk2mz->Reset();
+    meClPosDisk3mz->Reset();
+  }
+  
+  // get input data
+  edm::Handle< edmNew::DetSetVector<SiPixelCluster> >  input;
+  iEvent.getByToken(srcToken_, input);
+
+  edm::ESHandle<TrackerGeometry> pDD;
+  iSetup.get<TrackerDigiGeometryRecord> ().get (pDD);
+  const TrackerGeometry* tracker = &(* pDD);
+
+  int lumiSection = (int)iEvent.luminosityBlock();
+  int nEventFpixClusters = 0;
+
+
+  std::map<uint32_t,SiPixelClusterModulePhase1*>::iterator struct_iter;
+  for (struct_iter = thePixelStructure.begin() ; struct_iter != thePixelStructure.end() ; struct_iter++) {
+    
+    int numberOfFpixClusters = (*struct_iter).second->fill(*input, tracker,  
+							   meClPosLayer1,meClPosLayer2,meClPosLayer3,meClPosLayer4,
+							   meClPosDisk1pz, meClPosDisk2pz, meClPosDisk3pz,
+							   meClPosDisk1mz, meClPosDisk2mz, meClPosDisk3mz,
+							   modOn, ladOn, layOn, phiOn, 
+                                                           bladeOn, diskOn, ringOn, 
+							   twoDimOn, reducedSet, smileyOn);
+    nEventFpixClusters = nEventFpixClusters + numberOfFpixClusters;    
+    
+  }
+
+  if(nEventFpixClusters>bigEventSize){
+    if (bigFpixClusterEventRate){
+      bigFpixClusterEventRate->Fill(lumiSection,1./23.);
+    }
+  }
+  //std::cout<<"nEventFpixClusters: "<<nEventFpixClusters<<" , nLumiSecs: "<<nLumiSecs<<" , nBigEvents: "<<nBigEvents<<std::endl;
+  
+  // slow down...
+  if(slowDown) usleep(10000);
+  
+}
+
+//------------------------------------------------------------------
+// Build data structure
+//------------------------------------------------------------------
+void SiPixelClusterSourcePhase1::buildStructure(const edm::EventSetup& iSetup){
+
+  LogInfo ("PixelDQM") <<" SiPixelClusterSourcePhase1::buildStructure" ;
+  edm::ESHandle<TrackerGeometry> pDD;
+  iSetup.get<TrackerDigiGeometryRecord>().get( pDD );
+
+  LogVerbatim ("PixelDQM") << " *** Geometry node for TrackerGeom is  "<<&(*pDD)<<std::endl;
+  LogVerbatim ("PixelDQM") << " *** I have " << pDD->dets().size() <<" detectors"<<std::endl;
+  LogVerbatim ("PixelDQM") << " *** I have " << pDD->detTypes().size() <<" types"<<std::endl;
+  
+  for(TrackerGeometry::DetContainer::const_iterator it = pDD->dets().begin(); it != pDD->dets().end(); it++){
+    
+    if(dynamic_cast<PixelGeomDetUnit const *>((*it))!=0){
+
+      DetId detId = (*it)->geographicalId();
+      const GeomDetUnit      * geoUnit = pDD->idToDetUnit( detId );
+      const PixelGeomDetUnit * pixDet  = dynamic_cast<const PixelGeomDetUnit*>(geoUnit);
+      int nrows = (pixDet->specificTopology()).nrows();
+      int ncols = (pixDet->specificTopology()).ncolumns();
+
+      
+      if((detId.subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel)) ||
+         (detId.subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap))){ 
+        uint32_t id = detId();
+        SiPixelClusterModulePhase1* theModule = new SiPixelClusterModulePhase1(id, ncols, nrows);
+        if(detId.subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel)) {
+          if(isPIB) continue;
+	  LogDebug ("PixelDQM") << " ---> Adding Barrel Module " <<  detId.rawId() << endl;
+	  thePixelStructure.insert(pair<uint32_t,SiPixelClusterModulePhase1*> (id,theModule));
+        } else if ( detId.subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap) ) {
+          LogDebug ("PixelDQM") << " ---> Adding Endcap Module " <<  detId.rawId() << endl;
+          PixelEndcapNameUpgrade::HalfCylinder side = PixelEndcapNameUpgrade(DetId(id)).halfCylinder();
+          int disk   = PixelEndcapNameUpgrade(DetId(id)).diskName();
+          int blade  = PixelEndcapNameUpgrade(DetId(id)).bladeName();
+          int panel  = PixelEndcapNameUpgrade(DetId(id)).pannelName();
+          int module = PixelEndcapNameUpgrade(DetId(id)).plaquetteName();
+          char sside[80];  sprintf(sside,  "HalfCylinder_%i",side);
+          char sdisk[80];  sprintf(sdisk,  "Disk_%i",disk);
+          char sblade[80]; sprintf(sblade, "Blade_%02i",blade);
+          char spanel[80]; sprintf(spanel, "Panel_%i",panel);
+          char smodule[80];sprintf(smodule,"Module_%i",module);
+          std::string side_str = sside;
+	  std::string disk_str = sdisk;
+	  bool mask = side_str.find("HalfCylinder_1")!=string::npos||
+	              side_str.find("HalfCylinder_2")!=string::npos||
+		      side_str.find("HalfCylinder_4")!=string::npos||
+		      disk_str.find("Disk_2")!=string::npos;
+	  // clutch to take all of FPIX, but no BPIX:
+	  mask = false;
+	  if(isPIB && mask) continue;
+	  thePixelStructure.insert(pair<uint32_t,SiPixelClusterModulePhase1*> (id,theModule));
+        }
+      }
+    }
+  }
+  LogInfo ("PixelDQM") << " *** Pixel Structure Size " << thePixelStructure.size() << endl;
+}
+//------------------------------------------------------------------
+// Book MEs
+//------------------------------------------------------------------
+void SiPixelClusterSourcePhase1::bookMEs(DQMStore::IBooker & iBooker){
+  
+  // Get DQM interface
+  iBooker.setCurrentFolder("Pixel");
+  char title[256]; snprintf(title, 256, "Rate of events with >%i FPIX clusters;LumiSection;Rate of large FPIX events per LS [Hz]",bigEventSize);
+  bigFpixClusterEventRate = iBooker.book1D("bigFpixClusterEventRate",title,5000,0.,5000.);
+
+
+  std::map<uint32_t,SiPixelClusterModulePhase1*>::iterator struct_iter;
+    
+  SiPixelFolderOrganizer theSiPixelFolder(false);
+  
+  for(struct_iter = thePixelStructure.begin(); struct_iter != thePixelStructure.end(); struct_iter++){
+    
+    /// Create folder tree and book histograms 
+    if(modOn){
+      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,0)){
+        (*struct_iter).second->book( conf_,iBooker,0,twoDimOn,reducedSet);
+      } else {
+        
+        if(!isPIB) throw cms::Exception("LogicError")
+	  << "[SiPixelClusterSourcePhase1::bookMEs] Creation of DQM folder failed";
+      }
+    }
+    if(ladOn){
+      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,1)){
+	(*struct_iter).second->book( conf_,iBooker,1,twoDimOn,reducedSet);
+	} else {
+	LogDebug ("PixelDQM") << "PROBLEM WITH LADDER-FOLDER\n";
+      }
+    }
+    if(layOn){
+      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,2)){
+	(*struct_iter).second->book( conf_,iBooker,2,twoDimOn,reducedSet);
+	} else {
+	LogDebug ("PixelDQM") << "PROBLEM WITH LAYER-FOLDER\n";
+      }
+    }
+    if(phiOn){
+      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,3)){
+	(*struct_iter).second->book( conf_,iBooker,3,twoDimOn,reducedSet);
+	} else {
+	LogDebug ("PixelDQM") << "PROBLEM WITH PHI-FOLDER\n";
+      }
+    }
+    if(bladeOn){
+      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,4)){
+	(*struct_iter).second->book( conf_,iBooker,4,twoDimOn,reducedSet);
+	} else {
+	LogDebug ("PixelDQM") << "PROBLEM WITH BLADE-FOLDER\n";
+      }
+    }
+    if(diskOn){
+      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,5)){
+	(*struct_iter).second->book( conf_,iBooker,5,twoDimOn,reducedSet);
+	} else {
+	LogDebug ("PixelDQM") << "PROBLEM WITH DISK-FOLDER\n";
+      }
+    }
+    if(ringOn){
+      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,6)){
+	(*struct_iter).second->book( conf_,iBooker,6,twoDimOn,reducedSet);
+	} else {
+	LogDebug ("PixelDQM") << "PROBLEM WITH RING-FOLDER\n";
+      }
+    }
+    if(smileyOn){
+      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,7)){
+        (*struct_iter).second->book( conf_,iBooker,7,twoDimOn,reducedSet);
+        } else {
+        LogDebug ("PixelDQM") << "PROBLEM WITH BARREL-FOLDER\n";
+      }
+    }
+
+  }
+
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(SiPixelClusterSourcePhase1);

--- a/DQM/SiPixelMonitorDigi/interface/SiPixelDigiModule.h
+++ b/DQM/SiPixelMonitorDigi/interface/SiPixelDigiModule.h
@@ -47,7 +47,7 @@ class SiPixelDigiModule {
   typedef edm::DetSet<PixelDigi>::const_iterator    DigiIterator;
 
   /// Book histograms
-  void book(const edm::ParameterSet& iConfig, DQMStore::IBooker & iBooker, int type=0, bool twoD=true, bool hiRes=false, bool reducedSet=false, bool additInfo=false, bool isUpgrade=false);
+  void book(const edm::ParameterSet& iConfig, DQMStore::IBooker & iBooker, int type=0, bool twoD=true, bool hiRes=false, bool reducedSet=false, bool additInfo=false);
   /// Fill histograms
 //  int fill(const edm::DetSetVector<PixelDigi> & input, bool modon=true, 
 //						 bool ladon=false, bool layon=false, bool phion=false, 
@@ -59,7 +59,7 @@ class SiPixelDigiModule {
 	   const bool modon, const bool ladon, const bool layon, const bool phion, 
 	   const bool bladeon, const bool diskon, const bool ringon, 
 	   const bool twoD, const bool reducedSet, const bool twoDimModOn, const bool twoDimOnlyLayDisk,
-	   int &nDigisA, int &nDigisB, bool isUpgrade);
+	   int &nDigisA, int &nDigisB);
   void resetRocMap(); // This is to move the rocmap reset from the Source to the Module where the map is booked. Necessary for multithread safety.
   std::pair<int,int> getZeroLoEffROCs(); // Moved from Souce.cc. Gets number of zero and low eff ROCs from each module.
  private:

--- a/DQM/SiPixelMonitorDigi/interface/SiPixelDigiModulePhase1.h
+++ b/DQM/SiPixelMonitorDigi/interface/SiPixelDigiModulePhase1.h
@@ -1,0 +1,116 @@
+#ifndef SiPixelMonitorDigi_SiPixelDigiModulePhase1_h
+#define SiPixelMonitorDigi_SiPixelDigiModulePhase1_h
+// -*- C++ -*-
+//
+// Package:    SiPixelMonitorDigi
+// Class:      SiPixelDigiModulePhase1
+// 
+/**\class 
+
+ Description: Digi monitoring elements for a Pixel sensor
+
+ Implementation:
+     <Notes on implementation>
+*/
+//
+// Original Author:  Vincenzo Chiochia
+//         Created:  
+//
+//
+//  Updated by: Lukas Wehrli
+//  for pixel offline DQM 
+
+#include "DQMServices/Core/interface/MonitorElement.h"
+#include "DataFormats/SiPixelDigi/interface/PixelDigi.h"
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingMap.h"
+#include "CondFormats/DataRecord/interface/SiPixelFedCablingMapRcd.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelFrameReverter.h"
+#include "CondFormats/SiPixelObjects/interface/GlobalPixel.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include <boost/cstdint.hpp>
+
+class SiPixelDigiModulePhase1 {        
+
+ public:
+
+  /// Default constructor
+  SiPixelDigiModulePhase1();
+  /// Constructor with raw DetId
+  SiPixelDigiModulePhase1(const uint32_t& id);
+  /// Constructor with raw DetId and sensor size
+  SiPixelDigiModulePhase1(const uint32_t& id, const int& ncols, const int& nrows);
+  /// Destructor
+  ~SiPixelDigiModulePhase1();
+
+  typedef edm::DetSet<PixelDigi>::const_iterator    DigiIterator;
+
+  /// Book histograms
+  void book(const edm::ParameterSet& iConfig, DQMStore::IBooker & iBooker, int type=0, bool twoD=true, bool hiRes=false, bool reducedSet=false, bool additInfo=false);
+  /// Fill histograms
+//  int fill(const edm::DetSetVector<PixelDigi> & input, bool modon=true, 
+//						 bool ladon=false, bool layon=false, bool phion=false, 
+//						 bool bladeon=false, bool diskon=false, bool ringon=false, 
+//						 bool twoD=true, bool reducedSet=false, bool twoDimModOn = true, bool twoDimOnlyLayDisk = false,
+//						 int &nDigisA, int &nDigisB);
+  int fill(const edm::DetSetVector<PixelDigi> & input, 
+	   MonitorElement* combBarrel, MonitorElement* chanBarrel, MonitorElement* chanBarrelL1,MonitorElement* chanBarrelL2, MonitorElement* chanBarrelL3, MonitorElement* chanBarrelL4, MonitorElement* combEndcap,
+	   const bool modon, const bool ladon, const bool layon, const bool phion, 
+	   const bool bladeon, const bool diskon, const bool ringon, 
+	   const bool twoD, const bool reducedSet, const bool twoDimModOn, const bool twoDimOnlyLayDisk,
+	   int &nDigisA, int &nDigisB);
+  void resetRocMap(); // This is to move the rocmap reset from the Source to the Module where the map is booked. Necessary for multithread safety.
+  std::pair<int,int> getZeroLoEffROCs(); // Moved from Souce.cc. Gets number of zero and low eff ROCs from each module.
+ private:
+
+  uint32_t id_;
+  int ncols_;
+  int nrows_;
+  MonitorElement* meNDigis_;
+  MonitorElement* meADC_;
+  MonitorElement* mePixDigis_;
+  MonitorElement* mePixDigis_px_;
+  MonitorElement* mePixDigis_py_;
+
+  //barrel:
+  MonitorElement* meNDigisLad_;
+  MonitorElement* meADCLad_;
+  MonitorElement* mePixDigisLad_;
+  MonitorElement* mePixDigisLad_px_;
+  MonitorElement* mePixDigisLad_py_;
+
+  MonitorElement* meNDigisLay_;
+  MonitorElement* meADCLay_;
+  MonitorElement* mePixDigisLay_;
+  MonitorElement* mePixRocsLay_;
+  MonitorElement* meZeroOccRocsLay_;
+  MonitorElement* mePixDigisLay_px_;
+  MonitorElement* mePixDigisLay_py_;
+
+  MonitorElement* meNDigisPhi_;
+  MonitorElement* meADCPhi_;
+  MonitorElement* mePixDigisPhi_;
+  MonitorElement* mePixDigisPhi_px_;
+  MonitorElement* mePixDigisPhi_py_;
+
+  //forward:
+  MonitorElement* meNDigisBlade_;
+  MonitorElement* meADCBlade_;
+
+  MonitorElement* meNDigisDisk_;
+  MonitorElement* meADCDisk_;
+  MonitorElement* mePixDigisDisk_;
+  MonitorElement* mePixRocsDisk_;
+  MonitorElement* meZeroOccRocsDisk_;
+
+  MonitorElement* meNDigisRing_;
+  MonitorElement* meADCRing_;
+  MonitorElement* mePixDigisRing_;
+  MonitorElement* mePixDigisRing_px_;
+  MonitorElement* mePixDigisRing_py_;
+  
+  //int nEventDigis_;
+
+};
+#endif

--- a/DQM/SiPixelMonitorDigi/interface/SiPixelDigiSource.h
+++ b/DQM/SiPixelMonitorDigi/interface/SiPixelDigiSource.h
@@ -192,7 +192,6 @@
        MonitorElement* meNDigisCHANEndcapDm3_;
        
        int bigEventSize;
-       bool isUpgrade;
        bool firstRun;
        
        std::string I_name[1856];

--- a/DQM/SiPixelMonitorDigi/interface/SiPixelDigiSourcePhase1.h
+++ b/DQM/SiPixelMonitorDigi/interface/SiPixelDigiSourcePhase1.h
@@ -1,0 +1,213 @@
+#ifndef SiPixelMonitorDigi_SiPixelDigiSourcePhase1_h
+#define SiPixelMonitorDigi_SiPixelDigiSourcePhase1_h
+// -*- C++ -*-
+//
+// Package:     SiPixelMonitorDigi
+// Class  :     SiPixelDigiSourcePhase1
+// 
+/**
+
+ Description: <one line class summary>
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Vincenzo Chiochia
+//         Created:  
+//
+
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+
+#include "DQM/SiPixelMonitorDigi/interface/SiPixelDigiModulePhase1.h"
+
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "DataFormats/SiPixelDigi/interface/PixelDigi.h"
+#include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
+
+
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include <boost/cstdint.hpp>
+
+ class SiPixelDigiSourcePhase1 : public DQMEDAnalyzer {
+    public:
+       explicit SiPixelDigiSourcePhase1(const edm::ParameterSet& conf);
+       ~SiPixelDigiSourcePhase1();
+
+       typedef edm::DetSet<PixelDigi>::const_iterator    DigiIterator;
+       
+       virtual void analyze(const edm::Event&, const edm::EventSetup&);
+       virtual void dqmBeginRun(const edm::Run&, edm::EventSetup const&) ;
+       virtual void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
+
+       virtual void buildStructure(edm::EventSetup const&);
+       virtual void bookMEs(DQMStore::IBooker &);
+
+    private:
+       edm::ParameterSet conf_;
+       edm::InputTag src_;
+       bool saveFile;
+       bool isPIB;
+       bool slowDown;
+       bool modOn; 
+       bool twoDimOn;
+       bool twoDimModOn; 
+       bool twoDimOnlyLayDisk;
+       bool hiRes;
+       bool reducedSet;
+       //barrel:
+       bool ladOn, layOn, phiOn;
+       //forward:
+       bool ringOn, bladeOn, diskOn; 
+       int eventNo;
+       int lumSec;
+       int nLumiSecs;
+       std::map<uint32_t,SiPixelDigiModulePhase1*> thePixelStructure;
+
+       int nDP1P1M1;
+       int nDP1P1M2;
+       int nDP1P1M3;
+       int nDP1P1M4;
+       int nDP1P2M1;
+       int nDP1P2M2;
+       int nDP1P2M3;
+       int nDP2P1M1;
+       int nDP2P1M2;
+       int nDP2P1M3;
+       int nDP2P1M4;
+       int nDP2P2M1;
+       int nDP2P2M2;
+       int nDP2P2M3;
+       int nDP3P1M1;
+       int nDP3P2M1;
+       int nDM1P1M1;
+       int nDM1P1M2;
+       int nDM1P1M3;
+       int nDM1P1M4;
+       int nDM1P2M1;
+       int nDM1P2M2;
+       int nDM1P2M3;
+       int nDM2P1M1;
+       int nDM2P1M2;
+       int nDM2P1M3;
+       int nDM2P1M4;
+       int nDM2P2M1;
+       int nDM2P2M2;
+       int nDM2P2M3;
+       int nDM3P1M1;
+       int nDM3P2M1;
+       int nL1M1;
+       int nL1M2;
+       int nL1M3;
+       int nL1M4;
+       int nL2M1;
+       int nL2M2;
+       int nL2M3;
+       int nL2M4;
+       int nL3M1;
+       int nL3M2;
+       int nL3M3;
+       int nL3M4;
+       int nL4M1;
+       int nL4M2;
+       int nL4M3;
+       int nL4M4;
+       int nBigEvents;
+       int nBPIXDigis;
+       int nFPIXDigis;
+       MonitorElement* bigEventRate;
+       MonitorElement* pixEvtsPerBX;
+       MonitorElement* pixEventRate;
+       MonitorElement* noOccROCsBarrel;
+       MonitorElement* loOccROCsBarrel;
+       MonitorElement* noOccROCsEndcap;
+       MonitorElement* loOccROCsEndcap;
+       MonitorElement* averageDigiOccupancy;
+       MonitorElement* avgfedDigiOccvsLumi;
+       MonitorElement* meNDigisCOMBBarrel_;
+       MonitorElement* meNDigisCOMBEndcap_;
+       MonitorElement* meNDigisCHANBarrel_;
+       MonitorElement* meNDigisCHANBarrelL1_;
+       MonitorElement* meNDigisCHANBarrelL2_;
+       MonitorElement* meNDigisCHANBarrelL3_;
+       MonitorElement* meNDigisCHANBarrelL4_;
+       MonitorElement* meNDigisCHANBarrelCh1_;
+       MonitorElement* meNDigisCHANBarrelCh2_;
+       MonitorElement* meNDigisCHANBarrelCh3_;
+       MonitorElement* meNDigisCHANBarrelCh4_;
+       MonitorElement* meNDigisCHANBarrelCh5_;
+       MonitorElement* meNDigisCHANBarrelCh6_;
+       MonitorElement* meNDigisCHANBarrelCh7_;
+       MonitorElement* meNDigisCHANBarrelCh8_;
+       MonitorElement* meNDigisCHANBarrelCh9_;
+       MonitorElement* meNDigisCHANBarrelCh10_;
+       MonitorElement* meNDigisCHANBarrelCh11_;
+       MonitorElement* meNDigisCHANBarrelCh12_;
+       MonitorElement* meNDigisCHANBarrelCh13_;
+       MonitorElement* meNDigisCHANBarrelCh14_;
+       MonitorElement* meNDigisCHANBarrelCh15_;
+       MonitorElement* meNDigisCHANBarrelCh16_;
+       MonitorElement* meNDigisCHANBarrelCh17_;
+       MonitorElement* meNDigisCHANBarrelCh18_;
+       MonitorElement* meNDigisCHANBarrelCh19_;
+       MonitorElement* meNDigisCHANBarrelCh20_;
+       MonitorElement* meNDigisCHANBarrelCh21_;
+       MonitorElement* meNDigisCHANBarrelCh22_;
+       MonitorElement* meNDigisCHANBarrelCh23_;
+       MonitorElement* meNDigisCHANBarrelCh24_;
+       MonitorElement* meNDigisCHANBarrelCh25_;
+       MonitorElement* meNDigisCHANBarrelCh26_;
+       MonitorElement* meNDigisCHANBarrelCh27_;
+       MonitorElement* meNDigisCHANBarrelCh28_;
+       MonitorElement* meNDigisCHANBarrelCh29_;
+       MonitorElement* meNDigisCHANBarrelCh30_;
+       MonitorElement* meNDigisCHANBarrelCh31_;
+       MonitorElement* meNDigisCHANBarrelCh32_;
+       MonitorElement* meNDigisCHANBarrelCh33_;
+       MonitorElement* meNDigisCHANBarrelCh34_;
+       MonitorElement* meNDigisCHANBarrelCh35_;
+       MonitorElement* meNDigisCHANBarrelCh36_;
+       MonitorElement* meNDigisCHANEndcap_;
+       MonitorElement* meNDigisCHANEndcapDp1_;
+       MonitorElement* meNDigisCHANEndcapDp2_;
+       MonitorElement* meNDigisCHANEndcapDp3_;
+       MonitorElement* meNDigisCHANEndcapDm1_;
+       MonitorElement* meNDigisCHANEndcapDm2_;
+       MonitorElement* meNDigisCHANEndcapDm3_;
+       
+       int bigEventSize;
+       bool firstRun;
+       
+       std::string I_name[1856];
+       unsigned int I_detId[1856];
+       int I_fedId[1856];
+       int I_linkId1[1856];
+       int I_linkId2[1856];
+       int nDigisPerFed[40];
+       int nDigisPerChan[1152];
+       int nDigisPerDisk[6];
+       int numberOfDigis[336];
+       int nDigisA;
+       int nDigisB;
+       
+       //define Token(-s)
+       edm::EDGetTokenT<edm::DetSetVector<PixelDigi> > srcToken_;
+ };
+
+#endif

--- a/DQM/SiPixelMonitorDigi/python/SiPixelMonitorDigi_cfi.py
+++ b/DQM/SiPixelMonitorDigi/python/SiPixelMonitorDigi_cfi.py
@@ -25,4 +25,28 @@ SiPixelDigiSource = cms.EDAnalyzer("SiPixelDigiSource",
     bigEventSize = cms.untracked.int32(1000)
 )
 
+SiPixelDigiSourcePhase1 = cms.EDAnalyzer("SiPixelDigiSourcePhase1",
+    src = cms.InputTag("siPixelDigis"),
+    outputFile = cms.string('Pixel_DQM_Digi.root'),
+    saveFile = cms.untracked.bool(False),
+    isPIB = cms.untracked.bool(False),
+    slowDown = cms.untracked.bool(False),
+    modOn = cms.untracked.bool(True),
+    twoDimOn = cms.untracked.bool(True),	
+    twoDimModOn = cms.untracked.bool(True),     
+    #allows to have no twoD plots on Mod level (but possibly on other levels),
+    #if !twoDimOn no plots on module level anyway, no projections if twoDimOn and !twoDimModOn
+    twoDimOnlyLayDisk = cms.untracked.bool(False), 
+    #allows to have only twoD plots on lay/disk level (even if layOn/diskOn), no others (and no projections)
+    #only possible if !reducedSet, twoD has no impact, for SiPixelMonitorClient hiRes must be true
+    reducedSet = cms.untracked.bool(True),
+    hiRes = cms.untracked.bool(False), 
+    ladOn = cms.untracked.bool(False),
+    layOn = cms.untracked.bool(False),
+    phiOn = cms.untracked.bool(False),
+    ringOn = cms.untracked.bool(False),
+    bladeOn = cms.untracked.bool(False),
+    diskOn = cms.untracked.bool(False),
+    bigEventSize = cms.untracked.int32(1000)
+)
 

--- a/DQM/SiPixelMonitorDigi/src/SiPixelDigiModule.cc
+++ b/DQM/SiPixelMonitorDigi/src/SiPixelDigiModule.cc
@@ -49,19 +49,13 @@ SiPixelDigiModule::~SiPixelDigiModule() {}
 //
 // Book histograms
 //
-void SiPixelDigiModule::book(const edm::ParameterSet& iConfig, DQMStore::IBooker & iBooker, int type, bool twoD, bool hiRes, bool reducedSet, bool additInfo, bool isUpgrade) {
-
-  //isUpgrade = iConfig.getUntrackedParameter<bool>("isUpgrade");
+void SiPixelDigiModule::book(const edm::ParameterSet& iConfig, DQMStore::IBooker & iBooker, int type, bool twoD, bool hiRes, bool reducedSet, bool additInfo) {
     
   bool barrel = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
   bool endcap = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap);
   bool isHalfModule = false;
   if(barrel){
-    if (!isUpgrade) {
     isHalfModule = PixelBarrelName(DetId(id_)).isHalfModule(); 
-    } else if (isUpgrade) {
-      isHalfModule = PixelBarrelNameUpgrade(DetId(id_)).isHalfModule(); 
-    }
   }
 
   std::string hid;
@@ -118,8 +112,7 @@ void SiPixelDigiModule::book(const edm::ParameterSet& iConfig, DQMStore::IBooker
   
   if(type==1 && barrel){
     uint32_t DBladder;
-    if (!isUpgrade) { DBladder = PixelBarrelName(DetId(id_)).ladderName();}
-    else { DBladder = PixelBarrelNameUpgrade(DetId(id_)).ladderName();}
+    DBladder = PixelBarrelName(DetId(id_)).ladderName();
     char sladder[80]; sprintf(sladder,"Ladder_%02i",DBladder);
     hid = src.label() + "_" + sladder;
     if(isHalfModule) hid += "H";
@@ -150,8 +143,7 @@ void SiPixelDigiModule::book(const edm::ParameterSet& iConfig, DQMStore::IBooker
   }
   if(type==2 && barrel){
     uint32_t DBlayer;
-    if (!isUpgrade) { DBlayer = PixelBarrelName(DetId(id_)).layerName(); }
-    else { DBlayer = PixelBarrelNameUpgrade(DetId(id_)).layerName(); }
+    DBlayer = PixelBarrelName(DetId(id_)).layerName();
     char slayer[80]; sprintf(slayer,"Layer_%i",DBlayer);
     hid = src.label() + "_" + slayer;
     if(!additInfo){
@@ -200,8 +192,7 @@ void SiPixelDigiModule::book(const edm::ParameterSet& iConfig, DQMStore::IBooker
   }
   if(type==3 && barrel){
     uint32_t DBmodule;
-    if (!isUpgrade) { DBmodule = PixelBarrelName(DetId(id_)).moduleName(); }
-    else { DBmodule = PixelBarrelNameUpgrade(DetId(id_)).moduleName(); }
+    DBmodule = PixelBarrelName(DetId(id_)).moduleName();
     char smodule[80]; sprintf(smodule,"Ring_%i",DBmodule);
     hid = src.label() + "_" + smodule;
     // Number of digis
@@ -241,8 +232,7 @@ void SiPixelDigiModule::book(const edm::ParameterSet& iConfig, DQMStore::IBooker
   }
   if(type==4 && endcap){
     uint32_t blade;
-    if (!isUpgrade) { blade= PixelEndcapName(DetId(id_)).bladeName(); }
-    else { blade= PixelEndcapNameUpgrade(DetId(id_)).bladeName(); }
+    blade= PixelEndcapName(DetId(id_)).bladeName();
     
     char sblade[80]; sprintf(sblade, "Blade_%02i",blade);
     hid = src.label() + "_" + sblade;
@@ -255,8 +245,7 @@ void SiPixelDigiModule::book(const edm::ParameterSet& iConfig, DQMStore::IBooker
   }
   if(type==5 && endcap){
     uint32_t disk;
-    if (!isUpgrade) { disk = PixelEndcapName(DetId(id_)).diskName(); }
-    else { disk = PixelEndcapNameUpgrade(DetId(id_)).diskName(); }
+    disk = PixelEndcapName(DetId(id_)).diskName();
     
     char sdisk[80]; sprintf(sdisk, "Disk_%i",disk);
     hid = src.label() + "_" + sdisk;
@@ -284,13 +273,8 @@ void SiPixelDigiModule::book(const edm::ParameterSet& iConfig, DQMStore::IBooker
   if(type==6 && endcap){
     uint32_t panel;
     uint32_t module;
-    if (!isUpgrade) {
-      panel= PixelEndcapName(DetId(id_)).pannelName();
-      module= PixelEndcapName(DetId(id_)).plaquetteName();
-    } else {
-      panel= PixelEndcapNameUpgrade(DetId(id_)).pannelName();
-      module= PixelEndcapNameUpgrade(DetId(id_)).plaquetteName();
-    }
+    panel= PixelEndcapName(DetId(id_)).pannelName();
+    module= PixelEndcapName(DetId(id_)).plaquetteName();
     
     char slab[80]; sprintf(slab, "Panel_%i_Ring_%i",panel, module);
     hid = src.label() + "_" + slab;
@@ -329,24 +313,21 @@ int SiPixelDigiModule::fill(const edm::DetSetVector<PixelDigi>& input,
 			    bool modon, bool ladon, bool layon, bool phion, 
 			    bool bladeon, bool diskon, bool ringon, 
 			    bool twoD, bool reducedSet, bool twoDimModOn, bool twoDimOnlyLayDisk,
-			    int &nDigisA, int &nDigisB, bool isUpgrade) {
+			    int &nDigisA, int &nDigisB) {
   bool barrel = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
   bool endcap = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap);
   bool isHalfModule = false;
   uint32_t DBladder = 0;
-  if(barrel && !isUpgrade){
+  if(barrel){
     isHalfModule = PixelBarrelName(DetId(id_)).isHalfModule(); 
     DBladder = PixelBarrelName(DetId(id_)).ladderName();
-  } else if (barrel && isUpgrade) {
-    isHalfModule = PixelBarrelNameUpgrade(DetId(id_)).isHalfModule(); 
-    DBladder = PixelBarrelNameUpgrade(DetId(id_)).ladderName();
   }
 
   edm::DetSetVector<PixelDigi>::const_iterator isearch = input.find(id_); // search  digis of detid
   
   unsigned int numberOfDigisMod = 0;
   int msize;
-  if (isUpgrade) {msize=10;} else {msize=8;}
+  msize=10;
   int numberOfDigis[msize]; for(int i=0; i!=msize; i++) numberOfDigis[i]=0; 
   nDigisA=0; nDigisB=0;
   if( isearch != input.end() ) {  // Not an empty iterator
@@ -362,7 +343,6 @@ int SiPixelDigiModule::fill(const edm::DetSetVector<PixelDigi>& input,
       int DBlayer = 0;
       int DBmodule =0;
       
-      if (!isUpgrade) {
       PixelBarrelName::Shell DBshell = PixelBarrelName(DetId(id_)).shell();
         DBlayer  = PixelBarrelName(DetId(id_)).layerName();
         DBmodule = PixelBarrelName(DetId(id_)).moduleName();
@@ -393,26 +373,6 @@ int SiPixelDigiModule::fill(const edm::DetSetVector<PixelDigi>& input,
 	    if(DBlayer==3) numberOfDigis[7]++;
 	  }
         }
-      }
-      } else if (isUpgrade) {
-        //PixelBarrelNameUpgrade::Shell DBshell = PixelBarrelNameUpgrade(DetId(id_)).shell();
-        DBlayer  = PixelBarrelNameUpgrade(DetId(id_)).layerName();
-        DBmodule = PixelBarrelNameUpgrade(DetId(id_)).moduleName();
-	if(barrel){
-	  if(row<80){
-	    numberOfDigis[0]++; nDigisA++;
-	    if(DBlayer==1) numberOfDigis[2]++;
-	    if(DBlayer==2) numberOfDigis[3]++;
-	    if(DBlayer==3) numberOfDigis[4]++;
-	    if(DBlayer==4) numberOfDigis[5]++;
-	  }else{ 
-	    numberOfDigis[1]++; nDigisB++;
-	    if(DBlayer==1) numberOfDigis[6]++;
-	    if(DBlayer==2) numberOfDigis[7]++;
-	    if(DBlayer==3) numberOfDigis[8]++;
-	    if(DBlayer==4) numberOfDigis[9]++;
-	  }
-	}
       }
       
       if(modon){
@@ -485,20 +445,15 @@ int SiPixelDigiModule::fill(const edm::DetSetVector<PixelDigi>& input,
 	(meADCBlade_)->Fill((float)adc);
       }
 
-      if((diskon || twoDimOnlyLayDisk) && endcap){
+      if((diskon || twoDimOnlyLayDisk) && endcap) {
 	if(!twoDimOnlyLayDisk) (meADCDisk_)->Fill((float)adc);
 	if(twoDimOnlyLayDisk){
 	  (mePixDigisDisk_)->Fill((float)col,(float)row);
 	  //ROC monitoring
 	  int DBpanel;
 	  int DBblade;
-	  if (!isUpgrade) {
-	    DBpanel= PixelEndcapName(DetId(id_)).pannelName();
-	    DBblade= PixelEndcapName(DetId(id_)).bladeName();
-	  } else {
-	    DBpanel= PixelEndcapNameUpgrade(DetId(id_)).pannelName();
-	    DBblade= PixelEndcapNameUpgrade(DetId(id_)).bladeName();
-	  }
+	  DBpanel= PixelEndcapName(DetId(id_)).pannelName();
+	  DBblade= PixelEndcapName(DetId(id_)).bladeName();
 	  float offx = 0.;
 	  //This crazy offset takes into account the roc and module fpix configuration
 	  for (int i = DBpanel; i < DBmodule; ++i) {offx = offx + float(5+DBpanel-i);}

--- a/DQM/SiPixelMonitorDigi/src/SiPixelDigiModulePhase1.cc
+++ b/DQM/SiPixelMonitorDigi/src/SiPixelDigiModulePhase1.cc
@@ -1,0 +1,523 @@
+#include "DQM/SiPixelMonitorDigi/interface/SiPixelDigiModulePhase1.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQM/SiPixelCommon/interface/SiPixelHistogramId.h"
+/// Framework
+#include "FWCore/ServiceRegistry/interface/Service.h"
+// STL
+#include <vector>
+#include <memory>
+#include <string>
+#include <iostream>
+#include <stdlib.h>
+#include <sstream>
+#include <cstdio>
+
+// Data Formats
+#include "DataFormats/SiPixelDetId/interface/PixelBarrelName.h"
+#include "DataFormats/SiPixelDetId/interface/PixelBarrelNameUpgrade.h"
+#include "DataFormats/SiPixelDetId/interface/PixelEndcapName.h"
+#include "DataFormats/SiPixelDetId/interface/PixelEndcapNameUpgrade.h"
+#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+
+//
+// Constructors
+//
+SiPixelDigiModulePhase1::SiPixelDigiModulePhase1() : id_(0),
+					 ncols_(416),
+					 nrows_(160) 
+{
+}
+///
+SiPixelDigiModulePhase1::SiPixelDigiModulePhase1(const uint32_t& id) : 
+  id_(id),
+  ncols_(416),
+  nrows_(160)
+{ 
+}
+///
+SiPixelDigiModulePhase1::SiPixelDigiModulePhase1(const uint32_t& id, const int& ncols, const int& nrows) : 
+  id_(id),
+  ncols_(ncols),
+  nrows_(nrows)
+{ 
+}
+//
+// Destructor
+//
+SiPixelDigiModulePhase1::~SiPixelDigiModulePhase1() {}
+//
+// Book histograms
+//
+void SiPixelDigiModulePhase1::book(const edm::ParameterSet& iConfig, DQMStore::IBooker & iBooker, int type, bool twoD, bool hiRes, bool reducedSet, bool additInfo) {
+    
+  bool barrel = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
+  bool endcap = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap);
+  bool isHalfModule = false;
+  if(barrel){
+    isHalfModule = PixelBarrelNameUpgrade(DetId(id_)).isHalfModule(); 
+  }
+
+  std::string hid;
+  // Get collection name and instantiate Histo Id builder
+  edm::InputTag src = iConfig.getParameter<edm::InputTag>( "src" );
+  
+  int nbinx=ncols_/2, nbiny=nrows_/2;
+  std::string twodtitle           = "Number of Digis (1bin=four pixels)"; 
+  std::string pxtitle             = "Number of Digis (1bin=two columns)";
+  std::string pytitle             = "Number of Digis (1bin=two rows)";
+  std::string twodroctitle        = "ROC Occupancy (1bin=one ROC)";
+  std::string twodzeroOccroctitle = "Zero Occupancy ROC Map (1bin=one ROC) for ";
+  if(hiRes){
+    nbinx = ncols_;
+    nbiny = nrows_;
+    twodtitle    = "Number of Digis (1bin=one pixel)";
+    pxtitle = "Number of Digis (1bin=one column)";
+    pytitle = "Number of Digis (1bin=one row)";
+  }
+  if(type==0){
+    SiPixelHistogramId* theHistogramId = new SiPixelHistogramId( src.label() );
+    // Number of digis
+    hid = theHistogramId->setHistoId("ndigis",id_);
+    meNDigis_ = iBooker.book1D(hid,"Number of Digis",25,0.,25.);
+    meNDigis_->setAxisTitle("Number of digis",1);
+    // Charge in ADC counts
+    hid = theHistogramId->setHistoId("adc",id_);
+    meADC_ = iBooker.book1D(hid,"Digi charge",128,0.,256.);
+    meADC_->setAxisTitle("ADC counts",1);
+	if(!reducedSet)
+	{
+    if(twoD){
+      if(additInfo){
+	// 2D hit map
+	hid = theHistogramId->setHistoId("hitmap",id_);
+	mePixDigis_ = iBooker.book2D(hid,twodtitle,nbinx,0.,float(ncols_),nbiny,0.,float(nrows_));
+	mePixDigis_->setAxisTitle("Columns",1);
+	mePixDigis_->setAxisTitle("Rows",2);
+	//std::cout << "During booking: type is "<< type << ", ID is "<< id_ << ", pwd for booking is " << theDMBE->pwd() << ", Plot name: " << hid << std::endl;
+      }
+    }
+    else{
+      // projections of 2D hit map
+      hid = theHistogramId->setHistoId("hitmap",id_);
+      mePixDigis_px_ = iBooker.book1D(hid+"_px",pxtitle,nbinx,0.,float(ncols_));
+      mePixDigis_py_ = iBooker.book1D(hid+"_py",pytitle,nbiny,0.,float(nrows_));
+      mePixDigis_px_->setAxisTitle("Columns",1);
+      mePixDigis_py_->setAxisTitle("Rows",1);
+    }
+	}
+    delete theHistogramId;
+
+  }
+  
+  if(type==1 && barrel){
+    uint32_t DBladder;
+    DBladder = PixelBarrelNameUpgrade(DetId(id_)).ladderName();
+    char sladder[80]; sprintf(sladder,"Ladder_%02i",DBladder);
+    hid = src.label() + "_" + sladder;
+    if(isHalfModule) hid += "H";
+    else hid += "F";
+    // Number of digis
+    meNDigisLad_ = iBooker.book1D("ndigis_"+hid,"Number of Digis",25,0.,25.);
+    meNDigisLad_->setAxisTitle("Number of digis",1);
+    // Charge in ADC counts
+    meADCLad_ = iBooker.book1D("adc_" + hid,"Digi charge",128,0.,256.);
+    meADCLad_->setAxisTitle("ADC counts",1);
+	if(!reducedSet)
+	{
+    if(twoD){
+      // 2D hit map
+      mePixDigisLad_ = iBooker.book2D("hitmap_"+hid,twodtitle,nbinx,0.,float(ncols_),nbiny,0.,float(nrows_));
+      mePixDigisLad_->setAxisTitle("Columns",1);
+      mePixDigisLad_->setAxisTitle("Rows",2);
+      //std::cout << "During booking: type is "<< type << ", ID is "<< id_ << ", pwd for booking is " << theDMBE->pwd() << ", Plot name: " << hid << std::endl;
+    }
+    else{
+      // projections of 2D hit map
+      mePixDigisLad_px_ = iBooker.book1D("hitmap_"+hid+"_px",pxtitle,nbinx,0.,float(ncols_));
+      mePixDigisLad_py_ = iBooker.book1D("hitmap_"+hid+"_py",pytitle,nbiny,0.,float(nrows_));
+      mePixDigisLad_px_->setAxisTitle("Columns",1);
+      mePixDigisLad_py_->setAxisTitle("Rows",1);	
+    }
+	}
+  }
+  if(type==2 && barrel){
+    uint32_t DBlayer;
+    DBlayer = PixelBarrelNameUpgrade(DetId(id_)).layerName();
+    char slayer[80]; sprintf(slayer,"Layer_%i",DBlayer);
+    hid = src.label() + "_" + slayer;
+    if(!additInfo){
+      // Number of digis
+      meNDigisLay_ = iBooker.book1D("ndigis_"+hid,"Number of Digis",25,0.,25.);
+      meNDigisLay_->setAxisTitle("Number of digis",1);
+    // Charge in ADC counts
+      meADCLay_ = iBooker.book1D("adc_" + hid,"Digi charge",128,0.,256.);
+      meADCLay_->setAxisTitle("ADC counts",1);
+    }
+    if(!reducedSet){
+      if(twoD || additInfo){
+	// 2D hit map
+	if(isHalfModule){
+	  mePixDigisLay_ = iBooker.book2D("hitmap_"+hid,twodtitle,nbinx,0.,float(ncols_),2*nbiny,0.,float(2*nrows_));
+	}
+	else{
+	  mePixDigisLay_ = iBooker.book2D("hitmap_"+hid,twodtitle,nbinx,0.,float(ncols_),nbiny,0.,float(nrows_));
+
+	}
+	mePixDigisLay_->setAxisTitle("Columns",1);
+	mePixDigisLay_->setAxisTitle("Rows",2);
+	
+	//std::cout << "During booking: type is "<< type << ", ID is "<< id_ << ", pwd for booking is " << theDMBE->pwd() << ", Plot name: " << hid << std::endl;
+	int yROCbins[3] = {18,30,42};
+	mePixRocsLay_ = iBooker.book2D("rocmap_"+hid,twodroctitle,32,0.,32.,yROCbins[DBlayer-1],1.5,1.5+float(yROCbins[DBlayer-1]/2));
+	mePixRocsLay_->setAxisTitle("ROCs per Module",1);
+	mePixRocsLay_->setAxisTitle("ROCs per 1/2 Ladder",2);
+	meZeroOccRocsLay_ = iBooker.book2D("zeroOccROC_map",twodzeroOccroctitle+hid,32,0.,32.,yROCbins[DBlayer-1],1.5,1.5+float(yROCbins[DBlayer-1]/2));
+	meZeroOccRocsLay_->setAxisTitle("ROCs per Module",1);
+	meZeroOccRocsLay_->setAxisTitle("ROCs per 1/2 Ladder",2);
+      }
+      if(!twoD && !additInfo){
+	// projections of 2D hit map
+	mePixDigisLay_px_ = iBooker.book1D("hitmap_"+hid+"_px",pxtitle,nbinx,0.,float(ncols_));
+	if(isHalfModule){
+	  mePixDigisLay_py_ = iBooker.book1D("hitmap_"+hid+"_py",pytitle,2*nbiny,0.,float(2*nrows_));
+	}
+	else{
+	  mePixDigisLay_py_ = iBooker.book1D("hitmap_"+hid+"_py",pytitle,nbiny,0.,float(nrows_));
+	}
+	mePixDigisLay_px_->setAxisTitle("Columns",1);
+	mePixDigisLay_py_->setAxisTitle("Rows",1);
+      }
+    }
+  }
+  if(type==3 && barrel){
+    uint32_t DBmodule;
+    DBmodule = PixelBarrelNameUpgrade(DetId(id_)).moduleName();
+    char smodule[80]; sprintf(smodule,"Ring_%i",DBmodule);
+    hid = src.label() + "_" + smodule;
+    // Number of digis
+    meNDigisPhi_ = iBooker.book1D("ndigis_"+hid,"Number of Digis",25,0.,25.);
+    meNDigisPhi_->setAxisTitle("Number of digis",1);
+    // Charge in ADC counts
+    meADCPhi_ = iBooker.book1D("adc_" + hid,"Digi charge",128,0.,256.);
+    meADCPhi_->setAxisTitle("ADC counts",1);
+    if(!reducedSet)
+      {
+	if(twoD){
+	  
+	  // 2D hit map
+	  if(isHalfModule){
+	    mePixDigisPhi_ = iBooker.book2D("hitmap_"+hid,twodtitle,nbinx,0.,float(ncols_),2*nbiny,0.,float(2*nrows_));
+	  }
+	  else {
+	    mePixDigisPhi_ = iBooker.book2D("hitmap_"+hid,twodtitle,nbinx,0.,float(ncols_),nbiny,0.,float(nrows_));
+	  }
+	  mePixDigisPhi_->setAxisTitle("Columns",1);
+	  mePixDigisPhi_->setAxisTitle("Rows",2);
+	  //std::cout << "During booking: type is "<< type << ", ID is "<< id_ << ", pwd for booking is " << theDMBE->pwd() << ", Plot name: " << hid << std::endl;
+	}
+	else{
+	  // projections of 2D hit map
+	  mePixDigisPhi_px_ = iBooker.book1D("hitmap_"+hid+"_px",pxtitle,nbinx,0.,float(ncols_));
+	  if(isHalfModule){
+	    mePixDigisPhi_py_ = iBooker.book1D("hitmap_"+hid+"_py",pytitle,2*nbiny,0.,float(2*nrows_));
+	  }
+	  else{
+	    mePixDigisPhi_py_ = iBooker.book1D("hitmap_"+hid+"_py",pytitle,nbiny,0.,float(nrows_));
+	  }
+	  mePixDigisPhi_px_->setAxisTitle("Columns",1);
+	  mePixDigisPhi_py_->setAxisTitle("Rows",1);
+	}
+      }
+  }
+  if(type==4 && endcap){
+    uint32_t blade;
+    blade= PixelEndcapNameUpgrade(DetId(id_)).bladeName();
+    
+    char sblade[80]; sprintf(sblade, "Blade_%02i",blade);
+    hid = src.label() + "_" + sblade;
+    // Number of digis
+    meNDigisBlade_ = iBooker.book1D("ndigis_"+hid,"Number of Digis",25,0.,25.);
+    meNDigisBlade_->setAxisTitle("Number of digis",1);
+    // Charge in ADC counts
+    meADCBlade_ = iBooker.book1D("adc_" + hid,"Digi charge",128,0.,256.);
+    meADCBlade_->setAxisTitle("ADC counts",1);
+  }
+  if(type==5 && endcap){
+    uint32_t disk;
+    disk = PixelEndcapNameUpgrade(DetId(id_)).diskName();
+    
+    char sdisk[80]; sprintf(sdisk, "Disk_%i",disk);
+    hid = src.label() + "_" + sdisk;
+    if(!additInfo){
+      // Number of digis
+      meNDigisDisk_ = iBooker.book1D("ndigis_"+hid,"Number of Digis",25,0.,25.);
+      meNDigisDisk_->setAxisTitle("Number of digis",1);
+      // Charge in ADC counts
+      meADCDisk_ = iBooker.book1D("adc_" + hid,"Digi charge",128,0.,256.);
+      meADCDisk_->setAxisTitle("ADC counts",1);
+    }
+    if(additInfo){
+      mePixDigisDisk_ = iBooker.book2D("hitmap_"+hid,twodtitle,260,0.,260.,160,0.,160.);
+      mePixDigisDisk_->setAxisTitle("Columns",1);
+      mePixDigisDisk_->setAxisTitle("Rows",2);
+      //ROC information in disks
+      mePixRocsDisk_  = iBooker.book2D("rocmap_"+hid,twodroctitle,26,0.,26.,24,1.,13.);
+      mePixRocsDisk_ ->setAxisTitle("ROCs per Module (2 Panels)",1);
+      mePixRocsDisk_ ->setAxisTitle("Blade Number",2);
+      meZeroOccRocsDisk_  = iBooker.book2D("zeroOccROC_map",twodzeroOccroctitle+hid,26,0.,26.,24,1.,13.);
+      meZeroOccRocsDisk_ ->setAxisTitle("Zero-Occupancy ROCs per Module (2 Panels)",1);
+      meZeroOccRocsDisk_ ->setAxisTitle("Blade Number",2);
+    }
+  }
+  if(type==6 && endcap){
+    uint32_t panel;
+    uint32_t module;
+    panel= PixelEndcapNameUpgrade(DetId(id_)).pannelName();
+    module= PixelEndcapNameUpgrade(DetId(id_)).plaquetteName();
+    
+    char slab[80]; sprintf(slab, "Panel_%i_Ring_%i",panel, module);
+    hid = src.label() + "_" + slab;
+    // Number of digis
+    meNDigisRing_ = iBooker.book1D("ndigis_"+hid,"Number of Digis",25,0.,25.);
+    meNDigisRing_->setAxisTitle("Number of digis",1);
+    // Charge in ADC counts
+    meADCRing_ = iBooker.book1D("adc_" + hid,"Digi charge",128,0.,256.);
+    meADCRing_->setAxisTitle("ADC counts",1);
+	if(!reducedSet)
+	{
+    if(twoD){
+      // 2D hit map
+      mePixDigisRing_ = iBooker.book2D("hitmap_"+hid,twodtitle,nbinx,0.,float(ncols_),nbiny,0.,float(nrows_));
+      mePixDigisRing_->setAxisTitle("Columns",1);
+      mePixDigisRing_->setAxisTitle("Rows",2);
+      //std::cout << "During booking: type is "<< type << ", ID is "<< id_ << ", pwd for booking is " << theDMBE->pwd() << ", Plot name: " << hid << std::endl;
+    }
+    else{
+      // projections of 2D hit map
+      mePixDigisRing_px_ = iBooker.book1D("hitmap_"+hid+"_px",pxtitle,nbinx,0.,float(ncols_));
+      mePixDigisRing_py_ = iBooker.book1D("hitmap_"+hid+"_py",pytitle,nbiny,0.,float(nrows_));
+      mePixDigisRing_px_->setAxisTitle("Columns",1);
+      mePixDigisRing_py_->setAxisTitle("Rows",1);
+    }
+	}
+  }
+}
+
+
+//
+// Fill histograms
+//
+int SiPixelDigiModulePhase1::fill(const edm::DetSetVector<PixelDigi>& input, 
+			    MonitorElement* combBarrel, MonitorElement* chanBarrel, MonitorElement* chanBarrelL1, MonitorElement* chanBarrelL2, MonitorElement* chanBarrelL3, MonitorElement* chanBarrelL4, MonitorElement* combEndcap,
+			    bool modon, bool ladon, bool layon, bool phion, 
+			    bool bladeon, bool diskon, bool ringon, 
+			    bool twoD, bool reducedSet, bool twoDimModOn, bool twoDimOnlyLayDisk,
+			    int &nDigisA, int &nDigisB) {
+  bool barrel = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
+  bool endcap = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap);
+  bool isHalfModule = false;
+  uint32_t DBladder = 0;
+  if (barrel) {
+    isHalfModule = PixelBarrelNameUpgrade(DetId(id_)).isHalfModule(); 
+    DBladder = PixelBarrelNameUpgrade(DetId(id_)).ladderName();
+  }
+
+  edm::DetSetVector<PixelDigi>::const_iterator isearch = input.find(id_); // search  digis of detid
+  
+  unsigned int numberOfDigisMod = 0;
+  int msize;
+  msize=8;
+  int numberOfDigis[msize]; for(int i=0; i!=msize; i++) numberOfDigis[i]=0; 
+  nDigisA=0; nDigisB=0;
+  if( isearch != input.end() ) {  // Not an empty iterator
+    
+    // Look at digis now
+    edm::DetSet<PixelDigi>::const_iterator  di;
+    for(di = isearch->data.begin(); di != isearch->data.end(); di++) {
+      int adc = di->adc();    // charge
+      int col = di->column(); // column 
+      int row = di->row();    // row
+      numberOfDigisMod++;
+      
+      int DBlayer = 0;
+      int DBmodule =0;
+      
+      //PixelBarrelNameUpgrade::Shell DBshell = PixelBarrelNameUpgrade(DetId(id_)).shell();
+      DBlayer  = PixelBarrelNameUpgrade(DetId(id_)).layerName();
+      DBmodule = PixelBarrelNameUpgrade(DetId(id_)).moduleName();
+      if(barrel){
+	if(row<80){
+	  numberOfDigis[0]++; nDigisA++;
+	  if(DBlayer==1) numberOfDigis[2]++;
+	  if(DBlayer==2) numberOfDigis[3]++;
+	  if(DBlayer==3) numberOfDigis[4]++;
+	  if(DBlayer==4) numberOfDigis[5]++;
+	}else{ 
+	  numberOfDigis[1]++; nDigisB++;
+	  if(DBlayer==1) numberOfDigis[6]++;
+	  if(DBlayer==2) numberOfDigis[7]++;
+	  if(DBlayer==3) numberOfDigis[8]++;
+	  if(DBlayer==4) numberOfDigis[9]++;
+	}
+      }
+      
+      if(modon){
+	if(!reducedSet){
+	  if(twoD) {
+	    if(twoDimModOn) (mePixDigis_)->Fill((float)col,(float)row);
+	  }
+	  else {
+	    (mePixDigis_px_)->Fill((float)col);
+	    (mePixDigis_py_)->Fill((float)row);
+	  }
+	}
+	(meADC_)->Fill((float)adc);
+      }
+      if(ladon && barrel){
+	(meADCLad_)->Fill((float)adc);
+	if(!reducedSet){
+	  if(twoD) (mePixDigisLad_)->Fill((float)col,(float)row);
+	  else {
+	  (mePixDigisLad_px_)->Fill((float)col);
+	  (mePixDigisLad_py_)->Fill((float)row);
+	  }
+	}
+      }
+      if((layon || twoDimOnlyLayDisk) && barrel){
+	if(!twoDimOnlyLayDisk) (meADCLay_)->Fill((float)adc);
+	if(!reducedSet){
+	  if((layon && twoD) || twoDimOnlyLayDisk){
+	    //ROC histos...
+	    float rocx = (float)col/52. + 8.0*float(DBmodule-1);
+	    float rocy = (float)row/160.+float(DBladder);
+	    //Shift 1st ladder (half modules) up by 1 bin
+	    if(DBladder==1) rocy = rocy + 0.5;
+	    mePixRocsLay_->Fill(rocx,rocy);
+
+	    if(isHalfModule && DBladder==1){
+	      (mePixDigisLay_)->Fill((float)col,(float)row+80);
+	    }
+	    else (mePixDigisLay_)->Fill((float)col,(float)row);
+	  }
+	  if((layon && !twoD) && !twoDimOnlyLayDisk){
+	    (mePixDigisLay_px_)->Fill((float)col);
+	    if(isHalfModule && DBladder==1) {
+	      (mePixDigisLay_py_)->Fill((float)row+80);
+	    }
+	    else (mePixDigisLay_py_)->Fill((float)row);
+	  }
+	}
+      }
+      if(phion && barrel){
+	(meADCPhi_)->Fill((float)adc);
+	if(!reducedSet)
+	{
+	if(twoD){
+	  if(isHalfModule && DBladder==1){
+	    (mePixDigisPhi_)->Fill((float)col,(float)row+80);
+	  }
+	  else (mePixDigisPhi_)->Fill((float)col,(float)row);
+	}
+	else {
+	  (mePixDigisPhi_px_)->Fill((float)col);
+	  if(isHalfModule && DBladder==1) {
+	    (mePixDigisPhi_py_)->Fill((float)row+80);
+	  }
+	  else (mePixDigisPhi_py_)->Fill((float)row);
+	}
+	}
+      }
+      if(bladeon && endcap){
+	(meADCBlade_)->Fill((float)adc);
+      }
+
+      if((diskon || twoDimOnlyLayDisk) && endcap){
+	if(!twoDimOnlyLayDisk) (meADCDisk_)->Fill((float)adc);
+	if(twoDimOnlyLayDisk){
+	  (mePixDigisDisk_)->Fill((float)col,(float)row);
+	  //ROC monitoring
+	  int DBpanel;
+	  int DBblade;
+	  DBpanel= PixelEndcapNameUpgrade(DetId(id_)).pannelName();
+	  DBblade= PixelEndcapNameUpgrade(DetId(id_)).bladeName();
+	  float offx = 0.;
+	  //This crazy offset takes into account the roc and module fpix configuration
+	  for (int i = DBpanel; i < DBmodule; ++i) {offx = offx + float(5+DBpanel-i);}
+	  float rocx = (float)col/52. + offx + 14.0*float(DBpanel-1);
+	  float rocy = (float)row/160.+float(DBblade);
+	  mePixRocsDisk_->Fill(rocx,rocy);
+	}
+      }
+      if(ringon && endcap){
+	(meADCRing_)->Fill((float)adc);
+	if(!reducedSet)
+	{
+	if(twoD) (mePixDigisRing_)->Fill((float)col,(float)row);
+	else {
+	  (mePixDigisRing_px_)->Fill((float)col);
+	  (mePixDigisRing_py_)->Fill((float)row);
+	}
+	}
+      }
+    }
+    if(modon) (meNDigis_)->Fill((float)numberOfDigisMod);
+    if(ladon && barrel) (meNDigisLad_)->Fill((float)numberOfDigisMod);
+    if(layon && barrel && !twoDimOnlyLayDisk) (meNDigisLay_)->Fill((float)numberOfDigisMod);
+    if(phion && barrel) (meNDigisPhi_)->Fill((float)numberOfDigisMod);
+    if(bladeon && endcap) (meNDigisBlade_)->Fill((float)numberOfDigisMod);
+    if(diskon && endcap && !twoDimOnlyLayDisk) (meNDigisDisk_)->Fill((float)numberOfDigisMod);
+    if(ringon && endcap) (meNDigisRing_)->Fill((float)numberOfDigisMod);
+    if(barrel){ 
+      if(combBarrel) combBarrel->Fill((float)numberOfDigisMod);
+      if(chanBarrel){ if(numberOfDigis[0]>0) chanBarrel->Fill((float)numberOfDigis[0]); if(numberOfDigis[1]>0) chanBarrel->Fill((float)numberOfDigis[1]); }
+      if(chanBarrelL1){ if(numberOfDigis[2]>0) chanBarrelL1->Fill((float)numberOfDigis[2]); }
+      if(chanBarrelL2){ if(numberOfDigis[3]>0) chanBarrelL2->Fill((float)numberOfDigis[3]); }
+      if(chanBarrelL3){ if(numberOfDigis[4]>0) chanBarrelL3->Fill((float)numberOfDigis[4]); }
+      if(chanBarrelL4){ if(numberOfDigis[5]>0) chanBarrelL4->Fill((float)numberOfDigis[5]); }
+    }else if(endcap){
+      if(combEndcap) combEndcap->Fill((float)numberOfDigisMod);
+    }
+  }
+  
+  //std::cout<<"numberOfDigis for this module: "<<numberOfDigis<<std::endl;
+  return numberOfDigisMod;
+}
+
+// This was done in the Source file, but is moved to the Module for thread safety reasons. Using ME that is booked here.
+void SiPixelDigiModulePhase1::resetRocMap(){
+  if (mePixRocsDisk_) mePixRocsDisk_->Reset();
+  if (mePixRocsLay_) mePixRocsLay_->Reset();
+}
+
+//Moved from source. Gets the zero and low eff ROCs from each module. Called in source for each module.
+std::pair<int,int> SiPixelDigiModulePhase1::getZeroLoEffROCs(){
+  int nZeroROC = 0;
+  int nLoEffROC = 0;
+  float SF = 1.0;
+  if (mePixRocsDisk_ && meZeroOccRocsDisk_){
+    if (mePixRocsDisk_->getEntries() > 0) SF = float(mePixRocsDisk_->getNbinsX()*mePixRocsDisk_->getNbinsY()/mePixRocsDisk_->getEntries());
+    for (int i = 1; i < mePixRocsDisk_->getNbinsX(); ++i){
+      for (int j = 1; j < mePixRocsDisk_->getNbinsY(); ++j){
+	float localX = float(i) - 0.5;
+	float localY = float(j)/2.0 + 0.75;
+	if (mePixRocsDisk_->getBinContent(i,j)    <  1 ) {nZeroROC++; meZeroOccRocsDisk_->Fill(localX,localY);}
+	if (mePixRocsDisk_->getBinContent(i,j)*SF < 0.25){nLoEffROC++;}
+      }
+    }
+    return std::pair<int,int>(nZeroROC,nLoEffROC);
+  }
+  if (mePixRocsLay_ && meZeroOccRocsLay_){
+    if (mePixRocsLay_->getEntries() > 0) SF = float(mePixRocsLay_->getNbinsX()*mePixRocsLay_->getNbinsY()/mePixRocsLay_->getEntries());
+    for (int i = 1; i < mePixRocsLay_->getNbinsX(); ++i){
+      for (int j = 1; j < mePixRocsLay_->getNbinsY(); ++j){
+	float localX = float(i) - 0.5;
+	float localY = float(j)/2.0 + 1.25;
+	if (mePixRocsLay_->getBinContent(i,j)    <  1 ) {nZeroROC++; meZeroOccRocsLay_->Fill(localX,localY);}
+	if (mePixRocsLay_->getBinContent(i,j)*SF < 0.25){nLoEffROC++;}
+      }
+    }
+    return std::pair<int,int>(nZeroROC,nLoEffROC);
+  }
+  return std::pair<int,int>(0,0);
+}

--- a/DQM/SiPixelMonitorDigi/src/SiPixelDigiSource.cc
+++ b/DQM/SiPixelMonitorDigi/src/SiPixelDigiSource.cc
@@ -62,8 +62,7 @@ SiPixelDigiSource::SiPixelDigiSource(const edm::ParameterSet& iConfig) :
   ringOn( conf_.getUntrackedParameter<bool>("ringOn",false) ), 
   bladeOn( conf_.getUntrackedParameter<bool>("bladeOn",false) ), 
   diskOn( conf_.getUntrackedParameter<bool>("diskOn",false) ),
-  bigEventSize( conf_.getUntrackedParameter<int>("bigEventSize",1000) ), 
-  isUpgrade( conf_.getUntrackedParameter<bool>("isUpgrade",false) )
+  bigEventSize( conf_.getUntrackedParameter<int>("bigEventSize",1000) )
 {
    //set Token(-s)
    srcToken_ = consumes<edm::DetSetVector<PixelDigi> >(conf_.getParameter<edm::InputTag>( "src" ));
@@ -74,7 +73,7 @@ SiPixelDigiSource::SiPixelDigiSource(const edm::ParameterSet& iConfig) :
    int nModsInFile=0;
    assert(!infile.fail());
    int nTOTmodules;
-   if (isUpgrade) { nTOTmodules=1856; } else { nTOTmodules=1440; }
+   nTOTmodules=1440;
    while(!infile.eof()&&nModsInFile<nTOTmodules) {
      infile >> I_name[nModsInFile] >> I_detId[nModsInFile] >> I_fedId[nModsInFile] >> I_linkId1[nModsInFile] >> I_linkId2[nModsInFile];
      nModsInFile++;
@@ -218,7 +217,7 @@ void SiPixelDigiSource::analyze(const edm::Event& iEvent, const edm::EventSetup&
 						       modOn, ladOn, layOn, phiOn, 
 						       bladeOn, diskOn, ringOn, 
 						       twoDimOn, reducedSet, twoDimModOn, twoDimOnlyLayDisk,
-						       nDigisA, nDigisB, isUpgrade);
+						       nDigisA, nDigisB);
     if (modOn && twoDimOnlyLayDisk && lumiSection%10 == 0) (*struct_iter).second->resetRocMap();
 
     bool barrel = DetId((*struct_iter).first).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
@@ -228,13 +227,9 @@ void SiPixelDigiSource::analyze(const edm::Event& iEvent, const edm::EventSetup&
       nActiveModules++;  
       int nBPiXmodules;
       int nTOTmodules;
-      if (isUpgrade) {
-        nBPiXmodules=1184;
-        nTOTmodules=1856;
-      } else {
-        nBPiXmodules=768;
-        nTOTmodules=1440;
-      }
+      nBPiXmodules=768;
+      nTOTmodules=1440;
+      
       if(barrel){ // Barrel
         nBPIXDigis = nBPIXDigis + numberOfDigisMod;
         for(int i=0; i!=nBPiXmodules; ++i){
@@ -248,7 +243,7 @@ void SiPixelDigiSource::analyze(const edm::Event& iEvent, const edm::EventSetup&
             i=(nBPiXmodules-1);
 	  }
         }
-      }else if(endcap && !isUpgrade){ // Endcap
+      }else if(endcap){ // Endcap
         nFPIXDigis = nFPIXDigis + numberOfDigisMod;
         PixelEndcapName::HalfCylinder side = PixelEndcapName(DetId((*struct_iter).first)).halfCylinder();
 	int disk = PixelEndcapName(DetId((*struct_iter).first)).diskName();
@@ -353,93 +348,7 @@ void SiPixelDigiSource::analyze(const edm::Event& iEvent, const edm::EventSetup&
             i=nTOTmodules-1;
 	  }
         }
-      } //endif Barrel/(Endcap && !isUpgrade)
-      else if (endcap && isUpgrade) {
-        nFPIXDigis = nFPIXDigis + numberOfDigisMod;
-        PixelEndcapNameUpgrade::HalfCylinder side = PixelEndcapNameUpgrade(DetId((*struct_iter).first)).halfCylinder();
-        int disk = PixelEndcapNameUpgrade(DetId((*struct_iter).first)).diskName();
-        int blade = PixelEndcapNameUpgrade(DetId((*struct_iter).first)).bladeName();
-        int panel = PixelEndcapNameUpgrade(DetId((*struct_iter).first)).pannelName();
-        int module = PixelEndcapNameUpgrade(DetId((*struct_iter).first)).plaquetteName();
-        
-        int iter=0; int i=0;
-        if(side==PixelEndcapNameUpgrade::mI){
-          if(disk==1){
-            i=0;
-            if(panel==1){ if(module==1) nDM1P1M1+=numberOfDigisMod; }
-            else if(panel==2){ if(module==1) nDM1P2M1+=numberOfDigisMod; }
-	    if(blade<12 && blade>0 && (panel==1 || panel==2)) iter = i+2*(blade-1)+(panel-1);
-          }else if(disk==2){
-            i=22;
-            if(panel==1){ if(module==1) nDM2P1M1+=numberOfDigisMod; }
-            else if(panel==2){ if(module==1) nDM2P2M1+=numberOfDigisMod; }
-	    if(blade<12 && blade>0 && (panel==1 || panel==2)) iter = i+2*(blade-1)+(panel-1);
-          }else if(disk==3){
-            i=44;
-            if(panel==1){ if(module==1) nDM3P1M1+=numberOfDigisMod; }
-            else if(panel==2){ if(module==1) nDM3P2M1+=numberOfDigisMod; }
-	    if(blade<12 && blade>0 && (panel==1 || panel==2)) iter = i+2*(blade-1)+(panel-1);
-          }
-        }else if(side==PixelEndcapNameUpgrade::mO){
-          if(disk==1){
-            i=66;
-            if(panel==1){ if(module==1) nDM1P1M1+=numberOfDigisMod; }
-            else if(panel==2){ if(module==1) nDM1P2M1+=numberOfDigisMod; }
-	    if(blade<18 && blade>0 && (panel==1 || panel==2)) iter = i+2*(blade-1)+(panel-1);
-          }else if(disk==2){
-           i=100;
-           if(panel==1){ if(module==1) nDM2P1M1+=numberOfDigisMod; }
-           else if(panel==2){ if(module==1) nDM2P2M1+=numberOfDigisMod; }
-	    if(blade<18 && blade>0 && (panel==1 || panel==2)) iter = i+2*(blade-1)+(panel-1);
-          }else if (disk==3){
-            i=134;
-            if(panel==1){ if(module==1) nDM3P1M1+=numberOfDigisMod; }
-            else if(panel==2){ if(module==1) nDM3P2M1+=numberOfDigisMod; }
-	    if(blade<18 && blade>0 && (panel==1 || panel==2)) iter = i+2*(blade-1)+(panel-1);
-          }
-        }else if(side==PixelEndcapNameUpgrade::pI){
-          if(disk==1){
-            i=168;
-            if(panel==1){ if(module==1) nDP1P1M1+=numberOfDigisMod; }
-            else if(panel==2){ if(module==1) nDP1P2M1+=numberOfDigisMod; }
-	    if(blade<12 && blade>0 && (panel==1 || panel==2)) iter = i+2*(blade-1)+(panel-1);
-          }else if(disk==2){
-            i=190;
-            if(panel==1){ if(module==1) nDP2P1M1+=numberOfDigisMod; }
-            else if(panel==2){ if(module==1) nDP2P2M1+=numberOfDigisMod; }
-	    if(blade<12 && blade>0 && (panel==1 || panel==2)) iter = i+2*(blade-1)+(panel-1);
-          }else if(disk==3){
-            i=212;
-            if(panel==1){ if(module==1) nDP3P1M1+=numberOfDigisMod; }
-            else if(panel==2){ if(module==1) nDP3P2M1+=numberOfDigisMod; }
-	    if(blade<12 && blade>0 && (panel==1 || panel==2)) iter = i+2*(blade-1)+(panel-1);
-          }
-        }else if(side==PixelEndcapNameUpgrade::pO){
-          if(disk==1){
-            i=234;
-            if(panel==1){ if(module==1) nDP1P1M1+=numberOfDigisMod; }
-            else if(panel==2){ if(module==1) nDP1P2M1+=numberOfDigisMod; }
-	    if(blade<18 && blade>0 && (panel==1 || panel==2)) iter = i+2*(blade-1)+(panel-1);
-          }else if(disk==2){
-            i=268;
-            if(panel==1){ if(module==1) nDP2P1M1+=numberOfDigisMod; }
-            else if(panel==2){ if(module==1) nDP2P2M1+=numberOfDigisMod; }
-	    if(blade<18 && blade>0 && (panel==1 || panel==2)) iter = i+2*(blade-1)+(panel-1);
-          }else if(disk==3){
-            i=302;
-            if(panel==1){ if(module==1) nDP3P1M1+=numberOfDigisMod; }
-            else if(panel==2){ if(module==1) nDP3P2M1+=numberOfDigisMod; }
-	    if(blade<18 && blade>0 && (panel==1 || panel==2)) iter = i+2*(blade-1)+(panel-1);
-          }
-        }
-        numberOfDigis[iter]=numberOfDigis[iter]+numberOfDigisMod;
-        for(int i=nBPiXmodules; i!=nTOTmodules; i++){
-          if((*struct_iter).first == I_detId[i]){
-	    nDigisPerFed[I_fedId[i]]=nDigisPerFed[I_fedId[i]]+numberOfDigisMod;
-            i=nTOTmodules-1;
-	  }
-        }
-      }//endif(Endcap && isUpgrade)
+      } //endif Barrel/(Endcap)
     } // endif any digis in this module
     if (twoDimOnlyLayDisk && lumiSection%10 > 2){
       std::pair<int,int> tempPair = (*struct_iter).second->getZeroLoEffROCs();
@@ -462,21 +371,11 @@ void SiPixelDigiSource::analyze(const edm::Event& iEvent, const edm::EventSetup&
     if(loOccROCsEndcap) loOccROCsEndcap->setBinContent(1+lumiSection/10, NloEffROCs[1]);
   }
   
-  if (!isUpgrade) {
-    if(meNDigisCHANEndcap_){ for(int j=0; j!=192; j++) if(numberOfDigis[j]>0) meNDigisCHANEndcap_->Fill((float)numberOfDigis[j]);}
-    if(meNDigisCHANEndcapDm1_){ for(int j=0; j!=72; j++) if((j<24||j>47)&&numberOfDigis[j]>0) meNDigisCHANEndcapDm1_->Fill((float)numberOfDigis[j]);}
-    if(meNDigisCHANEndcapDm2_){ for(int j=24; j!=96; j++) if((j<48||j>71)&&numberOfDigis[j]>0) meNDigisCHANEndcapDm2_->Fill((float)numberOfDigis[j]);}
-    if(meNDigisCHANEndcapDp1_){ for(int j=96; j!=168; j++) if((j<120||j>143)&&numberOfDigis[j]>0) meNDigisCHANEndcapDp1_->Fill((float)numberOfDigis[j]);}
-    if(meNDigisCHANEndcapDp2_){ for(int j=120; j!=192; j++) if((j<144||j>167)&&numberOfDigis[j]>0) meNDigisCHANEndcapDp2_->Fill((float)numberOfDigis[j]);}
-  } else if (isUpgrade) {
-    if(meNDigisCHANEndcap_){ for(int j=0; j!=336; j++) if(numberOfDigis[j]>0) meNDigisCHANEndcap_->Fill((float)numberOfDigis[j]);}
-    if(meNDigisCHANEndcapDm1_){ for(int j=0; j!=100; j++) if((j<22||j>65)&&numberOfDigis[j]>0) meNDigisCHANEndcapDm1_->Fill((float)numberOfDigis[j]);}
-    if(meNDigisCHANEndcapDm2_){ for(int j=22; j!=134; j++) if((j<44||j>99)&&numberOfDigis[j]>0) meNDigisCHANEndcapDm2_->Fill((float)numberOfDigis[j]);}
-    if(meNDigisCHANEndcapDm3_){ for(int j=44; j!=168; j++) if((j<66||j>133)&&numberOfDigis[j]>0) meNDigisCHANEndcapDm3_->Fill((float)numberOfDigis[j]);}
-    if(meNDigisCHANEndcapDp1_){ for(int j=168; j!=268; j++) if((j<190||j>233)&&numberOfDigis[j]>0) meNDigisCHANEndcapDp1_->Fill((float)numberOfDigis[j]);}
-    if(meNDigisCHANEndcapDp2_){ for(int j=190; j!=302; j++) if((j<212||j>267)&&numberOfDigis[j]>0) meNDigisCHANEndcapDp2_->Fill((float)numberOfDigis[j]);}
-    if(meNDigisCHANEndcapDp3_){ for(int j=212; j!=336; j++) if((j<234||j>301)&&numberOfDigis[j]>0) meNDigisCHANEndcapDp3_->Fill((float)numberOfDigis[j]);}
-  }
+  if(meNDigisCHANEndcap_){ for(int j=0; j!=192; j++) if(numberOfDigis[j]>0) meNDigisCHANEndcap_->Fill((float)numberOfDigis[j]);}
+  if(meNDigisCHANEndcapDm1_){ for(int j=0; j!=72; j++) if((j<24||j>47)&&numberOfDigis[j]>0) meNDigisCHANEndcapDm1_->Fill((float)numberOfDigis[j]);}
+  if(meNDigisCHANEndcapDm2_){ for(int j=24; j!=96; j++) if((j<48||j>71)&&numberOfDigis[j]>0) meNDigisCHANEndcapDm2_->Fill((float)numberOfDigis[j]);}
+  if(meNDigisCHANEndcapDp1_){ for(int j=96; j!=168; j++) if((j<120||j>143)&&numberOfDigis[j]>0) meNDigisCHANEndcapDp1_->Fill((float)numberOfDigis[j]);}
+  if(meNDigisCHANEndcapDp2_){ for(int j=120; j!=192; j++) if((j<144||j>167)&&numberOfDigis[j]>0) meNDigisCHANEndcapDp2_->Fill((float)numberOfDigis[j]);}
   
   if(meNDigisCHANBarrelCh1_){ for(int i=0; i!=32; i++) if(nDigisPerChan[i*36+0]>0) meNDigisCHANBarrelCh1_->Fill((float)nDigisPerChan[i*36+0]);}
   if(meNDigisCHANBarrelCh2_){ for(int i=0; i!=32; i++) if(nDigisPerChan[i*36+1]>0) meNDigisCHANBarrelCh2_->Fill((float)nDigisPerChan[i*36+1]);}
@@ -586,7 +485,7 @@ void SiPixelDigiSource::buildStructure(const edm::EventSetup& iSetup){
 	SiPixelDigiModule* theModule = new SiPixelDigiModule(id, ncols, nrows);
 	thePixelStructure.insert(pair<uint32_t,SiPixelDigiModule*> (id,theModule));
 
-      }	else if((detId.subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap)) && (!isUpgrade)) {
+      }	else if((detId.subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap)) ) {
 	LogDebug ("PixelDQM") << " ---> Adding Endcap Module " <<  detId.rawId() << endl;
 	uint32_t id = detId();
 	SiPixelDigiModule* theModule = new SiPixelDigiModule(id, ncols, nrows);
@@ -613,35 +512,7 @@ void SiPixelDigiSource::buildStructure(const edm::EventSetup& iSetup){
 	if(isPIB && mask) continue;
 	
 	thePixelStructure.insert(pair<uint32_t,SiPixelDigiModule*> (id,theModule));
-      }	else if( (detId.subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap)) && (isUpgrade)) {
-	LogDebug ("PixelDQM") << " ---> Adding Endcap Module " <<  detId.rawId() << endl;
-	uint32_t id = detId();
-	SiPixelDigiModule* theModule = new SiPixelDigiModule(id, ncols, nrows);
-        
-        PixelEndcapNameUpgrade::HalfCylinder side = PixelEndcapNameUpgrade(DetId(id)).halfCylinder();
-        int disk   = PixelEndcapNameUpgrade(DetId(id)).diskName();
-        int blade  = PixelEndcapNameUpgrade(DetId(id)).bladeName();
-        int panel  = PixelEndcapNameUpgrade(DetId(id)).pannelName();
-        int module = PixelEndcapNameUpgrade(DetId(id)).plaquetteName();
-
-        char sside[80];  sprintf(sside,  "HalfCylinder_%i",side);
-        char sdisk[80];  sprintf(sdisk,  "Disk_%i",disk);
-        char sblade[80]; sprintf(sblade, "Blade_%02i",blade);
-        char spanel[80]; sprintf(spanel, "Panel_%i",panel);
-        char smodule[80];sprintf(smodule,"Module_%i",module);
-        std::string side_str = sside;
-	std::string disk_str = sdisk;
-	bool mask = side_str.find("HalfCylinder_1")!=string::npos||
-	            side_str.find("HalfCylinder_2")!=string::npos||
-		    side_str.find("HalfCylinder_4")!=string::npos||
-		    disk_str.find("Disk_2")!=string::npos;
-	// clutch to take all of FPIX, but no BPIX:
-	mask = false;
-	if(isPIB && mask) continue;
-	
-	thePixelStructure.insert(pair<uint32_t,SiPixelDigiModule*> (id,theModule));
-      }//end_elseif(isUpgrade)
-
+      }
     }
   }
   LogInfo ("PixelDQM") << " *** Pixel Structure Size " << thePixelStructure.size() << endl;
@@ -681,8 +552,8 @@ void SiPixelDigiSource::bookMEs(DQMStore::IBooker & iBooker){
   for(struct_iter = thePixelStructure.begin(); struct_iter != thePixelStructure.end(); struct_iter++){
     /// Create folder tree and book histograms 
     if(modOn){
-      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,0,isUpgrade)){
-	(*struct_iter).second->book( conf_,iBooker,0,twoDimOn,hiRes, reducedSet, twoDimModOn, isUpgrade);
+      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,0)){
+	(*struct_iter).second->book( conf_,iBooker,0,twoDimOn,hiRes, reducedSet, twoDimModOn);
       } else {
 
 	if(!isPIB) throw cms::Exception("LogicError")
@@ -690,45 +561,45 @@ void SiPixelDigiSource::bookMEs(DQMStore::IBooker & iBooker){
       }
     }
     if(ladOn){
-      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,1,isUpgrade)){
-	(*struct_iter).second->book( conf_,iBooker,1,twoDimOn,hiRes, reducedSet, isUpgrade);
+      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,1)){
+	(*struct_iter).second->book( conf_,iBooker,1,twoDimOn,hiRes, reducedSet);
 	} else {
 	LogDebug ("PixelDQM") << "PROBLEM WITH LADDER-FOLDER\n";
       }
    
     }
     if(layOn || twoDimOnlyLayDisk){
-      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,2,isUpgrade)){
-	(*struct_iter).second->book( conf_,iBooker,2,twoDimOn,hiRes, reducedSet, twoDimOnlyLayDisk, isUpgrade);
+      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,2)){
+	(*struct_iter).second->book( conf_,iBooker,2,twoDimOn,hiRes, reducedSet, twoDimOnlyLayDisk);
 	} else {
 	LogDebug ("PixelDQM") << "PROBLEM WITH LAYER-FOLDER\n";
       }
     }
 
     if(phiOn){
-      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,3,isUpgrade)){
-	(*struct_iter).second->book( conf_,iBooker,3,twoDimOn,hiRes, reducedSet, isUpgrade);
+      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,3)){
+	(*struct_iter).second->book( conf_,iBooker,3,twoDimOn,hiRes, reducedSet);
 	} else {
         LogDebug ("PixelDQM") << "PROBLEM WITH PHI-FOLDER\n";
       }
     }
     if(bladeOn){
-      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,4,isUpgrade)){
-	(*struct_iter).second->book( conf_,iBooker,4,twoDimOn,hiRes, reducedSet, isUpgrade);
+      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,4)){
+	(*struct_iter).second->book( conf_,iBooker,4,twoDimOn,hiRes, reducedSet);
 	} else {
 	LogDebug ("PixelDQM") << "PROBLEM WITH BLADE-FOLDER\n";
       }
     }
     if(diskOn || twoDimOnlyLayDisk){
-      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,5,isUpgrade)){
-	(*struct_iter).second->book( conf_,iBooker,5,twoDimOn,hiRes, reducedSet, twoDimOnlyLayDisk, isUpgrade);
+      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,5)){
+	(*struct_iter).second->book( conf_,iBooker,5,twoDimOn,hiRes, reducedSet, twoDimOnlyLayDisk);
       } else {
 	LogDebug ("PixelDQM") << "PROBLEM WITH DISK-FOLDER\n";
       }
     }
     if(ringOn){
-      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,6,isUpgrade)){
-	(*struct_iter).second->book( conf_,iBooker,6,twoDimOn,hiRes, reducedSet, isUpgrade);
+      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,6)){
+	(*struct_iter).second->book( conf_,iBooker,6,twoDimOn,hiRes, reducedSet);
       } else {
 	LogDebug ("PixelDQM") << "PROBLEM WITH RING-FOLDER\n";
       }
@@ -745,13 +616,8 @@ void SiPixelDigiSource::bookMEs(DQMStore::IBooker & iBooker){
   meNDigisCHANBarrelL2_->setAxisTitle("Number of digis per FED channel per event",1);
   meNDigisCHANBarrelL3_ = iBooker.book1D("ALLMODS_ndigisCHAN_BarrelL3","Number of Digis L3",100,0.,1000.);
   meNDigisCHANBarrelL3_->setAxisTitle("Number of digis per FED channel per event",1);
-  if (isUpgrade) {
-    meNDigisCHANBarrelL4_ = iBooker.book1D("ALLMODS_ndigisCHAN_BarrelL4","Number of Digis L4",100,0.,1000.);
-    meNDigisCHANBarrelL4_->setAxisTitle("Number of digis per FED channel per event",1);
-  }
-  else{
-    meNDigisCHANBarrelL4_=0;
-  }
+  meNDigisCHANBarrelL4_=0;
+ 
   meNDigisCHANBarrelCh1_ = iBooker.book1D("ALLMODS_ndigisCHAN_BarrelCh1","Number of Digis Ch1",100,0.,1000.);
   meNDigisCHANBarrelCh1_->setAxisTitle("Number of digis per FED channel per event",1);
   meNDigisCHANBarrelCh2_ = iBooker.book1D("ALLMODS_ndigisCHAN_BarrelCh2","Number of Digis Ch2",100,0.,1000.);
@@ -833,18 +699,10 @@ void SiPixelDigiSource::bookMEs(DQMStore::IBooker & iBooker){
   meNDigisCHANEndcapDp1_->setAxisTitle("Number of digis per FED channel per event",1);
   meNDigisCHANEndcapDp2_ = iBooker.book1D("ALLMODS_ndigisCHAN_EndcapDp2","Number of Digis Disk p2",100,0.,1000.);
   meNDigisCHANEndcapDp2_->setAxisTitle("Number of digis per FED channel per event",1);
-  if (isUpgrade) {
-    meNDigisCHANEndcapDp3_ = iBooker.book1D("ALLMODS_ndigisCHAN_EndcapDp3","Number of Digis Disk p3",100,0.,1000.);
-    meNDigisCHANEndcapDp3_->setAxisTitle("Number of digis per FED channel per event",1);
-  }
   meNDigisCHANEndcapDm1_ = iBooker.book1D("ALLMODS_ndigisCHAN_EndcapDm1","Number of Digis Disk m1",100,0.,1000.);
   meNDigisCHANEndcapDm1_->setAxisTitle("Number of digis per FED channel per event",1);
   meNDigisCHANEndcapDm2_ = iBooker.book1D("ALLMODS_ndigisCHAN_EndcapDm2","Number of Digis Disk m2",100,0.,1000.);
   meNDigisCHANEndcapDm2_->setAxisTitle("Number of digis per FED channel per event",1);
-  if (isUpgrade) {
-    meNDigisCHANEndcapDm3_ = iBooker.book1D("ALLMODS_ndigisCHAN_EndcapDm3","Number of Digis Disk m3",100,0.,1000.);
-    meNDigisCHANEndcapDm3_->setAxisTitle("Number of digis per FED channel per event",1);
-  }
   iBooker.cd("Pixel");
 }
 

--- a/DQM/SiPixelMonitorDigi/src/SiPixelDigiSourcePhase1.cc
+++ b/DQM/SiPixelMonitorDigi/src/SiPixelDigiSourcePhase1.cc
@@ -1,0 +1,699 @@
+// -*- C++ -*-
+//
+// Package:    SiPixelMonitorDigi
+// Class:      SiPixelDigiSourcePhase1
+// 
+/**\class 
+
+ Description: Pixel DQM source for Digis
+
+ Implementation:
+     <Notes on implementation>
+*/
+//
+// Original Author:  Vincenzo Chiochia
+//         Created:  
+//
+//
+#include "DQM/SiPixelMonitorDigi/interface/SiPixelDigiSourcePhase1.h"
+// Framework
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+// DQM Framework
+#include "DQM/SiPixelCommon/interface/SiPixelFolderOrganizer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+// Geometry
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
+#include "Geometry/CommonTopologies/interface/PixelTopology.h"
+// DataFormats
+#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+#include "DataFormats/SiPixelDetId/interface/PixelBarrelName.h"
+#include "DataFormats/SiPixelDetId/interface/PixelBarrelNameUpgrade.h"
+#include "DataFormats/SiPixelDetId/interface/PixelEndcapName.h"
+#include "DataFormats/SiPixelDetId/interface/PixelEndcapNameUpgrade.h"
+//
+#include <string>
+#include <stdlib.h>
+#include <iostream>
+#include <fstream>
+
+using namespace std;
+using namespace edm;
+
+SiPixelDigiSourcePhase1::SiPixelDigiSourcePhase1(const edm::ParameterSet& iConfig) :
+  conf_(iConfig),
+  src_( conf_.getParameter<edm::InputTag>( "src" ) ),
+  saveFile( conf_.getUntrackedParameter<bool>("saveFile",false) ),
+  isPIB( conf_.getUntrackedParameter<bool>("isPIB",false) ),
+  slowDown( conf_.getUntrackedParameter<bool>("slowDown",false) ),
+  modOn( conf_.getUntrackedParameter<bool>("modOn",true) ),
+  twoDimOn( conf_.getUntrackedParameter<bool>("twoDimOn",true) ),
+  twoDimModOn( conf_.getUntrackedParameter<bool>("twoDimModOn",true) ),
+  twoDimOnlyLayDisk( conf_.getUntrackedParameter<bool>("twoDimOnlyLayDisk",false) ),
+  hiRes( conf_.getUntrackedParameter<bool>("hiRes",false) ),
+  reducedSet( conf_.getUntrackedParameter<bool>("reducedSet",false) ),
+  ladOn( conf_.getUntrackedParameter<bool>("ladOn",false) ), 
+  layOn( conf_.getUntrackedParameter<bool>("layOn",false) ), 
+  phiOn( conf_.getUntrackedParameter<bool>("phiOn",false) ), 
+  ringOn( conf_.getUntrackedParameter<bool>("ringOn",false) ), 
+  bladeOn( conf_.getUntrackedParameter<bool>("bladeOn",false) ), 
+  diskOn( conf_.getUntrackedParameter<bool>("diskOn",false) ),
+  bigEventSize( conf_.getUntrackedParameter<int>("bigEventSize",1000) ) 
+{
+   //set Token(-s)
+   srcToken_ = consumes<edm::DetSetVector<PixelDigi> >(conf_.getParameter<edm::InputTag>( "src" ));
+
+   firstRun = true;  
+   // find a FED# for the current detId:
+   ifstream infile(edm::FileInPath("DQM/SiPixelMonitorClient/test/detId.dat").fullPath().c_str(),ios::in);
+   int nModsInFile=0;
+   assert(!infile.fail());
+   int nTOTmodules;
+   nTOTmodules=1856;
+   while(!infile.eof()&&nModsInFile<nTOTmodules) {
+     infile >> I_name[nModsInFile] >> I_detId[nModsInFile] >> I_fedId[nModsInFile] >> I_linkId1[nModsInFile] >> I_linkId2[nModsInFile];
+     nModsInFile++;
+   }
+   infile.close();
+   
+   LogInfo ("PixelDQM") << "SiPixelDigiSourcePhase1::SiPixelDigiSourcePhase1: Got DQM BackEnd interface"<<endl;
+}
+
+
+SiPixelDigiSourcePhase1::~SiPixelDigiSourcePhase1()
+{
+   // do anything here that needs to be done at desctruction time
+   // (e.g. close files, deallocate resources etc.)
+  LogInfo ("PixelDQM") << "SiPixelDigiSourcePhase1::~SiPixelDigiSourcePhase1: Destructor"<<endl;
+}
+
+
+void SiPixelDigiSourcePhase1::dqmBeginRun(const edm::Run& r, const edm::EventSetup& iSetup){
+  LogInfo ("PixelDQM") << " SiPixelDigiSourcePhase1::beginJob - Initialisation ... " << std::endl;
+  LogInfo ("PixelDQM") << "Mod/Lad/Lay/Phi " << modOn << "/" << ladOn << "/" 
+		       << layOn << "/" << phiOn << std::endl;
+  LogInfo ("PixelDQM") << "Blade/Disk/Ring" << bladeOn << "/" << diskOn << "/" 
+		       << ringOn << std::endl;
+  
+  LogInfo ("PixelDQM") << "2DIM IS " << twoDimOn << " and set to high resolution? " << hiRes << "\n";
+
+  if(firstRun){
+    eventNo = 0;
+    lumSec = 0;
+    nLumiSecs = 0;
+    nBigEvents = 0;
+    nBPIXDigis = 0; 
+    nFPIXDigis = 0;
+    for(int i=0; i!=40; i++) nDigisPerFed[i]=0;  
+    for(int i=0; i!=4; i++) nDigisPerDisk[i]=0;  
+    nDP1P1M1 = 0;
+    nDP1P1M2 = 0;
+    nDP1P1M3 = 0;
+    nDP1P1M4 = 0;
+    nDP1P2M1 = 0;
+    nDP1P2M2 = 0;
+    nDP1P2M3 = 0;
+    nDP2P1M1 = 0;
+    nDP2P1M2 = 0;
+    nDP2P1M3 = 0;
+    nDP2P1M4 = 0;
+    nDP2P2M1 = 0;
+    nDP2P2M2 = 0;
+    nDP2P2M3 = 0;
+    nDP3P1M1 = 0;
+    nDP3P2M1 = 0;
+    nDM1P1M1 = 0;
+    nDM1P1M2 = 0;
+    nDM1P1M3 = 0;
+    nDM1P1M4 = 0;
+    nDM1P2M1 = 0;
+    nDM1P2M2 = 0;
+    nDM1P2M3 = 0;
+    nDM2P1M1 = 0;
+    nDM2P1M2 = 0;
+    nDM2P1M3 = 0;
+    nDM2P1M4 = 0;
+    nDM2P2M1 = 0;
+    nDM2P2M2 = 0;
+    nDM2P2M3 = 0;
+    nDM3P1M1 = 0;
+    nDM3P2M1 = 0;
+    nL1M1 = 0;
+    nL1M2 = 0;
+    nL1M3 = 0;
+    nL1M4 = 0;
+    nL2M1 = 0;
+    nL2M2 = 0;
+    nL2M3 = 0;
+    nL2M4 = 0;
+    nL3M1 = 0;
+    nL3M2 = 0;
+    nL3M3 = 0;
+    nL3M4 = 0;
+    nL4M1 = 0;
+    nL4M2 = 0;
+    nL4M3 = 0;
+    nL4M4 = 0;
+    
+    // Build map
+    buildStructure(iSetup);
+    // Book Monitoring Elements
+    firstRun = false;
+  }
+}
+
+void SiPixelDigiSourcePhase1::bookHistograms(DQMStore::IBooker & iBooker, edm::Run const &, edm::EventSetup const &){
+  bookMEs(iBooker);
+}
+
+//------------------------------------------------------------------
+// Method called for every event
+//------------------------------------------------------------------
+void SiPixelDigiSourcePhase1::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+  eventNo++;
+
+  // get input data
+  edm::Handle< edm::DetSetVector<PixelDigi> >  input;
+  iEvent.getByToken(srcToken_, input);
+  if (!input.isValid()) return; 
+  
+
+  int bx = iEvent.bunchCrossing();
+
+  int lumiSection = (int)iEvent.luminosityBlock();
+  int nEventDigis = 0; int nActiveModules = 0;
+  
+  if(modOn){
+    if(averageDigiOccupancy && lumiSection%8==0){
+      averageDigiOccupancy->Reset();
+      nBPIXDigis = 0; 
+      nFPIXDigis = 0;
+      for(int i=0; i!=40; i++) nDigisPerFed[i]=0;  
+    }
+  }
+  if(!modOn){
+    if(averageDigiOccupancy && lumiSection%1==0){
+      averageDigiOccupancy->Reset();
+      nBPIXDigis = 0; 
+      nFPIXDigis = 0;
+      for(int i=0; i!=40; i++) nDigisPerFed[i]=0;  
+    }
+  }
+  
+  std::map<uint32_t,SiPixelDigiModulePhase1*>::iterator struct_iter;
+  for(int i=0; i!=192; i++) numberOfDigis[i]=0;
+  for(int i=0; i!=1152; i++) nDigisPerChan[i]=0;  
+  for(int i=0; i!=4; i++) nDigisPerDisk[i]=0;  
+  int NzeroROCs[2]        = {0,-672};
+  int NloEffROCs[2]       = {0,-672};
+  for (struct_iter = thePixelStructure.begin() ; struct_iter != thePixelStructure.end() ; struct_iter++) {
+    int numberOfDigisMod = (*struct_iter).second->fill(*input, 
+						       meNDigisCOMBBarrel_, meNDigisCHANBarrel_,meNDigisCHANBarrelL1_,meNDigisCHANBarrelL2_,meNDigisCHANBarrelL3_,meNDigisCHANBarrelL4_,meNDigisCOMBEndcap_,
+						       modOn, ladOn, layOn, phiOn, 
+						       bladeOn, diskOn, ringOn, 
+						       twoDimOn, reducedSet, twoDimModOn, twoDimOnlyLayDisk,
+						       nDigisA, nDigisB);
+    if (modOn && twoDimOnlyLayDisk && lumiSection%10 == 0) (*struct_iter).second->resetRocMap();
+
+    bool barrel = DetId((*struct_iter).first).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
+    bool endcap = DetId((*struct_iter).first).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap);
+    if(numberOfDigisMod>0){
+      nEventDigis = nEventDigis + numberOfDigisMod;  
+      nActiveModules++;  
+      int nBPiXmodules;
+      int nTOTmodules;
+      nBPiXmodules=1184;
+      nTOTmodules=1856;
+      
+      if(barrel){ // Barrel
+        nBPIXDigis = nBPIXDigis + numberOfDigisMod;
+        for(int i=0; i!=nBPiXmodules; ++i){
+          if((*struct_iter).first == I_detId[i]){
+	    nDigisPerFed[I_fedId[i]]=nDigisPerFed[I_fedId[i]]+numberOfDigisMod;
+	    int index1 = 0; int index2 = 0;
+	    if(I_linkId1[i]>0) index1 = I_fedId[i]*36+(I_linkId1[i]-1); 
+	    if(I_linkId2[i]>0) index2 = I_fedId[i]*36+(I_linkId2[i]-1);
+	    if(nDigisA>0 && I_linkId1[i]>0) nDigisPerChan[index1]=nDigisPerChan[index1]+nDigisA;
+	    if(nDigisB>0 && I_linkId2[i]>0) nDigisPerChan[index2]=nDigisPerChan[index2]+nDigisB;
+            i=(nBPiXmodules-1);
+	  }
+        }
+      }
+      else if (endcap) { // Endcap
+        nFPIXDigis = nFPIXDigis + numberOfDigisMod;
+        PixelEndcapNameUpgrade::HalfCylinder side = PixelEndcapNameUpgrade(DetId((*struct_iter).first)).halfCylinder();
+        int disk = PixelEndcapNameUpgrade(DetId((*struct_iter).first)).diskName();
+        int blade = PixelEndcapNameUpgrade(DetId((*struct_iter).first)).bladeName();
+        int panel = PixelEndcapNameUpgrade(DetId((*struct_iter).first)).pannelName();
+        int module = PixelEndcapNameUpgrade(DetId((*struct_iter).first)).plaquetteName();
+        
+        int iter=0; int i=0;
+        if(side==PixelEndcapNameUpgrade::mI){
+          if(disk==1){
+            i=0;
+            if(panel==1){ if(module==1) nDM1P1M1+=numberOfDigisMod; }
+            else if(panel==2){ if(module==1) nDM1P2M1+=numberOfDigisMod; }
+	    if(blade<12 && blade>0 && (panel==1 || panel==2)) iter = i+2*(blade-1)+(panel-1);
+          }else if(disk==2){
+            i=22;
+            if(panel==1){ if(module==1) nDM2P1M1+=numberOfDigisMod; }
+            else if(panel==2){ if(module==1) nDM2P2M1+=numberOfDigisMod; }
+	    if(blade<12 && blade>0 && (panel==1 || panel==2)) iter = i+2*(blade-1)+(panel-1);
+          }else if(disk==3){
+            i=44;
+            if(panel==1){ if(module==1) nDM3P1M1+=numberOfDigisMod; }
+            else if(panel==2){ if(module==1) nDM3P2M1+=numberOfDigisMod; }
+	    if(blade<12 && blade>0 && (panel==1 || panel==2)) iter = i+2*(blade-1)+(panel-1);
+          }
+        }else if(side==PixelEndcapNameUpgrade::mO){
+          if(disk==1){
+            i=66;
+            if(panel==1){ if(module==1) nDM1P1M1+=numberOfDigisMod; }
+            else if(panel==2){ if(module==1) nDM1P2M1+=numberOfDigisMod; }
+	    if(blade<18 && blade>0 && (panel==1 || panel==2)) iter = i+2*(blade-1)+(panel-1);
+          }else if(disk==2){
+           i=100;
+           if(panel==1){ if(module==1) nDM2P1M1+=numberOfDigisMod; }
+           else if(panel==2){ if(module==1) nDM2P2M1+=numberOfDigisMod; }
+	    if(blade<18 && blade>0 && (panel==1 || panel==2)) iter = i+2*(blade-1)+(panel-1);
+          }else if (disk==3){
+            i=134;
+            if(panel==1){ if(module==1) nDM3P1M1+=numberOfDigisMod; }
+            else if(panel==2){ if(module==1) nDM3P2M1+=numberOfDigisMod; }
+	    if(blade<18 && blade>0 && (panel==1 || panel==2)) iter = i+2*(blade-1)+(panel-1);
+          }
+        }else if(side==PixelEndcapNameUpgrade::pI){
+          if(disk==1){
+            i=168;
+            if(panel==1){ if(module==1) nDP1P1M1+=numberOfDigisMod; }
+            else if(panel==2){ if(module==1) nDP1P2M1+=numberOfDigisMod; }
+	    if(blade<12 && blade>0 && (panel==1 || panel==2)) iter = i+2*(blade-1)+(panel-1);
+          }else if(disk==2){
+            i=190;
+            if(panel==1){ if(module==1) nDP2P1M1+=numberOfDigisMod; }
+            else if(panel==2){ if(module==1) nDP2P2M1+=numberOfDigisMod; }
+	    if(blade<12 && blade>0 && (panel==1 || panel==2)) iter = i+2*(blade-1)+(panel-1);
+          }else if(disk==3){
+            i=212;
+            if(panel==1){ if(module==1) nDP3P1M1+=numberOfDigisMod; }
+            else if(panel==2){ if(module==1) nDP3P2M1+=numberOfDigisMod; }
+	    if(blade<12 && blade>0 && (panel==1 || panel==2)) iter = i+2*(blade-1)+(panel-1);
+          }
+        }else if(side==PixelEndcapNameUpgrade::pO){
+          if(disk==1){
+            i=234;
+            if(panel==1){ if(module==1) nDP1P1M1+=numberOfDigisMod; }
+            else if(panel==2){ if(module==1) nDP1P2M1+=numberOfDigisMod; }
+	    if(blade<18 && blade>0 && (panel==1 || panel==2)) iter = i+2*(blade-1)+(panel-1);
+          }else if(disk==2){
+            i=268;
+            if(panel==1){ if(module==1) nDP2P1M1+=numberOfDigisMod; }
+            else if(panel==2){ if(module==1) nDP2P2M1+=numberOfDigisMod; }
+	    if(blade<18 && blade>0 && (panel==1 || panel==2)) iter = i+2*(blade-1)+(panel-1);
+          }else if(disk==3){
+            i=302;
+            if(panel==1){ if(module==1) nDP3P1M1+=numberOfDigisMod; }
+            else if(panel==2){ if(module==1) nDP3P2M1+=numberOfDigisMod; }
+	    if(blade<18 && blade>0 && (panel==1 || panel==2)) iter = i+2*(blade-1)+(panel-1);
+          }
+        }
+        numberOfDigis[iter]=numberOfDigis[iter]+numberOfDigisMod;
+        for(int i=nBPiXmodules; i!=nTOTmodules; i++){
+          if((*struct_iter).first == I_detId[i]){
+	    nDigisPerFed[I_fedId[i]]=nDigisPerFed[I_fedId[i]]+numberOfDigisMod;
+            i=nTOTmodules-1;
+	  }
+        }
+      }//endif(Endcap)
+    } // endif any digis in this module
+    if (twoDimOnlyLayDisk && lumiSection%10 > 2){
+      std::pair<int,int> tempPair = (*struct_iter).second->getZeroLoEffROCs();
+      if (barrel){
+	NzeroROCs[0] += tempPair.first;
+	NloEffROCs[0] += tempPair.second;
+      }
+      else if (endcap){
+	NzeroROCs[1] += tempPair.first;  
+	NloEffROCs[1] += tempPair.second;
+      }
+    }
+  } // endfor loop over all modules
+
+  if (lumiSection%10> 2){
+    for (int i =0; i < 2; ++i) NloEffROCs[i] = NloEffROCs[i] - NzeroROCs[i];
+    if(noOccROCsBarrel) noOccROCsBarrel->setBinContent(1+lumiSection/10, NzeroROCs[0]);
+    if(loOccROCsBarrel) loOccROCsBarrel->setBinContent(1+lumiSection/10, NloEffROCs[0]);
+    if(noOccROCsEndcap) noOccROCsEndcap->setBinContent(1+lumiSection/10, NzeroROCs[1]);
+    if(loOccROCsEndcap) loOccROCsEndcap->setBinContent(1+lumiSection/10, NloEffROCs[1]);
+  }
+  
+  if(meNDigisCHANEndcap_){ for(int j=0; j!=336; j++) if(numberOfDigis[j]>0) meNDigisCHANEndcap_->Fill((float)numberOfDigis[j]);}
+  if(meNDigisCHANEndcapDm1_){ for(int j=0; j!=100; j++) if((j<22||j>65)&&numberOfDigis[j]>0) meNDigisCHANEndcapDm1_->Fill((float)numberOfDigis[j]);}
+  if(meNDigisCHANEndcapDm2_){ for(int j=22; j!=134; j++) if((j<44||j>99)&&numberOfDigis[j]>0) meNDigisCHANEndcapDm2_->Fill((float)numberOfDigis[j]);}
+  if(meNDigisCHANEndcapDm3_){ for(int j=44; j!=168; j++) if((j<66||j>133)&&numberOfDigis[j]>0) meNDigisCHANEndcapDm3_->Fill((float)numberOfDigis[j]);}
+  if(meNDigisCHANEndcapDp1_){ for(int j=168; j!=268; j++) if((j<190||j>233)&&numberOfDigis[j]>0) meNDigisCHANEndcapDp1_->Fill((float)numberOfDigis[j]);}
+  if(meNDigisCHANEndcapDp2_){ for(int j=190; j!=302; j++) if((j<212||j>267)&&numberOfDigis[j]>0) meNDigisCHANEndcapDp2_->Fill((float)numberOfDigis[j]);}
+  if(meNDigisCHANEndcapDp3_){ for(int j=212; j!=336; j++) if((j<234||j>301)&&numberOfDigis[j]>0) meNDigisCHANEndcapDp3_->Fill((float)numberOfDigis[j]);}
+  
+  if(meNDigisCHANBarrelCh1_){ for(int i=0; i!=32; i++) if(nDigisPerChan[i*36+0]>0) meNDigisCHANBarrelCh1_->Fill((float)nDigisPerChan[i*36+0]);}
+  if(meNDigisCHANBarrelCh2_){ for(int i=0; i!=32; i++) if(nDigisPerChan[i*36+1]>0) meNDigisCHANBarrelCh2_->Fill((float)nDigisPerChan[i*36+1]);}
+  if(meNDigisCHANBarrelCh3_){ for(int i=0; i!=32; i++) if(nDigisPerChan[i*36+2]>0) meNDigisCHANBarrelCh3_->Fill((float)nDigisPerChan[i*36+2]);}
+  if(meNDigisCHANBarrelCh4_){ for(int i=0; i!=32; i++) if(nDigisPerChan[i*36+3]>0) meNDigisCHANBarrelCh4_->Fill((float)nDigisPerChan[i*36+3]);}
+  if(meNDigisCHANBarrelCh5_){ for(int i=0; i!=32; i++) if(nDigisPerChan[i*36+4]>0) meNDigisCHANBarrelCh5_->Fill((float)nDigisPerChan[i*36+4]);}
+  if(meNDigisCHANBarrelCh6_){ for(int i=0; i!=32; i++) if(nDigisPerChan[i*36+5]>0) meNDigisCHANBarrelCh6_->Fill((float)nDigisPerChan[i*36+5]);}
+  if(meNDigisCHANBarrelCh7_){ for(int i=0; i!=32; i++) if(nDigisPerChan[i*36+6]>0) meNDigisCHANBarrelCh7_->Fill((float)nDigisPerChan[i*36+6]);}
+  if(meNDigisCHANBarrelCh8_){ for(int i=0; i!=32; i++) if(nDigisPerChan[i*36+7]>0) meNDigisCHANBarrelCh8_->Fill((float)nDigisPerChan[i*36+7]);}
+  if(meNDigisCHANBarrelCh9_){ for(int i=0; i!=32; i++) if(nDigisPerChan[i*36+8]>0) meNDigisCHANBarrelCh9_->Fill((float)nDigisPerChan[i*36+8]);}
+  if(meNDigisCHANBarrelCh10_){ for(int i=0; i!=32; i++) if(nDigisPerChan[i*36+9]>0) meNDigisCHANBarrelCh10_->Fill((float)nDigisPerChan[i*36+9]);}
+  if(meNDigisCHANBarrelCh11_){ for(int i=0; i!=32; i++) if(nDigisPerChan[i*36+10]>0) meNDigisCHANBarrelCh11_->Fill((float)nDigisPerChan[i*36+10]);}
+  if(meNDigisCHANBarrelCh12_){ for(int i=0; i!=32; i++) if(nDigisPerChan[i*36+11]>0) meNDigisCHANBarrelCh12_->Fill((float)nDigisPerChan[i*36+11]);}
+  if(meNDigisCHANBarrelCh13_){ for(int i=0; i!=32; i++) if(nDigisPerChan[i*36+12]>0) meNDigisCHANBarrelCh13_->Fill((float)nDigisPerChan[i*36+12]);}
+  if(meNDigisCHANBarrelCh14_){ for(int i=0; i!=32; i++) if(nDigisPerChan[i*36+13]>0) meNDigisCHANBarrelCh14_->Fill((float)nDigisPerChan[i*36+13]);}
+  if(meNDigisCHANBarrelCh15_){ for(int i=0; i!=32; i++) if(nDigisPerChan[i*36+14]>0) meNDigisCHANBarrelCh15_->Fill((float)nDigisPerChan[i*36+14]);}
+  if(meNDigisCHANBarrelCh16_){ for(int i=0; i!=32; i++) if(nDigisPerChan[i*36+15]>0) meNDigisCHANBarrelCh16_->Fill((float)nDigisPerChan[i*36+15]);}
+  if(meNDigisCHANBarrelCh17_){ for(int i=0; i!=32; i++) if(nDigisPerChan[i*36+16]>0) meNDigisCHANBarrelCh17_->Fill((float)nDigisPerChan[i*36+16]);}
+  if(meNDigisCHANBarrelCh18_){ for(int i=0; i!=32; i++) if(nDigisPerChan[i*36+17]>0) meNDigisCHANBarrelCh18_->Fill((float)nDigisPerChan[i*36+17]);}
+  if(meNDigisCHANBarrelCh19_){ for(int i=0; i!=32; i++) if(nDigisPerChan[i*36+18]>0) meNDigisCHANBarrelCh19_->Fill((float)nDigisPerChan[i*36+18]);}
+  if(meNDigisCHANBarrelCh20_){ for(int i=0; i!=32; i++) if(nDigisPerChan[i*36+19]>0) meNDigisCHANBarrelCh20_->Fill((float)nDigisPerChan[i*36+19]);}
+  if(meNDigisCHANBarrelCh21_){ for(int i=0; i!=32; i++) if(nDigisPerChan[i*36+20]>0) meNDigisCHANBarrelCh21_->Fill((float)nDigisPerChan[i*36+20]);}
+  if(meNDigisCHANBarrelCh22_){ for(int i=0; i!=32; i++) if(nDigisPerChan[i*36+21]>0) meNDigisCHANBarrelCh22_->Fill((float)nDigisPerChan[i*36+21]);}
+  if(meNDigisCHANBarrelCh23_){ for(int i=0; i!=32; i++) if(nDigisPerChan[i*36+22]>0) meNDigisCHANBarrelCh23_->Fill((float)nDigisPerChan[i*36+22]);}
+  if(meNDigisCHANBarrelCh24_){ for(int i=0; i!=32; i++) if(nDigisPerChan[i*36+23]>0) meNDigisCHANBarrelCh24_->Fill((float)nDigisPerChan[i*36+23]);}
+  if(meNDigisCHANBarrelCh25_){ for(int i=0; i!=32; i++) if(nDigisPerChan[i*36+24]>0) meNDigisCHANBarrelCh25_->Fill((float)nDigisPerChan[i*36+24]);}
+  if(meNDigisCHANBarrelCh26_){ for(int i=0; i!=32; i++) if(nDigisPerChan[i*36+25]>0) meNDigisCHANBarrelCh26_->Fill((float)nDigisPerChan[i*36+25]);}
+  if(meNDigisCHANBarrelCh27_){ for(int i=0; i!=32; i++) if(nDigisPerChan[i*36+26]>0) meNDigisCHANBarrelCh27_->Fill((float)nDigisPerChan[i*36+26]);}
+  if(meNDigisCHANBarrelCh28_){ for(int i=0; i!=32; i++) if(nDigisPerChan[i*36+27]>0) meNDigisCHANBarrelCh28_->Fill((float)nDigisPerChan[i*36+27]);}
+  if(meNDigisCHANBarrelCh29_){ for(int i=0; i!=32; i++) if(nDigisPerChan[i*36+28]>0) meNDigisCHANBarrelCh29_->Fill((float)nDigisPerChan[i*36+28]);}
+  if(meNDigisCHANBarrelCh30_){ for(int i=0; i!=32; i++) if(nDigisPerChan[i*36+29]>0) meNDigisCHANBarrelCh30_->Fill((float)nDigisPerChan[i*36+29]);}
+  if(meNDigisCHANBarrelCh31_){ for(int i=0; i!=32; i++) if(nDigisPerChan[i*36+30]>0) meNDigisCHANBarrelCh31_->Fill((float)nDigisPerChan[i*36+30]);}
+  if(meNDigisCHANBarrelCh32_){ for(int i=0; i!=32; i++) if(nDigisPerChan[i*36+31]>0) meNDigisCHANBarrelCh32_->Fill((float)nDigisPerChan[i*36+31]);}
+  if(meNDigisCHANBarrelCh33_){ for(int i=0; i!=32; i++) if(nDigisPerChan[i*36+32]>0) meNDigisCHANBarrelCh33_->Fill((float)nDigisPerChan[i*36+32]);}
+  if(meNDigisCHANBarrelCh34_){ for(int i=0; i!=32; i++) if(nDigisPerChan[i*36+33]>0) meNDigisCHANBarrelCh34_->Fill((float)nDigisPerChan[i*36+33]);}
+  if(meNDigisCHANBarrelCh35_){ for(int i=0; i!=32; i++) if(nDigisPerChan[i*36+34]>0) meNDigisCHANBarrelCh35_->Fill((float)nDigisPerChan[i*36+34]);}
+  if(meNDigisCHANBarrelCh36_){ for(int i=0; i!=32; i++) if(nDigisPerChan[i*36+35]>0) meNDigisCHANBarrelCh36_->Fill((float)nDigisPerChan[i*36+35]);}
+  
+  // Rate of events with >N digis:
+  if(nEventDigis>bigEventSize){
+    if(bigEventRate) bigEventRate->Fill(lumiSection,1./23.);    
+  }
+  
+  // Rate of pixel events and total number of pixel events per BX:
+  if(nActiveModules>=4){
+    if(pixEvtsPerBX) pixEvtsPerBX->Fill(float(bx));
+    if(pixEventRate) pixEventRate->Fill(lumiSection, 1./23.);
+  }
+  
+  // Actual digi occupancy in a FED compared to average digi occupancy per FED
+  if(averageDigiOccupancy){
+    int maxfed=0;
+    for(int i=0; i!=32; i++){
+      if(nDigisPerFed[i]>maxfed) maxfed=nDigisPerFed[i];
+    }
+    for(int i=0; i!=40; i++){
+      float averageOcc = 0.;
+      if(i<32){
+        float averageBPIXFed = float(nBPIXDigis-maxfed)/31.;
+	if(averageBPIXFed>0.) averageOcc = nDigisPerFed[i]/averageBPIXFed;
+      }else{
+        float averageFPIXFed = float(nFPIXDigis)/8.;
+	if(averageFPIXFed>0.) averageOcc = nDigisPerFed[i]/averageFPIXFed;
+      }
+      averageDigiOccupancy->setBinContent(i+1,averageOcc);
+      int lumiSections8 = int(lumiSection/8);
+      if (modOn){
+	if (avgfedDigiOccvsLumi){
+	  avgfedDigiOccvsLumi->setBinContent(1+lumiSections8, i+1, averageOcc);
+	}//endif meX5
+      }//endif modOn
+    }
+  }
+  
+  // slow down...
+  if(slowDown) usleep(10000);
+  
+}
+
+//------------------------------------------------------------------
+// Build data structure
+//------------------------------------------------------------------
+void SiPixelDigiSourcePhase1::buildStructure(const edm::EventSetup& iSetup){
+
+  LogInfo ("PixelDQM") <<" SiPixelDigiSourcePhase1::buildStructure" ;
+  edm::ESHandle<TrackerGeometry> pDD;
+  iSetup.get<TrackerDigiGeometryRecord>().get( pDD );
+
+  LogVerbatim ("PixelDQM") << " *** Geometry node for TrackerGeom is  "<<&(*pDD)<<std::endl;
+  LogVerbatim ("PixelDQM") << " *** I have " << pDD->dets().size() <<" detectors"<<std::endl;
+  LogVerbatim ("PixelDQM") << " *** I have " << pDD->detTypes().size() <<" types"<<std::endl;
+  
+  for(TrackerGeometry::DetContainer::const_iterator it = pDD->dets().begin(); it != pDD->dets().end(); it++){
+    
+    if(dynamic_cast<PixelGeomDetUnit const *>((*it))!=0){
+
+      DetId detId = (*it)->geographicalId();
+      const GeomDetUnit      * geoUnit = pDD->idToDetUnit( detId );
+      const PixelGeomDetUnit * pixDet  = dynamic_cast<const PixelGeomDetUnit*>(geoUnit);
+      int nrows = (pixDet->specificTopology()).nrows();
+      int ncols = (pixDet->specificTopology()).ncolumns();
+
+      if(detId.subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel)) {
+        if(isPIB) continue;
+	LogDebug ("PixelDQM") << " ---> Adding Barrel Module " <<  detId.rawId() << endl;
+	uint32_t id = detId();
+	SiPixelDigiModulePhase1* theModule = new SiPixelDigiModulePhase1(id, ncols, nrows);
+	thePixelStructure.insert(pair<uint32_t,SiPixelDigiModulePhase1*> (id,theModule));
+
+      }	else if( (detId.subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap)) ) {
+	LogDebug ("PixelDQM") << " ---> Adding Endcap Module " <<  detId.rawId() << endl;
+	uint32_t id = detId();
+	SiPixelDigiModulePhase1* theModule = new SiPixelDigiModulePhase1(id, ncols, nrows);
+        
+        PixelEndcapNameUpgrade::HalfCylinder side = PixelEndcapNameUpgrade(DetId(id)).halfCylinder();
+        int disk   = PixelEndcapNameUpgrade(DetId(id)).diskName();
+        int blade  = PixelEndcapNameUpgrade(DetId(id)).bladeName();
+        int panel  = PixelEndcapNameUpgrade(DetId(id)).pannelName();
+        int module = PixelEndcapNameUpgrade(DetId(id)).plaquetteName();
+
+        char sside[80];  sprintf(sside,  "HalfCylinder_%i",side);
+        char sdisk[80];  sprintf(sdisk,  "Disk_%i",disk);
+        char sblade[80]; sprintf(sblade, "Blade_%02i",blade);
+        char spanel[80]; sprintf(spanel, "Panel_%i",panel);
+        char smodule[80];sprintf(smodule,"Module_%i",module);
+        std::string side_str = sside;
+	std::string disk_str = sdisk;
+	bool mask = side_str.find("HalfCylinder_1")!=string::npos||
+	            side_str.find("HalfCylinder_2")!=string::npos||
+		    side_str.find("HalfCylinder_4")!=string::npos||
+		    disk_str.find("Disk_2")!=string::npos;
+	// clutch to take all of FPIX, but no BPIX:
+	mask = false;
+	if(isPIB && mask) continue;
+	
+	thePixelStructure.insert(pair<uint32_t,SiPixelDigiModulePhase1*> (id,theModule));
+      }
+
+    }
+  }
+  LogInfo ("PixelDQM") << " *** Pixel Structure Size " << thePixelStructure.size() << endl;
+}
+//------------------------------------------------------------------
+// Book MEs
+//------------------------------------------------------------------
+void SiPixelDigiSourcePhase1::bookMEs(DQMStore::IBooker & iBooker){
+  
+  // Get DQM interface
+  iBooker.setCurrentFolder("Pixel");
+  char title[80];   sprintf(title, "Rate of events with >%i digis;LumiSection;Rate [Hz]",bigEventSize);
+  bigEventRate    = iBooker.book1D("bigEventRate",title,5000,0.,5000.);
+  char title1[80];  sprintf(title1, "Pixel events vs. BX;BX;# events");
+  pixEvtsPerBX    = iBooker.book1D("pixEvtsPerBX",title1,3565,0.,3565.);
+  char title2[80];  sprintf(title2, "Rate of Pixel events;LumiSection;Rate [Hz]");
+  pixEventRate    = iBooker.book1D("pixEventRate",title2,5000,0.,5000.);
+  char title3[80];  sprintf(title3, "Number of Zero-Occupancy Barrel ROCs;LumiSection;N_{ZERO-OCCUPANCY} Barrel ROCs");
+  noOccROCsBarrel = iBooker.book1D("noOccROCsBarrel",title3,500,0.,5000.);
+  char title4[80];  sprintf(title4, "Number of Low-Efficiency Barrel ROCs;LumiSection;N_{LO EFF} Barrel ROCs");
+  loOccROCsBarrel = iBooker.book1D("loOccROCsBarrel",title4,500,0.,5000.);
+  char title5[80];  sprintf(title5, "Number of Zero-Occupancy Endcap ROCs;LumiSection;N_{ZERO-OCCUPANCY} Endcap ROCs");
+  noOccROCsEndcap = iBooker.book1D("noOccROCsEndcap",title5,500,0.,5000.);
+  char title6[80];  sprintf(title6, "Number of Low-Efficiency Endcap ROCs;LumiSection;N_{LO EFF} Endcap ROCs");
+  loOccROCsEndcap = iBooker.book1D("loOccROCsEndcap",title6,500,0.,5000.);
+  char title7[80];  sprintf(title7, "Average digi occupancy per FED;FED;NDigis/<NDigis>");
+  averageDigiOccupancy = iBooker.book1D("averageDigiOccupancy",title7,40,-0.5,39.5);
+  averageDigiOccupancy->setLumiFlag();
+  if(modOn){
+    char title4[80]; sprintf(title4, "FED Digi Occupancy (NDigis/<NDigis>) vs LumiSections;Lumi Section;FED");
+    avgfedDigiOccvsLumi = iBooker.book2D ("avgfedDigiOccvsLumi", title4, 400,0., 3200., 40, -0.5, 39.5);
+  }  
+  std::map<uint32_t,SiPixelDigiModulePhase1*>::iterator struct_iter;
+ 
+  SiPixelFolderOrganizer theSiPixelFolder(false);
+
+  for(struct_iter = thePixelStructure.begin(); struct_iter != thePixelStructure.end(); struct_iter++){
+    /// Create folder tree and book histograms 
+    if(modOn){
+      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,0)){
+	(*struct_iter).second->book( conf_,iBooker,0,twoDimOn,hiRes, reducedSet, twoDimModOn);
+      } else {
+
+	if(!isPIB) throw cms::Exception("LogicError")
+	  << "[SiPixelDigiSourcePhase1::bookMEs] Creation of DQM folder failed";
+      }
+    }
+    if(ladOn){
+      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,1)){
+	(*struct_iter).second->book( conf_,iBooker,1,twoDimOn,hiRes, reducedSet);
+	} else {
+	LogDebug ("PixelDQM") << "PROBLEM WITH LADDER-FOLDER\n";
+      }
+   
+    }
+    if(layOn || twoDimOnlyLayDisk){
+      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,2)){
+	(*struct_iter).second->book( conf_,iBooker,2,twoDimOn,hiRes, reducedSet, twoDimOnlyLayDisk);
+	} else {
+	LogDebug ("PixelDQM") << "PROBLEM WITH LAYER-FOLDER\n";
+      }
+    }
+
+    if(phiOn){
+      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,3)){
+	(*struct_iter).second->book( conf_,iBooker,3,twoDimOn,hiRes, reducedSet);
+	} else {
+        LogDebug ("PixelDQM") << "PROBLEM WITH PHI-FOLDER\n";
+      }
+    }
+    if(bladeOn){
+      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,4)){
+	(*struct_iter).second->book( conf_,iBooker,4,twoDimOn,hiRes, reducedSet);
+	} else {
+	LogDebug ("PixelDQM") << "PROBLEM WITH BLADE-FOLDER\n";
+      }
+    }
+    if(diskOn || twoDimOnlyLayDisk){
+      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,5)){
+	(*struct_iter).second->book( conf_,iBooker,5,twoDimOn,hiRes, reducedSet, twoDimOnlyLayDisk);
+      } else {
+	LogDebug ("PixelDQM") << "PROBLEM WITH DISK-FOLDER\n";
+      }
+    }
+    if(ringOn){
+      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,6)){
+	(*struct_iter).second->book( conf_,iBooker,6,twoDimOn,hiRes, reducedSet);
+      } else {
+	LogDebug ("PixelDQM") << "PROBLEM WITH RING-FOLDER\n";
+      }
+    }
+  }
+  iBooker.cd("Pixel/Barrel");
+  meNDigisCOMBBarrel_ = iBooker.book1D("ALLMODS_ndigisCOMB_Barrel","Number of Digis",200,0.,400.);
+  meNDigisCOMBBarrel_->setAxisTitle("Number of digis per module per event",1);
+  meNDigisCHANBarrel_ = iBooker.book1D("ALLMODS_ndigisCHAN_Barrel","Number of Digis",100,0.,1000.);
+  meNDigisCHANBarrel_->setAxisTitle("Number of digis per FED channel per event",1);
+  meNDigisCHANBarrelL1_ = iBooker.book1D("ALLMODS_ndigisCHAN_BarrelL1","Number of Digis L1",100,0.,1000.);
+  meNDigisCHANBarrelL1_->setAxisTitle("Number of digis per FED channel per event",1);
+  meNDigisCHANBarrelL2_ = iBooker.book1D("ALLMODS_ndigisCHAN_BarrelL2","Number of Digis L2",100,0.,1000.);
+  meNDigisCHANBarrelL2_->setAxisTitle("Number of digis per FED channel per event",1);
+  meNDigisCHANBarrelL3_ = iBooker.book1D("ALLMODS_ndigisCHAN_BarrelL3","Number of Digis L3",100,0.,1000.);
+  meNDigisCHANBarrelL3_->setAxisTitle("Number of digis per FED channel per event",1);
+  meNDigisCHANBarrelL4_ = iBooker.book1D("ALLMODS_ndigisCHAN_BarrelL4","Number of Digis L4",100,0.,1000.);
+  meNDigisCHANBarrelL4_->setAxisTitle("Number of digis per FED channel per event",1);
+
+  meNDigisCHANBarrelCh1_ = iBooker.book1D("ALLMODS_ndigisCHAN_BarrelCh1","Number of Digis Ch1",100,0.,1000.);
+  meNDigisCHANBarrelCh1_->setAxisTitle("Number of digis per FED channel per event",1);
+  meNDigisCHANBarrelCh2_ = iBooker.book1D("ALLMODS_ndigisCHAN_BarrelCh2","Number of Digis Ch2",100,0.,1000.);
+  meNDigisCHANBarrelCh2_->setAxisTitle("Number of digis per FED channel per event",1);
+  meNDigisCHANBarrelCh3_ = iBooker.book1D("ALLMODS_ndigisCHAN_BarrelCh3","Number of Digis Ch3",100,0.,1000.);
+  meNDigisCHANBarrelCh3_->setAxisTitle("Number of digis per FED channel per event",1);
+  meNDigisCHANBarrelCh4_ = iBooker.book1D("ALLMODS_ndigisCHAN_BarrelCh4","Number of Digis Ch4",100,0.,1000.);
+  meNDigisCHANBarrelCh4_->setAxisTitle("Number of digis per FED channel per event",1);
+  meNDigisCHANBarrelCh5_ = iBooker.book1D("ALLMODS_ndigisCHAN_BarrelCh5","Number of Digis Ch5",100,0.,1000.);
+  meNDigisCHANBarrelCh5_->setAxisTitle("Number of digis per FED channel per event",1);
+  meNDigisCHANBarrelCh6_ = iBooker.book1D("ALLMODS_ndigisCHAN_BarrelCh6","Number of Digis Ch6",100,0.,1000.);
+  meNDigisCHANBarrelCh6_->setAxisTitle("Number of digis per FED channel per event",1);
+  meNDigisCHANBarrelCh7_ = iBooker.book1D("ALLMODS_ndigisCHAN_BarrelCh7","Number of Digis Ch7",100,0.,1000.);
+  meNDigisCHANBarrelCh7_->setAxisTitle("Number of digis per FED channel per event",1);
+  meNDigisCHANBarrelCh8_ = iBooker.book1D("ALLMODS_ndigisCHAN_BarrelCh8","Number of Digis Ch8",100,0.,1000.);
+  meNDigisCHANBarrelCh8_->setAxisTitle("Number of digis per FED channel per event",1);
+  meNDigisCHANBarrelCh9_ = iBooker.book1D("ALLMODS_ndigisCHAN_BarrelCh9","Number of Digis Ch9",100,0.,1000.);
+  meNDigisCHANBarrelCh9_->setAxisTitle("Number of digis per FED channel per event",1);
+  meNDigisCHANBarrelCh10_ = iBooker.book1D("ALLMODS_ndigisCHAN_BarrelCh10","Number of Digis Ch10",100,0.,1000.);
+  meNDigisCHANBarrelCh10_->setAxisTitle("Number of digis per FED channel per event",1);
+  meNDigisCHANBarrelCh11_ = iBooker.book1D("ALLMODS_ndigisCHAN_BarrelCh11","Number of Digis Ch11",100,0.,1000.);
+  meNDigisCHANBarrelCh11_->setAxisTitle("Number of digis per FED channel per event",1);
+  meNDigisCHANBarrelCh12_ = iBooker.book1D("ALLMODS_ndigisCHAN_BarrelCh12","Number of Digis Ch12",100,0.,1000.);
+  meNDigisCHANBarrelCh12_->setAxisTitle("Number of digis per FED channel per event",1);
+  meNDigisCHANBarrelCh13_ = iBooker.book1D("ALLMODS_ndigisCHAN_BarrelCh13","Number of Digis Ch13",100,0.,1000.);
+  meNDigisCHANBarrelCh13_->setAxisTitle("Number of digis per FED channel per event",1);
+  meNDigisCHANBarrelCh14_ = iBooker.book1D("ALLMODS_ndigisCHAN_BarrelCh14","Number of Digis Ch14",100,0.,1000.);
+  meNDigisCHANBarrelCh14_->setAxisTitle("Number of digis per FED channel per event",1);
+  meNDigisCHANBarrelCh15_ = iBooker.book1D("ALLMODS_ndigisCHAN_BarrelCh15","Number of Digis Ch15",100,0.,1000.);
+  meNDigisCHANBarrelCh15_->setAxisTitle("Number of digis per FED channel per event",1);
+  meNDigisCHANBarrelCh16_ = iBooker.book1D("ALLMODS_ndigisCHAN_BarrelCh16","Number of Digis Ch16",100,0.,1000.);
+  meNDigisCHANBarrelCh16_->setAxisTitle("Number of digis per FED channel per event",1);
+  meNDigisCHANBarrelCh17_ = iBooker.book1D("ALLMODS_ndigisCHAN_BarrelCh17","Number of Digis Ch17",100,0.,1000.);
+  meNDigisCHANBarrelCh17_->setAxisTitle("Number of digis per FED channel per event",1);
+  meNDigisCHANBarrelCh18_ = iBooker.book1D("ALLMODS_ndigisCHAN_BarrelCh18","Number of Digis Ch18",100,0.,1000.);
+  meNDigisCHANBarrelCh18_->setAxisTitle("Number of digis per FED channel per event",1);
+  meNDigisCHANBarrelCh19_ = iBooker.book1D("ALLMODS_ndigisCHAN_BarrelCh19","Number of Digis Ch19",100,0.,1000.);
+  meNDigisCHANBarrelCh19_->setAxisTitle("Number of digis per FED channel per event",1);
+  meNDigisCHANBarrelCh20_ = iBooker.book1D("ALLMODS_ndigisCHAN_BarrelCh20","Number of Digis Ch20",100,0.,1000.);
+  meNDigisCHANBarrelCh20_->setAxisTitle("Number of digis per FED channel per event",1);
+  meNDigisCHANBarrelCh21_ = iBooker.book1D("ALLMODS_ndigisCHAN_BarrelCh21","Number of Digis Ch21",100,0.,1000.);
+  meNDigisCHANBarrelCh21_->setAxisTitle("Number of digis per FED channel per event",1);
+  meNDigisCHANBarrelCh22_ = iBooker.book1D("ALLMODS_ndigisCHAN_BarrelCh22","Number of Digis Ch22",100,0.,1000.);
+  meNDigisCHANBarrelCh22_->setAxisTitle("Number of digis per FED channel per event",1);
+  meNDigisCHANBarrelCh23_ = iBooker.book1D("ALLMODS_ndigisCHAN_BarrelCh23","Number of Digis Ch23",100,0.,1000.);
+  meNDigisCHANBarrelCh23_->setAxisTitle("Number of digis per FED channel per event",1);
+  meNDigisCHANBarrelCh24_ = iBooker.book1D("ALLMODS_ndigisCHAN_BarrelCh24","Number of Digis Ch24",100,0.,1000.);
+  meNDigisCHANBarrelCh24_->setAxisTitle("Number of digis per FED channel per event",1);
+  meNDigisCHANBarrelCh25_ = iBooker.book1D("ALLMODS_ndigisCHAN_BarrelCh25","Number of Digis Ch25",100,0.,1000.);
+  meNDigisCHANBarrelCh25_->setAxisTitle("Number of digis per FED channel per event",1);
+  meNDigisCHANBarrelCh26_ = iBooker.book1D("ALLMODS_ndigisCHAN_BarrelCh26","Number of Digis Ch26",100,0.,1000.);
+  meNDigisCHANBarrelCh26_->setAxisTitle("Number of digis per FED channel per event",1);
+  meNDigisCHANBarrelCh27_ = iBooker.book1D("ALLMODS_ndigisCHAN_BarrelCh27","Number of Digis Ch27",100,0.,1000.);
+  meNDigisCHANBarrelCh27_->setAxisTitle("Number of digis per FED channel per event",1);
+  meNDigisCHANBarrelCh28_ = iBooker.book1D("ALLMODS_ndigisCHAN_BarrelCh28","Number of Digis Ch28",100,0.,1000.);
+  meNDigisCHANBarrelCh28_->setAxisTitle("Number of digis per FED channel per event",1);
+  meNDigisCHANBarrelCh29_ = iBooker.book1D("ALLMODS_ndigisCHAN_BarrelCh29","Number of Digis Ch29",100,0.,1000.);
+  meNDigisCHANBarrelCh29_->setAxisTitle("Number of digis per FED channel per event",1);
+  meNDigisCHANBarrelCh30_ = iBooker.book1D("ALLMODS_ndigisCHAN_BarrelCh30","Number of Digis Ch30",100,0.,1000.);
+  meNDigisCHANBarrelCh30_->setAxisTitle("Number of digis per FED channel per event",1);
+  meNDigisCHANBarrelCh31_ = iBooker.book1D("ALLMODS_ndigisCHAN_BarrelCh31","Number of Digis Ch31",100,0.,1000.);
+  meNDigisCHANBarrelCh31_->setAxisTitle("Number of digis per FED channel per event",1);
+  meNDigisCHANBarrelCh32_ = iBooker.book1D("ALLMODS_ndigisCHAN_BarrelCh32","Number of Digis Ch32",100,0.,1000.);
+  meNDigisCHANBarrelCh32_->setAxisTitle("Number of digis per FED channel per event",1);
+  meNDigisCHANBarrelCh33_ = iBooker.book1D("ALLMODS_ndigisCHAN_BarrelCh33","Number of Digis Ch33",100,0.,1000.);
+  meNDigisCHANBarrelCh33_->setAxisTitle("Number of digis per FED channel per event",1);
+  meNDigisCHANBarrelCh34_ = iBooker.book1D("ALLMODS_ndigisCHAN_BarrelCh34","Number of Digis Ch34",100,0.,1000.);
+  meNDigisCHANBarrelCh34_->setAxisTitle("Number of digis per FED channel per event",1);
+  meNDigisCHANBarrelCh35_ = iBooker.book1D("ALLMODS_ndigisCHAN_BarrelCh35","Number of Digis Ch35",100,0.,1000.);
+  meNDigisCHANBarrelCh35_->setAxisTitle("Number of digis per FED channel per event",1);
+  meNDigisCHANBarrelCh36_ = iBooker.book1D("ALLMODS_ndigisCHAN_BarrelCh36","Number of Digis Ch36",100,0.,1000.);
+  meNDigisCHANBarrelCh36_->setAxisTitle("Number of digis per FED channel per event",1);
+  iBooker.cd("Pixel/Endcap");
+  meNDigisCOMBEndcap_ = iBooker.book1D("ALLMODS_ndigisCOMB_Endcap","Number of Digis",200,0.,400.);
+  meNDigisCOMBEndcap_->setAxisTitle("Number of digis per module per event",1);
+  meNDigisCHANEndcap_ = iBooker.book1D("ALLMODS_ndigisCHAN_Endcap","Number of Digis",100,0.,1000.);
+  meNDigisCHANEndcap_->setAxisTitle("Number of digis per FED channel per event",1);
+  meNDigisCHANEndcapDp1_ = iBooker.book1D("ALLMODS_ndigisCHAN_EndcapDp1","Number of Digis Disk p1",100,0.,1000.);
+  meNDigisCHANEndcapDp1_->setAxisTitle("Number of digis per FED channel per event",1);
+  meNDigisCHANEndcapDp2_ = iBooker.book1D("ALLMODS_ndigisCHAN_EndcapDp2","Number of Digis Disk p2",100,0.,1000.);
+  meNDigisCHANEndcapDp2_->setAxisTitle("Number of digis per FED channel per event",1);
+  meNDigisCHANEndcapDp3_ = iBooker.book1D("ALLMODS_ndigisCHAN_EndcapDp3","Number of Digis Disk p3",100,0.,1000.);
+  meNDigisCHANEndcapDp3_->setAxisTitle("Number of digis per FED channel per event",1);
+  meNDigisCHANEndcapDm1_ = iBooker.book1D("ALLMODS_ndigisCHAN_EndcapDm1","Number of Digis Disk m1",100,0.,1000.);
+  meNDigisCHANEndcapDm1_->setAxisTitle("Number of digis per FED channel per event",1);
+  meNDigisCHANEndcapDm2_ = iBooker.book1D("ALLMODS_ndigisCHAN_EndcapDm2","Number of Digis Disk m2",100,0.,1000.);
+  meNDigisCHANEndcapDm2_->setAxisTitle("Number of digis per FED channel per event",1);
+  meNDigisCHANEndcapDm3_ = iBooker.book1D("ALLMODS_ndigisCHAN_EndcapDm3","Number of Digis Disk m3",100,0.,1000.);
+  meNDigisCHANEndcapDm3_->setAxisTitle("Number of digis per FED channel per event",1);
+  iBooker.cd("Pixel");
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(SiPixelDigiSourcePhase1);

--- a/DQM/SiPixelMonitorRawData/interface/SiPixelRawDataErrorModule.h
+++ b/DQM/SiPixelMonitorRawData/interface/SiPixelRawDataErrorModule.h
@@ -41,7 +41,7 @@ class SiPixelRawDataErrorModule {
   typedef edm::DetSet<SiPixelRawDataError>::const_iterator    ErrorIterator;
 
   /// Book histograms
-  void book(const edm::ParameterSet& iConfig, DQMStore::IBooker &, int type=0, bool isUpgrade=false);
+  void book(const edm::ParameterSet& iConfig, DQMStore::IBooker &, int type=0);
   /// Fill histograms
   int fill(const edm::DetSetVector<SiPixelRawDataError> & input, std::map<std::string,MonitorElement**> * meMapFEDs, bool modon=true, bool ladon=false, bool bladeon=false);
   /// Fill FED histograms

--- a/DQM/SiPixelMonitorRawData/interface/SiPixelRawDataErrorModulePhase1.h
+++ b/DQM/SiPixelMonitorRawData/interface/SiPixelRawDataErrorModulePhase1.h
@@ -1,0 +1,80 @@
+#ifndef SiPixelMonitorRawData_SiPixelRawDataErrorModulePhase1_h
+#define SiPixelMonitorRawData_SiPixelRawDataErrorModulePhase1_h
+// -*- C++ -*-
+//
+// Package:    SiPixelMonitorRawData
+// Class:      SiPixelRawDataErrorModulePhase1
+// 
+/**\class 
+
+ Description: 
+ Error monitoring elements for a Pixel sensor.
+
+ Implementation:
+ Contains three functions to monitor error information.  "book" creates histograms in detector units and "fill" fills the monitoring elements with input error information.  
+     
+*/
+//
+// Original Author:  Andrew York
+//         Created:  
+//
+#include "DQMServices/Core/interface/MonitorElement.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DataFormats/SiPixelRawData/interface/SiPixelRawDataError.h"
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include <boost/cstdint.hpp>
+
+class SiPixelRawDataErrorModulePhase1 {        
+
+ public:
+
+  /// Default constructor
+  SiPixelRawDataErrorModulePhase1();
+  /// Constructor with raw DetId
+  SiPixelRawDataErrorModulePhase1(const uint32_t& id);
+  /// Constructor with raw DetId and sensor size
+  SiPixelRawDataErrorModulePhase1(const uint32_t& id, const int& ncols, const int& nrows);
+  /// Destructor
+  ~SiPixelRawDataErrorModulePhase1();
+
+  typedef edm::DetSet<SiPixelRawDataError>::const_iterator    ErrorIterator;
+
+  /// Book histograms
+  void book(const edm::ParameterSet& iConfig, DQMStore::IBooker &, int type=0);
+  /// Fill histograms
+  int fill(const edm::DetSetVector<SiPixelRawDataError> & input, std::map<std::string,MonitorElement**> * meMapFEDs, bool modon=true, bool ladon=false, bool bladeon=false);
+  /// Fill FED histograms
+  int fillFED(const edm::DetSetVector<SiPixelRawDataError> & input, std::map<std::string,MonitorElement**> *meMapFEDs);
+  
+ private:
+
+  uint32_t id_;
+  int ncols_;
+  int nrows_;
+  bool _debug_;
+
+  //barrel:
+  MonitorElement* meErrorTypeLad_;
+  MonitorElement* meNErrorsLad_;
+  MonitorElement* meFullTypeLad_;
+  MonitorElement* meTBMMessageLad_;
+  MonitorElement* meTBMTypeLad_;
+  MonitorElement* meEvtNbrLad_;
+  MonitorElement* meEvtSizeLad_;
+  
+  //forward:
+  MonitorElement* meErrorTypeBlade_;
+  MonitorElement* meNErrorsBlade_;
+  MonitorElement* meFullTypeBlade_;
+  MonitorElement* meTBMMessageBlade_;
+  MonitorElement* meTBMTypeBlade_;
+  MonitorElement* meEvtNbrBlade_;
+  MonitorElement* meEvtSizeBlade_;
+
+  static const int LINK_bits,  ROC_bits,  DCOL_bits,  PXID_bits,  ADC_bits, DataBit_bits, TRLRBGN_bits, EVTLGT_bits, TRLREND_bits;
+  static const int LINK_shift, ROC_shift, DCOL_shift, PXID_shift, ADC_shift, DB0_shift, DB1_shift, DB2_shift, DB3_shift, DB4_shift, DB5_shift, DB6_shift, DB7_shift, TRLRBGN_shift, EVTLGT_shift, TRLREND_shift;
+  static const uint32_t LINK_mask, ROC_mask, DCOL_mask, PXID_mask, ADC_mask, DataBit_mask;
+  static const long long TRLRBGN_mask, EVTLGT_mask, TRLREND_mask;
+};
+#endif

--- a/DQM/SiPixelMonitorRawData/interface/SiPixelRawDataErrorSource.h
+++ b/DQM/SiPixelMonitorRawData/interface/SiPixelRawDataErrorSource.h
@@ -75,7 +75,6 @@
        bool modOn;
        bool ladOn;
        bool bladeOn;
-       bool isUpgrade;
        int eventNo;
        std::map<uint32_t,SiPixelRawDataErrorModule*> thePixelStructure;
        std::map<uint32_t,SiPixelRawDataErrorModule*> theFEDStructure;

--- a/DQM/SiPixelMonitorRawData/interface/SiPixelRawDataErrorSourcePhase1.h
+++ b/DQM/SiPixelMonitorRawData/interface/SiPixelRawDataErrorSourcePhase1.h
@@ -1,0 +1,101 @@
+#ifndef SiPixelMonitorRawData_SiPixelRawDataErrorSourcePhase1_h
+#define SiPixelMonitorRawData_SiPixelRawDataErrorSourcePhase1_h
+// -*- C++ -*-
+//
+// Package:     SiPixelMonitorRawData
+// Class  :     SiPixelRawDataErrorSourcePhase1
+// 
+/**
+
+ Description: 
+ Produces histograms for error information generated at the raw2digi stage for the 
+ pixel tracker.
+
+ Usage: 
+ Takes a DetSetVector<SiPixelRawDataError> as input, and uses it to populate  a folder 
+ hierarchy (organized by detId) with histograms containing information about 
+ the errors.  Uses SiPixelRawDataErrorModulePhase1 class to book and fill individual folders.  
+ Note that this source is different than other DQM sources in the creation of an 
+ unphysical detId folder (detId=0xffffffff) to hold information about errors for which 
+ there is no detId available (except the dummy detId given to it at raw2digi).
+
+*/
+//
+// Original Author:  Andrew York
+//
+
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+
+#include "DQM/SiPixelMonitorRawData/interface/SiPixelRawDataErrorModulePhase1.h"
+
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "DataFormats/SiPixelRawData/interface/SiPixelRawDataError.h"
+
+
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include <boost/cstdint.hpp>
+
+ class SiPixelRawDataErrorSourcePhase1 : public DQMEDAnalyzer {
+    public:
+       explicit SiPixelRawDataErrorSourcePhase1(const edm::ParameterSet& conf);
+       ~SiPixelRawDataErrorSourcePhase1();
+
+       typedef edm::DetSet<SiPixelRawDataError>::const_iterator    ErrorIterator;
+       
+       virtual void analyze(const edm::Event&, const edm::EventSetup&);
+       virtual void dqmBeginRun(const edm::Run&, edm::EventSetup const&) ;
+       virtual void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
+
+
+       virtual void buildStructure(edm::EventSetup const&);
+       virtual void bookMEs(DQMStore::IBooker &);
+
+    private:
+       edm::ParameterSet conf_;
+       edm::EDGetTokenT<edm::DetSetVector<SiPixelRawDataError> > src_;
+       bool saveFile;
+       bool isPIB;
+       bool slowDown;
+       bool reducedSet;
+       bool modOn;
+       bool ladOn;
+       bool bladeOn;
+       int eventNo;
+       std::map<uint32_t,SiPixelRawDataErrorModulePhase1*> thePixelStructure;
+       std::map<uint32_t,SiPixelRawDataErrorModulePhase1*> theFEDStructure;
+       bool firstRun;
+       MonitorElement* byLumiErrors; 
+       MonitorElement* errorRate;
+
+       MonitorElement* meErrorType_[40];
+       MonitorElement* meNErrors_[40];
+       MonitorElement* meFullType_[40];
+       MonitorElement* meTBMMessage_[40];
+       MonitorElement* meTBMType_[40];
+       MonitorElement* meEvtNbr_[40];
+       MonitorElement* meEvtSize_[40];
+
+       MonitorElement* meFedChNErrArray_[1480];
+       MonitorElement* meFedChLErrArray_[1480];
+       MonitorElement* meFedETypeNErrArray_[840];
+
+       std::map<std::string,MonitorElement**> meMapFEDs_;
+       
+ };
+
+#endif

--- a/DQM/SiPixelMonitorRawData/python/SiPixelMonitorRawData_cfi.py
+++ b/DQM/SiPixelMonitorRawData/python/SiPixelMonitorRawData_cfi.py
@@ -12,4 +12,15 @@ SiPixelRawDataErrorSource = cms.EDAnalyzer("SiPixelRawDataErrorSource",
     bladeOn = cms.untracked.bool(False)
 )
 
+SiPixelRawDataErrorSourcePhase1 = cms.EDAnalyzer("SiPixelRawDataErrorSourcePhase1",
+    src = cms.InputTag("siPixelDigis"),
+    outputFile = cms.string('Pixel_DQM_Error.root'),
+    saveFile = cms.untracked.bool(False),
+    isPIB = cms.untracked.bool(False),
+    slowDown = cms.untracked.bool(False),
+    reducedSet = cms.untracked.bool(False),
+    modOn = cms.untracked.bool(True),
+    ladOn = cms.untracked.bool(False),
+    bladeOn = cms.untracked.bool(False)
+)
 

--- a/DQM/SiPixelMonitorRawData/src/SiPixelRawDataErrorModule.cc
+++ b/DQM/SiPixelMonitorRawData/src/SiPixelRawDataErrorModule.cc
@@ -93,7 +93,7 @@ SiPixelRawDataErrorModule::~SiPixelRawDataErrorModule() {}
 //
 // Book histograms for errors with detId
 //
-void SiPixelRawDataErrorModule::book(const edm::ParameterSet& iConfig, DQMStore::IBooker & iBooker, int type, bool isUpgrade) {}
+void SiPixelRawDataErrorModule::book(const edm::ParameterSet& iConfig, DQMStore::IBooker & iBooker, int type) {}
 //
 // Fill histograms
 //

--- a/DQM/SiPixelMonitorRawData/src/SiPixelRawDataErrorModulePhase1.cc
+++ b/DQM/SiPixelMonitorRawData/src/SiPixelRawDataErrorModulePhase1.cc
@@ -1,0 +1,634 @@
+#include "DQM/SiPixelMonitorRawData/interface/SiPixelRawDataErrorModulePhase1.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQM/SiPixelCommon/interface/SiPixelHistogramId.h"
+// Framework
+#include "FWCore/ServiceRegistry/interface/Service.h"
+// STL
+#include <vector>
+#include <memory>
+#include <string>
+#include <iostream>
+#include <stdlib.h>
+#include <sstream>
+ 
+// Data Formats
+#include "DataFormats/SiPixelDetId/interface/PixelBarrelName.h"
+#include "DataFormats/SiPixelDetId/interface/PixelBarrelNameUpgrade.h"
+#include "DataFormats/SiPixelDetId/interface/PixelEndcapName.h"
+#include "DataFormats/SiPixelDetId/interface/PixelEndcapNameUpgrade.h"
+#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+ 
+using namespace std;
+ 
+const int SiPixelRawDataErrorModulePhase1::LINK_bits = 6;
+const int SiPixelRawDataErrorModulePhase1::ROC_bits  = 5;
+const int SiPixelRawDataErrorModulePhase1::DCOL_bits = 5;
+const int SiPixelRawDataErrorModulePhase1::PXID_bits = 8;
+const int SiPixelRawDataErrorModulePhase1::ADC_bits  = 8;
+const int SiPixelRawDataErrorModulePhase1::DataBit_bits = 1;
+ 
+const int SiPixelRawDataErrorModulePhase1::ADC_shift  = 0;
+const int SiPixelRawDataErrorModulePhase1::PXID_shift = ADC_shift + ADC_bits;
+const int SiPixelRawDataErrorModulePhase1::DCOL_shift = PXID_shift + PXID_bits;
+const int SiPixelRawDataErrorModulePhase1::ROC_shift  = DCOL_shift + DCOL_bits;
+const int SiPixelRawDataErrorModulePhase1::LINK_shift = ROC_shift + ROC_bits;
+const int SiPixelRawDataErrorModulePhase1::DB0_shift = 0;
+const int SiPixelRawDataErrorModulePhase1::DB1_shift = DB0_shift + DataBit_bits;
+const int SiPixelRawDataErrorModulePhase1::DB2_shift = DB1_shift + DataBit_bits;
+const int SiPixelRawDataErrorModulePhase1::DB3_shift = DB2_shift + DataBit_bits;
+const int SiPixelRawDataErrorModulePhase1::DB4_shift = DB3_shift + DataBit_bits;
+const int SiPixelRawDataErrorModulePhase1::DB5_shift = DB4_shift + DataBit_bits;
+const int SiPixelRawDataErrorModulePhase1::DB6_shift = DB5_shift + DataBit_bits;
+const int SiPixelRawDataErrorModulePhase1::DB7_shift = DB6_shift + DataBit_bits;
+ 
+const uint32_t SiPixelRawDataErrorModulePhase1::LINK_mask = ~(~uint32_t(0) << LINK_bits);
+const uint32_t SiPixelRawDataErrorModulePhase1::ROC_mask  = ~(~uint32_t(0) << ROC_bits);
+const uint32_t SiPixelRawDataErrorModulePhase1::DCOL_mask = ~(~uint32_t(0) << DCOL_bits);
+const uint32_t SiPixelRawDataErrorModulePhase1::PXID_mask = ~(~uint32_t(0) << PXID_bits);
+const uint32_t SiPixelRawDataErrorModulePhase1::ADC_mask  = ~(~uint32_t(0) << ADC_bits);
+const uint32_t SiPixelRawDataErrorModulePhase1::DataBit_mask = ~(~uint32_t(0) << DataBit_bits);
+ 
+const int SiPixelRawDataErrorModulePhase1::TRLRBGN_bits = 32;
+const int SiPixelRawDataErrorModulePhase1::EVTLGT_bits  = 24;
+const int SiPixelRawDataErrorModulePhase1::TRLREND_bits = 8;
+ 
+const int SiPixelRawDataErrorModulePhase1::TRLRBGN_shift = 0;
+const int SiPixelRawDataErrorModulePhase1::EVTLGT_shift  = TRLRBGN_shift + TRLRBGN_bits;
+const int SiPixelRawDataErrorModulePhase1::TRLREND_shift = EVTLGT_shift + EVTLGT_bits;
+ 
+const long long SiPixelRawDataErrorModulePhase1::TRLREND_mask = ~(~(long long)(0) << TRLREND_bits);
+const long long SiPixelRawDataErrorModulePhase1::EVTLGT_mask  = ~(~(long long)(0) << EVTLGT_bits);
+const long long SiPixelRawDataErrorModulePhase1::TRLRBGN_mask = ~(~(long long)(0) << TRLRBGN_bits);
+//
+// Constructors
+//
+SiPixelRawDataErrorModulePhase1::SiPixelRawDataErrorModulePhase1() : 
+  id_(0),
+  ncols_(416),
+  nrows_(160) 
+{ 
+  _debug_ = false;
+}
+//
+SiPixelRawDataErrorModulePhase1::SiPixelRawDataErrorModulePhase1(const uint32_t& id) : 
+  id_(id),
+  ncols_(416),
+  nrows_(160)
+{ 
+  _debug_ = false;
+}
+//
+SiPixelRawDataErrorModulePhase1::SiPixelRawDataErrorModulePhase1(const uint32_t& id, const int& ncols, const int& nrows) : 
+  id_(id),
+  ncols_(ncols),
+  nrows_(nrows)
+{ 
+  _debug_ = false;
+} 
+//
+// Destructor
+//
+SiPixelRawDataErrorModulePhase1::~SiPixelRawDataErrorModulePhase1() {}
+//
+// Book histograms for errors with detId
+//
+void SiPixelRawDataErrorModulePhase1::book(const edm::ParameterSet& iConfig, DQMStore::IBooker & iBooker, int type) {}
+//
+// Fill histograms
+//
+int SiPixelRawDataErrorModulePhase1::fill(const edm::DetSetVector<SiPixelRawDataError>& input, std::map<std::string,MonitorElement**> *meMapFEDs, bool modon, bool ladon, bool bladeon) {
+  //std::cout<<"Entering SiPixelRawDataErrorModulePhase1::fill: "<<std::endl;
+  bool barrel = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
+  bool endcap = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap);
+   
+  // Get DQM interface
+   
+  unsigned int numberOfSeriousErrors = 0;
+   
+  edm::DetSetVector<SiPixelRawDataError>::const_iterator isearch = input.find(id_); // search  errors of detid
+   
+  if( isearch != input.end() ) {  // Not at empty iterator
+    // Look at errors now
+    edm::DetSet<SiPixelRawDataError>::const_iterator  di;
+    for(di = isearch->data.begin(); di != isearch->data.end(); di++) {
+      int FedId = di->getFedId();                  // FED the error came from
+      int chanNmbr = 0;
+      int errorType = di->getType();               // type of error
+      int TBMType=-1; int TBMMessage=-1; int evtSize=-1; int evtNbr=-1; int fullType=-1;
+      //bool notReset = true;
+      const int LINK_bits = 6;
+      const int LINK_shift = 26;
+      const uint32_t LINK_mask = ~(~(uint32_t)(0) << LINK_bits);
+ 
+      if(modon){
+	if(errorType == 32 || errorType == 33 || errorType == 34) {
+ 	  long long errorWord = di->getWord64();     // for 64-bit error words
+ 	  chanNmbr = (errorWord >> LINK_shift) & LINK_mask;
+ 	  if(errorType == 34) evtSize = (errorWord >> EVTLGT_shift) & EVTLGT_mask;
+	} else {
+ 	  uint32_t errorWord = di->getWord32();      // for 32-bit error words
+ 	  chanNmbr = (errorWord >> LINK_shift) & LINK_mask; // default way to get channel number.  Only different for case 29 below.
+ 	  switch(errorType) {  // fill in the appropriate monitorables based on the information stored in the error word
+ 	  case(28) : {
+ 	    int NFa = (errorWord >> DB0_shift) & DataBit_mask;
+ 	    int NFb = (errorWord >> DB1_shift) & DataBit_mask;
+ 	    int NFc = (errorWord >> DB2_shift) & DataBit_mask;
+ 	    int NFd = (errorWord >> DB3_shift) & DataBit_mask;
+ 	    int NFe = (errorWord >> DB4_shift) & DataBit_mask;
+ 	    int NF2 = (errorWord >> DB6_shift) & DataBit_mask;
+ 	    int L1A = (errorWord >> DB7_shift) & DataBit_mask;
+ 	    if (NFa==1) fullType = 1; ((*meMapFEDs)["meFullType_"][FedId])->Fill((int)fullType);
+ 	    if (NFb==1) fullType = 2; ((*meMapFEDs)["meFullType_"][FedId])->Fill((int)fullType);
+ 	    if (NFc==1) fullType = 3; ((*meMapFEDs)["meFullType_"][FedId])->Fill((int)fullType);
+ 	    if (NFd==1) fullType = 4; ((*meMapFEDs)["meFullType_"][FedId])->Fill((int)fullType);
+ 	    if (NFe==1) fullType = 5; ((*meMapFEDs)["meFullType_"][FedId])->Fill((int)fullType);
+ 	    if (NF2==1) fullType = 6; ((*meMapFEDs)["meFullType_"][FedId])->Fill((int)fullType);
+ 	    if (L1A==1) fullType = 7; ((*meMapFEDs)["meFullType_"][FedId])->Fill((int)fullType);
+ 	    chanNmbr = 0;  // signifies channel not known
+ 	    break; }
+ 	  case(29) : {
+ 	    int CH1 = (errorWord >> DB0_shift) & DataBit_mask;
+ 	    int CH2 = (errorWord >> DB1_shift) & DataBit_mask;
+ 	    int CH3 = (errorWord >> DB2_shift) & DataBit_mask;
+ 	    int CH4 = (errorWord >> DB3_shift) & DataBit_mask;
+ 	    int CH5 = (errorWord >> DB4_shift) & DataBit_mask;
+ 	    int BLOCK_bits      = 3;
+ 	    int BLOCK_shift     = 8;
+ 	    uint32_t BLOCK_mask = ~(~uint32_t(0) << BLOCK_bits);
+ 	    int BLOCK = (errorWord >> BLOCK_shift) & BLOCK_mask;
+ 	    int localCH = 1*CH1+2*CH2+3*CH3+4*CH4+5*CH5;
+ 	    if (BLOCK%2==0) chanNmbr=(BLOCK/2)*9+localCH;
+ 	    else chanNmbr = ((BLOCK-1)/2)*9+4+localCH;
+ 	    if ((chanNmbr<1)||(chanNmbr>36)) chanNmbr=0;  // signifies unexpected result
+ 	    break; }
+ 	  case(30) : {
+ 	    int T0 = (errorWord >> DB0_shift) & DataBit_mask;
+ 	    int T1 = (errorWord >> DB1_shift) & DataBit_mask;
+ 	    int T2 = (errorWord >> DB2_shift) & DataBit_mask;
+ 	    int T3 = (errorWord >> DB3_shift) & DataBit_mask;
+ 	    int T4 = (errorWord >> DB4_shift) & DataBit_mask;
+ 	    int T5 = (errorWord >> DB5_shift) & DataBit_mask;
+ 	    int T6 = (errorWord >> DB6_shift) & DataBit_mask;
+ 	    int T7 = (errorWord >> DB7_shift) & DataBit_mask;
+ 	    if (T0==1) TBMMessage=0;
+ 	    if (T1==1) TBMMessage=1;
+ 	    if (T2==1) TBMMessage=2;
+ 	    if (T3==1) TBMMessage=3;
+ 	    if (T4==1) TBMMessage=4;
+ 	    if (T5==1) TBMMessage=5;
+ 	    if (T6==1) TBMMessage=6;
+ 	    if (T7==1) TBMMessage=7;
+ 	    //if(TBMMessage==5 || TBMMessage==6) notReset=false;
+ 	    int StateMach_bits      = 4;
+ 	    int StateMach_shift     = 8;
+ 	    uint32_t StateMach_mask = ~(~uint32_t(0) << StateMach_bits);
+ 	    int StateMach = (errorWord >> StateMach_shift) & StateMach_mask;
+ 	    switch(StateMach) {
+ 	    case(0) : {
+ 	      TBMType = 0;
+ 	      break; }
+ 	    case(1) : case(9) : {
+		TBMType = 1;
+		break; }
+ 	    case(2) : case(4) : case(6) : {
+		TBMType = 2;
+		break; }
+ 	    case(8) : {
+ 	      TBMType = 3;
+ 	      break; }
+ 	    default : TBMType = 4;
+ 	    };
+ 	    break; }
+ 	  case(31) : {
+ 	    evtNbr = (errorWord >> ADC_shift) & ADC_mask;
+ 	    break; }
+ 	  case(36) : {
+ 	    //ROCId = (errorWord >> ROC_shift) & ROC_mask;
+ 	    break; }
+ 	  case(37) : {
+ 	    //DCOLId = (errorWord >> DCOL_shift) & DCOL_mask;
+ 	    //PXId = (errorWord >> PXID_shift) & PXID_mask;
+ 	    break; }
+ 	  case(38) : {
+ 	    //ROCNmbr = (errorWord >> ROC_shift) & ROC_mask;
+ 	    break; }
+ 	  default : break;
+ 	  };
+ 	}//end if not double precision  
+      }//end if modon
+ 
+      if(ladon && barrel){
+	if(errorType == 32 || errorType == 33 || errorType == 34){
+ 	  long long errorWord = di->getWord64();     // for 64-bit error words
+ 	  if(errorType == 34) evtSize = (errorWord >> EVTLGT_shift) & EVTLGT_mask;
+ 	  chanNmbr = (errorWord >> LINK_shift) & LINK_mask;
+	} else {
+ 	  uint32_t errorWord = di->getWord32();      // for 32-bit error words
+ 	  chanNmbr = (errorWord >> LINK_shift) & LINK_mask;
+ 	  switch(errorType) {  // fill in the appropriate monitorables based on the information stored in the error word
+ 	  case(28) : {
+ 	    int NFa = (errorWord >> DB0_shift) & DataBit_mask;
+ 	    int NFb = (errorWord >> DB1_shift) & DataBit_mask;
+ 	    int NFc = (errorWord >> DB2_shift) & DataBit_mask;
+ 	    int NFd = (errorWord >> DB3_shift) & DataBit_mask;
+ 	    int NFe = (errorWord >> DB4_shift) & DataBit_mask;
+ 	    int NF2 = (errorWord >> DB6_shift) & DataBit_mask;
+ 	    int L1A = (errorWord >> DB7_shift) & DataBit_mask;
+ 	    if (NFa==1) fullType = 1; ((*meMapFEDs)["meFullType_"][FedId])->Fill((int)fullType);
+ 	    if (NFb==1) fullType = 2; ((*meMapFEDs)["meFullType_"][FedId])->Fill((int)fullType);
+ 	    if (NFc==1) fullType = 3; ((*meMapFEDs)["meFullType_"][FedId])->Fill((int)fullType);
+ 	    if (NFd==1) fullType = 4; ((*meMapFEDs)["meFullType_"][FedId])->Fill((int)fullType);
+ 	    if (NFe==1) fullType = 5; ((*meMapFEDs)["meFullType_"][FedId])->Fill((int)fullType);
+ 	    if (NF2==1) fullType = 6; ((*meMapFEDs)["meFullType_"][FedId])->Fill((int)fullType);
+ 	    if (L1A==1) fullType = 7; ((*meMapFEDs)["meFullType_"][FedId])->Fill((int)fullType);
+ 	    chanNmbr = 0;
+ 	    break; }
+ 	  case(29) : {
+ 	    int CH1 = (errorWord >> DB0_shift) & DataBit_mask;
+ 	    int CH2 = (errorWord >> DB1_shift) & DataBit_mask;
+ 	    int CH3 = (errorWord >> DB2_shift) & DataBit_mask;
+ 	    int CH4 = (errorWord >> DB3_shift) & DataBit_mask;
+ 	    int CH5 = (errorWord >> DB4_shift) & DataBit_mask;
+ 	    int BLOCK_bits      = 3;
+ 	    int BLOCK_shift     = 8;
+ 	    uint32_t BLOCK_mask = ~(~uint32_t(0) << BLOCK_bits);
+ 	    int BLOCK = (errorWord >> BLOCK_shift) & BLOCK_mask;
+ 	    int localCH = 1*CH1+2*CH2+3*CH3+4*CH4+5*CH5;
+ 	    if (BLOCK%2==0) chanNmbr=(BLOCK/2)*9+localCH;
+ 	    else chanNmbr = ((BLOCK-1)/2)*9+4+localCH;
+ 	    if ((chanNmbr<1)||(chanNmbr>36)) chanNmbr=0;  // signifies unexpected result
+ 	    break; }
+ 	  case(30) : {
+ 	    int T0 = (errorWord >> DB0_shift) & DataBit_mask;
+ 	    int T1 = (errorWord >> DB1_shift) & DataBit_mask;
+ 	    int T2 = (errorWord >> DB2_shift) & DataBit_mask;
+ 	    int T3 = (errorWord >> DB3_shift) & DataBit_mask;
+ 	    int T4 = (errorWord >> DB4_shift) & DataBit_mask;
+ 	    int T5 = (errorWord >> DB5_shift) & DataBit_mask;
+ 	    int T6 = (errorWord >> DB6_shift) & DataBit_mask;
+ 	    int T7 = (errorWord >> DB7_shift) & DataBit_mask;
+ 	    if (T0==1) TBMMessage=0;
+ 	    if (T1==1) TBMMessage=1;
+ 	    if (T2==1) TBMMessage=2;
+ 	    if (T3==1) TBMMessage=3;
+ 	    if (T4==1) TBMMessage=4;
+ 	    if (T5==1) TBMMessage=5;
+ 	    if (T6==1) TBMMessage=6;
+ 	    if (T7==1) TBMMessage=7;
+ 	    int StateMach_bits      = 4;
+ 	    int StateMach_shift     = 8;
+ 	    uint32_t StateMach_mask = ~(~uint32_t(0) << StateMach_bits);
+ 	    int StateMach = (errorWord >> StateMach_shift) & StateMach_mask;
+ 	    switch(StateMach) {
+ 	    case(0) : {
+ 	      TBMType = 0;
+ 	      break; }
+ 	    case(1) : case(9) : {
+		TBMType = 1;
+		break; }
+ 	    case(2) : case(4) : case(6) : {
+		TBMType = 2;
+		break; }
+ 	    case(8) : {
+ 	      TBMType = 3;
+ 	      break; }
+ 	    default : TBMType = 4;
+ 	    };
+ 	    break; }
+ 	  case(31) : {
+ 	    evtNbr = (errorWord >> ADC_shift) & ADC_mask;
+ 	    break; }
+ 	  case(36) : {
+ 	    //int ROCId = (errorWord >> ROC_shift) & ROC_mask;
+ 	    break; }
+ 	  case(37) : {
+ 	    //int DCOLId = (errorWord >> DCOL_shift) & DCOL_mask;
+ 	    //int PXId = (errorWord >> PXID_shift) & PXID_mask;
+ 	    break; }
+ 	  case(38) : {
+ 	    //int ROCNmbr = (errorWord >> ROC_shift) & ROC_mask;
+ 	    break; }
+ 	  default : break;
+ 	  };
+ 	}
+      }//end if ladderon
+ 
+      if(bladeon && endcap){
+	if(errorType == 32 || errorType == 33 || errorType == 34){
+ 	  long long errorWord = di->getWord64();     // for 64-bit error words
+ 	  if(errorType == 34) evtSize = (errorWord >> EVTLGT_shift) & EVTLGT_mask;
+ 	  chanNmbr = (errorWord >> LINK_shift) & LINK_mask;
+	} else {
+ 	  uint32_t errorWord = di->getWord32();      // for 32-bit error words
+ 	  chanNmbr = (errorWord >> LINK_shift) & LINK_mask;
+ 	  switch(errorType) {  // fill in the appropriate monitorables based on the information stored in the error word
+ 	  case(28) : {
+ 	    int NFa = (errorWord >> DB0_shift) & DataBit_mask;
+ 	    int NFb = (errorWord >> DB1_shift) & DataBit_mask;
+ 	    int NFc = (errorWord >> DB2_shift) & DataBit_mask;
+ 	    int NFd = (errorWord >> DB3_shift) & DataBit_mask;
+ 	    int NFe = (errorWord >> DB4_shift) & DataBit_mask;
+ 	    int NF2 = (errorWord >> DB6_shift) & DataBit_mask;
+ 	    int L1A = (errorWord >> DB7_shift) & DataBit_mask;
+ 	    if (NFa==1) fullType = 1; ((*meMapFEDs)["meFullType_"][FedId])->Fill((int)fullType);
+ 	    if (NFb==1) fullType = 2; ((*meMapFEDs)["meFullType_"][FedId])->Fill((int)fullType);
+ 	    if (NFc==1) fullType = 3; ((*meMapFEDs)["meFullType_"][FedId])->Fill((int)fullType);
+ 	    if (NFd==1) fullType = 4; ((*meMapFEDs)["meFullType_"][FedId])->Fill((int)fullType);
+ 	    if (NFe==1) fullType = 5; ((*meMapFEDs)["meFullType_"][FedId])->Fill((int)fullType);
+ 	    if (NF2==1) fullType = 6; ((*meMapFEDs)["meFullType_"][FedId])->Fill((int)fullType);
+ 	    if (L1A==1) fullType = 7; ((*meMapFEDs)["meFullType_"][FedId])->Fill((int)fullType);
+ 	    chanNmbr = 0;
+ 	    break; }
+ 	  case(29) : {
+ 	    int CH1 = (errorWord >> DB0_shift) & DataBit_mask;
+ 	    int CH2 = (errorWord >> DB1_shift) & DataBit_mask;
+ 	    int CH3 = (errorWord >> DB2_shift) & DataBit_mask;
+ 	    int CH4 = (errorWord >> DB3_shift) & DataBit_mask;
+ 	    int CH5 = (errorWord >> DB4_shift) & DataBit_mask;
+ 	    int BLOCK_bits      = 3;
+ 	    int BLOCK_shift     = 8;
+ 	    uint32_t BLOCK_mask = ~(~uint32_t(0) << BLOCK_bits);
+ 	    int BLOCK = (errorWord >> BLOCK_shift) & BLOCK_mask;
+ 	    int localCH = 1*CH1+2*CH2+3*CH3+4*CH4+5*CH5;
+ 	    if (BLOCK%2==0) chanNmbr=(BLOCK/2)*9+localCH;
+ 	    else chanNmbr = ((BLOCK-1)/2)*9+4+localCH;
+ 	    if ((chanNmbr<1)||(chanNmbr>36)) chanNmbr=0;  // signifies unexpected result
+ 	    break; }
+ 	  case(30) : {
+ 	    int T0 = (errorWord >> DB0_shift) & DataBit_mask;
+ 	    int T1 = (errorWord >> DB1_shift) & DataBit_mask;
+ 	    int T2 = (errorWord >> DB2_shift) & DataBit_mask;
+ 	    int T3 = (errorWord >> DB3_shift) & DataBit_mask;
+ 	    int T4 = (errorWord >> DB4_shift) & DataBit_mask;
+ 	    int T5 = (errorWord >> DB5_shift) & DataBit_mask;
+ 	    int T6 = (errorWord >> DB6_shift) & DataBit_mask;
+ 	    int T7 = (errorWord >> DB7_shift) & DataBit_mask;
+ 	    if (T0==1) TBMMessage=0;
+ 	    if (T1==1) TBMMessage=1;
+ 	    if (T2==1) TBMMessage=2;
+ 	    if (T3==1) TBMMessage=3;
+ 	    if (T4==1) TBMMessage=4;
+ 	    if (T5==1) TBMMessage=5;
+ 	    if (T6==1) TBMMessage=6;
+ 	    if (T7==1) TBMMessage=7;
+ 	    int StateMach_bits      = 4;
+ 	    int StateMach_shift     = 8;
+ 	    uint32_t StateMach_mask = ~(~uint32_t(0) << StateMach_bits);
+ 	    int StateMach = (errorWord >> StateMach_shift) & StateMach_mask;
+ 	    switch(StateMach) {
+ 	    case(0) : {
+ 	      TBMType = 0;
+ 	      break; }
+ 	    case(1) : case(9) : {
+		TBMType = 1;
+		break; }
+ 	    case(2) : case(4) : case(6) : {
+		TBMType = 2;
+		break; }
+ 	    case(8) : {
+ 	      TBMType = 3;
+ 	      break; }
+ 	    default : TBMType = 4;
+ 	    };
+ 	    break; }
+ 	  case(31) : {
+ 	    evtNbr = (errorWord >> ADC_shift) & ADC_mask;
+ 	    break; }
+ 	  case(36) : {
+ 	    //int ROCId = (errorWord >> ROC_shift) & ROC_mask;
+ 	    break; }
+ 	  case(37) : {
+ 	    //int DCOLId = (errorWord >> DCOL_shift) & DCOL_mask;
+ 	    //int PXId = (errorWord >> PXID_shift) & PXID_mask;
+ 	    break; }
+ 	  case(38) : {
+ 	    //int ROCNmbr = (errorWord >> ROC_shift) & ROC_mask;
+ 	    break; }
+ 	  default : break;
+ 	  };
+ 	}
+      }//end if bladeon
+       
+      if(!(FedId==38&&chanNmbr==7)){ // mask slow channel that spits out lots of EventNumber errors even when in STDBY!
+ 	if(errorType==29 || (errorType==30 && TBMType==1)){ // consider only TIMEOUT and OVERFLOW as serious errors right now
+	  //if(!(errorType==30) || notReset){
+	  //cout<<"ERROR: "<<errorType<<" "<<TBMType<<endl;
+	  std::string hid;
+	  static const char chNfmt[] = "Pixel/AdditionalPixelErrors/FED_%d/FedChNErrArray_%d";
+	  char chNbuf[sizeof(chNfmt) + 2*32]; // 32 digits is enough for up to 2^105 + sign.
+	  sprintf(chNbuf, chNfmt, FedId, chanNmbr);
+	  hid = chNbuf;
+	  if((*meMapFEDs)["meFedChNErrArray_"][FedId*37 + chanNmbr]) (*meMapFEDs)["meFedChNErrArray_"][FedId*37 + chanNmbr]->Fill((*meMapFEDs)["meFedChNErrArray_"][FedId*37 + chanNmbr]->getIntValue()+1);
+ 
+	  static const char chLfmt[] = "Pixel/AdditionalPixelErrors/FED_%d/FedChLErrArray_%d";
+	  char chLbuf[sizeof(chLfmt) + 2*32]; // 32 digits is enough for up to 2^105 + sign.
+	  sprintf(chLbuf, chLfmt, FedId, chanNmbr);
+	  hid = chLbuf;
+	  if((*meMapFEDs)["meFedChLErrArray_"][FedId*37 + chanNmbr]) (*meMapFEDs)["meFedChLErrArray_"][FedId*37 + chanNmbr]->Fill(errorType); 
+ 
+	  numberOfSeriousErrors++;
+	  int messageType = 99;
+	  if(errorType<30) messageType = errorType-25;
+	  else if(errorType>30) messageType = errorType-19;
+	  else if(errorType==30 && TBMMessage==0) messageType = errorType-25;
+	  else if(errorType==30 && TBMMessage==1) messageType = errorType-24;
+	  else if(errorType==30 && (TBMMessage==2 || TBMMessage==3 || TBMMessage==4)) messageType = errorType-23;
+	  else if(errorType==30 && TBMMessage==7) messageType = errorType-22;
+	  else if(errorType==30 && TBMType==1) messageType = errorType-21;
+	  else if(errorType==30 && TBMType==2) messageType = errorType-20;
+	  else if(errorType==30 && TBMType==3) messageType = errorType-19;
+	  if(messageType<=20){
+	    static const char fmt[] = "Pixel/AdditionalPixelErrors/FED_%d/FedETypeNErrArray_%d";
+	    char buf[sizeof(fmt) + 2*32]; // 32 digits is enough for up to 2^105 + sign.
+	    sprintf(buf, fmt, FedId, messageType);
+	    hid = buf;
+	    if((*meMapFEDs)["meFedETypeNErrArray_"][FedId*21+messageType]) (*meMapFEDs)["meFedETypeNErrArray_"][FedId*21+messageType]->Fill((*meMapFEDs)["meFedETypeNErrArray_"][FedId*21+messageType]->getIntValue()+1); 
+	  }
+ 	}
+ 
+ 	(*meMapFEDs)["meNErrors_"][FedId]->Fill((int)numberOfSeriousErrors);
+ 	(*meMapFEDs)["meTBMMessage_"][FedId]->Fill((int)TBMMessage);
+ 	(*meMapFEDs)["meTBMType_"][FedId]->Fill((int)TBMType);
+	(*meMapFEDs)["meErrorType_"][FedId]->Fill((int)errorType);
+	(*meMapFEDs)["meFullType_"][FedId]->Fill((int)fullType);
+	(*meMapFEDs)["meEvtNbr_"][FedId]->Fill((int)evtNbr);
+	(*meMapFEDs)["meEvtSize_"][FedId]->Fill((int)evtSize);
+      }
+    }//end for loop over all errors on module
+  }//end if not an empty iterator
+  return numberOfSeriousErrors;
+}
+ 
+int SiPixelRawDataErrorModulePhase1::fillFED(const edm::DetSetVector<SiPixelRawDataError>& input, std::map<std::string,MonitorElement**> *meMapFEDs) {
+  //std::cout<<"Entering   SiPixelRawDataErrorModulePhase1::fillFED: "<<static_cast<int>(id_)<<std::endl;
+  unsigned int numberOfSeriousErrors = 0;
+   
+  edm::DetSetVector<SiPixelRawDataError>::const_iterator isearch = input.find(0xffffffff); // search  errors of detid
+  if( isearch != input.end() ) {  // Not an empty iterator
+    // Look at FED errors now	
+    edm::DetSet<SiPixelRawDataError>::const_iterator  di;
+    for(di = isearch->data.begin(); di != isearch->data.end(); di++) {
+      int FedId = di->getFedId();                  // FED the error came from
+      int chanNmbr = -1;
+      int errorType = 0;               // type of error
+      if(FedId==static_cast<int>(id_)) {
+ 	errorType = di->getType();               // type of error
+ 	((*meMapFEDs)["meErrorType_"][id_])->Fill((int)errorType);
+ 	//bool notReset=true;
+	int TBMType=-1; int TBMMessage=-1; int evtSize=-1; int fullType=-1;
+	const int LINK_bits = 6;
+	const int LINK_shift = 26;
+	const uint32_t LINK_mask = ~(~(uint32_t)(0) << LINK_bits);
+ 	if((errorType == 32)||(errorType == 33)||(errorType == 34)) {
+ 	  long long errorWord = di->getWord64();     // for 64-bit error words
+ 	  chanNmbr = 0;
+ 	  switch(errorType) {  // fill in the appropriate monitorables based on the information stored in the error word
+ 	  case(32) : {
+ 	    break; }
+ 	  case(33) : {
+ 	    break; }
+ 	  case(34) : {
+ 	    evtSize = (errorWord >> EVTLGT_shift) & EVTLGT_mask;
+ 	    if(!(FedId==38&&chanNmbr==7)) ((*meMapFEDs)["meEvtSize_"][id_])->Fill((int)evtSize); 
+ 	    break; }
+ 	  default : break;
+ 	  };
+ 	} else {
+ 	  uint32_t errorWord = di->getWord32();      // for 32-bit error words
+ 	  switch(errorType) {  // fill in the appropriate monitorables based on the information stored in the error word
+ 	  case(25) : case(39) : {
+	      chanNmbr = 0;
+	      break; }
+ 	  case(28) : {
+ 	    int NFa = (errorWord >> DB0_shift) & DataBit_mask;
+ 	    int NFb = (errorWord >> DB1_shift) & DataBit_mask;
+ 	    int NFc = (errorWord >> DB2_shift) & DataBit_mask;
+ 	    int NFd = (errorWord >> DB3_shift) & DataBit_mask;
+ 	    int NFe = (errorWord >> DB4_shift) & DataBit_mask;
+ 	    int NF2 = (errorWord >> DB6_shift) & DataBit_mask;
+ 	    int L1A = (errorWord >> DB7_shift) & DataBit_mask;
+ 	    if (NFa==1) fullType = 1; ((*meMapFEDs)["meFullType_"][id_])->Fill((int)fullType);
+ 	    if (NFb==1) fullType = 2; ((*meMapFEDs)["meFullType_"][id_])->Fill((int)fullType);
+ 	    if (NFc==1) fullType = 3; ((*meMapFEDs)["meFullType_"][id_])->Fill((int)fullType);
+ 	    if (NFd==1) fullType = 4; ((*meMapFEDs)["meFullType_"][id_])->Fill((int)fullType);
+ 	    if (NFe==1) fullType = 5; ((*meMapFEDs)["meFullType_"][id_])->Fill((int)fullType);
+ 	    if (NF2==1) fullType = 6; ((*meMapFEDs)["meFullType_"][id_])->Fill((int)fullType);
+ 	    if (L1A==1) fullType = 7; ((*meMapFEDs)["meFullType_"][id_])->Fill((int)fullType);
+ 	    chanNmbr = 0;
+ 	    break; }
+ 	  case(29) : {
+ 	    int CH1 = (errorWord >> DB0_shift) & DataBit_mask;
+ 	    int CH2 = (errorWord >> DB1_shift) & DataBit_mask;
+ 	    int CH3 = (errorWord >> DB2_shift) & DataBit_mask;
+ 	    int CH4 = (errorWord >> DB3_shift) & DataBit_mask;
+ 	    int CH5 = (errorWord >> DB4_shift) & DataBit_mask;
+ 	    int BLOCK_bits      = 3;
+ 	    int BLOCK_shift     = 8;
+ 	    uint32_t BLOCK_mask = ~(~uint32_t(0) << BLOCK_bits);
+ 	    int BLOCK = (errorWord >> BLOCK_shift) & BLOCK_mask;
+ 	    int localCH = 1*CH1+2*CH2+3*CH3+4*CH4+5*CH5;
+ 	    if (BLOCK%2==0) chanNmbr=(BLOCK/2)*9+localCH;
+ 	    else chanNmbr = ((BLOCK-1)/2)*9+4+localCH;
+ 	    if ((chanNmbr<1)||(chanNmbr>36)) chanNmbr=0;  // signifies unexpected result
+ 	    break; }
+ 	  case(30) : {
+ 	    int T0 = (errorWord >> DB0_shift) & DataBit_mask;
+ 	    int T1 = (errorWord >> DB1_shift) & DataBit_mask;
+ 	    int T2 = (errorWord >> DB2_shift) & DataBit_mask;
+ 	    int T3 = (errorWord >> DB3_shift) & DataBit_mask;
+ 	    int T4 = (errorWord >> DB4_shift) & DataBit_mask;
+ 	    int T5 = (errorWord >> DB5_shift) & DataBit_mask;
+ 	    int T6 = (errorWord >> DB6_shift) & DataBit_mask;
+ 	    int T7 = (errorWord >> DB7_shift) & DataBit_mask;
+ 	    if(!(FedId==38&&chanNmbr==7)){
+ 	      if (T0==1) { TBMMessage=0; ((*meMapFEDs)["meTBMMessage_"][id_])->Fill((int)TBMMessage); }
+ 	      if (T1==1) { TBMMessage=1; ((*meMapFEDs)["meTBMMessage_"][id_])->Fill((int)TBMMessage); }
+ 	      if (T2==1) { TBMMessage=2; ((*meMapFEDs)["meTBMMessage_"][id_])->Fill((int)TBMMessage); }
+ 	      if (T3==1) { TBMMessage=3; ((*meMapFEDs)["meTBMMessage_"][id_])->Fill((int)TBMMessage); }
+ 	      if (T4==1) { TBMMessage=4; ((*meMapFEDs)["meTBMMessage_"][id_])->Fill((int)TBMMessage); }
+ 	      if (T5==1) { TBMMessage=5; ((*meMapFEDs)["meTBMMessage_"][id_])->Fill((int)TBMMessage); }
+ 	      if (T6==1) { TBMMessage=6; ((*meMapFEDs)["meTBMMessage_"][id_])->Fill((int)TBMMessage); }
+ 	      if (T7==1) { TBMMessage=7; ((*meMapFEDs)["meTBMMessage_"][id_])->Fill((int)TBMMessage); }
+ 	    }
+ 	    //if(TBMMessage==5 || TBMMessage==6) notReset=false;
+ 	    int StateMach_bits      = 4;
+ 	    int StateMach_shift     = 8;
+ 	    uint32_t StateMach_mask = ~(~uint32_t(0) << StateMach_bits);
+ 	    int StateMach = (errorWord >> StateMach_shift) & StateMach_mask;
+ 	    switch(StateMach) {
+ 	    case(0) : {
+ 	      TBMType = 0;
+ 	      break; }
+ 	    case(1) : case(9) : {
+		TBMType = 1;
+		break; }
+ 	    case(2) : case(4) : case(6) : {
+		TBMType = 2;
+		break; }
+ 	    case(8) : {
+ 	      TBMType = 3;
+ 	      break; }
+ 	    default : TBMType = 4;
+ 	    };
+ 	    if(!(FedId==38&&chanNmbr==7)) ((*meMapFEDs)["meTBMType_"][id_])->Fill((int)TBMType);
+ 	    chanNmbr = (errorWord >> LINK_shift) & LINK_mask;
+ 	    break; }
+ 	  case(31) : {
+ 	    int evtNbr = (errorWord >> ADC_shift) & ADC_mask;
+ 	    if(!(FedId==38&&chanNmbr==7))((*meMapFEDs)["meEvtNbr_"][id_])->Fill((int)evtNbr);
+ 	    chanNmbr = (errorWord >> LINK_shift) & LINK_mask;
+ 	    break; }
+ 	  case(35) : case(36) : case(37) : case(38) : {
+	      chanNmbr = (errorWord >> LINK_shift) & LINK_mask;
+	      break; }
+ 	  default : break;
+ 	  };
+ 	}// end if errorType
+ 
+ 	//if(!(errorType==30) || notReset){
+ 	if(errorType==29 || (errorType==30 && TBMType==1)){ // consider only TIMEOUT and OVERFLOW as serious errors right now
+	  if(!(FedId==38&&chanNmbr==7)){ // mask slow channel that spits out lots of EventNumber errors even when in STDBY!
+	    std::string hid;
+	    //cout<<"FEDERROR: "<<errorType<<" "<<TBMType<<endl;
+	    static const char chNfmt[] = "Pixel/AdditionalPixelErrors/FED_%d/FedChNErrArray_%d";
+	    char chNbuf[sizeof(chNfmt) + 2*32]; // 32 digits is enough for up to 2^105 + sign.
+	    sprintf(chNbuf, chNfmt, FedId, chanNmbr);
+	    hid = chNbuf;
+	    if((*meMapFEDs)["meFedChNErrArray_"][id_*37 + chanNmbr]) (*meMapFEDs)["meFedChNErrArray_"][id_*37 + chanNmbr]->Fill((*meMapFEDs)["meFedChNErrArray_"][id_*37 + chanNmbr]->getIntValue()+1);
+ 
+	    static const char chLfmt[] = "Pixel/AdditionalPixelErrors/FED_%d/FedChLErrArray_%d";
+	    char chLbuf[sizeof(chLfmt) + 2*32]; // 32 digits is enough for up to 2^105 + sign.
+	    sprintf(chLbuf, chLfmt, FedId, chanNmbr);
+	    hid = chLbuf;
+	    if((*meMapFEDs)["meFedChLErrArray_"][id_*37 + chanNmbr]) (*meMapFEDs)["meFedChLErrArray_"][id_*37 + chanNmbr]->Fill(errorType); 
+ 
+	    numberOfSeriousErrors++;
+	    int messageType = 99;
+	    if(errorType<30) messageType = errorType-25;
+	    else if(errorType>30) messageType = errorType-19;
+	    else if(errorType==30 && TBMMessage==0) messageType = errorType-25;
+	    else if(errorType==30 && TBMMessage==1) messageType = errorType-24;
+	    else if(errorType==30 && (TBMMessage==2 || TBMMessage==3 || TBMMessage==4)) messageType = errorType-23;
+	    else if(errorType==30 && TBMMessage==7) messageType = errorType-22;
+	    else if(errorType==30 && TBMType==1) messageType = errorType-21;
+	    else if(errorType==30 && TBMType==2) messageType = errorType-20;
+	    else if(errorType==30 && TBMType==3) messageType = errorType-19;
+	    if(messageType<=20){
+	      static const char fmt[] = "Pixel/AdditionalPixelErrors/FED_%d/FedETypeNErrArray_%d";
+	      char buf[sizeof(fmt) + 2*32]; // 32 digits is enough for up to 2^105 + sign.
+	      sprintf(buf, fmt, FedId, messageType);
+	      hid = buf;
+	      if((*meMapFEDs)["meFedETypeNErrArray_"][id_*21 + messageType]) (*meMapFEDs)["meFedETypeNErrArray_"][id_+21 + messageType]->Fill((*meMapFEDs)["meFedETypeNErrArray_"][id_* 21 + messageType]->getIntValue()+1);
+	    }
+ 	  }//end if bad channel
+	}//end if not 30 || notReset
+      }//end if
+    }//end for
+    if(numberOfSeriousErrors>0) ((*meMapFEDs)["meNErrors_"][id_])->Fill((float)numberOfSeriousErrors);
+ 
+  }// end if not an empty iterator
+   
+  //std::cout<<"...leaving   SiPixelRawDataErrorModulePhase1::fillFED. "<<std::endl;
+  return numberOfSeriousErrors;
+}

--- a/DQM/SiPixelMonitorRawData/src/SiPixelRawDataErrorSource.cc
+++ b/DQM/SiPixelMonitorRawData/src/SiPixelRawDataErrorSource.cc
@@ -59,8 +59,7 @@ SiPixelRawDataErrorSource::SiPixelRawDataErrorSource(const edm::ParameterSet& iC
   reducedSet( conf_.getUntrackedParameter<bool>("reducedSet",false) ),
   modOn( conf_.getUntrackedParameter<bool>("modOn",true) ),
   ladOn( conf_.getUntrackedParameter<bool>("ladOn",false) ), 
-  bladeOn( conf_.getUntrackedParameter<bool>("bladeOn",false) ),
-  isUpgrade( conf_.getUntrackedParameter<bool>("isUpgrade",false) )
+  bladeOn( conf_.getUntrackedParameter<bool>("bladeOn",false) )
 {
   firstRun = true;
   LogInfo ("PixelDQM") << "SiPixelRawDataErrorSource::SiPixelRawDataErrorSource: Got DQM BackEnd interface"<<endl;
@@ -176,7 +175,7 @@ void SiPixelRawDataErrorSource::buildStructure(const edm::EventSetup& iSetup){
 	SiPixelRawDataErrorModule* theModule = new SiPixelRawDataErrorModule(id, ncols, nrows);
 	thePixelStructure.insert(pair<uint32_t,SiPixelRawDataErrorModule*> (id,theModule));
 
-      }	else if( (detId.subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap)) && (!isUpgrade)) {
+      }	else if( (detId.subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap)) ) {
 	LogDebug ("PixelDQM") << " ---> Adding Endcap Module " <<  detId.rawId() << endl;
 	uint32_t id = detId();
 	SiPixelRawDataErrorModule* theModule = new SiPixelRawDataErrorModule(id, ncols, nrows);
@@ -203,34 +202,7 @@ void SiPixelRawDataErrorSource::buildStructure(const edm::EventSetup& iSetup){
 	if(isPIB && mask) continue;
 		
 	thePixelStructure.insert(pair<uint32_t,SiPixelRawDataErrorModule*> (id,theModule));
-      }	else if( (detId.subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap)) && (isUpgrade)) {
-	LogDebug ("PixelDQM") << " ---> Adding Endcap Module " <<  detId.rawId() << endl;
-	uint32_t id = detId();
-	SiPixelRawDataErrorModule* theModule = new SiPixelRawDataErrorModule(id, ncols, nrows);
-	
-        PixelEndcapNameUpgrade::HalfCylinder side = PixelEndcapNameUpgrade(DetId(id)).halfCylinder();
-        int disk   = PixelEndcapNameUpgrade(DetId(id)).diskName();
-        int blade  = PixelEndcapNameUpgrade(DetId(id)).bladeName();
-        int panel  = PixelEndcapNameUpgrade(DetId(id)).pannelName();
-        int module = PixelEndcapNameUpgrade(DetId(id)).plaquetteName();
-
-        char sside[80];  sprintf(sside,  "HalfCylinder_%i",side);
-        char sdisk[80];  sprintf(sdisk,  "Disk_%i",disk);
-        char sblade[80]; sprintf(sblade, "Blade_%02i",blade);
-        char spanel[80]; sprintf(spanel, "Panel_%i",panel);
-        char smodule[80];sprintf(smodule,"Module_%i",module);
-        std::string side_str = sside;
-	std::string disk_str = sdisk;
-	bool mask = side_str.find("HalfCylinder_1")!=string::npos||
-	            side_str.find("HalfCylinder_2")!=string::npos||
-		    side_str.find("HalfCylinder_4")!=string::npos||
-		    disk_str.find("Disk_2")!=string::npos;
-	// clutch to take all of FPIX, but no BPIX:
-	mask = false;
-	if(isPIB && mask) continue;
-		
-	thePixelStructure.insert(pair<uint32_t,SiPixelRawDataErrorModule*> (id,theModule));
-      }//endif(isUpgrade)
+      }
     }
   }
   LogDebug ("PixelDQM") << " ---> Adding Module for Additional Errors " << endl;
@@ -267,7 +239,7 @@ void SiPixelRawDataErrorSource::bookMEs(DQMStore::IBooker & iBooker){
     /// Create folder tree and book histograms 
 
     if(modOn){
-      if(!theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,0,isUpgrade)) {
+      if(!theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,0)) {
         //std::cout<<"PIB! not booking histograms for non-PIB modules!"<<std::endl;
         if(!isPIB) throw cms::Exception("LogicError")
                        << "[SiPixelRawDataErrorSource::bookMEs] Creation of DQM folder failed";
@@ -275,13 +247,13 @@ void SiPixelRawDataErrorSource::bookMEs(DQMStore::IBooker & iBooker){
     }
     
     if(ladOn){
-      if(!theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,1,isUpgrade)) {
+      if(!theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,1)) {
         LogDebug ("PixelDQM") << "PROBLEM WITH LADDER-FOLDER\n";
       }
     }
     
     if(bladeOn){
-      if(!theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,4,isUpgrade)) {
+      if(!theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,4)) {
         LogDebug ("PixelDQM") << "PROBLEM WITH BLADE-FOLDER\n";
       }
     }

--- a/DQM/SiPixelMonitorRawData/src/SiPixelRawDataErrorSourcePhase1.cc
+++ b/DQM/SiPixelMonitorRawData/src/SiPixelRawDataErrorSourcePhase1.cc
@@ -1,0 +1,340 @@
+// -*- C++ -*-
+//
+// Package:    SiPixelMonitorRawData
+// Class:      SiPixelRawDataErrorSourcePhase1
+// 
+/**\class 
+
+ Description: 
+ Produces histograms for error information generated at the raw2digi stage for the 
+ pixel tracker.
+
+ Implementation:
+ Takes a DetSetVector<SiPixelRawDataError> as input, and uses it to populate  a folder 
+ hierarchy (organized by detId) with histograms containing information about 
+ the errors.  Uses SiPixelRawDataErrorModulePhase1 class to book and fill individual folders.  
+ Note that this source is different than other DQM sources in the creation of an 
+ unphysical detId folder (detId=0xffffffff) to hold information about errors for which 
+ there is no detId available (except the dummy detId given to it at raw2digi).
+
+*/
+//
+// Original Author:  Andrew York
+//
+#include "DQM/SiPixelMonitorRawData/interface/SiPixelRawDataErrorSourcePhase1.h"
+// Framework
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+// DQM Framework
+#include "DQM/SiPixelCommon/interface/SiPixelFolderOrganizer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQM/SiPixelCommon/interface/SiPixelHistogramId.h"
+
+// Geometry
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
+#include "Geometry/CommonTopologies/interface/PixelTopology.h"
+// DataFormats
+#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+#include "DataFormats/FEDRawData/interface/FEDNumbering.h"
+#include "DataFormats/SiPixelDetId/interface/PixelBarrelName.h"
+#include "DataFormats/SiPixelDetId/interface/PixelBarrelNameUpgrade.h"
+#include "DataFormats/SiPixelDetId/interface/PixelEndcapName.h"
+#include "DataFormats/SiPixelDetId/interface/PixelEndcapNameUpgrade.h"
+//
+#include <string>
+#include <stdlib.h>
+
+using namespace std;
+using namespace edm;
+
+SiPixelRawDataErrorSourcePhase1::SiPixelRawDataErrorSourcePhase1(const edm::ParameterSet& iConfig) :
+  conf_(iConfig),
+  src_( consumes<DetSetVector<SiPixelRawDataError> >( conf_.getParameter<edm::InputTag>( "src" ) ) ),
+  saveFile( conf_.getUntrackedParameter<bool>("saveFile",false) ),
+  isPIB( conf_.getUntrackedParameter<bool>("isPIB",false) ),
+  slowDown( conf_.getUntrackedParameter<bool>("slowDown",false) ),
+  reducedSet( conf_.getUntrackedParameter<bool>("reducedSet",false) ),
+  modOn( conf_.getUntrackedParameter<bool>("modOn",true) ),
+  ladOn( conf_.getUntrackedParameter<bool>("ladOn",false) ), 
+  bladeOn( conf_.getUntrackedParameter<bool>("bladeOn",false) )
+{
+  firstRun = true;
+  LogInfo ("PixelDQM") << "SiPixelRawDataErrorSourcePhase1::SiPixelRawDataErrorSourcePhase1: Got DQM BackEnd interface"<<endl;
+}
+
+
+SiPixelRawDataErrorSourcePhase1::~SiPixelRawDataErrorSourcePhase1()
+{
+   // do anything here that needs to be done at desctruction time
+   // (e.g. close files, deallocate resources etc.)
+  LogInfo ("PixelDQM") << "SiPixelRawDataErrorSourcePhase1::~SiPixelRawDataErrorSourcePhase1: Destructor"<<endl;
+}
+
+void SiPixelRawDataErrorSourcePhase1::dqmBeginRun(const edm::Run& r, const edm::EventSetup& iSetup){
+
+  LogInfo ("PixelDQM") << " SiPixelRawDataErrorSourcePhase1::beginRun - Initialisation ... " << std::endl;
+  LogInfo ("PixelDQM") << "Mod/Lad/Blade " << modOn << "/" << ladOn << "/" << bladeOn << std::endl;
+
+  if(firstRun){
+    eventNo = 0;
+    
+    firstRun = false;
+  }
+
+  // Build map
+  buildStructure(iSetup);
+}
+
+void SiPixelRawDataErrorSourcePhase1::bookHistograms(DQMStore::IBooker & iBooker, edm::Run const &, edm::EventSetup const & iSetup){
+  // Book Monitoring Elements
+  bookMEs(iBooker);
+}
+
+//------------------------------------------------------------------
+// Method called for every event
+//------------------------------------------------------------------
+void SiPixelRawDataErrorSourcePhase1::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+  eventNo++;
+
+  // get input data
+  edm::Handle< DetSetVector<SiPixelRawDataError> >  input;
+  iEvent.getByToken( src_, input );
+  if (!input.isValid()) return; 
+
+  int lumiSection = (int)iEvent.luminosityBlock();
+  
+  int nEventBPIXModuleErrors = 0; int nEventFPIXModuleErrors = 0; int nEventBPIXFEDErrors = 0; int nEventFPIXFEDErrors = 0;
+  int nErrors = 0;
+
+  std::map<uint32_t,SiPixelRawDataErrorModulePhase1*>::iterator struct_iter;
+  std::map<uint32_t,SiPixelRawDataErrorModulePhase1*>::iterator struct_iter2;
+  for (struct_iter = thePixelStructure.begin() ; struct_iter != thePixelStructure.end() ; struct_iter++) {
+    
+    int numberOfModuleErrors = (*struct_iter).second->fill(*input, &meMapFEDs_, modOn, ladOn, bladeOn);
+    if(DetId( (*struct_iter).first ).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel)) nEventBPIXModuleErrors = nEventBPIXModuleErrors + numberOfModuleErrors;
+    if(DetId( (*struct_iter).first ).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap)) nEventFPIXModuleErrors = nEventFPIXModuleErrors + numberOfModuleErrors;
+    //cout<<"NErrors: "<<nEventBPIXModuleErrors<<" "<<nEventFPIXModuleErrors<<endl;
+    nErrors = nErrors + numberOfModuleErrors;
+    //if(nErrors>0) cout<<"MODULES: nErrors: "<<nErrors<<endl;
+  }
+  for (struct_iter2 = theFEDStructure.begin() ; struct_iter2 != theFEDStructure.end() ; struct_iter2++) {
+    
+    int numberOfFEDErrors = (*struct_iter2).second->fillFED(*input, &meMapFEDs_);
+    if((*struct_iter2).first <= 31) nEventBPIXFEDErrors = nEventBPIXFEDErrors + numberOfFEDErrors; // (*struct_iter2).first >= 0, since (*struct_iter2).first is unsigned
+    if((*struct_iter2).first >= 32 && (*struct_iter2).first <= 39) nEventFPIXFEDErrors = nEventFPIXFEDErrors + numberOfFEDErrors;    
+    //cout<<"NFEDErrors: "<<nEventBPIXFEDErrors<<" "<<nEventFPIXFEDErrors<<endl;
+    nErrors = nErrors + numberOfFEDErrors;
+    //if(nErrors>0) cout<<"FEDS: nErrors: "<<nErrors<<endl;
+  }
+  if(byLumiErrors){
+    byLumiErrors->setBinContent(0,eventNo);
+    //cout<<"NErrors: "<<nEventBPIXModuleErrors<<" "<<nEventFPIXModuleErrors<<" "<<nEventBPIXFEDErrors<<" "<<nEventFPIXFEDErrors<<endl;
+    if(nEventBPIXModuleErrors+nEventBPIXFEDErrors>0) byLumiErrors->Fill(0,1.);
+    if(nEventFPIXModuleErrors+nEventFPIXFEDErrors>0) byLumiErrors->Fill(1,1.);
+    //cout<<"histo: "<<byLumiErrors->getBinContent(0)<<" "<<byLumiErrors->getBinContent(1)<<" "<<byLumiErrors->getBinContent(2)<<endl;
+  }  
+  
+  // Rate of errors per lumi section:
+  if(errorRate) errorRate->Fill(lumiSection, nErrors);
+
+  // slow down...
+  if(slowDown) usleep(100000);
+  
+}
+
+//------------------------------------------------------------------
+// Build data structure
+//------------------------------------------------------------------
+void SiPixelRawDataErrorSourcePhase1::buildStructure(const edm::EventSetup& iSetup){
+
+  LogInfo ("PixelDQM") <<" SiPixelRawDataErrorSourcePhase1::buildStructure" ;
+  edm::ESHandle<TrackerGeometry> pDD;
+  iSetup.get<TrackerDigiGeometryRecord>().get( pDD );
+
+  LogVerbatim ("PixelDQM") << " *** Geometry node for TrackerGeom is  "<<&(*pDD)<<std::endl;
+  LogVerbatim ("PixelDQM") << " *** I have " << pDD->dets().size() <<" detectors"<<std::endl;
+  LogVerbatim ("PixelDQM") << " *** I have " << pDD->detTypes().size() <<" types"<<std::endl;
+
+  for(TrackerGeometry::DetContainer::const_iterator it = pDD->dets().begin(); it != pDD->dets().end(); it++){
+
+    if( ((*it)->subDetector()==GeomDetEnumerators::PixelBarrel) || ((*it)->subDetector()==GeomDetEnumerators::PixelEndcap) ){
+      DetId detId = (*it)->geographicalId();
+      const GeomDetUnit      * geoUnit = pDD->idToDetUnit( detId );
+      const PixelGeomDetUnit * pixDet  = dynamic_cast<const PixelGeomDetUnit*>(geoUnit);
+      int nrows = (pixDet->specificTopology()).nrows();
+      int ncols = (pixDet->specificTopology()).ncolumns();
+
+      if(detId.subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel)) {
+        if(isPIB) continue;
+        LogDebug ("PixelDQM") << " ---> Adding Barrel Module " <<  detId.rawId() << endl;
+	uint32_t id = detId();
+	SiPixelRawDataErrorModulePhase1* theModule = new SiPixelRawDataErrorModulePhase1(id, ncols, nrows);
+	thePixelStructure.insert(pair<uint32_t,SiPixelRawDataErrorModulePhase1*> (id,theModule));
+
+      }	else if( (detId.subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap)) ) {
+	LogDebug ("PixelDQM") << " ---> Adding Endcap Module " <<  detId.rawId() << endl;
+	uint32_t id = detId();
+	SiPixelRawDataErrorModulePhase1* theModule = new SiPixelRawDataErrorModulePhase1(id, ncols, nrows);
+	
+        PixelEndcapNameUpgrade::HalfCylinder side = PixelEndcapNameUpgrade(DetId(id)).halfCylinder();
+        int disk   = PixelEndcapNameUpgrade(DetId(id)).diskName();
+        int blade  = PixelEndcapNameUpgrade(DetId(id)).bladeName();
+        int panel  = PixelEndcapNameUpgrade(DetId(id)).pannelName();
+        int module = PixelEndcapNameUpgrade(DetId(id)).plaquetteName();
+
+        char sside[80];  sprintf(sside,  "HalfCylinder_%i",side);
+        char sdisk[80];  sprintf(sdisk,  "Disk_%i",disk);
+        char sblade[80]; sprintf(sblade, "Blade_%02i",blade);
+        char spanel[80]; sprintf(spanel, "Panel_%i",panel);
+        char smodule[80];sprintf(smodule,"Module_%i",module);
+        std::string side_str = sside;
+	std::string disk_str = sdisk;
+	bool mask = side_str.find("HalfCylinder_1")!=string::npos||
+	            side_str.find("HalfCylinder_2")!=string::npos||
+		    side_str.find("HalfCylinder_4")!=string::npos||
+		    disk_str.find("Disk_2")!=string::npos;
+	// clutch to take all of FPIX, but no BPIX:
+	mask = false;
+	if(isPIB && mask) continue;
+		
+	thePixelStructure.insert(pair<uint32_t,SiPixelRawDataErrorModulePhase1*> (id,theModule));
+      }//endif(Endcap)
+    }
+  }
+  LogDebug ("PixelDQM") << " ---> Adding Module for Additional Errors " << endl;
+  pair<int,int> fedIds (FEDNumbering::MINSiPixelFEDID, FEDNumbering::MAXSiPixelFEDID);
+  fedIds.first = 0;
+  fedIds.second = 39;
+  for (int fedId = fedIds.first; fedId <= fedIds.second; fedId++) {
+    //std::cout<<"Adding FED module: "<<fedId<<std::endl;
+    uint32_t id = static_cast<uint32_t> (fedId);
+    SiPixelRawDataErrorModulePhase1* theModule = new SiPixelRawDataErrorModulePhase1(id);
+    theFEDStructure.insert(pair<uint32_t,SiPixelRawDataErrorModulePhase1*> (id,theModule));
+  }
+  
+  LogInfo ("PixelDQM") << " *** Pixel Structure Size " << thePixelStructure.size() << endl;
+}
+//------------------------------------------------------------------
+// Book MEs
+//------------------------------------------------------------------
+void SiPixelRawDataErrorSourcePhase1::bookMEs(DQMStore::IBooker & iBooker){
+  //cout<<"Entering SiPixelRawDataErrorSourcePhase1::bookMEs now: "<<endl;
+  iBooker.setCurrentFolder("Pixel/AdditionalPixelErrors");
+  char title[80]; sprintf(title, "By-LumiSection Error counters");
+  byLumiErrors = iBooker.book1D("byLumiErrors",title,2,0.,2.);
+  byLumiErrors->setLumiFlag();
+  char title1[80]; sprintf(title1, "Errors per LumiSection;LumiSection;NErrors");
+  errorRate = iBooker.book1D("errorRate",title1,5000,0.,5000.);
+  
+  std::map<uint32_t,SiPixelRawDataErrorModulePhase1*>::iterator struct_iter;
+  std::map<uint32_t,SiPixelRawDataErrorModulePhase1*>::iterator struct_iter2;
+  
+  SiPixelFolderOrganizer theSiPixelFolder(false);
+  
+  for(struct_iter = thePixelStructure.begin(); struct_iter != thePixelStructure.end(); struct_iter++){
+    /// Create folder tree and book histograms 
+
+    if(modOn){
+      if(!theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,0)) {
+        //std::cout<<"PIB! not booking histograms for non-PIB modules!"<<std::endl;
+        if(!isPIB) throw cms::Exception("LogicError")
+                       << "[SiPixelRawDataErrorSourcePhase1::bookMEs] Creation of DQM folder failed";
+      }
+    }
+    
+    if(ladOn){
+      if(!theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,1)) {
+        LogDebug ("PixelDQM") << "PROBLEM WITH LADDER-FOLDER\n";
+      }
+    }
+    
+    if(bladeOn){
+      if(!theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,4)) {
+        LogDebug ("PixelDQM") << "PROBLEM WITH BLADE-FOLDER\n";
+      }
+    }
+    
+  }//for loop
+
+  for(struct_iter2 = theFEDStructure.begin(); struct_iter2 != theFEDStructure.end(); struct_iter2++){
+    /// Create folder tree for errors without detId and book histograms 
+    if(!theSiPixelFolder.setFedFolder(iBooker,(*struct_iter2).first)) {
+      throw cms::Exception("LogicError")
+	<< "[SiPixelRawDataErrorSourcePhase1::bookMEs] Creation of DQM folder failed";
+    }
+
+  }
+
+  //Booking FED histograms
+  std::string hid;
+  // Get collection name and instantiate Histo Id builder
+  edm::InputTag src = conf_.getParameter<edm::InputTag>( "src" );
+  SiPixelHistogramId* theHistogramId = new SiPixelHistogramId( src.label() );
+
+  for (uint32_t id = 0; id < 40; id++){
+    char temp [50];
+    sprintf( temp, "Pixel/AdditionalPixelErrors/FED_%d",id);
+    iBooker.cd(temp);
+    // Types of errors
+    hid = theHistogramId->setHistoId("errorType",id);
+    meErrorType_[id] = iBooker.book1D(hid,"Type of errors",15,24.5,39.5);
+    meErrorType_[id]->setAxisTitle("Type of errors",1);
+    // Number of errors
+    hid = theHistogramId->setHistoId("NErrors",id);
+    meNErrors_[id] = iBooker.book1D(hid,"Number of errors",36,0.,36.);
+    meNErrors_[id]->setAxisTitle("Number of errors",1);
+    // Type of FIFO full (errorType = 28).  FIFO 1 is 1-5 (where fullType = channel of FIFO 1), 
+    // fullType = 6 signifies FIFO 2 nearly full, 7 signifies trigger FIFO nearly full, 8 
+    // indicates an unexpected result
+    hid = theHistogramId->setHistoId("fullType",id);
+    meFullType_[id] = iBooker.book1D(hid,"Type of FIFO full",7,0.5,7.5);
+    meFullType_[id]->setAxisTitle("FIFO type",1);
+    // For error type 30, the type of problem encoded in the TBM trailer
+    // 0 = stack full, 1 = Pre-cal issued, 2 = clear trigger counter, 3 = sync trigger, 
+    // 4 = sync trigger error, 5 = reset ROC, 6 = reset TBM, 7 = no token bit pass
+    hid = theHistogramId->setHistoId("TBMMessage",id);
+    meTBMMessage_[id] = iBooker.book1D(hid,"TBM trailer message",8,-0.5,7.5);
+    meTBMMessage_[id]->setAxisTitle("TBM message",1);
+    // For error type 30, the type of problem encoded in the TBM error trailer 0 = none
+    // 1 = data stream too long, 2 = FSM errors, 3 = invalid # of ROCs, 4 = multiple
+    hid = theHistogramId->setHistoId("TBMType",id);
+    meTBMType_[id] = iBooker.book1D(hid,"Type of TBM trailer",5,-0.5,4.5);
+    meTBMType_[id]->setAxisTitle("TBM Type",1);
+    // For error type 31, the event number of the TBM header with the error
+    hid = theHistogramId->setHistoId("EvtNbr",id);
+    meEvtNbr_[id] = iBooker.bookInt(hid);
+    // For errorType = 34, datastream size according to error word
+    hid = theHistogramId->setHistoId("evtSize",id);
+    meEvtSize_[id] = iBooker.bookInt(hid);
+    for(int j=0; j!=37; j++){
+      std::stringstream temp; temp << j;
+      hid = "FedChNErrArray_" + temp.str();
+      meFedChNErrArray_[id*37 + j] = iBooker.bookInt(hid);
+      hid = "FedChLErrArray_" + temp.str();
+      meFedChLErrArray_[id*37 + j] = iBooker.bookInt(hid);
+      hid = "FedETypeNErrArray_" + temp.str();
+      if(j<21) meFedETypeNErrArray_[id*21 + j] = iBooker.bookInt(hid);
+    }
+
+
+  }
+  //Add the booked histograms to the histogram map for booking
+  meMapFEDs_["meErrorType_"] = meErrorType_;
+  meMapFEDs_["meNErrors_"] = meNErrors_;
+  meMapFEDs_["meFullType_"] = meFullType_;
+  meMapFEDs_["meTBMMessage_"] = meTBMMessage_;
+  meMapFEDs_["meTBMType_"] = meTBMType_;
+  meMapFEDs_["meEvtNbr_"] = meEvtNbr_;
+  meMapFEDs_["meEvtSize_"] = meEvtSize_;
+  meMapFEDs_["meFedChNErrArray_"] = meFedChNErrArray_;
+  meMapFEDs_["meFedChLErrArray_"] = meFedChLErrArray_;
+  meMapFEDs_["meFedETypeNErrArray_"] = meFedETypeNErrArray_;
+
+  //cout<<"...leaving SiPixelRawDataErrorSourcePhase1::bookMEs now! "<<endl;
+}
+
+DEFINE_FWK_MODULE(SiPixelRawDataErrorSourcePhase1);

--- a/DQM/SiPixelMonitorRecHit/interface/SiPixelRecHitModule.h
+++ b/DQM/SiPixelMonitorRecHit/interface/SiPixelRecHitModule.h
@@ -46,7 +46,7 @@ class SiPixelRecHitModule {
 
   /// Book histograms
   void book(const edm::ParameterSet& iConfig, DQMStore::IBooker & iBooker, int type=0, bool twoD=true, 
-            bool reducedSet=false, bool isUpgrade=false);
+            bool reducedSet=false);
   /// Fill histograms
   void fill(const float& rechit_x, const float& rechit_y, const int& sizeX, 
             const int& sizeY, const float& lerr_x, const float& lerr_y, 

--- a/DQM/SiPixelMonitorRecHit/interface/SiPixelRecHitModulePhase1.h
+++ b/DQM/SiPixelMonitorRecHit/interface/SiPixelRecHitModulePhase1.h
@@ -1,0 +1,121 @@
+#ifndef SiPixelMonitorRecHits_SiPixelRecHitModulePhase1_h
+#define SiPixelMonitorRecHits_SiPixelRecHitModulePhase1_h
+// -*- C++ -*-
+//
+// Package:    SiPixelMonitorRecHits
+// Class:      SiPixelRecHitModulePhase1
+// 
+/**\class 
+
+ Description: RecHits monitoring elements for a single Pixel
+detector segment (detID)
+
+ Implementation:
+//	This package was marginally adapted from 
+//	SiPixelDigiModule
+     <Notes on implementation>
+*/
+//
+// Original Author:  Vincenzo Chiochia
+//         Created:  
+//
+//  Adapted by: Keith Rose
+//  for use in SiPixelMonitorRecHit package
+//  Updated by: Lukas Wehrli
+//  for pixel offline DQM 
+
+#include "DQMServices/Core/interface/MonitorElement.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h"
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include <boost/cstdint.hpp>
+
+class SiPixelRecHitModulePhase1 {        
+
+ public:
+
+  /// Default constructor
+  SiPixelRecHitModulePhase1();
+  /// Constructor with raw DetId
+  SiPixelRecHitModulePhase1(const uint32_t& id);
+  /// Destructor
+  ~SiPixelRecHitModulePhase1();
+
+  // typedef edm::DetSet<PixelRecHit>::const_iterator  RecHitsIterator;
+
+  /// Book histograms
+  void book(const edm::ParameterSet& iConfig, DQMStore::IBooker & iBooker, int type=0, bool twoD=true, 
+            bool reducedSet=false);
+  /// Fill histograms
+  void fill(const float& rechit_x, const float& rechit_y, const int& sizeX, 
+            const int& sizeY, const float& lerr_x, const float& lerr_y, 
+	    bool modon=true, bool ladon=false, bool layon=false, 
+	    bool phion=false, bool bladeon=false, bool diskon=false, 
+	    bool ringon=false, bool twoD=true, bool reducedSet=false);
+  void nfill(const int& nrec, bool modon=true, bool ladon=false, 
+             bool layon=false, bool phion=false, bool bladeon=false, 
+	     bool diskon=false, bool ringon=false);  
+
+ private:
+
+  uint32_t id_;
+  MonitorElement* meXYPos_;
+  MonitorElement* meXYPos_px_;
+  MonitorElement* meXYPos_py_;
+  MonitorElement* meClustX_;
+  MonitorElement* meClustY_;  
+  MonitorElement* meErrorX_;
+  MonitorElement* meErrorY_;  
+  MonitorElement* menRecHits_;
+  //barrel
+  MonitorElement* meXYPosLad_;
+  MonitorElement* meXYPosLad_px_;
+  MonitorElement* meXYPosLad_py_;
+  MonitorElement* meClustXLad_;
+  MonitorElement* meClustYLad_;
+  MonitorElement* meErrorXLad_;
+  MonitorElement* meErrorYLad_; 
+  MonitorElement* menRecHitsLad_;
+
+  MonitorElement* meXYPosLay_;
+  MonitorElement* meXYPosLay_px_;
+  MonitorElement* meXYPosLay_py_;
+  MonitorElement* meClustXLay_;
+  MonitorElement* meClustYLay_;
+  MonitorElement* meErrorXLay_;
+  MonitorElement* meErrorYLay_; 
+  MonitorElement* menRecHitsLay_;
+
+  MonitorElement* meXYPosPhi_;
+  MonitorElement* meXYPosPhi_px_;
+  MonitorElement* meXYPosPhi_py_;
+  MonitorElement* meClustXPhi_;
+  MonitorElement* meClustYPhi_;
+  MonitorElement* meErrorXPhi_;
+  MonitorElement* meErrorYPhi_; 
+  MonitorElement* menRecHitsPhi_;
+
+  //forward
+  MonitorElement* meClustXBlade_;
+  MonitorElement* meClustYBlade_;  
+  MonitorElement* meErrorXBlade_;
+  MonitorElement* meErrorYBlade_; 
+  MonitorElement* menRecHitsBlade_;
+
+  MonitorElement* meClustXDisk_;
+  MonitorElement* meClustYDisk_;  
+  MonitorElement* meErrorXDisk_;
+  MonitorElement* meErrorYDisk_; 
+  MonitorElement* menRecHitsDisk_;
+
+  MonitorElement* meXYPosRing_;
+  MonitorElement* meXYPosRing_px_;
+  MonitorElement* meXYPosRing_py_;
+  MonitorElement* meClustXRing_;
+  MonitorElement* meClustYRing_;
+  MonitorElement* meErrorXRing_;
+  MonitorElement* meErrorYRing_; 
+  MonitorElement* menRecHitsRing_;
+};
+#endif

--- a/DQM/SiPixelMonitorRecHit/interface/SiPixelRecHitSource.h
+++ b/DQM/SiPixelMonitorRecHit/interface/SiPixelRecHitSource.h
@@ -84,7 +84,6 @@ class SiPixelRecHitSource : public thread_unsafe::DQMEDAnalyzer {
        bool ringOn, bladeOn, diskOn; 
        
        bool firstRun;
-       bool isUpgrade;
 
  };
 

--- a/DQM/SiPixelMonitorRecHit/interface/SiPixelRecHitSourcePhase1.h
+++ b/DQM/SiPixelMonitorRecHit/interface/SiPixelRecHitSourcePhase1.h
@@ -1,0 +1,90 @@
+#ifndef SiPixelMonitorRecHits_SiPixelRecHitSourcePhase1_h
+#define SiPixelMonitorRecHits_SiPixelRecHitSourcePhase1_h
+// -*- C++ -*-
+//
+// Package:     SiPixelMonitorRecHits
+// Class  :     SiPixelRecHitSourcePhase1
+// 
+/**
+
+ Description: header file for Pixel Monitor Rec Hits
+
+ Usage:
+    see description
+
+*/
+//
+// Original Author:  Vincenzo Chiochia
+//         Created:  
+//
+// Updated by: Keith Rose
+// for use in SiPixelMonitorRecHits
+// Updated by: Lukas Wehrli
+// for pixel offline DQM 
+
+
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+
+#include "DQM/SiPixelMonitorRecHit/interface/SiPixelRecHitModulePhase1.h"
+
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
+#include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
+
+
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include <boost/cstdint.hpp>
+
+class SiPixelRecHitSourcePhase1 : public thread_unsafe::DQMEDAnalyzer {
+    public:
+       explicit SiPixelRecHitSourcePhase1(const edm::ParameterSet& conf);
+       ~SiPixelRecHitSourcePhase1();
+
+//       typedef edm::DetSet<PixelRecHit>::const_iterator    RecHitIterator;
+       
+       virtual void analyze(const edm::Event&, const edm::EventSetup&);
+       virtual void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
+       virtual void dqmBeginRun(const edm::Run&, edm::EventSetup const&) ;
+
+       virtual void buildStructure(edm::EventSetup const&);
+       virtual void bookMEs(DQMStore::IBooker &);
+
+    private:
+       edm::ParameterSet conf_;
+       edm::EDGetTokenT<SiPixelRecHitCollection> src_;
+
+       bool saveFile;
+       bool isPIB;
+       bool slowDown;
+       int eventNo;
+       std::map<uint32_t,SiPixelRecHitModulePhase1*> thePixelStructure;
+       std::map<uint32_t,int> rechit_count;
+       bool modOn; 
+       bool twoDimOn;
+       bool reducedSet;
+        //barrel:
+       bool ladOn, layOn, phiOn;
+       //forward:
+       bool ringOn, bladeOn, diskOn; 
+       
+       bool firstRun;
+
+ };
+
+#endif

--- a/DQM/SiPixelMonitorRecHit/python/SiPixelMonitorRecHit_cfi.py
+++ b/DQM/SiPixelMonitorRecHit/python/SiPixelMonitorRecHit_cfi.py
@@ -16,3 +16,20 @@ SiPixelRecHitSource = cms.EDAnalyzer("SiPixelRecHitSource",
     bladeOn = cms.untracked.bool(False),
     diskOn = cms.untracked.bool(False)
 )
+
+SiPixelRecHitSourcePhase1 = cms.EDAnalyzer("SiPixelRecHitSourcePhase1",
+    src = cms.InputTag("siPixelRecHits"),
+    outputFile = cms.string('Pixel_DQM_RecHits.root'),
+    saveFile = cms.untracked.bool(False),
+    slowDown = cms.untracked.bool(False),
+    isPIB = cms.untracked.bool(False),
+    modOn = cms.untracked.bool(True),
+    twoDimOn = cms.untracked.bool(True),                            
+    reducedSet = cms.untracked.bool(True),	
+    ladOn = cms.untracked.bool(False),
+    layOn = cms.untracked.bool(False),
+    phiOn = cms.untracked.bool(False),
+    ringOn = cms.untracked.bool(False),
+    bladeOn = cms.untracked.bool(False),
+    diskOn = cms.untracked.bool(False)
+)

--- a/DQM/SiPixelMonitorRecHit/src/SiPixelRecHitModule.cc
+++ b/DQM/SiPixelMonitorRecHit/src/SiPixelRecHitModule.cc
@@ -35,17 +35,13 @@ SiPixelRecHitModule::~SiPixelRecHitModule() {}
 // Book histograms
 //
 void SiPixelRecHitModule::book(const edm::ParameterSet& iConfig,DQMStore::IBooker & iBooker, int type, 
-                               bool twoD, bool reducedSet, bool isUpgrade) {
+                               bool twoD, bool reducedSet) {
 
   bool barrel = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
   bool endcap = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap);
   bool isHalfModule = false;
   if(barrel){
-    if (!isUpgrade) {
     isHalfModule = PixelBarrelName(DetId(id_)).isHalfModule(); 
-    } else if (isUpgrade) {
-      isHalfModule = PixelBarrelNameUpgrade(DetId(id_)).isHalfModule(); 
-    }
   }
 
   std::string hid;
@@ -97,8 +93,7 @@ void SiPixelRecHitModule::book(const edm::ParameterSet& iConfig,DQMStore::IBooke
 
   if(type==1 && barrel){
     uint32_t DBladder;
-    if (!isUpgrade) { DBladder = PixelBarrelName(DetId(id_)).ladderName(); }
-    else { DBladder = PixelBarrelNameUpgrade(DetId(id_)).ladderName(); }
+    DBladder = PixelBarrelName(DetId(id_)).ladderName();
     char sladder[80]; sprintf(sladder,"Ladder_%02i",DBladder);
     hid = src.label() + "_" + sladder;
     if(isHalfModule) hid += "H";
@@ -134,8 +129,7 @@ void SiPixelRecHitModule::book(const edm::ParameterSet& iConfig,DQMStore::IBooke
   if(type==2 && barrel){
     
     uint32_t DBlayer;
-    if (!isUpgrade) { DBlayer = PixelBarrelName(DetId(id_)).layerName(); }
-    else { DBlayer = PixelBarrelNameUpgrade(DetId(id_)).layerName(); }
+    DBlayer = PixelBarrelName(DetId(id_)).layerName();
     char slayer[80]; sprintf(slayer,"Layer_%i",DBlayer);
     hid = src.label() + "_" + slayer;
     
@@ -170,8 +164,7 @@ void SiPixelRecHitModule::book(const edm::ParameterSet& iConfig,DQMStore::IBooke
 
   if(type==3 && barrel){
     uint32_t DBmodule;
-    if (!isUpgrade) { DBmodule = PixelBarrelName(DetId(id_)).moduleName(); }
-    else { DBmodule = PixelBarrelNameUpgrade(DetId(id_)).moduleName(); }
+    DBmodule = PixelBarrelName(DetId(id_)).moduleName();
     char smodule[80]; sprintf(smodule,"Ring_%i",DBmodule);
     hid = src.label() + "_" + smodule;
     
@@ -205,8 +198,7 @@ void SiPixelRecHitModule::book(const edm::ParameterSet& iConfig,DQMStore::IBooke
 
   if(type==4 && endcap){
     uint32_t blade;
-    if (!isUpgrade) { blade= PixelEndcapName(DetId(id_)).bladeName(); }
-    else { blade= PixelEndcapNameUpgrade(DetId(id_)).bladeName(); }
+    blade= PixelEndcapName(DetId(id_)).bladeName();
     
     char sblade[80]; sprintf(sblade, "Blade_%02i",blade);
     hid = src.label() + "_" + sblade;
@@ -228,8 +220,7 @@ void SiPixelRecHitModule::book(const edm::ParameterSet& iConfig,DQMStore::IBooke
   }
   if(type==5 && endcap){
     uint32_t disk;
-    if (!isUpgrade) { disk = PixelEndcapName(DetId(id_)).diskName(); }
-    else { disk = PixelEndcapNameUpgrade(DetId(id_)).diskName(); }
+    disk = PixelEndcapName(DetId(id_)).diskName();
     
     char sdisk[80]; sprintf(sdisk, "Disk_%i",disk);
     hid = src.label() + "_" + sdisk;
@@ -253,13 +244,8 @@ void SiPixelRecHitModule::book(const edm::ParameterSet& iConfig,DQMStore::IBooke
   if(type==6 && endcap){
     uint32_t panel;
     uint32_t module;
-    if (!isUpgrade) {
-      panel= PixelEndcapName(DetId(id_)).pannelName();
-      module= PixelEndcapName(DetId(id_)).plaquetteName();
-    } else {
-      panel= PixelEndcapNameUpgrade(DetId(id_)).pannelName();
-      module= PixelEndcapNameUpgrade(DetId(id_)).plaquetteName();
-    }
+    panel= PixelEndcapName(DetId(id_)).pannelName();
+    module= PixelEndcapName(DetId(id_)).plaquetteName();
     
     char slab[80]; sprintf(slab, "Panel_%i_Ring_%i",panel, module);
     hid = src.label() + "_" + slab;

--- a/DQM/SiPixelMonitorRecHit/src/SiPixelRecHitModulePhase1.cc
+++ b/DQM/SiPixelMonitorRecHit/src/SiPixelRecHitModulePhase1.cc
@@ -1,0 +1,403 @@
+#include "DQM/SiPixelMonitorRecHit/interface/SiPixelRecHitModulePhase1.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQM/SiPixelCommon/interface/SiPixelHistogramId.h"
+/// Framework
+#include "FWCore/ServiceRegistry/interface/Service.h"
+// STL
+#include <vector>
+#include <memory>
+#include <string>
+#include <iostream>
+#include <stdlib.h>
+
+// Data Formats
+#include "DataFormats/SiPixelDetId/interface/PixelBarrelName.h"
+#include "DataFormats/SiPixelDetId/interface/PixelBarrelNameUpgrade.h"
+#include "DataFormats/SiPixelDetId/interface/PixelEndcapName.h"
+#include "DataFormats/SiPixelDetId/interface/PixelEndcapNameUpgrade.h"
+#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+//
+// Constructors
+//
+SiPixelRecHitModulePhase1::SiPixelRecHitModulePhase1() : id_(0) { }
+///
+SiPixelRecHitModulePhase1::SiPixelRecHitModulePhase1(const uint32_t& id) : 
+  id_(id)
+{ 
+}
+
+//
+// Destructor
+//
+SiPixelRecHitModulePhase1::~SiPixelRecHitModulePhase1() {}
+//
+// Book histograms
+//
+void SiPixelRecHitModulePhase1::book(const edm::ParameterSet& iConfig,DQMStore::IBooker & iBooker, int type, 
+                               bool twoD, bool reducedSet) {
+
+  bool barrel = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
+  bool endcap = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap);
+  bool isHalfModule = false;
+  if(barrel){
+    isHalfModule = PixelBarrelNameUpgrade(DetId(id_)).isHalfModule(); 
+  }
+
+  std::string hid;
+  // Get collection name and instantiate Histo Id builder
+  edm::InputTag src = iConfig.getParameter<edm::InputTag>( "src" );
+  // Get DQM interface
+
+
+  if(type==0){
+    SiPixelHistogramId* theHistogramId = new SiPixelHistogramId( src.label() );
+	if(!reducedSet)
+	{
+    if(twoD){
+      // XYPosition
+      hid = theHistogramId->setHistoId("xypos",id_);
+      meXYPos_ = iBooker.book2D(hid,"XY Position",100,-1.,1,100,-4,4);
+      meXYPos_->setAxisTitle("X Position",1);
+      meXYPos_->setAxisTitle("Y Position",2);
+    }
+    else{
+      // projections of XYPosition
+      hid = theHistogramId->setHistoId("xypos",id_);
+      meXYPos_px_ = iBooker.book1D(hid+"_px","X Position",100,-1.,1);
+      meXYPos_px_->setAxisTitle("X Position",1);
+      meXYPos_py_ = iBooker.book1D(hid+"_py","Y Position",100,-4,4);
+      meXYPos_py_->setAxisTitle("Y Position",1);
+    }
+	}
+    hid = theHistogramId->setHistoId("ClustX",id_);
+    meClustX_ = iBooker.book1D(hid, "RecHit X size", 10, 0., 10.);
+    meClustX_->setAxisTitle("RecHit size X dimension", 1);
+    hid = theHistogramId->setHistoId("ClustY",id_);
+    meClustY_ = iBooker.book1D(hid, "RecHit Y size", 15, 0., 15.);
+    meClustY_->setAxisTitle("RecHit size Y dimension", 1); 
+
+    hid = theHistogramId->setHistoId("ErrorX",id_);
+    meErrorX_ = iBooker.book1D(hid, "RecHit error X", 100,0.,0.02);
+    meErrorX_->setAxisTitle("RecHit error X", 1);
+    hid = theHistogramId->setHistoId("ErrorY",id_);
+    meErrorY_ = iBooker.book1D(hid, "RecHit error Y", 100,0.,0.02);
+    meErrorY_->setAxisTitle("RecHit error Y", 1);
+
+    //Removed to save offline memory
+    //hid = theHistogramId->setHistoId("nRecHits",id_);
+    //menRecHits_ = iBooker.book1D(hid, "# of rechits in this module", 8, 0, 8);
+    //menRecHits_->setAxisTitle("number of rechits",1);  
+    delete theHistogramId;
+  }
+
+  if(type==1 && barrel){
+    uint32_t DBladder;
+    DBladder = PixelBarrelNameUpgrade(DetId(id_)).ladderName();
+    char sladder[80]; sprintf(sladder,"Ladder_%02i",DBladder);
+    hid = src.label() + "_" + sladder;
+    if(isHalfModule) hid += "H";
+    else hid += "F";
+	if(!reducedSet)
+	{
+    if(twoD){
+      meXYPosLad_ = iBooker.book2D("xypos_" + hid,"XY Position",100,-1.,1,100,-4,4);
+      meXYPosLad_->setAxisTitle("X Position",1);
+      meXYPosLad_->setAxisTitle("Y Position",2);
+    }
+    else{
+      // projections of XYPosition
+      meXYPosLad_px_ = iBooker.book1D("xypos_"+hid+"_px","X Position",100,-1.,1);
+      meXYPosLad_px_->setAxisTitle("X Position",1);
+      meXYPosLad_py_ = iBooker.book1D("xypos_"+hid+"_py","Y Position",100,-4,4);
+      meXYPosLad_py_->setAxisTitle("Y Position",1);
+    }
+	}
+    meClustXLad_ = iBooker.book1D("ClustX_" +hid, "RecHit X size", 10, 0., 10.);
+    meClustXLad_->setAxisTitle("RecHit size X dimension", 1);
+    meClustYLad_ = iBooker.book1D("ClustY_" +hid,"RecHit Y size", 15, 0.,15.);
+    meClustYLad_->setAxisTitle("RecHit size Y dimension", 1);
+    meErrorXLad_ = iBooker.book1D("ErrorX_"+hid, "RecHit error X", 100,0.,0.02);
+    meErrorXLad_->setAxisTitle("RecHit error X", 1);
+    meErrorYLad_ = iBooker.book1D("ErrorY_"+hid, "RecHit error Y", 100,0.,0.02);
+    meErrorYLad_->setAxisTitle("RecHit error Y", 1);
+    menRecHitsLad_ = iBooker.book1D("nRecHits_"+hid, "# of rechits in this module", 8, 0, 8);
+    menRecHitsLad_->setAxisTitle("number of rechits",1);
+
+  }
+
+  if(type==2 && barrel){
+    
+    uint32_t DBlayer;
+    DBlayer = PixelBarrelNameUpgrade(DetId(id_)).layerName();
+    char slayer[80]; sprintf(slayer,"Layer_%i",DBlayer);
+    hid = src.label() + "_" + slayer;
+    
+	if(!reducedSet)
+	{
+    if(twoD){
+      meXYPosLay_ = iBooker.book2D("xypos_" + hid,"XY Position",100,-1.,1,100,-4,4);
+      meXYPosLay_->setAxisTitle("X Position",1);
+      meXYPosLay_->setAxisTitle("Y Position",2);
+    }
+    else{
+      // projections of XYPosition
+      meXYPosLay_px_ = iBooker.book1D("xypos_"+hid+"_px","X Position",100,-1.,1);
+      meXYPosLay_px_->setAxisTitle("X Position",1);
+      meXYPosLay_py_ = iBooker.book1D("xypos_"+hid+"_py","Y Position",100,-4,4);
+      meXYPosLay_py_->setAxisTitle("Y Position",1);
+    }
+	}
+
+    meClustXLay_ = iBooker.book1D("ClustX_" +hid, "RecHit X size", 10, 0., 10.);
+    meClustXLay_->setAxisTitle("RecHit size X dimension", 1);
+    meClustYLay_ = iBooker.book1D("ClustY_" +hid,"RecHit Y size", 15, 0.,15.);
+    meClustYLay_->setAxisTitle("RecHit size Y dimension", 1);
+    meErrorXLay_ = iBooker.book1D("ErrorX_"+hid, "RecHit error X", 100,0.,0.02);
+    meErrorXLay_->setAxisTitle("RecHit error X", 1);
+    meErrorYLay_ = iBooker.book1D("ErrorY_"+hid, "RecHit error Y", 100,0.,0.02);
+    meErrorYLay_->setAxisTitle("RecHit error Y", 1);
+    menRecHitsLay_ = iBooker.book1D("nRecHits_"+hid, "# of rechits in this module", 8, 0, 8);
+    menRecHitsLay_->setAxisTitle("number of rechits",1);
+
+  }
+
+  if(type==3 && barrel){
+    uint32_t DBmodule;
+    DBmodule = PixelBarrelNameUpgrade(DetId(id_)).moduleName();
+    char smodule[80]; sprintf(smodule,"Ring_%i",DBmodule);
+    hid = src.label() + "_" + smodule;
+    
+	if(!reducedSet)
+	{
+    if(twoD){
+      meXYPosPhi_ = iBooker.book2D("xypos_" + hid,"XY Position",100,-1.,1,100,-4,4);
+      meXYPosPhi_->setAxisTitle("X Position",1);
+      meXYPosPhi_->setAxisTitle("Y Position",2);
+    }
+    else{
+      // projections of XYPosition
+      meXYPosPhi_px_ = iBooker.book1D("xypos_"+hid+"_px","X Position",100,-1.,1);
+      meXYPosPhi_px_->setAxisTitle("X Position",1);
+      meXYPosPhi_py_ = iBooker.book1D("xypos_"+hid+"_py","Y Position",100,-4,4);
+      meXYPosPhi_py_->setAxisTitle("Y Position",1);
+    }
+	}
+    meClustXPhi_ = iBooker.book1D("ClustX_" +hid, "RecHit X size", 10, 0., 10.);
+    meClustXPhi_->setAxisTitle("RecHit size X dimension", 1);
+    meClustYPhi_ = iBooker.book1D("ClustY_" +hid,"RecHit Y size", 15, 0.,15.);
+    meClustYPhi_->setAxisTitle("RecHit size Y dimension", 1);
+    meErrorXPhi_ = iBooker.book1D("ErrorX_"+hid, "RecHit error X", 100,0.,0.02);
+    meErrorXPhi_->setAxisTitle("RecHit error X", 1);
+    meErrorYPhi_ = iBooker.book1D("ErrorY_"+hid, "RecHit error Y", 100,0.,0.02);
+    meErrorYPhi_->setAxisTitle("RecHit error Y", 1);
+    menRecHitsPhi_ = iBooker.book1D("nRecHits_"+hid, "# of rechits in this module", 8, 0, 8);
+    menRecHitsPhi_->setAxisTitle("number of rechits",1);
+
+  }
+
+  if(type==4 && endcap){
+    uint32_t blade;
+    blade= PixelEndcapNameUpgrade(DetId(id_)).bladeName();
+    
+    char sblade[80]; sprintf(sblade, "Blade_%02i",blade);
+    hid = src.label() + "_" + sblade;
+//     meXYPosBlade_ = iBooker.book2D("xypos_" + hid,"XY Position",100,-1.,1,100,-4,4);
+//     meXYPosBlade_->setAxisTitle("X Position",1);
+//     meXYPosBlade_->setAxisTitle("Y Position",2);
+
+    meClustXBlade_ = iBooker.book1D("ClustX_" +hid, "RecHit X size", 10, 0., 10.);
+    meClustXBlade_->setAxisTitle("RecHit size X dimension", 1);
+    meClustYBlade_ = iBooker.book1D("ClustY_" +hid,"RecHit Y size", 15, 0.,15.);
+    meClustYBlade_->setAxisTitle("RecHit size Y dimension", 1);
+    meErrorXBlade_ = iBooker.book1D("ErrorX_"+hid, "RecHit error X", 100,0.,0.02);
+    meErrorXBlade_->setAxisTitle("RecHit error X", 1);
+    meErrorYBlade_ = iBooker.book1D("ErrorY_"+hid, "RecHit error Y", 100,0.,0.02);
+    meErrorYBlade_->setAxisTitle("RecHit error Y", 1);
+    menRecHitsBlade_ = iBooker.book1D("nRecHits_"+hid, "# of rechits in this module", 8, 0, 8);
+    menRecHitsBlade_->setAxisTitle("number of rechits",1);
+
+  }
+  if(type==5 && endcap){
+    uint32_t disk;
+    disk = PixelEndcapNameUpgrade(DetId(id_)).diskName();
+    
+    char sdisk[80]; sprintf(sdisk, "Disk_%i",disk);
+    hid = src.label() + "_" + sdisk;
+//     meXYPosDisk_ = iBooker.book2D("xypos_" + hid,"XY Position",100,-1.,1,100,-4,4);
+//     meXYPosDisk_->setAxisTitle("X Position",1);
+//     meXYPosDisk_->setAxisTitle("Y Position",2);
+
+    meClustXDisk_ = iBooker.book1D("ClustX_" +hid, "RecHit X size", 10, 0., 10.);
+    meClustXDisk_->setAxisTitle("RecHit size X dimension", 1);
+    meClustYDisk_ = iBooker.book1D("ClustY_" +hid,"RecHit Y size", 15, 0.,15.);
+    meClustYDisk_->setAxisTitle("RecHit size Y dimension", 1);
+    meErrorXDisk_ = iBooker.book1D("ErrorX_"+hid, "RecHit error X", 100,0.,0.02);
+    meErrorXDisk_->setAxisTitle("RecHit error X", 1);
+    meErrorYDisk_ = iBooker.book1D("ErrorY_"+hid, "RecHit error Y", 100,0.,0.02);
+    meErrorYDisk_->setAxisTitle("RecHit error Y", 1);
+    menRecHitsDisk_ = iBooker.book1D("nRecHits_"+hid, "# of rechits in this module", 8, 0, 8);
+    menRecHitsDisk_->setAxisTitle("number of rechits",1);
+
+  }
+
+  if(type==6 && endcap){
+    uint32_t panel;
+    uint32_t module;
+    panel= PixelEndcapNameUpgrade(DetId(id_)).pannelName();
+    module= PixelEndcapNameUpgrade(DetId(id_)).plaquetteName();
+    
+    char slab[80]; sprintf(slab, "Panel_%i_Ring_%i",panel, module);
+    hid = src.label() + "_" + slab;
+    
+	if(!reducedSet)
+	{
+    if(twoD){
+      meXYPosRing_ = iBooker.book2D("xypos_" + hid,"XY Position",100,-1.,1,100,-4,4);
+      meXYPosRing_->setAxisTitle("X Position",1);
+      meXYPosRing_->setAxisTitle("Y Position",2);
+    }
+    else{
+      // projections of XYPosition
+      meXYPosRing_px_ = iBooker.book1D("xypos_"+hid+"_px","X Position",100,-1.,1);
+      meXYPosRing_px_->setAxisTitle("X Position",1);
+      meXYPosRing_py_ = iBooker.book1D("xypos_"+hid+"_py","Y Position",100,-4,4);
+      meXYPosRing_py_->setAxisTitle("Y Position",1);
+    }
+	}
+    meClustXRing_ = iBooker.book1D("ClustX_" +hid, "RecHit X size", 10, 0., 10.);
+    meClustXRing_->setAxisTitle("RecHit size X dimension", 1);
+    meClustYRing_ = iBooker.book1D("ClustY_" +hid,"RecHit Y size", 15, 0.,15.);
+    meClustYRing_->setAxisTitle("RecHit size Y dimension", 1);
+    meErrorXRing_ = iBooker.book1D("ErrorX_"+hid, "RecHit error X", 100,0.,0.02);
+    meErrorXRing_->setAxisTitle("RecHit error X", 1);
+    meErrorYRing_ = iBooker.book1D("ErrorY_"+hid, "RecHit error Y", 100,0.,0.02);
+    meErrorYRing_->setAxisTitle("RecHit error Y", 1);
+    menRecHitsRing_ = iBooker.book1D("nRecHits_"+hid, "# of rechits in this module", 8, 0, 8);
+    menRecHitsRing_->setAxisTitle("number of rechits",1);
+
+  }
+
+}
+//
+// Fill histograms
+//
+void SiPixelRecHitModulePhase1::fill(const float& rechit_x, const float& rechit_y, 
+                               const int& sizeX, const int& sizeY, 
+			       const float& lerr_x, const float& lerr_y, 
+			       bool modon, bool ladon, bool layon, bool phion, 
+			       bool bladeon, bool diskon, bool ringon, 
+			       bool twoD, bool reducedSet) {
+
+  bool barrel = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
+  bool endcap = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap);
+
+  //std::cout << rechit_x << " " << rechit_y << " " << sizeX << " " << sizeY << std::endl;
+  if(modon){
+    meClustX_->Fill(sizeX);
+    meClustY_->Fill(sizeY);
+    meErrorX_->Fill(lerr_x);
+    meErrorY_->Fill(lerr_y);  
+	if(!reducedSet)
+	{
+    if(twoD) meXYPos_->Fill(rechit_x, rechit_y);
+    else {
+      meXYPos_px_->Fill(rechit_x); 
+      meXYPos_py_->Fill(rechit_y);
+    }
+	}
+  }
+  //std::cout<<"number of detector units="<<numberOfDetUnits<<std::endl;
+
+  if(ladon && barrel){
+    meClustXLad_->Fill(sizeX);
+    meClustYLad_->Fill(sizeY);
+    meErrorXLad_->Fill(lerr_x);
+    meErrorYLad_->Fill(lerr_y);  
+	if(!reducedSet)
+	{
+    if(twoD) meXYPosLad_->Fill(rechit_x, rechit_y);
+    else{
+      meXYPosLad_px_->Fill(rechit_x); 
+      meXYPosLad_py_->Fill(rechit_y);
+    }
+	}
+  }
+
+  if(layon && barrel){
+    meClustXLay_->Fill(sizeX);
+    meClustYLay_->Fill(sizeY);
+    meErrorXLay_->Fill(lerr_x);
+    meErrorYLay_->Fill(lerr_y); 
+	if(!reducedSet)
+	{
+    if(twoD) meXYPosLay_->Fill(rechit_x, rechit_y);
+    else{
+      meXYPosLay_px_->Fill(rechit_x); 
+      meXYPosLay_py_->Fill(rechit_y);
+    }
+	}
+  }
+
+  if(phion && barrel){
+    meClustXPhi_->Fill(sizeX);
+    meClustYPhi_->Fill(sizeY);
+    meErrorXPhi_->Fill(lerr_x);
+    meErrorYPhi_->Fill(lerr_y); 
+    if(!reducedSet)
+	{
+    if(twoD) meXYPosPhi_->Fill(rechit_x, rechit_y);
+    else{
+      meXYPosPhi_px_->Fill(rechit_x); 
+      meXYPosPhi_py_->Fill(rechit_y);
+    }
+	}	
+  }
+
+  if(bladeon && endcap){
+    //meXYPosBlade_->Fill(rechit_x, rechit_y);
+    meClustXBlade_->Fill(sizeX);
+    meClustYBlade_->Fill(sizeY);
+    meErrorXBlade_->Fill(lerr_x);
+    meErrorYBlade_->Fill(lerr_y); 
+  }
+
+  if(diskon && endcap){
+    //meXYPosDisk_->Fill(rechit_x, rechit_y);
+    meClustXDisk_->Fill(sizeX);
+    meClustYDisk_->Fill(sizeY);
+    meErrorXDisk_->Fill(lerr_x);
+    meErrorYDisk_->Fill(lerr_y); 
+  }
+
+  if(ringon && endcap){
+    meClustXRing_->Fill(sizeX);
+    meClustYRing_->Fill(sizeY);
+    meErrorXRing_->Fill(lerr_x);
+    meErrorYRing_->Fill(lerr_y); 
+	if(!reducedSet)
+	{
+    if(twoD) meXYPosRing_->Fill(rechit_x, rechit_y);
+    else{
+      meXYPosRing_px_->Fill(rechit_x); 
+      meXYPosRing_py_->Fill(rechit_y);
+    }
+	}	
+  }
+}
+
+void SiPixelRecHitModulePhase1::nfill(const int& nrec, bool modon, bool ladon, bool layon, bool phion, bool bladeon, bool diskon, bool ringon) {
+  
+  bool barrel = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
+  bool endcap = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap);
+
+  //if(modon) menRecHits_->Fill(nrec);
+  //barrel
+  if(ladon && barrel) menRecHitsLad_->Fill(nrec);
+  if(layon && barrel) menRecHitsLay_->Fill(nrec);
+  if(phion && barrel) menRecHitsPhi_->Fill(nrec);
+  //endcap
+  if(bladeon && endcap) menRecHitsBlade_->Fill(nrec);
+  if(diskon && endcap) menRecHitsDisk_->Fill(nrec);
+  if(ringon && endcap) menRecHitsRing_->Fill(nrec);
+}

--- a/DQM/SiPixelMonitorRecHit/src/SiPixelRecHitSource.cc
+++ b/DQM/SiPixelMonitorRecHit/src/SiPixelRecHitSource.cc
@@ -61,8 +61,7 @@ SiPixelRecHitSource::SiPixelRecHitSource(const edm::ParameterSet& iConfig) :
   phiOn( conf_.getUntrackedParameter<bool>("phiOn",false) ), 
   ringOn( conf_.getUntrackedParameter<bool>("ringOn",false) ), 
   bladeOn( conf_.getUntrackedParameter<bool>("bladeOn",false) ), 
-  diskOn( conf_.getUntrackedParameter<bool>("diskOn",false) ), 
-  isUpgrade( conf_.getUntrackedParameter<bool>("isUpgrade",false) )
+  diskOn( conf_.getUntrackedParameter<bool>("diskOn",false) ) 
 {
   firstRun = true;
   LogInfo ("PixelDQM") << "SiPixelRecHitSource::SiPixelRecHitSource: Got DQM BackEnd interface"<<endl;
@@ -194,7 +193,7 @@ void SiPixelRecHitSource::buildStructure(const edm::EventSetup& iSetup){
 	  LogDebug ("PixelDQM") << " ---> Adding Barrel Module " <<  detId.rawId() << endl;
 	  thePixelStructure.insert(pair<uint32_t,SiPixelRecHitModule*> (id,theModule));
 		
-	}	else if( (detId.subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap)) && (!isUpgrade)) {
+	}	else if( detId.subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap) ) {
 	  LogDebug ("PixelDQM") << " ---> Adding Endcap Module " <<  detId.rawId() << endl;
 	  PixelEndcapName::HalfCylinder side = PixelEndcapName(DetId(id)).halfCylinder();
 	  int disk   = PixelEndcapName(DetId(id)).diskName();
@@ -216,29 +215,7 @@ void SiPixelRecHitSource::buildStructure(const edm::EventSetup& iSetup){
 	  if(isPIB && mask) continue;
 	
 	  thePixelStructure.insert(pair<uint32_t,SiPixelRecHitModule*> (id,theModule));
-	}	else if( (detId.subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap)) && (isUpgrade)) {
-	  LogDebug ("PixelDQM") << " ---> Adding Endcap Module " <<  detId.rawId() << endl;
-	  PixelEndcapNameUpgrade::HalfCylinder side = PixelEndcapNameUpgrade(DetId(id)).halfCylinder();
-	  int disk   = PixelEndcapNameUpgrade(DetId(id)).diskName();
-	  int blade  = PixelEndcapNameUpgrade(DetId(id)).bladeName();
-	  int panel  = PixelEndcapNameUpgrade(DetId(id)).pannelName();
-	  int module = PixelEndcapNameUpgrade(DetId(id)).plaquetteName();
-
-	  char sside[80];  sprintf(sside,  "HalfCylinder_%i",side);
-	  char sdisk[80];  sprintf(sdisk,  "Disk_%i",disk);
-	  char sblade[80]; sprintf(sblade, "Blade_%02i",blade);
-	  char spanel[80]; sprintf(spanel, "Panel_%i",panel);
-	  char smodule[80];sprintf(smodule,"Module_%i",module);
-	  std::string side_str = sside;
-	  std::string disk_str = sdisk;
-	  bool mask = side_str.find("HalfCylinder_1")!=string::npos||
-	    side_str.find("HalfCylinder_2")!=string::npos||
-	    side_str.find("HalfCylinder_4")!=string::npos||
-	    disk_str.find("Disk_2")!=string::npos;
-	  if(isPIB && mask) continue;
-	
-	  thePixelStructure.insert(pair<uint32_t,SiPixelRecHitModule*> (id,theModule));
-	}//endif(isUpgrade)
+	}
       }
     }	    
   }
@@ -258,51 +235,51 @@ void SiPixelRecHitSource::bookMEs(DQMStore::IBooker & iBooker){
     
     /// Create folder tree and book histograms 
     if(modOn){
-      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,0,isUpgrade)){
-	(*struct_iter).second->book( conf_,iBooker,0,twoDimOn, reducedSet, isUpgrade);
+      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,0)){
+	(*struct_iter).second->book( conf_,iBooker,0,twoDimOn, reducedSet);
       } else {
 	if(!isPIB) throw cms::Exception("LogicError")
 	  << "[SiPixelDigiSource::bookMEs] Creation of DQM folder failed";
       }
     }
     if(ladOn){
-      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,1,isUpgrade)){
-	(*struct_iter).second->book( conf_,iBooker,1,twoDimOn, reducedSet, isUpgrade);
+      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,1)){
+	(*struct_iter).second->book( conf_,iBooker,1,twoDimOn, reducedSet);
 	} else {
 	LogDebug ("PixelDQM") << "PROBLEM WITH LADDER-FOLDER\n";
       }
     }
     if(layOn){
-      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,2,isUpgrade)){
-	(*struct_iter).second->book( conf_,iBooker,2,twoDimOn, reducedSet, isUpgrade);
+      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,2)){
+	(*struct_iter).second->book( conf_,iBooker,2,twoDimOn, reducedSet);
 	} else {
 	LogDebug ("PixelDQM") << "PROBLEM WITH LAYER-FOLDER\n";
       }
     }
     if(phiOn){
-      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,3,isUpgrade)){
-	(*struct_iter).second->book( conf_,iBooker,3,twoDimOn, reducedSet, isUpgrade);
+      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,3)){
+	(*struct_iter).second->book( conf_,iBooker,3,twoDimOn, reducedSet);
 	} else {
 	LogDebug ("PixelDQM") << "PROBLEM WITH PHI-FOLDER\n";
       }
     }
     if(bladeOn){
-      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,4,isUpgrade)){
-	(*struct_iter).second->book( conf_,iBooker,4,twoDimOn, reducedSet, isUpgrade);
+      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,4)){
+	(*struct_iter).second->book( conf_,iBooker,4,twoDimOn, reducedSet);
 	} else {
 	LogDebug ("PixelDQM") << "PROBLEM WITH BLADE-FOLDER\n";
       }
     }
     if(diskOn){
-      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,5,isUpgrade)){
-	(*struct_iter).second->book( conf_,iBooker,5,twoDimOn, reducedSet, isUpgrade);
+      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,5)){
+	(*struct_iter).second->book( conf_,iBooker,5,twoDimOn, reducedSet);
 	} else {
 	LogDebug ("PixelDQM") << "PROBLEM WITH DISK-FOLDER\n";
       }
     }
     if(ringOn){
-      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,6,isUpgrade)){
-	(*struct_iter).second->book( conf_,iBooker,6,twoDimOn, reducedSet, isUpgrade);
+      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,6)){
+	(*struct_iter).second->book( conf_,iBooker,6,twoDimOn, reducedSet);
 	} else {
 	LogDebug ("PixelDQM") << "PROBLEM WITH RING-FOLDER\n";
       }

--- a/DQM/SiPixelMonitorRecHit/src/SiPixelRecHitSourcePhase1.cc
+++ b/DQM/SiPixelMonitorRecHit/src/SiPixelRecHitSourcePhase1.cc
@@ -1,0 +1,293 @@
+// -*- C++ -*-
+//
+// Package:    SiPixelMonitorRecHits
+// Class:      SiPixelRecHitSourcePhase1
+// 
+/**\class 
+
+ Description: Pixel DQM source for RecHits
+
+ Implementation:
+     Originally based on the code for Digis, adapted
+	to read RecHits and create relevant histograms
+*/
+//
+// Original Author:  Vincenzo Chiochia
+//         Created:  
+//
+//
+// Adapted by:  Keith Rose
+//  	For use in SiPixelMonitorClient for RecHits
+// Updated by: Lukas Wehrli
+// for pixel offline DQM 
+
+#include "DQM/SiPixelMonitorRecHit/interface/SiPixelRecHitSourcePhase1.h"
+// Framework
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+// DQM Framework
+#include "DQM/SiPixelCommon/interface/SiPixelFolderOrganizer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+// Geometry
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
+// DataFormats
+#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+#include "DataFormats/SiPixelDetId/interface/PixelBarrelName.h"
+#include "DataFormats/SiPixelDetId/interface/PixelBarrelNameUpgrade.h"
+#include "DataFormats/SiPixelDetId/interface/PixelEndcapName.h"
+#include "DataFormats/SiPixelDetId/interface/PixelEndcapNameUpgrade.h"
+
+//
+#include <string>
+#include <stdlib.h>
+#include <iostream>
+using namespace std;
+using namespace edm;
+
+SiPixelRecHitSourcePhase1::SiPixelRecHitSourcePhase1(const edm::ParameterSet& iConfig) :
+  conf_(iConfig),
+  src_( consumes<SiPixelRecHitCollection>( conf_.getParameter<edm::InputTag>( "src" ))),
+  saveFile( conf_.getUntrackedParameter<bool>("saveFile",false) ),
+  isPIB( conf_.getUntrackedParameter<bool>("isPIB",false) ),
+  slowDown( conf_.getUntrackedParameter<bool>("slowDown",false) ),
+  modOn( conf_.getUntrackedParameter<bool>("modOn",true) ),
+  twoDimOn( conf_.getUntrackedParameter<bool>("twoDimOn",true) ),
+  reducedSet( conf_.getUntrackedParameter<bool>("reducedSet",false) ),
+  ladOn( conf_.getUntrackedParameter<bool>("ladOn",false) ), 
+  layOn( conf_.getUntrackedParameter<bool>("layOn",false) ), 
+  phiOn( conf_.getUntrackedParameter<bool>("phiOn",false) ), 
+  ringOn( conf_.getUntrackedParameter<bool>("ringOn",false) ), 
+  bladeOn( conf_.getUntrackedParameter<bool>("bladeOn",false) ), 
+  diskOn( conf_.getUntrackedParameter<bool>("diskOn",false) )
+{
+  firstRun = true;
+  LogInfo ("PixelDQM") << "SiPixelRecHitSourcePhase1::SiPixelRecHitSourcePhase1: Got DQM BackEnd interface"<<endl;
+}
+
+
+SiPixelRecHitSourcePhase1::~SiPixelRecHitSourcePhase1()
+{
+   // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
+  LogInfo ("PixelDQM") << "SiPixelRecHitSourcePhase1::~SiPixelRecHitSourcePhase1: Destructor"<<endl;
+  std::map<uint32_t,SiPixelRecHitModulePhase1*>::iterator struct_iter;
+  for (struct_iter = thePixelStructure.begin() ; struct_iter != thePixelStructure.end() ; struct_iter++){
+    delete struct_iter->second;
+    struct_iter->second = 0;
+  }
+}
+
+
+void SiPixelRecHitSourcePhase1::dqmBeginRun(const edm::Run& r, const edm::EventSetup& iSetup){
+
+  LogInfo ("PixelDQM") << " SiPixelRecHitSourcePhase1::beginJob - Initialisation ... " << std::endl;
+  LogInfo ("PixelDQM") << "Mod/Lad/Lay/Phi " << modOn << "/" << ladOn << "/" 
+	    << layOn << "/" << phiOn << std::endl;
+  LogInfo ("PixelDQM") << "Blade/Disk/Ring" << bladeOn << "/" << diskOn << "/" 
+	    << ringOn << std::endl;
+  LogInfo ("PixelDQM") << "2DIM IS " << twoDimOn << "\n";
+  
+  if(firstRun){
+    eventNo = 0;
+    // Build map
+    buildStructure(iSetup);
+    // Book Monitoring Elements
+    firstRun = false;
+  }
+}
+
+void SiPixelRecHitSourcePhase1::bookHistograms(DQMStore::IBooker & iBooker, edm::Run const &, edm::EventSetup const &){
+  bookMEs(iBooker);
+}
+
+//------------------------------------------------------------------
+// Method called for every event
+//------------------------------------------------------------------
+void SiPixelRecHitSourcePhase1::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+  eventNo++;
+  //cout << eventNo << endl;
+  // get input data
+  edm::Handle<SiPixelRecHitCollection>  recHitColl;
+  iEvent.getByToken( src_, recHitColl );
+
+  std::map<uint32_t,SiPixelRecHitModulePhase1*>::iterator struct_iter;
+  for (struct_iter = thePixelStructure.begin() ; struct_iter != thePixelStructure.end() ; struct_iter++) {
+    uint32_t TheID = (*struct_iter).first;
+
+    SiPixelRecHitCollection::const_iterator match = recHitColl->find(TheID);
+    
+      // if( pixelrechitRangeIteratorBegin == pixelrechitRangeIteratorEnd) {cout << "oops" << endl;}
+      float rechit_x = 0;
+      float rechit_y = 0;
+      int rechit_count = 0;
+
+      if (match != recHitColl->end()) {
+	SiPixelRecHitCollection::DetSet pixelrechitRange = *match;
+	SiPixelRecHitCollection::DetSet::const_iterator pixelrechitRangeIteratorBegin = pixelrechitRange.begin();
+	SiPixelRecHitCollection::DetSet::const_iterator pixelrechitRangeIteratorEnd = pixelrechitRange.end();
+	SiPixelRecHitCollection::DetSet::const_iterator pixeliter = pixelrechitRangeIteratorBegin;
+
+       for ( ; pixeliter != pixelrechitRangeIteratorEnd; pixeliter++) 
+	 {
+	  
+
+	  rechit_count++;
+	  //cout << TheID << endl;
+	  SiPixelRecHit::ClusterRef const& clust = pixeliter->cluster();
+	  int sizeX = (*clust).sizeX();
+	  //cout << sizeX << endl;
+	  int sizeY = (*clust).sizeY();
+	  //cout << sizeY << endl;
+	  LocalPoint lp = pixeliter->localPosition();
+	  rechit_x = lp.x();
+	  rechit_y = lp.y();
+	  
+	  LocalError lerr = pixeliter->localPositionError();
+	  float lerr_x = sqrt(lerr.xx());
+	  float lerr_y = sqrt(lerr.yy());
+	  //std::cout << "errors " << lerr_x << " " << lerr_y << std::endl;
+	  (*struct_iter).second->fill(rechit_x, rechit_y, sizeX, sizeY, lerr_x, lerr_y, 
+	                              modOn, ladOn, layOn, phiOn, bladeOn, diskOn, ringOn, 
+				      twoDimOn, reducedSet);
+	
+	}
+      }
+      if(rechit_count > 0) (*struct_iter).second->nfill(rechit_count, modOn, ladOn, layOn, phiOn, bladeOn, diskOn, ringOn);
+    
+  }
+
+  // slow down...
+  if(slowDown) usleep(10000);
+  
+}
+
+//------------------------------------------------------------------
+// Build data structure
+//------------------------------------------------------------------
+void SiPixelRecHitSourcePhase1::buildStructure(const edm::EventSetup& iSetup){
+
+  LogInfo ("PixelDQM") <<" SiPixelRecHitSourcePhase1::buildStructure" ;
+  edm::ESHandle<TrackerGeometry> pDD;
+  iSetup.get<TrackerDigiGeometryRecord>().get( pDD );
+
+  LogVerbatim ("PixelDQM") << " *** Geometry node for TrackerGeom is  "<<&(*pDD)<<std::endl;
+  LogVerbatim ("PixelDQM") << " *** I have " << pDD->dets().size() <<" detectors"<<std::endl;
+  LogVerbatim ("PixelDQM") << " *** I have " << pDD->detTypes().size() <<" types"<<std::endl;
+  
+  for(TrackerGeometry::DetContainer::const_iterator it = pDD->dets().begin(); it != pDD->dets().end(); it++){
+    
+    if(dynamic_cast<PixelGeomDetUnit const *>((*it))!=0){
+
+      DetId detId = (*it)->geographicalId();
+      
+      if((detId.subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel)) ||
+	 (detId.subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap))){ 
+	uint32_t id = detId();
+	SiPixelRecHitModulePhase1* theModule = new SiPixelRecHitModulePhase1(id);
+	if(detId.subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel)) {
+	  if(isPIB) continue;
+	  LogDebug ("PixelDQM") << " ---> Adding Barrel Module " <<  detId.rawId() << endl;
+	  thePixelStructure.insert(pair<uint32_t,SiPixelRecHitModulePhase1*> (id,theModule));
+		
+	} else if( detId.subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap) ) {
+	  LogDebug ("PixelDQM") << " ---> Adding Endcap Module " <<  detId.rawId() << endl;
+	  PixelEndcapNameUpgrade::HalfCylinder side = PixelEndcapNameUpgrade(DetId(id)).halfCylinder();
+	  int disk   = PixelEndcapNameUpgrade(DetId(id)).diskName();
+	  int blade  = PixelEndcapNameUpgrade(DetId(id)).bladeName();
+	  int panel  = PixelEndcapNameUpgrade(DetId(id)).pannelName();
+	  int module = PixelEndcapNameUpgrade(DetId(id)).plaquetteName();
+
+	  char sside[80];  sprintf(sside,  "HalfCylinder_%i",side);
+	  char sdisk[80];  sprintf(sdisk,  "Disk_%i",disk);
+	  char sblade[80]; sprintf(sblade, "Blade_%02i",blade);
+	  char spanel[80]; sprintf(spanel, "Panel_%i",panel);
+	  char smodule[80];sprintf(smodule,"Module_%i",module);
+	  std::string side_str = sside;
+	  std::string disk_str = sdisk;
+	  bool mask = side_str.find("HalfCylinder_1")!=string::npos||
+	    side_str.find("HalfCylinder_2")!=string::npos||
+	    side_str.find("HalfCylinder_4")!=string::npos||
+	    disk_str.find("Disk_2")!=string::npos;
+	  if(isPIB && mask) continue;
+	
+	  thePixelStructure.insert(pair<uint32_t,SiPixelRecHitModulePhase1*> (id,theModule));
+	}
+      }
+    }	    
+  }
+
+  LogInfo ("PixelDQM") << " *** Pixel Structure Size " << thePixelStructure.size() << endl;
+}
+//------------------------------------------------------------------
+// Book MEs
+//------------------------------------------------------------------
+void SiPixelRecHitSourcePhase1::bookMEs(DQMStore::IBooker & iBooker){
+  
+  std::map<uint32_t,SiPixelRecHitModulePhase1*>::iterator struct_iter;
+    
+  SiPixelFolderOrganizer theSiPixelFolder(false);
+  
+  for(struct_iter = thePixelStructure.begin(); struct_iter != thePixelStructure.end(); struct_iter++){
+    
+    /// Create folder tree and book histograms 
+    if(modOn){
+      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,0)){
+	(*struct_iter).second->book( conf_,iBooker,0,twoDimOn, reducedSet);
+      } else {
+	if(!isPIB) throw cms::Exception("LogicError")
+	  << "[SiPixelDigiSource::bookMEs] Creation of DQM folder failed";
+      }
+    }
+    if(ladOn){
+      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,1)){
+	(*struct_iter).second->book( conf_,iBooker,1,twoDimOn, reducedSet);
+	} else {
+	LogDebug ("PixelDQM") << "PROBLEM WITH LADDER-FOLDER\n";
+      }
+    }
+    if(layOn){
+      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,2)){
+	(*struct_iter).second->book( conf_,iBooker,2,twoDimOn, reducedSet);
+	} else {
+	LogDebug ("PixelDQM") << "PROBLEM WITH LAYER-FOLDER\n";
+      }
+    }
+    if(phiOn){
+      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,3)){
+	(*struct_iter).second->book( conf_,iBooker,3,twoDimOn, reducedSet);
+	} else {
+	LogDebug ("PixelDQM") << "PROBLEM WITH PHI-FOLDER\n";
+      }
+    }
+    if(bladeOn){
+      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,4)){
+	(*struct_iter).second->book( conf_,iBooker,4,twoDimOn, reducedSet);
+	} else {
+	LogDebug ("PixelDQM") << "PROBLEM WITH BLADE-FOLDER\n";
+      }
+    }
+    if(diskOn){
+      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,5)){
+	(*struct_iter).second->book( conf_,iBooker,5,twoDimOn, reducedSet);
+	} else {
+	LogDebug ("PixelDQM") << "PROBLEM WITH DISK-FOLDER\n";
+      }
+    }
+    if(ringOn){
+      if(theSiPixelFolder.setModuleFolder(iBooker,(*struct_iter).first,6)){
+	(*struct_iter).second->book( conf_,iBooker,6,twoDimOn, reducedSet);
+	} else {
+	LogDebug ("PixelDQM") << "PROBLEM WITH RING-FOLDER\n";
+      }
+    }
+
+  }
+
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(SiPixelRecHitSourcePhase1);

--- a/DQM/SiPixelMonitorTrack/interface/SiPixelHitEfficiencyModule.h
+++ b/DQM/SiPixelMonitorTrack/interface/SiPixelHitEfficiencyModule.h
@@ -30,7 +30,7 @@ class SiPixelHitEfficiencyModule {
     SiPixelHitEfficiencyModule(const uint32_t);
    ~SiPixelHitEfficiencyModule();
 
-   void book(const edm::ParameterSet&, DQMStore::IBooker &, int type=0, bool isUpgrade=false);
+   void book(const edm::ParameterSet&, DQMStore::IBooker &, int type=0);
    void fill(const LocalTrajectoryParameters& ltp, bool isHitValid, bool modon=true, bool ladon=true, bool layon=true, bool phion = true, bool bladeon=true, bool diskon=true, bool ringon=true);
    void computeEfficiencies(bool modon=true, bool ladon=true, bool layon=true, bool phion = true, bool bladeon=true, bool diskon=true, bool ringon=true);
    std::pair<double,double> eff(double nValid, double nMissing);

--- a/DQM/SiPixelMonitorTrack/interface/SiPixelHitEfficiencyModulePhase1.h
+++ b/DQM/SiPixelMonitorTrack/interface/SiPixelHitEfficiencyModulePhase1.h
@@ -1,0 +1,176 @@
+// Package:    SiPixelMonitorTrack
+// Class:      SiPixelHitEfficiencyModulePhase1
+// 
+// class SiPixelHitEfficiencyModulePhase1 SiPixelHitEfficiencyModulePhase1.h 
+//       DQM/SiPixelMonitorTrack/src/SiPixelHitEfficiencyModulePhase1.h
+//
+// Description: SiPixel hit efficiency data quality monitoring modules
+// Implementation: prototype -> improved -> never final - end of the 1st step 
+//
+// Original Authors: Romain Rougny & Luca Mucibello
+//         Created: Mar Nov 10 13:29:00 CET 2009
+
+
+#ifndef SiPixelMonitorTrack_SiPixelHitEfficiencyModulePhase1_h
+#define SiPixelMonitorTrack_SiPixelHitEfficiencyModulePhase1_h
+
+
+#include <boost/cstdint.hpp>
+#include <utility>
+
+//#include "DataFormats/GeometryCommonDetAlgo/interface/MeasurementVector.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
+#include "DataFormats/TrajectoryState/interface/LocalTrajectoryParameters.h"
+
+class SiPixelHitEfficiencyModulePhase1 { 
+  public:
+    SiPixelHitEfficiencyModulePhase1();
+    SiPixelHitEfficiencyModulePhase1(const uint32_t);
+   ~SiPixelHitEfficiencyModulePhase1();
+
+   void book(const edm::ParameterSet&, DQMStore::IBooker &, int type=0);
+   void fill(const LocalTrajectoryParameters& ltp, bool isHitValid, bool modon=true, bool ladon=true, bool layon=true, bool phion = true, bool bladeon=true, bool diskon=true, bool ringon=true);
+   void computeEfficiencies(bool modon=true, bool ladon=true, bool layon=true, bool phion = true, bool bladeon=true, bool diskon=true, bool ringon=true);
+   std::pair<double,double> eff(double nValid, double nMissing);
+   
+  private:
+    uint32_t id_; 
+    bool bBookTracks;
+    bool debug_;
+    bool updateEfficiencies;
+    
+    //EFFICIENCY
+    MonitorElement* meEfficiency_;
+    MonitorElement* meEfficiencyX_;
+    MonitorElement* meEfficiencyY_;
+    MonitorElement* meEfficiencyAlpha_;
+    MonitorElement* meEfficiencyBeta_;
+    
+    MonitorElement* meEfficiencyLad_;
+    MonitorElement* meEfficiencyXLad_;
+    MonitorElement* meEfficiencyYLad_;
+    MonitorElement* meEfficiencyAlphaLad_;
+    MonitorElement* meEfficiencyBetaLad_;
+    
+    MonitorElement* meEfficiencyLay_;
+    MonitorElement* meEfficiencyXLay_;
+    MonitorElement* meEfficiencyYLay_;
+    MonitorElement* meEfficiencyAlphaLay_;
+    MonitorElement* meEfficiencyBetaLay_;
+    
+    MonitorElement* meEfficiencyPhi_;
+    MonitorElement* meEfficiencyXPhi_;
+    MonitorElement* meEfficiencyYPhi_;
+    MonitorElement* meEfficiencyAlphaPhi_;
+    MonitorElement* meEfficiencyBetaPhi_;
+    
+    MonitorElement* meEfficiencyBlade_;
+    MonitorElement* meEfficiencyXBlade_;
+    MonitorElement* meEfficiencyYBlade_;
+    MonitorElement* meEfficiencyAlphaBlade_;
+    MonitorElement* meEfficiencyBetaBlade_;
+    
+    MonitorElement* meEfficiencyDisk_;
+    MonitorElement* meEfficiencyXDisk_;
+    MonitorElement* meEfficiencyYDisk_;
+    MonitorElement* meEfficiencyAlphaDisk_;
+    MonitorElement* meEfficiencyBetaDisk_;
+    
+    MonitorElement* meEfficiencyRing_;
+    MonitorElement* meEfficiencyXRing_;
+    MonitorElement* meEfficiencyYRing_;
+    MonitorElement* meEfficiencyAlphaRing_;
+    MonitorElement* meEfficiencyBetaRing_;
+    
+    //VALID HITS
+    MonitorElement* meValid_;
+    MonitorElement* meValidX_;
+    MonitorElement* meValidY_;
+    MonitorElement* meValidAlpha_;
+    MonitorElement* meValidBeta_;
+    
+    MonitorElement* meValidLad_;
+    MonitorElement* meValidXLad_;
+    MonitorElement* meValidYLad_;
+    MonitorElement* meValidModLad_;
+    MonitorElement* meValidAlphaLad_;
+    MonitorElement* meValidBetaLad_;
+    
+    MonitorElement* meValidLay_;
+    MonitorElement* meValidXLay_;
+    MonitorElement* meValidYLay_;
+    MonitorElement* meValidAlphaLay_;
+    MonitorElement* meValidBetaLay_;
+    
+    MonitorElement* meValidPhi_;
+    MonitorElement* meValidXPhi_;
+    MonitorElement* meValidYPhi_;
+    MonitorElement* meValidAlphaPhi_;
+    MonitorElement* meValidBetaPhi_;
+    
+    MonitorElement* meValidBlade_;
+    MonitorElement* meValidXBlade_;
+    MonitorElement* meValidYBlade_;
+    MonitorElement* meValidAlphaBlade_;
+    MonitorElement* meValidBetaBlade_;
+    
+    MonitorElement* meValidDisk_;
+    MonitorElement* meValidXDisk_;
+    MonitorElement* meValidYDisk_;
+    MonitorElement* meValidAlphaDisk_;
+    MonitorElement* meValidBetaDisk_;
+    
+    MonitorElement* meValidRing_;
+    MonitorElement* meValidXRing_;
+    MonitorElement* meValidYRing_;
+    MonitorElement* meValidAlphaRing_;
+    MonitorElement* meValidBetaRing_;
+    
+    //MISSING HITS
+    MonitorElement* meMissing_;
+    MonitorElement* meMissingX_;
+    MonitorElement* meMissingY_;
+    MonitorElement* meMissingAlpha_;
+    MonitorElement* meMissingBeta_;
+    
+    MonitorElement* meMissingLad_;
+    MonitorElement* meMissingXLad_;
+    MonitorElement* meMissingYLad_;
+    MonitorElement* meMissingModLad_;
+    MonitorElement* meMissingAlphaLad_;
+    MonitorElement* meMissingBetaLad_;
+    
+    MonitorElement* meMissingLay_;
+    MonitorElement* meMissingXLay_;
+    MonitorElement* meMissingYLay_;
+    MonitorElement* meMissingAlphaLay_;
+    MonitorElement* meMissingBetaLay_;
+    
+    MonitorElement* meMissingPhi_;
+    MonitorElement* meMissingXPhi_;
+    MonitorElement* meMissingYPhi_;
+    MonitorElement* meMissingAlphaPhi_;
+    MonitorElement* meMissingBetaPhi_;
+    
+    MonitorElement* meMissingBlade_;
+    MonitorElement* meMissingXBlade_;
+    MonitorElement* meMissingYBlade_;
+    MonitorElement* meMissingAlphaBlade_;
+    MonitorElement* meMissingBetaBlade_;
+    
+    MonitorElement* meMissingDisk_;
+    MonitorElement* meMissingXDisk_;
+    MonitorElement* meMissingYDisk_;
+    MonitorElement* meMissingAlphaDisk_;
+    MonitorElement* meMissingBetaDisk_;
+    
+    MonitorElement* meMissingRing_;
+    MonitorElement* meMissingXRing_;
+    MonitorElement* meMissingYRing_;
+    MonitorElement* meMissingAlphaRing_;
+    MonitorElement* meMissingBetaRing_;
+};
+
+#endif

--- a/DQM/SiPixelMonitorTrack/interface/SiPixelHitEfficiencySource.h
+++ b/DQM/SiPixelMonitorTrack/interface/SiPixelHitEfficiencySource.h
@@ -84,8 +84,6 @@ class SiPixelHitEfficiencySource : public thread_unsafe::DQMEDAnalyzer {
     double vtxndof_;
     double vtxchi2_;
 
-    bool isUpgrade;
-
 };
 
 #endif

--- a/DQM/SiPixelMonitorTrack/interface/SiPixelHitEfficiencySourcePhase1.h
+++ b/DQM/SiPixelMonitorTrack/interface/SiPixelHitEfficiencySourcePhase1.h
@@ -1,0 +1,89 @@
+#ifndef SiPixelHitEfficiencySourcePhase1_H
+#define SiPixelHitEfficiencySourcePhase1_H
+
+// Package: SiPixelMonitorTrack
+// Class:   SiPixelHitEfficiencySourcePhase1
+// 
+// class SiPixelHitEfficiencySourcePhase1 SiPixelHitEfficiencySourcePhase1.h 
+//       DQM/SiPixelMonitorTrack/interface/SiPixelHitEfficiencySourcePhase1.h
+// 
+// Description:    <one line class summary>
+// Implementation: <Notes on implementation>
+//
+//
+// Original Authors: Romain Rougny & Luca Mucibello
+//         Created: Mar Nov 10 13:29:00 CET 2009
+
+
+#include <boost/cstdint.hpp>
+
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+#include "DQM/SiPixelMonitorTrack/interface/SiPixelHitEfficiencyModulePhase1.h"
+
+//Files added for monitoring track quantities
+#include "Alignment/TrackerAlignment/interface/TrackerAlignableId.h"
+#include "Alignment/OfflineValidation/interface/TrackerValidationVariables.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
+#include "Geometry/TrackerGeometryBuilder/interface/RectangularPixelTopology.h"
+#include "DataFormats/SiPixelDetId/interface/PixelBarrelName.h"
+#include "DataFormats/SiPixelDetId/interface/PixelBarrelNameUpgrade.h"
+#include "DataFormats/SiPixelDetId/interface/PixelEndcapName.h"
+#include "DataFormats/SiPixelDetId/interface/PixelEndcapNameUpgrade.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
+
+class SiPixelHitEfficiencySourcePhase1 : public thread_unsafe::DQMEDAnalyzer {
+  public:
+    explicit SiPixelHitEfficiencySourcePhase1(const edm::ParameterSet&);
+            ~SiPixelHitEfficiencySourcePhase1();
+
+    virtual void dqmBeginRun(const edm::Run& r, edm::EventSetup const& iSetup);
+    virtual void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
+    virtual void analyze(const edm::Event&, const edm::EventSetup&);
+
+  private: 
+    edm::ParameterSet pSet_; 
+    edm::InputTag src_; 
+    // edm::InputTag tracksrc_;
+    edm::EDGetTokenT<reco::VertexCollection> vertexCollectionToken_;
+    edm::EDGetTokenT<TrajTrackAssociationCollection> tracksrc_;
+    edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster> > clusterCollectionToken_;
+    
+    edm::EDGetTokenT<MeasurementTrackerEvent> measurementTrackerEventToken_;
+
+    bool applyEdgeCut_;
+    double nSigma_EdgeCut_;
+    
+    bool debug_; 
+    bool modOn; 
+    //barrel:
+    bool ladOn, layOn, phiOn;
+    //forward:
+    bool ringOn, bladeOn, diskOn; 
+
+    bool firstRun;
+    
+    std::map<uint32_t, SiPixelHitEfficiencyModulePhase1*> theSiPixelStructure;
+    
+    int nmissing,nvalid; 
+    
+    int nvtx_;
+    int vtxntrk_;
+    double vtxD0_;
+    double vtxX_;
+    double vtxY_;
+    double vtxZ_;
+    double vtxndof_;
+    double vtxchi2_;
+
+};
+
+#endif

--- a/DQM/SiPixelMonitorTrack/interface/SiPixelTrackResidualModule.h
+++ b/DQM/SiPixelMonitorTrack/interface/SiPixelTrackResidualModule.h
@@ -30,7 +30,7 @@ class SiPixelTrackResidualModule {
     SiPixelTrackResidualModule(const uint32_t);
    ~SiPixelTrackResidualModule();
 
-   void book(const edm::ParameterSet&, DQMStore::IBooker &, bool reducedSet=true, int type=0, bool isUpgrade=false);
+   void book(const edm::ParameterSet&, DQMStore::IBooker &, bool reducedSet=true, int type=0);
    void fill(const Measurement2DVector&, bool reducedSet=true, bool modon=true, bool ladon=true, bool layon=true, bool phion = true, bool bladeon=true, bool diskon=true, bool ringon=true);
    void fill(const SiPixelCluster &clust, bool onTrack, double corrCharge, bool reducedSet,  bool modon, bool ladon, bool layon, bool phion, bool bladeon, bool diskon, bool ringon); 
    void nfill(int onTrack, int offTrack, bool reducedSet,  bool modon, bool ladon, bool layon, bool phion, bool bladeon, bool diskon, bool ringon);

--- a/DQM/SiPixelMonitorTrack/interface/SiPixelTrackResidualModulePhase1.h
+++ b/DQM/SiPixelMonitorTrack/interface/SiPixelTrackResidualModulePhase1.h
@@ -1,0 +1,137 @@
+// Package:    SiPixelMonitorTrack
+// Class:      SiPixelTrackResidualModulePhase1
+// 
+// class SiPixelTrackResidualModulePhase1 SiPixelTrackResidualModulePhase1.h 
+//       DQM/SiPixelMonitorTrack/src/SiPixelTrackResidualModulePhase1.h
+//
+// Description: SiPixel hit-to-track residual data quality monitoring modules
+// Implementation: prototype -> improved -> never final - end of the 1st step 
+//
+// Original Author: Shan-Huei Chuang
+//         Created: Fri Mar 23 18:41:42 CET 2007
+//         Updated by Lukas Wehrli (plots for clusters on/off track added)
+
+
+#ifndef SiPixelMonitorTrack_SiPixelTrackResidualModulePhase1_h
+#define SiPixelMonitorTrack_SiPixelTrackResidualModulePhase1_h
+
+
+#include <boost/cstdint.hpp>
+
+#include "DataFormats/GeometryCommonDetAlgo/interface/MeasurementVector.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
+
+
+class SiPixelTrackResidualModulePhase1 { 
+  public:
+    SiPixelTrackResidualModulePhase1();
+    SiPixelTrackResidualModulePhase1(const uint32_t);
+   ~SiPixelTrackResidualModulePhase1();
+
+   void book(const edm::ParameterSet&, DQMStore::IBooker &, bool reducedSet=true, int type=0);
+   void fill(const Measurement2DVector&, bool reducedSet=true, bool modon=true, bool ladon=true, bool layon=true, bool phion = true, bool bladeon=true, bool diskon=true, bool ringon=true);
+   void fill(const SiPixelCluster &clust, bool onTrack, double corrCharge, bool reducedSet,  bool modon, bool ladon, bool layon, bool phion, bool bladeon, bool diskon, bool ringon); 
+   void nfill(int onTrack, int offTrack, bool reducedSet,  bool modon, bool ladon, bool layon, bool phion, bool bladeon, bool diskon, bool ringon);
+  
+  private:
+    uint32_t id_; 
+    bool bBookTracks;
+
+
+    MonitorElement* meResidualX_;
+    MonitorElement* meResidualY_;
+    MonitorElement* meNClusters_onTrack_;
+    MonitorElement* meCharge_onTrack_;
+    MonitorElement* meSize_onTrack_;
+    MonitorElement* meSizeX_onTrack_;
+    MonitorElement* meSizeY_onTrack_;
+    MonitorElement* meNClusters_offTrack_;
+    MonitorElement* meCharge_offTrack_;
+    MonitorElement* meSize_offTrack_;
+    MonitorElement* meSizeX_offTrack_;
+    MonitorElement* meSizeY_offTrack_;
+
+    //barrel
+    MonitorElement* meResidualXLad_;
+    MonitorElement* meResidualYLad_;
+    MonitorElement* meNClusters_onTrackLad_;
+    MonitorElement* meCharge_onTrackLad_;
+    MonitorElement* meSize_onTrackLad_;
+    MonitorElement* meSizeX_onTrackLad_;
+    MonitorElement* meSizeY_onTrackLad_;
+    MonitorElement* meNClusters_offTrackLad_;
+    MonitorElement* meCharge_offTrackLad_;
+    MonitorElement* meSize_offTrackLad_;
+    MonitorElement* meSizeX_offTrackLad_;
+    MonitorElement* meSizeY_offTrackLad_;
+
+    MonitorElement* meResidualXLay_;
+    MonitorElement* meResidualYLay_;
+    MonitorElement* meNClusters_onTrackLay_;
+    MonitorElement* meCharge_onTrackLay_;
+    MonitorElement* meSize_onTrackLay_;
+    MonitorElement* meSizeX_onTrackLay_;
+    MonitorElement* meSizeY_onTrackLay_;
+    MonitorElement* meNClusters_offTrackLay_;
+    MonitorElement* meCharge_offTrackLay_;
+    MonitorElement* meSize_offTrackLay_;
+    MonitorElement* meSizeX_offTrackLay_;
+    MonitorElement* meSizeY_offTrackLay_;
+
+    MonitorElement* meResidualXPhi_;
+    MonitorElement* meResidualYPhi_;
+    MonitorElement* meNClusters_onTrackPhi_;
+    MonitorElement* meCharge_onTrackPhi_;
+    MonitorElement* meSize_onTrackPhi_;
+    MonitorElement* meSizeX_onTrackPhi_;
+    MonitorElement* meSizeY_onTrackPhi_;
+    MonitorElement* meNClusters_offTrackPhi_;
+    MonitorElement* meCharge_offTrackPhi_;
+    MonitorElement* meSize_offTrackPhi_;
+    MonitorElement* meSizeX_offTrackPhi_;
+    MonitorElement* meSizeY_offTrackPhi_;
+
+    //forward
+    MonitorElement* meResidualXBlade_;
+    MonitorElement* meResidualYBlade_;
+    MonitorElement* meNClusters_onTrackBlade_;
+    MonitorElement* meCharge_onTrackBlade_;
+    MonitorElement* meSize_onTrackBlade_;
+    MonitorElement* meSizeX_onTrackBlade_;
+    MonitorElement* meSizeY_onTrackBlade_;
+    MonitorElement* meNClusters_offTrackBlade_;
+    MonitorElement* meCharge_offTrackBlade_;
+    MonitorElement* meSize_offTrackBlade_;
+    MonitorElement* meSizeX_offTrackBlade_;
+    MonitorElement* meSizeY_offTrackBlade_;
+
+    MonitorElement* meResidualXDisk_;
+    MonitorElement* meResidualYDisk_;
+    MonitorElement* meNClusters_onTrackDisk_;
+    MonitorElement* meCharge_onTrackDisk_;
+    MonitorElement* meSize_onTrackDisk_;
+    MonitorElement* meSizeX_onTrackDisk_;
+    MonitorElement* meSizeY_onTrackDisk_;
+    MonitorElement* meNClusters_offTrackDisk_;
+    MonitorElement* meCharge_offTrackDisk_;
+    MonitorElement* meSize_offTrackDisk_;
+    MonitorElement* meSizeX_offTrackDisk_;
+    MonitorElement* meSizeY_offTrackDisk_;
+
+    MonitorElement* meResidualXRing_;
+    MonitorElement* meResidualYRing_;
+    MonitorElement* meNClusters_onTrackRing_;
+    MonitorElement* meCharge_onTrackRing_;
+    MonitorElement* meSize_onTrackRing_;
+    MonitorElement* meSizeX_onTrackRing_;
+    MonitorElement* meSizeY_onTrackRing_;
+    MonitorElement* meNClusters_offTrackRing_;
+    MonitorElement* meCharge_offTrackRing_;
+    MonitorElement* meSize_offTrackRing_;
+    MonitorElement* meSizeX_offTrackRing_;
+    MonitorElement* meSizeY_offTrackRing_;
+};
+
+#endif

--- a/DQM/SiPixelMonitorTrack/interface/SiPixelTrackResidualSource.h
+++ b/DQM/SiPixelMonitorTrack/interface/SiPixelTrackResidualSource.h
@@ -76,7 +76,6 @@ class SiPixelTrackResidualSource : public thread_unsafe::DQMEDAnalyzer {
     bool ladOn, layOn, phiOn;
     //forward:
     bool ringOn, bladeOn, diskOn; 
-    bool isUpgrade;
     double ptminres_;
     bool firstRun;
     int NTotal;

--- a/DQM/SiPixelMonitorTrack/interface/SiPixelTrackResidualSourcePhase1.h
+++ b/DQM/SiPixelMonitorTrack/interface/SiPixelTrackResidualSourcePhase1.h
@@ -1,0 +1,252 @@
+#ifndef SiPixelTrackResidualSourcePhase1_H
+#define SiPixelTrackResidualSourcePhase1_H
+
+// Package: SiPixelMonitorTrack
+// Class:   SiPixelTrackResidualSourcePhase1
+// 
+// class SiPixelTrackResidualSourcePhase1 SiPixelTrackResidualSourcePhase1.h 
+//       DQM/SiPixelMonitorTrack/interface/SiPixelTrackResidualSourcePhase1.h
+// 
+// Description:    <one line class summary>
+// Implementation: <Notes on implementation>
+//
+// Original Author: Shan-Huei Chuang
+//         Created: Fri Mar 23 18:41:42 CET 2007
+//
+// Updated by: Lukas Wehrli
+// for pixel offline DQM 
+
+#include <boost/cstdint.hpp>
+
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+#include "DQM/SiPixelMonitorTrack/interface/SiPixelTrackResidualModulePhase1.h"
+
+//Files added for monitoring track quantities
+#include "Alignment/TrackerAlignment/interface/TrackerAlignableId.h"
+#include "Alignment/OfflineValidation/interface/TrackerValidationVariables.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
+#include "DataFormats/SiPixelDetId/interface/PixelBarrelName.h"
+#include "DataFormats/SiPixelDetId/interface/PixelBarrelNameUpgrade.h"
+#include "DataFormats/SiPixelDetId/interface/PixelEndcapName.h"
+#include "DataFormats/SiPixelDetId/interface/PixelEndcapNameUpgrade.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+
+#include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
+
+
+class SiPixelTrackResidualSourcePhase1 : public thread_unsafe::DQMEDAnalyzer {
+  public:
+    explicit SiPixelTrackResidualSourcePhase1(const edm::ParameterSet&);
+            ~SiPixelTrackResidualSourcePhase1();
+
+    virtual void dqmBeginRun(const edm::Run& r, edm::EventSetup const& iSetup);
+    virtual void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
+    virtual void analyze(const edm::Event&, const edm::EventSetup&);
+    void triplets(double x1,double y1,double z1,double x2,double y2,double z2,double x3,double y3,double z3,
+                  double ptsig, double & dc,double & dz, double kap); 
+  private: 
+    edm::ParameterSet pSet_; 
+    edm::InputTag src_; 
+    edm::InputTag clustersrc_; 
+    edm::InputTag tracksrc_; 
+    std::string ttrhbuilder_; 
+    edm::EDGetTokenT<reco::BeamSpot> beamSpotToken_;
+    edm::EDGetTokenT<reco::VertexCollection> offlinePrimaryVerticesToken_;
+    edm::EDGetTokenT<reco::TrackCollection> generalTracksToken_;
+    edm::EDGetTokenT<std::vector<Trajectory> > tracksrcToken_;
+    edm::EDGetTokenT<std::vector<reco::Track> > trackToken_;
+    edm::EDGetTokenT<TrajTrackAssociationCollection> trackAssociationToken_;
+    edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster> > clustersrcToken_;
+
+
+    bool debug_; 
+    bool modOn; 
+    bool reducedSet;
+    //barrel:
+    bool ladOn, layOn, phiOn;
+    //forward:
+    bool ringOn, bladeOn, diskOn; 
+    double ptminres_;
+    bool firstRun;
+    int NTotal;
+    int NLowProb;
+    
+    std::map<uint32_t, SiPixelTrackResidualModulePhase1*> theSiPixelStructure; 
+
+    MonitorElement* meSubdetResidualX[3];
+    MonitorElement* meSubdetResidualY[3];
+
+    MonitorElement* meNofTracks_;
+    MonitorElement* meNofTracksInPixVol_;
+    MonitorElement* meNofClustersOnTrack_;
+    MonitorElement* meNofClustersNotOnTrack_;
+    MonitorElement* meClChargeOnTrack_all; 
+    MonitorElement* meClChargeOnTrack_bpix; 
+    MonitorElement* meClChargeOnTrack_fpix; 
+    MonitorElement* meClChargeOnTrack_layer1; 
+    MonitorElement* meClChargeOnTrack_layer2; 
+    MonitorElement* meClChargeOnTrack_layer3; 
+    MonitorElement* meClChargeOnTrack_layer4;
+    MonitorElement* meClChargeOnTrack_diskp1; 
+    MonitorElement* meClChargeOnTrack_diskp2; 
+    MonitorElement* meClChargeOnTrack_diskp3;
+    MonitorElement* meClChargeOnTrack_diskm1; 
+    MonitorElement* meClChargeOnTrack_diskm2; 
+    MonitorElement* meClChargeOnTrack_diskm3;
+    MonitorElement* meClChargeNotOnTrack_all; 
+    MonitorElement* meClChargeNotOnTrack_bpix; 
+    MonitorElement* meClChargeNotOnTrack_fpix; 
+    MonitorElement* meClChargeNotOnTrack_layer1; 
+    MonitorElement* meClChargeNotOnTrack_layer2; 
+    MonitorElement* meClChargeNotOnTrack_layer3; 
+    MonitorElement* meClChargeNotOnTrack_layer4; 
+    MonitorElement* meClChargeNotOnTrack_diskp1; 
+    MonitorElement* meClChargeNotOnTrack_diskp2; 
+    MonitorElement* meClChargeNotOnTrack_diskp3;
+    MonitorElement* meClChargeNotOnTrack_diskm1; 
+    MonitorElement* meClChargeNotOnTrack_diskm2;
+    MonitorElement* meClChargeNotOnTrack_diskm3;
+    MonitorElement* meClSizeOnTrack_all; 
+    MonitorElement* meClSizeOnTrack_bpix; 
+    MonitorElement* meClSizeOnTrack_fpix; 
+    MonitorElement* meClSizeOnTrack_layer1; 
+    MonitorElement* meClSizeOnTrack_layer2; 
+    MonitorElement* meClSizeOnTrack_layer3; 
+    MonitorElement* meClSizeOnTrack_layer4; 
+    MonitorElement* meClSizeOnTrack_diskp1; 
+    MonitorElement* meClSizeOnTrack_diskp2; 
+    MonitorElement* meClSizeOnTrack_diskp3;
+    MonitorElement* meClSizeOnTrack_diskm1; 
+    MonitorElement* meClSizeOnTrack_diskm2; 
+    MonitorElement* meClSizeOnTrack_diskm3;
+    MonitorElement* meClSizeNotOnTrack_all; 
+    MonitorElement* meClSizeNotOnTrack_bpix; 
+    MonitorElement* meClSizeNotOnTrack_fpix; 
+    MonitorElement* meClSizeNotOnTrack_layer1; 
+    MonitorElement* meClSizeNotOnTrack_layer2; 
+    MonitorElement* meClSizeNotOnTrack_layer3; 
+    MonitorElement* meClSizeNotOnTrack_layer4; 
+    MonitorElement* meClSizeNotOnTrack_diskp1; 
+    MonitorElement* meClSizeNotOnTrack_diskp2; 
+    MonitorElement* meClSizeNotOnTrack_diskp3; 
+    MonitorElement* meClSizeNotOnTrack_diskm1; 
+    MonitorElement* meClSizeNotOnTrack_diskm2;
+    MonitorElement* meClSizeNotOnTrack_diskm3;
+    MonitorElement* meClSizeXOnTrack_all; 
+    MonitorElement* meClSizeXOnTrack_bpix; 
+    MonitorElement* meClSizeXOnTrack_fpix; 
+    MonitorElement* meClSizeXOnTrack_layer1; 
+    MonitorElement* meClSizeXOnTrack_layer2; 
+    MonitorElement* meClSizeXOnTrack_layer3; 
+    MonitorElement* meClSizeXOnTrack_layer4; 
+    MonitorElement* meClSizeXOnTrack_diskp1; 
+    MonitorElement* meClSizeXOnTrack_diskp2; 
+    MonitorElement* meClSizeXOnTrack_diskp3; 
+    MonitorElement* meClSizeXOnTrack_diskm1; 
+    MonitorElement* meClSizeXOnTrack_diskm2; 
+    MonitorElement* meClSizeXOnTrack_diskm3; 
+    MonitorElement* meClSizeXNotOnTrack_all; 
+    MonitorElement* meClSizeXNotOnTrack_bpix; 
+    MonitorElement* meClSizeXNotOnTrack_fpix; 
+    MonitorElement* meClSizeXNotOnTrack_layer1; 
+    MonitorElement* meClSizeXNotOnTrack_layer2; 
+    MonitorElement* meClSizeXNotOnTrack_layer3; 
+    MonitorElement* meClSizeXNotOnTrack_layer4; 
+    MonitorElement* meClSizeXNotOnTrack_diskp1; 
+    MonitorElement* meClSizeXNotOnTrack_diskp2; 
+    MonitorElement* meClSizeXNotOnTrack_diskp3; 
+    MonitorElement* meClSizeXNotOnTrack_diskm1; 
+    MonitorElement* meClSizeXNotOnTrack_diskm2;
+    MonitorElement* meClSizeXNotOnTrack_diskm3;
+    MonitorElement* meClSizeYOnTrack_all; 
+    MonitorElement* meClSizeYOnTrack_bpix; 
+    MonitorElement* meClSizeYOnTrack_fpix; 
+    MonitorElement* meClSizeYOnTrack_layer1; 
+    MonitorElement* meClSizeYOnTrack_layer2; 
+    MonitorElement* meClSizeYOnTrack_layer3; 
+    MonitorElement* meClSizeYOnTrack_layer4; 
+    MonitorElement* meClSizeYOnTrack_diskp1; 
+    MonitorElement* meClSizeYOnTrack_diskp2; 
+    MonitorElement* meClSizeYOnTrack_diskp3; 
+    MonitorElement* meClSizeYOnTrack_diskm1; 
+    MonitorElement* meClSizeYOnTrack_diskm2; 
+    MonitorElement* meClSizeYOnTrack_diskm3;
+    MonitorElement* meClSizeYNotOnTrack_all; 
+    MonitorElement* meClSizeYNotOnTrack_bpix; 
+    MonitorElement* meClSizeYNotOnTrack_fpix; 
+    MonitorElement* meClSizeYNotOnTrack_layer1; 
+    MonitorElement* meClSizeYNotOnTrack_layer2; 
+    MonitorElement* meClSizeYNotOnTrack_layer3; 
+    MonitorElement* meClSizeYNotOnTrack_layer4; 
+    MonitorElement* meClSizeYNotOnTrack_diskp1; 
+    MonitorElement* meClSizeYNotOnTrack_diskp2; 
+    MonitorElement* meClSizeYNotOnTrack_diskp3; 
+    MonitorElement* meClSizeYNotOnTrack_diskm1; 
+    MonitorElement* meClSizeYNotOnTrack_diskm2;
+    MonitorElement* meClSizeYNotOnTrack_diskm3;
+
+    //new
+    MonitorElement* meNClustersOnTrack_all;
+    MonitorElement* meNClustersOnTrack_bpix;
+    MonitorElement* meNClustersOnTrack_fpix; 
+    MonitorElement* meNClustersOnTrack_layer1; 
+    MonitorElement* meNClustersOnTrack_layer2; 
+    MonitorElement* meNClustersOnTrack_layer3; 
+    MonitorElement* meNClustersOnTrack_layer4; 
+    MonitorElement* meNClustersOnTrack_diskp1; 
+    MonitorElement* meNClustersOnTrack_diskp2; 
+    MonitorElement* meNClustersOnTrack_diskp3; 
+    MonitorElement* meNClustersOnTrack_diskm1; 
+    MonitorElement* meNClustersOnTrack_diskm2; 
+    MonitorElement* meNClustersOnTrack_diskm3; 
+    MonitorElement* meNClustersNotOnTrack_all; 
+    MonitorElement* meNClustersNotOnTrack_bpix; 
+    MonitorElement* meNClustersNotOnTrack_fpix; 
+    MonitorElement* meNClustersNotOnTrack_layer1; 
+    MonitorElement* meNClustersNotOnTrack_layer2; 
+    MonitorElement* meNClustersNotOnTrack_layer3; 
+    MonitorElement* meNClustersNotOnTrack_layer4; 
+    MonitorElement* meNClustersNotOnTrack_diskp1; 
+    MonitorElement* meNClustersNotOnTrack_diskp2; 
+    MonitorElement* meNClustersNotOnTrack_diskp3; 
+    MonitorElement* meNClustersNotOnTrack_diskm1; 
+    MonitorElement* meNClustersNotOnTrack_diskm2;
+    MonitorElement* meNClustersNotOnTrack_diskm3;
+    //
+
+    MonitorElement* meClPosLayer1OnTrack; 
+    MonitorElement* meClPosLayer2OnTrack; 
+    MonitorElement* meClPosLayer3OnTrack; 
+    MonitorElement* meClPosLayer4OnTrack; 
+    MonitorElement* meClPosLayer1NotOnTrack; 
+    MonitorElement* meClPosLayer2NotOnTrack; 
+    MonitorElement* meClPosLayer3NotOnTrack; 
+    MonitorElement* meClPosLayer4NotOnTrack; 
+
+    MonitorElement* meClPosDisk1pzOnTrack; 
+    MonitorElement* meClPosDisk2pzOnTrack; 
+    MonitorElement* meClPosDisk3pzOnTrack; 
+    MonitorElement* meClPosDisk1mzOnTrack; 
+    MonitorElement* meClPosDisk2mzOnTrack; 
+    MonitorElement* meClPosDisk3mzOnTrack; 
+    MonitorElement* meClPosDisk1pzNotOnTrack; 
+    MonitorElement* meClPosDisk2pzNotOnTrack; 
+    MonitorElement* meClPosDisk3pzNotOnTrack; 
+    MonitorElement* meClPosDisk1mzNotOnTrack; 
+    MonitorElement* meClPosDisk2mzNotOnTrack; 
+    MonitorElement* meClPosDisk3mzNotOnTrack; 
+    
+    MonitorElement* meHitProbability;
+};
+
+#endif

--- a/DQM/SiPixelMonitorTrack/python/SiPixelMonitorEfficiency_cfi.py
+++ b/DQM/SiPixelMonitorTrack/python/SiPixelMonitorEfficiency_cfi.py
@@ -18,3 +18,22 @@ SiPixelHitEfficiencySource = cms.EDAnalyzer("SiPixelHitEfficiencySource",
     applyEdgeCut = cms.untracked.bool(False),
     nSigma_EdgeCut = cms.untracked.double(2.)             
 )
+
+SiPixelHitEfficiencySourcePhase1 = cms.EDAnalyzer("SiPixelHitEfficiencySourcePhase1",
+    src = cms.InputTag("siPixelHitEfficiency"),
+    debug = cms.untracked.bool(False),                          
+    saveFile = cms.untracked.bool(True),
+    outputFile = cms.string('Pixel_DQM_HitEfficiency.root'),
+    modOn = cms.untracked.bool(False),
+    ladOn = cms.untracked.bool(True),
+    layOn = cms.untracked.bool(False),
+    phiOn = cms.untracked.bool(False),
+    ringOn = cms.untracked.bool(False),
+    bladeOn = cms.untracked.bool(True),
+    diskOn = cms.untracked.bool(False),
+    updateEfficiencies = cms.untracked.bool(False), 
+
+    trajectoryInput = cms.InputTag('rsWithMaterialTracksP5'),  
+    applyEdgeCut = cms.untracked.bool(False),
+    nSigma_EdgeCut = cms.untracked.double(2.)             
+)

--- a/DQM/SiPixelMonitorTrack/python/SiPixelMonitorTrack_Cosmics_cfi.py
+++ b/DQM/SiPixelMonitorTrack/python/SiPixelMonitorTrack_Cosmics_cfi.py
@@ -26,3 +26,30 @@ SiPixelTrackResidualSource_Cosmics = cms.EDAnalyzer("SiPixelTrackResidualSource"
 #    trajectoryInput = cms.InputTag('rsWithMaterialTracksP5')              
     trajectoryInput = cms.InputTag('ctfWithMaterialTracksP5')              
 )
+
+SiPixelTrackResidualSource_CosmicsPhase1 = cms.EDAnalyzer("SiPixelTrackResidualSourcePhase1",
+    src = cms.InputTag("siPixelTrackResiduals"),
+    clustersrc = cms.InputTag("siPixelClusters"),                            
+    debug = cms.untracked.bool(False),                          
+    saveFile = cms.untracked.bool(False),
+    outputFile = cms.string('Pixel_DQM_TrackResidual.root'),
+# (SK) keep rstracks commented out in case of resurrection
+#    TrackCandidateProducer = cms.string('rsTrackCandidatesP5'),
+    TrackCandidateProducer = cms.string('ckfTrackCandidatesP5'),
+    TrackCandidateLabel = cms.string(''),
+    TTRHBuilder = cms.string('WithTrackAngle'),
+    Fitter = cms.string('KFFittingSmootherWithOutliersRejectionAndRK'),
+    modOn = cms.untracked.bool(False),
+    reducedSet = cms.untracked.bool(True),
+    ladOn = cms.untracked.bool(True),
+    layOn = cms.untracked.bool(True),
+    phiOn = cms.untracked.bool(True),
+    ringOn = cms.untracked.bool(True),
+    bladeOn = cms.untracked.bool(True),
+    diskOn = cms.untracked.bool(True),
+    PtMinRes = cms.untracked.double(4.0),
+                                                    
+# (SK) keep rstracks commented out in case of resurrection
+#    trajectoryInput = cms.InputTag('rsWithMaterialTracksP5')              
+    trajectoryInput = cms.InputTag('ctfWithMaterialTracksP5')              
+)

--- a/DQM/SiPixelMonitorTrack/python/SiPixelMonitorTrack_cfi.py
+++ b/DQM/SiPixelMonitorTrack/python/SiPixelMonitorTrack_cfi.py
@@ -22,3 +22,26 @@ SiPixelTrackResidualSource = cms.EDAnalyzer("SiPixelTrackResidualSource",
 
     trajectoryInput = cms.InputTag('generalTracks')              
 )
+
+SiPixelTrackResidualSourcePhase1 = cms.EDAnalyzer("SiPixelTrackResidualSourcePhase1",
+    src = cms.InputTag("siPixelTrackResiduals"),
+    clustersrc = cms.InputTag("siPixelClusters"),                            
+    debug = cms.untracked.bool(False),                          
+    saveFile = cms.untracked.bool(False),
+    outputFile = cms.string('Pixel_DQM_TrackResidual.root'),
+    TrackCandidateProducer = cms.string('initialStepTrackCandidates'),
+    TrackCandidateLabel = cms.string(''),
+    TTRHBuilder = cms.string('WithTrackAngle'),
+    Fitter = cms.string('KFFittingSmootherWithOutliersRejectionAndRK'),
+    modOn = cms.untracked.bool(False),
+    reducedSet = cms.untracked.bool(True),
+    ladOn = cms.untracked.bool(True),
+    layOn = cms.untracked.bool(True),
+    phiOn = cms.untracked.bool(True),
+    ringOn = cms.untracked.bool(True),
+    bladeOn = cms.untracked.bool(True),
+    diskOn = cms.untracked.bool(True),
+    PtMinRes = cms.untracked.double(4.0),
+
+    trajectoryInput = cms.InputTag('generalTracks')              
+)

--- a/DQM/SiPixelMonitorTrack/src/SiPixelHitEfficiencyModule.cc
+++ b/DQM/SiPixelMonitorTrack/src/SiPixelHitEfficiencyModule.cc
@@ -51,17 +51,13 @@ SiPixelHitEfficiencyModule::~SiPixelHitEfficiencyModule() {
 }
 
 
-void SiPixelHitEfficiencyModule::book(const edm::ParameterSet& iConfig, DQMStore::IBooker & iBooker,int type, bool isUpgrade) {
+void SiPixelHitEfficiencyModule::book(const edm::ParameterSet& iConfig, DQMStore::IBooker & iBooker,int type) {
   
   bool barrel = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
   bool endcap = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap);
   bool isHalfModule = false;
   if(barrel){
-    if (!isUpgrade) {
-    isHalfModule = PixelBarrelName(DetId(id_)).isHalfModule(); 
-    } else if (isUpgrade) {
-      isHalfModule = PixelBarrelNameUpgrade(DetId(id_)).isHalfModule(); 
-    }
+    isHalfModule = PixelBarrelName(DetId(id_)).isHalfModule();
   }
 
   edm::InputTag src = iConfig.getParameter<edm::InputTag>("src");
@@ -114,8 +110,7 @@ void SiPixelHitEfficiencyModule::book(const edm::ParameterSet& iConfig, DQMStore
 
   if(type==1 && barrel){
     uint32_t DBladder;
-    if (!isUpgrade) { DBladder = PixelBarrelName(DetId(id_)).ladderName(); }
-    else { DBladder = PixelBarrelNameUpgrade(DetId(id_)).ladderName(); }
+    DBladder = PixelBarrelName(DetId(id_)).ladderName();
     char sladder[80]; sprintf(sladder,"Ladder_%02i",DBladder);
     hisID = src.label() + "_" + sladder;
     if(isHalfModule) hisID += "H";
@@ -180,8 +175,7 @@ void SiPixelHitEfficiencyModule::book(const edm::ParameterSet& iConfig, DQMStore
   
   if(type==2 && barrel){
     uint32_t DBlayer;
-    if (!isUpgrade) { DBlayer = PixelBarrelName(DetId(id_)).layerName(); }
-    else { DBlayer = PixelBarrelNameUpgrade(DetId(id_)).layerName(); }
+    DBlayer = PixelBarrelName(DetId(id_)).layerName();
     char slayer[80]; sprintf(slayer,"Layer_%i",DBlayer);
     hisID = src.label() + "_" + slayer;
 
@@ -239,8 +233,7 @@ void SiPixelHitEfficiencyModule::book(const edm::ParameterSet& iConfig, DQMStore
   
   if(type==3 && barrel){
     uint32_t DBmodule;
-    if (!isUpgrade) { DBmodule = PixelBarrelName(DetId(id_)).moduleName(); }
-    else { DBmodule = PixelBarrelNameUpgrade(DetId(id_)).moduleName(); }
+    DBmodule = PixelBarrelName(DetId(id_)).moduleName();
     char smodule[80]; sprintf(smodule,"Ring_%i",DBmodule);
     hisID = src.label() + "_" + smodule;
     
@@ -297,8 +290,7 @@ void SiPixelHitEfficiencyModule::book(const edm::ParameterSet& iConfig, DQMStore
   
   if(type==4 && endcap){
     uint32_t blade;
-    if (!isUpgrade) { blade= PixelEndcapName(DetId(id_)).bladeName(); }
-    else { blade= PixelEndcapNameUpgrade(DetId(id_)).bladeName(); }
+    blade= PixelEndcapName(DetId(id_)).bladeName();
     
     char sblade[80]; sprintf(sblade, "Blade_%02i",blade);
     hisID = src.label() + "_" + sblade;
@@ -356,8 +348,7 @@ void SiPixelHitEfficiencyModule::book(const edm::ParameterSet& iConfig, DQMStore
   
   if(type==5 && endcap){
     uint32_t disk;
-    if (!isUpgrade) { disk = PixelEndcapName(DetId(id_)).diskName(); }
-    else { disk = PixelEndcapNameUpgrade(DetId(id_)).diskName(); }
+    disk = PixelEndcapName(DetId(id_)).diskName();
     
     char sdisk[80]; sprintf(sdisk, "Disk_%i",disk);
     hisID = src.label() + "_" + sdisk;
@@ -417,13 +408,8 @@ void SiPixelHitEfficiencyModule::book(const edm::ParameterSet& iConfig, DQMStore
   if(type==6 && endcap){
     uint32_t panel;
     uint32_t module;
-    if (!isUpgrade) {
-      panel= PixelEndcapName(DetId(id_)).pannelName();
-      module= PixelEndcapName(DetId(id_)).plaquetteName();
-    } else {
-      panel= PixelEndcapNameUpgrade(DetId(id_)).pannelName();
-      module= PixelEndcapNameUpgrade(DetId(id_)).plaquetteName();
-    }
+    panel= PixelEndcapName(DetId(id_)).pannelName();
+    module= PixelEndcapName(DetId(id_)).plaquetteName();
     
     char slab[80]; sprintf(slab, "Panel_%i_Ring_%i",panel, module);
     hisID = src.label() + "_" + slab;

--- a/DQM/SiPixelMonitorTrack/src/SiPixelHitEfficiencyModulePhase1.cc
+++ b/DQM/SiPixelMonitorTrack/src/SiPixelHitEfficiencyModulePhase1.cc
@@ -1,0 +1,728 @@
+// Package:    SiPixelMonitorTrack
+// Class:      SiPixelHitEfficiencyModulePhase1
+// 
+// class SiPixelHitEfficiencyModulePhase1 SiPixelHitEfficiencyModulePhase1.cc 
+//       DQM/SiPixelMonitorTrack/src/SiPixelHitEfficiencyModulePhase1.cc
+//
+// Description: SiPixel hit efficiency data quality monitoring modules
+// Implementation: prototype -> improved -> never final - end of the 1st step 
+//
+// Original Authors: Romain Rougny & Luca Mucibello
+//         Created: Mar Nov 10 13:29:00 CET nbinangle9
+
+
+
+#include <string>
+#include <iostream>
+
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "DQM/SiPixelCommon/interface/SiPixelHistogramId.h"
+#include "DQM/SiPixelMonitorTrack/interface/SiPixelHitEfficiencyModulePhase1.h"
+
+// Data Formats
+#include "DataFormats/SiPixelDetId/interface/PixelBarrelName.h"
+#include "DataFormats/SiPixelDetId/interface/PixelBarrelNameUpgrade.h"
+#include "DataFormats/SiPixelDetId/interface/PixelEndcapName.h"
+#include "DataFormats/SiPixelDetId/interface/PixelEndcapNameUpgrade.h"
+#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+
+
+using namespace std; 
+
+
+SiPixelHitEfficiencyModulePhase1::SiPixelHitEfficiencyModulePhase1() : id_(0) {
+  bBookTracks = true;
+}
+
+
+SiPixelHitEfficiencyModulePhase1::SiPixelHitEfficiencyModulePhase1(uint32_t id) : id_(id) { 
+  bBookTracks = true;
+}
+
+
+SiPixelHitEfficiencyModulePhase1::~SiPixelHitEfficiencyModulePhase1() { 
+ 
+}
+
+
+void SiPixelHitEfficiencyModulePhase1::book(const edm::ParameterSet& iConfig, DQMStore::IBooker & iBooker,int type) {
+  
+  bool barrel = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
+  bool endcap = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap);
+  bool isHalfModule = false;
+  if(barrel){
+    isHalfModule = PixelBarrelNameUpgrade(DetId(id_)).isHalfModule(); 
+  }
+
+  edm::InputTag src = iConfig.getParameter<edm::InputTag>("src");
+  debug_ = iConfig.getUntrackedParameter<bool>("debug",false);
+  updateEfficiencies = iConfig.getUntrackedParameter<bool>("updateEfficiencies",false);
+  std::string hisID;
+  
+  int nbinangle = 28;
+  int nbinX = 45;
+  int nbinY = 40;
+
+  if(type==0){
+    SiPixelHistogramId* theHistogramId = new SiPixelHistogramId(src.label());
+    
+    if(updateEfficiencies){
+      //EFFICIENCY
+      hisID = theHistogramId->setHistoId("efficiency",id_);
+      meEfficiency_ = iBooker.book1D(hisID,"Hit efficiency",1,0,1.);
+      meEfficiency_->setAxisTitle("Hit efficiency",1);
+    
+      hisID = theHistogramId->setHistoId("efficiencyX",id_);
+      meEfficiencyX_ = iBooker.book1D(hisID,"Hit efficiency in X",nbinX,-1.5,1.5);
+      meEfficiencyX_->setAxisTitle("Hit efficiency in X",1);
+    
+      hisID = theHistogramId->setHistoId("efficiencyY",id_);
+      meEfficiencyY_ = iBooker.book1D(hisID,"Hit efficiency in Y",nbinY,-4.,4.);
+      meEfficiencyY_->setAxisTitle("Hit efficiency in Y",1);
+    
+      hisID = theHistogramId->setHistoId("efficiencyAlpha",id_);
+      meEfficiencyAlpha_ = iBooker.book1D(hisID,"Hit efficiency in Alpha",nbinangle,-3.5,3.5);
+      meEfficiencyAlpha_->setAxisTitle("Hit efficiency in Alpha",1);
+    
+      hisID = theHistogramId->setHistoId("efficiencyBeta",id_);
+      meEfficiencyBeta_ = iBooker.book1D(hisID,"Hit efficiency in Beta",nbinangle,-3.5,3.5);
+      meEfficiencyBeta_->setAxisTitle("Hit efficiency in Beta",1);
+    }
+
+    //VALID
+    hisID = theHistogramId->setHistoId("valid",id_);
+    meValid_ = iBooker.book1D(hisID,"# Valid hits",1,0,1.);
+    meValid_->setAxisTitle("# Valid hits",1);
+    
+    //MISSING
+    hisID = theHistogramId->setHistoId("missing",id_);
+    meMissing_ = iBooker.book1D(hisID,"# Missing hits",1,0,1.);
+    meMissing_->setAxisTitle("# Missing hits",1);
+    
+    delete theHistogramId;
+  }
+
+  if(type==1 && barrel){
+    uint32_t DBladder;
+    DBladder = PixelBarrelNameUpgrade(DetId(id_)).ladderName();
+    char sladder[80]; sprintf(sladder,"Ladder_%02i",DBladder);
+    hisID = src.label() + "_" + sladder;
+    if(isHalfModule) hisID += "H";
+    else hisID += "F";
+    
+    if(updateEfficiencies){
+      //EFFICIENCY
+      meEfficiencyLad_ = iBooker.book1D("efficiency_"+hisID,"Hit efficiency",1,0,1.);
+      meEfficiencyLad_->setAxisTitle("Hit efficiency",1);
+    
+      meEfficiencyXLad_ = iBooker.book1D("efficiencyX_"+hisID,"Hit efficiency in X",nbinX,-1.5,1.5);
+      meEfficiencyXLad_->setAxisTitle("Hit efficiency in X",1);
+    
+      meEfficiencyYLad_ = iBooker.book1D("efficiencyY_"+hisID,"Hit efficiency in Y",nbinY,-4.,4.);
+      meEfficiencyYLad_->setAxisTitle("Hit efficiency in Y",1);
+    
+      meEfficiencyAlphaLad_ = iBooker.book1D("efficiencyAlpha_"+hisID,"Hit efficiency in Alpha",nbinangle,-3.5,3.5);
+      meEfficiencyAlphaLad_->setAxisTitle("Hit efficiency in Alpha",1);
+    
+      meEfficiencyBetaLad_ = iBooker.book1D("efficiencyBeta_"+hisID,"Hit efficiency in Beta",nbinangle,-3.5,3.5);
+      meEfficiencyBetaLad_->setAxisTitle("Hit efficiency in Beta",1);
+    }
+    
+    //VALID
+    meValidLad_ = iBooker.book1D("valid_"+hisID,"# Valid hits",1,0,1.);
+    meValidLad_->setAxisTitle("# Valid hits",1);
+    
+    meValidXLad_ = iBooker.book1D("validX_"+hisID,"# Valid hits in X",nbinX,-1.5,1.5);
+    meValidXLad_->setAxisTitle("# Valid hits in X",1);
+    
+    meValidYLad_ = iBooker.book1D("validY_"+hisID,"# Valid hits in Y",nbinY,-4.,4.);
+    meValidYLad_->setAxisTitle("# Valid hits in Y",1);
+
+    meValidModLad_ = iBooker.book1D("validMod_"+hisID,"# Valid hits on Module",20,1,21.);
+    meValidModLad_->setAxisTitle("# Valid hits on Module",1);    
+
+    meValidAlphaLad_ = iBooker.book1D("validAlpha_"+hisID,"# Valid hits in Alpha",nbinangle,-3.5,3.5);
+    meValidAlphaLad_->setAxisTitle("# Valid hits in Alpha",1);
+    
+    meValidBetaLad_ = iBooker.book1D("validBeta_"+hisID,"# Valid hits in Beta",nbinangle,-3.5,3.5);
+    meValidBetaLad_->setAxisTitle("# Valid hits in Beta",1);
+
+    //MISSING
+    meMissingLad_ = iBooker.book1D("missing_"+hisID,"# Missing hits",1,0,1.);
+    meMissingLad_->setAxisTitle("# Missing hits",1);
+    
+    meMissingXLad_ = iBooker.book1D("missingX_"+hisID,"# Missing hits in X",nbinX,-1.5,1.5);
+    meMissingXLad_->setAxisTitle("# Missing hits in X",1);
+    
+    meMissingYLad_ = iBooker.book1D("missingY_"+hisID,"# Missing hits in Y",nbinY,-4.,4.);
+    meMissingYLad_->setAxisTitle("# Missing hits in Y",1);
+    
+    meMissingModLad_ = iBooker.book1D("missingMod_"+hisID,"# Missing hits on Module",20,1,21.);
+    meMissingModLad_->setAxisTitle("# Missing hits on Module",1);
+
+    meMissingAlphaLad_ = iBooker.book1D("missingAlpha_"+hisID,"# Missing hits in Alpha",nbinangle,-3.5,3.5);
+    meMissingAlphaLad_->setAxisTitle("# Missing hits in Alpha",1);
+    
+    meMissingBetaLad_ = iBooker.book1D("missingBeta_"+hisID,"# Missing hits in Beta",nbinangle,-3.5,3.5);
+    meMissingBetaLad_->setAxisTitle("# Missing hits in Beta",1);
+  }
+  
+  if(type==2 && barrel){
+    uint32_t DBlayer;
+    DBlayer = PixelBarrelNameUpgrade(DetId(id_)).layerName();
+    char slayer[80]; sprintf(slayer,"Layer_%i",DBlayer);
+    hisID = src.label() + "_" + slayer;
+
+
+    if(updateEfficiencies){
+      //EFFICIENCY
+      meEfficiencyLay_ = iBooker.book1D("efficiency_"+hisID,"Hit efficiency",1,0,1.);
+      meEfficiencyLay_->setAxisTitle("Hit efficiency",1);
+    
+      meEfficiencyXLay_ = iBooker.book1D("efficiencyX_"+hisID,"Hit efficiency in X",nbinX,-1.5,1.5);
+      meEfficiencyXLay_->setAxisTitle("Hit efficiency in X",1);
+    
+      meEfficiencyYLay_ = iBooker.book1D("efficiencyY_"+hisID,"Hit efficiency in Y",nbinY,-4.,4.);
+      meEfficiencyYLay_->setAxisTitle("Hit efficiency in Y",1);
+    
+      meEfficiencyAlphaLay_ = iBooker.book1D("efficiencyAlpha_"+hisID,"Hit efficiency in Alpha",nbinangle,-3.5,3.5);
+      meEfficiencyAlphaLay_->setAxisTitle("Hit efficiency in Alpha",1);
+    
+      meEfficiencyBetaLay_ = iBooker.book1D("efficiencyBeta_"+hisID,"Hit efficiency in Beta",nbinangle,-3.5,3.5);
+      meEfficiencyBetaLay_->setAxisTitle("Hit efficiency in Beta",1);
+    }
+    
+    //VALID
+    meValidLay_ = iBooker.book1D("valid_"+hisID,"# Valid hits",1,0,1.);
+    meValidLay_->setAxisTitle("# Valid hits",1);
+    
+    meValidXLay_ = iBooker.book1D("validX_"+hisID,"# Valid hits in X",nbinX,-1.5,1.5);
+    meValidXLay_->setAxisTitle("# Valid hits in X",1);
+    
+    meValidYLay_ = iBooker.book1D("validY_"+hisID,"# Valid hits in Y",nbinY,-4.,4.);
+    meValidYLay_->setAxisTitle("# Valid hits in Y",1);
+    
+    meValidAlphaLay_ = iBooker.book1D("validAlpha_"+hisID,"# Valid hits in Alpha",nbinangle,-3.5,3.5);
+    meValidAlphaLay_->setAxisTitle("# Valid hits in Alpha",1);
+    
+    meValidBetaLay_ = iBooker.book1D("validBeta_"+hisID,"# Valid hits in Beta",nbinangle,-3.5,3.5);
+    meValidBetaLay_->setAxisTitle("# Valid hits in Beta",1);
+
+    //MISSING
+    meMissingLay_ = iBooker.book1D("missing_"+hisID,"# Missing hits",1,0,1.);
+    meMissingLay_->setAxisTitle("# Missing hits",1);
+    
+    meMissingXLay_ = iBooker.book1D("missingX_"+hisID,"# Missing hits in X",nbinX,-1.5,1.5);
+    meMissingXLay_->setAxisTitle("# Missing hits in X",1);
+    
+    meMissingYLay_ = iBooker.book1D("missingY_"+hisID,"# Missing hits in Y",nbinY,-4.,4.);
+    meMissingYLay_->setAxisTitle("# Missing hits in Y",1);
+    
+    meMissingAlphaLay_ = iBooker.book1D("missingAlpha_"+hisID,"# Missing hits in Alpha",nbinangle,-3.5,3.5);
+    meMissingAlphaLay_->setAxisTitle("# Missing hits in Alpha",1);
+    
+    meMissingBetaLay_ = iBooker.book1D("missingBeta_"+hisID,"# Missing hits in Beta",nbinangle,-3.5,3.5);
+    meMissingBetaLay_->setAxisTitle("# Missing hits in Beta",1);
+  }
+  
+  if(type==3 && barrel){
+    uint32_t DBmodule;
+    DBmodule = PixelBarrelNameUpgrade(DetId(id_)).moduleName();
+    char smodule[80]; sprintf(smodule,"Ring_%i",DBmodule);
+    hisID = src.label() + "_" + smodule;
+    
+    if(updateEfficiencies){
+      //EFFICIENCY
+      meEfficiencyPhi_ = iBooker.book1D("efficiency_"+hisID,"Hit efficiency",1,0,1.);
+      meEfficiencyPhi_->setAxisTitle("Hit efficiency",1);
+    
+      meEfficiencyXPhi_ = iBooker.book1D("efficiencyX_"+hisID,"Hit efficiency in X",nbinX,-1.5,1.5);
+      meEfficiencyXPhi_->setAxisTitle("Hit efficiency in X",1);
+    
+      meEfficiencyYPhi_ = iBooker.book1D("efficiencyY_"+hisID,"Hit efficiency in Y",nbinY,-4.,4.);
+      meEfficiencyYPhi_->setAxisTitle("Hit efficiency in Y",1);
+    
+      meEfficiencyAlphaPhi_ = iBooker.book1D("efficiencyAlpha_"+hisID,"Hit efficiency in Alpha",nbinangle,-3.5,3.5);
+      meEfficiencyAlphaPhi_->setAxisTitle("Hit efficiency in Alpha",1);
+    
+      meEfficiencyBetaPhi_ = iBooker.book1D("efficiencyBeta_"+hisID,"Hit efficiency in Beta",nbinangle,-3.5,3.5);
+      meEfficiencyBetaPhi_->setAxisTitle("Hit efficiency in Beta",1);
+    }
+    
+    //VALID
+    meValidPhi_ = iBooker.book1D("valid_"+hisID,"# Valid hits",1,0,1.);
+    meValidPhi_->setAxisTitle("# Valid hits",1);
+    
+    meValidXPhi_ = iBooker.book1D("validX_"+hisID,"# Valid hits in X",nbinX,-1.5,1.5);
+    meValidXPhi_->setAxisTitle("# Valid hits in X",1);
+    
+    meValidYPhi_ = iBooker.book1D("validY_"+hisID,"# Valid hits in Y",nbinY,-4.,4.);
+    meValidYPhi_->setAxisTitle("# Valid hits in Y",1);
+    
+    meValidAlphaPhi_ = iBooker.book1D("validAlpha_"+hisID,"# Valid hits in Alpha",nbinangle,-3.5,3.5);
+    meValidAlphaPhi_->setAxisTitle("# Valid hits in Alpha",1);
+    
+    meValidBetaPhi_ = iBooker.book1D("validBeta_"+hisID,"# Valid hits in Beta",nbinangle,-3.5,3.5);
+    meValidBetaPhi_->setAxisTitle("# Valid hits in Beta",1);
+
+    //MISSING
+    meMissingPhi_ = iBooker.book1D("missing_"+hisID,"# Missing hits",1,0,1.);
+    meMissingPhi_->setAxisTitle("# Missing hits",1);
+    
+    meMissingXPhi_ = iBooker.book1D("missingX_"+hisID,"# Missing hits in X",nbinX,-1.5,1.5);
+    meMissingXPhi_->setAxisTitle("# Missing hits in X",1);
+    
+    meMissingYPhi_ = iBooker.book1D("missingY_"+hisID,"# Missing hits in Y",nbinY,-4.,4.);
+    meMissingYPhi_->setAxisTitle("# Missing hits in Y",1);
+    
+    meMissingAlphaPhi_ = iBooker.book1D("missingAlpha_"+hisID,"# Missing hits in Alpha",nbinangle,-3.5,3.5);
+    meMissingAlphaPhi_->setAxisTitle("# Missing hits in Alpha",1);
+    
+    meMissingBetaPhi_ = iBooker.book1D("missingBeta_"+hisID,"# Missing hits in Beta",nbinangle,-3.5,3.5);
+    meMissingBetaPhi_->setAxisTitle("# Missing hits in Beta",1); 
+  }
+  
+  if(type==4 && endcap){
+    uint32_t blade;
+    blade= PixelEndcapNameUpgrade(DetId(id_)).bladeName();
+    
+    char sblade[80]; sprintf(sblade, "Blade_%02i",blade);
+    hisID = src.label() + "_" + sblade;
+    
+    if(updateEfficiencies){
+      //EFFICIENCY
+      meEfficiencyBlade_ = iBooker.book1D("efficiency_"+hisID,"Hit efficiency",1,0,1.);
+      meEfficiencyBlade_->setAxisTitle("Hit efficiency",1);
+    
+      meEfficiencyXBlade_ = iBooker.book1D("efficiencyX_"+hisID,"Hit efficiency in X",nbinX,-1.5,1.5);
+      meEfficiencyXBlade_->setAxisTitle("Hit efficiency in X",1);
+    
+      meEfficiencyYBlade_ = iBooker.book1D("efficiencyY_"+hisID,"Hit efficiency in Y",nbinY,-4.,4.);
+      meEfficiencyYBlade_->setAxisTitle("Hit efficiency in Y",1);
+    
+      meEfficiencyAlphaBlade_ = iBooker.book1D("efficiencyAlpha_"+hisID,"Hit efficiency in Alpha",nbinangle,-3.5,3.5);
+      meEfficiencyAlphaBlade_->setAxisTitle("Hit efficiency in Alpha",1);
+    
+      meEfficiencyBetaBlade_ = iBooker.book1D("efficiencyBeta_"+hisID,"Hit efficiency in Beta",nbinangle,-3.5,3.5);
+      meEfficiencyBetaBlade_->setAxisTitle("Hit efficiency in Beta",1);
+    }
+    
+    //VALID
+    meValidBlade_ = iBooker.book1D("valid_"+hisID,"# Valid hits",1,0,1.);
+    meValidBlade_->setAxisTitle("# Valid hits",1);
+    
+    meValidXBlade_ = iBooker.book1D("validX_"+hisID,"# Valid hits in X",nbinX,-1.5,1.5);
+    meValidXBlade_->setAxisTitle("# Valid hits in X",1);
+    
+    meValidYBlade_ = iBooker.book1D("validY_"+hisID,"# Valid hits in Y",nbinY,-4.,4.);
+    meValidYBlade_->setAxisTitle("# Valid hits in Y",1);
+    
+    meValidAlphaBlade_ = iBooker.book1D("validAlpha_"+hisID,"# Valid hits in Alpha",nbinangle,-3.5,3.5);
+    meValidAlphaBlade_->setAxisTitle("# Valid hits in Alpha",1);
+    
+    meValidBetaBlade_ = iBooker.book1D("validBeta_"+hisID,"# Valid hits in Beta",nbinangle,-3.5,3.5);
+    meValidBetaBlade_->setAxisTitle("# Valid hits in Beta",1);
+
+    //MISSING
+    meMissingBlade_ = iBooker.book1D("missing_"+hisID,"# Missing hits",1,0,1.);
+    meMissingBlade_->setAxisTitle("# Missing hits",1);
+    
+    meMissingXBlade_ = iBooker.book1D("missingX_"+hisID,"# Missing hits in X",nbinX,-1.5,1.5);
+    meMissingXBlade_->setAxisTitle("# Missing hits in X",1);
+    
+    meMissingYBlade_ = iBooker.book1D("missingY_"+hisID,"# Missing hits in Y",nbinY,-4.,4.);
+    meMissingYBlade_->setAxisTitle("# Missing hits in Y",1);
+    
+    meMissingAlphaBlade_ = iBooker.book1D("missingAlpha_"+hisID,"# Missing hits in Alpha",nbinangle,-3.5,3.5);
+    meMissingAlphaBlade_->setAxisTitle("# Missing hits in Alpha",1);
+    
+    meMissingBetaBlade_ = iBooker.book1D("missingBeta_"+hisID,"# Missing hits in Beta",nbinangle,-3.5,3.5);
+    meMissingBetaBlade_->setAxisTitle("# Missing hits in Beta",1); 
+  }
+  
+  if(type==5 && endcap){
+    uint32_t disk;
+    disk = PixelEndcapNameUpgrade(DetId(id_)).diskName();
+    
+    char sdisk[80]; sprintf(sdisk, "Disk_%i",disk);
+    hisID = src.label() + "_" + sdisk;
+    
+    if(updateEfficiencies){
+      //EFFICIENCY
+      meEfficiencyDisk_ = iBooker.book1D("efficiency_"+hisID,"Hit efficiency",1,0,1.);
+      meEfficiencyDisk_->setAxisTitle("Hit efficiency",1);
+    
+      meEfficiencyXDisk_ = iBooker.book1D("efficiencyX_"+hisID,"Hit efficiency in X",nbinX,-1.5,1.5);
+      meEfficiencyXDisk_->setAxisTitle("Hit efficiency in X",1);
+    
+      meEfficiencyYDisk_ = iBooker.book1D("efficiencyY_"+hisID,"Hit efficiency in Y",nbinY,-4.,4.);
+      meEfficiencyYDisk_->setAxisTitle("Hit efficiency in Y",1);
+    
+      meEfficiencyAlphaDisk_ = iBooker.book1D("efficiencyAlpha_"+hisID,"Hit efficiency in Alpha",nbinangle,-3.5,3.5);
+      meEfficiencyAlphaDisk_->setAxisTitle("Hit efficiency in Alpha",1);
+    
+      meEfficiencyBetaDisk_ = iBooker.book1D("efficiencyBeta_"+hisID,"Hit efficiency in Beta",nbinangle,-3.5,3.5);
+      meEfficiencyBetaDisk_->setAxisTitle("Hit efficiency in Beta",1);
+    }
+    
+    //VALID
+    meValidDisk_ = iBooker.book1D("valid_"+hisID,"# Valid hits",1,0,1.);
+    meValidDisk_->setAxisTitle("# Valid hits",1);
+    
+    meValidXDisk_ = iBooker.book1D("validX_"+hisID,"# Valid hits in X",nbinX,-1.5,1.5);
+    meValidXDisk_->setAxisTitle("# Valid hits in X",1);
+    
+    meValidYDisk_ = iBooker.book1D("validY_"+hisID,"# Valid hits in Y",nbinY,-4.,4.);
+    meValidYDisk_->setAxisTitle("# Valid hits in Y",1);
+    
+    meValidAlphaDisk_ = iBooker.book1D("validAlpha_"+hisID,"# Valid hits in Alpha",nbinangle,-3.5,3.5);
+    meValidAlphaDisk_->setAxisTitle("# Valid hits in Alpha",1);
+    
+    meValidBetaDisk_ = iBooker.book1D("validBeta_"+hisID,"# Valid hits in Beta",nbinangle,-3.5,3.5);
+    meValidBetaDisk_->setAxisTitle("# Valid hits in Beta",1);
+
+    //MISSING
+    meMissingDisk_ = iBooker.book1D("missing_"+hisID,"# Missing hits",1,0,1.);
+    meMissingDisk_->setAxisTitle("# Missing hits",1);
+    
+    meMissingXDisk_ = iBooker.book1D("missingX_"+hisID,"# Missing hits in X",nbinX,-1.5,1.5);
+    meMissingXDisk_->setAxisTitle("# Missing hits in X",1);
+    
+    meMissingYDisk_ = iBooker.book1D("missingY_"+hisID,"# Missing hits in Y",nbinY,-4.,4.);
+    meMissingYDisk_->setAxisTitle("# Missing hits in Y",1);
+    
+    meMissingAlphaDisk_ = iBooker.book1D("missingAlpha_"+hisID,"# Missing hits in Alpha",nbinangle,-3.5,3.5);
+    meMissingAlphaDisk_->setAxisTitle("# Missing hits in Alpha",1);
+    
+    meMissingBetaDisk_ = iBooker.book1D("missingBeta_"+hisID,"# Missing hits in Beta",nbinangle,-3.5,3.5);
+    meMissingBetaDisk_->setAxisTitle("# Missing hits in Beta",1);
+  }
+    
+   
+  if(type==6 && endcap){
+    uint32_t panel;
+    uint32_t module;
+    panel= PixelEndcapNameUpgrade(DetId(id_)).pannelName();
+    module= PixelEndcapNameUpgrade(DetId(id_)).plaquetteName();
+    
+    char slab[80]; sprintf(slab, "Panel_%i_Ring_%i",panel, module);
+    hisID = src.label() + "_" + slab;
+    
+    if(updateEfficiencies){
+      //EFFICIENCY
+      meEfficiencyRing_ = iBooker.book1D("efficiency_"+hisID,"Hit efficiency",1,0,1.);
+      meEfficiencyRing_->setAxisTitle("Hit efficiency",1);
+    
+      meEfficiencyXRing_ = iBooker.book1D("efficiencyX_"+hisID,"Hit efficiency in X",nbinX,-1.5,1.5);
+      meEfficiencyXRing_->setAxisTitle("Hit efficiency in X",1);
+    
+      meEfficiencyYRing_ = iBooker.book1D("efficiencyY_"+hisID,"Hit efficiency in Y",nbinY,-4.,4.);
+      meEfficiencyYRing_->setAxisTitle("Hit efficiency in Y",1);
+    
+      meEfficiencyAlphaRing_ = iBooker.book1D("efficiencyAlpha_"+hisID,"Hit efficiency in Alpha",nbinangle,-3.5,3.5);
+      meEfficiencyAlphaRing_->setAxisTitle("Hit efficiency in Alpha",1);
+    
+      meEfficiencyBetaRing_ = iBooker.book1D("efficiencyBeta_"+hisID,"Hit efficiency in Beta",nbinangle,-3.5,3.5);
+      meEfficiencyBetaRing_->setAxisTitle("Hit efficiency in Beta",1);
+    }
+    
+    //VALID
+    meValidRing_ = iBooker.book1D("valid_"+hisID,"# Valid hits",1,0,1.);
+    meValidRing_->setAxisTitle("# Valid hits",1);
+    
+    meValidXRing_ = iBooker.book1D("validX_"+hisID,"# Valid hits in X",nbinX,-1.5,1.5);
+    meValidXRing_->setAxisTitle("# Valid hits in X",1);
+    
+    meValidYRing_ = iBooker.book1D("validY_"+hisID,"# Valid hits in Y",nbinY,-4.,4.);
+    meValidYRing_->setAxisTitle("# Valid hits in Y",1);
+    
+    meValidAlphaRing_ = iBooker.book1D("validAlpha_"+hisID,"# Valid hits in Alpha",nbinangle,-3.5,3.5);
+    meValidAlphaRing_->setAxisTitle("# Valid hits in Alpha",1);
+    
+    meValidBetaRing_ = iBooker.book1D("validBeta_"+hisID,"# Valid hits in Beta",nbinangle,-3.5,3.5);
+    meValidBetaRing_->setAxisTitle("# Valid hits in Beta",1);
+
+    //MISSING
+    meMissingRing_ = iBooker.book1D("missing_"+hisID,"# Missing hits",1,0,1.);
+    meMissingRing_->setAxisTitle("# Missing hits",1);
+    
+    meMissingXRing_ = iBooker.book1D("missingX_"+hisID,"# Missing hits in X",nbinX,-1.5,1.5);
+    meMissingXRing_->setAxisTitle("# Missing hits in X",1);
+    
+    meMissingYRing_ = iBooker.book1D("missingY_"+hisID,"# Missing hits in Y",nbinY,-4.,4.);
+    meMissingYRing_->setAxisTitle("# Missing hits in Y",1);
+    
+    meMissingAlphaRing_ = iBooker.book1D("missingAlpha_"+hisID,"# Missing hits in Alpha",nbinangle,-3.5,3.5);
+    meMissingAlphaRing_->setAxisTitle("# Missing hits in Alpha",1);
+    
+    meMissingBetaRing_ = iBooker.book1D("missingBeta_"+hisID,"# Missing hits in Beta",nbinangle,-3.5,3.5);
+    meMissingBetaRing_->setAxisTitle("# Missing hits in Beta",1);
+  }
+}
+
+
+void SiPixelHitEfficiencyModulePhase1::fill(const LocalTrajectoryParameters& ltp, bool isHitValid, bool modon, bool ladon, bool layon, bool phion, bool bladeon, bool diskon, bool ringon) {  
+  
+  bool barrel = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
+  bool endcap = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap);
+
+  LocalVector localDir = ltp.momentum()/ltp.momentum().mag();
+  float prediction_alpha = atan2(localDir.z(), localDir.x());
+  float prediction_beta = atan2(localDir.z(), localDir.y());
+  float prediction_x = ltp.position().x();
+  float prediction_y = ltp.position().y();
+  //CS - this will probably break with isUpgrade
+  int imod = PXBDetId(DetId(id_)).module();
+  
+  if(isHitValid){
+    if(modon){
+      meValid_->Fill(0.5);
+    }
+    if(barrel && ladon){
+      meValidLad_->Fill(0.5);
+      meValidXLad_->Fill(prediction_x);
+      meValidYLad_->Fill(prediction_y);
+      meValidModLad_->Fill(imod);
+      meValidAlphaLad_->Fill(prediction_alpha);
+      meValidBetaLad_->Fill(prediction_beta);
+    }
+    if(barrel && layon){
+      meValidLay_->Fill(0.5);
+      meValidXLay_->Fill(prediction_x);
+      meValidYLay_->Fill(prediction_y);
+      meValidAlphaLay_->Fill(prediction_alpha);
+      meValidBetaLay_->Fill(prediction_beta);
+    }   
+    if(barrel && phion){
+      meValidPhi_->Fill(0.5);
+      meValidXPhi_->Fill(prediction_x);
+      meValidYPhi_->Fill(prediction_y);
+      meValidAlphaPhi_->Fill(prediction_alpha);
+      meValidBetaPhi_->Fill(prediction_beta);
+    }
+    if(endcap && bladeon){
+      meValidBlade_->Fill(0.5);
+      meValidXBlade_->Fill(prediction_x);
+      meValidYBlade_->Fill(prediction_y);
+      meValidAlphaBlade_->Fill(prediction_alpha);
+      meValidBetaBlade_->Fill(prediction_beta);
+    }
+    if(endcap && diskon){
+      meValidDisk_->Fill(0.5);
+      meValidXDisk_->Fill(prediction_x);
+      meValidYDisk_->Fill(prediction_y);
+      meValidAlphaDisk_->Fill(prediction_alpha);
+      meValidBetaDisk_->Fill(prediction_beta);
+    }
+    if(endcap && ringon){
+      meValidRing_->Fill(0.5);
+      meValidXRing_->Fill(prediction_x);
+      meValidYRing_->Fill(prediction_y);
+      meValidAlphaRing_->Fill(prediction_alpha);
+      meValidBetaRing_->Fill(prediction_beta);
+    }
+  }
+  else {
+    if(modon){
+      meMissing_->Fill(0.5);
+    }
+    if(barrel && ladon){
+      meMissingLad_->Fill(0.5);
+      meMissingXLad_->Fill(prediction_x);
+      meMissingYLad_->Fill(prediction_y);
+      meMissingModLad_->Fill(imod);
+      meMissingAlphaLad_->Fill(prediction_alpha);
+      meMissingBetaLad_->Fill(prediction_beta);
+    }
+    if(barrel && layon){
+      meMissingLay_->Fill(0.5);
+      meMissingXLay_->Fill(prediction_x);
+      meMissingYLay_->Fill(prediction_y);
+      meMissingAlphaLay_->Fill(prediction_alpha);
+      meMissingBetaLay_->Fill(prediction_beta);
+    }   
+    if(barrel && phion){
+      meMissingPhi_->Fill(0.5);
+      meMissingXPhi_->Fill(prediction_x);
+      meMissingYPhi_->Fill(prediction_y);
+      meMissingAlphaPhi_->Fill(prediction_alpha);
+      meMissingBetaPhi_->Fill(prediction_beta);
+    }
+    if(endcap && bladeon){
+      meMissingBlade_->Fill(0.5);
+      meMissingXBlade_->Fill(prediction_x);
+      meMissingYBlade_->Fill(prediction_y);
+      meMissingAlphaBlade_->Fill(prediction_alpha);
+      meMissingBetaBlade_->Fill(prediction_beta);
+    }
+    if(endcap && diskon){
+      meMissingDisk_->Fill(0.5);
+      meMissingXDisk_->Fill(prediction_x);
+      meMissingYDisk_->Fill(prediction_y);
+      meMissingAlphaDisk_->Fill(prediction_alpha);
+      meMissingBetaDisk_->Fill(prediction_beta);
+    }
+    if(endcap && ringon){
+      meMissingRing_->Fill(0.5);
+      meMissingXRing_->Fill(prediction_x);
+      meMissingYRing_->Fill(prediction_y);
+      meMissingAlphaRing_->Fill(prediction_alpha);
+      meMissingBetaRing_->Fill(prediction_beta);
+    }
+  }
+  
+  if(updateEfficiencies)
+    computeEfficiencies(modon, ladon, layon, phion, bladeon, diskon, ringon);
+}
+
+void SiPixelHitEfficiencyModulePhase1::computeEfficiencies(bool modon, bool ladon, bool layon, bool phion, bool bladeon, bool diskon, bool ringon) {
+  
+  if(debug_)
+    std::cout<<"Now Filling histos for detid "<<id_<<std::endl;
+  
+  bool barrel = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
+  bool endcap = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap);
+  
+  if(modon){
+    meEfficiency_->setBinContent(1,(eff(meValid_->getBinContent(1),meMissing_->getBinContent(1))).first);
+    meEfficiency_->setBinError(1,(eff(meValid_->getBinContent(1),meMissing_->getBinContent(1))).second);
+  }
+  if(ladon && barrel){
+    meEfficiencyLad_->setBinContent(1,(eff(meValidLad_->getBinContent(1),meMissingLad_->getBinContent(1))).first);
+    meEfficiencyLad_->setBinError(1,(eff(meValidLad_->getBinContent(1),meMissingLad_->getBinContent(1))).second);
+    for(int i=1;i<=meValidXLad_->getNbinsX();++i){
+      meEfficiencyXLad_->setBinContent(i,(eff(meValidXLad_->getBinContent(i),meMissingXLad_->getBinContent(i))).first);
+      meEfficiencyXLad_->setBinError(i,(eff(meValidXLad_->getBinContent(i),meMissingXLad_->getBinContent(i))).second);
+    }
+    for(int i=1;i<=meValidYLad_->getNbinsX();++i){
+      meEfficiencyYLad_->setBinContent(i,(eff(meValidYLad_->getBinContent(i),meMissingYLad_->getBinContent(i))).first);
+      meEfficiencyYLad_->setBinError(i,(eff(meValidYLad_->getBinContent(i),meMissingYLad_->getBinContent(i))).second);
+    }
+    for(int i=1;i<=meValidAlphaLad_->getNbinsX();++i){
+      meEfficiencyAlphaLad_->setBinContent(i,(eff(meValidAlphaLad_->getBinContent(i),meMissingAlphaLad_->getBinContent(i))).first);
+      meEfficiencyAlphaLad_->setBinError(i,(eff(meValidAlphaLad_->getBinContent(i),meMissingAlphaLad_->getBinContent(i))).second);
+    }
+    for(int i=1;i<=meValidBetaLad_->getNbinsX();++i){
+      meEfficiencyBetaLad_->setBinContent(i,(eff(meValidBetaLad_->getBinContent(i),meMissingBetaLad_->getBinContent(i))).first);
+      meEfficiencyBetaLad_->setBinError(i,(eff(meValidBetaLad_->getBinContent(i),meMissingBetaLad_->getBinContent(i))).second);
+    }
+  }
+  
+  if(layon && barrel){
+    meEfficiencyLay_->setBinContent(1,(eff(meValidLay_->getBinContent(1),meMissingLay_->getBinContent(1))).first);
+    meEfficiencyLay_->setBinError(1,(eff(meValidLay_->getBinContent(1),meMissingLay_->getBinContent(1))).second);
+    for(int i=1;i<=meValidXLay_->getNbinsX();++i){
+      meEfficiencyXLay_->setBinContent(i,(eff(meValidXLay_->getBinContent(i),meMissingXLay_->getBinContent(i))).first);
+      meEfficiencyXLay_->setBinError(i,(eff(meValidXLay_->getBinContent(i),meMissingXLay_->getBinContent(i))).second);
+    }
+    for(int i=1;i<=meValidYLay_->getNbinsX();++i){
+      meEfficiencyYLay_->setBinContent(i,(eff(meValidYLay_->getBinContent(i),meMissingYLay_->getBinContent(i))).first);
+      meEfficiencyYLay_->setBinError(i,(eff(meValidYLay_->getBinContent(i),meMissingYLay_->getBinContent(i))).second);
+    }
+    for(int i=1;i<=meValidAlphaLay_->getNbinsX();++i){
+      meEfficiencyAlphaLay_->setBinContent(i,(eff(meValidAlphaLay_->getBinContent(i),meMissingAlphaLay_->getBinContent(i))).first);
+      meEfficiencyAlphaLay_->setBinError(i,(eff(meValidAlphaLay_->getBinContent(i),meMissingAlphaLay_->getBinContent(i))).second);
+    }
+    for(int i=1;i<=meValidBetaLay_->getNbinsX();++i){
+      meEfficiencyBetaLay_->setBinContent(i,(eff(meValidBetaLay_->getBinContent(i),meMissingBetaLay_->getBinContent(i))).first);
+      meEfficiencyBetaLay_->setBinError(i,(eff(meValidBetaLay_->getBinContent(i),meMissingBetaLay_->getBinContent(i))).second);
+    }
+  }
+  
+  if(phion && barrel){
+    meEfficiencyPhi_->setBinContent(1,(eff(meValidPhi_->getBinContent(1),meMissingPhi_->getBinContent(1))).first);
+    meEfficiencyPhi_->setBinError(1,(eff(meValidPhi_->getBinContent(1),meMissingPhi_->getBinContent(1))).second);
+    for(int i=1;i<=meValidXPhi_->getNbinsX();++i){
+      meEfficiencyXPhi_->setBinContent(i,(eff(meValidXPhi_->getBinContent(i),meMissingXPhi_->getBinContent(i))).first);
+      meEfficiencyXPhi_->setBinError(i,(eff(meValidXPhi_->getBinContent(i),meMissingXPhi_->getBinContent(i))).second);
+    }
+    for(int i=1;i<=meValidYPhi_->getNbinsX();++i){
+      meEfficiencyYPhi_->setBinContent(i,(eff(meValidYPhi_->getBinContent(i),meMissingYPhi_->getBinContent(i))).first);
+      meEfficiencyYPhi_->setBinError(i,(eff(meValidYPhi_->getBinContent(i),meMissingYPhi_->getBinContent(i))).second);
+    }
+    for(int i=1;i<=meValidAlphaPhi_->getNbinsX();++i){
+      meEfficiencyAlphaPhi_->setBinContent(i,(eff(meValidAlphaPhi_->getBinContent(i),meMissingAlphaPhi_->getBinContent(i))).first);
+      meEfficiencyAlphaPhi_->setBinError(i,(eff(meValidAlphaPhi_->getBinContent(i),meMissingAlphaPhi_->getBinContent(i))).second);
+    }
+    for(int i=1;i<=meValidBetaPhi_->getNbinsX();++i){
+      meEfficiencyBetaPhi_->setBinContent(i,(eff(meValidBetaPhi_->getBinContent(i),meMissingBetaPhi_->getBinContent(i))).first);
+      meEfficiencyBetaPhi_->setBinError(i,(eff(meValidBetaPhi_->getBinContent(i),meMissingBetaPhi_->getBinContent(i))).second);
+    }
+  }
+  if(bladeon && endcap){
+    meEfficiencyBlade_->setBinContent(1,(eff(meValidBlade_->getBinContent(1),meMissingBlade_->getBinContent(1))).first);
+    meEfficiencyBlade_->setBinError(1,(eff(meValidBlade_->getBinContent(1),meMissingBlade_->getBinContent(1))).second);
+    for(int i=1;i<=meValidXBlade_->getNbinsX();++i){
+      meEfficiencyXBlade_->setBinContent(i,(eff(meValidXBlade_->getBinContent(i),meMissingXBlade_->getBinContent(i))).first);
+      meEfficiencyXBlade_->setBinError(i,(eff(meValidXBlade_->getBinContent(i),meMissingXBlade_->getBinContent(i))).second);
+    }
+    for(int i=1;i<=meValidYBlade_->getNbinsX();++i){
+      meEfficiencyYBlade_->setBinContent(i,(eff(meValidYBlade_->getBinContent(i),meMissingYBlade_->getBinContent(i))).first);
+      meEfficiencyYBlade_->setBinError(i,(eff(meValidYBlade_->getBinContent(i),meMissingYBlade_->getBinContent(i))).second);
+    }
+    for(int i=1;i<=meValidAlphaBlade_->getNbinsX();++i){
+      meEfficiencyAlphaBlade_->setBinContent(i,(eff(meValidAlphaBlade_->getBinContent(i),meMissingAlphaBlade_->getBinContent(i))).first);
+      meEfficiencyAlphaBlade_->setBinError(i,(eff(meValidAlphaBlade_->getBinContent(i),meMissingAlphaBlade_->getBinContent(i))).second);
+    }
+    for(int i=1;i<=meValidBetaBlade_->getNbinsX();++i){
+      meEfficiencyBetaBlade_->setBinContent(i,(eff(meValidBetaBlade_->getBinContent(i),meMissingBetaBlade_->getBinContent(i))).first);
+      meEfficiencyBetaBlade_->setBinError(i,(eff(meValidBetaBlade_->getBinContent(i),meMissingBetaBlade_->getBinContent(i))).second);
+    }
+  }
+  if(diskon && endcap){
+    meEfficiencyDisk_->setBinContent(1,(eff(meValidDisk_->getBinContent(1),meMissingDisk_->getBinContent(1))).first);
+    meEfficiencyDisk_->setBinError(1,(eff(meValidDisk_->getBinContent(1),meMissingDisk_->getBinContent(1))).second);
+    for(int i=1;i<=meValidXDisk_->getNbinsX();++i){
+      meEfficiencyXDisk_->setBinContent(i,(eff(meValidXDisk_->getBinContent(i),meMissingXDisk_->getBinContent(i))).first);
+      meEfficiencyXDisk_->setBinError(i,(eff(meValidXDisk_->getBinContent(i),meMissingXDisk_->getBinContent(i))).second);
+    }
+    for(int i=1;i<=meValidYDisk_->getNbinsX();++i){
+      meEfficiencyYDisk_->setBinContent(i,(eff(meValidYDisk_->getBinContent(i),meMissingYDisk_->getBinContent(i))).first);
+      meEfficiencyYDisk_->setBinError(i,(eff(meValidYDisk_->getBinContent(i),meMissingYDisk_->getBinContent(i))).second);
+    }
+    for(int i=1;i<=meValidAlphaDisk_->getNbinsX();++i){
+      meEfficiencyAlphaDisk_->setBinContent(i,(eff(meValidAlphaDisk_->getBinContent(i),meMissingAlphaDisk_->getBinContent(i))).first);
+      meEfficiencyAlphaDisk_->setBinError(i,(eff(meValidAlphaDisk_->getBinContent(i),meMissingAlphaDisk_->getBinContent(i))).second);
+    }
+    for(int i=1;i<=meValidBetaDisk_->getNbinsX();++i){
+      meEfficiencyBetaDisk_->setBinContent(i,(eff(meValidBetaDisk_->getBinContent(i),meMissingBetaDisk_->getBinContent(i))).first);
+      meEfficiencyBetaDisk_->setBinError(i,(eff(meValidBetaDisk_->getBinContent(i),meMissingBetaDisk_->getBinContent(i))).second);
+    }
+  }
+  if(ringon && endcap){
+    meEfficiencyRing_->setBinContent(1,(eff(meValidRing_->getBinContent(1),meMissingRing_->getBinContent(1))).first);
+    meEfficiencyRing_->setBinError(1,(eff(meValidRing_->getBinContent(1),meMissingRing_->getBinContent(1))).second);
+    for(int i=1;i<=meValidXRing_->getNbinsX();++i){
+      meEfficiencyXRing_->setBinContent(i,(eff(meValidXRing_->getBinContent(i),meMissingXRing_->getBinContent(i))).first);
+      meEfficiencyXRing_->setBinError(i,(eff(meValidXRing_->getBinContent(i),meMissingXRing_->getBinContent(i))).second);
+    }
+    for(int i=1;i<=meValidYRing_->getNbinsX();++i){
+      meEfficiencyYRing_->setBinContent(i,(eff(meValidYRing_->getBinContent(i),meMissingYRing_->getBinContent(i))).first);
+      meEfficiencyYRing_->setBinError(i,(eff(meValidYRing_->getBinContent(i),meMissingYRing_->getBinContent(i))).second);
+    }
+    for(int i=1;i<=meValidAlphaRing_->getNbinsX();++i){
+      meEfficiencyAlphaRing_->setBinContent(i,(eff(meValidAlphaRing_->getBinContent(i),meMissingAlphaRing_->getBinContent(i))).first);
+      meEfficiencyAlphaRing_->setBinError(i,(eff(meValidAlphaRing_->getBinContent(i),meMissingAlphaRing_->getBinContent(i))).second);
+    }
+    for(int i=1;i<=meValidBetaRing_->getNbinsX();++i){
+      meEfficiencyBetaRing_->setBinContent(i,(eff(meValidBetaRing_->getBinContent(i),meMissingBetaRing_->getBinContent(i))).first);
+      meEfficiencyBetaRing_->setBinError(i,(eff(meValidBetaRing_->getBinContent(i),meMissingBetaRing_->getBinContent(i))).second);
+    }
+  }
+
+}
+
+std::pair<double,double> SiPixelHitEfficiencyModulePhase1::eff(double nValid, double nMissing){
+  double efficiency = 0, error = 0 ;
+  if(nValid+nMissing!=0){
+    efficiency=nValid/(nValid+nMissing);
+    error=sqrt(efficiency*(1.-efficiency)/(nValid+nMissing));
+  }
+  return make_pair(efficiency,error);
+}

--- a/DQM/SiPixelMonitorTrack/src/SiPixelHitEfficiencySource.cc
+++ b/DQM/SiPixelMonitorTrack/src/SiPixelHitEfficiencySource.cc
@@ -77,8 +77,7 @@ SiPixelHitEfficiencySource::SiPixelHitEfficiencySource(const edm::ParameterSet& 
   phiOn( pSet.getUntrackedParameter<bool>("phiOn",false) ), 
   ringOn( pSet.getUntrackedParameter<bool>("ringOn",false) ), 
   bladeOn( pSet.getUntrackedParameter<bool>("bladeOn",false) ), 
-  diskOn( pSet.getUntrackedParameter<bool>("diskOn",false) ), 
-  isUpgrade( pSet.getUntrackedParameter<bool>("isUpgrade",false) )
+  diskOn( pSet.getUntrackedParameter<bool>("diskOn",false) ) 
   //updateEfficiencies( pSet.getUntrackedParameter<bool>("updateEfficiencies",false) )
  { 
    pSet_ = pSet; 
@@ -155,31 +154,31 @@ void SiPixelHitEfficiencySource::bookHistograms(DQMStore::IBooker & iBooker, edm
        pxd!=theSiPixelStructure.end(); pxd++) {
 
     if(modOn){
-      if (theSiPixelFolder.setModuleFolder(iBooker,(*pxd).first,0,isUpgrade)) (*pxd).second->book(pSet_,iBooker,0,isUpgrade);
+      if (theSiPixelFolder.setModuleFolder(iBooker,(*pxd).first,0)) (*pxd).second->book(pSet_,iBooker,0);
       else throw cms::Exception("LogicError") << "SiPixelHitEfficiencySource Folder Creation Failed! "; 
     }
     if(ladOn){
-      if (theSiPixelFolder.setModuleFolder(iBooker,(*pxd).first,1,isUpgrade)) (*pxd).second->book(pSet_,iBooker,1,isUpgrade);
+      if (theSiPixelFolder.setModuleFolder(iBooker,(*pxd).first,1)) (*pxd).second->book(pSet_,iBooker,1);
       else throw cms::Exception("LogicError") << "SiPixelHitEfficiencySource ladder Folder Creation Failed! "; 
     }
     if(layOn){
-      if (theSiPixelFolder.setModuleFolder(iBooker,(*pxd).first,2,isUpgrade)) (*pxd).second->book(pSet_,iBooker,2,isUpgrade);
+      if (theSiPixelFolder.setModuleFolder(iBooker,(*pxd).first,2)) (*pxd).second->book(pSet_,iBooker,2);
       else throw cms::Exception("LogicError") << "SiPixelHitEfficiencySource layer Folder Creation Failed! "; 
     }
     if(phiOn){
-      if (theSiPixelFolder.setModuleFolder(iBooker,(*pxd).first,3,isUpgrade)) (*pxd).second->book(pSet_,iBooker,3,isUpgrade);
+      if (theSiPixelFolder.setModuleFolder(iBooker,(*pxd).first,3)) (*pxd).second->book(pSet_,iBooker,3);
       else throw cms::Exception("LogicError") << "SiPixelHitEfficiencySource phi Folder Creation Failed! "; 
     }
     if(bladeOn){
-      if (theSiPixelFolder.setModuleFolder(iBooker,(*pxd).first,4,isUpgrade)) (*pxd).second->book(pSet_,iBooker,4,isUpgrade);
+      if (theSiPixelFolder.setModuleFolder(iBooker,(*pxd).first,4)) (*pxd).second->book(pSet_,iBooker,4);
       else throw cms::Exception("LogicError") << "SiPixelHitEfficiencySource Blade Folder Creation Failed! "; 
     }
     if(diskOn){
-      if (theSiPixelFolder.setModuleFolder(iBooker,(*pxd).first,5,isUpgrade)) (*pxd).second->book(pSet_,iBooker,5,isUpgrade);
+      if (theSiPixelFolder.setModuleFolder(iBooker,(*pxd).first,5)) (*pxd).second->book(pSet_,iBooker,5);
       else throw cms::Exception("LogicError") << "SiPixelHitEfficiencySource Disk Folder Creation Failed! "; 
     }
     if(ringOn){
-      if (theSiPixelFolder.setModuleFolder(iBooker,(*pxd).first,6,isUpgrade)) (*pxd).second->book(pSet_,iBooker,6,isUpgrade);
+      if (theSiPixelFolder.setModuleFolder(iBooker,(*pxd).first,6)) (*pxd).second->book(pSet_,iBooker,6);
       else throw cms::Exception("LogicError") << "SiPixelHitEfficiencySource Ring Folder Creation Failed! "; 
     }
   }
@@ -262,7 +261,7 @@ void SiPixelHitEfficiencySource::analyze(const edm::Event& iEvent, const edm::Ev
     //tracks++;
     
     bool isBpixtrack = false, isFpixtrack = false;
-    int nStripHits=0; int L1hits=0; int L2hits=0; int L3hits=0; int L4hits=0; int D1hits=0; int D2hits=0; int D3hits=0;
+    int nStripHits=0; int L1hits=0; int L2hits=0; int L3hits=0; int D1hits=0; int D2hits=0;
     std::vector<TrajectoryMeasurement> tmeasColl =traj_iterator->measurements();
     std::vector<TrajectoryMeasurement>::const_iterator tmeasIt;
     //loop on measurements to find out what kind of hits there are
@@ -279,11 +278,7 @@ void SiPixelHitEfficiencySource::analyze(const edm::Event& iEvent, const edm::Ev
       
       if(testSubDetID==PixelSubdetector::PixelBarrel){
         isBpixtrack = true;
-	if (!isUpgrade) {
-          hit_layer = PixelBarrelName(hit_detId).layerName();
-	} else if (isUpgrade) {
-	  hit_layer = PixelBarrelNameUpgrade(hit_detId).layerName();
-	}
+	hit_layer = PixelBarrelName(hit_detId).layerName();
 	
 	hit_ladder = PXBDetId(hit_detId).ladder();
 	hit_mod = PXBDetId(hit_detId).module();
@@ -291,16 +286,13 @@ void SiPixelHitEfficiencySource::analyze(const edm::Event& iEvent, const edm::Ev
 	if(hit_layer==1) L1hits++;
 	if(hit_layer==2) L2hits++;
 	if(hit_layer==3) L3hits++;
-	if(isUpgrade && hit_layer==4) L4hits++;
       }
       if(testSubDetID==PixelSubdetector::PixelEndcap){
         isFpixtrack = true;
-        if (!isUpgrade) { hit_disk = PixelEndcapName(hit_detId).diskName(); }
-        else if (isUpgrade) { hit_disk = PixelEndcapNameUpgrade(hit_detId).diskName(); }
+        hit_disk = PixelEndcapName(hit_detId).diskName();
         
 	if(hit_disk==1) D1hits++;
 	if(hit_disk==2) D2hits++;
-        if(isUpgrade && hit_disk==3) D3hits++;
       }
       if(testSubDetID==StripSubdetector::TIB) nStripHits++;
       if(testSubDetID==StripSubdetector::TOB) nStripHits++;
@@ -458,26 +450,14 @@ float y=predTrajState.globalPosition().y();
 	  
 	  int disk=0; int layer=0; int panel=0; int module=0; bool isHalfModule=false;
 	  if(IntSubDetID==PixelSubdetector::PixelBarrel){ // it's a BPIX hit
-            if (!isUpgrade) {
             layer = PixelBarrelName(hit_detId).layerName();
 	    isHalfModule = PixelBarrelName(hit_detId).isHalfModule();
-	    } else if (isUpgrade) {
-	      layer = PixelBarrelNameUpgrade(hit_detId).layerName();
-	      isHalfModule = PixelBarrelNameUpgrade(hit_detId).isHalfModule();
-	    }
 	  }else if(IntSubDetID==PixelSubdetector::PixelEndcap){ // it's an FPIX hit
-	    if (!isUpgrade) {
 	    disk = PixelEndcapName(hit_detId).diskName();
 	    panel = PixelEndcapName(hit_detId).pannelName();
 	    module = PixelEndcapName(hit_detId).plaquetteName();
-	    } else if (isUpgrade) {
-              disk = PixelEndcapNameUpgrade(hit_detId).diskName();
-	      panel = PixelEndcapNameUpgrade(hit_detId).pannelName();
-	      module = PixelEndcapNameUpgrade(hit_detId).plaquetteName();
-	  }
           }
           
-	  if (!isUpgrade) {
 	  if(layer==1){
 	    if(fabs(trackref->dxy(bestVtx->position()))>0.01 ||
 	       fabs(trackref->dz(bestVtx->position()))>0.1) continue;
@@ -499,37 +479,6 @@ float y=predTrajState.globalPosition().y();
 	       fabs(trackref->dz(bestVtx->position()))>0.5) continue;
 	    if(!(L1hits>0&&D1hits>0)) continue;
 	  }
-          } else if (isUpgrade) {
-            if(layer==1){
-	      if(fabs(trackref->dxy(bestVtx->position()))>0.01 ||
-	         fabs(trackref->dz(bestVtx->position()))>0.1) continue;
-	      if(!(L2hits>0&&L3hits>0&&L4hits>0) && !(L2hits>0&&D1hits>0&&D2hits) && !(D1hits>0&&D2hits>0&&D3hits>0)) continue;
-	    }else if(layer==2){
-	      if(fabs(trackref->dxy(bestVtx->position()))>0.02 ||
-	         fabs(trackref->dz(bestVtx->position()))>0.1) continue;
-	      if(!(L1hits>0&&L3hits>0&&L4hits>0) && !(L1hits>0&&L3hits>0&&D1hits>0) && !(L1hits>0&&D1hits>0&&D2hits>0)) continue;
-	    }else if(layer==3){
-	      if(fabs(trackref->dxy(bestVtx->position()))>0.02 ||
-	         fabs(trackref->dz(bestVtx->position()))>0.1) continue;
-	      if(!(L1hits>0&&L2hits>0&&L4hits>0) && !(L1hits>0&&L2hits>0&&D1hits>0)) continue;
-	    }else if(isUpgrade && layer==4){
-	      if(fabs(trackref->dxy(bestVtx->position()))>0.02 ||
-	         fabs(trackref->dz(bestVtx->position()))>0.1) continue;
-	      if(!(L1hits>0&&L2hits>0&&L3hits>0)) continue; 
-	    }else if(disk==1){
-	      if(fabs(trackref->dxy(bestVtx->position()))>0.05 ||
-	         fabs(trackref->dz(bestVtx->position()))>0.5) continue;
-	      if(!(L1hits>0&&L2hits>0&&D2hits>0) && !(L1hits>0&&D2hits>0&&D3hits>0) && !(L2hits>0&&D2hits>0&&D3hits>0)) continue;
-	    }else if(disk==2){
-	      if(fabs(trackref->dxy(bestVtx->position()))>0.05 ||
-	         fabs(trackref->dz(bestVtx->position()))>0.5) continue;
-	      if(!(L1hits>0&&L2hits>0&&D1hits>0) && !(L1hits>0&&D1hits>0&&D3hits>0) && !(L2hits>0&&D1hits>0&&D3hits>0)) continue;
-	    }else if(disk==3){
-	      if(fabs(trackref->dxy(bestVtx->position()))>0.05 ||
-	         fabs(trackref->dz(bestVtx->position()))>0.5) continue;
-	      if(!(L1hits>0&&D1hits>0&&D2hits>0) && !(L2hits>0&&D1hits>0&&D2hits>0)) continue;
-	    }
-          }//endif(isUpgrade)
 	  
 	  //check whether hit is valid or missing using track algo flag
           bool isHitValid   =hit->hit()->getType()==TrackingRecHit::valid;

--- a/DQM/SiPixelMonitorTrack/src/SiPixelHitEfficiencySourcePhase1.cc
+++ b/DQM/SiPixelMonitorTrack/src/SiPixelHitEfficiencySourcePhase1.cc
@@ -1,0 +1,655 @@
+// Package:    SiPixelMonitorTrack
+// Class:      SiPixelHitEfficiencySourcePhase1
+// 
+// class SiPixelHitEfficiencyModulePhase1 SiPixelHitEfficiencyModulePhase1.cc 
+//       DQM/SiPixelMonitorTrack/src/SiPixelHitEfficiencyModulePhase1.cc
+//
+// Description: SiPixel hit efficiency data quality monitoring modules
+// Implementation: prototype -> improved -> never final - end of the 1st step 
+//
+// Original Authors: Romain Rougny & Luca Mucibello
+//         Created: Mar Nov 10 13:29:00 CET 2009
+
+
+#include <iostream>
+#include <map>
+#include <string>
+#include <vector>
+#include <utility>
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/TrackCandidate/interface/TrackCandidateCollection.h"
+
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/SiPixelDetId/interface/PixelBarrelName.h"
+#include "DataFormats/SiPixelDetId/interface/PixelBarrelNameUpgrade.h"
+#include "DataFormats/SiPixelDetId/interface/PixelEndcapName.h"
+#include "DataFormats/SiPixelDetId/interface/PixelEndcapNameUpgrade.h"
+
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+
+#include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
+
+#include "RecoTracker/TransientTrackingRecHit/interface/TkTransientTrackingRecHitBuilder.h"
+#include "RecoLocalTracker/ClusterParameterEstimator/interface/PixelClusterParameterEstimator.h"
+//#include "RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEGenericESProducer.h"
+
+#include "TrackingTools/TrackFitters/interface/TrajectoryFitter.h"
+#include "TrackingTools/Records/interface/TransientRecHitRecord.h"
+#include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
+#include "TrackingTools/TrackFitters/interface/TrajectoryStateCombiner.h"
+#include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
+#include "TrackingTools/PatternTools/interface/Trajectory.h"
+#include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrack.h"
+#include "TrackingTools/TrackAssociator/interface/TrackDetectorAssociator.h"
+#include "TrackingTools/MeasurementDet/interface/LayerMeasurements.h"
+
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQM/SiPixelCommon/interface/SiPixelFolderOrganizer.h"
+#include "DQM/SiPixelMonitorTrack/interface/SiPixelHitEfficiencySourcePhase1.h"
+
+#include "TrackingTools/DetLayers/interface/BarrelDetLayer.h"
+#include "RecoTracker/Record/interface/CkfComponentsRecord.h"
+#include "RecoTracker/MeasurementDet/interface/MeasurementTracker.h"
+#include "TrackingTools/KalmanUpdators/interface/Chi2MeasurementEstimator.h"
+#include "RecoTracker/MeasurementDet/interface/MeasurementTrackerEvent.h"
+#include "TrackingTools/MeasurementDet/interface/LayerMeasurements.h"
+#include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
+
+using namespace std;
+using namespace edm;
+
+
+SiPixelHitEfficiencySourcePhase1::SiPixelHitEfficiencySourcePhase1(const edm::ParameterSet& pSet) :
+  pSet_(pSet),
+  modOn( pSet.getUntrackedParameter<bool>("modOn",true) ),
+  ladOn( pSet.getUntrackedParameter<bool>("ladOn",false) ), 
+  layOn( pSet.getUntrackedParameter<bool>("layOn",false) ), 
+  phiOn( pSet.getUntrackedParameter<bool>("phiOn",false) ), 
+  ringOn( pSet.getUntrackedParameter<bool>("ringOn",false) ), 
+  bladeOn( pSet.getUntrackedParameter<bool>("bladeOn",false) ), 
+  diskOn( pSet.getUntrackedParameter<bool>("diskOn",false) )
+  //updateEfficiencies( pSet.getUntrackedParameter<bool>("updateEfficiencies",false) )
+ { 
+   pSet_ = pSet; 
+   debug_ = pSet_.getUntrackedParameter<bool>("debug", false); 
+   applyEdgeCut_ = pSet_.getUntrackedParameter<bool>("applyEdgeCut");
+   nSigma_EdgeCut_ = pSet_.getUntrackedParameter<double>("nSigma_EdgeCut");
+   vertexCollectionToken_ = consumes<reco::VertexCollection>(std::string("offlinePrimaryVertices"));
+   tracksrc_ = consumes<TrajTrackAssociationCollection>(pSet_.getParameter<edm::InputTag>("trajectoryInput"));
+   clusterCollectionToken_ = consumes<edmNew::DetSetVector<SiPixelCluster> >(std::string("siPixelClusters"));
+
+   measurementTrackerEventToken_ = consumes<MeasurementTrackerEvent>(std::string("MeasurementTrackerEvent"));
+
+   firstRun = true;
+   
+   LogInfo("PixelDQM") << "SiPixelHitEfficiencySourcePhase1 constructor" << endl;
+   LogInfo ("PixelDQM") << "Mod/Lad/Lay/Phi " << modOn << "/" << ladOn << "/" 
+			<< layOn << "/" << phiOn << std::endl;
+   LogInfo ("PixelDQM") << "Blade/Disk/Ring" << bladeOn << "/" << diskOn << "/" 
+			<< ringOn << std::endl;
+}
+
+
+SiPixelHitEfficiencySourcePhase1::~SiPixelHitEfficiencySourcePhase1() {
+  LogInfo("PixelDQM") << "SiPixelHitEfficiencySourcePhase1 destructor" << endl;
+
+  std::map<uint32_t,SiPixelHitEfficiencyModulePhase1*>::iterator struct_iter;
+  for (struct_iter = theSiPixelStructure.begin() ; struct_iter != theSiPixelStructure.end() ; struct_iter++){
+    delete struct_iter->second;
+    struct_iter->second = 0;
+  }
+}
+
+
+void SiPixelHitEfficiencySourcePhase1::dqmBeginRun(const edm::Run& r, edm::EventSetup const& iSetup) {
+  LogInfo("PixelDQM") << "SiPixelHitEfficiencySourcePhase1 beginRun()" << endl;
+  
+  if(firstRun){
+  // retrieve TrackerGeometry for pixel dets
+  
+  nvalid=0;
+  nmissing=0;
+  
+  firstRun = false;
+  }
+
+  edm::ESHandle<TrackerGeometry> TG;
+  iSetup.get<TrackerDigiGeometryRecord>().get(TG);
+  if (debug_) LogVerbatim("PixelDQM") << "TrackerGeometry "<< &(*TG) <<" size is "<< TG->dets().size() << endl;
+ 
+  // build theSiPixelStructure with the pixel barrel and endcap dets from TrackerGeometry
+  for (TrackerGeometry::DetContainer::const_iterator pxb = TG->detsPXB().begin();  
+       pxb!=TG->detsPXB().end(); pxb++) {
+    if (dynamic_cast<PixelGeomDetUnit const *>((*pxb))!=0) {
+      SiPixelHitEfficiencyModulePhase1* module = new SiPixelHitEfficiencyModulePhase1((*pxb)->geographicalId().rawId());
+      theSiPixelStructure.insert(pair<uint32_t, SiPixelHitEfficiencyModulePhase1*>((*pxb)->geographicalId().rawId(), module));
+    }
+  }
+  for (TrackerGeometry::DetContainer::const_iterator pxf = TG->detsPXF().begin(); 
+       pxf!=TG->detsPXF().end(); pxf++) {
+    if (dynamic_cast<PixelGeomDetUnit const *>((*pxf))!=0) {
+      SiPixelHitEfficiencyModulePhase1* module = new SiPixelHitEfficiencyModulePhase1((*pxf)->geographicalId().rawId());
+      theSiPixelStructure.insert(pair<uint32_t, SiPixelHitEfficiencyModulePhase1*>((*pxf)->geographicalId().rawId(), module));
+    }
+  }
+  LogInfo("PixelDQM") << "SiPixelStructure size is " << theSiPixelStructure.size() << endl;
+
+}
+
+void SiPixelHitEfficiencySourcePhase1::bookHistograms(DQMStore::IBooker & iBooker, edm::Run const & iRun, edm::EventSetup const & iSetup){
+
+  // book residual histograms in theSiPixelFolder - one (x,y) pair of histograms per det
+  SiPixelFolderOrganizer theSiPixelFolder(false);
+  for (std::map<uint32_t, SiPixelHitEfficiencyModulePhase1*>::iterator pxd = theSiPixelStructure.begin(); 
+       pxd!=theSiPixelStructure.end(); pxd++) {
+
+    if(modOn){
+      if (theSiPixelFolder.setModuleFolder(iBooker,(*pxd).first,0)) (*pxd).second->book(pSet_,iBooker,0);
+      else throw cms::Exception("LogicError") << "SiPixelHitEfficiencySourcePhase1 Folder Creation Failed! "; 
+    }
+    if(ladOn){
+      if (theSiPixelFolder.setModuleFolder(iBooker,(*pxd).first,1)) (*pxd).second->book(pSet_,iBooker,1);
+      else throw cms::Exception("LogicError") << "SiPixelHitEfficiencySourcePhase1 ladder Folder Creation Failed! "; 
+    }
+    if(layOn){
+      if (theSiPixelFolder.setModuleFolder(iBooker,(*pxd).first,2)) (*pxd).second->book(pSet_,iBooker,2);
+      else throw cms::Exception("LogicError") << "SiPixelHitEfficiencySourcePhase1 layer Folder Creation Failed! "; 
+    }
+    if(phiOn){
+      if (theSiPixelFolder.setModuleFolder(iBooker,(*pxd).first,3)) (*pxd).second->book(pSet_,iBooker,3);
+      else throw cms::Exception("LogicError") << "SiPixelHitEfficiencySourcePhase1 phi Folder Creation Failed! "; 
+    }
+    if(bladeOn){
+      if (theSiPixelFolder.setModuleFolder(iBooker,(*pxd).first,4)) (*pxd).second->book(pSet_,iBooker,4);
+      else throw cms::Exception("LogicError") << "SiPixelHitEfficiencySourcePhase1 Blade Folder Creation Failed! "; 
+    }
+    if(diskOn){
+      if (theSiPixelFolder.setModuleFolder(iBooker,(*pxd).first,5)) (*pxd).second->book(pSet_,iBooker,5);
+      else throw cms::Exception("LogicError") << "SiPixelHitEfficiencySourcePhase1 Disk Folder Creation Failed! "; 
+    }
+    if(ringOn){
+      if (theSiPixelFolder.setModuleFolder(iBooker,(*pxd).first,6)) (*pxd).second->book(pSet_,iBooker,6);
+      else throw cms::Exception("LogicError") << "SiPixelHitEfficiencySourcePhase1 Ring Folder Creation Failed! "; 
+    }
+  }
+
+
+}
+
+void SiPixelHitEfficiencySourcePhase1::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+
+  edm::Handle<reco::VertexCollection> vertexCollectionHandle;
+  iEvent.getByToken( vertexCollectionToken_, vertexCollectionHandle );
+  if(!vertexCollectionHandle.isValid()) return;
+  nvtx_=0;
+  vtxntrk_=-9999;
+  vtxD0_=-9999.; vtxX_=-9999.; vtxY_=-9999.; vtxZ_=-9999.; vtxndof_=-9999.; vtxchi2_=-9999.;
+  const reco::VertexCollection & vertices = *vertexCollectionHandle.product();
+  reco::VertexCollection::const_iterator bestVtx=vertices.end();
+  for(reco::VertexCollection::const_iterator it=vertices.begin(); it!=vertices.end(); ++it){
+    if(!it->isValid()) continue;
+    if(vtxntrk_==-9999 ||
+       vtxntrk_<int(it->tracksSize()) ||
+       (vtxntrk_==int(it->tracksSize()) && fabs(vtxZ_)>fabs(it->z()))){
+      vtxntrk_=it->tracksSize();
+      vtxD0_=it->position().rho();
+      vtxX_=it->x();
+      vtxY_=it->y();
+      vtxZ_=it->z();
+      vtxndof_=it->ndof();
+      vtxchi2_=it->chi2();
+      bestVtx=it;
+    }
+    if(fabs(it->z())<=20. && fabs(it->position().rho())<=2. && it->ndof()>4) nvtx_++;
+  }
+  if(nvtx_<1) return;
+    
+  //get the map
+  edm::Handle<TrajTrackAssociationCollection> match;
+  iEvent.getByToken( tracksrc_, match );
+  const TrajTrackAssociationCollection ttac = *(match.product());
+
+  if(debug_){
+    std::cout << "+++ NEW EVENT +++"<< std::endl;
+    std::cout << "Map entries \t : " << ttac.size() << std::endl;
+  }
+
+  std::set<SiPixelCluster> clusterSet;
+  //  TrajectoryStateCombiner tsoscomb;
+  //define variables for extrapolation
+  int extrapolateFrom_ = 2;
+  int extrapolateTo_ = 1;
+  float maxlxmatch_=0.2;
+  float maxlymatch_=0.2;
+  bool keepOriginalMissingHit_=true;
+  ESHandle<MeasurementTracker> measurementTrackerHandle;
+
+  iSetup.get<CkfComponentsRecord>().get(measurementTrackerHandle);
+  
+  edm::ESHandle<Chi2MeasurementEstimatorBase> est;
+  iSetup.get<TrackingComponentsRecord>().get("Chi2",est);
+  edm::Handle<MeasurementTrackerEvent> measurementTrackerEventHandle;
+  iEvent.getByToken(measurementTrackerEventToken_, measurementTrackerEventHandle);
+  edm::ESHandle<Propagator> prop;
+  iSetup.get<TrackingComponentsRecord>().get("PropagatorWithMaterial",prop);
+  Propagator* thePropagator = prop.product()->clone();
+  //determines direction of the propagator => inward
+  if (extrapolateFrom_>=extrapolateTo_) {
+    thePropagator->setPropagationDirection(oppositeToMomentum);
+  }
+  TrajectoryStateCombiner trajStateComb;
+  bool debug_ = false;
+  
+  //Loop over track collection
+  for(TrajTrackAssociationCollection::const_iterator it =  ttac.begin();it !=  ttac.end(); ++it){
+    //define vector to save extrapolated tracks
+    std::vector<TrajectoryMeasurement> expTrajMeasurements;
+
+    const edm::Ref<std::vector<Trajectory> > traj_iterator = it->key;  
+    // Trajectory Map, extract Trajectory for this track
+    reco::TrackRef trackref = it->val;
+    //tracks++;
+    
+    bool isBpixtrack = false, isFpixtrack = false;
+    int nStripHits=0; int L1hits=0; int L2hits=0; int L3hits=0; int L4hits=0; int D1hits=0; int D2hits=0; int D3hits=0;
+    std::vector<TrajectoryMeasurement> tmeasColl =traj_iterator->measurements();
+    std::vector<TrajectoryMeasurement>::const_iterator tmeasIt;
+    //loop on measurements to find out what kind of hits there are
+    for(tmeasIt = tmeasColl.begin();tmeasIt!=tmeasColl.end();tmeasIt++){
+      //if(! tmeasIt->updatedState().isValid()) continue; NOT NECESSARY (I HOPE)
+      TransientTrackingRecHit::ConstRecHitPointer testhit = tmeasIt->recHit();
+      if(testhit->geographicalId().det() != DetId::Tracker) continue; 
+      uint testSubDetID = (testhit->geographicalId().subdetId()); 
+      const DetId & hit_detId = testhit->geographicalId();
+      int hit_layer = 0;
+      int hit_ladder = 0;
+      int hit_mod = 0;
+      int hit_disk = 0;
+      
+      if(testSubDetID==PixelSubdetector::PixelBarrel){
+        isBpixtrack = true;
+	hit_layer = PixelBarrelNameUpgrade(hit_detId).layerName();
+ 	
+	hit_ladder = PXBDetId(hit_detId).ladder();
+	hit_mod = PXBDetId(hit_detId).module();
+
+	if(hit_layer==1) L1hits++;
+	if(hit_layer==2) L2hits++;
+	if(hit_layer==3) L3hits++;
+	if(hit_layer==4) L4hits++;
+      }
+      if(testSubDetID==PixelSubdetector::PixelEndcap){
+        isFpixtrack = true;
+        hit_disk = PixelEndcapNameUpgrade(hit_detId).diskName();
+        
+	if(hit_disk==1) D1hits++;
+	if(hit_disk==2) D2hits++;
+        if(hit_disk==3) D3hits++;
+      }
+      if(testSubDetID==StripSubdetector::TIB) nStripHits++;
+      if(testSubDetID==StripSubdetector::TOB) nStripHits++;
+      if(testSubDetID==StripSubdetector::TID) nStripHits++;
+      if(testSubDetID==StripSubdetector::TEC) nStripHits++;
+      //check if last valid hit is in Layer 2 or Disk 1
+
+      bool lastValidL2 = false;      
+      if ((testSubDetID == PixelSubdetector::PixelBarrel && hit_layer == extrapolateFrom_) 
+	  || (testSubDetID == PixelSubdetector::PixelEndcap && hit_disk == 1)) {
+	if (testhit->isValid()) {
+	  if (tmeasIt == tmeasColl.end()-1) {
+	    lastValidL2=true;
+	  } else {
+	    tmeasIt++;
+	    TransientTrackingRecHit::ConstRecHitPointer nextRecHit = tmeasIt->recHit();
+	    uint nextSubDetID = (nextRecHit->geographicalId().subdetId()); 
+	    int nextlayer = PixelBarrelName(nextRecHit->geographicalId()).layerName();
+	    if (nextSubDetID == PixelSubdetector::PixelBarrel && nextlayer==extrapolateTo_ ) {
+	      lastValidL2=true; //&& !nextRecHit->isValid()) lastValidL2=true;
+	    }
+	    tmeasIt--;
+	  }
+	}
+      }//end check last valid layer
+      if (lastValidL2) {
+	std::vector< const BarrelDetLayer*> pxbLayers = measurementTrackerHandle->geometricSearchTracker()->pixelBarrelLayers();
+	const DetLayer* pxb1 = pxbLayers[extrapolateTo_-1];
+	const MeasurementEstimator* estimator = est.product();
+	const LayerMeasurements* theLayerMeasurements =    new LayerMeasurements(*measurementTrackerHandle, *measurementTrackerEventHandle);  
+	const TrajectoryStateOnSurface tsosPXB2 = tmeasIt->updatedState();
+	expTrajMeasurements = theLayerMeasurements->measurements(*pxb1, tsosPXB2, *thePropagator, *estimator);
+	delete theLayerMeasurements;
+	if ( !expTrajMeasurements.empty()) {
+	  for(uint p=0; p<expTrajMeasurements.size();p++){
+	    TrajectoryMeasurement pxb1TM(expTrajMeasurements[p]);
+	    auto pxb1Hit = pxb1TM.recHit();
+	    //remove hits with rawID == 0
+	    if(pxb1Hit->geographicalId().rawId()==0){
+	      expTrajMeasurements.erase(expTrajMeasurements.begin()+p);
+	      continue;
+	    }
+	  }
+	}
+	//
+      }
+      //check if extrapolated hit to layer 1 one matches the original hit
+      TrajectoryStateOnSurface chkPredTrajState=trajStateComb(tmeasIt->forwardPredictedState(), tmeasIt->backwardPredictedState());
+      float chkx=chkPredTrajState.globalPosition().x();
+      float chky=chkPredTrajState.globalPosition().y();
+      float chkz=chkPredTrajState.globalPosition().z();
+      LocalPoint chklp=chkPredTrajState.localPosition();
+      if (testSubDetID == PixelSubdetector::PixelBarrel && hit_layer == extrapolateTo_) {
+	// Here we will drop the extrapolated hits if there is a hit and use that hit
+	vector<int > imatches;
+	size_t imatch=0;
+	float glmatch=9999.;
+	for (size_t iexp=0; iexp<expTrajMeasurements.size(); iexp++) {
+	  const DetId & exphit_detId = expTrajMeasurements[iexp].recHit()->geographicalId();
+	  int exphit_ladder = PXBDetId(exphit_detId).ladder();
+	  int exphit_mod = PXBDetId(exphit_detId).module();
+	  int dladder = abs( exphit_ladder - hit_ladder ); 
+	  if (dladder > 10) dladder = 20 - dladder;
+	  int dmodule = abs( exphit_mod - hit_mod);
+	  if (dladder != 0 || dmodule != 0) {
+	    continue;
+	  }
+
+ TrajectoryStateOnSurface predTrajState=expTrajMeasurements[iexp].updatedState();
+  float x=predTrajState.globalPosition().x();
+float y=predTrajState.globalPosition().y();
+ float z=predTrajState.globalPosition().z();
+  float dxyz=sqrt((chkx-x)*(chkx-x)+(chky-y)*(chky-y)+(chkz-z)*(chkz-z));
+
+  if (dxyz<=glmatch) {
+      glmatch=dxyz;
+     imatch=iexp;
+    imatches.push_back(int(imatch));
+   }
+
+  } // found the propagated traj best matching the hit in data
+
+  float lxmatch = 9999.0;
+  float lymatch = 9999.0;
+  if(!expTrajMeasurements.empty()){
+    if (glmatch<9999.) { // if there is any propagated trajectory for this hit
+      const DetId & matchhit_detId = expTrajMeasurements[imatch].recHit()->geographicalId();
+      
+      int matchhit_ladder = PXBDetId(matchhit_detId).ladder();
+      int dladder = abs(matchhit_ladder-hit_ladder);
+      if (dladder > 10) dladder = 20 - dladder;
+      LocalPoint lp = expTrajMeasurements[imatch].updatedState().localPosition();
+      lxmatch=fabs(lp.x() - chklp.x());
+      lymatch=fabs(lp.y() - chklp.y());
+    }
+    if (lxmatch < maxlxmatch_ && lymatch < maxlymatch_) {
+      
+      if (testhit->getType()!=TrackingRecHit::missing || keepOriginalMissingHit_) {
+	expTrajMeasurements.erase(expTrajMeasurements.begin()+imatch);
+      }
+      
+    }
+    
+  } //expected trajectory measurment not empty
+ }
+    }//loop on trajectory measurments tmeasColl
+    
+    //if an extrapolated hit was found but not matched to an exisitng L1 hit then push the hit back into the collection
+  //now keep the first one that is left
+  if(!expTrajMeasurements.empty()){
+  for (size_t f=0; f<expTrajMeasurements.size(); f++) {
+    TrajectoryMeasurement AddHit=expTrajMeasurements[f];
+    if (AddHit.recHit()->getType()==TrackingRecHit::missing){
+      tmeasColl.push_back(AddHit);
+      isBpixtrack = true;
+
+    }
+    
+  }
+
+
+
+    }
+    if(isBpixtrack || isFpixtrack){
+      if(trackref->pt()<0.6 ||
+         nStripHits<11 ||
+	 fabs(trackref->dxy(bestVtx->position()))>0.05 ||
+	 fabs(trackref->dz(bestVtx->position()))>0.5) continue;
+    
+      if(debug_){
+        std::cout << "isBpixtrack : " << isBpixtrack << std::endl;
+        std::cout << "isFpixtrack : " << isFpixtrack << std::endl;
+      }
+      //std::cout<<"This tracks has so many hits: "<<tmeasColl.size()<<std::endl;
+      for(std::vector<TrajectoryMeasurement>::const_iterator tmeasIt = tmeasColl.begin(); tmeasIt!=tmeasColl.end(); tmeasIt++){   
+	//if(! tmeasIt->updatedState().isValid()) continue; 
+	TrajectoryStateOnSurface tsos = tmeasIt->updatedState();
+
+	TransientTrackingRecHit::ConstRecHitPointer hit = tmeasIt->recHit();
+	if(hit->geographicalId().det() != DetId::Tracker )
+	  continue; 
+	else {
+	  
+// 	  //residual
+      	  const DetId & hit_detId = hit->geographicalId();
+	  //uint IntRawDetID = (hit_detId.rawId());
+	  uint IntSubDetID = (hit_detId.subdetId());
+	  
+ 	  if(IntSubDetID == 0 ){
+	    if(debug_) std::cout << "NO IntSubDetID\n";
+	    continue;
+	  }
+	  if(IntSubDetID!=PixelSubdetector::PixelBarrel && IntSubDetID!=PixelSubdetector::PixelEndcap)
+	    continue;
+	  
+	  int disk=0; int layer=0; int panel=0; int module=0; bool isHalfModule=false;
+	  if(IntSubDetID==PixelSubdetector::PixelBarrel){ // it's a BPIX hit
+	    layer = PixelBarrelNameUpgrade(hit_detId).layerName();
+	    isHalfModule = PixelBarrelNameUpgrade(hit_detId).isHalfModule();
+	  }else if(IntSubDetID==PixelSubdetector::PixelEndcap){ // it's an FPIX hit
+	    disk = PixelEndcapNameUpgrade(hit_detId).diskName();
+	    panel = PixelEndcapNameUpgrade(hit_detId).pannelName();
+	    module = PixelEndcapNameUpgrade(hit_detId).plaquetteName();
+          }
+          
+	  if(layer==1){
+	    if(fabs(trackref->dxy(bestVtx->position()))>0.01 ||
+	       fabs(trackref->dz(bestVtx->position()))>0.1) continue;
+	    if(!(L2hits>0&&L3hits>0&&L4hits>0) && !(L2hits>0&&D1hits>0&&D2hits) && !(D1hits>0&&D2hits>0&&D3hits>0)) continue;
+	  }else if(layer==2){
+	    if(fabs(trackref->dxy(bestVtx->position()))>0.02 ||
+	       fabs(trackref->dz(bestVtx->position()))>0.1) continue;
+	    if(!(L1hits>0&&L3hits>0&&L4hits>0) && !(L1hits>0&&L3hits>0&&D1hits>0) && !(L1hits>0&&D1hits>0&&D2hits>0)) continue;
+	  }else if(layer==3){
+	    if(fabs(trackref->dxy(bestVtx->position()))>0.02 ||
+	       fabs(trackref->dz(bestVtx->position()))>0.1) continue;
+	    if(!(L1hits>0&&L2hits>0&&L4hits>0) && !(L1hits>0&&L2hits>0&&D1hits>0)) continue;
+	  }else if(layer==4){
+	    if(fabs(trackref->dxy(bestVtx->position()))>0.02 ||
+	       fabs(trackref->dz(bestVtx->position()))>0.1) continue;
+	    if(!(L1hits>0&&L2hits>0&&L3hits>0)) continue; 
+	  }else if(disk==1){
+	    if(fabs(trackref->dxy(bestVtx->position()))>0.05 ||
+	       fabs(trackref->dz(bestVtx->position()))>0.5) continue;
+	    if(!(L1hits>0&&L2hits>0&&D2hits>0) && !(L1hits>0&&D2hits>0&&D3hits>0) && !(L2hits>0&&D2hits>0&&D3hits>0)) continue;
+	  }else if(disk==2){
+	    if(fabs(trackref->dxy(bestVtx->position()))>0.05 ||
+	       fabs(trackref->dz(bestVtx->position()))>0.5) continue;
+	    if(!(L1hits>0&&L2hits>0&&D1hits>0) && !(L1hits>0&&D1hits>0&&D3hits>0) && !(L2hits>0&&D1hits>0&&D3hits>0)) continue;
+	  }else if(disk==3){
+	    if(fabs(trackref->dxy(bestVtx->position()))>0.05 ||
+	       fabs(trackref->dz(bestVtx->position()))>0.5) continue;
+	    if(!(L1hits>0&&D1hits>0&&D2hits>0) && !(L2hits>0&&D1hits>0&&D2hits>0)) continue;
+	  }
+	  
+	  //check whether hit is valid or missing using track algo flag
+          bool isHitValid   =hit->hit()->getType()==TrackingRecHit::valid;
+          bool isHitMissing =hit->hit()->getType()==TrackingRecHit::missing;
+	  
+	  if(debug_) std::cout << "the hit is persistent\n";
+	 
+	  std::map<uint32_t, SiPixelHitEfficiencyModulePhase1*>::iterator pxd = theSiPixelStructure.find((*hit).geographicalId().rawId());
+
+	  // calculate alpha and beta from cluster position
+	  LocalTrajectoryParameters ltp = tsos.localParameters();
+	  //LocalVector localDir = ltp.momentum()/ltp.momentum().mag();
+	      
+	  //*************** Edge cut ********************
+	  double lx=tsos.localPosition().x();
+	  double ly=tsos.localPosition().y();
+
+	  if(fabs(lx)>0.55 || fabs(ly)>3.0) continue;
+
+	  bool passedFiducial=true;
+	  // Module fiducials:
+	  if(IntSubDetID==PixelSubdetector::PixelBarrel && fabs(ly)>=3.1) passedFiducial=false;
+	  if(IntSubDetID==PixelSubdetector::PixelEndcap &&
+	     !((panel==1 &&
+		((module==1 && fabs(ly)<0.7) ||
+		 ((module==2 && fabs(ly)<1.1) &&
+		  !(disk==-1 && ly>0.8 && lx>0.2) &&
+		  !(disk==1 && ly<-0.7 && lx>0.2) &&
+		  !(disk==2 && ly<-0.8)) ||
+		 ((module==3 && fabs(ly)<1.5) &&
+		  !(disk==-2 && lx>0.1 && ly>1.0) &&
+		  !(disk==2 && lx>0.1 && ly<-1.0)) ||
+		 ((module==4 && fabs(ly)<1.9) &&
+		  !(disk==-2 && ly>1.5) &&
+		  !(disk==2 && ly<-1.5)))) ||
+	       (panel==2 &&
+		((module==1 && fabs(ly)<0.7) ||
+		 (module==2 && fabs(ly)<1.2 &&
+		  !(disk>0 && ly>1.1) &&
+		  !(disk<0 && ly<-1.1)) ||
+		 (module==3 && fabs(ly)<1.6 &&
+		  !(disk>0 && ly>1.5) &&
+		  !(disk<0 && ly<-1.5)))))) passedFiducial=false;
+	  if(IntSubDetID==PixelSubdetector::PixelEndcap &&
+	     ((panel==1 && (module==1 || (module>=3 && abs(disk)==1))) ||
+	      (panel==2 && ((module==1 && abs(disk)==2) ||
+			    (module==3 && abs(disk)==1))))) passedFiducial=false;
+	  // ROC fiducials:
+	  double ly_mod = fabs(ly);
+	  if(IntSubDetID==PixelSubdetector::PixelEndcap && (panel+module)%2==1) ly_mod=ly_mod+0.405;
+	  float d_rocedge = fabs(fmod(ly_mod,0.81)-0.405);
+	  if(d_rocedge<=0.0625) passedFiducial=false;
+	  if(!( (IntSubDetID==PixelSubdetector::PixelBarrel &&
+		 ((!isHalfModule && fabs(lx)<0.6) ||
+		  (isHalfModule && lx>-0.3 && lx<0.2))) ||
+		(IntSubDetID==PixelSubdetector::PixelEndcap &&
+		 ((panel==1 &&
+		   ((module==1 && fabs(lx)<0.2) ||
+		    (module==2 &&
+		     ((fabs(lx)<0.55 && abs(disk)==1) ||
+		      (lx>-0.5 && lx<0.2 && disk==-2) ||
+		      (lx>-0.5 && lx<0.0 && disk==2))) ||
+		    (module==3 && lx>-0.6 && lx<0.5) ||
+		    (module==4 && lx>-0.3 && lx<0.15))) ||
+		  (panel==2 &&
+		   ((module==1 && fabs(lx)<0.6) ||
+		    (module==2 &&
+		     ((fabs(lx)<0.55 && abs(disk)==1) ||
+		      (lx>-0.6 && lx<0.5 && abs(disk)==2))) ||
+		    (module==3 && fabs(lx)<0.5))))))) passedFiducial=false;
+	  if(((IntSubDetID==PixelSubdetector::PixelBarrel && !isHalfModule) || 
+	      (IntSubDetID==PixelSubdetector::PixelEndcap && !(panel==1 && (module==1 || module==4)))) &&
+	     fabs(lx)<0.06) passedFiducial=false;
+	       
+	       
+	  //*************** find closest clusters ********************
+	  float dx_cl[2]; float dy_cl[2]; dx_cl[0]=dx_cl[1]=dy_cl[0]=dy_cl[1]=-9999.;
+	  ESHandle<PixelClusterParameterEstimator> cpEstimator;
+	  iSetup.get<TkPixelCPERecord>().get("PixelCPEGeneric", cpEstimator);
+	  if(cpEstimator.isValid()){
+	    const PixelClusterParameterEstimator &cpe(*cpEstimator);
+	    edm::ESHandle<TrackerGeometry> tracker;
+	    iSetup.get<TrackerDigiGeometryRecord>().get(tracker);
+	    if(tracker.isValid()){
+	      const TrackerGeometry *tkgeom=&(*tracker);
+	      edm::Handle<edmNew::DetSetVector<SiPixelCluster> > clusterCollectionHandle;
+	      iEvent.getByToken( clusterCollectionToken_, clusterCollectionHandle );
+	      if(clusterCollectionHandle.isValid()){
+		const edmNew::DetSetVector<SiPixelCluster>& clusterCollection=*clusterCollectionHandle;
+		edmNew::DetSetVector<SiPixelCluster>::const_iterator itClusterSet=clusterCollection.begin();
+		float minD[2]; minD[0]=minD[1]=10000.;
+		for( ; itClusterSet!=clusterCollection.end(); itClusterSet++){
+		  DetId detId(itClusterSet->id());
+		  if(detId.rawId()!=hit->geographicalId().rawId()) continue;
+		  //unsigned int sdId=detId.subdetId();
+		  const PixelGeomDetUnit *pixdet=(const PixelGeomDetUnit*) tkgeom->idToDetUnit(detId);
+		  edmNew::DetSet<SiPixelCluster>::const_iterator itCluster=itClusterSet->begin();
+		  for( ; itCluster!=itClusterSet->end(); ++itCluster){
+		    LocalPoint lp(itCluster->x(), itCluster->y(), 0.);
+		    PixelClusterParameterEstimator::ReturnType params=cpe.getParameters(*itCluster,*pixdet);
+		    lp=std::get<0>(params);
+		    float D = sqrt((lp.x()-lx)*(lp.x()-lx)+(lp.y()-ly)*(lp.y()-ly));
+		    if(D<minD[0]){
+		      minD[1]=minD[0];
+		      dx_cl[1]=dx_cl[0];
+		      dy_cl[1]=dy_cl[0];
+		      minD[0]=D;
+		      dx_cl[0]=lp.x();
+		      dy_cl[0]=lp.y();
+		    }else if(D<minD[1]){
+		      minD[1]=D;
+		      dx_cl[1]=lp.x();
+		      dy_cl[1]=lp.y();
+		    }
+		  }  // loop on clusterSets 
+		} // loop on clusterCollection
+		for(size_t i=0; i<2; i++){
+		  if(minD[i]<9999.){
+		    dx_cl[i]=fabs(dx_cl[i]-lx);
+		    dy_cl[i]=fabs(dy_cl[i]-ly);
+		  }
+		}
+	      } // valid clusterCollectionHandle
+	    } // valid tracker
+	  } // valid cpEstimator
+	  // distance of hit from closest cluster!
+	  float d_cl[2]; d_cl[0]=d_cl[1]=-9999.;
+	  if(dx_cl[0]!=-9999. && dy_cl[0]!=-9999.) d_cl[0]=sqrt(dx_cl[0]*dx_cl[0]+dy_cl[0]*dy_cl[0]);
+	  if(dx_cl[1]!=-9999. && dy_cl[1]!=-9999.) d_cl[1]=sqrt(dx_cl[1]*dx_cl[1]+dy_cl[1]*dy_cl[1]);
+	  if(isHitMissing && (d_cl[0]<0.05 || d_cl[1]<0.05)){ isHitMissing=0; isHitValid=1; }
+	      
+	      
+	  if(debug_){
+	    std::cout << "Ready to add hit in histogram:\n";
+	    //std::cout << "detid: "<<hit_detId<<std::endl;
+	    std::cout << "isHitValid: "<<isHitValid<<std::endl;
+	    std::cout << "isHitMissing: "<<isHitMissing<<std::endl;
+	    //std::cout << "passedEdgeCut: "<<passedFiducial<<std::endl;		
+	  }
+	      
+	      
+	  if(pxd!=theSiPixelStructure.end() && isHitValid && passedFiducial)
+	    ++nvalid;
+	  if(pxd!=theSiPixelStructure.end() && isHitMissing && passedFiducial)
+	    ++nmissing;
+		
+	  if (pxd!=theSiPixelStructure.end() && passedFiducial && (isHitValid || isHitMissing))
+	    (*pxd).second->fill(ltp, isHitValid, modOn, ladOn, layOn, phiOn, bladeOn, diskOn, ringOn); 	
+
+	  //}//end if (persistent hit exists and is pixel hit)
+	  
+	}//end of else 
+	
+	
+      }//end for (all traj measurements of pixeltrack)
+    }//end if (is pixeltrack)
+    else
+      if(debug_) std::cout << "no pixeltrack:\n";
+    
+  }//end loop on map entries
+}
+
+
+DEFINE_FWK_MODULE(SiPixelHitEfficiencySourcePhase1); // define this as a plug-in 

--- a/DQM/SiPixelMonitorTrack/src/SiPixelTrackResidualModule.cc
+++ b/DQM/SiPixelMonitorTrack/src/SiPixelTrackResidualModule.cc
@@ -48,17 +48,13 @@ SiPixelTrackResidualModule::~SiPixelTrackResidualModule() {
 }
 
 
-void SiPixelTrackResidualModule::book(const edm::ParameterSet& iConfig, DQMStore::IBooker & iBooker, bool reducedSet, int type, bool isUpgrade) {
+void SiPixelTrackResidualModule::book(const edm::ParameterSet& iConfig, DQMStore::IBooker & iBooker, bool reducedSet, int type) {
 
   bool barrel = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
   bool endcap = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap);
   bool isHalfModule = false;
   if(barrel){
-    if (!isUpgrade) {
     isHalfModule = PixelBarrelName(DetId(id_)).isHalfModule(); 
-    } else if (isUpgrade) {
-      isHalfModule = PixelBarrelNameUpgrade(DetId(id_)).isHalfModule(); 
-    }
   }
   
   edm::InputTag src = iConfig.getParameter<edm::InputTag>("src");
@@ -119,8 +115,7 @@ void SiPixelTrackResidualModule::book(const edm::ParameterSet& iConfig, DQMStore
 
   if(type==1 && barrel){
     uint32_t DBladder;
-    if (!isUpgrade) { DBladder = PixelBarrelName(DetId(id_)).ladderName(); }
-    else { DBladder = PixelBarrelNameUpgrade(DetId(id_)).ladderName(); }
+    DBladder = PixelBarrelName(DetId(id_)).ladderName();
     char sladder[80]; sprintf(sladder,"Ladder_%02i",DBladder);
     hisID = src.label() + "_" + sladder;
     if(isHalfModule) hisID += "H";
@@ -165,8 +160,7 @@ void SiPixelTrackResidualModule::book(const edm::ParameterSet& iConfig, DQMStore
 
   if(type==2 && barrel){
     uint32_t DBlayer;
-    if (!isUpgrade) { DBlayer = PixelBarrelName(DetId(id_)).layerName(); }
-    else { DBlayer = PixelBarrelNameUpgrade(DetId(id_)).layerName(); }
+    DBlayer = PixelBarrelName(DetId(id_)).layerName();
     char slayer[80]; sprintf(slayer,"Layer_%i",DBlayer);
     hisID = src.label() + "_" + slayer;
     meResidualXLay_ = iBooker.book1D("residualX_"+hisID,"Hit-to-Track Residual in r-phi",100,-150,150);
@@ -209,8 +203,7 @@ void SiPixelTrackResidualModule::book(const edm::ParameterSet& iConfig, DQMStore
 
   if(type==3 && barrel){
     uint32_t DBmodule;
-    if (!isUpgrade) { DBmodule = PixelBarrelName(DetId(id_)).moduleName(); }
-    else { DBmodule = PixelBarrelNameUpgrade(DetId(id_)).moduleName(); }
+    DBmodule = PixelBarrelName(DetId(id_)).moduleName();
     char smodule[80]; sprintf(smodule,"Ring_%i",DBmodule);
     hisID = src.label() + "_" + smodule;
     meResidualXPhi_ = iBooker.book1D("residualX_"+hisID,"Hit-to-Track Residual in r-phi",100,-150,150);
@@ -253,8 +246,7 @@ void SiPixelTrackResidualModule::book(const edm::ParameterSet& iConfig, DQMStore
 
   if(type==4 && endcap){
     uint32_t blade;
-    if (!isUpgrade) { blade= PixelEndcapName(DetId(id_)).bladeName(); }
-    else { blade= PixelEndcapNameUpgrade(DetId(id_)).bladeName(); }
+    blade= PixelEndcapName(DetId(id_)).bladeName();
     char sblade[80]; sprintf(sblade, "Blade_%02i",blade);
     hisID = src.label() + "_" + sblade;
     meResidualXBlade_ = iBooker.book1D("residualX_"+hisID,"Hit-to-Track Residual in r-phi",100,-150,150);
@@ -297,8 +289,7 @@ void SiPixelTrackResidualModule::book(const edm::ParameterSet& iConfig, DQMStore
 
   if(type==5 && endcap){
     uint32_t disk;
-    if (!isUpgrade) { disk = PixelEndcapName(DetId(id_)).diskName(); }
-    else { disk = PixelEndcapNameUpgrade(DetId(id_)).diskName(); }
+    disk = PixelEndcapName(DetId(id_)).diskName();
     
     char sdisk[80]; sprintf(sdisk, "Disk_%i",disk);
     hisID = src.label() + "_" + sdisk;
@@ -343,13 +334,8 @@ void SiPixelTrackResidualModule::book(const edm::ParameterSet& iConfig, DQMStore
   if(type==6 && endcap){
     uint32_t panel;
     uint32_t module;
-    if (!isUpgrade) {
-      panel= PixelEndcapName(DetId(id_)).pannelName();
-      module= PixelEndcapName(DetId(id_)).plaquetteName();
-    } else {
-      panel= PixelEndcapNameUpgrade(DetId(id_)).pannelName();
-      module= PixelEndcapNameUpgrade(DetId(id_)).plaquetteName();
-    }
+    panel= PixelEndcapName(DetId(id_)).pannelName();
+    module= PixelEndcapName(DetId(id_)).plaquetteName();
     
     char slab[80]; sprintf(slab, "Panel_%i_Ring_%i",panel, module);
     hisID = src.label() + "_" + slab;

--- a/DQM/SiPixelMonitorTrack/src/SiPixelTrackResidualModulePhase1.cc
+++ b/DQM/SiPixelMonitorTrack/src/SiPixelTrackResidualModulePhase1.cc
@@ -1,0 +1,594 @@
+// Package:    SiPixelMonitorTrack
+// Class:      SiPixelTrackResidualModulePhase1
+// 
+// class SiPixelTrackResidualModulePhase1 SiPixelTrackResidualModulePhase1.cc 
+//       DQM/SiPixelMonitorTrack/src/SiPixelTrackResidualModulePhase1.cc
+//
+// Description: SiPixel hit-to-track residual data quality monitoring modules
+// Implementation: prototype -> improved -> never final - end of the 1st step 
+//
+// Original Author: Shan-Huei Chuang
+//         Created: Fri Mar 23 18:41:42 CET 2007
+
+
+#include <string>
+#include <iostream>
+
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "DQM/SiPixelCommon/interface/SiPixelHistogramId.h"
+#include "DQM/SiPixelMonitorTrack/interface/SiPixelTrackResidualModulePhase1.h"
+
+// Data Formats
+#include "DataFormats/SiPixelDetId/interface/PixelBarrelName.h"
+#include "DataFormats/SiPixelDetId/interface/PixelBarrelNameUpgrade.h"
+#include "DataFormats/SiPixelDetId/interface/PixelEndcapName.h"
+#include "DataFormats/SiPixelDetId/interface/PixelEndcapNameUpgrade.h"
+#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+
+
+using namespace std; 
+
+
+SiPixelTrackResidualModulePhase1::SiPixelTrackResidualModulePhase1() : id_(0) {
+  bBookTracks = true;
+}
+
+
+SiPixelTrackResidualModulePhase1::SiPixelTrackResidualModulePhase1(uint32_t id) : id_(id) { 
+  bBookTracks = true;
+}
+
+
+SiPixelTrackResidualModulePhase1::~SiPixelTrackResidualModulePhase1() { 
+ 
+}
+
+
+void SiPixelTrackResidualModulePhase1::book(const edm::ParameterSet& iConfig, DQMStore::IBooker & iBooker, bool reducedSet, int type) {
+
+  bool barrel = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
+  bool endcap = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap);
+  bool isHalfModule = false;
+  if(barrel){
+    isHalfModule = PixelBarrelNameUpgrade(DetId(id_)).isHalfModule(); 
+  }
+  
+  edm::InputTag src = iConfig.getParameter<edm::InputTag>("src");
+  std::string hisID;
+
+  if(type==0){
+    SiPixelHistogramId* theHistogramId = new SiPixelHistogramId(src.label());
+    hisID = theHistogramId->setHistoId("residualX",id_);
+    meResidualX_ = iBooker.book1D(hisID,"Hit-to-Track Residual in r-phi",100,-150,150);
+    meResidualX_->setAxisTitle("hit-to-track residual in r-phi (um)",1);
+    hisID = theHistogramId->setHistoId("residualY",id_);
+    meResidualY_ = iBooker.book1D(hisID,"Hit-to-Track Residual in Z",100,-300,300);
+    meResidualY_->setAxisTitle("hit-to-track residual in z (um)",1);
+    // Number of clusters
+    hisID = theHistogramId->setHistoId("nclusters_OnTrack",id_);
+    meNClusters_onTrack_ = iBooker.book1D(hisID,"Number of Clusters (on Track)",10,0.,10.);
+    meNClusters_onTrack_->setAxisTitle("Number of Clusters on Track",1);
+    // Total cluster charge in ke
+    hisID = theHistogramId->setHistoId("charge_OnTrack",id_);
+    meCharge_onTrack_ = iBooker.book1D(hisID,"Normalized Cluster charge (on Track)",100,0.,200.);
+    meCharge_onTrack_->setAxisTitle("Charge [kilo electrons]",1);
+    // Total cluster size (in pixels)
+    hisID = theHistogramId->setHistoId("size_OnTrack",id_);
+    meSize_onTrack_ = iBooker.book1D(hisID,"Total cluster size (on Track)",30,0.,30.);
+    meSize_onTrack_->setAxisTitle("Cluster size [number of pixels]",1);
+    // Number of clusters
+    hisID = theHistogramId->setHistoId("nclusters_OffTrack",id_);
+    meNClusters_offTrack_ = iBooker.book1D(hisID,"Number of Clusters (off Track)",35,0.,35.);
+    meNClusters_offTrack_->setAxisTitle("Number of Clusters off Track",1);
+    // Total cluster charge in ke
+    hisID = theHistogramId->setHistoId("charge_OffTrack",id_);
+    meCharge_offTrack_ = iBooker.book1D(hisID,"Cluster charge (off Track)",100,0.,200.);
+    meCharge_offTrack_->setAxisTitle("Charge [kilo electrons]",1);
+    // Total cluster size (in pixels)
+    hisID = theHistogramId->setHistoId("size_OffTrack",id_);
+    meSize_offTrack_ = iBooker.book1D(hisID,"Total cluster size (off Track)",30,0.,30.);
+    meSize_offTrack_->setAxisTitle("Cluster size [number of pixels]",1);
+    if(!reducedSet){
+      // Cluster width on the x-axis
+      hisID = theHistogramId->setHistoId("sizeX_OnTrack",id_);
+      meSizeX_onTrack_ = iBooker.book1D(hisID,"Cluster x-width (rows) (on Track)",10,0.,10.);
+      meSizeX_onTrack_->setAxisTitle("Cluster x-size [rows]",1);
+      // Cluster width on the y-axis
+      hisID = theHistogramId->setHistoId("sizeY_OnTrack",id_);
+      meSizeY_onTrack_ = iBooker.book1D(hisID,"Cluster y-width (columns) (on Track)",15,0.,15.);
+      meSizeY_onTrack_->setAxisTitle("Cluster y-size [columns]",1);
+      // Cluster width on the x-axis
+      hisID = theHistogramId->setHistoId("sizeX_OffTrack",id_);
+      meSizeX_offTrack_ = iBooker.book1D(hisID,"Cluster x-width (rows) (off Track)",10,0.,10.);
+      meSizeX_offTrack_->setAxisTitle("Cluster x-size [rows]",1);
+      // Cluster width on the y-axis
+      hisID = theHistogramId->setHistoId("sizeY_OffTrack",id_);
+      meSizeY_offTrack_ = iBooker.book1D(hisID,"Cluster y-width (columns) (off Track)",15,0.,15.);
+      meSizeY_offTrack_->setAxisTitle("Cluster y-size [columns]",1);
+    }
+    delete theHistogramId;
+  }
+
+  if(type==1 && barrel){
+    uint32_t DBladder;
+    DBladder = PixelBarrelNameUpgrade(DetId(id_)).ladderName();
+    char sladder[80]; sprintf(sladder,"Ladder_%02i",DBladder);
+    hisID = src.label() + "_" + sladder;
+    if(isHalfModule) hisID += "H";
+    else hisID += "F";
+    meResidualXLad_ = iBooker.book1D("residualX_"+hisID,"Hit-to-Track Residual in r-phi",100,-150,150);
+    meResidualXLad_->setAxisTitle("hit-to-track residual in r-phi (um)",1);
+    meResidualYLad_ = iBooker.book1D("residualY_"+hisID,"Hit-to-Track Residual in Z",100,-300,300);
+    meResidualYLad_->setAxisTitle("hit-to-track residual in z (um)",1);
+    // Number of clusters
+    meNClusters_onTrackLad_ = iBooker.book1D("nclusters_OnTrack_" + hisID,"Number of Clusters (on Track)",10,0.,10.);
+    meNClusters_onTrackLad_->setAxisTitle("Number of Clusters on Track",1);
+    // Total cluster charge in MeV
+    meCharge_onTrackLad_ = iBooker.book1D("charge_OnTrack_" + hisID,"Normalized Cluster charge (on Track)",100,0.,200.);
+    meCharge_onTrackLad_->setAxisTitle("Charge [kilo electrons]",1);
+    // Total cluster size (in pixels)
+    meSize_onTrackLad_ = iBooker.book1D("size_OnTrack_" + hisID,"Total cluster size (on Track)",30,0.,30.);
+    meSize_onTrackLad_->setAxisTitle("Cluster size [number of pixels]",1);
+    // Number of clusters
+    meNClusters_offTrackLad_ = iBooker.book1D("nclusters_OffTrack_" + hisID,"Number of Clusters (off Track)",35,0.,35.);
+    meNClusters_offTrackLad_->setAxisTitle("Number of Clusters off Track",1);
+    // Total cluster charge in MeV
+    meCharge_offTrackLad_ = iBooker.book1D("charge_OffTrack_" + hisID,"Cluster charge (off Track)",100,0.,200.);
+    meCharge_offTrackLad_->setAxisTitle("Charge [kilo electrons]",1);
+    // Total cluster size (in pixels)
+    meSize_offTrackLad_ = iBooker.book1D("size_OffTrack_" + hisID,"Total cluster size (off Track)",30,0.,30.);
+    meSize_offTrackLad_->setAxisTitle("Cluster size [number of pixels]",1);
+    if(!reducedSet){
+      // Cluster width on the x-axis
+      meSizeX_offTrackLad_ = iBooker.book1D("sizeX_OffTrack_" + hisID,"Cluster x-width (rows) (off Track)",10,0.,10.);
+      meSizeX_offTrackLad_->setAxisTitle("Cluster x-size [rows]",1);
+      // Cluster width on the y-axis
+      meSizeY_offTrackLad_ = iBooker.book1D("sizeY_OffTrack_" + hisID,"Cluster y-width (columns) (off Track)",15,0.,15.);
+      meSizeY_offTrackLad_->setAxisTitle("Cluster y-size [columns]",1);
+      // Cluster width on the x-axis
+      meSizeX_onTrackLad_ = iBooker.book1D("sizeX_OnTrack_" + hisID,"Cluster x-width (rows) (on Track)",10,0.,10.);
+      meSizeX_onTrackLad_->setAxisTitle("Cluster x-size [rows]",1);
+      // Cluster width on the y-axis
+      meSizeY_onTrackLad_ = iBooker.book1D("sizeY_OnTrack_" + hisID,"Cluster y-width (columns) (on Track)",15,0.,15.);
+      meSizeY_onTrackLad_->setAxisTitle("Cluster y-size [columns]",1);
+    }
+  }
+
+  if(type==2 && barrel){
+    uint32_t DBlayer;
+    DBlayer = PixelBarrelNameUpgrade(DetId(id_)).layerName();
+    char slayer[80]; sprintf(slayer,"Layer_%i",DBlayer);
+    hisID = src.label() + "_" + slayer;
+    meResidualXLay_ = iBooker.book1D("residualX_"+hisID,"Hit-to-Track Residual in r-phi",100,-150,150);
+    meResidualXLay_->setAxisTitle("hit-to-track residual in r-phi (um)",1);
+    meResidualYLay_ = iBooker.book1D("residualY_"+hisID,"Hit-to-Track Residual in Z",100,-300,300);
+    meResidualYLay_->setAxisTitle("hit-to-track residual in z (um)",1);
+    // Number of clusters
+    meNClusters_onTrackLay_ = iBooker.book1D("nclusters_OnTrack_" + hisID,"Number of Clusters (on Track)",10,0.,10.);
+    meNClusters_onTrackLay_->setAxisTitle("Number of Clusters on Track",1);
+    // Total cluster charge in MeV
+    meCharge_onTrackLay_ = iBooker.book1D("charge_OnTrack_" + hisID,"Normalized Cluster charge (on Track)",100,0.,200.);
+    meCharge_onTrackLay_->setAxisTitle("Charge [kilo electrons]",1);
+    // Total cluster size (in pixels)
+    meSize_onTrackLay_ = iBooker.book1D("size_OnTrack_" + hisID,"Total cluster size (on Track)",30,0.,30.);
+    meSize_onTrackLay_->setAxisTitle("Cluster size [number of pixels]",1);    
+    // Number of clusters
+    meNClusters_offTrackLay_ = iBooker.book1D("nclusters_OffTrack_" + hisID,"Number of Clusters (off Track)",35,0.,35.);
+    meNClusters_offTrackLay_->setAxisTitle("Number of Clusters off Track",1);
+    // Total cluster charge in MeV
+    meCharge_offTrackLay_ = iBooker.book1D("charge_OffTrack_" + hisID,"Cluster charge (off Track)",100,0.,200.);
+    meCharge_offTrackLay_->setAxisTitle("Charge [kilo electrons]",1);
+    // Total cluster size (in pixels)
+    meSize_offTrackLay_ = iBooker.book1D("size_OffTrack_" + hisID,"Total cluster size (off Track)",30,0.,30.);
+    meSize_offTrackLay_->setAxisTitle("Cluster size [number of pixels]",1);
+    if(!reducedSet){
+      // Cluster width on the x-axis
+      meSizeX_onTrackLay_ = iBooker.book1D("sizeX_OnTrack_" + hisID,"Cluster x-width (rows) (on Track)",10,0.,10.);
+      meSizeX_onTrackLay_->setAxisTitle("Cluster x-size [rows]",1);
+      // Cluster width on the y-axis
+      meSizeY_onTrackLay_ = iBooker.book1D("sizeY_OnTrack_" + hisID,"Cluster y-width (columns) (on Track)",15,0.,15.);
+      meSizeY_onTrackLay_->setAxisTitle("Cluster y-size [columns]",1);
+      // Cluster width on the x-axis
+      meSizeX_offTrackLay_ = iBooker.book1D("sizeX_OffTrack_" + hisID,"Cluster x-width (rows) (off Track)",10,0.,10.);
+      meSizeX_offTrackLay_->setAxisTitle("Cluster x-size [rows]",1);
+      // Cluster width on the y-axis
+      meSizeY_offTrackLay_ = iBooker.book1D("sizeY_OffTrack_" + hisID,"Cluster y-width (columns) (off Track)",15,0.,15.);
+      meSizeY_offTrackLay_->setAxisTitle("Cluster y-size [columns]",1);
+    }
+  }
+
+  if(type==3 && barrel){
+    uint32_t DBmodule;
+    DBmodule = PixelBarrelNameUpgrade(DetId(id_)).moduleName();
+    char smodule[80]; sprintf(smodule,"Ring_%i",DBmodule);
+    hisID = src.label() + "_" + smodule;
+    meResidualXPhi_ = iBooker.book1D("residualX_"+hisID,"Hit-to-Track Residual in r-phi",100,-150,150);
+    meResidualXPhi_->setAxisTitle("hit-to-track residual in r-phi (um)",1);
+    meResidualYPhi_ = iBooker.book1D("residualY_"+hisID,"Hit-to-Track Residual in Z",100,-300,300);
+    meResidualYPhi_->setAxisTitle("hit-to-track residual in z (um)",1);
+    // Number of clusters
+    meNClusters_onTrackPhi_ = iBooker.book1D("nclusters_OnTrack_" + hisID,"Number of Clusters (on Track)",10,0.,10.);
+    meNClusters_onTrackPhi_->setAxisTitle("Number of Clusters on Track",1);
+    // Total cluster charge in MeV
+    meCharge_onTrackPhi_ = iBooker.book1D("charge_OnTrack_" + hisID,"Normalized Cluster charge (on Track)",100,0.,200.);
+    meCharge_onTrackPhi_->setAxisTitle("Charge [kilo electrons]",1);
+    // Total cluster size (in pixels)
+    meSize_onTrackPhi_ = iBooker.book1D("size_OnTrack_" + hisID,"Total cluster size (on Track)",30,0.,30.);
+    meSize_onTrackPhi_->setAxisTitle("Cluster size [number of pixels]",1);    
+    // Number of clusters
+    meNClusters_offTrackPhi_ = iBooker.book1D("nclusters_OffTrack_" + hisID,"Number of Clusters (off Track)",35,0.,35.);
+    meNClusters_offTrackPhi_->setAxisTitle("Number of Clusters off Track",1);
+    // Total cluster charge in MeV
+    meCharge_offTrackPhi_ = iBooker.book1D("charge_OffTrack_" + hisID,"Cluster charge (off Track)",100,0.,200.);
+    meCharge_offTrackPhi_->setAxisTitle("Charge [kilo electrons]",1);
+    // Total cluster size (in pixels)
+    meSize_offTrackPhi_ = iBooker.book1D("size_OffTrack_" + hisID,"Total cluster size (off Track)",30,0.,30.);
+    meSize_offTrackPhi_->setAxisTitle("Cluster size [number of pixels]",1);
+    if(!reducedSet){
+      // Cluster width on the x-axis
+      meSizeX_onTrackPhi_ = iBooker.book1D("sizeX_OnTrack_" + hisID,"Cluster x-width (rows) (on Track)",10,0.,10.);
+      meSizeX_onTrackPhi_->setAxisTitle("Cluster x-size [rows]",1);
+      // Cluster width on the y-axis
+      meSizeY_onTrackPhi_ = iBooker.book1D("sizeY_OnTrack_" + hisID,"Cluster y-width (columns) (on Track)",15,0.,15.);
+      meSizeY_onTrackPhi_->setAxisTitle("Cluster y-size [columns]",1);
+      // Cluster width on the x-axis
+      meSizeX_offTrackPhi_ = iBooker.book1D("sizeX_OffTrack_" + hisID,"Cluster x-width (rows) (off Track)",10,0.,10.);
+      meSizeX_offTrackPhi_->setAxisTitle("Cluster x-size [rows]",1);
+      // Cluster width on the y-axis
+      meSizeY_offTrackPhi_ = iBooker.book1D("sizeY_OffTrack_" + hisID,"Cluster y-width (columns) (off Track)",15,0.,15.);
+      meSizeY_offTrackPhi_->setAxisTitle("Cluster y-size [columns]",1);
+    }
+  }
+
+  if(type==4 && endcap){
+    uint32_t blade;
+    blade= PixelEndcapNameUpgrade(DetId(id_)).bladeName();
+    char sblade[80]; sprintf(sblade, "Blade_%02i",blade);
+    hisID = src.label() + "_" + sblade;
+    meResidualXBlade_ = iBooker.book1D("residualX_"+hisID,"Hit-to-Track Residual in r-phi",100,-150,150);
+    meResidualXBlade_->setAxisTitle("hit-to-track residual in r-phi (um)",1);
+    meResidualYBlade_ = iBooker.book1D("residualY_"+hisID,"Hit-to-Track Residual in Z",100,-300,300);
+    meResidualYBlade_->setAxisTitle("hit-to-track residual in z (um)",1);
+    // Number of clusters
+    meNClusters_onTrackBlade_ = iBooker.book1D("nclusters_OnTrack_" + hisID,"Number of Clusters (on Track)",10,0.,10.);
+    meNClusters_onTrackBlade_->setAxisTitle("Number of Clusters on Track",1);
+    // Total cluster charge in MeV
+    meCharge_onTrackBlade_ = iBooker.book1D("charge_OnTrack_" + hisID,"Normalized Cluster charge (on Track)",100,0.,200.);
+    meCharge_onTrackBlade_->setAxisTitle("Charge [kilo electrons]",1);
+    // Total cluster size (in pixels)
+    meSize_onTrackBlade_ = iBooker.book1D("size_OnTrack_" + hisID,"Total cluster size (on Track)",30,0.,30.);
+    meSize_onTrackBlade_->setAxisTitle("Cluster size [number of pixels]",1);    
+    // Number of clusters
+    meNClusters_offTrackBlade_ = iBooker.book1D("nclusters_OffTrack_" + hisID,"Number of Clusters (off Track)",35,0.,35.);
+    meNClusters_offTrackBlade_->setAxisTitle("Number of Clusters off Track",1);
+    // Total cluster charge in MeV
+    meCharge_offTrackBlade_ = iBooker.book1D("charge_OffTrack_" + hisID,"Cluster charge (off Track)",100,0.,200.);
+    meCharge_offTrackBlade_->setAxisTitle("Charge [kilo electrons]",1);
+    // Total cluster size (in pixels)
+    meSize_offTrackBlade_ = iBooker.book1D("size_OffTrack_" + hisID,"Total cluster size (off Track)",30,0.,30.);
+    meSize_offTrackBlade_->setAxisTitle("Cluster size [number of pixels]",1);
+    if(!reducedSet){
+      // Cluster width on the x-axis
+      meSizeX_onTrackBlade_ = iBooker.book1D("sizeX_OnTrack_" + hisID,"Cluster x-width (rows) (on Track)",10,0.,10.);
+      meSizeX_onTrackBlade_->setAxisTitle("Cluster x-size [rows]",1);
+      // Cluster width on the y-axis
+      meSizeY_onTrackBlade_ = iBooker.book1D("sizeY_OnTrack_" + hisID,"Cluster y-width (columns) (on Track)",15,0.,15.);
+      meSizeY_onTrackBlade_->setAxisTitle("Cluster y-size [columns]",1);
+      // Cluster width on the x-axis
+      meSizeX_offTrackBlade_ = iBooker.book1D("sizeX_OffTrack_" + hisID,"Cluster x-width (rows) (off Track)",10,0.,10.);
+      meSizeX_offTrackBlade_->setAxisTitle("Cluster x-size [rows]",1);
+      // Cluster width on the y-axis
+      meSizeY_offTrackBlade_ = iBooker.book1D("sizeY_OffTrack_" + hisID,"Cluster y-width (columns) (off Track)",15,0.,15.);
+      meSizeY_offTrackBlade_->setAxisTitle("Cluster y-size [columns]",1);
+    }
+  }
+
+  if(type==5 && endcap){
+    uint32_t disk;
+    disk = PixelEndcapNameUpgrade(DetId(id_)).diskName();
+    
+    char sdisk[80]; sprintf(sdisk, "Disk_%i",disk);
+    hisID = src.label() + "_" + sdisk;
+    meResidualXDisk_ = iBooker.book1D("residualX_"+hisID,"Hit-to-Track Residual in r-phi",100,-150,150);
+    meResidualXDisk_->setAxisTitle("hit-to-track residual in r-phi (um)",1);
+    meResidualYDisk_ = iBooker.book1D("residualY_"+hisID,"Hit-to-Track Residual in Z",100,-300,300);
+    meResidualYDisk_->setAxisTitle("hit-to-track residual in z (um)",1);
+    // Number of clusters
+    meNClusters_onTrackDisk_ = iBooker.book1D("nclusters_OnTrack_" + hisID,"Number of Clusters (on Track)",10,0.,10.);
+    meNClusters_onTrackDisk_->setAxisTitle("Number of Clusters on Track",1);
+    // Total cluster charge in MeV
+    meCharge_onTrackDisk_ = iBooker.book1D("charge_OnTrack_" + hisID,"Normalized Cluster charge (on Track)",100,0.,200.);
+    meCharge_onTrackDisk_->setAxisTitle("Charge [kilo electrons]",1);
+    // Total cluster size (in pixels)
+    meSize_onTrackDisk_ = iBooker.book1D("size_OnTrack_" + hisID,"Total cluster size (on Track)",30,0.,30.);
+    meSize_onTrackDisk_->setAxisTitle("Cluster size [number of pixels]",1);    
+    // Number of clusters
+    meNClusters_offTrackDisk_ = iBooker.book1D("nclusters_OffTrack_" + hisID,"Number of Clusters (off Track)",35,0.,35.);
+    meNClusters_offTrackDisk_->setAxisTitle("Number of Clusters off Track",1);
+    // Total cluster charge in MeV
+    meCharge_offTrackDisk_ = iBooker.book1D("charge_OffTrack_" + hisID,"Cluster charge (off Track)",100,0.,200.);
+    meCharge_offTrackDisk_->setAxisTitle("Charge [kilo electrons]",1);
+    // Total cluster size (in pixels)
+    meSize_offTrackDisk_ = iBooker.book1D("size_OffTrack_" + hisID,"Total cluster size (off Track)",30,0.,30.);
+    meSize_offTrackDisk_->setAxisTitle("Cluster size [number of pixels]",1);
+    if(!reducedSet){
+      // Cluster width on the x-axis
+      meSizeX_onTrackDisk_ = iBooker.book1D("sizeX_OnTrack_" + hisID,"Cluster x-width (rows) (on Track)",10,0.,10.);
+      meSizeX_onTrackDisk_->setAxisTitle("Cluster x-size [rows]",1);
+      // Cluster width on the y-axis
+      meSizeY_onTrackDisk_ = iBooker.book1D("sizeY_OnTrack_" + hisID,"Cluster y-width (columns) (on Track)",15,0.,15.);
+      meSizeY_onTrackDisk_->setAxisTitle("Cluster y-size [columns]",1);
+      // Cluster width on the x-axis
+      meSizeX_offTrackDisk_ = iBooker.book1D("sizeX_OffTrack_" + hisID,"Cluster x-width (rows) (off Track)",10,0.,10.);
+      meSizeX_offTrackDisk_->setAxisTitle("Cluster x-size [rows]",1);
+      // Cluster width on the y-axis
+      meSizeY_offTrackDisk_ = iBooker.book1D("sizeY_OffTrack_" + hisID,"Cluster y-width (columns) (off Track)",15,0.,15.);
+      meSizeY_offTrackDisk_->setAxisTitle("Cluster y-size [columns]",1);
+    }
+  }
+
+  if(type==6 && endcap){
+    uint32_t panel;
+    uint32_t module;
+    
+    panel= PixelEndcapNameUpgrade(DetId(id_)).pannelName();
+    module= PixelEndcapNameUpgrade(DetId(id_)).plaquetteName();
+    
+    
+    char slab[80]; sprintf(slab, "Panel_%i_Ring_%i",panel, module);
+    hisID = src.label() + "_" + slab;
+    meResidualXRing_ = iBooker.book1D("residualX_"+hisID,"Hit-to-Track Residual in r-phi",100,-150,150);
+    meResidualXRing_->setAxisTitle("hit-to-track residual in r-phi (um)",1);
+    meResidualYRing_ = iBooker.book1D("residualY_"+hisID,"Hit-to-Track Residual in Z",100,-300,300);
+    meResidualYRing_->setAxisTitle("hit-to-track residual in z (um)",1);
+    // Number of clusters
+    meNClusters_onTrackRing_ = iBooker.book1D("nclusters_OnTrack_" + hisID,"Number of Clusters (on Track)",10,0.,10.);
+    meNClusters_onTrackRing_->setAxisTitle("Number of Clusters on Track",1);
+    // Total cluster charge in MeV
+    meCharge_onTrackRing_ = iBooker.book1D("charge_OnTrack_" + hisID,"Normalized Cluster charge (on Track)",100,0.,200.);
+    meCharge_onTrackRing_->setAxisTitle("Charge [kilo electrons]",1);
+    // Total cluster size (in pixels)
+    meSize_onTrackRing_ = iBooker.book1D("size_OnTrack_" + hisID,"Total cluster size (on Track)",30,0.,30.);
+    meSize_onTrackRing_->setAxisTitle("Cluster size [number of pixels]",1);    
+    // Number of clusters
+    meNClusters_offTrackRing_ = iBooker.book1D("nclusters_OffTrack_" + hisID,"Number of Clusters (off Track)",35,0.,35.);
+    meNClusters_offTrackRing_->setAxisTitle("Number of Clusters off Track",1);
+    // Total cluster charge in MeV
+    meCharge_offTrackRing_ = iBooker.book1D("charge_OffTrack_" + hisID,"Cluster charge (off Track)",100,0.,200.);
+    meCharge_offTrackRing_->setAxisTitle("Charge [kilo electrons]",1);
+    // Total cluster size (in pixels)
+    meSize_offTrackRing_ = iBooker.book1D("size_OffTrack_" + hisID,"Total cluster size (off Track)",30,0.,30.);
+    meSize_offTrackRing_->setAxisTitle("Cluster size [number of pixels]",1);
+    if(!reducedSet){
+      // Cluster width on the x-axis
+      meSizeX_onTrackRing_ = iBooker.book1D("sizeX_OnTrack_" + hisID,"Cluster x-width (rows) (on Track)",10,0.,10.);
+      meSizeX_onTrackRing_->setAxisTitle("Cluster x-size [rows]",1);
+      // Cluster width on the y-axis
+      meSizeY_onTrackRing_ = iBooker.book1D("sizeY_OnTrack_" + hisID,"Cluster y-width (columns) (on Track)",15,0.,15.);
+      meSizeY_onTrackRing_->setAxisTitle("Cluster y-size [columns]",1);
+      // Cluster width on the x-axis
+      meSizeX_offTrackRing_ = iBooker.book1D("sizeX_OffTrack_" + hisID,"Cluster x-width (rows) (off Track)",10,0.,10.);
+      meSizeX_offTrackRing_->setAxisTitle("Cluster x-size [rows]",1);
+      // Cluster width on the y-axis
+      meSizeY_offTrackRing_ = iBooker.book1D("sizeY_OffTrack_" + hisID,"Cluster y-width (columns) (off Track)",15,0.,15.);
+      meSizeY_offTrackRing_->setAxisTitle("Cluster y-size [columns]",1);
+    }
+  }
+}
+
+
+void SiPixelTrackResidualModulePhase1::fill(const Measurement2DVector& residual, bool reducedSet, bool modon, bool ladon, bool layon, bool phion, bool bladeon, bool diskon, bool ringon) {
+
+  bool barrel = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
+  bool endcap = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap);
+
+  if(modon){
+    (meResidualX_)->Fill(residual.x()); 
+    (meResidualY_)->Fill(residual.y()); 
+  }
+
+  if(ladon && barrel){
+    (meResidualXLad_)->Fill(residual.x()); 
+    (meResidualYLad_)->Fill(residual.y()); 
+  }
+
+  if(layon && barrel){
+    (meResidualXLay_)->Fill(residual.x()); 
+    (meResidualYLay_)->Fill(residual.y()); 
+  }
+  if(phion && barrel){
+    (meResidualXPhi_)->Fill(residual.x()); 
+    (meResidualYPhi_)->Fill(residual.y()); 
+  }
+
+  if(bladeon && endcap){
+    (meResidualXBlade_)->Fill(residual.x()); 
+    (meResidualYBlade_)->Fill(residual.y()); 
+  }
+
+  if(diskon && endcap){
+    (meResidualXDisk_)->Fill(residual.x()); 
+    (meResidualYDisk_)->Fill(residual.y()); 
+  }
+
+  if(ringon && endcap){
+    (meResidualXRing_)->Fill(residual.x()); 
+    (meResidualYRing_)->Fill(residual.y()); 
+  }
+}
+
+
+void SiPixelTrackResidualModulePhase1::fill(const SiPixelCluster &clust, bool onTrack, double corrCharge, bool reducedSet, bool modon, bool ladon, bool layon, bool phion, bool bladeon, bool diskon, bool ringon){
+
+  bool barrel = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
+  bool endcap = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap);
+
+  float charge = 0.001*(clust.charge()); // total charge of cluster
+  if(onTrack) charge = corrCharge;              // corrected cluster charge
+  int size = clust.size();               // total size of cluster (in pixels)
+  int sizeX = clust.sizeX();             // size of cluster in x-clustrection
+  int sizeY = clust.sizeY();             // size of cluster in y-direction
+  
+  if(onTrack){
+    if(modon){
+      (meCharge_onTrack_)->Fill((float)charge);
+      (meSize_onTrack_)->Fill((int)size);
+      if(!reducedSet){
+        (meSizeX_onTrack_)->Fill((int)sizeX);
+        (meSizeY_onTrack_)->Fill((int)sizeY);
+      }
+    }
+    if(barrel && ladon){
+      (meCharge_onTrackLad_)->Fill((float)charge);
+      (meSize_onTrackLad_)->Fill((int)size);
+      if(!reducedSet){
+        (meSizeX_onTrackLad_)->Fill((int)sizeX);
+        (meSizeY_onTrackLad_)->Fill((int)sizeY);
+      }
+    }
+    if(barrel && layon){
+      (meCharge_onTrackLay_)->Fill((float)charge);
+      (meSize_onTrackLay_)->Fill((int)size);
+      if(!reducedSet){
+        (meSizeX_onTrackLay_)->Fill((int)sizeX);
+        (meSizeY_onTrackLay_)->Fill((int)sizeY);
+      }
+    }   
+    if(barrel && phion){
+      (meCharge_onTrackPhi_)->Fill((float)charge);
+      (meSize_onTrackPhi_)->Fill((int)size);
+      if(!reducedSet){
+        (meSizeX_onTrackPhi_)->Fill((int)sizeX);
+        (meSizeY_onTrackPhi_)->Fill((int)sizeY);
+      }
+    }
+    if(endcap && bladeon){
+      (meCharge_onTrackBlade_)->Fill((float)charge);
+      (meSize_onTrackBlade_)->Fill((int)size);
+      if(!reducedSet){
+        (meSizeX_onTrackBlade_)->Fill((int)sizeX);
+        (meSizeY_onTrackBlade_)->Fill((int)sizeY);
+      }
+    }
+    if(endcap && diskon){
+      (meCharge_onTrackDisk_)->Fill((float)charge);
+      (meSize_onTrackDisk_)->Fill((int)size);
+      if(!reducedSet){
+        (meSizeX_onTrackDisk_)->Fill((int)sizeX);
+        (meSizeY_onTrackDisk_)->Fill((int)sizeY);
+      }
+    }
+    if(endcap && ringon){
+      (meCharge_onTrackRing_)->Fill((float)charge);
+      (meSize_onTrackRing_)->Fill((int)size);
+      if(!reducedSet){
+        (meSizeX_onTrackRing_)->Fill((int)sizeX);
+        (meSizeY_onTrackRing_)->Fill((int)sizeY);
+      }
+    }
+  }
+
+  if(!onTrack){
+    if(modon){
+      (meCharge_offTrack_)->Fill((float)charge);
+      (meSize_offTrack_)->Fill((int)size);
+      if(!reducedSet){
+        (meSizeX_offTrack_)->Fill((int)sizeX);
+        (meSizeY_offTrack_)->Fill((int)sizeY);
+      }
+    }
+    if(barrel && ladon){
+      (meCharge_offTrackLad_)->Fill((float)charge);
+      (meSize_offTrackLad_)->Fill((int)size);
+      if(!reducedSet){
+        (meSizeX_offTrackLad_)->Fill((int)sizeX);
+        (meSizeY_offTrackLad_)->Fill((int)sizeY);
+      }
+    }
+    if(barrel && layon){
+      (meCharge_offTrackLay_)->Fill((float)charge);
+      (meSize_offTrackLay_)->Fill((int)size);
+      if(!reducedSet){
+        (meSizeX_offTrackLay_)->Fill((int)sizeX);
+        (meSizeY_offTrackLay_)->Fill((int)sizeY);
+      }
+    }   
+    if(barrel && phion){
+      (meCharge_offTrackPhi_)->Fill((float)charge);
+      (meSize_offTrackPhi_)->Fill((int)size);
+      if(!reducedSet){
+        (meSizeX_offTrackPhi_)->Fill((int)sizeX);
+        (meSizeY_offTrackPhi_)->Fill((int)sizeY);
+      }
+    }
+    if(endcap && bladeon){
+      (meCharge_offTrackBlade_)->Fill((float)charge);
+      (meSize_offTrackBlade_)->Fill((int)size);
+      if(!reducedSet){
+        (meSizeX_offTrackBlade_)->Fill((int)sizeX);
+        (meSizeY_offTrackBlade_)->Fill((int)sizeY);
+      }
+    }
+    if(endcap && diskon){
+      (meCharge_offTrackDisk_)->Fill((float)charge);
+      (meSize_offTrackDisk_)->Fill((int)size);
+      if(!reducedSet){
+        (meSizeX_offTrackDisk_)->Fill((int)sizeX);
+        (meSizeY_offTrackDisk_)->Fill((int)sizeY);
+      }
+    }
+    if(endcap && ringon){
+      (meCharge_offTrackRing_)->Fill((float)charge);
+      (meSize_offTrackRing_)->Fill((int)size);
+      if(!reducedSet){
+        (meSizeX_offTrackRing_)->Fill((int)sizeX);
+        (meSizeY_offTrackRing_)->Fill((int)sizeY);
+      }
+    }
+  }
+
+
+  
+}
+
+void SiPixelTrackResidualModulePhase1::nfill(int onTrack, int offTrack, bool reducedSet, bool modon, bool ladon, bool layon, bool phion, bool bladeon, bool diskon, bool ringon){
+
+  bool barrel = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
+  bool endcap = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap);
+  bool fillOn = false; if(onTrack>0) fillOn = true; 
+  bool fillOff = false; if(offTrack>0) fillOff = true; 
+
+  if(modon){
+    if(fillOn) meNClusters_onTrack_->Fill(onTrack); 
+    if(fillOff) meNClusters_offTrack_->Fill(offTrack); 
+  }
+  if(ladon && barrel){
+    if(fillOn) meNClusters_onTrackLad_->Fill(onTrack); 
+    if(fillOff) meNClusters_offTrackLad_->Fill(offTrack); 
+  }
+  
+  if(layon && barrel){
+    if(fillOn) meNClusters_onTrackLay_->Fill(onTrack); 
+    if(fillOff) meNClusters_offTrackLay_->Fill(offTrack); 
+  }
+  if(phion && barrel){
+    if(fillOn) meNClusters_onTrackPhi_->Fill(onTrack); 
+    if(fillOff) meNClusters_offTrackPhi_->Fill(offTrack); 
+  }
+  if(bladeon && endcap){
+    if(fillOn) meNClusters_onTrackBlade_->Fill(onTrack); 
+    if(fillOff) meNClusters_offTrackBlade_->Fill(offTrack); 
+  }
+  if(diskon && endcap){
+    if(fillOn) meNClusters_onTrackDisk_->Fill(onTrack); 
+    if(fillOff) meNClusters_offTrackDisk_->Fill(offTrack); 
+  }
+  if(ringon && endcap){
+    if(fillOn) meNClusters_onTrackRing_->Fill(onTrack); 
+    if(fillOff) meNClusters_offTrackRing_->Fill(offTrack); 
+  }
+}

--- a/DQM/SiPixelMonitorTrack/src/SiPixelTrackResidualSource.cc
+++ b/DQM/SiPixelMonitorTrack/src/SiPixelTrackResidualSource.cc
@@ -69,8 +69,7 @@ SiPixelTrackResidualSource::SiPixelTrackResidualSource(const edm::ParameterSet& 
   phiOn( pSet.getUntrackedParameter<bool>("phiOn",false) ), 
   ringOn( pSet.getUntrackedParameter<bool>("ringOn",false) ), 
   bladeOn( pSet.getUntrackedParameter<bool>("bladeOn",false) ), 
-  diskOn( pSet.getUntrackedParameter<bool>("diskOn",false) ),
-  isUpgrade( pSet.getUntrackedParameter<bool>("isUpgrade",false) )
+  diskOn( pSet.getUntrackedParameter<bool>("diskOn",false) )
 { 
    pSet_ = pSet; 
    debug_ = pSet_.getUntrackedParameter<bool>("debug", false); 
@@ -143,34 +142,34 @@ void SiPixelTrackResidualSource::bookHistograms(DQMStore::IBooker & iBooker, edm
        pxd!=theSiPixelStructure.end(); pxd++) {
 
     if(modOn){
-      if (theSiPixelFolder.setModuleFolder(iBooker,(*pxd).first,0,isUpgrade)) (*pxd).second->book(pSet_,iBooker,reducedSet,0,isUpgrade);
+      if (theSiPixelFolder.setModuleFolder(iBooker,(*pxd).first,0)) (*pxd).second->book(pSet_,iBooker,reducedSet,0);
       else throw cms::Exception("LogicError") << "SiPixelTrackResidualSource Folder Creation Failed! "; 
     }
     if(ladOn){
-      if (theSiPixelFolder.setModuleFolder(iBooker,(*pxd).first,1,isUpgrade)) {
+      if (theSiPixelFolder.setModuleFolder(iBooker,(*pxd).first,1)) {
 	
-	(*pxd).second->book(pSet_,iBooker,reducedSet,1,isUpgrade);
+	(*pxd).second->book(pSet_,iBooker,reducedSet,1);
       }
       else throw cms::Exception("LogicError") << "SiPixelTrackResidualSource ladder Folder Creation Failed! "; 
     }
     if(layOn){
-      if (theSiPixelFolder.setModuleFolder(iBooker,(*pxd).first,2,isUpgrade)) (*pxd).second->book(pSet_,iBooker,reducedSet,2,isUpgrade);
+      if (theSiPixelFolder.setModuleFolder(iBooker,(*pxd).first,2)) (*pxd).second->book(pSet_,iBooker,reducedSet,2);
       else throw cms::Exception("LogicError") << "SiPixelTrackResidualSource layer Folder Creation Failed! "; 
     }
     if(phiOn){
-      if (theSiPixelFolder.setModuleFolder(iBooker,(*pxd).first,3,isUpgrade)) (*pxd).second->book(pSet_,iBooker,reducedSet,3,isUpgrade);
+      if (theSiPixelFolder.setModuleFolder(iBooker,(*pxd).first,3)) (*pxd).second->book(pSet_,iBooker,reducedSet,3);
       else throw cms::Exception("LogicError") << "SiPixelTrackResidualSource phi Folder Creation Failed! "; 
     }
     if(bladeOn){
-      if (theSiPixelFolder.setModuleFolder(iBooker,(*pxd).first,4,isUpgrade)) (*pxd).second->book(pSet_,iBooker,reducedSet,4,isUpgrade);
+      if (theSiPixelFolder.setModuleFolder(iBooker,(*pxd).first,4)) (*pxd).second->book(pSet_,iBooker,reducedSet,4);
       else throw cms::Exception("LogicError") << "SiPixelTrackResidualSource Blade Folder Creation Failed! "; 
     }
     if(diskOn){
-      if (theSiPixelFolder.setModuleFolder(iBooker,(*pxd).first,5,isUpgrade)) (*pxd).second->book(pSet_,iBooker,reducedSet,5,isUpgrade);
+      if (theSiPixelFolder.setModuleFolder(iBooker,(*pxd).first,5)) (*pxd).second->book(pSet_,iBooker,reducedSet,5);
       else throw cms::Exception("LogicError") << "SiPixelTrackResidualSource Disk Folder Creation Failed! "; 
     }
     if(ringOn){
-      if (theSiPixelFolder.setModuleFolder(iBooker,(*pxd).first,6,isUpgrade)) (*pxd).second->book(pSet_,iBooker,reducedSet,6,isUpgrade);
+      if (theSiPixelFolder.setModuleFolder(iBooker,(*pxd).first,6)) (*pxd).second->book(pSet_,iBooker,reducedSet,6);
       else throw cms::Exception("LogicError") << "SiPixelTrackResidualSource Ring Folder Creation Failed! "; 
     }
   }
@@ -225,26 +224,14 @@ void SiPixelTrackResidualSource::bookHistograms(DQMStore::IBooker & iBooker, edm
   meClChargeOnTrack_layer2->setAxisTitle("Charge size (in ke)",1);
   meClChargeOnTrack_layer3 = iBooker.book1D("charge_" + clustersrc_.label() + "_Layer_3","Charge (on track, layer3)",500,0.,500.);
   meClChargeOnTrack_layer3->setAxisTitle("Charge size (in ke)",1);
-  if (isUpgrade) {
-    meClChargeOnTrack_layer4 = iBooker.book1D("charge_" + clustersrc_.label() + "_Layer_4","Charge (on track, layer4)",500,0.,500.);
-    meClChargeOnTrack_layer4->setAxisTitle("Charge size (in ke)",1);
-  }
   meClChargeOnTrack_diskp1 = iBooker.book1D("charge_" + clustersrc_.label() + "_Disk_p1","Charge (on track, diskp1)",500,0.,500.);
   meClChargeOnTrack_diskp1->setAxisTitle("Charge size (in ke)",1);
   meClChargeOnTrack_diskp2 = iBooker.book1D("charge_" + clustersrc_.label() + "_Disk_p2","Charge (on track, diskp2)",500,0.,500.);
   meClChargeOnTrack_diskp2->setAxisTitle("Charge size (in ke)",1);
-  if (isUpgrade) {
-    meClChargeOnTrack_diskp3 = iBooker.book1D("charge_" + clustersrc_.label() + "_Disk_p3","Charge (on track, diskp3)",500,0.,500.);
-    meClChargeOnTrack_diskp3->setAxisTitle("Charge size (in ke)",1);
-  }
   meClChargeOnTrack_diskm1 = iBooker.book1D("charge_" + clustersrc_.label() + "_Disk_m1","Charge (on track, diskm1)",500,0.,500.);
   meClChargeOnTrack_diskm1->setAxisTitle("Charge size (in ke)",1);
   meClChargeOnTrack_diskm2 = iBooker.book1D("charge_" + clustersrc_.label() + "_Disk_m2","Charge (on track, diskm2)",500,0.,500.);
   meClChargeOnTrack_diskm2->setAxisTitle("Charge size (in ke)",1);
-  if (isUpgrade) {
-    meClChargeOnTrack_diskm3 = iBooker.book1D("charge_" + clustersrc_.label() + "_Disk_m3","Charge (on track, diskm3)",500,0.,500.);
-    meClChargeOnTrack_diskm3->setAxisTitle("Charge size (in ke)",1);
-  }
   //off track
   iBooker.setCurrentFolder("Pixel/Clusters/OffTrack");
   meClChargeNotOnTrack_all = iBooker.book1D("charge_" + clustersrc_.label(),"Charge (off track)",500,0.,500.);
@@ -259,26 +246,14 @@ void SiPixelTrackResidualSource::bookHistograms(DQMStore::IBooker & iBooker, edm
   meClChargeNotOnTrack_layer2->setAxisTitle("Charge size (in ke)",1);
   meClChargeNotOnTrack_layer3 = iBooker.book1D("charge_" + clustersrc_.label() + "_Layer_3","Charge (off track, layer3)",500,0.,500.);
   meClChargeNotOnTrack_layer3->setAxisTitle("Charge size (in ke)",1);
-  if (isUpgrade) {
-    meClChargeNotOnTrack_layer4 = iBooker.book1D("charge_" + clustersrc_.label() + "_Layer_4","Charge (off track, layer4)",500,0.,500.);
-    meClChargeNotOnTrack_layer4->setAxisTitle("Charge size (in ke)",1);
-  }
   meClChargeNotOnTrack_diskp1 = iBooker.book1D("charge_" + clustersrc_.label() + "_Disk_p1","Charge (off track, diskp1)",500,0.,500.);
   meClChargeNotOnTrack_diskp1->setAxisTitle("Charge size (in ke)",1);
   meClChargeNotOnTrack_diskp2 = iBooker.book1D("charge_" + clustersrc_.label() + "_Disk_p2","Charge (off track, diskp2)",500,0.,500.);
   meClChargeNotOnTrack_diskp2->setAxisTitle("Charge size (in ke)",1);
-  if (isUpgrade) {
-    meClChargeNotOnTrack_diskp3 = iBooker.book1D("charge_" + clustersrc_.label() + "_Disk_p3","Charge (off track, diskp3)",500,0.,500.);
-    meClChargeNotOnTrack_diskp3->setAxisTitle("Charge size (in ke)",1);
-  }
   meClChargeNotOnTrack_diskm1 = iBooker.book1D("charge_" + clustersrc_.label() + "_Disk_m1","Charge (off track, diskm1)",500,0.,500.);
   meClChargeNotOnTrack_diskm1->setAxisTitle("Charge size (in ke)",1);
   meClChargeNotOnTrack_diskm2 = iBooker.book1D("charge_" + clustersrc_.label() + "_Disk_m2","Charge (off track, diskm2)",500,0.,500.);
   meClChargeNotOnTrack_diskm2->setAxisTitle("Charge size (in ke)",1);
-  if (isUpgrade) {
-    meClChargeNotOnTrack_diskm3 = iBooker.book1D("charge_" + clustersrc_.label() + "_Disk_m3","Charge (off track, diskm3)",500,0.,500.);
-    meClChargeNotOnTrack_diskm3->setAxisTitle("Charge size (in ke)",1);
-  }
 
   //size
   //on track
@@ -295,26 +270,14 @@ void SiPixelTrackResidualSource::bookHistograms(DQMStore::IBooker & iBooker, edm
   meClSizeOnTrack_layer2->setAxisTitle("Cluster size (in pixels)",1);
   meClSizeOnTrack_layer3 = iBooker.book1D("size_" + clustersrc_.label() + "_Layer_3","Size (on track, layer3)",100,0.,100.);
   meClSizeOnTrack_layer3->setAxisTitle("Cluster size (in pixels)",1);
-  if (isUpgrade) {
-    meClSizeOnTrack_layer4 = iBooker.book1D("size_" + clustersrc_.label() + "_Layer_4","Size (on track, layer4)",100,0.,100.);
-    meClSizeOnTrack_layer4->setAxisTitle("Cluster size (in pixels)",1);
-  }
   meClSizeOnTrack_diskp1 = iBooker.book1D("size_" + clustersrc_.label() + "_Disk_p1","Size (on track, diskp1)",100,0.,100.);
   meClSizeOnTrack_diskp1->setAxisTitle("Cluster size (in pixels)",1);
   meClSizeOnTrack_diskp2 = iBooker.book1D("size_" + clustersrc_.label() + "_Disk_p2","Size (on track, diskp2)",100,0.,100.);
   meClSizeOnTrack_diskp2->setAxisTitle("Cluster size (in pixels)",1);
-  if (isUpgrade) {
-    meClSizeOnTrack_diskp3 = iBooker.book1D("size_" + clustersrc_.label() + "_Disk_p3","Size (on track, diskp3)",100,0.,100.);
-    meClSizeOnTrack_diskp3->setAxisTitle("Cluster size (in pixels)",1);
-  }
   meClSizeOnTrack_diskm1 = iBooker.book1D("size_" + clustersrc_.label() + "_Disk_m1","Size (on track, diskm1)",100,0.,100.);
   meClSizeOnTrack_diskm1->setAxisTitle("Cluster size (in pixels)",1);
   meClSizeOnTrack_diskm2 = iBooker.book1D("size_" + clustersrc_.label() + "_Disk_m2","Size (on track, diskm2)",100,0.,100.);
   meClSizeOnTrack_diskm2->setAxisTitle("Cluster size (in pixels)",1);
-  if (isUpgrade) {
-    meClSizeOnTrack_diskm3 = iBooker.book1D("size_" + clustersrc_.label() + "_Disk_m3","Size (on track, diskm3)",100,0.,100.);
-    meClSizeOnTrack_diskm3->setAxisTitle("Cluster size (in pixels)",1);
-  }
   meClSizeXOnTrack_all = iBooker.book1D("sizeX_" + clustersrc_.label(),"SizeX (on track)",100,0.,100.);
   meClSizeXOnTrack_all->setAxisTitle("Cluster sizeX (in pixels)",1);
   meClSizeXOnTrack_bpix = iBooker.book1D("sizeX_" + clustersrc_.label() + "_Barrel","SizeX (on track, barrel)",100,0.,100.);
@@ -327,26 +290,14 @@ void SiPixelTrackResidualSource::bookHistograms(DQMStore::IBooker & iBooker, edm
   meClSizeXOnTrack_layer2->setAxisTitle("Cluster size (in pixels)",1);
   meClSizeXOnTrack_layer3 = iBooker.book1D("sizeX_" + clustersrc_.label() + "_Layer_3","SizeX (on track, layer3)",100,0.,100.);
   meClSizeXOnTrack_layer3->setAxisTitle("Cluster size (in pixels)",1);
-  if (isUpgrade) {
-    meClSizeXOnTrack_layer4 = iBooker.book1D("sizeX_" + clustersrc_.label() + "_Layer_4","SizeX (on track, layer4)",100,0.,100.);
-    meClSizeXOnTrack_layer4->setAxisTitle("Cluster size (in pixels)",1);
-  }
   meClSizeXOnTrack_diskp1 = iBooker.book1D("sizeX_" + clustersrc_.label() + "_Disk_p1","SizeX (on track, diskp1)",100,0.,100.);
   meClSizeXOnTrack_diskp1->setAxisTitle("Cluster size (in pixels)",1);
   meClSizeXOnTrack_diskp2 = iBooker.book1D("sizeX_" + clustersrc_.label() + "_Disk_p2","SizeX (on track, diskp2)",100,0.,100.);
   meClSizeXOnTrack_diskp2->setAxisTitle("Cluster size (in pixels)",1);
-  if (isUpgrade) {
-    meClSizeXOnTrack_diskp3 = iBooker.book1D("sizeX_" + clustersrc_.label() + "_Disk_p3","SizeX (on track, diskp3)",100,0.,100.);
-    meClSizeXOnTrack_diskp3->setAxisTitle("Cluster size (in pixels)",1);
-  }
   meClSizeXOnTrack_diskm1 = iBooker.book1D("sizeX_" + clustersrc_.label() + "_Disk_m1","SizeX (on track, diskm1)",100,0.,100.);
   meClSizeXOnTrack_diskm1->setAxisTitle("Cluster size (in pixels)",1);
   meClSizeXOnTrack_diskm2 = iBooker.book1D("sizeX_" + clustersrc_.label() + "_Disk_m2","SizeX (on track, diskm2)",100,0.,100.);
   meClSizeXOnTrack_diskm2->setAxisTitle("Cluster size (in pixels)",1);
-  if (isUpgrade) {
-    meClSizeXOnTrack_diskm3 = iBooker.book1D("sizeX_" + clustersrc_.label() + "_Disk_m3","SizeX (on track, diskm3)",100,0.,100.);
-    meClSizeXOnTrack_diskm3->setAxisTitle("Cluster size (in pixels)",1);
-  }
   meClSizeYOnTrack_all = iBooker.book1D("sizeY_" + clustersrc_.label(),"SizeY (on track)",100,0.,100.);
   meClSizeYOnTrack_all->setAxisTitle("Cluster sizeY (in pixels)",1);
   meClSizeYOnTrack_bpix = iBooker.book1D("sizeY_" + clustersrc_.label() + "_Barrel","SizeY (on track, barrel)",100,0.,100.);
@@ -359,26 +310,14 @@ void SiPixelTrackResidualSource::bookHistograms(DQMStore::IBooker & iBooker, edm
   meClSizeYOnTrack_layer2->setAxisTitle("Cluster size (in pixels)",1);
   meClSizeYOnTrack_layer3 = iBooker.book1D("sizeY_" + clustersrc_.label() + "_Layer_3","SizeY (on track, layer3)",100,0.,100.);
   meClSizeYOnTrack_layer3->setAxisTitle("Cluster size (in pixels)",1);
-  if (isUpgrade) {
-    meClSizeYOnTrack_layer4 = iBooker.book1D("sizeY_" + clustersrc_.label() + "_Layer_4","SizeY (on track, layer4)",100,0.,100.);
-    meClSizeYOnTrack_layer4->setAxisTitle("Cluster size (in pixels)",1);
-  }
   meClSizeYOnTrack_diskp1 = iBooker.book1D("sizeY_" + clustersrc_.label() + "_Disk_p1","SizeY (on track, diskp1)",100,0.,100.);
   meClSizeYOnTrack_diskp1->setAxisTitle("Cluster size (in pixels)",1);
   meClSizeYOnTrack_diskp2 = iBooker.book1D("sizeY_" + clustersrc_.label() + "_Disk_p2","SizeY (on track, diskp2)",100,0.,100.);
   meClSizeYOnTrack_diskp2->setAxisTitle("Cluster size (in pixels)",1);
-  if (isUpgrade) {
-    meClSizeYOnTrack_diskp3 = iBooker.book1D("sizeY_" + clustersrc_.label() + "_Disk_p3","SizeY (on track, diskp3)",100,0.,100.);
-    meClSizeYOnTrack_diskp3->setAxisTitle("Cluster size (in pixels)",1);
-  }
   meClSizeYOnTrack_diskm1 = iBooker.book1D("sizeY_" + clustersrc_.label() + "_Disk_m1","SizeY (on track, diskm1)",100,0.,100.);
   meClSizeYOnTrack_diskm1->setAxisTitle("Cluster size (in pixels)",1);
   meClSizeYOnTrack_diskm2 = iBooker.book1D("sizeY_" + clustersrc_.label() + "_Disk_m2","SizeY (on track, diskm2)",100,0.,100.);
   meClSizeYOnTrack_diskm2->setAxisTitle("Cluster size (in pixels)",1);
-  if (isUpgrade) {
-    meClSizeYOnTrack_diskm3 = iBooker.book1D("sizeY_" + clustersrc_.label() + "_Disk_m3","SizeY (on track, diskm3)",100,0.,100.);
-    meClSizeYOnTrack_diskm3->setAxisTitle("Cluster size (in pixels)",1);
-  }
   //off track
   iBooker.setCurrentFolder("Pixel/Clusters/OffTrack");
   meClSizeNotOnTrack_all = iBooker.book1D("size_" + clustersrc_.label(),"Size (off track)",100,0.,100.);
@@ -393,26 +332,14 @@ void SiPixelTrackResidualSource::bookHistograms(DQMStore::IBooker & iBooker, edm
   meClSizeNotOnTrack_layer2->setAxisTitle("Cluster size (in pixels)",1);
   meClSizeNotOnTrack_layer3 = iBooker.book1D("size_" + clustersrc_.label() + "_Layer_3","Size (off track, layer3)",100,0.,100.);
   meClSizeNotOnTrack_layer3->setAxisTitle("Cluster size (in pixels)",1);
-  if (isUpgrade) {
-    meClSizeNotOnTrack_layer4 = iBooker.book1D("size_" + clustersrc_.label() + "_Layer_4","Size (off track, layer4)",100,0.,100.);
-    meClSizeNotOnTrack_layer4->setAxisTitle("Cluster size (in pixels)",1);
-  }
   meClSizeNotOnTrack_diskp1 = iBooker.book1D("size_" + clustersrc_.label() + "_Disk_p1","Size (off track, diskp1)",100,0.,100.);
   meClSizeNotOnTrack_diskp1->setAxisTitle("Cluster size (in pixels)",1);
   meClSizeNotOnTrack_diskp2 = iBooker.book1D("size_" + clustersrc_.label() + "_Disk_p2","Size (off track, diskp2)",100,0.,100.);
   meClSizeNotOnTrack_diskp2->setAxisTitle("Cluster size (in pixels)",1);
-  if (isUpgrade) {
-    meClSizeNotOnTrack_diskp3 = iBooker.book1D("size_" + clustersrc_.label() + "_Disk_p3","Size (off track, diskp3)",100,0.,100.);
-    meClSizeNotOnTrack_diskp3->setAxisTitle("Cluster size (in pixels)",1);
-  }
   meClSizeNotOnTrack_diskm1 = iBooker.book1D("size_" + clustersrc_.label() + "_Disk_m1","Size (off track, diskm1)",100,0.,100.);
   meClSizeNotOnTrack_diskm1->setAxisTitle("Cluster size (in pixels)",1);
   meClSizeNotOnTrack_diskm2 = iBooker.book1D("size_" + clustersrc_.label() + "_Disk_m2","Size (off track, diskm2)",100,0.,100.);
   meClSizeNotOnTrack_diskm2->setAxisTitle("Cluster size (in pixels)",1);
-  if (isUpgrade) {
-    meClSizeNotOnTrack_diskm3 = iBooker.book1D("size_" + clustersrc_.label() + "_Disk_m3","Size (off track, diskm3)",100,0.,100.);
-    meClSizeNotOnTrack_diskm3->setAxisTitle("Cluster size (in pixels)",1);
-  }
   meClSizeXNotOnTrack_all = iBooker.book1D("sizeX_" + clustersrc_.label(),"SizeX (off track)",100,0.,100.);
   meClSizeXNotOnTrack_all->setAxisTitle("Cluster sizeX (in pixels)",1);
   meClSizeXNotOnTrack_bpix = iBooker.book1D("sizeX_" + clustersrc_.label() + "_Barrel","SizeX (off track, barrel)",100,0.,100.);
@@ -425,26 +352,14 @@ void SiPixelTrackResidualSource::bookHistograms(DQMStore::IBooker & iBooker, edm
   meClSizeXNotOnTrack_layer2->setAxisTitle("Cluster size (in pixels)",1);
   meClSizeXNotOnTrack_layer3 = iBooker.book1D("sizeX_" + clustersrc_.label() + "_Layer_3","SizeX (off track, layer3)",100,0.,100.);
   meClSizeXNotOnTrack_layer3->setAxisTitle("Cluster size (in pixels)",1);
-  if (isUpgrade) {
-    meClSizeXNotOnTrack_layer4 = iBooker.book1D("sizeX_" + clustersrc_.label() + "_Layer_4","SizeX (off track, layer4)",100,0.,100.);
-    meClSizeXNotOnTrack_layer4->setAxisTitle("Cluster size (in pixels)",1);
-  }
   meClSizeXNotOnTrack_diskp1 = iBooker.book1D("sizeX_" + clustersrc_.label() + "_Disk_p1","SizeX (off track, diskp1)",100,0.,100.);
   meClSizeXNotOnTrack_diskp1->setAxisTitle("Cluster size (in pixels)",1);
   meClSizeXNotOnTrack_diskp2 = iBooker.book1D("sizeX_" + clustersrc_.label() + "_Disk_p2","SizeX (off track, diskp2)",100,0.,100.);
   meClSizeXNotOnTrack_diskp2->setAxisTitle("Cluster size (in pixels)",1);
-  if (isUpgrade) {
-    meClSizeXNotOnTrack_diskp3 = iBooker.book1D("sizeX_" + clustersrc_.label() + "_Disk_p3","SizeX (off track, diskp3)",100,0.,100.);
-    meClSizeXNotOnTrack_diskp3->setAxisTitle("Cluster size (in pixels)",1);
-  }
   meClSizeXNotOnTrack_diskm1 = iBooker.book1D("sizeX_" + clustersrc_.label() + "_Disk_m1","SizeX (off track, diskm1)",100,0.,100.);
   meClSizeXNotOnTrack_diskm1->setAxisTitle("Cluster size (in pixels)",1);
   meClSizeXNotOnTrack_diskm2 = iBooker.book1D("sizeX_" + clustersrc_.label() + "_Disk_m2","SizeX (off track, diskm2)",100,0.,100.);
   meClSizeXNotOnTrack_diskm2->setAxisTitle("Cluster size (in pixels)",1);
-  if (isUpgrade) {
-    meClSizeXNotOnTrack_diskm3 = iBooker.book1D("sizeX_" + clustersrc_.label() + "_Disk_m3","SizeX (off track, diskm3)",100,0.,100.);
-    meClSizeXNotOnTrack_diskm3->setAxisTitle("Cluster size (in pixels)",1);
-  }
   meClSizeYNotOnTrack_all = iBooker.book1D("sizeY_" + clustersrc_.label(),"SizeY (off track)",100,0.,100.);
   meClSizeYNotOnTrack_all->setAxisTitle("Cluster sizeY (in pixels)",1);
   meClSizeYNotOnTrack_bpix = iBooker.book1D("sizeY_" + clustersrc_.label() + "_Barrel","SizeY (off track, barrel)",100,0.,100.);
@@ -457,26 +372,14 @@ void SiPixelTrackResidualSource::bookHistograms(DQMStore::IBooker & iBooker, edm
   meClSizeYNotOnTrack_layer2->setAxisTitle("Cluster size (in pixels)",1);
   meClSizeYNotOnTrack_layer3 = iBooker.book1D("sizeY_" + clustersrc_.label() + "_Layer_3","SizeY (off track, layer3)",100,0.,100.);
   meClSizeYNotOnTrack_layer3->setAxisTitle("Cluster size (in pixels)",1);
-  if (isUpgrade) {
-    meClSizeYNotOnTrack_layer4 = iBooker.book1D("sizeY_" + clustersrc_.label() + "_Layer_4","SizeY (off track, layer4)",100,0.,100.);
-    meClSizeYNotOnTrack_layer4->setAxisTitle("Cluster size (in pixels)",1);
-  }
   meClSizeYNotOnTrack_diskp1 = iBooker.book1D("sizeY_" + clustersrc_.label() + "_Disk_p1","SizeY (off track, diskp1)",100,0.,100.);
   meClSizeYNotOnTrack_diskp1->setAxisTitle("Cluster size (in pixels)",1);
   meClSizeYNotOnTrack_diskp2 = iBooker.book1D("sizeY_" + clustersrc_.label() + "_Disk_p2","SizeY (off track, diskp2)",100,0.,100.);
   meClSizeYNotOnTrack_diskp2->setAxisTitle("Cluster size (in pixels)",1);
-  if (isUpgrade) {
-    meClSizeYNotOnTrack_diskp3 = iBooker.book1D("sizeY_" + clustersrc_.label() + "_Disk_p3","SizeY (off track, diskp3)",100,0.,100.);
-    meClSizeYNotOnTrack_diskp3->setAxisTitle("Cluster size (in pixels)",1);
-  }
   meClSizeYNotOnTrack_diskm1 = iBooker.book1D("sizeY_" + clustersrc_.label() + "_Disk_m1","SizeY (off track, diskm1)",100,0.,100.);
   meClSizeYNotOnTrack_diskm1->setAxisTitle("Cluster size (in pixels)",1);
   meClSizeYNotOnTrack_diskm2 = iBooker.book1D("sizeY_" + clustersrc_.label() + "_Disk_m2","SizeY (off track, diskm2)",100,0.,100.);
   meClSizeYNotOnTrack_diskm2->setAxisTitle("Cluster size (in pixels)",1);
-  if (isUpgrade) {
-    meClSizeYNotOnTrack_diskm3 = iBooker.book1D("sizeY_" + clustersrc_.label() + "_Disk_m3","SizeY (off track, diskm3)",100,0.,100.);
-    meClSizeYNotOnTrack_diskm3->setAxisTitle("Cluster size (in pixels)",1);
-  }
 
   //cluster global position
   //on track
@@ -491,11 +394,6 @@ void SiPixelTrackResidualSource::bookHistograms(DQMStore::IBooker & iBooker, edm
   meClPosLayer3OnTrack = iBooker.book2D("position_" + clustersrc_.label() + "_Layer_3","Clusters Layer3 (on track)",200,-30.,30.,128,-3.2,3.2);
   meClPosLayer3OnTrack->setAxisTitle("Global Z (cm)",1);
   meClPosLayer3OnTrack->setAxisTitle("Global #phi",2);
-  if (isUpgrade) {
-    meClPosLayer4OnTrack = iBooker.book2D("position_" + clustersrc_.label() + "_Layer_4","Clusters Layer4 (on track)",200,-30.,30.,128,-3.2,3.2);
-    meClPosLayer4OnTrack->setAxisTitle("Global Z (cm)",1);
-    meClPosLayer4OnTrack->setAxisTitle("Global #phi",2);
-  }
   //fpix
   meClPosDisk1pzOnTrack = iBooker.book2D("position_" + clustersrc_.label() + "_pz_Disk_1","Clusters +Z Disk1 (on track)",80,-20.,20.,80,-20.,20.);
   meClPosDisk1pzOnTrack->setAxisTitle("Global X (cm)",1);
@@ -503,22 +401,12 @@ void SiPixelTrackResidualSource::bookHistograms(DQMStore::IBooker & iBooker, edm
   meClPosDisk2pzOnTrack = iBooker.book2D("position_" + clustersrc_.label() + "_pz_Disk_2","Clusters +Z Disk2 (on track)",80,-20.,20.,80,-20.,20.);
   meClPosDisk2pzOnTrack->setAxisTitle("Global X (cm)",1);
   meClPosDisk2pzOnTrack->setAxisTitle("Global Y (cm)",2);
-  if (isUpgrade) {
-    meClPosDisk3pzOnTrack = iBooker.book2D("position_" + clustersrc_.label() + "_pz_Disk_3","Clusters +Z Disk3 (on track)",80,-20.,20.,80,-20.,20.);
-    meClPosDisk3pzOnTrack->setAxisTitle("Global X (cm)",1);
-    meClPosDisk3pzOnTrack->setAxisTitle("Global Y (cm)",2);
-  }
   meClPosDisk1mzOnTrack = iBooker.book2D("position_" + clustersrc_.label() + "_mz_Disk_1","Clusters -Z Disk1 (on track)",80,-20.,20.,80,-20.,20.);
   meClPosDisk1mzOnTrack->setAxisTitle("Global X (cm)",1);
   meClPosDisk1mzOnTrack->setAxisTitle("Global Y (cm)",2);
   meClPosDisk2mzOnTrack = iBooker.book2D("position_" + clustersrc_.label() + "_mz_Disk_2","Clusters -Z Disk2 (on track)",80,-20.,20.,80,-20.,20.);
   meClPosDisk2mzOnTrack->setAxisTitle("Global X (cm)",1);
   meClPosDisk2mzOnTrack->setAxisTitle("Global Y (cm)",2);
-  if (isUpgrade) {
-    meClPosDisk3mzOnTrack = iBooker.book2D("position_" + clustersrc_.label() + "_mz_Disk_3","Clusters -Z Disk3 (on track)",80,-20.,20.,80,-20.,20.);
-    meClPosDisk3mzOnTrack->setAxisTitle("Global X (cm)",1);
-    meClPosDisk3mzOnTrack->setAxisTitle("Global Y (cm)",2);
-  }
   meNClustersOnTrack_all = iBooker.book1D("nclusters_" + clustersrc_.label(),"Number of Clusters (on Track)",50,0.,50.);
   meNClustersOnTrack_all->setAxisTitle("Number of Clusters",1);
   meNClustersOnTrack_bpix = iBooker.book1D("nclusters_" + clustersrc_.label() + "_Barrel","Number of Clusters (on track, barrel)",50,0.,50.);
@@ -531,26 +419,14 @@ void SiPixelTrackResidualSource::bookHistograms(DQMStore::IBooker & iBooker, edm
   meNClustersOnTrack_layer2->setAxisTitle("Number of Clusters",1);
   meNClustersOnTrack_layer3 = iBooker.book1D("nclusters_" + clustersrc_.label() + "_Layer_3","Number of Clusters (on track, layer3)",50,0.,50.);
   meNClustersOnTrack_layer3->setAxisTitle("Number of Clusters",1);
-  if (isUpgrade) {
-    meNClustersOnTrack_layer4 = iBooker.book1D("nclusters_" + clustersrc_.label() + "_Layer_4","Number of Clusters (on track, layer4)",50,0.,50.);
-    meNClustersOnTrack_layer4->setAxisTitle("Number of Clusters",1);
-  }
   meNClustersOnTrack_diskp1 = iBooker.book1D("nclusters_" + clustersrc_.label() + "_Disk_p1","Number of Clusters (on track, diskp1)",50,0.,50.);
   meNClustersOnTrack_diskp1->setAxisTitle("Number of Clusters",1);
   meNClustersOnTrack_diskp2 = iBooker.book1D("nclusters_" + clustersrc_.label() + "_Disk_p2","Number of Clusters (on track, diskp2)",50,0.,50.);
   meNClustersOnTrack_diskp2->setAxisTitle("Number of Clusters",1);
-  if (isUpgrade) {
-    meNClustersOnTrack_diskp3 = iBooker.book1D("nclusters_" + clustersrc_.label() + "_Disk_p3","Number of Clusters (on track, diskp3)",50,0.,50.);
-    meNClustersOnTrack_diskp3->setAxisTitle("Number of Clusters",1);
-  }
   meNClustersOnTrack_diskm1 = iBooker.book1D("nclusters_" + clustersrc_.label() + "_Disk_m1","Number of Clusters (on track, diskm1)",50,0.,50.);
   meNClustersOnTrack_diskm1->setAxisTitle("Number of Clusters",1);
   meNClustersOnTrack_diskm2 = iBooker.book1D("nclusters_" + clustersrc_.label() + "_Disk_m2","Number of Clusters (on track, diskm2)",50,0.,50.);
   meNClustersOnTrack_diskm2->setAxisTitle("Number of Clusters",1);
-  if (isUpgrade) {
-    meNClustersOnTrack_diskm3 = iBooker.book1D("nclusters_" + clustersrc_.label() + "_Disk_m3","Number of Clusters (on track, diskm3)",50,0.,50.);
-    meNClustersOnTrack_diskm3->setAxisTitle("Number of Clusters",1);
-  }
 
   //not on track
   iBooker.setCurrentFolder("Pixel/Clusters/OffTrack");
@@ -564,11 +440,6 @@ void SiPixelTrackResidualSource::bookHistograms(DQMStore::IBooker & iBooker, edm
   meClPosLayer3NotOnTrack = iBooker.book2D("position_" + clustersrc_.label() + "_Layer_3","Clusters Layer3 (off track)",200,-30.,30.,128,-3.2,3.2);
   meClPosLayer3NotOnTrack->setAxisTitle("Global Z (cm)",1);
   meClPosLayer3NotOnTrack->setAxisTitle("Global #phi",2);
-  if (isUpgrade) {
-    meClPosLayer4NotOnTrack = iBooker.book2D("position_" + clustersrc_.label() + "_Layer_4","Clusters Layer4 (off track)",200,-30.,30.,128,-3.2,3.2);
-    meClPosLayer4NotOnTrack->setAxisTitle("Global Z (cm)",1);
-    meClPosLayer4NotOnTrack->setAxisTitle("Global #phi",2);
-  }
   //fpix
   meClPosDisk1pzNotOnTrack = iBooker.book2D("position_" + clustersrc_.label() + "_pz_Disk_1","Clusters +Z Disk1 (off track)",80,-20.,20.,80,-20.,20.);
   meClPosDisk1pzNotOnTrack->setAxisTitle("Global X (cm)",1);
@@ -576,22 +447,12 @@ void SiPixelTrackResidualSource::bookHistograms(DQMStore::IBooker & iBooker, edm
   meClPosDisk2pzNotOnTrack = iBooker.book2D("position_" + clustersrc_.label() + "_pz_Disk_2","Clusters +Z Disk2 (off track)",80,-20.,20.,80,-20.,20.);
   meClPosDisk2pzNotOnTrack->setAxisTitle("Global X (cm)",1);
   meClPosDisk2pzNotOnTrack->setAxisTitle("Global Y (cm)",2);
-  if (isUpgrade) {
-    meClPosDisk3pzNotOnTrack = iBooker.book2D("position_" + clustersrc_.label() + "_pz_Disk_3","Clusters +Z Disk3 (off track)",80,-20.,20.,80,-20.,20.);
-    meClPosDisk3pzNotOnTrack->setAxisTitle("Global X (cm)",1);
-    meClPosDisk3pzNotOnTrack->setAxisTitle("Global Y (cm)",2);
-  }
   meClPosDisk1mzNotOnTrack = iBooker.book2D("position_" + clustersrc_.label() + "_mz_Disk_1","Clusters -Z Disk1 (off track)",80,-20.,20.,80,-20.,20.);
   meClPosDisk1mzNotOnTrack->setAxisTitle("Global X (cm)",1);
   meClPosDisk1mzNotOnTrack->setAxisTitle("Global Y (cm)",2);
   meClPosDisk2mzNotOnTrack = iBooker.book2D("position_" + clustersrc_.label() + "_mz_Disk_2","Clusters -Z Disk2 (off track)",80,-20.,20.,80,-20.,20.);
   meClPosDisk2mzNotOnTrack->setAxisTitle("Global X (cm)",1);
   meClPosDisk2mzNotOnTrack->setAxisTitle("Global Y (cm)",2);
-  if (isUpgrade) {
-    meClPosDisk3mzNotOnTrack = iBooker.book2D("position_" + clustersrc_.label() + "_mz_Disk_3","Clusters -Z Disk3 (off track)",80,-20.,20.,80,-20.,20.);
-    meClPosDisk3mzNotOnTrack->setAxisTitle("Global X (cm)",1);
-    meClPosDisk3mzNotOnTrack->setAxisTitle("Global Y (cm)",2);
-  }
   meNClustersNotOnTrack_all = iBooker.book1D("nclusters_" + clustersrc_.label(),"Number of Clusters (off Track)",50,0.,50.);
   meNClustersNotOnTrack_all->setAxisTitle("Number of Clusters",1);
   meNClustersNotOnTrack_bpix = iBooker.book1D("nclusters_" + clustersrc_.label() + "_Barrel","Number of Clusters (off track, barrel)",50,0.,50.);
@@ -604,26 +465,14 @@ void SiPixelTrackResidualSource::bookHistograms(DQMStore::IBooker & iBooker, edm
   meNClustersNotOnTrack_layer2->setAxisTitle("Number of Clusters",1);
   meNClustersNotOnTrack_layer3 = iBooker.book1D("nclusters_" + clustersrc_.label() + "_Layer_3","Number of Clusters (off track, layer3)",50,0.,50.);
   meNClustersNotOnTrack_layer3->setAxisTitle("Number of Clusters",1);
-  if (isUpgrade) {
-    meNClustersNotOnTrack_layer4 = iBooker.book1D("nclusters_" + clustersrc_.label() + "_Layer_4","Number of Clusters (off track, layer4)",50,0.,50.);
-    meNClustersNotOnTrack_layer4->setAxisTitle("Number of Clusters",1);
-  }
   meNClustersNotOnTrack_diskp1 = iBooker.book1D("nclusters_" + clustersrc_.label() + "_Disk_p1","Number of Clusters (off track, diskp1)",50,0.,50.);
   meNClustersNotOnTrack_diskp1->setAxisTitle("Number of Clusters",1);
   meNClustersNotOnTrack_diskp2 = iBooker.book1D("nclusters_" + clustersrc_.label() + "_Disk_p2","Number of Clusters (off track, diskp2)",50,0.,50.);
   meNClustersNotOnTrack_diskp2->setAxisTitle("Number of Clusters",1);
-  if (isUpgrade) {
-    meNClustersNotOnTrack_diskp3 = iBooker.book1D("nclusters_" + clustersrc_.label() + "_Disk_p3","Number of Clusters (off track, diskp3)",50,0.,50.);
-    meNClustersNotOnTrack_diskp3->setAxisTitle("Number of Clusters",1);
-  }
   meNClustersNotOnTrack_diskm1 = iBooker.book1D("nclusters_" + clustersrc_.label() + "_Disk_m1","Number of Clusters (off track, diskm1)",50,0.,50.);
   meNClustersNotOnTrack_diskm1->setAxisTitle("Number of Clusters",1);
   meNClustersNotOnTrack_diskm2 = iBooker.book1D("nclusters_" + clustersrc_.label() + "_Disk_m2","Number of Clusters (off track, diskm2)",50,0.,50.);
   meNClustersNotOnTrack_diskm2->setAxisTitle("Number of Clusters",1);
-  if (isUpgrade) {
-    meNClustersNotOnTrack_diskm3 = iBooker.book1D("nclusters_" + clustersrc_.label() + "_Disk_m3","Number of Clusters (off track, diskm3)",50,0.,50.);
-    meNClustersNotOnTrack_diskm3->setAxisTitle("Number of Clusters",1);
-  }
 
   //HitProbability
   //on track
@@ -1071,8 +920,7 @@ void SiPixelTrackResidualSource::analyze(const edm::Event& iEvent, const edm::Ev
 		meClSizeXOnTrack_bpix->Fill((*clust).sizeX());
 		meClSizeYOnTrack_bpix->Fill((*clust).sizeY());
 		uint32_t DBlayer;
-		if (!isUpgrade) { DBlayer = PixelBarrelName(DetId((*hit).geographicalId())).layerName(); }
-                else { DBlayer = PixelBarrelNameUpgrade(DetId((*hit).geographicalId())).layerName(); }
+		DBlayer = PixelBarrelName(DetId((*hit).geographicalId())).layerName();
 		float phi = clustgp.phi(); 
 		float z = clustgp.z();
 		switch(DBlayer){
@@ -1100,16 +948,6 @@ void SiPixelTrackResidualSource::analyze(const edm::Event& iEvent, const edm::Ev
 		  meClSizeYOnTrack_layer3->Fill((*clust).sizeY());
 		  break;
 		}
-		case 4: {
-		  if (isUpgrade) {
-		    meClPosLayer4OnTrack->Fill(z,phi); 
-		    meClChargeOnTrack_layer4->Fill(corrCharge);
-		    meClSizeOnTrack_layer4->Fill((*clust).size());
-		    meClSizeXOnTrack_layer4->Fill((*clust).sizeX());
-		    meClSizeYOnTrack_layer4->Fill((*clust).sizeY());
-		  }
-		  break;
-		}
 		
 		}
 		
@@ -1122,8 +960,7 @@ void SiPixelTrackResidualSource::analyze(const edm::Event& iEvent, const edm::Ev
 		meClSizeXOnTrack_fpix->Fill((*clust).sizeX());
 		meClSizeYOnTrack_fpix->Fill((*clust).sizeY());
 		uint32_t DBdisk;
-                if (!isUpgrade) { DBdisk = PixelEndcapName(DetId((*hit).geographicalId())).diskName(); }
-                else if (isUpgrade) { DBdisk = PixelEndcapNameUpgrade(DetId((*hit).geographicalId())).diskName(); }
+                DBdisk = PixelEndcapName(DetId((*hit).geographicalId())).diskName();
 		float x = clustgp.x(); 
 		float y = clustgp.y(); 
 		float z = clustgp.z();
@@ -1142,13 +979,6 @@ void SiPixelTrackResidualSource::analyze(const edm::Event& iEvent, const edm::Ev
 		    meClSizeXOnTrack_diskp2->Fill((*clust).sizeX());
 		    meClSizeYOnTrack_diskp2->Fill((*clust).sizeY());
 		  }
-		  if(DBdisk==3 && isUpgrade) {
-		    meClPosDisk3pzOnTrack->Fill(x,y);
-                    meClChargeOnTrack_diskp3->Fill(corrCharge);
-		    meClSizeOnTrack_diskp3->Fill((*clust).size());
-		    meClSizeXOnTrack_diskp3->Fill((*clust).sizeX());
-		    meClSizeYOnTrack_diskp3->Fill((*clust).sizeY());
-		  }
 		}
 		else{
 		  if(DBdisk==1) {
@@ -1164,13 +994,6 @@ void SiPixelTrackResidualSource::analyze(const edm::Event& iEvent, const edm::Ev
 		    meClSizeOnTrack_diskm2->Fill((*clust).size());
 		    meClSizeXOnTrack_diskm2->Fill((*clust).sizeX());
 		    meClSizeYOnTrack_diskm2->Fill((*clust).sizeY());
-		  }
-		  if(DBdisk==3 && isUpgrade) {
-		    meClPosDisk3mzOnTrack->Fill(x,y);
-                    meClChargeOnTrack_diskm3->Fill(corrCharge);
-		    meClSizeOnTrack_diskm3->Fill((*clust).size());
-		    meClSizeXOnTrack_diskm3->Fill((*clust).sizeX());
-		    meClSizeYOnTrack_diskm3->Fill((*clust).sizeY());
 		  }
 		} 
 	      }
@@ -1204,15 +1027,10 @@ void SiPixelTrackResidualSource::analyze(const edm::Event& iEvent, const edm::Ev
       float z=0.; 
       //set layer/disk
       if(DetId(detId).subdetId() == 1) { // Barrel module
-        if (!isUpgrade) {
 	DBlayer = PixelBarrelName(DetId(detId)).layerName();
-	} else if (isUpgrade) {
-	  DBlayer = PixelBarrelNameUpgrade(DetId(detId)).layerName();
-	}
       }
       if(DetId(detId).subdetId() == 2){ // Endcap module
-        if (!isUpgrade) { DBdisk = PixelEndcapName(DetId(detId )).diskName(); }
-        else if (isUpgrade) { DBdisk = PixelEndcapNameUpgrade(DetId(detId )).diskName(); }
+        DBdisk = PixelEndcapName(DetId(detId )).diskName();
       }
       edmNew::DetSetVector<SiPixelCluster>::const_iterator isearch = clustColl.find(detId);
       if( isearch != clustColl.end() ) {  // Not an empty iterator
@@ -1295,16 +1113,6 @@ void SiPixelTrackResidualSource::analyze(const edm::Event& iEvent, const edm::Ev
 		meClChargeNotOnTrack_layer3->Fill((*di).charge()/1000);
 		break;
 	      }
-	      case 4: {
-	        if (isUpgrade) {
-		  meClPosLayer4NotOnTrack->Fill(z,phi); 
-		  meClSizeNotOnTrack_layer4->Fill((*di).size());
-		  meClSizeXNotOnTrack_layer4->Fill((*di).sizeX());
-		  meClSizeYNotOnTrack_layer4->Fill((*di).sizeY());
-		  meClChargeNotOnTrack_layer4->Fill((*di).charge()/1000);
-		}
-		break;
-	      }
 		
 	      }
 	    }
@@ -1334,13 +1142,6 @@ void SiPixelTrackResidualSource::analyze(const edm::Event& iEvent, const edm::Ev
 		  meClSizeYNotOnTrack_diskp2->Fill((*di).sizeY());
 		  meClChargeNotOnTrack_diskp2->Fill((*di).charge()/1000);
 		}
-		if(DBdisk==3 && isUpgrade) {
-		  meClPosDisk3pzNotOnTrack->Fill(x,y);
-                  meClSizeNotOnTrack_diskp3->Fill((*di).size());
-		  meClSizeXNotOnTrack_diskp3->Fill((*di).sizeX());
-		  meClSizeYNotOnTrack_diskp3->Fill((*di).sizeY());
-		  meClChargeNotOnTrack_diskp3->Fill((*di).charge()/1000);
-		}
 	      }
 	      else{
 		if(DBdisk==1) {
@@ -1356,13 +1157,6 @@ void SiPixelTrackResidualSource::analyze(const edm::Event& iEvent, const edm::Ev
 		  meClSizeXNotOnTrack_diskm2->Fill((*di).sizeX());
 		  meClSizeYNotOnTrack_diskm2->Fill((*di).sizeY());
 		  meClChargeNotOnTrack_diskm2->Fill((*di).charge()/1000);
-		}
-		if(DBdisk==3 && isUpgrade) {
-		  meClPosDisk3mzNotOnTrack->Fill(x,y);
-                  meClSizeNotOnTrack_diskm3->Fill((*di).size());
-		  meClSizeXNotOnTrack_diskm3->Fill((*di).sizeX());
-		  meClSizeYNotOnTrack_diskm3->Fill((*di).sizeY());
-		  meClChargeNotOnTrack_diskm3->Fill((*di).charge()/1000);
 		}
 	      } 
 
@@ -1416,10 +1210,6 @@ void SiPixelTrackResidualSource::analyze(const edm::Event& iEvent, const edm::Ev
 	  if(nofclOnTrack!=0) meNClustersOnTrack_layer3->Fill(nofclOnTrack); 
 	  if(nofclOffTrack!=0) meNClustersNotOnTrack_layer3->Fill(nofclOffTrack); break; 
 	}
-	case 4: {
-	  if(nofclOnTrack!=0 && isUpgrade) meNClustersOnTrack_layer4->Fill(nofclOnTrack); 
-	  if(nofclOffTrack!=0 && isUpgrade) meNClustersNotOnTrack_layer4->Fill(nofclOffTrack); break; 
-	}
 	}
       }//end barrel
       //endcap
@@ -1437,10 +1227,6 @@ void SiPixelTrackResidualSource::analyze(const edm::Event& iEvent, const edm::Ev
 	    if(nofclOnTrack!=0) meNClustersOnTrack_diskp2->Fill(nofclOnTrack); 
 	    if(nofclOffTrack!=0) meNClustersNotOnTrack_diskp2->Fill(nofclOffTrack);
 	  }
-          if(DBdisk==3) {
-	    if(nofclOnTrack!=0 && isUpgrade) meNClustersOnTrack_diskp3->Fill(nofclOnTrack); 
-	    if(nofclOffTrack!=0) meNClustersNotOnTrack_diskp3->Fill(nofclOffTrack);
-	  }
 	}
 	if(z<0){
 	  if(DBdisk==1) {
@@ -1450,10 +1236,6 @@ void SiPixelTrackResidualSource::analyze(const edm::Event& iEvent, const edm::Ev
 	  if(DBdisk==2) {
 	    if(nofclOnTrack!=0) meNClustersOnTrack_diskm2->Fill(nofclOnTrack); 
 	    if(nofclOffTrack!=0) meNClustersNotOnTrack_diskm2->Fill(nofclOffTrack);
-	  }
-          if(DBdisk==3) {
-	    if(nofclOnTrack!=0 && isUpgrade) meNClustersOnTrack_diskm3->Fill(nofclOnTrack); 
-	    if(nofclOffTrack!=0 && isUpgrade) meNClustersNotOnTrack_diskm3->Fill(nofclOffTrack);
 	  }
 	}
       }

--- a/DQM/SiPixelMonitorTrack/src/SiPixelTrackResidualSourcePhase1.cc
+++ b/DQM/SiPixelMonitorTrack/src/SiPixelTrackResidualSourcePhase1.cc
@@ -1,0 +1,1486 @@
+// Package:    SiPixelMonitorTrack
+// Class:      SiPixelTrackResidualSourcePhase1
+// 
+// class SiPixelTrackResidualSourcePhase1 SiPixelTrackResidualSourcePhase1.cc 
+//       DQM/SiPixelMonitorTrack/src/SiPixelTrackResidualSourcePhase1.cc
+//
+// Description: SiPixel hit-to-track residual data quality monitoring modules
+// Implementation: prototype -> improved -> never final - end of the 1st step 
+//
+// Original Author: Shan-Huei Chuang
+//         Created: Fri Mar 23 18:41:42 CET 2007
+//         Updated by Lukas Wehrli (plots for clusters on/off track added)
+
+
+#include <iostream>
+#include <map>
+#include <string>
+#include <vector>
+#include <utility>
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/TrackCandidate/interface/TrackCandidateCollection.h"
+
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"
+
+#include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
+#include "Geometry/CommonTopologies/interface/PixelTopology.h"
+
+#include "RecoTracker/TransientTrackingRecHit/interface/TkTransientTrackingRecHitBuilder.h"
+
+#include "TrackingTools/TrackFitters/interface/TrajectoryFitter.h"
+#include "TrackingTools/Records/interface/TransientRecHitRecord.h"
+#include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
+#include "TrackingTools/TrackFitters/interface/TrajectoryStateCombiner.h"
+#include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
+
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQM/SiPixelCommon/interface/SiPixelFolderOrganizer.h"
+#include "DQM/SiPixelMonitorTrack/interface/SiPixelTrackResidualSourcePhase1.h"
+
+//Claudia new libraries
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
+#include "TrackingTools/Records/interface/TransientTrackRecord.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrack.h"
+#include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHitBuilder.h"
+#include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHit.h"
+#include "TrackingTools/Records/interface/TransientRecHitRecord.h"
+
+using namespace std;
+using namespace edm;
+
+
+SiPixelTrackResidualSourcePhase1::SiPixelTrackResidualSourcePhase1(const edm::ParameterSet& pSet) :
+  pSet_(pSet),
+  modOn( pSet.getUntrackedParameter<bool>("modOn",true) ),
+  reducedSet( pSet.getUntrackedParameter<bool>("reducedSet",true) ),
+  ladOn( pSet.getUntrackedParameter<bool>("ladOn",false) ), 
+  layOn( pSet.getUntrackedParameter<bool>("layOn",false) ), 
+  phiOn( pSet.getUntrackedParameter<bool>("phiOn",false) ), 
+  ringOn( pSet.getUntrackedParameter<bool>("ringOn",false) ), 
+  bladeOn( pSet.getUntrackedParameter<bool>("bladeOn",false) ), 
+  diskOn( pSet.getUntrackedParameter<bool>("diskOn",false) )
+{ 
+   pSet_ = pSet; 
+   debug_ = pSet_.getUntrackedParameter<bool>("debug", false); 
+   src_ = pSet_.getParameter<edm::InputTag>("src"); 
+   clustersrc_ = pSet_.getParameter<edm::InputTag>("clustersrc");
+   tracksrc_ = pSet_.getParameter<edm::InputTag>("trajectoryInput");
+   ttrhbuilder_ = pSet_.getParameter<std::string>("TTRHBuilder");
+   ptminres_= pSet.getUntrackedParameter<double>("PtMinRes",4.0) ;
+   beamSpotToken_ = consumes<reco::BeamSpot>(std::string("offlineBeamSpot"));
+   offlinePrimaryVerticesToken_ = consumes<reco::VertexCollection>(std::string("offlinePrimaryVertices"));
+   generalTracksToken_ = consumes<reco::TrackCollection>(std::string("generalTracks"));
+   tracksrcToken_ = consumes<std::vector<Trajectory> >(pSet_.getParameter<edm::InputTag>("trajectoryInput"));
+   trackToken_ = consumes<std::vector<reco::Track> >(pSet_.getParameter<edm::InputTag>("trajectoryInput"));
+   trackAssociationToken_ = consumes<TrajTrackAssociationCollection>(pSet_.getParameter<edm::InputTag>("trajectoryInput"));
+   clustersrcToken_ = consumes<edmNew::DetSetVector<SiPixelCluster> >(pSet_.getParameter<edm::InputTag>("clustersrc"));
+
+  LogInfo("PixelDQM") << "SiPixelTrackResidualSourcePhase1 constructor" << endl;
+  LogInfo ("PixelDQM") << "Mod/Lad/Lay/Phi " << modOn << "/" << ladOn << "/" 
+            << layOn << "/" << phiOn << std::endl;
+  LogInfo ("PixelDQM") << "Blade/Disk/Ring" << bladeOn << "/" << diskOn << "/" 
+            << ringOn << std::endl;
+
+  firstRun = true;
+  NTotal=0;
+  NLowProb=0;
+}
+
+
+SiPixelTrackResidualSourcePhase1::~SiPixelTrackResidualSourcePhase1() {
+  LogInfo("PixelDQM") << "SiPixelTrackResidualSourcePhase1 destructor" << endl;
+
+  std::map<uint32_t,SiPixelTrackResidualModulePhase1*>::iterator struct_iter;
+  for (struct_iter = theSiPixelStructure.begin() ; struct_iter != theSiPixelStructure.end() ; struct_iter++){
+    delete struct_iter->second;
+    struct_iter->second = 0;
+  }
+}
+
+
+void SiPixelTrackResidualSourcePhase1::dqmBeginRun(const edm::Run& r, edm::EventSetup const& iSetup) {
+  LogInfo("PixelDQM") << "SiPixelTrackResidualSourcePhase1 beginRun()" << endl;
+  // retrieve TrackerGeometry for pixel dets
+  edm::ESHandle<TrackerGeometry> TG;
+  iSetup.get<TrackerDigiGeometryRecord>().get(TG);
+  if (debug_) LogVerbatim("PixelDQM") << "TrackerGeometry "<< &(*TG) <<" size is "<< TG->dets().size() << endl;
+ 
+  // build theSiPixelStructure with the pixel barrel and endcap dets from TrackerGeometry
+  for (TrackerGeometry::DetContainer::const_iterator pxb = TG->detsPXB().begin();  
+       pxb!=TG->detsPXB().end(); pxb++) {
+    if (dynamic_cast<PixelGeomDetUnit const *>((*pxb))!=0) {
+      SiPixelTrackResidualModulePhase1* module = new SiPixelTrackResidualModulePhase1((*pxb)->geographicalId().rawId());
+      theSiPixelStructure.insert(pair<uint32_t, SiPixelTrackResidualModulePhase1*>((*pxb)->geographicalId().rawId(), module));
+    }
+  }
+  for (TrackerGeometry::DetContainer::const_iterator pxf = TG->detsPXF().begin(); 
+       pxf!=TG->detsPXF().end(); pxf++) {
+    if (dynamic_cast<PixelGeomDetUnit const *>((*pxf))!=0) {
+      SiPixelTrackResidualModulePhase1* module = new SiPixelTrackResidualModulePhase1((*pxf)->geographicalId().rawId());
+      theSiPixelStructure.insert(pair<uint32_t, SiPixelTrackResidualModulePhase1*>((*pxf)->geographicalId().rawId(), module));
+    }
+  }
+  LogInfo("PixelDQM") << "SiPixelStructure size is " << theSiPixelStructure.size() << endl;
+}
+
+void SiPixelTrackResidualSourcePhase1::bookHistograms(DQMStore::IBooker & iBooker, edm::Run const &, edm::EventSetup const & iSetup){
+
+  // book residual histograms in theSiPixelFolder - one (x,y) pair of histograms per det
+  SiPixelFolderOrganizer theSiPixelFolder(false);
+  for (std::map<uint32_t, SiPixelTrackResidualModulePhase1*>::iterator pxd = theSiPixelStructure.begin(); 
+       pxd!=theSiPixelStructure.end(); pxd++) {
+
+    if(modOn){
+      if (theSiPixelFolder.setModuleFolder(iBooker,(*pxd).first,0)) (*pxd).second->book(pSet_,iBooker,reducedSet,0);
+      else throw cms::Exception("LogicError") << "SiPixelTrackResidualSourcePhase1 Folder Creation Failed! "; 
+    }
+    if(ladOn){
+      if (theSiPixelFolder.setModuleFolder(iBooker,(*pxd).first,1)) {
+	
+	(*pxd).second->book(pSet_,iBooker,reducedSet,1);
+      }
+      else throw cms::Exception("LogicError") << "SiPixelTrackResidualSourcePhase1 ladder Folder Creation Failed! "; 
+    }
+    if(layOn){
+      if (theSiPixelFolder.setModuleFolder(iBooker,(*pxd).first,2)) (*pxd).second->book(pSet_,iBooker,reducedSet,2);
+      else throw cms::Exception("LogicError") << "SiPixelTrackResidualSourcePhase1 layer Folder Creation Failed! "; 
+    }
+    if(phiOn){
+      if (theSiPixelFolder.setModuleFolder(iBooker,(*pxd).first,3)) (*pxd).second->book(pSet_,iBooker,reducedSet,3);
+      else throw cms::Exception("LogicError") << "SiPixelTrackResidualSourcePhase1 phi Folder Creation Failed! "; 
+    }
+    if(bladeOn){
+      if (theSiPixelFolder.setModuleFolder(iBooker,(*pxd).first,4)) (*pxd).second->book(pSet_,iBooker,reducedSet,4);
+      else throw cms::Exception("LogicError") << "SiPixelTrackResidualSourcePhase1 Blade Folder Creation Failed! "; 
+    }
+    if(diskOn){
+      if (theSiPixelFolder.setModuleFolder(iBooker,(*pxd).first,5)) (*pxd).second->book(pSet_,iBooker,reducedSet,5);
+      else throw cms::Exception("LogicError") << "SiPixelTrackResidualSourcePhase1 Disk Folder Creation Failed! "; 
+    }
+    if(ringOn){
+      if (theSiPixelFolder.setModuleFolder(iBooker,(*pxd).first,6)) (*pxd).second->book(pSet_,iBooker,reducedSet,6);
+      else throw cms::Exception("LogicError") << "SiPixelTrackResidualSourcePhase1 Ring Folder Creation Failed! "; 
+    }
+  }
+
+
+//   edm::InputTag tracksrc = pSet_.getParameter<edm::InputTag>("trajectoryInput");
+//   edm::InputTag clustersrc = pSet_.getParameter<edm::InputTag>("clustersrc");
+
+  //number of tracks
+  iBooker.setCurrentFolder("Pixel/Tracks");
+  meNofTracks_ = iBooker.book1D("ntracks_" + tracksrc_.label(),"Number of Tracks",4,0,4);
+  meNofTracks_->setAxisTitle("Number of Tracks",1);
+  meNofTracks_->setBinLabel(1,"All");
+  meNofTracks_->setBinLabel(2,"Pixel");
+  meNofTracks_->setBinLabel(3,"BPix");
+  meNofTracks_->setBinLabel(4,"FPix");
+
+  //number of tracks in pixel fiducial volume
+  iBooker.setCurrentFolder("Pixel/Tracks");
+  meNofTracksInPixVol_ = iBooker.book1D("ntracksInPixVol_" + tracksrc_.label(),"Number of Tracks crossing Pixel fiducial Volume",2,0,2);
+  meNofTracksInPixVol_->setAxisTitle("Number of Tracks",1);
+  meNofTracksInPixVol_->setBinLabel(1,"With Hits");
+  meNofTracksInPixVol_->setBinLabel(2,"Without Hits");
+
+  //number of clusters (associated to track / not associated)
+  iBooker.setCurrentFolder("Pixel/Clusters/OnTrack");
+  meNofClustersOnTrack_ = iBooker.book1D("nclusters_" + clustersrc_.label() + "_tot","Number of Clusters (on track)",3,0,3);
+  meNofClustersOnTrack_->setAxisTitle("Number of Clusters on Track",1);
+  meNofClustersOnTrack_->setBinLabel(1,"All");
+  meNofClustersOnTrack_->setBinLabel(2,"BPix");
+  meNofClustersOnTrack_->setBinLabel(3,"FPix");
+  iBooker.setCurrentFolder("Pixel/Clusters/OffTrack");
+  meNofClustersNotOnTrack_ = iBooker.book1D("nclusters_" + clustersrc_.label() + "_tot","Number of Clusters (off track)",3,0,3);
+  meNofClustersNotOnTrack_->setAxisTitle("Number of Clusters off Track",1);
+  meNofClustersNotOnTrack_->setBinLabel(1,"All");
+  meNofClustersNotOnTrack_->setBinLabel(2,"BPix");
+  meNofClustersNotOnTrack_->setBinLabel(3,"FPix");
+
+  //cluster charge and size
+  //charge
+  //on track
+  iBooker.setCurrentFolder("Pixel/Clusters/OnTrack");
+  meClChargeOnTrack_all = iBooker.book1D("charge_" + clustersrc_.label(),"Charge (on track)",500,0.,500.);
+  meClChargeOnTrack_all->setAxisTitle("Charge size (in ke)",1);
+  meClChargeOnTrack_bpix = iBooker.book1D("charge_" + clustersrc_.label() + "_Barrel","Charge (on track, barrel)",500,0.,500.);
+  meClChargeOnTrack_bpix->setAxisTitle("Charge size (in ke)",1);
+  meClChargeOnTrack_fpix = iBooker.book1D("charge_" + clustersrc_.label() + "_Endcap","Charge (on track, endcap)",500,0.,500.);
+  meClChargeOnTrack_fpix->setAxisTitle("Charge size (in ke)",1);
+  meClChargeOnTrack_layer1 = iBooker.book1D("charge_" + clustersrc_.label() + "_Layer_1","Charge (on track, layer1)",500,0.,500.);
+  meClChargeOnTrack_layer1->setAxisTitle("Charge size (in ke)",1);
+  meClChargeOnTrack_layer2 = iBooker.book1D("charge_" + clustersrc_.label() + "_Layer_2","Charge (on track, layer2)",500,0.,500.);
+  meClChargeOnTrack_layer2->setAxisTitle("Charge size (in ke)",1);
+  meClChargeOnTrack_layer3 = iBooker.book1D("charge_" + clustersrc_.label() + "_Layer_3","Charge (on track, layer3)",500,0.,500.);
+  meClChargeOnTrack_layer3->setAxisTitle("Charge size (in ke)",1);
+  meClChargeOnTrack_layer4 = iBooker.book1D("charge_" + clustersrc_.label() + "_Layer_4","Charge (on track, layer4)",500,0.,500.);
+  meClChargeOnTrack_layer4->setAxisTitle("Charge size (in ke)",1);
+  meClChargeOnTrack_diskp1 = iBooker.book1D("charge_" + clustersrc_.label() + "_Disk_p1","Charge (on track, diskp1)",500,0.,500.);
+  meClChargeOnTrack_diskp1->setAxisTitle("Charge size (in ke)",1);
+  meClChargeOnTrack_diskp2 = iBooker.book1D("charge_" + clustersrc_.label() + "_Disk_p2","Charge (on track, diskp2)",500,0.,500.);
+  meClChargeOnTrack_diskp2->setAxisTitle("Charge size (in ke)",1);
+  meClChargeOnTrack_diskp3 = iBooker.book1D("charge_" + clustersrc_.label() + "_Disk_p3","Charge (on track, diskp3)",500,0.,500.);
+  meClChargeOnTrack_diskp3->setAxisTitle("Charge size (in ke)",1);
+  meClChargeOnTrack_diskm1 = iBooker.book1D("charge_" + clustersrc_.label() + "_Disk_m1","Charge (on track, diskm1)",500,0.,500.);
+  meClChargeOnTrack_diskm1->setAxisTitle("Charge size (in ke)",1);
+  meClChargeOnTrack_diskm2 = iBooker.book1D("charge_" + clustersrc_.label() + "_Disk_m2","Charge (on track, diskm2)",500,0.,500.);
+  meClChargeOnTrack_diskm2->setAxisTitle("Charge size (in ke)",1);
+  meClChargeOnTrack_diskm3 = iBooker.book1D("charge_" + clustersrc_.label() + "_Disk_m3","Charge (on track, diskm3)",500,0.,500.);
+  meClChargeOnTrack_diskm3->setAxisTitle("Charge size (in ke)",1);
+  //off track
+  iBooker.setCurrentFolder("Pixel/Clusters/OffTrack");
+  meClChargeNotOnTrack_all = iBooker.book1D("charge_" + clustersrc_.label(),"Charge (off track)",500,0.,500.);
+  meClChargeNotOnTrack_all->setAxisTitle("Charge size (in ke)",1);
+  meClChargeNotOnTrack_bpix = iBooker.book1D("charge_" + clustersrc_.label() + "_Barrel","Charge (off track, barrel)",500,0.,500.);
+  meClChargeNotOnTrack_bpix->setAxisTitle("Charge size (in ke)",1);
+  meClChargeNotOnTrack_fpix = iBooker.book1D("charge_" + clustersrc_.label() + "_Endcap","Charge (off track, endcap)",500,0.,500.);
+  meClChargeNotOnTrack_fpix->setAxisTitle("Charge size (in ke)",1);
+  meClChargeNotOnTrack_layer1 = iBooker.book1D("charge_" + clustersrc_.label() + "_Layer_1","Charge (off track, layer1)",500,0.,500.);
+  meClChargeNotOnTrack_layer1->setAxisTitle("Charge size (in ke)",1);
+  meClChargeNotOnTrack_layer2 = iBooker.book1D("charge_" + clustersrc_.label() + "_Layer_2","Charge (off track, layer2)",500,0.,500.);
+  meClChargeNotOnTrack_layer2->setAxisTitle("Charge size (in ke)",1);
+  meClChargeNotOnTrack_layer3 = iBooker.book1D("charge_" + clustersrc_.label() + "_Layer_3","Charge (off track, layer3)",500,0.,500.);
+  meClChargeNotOnTrack_layer3->setAxisTitle("Charge size (in ke)",1);
+  meClChargeNotOnTrack_layer4 = iBooker.book1D("charge_" + clustersrc_.label() + "_Layer_4","Charge (off track, layer4)",500,0.,500.);
+  meClChargeNotOnTrack_layer4->setAxisTitle("Charge size (in ke)",1);
+  meClChargeNotOnTrack_diskp1 = iBooker.book1D("charge_" + clustersrc_.label() + "_Disk_p1","Charge (off track, diskp1)",500,0.,500.);
+  meClChargeNotOnTrack_diskp1->setAxisTitle("Charge size (in ke)",1);
+  meClChargeNotOnTrack_diskp2 = iBooker.book1D("charge_" + clustersrc_.label() + "_Disk_p2","Charge (off track, diskp2)",500,0.,500.);
+  meClChargeNotOnTrack_diskp2->setAxisTitle("Charge size (in ke)",1);
+  meClChargeNotOnTrack_diskp3 = iBooker.book1D("charge_" + clustersrc_.label() + "_Disk_p3","Charge (off track, diskp3)",500,0.,500.);
+  meClChargeNotOnTrack_diskp3->setAxisTitle("Charge size (in ke)",1);
+  meClChargeNotOnTrack_diskm1 = iBooker.book1D("charge_" + clustersrc_.label() + "_Disk_m1","Charge (off track, diskm1)",500,0.,500.);
+  meClChargeNotOnTrack_diskm1->setAxisTitle("Charge size (in ke)",1);
+  meClChargeNotOnTrack_diskm2 = iBooker.book1D("charge_" + clustersrc_.label() + "_Disk_m2","Charge (off track, diskm2)",500,0.,500.);
+  meClChargeNotOnTrack_diskm2->setAxisTitle("Charge size (in ke)",1);
+  meClChargeNotOnTrack_diskm3 = iBooker.book1D("charge_" + clustersrc_.label() + "_Disk_m3","Charge (off track, diskm3)",500,0.,500.);
+  meClChargeNotOnTrack_diskm3->setAxisTitle("Charge size (in ke)",1);
+  
+  //size
+  //on track
+  iBooker.setCurrentFolder("Pixel/Clusters/OnTrack");
+  meClSizeOnTrack_all = iBooker.book1D("size_" + clustersrc_.label(),"Size (on track)",100,0.,100.);
+  meClSizeOnTrack_all->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeOnTrack_bpix = iBooker.book1D("size_" + clustersrc_.label() + "_Barrel","Size (on track, barrel)",100,0.,100.);
+  meClSizeOnTrack_bpix->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeOnTrack_fpix = iBooker.book1D("size_" + clustersrc_.label() + "_Endcap","Size (on track, endcap)",100,0.,100.);
+  meClSizeOnTrack_fpix->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeOnTrack_layer1 = iBooker.book1D("size_" + clustersrc_.label() + "_Layer_1","Size (on track, layer1)",100,0.,100.);
+  meClSizeOnTrack_layer1->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeOnTrack_layer2 = iBooker.book1D("size_" + clustersrc_.label() + "_Layer_2","Size (on track, layer2)",100,0.,100.);
+  meClSizeOnTrack_layer2->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeOnTrack_layer3 = iBooker.book1D("size_" + clustersrc_.label() + "_Layer_3","Size (on track, layer3)",100,0.,100.);
+  meClSizeOnTrack_layer3->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeOnTrack_layer4 = iBooker.book1D("size_" + clustersrc_.label() + "_Layer_4","Size (on track, layer4)",100,0.,100.);
+  meClSizeOnTrack_layer4->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeOnTrack_diskp1 = iBooker.book1D("size_" + clustersrc_.label() + "_Disk_p1","Size (on track, diskp1)",100,0.,100.);
+  meClSizeOnTrack_diskp1->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeOnTrack_diskp2 = iBooker.book1D("size_" + clustersrc_.label() + "_Disk_p2","Size (on track, diskp2)",100,0.,100.);
+  meClSizeOnTrack_diskp2->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeOnTrack_diskp3 = iBooker.book1D("size_" + clustersrc_.label() + "_Disk_p3","Size (on track, diskp3)",100,0.,100.);
+  meClSizeOnTrack_diskp3->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeOnTrack_diskm1 = iBooker.book1D("size_" + clustersrc_.label() + "_Disk_m1","Size (on track, diskm1)",100,0.,100.);
+  meClSizeOnTrack_diskm1->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeOnTrack_diskm2 = iBooker.book1D("size_" + clustersrc_.label() + "_Disk_m2","Size (on track, diskm2)",100,0.,100.);
+  meClSizeOnTrack_diskm2->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeOnTrack_diskm3 = iBooker.book1D("size_" + clustersrc_.label() + "_Disk_m3","Size (on track, diskm3)",100,0.,100.);
+  meClSizeOnTrack_diskm3->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeXOnTrack_all = iBooker.book1D("sizeX_" + clustersrc_.label(),"SizeX (on track)",100,0.,100.);
+  meClSizeXOnTrack_all->setAxisTitle("Cluster sizeX (in pixels)",1);
+  meClSizeXOnTrack_bpix = iBooker.book1D("sizeX_" + clustersrc_.label() + "_Barrel","SizeX (on track, barrel)",100,0.,100.);
+  meClSizeXOnTrack_bpix->setAxisTitle("Cluster sizeX (in pixels)",1);
+  meClSizeXOnTrack_fpix = iBooker.book1D("sizeX_" + clustersrc_.label() + "_Endcap","SizeX (on track, endcap)",100,0.,100.);
+  meClSizeXOnTrack_fpix->setAxisTitle("Cluster sizeX (in pixels)",1);
+  meClSizeXOnTrack_layer1 = iBooker.book1D("sizeX_" + clustersrc_.label() + "_Layer_1","SizeX (on track, layer1)",100,0.,100.);
+  meClSizeXOnTrack_layer1->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeXOnTrack_layer2 = iBooker.book1D("sizeX_" + clustersrc_.label() + "_Layer_2","SizeX (on track, layer2)",100,0.,100.);
+  meClSizeXOnTrack_layer2->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeXOnTrack_layer3 = iBooker.book1D("sizeX_" + clustersrc_.label() + "_Layer_3","SizeX (on track, layer3)",100,0.,100.);
+  meClSizeXOnTrack_layer3->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeXOnTrack_layer4 = iBooker.book1D("sizeX_" + clustersrc_.label() + "_Layer_4","SizeX (on track, layer4)",100,0.,100.);
+  meClSizeXOnTrack_layer4->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeXOnTrack_diskp1 = iBooker.book1D("sizeX_" + clustersrc_.label() + "_Disk_p1","SizeX (on track, diskp1)",100,0.,100.);
+  meClSizeXOnTrack_diskp1->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeXOnTrack_diskp2 = iBooker.book1D("sizeX_" + clustersrc_.label() + "_Disk_p2","SizeX (on track, diskp2)",100,0.,100.);
+  meClSizeXOnTrack_diskp2->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeXOnTrack_diskp3 = iBooker.book1D("sizeX_" + clustersrc_.label() + "_Disk_p3","SizeX (on track, diskp3)",100,0.,100.);
+  meClSizeXOnTrack_diskp3->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeXOnTrack_diskm1 = iBooker.book1D("sizeX_" + clustersrc_.label() + "_Disk_m1","SizeX (on track, diskm1)",100,0.,100.);
+  meClSizeXOnTrack_diskm1->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeXOnTrack_diskm2 = iBooker.book1D("sizeX_" + clustersrc_.label() + "_Disk_m2","SizeX (on track, diskm2)",100,0.,100.);
+  meClSizeXOnTrack_diskm2->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeXOnTrack_diskm3 = iBooker.book1D("sizeX_" + clustersrc_.label() + "_Disk_m3","SizeX (on track, diskm3)",100,0.,100.);
+  meClSizeXOnTrack_diskm3->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeYOnTrack_all = iBooker.book1D("sizeY_" + clustersrc_.label(),"SizeY (on track)",100,0.,100.);
+  meClSizeYOnTrack_all->setAxisTitle("Cluster sizeY (in pixels)",1);
+  meClSizeYOnTrack_bpix = iBooker.book1D("sizeY_" + clustersrc_.label() + "_Barrel","SizeY (on track, barrel)",100,0.,100.);
+  meClSizeYOnTrack_bpix->setAxisTitle("Cluster sizeY (in pixels)",1);
+  meClSizeYOnTrack_fpix = iBooker.book1D("sizeY_" + clustersrc_.label() + "_Endcap","SizeY (on track, endcap)",100,0.,100.);
+  meClSizeYOnTrack_fpix->setAxisTitle("Cluster sizeY (in pixels)",1);
+  meClSizeYOnTrack_layer1 = iBooker.book1D("sizeY_" + clustersrc_.label() + "_Layer_1","SizeY (on track, layer1)",100,0.,100.);
+  meClSizeYOnTrack_layer1->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeYOnTrack_layer2 = iBooker.book1D("sizeY_" + clustersrc_.label() + "_Layer_2","SizeY (on track, layer2)",100,0.,100.);
+  meClSizeYOnTrack_layer2->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeYOnTrack_layer3 = iBooker.book1D("sizeY_" + clustersrc_.label() + "_Layer_3","SizeY (on track, layer3)",100,0.,100.);
+  meClSizeYOnTrack_layer3->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeYOnTrack_layer4 = iBooker.book1D("sizeY_" + clustersrc_.label() + "_Layer_4","SizeY (on track, layer4)",100,0.,100.);
+  meClSizeYOnTrack_layer4->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeYOnTrack_diskp1 = iBooker.book1D("sizeY_" + clustersrc_.label() + "_Disk_p1","SizeY (on track, diskp1)",100,0.,100.);
+  meClSizeYOnTrack_diskp1->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeYOnTrack_diskp2 = iBooker.book1D("sizeY_" + clustersrc_.label() + "_Disk_p2","SizeY (on track, diskp2)",100,0.,100.);
+  meClSizeYOnTrack_diskp2->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeYOnTrack_diskp3 = iBooker.book1D("sizeY_" + clustersrc_.label() + "_Disk_p3","SizeY (on track, diskp3)",100,0.,100.);
+  meClSizeYOnTrack_diskp3->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeYOnTrack_diskm1 = iBooker.book1D("sizeY_" + clustersrc_.label() + "_Disk_m1","SizeY (on track, diskm1)",100,0.,100.);
+  meClSizeYOnTrack_diskm1->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeYOnTrack_diskm2 = iBooker.book1D("sizeY_" + clustersrc_.label() + "_Disk_m2","SizeY (on track, diskm2)",100,0.,100.);
+  meClSizeYOnTrack_diskm2->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeYOnTrack_diskm3 = iBooker.book1D("sizeY_" + clustersrc_.label() + "_Disk_m3","SizeY (on track, diskm3)",100,0.,100.);
+  meClSizeYOnTrack_diskm3->setAxisTitle("Cluster size (in pixels)",1);
+  //off track
+  iBooker.setCurrentFolder("Pixel/Clusters/OffTrack");
+  meClSizeNotOnTrack_all = iBooker.book1D("size_" + clustersrc_.label(),"Size (off track)",100,0.,100.);
+  meClSizeNotOnTrack_all->setAxisTitle("Cluster size (in pixels)",1); 
+  meClSizeNotOnTrack_bpix = iBooker.book1D("size_" + clustersrc_.label() + "_Barrel","Size (off track, barrel)",100,0.,100.);
+  meClSizeNotOnTrack_bpix->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeNotOnTrack_fpix = iBooker.book1D("size_" + clustersrc_.label() + "_Endcap","Size (off track, endcap)",100,0.,100.);
+  meClSizeNotOnTrack_fpix->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeNotOnTrack_layer1 = iBooker.book1D("size_" + clustersrc_.label() + "_Layer_1","Size (off track, layer1)",100,0.,100.);
+  meClSizeNotOnTrack_layer1->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeNotOnTrack_layer2 = iBooker.book1D("size_" + clustersrc_.label() + "_Layer_2","Size (off track, layer2)",100,0.,100.);
+  meClSizeNotOnTrack_layer2->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeNotOnTrack_layer3 = iBooker.book1D("size_" + clustersrc_.label() + "_Layer_3","Size (off track, layer3)",100,0.,100.);
+  meClSizeNotOnTrack_layer3->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeNotOnTrack_layer4 = iBooker.book1D("size_" + clustersrc_.label() + "_Layer_4","Size (off track, layer4)",100,0.,100.);
+  meClSizeNotOnTrack_layer4->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeNotOnTrack_diskp1 = iBooker.book1D("size_" + clustersrc_.label() + "_Disk_p1","Size (off track, diskp1)",100,0.,100.);
+  meClSizeNotOnTrack_diskp1->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeNotOnTrack_diskp2 = iBooker.book1D("size_" + clustersrc_.label() + "_Disk_p2","Size (off track, diskp2)",100,0.,100.);
+  meClSizeNotOnTrack_diskp2->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeNotOnTrack_diskp3 = iBooker.book1D("size_" + clustersrc_.label() + "_Disk_p3","Size (off track, diskp3)",100,0.,100.);
+  meClSizeNotOnTrack_diskp3->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeNotOnTrack_diskm1 = iBooker.book1D("size_" + clustersrc_.label() + "_Disk_m1","Size (off track, diskm1)",100,0.,100.);
+  meClSizeNotOnTrack_diskm1->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeNotOnTrack_diskm2 = iBooker.book1D("size_" + clustersrc_.label() + "_Disk_m2","Size (off track, diskm2)",100,0.,100.);
+  meClSizeNotOnTrack_diskm2->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeNotOnTrack_diskm3 = iBooker.book1D("size_" + clustersrc_.label() + "_Disk_m3","Size (off track, diskm3)",100,0.,100.);
+  meClSizeNotOnTrack_diskm3->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeXNotOnTrack_all = iBooker.book1D("sizeX_" + clustersrc_.label(),"SizeX (off track)",100,0.,100.);
+  meClSizeXNotOnTrack_all->setAxisTitle("Cluster sizeX (in pixels)",1);
+  meClSizeXNotOnTrack_bpix = iBooker.book1D("sizeX_" + clustersrc_.label() + "_Barrel","SizeX (off track, barrel)",100,0.,100.);
+  meClSizeXNotOnTrack_bpix->setAxisTitle("Cluster sizeX (in pixels)",1);
+  meClSizeXNotOnTrack_fpix = iBooker.book1D("sizeX_" + clustersrc_.label() + "_Endcap","SizeX (off track, endcap)",100,0.,100.);
+  meClSizeXNotOnTrack_fpix->setAxisTitle("Cluster sizeX (in pixels)",1);
+  meClSizeXNotOnTrack_layer1 = iBooker.book1D("sizeX_" + clustersrc_.label() + "_Layer_1","SizeX (off track, layer1)",100,0.,100.);
+  meClSizeXNotOnTrack_layer1->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeXNotOnTrack_layer2 = iBooker.book1D("sizeX_" + clustersrc_.label() + "_Layer_2","SizeX (off track, layer2)",100,0.,100.);
+  meClSizeXNotOnTrack_layer2->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeXNotOnTrack_layer3 = iBooker.book1D("sizeX_" + clustersrc_.label() + "_Layer_3","SizeX (off track, layer3)",100,0.,100.);
+  meClSizeXNotOnTrack_layer3->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeXNotOnTrack_layer4 = iBooker.book1D("sizeX_" + clustersrc_.label() + "_Layer_4","SizeX (off track, layer4)",100,0.,100.);
+  meClSizeXNotOnTrack_layer4->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeXNotOnTrack_diskp1 = iBooker.book1D("sizeX_" + clustersrc_.label() + "_Disk_p1","SizeX (off track, diskp1)",100,0.,100.);
+  meClSizeXNotOnTrack_diskp1->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeXNotOnTrack_diskp2 = iBooker.book1D("sizeX_" + clustersrc_.label() + "_Disk_p2","SizeX (off track, diskp2)",100,0.,100.);
+  meClSizeXNotOnTrack_diskp2->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeXNotOnTrack_diskp3 = iBooker.book1D("sizeX_" + clustersrc_.label() + "_Disk_p3","SizeX (off track, diskp3)",100,0.,100.);
+  meClSizeXNotOnTrack_diskp3->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeXNotOnTrack_diskm1 = iBooker.book1D("sizeX_" + clustersrc_.label() + "_Disk_m1","SizeX (off track, diskm1)",100,0.,100.);
+  meClSizeXNotOnTrack_diskm1->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeXNotOnTrack_diskm2 = iBooker.book1D("sizeX_" + clustersrc_.label() + "_Disk_m2","SizeX (off track, diskm2)",100,0.,100.);
+  meClSizeXNotOnTrack_diskm2->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeXNotOnTrack_diskm3 = iBooker.book1D("sizeX_" + clustersrc_.label() + "_Disk_m3","SizeX (off track, diskm3)",100,0.,100.);
+  meClSizeXNotOnTrack_diskm3->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeYNotOnTrack_all = iBooker.book1D("sizeY_" + clustersrc_.label(),"SizeY (off track)",100,0.,100.);
+  meClSizeYNotOnTrack_all->setAxisTitle("Cluster sizeY (in pixels)",1);
+  meClSizeYNotOnTrack_bpix = iBooker.book1D("sizeY_" + clustersrc_.label() + "_Barrel","SizeY (off track, barrel)",100,0.,100.);
+  meClSizeYNotOnTrack_bpix->setAxisTitle("Cluster sizeY (in pixels)",1);
+  meClSizeYNotOnTrack_fpix = iBooker.book1D("sizeY_" + clustersrc_.label() + "_Endcap","SizeY (off track, endcap)",100,0.,100.);
+  meClSizeYNotOnTrack_fpix->setAxisTitle("Cluster sizeY (in pixels)",1);
+  meClSizeYNotOnTrack_layer1 = iBooker.book1D("sizeY_" + clustersrc_.label() + "_Layer_1","SizeY (off track, layer1)",100,0.,100.);
+  meClSizeYNotOnTrack_layer1->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeYNotOnTrack_layer2 = iBooker.book1D("sizeY_" + clustersrc_.label() + "_Layer_2","SizeY (off track, layer2)",100,0.,100.);
+  meClSizeYNotOnTrack_layer2->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeYNotOnTrack_layer3 = iBooker.book1D("sizeY_" + clustersrc_.label() + "_Layer_3","SizeY (off track, layer3)",100,0.,100.);
+  meClSizeYNotOnTrack_layer3->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeYNotOnTrack_layer4 = iBooker.book1D("sizeY_" + clustersrc_.label() + "_Layer_4","SizeY (off track, layer4)",100,0.,100.);
+  meClSizeYNotOnTrack_layer4->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeYNotOnTrack_diskp1 = iBooker.book1D("sizeY_" + clustersrc_.label() + "_Disk_p1","SizeY (off track, diskp1)",100,0.,100.);
+  meClSizeYNotOnTrack_diskp1->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeYNotOnTrack_diskp2 = iBooker.book1D("sizeY_" + clustersrc_.label() + "_Disk_p2","SizeY (off track, diskp2)",100,0.,100.);
+  meClSizeYNotOnTrack_diskp2->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeYNotOnTrack_diskp3 = iBooker.book1D("sizeY_" + clustersrc_.label() + "_Disk_p3","SizeY (off track, diskp3)",100,0.,100.);
+  meClSizeYNotOnTrack_diskp3->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeYNotOnTrack_diskm1 = iBooker.book1D("sizeY_" + clustersrc_.label() + "_Disk_m1","SizeY (off track, diskm1)",100,0.,100.);
+  meClSizeYNotOnTrack_diskm1->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeYNotOnTrack_diskm2 = iBooker.book1D("sizeY_" + clustersrc_.label() + "_Disk_m2","SizeY (off track, diskm2)",100,0.,100.);
+  meClSizeYNotOnTrack_diskm2->setAxisTitle("Cluster size (in pixels)",1);
+  meClSizeYNotOnTrack_diskm3 = iBooker.book1D("sizeY_" + clustersrc_.label() + "_Disk_m3","SizeY (off track, diskm3)",100,0.,100.);
+  meClSizeYNotOnTrack_diskm3->setAxisTitle("Cluster size (in pixels)",1);
+
+  //cluster global position
+  //on track
+  iBooker.setCurrentFolder("Pixel/Clusters/OnTrack");
+  //bpix
+  meClPosLayer1OnTrack = iBooker.book2D("position_" + clustersrc_.label() + "_Layer_1","Clusters Layer1 (on track)",200,-30.,30.,128,-3.2,3.2);
+  meClPosLayer1OnTrack->setAxisTitle("Global Z (cm)",1);
+  meClPosLayer1OnTrack->setAxisTitle("Global #phi",2);
+  meClPosLayer2OnTrack = iBooker.book2D("position_" + clustersrc_.label() + "_Layer_2","Clusters Layer2 (on track)",200,-30.,30.,128,-3.2,3.2);
+  meClPosLayer2OnTrack->setAxisTitle("Global Z (cm)",1);
+  meClPosLayer2OnTrack->setAxisTitle("Global #phi",2);
+  meClPosLayer3OnTrack = iBooker.book2D("position_" + clustersrc_.label() + "_Layer_3","Clusters Layer3 (on track)",200,-30.,30.,128,-3.2,3.2);
+  meClPosLayer3OnTrack->setAxisTitle("Global Z (cm)",1);
+  meClPosLayer3OnTrack->setAxisTitle("Global #phi",2);
+  meClPosLayer4OnTrack = iBooker.book2D("position_" + clustersrc_.label() + "_Layer_4","Clusters Layer4 (on track)",200,-30.,30.,128,-3.2,3.2);
+  meClPosLayer4OnTrack->setAxisTitle("Global Z (cm)",1);
+  meClPosLayer4OnTrack->setAxisTitle("Global #phi",2);
+  //fpix
+  meClPosDisk1pzOnTrack = iBooker.book2D("position_" + clustersrc_.label() + "_pz_Disk_1","Clusters +Z Disk1 (on track)",80,-20.,20.,80,-20.,20.);
+  meClPosDisk1pzOnTrack->setAxisTitle("Global X (cm)",1);
+  meClPosDisk1pzOnTrack->setAxisTitle("Global Y (cm)",2);
+  meClPosDisk2pzOnTrack = iBooker.book2D("position_" + clustersrc_.label() + "_pz_Disk_2","Clusters +Z Disk2 (on track)",80,-20.,20.,80,-20.,20.);
+  meClPosDisk2pzOnTrack->setAxisTitle("Global X (cm)",1);
+  meClPosDisk2pzOnTrack->setAxisTitle("Global Y (cm)",2);
+  meClPosDisk3pzOnTrack = iBooker.book2D("position_" + clustersrc_.label() + "_pz_Disk_3","Clusters +Z Disk3 (on track)",80,-20.,20.,80,-20.,20.);
+  meClPosDisk3pzOnTrack->setAxisTitle("Global X (cm)",1);
+  meClPosDisk3pzOnTrack->setAxisTitle("Global Y (cm)",2);
+  meClPosDisk1mzOnTrack = iBooker.book2D("position_" + clustersrc_.label() + "_mz_Disk_1","Clusters -Z Disk1 (on track)",80,-20.,20.,80,-20.,20.);
+  meClPosDisk1mzOnTrack->setAxisTitle("Global X (cm)",1);
+  meClPosDisk1mzOnTrack->setAxisTitle("Global Y (cm)",2);
+  meClPosDisk2mzOnTrack = iBooker.book2D("position_" + clustersrc_.label() + "_mz_Disk_2","Clusters -Z Disk2 (on track)",80,-20.,20.,80,-20.,20.);
+  meClPosDisk2mzOnTrack->setAxisTitle("Global X (cm)",1);
+  meClPosDisk2mzOnTrack->setAxisTitle("Global Y (cm)",2);
+  meClPosDisk3mzOnTrack = iBooker.book2D("position_" + clustersrc_.label() + "_mz_Disk_3","Clusters -Z Disk3 (on track)",80,-20.,20.,80,-20.,20.);
+  meClPosDisk3mzOnTrack->setAxisTitle("Global X (cm)",1);
+  meClPosDisk3mzOnTrack->setAxisTitle("Global Y (cm)",2);
+  meNClustersOnTrack_all = iBooker.book1D("nclusters_" + clustersrc_.label(),"Number of Clusters (on Track)",50,0.,50.);
+  meNClustersOnTrack_all->setAxisTitle("Number of Clusters",1);
+  meNClustersOnTrack_bpix = iBooker.book1D("nclusters_" + clustersrc_.label() + "_Barrel","Number of Clusters (on track, barrel)",50,0.,50.);
+  meNClustersOnTrack_bpix->setAxisTitle("Number of Clusters",1);
+  meNClustersOnTrack_fpix = iBooker.book1D("nclusters_" + clustersrc_.label() + "_Endcap","Number of Clusters (on track, endcap)",50,0.,50.);
+  meNClustersOnTrack_fpix->setAxisTitle("Number of Clusters",1);
+  meNClustersOnTrack_layer1 = iBooker.book1D("nclusters_" + clustersrc_.label() + "_Layer_1","Number of Clusters (on track, layer1)",50,0.,50.);
+  meNClustersOnTrack_layer1->setAxisTitle("Number of Clusters",1);
+  meNClustersOnTrack_layer2 = iBooker.book1D("nclusters_" + clustersrc_.label() + "_Layer_2","Number of Clusters (on track, layer2)",50,0.,50.);
+  meNClustersOnTrack_layer2->setAxisTitle("Number of Clusters",1);
+  meNClustersOnTrack_layer3 = iBooker.book1D("nclusters_" + clustersrc_.label() + "_Layer_3","Number of Clusters (on track, layer3)",50,0.,50.);
+  meNClustersOnTrack_layer3->setAxisTitle("Number of Clusters",1);
+  meNClustersOnTrack_layer4 = iBooker.book1D("nclusters_" + clustersrc_.label() + "_Layer_4","Number of Clusters (on track, layer4)",50,0.,50.);
+  meNClustersOnTrack_layer4->setAxisTitle("Number of Clusters",1);
+  meNClustersOnTrack_diskp1 = iBooker.book1D("nclusters_" + clustersrc_.label() + "_Disk_p1","Number of Clusters (on track, diskp1)",50,0.,50.);
+  meNClustersOnTrack_diskp1->setAxisTitle("Number of Clusters",1);
+  meNClustersOnTrack_diskp2 = iBooker.book1D("nclusters_" + clustersrc_.label() + "_Disk_p2","Number of Clusters (on track, diskp2)",50,0.,50.);
+  meNClustersOnTrack_diskp2->setAxisTitle("Number of Clusters",1);
+  meNClustersOnTrack_diskp3 = iBooker.book1D("nclusters_" + clustersrc_.label() + "_Disk_p3","Number of Clusters (on track, diskp3)",50,0.,50.);
+  meNClustersOnTrack_diskp3->setAxisTitle("Number of Clusters",1);
+  meNClustersOnTrack_diskm1 = iBooker.book1D("nclusters_" + clustersrc_.label() + "_Disk_m1","Number of Clusters (on track, diskm1)",50,0.,50.);
+  meNClustersOnTrack_diskm1->setAxisTitle("Number of Clusters",1);
+  meNClustersOnTrack_diskm2 = iBooker.book1D("nclusters_" + clustersrc_.label() + "_Disk_m2","Number of Clusters (on track, diskm2)",50,0.,50.);
+  meNClustersOnTrack_diskm2->setAxisTitle("Number of Clusters",1);
+  meNClustersOnTrack_diskm3 = iBooker.book1D("nclusters_" + clustersrc_.label() + "_Disk_m3","Number of Clusters (on track, diskm3)",50,0.,50.);
+  meNClustersOnTrack_diskm3->setAxisTitle("Number of Clusters",1);
+
+  //not on track
+  iBooker.setCurrentFolder("Pixel/Clusters/OffTrack");
+  //bpix
+  meClPosLayer1NotOnTrack = iBooker.book2D("position_" + clustersrc_.label() + "_Layer_1","Clusters Layer1 (off track)",200,-30.,30.,128,-3.2,3.2);
+  meClPosLayer1NotOnTrack->setAxisTitle("Global Z (cm)",1);
+  meClPosLayer1NotOnTrack->setAxisTitle("Global #phi",2);
+  meClPosLayer2NotOnTrack = iBooker.book2D("position_" + clustersrc_.label() + "_Layer_2","Clusters Layer2 (off track)",200,-30.,30.,128,-3.2,3.2);
+  meClPosLayer2NotOnTrack->setAxisTitle("Global Z (cm)",1);
+  meClPosLayer2NotOnTrack->setAxisTitle("Global #phi",2);
+  meClPosLayer3NotOnTrack = iBooker.book2D("position_" + clustersrc_.label() + "_Layer_3","Clusters Layer3 (off track)",200,-30.,30.,128,-3.2,3.2);
+  meClPosLayer3NotOnTrack->setAxisTitle("Global Z (cm)",1);
+  meClPosLayer3NotOnTrack->setAxisTitle("Global #phi",2);
+  meClPosLayer4NotOnTrack = iBooker.book2D("position_" + clustersrc_.label() + "_Layer_4","Clusters Layer4 (off track)",200,-30.,30.,128,-3.2,3.2);
+  meClPosLayer4NotOnTrack->setAxisTitle("Global Z (cm)",1);
+  meClPosLayer4NotOnTrack->setAxisTitle("Global #phi",2);
+  //fpix
+  meClPosDisk1pzNotOnTrack = iBooker.book2D("position_" + clustersrc_.label() + "_pz_Disk_1","Clusters +Z Disk1 (off track)",80,-20.,20.,80,-20.,20.);
+  meClPosDisk1pzNotOnTrack->setAxisTitle("Global X (cm)",1);
+  meClPosDisk1pzNotOnTrack->setAxisTitle("Global Y (cm)",2);
+  meClPosDisk2pzNotOnTrack = iBooker.book2D("position_" + clustersrc_.label() + "_pz_Disk_2","Clusters +Z Disk2 (off track)",80,-20.,20.,80,-20.,20.);
+  meClPosDisk2pzNotOnTrack->setAxisTitle("Global X (cm)",1);
+  meClPosDisk2pzNotOnTrack->setAxisTitle("Global Y (cm)",2);
+  meClPosDisk3pzNotOnTrack = iBooker.book2D("position_" + clustersrc_.label() + "_pz_Disk_3","Clusters +Z Disk3 (off track)",80,-20.,20.,80,-20.,20.);
+  meClPosDisk3pzNotOnTrack->setAxisTitle("Global X (cm)",1);
+  meClPosDisk3pzNotOnTrack->setAxisTitle("Global Y (cm)",2);
+  meClPosDisk1mzNotOnTrack = iBooker.book2D("position_" + clustersrc_.label() + "_mz_Disk_1","Clusters -Z Disk1 (off track)",80,-20.,20.,80,-20.,20.);
+  meClPosDisk1mzNotOnTrack->setAxisTitle("Global X (cm)",1);
+  meClPosDisk1mzNotOnTrack->setAxisTitle("Global Y (cm)",2);
+  meClPosDisk2mzNotOnTrack = iBooker.book2D("position_" + clustersrc_.label() + "_mz_Disk_2","Clusters -Z Disk2 (off track)",80,-20.,20.,80,-20.,20.);
+  meClPosDisk2mzNotOnTrack->setAxisTitle("Global X (cm)",1);
+  meClPosDisk2mzNotOnTrack->setAxisTitle("Global Y (cm)",2);
+  meClPosDisk3mzNotOnTrack = iBooker.book2D("position_" + clustersrc_.label() + "_mz_Disk_3","Clusters -Z Disk3 (off track)",80,-20.,20.,80,-20.,20.);
+  meClPosDisk3mzNotOnTrack->setAxisTitle("Global X (cm)",1);
+  meClPosDisk3mzNotOnTrack->setAxisTitle("Global Y (cm)",2);
+  meNClustersNotOnTrack_all = iBooker.book1D("nclusters_" + clustersrc_.label(),"Number of Clusters (off Track)",50,0.,50.);
+  meNClustersNotOnTrack_all->setAxisTitle("Number of Clusters",1);
+  meNClustersNotOnTrack_bpix = iBooker.book1D("nclusters_" + clustersrc_.label() + "_Barrel","Number of Clusters (off track, barrel)",50,0.,50.);
+  meNClustersNotOnTrack_bpix->setAxisTitle("Number of Clusters",1);
+  meNClustersNotOnTrack_fpix = iBooker.book1D("nclusters_" + clustersrc_.label() + "_Endcap","Number of Clusters (off track, endcap)",50,0.,50.);
+  meNClustersNotOnTrack_fpix->setAxisTitle("Number of Clusters",1);
+  meNClustersNotOnTrack_layer1 = iBooker.book1D("nclusters_" + clustersrc_.label() + "_Layer_1","Number of Clusters (off track, layer1)",50,0.,50.);
+  meNClustersNotOnTrack_layer1->setAxisTitle("Number of Clusters",1);
+  meNClustersNotOnTrack_layer2 = iBooker.book1D("nclusters_" + clustersrc_.label() + "_Layer_2","Number of Clusters (off track, layer2)",50,0.,50.);
+  meNClustersNotOnTrack_layer2->setAxisTitle("Number of Clusters",1);
+  meNClustersNotOnTrack_layer3 = iBooker.book1D("nclusters_" + clustersrc_.label() + "_Layer_3","Number of Clusters (off track, layer3)",50,0.,50.);
+  meNClustersNotOnTrack_layer3->setAxisTitle("Number of Clusters",1);
+  meNClustersNotOnTrack_layer4 = iBooker.book1D("nclusters_" + clustersrc_.label() + "_Layer_4","Number of Clusters (off track, layer4)",50,0.,50.);
+  meNClustersNotOnTrack_layer4->setAxisTitle("Number of Clusters",1);
+  meNClustersNotOnTrack_diskp1 = iBooker.book1D("nclusters_" + clustersrc_.label() + "_Disk_p1","Number of Clusters (off track, diskp1)",50,0.,50.);
+  meNClustersNotOnTrack_diskp1->setAxisTitle("Number of Clusters",1);
+  meNClustersNotOnTrack_diskp2 = iBooker.book1D("nclusters_" + clustersrc_.label() + "_Disk_p2","Number of Clusters (off track, diskp2)",50,0.,50.);
+  meNClustersNotOnTrack_diskp2->setAxisTitle("Number of Clusters",1);
+  meNClustersNotOnTrack_diskp3 = iBooker.book1D("nclusters_" + clustersrc_.label() + "_Disk_p3","Number of Clusters (off track, diskp3)",50,0.,50.);
+  meNClustersNotOnTrack_diskp3->setAxisTitle("Number of Clusters",1);
+  meNClustersNotOnTrack_diskm1 = iBooker.book1D("nclusters_" + clustersrc_.label() + "_Disk_m1","Number of Clusters (off track, diskm1)",50,0.,50.);
+  meNClustersNotOnTrack_diskm1->setAxisTitle("Number of Clusters",1);
+  meNClustersNotOnTrack_diskm2 = iBooker.book1D("nclusters_" + clustersrc_.label() + "_Disk_m2","Number of Clusters (off track, diskm2)",50,0.,50.);
+  meNClustersNotOnTrack_diskm2->setAxisTitle("Number of Clusters",1);
+  meNClustersNotOnTrack_diskm3 = iBooker.book1D("nclusters_" + clustersrc_.label() + "_Disk_m3","Number of Clusters (off track, diskm3)",50,0.,50.);
+  meNClustersNotOnTrack_diskm3->setAxisTitle("Number of Clusters",1);
+
+  //HitProbability
+  //on track
+  iBooker.setCurrentFolder("Pixel/Clusters/OnTrack");
+  meHitProbability = iBooker.book1D("FractionLowProb","Fraction of hits with low probability;FractionLowProb;#HitsOnTrack",100,0.,1.);
+
+  if (debug_) {
+    // book summary residual histograms in a debugging folder - one (x,y) pair of histograms per subdetector 
+    iBooker.setCurrentFolder("debugging"); 
+    char hisID[80]; 
+    for (int s=0; s<3; s++) {
+      sprintf(hisID,"residual_x_subdet_%i",s); 
+      meSubdetResidualX[s] = iBooker.book1D(hisID,"Pixel Hit-to-Track Residual in X",500,-5.,5.);
+      
+      sprintf(hisID,"residual_y_subdet_%i",s);
+      meSubdetResidualY[s] = iBooker.book1D(hisID,"Pixel Hit-to-Track Residual in Y",500,-5.,5.);  
+    }
+  }
+  
+  firstRun = false;
+}
+
+
+void SiPixelTrackResidualSourcePhase1::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  //Retrieve tracker topology from geometry
+  edm::ESHandle<TrackerTopology> tTopoHandle;
+  iSetup.get<IdealGeometryRecord>().get(tTopoHandle);
+  const TrackerTopology* const tTopo = tTopoHandle.product();
+
+
+  
+  // retrieve TrackerGeometry again and MagneticField for use in transforming 
+  // a TrackCandidate's P(ersistent)TrajectoryStateoOnDet (PTSoD) to a TrajectoryStateOnSurface (TSoS)
+  ESHandle<TrackerGeometry> TG;
+  iSetup.get<TrackerDigiGeometryRecord>().get(TG);
+  const TrackerGeometry* theTrackerGeometry = TG.product();
+  
+  //analytic triplet method to calculate the track residuals in the pixe barrel detector    
+  
+  //--------------------------------------------------------------------
+  // beam spot:
+  //
+  edm::Handle<reco::BeamSpot> rbs;
+  //iEvent.getByLabel( "offlineBeamSpot", rbs );
+  iEvent.getByToken( beamSpotToken_, rbs );
+  math::XYZPoint bsP = math::XYZPoint(0,0,0);
+  if( !rbs.failedToGet() && rbs.isValid() )
+    {
+      bsP = math::XYZPoint( rbs->x0(), rbs->y0(), rbs->z0() );
+    }
+  
+  //--------------------------------------------------------------------
+  // primary vertices:
+  //
+  edm::Handle<reco::VertexCollection> vertices;
+  //iEvent.getByLabel("offlinePrimaryVertices", vertices );
+  iEvent.getByToken(  offlinePrimaryVerticesToken_, vertices );
+  
+  if( vertices.failedToGet() ) return;
+  if( !vertices.isValid() ) return;
+  
+  math::XYZPoint vtxN = math::XYZPoint(0,0,0);
+  math::XYZPoint vtxP = math::XYZPoint(0,0,0);
+  
+  double bestNdof = 0;
+  double maxSumPt = 0;
+  reco::Vertex bestPvx;
+  for(reco::VertexCollection::const_iterator iVertex = vertices->begin();
+      iVertex != vertices->end(); ++iVertex ) {
+    if( iVertex->ndof() > bestNdof ) {
+      bestNdof = iVertex->ndof();
+      vtxN = math::XYZPoint( iVertex->x(), iVertex->y(), iVertex->z() );
+    }//ndof
+    if( iVertex->p4().pt() > maxSumPt ) {
+      maxSumPt = iVertex->p4().pt();
+      vtxP = math::XYZPoint( iVertex->x(), iVertex->y(), iVertex->z() );
+      bestPvx = *iVertex;
+    }//sumpt
+    
+  }//vertex
+  
+  if( maxSumPt < 1 ) return;
+  
+  if( maxSumPt < 1 ) vtxP = vtxN;
+  
+  //---------------------------------------------
+  //get Tracks
+  //
+  edm:: Handle<reco::TrackCollection> TracksForRes;
+  //iEvent.getByLabel( "generalTracks", TracksForRes );
+  iEvent.getByToken(  generalTracksToken_, TracksForRes );
+
+  //
+  // transient track builder, needs B-field from data base (global tag in .py)
+  //
+  edm::ESHandle<TransientTrackBuilder> theB;
+  iSetup.get<TransientTrackRecord>().get( "TransientTrackBuilder", theB );
+
+  //get the TransienTrackingRecHitBuilder needed for extracting the global position of the hits in the pixel
+  edm::ESHandle<TransientTrackingRecHitBuilder> theTrackerRecHitBuilder;
+  iSetup.get<TransientRecHitRecord>().get(ttrhbuilder_,theTrackerRecHitBuilder);
+
+  //check that tracks are valid
+  if( TracksForRes.failedToGet() ) return;
+  if( !TracksForRes.isValid() ) return;
+
+  //get tracker geometry
+  edm::ESHandle<TrackerGeometry> pDD;
+  iSetup.get<TrackerDigiGeometryRecord>().get(pDD);
+  
+  if( !pDD.isValid() ) {
+    cout << "Unable to find TrackerDigiGeometry. Return\n";
+    return;
+  }
+ 
+  int kk = -1;
+  //----------------------------------------------------------------------------
+  // Residuals:
+  //
+  for( reco::TrackCollection::const_iterator iTrack = TracksForRes->begin();
+       iTrack != TracksForRes->end(); ++iTrack ) {
+    //count
+    kk++;
+    //Calculate minimal track pt before curling
+    // cpt = cqRB = 0.3*R[m]*B[T] = 1.14*R[m] for B=3.8T
+    // D = 2R = 2*pt/1.14
+    // calo: D = 1.3 m => pt = 0.74 GeV/c
+    double pt = iTrack->pt();
+    if( pt < 0.75 ) continue;// curls up
+    if( abs( iTrack->dxy(vtxP) ) > 5*iTrack->dxyError() ) continue; // not prompt
+    
+    double charge = iTrack->charge();
+       
+    reco::TransientTrack tTrack = theB->build(*iTrack);
+    //get curvature of the track, needed for the residuals
+    double kap = tTrack.initialFreeState().transverseCurvature();
+    //needed for the TransienTrackingRecHitBuilder
+    TrajectoryStateOnSurface initialTSOS = tTrack.innermostMeasurementState();
+    if( iTrack->extra().isNonnull() &&iTrack->extra().isAvailable() ){
+      
+      double x1 = 0;
+      double y1 = 0;
+      double z1 = 0;
+      double x2 = 0;
+      double y2 = 0;
+      double z2 = 0;
+      double x3 = 0;
+      double y3 = 0;
+      double z3 = 0;
+      int n1 = 0;
+      int n2 = 0;
+      int n3 = 0;
+      
+      //for saving the pixel barrel hits
+      vector<TransientTrackingRecHit::RecHitPointer> GoodPixBarrelHits;
+      //looping through the RecHits of the track
+      for( trackingRecHit_iterator irecHit = iTrack->recHitsBegin();
+	   irecHit != iTrack->recHitsEnd(); ++irecHit){
+	
+	if( (*irecHit)->isValid() ){
+	  DetId detId = (*irecHit)->geographicalId();
+	  // enum Detector { Tracker=1, Muon=2, Ecal=3, Hcal=4, Calo=5 };
+	  if( detId.det() != 1 ){
+	    if(debug_){
+	      cout << "rec hit ID = " << detId.det() << " not in tracker!?!?\n";
+	    }
+	    continue;
+	  }
+	  uint32_t subDet = detId.subdetId();
+	  
+	  // enum SubDetector{ PixelBarrel=1, PixelEndcap=2 };
+	  // enum SubDetector{ TIB=3, TID=4, TOB=5, TEC=6 };
+	  
+	  TransientTrackingRecHit::RecHitPointer trecHit = theTrackerRecHitBuilder->build(  &*(*irecHit), initialTSOS);
+	  
+	  
+	  double gX = trecHit->globalPosition().x();
+	  double gY = trecHit->globalPosition().y();
+	  double gZ = trecHit->globalPosition().z();
+	      
+	      
+	      if( subDet == PixelSubdetector::PixelBarrel ) {
+
+		int ilay = tTopo->pxbLayer(detId);
+		
+		if( ilay == 1 ){
+		  n1++;
+		  x1 = gX;
+		  y1 = gY;
+		  z1 = gZ;
+		  
+		  GoodPixBarrelHits.push_back((trecHit));
+		}//PXB1
+		if( ilay == 2 ){
+		  
+		  n2++;
+		  x2 = gX;
+		  y2 = gY;
+		  z2 = gZ;
+		  
+		  GoodPixBarrelHits.push_back((trecHit));
+		  
+		}//PXB2
+		if( ilay == 3 ){
+		  
+		  n3++;
+		  x3 = gX;
+		  y3 = gY;
+		  z3 = gZ;
+		  GoodPixBarrelHits.push_back((trecHit));
+		}
+	      }//PXB
+	      
+	      
+	    }//valid
+	  }//loop rechits
+	  
+	  //CS extra plots    
+	  
+	 	  
+	  if( n1+n2+n3 == 3 && n1*n2*n3 > 0) {      
+	    for( unsigned int i = 0; i < GoodPixBarrelHits.size(); i++){
+	      
+	      if( GoodPixBarrelHits[i]->isValid() ){
+		DetId detId = GoodPixBarrelHits[i]->geographicalId().rawId();
+		int ilay = tTopo->pxbLayer(detId);
+		if(pt > ptminres_){   
+		  
+		  double dca2 = 0.0, dz2=0.0;
+		  double ptsig = pt;
+		  if(charge<0.) ptsig = -pt;
+		  //Filling the histograms in modules
+		  
+		  MeasurementPoint Test;
+		  MeasurementPoint Test2;
+		  Test=MeasurementPoint(0,0);
+		  Test2=MeasurementPoint(0,0);
+		  Measurement2DVector residual;
+		 
+		  if( ilay == 1 ){
+		    
+		    triplets(x2,y2,z2,x1,y1,z1,x3,y3,z3,ptsig,dca2,dz2, kap);	
+		    		
+		    Test=MeasurementPoint(dca2*1E4,dz2*1E4);
+		    residual=Test-Test2;
+		  }
+		  
+		  if( ilay == 2 ){
+		    
+		    triplets(x1,y1,z1,x2,y2,z2,x3,y3,z3,ptsig,dca2,dz2, kap);
+		    
+		    Test=MeasurementPoint(dca2*1E4,dz2*1E4);
+		    residual=Test-Test2;
+	      
+		  }
+		  
+		  if( ilay == 3 ){
+		    
+		    triplets(x1,y1,z1,x3,y3,z3,x2,y2,z2,ptsig,dca2,dz2, kap);
+		    
+		    Test=MeasurementPoint(dca2*1E4,dz2*1E4);
+		    residual=Test-Test2;
+	    }
+		  // fill the residual histograms 
+
+		  std::map<uint32_t, SiPixelTrackResidualModulePhase1*>::iterator pxd = theSiPixelStructure.find(detId);
+		  if (pxd!=theSiPixelStructure.end()) (*pxd).second->fill(residual, reducedSet, modOn, ladOn, layOn, phiOn, bladeOn, diskOn, ringOn);		
+		}//three hits
+	      }//is valid
+	    }//rechits loop
+	  }//pt 4
+	}
+	
+	
+ }//-----Tracks
+  ////////////////////////////
+  //get trajectories
+  edm::Handle<std::vector<Trajectory> > trajCollectionHandle;
+  //iEvent.getByLabel(tracksrc_,trajCollectionHandle);
+  iEvent.getByToken ( tracksrcToken_, trajCollectionHandle );
+  const std::vector<Trajectory> trajColl = *(trajCollectionHandle.product());
+   
+  //get tracks
+  edm::Handle<std::vector<reco::Track> > trackCollectionHandle;
+  //iEvent.getByLabel(tracksrc_,trackCollectionHandle);
+  iEvent.getByToken( trackToken_, trackCollectionHandle );
+
+  const std::vector<reco::Track> trackColl = *(trackCollectionHandle.product());
+
+  //get the map
+  edm::Handle<TrajTrackAssociationCollection> match;
+  //iEvent.getByLabel(tracksrc_,match);
+  iEvent.getByToken( trackAssociationToken_, match);
+  const TrajTrackAssociationCollection ttac = *(match.product());
+
+  // get clusters
+  edm::Handle< edmNew::DetSetVector<SiPixelCluster> >  clusterColl;
+  //iEvent.getByLabel( clustersrc_, clusterColl );
+  iEvent.getByToken( clustersrcToken_, clusterColl );
+  const edmNew::DetSetVector<SiPixelCluster> clustColl = *(clusterColl.product());
+
+  if(debug_){
+    std::cout << "Trajectories\t : " << trajColl.size() << std::endl;
+    std::cout << "recoTracks  \t : " << trackColl.size() << std::endl;
+    std::cout << "Map entries \t : " << ttac.size() << std::endl;
+  }
+
+  std::set<SiPixelCluster> clusterSet;
+  TrajectoryStateCombiner tsoscomb;
+  int tracks=0, pixeltracks=0, bpixtracks=0, fpixtracks=0; 
+  int trackclusters=0, barreltrackclusters=0, endcaptrackclusters=0;
+  int otherclusters=0, barrelotherclusters=0, endcapotherclusters=0;
+
+  //Loop over map entries
+  for(TrajTrackAssociationCollection::const_iterator it =  ttac.begin();it !=  ttac.end(); ++it){
+    const edm::Ref<std::vector<Trajectory> > traj_iterator = it->key;  
+    // Trajectory Map, extract Trajectory for this track
+    reco::TrackRef trackref = it->val;
+    tracks++;
+
+    bool isBpixtrack = false, isFpixtrack = false, crossesPixVol=false;
+    
+    //find out whether track crosses pixel fiducial volume (for cosmic tracks)
+    
+    double d0 = (*trackref).d0(), dz = (*trackref).dz(); 
+    
+    if(abs(d0)<15 && abs(dz)<50) crossesPixVol = true;
+
+    std::vector<TrajectoryMeasurement> tmeasColl =traj_iterator->measurements();
+    std::vector<TrajectoryMeasurement>::const_iterator tmeasIt;
+    //loop on measurements to find out whether there are bpix and/or fpix hits
+    for(tmeasIt = tmeasColl.begin();tmeasIt!=tmeasColl.end();tmeasIt++){
+      if(! tmeasIt->updatedState().isValid()) continue; 
+      TransientTrackingRecHit::ConstRecHitPointer testhit = tmeasIt->recHit();
+      if(! testhit->isValid() || testhit->geographicalId().det() != DetId::Tracker) continue; 
+      uint testSubDetID = (testhit->geographicalId().subdetId()); 
+      if(testSubDetID==PixelSubdetector::PixelBarrel) isBpixtrack = true;
+      if(testSubDetID==PixelSubdetector::PixelEndcap) isFpixtrack = true;
+    }//end loop on measurements
+    if(isBpixtrack) {
+      bpixtracks++; 
+      if(debug_) std::cout << "bpixtrack\n";
+    }
+    if(isFpixtrack) {
+      fpixtracks++; 
+      if(debug_) std::cout << "fpixtrack\n";
+    }
+    if(isBpixtrack || isFpixtrack){
+      pixeltracks++;
+      
+      if(crossesPixVol) meNofTracksInPixVol_->Fill(0,1);
+
+      std::vector<TrajectoryMeasurement> tmeasColl = traj_iterator->measurements();
+      for(std::vector<TrajectoryMeasurement>::const_iterator tmeasIt = tmeasColl.begin(); tmeasIt!=tmeasColl.end(); tmeasIt++){   
+	if(! tmeasIt->updatedState().isValid()) continue; 
+	
+	TrajectoryStateOnSurface tsos = tsoscomb( tmeasIt->forwardPredictedState(), tmeasIt->backwardPredictedState() );
+	TransientTrackingRecHit::ConstRecHitPointer hit = tmeasIt->recHit();
+	if(! hit->isValid() || hit->geographicalId().det() != DetId::Tracker ) {
+	  continue; 
+	} else {
+	  
+// 	  //residual
+      	  const DetId & hit_detId = hit->geographicalId();
+	  //uint IntRawDetID = (hit_detId.rawId());
+	  uint IntSubDetID = (hit_detId.subdetId());
+	  
+ 	  if(IntSubDetID == 0 ) continue; // don't look at SiStrip hits!	    
+
+	  // get the enclosed persistent hit
+	  const TrackingRecHit *persistentHit = hit->hit();
+	  // check if it's not null, and if it's a valid pixel hit
+	  if ((persistentHit != 0) && (typeid(*persistentHit) == typeid(SiPixelRecHit))) {
+	    // tell the C++ compiler that the hit is a pixel hit
+	    const SiPixelRecHit* pixhit = static_cast<const SiPixelRecHit*>( hit->hit() );
+	    //Hit probability:
+	    float hit_prob = -1.;
+	    if(pixhit->hasFilledProb()){
+	      hit_prob = pixhit->clusterProbability(0);
+	      //std::cout<<"HITPROB= "<<hit_prob<<std::endl;
+	      if(hit_prob<pow(10.,-15.)) NLowProb++;
+	      NTotal++;
+	      if(NTotal>0) meHitProbability->Fill(float(NLowProb/NTotal));
+	    }
+	    
+	    // get the edm::Ref to the cluster
+ 	    edm::Ref<edmNew::DetSetVector<SiPixelCluster>, SiPixelCluster> const& clust = (*pixhit).cluster();
+	    //  check if the ref is not null
+	    if (clust.isNonnull()) {
+
+	      //define tracker and pixel geometry and topology
+	      const TrackerGeometry& theTracker(*theTrackerGeometry);
+	      const PixelGeomDetUnit* theGeomDet = static_cast<const PixelGeomDetUnit*> (theTracker.idToDet(hit_detId) );
+	      //test if PixelGeomDetUnit exists
+	      if(theGeomDet == 0) {
+		if(debug_) std::cout << "NO THEGEOMDET\n";
+		continue;
+	      }
+
+	      const PixelTopology * topol = &(theGeomDet->specificTopology());
+	      //fill histograms for clusters on tracks
+	      //correct SiPixelTrackResidualModulePhase1
+	      std::map<uint32_t, SiPixelTrackResidualModulePhase1*>::iterator pxd = theSiPixelStructure.find((*hit).geographicalId().rawId());
+
+	      //CHARGE CORRECTION (for track impact angle)
+	      // calculate alpha and beta from cluster position
+	      LocalTrajectoryParameters ltp = tsos.localParameters();
+	      LocalVector localDir = ltp.momentum()/ltp.momentum().mag();
+	      
+	      float clust_alpha = atan2(localDir.z(), localDir.x());
+	      float clust_beta = atan2(localDir.z(), localDir.y());
+	      double corrCharge = clust->charge() * sqrt( 1.0 / ( 1.0/pow( tan(clust_alpha), 2 ) + 
+								  1.0/pow( tan(clust_beta ), 2 ) + 
+								  1.0 )
+							  )/1000.;
+
+	      if (pxd!=theSiPixelStructure.end()) (*pxd).second->fill((*clust), true, corrCharge, reducedSet, modOn, ladOn, layOn, phiOn, bladeOn, diskOn, ringOn); 	
+
+
+	      trackclusters++;
+	      //CORR CHARGE
+	      meClChargeOnTrack_all->Fill(corrCharge);
+	      meClSizeOnTrack_all->Fill((*clust).size());
+	      meClSizeXOnTrack_all->Fill((*clust).sizeX());
+	      meClSizeYOnTrack_all->Fill((*clust).sizeY());
+	      clusterSet.insert(*clust);
+
+	      //find cluster global position (rphi, z)
+	      // get cluster center of gravity (of charge)
+	      float xcenter = clust->x();
+	      float ycenter = clust->y();
+	      // get the cluster position in local coordinates (cm) 
+	      LocalPoint clustlp = topol->localPosition( MeasurementPoint(xcenter, ycenter) );
+	      // get the cluster position in global coordinates (cm)
+	      GlobalPoint clustgp = theGeomDet->surface().toGlobal( clustlp );
+
+	      //find location of hit (barrel or endcap, same for cluster)
+	      bool barrel = DetId((*hit).geographicalId()).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
+	      bool endcap = DetId((*hit).geographicalId()).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap);
+	      if(barrel) {
+		barreltrackclusters++;
+		//CORR CHARGE
+		meClChargeOnTrack_bpix->Fill(corrCharge);
+		meClSizeOnTrack_bpix->Fill((*clust).size());
+		meClSizeXOnTrack_bpix->Fill((*clust).sizeX());
+		meClSizeYOnTrack_bpix->Fill((*clust).sizeY());
+		uint32_t DBlayer;
+                DBlayer = PixelBarrelNameUpgrade(DetId((*hit).geographicalId())).layerName();
+		float phi = clustgp.phi(); 
+		float z = clustgp.z();
+		switch(DBlayer){
+		case 1: {
+		  meClPosLayer1OnTrack->Fill(z,phi); 
+		  meClChargeOnTrack_layer1->Fill(corrCharge);
+		  meClSizeOnTrack_layer1->Fill((*clust).size());
+		  meClSizeXOnTrack_layer1->Fill((*clust).sizeX());
+		  meClSizeYOnTrack_layer1->Fill((*clust).sizeY());
+		  break;
+		}
+		case 2: {
+		  meClPosLayer2OnTrack->Fill(z,phi); 
+		  meClChargeOnTrack_layer2->Fill(corrCharge);
+		  meClSizeOnTrack_layer2->Fill((*clust).size());
+		  meClSizeXOnTrack_layer2->Fill((*clust).sizeX());
+		  meClSizeYOnTrack_layer2->Fill((*clust).sizeY());
+		  break;
+		}
+		case 3: {
+		  meClPosLayer3OnTrack->Fill(z,phi); 
+		  meClChargeOnTrack_layer3->Fill(corrCharge);
+		  meClSizeOnTrack_layer3->Fill((*clust).size());
+		  meClSizeXOnTrack_layer3->Fill((*clust).sizeX());
+		  meClSizeYOnTrack_layer3->Fill((*clust).sizeY());
+		  break;
+		}
+		case 4: {
+		  meClPosLayer4OnTrack->Fill(z,phi); 
+		  meClChargeOnTrack_layer4->Fill(corrCharge);
+		  meClSizeOnTrack_layer4->Fill((*clust).size());
+		  meClSizeXOnTrack_layer4->Fill((*clust).sizeX());
+		  meClSizeYOnTrack_layer4->Fill((*clust).sizeY());
+		  break;
+		}
+		
+		}
+		
+	      }
+	      if(endcap) {
+		endcaptrackclusters++;
+		//CORR CHARGE
+		meClChargeOnTrack_fpix->Fill(corrCharge);
+		meClSizeOnTrack_fpix->Fill((*clust).size());
+		meClSizeXOnTrack_fpix->Fill((*clust).sizeX());
+		meClSizeYOnTrack_fpix->Fill((*clust).sizeY());
+		uint32_t DBdisk;
+                DBdisk = PixelEndcapNameUpgrade(DetId((*hit).geographicalId())).diskName();
+		float x = clustgp.x(); 
+		float y = clustgp.y(); 
+		float z = clustgp.z();
+		if(z>0){
+		  if(DBdisk==1) {
+		    meClPosDisk1pzOnTrack->Fill(x,y);
+		    meClChargeOnTrack_diskp1->Fill(corrCharge);
+		    meClSizeOnTrack_diskp1->Fill((*clust).size());
+		    meClSizeXOnTrack_diskp1->Fill((*clust).sizeX());
+		    meClSizeYOnTrack_diskp1->Fill((*clust).sizeY());
+		  }
+		  if(DBdisk==2) {
+		    meClPosDisk2pzOnTrack->Fill(x,y); 
+		    meClChargeOnTrack_diskp2->Fill(corrCharge);
+		    meClSizeOnTrack_diskp2->Fill((*clust).size());
+		    meClSizeXOnTrack_diskp2->Fill((*clust).sizeX());
+		    meClSizeYOnTrack_diskp2->Fill((*clust).sizeY());
+		  }
+		  if(DBdisk==3) {
+		    meClPosDisk3pzOnTrack->Fill(x,y);
+                    meClChargeOnTrack_diskp3->Fill(corrCharge);
+		    meClSizeOnTrack_diskp3->Fill((*clust).size());
+		    meClSizeXOnTrack_diskp3->Fill((*clust).sizeX());
+		    meClSizeYOnTrack_diskp3->Fill((*clust).sizeY());
+		  }
+		}
+		else{
+		  if(DBdisk==1) {
+		    meClPosDisk1mzOnTrack->Fill(x,y);
+		    meClChargeOnTrack_diskm1->Fill(corrCharge);
+		    meClSizeOnTrack_diskm1->Fill((*clust).size());
+		    meClSizeXOnTrack_diskm1->Fill((*clust).sizeX());
+		    meClSizeYOnTrack_diskm1->Fill((*clust).sizeY());
+		  }
+		  if(DBdisk==2) {
+		    meClPosDisk2mzOnTrack->Fill(x,y); 
+		    meClChargeOnTrack_diskm2->Fill(corrCharge);
+		    meClSizeOnTrack_diskm2->Fill((*clust).size());
+		    meClSizeXOnTrack_diskm2->Fill((*clust).sizeX());
+		    meClSizeYOnTrack_diskm2->Fill((*clust).sizeY());
+		  }
+		  if(DBdisk==3) {
+		    meClPosDisk3mzOnTrack->Fill(x,y);
+                    meClChargeOnTrack_diskm3->Fill(corrCharge);
+		    meClSizeOnTrack_diskm3->Fill((*clust).size());
+		    meClSizeXOnTrack_diskm3->Fill((*clust).sizeX());
+		    meClSizeYOnTrack_diskm3->Fill((*clust).sizeY());
+		  }
+		} 
+	      }
+	      
+	    }//end if (cluster exists)
+
+	  }//end if (persistent hit exists and is pixel hit)
+	  
+	}//end of else 
+	
+	
+      }//end for (all traj measurements of pixeltrack)
+    }//end if (is pixeltrack)
+    else {
+      if(debug_) std::cout << "no pixeltrack:\n";
+      if(crossesPixVol) meNofTracksInPixVol_->Fill(1,1);
+    }
+    
+  }//end loop on map entries
+
+  //find clusters that are NOT on track
+  //edmNew::DetSet<SiPixelCluster>::const_iterator  di;
+  if(debug_) std::cout << "clusters not on track: (size " << clustColl.size() << ") ";
+
+  for(TrackerGeometry::DetContainer::const_iterator it = TG->dets().begin(); it != TG->dets().end(); it++){
+    //if(dynamic_cast<PixelGeomDetUnit const *>((*it))!=0){
+    DetId detId = (*it)->geographicalId();
+    if(detId>=302055684 && detId<=352477708){ // make sure it's a Pixel module WITHOUT using dynamic_cast!  
+      int nofclOnTrack = 0, nofclOffTrack=0; 
+      uint32_t DBlayer=10, DBdisk=10; 
+      float z=0.; 
+      //set layer/disk
+      if(DetId(detId).subdetId() == 1) { // Barrel module
+	DBlayer = PixelBarrelNameUpgrade(DetId(detId)).layerName();
+      }
+      if(DetId(detId).subdetId() == 2){ // Endcap module
+        DBdisk = PixelEndcapNameUpgrade(DetId(detId )).diskName();
+      }
+      edmNew::DetSetVector<SiPixelCluster>::const_iterator isearch = clustColl.find(detId);
+      if( isearch != clustColl.end() ) {  // Not an empty iterator
+	edmNew::DetSet<SiPixelCluster>::const_iterator  di;
+	for(di=isearch->begin(); di!=isearch->end(); di++){
+	  unsigned int temp = clusterSet.size();
+	  clusterSet.insert(*di);
+	  //check if cluster is off track
+	  if(clusterSet.size()>temp) {
+	    otherclusters++;
+	    nofclOffTrack++; 
+	    //fill histograms for clusters off tracks
+	    //correct SiPixelTrackResidualModulePhase1
+	    std::map<uint32_t, SiPixelTrackResidualModulePhase1*>::iterator pxd = theSiPixelStructure.find((*it)->geographicalId().rawId());
+
+	    if (pxd!=theSiPixelStructure.end()) (*pxd).second->fill((*di), false, -1., reducedSet, modOn, ladOn, layOn, phiOn, bladeOn, diskOn, ringOn); 
+	    
+
+
+	    meClSizeNotOnTrack_all->Fill((*di).size());
+	    meClSizeXNotOnTrack_all->Fill((*di).sizeX());
+	    meClSizeYNotOnTrack_all->Fill((*di).sizeY());
+	    meClChargeNotOnTrack_all->Fill((*di).charge()/1000);
+
+	    /////////////////////////////////////////////////
+	    //find cluster global position (rphi, z) get cluster
+	    //define tracker and pixel geometry and topology
+	    const TrackerGeometry& theTracker(*theTrackerGeometry);
+	    const PixelGeomDetUnit* theGeomDet = static_cast<const PixelGeomDetUnit*> (theTracker.idToDet(detId) );
+	    //test if PixelGeomDetUnit exists
+	    if(theGeomDet == 0) {
+	      if(debug_) std::cout << "NO THEGEOMDET\n";
+	      continue;
+	    }
+	    const PixelTopology * topol = &(theGeomDet->specificTopology());
+	   
+	    //center of gravity (of charge)
+	    float xcenter = di->x();
+	    float ycenter = di->y();
+	    // get the cluster position in local coordinates (cm) 
+	    LocalPoint clustlp = topol->localPosition( MeasurementPoint(xcenter, ycenter) );
+	    // get the cluster position in global coordinates (cm)
+	    GlobalPoint clustgp = theGeomDet->surface().toGlobal( clustlp );
+
+	    /////////////////////////////////////////////////
+
+	    //barrel
+	    if(DetId(detId).subdetId() == 1) {
+	      meClSizeNotOnTrack_bpix->Fill((*di).size());
+	      meClSizeXNotOnTrack_bpix->Fill((*di).sizeX());
+	      meClSizeYNotOnTrack_bpix->Fill((*di).sizeY());
+	      meClChargeNotOnTrack_bpix->Fill((*di).charge()/1000);
+	      barrelotherclusters++;
+	      //DBlayer = PixelBarrelName(DetId(detId)).layerName();
+	      float phi = clustgp.phi(); 
+	      //float r = clustgp.perp();
+	      z = clustgp.z();
+	      switch(DBlayer){
+	      case 1: {
+		meClPosLayer1NotOnTrack->Fill(z,phi); 
+		meClSizeNotOnTrack_layer1->Fill((*di).size());
+		meClSizeXNotOnTrack_layer1->Fill((*di).sizeX());
+		meClSizeYNotOnTrack_layer1->Fill((*di).sizeY());
+		meClChargeNotOnTrack_layer1->Fill((*di).charge()/1000);
+		break;
+	      }
+	      case 2: {
+		meClPosLayer2NotOnTrack->Fill(z,phi);
+		meClSizeNotOnTrack_layer2->Fill((*di).size());
+		meClSizeXNotOnTrack_layer2->Fill((*di).sizeX());
+		meClSizeYNotOnTrack_layer2->Fill((*di).sizeY());
+		meClChargeNotOnTrack_layer2->Fill((*di).charge()/1000);
+		break;
+	      }
+	      case 3: {
+		meClPosLayer3NotOnTrack->Fill(z,phi); 
+		meClSizeNotOnTrack_layer3->Fill((*di).size());
+		meClSizeXNotOnTrack_layer3->Fill((*di).sizeX());
+		meClSizeYNotOnTrack_layer3->Fill((*di).sizeY());
+		meClChargeNotOnTrack_layer3->Fill((*di).charge()/1000);
+		break;
+	      }
+	      case 4: {
+		meClPosLayer4NotOnTrack->Fill(z,phi); 
+		meClSizeNotOnTrack_layer4->Fill((*di).size());
+		meClSizeXNotOnTrack_layer4->Fill((*di).sizeX());
+		meClSizeYNotOnTrack_layer4->Fill((*di).sizeY());
+		meClChargeNotOnTrack_layer4->Fill((*di).charge()/1000);
+		break;
+	      }
+		
+	      }
+	    }
+	    //endcap
+	    if(DetId(detId).subdetId() == 2) {
+	      meClSizeNotOnTrack_fpix->Fill((*di).size());
+	      meClSizeXNotOnTrack_fpix->Fill((*di).sizeX());
+	      meClSizeYNotOnTrack_fpix->Fill((*di).sizeY());
+	      meClChargeNotOnTrack_fpix->Fill((*di).charge()/1000);
+	      endcapotherclusters++;
+	      //DBdisk = PixelEndcapName(DetId(detId )).diskName();
+	      float x = clustgp.x(); 
+	      float y = clustgp.y(); 
+	      z = clustgp.z();
+	      if(z>0){
+		if(DBdisk==1) {
+		  meClPosDisk1pzNotOnTrack->Fill(x,y);
+		  meClSizeNotOnTrack_diskp1->Fill((*di).size());
+		  meClSizeXNotOnTrack_diskp1->Fill((*di).sizeX());
+		  meClSizeYNotOnTrack_diskp1->Fill((*di).sizeY());
+		  meClChargeNotOnTrack_diskp1->Fill((*di).charge()/1000);
+		}
+		if(DBdisk==2) {
+		  meClPosDisk2pzNotOnTrack->Fill(x,y); 
+		  meClSizeNotOnTrack_diskp2->Fill((*di).size());
+		  meClSizeXNotOnTrack_diskp2->Fill((*di).sizeX());
+		  meClSizeYNotOnTrack_diskp2->Fill((*di).sizeY());
+		  meClChargeNotOnTrack_diskp2->Fill((*di).charge()/1000);
+		}
+		if(DBdisk==3) {
+		  meClPosDisk3pzNotOnTrack->Fill(x,y);
+                  meClSizeNotOnTrack_diskp3->Fill((*di).size());
+		  meClSizeXNotOnTrack_diskp3->Fill((*di).sizeX());
+		  meClSizeYNotOnTrack_diskp3->Fill((*di).sizeY());
+		  meClChargeNotOnTrack_diskp3->Fill((*di).charge()/1000);
+		}
+	      }
+	      else{
+		if(DBdisk==1) {
+		  meClPosDisk1mzNotOnTrack->Fill(x,y);
+		  meClSizeNotOnTrack_diskm1->Fill((*di).size());
+		  meClSizeXNotOnTrack_diskm1->Fill((*di).sizeX());
+		  meClSizeYNotOnTrack_diskm1->Fill((*di).sizeY());
+		  meClChargeNotOnTrack_diskm1->Fill((*di).charge()/1000);
+		}
+		if(DBdisk==2) {
+		  meClPosDisk2mzNotOnTrack->Fill(x,y); 
+		  meClSizeNotOnTrack_diskm2->Fill((*di).size());
+		  meClSizeXNotOnTrack_diskm2->Fill((*di).sizeX());
+		  meClSizeYNotOnTrack_diskm2->Fill((*di).sizeY());
+		  meClChargeNotOnTrack_diskm2->Fill((*di).charge()/1000);
+		}
+		if(DBdisk==3) {
+		  meClPosDisk3mzNotOnTrack->Fill(x,y);
+                  meClSizeNotOnTrack_diskm3->Fill((*di).size());
+		  meClSizeXNotOnTrack_diskm3->Fill((*di).sizeX());
+		  meClSizeYNotOnTrack_diskm3->Fill((*di).sizeY());
+		  meClChargeNotOnTrack_diskm3->Fill((*di).charge()/1000);
+		}
+	      } 
+
+	    }
+	  }// end "if cluster off track"
+	  else {
+	    nofclOnTrack++; 
+	    if(z == 0 && DBdisk != 10){
+	      //find cluster global position (rphi, z) get cluster
+	      //define tracker and pixel geometry and topology
+	      const TrackerGeometry& theTracker(*theTrackerGeometry);
+	      const PixelGeomDetUnit* theGeomDet = static_cast<const PixelGeomDetUnit*> (theTracker.idToDet(detId) );
+	      //test if PixelGeomDetUnit exists
+	      if(theGeomDet == 0) {
+		if(debug_) std::cout << "NO THEGEOMDET\n";
+		continue;
+	      }
+	      const PixelTopology * topol = &(theGeomDet->specificTopology());
+	      //center of gravity (of charge)
+	      float xcenter = di->x();
+	      float ycenter = di->y();
+	      // get the cluster position in local coordinates (cm) 
+	      LocalPoint clustlp = topol->localPosition( MeasurementPoint(xcenter, ycenter) );
+	      // get the cluster position in global coordinates (cm)
+	      GlobalPoint clustgp = theGeomDet->surface().toGlobal( clustlp );  
+	      z = clustgp.z();
+	    }
+	  }
+	}
+      }
+      //++ fill the number of clusters on a module
+      std::map<uint32_t, SiPixelTrackResidualModulePhase1*>::iterator pxd = theSiPixelStructure.find((*it)->geographicalId().rawId());
+      if (pxd!=theSiPixelStructure.end()) (*pxd).second->nfill(nofclOnTrack, nofclOffTrack, reducedSet, modOn, ladOn, layOn, phiOn, bladeOn, diskOn, ringOn); 
+      if(nofclOnTrack!=0) meNClustersOnTrack_all->Fill(nofclOnTrack); 
+      if(nofclOffTrack!=0) meNClustersNotOnTrack_all->Fill(nofclOffTrack); 
+      //barrel
+      if(DetId(detId).subdetId() == 1){
+	if(nofclOnTrack!=0) meNClustersOnTrack_bpix->Fill(nofclOnTrack); 
+	if(nofclOffTrack!=0) meNClustersNotOnTrack_bpix->Fill(nofclOffTrack); 
+	//DBlayer = PixelBarrelName(DetId(detId)).layerName();
+	switch(DBlayer){
+	case 1: { 
+	  if(nofclOnTrack!=0) meNClustersOnTrack_layer1->Fill(nofclOnTrack);
+	  if(nofclOffTrack!=0) meNClustersNotOnTrack_layer1->Fill(nofclOffTrack); break;
+	}
+	case 2: {
+	  if(nofclOnTrack!=0) meNClustersOnTrack_layer2->Fill(nofclOnTrack);
+	  if(nofclOffTrack!=0) meNClustersNotOnTrack_layer2->Fill(nofclOffTrack); break; 
+	}
+	case 3: {
+	  if(nofclOnTrack!=0) meNClustersOnTrack_layer3->Fill(nofclOnTrack); 
+	  if(nofclOffTrack!=0) meNClustersNotOnTrack_layer3->Fill(nofclOffTrack); break; 
+	}
+	case 4: {
+	  if(nofclOnTrack!=0) meNClustersOnTrack_layer4->Fill(nofclOnTrack); 
+	  if(nofclOffTrack!=0) meNClustersNotOnTrack_layer4->Fill(nofclOffTrack); break; 
+	}
+	}
+      }//end barrel
+      //endcap
+      if(DetId(detId).subdetId() == 2) {
+	//DBdisk = PixelEndcapName(DetId(detId )).diskName();
+	//z = clustgp.z();
+	if(nofclOnTrack!=0) meNClustersOnTrack_fpix->Fill(nofclOnTrack); 
+	if(nofclOffTrack!=0) meNClustersNotOnTrack_fpix->Fill(nofclOffTrack);
+	if(z>0){
+	  if(DBdisk==1) {
+	    if(nofclOnTrack!=0) meNClustersOnTrack_diskp1->Fill(nofclOnTrack); 
+	    if(nofclOffTrack!=0) meNClustersNotOnTrack_diskp1->Fill(nofclOffTrack);
+	  }
+	  if(DBdisk==2) {
+	    if(nofclOnTrack!=0) meNClustersOnTrack_diskp2->Fill(nofclOnTrack); 
+	    if(nofclOffTrack!=0) meNClustersNotOnTrack_diskp2->Fill(nofclOffTrack);
+	  }
+          if(DBdisk==3) {
+	    if(nofclOnTrack!=0) meNClustersOnTrack_diskp3->Fill(nofclOnTrack); 
+	    if(nofclOffTrack!=0) meNClustersNotOnTrack_diskp3->Fill(nofclOffTrack);
+	  }
+	}
+	if(z<0){
+	  if(DBdisk==1) {
+	    if(nofclOnTrack!=0) meNClustersOnTrack_diskm1->Fill(nofclOnTrack); 
+	    if(nofclOffTrack!=0) meNClustersNotOnTrack_diskm1->Fill(nofclOffTrack);
+	  }
+	  if(DBdisk==2) {
+	    if(nofclOnTrack!=0) meNClustersOnTrack_diskm2->Fill(nofclOnTrack); 
+	    if(nofclOffTrack!=0) meNClustersNotOnTrack_diskm2->Fill(nofclOffTrack);
+	  }
+          if(DBdisk==3) {
+	    if(nofclOnTrack!=0) meNClustersOnTrack_diskm3->Fill(nofclOnTrack); 
+	    if(nofclOffTrack!=0) meNClustersNotOnTrack_diskm3->Fill(nofclOffTrack);
+	  }
+	}
+      }
+
+    }//end if it's a Pixel module
+  }//end for loop over tracker detector geometry modules
+
+
+  if(trackclusters>0) (meNofClustersOnTrack_)->Fill(0,trackclusters);
+  if(barreltrackclusters>0)(meNofClustersOnTrack_)->Fill(1,barreltrackclusters);
+  if(endcaptrackclusters>0)(meNofClustersOnTrack_)->Fill(2,endcaptrackclusters);
+  if(otherclusters>0)(meNofClustersNotOnTrack_)->Fill(0,otherclusters);
+  if(barrelotherclusters>0)(meNofClustersNotOnTrack_)->Fill(1,barrelotherclusters);
+  if(endcapotherclusters>0)(meNofClustersNotOnTrack_)->Fill(2,endcapotherclusters);
+  if(tracks>0)(meNofTracks_)->Fill(0,tracks);
+  if(pixeltracks>0)(meNofTracks_)->Fill(1,pixeltracks);
+  if(bpixtracks>0)(meNofTracks_)->Fill(2,bpixtracks);
+  if(fpixtracks>0)(meNofTracks_)->Fill(3,fpixtracks);
+}
+void SiPixelTrackResidualSourcePhase1::triplets(double x1,double y1,double z1,double x2,double y2,double z2,double x3,double y3,double z3,
+					  double ptsig, double & dca2,double & dz2, double kap) {
+  
+  //Define some constants
+  using namespace std;
+
+  //Curvature kap from global Track
+
+ //inverse of the curvature is the radius in the transverse plane
+  double rho = 1/kap;
+  //Check that the hits are in the correct layers
+  double r1 = sqrt( x1*x1 + y1*y1 );
+  double r3 = sqrt( x3*x3 + y3*y3 );
+
+  if( r3-r1 < 2.0 ) cout << "warn r1 = " << r1 << ", r3 = " << r3 << endl;
+  
+  // Calculate the centre of the helix in xy-projection with radius rho from the track.
+  //start with a line (sekante) connecting the two points (x1,y1) and (x3,y3) vec_L = vec_x3-vec_x1
+  //with L being the length of that vector.
+  double L=sqrt((x3-x1)*(x3-x1)+(y3-y1)*(y3-y1));
+  //lam is the line from the middel point of vec_q towards the center of the circle X0,Y0
+  // we already have kap and rho = 1/kap
+  double lam = sqrt(rho*rho - L*L/4);
+  
+  // There are two solutions, the sign of kap gives the information
+  // which of them is correct.
+  //
+  if( kap > 0 ) lam = -lam;
+
+  //
+  // ( X0, Y0 ) is the centre of the circle that describes the helix in xy-projection.
+  //
+  double x0 =  0.5*( x1 + x3 ) + lam/L * ( -y1 + y3 );
+  double y0 =  0.5*( y1 + y3 ) + lam/L * (  x1 - x3 );
+
+  // Calculate the dipangle in z direction (needed later for z residual) :
+  //Starting from the heliz equation whihc has to hold for both points z1,z3
+  double num = ( y3 - y0 ) * ( x1 - x0 ) - ( x3 - x0 ) * ( y1 - y0 );
+  double den = ( x1 - x0 ) * ( x3 - x0 ) + ( y1 - y0 ) * ( y3 - y0 );
+  double tandip = kap * ( z3 - z1 ) / atan( num / den );
+
+ 
+  // angle from first hit to dca point:
+  //
+  double dphi = atan( ( ( x1 - x0 ) * y0 - ( y1 - y0 ) * x0 )
+                      / ( ( x1 - x0 ) * x0 + ( y1 - y0 ) * y0 ) );
+  //z position of the track based on the middle of the circle
+  //track equation for the z component
+  double uz0 = z1 + tandip * dphi * rho;
+
+  /////////////////////////
+  //RESIDUAL IN R-PHI
+  ////////////////////////////////
+  //Calculate distance dca2 from point (x2,y2) to the circle which is given by
+  //the distance of the point to the middlepoint dcM = sqrt((x0-x2)^2+(y0-y2)) and rho
+  //dca = rho +- dcM
+  if(kap>0) dca2=rho-sqrt((x0-x2)*(x0-x2)+(y0-y2)*(y0-y2));
+  else dca2=rho+sqrt((-x0+x2)*(-x0+x2)+(-y0+y2)*(-y0+y2));
+
+  /////////////////////////
+  //RESIDUAL IN Z
+  /////////////////////////
+  double xx =0 ;
+  double yy =0 ;
+  //sign of kappa determines the calculation
+  //xx and yy are the new coordinates starting from x2, y2 that are on the track itself
+  //vec_X2+-dca2*vec(X0-X2)/|(X0-X2)|
+  if(kap<0){
+    xx =   x2+(dca2*((x0-x2))/sqrt((x0-x2)*(x0-x2)+(y0-y2)*(y0-y2)));
+    yy = y2+(dca2*((y0-y2))/sqrt((x0-x2)*(x0-x2)+(y0-y2)*(y0-y2)));
+  }
+  else if(kap>=0){
+    xx =   x2-(dca2*((x0-x2))/sqrt((x0-x2)*(x0-x2)+(y0-y2)*(y0-y2)));
+    yy = y2-(dca2*((y0-y2))/sqrt((x0-x2)*(x0-x2)+(y0-y2)*(y0-y2)));
+  }
+
+  //to get residual in z start with calculating the new uz2 position if one has moved to xx, yy
+  //on the track. First calculate the change in phi2 with respect to the center X0, Y0
+  double dphi2 = atan( ( ( xx - x0 ) * y0 - ( yy - y0 ) * x0 )
+		       / ( ( xx - x0 ) * x0 + ( yy - y0 ) * y0 ) );
+  //Solve track equation for this new z depending on the dip angle of the track (see above
+  //calculated based on X1, X3 and X0, use uz0 as reference point again.
+  double  uz2= uz0 - dphi2*tandip*rho;
+  
+  //subtract new z position from the old one
+  dz2=z2-uz2;
+  
+  //if we are interested in the arclength this is unsigned though
+  //  double cosphi2 = (x2*xx+y2*yy)/(sqrt(x2*x2+y2*y2)*sqrt(xx*xx+yy*yy));
+  //double arcdca2=sqrt(x2*x2+y2*y2)*acos(cosphi2);
+  
+}
+
+
+DEFINE_FWK_MODULE(SiPixelTrackResidualSourcePhase1); // define this as a plug-in 


### PR DESCRIPTION
- I removed most instances of the "isUpgrade" flag in DQM/SiPixel\* (exceptions being in DQM/SiPixelCommon, where some instances were left behind so as not to make things incompatible with code outside DQM/)
- wherever "isUpgrade" was removed, I separated source files (and their associated header files and analyzer declarations in _cfi.py config files) into a standard-geometry version, which retains its original name, and a Phase1 version, in which the name has "Phase1" tacked onto the end (for instance, SiPixelMonitorRecHit/src/SiPixelRecHitModule.cc and SiPixelMonitorRecHit/src/SiPixelRecHitModulePhase1.cc)
