### PR TITLE
Converted MultiTrackSelector from global to stream

### DIFF
--- a/RecoTracker/FinalTrackSelectors/plugins/MultiTrackSelector.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/MultiTrackSelector.cc
@@ -187,7 +187,7 @@ MultiTrackSelector::~MultiTrackSelector() {
 }
 
 
-void MultiTrackSelector::beginJob() {
+void MultiTrackSelector::beginStream(edm::StreamID) {
   if(!useForestFromDB_){
      TFile gbrfile(dbFileName_.c_str());
        forest_ = (GBRForest*)gbrfile.Get(forestLabel_.c_str());

--- a/RecoTracker/FinalTrackSelectors/plugins/MultiTrackSelector.h
+++ b/RecoTracker/FinalTrackSelectors/plugins/MultiTrackSelector.h
@@ -15,7 +15,7 @@
 #include <memory>
 #include <algorithm>
 #include <map>
-#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -32,7 +32,7 @@
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
 #include "CondFormats/EgammaObjects/interface/GBRForest.h"
 
-    class dso_hidden MultiTrackSelector : public edm::global::EDProducer<> {
+    class dso_hidden MultiTrackSelector : public edm::stream::EDProducer<> {
         private:
         public:
             /// constructor 
@@ -42,7 +42,7 @@
             virtual ~MultiTrackSelector() ;
 
         protected:
-            void beginJob() final;
+            void beginStream(edm::StreamID) override final;
  
             // void streamBeginRun(edm::StreamID, edm::Run const&, edm::EventSetup const&) const final {
             //  init();
@@ -52,7 +52,7 @@
 
             typedef math::XYZPoint Point;
             /// process one event
-            void produce(edm::StreamID, edm::Event& evt, const edm::EventSetup& es ) const final {
+            void produce(edm::Event& evt, const edm::EventSetup& es ) override final {
                run(evt,es);
             }
             virtual void run( edm::Event& evt, const edm::EventSetup& es ) const;
@@ -87,6 +87,7 @@
 
             /// vertex cuts
 	    std::vector<int32_t> vtxNumber_;
+	    //StringCutObjectSelector is not const thread safe
 	    std::vector<StringCutObjectSelector<reco::Vertex> > vertexCut_;
 
 	    //  parameters for adapted optimal cuts on chi2 and primary vertex compatibility


### PR DESCRIPTION
Helgrind identified a race condition in MultiTrackSelector. The problem
was StringCutObjectSelector is not const thread safe (i.e. it has a const
function which modifies its internal state) and therefore only one thread
at a time can call it. Therefore MultiTrackSelector can not simultaneously
talk to multiple events which means it can not be a global module. However, 
converting the module to a stream module is thread safe.
