### PR TITLE
New feature. Thinned collections.

### DIFF
--- a/DQM/SiStripMonitorHardware/src/SiStripSpyEventMatcher.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyEventMatcher.cc
@@ -13,6 +13,7 @@
 #include "DataFormats/Provenance/interface/BranchIDListHelper.h"
 #include "DataFormats/Provenance/interface/EventID.h"
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
+#include "DataFormats/Provenance/interface/ThinnedAssociationsHelper.h"
 #include "CondFormats/SiStripObjects/interface/SiStripFedCabling.h"
 #include "DataFormats/SiStripCommon/interface/SiStripFedKey.h"
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
@@ -65,6 +66,7 @@ namespace sistrip {
 
     eventPrincipal_.reset(new edm::EventPrincipal(source_->productRegistry(),
                                                   source_->branchIDListHelper(),
+                                                  source_->thinnedAssociationsHelper(),
                                                   *processConfiguration_,
                                                   nullptr));
   }
@@ -75,6 +77,7 @@ namespace sistrip {
     edm::InputSourceDescription description(edm::ModuleDescription(),
                                             *productRegistry_,
                                             std::make_shared<edm::BranchIDListHelper>(),
+                                            std::make_shared<edm::ThinnedAssociationsHelper>(),
                                             std::make_shared<edm::ActivityRegistry>(),
                                             -1, -1, -1,
                                             edm::PreallocationConfiguration());

--- a/DataFormats/Common/interface/EDProductGetter.h
+++ b/DataFormats/Common/interface/EDProductGetter.h
@@ -17,15 +17,20 @@
 //
 
 // user include files
-#include "DataFormats/Common/interface/WrapperBase.h"
-#include "DataFormats/Provenance/interface/ProductID.h"
 
 // system include files
+#include <string>
+#include <vector>
+
 #include "boost/utility.hpp"
 
 // forward declarations
 
 namespace edm {
+
+   class ProductID;
+   class WrapperBase;
+
    class EDProductGetter : private boost::noncopyable {
 
    public:
@@ -35,6 +40,30 @@ namespace edm {
 
      // ---------- const member functions ---------------------
      virtual WrapperBase const* getIt(ProductID const&) const = 0;
+
+     // getThinnedProduct assumes getIt was already called and failed to find
+     // the product. The input key is the index of the desired element in the
+     // container identified by ProductID (which cannot be found).
+     // If the return value is not null, then the desired element was found
+     // in a thinned container and key is modified to be the index into
+     // that thinned container. If the desired element is not found, then
+     // nullptr is returned.
+     virtual WrapperBase const* getThinnedProduct(ProductID const&, unsigned int& key) const = 0;
+
+     // getThinnedProducts assumes getIt was already called and failed to find
+     // the product. The input keys are the indexes into the container identified
+     // by ProductID (which cannot be found). On input the WrapperBase pointers
+     // must all be set to nullptr (except when the function calls itself
+     // recursively where non-null pointers mark already found elements).
+     // Thinned containers derived from the product are searched to see
+     // if they contain the desired elements. For each that is
+     // found, the corresponding WrapperBase pointer is set and the key
+     // is modified to be the key into the container where the element
+     // was found. The WrapperBase pointers might or might not all point
+     // to the same thinned container.
+     virtual void getThinnedProducts(ProductID const& pid,
+                                     std::vector<WrapperBase const*>& foundContainers,
+                                     std::vector<unsigned int>& keys) const = 0;
 
      unsigned int transitionIndex() const {
        return transitionIndex_();

--- a/DataFormats/Common/interface/PtrVectorBase.h
+++ b/DataFormats/Common/interface/PtrVectorBase.h
@@ -5,7 +5,7 @@
 // Package:     Common
 // Class  :     PtrVectorBase
 //
-/**\class PtrVectorBase PtrVectorBase.h DataFormats/Common/interface/PtrVectorBase.h
+/**\class edm::PtrVectorBase
 
  Description: Base class for PtrVector
 
@@ -60,11 +60,9 @@ namespace edm {
 
     bool hasCache() const { return !cachedItems_.empty(); }
 
-    bool hasProductCache() const { return 0 == core_.productPtr(); }
-
     /// True if the data is in memory or is available in the Event
     /// No type checking is done.
-    bool isAvailable() const { return core_.isAvailable(); }
+    bool isAvailable() const;
 
     /// Is the RefVector empty
     bool empty() const {return indicies_.empty();}
@@ -90,7 +88,7 @@ namespace edm {
     bool isTransient() const {return core_.isTransient();}
 
     void const* product() const {
-       return 0;
+      return 0;
     }
 
   protected:
@@ -103,10 +101,12 @@ namespace edm {
 
     std::vector<void const*>::const_iterator void_begin() const {
       getProduct_();
+      checkCachedItems();
       return cachedItems_.begin();
     }
     std::vector<void const*>::const_iterator void_end() const {
       getProduct_();
+      checkCachedItems();
       return cachedItems_.end();
     }
 
@@ -116,7 +116,7 @@ namespace edm {
         return TPtr(reinterpret_cast<typename TPtr::value_type const*>(cachedItems_[iIndex]),
                   indicies_[iIndex]);
       }
-      if (hasCache()) {
+      if (hasCache() && (cachedItems_[iIndex] != nullptr || productGetter() == nullptr)) {
         return TPtr(this->id(),
                   reinterpret_cast<typename TPtr::value_type const*>(cachedItems_[iIndex]),
                   indicies_[iIndex]);
@@ -130,7 +130,7 @@ namespace edm {
         return TPtr(reinterpret_cast<typename TPtr::value_type const*>(*iIt),
                   indicies_[iIt - cachedItems_.begin()]);
       }
-      if (hasCache()) {
+      if (hasCache() && (*iIt != nullptr || productGetter() == nullptr)) {
         return TPtr(this->id(),
                   reinterpret_cast<typename TPtr::value_type const*>(*iIt),
                   indicies_[iIt - cachedItems_.begin()]);
@@ -145,6 +145,9 @@ namespace edm {
       assert(false);
       return *reinterpret_cast<const std::type_info*>(0);
     }
+
+    void checkCachedItems() const;
+
     // ---------- member data --------------------------------
     RefCore core_;
     std::vector<key_type> indicies_;

--- a/DataFormats/Common/interface/Ref.h
+++ b/DataFormats/Common/interface/Ref.h
@@ -273,7 +273,7 @@ namespace edm {
 
     /// Checks if collection is in memory or available
     /// in the Event. No type checking is done.
-    bool isAvailable() const {return product_.isAvailable();}
+    bool isAvailable() const;
 
     /// Checks if this ref is transient (i.e. not persistable).
     bool isTransient() const {return product_.isTransient();}
@@ -431,8 +431,8 @@ namespace edm {
     
     /// Checks if collection is in memory or available
     /// in the Event. No type checking is done.
-    bool isAvailable() const {return product_.isAvailable();}
-    
+    bool isAvailable() const;
+
     /// Checks if this ref is transient (i.e. not persistable).
     bool isTransient() const {return product_.isTransient();}
     
@@ -606,6 +606,26 @@ namespace edm {
   std::vector<E> const*
   Ref<REF_FOR_VECTOR_ARGS>::product() const {
     return isNull() ? 0 : edm::template getProduct<std::vector<E> >(product_.toRefCore());
+  }
+
+  template <typename C, typename T, typename F>
+  inline
+  bool
+  Ref<C, T, F>::isAvailable() const {
+    if(product_.isAvailable()) {
+      return true;
+    }
+    return isThinnedAvailable<C>(product_, index_);
+  }
+
+  template <typename E>
+  inline
+  bool
+  Ref<REF_FOR_VECTOR_ARGS>::isAvailable() const {
+    if(product_.isAvailable()) {
+      return true;
+    }
+    return isThinnedAvailable<std::vector<E> >(product_.toRefCore(), key());
   }
 
   /// Dereference operator

--- a/DataFormats/Common/interface/RefCore.h
+++ b/DataFormats/Common/interface/RefCore.h
@@ -58,6 +58,12 @@ namespace edm {
 
     WrapperBase const* getProductPtr(std::type_info const& type) const;
 
+    WrapperBase const* tryToGetProductPtr(std::type_info const& type) const;
+
+    WrapperBase const* getThinnedProductPtr(std::type_info const& type, unsigned int& thinnedKey) const;
+
+    bool isThinnedAvailable(unsigned int thinnedKey) const;
+
     void productNotFoundException(std::type_info const& type) const;
 
     void wrongTypeException(std::type_info const& expectedType, std::type_info const& actualType) const;

--- a/DataFormats/Common/interface/RefCoreGet.h
+++ b/DataFormats/Common/interface/RefCoreGet.h
@@ -41,5 +41,62 @@ namespace edm {
     }
     return refcore::getProductPtr_<T>(ref);
   }
+
+  namespace refcore {
+    template <typename T>
+    inline
+    T const*
+    tryToGetProductPtr_(RefCore const& ref) {
+      //if (isNull()) throwInvalidReference();
+      assert (!ref.isTransient());
+      WrapperBase const* product = ref.tryToGetProductPtr(typeid(T));
+      if(product == nullptr) {
+        return nullptr;
+      }
+      Wrapper<T> const* wrapper = static_cast<Wrapper<T> const*>(product);
+      ref.setProductPtr(wrapper->product());
+      return wrapper->product();
+    }
+  }
+
+  template <typename T>
+  inline
+  T const*
+  tryToGetProduct(RefCore const& ref) {
+    T const* p = static_cast<T const*>(ref.productPtr());
+    if (p != 0) return p;
+    if (ref.isTransient()) {
+      ref.nullPointerForTransientException(typeid(T));
+    }
+    return refcore::tryToGetProductPtr_<T>(ref);
+  }
+
+  namespace refcore {
+    template <typename T>
+    inline
+    T const*
+    getThinnedProductPtr_(RefCore const& ref, unsigned int& thinnedKey) {
+      assert (!ref.isTransient());
+      WrapperBase const* product = ref.getThinnedProductPtr(typeid(T), thinnedKey);
+      Wrapper<T> const* wrapper = static_cast<Wrapper<T> const*>(product);
+      // Do not cache the pointer to a thinned collection
+      // ref.setProductPtr(wrapper->product());
+      return wrapper->product();
+    }
+  }
+
+  template <typename T>
+  inline
+  T const*
+  getThinnedProduct(RefCore const& ref, unsigned int& thinnedKey) {
+    // The pointer to a thinned collection will never be cached
+    // T const* p = static_cast<T const*>(ref.productPtr());
+    // if (p != 0) return p;
+
+    if (ref.isTransient()) {
+      ref.nullPointerForTransientException(typeid(T));
+    }
+    return refcore::getThinnedProductPtr_<T>(ref, thinnedKey);
+  }
 }
 #endif

--- a/DataFormats/Common/interface/RefVector.h
+++ b/DataFormats/Common/interface/RefVector.h
@@ -121,7 +121,7 @@ namespace edm {
 
     /// Checks if product collection is in memory or available
     /// in the Event. No type checking is done.
-    bool isAvailable() const {return refVector_.refCore().isAvailable();}
+  bool isAvailable() const;
 
     /// Checks if product collection is tansient (i.e. non persistable)
     bool isTransient() const {return refVector_.refCore().isTransient();}
@@ -248,6 +248,30 @@ namespace edm {
   template<typename C, typename T, typename F>
   typename RefVector<C, T, F>::const_iterator RefVector<C, T, F>::end() const {
     return iterator(refVector_.refCore(), refVector_.keys().end());
+  }
+
+  template<typename C, typename T, typename F>
+  bool
+  RefVector<C, T, F>::isAvailable() const {
+    if(refVector_.refCore().isAvailable()) {
+      return true;
+    } else if(empty()) {
+      return false;
+    }
+
+    // The following is the simplest implementation, but
+    // this is woefully inefficient and could be optimized
+    // to run much faster with some nontrivial effort. There
+    // is only 1 place in the code base where this function
+    // is used at all and I'm not sure whether it will ever
+    // be used with thinned collections, so for the moment I
+    // am not spending the time to optimize this.
+    for(size_type i = 0; i < size(); ++i) {
+      if(!(*this)[i].isAvailable()) {
+        return false;
+      }
+    }
+    return true;
   }
 
   template<typename C, typename T, typename F>

--- a/DataFormats/Common/interface/ThinnedAssociation.h
+++ b/DataFormats/Common/interface/ThinnedAssociation.h
@@ -1,0 +1,43 @@
+#ifndef DataFormats_Common_ThinnedAssociation_h
+#define DataFormats_Common_ThinnedAssociation_h
+
+/** \class edm::ThinnedAssociation
+\author W. David Dagenhart, created 11 June 2014
+*/
+
+#include "DataFormats/Provenance/interface/ProductID.h"
+
+#include <vector>
+
+namespace edm {
+
+  class ThinnedAssociation {
+  public:
+
+    ThinnedAssociation();
+
+    ProductID const& parentCollectionID() const { return parentCollectionID_; }
+    ProductID const& thinnedCollectionID() const { return thinnedCollectionID_; }
+    std::vector<unsigned int> const& indexesIntoParent() const { return indexesIntoParent_; }
+
+    bool hasParentIndex(unsigned int parentIndex, unsigned int& thinnedIndex) const;
+
+    void setParentCollectionID(ProductID const& v) { parentCollectionID_ = v; }
+    void setThinnedCollectionID(ProductID const& v) { thinnedCollectionID_ = v; }
+    void push_back(unsigned int index) { indexesIntoParent_.push_back(index); }
+
+  private:
+
+    ProductID parentCollectionID_;
+    ProductID thinnedCollectionID_;
+
+    // The size of indexesIntoParent_ is the same as
+    // the size of the thinned collection and each
+    // element of indexesIntoParent corresponds to the
+    // element of the thinned collection at the same position.
+    // The values give the index of the corresponding element
+    // in the parent collection.
+    std::vector<unsigned int> indexesIntoParent_;
+  };
+}
+#endif

--- a/DataFormats/Common/src/EDProductGetter.cc
+++ b/DataFormats/Common/src/EDProductGetter.cc
@@ -14,6 +14,7 @@
 
 // user include files
 #include "DataFormats/Common/interface/EDProductGetter.h"
+#include "DataFormats/Provenance/interface/ProductID.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 
 namespace edm {

--- a/DataFormats/Common/src/PtrVectorBase.cc
+++ b/DataFormats/Common/src/PtrVectorBase.cc
@@ -69,6 +69,25 @@ namespace edm {
     indicies_.push_back(iKey);
   }
 
+  bool
+  PtrVectorBase::isAvailable() const {
+    if(indicies_.empty()) {
+      return core_.isAvailable();
+    }
+    if(!hasCache()) {
+      if(!id().isValid() || productGetter() == nullptr) {
+        return false;
+      }
+      getProduct_();
+    }
+    for(auto ptr : cachedItems_) {
+      if(ptr == nullptr) {
+        return false;
+      }
+    }
+    return true;
+  }
+
 //
 // const member functions
 //
@@ -85,10 +104,35 @@ namespace edm {
     }
     WrapperBase const* product = productGetter()->getIt(id());
 
-    if(product == nullptr) {
-      throw Exception(errors::InvalidReference) << "Asked for data from a PtrVector which refers to a non-existent product which id " << id() << "\n";
+    if(product != nullptr) {
+      product->fillPtrVector(typeInfo(), indicies_, cachedItems_);
+      return;
     }
-    product->fillPtrVector(typeInfo(), indicies_, cachedItems_);
+
+    cachedItems_.resize(indicies_.size(), nullptr);
+
+    std::vector<unsigned int> thinnedKeys;
+    thinnedKeys.assign(indicies_.begin(), indicies_.end());
+    std::vector<WrapperBase const*> wrappers(indicies_.size(), nullptr);
+    productGetter()->getThinnedProducts(id(), wrappers, thinnedKeys);
+    unsigned int nWrappers = wrappers.size();
+    assert(wrappers.size() == indicies_.size());
+    assert(wrappers.size() == cachedItems_.size());
+    for(unsigned k = 0; k < nWrappers; ++k) {
+      if (wrappers[k] != nullptr) {
+        wrappers[k]->setPtr(typeInfo(), thinnedKeys[k], cachedItems_[k]);
+      }
+    }
+  }
+
+  void
+  PtrVectorBase::checkCachedItems() const {
+    for(auto item : cachedItems_) {
+      if(item == nullptr) {
+        throw Exception(errors::InvalidReference) << "Asked for data from a PtrVector which refers to a non-existent product with ProductID "
+                                                  << id() << "\n";
+      }
+    }
   }
 
   bool
@@ -102,7 +146,6 @@ namespace edm {
     return std::equal(indicies_.begin(),
                       indicies_.end(),
                       iRHS.indicies_.begin());
-    return true;
   }
 
 //

--- a/DataFormats/Common/src/ThinnedAssociation.cc
+++ b/DataFormats/Common/src/ThinnedAssociation.cc
@@ -1,0 +1,20 @@
+#include "DataFormats/Common/interface/ThinnedAssociation.h"
+
+#include <algorithm>
+
+namespace edm {
+
+  ThinnedAssociation::ThinnedAssociation() {
+  }
+
+  bool
+  ThinnedAssociation::hasParentIndex(unsigned int parentIndex,
+                                     unsigned int& thinnedIndex) const {
+    auto iter = std::lower_bound(indexesIntoParent_.begin(), indexesIntoParent_.end(), parentIndex);
+    if(iter != indexesIntoParent_.end() && *iter == parentIndex) {
+      thinnedIndex = iter - indexesIntoParent_.begin();
+      return true;
+    }
+    return false;
+  }
+}

--- a/DataFormats/Common/src/classes.h
+++ b/DataFormats/Common/src/classes.h
@@ -24,6 +24,7 @@
 #include "DataFormats/Common/interface/RefCore.h"
 #include "DataFormats/Common/interface/RefCoreWithIndex.h"
 #include "DataFormats/Common/interface/IntValues.h"
+#include "DataFormats/Common/interface/ThinnedAssociation.h"
 #include "DataFormats/Provenance/interface/EventAuxiliary.h"
 #include "FWCore/MessageLogger/interface/ErrorSummaryEntry.h"
 
@@ -31,6 +32,7 @@
 
 namespace DataFormats_Common {
   struct dictionary {
+    edm::Wrapper<edm::ThinnedAssociation> dummyThinnedAssociation;
     edm::Wrapper<edm::DataFrameContainer> dummywdfc;
     edm::Wrapper<edm::HLTPathStatus> dummyx16;
     edm::Wrapper<std::vector<edm::HLTPathStatus> > dummyx17;

--- a/DataFormats/Common/src/classes_def.xml
+++ b/DataFormats/Common/src/classes_def.xml
@@ -24,6 +24,10 @@
       edm::EDProductGetter::assignEDProductGetter(reinterpret_cast<edm::EDProductGetter const*&>(cachePtr_));
     ]]>
   </ioread>
+ <class name="edm::ThinnedAssociation" ClassVersion="10">
+  <version ClassVersion="10" checksum="1914950449"/>
+ </class>
+ <class name="edm::Wrapper<edm::ThinnedAssociation>" splitLevel="0"/>
  <class name="edm::ConstPtrCache" ClassVersion="10">
   <version ClassVersion="10" checksum="2166959629"/>
    <field name="ptr_" transient="true"/>

--- a/DataFormats/Common/test/DetSetVector_t.cpp
+++ b/DataFormats/Common/test/DetSetVector_t.cpp
@@ -165,9 +165,19 @@ void detsetTest() {
 namespace {
   template<typename T>
   struct DSVGetter : edm::EDProductGetter {
+
     DSVGetter() : edm::EDProductGetter(), prod_(nullptr) {}
     virtual WrapperBase const*
     getIt(ProductID const&) const override {return prod_;}
+
+    virtual WrapperBase const*
+    getThinnedProduct(ProductID const&, unsigned int&) const override {return nullptr;}
+
+    virtual void
+    getThinnedProducts(ProductID const& pid,
+                       std::vector<WrapperBase const*>& wrappers,
+                       std::vector<unsigned int>& keys) const { }
+
     virtual unsigned int
     transitionIndex_() const override {return 0U;}
 

--- a/DataFormats/Common/test/SimpleEDProductGetter.h
+++ b/DataFormats/Common/test/SimpleEDProductGetter.h
@@ -36,6 +36,15 @@ public:
     return i->second.get();
   }
 
+  virtual edm::WrapperBase const*
+  getThinnedProduct(edm::ProductID const&, unsigned int&) const override {return nullptr;}
+
+  virtual void
+  getThinnedProducts(edm::ProductID const& pid,
+                     std::vector<edm::WrapperBase const*>& wrappers,
+                     std::vector<unsigned int>& keys) const { }
+
+
 private:
   virtual unsigned int transitionIndex_() const override {
     return 0U;

--- a/DataFormats/Common/test/ptr_t.cppunit.cc
+++ b/DataFormats/Common/test/ptr_t.cppunit.cc
@@ -291,6 +291,14 @@ namespace {
       virtual WrapperBase const* getIt(ProductID const&) const override {
          return hold_;
       }
+      virtual WrapperBase const*
+      getThinnedProduct(ProductID const&, unsigned int&) const override {return nullptr;}
+
+      virtual void
+      getThinnedProducts(ProductID const& pid,
+                         std::vector<WrapperBase const*>& wrappers,
+                         std::vector<unsigned int>& keys) const { }
+
       virtual unsigned int transitionIndex_() const override {
         return 0U;
       }

--- a/DataFormats/Common/test/ptrvector_t.cppunit.cc
+++ b/DataFormats/Common/test/ptrvector_t.cppunit.cc
@@ -43,6 +43,15 @@ namespace testPtr {
     virtual edm::WrapperBase const* getIt(edm::ProductID const&) const override {
       return hold_;
     }
+    virtual edm::WrapperBase const*
+    getThinnedProduct(edm::ProductID const&, unsigned int&) const override {return nullptr;}
+
+    virtual void
+    getThinnedProducts(edm::ProductID const& pid,
+                       std::vector<edm::WrapperBase const*>& wrappers,
+                       std::vector<unsigned int>& keys) const { }
+
+
     virtual unsigned int transitionIndex_() const override {
     return 0U;
     }

--- a/DataFormats/Common/test/ref_t.cppunit.cc
+++ b/DataFormats/Common/test/ref_t.cppunit.cc
@@ -162,6 +162,15 @@ namespace {
       virtual WrapperBase const* getIt(ProductID const&) const override {
          return hold_;
       }
+
+      virtual WrapperBase const*
+      getThinnedProduct(ProductID const&, unsigned int&) const override {return nullptr;}
+
+      virtual void
+      getThinnedProducts(ProductID const& pid,
+                         std::vector<WrapperBase const*>& wrappers,
+                         std::vector<unsigned int>& keys) const { }
+
       virtual unsigned int transitionIndex_() const override {
         return 0U;
       }

--- a/DataFormats/Common/test/reftobaseprod_t.cppunit.cc
+++ b/DataFormats/Common/test/reftobaseprod_t.cppunit.cc
@@ -178,6 +178,14 @@ namespace {
       virtual WrapperBase const* getIt(ProductID const&) const override {
          return hold_;
       }
+      virtual edm::WrapperBase const*
+      getThinnedProduct(ProductID const&, unsigned int&) const override {return nullptr;}
+
+      virtual void
+      getThinnedProducts(ProductID const& pid,
+                         std::vector<WrapperBase const*>& wrappers,
+                         std::vector<unsigned int>& keys) const { }
+
       virtual unsigned int transitionIndex_() const override {
          return 0U;
       }

--- a/DataFormats/FWLite/interface/ChainEvent.h
+++ b/DataFormats/FWLite/interface/ChainEvent.h
@@ -116,6 +116,12 @@ namespace fwlite {
       // ---------- member functions ---------------------------
 
       edm::WrapperBase const* getByProductID(edm::ProductID const&) const;
+      edm::WrapperBase const* getThinnedProduct(edm::ProductID const& pid, unsigned int& key) const;
+
+      void getThinnedProducts(edm::ProductID const& pid,
+                              std::vector<edm::WrapperBase const*>& foundContainers,
+                              std::vector<unsigned int>& keys) const;
+
       fwlite::LuminosityBlock const& getLuminosityBlock();
       fwlite::Run             const& getRun();
 

--- a/DataFormats/FWLite/interface/Event.h
+++ b/DataFormats/FWLite/interface/Event.h
@@ -145,6 +145,10 @@ namespace fwlite {
          }
 
          edm::WrapperBase const* getByProductID(edm::ProductID const&) const;
+         edm::WrapperBase const* getThinnedProduct(edm::ProductID const& pid, unsigned int& key) const;
+         void getThinnedProducts(edm::ProductID const& pid,
+                                 std::vector<edm::WrapperBase const*>& foundContainers,
+                                 std::vector<unsigned int>& keys) const;
 
          virtual edm::TriggerNames const& triggerNames(edm::TriggerResults const& triggerResults) const;
 

--- a/DataFormats/FWLite/interface/InternalDataKey.h
+++ b/DataFormats/FWLite/interface/InternalDataKey.h
@@ -82,8 +82,8 @@ namespace fwlite {
             TBranch* branch_;
             Long64_t lastProduct_;
             edm::ObjectWithDict obj_; // For wrapped object
-            void* pObj_; // pointer to pProd_.  ROOT requires the address of the pointer be stable
-            edm::WrapperBase* pProd_; // pointer to product wrapper
+            void* pObj_; // ROOT requires the address of the pointer be stable
+            edm::WrapperBase const* pProd_; // WrapperBase of the wrapped object
 
             ~Data() {
                obj_.typeOf().destruct(obj_.address(), true);

--- a/DataFormats/FWLite/interface/MultiChainEvent.h
+++ b/DataFormats/FWLite/interface/MultiChainEvent.h
@@ -135,6 +135,11 @@ class MultiChainEvent: public EventBase
 
       edm::WrapperBase const* getByProductID(edm::ProductID const&) const;
 
+      edm::WrapperBase const* getThinnedProduct(edm::ProductID const& pid, unsigned int& key) const;
+
+      void getThinnedProducts(edm::ProductID const& pid,
+                              std::vector<edm::WrapperBase const*>& foundContainers,
+                              std::vector<unsigned int>& keys) const;
 
    private:
 

--- a/DataFormats/FWLite/src/ChainEvent.cc
+++ b/DataFormats/FWLite/src/ChainEvent.cc
@@ -278,6 +278,16 @@ edm::WrapperBase const* ChainEvent::getByProductID(edm::ProductID const& iID) co
   return event_->getByProductID(iID);
 }
 
+edm::WrapperBase const* ChainEvent::getThinnedProduct(edm::ProductID const& pid, unsigned int& key) const {
+  return event_->getThinnedProduct(pid, key);
+}
+
+void ChainEvent::getThinnedProducts(edm::ProductID const& pid,
+                                    std::vector<edm::WrapperBase const*>& foundContainers,
+                                    std::vector<unsigned int>& keys) const {
+  event_->getThinnedProducts(pid, foundContainers, keys);
+}
+
 bool
 ChainEvent::isValid() const
 {

--- a/DataFormats/FWLite/src/DataGetterHelper.cc
+++ b/DataFormats/FWLite/src/DataGetterHelper.cc
@@ -19,7 +19,11 @@
 #include "TFile.h"
 #include "TTree.h"
 #include "TTreeCache.h"
+
+#include "DataFormats/Common/interface/ThinnedAssociation.h"
+#include "DataFormats/Common/interface/Wrapper.h"
 #include "DataFormats/Common/interface/WrapperBase.h"
+#include "DataFormats/Provenance/interface/ThinnedAssociationsHelper.h"
 
 #include "FWCore/FWLite/interface/setRefStreamer.h"
 
@@ -37,7 +41,6 @@ namespace fwlite {
     //
     // static data member definitions
     //
-    typedef std::map<internal::DataKey, std::shared_ptr<internal::Data> > DataMap;
     // empty object used to signal that the branch requested was not found
     static internal::Data branchNotFound;
 
@@ -108,12 +111,15 @@ namespace fwlite {
 
     void
     DataGetterHelper::getBranchData(edm::EDProductGetter* iGetter,
-                    Long64_t index,
+                    Long64_t eventEntry,
                     internal::Data& iData) const
     {
         GetterOperate op(iGetter);
 
 #if 0
+        // I'm not sure why this is still here. It would fail to
+        // compile for 3 reasons if switched on ...
+
         //WORK AROUND FOR ROOT!!
         //Create a new instance so that we can clear any cache the object uses
         //this slows the code down
@@ -132,17 +138,17 @@ namespace fwlite {
         TTreeCache* tcache = dynamic_cast<TTreeCache*> (branchMap_->getFile()->GetCacheRead());
 
         if (0 == tcache) {
-            iData.branch_->GetEntry(index);
+            iData.branch_->GetEntry(eventEntry);
         } else {
             if (!tcTrained_) {
                 tcache->SetLearnEntries(100);
                 tcache->SetEntryRange(0, tree_->GetEntries());
                 tcTrained_ = true;
             }
-            tree_->LoadTree(index);
-            iData.branch_->GetEntry(index);
+            tree_->LoadTree(eventEntry);
+            iData.branch_->GetEntry(eventEntry);
        }
-       iData.lastProduct_=index;
+       iData.lastProduct_=eventEntry;
     }
 
     internal::Data&
@@ -154,8 +160,7 @@ namespace fwlite {
         edm::TypeID type(iInfo);
         internal::DataKey key(type, iModuleLabel, iProductInstanceLabel, iProcessLabel);
 
-        std::shared_ptr<internal::Data> theData;
-        DataMap::iterator itFind = data_.find(key);
+        KeyToDataMap::iterator itFind = data_.find(key);
         if(itFind == data_.end()) {
             //see if such a branch actually exists
             std::string const sep("_");
@@ -167,6 +172,7 @@ namespace fwlite {
             //if we have to lookup the process label, remember it and register the product again
             std::string foundProcessLabel;
             TBranch* branch = 0;
+            std::shared_ptr<internal::Data> theData;
 
             if (0==iProcessLabel || iProcessLabel==key.kEmpty() ||
                 strlen(iProcessLabel)==0) {
@@ -242,7 +248,7 @@ namespace fwlite {
                 if(obj.address() == nullptr) {
                     throw cms::Exception("ConstructionFailed") << "failed to construct an instance of " << type.name();
                 }
-                std::shared_ptr<internal::Data> newData(new internal::Data());
+                auto newData = std::make_shared<internal::Data>();
                 newData->branch_ = branch;
                 newData->obj_ = obj;
                 newData->lastProduct_ = -1;
@@ -286,7 +292,7 @@ namespace fwlite {
                     char const* iModuleLabel,
                     char const* iProductInstanceLabel,
                     char const* iProcessLabel,
-                    void* oData, Long_t index) const
+                    void* oData, Long_t eventEntry) const
     {
         // Maintain atEnd() check in parent classes
         void** pOData = reinterpret_cast<void**>(oData);
@@ -296,9 +302,9 @@ namespace fwlite {
             DataGetterHelper::getBranchDataFor(iInfo, iModuleLabel, iProductInstanceLabel, iProcessLabel);
 
         if (0 != theData.branch_) {
-            if(index != theData.lastProduct_) {
+            if(eventEntry != theData.lastProduct_) {
                 //haven't gotten the data for this event
-                getBranchData(getter_.get(), index, theData);
+                getBranchData(getter_.get(), eventEntry, theData);
             }
             *pOData = theData.obj_.address();
         }
@@ -307,8 +313,51 @@ namespace fwlite {
         else return true;
     }
 
+    bool
+    DataGetterHelper::getByBranchDescription(edm::BranchDescription const& bDesc,
+                                             Long_t eventEntry,
+                                             KeyToDataMap::iterator& itData) const {
+      if (!bDesc.branchID().isValid()) {
+        return false;
+      }
+
+      //Calculate the key from the branch description
+      edm::TypeWithDict typeWD(edm::TypeWithDict::byName(edm::wrappedClassName(bDesc.fullClassName())));
+      edm::TypeID type(typeWD.typeInfo());
+      assert(bool(type));
+
+      //Only the product instance label may be empty
+      char const* pIL = bDesc.productInstanceName().c_str();
+      if(pIL[0] == 0) {
+        pIL = 0;
+      }
+      internal::DataKey k(type,
+                          bDesc.moduleLabel().c_str(),
+                          pIL,
+                          bDesc.processName().c_str());
+
+      //has this already been gotten?
+      itData = data_.find(k);
+      if(data_.end() == itData) {
+        //ask for the data
+        edm::WrapperBase const* dummy = nullptr;
+        getByLabel(type.typeInfo(),
+                   k.module(),
+                   k.product(),
+                   k.process(),
+                   &dummy, eventEntry);
+        if(nullptr == dummy) {
+          return false;
+        }
+        itData = data_.find(k);
+        assert(itData != data_.end());
+        assert(dummy == itData->second->obj_.address());
+      }
+      return true;
+    }
+
     edm::WrapperBase const*
-    DataGetterHelper::getByProductID(edm::ProductID const& iID, Long_t index) const
+    DataGetterHelper::getByProductID(edm::ProductID const& iID, Long_t eventEntry) const
     {
         typedef std::pair<edm::ProductID,edm::BranchListIndex> IDPair;
         IDPair theID = std::make_pair(iID, branchMap_->branchListIndexes()[iID.processIndex()-1]);
@@ -316,57 +365,190 @@ namespace fwlite {
 
         if(itFound == idToData_.end()) {
             edm::BranchDescription const& bDesc = branchMap_->productToBranch(iID);
+            KeyToDataMap::iterator itData;
 
-            if (!bDesc.branchID().isValid()) {
-                return nullptr;
-            }
-
-            //Calculate the key from the branch description
-            edm::TypeWithDict typeWD(edm::TypeWithDict::byName(edm::wrappedClassName(bDesc.fullClassName())));
-            edm::TypeID type(typeWD.typeInfo());
-            assert(bool(type));
-
-            //Only the product instance label may be empty
-            char const* pIL = bDesc.productInstanceName().c_str();
-            if(pIL[0] == 0) {
-                pIL = 0;
-            }
-            internal::DataKey k(type,
-                                bDesc.moduleLabel().c_str(),
-                                pIL,
-                                bDesc.processName().c_str());
-
-            //has this already been gotten?
-            KeyToDataMap::iterator itData = data_.find(k);
-            if(data_.end() == itData) {
-                //ask for the data
-                edm::WrapperBase const* dummy = nullptr;
-                getByLabel(type.typeInfo(),
-                            k.module(),
-                            k.product(),
-                            k.process(),
-                            &dummy, index);
-                if(nullptr == dummy) {
-                    return nullptr;
-                }
-                itData = data_.find(k);
-                assert(itData != data_.end());
-                assert(dummy == itData->second->obj_.address());
+            if(!getByBranchDescription(bDesc, eventEntry, itData)) {
+              return nullptr;
             }
             itFound = idToData_.insert(std::make_pair(theID,itData->second)).first;
         }
-        if(index != itFound->second->lastProduct_) {
+        if(eventEntry != itFound->second->lastProduct_) {
             //haven't gotten the data for this event
-            getBranchData(getter_.get(), index, *(itFound->second));
+            getBranchData(getter_.get(), eventEntry, *(itFound->second));
         }
         if(nullptr == itFound->second->pProd_) {
-            itFound->second->pProd_ = static_cast<edm::WrapperBase*>(itFound->second->obj_.address());
-
+            itFound->second->pProd_ = wrapperBasePtr(itFound->second->obj_);
             if(nullptr == itFound->second->pProd_) {
+                return nullptr;
+            }
+         }
+         return itFound->second->pProd_;
+    }
+
+    edm::WrapperBase const*
+    DataGetterHelper::getByBranchID(edm::BranchID const& bid, Long_t eventEntry) const
+    {
+        auto itFound = bidToData_.find(bid);
+
+        if(itFound == bidToData_.end()) {
+            edm::BranchDescription const& bDesc = branchMap_->branchIDToBranch(bid);
+            KeyToDataMap::iterator itData;
+
+            if(!getByBranchDescription(bDesc, eventEntry, itData)) {
               return nullptr;
+            }
+            itFound = bidToData_.insert(std::make_pair(bid,itData->second)).first;
+        }
+        if(eventEntry != itFound->second->lastProduct_) {
+            //haven't gotten the data for this event
+            getBranchData(getter_.get(), eventEntry, *(itFound->second));
+        }
+        if(nullptr == itFound->second->pProd_) {
+            itFound->second->pProd_ = wrapperBasePtr(itFound->second->obj_);
+            if(nullptr == itFound->second->pProd_) {
+                return nullptr;
             }
         }
         return itFound->second->pProd_;
+    }
+
+    edm::WrapperBase const*
+    DataGetterHelper::wrapperBasePtr(edm::ObjectWithDict const& objectWithDict) const {
+        // This converts a void* that points at a Wrapper<T>* into a WrapperBase*
+        edm::TypeWithDict wrapperBaseTypeWithDict(typeid(edm::WrapperBase));
+        return static_cast<edm::WrapperBase const*>(wrapperBaseTypeWithDict.pointerToBaseType(objectWithDict.address(),
+                                                                                              objectWithDict.typeOf()));
+    }
+
+    edm::WrapperBase const*
+    DataGetterHelper::getThinnedProduct(edm::ProductID const& pid, unsigned int& key, Long_t eventEntry) const {
+
+        edm::BranchID parent = branchMap_->productToBranchID(pid);
+        if(!parent.isValid()) return nullptr;
+        edm::ThinnedAssociationsHelper const& thinnedAssociationsHelper = branchMap_->thinnedAssociationsHelper();
+
+        // Loop over thinned containers which were made by selecting elements from the parent container
+        for(auto associatedBranches = thinnedAssociationsHelper.parentBegin(parent),
+                               iEnd = thinnedAssociationsHelper.parentEnd(parent);
+            associatedBranches != iEnd; ++associatedBranches) {
+
+            edm::ThinnedAssociation const* thinnedAssociation =
+                getThinnedAssociation(associatedBranches->association(), eventEntry);
+            if(thinnedAssociation == nullptr) continue;
+
+            if(associatedBranches->parent() != branchMap_->productToBranchID(thinnedAssociation->parentCollectionID())) {
+              continue;
+            }
+
+            unsigned int thinnedIndex = 0;
+            // Does this thinned container have the element referenced by key?
+            // If yes, thinnedIndex is set to point to it in the thinned container
+            if(!thinnedAssociation->hasParentIndex(key, thinnedIndex)) {
+                continue;
+            }
+            // Get the thinned container and return a pointer if we can find it
+            edm::ProductID const& thinnedCollectionPID = thinnedAssociation->thinnedCollectionID();
+            edm::WrapperBase const* thinnedCollection = getByProductID(thinnedCollectionPID, eventEntry);
+
+            if(thinnedCollection == nullptr) {
+                // Thinned container is not found, try looking recursively in thinned containers
+                // which were made by selecting elements from this thinned container.
+                edm::WrapperBase const* thinnedFromRecursiveCall = getThinnedProduct(thinnedCollectionPID, thinnedIndex, eventEntry);
+                if(thinnedFromRecursiveCall != nullptr) {
+                    key = thinnedIndex;
+                    return thinnedFromRecursiveCall;
+                } else {
+                    continue;
+                }
+            }
+            key = thinnedIndex;
+            return thinnedCollection;
+        }
+        return nullptr;
+    }
+
+    void DataGetterHelper::getThinnedProducts(edm::ProductID const& pid,
+                                              std::vector<edm::WrapperBase const*>& foundContainers,
+                                              std::vector<unsigned int>& keys,
+                                              Long_t eventEntry) const {
+
+        edm::BranchID parent = branchMap_->productToBranchID(pid);
+        if(!parent.isValid()) return;
+        edm::ThinnedAssociationsHelper const& thinnedAssociationsHelper = branchMap_->thinnedAssociationsHelper();
+
+        // Loop over thinned containers which were made by selecting elements from the parent container
+        for(auto associatedBranches = thinnedAssociationsHelper.parentBegin(parent),
+                               iEnd = thinnedAssociationsHelper.parentEnd(parent);
+            associatedBranches != iEnd; ++associatedBranches) {
+
+            edm::ThinnedAssociation const* thinnedAssociation =
+                getThinnedAssociation(associatedBranches->association(), eventEntry);
+            if(thinnedAssociation == nullptr) continue;
+
+            if(associatedBranches->parent() != branchMap_->productToBranchID(thinnedAssociation->parentCollectionID())) {
+              continue;
+            }
+
+            unsigned int nKeys = keys.size();
+            unsigned int doNotLookForThisIndex = std::numeric_limits<unsigned int>::max();
+            std::vector<unsigned int> thinnedIndexes(nKeys, doNotLookForThisIndex);
+            bool hasAny = false;
+            for(unsigned k = 0; k < nKeys; ++k) {
+                // Already found this one
+                if(foundContainers[k] != nullptr) continue;
+                // Already know this one is not in this thinned container
+                if(keys[k] == doNotLookForThisIndex ) continue;
+                // Does the thinned container hold the entry of interest?
+                // Modifies thinnedIndexes[k] only if it returns true and
+                // sets it to the index in the thinned collection.
+                if(thinnedAssociation->hasParentIndex(keys[k], thinnedIndexes[k])) {
+                    hasAny = true;
+                }
+            }
+            if(!hasAny) {
+                continue;
+            }
+            // Get the thinned container and set the pointers and indexes into
+            // it (if we can find it)
+            edm::ProductID thinnedCollectionPID = thinnedAssociation->thinnedCollectionID();
+            edm::WrapperBase const* thinnedCollection = getByProductID(thinnedCollectionPID, eventEntry);
+
+            if(thinnedCollection == nullptr) {
+                // Thinned container is not found, try looking recursively in thinned containers
+                // which were made by selecting elements from this thinned container.
+                getThinnedProducts(thinnedCollectionPID, foundContainers, thinnedIndexes, eventEntry);
+                for(unsigned k = 0; k < nKeys; ++k) {
+                    if(foundContainers[k] == nullptr) continue;
+                    if(thinnedIndexes[k] == doNotLookForThisIndex) continue;
+                    keys[k] = thinnedIndexes[k];
+                }
+            } else {
+                for(unsigned k = 0; k < nKeys; ++k) {
+                    if(thinnedIndexes[k] == doNotLookForThisIndex) continue;
+                    keys[k] = thinnedIndexes[k];
+                    foundContainers[k] = thinnedCollection;
+                }
+            }
+        }
+    }
+
+    edm::ThinnedAssociation const*
+    DataGetterHelper::getThinnedAssociation(edm::BranchID const& branchID, Long_t eventEntry) const {
+
+        edm::WrapperBase const* wrapperBase = getByBranchID(branchID, eventEntry);
+        if(wrapperBase == nullptr) {
+            throw edm::Exception(edm::errors::LogicError)
+              << "DataGetterHelper::getThinnedAssociation, product ThinnedAssociation not found.\n";
+        }
+        if(!(typeid(edm::ThinnedAssociation) == wrapperBase->dynamicTypeInfo())) {
+            throw edm::Exception(edm::errors::LogicError)
+              << "DataGetterHelper::getThinnedAssociation, product has wrong type, not a ThinnedAssociation.\n";
+        }
+        edm::Wrapper<edm::ThinnedAssociation> const* wrapper =
+            static_cast<edm::Wrapper<edm::ThinnedAssociation> const*>(wrapperBase);
+
+        edm::ThinnedAssociation const* thinnedAssociation = wrapper->product();
+        return thinnedAssociation;
     }
 
     const edm::ProcessHistory& DataGetterHelper::history() const {
@@ -377,13 +559,4 @@ namespace fwlite {
     //
     // static member functions
     //
-    void
-    DataGetterHelper::throwProductNotFoundException(std::type_info const& iType, char const* iModule, char const* iProduct, char const* iProcess)
-    {
-        edm::TypeID type(iType);
-        throw edm::Exception(edm::errors::ProductNotFound)<<"A branch was found for \n  type ='"<<type.className()<<"'\n  module='"<<iModule
-            <<"'\n  productInstance='"<<((0!=iProduct)?iProduct:"")<<"'\n  process='"<<((0!=iProcess)?iProcess:"")<<"'\n"
-            "but no data is available for this Lumi";
-    }
-
 }

--- a/DataFormats/FWLite/src/Event.cc
+++ b/DataFormats/FWLite/src/Event.cc
@@ -65,6 +65,36 @@ namespace fwlite {
                     return event_->getByProductID(iID);
                 }
 
+                // getThinnedProduct assumes getIt was already called and failed to find
+                // the product. The input key is the index of the desired element in the
+                // container identified by ProductID (which cannot be found).
+                // If the return value is not null, then the desired element was found
+                // in a thinned container and key is modified to be the index into
+                // that thinned container. If the desired element is not found, then
+                // nullptr is returned.
+                virtual edm::WrapperBase const* getThinnedProduct(edm::ProductID const& pid,
+                                                                  unsigned int& key) const override {
+                  return event_->getThinnedProduct(pid, key);
+                }
+
+
+                // getThinnedProducts assumes getIt was already called and failed to find
+                // the product. The input keys are the indexes into the container identified
+                // by ProductID (which cannot be found). On input the WrapperBase pointers
+                // must all be set to nullptr (except when the function calls itself
+                // recursively where non-null pointers mark already found elements).
+                // Thinned containers derived from the product are searched to see
+                // if they contain the desired elements. For each that is
+                // found, the corresponding WrapperBase pointer is set and the key
+                // is modified to be the key into the container where the element
+                // was found. The WrapperBase pointers might or might not all point
+                // to the same thinned container.
+                virtual void getThinnedProducts(edm::ProductID const& pid,
+                                                std::vector<edm::WrapperBase const*>& foundContainers,
+                                                std::vector<unsigned int>& keys) const override {
+                  event_->getThinnedProducts(pid, foundContainers, keys);
+                }
+
             private:
                 virtual
                 unsigned int
@@ -377,10 +407,23 @@ Event::history() const {
 
 edm::WrapperBase const*
 Event::getByProductID(edm::ProductID const& iID) const {
-  Long_t eventIndex = branchMap_.getEventEntry();
-  return dataHelper_.getByProductID(iID, eventIndex);
+  Long_t eventEntry = branchMap_.getEventEntry();
+  return dataHelper_.getByProductID(iID, eventEntry);
 }
 
+edm::WrapperBase const*
+Event::getThinnedProduct(edm::ProductID const& pid, unsigned int& key) const {
+  Long_t eventEntry = branchMap_.getEventEntry();
+  return dataHelper_.getThinnedProduct(pid, key, eventEntry);
+}
+
+void
+Event::getThinnedProducts(edm::ProductID const& pid,
+                          std::vector<edm::WrapperBase const*>& foundContainers,
+                          std::vector<unsigned int>& keys) const {
+  Long_t eventEntry = branchMap_.getEventEntry();
+  return dataHelper_.getThinnedProducts(pid, foundContainers, keys, eventEntry);
+}
 
 edm::TriggerNames const&
 Event::triggerNames(edm::TriggerResults const& triggerResults) const {

--- a/DataFormats/FWLite/src/MultiChainEvent.cc
+++ b/DataFormats/FWLite/src/MultiChainEvent.cc
@@ -21,6 +21,8 @@
 #include "DataFormats/Provenance/interface/ProcessHistory.h"
 #include "FWCore/Common/interface/TriggerResultsByName.h"
 
+#include <algorithm>
+
 namespace fwlite {
 
   namespace internal {
@@ -32,6 +34,17 @@ public:
       virtual edm::WrapperBase const*
       getIt(edm::ProductID const& iID) const override {
         return event_->getByProductID(iID);
+      }
+
+      virtual edm::WrapperBase const*
+      getThinnedProduct(edm::ProductID const& pid, unsigned int& key) const override {
+        return event_->getThinnedProduct(pid, key);
+      }
+
+      virtual void getThinnedProducts(edm::ProductID const& pid,
+                                      std::vector<edm::WrapperBase const*>& foundContainers,
+                                      std::vector<unsigned int>& keys) const {
+        event_->getThinnedProducts(pid, foundContainers, keys);
       }
 
 private:
@@ -367,13 +380,32 @@ edm::WrapperBase const* MultiChainEvent::getByProductID(edm::ProductID const&iID
   if (edp == nullptr) {
     (const_cast<MultiChainEvent*>(this))->toSec(event1_->id());
     edp = event2_->getByProductID(iID);
-    if (edp == nullptr) {
-      throw cms::Exception("ProductNotFound") << "Cannot find product " << iID;
-    }
   }
   return edp;
 }
 
+edm::WrapperBase const* MultiChainEvent::getThinnedProduct(edm::ProductID const& pid, unsigned int& key) const {
+  // First try the first file
+  edm::WrapperBase const* edp = event1_->getThinnedProduct(pid, key);
+  // Did not find the product, try secondary file
+  if (edp == nullptr) {
+    (const_cast<MultiChainEvent*>(this))->toSec(event1_->id());
+    edp = event2_->getThinnedProduct(pid, key);
+  }
+  return edp;
+}
+
+void MultiChainEvent::getThinnedProducts(edm::ProductID const& pid,
+                                         std::vector<edm::WrapperBase const*>& wrappers,
+                                         std::vector<unsigned int>& keys) const {
+  // First try the first file
+  event1_->getThinnedProducts(pid, wrappers, keys);
+  // Did not find all the products, try secondary file
+  if(std::find(wrappers.begin(), wrappers.end(), nullptr) != wrappers.end()) {
+    (const_cast<MultiChainEvent*>(this))->toSec(event1_->id());
+    event2_->getThinnedProducts(pid, wrappers, keys);
+  }
+}
 
 bool
 MultiChainEvent::isValid() const

--- a/DataFormats/FWLite/test/RefTest.sh
+++ b/DataFormats/FWLite/test/RefTest.sh
@@ -1,7 +1,13 @@
 #!/bin/sh
+
+
+function die { echo Failure $1: status $2 ; exit $2 ; }
+
 rm -f ${LOCAL_TEST_DIR}/good.root ${LOCAL_TEST_DIR}/good2.root ${LOCAL_TEST_DIR}/empty.root ${LOCAL_TEST_DIR}/other_only.root ${LOCAL_TEST_DIR}/good_delta5.root
 rm -f good.root good2.root empty.root other_only.root good_delta5.root
-cmsRun ${LOCAL_TEST_DIR}/RefTest_cfg.py
-cmsRun ${LOCAL_TEST_DIR}/RefTest2_cfg.py
-cmsRun ${LOCAL_TEST_DIR}/EmptyFile_cfg.py
-cmsRun ${LOCAL_TEST_DIR}/PartialEventTest_cfg.py
+
+cmsRun ${LOCAL_TEST_DIR}/RefTest_cfg.py || die "cmsRun RefTest_cfg.py" $?
+cmsRun ${LOCAL_TEST_DIR}/RefTest2_cfg.py || die "cmsRun RefTest2_cfg.py" $?
+cmsRun ${LOCAL_TEST_DIR}/EmptyFile_cfg.py || die "cmsRun EmptyFile_cfg.py" $?
+cmsRun ${LOCAL_TEST_DIR}/PartialEventTest_cfg.py || die "cmsRun PartialEventTest_cfg.py" $?
+cmsRun ${LOCAL_TEST_DIR}/RefTestCopyDrop_cfg.py || die "cmsRun RefTestCopyDrop_cfg.py" $?

--- a/DataFormats/FWLite/test/RefTestCopyDrop_cfg.py
+++ b/DataFormats/FWLite/test/RefTestCopyDrop_cfg.py
@@ -1,0 +1,20 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("COPYDROP")
+
+process.load("FWCore.Framework.test.cmsExceptionsFatal_cff")
+
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring('file:good.root')
+)
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('refTestCopyDrop.root'),
+    outputCommands = cms.untracked.vstring(
+        'keep *',
+        'drop *_thinningThingProducerE_*_*',
+        'drop *_thinningThingProducerF_*_*'
+    )
+)
+
+process.outp = cms.EndPath(process.out)

--- a/DataFormats/FWLite/test/RefTest_cfg.py
+++ b/DataFormats/FWLite/test/RefTest_cfg.py
@@ -12,14 +12,225 @@ process.maxEvents = cms.untracked.PSet(
 
 process.source = cms.Source("EmptySource")
 
+process.WhatsItESProducer = cms.ESProducer("WhatsItESProducer")
+
+process.DoodadESSource = cms.ESSource("DoodadESSource")
+
 process.Thing = cms.EDProducer("ThingProducer",
     offsetDelta = cms.int32(1)
 )
 
 process.OtherThing = cms.EDProducer("OtherThingProducer")
 
+process.thingProducer = cms.EDProducer("ThingProducer",
+                                       offsetDelta = cms.int32(100),
+                                       nThings = cms.int32(50)
+)
+
+process.trackOfThingsProducerA = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(0, 1, 2, 3, 4, 5, 6, 7, 8)
+)
+
+process.trackOfThingsProducerB = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(0, 1, 2, 3)
+)
+
+process.trackOfThingsProducerC = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(4, 5, 6, 7)
+)
+
+process.trackOfThingsProducerD = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(10, 11, 12, 13, 14, 15, 16, 17, 18)
+)
+
+process.trackOfThingsProducerDMinus = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(10, 11, 12, 13, 14, 15, 16, 17)
+)
+
+process.trackOfThingsProducerDPlus = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(10, 11, 12, 13, 14, 15, 16, 17, 18, 21)
+)
+
+process.trackOfThingsProducerE = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(10, 11, 12, 13, 14)
+)
+
+process.trackOfThingsProducerF = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(14, 15, 16, 17)
+)
+
+process.trackOfThingsProducerG = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(20, 21, 22, 23, 24, 25, 26, 27, 28)
+)
+
+process.trackOfThingsProducerH = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(20, 21, 22, 23)
+)
+
+process.trackOfThingsProducerI = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(24, 25, 26, 27)
+)
+
+process.trackOfThingsProducerJ = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(30, 31, 32, 33, 34, 35, 36, 37, 38)
+)
+
+process.trackOfThingsProducerK = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(30, 31, 32, 33)
+)
+
+process.trackOfThingsProducerL = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(34, 35, 36, 37)
+)
+
+process.trackOfThingsProducerM = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(40, 41, 42, 43, 44, 45, 46, 47, 48)
+)
+
+process.trackOfThingsProducerN = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(40, 41, 42, 43)
+)
+
+process.trackOfThingsProducerO = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(44, 45, 46, 47)
+)
+
+process.thinningThingProducerA = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    trackTag = cms.InputTag('trackOfThingsProducerA'),
+    offsetToThinnedKey = cms.uint32(0),
+    expectedCollectionSize = cms.uint32(50)
+)
+
+process.thinningThingProducerB = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thinningThingProducerA'),
+    trackTag = cms.InputTag('trackOfThingsProducerB'),
+    offsetToThinnedKey = cms.uint32(0),
+    expectedCollectionSize = cms.uint32(9)
+)
+
+process.thinningThingProducerC = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thinningThingProducerA'),
+    trackTag = cms.InputTag('trackOfThingsProducerC'),
+    offsetToThinnedKey = cms.uint32(0),
+    expectedCollectionSize = cms.uint32(9)
+)
+
+process.thinningThingProducerD = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    trackTag = cms.InputTag('trackOfThingsProducerD'),
+    offsetToThinnedKey = cms.uint32(0),
+    expectedCollectionSize = cms.uint32(50)
+)
+
+process.thinningThingProducerE = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thinningThingProducerD'),
+    trackTag = cms.InputTag('trackOfThingsProducerE'),
+    offsetToThinnedKey = cms.uint32(10),
+    expectedCollectionSize = cms.uint32(9)
+)
+
+process.thinningThingProducerF = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thinningThingProducerD'),
+    trackTag = cms.InputTag('trackOfThingsProducerF'),
+    offsetToThinnedKey = cms.uint32(10),
+    expectedCollectionSize = cms.uint32(9)
+)
+
+process.thinningThingProducerG = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    trackTag = cms.InputTag('trackOfThingsProducerG'),
+    offsetToThinnedKey = cms.uint32(0),
+    expectedCollectionSize = cms.uint32(50)
+)
+
+process.thinningThingProducerH = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thinningThingProducerG'),
+    trackTag = cms.InputTag('trackOfThingsProducerH'),
+    offsetToThinnedKey = cms.uint32(20),
+    expectedCollectionSize = cms.uint32(9)
+)
+
+process.thinningThingProducerI = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thinningThingProducerG'),
+    trackTag = cms.InputTag('trackOfThingsProducerI'),
+    offsetToThinnedKey = cms.uint32(20),
+    expectedCollectionSize = cms.uint32(9)
+)
+
+process.thinningThingProducerJ = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    trackTag = cms.InputTag('trackOfThingsProducerJ'),
+    offsetToThinnedKey = cms.uint32(0),
+    expectedCollectionSize = cms.uint32(50)
+)
+
+process.thinningThingProducerK = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thinningThingProducerJ'),
+    trackTag = cms.InputTag('trackOfThingsProducerK'),
+    offsetToThinnedKey = cms.uint32(30),
+    expectedCollectionSize = cms.uint32(9)
+)
+
+process.thinningThingProducerL = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thinningThingProducerJ'),
+    trackTag = cms.InputTag('trackOfThingsProducerL'),
+    offsetToThinnedKey = cms.uint32(30),
+    expectedCollectionSize = cms.uint32(9)
+)
+
+process.thinningThingProducerM = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    trackTag = cms.InputTag('trackOfThingsProducerM'),
+    offsetToThinnedKey = cms.uint32(0),
+    expectedCollectionSize = cms.uint32(50)
+)
+
+process.thinningThingProducerN = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thinningThingProducerM'),
+    trackTag = cms.InputTag('trackOfThingsProducerN'),
+    offsetToThinnedKey = cms.uint32(40),
+    expectedCollectionSize = cms.uint32(9)
+)
+
+process.thinningThingProducerO = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thinningThingProducerM'),
+    trackTag = cms.InputTag('trackOfThingsProducerO'),
+    offsetToThinnedKey = cms.uint32(40),
+    expectedCollectionSize = cms.uint32(9)
+)
+
 process.out = cms.OutputModule("PoolOutputModule",
-    fileName = cms.untracked.string('good.root')
+    fileName = cms.untracked.string('good.root'),
+    outputCommands = cms.untracked.vstring(
+        'keep *',
+        'drop *_thingProducer_*_*',
+        'drop *_thinningThingProducerD_*_*',
+        'drop *_thinningThingProducerH_*_*',
+        'drop *_thinningThingProducerI_*_*',
+        'drop *_thinningThingProducerJ_*_*',
+        'drop *_thinningThingProducerK_*_*',
+        'drop *_thinningThingProducerL_*_*',
+        'drop *_thinningThingProducerM_*_*',
+        'drop *_thinningThingProducerN_*_*',
+    )
 )
 
 process.out2 = cms.OutputModule("PoolOutputModule",
@@ -33,6 +244,40 @@ process.out_other = cms.OutputModule("PoolOutputModule",
     fileName = cms.untracked.string('other_only.root')
 )
 
+process.thinningTestPath = cms.Path(process.thingProducer
+                                    * process.trackOfThingsProducerA
+                                    * process.trackOfThingsProducerB
+                                    * process.trackOfThingsProducerC
+                                    * process.trackOfThingsProducerD
+                                    * process.trackOfThingsProducerDMinus
+                                    * process.trackOfThingsProducerDPlus
+                                    * process.trackOfThingsProducerE
+                                    * process.trackOfThingsProducerF
+                                    * process.trackOfThingsProducerG
+                                    * process.trackOfThingsProducerH
+                                    * process.trackOfThingsProducerI
+                                    * process.trackOfThingsProducerJ
+                                    * process.trackOfThingsProducerK
+                                    * process.trackOfThingsProducerL
+                                    * process.trackOfThingsProducerM
+                                    * process.trackOfThingsProducerN
+                                    * process.trackOfThingsProducerO
+                                    * process.thinningThingProducerA
+                                    * process.thinningThingProducerB
+                                    * process.thinningThingProducerC
+                                    * process.thinningThingProducerD
+                                    * process.thinningThingProducerE
+                                    * process.thinningThingProducerF
+                                    * process.thinningThingProducerG
+                                    * process.thinningThingProducerH
+                                    * process.thinningThingProducerI
+                                    * process.thinningThingProducerJ
+                                    * process.thinningThingProducerK
+                                    * process.thinningThingProducerL
+                                    * process.thinningThingProducerM
+                                    * process.thinningThingProducerN
+                                    * process.thinningThingProducerO
+)
 
 process.p = cms.Path(process.Thing*process.OtherThing)
 process.outp = cms.EndPath(process.out*process.out2*process.out_other)

--- a/DataFormats/FWLite/test/test.cppunit.cpp
+++ b/DataFormats/FWLite/test/test.cppunit.cpp
@@ -6,15 +6,18 @@ Test program for edm::Ref use in ROOT.
 
 #include <iostream>
 #include <string>
+#include <vector>
 #include <cppunit/extensions/HelperMacros.h>
 #include "FWCore/FWLite/interface/AutoLibraryLoader.h"
 #include "TFile.h"
 #include "TSystem.h"
 #include "DataFormats/TestObjects/interface/OtherThingCollection.h"
 #include "DataFormats/TestObjects/interface/ThingCollection.h"
+#include "DataFormats/TestObjects/interface/TrackOfThings.h"
 #include "FWCore/Utilities/interface/TestHelper.h"
 
-#include "DataFormats/FWLite/interface/Event.h"
+#include "DataFormats/FWLite/interface/ChainEvent.h"
+#include "DataFormats/FWLite/interface/MultiChainEvent.h"
 #include "DataFormats/FWLite/interface/Handle.h"
 #include "DataFormats/Common/interface/Handle.h"
 static char* gArgV = 0;
@@ -39,6 +42,7 @@ class testRefInROOT: public CppUnit::TestFixture
    CPPUNIT_TEST(testEventBase);
    CPPUNIT_TEST(testSometimesMissingData);
    CPPUNIT_TEST(testTo);
+   CPPUNIT_TEST(testThinning);
 
   // CPPUNIT_TEST_EXCEPTION(failChainWithMissingFile,std::exception);
   //failTwoDifferentFiles
@@ -81,6 +85,7 @@ public:
   void testTo();
   // void failChainWithMissingFile();
   //void failDidNotCallGetEntryForEvents();
+  void testThinning();
 
  private:
   static bool sWasRun_;
@@ -405,6 +410,207 @@ void testRefInROOT::failChainWithMissingFile()
   
 }
 */
+
+void testRefInROOT::testThinning() {
+
+  std::vector<std::string> files { "good.root", "good.root" };
+  fwlite::ChainEvent events(files);
+
+  for(events.toBegin(); not events.atEnd(); ++events) {
+
+    fwlite::Handle<std::vector<edmtest::TrackOfThings> > pTrackOfThingsDPlus;
+    pTrackOfThingsDPlus.getByLabel(events,"trackOfThingsProducerDPlus");
+
+    fwlite::Handle<std::vector<edmtest::TrackOfThings> > pTrackOfThingsG;
+    pTrackOfThingsG.getByLabel(events,"trackOfThingsProducerG");
+
+    fwlite::Handle<std::vector<edmtest::TrackOfThings> > pTrackOfThingsM;
+    pTrackOfThingsM.getByLabel(events,"trackOfThingsProducerM");
+
+    // The values in the tests below have no particular meaning.
+    // It is just checking that we read the values known to be
+    // be put in by the relevant producer.
+
+    int offset = 100 + 100 * events.eventAuxiliary().event();
+
+    // In the D branch this tests accessing a value in
+    // thinned collection made from a thinned collection
+    // made from a master collection.
+    edmtest::TrackOfThings const& trackD = pTrackOfThingsDPlus->at(0);
+    CPPUNIT_ASSERT(trackD.ref1.isAvailable());
+    CPPUNIT_ASSERT(trackD.ref1->a == 10 + offset);
+    CPPUNIT_ASSERT(trackD.ptr1.isAvailable());
+    CPPUNIT_ASSERT(trackD.ptr1->a == 12 + offset);
+    CPPUNIT_ASSERT(trackD.refToBase1.isAvailable());
+    CPPUNIT_ASSERT(trackD.refToBase1->a == 10 + offset);
+
+    CPPUNIT_ASSERT(trackD.refVector1[0]->a == 10 + offset);
+    CPPUNIT_ASSERT(trackD.refVector1[4]->a == 14 + offset);
+    CPPUNIT_ASSERT_THROW(trackD.refVector1[8]->a, cms::Exception);
+    CPPUNIT_ASSERT(!trackD.refVector1.isAvailable());
+    CPPUNIT_ASSERT(trackD.refVector1[0]->a == 10 + offset);
+    CPPUNIT_ASSERT(trackD.refVector1[4]->a == 14 + offset);
+    CPPUNIT_ASSERT_THROW(trackD.refVector1[8]->a, cms::Exception);
+
+    CPPUNIT_ASSERT(trackD.ptrVector1[0]->a == 10 + offset);
+    CPPUNIT_ASSERT(trackD.ptrVector1[4]->a == 14 + offset);
+    CPPUNIT_ASSERT_THROW(trackD.ptrVector1[8]->a, cms::Exception);
+    CPPUNIT_ASSERT(trackD.ptrVector1[9]->a == 21 + offset);
+    CPPUNIT_ASSERT(!trackD.ptrVector1.isAvailable());
+    CPPUNIT_ASSERT(trackD.ptrVector1[0]->a == 10 + offset);
+    CPPUNIT_ASSERT(trackD.ptrVector1[4]->a == 14 + offset);
+    CPPUNIT_ASSERT_THROW(trackD.ptrVector1[8]->a, cms::Exception);
+    CPPUNIT_ASSERT(trackD.ptrVector1[9]->a == 21 + offset);
+
+    CPPUNIT_ASSERT(trackD.refToBaseVector1[0]->a == 10 + offset);
+    CPPUNIT_ASSERT(trackD.refToBaseVector1[4]->a == 14 + offset);
+    CPPUNIT_ASSERT_THROW(trackD.refToBaseVector1[8]->a, cms::Exception);
+    CPPUNIT_ASSERT(!trackD.refToBaseVector1.isAvailable());
+    CPPUNIT_ASSERT(trackD.refToBaseVector1[0]->a == 10 + offset);
+    CPPUNIT_ASSERT(trackD.refToBaseVector1[4]->a == 14 + offset);
+    CPPUNIT_ASSERT_THROW(trackD.refToBaseVector1[8]->a, cms::Exception);
+
+    // In the G branch this tests accessing a value in
+    // thinned collection made from a master collection.
+    // Otherwise the tests are very similar the preceding
+    // tests.
+    edmtest::TrackOfThings const& trackG = pTrackOfThingsG->at(0);
+    CPPUNIT_ASSERT(trackG.ref1.isAvailable());
+    CPPUNIT_ASSERT(trackG.ref1->a == 20 + offset);
+    CPPUNIT_ASSERT(trackG.ptr1.isAvailable());
+    CPPUNIT_ASSERT(trackG.ptr1->a == 22 + offset);
+    CPPUNIT_ASSERT(trackG.refToBase1.isAvailable());
+    CPPUNIT_ASSERT(trackG.refToBase1->a == 20 + offset);
+
+    CPPUNIT_ASSERT(trackG.refVector1[0]->a == 20 + offset);
+    CPPUNIT_ASSERT(trackG.refVector1[4]->a == 24 + offset);
+    CPPUNIT_ASSERT(trackG.refVector1[8]->a == 28 + offset);
+    CPPUNIT_ASSERT(trackG.refVector1.isAvailable());
+    CPPUNIT_ASSERT(trackG.refVector1[0]->a == 20 + offset);
+    CPPUNIT_ASSERT(trackG.refVector1[4]->a == 24 + offset);
+    CPPUNIT_ASSERT(trackG.refVector1[8]->a == 28 + offset);
+
+    CPPUNIT_ASSERT(trackG.ptrVector1[0]->a == 20 + offset);
+    CPPUNIT_ASSERT(trackG.ptrVector1[4]->a == 24 + offset);
+    CPPUNIT_ASSERT(trackG.ptrVector1[8]->a == 28 + offset);
+    CPPUNIT_ASSERT(trackG.ptrVector1.isAvailable());
+    CPPUNIT_ASSERT(trackG.ptrVector1[0]->a == 20 + offset);
+    CPPUNIT_ASSERT(trackG.ptrVector1[4]->a == 24 + offset);
+    CPPUNIT_ASSERT(trackG.ptrVector1[8]->a == 28 + offset);
+
+    CPPUNIT_ASSERT(trackG.refToBaseVector1[0]->a == 20 + offset);
+    CPPUNIT_ASSERT(trackG.refToBaseVector1[4]->a == 24 + offset);
+    CPPUNIT_ASSERT(trackG.refToBaseVector1[8]->a == 28 + offset);
+    CPPUNIT_ASSERT(trackG.refToBaseVector1.isAvailable());
+    CPPUNIT_ASSERT(trackG.refToBaseVector1[0]->a == 20 + offset);
+    CPPUNIT_ASSERT(trackG.refToBaseVector1[4]->a == 24 + offset);
+    CPPUNIT_ASSERT(trackG.refToBaseVector1[8]->a == 28 + offset);
+
+    // The tests for the M branch are very similar to the preceding
+    // tests except some of the elements are through two levels
+    // of thinning or some just one level of thinning.
+    edmtest::TrackOfThings const& trackM0 = pTrackOfThingsM->at(0);
+    CPPUNIT_ASSERT(!trackM0.ref1.isAvailable());
+    CPPUNIT_ASSERT_THROW(trackM0.ref1->a, cms::Exception);
+    CPPUNIT_ASSERT(!trackM0.ptr1.isAvailable());
+    CPPUNIT_ASSERT_THROW(trackM0.ptr1->a, cms::Exception);
+    CPPUNIT_ASSERT(!trackM0.refToBase1.isAvailable());
+    CPPUNIT_ASSERT_THROW(trackM0.refToBase1->a, cms::Exception);
+
+    edmtest::TrackOfThings const& trackM1 = pTrackOfThingsM->at(1);
+    CPPUNIT_ASSERT(trackM1.ref1.isAvailable());
+    CPPUNIT_ASSERT(trackM1.ref1->a == 44 + offset);
+    CPPUNIT_ASSERT(trackM1.ptr1.isAvailable());
+    CPPUNIT_ASSERT(trackM1.ptr1->a == 46 + offset);
+    CPPUNIT_ASSERT(trackM1.refToBase1.isAvailable());
+    CPPUNIT_ASSERT(trackM1.refToBase1->a == 44 + offset);
+
+    edmtest::TrackOfThings const& trackM = pTrackOfThingsM->at(0);
+    CPPUNIT_ASSERT_THROW(trackM.refVector1[0]->a, cms::Exception);
+    CPPUNIT_ASSERT(trackM.refVector1[4]->a == 44 + offset);
+    CPPUNIT_ASSERT_THROW(trackM.refVector1[8]->a, cms::Exception);
+    CPPUNIT_ASSERT(!trackM.refVector1.isAvailable());
+    CPPUNIT_ASSERT_THROW(trackM.refVector1[0]->a, cms::Exception);
+    CPPUNIT_ASSERT(trackM.refVector1[4]->a == 44 + offset);
+    CPPUNIT_ASSERT_THROW(trackM.refVector1[8]->a, cms::Exception);
+
+    CPPUNIT_ASSERT_THROW(trackM.ptrVector1[0]->a, cms::Exception);
+    CPPUNIT_ASSERT(trackM.ptrVector1[4]->a == 44 + offset);
+    CPPUNIT_ASSERT_THROW(trackM.ptrVector1[8]->a, cms::Exception);
+    CPPUNIT_ASSERT(!trackM.ptrVector1.isAvailable());
+    CPPUNIT_ASSERT_THROW(trackM.ptrVector1[0]->a, cms::Exception);
+    CPPUNIT_ASSERT(trackM.ptrVector1[4]->a == 44 + offset);
+    CPPUNIT_ASSERT_THROW(trackM.ptrVector1[8]->a, cms::Exception);
+
+    CPPUNIT_ASSERT_THROW(trackM.refToBaseVector1[0]->a, cms::Exception);
+    CPPUNIT_ASSERT(trackM.refToBaseVector1[4]->a == 44 + offset);
+    CPPUNIT_ASSERT_THROW(trackM.refToBaseVector1[8]->a, cms::Exception);
+    CPPUNIT_ASSERT(!trackM.refToBaseVector1.isAvailable());
+    CPPUNIT_ASSERT_THROW(trackM.refToBaseVector1[0]->a, cms::Exception);
+    CPPUNIT_ASSERT(trackM.refToBaseVector1[4]->a == 44 + offset);
+    CPPUNIT_ASSERT_THROW(trackM.refToBaseVector1[8]->a, cms::Exception);
+  }
+
+  std::vector<std::string> files1 { "refTestCopyDrop.root" };
+  std::vector<std::string> files2 { "good.root" };
+
+  fwlite::MultiChainEvent multiChainEvents(files1, files2);
+  for (multiChainEvents.toBegin(); ! multiChainEvents.atEnd(); ++multiChainEvents) {
+
+    fwlite::Handle<std::vector<edmtest::TrackOfThings> > pTrackOfThingsDPlus;
+    pTrackOfThingsDPlus.getByLabel(multiChainEvents,"trackOfThingsProducerDPlus");
+
+    fwlite::Handle<std::vector<edmtest::TrackOfThings> > pTrackOfThingsG;
+    pTrackOfThingsG.getByLabel(multiChainEvents,"trackOfThingsProducerG");
+
+    // The values in the tests below have no particular meaning.
+    // It is just checking that we read the values known to be
+    // be put in by the relevant producer.
+
+    int offset = 100 + 100 * multiChainEvents.eventAuxiliary().event();
+
+    // In the D branch this tests accessing a value in
+    // thinned collection made from a thinned collection
+    // made from a master collection.
+    edmtest::TrackOfThings const& trackD = pTrackOfThingsDPlus->at(0);
+    CPPUNIT_ASSERT(trackD.ref1.isAvailable());
+    CPPUNIT_ASSERT(trackD.ref1->a == 10 + offset);
+    CPPUNIT_ASSERT(trackD.ptr1.isAvailable());
+    CPPUNIT_ASSERT(trackD.ptr1->a == 12 + offset);
+    CPPUNIT_ASSERT(trackD.refToBase1.isAvailable());
+    CPPUNIT_ASSERT(trackD.refToBase1->a == 10 + offset);
+
+    CPPUNIT_ASSERT(trackD.ptrVector1[0]->a == 10 + offset);
+    CPPUNIT_ASSERT(trackD.ptrVector1[4]->a == 14 + offset);
+    CPPUNIT_ASSERT_THROW(trackD.ptrVector1[8]->a, cms::Exception);
+    CPPUNIT_ASSERT(trackD.ptrVector1[9]->a == 21 + offset);
+    CPPUNIT_ASSERT(!trackD.ptrVector1.isAvailable());
+    CPPUNIT_ASSERT(trackD.ptrVector1[0]->a == 10 + offset);
+    CPPUNIT_ASSERT(trackD.ptrVector1[4]->a == 14 + offset);
+    CPPUNIT_ASSERT_THROW(trackD.ptrVector1[8]->a, cms::Exception);
+    CPPUNIT_ASSERT(trackD.ptrVector1[9]->a == 21 + offset);
+
+    // In the G branch this tests accessing a value in
+    // thinned collection made from a master collection.
+    // Otherwise the tests are very similar the preceding
+    // tests.
+    edmtest::TrackOfThings const& trackG = pTrackOfThingsG->at(0);
+    CPPUNIT_ASSERT(trackG.ref1.isAvailable());
+    CPPUNIT_ASSERT(trackG.ref1->a == 20 + offset);
+    CPPUNIT_ASSERT(trackG.ptr1.isAvailable());
+    CPPUNIT_ASSERT(trackG.ptr1->a == 22 + offset);
+    CPPUNIT_ASSERT(trackG.refToBase1.isAvailable());
+    CPPUNIT_ASSERT(trackG.refToBase1->a == 20 + offset);
+
+    CPPUNIT_ASSERT(trackG.ptrVector1[0]->a == 20 + offset);
+    CPPUNIT_ASSERT(trackG.ptrVector1[4]->a == 24 + offset);
+    CPPUNIT_ASSERT(trackG.ptrVector1[8]->a == 28 + offset);
+    CPPUNIT_ASSERT(trackG.ptrVector1.isAvailable());
+    CPPUNIT_ASSERT(trackG.ptrVector1[0]->a == 20 + offset);
+    CPPUNIT_ASSERT(trackG.ptrVector1[4]->a == 24 + offset);
+    CPPUNIT_ASSERT(trackG.ptrVector1[8]->a == 28 + offset);
+  }
+}
 
 //Stolen from Utilities/Testing/interface/CppUnit_testdriver.icpp
 // need to refactor

--- a/DataFormats/Provenance/interface/BranchType.h
+++ b/DataFormats/Provenance/interface/BranchType.h
@@ -69,6 +69,7 @@ namespace edm {
     std::string const& processHistoryBranchName();
     std::string const& processConfigurationBranchName();
     std::string const& branchIDListBranchName();
+    std::string const& thinnedAssociationsHelperBranchName();
     std::string const& fileFormatVersionBranchName();
     std::string const& fileIdentifierBranchName();
     std::string const& fileIndexBranchName(); // backward compatibility

--- a/DataFormats/Provenance/interface/FileFormatVersion.h
+++ b/DataFormats/Provenance/interface/FileFormatVersion.h
@@ -30,6 +30,7 @@ namespace edm
     bool noMetaDataTrees() const;
     bool storedProductProvenanceUsed() const;
     bool useReducedProcessHistoryID() const;
+    bool hasThinnedAssociations() const;
     int value() const {return value_;}
     
    private:

--- a/DataFormats/Provenance/interface/ThinnedAssociationsHelper.h
+++ b/DataFormats/Provenance/interface/ThinnedAssociationsHelper.h
@@ -1,0 +1,85 @@
+#ifndef DataFormats_Provenance_ThinnedAssociationsHelper_h
+#define DataFormats_Provenance_ThinnedAssociationsHelper_h
+
+/** \class edm::ThinnedAssociationsHelper
+\author W. David Dagenhart, created 11 June 2014
+*/
+
+#include "DataFormats/Provenance/interface/BranchID.h"
+
+#include <map>
+#include <set>
+#include <vector>
+
+namespace edm {
+
+  class BranchDescription;
+
+  class ThinnedAssociationBranches {
+  public:
+    ThinnedAssociationBranches();
+    ThinnedAssociationBranches(BranchID const&, BranchID const&, BranchID const&);
+
+    BranchID const& parent() const { return parent_; }
+    BranchID const& association() const { return association_; }
+    BranchID const& thinned() const { return thinned_; }
+
+    bool operator<(ThinnedAssociationBranches const& rhs) const { return parent_ < rhs.parent_; }
+
+  private:
+    BranchID parent_;
+    BranchID association_;
+    BranchID thinned_;
+  };
+
+  class ThinnedAssociationsHelper {
+  public:
+
+    ThinnedAssociationsHelper();
+
+    std::vector<ThinnedAssociationBranches>::const_iterator begin() const;
+    std::vector<ThinnedAssociationBranches>::const_iterator end() const;
+
+    std::vector<ThinnedAssociationBranches>::const_iterator parentBegin(BranchID const&) const;
+    std::vector<ThinnedAssociationBranches>::const_iterator parentEnd(BranchID const&) const;
+
+    void addAssociation(BranchID const&, BranchID const&, BranchID const&);
+    void addAssociation(ThinnedAssociationBranches const&);
+
+    std::vector<std::pair<BranchID, ThinnedAssociationBranches const*> > associationToBranches() const;
+
+    void sort();
+    void clear() { vThinnedAssociationBranches_.clear(); }
+
+    void selectAssociationProducts(std::vector<BranchDescription const*> const& associationDescriptions,
+                                   std::set<BranchID> const& keptProductsInEvent,
+                                   std::map<BranchID, bool>& keepAssociation) const;
+
+    std::vector<ThinnedAssociationBranches> const& data() const { return vThinnedAssociationBranches_; }
+
+    void requireMatch(ThinnedAssociationBranches const& input) const;
+
+    void updateFromInput(ThinnedAssociationsHelper const&,
+                         bool isSecondaryFile,
+                         std::vector<BranchID> const& associationsFromSecondary);
+
+    void updateFromParentProcess(ThinnedAssociationsHelper const& parentThinnedAssociationsHelper,
+                                 std::map<BranchID, bool> const& keepAssociation,
+                                 std::map<BranchID::value_type, BranchID::value_type> const& droppedBranchIDToKeptBranchID);
+
+    void initAssociationsFromSecondary(std::vector<BranchID> const&,
+                                       ThinnedAssociationsHelper const&);
+
+  private:
+
+    bool shouldKeepAssociation(BranchID const& association,
+                               std::vector<std::pair<BranchID, ThinnedAssociationBranches const*> > const& associationToBranches,
+                               std::set<BranchID>& branchesInRecursion,
+                               std::set<BranchID> const& keptProductsInEvent,
+                               std::map<BranchID, bool>& keepAssociation) const;
+
+
+    std::vector<ThinnedAssociationBranches> vThinnedAssociationBranches_;
+  };
+}
+#endif

--- a/DataFormats/Provenance/src/BranchType.cc
+++ b/DataFormats/Provenance/src/BranchType.cc
@@ -81,6 +81,7 @@ namespace edm {
     std::string const processHistory = "ProcessHistory";
     std::string const processConfiguration = "ProcessConfiguration";
     std::string const branchIDLists = "BranchIDLists";
+    std::string const thinnedAssociationsHelper = "ThinnedAssociationsHelper";
     std::string const fileFormatVersion = "FileFormatVersion";
     std::string const fileIdentifier = "FileIdentifier";
     std::string const fileIndex = "FileIndex";
@@ -206,6 +207,11 @@ namespace edm {
     // Branch on MetaData Tree
     std::string const& branchIDListBranchName() {
       return branchIDLists;
+    }
+
+    // Branch on MetaData Tree
+    std::string const& thinnedAssociationsHelperBranchName() {
+      return thinnedAssociationsHelper;
     }
 
     // Branch on MetaData Tree

--- a/DataFormats/Provenance/src/FileFormatVersion.cc
+++ b/DataFormats/Provenance/src/FileFormatVersion.cc
@@ -102,6 +102,11 @@ namespace edm {
     return value_ >= 19;
   }
   
+  bool
+  FileFormatVersion::hasThinnedAssociations() const {
+    return value_ >= 20;
+  }
+
   std::ostream&
   operator<< (std::ostream& os, FileFormatVersion const& ff) {
     os << ff.value();

--- a/DataFormats/Provenance/src/ThinnedAssociationsHelper.cc
+++ b/DataFormats/Provenance/src/ThinnedAssociationsHelper.cc
@@ -1,0 +1,255 @@
+#include "DataFormats/Provenance/interface/ThinnedAssociationsHelper.h"
+#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+#include <algorithm>
+
+namespace edm {
+
+  ThinnedAssociationBranches::ThinnedAssociationBranches() { }
+
+  ThinnedAssociationBranches::ThinnedAssociationBranches(BranchID const& parent,
+                                                         BranchID const& association,
+                                                         BranchID const& thinned) :
+    parent_(parent),
+    association_(association),
+    thinned_(thinned) {
+  }
+
+  ThinnedAssociationsHelper::ThinnedAssociationsHelper() {
+  }
+
+  std::vector<ThinnedAssociationBranches>::const_iterator
+  ThinnedAssociationsHelper::begin() const {
+    return vThinnedAssociationBranches_.begin();
+  }
+
+  std::vector<ThinnedAssociationBranches>::const_iterator
+  ThinnedAssociationsHelper::end() const {
+    return vThinnedAssociationBranches_.end();
+  }
+
+  std::vector<ThinnedAssociationBranches>::const_iterator
+  ThinnedAssociationsHelper::parentBegin(BranchID const& parent) const {
+    ThinnedAssociationBranches target(parent, BranchID(), BranchID());
+    return std::lower_bound(vThinnedAssociationBranches_.begin(), vThinnedAssociationBranches_.end(), target,
+                            [](ThinnedAssociationBranches const& x,
+                               ThinnedAssociationBranches const& y)
+                            { return x.parent() < y.parent(); });
+  }
+
+  std::vector<ThinnedAssociationBranches>::const_iterator
+  ThinnedAssociationsHelper:: parentEnd(BranchID const& parent) const {
+    ThinnedAssociationBranches target(parent, BranchID(), BranchID());
+    return std::upper_bound(vThinnedAssociationBranches_.begin(), vThinnedAssociationBranches_.end(), target,
+                            [](ThinnedAssociationBranches const& x,
+                               ThinnedAssociationBranches const& y)
+                            { return x.parent() < y.parent(); });
+  }
+
+  void ThinnedAssociationsHelper::sort() {
+    std::sort(vThinnedAssociationBranches_.begin(), vThinnedAssociationBranches_.end(),
+              [](ThinnedAssociationBranches const& x,
+                 ThinnedAssociationBranches const& y)
+              { return x.parent() < y.parent() ? true : y.parent() < x.parent() ? false : x.association() < y.association(); });
+  }
+
+  void ThinnedAssociationsHelper::addAssociation(BranchID const& parent,
+                                                 BranchID const& association,
+                                                 BranchID const& thinned) {
+    vThinnedAssociationBranches_.push_back(ThinnedAssociationBranches(parent, association, thinned));
+  }
+
+  void ThinnedAssociationsHelper::addAssociation(ThinnedAssociationBranches const& branches) {
+    vThinnedAssociationBranches_.push_back(branches);
+  }
+
+  std::vector<std::pair<BranchID, ThinnedAssociationBranches const*> >
+  ThinnedAssociationsHelper::associationToBranches() const {
+    std::vector<std::pair<BranchID, ThinnedAssociationBranches const*> > temp;
+    for(auto const& item : vThinnedAssociationBranches_) {
+      temp.push_back(std::make_pair(item.association(), &item));
+    }
+    std::sort(temp.begin(), temp.end(), [](std::pair<BranchID, ThinnedAssociationBranches const*> const& x,
+                                           std::pair<BranchID, ThinnedAssociationBranches const*> const& y)
+                                          { return x.first < y.first; });
+    return temp;
+  }
+
+  void
+  ThinnedAssociationsHelper::
+  selectAssociationProducts(std::vector<BranchDescription const*> const& associationDescriptions,
+                            std::set<BranchID> const& keptProductsInEvent,
+                            std::map<BranchID, bool>& keepAssociation) const {
+
+    keepAssociation.clear();
+    // Copy the elements in vThinnedAssociationBranches_ into a vector sorted on
+    // the association BranchID so we can do searches on that BranchID faster.
+    std::vector<std::pair<BranchID, ThinnedAssociationBranches const*> > assocToBranches =
+      associationToBranches();
+
+    for(auto association : associationDescriptions) {
+      if(association->isAlias()) { // There is no reason to configure an association product with an EDAlias (ignore and drop them if they exist)
+        keepAssociation.insert(std::make_pair(association->branchID(), false));
+      } else {
+        std::set<BranchID> branchesInRecursion;
+        shouldKeepAssociation(association->branchID(),
+                              assocToBranches,
+                              branchesInRecursion,
+                              keptProductsInEvent,
+                              keepAssociation);
+      }
+    }
+  }
+
+  bool ThinnedAssociationsHelper::shouldKeepAssociation(
+    BranchID const& association,
+    std::vector<std::pair<BranchID, ThinnedAssociationBranches const*> > const& associationToBranches,
+    std::set<BranchID>& branchesInRecursion,
+    std::set<BranchID> const& keptProductsInEvent,
+    std::map<BranchID, bool>& keepAssociation) const {
+
+    // If we already decided to keep or drop this one, then
+    // return the same decision.
+    auto decision = keepAssociation.find(association);
+    if(decision != keepAssociation.end()) {
+      return decision->second;
+    }
+
+    // Be careful not to fall into an infinite loop because
+    // of a circular recursion.
+    if(!branchesInRecursion.insert(association).second) {
+      return false;
+    }
+
+    // If the thinned collection is being kept then keep the association
+    auto branches = std::lower_bound(associationToBranches.begin(), associationToBranches.end(),
+                                     std::make_pair(association, static_cast<ThinnedAssociationBranches const*>(nullptr)),
+                                      [](std::pair<BranchID, ThinnedAssociationBranches const*> const& x,
+                                         std::pair<BranchID, ThinnedAssociationBranches const*> const& y)
+                                        { return x.first < y.first; });
+    // This should never happen
+    if(branches == associationToBranches.end() || branches->first != association) {
+      throw edm::Exception(errors::LogicError, "ThinnedAssociationHelper::shouldKeepAssociation could not find branches information, contact Framework developers");
+    }
+    BranchID const& thinnedCollection = branches->second->thinned();
+    if(keptProductsInEvent.find(thinnedCollection) != keptProductsInEvent.end()) {
+      keepAssociation.insert(std::make_pair(association , true));
+      return true;
+    }
+    // otherwise loop over any associations where the thinned collection
+    // is also a parent collection and recursively examine those to see
+    // if their thinned collections are being kept.
+    auto iterEnd = parentEnd(thinnedCollection);
+    for(auto match = parentBegin(thinnedCollection); match != iterEnd; ++match) {
+      if(shouldKeepAssociation(match->association(),
+                               associationToBranches,
+                               branchesInRecursion,
+                               keptProductsInEvent,
+                               keepAssociation)) {
+        keepAssociation.insert(std::make_pair(association , true));
+        return true;
+      }
+    }
+    // drop the association
+    keepAssociation.insert(std::make_pair(association , false));
+    return false;
+  }
+
+  void ThinnedAssociationsHelper::requireMatch(ThinnedAssociationBranches const& input) const {
+    bool foundMatch = false;
+    for(auto entry = parentBegin(input.parent()), iEnd = parentEnd(input.parent());
+        entry != iEnd; ++entry) {
+      if(entry->association() == input.association() &&
+         entry->thinned() == input.thinned()) {
+        foundMatch = true;
+        break;
+      }
+    }
+    if(!foundMatch) {
+      throw edm::Exception(errors::MismatchedInputFiles, "ThinnedAssociationHelper::requireMatch, Illegal attempt to merge files with different ThinnedAssociations");
+    }
+  }
+
+  void ThinnedAssociationsHelper::updateFromInput(ThinnedAssociationsHelper const& helper, bool isSecondaryFile,
+                                                  std::vector<BranchID> const& associationsFromSecondary) {
+    if(!isSecondaryFile) {
+      if(vThinnedAssociationBranches_.empty()) {
+        vThinnedAssociationBranches_ = helper.data();
+        return;
+      }
+      std::vector<ThinnedAssociationBranches> const& inputData = helper.data();
+      for (auto const& inputEntry : inputData) {
+        requireMatch(inputEntry);
+      }
+    } else { // Input is from a secondary file
+
+      if(associationsFromSecondary.empty()) return;
+
+      std::vector<std::pair<BranchID, ThinnedAssociationBranches const*> > assocToBranches = helper.associationToBranches();
+
+      for(BranchID const& association : associationsFromSecondary) {
+
+        auto branches = std::lower_bound(assocToBranches.begin(), assocToBranches.end(),
+                                         std::make_pair(association, static_cast<ThinnedAssociationBranches const*>(nullptr)),
+                                          [](std::pair<BranchID, ThinnedAssociationBranches const*> const& x,
+                                             std::pair<BranchID, ThinnedAssociationBranches const*> const& y)
+                                            { return x.first < y.first; });
+        // This should never happen
+        if(branches == assocToBranches.end() || branches->first != association) {
+          throw edm::Exception(errors::LogicError,
+                             "ThinnedAssociationHelper::initAssociationsFromSecondary could not find branches information, contact Framework developers");
+        }
+        requireMatch(*(branches->second));
+      }
+    }
+  }
+
+  void
+  ThinnedAssociationsHelper::updateFromParentProcess(ThinnedAssociationsHelper const& parentThinnedAssociationsHelper,
+                                                     std::map<BranchID, bool> const& keepAssociation,
+                                                     std::map<BranchID::value_type, BranchID::value_type> const& droppedBranchIDToKeptBranchID) {
+    clear();
+    for(auto const& associationBranches : parentThinnedAssociationsHelper.data()) {
+      auto keep = keepAssociation.find(associationBranches.association());
+      if(keep != keepAssociation.end() && keep->second) {
+        BranchID parent = associationBranches.parent();
+        auto iter = droppedBranchIDToKeptBranchID.find(parent.id());
+        if(iter != droppedBranchIDToKeptBranchID.end()) {
+          parent = BranchID(iter->second);
+        }
+        BranchID thinned = associationBranches.thinned();
+        iter = droppedBranchIDToKeptBranchID.find(thinned.id());
+        if(iter != droppedBranchIDToKeptBranchID.end()) {
+          thinned = BranchID(iter->second);
+        }
+        addAssociation(parent, associationBranches.association(), thinned);
+      }
+    }
+    sort();
+  }
+
+  void
+  ThinnedAssociationsHelper::initAssociationsFromSecondary(std::vector<BranchID> const& associationsFromSecondary,
+                                                           ThinnedAssociationsHelper const& fileAssociationsHelper) {
+    if(associationsFromSecondary.empty()) return;
+
+    std::vector<std::pair<BranchID, ThinnedAssociationBranches const*> > assocToBranches =
+      fileAssociationsHelper.associationToBranches();
+
+    for(BranchID const& association : associationsFromSecondary) {
+
+      auto branches = std::lower_bound(assocToBranches.begin(), assocToBranches.end(),
+                                       std::make_pair(association, static_cast<ThinnedAssociationBranches const*>(nullptr)),
+                                        [](std::pair<BranchID, ThinnedAssociationBranches const*> const& x,
+                                           std::pair<BranchID, ThinnedAssociationBranches const*> const& y)
+                                          { return x.first < y.first; });
+      // This should never happen
+      if(branches == assocToBranches.end() || branches->first != association) {
+        throw edm::Exception(errors::LogicError,
+                             "ThinnedAssociationHelper::initAssociationsFromSecondary could not find branches information, contact Framework developers");
+      }
+      addAssociation(*(branches->second));
+    }
+    sort();
+  }
+}

--- a/DataFormats/Provenance/src/classes.h
+++ b/DataFormats/Provenance/src/classes.h
@@ -29,6 +29,7 @@
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
 #include "DataFormats/Provenance/interface/RunAuxiliary.h"
 #include "DataFormats/Provenance/interface/RunID.h"
+#include "DataFormats/Provenance/interface/ThinnedAssociationsHelper.h"
 #include "DataFormats/Provenance/interface/Timestamp.h"
 #include "DataFormats/Provenance/interface/ESRecordAuxiliary.h"
 #include "FWCore/Utilities/interface/typedefs.h"

--- a/DataFormats/Provenance/src/classes_def.xml
+++ b/DataFormats/Provenance/src/classes_def.xml
@@ -186,7 +186,13 @@
  </class>
  <class name="std::vector<ROOT::TSchemaHelper>"/>
  <class name="std::vector<TFormula*>"/>
- 
+
+ <class name="edm::ThinnedAssociationBranches"/>
+ <class name="std::vector<edm::ThinnedAssociationBranches>"/>
+ <class name="edm::ThinnedAssociationsHelper" ClassVersion="10">
+  <version ClassVersion="10" checksum="3444973106"/>
+ </class>
+
  <ioread sourceClass="edm::ProductProvenance" targetClass="edm::ProductProvenance" version="[1-]" source="" target="transient_">
  <![CDATA[
 	newObj->initializeTransients();

--- a/DataFormats/Streamer/interface/StreamedProducts.h
+++ b/DataFormats/Streamer/interface/StreamedProducts.h
@@ -22,6 +22,7 @@
 #include "DataFormats/Provenance/interface/BranchListIndex.h"
 #include "DataFormats/Provenance/interface/ProcessHistory.h"
 #include "DataFormats/Provenance/interface/BranchIDList.h"
+#include "DataFormats/Provenance/interface/ThinnedAssociationsHelper.h"
 
 namespace edm {
 
@@ -104,15 +105,18 @@ namespace edm {
     SendDescs const& descs() const {return descs_;}
     ParameterSetMap const& processParameterSet() const {return processParameterSet_;}
     BranchIDLists const& branchIDLists() const {return branchIDLists_;}
+    ThinnedAssociationsHelper const& thinnedAssociationsHelper() const { return thinnedAssociationsHelper_; }
     void push_back(BranchDescription const& bd) {descs_.push_back(bd);}
     void setParameterSetMap(ParameterSetMap const& psetMap) {processParameterSet_ = psetMap;}
     void setBranchIDLists(BranchIDLists const& bidlists) {branchIDLists_ = bidlists;}
+    void setThinnedAssociationsHelper(ThinnedAssociationsHelper const& v) { thinnedAssociationsHelper_ = v; }
     void initializeTransients();
 
   private:
     SendDescs descs_;
     ParameterSetMap processParameterSet_;
     BranchIDLists branchIDLists_;
+    ThinnedAssociationsHelper thinnedAssociationsHelper_;
     // trigger bit descriptions will be added here and permanent
     //  provenance values
   };

--- a/DataFormats/Streamer/src/classes_def.xml
+++ b/DataFormats/Streamer/src/classes_def.xml
@@ -8,8 +8,8 @@
  <class name="edm::SendEvent" ClassVersion="10">
   <version ClassVersion="10" checksum="747121728"/>
  </class>
- <class name="edm::SendJobHeader" ClassVersion="10">
-  <version ClassVersion="10" checksum="1238072397"/>
+ <class name="edm::SendJobHeader" ClassVersion="11">
+  <version ClassVersion="11" checksum="79372782"/>
  </class>
  <class name="std::vector<edm::BranchDescription>"/>
 </lcgdict>

--- a/DataFormats/TestObjects/interface/TrackOfThings.h
+++ b/DataFormats/TestObjects/interface/TrackOfThings.h
@@ -1,0 +1,36 @@
+#ifndef DataFormats_TestObjects_TrackOfThings_h
+#define DataFormats_TestObjects_TrackOfThings_h
+
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/Common/interface/RefVector.h"
+#include "DataFormats/Common/interface/Ptr.h"
+#include "DataFormats/Common/interface/PtrVector.h"
+#include "DataFormats/Common/interface/RefToBase.h"
+#include "DataFormats/Common/interface/RefToBaseVector.h"
+#include "DataFormats/TestObjects/interface/Thing.h"
+#include "DataFormats/TestObjects/interface/ThingCollection.h"
+
+namespace edmtest {
+
+  struct TrackOfThings {
+    ~TrackOfThings() { }
+    TrackOfThings() { }
+
+    edm::Ref<ThingCollection> ref1;
+    edm::Ref<ThingCollection> ref2;
+    edm::RefVector<ThingCollection> refVector1;
+
+    edm::Ptr<Thing> ptr1;
+    edm::Ptr<Thing> ptr2;
+    edm::PtrVector<Thing> ptrVector1;
+
+    edm::RefToBase<Thing> refToBase1;
+    edm::RefToBaseVector<Thing> refToBaseVector1;
+  };
+}
+
+namespace edmtest {
+  typedef std::vector<edmtest::TrackOfThings> TrackOfThingsCollection;
+}
+
+#endif

--- a/DataFormats/TestObjects/src/classes.h
+++ b/DataFormats/TestObjects/src/classes.h
@@ -9,6 +9,7 @@
 #include "DataFormats/TestObjects/interface/Thing.h"
 #include "DataFormats/TestObjects/interface/ThingWithMerge.h"
 #include "DataFormats/TestObjects/interface/ThingWithIsEqual.h"
+#include "DataFormats/TestObjects/interface/TrackOfThings.h"
 
 #include "DataFormats/TestObjects/interface/StreamTestSimple.h"
 #include "DataFormats/TestObjects/interface/StreamTestThing.h"
@@ -18,6 +19,7 @@
 
 #include "DataFormats/Common/interface/Holder.h"
 #include "DataFormats/Common/interface/RefToBaseProd.h"
+#include "DataFormats/Common/interface/RefToBaseVector.h"
 
 namespace DataFormats_TestObjects {
 struct dictionary {
@@ -45,6 +47,8 @@ struct dictionary {
   edmtest::OtherThingCollection dummy2;
   edm::Wrapper<edmtest::ThingCollection> dummy3;
   edm::Wrapper<edmtest::OtherThingCollection> dummy4;
+  edmtest::TrackOfThingsCollection dummyTrackOfThingsC;
+  edm::Wrapper<edmtest::TrackOfThingsCollection> dummyWTrackOfThingsC;
 
   edmtestprod::Ord<edmtestprod::Simple> dummy20;
   edmtestprod::StreamTestTmpl<edmtestprod::Ord<edmtestprod::Simple> > dummy21;
@@ -62,12 +66,16 @@ struct dictionary {
   std::vector<edmtest::Sortable> x3;
   std::vector<edmtest::Unsortable> x4;
 
+  edm::Ref<std::vector<edmtest::Thing> > dummyRefThings;
   edm::reftobase::Holder<edmtest::Thing,edm::Ref<std::vector<edmtest::Thing> > > bhThing;
   edm::RefToBaseProd<edmtest::Thing> rtbpThing;
   
   edm::Ptr<edmtest::Thing> ptrThing;
   edm::PtrVector<edmtest::Thing> ptrVecThing;
-  
+
+  edm::RefToBaseVector<edmtest::Thing> refToBaseVectorThing;
+  edm::reftobase::VectorHolder<edmtest::Thing, edm::RefVector<std::vector<edmtest::Thing> > > vectorHolderThing;
+
   edm::Wrapper<edmtest::DeleteEarly> wrapperDeleteEarly;
 };
 }

--- a/DataFormats/TestObjects/src/classes_def.xml
+++ b/DataFormats/TestObjects/src/classes_def.xml
@@ -97,10 +97,18 @@
  <class name="edm::reftobase::BaseHolder<edmtest::Thing>"/>
  <class name="edm::reftobase::Holder<edmtest::Thing,edm::Ref<std::vector<edmtest::Thing>,edmtest::Thing,edm::refhelper::FindUsingAdvance<std::vector<edmtest::Thing>,edmtest::Thing> > >"/>
  <class name="edm::RefToBase<edmtest::Thing>"/>
+ <class name="edm::RefToBaseVector<edmtest::Thing>"/>
+ <class name="edm::reftobase::BaseVectorHolder<edmtest::Thing>"/>
+ <class name="edm::reftobase::VectorHolder<edmtest::Thing, edm::RefVector<std::vector<edmtest::Thing>,edmtest::Thing,edm::refhelper::FindUsingAdvance<std::vector<edmtest::Thing>,edmtest::Thing> > >"/>
  <class name="edm::Ptr<edmtest::Thing>"/>
  <class name="edm::PtrVector<edmtest::Thing>"/>
  <class name="edm::Ref<std::vector<edmtest::Thing>,edmtest::Thing,edm::refhelper::FindUsingAdvance<std::vector<edmtest::Thing>,edmtest::Thing> >"/>
  <class name="edm::RefVector<std::vector<edmtest::Thing>,edmtest::Thing,edm::refhelper::FindUsingAdvance<std::vector<edmtest::Thing>,edmtest::Thing> >"/>
+ <class name="edmtest::TrackOfThings"/>
+ <class name="std::vector<edmtest::TrackOfThings>" ClassVersion="10">
+  <version ClassVersion="10" checksum="1189167006"/>
+ </class>
+ <class name="edm::Wrapper<std::vector<edmtest::TrackOfThings> >"/>
  <class name="edm::Wrapper<edmtest::Thing>"/>
  <class name="edm::Wrapper<edmtest::ThingWithMerge>"/>
  <class name="edm::Wrapper<edmtest::ThingWithIsEqual>"/>

--- a/FWCore/FWLite/interface/BranchMapReader.h
+++ b/FWCore/FWLite/interface/BranchMapReader.h
@@ -31,6 +31,10 @@ class TFile;
 class TTree;
 class TBranch;
 
+namespace edm {
+  class ThinnedAssociationsHelper;
+}
+
 namespace fwlite {
   namespace internal {
     class BMRStrategy {
@@ -45,8 +49,10 @@ namespace fwlite {
       virtual bool updateMap() = 0;
       virtual edm::BranchID productToBranchID(const edm::ProductID& pid) = 0;
       virtual const edm::BranchDescription& productToBranch(const edm::ProductID& pid) = 0;
+      virtual const edm::BranchDescription& branchIDToBranch(const edm::BranchID& bid) const = 0;
       virtual const std::vector<edm::BranchDescription>& getBranchDescriptions() = 0;
       virtual const edm::BranchListIndexes& branchListIndexes() const = 0;
+      virtual const edm::ThinnedAssociationsHelper& thinnedAssociationsHelper() const = 0;
 
       TFile* currentFile_;
       TTree* eventTree_;
@@ -74,7 +80,9 @@ namespace fwlite {
     bool updateEvent(Long_t eventEntry);
     bool updateLuminosityBlock(Long_t luminosityBlockEntry);
     bool updateRun(Long_t runEntry);
+    edm::BranchID productToBranchID(const edm::ProductID& pid) { return strategy_->productToBranchID(pid); }
     const edm::BranchDescription& productToBranch(const edm::ProductID& pid);
+    const edm::BranchDescription& branchIDToBranch(const edm::BranchID& bid) const { return strategy_->branchIDToBranch(bid); }
     int getFileVersion(TFile* file);
     int getFileVersion() const { return  fileVersion_;}
 
@@ -88,6 +96,7 @@ namespace fwlite {
     Long_t getRunEntry() const { return strategy_->runEntry_; }
     const std::vector<edm::BranchDescription>& getBranchDescriptions();
     const edm::BranchListIndexes& branchListIndexes() const { strategy_->updateMap(); return strategy_->branchListIndexes(); }
+    const edm::ThinnedAssociationsHelper& thinnedAssociationsHelper() const { return strategy_->thinnedAssociationsHelper(); }
 
       // ---------- member data --------------------------------
   private:

--- a/FWCore/FWLite/src/BareRootProductGetter.h
+++ b/FWCore/FWLite/src/BareRootProductGetter.h
@@ -26,11 +26,18 @@
 // system include files
 #include "Rtypes.h"
 #include <map>
+#include <memory>
+#include <vector>
 
 // forward declarations
 class TBranch;
-class TFile;
-class TTree;
+class TClass;
+
+namespace edm {
+   class BranchID;
+   class ProductID;
+   class ThinnedAssociation;
+}
 
 class BareRootProductGetter : public edm::EDProductGetter {
 
@@ -41,7 +48,32 @@ class BareRootProductGetter : public edm::EDProductGetter {
       // ---------- const member functions ---------------------
       virtual edm::WrapperBase const* getIt(edm::ProductID const&) const override;
 
-private:
+     // getThinnedProduct assumes getIt was already called and failed to find
+     // the product. The input key is the index of the desired element in the
+     // container identified by ProductID (which cannot be found).
+     // If the return value is not null, then the desired element was found
+     // in a thinned container and key is modified to be the index into
+     // that thinned container. If the desired element is not found, then
+     // nullptr is returned.
+      virtual edm::WrapperBase const* getThinnedProduct(edm::ProductID const&,
+                                                        unsigned int& key) const override;
+
+     // getThinnedProducts assumes getIt was already called and failed to find
+     // the product. The input keys are the indexes into the container identified
+     // by ProductID (which cannot be found). On input the WrapperBase pointers
+     // must all be set to nullptr (except when the function calls itself
+     // recursively where non-null pointers mark already found elements).
+     // Thinned containers derived from the product are searched to see
+     // if they contain the desired elements. For each that is
+     // found, the corresponding WrapperBase pointer is set and the key
+     // is modified to be the key into the container where the element
+     // was found. The WrapperBase pointers might or might not all point
+     // to the same thinned container.
+      virtual void getThinnedProducts(edm::ProductID const&,
+                                      std::vector<edm::WrapperBase const*>& foundContainers,
+                                      std::vector<unsigned int>& keys) const override;
+
+   private:
 
       // ---------- static member functions --------------------
 
@@ -49,6 +81,8 @@ private:
       virtual unsigned int transitionIndex_() const override {
         return 0u;
       }
+
+      edm::WrapperBase const* getIt(edm::BranchID const&, Long_t eventEntry) const;
 
       struct Buffer {
         Buffer(edm::WrapperBase const* iProd, TBranch* iBranch, void* iAddress,
@@ -63,24 +97,18 @@ private:
         Long_t eventEntry_; //the event Entry used with the last GetEntry call
         TClass* class_;
       };
-   private:
+
       BareRootProductGetter(BareRootProductGetter const&); // stop default
 
       BareRootProductGetter const& operator=(BareRootProductGetter const&); // stop default
 
-      // ---------- member data --------------------------------
-      void setupNewFile(TFile*) const;
-      TBranch* findBranch(edm::ProductID const&) const;
-      Buffer* createNewBuffer(edm::ProductID const&) const;
+      Buffer* createNewBuffer(edm::BranchID const&) const;
+      edm::ThinnedAssociation const* getThinnedAssociation(edm::BranchID const& branchID, Long_t eventEntry) const;
 
-//      mutable TFile* presentFile_;
-//      mutable TTree* eventTree_;
-//      mutable Long_t eventEntry_;
-//      typedef std::map<edm::ProductID,edm::BranchDescription> IdToBranchDesc;
-//      mutable IdToBranchDesc idToBranchDesc_;
-      typedef std::map<edm::ProductID, Buffer> IdToBuffers;
+      // ---------- member data --------------------------------
+
+      typedef std::map<edm::BranchID, Buffer> IdToBuffers;
       mutable IdToBuffers idToBuffers_;
       mutable fwlite::BranchMapReader branchMap_;
 };
-
 #endif

--- a/FWCore/FWLite/test/RefTest.sh
+++ b/FWCore/FWLite/test/RefTest.sh
@@ -1,9 +1,14 @@
 #!/bin/sh
+
+function die { echo Failure $1: status $2 ; exit $2 ; }
+
 rm -f ${LOCAL_TEST_DIR}/good.root
 rm -f ${LOCAL_TEST_DIR}/good2.root
 rm -f ${LOCAL_TEST_DIR}/good_delta5.root
 rm -f good.root
 rm -f good2.root
 rm -f good_delta5.root
-cmsRun ${LOCAL_TEST_DIR}/RefTest_cfg.py
-cmsRun ${LOCAL_TEST_DIR}/RefTest2_cfg.py
+
+cmsRun ${LOCAL_TEST_DIR}/RefTest_cfg.py || die "cmsRun RefTest_cfg.py" $?
+
+cmsRun ${LOCAL_TEST_DIR}/RefTest2_cfg.py || die "cmsRun RefTest2_cfg.py" $?

--- a/FWCore/FWLite/test/RefTest_cfg.py
+++ b/FWCore/FWLite/test/RefTest_cfg.py
@@ -12,14 +12,226 @@ process.maxEvents = cms.untracked.PSet(
 
 process.source = cms.Source("EmptySource")
 
+process.WhatsItESProducer = cms.ESProducer("WhatsItESProducer")
+
+process.DoodadESSource = cms.ESSource("DoodadESSource")
+
+
 process.Thing = cms.EDProducer("ThingProducer",
     offsetDelta = cms.int32(1)
 )
 
 process.OtherThing = cms.EDProducer("OtherThingProducer")
 
+process.thingProducer = cms.EDProducer("ThingProducer",
+                                       offsetDelta = cms.int32(100),
+                                       nThings = cms.int32(50)
+)
+
+process.trackOfThingsProducerA = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(0, 1, 2, 3, 4, 5, 6, 7, 8)
+)
+
+process.trackOfThingsProducerB = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(0, 1, 2, 3)
+)
+
+process.trackOfThingsProducerC = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(4, 5, 6, 7)
+)
+
+process.trackOfThingsProducerD = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(10, 11, 12, 13, 14, 15, 16, 17, 18)
+)
+
+process.trackOfThingsProducerDMinus = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(10, 11, 12, 13, 14, 15, 16, 17)
+)
+
+process.trackOfThingsProducerDPlus = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(10, 11, 12, 13, 14, 15, 16, 17, 18, 21)
+)
+
+process.trackOfThingsProducerE = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(10, 11, 12, 13, 14)
+)
+
+process.trackOfThingsProducerF = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(14, 15, 16, 17)
+)
+
+process.trackOfThingsProducerG = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(20, 21, 22, 23, 24, 25, 26, 27, 28)
+)
+
+process.trackOfThingsProducerH = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(20, 21, 22, 23)
+)
+
+process.trackOfThingsProducerI = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(24, 25, 26, 27)
+)
+
+process.trackOfThingsProducerJ = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(30, 31, 32, 33, 34, 35, 36, 37, 38)
+)
+
+process.trackOfThingsProducerK = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(30, 31, 32, 33)
+)
+
+process.trackOfThingsProducerL = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(34, 35, 36, 37)
+)
+
+process.trackOfThingsProducerM = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(40, 41, 42, 43, 44, 45, 46, 47, 48)
+)
+
+process.trackOfThingsProducerN = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(40, 41, 42, 43)
+)
+
+process.trackOfThingsProducerO = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(44, 45, 46, 47)
+)
+
+process.thinningThingProducerA = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    trackTag = cms.InputTag('trackOfThingsProducerA'),
+    offsetToThinnedKey = cms.uint32(0),
+    expectedCollectionSize = cms.uint32(50)
+)
+
+process.thinningThingProducerB = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thinningThingProducerA'),
+    trackTag = cms.InputTag('trackOfThingsProducerB'),
+    offsetToThinnedKey = cms.uint32(0),
+    expectedCollectionSize = cms.uint32(9)
+)
+
+process.thinningThingProducerC = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thinningThingProducerA'),
+    trackTag = cms.InputTag('trackOfThingsProducerC'),
+    offsetToThinnedKey = cms.uint32(0),
+    expectedCollectionSize = cms.uint32(9)
+)
+
+process.thinningThingProducerD = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    trackTag = cms.InputTag('trackOfThingsProducerD'),
+    offsetToThinnedKey = cms.uint32(0),
+    expectedCollectionSize = cms.uint32(50)
+)
+
+process.thinningThingProducerE = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thinningThingProducerD'),
+    trackTag = cms.InputTag('trackOfThingsProducerE'),
+    offsetToThinnedKey = cms.uint32(10),
+    expectedCollectionSize = cms.uint32(9)
+)
+
+process.thinningThingProducerF = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thinningThingProducerD'),
+    trackTag = cms.InputTag('trackOfThingsProducerF'),
+    offsetToThinnedKey = cms.uint32(10),
+    expectedCollectionSize = cms.uint32(9)
+)
+
+process.thinningThingProducerG = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    trackTag = cms.InputTag('trackOfThingsProducerG'),
+    offsetToThinnedKey = cms.uint32(0),
+    expectedCollectionSize = cms.uint32(50)
+)
+
+process.thinningThingProducerH = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thinningThingProducerG'),
+    trackTag = cms.InputTag('trackOfThingsProducerH'),
+    offsetToThinnedKey = cms.uint32(20),
+    expectedCollectionSize = cms.uint32(9)
+)
+
+process.thinningThingProducerI = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thinningThingProducerG'),
+    trackTag = cms.InputTag('trackOfThingsProducerI'),
+    offsetToThinnedKey = cms.uint32(20),
+    expectedCollectionSize = cms.uint32(9)
+)
+
+process.thinningThingProducerJ = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    trackTag = cms.InputTag('trackOfThingsProducerJ'),
+    offsetToThinnedKey = cms.uint32(0),
+    expectedCollectionSize = cms.uint32(50)
+)
+
+process.thinningThingProducerK = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thinningThingProducerJ'),
+    trackTag = cms.InputTag('trackOfThingsProducerK'),
+    offsetToThinnedKey = cms.uint32(30),
+    expectedCollectionSize = cms.uint32(9)
+)
+
+process.thinningThingProducerL = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thinningThingProducerJ'),
+    trackTag = cms.InputTag('trackOfThingsProducerL'),
+    offsetToThinnedKey = cms.uint32(30),
+    expectedCollectionSize = cms.uint32(9)
+)
+
+process.thinningThingProducerM = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    trackTag = cms.InputTag('trackOfThingsProducerM'),
+    offsetToThinnedKey = cms.uint32(0),
+    expectedCollectionSize = cms.uint32(50)
+)
+
+process.thinningThingProducerN = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thinningThingProducerM'),
+    trackTag = cms.InputTag('trackOfThingsProducerN'),
+    offsetToThinnedKey = cms.uint32(40),
+    expectedCollectionSize = cms.uint32(9)
+)
+
+process.thinningThingProducerO = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thinningThingProducerM'),
+    trackTag = cms.InputTag('trackOfThingsProducerO'),
+    offsetToThinnedKey = cms.uint32(40),
+    expectedCollectionSize = cms.uint32(9)
+)
+
 process.out = cms.OutputModule("PoolOutputModule",
-    fileName = cms.untracked.string('good.root')
+    fileName = cms.untracked.string('good.root'),
+    outputCommands = cms.untracked.vstring(
+        'keep *',
+        'drop *_thingProducer_*_*',
+        'drop *_thinningThingProducerD_*_*',
+        'drop *_thinningThingProducerH_*_*',
+        'drop *_thinningThingProducerI_*_*',
+        'drop *_thinningThingProducerJ_*_*',
+        'drop *_thinningThingProducerK_*_*',
+        'drop *_thinningThingProducerL_*_*',
+        'drop *_thinningThingProducerM_*_*',
+        'drop *_thinningThingProducerN_*_*',
+    )
 )
 
 process.out2 = cms.OutputModule("PoolOutputModule",
@@ -33,6 +245,40 @@ process.out_other = cms.OutputModule("PoolOutputModule",
     fileName = cms.untracked.string('other_only.root')
 )
 
+process.thinningTestPath = cms.Path(process.thingProducer
+                                    * process.trackOfThingsProducerA
+                                    * process.trackOfThingsProducerB
+                                    * process.trackOfThingsProducerC
+                                    * process.trackOfThingsProducerD
+                                    * process.trackOfThingsProducerDMinus
+                                    * process.trackOfThingsProducerDPlus
+                                    * process.trackOfThingsProducerE
+                                    * process.trackOfThingsProducerF
+                                    * process.trackOfThingsProducerG
+                                    * process.trackOfThingsProducerH
+                                    * process.trackOfThingsProducerI
+                                    * process.trackOfThingsProducerJ
+                                    * process.trackOfThingsProducerK
+                                    * process.trackOfThingsProducerL
+                                    * process.trackOfThingsProducerM
+                                    * process.trackOfThingsProducerN
+                                    * process.trackOfThingsProducerO
+                                    * process.thinningThingProducerA
+                                    * process.thinningThingProducerB
+                                    * process.thinningThingProducerC
+                                    * process.thinningThingProducerD
+                                    * process.thinningThingProducerE
+                                    * process.thinningThingProducerF
+                                    * process.thinningThingProducerG
+                                    * process.thinningThingProducerH
+                                    * process.thinningThingProducerI
+                                    * process.thinningThingProducerJ
+                                    * process.thinningThingProducerK
+                                    * process.thinningThingProducerL
+                                    * process.thinningThingProducerM
+                                    * process.thinningThingProducerN
+                                    * process.thinningThingProducerO
+)
 
 process.p = cms.Path(process.Thing*process.OtherThing)
 process.outp = cms.EndPath(process.out*process.out2*process.out_other)

--- a/FWCore/Framework/interface/EDAnalyzer.h
+++ b/FWCore/Framework/interface/EDAnalyzer.h
@@ -17,6 +17,8 @@ namespace edm {
   class ModuleCallingContext;
   class PreallocationConfiguration;
   class ActivityRegistry;
+  class ProductRegistry;
+  class ThinnedAssociationsHelper;
 
   namespace maker {
     template<typename T> class ModuleHolderT;
@@ -61,6 +63,9 @@ namespace edm {
     void doRespondToCloseInputFile(FileBlock const& fb);
     void doPreForkReleaseResources();
     void doPostForkReacquireResources(unsigned int iChildIndex, unsigned int iNumberOfChildren);
+    void doRegisterThinnedAssociations(ProductRegistry const&,
+                                       ThinnedAssociationsHelper&) { }
+
     void registerProductsAndCallbacks(EDAnalyzer const*, ProductRegistry* reg);
 
     virtual void analyze(Event const&, EventSetup const&) = 0;

--- a/FWCore/Framework/interface/EDFilter.h
+++ b/FWCore/Framework/interface/EDFilter.h
@@ -31,6 +31,8 @@ namespace edm {
   class ModuleCallingContext;
   class PreallocationConfiguration;
   class ActivityRegistry;
+  class ProductRegistry;
+  class ThinnedAssociationsHelper;
 
   class EDFilter : public ProducerBase, public EDConsumerBase {
   public:
@@ -68,6 +70,8 @@ namespace edm {
     void doRespondToCloseInputFile(FileBlock const& fb);
     void doPreForkReleaseResources();
     void doPostForkReacquireResources(unsigned int iChildIndex, unsigned int iNumberOfChildren);
+    void doRegisterThinnedAssociations(ProductRegistry const&,
+                                       ThinnedAssociationsHelper&) { }
 
     void registerProductsAndCallbacks(EDFilter* module, ProductRegistry* reg) {
       registerProducts(module, reg, moduleDescription_);

--- a/FWCore/Framework/interface/EDProducer.h
+++ b/FWCore/Framework/interface/EDProducer.h
@@ -25,7 +25,9 @@ namespace edm {
   class ModuleCallingContext;
   class PreallocationConfiguration;
   class ActivityRegistry;
-  
+  class ProductRegistry;
+  class ThinnedAssociationsHelper;
+
   namespace maker {
     template<typename T> class ModuleHolderT;
   }
@@ -65,6 +67,8 @@ namespace edm {
     void doRespondToCloseInputFile(FileBlock const& fb);
     void doPreForkReleaseResources();
     void doPostForkReacquireResources(unsigned int iChildIndex, unsigned int iNumberOfChildren);
+    void doRegisterThinnedAssociations(ProductRegistry const&,
+                                       ThinnedAssociationsHelper&) { }
     void registerProductsAndCallbacks(EDProducer* module, ProductRegistry* reg) {
       registerProducts(module, reg, moduleDescription_);
     }

--- a/FWCore/Framework/interface/EventPrincipal.h
+++ b/FWCore/Framework/interface/EventPrincipal.h
@@ -27,6 +27,7 @@ is the DataBlock.
 #include <vector>
 
 namespace edm {
+  class BranchID;
   class BranchIDListHelper;
   class ProductProvenanceRetriever;
   class DelayedReader;
@@ -34,7 +35,10 @@ namespace edm {
   class HistoryAppender;
   class LuminosityBlockPrincipal;
   class ModuleCallingContext;
+  class ProductID;
   class StreamContext;
+  class ThinnedAssociation;
+  class ThinnedAssociationsHelper;
   class ProcessHistoryRegistry;
   class RunPrincipal;
   class UnscheduledHandler;
@@ -50,6 +54,7 @@ namespace edm {
     EventPrincipal(
         std::shared_ptr<ProductRegistry const> reg,
         std::shared_ptr<BranchIDListHelper const> branchIDListHelper,
+        std::shared_ptr<ThinnedAssociationsHelper const> thinnedAssociationsHelper,
         ProcessConfiguration const& pc,
         HistoryAppender* historyAppender,
         unsigned int streamIndex = 0);
@@ -154,7 +159,11 @@ namespace edm {
         std::unique_ptr<WrapperBase> edp,
         ProductProvenance const& productProvenance);
 
-    WrapperBase const* getIt(ProductID const& pid) const;
+    virtual WrapperBase const* getIt(ProductID const& pid) const override;
+    virtual WrapperBase const* getThinnedProduct(ProductID const& pid, unsigned int& key) const override;
+    virtual void getThinnedProducts(ProductID const& pid,
+                                    std::vector<WrapperBase const*>& foundContainers,
+                                    std::vector<unsigned int>& keys) const override;
 
     ProductID branchIDToProductID(BranchID const& bid) const;
 
@@ -171,6 +180,8 @@ namespace edm {
   private:
 
     BranchID pidToBid(ProductID const& pid) const;
+
+    edm::ThinnedAssociation const* getThinnedAssociation(edm::BranchID const& branchID) const;
 
     virtual bool unscheduledFill(std::string const& moduleLabel,
                                  ModuleCallingContext const* mcc) const override;
@@ -209,6 +220,7 @@ namespace edm {
     EventSelectionIDVector eventSelectionIDs_;
 
     std::shared_ptr<BranchIDListHelper const> branchIDListHelper_;
+    std::shared_ptr<ThinnedAssociationsHelper const> thinnedAssociationsHelper_;
 
     BranchListIndexes branchListIndexes_;
 

--- a/FWCore/Framework/interface/EventProcessor.h
+++ b/FWCore/Framework/interface/EventProcessor.h
@@ -46,6 +46,7 @@ namespace edm {
 
   class ExceptionToActionTable;
   class BranchIDListHelper;
+  class ThinnedAssociationsHelper;
   class EDLooperBase;
   class HistoryAppender;
   class ProcessDesc;
@@ -255,6 +256,7 @@ namespace edm {
     std::shared_ptr<ActivityRegistry>           actReg_;
     std::shared_ptr<ProductRegistry const>      preg_;
     std::shared_ptr<BranchIDListHelper>         branchIDListHelper_;
+    std::shared_ptr<ThinnedAssociationsHelper>  thinnedAssociationsHelper_;
     ServiceToken                                  serviceToken_;
     std::unique_ptr<InputSource>                  input_;
     std::unique_ptr<eventsetup::EventSetupsController> espController_;

--- a/FWCore/Framework/interface/InputSource.h
+++ b/FWCore/Framework/interface/InputSource.h
@@ -68,6 +68,7 @@ namespace edm {
   class ProductRegistry;
   class StreamContext;
   class SharedResourcesAcquirer;
+  class ThinnedAssociationsHelper;
   namespace multicore {
     class MessageReceiverForSource;
   }
@@ -175,6 +176,9 @@ namespace edm {
 
     /// Accessor for branchIDListHelper
     std::shared_ptr<BranchIDListHelper> branchIDListHelper() const {return branchIDListHelper_;}
+
+    /// Accessor for thinnedAssociationsHelper
+    std::shared_ptr<ThinnedAssociationsHelper> thinnedAssociationsHelper() const {return thinnedAssociationsHelper_;}
 
     /// Reset the remaining number of events/lumis to the maximum number.
     void repeat() {
@@ -439,6 +443,7 @@ namespace edm {
     std::shared_ptr<ProductRegistry> productRegistry_;
     std::unique_ptr<ProcessHistoryRegistry> processHistoryRegistry_;
     std::shared_ptr<BranchIDListHelper> branchIDListHelper_;
+    std::shared_ptr<ThinnedAssociationsHelper> thinnedAssociationsHelper_;
     bool const primary_;
     std::string processGUID_;
     Timestamp time_;

--- a/FWCore/Framework/interface/InputSourceDescription.h
+++ b/FWCore/Framework/interface/InputSourceDescription.h
@@ -15,6 +15,7 @@ namespace edm {
   class ActivityRegistry;
   class BranchIDListHelper;
   class PreallocationConfiguration;
+  class ThinnedAssociationsHelper;
 
   struct InputSourceDescription {
     InputSourceDescription() :
@@ -29,6 +30,7 @@ namespace edm {
     InputSourceDescription(ModuleDescription const& md,
                            ProductRegistry& preg,
                            std::shared_ptr<BranchIDListHelper> branchIDListHelper,
+                           std::shared_ptr<ThinnedAssociationsHelper> thinnedAssociationsHelper,
                            std::shared_ptr<ActivityRegistry> areg,
                            int maxEvents,
                            int maxLumis,
@@ -37,6 +39,7 @@ namespace edm {
       moduleDescription_(md),
       productRegistry_(&preg),
       branchIDListHelper_(branchIDListHelper),
+      thinnedAssociationsHelper_(thinnedAssociationsHelper),
       actReg_(areg),
       maxEvents_(maxEvents),
       maxLumis_(maxLumis),
@@ -47,6 +50,7 @@ namespace edm {
     ModuleDescription moduleDescription_;
     ProductRegistry* productRegistry_;
     std::shared_ptr<BranchIDListHelper> branchIDListHelper_;
+    std::shared_ptr<ThinnedAssociationsHelper> thinnedAssociationsHelper_;
     std::shared_ptr<ActivityRegistry> actReg_;
     int maxEvents_;
     int maxLumis_;

--- a/FWCore/Framework/interface/Principal.h
+++ b/FWCore/Framework/interface/Principal.h
@@ -210,7 +210,12 @@ namespace edm {
     void putOrMerge(std::unique_ptr<WrapperBase> prod, ProductProvenance& prov, ProductHolderBase* productHolder);
 
   private:
-    virtual WrapperBase const* getIt(ProductID const&) const;
+
+    virtual WrapperBase const* getIt(ProductID const&) const override;
+    virtual WrapperBase const* getThinnedProduct(ProductID const&, unsigned int&) const override;
+    virtual void getThinnedProducts(ProductID const&,
+                                    std::vector<WrapperBase const*>&,
+                                    std::vector<unsigned int>&) const override;
 
     void findProducts(std::vector<ProductHolderBase const*> const& holders,
                       TypeID const& typeID,

--- a/FWCore/Framework/interface/ProductSelector.h
+++ b/FWCore/Framework/interface/ProductSelector.h
@@ -9,12 +9,17 @@
 //
 //////////////////////////////////////////////////////////////////////
 
+#include "DataFormats/Provenance/interface/BranchID.h"
+
 #include <iosfwd>
+#include <map>
 #include <string>
 #include <vector>
 
 namespace edm {
   class BranchDescription;
+  class BranchID;
+  class ProductRegistry;
   class ProductSelectorRules;
   class ParameterSet;
 
@@ -32,6 +37,13 @@ namespace edm {
     void print(std::ostream& os) const;
 
     bool initialized() const {return initialized_;}
+
+    static void checkForDuplicateKeptBranch(BranchDescription const& desc,
+                                            std::map<BranchID, BranchDescription const*>& trueBranchIDToKeptBranchDesc);
+
+    static void fillDroppedToKept(ProductRegistry const& preg,
+                                  std::map<BranchID, BranchDescription const*> const& trueBranchIDToKeptBranchDesc,
+                                  std::map<BranchID::value_type, BranchID::value_type>& droppedBranchIDToKeptBranchID_);
 
   private:
 

--- a/FWCore/Framework/interface/Schedule.h
+++ b/FWCore/Framework/interface/Schedule.h
@@ -105,6 +105,7 @@ namespace edm {
   class GlobalSchedule;
   struct TriggerTimingReport;
   class ModuleRegistry;
+  class ThinnedAssociationsHelper;
   class TriggerResultInserter;
   
   class Schedule {
@@ -120,6 +121,7 @@ namespace edm {
              service::TriggerNamesService& tns,
              ProductRegistry& pregistry,
              BranchIDListHelper& branchIDListHelper,
+             ThinnedAssociationsHelper& thinnedAssociationsHelper,
              ExceptionToActionTable const& actions,
              std::shared_ptr<ActivityRegistry> areg,
              std::shared_ptr<ProcessConfiguration> processConfiguration,

--- a/FWCore/Framework/interface/ScheduleItems.h
+++ b/FWCore/Framework/interface/ScheduleItems.h
@@ -11,6 +11,7 @@ namespace edm {
   class ExceptionToActionTable;
   class ActivityRegistry;
   class BranchIDListHelper;
+  class ThinnedAssociationsHelper;
   struct CommonParams;
   class SubProcess;
   class ParameterSet;
@@ -52,12 +53,12 @@ namespace edm {
     void
     clear();
 
-    std::shared_ptr<ActivityRegistry>           actReg_;
-    std::unique_ptr<SignallingProductRegistry>    preg_;
-    std::shared_ptr<BranchIDListHelper>         branchIDListHelper_;
-    std::unique_ptr<ExceptionToActionTable const>            act_table_;
-    std::shared_ptr<ProcessConfiguration>       processConfiguration_;
+    std::shared_ptr<ActivityRegistry> actReg_;
+    std::unique_ptr<SignallingProductRegistry> preg_;
+    std::shared_ptr<BranchIDListHelper> branchIDListHelper_;
+    std::shared_ptr<ThinnedAssociationsHelper> thinnedAssociationsHelper_;
+    std::unique_ptr<ExceptionToActionTable const> act_table_;
+    std::shared_ptr<ProcessConfiguration> processConfiguration_;
   };
 }
-
 #endif

--- a/FWCore/Framework/interface/global/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/global/EDAnalyzerBase.h
@@ -33,7 +33,9 @@ namespace edm {
   class PreallocationConfiguration;
   class StreamID;
   class ActivityRegistry;
-  
+  class ProductRegistry;
+  class ThinnedAssociationsHelper;
+
   namespace maker {
     template<typename T> class ModuleHolderT;
   }
@@ -101,8 +103,9 @@ namespace edm {
       //For now, the following are just dummy implemenations with no ability for users to override
       void doRespondToOpenInputFile(FileBlock const& fb);
       void doRespondToCloseInputFile(FileBlock const& fb);
-      
-      
+      void doRegisterThinnedAssociations(ProductRegistry const&,
+                                         ThinnedAssociationsHelper&) { }
+
       void registerProductsAndCallbacks(EDAnalyzerBase* module, ProductRegistry* reg);
       std::string workerType() const {return "WorkerT<EDAnalyzer>";}
       

--- a/FWCore/Framework/interface/global/EDFilterBase.h
+++ b/FWCore/Framework/interface/global/EDFilterBase.h
@@ -35,7 +35,9 @@ namespace edm {
   class PreallocationConfiguration;
   class StreamID;
   class ActivityRegistry;
-  
+  class ProductRegistry;
+  class ThinnedAssociationsHelper;
+
   namespace maker {
     template<typename T> class ModuleHolderT;
   }
@@ -103,8 +105,9 @@ namespace edm {
       //For now, the following are just dummy implemenations with no ability for users to override
       void doRespondToOpenInputFile(FileBlock const& fb);
       void doRespondToCloseInputFile(FileBlock const& fb);
-      
-      
+      void doRegisterThinnedAssociations(ProductRegistry const&,
+                                         ThinnedAssociationsHelper&) { }
+
       void registerProductsAndCallbacks(EDFilterBase* module, ProductRegistry* reg) {
         registerProducts(module, reg, moduleDescription_);
       }

--- a/FWCore/Framework/interface/global/EDProducerBase.h
+++ b/FWCore/Framework/interface/global/EDProducerBase.h
@@ -36,7 +36,9 @@ namespace edm {
   class StreamID;
   class GlobalSchedule;
   class ActivityRegistry;
-  
+  class ProductRegistry;
+  class ThinnedAssociationsHelper;
+
   namespace maker {
     template<typename T> class ModuleHolderT;
   }
@@ -106,8 +108,9 @@ namespace edm {
       //For now, the following are just dummy implemenations with no ability for users to override
       void doRespondToOpenInputFile(FileBlock const& fb);
       void doRespondToCloseInputFile(FileBlock const& fb);
-      
-      
+      void doRegisterThinnedAssociations(ProductRegistry const&,
+                                         ThinnedAssociationsHelper&) { }
+
       void registerProductsAndCallbacks(EDProducerBase* module, ProductRegistry* reg) {
         registerProducts(module, reg, moduleDescription_);
       }

--- a/FWCore/Framework/interface/one/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/one/EDAnalyzerBase.h
@@ -34,6 +34,8 @@ namespace edm {
   class ModuleCallingContext;
   class PreallocationConfiguration;
   class ActivityRegistry;
+  class ProductRegistry;
+  class ThinnedAssociationsHelper;
 
   namespace maker {
     template<typename T> class ModuleHolderT;
@@ -88,8 +90,9 @@ namespace edm {
       //For now, the following are just dummy implemenations with no ability for users to override
       void doRespondToOpenInputFile(FileBlock const& fb);
       void doRespondToCloseInputFile(FileBlock const& fb);
+      void doRegisterThinnedAssociations(ProductRegistry const&,
+                                         ThinnedAssociationsHelper&) { }
 
-      
       void registerProductsAndCallbacks(EDAnalyzerBase const* module, ProductRegistry* reg);
       std::string workerType() const {return "WorkerT<EDAnalyzer>";}
       

--- a/FWCore/Framework/interface/one/EDFilterBase.h
+++ b/FWCore/Framework/interface/one/EDFilterBase.h
@@ -35,6 +35,8 @@ namespace edm {
   class ModuleCallingContext;
   class PreallocationConfiguration;
   class ActivityRegistry;
+  class ProductRegistry;
+  class ThinnedAssociationsHelper;
   
   namespace maker {
     template<typename T> class ModuleHolderT;
@@ -84,8 +86,9 @@ namespace edm {
       //For now, the following are just dummy implemenations with no ability for users to override
       void doRespondToOpenInputFile(FileBlock const& fb);
       void doRespondToCloseInputFile(FileBlock const& fb);
+      void doRegisterThinnedAssociations(ProductRegistry const&,
+                                         ThinnedAssociationsHelper&) { }
 
-      
       void registerProductsAndCallbacks(EDFilterBase* module, ProductRegistry* reg) {
         registerProducts(module, reg, moduleDescription_);
       }

--- a/FWCore/Framework/interface/one/EDProducerBase.h
+++ b/FWCore/Framework/interface/one/EDProducerBase.h
@@ -35,6 +35,9 @@ namespace edm {
   class ModuleCallingContext;
   class PreallocationConfiguration;
   class ActivityRegistry;
+  class ProductRegistry;
+  class ThinnedAssociationsHelper;
+
   namespace maker {
     template<typename T> class ModuleHolderT;
   }
@@ -83,8 +86,9 @@ namespace edm {
       //For now, the following are just dummy implemenations with no ability for users to override
       void doRespondToOpenInputFile(FileBlock const& fb);
       void doRespondToCloseInputFile(FileBlock const& fb);
+      void doRegisterThinnedAssociations(ProductRegistry const&,
+                                         ThinnedAssociationsHelper&) { }
 
-      
       void registerProductsAndCallbacks(EDProducerBase* module, ProductRegistry* reg) {
         registerProducts(module, reg, moduleDescription_);
       }

--- a/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
@@ -41,6 +41,8 @@ namespace edm {
   class PreallocationConfiguration;
   class ProductHolderIndexAndSkipBit;
   class ActivityRegistry;
+  class ProductRegistry;
+  class ThinnedAssociationsHelper;
 
   namespace maker {
     template<typename T> class ModuleHolderT;
@@ -141,6 +143,8 @@ namespace edm {
       //For now, the following are just dummy implemenations with no ability for users to override
       void doRespondToOpenInputFile(FileBlock const& fb);
       void doRespondToCloseInputFile(FileBlock const& fb);
+      void doRegisterThinnedAssociations(ProductRegistry const&,
+                                         ThinnedAssociationsHelper&) { }
 
       // ---------- member data --------------------------------
       void setModuleDescription(ModuleDescription const& md) {

--- a/FWCore/Framework/interface/stream/EDFilterBase.h
+++ b/FWCore/Framework/interface/stream/EDFilterBase.h
@@ -30,6 +30,9 @@
 
 // forward declarations
 namespace edm {
+  class ProductRegistry;
+  class ThinnedAssociationsHelper;
+
   namespace stream {
     class EDFilterAdaptorBase;
     template<typename> class ProducingModuleAdaptorBase;
@@ -70,6 +73,8 @@ namespace edm {
 
       virtual void preForkReleaseResources() {}
       virtual void postForkReacquireResources(unsigned int /*iChildIndex*/, unsigned int /*iNumberOfChildren*/) {}
+      virtual void registerThinnedAssociations(ProductRegistry const&,
+                                               ThinnedAssociationsHelper&) { }
 
       void setModuleDescriptionPtr(ModuleDescription const* iDesc) {
         moduleDescriptionPtr_ = iDesc;

--- a/FWCore/Framework/interface/stream/EDProducerBase.h
+++ b/FWCore/Framework/interface/stream/EDProducerBase.h
@@ -31,6 +31,9 @@
 // forward declarations
 namespace edm {
   template<typename T> class WorkerT;
+  class ProductRegistry;
+  class ThinnedAssociationsHelper;
+
   namespace stream {
     class EDProducerAdaptorBase;
     template<typename> class ProducingModuleAdaptorBase;
@@ -70,6 +73,8 @@ namespace edm {
 
       virtual void preForkReleaseResources() {}
       virtual void postForkReacquireResources(unsigned int /*iChildIndex*/, unsigned int /*iNumberOfChildren*/) {}
+      virtual void registerThinnedAssociations(ProductRegistry const&,
+                                               ThinnedAssociationsHelper&) { }
 
       void setModuleDescriptionPtr(ModuleDescription const* iDesc) {
         moduleDescriptionPtr_ = iDesc;

--- a/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
@@ -42,7 +42,9 @@ namespace edm {
   class EDConsumerBase;
   class PreallocationConfiguration;
   class ProductHolderIndexAndSkipBit;
-  
+  class ProductRegistry;
+  class ThinnedAssociationsHelper;
+
   namespace maker {
     template<typename T> class ModuleHolderT;
   }
@@ -154,6 +156,8 @@ namespace edm {
       //For now, the following are just dummy implemenations with no ability for users to override
       void doRespondToOpenInputFile(FileBlock const& fb);
       void doRespondToCloseInputFile(FileBlock const& fb);
+      void doRegisterThinnedAssociations(ProductRegistry const&,
+                                         ThinnedAssociationsHelper&);
 
       // ---------- member data --------------------------------
       void setModuleDescription(ModuleDescription const& md) {

--- a/FWCore/Framework/interface/stream/ThinningProducer.h
+++ b/FWCore/Framework/interface/stream/ThinningProducer.h
@@ -1,0 +1,166 @@
+#ifndef FWCore_Framework_ThinningProducer_h
+#define FWCore_Framework_ThinningProducer_h
+
+/** \class edm::ThinningProducer
+\author W. David Dagenhart, created 11 June 2014
+*/
+
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Common/interface/OrphanHandle.h"
+#include "DataFormats/Common/interface/ThinnedAssociation.h"
+#include "DataFormats/Provenance/interface/ProductRegistry.h"
+#include "DataFormats/Provenance/interface/ThinnedAssociationsHelper.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+#include <memory>
+
+namespace edm {
+
+  class EventSetup;
+
+  template <typename Collection, typename Selector>
+  class ThinningProducer : public stream::EDProducer<> {
+  public:
+    explicit ThinningProducer(ParameterSet const& pset);
+    virtual ~ThinningProducer();
+
+    static void fillDescriptions(ConfigurationDescriptions & descriptions);
+
+    virtual void produce(Event& event, EventSetup const& eventSetup) override;
+
+    virtual void registerThinnedAssociations(ProductRegistry const& productRegistry,
+                                             ThinnedAssociationsHelper& thinnedAssociationsHelper) override;
+  private:
+    std::unique_ptr<Selector> selector_;
+    edm::EDGetTokenT<Collection> inputToken_;
+    edm::InputTag inputTag_;
+  };
+
+  template <typename Collection, typename Selector>
+  ThinningProducer<Collection, Selector>::
+  ThinningProducer(ParameterSet const& pset) :
+    selector_(new Selector(pset, consumesCollector())) {
+
+    inputTag_ = pset.getParameter<InputTag>("inputTag");
+    inputToken_ = consumes<Collection>(inputTag_);
+
+    produces<Collection>();
+    produces<ThinnedAssociation>();
+  }
+
+  template <typename Collection, typename Selector>
+  ThinningProducer<Collection, Selector>::
+  ~ThinningProducer() {}
+
+  template <typename Collection, typename Selector>
+  void ThinningProducer<Collection, Selector>::
+  fillDescriptions(ConfigurationDescriptions & descriptions) {
+    ParameterSetDescription desc;
+    desc.setComment("Produces thinned collections and associations to them");
+    desc.add<edm::InputTag>("inputTag");
+    Selector::fillDescription(desc);
+    descriptions.addDefault(desc);
+  }
+
+  template <typename Collection, typename Selector>
+  void ThinningProducer<Collection, Selector>::
+  produce(Event& event, EventSetup const& eventSetup) {
+
+    edm::Handle<Collection> inputCollection;
+    event.getByToken(inputToken_, inputCollection);
+
+    edm::Event const& constEvent = event;
+    selector_->preChoose(inputCollection, constEvent, eventSetup);
+
+    std::auto_ptr<Collection> thinnedCollection(new Collection);
+    std::auto_ptr<ThinnedAssociation> thinnedAssociation(new ThinnedAssociation);
+
+    unsigned int iIndex = 0;
+    for(auto iter = inputCollection->begin(), iterEnd = inputCollection->end();
+        iter != iterEnd; ++iter, ++iIndex) {
+      if(selector_->choose(iIndex, *iter)) {
+        thinnedCollection->push_back(*iter);
+        thinnedAssociation->push_back(iIndex);
+      }
+    }
+    OrphanHandle<Collection> orphanHandle = event.put(thinnedCollection);
+
+    thinnedAssociation->setParentCollectionID(inputCollection.id());
+    thinnedAssociation->setThinnedCollectionID(orphanHandle.id());
+    event.put(thinnedAssociation);
+  }
+
+  template <typename Collection, typename Selector>
+  void ThinningProducer<Collection, Selector>::
+  registerThinnedAssociations(ProductRegistry const& productRegistry,
+                              ThinnedAssociationsHelper& thinnedAssociationsHelper) {
+
+    BranchID associationID;
+    BranchID thinnedCollectionID;
+
+    // If the InputTag does not specify the process name, it is
+    // possible that there will be more than one match found below.
+    // For a particular event only one match is correct and the
+    // others will be false. It even possible for some events one
+    // match is correct and for others another is correct. This is
+    // a side effect of the lookup mechanisms when the process name
+    // is not specified.
+    // When using the registry this generates one would have to
+    // check the ProductIDs in ThinnedAssociation product to get
+    // the correct association. This ambiguity will probably be
+    // rare and possibly never occur in practice.
+    std::vector<BranchID> parentCollectionIDs;
+
+    ProductRegistry::ProductList const& productList = productRegistry.productList();
+    for(auto const& product : productList) {
+      BranchDescription const& desc = product.second;
+      if(desc.unwrappedType().typeInfo() == typeid(Collection) ) {
+        if(desc.produced() &&
+           desc.moduleLabel() == moduleDescription().moduleLabel() &&
+           desc.productInstanceName().empty()) {
+
+          thinnedCollectionID = desc.branchID();
+        }
+        if(desc.moduleLabel() == inputTag_.label() &&
+           desc.productInstanceName() == inputTag_.instance()) {
+          if(inputTag_.willSkipCurrentProcess()) {
+            if(!desc.produced()) {
+              parentCollectionIDs.push_back(desc.branchID());
+            }
+          } else if (inputTag_.process().empty() || inputTag_.process() == desc.processName()) {
+            if(desc.produced()) {
+              parentCollectionIDs.push_back(desc.originalBranchID());
+            } else {
+              parentCollectionIDs.push_back(desc.branchID());
+            }
+          }
+        }
+      }
+      if(desc.produced() &&
+         desc.unwrappedType().typeInfo() == typeid(ThinnedAssociation) &&
+         desc.moduleLabel() == moduleDescription().moduleLabel() &&
+         desc.productInstanceName().empty()) {
+
+        associationID = desc.branchID();
+      }
+    }
+    if(parentCollectionIDs.empty()) {
+      // This could happen if the input collection was dropped. Go ahead and add
+      // an entry and let the exception be thrown only if the module is run (when
+      // it cannot find the product).
+      thinnedAssociationsHelper.addAssociation(BranchID(), associationID, thinnedCollectionID);
+    } else {
+      for(auto const& parentCollectionID : parentCollectionIDs) {
+        thinnedAssociationsHelper.addAssociation(parentCollectionID, associationID, thinnedCollectionID);
+      }
+    }
+  }
+}
+#endif

--- a/FWCore/Framework/src/EventPrincipal.cc
+++ b/FWCore/Framework/src/EventPrincipal.cc
@@ -2,12 +2,15 @@
 
 #include "DataFormats/Common/interface/BasicHandle.h"
 #include "DataFormats/Common/interface/FunctorHandleExceptionFactory.h"
+#include "DataFormats/Common/interface/ThinnedAssociation.h"
+#include "DataFormats/Common/interface/Wrapper.h"
 #include "DataFormats/Provenance/interface/BranchIDList.h"
 #include "DataFormats/Provenance/interface/BranchIDListHelper.h"
 #include "DataFormats/Provenance/interface/BranchListIndex.h"
 #include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
 #include "DataFormats/Provenance/interface/ProductIDToBranchID.h"
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
+#include "DataFormats/Provenance/interface/ThinnedAssociationsHelper.h"
 #include "FWCore/Common/interface/Provenance.h"
 #include "FWCore/Framework/interface/DelayedReader.h"
 #include "FWCore/Framework/interface/ProductHolder.h"
@@ -19,12 +22,15 @@
 #include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
 
 #include <algorithm>
+#include <cassert>
+#include <limits>
 #include <memory>
 
 namespace edm {
   EventPrincipal::EventPrincipal(
         std::shared_ptr<ProductRegistry const> reg,
         std::shared_ptr<BranchIDListHelper const> branchIDListHelper,
+        std::shared_ptr<ThinnedAssociationsHelper const> thinnedAssociationsHelper,
         ProcessConfiguration const& pc,
         HistoryAppender* historyAppender,
         unsigned int streamIndex) :
@@ -36,9 +42,12 @@ namespace edm {
           moduleLabelsRunning_(),
           eventSelectionIDs_(),
           branchIDListHelper_(branchIDListHelper),
+          thinnedAssociationsHelper_(thinnedAssociationsHelper),
           branchListIndexes_(),
           branchListIndexToProcessIndex_(),
-          streamID_(streamIndex){}
+          streamID_(streamIndex) {
+    assert(thinnedAssociationsHelper_);
+  }
 
   void
   EventPrincipal::clearEventPrincipal() {
@@ -284,6 +293,112 @@ namespace edm {
     return getByProductID(pid).wrapper();
   }
 
+  WrapperBase const*
+  EventPrincipal::getThinnedProduct(ProductID const& pid, unsigned int& key) const {
+
+    BranchID parent = pidToBid(pid);
+
+    // Loop over thinned containers which were made by selecting elements from the parent container
+    for(auto associatedBranches = thinnedAssociationsHelper_->parentBegin(parent),
+                           iEnd = thinnedAssociationsHelper_->parentEnd(parent);
+        associatedBranches != iEnd; ++associatedBranches) {
+
+      ThinnedAssociation const* thinnedAssociation =
+        getThinnedAssociation(associatedBranches->association());
+      if(thinnedAssociation == nullptr) continue;
+
+      if(associatedBranches->parent() != pidToBid(thinnedAssociation->parentCollectionID())) {
+        continue;
+      }
+
+      unsigned int thinnedIndex = 0;
+      // Does this thinned container have the element referenced by key?
+      // If yes, thinnedIndex is set to point to it in the thinned container
+      if(!thinnedAssociation->hasParentIndex(key, thinnedIndex)) {
+        continue;
+      }
+      // Get the thinned container and return a pointer if we can find it
+      ProductID const& thinnedCollectionPID = thinnedAssociation->thinnedCollectionID();
+      BasicHandle bhThinned = getByProductID(thinnedCollectionPID);
+      if(!bhThinned.isValid()) {
+        // Thinned container is not found, try looking recursively in thinned containers
+        // which were made by selecting elements from this thinned container.
+        WrapperBase const* wrapperBase = getThinnedProduct(thinnedCollectionPID, thinnedIndex);
+        if(wrapperBase != nullptr) {
+          key = thinnedIndex;
+          return wrapperBase;
+        } else {
+          continue;
+        }
+      }
+      key = thinnedIndex;
+      return bhThinned.wrapper();
+    }
+    return nullptr;
+  }
+
+  void
+  EventPrincipal::getThinnedProducts(ProductID const& pid,
+                                     std::vector<WrapperBase const*>& foundContainers,
+                                     std::vector<unsigned int>& keys) const {
+
+    BranchID parent = pidToBid(pid);
+
+    // Loop over thinned containers which were made by selecting elements from the parent container
+    for(auto associatedBranches = thinnedAssociationsHelper_->parentBegin(parent),
+                           iEnd = thinnedAssociationsHelper_->parentEnd(parent);
+        associatedBranches != iEnd; ++associatedBranches) {
+
+      ThinnedAssociation const* thinnedAssociation =
+        getThinnedAssociation(associatedBranches->association());
+      if(thinnedAssociation == nullptr) continue;
+
+      if(associatedBranches->parent() != pidToBid(thinnedAssociation->parentCollectionID())) {
+        continue;
+      }
+
+      unsigned nKeys = keys.size();
+      unsigned int doNotLookForThisIndex = std::numeric_limits<unsigned int>::max();
+      std::vector<unsigned int> thinnedIndexes(nKeys, doNotLookForThisIndex);
+      bool hasAny = false;
+      for(unsigned k = 0; k < nKeys; ++k) {
+        // Already found this one
+        if(foundContainers[k] != nullptr) continue;
+        // Already know this one is not in this thinned container
+        if(keys[k] == doNotLookForThisIndex) continue;
+        // Does the thinned container hold the entry of interest?
+        // Modifies thinnedIndexes[k] only if it returns true and
+        // sets it to the index in the thinned collection.
+        if(thinnedAssociation->hasParentIndex(keys[k], thinnedIndexes[k])) {
+          hasAny = true;
+        }
+      }
+      if(!hasAny) {
+        continue;
+      }
+      // Get the thinned container and set the pointers and indexes into
+      // it (if we can find it)
+      ProductID thinnedCollectionPID = thinnedAssociation->thinnedCollectionID();
+      BasicHandle bhThinned = getByProductID(thinnedCollectionPID);
+      if(!bhThinned.isValid()) {
+        // Thinned container is not found, try looking recursively in thinned containers
+        // which were made by selecting elements from this thinned container.
+        getThinnedProducts(thinnedCollectionPID, foundContainers, thinnedIndexes);
+        for(unsigned k = 0; k < nKeys; ++k) {
+          if(foundContainers[k] == nullptr) continue;
+          if(thinnedIndexes[k] == doNotLookForThisIndex) continue;
+          keys[k] = thinnedIndexes[k];
+        }
+      } else {
+        for(unsigned k = 0; k < nKeys; ++k) {
+          if(thinnedIndexes[k] == doNotLookForThisIndex) continue;
+          keys[k] = thinnedIndexes[k];
+          foundContainers[k] = bhThinned.wrapper();
+        }
+      }
+    }
+  }
+
   Provenance
   EventPrincipal::getProvenance(ProductID const& pid, ModuleCallingContext const* mcc) const {
     BranchID bid = pidToBid(pid);
@@ -308,6 +423,30 @@ namespace edm {
   BranchListIndexes const&
   EventPrincipal::branchListIndexes() const {
     return branchListIndexes_;
+  }
+
+  edm::ThinnedAssociation const*
+  EventPrincipal::getThinnedAssociation(edm::BranchID const& branchID) const {
+
+    ConstProductHolderPtr const phb = getProductHolder(branchID);
+
+    if(phb == nullptr) {
+      throw Exception(errors::LogicError)
+        << "EventPrincipal::getThinnedAssociation, ThinnedAssociation ProductHolder cannot be found\n"
+        << "This should never happen. Contact a Framework developer";
+    }
+    ProductHolderBase::ResolveStatus status;
+    ProductData const* productData = phb->resolveProduct(status,false,nullptr);
+    if (productData == nullptr) {
+      return nullptr;
+    }
+    WrapperBase const* product = productData->wrapper_.get();
+    if(!(typeid(edm::ThinnedAssociation) == product->dynamicTypeInfo())) {
+      throw Exception(errors::LogicError)
+        << "EventPrincipal::getThinnedProduct, product has wrong type, not a ThinnedAssociation.\n";
+    }
+    Wrapper<ThinnedAssociation> const* wrapper = static_cast<Wrapper<ThinnedAssociation> const*>(product);
+    return wrapper->product();
   }
 
   bool

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -121,6 +121,7 @@ namespace edm {
             CommonParams const& common,
             ProductRegistry& preg,
             std::shared_ptr<BranchIDListHelper> branchIDListHelper,
+            std::shared_ptr<ThinnedAssociationsHelper> thinnedAssociationsHelper,
             std::shared_ptr<ActivityRegistry> areg,
             std::shared_ptr<ProcessConfiguration const> processConfiguration,
             PreallocationConfiguration const& allocations) {
@@ -164,7 +165,10 @@ namespace edm {
                          processConfiguration.get(),
                          ModuleDescription::getUniqueID());
 
-    InputSourceDescription isdesc(md, preg, branchIDListHelper, areg, common.maxEventsInput_, common.maxLumisInput_, common.maxSecondsUntilRampdown_, allocations);
+    InputSourceDescription isdesc(md, preg, branchIDListHelper, thinnedAssociationsHelper, areg,
+                                  common.maxEventsInput_, common.maxLumisInput_,
+                                  common.maxSecondsUntilRampdown_, allocations);
+
     areg->preSourceConstructionSignal_(md);
     std::unique_ptr<InputSource> input;
     try {
@@ -515,7 +519,7 @@ namespace edm {
     preallocations_ = PreallocationConfiguration{nThreads,nStreams,nConcurrentLumis,nConcurrentRuns};
 
     // initialize the input source
-    input_ = makeInput(*parameterSet, *common, *items.preg_, items.branchIDListHelper_, items.actReg_, items.processConfiguration_, preallocations_);
+    input_ = makeInput(*parameterSet, *common, *items.preg_, items.branchIDListHelper_, items.thinnedAssociationsHelper_, items.actReg_, items.processConfiguration_, preallocations_);
 
     // intialize the Schedule
     schedule_ = items.initSchedule(*parameterSet,subProcessParameterSet.get(),preallocations_,&processContext_);
@@ -525,6 +529,7 @@ namespace edm {
     actReg_ = items.actReg_;
     preg_.reset(items.preg_.release());
     branchIDListHelper_ = items.branchIDListHelper_;
+    thinnedAssociationsHelper_ = items.thinnedAssociationsHelper_;
     processConfiguration_ = items.processConfiguration_;
     processContext_.setProcessConfiguration(processConfiguration_.get());
     principalCache_.setProcessHistoryRegistry(input_->processHistoryRegistry());
@@ -534,7 +539,7 @@ namespace edm {
     principalCache_.setNumberOfConcurrentPrincipals(preallocations_);
     for(unsigned int index = 0; index<preallocations_.numberOfStreams(); ++index ) {
       // Reusable event principal
-      auto ep = std::make_shared<EventPrincipal>(preg_, branchIDListHelper_, *processConfiguration_, historyAppender_.get(), index);
+      auto ep = std::make_shared<EventPrincipal>(preg_, branchIDListHelper_, thinnedAssociationsHelper_, *processConfiguration_, historyAppender_.get(), index);
       ep->preModuleDelayedGetSignal_.connect(std::cref(actReg_->preModuleEventDelayedGetSignal_));
       ep->postModuleDelayedGetSignal_.connect(std::cref(actReg_->postModuleEventDelayedGetSignal_));
       principalCache_.insert(ep);
@@ -545,6 +550,7 @@ namespace edm {
                                        *parameterSet,
                                        preg_,
                                        branchIDListHelper_,
+                                       *thinnedAssociationsHelper_,
                                        *espController_,
                                        *actReg_,
                                        token,

--- a/FWCore/Framework/src/InputSource.cc
+++ b/FWCore/Framework/src/InputSource.cc
@@ -63,6 +63,7 @@ namespace edm {
       productRegistry_(createSharedPtrToStatic<ProductRegistry>(desc.productRegistry_)),
       processHistoryRegistry_(new ProcessHistoryRegistry),
       branchIDListHelper_(desc.branchIDListHelper_),
+      thinnedAssociationsHelper_(desc.thinnedAssociationsHelper_),
       primary_(pset.getParameter<std::string>("@module_label") == std::string("@main_input")),
       processGUID_(primary_ ? createGlobalIdentifier() : std::string()),
       time_(),

--- a/FWCore/Framework/src/OutputModuleCommunicator.h
+++ b/FWCore/Framework/src/OutputModuleCommunicator.h
@@ -31,6 +31,7 @@
 namespace edm {
 
   class ProcessContext;
+  class ThinnedAssociationsHelper;
 
   class OutputModuleCommunicator
   {
@@ -62,7 +63,7 @@ namespace edm {
     
     virtual SelectedProductsForBranchType const& keptProducts() const = 0;
     
-    virtual void selectProducts(ProductRegistry const& preg) = 0;
+    virtual void selectProducts(ProductRegistry const& preg, ThinnedAssociationsHelper const&) = 0;
     
     virtual void setEventSelectionInfo(std::map<std::string, std::vector<std::pair<std::string, int> > > const& outputModulePathPositions,
                                        bool anyProductProduced) = 0;

--- a/FWCore/Framework/src/OutputModuleCommunicatorT.cc
+++ b/FWCore/Framework/src/OutputModuleCommunicatorT.cc
@@ -84,8 +84,8 @@ namespace edm {
   }
   
   template<typename T>
-  void OutputModuleCommunicatorT<T>::selectProducts(edm::ProductRegistry const& preg) {
-    module().selectProducts(preg);
+  void OutputModuleCommunicatorT<T>::selectProducts(edm::ProductRegistry const& preg, ThinnedAssociationsHelper const& helper) {
+    module().selectProducts(preg, helper);
   }
   
   template<typename T>

--- a/FWCore/Framework/src/OutputModuleCommunicatorT.h
+++ b/FWCore/Framework/src/OutputModuleCommunicatorT.h
@@ -8,7 +8,8 @@
 
 namespace edm {
   class OutputModule;
-  
+  class ThinnedAssociationsHelper;
+
   namespace one {
     class OutputModuleBase;
   }
@@ -47,7 +48,7 @@ namespace edm {
     
     virtual edm::SelectedProductsForBranchType const& keptProducts() const override;
     
-    virtual void selectProducts(edm::ProductRegistry const& preg) override;
+    virtual void selectProducts(edm::ProductRegistry const& preg, ThinnedAssociationsHelper const&) override;
     
     virtual void setEventSelectionInfo(std::map<std::string, std::vector<std::pair<std::string, int> > > const& outputModulePathPositions,
                                        bool anyProductProduced) override;

--- a/FWCore/Framework/src/Principal.cc
+++ b/FWCore/Framework/src/Principal.cc
@@ -788,6 +788,19 @@ namespace edm {
     return nullptr;
   }
 
+  WrapperBase const*
+  Principal::getThinnedProduct(ProductID const&, unsigned int&) const {
+    assert(nullptr);
+    return nullptr;
+  }
+
+  void
+  Principal::getThinnedProducts(ProductID const&,
+                                  std::vector<WrapperBase const*>&,
+                                  std::vector<unsigned int>&) const {
+    assert(nullptr);
+  }
+
   void
   Principal::checkUniquenessAndType(WrapperBase const* prod, ProductHolderBase const* phb) const {
     if(prod == nullptr) return;

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -2,6 +2,7 @@
 
 #include "DataFormats/Provenance/interface/ProcessConfiguration.h"
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
+#include "DataFormats/Provenance/interface/ThinnedAssociationsHelper.h"
 #include "DataFormats/Provenance/interface/BranchIDListHelper.h"
 #include "FWCore/Framework/interface/OutputModuleDescription.h"
 #include "FWCore/Framework/interface/TriggerNamesService.h"
@@ -358,6 +359,7 @@ namespace edm {
                      service::TriggerNamesService& tns,
                      ProductRegistry& preg,
                      BranchIDListHelper& branchIDListHelper,
+                     ThinnedAssociationsHelper& thinnedAssociationsHelper,
                      ExceptionToActionTable const& actions,
                      std::shared_ptr<ActivityRegistry> areg,
                      std::shared_ptr<ProcessConfiguration> processConfiguration,
@@ -446,9 +448,14 @@ namespace edm {
 
     preg.setFrozen();
 
+    for(auto const& worker : streamSchedules_[0]->allWorkers()) {
+      worker->registerThinnedAssociations(preg, thinnedAssociationsHelper);
+    }
+    thinnedAssociationsHelper.sort();
+
     for (auto c : all_output_communicators_) {
       c->setEventSelectionInfo(outputModulePathPositions, preg.anyProductProduced());
-      c->selectProducts(preg);
+      c->selectProducts(preg, thinnedAssociationsHelper);
     }
     
     if(wantSummary_) {

--- a/FWCore/Framework/src/ScheduleItems.cc
+++ b/FWCore/Framework/src/ScheduleItems.cc
@@ -3,6 +3,7 @@
 #include "DataFormats/Provenance/interface/BranchDescription.h"
 #include "DataFormats/Provenance/interface/BranchID.h"
 #include "DataFormats/Provenance/interface/BranchIDListHelper.h"
+#include "DataFormats/Provenance/interface/ThinnedAssociationsHelper.h"
 #include "DataFormats/Provenance/interface/SelectedProducts.h"
 #include "FWCore/Framework/interface/ExceptionActions.h"
 #include "FWCore/Framework/interface/CommonParams.h"
@@ -25,6 +26,7 @@ namespace edm {
       actReg_(new ActivityRegistry),
       preg_(new SignallingProductRegistry),
       branchIDListHelper_(new BranchIDListHelper),
+      thinnedAssociationsHelper_(new ThinnedAssociationsHelper),
       act_table_(),
       processConfiguration_() {
   }
@@ -33,6 +35,7 @@ namespace edm {
       actReg_(new ActivityRegistry),
       preg_(new SignallingProductRegistry(preg)),
       branchIDListHelper_(new BranchIDListHelper),
+      thinnedAssociationsHelper_(new ThinnedAssociationsHelper),
       act_table_(),
       processConfiguration_() {
 
@@ -134,6 +137,7 @@ namespace edm {
                      ServiceRegistry::instance().get<service::TriggerNamesService>(),
                      *preg_,
                      *branchIDListHelper_,
+                     *thinnedAssociationsHelper_,
                      *act_table_,
                      actReg_,
                      processConfiguration_,
@@ -148,7 +152,7 @@ namespace edm {
     actReg_.reset();
     preg_.reset();
     branchIDListHelper_.reset();
+    thinnedAssociationsHelper_.reset();
     processConfiguration_.reset();
   }
 }
-

--- a/FWCore/Framework/src/Worker.h
+++ b/FWCore/Framework/src/Worker.h
@@ -54,7 +54,9 @@ namespace edm {
   class ProductHolderIndexAndSkipBit;
   class StreamID;
   class StreamContext;
-  
+  class ProductRegistry;
+  class ThinnedAssociationsHelper;
+
   namespace workerhelper {
     template< typename O> class CallImpl;
   }
@@ -84,6 +86,7 @@ namespace edm {
 
     void preForkReleaseResources() {implPreForkReleaseResources();}
     void postForkReacquireResources(unsigned int iChildIndex, unsigned int iNumberOfChildren) {implPostForkReacquireResources(iChildIndex, iNumberOfChildren);}
+    void registerThinnedAssociations(ProductRegistry const& registry, ThinnedAssociationsHelper& helper) { implRegisterThinnedAssociations(registry, helper); }
 
     void reset() { state_ = Ready; }
 
@@ -162,6 +165,8 @@ namespace edm {
     virtual void implPreForkReleaseResources() = 0;
     virtual void implPostForkReacquireResources(unsigned int iChildIndex,
                                                unsigned int iNumberOfChildren) = 0;
+    virtual void implRegisterThinnedAssociations(ProductRegistry const&, ThinnedAssociationsHelper&) = 0;
+
     int timesRun_;
     int timesVisited_;
     int timesPassed_;

--- a/FWCore/Framework/src/WorkerT.cc
+++ b/FWCore/Framework/src/WorkerT.cc
@@ -323,6 +323,15 @@ namespace edm{
     module_->doPostForkReacquireResources(iChildIndex, iNumberOfChildren);
   }
 
+
+  template<typename T>
+  inline
+  void
+  WorkerT<T>::implRegisterThinnedAssociations(ProductRegistry const& registry,
+                                               ThinnedAssociationsHelper& helper) {
+    module_->doRegisterThinnedAssociations(registry, helper);
+  }
+
   template<typename T>
   void WorkerT<T>::updateLookup(BranchType iBranchType,
                                 ProductHolderIndexHelper const& iHelper) {

--- a/FWCore/Framework/src/WorkerT.h
+++ b/FWCore/Framework/src/WorkerT.h
@@ -18,6 +18,8 @@ namespace edm {
 
   class ModuleCallingContext;
   class ProductHolderIndexAndSkipBit;
+  class ProductRegistry;
+  class ThinnedAssociationsHelper;
 
   UnscheduledHandler* getUnscheduledHandler(EventPrincipal const& ep);
 
@@ -96,6 +98,7 @@ namespace edm {
     virtual void implPreForkReleaseResources() override;
     virtual void implPostForkReacquireResources(unsigned int iChildIndex, 
                                                unsigned int iNumberOfChildren) override;
+    virtual void implRegisterThinnedAssociations(ProductRegistry const&, ThinnedAssociationsHelper&) override;
     virtual std::string workerType() const override;
 
     virtual void modulesDependentUpon(std::vector<const char*>& oModuleLabels) const override {

--- a/FWCore/Framework/src/one/OutputModuleBase.cc
+++ b/FWCore/Framework/src/one/OutputModuleBase.cc
@@ -17,10 +17,12 @@
 #include "FWCore/Framework/interface/one/OutputModuleBase.h"
 
 #include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Common/interface/ThinnedAssociation.h"
 #include "DataFormats/Provenance/interface/BranchDescription.h"
 #include "DataFormats/Provenance/interface/BranchKey.h"
 #include "DataFormats/Provenance/interface/ParentageRegistry.h"
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
+#include "DataFormats/Provenance/interface/ThinnedAssociationsHelper.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventPrincipal.h"
 #include "FWCore/Framework/interface/OutputModuleDescription.h"
@@ -52,6 +54,7 @@ namespace edm {
     droppedBranchIDToKeptBranchID_(),
     branchIDLists_(new BranchIDLists),
     origBranchIDLists_(nullptr),
+    thinnedAssociationsHelper_(new ThinnedAssociationsHelper),
     branchParents_(),
     branchChildren_() {
       
@@ -77,7 +80,8 @@ namespace edm {
       origBranchIDLists_ = desc.branchIDLists_;
     }
     
-    void OutputModuleBase::selectProducts(ProductRegistry const& preg) {
+    void OutputModuleBase::selectProducts(ProductRegistry const& preg,
+                                          ThinnedAssociationsHelper const& thinnedAssociationsHelper) {
       if(productSelector_.initialized()) return;
       productSelector_.initialize(productSelectorRules_, preg.allBranchDescriptions());
       
@@ -86,7 +90,9 @@ namespace edm {
       // for more information.
       
       std::map<BranchID, BranchDescription const*> trueBranchIDToKeptBranchDesc;
-      
+      std::vector<BranchDescription const*> associationDescriptions;
+      std::set<BranchID> keptProductsInEvent;
+
       for(auto const& it : preg.productList()) {
         BranchDescription const& desc = it.second;
         if(desc.transient()) {
@@ -94,76 +100,80 @@ namespace edm {
         } else if(!desc.present() && !desc.produced()) {
           // else if the branch containing the product has been previously dropped,
           // output nothing
+        } else if(desc.unwrappedType().typeInfo() == typeid(ThinnedAssociation)) {
+          associationDescriptions.push_back(&desc);
         } else if(selected(desc)) {
-          // else if the branch has been selected, put it in the list of selected branches.
-          if(desc.produced()) {
-            // First we check if an equivalent branch has already been selected due to an EDAlias.
-            // We only need the check for products produced in this process.
-            BranchID const& trueBranchID = desc.originalBranchID();
-            std::map<BranchID, BranchDescription const*>::const_iterator iter = trueBranchIDToKeptBranchDesc.find(trueBranchID);
-            if(iter != trueBranchIDToKeptBranchDesc.end()) {
-              throw edm::Exception(errors::Configuration, "Duplicate Output Selection")
-              << "Two (or more) equivalent branches have been selected for output.\n"
-              << "#1: " << BranchKey(desc) << "\n"
-              << "#2: " << BranchKey(*iter->second) << "\n"
-              << "Please drop at least one of them.\n";
-            }
-            trueBranchIDToKeptBranchDesc.insert(std::make_pair(trueBranchID, &desc));
-          }
-          switch (desc.branchType()) {
-            case InEvent:
-            {
-              consumes(TypeToGet{desc.unwrappedTypeID(),PRODUCT_TYPE},
-                       InputTag{desc.moduleLabel(),
-                         desc.productInstanceName(),
-                         desc.processName()});
-              break;
-            }
-            case InLumi:
-            {
-              consumes<InLumi>(TypeToGet{desc.unwrappedTypeID(),PRODUCT_TYPE},
-                               InputTag(desc.moduleLabel(),
-                                        desc.productInstanceName(),
-                                        desc.processName()));
-              break;
-            }
-            case InRun:
-            {
-              consumes<InRun>(TypeToGet{desc.unwrappedTypeID(),PRODUCT_TYPE},
-                              InputTag(desc.moduleLabel(),
-                                       desc.productInstanceName(),
-                                       desc.processName()));
-              break;
-            }
-            default:
-              assert(false);
-              break;
-          }
-          // Now put it in the list of selected branches.
-          keptProducts_[desc.branchType()].push_back(&desc);
+          keepThisBranch(desc, trueBranchIDToKeptBranchDesc, keptProductsInEvent);
         } else {
           // otherwise, output nothing,
           // and mark the fact that there is a newly dropped branch of this type.
           hasNewlyDroppedBranch_[desc.branchType()] = true;
         }
       }
-      // Now fill in a mapping needed in the case that a branch was dropped while its EDAlias was kept.
-      for(auto const& it : preg.productList()) {
-        BranchDescription const& desc = it.second;
-        if(!desc.produced() || desc.isAlias()) continue;
-        BranchID const& branchID = desc.branchID();
-        std::map<BranchID, BranchDescription const*>::const_iterator iter = trueBranchIDToKeptBranchDesc.find(branchID);
-        if(iter != trueBranchIDToKeptBranchDesc.end()) {
-          // This branch, produced in this process, or an alias of it, was persisted.
-          BranchID const& keptBranchID = iter->second->branchID();
-          if(keptBranchID != branchID) {
-            // An EDAlias branch was persisted.
-            droppedBranchIDToKeptBranchID_.insert(std::make_pair(branchID.id(), keptBranchID.id()));
-          }
+
+      thinnedAssociationsHelper.selectAssociationProducts(associationDescriptions,
+                                                          keptProductsInEvent,
+                                                          keepAssociation_);
+
+      for(auto association : associationDescriptions) {
+        if(keepAssociation_[association->branchID()]) {
+          keepThisBranch(*association, trueBranchIDToKeptBranchDesc, keptProductsInEvent);
+        } else {
+          hasNewlyDroppedBranch_[association->branchType()] = true;
         }
       }
+
+      // Now fill in a mapping needed in the case that a branch was dropped while its EDAlias was kept.
+      ProductSelector::fillDroppedToKept(preg, trueBranchIDToKeptBranchDesc, droppedBranchIDToKeptBranchID_);
+
+      thinnedAssociationsHelper_->updateFromParentProcess(thinnedAssociationsHelper, keepAssociation_, droppedBranchIDToKeptBranchID_);
     }
-    
+
+    void OutputModuleBase::keepThisBranch(BranchDescription const& desc,
+                        std::map<BranchID, BranchDescription const*>& trueBranchIDToKeptBranchDesc,
+                        std::set<BranchID>& keptProductsInEvent) {
+
+      ProductSelector::checkForDuplicateKeptBranch(desc,
+                                                   trueBranchIDToKeptBranchDesc);
+
+      switch (desc.branchType()) {
+      case InEvent:
+        {
+          if(desc.produced()) {
+            keptProductsInEvent.insert(desc.originalBranchID());
+          } else {
+            keptProductsInEvent.insert(desc.branchID());
+          }
+          consumes(TypeToGet{desc.unwrappedTypeID(),PRODUCT_TYPE},
+                   InputTag{desc.moduleLabel(),
+                       desc.productInstanceName(),
+                       desc.processName()});
+          break;
+        }
+      case InLumi:
+        {
+          consumes<InLumi>(TypeToGet{desc.unwrappedTypeID(),PRODUCT_TYPE},
+                           InputTag(desc.moduleLabel(),
+                                    desc.productInstanceName(),
+                                    desc.processName()));
+          break;
+        }
+      case InRun:
+        {
+          consumes<InRun>(TypeToGet{desc.unwrappedTypeID(),PRODUCT_TYPE},
+                          InputTag(desc.moduleLabel(),
+                                   desc.productInstanceName(),
+                                   desc.processName()));
+          break;
+        }
+      default:
+        assert(false);
+        break;
+      }
+      // Now put it in the list of selected branches.
+      keptProducts_[desc.branchType()].push_back(&desc);
+    }
+
     OutputModuleBase::~OutputModuleBase() { }
     
     SharedResourcesAcquirer OutputModuleBase::createAcquirer() {
@@ -319,6 +329,11 @@ namespace edm {
       return origBranchIDLists_;
     }
     
+    ThinnedAssociationsHelper const*
+    OutputModuleBase::thinnedAssociationsHelper() const {
+      return thinnedAssociationsHelper_.get();
+    }
+
     ModuleDescription const&
     OutputModuleBase::description() const {
       return moduleDescription_;

--- a/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
@@ -214,5 +214,14 @@ namespace edm {
         m->postForkReacquireResources(iChildIndex,iNumberOfChildren);
       }
     }
+
+    template< typename T>
+    void
+    ProducingModuleAdaptorBase<T>::doRegisterThinnedAssociations(ProductRegistry const& registry,
+                                                                 ThinnedAssociationsHelper& helper) {
+      assert(not m_streamModules.empty());
+      auto mod = m_streamModules[0];
+      mod->registerThinnedAssociations(registry, helper);
+    }
   }
 }

--- a/FWCore/Framework/test/Event_t.cpp
+++ b/FWCore/Framework/test/Event_t.cpp
@@ -17,6 +17,7 @@ Test program for edm::Event.
 #include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
 #include "DataFormats/Provenance/interface/RunAuxiliary.h"
+#include "DataFormats/Provenance/interface/ThinnedAssociationsHelper.h"
 #include "DataFormats/Provenance/interface/Timestamp.h"
 #include "DataFormats/TestObjects/interface/Thing.h"
 #include "DataFormats/TestObjects/interface/ToyProducts.h"
@@ -150,6 +151,7 @@ class testEvent: public CppUnit::TestFixture {
 
   std::shared_ptr<ProductRegistry>   availableProducts_;
   std::shared_ptr<BranchIDListHelper> branchIDListHelper_;
+  std::shared_ptr<ThinnedAssociationsHelper> thinnedAssociationsHelper_;
   std::shared_ptr<EventPrincipal>    principal_;
   std::shared_ptr<Event>             currentEvent_;
   std::shared_ptr<ModuleDescription> currentModuleDescription_;
@@ -234,6 +236,7 @@ testEvent::addProduct(std::unique_ptr<T> product,
 testEvent::testEvent() :
   availableProducts_(new ProductRegistry()),
   branchIDListHelper_(new BranchIDListHelper()),
+  thinnedAssociationsHelper_(new ThinnedAssociationsHelper()),
   principal_(),
   currentEvent_(),
   currentModuleDescription_(),
@@ -373,7 +376,7 @@ void testEvent::setUp() {
   lbp->setRunPrincipal(rp);
   EventAuxiliary eventAux(id, uuid, time, true);
   const_cast<ProcessHistoryID &>(eventAux.processHistoryID()) = processHistoryID;
-  principal_.reset(new edm::EventPrincipal(preg, branchIDListHelper_, pc, &historyAppender_,edm::StreamID::invalidStreamID()));
+  principal_.reset(new edm::EventPrincipal(preg, branchIDListHelper_, thinnedAssociationsHelper_, pc, &historyAppender_,edm::StreamID::invalidStreamID()));
   principal_->fillEventPrincipal(eventAux, processHistoryRegistry_);
   principal_->setLuminosityBlockPrincipal(lbp);
   ModuleCallingContext mcc(currentModuleDescription_.get());

--- a/FWCore/Framework/test/event_getrefbeforeput_t.cppunit.cc
+++ b/FWCore/Framework/test/event_getrefbeforeput_t.cppunit.cc
@@ -12,6 +12,7 @@ Test of the EventPrincipal class.
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
 #include "DataFormats/Provenance/interface/BranchDescription.h"
 #include "DataFormats/Provenance/interface/BranchIDListHelper.h"
+#include "DataFormats/Provenance/interface/ThinnedAssociationsHelper.h"
 #include "DataFormats/Provenance/interface/Timestamp.h"
 #include "DataFormats/TestObjects/interface/ToyProducts.h"
 
@@ -66,6 +67,7 @@ void testEventGetRefBeforePut::failGetProductNotRegisteredTest() {
   preg->setFrozen();
   auto branchIDListHelper = std::make_shared<edm::BranchIDListHelper>();
   branchIDListHelper->updateFromRegistry(*preg);
+  auto thinnedAssociationsHelper = std::make_shared<edm::ThinnedAssociationsHelper>();
   edm::EventID col(1L, 1L, 1L);
   std::string uuid = edm::createGlobalIdentifier();
   edm::Timestamp fakeTime;
@@ -77,7 +79,7 @@ void testEventGetRefBeforePut::failGetProductNotRegisteredTest() {
   auto lbp = std::make_shared<edm::LuminosityBlockPrincipal>(lumiAux, pregc, pc, &historyAppender_,0);
   lbp->setRunPrincipal(rp);
   edm::EventAuxiliary eventAux(col, uuid, fakeTime, true);
-  edm::EventPrincipal ep(pregc, branchIDListHelper, pc, &historyAppender_,edm::StreamID::invalidStreamID());
+  edm::EventPrincipal ep(pregc, branchIDListHelper, thinnedAssociationsHelper, pc, &historyAppender_,edm::StreamID::invalidStreamID());
   edm::ProcessHistoryRegistry phr;
   ep.fillEventPrincipal(eventAux, phr);
   ep.setLuminosityBlockPrincipal(lbp);
@@ -136,6 +138,7 @@ void testEventGetRefBeforePut::getRefTest() {
   preg->setFrozen();
   auto branchIDListHelper = std::make_shared<edm::BranchIDListHelper>();
   branchIDListHelper->updateFromRegistry(*preg);
+  auto thinnedAssociationsHelper = std::make_shared<edm::ThinnedAssociationsHelper>();
   edm::EventID col(1L, 1L, 1L);
   std::string uuid = edm::createGlobalIdentifier();
   edm::Timestamp fakeTime;
@@ -148,7 +151,7 @@ void testEventGetRefBeforePut::getRefTest() {
   auto lbp = std::make_shared<edm::LuminosityBlockPrincipal>(lumiAux, pregc, pc, &historyAppender_,0);
   lbp->setRunPrincipal(rp);
   edm::EventAuxiliary eventAux(col, uuid, fakeTime, true);
-  edm::EventPrincipal ep(pregc, branchIDListHelper, pc, &historyAppender_,edm::StreamID::invalidStreamID());
+  edm::EventPrincipal ep(pregc, branchIDListHelper, thinnedAssociationsHelper, pc, &historyAppender_,edm::StreamID::invalidStreamID());
   edm::ProcessHistoryRegistry phr;
   ep.fillEventPrincipal(eventAux, phr);
   ep.setLuminosityBlockPrincipal(lbp);

--- a/FWCore/Framework/test/eventprincipal_t.cppunit.cc
+++ b/FWCore/Framework/test/eventprincipal_t.cppunit.cc
@@ -19,6 +19,7 @@ Test of the EventPrincipal class.
 #include "DataFormats/Provenance/interface/Timestamp.h"
 #include "DataFormats/Provenance/interface/ProductProvenance.h"
 #include "DataFormats/Provenance/interface/RunAuxiliary.h"
+#include "DataFormats/Provenance/interface/ThinnedAssociationsHelper.h"
 #include "DataFormats/TestObjects/interface/ToyProducts.h"
 #include "FWCore/Common/interface/Provenance.h"
 #include "FWCore/Framework/interface/EventPrincipal.h"
@@ -155,6 +156,7 @@ void test_ep::setUp() {
   pProductRegistry_->setFrozen();
   auto branchIDListHelper = std::make_shared<edm::BranchIDListHelper>();
   branchIDListHelper->updateFromRegistry(*pProductRegistry_);
+  auto thinnedAssociationsHelper = std::make_shared<edm::ThinnedAssociationsHelper>();
 
   // Put products we'll look for into the EventPrincipal.
   {
@@ -189,7 +191,7 @@ void test_ep::setUp() {
     auto lbp = std::make_shared<edm::LuminosityBlockPrincipal>(lumiAux, pProductRegistry_, *process, &historyAppender_,0);
     lbp->setRunPrincipal(rp);
     edm::EventAuxiliary eventAux(eventID_, uuid, now, true);
-    pEvent_.reset(new edm::EventPrincipal(pProductRegistry_, branchIDListHelper, *process, &historyAppender_,edm::StreamID::invalidStreamID()));
+    pEvent_.reset(new edm::EventPrincipal(pProductRegistry_, branchIDListHelper, thinnedAssociationsHelper, *process, &historyAppender_,edm::StreamID::invalidStreamID()));
     edm::ProcessHistoryRegistry phr;
     pEvent_->fillEventPrincipal(eventAux, phr);
     pEvent_->setLuminosityBlockPrincipal(lbp);

--- a/FWCore/Framework/test/generichandle_t.cppunit.cc
+++ b/FWCore/Framework/test/generichandle_t.cppunit.cc
@@ -11,6 +11,7 @@ Test of GenericHandle class.
 #include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
 #include "DataFormats/Provenance/interface/RunAuxiliary.h"
+#include "DataFormats/Provenance/interface/ThinnedAssociationsHelper.h"
 #include "DataFormats/Provenance/interface/Timestamp.h"
 #include "DataFormats/TestObjects/interface/ToyProducts.h"
 
@@ -90,8 +91,9 @@ void testGenericHandle::failgetbyLabelTest() {
   lbp->setRunPrincipal(rp);
   auto branchIDListHelper = std::make_shared<edm::BranchIDListHelper>();
   branchIDListHelper->updateFromRegistry(*preg);
+  auto thinnedAssociationsHelper = std::make_shared<edm::ThinnedAssociationsHelper>();
   edm::EventAuxiliary eventAux(id, uuid, time, true);
-  edm::EventPrincipal ep(preg, branchIDListHelper, pc, &historyAppender_,edm::StreamID::invalidStreamID());
+  edm::EventPrincipal ep(preg, branchIDListHelper, thinnedAssociationsHelper, pc, &historyAppender_,edm::StreamID::invalidStreamID());
   edm::ProcessHistoryRegistry phr; 
   ep.fillEventPrincipal(eventAux, phr);
   ep.setLuminosityBlockPrincipal(lbp);
@@ -164,6 +166,7 @@ void testGenericHandle::getbyLabelTest() {
   preg->setFrozen();
   auto branchIDListHelper = std::make_shared<edm::BranchIDListHelper>();
   branchIDListHelper->updateFromRegistry(*preg);
+  auto thinnedAssociationsHelper = std::make_shared<edm::ThinnedAssociationsHelper>();
 
   edm::ProductRegistry::ProductList const& pl = preg->productList();
   edm::BranchKey const bk(product);
@@ -180,7 +183,7 @@ void testGenericHandle::getbyLabelTest() {
   auto lbp = std::make_shared<edm::LuminosityBlockPrincipal>(lumiAux, pregc, pc, &historyAppender_,0);
   lbp->setRunPrincipal(rp);
   edm::EventAuxiliary eventAux(col, uuid, fakeTime, true);
-  edm::EventPrincipal ep(pregc, branchIDListHelper, pc, &historyAppender_,edm::StreamID::invalidStreamID());
+  edm::EventPrincipal ep(pregc, branchIDListHelper, thinnedAssociationsHelper, pc, &historyAppender_,edm::StreamID::invalidStreamID());
   edm::ProcessHistoryRegistry phr; 
   ep.fillEventPrincipal(eventAux, phr);
   ep.setLuminosityBlockPrincipal(lbp);

--- a/FWCore/Framework/test/global_module_t.cppunit.cc
+++ b/FWCore/Framework/test/global_module_t.cppunit.cc
@@ -18,6 +18,7 @@
 #include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
 #include "DataFormats/Provenance/interface/BranchIDListHelper.h"
+#include "DataFormats/Provenance/interface/ThinnedAssociationsHelper.h"
 #include "FWCore/Framework/interface/HistoryAppender.h"
 #include "FWCore/ServiceRegistry/interface/ParentContext.h"
 #include "FWCore/ServiceRegistry/interface/StreamContext.h"
@@ -92,6 +93,7 @@ private:
   edm::ProcessConfiguration m_procConfig;
   std::shared_ptr<edm::ProductRegistry> m_prodReg;
   std::shared_ptr<edm::BranchIDListHelper> m_idHelper;
+  std::shared_ptr<edm::ThinnedAssociationsHelper> m_associationsHelper;
   std::unique_ptr<edm::EventPrincipal> m_ep;
   edm::HistoryAppender historyAppender_;
   std::shared_ptr<edm::LuminosityBlockPrincipal> m_lbp;
@@ -343,6 +345,7 @@ CPPUNIT_TEST_SUITE_REGISTRATION(testGlobalModule);
 testGlobalModule::testGlobalModule():
 m_prodReg(new edm::ProductRegistry{}),
 m_idHelper(new edm::BranchIDListHelper{}),
+m_associationsHelper(new edm::ThinnedAssociationsHelper{}),
 m_ep()
 {
   //Setup the principals
@@ -361,6 +364,7 @@ m_ep()
 
   m_ep.reset(new edm::EventPrincipal(m_prodReg,
                                      m_idHelper,
+                                     m_associationsHelper,
                                      m_procConfig,nullptr));
   edm::ProcessHistoryRegistry phr;
   m_ep->fillEventPrincipal(eventAux, phr);

--- a/FWCore/Framework/test/one_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/one_outputmodule_t.cppunit.cc
@@ -17,6 +17,7 @@
 #include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
 #include "DataFormats/Provenance/interface/BranchIDListHelper.h"
+#include "DataFormats/Provenance/interface/ThinnedAssociationsHelper.h"
 #include "FWCore/Framework/interface/HistoryAppender.h"
 #include "FWCore/Utilities/interface/GlobalIdentifier.h"
 #include "FWCore/Framework/interface/TriggerNamesService.h"
@@ -79,6 +80,7 @@ private:
   edm::ProcessConfiguration m_procConfig;
   std::shared_ptr<edm::ProductRegistry> m_prodReg;
   std::shared_ptr<edm::BranchIDListHelper> m_idHelper;
+  std::shared_ptr<edm::ThinnedAssociationsHelper> m_associationsHelper;
   std::unique_ptr<edm::EventPrincipal> m_ep;
   edm::HistoryAppender historyAppender_;
   std::shared_ptr<edm::LuminosityBlockPrincipal> m_lbp;
@@ -230,6 +232,7 @@ CPPUNIT_TEST_SUITE_REGISTRATION(testOneOutputModule);
 testOneOutputModule::testOneOutputModule():
 m_prodReg(new edm::ProductRegistry{}),
 m_idHelper(new edm::BranchIDListHelper{}),
+m_associationsHelper(new edm::ThinnedAssociationsHelper{}),
 m_ep()
 {
   //Setup the principals
@@ -248,6 +251,7 @@ m_ep()
 
   m_ep.reset(new edm::EventPrincipal(m_prodReg,
                                      m_idHelper,
+                                     m_associationsHelper,
                                      m_procConfig,nullptr));
   edm::ProcessHistoryRegistry phr;
   m_ep->fillEventPrincipal(eventAux, phr);

--- a/FWCore/Framework/test/stream_module_t.cppunit.cc
+++ b/FWCore/Framework/test/stream_module_t.cppunit.cc
@@ -19,6 +19,7 @@
 #include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
 #include "DataFormats/Provenance/interface/BranchIDListHelper.h"
+#include "DataFormats/Provenance/interface/ThinnedAssociationsHelper.h"
 #include "FWCore/Framework/interface/HistoryAppender.h"
 #include "FWCore/ServiceRegistry/interface/ParentContext.h"
 #include "FWCore/ServiceRegistry/interface/StreamContext.h"
@@ -91,6 +92,7 @@ private:
   edm::ProcessConfiguration m_procConfig;
   std::shared_ptr<edm::ProductRegistry> m_prodReg;
   std::shared_ptr<edm::BranchIDListHelper> m_idHelper;
+  std::shared_ptr<edm::ThinnedAssociationsHelper> m_associationsHelper;
   std::unique_ptr<edm::EventPrincipal> m_ep;
   edm::HistoryAppender historyAppender_;
   std::shared_ptr<edm::LuminosityBlockPrincipal> m_lbp;
@@ -366,6 +368,7 @@ static const edm::StreamID s_streamID0 = makeID();
 testStreamModule::testStreamModule():
 m_prodReg(new edm::ProductRegistry{}),
 m_idHelper(new edm::BranchIDListHelper{}),
+m_associationsHelper(new edm::ThinnedAssociationsHelper{}),
 m_ep()
 {
   //Setup the principals
@@ -390,6 +393,7 @@ m_ep()
   
   m_ep.reset(new edm::EventPrincipal(m_prodReg,
                                      m_idHelper,
+                                     m_associationsHelper,
                                      m_procConfig,nullptr,*pID));
   edm::ProcessHistoryRegistry phr;
   m_ep->fillEventPrincipal(eventAux, phr);

--- a/FWCore/Integration/test/BuildFile.xml
+++ b/FWCore/Integration/test/BuildFile.xml
@@ -46,6 +46,10 @@
     <flags   TEST_RUNNER_ARGS=" /bin/bash FWCore/Integration/test run_SeriesOfProcesses.sh"/>
     <use   name="FWCore/Utilities"/>
   </bin>
+  <bin   file="TestIntegration.cpp" name="TestIntegrationThinningTests">
+    <flags   TEST_RUNNER_ARGS=" /bin/bash FWCore/Integration/test run_ThinningTests.sh"/>
+    <use   name="FWCore/Utilities"/>
+  </bin>
   <bin   file="TestIntegration.cpp" name="TestIntegrationGetBy">
     <flags   TEST_RUNNER_ARGS=" /bin/bash FWCore/Integration/test run_TestGetBy.sh"/>
     <use   name="FWCore/Utilities"/>
@@ -98,7 +102,7 @@
     <use   name="FWCore/ParameterSet"/>
     <use   name="FWCore/Framework"/>
   </library>
-  <library   file="ThingProducer.cc,ThingAlgorithm.cc" name="TestThingProducer">
+  <library   file="ThingProducer.cc,ThingAlgorithm.cc,TrackOfThingsProducer.cc,ThinningThingProducer.cc,ThinningTestAnalyzer.cc,WhatsIt.cc,GadgetRcd.cc" name="TestThingProducer">
     <flags   EDM_PLUGIN="1"/>
     <use   name="FWCore/Framework"/>
   </library>

--- a/FWCore/Integration/test/ThingAlgorithm.cc
+++ b/FWCore/Integration/test/ThingAlgorithm.cc
@@ -3,8 +3,8 @@
 
 namespace edmtest {
   void ThingAlgorithm::run(ThingCollection & thingCollection) {
-    thingCollection.reserve(20);
-    for (int i = 0; i < 20; ++i) {
+    thingCollection.reserve(nThings_);
+    for (int i = 0; i < nThings_; ++i) {
       Thing tc;
       tc.a = i+offset;
       thingCollection.push_back(tc);

--- a/FWCore/Integration/test/ThingAlgorithm.h
+++ b/FWCore/Integration/test/ThingAlgorithm.h
@@ -9,8 +9,8 @@
 namespace edmtest {
   class ThingAlgorithm {
   public:
-    ThingAlgorithm(long iOffsetDelta = 0) : theDebugLevel(0), offset(0), offsetDelta(iOffsetDelta) {}
-    
+  ThingAlgorithm(long iOffsetDelta = 0, int nThings = 20) : theDebugLevel(0), offset(0), offsetDelta(iOffsetDelta),
+      nThings_(nThings) {}
 
     /// Runs the algorithm and returns a list of Things
     /// The user declares the vector and calls this method.
@@ -19,6 +19,7 @@ namespace edmtest {
     int    theDebugLevel;
     long   offset;
     long   offsetDelta;
+    int    nThings_;
   };
 
 }

--- a/FWCore/Integration/test/ThingProducer.cc
+++ b/FWCore/Integration/test/ThingProducer.cc
@@ -7,7 +7,8 @@
 
 namespace edmtest {
   ThingProducer::ThingProducer(edm::ParameterSet const& iConfig): 
-  alg_(iConfig.getParameter<int>("offsetDelta")), //this really should be tracked, but I want backwards compatibility
+  alg_(iConfig.getParameter<int>("offsetDelta"), //this really should be tracked, but I want backwards compatibility
+       iConfig.getParameter<int>("nThings")),
   noPut_(iConfig.getUntrackedParameter<bool>("noPut")) // used for testing with missing products
   {
     produces<ThingCollection>();
@@ -91,6 +92,7 @@ namespace edmtest {
   void ThingProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
     edm::ParameterSetDescription desc;
     desc.add<int>("offsetDelta",0)->setComment("How much extra to increment the value used when creating Things for a new container. E.g. the last value used to create Thing from the previous event is incremented by 'offsetDelta' to compute the value to use of the first Thing created in the next Event.");
+    desc.add<int>("nThings",20)->setComment("How many Things to put in each collection");
     desc.addUntracked<bool>("noPut",false)->setComment("If true, data is not put into the Principal. This is used to test missing products.");
     descriptions.add("thingProd", desc);
   }

--- a/FWCore/Integration/test/ThinningTest1_cfg.py
+++ b/FWCore/Integration/test/ThinningTest1_cfg.py
@@ -1,0 +1,406 @@
+# This process is the first step of a test that involves multiple
+# processing steps. It tests the thinning collections and
+# redirecting Refs, Ptrs, and RefToBases.
+#
+# Produce 15 thinned collections
+#
+#   Collection A contains Things 0-8
+#   Collection B contains Things 0-3 and made from collection A
+#   Collection C contains Things 4-7 and made from collection A
+#
+# x Collection D contains Things 10-18
+#   Collection E contains Things 10-14 and made from collection D
+#   Collection F contains Things 14-17 and made from collection D
+#
+#   Collection G contains Things 20-28
+# x Collection H contains Things 20-23 and made from collection G
+# x Collection I contains Things 24-27 and made from collection G
+#
+# x Collection J contains Things 30-38
+# x Collection K contains Things 30-33 and made from collection J
+# x Collection L contains Things 34-37 and made from collection J
+#
+# x Collection M contains Things 40-48
+# x Collection N contains Things 40-43 and made from collection M
+#   Collection O contains Things 44-47 and made from collection M
+#
+# The collections marked with an x will get deleted in the next
+# processing step.
+#
+# The Things kept are set by creating TracksOfThings which
+# reference them and using those in the selection of a
+# Thinning Producer.
+#
+# The ThinningTestAnalyzer checks that things are working as
+# they are supposed to work.
+
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("PROD")
+
+process.options = cms.untracked.PSet(
+    numberOfStreams = cms.untracked.uint32(1)
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(3)
+)
+
+process.source = cms.Source("EmptySource")
+
+process.WhatsItESProducer = cms.ESProducer("WhatsItESProducer")
+
+process.DoodadESSource = cms.ESSource("DoodadESSource")
+
+process.thingProducer = cms.EDProducer("ThingProducer",
+                                       offsetDelta = cms.int32(100),
+                                       nThings = cms.int32(50)
+)
+process.thingProducer2 = cms.EDProducer("ThingProducer",
+                                        offsetDelta = cms.int32(100),
+                                        nThings = cms.int32(50)
+)
+
+process.thingProducer2alias = cms.EDAlias(
+  thingProducer2 = cms.VPSet(
+    cms.PSet(type = cms.string('edmtestThings'))
+  )
+)
+
+process.trackOfThingsProducerA = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(0, 1, 2, 3, 4, 5, 6, 7, 8)
+)
+
+process.trackOfThingsProducerB = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(0, 1, 2, 3)
+)
+
+process.trackOfThingsProducerC = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(4, 5, 6, 7)
+)
+
+process.trackOfThingsProducerD = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(10, 11, 12, 13, 14, 15, 16, 17, 18)
+)
+
+process.trackOfThingsProducerDPlus = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(10, 11, 12, 13, 14, 15, 16, 17, 18, 21)
+)
+
+process.trackOfThingsProducerE = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(10, 11, 12, 13, 14)
+)
+
+process.trackOfThingsProducerF = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(14, 15, 16, 17)
+)
+
+process.trackOfThingsProducerG = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(20, 21, 22, 23, 24, 25, 26, 27, 28)
+)
+
+process.trackOfThingsProducerH = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(20, 21, 22, 23)
+)
+
+process.trackOfThingsProducerI = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(24, 25, 26, 27)
+)
+
+process.trackOfThingsProducerJ = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(30, 31, 32, 33, 34, 35, 36, 37, 38)
+)
+
+process.trackOfThingsProducerK = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(30, 31, 32, 33)
+)
+
+process.trackOfThingsProducerL = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(34, 35, 36, 37)
+)
+
+process.trackOfThingsProducerM = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(40, 41, 42, 43, 44, 45, 46, 47, 48)
+)
+
+process.trackOfThingsProducerN = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(40, 41, 42, 43)
+)
+
+process.trackOfThingsProducerO = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(44, 45, 46, 47)
+)
+
+process.trackOfThingsProducerD2 = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer2'),
+    keysToReference = cms.vuint32(10, 11, 12, 13, 14, 15, 16, 17, 18)
+)
+
+process.trackOfThingsProducerE2 = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer2'),
+    keysToReference = cms.vuint32(10, 11, 12, 13, 14)
+)
+
+process.trackOfThingsProducerF2 = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer2'),
+    keysToReference = cms.vuint32(14, 15, 16, 17)
+)
+
+process.thinningThingProducerA = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    trackTag = cms.InputTag('trackOfThingsProducerA'),
+    offsetToThinnedKey = cms.uint32(0),
+    expectedCollectionSize = cms.uint32(50)
+)
+
+process.thinningThingProducerB = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thinningThingProducerA'),
+    trackTag = cms.InputTag('trackOfThingsProducerB'),
+    offsetToThinnedKey = cms.uint32(0),
+    expectedCollectionSize = cms.uint32(9)
+)
+
+process.thinningThingProducerC = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thinningThingProducerA'),
+    trackTag = cms.InputTag('trackOfThingsProducerC'),
+    offsetToThinnedKey = cms.uint32(0),
+    expectedCollectionSize = cms.uint32(9)
+)
+
+process.thinningThingProducerD = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    trackTag = cms.InputTag('trackOfThingsProducerD'),
+    offsetToThinnedKey = cms.uint32(0),
+    expectedCollectionSize = cms.uint32(50)
+)
+
+process.thinningThingProducerE = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thinningThingProducerD'),
+    trackTag = cms.InputTag('trackOfThingsProducerE'),
+    offsetToThinnedKey = cms.uint32(10),
+    expectedCollectionSize = cms.uint32(9)
+)
+
+process.thinningThingProducerF = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thinningThingProducerD'),
+    trackTag = cms.InputTag('trackOfThingsProducerF'),
+    offsetToThinnedKey = cms.uint32(10),
+    expectedCollectionSize = cms.uint32(9)
+)
+
+process.thinningThingProducerG = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    trackTag = cms.InputTag('trackOfThingsProducerG'),
+    offsetToThinnedKey = cms.uint32(0),
+    expectedCollectionSize = cms.uint32(50)
+)
+
+process.thinningThingProducerH = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thinningThingProducerG'),
+    trackTag = cms.InputTag('trackOfThingsProducerH'),
+    offsetToThinnedKey = cms.uint32(20),
+    expectedCollectionSize = cms.uint32(9)
+)
+
+process.thinningThingProducerI = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thinningThingProducerG'),
+    trackTag = cms.InputTag('trackOfThingsProducerI'),
+    offsetToThinnedKey = cms.uint32(20),
+    expectedCollectionSize = cms.uint32(9)
+)
+
+process.thinningThingProducerJ = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    trackTag = cms.InputTag('trackOfThingsProducerJ'),
+    offsetToThinnedKey = cms.uint32(0),
+    expectedCollectionSize = cms.uint32(50)
+)
+
+process.thinningThingProducerK = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thinningThingProducerJ'),
+    trackTag = cms.InputTag('trackOfThingsProducerK'),
+    offsetToThinnedKey = cms.uint32(30),
+    expectedCollectionSize = cms.uint32(9)
+)
+
+process.thinningThingProducerL = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thinningThingProducerJ'),
+    trackTag = cms.InputTag('trackOfThingsProducerL'),
+    offsetToThinnedKey = cms.uint32(30),
+    expectedCollectionSize = cms.uint32(9)
+)
+
+process.thinningThingProducerM = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    trackTag = cms.InputTag('trackOfThingsProducerM'),
+    offsetToThinnedKey = cms.uint32(0),
+    expectedCollectionSize = cms.uint32(50)
+)
+
+process.aliasM = cms.EDAlias(
+  thinningThingProducerM = cms.VPSet(
+    cms.PSet(type = cms.string('edmtestThings')),
+    # the next one should get ignored
+    cms.PSet(type = cms.string('edmThinnedAssociation')) 
+  )
+)
+
+process.thinningThingProducerN = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thinningThingProducerM'),
+    trackTag = cms.InputTag('trackOfThingsProducerN'),
+    offsetToThinnedKey = cms.uint32(40),
+    expectedCollectionSize = cms.uint32(9)
+)
+
+process.aliasN = cms.EDAlias(
+  thinningThingProducerN = cms.VPSet(
+    cms.PSet(type = cms.string('edmtestThings')),
+    # the next one should get ignored
+    cms.PSet(type = cms.string('edmThinnedAssociation')) 
+  )
+)
+
+process.thinningThingProducerO = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('aliasM'),
+    trackTag = cms.InputTag('trackOfThingsProducerO'),
+    offsetToThinnedKey = cms.uint32(40),
+    expectedCollectionSize = cms.uint32(9)
+)
+
+process.aliasO = cms.EDAlias(
+  thinningThingProducerO = cms.VPSet(
+    cms.PSet(type = cms.string('edmtestThings')),
+    # the next one should get ignored
+    cms.PSet(type = cms.string('edmThinnedAssociation')) 
+  )
+)
+
+process.testA = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thingProducer'),
+    thinnedTag = cms.InputTag('thinningThingProducerA'),
+    associationTag = cms.InputTag('thinningThingProducerA'),
+    trackTag = cms.InputTag('trackOfThingsProducerA'),
+    expectedParentContent = cms.vint32( 0,  1,  2,  3,  4,  5,  6,  7,  8,  9,
+                                       10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+                                       20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
+                                       30, 31, 32, 33, 34, 35, 36, 37, 38, 39,
+                                       40, 41, 42, 43, 44, 45, 46, 47, 48, 49
+    ),
+    expectedThinnedContent = cms.vint32(0, 1, 2, 3, 4, 5, 6, 7, 8),
+    expectedIndexesIntoParent = cms.vuint32(0, 1, 2, 3, 4, 5, 6, 7, 8),
+    expectedValues = cms.vint32(0, 1, 2, 3, 4, 5, 6, 7, 8)
+)
+
+process.testB = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerA'),
+    thinnedTag = cms.InputTag('thinningThingProducerB'),
+    associationTag = cms.InputTag('thinningThingProducerB'),
+    trackTag = cms.InputTag('trackOfThingsProducerB'),
+    expectedParentContent = cms.vint32( 0,  1,  2,  3,  4,  5,  6,  7,  8),
+    expectedThinnedContent = cms.vint32(0, 1, 2, 3),
+    expectedIndexesIntoParent = cms.vuint32(0, 1, 2, 3),
+    expectedValues = cms.vint32(0, 1, 2, 3)
+)
+
+process.testC = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerA'),
+    thinnedTag = cms.InputTag('thinningThingProducerC'),
+    associationTag = cms.InputTag('thinningThingProducerC'),
+    trackTag = cms.InputTag('trackOfThingsProducerC'),
+    expectedParentContent = cms.vint32( 0,  1,  2,  3,  4,  5,  6,  7,  8),
+    expectedThinnedContent = cms.vint32(4, 5, 6, 7),
+    expectedIndexesIntoParent = cms.vuint32(4, 5, 6, 7),
+    expectedValues = cms.vint32(4, 5, 6, 7)
+)
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testThinningTest1.root'),
+    outputCommands = cms.untracked.vstring(
+        'keep *',
+        'drop *_thingProducer2_*_*',
+        'drop *_thinningThingProducerM_*_*',
+        'drop *_thinningThingProducerN_*_*',
+        'drop *_thinningThingProducerO_*_*'
+    )
+)
+
+process.out2 = cms.OutputModule("EventStreamFileWriter",
+    fileName = cms.untracked.string('testThinningStreamerout.dat'),
+    compression_level = cms.untracked.int32(1),
+    use_compression = cms.untracked.bool(True),
+    max_event_size = cms.untracked.int32(7000000),
+    outputCommands = cms.untracked.vstring(
+        'keep *',
+        'drop *_thingProducer_*_*',
+        'drop *_thingProducer2_*_*',
+        'drop *_thinningThingProducerD_*_*',
+        'drop *_thinningThingProducerH_*_*',
+        'drop *_thinningThingProducerI_*_*',
+        'drop *_thinningThingProducerJ_*_*',
+        'drop *_thinningThingProducerK_*_*',
+        'drop *_thinningThingProducerL_*_*',
+        'drop *_thinningThingProducerM_*_*',
+        'drop *_thinningThingProducerN_*_*',
+        'drop *_thinningThingProducerO_*_*',
+        'drop *_aliasM_*_*',
+        'drop *_aliasN_*_*'
+    )
+)
+
+process.p = cms.Path(process.thingProducer * process.thingProducer2
+                                           * process.trackOfThingsProducerA
+                                           * process.trackOfThingsProducerB
+                                           * process.trackOfThingsProducerC
+                                           * process.trackOfThingsProducerD
+                                           * process.trackOfThingsProducerDPlus
+                                           * process.trackOfThingsProducerE
+                                           * process.trackOfThingsProducerF
+                                           * process.trackOfThingsProducerG
+                                           * process.trackOfThingsProducerH
+                                           * process.trackOfThingsProducerI
+                                           * process.trackOfThingsProducerJ
+                                           * process.trackOfThingsProducerK
+                                           * process.trackOfThingsProducerL
+                                           * process.trackOfThingsProducerM
+                                           * process.trackOfThingsProducerN
+                                           * process.trackOfThingsProducerO
+                                           * process.trackOfThingsProducerD2
+                                           * process.trackOfThingsProducerE2
+                                           * process.trackOfThingsProducerF2
+                                           * process.thinningThingProducerA
+                                           * process.thinningThingProducerB
+                                           * process.thinningThingProducerC
+                                           * process.thinningThingProducerD
+                                           * process.thinningThingProducerE
+                                           * process.thinningThingProducerF
+                                           * process.thinningThingProducerG
+                                           * process.thinningThingProducerH
+                                           * process.thinningThingProducerI
+                                           * process.thinningThingProducerJ
+                                           * process.thinningThingProducerK
+                                           * process.thinningThingProducerL
+                                           * process.thinningThingProducerM
+                                           * process.thinningThingProducerN
+                                           * process.thinningThingProducerO
+                                           * process.testA
+                                           * process.testB
+                                           * process.testC
+                    )
+
+process.endPath = cms.EndPath(process.out * process.out2)

--- a/FWCore/Integration/test/ThinningTest2_cfg.py
+++ b/FWCore/Integration/test/ThinningTest2_cfg.py
@@ -1,0 +1,124 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.options = cms.untracked.PSet(
+    numberOfStreams = cms.untracked.uint32(1)
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(3)
+)
+
+process.source = cms.Source("PoolSource",
+  fileNames = cms.untracked.vstring('file:testThinningTest1.root')
+)
+
+process.WhatsItESProducer = cms.ESProducer("WhatsItESProducer")
+
+process.DoodadESSource = cms.ESSource("DoodadESSource")
+
+# Produce some products that have the same branch name except process
+# These test disambiguation when there are multiple entries
+# in the ThinnedAssociationsHelper with the same parent BranchID.
+process.thingProducer = cms.EDProducer("ThingProducer",
+                                       offsetDelta = cms.int32(2000),
+                                       nThings = cms.int32(50)
+)
+
+process.thinningThingProducerD = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    trackTag = cms.InputTag('trackOfThingsProducerD'),
+    offsetToThinnedKey = cms.uint32(0),
+    expectedCollectionSize = cms.uint32(50)
+)
+
+process.thinningThingProducerETEST = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thinningThingProducerD'),
+    trackTag = cms.InputTag('trackOfThingsProducerE'),
+    offsetToThinnedKey = cms.uint32(10),
+    expectedCollectionSize = cms.uint32(9)
+)
+
+process.thinningThingProducerFTEST = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thinningThingProducerD'),
+    trackTag = cms.InputTag('trackOfThingsProducerF'),
+    offsetToThinnedKey = cms.uint32(10),
+    expectedCollectionSize = cms.uint32(9)
+)
+
+process.thinningThingProducerD2 = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thingProducer2alias'),
+    trackTag = cms.InputTag('trackOfThingsProducerD2'),
+    offsetToThinnedKey = cms.uint32(0),
+    expectedCollectionSize = cms.uint32(50)
+)
+
+process.thinningThingProducerD2alias = cms.EDAlias(
+  thinningThingProducerD2 = cms.VPSet(
+    cms.PSet(type = cms.string('edmtestThings'))
+  )
+)
+
+process.testA = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thingProducer', '', 'PROD'),
+    thinnedTag = cms.InputTag('thinningThingProducerA'),
+    associationTag = cms.InputTag('thinningThingProducerA'),
+    trackTag = cms.InputTag('trackOfThingsProducerA'),
+    expectedParentContent = cms.vint32( 0,  1,  2,  3,  4,  5,  6,  7,  8,  9,
+                                       10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+                                       20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
+                                       30, 31, 32, 33, 34, 35, 36, 37, 38, 39,
+                                       40, 41, 42, 43, 44, 45, 46, 47, 48, 49
+    ),
+    expectedThinnedContent = cms.vint32(0, 1, 2, 3, 4, 5, 6, 7, 8),
+    expectedIndexesIntoParent = cms.vuint32(0, 1, 2, 3, 4, 5, 6, 7, 8),
+    expectedValues = cms.vint32(0, 1, 2, 3, 4, 5, 6, 7, 8)
+)
+
+process.testB = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerA'),
+    thinnedTag = cms.InputTag('thinningThingProducerB'),
+    associationTag = cms.InputTag('thinningThingProducerB'),
+    trackTag = cms.InputTag('trackOfThingsProducerB'),
+    expectedParentContent = cms.vint32( 0,  1,  2,  3,  4,  5,  6,  7,  8),
+    expectedThinnedContent = cms.vint32(0, 1, 2, 3),
+    expectedIndexesIntoParent = cms.vuint32(0, 1, 2, 3),
+    expectedValues = cms.vint32(0, 1, 2, 3)
+)
+
+process.testC = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerA'),
+    thinnedTag = cms.InputTag('thinningThingProducerC'),
+    associationTag = cms.InputTag('thinningThingProducerC'),
+    trackTag = cms.InputTag('trackOfThingsProducerC'),
+    expectedParentContent = cms.vint32( 0,  1,  2,  3,  4,  5,  6,  7,  8),
+    expectedThinnedContent = cms.vint32(4, 5, 6, 7),
+    expectedIndexesIntoParent = cms.vuint32(4, 5, 6, 7),
+    expectedValues = cms.vint32(4, 5, 6, 7)
+)
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testThinningTest2.root'),
+    outputCommands = cms.untracked.vstring(
+        'keep *',
+        'drop *_thingProducer_*_*',
+        'drop *_thinningThingProducerD2_*_*',
+        'drop *_thinningThingProducerD_*_*',
+        'drop *_thinningThingProducerH_*_*',
+        'drop *_thinningThingProducerI_*_*',
+        'drop *_thinningThingProducerJ_*_*',
+        'drop *_thinningThingProducerK_*_*',
+        'drop *_thinningThingProducerL_*_*',
+        'drop *_aliasM_*_*',
+        'drop *_aliasN_*_*',
+    )
+)
+
+process.p = cms.Path(process.thinningThingProducerD2 * process.testA * process.testB * process.testC
+                     * process.thingProducer
+                     * process.thinningThingProducerD
+                     * process.thinningThingProducerETEST
+                     * process.thinningThingProducerFTEST)
+
+process.endPath = cms.EndPath(process.out)

--- a/FWCore/Integration/test/ThinningTest3_cfg.py
+++ b/FWCore/Integration/test/ThinningTest3_cfg.py
@@ -1,0 +1,263 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST3")
+
+process.options = cms.untracked.PSet(
+    numberOfStreams = cms.untracked.uint32(1)
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(3)
+)
+
+process.source = cms.Source("PoolSource",
+  fileNames = cms.untracked.vstring('file:testThinningTest2.root')
+  #secondaryFileNames = cms.untracked.vstring('file:testSeriesOfProcessesPROD1.root')
+)
+
+process.WhatsItESProducer = cms.ESProducer("WhatsItESProducer")
+
+process.DoodadESSource = cms.ESSource("DoodadESSource")
+
+process.thinningThingProducerE2 = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thinningThingProducerD2alias'),
+    trackTag = cms.InputTag('trackOfThingsProducerE2'),
+    offsetToThinnedKey = cms.uint32(10),
+    expectedCollectionSize = cms.uint32(9)
+)
+
+process.thinningThingProducerE2alias = cms.EDAlias(
+  thinningThingProducerE2 = cms.VPSet(
+    cms.PSet(type = cms.string('edmtestThings'))
+  )
+)
+
+process.thinningThingProducerF2 = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thinningThingProducerD2alias'),
+    trackTag = cms.InputTag('trackOfThingsProducerF2'),
+    offsetToThinnedKey = cms.uint32(10),
+    expectedCollectionSize = cms.uint32(9)
+)
+
+process.thinningThingProducerF2alias = cms.EDAlias(
+  thinningThingProducerF2 = cms.VPSet(
+    cms.PSet(type = cms.string('edmtestThings'))
+  )
+)
+
+process.testA = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thingProducer', '', 'PROD'),
+    thinnedTag = cms.InputTag('thinningThingProducerA'),
+    associationTag = cms.InputTag('thinningThingProducerA'),
+    trackTag = cms.InputTag('trackOfThingsProducerA'),
+    parentWasDropped = cms.bool(True),
+    expectedThinnedContent = cms.vint32(0, 1, 2, 3, 4, 5, 6, 7, 8),
+    expectedIndexesIntoParent = cms.vuint32(0, 1, 2, 3, 4, 5, 6, 7, 8),
+    expectedValues = cms.vint32(0, 1, 2, 3, 4, 5, 6, 7, 8)
+)
+
+process.testB = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerA'),
+    thinnedTag = cms.InputTag('thinningThingProducerB'),
+    associationTag = cms.InputTag('thinningThingProducerB'),
+    trackTag = cms.InputTag('trackOfThingsProducerB'),
+    expectedParentContent = cms.vint32( 0,  1,  2,  3,  4,  5,  6,  7,  8),
+    expectedThinnedContent = cms.vint32(0, 1, 2, 3),
+    expectedIndexesIntoParent = cms.vuint32(0, 1, 2, 3),
+    expectedValues = cms.vint32(0, 1, 2, 3)
+)
+
+process.testC = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerA'),
+    thinnedTag = cms.InputTag('thinningThingProducerC'),
+    associationTag = cms.InputTag('thinningThingProducerC'),
+    trackTag = cms.InputTag('trackOfThingsProducerC'),
+    expectedParentContent = cms.vint32( 0,  1,  2,  3,  4,  5,  6,  7,  8),
+    expectedThinnedContent = cms.vint32(4, 5, 6, 7),
+    expectedIndexesIntoParent = cms.vuint32(4, 5, 6, 7),
+    expectedValues = cms.vint32(4, 5, 6, 7)
+)
+
+process.testD = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thingProducer', '', 'PROD'),
+    thinnedTag = cms.InputTag('thinningThingProducerD', '', 'PROD'),
+    associationTag = cms.InputTag('thinningThingProducerD', '', 'PROD'),
+    trackTag = cms.InputTag('trackOfThingsProducerD'),
+    parentWasDropped = cms.bool(True),
+    thinnedWasDropped = cms.bool(True),
+    expectedIndexesIntoParent = cms.vuint32(10, 11, 12, 13, 14, 15, 16, 17, 18),
+    expectedValues = cms.vint32(10, 11, 12, 13, 14, 15, 16, 17, -1)
+)
+
+process.testDPlus = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thingProducer'),
+    thinnedTag = cms.InputTag('thinningThingProducerD', '', 'PROD'),
+    associationTag = cms.InputTag('thinningThingProducerD', '', 'PROD'),
+    trackTag = cms.InputTag('trackOfThingsProducerDPlus'),
+    parentWasDropped = cms.bool(True),
+    thinnedWasDropped = cms.bool(True),
+    expectedIndexesIntoParent = cms.vuint32(10, 11, 12, 13, 14, 15, 16, 17, 18),
+    expectedValues = cms.vint32(10, 11, 12, 13, 14, 15, 16, 17, -1, 21)
+)
+
+process.testE = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerD', '', 'PROD'),
+    thinnedTag = cms.InputTag('thinningThingProducerE'),
+    associationTag = cms.InputTag('thinningThingProducerE'),
+    trackTag = cms.InputTag('trackOfThingsProducerE'),
+    parentWasDropped = cms.bool(True),
+    expectedThinnedContent = cms.vint32(10, 11, 12, 13, 14),
+    expectedIndexesIntoParent = cms.vuint32(0, 1, 2, 3, 4),
+    expectedValues = cms.vint32(10, 11, 12, 13, 14)
+)
+
+process.testF = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerD', '', 'PROD'),
+    thinnedTag = cms.InputTag('thinningThingProducerF'),
+    associationTag = cms.InputTag('thinningThingProducerF'),
+    trackTag = cms.InputTag('trackOfThingsProducerF'),
+    parentWasDropped = cms.bool(True),
+    expectedThinnedContent = cms.vint32(14, 15, 16, 17),
+    expectedIndexesIntoParent = cms.vuint32(4, 5, 6, 7),
+    expectedValues = cms.vint32(14, 15, 16, 17)
+)
+
+process.testG = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thingProducer', '', 'PROD'),
+    thinnedTag = cms.InputTag('thinningThingProducerG'),
+    associationTag = cms.InputTag('thinningThingProducerG'),
+    trackTag = cms.InputTag('trackOfThingsProducerG'),
+    parentWasDropped = cms.bool(True),
+    expectedThinnedContent = cms.vint32(20, 21, 22, 23, 24, 25, 26, 27, 28),
+    expectedIndexesIntoParent = cms.vuint32(20, 21, 22, 23, 24, 25, 26, 27, 28),
+    expectedValues = cms.vint32(20, 21, 22, 23, 24, 25, 26, 27, 28)
+)
+
+process.testH = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerG'),
+    thinnedTag = cms.InputTag('thinningThingProducerH'),
+    associationTag = cms.InputTag('thinningThingProducerH'),
+    trackTag = cms.InputTag('trackOfThingsProducerH'),
+    thinnedWasDropped = cms.bool(True),
+    expectedParentContent = cms.vint32( 20,  21,  22,  23,  24,  25,  26,  27,  28),
+    associationShouldBeDropped = cms.bool(True),
+    expectedValues = cms.vint32(20, 21, 22, 23)
+)
+
+process.testI = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerG'),
+    thinnedTag = cms.InputTag('thinningThingProducerI'),
+    associationTag = cms.InputTag('thinningThingProducerI'),
+    trackTag = cms.InputTag('trackOfThingsProducerI'),
+    thinnedWasDropped = cms.bool(True),
+    associationShouldBeDropped = cms.bool(True),
+    expectedParentContent = cms.vint32( 20,  21,  22,  23,  24,  25,  26,  27,  28),
+    expectedValues = cms.vint32(24, 25, 26, 27)
+)
+
+process.testJ = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thingProducer', '', 'PROD'),
+    thinnedTag = cms.InputTag('thinningThingProducerJ'),
+    associationTag = cms.InputTag('thinningThingProducerJ'),
+    trackTag = cms.InputTag('trackOfThingsProducerJ'),
+    parentWasDropped = cms.bool(True),
+    thinnedWasDropped = cms.bool(True),
+    associationShouldBeDropped = cms.bool(True),
+    expectedValues = cms.vint32(-1, -1, -1, -1, -1, -1, -1, -1, -1)
+)
+
+process.testK = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerJ'),
+    thinnedTag = cms.InputTag('thinningThingProducerK'),
+    associationTag = cms.InputTag('thinningThingProducerK'),
+    trackTag = cms.InputTag('trackOfThingsProducerK'),
+    parentWasDropped = cms.bool(True),
+    thinnedWasDropped = cms.bool(True),
+    associationShouldBeDropped = cms.bool(True),
+    expectedValues = cms.vint32(-1, -1, -1, -1)
+)
+
+process.testL = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerJ'),
+    thinnedTag = cms.InputTag('thinningThingProducerL'),
+    associationTag = cms.InputTag('thinningThingProducerL'),
+    trackTag = cms.InputTag('trackOfThingsProducerL'),
+    parentWasDropped = cms.bool(True),
+    thinnedWasDropped = cms.bool(True),
+    associationShouldBeDropped = cms.bool(True),
+    expectedValues = cms.vint32(-1, -1, -1, -1)
+)
+
+process.testM = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thingProducer', '', 'PROD'),
+    thinnedTag = cms.InputTag('thinningThingProducerM'),
+    associationTag = cms.InputTag('thinningThingProducerM'),
+    trackTag = cms.InputTag('trackOfThingsProducerM'),
+    parentWasDropped = cms.bool(True),
+    thinnedWasDropped = cms.bool(True),
+    expectedIndexesIntoParent = cms.vuint32(40, 41, 42, 43, 44, 45, 46, 47, 48),
+    expectedValues = cms.vint32(-1, -1, -1, -1, 44, 45, 46, 47, -1)
+)
+
+process.testN = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerM'),
+    thinnedTag = cms.InputTag('thinningThingProducerN'),
+    associationTag = cms.InputTag('thinningThingProducerN'),
+    trackTag = cms.InputTag('trackOfThingsProducerN'),
+    parentWasDropped = cms.bool(True),
+    thinnedWasDropped = cms.bool(True),
+    associationShouldBeDropped = cms.bool(True),
+    expectedValues = cms.vint32(-1, -1, -1, -1)
+)
+
+process.testO = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerM'),
+    thinnedTag = cms.InputTag('aliasO'),
+    associationTag = cms.InputTag('thinningThingProducerO'),
+    trackTag = cms.InputTag('trackOfThingsProducerO'),
+    parentWasDropped = cms.bool(True),
+    thinnedIsAlias = cms.bool(True),
+    expectedThinnedContent = cms.vint32(44, 45, 46, 47),
+    expectedIndexesIntoParent = cms.vuint32(4, 5, 6, 7),
+    expectedValues = cms.vint32(44, 45, 46, 47)
+)
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testThinningTest3.root'),
+    outputCommands = cms.untracked.vstring(
+        'keep *',
+        'drop *_thingProducer2alias_*_*',
+        'drop *_thinningThingProducerD2alias_*_*',
+        'drop *_thinningThingProducerE2_*_*',
+        'drop *_thinningThingProducerF2_*_*',
+        'drop *_thinningThingProducerA_*_*',
+        'drop *_thinningThingProducerB_*_*',
+        'drop *_thinningThingProducerC_*_*',
+        'drop *_thinningThingProducerE_*_*',
+        'drop *_thinningThingProducerF_*_*',
+        'drop *_thinningThingProducerG_*_*',
+        'drop *_thinningThingProducerO_*_*'
+    )
+)
+
+process.p = cms.Path(process.thinningThingProducerE2 *
+                     process.thinningThingProducerF2 *
+                     process.testA *
+                     process.testB *
+                     process.testC *
+                     process.testD *
+                     process.testDPlus *
+                     process.testE *
+                     process.testF *
+                     process.testG *
+                     process.testH *
+                     process.testI *
+                     process.testJ *
+                     process.testK *
+                     process.testL *
+                     process.testM *
+                     process.testN *
+                     process.testO
+)
+
+process.endPath = cms.EndPath(process.out)

--- a/FWCore/Integration/test/ThinningTest4_cfg.py
+++ b/FWCore/Integration/test/ThinningTest4_cfg.py
@@ -1,0 +1,252 @@
+# Test 2 file input
+
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST4")
+
+process.options = cms.untracked.PSet(
+    numberOfStreams = cms.untracked.uint32(1)
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(3)
+)
+
+process.source = cms.Source("PoolSource",
+  fileNames = cms.untracked.vstring('file:testThinningTest3.root'),
+  secondaryFileNames = cms.untracked.vstring('file:testThinningTest2.root'),
+  inputCommands = cms.untracked.vstring(
+    'keep *',
+    'drop *_thingProducer2alias_*_*',
+    'drop *_thinningThingProducerD2alias_*_*'
+  ),
+  dropDescendantsOfDroppedBranches = cms.untracked.bool(False)
+)
+
+process.testA = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thingProducer'),
+    thinnedTag = cms.InputTag('thinningThingProducerA'),
+    associationTag = cms.InputTag('thinningThingProducerA'),
+    trackTag = cms.InputTag('trackOfThingsProducerA'),
+    parentWasDropped = cms.bool(True),
+    expectedThinnedContent = cms.vint32(0, 1, 2, 3, 4, 5, 6, 7, 8),
+    expectedIndexesIntoParent = cms.vuint32(0, 1, 2, 3, 4, 5, 6, 7, 8),
+    expectedValues = cms.vint32(0, 1, 2, 3, 4, 5, 6, 7, 8)
+)
+
+process.testB = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerA'),
+    thinnedTag = cms.InputTag('thinningThingProducerB'),
+    associationTag = cms.InputTag('thinningThingProducerB'),
+    trackTag = cms.InputTag('trackOfThingsProducerB'),
+    expectedParentContent = cms.vint32( 0,  1,  2,  3,  4,  5,  6,  7,  8),
+    expectedThinnedContent = cms.vint32(0, 1, 2, 3),
+    expectedIndexesIntoParent = cms.vuint32(0, 1, 2, 3),
+    expectedValues = cms.vint32(0, 1, 2, 3)
+)
+
+process.testC = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerA'),
+    thinnedTag = cms.InputTag('thinningThingProducerC'),
+    associationTag = cms.InputTag('thinningThingProducerC'),
+    trackTag = cms.InputTag('trackOfThingsProducerC'),
+    expectedParentContent = cms.vint32( 0,  1,  2,  3,  4,  5,  6,  7,  8),
+    expectedThinnedContent = cms.vint32(4, 5, 6, 7),
+    expectedIndexesIntoParent = cms.vuint32(4, 5, 6, 7),
+    expectedValues = cms.vint32(4, 5, 6, 7)
+)
+
+process.testD = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thingProducer'),
+    thinnedTag = cms.InputTag('thinningThingProducerD'),
+    associationTag = cms.InputTag('thinningThingProducerD'),
+    trackTag = cms.InputTag('trackOfThingsProducerD'),
+    parentWasDropped = cms.bool(True),
+    thinnedWasDropped = cms.bool(True),
+    expectedIndexesIntoParent = cms.vuint32(10, 11, 12, 13, 14, 15, 16, 17, 18),
+    expectedValues = cms.vint32(10, 11, 12, 13, 14, 15, 16, 17, -1)
+)
+
+process.testE = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerD'),
+    thinnedTag = cms.InputTag('thinningThingProducerE'),
+    associationTag = cms.InputTag('thinningThingProducerE'),
+    trackTag = cms.InputTag('trackOfThingsProducerE'),
+    parentWasDropped = cms.bool(True),
+    expectedThinnedContent = cms.vint32(10, 11, 12, 13, 14),
+    expectedIndexesIntoParent = cms.vuint32(0, 1, 2, 3, 4),
+    expectedValues = cms.vint32(10, 11, 12, 13, 14)
+)
+
+process.testF = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerD'),
+    thinnedTag = cms.InputTag('thinningThingProducerF'),
+    associationTag = cms.InputTag('thinningThingProducerF'),
+    trackTag = cms.InputTag('trackOfThingsProducerF'),
+    parentWasDropped = cms.bool(True),
+    expectedThinnedContent = cms.vint32(14, 15, 16, 17),
+    expectedIndexesIntoParent = cms.vuint32(4, 5, 6, 7),
+    expectedValues = cms.vint32(14, 15, 16, 17)
+)
+
+process.testG = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thingProducer'),
+    thinnedTag = cms.InputTag('thinningThingProducerG'),
+    associationTag = cms.InputTag('thinningThingProducerG'),
+    trackTag = cms.InputTag('trackOfThingsProducerG'),
+    parentWasDropped = cms.bool(True),
+    expectedThinnedContent = cms.vint32(20, 21, 22, 23, 24, 25, 26, 27, 28),
+    expectedIndexesIntoParent = cms.vuint32(20, 21, 22, 23, 24, 25, 26, 27, 28),
+    expectedValues = cms.vint32(20, 21, 22, 23, 24, 25, 26, 27, 28)
+)
+
+process.testH = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerG'),
+    thinnedTag = cms.InputTag('thinningThingProducerH'),
+    associationTag = cms.InputTag('thinningThingProducerH'),
+    trackTag = cms.InputTag('trackOfThingsProducerH'),
+    thinnedWasDropped = cms.bool(True),
+    expectedParentContent = cms.vint32( 20,  21,  22,  23,  24,  25,  26,  27,  28),
+    associationShouldBeDropped = cms.bool(True),
+    expectedValues = cms.vint32(20, 21, 22, 23)
+)
+
+process.testI = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerG'),
+    thinnedTag = cms.InputTag('thinningThingProducerI'),
+    associationTag = cms.InputTag('thinningThingProducerI'),
+    trackTag = cms.InputTag('trackOfThingsProducerI'),
+    thinnedWasDropped = cms.bool(True),
+    associationShouldBeDropped = cms.bool(True),
+    expectedParentContent = cms.vint32( 20,  21,  22,  23,  24,  25,  26,  27,  28),
+    expectedValues = cms.vint32(24, 25, 26, 27)
+)
+
+process.testJ = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thingProducer'),
+    thinnedTag = cms.InputTag('thinningThingProducerJ'),
+    associationTag = cms.InputTag('thinningThingProducerJ'),
+    trackTag = cms.InputTag('trackOfThingsProducerJ'),
+    parentWasDropped = cms.bool(True),
+    thinnedWasDropped = cms.bool(True),
+    associationShouldBeDropped = cms.bool(True),
+    expectedValues = cms.vint32(-1, -1, -1, -1, -1, -1, -1, -1, -1)
+)
+
+process.testK = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerJ'),
+    thinnedTag = cms.InputTag('thinningThingProducerK'),
+    associationTag = cms.InputTag('thinningThingProducerK'),
+    trackTag = cms.InputTag('trackOfThingsProducerK'),
+    parentWasDropped = cms.bool(True),
+    thinnedWasDropped = cms.bool(True),
+    associationShouldBeDropped = cms.bool(True),
+    expectedValues = cms.vint32(-1, -1, -1, -1)
+)
+
+process.testL = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerJ'),
+    thinnedTag = cms.InputTag('thinningThingProducerL'),
+    associationTag = cms.InputTag('thinningThingProducerL'),
+    trackTag = cms.InputTag('trackOfThingsProducerL'),
+    parentWasDropped = cms.bool(True),
+    thinnedWasDropped = cms.bool(True),
+    associationShouldBeDropped = cms.bool(True),
+    expectedValues = cms.vint32(-1, -1, -1, -1)
+)
+
+process.testM = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thingProducer'),
+    thinnedTag = cms.InputTag('thinningThingProducerM'),
+    associationTag = cms.InputTag('thinningThingProducerM'),
+    trackTag = cms.InputTag('trackOfThingsProducerM'),
+    parentWasDropped = cms.bool(True),
+    thinnedWasDropped = cms.bool(True),
+    expectedIndexesIntoParent = cms.vuint32(40, 41, 42, 43, 44, 45, 46, 47, 48),
+    expectedValues = cms.vint32(-1, -1, -1, -1, 44, 45, 46, 47, -1)
+)
+
+process.testN = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerM'),
+    thinnedTag = cms.InputTag('thinningThingProducerN'),
+    associationTag = cms.InputTag('thinningThingProducerN'),
+    trackTag = cms.InputTag('trackOfThingsProducerN'),
+    parentWasDropped = cms.bool(True),
+    thinnedWasDropped = cms.bool(True),
+    associationShouldBeDropped = cms.bool(True),
+    expectedValues = cms.vint32(-1, -1, -1, -1)
+)
+
+process.testO = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerM'),
+    thinnedTag = cms.InputTag('aliasO'),
+    thinnedIsAlias = cms.bool(True),
+    associationTag = cms.InputTag('thinningThingProducerO'),
+    trackTag = cms.InputTag('trackOfThingsProducerO'),
+    parentWasDropped = cms.bool(True),
+    expectedThinnedContent = cms.vint32(44, 45, 46, 47),
+    expectedIndexesIntoParent = cms.vuint32(4, 5, 6, 7),
+    expectedValues = cms.vint32(44, 45, 46, 47)
+)
+
+process.testD2 = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thingProducer2alias'),
+    thinnedTag = cms.InputTag('thinningThingProducerD2alias'),
+    associationTag = cms.InputTag('thinningThingProducerD2'),
+    trackTag = cms.InputTag('trackOfThingsProducerD2'),
+    parentWasDropped = cms.bool(True),
+    thinnedWasDropped = cms.bool(True),
+    expectedIndexesIntoParent = cms.vuint32(10, 11, 12, 13, 14, 15, 16, 17, 18),
+    expectedValues = cms.vint32(10, 11, 12, 13, 14, 15, 16, 17, -1)
+)
+
+process.testE2 = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerD2alias'),
+    thinnedTag = cms.InputTag('thinningThingProducerE2alias'),
+    associationTag = cms.InputTag('thinningThingProducerE2'),
+    trackTag = cms.InputTag('trackOfThingsProducerE2'),
+    parentWasDropped = cms.bool(True),
+    expectedThinnedContent = cms.vint32(10, 11, 12, 13, 14),
+    expectedIndexesIntoParent = cms.vuint32(0, 1, 2, 3, 4),
+    expectedValues = cms.vint32(10, 11, 12, 13, 14)
+)
+
+process.testF2 = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerD2alias'),
+    thinnedTag = cms.InputTag('thinningThingProducerF2alias'),
+    associationTag = cms.InputTag('thinningThingProducerF2'),
+    trackTag = cms.InputTag('trackOfThingsProducerF2'),
+    parentWasDropped = cms.bool(True),
+    expectedThinnedContent = cms.vint32(14, 15, 16, 17),
+    expectedIndexesIntoParent = cms.vuint32(4, 5, 6, 7),
+    expectedValues = cms.vint32(14, 15, 16, 17)
+)
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testThinningTest4.root'),
+    outputCommands = cms.untracked.vstring(
+        'keep *'
+   )
+)
+
+process.p = cms.Path(process.testA *
+                     process.testB *
+                     process.testC *
+                     process.testD *
+                     process.testE *
+                     process.testF *
+                     process.testG *
+                     process.testH *
+                     process.testI *
+                     process.testJ *
+                     process.testK *
+                     process.testL *
+                     process.testM *
+                     process.testN *
+                     process.testO *
+                     process.testD2 *
+                     process.testE2 *
+                     process.testF2
+)
+
+process.endPath = cms.EndPath(process.out)

--- a/FWCore/Integration/test/ThinningTestAnalyzer.cc
+++ b/FWCore/Integration/test/ThinningTestAnalyzer.cc
@@ -1,0 +1,358 @@
+
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "DataFormats/Common/interface/ThinnedAssociation.h"
+#include "DataFormats/TestObjects/interface/Thing.h"
+#include "DataFormats/TestObjects/interface/ThingCollection.h"
+#include "DataFormats/TestObjects/interface/TrackOfThings.h"
+#include "DataFormats/Provenance/interface/ProductID.h"
+
+#include <vector>
+
+namespace edmtest {
+
+  class ThinningTestAnalyzer : public edm::EDAnalyzer {
+  public:
+
+    explicit ThinningTestAnalyzer(edm::ParameterSet const& pset);
+
+    virtual ~ThinningTestAnalyzer() {}
+
+    static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+
+    virtual void analyze(edm::Event const& e, edm::EventSetup const& c) override;
+
+  private:
+
+    void incrementExpectedValue(std::vector<int>::const_iterator& iter) const;
+
+    edm::EDGetTokenT<ThingCollection> parentToken_;
+    edm::EDGetTokenT<ThingCollection> thinnedToken_;
+    edm::EDGetTokenT<edm::ThinnedAssociation> associationToken_;
+    edm::EDGetTokenT<TrackOfThingsCollection> trackToken_;
+
+    bool parentWasDropped_;
+    std::vector<int> expectedParentContent_;
+    bool thinnedWasDropped_;
+    bool thinnedIsAlias_;
+    std::vector<int> expectedThinnedContent_;
+    std::vector<unsigned int> expectedIndexesIntoParent_;
+    bool associationShouldBeDropped_;
+    std::vector<int> expectedValues_;
+  };
+
+  ThinningTestAnalyzer::ThinningTestAnalyzer(edm::ParameterSet const& pset) {
+    parentToken_ = consumes<ThingCollection>(pset.getParameter<edm::InputTag>("parentTag"));
+    thinnedToken_ = mayConsume<ThingCollection>(pset.getParameter<edm::InputTag>("thinnedTag"));
+    associationToken_ = mayConsume<edm::ThinnedAssociation>(pset.getParameter<edm::InputTag>("associationTag"));
+    trackToken_ = consumes<TrackOfThingsCollection>(pset.getParameter<edm::InputTag>("trackTag"));
+    parentWasDropped_ = pset.getParameter<bool>("parentWasDropped");
+    if(!parentWasDropped_) {
+      expectedParentContent_ = pset.getParameter<std::vector<int> >("expectedParentContent");
+    }
+    thinnedWasDropped_ = pset.getParameter<bool>("thinnedWasDropped");
+    thinnedIsAlias_ = pset.getParameter<bool>("thinnedIsAlias");
+    if(!thinnedWasDropped_) {
+      expectedThinnedContent_ = pset.getParameter<std::vector<int> >("expectedThinnedContent");
+    }
+    associationShouldBeDropped_ = pset.getParameter<bool>("associationShouldBeDropped");
+    if(!associationShouldBeDropped_) {
+      expectedIndexesIntoParent_ = pset.getParameter<std::vector<unsigned int> >("expectedIndexesIntoParent");
+    }
+    expectedValues_ = pset.getParameter<std::vector<int> >("expectedValues");
+  }
+
+  void ThinningTestAnalyzer::fillDescriptions(edm::ConfigurationDescriptions & descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<edm::InputTag>("parentTag");
+    desc.add<edm::InputTag>("thinnedTag");
+    desc.add<edm::InputTag>("associationTag");
+    desc.add<edm::InputTag>("trackTag");
+    desc.add<bool>("parentWasDropped", false);
+    desc.add<bool>("thinnedWasDropped", false);
+    desc.add<bool>("thinnedIsAlias", false);
+    std::vector<int> defaultV;
+    std::vector<unsigned int> defaultVU;
+    desc.add<std::vector<int> >("expectedParentContent", defaultV);
+    desc.add<std::vector<int> >("expectedThinnedContent", defaultV);
+    desc.add<std::vector<unsigned int> >("expectedIndexesIntoParent", defaultVU);
+    desc.add<bool>("associationShouldBeDropped", false);
+    desc.add<std::vector<int> >("expectedValues");
+    descriptions.addDefault(desc);
+  }
+
+  void ThinningTestAnalyzer::analyze(edm::Event const& event, edm::EventSetup const&) {
+
+    edm::Handle<ThingCollection> parentCollection;
+    event.getByToken(parentToken_, parentCollection);
+
+    edm::Handle<ThingCollection> thinnedCollection;
+    event.getByToken(thinnedToken_, thinnedCollection);
+
+    edm::Handle<edm::ThinnedAssociation> associationCollection;
+    event.getByToken(associationToken_, associationCollection);
+
+    edm::Handle<TrackOfThingsCollection> trackCollection;
+    event.getByToken(trackToken_, trackCollection);
+
+    unsigned int i = 0;
+    if(parentWasDropped_) {
+      if(parentCollection.isValid()) {
+        throw cms::Exception("TestFailure") << "parent collection present, should have been dropped";
+      }
+    } else if(!expectedParentContent_.empty()) {
+      if(parentCollection->size() != expectedParentContent_.size()) {
+        throw cms::Exception("TestFailure") << "parent collection has unexpected size";
+      }
+      for(auto const& thing : *parentCollection) {
+        // Just some numbers that match the somewhat arbitrary values put in
+        // by the ThingProducer.
+        int expected  = expectedParentContent_.at(i) + event.eventAuxiliary().event() * 100 + 100;
+        if(thing.a != expected) {
+          throw cms::Exception("TestFailure") << "parent collection has unexpected content";
+        }
+        ++i;
+      }
+    }
+
+    // Check to see the content is what we expect based on what was written
+    // by ThingProducer and TrackOfThingsProducer. The values are somewhat
+    // arbitrary and meaningless.
+    if(thinnedWasDropped_) {
+      if(thinnedCollection.isValid()) {
+        throw cms::Exception("TestFailure") << "thinned collection present, should have been dropped";
+      }
+    } else {
+      unsigned expectedIndex = 0;
+      if(thinnedCollection->size() != expectedThinnedContent_.size()) {
+        throw cms::Exception("TestFailure") << "thinned collection has unexpected size";
+      }
+      for(auto const& thing : *thinnedCollection) {
+        if(thing.a != static_cast<int>(expectedThinnedContent_.at(expectedIndex) + event.eventAuxiliary().event() * 100 + 100)) {
+          throw cms::Exception("TestFailure") << "thinned collection has unexpected content";
+        }
+        ++expectedIndex;
+      }
+    }
+
+    if(associationShouldBeDropped_ && associationCollection.isValid()) {
+      throw cms::Exception("TestFailure") << "association collection should have been dropped but was not";
+    }
+    if(!associationShouldBeDropped_) {
+      unsigned int expectedIndex = 0;
+      if(associationCollection->indexesIntoParent().size() != expectedIndexesIntoParent_.size()) {
+        throw cms::Exception("TestFailure") << "association collection has unexpected size";
+      }
+      for(auto const& association : associationCollection->indexesIntoParent()) {
+        if(association != expectedIndexesIntoParent_.at(expectedIndex)) {
+          throw cms::Exception("TestFailure") << "association collection has unexpected content";
+        }
+        ++expectedIndex;
+      }
+    }
+
+    if(!parentWasDropped_ && !associationShouldBeDropped_) {
+      if(associationCollection->parentCollectionID() != parentCollection.id()) {
+        throw cms::Exception("TestFailure") << "analyze parent ProductID is not correct";
+      }
+    }
+
+    if(!thinnedWasDropped_ && !associationShouldBeDropped_) {
+      if(!thinnedIsAlias_) {
+        if(associationCollection->thinnedCollectionID() != thinnedCollection.id()) {
+          throw cms::Exception("TestFailure") << "analyze thinned ProductID is not correct";
+        }
+      } else {
+        if(associationCollection->thinnedCollectionID() == thinnedCollection.id()) {
+          throw cms::Exception("TestFailure") << "analyze thinned ProductID is not correct";
+        }
+      }
+    }
+
+    if(trackCollection->size() != 5u) {
+      throw cms::Exception("TestFailure") << "unexpected Track size";
+    }
+
+    int eventOffset = static_cast<int>(event.eventAuxiliary().event() * 100 + 100);
+
+    std::vector<int>::const_iterator expectedValue = expectedValues_.begin();
+    for(auto const& track : *trackCollection) {
+
+      if(*expectedValue == -1) {
+        if(track.ref1.isAvailable()) {
+          throw cms::Exception("TestFailure") << "ref1 is available when it should not be";
+        }
+      } else {
+        if(!track.ref1.isAvailable()) {
+          throw cms::Exception("TestFailure") << "ref1 is not available when it should be";
+        }
+        // Check twice to test some possible caching problems.
+        if(track.ref1->a !=
+           *expectedValue + eventOffset) {
+          throw cms::Exception("TestFailure") << "Unexpected values from ref1";
+        }
+        if(track.ref1->a !=
+           *expectedValue + eventOffset) {
+          throw cms::Exception("TestFailure") << "Unexpected values from ref1 (2nd try)";
+        }
+      }
+
+      if(*expectedValue == -1) {
+        if(track.refToBase1.isAvailable()) {
+          throw cms::Exception("TestFailure") << "refToBase1 is available when it should not be";
+        }
+      } else {
+        if(!track.refToBase1.isAvailable()) {
+          throw cms::Exception("TestFailure") << "refToBase1 is not available when it should be";
+        }
+
+        // Check twice to test some possible caching problems.
+        if(track.refToBase1->a !=
+           *expectedValue + eventOffset) {
+          throw cms::Exception("TestFailure") << "unexpected values from refToBase1";
+        }
+        if(track.refToBase1->a !=
+           *expectedValue + eventOffset) {
+          throw cms::Exception("TestFailure") << "unexpected values from refToBase1";
+        }
+      }
+      incrementExpectedValue(expectedValue);
+
+      if(*expectedValue == -1) {
+        if(track.ref2.isAvailable()) {
+          throw cms::Exception("TestFailure") << "ref2 is available when it should not be";
+        }
+      } else {
+        if(!track.ref2.isAvailable()) {
+          throw cms::Exception("TestFailure") << "ref2 is not available when it should be";
+        }
+
+        if(track.ref2->a !=
+           *expectedValue + eventOffset) {
+          throw cms::Exception("TestFailure") << "unexpected values from ref2";
+        }
+        if(track.ref2->a !=
+           *expectedValue + eventOffset) {
+          throw cms::Exception("TestFailure") <<  "unexpected values from ref2";
+        }
+      }
+      incrementExpectedValue(expectedValue);
+
+      if(*expectedValue == -1) {
+        if(track.ptr1.isAvailable()) {
+          throw cms::Exception("TestFailure") << "ptr1 is available when it should not be";
+        }
+      } else {
+        if(!track.ptr1.isAvailable()) {
+          throw cms::Exception("TestFailure") << "ptr1 is not available when it should be";
+        }
+
+        if(track.ptr1->a !=
+           *expectedValue + eventOffset) {
+          throw cms::Exception("TestFailure") << "unexpected values from ptr1";
+        }
+        if(track.ptr1->a !=
+          *expectedValue + eventOffset) {
+          throw cms::Exception("TestFailure") << "unexpected values from ptr1 (2)";
+        }
+      }
+      incrementExpectedValue(expectedValue);
+
+      if(*expectedValue == -1) {
+        if(track.ptr2.isAvailable()) {
+          throw cms::Exception("TestFailure") << "ptr2 is available when it should not be";
+        }
+      } else {
+        if(!track.ptr2.isAvailable()) {
+          throw cms::Exception("TestFailure") << "ptr2 is not available when it should be";
+        }
+
+        if(track.ptr2->a !=
+           *expectedValue + eventOffset) {
+          throw cms::Exception("TestFailure") << "unexpected values from ptr2";
+        }
+        if(track.ptr2->a !=
+           *expectedValue + eventOffset) {
+          throw cms::Exception("TestFailure") << " unexpected values from ptr2";
+        }
+      }
+      incrementExpectedValue(expectedValue);
+
+      // Test RefVector, PtrVector, and RefToBaseVector
+      unsigned int k = 0;
+      bool allPresent = true;
+      for(auto iExpectedValue : expectedValues_) {
+
+        if(iExpectedValue != -1) {
+          if(track.refVector1[k]->a != iExpectedValue + eventOffset) {
+            throw cms::Exception("TestFailure") << "unexpected values from refVector1";
+          }
+          if(track.ptrVector1[k]->a != iExpectedValue + eventOffset) {
+            throw cms::Exception("TestFailure") << "unexpected values from ptrVector1";
+          }
+          if(track.refToBaseVector1[k]->a != iExpectedValue + eventOffset) {
+            throw cms::Exception("TestFailure") << "unexpected values from refToBaseVector1";
+          }
+        } else {
+          allPresent = false;
+        }
+        ++k;
+      }
+
+      if(allPresent) {
+        if(!track.refVector1.isAvailable()) {
+          throw cms::Exception("TestFailure") << "unexpected value (false) from refVector::isAvailable";
+        }
+        if(!track.ptrVector1.isAvailable()) {
+          throw cms::Exception("TestFailure") << "unexpected value (false) from ptrVector::isAvailable";
+        }
+        if(!track.refToBaseVector1.isAvailable()) {
+          throw cms::Exception("TestFailure") << "unexpected value (false) from refToBaseVector::isAvailable";
+        }
+      } else {
+        if(track.refVector1.isAvailable()) {
+          throw cms::Exception("TestFailure") << "unexpected value (true) from refVector::isAvailable";
+        }
+        if(track.ptrVector1.isAvailable()) {
+          throw cms::Exception("TestFailure") << "unexpected value (true) from ptrVector::isAvailable";
+        }
+        if(track.refToBaseVector1.isAvailable()) {
+          throw cms::Exception("TestFailure") << "unexpected value (true) from refToBaseVector::isAvailable";
+        }
+      }
+      k = 0;
+      for(auto iExpectedValue : expectedValues_) {
+        if(iExpectedValue != -1) {
+          if(track.refVector1[k]->a != iExpectedValue + eventOffset) {
+            throw cms::Exception("TestFailure") << "unexpected values from refVector1";
+          }
+          if(track.ptrVector1[k]->a != iExpectedValue + eventOffset) {
+            throw cms::Exception("TestFailure") << "unexpected values from ptrVector1";
+          }
+          if(track.refToBaseVector1[k]->a != iExpectedValue + eventOffset) {
+            throw cms::Exception("TestFailure") << "unexpected values from refToBaseVector1";
+          }
+        } else {
+          allPresent = false;
+        }
+        ++k;
+      }
+    }
+  }
+
+  void ThinningTestAnalyzer::incrementExpectedValue(std::vector<int>::const_iterator& iter) const {
+    ++iter;
+    if(iter == expectedValues_.end()) iter = expectedValues_.begin();
+  }
+}
+using edmtest::ThinningTestAnalyzer;
+DEFINE_FWK_MODULE(ThinningTestAnalyzer);

--- a/FWCore/Integration/test/ThinningTestStreamerIn_cfg.py
+++ b/FWCore/Integration/test/ThinningTestStreamerIn_cfg.py
@@ -1,0 +1,204 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST3")
+
+process.options = cms.untracked.PSet(
+    numberOfStreams = cms.untracked.uint32(1)
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(3)
+)
+
+process.source = cms.Source("NewEventStreamFileReader",
+    fileNames = cms.untracked.vstring('file:testThinningStreamerout.dat')
+)
+
+process.testA = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thingProducer'),
+    thinnedTag = cms.InputTag('thinningThingProducerA'),
+    associationTag = cms.InputTag('thinningThingProducerA'),
+    trackTag = cms.InputTag('trackOfThingsProducerA'),
+    parentWasDropped = cms.bool(True),
+    expectedThinnedContent = cms.vint32(0, 1, 2, 3, 4, 5, 6, 7, 8),
+    expectedIndexesIntoParent = cms.vuint32(0, 1, 2, 3, 4, 5, 6, 7, 8),
+    expectedValues = cms.vint32(0, 1, 2, 3, 4, 5, 6, 7, 8)
+)
+
+process.testB = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerA'),
+    thinnedTag = cms.InputTag('thinningThingProducerB'),
+    associationTag = cms.InputTag('thinningThingProducerB'),
+    trackTag = cms.InputTag('trackOfThingsProducerB'),
+    expectedParentContent = cms.vint32( 0,  1,  2,  3,  4,  5,  6,  7,  8),
+    expectedThinnedContent = cms.vint32(0, 1, 2, 3),
+    expectedIndexesIntoParent = cms.vuint32(0, 1, 2, 3),
+    expectedValues = cms.vint32(0, 1, 2, 3)
+)
+
+process.testC = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerA'),
+    thinnedTag = cms.InputTag('thinningThingProducerC'),
+    associationTag = cms.InputTag('thinningThingProducerC'),
+    trackTag = cms.InputTag('trackOfThingsProducerC'),
+    expectedParentContent = cms.vint32( 0,  1,  2,  3,  4,  5,  6,  7,  8),
+    expectedThinnedContent = cms.vint32(4, 5, 6, 7),
+    expectedIndexesIntoParent = cms.vuint32(4, 5, 6, 7),
+    expectedValues = cms.vint32(4, 5, 6, 7)
+)
+
+process.testD = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thingProducer'),
+    thinnedTag = cms.InputTag('thinningThingProducerD'),
+    associationTag = cms.InputTag('thinningThingProducerD'),
+    trackTag = cms.InputTag('trackOfThingsProducerD'),
+    parentWasDropped = cms.bool(True),
+    thinnedWasDropped = cms.bool(True),
+    expectedIndexesIntoParent = cms.vuint32(10, 11, 12, 13, 14, 15, 16, 17, 18),
+    expectedValues = cms.vint32(10, 11, 12, 13, 14, 15, 16, 17, -1)
+)
+
+process.testE = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerD'),
+    thinnedTag = cms.InputTag('thinningThingProducerE'),
+    associationTag = cms.InputTag('thinningThingProducerE'),
+    trackTag = cms.InputTag('trackOfThingsProducerE'),
+    parentWasDropped = cms.bool(True),
+    expectedThinnedContent = cms.vint32(10, 11, 12, 13, 14),
+    expectedIndexesIntoParent = cms.vuint32(0, 1, 2, 3, 4),
+    expectedValues = cms.vint32(10, 11, 12, 13, 14)
+)
+
+process.testF = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerD'),
+    thinnedTag = cms.InputTag('thinningThingProducerF'),
+    associationTag = cms.InputTag('thinningThingProducerF'),
+    trackTag = cms.InputTag('trackOfThingsProducerF'),
+    parentWasDropped = cms.bool(True),
+    expectedThinnedContent = cms.vint32(14, 15, 16, 17),
+    expectedIndexesIntoParent = cms.vuint32(4, 5, 6, 7),
+    expectedValues = cms.vint32(14, 15, 16, 17)
+)
+
+process.testG = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thingProducer'),
+    thinnedTag = cms.InputTag('thinningThingProducerG'),
+    associationTag = cms.InputTag('thinningThingProducerG'),
+    trackTag = cms.InputTag('trackOfThingsProducerG'),
+    parentWasDropped = cms.bool(True),
+    expectedThinnedContent = cms.vint32(20, 21, 22, 23, 24, 25, 26, 27, 28),
+    expectedIndexesIntoParent = cms.vuint32(20, 21, 22, 23, 24, 25, 26, 27, 28),
+    expectedValues = cms.vint32(20, 21, 22, 23, 24, 25, 26, 27, 28)
+)
+
+process.testH = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerG'),
+    thinnedTag = cms.InputTag('thinningThingProducerH'),
+    associationTag = cms.InputTag('thinningThingProducerH'),
+    trackTag = cms.InputTag('trackOfThingsProducerH'),
+    thinnedWasDropped = cms.bool(True),
+    expectedParentContent = cms.vint32( 20,  21,  22,  23,  24,  25,  26,  27,  28),
+    associationShouldBeDropped = cms.bool(True),
+    expectedValues = cms.vint32(20, 21, 22, 23)
+)
+
+process.testI = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerG'),
+    thinnedTag = cms.InputTag('thinningThingProducerI'),
+    associationTag = cms.InputTag('thinningThingProducerI'),
+    trackTag = cms.InputTag('trackOfThingsProducerI'),
+    thinnedWasDropped = cms.bool(True),
+    associationShouldBeDropped = cms.bool(True),
+    expectedParentContent = cms.vint32( 20,  21,  22,  23,  24,  25,  26,  27,  28),
+    expectedValues = cms.vint32(24, 25, 26, 27)
+)
+
+process.testJ = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thingProducer'),
+    thinnedTag = cms.InputTag('thinningThingProducerJ'),
+    associationTag = cms.InputTag('thinningThingProducerJ'),
+    trackTag = cms.InputTag('trackOfThingsProducerJ'),
+    parentWasDropped = cms.bool(True),
+    thinnedWasDropped = cms.bool(True),
+    associationShouldBeDropped = cms.bool(True),
+    expectedValues = cms.vint32(-1, -1, -1, -1, -1, -1, -1, -1, -1)
+)
+
+process.testK = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerJ'),
+    thinnedTag = cms.InputTag('thinningThingProducerK'),
+    associationTag = cms.InputTag('thinningThingProducerK'),
+    trackTag = cms.InputTag('trackOfThingsProducerK'),
+    parentWasDropped = cms.bool(True),
+    thinnedWasDropped = cms.bool(True),
+    associationShouldBeDropped = cms.bool(True),
+    expectedValues = cms.vint32(-1, -1, -1, -1)
+)
+
+process.testL = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerJ'),
+    thinnedTag = cms.InputTag('thinningThingProducerL'),
+    associationTag = cms.InputTag('thinningThingProducerL'),
+    trackTag = cms.InputTag('trackOfThingsProducerL'),
+    parentWasDropped = cms.bool(True),
+    thinnedWasDropped = cms.bool(True),
+    associationShouldBeDropped = cms.bool(True),
+    expectedValues = cms.vint32(-1, -1, -1, -1)
+)
+
+process.testM = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thingProducer'),
+    thinnedTag = cms.InputTag('thinningThingProducerM'),
+    associationTag = cms.InputTag('thinningThingProducerM'),
+    trackTag = cms.InputTag('trackOfThingsProducerM'),
+    parentWasDropped = cms.bool(True),
+    thinnedWasDropped = cms.bool(True),
+    expectedIndexesIntoParent = cms.vuint32(40, 41, 42, 43, 44, 45, 46, 47, 48),
+    expectedValues = cms.vint32(-1, -1, -1, -1, 44, 45, 46, 47, -1)
+)
+
+process.testN = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerM'),
+    thinnedTag = cms.InputTag('thinningThingProducerN'),
+    associationTag = cms.InputTag('thinningThingProducerN'),
+    trackTag = cms.InputTag('trackOfThingsProducerN'),
+    parentWasDropped = cms.bool(True),
+    thinnedWasDropped = cms.bool(True),
+    associationShouldBeDropped = cms.bool(True),
+    expectedValues = cms.vint32(-1, -1, -1, -1)
+)
+
+process.testO = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerM'),
+    thinnedTag = cms.InputTag('aliasO'),
+    thinnedIsAlias = cms.bool(True),
+    associationTag = cms.InputTag('thinningThingProducerO'),
+    trackTag = cms.InputTag('trackOfThingsProducerO'),
+    parentWasDropped = cms.bool(True),
+    expectedThinnedContent = cms.vint32(44, 45, 46, 47),
+    expectedIndexesIntoParent = cms.vuint32(4, 5, 6, 7),
+    expectedValues = cms.vint32(44, 45, 46, 47)
+)
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testThinningTestStreamerIn.root')
+)
+
+process.p = cms.Path(process.testA *
+                     process.testB *
+                     process.testC *
+                     process.testD *
+                     process.testE *
+                     process.testF *
+                     process.testG *
+                     process.testH *
+                     process.testI *
+                     process.testJ *
+                     process.testK *
+                     process.testL *
+                     process.testM *
+                     process.testN *
+                     process.testO
+)
+
+process.endPath = cms.EndPath(process.out)

--- a/FWCore/Integration/test/ThinningTestSubProcessRead_cfg.py
+++ b/FWCore/Integration/test/ThinningTestSubProcessRead_cfg.py
@@ -1,0 +1,208 @@
+# Reads a file produce by a process with SubProcesses
+# to see that redirection of Refs to thinned collections
+# is working.
+
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("READ")
+
+process.options = cms.untracked.PSet(
+    numberOfStreams = cms.untracked.uint32(1)
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(3)
+)
+
+process.source = cms.Source("PoolSource",
+  fileNames = cms.untracked.vstring('file:testThinningTestSubProcess3.root')
+)
+
+process.testA = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thingProducer'),
+    thinnedTag = cms.InputTag('thinningThingProducerA'),
+    associationTag = cms.InputTag('thinningThingProducerA'),
+    trackTag = cms.InputTag('trackOfThingsProducerA'),
+    parentWasDropped = cms.bool(True),
+    expectedThinnedContent = cms.vint32(0, 1, 2, 3, 4, 5, 6, 7, 8),
+    expectedIndexesIntoParent = cms.vuint32(0, 1, 2, 3, 4, 5, 6, 7, 8),
+    expectedValues = cms.vint32(0, 1, 2, 3, 4, 5, 6, 7, 8)
+)
+
+process.testB = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerA'),
+    thinnedTag = cms.InputTag('thinningThingProducerB'),
+    associationTag = cms.InputTag('thinningThingProducerB'),
+    trackTag = cms.InputTag('trackOfThingsProducerB'),
+    expectedParentContent = cms.vint32( 0,  1,  2,  3,  4,  5,  6,  7,  8),
+    expectedThinnedContent = cms.vint32(0, 1, 2, 3),
+    expectedIndexesIntoParent = cms.vuint32(0, 1, 2, 3),
+    expectedValues = cms.vint32(0, 1, 2, 3)
+)
+
+process.testC = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerA'),
+    thinnedTag = cms.InputTag('thinningThingProducerC'),
+    associationTag = cms.InputTag('thinningThingProducerC'),
+    trackTag = cms.InputTag('trackOfThingsProducerC'),
+    expectedParentContent = cms.vint32( 0,  1,  2,  3,  4,  5,  6,  7,  8),
+    expectedThinnedContent = cms.vint32(4, 5, 6, 7),
+    expectedIndexesIntoParent = cms.vuint32(4, 5, 6, 7),
+    expectedValues = cms.vint32(4, 5, 6, 7)
+)
+
+process.testD = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thingProducer'),
+    thinnedTag = cms.InputTag('thinningThingProducerD'),
+    associationTag = cms.InputTag('thinningThingProducerD'),
+    trackTag = cms.InputTag('trackOfThingsProducerD'),
+    parentWasDropped = cms.bool(True),
+    thinnedWasDropped = cms.bool(True),
+    expectedIndexesIntoParent = cms.vuint32(10, 11, 12, 13, 14, 15, 16, 17, 18),
+    expectedValues = cms.vint32(10, 11, 12, 13, 14, 15, 16, 17, -1)
+)
+
+process.testE = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerD'),
+    thinnedTag = cms.InputTag('thinningThingProducerE'),
+    associationTag = cms.InputTag('thinningThingProducerE'),
+    trackTag = cms.InputTag('trackOfThingsProducerE'),
+    parentWasDropped = cms.bool(True),
+    expectedThinnedContent = cms.vint32(10, 11, 12, 13),
+    expectedIndexesIntoParent = cms.vuint32(0, 1, 2, 3),
+    expectedValues = cms.vint32(10, 11, 12, 13)
+)
+
+process.testF = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerD'),
+    thinnedTag = cms.InputTag('thinningThingProducerF'),
+    associationTag = cms.InputTag('thinningThingProducerF'),
+    trackTag = cms.InputTag('trackOfThingsProducerF'),
+    parentWasDropped = cms.bool(True),
+    expectedThinnedContent = cms.vint32(14, 15, 16, 17),
+    expectedIndexesIntoParent = cms.vuint32(4, 5, 6, 7),
+    expectedValues = cms.vint32(14, 15, 16, 17)
+)
+
+process.testG = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thingProducer'),
+    thinnedTag = cms.InputTag('thinningThingProducerG'),
+    associationTag = cms.InputTag('thinningThingProducerG'),
+    trackTag = cms.InputTag('trackOfThingsProducerG'),
+    parentWasDropped = cms.bool(True),
+    expectedThinnedContent = cms.vint32(20, 21, 22, 23, 24, 25, 26, 27, 28),
+    expectedIndexesIntoParent = cms.vuint32(20, 21, 22, 23, 24, 25, 26, 27, 28),
+    expectedValues = cms.vint32(20, 21, 22, 23, 24, 25, 26, 27, 28)
+)
+
+process.testH = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerG'),
+    thinnedTag = cms.InputTag('thinningThingProducerH'),
+    associationTag = cms.InputTag('thinningThingProducerH'),
+    trackTag = cms.InputTag('trackOfThingsProducerH'),
+    thinnedWasDropped = cms.bool(True),
+    expectedParentContent = cms.vint32( 20,  21,  22,  23,  24,  25,  26,  27,  28),
+    associationShouldBeDropped = cms.bool(True),
+    expectedValues = cms.vint32(20, 21, 22, 23)
+)
+
+process.testI = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerG'),
+    thinnedTag = cms.InputTag('thinningThingProducerI'),
+    associationTag = cms.InputTag('thinningThingProducerI'),
+    trackTag = cms.InputTag('trackOfThingsProducerI'),
+    thinnedWasDropped = cms.bool(True),
+    associationShouldBeDropped = cms.bool(True),
+    expectedParentContent = cms.vint32( 20,  21,  22,  23,  24,  25,  26,  27,  28),
+    expectedValues = cms.vint32(24, 25, 26, 27)
+)
+
+process.testJ = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thingProducer'),
+    thinnedTag = cms.InputTag('thinningThingProducerJ'),
+    associationTag = cms.InputTag('thinningThingProducerJ'),
+    trackTag = cms.InputTag('trackOfThingsProducerJ'),
+    parentWasDropped = cms.bool(True),
+    thinnedWasDropped = cms.bool(True),
+    associationShouldBeDropped = cms.bool(True),
+    expectedValues = cms.vint32(-1, -1, -1, -1, -1, -1, -1, -1, -1)
+)
+
+process.testK = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerJ'),
+    thinnedTag = cms.InputTag('thinningThingProducerK'),
+    associationTag = cms.InputTag('thinningThingProducerK'),
+    trackTag = cms.InputTag('trackOfThingsProducerK'),
+    parentWasDropped = cms.bool(True),
+    thinnedWasDropped = cms.bool(True),
+    associationShouldBeDropped = cms.bool(True),
+    expectedValues = cms.vint32(-1, -1, -1, -1)
+)
+
+process.testL = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerJ'),
+    thinnedTag = cms.InputTag('thinningThingProducerL'),
+    associationTag = cms.InputTag('thinningThingProducerL'),
+    trackTag = cms.InputTag('trackOfThingsProducerL'),
+    parentWasDropped = cms.bool(True),
+    thinnedWasDropped = cms.bool(True),
+    associationShouldBeDropped = cms.bool(True),
+    expectedValues = cms.vint32(-1, -1, -1, -1)
+)
+
+process.testM = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thingProducer'),
+    thinnedTag = cms.InputTag('thinningThingProducerM'),
+    associationTag = cms.InputTag('thinningThingProducerM'),
+    trackTag = cms.InputTag('trackOfThingsProducerM'),
+    parentWasDropped = cms.bool(True),
+    thinnedWasDropped = cms.bool(True),
+    expectedIndexesIntoParent = cms.vuint32(40, 41, 42, 43, 44, 45, 46, 47, 48),
+    expectedValues = cms.vint32(-1, -1, -1, -1, 44, 45, 46, 47, -1)
+)
+
+process.testN = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerM'),
+    thinnedTag = cms.InputTag('thinningThingProducerN'),
+    associationTag = cms.InputTag('thinningThingProducerN'),
+    trackTag = cms.InputTag('trackOfThingsProducerN'),
+    parentWasDropped = cms.bool(True),
+    thinnedWasDropped = cms.bool(True),
+    associationShouldBeDropped = cms.bool(True),
+    expectedValues = cms.vint32(-1, -1, -1, -1)
+)
+
+process.testO = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerM'),
+    thinnedTag = cms.InputTag('aliasO'),
+    associationTag = cms.InputTag('thinningThingProducerO'),
+    trackTag = cms.InputTag('trackOfThingsProducerO'),
+    parentWasDropped = cms.bool(True),
+    thinnedIsAlias = cms.bool(True),
+    expectedThinnedContent = cms.vint32(44, 45, 46, 47),
+    expectedIndexesIntoParent = cms.vuint32(4, 5, 6, 7),
+    expectedValues = cms.vint32(44, 45, 46, 47)
+)
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testThinningTestSubProcessRead.root')
+)
+
+process.p = cms.Path(process.testA *
+                     process.testB *
+                     process.testC *
+                     process.testD *
+                     process.testE *
+                     process.testF *
+                     process.testG *
+                     process.testH *
+                     process.testI *
+                     process.testJ *
+                     process.testK *
+                     process.testL *
+                     process.testM *
+                     process.testN *
+                     process.testO
+)
+
+process.endPath = cms.EndPath(process.out)

--- a/FWCore/Integration/test/ThinningTestSubProcess_cfg.py
+++ b/FWCore/Integration/test/ThinningTestSubProcess_cfg.py
@@ -1,0 +1,613 @@
+# Test for thinning collections and redirecting Refs
+# with SubProcesses. The basic strategy here is to
+# repeat tests ThinningTest1_cfg.py, ThinningTest2_cfg.py
+# and ThinningTest3_cfg.py except run them in one
+# process with SubProcesses.  There is one possibly
+# surprising feature here.  Refs to dropped products
+# will still succeed to find elements in containers
+# the were dropped in earlier SubProcesses even though
+# a getByToken call will not find the product. This
+# is because Refs contain direct pointers to the
+# product or the ProductGetter and do not use
+# the lookup mechanism that respects the product
+# drops. So the expected values in the test
+# below must all reflect that. We have to
+# run a separate process to actually test that
+# the redirection of Refs is working.
+# See ThinningTestSubProcessRead_cfg.py.
+
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("FIRST")
+
+#process.Tracer = cms.Service('Tracer')
+
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+
+process.MessageLogger.cerr.threshold = 'INFO'
+process.MessageLogger.cerr.INFO.limit = 100
+
+process.options = cms.untracked.PSet(
+    numberOfStreams = cms.untracked.uint32(1)
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(3)
+)
+
+process.source = cms.Source("EmptySource")
+
+process.WhatsItESProducer = cms.ESProducer("WhatsItESProducer")
+
+process.DoodadESSource = cms.ESSource("DoodadESSource")
+
+process.thingProducer = cms.EDProducer("ThingProducer",
+                                       offsetDelta = cms.int32(100),
+                                       nThings = cms.int32(50)
+)
+
+process.trackOfThingsProducerA = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(0, 1, 2, 3, 4, 5, 6, 7, 8)
+)
+
+process.trackOfThingsProducerB = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(0, 1, 2, 3)
+)
+
+process.trackOfThingsProducerC = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(4, 5, 6, 7)
+)
+
+process.trackOfThingsProducerD = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(10, 11, 12, 13, 14, 15, 16, 17, 18)
+)
+
+process.trackOfThingsProducerE = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(10, 11, 12, 13)
+)
+
+process.trackOfThingsProducerF = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(14, 15, 16, 17)
+)
+
+process.trackOfThingsProducerG = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(20, 21, 22, 23, 24, 25, 26, 27, 28)
+)
+
+process.trackOfThingsProducerH = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(20, 21, 22, 23)
+)
+
+process.trackOfThingsProducerI = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(24, 25, 26, 27)
+)
+
+process.trackOfThingsProducerJ = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(30, 31, 32, 33, 34, 35, 36, 37, 38)
+)
+
+process.trackOfThingsProducerK = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(30, 31, 32, 33)
+)
+
+process.trackOfThingsProducerL = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(34, 35, 36, 37)
+)
+
+process.trackOfThingsProducerM = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(40, 41, 42, 43, 44, 45, 46, 47, 48)
+)
+
+process.trackOfThingsProducerN = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(40, 41, 42, 43)
+)
+
+process.trackOfThingsProducerO = cms.EDProducer("TrackOfThingsProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    keysToReference = cms.vuint32(44, 45, 46, 47)
+)
+
+process.thinningThingProducerA = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    trackTag = cms.InputTag('trackOfThingsProducerA'),
+    offsetToThinnedKey = cms.uint32(0),
+    expectedCollectionSize = cms.uint32(50)
+)
+
+process.thinningThingProducerB = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thinningThingProducerA'),
+    trackTag = cms.InputTag('trackOfThingsProducerB'),
+    offsetToThinnedKey = cms.uint32(0),
+    expectedCollectionSize = cms.uint32(9)
+)
+
+process.thinningThingProducerC = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thinningThingProducerA'),
+    trackTag = cms.InputTag('trackOfThingsProducerC'),
+    offsetToThinnedKey = cms.uint32(0),
+    expectedCollectionSize = cms.uint32(9)
+)
+
+process.thinningThingProducerD = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    trackTag = cms.InputTag('trackOfThingsProducerD'),
+    offsetToThinnedKey = cms.uint32(0),
+    expectedCollectionSize = cms.uint32(50)
+)
+
+process.thinningThingProducerE = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thinningThingProducerD'),
+    trackTag = cms.InputTag('trackOfThingsProducerE'),
+    offsetToThinnedKey = cms.uint32(10),
+    expectedCollectionSize = cms.uint32(9)
+)
+
+process.thinningThingProducerF = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thinningThingProducerD'),
+    trackTag = cms.InputTag('trackOfThingsProducerF'),
+    offsetToThinnedKey = cms.uint32(10),
+    expectedCollectionSize = cms.uint32(9)
+)
+
+process.thinningThingProducerG = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    trackTag = cms.InputTag('trackOfThingsProducerG'),
+    offsetToThinnedKey = cms.uint32(0),
+    expectedCollectionSize = cms.uint32(50)
+)
+
+process.thinningThingProducerH = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thinningThingProducerG'),
+    trackTag = cms.InputTag('trackOfThingsProducerH'),
+    offsetToThinnedKey = cms.uint32(20),
+    expectedCollectionSize = cms.uint32(9)
+)
+
+process.thinningThingProducerI = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thinningThingProducerG'),
+    trackTag = cms.InputTag('trackOfThingsProducerI'),
+    offsetToThinnedKey = cms.uint32(20),
+    expectedCollectionSize = cms.uint32(9)
+)
+
+process.thinningThingProducerJ = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    trackTag = cms.InputTag('trackOfThingsProducerJ'),
+    offsetToThinnedKey = cms.uint32(0),
+    expectedCollectionSize = cms.uint32(50)
+)
+
+process.thinningThingProducerK = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thinningThingProducerJ'),
+    trackTag = cms.InputTag('trackOfThingsProducerK'),
+    offsetToThinnedKey = cms.uint32(30),
+    expectedCollectionSize = cms.uint32(9)
+)
+
+process.thinningThingProducerL = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thinningThingProducerJ'),
+    trackTag = cms.InputTag('trackOfThingsProducerL'),
+    offsetToThinnedKey = cms.uint32(30),
+    expectedCollectionSize = cms.uint32(9)
+)
+
+process.thinningThingProducerM = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thingProducer'),
+    trackTag = cms.InputTag('trackOfThingsProducerM'),
+    offsetToThinnedKey = cms.uint32(0),
+    expectedCollectionSize = cms.uint32(50)
+)
+
+process.aliasM = cms.EDAlias(
+  thinningThingProducerM = cms.VPSet(
+    cms.PSet(type = cms.string('edmtestThings')),
+    # the next one should get ignored
+    cms.PSet(type = cms.string('edmThinnedAssociation')) 
+  )
+)
+
+process.thinningThingProducerN = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thinningThingProducerM'),
+    trackTag = cms.InputTag('trackOfThingsProducerN'),
+    offsetToThinnedKey = cms.uint32(40),
+    expectedCollectionSize = cms.uint32(9)
+)
+
+process.aliasN = cms.EDAlias(
+  thinningThingProducerN = cms.VPSet(
+    cms.PSet(type = cms.string('edmtestThings')),
+    # the next one should get ignored
+    cms.PSet(type = cms.string('edmThinnedAssociation')) 
+  )
+)
+
+process.thinningThingProducerO = cms.EDProducer("ThinningThingProducer",
+    inputTag = cms.InputTag('thinningThingProducerM'),
+    trackTag = cms.InputTag('trackOfThingsProducerO'),
+    offsetToThinnedKey = cms.uint32(40),
+    expectedCollectionSize = cms.uint32(9)
+)
+
+process.aliasO = cms.EDAlias(
+  thinningThingProducerO = cms.VPSet(
+    cms.PSet(type = cms.string('edmtestThings')),
+    # the next one should get ignored
+    cms.PSet(type = cms.string('edmThinnedAssociation')) 
+  )
+)
+
+process.testFirstA = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thingProducer'),
+    thinnedTag = cms.InputTag('thinningThingProducerA'),
+    associationTag = cms.InputTag('thinningThingProducerA'),
+    trackTag = cms.InputTag('trackOfThingsProducerA'),
+    expectedParentContent = cms.vint32( 0,  1,  2,  3,  4,  5,  6,  7,  8,  9,
+                                       10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+                                       20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
+                                       30, 31, 32, 33, 34, 35, 36, 37, 38, 39,
+                                       40, 41, 42, 43, 44, 45, 46, 47, 48, 49
+    ),
+    expectedThinnedContent = cms.vint32(0, 1, 2, 3, 4, 5, 6, 7, 8),
+    expectedIndexesIntoParent = cms.vuint32(0, 1, 2, 3, 4, 5, 6, 7, 8),
+    expectedValues = cms.vint32(0, 1, 2, 3, 4, 5, 6, 7, 8)
+)
+
+process.testFirstB = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerA'),
+    thinnedTag = cms.InputTag('thinningThingProducerB'),
+    associationTag = cms.InputTag('thinningThingProducerB'),
+    trackTag = cms.InputTag('trackOfThingsProducerB'),
+    expectedParentContent = cms.vint32( 0,  1,  2,  3,  4,  5,  6,  7,  8),
+    expectedThinnedContent = cms.vint32(0, 1, 2, 3),
+    expectedIndexesIntoParent = cms.vuint32(0, 1, 2, 3),
+    expectedValues = cms.vint32(0, 1, 2, 3)
+)
+
+process.testFirstC = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerA'),
+    thinnedTag = cms.InputTag('thinningThingProducerC'),
+    associationTag = cms.InputTag('thinningThingProducerC'),
+    trackTag = cms.InputTag('trackOfThingsProducerC'),
+    expectedParentContent = cms.vint32( 0,  1,  2,  3,  4,  5,  6,  7,  8),
+    expectedThinnedContent = cms.vint32(4, 5, 6, 7),
+    expectedIndexesIntoParent = cms.vuint32(4, 5, 6, 7),
+    expectedValues = cms.vint32(4, 5, 6, 7)
+)
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testThinningTestSubProcess1.root'),
+    outputCommands = cms.untracked.vstring(
+        'keep *',
+        'drop *_thinningThingProducerM_*_*',
+        'drop *_thinningThingProducerN_*_*',
+        'drop *_thinningThingProducerO_*_*'
+    )
+)
+
+process.p = cms.Path(process.thingProducer * process.trackOfThingsProducerA
+                                           * process.trackOfThingsProducerB
+                                           * process.trackOfThingsProducerC
+                                           * process.trackOfThingsProducerD
+                                           * process.trackOfThingsProducerE
+                                           * process.trackOfThingsProducerF
+                                           * process.trackOfThingsProducerG
+                                           * process.trackOfThingsProducerH
+                                           * process.trackOfThingsProducerI
+                                           * process.trackOfThingsProducerJ
+                                           * process.trackOfThingsProducerK
+                                           * process.trackOfThingsProducerL
+                                           * process.trackOfThingsProducerM
+                                           * process.trackOfThingsProducerN
+                                           * process.trackOfThingsProducerO
+                                           * process.thinningThingProducerA
+                                           * process.thinningThingProducerB
+                                           * process.thinningThingProducerC
+                                           * process.thinningThingProducerD
+                                           * process.thinningThingProducerE
+                                           * process.thinningThingProducerF
+                                           * process.thinningThingProducerG
+                                           * process.thinningThingProducerH
+                                           * process.thinningThingProducerI
+                                           * process.thinningThingProducerJ
+                                           * process.thinningThingProducerK
+                                           * process.thinningThingProducerL
+                                           * process.thinningThingProducerM
+                                           * process.thinningThingProducerN
+                                           * process.thinningThingProducerO
+                                           * process.testFirstA
+                                           * process.testFirstB
+                                           * process.testFirstC
+                    )
+
+process.endPath = cms.EndPath(process.out)
+
+# ---------------------------------------------------------------
+
+secondProcess = cms.Process("SECOND")
+process.subProcess = cms.SubProcess(secondProcess,
+    outputCommands = cms.untracked.vstring(
+        'keep *',
+        'drop *_thinningThingProducerM_*_*',
+        'drop *_thinningThingProducerN_*_*',
+        'drop *_thinningThingProducerO_*_*',
+    )
+)
+
+secondProcess.testSecondA = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thingProducer'),
+    thinnedTag = cms.InputTag('thinningThingProducerA'),
+    associationTag = cms.InputTag('thinningThingProducerA'),
+    trackTag = cms.InputTag('trackOfThingsProducerA'),
+    expectedParentContent = cms.vint32( 0,  1,  2,  3,  4,  5,  6,  7,  8,  9,
+                                       10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+                                       20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
+                                       30, 31, 32, 33, 34, 35, 36, 37, 38, 39,
+                                       40, 41, 42, 43, 44, 45, 46, 47, 48, 49
+    ),
+    expectedThinnedContent = cms.vint32(0, 1, 2, 3, 4, 5, 6, 7, 8),
+    expectedIndexesIntoParent = cms.vuint32(0, 1, 2, 3, 4, 5, 6, 7, 8),
+    expectedValues = cms.vint32(0, 1, 2, 3, 4, 5, 6, 7, 8)
+)
+
+secondProcess.testSecondB = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerA'),
+    thinnedTag = cms.InputTag('thinningThingProducerB'),
+    associationTag = cms.InputTag('thinningThingProducerB'),
+    trackTag = cms.InputTag('trackOfThingsProducerB'),
+    expectedParentContent = cms.vint32( 0,  1,  2,  3,  4,  5,  6,  7,  8),
+    expectedThinnedContent = cms.vint32(0, 1, 2, 3),
+    expectedIndexesIntoParent = cms.vuint32(0, 1, 2, 3),
+    expectedValues = cms.vint32(0, 1, 2, 3)
+)
+
+secondProcess.testSecondC = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerA'),
+    thinnedTag = cms.InputTag('thinningThingProducerC'),
+    associationTag = cms.InputTag('thinningThingProducerC'),
+    trackTag = cms.InputTag('trackOfThingsProducerC'),
+    expectedParentContent = cms.vint32( 0,  1,  2,  3,  4,  5,  6,  7,  8),
+    expectedThinnedContent = cms.vint32(4, 5, 6, 7),
+    expectedIndexesIntoParent = cms.vuint32(4, 5, 6, 7),
+    expectedValues = cms.vint32(4, 5, 6, 7)
+)
+
+secondProcess.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testThinningTestSubProcess2.root'),
+    outputCommands = cms.untracked.vstring(
+        'keep *',
+        'drop *_thingProducer_*_*',
+        'drop *_thinningThingProducerD_*_*',
+        'drop *_thinningThingProducerH_*_*',
+        'drop *_thinningThingProducerI_*_*',
+        'drop *_thinningThingProducerJ_*_*',
+        'drop *_thinningThingProducerK_*_*',
+        'drop *_thinningThingProducerL_*_*',
+        'drop *_aliasM_*_*',
+        'drop *_aliasN_*_*',
+    )
+)
+
+secondProcess.p = cms.Path(secondProcess.testSecondA * secondProcess.testSecondB * secondProcess.testSecondC)
+
+secondProcess.endPath = cms.EndPath(secondProcess.out)
+
+# ---------------------------------------------------------------
+
+thirdProcess = cms.Process("THIRD")
+secondProcess.subProcess = cms.SubProcess(thirdProcess,
+    outputCommands = cms.untracked.vstring(
+        'keep *',
+        'drop *_thingProducer_*_*',
+        'drop *_thinningThingProducerD_*_*',
+        'drop *_thinningThingProducerH_*_*',
+        'drop *_thinningThingProducerI_*_*',
+        'drop *_thinningThingProducerJ_*_*',
+        'drop *_thinningThingProducerK_*_*',
+        'drop *_thinningThingProducerL_*_*',
+        'drop *_aliasM_*_*',
+        'drop *_aliasN_*_*',
+    )
+)
+
+thirdProcess.testThirdA = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thingProducer'),
+    thinnedTag = cms.InputTag('thinningThingProducerA'),
+    associationTag = cms.InputTag('thinningThingProducerA'),
+    trackTag = cms.InputTag('trackOfThingsProducerA'),
+    parentWasDropped = cms.bool(True),
+    expectedThinnedContent = cms.vint32(0, 1, 2, 3, 4, 5, 6, 7, 8),
+    expectedIndexesIntoParent = cms.vuint32(0, 1, 2, 3, 4, 5, 6, 7, 8),
+    expectedValues = cms.vint32(0, 1, 2, 3, 4, 5, 6, 7, 8)
+)
+
+thirdProcess.testThirdB = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerA'),
+    thinnedTag = cms.InputTag('thinningThingProducerB'),
+    associationTag = cms.InputTag('thinningThingProducerB'),
+    trackTag = cms.InputTag('trackOfThingsProducerB'),
+    expectedParentContent = cms.vint32( 0,  1,  2,  3,  4,  5,  6,  7,  8),
+    expectedThinnedContent = cms.vint32(0, 1, 2, 3),
+    expectedIndexesIntoParent = cms.vuint32(0, 1, 2, 3),
+    expectedValues = cms.vint32(0, 1, 2, 3)
+)
+
+thirdProcess.testThirdC = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerA'),
+    thinnedTag = cms.InputTag('thinningThingProducerC'),
+    associationTag = cms.InputTag('thinningThingProducerC'),
+    trackTag = cms.InputTag('trackOfThingsProducerC'),
+    expectedParentContent = cms.vint32( 0,  1,  2,  3,  4,  5,  6,  7,  8),
+    expectedThinnedContent = cms.vint32(4, 5, 6, 7),
+    expectedIndexesIntoParent = cms.vuint32(4, 5, 6, 7),
+    expectedValues = cms.vint32(4, 5, 6, 7)
+)
+
+thirdProcess.testThirdD = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thingProducer'),
+    thinnedTag = cms.InputTag('thinningThingProducerD'),
+    associationTag = cms.InputTag('thinningThingProducerD'),
+    trackTag = cms.InputTag('trackOfThingsProducerD'),
+    parentWasDropped = cms.bool(True),
+    thinnedWasDropped = cms.bool(True),
+    expectedIndexesIntoParent = cms.vuint32(10, 11, 12, 13, 14, 15, 16, 17, 18),
+    expectedValues = cms.vint32(10, 11, 12, 13, 14, 15, 16, 17, 18)
+)
+
+thirdProcess.testThirdE = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerD'),
+    thinnedTag = cms.InputTag('thinningThingProducerE'),
+    associationTag = cms.InputTag('thinningThingProducerE'),
+    trackTag = cms.InputTag('trackOfThingsProducerE'),
+    parentWasDropped = cms.bool(True),
+    expectedThinnedContent = cms.vint32(10, 11, 12, 13),
+    expectedIndexesIntoParent = cms.vuint32(0, 1, 2, 3),
+    expectedValues = cms.vint32(10, 11, 12, 13)
+)
+
+thirdProcess.testThirdF = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerD'),
+    thinnedTag = cms.InputTag('thinningThingProducerF'),
+    associationTag = cms.InputTag('thinningThingProducerF'),
+    trackTag = cms.InputTag('trackOfThingsProducerF'),
+    parentWasDropped = cms.bool(True),
+    expectedThinnedContent = cms.vint32(14, 15, 16, 17),
+    expectedIndexesIntoParent = cms.vuint32(4, 5, 6, 7),
+    expectedValues = cms.vint32(14, 15, 16, 17)
+)
+
+thirdProcess.testThirdG = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thingProducer'),
+    thinnedTag = cms.InputTag('thinningThingProducerG'),
+    associationTag = cms.InputTag('thinningThingProducerG'),
+    trackTag = cms.InputTag('trackOfThingsProducerG'),
+    parentWasDropped = cms.bool(True),
+    expectedThinnedContent = cms.vint32(20, 21, 22, 23, 24, 25, 26, 27, 28),
+    expectedIndexesIntoParent = cms.vuint32(20, 21, 22, 23, 24, 25, 26, 27, 28),
+    expectedValues = cms.vint32(20, 21, 22, 23, 24, 25, 26, 27, 28)
+)
+
+thirdProcess.testThirdH = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerG'),
+    thinnedTag = cms.InputTag('thinningThingProducerH'),
+    associationTag = cms.InputTag('thinningThingProducerH'),
+    trackTag = cms.InputTag('trackOfThingsProducerH'),
+    thinnedWasDropped = cms.bool(True),
+    expectedParentContent = cms.vint32( 20,  21,  22,  23,  24,  25,  26,  27,  28),
+    associationShouldBeDropped = cms.bool(True),
+    expectedValues = cms.vint32(20, 21, 22, 23)
+)
+
+thirdProcess.testThirdI = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerG'),
+    thinnedTag = cms.InputTag('thinningThingProducerI'),
+    associationTag = cms.InputTag('thinningThingProducerI'),
+    trackTag = cms.InputTag('trackOfThingsProducerI'),
+    thinnedWasDropped = cms.bool(True),
+    associationShouldBeDropped = cms.bool(True),
+    expectedParentContent = cms.vint32( 20,  21,  22,  23,  24,  25,  26,  27,  28),
+    expectedValues = cms.vint32(24, 25, 26, 27)
+)
+
+thirdProcess.testThirdJ = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thingProducer'),
+    thinnedTag = cms.InputTag('thinningThingProducerJ'),
+    associationTag = cms.InputTag('thinningThingProducerJ'),
+    trackTag = cms.InputTag('trackOfThingsProducerJ'),
+    parentWasDropped = cms.bool(True),
+    thinnedWasDropped = cms.bool(True),
+    associationShouldBeDropped = cms.bool(True),
+    expectedValues = cms.vint32(30, 31, 32, 33, 34, 35, 36, 37, 38)
+)
+
+thirdProcess.testThirdK = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerJ'),
+    thinnedTag = cms.InputTag('thinningThingProducerK'),
+    associationTag = cms.InputTag('thinningThingProducerK'),
+    trackTag = cms.InputTag('trackOfThingsProducerK'),
+    parentWasDropped = cms.bool(True),
+    thinnedWasDropped = cms.bool(True),
+    associationShouldBeDropped = cms.bool(True),
+    expectedValues = cms.vint32(30, 31, 32, 33)
+)
+
+thirdProcess.testThirdL = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerJ'),
+    thinnedTag = cms.InputTag('thinningThingProducerL'),
+    associationTag = cms.InputTag('thinningThingProducerL'),
+    trackTag = cms.InputTag('trackOfThingsProducerL'),
+    parentWasDropped = cms.bool(True),
+    thinnedWasDropped = cms.bool(True),
+    associationShouldBeDropped = cms.bool(True),
+    expectedValues = cms.vint32(34, 35, 36, 37)
+)
+
+thirdProcess.testThirdM = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thingProducer'),
+    thinnedTag = cms.InputTag('thinningThingProducerM'),
+    associationTag = cms.InputTag('thinningThingProducerM'),
+    trackTag = cms.InputTag('trackOfThingsProducerM'),
+    parentWasDropped = cms.bool(True),
+    thinnedWasDropped = cms.bool(True),
+    expectedIndexesIntoParent = cms.vuint32(40, 41, 42, 43, 44, 45, 46, 47, 48),
+    expectedValues = cms.vint32(40, 41, 42, 43, 44, 45, 46, 47, 48)
+)
+
+thirdProcess.testThirdN = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerM'),
+    thinnedTag = cms.InputTag('thinningThingProducerN'),
+    associationTag = cms.InputTag('thinningThingProducerN'),
+    trackTag = cms.InputTag('trackOfThingsProducerN'),
+    parentWasDropped = cms.bool(True),
+    thinnedWasDropped = cms.bool(True),
+    associationShouldBeDropped = cms.bool(True),
+    expectedValues = cms.vint32(40, 41, 42, 43)
+)
+
+thirdProcess.testThirdO = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerM'),
+    thinnedTag = cms.InputTag('aliasO'),
+    associationTag = cms.InputTag('thinningThingProducerO'),
+    trackTag = cms.InputTag('trackOfThingsProducerO'),
+    thinnedIsAlias = cms.bool(False), # See unaliased in SubProcess
+    parentWasDropped = cms.bool(True),
+    expectedThinnedContent = cms.vint32(44, 45, 46, 47),
+    expectedIndexesIntoParent = cms.vuint32(4, 5, 6, 7),
+    expectedValues = cms.vint32(44, 45, 46, 47)
+)
+
+thirdProcess.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testThinningTestSubProcess3.root')
+)
+
+thirdProcess.p = cms.Path(thirdProcess.testThirdA *
+                     thirdProcess.testThirdB *
+                     thirdProcess.testThirdC *
+                     thirdProcess.testThirdD *
+                     thirdProcess.testThirdE *
+                     thirdProcess.testThirdF *
+                     thirdProcess.testThirdG *
+                     thirdProcess.testThirdH *
+                     thirdProcess.testThirdI *
+                     thirdProcess.testThirdJ *
+                     thirdProcess.testThirdK *
+                     thirdProcess.testThirdL *
+                     thirdProcess.testThirdM *
+                     thirdProcess.testThirdN *
+                     thirdProcess.testThirdO
+)
+
+thirdProcess.endPath = cms.EndPath(thirdProcess.out)

--- a/FWCore/Integration/test/ThinningTest_dropOnInput_cfg.py
+++ b/FWCore/Integration/test/ThinningTest_dropOnInput_cfg.py
@@ -1,0 +1,219 @@
+# Test drop on input
+
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TESTDROPONINPUT")
+
+process.options = cms.untracked.PSet(
+    numberOfStreams = cms.untracked.uint32(1)
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(3)
+)
+
+process.source = cms.Source("PoolSource",
+  fileNames = cms.untracked.vstring('file:testThinningTest1.root'),
+  inputCommands = cms.untracked.vstring(
+    'keep *',
+    'drop *_thingProducer_*_*',
+    'drop *_thinningThingProducerD_*_*',
+    'drop *_thinningThingProducerH_*_*',
+    'drop *_thinningThingProducerI_*_*',
+    'drop *_thinningThingProducerJ_*_*',
+    'drop *_thinningThingProducerK_*_*',
+    'drop *_thinningThingProducerL_*_*',
+    'drop *_aliasM_*_*',
+    'drop *_aliasN_*_*'
+  ),
+  dropDescendantsOfDroppedBranches = cms.untracked.bool(False)
+)
+
+process.testA = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thingProducer'),
+    thinnedTag = cms.InputTag('thinningThingProducerA'),
+    associationTag = cms.InputTag('thinningThingProducerA'),
+    trackTag = cms.InputTag('trackOfThingsProducerA'),
+    parentWasDropped = cms.bool(True),
+    expectedThinnedContent = cms.vint32(0, 1, 2, 3, 4, 5, 6, 7, 8),
+    expectedIndexesIntoParent = cms.vuint32(0, 1, 2, 3, 4, 5, 6, 7, 8),
+    expectedValues = cms.vint32(0, 1, 2, 3, 4, 5, 6, 7, 8)
+)
+
+process.testB = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerA'),
+    thinnedTag = cms.InputTag('thinningThingProducerB'),
+    associationTag = cms.InputTag('thinningThingProducerB'),
+    trackTag = cms.InputTag('trackOfThingsProducerB'),
+    expectedParentContent = cms.vint32( 0,  1,  2,  3,  4,  5,  6,  7,  8),
+    expectedThinnedContent = cms.vint32(0, 1, 2, 3),
+    expectedIndexesIntoParent = cms.vuint32(0, 1, 2, 3),
+    expectedValues = cms.vint32(0, 1, 2, 3)
+)
+
+process.testC = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerA'),
+    thinnedTag = cms.InputTag('thinningThingProducerC'),
+    associationTag = cms.InputTag('thinningThingProducerC'),
+    trackTag = cms.InputTag('trackOfThingsProducerC'),
+    expectedParentContent = cms.vint32( 0,  1,  2,  3,  4,  5,  6,  7,  8),
+    expectedThinnedContent = cms.vint32(4, 5, 6, 7),
+    expectedIndexesIntoParent = cms.vuint32(4, 5, 6, 7),
+    expectedValues = cms.vint32(4, 5, 6, 7)
+)
+
+process.testD = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thingProducer'),
+    thinnedTag = cms.InputTag('thinningThingProducerD'),
+    associationTag = cms.InputTag('thinningThingProducerD'),
+    trackTag = cms.InputTag('trackOfThingsProducerD'),
+    parentWasDropped = cms.bool(True),
+    thinnedWasDropped = cms.bool(True),
+    expectedIndexesIntoParent = cms.vuint32(10, 11, 12, 13, 14, 15, 16, 17, 18),
+    expectedValues = cms.vint32(10, 11, 12, 13, 14, 15, 16, 17, -1)
+)
+
+process.testE = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerD'),
+    thinnedTag = cms.InputTag('thinningThingProducerE'),
+    associationTag = cms.InputTag('thinningThingProducerE'),
+    trackTag = cms.InputTag('trackOfThingsProducerE'),
+    parentWasDropped = cms.bool(True),
+    expectedThinnedContent = cms.vint32(10, 11, 12, 13, 14),
+    expectedIndexesIntoParent = cms.vuint32(0, 1, 2, 3, 4),
+    expectedValues = cms.vint32(10, 11, 12, 13, 14)
+)
+
+process.testF = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerD'),
+    thinnedTag = cms.InputTag('thinningThingProducerF'),
+    associationTag = cms.InputTag('thinningThingProducerF'),
+    trackTag = cms.InputTag('trackOfThingsProducerF'),
+    parentWasDropped = cms.bool(True),
+    expectedThinnedContent = cms.vint32(14, 15, 16, 17),
+    expectedIndexesIntoParent = cms.vuint32(4, 5, 6, 7),
+    expectedValues = cms.vint32(14, 15, 16, 17)
+)
+
+process.testG = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thingProducer'),
+    thinnedTag = cms.InputTag('thinningThingProducerG'),
+    associationTag = cms.InputTag('thinningThingProducerG'),
+    trackTag = cms.InputTag('trackOfThingsProducerG'),
+    parentWasDropped = cms.bool(True),
+    expectedThinnedContent = cms.vint32(20, 21, 22, 23, 24, 25, 26, 27, 28),
+    expectedIndexesIntoParent = cms.vuint32(20, 21, 22, 23, 24, 25, 26, 27, 28),
+    expectedValues = cms.vint32(20, 21, 22, 23, 24, 25, 26, 27, 28)
+)
+
+process.testH = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerG'),
+    thinnedTag = cms.InputTag('thinningThingProducerH'),
+    associationTag = cms.InputTag('thinningThingProducerH'),
+    trackTag = cms.InputTag('trackOfThingsProducerH'),
+    thinnedWasDropped = cms.bool(True),
+    expectedParentContent = cms.vint32( 20,  21,  22,  23,  24,  25,  26,  27,  28),
+    associationShouldBeDropped = cms.bool(True),
+    expectedValues = cms.vint32(20, 21, 22, 23)
+)
+
+process.testI = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerG'),
+    thinnedTag = cms.InputTag('thinningThingProducerI'),
+    associationTag = cms.InputTag('thinningThingProducerI'),
+    trackTag = cms.InputTag('trackOfThingsProducerI'),
+    thinnedWasDropped = cms.bool(True),
+    associationShouldBeDropped = cms.bool(True),
+    expectedParentContent = cms.vint32( 20,  21,  22,  23,  24,  25,  26,  27,  28),
+    expectedValues = cms.vint32(24, 25, 26, 27)
+)
+
+process.testJ = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thingProducer'),
+    thinnedTag = cms.InputTag('thinningThingProducerJ'),
+    associationTag = cms.InputTag('thinningThingProducerJ'),
+    trackTag = cms.InputTag('trackOfThingsProducerJ'),
+    parentWasDropped = cms.bool(True),
+    thinnedWasDropped = cms.bool(True),
+    associationShouldBeDropped = cms.bool(True),
+    expectedValues = cms.vint32(-1, -1, -1, -1, -1, -1, -1, -1, -1)
+)
+
+process.testK = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerJ'),
+    thinnedTag = cms.InputTag('thinningThingProducerK'),
+    associationTag = cms.InputTag('thinningThingProducerK'),
+    trackTag = cms.InputTag('trackOfThingsProducerK'),
+    parentWasDropped = cms.bool(True),
+    thinnedWasDropped = cms.bool(True),
+    associationShouldBeDropped = cms.bool(True),
+    expectedValues = cms.vint32(-1, -1, -1, -1)
+)
+
+process.testL = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerJ'),
+    thinnedTag = cms.InputTag('thinningThingProducerL'),
+    associationTag = cms.InputTag('thinningThingProducerL'),
+    trackTag = cms.InputTag('trackOfThingsProducerL'),
+    parentWasDropped = cms.bool(True),
+    thinnedWasDropped = cms.bool(True),
+    associationShouldBeDropped = cms.bool(True),
+    expectedValues = cms.vint32(-1, -1, -1, -1)
+)
+
+process.testM = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thingProducer'),
+    thinnedTag = cms.InputTag('thinningThingProducerM'),
+    associationTag = cms.InputTag('thinningThingProducerM'),
+    trackTag = cms.InputTag('trackOfThingsProducerM'),
+    parentWasDropped = cms.bool(True),
+    thinnedWasDropped = cms.bool(True),
+    expectedIndexesIntoParent = cms.vuint32(40, 41, 42, 43, 44, 45, 46, 47, 48),
+    expectedValues = cms.vint32(-1, -1, -1, -1, 44, 45, 46, 47, -1)
+)
+
+process.testN = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerM'),
+    thinnedTag = cms.InputTag('thinningThingProducerN'),
+    associationTag = cms.InputTag('thinningThingProducerN'),
+    trackTag = cms.InputTag('trackOfThingsProducerN'),
+    parentWasDropped = cms.bool(True),
+    thinnedWasDropped = cms.bool(True),
+    associationShouldBeDropped = cms.bool(True),
+    expectedValues = cms.vint32(-1, -1, -1, -1)
+)
+
+process.testO = cms.EDAnalyzer("ThinningTestAnalyzer",
+    parentTag = cms.InputTag('thinningThingProducerM'),
+    thinnedTag = cms.InputTag('aliasO'),
+    associationTag = cms.InputTag('thinningThingProducerO'),
+    trackTag = cms.InputTag('trackOfThingsProducerO'),
+    thinnedIsAlias = cms.bool(True),
+    parentWasDropped = cms.bool(True),
+    expectedThinnedContent = cms.vint32(44, 45, 46, 47),
+    expectedIndexesIntoParent = cms.vuint32(4, 5, 6, 7),
+    expectedValues = cms.vint32(44, 45, 46, 47)
+)
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testThinningTestDropOnInput.root')
+)
+
+process.p = cms.Path(process.testA *
+                     process.testB *
+                     process.testC *
+                     process.testD *
+                     process.testE *
+                     process.testF *
+                     process.testG *
+                     process.testH *
+                     process.testI *
+                     process.testJ *
+                     process.testK *
+                     process.testL *
+                     process.testM *
+                     process.testN *
+                     process.testO
+)
+
+process.endPath = cms.EndPath(process.out)

--- a/FWCore/Integration/test/ThinningThingProducer.cc
+++ b/FWCore/Integration/test/ThinningThingProducer.cc
@@ -1,0 +1,95 @@
+
+/** \class edm::ThinningThingSelector
+\author W. David Dagenhart, created 11 June 2014
+*/
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/TestObjects/interface/Thing.h"
+#include "DataFormats/TestObjects/interface/ThingCollection.h"
+#include "DataFormats/TestObjects/interface/TrackOfThings.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/stream/ThinningProducer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Integration/test/WhatsIt.h"
+#include "FWCore/Integration/test/GadgetRcd.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+#include <set>
+#include <string>
+
+namespace edmtest {
+
+  class ThinningThingSelector {
+  public:
+
+    ThinningThingSelector(edm::ParameterSet const& pset, edm::ConsumesCollector&& cc);
+
+    static void fillDescription(edm::ParameterSetDescription & desc);
+
+    void preChoose(edm::Handle<edmtest::ThingCollection> tc, edm::Event const& event, edm::EventSetup const& es);
+
+    bool choose( unsigned int iIndex, edmtest::Thing const& iItem);
+
+  private:
+    edm::EDGetTokenT<TrackOfThingsCollection> trackToken_;
+    std::set<unsigned int> keysToSave_;
+    unsigned int offsetToThinnedKey_;
+    unsigned int expectedCollectionSize_;
+  };
+
+  ThinningThingSelector::ThinningThingSelector(edm::ParameterSet const& pset, edm::ConsumesCollector&& cc) {
+    trackToken_ = cc.consumes<TrackOfThingsCollection>(pset.getParameter<edm::InputTag>("trackTag"));
+    offsetToThinnedKey_ = pset.getParameter<unsigned int>("offsetToThinnedKey");
+    expectedCollectionSize_ = pset.getParameter<unsigned int>("expectedCollectionSize");
+  }
+
+  void ThinningThingSelector::fillDescription(edm::ParameterSetDescription & desc) {
+    desc.add<edm::InputTag>("trackTag");
+    desc.add<unsigned int>("offsetToThinnedKey");
+    desc.add<unsigned int>("expectedCollectionSize");
+  }
+
+  void ThinningThingSelector::preChoose(edm::Handle<edmtest::ThingCollection> tc, edm::Event const& event, edm::EventSetup const& es) {
+    edm::Handle<TrackOfThingsCollection> trackCollection;
+    event.getByToken(trackToken_, trackCollection);
+    for (auto const& track : *trackCollection) {
+      keysToSave_.insert(track.ref1.key() - offsetToThinnedKey_);
+      keysToSave_.insert(track.ref2.key() - offsetToThinnedKey_);
+      keysToSave_.insert(track.ptr1.key() - offsetToThinnedKey_);
+      keysToSave_.insert(track.ptr2.key() - offsetToThinnedKey_);
+    }
+
+    // Just checking to see if the collection got passed in. Not really using it for anything.
+    if(tc->size() != expectedCollectionSize_) {
+      throw cms::Exception("TestFailure") << "ThinningThingSelector::preChoose, collection size = " << tc->size() << " expected size = " << expectedCollectionSize_;
+    }
+
+    // Just checking to see the EventSetup works from here. Not really using it for anything.
+    edm::ESHandle<edmtest::WhatsIt> pSetup;
+    es.get<GadgetRcd>().get(pSetup);
+    pSetup.isValid();
+  }
+
+  bool ThinningThingSelector::choose( unsigned int iIndex, edmtest::Thing const& iItem) {
+
+    // Just checking to see the element in the container got passed in OK. Not really using it.
+    // Just using %10 because it coincidentally works with the arbitrary numbers I picked, no meaning really.
+    if(static_cast<unsigned>(iItem.a % 10) != iIndex % 10) {
+      throw cms::Exception("TestFailure") << "ThinningThingSelector::choose, item content = " << iItem.a << " index = " << iIndex;
+    }
+
+    // Save the Things referenced by the Tracks
+    if(keysToSave_.find(iIndex) == keysToSave_.end()) return false;
+    return true;
+  }
+}
+
+typedef edm::ThinningProducer<edmtest::ThingCollection, edmtest::ThinningThingSelector> ThinningThingProducer;
+DEFINE_FWK_MODULE(ThinningThingProducer);

--- a/FWCore/Integration/test/TrackOfThingsProducer.cc
+++ b/FWCore/Integration/test/TrackOfThingsProducer.cc
@@ -1,0 +1,98 @@
+/** \class edm::ThinningProducer
+\author W. David Dagenhart, created 11 June 2014
+*/
+
+#include "FWCore/Framework/interface/one/EDProducer.h"
+#include "DataFormats/TestObjects/interface/ThingCollection.h"
+#include "DataFormats/TestObjects/interface/TrackOfThings.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+namespace edm {
+  class EventSetup;
+}
+
+namespace edmtest {
+
+  class TrackOfThingsProducer : public edm::one::EDProducer<> {
+  public:
+
+    explicit TrackOfThingsProducer(edm::ParameterSet const&);
+    virtual ~TrackOfThingsProducer();
+
+    void produce(edm::Event&, edm::EventSetup const&) override;
+
+  private:
+
+    void incrementKey(std::vector<unsigned int>::const_iterator& key) const;
+
+    edm::EDGetTokenT<ThingCollection> inputToken_;
+    std::vector<unsigned int> keysToReference_;
+  };
+
+  TrackOfThingsProducer::TrackOfThingsProducer(edm::ParameterSet const& pset) {
+
+    inputToken_ = consumes<ThingCollection>(pset.getParameter<edm::InputTag>("inputTag"));
+
+    keysToReference_ = pset.getParameter<std::vector<unsigned int> >("keysToReference");
+
+    produces<TrackOfThingsCollection>();
+  }
+
+  TrackOfThingsProducer::~TrackOfThingsProducer() { }
+
+  void TrackOfThingsProducer::incrementKey(std::vector<unsigned int>::const_iterator& key) const {
+    ++key;
+    if(key == keysToReference_.end()) key = keysToReference_.begin();
+  }
+
+  void TrackOfThingsProducer::produce(edm::Event& event, edm::EventSetup const&) {
+
+    edm::Handle<ThingCollection> inputCollection;
+    event.getByToken(inputToken_, inputCollection);
+
+    std::auto_ptr<TrackOfThingsCollection> result(new TrackOfThingsCollection);
+
+    // Arbitrarily fabricate some fake data with TrackOfThings pointing to
+    // Thing objects in products written to the event by a different module.
+    // The numbers in the keys here are made up, passed in via the configuration
+    // and have no meaning other than that we will later check that we can
+    // read out what we put in here.
+    std::vector<unsigned int>::const_iterator key = keysToReference_.begin();
+    std::vector<unsigned int>::const_iterator keyEnd = keysToReference_.end();
+    for(unsigned int i = 0; i < 5; ++i) {
+
+
+      edmtest::TrackOfThings trackOfThings;
+
+      trackOfThings.ref1 = edm::Ref<ThingCollection>(inputCollection, *key);
+      incrementKey(key);
+
+      trackOfThings.ref2 = edm::Ref<ThingCollection>(inputCollection, *key);
+      incrementKey(key);
+
+      trackOfThings.ptr1 = edm::Ptr<Thing>(inputCollection, *key);
+      incrementKey(key);
+
+      trackOfThings.ptr2 = edm::Ptr<Thing>(inputCollection, *key);
+      incrementKey(key);
+
+      trackOfThings.refToBase1 = edm::RefToBase<Thing>(trackOfThings.ref1);
+
+      for(auto iKey : keysToReference_) {
+        trackOfThings.refVector1.push_back(edm::Ref<ThingCollection>(inputCollection, iKey));
+        trackOfThings.ptrVector1.push_back(edm::Ptr<Thing>(inputCollection, iKey));
+        trackOfThings.refToBaseVector1.push_back(edm::RefToBase<Thing>(edm::Ref<ThingCollection>(inputCollection, iKey)));
+      }
+
+      result->push_back(trackOfThings);
+    }
+
+    event.put(result);
+  }
+}
+using edmtest::TrackOfThingsProducer;
+DEFINE_FWK_MODULE(TrackOfThingsProducer);

--- a/FWCore/Integration/test/run_ThinningTests.sh
+++ b/FWCore/Integration/test/run_ThinningTests.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+function die { echo Failure $1: status $2 ; exit $2 ; }
+
+pushd ${LOCAL_TMP_DIR}
+
+  cmsRun -p ${LOCAL_TEST_DIR}/ThinningTest1_cfg.py || die "cmsRun ThinningTest1_cfg.py" $?
+
+  cmsRun -p ${LOCAL_TEST_DIR}/ThinningTest2_cfg.py || die "cmsRun ThinningTest2_cfg.py" $?
+
+  cmsRun -p ${LOCAL_TEST_DIR}/ThinningTest3_cfg.py || die "cmsRun ThinningTest3_cfg.py" $?
+
+  cmsRun -p ${LOCAL_TEST_DIR}/ThinningTest4_cfg.py || die "cmsRun ThinningTest4_cfg.py" $?
+
+  cmsRun -p ${LOCAL_TEST_DIR}/ThinningTest_dropOnInput_cfg.py || die "cmsRun ThinningTest_dropOnInput_cfg.py" $?
+
+  cmsRun -p ${LOCAL_TEST_DIR}/ThinningTestSubProcess_cfg.py || die "cmsRun ThinningTestSubProcess_cfg.py" $?
+
+  cmsRun -p ${LOCAL_TEST_DIR}/ThinningTestSubProcessRead_cfg.py || die "cmsRun ThinningTestSubProcessRead_cfg.py" $?
+
+  cmsRun -p ${LOCAL_TEST_DIR}/ThinningTestStreamerIn_cfg.py || die "cmsRun ThinningTestStreamerIn_cfg.py" $?
+
+popd
+
+exit 0

--- a/FWCore/TFWLiteSelector/src/TFWLiteSelectorBasic.cc
+++ b/FWCore/TFWLiteSelector/src/TFWLiteSelectorBasic.cc
@@ -33,6 +33,7 @@
 #include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
 #include "DataFormats/Provenance/interface/RunAuxiliary.h"
+#include "DataFormats/Provenance/interface/ThinnedAssociationsHelper.h"
 #include "FWCore/Framework/interface/DelayedReader.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventPrincipal.h"
@@ -128,6 +129,13 @@ namespace edm {
       reg_(new ProductRegistry()),
       phreg_(new ProcessHistoryRegistry()),
       branchIDListHelper_(new BranchIDListHelper()),
+      // Note that thinned collections are not supported yet, the next
+      // line just makes it compile but when the Ref or Ptr tries to
+      // find the thinned collection it will report them not found.
+      // More work needed here if this is needed (we think no one
+      // is using TFWLiteSelector anymore and intend to implement
+      // this properly if it turns out we are wrong)
+      thinnedAssociationsHelper_(new ThinnedAssociationsHelper()),
       processNames_(),
       reader_(new FWLiteDelayedReader),
       prov_(),
@@ -143,6 +151,7 @@ namespace edm {
       std::shared_ptr<ProductRegistry> reg_;
       std::shared_ptr<ProcessHistoryRegistry> phreg_;
       std::shared_ptr<BranchIDListHelper> branchIDListHelper_;
+      std::shared_ptr<ThinnedAssociationsHelper> thinnedAssociationsHelper_;
       ProcessHistory processNames_;
       std::shared_ptr<FWLiteDelayedReader> reader_;
       std::vector<EventEntryDescription> prov_;
@@ -466,7 +475,7 @@ TFWLiteSelectorBasic::setupNewFile(TFile& iFile) {
   }
   m_->branchIDListHelper_->updateFromInput(*branchIDListsPtr);
   m_->reg_->setFrozen();
-  m_->ep_.reset(new edm::EventPrincipal(m_->reg_, m_->branchIDListHelper_, m_->pc_, nullptr));
+  m_->ep_.reset(new edm::EventPrincipal(m_->reg_, m_->branchIDListHelper_, m_->thinnedAssociationsHelper_, m_->pc_, nullptr));
   everythingOK_ = true;
 }
 

--- a/FWCore/Version/src/GetFileFormatVersion.cc
+++ b/FWCore/Version/src/GetFileFormatVersion.cc
@@ -1,5 +1,5 @@
 #include "FWCore/Version/interface/GetFileFormatVersion.h"
 
 namespace edm {
-  int getFileFormatVersion() { return 19; }
+  int getFileFormatVersion() { return 20; }
 }

--- a/IOPool/Input/src/RootFile.h
+++ b/IOPool/Input/src/RootFile.h
@@ -35,6 +35,7 @@ namespace edm {
   //------------------------------------------------------------
   // Class RootFile: supports file reading.
 
+  class BranchID;
   class BranchIDListHelper;
   class ProductProvenanceRetriever;
   class DaqProvenanceHelper;
@@ -45,6 +46,8 @@ namespace edm {
   class InputFile;
   class ProvenanceReaderBase;
   class ProvenanceAdaptor;
+  class ThinnedAssociationsHelper;
+
   typedef std::map<EntryDescriptionID, EventEntryDescription> EntryDescriptionMap;
 
   class MakeProvenanceReader {
@@ -72,6 +75,8 @@ namespace edm {
              ProductSelectorRules const& productSelectorRules,
              InputType inputType,
              std::shared_ptr<BranchIDListHelper> branchIDListHelper,
+             std::shared_ptr<ThinnedAssociationsHelper> thinnedAssociationsHelper,
+             std::vector<BranchID> const& associationsFromSecondary,
              std::shared_ptr<DuplicateChecker> duplicateChecker,
              bool dropDescendantsOfDroppedProducts,
              ProcessHistoryRegistry& processHistoryRegistry,
@@ -99,7 +104,6 @@ namespace edm {
     std::string const& file() const {return file_;}
     std::shared_ptr<ProductRegistry const> productRegistry() const {return productRegistry_;}
     std::shared_ptr<BranchIDListHelper const> branchIDListHelper() const {return branchIDListHelper_;}
-    BranchIDLists const& branchIDLists() {return *branchIDLists_;}
     EventAuxiliary const& eventAux() const {return eventAux_;}
     // IndexIntoFile::EntryNumber_t const& entryNumber() const {return indexIntoFileIter().entry();}
     // LuminosityBlockNumber_t const& luminosityBlockNumber() const {return indexIntoFileIter().lumi();}
@@ -145,6 +149,7 @@ namespace edm {
     bool wasFirstEventJustRead() const;
     IndexIntoFile::IndexIntoFileItr indexIntoFileIter() const;
     void setPosition(IndexIntoFile::IndexIntoFileItr const& position);
+    void initAssociationsFromSecondary(std::vector<BranchID> const&);
 
   private:
     RootTreePtrArray& treePointers() {return treePointers_;}
@@ -161,6 +166,7 @@ namespace edm {
     void overrideRunNumber(LuminosityBlockID& id);
     void overrideRunNumber(EventID& id, bool isRealData);
     std::string const& newBranchToOldBranch(std::string const& newBranch) const;
+    void markBranchToBeDropped(bool dropDescendants, BranchID const& branchID, std::set<BranchID>& branchesToDrop) const;
     void dropOnInput(ProductRegistry& reg, ProductSelectorRules const& rules, bool dropDescendants, InputType inputType);
     void readParentageTree(InputType inputType);
     void readEntryDescriptionTree(EntryDescriptionMap& entryDescriptionMap, InputType inputType); // backward compatibility
@@ -204,6 +210,8 @@ namespace edm {
     std::shared_ptr<ProductRegistry const> productRegistry_;
     std::shared_ptr<BranchIDLists const> branchIDLists_;
     std::shared_ptr<BranchIDListHelper> branchIDListHelper_;
+    std::unique_ptr<ThinnedAssociationsHelper> fileThinnedAssociationsHelper_;
+    std::shared_ptr<ThinnedAssociationsHelper> thinnedAssociationsHelper_;
     InputSource::ProcessingMode processingMode_;
     int forcedRunOffset_;
     std::map<std::string, std::string> newBranchToOldBranch_;

--- a/IOPool/Input/src/RootInputFileSequence.cc
+++ b/IOPool/Input/src/RootInputFileSequence.cc
@@ -6,6 +6,7 @@
 #include "RootInputFileSequence.h"
 #include "RootTree.h"
 
+#include "DataFormats/Provenance/interface/BranchID.h"
 #include "DataFormats/Provenance/interface/BranchIDListHelper.h"
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
 #include "FWCore/Catalog/interface/SiteLocalConfig.h"
@@ -259,6 +260,8 @@ namespace edm {
           productSelectorRules_,
           inputType_,
           (inputType_ == InputType::SecondarySource ?  std::make_shared<BranchIDListHelper>() :  input_.branchIDListHelper()),
+          (inputType_ == InputType::SecondarySource ?  std::shared_ptr<ThinnedAssociationsHelper>() : input_.thinnedAssociationsHelper()),
+          associationsFromSecondary_,
           duplicateChecker_,
           dropDescendants_,
           processHistoryRegistryForUpdate(),
@@ -841,5 +844,12 @@ namespace edm {
       return ProcessingController::kAtFirstEvent;
     }
     return ProcessingController::kUnknownReverse;
+  }
+
+  void RootInputFileSequence::initAssociationsFromSecondary(std::set<BranchID> const& associationsFromSecondary) {
+    for(auto const& branchID : associationsFromSecondary) {
+      associationsFromSecondary_.push_back(branchID);
+    }
+    rootFile_->initAssociationsFromSecondary(associationsFromSecondary_);
   }
 }

--- a/IOPool/Input/src/RootInputFileSequence.h
+++ b/IOPool/Input/src/RootInputFileSequence.h
@@ -18,6 +18,7 @@ RootInputFileSequence: This is an InputSource
 #include "DataFormats/Provenance/interface/ProcessHistoryID.h"
 
 #include <memory>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -27,6 +28,7 @@ namespace CLHEP {
 
 namespace edm {
 
+  class BranchID;
   class DuplicateChecker;
   class FileCatalogItem;
   class InputFileCatalog;
@@ -76,6 +78,7 @@ namespace edm {
     static void fillDescription(ParameterSetDescription & desc);
     ProcessingController::ForwardState forwardState() const;
     ProcessingController::ReverseState reverseState() const;
+    void initAssociationsFromSecondary(std::set<BranchID> const&);
   private:
     void initFile(bool skipBadFiles);
     bool nextFile();
@@ -103,6 +106,7 @@ namespace edm {
 
     std::vector<std::shared_ptr<IndexIntoFile> > indexesIntoFiles_;
     std::vector<ProcessHistoryID> orderedProcessHistoryIDs_;
+    std::vector<BranchID> associationsFromSecondary_;
 
     unsigned int nStreams_; 
     std::shared_ptr<EventSkipperByID> eventSkipperByID_;

--- a/IOPool/Output/interface/PoolOutputModule.h
+++ b/IOPool/Output/interface/PoolOutputModule.h
@@ -123,6 +123,7 @@ namespace edm {
     void writeProductDescriptionRegistry();
     void writeParentageRegistry();
     void writeBranchIDListRegistry();
+    void writeThinnedAssociationsHelper();
     void writeProductDependencies();
     void finishEndFile();
 

--- a/IOPool/Output/src/PoolOutputModule.cc
+++ b/IOPool/Output/src/PoolOutputModule.cc
@@ -266,6 +266,7 @@ namespace edm {
     writeProductDescriptionRegistry();
     writeParentageRegistry();
     writeBranchIDListRegistry();
+    writeThinnedAssociationsHelper();
     writeProductDependencies();
     finishEndFile();
   }
@@ -283,6 +284,7 @@ namespace edm {
   void PoolOutputModule::writeProductDescriptionRegistry() { rootOutputFile_->writeProductDescriptionRegistry(); }
   void PoolOutputModule::writeParentageRegistry() { rootOutputFile_->writeParentageRegistry(); }
   void PoolOutputModule::writeBranchIDListRegistry() { rootOutputFile_->writeBranchIDListRegistry(); }
+  void PoolOutputModule::writeThinnedAssociationsHelper() { rootOutputFile_->writeThinnedAssociationsHelper(); }
   void PoolOutputModule::writeProductDependencies() { rootOutputFile_->writeProductDependencies(); }
   void PoolOutputModule::finishEndFile() { rootOutputFile_->finishEndFile(); rootOutputFile_.reset(); }
   bool PoolOutputModule::isFileOpen() const { return rootOutputFile_.get() != 0; }

--- a/IOPool/Output/src/RootOutputFile.cc
+++ b/IOPool/Output/src/RootOutputFile.cc
@@ -26,6 +26,7 @@
 #include "DataFormats/Provenance/interface/ParameterSetID.h"
 #include "DataFormats/Provenance/interface/ProcessHistoryID.h"
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
+#include "DataFormats/Provenance/interface/ThinnedAssociationsHelper.h"
 #include "FWCore/Framework/interface/ConstProductRegistry.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/Registry.h"
@@ -534,6 +535,13 @@ namespace edm {
   void RootOutputFile::writeBranchIDListRegistry() {
     BranchIDLists const* p = om_->branchIDLists();
     TBranch* b = metaDataTree_->Branch(poolNames::branchIDListBranchName().c_str(), &p, om_->basketSize(), 0);
+    assert(b);
+    b->Fill();
+  }
+
+  void RootOutputFile::writeThinnedAssociationsHelper() {
+    ThinnedAssociationsHelper const* p = om_->thinnedAssociationsHelper();
+    TBranch* b = metaDataTree_->Branch(poolNames::thinnedAssociationsHelperBranchName().c_str(), &p, om_->basketSize(), 0);
     assert(b);
     b->Fill();
   }

--- a/IOPool/Output/src/RootOutputFile.h
+++ b/IOPool/Output/src/RootOutputFile.h
@@ -61,6 +61,7 @@ namespace edm {
     void writeProductDescriptionRegistry();
     void writeParentageRegistry();
     void writeBranchIDListRegistry();
+    void writeThinnedAssociationsHelper();
     void writeProductDependencies();
 
     void finishEndFile();

--- a/IOPool/SecondaryInput/test/SecondaryProducer.cc
+++ b/IOPool/SecondaryInput/test/SecondaryProducer.cc
@@ -10,6 +10,7 @@
 #include "DataFormats/Provenance/interface/BranchIDListHelper.h"
 #include "DataFormats/Provenance/interface/LuminosityBlockID.h"
 #include "DataFormats/Provenance/interface/ProcessConfiguration.h"
+#include "DataFormats/Provenance/interface/ThinnedAssociationsHelper.h"
 #include "DataFormats/TestObjects/interface/OtherThingCollection.h"
 #include "DataFormats/TestObjects/interface/ThingCollection.h"
 #include "DataFormats/TestObjects/interface/ToyProducts.h"
@@ -70,6 +71,7 @@ namespace edm {
   void SecondaryProducer::beginJob() {
     eventPrincipal_.reset(new EventPrincipal(secInput_->productRegistry(),
                                              secInput_->branchIDListHelper(),
+                                             secInput_->thinnedAssociationsHelper(),
                                              *processConfiguration_,
                                              nullptr));
 
@@ -171,6 +173,7 @@ namespace edm {
     InputSourceDescription desc(ModuleDescription(),
                                 *productRegistry_,
 				std::make_shared<BranchIDListHelper>(),
+                                std::make_shared<ThinnedAssociationsHelper>(),
 				std::make_shared<ActivityRegistry>(),
 				-1, -1, -1, dummy);
     std::shared_ptr<VectorInputSource> input_(static_cast<VectorInputSource *>

--- a/IOPool/Streamer/interface/StreamSerializer.h
+++ b/IOPool/Streamer/interface/StreamSerializer.h
@@ -61,6 +61,8 @@ namespace edm
   
   class EventPrincipal;
   class ModuleCallingContext;
+  class ThinnedAssociationsHelper;
+
   class StreamSerializer
   {
 
@@ -68,7 +70,10 @@ namespace edm
 
     StreamSerializer(SelectedProducts const* selections);
 
-    int serializeRegistry(SerializeDataBuffer &data_buffer, const BranchIDLists &branchIDLists);   
+    int serializeRegistry(SerializeDataBuffer &data_buffer,
+                          const BranchIDLists &branchIDLists,
+                          ThinnedAssociationsHelper const& thinnedAssociationsHelper);
+
     int serializeEvent(EventPrincipal const& eventPrincipal,
                        ParameterSetID const& selectorConfig,
                        bool use_compression, int compression_level,

--- a/IOPool/Streamer/interface/StreamerInputSource.h
+++ b/IOPool/Streamer/interface/StreamerInputSource.h
@@ -26,6 +26,8 @@ class EventMsgView;
 namespace edm {
   class BranchIDListHelper;
   class ParameterSetDescription;
+  class ThinnedAssociationsHelper;
+
   class StreamerInputSource : public RawInputSource {
   public:  
     explicit StreamerInputSource(ParameterSet const& pset,
@@ -40,7 +42,11 @@ namespace edm {
     void deserializeEvent(EventMsgView const& eventView);
 
     static
-    void mergeIntoRegistry(SendJobHeader const& header, ProductRegistry&, BranchIDListHelper&, bool subsequent);
+    void mergeIntoRegistry(SendJobHeader const& header,
+                           ProductRegistry&,
+                           BranchIDListHelper&,
+                           ThinnedAssociationsHelper&,
+                           bool subsequent);
 
     /**
      * Uncompresses the data in the specified input buffer into the
@@ -66,8 +72,13 @@ namespace edm {
       EventPrincipalHolder();
       virtual ~EventPrincipalHolder();
 
-      virtual WrapperBase const* getIt(edm::ProductID const& id) const override;
- 
+      virtual WrapperBase const* getIt(ProductID const& id) const override;
+      virtual WrapperBase const* getThinnedProduct(ProductID const&, unsigned int&) const override;
+      virtual void getThinnedProducts(ProductID const& pid,
+                                      std::vector<WrapperBase const*>& wrappers,
+                                      std::vector<unsigned int>& keys) const override;
+
+
       virtual unsigned int transitionIndex_() const override;
 
       void setEventPrincipal(EventPrincipal* ep);

--- a/IOPool/Streamer/src/StreamSerializer.cc
+++ b/IOPool/Streamer/src/StreamSerializer.cc
@@ -42,7 +42,9 @@ namespace edm {
    * into the specified InitMessage.
    */
 
-  int StreamSerializer::serializeRegistry(SerializeDataBuffer &data_buffer, const BranchIDLists &branchIDLists) {
+  int StreamSerializer::serializeRegistry(SerializeDataBuffer &data_buffer,
+                                          const BranchIDLists &branchIDLists,
+                                          ThinnedAssociationsHelper const& thinnedAssociationsHelper) {
     FDEBUG(6) << "StreamSerializer::serializeRegistry" << std::endl;
     SendJobHeader sd;
 
@@ -56,6 +58,7 @@ namespace edm {
     }
     Service<ConstProductRegistry> reg;
     sd.setBranchIDLists(branchIDLists);
+    sd.setThinnedAssociationsHelper(thinnedAssociationsHelper);
     SendJobHeader::ParameterSetMap psetMap;
 
     pset::Registry::instance()->fillMap(psetMap);

--- a/IOPool/Streamer/src/StreamerInputSource.cc
+++ b/IOPool/Streamer/src/StreamerInputSource.cc
@@ -14,6 +14,7 @@
 #include "DataFormats/Provenance/interface/EventSelectionID.h"
 #include "DataFormats/Provenance/interface/BranchIDListHelper.h"
 #include "DataFormats/Provenance/interface/BranchListIndex.h"
+#include "DataFormats/Provenance/interface/ThinnedAssociationsHelper.h"
 
 #include "zlib.h"
 
@@ -61,7 +62,11 @@ namespace edm {
   }
 
   void
-  StreamerInputSource::mergeIntoRegistry(SendJobHeader const& header, ProductRegistry& reg, BranchIDListHelper& branchIDListHelper, bool subsequent) {
+  StreamerInputSource::mergeIntoRegistry(SendJobHeader const& header,
+                                         ProductRegistry& reg,
+                                         BranchIDListHelper& branchIDListHelper,
+                                         ThinnedAssociationsHelper& thinnedHelper,
+                                         bool subsequent) {
 
     SendDescs const& descs = header.descs();
 
@@ -75,6 +80,7 @@ namespace edm {
         throw cms::Exception("MismatchedInput","RootInputFileSequence::previousEvent()") << mergeInfo;
       }
       branchIDListHelper.updateFromInput(header.branchIDLists());
+      thinnedHelper.updateFromInput(header.thinnedAssociationsHelper(), false, std::vector<BranchID>());
     } else {
       declareStreamers(descs);
       buildClassCache(descs);
@@ -83,6 +89,7 @@ namespace edm {
         reg.updateFromInput(descs);
       }
       branchIDListHelper.updateFromInput(header.branchIDLists());
+      thinnedHelper.updateFromInput(header.thinnedAssociationsHelper(), false, std::vector<BranchID>());
     }
   }
 
@@ -163,7 +170,7 @@ namespace edm {
   void
   StreamerInputSource::deserializeAndMergeWithRegistry(InitMsgView const& initView, bool subsequent) {
      std::auto_ptr<SendJobHeader> sd = deserializeRegistry(initView);
-     mergeIntoRegistry(*sd, productRegistryUpdate(), *branchIDListHelper(), subsequent);
+     mergeIntoRegistry(*sd, productRegistryUpdate(), *branchIDListHelper(), *thinnedAssociationsHelper(), subsequent);
      if (subsequent) {
        adjustEventToNewProductRegistry_ = true;
      }
@@ -371,6 +378,19 @@ namespace edm {
   StreamerInputSource::EventPrincipalHolder::getIt(ProductID const& id) const {
     return eventPrincipal_ ? eventPrincipal_->getIt(id) : nullptr;
   }
+
+  WrapperBase const*
+  StreamerInputSource::EventPrincipalHolder::getThinnedProduct(edm::ProductID const& id, unsigned int& index) const {
+    return eventPrincipal_ ? eventPrincipal_->getThinnedProduct(id, index) : nullptr;
+  }
+
+  void
+  StreamerInputSource::EventPrincipalHolder::getThinnedProducts(ProductID const& pid,
+                                                                std::vector<WrapperBase const*>& wrappers,
+                                                                std::vector<unsigned int>& keys) const {
+    if (eventPrincipal_) eventPrincipal_->getThinnedProducts(pid, wrappers, keys);
+  }
+
 
   unsigned int
   StreamerInputSource::EventPrincipalHolder::transitionIndex_() const {

--- a/IOPool/Streamer/src/StreamerOutputModuleBase.cc
+++ b/IOPool/Streamer/src/StreamerOutputModuleBase.cc
@@ -138,7 +138,7 @@ namespace edm {
   std::auto_ptr<InitMsgBuilder>
   StreamerOutputModuleBase::serializeRegistry() {
 
-    serializer_.serializeRegistry(serializeDataBuffer_, *branchIDLists());
+    serializer_.serializeRegistry(serializeDataBuffer_, *branchIDLists(), *thinnedAssociationsHelper());
 
     // resize bufs_ to reflect space used in serializer_ + header
     // I just added an overhead for header of 50000 for now

--- a/Mixing/Base/src/PileUp.cc
+++ b/Mixing/Base/src/PileUp.cc
@@ -1,6 +1,7 @@
 #include "Mixing/Base/interface/PileUp.h"
 #include "DataFormats/Provenance/interface/BranchIDListHelper.h"
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
+#include "DataFormats/Provenance/interface/ThinnedAssociationsHelper.h"
 #include "FWCore/Framework/interface/EventPrincipal.h"
 #include "FWCore/Framework/interface/InputSourceDescription.h"
 #include "FWCore/Framework/src/SignallingProductRegistry.h"
@@ -44,6 +45,7 @@ namespace edm {
                                                                    ModuleDescription(),
                                                                    *productRegistry_,
                                                                    std::make_shared<BranchIDListHelper>(),
+                                                                   std::make_shared<ThinnedAssociationsHelper>(),
                                                                    std::make_shared<ActivityRegistry>(),
                                                                    -1, -1, -1,
                                                                    PreallocationConfiguration()
@@ -74,6 +76,7 @@ namespace edm {
     // A modified HistoryAppender must be used for unscheduled processing.
     eventPrincipal_.reset(new EventPrincipal(input_->productRegistry(),
                                        input_->branchIDListHelper(),
+                                       input_->thinnedAssociationsHelper(),
                                        *processConfiguration_,
                                        nullptr));
 


### PR DESCRIPTION
Implementation of a new feature. This includes a
template class to be used to create thinned collection
producers. It also includes code to automatically redirect
Ref's, Ptr's, RefVector's, PtrVector's and things derived
from them to the thinned collections if the original
collections have been dropped. ThinnedAssociations and
a new table in the Framework are implemented to make
the redirection work. Keeping and dropping of the
ThinnedAssociations and table entries is handled automatically.
This includes code to make this work with Root I/O, Secondary
file input, secondary source, subprocesses, FWLite, EDAlias's,
and Streamer I/O. There are new unit tests for all
those cases as well.
