### PR TITLE
Update ROOT class checksum for HEDarkening

### DIFF
--- a/DataFormats/HcalCalibObjects/src/classes_def.xml
+++ b/DataFormats/HcalCalibObjects/src/classes_def.xml
@@ -1,6 +1,6 @@
 <lcgdict>
   <class name="HEDarkening" ClassVersion="0">
-   <version ClassVersion="0" checksum="3959036251"/>
+   <version ClassVersion="0" checksum="3959036241"/>
   </class>
   <class name="HFRecalibration" ClassVersion="0">
    <version ClassVersion="0" checksum="526251233"/>


### PR DESCRIPTION
ROOT 5.34.20 changed how class checksums are calculated. This changed
the checksum for HEDarkening which meant we needed to update our
classes_def.xml.
