### PR TITLE
Fix G4Monopole for MT

### DIFF
--- a/SimG4Core/Application/interface/RunManagerMT.h
+++ b/SimG4Core/Application/interface/RunManagerMT.h
@@ -96,6 +96,15 @@ public:
     return m_physicsList.get();
   }
 
+  // In order to share the ChordFinderSetter (for
+  // G4MonopoleTransportation) with the worker threads, we need a
+  // non-const pointer. Thread-safety is handled inside
+  // ChordFinderStter with TLS. Should we consider a friend
+  // declaration here in order to avoid misuse?
+  sim::ChordFinderSetter *chordFinderSetterForWorker() const {
+    return m_chordFinderSetter.get();
+  }
+
 private:
   void terminateRun();
   void DumpMagneticField( const G4Field*) const;

--- a/SimG4Core/Application/src/CustomUIsession.cc
+++ b/SimG4Core/Application/src/CustomUIsession.cc
@@ -16,16 +16,24 @@ CustomUIsession::~CustomUIsession()
 
 }
 
+namespace {
+  std::string trim(const std::string& str) {
+    if(!str.empty() && str.back() == '\n')
+      return str.substr(0, str.length()-1);
+    return str;
+  }
+}
+
 G4int CustomUIsession::ReceiveG4cout(const G4String& coutString)
 {
   //std::cout << coutString << std::flush;
-  edm::LogInfo("G4cout") << coutString;
+  edm::LogVerbatim("G4cout") << trim(coutString);
   return 0;
 }
 
 G4int CustomUIsession::ReceiveG4cerr(const G4String& cerrString)
 {
   //std::cerr << cerrString << std::flush;
-  edm::LogWarning("G4cerr") << cerrString;
+  edm::LogWarning("G4cerr") << trim(cerrString);
   return 0;
 }

--- a/SimG4Core/Application/src/RunManagerMT.cc
+++ b/SimG4Core/Application/src/RunManagerMT.cc
@@ -115,8 +115,7 @@ void RunManagerMT::initG4(const DDCompactView *pDD, const MagneticField *pMF, co
       G4TransportationManager * tM =
 	G4TransportationManager::GetTransportationManager();
       m_fieldBuilder->build( tM->GetFieldManager(),
-			     tM->GetPropagatorInField(),
-                             m_chordFinderSetter.get());
+			     tM->GetPropagatorInField());
       if("" != m_FieldFile) {
 	DumpMagneticField(tM->GetFieldManager()->GetDetectorField());
       }

--- a/SimG4Core/Application/src/RunManagerMTWorker.cc
+++ b/SimG4Core/Application/src/RunManagerMTWorker.cc
@@ -204,7 +204,8 @@ void RunManagerMTWorker::initializeThread(const RunManagerMT& runManagerMaster, 
       G4TransportationManager * tM =
 	G4TransportationManager::GetTransportationManager();
       m_tls->fieldBuilder->build( tM->GetFieldManager(),
-                                  tM->GetPropagatorInField());
+                                  tM->GetPropagatorInField(),
+                                  runManagerMaster.chordFinderSetterForWorker());
     }
 
 

--- a/SimG4Core/PhysicsLists/src/CMSMonopolePhysics.cc
+++ b/SimG4Core/PhysicsLists/src/CMSMonopolePhysics.cc
@@ -94,8 +94,27 @@ void CMSMonopolePhysics::ConstructProcess() {
   for (unsigned int ii=0; ii<monopoles.size(); ++ii) {
     if (monopoles[ii]) {
       G4Monopole* mpl = monopoles[ii];
-      G4ProcessManager* pmanager = new G4ProcessManager(mpl);
-      mpl->SetProcessManager(pmanager);
+      G4ProcessManager *pmanager = mpl->GetProcessManager();
+      if(!pmanager) {
+        std::ostringstream o;
+        o << "Monopole without a Process Manager";
+        G4Exception("CMSMonopolePhysics::ConstructProcess()","",
+                    FatalException,o.str().c_str());
+      }
+
+      // Clear process list, for some reason G4Transportation is added
+      // somewhere, and it is not wanted (at least that was the
+      // behaviour before MT)
+      const G4int procLength = pmanager->GetProcessListLength();
+      for(G4int ip=procLength-1; ip >= 0; --ip) {
+        G4VProcess *proc = pmanager->RemoveProcess(ip);
+        if(!proc) {
+          std::ostringstream o;
+          o << "Clearing Monopole Process Manager failed for process " << ip << ", total number of processes " << procLength;
+          G4Exception("CMSMonopolePhysics::ConstructProcess()","",
+                      FatalException,o.str().c_str());
+        }
+      }
 
       G4String particleName = mpl->GetParticleName();
       G4double magn         = mpl->MagneticCharge();


### PR DESCRIPTION
Two fixes for G4Monopole in multithreaded sim:
- monopole-specific G4ChordFinder that is thread-local in ChordFinderSetter is now set in the worker threads instead of the master thread
- In CMSMonopolePhysics, do not associate G4ProcessManager to G4Monopole instance but use the association done in G4VUserPhysicsList::InitializeProcessManager() (that is MT-aware)

In addition, redirect G4cout to LogVerbatim (in CustomUIsession) and trim the trailing newline. This way the verbose output from OscarProducer does not get garbled by the message context information. I decided to keep G4cerr to be redirected to LogWarning, because for by-default-visible messages it is probably better to keep the context information.

Tested in CMSSW_7_2_GEANT10_X_2014-09-16-1400 with 100 events of

```
git clone git@github.com:cms-sw/GenProductions Configuration/GenProductions

cmsDriver.py Configuration/GenProductions/python/EightTeV/monopoles_cff.py -s GEN,SIM --conditions auto:mc --datatier GEN-SIM  --eventcontent=FEVTDEBUGHLT --customise Configuration/GenProductions/monopoles_customise.monopoles_customise --fileout file:mp.root --mc -n 10 --no_exec 
```

Results from serial OscarProducer are the identical before and after this PR, and after this PR the results from serial and 1-thread OscarMTProducer are identical.
