### PR TITLE
RequestType RequestPriority for relval submission

### DIFF
--- a/Configuration/PyReleaseValidation/python/MatrixInjector.py
+++ b/Configuration/PyReleaseValidation/python/MatrixInjector.py
@@ -81,7 +81,7 @@ class MatrixInjector(object):
         self.defaultChain={
             "RequestType" :    "TaskChain",                    #this is how we handle relvals
             "SubRequestType" : "RelVal",                       #this is how we handle relvals, now that TaskChain is also used for central MC production
-            "RequestPriority": 1000000,
+            "RequestPriority": 999999,
             "Requestor": self.user,                           #Person responsible
             "Group": self.group,                              #group for the request
             "CMSSWVersion": os.getenv('CMSSW_VERSION'),       #CMSSW Version (used for all tasks in chain)

--- a/Configuration/PyReleaseValidation/python/MatrixInjector.py
+++ b/Configuration/PyReleaseValidation/python/MatrixInjector.py
@@ -79,7 +79,9 @@ class MatrixInjector(object):
             print '\n\tFound wmclient\n'
             
         self.defaultChain={
-            "RequestType" :   "TaskChain",                    #this is how we handle relvals
+            "RequestType" :    "TaskChain",                    #this is how we handle relvals
+            "SubRequestType" : "RelVal",                       #this is how we handle relvals, now that TaskChain is also used for central MC production
+            "RequestPriority": 110000,
             "Requestor": self.user,                           #Person responsible
             "Group": self.group,                              #group for the request
             "CMSSWVersion": os.getenv('CMSSW_VERSION'),       #CMSSW Version (used for all tasks in chain)

--- a/Configuration/PyReleaseValidation/python/MatrixInjector.py
+++ b/Configuration/PyReleaseValidation/python/MatrixInjector.py
@@ -81,7 +81,7 @@ class MatrixInjector(object):
         self.defaultChain={
             "RequestType" :    "TaskChain",                    #this is how we handle relvals
             "SubRequestType" : "RelVal",                       #this is how we handle relvals, now that TaskChain is also used for central MC production
-            "RequestPriority": 110000,
+            "RequestPriority": 1000000,
             "Requestor": self.user,                           #Person responsible
             "Group": self.group,                              #group for the request
             "CMSSWVersion": os.getenv('CMSSW_VERSION'),       #CMSSW Version (used for all tasks in chain)


### PR DESCRIPTION
- back port from 72x
- RequestType RequestPriority are now set for all relvals submissions; as agreed with dcompops/dataops
- this change affects only relval production submission, not IB's
