### PR TITLE
Hbhe channel grouping

### DIFF
--- a/CondFormats/HcalObjects/interface/HBHEChannelGroups.h
+++ b/CondFormats/HcalObjects/interface/HBHEChannelGroups.h
@@ -1,0 +1,94 @@
+#ifndef CondFormats_HcalObjects_HBHEChannelGroups_h_
+#define CondFormats_HcalObjects_HBHEChannelGroups_h_
+
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include "boost/cstdint.hpp"
+#include "boost/serialization/access.hpp"
+#include "boost/serialization/vector.hpp"
+
+#include "CondFormats/HcalObjects/interface/HBHELinearMap.h"
+
+class HBHEChannelGroups
+{
+public:
+    inline HBHEChannelGroups() : group_(HBHELinearMap::ChannelCount, 0U) {}
+
+    //
+    // Main constructor. It is expected that "len" equals
+    // HBHELinearMap::ChannelCount and that every element of "data"
+    // indicates to which group that particular channel should belong.
+    //
+    inline HBHEChannelGroups(const unsigned* data, const unsigned len)
+        : group_(data, data+len)
+    {
+        if (!validate()) throw cms::Exception(
+            "In HBHEChannelGroups constructor: invalid input data");
+    }
+
+    //
+    // Set the group number for the given HBHE linear channel number.
+    // Linear channel numbers are calculated by HBHELinearMap.
+    //
+    inline void setGroup(const unsigned linearChannel, const unsigned groupNum)
+        {group_.at(linearChannel) = groupNum;}
+
+    // Inspectors
+    inline unsigned size() const {return group_.size();}
+
+    inline const uint32_t* groupData() const
+        {return group_.empty() ? 0 : &group_[0];}
+
+    inline unsigned getGroup(const unsigned linearChannel) const
+        {return group_.at(linearChannel);}
+
+    inline unsigned largestGroupNumber() const
+    {
+        unsigned lg = 0;
+        const unsigned sz = group_.size();
+        const uint32_t* dat = sz ? &group_[0] : 0;
+        for (unsigned i=0; i<sz; ++i)
+            if (dat[i] > lg)
+                lg = dat[i];
+        return lg;
+    }
+
+    // Comparators
+    inline bool operator==(const HBHEChannelGroups& r) const
+        {return group_ == r.group_;}
+
+    inline bool operator!=(const HBHEChannelGroups& r) const
+        {return !(*this == r);}
+
+private:
+    std::vector<uint32_t> group_;
+
+    inline bool validate() const
+    {
+        return group_.size() == HBHELinearMap::ChannelCount;
+    }
+
+    friend class boost::serialization::access;
+
+    template<class Archive>
+    inline void save(Archive & ar, const unsigned /* version */) const
+    {
+        if (!validate()) throw cms::Exception(
+            "In HBHEChannelGroups::save: invalid data");
+        ar & group_;
+    }
+
+    template<class Archive>
+    inline void load(Archive & ar, const unsigned /* version */)
+    {
+        ar & group_;
+        if (!validate()) throw cms::Exception(
+            "In HBHEChannelGroups::load: invalid data");
+    }
+
+    BOOST_SERIALIZATION_SPLIT_MEMBER()
+};
+
+BOOST_CLASS_VERSION(HBHEChannelGroups, 1)
+
+#endif // CondFormats_HcalObjects_HBHEChannelGroups_h_

