### PR TITLE
Fix/mask default behaviour/reproducability issue in StripCPEfromTrackAngle

### DIFF
--- a/RecoLocalTracker/SiStripRecHitConverter/interface/StripCPEfromTrackAngle.h
+++ b/RecoLocalTracker/SiStripRecHitConverter/interface/StripCPEfromTrackAngle.h
@@ -35,7 +35,7 @@ public:
 			  const SiStripConfObject& confObj,
 			  const SiStripLatency& latency) 
   : StripCPE(conf, mag, geom, lorentz, backPlaneCorrection, confObj, latency )
-  , useLegacyError(conf.existsAs<bool>("useLegacyError") ? conf.getParameter<bool>("useLegacyError") : false)
+  , useLegacyError(conf.existsAs<bool>("useLegacyError") ? conf.getParameter<bool>("useLegacyError") : true)
   {
     mLC_P[0] = conf.existsAs<double>("mLC_P0") ? conf.getParameter<double>("mLC_P0") : -.326;
     mLC_P[1] = conf.existsAs<double>("mLC_P1") ? conf.getParameter<double>("mLC_P1") :  .618;


### PR DESCRIPTION
This PR fixes (or masks) non-reproducability issue observed in HLT 
when using the non-legacy errors: it switches the default back to be 
the legacy error in StripCPEfromTrackAngle. All the gory details are
discussed in PR #5151 .

This PR here affects only those configurations where the py file does not
contain the new parameters added with #5151. Hence RECO, which uses
the (updated) cfi file of the module, will continue to use the new non-legacy
errors. But at HLT, where the menu is kept in ConfDb based on a 71X template,
we do not want any non-reproducability.

[Of course, the non-reproducabilit may actually be elsewhere, as
pointed out by Vincenzo, but the bottom line is that for HLT we want
revert until the issue is fixed]

I should add that we (TSG) want this PR even independently of the reproducability
issue: all new code should be configured to reproduce the old behaviour on unchanged
py config files.!
