### PR TITLE
Fixed clang compiler warnings and errors

### DIFF
--- a/L1Trigger/L1TCalorimeter/interface/Stage1Layer2HFBitCountAlgorithmImp.h
+++ b/L1Trigger/L1TCalorimeter/interface/Stage1Layer2HFBitCountAlgorithmImp.h
@@ -34,7 +34,6 @@ namespace l1t {
 			      std::vector<l1t::CaloSpare> * spares);
 
   private:
-    CaloParamsStage1* const params_;
   };
 }
 

--- a/L1Trigger/L1TCalorimeter/interface/Stage1Layer2HFRingSumAlgorithmImp.h
+++ b/L1Trigger/L1TCalorimeter/interface/Stage1Layer2HFRingSumAlgorithmImp.h
@@ -35,7 +35,6 @@ namespace l1t {
 			      std::vector<l1t::CaloSpare> * spares);
 
   private:
-    CaloParamsStage1* const params_;
     std::vector<double> cosPhi;
     std::vector<double> sinPhi;
   };
@@ -49,7 +48,6 @@ namespace l1t {
 			      const std::vector<l1t::Tau> * taus,
 			      std::vector<l1t::CaloSpare> * spares);
   private:
-    CaloParamsStage1* const params_;
   };
 }
 

--- a/L1Trigger/L1TCalorimeter/interface/Stage2MainProcessorFirmware.h
+++ b/L1Trigger/L1TCalorimeter/interface/Stage2MainProcessorFirmware.h
@@ -48,7 +48,6 @@ namespace l1t {
 
   private:
     
-    unsigned const & m_fwv;
     CaloParams* m_params;
 
     Stage2TowerDecompressAlgorithm* m_towerAlgo;

--- a/L1Trigger/L1TCalorimeter/interface/Stage2PreProcessorFirmware.h
+++ b/L1Trigger/L1TCalorimeter/interface/Stage2PreProcessorFirmware.h
@@ -36,7 +36,6 @@ namespace l1t {
   private:
     
     //FirmwareVersion const & m_fwv;
-    int const & m_fwv;
     CaloParams* m_params;
 
     Stage2TowerCompressAlgorithm* m_towerAlgo;

--- a/L1Trigger/L1TCalorimeter/src/firmware/Stage1Layer2CentralityAlgorithm.cc
+++ b/L1Trigger/L1TCalorimeter/src/firmware/Stage1Layer2CentralityAlgorithm.cc
@@ -11,7 +11,7 @@
 #include "L1Trigger/L1TCalorimeter/interface/PUSubtractionMethods.h"
 #include "L1Trigger/L1TCalorimeter/interface/legacyGtHelper.h"
 
-l1t::Stage1Layer2CentralityAlgorithm::Stage1Layer2CentralityAlgorithm(CaloParamsStage1* params) : params_(params)
+l1t::Stage1Layer2CentralityAlgorithm::Stage1Layer2CentralityAlgorithm(CaloParamsStage1* )
 {
 
 }

--- a/L1Trigger/L1TCalorimeter/src/firmware/Stage1Layer2DiTauAlgorithm.cc
+++ b/L1Trigger/L1TCalorimeter/src/firmware/Stage1Layer2DiTauAlgorithm.cc
@@ -11,7 +11,7 @@
 //#include "L1Trigger/L1TCalorimeter/interface/PUSubtractionMethods.h"
 //#include "L1Trigger/L1TCalorimeter/interface/legacyGtHelper.h"
 
-l1t::Stage1Layer2DiTauAlgorithm::Stage1Layer2DiTauAlgorithm(CaloParamsStage1* params) : params_(params)
+l1t::Stage1Layer2DiTauAlgorithm::Stage1Layer2DiTauAlgorithm(CaloParamsStage1* )
 {
 }
 

--- a/L1Trigger/L1TCalorimeter/src/firmware/Stage1Layer2FlowAlgorithm.cc
+++ b/L1Trigger/L1TCalorimeter/src/firmware/Stage1Layer2FlowAlgorithm.cc
@@ -11,7 +11,7 @@
 #include "L1Trigger/L1TCalorimeter/interface/PUSubtractionMethods.h"
 #include "L1Trigger/L1TCalorimeter/interface/legacyGtHelper.h"
 
-l1t::Stage1Layer2FlowAlgorithm::Stage1Layer2FlowAlgorithm(CaloParamsStage1* params) : params_(params)
+l1t::Stage1Layer2FlowAlgorithm::Stage1Layer2FlowAlgorithm(CaloParamsStage1* )
 {
  //now do what ever initialization is needed
  //Converting phi to be as it is define at GCT (-pi to pi instead of 0 to 2*pi)

--- a/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2EtSumAlgorithmFirmwareImp1.cc
+++ b/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2EtSumAlgorithmFirmwareImp1.cc
@@ -32,7 +32,7 @@ l1t::Stage2Layer2EtSumAlgorithmFirmwareImp1::~Stage2Layer2EtSumAlgorithmFirmware
 void l1t::Stage2Layer2EtSumAlgorithmFirmwareImp1::processEvent(const std::vector<l1t::CaloTower> & towers,
       std::vector<l1t::EtSum> & etsums) {
 
-  double pi = std::atan(1.d) * 4.0d;
+  double pi = std::atan(1.0) * 4.0;
 
   int ietaMax=28, ietaMin=-28, iphiMax=72, iphiMin=1;
   

--- a/L1Trigger/L1TCalorimeter/src/firmware/Stage2MainProcessorImp1.cc
+++ b/L1Trigger/L1TCalorimeter/src/firmware/Stage2MainProcessorImp1.cc
@@ -20,7 +20,6 @@
 using namespace std;
 
 l1t::Stage2MainProcessorFirmwareImp1::Stage2MainProcessorFirmwareImp1(unsigned fwv, CaloParams* params) :
-  m_fwv(fwv),
   m_params(params)
 {
 

--- a/L1Trigger/L1TCalorimeter/src/firmware/Stage2PreProcessFirmwareImp1.cc
+++ b/L1Trigger/L1TCalorimeter/src/firmware/Stage2PreProcessFirmwareImp1.cc
@@ -14,7 +14,6 @@
 using namespace std;
 
 l1t::Stage2PreProcessorFirmwareImp1::Stage2PreProcessorFirmwareImp1(unsigned fwv, CaloParams* params) :
-  m_fwv(fwv),
   m_params(params)
 {
 


### PR DESCRIPTION
Fixed unused member data warnings.
Fixed invalid use of 'd' to declare a double.
Automatically ported from CMSSW_7_2_X #5302
