### PR TITLE
chrono: improvements to IFUNC and native timers

### DIFF
--- a/HLTrigger/Timer/test/chrono/interface/native/x86_tsc_clock.h
+++ b/HLTrigger/Timer/test/chrono/interface/native/x86_tsc_clock.h
@@ -106,6 +106,29 @@ namespace native {
     }
   };
 
+
+  // TSC-based clock, determining at run-time the best strategy to serialise the reads from the TSC
+  struct clock_serialising_rdtsc
+  {
+    // std::chrono-like native interface
+    typedef native_duration<int64_t, tsc_tick>                          duration;
+    typedef duration::rep                                               rep;
+    typedef duration::period                                            period;
+    typedef native_time_point<clock_serialising_rdtsc, duration>        time_point;
+
+    static const bool is_steady;
+    static const bool is_available;
+
+    static time_point now() noexcept
+    {
+      rep        ticks = serialising_rdtsc();
+      duration   d(ticks);
+      time_point t(d);
+      return t;
+    }
+  };
+
+
 } // namespace native
 
 #endif // native_x86_tsc_clock_h

--- a/HLTrigger/Timer/test/chrono/interface/x86_tsc.h
+++ b/HLTrigger/Timer/test/chrono/interface/x86_tsc.h
@@ -52,12 +52,19 @@ bool tsc_allowed();
 double calibrate_tsc_hz();
 
 
-#if defined __GLIBC__ && (__GLIBC__ > 2) || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 11)
-// IFUNC support requires GLIBC >= 2.11.1
+// IFUNC support requires GCC >= 4.6.0 and GLIBC >= 2.11.1
+#if ( defined __GNUC__ && (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6) ) \
+  and ( defined __GLIBC__ && (__GLIBC__ > 2) || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 11) )
+
 // processor specific serialising access to the TSC
 extern uint64_t serialising_rdtsc(void);
-#endif // defined __GLIBC__ && (__GLIBC__ > 2) || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 11)
 
+#else
+
+// processor specific serialising access to the TSC
+extern uint64_t (*serialising_rdtsc)(void);
+
+#endif // IFUNC support
 
 #endif // x86_tsc_h
 

--- a/HLTrigger/Timer/test/chrono/interface/x86_tsc_clock.h
+++ b/HLTrigger/Timer/test/chrono/interface/x86_tsc_clock.h
@@ -104,8 +104,6 @@ struct clock_rdtscp
 };
 
 
-#if defined __GLIBC__ && (__GLIBC__ > 2) || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 11)
-// IFUNC support requires GLIBC >= 2.11.1
 // TSC-based clock, determining at run-time the best strategy to serialise the reads from the TSC
 struct clock_serialising_rdtsc
 {
@@ -113,7 +111,7 @@ struct clock_serialising_rdtsc
   typedef std::chrono::nanoseconds                                      duration;
   typedef duration::rep                                                 rep;
   typedef duration::period                                              period;
-  typedef std::chrono::time_point<clock_rdtscp, duration>               time_point;
+  typedef std::chrono::time_point<clock_serialising_rdtsc, duration>    time_point;
 
   static const bool is_steady;
   static const bool is_available;
@@ -126,7 +124,6 @@ struct clock_serialising_rdtsc
     return time;
   }
 };
-#endif // defined __GLIBC__ && (__GLIBC__ > 2) || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 11)
 
 
 #endif // x86_tsc_clock_h

--- a/HLTrigger/Timer/test/chrono/src/native/x86_tsc_clock.cc
+++ b/HLTrigger/Timer/test/chrono/src/native/x86_tsc_clock.cc
@@ -18,6 +18,9 @@ namespace native {
   const bool clock_rdtscp::is_available        = has_rdtscp() and tsc_allowed();
   const bool clock_rdtscp::is_steady           = has_invariant_tsc();
 
+  const bool clock_serialising_rdtsc::is_available    = has_tsc() and tsc_allowed();
+  const bool clock_serialising_rdtsc::is_steady       = has_invariant_tsc();
+
 } // namespace native
 
 #endif // defined __x86_64__ or defined __i386__

--- a/HLTrigger/Timer/test/chrono/src/x86_tsc_clock.cc
+++ b/HLTrigger/Timer/test/chrono/src/x86_tsc_clock.cc
@@ -16,10 +16,7 @@ const bool clock_rdtsc_mfence::is_steady            = has_invariant_tsc();
 const bool clock_rdtscp::is_available               = has_rdtscp() and tsc_allowed();
 const bool clock_rdtscp::is_steady                  = has_invariant_tsc();
 
-#if defined __GLIBC__ && (__GLIBC__ > 2) || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 11)
-// IFUNC support requires GLIBC >= 2.11.1
 const bool clock_serialising_rdtsc::is_available    = has_tsc() and tsc_allowed();
 const bool clock_serialising_rdtsc::is_steady       = has_invariant_tsc();
-#endif // defined __GLIBC__ && (__GLIBC__ > 2) || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 11)
 
 #endif // defined __x86_64__ or defined __i386__

--- a/HLTrigger/Timer/test/chrono/test/chrono.cc
+++ b/HLTrigger/Timer/test/chrono/test/chrono.cc
@@ -154,19 +154,19 @@ void init_timers(std::vector<BenchmarkBase *> & timers)
     timers.push_back(new Benchmark<clock_rdtsc_mfence>("MFENCE; RDTSC (" + tsc_freq + ") (using nanoseconds)"));
   if (clock_rdtscp::is_available)
     timers.push_back(new Benchmark<clock_rdtscp>("RDTSCP (" + tsc_freq + ") (using nanoseconds)"));
-#if defined __GLIBC__ && (__GLIBC__ > 2) || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 11)
   if (clock_serialising_rdtsc::is_available)
     timers.push_back(new Benchmark<clock_serialising_rdtsc>("run-time selected serialising RDTSC (" + tsc_freq + ") (using nanoseconds)"));
-#endif // defined __GLIBC__ && (__GLIBC__ > 2) || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 11)
   // x86 DST-based clock (native)
-  if (clock_rdtsc::is_available)
+  if (native::clock_rdtsc::is_available)
     timers.push_back(new Benchmark<native::clock_rdtsc>("RDTSC (" + tsc_freq + ") (native)"));
-  if (clock_rdtsc_lfence::is_available)
+  if (native::clock_rdtsc_lfence::is_available)
     timers.push_back(new Benchmark<native::clock_rdtsc_lfence>("LFENCE; RDTSC (" + tsc_freq + ") (native)"));
-  if (clock_rdtsc_mfence::is_available)
+  if (native::clock_rdtsc_mfence::is_available)
     timers.push_back(new Benchmark<native::clock_rdtsc_mfence>("MFENCE; RDTSC (" + tsc_freq + ") (native)"));
-  if (clock_rdtscp::is_available)
+  if (native::clock_rdtscp::is_available)
     timers.push_back(new Benchmark<native::clock_rdtscp>("RDTSCP (" + tsc_freq + ") (native)"));
+  if (native::clock_serialising_rdtsc::is_available)
+    timers.push_back(new Benchmark<native::clock_serialising_rdtsc>("run-time selected serialising RDTSC (" + tsc_freq + ") (native)"));
 
 #endif // defined __x86_64__ or defined __i386__
 


### PR DESCRIPTION
- check for GCC >= 4.6 (not only GLIBC >= 2.11.2) before using IFUNC
- implement native IFUNC-based timer
- implement fall-back mechanism when IFUNC is not available
- clean up native TSC timers
  Automatically ported from CMSSW_7_2_X #5309
