### PR TITLE
Hide messy stuff from rootcling

### DIFF
--- a/FWCore/MessageLogger/interface/ELseverityLevel.h
+++ b/FWCore/MessageLogger/interface/ELseverityLevel.h
@@ -53,6 +53,7 @@ namespace edm {
 class ELseverityLevel;
 
 
+#ifndef __ROOTCLING__
 // ----------------------------------------------------------------------
 // Synonym for type of ELseverityLevel-generating function:
 // ----------------------------------------------------------------------
@@ -90,6 +91,7 @@ struct ELslProxy  {
   const ELstring  getVarName()  const;
 
 };  // ELslProxy<ELslGen>
+#endif
 
 // ----------------------------------------------------------------------
 
@@ -155,6 +157,7 @@ private:
 };  // ELseverityLevel
 
 
+#ifndef __ROOTCLING__
 // ----------------------------------------------------------------------
 // Declare the globally available severity objects,
 // one generator function and one proxy per non-default ELsev_:
@@ -183,6 +186,16 @@ extern ELslProxy< ELsevereGen          > const  ELsevere;
 
 extern ELslGen  ELhighestSeverityGen;
 extern ELslProxy< ELhighestSeverityGen > const  ELhighestSeverity;
+#else
+ELseverityLevel const  ELzeroSeverity;
+ELseverityLevel const  ELdebug;
+ELseverityLevel const  ELinfo;
+ELseverityLevel const  ELwarning;
+ELseverityLevel const  ELerror;
+ELseverityLevel const  ELunspecified;
+ELseverityLevel const  ELsevere;
+ELseverityLevel const  ELhighestSeverity;
+#endif
 
 
 // ----------------------------------------------------------------------
@@ -210,9 +223,11 @@ extern bool  operator>= ( ELseverityLevel const & e1
 
 // ----------------------------------------------------------------------
 
+#ifndef __ROOTCLING__
 #define ELSEVERITYLEVEL_ICC
   #include "FWCore/MessageLogger/interface/ELseverityLevel.icc"
 #undef  ELSEVERITYLEVEL_ICC
+#endif
 
 
 // ----------------------------------------------------------------------


### PR DESCRIPTION
A recently introduced bug in ROOT6 causes non-fatal runtime error messages because there are missing forward declarations corresponding to the dictionary in FWCore/MessageLogger.
This pull request hides the offending types from rootcling (genreflex), so the error messages are not observed.
This workaround can remain permanently, because the types in question are not persisted, and do not need to be known to rootcling.
Please merge this pull request as soon as convenient.
