### PR TITLE
Attempt to fix dictionary for edm::AssociationVector

### DIFF
--- a/DataFormats/FWLite/test/make_associationvector_file_cfg.py
+++ b/DataFormats/FWLite/test/make_associationvector_file_cfg.py
@@ -1,0 +1,19 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.source = cms.Source("EmptySource")
+
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(10))
+
+process.vsimple = cms.EDProducer("VSimpleProducer",
+    size = cms.int32(7)
+)
+
+process.tester = cms.EDProducer("AVSimpleProducer", src = cms.InputTag("vsimple"))
+
+process.options = cms.untracked.PSet( allowUnscheduled = cms.untracked.bool(True) )
+
+process.out = cms.OutputModule("PoolOutputModule", fileName = cms.untracked.string("avtester.root"))
+
+process.o = cms.EndPath(process.out)

--- a/DataFormats/FWLite/test/pyroot_read_associationvector.py
+++ b/DataFormats/FWLite/test/pyroot_read_associationvector.py
@@ -1,0 +1,24 @@
+#! /usr/bin/env python
+
+import ROOT
+import sys
+from DataFormats.FWLite import Events, Handle
+events = Events (['avtester.root'])
+
+handle  = Handle ("edm::AssociationVector<edm::RefProd<std::vector<edmtest::Simple> >,std::vector<edmtest::Simple>,edm::Ref<std::vector<edmtest::Simple>,edmtest::Simple,edm::refhelper::FindUsingAdvance<std::vector<edmtest::Simple>,edmtest::Simple> >,unsigned int,edm::helper::AssociationIdenticalKeyReference>")
+
+label = ("tester","","TEST")
+
+
+# loop over events
+count= 0
+for event in events:
+    #print "###################### ", count
+    event.getByLabel (label, handle)
+    cont = handle.product()
+    values = [ cont.value(i).value for i in xrange(len(cont))]
+    for i,v in enumerate(handle.product()):
+      #print v.second.value, values[i]
+      if v.second.value != values[i]:
+        raise RuntimeError("Values do not match for event index:{0}  from data:{1} from ref:{2}".format(count, v.second.value,values[i]))
+    count+=1 

--- a/DataFormats/FWLite/test/run_all_t.sh
+++ b/DataFormats/FWLite/test/run_all_t.sh
@@ -21,3 +21,10 @@ root -b -n -q ${LOCAL_TEST_DIR}/triggerResultsByName_multi_cint.C || die 'Failed
 
 ${LOCAL_TEST_DIR}/VIPTest.sh || die 'Failed to create file' $?
 root -b -n -q ${LOCAL_TEST_DIR}/vector_int_cint.C || die 'Failed in vector_int_cint.C' $?
+
+#NOTE: ROOT has a bug which keeps the AssociationVector from running its ioread rule and therefore it never clears its cache
+#test AssociationVector reading
+#rm -f ${LOCAL_TEST_DIR}/avtester.root
+#rm -f avtester.root
+#cmsRun ${LOCAL_TEST_DIR}/make_associationvector_file_cfg.py  || die "cmsRun make_associationvector_file_cfg.py " $?
+#python ${LOCAL_TEST_DIR}/pyroot_read_associationvector.py || die 'Failed in pyroot_read_associationvector.py'

