### PR TITLE
condformats_serialization_generate.py: fix libClang ussage

### DIFF
--- a/CondFormats/Serialization/python/condformats_serialization_generate.py
+++ b/CondFormats/Serialization/python/condformats_serialization_generate.py
@@ -431,7 +431,7 @@ class SerializationCodeGenerator(object):
         log_flags('cxx_flags', cxx_flags)
         log_flags('std_flags', std_flags)
 
-        flags = cpp_flags + cxx_flags + std_flags
+        flags = ['-xc++'] + cpp_flags + cxx_flags + std_flags
 
         headers_h = self._join_package_path('src', 'headers.h')
         logging.debug('headers_h = %s', headers_h)
@@ -442,7 +442,7 @@ class SerializationCodeGenerator(object):
 
         logging.debug('Parsing C++ classes in file %s ...', headers_h)
         index = clang.cindex.Index.create()
-        translation_unit = index.parse(None, [headers_h] + flags)
+        translation_unit = index.parse(headers_h, flags)
         if not translation_unit:
             raise Exception('Unable to load input.')
 


### PR DESCRIPTION
libClang is being used incorrectly. libClang does not understand what
language you are attemping to compile, it assumes C/ObjC as default.

This comes from headers.h name. Clang relies on correct extension to
select a language, but it cannot be done with header file. Same
extension is used for ObjC/C/C++.

The first argument must not be none, but a patch to header file.
An additional option must be passed '-xc++' to tell Clang that
it will be C++.

If the header file is passed as argument to libClang then the order of
arguments is important! Otherwise libClang will ignore flags like -xc++,
and go for the default.

This behaviors are documented in Clang source code.

Because of this on Darwin C++ exception handling is disabled, there is
not need for in C front-end. Simply put you loose all default C++
language options.

This resolves majority of ERROR: messages from
condformats_serialization_generate.py

A few a left, but are the same as in CLANG IBs. More people should join
the effort to clean it up. There is <10 such issues, I might fix them. For 
yet unknown reason their are not visible on standard CMSSW IB on Linux,
just on CLANG.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
