### PR TITLE
72X - fix division by zero

### DIFF
--- a/PhysicsTools/MVATrainer/src/ProcNormalize.cc
+++ b/PhysicsTools/MVATrainer/src/ProcNormalize.cc
@@ -46,7 +46,7 @@ class ProcNormalize : public TrainProcessor {
 
 	virtual bool load() override;
 	virtual void save() override;
-	
+
     private:
 	enum Iteration {
 		ITER_EMPTY,
@@ -174,9 +174,10 @@ void ProcNormalize::configure(DOMElement *elem)
 
 	if (pdfs.size() != nInputs * nCategories)
 		throw cms::Exception("ProcNormalize")
-			<< "Got " << (pdfs.size() / nCategories)
-			<< " pdf configs for " << nInputs
-			<< " input varibles." << std::endl;
+			<< "Got " << pdfs.size()
+			<< " pdf configs in total for " << nCategories
+			<< " categories and " << nInputs
+			<< " input varibles (" << (nInputs * nCategories) << " in total)." << std::endl;
 }
 
 Calibration::VarProcessor *ProcNormalize::getCalibration() const
@@ -522,7 +523,7 @@ void ProcNormalize::save()
 		    iter->distr.begin(); iter2 != iter->distr.end(); iter2++) {
 			DOMElement *value =
 					doc->createElement(XMLUniStr("value"));
-			elem->appendChild(value);	
+			elem->appendChild(value);
 
 			XMLDocument::writeContent<double>(value, doc, *iter2);
 		}

--- a/PhysicsTools/MVATrainer/test/BuildFile.xml
+++ b/PhysicsTools/MVATrainer/test/BuildFile.xml
@@ -1,5 +1,6 @@
 <bin name="testMVATrainer" file="testMVATrainer.cpp">
-   <use name="FWCore/Utilities"/>
+  <use name="FWCore/Utilities"/>
+   <use name="FWCore/ParameterSet"/>
    <use name="PhysicsTools/MVAComputer"/>
    <use name="PhysicsTools/MVATrainer"/>
 </bin>

--- a/PhysicsTools/MVATrainer/test/testMVATrainer.cpp
+++ b/PhysicsTools/MVATrainer/test/testMVATrainer.cpp
@@ -14,6 +14,8 @@
 
 #include "PhysicsTools/MVATrainer/interface/MVATrainer.h"
 
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+
 using namespace PhysicsTools;
 
 static double gauss()
