### PR TITLE
Fix unoptimized debug build

### DIFF
--- a/GeneratorInterface/HijingInterface/interface/HijingPythiaWrapper.h
+++ b/GeneratorInterface/HijingInterface/interface/HijingPythiaWrapper.h
@@ -21,16 +21,16 @@
     void   txgive_(const char*, int );
     void   txgive_init_(void);
     
-    static bool call_pygive(const std::string &line)
-    {
-       int numWarn = pydat1.mstu[26];    // # warnings
-       int numErr = pydat1.mstu[22];     // # errors
-       
-       pygive_(line.c_str(), line.length());
-       
-       return pydat1.mstu[26] == numWarn &&
-	  pydat1.mstu[22] == numErr;
-    }
+    // static bool call_pygive(const std::string &line)
+    // {
+    //    int numWarn = pydat1.mstu[26];    // # warnings
+    //    int numErr = pydat1.mstu[22];     // # errors
+    //   
+    //    pygive_(line.c_str(), line.length());
+    //   
+    //    return pydat1.mstu[26] == numWarn &&
+    //	  pydat1.mstu[22] == numErr;
+    // }
  }
  
 #define PYCOMP pycomp_

--- a/GeneratorInterface/HijingInterface/src/HijingHadronizer.cc
+++ b/GeneratorInterface/HijingInterface/src/HijingHadronizer.cc
@@ -270,10 +270,8 @@ bool HijingHadronizer::initializeForInternalPartons(){
 
   //initialize pythia5
 
-  if(0){
-    std::string dumstr = "";
-    call_pygive(dumstr);
-  }
+   // std::string dumstr = "";
+   // call_pygive(dumstr);
 
    // initialize hijing
    LogInfo("HIJINGinAction") << "##### Calling HIJSET(" << efrm_ << "," <<frame_<<","<<proj_<<","<<targ_<<","<<iap_<<","<<izp_<<","<<iat_<<","<<izt_<<") ####";


### PR DESCRIPTION
There is a call to a function not brought
in by a use statement in the BuildFile. It
normally links because it is surrounded by
an if(0) and the optimizer removes the call.
But it fails to link in an unoptimized debug
build. I commented out the offending code
instead.
