### PR TITLE
Fix dictionary checking errors

### DIFF
--- a/FWCore/Utilities/src/DictionaryTools.cc
+++ b/FWCore/Utilities/src/DictionaryTools.cc
@@ -123,7 +123,7 @@ namespace edm {
     TClass *cl = TClass::GetClass(type.typeInfo(), true);
     if(cl == nullptr) {
       throw Exception(errors::DictionaryNotFound)
-          << "No TClass for class: '" << cl->GetName() << "'" << std::endl;
+          << "No TClass for class: '" << type.className() << "'" << std::endl;
     }
     if(!cl->HasDictionary()) {
       missingTypes().insert(type);
@@ -137,7 +137,7 @@ namespace edm {
     TClass *cl = TClass::GetClass(type.typeInfo(), true);
     if(cl == nullptr) {
       throw Exception(errors::DictionaryNotFound)
-          << "No TClass for class: '" << cl->GetName() << "'" << std::endl;
+          << "No TClass for class: '" << type.className() << "'" << std::endl;
     }
     THashTable result;
     cl->GetMissingDictionaries(result, recursive); 

--- a/IOPool/Streamer/src/ClassFiller.cc
+++ b/IOPool/Streamer/src/ClassFiller.cc
@@ -28,7 +28,7 @@ namespace edm {
     FDEBUG(1) << "Loading dictionary for " << name << "\n";
     edmplugin::PluginCapabilities::get()->load(dictionaryPlugInPrefix() + name);
     TClass* cl = TClass::GetClass(name.c_str());
-    loadType(TypeID(cl->GetTypeInfo()));
+    loadType(TypeID(*cl->GetTypeInfo()));
   }
 
   void doBuildRealData(std::string const& name) {


### PR DESCRIPTION
Fix two errors in dictionary checking that cause or affect unit test failures in the ROOT6 IB:
1) In checkClassDictionary(), if a type does not have a TClass, don't dereference the null TClass pointer in the exception message (doh!), as this segfaults.  Get the type name for the exception message from the type_info.
2) TClass->GetTypeInfo() returns a type_info pointer, not a typeinfo reference. So the pointer returned must be dereferenced in the argument to the TypeID constructor.
Please merge this rerquest as soon as convenient.
