### PR TITLE
Hgc deadzone mitigation

### DIFF
--- a/Geometry/FCalGeometry/src/HGCalGeometry.cc
+++ b/Geometry/FCalGeometry/src/HGCalGeometry.cc
@@ -148,10 +148,13 @@ DetId HGCalGeometry::getClosestCell( const GlobalPoint& r ) const {
 	      << ":" << id_.iLay << ":" << id_.iSec << ":" << id_.iSubSec
 	      << ":" << id_.iCell << " Cell " << m_cellVec[cellIndex];
 #endif
-    return topology().encode(id_);
-  } else {
-    return DetId();
+
+    //check if returned cell is valid
+    if(id_.iCell>=0) return topology().encode(id_);
   }
+
+  //if not valid or out of bounds return a null DetId
+  return DetId();
 }
 
 HGCalGeometry::DetIdSet HGCalGeometry::getCells( const GlobalPoint& r, double dR ) const {

--- a/Geometry/HGCalCommonData/interface/HGCalDDDConstants.h
+++ b/Geometry/HGCalCommonData/interface/HGCalDDDConstants.h
@@ -77,7 +77,7 @@ public:
  
 private:
   void                initialize(const DDCompactView& cpv, std::string name);
-  void                loadGeometry(const DDFilteredView& fv, std::string& tag);
+  void                loadGeometry(const DDFilteredView& fv, const std::string& tag);
   void                loadSpecPars(const DDFilteredView& fv);
   std::vector<double> getDDDArray(const std::string &, 
                                   const DDsvalues_type &, int &) const;

--- a/SimG4CMS/Calo/interface/HGCNumberingScheme.h
+++ b/SimG4CMS/Calo/interface/HGCNumberingScheme.h
@@ -29,7 +29,7 @@ public:
   /**
      @short assigns the det id to a hit
    */
-  virtual uint32_t getUnitID(ForwardSubdetector &subdet, int &layer, int &module, int &iz, const G4ThreeVector &pos);
+  virtual uint32_t getUnitID(ForwardSubdetector subdet, int layer, int module, int iz, const G4ThreeVector &pos);
 
   /**
      @short maps a hit position to a sequential cell in a trapezoid surface defined by h,b,t

--- a/SimG4CMS/Calo/interface/HGCNumberingScheme.h
+++ b/SimG4CMS/Calo/interface/HGCNumberingScheme.h
@@ -29,7 +29,7 @@ public:
   /**
      @short assigns the det id to a hit
    */
-  virtual uint32_t getUnitID(ForwardSubdetector &subdet, int &layer, int &module, int &iz, G4ThreeVector &pos);
+  virtual uint32_t getUnitID(ForwardSubdetector &subdet, int &layer, int &module, int &iz, const G4ThreeVector &pos);
 
   /**
      @short maps a hit position to a sequential cell in a trapezoid surface defined by h,b,t

--- a/SimG4CMS/Calo/src/HGCNumberingScheme.cc
+++ b/SimG4CMS/Calo/src/HGCNumberingScheme.cc
@@ -35,7 +35,7 @@ uint32_t HGCNumberingScheme::getUnitID(ForwardSubdetector &subdet, int &layer, i
   if ((!HGCalDetId::isValid(subdet,iz,layer,sector,phiSector,icell)) ||
       (!hgcons->isValid(layer,sector,icell,false))) {
     index = 0;
-    if (check_ && icell != -2) {
+    if (check_ && icell != -1) {
       edm::LogError("HGCSim") << "[HGCNumberingScheme] ID out of bounds :"
 			      << " Subdet= " << subdet << " Zside= " << iz
 			      << " Layer= " << layer << " Sector= " << sector

--- a/SimG4CMS/Calo/src/HGCNumberingScheme.cc
+++ b/SimG4CMS/Calo/src/HGCNumberingScheme.cc
@@ -22,7 +22,7 @@ HGCNumberingScheme::~HGCNumberingScheme() {
 }
 
 //
-uint32_t HGCNumberingScheme::getUnitID(ForwardSubdetector &subdet, int &layer, int &sector, int &iz, G4ThreeVector &pos) {
+uint32_t HGCNumberingScheme::getUnitID(ForwardSubdetector &subdet, int &layer, int &sector, int &iz, const G4ThreeVector &pos) {
   
   std::pair<int,int> phicell = hgcons->assignCell(pos.x(),pos.y(),layer,0,false);
   int phiSector = phicell.first;

--- a/SimG4CMS/Calo/src/HGCNumberingScheme.cc
+++ b/SimG4CMS/Calo/src/HGCNumberingScheme.cc
@@ -22,7 +22,7 @@ HGCNumberingScheme::~HGCNumberingScheme() {
 }
 
 //
-uint32_t HGCNumberingScheme::getUnitID(ForwardSubdetector &subdet, int &layer, int &sector, int &iz, const G4ThreeVector &pos) {
+uint32_t HGCNumberingScheme::getUnitID(ForwardSubdetector subdet, int layer, int sector, int iz, const G4ThreeVector &pos) {
   
   std::pair<int,int> phicell = hgcons->assignCell(pos.x(),pos.y(),layer,0,false);
   int phiSector = phicell.first;


### PR DESCRIPTION
This includes some further protections for invalid cells set by HGCalDDDConstants, following the tests from Fedor.
It also extends the evaluation of the boundaries of the cells to mitigate further the dead zone in the active material.
@vandreev11 @bsunanda @lgray please follow this one as well