--- a/CondFormats/HcalObjects/interface/HBHELinearMap.h
+++ b/CondFormats/HcalObjects/interface/HBHELinearMap.h
@@ -1,0 +1,78 @@
+#ifndef CondFormats_HcalObjects_HBHELinearMap_h_
+#define CondFormats_HcalObjects_HBHELinearMap_h_
+
+//
+// Linearize the channel id in the HBHE
+//
+// I. Volobouev
+// September 2014
+//
+
+#include <map>
+
+#include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
+
+class HBHELinearMap
+{
+public:
+    enum {ChannelCount = 5184U};
+
+    HBHELinearMap();
+
+    // Mapping from the depth/ieta/iphi triple which uniquely
+    // identifies an HBHE channels into a linear index, currently
+    // from 0 to 5183 (inclusive). This linear index should not
+    // be treated as anything meaningful -- consider it to be
+    // just a convenient unique key in a database table.
+    unsigned linearIndex(unsigned depth, int ieta, unsigned iphi) const;
+
+    // Check whether the given triple is a valid depth/ieta/iphi combination
+    bool isValidTriple(unsigned depth, int ieta, unsigned iphi) const;
+
+    // Inverse mapping, from a linear index into depth/ieta/iphi triple.
+    // Any of the argument pointers is allowed to be NULL in which case
+    // the corresponding variable is simply not filled out.
+    void getChannelTriple(unsigned index, unsigned* depth,
+                          int* ieta, unsigned* iphi) const;
+
+    // The following assumes a valid HBHE depth/ieta combination
+    static HcalSubdetector getSubdetector(unsigned depth, int ieta);
+
+private:
+    class HBHEChannelId
+    {
+    public:
+        inline HBHEChannelId() : depth_(1000U), ieta_(1000), iphi_(1000U) {}
+
+        inline HBHEChannelId(const unsigned i_depth,
+                             const int i_ieta,
+                             const unsigned i_iphi)
+            : depth_(i_depth), ieta_(i_ieta), iphi_(i_iphi) {}
+
+        // Inspectors
+        inline unsigned depth() const {return depth_;}
+        inline int ieta() const {return ieta_;}
+        inline unsigned iphi() const {return iphi_;}
+
+        inline bool operator<(const HBHEChannelId& r) const
+        {
+            if (depth_ < r.depth_) return true;
+            if (r.depth_ < depth_) return false;
+            if (ieta_ < r.ieta_) return true;
+            if (r.ieta_ < ieta_) return false;
+            return iphi_ < r.iphi_;
+        }
+
+    private:
+        unsigned depth_;
+        int ieta_;
+        unsigned iphi_;
+    };
+
+    typedef std::map<HBHEChannelId,unsigned> ChannelMap;
+
+    HBHEChannelId lookup_[ChannelCount];
+    ChannelMap inverse_;
+};
+
+#endif // CondFormats_HcalObjects_HBHELinearMap_h_

--- a/CondFormats/HcalObjects/interface/HBHELinearMap.h
+++ b/CondFormats/HcalObjects/interface/HBHELinearMap.h
@@ -8,7 +8,8 @@
 // September 2014
 //
 
-#include <map>
+#include <vector>
+#include <utility>
 
 #include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
 
@@ -63,13 +64,22 @@ private:
             return iphi_ < r.iphi_;
         }
 
+        inline bool operator==(const HBHEChannelId& r) const
+            {return depth_ == r.depth_ && ieta_ == r.ieta_ && iphi_ == r.iphi_;}
+
+        inline bool operator!=(const HBHEChannelId& r) const
+            {return !(*this == r);}
+
     private:
         unsigned depth_;
         int ieta_;
         unsigned iphi_;
     };
 
-    typedef std::map<HBHEChannelId,unsigned> ChannelMap;
+    typedef std::pair<HBHEChannelId,unsigned> MapPair;
+    typedef std::vector<MapPair> ChannelMap;
+
+    unsigned find(unsigned depth, int ieta, unsigned iphi) const;
 
     HBHEChannelId lookup_[ChannelCount];
     ChannelMap inverse_;

