### PR TITLE
Fix for L1KeyList migration tools

### DIFF
--- a/CondCore/CondDB/src/IOVSchema.h
+++ b/CondCore/CondDB/src/IOVSchema.h
@@ -165,7 +165,7 @@ namespace cond {
       
       column( SOURCE_ACCOUNT, std::string );
       column( SOURCE_TOKEN, std::string );
-      column( PAYLOAD_HASH, std::string );
+      column( PAYLOAD_HASH, std::string, PAYLOAD::PAYLOAD_HASH_SIZE );
       column( INSERTION_TIME, boost::posix_time::ptime );
       
       class Table : public IPayloadMigrationTable {

--- a/CondCore/Utilities/bin/conddb_migrate.cpp
+++ b/CondCore/Utilities/bin/conddb_migrate.cpp
@@ -47,12 +47,21 @@ cond::MigrateUtilities::~MigrateUtilities(){
 int cond::MigrateUtilities::execute(){
 
   bool debug = hasDebug();
+  int filterPosition = -1;
   std::string tag("");
   if( hasOptionValue("tag")) {
     tag = getOptionValue<std::string>("tag");
     if(debug){
       std::cout << "tag " << tag << std::endl;
     }  
+    if( tag[0] == '*' ){ 
+      tag = tag.substr(1);
+      filterPosition = 0;
+    }
+    if( tag[tag.size()-1] == '*' ){
+      tag = tag.substr(0,tag.size()-1);
+      filterPosition = 1;
+    }
   }
   bool replace = hasOptionValue("replace");
   bool validate = !hasOptionValue("fast");
@@ -68,10 +77,18 @@ int cond::MigrateUtilities::execute(){
   sourcedb.transaction().start( true );
   cond::MetaData  metadata(sourcedb);
   std::vector<std::string> tagToProcess;
-  if( !tag.empty() ){
+  if( !tag.empty() && filterPosition == -1 ){
     tagToProcess.push_back( tag );
   } else {
     metadata.listAllTags( tagToProcess );
+    if( filterPosition != -1 ) {
+      std::vector<std::string> filteredList;
+      for( const auto& t: tagToProcess ) {
+	size_t ptr = t.find( tag );
+	if( ptr != std::string::npos && ptr < filterPosition ) filteredList.push_back( t );
+      }
+      tagToProcess = filteredList;
+    }
   }
 
   cond::DbSession logdb = openDbSession("log", cond::Auth::COND_READER_ROLE, true ); 

--- a/CondCore/Utilities/src/CondDBImport.cc
+++ b/CondCore/Utilities/src/CondDBImport.cc
@@ -232,6 +232,8 @@ namespace cond {
 	    bool exists = false;
             std::pair<std::string,boost::shared_ptr<void> > missingPayload = fetchIfExists( sourcePid, source, exists );
 	    if( exists ) pid = import( source, sourcePid, missingPayload.first, missingPayload.second.get(), destination );
+	    std::cout <<"WARNING: OID "<<sourcePid<<" will be mapped to HASH "<<pid<<std::endl;
+	    if( pid != "0" ) destination.addMigratedPayload( source.connectionString(), sourcePid, pid );
 	  }
           converted.addKey( kitem.first, pid );
 	}
@@ -244,6 +246,8 @@ namespace cond {
 	      bool exists = false;
 	      std::pair<std::string,boost::shared_ptr<void> > missingPayload = fetchIfExists( sourcePid, source, exists );
 	      if( exists ) pid = import( source, sourcePid, missingPayload.first, missingPayload.second.get(), destination );
+	      std::cout <<"WARNING: OID "<<sourcePid<<" will be mapped to HASH "<<pid<<std::endl;
+	      if( pid != "0" ) destination.addMigratedPayload( source.connectionString(), sourcePid, pid );
 	    }
 	    converted.addKey( ritem.first, kitem.first, pid );
 	  }


### PR DESCRIPTION
This fix only involves the specific migration tool converting the L1TriggerKeyList from conddbv1 to conddbv2
