### PR TITLE
change comments in Geometry/CaloEventSetup/test

### DIFF
--- a/Geometry/CaloEventSetup/test/ali2Screen_cfg.py
+++ b/Geometry/CaloEventSetup/test/ali2Screen_cfg.py
@@ -15,7 +15,8 @@ process.CaloAlignmentRcdRead = cms.EDAnalyzer("CaloAlignmentRcdRead")
 
 ##
 ## Please, rebuild the test with debug enabled
-## scram b USER_CXXFLAGS="-g\ -D=EDM_ML_DEBUG"
+## USER_CXXFLAGS="-g -D=EDM_ML_DEBUG" scram b -v # for bash
+## env USER_CXXFLAGS="-g -D=EDM_ML_DEBUG" scram b -v # for tcsh
 ##
 process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.cerr.threshold = cms.untracked.string('DEBUG')

--- a/Geometry/CaloEventSetup/test/aliFile2Screen_cfg.py
+++ b/Geometry/CaloEventSetup/test/aliFile2Screen_cfg.py
@@ -30,7 +30,8 @@ process.PoolDBESSource = cms.ESSource("PoolDBESSource",
 
 ##
 ## Please, rebuild the test with debug enabled
-## scram b USER_CXXFLAGS="-g\ -D=EDM_ML_DEBUG"
+## USER_CXXFLAGS="-g -D=EDM_ML_DEBUG" scram b -v # for bash
+## env USER_CXXFLAGS="-g -D=EDM_ML_DEBUG" scram b -v # for tcsh
 ##
 process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.cerr.threshold = cms.untracked.string('DEBUG')


### PR DESCRIPTION
This PR updates example scram options to enable LogDebug in comment lines in two python files in Geometry/CaloEventSetup/test as the old example no longer works in recent versions of scram as suggested in a HN post at: https://hypernews.cern.ch/HyperNews/CMS/get/edmFramework/3373/1.html.
