### PR TITLE
Enable Address Sanitizer and debug information

### DIFF
--- a/FWCore/Framework/bin/BuildFile.xml
+++ b/FWCore/Framework/bin/BuildFile.xml
@@ -1,5 +1,5 @@
 <architecture name="slc[6-9]_amd64">
-  <flags LDFLAGS="-Wl,-dynamic-linker,$(GLIBC_BASE)/lib64/ld.so"/>
+  <flags LDFLAGS="-Wl,-dynamic-linker,$(GLIBC_BASE)/lib64/ld.so -fsanitize=address -static-libasan"/>
 </architecture>
 <bin   name="cmsRunGlibC" file="cmsRun.cpp">
   <use   name="roothistmatrix"/>

--- a/FWCore/ParameterSet/bin/BuildFile.xml
+++ b/FWCore/ParameterSet/bin/BuildFile.xml
@@ -1,3 +1,6 @@
+<architecture name="slc[6-9]_amd64">
+  <flags LDFLAGS="-Wl,-dynamic-linker,$(GLIBC_BASE)/lib64/ld.so -fsanitize=address -static-libasan"/>
+</architecture>
 <use   name="boost"/>
 <use   name="FWCore/ParameterSet"/>
 <bin   file="edmPluginHelp.cpp">

--- a/FWCore/PluginManager/bin/BuildFile.xml
+++ b/FWCore/PluginManager/bin/BuildFile.xml
@@ -3,7 +3,7 @@
   <use   name="boost_program_options"/>
   <use   name="FWCore/PluginManager"/>
 <architecture name="slc[6-9]_amd64">
-  <flags LDFLAGS="-Wl,-dynamic-linker,$(GLIBC_BASE)/lib64/ld.so"/>
+  <flags LDFLAGS="-Wl,-dynamic-linker,$(GLIBC_BASE)/lib64/ld.so -fsanitize=address -static-libasan"/>
 </architecture>
 </bin>
 <bin   name="edmPluginRefresh" file="refresh.cc">
@@ -11,6 +11,6 @@
   <use   name="boost_program_options"/>
   <use   name="FWCore/PluginManager"/>
 <architecture name="slc[6-9]_amd64">
-  <flags LDFLAGS="-Wl,-dynamic-linker,$(GLIBC_BASE)/lib64/ld.so"/>
+  <flags LDFLAGS="-Wl,-dynamic-linker,$(GLIBC_BASE)/lib64/ld.so -fsanitize=address -static-libasan"/>
 </architecture>
 </bin>


### PR DESCRIPTION
All compiler and linker invocations must have Address Sanitizer (ASan)
enabled. Because we do not have a full stack compiled with ASan we have
to link-in ASan run-time staticlly into critical executables to get
ASan initialized.

Additional flags are required to get accurate pointer to a file and
line.

ASan built software will run slower and require atleast double the
memory.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
