### PR TITLE
Clean couts validation seq

### DIFF
--- a/DQMOffline/L1Trigger/src/L1TRate_Offline.cc
+++ b/DQMOffline/L1Trigger/src/L1TRate_Offline.cc
@@ -113,7 +113,7 @@ void L1TRate_Offline::beginRun(const edm::Run& run, const edm::EventSetup& iSetu
   m_ErrorMonitor->setBinLabel(UNKNOWN               ,"UNKNOWN");
   m_ErrorMonitor->setBinLabel(WARNING_PY_MISSING_FIT,"WARNING_PY_MISSING_FIT");
 
-  cout << "[L1TRate_Offline:] m_ErrorMonitor: " << m_ErrorMonitor << endl;
+  if (m_verbose) {cout << "[L1TRate_Offline:] m_ErrorMonitor: " << m_ErrorMonitor << endl;}
 
   // Retriving the list of prescale sets
   m_listsPrescaleFactors = &(m_l1GtPfAlgo->gtPrescaleFactors());

--- a/JetMETCorrections/Type1MET/python/correctionTermsPfMetType0PFCandidate_cff.py
+++ b/JetMETCorrections/Type1MET/python/correctionTermsPfMetType0PFCandidate_cff.py
@@ -12,4 +12,9 @@ correctionTermsPfMetType0PFCandidate = cms.Sequence(
     corrPfMetType0PfCand
     )
 
+correctionTermsPfMetType0PFCandidateForValidation = cms.Sequence(
+    type0PFMEtCorrectionPFCandToVertexAssociationForValidation +
+    corrPfMetType0PfCand
+    )
+
 ##____________________________________________________________________________||

--- a/JetMETCorrections/Type1MET/python/pfMETCorrectionType0_cfi.py
+++ b/JetMETCorrections/Type1MET/python/pfMETCorrectionType0_cfi.py
@@ -48,8 +48,8 @@ pfMETcorrType0 = cms.EDProducer("Type0PFMETcorrInputProducer",
 #--------------------------------------------------------------------------------
 
 type0PFMEtCorrectionPFCandToVertexAssociation = cms.Sequence(
-    selectedVerticesForPFMEtCorrType0
-   * selectedPrimaryVertexHighestPtTrackSumForPFMEtCorrType0
+    cms.ignore(selectedVerticesForPFMEtCorrType0)
+   * cms.ignore(selectedPrimaryVertexHighestPtTrackSumForPFMEtCorrType0)
    * particleFlowDisplacedVertex
    * pfCandidateToVertexAssociation
 )

--- a/JetMETCorrections/Type1MET/python/pfMETCorrectionType0_cfi.py
+++ b/JetMETCorrections/Type1MET/python/pfMETCorrectionType0_cfi.py
@@ -48,6 +48,13 @@ pfMETcorrType0 = cms.EDProducer("Type0PFMETcorrInputProducer",
 #--------------------------------------------------------------------------------
 
 type0PFMEtCorrectionPFCandToVertexAssociation = cms.Sequence(
+    selectedVerticesForPFMEtCorrType0
+   * selectedPrimaryVertexHighestPtTrackSumForPFMEtCorrType0
+   * particleFlowDisplacedVertex
+   * pfCandidateToVertexAssociation
+)
+
+type0PFMEtCorrectionPFCandToVertexAssociationForValidation = cms.Sequence(
     cms.ignore(selectedVerticesForPFMEtCorrType0)
    * cms.ignore(selectedPrimaryVertexHighestPtTrackSumForPFMEtCorrType0)
    * particleFlowDisplacedVertex

--- a/Validation/RecoEgamma/plugins/PhotonValidator.cc
+++ b/Validation/RecoEgamma/plugins/PhotonValidator.cc
@@ -263,8 +263,7 @@ void PhotonValidator::bookHistograms( DQMStore::IBooker & iBooker, edm::Run cons
   
   
   iBooker.setCurrentFolder("EgammaV/"+fName_+"/SimulationInfo");
-  std::cout <<"made directory "<<"EgammaV/"+fName_+"/SimulationInfo"<<std::endl;
-  //
+
   // simulation information about all MC photons found
   std::string histname = "nOfSimPhotons";
   if ( ! isRunCentrally_ ) {
@@ -366,7 +365,6 @@ void PhotonValidator::bookHistograms( DQMStore::IBooker & iBooker, edm::Run cons
   //
   histname = "h_SimConvOneMTracksEta";
   h_SimConvOneMTracks_[0] =  iBooker.book1D(histname," All vis conversions with 1 reco-matching tracks: simulated #eta",etaBin2,etaMin, etaMax);
-  std::cout <<"monitor element "<<h_SimConvOneMTracks_[0]->getFullname()<<std::endl;
   histname = "h_SimConvOneMTracksPhi";
   h_SimConvOneMTracks_[1] =  iBooker.book1D(histname," All vis conversions with 1 reco-matching tracks: simulated #phi",phiBin,phiMin, phiMax);
   histname = "h_SimConvOneMTracksR";
@@ -1649,7 +1647,6 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
 
   nEvt_++;
   LogInfo("PhotonValidator") << "PhotonValidator Analyzing event number: " << e.id() << " Global Counter " << nEvt_ <<"\n";
-  //  std::cout << "PhotonValidator Analyzing event number: "  << e.id() << " Global Counter " << nEvt_ <<"\n";
 
 
   // get the geometry from the event setup:
@@ -1693,48 +1690,23 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
     }
     phoToParticleBasedIsoMap = *(phoToParticleBasedIsoMapHandle.product());
   }
-  ///// debug
-  unsigned nObj=photonHandle->size();
-  if ( fName_ == "pfPhotonValidator") {
-    //std::cout << "    photonHandle->size() " << photonHandle->size() << std::endl;
-    for(unsigned int lCand=0; lCand < nObj; lCand++) { 
-      //std::cout << "  I am in the loop " << std::endl;
-      reco::PhotonRef photonRef (reco::PhotonRef( photonHandle,lCand));
-      //std::cout << "  photon SC energy " << photonRef->superCluster()->energy() << " " <<  phoToParticleBasedIsoMap[photonRef].size() <<  std::endl;
-      for( std::vector<reco::PFCandidateRef>::const_iterator i = phoToParticleBasedIsoMap[photonRef].begin(); i != phoToParticleBasedIsoMap[photonRef].end(); ++i ) {
-	//if ( (*i).isNonnull() ) {
-	// float dR= deltaR(photonRef->eta(),  photonRef->phi(), (*i)->eta(),  (*i)->phi() );
-	//  std::cout << " Debugging  Candidate dR " << dR << " type " << (*i)->particleId() << " pt " << (*i)->pt() <<  std::endl;
-	  //	}
-       }
-    }
-  }
-
-
-
 
   Handle< edm::View<reco::Track> > outInTrkHandle;
   Handle< edm::View<reco::Track> > inOutTrkHandle;
   if ( !fastSim_) {
     //// Get the Out In CKF tracks from conversions
     e.getByToken(conversionOITrackPr_Token_, outInTrkHandle);
-    //std::cout << "ConvPhoAnalyzerWithOfficialAssociation  outInTrack collection size " << (*outInTrkHandle).size() << "\n";
-
     //// Get the In Out  CKF tracks from conversions
     e.getByToken(conversionIOTrackPr_Token_, inOutTrkHandle);
-    //std::cout  << " ConvPhoAnalyzerWithOfficialAssociation inOutTrack collection size " << (*inOutTrkHandle).size() << "\n";
 
     // Loop over Out In Tracks
     int iTrk=0;
     int nHits=0;
     for( View<reco::Track>::const_iterator    iTk = outInTrkHandle->begin(); iTk !=  outInTrkHandle->end(); iTk++) {
-      //    std::cout  << " Barrel  Out In Track charge " << iTk->charge() << " Num of RecHits " << iTk->recHitsSize() << " inner momentum " << sqrt( iTk->innerMomentum().Mag2() ) << "\n";
-      // std::cout  << " Barrel Out In Track Extra inner momentum  " << sqrt(iTk->extra()->innerMomentum().Mag2()) <<  " inner position R " <<  sqrt( iTk->innerPosition().Perp2() ) << "\n";
       h_OIinnermostHitR_ ->Fill ( sqrt( iTk->innerPosition().Perp2() ) );
       for (  trackingRecHit_iterator itHits=iTk->extra()->recHitsBegin();  itHits!=iTk->extra()->recHitsEnd(); ++itHits ) {
 		if ( (*itHits)->isValid() ) {
 		    nHits++;
-		    //	cout <<nHits <<") RecHit in GP " <<  trackerGeom->idToDet((*itHits)->geographicalId())->surface().toGlobal((*itHits)->localPosition()) << " R "<< trackerGeom->idToDet((*itHits)->geographicalId())->surface().toGlobal((*itHits)->localPosition()).perp() << " Z " << trackerGeom->idToDet((*itHits)->geographicalId())->surface().toGlobal((*itHits)->localPosition()).z() << "\n";
 		}
 
 		
@@ -1748,15 +1720,11 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
     // Loop over In Out Tracks Barrel
     iTrk=0;
     for( View<reco::Track>::const_iterator    iTk =  inOutTrkHandle->begin(); iTk !=  inOutTrkHandle->end(); iTk++) {
-      //std::cout  << " Barrel In Out Track charge " << iTk->charge() << " Num of RecHits " << iTk->recHitsSize() << " inner momentum " << sqrt( iTk->innerMomentum().Mag2())  << "\n";
-      // std::cout   << " Barrel In Out  Track Extra inner momentum  " << sqrt(iTk->extra()->innerMomentum().Mag2()) << "\n";
       h_IOinnermostHitR_ ->Fill ( sqrt( iTk->innerPosition().Perp2() ) );
       nHits=0;
       for (  trackingRecHit_iterator itHits=iTk->extra()->recHitsBegin();  itHits!=iTk->extra()->recHitsEnd(); ++itHits ) {
     	if ( (*itHits)->isValid() ) {
     	  nHits++;
-	  //cout <<nHits <<") RecHit in GP " << trackerGeom->idToDet((*itHits)->geographicalId())->surface().toGlobal((*itHits)->localPosition())  << " R "<< trackerGeom->idToDet((*itHits)->geographicalId())->surface().toGlobal((*itHits)->localPosition()).perp() << " Z " << trackerGeom->idToDet((*itHits)->geographicalId())->surface().toGlobal((*itHits)->localPosition()).z() << "\n";
-
       	}
       }
       iTrk++;
@@ -2118,28 +2086,16 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
 	    ||  (mother != 0  && mother->pdg_id() == 25)
 	    ||  (mother != 0  && mother->pdg_id() == 35) )
       {
-        //std::cout << " ZERO mother or Higgs or primary photon  " << std::endl;
-        //if (mother !=0) std::cout <<  mother->pdg_id() << std::endl;
         double dPt =  fabs((*mcIter)->momentum().perp() - (*mcPho).fourMomentum().et());
         float phiMother=(*mcIter)->momentum().phi();
         double dPhi = phiNormalization(phiMother) - mcPhi_ ;
         double dEta = fabs( (*mcIter)->momentum().eta() - (*mcPho).fourMomentum().pseudoRapidity() );
 
-        //std::cout << " HEP photon pt " << (*mcIter)->momentum().perp() << " eta " << (*mcIter)->momentum().eta() << " phi " << (*mcIter)->momentum().phi() << std::endl;
-        //std::cout << "   (*mcPho).motherType() selection  " <<   (*mcPho).motherType() << " pt " <<  (*mcPho).fourMomentum().et()  << " eta " << (*mcPho).fourMomentum().pseudoRapidity() << " phi " << mcPhi_ << std::endl;
-        //std::cout << " dPt " << dPt << " dEta " << dEta << " dPhi " << dPhi << std::endl;
         if ( dEta <=0.0001 && dPhi <=0.0001 && dPt <=0.0001)
           isTheSame = true;
 
       }
       if ( ! isTheSame ) continue;
-      //      std::cout << " HEP photon pt " << (*mcIter)->momentum().perp() << " eta " << (*mcIter)->momentum().eta() << " phi " << (*mcIter)->momentum().phi() << std::endl;
-      //std::cout << "   (*mcPho).motherType() after  " <<   (*mcPho).motherType() << " pt " <<  (*mcPho).fourMomentum().et()  << " eta " << (*mcPho).fourMomentum().pseudoRapidity() << " phi " << mcPhi_ << std::endl;
-
-
-
-      // if ( ! (  fabs(mcEta_) <= BARL || ( fabs(mcEta_) >= END_LO && fabs(mcEta_) <=END_HI ) ) )
-      //	continue;  // all ecal fiducial region
 
       nSimPho_[0]++;
       if ( ! isRunCentrally_ ) {
@@ -2177,25 +2133,15 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
 
 
 	theConvTP_.clear();
-	//std::cout << " PhotonValidator TrackingParticles   TrackingParticleCollection size "<<  trackingParticles.size() <<  "\n";
 	for(size_t i = 0; i < trackingParticles.size(); ++i){
 	  TrackingParticleRef tp (ElectronTPHandle,i);
-	  //std::cout << "  Electron pt " << tp -> pt() << " charge " << tp -> charge() << " pdgId " << tp->pdgId() << " Hits for this track: " << tp -> trackPSimHit().size() << std::endl;
-	  //std::cout << " track vertex position x " <<  tp->vertex().x() << " y " << tp->vertex().y() << " z " << tp->vertex().z() << std::endl;
-	  //std::cout << " track vertex position x " <<  tp->vx() << " y " << tp->vy() << " z " << tp->vz() << std::endl;
-	  //std::cout << " conversion vertex position x " <<  (*mcPho).vertex().x() << " y " << (*mcPho).vertex().y() << " z " << (*mcPho).vertex().z() << std::endl;
 	  if ( fabs( tp->vx() - (*mcPho).vertex().x() ) < 0.001   &&
 	       fabs( tp->vy() - (*mcPho).vertex().y() ) < 0.001   &&
 	       fabs( tp->vz() - (*mcPho).vertex().z() ) < 0.001) {
 
-	    //std::cout << " From conversion Electron pt " << tp -> pt() << " charge " << tp -> charge() << " pdgId " << tp->pdgId() << " Hits for this track: " << tp -> trackPSimHit().size() << std::endl;
-	    //	std::cout << " track vertex position x " <<  tp->vertex().x() << " y " << tp->vertex().y() << " z " << tp->vertex().z() << std::endl;
-	    //std::cout << " conversion vertex position x " <<  (*mcPho).vertex().x() << " y " << (*mcPho).vertex().y() << " z " << (*mcPho).vertex().z() << "  R " <<  (*mcPho).vertex().perp() << std::endl;
 	    theConvTP_.push_back( tp );
 	  }
 	}
-	//      std::cout << " PhotonValidator  theConvTP_ size " <<   theConvTP_.size() << std::endl;
-
 	if ( theConvTP_.size() == 2 )   visibleConversionsWithTwoSimTracks=true;
 	goodSimConversion=false;
 
@@ -2229,7 +2175,6 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
       int iMatch=-1;
       bool matched=false;
 
-      //std::cout << " Reco photon size " <<  photonCollection.size() << std::endl;
       for(unsigned int iPho=0; iPho < photonHandle->size(); iPho++) {
 	reco::PhotonRef aPho(reco::PhotonRef(photonHandle, iPho));
 	thePhotons.push_back(aPho);
@@ -2250,7 +2195,6 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
 	index++;
       }  // end loop over reco photons
       if ( iMatch>-1 ) matched=true;
-      //std::cout << " Debug 1 " << std::endl;
 
       if ( matched ) {
 	nSimPho_[1]++;
@@ -2284,7 +2228,6 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
 	if ( matchingPho->superCluster()->position().eta() < 0) phoIsInEndcapM=true;
 
       }
-      //std::cout << " Debug 1.1 " << std::endl;
 
       edm::Handle<EcalRecHitCollection>   ecalRecHitHandle;
       if ( phoIsInBarrel ) {
@@ -2340,9 +2283,6 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
       int   nClusterOutsideMustache = matchingPho->nClusterOutsideMustache();
       float pfMVA = matchingPho->pfMVA();
 
-      ///
-
-      //std::cout << " Debug 1.2 " << std::endl;
       std::vector< std::pair<DetId, float> >::const_iterator rhIt;
       bool atLeastOneDeadChannel=false;
       for(reco::CaloCluster_iterator bcIt = matchingPho->superCluster()->clustersBegin();bcIt != matchingPho->superCluster()->clustersEnd(); ++bcIt) {
@@ -2359,7 +2299,6 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
 	}
       }
 
-      //std::cout << " Debug 1.3 " << std::endl;
       if (   atLeastOneDeadChannel ) {
 	h_MatchedSimPhoBadCh_[0]->Fill( mcEta_ ) ;
 	h_MatchedSimPhoBadCh_[1]->Fill( mcPhi_ );
@@ -2415,7 +2354,6 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
 
       //
       h_ecalRecHitSumEtConeDR04_[type][0]->Fill( ecalIso );
-      //std::cout << " Debug 1.4 " << std::endl;
       if ( ! isRunCentrally_ ) {
 	h2_ecalRecHitSumEtConeDR04VsEta_[0] -> Fill (mcEta_, ecalIso );
 	h2_ecalRecHitSumEtConeDR04VsEt_[0] -> Fill ((*mcPho).fourMomentum().et(), ecalIso);
@@ -2481,7 +2419,6 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
       if ( ! isRunCentrally_ ) p_eResVsR9_[0]->Fill (r9, photonE/(*mcPho).fourMomentum().e()  ) ;
       if ( ! isRunCentrally_ ) p_sceResVsR9_[0]->Fill (r9,  matchingPho->superCluster()->energy()/(*mcPho).fourMomentum().e()  ) ;
       //
-      //std::cout << " Debug 1.6 " << std::endl;
       if (  (*mcPho).isAConversion() == 0 ) {
 	if ( ! isRunCentrally_ ) {
 	  h2_eResVsEta_[1]->Fill (mcEta_, photonE/ (*mcPho).fourMomentum().e()  ) ;
@@ -2500,10 +2437,6 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
 	  h2_hOverEVsEt_[1] -> Fill ((*mcPho).fourMomentum().et(), hOverE);
 	}
 
-	//std::cout << " Debug 1.7 " << std::endl;
-
-	
-	//
 	if ( ! isRunCentrally_ ) {
 	  h2_ecalRecHitSumEtConeDR04VsEta_[1] -> Fill (mcEta_, ecalIso );
 	  h2_hcalTowerSumEtConeDR04VsEta_[1] -> Fill (mcEta_, hcalIso );
@@ -2515,14 +2448,11 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
 	}
 	p_ecalRecHitSumEtConeDR04VsEta_[1] -> Fill (mcEta_, ecalIso );
 	if ( ! isRunCentrally_ ) p_hcalTowerSumEtConeDR04VsEta_[1] -> Fill (mcEta_, hcalIso );
-	//
-	//std::cout << " Debug 1.8 " << std::endl;
       }
 
       
 
       if ( photonE/(*mcPho).fourMomentum().e()  < 0.3 &&   photonE/(*mcPho).fourMomentum().e() > 0.1 ) {
-	//      std::cout << " Eta sim " << mcEta_ << " sc eta " << matchingPho->superCluster()->eta() << " pho eta " << matchingPho->eta() << std::endl;
 
       }
 
@@ -2555,8 +2485,6 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
 	}
 
       }
-
-      //std::cout << " Debug 1.9 " << std::endl;
 
       if ( phoIsInBarrel ) {
 	h_scE_[type][1]->Fill( matchingPho->superCluster()->energy() );
@@ -2603,7 +2531,6 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
 	p_sigmaEoEVsEt_[1][0] ->Fill ((*mcPho).fourMomentum().et(),sigmaEoE);
 	p_sigmaEoEVsNVtx_[1][0]->Fill ( float(vtxH->size()), sigmaEoE);
 
-	//std::cout << " Debug 1.10 " << std::endl;
 	if ( r9 > 0.94 ) {
 	  h_phoERes_[1][1]->Fill(  photonE  / (*mcPho).fourMomentum().e() );
 	  h_phoSigmaEoE_[1][1] -> Fill (sigmaEoE);
@@ -2629,16 +2556,13 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
 	    h_EtR9Less093_[0][1] ->Fill ( photonEt );
 	  }
 	}
-	//std::cout << " Debug 1.11 " << std::endl;
       }
       if ( phoIsInEndcap ) {
-	//std::cout << " Looking for troubles 1 " << std::endl;
 	h_scE_[type][2]->Fill( matchingPho->superCluster()->energy() );
 	h_scEt_[type][2]->Fill( matchingPho->superCluster()->energy()/cosh( matchingPho->superCluster()->eta()) );
 	h_r9_[type][2]->Fill( r9 );
 	h_r1_[type][2]->Fill( r1 );
 	h_r2_[type][2]->Fill( r2 );
-	//std::cout << " Looking for troubles 2 " << std::endl;
 	h_sigmaIetaIeta_[type][2]->Fill( sigmaIetaIeta );
 	h_hOverE_[type][2]->Fill( hOverE );
 	h_newhOverE_[type][2]->Fill( newhOverE );
@@ -2646,18 +2570,15 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
 	p_ecalRecHitSumEtConeDR04VsEt_[2] -> Fill ((*mcPho).fourMomentum().et(), ecalIso);
 	h_hcalTowerSumEtConeDR04_[type][2]->Fill( hcalIso );
         p_hcalTowerSumEtConeDR04VsEt_[2] -> Fill ((*mcPho).fourMomentum().et(), hcalIso);
-	//std::cout << " Looking for troubles 3 " << std::endl;
 	h_hcalTowerBcSumEtConeDR04_[type][2]->Fill( newhcalIso );
         p_hcalTowerBcSumEtConeDR04VsEt_[2] -> Fill ((*mcPho).fourMomentum().et(), newhcalIso);
 	h_isoTrkSolidConeDR04_[type][2]->Fill( trkIso );
 	h_nTrkSolidConeDR04_[type][2]->Fill( nIsoTrk );
-	//std::cout << " Looking for troubles 4 " << std::endl;
 	h_chHadIso_[2]-> Fill (chargedHadIso);
 	h_nHadIso_[2]-> Fill (neutralHadIso);
 	h_phoIso_[2]-> Fill (photonIso);
 	h_nCluOutsideMustache_[2]->Fill(float(nClusterOutsideMustache));
 	h_etOutsideMustache_[2]->Fill(etOutsideMustache);
-	//std::cout << " Looking for troubles 5 " << std::endl;
 	h_pfMva_[2]->Fill(pfMVA);
 	h_phoE_[type][2]->Fill( photonE );
 	h_phoEt_[type][2]->Fill( photonEt );
@@ -2665,10 +2586,8 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
 	h_nConv_[1][2]->Fill(float( matchingPho->conversionsOneLeg().size()));
 	h_phoERes_[0][2]->Fill( photonE / (*mcPho).fourMomentum().e() );
 	h_phoSigmaEoE_[0][2] -> Fill (sigmaEoE);
-	//std::cout << " Looking for troubles 6 " << std::endl;
 	h_phoEResRegr1_[0][2]->Fill( photonERegr1 / (*mcPho).fourMomentum().e() );
 	h_phoEResRegr2_[0][2]->Fill( photonERegr2 / (*mcPho).fourMomentum().e() );
-	//std::cout << " Looking for troubles 7 " << std::endl;
         p_eResVsR9_[2]->Fill (r9, photonE/(*mcPho).fourMomentum().e()  ) ;
 	p_sceResVsR9_[2]->Fill (r9,  matchingPho->superCluster()->energy()/(*mcPho).fourMomentum().e()  ) ;
 	if ( ! isRunCentrally_ ) {
@@ -2678,7 +2597,6 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
 	  h2_hcalTowerSumEtConeDR04VsEt_[2] -> Fill ((*mcPho).fourMomentum().et(), hcalIso);
 	  h2_eResVsEt_[2][0]->Fill ((*mcPho).fourMomentum().et(), photonE/(*mcPho).fourMomentum().e()  ) ;
 	}
-	//std::cout << " Debug 1.12 " << std::endl;
 
 	p_eResVsEt_[2][0]->Fill ((*mcPho).fourMomentum().et(), photonE/(*mcPho).fourMomentum().e()  ) ;
 	p_eResVsNVtx_[2][0]->Fill ( float(vtxH->size()), photonE/(*mcPho).fourMomentum().e()  ) ;
@@ -2712,7 +2630,6 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
 	    h_EtR9Less093_[0][2] ->Fill ( photonEt );
 	  }
 	}
-	//std::cout << " Debug 1.13 " << std::endl;
       }
 
       ///////////////////////   Particle based isolation
@@ -2762,7 +2679,6 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
 	    ////////// acces the value map to access the PFCandidates in overlap with the photon which need to be excluded from the isolation
             bool skip=false;
 	    for( std::vector<reco::PFCandidateRef>::const_iterator i = phoToParticleBasedIsoMap[matchingPho].begin(); i != phoToParticleBasedIsoMap[matchingPho].end(); ++i ) {
-	      //	      std::cout << " PhotonValidator PfCand pt " << pfCandRef->pt() << " id " <<pfCandRef->particleId() <<  " and in the map " << (*i)->pt() << " type " << (*i)->particleId() << std::endl;
 	      if ( (*i) == pfCandRef ) {
 		skip=true;
 	      }
@@ -2827,7 +2743,6 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
 
       if ( ! (visibleConversion &&  visibleConversionsWithTwoSimTracks ) ) continue;
       
-      //      std::cout << " Debug 1.14 " << std::endl;
 
       if ( ! isRunCentrally_ ) {
 	h_r9_[1][0]->Fill( r9 );
@@ -2845,7 +2760,6 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
 
 
       if ( ! fastSim_) {
-	//std::cout << " Conversion size " <<  matchingPho->conversions().size() << std::endl;
 	////////////////// plot quantities related to conversions
 	reco::ConversionRefVector conversions = matchingPho->conversions();
         bool atLeastOneRecoTwoTrackConversion=false;
@@ -2876,8 +2790,6 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
 	    if ( fabs( aConv->pairCotThetaSeparation() ) > dCotCutValue_ ) continue;
 	  }
 
-	  //std::cout << " PhotonValidator converison algo name " << aConv->algoName() << " " << aConv->algo() << std::endl;
-
 	  nRecConv_++;
 
 	  std::map<const reco::Track*,TrackingParticleRef> myAss;
@@ -2896,8 +2808,6 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
 	    p_nHitsVsEta_[type] ->Fill (mcEta_,   float(tracks[i]->numberOfValidHits()-0.0001) );
 	    p_nHitsVsR_[type] ->Fill (mcConvR_,   float(tracks[i]->numberOfValidHits()-0.0001) );
 	    h_tkChi2_[type] ->Fill (tracks[i]->normalizedChi2() );
-
-	    //std::cout << " Debug 1.15 " << std::endl;
 
 	    RefToBase<reco::Track> tfrb = tracks[i];
 	    RefToBaseVector<reco::Track> tc;
@@ -2922,31 +2832,6 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
 	  }
 
 
-	  //std::cout << " Debug 1.16 " << std::endl;
-
-
-          /*
- /////////// fill my local track - trackingparticle association map
- TrackingParticleRef myTP;
- for (size_t j = 0; j < RtoSCollPtrs.size(); j++) {
- reco::RecoToSimCollection q = *(RtoSCollPtrs[j]);
-
- RefToBase<reco::Track> myTk( track );
-
- if( q.find(myTk ) != q.end() ) {
- std::vector<std::pair<TrackingParticleRef, double> > tp = q[myTk];
- for (unsigned int itp=0; itp<tp.size(); itp++) {
- myTP=tp[itp].first;
- //      std::cout << " associated with TP " << myTP->pdgId() << " pt " << sqrt(myTP->momentum().perp2()) << std::endl;
- myAss.insert( std::make_pair ( track  , myTP) );
- nAssT2++;
- }
- }
- }
- }
-	  */
-
-
 	  type=0;
 
 	  //	  float totP = sqrt(aConv->pairMomentum().Mag2());
@@ -2962,8 +2847,6 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
 	  if ( phoIsInBarrel ) h_invMass_[type][1] ->Fill(invM);
 	  if ( phoIsInEndcap ) h_invMass_[type][2] ->Fill(invM);
 
-	  //std::cout << " Debug 1.17 " << std::endl;
-
 	  ////////// Numerators for conversion absolute efficiency
 	  if ( tracks.size() ==2 ) {
 	    
@@ -2973,9 +2856,7 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
 	    h_SimConvTwoTracks_[3]->Fill( mcConvZ_ );
 	    h_SimConvTwoTracks_[4]->Fill(  (*mcPho).fourMomentum().et());
 
-	    //std::cout << " Debug 1.17.1 " << std::endl;
 	    if (aConv->caloCluster().size() !=0) h_convEta_[1]->Fill( aConv->caloCluster()[0]->eta() );
-	    //std::cout << " Debug 1.17.2 " << std::endl;
 
 	    float trkProvenance=3;
 	    if ( tracks[0]->algoName() == "outInEcalSeededConv"  &&  tracks[1]->algoName() == "outInEcalSeededConv" ) trkProvenance=0;
@@ -2983,7 +2864,6 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
 	    if ( ( tracks[0]->algoName() == "outInEcalSeededConv"  &&  tracks[1]->algoName() == "inOutEcalSeededConv") ||
 		 ( tracks[1]->algoName() == "outInEcalSeededConv"  &&  tracks[0]->algoName() == "inOutEcalSeededConv") ) trkProvenance=2;
 	    if ( trkProvenance==3 ) {
-	      // std::cout << " PhotonValidator provenance of tracks is " << tracks[0]->algoName() << " and " << tracks[1]->algoName() << std::endl;
 	    }
 	    h_trkProv_[0]->Fill( trkProvenance );
             h_trkAlgo_->Fill (  tracks[0]->algo() );
@@ -3012,7 +2892,6 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
 	      h_SimConvTwoMTracks_[4]->Fill(  (*mcPho).fourMomentum().et());
 
 	      if ( aConv->conversionVertex().isValid() ) {
-		//if ( trkProvenance==3 ) std::cout << " PhotonValidator provenance of tracks is mixed and vertex is valid " << std::endl;
 		float chi2Prob = ChiSquaredProbability( aConv->conversionVertex().chi2(),  aConv->conversionVertex().ndof() );
 		if (   chi2Prob > 0) {
 		  h_SimConvTwoMTracksAndVtxPGT0_[0]->Fill( mcEta_ ) ;
@@ -3031,7 +2910,6 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
 
 		}
 
-		//std::cout << " Debug 1.18 " << std::endl;
 		if (  chi2Prob > 0.0005 ) {
 		  if (aConv->caloCluster().size() !=0) {
 		    h_convEta_[0]->Fill( aConv->caloCluster()[0]->eta() );
@@ -3044,7 +2922,6 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
 		    if ( phoIsInBarrel ) h_EtR9Less093_[1][1] ->Fill ( photonEt );
 		    if ( phoIsInEndcap ) h_EtR9Less093_[1][2] ->Fill ( photonEt );
 		  }
-		  //std::cout << " Debug 1.19 " << std::endl;
 		  if ( phoIsInBarrel )  {
 		    if (aConv->caloCluster().size() !=0) h_convERes_[0][1]->Fill(aConv->caloCluster()[0]->energy() / (*mcPho).fourMomentum().e() );
 		    if ( ! isRunCentrally_ ) h_r9VsNofTracks_[0][1]->Fill( r9, aConv->nTracks() ) ;
@@ -3055,7 +2932,6 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
 		    if ( ! isRunCentrally_ ) h_r9VsNofTracks_[0][2]->Fill( r9, aConv->nTracks() ) ;
 		    h_mvaOut_[2]-> Fill(like);
 		  }
-		  //std::cout << " Debug 1.20 " << std::endl;
 
 		}
 
@@ -3064,7 +2940,6 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
 
 	      }
 
-	      //	      std::cout << " Debug 2 " << std::endl;
 
 	      ///////////  Quantities per conversion
 	      type =1;
@@ -3093,7 +2968,6 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
 
 	      }
 
-	      //std::cout << " Debug 3 " << std::endl;
 	      if ( ! isRunCentrally_ )  h2_EoverEtrueVsEta_[0]->Fill (mcEta_,matchingPho->superCluster()->energy()/ (*mcPho).fourMomentum().e()  ) ;
 	      if ( ! isRunCentrally_ )  h2_EoverEtrueVsR_[0]->Fill (mcConvR_,matchingPho->superCluster()->energy()/ (*mcPho).fourMomentum().e()  ) ;
 	      p_EoverEtrueVsEta_[0]->Fill (mcEta_,matchingPho->superCluster()->energy()/ (*mcPho).fourMomentum().e()  ) ;
@@ -3101,22 +2975,6 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
 
 
 	      if ( ! isRunCentrally_ ) h2_etaVsRsim_[0]->Fill (mcEta_,mcConvR_);
-
-	      /*
-                reco::TrackRef track1 = tracks[0].castTo<reco::TrackRef>();
-                reco::TrackRef track2 = tracks[1].castTo<reco::TrackRef>();
-                reco::TransientTrack tt1 = (*theTTB).build( &track1);
-                reco::TransientTrack tt2 = (*theTTB).build( &track2);
-                TwoTrackMinimumDistance md;
-                md.calculate  (  tt1.initialFreeState(),  tt2.initialFreeState() );
-                if (md.status() )  {
-		//cout << " Min Dist " << md.distance() << std::endl;
-		h_distMinAppTracks_[1][0]->Fill ( md.distance() );
-                }  else {
-		nInvalidPCA_++;
-
-                }
-	      */
 
 	      //  here original tracks and their inner momentum is considered
 	      float  dPhiTracksAtVtx =  aConv->dPhiTracksAtVtx();
@@ -3131,8 +2989,6 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
 	      if ( ! isRunCentrally_ ) h2_DCotTracksVsR_->Fill( mcConvR_, aConv->pairCotThetaSeparation() );
 	      p_DCotTracksVsEta_->Fill( mcEta_, aConv->pairCotThetaSeparation() );
 	      p_DCotTracksVsR_->Fill( mcConvR_, aConv->pairCotThetaSeparation() );
-
-	      //std::cout << " Debug 4 " << std::endl;
 
 	      if ( phoIsInBarrel ) {
 		h_invMass_[type][1] ->Fill(invM);
@@ -3152,8 +3008,6 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
 
 	      }
 
-	      //std::cout << " Debug 5 " << std::endl;
-
 	      if ( phoIsInEndcap ) {
 		h_invMass_[type][2] ->Fill(invM);
 		if ( aConv->conversionVertex().isValid() ) {
@@ -3168,7 +3022,6 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
 
 	      }
 
-	      //std::cout << " Debug 6 " << std::endl;
 	      if ( aConv->conversionVertex().isValid() ) {
 
 		h_convVtxdX_ ->Fill ( aConv->conversionVertex().position().x() - mcConvX_);
@@ -3188,7 +3041,6 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
 		  h_convVtxdR_endcap_ ->Fill ( sqrt(aConv->conversionVertex().position().perp2()) - mcConvR_);
 		}
 
-		//std::cout << " Debug 7 " << std::endl;
 		h_convVtxdPhi_ ->Fill ( aConv->conversionVertex().position().phi() - mcConvPhi_);
 		h_convVtxdEta_ ->Fill ( aConv->conversionVertex().position().eta() - mcConvEta_);
 		if ( ! isRunCentrally_ ) h2_convVtxdRVsR_ ->Fill (mcConvR_, sqrt(aConv->conversionVertex().position().perp2()) - mcConvR_ );
@@ -3218,8 +3070,6 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
 		h_zPVFromTracks_[0]->Fill (  zPV );
 		h_dzPVFromTracks_[0]->Fill ( zPV- (*mcPho).primaryVertex().z() );
 
-		//std::cout << " Debug 8 " << std::endl;
-
 		if ( phoIsInBarrel ) {
 		  h_zPVFromTracks_[1]->Fill ( zPV );
 		  h_dzPVFromTracks_[1]->Fill ( zPV - (*mcPho).primaryVertex().z() );
@@ -3234,20 +3084,14 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
 		  h_dzPVFromTracks_[4]->Fill ( zPV - (*mcPho).primaryVertex().z() );
 		}
 
-		//		std::cout << " Debug 8.1 " << std::endl;
 		p_dzPVVsR_ ->Fill(mcConvR_, zPV - (*mcPho).primaryVertex().z() );
 		p_dzPVVsEta_ ->Fill(mcConvEta_, zPV - (*mcPho).primaryVertex().z() );
 		if ( ! isRunCentrally_ ) h2_dzPVVsR_ ->Fill(mcConvR_, zPV - (*mcPho).primaryVertex().z() );
-		//		std::cout << " Debug 8.2 " << std::endl;
-
 	      }
 
 	      float  dPhiTracksAtEcal=-99;
 	      float  dEtaTracksAtEcal=-99;
-              //if ( fName_ != "pfPhotonValidator" &&  fName_ != "oldpfPhotonValidator" ) {
-	      //std::cout << " aConv->bcMatchingWithTracks() size " << aConv->bcMatchingWithTracks().size() << std::endl;
 		if (aConv->bcMatchingWithTracks().size() > 0 && aConv->bcMatchingWithTracks()[0].isNonnull() && aConv->bcMatchingWithTracks()[1].isNonnull() ) {
-		  //  std::cout << " Debug 8.3 " << std::endl;
 		  nRecConvAssWithEcal_++;
 		  float recoPhi1 = aConv->ecalImpactPosition()[0].phi();
 		  float recoPhi2 = aConv->ecalImpactPosition()[1].phi();
@@ -3264,7 +3108,6 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
 		  dPhiTracksAtEcal = recoPhi1 -recoPhi2;
 		  dPhiTracksAtEcal = phiNormalization( dPhiTracksAtEcal );
 		  dEtaTracksAtEcal = recoEta1 -recoEta2;
-		  //		  std::cout << " Debug 8.4 " << std::endl;
 
 		  h_DPhiTracksAtEcal_[type][0]->Fill( fabs(dPhiTracksAtEcal));
 		  if ( ! isRunCentrally_ ) h2_DPhiTracksAtEcalVsR_ ->Fill (mcConvR_, fabs(dPhiTracksAtEcal));
@@ -3274,24 +3117,15 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
 
 		  h_DEtaTracksAtEcal_[type][0]->Fill( dEtaTracksAtEcal);
 
-		  //		  std::cout << " Debug 8.5 " << std::endl;
 		  if ( phoIsInBarrel ) {
 		    h_DPhiTracksAtEcal_[type][1]->Fill( fabs(dPhiTracksAtEcal));
 		    h_DEtaTracksAtEcal_[type][1]->Fill( dEtaTracksAtEcal);
 		  }
-		  // std::cout << " Debug 8.6 " << std::endl;
 		  if ( phoIsInEndcap ) {
 		    h_DPhiTracksAtEcal_[type][2]->Fill( fabs(dPhiTracksAtEcal));
 		    h_DEtaTracksAtEcal_[type][2]->Fill( dEtaTracksAtEcal);
 		  }
-		  //std::cout << " Debug 8.7 " << std::endl;
-
 		}
-		//	      }
-
-
-	      //std::cout << " Debug 9 " << std::endl;
-
 	      ///////////  Quantities per track
 	      for (unsigned int i=0; i<tracks.size(); i++) {
 		RefToBase<reco::Track> tfrb(tracks[i] );
@@ -3303,8 +3137,6 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
 		if ( tracks[0]->algoName() == "inOutEcalSeededConv"  &&  tracks[1]->algoName() == "inOutEcalSeededConv" ) trkProvenance=1;
 		if ( ( tracks[0]->algoName() == "outInEcalSeededConv"  &&  tracks[1]->algoName() == "inOutEcalSeededConv") ||
 		     ( tracks[1]->algoName() == "outInEcalSeededConv"  &&  tracks[0]->algoName() == "inOutEcalSeededConv") ) trkProvenance=2;
-
-		//		std::cout << " Debug 9.1 " << std::endl;
 
 		if ( ! isRunCentrally_ ) nHitsVsEta_[type] ->Fill (mcEta_,   float(tracks[i]->numberOfValidHits()) );
                 if ( ! isRunCentrally_ ) nHitsVsR_[type] ->Fill (mcConvR_,   float(tracks[i]->numberOfValidHits()) );
@@ -3392,7 +3224,6 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
 
 
 	      float eoverp = photonE/tracks[0]->p();
-	      //	      std::cout << " Tracks quantities " << float(tracks[0]->numberOfValidHits()-0.0001) << " " <<   tracks[0]->normalizedChi2() << " " << eoverp <<std::endl; 
 	      h_EoverP_SL_[0]->Fill ( eoverp );
 	      if ( phoIsInBarrel ) {
 		h_EoverP_SL_[1]->Fill ( eoverp );
@@ -3478,7 +3309,6 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
 	} else {
 	  phoIsInEndcap=true;
 	}
-	//std::cout << " Debug 10 " << std::endl;
 
 	if ( dCotCutOn_ ) {
 	  if ( ( fabs(mcEta_) > 1.1 && fabs (mcEta_)  < 1.4  )  &&
@@ -3520,7 +3350,6 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
 		 ( fabs(mcEta_) > BARL && fabs(mcEta_) <=END_HI && fabs( (*mcPho).vertex().z() ) < 210 )  ) )
 	    continue;
 
-	  //std::cout << " Debug 11 " << std::endl;
 	  theConvTP_.clear();
 	  for(size_t i = 0; i <  trackingParticles.size(); ++i){
 	    TrackingParticleRef tp (ElectronTPHandle,i);
@@ -3549,17 +3378,6 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
                 if ( (tpr1->parentVertex()->sourceTracks_end()-tpr1->parentVertex()->sourceTracks_begin()==1) &&
                      (tpr2->parentVertex()->sourceTracks_end()-tpr2->parentVertex()->sourceTracks_begin()==1)) {
                   if (tpr1->parentVertex().key()==tpr2->parentVertex().key() && ((*tpr1->parentVertex()->sourceTracks_begin())->pdgId()==22)) {
-                    //		  std::cout << " ciao 5.6 " << std::endl;
-                    //		mcConvR_ = sqrt(tpr1->parentVertex()->position().Perp2());
-                    //mcConvZ_ = tpr1->parentVertex()->position().z();
-                    //mcConvX_ = tpr1->parentVertex()->position().x();
-                    //mcConvY_ = tpr1->parentVertex()->position().y();
-                    //mcConvEta_ = tpr1->parentVertex()->position().eta();
-                    //mcConvPhi_ = tpr1->parentVertex()->position().phi();
-                    //mcConvPt_ = sqrt((*tpr1->parentVertex()->sourceTracks_begin())->momentum().Perp2());
-                    //std::cout << " Reco to Sim mcconvpt " << mcConvPt_ << std::endl;
-                    //cout << "associated track1 to " << tpr1->pdgId() << " with p=" << tpr1->p4() << " with pT=" << tpr1->pt() << endl;
-                    //cout << "associated track2 to " << tpr2->pdgId() << " with p=" << tpr2->p4() << " with pT=" << tpr2->pt() << endl;
                     nAssT2 = 2;
                     break;
                   }
@@ -3568,32 +3386,10 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
             }
 
 	  } catch (Exception event) {
-	    //cout << "do not continue: " << event.what()  << endl;
-	    //continue;
 	  }
 
 	} // end loop over simulated photons
 
-
-
-        /*
-	  TrackingParticleRef myTP;
-	  for (size_t j = 0; j < RtoSCollPtrs.size(); j++) {
-          reco::RecoToSimCollection q = *(RtoSCollPtrs[j]);
-
-          RefToBase<reco::Track> myTk( track );
-
-          if( q.find(myTk ) != q.end() ) {
-          std::vector<std::pair<TrackingParticleRef, double> > tp = q[myTk];
-          for (unsigned int itp=0; itp<tp.size(); itp++) {
-          myTP=tp[itp].first;
-          //	      std::cout << " associated with TP " << myTP->pdgId() << " pt " << sqrt(myTP->momentum().perp2()) << std::endl;
-          myAss.insert( std::make_pair ( track  , myTP) );
-          nAssT2++;
-          }
-          }
-	  }
-        */
 
         if ( nAssT2 == 2) {
 
@@ -3609,14 +3405,12 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
 
 	///////////////////////////// xray
 	if ( aConv->conversionVertex().isValid() ) {
-	  // std::cout << " Debug 11.1 " << std::endl;
 
 	  float chi2Prob = ChiSquaredProbability( aConv->conversionVertex().chi2(),  aConv->conversionVertex().ndof() );
 	  double convR= sqrt(aConv->conversionVertex().position().perp2());
 	  double scalar = aConv->conversionVertex().position().x()*aConv->pairMomentum().x() +
               aConv->conversionVertex().position().y()*aConv->pairMomentum().y();
 
-	  //std::cout << " Debug 11.2 " << std::endl;
 
 	  if ( scalar < 0 ) convR= -sqrt(aConv->conversionVertex().position().perp2());
 	  h_convVtxRvsZ_[0] ->Fill ( fabs (aConv->conversionVertex().position().z() ),  sqrt(aConv->conversionVertex().position().perp2())  ) ;
@@ -3639,7 +3433,6 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
 	    if ( fabs(aConv->caloCluster()[0]->eta() ) > 1.)      h_convVtxRvsZ_[2] ->Fill ( fabs (aConv->conversionVertex().position().z() ),  convR  ) ;
 	  }
 
-	  //std::cout << " Debug 12 " << std::endl;
 
 	  h_vtxChi2Prob_[0]->Fill( chi2Prob );
 	  h_vtxChi2_[0]->Fill(  aConv->conversionVertex().normalizedChi2() );
@@ -3651,8 +3444,6 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
 	    h_vtxChi2Prob_[2]->Fill(  chi2Prob );
 	    h_vtxChi2_[2]->Fill( aConv->conversionVertex().normalizedChi2() );
 	  }
-
-	  //std::cout << " Debug 13 " << std::endl;
 
 
 	} // end conversion vertex valid
@@ -3674,8 +3465,6 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
     mcJetPhi_= phiNormalization(mcJetPhi);
     mcJetEta_= genJetIter->eta();
     float mcJetPt = genJetIter->pt() ;
-
-    //std::cout << " Debug 14 " << std::endl;
 
     h_SimJet_[0]->Fill ( mcJetEta_);
     h_SimJet_[1]->Fill ( mcJetPhi_);
@@ -3701,8 +3490,6 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
         matched = true;
       }
     }  // end loop over reco photons
-
-    //std::cout << " Debug 15 " << std::endl;
 
     if (!  matched ) continue;
     nPho++;
@@ -3746,8 +3533,6 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
       }
 
     }
-
-    //std::cout << " Debug 16 " << std::endl;
 
     const EcalRecHitCollection ecalRecHitCollection = *(ecalRecHitHandle.product());
     float photonE = matchingPho.energy();
@@ -3796,8 +3581,6 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
     h_phoBkgEt_[0]->Fill( photonEt);
     h_phoBkgDEta_->Fill (  matchingPho.eta() - mcJetEta_ );
     h_phoBkgDPhi_->Fill (  matchingPho.phi() - mcJetPhi_ );
-
-    //std::cout << " Debug 17 " << std::endl;
 
     h_r9Bkg_[0]->Fill( r9 );
     h_r1Bkg_[0]->Fill( r1 );
@@ -3881,8 +3664,6 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
         p_isoTrkSolidConeDR04VsEtBkg_[1] -> Fill (mcJetPt, trkIso);
         p_nTrkSolidConeDR04VsEtBkg_[1] -> Fill (mcJetPt, nIsoTrk);
       }
-      //std::cout << " Debug 20 " << std::endl;
-
     } else if ( phoIsInEndcap )  {
 
       h_r9Bkg_[2]->Fill( r9 );
@@ -3908,8 +3689,6 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
         p_isoTrkSolidConeDR04VsEtBkg_[2] -> Fill (mcJetPt, trkIso);
         p_nTrkSolidConeDR04VsEtBkg_[2] -> Fill (mcJetPt, nIsoTrk);
       }
