### PR TITLE
Fix StripCPEESProducer config to use Legacy Error Calculation in HLT

### DIFF
--- a/HLTrigger/Configuration/python/HLT_2014_Famos_cff.py
+++ b/HLTrigger/Configuration/python/HLT_2014_Famos_cff.py
@@ -42509,11 +42509,8 @@ HLTSchedule = cms.Schedule( *(HLTriggerFirstPath, HLT_L1SingleJet16_v7, HLT_L1Si
 import os
 cmsswVersion = os.environ['CMSSW_VERSION']
 
-# none for now
-
-
 # from CMSSW_7_2_0_pre6: Use Legacy Errors in "StripCPEESProducer" for HLT (PRs 5286/5151)
-if cmsswVersion > "CMSSW_7_1":
+if cmsswVersion >= "CMSSW_7_2":
     if 'hltESPStripCPEfromTrackAngle' in locals():
         hltESPStripCPEfromTrackAngle.useLegacyError = cms.bool(True)
 

--- a/HLTrigger/Configuration/python/HLT_2014_Famos_cff.py
+++ b/HLTrigger/Configuration/python/HLT_2014_Famos_cff.py
@@ -42512,3 +42512,8 @@ cmsswVersion = os.environ['CMSSW_VERSION']
 # none for now
 
 
+# from CMSSW_7_2_0_pre6: Use Legacy Errors in "StripCPEESProducer" for HLT (PRs 5286/5151)
+if cmsswVersion > "CMSSW_7_1":
+    if 'hltESPStripCPEfromTrackAngle' in locals():
+        hltESPStripCPEfromTrackAngle.useLegacyError = cms.bool(True)
+

--- a/HLTrigger/Configuration/python/HLT_2014_cff.py
+++ b/HLTrigger/Configuration/python/HLT_2014_cff.py
@@ -51938,11 +51938,8 @@ HLTSchedule = cms.Schedule( *(HLTriggerFirstPath, HLT_Activity_Ecal_SC7_v14, HLT
 import os
 cmsswVersion = os.environ['CMSSW_VERSION']
 
-# none for now
-
-
 # from CMSSW_7_2_0_pre6: Use Legacy Errors in "StripCPEESProducer" for HLT (PRs 5286/5151)
-if cmsswVersion > "CMSSW_7_1":
+if cmsswVersion >= "CMSSW_7_2":
     if 'hltESPStripCPEfromTrackAngle' in locals():
         hltESPStripCPEfromTrackAngle.useLegacyError = cms.bool(True)
 

--- a/HLTrigger/Configuration/python/HLT_2014_cff.py
+++ b/HLTrigger/Configuration/python/HLT_2014_cff.py
@@ -51941,3 +51941,8 @@ cmsswVersion = os.environ['CMSSW_VERSION']
 # none for now
 
 
+# from CMSSW_7_2_0_pre6: Use Legacy Errors in "StripCPEESProducer" for HLT (PRs 5286/5151)
+if cmsswVersion > "CMSSW_7_1":
+    if 'hltESPStripCPEfromTrackAngle' in locals():
+        hltESPStripCPEfromTrackAngle.useLegacyError = cms.bool(True)
+

--- a/HLTrigger/Configuration/python/HLT_FULL_Famos_cff.py
+++ b/HLTrigger/Configuration/python/HLT_FULL_Famos_cff.py
@@ -17299,3 +17299,8 @@ cmsswVersion = os.environ['CMSSW_VERSION']
 # none for now
 
 
+# from CMSSW_7_2_0_pre6: Use Legacy Errors in "StripCPEESProducer" for HLT (PRs 5286/5151)
+if cmsswVersion > "CMSSW_7_1":
+    if 'hltESPStripCPEfromTrackAngle' in locals():
+        hltESPStripCPEfromTrackAngle.useLegacyError = cms.bool(True)
+

--- a/HLTrigger/Configuration/python/HLT_FULL_Famos_cff.py
+++ b/HLTrigger/Configuration/python/HLT_FULL_Famos_cff.py
@@ -17296,11 +17296,8 @@ HLTSchedule = cms.Schedule( *(HLTriggerFirstPath, HLT_Mu17_NoFilters_v1, HLT_Mu4
 import os
 cmsswVersion = os.environ['CMSSW_VERSION']
 
-# none for now
-
-
 # from CMSSW_7_2_0_pre6: Use Legacy Errors in "StripCPEESProducer" for HLT (PRs 5286/5151)
-if cmsswVersion > "CMSSW_7_1":
+if cmsswVersion >= "CMSSW_7_2":
     if 'hltESPStripCPEfromTrackAngle' in locals():
         hltESPStripCPEfromTrackAngle.useLegacyError = cms.bool(True)
 

--- a/HLTrigger/Configuration/python/HLT_FULL_cff.py
+++ b/HLTrigger/Configuration/python/HLT_FULL_cff.py
@@ -28370,11 +28370,8 @@ HLTSchedule = cms.Schedule( *(HLTriggerFirstPath, HLT_Mu17_NoFilters_v1, HLT_Mu4
 import os
 cmsswVersion = os.environ['CMSSW_VERSION']
 
-# none for now
-
-
 # from CMSSW_7_2_0_pre6: Use Legacy Errors in "StripCPEESProducer" for HLT (PRs 5286/5151)
-if cmsswVersion > "CMSSW_7_1":
+if cmsswVersion >= "CMSSW_7_2":
     if 'hltESPStripCPEfromTrackAngle' in locals():
         hltESPStripCPEfromTrackAngle.useLegacyError = cms.bool(True)
 

--- a/HLTrigger/Configuration/python/HLT_FULL_cff.py
+++ b/HLTrigger/Configuration/python/HLT_FULL_cff.py
@@ -28373,3 +28373,8 @@ cmsswVersion = os.environ['CMSSW_VERSION']
 # none for now
 
 
+# from CMSSW_7_2_0_pre6: Use Legacy Errors in "StripCPEESProducer" for HLT (PRs 5286/5151)
+if cmsswVersion > "CMSSW_7_1":
+    if 'hltESPStripCPEfromTrackAngle' in locals():
+        hltESPStripCPEfromTrackAngle.useLegacyError = cms.bool(True)
+

--- a/HLTrigger/Configuration/python/HLT_GRun_Famos_cff.py
+++ b/HLTrigger/Configuration/python/HLT_GRun_Famos_cff.py
@@ -15571,3 +15571,8 @@ cmsswVersion = os.environ['CMSSW_VERSION']
 # none for now
 
 
+# from CMSSW_7_2_0_pre6: Use Legacy Errors in "StripCPEESProducer" for HLT (PRs 5286/5151)
+if cmsswVersion > "CMSSW_7_1":
+    if 'hltESPStripCPEfromTrackAngle' in locals():
+        hltESPStripCPEfromTrackAngle.useLegacyError = cms.bool(True)
+

--- a/HLTrigger/Configuration/python/HLT_GRun_Famos_cff.py
+++ b/HLTrigger/Configuration/python/HLT_GRun_Famos_cff.py
@@ -15568,11 +15568,8 @@ HLTSchedule = cms.Schedule( *(HLTriggerFirstPath, HLT_Mu40_v1, HLT_IsoMu24_IterT
 import os
 cmsswVersion = os.environ['CMSSW_VERSION']
 
-# none for now
-
-
 # from CMSSW_7_2_0_pre6: Use Legacy Errors in "StripCPEESProducer" for HLT (PRs 5286/5151)
-if cmsswVersion > "CMSSW_7_1":
+if cmsswVersion >= "CMSSW_7_2":
     if 'hltESPStripCPEfromTrackAngle' in locals():
         hltESPStripCPEfromTrackAngle.useLegacyError = cms.bool(True)
 

--- a/HLTrigger/Configuration/python/HLT_GRun_cff.py
+++ b/HLTrigger/Configuration/python/HLT_GRun_cff.py
@@ -24448,3 +24448,8 @@ cmsswVersion = os.environ['CMSSW_VERSION']
 # none for now
 
 
+# from CMSSW_7_2_0_pre6: Use Legacy Errors in "StripCPEESProducer" for HLT (PRs 5286/5151)
+if cmsswVersion > "CMSSW_7_1":
+    if 'hltESPStripCPEfromTrackAngle' in locals():
+        hltESPStripCPEfromTrackAngle.useLegacyError = cms.bool(True)
+

--- a/HLTrigger/Configuration/python/HLT_GRun_cff.py
+++ b/HLTrigger/Configuration/python/HLT_GRun_cff.py
@@ -24445,11 +24445,8 @@ HLTSchedule = cms.Schedule( *(HLTriggerFirstPath, HLT_Mu40_v1, HLT_IsoMu24_IterT
 import os
 cmsswVersion = os.environ['CMSSW_VERSION']
 
-# none for now
-
-
 # from CMSSW_7_2_0_pre6: Use Legacy Errors in "StripCPEESProducer" for HLT (PRs 5286/5151)
-if cmsswVersion > "CMSSW_7_1":
+if cmsswVersion >= "CMSSW_7_2":
     if 'hltESPStripCPEfromTrackAngle' in locals():
         hltESPStripCPEfromTrackAngle.useLegacyError = cms.bool(True)
 

--- a/HLTrigger/Configuration/python/HLT_HIon_cff.py
+++ b/HLTrigger/Configuration/python/HLT_HIon_cff.py
@@ -7770,3 +7770,8 @@ cmsswVersion = os.environ['CMSSW_VERSION']
 # none for now
 
 
+# from CMSSW_7_2_0_pre6: Use Legacy Errors in "StripCPEESProducer" for HLT (PRs 5286/5151)
+if cmsswVersion > "CMSSW_7_1":
+    if 'hltESPStripCPEfromTrackAngle' in locals():
+        hltESPStripCPEfromTrackAngle.useLegacyError = cms.bool(True)
+

--- a/HLTrigger/Configuration/python/HLT_HIon_cff.py
+++ b/HLTrigger/Configuration/python/HLT_HIon_cff.py
@@ -7767,11 +7767,8 @@ HLTSchedule = cms.Schedule( *(HLTriggerFirstPath, HLT_Mu40_v1, HLT_Ele27_WP85_Gs
 import os
 cmsswVersion = os.environ['CMSSW_VERSION']
 
-# none for now
-
-
 # from CMSSW_7_2_0_pre6: Use Legacy Errors in "StripCPEESProducer" for HLT (PRs 5286/5151)
-if cmsswVersion > "CMSSW_7_1":
+if cmsswVersion >= "CMSSW_7_2":
     if 'hltESPStripCPEfromTrackAngle' in locals():
         hltESPStripCPEfromTrackAngle.useLegacyError = cms.bool(True)
 

--- a/HLTrigger/Configuration/python/HLT_PIon_cff.py
+++ b/HLTrigger/Configuration/python/HLT_PIon_cff.py
@@ -7770,3 +7770,8 @@ cmsswVersion = os.environ['CMSSW_VERSION']
 # none for now
 
 
+# from CMSSW_7_2_0_pre6: Use Legacy Errors in "StripCPEESProducer" for HLT (PRs 5286/5151)
+if cmsswVersion > "CMSSW_7_1":
+    if 'hltESPStripCPEfromTrackAngle' in locals():
+        hltESPStripCPEfromTrackAngle.useLegacyError = cms.bool(True)
+

--- a/HLTrigger/Configuration/python/HLT_PIon_cff.py
+++ b/HLTrigger/Configuration/python/HLT_PIon_cff.py
@@ -7767,11 +7767,8 @@ HLTSchedule = cms.Schedule( *(HLTriggerFirstPath, HLT_Mu40_v1, HLT_Ele27_WP85_Gs
 import os
 cmsswVersion = os.environ['CMSSW_VERSION']
 
-# none for now
-
-
 # from CMSSW_7_2_0_pre6: Use Legacy Errors in "StripCPEESProducer" for HLT (PRs 5286/5151)
-if cmsswVersion > "CMSSW_7_1":
+if cmsswVersion >= "CMSSW_7_2":
     if 'hltESPStripCPEfromTrackAngle' in locals():
         hltESPStripCPEfromTrackAngle.useLegacyError = cms.bool(True)
 

--- a/HLTrigger/Configuration/python/Tools/confdb.py
+++ b/HLTrigger/Configuration/python/Tools/confdb.py
@@ -194,6 +194,13 @@ cmsswVersion = os.environ['CMSSW_VERSION']
 
 """
 
+    self.data += """
+# from CMSSW_7_2_0_pre6: Use Legacy Errors in "StripCPEESProducer" for HLT (PRs 5286/5151)
+if cmsswVersion > "CMSSW_7_1":
+    if 'hltESPStripCPEfromTrackAngle' in %(dict)s:
+        %(process)shltESPStripCPEfromTrackAngle.useLegacyError = cms.bool(True)
+"""
+
   # customize the configuration according to the options
   def customize(self):
 

--- a/HLTrigger/Configuration/python/Tools/confdb.py
+++ b/HLTrigger/Configuration/python/Tools/confdb.py
@@ -190,13 +190,8 @@ class HLTProcess(object):
 import os
 cmsswVersion = os.environ['CMSSW_VERSION']
 
-# none for now
-
-"""
-
-    self.data += """
 # from CMSSW_7_2_0_pre6: Use Legacy Errors in "StripCPEESProducer" for HLT (PRs 5286/5151)
-if cmsswVersion > "CMSSW_7_1":
+if cmsswVersion >= "CMSSW_7_2":
     if 'hltESPStripCPEfromTrackAngle' in %(dict)s:
         %(process)shltESPStripCPEfromTrackAngle.useLegacyError = cms.bool(True)
 """

--- a/HLTrigger/Configuration/test/OnData_HLT_2014.py
+++ b/HLTrigger/Configuration/test/OnData_HLT_2014.py
@@ -54920,11 +54920,8 @@ process.source = cms.Source( "PoolSource",
 import os
 cmsswVersion = os.environ['CMSSW_VERSION']
 
-# none for now
-
-
 # from CMSSW_7_2_0_pre6: Use Legacy Errors in "StripCPEESProducer" for HLT (PRs 5286/5151)
-if cmsswVersion > "CMSSW_7_1":
+if cmsswVersion >= "CMSSW_7_2":
     if 'hltESPStripCPEfromTrackAngle' in process.__dict__:
         process.hltESPStripCPEfromTrackAngle.useLegacyError = cms.bool(True)
 

--- a/HLTrigger/Configuration/test/OnData_HLT_2014.py
+++ b/HLTrigger/Configuration/test/OnData_HLT_2014.py
@@ -54923,6 +54923,11 @@ cmsswVersion = os.environ['CMSSW_VERSION']
 # none for now
 
 
+# from CMSSW_7_2_0_pre6: Use Legacy Errors in "StripCPEESProducer" for HLT (PRs 5286/5151)
+if cmsswVersion > "CMSSW_7_1":
+    if 'hltESPStripCPEfromTrackAngle' in process.__dict__:
+        process.hltESPStripCPEfromTrackAngle.useLegacyError = cms.bool(True)
+
 # adapt HLT modules to the correct process name
 if 'hltTrigReport' in process.__dict__:
     process.hltTrigReport.HLTriggerResults                    = cms.InputTag( 'TriggerResults', '', 'HLT2014' )

--- a/HLTrigger/Configuration/test/OnData_HLT_FULL.py
+++ b/HLTrigger/Configuration/test/OnData_HLT_FULL.py
@@ -29022,6 +29022,11 @@ cmsswVersion = os.environ['CMSSW_VERSION']
 # none for now
 
 
+# from CMSSW_7_2_0_pre6: Use Legacy Errors in "StripCPEESProducer" for HLT (PRs 5286/5151)
+if cmsswVersion > "CMSSW_7_1":
+    if 'hltESPStripCPEfromTrackAngle' in process.__dict__:
+        process.hltESPStripCPEfromTrackAngle.useLegacyError = cms.bool(True)
+
 # adapt HLT modules to the correct process name
 if 'hltTrigReport' in process.__dict__:
     process.hltTrigReport.HLTriggerResults                    = cms.InputTag( 'TriggerResults', '', 'HLTFULL' )

--- a/HLTrigger/Configuration/test/OnData_HLT_FULL.py
+++ b/HLTrigger/Configuration/test/OnData_HLT_FULL.py
@@ -29019,11 +29019,8 @@ process.source = cms.Source( "PoolSource",
 import os
 cmsswVersion = os.environ['CMSSW_VERSION']
 
-# none for now
-
-
 # from CMSSW_7_2_0_pre6: Use Legacy Errors in "StripCPEESProducer" for HLT (PRs 5286/5151)
-if cmsswVersion > "CMSSW_7_1":
+if cmsswVersion >= "CMSSW_7_2":
     if 'hltESPStripCPEfromTrackAngle' in process.__dict__:
         process.hltESPStripCPEfromTrackAngle.useLegacyError = cms.bool(True)
 

--- a/HLTrigger/Configuration/test/OnData_HLT_GRun.py
+++ b/HLTrigger/Configuration/test/OnData_HLT_GRun.py
@@ -25070,11 +25070,8 @@ process.source = cms.Source( "PoolSource",
 import os
 cmsswVersion = os.environ['CMSSW_VERSION']
 
-# none for now
-
-
 # from CMSSW_7_2_0_pre6: Use Legacy Errors in "StripCPEESProducer" for HLT (PRs 5286/5151)
-if cmsswVersion > "CMSSW_7_1":
+if cmsswVersion >= "CMSSW_7_2":
     if 'hltESPStripCPEfromTrackAngle' in process.__dict__:
         process.hltESPStripCPEfromTrackAngle.useLegacyError = cms.bool(True)
 

--- a/HLTrigger/Configuration/test/OnData_HLT_GRun.py
+++ b/HLTrigger/Configuration/test/OnData_HLT_GRun.py
@@ -25073,6 +25073,11 @@ cmsswVersion = os.environ['CMSSW_VERSION']
 # none for now
 
 
+# from CMSSW_7_2_0_pre6: Use Legacy Errors in "StripCPEESProducer" for HLT (PRs 5286/5151)
+if cmsswVersion > "CMSSW_7_1":
+    if 'hltESPStripCPEfromTrackAngle' in process.__dict__:
+        process.hltESPStripCPEfromTrackAngle.useLegacyError = cms.bool(True)
+
 # adapt HLT modules to the correct process name
 if 'hltTrigReport' in process.__dict__:
     process.hltTrigReport.HLTriggerResults                    = cms.InputTag( 'TriggerResults', '', 'HLTGRun' )

--- a/HLTrigger/Configuration/test/OnData_HLT_HIon.py
+++ b/HLTrigger/Configuration/test/OnData_HLT_HIon.py
@@ -8320,11 +8320,8 @@ process.source = cms.Source( "PoolSource",
 import os
 cmsswVersion = os.environ['CMSSW_VERSION']
 
-# none for now
-
-
 # from CMSSW_7_2_0_pre6: Use Legacy Errors in "StripCPEESProducer" for HLT (PRs 5286/5151)
-if cmsswVersion > "CMSSW_7_1":
+if cmsswVersion >= "CMSSW_7_2":
     if 'hltESPStripCPEfromTrackAngle' in process.__dict__:
         process.hltESPStripCPEfromTrackAngle.useLegacyError = cms.bool(True)
 

--- a/HLTrigger/Configuration/test/OnData_HLT_HIon.py
+++ b/HLTrigger/Configuration/test/OnData_HLT_HIon.py
@@ -8323,6 +8323,11 @@ cmsswVersion = os.environ['CMSSW_VERSION']
 # none for now
 
 
+# from CMSSW_7_2_0_pre6: Use Legacy Errors in "StripCPEESProducer" for HLT (PRs 5286/5151)
+if cmsswVersion > "CMSSW_7_1":
+    if 'hltESPStripCPEfromTrackAngle' in process.__dict__:
+        process.hltESPStripCPEfromTrackAngle.useLegacyError = cms.bool(True)
+
 # adapt HLT modules to the correct process name
 if 'hltTrigReport' in process.__dict__:
     process.hltTrigReport.HLTriggerResults                    = cms.InputTag( 'TriggerResults', '', 'HLTHIon' )

--- a/HLTrigger/Configuration/test/OnData_HLT_PIon.py
+++ b/HLTrigger/Configuration/test/OnData_HLT_PIon.py
@@ -8320,11 +8320,8 @@ process.source = cms.Source( "PoolSource",
 import os
 cmsswVersion = os.environ['CMSSW_VERSION']
 
-# none for now
-
-
 # from CMSSW_7_2_0_pre6: Use Legacy Errors in "StripCPEESProducer" for HLT (PRs 5286/5151)
-if cmsswVersion > "CMSSW_7_1":
+if cmsswVersion >= "CMSSW_7_2":
     if 'hltESPStripCPEfromTrackAngle' in process.__dict__:
         process.hltESPStripCPEfromTrackAngle.useLegacyError = cms.bool(True)
 

--- a/HLTrigger/Configuration/test/OnData_HLT_PIon.py
+++ b/HLTrigger/Configuration/test/OnData_HLT_PIon.py
@@ -8323,6 +8323,11 @@ cmsswVersion = os.environ['CMSSW_VERSION']
 # none for now
 
 
+# from CMSSW_7_2_0_pre6: Use Legacy Errors in "StripCPEESProducer" for HLT (PRs 5286/5151)
+if cmsswVersion > "CMSSW_7_1":
+    if 'hltESPStripCPEfromTrackAngle' in process.__dict__:
+        process.hltESPStripCPEfromTrackAngle.useLegacyError = cms.bool(True)
+
 # adapt HLT modules to the correct process name
 if 'hltTrigReport' in process.__dict__:
     process.hltTrigReport.HLTriggerResults                    = cms.InputTag( 'TriggerResults', '', 'HLTPIon' )

--- a/HLTrigger/Configuration/test/OnLine_HLT_2014.py
+++ b/HLTrigger/Configuration/test/OnLine_HLT_2014.py
@@ -54927,6 +54927,11 @@ cmsswVersion = os.environ['CMSSW_VERSION']
 # none for now
 
 
+# from CMSSW_7_2_0_pre6: Use Legacy Errors in "StripCPEESProducer" for HLT (PRs 5286/5151)
+if cmsswVersion > "CMSSW_7_1":
+    if 'hltESPStripCPEfromTrackAngle' in process.__dict__:
+        process.hltESPStripCPEfromTrackAngle.useLegacyError = cms.bool(True)
+
 # adapt HLT modules to the correct process name
 if 'hltTrigReport' in process.__dict__:
     process.hltTrigReport.HLTriggerResults                    = cms.InputTag( 'TriggerResults', '', 'HLT2014' )

--- a/HLTrigger/Configuration/test/OnLine_HLT_2014.py
+++ b/HLTrigger/Configuration/test/OnLine_HLT_2014.py
@@ -54924,11 +54924,8 @@ process = customizeHLTforMC(process)
 import os
 cmsswVersion = os.environ['CMSSW_VERSION']
 
-# none for now
-
-
 # from CMSSW_7_2_0_pre6: Use Legacy Errors in "StripCPEESProducer" for HLT (PRs 5286/5151)
-if cmsswVersion > "CMSSW_7_1":
+if cmsswVersion >= "CMSSW_7_2":
     if 'hltESPStripCPEfromTrackAngle' in process.__dict__:
         process.hltESPStripCPEfromTrackAngle.useLegacyError = cms.bool(True)
 

--- a/HLTrigger/Configuration/test/OnLine_HLT_FULL.py
+++ b/HLTrigger/Configuration/test/OnLine_HLT_FULL.py
@@ -29023,11 +29023,8 @@ process = customizeHLTforMC(process)
 import os
 cmsswVersion = os.environ['CMSSW_VERSION']
 
-# none for now
-
-
 # from CMSSW_7_2_0_pre6: Use Legacy Errors in "StripCPEESProducer" for HLT (PRs 5286/5151)
-if cmsswVersion > "CMSSW_7_1":
+if cmsswVersion >= "CMSSW_7_2":
     if 'hltESPStripCPEfromTrackAngle' in process.__dict__:
         process.hltESPStripCPEfromTrackAngle.useLegacyError = cms.bool(True)
 

--- a/HLTrigger/Configuration/test/OnLine_HLT_FULL.py
+++ b/HLTrigger/Configuration/test/OnLine_HLT_FULL.py
@@ -29026,6 +29026,11 @@ cmsswVersion = os.environ['CMSSW_VERSION']
 # none for now
 
 
+# from CMSSW_7_2_0_pre6: Use Legacy Errors in "StripCPEESProducer" for HLT (PRs 5286/5151)
+if cmsswVersion > "CMSSW_7_1":
+    if 'hltESPStripCPEfromTrackAngle' in process.__dict__:
+        process.hltESPStripCPEfromTrackAngle.useLegacyError = cms.bool(True)
+
 # adapt HLT modules to the correct process name
 if 'hltTrigReport' in process.__dict__:
     process.hltTrigReport.HLTriggerResults                    = cms.InputTag( 'TriggerResults', '', 'HLTFULL' )

--- a/HLTrigger/Configuration/test/OnLine_HLT_GRun.py
+++ b/HLTrigger/Configuration/test/OnLine_HLT_GRun.py
@@ -25077,6 +25077,11 @@ cmsswVersion = os.environ['CMSSW_VERSION']
 # none for now
 
 
+# from CMSSW_7_2_0_pre6: Use Legacy Errors in "StripCPEESProducer" for HLT (PRs 5286/5151)
+if cmsswVersion > "CMSSW_7_1":
+    if 'hltESPStripCPEfromTrackAngle' in process.__dict__:
+        process.hltESPStripCPEfromTrackAngle.useLegacyError = cms.bool(True)
+
 # adapt HLT modules to the correct process name
 if 'hltTrigReport' in process.__dict__:
     process.hltTrigReport.HLTriggerResults                    = cms.InputTag( 'TriggerResults', '', 'HLTGRun' )

--- a/HLTrigger/Configuration/test/OnLine_HLT_GRun.py
+++ b/HLTrigger/Configuration/test/OnLine_HLT_GRun.py
@@ -25074,11 +25074,8 @@ process = customizeHLTforMC(process)
 import os
 cmsswVersion = os.environ['CMSSW_VERSION']
 
-# none for now
-
-
 # from CMSSW_7_2_0_pre6: Use Legacy Errors in "StripCPEESProducer" for HLT (PRs 5286/5151)
-if cmsswVersion > "CMSSW_7_1":
+if cmsswVersion >= "CMSSW_7_2":
     if 'hltESPStripCPEfromTrackAngle' in process.__dict__:
         process.hltESPStripCPEfromTrackAngle.useLegacyError = cms.bool(True)
 

--- a/HLTrigger/Configuration/test/OnLine_HLT_HIon.py
+++ b/HLTrigger/Configuration/test/OnLine_HLT_HIon.py
@@ -8324,11 +8324,8 @@ process = customizeHLTforMC(process)
 import os
 cmsswVersion = os.environ['CMSSW_VERSION']
 
-# none for now
-
-
 # from CMSSW_7_2_0_pre6: Use Legacy Errors in "StripCPEESProducer" for HLT (PRs 5286/5151)
-if cmsswVersion > "CMSSW_7_1":
+if cmsswVersion >= "CMSSW_7_2":
     if 'hltESPStripCPEfromTrackAngle' in process.__dict__:
         process.hltESPStripCPEfromTrackAngle.useLegacyError = cms.bool(True)
 

--- a/HLTrigger/Configuration/test/OnLine_HLT_HIon.py
+++ b/HLTrigger/Configuration/test/OnLine_HLT_HIon.py
@@ -8327,6 +8327,11 @@ cmsswVersion = os.environ['CMSSW_VERSION']
 # none for now
 
 
+# from CMSSW_7_2_0_pre6: Use Legacy Errors in "StripCPEESProducer" for HLT (PRs 5286/5151)
+if cmsswVersion > "CMSSW_7_1":
+    if 'hltESPStripCPEfromTrackAngle' in process.__dict__:
+        process.hltESPStripCPEfromTrackAngle.useLegacyError = cms.bool(True)
+
 # adapt HLT modules to the correct process name
 if 'hltTrigReport' in process.__dict__:
     process.hltTrigReport.HLTriggerResults                    = cms.InputTag( 'TriggerResults', '', 'HLTHIon' )

--- a/HLTrigger/Configuration/test/OnLine_HLT_PIon.py
+++ b/HLTrigger/Configuration/test/OnLine_HLT_PIon.py
@@ -8327,6 +8327,11 @@ cmsswVersion = os.environ['CMSSW_VERSION']
 # none for now
 
 
+# from CMSSW_7_2_0_pre6: Use Legacy Errors in "StripCPEESProducer" for HLT (PRs 5286/5151)
+if cmsswVersion > "CMSSW_7_1":
+    if 'hltESPStripCPEfromTrackAngle' in process.__dict__:
+        process.hltESPStripCPEfromTrackAngle.useLegacyError = cms.bool(True)
+
 # adapt HLT modules to the correct process name
 if 'hltTrigReport' in process.__dict__:
     process.hltTrigReport.HLTriggerResults                    = cms.InputTag( 'TriggerResults', '', 'HLTPIon' )

--- a/HLTrigger/Configuration/test/OnLine_HLT_PIon.py
+++ b/HLTrigger/Configuration/test/OnLine_HLT_PIon.py
@@ -8324,11 +8324,8 @@ process = customizeHLTforMC(process)
 import os
 cmsswVersion = os.environ['CMSSW_VERSION']
 
-# none for now
-
-
 # from CMSSW_7_2_0_pre6: Use Legacy Errors in "StripCPEESProducer" for HLT (PRs 5286/5151)
-if cmsswVersion > "CMSSW_7_1":
+if cmsswVersion >= "CMSSW_7_2":
     if 'hltESPStripCPEfromTrackAngle' in process.__dict__:
         process.hltESPStripCPEfromTrackAngle.useLegacyError = cms.bool(True)
 


### PR DESCRIPTION
Fix StripCPEESProducer config to use Legacy Error Calculation in HLT
