### PR TITLE
Removing QJetAdder:QJetVolatility being too slow from miniAOD config

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -102,19 +102,6 @@ def miniAOD_customizeCommon(process):
     process.cmsTopTagPFJetsCHSLinksAK8.matched = cms.InputTag("cmsTopTagPFJetsCHS")
     process.patJetsAK8.userData.userFloats.src += ['cmsTopTagPFJetsCHSLinksAK8']
 
-    #QJetsAdder
-    if hasattr(process,"RandomNumberGeneratorService") :
-	    process.RandomNumberGeneratorService.QJetsAdderAK8 = cms.PSet(initialSeed = cms.untracked.uint32(7))
-	    process.RandomNumberGeneratorService.QJetsAdder = cms.PSet(initialSeed = cms.untracked.uint32(7))
-    else:
-	    process.RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService", QJetsAdderAK8 = cms.PSet(initialSeed = cms.untracked.uint32(7)), QJetsAdder = cms.PSet(initialSeed = cms.untracked.uint32(7)))
-    process.load('RecoJets.JetProducers.qjetsadder_cfi')
-    process.QJetsAdderAK8 = process.QJetsAdder.clone()
-    process.QJetsAdderAK8.src = cms.InputTag("ak8PFJetsCHS")
-    process.QJetsAdderAK8.jetRad = cms.double(0.8)
-    process.QJetsAdderAK8.jetAlgo = cms.string('AK')
-    process.patJetsAK8.userData.userFloats.src += ['QJetsAdderAK8:QjetsVolatility']
-
     # add Njetiness
     process.load('RecoJets.JetProducers.nJettinessAdder_cfi')
     process.NjettinessAK8 = process.Njettiness.clone()


### PR DESCRIPTION
This removes the QJetVolatility from miniAOD config as it takes 4sec/event
QJetsVolatility was added in #4929

@rappoccio @alefisico @davidlange6 @gpetruc 
