### PR TITLE
cosmic digitizer parameters within the mixing module

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -933,6 +933,7 @@ class ConfigBuilder(object):
 		self.GENDefaultSeq='fixGenInfo'
 
         if self._options.scenario=='cosmics':
+	    self._options.pileup='Cosmics'	
             self.DIGIDefaultCFF="Configuration/StandardSequences/DigiCosmics_cff"
             self.RECODefaultCFF="Configuration/StandardSequences/ReconstructionCosmics_cff"
 	    self.SKIMDefaultCFF="Configuration/StandardSequences/SkimsCosmics_cff"

--- a/Configuration/StandardSequences/python/DigiCosmics_cff.py
+++ b/Configuration/StandardSequences/python/DigiCosmics_cff.py
@@ -32,16 +32,16 @@ from SimGeneral.Configuration.SimGeneral_cff import *
 #Special parameterization for cosmics
 #simSiPixelDigis.TofLowerCut = cms.double(18.5)
 #simSiPixelDigis.TofUpperCut = cms.double(43.5)
-#mix.digitizers.pixel.TofLowerCut = cms.double(18.5)
-#mix.digitizers.pixel.TofUpperCut = cms.double(43.5)
+#mix.digitizers.pixel.TofLowerCut = cms.double(18.5) moved to digitizersCosmics_cfi.py in the mixingmodule
+#mix.digitizers.pixel.TofUpperCut = cms.double(43.5) moved to digitizersCosmics_cfi.py in the mixingmodule
 
 #simSiStripDigis.CosmicDelayShift = cms.untracked.double(31)
-#mix.digitizers.strip.CosmicDelayShift = cms.untracked.double(31)
+#mix.digitizers.strip.CosmicDelayShift = cms.untracked.double(31) moved to digitizersCosmics_cfi.py in the mixingmodule
 
 #simEcalUnsuppressedDigis.cosmicsPhase = cms.bool(True)
 #simEcalUnsuppressedDigis.cosmicsShift = cms.double(1.)
-#mix.digitizers.ecal.cosmicsPhase = cms.bool(True)
-#mix.digitizers.ecal.cosmicsShift = cms.double(1.)
+#mix.digitizers.ecal.cosmicsPhase = cms.bool(True) moved to digitizersCosmics_cfi.py in the mixingmodule
+#mix.digitizers.ecal.cosmicsShift = cms.double(1.) moved to digitizersCosmics_cfi.py in the mixingmodule
 
 simEcalDigis.ebDccAdcToGeV = cms.double(0.00875)
 simEcalDigis.srpBarrelLowInterestChannelZS = cms.double(0.0153125)

