### PR TITLE
Fixing comment for JetDeltaRValueMapProducer

### DIFF
--- a/CommonTools/RecoAlgos/plugins/JetDeltaRValueMapProducer.cc
+++ b/CommonTools/RecoAlgos/plugins/JetDeltaRValueMapProducer.cc
@@ -1,8 +1,8 @@
-/* \class PFJetSelector
+/* \class JetDeltaRValueMapProducer
  *
- * Selects jets with a configurable string-based cut,
- * and also writes out the constituents of the jet
- * into a separate collection.
+ * Associates jets using delta-R matching, and writes out
+ * a valuemap of single float variables based on a StringObjectFunction. 
+ * This is used for miniAOD. 
  *
  * \author: Sal Rappoccio
  *


### PR DESCRIPTION
The comment for the file JetDeltaRValueMapProducer.cc is completely copied (wrongly) from another module.
I fixed it to have the correct comment for posterity and to avoid confusion.

(As if anyone but my future self will ever read this file). 

http://xkcd.com/1421/

Automatically ported from CMSSW_7_2_X #5353
