### PR TITLE
Fix setting the # of presamples for HcalUpgradeDataFrame.

### DIFF
--- a/DataFormats/HcalDigi/src/HcalUpgradeDataFrame.cc
+++ b/DataFormats/HcalDigi/src/HcalUpgradeDataFrame.cc
@@ -32,9 +32,9 @@ void HcalUpgradeDataFrame::setSize(int size) {
 }
 
 void HcalUpgradeDataFrame::setPresamples(int presamples) {
-  if (presamples>MAXSAMPLES) presamples_|=MAXSAMPLES&0xF;
+  if (presamples>MAXSAMPLES) presamples_=MAXSAMPLES&0xF;
   else if (presamples<=0) presamples_=0;
-  else presamples_|=presamples&0xF;
+  else presamples_=presamples&0xF;
 }
 
 void HcalUpgradeDataFrame::setReadoutIds(const HcalElectronicsId& eid) {


### PR DESCRIPTION
The constructor `HcalUpgradeDataFrame::HcalUpgradeDataFrame(HcalDetId id, int capId, int samples, int presamples)` will use an uninitialized (random) value of `presamples_` to bit-or the passed `presamples` parameter.  This will yield unexpected values for `presamples`, which fail an assert in the HCAL trigger primitive chain [starting here](https://github.com/cms-sw/cmssw/blob/CMSSW_6_2_X_SLHC/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc#L203).

Remove the bit-wise or to have well-behaved data frames.
