### PR TITLE
introduce NominalCollision2015 beamspot scenario, 

### DIFF
--- a/Configuration/StandardSequences/python/VtxSmeared.py
+++ b/Configuration/StandardSequences/python/VtxSmeared.py
@@ -28,7 +28,8 @@ VtxSmeared = {
     'Centered7TeV2011Collision':     'IOMC.EventVertexGenerators.VtxSmearedCentered7TeV2011Collision_cfi',
     'RealisticHI2011Collision':      'IOMC.EventVertexGenerators.VtxSmearedRealisticHI2011Collision_cfi',
     'Realistic8TeVCollisionPPbBoost': 'GeneratorInterface.HiGenCommon.VtxSmearedRealisticPPbBoost8TeVCollision_cff',
-    'HLLHC'  :                       'IOMC.EventVertexGenerators.VtxSmearedHLLHC_cfi'
+    'HLLHC'  :                       'IOMC.EventVertexGenerators.VtxSmearedHLLHC_cfi',
+    'NominalCollision2015'  :        'IOMC.EventVertexGenerators.VtxSmearedNominalCollision2015_cfi'
 
 }
 VtxSmearedDefaultKey='Realistic8TeVCollision'

--- a/IOMC/EventVertexGenerators/python/VtxSmearedNominalCollision2015_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedNominalCollision2015_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import *
+VtxSmeared = cms.EDProducer("BetafuncEvtVtxGenerator",
+    NominalCollision2015VtxSmearingParameters,
+    VtxSmearedCommon
+)

--- a/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
@@ -395,5 +395,14 @@ NominalCollision4VtxSmearingParameters = cms.PSet(
     X0 = cms.double(0.2),
     Z0 = cms.double(0.0)
 )
-
-
+NominalCollision2015VtxSmearingParameters = cms.PSet(
+    Phi = cms.double(0.0),
+    BetaStar = cms.double(65.0),
+    Emittance = cms.double(5.411e-08),
+    Alpha = cms.double(0.0),
+    SigmaZ = cms.double(5.3),
+    TimeOffset = cms.double(0.0),
+    X0 = cms.double(0.0322),
+    Y0 = cms.double(0.0),
+    Z0 = cms.double(0.0)
+)


### PR DESCRIPTION
- introduce beamspot parameters as agreed during PPD General discussion https://indico.cern.ch/event/341218/ , NominalCollision2015
- both VtxSmearedDefaultKey and relvals are not touched by this PR
