### PR TITLE
Clang fix problems in L1Trigger/CSCTrackFinder

### DIFF
--- a/L1Trigger/CSCTrackFinder/interface/CSCTFSectorProcessor.h
+++ b/L1Trigger/CSCTrackFinder/interface/CSCTFSectorProcessor.h
@@ -89,7 +89,6 @@ public:
   int run_core;
   int trigger_on_ME1a, trigger_on_ME1b, trigger_on_ME2, trigger_on_ME3, trigger_on_ME4;
   int trigger_on_MB1a, trigger_on_MB1d;
-  int singlesTrackPt;
   unsigned int singlesTrackOutput;
   int rescaleSinglesPhi;
 

--- a/L1Trigger/CSCTrackFinder/src/CSCSectorReceiverMiniLUT.cc
+++ b/L1Trigger/CSCTrackFinder/src/CSCSectorReceiverMiniLUT.cc
@@ -28,10 +28,10 @@ lclphidat CSCSectorReceiverMiniLUT::calcLocalPhiMini(unsigned theadd,  const boo
   unsigned short int pattern = ((theadd >> 8) & 0xf);
   unsigned short int strip   = (theadd & 0xff);
   
-  if(strip < 2*CSCConstants::MAX_NUM_STRIPS && pattern < CSCConstants::NUM_CLCT_PATTERNS) 
-    gangedME1a ? data.phi_local = static_cast<unsigned>((lcl_phi_param0[pattern] + strip)*lcl_phi_param1) : data.phi_local = static_cast<unsigned>((lcl_phi_param0[pattern] + strip)*0.625* lcl_phi_param1);
+  if(strip < 2*CSCConstants::MAX_NUM_STRIPS && pattern < CSCConstants::NUM_CLCT_PATTERNS) {
+    data.phi_local = gangedME1a ? static_cast<unsigned>((lcl_phi_param0[pattern] + strip)*lcl_phi_param1) : static_cast<unsigned>((lcl_phi_param0[pattern] + strip)*0.625* lcl_phi_param1);
   //DA and MDG, rescale range of local phi so ME1/1b fits in 0-511
-  else
+  } else
     edm::LogWarning("CSCSectorReceiverMiniLUT")
       << "+++ Value of strip, " << strip
       << ", exceeds max allowed, " << 2*CSCConstants::MAX_NUM_STRIPS-1


### PR DESCRIPTION
Fixed clang compiler errors and warnings in L1Trigger/CSCTrackFinder
Clang has many warnings from the generated code, but those were left unchanged. Also, the generated code might be too long for clang to parse in a finite amount of time.
Automatically ported from CMSSW_7_2_X #5304
