### PR TITLE
Fix sim g4 core generators

### DIFF
--- a/Validation/EventGenerator/src/HepMCValidationHelper.cc
+++ b/Validation/EventGenerator/src/HepMCValidationHelper.cc
@@ -2,7 +2,6 @@
 #include "DataFormats/Math/interface/deltaR.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <iostream>
-#include <cassert>
 #include <limits>
 #include "TLorentzVector.h"
 
@@ -185,10 +184,9 @@ namespace HepMCValidationHelper {
     for (unsigned int i = 0; i < taus.size(); ++i){
       std::vector<const HepMC::GenParticle*> taudaughters;
       findDescendents(taus[i], taudaughters);
-      assert(taudaughters.size()>0);
-      if ( taudaughters.size()==0 ) {
+      if ( taudaughters.size()<=0 ) {
 	edm::LogError("HepMCValidationHelper") << "Tau with no daughters. This is a bug. Fix it";
-	continue;
+	abort();
       }
       const HepMC::FourVector& taumom = taus[i]->momentum();
       //remove the daughters from the list of particles to compute isolation

--- a/Validation/EventGenerator/src/HepMCValidationHelper.cc
+++ b/Validation/EventGenerator/src/HepMCValidationHelper.cc
@@ -186,7 +186,7 @@ namespace HepMCValidationHelper {
       findDescendents(taus[i], taudaughters);
       if ( taudaughters.size()<=0 ) {
 	edm::LogError("HepMCValidationHelper") << "Tau with no daughters. This is a bug. Fix it";
-	abort();
+	//comment out for now to be safe abort();
       }
       const HepMC::FourVector& taumom = taus[i]->momentum();
       //remove the daughters from the list of particles to compute isolation


### PR DESCRIPTION
72x version of PR5635 with addition of avoiding a change to a const variable. LIkely some performance hit, but should restore intented behavior. While not conclusive, I do see that the MET values start to diverge with and without this PR on an event with high MET. Good.
