### PR TITLE
Avoid division by zero report by static analyzer.

### DIFF
--- a/FWCore/Sources/src/ProducerSourceBase.cc
+++ b/FWCore/Sources/src/ProducerSourceBase.cc
@@ -206,6 +206,7 @@ namespace edm {
       }
     } else {
       // new run
+      assert(numberEventsInLumi_ != 0);
       eventID = eventID.previousRunLastEvent(origEventID_.luminosityBlock() + numberEventsInRun_/numberEventsInLumi_);
       eventID = EventID(numberEventsInRun_, eventID.luminosityBlock(), eventID.run());
       numberEventsInThisLumi_ = numberEventsInLumi_;


### PR DESCRIPTION
Automatically ported from CMSSW_7_2_X #5315
