### PR TITLE
DQMOffline_Trigger_cosmics_cff.py:  clean up

### DIFF
--- a/DQMOffline/Trigger/python/DQMOffline_Trigger_cosmics_cff.py
+++ b/DQMOffline/Trigger/python/DQMOffline_Trigger_cosmics_cff.py
@@ -3,15 +3,15 @@ import FWCore.ParameterSet.Config as cms
 
 # HLT Online -----------------------------------
 # AlCa
-from DQM.HLTEvF.HLTAlCaMonPi0_cfi import *
-from DQM.HLTEvF.HLTAlCaMonEcalPhiSym_cfi import *
+#from DQM.HLTEvF.HLTAlCaMonPi0_cfi import *
+#from DQM.HLTEvF.HLTAlCaMonEcalPhiSym_cfi import *
 #JetMET
-from DQM.HLTEvF.HLTMonJetMETDQMSource_cfi import *
+#from DQM.HLTEvF.HLTMonJetMETDQMSource_cfi import *
 # Electron
-from DQM.HLTEvF.HLTMonEleBits_cfi import *
+#from DQM.HLTEvF.HLTMonEleBits_cfi import *
 # Muon
-from DQM.HLTEvF.HLTMonMuonDQM_cfi import *
-from DQM.HLTEvF.HLTMonMuonBits_cfi import *
+#from DQM.HLTEvF.HLTMonMuonDQM_cfi import *
+#from DQM.HLTEvF.HLTMonMuonBits_cfi import *
 # Photon
 #from DQM.HLTEvF.HLTMonPhotonBits_cfi import *
 # Tau
@@ -26,12 +26,12 @@ from DQM.HLTEvF.HLTMonMuonBits_cfi import *
 # *hltMonJetMET makes a log file, need to learn how to turn it off
 # *hltMonEleBits causes SegmentFaults in HARVESTING(step3) in inlcuded in step2
 
-import DQMServices.Components.DQMEnvironment_cfi
-dqmEnvHLTOnline = DQMServices.Components.DQMEnvironment_cfi.dqmEnv.clone()
-dqmEnvHLTOnline.subSystemFolder = 'HLT'
+#import DQMServices.Components.DQMEnvironment_cfi
+#dqmEnvHLTOnline = DQMServices.Components.DQMEnvironment_cfi.dqmEnv.clone()
+#dqmEnvHLTOnline.subSystemFolder = 'HLT'
 
 #onlineHLTSource = cms.Sequence(EcalPi0Mon*EcalPhiSymMon*hltMonEleBits*hltMonMuBits*hltMonTauReco*hltMonBTagIPSource*hltMonBTagMuSource*dqmEnvHLTOnline)
-onlineHLTSource = cms.Sequence(EcalPi0Mon*EcalPhiSymMon*hltMonMuBits*dqmEnvHLTOnline)
+#onlineHLTSource = cms.Sequence(EcalPi0Mon*EcalPhiSymMon*hltMonMuBits*dqmEnvHLTOnline)
 
 
 # HLT Offline -----------------------------------
@@ -65,4 +65,5 @@ offlineHLTSource = cms.Sequence(
     dqmEnvHLT)
 
 
-triggerCosmicOfflineDQMSource =  cms.Sequence(onlineHLTSource*offlineHLTSource)
+#triggerCosmicOfflineDQMSource =  cms.Sequence(onlineHLTSource*offlineHLTSource)
+triggerCosmicOfflineDQMSource =  cms.Sequence(offlineHLTSource)


### PR DESCRIPTION
remove unused modules from the HLT DQM configuration
brings DQMOffline_Trigger_cosmics_cff.py in line with DQMOffline_Trigger_cosmics.py
