### PR TITLE
Use TClass::GetClass(), not gROOT->GetClass()

### DIFF
--- a/DataFormats/Common/src/RefCoreStreamer.cc
+++ b/DataFormats/Common/src/RefCoreStreamer.cc
@@ -2,7 +2,7 @@
 #include "DataFormats/Common/interface/RefCore.h"
 #include "DataFormats/Common/interface/RefCoreWithIndex.h"
 #include "FWCore/Utilities/interface/EDMException.h"
-#include "TROOT.h"
+#include "TClass.h"
 #include <ostream>
 #include <cassert>
 #include <iostream>
@@ -76,13 +76,13 @@ namespace edm {
 
   void setRefCoreStreamer(bool resetAll) {
     {
-      TClass *cl = gROOT->GetClass("edm::RefCore");
+      TClass *cl = TClass::GetClass("edm::RefCore");
       TClassStreamer *st = cl->GetStreamer();
       if (st == 0) {
         cl->AdoptStreamer(new RefCoreStreamer());
       }
       {
-        TClass *cl = gROOT->GetClass("edm::RefCoreWithIndex");
+        TClass *cl = TClass::GetClass("edm::RefCoreWithIndex");
         TClassStreamer *st = cl->GetStreamer();
         if (st == 0) {
           cl->AdoptStreamer(new RefCoreWithIndexStreamer());
@@ -96,14 +96,14 @@ namespace edm {
     EDProductGetter const* returnValue=0;
     if (ep != 0) {
       {
-        TClass *cl = gROOT->GetClass("edm::RefCore");
+        TClass *cl = TClass::GetClass("edm::RefCore");
         TClassStreamer *st = cl->GetStreamer();
         if (st == 0) {
           cl->AdoptStreamer(new RefCoreStreamer());
         }
       }
       {
-        TClass *cl = gROOT->GetClass("edm::RefCoreWithIndex");
+        TClass *cl = TClass::GetClass("edm::RefCoreWithIndex");
         TClassStreamer *st = cl->GetStreamer();
         if (st == 0) {
           cl->AdoptStreamer(new RefCoreWithIndexStreamer());

--- a/FWCore/FWLite/src/RefStreamer.cc
+++ b/FWCore/FWLite/src/RefStreamer.cc
@@ -1,6 +1,6 @@
 #include "DataFormats/Common/interface/RefCore.h"
 #include "DataFormats/Common/interface/RefCoreStreamer.h"
-#include "TROOT.h"
+#include "TClass.h"
 #include <cassert>
 #include <ostream>
 
@@ -9,14 +9,14 @@ class TBuffer;
 namespace fwlite {
   edm::EDProductGetter const* setRefStreamer(edm::EDProductGetter const* ep) {
     {
-      TClass* cl = gROOT->GetClass("edm::RefCore");
+      TClass* cl = TClass::GetClass("edm::RefCore");
       TClassStreamer* st = cl->GetStreamer();
       if (st == 0) {
         cl->AdoptStreamer(new edm::RefCoreStreamer());
       }
     }
     {
-      TClass* cl = gROOT->GetClass("edm::RefCoreWithIndex");
+      TClass* cl = TClass::GetClass("edm::RefCoreWithIndex");
       TClassStreamer* st = cl->GetStreamer();
       if (st == 0) {
         cl->AdoptStreamer(new edm::RefCoreWithIndexStreamer());

--- a/FWCore/RootAutoLibraryLoader/src/RootAutoLibraryLoader.cc
+++ b/FWCore/RootAutoLibraryLoader/src/RootAutoLibraryLoader.cc
@@ -357,7 +357,7 @@ namespace edm {
               className.replace(idx + 6, 1, "");
             }
             classNameAttemptingToLoad_ = className.c_str();
-            returnValue = gROOT->GetClass(className.c_str(), kTRUE);
+            returnValue = TClass::GetClass(className.c_str(), kTRUE);
             classNameAttemptingToLoad_ = classname;
             return returnValue;
          }
@@ -383,7 +383,7 @@ namespace edm {
           // It will also attempt to load the dictionary for the class
           // if the second argument is kTRUE. This is the default, so it
           // need not be explicitly specified.
-          returnValue = gROOT->GetClass(classname, kTRUE);
+          returnValue = TClass::GetClass(classname, kTRUE);
           classNameAttemptingToLoad_ = nullptr;
         }
       }

--- a/FWCore/Utilities/src/DictionaryTools.cc
+++ b/FWCore/Utilities/src/DictionaryTools.cc
@@ -226,7 +226,7 @@ namespace edm {
       for (StringSet::const_iterator it = missing.begin(), itEnd = missing.end();
          it != itEnd; ++it) {
         try {
-          gROOT->GetClass(it->c_str(), kTRUE);
+          TClass::GetClass(it->c_str(), kTRUE);
         }
         // We don't want to fail if we can't load a plug-in.
         catch(...) {}

--- a/IOPool/Common/interface/CustomStreamer.h
+++ b/IOPool/Common/interface/CustomStreamer.h
@@ -2,7 +2,7 @@
 #define IOPool_Common_CustomStreamer_h
 
 #include <string>
-#include "TROOT.h"
+#include "TClass.h"
 #include "TClassStreamer.h"
 #include "TClassRef.h"
 #include "FWCore/Utilities/interface/TypeID.h"
@@ -39,7 +39,7 @@ namespace edm {
   template <typename T>
   void
   SetCustomStreamer() {
-    TClass *cl = gROOT->GetClass(TypeID(typeid(T)).className().c_str());
+    TClass *cl = TClass::GetClass(TypeID(typeid(T)).className().c_str());
     if (cl->GetStreamer() == 0) {
       cl->AdoptStreamer(new CustomStreamer<T>());
     }
@@ -48,7 +48,7 @@ namespace edm {
   template <typename T>
   void
   SetCustomStreamer(T const&) {
-    TClass *cl = gROOT->GetClass(TypeID(typeid(T)).className().c_str());
+    TClass *cl = TClass::GetClass(TypeID(typeid(T)).className().c_str());
     if (cl->GetStreamer() == 0) {
       cl->AdoptStreamer(new CustomStreamer<T>());
     }

--- a/IOPool/Input/src/RootDelayedReader.cc
+++ b/IOPool/Input/src/RootDelayedReader.cc
@@ -11,7 +11,6 @@
 
 #include "IOPool/Common/interface/getWrapperBasePtr.h"
 
-#include "TROOT.h"
 #include "TBranch.h"
 #include "TClass.h"
 
@@ -28,7 +27,7 @@ namespace edm {
    nextReader_(),
    resourceAcquirer_(inputType == InputType::Primary ? new SharedResourcesAcquirer(SharedResourcesRegistry::instance()->createAcquirerForSourceDelayedReader()) : static_cast<SharedResourcesAcquirer*>(nullptr)),
    inputType_(inputType),
-   wrapperBaseTClass_(gROOT->GetClass("edm::WrapperBase")) {
+   wrapperBaseTClass_(TClass::GetClass("edm::WrapperBase")) {
   }
 
   RootDelayedReader::~RootDelayedReader() {
@@ -62,7 +61,7 @@ namespace edm {
     setRefCoreStreamer(ep);
     TClass* cp = branchInfo.classCache_;
     if(nullptr == cp) {
-      branchInfo.classCache_ = gROOT->GetClass(branchInfo.branchDescription_.wrappedName().c_str());
+      branchInfo.classCache_ = TClass::GetClass(branchInfo.branchDescription_.wrappedName().c_str());
       cp = branchInfo.classCache_;
       branchInfo.offsetToWrapperBase_ = cp->GetBaseClassOffset(wrapperBaseTClass_);
     }

--- a/IOPool/Input/src/RootFile.cc
+++ b/IOPool/Input/src/RootFile.cc
@@ -47,7 +47,6 @@
 #include "DataFormats/Provenance/interface/RunAux.h"
 #include "FWCore/ParameterSet/interface/ParameterSetConverter.h"
 
-#include "TROOT.h"
 #include "Rtypes.h"
 #include "TClass.h"
 #include "TString.h"
@@ -213,7 +212,7 @@ namespace edm {
       eventProductProvenanceRetrievers_(),
       parentageIDLookup_(),
       daqProvenanceHelper_(),
-      edProductClass_(gROOT->GetClass("edm::WrapperBase")) {
+      edProductClass_(TClass::GetClass("edm::WrapperBase")) {
 
     hasNewlyDroppedBranch_.fill(false);
 
@@ -1800,7 +1799,7 @@ namespace edm {
       for(ProductRegistry::ProductList::iterator it = prodList.begin(), itEnd = prodList.end(); it != itEnd;) {
         BranchDescription const& prod = it->second;
         if(prod.branchType() != InEvent) {
-          TClass* cp = gROOT->GetClass(prod.wrappedName().c_str());
+          TClass* cp = TClass::GetClass(prod.wrappedName().c_str());
           void* p = cp->New();
           int offset = cp->GetBaseClassOffset(edProductClass_);
           std::unique_ptr<WrapperBase> edp = getWrapperBasePtr(p, offset);

--- a/IOPool/Output/src/RootOutputFile.cc
+++ b/IOPool/Output/src/RootOutputFile.cc
@@ -33,7 +33,6 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "IOPool/Common/interface/getWrapperBasePtr.h"
 
-#include "TROOT.h"
 #include "TTree.h"
 #include "TFile.h"
 #include "TClass.h"
@@ -98,7 +97,7 @@ namespace edm {
       processHistoryRegistry_(),
       parentageIDs_(),
       branchesWithStoredHistory_(),
-      wrapperBaseTClass_(gROOT->GetClass("edm::WrapperBase")) {
+      wrapperBaseTClass_(TClass::GetClass("edm::WrapperBase")) {
 #if ROOT_VERSION_CODE >= ROOT_VERSION(5,30,0)
     if (om_->compressionAlgorithm() == std::string("ZLIB")) {
       filePtr_->SetCompressionAlgorithm(ROOT::kZLIB);
@@ -717,7 +716,7 @@ namespace edm {
         if(product == nullptr) {
           // No product with this ID is in the event.
           // Add a null product.
-          TClass* cp = gROOT->GetClass(item.branchDescription_->wrappedName().c_str());
+          TClass* cp = TClass::GetClass(item.branchDescription_->wrappedName().c_str());
           int offset = cp->GetBaseClassOffset(wrapperBaseTClass_);
           void* p = cp->New();
           std::unique_ptr<WrapperBase> dummy = getWrapperBasePtr(p, offset);


### PR DESCRIPTION
This is a trivial technical change.  It is being requested for standardization, and for  code commonality with the ROOT6 7_3_X branch, as these changes have already been made there.
gROOT->GetClass(...) is obsolete.  It just calls TClass::GetClass(...). Instead, calling TClass::GetClass() directly is recommended by the ROOT team, and it saves a function call.
