### PR TITLE
Update QGLikelihoodDBWriter to read bins from file

### DIFF
--- a/JetMETCorrections/Modules/test/QGLikelihoodDBWriter_cfg.py
+++ b/JetMETCorrections/Modules/test/QGLikelihoodDBWriter_cfg.py
@@ -10,7 +10,7 @@ process.MessageLogger = cms.Service("MessageLogger",
             ),
 )
 
-qgDatabaseVersion = 'v0-test'
+qgDatabaseVersion = 'v1.1'
 
 process.load('CondCore.DBCommon.CondDBCommon_cfi')
 process.CondDBCommon.connect = 'sqlite_file:QGL_'+qgDatabaseVersion+'.db'
@@ -30,34 +30,56 @@ process.PoolDBOutputService = cms.Service('PoolDBOutputService',
          label  = cms.string('QGL_AK5PFchs')
       ),
       cms.PSet(
-         record = cms.string('QGL_Syst_Pythia'),
-         tag    = cms.string('QGLikelihoodSystematicsObject_'+qgDatabaseVersion+'_Pythia'),
-         label  = cms.string('QGL_Syst_Pythia')
+         record = cms.string('QGL_AK4PF'),
+         tag    = cms.string('QGLikelihoodObject_'+qgDatabaseVersion+'_AK4PF'),
+         label  = cms.string('QGL_AK4PF')
       ),
       cms.PSet(
-         record = cms.string('QGL_Syst_Herwig++'),
-         tag    = cms.string('QGLikelihoodSystematicsObject_'+qgDatabaseVersion+'_Herwig++'),
-         label  = cms.string('QGL_Syst_Herwig++')
+         record = cms.string('QGL_AK4PFchs'),
+         tag    = cms.string('QGLikelihoodObject_'+qgDatabaseVersion+'_AK4PFchs'),
+         label  = cms.string('QGL_AK4PFchs')
       ),
+# ONLY AFTER FIRST DATA
+#     cms.PSet(
+#        record = cms.string('QGL_Syst_Pythia'),
+#        tag    = cms.string('QGLikelihoodSystematicsObject_'+qgDatabaseVersion+'_Pythia'),
+#        label  = cms.string('QGL_Syst_Pythia')
+#     ),
+#     cms.PSet(
+#        record = cms.string('QGL_Syst_Herwig++'),
+#        tag    = cms.string('QGLikelihoodSystematicsObject_'+qgDatabaseVersion+'_Herwig++'),
+#        label  = cms.string('QGL_Syst_Herwig++')
+#     ),
    )
 )
 
 srcDirectory = 'temp/'
+process.dbWriterAK4PF = cms.EDAnalyzer('QGLikelihoodDBWriter',
+   src    = cms.string(srcDirectory + 'pdfQG_AK4_13TeV.root'),
+   payload= cms.string('QGL_AK4PF')
+) 
+process.dbWriterAK4PFchs = cms.EDAnalyzer('QGLikelihoodDBWriter',
+   src    = cms.string(srcDirectory + 'pdfQG_AK4chs_13TeV.root'),
+   payload= cms.string('QGL_AK4PFchs')
+) 
 process.dbWriterAK5PF = cms.EDAnalyzer('QGLikelihoodDBWriter',
-   src    = cms.string(srcDirectory + 'ReducedHisto_2012.root'),
+   src    = cms.string(srcDirectory + 'pdfQG_AK5_13TeV.root'),
    payload= cms.string('QGL_AK5PF')
 ) 
 process.dbWriterAK5PFchs = cms.EDAnalyzer('QGLikelihoodDBWriter',
-   src    = cms.string(srcDirectory + 'ReducedHisto_2012_CHS.root'),
+   src    = cms.string(srcDirectory + 'pdfQG_AK5chs_13TeV.root'),
    payload= cms.string('QGL_AK5PFchs')
-) 
-process.dbWriterSystPythia = cms.EDAnalyzer('QGLikelihoodSystematicsDBWriter',
-   src    = cms.string(srcDirectory + 'SystDatabase.txt'),
-   payload= cms.string('QGL_Syst_Pythia')
-)
-process.dbWriterSystHerwigpp = cms.EDAnalyzer('QGLikelihoodSystematicsDBWriter',
-   src    = cms.string(srcDirectory + 'SystDatabase_Hpp.txt'),
-   payload= cms.string('QGL_Syst_Herwig++')
 )
 
-process.p = cms.Path(process.dbWriterAK5PF * process.dbWriterAK5PFchs * process.dbWriterSystPythia * process.dbWriterSystHerwigpp)
+# ONLY AFTER FIRST DATA:
+#process.dbWriterSystPythia = cms.EDAnalyzer('QGLikelihoodSystematicsDBWriter',
+#   src    = cms.string(srcDirectory + 'SystDatabase.txt'),
+#   payload= cms.string('QGL_Syst_Pythia')
+#)
+#process.dbWriterSystHerwigpp = cms.EDAnalyzer('QGLikelihoodSystematicsDBWriter',
+#   src    = cms.string(srcDirectory + 'SystDatabase_Hpp.txt'),
+#   payload= cms.string('QGL_Syst_Herwig++')
+#)
+ 
+
+process.p = cms.Path(process.dbWriterAK4PF*process.dbWriterAK5PF*process.dbWriterAK4PFchs*process.dbWriterAK5PFchs)


### PR DESCRIPTION
Changed the QGLikelihoodDBWriter to read the bins from the ROOT file, so that we don't have to redefine the binnings anymore (less change on messing them up)
Also scaling and rebinning is removed: this is now done by the macro which writes the ROOT file
