### PR TITLE
MiniAOD JME changes

### DIFF
--- a/CommonTools/RecoAlgos/plugins/JetDeltaRTagInfoValueMapProducer.cc
+++ b/CommonTools/RecoAlgos/plugins/JetDeltaRTagInfoValueMapProducer.cc
@@ -1,0 +1,132 @@
+/* \class PFJetSelector
+ *
+ * Selects jets with a configurable string-based cut,
+ * and also writes out the constituents of the jet
+ * into a separate collection.
+ *
+ * \author: Sal Rappoccio
+ *
+ *
+ * for more details about the cut syntax, see the documentation
+ * page below:
+ *
+ *   https://twiki.cern.ch/twiki/bin/view/CMS/SWGuidePhysicsCutParser
+ *
+ *
+ */
+
+
+#include "FWCore/Framework/interface/EDProducer.h"
+
+#include "DataFormats/JetReco/interface/Jet.h"
+#include "DataFormats/JetReco/interface/CATopJetTagInfo.h"
+#include "DataFormats/JetReco/interface/PFJet.h"
+#include "DataFormats/JetReco/interface/CaloJet.h"
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "DataFormats/Common/interface/ValueMap.h"
+#include "DataFormats/Math/interface/deltaR.h"
+
+template < class T, class I >
+class JetDeltaRTagInfoValueMapProducer : public edm::EDProducer {
+
+public:
+
+  typedef std::vector<T> JetsInput;
+  typedef std::vector<I> TagInfosCollection;
+
+  JetDeltaRTagInfoValueMapProducer ( edm::ParameterSet const & params ) :
+      srcToken_( consumes< typename edm::View<T> >( params.getParameter<edm::InputTag>("src") ) ),
+      matchedToken_( consumes< typename edm::View<T> >( params.getParameter<edm::InputTag>( "matched" ) ) ),
+      matchedTagInfosToken_( consumes< typename edm::View<I> >( params.getParameter<edm::InputTag>( "matchedTagInfos" ) ) ),
+      distMax_( params.getParameter<double>( "distMax" ) )
+  {
+        produces< TagInfosCollection >();
+  }
+
+  virtual ~JetDeltaRTagInfoValueMapProducer() {}
+
+private:
+
+  virtual void beginJob() override {}
+  virtual void endJob() override {}
+
+  virtual void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override {
+
+    std::auto_ptr< TagInfosCollection > mappedTagInfos ( new TagInfosCollection() );
+
+
+    edm::Handle< typename edm::View<T> > h_jets1;
+    iEvent.getByToken( srcToken_, h_jets1 );
+    edm::Handle< typename edm::View<T> > h_jets2;
+    iEvent.getByToken( matchedToken_, h_jets2 );
+    edm::Handle< typename edm::View<I> > h_tagInfos;
+    iEvent.getByToken( matchedTagInfosToken_, h_tagInfos );
+
+
+    std::vector<bool> jets2_locks( h_jets2->size(), false );
+
+    for ( typename edm::View<T>::const_iterator ibegin = h_jets1->begin(),
+          iend = h_jets1->end(), ijet = ibegin;
+          ijet != iend; ++ijet )
+    {
+      float matched_dR2 = 1e9;
+      int matched_index = -1;
+
+      //std::cout << "Looking at jet " << ijet - ibegin << ", mass = " << ijet->mass() << std::endl;
+     
+      for ( typename edm::View<T>::const_iterator jbegin = h_jets2->begin(),
+            jend = h_jets2->end(), jjet = jbegin;
+            jjet != jend; ++jjet )
+      {
+        int index=jjet - jbegin;
+
+	//std::cout << "Checking jet " << index << ", mass = " << jjet->mass() << std::endl;
+
+        if( jets2_locks.at(index) ) continue; // skip jets that have already been matched
+
+        float temp_dR2 = reco::deltaR2(ijet->eta(),ijet->phi(),jjet->eta(),jjet->phi());
+        if ( temp_dR2 < matched_dR2 )
+        {
+          matched_dR2 = temp_dR2;
+          matched_index = index;
+        }
+      }// end loop over src jets
+
+      I mappedTagInfo; 
+
+      if( matched_index>=0 && matched_index < h_tagInfos->size() )
+      {
+        if ( matched_dR2 > distMax_*distMax_ )
+          edm::LogWarning("MatchedJetsFarApart") << "Matched jets separated by dR greater than distMax=" << distMax_;
+        else
+        {
+          jets2_locks.at(matched_index) = true;
+	  
+          auto otherTagInfo = h_tagInfos->at( matched_index );
+	  otherTagInfo.setJetRef( h_jets1->refAt( ijet - ibegin) );
+	  mappedTagInfo = otherTagInfo;
+	  //std::cout << "Matched! : " << matched_index << ", mass = " << mappedTagInfo.properties().topMass << std::endl;
+        }
+      }
+
+      mappedTagInfos->push_back( mappedTagInfo );
+
+    }// end loop over matched jets
+    
+
+    // put  in Event
+    iEvent.put(mappedTagInfos);
+  }
+
+  edm::EDGetTokenT< typename edm::View<T> >  srcToken_;
+  edm::EDGetTokenT< typename edm::View<T> >  matchedToken_;
+  edm::EDGetTokenT< typename edm::View<I> >  matchedTagInfosToken_;
+  double                                     distMax_;
+
+};
+
+typedef JetDeltaRTagInfoValueMapProducer<reco::Jet, reco::CATopJetTagInfo> RecoJetDeltaRTagInfoValueMapProducer;
+
+DEFINE_FWK_MODULE( RecoJetDeltaRTagInfoValueMapProducer );

