### PR TITLE
Avoid unnecessary use of TType

### DIFF
--- a/FWCore/Utilities/interface/TypeWithDict.h
+++ b/FWCore/Utilities/interface/TypeWithDict.h
@@ -66,7 +66,6 @@ public:
   bool hasDictionary() const;
   std::type_info const& typeInfo() const;
   std::type_info const& id() const;
-  TType* getType() const;
   TClass* getClass() const;
   TEnum* getEnum() const;
   TDataType* getDataType() const;
@@ -118,9 +117,6 @@ public:
   void deallocate(void* address) const;
   ObjectWithDict construct() const;
   void destruct(void* address, bool dealloc = true) const;
-  void* ttype() const {
-    return type_;
-  }
 };
 
 // A related free function

--- a/FWCore/Utilities/src/TypeWithDict.cc
+++ b/FWCore/Utilities/src/TypeWithDict.cc
@@ -59,13 +59,53 @@ namespace edm {
     typedef tbb::concurrent_unordered_map<std::string, TypeWithDict> TypeMap;
     static TypeMap typeMap;
     TypeMap::const_iterator it = typeMap.find(name);
-    if(it != typeMap.end()) {
+    if (it != typeMap.end()) {
       return TypeWithDict(it->second, property);
     }
     TClass* theClass = TClass::GetClass(name.c_str());
-    if(theClass != nullptr && theClass->GetTypeInfo() != nullptr) {
+    if (theClass != nullptr && theClass->GetTypeInfo() != nullptr) {
       return TypeWithDict(theClass, property);
     }
+    TDataType* theDataType = gROOT->GetType(name.c_str()); 
+    if(theDataType) {
+      switch(theDataType->GetType()) {
+      case kUInt_t:
+        return TypeWithDict(typeid(unsigned int), property);
+      case kInt_t:
+        return TypeWithDict(typeid(int), property);
+      case kULong_t:
+        return TypeWithDict(typeid(unsigned long), property);
+      case kLong_t:
+        return TypeWithDict(typeid(long), property);
+      case kULong64_t:
+        return TypeWithDict(typeid(unsigned long long), property);
+      case kLong64_t:
+        return TypeWithDict(typeid(long long), property);
+      case kUShort_t:
+        return TypeWithDict(typeid(unsigned short), property);
+      case kShort_t:
+        return TypeWithDict(typeid(short), property);
+      case kUChar_t:
+        return TypeWithDict(typeid(unsigned char), property);
+      case kChar_t:
+        return TypeWithDict(typeid(char), property);
+      case kBool_t:
+        return TypeWithDict(typeid(bool), property);
+      case kFloat_t:
+        return TypeWithDict(typeid(float), property);
+      case kFloat16_t:
+        return TypeWithDict(typeid(Float16_t), property);
+      case kDouble_t:
+        return TypeWithDict(typeid(double), property);
+      case kDouble32_t:
+        return TypeWithDict(typeid(Double32_t), property);
+      case kCharStar:
+        return TypeWithDict(typeid(char*), property);
+      case kDataTypeAliasSignedChar_t:
+        return TypeWithDict(typeid(signed char), property);
+      }
+    }
+
     TType* type = gInterpreter->Type_Factory(name);
     if (!gInterpreter->Type_IsValid(type)) {
       typeMap.insert(std::make_pair(name, TypeWithDict()));
@@ -127,26 +167,18 @@ namespace edm {
   TypeWithDict::TypeWithDict(std::type_info const& ti, long property /*= 0L*/) :
     ti_(&ti),
     type_(nullptr),
-    class_(nullptr),
+    class_(TClass::GetClass(ti)),
     enum_(nullptr),
-    dataType_(nullptr),
+    dataType_(TDataType::GetDataType(TDataType::GetType(ti))),
     property_(property) {
+
+    if(class_ != nullptr || dataType_ != nullptr) {
+      return;
+    }
 
     type_ = gInterpreter->Type_Factory(ti);
     if (!gInterpreter->Type_IsValid(type_)) {
-      // This can happen if no dictionary has been loaded for the class or enum.
-      // If this is a class, trigger the loading of the dictionary.
-      class_ = TClass::GetClass(ti);
-    }
-    if (!gInterpreter->Type_IsValid(type_)) {
       throwTypeException("TypeWithDict(TType*, property): ", name());
-    }
-    dataType_ = TDataType::GetDataType(TDataType::GetType(ti));
-    if (class_ == nullptr &&
-        !gInterpreter->Type_IsFundamental(type_) &&
-        !gInterpreter->Type_IsEnum(type_)) {
-      // Must be a class, struct, or union.
-      class_ = TClass::GetClass(ti);
     }
     if (gInterpreter->Type_IsEnum(type_)) {
       processEnumeration();
@@ -162,7 +194,6 @@ namespace edm {
     property_((long) kIsClass | property) {
 
     ti_ = cl->GetTypeInfo();
-    type_ = gInterpreter->Type_Factory(*cl->GetTypeInfo());
   }
 
   TypeWithDict::TypeWithDict(TMethodArg* arg, long property /*= 0L*/) :
@@ -210,9 +241,10 @@ namespace edm {
     if (*ti_ == typeid(void)) {
       return false;
     }
-    if (type_ == nullptr) {
-      throwTypeException("TypeWithDict::operator bool(): ", name());
+    if (class_ != nullptr || dataType_ != nullptr || enum_ != nullptr) {
+      return true; 
     }
+    assert(type_ != nullptr);
     return gInterpreter->Type_Bool(type_);
   }
 
@@ -221,7 +253,7 @@ namespace edm {
     if (*ti_ == typeid(void)) {
       return true;
     }
-    if(ti_->name()[1] == '\0') {
+    if (ti_->name()[1] == '\0') {
       // returns true for built in types (single character mangled names)
       return true; 
     }
@@ -236,11 +268,6 @@ namespace edm {
   std::type_info const&
   TypeWithDict::id() const {
     return *ti_;
-  }
-
-  TType*
-  TypeWithDict::getType() const {
-    return type_;
   }
 
   TClass*
@@ -266,87 +293,71 @@ namespace edm {
   bool
   TypeWithDict::isClass() const {
     // Note: This really means is class, struct, or union.
-    if (type_ == nullptr) {
-      return false;
-    }
-    return gInterpreter->Type_IsClass(type_);
+    return class_ != nullptr;
   }
 
   bool
   TypeWithDict::isConst() const {
-    // Note: We must check the property flags here too because
-    //       typeid() ignores const.
-    if (type_ == nullptr) {
-      return false;
-    }
-    return gInterpreter->Type_IsConst(type_) || (property_ & (long) kIsConstant);
+    // Note: We must check the property flags here because typeid() ignores const.
+    return (property_ & (long) kIsConstant);
   }
 
   bool
   TypeWithDict::isArray() const {
-    if (type_ == nullptr) {
-      return false;
-    }
-    return gInterpreter->Type_IsArray(type_);
+    return (name().back() == ']');
   }
 
   bool
   TypeWithDict::isEnum() const {
-    if (type_ == nullptr) {
-      return false;
-    }
-    return gInterpreter->Type_IsEnum(type_);
+    return enum_ != nullptr;
   }
 
   bool
   TypeWithDict::isFundamental() const {
-    if (type_ == nullptr) {
-      return false;
-    }
-    return gInterpreter->Type_IsFundamental(type_);
+    return dataType_ != nullptr;
   }
 
   bool
   TypeWithDict::isPointer() const {
-    if (type_ == nullptr) {
-      return false;
-    }
-    return gInterpreter->Type_IsPointer(type_);
+    return (name().back() == '*');
   }
 
   bool
   TypeWithDict::isReference() const {
     // Note: We must check the property flags here too because
     //       typeid() ignores references.
+    if (property_ & (long) kIsReference) {
+      return true;
+    }
     if (type_ == nullptr) {
       return false;
     }
-    return gInterpreter->Type_IsReference(type_) ||
-           (property_ & (long) kIsReference);
+    return gInterpreter->Type_IsReference(type_);
   }
 
   bool
   TypeWithDict::isTemplateInstance() const {
-    if (type_ == nullptr) {
+    if (class_ == nullptr ) {
       return false;
     }
-    return gInterpreter->Type_IsTemplateInstance(type_);
+    return (name().back() == '>');
   }
 
   bool
   TypeWithDict::isTypedef() const {
-    if (type_ == nullptr) {
+    if (class_ != nullptr || dataType_ != nullptr) {
       return false;
     }
+    assert(type_ != nullptr);
     return gInterpreter->Type_IsTypedef(type_);
   }
 
   bool
   TypeWithDict::isVirtual() const {
-    if (type_ == nullptr) {
+    if (class_ == nullptr) {
       return false;
     }
-    return gInterpreter->Type_IsVirtual(type_);
+    return (class_->ClassProperty() & (long) kClassHasVirtual);
   }
 
   void
@@ -365,9 +376,6 @@ namespace edm {
 
   std::string
   TypeWithDict::qualifiedName() const {
-    if (type_ == nullptr) {
-      return "undefined";
-    }
     std::string qname(name());
     if (isConst()) {
       qname = "const " + qname;
@@ -380,24 +388,18 @@ namespace edm {
 
   std::string
   TypeWithDict::unscopedName() const {
-    if (type_ == nullptr) {
-      return "undefined";
-    }
     return stripNamespace(name());
   }
 
   std::string
   TypeWithDict::name() const {
-    if (type_ == nullptr) {
-      return "undefined";
-    }
     return TypeID(*ti_).className();
   }
 
   std::string
   TypeWithDict::unscopedNameWithTypedef() const {
     if (type_ == nullptr) {
-      return "undefined";
+      return unscopedName();
     }
     return stripNamespace(gInterpreter->Type_QualifiedName(type_));
   }
@@ -405,50 +407,42 @@ namespace edm {
   std::string
   TypeWithDict::userClassName() const {
     //FIXME: What about const and reference?
-    if (type_ == nullptr) {
-      return "undefined";
-    }
     return TypeID(*ti_).userClassName();
   }
 
   std::string
   TypeWithDict::friendlyClassName() const {
     //FIXME: What about const and reference?
-    if (type_ == nullptr) {
-      return "undefined";
-    }
     return TypeID(*ti_).friendlyClassName();
   }
 
   size_t
   TypeWithDict::size() const {
-    if (type_ == nullptr) {
-      return 0;
+    if(class_ != nullptr) {
+      return class_->GetClassSize();
     }
+    if(dataType_ != nullptr) {
+      return dataType_->Size();
+    }
+    assert(type_ != nullptr);
     return gInterpreter->Type_Size(type_);
   }
 
   size_t
   TypeWithDict::arrayLength() const {
-    if (type_ == nullptr) {
-      return 0;
-    }
+    assert(type_ != nullptr);
     return gInterpreter->Type_ArraySize(type_);
   }
 
   size_t
   TypeWithDict::arrayDimension() const {
-    if (type_ == nullptr) {
-      return 0;
-    }
+    assert(type_ != nullptr);
     return gInterpreter->Type_ArrayDim(type_);
   }
 
   size_t
   TypeWithDict::maximumIndex(size_t dim) const {
-    if (type_ == nullptr) {
-      return 0;
-    }
+    assert(type_ != nullptr);
     return gInterpreter->Type_MaxIndex(type_, dim);
   }
 
@@ -537,7 +531,7 @@ namespace edm {
 
   TypeWithDict
   TypeWithDict::finalType() const {
-    if (type_ == nullptr) {
+    if (*ti_ == typeid(void)) {
       return TypeWithDict();
     }
     return TypeWithDict(*ti_);
@@ -545,18 +539,32 @@ namespace edm {
 
   TypeWithDict
   TypeWithDict::toType() const {
-    if (type_ == nullptr) {
-      return *this;
+    if (*ti_ == typeid(void)) {
+      return TypeWithDict();
     }
-    TType* ty = gInterpreter->Type_ToType(type_);
-    if (ty == nullptr) {
-      return *this;
+    if(isReference()) {
+      long prop = property_ & ~((long) kIsReference);
+      return TypeWithDict(*ti_, prop);
     }
-    std::type_info const* ti = gInterpreter->Type_TypeInfo(ty);
-    if (ti == nullptr) {
-      return *this;
+    if(isPointer()) {
+      std::string newname = name();
+      size_t newsize = newname.size() - 1;
+      newname.resize(newsize);
+      return byName(newname);
     }
-    return TypeWithDict(*ti);
+    if(isArray()) {
+      assert(type_ != nullptr);
+      TType* ty = gInterpreter->Type_ToType(type_);
+      if (ty == nullptr) {
+        return *this;
+      }
+      std::type_info const* ti = gInterpreter->Type_TypeInfo(ty);
+      if (ti == nullptr) {
+        return *this;
+      }
+      return TypeWithDict(*ti);
+    }
+    return *this;
   }
 
   std::string
@@ -786,7 +794,7 @@ namespace edm {
   // A related free function
   bool
   hasDictionary(std::type_info const& ti) {
-    if(ti.name()[1] == '\0') {
+    if (ti.name()[1] == '\0') {
       // returns true for built in types (single character mangled names)
       return true; 
     }


### PR DESCRIPTION
This pull request avoids unnecessary creation of the TType data member of TypeWithDict. In cases where the type can be represented by a TClass or TDataType, there is no need to also create a TType. This pull request greatly reduces autoparsing of headers, and thereby saves memory.
Please merge this request as soon as convenent.
