### PR TITLE
L1t post ls1 customs initial push

### DIFF
--- a/L1Trigger/L1TCalorimeter/plugins/L1TCaloUpgradeToGCTConverter.cc
+++ b/L1Trigger/L1TCalorimeter/plugins/L1TCaloUpgradeToGCTConverter.cc
@@ -130,6 +130,8 @@ l1t::L1TCaloUpgradeToGCTConverter::produce(Event& e, const EventSetup& es)
 	}
       }
     }
+    isoEmResult->resize(4);
+    nonIsoEmResult->resize(4);
 
     //looping over Tau elments with a specific BX
     int tauCount = 0; //max 4
@@ -147,6 +149,7 @@ l1t::L1TCaloUpgradeToGCTConverter::produce(Event& e, const EventSetup& es)
 	tauCount++;
       }
     }
+    tauJetResult->resize(4);
 
     //looping over Jet elments with a specific BX
     int forCount = 0; //max 4
@@ -172,6 +175,8 @@ l1t::L1TCaloUpgradeToGCTConverter::produce(Event& e, const EventSetup& es)
 	}
       }
     }
+    forJetResult->resize(4);
+    cenJetResult->resize(4);
 
     //looping over EtSum elments with a specific BX
     for (l1t::EtSumBxCollection::const_iterator itEtSum = EtSum->begin(itBX);
@@ -193,6 +198,10 @@ l1t::L1TCaloUpgradeToGCTConverter::produce(Event& e, const EventSetup& es)
 	LogError("l1t|stage 1 Converter") <<" Unknown EtSumType --- EtSum collection will not be saved...\n ";
       }
     }
+    etMissResult->resize(1);
+    htMissResult->resize(1);
+    etTotResult->resize(1);
+    etHadResult->resize(1);
 
     for (l1t::CaloSpareBxCollection::const_iterator itCaloSpare = CaloSpare->begin(itBX);
 	 itCaloSpare != CaloSpare->end(itBX); ++itCaloSpare){
@@ -229,6 +238,8 @@ l1t::L1TCaloUpgradeToGCTConverter::produce(Event& e, const EventSetup& es)
 	hfRingEtSumResult->push_back(sum);
       }
     }
+    hfRingEtSumResult->resize(1);
+    hfBitCountResult->resize(1);
   }
 
   e.put(isoEmResult,"isoEm");

--- a/L1Trigger/L1TCommon/python/customsPostLS1.py
+++ b/L1Trigger/L1TCommon/python/customsPostLS1.py
@@ -1,29 +1,24 @@
 
 import FWCore.ParameterSet.Config as cms
 
-#def customiseSimL1EmulatorForPostLS1(process):
-#    return (process)
-
-#
-# customize to use upgrade L1 emulation based on carrying forward simGctDigis
-#  (converted-to-legacy-format output of Stage 1 calo)
-#
+# customize to use upgrade L1 emulation 
 
 # customization of run L1 emulator for 2015 run configuration
 def customiseSimL1EmulatorForPostLS1(process):
-    print "INFO:  Customising L1T emulator for 2015 run configuration"
-#    print "INFO:  Customize the L1 menu"
-#    process=customiseL1Menu(process)
-    print "INFO:  loading RCT LUTs"
+    #print "INFO:  Customising L1T emulator for 2015 run configuration"
+    #print "INFO:  Customize the L1 menu"
+    # the following line will break HLT if HLT menu is not updated with the corresponding menu
+    process=customiseL1Menu(process)
+    #print "INFO:  loading RCT LUTs"
     process.load("L1Trigger.L1TCalorimeter.caloStage1RCTLuts_cff")
     if hasattr(process,'L1simulation_step'):
-        print "INFO:  Removing GCT from simulation and adding new Stage 1"
+        #print "INFO:  Removing GCT from simulation and adding new Stage 1"
         process.load('L1Trigger.L1TCalorimeter.caloStage1Params_cfi')
         process.load('L1Trigger.L1TCalorimeter.L1TCaloStage1_cff')
         process.L1simulation_step.replace(process.simGctDigis,process.L1TCaloStage1)
         process.rctUpgradeFormatDigis.regionTag = cms.InputTag("simRctDigis")
         process.rctUpgradeFormatDigis.emTag = cms.InputTag("simRctDigis")
-        print "New L1 simulation step is:", process.L1simulation_step
+        #print "New L1 simulation step is:", process.L1simulation_step
         process.simGtDigis.GmtInputTag = 'gtDigis'
         process.simGtDigis.GctInputTag = 'caloStage1LegacyFormatDigis'
         process.simGtDigis.TechnicalTriggersInputTags = cms.VInputTag( )
@@ -31,7 +26,7 @@ def customiseSimL1EmulatorForPostLS1(process):
     return process
 
 #    #
-#    # Plan B:  (Not Needed if packing unpacking works)
+#    # Plan B:  (Not Needed if packing/unpacking of Stage 1 calo via legacy formats and GCT packer works)
 #    #
 #    process.digi2raw_step.remove(process.gctDigiToRaw)
 #   