--- a/CondFormats/HcalObjects/src/HBHELinearMap.cc
+++ b/CondFormats/HcalObjects/src/HBHELinearMap.cc
@@ -1,0 +1,132 @@
+#include <cassert>
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include "CondFormats/HcalObjects/interface/HBHELinearMap.h"
+
+void HBHELinearMap::getChannelTriple(const unsigned index, unsigned* depth,
+                                     int* ieta, unsigned* iphi) const
+{
+    if (index >= ChannelCount)
+        throw cms::Exception("In HBHELinearMap::getChannelTriple: "
+                                    "input index out of range");
+    const HBHEChannelId& id = lookup_[index];
+    if (depth)
+        *depth = id.depth();
+    if (ieta)
+        *ieta = id.ieta();
+    if (iphi)
+        *iphi = id.iphi();
+}
+
+bool HBHELinearMap::isValidTriple(const unsigned depth, const int ieta,
+                                  const unsigned iphi) const
+{
+    ChannelMap::const_iterator it = inverse_.find(HBHEChannelId(depth, ieta, iphi));
+    return it != inverse_.end();
+}
+
+unsigned HBHELinearMap::linearIndex(const unsigned depth, const int ieta,
+                                    const unsigned iphi) const
+{
+    ChannelMap::const_iterator it = inverse_.find(HBHEChannelId(depth, ieta, iphi));
+    if (it == inverse_.end())
+        throw cms::Exception("In HBHELinearMap::linearIndex: "
+                                    "invalid channel triple");
+    return it->second;
+}
+
+HBHELinearMap::HBHELinearMap()
+{
+    unsigned l = 0;
+    unsigned depth = 1;
+
+    for (int ieta = -29; ieta <= -21; ++ieta)
+        for (unsigned iphi=1; iphi<72; iphi+=2)
+            lookup_[l++] = HBHEChannelId(depth, ieta, iphi);
+
+    for (int ieta = -20; ieta <= 20; ++ieta)
+        if (ieta)
+            for (unsigned iphi=1; iphi<=72; ++iphi)
+                lookup_[l++] = HBHEChannelId(depth, ieta, iphi);
+
+    for (int ieta = 21; ieta <= 29; ++ieta)
+        for (unsigned iphi=1; iphi<72; iphi+=2)
+            lookup_[l++] = HBHEChannelId(depth, ieta, iphi);
+
+    depth = 2;
+
+    for (int ieta = -29; ieta <= -21; ++ieta)
+        for (unsigned iphi=1; iphi<72; iphi+=2)
+            lookup_[l++] = HBHEChannelId(depth, ieta, iphi);
+
+    for (int ieta = -20; ieta <= -18; ++ieta)
+        for (unsigned iphi=1; iphi<=72; ++iphi)
+            lookup_[l++] = HBHEChannelId(depth, ieta, iphi);
+
+    for (int ieta = -16; ieta <= -15; ++ieta)
+        for (unsigned iphi=1; iphi<=72; ++iphi)
+            lookup_[l++] = HBHEChannelId(depth, ieta, iphi);
+
+    for (int ieta = 15; ieta <= 16; ++ieta)
+        for (unsigned iphi=1; iphi<=72; ++iphi)
+            lookup_[l++] = HBHEChannelId(depth, ieta, iphi);
+
+    for (int ieta = 18; ieta <= 20; ++ieta)
+        for (unsigned iphi=1; iphi<=72; ++iphi)
+            lookup_[l++] = HBHEChannelId(depth, ieta, iphi);
+
+    for (int ieta = 21; ieta <= 29; ++ieta)
+        for (unsigned iphi=1; iphi<72; iphi+=2)
+            lookup_[l++] = HBHEChannelId(depth, ieta, iphi);
+
+    depth = 3;
+
+    for (int ieta = -28; ieta <= -27; ++ieta)
+        for (unsigned iphi=1; iphi<72; iphi+=2)
+            lookup_[l++] = HBHEChannelId(depth, ieta, iphi);
+
+    for (int ieta = -16; ieta <= -16; ++ieta)
+        for (unsigned iphi=1; iphi<=72; ++iphi)
+             lookup_[l++] = HBHEChannelId(depth, ieta, iphi);
+
+    for (int ieta = 16; ieta <= 16; ++ieta)
+        for (unsigned iphi=1; iphi<=72; ++iphi)
+             lookup_[l++] = HBHEChannelId(depth, ieta, iphi);
+
+    for (int ieta = 27; ieta <= 28; ++ieta)
+        for (unsigned iphi=1; iphi<72; iphi+=2)
+            lookup_[l++] = HBHEChannelId(depth, ieta, iphi);
+
+    assert(l == ChannelCount);
+
+    for (unsigned i=0; i<ChannelCount; ++i)
+    {
+        const HBHEChannelId& cid = lookup_[i];
+        inverse_[cid] = i;
+    }
+}
+
+HcalSubdetector HBHELinearMap::getSubdetector(const unsigned depth,
+                                              const int ieta)
+{
+    const unsigned abseta = std::abs(ieta);
+
+    // Make sure the arguments are in range
+    if (!(abseta <= 29U))
+        throw cms::Exception("In HBHELinearMap::getSubdetector: "
+                                    "eta argument out of range");
+    if (!(depth > 0U && depth < 4U))
+        throw cms::Exception("In HBHELinearMap::getSubdetector: "
+                                    "depth argument out of range");
+    if (abseta == 29U)
+        if (!(depth <= 2U))
+            throw cms::Exception("In HBHELinearMap::getSubdetector: "
+                                        "depth argument out of range "
+                                        "for |ieta| = 29");
+    if (abseta <= 15U)
+        return HcalBarrel;
+    else if (abseta == 16U)
+        return depth <= 2U ? HcalBarrel : HcalEndcap;
+    else
+        return HcalEndcap;
+}

