### PR TITLE
Add btag algos and susy pruned gen for miniAOD V2

### DIFF
--- a/PhysicsTools/PatAlgos/python/recoLayer0/bTagging_cff.py
+++ b/PhysicsTools/PatAlgos/python/recoLayer0/bTagging_cff.py
@@ -72,7 +72,7 @@ supportedBtagDiscr = {
   , 'doubleSecondaryVertexHighEffBJetTags'                  : ['inclusiveSecondaryVertexFinderFilteredTagInfos']
   , 'combinedInclusiveSecondaryVertexBJetTags'              : ['impactParameterTagInfos', 'inclusiveSecondaryVertexFinderTagInfos']
   , 'combinedInclusiveSecondaryVertexPositiveBJetTags'      : ['impactParameterTagInfos', 'inclusiveSecondaryVertexFinderTagInfos']
-  #, 'combinedMVABJetTags'                                   : ['impactParameterTagInfos', 'inclusiveSecondaryVertexFinderTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
+  , 'combinedMVABJetTags'                                   : ['impactParameterTagInfos', 'inclusiveSecondaryVertexFinderTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
   , 'positiveCombinedMVABJetTags'                           : ['impactParameterTagInfos', 'inclusiveSecondaryVertexFinderTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
   , 'negativeCombinedMVABJetTags'                           : ['impactParameterTagInfos', 'inclusiveSecondaryVertexFinderTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
   #, 'combinedSecondaryVertexSoftPFLeptonV1BJetTags'         : ['impactParameterTagInfos', 'secondaryVertexTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -72,7 +72,7 @@ def miniAOD_customizeCommon(process):
     switchJetCollection(process, jetSource = cms.InputTag('ak4PFJetsCHS'),  
     jetCorrections = ('AK4PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), ''),
     btagDiscriminators = ['jetBProbabilityBJetTags', 'jetProbabilityBJetTags', 'trackCountingHighPurBJetTags', 'trackCountingHighEffBJetTags', 'simpleSecondaryVertexHighEffBJetTags',
-                         'simpleSecondaryVertexHighPurBJetTags', 'combinedSecondaryVertexBJetTags' , 'combinedInclusiveSecondaryVertexBJetTags' ],
+                         'simpleSecondaryVertexHighPurBJetTags', 'combinedSecondaryVertexBJetTags' , 'combinedInclusiveSecondaryVertexBJetTags','combinedMVABJetTags' ],
     )
     #add AK8   
     from PhysicsTools.PatAlgos.tools.jetTools import addJetCollection

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -102,19 +102,6 @@ def miniAOD_customizeCommon(process):
     process.cmsTopTagPFJetsCHSLinksAK8.matched = cms.InputTag("cmsTopTagPFJetsCHS")
     process.patJetsAK8.userData.userFloats.src += ['cmsTopTagPFJetsCHSLinksAK8']
 
-    #QJetsAdder
-    if hasattr(process,"RandomNumberGeneratorService") :
-	    process.RandomNumberGeneratorService.QJetsAdderAK8 = cms.PSet(initialSeed = cms.untracked.uint32(7))
-	    process.RandomNumberGeneratorService.QJetsAdder = cms.PSet(initialSeed = cms.untracked.uint32(7))
-    else:
-	    process.RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService", QJetsAdderAK8 = cms.PSet(initialSeed = cms.untracked.uint32(7)), QJetsAdder = cms.PSet(initialSeed = cms.untracked.uint32(7)))
-    process.load('RecoJets.JetProducers.qjetsadder_cfi')
-    process.QJetsAdderAK8 = process.QJetsAdder.clone()
-    process.QJetsAdderAK8.src = cms.InputTag("ak8PFJetsCHS")
-    process.QJetsAdderAK8.jetRad = cms.double(0.8)
-    process.QJetsAdderAK8.jetAlgo = cms.string('AK')
-    process.patJetsAK8.userData.userFloats.src += ['QJetsAdderAK8:QjetsVolatility']
-
     # add Njetiness
     process.load('RecoJets.JetProducers.nJettinessAdder_cfi')
     process.NjettinessAK8 = process.Njettiness.clone()

--- a/PhysicsTools/PatAlgos/python/slimming/prunedGenParticles_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/prunedGenParticles_cfi.py
@@ -26,6 +26,7 @@ prunedGenParticles = cms.EDProducer("GenParticlePruner",
 # additional b hadrons for jet fragmentation studies
 	"keep abs(pdgId) = 10511 || abs(pdgId) = 10521 || abs(pdgId) = 10513 || abs(pdgId) = 10523 || abs(pdgId) = 20513 || abs(pdgId) = 20523 || abs(pdgId) = 10531 || abs(pdgId) = 10533 || abs(pdgId) = 20533 || abs(pdgId) = 10541 || abs(pdgId) = 10543 || abs(pdgId) = 20543", 
 # keep protons 
+	"keep (1000001 <= abs(pdgId) <= 1000039 ) ||  ( 2000001 <= abs(pdgId) <= 2000015)",
         "keep pdgId = 2212",
         "keep status == 3 || status == 22 || status == 23 || ( 11 <= status <= 19)",  #keep event summary status3 (for pythia), 22,23 (pythia8)
 

--- a/PhysicsTools/PatAlgos/test/patTuple_addBTagging_cfg.py
+++ b/PhysicsTools/PatAlgos/test/patTuple_addBTagging_cfg.py
@@ -68,7 +68,7 @@ addJetCollection(
       ,'doubleSecondaryVertexHighEffBJetTags'
       ,'combinedInclusiveSecondaryVertexBJetTags'
       ,'combinedInclusiveSecondaryVertexPositiveBJetTags'
-      #,'combinedMVABJetTags'
+      ,'combinedMVABJetTags'
       ,'positiveCombinedMVABJetTags'
       ,'negativeCombinedMVABJetTags'
       #,'combinedSecondaryVertexSoftPFLeptonV1BJetTags'


### PR DESCRIPTION
This PR is made starting from 709 plus #5519 
It adds one btag algo as requested in 
https://twiki.cern.ch/twiki/bin/view/CMS/MiniAODCSA14FollowUp 
and add keep statement in pruned gen particles for SUSY particles

the btag part is already propagated in 72X and 73X by recent updates of #5446 and #5449 
For the gen particles part  I will update #5525  and #5526  to propagate in 72X and 73X
@gpetruc @ferencek @davidlange6 
