### PR TITLE
restore assert ValidationEventGenerator 4tau decays

### DIFF
--- a/Validation/EventGenerator/src/HepMCValidationHelper.cc
+++ b/Validation/EventGenerator/src/HepMCValidationHelper.cc
@@ -185,7 +185,7 @@ namespace HepMCValidationHelper {
     for (unsigned int i = 0; i < taus.size(); ++i){
       std::vector<const HepMC::GenParticle*> taudaughters;
       findDescendents(taus[i], taudaughters);
-      //assert(taudaughters.size()>0);
+      assert(taudaughters.size()>0);
       if ( taudaughters.size()==0 ) {
 	edm::LogError("HepMCValidationHelper") << "Tau with no daughters. This is a bug. Fix it";
 	continue;


### PR DESCRIPTION
restore assert ValidationEventGenerator 4tau decays; it'll re-introduced the check to asses the fix of #5119 

@inugent @bendavid : please confirm that indeed with #5119 already merged, the tau decay is now fixed.

And please, if that is the case, confirm in an email to cms-PPD-PdmV-val-admin@cern.ch that we need to re-do GEN-SIM for 72_pre6
