### PR TITLE
Avoid crash of GenParticles2HepMCConverter

### DIFF
--- a/GeneratorInterface/RivetInterface/plugins/GenParticles2HepMCConverter.cc
+++ b/GeneratorInterface/RivetInterface/plugins/GenParticles2HepMCConverter.cc
@@ -127,7 +127,9 @@ void GenParticles2HepMCConverter::produce(edm::Event& event, const edm::EventSet
     hepmc_particle->suggest_barcode(i+1);
 
     // Assign particle's generated mass from the standard particle data table
-    double particleMass = pTable_->particle(p->pdgId())->mass();
+    double particleMass;
+    if ( pTable_->particle(p->pdgId()) ) particleMass = pTable_->particle(p->pdgId())->mass();
+    else particleMass = p->mass();
 //    // Re-assign generated mass from LHE, find particle among the LHE
 //    for ( unsigned int j=0, m=lhe_meIndex.size(); j<m; ++j )
 //    {


### PR DESCRIPTION
The GenParticles2HepMCConverter can crash if a particle's pdgId is not present in the HepPDT while setting the generated_mass.
The problem was spotted by Bhawan. 
Query to get particle info with pdgId=102112 returns null pointer, causes segmentation fault.

As a solution, particle's generated_mass in HepMC is assigned to be same as the GenParticle's mass itself if it fails to get particle from PDT.
This is safe for the Rivet analysis since this information shouldn't be used in the particle level analysis.
