### PR TITLE
Clang fixes for PhysicsTools/SelectorUtils

### DIFF
--- a/PhysicsTools/SelectorUtils/interface/VersionedIdProducer.h
+++ b/PhysicsTools/SelectorUtils/interface/VersionedIdProducer.h
@@ -20,15 +20,15 @@
 template< class PhysicsObjectPtr , class SelectorType=VersionedSelector<PhysicsObjectPtr> >
 class VersionedIdProducer : public edm::stream::EDProducer<> {
 public:
-  typedef typename PhysicsObjectPtr::value_type   PhysicsObjectType;
+  using PhysicsObjectType =  typename PhysicsObjectPtr::value_type;
 
-  typedef edm::View<PhysicsObjectType> Collection;
-  typedef edm::EDGetTokenT<Collection> TokenType;
+  using Collection =  edm::View<PhysicsObjectType>;
+  using TokenType = edm::EDGetTokenT<Collection>;
 
   explicit VersionedIdProducer(const edm::ParameterSet&);
   ~VersionedIdProducer() {}
   
-  virtual void produce(edm::Event&, const edm::EventSetup&);
+  virtual void produce(edm::Event&, const edm::EventSetup&) override;
 
 private:  
   // ----------member data ---------------------------

--- a/PhysicsTools/SelectorUtils/interface/VersionedSelector.h
+++ b/PhysicsTools/SelectorUtils/interface/VersionedSelector.h
@@ -100,7 +100,7 @@ class VersionedSelector : public Selector<T> {
     return this->operator()(ref, ret);
   }
   
-  using typename Selector<T>::operator();
+  using Selector<T>::operator();
   
   const unsigned char* md55Raw() const { return id_md5_; } 
   bool operator==(const VersionedSelector& other) const {


### PR DESCRIPTION
Fixed the clang compiler errors and warnings originating from PhysicsTools/SelectorUtils.
These fixes are needed for the static analyzer to successfully parse the code.
Automatically ported from CMSSW_7_2_X #5300
