### PR TITLE
Use class type_info, rather than class name, for dictionary checking

### DIFF
--- a/DataFormats/Common/src/RefCoreStreamer.cc
+++ b/DataFormats/Common/src/RefCoreStreamer.cc
@@ -2,7 +2,7 @@
 #include "DataFormats/Common/interface/RefCore.h"
 #include "DataFormats/Common/interface/RefCoreWithIndex.h"
 #include "FWCore/Utilities/interface/EDMException.h"
-#include "TROOT.h"
+#include "TClass.h"
 #include <ostream>
 #include <cassert>
 #include <iostream>
@@ -76,13 +76,13 @@ namespace edm {
 
   void setRefCoreStreamer(bool resetAll) {
     {
-      TClass *cl = gROOT->GetClass("edm::RefCore");
+      TClass *cl = TClass::GetClass("edm::RefCore");
       TClassStreamer *st = cl->GetStreamer();
       if (st == 0) {
         cl->AdoptStreamer(new RefCoreStreamer());
       }
       {
-        TClass *cl = gROOT->GetClass("edm::RefCoreWithIndex");
+        TClass *cl = TClass::GetClass("edm::RefCoreWithIndex");
         TClassStreamer *st = cl->GetStreamer();
         if (st == 0) {
           cl->AdoptStreamer(new RefCoreWithIndexStreamer());
@@ -96,14 +96,14 @@ namespace edm {
     EDProductGetter const* returnValue=0;
     if (ep != 0) {
       {
-        TClass *cl = gROOT->GetClass("edm::RefCore");
+        TClass *cl = TClass::GetClass("edm::RefCore");
         TClassStreamer *st = cl->GetStreamer();
         if (st == 0) {
           cl->AdoptStreamer(new RefCoreStreamer());
         }
       }
       {
-        TClass *cl = gROOT->GetClass("edm::RefCoreWithIndex");
+        TClass *cl = TClass::GetClass("edm::RefCoreWithIndex");
         TClassStreamer *st = cl->GetStreamer();
         if (st == 0) {
           cl->AdoptStreamer(new RefCoreWithIndexStreamer());

--- a/DataFormats/Provenance/interface/ProductRegistry.h
+++ b/DataFormats/Provenance/interface/ProductRegistry.h
@@ -13,6 +13,7 @@
 #include "DataFormats/Provenance/interface/BranchListIndex.h"
 #include "DataFormats/Provenance/interface/BranchType.h"
 #include "FWCore/Utilities/interface/ProductHolderIndex.h"
+#include "FWCore/Utilities/interface/TypeID.h"
 
 #include "boost/array.hpp"
 #include <memory>
@@ -109,11 +110,11 @@ namespace edm {
     bool productProduced(BranchType branchType) const {return transient_.productProduced_[branchType];}
     bool anyProductProduced() const {return transient_.anyProductProduced_;}
 
-    std::vector<std::string> const& missingDictionaries() const {
+    std::vector<TypeID> const& missingDictionaries() const {
       return transient_.missingDictionaries_;
     }
 
-    std::vector<std::string>& missingDictionariesForUpdate() {
+    std::vector<TypeID>& missingDictionariesForUpdate() {
       return transient_.missingDictionaries_;
     }
 
@@ -142,7 +143,7 @@ namespace edm {
 
       std::map<BranchID, ProductHolderIndex> branchIDToIndex_;
 
-      std::vector<std::string> missingDictionaries_;
+      std::vector<TypeID> missingDictionaries_;
     };
 
   private:

--- a/DataFormats/Provenance/src/ProductRegistry.cc
+++ b/DataFormats/Provenance/src/ProductRegistry.cc
@@ -15,6 +15,7 @@
 #include "FWCore/Utilities/interface/Algorithms.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Utilities/interface/DictionaryTools.h"
+#include "FWCore/Utilities/interface/TypeID.h"
 #include "FWCore/Utilities/interface/TypeWithDict.h"
 #include "FWCore/Utilities/interface/WrappedClassName.h"
 
@@ -28,9 +29,9 @@ namespace edm {
   namespace {
     void checkDicts(BranchDescription const& productDesc) {
       if(productDesc.transient()) {
-        checkClassDictionaries(wrappedClassName(productDesc.fullClassName()), false);
+        checkClassDictionaries(TypeID(productDesc.wrappedType().typeInfo()), false);
       } else {
-        checkClassDictionaries(wrappedClassName(productDesc.fullClassName()), true);
+        checkClassDictionaries(TypeID(productDesc.wrappedType().typeInfo()), true);
       }
     }
   }
@@ -266,7 +267,7 @@ namespace edm {
 
   void ProductRegistry::initializeLookupTables() {
 
-    StringSet missingDicts;
+    TypeSet missingDicts;
     transient_.branchIDToIndex_.clear();
     constProductList().clear();
 
@@ -282,7 +283,7 @@ namespace edm {
 
       //only do the following if the data is supposed to be available in the event
       if(desc.present()) {
-        bool hasDict = checkTypeDictionary(desc.className()) && checkClassDictionary(wrappedClassName(desc.className()));
+        bool hasDict = checkTypeDictionary(TypeID(desc.unwrappedType().typeInfo())) && checkClassDictionary(TypeID(desc.wrappedType().typeInfo()));
         if(hasDict) {
           TypeWithDict type(TypeWithDict::byName(desc.className()));
           ProductHolderIndex index =

--- a/FWCore/FWLite/src/RefStreamer.cc
+++ b/FWCore/FWLite/src/RefStreamer.cc
@@ -1,6 +1,6 @@
 #include "DataFormats/Common/interface/RefCore.h"
 #include "DataFormats/Common/interface/RefCoreStreamer.h"
-#include "TROOT.h"
+#include "TClass.h"
 #include <cassert>
 #include <ostream>
 
@@ -9,14 +9,14 @@ class TBuffer;
 namespace fwlite {
   edm::EDProductGetter const* setRefStreamer(edm::EDProductGetter const* ep) {
     {
-      TClass* cl = gROOT->GetClass("edm::RefCore");
+      TClass* cl = TClass::GetClass("edm::RefCore");
       TClassStreamer* st = cl->GetStreamer();
       if (st == 0) {
         cl->AdoptStreamer(new edm::RefCoreStreamer());
       }
     }
     {
-      TClass* cl = gROOT->GetClass("edm::RefCoreWithIndex");
+      TClass* cl = TClass::GetClass("edm::RefCoreWithIndex");
       TClassStreamer* st = cl->GetStreamer();
       if (st == 0) {
         cl->AdoptStreamer(new edm::RefCoreWithIndexStreamer());

--- a/FWCore/Framework/src/Principal.cc
+++ b/FWCore/Framework/src/Principal.cc
@@ -20,6 +20,7 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
+#include "TClass.h"
 
 #include <algorithm>
 #include <cstring>
@@ -35,14 +36,19 @@ namespace edm {
 
   static
   void
-  maybeThrowMissingDictionaryException(TypeID const& productType, bool isElement, std::vector<std::string> const& missingDictionaries) {
-    if(binary_search_all(missingDictionaries, productType.className())) {
-      if(isElement) {
-        checkTypeDictionary(productType.className());
-      } else {
-        checkClassDictionary(wrappedClassName(productType.className()));
+  maybeThrowMissingDictionaryException(TypeID const& productType, bool isElement, std::vector<TypeID> const& missingDictionaries) {
+    if(isElement) {
+      if(binary_search_all(missingDictionaries, productType)) {
+        checkTypeDictionary(productType);
+        throwMissingDictionariesException();
       }
-      throwMissingDictionariesException();
+    } else {
+      TClass* cl = TClass::GetClass(wrappedClassName(productType.className()).c_str());
+      TypeID wrappedProductType = TypeID(cl->GetTypeInfo());
+      if(binary_search_all(missingDictionaries, wrappedProductType)) {
+        checkClassDictionary(wrappedProductType);
+        throwMissingDictionariesException();
+      }
     }
   }
 

--- a/FWCore/RootAutoLibraryLoader/src/RootAutoLibraryLoader.cc
+++ b/FWCore/RootAutoLibraryLoader/src/RootAutoLibraryLoader.cc
@@ -223,7 +223,7 @@ GetClass(char const* classname, bool load)
   // Good, library was loaded, now have ROOT provide the TClass.
   // Note: Here we guard against a recursive call to ourselves.
   classNameAttemptingToLoad_ = classname;
-  auto ret = gROOT->GetClass(classname, true);
+  auto ret = TClass::GetClass(classname, true);
   classNameAttemptingToLoad_.clear();
   return ret;
 }

--- a/FWCore/Utilities/interface/DictionaryTools.h
+++ b/FWCore/Utilities/interface/DictionaryTools.h
@@ -12,10 +12,13 @@ the CMS event model.
 #include <string>
 #include <vector>
 
+#include "FWCore/Utilities/interface/TypeID.h"
+
 namespace edm {
 
+class TypeID;
 class TypeWithDict;
-using StringSet = std::set<std::string>;
+using TypeSet = std::set<TypeID>;
 
 bool
 find_nested_type_named(std::string const& nested_type,
@@ -56,13 +59,13 @@ bool
 is_RefToBaseVector(TypeWithDict const& possible_ref_vector,
                    TypeWithDict& value_type);
 
-bool checkClassDictionary(std::string const& name);
-void checkClassDictionaries(std::string const& name, bool recursive = true);
-bool checkTypeDictionary(std::string const& name);
-void checkTypeDictionaries(std::string const& name, bool recursive = true);
+bool checkClassDictionary(TypeID const& type);
+void checkClassDictionaries(TypeID const& type, bool recursive = true);
+bool checkTypeDictionary(TypeID const& type);
+void checkTypeDictionaries(TypeID const& type, bool recursive = true);
 void throwMissingDictionariesException();
 void loadMissingDictionaries();
-StringSet& missingTypes();
+TypeSet& missingTypes();
 
 void public_base_classes(TypeWithDict const& type,
                          std::vector<TypeWithDict>& baseTypes);

--- a/IOPool/Common/interface/CustomStreamer.h
+++ b/IOPool/Common/interface/CustomStreamer.h
@@ -2,7 +2,7 @@
 #define IOPool_Common_CustomStreamer_h
 
 #include <string>
-#include "TROOT.h"
+#include "TClass.h"
 #include "TClassStreamer.h"
 #include "TClassRef.h"
 #include "FWCore/Utilities/interface/TypeID.h"
@@ -39,7 +39,7 @@ namespace edm {
   template <typename T>
   void
   SetCustomStreamer() {
-    TClass *cl = gROOT->GetClass(TypeID(typeid(T)).className().c_str());
+    TClass *cl = TClass::GetClass(typeid(T));
     if (cl->GetStreamer() == 0) {
       cl->AdoptStreamer(new CustomStreamer<T>());
     }
@@ -48,7 +48,7 @@ namespace edm {
   template <typename T>
   void
   SetCustomStreamer(T const&) {
-    TClass *cl = gROOT->GetClass(TypeID(typeid(T)).className().c_str());
+    TClass *cl = TClass::GetClass(typeid(T));
     if (cl->GetStreamer() == 0) {
       cl->AdoptStreamer(new CustomStreamer<T>());
     }

--- a/IOPool/Input/src/RootDelayedReader.cc
+++ b/IOPool/Input/src/RootDelayedReader.cc
@@ -11,7 +11,6 @@
 
 #include "IOPool/Common/interface/getWrapperBasePtr.h"
 
-#include "TROOT.h"
 #include "TBranch.h"
 #include "TClass.h"
 
@@ -28,7 +27,7 @@ namespace edm {
    nextReader_(),
    resourceAcquirer_(inputType == InputType::Primary ? new SharedResourcesAcquirer(SharedResourcesRegistry::instance()->createAcquirerForSourceDelayedReader()) : static_cast<SharedResourcesAcquirer*>(nullptr)),
    inputType_(inputType),
-   wrapperBaseTClass_(gROOT->GetClass("edm::WrapperBase")) {
+   wrapperBaseTClass_(TClass::GetClass("edm::WrapperBase")) {
   }
 
   RootDelayedReader::~RootDelayedReader() {
@@ -62,7 +61,7 @@ namespace edm {
     setRefCoreStreamer(ep);
     TClass* cp = branchInfo.classCache_;
     if(nullptr == cp) {
-      branchInfo.classCache_ = gROOT->GetClass(branchInfo.branchDescription_.wrappedName().c_str());
+      branchInfo.classCache_ = TClass::GetClass(branchInfo.branchDescription_.wrappedName().c_str());
       cp = branchInfo.classCache_;
       branchInfo.offsetToWrapperBase_ = cp->GetBaseClassOffset(wrapperBaseTClass_);
     }

--- a/IOPool/Input/src/RootFile.cc
+++ b/IOPool/Input/src/RootFile.cc
@@ -45,7 +45,6 @@
 #include "DataFormats/Provenance/interface/RunAux.h"
 #include "FWCore/ParameterSet/interface/ParameterSetConverter.h"
 
-#include "TROOT.h"
 #include "Rtypes.h"
 #include "TClass.h"
 #include "TString.h"
@@ -207,7 +206,7 @@ namespace edm {
       eventProductProvenanceRetrievers_(),
       parentageIDLookup_(),
       daqProvenanceHelper_(),
-      edProductClass_(gROOT->GetClass("edm::WrapperBase")) {
+      edProductClass_(TClass::GetClass("edm::WrapperBase")) {
 
     hasNewlyDroppedBranch_.fill(false);
 
@@ -1712,7 +1711,7 @@ namespace edm {
       for(ProductRegistry::ProductList::iterator it = prodList.begin(), itEnd = prodList.end(); it != itEnd;) {
         BranchDescription const& prod = it->second;
         if(prod.branchType() != InEvent) {
-          TClass* cp = gROOT->GetClass(prod.wrappedName().c_str());
+          TClass* cp = TClass::GetClass(prod.wrappedName().c_str());
           void* p = cp->New();
           int offset = cp->GetBaseClassOffset(edProductClass_);
           std::unique_ptr<WrapperBase> edp = getWrapperBasePtr(p, offset);

--- a/IOPool/Output/src/PoolOutputModule.cc
+++ b/IOPool/Output/src/PoolOutputModule.cc
@@ -92,9 +92,8 @@ namespace edm {
     for(int i = InEvent; i < NumBranchTypes; ++i) {
       BranchType branchType = static_cast<BranchType>(i);
       SelectedProducts const& keptVector = keptProducts()[branchType];
-      for(SelectedProducts::const_iterator it = keptVector.begin(), itEnd = keptVector.end(); it != itEnd; ++it) {
-        BranchDescription const& prod = **it;
-        checkClassDictionaries(wrappedClassName(prod.fullClassName()), false);
+      for(auto const& prod : keptVector) {
+        checkClassDictionaries(TypeID(prod->wrappedType().typeInfo()), false);
       }
     }
   }

--- a/IOPool/Output/src/RootOutputFile.cc
+++ b/IOPool/Output/src/RootOutputFile.cc
@@ -33,7 +33,6 @@
 #include "FWCore/Utilities/interface/ExceptionPropagate.h"
 #include "IOPool/Common/interface/getWrapperBasePtr.h"
 
-#include "TROOT.h"
 #include "TTree.h"
 #include "TFile.h"
 #include "TClass.h"
@@ -109,7 +108,7 @@ namespace edm {
       processHistoryRegistry_(),
       parentageIDs_(),
       branchesWithStoredHistory_(),
-      wrapperBaseTClass_(gROOT->GetClass("edm::WrapperBase")) {
+      wrapperBaseTClass_(TClass::GetClass("edm::WrapperBase")) {
 #if ROOT_VERSION_CODE >= ROOT_VERSION(5,30,0)
     if (om_->compressionAlgorithm() == std::string("ZLIB")) {
       filePtr_->SetCompressionAlgorithm(ROOT::kZLIB);
@@ -721,7 +720,7 @@ namespace edm {
         if(product == nullptr) {
           // No product with this ID is in the event.
           // Add a null product.
-          TClass* cp = gROOT->GetClass(item.branchDescription_->wrappedName().c_str());
+          TClass* cp = TClass::GetClass(item.branchDescription_->wrappedName().c_str());
           int offset = cp->GetBaseClassOffset(wrapperBaseTClass_);
           void* p = cp->New();
           std::unique_ptr<WrapperBase> dummy = getWrapperBasePtr(p, offset);

--- a/IOPool/Streamer/src/ClassFiller.cc
+++ b/IOPool/Streamer/src/ClassFiller.cc
@@ -15,15 +15,20 @@
 #include <iostream>
 
 namespace edm {
+  void loadType(TypeID const& type) {
+    checkClassDictionaries(type, true);
+    if (!missingTypes().empty()) {
+      TypeSet missing = missingTypes();
+      missingTypes().clear();
+      for_all(missing, loadType);
+    }
+  }
+
   void loadCap(std::string const& name) {
     FDEBUG(1) << "Loading dictionary for " << name << "\n";
     edmplugin::PluginCapabilities::get()->load(dictionaryPlugInPrefix() + name);
-    checkClassDictionaries(name, true);
-    if (!missingTypes().empty()) {
-      StringSet missing = missingTypes();
-      missingTypes().clear();
-      for_all(missing, loadCap);
-    }
+    TClass* cl = TClass::GetClass(name.c_str());
+    loadType(TypeID(cl->GetTypeInfo()));
   }
 
   void doBuildRealData(std::string const& name) {


### PR DESCRIPTION
When checking for a class dictionary, use the std::type_info of the class, rather than the name of the class. This makes the checking independent of naming conventions, and also reduces string demangling and other string manipulations.
This pull request also changes the obsolete "gROOT->GetClass()" to the preferred equivalent, "TClass::GetClass()", in the framework.
Please merge this pull request as soon as convenient.
