### PR TITLE
add missing parameter [set to default value (-1.)] needed for confDB

### DIFF
--- a/TrackingTools/KalmanUpdators/python/Chi2ChargeMeasurementEstimatorESProducer_cfi.py
+++ b/TrackingTools/KalmanUpdators/python/Chi2ChargeMeasurementEstimatorESProducer_cfi.py
@@ -1,10 +1,11 @@
 import FWCore.ParameterSet.Config as cms
 
 Chi2ChargeMeasurementEstimator = cms.ESProducer("Chi2ChargeMeasurementEstimatorESProducer",
-    ComponentName = cms.string('Chi2Charge'),
-    nSigma = cms.double(3.0),
-    MaxChi2 = cms.double(30.0),
-    minGoodStripCharge = cms.double(2069)
+    ComponentName        = cms.string('Chi2Charge'),
+    nSigma               = cms.double(3.0),
+    MaxChi2              = cms.double(30.0),
+    minGoodStripCharge   = cms.double(2069),
+    pTChargeCutThreshold = cms.double(-1.)
 )
 
 


### PR DESCRIPTION
in integrating the new strip cluster charge cut @HLT
I found there was a missing parameter (pTChargeCutThreshold) in the template module in confDB
it is needed for the new implementation of the CCC@HLT

please, integrate this PR asap
[the new configuration should go into confDB w/in pre7, and JetMET should cross check the performance]
