### PR TITLE
Provide only const access to ME0EtaPartitions

### DIFF
--- a/Geometry/GEMGeometry/interface/ME0Geometry.h
+++ b/Geometry/GEMGeometry/interface/ME0Geometry.h
@@ -50,7 +50,7 @@ class ME0Geometry : public TrackingGeometry {
   //---- Extension of the interface
 
   /// Return a vector of all ME0 eta partitions
-  const std::vector<ME0EtaPartition*>& etaPartitions() const;
+  const std::vector<ME0EtaPartition const*>& etaPartitions() const;
 
   /// Return a etaPartition given its id
   const ME0EtaPartition* etaPartition(ME0DetId id) const;
@@ -68,7 +68,7 @@ class ME0Geometry : public TrackingGeometry {
   // Map for efficient lookup by DetId 
   mapIdToDet theMap;
 
-  std::vector<ME0EtaPartition*> allEtaPartitions; // Are not owned by this class; are owned by their chamber.
+  std::vector<ME0EtaPartition const*> allEtaPartitions; // Are not owned by this class; are owned by their chamber.
 
 };
 

--- a/Geometry/GEMGeometry/src/ME0Geometry.cc
+++ b/Geometry/GEMGeometry/src/ME0Geometry.cc
@@ -54,7 +54,7 @@ const std::vector<ME0Chamber*>& ME0Geometry::chambers() const {
 */
 
 
-const std::vector<ME0EtaPartition*>& ME0Geometry::etaPartitions() const{
+const std::vector<ME0EtaPartition const*>& ME0Geometry::etaPartitions() const{
   return allEtaPartitions;
 }
 


### PR DESCRIPTION
The const function ME0Geometry::etaPartitions() was allowing non-const
access to the ME0EtaPartitions. This modification fixes that in order
to avoid thread safety issues.
