### PR TITLE
Changed global array of const char* so addresses can not be changed

### DIFF
--- a/SimTracker/TrackHistory/interface/TrackCategories.h
+++ b/SimTracker/TrackHistory/interface/TrackCategories.h
@@ -67,7 +67,7 @@ public:
     };
 
     //! Name of the different categories
-    static const char * Names[];
+    static const char * const Names[];
 
     //! Main types associated to the class
     typedef std::vector<bool> Flags;

--- a/SimTracker/TrackHistory/interface/VertexCategories.h
+++ b/SimTracker/TrackHistory/interface/VertexCategories.h
@@ -52,7 +52,7 @@ public:
     };
 
     //! Name of the different categories
-    static const char * Names[];
+    static const char * const Names[];
 
     //! Main types associated to the class
     typedef std::vector<bool> Flags;

--- a/SimTracker/TrackHistory/src/TrackCategories.cc
+++ b/SimTracker/TrackHistory/src/TrackCategories.cc
@@ -3,7 +3,7 @@
 
 #include "SimTracker/TrackHistory/interface/TrackCategories.h"
 
-const char * TrackCategories::Names[] =
+const char * const TrackCategories::Names[] =
 {
     "Fake",
     "Bad",

--- a/SimTracker/TrackHistory/src/VertexCategories.cc
+++ b/SimTracker/TrackHistory/src/VertexCategories.cc
@@ -3,7 +3,7 @@
 
 #include "SimTracker/TrackHistory/interface/VertexCategories.h"
 
-const char * VertexCategories::Names[] =
+const char * const VertexCategories::Names[] =
 {
     "Fake",
     "SignalEvent",


### PR DESCRIPTION
Changed arrays from 'const char\* []' to 'const char\* const []'. This
way the pointers in the array can not be changed to point to a new
non-mutable character array.
This fixes a thread safety complaint from the static analyzer.
