### PR TITLE
Codes that fix the cross section computation 

### DIFF
--- a/GeneratorInterface/Core/plugins/GenFilterEfficiencyProducer.cc
+++ b/GeneratorInterface/Core/plugins/GenFilterEfficiencyProducer.cc
@@ -53,11 +53,9 @@ GenFilterEfficiencyProducer::produce(edm::Event& iEvent, const edm::EventSetup& 
   edm::Handle<edm::TriggerResults> trigR;
   iEvent.getByLabel(theTrig,trigR); 
   edm::Handle<GenEventInfoProduct>    genEventScale;
-  double weight = 1;
-  if (iEvent.getByLabel("generator", genEventScale)) 
-    weight = genEventScale->weight();
+  if (!iEvent.getByLabel("generator", genEventScale))return;
+  double weight = genEventScale->weight();
   
-
   unsigned int nSize = (*trigR).size();
   // std::cout << "Number of paths in TriggerResults = " << nSize  << std::endl;
   if ( nSize >= pathIndex ) {

--- a/GeneratorInterface/Core/plugins/GenXSecAnalyzer.cc
+++ b/GeneratorInterface/Core/plugins/GenXSecAnalyzer.cc
@@ -136,10 +136,6 @@ GenXSecAnalyzer::compute()
 	GenLumiInfoProduct::ProcessInfo proc = products_[i].getProcessInfos()[ip];	  
 	double hepxsec_value = proc.lheXSec().value();
 	double hepxsec_error = proc.lheXSec().error();
-	std::cout << "hepxsec_value = " << hepxsec_value << std::endl;
-	std::cout << "hepxsec_error = " << hepxsec_error << std::endl;
-	std::cout << "proc.killed().sum() = " << proc.killed().sum() << std::endl;
-	std::cout << "proc.selected().sum() = " << proc.selected().sum() << std::endl;
 
 	if (!proc.killed().n())
 	  continue;

--- a/GeneratorInterface/Core/plugins/GenXSecAnalyzer.cc
+++ b/GeneratorInterface/Core/plugins/GenXSecAnalyzer.cc
@@ -101,7 +101,7 @@ void
 GenXSecAnalyzer::compute()
 {
   // for pure parton shower generator
-  
+
   if(hepidwtup_== -1)
     {
       double sigSum = 0.0;
@@ -136,14 +136,17 @@ GenXSecAnalyzer::compute()
 	GenLumiInfoProduct::ProcessInfo proc = products_[i].getProcessInfos()[ip];	  
 	double hepxsec_value = proc.lheXSec().value();
 	double hepxsec_error = proc.lheXSec().error();
-
+	std::cout << "hepxsec_value = " << hepxsec_value << std::endl;
+	std::cout << "hepxsec_error = " << hepxsec_error << std::endl;
+	std::cout << "proc.killed().sum() = " << proc.killed().sum() << std::endl;
+	std::cout << "proc.selected().sum() = " << proc.selected().sum() << std::endl;
 
 	if (!proc.killed().n())
 	  continue;
 
 	double sigma2Sum, sigma2Err;
-	sigma2Sum = proc.tried().sum2() * hepxsec_value * hepxsec_value;
-	sigma2Err = proc.tried().sum2() * hepxsec_error * hepxsec_error;
+	sigma2Sum = hepxsec_value * hepxsec_value;
+	sigma2Err = hepxsec_error * hepxsec_error;
 
 	double sigmaAvg = hepxsec_value;
 
@@ -168,11 +171,6 @@ GenXSecAnalyzer::compute()
 
 	double relErr = 1.0;
 	if (proc.killed().n() > 1) {
-	  double sigmaAvg2 = sigmaAvg * sigmaAvg;
-	  double delta2Sig =
-	    fabs(sigma2Sum / proc.tried().n() - sigmaAvg2) /
-	    (proc.tried().n() * sigmaAvg2);
-
 	  double efferr2=0;
 	  switch(hepidwtup_) {
 	  case 3: case -3:
@@ -209,7 +207,7 @@ GenXSecAnalyzer::compute()
 	    }
 	  }
 	  double delta2Veto = efferr2/fracAcc/fracAcc;
-	  double delta2Sum = delta2Sig + delta2Veto
+	  double delta2Sum = delta2Veto
 	    + sigma2Err / sigma2Sum;
 	  relErr = (delta2Sum > 0.0 ?
 		    std::sqrt(delta2Sum) : 0.0);
@@ -233,8 +231,8 @@ GenXSecAnalyzer::compute()
 
 
     } // end of loop over different samples
-    double final_value = sum_denominator > 1e-6? sum_numerator/sum_denominator : 0;
-    double final_error = sum_denominator > 1e-6? 1/sqrt(sum_denominator) : -1;
+    double final_value = sum_denominator > 0? sum_numerator/sum_denominator : 0;
+    double final_error = sum_denominator > 0? 1/sqrt(sum_denominator) : -1;
     xsec_ = GenLumiInfoProduct::XSec(final_value, final_error);
   }
   return;
@@ -247,10 +245,8 @@ GenXSecAnalyzer::endJob() {
   if(products_.size()>0)
     compute();
 
-  double total_eff = totalEffStat_.filterEfficiency(hepidwtup_);
-  double total_err = totalEffStat_.filterEfficiencyError(hepidwtup_);
-  std::cout << "total_eff = " << totalEffStat_.sumPassWeights() << "/" << totalEffStat_.sumWeights() 
-	    << " = " <<  total_eff << " +- " << total_err << std::endl;
+  double filterOnly_eff = totalEffStat_.filterEfficiency(hepidwtup_);
+  double filterOnly_err = totalEffStat_.filterEfficiencyError(hepidwtup_);
   
   double jetmatching_eff_total = jetMatchEffStat_.filterEfficiency(hepidwtup_);
   double jetmatching_err_total = jetMatchEffStat_.filterEfficiencyError(hepidwtup_);
@@ -259,9 +255,6 @@ GenXSecAnalyzer::endJob() {
     jetMatchEffStat_.sumPassWeights() << "/" << 
     jetMatchEffStat_.sumWeights() << " = " 
 	    << jetmatching_eff_total << " +- " << jetmatching_err_total << std::endl;
-  double filterOnly_eff = jetmatching_eff_total > 1e-6? total_eff/jetmatching_eff_total : total_eff;
-  double filterOnly_err = total_eff>1e-6 && jetmatching_eff_total > 1e-6? 
-    filterOnly_eff*sqrt(total_err*total_err/total_eff/total_eff-jetmatching_err_total*jetmatching_err_total/jetmatching_eff_total/jetmatching_eff_total): total_err;
 
   std::cout << "Before filter: cross section = " << std::setprecision(6)  << xsec_.value() << " +- " << std::setprecision(6) << xsec_.error() <<  " pb" << std::endl;
 

--- a/GeneratorInterface/LHEInterface/src/LHERunInfo.cc
+++ b/GeneratorInterface/LHEInterface/src/LHERunInfo.cc
@@ -212,10 +212,8 @@ LHERunInfo::XSec LHERunInfo::xsec() const
 		  continue;
 
 		double sigma2Sum, sigma2Err;
-			sigma2Sum = proc->tried().sum2() * heprup.XSECUP[idx]
-			                             * heprup.XSECUP[idx];
-			sigma2Err = proc->tried().sum2() * heprup.XERRUP[idx]
-			                             * heprup.XERRUP[idx];
+		sigma2Sum = heprup.XSECUP[idx]* heprup.XSECUP[idx];
+		sigma2Err = heprup.XERRUP[idx]* heprup.XERRUP[idx];
 
 	        double sigmaAvg = heprup.XSECUP[idx];
 
@@ -240,10 +238,6 @@ LHERunInfo::XSec LHERunInfo::xsec() const
 
 		double relErr = 1.0;
 		if (proc->killed().n() > 1) {
-			double sigmaAvg2 = sigmaAvg * sigmaAvg;
-			double delta2Sig =
-			    fabs(sigma2Sum / proc->tried().n() - sigmaAvg2) /
-				(proc->tried().n() * sigmaAvg2);
 
 			double efferr2=0;
 			switch(idwtup) {
@@ -281,7 +275,7 @@ LHERunInfo::XSec LHERunInfo::xsec() const
 			  }
 			}
 			double delta2Veto = efferr2/fracAcc/fracAcc;
-			double delta2Sum = delta2Sig + delta2Veto
+			double delta2Sum = delta2Veto
 			                   + sigma2Err / sigma2Sum;
 			relErr = (delta2Sum > 0.0 ?
 					std::sqrt(delta2Sum) : 0.0);
@@ -311,6 +305,7 @@ void LHERunInfo::statistics() const
 	unsigned long nAccepted = 0;
 	unsigned long nTried = 0;
 	int idwtup = std::abs(heprup.IDWTUP);
+
 	std::cout << std::endl;
 	std::cout << "Process and cross-section statistics" << std::endl;
 	std::cout << "------------------------------------" << std::endl;
@@ -321,21 +316,18 @@ void LHERunInfo::statistics() const
 	    proc != processes.end(); ++proc) {
 	  unsigned int idx = proc->heprupIndex();
 
-		double sigmaSum, sigma2Sum, sigma2Err;
-			sigmaSum = proc->tried().sum() * heprup.XSECUP[idx];
-			sigma2Sum = proc->tried().sum2() * heprup.XSECUP[idx]
-			                             * heprup.XSECUP[idx];
-			sigma2Err = proc->tried().sum2() * heprup.XERRUP[idx]
-			                             * heprup.XERRUP[idx];
-		
-
 		if (!proc->selected().n()) {
 		  std::cout << proc->process() << "\t0\t0\tn/a\t\t\tn/a"
 			          << std::endl;
 			continue;
 		}
 
-		double sigmaAvg = sigmaSum / proc->tried().sum();
+		double sigma2Sum, sigma2Err;
+		sigma2Sum = heprup.XSECUP[idx]* heprup.XSECUP[idx];
+		sigma2Err = heprup.XERRUP[idx]* heprup.XERRUP[idx];
+
+	        double sigmaAvg = heprup.XSECUP[idx];
+
 		double fracAcc = 0;
 		double ntotal = proc->nTotalPos()-proc->nTotalNeg();
 		double npass  = proc->nPassPos() -proc->nPassNeg();
@@ -350,7 +342,6 @@ void LHERunInfo::statistics() const
 
 		if(fracAcc<1e-6)continue;
 
-
 		double fracBr = proc->accepted().sum() > 0.0 ?
 		                proc->acceptedBr().sum() / proc->accepted().sum() : 1;
 		double sigmaFin = sigmaAvg * fracAcc;
@@ -358,10 +349,6 @@ void LHERunInfo::statistics() const
 
 		double relErr = 1.0;
 		if (proc->killed().n() > 1) {
-			double sigmaAvg2 = sigmaAvg * sigmaAvg;
-			double delta2Sig =
-			    fabs(sigma2Sum / proc->tried().n() - sigmaAvg2) /
-				(proc->tried().n() * sigmaAvg2);
 			double efferr2=0;
 			switch(idwtup) {
 			case 3: case -3:
@@ -398,7 +385,7 @@ void LHERunInfo::statistics() const
 			  }
 			}
 			double delta2Veto = efferr2/fracAcc/fracAcc;
-			double delta2Sum = delta2Sig + delta2Veto
+			double delta2Sum = delta2Veto
 			                   + sigma2Err / sigma2Sum;
 			relErr = (delta2Sum > 0.0 ?
 					std::sqrt(delta2Sum) : 0.0);


### PR DESCRIPTION
1. GenFilterEfficiencyProducer 
   now only efficiency from additional filter is saved in GenFilterInfo.
   JetMatching efficiency is not saved.
2. LHERunInfo.cc
   remove the error from delta2Sig 
3. GenXSecAnalyzer.cc
   remove the error from delta2Sig, and also computes cross sections before and after additional filter 
