### PR TITLE
Use a std::shared_ptr to handle the lifetime of a module

### DIFF
--- a/FWCore/Framework/src/GlobalSchedule.cc
+++ b/FWCore/Framework/src/GlobalSchedule.cc
@@ -16,7 +16,7 @@
 #include <map>
 
 namespace edm {
-  GlobalSchedule::GlobalSchedule(TriggerResultInserter* inserter,
+  GlobalSchedule::GlobalSchedule(std::shared_ptr<TriggerResultInserter> inserter,
                                  std::shared_ptr<ModuleRegistry> modReg,
                                  std::vector<std::string> const& iModulesToUse,
                                  ParameterSet& proc_pset,

--- a/FWCore/Framework/src/GlobalSchedule.h
+++ b/FWCore/Framework/src/GlobalSchedule.h
@@ -73,7 +73,7 @@ namespace edm {
     typedef std::shared_ptr<Worker> WorkerPtr;
     typedef std::vector<Worker*> Workers;
 
-    GlobalSchedule(TriggerResultInserter* inserter,
+    GlobalSchedule(std::shared_ptr<TriggerResultInserter> inserter,
                    std::shared_ptr<ModuleRegistry> modReg,
                    std::vector<std::string> const& modulesToUse,
                    ParameterSet& proc_pset,

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -71,10 +71,10 @@ namespace edm {
       bool postCalled = false;
       std::shared_ptr<TriggerResultInserter> returnValue;
       try {
-        maker::ModuleHolderT<TriggerResultInserter> holder(new TriggerResultInserter(*trig_pset, iPrealloc.numberOfStreams()),static_cast<Maker const*>(nullptr));
+        maker::ModuleHolderT<TriggerResultInserter> holder(std::make_shared<TriggerResultInserter>(*trig_pset, iPrealloc.numberOfStreams()),static_cast<Maker const*>(nullptr));
         holder.setModuleDescription(md);
         holder.registerProductsAndCallbacks(&preg);
-        returnValue.reset(holder.release());
+        returnValue =holder.module();
         postCalled = true;
         // if exception then post will be called in the catch block
         areg->postModuleConstructionSignal_(md);
@@ -375,7 +375,7 @@ namespace edm {
     assert(0<prealloc.numberOfStreams());
     streamSchedules_.reserve(prealloc.numberOfStreams());
     for(unsigned int i=0; i<prealloc.numberOfStreams();++i) {
-      streamSchedules_.emplace_back(std::make_shared<StreamSchedule>(resultsInserter_.get(),moduleRegistry_,proc_pset,tns,prealloc,preg,branchIDListHelper,actions,areg,processConfiguration,nullptr==subProcPSet,StreamID{i},processContext));
+      streamSchedules_.emplace_back(std::make_shared<StreamSchedule>(resultsInserter_,moduleRegistry_,proc_pset,tns,prealloc,preg,branchIDListHelper,actions,areg,processConfiguration,nullptr==subProcPSet,StreamID{i},processContext));
     }
     
     //TriggerResults are injected automatically by StreamSchedules and are
@@ -399,7 +399,7 @@ namespace edm {
       std::copy(modulesToUse.begin(),itBeginUnscheduled,std::back_inserter(temp));
       temp.swap(modulesToUse);
     }
-    globalSchedule_.reset( new GlobalSchedule{ resultsInserter_.get(),
+    globalSchedule_.reset( new GlobalSchedule{ resultsInserter_,
       moduleRegistry_,
       modulesToUse,
       proc_pset, preg, prealloc,

--- a/FWCore/Framework/src/StreamSchedule.cc
+++ b/FWCore/Framework/src/StreamSchedule.cc
@@ -72,7 +72,7 @@ namespace edm {
     StreamSchedule::WorkerPtr
     makeInserter(ExceptionToActionTable const& actions,
                  std::shared_ptr<ActivityRegistry> areg,
-                 TriggerResultInserter* inserter) {
+                 std::shared_ptr<TriggerResultInserter> inserter) {
       StreamSchedule::WorkerPtr ptr(new edm::WorkerT<TriggerResultInserter::ModuleType>(inserter, inserter->moduleDescription(), &actions));
       ptr->setActivityRegistry(areg);
       return ptr;
@@ -130,7 +130,7 @@ namespace edm {
 
   // -----------------------------
 
-  StreamSchedule::StreamSchedule(TriggerResultInserter* inserter,
+  StreamSchedule::StreamSchedule(std::shared_ptr<TriggerResultInserter> inserter,
                                  std::shared_ptr<ModuleRegistry> modReg,
                                  ParameterSet& proc_pset,
                                  service::TriggerNamesService& tns,

--- a/FWCore/Framework/src/StreamSchedule.h
+++ b/FWCore/Framework/src/StreamSchedule.h
@@ -149,7 +149,7 @@ namespace edm {
 
     typedef std::vector<WorkerInPath> PathWorkers;
 
-    StreamSchedule(TriggerResultInserter* inserter,
+    StreamSchedule(std::shared_ptr<TriggerResultInserter> inserter,
                    std::shared_ptr<ModuleRegistry>,
                    ParameterSet& proc_pset,
                    service::TriggerNamesService& tns,

--- a/FWCore/Framework/src/WorkerMaker.h
+++ b/FWCore/Framework/src/WorkerMaker.h
@@ -82,7 +82,7 @@ protected:
     typedef typename UserType::ModuleType ModuleType;
     typedef MakeModuleHelper<ModuleType> MakerHelperType;
     
-    return std::shared_ptr<maker::ModuleHolder>(std::make_shared<maker::ModuleHolderT<ModuleType> >(MakerHelperType::template makeModule<UserType>(p).release(),this));
+    return std::shared_ptr<maker::ModuleHolder>(std::make_shared<maker::ModuleHolderT<ModuleType> >(MakerHelperType::template makeModule<UserType>(p),this));
   }
   
   template <class T>

--- a/FWCore/Framework/src/WorkerT.cc
+++ b/FWCore/Framework/src/WorkerT.cc
@@ -101,7 +101,7 @@ namespace edm{
 
   template<typename T>
   inline
-  WorkerT<T>::WorkerT(T* ed, ModuleDescription const& md, ExceptionToActionTable const* actions) :
+  WorkerT<T>::WorkerT(std::shared_ptr<T> ed, ModuleDescription const& md, ExceptionToActionTable const* actions) :
   Worker(md, actions),
   module_(ed) {
     assert(module_ != 0);

--- a/FWCore/Framework/src/WorkerT.h
+++ b/FWCore/Framework/src/WorkerT.h
@@ -26,16 +26,16 @@ namespace edm {
   public:
     typedef T ModuleType;
     typedef WorkerT<T> WorkerType;
-    WorkerT(T*,
+    WorkerT(std::shared_ptr<T>,
             ModuleDescription const&,
             ExceptionToActionTable const* actions);
 
     virtual ~WorkerT();
 
-  void setModule( T* iModule) {
-    module_ = iModule;
-    resetModuleDescription(&(module_->moduleDescription()));
-  }
+    void setModule( std::shared_ptr<T> iModule) {
+      module_ = iModule;
+      resetModuleDescription(&(module_->moduleDescription()));
+    }
     
     virtual Types moduleType() const override;
 
@@ -112,7 +112,7 @@ namespace edm {
 
     virtual std::vector<ProductHolderIndexAndSkipBit> const& itemsToGetFromEvent() const override { return module_->itemsToGetFromEvent(); }
 
-    T* module_;
+    std::shared_ptr<T> module_;
   };
 
 }

--- a/FWCore/Framework/test/global_module_t.cppunit.cc
+++ b/FWCore/Framework/test/global_module_t.cppunit.cc
@@ -101,7 +101,7 @@ private:
   edm::ModuleDescription m_desc = {"Dummy","dummy"};
   
   template<typename T>
-  void testTransitions(T* iMod, Expectations const& iExpect);
+  void testTransitions(std::shared_ptr<T> iMod, Expectations const& iExpect);
   
   class BasicProd : public edm::global::EDProducer<> {
   public:
@@ -427,7 +427,7 @@ m_ep()
 namespace {
   template<typename T>
   void
-  testTransition(T* iMod, edm::Worker* iWorker, testGlobalModule::Trans iTrans, testGlobalModule::Expectations const& iExpect, std::function<void(edm::Worker*)> iFunc) {
+  testTransition(std::shared_ptr<T> iMod, edm::Worker* iWorker, testGlobalModule::Trans iTrans, testGlobalModule::Expectations const& iExpect, std::function<void(edm::Worker*)> iFunc) {
     assert(0==iMod->m_count);
     iFunc(iWorker);
     auto count = std::count(iExpect.begin(),iExpect.end(),iTrans);
@@ -442,7 +442,7 @@ namespace {
 
 template<typename T>
 void
-testGlobalModule::testTransitions(T* iMod, Expectations const& iExpect) {
+testGlobalModule::testTransitions(std::shared_ptr<T> iMod, Expectations const& iExpect) {
   edm::WorkerT<edm::global::EDProducerBase> w{iMod,m_desc,nullptr};
   for(auto& keyVal: m_transToFunc) {
     testTransition(iMod,&w,keyVal.first,iExpect,keyVal.second);
@@ -452,101 +452,100 @@ testGlobalModule::testTransitions(T* iMod, Expectations const& iExpect) {
 
 void testGlobalModule::basicTest()
 {
-  std::unique_ptr<BasicProd> testProd{ new BasicProd };
+  std::shared_ptr<BasicProd> testProd{ new BasicProd };
   
   CPPUNIT_ASSERT(0 == testProd->m_count);
-  testTransitions(testProd.get(), {Trans::kEvent});
+  testTransitions(testProd, {Trans::kEvent});
 }
 
 void testGlobalModule::streamTest()
 {
-  std::unique_ptr<StreamProd> testProd{ new StreamProd };
-  edm::maker::ModuleHolderT<edm::global::EDProducerBase> h(testProd.get(),nullptr);
+  std::shared_ptr<StreamProd> testProd{ new StreamProd };
+  edm::maker::ModuleHolderT<edm::global::EDProducerBase> h(testProd,nullptr);
   h.preallocate(edm::PreallocationConfiguration{});
-  h.release();
   
   CPPUNIT_ASSERT(0 == testProd->m_count);
-  testTransitions(testProd.get(), {Trans::kBeginStream, Trans::kStreamBeginRun, Trans::kStreamBeginLuminosityBlock, Trans::kEvent,
+  testTransitions(testProd, {Trans::kBeginStream, Trans::kStreamBeginRun, Trans::kStreamBeginLuminosityBlock, Trans::kEvent,
     Trans::kStreamEndLuminosityBlock,Trans::kStreamEndRun,Trans::kEndStream});
 }
 
 void testGlobalModule::runTest()
 {
-  std::unique_ptr<RunProd> testProd{ new RunProd };
+  std::shared_ptr<RunProd> testProd{ new RunProd };
   
   CPPUNIT_ASSERT(0 == testProd->m_count);
-  testTransitions(testProd.get(), {Trans::kGlobalBeginRun, Trans::kEvent, Trans::kGlobalEndRun});
+  testTransitions(testProd, {Trans::kGlobalBeginRun, Trans::kEvent, Trans::kGlobalEndRun});
 }
 
 void testGlobalModule::runSummaryTest()
 {
-  std::unique_ptr<RunSummaryProd> testProd{ new RunSummaryProd };
+  std::shared_ptr<RunSummaryProd> testProd{ new RunSummaryProd };
   
   CPPUNIT_ASSERT(0 == testProd->m_count);
-  testTransitions(testProd.get(), {Trans::kGlobalBeginRun, Trans::kEvent, Trans::kStreamEndRun, Trans::kGlobalEndRun});
+  testTransitions(testProd, {Trans::kGlobalBeginRun, Trans::kEvent, Trans::kStreamEndRun, Trans::kGlobalEndRun});
 }
 
 void testGlobalModule::lumiTest()
 {
-  std::unique_ptr<LumiProd> testProd{ new LumiProd };
+  std::shared_ptr<LumiProd> testProd{ new LumiProd };
   
   CPPUNIT_ASSERT(0 == testProd->m_count);
-  testTransitions(testProd.get(), {Trans::kGlobalBeginLuminosityBlock, Trans::kEvent, Trans::kGlobalEndLuminosityBlock});
+  testTransitions(testProd, {Trans::kGlobalBeginLuminosityBlock, Trans::kEvent, Trans::kGlobalEndLuminosityBlock});
 }
 
 void testGlobalModule::lumiSummaryTest()
 {
-  std::unique_ptr<LumiSummaryProd> testProd{ new LumiSummaryProd };
+  std::shared_ptr<LumiSummaryProd> testProd{ new LumiSummaryProd };
   
   CPPUNIT_ASSERT(0 == testProd->m_count);
-  testTransitions(testProd.get(), {Trans::kGlobalBeginLuminosityBlock, Trans::kEvent, Trans::kStreamEndLuminosityBlock, Trans::kGlobalEndLuminosityBlock});
+  testTransitions(testProd, {Trans::kGlobalBeginLuminosityBlock, Trans::kEvent, Trans::kStreamEndLuminosityBlock, Trans::kGlobalEndLuminosityBlock});
 }
 
 void testGlobalModule::beginRunProdTest()
 {
-  std::unique_ptr<BeginRunProd> testProd{ new BeginRunProd };
+  std::shared_ptr<BeginRunProd> testProd{ new BeginRunProd };
   
   CPPUNIT_ASSERT(0 == testProd->m_count);
-  testTransitions(testProd.get(), {Trans::kGlobalBeginRun, Trans::kEvent});
+  testTransitions(testProd, {Trans::kGlobalBeginRun, Trans::kEvent});
 }
 
 void testGlobalModule::beginLumiProdTest()
 {
-  std::unique_ptr<BeginLumiProd> testProd{ new BeginLumiProd };
+  std::shared_ptr<BeginLumiProd> testProd{ new BeginLumiProd };
   
   CPPUNIT_ASSERT(0 == testProd->m_count);
-  testTransitions(testProd.get(), {Trans::kGlobalBeginLuminosityBlock, Trans::kEvent});
+  testTransitions(testProd, {Trans::kGlobalBeginLuminosityBlock, Trans::kEvent});
 }
 
 void testGlobalModule::endRunProdTest()
 {
-  std::unique_ptr<EndRunProd> testProd{ new EndRunProd };
+  std::shared_ptr<EndRunProd> testProd{ new EndRunProd };
   
   CPPUNIT_ASSERT(0 == testProd->m_count);
-  testTransitions(testProd.get(), {Trans::kGlobalEndRun, Trans::kEvent});
+  testTransitions(testProd, {Trans::kGlobalEndRun, Trans::kEvent});
 }
 
 void testGlobalModule::endLumiProdTest()
 {
-  std::unique_ptr<EndLumiProd> testProd{ new EndLumiProd };
+  std::shared_ptr<EndLumiProd> testProd{ new EndLumiProd };
   
   CPPUNIT_ASSERT(0 == testProd->m_count);
-  testTransitions(testProd.get(), {Trans::kGlobalEndLuminosityBlock, Trans::kEvent});
+  testTransitions(testProd, {Trans::kGlobalEndLuminosityBlock, Trans::kEvent});
 }
 
 void testGlobalModule::endRunSummaryProdTest()
 {
-  std::unique_ptr<EndRunSummaryProd> testProd{ new EndRunSummaryProd };
+  std::shared_ptr<EndRunSummaryProd> testProd{ new EndRunSummaryProd };
   
   CPPUNIT_ASSERT(0 == testProd->m_count);
-  testTransitions(testProd.get(), {Trans::kGlobalEndRun, Trans::kEvent, Trans::kGlobalBeginRun, Trans::kStreamEndRun, Trans::kGlobalEndRun});
+  testTransitions(testProd, {Trans::kGlobalEndRun, Trans::kEvent, Trans::kGlobalBeginRun, Trans::kStreamEndRun, Trans::kGlobalEndRun});
 }
 
 void testGlobalModule::endLumiSummaryProdTest()
 {
-  std::unique_ptr<EndLumiSummaryProd> testProd{ new EndLumiSummaryProd };
+  std::shared_ptr<EndLumiSummaryProd> testProd{ new EndLumiSummaryProd };
   
   CPPUNIT_ASSERT(0 == testProd->m_count);
-  testTransitions(testProd.get(), {Trans::kGlobalEndLuminosityBlock, Trans::kEvent, Trans::kGlobalBeginLuminosityBlock, Trans::kStreamEndLuminosityBlock, Trans::kGlobalEndLuminosityBlock}); 
+  testTransitions(testProd, {Trans::kGlobalEndLuminosityBlock, Trans::kEvent, Trans::kGlobalBeginLuminosityBlock, Trans::kStreamEndLuminosityBlock, Trans::kGlobalEndLuminosityBlock}); 
 }
 

--- a/FWCore/Framework/test/one_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/one_outputmodule_t.cppunit.cc
@@ -94,7 +94,7 @@ private:
   edm::ServiceToken serviceToken_;
   
   template<typename T>
-  void testTransitions(T* iMod, Expectations const& iExpect);
+  void testTransitions(std::shared_ptr<T> iMod, Expectations const& iExpect);
   
   class BasicOutputModule : public edm::one::OutputModule<> {
   public:
@@ -327,7 +327,7 @@ m_ep()
 namespace {
   template<typename T>
   void
-  testTransition(T* iMod, edm::Worker* iWorker, edm::OutputModuleCommunicator* iComm, testOneOutputModule::Trans iTrans, testOneOutputModule::Expectations const& iExpect, std::function<void(edm::Worker*, edm::OutputModuleCommunicator*)> iFunc) {
+  testTransition(std::shared_ptr<T> iMod, edm::Worker* iWorker, edm::OutputModuleCommunicator* iComm, testOneOutputModule::Trans iTrans, testOneOutputModule::Expectations const& iExpect, std::function<void(edm::Worker*, edm::OutputModuleCommunicator*)> iFunc) {
     assert(0==iMod->m_count);
     iFunc(iWorker,iComm);
     auto count = std::count(iExpect.begin(),iExpect.end(),iTrans);
@@ -342,9 +342,9 @@ namespace {
 
 template<typename T>
 void
-testOneOutputModule::testTransitions(T* iMod, Expectations const& iExpect) {
+testOneOutputModule::testTransitions(std::shared_ptr<T> iMod, Expectations const& iExpect) {
   edm::WorkerT<edm::one::OutputModuleBase> w{iMod,m_desc,m_params.actions_};
-  edm::OutputModuleCommunicatorT<edm::one::OutputModuleBase> comm(iMod);
+  edm::OutputModuleCommunicatorT<edm::one::OutputModuleBase> comm(iMod.get());
   for(auto& keyVal: m_transToFunc) {
     testTransition(iMod,&w,&comm,keyVal.first,iExpect,keyVal.second);
   }
@@ -357,10 +357,10 @@ void testOneOutputModule::basicTest()
   edm::ServiceRegistry::Operate operate(serviceToken_);
 
   edm::ParameterSet pset;
-  std::unique_ptr<BasicOutputModule> testProd{ new BasicOutputModule(pset) };
+  std::shared_ptr<BasicOutputModule> testProd{ new BasicOutputModule(pset) };
   
   CPPUNIT_ASSERT(0 == testProd->m_count);
-  testTransitions(testProd.get(), {Trans::kEvent,Trans::kGlobalEndLuminosityBlock, Trans::kGlobalEndRun});
+  testTransitions(testProd, {Trans::kEvent,Trans::kGlobalEndLuminosityBlock, Trans::kGlobalEndRun});
 }
 
 void testOneOutputModule::runTest()
@@ -369,10 +369,10 @@ void testOneOutputModule::runTest()
   edm::ServiceRegistry::Operate operate(serviceToken_);
 
   edm::ParameterSet pset;
-  std::unique_ptr<RunOutputModule> testProd{ new RunOutputModule(pset) };
+  std::shared_ptr<RunOutputModule> testProd{ new RunOutputModule(pset) };
   
   CPPUNIT_ASSERT(0 == testProd->m_count);
-  testTransitions(testProd.get(), {Trans::kGlobalBeginRun, Trans::kEvent, Trans::kGlobalEndLuminosityBlock, Trans::kGlobalEndRun, Trans::kGlobalEndRun});
+  testTransitions(testProd, {Trans::kGlobalBeginRun, Trans::kEvent, Trans::kGlobalEndLuminosityBlock, Trans::kGlobalEndRun, Trans::kGlobalEndRun});
 }
 
 void testOneOutputModule::lumiTest()
@@ -381,10 +381,10 @@ void testOneOutputModule::lumiTest()
   edm::ServiceRegistry::Operate operate(serviceToken_);
 
   edm::ParameterSet pset;
-  std::unique_ptr<LumiOutputModule> testProd{ new LumiOutputModule(pset) };
+  std::shared_ptr<LumiOutputModule> testProd{ new LumiOutputModule(pset) };
   
   CPPUNIT_ASSERT(0 == testProd->m_count);
-  testTransitions(testProd.get(), {Trans::kGlobalBeginLuminosityBlock, Trans::kEvent, Trans::kGlobalEndLuminosityBlock, Trans::kGlobalEndLuminosityBlock, Trans::kGlobalEndRun});
+  testTransitions(testProd, {Trans::kGlobalBeginLuminosityBlock, Trans::kEvent, Trans::kGlobalEndLuminosityBlock, Trans::kGlobalEndLuminosityBlock, Trans::kGlobalEndRun});
 }
 
 void testOneOutputModule::fileTest()
@@ -393,10 +393,10 @@ void testOneOutputModule::fileTest()
   edm::ServiceRegistry::Operate operate(serviceToken_);
   
   edm::ParameterSet pset;
-  std::unique_ptr<FileOutputModule> testProd{ new FileOutputModule(pset) };
+  std::shared_ptr<FileOutputModule> testProd{ new FileOutputModule(pset) };
   
   CPPUNIT_ASSERT(0 == testProd->m_count);
-  testTransitions(testProd.get(), {Trans::kGlobalOpenInputFile, Trans::kEvent, Trans::kGlobalEndLuminosityBlock, Trans::kGlobalEndRun, Trans::kGlobalCloseInputFile});
+  testTransitions(testProd, {Trans::kGlobalOpenInputFile, Trans::kEvent, Trans::kGlobalEndLuminosityBlock, Trans::kGlobalEndRun, Trans::kGlobalCloseInputFile});
 }
 
 void testOneOutputModule::resourceTest()
@@ -405,9 +405,9 @@ void testOneOutputModule::resourceTest()
   edm::ServiceRegistry::Operate operate(serviceToken_);
   
   edm::ParameterSet pset;
-  std::unique_ptr<ResourceOutputModule> testProd{ new ResourceOutputModule(pset) };
+  std::shared_ptr<ResourceOutputModule> testProd{ new ResourceOutputModule(pset) };
   
   CPPUNIT_ASSERT(0 == testProd->m_count);
-  testTransitions(testProd.get(), {Trans::kEvent,Trans::kGlobalEndLuminosityBlock, Trans::kGlobalEndRun});
+  testTransitions(testProd, {Trans::kEvent,Trans::kGlobalEndLuminosityBlock, Trans::kGlobalEndRun});
 }
 

--- a/FWCore/Framework/test/stream_module_t.cppunit.cc
+++ b/FWCore/Framework/test/stream_module_t.cppunit.cc
@@ -100,7 +100,7 @@ private:
   edm::ModuleDescription m_desc = {"Dummy","dummy"};
   
   template<typename T, typename U>
-  void testTransitions(U* iMod, Expectations const& iExpect);
+  void testTransitions(std::shared_ptr<U> iMod, Expectations const& iExpect);
   
   template<typename T>
   void runTest(Expectations const& iExpect);
@@ -454,12 +454,11 @@ m_ep()
 
 namespace {
   template<typename T>
-  std::unique_ptr<edm::stream::EDProducerAdaptorBase> createModule() {
+  std::shared_ptr<edm::stream::EDProducerAdaptorBase> createModule() {
     edm::ParameterSet pset;
-    std::unique_ptr<edm::stream::EDProducerAdaptorBase> retValue(new edm::stream::EDProducerAdaptor<T>(pset));
-    edm::maker::ModuleHolderT<edm::stream::EDProducerAdaptorBase> h(retValue.get(),nullptr);
+    std::shared_ptr<edm::stream::EDProducerAdaptorBase> retValue(new edm::stream::EDProducerAdaptor<T>(pset));
+    edm::maker::ModuleHolderT<edm::stream::EDProducerAdaptorBase> h(retValue,nullptr);
     h.preallocate(edm::PreallocationConfiguration{});
-    h.release();
     return retValue;
   }
   template<typename T>
@@ -479,7 +478,7 @@ namespace {
 
 template<typename T, typename U>
 void
-testStreamModule::testTransitions(U* iMod, Expectations const& iExpect) {
+testStreamModule::testTransitions(std::shared_ptr<U> iMod, Expectations const& iExpect) {
   edm::WorkerT<edm::stream::EDProducerAdaptorBase> w{iMod,m_desc,nullptr};
   for(auto& keyVal: m_transToFunc) {
     testTransition<T>(&w,keyVal.first,iExpect,keyVal.second);
@@ -490,7 +489,7 @@ void
 testStreamModule::runTest(Expectations const& iExpect) {
   auto mod = createModule<T>();
   CPPUNIT_ASSERT(0 == T::m_count);
-  testTransitions<T>(mod.get(),iExpect);
+  testTransitions<T>(mod,iExpect);
 }
 
 


### PR DESCRIPTION
The extremely rarely used case (used only by Fireworks) where a Looper modifies the parameters of a module had a memory problem due to inconsistent lifetime of a module. Switching to a std::shared_ptr rather than a bare pointer allows the lifetime to be correct. This bug was found by the address sanitizer.
