### PR TITLE
added validation plots for Strip ALCA

### DIFF
--- a/DQM/SiStripMonitorCluster/interface/SiStripMonitorCluster.h
+++ b/DQM/SiStripMonitorCluster/interface/SiStripMonitorCluster.h
@@ -84,6 +84,8 @@ class SiStripMonitorCluster : public thread_unsafe::DQMEDAnalyzer {
     MonitorElement* SubDetClusterApvTH2 = 0;
     MonitorElement* SubDetClusterDBxCycleProf = 0;
     MonitorElement* SubDetApvDBxProf2 = 0;
+    MonitorElement* SubDetClusterChargeTH1 = 0;
+    MonitorElement* SubDetClusterWidthTH1 = 0;
   };
 
   struct ClusterProperties { // Cluster Properties
@@ -181,6 +183,8 @@ class SiStripMonitorCluster : public thread_unsafe::DQMEDAnalyzer {
   bool subdetswitchapvcycledbxprof2on;
   bool subdetswitchdbxcycleprofon;
   bool subdetswitchtotclusth1on;
+  bool subdetswitchcluschargeon;
+  bool subdetswitchcluswidthon;
   bool globalswitchapvcycledbxth2on;
   bool globalswitchcstripvscpix;
   bool globalswitchMultiRegions;

--- a/DQM/SiStripMonitorCluster/python/SiStripMonitorClusterAlca_cfi.py
+++ b/DQM/SiStripMonitorCluster/python/SiStripMonitorClusterAlca_cfi.py
@@ -100,14 +100,16 @@ SiStripCalZeroBiasMonitorCluster.TH1ClusterCharge = cms.PSet(
     xmin           = cms.double(-0.5),        
     xmax           = cms.double(799.5),
     layerswitchon  = cms.bool(False),
-    moduleswitchon = cms.bool(False)
+    moduleswitchon = cms.bool(False),
+    subdetswitchon = cms.bool(True)
 )
 SiStripCalZeroBiasMonitorCluster.TH1ClusterWidth = cms.PSet(
-    Nbinx          = cms.int32(20),
+    Nbinx          = cms.int32(30),
     xmin           = cms.double(-0.5),
-    xmax           = cms.double(19.5),
+    xmax           = cms.double(29.5),
     layerswitchon  = cms.bool(False),        
-    moduleswitchon = cms.bool(False)
+    moduleswitchon = cms.bool(False),
+    subdetswitchon = cms.bool(True)
 )
 SiStripCalZeroBiasMonitorCluster.TProfNumberOfCluster = cms.PSet(
     Nbinx            = cms.int32(100),

--- a/DQM/SiStripMonitorCluster/python/SiStripMonitorCluster_cfi.py
+++ b/DQM/SiStripMonitorCluster/python/SiStripMonitorCluster_cfi.py
@@ -99,14 +99,16 @@ SiStripMonitorCluster = cms.EDAnalyzer("SiStripMonitorCluster",
         xmin           = cms.double(-0.5),        
         xmax           = cms.double(799.5),
         layerswitchon  = cms.bool(False),
-        moduleswitchon = cms.bool(True)
+        moduleswitchon = cms.bool(True),
+        subdetswitchon = cms.bool(False)
     ),
     TH1ClusterWidth = cms.PSet(
         Nbinx          = cms.int32(20),
         xmin           = cms.double(-0.5),
         xmax           = cms.double(19.5),
         layerswitchon  = cms.bool(False),        
-        moduleswitchon = cms.bool(True)
+        moduleswitchon = cms.bool(True),
+        subdetswitchon = cms.bool(False)
     ),
 
     TProfNumberOfCluster = cms.PSet(

--- a/DQM/SiStripMonitorCluster/src/SiStripMonitorCluster.cc
+++ b/DQM/SiStripMonitorCluster/src/SiStripMonitorCluster.cc
@@ -73,6 +73,7 @@ SiStripMonitorCluster::SiStripMonitorCluster(const edm::ParameterSet& iConfig)
   edm::ParameterSet ParametersClusterCharge =  conf_.getParameter<edm::ParameterSet>("TH1ClusterCharge");
   layerswitchcluschargeon = ParametersClusterCharge.getParameter<bool>("layerswitchon");
   moduleswitchcluschargeon = ParametersClusterCharge.getParameter<bool>("moduleswitchon");
+  subdetswitchcluschargeon = ParametersClusterCharge.getParameter<bool>("subdetswitchon");
 
   edm::ParameterSet ParametersClusterStoN =  conf_.getParameter<edm::ParameterSet>("TH1ClusterStoN");
   layerswitchclusstonon = ParametersClusterStoN.getParameter<bool>("layerswitchon");
@@ -97,6 +98,7 @@ SiStripMonitorCluster::SiStripMonitorCluster(const edm::ParameterSet& iConfig)
   edm::ParameterSet ParametersClusterWidth =  conf_.getParameter<edm::ParameterSet>("TH1ClusterWidth");
   layerswitchcluswidthon = ParametersClusterWidth.getParameter<bool>("layerswitchon");
   moduleswitchcluswidthon = ParametersClusterWidth.getParameter<bool>("moduleswitchon");
+  subdetswitchcluswidthon = ParametersClusterWidth.getParameter<bool>("subdetswitchon");
 
   edm::ParameterSet ParametersModuleLocalOccupancy =  conf_.getParameter<edm::ParameterSet>("TH1ModuleLocalOccupancy");
   layerswitchlocaloccupancy = ParametersModuleLocalOccupancy.getParameter<bool>("layerswitchon");
@@ -644,6 +646,16 @@ void SiStripMonitorCluster::analyze(const edm::Event& iEvent, const edm::EventSe
 	  if (layerswitchclusterwidthprofon)
 	    layer_single.LayerClusterWidthProfile->Fill(iDet, cluster_width);
 	}
+	
+	if (subdetswitchcluschargeon || subdetswitchcluswidthon)
+	  {
+	    std::map<std::string, SubDetMEs>::iterator iSubdet  = SubDetMEsMap.find(subdet_label);
+	    if(iSubdet != SubDetMEsMap.end()) 
+	      {
+		if (subdetswitchcluschargeon) iSubdet->second.SubDetClusterChargeTH1->Fill(cluster_signal);
+		if (subdetswitchcluswidthon)  iSubdet->second.SubDetClusterWidthTH1->Fill(cluster_width);
+	      }
+	  }
       } // end loop over clusters
 
       short total_nr_strips = SiStripDetCabling_->nApvPairs(detid) * 2 * 128; // get correct # of avp pairs
@@ -937,8 +949,24 @@ void SiStripMonitorCluster::createSubDetMEs(std::string label , DQMStore::IBooke
   subdetMEs.SubDetClusterApvTH2       = 0;
   subdetMEs.SubDetClusterDBxCycleProf = 0;
   subdetMEs.SubDetApvDBxProf2         = 0;
+  subdetMEs.SubDetClusterChargeTH1    = 0;
+  subdetMEs.SubDetClusterWidthTH1     = 0;
 
   std::string HistoName;
+  // cluster charge
+  if (subdetswitchcluschargeon){
+    HistoName = "ClusterCharge__" + label;
+    subdetMEs.SubDetClusterChargeTH1 = bookME1D("TH1ClusterCharge",HistoName.c_str() , ibooker);
+    subdetMEs.SubDetClusterChargeTH1->setAxisTitle("Cluster charge [ADC counts]");
+    subdetMEs.SubDetClusterChargeTH1->getTH1()->StatOverflows(kTRUE);  // over/underflows in Mean calculation
+  }
+  // cluster width
+  if (subdetswitchcluswidthon){
+    HistoName = "ClusterWidth__" + label;
+    subdetMEs.SubDetClusterWidthTH1 = bookME1D("TH1ClusterWidth",HistoName.c_str() , ibooker);
+    subdetMEs.SubDetClusterWidthTH1->setAxisTitle("Cluster width [strips]");
+    subdetMEs.SubDetClusterWidthTH1->getTH1()->StatOverflows(kTRUE);  // over/underflows in Mean calculation
+  }
   // Total Number of Cluster - 1D
   if (subdetswitchtotclusth1on){
     HistoName = "TotalNumberOfCluster__" + label;


### PR DESCRIPTION
Added couple DQM plots inside AlCaReco/SiStrip directory, allowing the Strip ALCA validation using RelVal samples.
If too late for 72X, I'll make another PR for 73X (when opened).
Automatically ported from CMSSW_7_2_X #5284
