### PR TITLE
Update ROOT class checksum for L1DataEmulRecord

### DIFF
--- a/DataFormats/L1Trigger/src/classes_def.xml
+++ b/DataFormats/L1Trigger/src/classes_def.xml
@@ -128,7 +128,8 @@
    <version ClassVersion="10" checksum="634833762"/>
   </class>
   <class name="std::vector<L1DataEmulDigi>"/>
-  <class name="L1DataEmulRecord" ClassVersion="11">
+  <class name="L1DataEmulRecord" ClassVersion="12">
+   <version ClassVersion="12" checksum="3255820845"/>
    <version ClassVersion="11" checksum="3617630969"/>
    <version ClassVersion="10" checksum="466303541"/>
   </class>


### PR DESCRIPTION
ROOT 5.34.20 changed how class checksums are calculated. This changed
the checksum for L1DataEmulRecord which meant we needed to update our
classes_def.xml with a new version and checksum.
