### PR TITLE
add JECpayload protection in PhysicsTools/PatUtils/interface/ShiftedJetProducerT.h

### DIFF
--- a/PhysicsTools/PatAlgos/test/runtests.sh
+++ b/PhysicsTools/PatAlgos/test/runtests.sh
@@ -31,7 +31,7 @@ cmsRun ${LOCAL_TEST_DIR}/patTuple_addVertexInfo_cfg.py || die 'Failure using pat
 
 # cmsRun ${LOCAL_TEST_DIR}/patTuple_userData_cfg.py || die 'Failure using patTuple_userData_cfg.py' $?
 
-#cmsRun ${LOCAL_TEST_DIR}/patTuple_metUncertainties_cfg.py || die 'Failure using patTuple_metUncertainties_cfg.py' $?
+cmsRun ${LOCAL_TEST_DIR}/patTuple_metUncertainties_cfg.py || die 'Failure using patTuple_metUncertainties_cfg.py' $?
 
 # Not needed in IBs
 # cmsRun ${LOCAL_TEST_DIR}/patTuple_onlyElectrons_cfg.py || die 'Failure using patTuple_onlyElectrons_cfg.py' $?

--- a/PhysicsTools/PatUtils/interface/ShiftedJetProducerT.h
+++ b/PhysicsTools/PatUtils/interface/ShiftedJetProducerT.h
@@ -133,7 +133,7 @@ class ShiftedJetProducerT : public edm::EDProducer
 	std::cout << "shift = " << shift << std::endl;
       }
 
-      if ( addResidualJES_ ) {
+      if ( evt.isRealData() && addResidualJES_ ) {
 	const static SmearedJetProducer_namespace::RawJetExtractorT<T> rawJetExtractor;
 	reco::Candidate::LorentzVector rawJetP4 = rawJetExtractor(*originalJet);
 	if ( rawJetP4.E() > 1.e-1 ) {


### PR DESCRIPTION
Following a request from @vadler, a protection is added in ShiftedJetProducerT.h in order to run on simulation with PhysicsTools/PatAlgos/test/patTuple_metUncertainties_cfg.py  even if residual jet corrections are missing (as in the auto:run2_mc GT configuration)
