### PR TITLE
Silence static analyzer warning for BXVector

### DIFF
--- a/DataFormats/L1Trigger/interface/BXVector.h
+++ b/DataFormats/L1Trigger/interface/BXVector.h
@@ -93,7 +93,7 @@ class BXVector  {
   // this method converts integer BX index into an unsigned index
   // used by the internal data representation
   unsigned indexFromBX(int bx) const;
-  unsigned numBX() const {return (unsigned) bxLast_ - bxFirst_; }
+  unsigned numBX() const {return static_cast<const unsigned>(bxLast_) - bxFirst_; }
 
  private:
 


### PR DESCRIPTION
The static analyzer was complaining about a C style cast casting
away const on an integral value. Although this case was harmless
since the value was only read, the cast was changed to a static_cast.