@@ -57,7 +59,8 @@ static void train(MVAComputer *computer)
 
 void test()
 {
-	MVATrainer trainer("testMVATrainer.xml");
+	edm::FileInPath file("PhysicsTools/MVATrainer/test/testMVATrainer.xml");
+	MVATrainer trainer(file.fullPath());
 
 	for(;;) {
 		std::auto_ptr<Calibration::MVAComputer> calib(

--- a/Utilities/StaticAnalyzers/scripts/run_class_checker.sh
+++ b/Utilities/StaticAnalyzers/scripts/run_class_checker.sh
@@ -19,7 +19,7 @@ cd ${LOCALRT}/src/Utilities/StaticAnalyzers
 scram b -j $J
 cd ${LOCALRT}/
 export USER_CXXFLAGS="-DEDM_ML_DEBUG -w"
-export USER_LLVM_CHECKERS="-enable-checker threadsafety -enable-checker optional.ClassChecker -enable-checker cms.FunctionChecker"
+export USER_LLVM_CHECKERS="-enable-checker threadsafety -enable-checker optional.ClassChecker -enable-checker cms.FunctionChecker -enable-checker cms.ThrUnsafeFCallChecker"
 scram b -k -j $J checker  SCRAM_IGNORE_PACKAGES=Fireworks/% SCRAM_IGNORE_SUBDIRS=test 2>&1 > ${LOCALRT}/tmp/class+function-checker.log
 cd ${LOCALRT}/tmp/
 touch check-end

--- a/Utilities/StaticAnalyzers/scripts/statics.py
+++ b/Utilities/StaticAnalyzers/scripts/statics.py
@@ -31,6 +31,9 @@ for line in f :
 		if fields[2] == ' static variable ' :
 			G.add_edge(fields[1],fields[3],kind=' static variable ')
 			statics.add(fields[3])
+		if fields[2] == ' known thread unsafe function ' :
+			G.add_edge(fields[1],fields[3],kind=' known thread unsafe function ')
+			statics.add(fields[3])
 f.close()
 for tfunc in sorted(toplevelfuncs):
 	for static in sorted(statics): 

--- a/Utilities/StaticAnalyzers/src/ClangCmsCheckerPluginRegister.cpp
+++ b/Utilities/StaticAnalyzers/src/ClangCmsCheckerPluginRegister.cpp
@@ -22,6 +22,7 @@
 #include "FunctionChecker.h"
 #include "FunctionDumper.h"
 #include "EDMPluginDumper.h"
+#include "ThrUnsafeFCallChecker.h"
 
 #include <clang/StaticAnalyzer/Core/CheckerRegistry.h>
 
@@ -50,6 +51,7 @@ void clang_registerCheckers ( clang::ento::CheckerRegistry &registry)
 	registry.addChecker< clangcms::FunctionChecker>( "cms.FunctionChecker", "Reports functions which access non-const statics" );
 	registry.addChecker< clangcms::FunctionDumper>( "cms.FunctionDumper", "Reports function calls and overrides" );
 	registry.addChecker< clangcms::EDMPluginDumper>( "optional.EDMPluginDumper", "Dumps macro DEFINE_EDM_PLUGIN types" );
+	registry.addChecker< clangcms::ThrUnsafeFCallChecker>( "cms.ThrUnsafeFCallChecker", "Reports calls of known thread unsafe functions" );
 }
 
 extern "C"

--- a/Utilities/StaticAnalyzers/src/CmsSupport.cpp
+++ b/Utilities/StaticAnalyzers/src/CmsSupport.cpp
@@ -89,37 +89,31 @@ std::string support::getQualifiedName(const clang::NamedDecl &d) {
 }
 
 
-bool support::isSafeClassName(const std::string &name) {
-  static const std::string atomic = "std::atomic";
-  static const std::string satomic = "struct std::atomic";
-  static const std::string uatomic = "std::__atomic_";
-  static const std::string mutex = "std::mutex";
-  static const std::string rmutex = "std::recursive_mutex";
-  static const std::string btsp = "boost::thread_specific_ptr";
-  static const std::string catomic = "class std::atomic";
-  static const std::string cuatomic = "class std::__atomic_";
-  static const std::string cmutex = "class std::mutex";
-  static const std::string crmutex = "class std::recursive_mutex";
-  static const std::string cbtsp = "class boost::thread_specific_ptr";
-  static const std::string tbb = "tbb::";
-  static const std::string ctbb = "class tbb::";
-  static const std::string eap = "edm::AtomicPtrCache";
-  static const std::string ceap = "class edm::AtomicPtrCache";
-  static const std::string once = "std::once_flag";
-  static const std::string conce = "struct std::once_flag";
-  static const std::string boostext = "boost::<anonymous namespace>::extents";
+bool support::isSafeClassName(const std::string &cname) {
+
+  static const std::vector<std::string> names = {
+    "std::atomic",
+    "struct std::atomic",
+    "std::__atomic_",
+    "std::mutex",
+    "std::recursive_mutex",
+    "boost::thread_specific_ptr",
+    "class std::atomic",
+    "class std::__atomic_",
+    "class std::mutex",
+    "class std::recursive_mutex",
+    "class boost::thread_specific_ptr",
+    "tbb::",
+    "class tbb::",
+    "edm::AtomicPtrCache",
+    "class edm::AtomicPtrCache"
+    "std::once_flag",
+    "struct std::once_flag",
+    "boost::<anonymous namespace>::extents"
+  };
   
-  if ( name.substr(0,atomic.length()) == atomic || name.substr(0,catomic.length()) == catomic || name.substr(0,satomic.length()) == satomic
-	|| name.substr(0,uatomic.length()) == uatomic  || name.substr(0,cuatomic.length()) == cuatomic
-	|| name.substr(0,mutex.length()) == mutex || name.substr(0,cmutex.length()) == cmutex 
-	|| name.substr(0,rmutex.length()) == rmutex || name.substr(0,crmutex.length()) == rmutex 
-	|| name.substr(0,btsp.length()) == btsp || name.substr(0,cbtsp.length()) == cbtsp 
-	|| name.substr(0,ctbb.length()) == ctbb ||  name.substr(0,tbb.length()) == tbb
-	|| name.substr(0,eap.length()) == eap || name.substr(0,ceap.length()) == ceap
-	|| name.substr(0,once.length()) == once || name.substr(0,conce.length()) == conce
-	|| name.substr(0,boostext.length()) == boostext
-	) 
-	return true;	
+  for (auto& name: names)
+  	if ( cname.substr(0,name.length()) == name ) return true;	
   return false;
 }
 
@@ -160,4 +154,19 @@ bool support::isInterestingLocation(const std::string & name) {
 	if ( name[0] == '<' && name.find(".h")==std::string::npos ) return false;
 	if ( name.find("/test/") != std::string::npos ) return false;
 	return true;
+}
+
+bool support::isKnownThrUnsafeFunc(const std::string &fname ) {
+	static const std::vector<std::string> names = {
+		"TGraph::Fit(const char *,", 
+		"TGraph2D::Fit(const char *,", 
+		"TH1::Fit(const char *,", 
+		"TMultiGraph::Fit(const char *,", 
+		"TTable::Fit(const char *,", 
+		"TTree::Fit(const char *,", 
+		"TTreePlayer::Fit(const char *,"
+	};
+	for (auto& name: names)
+  		if ( fname.substr(0,name.length()) == name ) return true;	
+	return false;
 }

--- a/Utilities/StaticAnalyzers/src/CmsSupport.cpp
+++ b/Utilities/StaticAnalyzers/src/CmsSupport.cpp
@@ -34,6 +34,8 @@ bool support::isCmsLocalFile(const char* file)
   if ((DirLen==0) || (strncmp(file,LocalDir,DirLen)!=0) || (strncmp(&file[DirLen],"/src/",5)!=0)) return false;
   return true;
 }
+
+
 // This is a wrapper around NamedDecl::getQualifiedNameAsString.
 // It produces more qualified output to distinguish several cases
 // which would otherwise be ambiguous.
@@ -85,6 +87,7 @@ std::string support::getQualifiedName(const clang::NamedDecl &d) {
 
   return ret;
 }
+
 
 bool support::isSafeClassName(const std::string &name) {
   static const std::string atomic = "std::atomic";
@@ -151,4 +154,10 @@ bool support::isDataClass(const std::string & name) {
 		if ( line == os.str() ) return true;
 	}
 	return false;
+}
+
+bool support::isInterestingLocation(const std::string & name) {
+	if ( name[0] == '<' && name.find(".h")==std::string::npos ) return false;
+	if ( name.find("/test/") != std::string::npos ) return false;
+	return true;
 }

--- a/Utilities/StaticAnalyzers/src/CmsSupport.h
+++ b/Utilities/StaticAnalyzers/src/CmsSupport.h
@@ -48,6 +48,7 @@ bool isCmsLocalFile(const char* file);
 std::string getQualifiedName(const clang::NamedDecl &d);
 bool isSafeClassName(const std::string &d);
 bool isDataClass(const std::string &d);
+bool isInterestingLocation(const std::string &d);
 }
 } 
 

