### PR TITLE
Avoid unnecessary use of TType

### DIFF
--- a/FWCore/Utilities/interface/TypeWithDict.h
+++ b/FWCore/Utilities/interface/TypeWithDict.h
@@ -66,7 +66,6 @@ public:
   bool hasDictionary() const;
   std::type_info const& typeInfo() const;
   std::type_info const& id() const;
-  TType* getType() const;
   TClass* getClass() const;
   TEnum* getEnum() const;
   TDataType* getDataType() const;
@@ -118,9 +117,6 @@ public:
   void deallocate(void* address) const;
   ObjectWithDict construct() const;
   void destruct(void* address, bool dealloc = true) const;
-  void* ttype() const {
-    return type_;
-  }
 };
 
 // A related free function


### PR DESCRIPTION
This pull request avoids unnecessary creation of the TType data member of TypeWithDict.  In cases where the type can be represented by a TClass or TDataType, there is no need to also create a TType.  This pull request greatly reduces autoparsing of headers, and thereby saves memory.
Please merge this request as soon as convenent.
