### PR TITLE
Use conditions V2 by default

### DIFF
--- a/Configuration/AlCa/python/autoCond_condDBv2.py
+++ b/Configuration/AlCa/python/autoCond_condDBv2.py
@@ -39,16 +39,16 @@ aliases = {
 # L1 configuration used during Run2012D
 conditions_L1_Run2012D = (
     # L1 GT menu 2012 v3, used during Run2012D
-    'L1GtTriggerMenu_L1Menu_Collisions2012_v3_mc,L1GtTriggerMenuRcd,frontier://FrontierProd/CMS_COND_31X_L1T',
+    'L1GtTriggerMenu_L1Menu_Collisions2012_v3_mc,L1GtTriggerMenuRcd,frontier://FrontierProd/CMS_CONDITIONS',
     # L1 GCT configuration with 5 GeV jet seed threshold, used since Run2012C
-    'L1GctJetFinderParams_GCTPhysics_2012_04_27_JetSeedThresh5GeV_mc,L1GctJetFinderParamsRcd,frontier://FrontierProd/CMS_COND_31X_L1T',
-    'L1HfRingEtScale_GCTPhysics_2012_04_27_JetSeedThresh5GeV_mc,L1HfRingEtScaleRcd,frontier://FrontierProd/CMS_COND_31X_L1T',
-    'L1HtMissScale_GCTPhysics_2012_04_27_JetSeedThresh5GeV_mc,L1HtMissScaleRcd,frontier://FrontierProd/CMS_COND_31X_L1T',
-    'L1JetEtScale_GCTPhysics_2012_04_27_JetSeedThresh5GeV_mc,L1JetEtScaleRcd,frontier://FrontierProd/CMS_COND_31X_L1T',
+    'L1GctJetFinderParams_GCTPhysics_2012_04_27_JetSeedThresh5GeV_mc,L1GctJetFinderParamsRcd,frontier://FrontierProd/CMS_CONDITIONS',
+    'L1HfRingEtScale_GCTPhysics_2012_04_27_JetSeedThresh5GeV_mc,L1HfRingEtScaleRcd,frontier://FrontierProd/CMS_CONDITIONS',
+    'L1HtMissScale_GCTPhysics_2012_04_27_JetSeedThresh5GeV_mc,L1HtMissScaleRcd,frontier://FrontierProd/CMS_CONDITIONS',
+    'L1JetEtScale_GCTPhysics_2012_04_27_JetSeedThresh5GeV_mc,L1JetEtScaleRcd,frontier://FrontierProd/CMS_CONDITIONS',
     # L1 CSCTF configuration used since Run2012B
-    'L1MuCSCPtLut_key-11_mc,L1MuCSCPtLutRcd,frontier://FrontierProd/CMS_COND_31X_L1T',
+    'L1MuCSCPtLut_key-11_mc,L1MuCSCPtLutRcd,frontier://FrontierProd/CMS_CONDITIONS',
     # L1 DTTF settings used since Run2012C
-    'L1MuDTTFParameters_dttf12_TSC_03_csc_col_mc,L1MuDTTFParametersRcd,frontier://FrontierProd/CMS_COND_31X_L1T',
+    'L1MuDTTFParameters_dttf12_TSC_03_csc_col_mc,L1MuDTTFParametersRcd,frontier://FrontierProd/CMS_CONDITIONS',
 )
 
 autoCond['run1_mc']          = ( autoCond['run1_mc'], ) \

--- a/Configuration/Applications/python/Options.py
+++ b/Configuration/Applications/python/Options.py
@@ -34,10 +34,10 @@ parser.add_option("--conditions",
                   default=None,
                   dest="conditions")
 
-parser.add_option("--useCondDBv2",
+parser.add_option("--useCondDBv1",
                   help="use conditions DB V1",
                   action="store_false",
-                  default=True,
+                  default=False,
                   dest="useCondDBv1")
 
 parser.add_option("--eventcontent",

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -86,10 +86,6 @@
 #include <sched.h>
 #endif
 
-//FIXME: Needed for temporary workaround for checksum problem in conditions
-#include "TFile.h"
-
-
 namespace {
   //Sentry class to only send a signal if an
   // exception occurs. An exception is identified
@@ -498,12 +494,6 @@ namespace edm {
 
     // intialize miscellaneous items
     std::shared_ptr<CommonParams> common(items.initMisc(*parameterSet));
-
-    // FIXME: BEGIN temporary workaround for checksum problems in conditions
-    edm::FileInPath condfile("FWCore/Framework/data/cond_dump.root");
-    TFile* fptr = TFile::Open(condfile.fullPath().c_str());
-    fptr->Close();
-    // END temporary workaround for checksum problems in conditions
 
     // intialize the event setup provider
     esp_ = espController_->makeProvider(*parameterSet);


### PR DESCRIPTION
This pull request updates the default conditions DB to V2 by merging pull request 5541 from Andreas Pfeiffer.
It also removes the workaround for conditions DB V1 we were using because of a bug in ROOT 6 that has since been fixed.
This pull request fixes relval test failures.
Please merge as soon as convenient.
Once this is merged, file FWCore/Framework/data/cond_dump.root can be removed from the data area.