--- a/Utilities/StaticAnalyzers/src/CmsSupport.h
+++ b/Utilities/StaticAnalyzers/src/CmsSupport.h
@@ -49,6 +49,7 @@ std::string getQualifiedName(const clang::NamedDecl &d);
 bool isSafeClassName(const std::string &d);
 bool isDataClass(const std::string &d);
 bool isInterestingLocation(const std::string &d);
+bool isKnownThrUnsafeFunc(const std::string &name );
 }
 } 
 

--- a/Utilities/StaticAnalyzers/src/ThrUnsafeFCallChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/ThrUnsafeFCallChecker.cpp
@@ -1,0 +1,83 @@
+#include "ThrUnsafeFCallChecker.h"
+using namespace clang;
+using namespace ento;
+using namespace llvm;
+
+namespace clangcms {
+
+class TUFWalker : public clang::StmtVisitor<TUFWalker> {
+  clang::ento::BugReporter &BR;
+  clang::AnalysisDeclContext *AC;
+
+public:
+  TUFWalker(clang::ento::BugReporter &br, clang::AnalysisDeclContext *ac )
+    : BR(br),
+      AC(ac) {}
+
+  void VisitChildren(clang::Stmt *S );
+  void VisitStmt( clang::Stmt *S) { VisitChildren(S); }
+  void VisitCXXMemberCallExpr( clang::CXXMemberCallExpr *CE );
+ 
+};
+
+void TUFWalker::VisitChildren( clang::Stmt *S) {
+  for (clang::Stmt::child_iterator I = S->child_begin(), E = S->child_end(); I!=E; ++I)
+    if (clang::Stmt *child = *I) {
+      Visit(child);
+    }
+}
+
+
+
+void TUFWalker::VisitCXXMemberCallExpr( CXXMemberCallExpr *CE ) {
+	CXXMethodDecl * MD = CE->getMethodDecl();
+	if (!MD) return;
+	const CXXMethodDecl * PD = llvm::dyn_cast<CXXMethodDecl>(AC->getDecl());
+	if (!PD) return;
+	std::string mname = support::getQualifiedName(*MD);
+	std::string pname = support::getQualifiedName(*PD);
+	llvm::SmallString<100> buf;
+	llvm::raw_svector_ostream os(buf);
+	if ( support::isKnownThrUnsafeFunc(mname) ) {
+		os << "Known thread unsafe function " << mname << " is called in function " << pname;
+		PathDiagnosticLocation CELoc = PathDiagnosticLocation::createBegin(CE, BR.getSourceManager(),AC);
+ 		BugType * BT = new BugType("known thread unsafe function called","optional");
+		BugReport * R = new BugReport(*BT,os.str(),CELoc);
+		R->addRange(CE->getSourceRange());
+		BR.emitReport(R);
+	}
+		
+		
+}
+
+void ThrUnsafeFCallChecker::checkASTDecl(const CXXMethodDecl *MD, AnalysisManager& mgr,
+                    BugReporter &BR) const {
+       	const SourceManager &SM = BR.getSourceManager();
+       	PathDiagnosticLocation DLoc =PathDiagnosticLocation::createBegin( MD, SM );
+	if ( SM.isInSystemHeader(DLoc.asLocation()) || SM.isInExternCSystemHeader(DLoc.asLocation()) ) return;
+       	if (!MD->doesThisDeclarationHaveABody()) return;
+	clangcms::TUFWalker walker(BR, mgr.getAnalysisDeclContext(MD));
+	walker.Visit(MD->getBody());
+       	return;
+} 
+
+void ThrUnsafeFCallChecker::checkASTDecl(const FunctionTemplateDecl *TD, AnalysisManager& mgr,
+                    BugReporter &BR) const {
+	const clang::SourceManager &SM = BR.getSourceManager();
+	clang::ento::PathDiagnosticLocation DLoc =clang::ento::PathDiagnosticLocation::createBegin( TD, SM );
+	if ( SM.isInSystemHeader(DLoc.asLocation()) || SM.isInExternCSystemHeader(DLoc.asLocation()) ) return;
+
+	for (FunctionTemplateDecl::spec_iterator I = const_cast<clang::FunctionTemplateDecl *>(TD)->spec_begin(), 
+			E = const_cast<clang::FunctionTemplateDecl *>(TD)->spec_end(); I != E; ++I) 
+		{
+			if (I->doesThisDeclarationHaveABody()) {
+				clangcms::TUFWalker walker(BR, mgr.getAnalysisDeclContext(*I));
+				walker.Visit(I->getBody());
+				}
+		}	
+	return;
+}
+
+
+
+}

