### PR TITLE
Handle void data type

### DIFF
--- a/FWCore/Utilities/src/TypeWithDict.cc
+++ b/FWCore/Utilities/src/TypeWithDict.cc
@@ -345,7 +345,7 @@ namespace edm {
 
   bool
   TypeWithDict::isTypedef() const {
-    if (class_ != nullptr || dataType_ != nullptr) {
+    if (class_ != nullptr || dataType_ != nullptr || *ti_ == typeid(void)) {
       return false;
     }
     assert(type_ != nullptr);


### PR DESCRIPTION
If a check is made that a given type is a typedef, and the type happens to be "void" a fatal assert resulted.
This pull request fixes this bug, which caused failures in release validation tests.
Please merge as soon as convenient.
