### PR TITLE
Remove unused seedsRefs from DuplicateListMerger.cc

### DIFF
--- a/RecoTracker/FinalTrackSelectors/plugins/DuplicateListMerger.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/DuplicateListMerger.cc
@@ -192,9 +192,6 @@ void DuplicateListMerger::produce(edm::Event& iEvent, const edm::EventSetup& iSe
   std::auto_ptr<TrajectorySeedCollection> outputSeeds;
   edm::RefProd< TrajectorySeedCollection > refTrajSeeds;
 
-  const int rSize = (int)originalHandle->size();
-  edm::RefToBase<TrajectorySeed> seedsRefs[rSize];
-
   edm::Handle<edm::ValueMap<float> > originalMVAStore;
   edm::Handle<edm::ValueMap<float> > mergedMVAStore;
 
@@ -337,7 +334,6 @@ void DuplicateListMerger::produce(edm::Event& iEvent, const edm::EventSetup& iSe
 						   track.outerStateCovariance(), track.outerDetId(),
 						   track.innerStateCovariance(), track.innerDetId(),
 						   track.seedDirection(), origSeedRef ) );
-      seedsRefs[(*matchIter0).first]=origSeedRef;
       out_generalTracks->back().setExtra( reco::TrackExtraRef( refTrkExtras, outputTrkExtras->size() - 1) );
       reco::TrackExtra & tx = outputTrkExtras->back();
       tx.setResiduals(track.residuals());
@@ -435,7 +431,6 @@ void DuplicateListMerger::produce(edm::Event& iEvent, const edm::EventSetup& iSe
 						     track.outerStateCovariance(), track.outerDetId(),
 						     track.innerStateCovariance(), track.innerDetId(),
 						     track.seedDirection(), origSeedRef ) );
-	seedsRefs[i]=origSeedRef;
 	out_generalTracks->back().setExtra( reco::TrackExtraRef( refTrkExtras, outputTrkExtras->size() - 1) );
 	reco::TrackExtra & tx = outputTrkExtras->back();
 	tx.setResiduals(track.residuals());


### PR DESCRIPTION
`RecoTracker/FinalTrackSelectors/plugins/DuplicateListMerger.cc:196:49`
was reported by UBSan 25 times during full matrix.

```
DuplicateListMerger.cc:196:49: runtime error: variable length array
bound evaluates to non-positive value 0
```

Example workflows:
- 33.0 / step3
- 1319.0 / step3
- 1001.0 / step2
- 1002.0 / step2

`seedsRefs` is not used and removing it does not trigger any side effects.
Otherwise this is a potential spot for out-of-bounds writes to stack if
a possible code path if found.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