--- a/Configuration/StandardSequences/python/Mixing.py
+++ b/Configuration/StandardSequences/python/Mixing.py
@@ -58,6 +58,7 @@ addMixingScenario("LowLumiPileUp4Sources",{'file': 'SimGeneral.MixingModule.mixL
 addMixingScenario("LowLumiPileUp4Sources_ProdStep1",{'file': 'SimGeneral.MixingModule.mixLowLumPU_4sources_mixProdStep1_cfi'})
 addMixingScenario("LowLumiPileUp_ProdStep1",{'file': 'SimGeneral.MixingModule.mixLowLumPU_mixProdStep1_cfi'})
 addMixingScenario("NoPileUp",{'file': 'SimGeneral.MixingModule.mixNoPU_cfi'})
+addMixingScenario("Cosmics",{'file': 'SimGeneral.MixingModule.mixCosmics_cfi'})
 addMixingScenario("E7TeV_ProbDist_2010Data_BX156",{'file': 'SimGeneral.MixingModule.mix_E7TeV_ProbDist_2010Data_BX156_cfi'})
 addMixingScenario("E8TeV_ProbDist_2011EarlyData_50ns",{'file': 'SimGeneral.MixingModule.mix_E8TeV_ProbDist_2011EarlyData_50ns_cfi'})
 addMixingScenario("E8TeV_FlatDist_2011EarlyData_50ns",{'file': 'SimGeneral.MixingModule.mix_E8TeV_FlatDist_2011EarlyData_50ns_cfi'})

--- a/SimGeneral/MixingModule/python/digitizersCosmics_cfi.py
+++ b/SimGeneral/MixingModule/python/digitizersCosmics_cfi.py
@@ -1,0 +1,61 @@
+import FWCore.ParameterSet.Config as cms
+
+# configuration to model pileup for initial physics phase
+from SimGeneral.MixingModule.aliases_cfi import *
+from SimGeneral.MixingModule.pixelDigitizer_cfi import *
+from SimGeneral.MixingModule.stripDigitizer_cfi import *
+from SimGeneral.MixingModule.ecalDigitizer_cfi import *
+from SimGeneral.MixingModule.hcalDigitizer_cfi import *
+from SimGeneral.MixingModule.castorDigitizer_cfi import *
+from SimGeneral.MixingModule.trackingTruthProducer_cfi import *
+
+pixelDigitizer.TofLowerCut=cms.double(18.5)
+pixelDigitizer.TofUpperCut=cms.double(43.5)
+stripDigitizer.CosmicDelayShift = cms.untracked.double(31)
+
+ecalDigitizer.cosmicsPhase = cms.bool(True)
+ecalDigitizer.cosmicsShift = cms.double(1.)
+
+theDigitizers = cms.PSet(
+  pixel = cms.PSet(
+    pixelDigitizer
+  ),
+  strip = cms.PSet(
+    stripDigitizer
+  ),
+  ecal = cms.PSet(
+    ecalDigitizer
+  ),
+  hcal = cms.PSet(
+    hcalDigitizer
+  ),
+  castor  = cms.PSet(
+    castorDigitizer
+  )
+)
+
+theDigitizersValid = cms.PSet(
+  pixel = cms.PSet(
+    pixelDigitizer
+  ),
+  strip = cms.PSet(
+    stripDigitizer
+  ),
+  ecal = cms.PSet(
+    ecalDigitizer
+  ),
+  hcal = cms.PSet(
+    hcalDigitizer
+  ),
+  castor  = cms.PSet(
+    castorDigitizer
+  ),
+  mergedtruth = cms.PSet(
+    trackingParticles
+  )
+)
+
+
+
+
+

--- a/SimGeneral/MixingModule/python/mixCosmics_cfi.py
+++ b/SimGeneral/MixingModule/python/mixCosmics_cfi.py
@@ -1,0 +1,26 @@
+import FWCore.ParameterSet.Config as cms
+
+# this is a minimum configuration of the Mixing module,
+# to run it in the zero-pileup mode
+#
+from SimGeneral.MixingModule.mixObjects_cfi import theMixObjects
+from SimGeneral.MixingModule.mixPoolSource_cfi import *
+from SimGeneral.MixingModule.digitizersCosmics_cfi import *
+
+mix = cms.EDProducer("MixingModule",
+    digitizers = cms.PSet(theDigitizers),
+    LabelPlayback = cms.string(''),
+    maxBunch = cms.int32(3),
+    minBunch = cms.int32(-5), ## in terms of 25 ns
+
+    bunchspace = cms.int32(25),
+    mixProdStep1 = cms.bool(False),
+    mixProdStep2 = cms.bool(False),
+
+    playback = cms.untracked.bool(False),
+    useCurrentProcessOnly = cms.bool(False),
+    mixObjects = cms.PSet(theMixObjects)
+)
+
+
+


### PR DESCRIPTION
This PR is intended to fix the cosmic scenario for which the some of cosmic paramters for the digitizers were actually not loaded - I'm requesting this to be included in 70X  as it is the release we would like to use for comsic production.
If this PR is ok , I will also PR the sames changes for the other cycles (71-72-73) 
