### PR TITLE
Make HcalCholeskyMatrix compatible with new ROOT

### DIFF
--- a/CondFormats/HcalObjects/interface/HcalCholeskyMatrix.h
+++ b/CondFormats/HcalObjects/interface/HcalCholeskyMatrix.h
@@ -5,11 +5,10 @@
 
 #include <boost/cstdint.hpp>
 #include "CondFormats/HcalObjects/interface/HcalPedestal.h"
-#include <math.h>
 
 class HcalCholeskyMatrix {
    public:
-   HcalCholeskyMatrix(int fId=0);
+   explicit HcalCholeskyMatrix(int fId=0);
  
    float getValue(int capid, int i,int j) const;// {return cmatrix[capid][i][j];}
    void setValue(int capid, int i, int j, float val);// {cmatrix[capid][i][j] = val;}
@@ -17,9 +16,14 @@ class HcalCholeskyMatrix {
    uint32_t rawId () const {return mId;}
 
    private:
-   signed short int cmatrix[4][55];
+
+   static int findIndex(int i, int j);
+   //Due to a bug in ROOT versions before 5.34.20
+   // only the first 4 elements of the array were 
+   // ever stored. The previous array dimensions were
+   //signed short int cmatrix[4][55];
+   signed short int cmatrix[4];
    uint32_t mId;
-//   float cmatrix[4][10][10];
 
  COND_SERIALIZABLE;
 };


### PR DESCRIPTION
ROOT versions before 5.34.20 did not properly store a multi-dimensional
array. Instead, they only stored such arrays as if they were one dimensional
equal to the first dimension. In this case, only the first 4 array elements
were ever stored. With versions 5.34.20 and beyond this was fixed, however
it means the data stored in the conditions database is no longer readable.
Changing HcalCholeskyMatrix to match what ROOT did in the old versions allows
us to read the old data. If a value outside of the stored range is requested,
the code returns the value of 0 which matches the old behavior.
