### PR TITLE
Small update of FastPV sequence

### DIFF
--- a/RecoPixelVertexing/PixelVertexFinding/src/FastPrimaryVertexWithWeightsProducer.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/src/FastPrimaryVertexWithWeightsProducer.cc
@@ -117,6 +117,10 @@ class FastPrimaryVertexWithWeightsProducer : public edm::EDProducer {
   double m_zClusterWidth_step3; 	// cluster width in step3
   double m_zClusterSearchArea_step3;	// cluster width in step3
   double m_weightCut_step3; 		// minimum z-projections weight required in step3
+
+  // use the jetPt weighting
+  bool m_ptWeighting;
+  double m_ptWeighting_parameter;	// parameter used in the pt-reweighting: weight=weight*(pt-ptWeighting_parameter)/(40-ptWeighting_parameter);
   
 };
 
@@ -167,6 +171,9 @@ FastPrimaryVertexWithWeightsProducer::FastPrimaryVertexWithWeightsProducer(const
   m_zClusterSearchArea_step3    = iConfig.getParameter<double>("zClusterSearchArea_step3");
   m_weightCut_step3      	= iConfig.getParameter<double>("weightCut_step3");
 
+  m_ptWeighting		      	= iConfig.getParameter<bool>("ptWeighting");
+  m_ptWeighting_parameter	= iConfig.getParameter<double>("ptWeighting_parameter");
+
   produces<reco::VertexCollection>();
   produces<float>();
 
@@ -210,6 +217,8 @@ FastPrimaryVertexWithWeightsProducer::fillDescriptions(edm::ConfigurationDescrip
   desc.add<double>("zClusterWidth_step3",0.3);
   desc.add<double>("zClusterSearchArea_step3",0.55);
   desc.add<double>("weightCut_step3",0.1);
+  desc.add<bool>("ptWeighting",false); // <---- newMethod 
+  desc.add<double>("ptWeighting_parameter",20);
   descriptions.add("fastPrimaryVertexWithWeightsProducer",desc);
 }
 
@@ -360,6 +369,7 @@ FastPrimaryVertexWithWeightsProducer::produce(edm::Event& iEvent, const edm::Eve
 	        	//calculate the final weight
 			weight=	 m_EC_weight*(weight_dPhi) ;    	        
 	        }
+		if(m_ptWeighting)	weight=weight*(pt-m_ptWeighting_parameter)/(40-m_ptWeighting_parameter); // a jetPt=40 doesn't change weight
 	        zWeights.push_back(weight); //add the weight to zWeights
 	      }	
   	    }//if it pass DeltaPhi(Jet,Cluster) requirements

--- a/RecoPixelVertexing/PixelVertexFinding/src/FastPrimaryVertexWithWeightsProducer.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/src/FastPrimaryVertexWithWeightsProducer.cc
@@ -285,7 +285,7 @@ FastPrimaryVertexWithWeightsProducer::produce(edm::Event& iEvent, const edm::Eve
      float pt=(*jit)->pt();
      float eta=(*jit)->eta();
      float jetZOverRho = (*jit)->momentum().Z()/(*jit)->momentum().Rho();
-     float pt_weigth= pt*m_ptWeighting_slope +m_ptWeighting_offset;
+     float pt_weight= pt*m_ptWeighting_slope +m_ptWeighting_offset;
      for(SiPixelClusterCollectionNew::const_iterator it = pixelClusters.begin() ; it != pixelClusters.end() ; it++) //Loop on pixel modules with clusters
      {//loop on pixel modules
         DetId id = it->detId();
@@ -372,7 +372,7 @@ FastPrimaryVertexWithWeightsProducer::produce(edm::Event& iEvent, const edm::Eve
 	        	//calculate the final weight
 			weight=	 m_EC_weight*(weight_dPhi) ;    	        
 	        }
-		   if(m_ptWeighting)	weight=weight*pt_weigth; 
+		   if(m_ptWeighting)	weight=weight*pt_weight; 
 	        zWeights.push_back(weight); //add the weight to zWeights
 	      }	
   	    }//if it pass DeltaPhi(Jet,Cluster) requirements

