### PR TITLE
Clang fixes for RecoEgamma/ElectronIdentification

### DIFF
--- a/RecoEgamma/ElectronIdentification/interface/ElectronLikelihood.h
+++ b/RecoEgamma/ElectronIdentification/interface/ElectronLikelihood.h
@@ -85,8 +85,6 @@ class ElectronLikelihood {
   //! splitting rule for PDF's
   std::string m_signalWeightSplitting;
   std::string m_backgroundWeightSplitting;
-  bool m_splitSignalPdfs;
-  bool m_splitBackgroundPdfs;
 
 };
 

--- a/RecoEgamma/ElectronIdentification/interface/ElectronNeuralNet.h
+++ b/RecoEgamma/ElectronIdentification/interface/ElectronNeuralNet.h
@@ -14,7 +14,9 @@ public:
 
   virtual ~ElectronNeuralNet(){};
 
-  void setup(const edm::ParameterSet& conf){};
+  void setup(const edm::ParameterSet& conf) override {} ;
+  using ElectronIDAlgo::result;
+  //the following is a new function not in the base class
   double result(const reco::GsfElectron* electron, const edm::Event&);
 
  private:

--- a/RecoEgamma/ElectronIdentification/src/ElectronLikelihood.cc
+++ b/RecoEgamma/ElectronIdentification/src/ElectronLikelihood.cc
@@ -21,9 +21,7 @@ ElectronLikelihood::ElectronLikelihood (const ElectronLikelihoodCalibration *cal
   _EEgt15lh (new LikelihoodPdfProduct ("electronID_EE_ptGt15_likelihood",2,1)) ,
   m_eleIDSwitches (eleIDSwitches) ,
   m_signalWeightSplitting (signalWeightSplitting), 
-  m_backgroundWeightSplitting (backgroundWeightSplitting),
-  m_splitSignalPdfs (splitSignalPdfs), 
-  m_splitBackgroundPdfs (splitBackgroundPdfs)  
+  m_backgroundWeightSplitting (backgroundWeightSplitting)
 {
   Setup (calibration,
 	 signalWeightSplitting, backgroundWeightSplitting,


### PR DESCRIPTION
Fixed clang compiler warnings.
Automatically ported from CMSSW_7_2_X #5301