--- a/DataFormats/TestObjects/src/classes.h
+++ b/DataFormats/TestObjects/src/classes.h
@@ -43,6 +43,9 @@ struct dictionary {
   edm::Wrapper<edmtest::ThingWithMerge> dummy104;
   edm::Wrapper<edmtest::ThingWithIsEqual> dummy103;
 
+  edmtest::AVSimpleProduct dummyAVSimpleProduct;
+  edmtest::AVSimpleProduct::value_type dummyAVSimpleProductValueType;
+  
   edmtest::ThingCollection dummy1;
   edmtest::OtherThingCollection dummy2;
   edm::Wrapper<edmtest::ThingCollection> dummy3;

--- a/DataFormats/TestObjects/src/classes_def.xml
+++ b/DataFormats/TestObjects/src/classes_def.xml
@@ -41,9 +41,7 @@
  <class name="edm::OwnVector<edmtest::SimpleDerived, edm::ClonePolicy<edmtest::SimpleDerived> >"/>
  <class name="std::vector<edmtest::Simple>"/>
  <class name="edm::Wrapper<std::vector<edmtest::Simple> >"/>
- <class name="std::vector<edmtest::Simple*>"/>
  <class name="std::vector<edmtest::SimpleDerived>"/>
- <class name="std::vector<edmtest::SimpleDerived*>"/>
  <class name="edm::RefProd<std::vector<edmtest::Simple> >"/>
  <class name="edm::DetSet<edmtest::Sortable>"/>
  <class name="std::vector<edm::DetSet<edmtest::Sortable> >"/>
@@ -53,9 +51,14 @@
  <class name="std::vector<edmtest::Unsortable>"/>
  <class name="edm::DetSetVector<edmtest::Sortable>"/>
  <class name="edm::DetSetVector<edmtest::Unsortable>"/>
- <class pattern="class edm::AssociationVector<edm::RefProd<std::vector<edmtest::Simple> >,std::vector<edmtest::Simple>,edm::Ref<std::vector<edmtest::Simple>,edmtest::Simple,edm::refhelper::FindUsingAdvance<std::vector<edmtest::Simple>,edmtest::Simple> >,unsigned int>">
+ <class name="edm::AssociationVector<edm::RefProd<std::vector<edmtest::Simple> >,std::vector<edmtest::Simple>,edm::Ref<std::vector<edmtest::Simple>,edmtest::Simple,edm::refhelper::FindUsingAdvance<std::vector<edmtest::Simple>,edmtest::Simple> >,unsigned int,edm::helper::AssociationIdenticalKeyReference>">
    <field name="transientVector_" transient="true"/>
  </class>
+ <class name="std::pair<edm::Ref<std::vector<edmtest::Simple>,edmtest::Simple,edm::refhelper::FindUsingAdvance<std::vector<edmtest::Simple>,edmtest::Simple> >,edmtest::Simple>"/>
+ <ioread sourceClass = "edm::AssociationVector<edm::RefProd<std::vector<edmtest::Simple> >,std::vector<edmtest::Simple>,edm::Ref<std::vector<edmtest::Simple>,edmtest::Simple,edm::refhelper::FindUsingAdvance<std::vector<edmtest::Simple>,edmtest::Simple> >,unsigned int,edm::helper::AssociationIdenticalKeyReference>" version="[1-]" targetClass = "edm::AssociationVector<edm::RefProd<std::vector<edmtest::Simple> >,std::vector<edmtest::Simple>,edm::Ref<std::vector<edmtest::Simple>,edmtest::Simple,edm::refhelper::FindUsingAdvance<std::vector<edmtest::Simple>,edmtest::Simple> >,unsigned int,edm::helper::AssociationIdenticalKeyReference>" source = "" target="transientVector_">
+   <![CDATA[delete transientVector_; transientVector_=nullptr;
+   ]]>
+ </ioread>
  <class name="edm::Wrapper<edmtest::DummyProduct>"/>
  <class name="edm::Wrapper<edmtest::IntProduct>"/>
  <class name="edm::Wrapper<edmtest::TransientIntProduct>" persistent="false"/>
@@ -66,9 +69,7 @@
  <class name="edm::Wrapper<edm::SortedCollection<edmtest::Simple, edm::StrictWeakOrdering<edmtest::Simple> > >"/>
  <class name="edm::Wrapper<edm::OwnVector<edmtest::Simple, edm::ClonePolicy<edmtest::Simple> > >"/>
  <class name="edm::Wrapper<edm::OwnVector<edmtest::SimpleDerived, edm::ClonePolicy<edmtest::SimpleDerived> > >"/>
-<!--
- <class name="edm::Wrapper<edm::AssociationVector<edm::RefProd<std::vector<edmtest::Simple> >, std::vector<edmtest::Simple> > >"/>
--->
+ <class name="edm::Wrapper<edm::AssociationVector<edm::RefProd<std::vector<edmtest::Simple> >,std::vector<edmtest::Simple>,edm::Ref<std::vector<edmtest::Simple>,edmtest::Simple,edm::refhelper::FindUsingAdvance<std::vector<edmtest::Simple>,edmtest::Simple> >,unsigned int,edm::helper::AssociationIdenticalKeyReference> >"/>
  <class name="edm::Wrapper<edm::DetSetVector<edmtest::Sortable> >"/>
  <class name="edm::Wrapper<edm::DetSetVector<edmtest::Unsortable> >"/>
 

--- a/FWCore/Framework/src/PrincipalGetAdapter.cc
+++ b/FWCore/Framework/src/PrincipalGetAdapter.cc
@@ -221,10 +221,10 @@ namespace edm {
       throw edm::Exception(edm::errors::InsertFailure)
 	<< "Illegal attempt to 'put' an unregistered product.\n"
 	<< "No product is registered for\n"
-	<< "  process name:                '" << md_.processName() << "'\n"
-	<< "  module label:                '" << md_.moduleLabel() << "'\n"
 	<< "  product friendly class name: '" << type.friendlyClassName() << "'\n"
+  << "  module label:                '" << md_.moduleLabel() << "'\n"
 	<< "  product instance name:       '" << productInstanceName << "'\n"
+  << "  process name:                '" << md_.processName() << "'\n"
 
 	<< "The ProductRegistry contains:\n"
 	<< principal_.productRegistry()

--- a/FWCore/Framework/test/stubs/ToyModules.cc
+++ b/FWCore/Framework/test/stubs/ToyModules.cc
@@ -11,7 +11,7 @@ Toy EDProducers and EDProducts for testing purposes only.
 #include "DataFormats/Common/interface/View.h"
 #include "DataFormats/TestObjects/interface/ToyProducts.h"
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -33,7 +33,7 @@ namespace edmtest {
   //
   // Produces and SCSimpleProduct product instance.
   //
-  class SCSimpleProducer : public edm::EDProducer {
+  class SCSimpleProducer : public edm::stream::EDProducer<> {
   public:
     explicit SCSimpleProducer(edm::ParameterSet const& p) :
       size_(p.getParameter<int>("size")) {
@@ -47,7 +47,7 @@ namespace edmtest {
     }
 
     virtual ~SCSimpleProducer() {}
-    virtual void produce(edm::Event& e, edm::EventSetup const& c);
+    virtual void produce(edm::Event& e, edm::EventSetup const& c) override;
 
   private:
     int size_;  // number of Simples to put in the collection
@@ -79,7 +79,7 @@ namespace edmtest {
   //
   // Produces and OVSimpleProduct product instance.
   //
-  class OVSimpleProducer : public edm::EDProducer {
+  class OVSimpleProducer : public edm::stream::EDProducer<> {
   public:
     explicit OVSimpleProducer(edm::ParameterSet const& p) :
         size_(p.getParameter<int>("size")) {
@@ -95,7 +95,7 @@ namespace edmtest {
     }
 
     virtual ~OVSimpleProducer() {}
-    virtual void produce(edm::Event& e, edm::EventSetup const& c);
+    virtual void produce(edm::Event& e, edm::EventSetup const& c) override;
 
   private:
     int size_;  // number of Simples to put in the collection
@@ -136,7 +136,7 @@ namespace edmtest {
   //
   // Produces and OVSimpleProduct product instance.
   //
-  class VSimpleProducer : public edm::EDProducer {
+  class VSimpleProducer : public edm::stream::EDProducer<> {
   public:
     explicit VSimpleProducer(edm::ParameterSet const& p) :
         size_(p.getParameter<int>("size")) {
@@ -150,7 +150,7 @@ namespace edmtest {
     }
 
     virtual ~VSimpleProducer() {}
-    virtual void produce(edm::Event& e, edm::EventSetup const& c);
+    virtual void produce(edm::Event& e, edm::EventSetup const& c) override;
 
   private:
     int size_;  // number of Simples to put in the collection
@@ -165,7 +165,7 @@ namespace edmtest {
     for(int i = 0; i < size_; ++i) {
         Simple simple;
         simple.key = size_ - i;
-        simple.value = 1.5 * i;
+        simple.value = 1.5 * i + e.id().event();
         p->push_back(simple);
     }
 
@@ -178,7 +178,7 @@ namespace edmtest {
   // Produces AssociationVector<vector<Simple>, vector<Simple> > object
   // This is used to test a View of an AssociationVector
   //
-  class AVSimpleProducer : public edm::EDProducer {
+  class AVSimpleProducer : public edm::stream::EDProducer<> {
   public:
 
     explicit AVSimpleProducer(edm::ParameterSet const& p) :
@@ -187,8 +187,7 @@ namespace edmtest {
       consumes<std::vector<edmtest::Simple>>(src_);
     }
 
-    virtual ~AVSimpleProducer() {}
-    virtual void produce(edm::Event& e, edm::EventSetup const& c);
+    virtual void produce(edm::Event& e, edm::EventSetup const& c) override;
 
   private:
     edm::InputTag src_;
@@ -205,6 +204,7 @@ namespace edmtest {
     for(unsigned int i = 0; i < vs->size(); ++i) {
         edmtest::Simple simple;
         simple.key = 100 + i;  // just some arbitrary number for testing
+        simple.value = .1 * e.id().event();
         p->setValue(i, simple);
     }
 
@@ -218,7 +218,7 @@ namespace edmtest {
   //    DSVSimpleProduct
   //    DSVWeirdProduct
   //
-  class DSVProducer : public edm::EDProducer {
+  class DSVProducer : public edm::stream::EDProducer<> {
   public:
 
     explicit DSVProducer(edm::ParameterSet const& p) :
@@ -236,7 +236,7 @@ namespace edmtest {
 
     virtual ~DSVProducer() {}
 
-    virtual void produce(edm::Event& e, edm::EventSetup const&);
+    virtual void produce(edm::Event& e, edm::EventSetup const&) override;
 
   private:
     template<typename PROD> void make_a_product(edm::Event& e);
@@ -288,7 +288,7 @@ namespace edmtest {
   //    DSTVSimpleProduct
   //    DSTVSimpleDerivedProduct
   //
-  class DSTVProducer : public edm::EDProducer {
+  class DSTVProducer : public edm::stream::EDProducer<> {
   public:
 
     explicit DSTVProducer(edm::ParameterSet const& p) :
@@ -306,7 +306,7 @@ namespace edmtest {
 
     virtual ~DSTVProducer() {}
 
-    virtual void produce(edm::Event& e, edm::EventSetup const&);
+    virtual void produce(edm::Event& e, edm::EventSetup const&) override;
 
   private:
     template<typename PROD> void make_a_product(edm::Event& e);
@@ -363,7 +363,7 @@ namespace edmtest {
   //
   // Produces an Prodigal instance.
   //
-  class ProdigalProducer : public edm::EDProducer {
+  class ProdigalProducer : public edm::stream::EDProducer<> {
   public:
     explicit ProdigalProducer(edm::ParameterSet const& p) :
       label_(p.getParameter<std::string>("label")) {
@@ -371,7 +371,7 @@ namespace edmtest {
       consumes<IntProduct>(edm::InputTag{label_});
     }
     virtual ~ProdigalProducer() {}
-    virtual void produce(edm::Event& e, edm::EventSetup const& c);
+    virtual void produce(edm::Event& e, edm::EventSetup const& c) override;
 
   private:
     std::string label_;

--- a/FWCore/Integration/test/ViewAnalyzer.cc
+++ b/FWCore/Integration/test/ViewAnalyzer.cc
@@ -39,6 +39,8 @@ namespace edmtest
     consumes<edm::View<SCSimpleProduct::value_type>>(edm::InputTag{"simple"});
     consumes<OVSimpleProduct>(edm::InputTag{"ovsimple"});
     consumes<edm::View<OVSimpleProduct::value_type>>(edm::InputTag{"ovsimple"});
+    consumes<AVSimpleProduct>(edm::InputTag{"avsimple"});
+    consumes<edm::View<AVSimpleProduct>::value_type>(edm::InputTag{"avsimple"});
     consumes<edmtest::DSVSimpleProduct>(edm::InputTag{"dsvsimple"});
     consumes<edm::View<edmtest::DSVSimpleProduct::value_type>>(edm::InputTag{"dsvsimple"});
 
@@ -85,7 +87,7 @@ namespace edmtest
     tester<OVSimpleProduct>::call(this, e, "ovsimple");
 
     // This is commented out because it causes a missing dictionary failure
-    //tester<AVSimpleProduct>::call(this, e, "avsimple");
+    tester<AVSimpleProduct>::call(this, e, "avsimple");
 
 
     testDSVProduct(e, "dsvsimple");

--- a/FWCore/Integration/test/ViewTest_cfg.py
+++ b/FWCore/Integration/test/ViewTest_cfg.py
@@ -64,12 +64,15 @@ process.vsimple = cms.EDProducer("VSimpleProducer",
     size = cms.int32(7)
 )
 
+process.avsimple = cms.EDProducer("AVSimpleProducer",
+                                  src = cms.InputTag("vsimple"))
+
 process.testview = cms.EDAnalyzer("ViewAnalyzer")
 
 process.p = cms.Path(process.simple +
                      process.vsimple +
                      process.ovsimple +
-                     # avsimple +
+                     process.avsimple +
                      process.dsvsimple +
                      process.intvec +
                      process.intlist +


### PR DESCRIPTION
Andrea Rizzi reported a problem reading edm::AssociationVectors from pyroot. The problem was a cache internal to edm::AssociationVector was not getting cleared on each event. An ioread rule was added for the class, however it appears there is a bug in ROOT which prevents this rule from being used.

This pull request sets up unit tests for edm::AssociationVector to prove it works properly in the full framework. There is also a commented out test for reading in pyroot which can be used to test any fixes in ROOT for the problem.
