### PR TITLE
Add Updated Cross Section printout to default sequence, and update GenParticle selection for GenJets

### DIFF
--- a/Configuration/Generator/python/Pythia8CommonSettings_cfi.py
+++ b/Configuration/Generator/python/Pythia8CommonSettings_cfi.py
@@ -9,5 +9,6 @@ pythia8CommonSettingsBlock = cms.PSet(
       'ParticleDecays:limitTau0 = on',
       'ParticleDecays:tau0Max = 10',
       'ParticleDecays:allowPhotonRadiation = on',
+      'ParticleDecays:tauIgnoreSpinUpCMSSW = on',
     )
 )

--- a/GeneratorInterface/Core/interface/GenFilterEfficiencyProducer.h
+++ b/GeneratorInterface/Core/interface/GenFilterEfficiencyProducer.h
@@ -19,6 +19,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Utilities/interface/BranchType.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
 
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Framework/interface/TriggerNamesService.h"
@@ -47,6 +48,9 @@ private:
   virtual void endLuminosityBlockProduce(edm::LuminosityBlock &, const edm::EventSetup &) override;
 
   // ----------member data ---------------------------
+
+  edm::EDGetTokenT<edm::TriggerResults> triggerResultsToken_;
+  edm::EDGetTokenT<GenEventInfoProduct> genEventInfoToken_;
   
   std::string filterPath;
 

--- a/GeneratorInterface/Core/interface/GenXSecAnalyzer.h
+++ b/GeneratorInterface/Core/interface/GenXSecAnalyzer.h
@@ -13,7 +13,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Run.h"
@@ -27,7 +27,7 @@
 // class declaration
 //
 
