### PR TITLE
DQM info summary fix for online LS reporting

### DIFF
--- a/DQMServices/Components/src/DQMProvInfo.cc
+++ b/DQMServices/Components/src/DQMProvInfo.cc
@@ -183,21 +183,11 @@ DQMProvInfo::endLuminosityBlock(const edm::LuminosityBlock& l, const edm::EventS
   // set to previous in case there was a jump or no previous fill
   for (int l=lastlumi_+1;l<nlumi;l++)
   {
-    if (lastlumi_ > 0 && reportSummaryMap_->getBinContent(lastlumi_,YBINS+1) == 1) 
-    {
-      reportSummaryMap_->setBinContent(l,YBINS+1,0.);
-      for (int i=0;i<YBINS;i++)
-      {
-	  float lastvalue = reportSummaryMap_->getBinContent(lastlumi_,i+1);
-	  reportSummaryMap_->setBinContent(l,i+1,lastvalue);
-      }
-    }
-    else
-    {
-      reportSummaryMap_->setBinContent(l,YBINS+1,0.);
-      for (int i=0;i<YBINS;i++)
-	reportSummaryMap_->setBinContent(l,i+1,-1.);
-    }
+    // setting valid flag to zero for missed LSs
+    reportSummaryMap_->setBinContent(l,YBINS+1,0.);
+    // setting all other bins to -1 for missed LSs
+    for (int i=0;i<YBINS;i++)
+      reportSummaryMap_->setBinContent(l,i+1,-1.);
   }
 
       


### PR DESCRIPTION
Reporting missing LS in DQM info summary as white bins instead of extrapolating last conditions in previous LSs, needed for online running.
