### PR TITLE
FWCore: add support for Address Sanitizer IBs

### DIFF
--- a/FWCore/Framework/bin/BuildFile.xml
+++ b/FWCore/Framework/bin/BuildFile.xml
@@ -1,6 +1,9 @@
 <architecture name="slc[6-9]_amd64">
   <flags LDFLAGS="-Wl,-dynamic-linker,$(GLIBC_BASE)/lib64/ld.so"/>
 </architecture>
+<release name=".*_ASAN_.*">
+  <flags LDFLAGS="-fsanitize=address -static-libasan"/>
+</release>
 <bin   name="cmsRunGlibC" file="cmsRun.cpp">
   <use   name="roothistmatrix"/>
   <use   name="tbb"/>

--- a/FWCore/ParameterSet/bin/BuildFile.xml
+++ b/FWCore/ParameterSet/bin/BuildFile.xml
@@ -1,3 +1,9 @@
+<architecture name="slc[6-9]_amd64">
+ <flags LDFLAGS="-Wl,-dynamic-linker,$(GLIBC_BASE)/lib64/ld.so"/>
+</architecture>
+<release name=".*_ASAN_.*">
+  <flags LDFLAGS="-fsanitize=address -static-libasan"/>
+</release>
 <use   name="boost"/>
 <use   name="FWCore/ParameterSet"/>
 <bin   file="edmPluginHelp.cpp">

--- a/FWCore/PluginManager/bin/BuildFile.xml
+++ b/FWCore/PluginManager/bin/BuildFile.xml
@@ -1,16 +1,16 @@
+<architecture name="slc[6-9]_amd64">
+  <flags LDFLAGS="-Wl,-dynamic-linker,$(GLIBC_BASE)/lib64/ld.so"/>
+</architecture>
+<release name=".*_ASAN_.*">
+  <flags LDFLAGS="-fsanitize=address -static-libasan"/>
+</release>
 <bin   name="edmPluginDump" file="dump.cc">
   <use   name="boost"/>
   <use   name="boost_program_options"/>
   <use   name="FWCore/PluginManager"/>
-<architecture name="slc[6-9]_amd64">
-  <flags LDFLAGS="-Wl,-dynamic-linker,$(GLIBC_BASE)/lib64/ld.so"/>
-</architecture>
 </bin>
 <bin   name="edmPluginRefresh" file="refresh.cc">
   <use   name="boost"/>
   <use   name="boost_program_options"/>
   <use   name="FWCore/PluginManager"/>
-<architecture name="slc[6-9]_amd64">
-  <flags LDFLAGS="-Wl,-dynamic-linker,$(GLIBC_BASE)/lib64/ld.so"/>
-</architecture>
 </bin>


### PR DESCRIPTION
The following adds support for Address Sanitizer (asan) IBs using
mainstream branch. Because a full stack of CMSSW is not compiled with
ASan we need some extra steps. ASan run-time must be linked into
main executables statically to force early ASan initialization.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
Automatically ported from CMSSW_7_2_X #5329