-class GenXSecAnalyzer : public edm::EDAnalyzer {
+class GenXSecAnalyzer : public edm::one::EDAnalyzer<edm::one::WatchLuminosityBlocks> {
 
 
 public:
@@ -40,10 +40,14 @@ private:
 
   virtual void beginJob() override;
   virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+  virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
   virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
   virtual void endJob() override;
   void compute();
 
+  edm::EDGetTokenT<GenFilterInfo> genFilterInfoToken_;
+  edm::EDGetTokenT<GenLumiInfoProduct> genLumiInfoToken_;
+  
   int hepidwtup_;
   GenLumiInfoProduct::XSec xsec_;
   GenFilterInfo  jetMatchEffStat_;

--- a/GeneratorInterface/Core/plugins/GenFilterEfficiencyProducer.cc
+++ b/GeneratorInterface/Core/plugins/GenFilterEfficiencyProducer.cc
@@ -29,8 +29,11 @@ GenFilterEfficiencyProducer::GenFilterEfficiencyProducer(const edm::ParameterSet
       edm::LogError("ServiceNotAvailable") << "TriggerNamesServive not available, no filter information stored";
   }
 
+  triggerResultsToken_ = consumes<edm::TriggerResults>(edm::InputTag("TriggerResults","",thisProcess));
+  genEventInfoToken_ = consumes<GenEventInfoProduct>(edm::InputTag("generator",""));
   produces<GenFilterInfo, edm::InLumi>(); 
 
+  
 }
 
 
@@ -49,11 +52,11 @@ void
 GenFilterEfficiencyProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
 
-  edm::InputTag theTrig("TriggerResults","",thisProcess);
   edm::Handle<edm::TriggerResults> trigR;
-  iEvent.getByLabel(theTrig,trigR); 
+  iEvent.getByToken(triggerResultsToken_,trigR); 
   edm::Handle<GenEventInfoProduct>    genEventScale;
-  if (!iEvent.getByLabel("generator", genEventScale))return;
+  iEvent.getByToken(genEventInfoToken_,genEventScale);
+  if (!genEventScale.isValid()) return;
   double weight = genEventScale->weight();
   
   unsigned int nSize = (*trigR).size();

--- a/GeneratorInterface/Core/plugins/GenXSecAnalyzer.cc
+++ b/GeneratorInterface/Core/plugins/GenXSecAnalyzer.cc
@@ -247,10 +247,15 @@ GenXSecAnalyzer::endJob() {
   double jetmatching_eff_total = jetMatchEffStat_.filterEfficiency(hepidwtup_);
   double jetmatching_err_total = jetMatchEffStat_.filterEfficiencyError(hepidwtup_);
 
+  std::cout << std::endl;
+  std::cout << "------------------------------------" << std::endl;
+  std::cout << "Overall cross-section summary:" << std::endl;
+  std::cout << "------------------------------------" << std::endl;
+  
   std::cout << "jet matching efficiency = " << 
     jetMatchEffStat_.sumPassWeights() << "/" << 
     jetMatchEffStat_.sumWeights() << " = " 
-	    << jetmatching_eff_total << " +- " << jetmatching_err_total << std::endl;
+	   << std::setprecision(6) << jetmatching_eff_total << " +- " << jetmatching_err_total << std::endl;
 
   std::cout << "Before filter: cross section = " << std::setprecision(6)  << xsec_.value() << " +- " << std::setprecision(6) << xsec_.error() <<  " pb" << std::endl;
 

--- a/GeneratorInterface/Core/plugins/GenXSecAnalyzer.cc
+++ b/GeneratorInterface/Core/plugins/GenXSecAnalyzer.cc
@@ -10,6 +10,9 @@ GenXSecAnalyzer::GenXSecAnalyzer(const edm::ParameterSet& iConfig):
   totalEffStat_(0,0,0,0,0.,0.,0.,0.)
 {
   products_.clear();
+  
+  genFilterInfoToken_ = consumes<GenFilterInfo,edm::InLumi>(edm::InputTag("genFilterEfficiencyProducer",""));
+  genLumiInfoToken_ = consumes<GenLumiInfoProduct,edm::InLumi>(edm::InputTag("generator",""));
 }
 
 GenXSecAnalyzer::~GenXSecAnalyzer()
@@ -26,19 +29,23 @@ GenXSecAnalyzer::analyze(const edm::Event&, const edm::EventSetup&)
 {
 }
 
-// ------------ method called once each job just after ending the event loop  ------------
+
+void
+GenXSecAnalyzer::beginLuminosityBlock(edm::LuminosityBlock const& iLumi, edm::EventSetup const&) {
+}
 
 void
 GenXSecAnalyzer::endLuminosityBlock(edm::LuminosityBlock const& iLumi, edm::EventSetup const&) {
 
   edm::Handle<GenFilterInfo> genFilter;
-  if(iLumi.getByLabel("genFilterEfficiencyProducer", genFilter))
+  iLumi.getByToken(genFilterInfoToken_,genFilter);
+  if(genFilter.isValid())
     totalEffStat_.mergeProduct(*genFilter);
 
 
   edm::Handle<GenLumiInfoProduct> genLumiInfo;
-  bool foundLumiInfo = iLumi.getByLabel("generator",genLumiInfo);
-  if (!foundLumiInfo) return;
+  iLumi.getByToken(genLumiInfoToken_,genLumiInfo);
+  if (!genLumiInfo.isValid()) return;
   
   hepidwtup_ = genLumiInfo->getHEPIDWTUP();
 

--- a/GeneratorInterface/Core/plugins/GenXSecAnalyzer.cc
+++ b/GeneratorInterface/Core/plugins/GenXSecAnalyzer.cc
@@ -246,15 +246,15 @@ GenXSecAnalyzer::compute()
 void
 GenXSecAnalyzer::endJob() {
 
-  std::cout << std::endl;
-  std::cout << "------------------------------------" << std::endl;
-  std::cout << "GenXsecAnalyzer:" << std::endl;
-  std::cout << "------------------------------------" << std::endl;  
+  edm::LogPrint("GenXSecAnalyzer") << "\n"
+  << "------------------------------------" << "\n"
+  << "GenXsecAnalyzer:" << "\n"
+  << "------------------------------------";
   
   if(!products_.size()) {
-    std::cout << "------------------------------------" << std::endl;
-    std::cout << "Cross-section summary not available" << std::endl;
-    std::cout << "------------------------------------" << std::endl;
+    edm::LogPrint("GenXSecAnalyzer") << "------------------------------------" << "\n"
+    << "Cross-section summary not available" << "\n"
+    << "------------------------------------";
     return;
   }
   
@@ -267,31 +267,30 @@ GenXSecAnalyzer::endJob() {
   double jetmatching_eff_total = jetMatchEffStat_.filterEfficiency(hepidwtup_);
   double jetmatching_err_total = jetMatchEffStat_.filterEfficiencyError(hepidwtup_);
 
-  std::cout << "------------------------------------" << std::endl;
-  std::cout << "Overall cross-section summary:" << std::endl;
-  std::cout << "------------------------------------" << std::endl;
+  edm::LogPrint("GenXSecAnalyzer") << "------------------------------------" << "\n"
+  << "Overall cross-section summary:" << "\n"
+  << "------------------------------------";
   
-  std::cout << "jet matching efficiency = " << 
+  edm::LogPrint("GenXSecAnalyzer") << "jet matching efficiency = " << 
     jetMatchEffStat_.sumPassWeights() << "/" << 
     jetMatchEffStat_.sumWeights() << " = " 
-	   << std::setprecision(6) << jetmatching_eff_total << " +- " << jetmatching_err_total << std::endl;
+	   << std::setprecision(6) << jetmatching_eff_total << " +- " << jetmatching_err_total << "\n";
 
-  std::cout << "Before filter: cross section = " << std::setprecision(6)  << xsec_.value() << " +- " << std::setprecision(6) << xsec_.error() <<  " pb" << std::endl;
+  edm::LogPrint("GenXSecAnalyzer") << "Before filter: cross section = " << std::setprecision(6)  << xsec_.value() << " +- " << std::setprecision(6) << xsec_.error() <<  " pb";
 
-  std::cout << "Filter efficiency = " << std::setprecision(6)  
-	    << filterOnly_eff << " +- " << filterOnly_err << std::endl;
+  edm::LogPrint("GenXSecAnalyzer") << "Filter efficiency = " << std::setprecision(6)  
+	    << filterOnly_eff << " +- " << filterOnly_err;
 
 
   double xsec_after  = xsec_.value()*filterOnly_eff ;
   double error_after = xsec_after*sqrt(xsec_.error()*xsec_.error()/xsec_.value()/xsec_.value()+
 				  filterOnly_err*filterOnly_err/filterOnly_eff/filterOnly_eff);
 
-  std::cout << "After filter: cross section = " 
+  edm::LogPrint("GenXSecAnalyzer") << "After filter: cross section = " 
 	    << std::setprecision(6) << xsec_after
 	    << " +- " 
 	    << std::setprecision(6) << error_after
-	    << " pb"
-	    << std::endl;
+	    << " pb";
 
 }
 

--- a/GeneratorInterface/Core/plugins/GenXSecAnalyzer.cc
+++ b/GeneratorInterface/Core/plugins/GenXSecAnalyzer.cc
@@ -37,8 +37,9 @@ GenXSecAnalyzer::endLuminosityBlock(edm::LuminosityBlock const& iLumi, edm::Even
 
 
   edm::Handle<GenLumiInfoProduct> genLumiInfo;
-  iLumi.getByLabel("generator",genLumiInfo);
-
+  bool foundLumiInfo = iLumi.getByLabel("generator",genLumiInfo);
+  if (!foundLumiInfo) return;
+  
   hepidwtup_ = genLumiInfo->getHEPIDWTUP();
 
   std::vector<GenLumiInfoProduct::ProcessInfo> theProcesses = genLumiInfo->getProcessInfos();
@@ -238,8 +239,20 @@ GenXSecAnalyzer::compute()
 void
 GenXSecAnalyzer::endJob() {
 
-  if(products_.size()>0)
-    compute();
+  std::cout << std::endl;
+  std::cout << "------------------------------------" << std::endl;
+  std::cout << "GenXsecAnalyzer:" << std::endl;
+  std::cout << "------------------------------------" << std::endl;  
+  
+  if(!products_.size()) {
+    std::cout << "------------------------------------" << std::endl;
+    std::cout << "Cross-section summary not available" << std::endl;
+    std::cout << "------------------------------------" << std::endl;
+    return;
+  }
+  
+  
+  compute();
 
   double filterOnly_eff = totalEffStat_.filterEfficiency(hepidwtup_);
   double filterOnly_err = totalEffStat_.filterEfficiencyError(hepidwtup_);
@@ -247,7 +260,6 @@ GenXSecAnalyzer::endJob() {
   double jetmatching_eff_total = jetMatchEffStat_.filterEfficiency(hepidwtup_);
   double jetmatching_err_total = jetMatchEffStat_.filterEfficiencyError(hepidwtup_);
 
-  std::cout << std::endl;
   std::cout << "------------------------------------" << std::endl;
   std::cout << "Overall cross-section summary:" << std::endl;
   std::cout << "------------------------------------" << std::endl;

--- a/GeneratorInterface/Core/python/genFilterSummary_cff.py
+++ b/GeneratorInterface/Core/python/genFilterSummary_cff.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
 from GeneratorInterface.Core.genFilterEfficiencyProducer_cfi import *
+from GeneratorInterface.Core.genXSecAnalyzer_cfi import *
 
-genFilterSummary = cms.Sequence(genFilterEfficiencyProducer)
+genFilterSummary = cms.Sequence(genFilterEfficiencyProducer*genXSecAnalyzer)

--- a/GeneratorInterface/Core/python/genXSecAnalyzer_cfi.py
+++ b/GeneratorInterface/Core/python/genXSecAnalyzer_cfi.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+genXSecAnalyzer = cms.EDAnalyzer('GenXSecAnalyzer',
+)

--- a/GeneratorInterface/Pythia8Interface/plugins/LHAupLesHouches.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/LHAupLesHouches.cc
@@ -67,6 +67,9 @@ bool LHAupLesHouches::setEvent(int inProcId, double mRecalculate)
   
   unsigned int iscale = 0;
   for(int i = 0; i < hepeup.NUP; i++) {
+    //override spinup flag if so configured
+    double spinup = (std::abs(hepeup.IDUP[i])==15 && ignoreTauSpinUp_) ? 9. : hepeup.SPINUP[i];
+        
     //retrieve scale corresponding to each particle
     double scalein = -1.;
     
@@ -87,7 +90,7 @@ bool LHAupLesHouches::setEvent(int inProcId, double mRecalculate)
                 hepeup.PUP[i][0], hepeup.PUP[i][1],
                 hepeup.PUP[i][2], hepeup.PUP[i][3],
                 hepeup.PUP[i][4], hepeup.VTIMUP[i],
-                hepeup.SPINUP[i],scalein);
+                spinup, scalein);
   }
   
   infoPtr->eventAttributes->clear();

--- a/GeneratorInterface/Pythia8Interface/plugins/LHAupLesHouches.h
+++ b/GeneratorInterface/Pythia8Interface/plugins/LHAupLesHouches.h
@@ -21,7 +21,7 @@
 
 class LHAupLesHouches : public Pythia8::LHAup {
   public:
-    LHAupLesHouches() {;}
+    LHAupLesHouches() : ignoreTauSpinUp_(false) {;}
 
     //void loadRunInfo(const boost::shared_ptr<lhef::LHERunInfo> &runInfo)
     void loadRunInfo(lhef::LHERunInfo* runInfo)
@@ -30,12 +30,16 @@ class LHAupLesHouches : public Pythia8::LHAup {
     //void loadEvent(const boost::shared_ptr<lhef::LHEEvent> &event)
     void loadEvent(lhef::LHEEvent* event)
       { this->event = event; }
+      
+    void setIgnoreTauSpinUp(bool b) { ignoreTauSpinUp_ = b; }
 
   private:
 
     bool setInit();
     bool setEvent(int idProcIn, double mRecalculate = -1.);
 
+    bool ignoreTauSpinUp_;
+    
     //boost::shared_ptr<lhef::LHERunInfo> runInfo;
     lhef::LHERunInfo* runInfo;
     //boost::shared_ptr<lhef::LHEEvent>	event;

--- a/GeneratorInterface/Pythia8Interface/plugins/Pythia8Hadronizer.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Pythia8Hadronizer.cc
@@ -407,7 +407,10 @@ bool Pythia8Hadronizer::initializeForExternalPartons()
   } else {
 
     lhaUP.reset(new LHAupLesHouches());
+    lhaUP->setIgnoreTauSpinUp(fMasterGen->settings.flag("ParticleDecays:tauIgnoreSpinUpCMSSW"));
     lhaUP->loadRunInfo(lheRunInfo());
+
+    
     
     if ( fJetMatchingHook )
     {

--- a/GeneratorInterface/Pythia8Interface/src/Py8InterfaceBase.cc
+++ b/GeneratorInterface/Pythia8Interface/src/Py8InterfaceBase.cc
@@ -12,6 +12,8 @@ Py8InterfaceBase::Py8InterfaceBase( edm::ParameterSet const& ps )
   fMasterGen.reset(new Pythia);
   fDecayer.reset(new Pythia);
 
+  fMasterGen->settings.addFlag("ParticleDecays:tauIgnoreSpinUpCMSSW",false);
+  
   fMasterGen->readString("Next:numberShowEvent = 0");
   fDecayer->readString("Next:numberShowEvent = 0");
 

--- a/RecoJets/Configuration/python/GenJetParticles_cff.py
+++ b/RecoJets/Configuration/python/GenJetParticles_cff.py
@@ -16,7 +16,7 @@ genParticlesForJets = cms.EDProducer("InputGenJetsParticleSelector",
          9900012, 9900014, 9900016,
          39),
     partonicFinalState = cms.bool(False),
-    excludeResonances = cms.bool(True),
+    excludeResonances = cms.bool(False),
     excludeFromResonancePids = cms.vuint32(12, 13, 14, 16),
     tausAsJets = cms.bool(False)
 )

--- a/SimDataFormats/GeneratorProducts/src/classes_def.xml
+++ b/SimDataFormats/GeneratorProducts/src/classes_def.xml
@@ -140,6 +140,7 @@
 	<class name="GenLumiInfoProduct::XSec" ClassVersion="10">
 	  <version ClassVersion="10" checksum="1482608724"/> 
 	</class>
+	<class name="std::vector&lt;GenLumiInfoProduct::ProcessInfo&gt;"/>
 	<class name="GenLumiInfoProduct::ProcessInfo" ClassVersion="10">
 	  <version ClassVersion="10" checksum="621228037"/>
 	</class>


### PR DESCRIPTION
"Loose Ends" from the generator side for Run 2 MC production:

1) Add updated cross section analyzer to the default sequence so that printout in interactive running has the best estimate of the cross section in all combinations of lhe/not, matching/not, gen filter/not.

2) Change config for GenJets to no longer exclude resonance decay products, since this cannot be done in a robust and generator-agnostic way.  (Old config would lead to decay products being excluded or not depending on generator and event properties.)
