### PR TITLE
MiniAOD: set track_ as transient in PackedPFCandidate

### DIFF
--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -166,7 +166,8 @@
    <version ClassVersion="11" checksum="1239840459"/>
   </class>
 
-  <class name="pat::PackedCandidate" ClassVersion="14">
+  <class name="pat::PackedCandidate" ClassVersion="15">
+    <version ClassVersion="15" checksum="2118306102"/>
     <version ClassVersion="14" checksum="1075333340"/>
     <version ClassVersion="13" checksum="981046949"/>
     <version ClassVersion="12" checksum="981046949"/>
@@ -188,6 +189,7 @@
     <field name="dphidphi_" transient="true" />
     <field name="detadeta_" transient="true" />
     <field name="dptdpt_" transient="true" />
+    <field name="track_" transient="true" />
   </class>
   <ioread sourceClass="pat::PackedCandidate"  version="[1-]" targetClass="pat::PackedCandidate" source="" target="unpacked_">
     <![CDATA[unpacked_ = false;


### PR DESCRIPTION
Fixing the issue reported by David on uncompressed size increase for PackedPFCandidate.
The mutable track_ should not be stored (it is anyhow compressed to negligible size being never filled, but it should not be stored)

on 100 events is now:
patPackedCandidates_packedPFCandidates__PAT. 62292.6 14063.3
to be compared with 70X numbers from david:
patPackedCandidates_packedPFCandidates__PAT. 64448.1 15698.8

@ferencek @davidlange6 @gpetruc 
