### PR TITLE
Backport of Cross Section machinery and GenJet config change to 71x

### DIFF
--- a/GeneratorInterface/Configuration/python/GeneratorInterface_EventContent_cff.py
+++ b/GeneratorInterface/Configuration/python/GeneratorInterface_EventContent_cff.py
@@ -15,6 +15,7 @@ GeneratorInterfaceRAW = cms.PSet(
         'keep LHERunInfoProduct_*_*_*',
         'keep LHEEventProduct_*_*_*',
         'keep GenRunInfoProduct_generator_*_*',
+        'keep GenLumiInfoProduct_generator_*_*',
         'keep GenEventInfoProduct_generator_*_*',
         'keep edmHepMCProduct_generator_*_*',
         'keep GenFilterInfo_*_*_*',
@@ -28,6 +29,7 @@ GeneratorInterfaceRECO = cms.PSet(
         'keep LHERunInfoProduct_*_*_*',
         'keep LHEEventProduct_*_*_*',
         'keep GenRunInfoProduct_generator_*_*',
+        'keep GenLumiInfoProduct_generator_*_*',
         'keep GenEventInfoProduct_generator_*_*',
         'keep edmHepMCProduct_generator_*_*',
         'keep GenFilterInfo_*_*_*',
@@ -41,6 +43,7 @@ GeneratorInterfaceAOD = cms.PSet(
         'keep LHERunInfoProduct_*_*_*',
         'keep LHEEventProduct_*_*_*',
         'keep GenRunInfoProduct_generator_*_*',
+        'keep GenLumiInfoProduct_generator_*_*',
         'keep GenEventInfoProduct_generator_*_*',
         'keep GenFilterInfo_*_*_*',
         'keep *_genParticles_*_*'

--- a/GeneratorInterface/Core/interface/GenFilterEfficiencyProducer.h
+++ b/GeneratorInterface/Core/interface/GenFilterEfficiencyProducer.h
@@ -19,6 +19,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Utilities/interface/BranchType.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
 
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Framework/interface/TriggerNamesService.h"
@@ -47,6 +48,9 @@ private:
   virtual void endLuminosityBlockProduce(edm::LuminosityBlock &, const edm::EventSetup &) override;
 
   // ----------member data ---------------------------
+
+  edm::EDGetTokenT<edm::TriggerResults> triggerResultsToken_;
+  edm::EDGetTokenT<GenEventInfoProduct> genEventInfoToken_;
   
   std::string filterPath;
 

--- a/GeneratorInterface/Core/interface/GenFilterEfficiencyProducer.h
+++ b/GeneratorInterface/Core/interface/GenFilterEfficiencyProducer.h
@@ -26,6 +26,7 @@
 #include "DataFormats/Common/interface/TriggerResults.h"
 
 #include "SimDataFormats/GeneratorProducts/interface/GenFilterInfo.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
 
 //
 // class declaration
@@ -54,8 +55,14 @@ private:
   std::string thisProcess;
   unsigned int pathIndex;
 
-  int numEventsTotal;
-  int numEventsPassed;
+  unsigned int numEventsPassPos_;
+  unsigned int numEventsPassNeg_;
+  unsigned int numEventsTotalPos_;
+  unsigned int numEventsTotalNeg_;
+  double sumpass_w_;
+  double sumpass_w2_;
+  double sumtotal_w_;
+  double sumtotal_w2_;
 
 };
 

--- a/GeneratorInterface/Core/interface/GenXSecAnalyzer.h
+++ b/GeneratorInterface/Core/interface/GenXSecAnalyzer.h
@@ -1,7 +1,6 @@
-#ifndef GENFILTEREFFICIENCYANALYZER_H
-#define GENFILTEREFFICIENCYANALYZER_H
+#ifndef GENXSECANALYZER_H
+#define GENXSECANALYZER_H
 
-// F. Cossutti
 // $Revision://
 
 // analyzer of a summary information product on filter efficiency for a user specified path
@@ -10,6 +9,7 @@
 
 // system include files
 #include <memory>
+#include <vector>
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
@@ -18,31 +18,38 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Utilities/interface/InputTag.h"
-
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenLumiInfoProduct.h"
 #include "SimDataFormats/GeneratorProducts/interface/GenFilterInfo.h"
 //
 // class declaration
 //
 
-class GenFilterEfficiencyAnalyzer : public edm::EDAnalyzer {
+class GenXSecAnalyzer : public edm::EDAnalyzer {
+
+
 public:
-  explicit GenFilterEfficiencyAnalyzer(const edm::ParameterSet&);
-  ~GenFilterEfficiencyAnalyzer();
-  
+  explicit GenXSecAnalyzer(const edm::ParameterSet&);
+  ~GenXSecAnalyzer();
+  const double final_xsec_value() const {return xsec_.value();}
+  const double final_xsec_error() const {return xsec_.error();}
   
 private:
+
+  virtual void beginJob() override;
   virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
   virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
   virtual void endJob() override;
+  void compute();
 
-  edm::InputTag genFilterInfoTag_;
-  GenFilterInfo totalGenFilterInfo_;
-
+  int hepidwtup_;
+  GenLumiInfoProduct::XSec xsec_;
+  GenFilterInfo  jetMatchEffStat_;
+  GenFilterInfo  totalEffStat_;     // statistics from total filter
   // ----------member data ---------------------------
-  
+  std::vector<GenLumiInfoProduct> products_; // the size depends on the number of MC with different LHE information
 };
 
 #endif

--- a/GeneratorInterface/Core/interface/GenXSecAnalyzer.h
+++ b/GeneratorInterface/Core/interface/GenXSecAnalyzer.h
@@ -13,7 +13,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Run.h"
@@ -27,7 +27,7 @@
 // class declaration
 //
 
-class GenXSecAnalyzer : public edm::EDAnalyzer {
+class GenXSecAnalyzer : public edm::one::EDAnalyzer<edm::one::WatchLuminosityBlocks> {
 
 
 public:
@@ -40,10 +40,14 @@ private:
 
   virtual void beginJob() override;
   virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+  virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
   virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
   virtual void endJob() override;
   void compute();
 
+  edm::EDGetTokenT<GenFilterInfo> genFilterInfoToken_;
+  edm::EDGetTokenT<GenLumiInfoProduct> genLumiInfoToken_;
+  
   int hepidwtup_;
   GenLumiInfoProduct::XSec xsec_;
   GenFilterInfo  jetMatchEffStat_;

--- a/GeneratorInterface/Core/interface/GeneratorFilter.h
+++ b/GeneratorInterface/Core/interface/GeneratorFilter.h
@@ -30,11 +30,13 @@
 //#include "GeneratorInterface/LHEInterface/interface/LHEEvent.h"
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 #include "SimDataFormats/GeneratorProducts/interface/GenRunInfoProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenLumiInfoProduct.h"
 #include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
 
 namespace edm
 {
   template <class HAD, class DEC> class GeneratorFilter : public one::EDFilter<EndRunProducer,
+									       EndLuminosityBlockProducer,
                                                                                one::WatchLuminosityBlocks,
                                                                                one::SharedResources>
   {
@@ -52,11 +54,13 @@ namespace edm
     virtual void endRunProduce(Run &, EventSetup const&) override;
     virtual void beginLuminosityBlock(LuminosityBlock const&, EventSetup const&) override;
     virtual void endLuminosityBlock(LuminosityBlock const&, EventSetup const&) override;
+    virtual void endLuminosityBlockProduce(LuminosityBlock &, EventSetup const&) override;
 
   private:
     Hadronizer            hadronizer_;
     //gen::ExternalDecayDriver* decayer_;
     Decayer*              decayer_;
+    unsigned int          nEventsInLumiBlock_;
   };
 
   //------------------------------------------------------------------------
@@ -67,7 +71,8 @@ namespace edm
   GeneratorFilter<HAD,DEC>::GeneratorFilter(ParameterSet const& ps) :
     EDFilter(),
     hadronizer_(ps),
-    decayer_(0)
+    decayer_(0),
+    nEventsInLumiBlock_(0)
   {
     // TODO:
     // Put the list of types produced by the filters here.
@@ -102,6 +107,7 @@ namespace edm
 
     produces<edm::HepMCProduct>();
     produces<GenEventInfoProduct>();
+    produces<GenLumiInfoProduct, edm::InLumi>();
     produces<GenRunInfoProduct, edm::InRun>();
  
   }
@@ -185,7 +191,7 @@ namespace edm
     std::auto_ptr<HepMCProduct> bare_product(new HepMCProduct());
     bare_product->addHepMCData( event.release() );
     ev.put(bare_product);
-    
+    nEventsInLumiBlock_ ++;
     return true;
   }
 
@@ -210,6 +216,7 @@ namespace edm
   void
   GeneratorFilter<HAD, DEC>::beginLuminosityBlock( LuminosityBlock const& lumi, EventSetup const& es )
   {
+    nEventsInLumiBlock_ = 0;
     RandomEngineSentry<HAD> randomEngineSentry(&hadronizer_, lumi.index());
     RandomEngineSentry<DEC> randomEngineSentryDecay(decayer_, lumi.index());
 
@@ -244,6 +251,39 @@ namespace edm
   void
   GeneratorFilter<HAD, DEC>::endLuminosityBlock(LuminosityBlock const&, EventSetup const&)
   {}
+
+  template <class HAD, class DEC>
+  void
+  GeneratorFilter<HAD,DEC>::endLuminosityBlockProduce(LuminosityBlock & lumi, EventSetup const&)
+  {
+    hadronizer_.statistics();    
+    if ( decayer_ ) decayer_->statistics();
+
+    GenRunInfoProduct genRunInfo = GenRunInfoProduct(hadronizer_.getGenRunInfo());
+    std::vector<GenLumiInfoProduct::ProcessInfo> GenLumiProcess;
+    GenRunInfoProduct::XSec xsec = genRunInfo.internalXSec();
+    GenLumiInfoProduct::ProcessInfo temp;      
+    temp.setProcess(0);
+    temp.setLheXSec(xsec.value(), xsec.error()); // Pythia gives error of -1
+    temp.setNPassPos(nEventsInLumiBlock_);
+    temp.setNPassNeg(0);
+    temp.setNTotalPos(nEventsInLumiBlock_);
+    temp.setNTotalNeg(0);
+    temp.setTried(nEventsInLumiBlock_, nEventsInLumiBlock_, nEventsInLumiBlock_);
+    temp.setSelected(nEventsInLumiBlock_, nEventsInLumiBlock_, nEventsInLumiBlock_);
+    temp.setKilled(nEventsInLumiBlock_, nEventsInLumiBlock_, nEventsInLumiBlock_);
+    temp.setAccepted(0,-1,-1);
+    temp.setAcceptedBr(0,-1,-1);
+    GenLumiProcess.push_back(temp);
+
+    std::auto_ptr<GenLumiInfoProduct> genLumiInfo(new GenLumiInfoProduct());
+    genLumiInfo->setHEPIDWTUP(-1);
+    genLumiInfo->setProcessInfo( GenLumiProcess );
+    lumi.put(genLumiInfo);
+
+    nEventsInLumiBlock_ = 0;
+
+  }
 }
 
 #endif // gen_GeneratorFilter_h

--- a/GeneratorInterface/Core/interface/HadronizerFilter.h
+++ b/GeneratorInterface/Core/interface/HadronizerFilter.h
@@ -41,11 +41,14 @@
 
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 #include "SimDataFormats/GeneratorProducts/interface/GenRunInfoProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenLumiInfoProduct.h"
 #include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
+
 
 namespace edm
 {
   template <class HAD, class DEC> class HadronizerFilter : public one::EDFilter<EndRunProducer,
+										EndLuminosityBlockProducer,
                                                                                 one::WatchRuns,
                                                                                 one::WatchLuminosityBlocks,
                                                                                 one::SharedResources>
@@ -66,6 +69,7 @@ namespace edm
     virtual void endRunProduce(Run &, EventSetup const&) override;
     virtual void beginLuminosityBlock(LuminosityBlock const&, EventSetup const&) override;
     virtual void endLuminosityBlock(LuminosityBlock const&, EventSetup const&) override;
+    virtual void endLuminosityBlockProduce(LuminosityBlock &, EventSetup const&) override;
 
   private:
     Hadronizer hadronizer_;
@@ -132,6 +136,7 @@ namespace edm
 
     produces<edm::HepMCProduct>();
     produces<GenEventInfoProduct>();
+    produces<GenLumiInfoProduct, edm::InLumi>();
     produces<GenRunInfoProduct, edm::InRun>();
   }
 
@@ -155,6 +160,7 @@ namespace edm
       ev.getByLabel("source", product);
     else
       ev.getByLabel("externalLHEProducer", product);
+
 
     lhef::LHEEvent *lheEvent =
 		new lhef::LHEEvent(hadronizer_.getLHERunInfo(), *product);
@@ -232,6 +238,9 @@ namespace edm
     edm::Handle<LHERunInfoProduct> lheRunInfoProduct;
     run.getByLabel(runInfoProductTag_, lheRunInfoProduct);
     hadronizer_.setLHERunInfo( new lhef::LHERunInfo(*lheRunInfoProduct) );
+    lhef::LHERunInfo* lheRunInfo = hadronizer_.getLHERunInfo().get();
+    lheRunInfo->initLumi();
+
   }
 
   template <class HAD, class DEC>
@@ -249,7 +258,7 @@ namespace edm
     lhef::LHERunInfo::XSec xsec = lheRunInfo->xsec();
 
     GenRunInfoProduct& genRunInfo = hadronizer_.getGenRunInfo();
-    genRunInfo.setInternalXSec( GenRunInfoProduct::XSec(xsec.value, xsec.error) );
+    genRunInfo.setInternalXSec( GenRunInfoProduct::XSec(xsec.value(), xsec.error()) );
 
     // If relevant, record the integrated luminosity for this run
     // here.  To do so, we would need a standard function to invoke on
@@ -268,6 +277,9 @@ namespace edm
   void
   HadronizerFilter<HAD,DEC>::beginLuminosityBlock(LuminosityBlock const& lumi, EventSetup const& es)
   {
+    lhef::LHERunInfo* lheRunInfo = hadronizer_.getLHERunInfo().get();
+    lheRunInfo->initLumi();
+
     RandomEngineSentry<HAD> randomEngineSentry(&hadronizer_, lumi.index());
     RandomEngineSentry<DEC> randomEngineSentryDecay(decayer_, lumi.index());
 
@@ -302,6 +314,42 @@ namespace edm
   void
   HadronizerFilter<HAD,DEC>::endLuminosityBlock(LuminosityBlock const&, EventSetup const&)
   {}
+
+  template <class HAD, class DEC>
+  void
+  HadronizerFilter<HAD,DEC>::endLuminosityBlockProduce(LuminosityBlock & lumi, EventSetup const&)
+  {
+    const lhef::LHERunInfo* lheRunInfo = hadronizer_.getLHERunInfo().get();
+
+
+    std::vector<lhef::LHERunInfo::Process> LHELumiProcess = lheRunInfo->getLumiProcesses();
+    std::vector<GenLumiInfoProduct::ProcessInfo> GenLumiProcess;
+    for(unsigned int i=0; i < LHELumiProcess.size(); i++){
+      lhef::LHERunInfo::Process thisProcess=LHELumiProcess[i];
+
+      GenLumiInfoProduct::ProcessInfo temp;      
+      temp.setProcess(thisProcess.process());
+      temp.setLheXSec(thisProcess.getLHEXSec().value(),thisProcess.getLHEXSec().error());
+      temp.setNPassPos(thisProcess.nPassPos());
+      temp.setNPassNeg(thisProcess.nPassNeg());
+      temp.setNTotalPos(thisProcess.nTotalPos());
+      temp.setNTotalNeg(thisProcess.nTotalNeg());
+      temp.setTried(thisProcess.tried().n(), thisProcess.tried().sum(), thisProcess.tried().sum2());
+      temp.setSelected(thisProcess.selected().n(), thisProcess.selected().sum(), thisProcess.selected().sum2());
+      temp.setKilled(thisProcess.killed().n(), thisProcess.killed().sum(), thisProcess.killed().sum2());
+      temp.setAccepted(thisProcess.accepted().n(), thisProcess.accepted().sum(), thisProcess.accepted().sum2());
+      temp.setAcceptedBr(thisProcess.acceptedBr().n(), thisProcess.acceptedBr().sum(), thisProcess.acceptedBr().sum2());
+      GenLumiProcess.push_back(temp);
+    }
+    std::auto_ptr<GenLumiInfoProduct> genLumiInfo(new GenLumiInfoProduct());
+    genLumiInfo->setHEPIDWTUP(lheRunInfo->getHEPRUP()->IDWTUP);
+    genLumiInfo->setProcessInfo( GenLumiProcess );
+    lumi.put(genLumiInfo);
+
+
+  }
+
+
 }
 
 #endif // gen_HadronizerFilter_h

--- a/GeneratorInterface/Core/plugins/GenFilterEfficiencyAnalyzer.cc
+++ b/GeneratorInterface/Core/plugins/GenFilterEfficiencyAnalyzer.cc
@@ -2,8 +2,8 @@
 #include <iostream>
 
 GenFilterEfficiencyAnalyzer::GenFilterEfficiencyAnalyzer(const edm::ParameterSet& pset):
-  nTota_(0),nPass_(0),
-  genFilterInfoTag_(pset.getParameter<edm::InputTag>("genFilterInfoTag"))
+  genFilterInfoTag_(pset.getParameter<edm::InputTag>("genFilterInfoTag")),
+  totalGenFilterInfo_(0,0,0,0,0.,0.,0.,0.)
 {
 }
 
@@ -25,19 +25,19 @@ GenFilterEfficiencyAnalyzer::endLuminosityBlock(edm::LuminosityBlock const& iLum
   iLumi.getByLabel(genFilterInfoTag_, genFilter);
 
   std::cout << "Lumi section " << iLumi.id() << std::endl;
-  nTota_ += genFilter->numEventsTried();
-  nPass_ += genFilter->numEventsPassed();
-  std::cout << "N total = " << genFilter->numEventsTried() << " N passed = " << genFilter->numEventsPassed() << std::endl;
-  std::cout << "Generator filter efficiency = " << genFilter->filterEfficiency() << " +- " << genFilter->filterEfficiencyError() << std::endl;
+
+  std::cout << "N total = " << genFilter->sumWeights() << " N passed = " << genFilter->sumPassWeights() << " N failed = " << genFilter->sumFailWeights() << std::endl;
+  std::cout << "Generator filter efficiency = " << genFilter->filterEfficiency(-1) << " +- " << genFilter->filterEfficiencyError(-1) << std::endl;
+  totalGenFilterInfo_.mergeProduct(*genFilter);
   
 }
 
 void
 GenFilterEfficiencyAnalyzer::endJob() {
 
-  double eff = ( nTota_ > 0 ? (double)nPass_/(double)nTota_ : 1. ) ;
-  double err = ( nTota_ > 0 ? std::sqrt((double)nPass_*(1.-(double)nPass_/(double)nTota_))/(double)nTota_ : 1. ); 
-  std::cout << "Total events = " << nTota_ << " Passed events = " << nPass_ << std::endl;
-  std::cout << "Filter efficiency = " << eff << " +- " << err << std::endl;
+  std::cout << "Total events = " << totalGenFilterInfo_.sumWeights()
+	    << " Passed events = " << totalGenFilterInfo_.sumPassWeights() << std::endl;
+  std::cout << "Filter efficiency = " << totalGenFilterInfo_.filterEfficiency(-1)  
+	    << " +- " << totalGenFilterInfo_.filterEfficiencyError(-1)  << std::endl;
 
 }

--- a/GeneratorInterface/Core/plugins/GenFilterEfficiencyProducer.cc
+++ b/GeneratorInterface/Core/plugins/GenFilterEfficiencyProducer.cc
@@ -29,8 +29,11 @@ GenFilterEfficiencyProducer::GenFilterEfficiencyProducer(const edm::ParameterSet
       edm::LogError("ServiceNotAvailable") << "TriggerNamesServive not available, no filter information stored";
   }
 
+  triggerResultsToken_ = consumes<edm::TriggerResults>(edm::InputTag("TriggerResults","",thisProcess));
+  genEventInfoToken_ = consumes<GenEventInfoProduct>(edm::InputTag("generator",""));
   produces<GenFilterInfo, edm::InLumi>(); 
 
+  
 }
 
 
@@ -49,11 +52,11 @@ void
 GenFilterEfficiencyProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
 
-  edm::InputTag theTrig("TriggerResults","",thisProcess);
   edm::Handle<edm::TriggerResults> trigR;
-  iEvent.getByLabel(theTrig,trigR); 
+  iEvent.getByToken(triggerResultsToken_,trigR); 
   edm::Handle<GenEventInfoProduct>    genEventScale;
-  if (!iEvent.getByLabel("generator", genEventScale))return;
+  iEvent.getByToken(genEventInfoToken_,genEventScale);
+  if (!genEventScale.isValid()) return;
   double weight = genEventScale->weight();
   
   unsigned int nSize = (*trigR).size();

--- a/GeneratorInterface/Core/plugins/GenFilterEfficiencyProducer.cc
+++ b/GeneratorInterface/Core/plugins/GenFilterEfficiencyProducer.cc
@@ -53,11 +53,9 @@ GenFilterEfficiencyProducer::produce(edm::Event& iEvent, const edm::EventSetup& 
   edm::Handle<edm::TriggerResults> trigR;
   iEvent.getByLabel(theTrig,trigR); 
   edm::Handle<GenEventInfoProduct>    genEventScale;
-  double weight = 1;
-  if (iEvent.getByLabel("generator", genEventScale)) 
-    weight = genEventScale->weight();
+  if (!iEvent.getByLabel("generator", genEventScale))return;
+  double weight = genEventScale->weight();
   
-
   unsigned int nSize = (*trigR).size();
   // std::cout << "Number of paths in TriggerResults = " << nSize  << std::endl;
   if ( nSize >= pathIndex ) {

--- a/GeneratorInterface/Core/plugins/GenFilterEfficiencyProducer.cc
+++ b/GeneratorInterface/Core/plugins/GenFilterEfficiencyProducer.cc
@@ -1,12 +1,18 @@
 #include "GeneratorInterface/Core/interface/GenFilterEfficiencyProducer.h"
-
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 GenFilterEfficiencyProducer::GenFilterEfficiencyProducer(const edm::ParameterSet& iConfig) :
   filterPath(iConfig.getParameter<std::string>("filterPath")),
   tns_(),
   thisProcess(),pathIndex(100000),
-  numEventsTotal(0),numEventsPassed(0)
+  numEventsPassPos_(0),
+  numEventsPassNeg_(0),
+  numEventsTotalPos_(0),
+  numEventsTotalNeg_(0),
+  sumpass_w_(0.),
+  sumpass_w2_(0.),
+  sumtotal_w_(0.),
+  sumtotal_w2_(0.)
 {
    //now do what ever initialization is needed
   if (edm::Service<edm::service::TriggerNamesService>().isAvailable()) {
@@ -46,21 +52,64 @@ GenFilterEfficiencyProducer::produce(edm::Event& iEvent, const edm::EventSetup& 
   edm::InputTag theTrig("TriggerResults","",thisProcess);
   edm::Handle<edm::TriggerResults> trigR;
   iEvent.getByLabel(theTrig,trigR); 
- 
+  edm::Handle<GenEventInfoProduct>    genEventScale;
+  double weight = 1;
+  if (iEvent.getByLabel("generator", genEventScale)) 
+    weight = genEventScale->weight();
+  
+
   unsigned int nSize = (*trigR).size();
   // std::cout << "Number of paths in TriggerResults = " << nSize  << std::endl;
   if ( nSize >= pathIndex ) {
-    if ( trigR->wasrun(pathIndex) ) { numEventsTotal++; }
-    if ( trigR->accept(pathIndex) ) { numEventsPassed++; }
+
+    if (!trigR->wasrun(pathIndex))return;
+    if ( trigR->accept(pathIndex) ) { 
+      sumpass_w_ += weight;
+      sumpass_w2_+= weight*weight;
+      
+      sumtotal_w_ += weight;
+      sumtotal_w2_+= weight*weight;
+
+      if(weight > 0)
+	{
+	  numEventsPassPos_++;
+	  numEventsTotalPos_++;
+	}
+      else
+	{
+	  numEventsPassNeg_++;
+	  numEventsTotalNeg_++;
+	}
+
+    }
+    else // if fail the filter
+      {
+	sumtotal_w_ += weight;
+	sumtotal_w2_+= weight*weight;
+
+	if(weight > 0)
+	  numEventsTotalPos_++;
+	else
+	  numEventsTotalNeg_++;
+      }
     //    std::cout << "Total events = " << numEventsTotal << " passed = " << numEventsPassed << std::endl;
+
   }
+  
 }
 
 void
 GenFilterEfficiencyProducer::beginLuminosityBlock(edm::LuminosityBlock const&, const edm::EventSetup&) {
 
-  numEventsTotal = 0;
-  numEventsPassed = 0;  
+  numEventsPassPos_=0;
+  numEventsPassNeg_=0;
+  numEventsTotalPos_=0;
+  numEventsTotalNeg_=0;
+  sumpass_w_=0;
+  sumpass_w2_=0;
+  sumtotal_w_=0;
+  sumtotal_w2_=0;
+ 
 }
 void
 GenFilterEfficiencyProducer::endLuminosityBlock(edm::LuminosityBlock const& iLumi, const edm::EventSetup&) {
@@ -69,6 +118,15 @@ GenFilterEfficiencyProducer::endLuminosityBlock(edm::LuminosityBlock const& iLum
 void
 GenFilterEfficiencyProducer::endLuminosityBlockProduce(edm::LuminosityBlock & iLumi, const edm::EventSetup&) {
 
-  std::auto_ptr<GenFilterInfo> thisProduct(new GenFilterInfo(numEventsTotal,numEventsPassed));
+  std::auto_ptr<GenFilterInfo> thisProduct(new GenFilterInfo(
+							     numEventsPassPos_,
+							     numEventsPassNeg_,
+							     numEventsTotalPos_,
+							     numEventsTotalNeg_,
+							     sumpass_w_,
+							     sumpass_w2_,
+							     sumtotal_w_,
+							     sumtotal_w2_
+							     ));
   iLumi.put(thisProduct);
 }

--- a/GeneratorInterface/Core/plugins/GenXSecAnalyzer.cc
+++ b/GeneratorInterface/Core/plugins/GenXSecAnalyzer.cc
@@ -247,10 +247,15 @@ GenXSecAnalyzer::endJob() {
   double jetmatching_eff_total = jetMatchEffStat_.filterEfficiency(hepidwtup_);
   double jetmatching_err_total = jetMatchEffStat_.filterEfficiencyError(hepidwtup_);
 
+  std::cout << std::endl;
+  std::cout << "------------------------------------" << std::endl;
+  std::cout << "Overall cross-section summary:" << std::endl;
+  std::cout << "------------------------------------" << std::endl;
+  
   std::cout << "jet matching efficiency = " << 
     jetMatchEffStat_.sumPassWeights() << "/" << 
     jetMatchEffStat_.sumWeights() << " = " 
-	    << jetmatching_eff_total << " +- " << jetmatching_err_total << std::endl;
+	   << std::setprecision(6) << jetmatching_eff_total << " +- " << jetmatching_err_total << std::endl;
 
   std::cout << "Before filter: cross section = " << std::setprecision(6)  << xsec_.value() << " +- " << std::setprecision(6) << xsec_.error() <<  " pb" << std::endl;
 

--- a/GeneratorInterface/Core/plugins/GenXSecAnalyzer.cc
+++ b/GeneratorInterface/Core/plugins/GenXSecAnalyzer.cc
@@ -10,6 +10,9 @@ GenXSecAnalyzer::GenXSecAnalyzer(const edm::ParameterSet& iConfig):
   totalEffStat_(0,0,0,0,0.,0.,0.,0.)
 {
   products_.clear();
+  
+  genFilterInfoToken_ = consumes<GenFilterInfo,edm::InLumi>(edm::InputTag("genFilterEfficiencyProducer",""));
+  genLumiInfoToken_ = consumes<GenLumiInfoProduct,edm::InLumi>(edm::InputTag("generator",""));
 }
 
 GenXSecAnalyzer::~GenXSecAnalyzer()
@@ -26,19 +29,23 @@ GenXSecAnalyzer::analyze(const edm::Event&, const edm::EventSetup&)
 {
 }
 
-// ------------ method called once each job just after ending the event loop  ------------
+
+void
+GenXSecAnalyzer::beginLuminosityBlock(edm::LuminosityBlock const& iLumi, edm::EventSetup const&) {
+}
 
 void
 GenXSecAnalyzer::endLuminosityBlock(edm::LuminosityBlock const& iLumi, edm::EventSetup const&) {
 
   edm::Handle<GenFilterInfo> genFilter;
-  if(iLumi.getByLabel("genFilterEfficiencyProducer", genFilter))
+  iLumi.getByToken(genFilterInfoToken_,genFilter);
+  if(genFilter.isValid())
     totalEffStat_.mergeProduct(*genFilter);
 
 
   edm::Handle<GenLumiInfoProduct> genLumiInfo;
-  bool foundLumiInfo = iLumi.getByLabel("generator",genLumiInfo);
-  if (!foundLumiInfo) return;
+  iLumi.getByToken(genLumiInfoToken_,genLumiInfo);
+  if (!genLumiInfo.isValid()) return;
   
   hepidwtup_ = genLumiInfo->getHEPIDWTUP();
 

--- a/GeneratorInterface/Core/plugins/GenXSecAnalyzer.cc
+++ b/GeneratorInterface/Core/plugins/GenXSecAnalyzer.cc
@@ -246,15 +246,15 @@ GenXSecAnalyzer::compute()
 void
 GenXSecAnalyzer::endJob() {
 
-  std::cout << std::endl;
-  std::cout << "------------------------------------" << std::endl;
-  std::cout << "GenXsecAnalyzer:" << std::endl;
-  std::cout << "------------------------------------" << std::endl;  
+  edm::LogPrint("GenXSecAnalyzer") << "\n"
+  << "------------------------------------" << "\n"
+  << "GenXsecAnalyzer:" << "\n"
+  << "------------------------------------";
   
   if(!products_.size()) {
-    std::cout << "------------------------------------" << std::endl;
-    std::cout << "Cross-section summary not available" << std::endl;
-    std::cout << "------------------------------------" << std::endl;
+    edm::LogPrint("GenXSecAnalyzer") << "------------------------------------" << "\n"
+    << "Cross-section summary not available" << "\n"
+    << "------------------------------------";
     return;
   }
   
@@ -267,31 +267,30 @@ GenXSecAnalyzer::endJob() {
   double jetmatching_eff_total = jetMatchEffStat_.filterEfficiency(hepidwtup_);
   double jetmatching_err_total = jetMatchEffStat_.filterEfficiencyError(hepidwtup_);
 
-  std::cout << "------------------------------------" << std::endl;
-  std::cout << "Overall cross-section summary:" << std::endl;
-  std::cout << "------------------------------------" << std::endl;
+  edm::LogPrint("GenXSecAnalyzer") << "------------------------------------" << "\n"
+  << "Overall cross-section summary:" << "\n"
+  << "------------------------------------";
   
-  std::cout << "jet matching efficiency = " << 
+  edm::LogPrint("GenXSecAnalyzer") << "jet matching efficiency = " << 
     jetMatchEffStat_.sumPassWeights() << "/" << 
     jetMatchEffStat_.sumWeights() << " = " 
-	   << std::setprecision(6) << jetmatching_eff_total << " +- " << jetmatching_err_total << std::endl;
+	   << std::setprecision(6) << jetmatching_eff_total << " +- " << jetmatching_err_total << "\n";
 
-  std::cout << "Before filter: cross section = " << std::setprecision(6)  << xsec_.value() << " +- " << std::setprecision(6) << xsec_.error() <<  " pb" << std::endl;
+  edm::LogPrint("GenXSecAnalyzer") << "Before filter: cross section = " << std::setprecision(6)  << xsec_.value() << " +- " << std::setprecision(6) << xsec_.error() <<  " pb";
 
-  std::cout << "Filter efficiency = " << std::setprecision(6)  
-	    << filterOnly_eff << " +- " << filterOnly_err << std::endl;
+  edm::LogPrint("GenXSecAnalyzer") << "Filter efficiency = " << std::setprecision(6)  
+	    << filterOnly_eff << " +- " << filterOnly_err;
 
 
   double xsec_after  = xsec_.value()*filterOnly_eff ;
   double error_after = xsec_after*sqrt(xsec_.error()*xsec_.error()/xsec_.value()/xsec_.value()+
 				  filterOnly_err*filterOnly_err/filterOnly_eff/filterOnly_eff);
 
-  std::cout << "After filter: cross section = " 
+  edm::LogPrint("GenXSecAnalyzer") << "After filter: cross section = " 
 	    << std::setprecision(6) << xsec_after
 	    << " +- " 
 	    << std::setprecision(6) << error_after
-	    << " pb"
-	    << std::endl;
+	    << " pb";
 
 }
 

--- a/GeneratorInterface/Core/plugins/GenXSecAnalyzer.cc
+++ b/GeneratorInterface/Core/plugins/GenXSecAnalyzer.cc
@@ -37,8 +37,9 @@ GenXSecAnalyzer::endLuminosityBlock(edm::LuminosityBlock const& iLumi, edm::Even
 
 
   edm::Handle<GenLumiInfoProduct> genLumiInfo;
-  iLumi.getByLabel("generator",genLumiInfo);
-
+  bool foundLumiInfo = iLumi.getByLabel("generator",genLumiInfo);
+  if (!foundLumiInfo) return;
+  
   hepidwtup_ = genLumiInfo->getHEPIDWTUP();
 
   std::vector<GenLumiInfoProduct::ProcessInfo> theProcesses = genLumiInfo->getProcessInfos();
@@ -238,8 +239,20 @@ GenXSecAnalyzer::compute()
 void
 GenXSecAnalyzer::endJob() {
 
-  if(products_.size()>0)
-    compute();
+  std::cout << std::endl;
+  std::cout << "------------------------------------" << std::endl;
+  std::cout << "GenXsecAnalyzer:" << std::endl;
+  std::cout << "------------------------------------" << std::endl;  
+  
+  if(!products_.size()) {
+    std::cout << "------------------------------------" << std::endl;
+    std::cout << "Cross-section summary not available" << std::endl;
+    std::cout << "------------------------------------" << std::endl;
+    return;
+  }
+  
+  
+  compute();
 
   double filterOnly_eff = totalEffStat_.filterEfficiency(hepidwtup_);
   double filterOnly_err = totalEffStat_.filterEfficiencyError(hepidwtup_);
@@ -247,7 +260,6 @@ GenXSecAnalyzer::endJob() {
   double jetmatching_eff_total = jetMatchEffStat_.filterEfficiency(hepidwtup_);
   double jetmatching_err_total = jetMatchEffStat_.filterEfficiencyError(hepidwtup_);
 
-  std::cout << std::endl;
   std::cout << "------------------------------------" << std::endl;
   std::cout << "Overall cross-section summary:" << std::endl;
   std::cout << "------------------------------------" << std::endl;

--- a/GeneratorInterface/Core/plugins/GenXSecAnalyzer.cc
+++ b/GeneratorInterface/Core/plugins/GenXSecAnalyzer.cc
@@ -1,0 +1,284 @@
+#include "GeneratorInterface/Core/interface/GenXSecAnalyzer.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include <iostream>
+#include <iomanip>
+
+GenXSecAnalyzer::GenXSecAnalyzer(const edm::ParameterSet& iConfig):
+  hepidwtup_(-1),
+  xsec_(0,0),
+  jetMatchEffStat_(0,0,0,0,0.,0.,0.,0.),
+  totalEffStat_(0,0,0,0,0.,0.,0.,0.)
+{
+  products_.clear();
+}
+
+GenXSecAnalyzer::~GenXSecAnalyzer()
+{
+}
+
+void
+GenXSecAnalyzer::beginJob() {
+  products_.clear();  
+}
+
+void
+GenXSecAnalyzer::analyze(const edm::Event&, const edm::EventSetup&)
+{
+}
+
+// ------------ method called once each job just after ending the event loop  ------------
+
+void
+GenXSecAnalyzer::endLuminosityBlock(edm::LuminosityBlock const& iLumi, edm::EventSetup const&) {
+
+  edm::Handle<GenFilterInfo> genFilter;
+  if(iLumi.getByLabel("genFilterEfficiencyProducer", genFilter))
+    totalEffStat_.mergeProduct(*genFilter);
+
+
+  edm::Handle<GenLumiInfoProduct> genLumiInfo;
+  iLumi.getByLabel("generator",genLumiInfo);
+
+  hepidwtup_ = genLumiInfo->getHEPIDWTUP();
+
+  std::vector<GenLumiInfoProduct::ProcessInfo> theProcesses = genLumiInfo->getProcessInfos();
+  unsigned int theProcesses_size = theProcesses.size();
+  // if it's a pure parton-shower generator, check there should be only one element in thisProcessInfos
+  // the error of lheXSec is -1
+  if(hepidwtup_== -1)
+    {
+      if(theProcesses_size!=1){
+	edm::LogError("GenXSecAnalyzer::endLuminosityBlock") << "Pure parton shower has thisProcessInfos size!=1";
+	return;
+      }
+      if(theProcesses[0].lheXSec().value()<1e-6){
+	edm::LogError("GenXSecAnalyzer::endLuminosityBlock") << "cross section value = "  << theProcesses[0].lheXSec().value();
+	return;
+      }
+    }
+
+  // doing generic summing 
+  for(unsigned int ip=0; ip < theProcesses_size; ip++)
+    {
+      GenLumiInfoProduct::FinalStat temp_killed   = theProcesses[ip].killed();
+      GenLumiInfoProduct::FinalStat temp_selected = theProcesses[ip].selected();
+      double passw  = temp_killed.sum();
+      double passw2 = temp_killed.sum2();
+      double totalw  = temp_selected.sum();
+      double totalw2 = temp_selected.sum2();
+      jetMatchEffStat_.mergeProduct(GenFilterInfo(
+						  theProcesses[ip].nPassPos(),
+						  theProcesses[ip].nPassNeg(),
+						  theProcesses[ip].nTotalPos(),
+						  theProcesses[ip].nTotalNeg(),
+						  passw,
+						  passw2,
+						  totalw,
+						  totalw2)
+				    );
+
+    }
+  // now determine if this LuminosityBlock has the same lheXSec as existing products
+  bool sameMC = false;
+  for(unsigned int i=0; i < products_.size(); i++){
+
+    if(products_[i].mergeProduct(*genLumiInfo))
+      sameMC = true;
+    else if(!products_[i].samePhysics(*genLumiInfo))
+      {
+	edm::LogError("GenXSecAnalyzer::endLuminosityBlock") << "Merging samples that come from different physics processes";
+	return;
+      }
+
+  }
+  
+  if(!sameMC)
+      products_.push_back(*genLumiInfo);
+  return;
+}
+
+void 
+GenXSecAnalyzer::compute()
+{
+  // for pure parton shower generator
+  
+  if(hepidwtup_== -1)
+    {
+      double sigSum = 0.0;
+      double totalN = 0.0;
+      for(unsigned int i=0; i < products_.size(); i++){
+
+	GenLumiInfoProduct::ProcessInfo proc = products_[i].getProcessInfos()[0];	  
+	double hepxsec_value = proc.lheXSec().value();
+
+	sigSum += proc.tried().sum() * hepxsec_value;
+	totalN += proc.tried().sum();
+      }
+      double sigAve = totalN>1e-6? sigSum/totalN: 0;
+      xsec_ = GenLumiInfoProduct::XSec(sigAve,-1);      
+    }
+  // for ME+parton shower MC
+  else{
+
+    double sum_numerator = 0;
+    double sum_denominator = 0;
+  
+    for(unsigned int i=0; i < products_.size(); i++){
+
+      double sigSelSum = 0.0;
+      double sigSum = 0.0;
+      double sigBrSum = 0.0;
+      double err2Sum = 0.0;
+      double errBr2Sum = 0.0;
+
+      unsigned int vectorSize = products_[i].getProcessInfos().size();
+      for(unsigned int ip=0; ip < vectorSize; ip++){
+	GenLumiInfoProduct::ProcessInfo proc = products_[i].getProcessInfos()[ip];	  
+	double hepxsec_value = proc.lheXSec().value();
+	double hepxsec_error = proc.lheXSec().error();
+
+
+	if (!proc.killed().n())
+	  continue;
+
+	double sigma2Sum, sigma2Err;
+	sigma2Sum = proc.tried().sum2() * hepxsec_value * hepxsec_value;
+	sigma2Err = proc.tried().sum2() * hepxsec_error * hepxsec_error;
+
+	double sigmaAvg = hepxsec_value;
+
+	double fracAcc = 0;
+	double ntotal = proc.nTotalPos()-proc.nTotalNeg();
+	double npass  = proc.nPassPos() -proc.nPassNeg();
+	switch(hepidwtup_){
+	case 3: case -3:
+	  fracAcc = ntotal > 1e-6? npass/ntotal: -1;
+	    break;
+	default:
+	  fracAcc = proc.selected().sum() > 1e-6? proc.killed().sum() / proc.selected().sum():-1;
+	  break;
+	}
+
+	if(fracAcc<1e-6)continue;
+
+	double fracBr = proc.accepted().sum() > 0.0 ?
+	  proc.acceptedBr().sum() / proc.accepted().sum() : 1;
+	double sigmaFin = sigmaAvg * fracAcc * fracBr;
+	double sigmaFinBr = sigmaFin * fracBr;
+
+	double relErr = 1.0;
+	if (proc.killed().n() > 1) {
+	  double sigmaAvg2 = sigmaAvg * sigmaAvg;
+	  double delta2Sig =
+	    fabs(sigma2Sum / proc.tried().n() - sigmaAvg2) /
+	    (proc.tried().n() * sigmaAvg2);
+
+	  double efferr2=0;
+	  switch(hepidwtup_) {
+	  case 3: case -3:
+	    {
+	      double ntotal_pos = proc.nTotalPos();
+	      double effp  = ntotal_pos > 1e-6?
+		(double)proc.nPassPos()/ntotal_pos:0;
+	      double effp_err2 = ntotal_pos > 1e-6?
+		(1-effp)*effp/ntotal_pos: 0;
+
+	      double ntotal_neg = proc.nTotalNeg();
+	      double effn  = ntotal_neg > 1e-6?
+		(double)proc.nPassNeg()/ntotal_neg:0;
+	      double effn_err2 = ntotal_neg > 1e-6?
+		(1-effn)*effn/ntotal_neg: 0;
+
+	      efferr2 = ntotal > 0 ? 
+		(ntotal_pos*ntotal_pos*effp_err2 +
+		 ntotal_neg*ntotal_neg*effn_err2)/ntotal/ntotal:0;
+	      break;
+	    }
+	  default:
+	    {
+	      double denominator = pow(proc.selected().sum(),4);
+	      double passw       = proc.killed().sum();
+	      double passw2      = proc.killed().sum2();
+	      double failw       = proc.selected().sum() - passw;
+	      double failw2      = proc.selected().sum2() - passw2;
+	      double numerator   = (passw2*failw*failw + failw2*passw*passw); 
+			    
+	      efferr2 = denominator>1e-6?
+		numerator/denominator:0;
+	      break;
+	    }
+	  }
+	  double delta2Veto = efferr2/fracAcc/fracAcc;
+	  double delta2Sum = delta2Sig + delta2Veto
+	    + sigma2Err / sigma2Sum;
+	  relErr = (delta2Sum > 0.0 ?
+		    std::sqrt(delta2Sum) : 0.0);
+	}
+	double deltaFin = sigmaFin * relErr;
+	double deltaFinBr = sigmaFinBr * relErr;
+
+	sigSelSum += sigmaAvg;
+	sigSum += sigmaFin;
+	sigBrSum += sigmaFinBr;
+	err2Sum += deltaFin * deltaFin;
+	errBr2Sum += deltaFinBr * deltaFinBr;
+
+
+
+      } // end of loop over different processes
+      
+      double dN = std::sqrt(errBr2Sum);
+      sum_denominator  +=  (dN> 1e-6)? 1/dN/dN: 0;
+      sum_numerator    +=  (dN> 1e-6)? sigBrSum/dN/dN: 0;
+
+
+    } // end of loop over different samples
+    double final_value = sum_denominator > 1e-6? sum_numerator/sum_denominator : 0;
+    double final_error = sum_denominator > 1e-6? 1/sqrt(sum_denominator) : -1;
+    xsec_ = GenLumiInfoProduct::XSec(final_value, final_error);
+  }
+  return;
+}
+
+
+void
+GenXSecAnalyzer::endJob() {
+
+  if(products_.size()>0)
+    compute();
+
+  double total_eff = totalEffStat_.filterEfficiency(hepidwtup_);
+  double total_err = totalEffStat_.filterEfficiencyError(hepidwtup_);
+  std::cout << "total_eff = " << totalEffStat_.sumPassWeights() << "/" << totalEffStat_.sumWeights() 
+	    << " = " <<  total_eff << " +- " << total_err << std::endl;
+  
+  double jetmatching_eff_total = jetMatchEffStat_.filterEfficiency(hepidwtup_);
+  double jetmatching_err_total = jetMatchEffStat_.filterEfficiencyError(hepidwtup_);
+
+  std::cout << "jet matching efficiency = " << 
+    jetMatchEffStat_.sumPassWeights() << "/" << 
+    jetMatchEffStat_.sumWeights() << " = " 
+	    << jetmatching_eff_total << " +- " << jetmatching_err_total << std::endl;
+  double filterOnly_eff = jetmatching_eff_total > 1e-6? total_eff/jetmatching_eff_total : total_eff;
+  double filterOnly_err = total_eff>1e-6 && jetmatching_eff_total > 1e-6? 
+    filterOnly_eff*sqrt(total_err*total_err/total_eff/total_eff-jetmatching_err_total*jetmatching_err_total/jetmatching_eff_total/jetmatching_eff_total): total_err;
+
+  std::cout << "Before filter: cross section = " << std::setprecision(6)  << xsec_.value() << " +- " << std::setprecision(6) << xsec_.error() <<  " pb" << std::endl;
+
+  std::cout << "Filter efficiency = " << std::setprecision(6)  
+	    << filterOnly_eff << " +- " << filterOnly_err << std::endl;
+
+
+  double xsec_after  = xsec_.value()*filterOnly_eff ;
+  double error_after = xsec_after*sqrt(xsec_.error()*xsec_.error()/xsec_.value()/xsec_.value()+
+				  filterOnly_err*filterOnly_err/filterOnly_eff/filterOnly_eff);
+
+  std::cout << "After filter: cross section = " 
+	    << std::setprecision(6) << xsec_after
+	    << " +- " 
+	    << std::setprecision(6) << error_after
+	    << " pb"
+	    << std::endl;
+
+}
+

--- a/GeneratorInterface/Core/plugins/module.cc
+++ b/GeneratorInterface/Core/plugins/module.cc
@@ -5,3 +5,7 @@ DEFINE_FWK_MODULE(GenFilterEfficiencyProducer);
 
 #include "GeneratorInterface/Core/interface/GenFilterEfficiencyAnalyzer.h"
 DEFINE_FWK_MODULE(GenFilterEfficiencyAnalyzer);
+
+
+#include "GeneratorInterface/Core/interface/GenXSecAnalyzer.h"
+DEFINE_FWK_MODULE(GenXSecAnalyzer);

--- a/GeneratorInterface/Core/python/genFilterSummary_cff.py
+++ b/GeneratorInterface/Core/python/genFilterSummary_cff.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
 from GeneratorInterface.Core.genFilterEfficiencyProducer_cfi import *
+from GeneratorInterface.Core.genXSecAnalyzer_cfi import *
 
-genFilterSummary = cms.Sequence(genFilterEfficiencyProducer)
+genFilterSummary = cms.Sequence(genFilterEfficiencyProducer*genXSecAnalyzer)

--- a/GeneratorInterface/Core/python/genXSecAnalyzer_cfi.py
+++ b/GeneratorInterface/Core/python/genXSecAnalyzer_cfi.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+genXSecAnalyzer = cms.EDAnalyzer('GenXSecAnalyzer',
+)

--- a/GeneratorInterface/LHEInterface/interface/LHERunInfo.h
+++ b/GeneratorInterface/LHEInterface/interface/LHERunInfo.h
@@ -71,10 +71,14 @@ class LHERunInfo {
 	};
 
 	struct XSec {
-		XSec() : value(0.0), error(0.0) {}
-
-		double	value;
-		double	error;
+	public:
+	XSec() : value_(0.0), error_(0.0) {}
+	XSec(double v, double e): value_(v), error_(e){}
+	  double value(){return value_;}
+	  double error(){return error_;}
+	private:
+	  double	value_;
+	  double	error_;
 	};
 
 	void count(int process, CountMode count, double eventWeight = 1.0,
@@ -84,45 +88,91 @@ class LHERunInfo {
 
 	std::pair<int, int> pdfSetTranslation() const;
 
-    private:
 	struct Counter {
-		Counter() : n(0), sum(0.0), sum2(0.0) {}
-
-		inline void add(double weight)
-		{
-			n++;
-			sum += weight;
-			sum2 += weight * weight;
-		}
-
-		unsigned int	n;
-		double		sum;
-		double		sum2;
+	public:
+	Counter() : n_(0), sum_(0.0), sum2_(0.0) {}
+	Counter(unsigned int n1, double sum1, double sum21) 
+	:n_(n1), sum_(sum1), sum2_(sum21) {}
+	  inline void add(double weight)
+	  {
+	    n_++;
+	    sum_ += weight;
+	    sum2_ += weight * weight;
+	  }
+	  unsigned int n() const {return n_;}
+	  double sum() const {return sum_;}
+	  double sum2() const {return sum2_;}
+	private: 
+	  unsigned int	n_;
+	  double		sum_;
+	  double		sum2_;
 	};
 
 	struct Process {
-		int		process;
-		unsigned int	heprupIndex;
-		Counter		tried;
-		Counter		selected;
-		Counter		killed;
-		Counter		accepted;
-		Counter		acceptedBr;
+	public:
+	Process(): process_(-1), heprupIndex_(-1), nPassPos_(0), nPassNeg_(0), nTotalPos_(0), nTotalNeg_(0){}
+	Process(int id): process_(id), heprupIndex_(-1), nPassPos_(0), nPassNeg_(0), nTotalPos_(0), nTotalNeg_(0){}
+	  // accessors
+	  int process() const {return process_;} 
+	  unsigned int heprupIndex() const {return heprupIndex_;}
+          XSec  getLHEXSec() const {return lheXSec_;}
 
-		inline bool operator < (const Process &other) const
-		{ return process < other.process; }
-		inline bool operator < (int process) const
-		{ return this->process < process; }
-		inline bool operator == (int process) const
-		{ return this->process == process; }
+	  unsigned int nPassPos() const {return nPassPos_;}
+	  unsigned int nPassNeg() const {return nPassNeg_;}
+	  unsigned int nTotalPos() const {return nTotalPos_;}
+	  unsigned int nTotalNeg() const {return nTotalNeg_;}
+
+	  Counter tried() const {return tried_;}
+	  Counter selected() const {return selected_;}
+	  Counter killed() const {return killed_;}
+	  Counter accepted() const {return accepted_;}
+	  Counter acceptedBr() const {return acceptedBr_;}	        
+	  
+	  // setters
+	  void setProcess(int id) {process_ = id;}
+	  void setHepRupIndex(int id) {heprupIndex_ = id;}
+          void setLHEXSec(double value, double error) {lheXSec_ = XSec(value,error);}
+
+	  void addNPassPos(unsigned int n=1) { nPassPos_ += n; }
+	  void addNPassNeg(unsigned int n=1) { nPassNeg_ += n; }
+	  void addNTotalPos(unsigned int n=1) { nTotalPos_ += n; }
+	  void addNTotalNeg(unsigned int n=1) { nTotalNeg_ += n; }
+
+	  void addTried(double w) {tried_.add(w);}
+	  void addSelected(double w) {selected_.add(w);}
+	  void addKilled(double w) {killed_.add(w);}
+	  void addAccepted(double w) {accepted_.add(w);}
+	  void addAcceptedBr(double w) {acceptedBr_.add(w);}	        
+	  
+	private:
+	  int		        process_;
+          XSec                  lheXSec_;
+	  unsigned int	        heprupIndex_;
+	  unsigned int          nPassPos_;
+	  unsigned int          nPassNeg_;
+	  unsigned int          nTotalPos_;
+	  unsigned int          nTotalNeg_;
+	  Counter		tried_;
+	  Counter		selected_;
+	  Counter		killed_;
+	  Counter		accepted_;
+	  Counter		acceptedBr_;
 	};
-
+	
+ private:
 	void init();
 
 	HEPRUP				heprup;
 	std::vector<Process>		processes;
 	std::vector<Header>		headers;
 	std::vector<std::string>	comments;
+
+ public:
+    const std::vector<Process>& getLumiProcesses() const {return processesLumi;}
+    const int getHEPIDWTUP() const {return heprup.IDWTUP;}
+    void initLumi();
+  private:
+    std::vector<Process>       	processesLumi;
 };
 
 } // namespace lhef

--- a/GeneratorInterface/LHEInterface/plugins/LHEProducer.cc
+++ b/GeneratorInterface/LHEInterface/plugins/LHEProducer.cc
@@ -164,8 +164,8 @@ void LHEProducer::endRunProduce(edm::Run &run, const edm::EventSetup &es)
 	std::auto_ptr<GenRunInfoProduct> runInfo(new GenRunInfoProduct);
 
 	runInfo->setInternalXSec(
-			GenRunInfoProduct::XSec(crossSection.value,
-			                        crossSection.error));
+				 GenRunInfoProduct::XSec(crossSection.value(),
+							 crossSection.error()));
 	runInfo->setExternalXSecLO(extCrossSect);
 	runInfo->setFilterEfficiency(extFilterEff);
 

--- a/GeneratorInterface/LHEInterface/src/LHERunInfo.cc
+++ b/GeneratorInterface/LHEInterface/src/LHERunInfo.cc
@@ -212,10 +212,8 @@ LHERunInfo::XSec LHERunInfo::xsec() const
 		  continue;
 
 		double sigma2Sum, sigma2Err;
-			sigma2Sum = proc->tried().sum2() * heprup.XSECUP[idx]
-			                             * heprup.XSECUP[idx];
-			sigma2Err = proc->tried().sum2() * heprup.XERRUP[idx]
-			                             * heprup.XERRUP[idx];
+		sigma2Sum = heprup.XSECUP[idx]* heprup.XSECUP[idx];
+		sigma2Err = heprup.XERRUP[idx]* heprup.XERRUP[idx];
 
 	        double sigmaAvg = heprup.XSECUP[idx];
 
@@ -240,10 +238,6 @@ LHERunInfo::XSec LHERunInfo::xsec() const
 
 		double relErr = 1.0;
 		if (proc->killed().n() > 1) {
-			double sigmaAvg2 = sigmaAvg * sigmaAvg;
-			double delta2Sig =
-			    fabs(sigma2Sum / proc->tried().n() - sigmaAvg2) /
-				(proc->tried().n() * sigmaAvg2);
 
 			double efferr2=0;
 			switch(idwtup) {
@@ -281,7 +275,7 @@ LHERunInfo::XSec LHERunInfo::xsec() const
 			  }
 			}
 			double delta2Veto = efferr2/fracAcc/fracAcc;
-			double delta2Sum = delta2Sig + delta2Veto
+			double delta2Sum = delta2Veto
 			                   + sigma2Err / sigma2Sum;
 			relErr = (delta2Sum > 0.0 ?
 					std::sqrt(delta2Sum) : 0.0);
@@ -311,6 +305,7 @@ void LHERunInfo::statistics() const
 	unsigned long nAccepted = 0;
 	unsigned long nTried = 0;
 	int idwtup = std::abs(heprup.IDWTUP);
+
 	std::cout << std::endl;
 	std::cout << "Process and cross-section statistics" << std::endl;
 	std::cout << "------------------------------------" << std::endl;
@@ -321,21 +316,18 @@ void LHERunInfo::statistics() const
 	    proc != processes.end(); ++proc) {
 	  unsigned int idx = proc->heprupIndex();
 
-		double sigmaSum, sigma2Sum, sigma2Err;
-			sigmaSum = proc->tried().sum() * heprup.XSECUP[idx];
-			sigma2Sum = proc->tried().sum2() * heprup.XSECUP[idx]
-			                             * heprup.XSECUP[idx];
-			sigma2Err = proc->tried().sum2() * heprup.XERRUP[idx]
-			                             * heprup.XERRUP[idx];
-		
-
 		if (!proc->selected().n()) {
 		  std::cout << proc->process() << "\t0\t0\tn/a\t\t\tn/a"
 			          << std::endl;
 			continue;
 		}
 
-		double sigmaAvg = sigmaSum / proc->tried().sum();
+		double sigma2Sum, sigma2Err;
+		sigma2Sum = heprup.XSECUP[idx]* heprup.XSECUP[idx];
+		sigma2Err = heprup.XERRUP[idx]* heprup.XERRUP[idx];
+
+	        double sigmaAvg = heprup.XSECUP[idx];
+
 		double fracAcc = 0;
 		double ntotal = proc->nTotalPos()-proc->nTotalNeg();
 		double npass  = proc->nPassPos() -proc->nPassNeg();
@@ -350,7 +342,6 @@ void LHERunInfo::statistics() const
 
 		if(fracAcc<1e-6)continue;
 
-
 		double fracBr = proc->accepted().sum() > 0.0 ?
 		                proc->acceptedBr().sum() / proc->accepted().sum() : 1;
 		double sigmaFin = sigmaAvg * fracAcc;
@@ -358,10 +349,6 @@ void LHERunInfo::statistics() const
 
 		double relErr = 1.0;
 		if (proc->killed().n() > 1) {
-			double sigmaAvg2 = sigmaAvg * sigmaAvg;
-			double delta2Sig =
-			    fabs(sigma2Sum / proc->tried().n() - sigmaAvg2) /
-				(proc->tried().n() * sigmaAvg2);
 			double efferr2=0;
 			switch(idwtup) {
 			case 3: case -3:
@@ -398,7 +385,7 @@ void LHERunInfo::statistics() const
 			  }
 			}
 			double delta2Veto = efferr2/fracAcc/fracAcc;
-			double delta2Sum = delta2Sig + delta2Veto
+			double delta2Sum = delta2Veto
 			                   + sigma2Err / sigma2Sum;
 			relErr = (delta2Sum > 0.0 ?
 					std::sqrt(delta2Sum) : 0.0);

--- a/RecoJets/Configuration/python/GenJetParticles_cff.py
+++ b/RecoJets/Configuration/python/GenJetParticles_cff.py
@@ -16,7 +16,7 @@ genParticlesForJets = cms.EDProducer("InputGenJetsParticleSelector",
          9900012, 9900014, 9900016,
          39),
     partonicFinalState = cms.bool(False),
-    excludeResonances = cms.bool(True),
+    excludeResonances = cms.bool(False),
     excludeFromResonancePids = cms.vuint32(12, 13, 14, 16),
     tausAsJets = cms.bool(False)
 )

--- a/SimDataFormats/GeneratorProducts/doc/GeneratorProducts.doc
+++ b/SimDataFormats/GeneratorProducts/doc/GeneratorProducts.doc
@@ -22,6 +22,7 @@
 
 - GenEventInfoProduct
 - GenFilterInfo
+- GenLumiInfoProduct
 - GenRunInfoProduct
 - HepMCProduct
 - LHECommonBlocks

--- a/SimDataFormats/GeneratorProducts/interface/GenFilterInfo.h
+++ b/SimDataFormats/GeneratorProducts/interface/GenFilterInfo.h
@@ -6,28 +6,58 @@
  */
 
 #include <cmath>
+#include <iostream>
 
 class GenFilterInfo {
 public:
   
   // constructors, destructors
   GenFilterInfo();
-  GenFilterInfo(unsigned int, unsigned int);
+  GenFilterInfo(unsigned int, unsigned int); // obsolete, should be avoided for new classes
+  GenFilterInfo(unsigned int, unsigned int, unsigned int, unsigned int,
+		double, double, double, double);
+  GenFilterInfo(const GenFilterInfo&);
   virtual ~GenFilterInfo();
   
   // getters
-  unsigned int numEventsTried() const { return numEventsTried_;}
-  unsigned int numEventsPassed() const { return numEventsPassed_;}
-  double filterEfficiency() const { return ( numEventsTried_ > 0 ? (double)numEventsPassed_/(double)numEventsTried_ : 1. ) ; }
-  double filterEfficiencyError() const { return ( numEventsTried_ > 0 ? std::sqrt((double)numEventsPassed_*(1.-(double)numEventsPassed_/(double)numEventsTried_))/(double)numEventsTried_ : 1. ); }
+  unsigned int numEventsTried() const { return (numTotalPositiveEvents_ + numTotalNegativeEvents_);}
+  unsigned int numEventsPassed() const { return fmax(0, (numPassPositiveEvents_ - numPassNegativeEvents_));}
+  unsigned int numEventsTotal() const { return fmax(0, (numTotalPositiveEvents_ - numTotalNegativeEvents_));}
 
+  unsigned int  numPassPositiveEvents() const { return numPassPositiveEvents_;}
+  unsigned int  numTotalPositiveEvents() const { return numTotalPositiveEvents_;}
+
+  unsigned int  numPassNegativeEvents() const { return numPassNegativeEvents_;}
+  unsigned int  numTotalNegativeEvents() const { return numTotalNegativeEvents_;}
+
+
+  double sumPassWeights() const { return sumPassWeights_;}
+  double sumPassWeights2() const { return sumPassWeights2_;}
+
+  double sumFailWeights() const { return sumTotalWeights_ - sumPassWeights_;}
+  double sumFailWeights2() const { return sumTotalWeights2_ - sumPassWeights2_;}
+
+  double sumWeights() const { return sumTotalWeights_;}
+  double sumWeights2() const { return sumTotalWeights2_;}
+
+  double filterEfficiency(int idwtup=+3) const;
+  double filterEfficiencyError(int idwtup=+3) const;
   // merge method. It will be used when merging different jobs populating the same lumi section
   bool mergeProduct(GenFilterInfo const &other);
   
-  
 private:
-  unsigned int  numEventsTried_;
-  unsigned int  numEventsPassed_;
+  
+  unsigned int  numPassPositiveEvents_;
+  unsigned int  numPassNegativeEvents_;
+  unsigned int  numTotalPositiveEvents_;
+  unsigned int  numTotalNegativeEvents_;
+
+  double        sumPassWeights_;
+  double        sumPassWeights2_;
+  double        sumTotalWeights_;
+  double        sumTotalWeights2_;
+
+
 
 };
 

--- a/SimDataFormats/GeneratorProducts/interface/GenLumiInfoProduct.h
+++ b/SimDataFormats/GeneratorProducts/interface/GenLumiInfoProduct.h
@@ -1,0 +1,159 @@
+#ifndef SimDataFormats_GeneratorProducts_GenLumiInfoProduct_h
+#define SimDataFormats_GeneratorProducts_GenLumiInfoProduct_h
+
+/** \class GenLumiInfoProduct
+ *
+ */
+
+class GenLumiInfoProduct {
+ public:
+  // a few forward declarations
+  struct XSec;
+  struct ProcessInfo;
+
+  // constructors, destructors
+  GenLumiInfoProduct();
+  GenLumiInfoProduct(const int id);
+  GenLumiInfoProduct(const GenLumiInfoProduct &other);
+  virtual ~GenLumiInfoProduct();
+
+  // getters
+
+  const int  getHEPIDWTUP() const {return hepidwtup_;}
+  const std::vector<ProcessInfo>& getProcessInfos() const {return internalProcesses_;}
+
+  // setters
+
+  void setHEPIDWTUP(const int id) { hepidwtup_ = id;}
+  void setProcessInfo(const std::vector<ProcessInfo> & processes) {internalProcesses_ = processes;}
+
+  // Struct- definitions
+  struct XSec {
+  public:
+  XSec() : value_(-1.), error_(-1.) {}
+  XSec(double v, double e = -1.) :
+    value_(v), error_(e) {}
+  XSec(const XSec &other) :
+    value_(other.value_), error_(other.error_) {}
+
+    double value() const { return value_; }
+    double error() const { return error_; }
+
+    bool isSet() const { return value_ >= 0.; }
+    bool hasError() const { return error_ >= 0.; }
+
+    operator double() const { return value_; }
+    operator bool() const { return isSet(); }
+
+    bool operator == (const XSec &other) const
+    { return value_ == other.value_ && error_ == other.error_; }
+    bool operator != (const XSec &other) const { return !(*this == other); }
+
+  private:
+    double value_, error_;
+  };
+
+
+  struct FinalStat {
+  public:
+  FinalStat() : n_(0), sum_(0.0), sum2_(0.0) {}
+  FinalStat(unsigned int n1, double sum1, double sum21) :
+    n_(n1), sum_(sum1), sum2_(sum21) {}
+  FinalStat(const FinalStat &other) :
+    n_(other.n_), sum_(other.sum_), sum2_(other.sum2_) {}
+
+    unsigned int n() const { return n_; }
+    double sum() const { return sum_; }
+    double sum2() const{ return sum2_; }
+
+    void add(const FinalStat& other)
+    {
+      n_ += other.n();
+      sum_ += other.sum();
+      sum2_ += other.sum2();
+      }
+
+    bool operator == (const FinalStat &other) const
+    { return n_ == other.n_ && sum_ == other.sum_ && sum2_ == other.sum2_; }
+    bool operator != (const FinalStat &other) const { return !(*this == other); }
+  private:
+    unsigned int	n_;
+    double		sum_;
+    double		sum2_;
+  };
+
+
+  struct ProcessInfo {
+  public:
+  ProcessInfo():process_(-1),nPassPos_(0),nPassNeg_(0),nTotalPos_(0),nTotalNeg_(0){}
+  ProcessInfo(int id):process_(id),nPassPos_(0),nPassNeg_(0),nTotalPos_(0),nTotalNeg_(0){}
+
+    // accessors
+    int process() const {return process_;}
+    XSec lheXSec() const {return lheXSec_;}
+
+    unsigned int nPassPos() const {return nPassPos_;}
+    unsigned int nPassNeg() const {return nPassNeg_;}
+    unsigned int nTotalPos() const {return nTotalPos_;}
+    unsigned int nTotalNeg() const {return nTotalNeg_;}
+
+    FinalStat tried() const {return tried_;}
+    FinalStat selected() const {return selected_;}
+    FinalStat killed() const {return killed_;}
+    FinalStat accepted() const {return accepted_;}
+    FinalStat acceptedBr() const {return acceptedBr_;}
+
+    // setters
+    void addOthers(const ProcessInfo& other){
+      nPassPos_ += other.nPassPos();
+      nPassNeg_ += other.nPassNeg();
+      nTotalPos_ += other.nTotalPos();
+      nTotalNeg_ += other.nTotalNeg();
+      tried_.add(other.tried());
+      selected_.add(other.selected());
+      killed_.add(other.killed());
+      accepted_.add(other.accepted());
+      acceptedBr_.add(other.acceptedBr());
+    }
+    void setProcess(int id) { process_ = id; }
+    void setLheXSec(double value, double err) { lheXSec_ = XSec(value,err); }
+    void setNPassPos(unsigned int n) { nPassPos_ = n; }
+    void setNPassNeg(unsigned int n) { nPassNeg_ = n; }
+    void setNTotalPos(unsigned int n) { nTotalPos_ = n; }
+    void setNTotalNeg(unsigned int n) { nTotalNeg_ = n; }
+    void setTried(unsigned int n, double sum, double sum2) { tried_ = FinalStat(n,sum,sum2); }
+    void setSelected(unsigned int n, double sum, double sum2) { selected_ = FinalStat(n,sum,sum2); }
+    void setKilled(unsigned int n, double sum, double sum2) { killed_ = FinalStat(n,sum,sum2); }
+    void setAccepted(unsigned int n, double sum, double sum2) { accepted_ = FinalStat(n,sum,sum2); }
+    void setAcceptedBr(unsigned int n, double sum, double sum2) { acceptedBr_ = FinalStat(n,sum,sum2); }
+	  
+  private:
+    int             process_;
+    XSec            lheXSec_;
+    unsigned int    nPassPos_;
+    unsigned int    nPassNeg_;
+    unsigned int    nTotalPos_;
+    unsigned int    nTotalNeg_;
+    FinalStat       tried_;
+    FinalStat       selected_;
+    FinalStat       killed_;
+    FinalStat       accepted_;
+    FinalStat       acceptedBr_;
+
+  };
+
+
+
+  // methods used by EDM
+  virtual bool mergeProduct(const GenLumiInfoProduct &other);
+  virtual bool isProductEqual(const GenLumiInfoProduct &other) const;
+  virtual bool samePhysics(const GenLumiInfoProduct &other) const;
+ private:
+  // cross sections
+  int     hepidwtup_;
+  std::vector<ProcessInfo> internalProcesses_; 
+
+
+};
+
+#endif // SimDataFormats_GeneratorProducts_GenLumiInfoProduct_h

--- a/SimDataFormats/GeneratorProducts/src/GenFilterInfo.cc
+++ b/SimDataFormats/GeneratorProducts/src/GenFilterInfo.cc
@@ -9,14 +9,51 @@ using namespace edm;
 using namespace std;
 
 GenFilterInfo::GenFilterInfo() :
-  numEventsTried_(0),
-  numEventsPassed_(0)
+  numPassPositiveEvents_(0),
+  numPassNegativeEvents_(0),
+  numTotalPositiveEvents_(0),
+  numTotalNegativeEvents_(0),
+  sumPassWeights_(0.),
+  sumPassWeights2_(0.),
+  sumTotalWeights_(0.),
+  sumTotalWeights2_(0.)
 {
 }
 
-GenFilterInfo::GenFilterInfo(unsigned int tried_, unsigned int passed_) :
-  numEventsTried_(tried_),
-  numEventsPassed_(passed_)
+GenFilterInfo::GenFilterInfo(unsigned int tried, unsigned int pass) :
+  numPassPositiveEvents_(pass),
+  numPassNegativeEvents_(0),
+  numTotalPositiveEvents_(tried),
+  numTotalNegativeEvents_(0),
+  sumPassWeights_(pass),
+  sumPassWeights2_(pass),
+  sumTotalWeights_(tried),
+  sumTotalWeights2_(tried)
+{
+}
+
+GenFilterInfo::GenFilterInfo(unsigned int passp, unsigned int passn, unsigned int totalp, unsigned int totaln,
+			     double passw, double passw2, double totalw, double totalw2) :
+  numPassPositiveEvents_(passp),
+  numPassNegativeEvents_(passn),
+  numTotalPositiveEvents_(totalp),
+  numTotalNegativeEvents_(totaln),
+  sumPassWeights_(passw),
+  sumPassWeights2_(passw2),
+  sumTotalWeights_(totalw),
+  sumTotalWeights2_(totalw2)
+{
+}
+
+GenFilterInfo::GenFilterInfo(const GenFilterInfo& other):
+  numPassPositiveEvents_(other.numPassPositiveEvents_),
+  numPassNegativeEvents_(other.numPassNegativeEvents_),
+  numTotalPositiveEvents_(other.numTotalPositiveEvents_),
+  numTotalNegativeEvents_(other.numTotalNegativeEvents_),
+  sumPassWeights_(other.sumPassWeights_),
+  sumPassWeights2_(other.sumPassWeights2_),
+  sumTotalWeights_(other.sumTotalWeights_),
+  sumTotalWeights2_(other.sumTotalWeights2_)
 {
 }
 
@@ -29,8 +66,67 @@ bool GenFilterInfo::mergeProduct(GenFilterInfo const &other)
   // merging two GenFilterInfos means that the numerator and
   // denominator from the original product need to besummed with
   // those in the product we are going to merge
-  numEventsTried_ += other.numEventsTried(); 
-  numEventsPassed_ += other.numEventsPassed();   
+
+  numPassPositiveEvents_ += other.numPassPositiveEvents_;
+  numPassNegativeEvents_ += other.numPassNegativeEvents_;
+  numTotalPositiveEvents_ += other.numTotalPositiveEvents_;
+  numTotalNegativeEvents_ += other.numTotalNegativeEvents_;
+  sumPassWeights_        += other.sumPassWeights_;
+  sumPassWeights2_       += other.sumPassWeights2_;
+  sumTotalWeights_        += other.sumTotalWeights_;
+  sumTotalWeights2_       += other.sumTotalWeights2_;
+
   return true;
 }
 
+double GenFilterInfo::filterEfficiency(int idwtup) const {
+  double eff = -1;
+  switch(idwtup) {
+  case 3: case -3:
+    eff = numEventsTotal() > 0 ? (double) numEventsPassed() / (double) numEventsTotal(): -1;
+    break;
+  default:
+    eff = sumWeights() > 1e-6? sumPassWeights()/sumWeights(): -1;
+    break;
+  }
+  return eff;
+
+}
+
+double GenFilterInfo::filterEfficiencyError(int idwtup) const {
+
+  double efferr = -1;
+  switch(idwtup) {
+  case 3: case -3:
+    {
+      double effp  = numTotalPositiveEvents() > 1e-6? 
+	(double)numPassPositiveEvents()/(double)numTotalPositiveEvents():0;
+      double effp_err2 = numTotalPositiveEvents() > 1e-6?
+	(1-effp)*effp/(double)numTotalPositiveEvents(): 0;
+
+      double effn  = numTotalNegativeEvents() > 1e-6? 
+	(double)numPassNegativeEvents()/(double)numTotalNegativeEvents():0;
+      double effn_err2 = numTotalNegativeEvents() > 1e-6? 
+	(1-effn)*effn/(double)numTotalNegativeEvents(): 0;
+
+      efferr = numEventsTotal() > 0 ? sqrt ( 
+					    ((double)numTotalPositiveEvents()*(double)numTotalPositiveEvents()*effp_err2 + 
+					     (double)numTotalNegativeEvents()*(double)numTotalNegativeEvents()*effn_err2)
+					    /(double)numEventsTotal()/(double)numEventsTotal()
+					     ) : -1;
+      break;
+    }
+  default:
+    {
+      double denominator = sumWeights()*sumWeights()*sumWeights()*sumWeights();
+      double numerator =
+	sumPassWeights2() * sumFailWeights()* sumFailWeights() +
+	sumFailWeights2() * sumPassWeights()* sumPassWeights();
+      efferr = denominator>1e-6? 
+	sqrt(numerator/denominator):-1;
+      break;
+    }
+  }
+
+  return efferr;
+}

--- a/SimDataFormats/GeneratorProducts/src/GenLumiInfoProduct.cc
+++ b/SimDataFormats/GeneratorProducts/src/GenLumiInfoProduct.cc
@@ -1,0 +1,143 @@
+#include <iostream>
+#include <algorithm> 
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "SimDataFormats/GeneratorProducts/interface/GenLumiInfoProduct.h"
+
+using namespace edm;
+using namespace std;
+
+
+const bool operator < (const GenLumiInfoProduct::ProcessInfo& lhs, const GenLumiInfoProduct::ProcessInfo& rhs) 
+{ return (lhs.process() < rhs.process()); }
+
+const bool operator != (const GenLumiInfoProduct::ProcessInfo& lhs, const GenLumiInfoProduct::ProcessInfo& rhs) 
+{ bool condition = (lhs.process() != rhs.process()) ||
+    (lhs.lheXSec() != rhs.lheXSec());
+  return condition; 
+}
+
+const bool operator == (const GenLumiInfoProduct::ProcessInfo& lhs, const GenLumiInfoProduct::ProcessInfo& rhs)
+{ 
+  bool condition=
+    (lhs.process() == rhs.process() && lhs.lheXSec() == rhs.lheXSec()
+     && lhs.nPassPos() == rhs.nPassPos() && lhs.nPassNeg() == rhs.nPassNeg()
+     && lhs.nTotalPos() == rhs.nTotalPos() && lhs.nTotalNeg() == rhs.nTotalNeg()
+     && lhs.tried() == rhs.tried() && lhs.selected() == rhs.selected()
+     && lhs.killed() == rhs.killed() && lhs.accepted() == rhs.accepted() 
+     && lhs.acceptedBr() == rhs.acceptedBr()); 
+  return condition;
+}
+
+const bool operator !=(const GenLumiInfoProduct& lhs, const GenLumiInfoProduct& rhs)
+{
+  std::vector<GenLumiInfoProduct::ProcessInfo> lhsVector = lhs.getProcessInfos();
+  std::vector<GenLumiInfoProduct::ProcessInfo> rhsVector = rhs.getProcessInfos();
+  std::sort(lhsVector.begin(),lhsVector.end());
+  std::sort(rhsVector.begin(),rhsVector.end());
+  unsigned int lhssize=lhsVector.size();
+  unsigned int rhssize=rhsVector.size();  
+  bool condition= (lhs.getHEPIDWTUP() != rhs.getHEPIDWTUP()) ||
+    (lhssize != rhssize);
+  bool fail=false;
+  if(!condition)
+    {
+      for(unsigned int i=0; i<lhssize; i++){
+	if(lhsVector[i] != rhsVector[i])
+	  {
+	    fail=true;
+	    break;
+	  }
+
+      }
+
+    }
+  return (condition || fail);
+  
+}
+
+
+const bool operator ==(const GenLumiInfoProduct& lhs, const GenLumiInfoProduct& rhs)
+{
+  std::vector<GenLumiInfoProduct::ProcessInfo> lhsVector = lhs.getProcessInfos();
+  std::vector<GenLumiInfoProduct::ProcessInfo> rhsVector = rhs.getProcessInfos();
+  std::sort(lhsVector.begin(),lhsVector.end());
+  std::sort(rhsVector.begin(),rhsVector.end());
+  unsigned int lhssize=lhsVector.size();
+  unsigned int rhssize=rhsVector.size();  
+
+  bool condition= (lhs.getHEPIDWTUP() == rhs.getHEPIDWTUP()) &&
+    (lhssize == rhssize);
+  unsigned int passCounts=-999;
+  if(condition)
+    {
+      for(unsigned int i=0; i<lhssize; i++){
+	if(lhsVector[i] == rhsVector[i])
+	  passCounts++;
+      }
+    }
+  return (condition && (passCounts==lhssize));
+  
+}
+
+
+GenLumiInfoProduct::GenLumiInfoProduct() :
+  hepidwtup_(-1)
+{
+  internalProcesses_.clear();
+  
+}
+
+GenLumiInfoProduct::GenLumiInfoProduct(const int id) :
+  hepidwtup_(id)
+{
+  internalProcesses_.clear();
+}
+
+GenLumiInfoProduct::GenLumiInfoProduct(GenLumiInfoProduct const &other) :
+  hepidwtup_(other.hepidwtup_),
+  internalProcesses_(other.internalProcesses_)
+{
+}
+
+GenLumiInfoProduct::~GenLumiInfoProduct()
+{
+}
+
+bool GenLumiInfoProduct::mergeProduct(GenLumiInfoProduct const &other)
+{
+  if ( (*this) != other)
+    {
+
+      edm::LogWarning("GenLumiInfoProduct|ProductsNotMergeable")
+	<< "You are merging runs with different cross-sections"
+	"The resulting cross-section will not be consistent." << std::endl;
+
+      return false;
+    }
+  for(unsigned int i=0; i < internalProcesses_.size(); i++)
+    {
+      internalProcesses_[i].addOthers(other.getProcessInfos()[i]);
+      
+    }
+    
+  return true;
+}
+
+bool GenLumiInfoProduct::isProductEqual(GenLumiInfoProduct const &other) const
+{
+  return ((*this) == other);
+}
+
+
+bool GenLumiInfoProduct::samePhysics(GenLumiInfoProduct const &other) const
+{
+
+  unsigned int lhssize=getProcessInfos().size();
+  unsigned int rhssize=other.getProcessInfos().size();  
+  return ( (getHEPIDWTUP() == other.getHEPIDWTUP()) &&
+	   (lhssize == rhssize));
+
+}
+

--- a/SimDataFormats/GeneratorProducts/src/classes.h
+++ b/SimDataFormats/GeneratorProducts/src/classes.h
@@ -15,7 +15,7 @@
 #include "SimDataFormats/GeneratorProducts/interface/GenRunInfoProduct.h"
 #include "SimDataFormats/GeneratorProducts/interface/GenFilterInfo.h"
 #include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
-
+#include "SimDataFormats/GeneratorProducts/interface/GenLumiInfoProduct.h"
 #include <HepMC/GenRanges.h>
 
 namespace SimDataFormats_GeneratorProducts {
@@ -57,7 +57,7 @@ namespace SimDataFormats_GeneratorProducts {
 		edm::Wrapper<GenRunInfoProduct> wgenruninfo;
 		edm::Wrapper<GenFilterInfo> wgenfilterinfo;
 		edm::Wrapper<GenEventInfoProduct> wgeneventinfo;
-
+		edm::Wrapper<GenLumiInfoProduct> wgenlumiinfo;
 		// LHE products
 
 		edm::Wrapper<LHERunInfoProduct>	wcommon;

--- a/SimDataFormats/GeneratorProducts/src/classes_def.xml
+++ b/SimDataFormats/GeneratorProducts/src/classes_def.xml
@@ -99,11 +99,51 @@
 
 	<!-- GenFilterInfo -->
 
-	<class name="GenFilterInfo" ClassVersion="10">
+	<class name="GenFilterInfo" ClassVersion="11">
+  <version ClassVersion="11" checksum="1506634242"/>
   <version ClassVersion="10" checksum="2060912306"/>
  </class>
+	<ioread sourceClass = "GenFilterInfo" source = "unsigned int numEventsPassed_" version="[-10]" targetClass="GenFilterInfo" target="numPassPositiveEvents_">
+	  <![CDATA[numPassPositiveEvents_ = onfile.numEventsPassed_;]]>
+	</ioread> 
+	<ioread sourceClass = "GenFilterInfo" source = "" version="[-10]" targetClass="GenFilterInfo" target="numPassNegativeEvents_">
+	  <![CDATA[numPassNegativeEvents_ = 0;]]>
+	</ioread> 
+	<ioread sourceClass = "GenFilterInfo" source = "unsigned int numEventsTried_" version="[-10]" targetClass="GenFilterInfo" target="numTotalPositiveEvents_">
+	  <![CDATA[numTotalPositiveEvents_ = onfile.numEventsTried_;]]>
+	</ioread> 
+	<ioread sourceClass = "GenFilterInfo" source = "" version="[-10]" targetClass="GenFilterInfo" target="numTotalNegativeEvents_">
+	  <![CDATA[numTotalNegativeEvents_ = 0;]]>
+	</ioread> 
+	<ioread sourceClass = "GenFilterInfo" source = "unsigned int numEventsPassed_" version="[-10]" targetClass="GenFilterInfo" target="sumPassWeights_">
+	  <![CDATA[sumPassWeights_ = onfile.numEventsPassed_;]]>
+	</ioread> 
+	<ioread sourceClass = "GenFilterInfo" source = "unsigned int numEventsPassed_" version="[-10]" targetClass="GenFilterInfo" target="sumPassWeights2_">
+	  <![CDATA[sumPassWeights2_ = onfile.numEventsPassed_;]]>
+	</ioread> 
+	<ioread sourceClass = "GenFilterInfo" source = "unsigned int numEventsTried_" version="[-10]" targetClass="GenFilterInfo" target="sumTotalWeights_">
+	  <![CDATA[sumTotalWeights_ = onfile.numEventsTried_;]]>
+	</ioread> 
+	<ioread sourceClass = "GenFilterInfo" source = "unsigned int numEventsTried_" version="[-10]" targetClass="GenFilterInfo" target="sumTotalWeights2_">
+	  <![CDATA[sumTotalWeights2_ = onfile.numEventsTried_;]]>
+	</ioread> 
 	<class name="edm::Wrapper&lt;GenFilterInfo&gt;"/>
 
+	<!-- GenLumiInfoProduct -->
+
+	<class name="GenLumiInfoProduct" ClassVersion="10">
+	  <version ClassVersion="10" checksum="2365797689"/> 
+	</class>
+	<class name="GenLumiInfoProduct::FinalStat" ClassVersion="10">
+	  <version ClassVersion="10" checksum="1937303025"/>  
+	</class>
+	<class name="GenLumiInfoProduct::XSec" ClassVersion="10">
+	  <version ClassVersion="10" checksum="1482608724"/> 
+	</class>
+	<class name="GenLumiInfoProduct::ProcessInfo" ClassVersion="10">
+	  <version ClassVersion="10" checksum="621228037"/>
+	</class>
+	<class name="edm::Wrapper&lt;GenLumiInfoProduct&gt;"/>
 
 	<!-- GenEventInfoProduct -->
 

--- a/SimDataFormats/GeneratorProducts/src/classes_def.xml
+++ b/SimDataFormats/GeneratorProducts/src/classes_def.xml
@@ -140,6 +140,7 @@
 	<class name="GenLumiInfoProduct::XSec" ClassVersion="10">
 	  <version ClassVersion="10" checksum="1482608724"/> 
 	</class>
+	<class name="std::vector&lt;GenLumiInfoProduct::ProcessInfo&gt;"/>
 	<class name="GenLumiInfoProduct::ProcessInfo" ClassVersion="10">
 	  <version ClassVersion="10" checksum="621228037"/>
 	</class>


### PR DESCRIPTION
Backports (from 73x) the GenLumiInfoProduct and associated machinery to produce and analyze it to allow consistent determination of Monte Carlo cross sections from the output sample.

Backports also the change in GenJet configuration such that resonance decay products are no longer excluded from the GenJet clustering.
