### PR TITLE
Strip cluster shape filter with subcluster info

### DIFF
--- a/RecoHI/HiTracking/python/hiRegitDetachedTripletStep_cff.py
+++ b/RecoHI/HiTracking/python/hiRegitDetachedTripletStep_cff.py
@@ -46,7 +46,7 @@ from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi 
 hiRegitDetachedTripletStepSeeds.RegionFactoryPSet.RegionPSet.ptMin = 1.2
 
 # building: feed the new-named seeds
-hiRegitDetachedTripletStepTrajectoryFilter = RecoTracker.IterativeTracking.DetachedTripletStep_cff.detachedTripletStepTrajectoryFilter.clone()
+hiRegitDetachedTripletStepTrajectoryFilter = RecoTracker.IterativeTracking.DetachedTripletStep_cff.detachedTripletStepTrajectoryFilterBase.clone()
 
 hiRegitDetachedTripletStepTrajectoryBuilder = RecoTracker.IterativeTracking.DetachedTripletStep_cff.detachedTripletStepTrajectoryBuilder.clone(
     trajectoryFilter     = cms.PSet(refToPSet_ = cms.string('hiRegitDetachedTripletStepTrajectoryFilter')),

--- a/RecoHI/HiTracking/python/hiRegitInitialStep_cff.py
+++ b/RecoHI/HiTracking/python/hiRegitInitialStep_cff.py
@@ -40,7 +40,7 @@ hiRegitInitialStepSeeds.skipClusters = cms.InputTag('hiRegitInitialStepClusters'
 hiRegitInitialStepSeeds.RegionFactoryPSet.RegionPSet.ptMin = 1.2
 
 # building: feed the new-named seeds
-hiRegitInitialStepTrajectoryFilter = RecoTracker.IterativeTracking.InitialStep_cff.initialStepTrajectoryFilter.clone()
+hiRegitInitialStepTrajectoryFilter = RecoTracker.IterativeTracking.InitialStep_cff.initialStepTrajectoryFilterBase.clone()
 
 
 hiRegitInitialStepTrajectoryBuilder = RecoTracker.IterativeTracking.InitialStep_cff.initialStepTrajectoryBuilder.clone(

--- a/RecoHI/HiTracking/python/hiRegitPixelPairStep_cff.py
+++ b/RecoHI/HiTracking/python/hiRegitPixelPairStep_cff.py
@@ -45,7 +45,7 @@ hiRegitPixelPairStepSeeds.RegionFactoryPSet.RegionPSet.ptMin = 1.2
 
 
 # building: feed the new-named seeds
-hiRegitPixelPairStepTrajectoryFilter = RecoTracker.IterativeTracking.PixelPairStep_cff.pixelPairStepTrajectoryFilter.clone()
+hiRegitPixelPairStepTrajectoryFilter = RecoTracker.IterativeTracking.PixelPairStep_cff.pixelPairStepTrajectoryFilterBase.clone()
 
 hiRegitPixelPairStepTrajectoryBuilder = RecoTracker.IterativeTracking.PixelPairStep_cff.pixelPairStepTrajectoryBuilder.clone(
     trajectoryFilter     = cms.PSet(refToPSet_ = cms.string('hiRegitPixelPairStepTrajectoryFilter')),

--- a/RecoPixelVertexing/PixelLowPtUtilities/interface/ClusterShapeHitFilter.h
+++ b/RecoPixelVertexing/PixelLowPtUtilities/interface/ClusterShapeHitFilter.h
@@ -188,26 +188,48 @@ class ClusterShapeHitFilter
 		    PixelData const * pd=nullptr ) const;
 
 
-  bool getSizes(DetId detId, const SiStripCluster & cluster, const LocalVector & ldir,
+  bool getSizes(DetId detId, const SiStripCluster & cluster, const LocalPoint &lpos, const LocalVector & ldir,
      int & meas, float & pred) const;
-  bool getSizes(const SiStripRecHit2D & recHit, const LocalVector & ldir,
+  bool getSizes(const SiStripRecHit2D & recHit, const LocalPoint &lpos, const LocalVector & ldir,
      int & meas, float & pred) const {
-    return getSizes(recHit.geographicalId(), recHit.stripCluster(), ldir, meas, pred);
+    return getSizes(recHit.geographicalId(), recHit.stripCluster(), lpos, ldir, meas, pred);
   }
   bool isCompatible(DetId detId,
                     const SiStripCluster & cluster,
+                    const LocalPoint  & lpos,
                     const LocalVector & ldir) const;
   bool isCompatible(DetId detId,
                     const SiStripCluster & cluster,
+                    const LocalVector & ldir) const { 
+      return isCompatible(detId, cluster, LocalPoint(0,0,0), ldir); 
+  }
+
+  bool isCompatible(DetId detId,
+                    const SiStripCluster & cluster,
+                    const GlobalPoint  & gpos,
                     const GlobalVector & gdir ) const;
+  bool isCompatible(DetId detId,
+                    const SiStripCluster & cluster,
+                    const GlobalVector & gdir ) const;
+  bool isCompatible(const SiStripRecHit2D & recHit,
+                    const LocalPoint  & lpos,
+                    const LocalVector & ldir) const {
+            return isCompatible(recHit.geographicalId(), recHit.stripCluster(), lpos, ldir);
+  }
   bool isCompatible(const SiStripRecHit2D & recHit,
                     const LocalVector & ldir) const {
             return isCompatible(recHit.geographicalId(), recHit.stripCluster(), ldir);
   }
   bool isCompatible(const SiStripRecHit2D & recHit,
+                    const GlobalPoint  & gpos,
+                    const GlobalVector & gdir ) const {
+            return isCompatible(recHit.geographicalId(), recHit.stripCluster(), gpos, gdir);
+  } 
+  bool isCompatible(const SiStripRecHit2D & recHit,
                     const GlobalVector & gdir ) const {
             return isCompatible(recHit.geographicalId(), recHit.stripCluster(), gdir);
   } 
+
 
 
  private:
@@ -227,7 +249,7 @@ class ClusterShapeHitFilter
   void fillPixelData();
 
   std::pair<float,float> getCotangent(const PixelGeomDetUnit * pixelDet) const;
-                   float getCotangent(const StripGeomDetUnit * stripDet) const;
+                   float getCotangent(const StripGeomDetUnit * stripDet, const LocalPoint &p = LocalPoint(0,0,0)) const;
 
   std::pair<float,float> getDrift(const PixelGeomDetUnit * pixelDet) const;
                    float getDrift(const StripGeomDetUnit * stripDet) const;

--- a/RecoPixelVertexing/PixelLowPtUtilities/interface/StripSubClusterShapeTrajectoryFilter.h
+++ b/RecoPixelVertexing/PixelLowPtUtilities/interface/StripSubClusterShapeTrajectoryFilter.h
@@ -1,0 +1,112 @@
+#ifndef _StripSubClusterShapeTrajectoryFilter_h_
+#define _StripSubClusterShapeTrajectoryFilter_h_
+
+#include <vector>
+#include <unordered_map>
+#include "TrackingTools/TrajectoryFiltering/interface/TrajectoryFilter.h"
+#include "RecoTracker/MeasurementDet/interface/MeasurementTrackerEvent.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "RecoTracker/TkSeedingLayers/interface/SeedComparitor.h"
+
+class ClusterShapeHitFilter;
+class TrackerTopology;
+class TrackerGeometry;
+class TrajectoryMeasurement;
+class TrajectoryStateOnSurface;
+class MeasurementTrackerEvent;
+class SiStripNoises;
+class TTree;
+namespace edm { class Event; class EventSetup; class ConsumesCollector; }
+
+//#define StripSubClusterShapeFilterBase_COUNTERS
+
+
+class StripSubClusterShapeFilterBase {
+    public:
+        StripSubClusterShapeFilterBase(const edm::ParameterSet &iConfig, edm::ConsumesCollector& iC);
+        virtual ~StripSubClusterShapeFilterBase();
+
+    protected:
+
+        void setEventBase(const edm::Event &, const edm::EventSetup &) ;
+
+        bool testLastHit(const TrackingRecHit *hit, const TrajectoryStateOnSurface &tsos, bool mustProject=false) const ;
+        bool testLastHit(const TrackingRecHit *hit, const GlobalPoint &gpos, const GlobalVector &gdir, bool mustProject=false) const ;
+
+        // who am i
+        std::string label_;
+
+        // pass-through of clusters with too many consecutive saturated strips
+        uint32_t maxNSat_;
+
+        // trimming parameters
+        uint8_t trimMaxADC_;
+        float   trimMaxFracTotal_, trimMaxFracNeigh_;
+
+        // maximum difference after peak finding
+        float   maxTrimmedSizeDiffPos_, maxTrimmedSizeDiffNeg_;
+
+        // peak finding parameters
+        float subclusterWindow_;
+        float seedCutMIPs_, seedCutSN_;
+        float subclusterCutMIPs_, subclusterCutSN_;
+
+        // layers in which to apply the filter 
+        std::array<std::array<uint8_t,10>, 7> layerMask_;
+
+#ifdef StripSubClusterShapeFilterBase_COUNTERS
+        mutable uint64_t called_, saturated_, test_, passTrim_, failTooLarge_, passSC_, failTooNarrow_;
+#endif
+
+        edm::ESHandle<TrackerGeometry> theTracker;
+        edm::ESHandle<ClusterShapeHitFilter> theFilter;
+        edm::ESHandle<SiStripNoises>  theNoise;
+        edm::ESHandle<TrackerTopology> theTopology;
+};
+
+class StripSubClusterShapeTrajectoryFilter: public StripSubClusterShapeFilterBase, public TrajectoryFilter {
+    public:
+        StripSubClusterShapeTrajectoryFilter(const edm::ParameterSet &iConfig, edm::ConsumesCollector& iC):
+            StripSubClusterShapeFilterBase(iConfig,iC) {}
+
+        virtual ~StripSubClusterShapeTrajectoryFilter() {}
+
+        virtual bool qualityFilter(const TempTrajectory&) const override;
+        virtual bool qualityFilter(const Trajectory&) const override;
+
+        virtual bool toBeContinued(TempTrajectory&) const override;
+        virtual bool toBeContinued(Trajectory&) const override;
+
+        virtual std::string name() const { return "StripSubClusterShapeTrajectoryFilter"; }
+
+        virtual void setEvent(const edm::Event & e, const edm::EventSetup & es) override {
+            setEventBase(e,es);
+        }
+};
+
+class StripSubClusterShapeSeedFilter: public StripSubClusterShapeFilterBase, public SeedComparitor {
+    public:
+        StripSubClusterShapeSeedFilter(const edm::ParameterSet &iConfig, edm::ConsumesCollector& iC) ;
+
+        virtual ~StripSubClusterShapeSeedFilter() {}
+
+        virtual void init(const edm::Event& ev, const edm::EventSetup& es) override {
+            setEventBase(ev,es);
+        }
+        // implemented
+        virtual bool compatible(const TrajectoryStateOnSurface &tsos,  SeedingHitSet::ConstRecHitPointer hit) const ;
+        // not implemented 
+        virtual bool compatible(const SeedingHitSet &hits, const TrackingRegion & region) const { return true; }
+        virtual bool compatible(const TrajectorySeed &seed) const { return true; }
+        virtual bool compatible(const SeedingHitSet &hits, const GlobalTrajectoryParameters &helixStateAtVertex, const FastHelix &helix, const TrackingRegion & region) const ;
+        virtual bool compatible(const SeedingHitSet &hits, const GlobalTrajectoryParameters &straightLineStateAtVertex, const TrackingRegion & region) const { return true; }
+
+    protected:
+        bool filterAtHelixStage_;
+};
+
+
+
+#endif

--- a/RecoPixelVertexing/PixelLowPtUtilities/interface/StripSubClusterShapeTrajectoryFilter.h
+++ b/RecoPixelVertexing/PixelLowPtUtilities/interface/StripSubClusterShapeTrajectoryFilter.h
@@ -84,6 +84,10 @@ class StripSubClusterShapeTrajectoryFilter: public StripSubClusterShapeFilterBas
         virtual void setEvent(const edm::Event & e, const edm::EventSetup & es) override {
             setEventBase(e,es);
         }
+
+    protected:
+        using StripSubClusterShapeFilterBase::testLastHit;
+        bool testLastHit(const TrajectoryMeasurement &last) const ;
 };
 
 class StripSubClusterShapeSeedFilter: public StripSubClusterShapeFilterBase, public SeedComparitor {

--- a/RecoPixelVertexing/PixelLowPtUtilities/plugins/modules.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/plugins/modules.cc
@@ -66,3 +66,7 @@ DEFINE_FWK_EVENTSETUP_MODULE(ClusterShapeHitFilterESProducer);
 #include "RecoPixelVertexing/PixelLowPtUtilities/interface/LowPtClusterShapeSeedComparitor.h"
 #include "RecoTracker/TkSeedingLayers/interface/SeedComparitorFactory.h"
 DEFINE_EDM_PLUGIN(SeedComparitorFactory, LowPtClusterShapeSeedComparitor, "LowPtClusterShapeSeedComparitor");
+
+#include "RecoPixelVertexing/PixelLowPtUtilities/interface/StripSubClusterShapeTrajectoryFilter.h"
+DEFINE_EDM_PLUGIN(TrajectoryFilterFactory, StripSubClusterShapeTrajectoryFilter, "StripSubClusterShapeTrajectoryFilter");
+DEFINE_EDM_PLUGIN(SeedComparitorFactory,   StripSubClusterShapeSeedFilter, "StripSubClusterShapeSeedFilter");

--- a/RecoPixelVertexing/PixelLowPtUtilities/python/StripSubClusterShapeFilter_cfi.py
+++ b/RecoPixelVertexing/PixelLowPtUtilities/python/StripSubClusterShapeFilter_cfi.py
@@ -1,0 +1,15 @@
+import FWCore.ParameterSet.Config as cms
+
+StripSubClusterShapeFilterParams = cms.PSet(
+    maxNSat = cms.uint32(3),
+    trimMaxADC = cms.double(30.),
+    trimMaxFracTotal = cms.double(0.15),
+    trimMaxFracNeigh = cms.double(0.25),
+    maxTrimmedSizeDiffPos = cms.double(0.7),
+    maxTrimmedSizeDiffNeg = cms.double(1.0),
+    subclusterWindow = cms.double(0.7),
+    seedCutMIPs = cms.double(0.35),
+    seedCutSN = cms.double(7.),
+    subclusterCutMIPs = cms.double(0.45),
+    subclusterCutSN = cms.double(12.),
+)

--- a/RecoPixelVertexing/PixelLowPtUtilities/python/StripSubClusterShapeSeedFilter_cfi.py
+++ b/RecoPixelVertexing/PixelLowPtUtilities/python/StripSubClusterShapeSeedFilter_cfi.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+
+from RecoPixelVertexing.PixelLowPtUtilities.StripSubClusterShapeFilter_cfi import StripSubClusterShapeFilterParams
+StripSubClusterShapeSeedFilter = cms.PSet(
+    StripSubClusterShapeFilterParams,
+    ComponentName = cms.string('StripSubClusterShapeSeedFilter'),
+    FilterAtHelixStage = cms.bool(False),
+    label = cms.untracked.string("Seeds"),
+)
+

--- a/RecoPixelVertexing/PixelLowPtUtilities/python/StripSubClusterShapeTrajectoryFilter_cfi.py
+++ b/RecoPixelVertexing/PixelLowPtUtilities/python/StripSubClusterShapeTrajectoryFilter_cfi.py
@@ -1,0 +1,17 @@
+import FWCore.ParameterSet.Config as cms
+
+from RecoPixelVertexing.PixelLowPtUtilities.StripSubClusterShapeFilter_cfi import StripSubClusterShapeFilterParams
+StripSubClusterShapeTrajectoryFilter = cms.PSet(
+    StripSubClusterShapeFilterParams,
+    ComponentType = cms.string('StripSubClusterShapeTrajectoryFilter'),
+)
+
+StripSubClusterShapeTrajectoryFilterTIB12 = cms.PSet(
+    StripSubClusterShapeTrajectoryFilter,
+    layerMask = cms.PSet(
+        TIB = cms.vuint32(1,2),
+        TOB = cms.bool(False),
+        TID = cms.bool(False),
+        TEC = cms.bool(False),
+    ),
+)

--- a/RecoPixelVertexing/PixelLowPtUtilities/python/StripSubClusterShapeTrajectoryFilter_cfi.py
+++ b/RecoPixelVertexing/PixelLowPtUtilities/python/StripSubClusterShapeTrajectoryFilter_cfi.py
@@ -15,3 +15,13 @@ StripSubClusterShapeTrajectoryFilterTIB12 = cms.PSet(
         TEC = cms.bool(False),
     ),
 )
+
+StripSubClusterShapeTrajectoryFilterTIX12 = cms.PSet(
+    StripSubClusterShapeTrajectoryFilter,
+    layerMask = cms.PSet(
+        TIB = cms.vuint32(1,2),
+        TOB = cms.bool(False),
+        TID = cms.vuint32(1,2),
+        TEC = cms.bool(False),
+    ),
+)

--- a/RecoPixelVertexing/PixelLowPtUtilities/src/StripSubClusterShapeTrajectoryFilter.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/src/StripSubClusterShapeTrajectoryFilter.cc
@@ -1,0 +1,408 @@
+#include "RecoPixelVertexing/PixelLowPtUtilities/interface/StripSubClusterShapeTrajectoryFilter.h"
+
+#include <map>
+#include <set>
+#include <algorithm>
+
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "DataFormats/TrackerRecHit2D/interface/ProjectedSiStripRecHit2D.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2D.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h"
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "Geometry/CommonDetUnit/interface/GeomDetType.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "RecoPixelVertexing/PixelLowPtUtilities/interface/ClusterShapeHitFilter.h"
+#include "RecoTracker/Record/interface/CkfComponentsRecord.h"
+#include "RecoTracker/MeasurementDet/src/TkMeasurementDetSet.h"
+#include "RecoTracker/MeasurementDet/interface/MeasurementTrackerEvent.h"
+#include "TrackingTools/PatternTools/interface/TempTrajectory.h"
+#include "TrackingTools/PatternTools/interface/Trajectory.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "RecoTracker/TkSeedGenerator/interface/FastHelix.h"
+#include "RecoTracker/TkSeedingLayers/interface/SeedingHitSet.h"
+
+#include "CondFormats/SiStripObjects/interface/SiStripNoises.h"
+#include "CondFormats/DataRecord/interface/SiStripNoisesRcd.h"
+
+#ifdef StripSubClusterShapeFilterBase_COUNTERS
+#define INC_COUNTER(X) X++;
+#else
+#define INC_COUNTER(X)
+#endif
+namespace {
+    class SlidingPeakFinder {
+        public:
+            SlidingPeakFinder(unsigned int size) :
+                size_(size), half_((size+1)/2) {}
+
+            template<typename Test>
+            bool apply(const uint8_t *x, const uint8_t *begin, const uint8_t *end, const Test & test, bool verbose=false, int firststrip=0) {
+                const uint8_t * ileft  = (x != begin)      ? std::min_element(x-1,x+half_)                     : begin - 1;
+                const uint8_t * iright = ((x+size_) < end) ? std::min_element(x+half_,std::min(x+size_+1,end)) : end;
+                uint8_t left   = (ileft  <  begin ? 0 : *ileft );
+                uint8_t right =  (iright >= end   ? 0 : *iright);
+                uint8_t center = *std::max_element(x, std::min(x+size_,end));
+                uint8_t maxmin = std::max(left,right);
+                if (maxmin < center) {
+                    bool ret = test(center, maxmin);
+                    if (ret) {
+                       ret = test(ileft,iright,begin,end);
+                    }
+                    return ret;
+                } else {
+                    return false;
+                }
+            }
+
+            template<typename Test>
+            bool apply(const std::vector<uint8_t> & ampls, const Test & test, bool verbose=false, int firststrip=0) {
+                const uint8_t *begin = &*ampls.begin();
+                const uint8_t *end = &*ampls.end();
+                for (const uint8_t *x = begin; x < end - (half_-1); ++x) {
+                    if (apply(x,begin,end,test,verbose,firststrip)) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+        private:
+            unsigned int size_, half_;
+
+    };
+
+    struct PeakFinderTest {
+        PeakFinderTest(float mip, uint32_t detid, uint32_t firstStrip, const SiStripNoises *theNoise,
+                float seedCutMIPs, float seedCutSN, 
+                float subclusterCutMIPs, float subclusterCutSN) :
+            mip_(mip),  detid_(detid), firstStrip_(firstStrip), noiseObj_(theNoise), noises_(theNoise->getRange(detid)),
+            subclusterCutMIPs_(subclusterCutMIPs), subclusterCutSN_(subclusterCutSN)
+        {
+            cut_ = std::min<float>(seedCutMIPs*mip, seedCutSN*noiseObj_->getNoise(firstStrip+1, noises_));
+        }
+
+        bool operator()(uint8_t max, uint8_t min) const {
+            return max-min > cut_;
+        } 
+        bool operator()(const uint8_t *left, const uint8_t *right, const uint8_t *begin, const uint8_t *end) const {
+            int yleft  = (left  <  begin ? 0 : *left);
+            int yright = (right >= end   ? 0 : *right);
+            unsigned int sum = 0, sumall = 0, strips = 0; int maxval = 0; float noise = 0;
+            for (const uint8_t *x = left+1; x < right; ++x) {
+                int baseline = (yleft * int(right-x) + yright * int(x-left)) / int(right-left);
+                sumall += int(*x);
+                sum += int(*x) - baseline;
+                noise += std::pow(noiseObj_->getNoise(firstStrip_ + int(x-begin), noises_), 2);
+                maxval = std::max(maxval, int(*x) - baseline);
+                strips++;
+            }
+            if (sum/mip_ > subclusterCutMIPs_ && sum/std::sqrt(noise) > subclusterCutSN_) return true;
+            return false; 
+        }
+
+        private:
+            float mip_;
+            unsigned int detid_; int firstStrip_;
+            const SiStripNoises *noiseObj_;
+            SiStripNoises::Range noises_;
+            uint8_t cut_;
+            float subclusterCutMIPs_, subclusterCutSN_;
+    };
+
+}
+
+/*****************************************************************************/
+StripSubClusterShapeFilterBase::StripSubClusterShapeFilterBase
+   (const edm::ParameterSet &iCfg, edm::ConsumesCollector& iC) :
+   label_(iCfg.getUntrackedParameter<std::string>("label","")),
+   maxNSat_(iCfg.getParameter<uint32_t>("maxNSat")),
+   trimMaxADC_(iCfg.getParameter<double>("trimMaxADC")),
+   trimMaxFracTotal_(iCfg.getParameter<double>("trimMaxFracTotal")),
+   trimMaxFracNeigh_(iCfg.getParameter<double>("trimMaxFracNeigh")),
+   maxTrimmedSizeDiffPos_(iCfg.getParameter<double>("maxTrimmedSizeDiffPos")),
+   maxTrimmedSizeDiffNeg_(iCfg.getParameter<double>("maxTrimmedSizeDiffNeg")),
+   subclusterWindow_(iCfg.getParameter<double>("subclusterWindow")),
+   seedCutMIPs_(iCfg.getParameter<double>("seedCutMIPs")),
+   seedCutSN_(iCfg.getParameter<double>("seedCutSN")),
+   subclusterCutMIPs_(iCfg.getParameter<double>("subclusterCutMIPs")),
+   subclusterCutSN_(iCfg.getParameter<double>("subclusterCutSN"))
+#ifdef StripSubClusterShapeFilterBase_COUNTERS
+   ,called_(0),saturated_(0),test_(0),passTrim_(0),failTooLarge_(0),passSC_(0),failTooNarrow_(0)
+#endif
+{
+    if (iCfg.exists("layerMask")) {
+        const edm::ParameterSet &iLM = iCfg.getParameter<edm::ParameterSet>("layerMask");
+        const char *ndets[4] =  { "TIB", "TID", "TOB", "TEC" };
+        const int   idets[4] =  {   3,     4,     5,     6   };
+        for (unsigned int i = 0; i < 4; ++i) {
+            if (iLM.existsAs<bool>(ndets[i])) {
+                std::fill(layerMask_[idets[i]].begin(), layerMask_[idets[i]].end(), iLM.getParameter<bool>(ndets[i]));
+            } else {
+                layerMask_[idets[i]][0] = 2;
+                std::fill(layerMask_[idets[i]].begin()+1, layerMask_[idets[i]].end(), 0);
+                for (uint32_t lay : iLM.getParameter<std::vector<uint32_t>>(ndets[i])) {
+                    layerMask_[idets[i]][lay] = 1;
+                }
+            }
+        }
+    } else {
+        for (auto & arr : layerMask_) {
+            std::fill(arr.begin(), arr.end(), 1);
+        }
+    }
+}
+
+/*****************************************************************************/
+StripSubClusterShapeFilterBase::~StripSubClusterShapeFilterBase()
+{
+#if 0
+    std::cout << "StripSubClusterShapeFilterBase " << label_ <<": called        " << called_ << std::endl;
+    std::cout << "StripSubClusterShapeFilterBase " << label_ <<": saturated     " << saturated_ << std::endl;
+    std::cout << "StripSubClusterShapeFilterBase " << label_ <<": test          " << test_ << std::endl;
+    std::cout << "StripSubClusterShapeFilterBase " << label_ <<": failTooNarrow " << failTooNarrow_ << std::endl;
+    std::cout << "StripSubClusterShapeFilterBase " << label_ <<": passTrim      " << passTrim_ << std::endl;
+    std::cout << "StripSubClusterShapeFilterBase " << label_ <<": passSC        " << passSC_ << std::endl;
+    std::cout << "StripSubClusterShapeFilterBase " << label_ <<": failTooLarge  " << failTooLarge_ << std::endl;
+#endif
+}
+
+
+bool StripSubClusterShapeFilterBase::testLastHit
+   (const TrackingRecHit *hit, const TrajectoryStateOnSurface &tsos, bool mustProject) const
+{
+    return testLastHit(hit, tsos.globalPosition(), tsos.globalDirection(), mustProject);
+
+}
+bool StripSubClusterShapeFilterBase::testLastHit
+   (const TrackingRecHit *hit, const GlobalPoint &gpos, const GlobalVector &gdir, bool mustProject) const
+{
+   const TrackerSingleRecHit *stripHit = 0;
+   if (typeid(*hit) == typeid(SiStripMatchedRecHit2D)) {
+      const SiStripMatchedRecHit2D & mhit = static_cast<const SiStripMatchedRecHit2D &>(*hit);
+      SiStripRecHit2D mono = mhit.monoHit();
+      SiStripRecHit2D stereo = mhit.stereoHit();
+      return testLastHit(&mono, gpos, gdir, true) && testLastHit(&stereo, gpos, gdir, true);
+   } else if (typeid(*hit) == typeid(ProjectedSiStripRecHit2D)) {
+      const ProjectedSiStripRecHit2D & mhit = static_cast<const ProjectedSiStripRecHit2D &>(*hit);
+      const SiStripRecHit2D &orig = mhit.originalHit();
+      return testLastHit(&orig,   gpos, gdir, true);
+   } else if ((stripHit = dynamic_cast<const TrackerSingleRecHit *>(hit)) != 0) {
+      DetId detId = hit->geographicalId();
+
+      if (layerMask_[detId.subdetId()][0] == 0) {
+          return true; // no filtering here
+      } else if (layerMask_[detId.subdetId()][0] == 2) {
+          unsigned int ilayer = theTopology->layer(detId);          
+          if (layerMask_[detId.subdetId()][ilayer] == 0) {
+              return true; // no filtering here
+          }
+      }
+
+      const GeomDet *det = theTracker->idToDet(detId);
+      LocalVector ldir = det->toLocal(gdir);
+      LocalPoint  lpos = det->toLocal(gpos);
+      if (mustProject) {
+         lpos -= ldir * lpos.z()/ldir.z();
+      }
+      int hitStrips; float hitPredPos;
+      const SiStripCluster &cluster = stripHit->stripCluster();
+      bool usable = theFilter->getSizes(detId, cluster, lpos, ldir, hitStrips, hitPredPos);
+      if (!usable) return true;
+
+      INC_COUNTER(called_)
+      const std::vector<uint8_t> &ampls = cluster.amplitudes();
+      
+      // pass-through of trivial case 
+      if (std::abs(hitPredPos) < 1.5f && hitStrips <= 2) {
+        return true;
+      }
+
+
+      // compute number of consecutive saturated strips
+      unsigned int thisSat = (ampls[0] >= 254), maxSat = thisSat;
+      for (unsigned int i = 1, n = ampls.size(); i < n; ++i) {
+          if (ampls[i] >= 254) {
+              thisSat++;
+          } else if (thisSat > 0) {
+              maxSat = std::max<int>(maxSat, thisSat);
+              thisSat = 0;
+          }
+      }
+      if (thisSat > 0) {
+          maxSat = std::max<int>(maxSat, thisSat);
+      }
+      if (maxSat >= maxNSat_) {
+          INC_COUNTER(saturated_)
+          return true;
+      }
+     
+      // trimming
+      INC_COUNTER(test_)
+      unsigned int hitStripsTrim = ampls.size();
+      int sum = std::accumulate(ampls.begin(), ampls.end(), 0);
+      uint8_t trimCut = std::min<uint8_t>(trimMaxADC_, std::floor(trimMaxFracTotal_ * sum));
+      std::vector<uint8_t>::const_iterator begin = ampls.begin();
+      std::vector<uint8_t>::const_iterator last = ampls.end()-1;
+      while (hitStripsTrim > 1 && (*begin < std::max<uint8_t>(trimCut, trimMaxFracNeigh_*(*(begin+1)))) ) { hitStripsTrim--; ++begin; }
+      while (hitStripsTrim > 1 && (*last  < std::max<uint8_t>(trimCut, trimMaxFracNeigh_*(*(last -1)))) ) { hitStripsTrim--; --last; }
+
+      if (hitStripsTrim < std::floor(std::abs(hitPredPos)-maxTrimmedSizeDiffNeg_)) {
+          INC_COUNTER(failTooNarrow_)
+          return false;
+      } else if (hitStripsTrim <= std::ceil(std::abs(hitPredPos)+maxTrimmedSizeDiffPos_)) {
+          INC_COUNTER(passTrim_)
+          return true;
+      } 
+
+      const StripGeomDetUnit* stripDetUnit = dynamic_cast<const StripGeomDetUnit *>(det);
+      if (det == 0) { edm::LogError("Strip not a StripGeomDetUnit?") << " on " << detId.rawId() << "\n"; return true; }
+
+      float MeVperADCStrip =  3.61e-06*265; 
+      float mip = 3.9 / ( MeVperADCStrip/stripDetUnit->surface().bounds().thickness() ); // 3.9 MeV/cm = ionization in silicon 
+      float mipnorm = mip/std::abs(ldir.z());
+      ::SlidingPeakFinder pf(std::max<int>(2,std::ceil(std::abs(hitPredPos)+subclusterWindow_)));
+      ::PeakFinderTest test(mipnorm, detId(), cluster.firstStrip(), &*theNoise, seedCutMIPs_, seedCutSN_, subclusterCutMIPs_, subclusterCutSN_);
+      if (pf.apply(cluster.amplitudes(), test)) {
+          INC_COUNTER(passSC_)
+          return true;
+      } else {
+          INC_COUNTER(failTooLarge_)
+          return false;
+      }
+
+    }
+    return true; 
+}
+
+void StripSubClusterShapeFilterBase::setEventBase
+  (const edm::Event &event, const edm::EventSetup &es) 
+{
+  // Get tracker geometry
+  es.get<TrackerDigiGeometryRecord>().get(theTracker);
+
+  es.get<CkfComponentsRecord>().get("ClusterShapeHitFilter",theFilter);
+
+  //Retrieve tracker topology from geometry
+  es.get<IdealGeometryRecord>().get(theTopology);
+
+  es.get<SiStripNoisesRcd>().get(theNoise);
+
+}
+
+/*****************************************************************************/
+bool StripSubClusterShapeTrajectoryFilter::toBeContinued
+(Trajectory& trajectory) const 
+{
+   throw cms::Exception("toBeContinued(Traj) instead of toBeContinued(TempTraj)");
+}
+
+/*****************************************************************************/
+bool StripSubClusterShapeTrajectoryFilter::toBeContinued
+(TempTrajectory& trajectory) const 
+{
+   const TempTrajectory::DataContainer & tms = trajectory.measurements();
+
+   const TrajectoryMeasurement &last = *tms.rbegin();
+   const TrackingRecHit* hit = last.recHit()->hit();
+   if (!last.updatedState().isValid()) return true;
+   if (hit == 0 || !hit->isValid()) return true;
+   if (hit->geographicalId().subdetId() <= 2) return true; // we look only at strips for now
+   return testLastHit(hit, last.updatedState(), false);
+}
+
+/*****************************************************************************/
+bool StripSubClusterShapeTrajectoryFilter::qualityFilter
+  (const Trajectory& trajectory) const
+{
+   const Trajectory::DataContainer & tms = trajectory.measurements();
+
+   const TrajectoryMeasurement &last = *tms.rbegin();
+   const TrackingRecHit* hit = last.recHit()->hit();
+   if (!last.updatedState().isValid()) return true;
+   if (hit == 0 || !hit->isValid()) return true;
+   if (hit->geographicalId().subdetId() <= 2) return true; // we look only at strips for now
+   return testLastHit(hit, last.updatedState(), false);
+
+}
+
+/*****************************************************************************/
+bool StripSubClusterShapeTrajectoryFilter::qualityFilter
+  (const TempTrajectory& trajectory) const
+{
+   const TempTrajectory::DataContainer & tms = trajectory.measurements();
+   const TrajectoryMeasurement &last = *tms.rbegin();
+   const TrackingRecHit* hit = last.recHit()->hit();
+   if (!last.updatedState().isValid()) return true;
+   if (hit == 0 || !hit->isValid()) return true;
+   if (hit->geographicalId().subdetId() <= 2) return true; // we look only at strips for now
+   return testLastHit(hit, last.updatedState(), false);
+
+}
+
+
+/*****************************************************************************/
+StripSubClusterShapeSeedFilter::StripSubClusterShapeSeedFilter
+   (const edm::ParameterSet &iConfig, edm::ConsumesCollector& iC) :
+        StripSubClusterShapeFilterBase(iConfig,iC), 
+        filterAtHelixStage_(iConfig.getParameter<bool>("FilterAtHelixStage")) 
+
+{
+    if (filterAtHelixStage_) edm::LogError("Configuration") << "StripSubClusterShapeSeedFilter: FilterAtHelixStage is not yet working correctly.\n";
+}
+
+
+/*****************************************************************************/
+bool StripSubClusterShapeSeedFilter::compatible
+  (const  TrajectoryStateOnSurface & tsos, SeedingHitSet::ConstRecHitPointer thit) const
+{
+   if (filterAtHelixStage_) return true;
+   const TrackingRecHit* hit = thit->hit();
+   if (hit == 0 || !hit->isValid()) return true;
+   if (hit->geographicalId().subdetId() <= 2) return true; // we look only at strips for now
+   return testLastHit(hit, tsos, false);
+}
+
+bool StripSubClusterShapeSeedFilter::compatible
+    (const SeedingHitSet &hits, const GlobalTrajectoryParameters &helixStateAtVertex, const FastHelix &helix, const TrackingRegion & region) const 
+{ 
+   if (!filterAtHelixStage_) return true;
+
+   if (!helix.isValid()) edm::LogWarning("InvalidHelix") << "PixelClusterShapeSeedComparitor helix is not valid, result is bad";
+
+    float xc = helix.circle().x0(), yc = helix.circle().y0();
+
+    GlobalPoint  vertex = helixStateAtVertex.position();
+    GlobalVector momvtx = helixStateAtVertex.momentum();
+    float x0 = vertex.x(), y0 = vertex.y();
+    for (unsigned int i = 0, n = hits.size(); i < n; ++i) {
+        auto const  & hit = *hits[i];
+        if (hit.geographicalId().subdetId() <= 2) continue; 
+
+        GlobalPoint pos = hit.globalPosition();
+        float x1 = pos.x(), y1 = pos.y(), dx1 = x1 - xc, dy1 = y1 - yc;
+
+        // now figure out the proper tangent vector
+        float perpx = -dy1, perpy = dx1;
+        if (perpx * (x1-x0) + perpy * (y1 - y0) < 0) {
+            perpy = -perpy; perpx = -perpx;
+        }
+
+        // now normalize (perpx, perpy, 1.0) to unity
+        float pnorm = 1.0/std::sqrt(perpx*perpx + perpy*perpy + 1);
+        GlobalVector gdir(perpx*pnorm, perpy*pnorm, (momvtx.z() > 0 ? pnorm : -pnorm));
+
+        if (!testLastHit(&hit, pos, gdir)) {
+            return false; // not yet
+        }
+    }
+    return true; 
+}
+

--- a/RecoPixelVertexing/PixelLowPtUtilities/test/ClusterShapeExtractor.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/test/ClusterShapeExtractor.cc
@@ -50,9 +50,9 @@ class ClusterShapeExtractor : public edm::EDAnalyzer
  public:
    explicit ClusterShapeExtractor(const edm::ParameterSet& pset);
    ~ClusterShapeExtractor();
-   virtual void beginRun(edm::Run & run,       const edm::EventSetup& es);
-   virtual void analyze (const edm::Event& ev, const edm::EventSetup& es);
-   virtual void endJob();
+   virtual void beginRun(const edm::Run & run, const edm::EventSetup& es) override;
+   virtual void analyze (const edm::Event& ev, const edm::EventSetup& es) override;
+   virtual void endJob() override;
 
  private:
    bool isSuitable(const PSimHit & simHit);
@@ -104,7 +104,7 @@ class ClusterShapeExtractor : public edm::EDAnalyzer
 };
 
 /*****************************************************************************/
-void ClusterShapeExtractor::beginRun(edm::Run & run, const edm::EventSetup& es)
+void ClusterShapeExtractor::beginRun(const edm::Run & run, const edm::EventSetup& es)
 {
   // Get tracker geometry
   edm::ESHandle<TrackerGeometry>          tracker;
@@ -194,7 +194,8 @@ bool ClusterShapeExtractor::isSuitable(const PSimHit & simHit)
 {
   // Outgoing?
   DetId id = DetId(simHit.detUnitId());
-
+  const GeomDetUnit *gdu = theTracker->idToDetUnit(id);
+  if (gdu == 0) throw cms::Exception("MissingData") << "Missing DetUnit for detid " << id.rawId() << "\n" << std::endl;
   GlobalVector gvec = theTracker->idToDetUnit(id)->position() -
                       GlobalPoint(0,0,0);
   LocalVector  lvec = theTracker->idToDetUnit(id)->toLocal(gvec);
@@ -219,7 +220,7 @@ void ClusterShapeExtractor::processRec(const SiStripRecHit2D & recHit,
   int meas;
   float pred;
  
-  if(theClusterShape->getSizes(recHit,ldir, meas,pred))
+  if(theClusterShape->getSizes(recHit,LocalPoint(0,0,0), ldir, meas,pred))
     if(meas <= ewMax)
       histo[meas]->Fill(pred);
 }
@@ -353,6 +354,7 @@ void ClusterShapeExtractor::processMatchedRecHits
   map<pair<unsigned int, float>, const SiStripRecHit2D *> simHitMap;
   // VI very very quick fix
   std::vector<SiStripRecHit2D> cache;
+  cache.reserve(2*recHits->size());
   PSimHit simHit;
   pair<unsigned int, float> key;
 

--- a/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
@@ -49,12 +49,21 @@ detachedTripletStepSeeds.SeedComparitorPSet = cms.PSet(
 
 # QUALITY CUTS DURING TRACK BUILDING
 import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
-detachedTripletStepTrajectoryFilter = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
+detachedTripletStepTrajectoryFilterBase = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
     maxLostHitsFraction = cms.double(1./10.),
     constantValueForLostHitsFractionFilter = cms.double(0.701),
     minimumNumberOfHits = 3,
     minPt = 0.075
     )
+import RecoPixelVertexing.PixelLowPtUtilities.StripSubClusterShapeTrajectoryFilter_cfi
+detachedTripletStepTrajectoryFilterShape = RecoPixelVertexing.PixelLowPtUtilities.StripSubClusterShapeTrajectoryFilter_cfi.StripSubClusterShapeTrajectoryFilterTIX12.clone()
+detachedTripletStepTrajectoryFilter = cms.PSet(
+    ComponentType = cms.string('CompositeTrajectoryFilter'),
+    filters = cms.VPSet(
+        cms.PSet( refToPSet_ = cms.string('detachedTripletStepTrajectoryFilterBase')),
+        cms.PSet( refToPSet_ = cms.string('detachedTripletStepTrajectoryFilterShape'))),
+)
+
 
 import TrackingTools.KalmanUpdators.Chi2ChargeMeasurementEstimatorESProducer_cfi
 detachedTripletStepChi2Est = TrackingTools.KalmanUpdators.Chi2ChargeMeasurementEstimatorESProducer_cfi.Chi2ChargeMeasurementEstimator.clone(

--- a/RecoTracker/IterativeTracking/python/InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStep_cff.py
@@ -32,10 +32,18 @@ initialStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.SeedComparitorPSet = RecoP
 
 # building
 import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
-initialStepTrajectoryFilter = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
+initialStepTrajectoryFilterBase = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
     minimumNumberOfHits = 3,
     minPt = 0.2
     )
+import RecoPixelVertexing.PixelLowPtUtilities.StripSubClusterShapeTrajectoryFilter_cfi
+initialStepTrajectoryFilterShape = RecoPixelVertexing.PixelLowPtUtilities.StripSubClusterShapeTrajectoryFilter_cfi.StripSubClusterShapeTrajectoryFilterTIX12.clone()
+initialStepTrajectoryFilter = cms.PSet(
+    ComponentType = cms.string('CompositeTrajectoryFilter'),
+    filters = cms.VPSet(
+        cms.PSet( refToPSet_ = cms.string('initialStepTrajectoryFilterBase')),
+        cms.PSet( refToPSet_ = cms.string('initialStepTrajectoryFilterShape'))),
+)
 
 import TrackingTools.KalmanUpdators.Chi2ChargeMeasurementEstimatorESProducer_cfi
 initialStepChi2Est = TrackingTools.KalmanUpdators.Chi2ChargeMeasurementEstimatorESProducer_cfi.Chi2ChargeMeasurementEstimator.clone(

--- a/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
@@ -109,16 +109,24 @@ import RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cf
 pixelLessStepClusterShapeHitFilter  = RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi.ClusterShapeHitFilterESProducer.clone(
 	ComponentName = cms.string('pixelLessStepClusterShapeHitFilter'),
         PixelShapeFile= cms.string('RecoPixelVertexing/PixelLowPtUtilities/data/pixelShape.par'),
+        doStripShapeCut = cms.bool(False),
 	minGoodStripCharge = cms.double(2069)
 	)
-
+import RecoPixelVertexing.PixelLowPtUtilities.StripSubClusterShapeSeedFilter_cfi
 pixelLessStepSeeds.SeedComparitorPSet = cms.PSet(
-        ComponentName = cms.string('PixelClusterShapeSeedComparitor'),
-        FilterAtHelixStage = cms.bool(True),
-        FilterPixelHits = cms.bool(False),
-        FilterStripHits = cms.bool(True),
-        ClusterShapeHitFilterName = cms.string('pixelLessStepClusterShapeHitFilter'),
-        ClusterShapeCacheSrc = cms.InputTag("siPixelClusterShapeCache") # not really needed here since FilterPixelHits=False
+    ComponentName = cms.string('CombinedSeedComparitor'),
+        mode = cms.string("and"),
+        comparitors = cms.VPSet(
+            cms.PSet(
+                ComponentName = cms.string('PixelClusterShapeSeedComparitor'),
+                FilterAtHelixStage = cms.bool(True),
+                FilterPixelHits = cms.bool(False),
+                FilterStripHits = cms.bool(True),
+                ClusterShapeHitFilterName = cms.string('pixelLessStepClusterShapeHitFilter'),
+                ClusterShapeCacheSrc = cms.InputTag("siPixelClusterShapeCache") # not really needed here since FilterPixelHits=False
+            ), 
+            RecoPixelVertexing.PixelLowPtUtilities.StripSubClusterShapeSeedFilter_cfi.StripSubClusterShapeSeedFilter.clone()
+        )
     )
 
 # QUALITY CUTS DURING TRACK BUILDING

--- a/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
@@ -53,10 +53,20 @@ pixelPairStepSeeds.SeedComparitorPSet = cms.PSet(
 
 # QUALITY CUTS DURING TRACK BUILDING
 import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
-pixelPairStepTrajectoryFilter = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
+pixelPairStepTrajectoryFilterBase = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
     minimumNumberOfHits = 3,
     minPt = 0.1
     )
+import RecoPixelVertexing.PixelLowPtUtilities.StripSubClusterShapeTrajectoryFilter_cfi
+pixelPairStepTrajectoryFilterShape = RecoPixelVertexing.PixelLowPtUtilities.StripSubClusterShapeTrajectoryFilter_cfi.StripSubClusterShapeTrajectoryFilterTIX12.clone()
+pixelPairStepTrajectoryFilter = cms.PSet(
+    ComponentType = cms.string('CompositeTrajectoryFilter'),
+    filters = cms.VPSet(
+        cms.PSet( refToPSet_ = cms.string('pixelPairStepTrajectoryFilterBase')),
+        cms.PSet( refToPSet_ = cms.string('pixelPairStepTrajectoryFilterShape'))),
+)
+
+
 
 import TrackingTools.KalmanUpdators.Chi2ChargeMeasurementEstimatorESProducer_cfi
 pixelPairStepChi2Est = TrackingTools.KalmanUpdators.Chi2ChargeMeasurementEstimatorESProducer_cfi.Chi2ChargeMeasurementEstimator.clone(

--- a/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
@@ -63,14 +63,22 @@ tobTecStepSeedsTripl.RegionFactoryPSet.RegionPSet.originRadius = 3.5
 tobTecStepSeedsTripl.SeedCreatorPSet.ComponentName = 'SeedFromConsecutiveHitsCreator' #empirically better than 'SeedFromConsecutiveHitsTripletOnlyCreator'
 tobTecStepSeedsTripl.SeedCreatorPSet.OriginTransverseErrorMultiplier = 1.0
 #SeedComparitor
+import RecoPixelVertexing.PixelLowPtUtilities.StripSubClusterShapeSeedFilter_cfi
 
 tobTecStepSeedsTripl.SeedComparitorPSet = cms.PSet(
+   ComponentName = cms.string('CombinedSeedComparitor'),
+   mode = cms.string("and"),
+   comparitors = cms.VPSet(
+     cms.PSet(
         ComponentName = cms.string('PixelClusterShapeSeedComparitor'),
         FilterAtHelixStage = cms.bool(True),
         FilterPixelHits = cms.bool(False),
         FilterStripHits = cms.bool(True),
         ClusterShapeHitFilterName = cms.string('tobTecStepClusterShapeHitFilter'),
         ClusterShapeCacheSrc = cms.InputTag("siPixelClusterShapeCache") # not really needed here since FilterPixelHits=False
+    ),
+    RecoPixelVertexing.PixelLowPtUtilities.StripSubClusterShapeSeedFilter_cfi.StripSubClusterShapeSeedFilter.clone()
+  )
 )
 # PAIR SEEDING LAYERS
 tobTecStepSeedLayersPair = cms.EDProducer("SeedingLayersEDProducer",
@@ -117,12 +125,19 @@ tobTecStepSeedsPair.RegionFactoryPSet.RegionPSet.originRadius = 6.0
 tobTecStepSeedsPair.SeedCreatorPSet.OriginTransverseErrorMultiplier = 1.0
 #SeedComparitor
 tobTecStepSeedsPair.SeedComparitorPSet = cms.PSet(
+   ComponentName = cms.string('CombinedSeedComparitor'),
+   mode = cms.string("and"),
+   comparitors = cms.VPSet(
+     cms.PSet(
         ComponentName = cms.string('PixelClusterShapeSeedComparitor'),
         FilterAtHelixStage = cms.bool(True),
         FilterPixelHits = cms.bool(False),
         FilterStripHits = cms.bool(True),
         ClusterShapeHitFilterName = cms.string('tobTecStepClusterShapeHitFilter'),
         ClusterShapeCacheSrc = cms.InputTag("siPixelClusterShapeCache") # not really needed here since FilterPixelHits=False
+    ),
+    RecoPixelVertexing.PixelLowPtUtilities.StripSubClusterShapeSeedFilter_cfi.StripSubClusterShapeSeedFilter.clone()
+  )
 )
 import RecoTracker.TkSeedGenerator.GlobalCombinedSeeds_cfi
 tobTecStepSeeds = RecoTracker.TkSeedGenerator.GlobalCombinedSeeds_cfi.globalCombinedSeeds.clone()

--- a/RecoTracker/MeasurementDet/src/TkMeasurementDetSet.h
+++ b/RecoTracker/MeasurementDet/src/TkMeasurementDetSet.h
@@ -86,6 +86,10 @@ public:
   bool maskBad128StripBlocks() const { return maskBad128StripBlocks_;}
   bool hasAny128StripBad(int i) const { return  hasAny128StripBad_[i];}
   
+  /// note: index is 6*detector index + offset!
+  bool bad128Strip(int offset) const { return  bad128Strip_[offset];}
+  bool bad128Strip(int index, int strip) const { return  bad128Strip_[nbad128*index+(strip>>7)];}
+
   std::vector<BadStripBlock> & getBadStripBlocks(int i) { return badStripBlocks_[i]; }
   std::vector<BadStripBlock> const & badStripBlocks(int i) const {return badStripBlocks_[i]; }
 


### PR DESCRIPTION
Introduce a new strip cluster shape filter:
- in the trajectory building of the initial, pixelPair and detachedTriplet steps, only for the TIB and TID layers 1,2
- in the seed building for pixelLess (replacing the old one) and tobTec (where there was none)

Presented at the tracking POG meeting on 22 Sep 2014, https://indico.cern.ch/event/337840/
After the meeting, it was verified that it doesn't have ill effects on the QCD 3TeV relval, and that the small inefficiency introduced in the pixelLess and tobTec does not depend on the transverse impact parameter of the tracks.