--- a/L1Trigger/L1TCommon/python/customsPostLS1.py
+++ b/L1Trigger/L1TCommon/python/customsPostLS1.py
@@ -1,0 +1,69 @@
+
+import FWCore.ParameterSet.Config as cms
+
+#def customiseSimL1EmulatorForPostLS1(process):
+#    return (process)
+
+#
+# customize to use upgrade L1 emulation based on carrying forward simGctDigis
+#  (converted-to-legacy-format output of Stage 1 calo)
+#
+
+# customization of run L1 emulator for 2015 run configuration
+def customiseSimL1EmulatorForPostLS1(process):
+    print "INFO:  Customising L1T emulator for 2015 run configuration"
+#    print "INFO:  Customize the L1 menu"
+#    process=customiseL1Menu(process)
+    print "INFO:  loading RCT LUTs"
+    process.load("L1Trigger.L1TCalorimeter.caloStage1RCTLuts_cff")
+    if hasattr(process,'L1simulation_step'):
+        print "INFO:  Removing GCT from simulation and adding new Stage 1"
+        process.load('L1Trigger.L1TCalorimeter.caloStage1Params_cfi')
+        process.load('L1Trigger.L1TCalorimeter.L1TCaloStage1_cff')
+        process.L1simulation_step.replace(process.simGctDigis,process.L1TCaloStage1)
+        process.rctUpgradeFormatDigis.regionTag = cms.InputTag("simRctDigis")
+        process.rctUpgradeFormatDigis.emTag = cms.InputTag("simRctDigis")
+        print "New L1 simulation step is:", process.L1simulation_step
+        process.simGtDigis.GmtInputTag = 'gtDigis'
+        process.simGtDigis.GctInputTag = 'caloStage1LegacyFormatDigis'
+        process.simGtDigis.TechnicalTriggersInputTags = cms.VInputTag( )
+        process.gctDigiToRaw.gctInputLabel = 'caloStage1LegacyFormatDigis'
+    return process
+
+#    #
+#    # Plan B:  (Not Needed if packing unpacking works)
+#    #
+#    process.digi2raw_step.remove(process.gctDigiToRaw)
+#   
+#    # Carry forward legacy format digis for now (keep rest of workflow working)
+#    alist=['RAWSIM','RAWDEBUG','FEVTDEBUG','FEVTDEBUGHLT','GENRAW','RAWSIMHLT','FEVT']
+#    for a in alist:
+#        b=a+'output'
+#        if hasattr(process,b):
+#            getattr(process,b).outputCommands.append('keep *_caloStage1LegacyFormatDigis_*_*')
+#            print "INFO:  keeping L1T legacy format digis in event."
+#    
+#    blist=['l1extraParticles','recoL1ExtraParticles','hltL1ExtraParticles','dqmL1ExtraParticles']
+#    for b in blist:
+#        if hasattr(process,b):
+#            print "INFO:  customizing ", b, "to use simulated legacy formats, without packing/unpacking"
+#            getattr(process, b).etTotalSource = cms.InputTag("caloStage1LegacyFormatDigis")
+#            getattr(process, b).nonIsolatedEmSource = cms.InputTag("caloStage1LegacyFormatDigis","nonIsoEm")
+#            getattr(process, b).etMissSource = cms.InputTag("caloStage1LegacyFormatDigis")
+#            getattr(process, b).htMissSource = cms.InputTag("caloStage1LegacyFormatDigis")
+#            getattr(process, b).forwardJetSource = cms.InputTag("caloStage1LegacyFormatDigis","forJets")
+#            getattr(process, b).centralJetSource = cms.InputTag("caloStage1LegacyFormatDigis","cenJets")
+#            getattr(process, b).tauJetSource = cms.InputTag("caloStage1LegacyFormatDigis","tauJets")
+#            getattr(process, b).isolatedEmSource = cms.InputTag("caloStage1LegacyFormatDigis","isoEm")
+#            getattr(process, b).etHadSource = cms.InputTag("caloStage1LegacyFormatDigis")
+#            getattr(process, b).hfRingEtSumsSource = cms.InputTag("caloStage1LegacyFormatDigis")
+#            getattr(process, b).hfRingBitCountsSource = cms.InputTag("caloStage1LegacyFormatDigis")
+#
+#    # automatic replacements of "simGctDigis" instead of "hltGctDigis"
+#    for module in process.__dict__.itervalues():
+#        if isinstance(module, cms._Module):
+#            for parameter in module.__dict__.itervalues():
+#                if isinstance(parameter, cms.InputTag):
+#                    if parameter.moduleLabel == 'hltGctDigis':
+#                        parameter.moduleLabel = "simGctDigis"
+

--- a/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py
+++ b/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py
@@ -2,12 +2,15 @@
 import FWCore.ParameterSet.Config as cms
 
 from SLHCUpgradeSimulations.Configuration.muonCustoms import customise_csc_PostLS1,customise_csc_hlt
-
+from L1Trigger.L1TCommon.customsPostLS1 import customiseSimL1EmulatorForPostLS1
 
 def customisePostLS1(process):
 
     # deal with CSC separately:
     process = customise_csc_PostLS1(process)
+
+    # deal with L1 Emulation separately:
+    customiseSimL1EmulatorForPostLS1(process)
 
     # all the rest:
     if hasattr(process,'g4SimHits'):


### PR DESCRIPTION
This PR is a placeholder.  This turns on the new L1 emulation for 2015, but leaves a legacy global L1 menu in place.  Turning on this new L1 menu before the HLT does likewise breaks the standard work flows.  This PR will be superseded by one which turns on L1 and HLT new menus simultaneously.  Note that #5529 will be needed (to provide the new L1 menu as XML file).   I included this here to get Jenkins to work checking all but the last bit about menus.