--- a/Utilities/StaticAnalyzers/src/ThrUnsafeFCallChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/ThrUnsafeFCallChecker.cpp
@@ -1,4 +1,10 @@
 #include "ThrUnsafeFCallChecker.h"
+#include <iostream>
+#include <fstream>
+#include <iterator>
+#include <string>
+
+
 using namespace clang;
 using namespace ento;
 using namespace llvm;
@@ -45,6 +51,14 @@ void TUFWalker::VisitCXXMemberCallExpr( CXXMemberCallExpr *CE ) {
 		BugReport * R = new BugReport(*BT,os.str(),CELoc);
 		R->addRange(CE->getSourceRange());
 		BR.emitReport(R);
+		const char * pPath = std::getenv("LOCALRT");
+		std::string tname = ""; 
+		if ( pPath != NULL ) tname += std::string(pPath);
+		tname+="/tmp/function-checker.txt.unsorted";
+		std::string ostring =  "function '"+ pname + "' known thread unsafe function '" + mname + "'.\n";
+		std::ofstream file(tname.c_str(),std::ios::app);
+		file<<ostring;
+	
 	}
 		
 		

--- a/Utilities/StaticAnalyzers/src/ThrUnsafeFCallChecker.h
+++ b/Utilities/StaticAnalyzers/src/ThrUnsafeFCallChecker.h
@@ -1,0 +1,43 @@
+#ifndef Utilities_StaticAnalyzers_ThrUnsafeFCallChecker_h
+#define Utilities_StaticAnalyzers_ThrUnsafeFCallChecker_h
+#include <clang/AST/DeclCXX.h>
+#include <clang/AST/Decl.h>
+#include <clang/AST/DeclTemplate.h>
+#include <clang/AST/StmtVisitor.h>
+#include <clang/AST/ParentMap.h>
+#include <clang/Analysis/CFGStmtMap.h>
+#include <clang/Analysis/CallGraph.h>
+#include <llvm/Support/SaveAndRestore.h>
+#include <clang/StaticAnalyzer/Core/PathSensitive/AnalysisManager.h>
+#include <clang/StaticAnalyzer/Core/PathSensitive/CallEvent.h>
+#include <clang/StaticAnalyzer/Core/Checker.h>
+#include <clang/StaticAnalyzer/Core/BugReporter/BugReporter.h>
+#include <clang/StaticAnalyzer/Core/BugReporter/BugType.h>
+#include <llvm/ADT/SmallString.h>
+
+#include "CmsException.h"
+#include "CmsSupport.h"
+
+namespace clangcms {
+
+class ThrUnsafeFCallChecker : public clang::ento::Checker< clang::ento::check::ASTDecl<clang::CXXMethodDecl>,
+						clang::ento::check::ASTDecl<clang::FunctionTemplateDecl> > 
+{
+  mutable clang::OwningPtr< clang::ento::BugType> BT;
+
+
+public:
+
+  void checkASTDecl(const clang::CXXMethodDecl *CMD, clang::ento::AnalysisManager& mgr,
+                    clang::ento::BugReporter &BR) const ;
+
+  void checkASTDecl(const clang::FunctionTemplateDecl *TD, clang::ento::AnalysisManager& mgr,
+                    clang::ento::BugReporter &BR) const ;
+
+
+private:
+  CmsException m_exception;
+};
+
+}
+#endif


### PR DESCRIPTION
Trivial change to output message plus usage of `edm::FileInPath` in integration test code.
Automatically ported from CMSSW_7_2_X#5337