--- a/CommonTools/RecoAlgos/plugins/JetDeltaRTagInfoValueMapProducer.cc
+++ b/CommonTools/RecoAlgos/plugins/JetDeltaRTagInfoValueMapProducer.cc
@@ -69,6 +69,7 @@ private:
     edm::Handle< typename edm::View<I> > h_tagInfos;
     iEvent.getByToken( matchedTagInfosToken_, h_tagInfos );
 
+    double distMax2 = distMax_*distMax_;
 
     std::vector<bool> jets2_locks( h_jets2->size(), false );
 
@@ -103,7 +104,7 @@ private:
 
       if( matched_index>=0 && matched_index < h_tagInfos->size() )
       {
-        if ( matched_dR2 > distMax_*distMax_ )
+        if ( matched_dR2 > distMax2 )
           edm::LogWarning("MatchedJetsFarApart") << "Matched jets separated by dR greater than distMax=" << distMax_;
         else
         {

--- a/CommonTools/RecoAlgos/plugins/JetDeltaRTagInfoValueMapProducer.cc
+++ b/CommonTools/RecoAlgos/plugins/JetDeltaRTagInfoValueMapProducer.cc
@@ -1,8 +1,13 @@
-/* \class PFJetSelector
+/* \class JetDeltaRTagInfoValueMapProducer<T,I>
  *
- * Selects jets with a configurable string-based cut,
- * and also writes out the constituents of the jet
- * into a separate collection.
+ * Inputs two jet collections ("src" and "matched", type T), with
+ * the second having tag infos run on them ("matchedTagInfos", type I). 
+ * The jet collections are matched using delta-R matching. The
+ * tag infos from the second collection are then rewritten into a
+ * new TagInfoCollection, keyed to the first jet collection. 
+ * This can be used in the miniAOD to associate the previously-run
+ * CA8 "Top-Tagged" jets with their CATopTagInfos to the AK8 jets
+ * that are stored in the miniAOD. 
  *
  * \author: Sal Rappoccio
  *

--- a/CommonTools/RecoAlgos/plugins/JetDeltaRTagInfoValueMapProducer.cc
+++ b/CommonTools/RecoAlgos/plugins/JetDeltaRTagInfoValueMapProducer.cc
@@ -105,7 +105,7 @@ private:
       if( matched_index>=0 && matched_index < h_tagInfos->size() )
       {
         if ( matched_dR2 > distMax2 )
-          edm::LogWarning("MatchedJetsFarApart") << "Matched jets separated by dR greater than distMax=" << distMax_;
+          LogDebug("MatchedJetsFarApart") << "Matched jets separated by dR greater than distMax=" << distMax_;
         else
         {
           jets2_locks.at(matched_index) = true;

--- a/CommonTools/RecoAlgos/plugins/JetDeltaRTagInfoValueMapProducer.cc
+++ b/CommonTools/RecoAlgos/plugins/JetDeltaRTagInfoValueMapProducer.cc
@@ -1,0 +1,127 @@
+/* \class PFJetSelector
+ *
+ * Selects jets with a configurable string-based cut,
+ * and also writes out the constituents of the jet
+ * into a separate collection.
+ *
+ * \author: Sal Rappoccio
+ *
+ *
+ * for more details about the cut syntax, see the documentation
+ * page below:
+ *
+ *   https://twiki.cern.ch/twiki/bin/view/CMS/SWGuidePhysicsCutParser
+ *
+ *
+ */
+
+
+#include "FWCore/Framework/interface/EDProducer.h"
+
+#include "DataFormats/JetReco/interface/Jet.h"
+#include "DataFormats/JetReco/interface/CATopJetTagInfo.h"
+#include "DataFormats/JetReco/interface/PFJet.h"
+#include "DataFormats/JetReco/interface/CaloJet.h"
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "DataFormats/Common/interface/ValueMap.h"
+#include "DataFormats/Math/interface/deltaR.h"
+
+template < class T, class I >
+class JetDeltaRTagInfoValueMapProducer : public edm::EDProducer {
+
+public:
+
+  typedef std::vector<T> JetsInput;
+  typedef std::vector<I> TagInfosCollection;
+
+  JetDeltaRTagInfoValueMapProducer ( edm::ParameterSet const & params ) :
+      srcToken_( consumes< typename edm::View<T> >( params.getParameter<edm::InputTag>("src") ) ),
+      matchedToken_( consumes< typename edm::View<T> >( params.getParameter<edm::InputTag>( "matched" ) ) ),
+      matchedTagInfosToken_( consumes< typename edm::View<I> >( params.getParameter<edm::InputTag>( "matchedTagInfos" ) ) ),
+      distMax_( params.getParameter<double>( "distMax" ) )
+  {
+        produces< TagInfosCollection >();
+  }
+
+  virtual ~JetDeltaRTagInfoValueMapProducer() {}
+
+private:
+
+  virtual void beginJob() override {}
+  virtual void endJob() override {}
+
+  virtual void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override {
+
+    std::auto_ptr< TagInfosCollection > mappedTagInfos ( new TagInfosCollection() );
+
+
+    edm::Handle< typename edm::View<T> > h_jets1;
+    iEvent.getByToken( srcToken_, h_jets1 );
+    edm::Handle< typename edm::View<T> > h_jets2;
+    iEvent.getByToken( matchedToken_, h_jets2 );
+    edm::Handle< typename edm::View<I> > h_tagInfos;
+    iEvent.getByToken( matchedTagInfosToken_, h_tagInfos );
+
+
+    std::vector<float> values( h_jets1->size(), -99999 );
+    std::vector<bool> jets1_locks( h_jets1->size(), false );
+
+    for ( typename edm::View<T>::const_iterator ibegin = h_jets2->begin(),
+          iend = h_jets2->end(), ijet = ibegin;
+          ijet != iend; ++ijet )
+    {
+      float matched_dR2 = 1e9;
+      int matched_index = -1;
+     
+      for ( typename edm::View<T>::const_iterator jbegin = h_jets1->begin(),
+            jend = h_jets1->end(), jjet = jbegin;
+            jjet != jend; ++jjet )
+      {
+        int index=jjet - jbegin;
+
+        if( jets1_locks.at(index) ) continue; // skip jets that have already been matched
+
+        float temp_dR2 = reco::deltaR2(ijet->eta(),ijet->phi(),jjet->eta(),jjet->phi());
+        if ( temp_dR2 < matched_dR2 )
+        {
+          matched_dR2 = temp_dR2;
+          matched_index = index;
+        }
+      }// end loop over src jets
+
+      I mappedTagInfo; 
+
+      if( matched_index>=0 )
+      {
+        if ( matched_dR2 > distMax_*distMax_ )
+          edm::LogWarning("MatchedJetsFarApart") << "Matched jets separated by dR greater than distMax=" << distMax_;
+        else
+        {
+          jets1_locks.at(matched_index) = true;
+
+
+          mappedTagInfo = h_tagInfos->at( matched_index );
+        }
+      }
+
+      mappedTagInfos->push_back( mappedTagInfo );
+
+    }// end loop over matched jets
+    
+
+    // put  in Event
+    iEvent.put(mappedTagInfos);
+  }
+
+  edm::EDGetTokenT< typename edm::View<T> >  srcToken_;
+  edm::EDGetTokenT< typename edm::View<T> >  matchedToken_;
+  edm::EDGetTokenT< typename edm::View<I> >  matchedTagInfosToken_;
+  double                                     distMax_;
+
+};
+
+typedef JetDeltaRTagInfoValueMapProducer<reco::Jet, reco::CATopJetTagInfo> RecoJetDeltaRTagInfoValueMapProducer;
+
+DEFINE_FWK_MODULE( RecoJetDeltaRTagInfoValueMapProducer );

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -120,12 +120,12 @@ def miniAOD_customizeCommon(process):
     #keep this after all addJetCollections otherwise it will attempt computing them also for stuf with no taginfos
     #Some useful BTAG vars
     ## process.patJetsAK8.userData.userFunctions = cms.vstring(
-    ##     "jet.tagInfo('CATop').properties().topMass",
-    ##     "jet.tagInfo('CATop').properties().nSubJets",
-    ##     "jet.tagInfo('CATop').properties().minMass"
+    ##     "jet.tagInfo('caTop').properties().topMass",
+    ##     "jet.tagInfo('caTop').properties().nSubJets",
+    ##     "jet.tagInfo('caTop').properties().minMass"
     ## )
     ## process.patJetsAK8.userData.userFunctionLabels = cms.vstring('topMass','vtxNtracks','vtx3DVal','vtx3DSig')
-    process.patJetsAK8.tagInfoSources = cms.VInputTag(cms.InputTag("caTopTagInfos"))
+    process.patJetsAK8.tagInfoSources = cms.VInputTag(cms.InputTag("ak8TopTagInfos"))
     process.patJetsAK8.addTagInfos = cms.bool(True) 
 
 

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -119,15 +119,18 @@ def miniAOD_customizeCommon(process):
 
     #keep this after all addJetCollections otherwise it will attempt computing them also for stuf with no taginfos
     #Some useful BTAG vars
-    ## process.patJetsAK8.userData.userFunctions = cms.vstring(
-    ##     "jet.tagInfo('caTop').properties().topMass",
-    ##     "jet.tagInfo('caTop').properties().nSubJets",
-    ##     "jet.tagInfo('caTop').properties().minMass"
-    ## )
+
     ## process.patJetsAK8.userData.userFunctionLabels = cms.vstring('topMass','vtxNtracks','vtx3DVal','vtx3DSig')
     process.patJetsAK8.tagInfoSources = cms.VInputTag(cms.InputTag("ak8TopTagInfos"))
     process.patJetsAK8.addTagInfos = cms.bool(True) 
-
+    process.patJetsAK8.userData.userFunctions = cms.vstring(
+        "jet.tagInfo('caTop').properties().topMass",
+        "jet.tagInfo('caTop').properties().nSubJets",
+        "jet.tagInfo('caTop').properties().minMass"
+    )
+    process.patJetsAK8.userData.userFunctionLabels = cms.vstring(
+        "topMass", "nSubJets", "minMass"
+        )
 
 
     # add Njetiness
@@ -136,8 +139,6 @@ def miniAOD_customizeCommon(process):
     process.NjettinessAK8.src = cms.InputTag("ak8PFJetsCHS")
     process.NjettinessAK8.cone = cms.double(0.8)
     process.patJetsAK8.userData.userFloats.src += ['NjettinessAK8:tau1','NjettinessAK8:tau2','NjettinessAK8:tau3']
-
-
 
             
     

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -124,9 +124,9 @@ def miniAOD_customizeCommon(process):
     process.patJetsAK8.tagInfoSources = cms.VInputTag(cms.InputTag("ak8TopTagInfos"))
     process.patJetsAK8.addTagInfos = cms.bool(True) 
     process.patJetsAK8.userData.userFunctions = cms.vstring(
-        "jet.tagInfo('caTop').properties().topMass",
-        "jet.tagInfo('caTop').properties().nSubJets",
-        "jet.tagInfo('caTop').properties().minMass"
+        "tagInfo('caTop').properties().topMass",
+        "tagInfo('caTop').properties().nSubJets",
+        "tagInfo('caTop').properties().minMass"
     )
     process.patJetsAK8.userData.userFunctionLabels = cms.vstring(
         "topMass", "nSubJets", "minMass"

--- a/PhysicsTools/PatAlgos/python/slimming/slimmedJets_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimmedJets_cfi.py
@@ -16,6 +16,6 @@ slimmedJetsAK8 = cms.EDProducer("PATJetSlimmer",
    dropDaughters = cms.string("0"),
    dropTrackRefs = cms.string("1"),
    dropSpecific = cms.string("0"),
-   dropTagInfos = cms.string("1"),
+   dropTagInfos = cms.string("0"),
 )
 

--- a/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
@@ -52,8 +52,9 @@ MicroEventContent = cms.PSet(
         'keep L1GlobalTriggerReadoutRecord_gtDigis_*_HLT',
         'keep *_TriggerResults_*_HLT',
         'keep *_TriggerResults_*_PAT', # for MET filters
-	'keep patPackedCandidates_lostTracks_*_PAT',
-	'keep HcalNoiseSummary_hcalnoise__*'
+        'keep patPackedCandidates_lostTracks_*_PAT',
+        'keep HcalNoiseSummary_hcalnoise__*',
+        'keep *_caTopTagInfos_*_*'
     )
 )
 MicroEventContentMC = cms.PSet(

--- a/PhysicsTools/PatAlgos/python/tools/jetTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/jetTools.py
@@ -327,7 +327,8 @@ class AddJetCollection(ConfigToolBase):
             ## load sequences and setups needed fro btagging
             ## This loads all available btagger, but the ones we need are added to the process by hand later. Only needed to get the ESProducer. Needs improvement
             #loadWithPostFix(process,"RecoBTag.Configuration.RecoBTag_cff",postfix)
-            process.load("RecoBTag.Configuration.RecoBTag_cff")
+            if hasattr( process, 'secondaryVertexNegativeTagInfos' ) == False : 
+                process.load("RecoBTag.Configuration.RecoBTag_cff")
             #addESProducers(process,'RecoBTag.Configuration.RecoBTag_cff')
             import RecoBTag.Configuration.RecoBTag_cff as btag
             import RecoJets.JetProducers.caTopTaggers_cff as toptag
@@ -394,8 +395,8 @@ class AddJetCollection(ConfigToolBase):
                     process.load( 'RecoBTag.SecondaryVertex.bToCharmDecayVertexMerger_cfi' )
             if 'caTopTagInfos' in acceptedTagInfos :
                 _newPatJets.addTagInfos = True
-                if not hasattr( process, 'caTopTagInfos' ):
-                    process.load( 'RecoJets.JetProducers.CATopTagInfos_cff' )
+                if not hasattr( process, 'caTopTagInfos' ) and not hasattr( process, 'caTopTagInfosAK8' ):
+                    process.load( 'RecoJets.JetProducers.caTopTaggers_cff' )
         else:
             _newPatJets.addBTagInfo = False
             _newPatJets.addTagInfos = False


### PR DESCRIPTION
This is a bug fix PR to correctly update miniAOD from 70x to 72x : 
1. Trivial : Adding AK8 jet corrections (now available in 72x)
2. Adding nsubjettiness.
3. Removing QJets volatility (too slow)
4. Adding CMS top tagger correctly.
   = To do this, had to "forward" the value map of CA8Jet->CATopTagInfo to the associated AK8Jet->CATopTagInfo. Invented a new delta-R matching module for this (JetDeltaRTagInfoValueMapProducer.cc). 
   = Also had a bug fix for the jet tools file when running CATopTagger. Was not loading the right file under the right conditions. 

The added material is the CATopTagInfos. Instead of accessing via user floats, it is sufficient to keep the "tag infos" to maintain backwards compatibility. They only contribute 3 floats (plus refs) for each jet with pt > 100 GeV. The CATopTag algorithm itself is not run, since that is done in RECO and we just take the value. The CA8 jets are associated to the AK8 jets to get the right association of the AK8 jets to the CATopTag values. 

Also adding @gpetruc and @arizzi to the thread to have them weigh in. 