-      //std::cout << " Debug 21 " << std::endl;
-
     }
 
     if ( !fastSim_) {
@@ -3989,9 +3768,6 @@ void PhotonValidator::endJob() {
   }
 
   edm::LogInfo("PhotonValidator") << "Analyzed " << nEvt_  << "\n";
-  // std::cout  << "::endJob Analyzed " << nEvt_ << " events " << " with total " << nPho_ << " Photons " << "\n";
-  //  std::cout  << "PhotonValidator::endJob Analyzed " << nEvt_ << " events " << "\n";
-
   return ;
 }
 
@@ -4005,7 +3781,6 @@ float PhotonValidator::phiNormalization(float & phi)
   if(phi >  PI) {phi = phi - TWOPI;}
   if(phi < -PI) {phi = phi + TWOPI;}
 
-  //  cout << " Float_t PHInormalization out " << PHI << endl;
   return phi;
 
 }

--- a/Validation/RecoMET/python/METRelValForDQM_cff.py
+++ b/Validation/RecoMET/python/METRelValForDQM_cff.py
@@ -34,7 +34,7 @@ METRelValSequence = cms.Sequence(
     genMetTrueAnalyzer*
     #genMetCaloAnalyzer*
     #genMetCaloAndNonPromptAnalyzer
-    correctionTermsPfMetType0PFCandidate*
+    correctionTermsPfMetType0PFCandidateForValidation*
     corrPfMetType1*
     #pfchsMETcorr*
     pfMetT0pc*
@@ -61,7 +61,7 @@ METValidation = cms.Sequence(
     genMetTrueAnalyzer*#*
     #genMetCaloAnalyzer*
     #genMetCaloAndNonPromptAnalyzer
-    correctionTermsPfMetType0PFCandidate*
+    correctionTermsPfMetType0PFCandidateForValidation*
     corrPfMetType1*
     #pfchsMETcorr*
     pfMetT0pc*

--- a/Validation/RecoMET/python/METRelValForDQM_cff.py
+++ b/Validation/RecoMET/python/METRelValForDQM_cff.py
@@ -71,7 +71,3 @@ METValidation = cms.Sequence(
     pfType1CorrectedMetAnalyzer*
     pfType01CorrectedMetAnalyzer
     )
-
-
-
-

--- a/Validation/RecoParticleFlow/python/PFElectronValidation_cff.py
+++ b/Validation/RecoParticleFlow/python/PFElectronValidation_cff.py
@@ -20,7 +20,7 @@ pfElectronValidation1 = pfElectronDQMAnalyzer.clone()
 pfElectronValidation1.InputCollection = cms.InputTag('pfAllElectrons') # for global Validation
 pfElectronValidation1.MatchCollection = cms.InputTag('gensource') # for global Validation
 pfElectronValidation1.BenchmarkLabel  = cms.string('PFElectronValidation/CompWithGenElectron')
-pfElectronValidationSequence = cms.Sequence( pfAllElectrons + gensource + pfElectronValidation1 )
+pfElectronValidationSequence = cms.Sequence( gensource + pfElectronValidation1 )
 
 
 # NoTracking


### PR DESCRIPTION
the filters in:
https://cmssdt.cern.ch/SDT/lxr/source/JetMETCorrections/Type1MET/python/pfMETCorrectionType0_cfi.py#0050

which actually don't filter anything, but are producers instead, are called in the validation sequence. the framework is complaining with messages like:

The EDFilter 'VertexSelector' with module label 'selectedVerticesForPFMEtCorrType0' appears on EndPath 'selectedVerticesForPFMEtCorrType0'.
The return value of the filter will be ignored.
To suppress this warning, either remove the filter from the endpath,
or explicitly ignore it in the configuration by using cms.ignore().

commit 6a51a32 cures the problem even if I don't particularly like this solution..  @slava77 
removing them is not an option..
Automatically ported from CMSSW_7_2_X #5335
