### PR TITLE
Resolve undefined behavior with VLAs length

### DIFF
--- a/RecoEcal/EgammaClusterAlgos/src/Multi5x5BremRecoveryClusterAlgo.cc
+++ b/RecoEcal/EgammaClusterAlgos/src/Multi5x5BremRecoveryClusterAlgo.cc
@@ -42,7 +42,7 @@ reco::SuperClusterCollection Multi5x5BremRecoveryClusterAlgo::makeSuperClusters(
 void Multi5x5BremRecoveryClusterAlgo::makeIslandSuperClusters(reco::CaloClusterPtrVector &clusters_v, 
 		double etaRoad, double phiRoad)
 {
-
+  if(clusters_v.empty()) return;
 
   bool usedSeed[clusters_v.size()];
   for (auto ic=0U; ic<clusters_v.size(); ++ic) usedSeed[ic]=false;


### PR DESCRIPTION
```
RecoEcal/EgammaClusterAlgos/src/Multi5x5BremRecoveryClusterAlgo.cc:47:34:
runtime error: variable length array bound evaluates to non-positive
value 0
RecoEcal/EgammaClusterAlgos/src/Multi5x5BremRecoveryClusterAlgo.cc:50:30:
runtime error: variable length array bound evaluates to non-positive
value 0
```

`Multi5x5BremRecoveryClusterAlgo::makeIslandSuperClusters(..)` is called
with empty `clusters_v`. There is nothing to be done if `clusters_v` is
empty, thus bail out early.

This happens 36 times while running short matrix.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