--- a/CondFormats/HcalObjects/src/classes.h
+++ b/CondFormats/HcalObjects/src/classes.h
@@ -86,7 +86,6 @@ namespace CondFormats_HcalObjects {
     // OOT pileup correction objects
     std::map<std::string, AbsOOTPileupCorrection*> myInnerMap;
     std::map<std::string, std::map<std::string, AbsOOTPileupCorrection*> > myOuterMap;
-    std::vector<uint32_t> myVectorUint32T;
     ScalingExponential myScalingExponential;
     PiecewiseScalingPolynomial myPiecewiseScalingPolynomial;
     OOTPileupCorrDataFcn myOOTPileupCorrDataFcn;

--- a/CondFormats/HcalObjects/src/classes.h
+++ b/CondFormats/HcalObjects/src/classes.h
@@ -86,6 +86,7 @@ namespace CondFormats_HcalObjects {
     // OOT pileup correction objects
     std::map<std::string, AbsOOTPileupCorrection*> myInnerMap;
     std::map<std::string, std::map<std::string, AbsOOTPileupCorrection*> > myOuterMap;
+    std::vector<uint32_t> myVectorUint32T;
     ScalingExponential myScalingExponential;
     PiecewiseScalingPolynomial myPiecewiseScalingPolynomial;
     OOTPileupCorrDataFcn myOOTPileupCorrDataFcn;
@@ -93,6 +94,7 @@ namespace CondFormats_HcalObjects {
     DummyOOTPileupCorrection myDummyOOTPileupCorrection;
     OOTPileupCorrectionMapColl myOOTPileupCorrectionMapColl;
     OOTPileupCorrectionBuffer myOOTPileupCorrectionBuffer;
+    HBHEChannelGroups myHBHEChannelGroups;
   };
 }
 

--- a/CondFormats/HcalObjects/src/classes_def.xml
+++ b/CondFormats/HcalObjects/src/classes_def.xml
@@ -391,5 +391,9 @@
  <class name="OOTPileupCorrectionBuffer">
   <field name="m_buffer" mapping="blob" />
  </class>
+ <class name="std::vector<uint32_t>"/>
+ <class name="HBHEChannelGroups">
+  <field name="group_" mapping="blob" />
+ </class>
 
 </lcgdict>   

--- a/CondFormats/HcalObjects/src/classes_def.xml
+++ b/CondFormats/HcalObjects/src/classes_def.xml
@@ -391,7 +391,6 @@
  <class name="OOTPileupCorrectionBuffer">
   <field name="m_buffer" mapping="blob" />
  </class>
- <class name="std::vector<uint32_t>"/>
  <class name="HBHEChannelGroups">
   <field name="group_" mapping="blob" />
  </class>

--- a/CondFormats/HcalObjects/src/headers.h
+++ b/CondFormats/HcalObjects/src/headers.h
@@ -8,3 +8,4 @@
 #include "CondFormats/HcalObjects/interface/OOTPileupCorrData.h"
 #include "CondFormats/HcalObjects/interface/DummyOOTPileupCorrection.h"
 #include "CondFormats/HcalObjects/interface/OOTPileupCorrectionMapColl.h"
+#include "CondFormats/HcalObjects/interface/HBHEChannelGroups.h"


### PR DESCRIPTION
Arbitrary persistent grouping of Hcal channels. Will be needed in the future to implement lookup tables from channel id to channel pulse shapes.

The lookup will be two-staged. In the first stage, the channel id will be mapped into a linear channel number ( computational complexity O(log(N)) ). In the second stage the linear channel number will be mapped into its group number (e.g., pulse shape number). This is O(1). The two-stage lookup should work better than the direct one because we will likely have several O(1) operations (for different collections of objects). All of these can use the same linear channel number which has to be looked up only once.
