### PR TITLE
fix uninitialised var timetype to avoid error from checker

### DIFF
--- a/CondCore/ESSources/plugins/CondDBESSource.cc
+++ b/CondCore/ESSources/plugins/CondDBESSource.cc
@@ -344,7 +344,7 @@ CondDBESSource::setIntervalFor( const edm::eventsetup::EventSetupRecordKey& iKey
 
   // compute the smallest interval (assume all objects have the same timetype....)                                                                                                          
   cond::ValidityInterval recordValidity(1,cond::TIMELIMIT);
-  cond::TimeType timetype = cond::TimeType::invalid;;
+  cond::TimeType timetype = cond::TimeType::invalid;
   bool userTime=true;
 
  //FIXME use equal_range

--- a/CondCore/ESSources/plugins/CondDBESSource.cc
+++ b/CondCore/ESSources/plugins/CondDBESSource.cc
@@ -344,7 +344,7 @@ CondDBESSource::setIntervalFor( const edm::eventsetup::EventSetupRecordKey& iKey
 
   // compute the smallest interval (assume all objects have the same timetype....)                                                                                                          
   cond::ValidityInterval recordValidity(1,cond::TIMELIMIT);
-  cond::TimeType timetype;
+  cond::TimeType timetype = cond::TimeType::invalid;;
   bool userTime=true;
 
  //FIXME use equal_range


### PR DESCRIPTION
... as reported by DavidA in https://hypernews.cern.ch/HyperNews/CMS/get/swDevelopment/3051.html
7.3.X version
