### PR TITLE
fix out of bound array index in HCalResponse

### DIFF
--- a/FastSimulation/Calorimetry/interface/HCALResponse.h
+++ b/FastSimulation/Calorimetry/interface/HCALResponse.h
@@ -87,7 +87,7 @@ private:
   double respFactorEM;
 
   // Tabulated energy, et/pt and eta points
-  vec1 eGridHD[3];
+  vec1 eGridHD[4];
   vec1 eGridEM;
   vec1 eGridMU;
   vec1 etaGridMU;

--- a/FastSimulation/Calorimetry/src/HCALResponse.cc
+++ b/FastSimulation/Calorimetry/src/HCALResponse.cc
@@ -396,10 +396,9 @@ double HCALResponse::interHD(int mip, double e, int ie, int ieta, int det, Rando
   double mean = 0;
   vec1 pars(nPar,0);
 
-  // why this ieta> 5 condition?
-  //if (det==2 && ieta>5 && e<20){
-  if (det==2 && e<20){
-
+  // for ieta < 5 there is overlap between HE and HF, and measurement comes from HE
+  if (det==2 && ieta>5 && e<20){
+  
     for(int p = 0; p < 4; p++){
       y1=PoissonParameters[p][ie][ieta];
       y2=PoissonParameters[p][ie+1][ieta];


### PR DESCRIPTION
note:

changed indents causes messy diffs
relevant changes:

FastSimulation/Calorimetry/interface/HCALResponse.h, 
line 90: changed array size

FastSimulation/Calorimetry/src/HCALResponse.cc
line 397: got rid of redundant condition
line 407: only read x1 and x2 when they are actually used
