### PR TITLE
make condDBv2 default

### DIFF
--- a/Configuration/AlCa/python/autoCond_condDBv2.py
+++ b/Configuration/AlCa/python/autoCond_condDBv2.py
@@ -39,16 +39,16 @@ aliases = {
 # L1 configuration used during Run2012D
 conditions_L1_Run2012D = (
     # L1 GT menu 2012 v3, used during Run2012D
-    'L1GtTriggerMenu_L1Menu_Collisions2012_v3_mc,L1GtTriggerMenuRcd,frontier://FrontierProd/CMS_COND_31X_L1T',
+    'L1GtTriggerMenu_L1Menu_Collisions2012_v3_mc,L1GtTriggerMenuRcd,frontier://FrontierProd/CMS_CONDITIONS',
     # L1 GCT configuration with 5 GeV jet seed threshold, used since Run2012C
-    'L1GctJetFinderParams_GCTPhysics_2012_04_27_JetSeedThresh5GeV_mc,L1GctJetFinderParamsRcd,frontier://FrontierProd/CMS_COND_31X_L1T',
-    'L1HfRingEtScale_GCTPhysics_2012_04_27_JetSeedThresh5GeV_mc,L1HfRingEtScaleRcd,frontier://FrontierProd/CMS_COND_31X_L1T',
-    'L1HtMissScale_GCTPhysics_2012_04_27_JetSeedThresh5GeV_mc,L1HtMissScaleRcd,frontier://FrontierProd/CMS_COND_31X_L1T',
-    'L1JetEtScale_GCTPhysics_2012_04_27_JetSeedThresh5GeV_mc,L1JetEtScaleRcd,frontier://FrontierProd/CMS_COND_31X_L1T',
+    'L1GctJetFinderParams_GCTPhysics_2012_04_27_JetSeedThresh5GeV_mc,L1GctJetFinderParamsRcd,frontier://FrontierProd/CMS_CONDITIONS',
+    'L1HfRingEtScale_GCTPhysics_2012_04_27_JetSeedThresh5GeV_mc,L1HfRingEtScaleRcd,frontier://FrontierProd/CMS_CONDITIONS',
+    'L1HtMissScale_GCTPhysics_2012_04_27_JetSeedThresh5GeV_mc,L1HtMissScaleRcd,frontier://FrontierProd/CMS_CONDITIONS',
+    'L1JetEtScale_GCTPhysics_2012_04_27_JetSeedThresh5GeV_mc,L1JetEtScaleRcd,frontier://FrontierProd/CMS_CONDITIONS',
     # L1 CSCTF configuration used since Run2012B
-    'L1MuCSCPtLut_key-11_mc,L1MuCSCPtLutRcd,frontier://FrontierProd/CMS_COND_31X_L1T',
+    'L1MuCSCPtLut_key-11_mc,L1MuCSCPtLutRcd,frontier://FrontierProd/CMS_CONDITIONS',
     # L1 DTTF settings used since Run2012C
-    'L1MuDTTFParameters_dttf12_TSC_03_csc_col_mc,L1MuDTTFParametersRcd,frontier://FrontierProd/CMS_COND_31X_L1T',
+    'L1MuDTTFParameters_dttf12_TSC_03_csc_col_mc,L1MuDTTFParametersRcd,frontier://FrontierProd/CMS_CONDITIONS',
 )
 
 autoCond['run1_mc']          = ( autoCond['run1_mc'], ) \

--- a/Configuration/Applications/python/Options.py
+++ b/Configuration/Applications/python/Options.py
@@ -34,10 +34,10 @@ parser.add_option("--conditions",
                   default=None,
                   dest="conditions")
 
-parser.add_option("--useCondDBv2",
+parser.add_option("--useCondDBv1",
                   help="use conditions DB V1",
                   action="store_false",
-                  default=True,
+                  default=False,
                   dest="useCondDBv1")
 
 parser.add_option("--eventcontent",


### PR DESCRIPTION
- set default to use condDBv2 for cmsDriver options
- update L1 customisations in autoCond_conddbv2.py to use condDBv2 
  73x version
