### PR TITLE
Traj float

### DIFF
--- a/DataFormats/TrajectoryState/interface/LocalTrajectoryParameters.h
+++ b/DataFormats/TrajectoryState/interface/LocalTrajectoryParameters.h
@@ -74,8 +74,8 @@ public:
   LocalTrajectoryParameters( const LocalPoint& pos, const LocalVector& p,
 			     TrackCharge charge) :
     theQbp( charge/p.mag()), theDxdz( p.x()/p.z()), theDydz( p.y()/p.z()), 
-    theX( pos.x()), theY(pos.y()), thePzSign( p.z()>0. ? 1.:-1.), theCharge(charge) {
-    if ( charge==0 )  theQbp = 1./p.mag();
+    theX( pos.x()), theY(pos.y()), thePzSign( p.z()>0. ? 1.f:-1.f), theCharge(charge) {
+    if ( charge==0 )  theQbp = 1.f/p.mag();
   }
 
 // access
@@ -87,9 +87,9 @@ public:
 
   /// Momentum vector in the local frame. 
   LocalVector momentum() const {
-    float op = fabs(theQbp);
-    if ( op<1.e-9 )  op = 1.e-9;
-    float pz = thePzSign/(op*sqrt(1. + theDxdz*theDxdz + theDydz*theDydz));
+    float op = std::abs(theQbp);
+    if ( op<1.e-9f )  op = 1.e-9f;
+    float pz = thePzSign/(op*std::sqrt(1. + theDxdz*theDxdz + theDydz*theDydz));
     float px = pz*theDxdz;
     float py = pz*theDydz;
     return LocalVector(px, py, pz);
@@ -97,7 +97,7 @@ public:
 
  /// Momentum vector unit in the local frame. 
   LocalVector direction() const {
-    float dz = thePzSign/sqrt(1. + theDxdz*theDxdz + theDydz*theDydz);
+    float dz = thePzSign/std::sqrt(1. + theDxdz*theDxdz + theDydz*theDydz);
     float dx = dz*theDxdz;
     float dy = dz*theDydz;
     return LocalVector(dx, dy, dz);
@@ -109,7 +109,7 @@ public:
 
   /// Signed inverse momentum q/p (zero for neutrals).
   float signedInverseMomentum() const {
-    return charge()==0 ? 0. : theQbp;
+    return charge()==0 ? 0.f : theQbp;
   }
 
   /** Vector of parameters with signed inverse momentum.
@@ -149,9 +149,9 @@ public:
 
   /// Update of momentum by a scalar dP.
   bool updateP(float dP) {
-    float p = 1./fabs(theQbp);
-    if ((p += dP) <= 0.) return false;
-    float newQbp = theQbp > 0. ? 1./p : -1./p;
+    float p = 1.f/std::abs(theQbp);
+    if ((p += dP) <= 0.f) return false;
+    float newQbp = theQbp > 0. ? 1.f/p : -1.f/p;
     theQbp = newQbp;
     return true;
   }

--- a/DataFormats/TrajectoryState/interface/LocalTrajectoryParameters.h
+++ b/DataFormats/TrajectoryState/interface/LocalTrajectoryParameters.h
@@ -35,7 +35,7 @@ public:
    *  the first element. For neutral particles the last argument should be false, 
    *  in which case the charge of the first element will be neglected.
    */
-  LocalTrajectoryParameters(const AlgebraicVector5& v, double aPzSign, bool charged = true) {
+  LocalTrajectoryParameters(const AlgebraicVector5& v, float aPzSign, bool charged = true) {
     theQbp  = v[0];
     theDxdz = v[1];
     theDydz = v[2];
@@ -56,8 +56,8 @@ public:
    *  the first argument. For neutral particles the last argument should be false, 
    *  in which case the charge of the first argument will be neglected.
    */
-  LocalTrajectoryParameters(double aQbp, double aDxdz, double aDydz,
-                            double aX, double aY, double aPzSign, bool charged = true) :
+  LocalTrajectoryParameters(float aQbp, float aDxdz, float aDydz,
+                            float aX, float aY, float aPzSign, bool charged = true) :
     theDxdz(aDxdz), theDydz(aDydz),
     theX(aX), theY(aY), thePzSign(aPzSign) {
     if ( charged ) {
@@ -87,19 +87,19 @@ public:
 
   /// Momentum vector in the local frame. 
   LocalVector momentum() const {
-    double op = fabs(theQbp);
+    float op = fabs(theQbp);
     if ( op<1.e-9 )  op = 1.e-9;
-    double pz = thePzSign/(op*sqrt(1. + theDxdz*theDxdz + theDydz*theDydz));
-    double px = pz*theDxdz;
-    double py = pz*theDydz;
+    float pz = thePzSign/(op*sqrt(1. + theDxdz*theDxdz + theDydz*theDydz));
+    float px = pz*theDxdz;
+    float py = pz*theDydz;
     return LocalVector(px, py, pz);
   }
 
  /// Momentum vector unit in the local frame. 
   LocalVector direction() const {
-    double dz = thePzSign/sqrt(1. + theDxdz*theDxdz + theDydz*theDydz);
-    double dx = dz*theDxdz;
-    double dy = dz*theDydz;
+    float dz = thePzSign/sqrt(1. + theDxdz*theDxdz + theDydz*theDydz);
+    float dx = dz*theDxdz;
+    float dy = dz*theDydz;
     return LocalVector(dx, dy, dz);
   }
 
@@ -108,7 +108,7 @@ public:
   TrackCharge charge() const {return theCharge;}
 
   /// Signed inverse momentum q/p (zero for neutrals).
-  double signedInverseMomentum() const {
+  float signedInverseMomentum() const {
     return charge()==0 ? 0. : theQbp;
   }
 
@@ -143,31 +143,31 @@ public:
   }
 
   /// Sign of the z-component of the momentum in the local frame.
-  double pzSign() const {
+  float pzSign() const {
     return thePzSign;
   }
 
   /// Update of momentum by a scalar dP.
-  bool updateP(double dP) {
-    double p = 1./fabs(theQbp);
+  bool updateP(float dP) {
+    float p = 1./fabs(theQbp);
     if ((p += dP) <= 0.) return false;
-    double newQbp = theQbp > 0. ? 1./p : -1./p;
+    float newQbp = theQbp > 0. ? 1./p : -1./p;
     theQbp = newQbp;
     return true;
   }
 
 
-  double qbp() const { return theQbp;}
-  double dxdz() const { return theDxdz;}
-  double dydz() const { return theDydz;}
+  float qbp() const { return theQbp;}
+  float dxdz() const { return theDxdz;}
+  float dydz() const { return theDydz;}
 
 
 private:
-  double theQbp;    ///< q/p (charged) or 1/p (neutral)
-  double theDxdz;   ///< tangent of direction in local x vs. z
-  double theDydz;   ///< tangent of direction in local y vs. z
-  double theX;      ///< local x position
-  double theY;      ///< local y position
+  float theQbp;    ///< q/p (charged) or 1/p (neutral)
+  float theDxdz;   ///< tangent of direction in local x vs. z
+  float theDydz;   ///< tangent of direction in local y vs. z
+  float theX;      ///< local x position
+  float theY;      ///< local y position
 
   float thePzSign; ///< sign of local pz
 

--- a/DataFormats/TrajectoryState/interface/LocalTrajectoryParameters.h
+++ b/DataFormats/TrajectoryState/interface/LocalTrajectoryParameters.h
@@ -59,7 +59,7 @@ public:
   LocalTrajectoryParameters(float aQbp, float aDxdz, float aDydz,
                             float aX, float aY, float aPzSign, bool charged = true) :
     theDxdz(aDxdz), theDydz(aDydz),
-    theX(aX), theY(aY), thePzSign(aPzSign) {
+    theX(aX), theY(aY), thePzSign(aPzSign>0 ? 1 : -1) {
     if ( charged ) {
       theQbp = aQbp;
       theCharge = theQbp>0 ? 1 : -1;
@@ -74,7 +74,7 @@ public:
   LocalTrajectoryParameters( const LocalPoint& pos, const LocalVector& p,
 			     TrackCharge charge) :
     theQbp( charge/p.mag()), theDxdz( p.x()/p.z()), theDydz( p.y()/p.z()), 
-    theX( pos.x()), theY(pos.y()), thePzSign( p.z()>0. ? 1.f:-1.f), theCharge(charge) {
+    theX( pos.x()), theY(pos.y()), thePzSign( p.z()>0. ? 1:-1), theCharge(charge) {
     if ( charge==0 )  theQbp = 1.f/p.mag();
   }
 
@@ -89,7 +89,7 @@ public:
   LocalVector momentum() const {
     float op = std::abs(theQbp);
     if ( op<1.e-9f )  op = 1.e-9f;
-    float pz = thePzSign/(op*std::sqrt(1. + theDxdz*theDxdz + theDydz*theDydz));
+    float pz = float(thePzSign)/(op*std::sqrt(1. + theDxdz*theDxdz + theDydz*theDydz));
     float px = pz*theDxdz;
     float py = pz*theDydz;
     return LocalVector(px, py, pz);
@@ -97,7 +97,7 @@ public:
 
  /// Momentum vector unit in the local frame. 
   LocalVector direction() const {
-    float dz = thePzSign/std::sqrt(1. + theDxdz*theDxdz + theDydz*theDydz);
+    float dz = float(thePzSign)/std::sqrt(1. + theDxdz*theDxdz + theDydz*theDydz);
     float dx = dz*theDxdz;
     float dy = dz*theDydz;
     return LocalVector(dx, dy, dz);
@@ -169,9 +169,9 @@ private:
   float theX;      ///< local x position
   float theY;      ///< local y position
 
-  float thePzSign; ///< sign of local pz
+  short thePzSign; ///< sign of local pz
 
-  TrackCharge theCharge; ///< charge
+  short theCharge; ///< charge
 
 };
 

--- a/DataFormats/TrajectoryState/interface/PTrajectoryStateOnDet.h
+++ b/DataFormats/TrajectoryState/interface/PTrajectoryStateOnDet.h
@@ -42,20 +42,20 @@ public:
 
   PTrajectoryStateOnDet() {}
 
-  PTrajectoryStateOnDet( const LocalTrajectoryParameters& param,
+  PTrajectoryStateOnDet( const LocalTrajectoryParameters& param, float ipt,
 			 unsigned int id,
 			 int surfaceSide) :   
-    theLocalParameters(param) 
+    theLocalParameters(param) ,	thePt(ipt)
   {
     Pack p(id, surfaceSide);
     thePack = p.packed;
     theLocalErrors[0]=-99999.e10; 
   }
   
-  PTrajectoryStateOnDet( const LocalTrajectoryParameters& param,
+  PTrajectoryStateOnDet( const LocalTrajectoryParameters& param, float ipt,
 			 float errmatrix[15], unsigned int id,
 			 int surfaceSide) :   
-    theLocalParameters( param)
+    theLocalParameters( param), thePt(ipt)
   {
     Pack p(id, surfaceSide);
     thePack = p.packed;
@@ -64,6 +64,7 @@ public:
 
 
   const LocalTrajectoryParameters& parameters() const {return theLocalParameters;}
+  float pt() const { return thePt; }
   bool hasError() const { return theLocalErrors[0] > -1.e10; }
   float & error(int i)  {return theLocalErrors[i];}
   float   error(int i) const {return theLocalErrors[i];}
@@ -79,9 +80,8 @@ private:
 
   LocalTrajectoryParameters theLocalParameters;
   float theLocalErrors[15];
+  float thePt;
   unsigned int thePack;
-  //unsigned int theDetId;
-  //int          theSurfaceSide;
 
 };
 

--- a/DataFormats/TrajectoryState/src/classes_def.xml
+++ b/DataFormats/TrajectoryState/src/classes_def.xml
@@ -1,7 +1,8 @@
 <lcgdict>
-  <class name="PTrajectoryStateOnDet"  ClassVersion="11">
+  <class name="PTrajectoryStateOnDet"  ClassVersion="12">
    <version ClassVersion="10" checksum="569579863"/>
    <version ClassVersion="11" checksum="3544593532"/>
+   <version ClassVersion="12" checksum="38149313"/>
   </class>
   <class name="LocalTrajectoryParameters"  ClassVersion="12">
    <version ClassVersion="10" checksum="1521038602"/>

--- a/DataFormats/TrajectoryState/src/classes_def.xml
+++ b/DataFormats/TrajectoryState/src/classes_def.xml
@@ -7,6 +7,6 @@
   <class name="LocalTrajectoryParameters"  ClassVersion="12">
    <version ClassVersion="10" checksum="1521038602"/>
    <version ClassVersion="11" checksum="1957420259"/>
-   <version ClassVersion="12" checksum="2256807700"/>
+   <version ClassVersion="12" checksum="3600271005"/>
   </class>
 </lcgdict>                                                                                                                                                        

--- a/DataFormats/TrajectoryState/src/classes_def.xml
+++ b/DataFormats/TrajectoryState/src/classes_def.xml
@@ -3,8 +3,9 @@
    <version ClassVersion="10" checksum="569579863"/>
    <version ClassVersion="11" checksum="3544593532"/>
   </class>
-  <class name="LocalTrajectoryParameters"  ClassVersion="11">
+  <class name="LocalTrajectoryParameters"  ClassVersion="12">
    <version ClassVersion="10" checksum="1521038602"/>
    <version ClassVersion="11" checksum="1957420259"/>
+   <version ClassVersion="12" checksum="2256807700"/>
   </class>
 </lcgdict>                                                                                                                                                        

--- a/DataFormats/TrajectoryState/test/PTraj_t.cpp
+++ b/DataFormats/TrajectoryState/test/PTraj_t.cpp
@@ -15,7 +15,7 @@ namespace {
   void verify(DetId id,
 	      sn::Side ss) {
     LocalTrajectoryParameters tp;
-    PTrajectoryStateOnDet p(tp, id, ss);
+    PTrajectoryStateOnDet p(tp, 0., id, ss);
     assert(p.detId()==id);
     assert(p.surfaceSide()==ss);
   }

--- a/FastSimulation/Muons/plugins/FastTSGFromPropagation.cc
+++ b/FastSimulation/Muons/plugins/FastTSGFromPropagation.cc
@@ -577,7 +577,7 @@ void FastTSGFromPropagation::stateOnDet(const TrajectoryStateOnSurface& ts,
 	}
     }
     int surfaceSide = static_cast<int>(ts.surfaceSide());
-    pts = PTrajectoryStateOnDet( ts.localParameters(),
+    pts = PTrajectoryStateOnDet( ts.localParameters(),ts.globalMomentum().perp(),
     				localErrors, detid,
 				surfaceSide);
 }

--- a/FastSimulation/Tracking/plugins/TrajectorySeedProducer.cc
+++ b/FastSimulation/Tracking/plugins/TrajectorySeedProducer.cc
@@ -819,7 +819,7 @@ TrajectorySeedProducer::stateOnDet(const TrajectoryStateOnSurface& ts,
   }
   int surfaceSide = static_cast<int>(ts.surfaceSide());
 
-  pts = PTrajectoryStateOnDet( ts.localParameters(),
+  pts = PTrajectoryStateOnDet( ts.localParameters(),ts.globalMomentum().perp(),
 			       localErrors, detid,
 			       surfaceSide);
 }

--- a/RecoLocalTracker/SubCollectionProducers/src/HLTTrackClusterRemoverNew.cc
+++ b/RecoLocalTracker/SubCollectionProducers/src/HLTTrackClusterRemoverNew.cc
@@ -368,8 +368,8 @@ HLTTrackClusterRemoverNew::produce(Event& iEvent, const EventSetup& iSetup)
       oldPxlMask->copyMaskTo(collectedPixels_);
       collectedRegStrips_.resize(stripClusters->dataSize(),false);
     }else {
-      collectedRegStrips_.resize(stripClusters->dataSize()); fill(collectedRegStrips_.begin(), collectedRegStrips_.end(), false);
-      collectedPixels_.resize(pixelClusters->dataSize()); fill(collectedPixels_.begin(), collectedPixels_.end(), false);
+      collectedRegStrips_.resize(stripClusters->dataSize(), false);
+      collectedPixels_.resize(pixelClusters->dataSize(), false);
     } 
 
 
@@ -393,6 +393,9 @@ HLTTrackClusterRemoverNew::produce(Event& iEvent, const EventSetup& iSetup)
     
     //    std::cout << " => collectedRegStrips_: " << collectedRegStrips_.size() << std::endl;
     //    std::cout << " total strip to skip (before charge check): "<<std::count(collectedRegStrips_.begin(),collectedRegStrips_.end(),true) << std::endl;
+
+
+    // checks only cluster already found! creates regression 
     if (doStripChargeCheck_) {
       //      std::cout << "[HLTTrackClusterRemoverNew::produce] doStripChargeCheck_: " << (doStripChargeCheck_ ? "true" : "false") << " stripClusters: " << stripClusters->size() << std::endl;
       
@@ -431,6 +434,9 @@ HLTTrackClusterRemoverNew::produce(Event& iEvent, const EventSetup& iSetup)
 							      new PixelMaskContainer(edm::RefProd<edmNew::DetSetVector<SiPixelCluster> >(pixelClusters),collectedPixels_));      
     LogDebug("TrackClusterRemover")<<"total pxl to skip: "<<std::count(collectedPixels_.begin(),collectedPixels_.end(),true);
     iEvent.put( removedPixelClusterMask );
+
+    collectedRegStrips_.clear();
+    collectedPixels_.clear();
     
     
 }

--- a/RecoLocalTracker/SubCollectionProducers/src/HLTTrackClusterRemoverNew.cc
+++ b/RecoLocalTracker/SubCollectionProducers/src/HLTTrackClusterRemoverNew.cc
@@ -413,7 +413,7 @@ HLTTrackClusterRemoverNew::produce(Event& iEvent, const EventSetup& iSetup)
 	  for ( auto cAmp : clusters[i].amplitudes() ) clusCharge+=cAmp;
 	  
 	  //	if (clusCharge < pblocks_[subdet-1].minGoodStripCharge_) std::cout << " clusCharge: " << clusCharge << std::endl;
-/	  if(clusCharge < pblocks_[subdet-1].minGoodStripCharge_) collectedRegStrips_[i] = true; // (|= does not work!)
+	  if(clusCharge < pblocks_[subdet-1].minGoodStripCharge_) collectedRegStrips_[i] = true; // (|= does not work!)
 	}
 	
       }

--- a/RecoLocalTracker/SubCollectionProducers/src/HLTTrackClusterRemoverNew.cc
+++ b/RecoLocalTracker/SubCollectionProducers/src/HLTTrackClusterRemoverNew.cc
@@ -366,7 +366,7 @@ HLTTrackClusterRemoverNew::produce(Event& iEvent, const EventSetup& iSetup)
       LogDebug("TrackClusterRemover")<<"to merge in, "<<oldStrMask->size()<<" strp and "<<oldPxlMask->size()<<" pxl";
       oldStrMask->copyMaskTo(collectedRegStrips_);
       oldPxlMask->copyMaskTo(collectedPixels_);
-      collectedRegStrips_.resize(stripClusters->dataSize());
+      collectedRegStrips_.resize(stripClusters->dataSize(),false);
     }else {
       collectedRegStrips_.resize(stripClusters->dataSize()); fill(collectedRegStrips_.begin(), collectedRegStrips_.end(), false);
       collectedPixels_.resize(pixelClusters->dataSize()); fill(collectedPixels_.begin(), collectedPixels_.end(), false);
@@ -413,7 +413,7 @@ HLTTrackClusterRemoverNew::produce(Event& iEvent, const EventSetup& iSetup)
 	  for ( auto cAmp : clusters[i].amplitudes() ) clusCharge+=cAmp;
 	  
 	  //	if (clusCharge < pblocks_[subdet-1].minGoodStripCharge_) std::cout << " clusCharge: " << clusCharge << std::endl;
-	  if(clusCharge < pblocks_[subdet-1].minGoodStripCharge_) collectedRegStrips_[i] = true; // (|= does not work!)
+/	  if(clusCharge < pblocks_[subdet-1].minGoodStripCharge_) collectedRegStrips_[i] = true; // (|= does not work!)
 	}
 	
       }

--- a/RecoTracker/CkfPattern/src/CkfTrackCandidateMakerBase.cc
+++ b/RecoTracker/CkfPattern/src/CkfTrackCandidateMakerBase.cc
@@ -223,7 +223,7 @@ namespace cms{
       auto spt = [&](unsigned int i) { return seeds[i].startingState().pt();};
       std::sort(indeces,indeces+collseed_size, [&](unsigned int i, unsigned int j){return spt(i)>spt(j);});
 
-      std::cout << spt(indeces[0]) << ' ' << spt(indeces[collseed_size-1]) << std::endl;
+      // std::cout << spt(indeces[0]) << ' ' << spt(indeces[collseed_size-1]) << std::endl;
       
       auto theLoop = [&](size_t ii) {    
         auto j = indeces[ii];

--- a/RecoTracker/CkfPattern/src/CkfTrackCandidateMakerBase.cc
+++ b/RecoTracker/CkfPattern/src/CkfTrackCandidateMakerBase.cc
@@ -219,12 +219,38 @@ namespace cms{
       unsigned int indeces[collseed_size]; for (auto i=0U; i< collseed_size; ++i) indeces[i]=i;
       // std::random_shuffle(indeces,indeces+collseed_size);
 
+
+      /* 
+       * here only for reference: does not seems to help
+     
       auto const & seeds = *collseed;
-      auto spt = [&](unsigned int i) { return seeds[i].startingState().pt();};
-      std::sort(indeces,indeces+collseed_size, [&](unsigned int i, unsigned int j){return spt(i)>spt(j);});
+      
+      
+      float val[collseed_size]; 
+      for (auto i=0U; i< collseed_size; ++i) 
+        {  val[i] =  seeds[i].startingState().pt();};
+      //  { val[i] =  std::abs((*seeds[i].recHits().first).surface()->eta());}
+      
+
+      unsigned long long val[collseed_size];
+      for (auto i=0U; i< collseed_size; ++i) {
+        if (seeds[i].nHits()<2) { val[i]=0; continue;}
+        auto h = seeds[i].recHits().first;  
+        auto const & hit = static_cast<BaseTrackerRecHit const&>(*h);
+        val[i] = hit.firstClusterRef().key(); 
+        if (++h != seeds[i].recHits().second) {
+          auto	const &	hit = static_cast<BaseTrackerRecHit const&>(*h);
+    	  val[i] |= (unsigned long long)(hit.firstClusterRef().key())<<32; 
+        }
+      }
+
+      std::sort(indeces,indeces+collseed_size, [&](unsigned int i, unsigned int j){return val[i]<val[j];});
+             
 
       // std::cout << spt(indeces[0]) << ' ' << spt(indeces[collseed_size-1]) << std::endl;
       
+      */
+
       auto theLoop = [&](size_t ii) {    
         auto j = indeces[ii];
 

--- a/RecoTracker/CkfPattern/src/CkfTrackCandidateMakerBase.cc
+++ b/RecoTracker/CkfPattern/src/CkfTrackCandidateMakerBase.cc
@@ -201,7 +201,7 @@ namespace cms{
     if ((*collseed).size()>0){
 
       unsigned int lastCleanResult=0;
-      vector<Trajectory> rawResult;
+      std::vector<Trajectory> rawResult;
       rawResult.reserve(collseed->size() * 4);
 
       if (theSeedCleaner) theSeedCleaner->init( &rawResult );
@@ -210,8 +210,8 @@ namespace cms{
       countSeedsDebugger();
 
       // the mutex
-     std::mutex theMutex;
-     using Lock = std::unique_lock<std::mutex>;
+      std::mutex theMutex;
+      using Lock = std::unique_lock<std::mutex>;
 
       // Loop over seeds
       size_t collseed_size = collseed->size();
@@ -221,14 +221,15 @@ namespace cms{
 
       auto const & seeds = *collseed;
       auto spt = [&](unsigned int i) { return seeds[i].startingState().pt();};
-
       std::sort(indeces,indeces+collseed_size, [&](unsigned int i, unsigned int j){return spt(i)>spt(j);});
 
+      std::cout << spt(indeces[0]) << ' ' << spt(indeces[collseed_size-1]) << std::endl;
+      
       auto theLoop = [&](size_t ii) {    
         auto j = indeces[ii];
 
-        // to be moved inside a par section
-        vector<Trajectory> theTmpTrajectories;
+        // to be moved inside a par section (how with tbb??)
+        std::vector<Trajectory> theTmpTrajectories;
 
 
 	LogDebug("CkfPattern") << "======== Begin to look for trajectories from seed " << j << " ========"<<endl;

--- a/RecoTracker/CkfPattern/src/CkfTrackCandidateMakerBase.cc
+++ b/RecoTracker/CkfPattern/src/CkfTrackCandidateMakerBase.cc
@@ -216,10 +216,19 @@ namespace cms{
       // Loop over seeds
       size_t collseed_size = collseed->size();
 
-      auto theLoop = [&](size_t j) {    
+      unsigned int indeces[collseed_size]; for (auto i=0U; i< collseed_size; ++i) indeces[i]=i;
+      // std::random_shuffle(indeces,indeces+collseed_size);
 
-      // to be moved inside a par section
-      vector<Trajectory> theTmpTrajectories;
+      auto const & seeds = *collseed;
+      auto spt = [&](unsigned int i) { return seeds[i].startingState().pt();};
+
+      std::sort(indeces,indeces+collseed_size, [&](unsigned int i, unsigned int j){return spt(i)>spt(j);});
+
+      auto theLoop = [&](size_t ii) {    
+        auto j = indeces[ii];
+
+        // to be moved inside a par section
+        vector<Trajectory> theTmpTrajectories;
 
 
 	LogDebug("CkfPattern") << "======== Begin to look for trajectories from seed " << j << " ========"<<endl;

--- a/TrackingTools/TrajectoryState/src/TrajectoryStateTransform.cc
+++ b/TrackingTools/TrajectoryState/src/TrajectoryStateTransform.cc
@@ -17,6 +17,7 @@ namespace trajectoryStateTransform {
 		   unsigned int detid)
   {
     int surfaceSide = static_cast<int>(ts.surfaceSide());
+    auto pt = ts.globalMomentum().perp();
     
     if (ts.hasError()) {
       AlgebraicSymMatrix55 const & m = ts.localError().matrix();
@@ -30,11 +31,11 @@ namespace trajectoryStateTransform {
 	  localErrors[k++] = m(i,j);
 	}
       }
-    return PTrajectoryStateOnDet(ts.localParameters(),
+    return PTrajectoryStateOnDet(ts.localParameters(),pt,
 				 localErrors, detid,
 				 surfaceSide);
     }
-    return PTrajectoryStateOnDet(ts.localParameters(),
+    return PTrajectoryStateOnDet(ts.localParameters(),pt,
 				 detid,
 				 surfaceSide);
   }


### PR DESCRIPTION
This PR contains two components:
1)
change double to float in LocalTrajectoryParameters.
for TTBAR 40PU25ns  I observe a reduction of ~100MB of RSS for a very-small regression and no changes in tracking performances
No clue why was not done before (most probably less relevant at low pileup)

2) add "pt" to PTrajectoryStateOnDet
the original idea was to be able to access the "pt" of a seed w/o converting to a TSOS
it turns out that sorting seed in pt does not improve anything.
I prefer to keep it around for a couple of pre-releases, eventually remove (and clean code) if not useful in any way
