### PR TITLE
add 2 new MEs for monitoring FED data vs LS

### DIFF
--- a/DQM/Integration/python/test/fedtest_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/test/fedtest_dqm_sourceclient-live_cfg.py
@@ -86,8 +86,8 @@ process.SiPixelHLTSource.DirName = cms.untracked.string('Pixel/FEDIntegrity_SM/'
 
 # SiStrip DQM sequences
 process.load("DQM.SiStripMonitorHardware.siStripFEDCheck_cfi")
-process.siStripFEDCheck.DirName = cms.untracked.string('SiStrip/FEDIntegrity_SM/')
-
+process.siStripFEDCheck.RawDataTag = cms.InputTag("rawDataCollector")
+process.siStripFEDCheck.DirName    = cms.untracked.string('SiStrip/FEDIntegrity_SM/')
 
 # Hcal DQM sequences
 process.load("EventFilter.HcalRawToDigi.HcalRawToDigi_cfi")

--- a/DQM/Integration/python/test/sistrip_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/test/sistrip_dqm_sourceclient-live_cfg.py
@@ -279,6 +279,24 @@ if (process.runType.getRunType() == process.runType.cosmic_run):
                          process.TrackingClient
                          )
 
+    if offlineTesting :
+        process.load("DQM.SiStripMonitorHardware.siStripFEDCheck_cfi")
+        process.siStripFEDCheck.RawDataTag = cms.InputTag("rawDataCollector")
+        process.siStripFEDCheck.DirName    = cms.untracked.string('SiStrip/FEDIntegrity_SM/')
+        process.p = cms.Path(process.scalersRawToDigi*
+                             process.APVPhases*
+                             process.consecutiveHEs*
+                             process.hltTriggerTypeFilter*
+                             process.siStripFEDCheck *
+                             process.RecoForDQM_LocalReco*
+                             process.DQMCommon*
+                             process.SiStripClients*
+                             process.SiStripSources_LocalReco*
+                             process.RecoForDQM_TrkReco_cosmic*
+                             process.SiStripSources_TrkReco_cosmic*
+                             process.TrackingClient
+                             )
+
 
 
 #else :
@@ -371,6 +389,25 @@ if (process.runType.getRunType() == process.runType.pp_run):
                          process.SiStripSources_TrkReco*
                          process.TrackingClient
                          )
+    if offlineTesting :
+        process.load("DQM.SiStripMonitorHardware.siStripFEDCheck_cfi")
+        process.siStripFEDCheck.RawDataTag = cms.InputTag("rawDataCollector")
+        process.siStripFEDCheck.DirName    = cms.untracked.string('SiStrip/FEDIntegrity_SM/')
+        process.p = cms.Path(process.scalersRawToDigi*
+                             process.APVPhases*
+                             process.consecutiveHEs*
+                             process.hltTriggerTypeFilter*
+                             process.siStripFEDCheck *
+                             process.RecoForDQM_LocalReco*
+                             process.DQMCommon*
+                             process.SiStripClients*
+                             process.SiStripSources_LocalReco*
+                             process.hltHighLevel*
+                             process.RecoForDQM_TrkReco*
+                             process.SiStripSources_TrkReco*
+                             process.TrackingClient
+                             )
+
 #--------------------------------------------------
 # For high PU run - no tracking in cmssw42x
 #--------------------------------------------------
@@ -464,6 +501,25 @@ if (process.runType.getRunType() == process.runType.hpu_run):
                          process.SiStripSources_TrkReco*
                          process.TrackingClient
                          )
+    if offlineTesting :
+        process.load("DQM.SiStripMonitorHardware.siStripFEDCheck_cfi")
+        process.siStripFEDCheck.RawDataTag = cms.InputTag("rawDataCollector")
+        process.siStripFEDCheck.DirName    = cms.untracked.string('SiStrip/FEDIntegrity_SM/')
+        process.p = cms.Path(process.scalersRawToDigi*
+                             process.APVPhases*
+                             process.consecutiveHEs*
+                             process.hltTriggerTypeFilter*
+                             process.siStripFEDCheck *
+                             process.RecoForDQM_LocalReco*
+                             process.DQMCommon*
+                             process.SiStripClients*
+                             process.SiStripSources_LocalReco*
+                             process.hltHighLevel*
+                             process.eventFilter*
+                             process.RecoForDQM_TrkReco*
+                             process.SiStripSources_TrkReco*
+                             process.TrackingClient
+                             )
 
 process.castorDigis.InputLabel = cms.InputTag("rawDataCollector")
 process.csctfDigis.producer = cms.InputTag("rawDataCollector")
@@ -577,4 +633,22 @@ if (process.runType.getRunType() == process.runType.hi_run):
                          process.SiStripBaselineValidator*
                          process.TrackingClients
                          )
-
+    if offlineTesting :
+        process.load("DQM.SiStripMonitorHardware.siStripFEDCheck_cfi")
+        process.siStripFEDCheck.RawDataTag = cms.InputTag("rawDataCollector")
+        process.siStripFEDCheck.DirName    = cms.untracked.string('SiStrip/FEDIntegrity_SM/')
+        process.p = cms.Path(process.scalersRawToDigi*
+                             process.APVPhases*
+                             process.consecutiveHEs*
+                             process.hltTriggerTypeFilter*
+                             process.siStripFEDCheck *
+                             process.RecoForDQM_LocalReco*
+                             process.DQMCommon*
+                             process.SiStripClients*
+                             process.SiStripSources_LocalReco*
+                             process.RecoForDQM_TrkReco*
+                             process.SiStripSources_TrkReco*
+                             process.multFilter*
+                             process.SiStripBaselineValidator*
+                             process.TrackingClients
+                             )

--- a/DQM/SiStripMonitorHardware/python/siStripFEDCheck_cfi.py
+++ b/DQM/SiStripMonitorHardware/python/siStripFEDCheck_cfi.py
@@ -23,4 +23,7 @@ siStripFEDCheck = cms.EDAnalyzer("SiStripFEDCheckPlugin",
   CheckFELengths = cms.untracked.bool(True),
   #Use to disable check on channel status bits
   CheckChannelStatus = cms.untracked.bool(True),
+  LSBin = cms.int32(5000),
+  LSMin = cms.double(0.),
+  LSMax = cms.double(5000.),  
 )


### PR DESCRIPTION
while migrating to DQMHarvester,
I realized we will have problems in handling the number of FED in and number of FED w/ data
moreover, it will anyhow useful to have such an information also in the certification process ...

so, I add 2 new MEs
- nFEDinVsLS
- nFEDinWdataVsLS
  they are TProfile and they have 5000 bins each, as now

they are produced by 
DQM/SiStripMonitorHardware/src/SiStripFEDDataCheck.cc
which is run by the module 
DQM/Integration/python/test/fedtest_dqm_sourceclient-live_cfg.py

please, if you plan to not run such a job in p5,
let us know and we will add the module w/in the strip/tracking workflow !

those 2 new MEs will be used by the strip and tracking clients (in the harvesting step)
in order to handle the reportSummaryMap of the sub-systems

while checking and developing the code,
I realized there was a missing parameter setting in 
DQM/Integration/python/test/fedtest_dqm_sourceclient-live_cfg.py
which was preventing the proper filling of the histograms
this PR fixes it as well