--- a/RecoPixelVertexing/PixelVertexFinding/src/JetVertexChecker.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/src/JetVertexChecker.cc
@@ -129,7 +129,7 @@ JetVertexChecker::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
    //limit to first two jets
    for(reco::JetTracksAssociationCollection::const_iterator it = jetTracksAssociation->begin();
        it != jetTracksAssociation->end() && i < m_maxNjets; it++, i++) {
-     if(fabs(it->first->eta()) < 2.4)
+     if(std::abs(it->first->eta()) < 2.4)
      {
       reco::TrackRefVector tracks = it->second;
       math::XYZVector jetMomentum = it->first->momentum();
@@ -137,10 +137,10 @@ JetVertexChecker::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
       for(reco::TrackRefVector::const_iterator itTrack = tracks.begin(); itTrack != tracks.end(); ++itTrack) 
       {
          const reco::Track& iTrack = **itTrack;
-	     if(m_newMethod && (iTrack).chi2()>m_maxChi2) continue;
-             trMomentum += (iTrack).momentum();
-	     if(m_newMethod) trkpt += std::min(m_maxTrackPt,( (iTrack).pt()));
-	     else trkpt += (iTrack).momentum().rho();
+	     if(m_newMethod && iTrack.chi2()>m_maxChi2) continue;
+             trMomentum += iTrack.momentum();
+	     if(m_newMethod) trkpt += std::min(m_maxTrackPt,( iTrack.pt()));
+	     else trkpt += iTrack.pt();
       }
       calopt += jetMomentum.rho();
       if(trMomentum.rho()/jetMomentum.rho() < m_cutMinPtRatio || trMomentum.rho() < m_cutMinPt) 
@@ -157,7 +157,7 @@ JetVertexChecker::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
 	   if(trkpt/calopt < m_cutMinPtRatio) result=false;   
 	   for(reco::JetTracksAssociationCollection::const_iterator it = jetTracksAssociation->begin(); it != jetTracksAssociation->end() && i < m_maxNjetsOutput; it++, i++)
 	   {
-	     if(!result && fabs(it->first->eta()) < 2.4)
+	     if(!result && std::abs(it->first->eta()) < 2.4)
 	     {
 		pOut->push_back(* dynamic_cast<const reco::CaloJet *>(&(*it->first)));
 	     }

--- a/RecoPixelVertexing/PixelVertexFinding/src/JetVertexChecker.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/src/JetVertexChecker.cc
@@ -96,7 +96,6 @@ JetVertexChecker::JetVertexChecker(const edm::ParameterSet& iConfig)
   m_maxChi2           = iConfig.getParameter<double>("maxChi2");
   produces<std::vector<reco::CaloJet> >(); 
   produces<reco::VertexCollection >(); 
-  produces<float >(); 
 }
 
 
@@ -149,22 +148,6 @@ JetVertexChecker::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
       }
      }
     }
-   if(m_newMethod)
-   {
-	   pOut->clear();
-	   result=true;
-	   i=0;
-	   if(trkpt/calopt < m_cutMinPtRatio) result=false;   
-	   for(reco::JetTracksAssociationCollection::const_iterator it = jetTracksAssociation->begin(); it != jetTracksAssociation->end() && i < m_maxNjetsOutput; it++, i++)
-	   {
-	     if(!result && std::abs(it->first->eta()) < 2.4)
-	     {
-		pOut->push_back(* dynamic_cast<const reco::CaloJet *>(&(*it->first)));
-	     }
-	    } 
-   }
-    
-  
    iEvent.put(pOut);
 
    edm::Handle<reco::BeamSpot> beamSpot;
@@ -180,12 +163,6 @@ JetVertexChecker::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
    pOut2->push_back(thePV);
    iEvent.put(pOut2);
 
-   std::auto_ptr<float> pOut3(new float);
-   *pOut3=(calopt>0.0?trkpt/calopt:0);
-
-   iEvent.put(pOut3);
-
-//   std::cout << " filter " << result << std::endl;
    if(m_doFilter) return result;
    else 
    return true;


### PR DESCRIPTION
Small updates of the FastPrimaryVertex code and JetVertexChecker, presented at TSG meeting:
https://indico.cern.ch/event/338610/contribution/1/1/material/slides/0.pdf

In both Producer is possible to maintaing the "old" method, with the options:
- "newMethod" in JetVertexChecker
-  "m_ptWeighting" in FastPrimaryVertexWithWeightsProducer
