### PR TITLE
Use CHS jets (i.e. defaults) in new candidate based b-tagging

### DIFF
--- a/RecoBTag/ImpactParameter/python/pfImpactParameter_cfi.py
+++ b/RecoBTag/ImpactParameter/python/pfImpactParameter_cfi.py
@@ -14,7 +14,7 @@ pfImpactParameterTagInfos = cms.EDProducer("CandIPProducer",
     useTrackQuality = cms.bool(False),
     maximumChiSquared = cms.double(5.0),
 #this is candidate specific
-    jets = cms.InputTag("ak4PFJets"),
+    jets = cms.InputTag("ak4PFJetsCHS"),
     candidates = cms.InputTag("particleFlow"),
     maxDeltaR= cms.double(0.4),
 


### PR DESCRIPTION
Fix the input jet collection for candidate btag
Bug fix related to what found in #5446 
