### PR TITLE
ThroughputService: use std::chrono::steady_clock instead of clock_gettime(CLOCK_MONOTONIC, ...)

### DIFF
--- a/HLTrigger/Timer/plugins/ThroughputService.cc
+++ b/HLTrigger/Timer/plugins/ThroughputService.cc
@@ -1,5 +1,6 @@
 // C++ headers
 #include <algorithm>
+#include <chrono>
 
 // boost headers
 #include <boost/format.hpp>
@@ -40,7 +41,7 @@ ThroughputService::~ThroughputService()
 void
 ThroughputService::preallocate(edm::service::SystemBounds const & bounds)
 {
-  m_startup = clock_gettime_monotonic::now();
+  m_startup = std::chrono::steady_clock::now();
 
   m_stream_histograms.resize( bounds.maxNumberOfStreams() );
 
@@ -93,7 +94,7 @@ ThroughputService::postStreamEndRun(edm::StreamContext const & sc)
 void
 ThroughputService::preSourceEvent(edm::StreamID sid)
 {
-  auto timestamp = clock_gettime_monotonic::now();
+  auto timestamp = std::chrono::steady_clock::now();
   m_stream_histograms[sid].sourced_events->Fill( std::chrono::duration_cast<std::chrono::duration<double>>(timestamp - m_startup).count() );
 }
 
@@ -101,7 +102,7 @@ void
 ThroughputService::postEvent(edm::StreamContext const & sc)
 {
   unsigned int sid = sc.streamID().value();
-  auto timestamp = clock_gettime_monotonic::now();
+  auto timestamp = std::chrono::steady_clock::now();
   m_stream_histograms[sid].retired_events->Fill( std::chrono::duration_cast<std::chrono::duration<double>>(timestamp - m_startup).count() );
 }
 

--- a/HLTrigger/Timer/plugins/ThroughputService.h
+++ b/HLTrigger/Timer/plugins/ThroughputService.h
@@ -26,27 +26,6 @@
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
 #include "HLTrigger/Timer/interface/FastTimer.h"
 
-// based on clock_gettime(CLOCK_MONOTONIC, ...)
-struct clock_gettime_monotonic
-{
-  typedef std::chrono::nanoseconds                                      duration;
-  typedef duration::rep                                                 rep;
-  typedef duration::period                                              period;
-  typedef std::chrono::time_point<clock_gettime_monotonic, duration>    time_point;
-
-  static constexpr bool is_steady = true;
-  static const     bool is_available;
-
-  static time_point now() noexcept
-  {
-    timespec t;
-    clock_gettime(CLOCK_MONOTONIC, &t);
-
-    return time_point( std::chrono::seconds(t.tv_sec) + std::chrono::nanoseconds(t.tv_nsec) );
-  }
-
-};
-
 class ThroughputService {
 public:
   ThroughputService(const edm::ParameterSet &, edm::ActivityRegistry & );
@@ -78,7 +57,7 @@ private:
 
   std::vector<stream_histograms>        m_stream_histograms;
   
-  clock_gettime_monotonic::time_point   m_startup;
+  std::chrono::steady_clock::time_point m_startup;
 
   // histogram-related data members
   double                                m_time_range;


### PR DESCRIPTION
This should fix the ThroughputService on OS X, where clock_gettime is not implemented

According to testChrono, `steady_clock::now()` is marginally slower than `(CLOCK_MONOTONIC, ...)`, but in this case the difference should be negligible.
