### PR TITLE
Backport clang fixes

### DIFF
--- a/DQM/CSCMonitorModule/plugins/CSCDQM_EventProcessor_processCSC.cc
+++ b/DQM/CSCMonitorModule/plugins/CSCDQM_EventProcessor_processCSC.cc
@@ -1262,8 +1262,13 @@ namespace cscdqm {
 //     CSCCFEBTimeSlice *  timeSlice[N_CFEBs][16];
 //     CSCCFEBDataWord * timeSample[N_CFEBs][16][6][16];
     int Pedestal[N_CFEBs][6][16];
+    #ifdef __clang__
+    std::vector<std::array<std::array<std::pair<int,int>, 6>, 16>> CellPeak(N_CFEBs);
+    std::fill(CellPeak.begin(), CellPeak.end(), std::array<std::array<std::pair<int,int>, 6>, 16>{});
+    #else
     std::pair<int,int> CellPeak[N_CFEBs][6][16];
     memset(CellPeak, 0, sizeof(CellPeak));
+    #endif
 //     float PedestalError[N_CFEBs][6][16];
 //     CSCCFEBSCAControllerWord scaControllerWord[5][16][6];
     bool CheckCFEB = true;

--- a/DQMOffline/PFTau/plugins/PFClient_JetRes.cc
+++ b/DQMOffline/PFTau/plugins/PFClient_JetRes.cc
@@ -87,7 +87,7 @@ void PFClient_JetRes::createResolutionPlots(std::string& folder, std::string& na
 
   //std::vector<std::string> pTRange (PtBins_.size() -1) ;
   //char* pTRange[PtBins_.size() -1] ;
-  TString pTRange[PtBins_.size() -1] ;
+  std::vector<TString> pTRange(PtBins_.size() -1) ;
   //float pTCenter[PtBins_.size() -1] ;
 
   MonitorElement* me_average; 

--- a/DataFormats/Math/interface/ExtVec.h
+++ b/DataFormats/Math/interface/ExtVec.h
@@ -3,20 +3,46 @@
 
 #include<type_traits>
 
-typedef float  __attribute__( ( vector_size(  8 ) ) ) float32x2_t;
-typedef float  __attribute__( ( vector_size( 16 ) ) ) float32x4_t;
-typedef float  __attribute__( ( vector_size( 32 ) ) ) float32x8_t;
-typedef double __attribute__( ( vector_size( 16 ) ) ) float64x2_t;
-typedef double __attribute__( ( vector_size( 32 ) ) ) float64x4_t;
-typedef double __attribute__( ( vector_size( 64 ) ) ) float64x8_t;
+#ifdef __clang__
+#define VECTOR_EXT(N) __attribute__( ( ext_vector_type( N ) ) )
+#else
+#define VECTOR_EXT(N) __attribute__( ( vector_size( N ) ) )
+#endif
 
+typedef float  VECTOR_EXT(  8 ) float32x2_t;
+typedef float  VECTOR_EXT( 16 ) float32x4_t;
+typedef float  VECTOR_EXT( 32 ) float32x8_t;
+typedef double VECTOR_EXT( 16 ) float64x2_t;
+typedef double VECTOR_EXT( 32 ) float64x4_t;
+typedef double VECTOR_EXT( 64 ) float64x8_t;
 
 // template<typename T, int N> using ExtVec =  T __attribute__( ( vector_size( N*sizeof(T) ) ) );
 
 template<typename T, int N>
 struct ExtVecTraits {
-  typedef T __attribute__( ( vector_size( N*sizeof(T) ) ) ) type;
+//  typedef T __attribute__( ( vector_size( N*sizeof(T) ) ) ) type;
 };
+
+template<>
+struct ExtVecTraits<float, 2> {
+  typedef float VECTOR_EXT( 2*sizeof(float) ) type;
+};
+
+template<>
+struct ExtVecTraits<float, 4> {
+  typedef float VECTOR_EXT(4*sizeof(float)) type;
+};
+
+template<>
+struct ExtVecTraits<double, 2> {
+  typedef float VECTOR_EXT( 2*sizeof(double) ) type;
+};
+
+template<>
+struct ExtVecTraits<double, 4> {
+  typedef float VECTOR_EXT( 4*sizeof(double) ) type;
+};
+
 
 template<typename T, int N> using ExtVec =  typename ExtVecTraits<T,N>::type;
 
@@ -234,8 +260,8 @@ struct Rot2 {
 		 );
   }
 
-  constexpr Vec2<T> x() { return axis[0];}
-  constexpr Vec2<T> y() { return axis[1];}
+  constexpr Vec2<T> x() const { return axis[0];}
+  constexpr Vec2<T> y() const { return axis[1];}
   
   // toLocal...
   constexpr Vec2<T> rotate(Vec2<T> v) const {

--- a/DataFormats/Math/src/ExtVec.cc
+++ b/DataFormats/Math/src/ExtVec.cc
@@ -11,9 +11,6 @@ std::ostream & operator<<(std::ostream & out,  Vec4D const & v) {
 std::ostream & operator<<(std::ostream & out,  Vec2F const & v) {
   return out << '(' << v[0] <<", " << v[1] <<')';
 }
-std::ostream & operator<<(std::ostream & out,  Vec2D const & v) {
-  return out << '(' << v[0] <<", " << v[1] <<')';
-}
 
 std::ostream & operator<<(std::ostream & out, ::As3D<Vec4F> const & v) {
   return out << '(' << v.v[0] <<", " << v.v[1] <<", "<< v.v[2] <<')';

--- a/DataFormats/Math/test/ExtVec_t.cpp
+++ b/DataFormats/Math/test/ExtVec_t.cpp
@@ -1,5 +1,5 @@
 #include "FWCore/Utilities/interface/GCC11Compatibility.h"
-#if GCC_PREREQUISITE(4,8,0) || defined(__clang__)
+#if GCC_PREREQUISITE(4,8,0)
 
 #include "DataFormats/Math/interface/ExtVec.h"
 

--- a/EventFilter/CSCRawToDigi/interface/CSCEventData.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCEventData.h
@@ -8,7 +8,7 @@ class CSCDMBHeader;
 class CSCDMBTrailer;
 class CSCStripDigi;
 class CSCALCTHeader;
-class CSCALCTHeader2007;
+struct CSCALCTHeader2007;
 class CSCAnodeData;
 class CSCALCTTrailer;
 class CSCTMBHeader;

--- a/EventFilter/CSCRawToDigi/interface/CSCTMBHeader.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCTMBHeader.h
@@ -16,9 +16,9 @@
 #include <atomic>
 #endif
 class CSCDMBHeader;
-class CSCTMBHeader2006;
-class CSCTMBHeader2007;
-class CSCTMBHeader2013;
+struct CSCTMBHeader2006;
+struct CSCTMBHeader2007;
+struct CSCTMBHeader2013;
 
 
 class CSCTMBHeader {

--- a/L1Trigger/CSCTrackFinder/BuildFile.xml
+++ b/L1Trigger/CSCTrackFinder/BuildFile.xml
@@ -14,5 +14,5 @@
 <use   name="boost"/>
 
 <flags ADD_SUBDIR="1"/>
-<flags CXXFLAGS="-O1"/>
+<flags CXXFLAGS="-O0 -Wno-constant-logical-operand -Wno-parentheses-equality"/>
 <flags REM_CXXFLAGS="-flto"/>

--- a/L1Trigger/CSCTrackFinder/BuildFile.xml
+++ b/L1Trigger/CSCTrackFinder/BuildFile.xml
@@ -14,5 +14,11 @@
 <use   name="boost"/>
 
 <flags ADD_SUBDIR="1"/>
-<flags CXXFLAGS="-O0 -Wno-constant-logical-operand -Wno-parentheses-equality"/>
+<flags CXXFLAGS="-O1"/>
+# For clang we need to overwrite a few options because memory usage otherwise
+# diverges due to a bug in the compiler itself. Notice this has to come
+# *after* the above -O1 flag.
+<compiler name="llvm">
+  <flags CXXFLAGS="-O0 -Wno-constant-logical-operand -Wno-parentheses-equality"/>
+</compiler>
 <flags REM_CXXFLAGS="-flto"/>

--- a/RecoEcal/EgammaClusterAlgos/src/Multi5x5BremRecoveryClusterAlgo.cc
+++ b/RecoEcal/EgammaClusterAlgos/src/Multi5x5BremRecoveryClusterAlgo.cc
@@ -47,7 +47,11 @@ void Multi5x5BremRecoveryClusterAlgo::makeIslandSuperClusters(reco::CaloClusterP
   bool usedSeed[clusters_v.size()];
   for (auto ic=0U; ic<clusters_v.size(); ++ic) usedSeed[ic]=false;
  
+  #ifdef __clang__ 
+  std::vector<float> eta(clusters_v.size()), phi(clusters_v.size()), et(clusters_v.size());
+  #else
   float eta[clusters_v.size()], phi[clusters_v.size()], et[clusters_v.size()];
+  #endif
   for (auto ic=0U; ic<clusters_v.size(); ++ic) {
     eta[ic]=clusters_v[ic]->eta();
     phi[ic]=clusters_v[ic]->phi();

--- a/RecoEgamma/EgammaIsolationAlgos/interface/EgammaTowerIsolation.h
+++ b/RecoEgamma/EgammaIsolationAlgos/interface/EgammaTowerIsolation.h
@@ -136,7 +136,11 @@ EgammaTowerIsolationNew<NC>::EgammaTowerIsolationNew(float extRadius[NC],
   
   // sort in eta  (kd-tree anoverkill,does not vectorize...)
   uint32_t index[nt];
+  #ifdef __clang__
+  std::vector<float> e(nt);
+  #else
   float e[nt];
+  #endif
   for (std::size_t k=0; k!=nt; ++k) {
     e[k]=towers[k].eta();
     index[k]=k;

--- a/RecoLocalCalo/EcalRecAlgos/src/ESRecHitSimAlgo.cc
+++ b/RecoLocalCalo/EcalRecAlgos/src/ESRecHitSimAlgo.cc
@@ -51,7 +51,11 @@ EcalRecHit::ESFlags ESRecHitSimAlgo::evalAmplitude(float * results, const ESData
 
   // A from analytical formula:
   constexpr float t1 = 20.;
+  #ifdef __clang__
+  const float A_1 = 1./( std::pow(w/n*(t1),n) * std::exp(n-w*(t1)) );
+  #else
   constexpr float A_1 = 1./( std::pow(w/n*(t1),n) * std::exp(n-w*(t1)) );
+  #endif
   auto AA1 = A1 * A_1 ;
 
  if (adc[1] > 2800.f && adc[2] > 2800.f) status = EcalRecHit::kESSaturated;

--- a/RecoPixelVertexing/PixelTriplets/plugins/BuildFile.xml
+++ b/RecoPixelVertexing/PixelTriplets/plugins/BuildFile.xml
@@ -5,4 +5,4 @@
   <flags   EDM_PLUGIN="1"/>
 </library>
 
-<flags   CXXFLAGS="-Ofast -ftree-loop-if-convert-stores -fno-math-errno"/>
+<flags   CXXFLAGS="-Ofast -fno-math-errno"/>

--- a/RecoPixelVertexing/PixelTriplets/plugins/BuildFile.xml
+++ b/RecoPixelVertexing/PixelTriplets/plugins/BuildFile.xml
@@ -6,3 +6,6 @@
 </library>
 
 <flags   CXXFLAGS="-Ofast -fno-math-errno"/>
+<compiler name="gcc">
+  <flags CXXFLAGS="-ftree-loop-if-convert-stores"/>
+</compiler>

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.cc
@@ -86,7 +86,11 @@ void PixelTripletHLTGenerator::hitTriplets(const TrackingRegion& region,
   float regOffset = region.origin().perp(); //try to take account of non-centrality (?)
   int size = theLayers.size();
   
+  #ifdef __clang__
+  std::vector<ThirdHitRZPrediction<PixelRecoLineRZ>> preds(size);
+  #else
   ThirdHitRZPrediction<PixelRecoLineRZ> preds[size];
+  #endif
   
   const RecHitsSortedInPhi * thirdHitMap[size];
   typedef RecHitsSortedInPhi::Hit Hit;
@@ -96,7 +100,11 @@ void PixelTripletHLTGenerator::hitTriplets(const TrackingRegion& region,
   std::vector<unsigned int> foundNodes; // re-used thoughout
   foundNodes.reserve(100);
 
+  #ifdef __clang__
+  std::vector<KDTreeLinkerAlgo<unsigned int>> hitTree(size);
+  #else
   KDTreeLinkerAlgo<unsigned int> hitTree[size];
+  #endif
   float rzError[size]; //save maximum errors
   float maxphi = Geom::ftwoPi(), minphi = -maxphi; // increase to cater for any range
   

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletLargeTipGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletLargeTipGenerator.cc
@@ -107,12 +107,17 @@ void PixelTripletLargeTipGenerator::hitTriplets(const TrackingRegion& region,
   std::vector<NodeInfo > layerTree; // re-used throughout
   std::vector<unsigned int> foundNodes; // re-used throughout
   foundNodes.reserve(100);
+  #ifdef __clang__
+  std::vector<KDTreeLinkerAlgo<unsigned int>> hitTree(size);
+  std::vector<LayerRZPredictions> mapPred(size);
+  #else
   KDTreeLinkerAlgo<unsigned int> hitTree[size];
+  LayerRZPredictions mapPred[size];
+  #endif
 
   float rzError[size]; //save maximum errors
   float maxphi = Geom::ftwoPi(), minphi = -maxphi; //increase to cater for any range
 
-  LayerRZPredictions mapPred[size];
 
   const RecHitsSortedInPhi * thirdHitMap[size];
 

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackListMerger.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackListMerger.cc
@@ -407,7 +407,11 @@ namespace {
 
     //cache the id and rechits of valid hits
     typedef std::pair<unsigned int, const TrackingRecHit*> IHit;
+    #ifdef __clang__
+    std::vector<std::vector<IHit>> rh1(ngood);  // an array of vectors!
+    #else
     std::vector<IHit> rh1[ngood];  // an array of vectors!
+    #endif
     //const TrackingRecHit*  fh1[ngood];  // first hit...
     uint8_t algo[ngood];
     float score[ngood];
@@ -636,8 +640,13 @@ namespace {
     //  output selected tracks - if any
     //
 
+    #ifdef __clang__
+    std::vector<reco::TrackRef> trackRefs(rSize);
+    std::vector<edm::RefToBase<TrajectorySeed>> seedsRefs(rSize);
+    #else
     reco::TrackRef trackRefs[rSize];
     edm::RefToBase<TrajectorySeed> seedsRefs[rSize];
+    #endif
 
     unsigned int nToWrite=0;
     for ( unsigned int i=0; i<rSize; i++)

--- a/RecoTracker/TkSeedGenerator/plugins/MultiHitGeneratorFromChi2.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/MultiHitGeneratorFromChi2.cc
@@ -170,7 +170,11 @@ void MultiHitGeneratorFromChi2::hitSets(const TrackingRegion& region,
   std::vector<KDTreeNodeInfo<RecHitsSortedInPhi::HitIter> > layerTree; // re-used throughout
   std::vector<RecHitsSortedInPhi::HitIter> foundNodes; // re-used thoughout
   foundNodes.reserve(100);
+  #ifdef __clang__
+  std::vector<KDTreeLinkerAlgo<RecHitsSortedInPhi::HitIter>> hitTree(size);
+  #else
   KDTreeLinkerAlgo<RecHitsSortedInPhi::HitIter> hitTree[size];
+  #endif
   float rzError[size]; //save maximum errors
   double maxphi = Geom::twoPi(), minphi = -maxphi; //increase to cater for any range
 

--- a/TrackingTools/GsfTracking/src/GsfBetheHeitlerUpdator.cc
+++ b/TrackingTools/GsfTracking/src/GsfBetheHeitlerUpdator.cc
@@ -122,7 +122,12 @@ GsfBetheHeitlerUpdator::compute (const TrajectoryStateOnSurface& TSoS,
     if ( rl<0.01f )  rl = 0.01f;
     if ( rl>0.20f )  rl = 0.20f;
 
-    GSContainer mixture[theNrComponents];
+    #if __clang__
+    std::vector<GSContainer> mixtureHolder(theNrComponents);
+    GSContainer *mixture = mixtureHolder.data();
+    #else
+    GSContainer mixture(theNrComponents);
+    #endif
     getMixtureParameters(rl,mixture);
     correctWeights(mixture);
     if ( theCorrectionFlag>=1 )

--- a/TrackingTools/GsfTracking/src/GsfCombinedMaterialEffectsUpdator.cc
+++ b/TrackingTools/GsfTracking/src/GsfCombinedMaterialEffectsUpdator.cc
@@ -16,10 +16,17 @@ GsfCombinedMaterialEffectsUpdator::GsfCombinedMaterialEffectsUpdator(GsfMaterial
 void GsfCombinedMaterialEffectsUpdator::compute (const TrajectoryStateOnSurface& TSoS,
 						 const PropagationDirection propDir, Effect effects[]) const
 {
+  #if __clang__
+  std::vector<Effect> msEffects(theMSUpdator->size());
+  theMSUpdator->compute(TSoS,propDir,msEffects.data());
+  std::vector<Effect> elEffects(theELUpdator->size());
+  theELUpdator->compute(TSoS,propDir,elEffects.data());
+  #else
   Effect msEffects[theMSUpdator->size()];
   theMSUpdator->compute(TSoS,propDir,msEffects);
   Effect elEffects[theELUpdator->size()];
   theELUpdator->compute(TSoS,propDir,elEffects);
+  #endif
  
   //
   // combine the two multi-updates

--- a/TrackingTools/GsfTracking/src/GsfMaterialEffectsUpdator.cc
+++ b/TrackingTools/GsfTracking/src/GsfMaterialEffectsUpdator.cc
@@ -27,8 +27,13 @@ GsfMaterialEffectsUpdator::updateState (const TrajectoryStateOnSurface& TSoS,
   //
   // Get components (will force recalculation, if necessary)
   //
+  #if __clang__
+  std::vector<Effect> effects(size());
+  compute(TSoS,propDir,effects.data());
+  #else
   Effect effects[size()];
   compute(TSoS,propDir,effects);
+  #endif
 
   //
   // prepare output vector


### PR DESCRIPTION
This pull request almost aligns CMSSW_7_2_X with CMSSW_7_2_CLANG_X, this should make the clang static analyser and the root build even happier. gcc builds should not be affected by any of the changes, since they are all protected by an ifdef. As agreed with @VinInn we should find a better way to avoid capturing VLAs in lambdas (eventually getting rid of the VLA itself, since it did not make C++14).
