### PR TITLE
replace importlib with __import__

### DIFF
--- a/PhysicsTools/SelectorUtils/python/tools/vid_id_tools.py
+++ b/PhysicsTools/SelectorUtils/python/tools/vid_id_tools.py
@@ -2,7 +2,8 @@ import FWCore.ParameterSet.Config as cms
 
 from PhysicsTools.SelectorUtils.centralIDRegistry import central_id_registry
 
-import importlib
+#keep python2.6 compatibility for computing
+#import importlib
 
 #general simple tools for various object types
 def setupVIDSelection(vidproducer,cutflow):
@@ -28,7 +29,8 @@ def addVIDSelectionToPATProducer(patProducer,idProducer,idName):
     print '\t--- %s:%s added to %s'%(idProducer,idName,patProducer.label())
 
 def setupAllVIDIdsInModule(process,id_module_name,setupFunction,patProducer=None):
-    idmod = importlib.import_module(id_module_name)
+#    idmod = importlib.import_module(id_module_name)
+    idmod= __import__(id_module_name)
     for name in dir(idmod):
         item = getattr(idmod,name)
         if hasattr(item,'idName') and hasattr(item,'cutFlow'):


### PR DESCRIPTION
seems that comp-ops would like to use python2.6 for some reason. so preserve backwards compatibility
