### PR TITLE
fix to #5149: 'generator' and 'extendedgen' made exclusive

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_extendedgen.py
+++ b/Configuration/PyReleaseValidation/python/relval_extendedgen.py
@@ -10,24 +10,21 @@ workflows = Matrix()
 # if no explicit name/label given for the workflow (first arg),
 # the name of step1 will be used
 
+# 'generator' the base set of relval for generators
+# 'extendedgen' extends the base set to a more thorough assesment of GEN
+# the two sets are exclusive
+
 # LO Generators
-workflows[501]=['',['MinBias_TuneZ2star_13TeV_pythia6','HARVGEN']]
-workflows[502]=['',['QCD_Pt-30_TuneZ2star_13TeV_pythia6','HARVGEN']]
-workflows[503]=['',['MinBias_13TeV_pythia8','HARVGEN']]
-workflows[504]=['',['QCD_Pt-30_13TeV_pythia8','HARVGEN']]
 workflows[505]=['',['DYToLL_M-50_13TeV_pythia8','HARVGEN']]
 workflows[506]=['',['WToLNu_13TeV_pythia8','HARVGEN']]
 workflows[507]=['',['SoftQCDDiffractive_13TeV_pythia8','HARVGEN']]
 workflows[508]=['',['SoftQCDnonDiffractive_13TeV_pythia8','HARVGEN']]
 workflows[509]=['',['SoftQCDelastic_13TeV_pythia8','HARVGEN']]
 workflows[510]=['',['SoftQCDinelastic_13TeV_pythia8','HARVGEN']]
-workflows[511]=['',['QCD_Pt-30_8TeV_herwigpp','HARVGEN']]
 
 # Matrix Element Generations (LHE Generation)
 
 # Hadronization (Hadronization of LHE)
-workflows[512]=['',['ZJetsLL_13TeV_madgraph-pythia8','HARVGEN']]
-workflows[513]=['',['WJetsLNu_13TeV_madgraph-pythia8','HARVGEN']]
 workflows[514]=['',['GGToH_13TeV_pythia8','HARVGEN']]
 workflows[515]=['',['ZJetsLLtaupinu_13TeV_madgraph-pythia8','HARVGEN']]
 workflows[516]=['',['WJetsLNutaupinu_13TeV_madgraph-pythia8','HARVGEN']]
@@ -37,9 +34,6 @@ workflows[519]=['',['WJetsLNutaurhonu_13TeV_madgraph-pythia8','HARVGEN']]
 workflows[520]=['',['GGToHtaurhonu_13TeV_pythia8','HARVGEN']]
 
 # External Decays
-workflows[521]=['',['TT_13TeV_pythia8-evtgen','HARVGEN']]
-workflows[522]=['',['DYToLL_M-50_13TeV_pythia8-tauola','HARVGEN']]
-workflows[523]=['',['WToLNu_13TeV_pythia8-tauola','HARVGEN']]
 workflows[524]=['',['GGToH_13TeV_pythia8-tauola','HARVGEN']]
 workflows[525]=['',['WToLNutaupinu_13TeV_pythia8-tauola','HARVGEN']]
 workflows[526]=['',['DYToLLtaupinu_M-50_13TeV_pythia8-tauola','HARVGEN']]
@@ -49,7 +43,6 @@ workflows[529]=['',['DYToLLtaurhonu_M-50_13TeV_pythia8-tauola','HARVGEN']]
 workflows[530]=['',['GGToHtaurhonu_13TeV_pythia8-tauola','HARVGEN']]
 
 # Heavy Ion
-workflows[531]=['',['ReggeGribovPartonMC_EposLHC_5TeV_pPb','HARVGEN']]
 #workflows[532]=['',['Hijing_PPb_MinimumBias','HARVGEN']]
 
 # Miscellaneous

--- a/Configuration/PyReleaseValidation/python/relval_generator.py
+++ b/Configuration/PyReleaseValidation/python/relval_generator.py
@@ -10,6 +10,10 @@ workflows = Matrix()
 # if no explicit name/label given for the workflow (first arg),
 # the name of step1 will be used
 
+# 'generator' the base set of relval for generators
+# 'extendedgen' extends the base set to a more thorough assesment of GEN
+# the two sets are exclusive
+
 # LO Generators
 workflows[501]=['',['MinBias_TuneZ2star_13TeV_pythia6','HARVGEN']]
 workflows[502]=['',['QCD_Pt-30_TuneZ2star_13TeV_pythia6','HARVGEN']]
@@ -30,6 +34,5 @@ workflows[523]=['',['WToLNu_13TeV_pythia8-tauola','HARVGEN']]
 
 # Heavy Ion
 workflows[531]=['',['ReggeGribovPartonMC_EposLHC_5TeV_pPb','HARVGEN']]
-#workflows[532]=['',['Hijing_PPb_MinimumBias','HARVGEN']]
 
 # Miscellaneous


### PR DESCRIPTION
- 'generator' the base set of relval for generators
- 'extendedgen' extends the base set to a more thorough assesment of GEN
- the two sets are exclusive
