### PR TITLE
DQMEDHarvester: fix the inheritance

### DIFF
--- a/DQMServices/Core/interface/DQMEDHarvester.h
+++ b/DQMServices/Core/interface/DQMEDHarvester.h
@@ -1,9 +1,10 @@
 #ifndef CORE_DQMED_HARVESTER_H
-# define CORE_DQMED_HARVESTER_H
+#define CORE_DQMED_HARVESTER_H
 
 //<<<<<< INCLUDES                                                       >>>>>>
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
+
 //<<<<<< PUBLIC DEFINES                                                 >>>>>>
 //<<<<<< PUBLIC CONSTANTS                                               >>>>>>
 //<<<<<< PUBLIC TYPES                                                   >>>>>>
@@ -12,16 +13,17 @@
 //<<<<<< CLASS DECLARATIONS                                             >>>>>>
 
 class DQMEDHarvester
-: public edm::one::EDAnalyzer<edm::one::SharedResources>
+: public edm::one::EDAnalyzer<edm::one::WatchRuns,edm::one::WatchLuminosityBlocks,edm::one::SharedResources>
 {
 public:
   DQMEDHarvester(void);
   // implicit copy constructor
   // implicit assignment operator
   // implicit destructor
-  virtual void beginRun(edm::Run const&, edm::EventSetup const&) {};
+  virtual void beginRun(edm::Run const&, edm::EventSetup const&) final {};
   virtual void analyze(edm::Event const&, edm::EventSetup const&) final {};
-  virtual void endRun(edm::Run const&, edm::EventSetup const&) {};
+  virtual void endRun(edm::Run const&, edm::EventSetup const&) final {};
+  virtual void beginLuminosityBlock(edm::LuminosityBlock const &, edm::EventSetup const&) final {};
   virtual void endLuminosityBlock(edm::LuminosityBlock const &, edm::EventSetup const&) final;
   virtual void endJob() final;
   virtual void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const&) {};

--- a/DQMServices/Core/interface/DQMEDHarvester.h
+++ b/DQMServices/Core/interface/DQMEDHarvester.h
@@ -20,9 +20,9 @@ public:
   // implicit copy constructor
   // implicit assignment operator
   // implicit destructor
-  virtual void beginRun(edm::Run const&, edm::EventSetup const&) final {};
+  virtual void beginRun(edm::Run const&, edm::EventSetup const&) {};
   virtual void analyze(edm::Event const&, edm::EventSetup const&) final {};
-  virtual void endRun(edm::Run const&, edm::EventSetup const&) final {};
+  virtual void endRun(edm::Run const&, edm::EventSetup const&) {};
   virtual void beginLuminosityBlock(edm::LuminosityBlock const &, edm::EventSetup const&) final {};
   virtual void endLuminosityBlock(edm::LuminosityBlock const &, edm::EventSetup const&) final;
   virtual void endJob() final;


### PR DESCRIPTION
Fix the inheritance of DQMEDHarvester in order to properly receive and handle the begin/end Lumi and Run transitions.
