### PR TITLE
Multithread-safe version which uses HistoJ for vectors

### DIFF
--- a/HLTrigger/JSONMonitoring/interface/TriggerJSONMonitoring.h
+++ b/HLTrigger/JSONMonitoring/interface/TriggerJSONMonitoring.h
@@ -1,5 +1,5 @@
-#ifndef HLTcore_TriggerJSONMonitoring_h
-#define HLTcore_TriggerJSONMonitoring_h
+#ifndef JSONMonitoring_TriggerJSONMonitoring_h
+#define JSONMonitoring_TriggerJSONMonitoring_h
 
 /** \class TriggerJSONMonitoring
  *
@@ -15,7 +15,7 @@
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/stream/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 
@@ -30,38 +30,103 @@
 
 #include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
 
+namespace hltJson {
+  //Struct for storing variables that must be written and reset every lumi section
+  struct lumiVars {
+    HistoJ<unsigned int> *processed; // # of events processed
+
+    HistoJ<unsigned int> *hltWasRun; // # of events where HLT[i] was run
+    HistoJ<unsigned int> *hltL1s;    // # of events after L1 seed
+    HistoJ<unsigned int> *hltPre;    // # of events after HLT prescale
+    HistoJ<unsigned int> *hltAccept; // # of events accepted by HLT[i]
+    HistoJ<unsigned int> *hltReject; // # of events rejected by HLT[i]
+    HistoJ<unsigned int> *hltErrors; // # of events with error in HLT[i]
+
+    HistoJ<unsigned int> *hltDatasets; // # of events accepted by each dataset
+
+    //Names and directories aren't changed at lumi section boundaries, 
+    //but they need to be in this struct to be write JSON files at the end
+    HistoJ<std::string> *hltNames;     // list of HLT path names
+    HistoJ<std::string> *datasetNames; // list of dataset names
+
+    std::string baseRunDir;        //Base directory from EvFDaqDirector
+    std::string jsonRateDefFile;   //Definition file name for JSON with rates
+    std::string jsonLegendDefFile; //Definition file name for JSON with legend of names
+  };
+}//End hltJson namespace
+
 //
 // class declaration
 //
-class TriggerJSONMonitoring : public edm::EDAnalyzer {
-  
+class TriggerJSONMonitoring : public edm::stream::EDAnalyzer <edm::LuminosityBlockSummaryCache<hltJson::lumiVars>>
+{
  public:
   explicit TriggerJSONMonitoring(const edm::ParameterSet&);
   ~TriggerJSONMonitoring();
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
-  virtual void beginRun(edm::Run const&, edm::EventSetup const&);
-  virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
-  virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
 
-  void reset(bool changed = false);       // reset all counters
+  void analyze(edm::Event const&, 
+	       edm::EventSetup const&);
 
- private:
-  boost::shared_ptr<jsoncollector::FastMonitor> jsonMonitor_;
-  DataPointDefinition outJson_;
-  IntJ processed_; 
+  void beginRun(edm::Run const&, 
+		edm::EventSetup const&);
 
-  std::string baseRunDir;
+  void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
 
-  std::vector<std::string>  hltNames_;  // name of each HLT algorithm
-  std::vector<IntJ> hltPaths_;          // stores name and # of event accepted by HLT paths
+  static std::shared_ptr<hltJson::lumiVars> globalBeginLuminosityBlockSummary(edm::LuminosityBlock const&,
+									      edm::EventSetup const&,
+									      LuminosityBlockContext const*);
 
-  std::string jsonDefinitionFile;       // JSON definition file name
+  void endLuminosityBlockSummary(edm::LuminosityBlock const&, 
+				 edm::EventSetup const&, 
+				 hltJson::lumiVars*) const;
 
+
+  static void globalEndLuminosityBlockSummary(edm::LuminosityBlock const&, 
+					      edm::EventSetup const&, 
+					      LuminosityBlockContext const*, 
+					      hltJson::lumiVars*);
+
+  void resetRun(bool changed);   //Reset run-related info    
+  void resetLumi();              //Reset all counters
+
+  void writeDefJson(std::string path);
+  void writeDefLegJson(std::string path);
+  
+  //Variables from cfg and associated tokens
   edm::InputTag triggerResults_;                               // Input tag for TriggerResults
   edm::EDGetTokenT<edm::TriggerResults> triggerResultsToken_;  // Token for TriggerResults
-      
+
+  //Variables that change at most once per run
   HLTConfigProvider hltConfig_;         // to get configuration for HLT
+  
+  std::string baseRunDir_; //Base directory from EvFDaqDirector
+  
+  // hltIndex_[ds][p] stores the hltNames_ index of the p-th path of the ds-th dataset
+  std::vector<std::vector<unsigned int> > hltIndex_;
+  std::vector<std::string> hltNames_;                      // list of HLT path names
+  std::vector<std::string> datasetNames_;                  // list of dataset names
+  std::vector<std::vector<std::string> > datasetContents_; // list of path names for each dataset
+
+  std::vector<int> posL1s_;             // pos # of last L1 seed
+  std::vector<int> posPre_;             // pos # of last HLT prescale
+  
+  std::string jsonRateDefFile_;   //Definition file name for JSON with rates
+  std::string jsonLegendDefFile_; //Definition file name for JSON with legend of names
+  
+  //Variables that need to be reset at lumi section boundaries
+  unsigned int              processed_; // # of events processed
+
+  std::vector<unsigned int> hltWasRun_; // # of events where HLT[i] was run
+  std::vector<unsigned int> hltL1s_;    // # of events after L1 seed
+  std::vector<unsigned int> hltPre_;    // # of events after HLT prescale
+  std::vector<unsigned int> hltAccept_; // # of events accepted by HLT[i]
+  std::vector<unsigned int> hltReject_; // # of events rejected by HLT[i]
+  std::vector<unsigned int> hltErrors_; // # of events with error in HLT[i]
+
+  std::vector<unsigned int> hltDatasets_; // # of events accepted by each dataset
+  
+ private:
 
 };
 #endif

--- a/HLTrigger/JSONMonitoring/plugins/TriggerJSONMonitoring.cc
+++ b/HLTrigger/JSONMonitoring/plugins/TriggerJSONMonitoring.cc
@@ -45,7 +45,7 @@ TriggerJSONMonitoring::analyze(const edm::Event& iEvent, const edm::EventSetup& 
   using namespace std;
   using namespace edm;
 
-  processed_.value()++;
+  processed_++;
 
   //Get hold of TriggerResults
   Handle<TriggerResults> HLTR;
@@ -55,145 +55,366 @@ TriggerJSONMonitoring::analyze(const edm::Event& iEvent, const edm::EventSetup& 
     return;
   }
   
-  // decision for each HLT path
-  const unsigned int n(hltNames_.size());
-  for (unsigned int i=0; i<n; i++) {
-    if (HLTR->accept(i)){
-      hltPaths_[i].value()++;
-    }
-  }
+   //Decision for each HLT path
+   const unsigned int n(hltNames_.size());
+   for (unsigned int i=0; i<n; i++) {
+     if (HLTR->wasrun(i))                     hltWasRun_[i]++;
+     if (HLTR->accept(i))                     hltAccept_[i]++;
+     if (HLTR->wasrun(i) && !HLTR->accept(i)) hltReject_[i]++;
+     if (HLTR->error(i))                      hltErrors_[i]++;
+     //Count L1 seeds and Prescales
+     const int index(static_cast<int>(HLTR->index(i)));
+     if (HLTR->accept(i)) {
+       if (index >= posL1s_[i]) hltL1s_[i]++;
+       if (index >= posPre_[i]) hltPre_[i]++;
+     } else {
+       if (index >  posL1s_[i]) hltL1s_[i]++;
+       if (index >  posPre_[i]) hltPre_[i]++;
+     }
+   }
 
-}
+  //Decision for each HLT dataset
+   std::vector<bool> acceptedByDS(hltIndex_.size(), false);
+   for (unsigned int ds=0; ds < hltIndex_.size(); ds++) {  // ds = index of dataset
+     for (unsigned int p=0; p<hltIndex_[ds].size(); p++) {   // p = index of path with dataset ds
+       if (acceptedByDS[ds]>0 || HLTR->accept(hltIndex_[ds][p]) ) {
+         acceptedByDS[ds] = true;
+       }
+     }
+     if (acceptedByDS[ds]) hltDatasets_[ds]++;
+   }
+}//End analyze function
 
 void 
-TriggerJSONMonitoring::reset(bool changed ){
+TriggerJSONMonitoring::resetRun(bool changed){
 
-  processed_.value() = 0;
-
-  // update trigger names
-  if (changed) hltNames_ = hltConfig_.triggerNames();
+  //Update trigger and dataset names
+  if (changed){
+    hltNames_        = hltConfig_.triggerNames();
+    datasetNames_    = hltConfig_.datasetNames();
+    datasetContents_ = hltConfig_.datasetContents();
+  }
 
   const unsigned int n = hltNames_.size();
+  const unsigned int d = datasetNames_.size();
+  
+   if (changed) {
+     //Resize per-path counters
+     hltWasRun_.resize(n);
+     hltL1s_.resize(n);
+     hltPre_.resize(n);
+     hltAccept_.resize(n);
+     hltReject_.resize(n);
+     hltErrors_.resize(n);
+     //Resize per-dataset counter
+     hltDatasets_.resize(d);
+     //Resize htlIndex
+     hltIndex_.resize(d);
+     //Set-up hltIndex
+     for (unsigned int ds = 0; ds < d; ds++) {
+       unsigned int size = datasetContents_[ds].size();
+       hltIndex_[ds].reserve(size);
+       for (unsigned int p = 0; p < size; p++) {
+         unsigned int i = hltConfig_.triggerIndex(datasetContents_[ds][p]);
+         if (i<n) {
+           hltIndex_[ds].push_back(i);
+         }
+       }
+     }
+     //Find the positions of seeding and prescaler modules
+     posL1s_.resize(n);
+     posPre_.resize(n);
+     for (unsigned int i = 0; i < n; ++i) {
+       posL1s_[i] = -1;
+       posPre_[i] = -1;
+       const std::vector<std::string> & moduleLabels(hltConfig_.moduleLabels(i));
+       for (unsigned int j = 0; j < moduleLabels.size(); ++j) {
+         const std::string & label = hltConfig_.moduleType(moduleLabels[j]);
+         if (label == "HLTLevel1GTSeed")
+           posL1s_[i] = j;
+         else if (label == "HLTPrescaler")
+           posPre_[i] = j;
+       }
+     }
+   }
+   resetLumi();
+}//End resetRun function
 
-  if (changed) {
-    // resize per-path counter
-    hltPaths_.resize(n);
+void
+TriggerJSONMonitoring::resetLumi(){
+  //Reset total number of events
+  processed_ = 0;
+  
+  //Reset per-path counters
+  for (unsigned int i = 0; i < hltWasRun_.size(); i++) {
+    hltWasRun_[i] = 0;
+    hltL1s_[i]   = 0;
+    hltPre_[i]   = 0;
+    hltAccept_[i] = 0;
+    hltReject_[i] = 0;
+    hltErrors_[i] = 0;
+  }
+  //Reset per-dataset counter
+  for (unsigned int i = 0; i < hltDatasets_.size(); i++) {
+    hltDatasets_[i] = 0;
+  }
+}//End resetLumi function
+
+void  
+TriggerJSONMonitoring::beginRun(edm::Run const& iRun, edm::EventSetup const& iSetup)
+{  
+  //Get the run directory from the EvFDaqDirector
+  if (edm::Service<evf::EvFDaqDirector>().isAvailable()) baseRunDir_ = edm::Service<evf::EvFDaqDirector>()->baseRunDir();
+  else                                                   baseRunDir_ = ".";
+
+  //Create mon directory if it doesn't exist
+  boost::filesystem::path monPath = baseRunDir_ + "/mon";
+  if (not boost::filesystem::is_directory(monPath)) boost::filesystem::create_directories(monPath);
+
+  //Initialize hltConfig_
+  bool changed = true;
+  if (hltConfig_.init(iRun, iSetup, triggerResults_.process(), changed)) resetRun(changed);
+  else{ 
+    LogDebug("TriggerJSONMonitoring") << "HLTConfigProvider initialization failed!" << std::endl;
+    return;
   }
 
-  // reset per-path counter
-  for (unsigned int i = 0; i < n; i++) {
-    hltPaths_[i].value() = 0;
-  }
+  unsigned int nRun = iRun.run();
 
-}
+  //Create definition file for Rates
+  std::stringstream sjsdr;
+  sjsdr << baseRunDir_ + "/mon/run" << nRun << "_ls0000";    
+  sjsdr << "_HLTRates_pid" << std::setfill('0') << std::setw(5) << getpid() << ".jsd";
+  jsonRateDefFile_ = sjsdr.str();
+  
+  writeDefJson(jsonRateDefFile_);
+
+  //Create definition file for Legend
+  std::stringstream sjsdl;
+  sjsdl << baseRunDir_ << "/mon/run" << nRun << "_ls0000";
+  sjsdl << "_HLTRatesLegend_pid" << std::setfill('0') << std::setw(5) << getpid() << ".jsd";
+  jsonLegendDefFile_ = sjsdl.str();
+  
+  writeDefLegJson(jsonLegendDefFile_);
+  
+}//End beginRun function
+
+void TriggerJSONMonitoring::beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup& iSetup){ resetLumi(); }
+
+std::shared_ptr<hltJson::lumiVars>
+TriggerJSONMonitoring::globalBeginLuminosityBlockSummary(const edm::LuminosityBlock& iLumi, const edm::EventSetup& iSetup, const LuminosityBlockContext* iContext)
+{
+  std::shared_ptr<hltJson::lumiVars> iSummary(new hltJson::lumiVars);
+
+  unsigned int MAXPATHS = 500;
+  
+  iSummary->processed = new HistoJ<unsigned int>(1, 1);
+
+  iSummary->hltWasRun = new HistoJ<unsigned int>(1, MAXPATHS);
+  iSummary->hltL1s    = new HistoJ<unsigned int>(1, MAXPATHS);
+  iSummary->hltPre    = new HistoJ<unsigned int>(1, MAXPATHS);
+  iSummary->hltAccept = new HistoJ<unsigned int>(1, MAXPATHS);
+  iSummary->hltReject = new HistoJ<unsigned int>(1, MAXPATHS);
+  iSummary->hltErrors = new HistoJ<unsigned int>(1, MAXPATHS);
+
+  iSummary->hltDatasets = new HistoJ<unsigned int>(1, MAXPATHS);
+  
+  iSummary->hltNames     = new HistoJ<std::string>(1, MAXPATHS);
+  iSummary->datasetNames = new HistoJ<std::string>(1, MAXPATHS);
+  
+  return iSummary;
+}//End globalBeginLuminosityBlockSummary function
+
+void 
+TriggerJSONMonitoring::endLuminosityBlockSummary(const edm::LuminosityBlock& iLumi, const edm::EventSetup& iEventSetup, hltJson::lumiVars* iSummary) const{
+
+  //Whichever stream gets there first does the initialiazation
+  if (iSummary->hltNames->value().size() == 0){
+    iSummary->processed->update(processed_);
+
+    for (unsigned int ui = 0; ui < hltNames_.size(); ui++){
+      iSummary->hltWasRun->update(hltWasRun_.at(ui));
+      iSummary->hltL1s   ->update(hltL1s_   .at(ui));
+      iSummary->hltPre   ->update(hltPre_   .at(ui));
+      iSummary->hltAccept->update(hltAccept_.at(ui));
+      iSummary->hltReject->update(hltReject_.at(ui));
+      iSummary->hltErrors->update(hltErrors_.at(ui));
+      
+      iSummary->hltNames->update(hltNames_.at(ui));
+    }
+
+    for (unsigned int ui = 0; ui < datasetNames_.size(); ui++){
+      iSummary->hltDatasets->update(hltDatasets_.at(ui));      
+
+      iSummary->datasetNames->update(datasetNames_.at(ui));      
+    }
+    iSummary->jsonRateDefFile   = jsonRateDefFile_;
+    iSummary->jsonLegendDefFile = jsonLegendDefFile_;
+    iSummary->baseRunDir        = baseRunDir_;
+  }
+  else{
+    iSummary->processed->value().at(0) += processed_;
+
+    for (unsigned int ui = 0; ui < hltNames_.size(); ui++){
+      iSummary->hltWasRun->value().at(ui) += hltWasRun_.at(ui);
+      iSummary->hltL1s   ->value().at(ui) += hltL1s_   .at(ui);
+      iSummary->hltPre   ->value().at(ui) += hltPre_   .at(ui);
+      iSummary->hltAccept->value().at(ui) += hltAccept_.at(ui);
+      iSummary->hltReject->value().at(ui) += hltReject_.at(ui);
+      iSummary->hltErrors->value().at(ui) += hltErrors_.at(ui);
+    }
+    for (unsigned int ui = 0; ui < datasetNames_.size(); ui++){
+      iSummary->hltDatasets->value().at(ui) += hltDatasets_.at(ui);      
+    }
+  }
+}//End endLuminosityBlockSummary function
+
+
+void  
+TriggerJSONMonitoring::globalEndLuminosityBlockSummary(const edm::LuminosityBlock& iLumi, const edm::EventSetup& iSetup, const LuminosityBlockContext* iContext, hltJson::lumiVars* iSummary)
+{
+  Json::StyledWriter writer;
+
+  char hostname[33];
+  gethostname(hostname,32);
+  std::string sourceHost(hostname);
+
+  //Get the mon directory
+  std::string monPath = iSummary->baseRunDir + "/mon";
+
+  unsigned int iLs  = iLumi.luminosityBlock();
+  unsigned int iRun = iLumi.run();
+
+  Json::Value hltRates;
+  hltRates[DataPoint::SOURCE] = sourceHost;
+  hltRates[DataPoint::DEFINITION] = iSummary->jsonRateDefFile;
+
+  hltRates[DataPoint::DATA].append(iSummary->processed->toString());
+  hltRates[DataPoint::DATA].append(iSummary->hltWasRun->toString());
+  hltRates[DataPoint::DATA].append(iSummary->hltL1s   ->toString());
+  hltRates[DataPoint::DATA].append(iSummary->hltPre   ->toString());
+  hltRates[DataPoint::DATA].append(iSummary->hltAccept->toString());
+  hltRates[DataPoint::DATA].append(iSummary->hltReject->toString());
+  hltRates[DataPoint::DATA].append(iSummary->hltErrors->toString());
+
+  hltRates[DataPoint::DATA].append(iSummary->hltDatasets->toString());
+
+  std::string && result = writer.write(hltRates);
+
+  std::stringstream sjsnr;
+  sjsnr << monPath << "/run" << iRun << "_ls" << std::setfill('0') << std::setw(4) << iLs;
+  sjsnr << "_HLTRates_pid" << std::setfill('0') << std::setw(5) << getpid() << ".jsn";
+
+  std::ofstream outJsnFileR( sjsnr.str() );
+  outJsnFileR<<result;
+  outJsnFileR.close();
+
+  Json::Value hltNames;
+  hltNames[DataPoint::SOURCE] = sourceHost;
+  hltNames[DataPoint::DEFINITION] = iSummary->jsonLegendDefFile;
+
+  hltNames[DataPoint::DATA].append(iSummary->hltNames->toString());
+  hltNames[DataPoint::DATA].append(iSummary->datasetNames->toString());
+
+  result = writer.write(hltNames);
+
+  std::stringstream sjsnl;
+  sjsnl << monPath << "/run" << iRun << "_ls" << std::setfill('0') << std::setw(4) << iLs;
+  sjsnl << "_HLTRatesLegend_pid" << std::setfill('0') << std::setw(5) << getpid() << ".jsn";
+
+  std::ofstream outJsnFileL( sjsnl.str() );
+  outJsnFileL<<result;
+  outJsnFileL.close();
+  
+  //Delete the individual HistoJ pointers
+  delete iSummary->processed;
+
+  delete iSummary->hltWasRun;
+  delete iSummary->hltL1s   ;
+  delete iSummary->hltPre   ;
+  delete iSummary->hltAccept;
+  delete iSummary->hltReject;
+  delete iSummary->hltErrors;
+
+  delete iSummary->hltDatasets;
+  
+  delete iSummary->hltNames;    
+  delete iSummary->datasetNames;
+
+  //Note: Do not delete the iSummary pointer. The framework does something with it later on
+  //      and deleting it results in a segmentation fault.
+
+}//End globalEndLuminosityBlockSummary function
 
 
 void 
-TriggerJSONMonitoring::beginRun(edm::Run const& iRun, edm::EventSetup const& iSetup)
-{
+TriggerJSONMonitoring::writeDefJson(std::string path){
 
-   //Get the run directory from the EvFDaqDirector
-   baseRunDir = edm::Service<evf::EvFDaqDirector>()->baseRunDir();
-  
-   // initialize hltConfig_
-   bool changed = true;
-   if (hltConfig_.init(iRun, iSetup, triggerResults_.process(), changed)) {
-     reset(true);
-   }
-
-   // set up JSON
-   processed_.setName("Processed");
-
-   DataPointDefinition outJsonTemp_;
-
-   outJsonTemp_.setDefaultGroup("data");
-   outJsonTemp_.addLegendItem("Processed","integer",DataPointDefinition::SUM);
-
-   const unsigned int n = hltNames_.size();
-
-   for(unsigned int i =0; i<n; i++){
-     hltPaths_[i].setName( hltNames_[i] );
-     outJsonTemp_.addLegendItem(hltNames_[i],"integer",DataPointDefinition::SUM);
-   }
-
-   outJson_ = outJsonTemp_;
-
-   // create JSON definition file
-   unsigned int nRun = iRun.run();
-
-   std::stringstream sjsd;
-   sjsd << baseRunDir << "/mon/HLTRates_run"<< nRun; 
-   sjsd << "_pid" << std::setfill('0') << std::setw(5) << getpid() << ".jsd";
-   jsonDefinitionFile = sjsd.str();
-   
-   std::ofstream outfile( jsonDefinitionFile );
+   std::ofstream outfile( path );
    outfile << "{" << std::endl;
    outfile << "   \"data\" : [" << std::endl;
-   outfile << "      {" << std::endl;
-   outfile << "         \"name\" : \"Processed\"," << std::endl;
-   outfile << "         \"operation\" : \"sum\"," << std::endl;
-   outfile << "         \"type\" : \"integer\"" << std::endl;
+   outfile << "      {" ;
+   outfile << " \"name\" : \"Processed\"," ;  //***
+   outfile << " type = \"integer\"," ;
+   outfile << " \"operation\" : \"sum\"}," << std::endl;
+
+   outfile << "      {" ;
+   outfile << " \"name\" : \"Path-WasRun\"," ;
+   outfile << " type = \"integer\"," ;
+   outfile << " \"operation\" : \"sum\"}," << std::endl;
+
+   outfile << "      {" ;
+   outfile << " \"name\" : \"Path-AfterL1Seed\"," ;
+   outfile << " type = \"integer\"," ;
+   outfile << " \"operation\" : \"sum\"}," << std::endl;
+
+   outfile << "      {" ;
+   outfile << " \"name\" : \"Path-AfterPrescale\"," ;
+   outfile << " type = \"integer\"," ;
+   outfile << " \"operation\" : \"sum\"}," << std::endl;
+
+   outfile << "      {" ;
+   outfile << " \"name\" : \"Path-Accepted\"," ;
+   outfile << " type = \"integer\"," ;
+   outfile << " \"operation\" : \"sum\"}," << std::endl;
+ 
+   outfile << "      {" ;
+   outfile << " \"name\" : \"Path-Rejected\"," ;
+   outfile << " type = \"integer\"," ;
+   outfile << " \"operation\" : \"sum\"}," << std::endl;
+
+   outfile << "      {" ;
+   outfile << " \"name\" : \"Path-Errors\"," ;
+   outfile << " type = \"integer\"," ;
+   outfile << " \"operation\" : \"sum\"}," << std::endl;
+
+   outfile << "      {" ;
+   outfile << " \"name\" : \"Dataset-Accepted\"," ;
+   outfile << " type = \"integer\"," ;
+   outfile << " \"operation\" : \"sum\"}" << std::endl;
    
-   for(unsigned int j =0; j<n; j++){
-     outfile << "      }," << std::endl;
-     outfile << "      {" << std::endl;
-     outfile << "         \"name\" : \"" << hltNames_[j] << "\"," << std::endl;
-     outfile << "         \"operation\" : \"sum\"," << std::endl;
-     outfile << "         \"type\" : \"integer\"" << std::endl;
-   } 
-   
-   outfile << "      }" << std::endl;
    outfile << "   ]" << std::endl;
    outfile << "}" << std::endl;
    
-   outfile.close();
-
-   //std::cout << "CurrentRunDir is " << RunDir << std::endl;  //***
-}
+   outfile.close(); 
+}//End writeDefJson function
 
 void 
-TriggerJSONMonitoring::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
-{
+TriggerJSONMonitoring::writeDefLegJson(std::string path){
 
-  std::string outJsonDefName = jsonDefinitionFile;
+   std::ofstream legfile(path);
+   legfile << "{" << std::endl;
+   legfile << "   \"data\" : [" << std::endl;
+   legfile << "      {" ;
+   legfile << " \"name\" : \"Path-Names\"," ;
+   legfile << " type = \"string\"," ;
+   legfile << " \"operation\" : \"cat\"}," << std::endl;
 
-  jsonMonitor_.reset(new jsoncollector::FastMonitor(&outJson_, false));
-  jsonMonitor_->setDefPath(outJsonDefName);
-  jsonMonitor_->registerGlobalMonitorable(&processed_,false);
-
-  for(unsigned int i = 0; i < hltPaths_.size(); i++){
-    jsonMonitor_->registerGlobalMonitorable(&hltPaths_[i], false);
-  }
-
-  jsonMonitor_->commit(nullptr);
-
-  reset();
-}
-
-void 
-TriggerJSONMonitoring::endLuminosityBlock(edm::LuminosityBlock const& ls, edm::EventSetup const&)
-{
-
-  unsigned int uiLS  = ls.luminosityBlock();
-  unsigned int uiRun = ls.run();
-
-  jsonMonitor_->snap(uiLS);
-
-  std::stringstream ss;
-  ss << baseRunDir << "/mon/" << "HLTRates";
-  ss << "_run" << uiRun << "_ls" << std::setfill('0') << std::setw(4) << uiLS;
-  ss << "_pid" << std::setfill('0') << std::setw(5) << getpid() << ".jsn";
-  std::string outputJsonNameStream = ss.str();
-  
-  jsonMonitor_->outputFullJSON(outputJsonNameStream, uiLS);
-
-  // Debug output
-  LogDebug("TriggerJSONMonitoring") << "i hltNames #Accepted" << std::endl;
-  const unsigned int size = hltNames_.size();
-  for (unsigned int i = 0; i < size; i++) {
-    LogDebug("TriggerJSONMonitoring") << i                    << " "
-				      << hltNames_[i]         << " "
-				      << hltPaths_[i].value() << std::endl;
-  }
-
-}
+   legfile << "      {" ;
+   legfile << " \"name\" : \"Dataset-Names\"," ;
+   legfile << " type = \"string\"," ;
+   legfile << " \"operation\" : \"cat\"}" << std::endl;
+   legfile << "   ]" << std::endl;
+   legfile << "}" << std::endl;
+   legfile.close();
+}//End writeDefLegJson function


### PR DESCRIPTION
This version of the JSON monitoring switches to edm::stream::EDAnalyzer and changes the structure written to JSON files to HistoJ per suggestions from the DAQ group. In addition to monitoring HLT accepts by path and processed events, it now also monitors L1 seed accepts, prescale accepts, rejects and errors by path as well as accepts by primary dataset.

Because the changes made by this module require corresponding changes in DAQ tools (hltd and Elastic Search), DAQ experts request that if possible, this change should go into a patch release on Monday or Tuesday rather than straight into the release used for MWGR8.
