### PR TITLE
Speedup Hit-in-Track, HitPattern and MultiTrackSelector

### DIFF
--- a/Alignment/CommonAlignmentMonitor/plugins/AlignmentStats.cc
+++ b/Alignment/CommonAlignmentMonitor/plugins/AlignmentStats.cc
@@ -147,7 +147,7 @@ void AlignmentStats::analyze(const edm::Event &iEvent, const edm::EventSetup &iS
     //std::cout << "   loop on hits of track #" << (itt - tracks->begin()) << std::endl;
     for (trackingRecHit_iterator ith = ittrk->recHitsBegin(), edh = ittrk->recHitsEnd(); ith != edh; ++ith) {
 
-      const TrackingRecHit *hit = ith->get(); // ith is an iterator on edm::Ref to rechit
+      const TrackingRecHit *hit = *ith; // ith is an iterator on edm::Ref to rechit
       if(! hit->isValid())continue;
       DetId detid = hit->geographicalId();
       int subDet = detid.subdetId();

--- a/Alignment/CommonAlignmentProducer/src/AlignmentTrackSelector.cc
+++ b/Alignment/CommonAlignmentProducer/src/AlignmentTrackSelector.cc
@@ -379,7 +379,7 @@ bool AlignmentTrackSelector::detailedHitsCheck(const reco::Track *trackp, const 
                                           << "DetId.det() != DetId::Tracker (=" << DetId::Tracker
                                           << "), but " << detId.det() << ".";
       }
-      const TrackingRecHit* therechit = (*iHit).get();
+      const TrackingRecHit* therechit = (*iHit);
       if (chargeCheck_ && !(this->isOkCharge(therechit))) return false;
       if (applyIsolation_ && (!this->isIsolated(therechit, evt))) return false;
       if      (SiStripDetId::TIB == subdetId) ++nhitinTIB;
@@ -695,7 +695,7 @@ AlignmentTrackSelector::checkPrescaledHits(const Tracks& tracks, const edm::Even
     //    float pt=trackp->pt();
 
     for (trackingRecHit_iterator ith = trackp->recHitsBegin(), edh = trackp->recHitsEnd(); ith != edh; ++ith) {
-      const TrackingRecHit *hit = ith->get(); // ith is an iterator on edm::Ref to rechit
+      const TrackingRecHit *hit = (*ith); // ith is an iterator on edm::Ref to rechit
       if(! hit->isValid())continue;
       DetId detid = hit->geographicalId();
       int subDet = detid.subdetId();

--- a/Alignment/TrackerAlignment/plugins/AlignmentPrescaler.cc
+++ b/Alignment/TrackerAlignment/plugins/AlignmentPrescaler.cc
@@ -99,7 +99,7 @@ void AlignmentPrescaler::produce(edm::Event &iEvent, const edm::EventSetup &iSet
     bool firstTakenHit=false;
 
     for (trackingRecHit_iterator ith = ittrk->recHitsBegin(), edh = ittrk->recHitsEnd(); ith != edh; ++ith) {
-      const TrackingRecHit *hit = ith->get(); // ith is an iterator on edm::Ref to rechit
+      const TrackingRecHit *hit = *ith; // ith is an iterator on edm::Ref to rechit
       if(! hit->isValid()){
        	nhit++;
 	continue;

--- a/AnalysisAlgos/TrackInfoProducer/src/TrackInfoProducerAlgorithm.cc
+++ b/AnalysisAlgos/TrackInfoProducer/src/TrackInfoProducerAlgorithm.cc
@@ -38,7 +38,8 @@ void TrackInfoProducerAlgorithm::run(const edm::Ref<std::vector<Trajectory> > tr
       unsigned int detid=ttrh->hit()->geographicalId().rawId();
       
       trackingRecHit_iterator thehit;
-      TrackingRecHitRef thehitref;
+      TrackingRecHitRef thehitref; // needs to be keyed; as is is broken
+      TrackingRecHit const * thehitptr=nullptr;
       int i=0,j=0;
 
       for (thehit=track->recHitsBegin();thehit!=track->recHitsEnd();thehit++){
@@ -48,7 +49,7 @@ void TrackInfoProducerAlgorithm::run(const edm::Ref<std::vector<Trajectory> > tr
 	if((*thehit)->geographicalId().rawId()==detid&&
 	   (hitpos - pos).mag() < 1e-4)
 	  {
-	    thehitref=(*thehit);
+	    thehitptr=(*thehit);
 	    j++;
 	    break;
 	  }
@@ -60,8 +61,8 @@ void TrackInfoProducerAlgorithm::run(const edm::Ref<std::vector<Trajectory> > tr
       PTrajectoryStateOnDet const &  combinedptsod=trajectoryStateTransform::persistentState( combinedtsos,detid);
       
 
-      const ProjectedSiStripRecHit2D* phit=dynamic_cast<const ProjectedSiStripRecHit2D*>( &*(thehitref));
-      const SiStripMatchedRecHit2D* matchedhit=dynamic_cast<const SiStripMatchedRecHit2D*>( &*(thehitref));
+      const ProjectedSiStripRecHit2D* phit=dynamic_cast<const ProjectedSiStripRecHit2D*>( thehitptr);
+      const SiStripMatchedRecHit2D* matchedhit=dynamic_cast<const SiStripMatchedRecHit2D*>( thehitptr);
 
       RecHitType type=Single;
       LocalVector monofwd, stereofwd;

--- a/AnalysisAlgos/TrackInfoProducer/src/TrackInfoProducerAlgorithm.cc
+++ b/AnalysisAlgos/TrackInfoProducer/src/TrackInfoProducerAlgorithm.cc
@@ -38,7 +38,7 @@ void TrackInfoProducerAlgorithm::run(const edm::Ref<std::vector<Trajectory> > tr
       unsigned int detid=ttrh->hit()->geographicalId().rawId();
       
       trackingRecHit_iterator thehit;
-      TrackingRecHitRef thehitref; // needs to be keyed; as is is broken
+      TrackingRecHitRef thehitref;
       TrackingRecHit const * thehitptr=nullptr;
       int i=0,j=0;
 
@@ -50,6 +50,7 @@ void TrackInfoProducerAlgorithm::run(const edm::Ref<std::vector<Trajectory> > tr
 	   (hitpos - pos).mag() < 1e-4)
 	  {
 	    thehitptr=(*thehit);
+            thehitref = track->extra()->recHitRef(i-1);
 	    j++;
 	    break;
 	  }

--- a/Calibration/TkAlCaRecoProducers/src/CalibrationTrackSelector.cc
+++ b/Calibration/TkAlCaRecoProducers/src/CalibrationTrackSelector.cc
@@ -197,7 +197,7 @@ bool CalibrationTrackSelector::detailedHitsCheck(const reco::Track *trackp, cons
                                           << "DetId.det() != DetId::Tracker (=" << DetId::Tracker
                                           << "), but " << detId.det() << ".";
       }
-      const TrackingRecHit* therechit = (*iHit).get();
+      const TrackingRecHit* therechit = (*iHit);
       if (chargeCheck_ && !(this->isOkCharge(therechit))) return false;
       if (applyIsolation_ && (!this->isIsolated(therechit, evt))) return false;
       if      (StripSubdetector::TIB == detId.subdetId()) ++nhitinTIB;
@@ -253,7 +253,6 @@ bool CalibrationTrackSelector::isHit2D(const TrackingRecHit &hit) const
 
 bool CalibrationTrackSelector::isOkCharge(const TrackingRecHit* therechit) const
 {
-  // const TrackingRecHit* therechit = hit.get();
   float charge1 = 0;
   float charge2 = 0;
   const SiStripMatchedRecHit2D* matchedhit = dynamic_cast<const SiStripMatchedRecHit2D*>(therechit);

--- a/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
+++ b/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
@@ -631,7 +631,7 @@ void SiStripMonitorTrack::trackStudyFromTrack(edm::Handle<reco::TrackCollection 
       if (!(*hit)->isValid()) continue;
       DetId detID = (*hit)->geographicalId();
       if (detID.det() != DetId::Tracker) continue;
-      const TrackingRecHit* theHit = (*hit).get();
+      const TrackingRecHit* theHit = (*hit);
       const ProjectedSiStripRecHit2D* projhit    = dynamic_cast<const ProjectedSiStripRecHit2D*>( (theHit) );
       const SiStripMatchedRecHit2D*   matchedhit = dynamic_cast<const SiStripMatchedRecHit2D*>  ( (theHit) );
       const SiStripRecHit2D*          hit2D      = dynamic_cast<const SiStripRecHit2D*>         ( (theHit) );

--- a/DQMOffline/Alignment/src/TkAlCaRecoMonitor.cc
+++ b/DQMOffline/Alignment/src/TkAlCaRecoMonitor.cc
@@ -290,7 +290,7 @@ void TkAlCaRecoMonitor::fillHitmaps(const reco::Track &track, const TrackerGeome
 {
   for (trackingRecHit_iterator iHit = track.recHitsBegin(); iHit != track.recHitsEnd(); ++iHit) {    
     if( (*iHit)->isValid() ){
-      const TrackingRecHit *hit = (*iHit).get();
+      const TrackingRecHit *hit = (*iHit);
       const DetId geoId(hit->geographicalId());
       const GeomDet* gd = geometry.idToDet(geoId);
       // since 2_1_X local hit positions are transient. taking center of the hit module for now.

--- a/DQMOffline/JetMET/src/BeamHaloAnalyzer.cc
+++ b/DQMOffline/JetMET/src/BeamHaloAnalyzer.cc
@@ -346,9 +346,9 @@ void BeamHaloAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& 
 	  float innermost_x =0.;
 	  float innermost_y =0.;
 	  float innermost_r =0.;
-	  for(unsigned int j = 0 ; j < Track->extra()->recHits().size(); j++ )
+	  for(unsigned int j = 0 ; j < Track->extra()->recHitsSize(); j++ )
 	    {
-	      edm::Ref<TrackingRecHitCollection> hit( Track->extra()->recHits(), j );
+	      auto hit = Track->extra()->recHitRef(j);
 	      DetId TheDetUnitId(hit->geographicalId());
 	      if( TheDetUnitId.det() != DetId::Muon ) continue;
 	      if( TheDetUnitId.subdetId() != MuonSubdetId::CSC ) continue;

--- a/DataFormats/CSCRecHit/test/CSCSharesInputTest.cc
+++ b/DataFormats/CSCRecHit/test/CSCSharesInputTest.cc
@@ -73,7 +73,7 @@ void CSCSharesInputTest::analyze(const edm::Event &myEvent, const edm::EventSetu
 			float perRecHitData[7] = {0,0,0,0,0,0,0};
 			
 			// Kill us quickly if this is not a CSCRecHit.  Also allows us to use the CSCRecHit version of sharesInput, which we like.
-			const CSCRecHit2D *myHit = dynamic_cast<const CSCRecHit2D *>((*jHit).get());
+			const CSCRecHit2D *myHit = dynamic_cast<const CSCRecHit2D *>((*jHit));
 			if (myHit == 0) {
 				++counts_["NotMatchedRecHits"];
 				++perEventData[9];

--- a/DataFormats/Common/interface/OwnVector.h
+++ b/DataFormats/Common/interface/OwnVector.h
@@ -23,7 +23,7 @@ namespace edm {
   class ProductID;
   template <typename T, typename P = ClonePolicy<T> >
   class OwnVector {
-  private:
+  public:
 #if defined(CMS_USE_DEBUGGING_ALLOCATOR)
     typedef std::vector<T*, debugging_allocator<T> > base;
 #else

--- a/DataFormats/Common/interface/RefVectorIterator.h
+++ b/DataFormats/Common/interface/RefVectorIterator.h
@@ -61,6 +61,8 @@ namespace edm {
     bool operator<=(iterator const& rhs) const {return this->iter_ <= rhs.iter_;}
     bool operator>=(iterator const& rhs) const {return this->iter_ >= rhs.iter_;}
 
+    key_type  key() const { return *iter_;}
+
   private:
     RefCore product_;
     keyIter iter_;

--- a/DataFormats/TrackReco/interface/HitPattern.h
+++ b/DataFormats/TrackReco/interface/HitPattern.h
@@ -287,6 +287,7 @@ public:
 
     int trackerLayersWithMeasurementOld() const;        // case 0: tracker
     int trackerLayersWithMeasurement() const;        // case 0: tracker
+    int pixelLayersWithMeasurementOld() const;          // case 0: pixel  
     int pixelLayersWithMeasurement() const;          // case 0: pixel
     int stripLayersWithMeasurement() const;          // case 0: strip
     int pixelBarrelLayersWithMeasurement() const;    // case 0: pixel PXB
@@ -910,7 +911,7 @@ inline int HitPattern::trackerLayersWithMeasurementOld() const
     return pixelLayersWithMeasurement() + stripLayersWithMeasurement();
 }
 
-inline int HitPattern::pixelLayersWithMeasurement() const
+inline int HitPattern::pixelLayersWithMeasurementOld() const
 {
     return pixelBarrelLayersWithMeasurement() + pixelEndcapLayersWithMeasurement();
 }

--- a/DataFormats/TrackReco/interface/HitPattern.h
+++ b/DataFormats/TrackReco/interface/HitPattern.h
@@ -297,6 +297,7 @@ public:
     int stripTECLayersWithMeasurement() const;       // case 0: strip TEC
 
     int trackerLayersWithoutMeasurement(HitCategory category) const;     // case 1: tracker
+    int trackerLayersWithoutMeasurementOld(HitCategory category) const;     // case 1: tracker 
     int pixelLayersWithoutMeasurement(HitCategory category) const;       // case 1: pixel
     int stripLayersWithoutMeasurement(HitCategory category) const;       // case 1: strip
     int pixelBarrelLayersWithoutMeasurement(HitCategory category) const; // case 1: pixel PXB
@@ -920,7 +921,7 @@ inline int HitPattern::stripLayersWithMeasurement() const
            stripTOBLayersWithMeasurement() + stripTECLayersWithMeasurement();
 }
 
-inline int HitPattern::trackerLayersWithoutMeasurement(HitCategory category) const
+inline int HitPattern::trackerLayersWithoutMeasurementOld(HitCategory category) const
 {
     return pixelLayersWithoutMeasurement(category) +
            stripLayersWithoutMeasurement(category);

--- a/DataFormats/TrackReco/interface/HitPattern.h
+++ b/DataFormats/TrackReco/interface/HitPattern.h
@@ -382,6 +382,11 @@ private:
     const static unsigned short SubDetectorOffset = 10;
     const static unsigned short SubDetectorMask = 0x1;
 
+    const static unsigned short minTrackerWord = 1<< SubDetectorOffset;
+    const static unsigned short minPixelWord = minTrackerWord |  (1<<SubstrOffset);
+    const static unsigned short minStripWord = minTrackerWord |  (3<<SubstrOffset);
+
+
     // detector side for tracker modules (mono/stereo)
     static uint16_t isStereo(DetId i);
     static bool stripSubdetectorHitFilter(uint16_t pattern, StripSubdetector::SubDetector substructure);
@@ -527,16 +532,9 @@ inline bool HitPattern::pixelEndcapHitFilter(uint16_t pattern)
 
 inline bool HitPattern::stripHitFilter(uint16_t pattern)
 {
-    if unlikely(!trackerHitFilter(pattern)) {
-        return false;
-    }
-
-    uint32_t substructure = getSubStructure(pattern);
-    return (substructure == StripSubdetector::TIB ||
-            substructure == StripSubdetector::TID ||
-            substructure == StripSubdetector::TOB ||
-            substructure == StripSubdetector::TEC);
+    return pattern > minStripWord;
 }
+
 
 inline bool HitPattern::stripSubdetectorHitFilter(uint16_t pattern, StripSubdetector::SubDetector substructure)
 {
@@ -599,11 +597,7 @@ inline bool HitPattern::muonRPCHitFilter(uint16_t pattern)
 
 inline bool HitPattern::trackerHitFilter(uint16_t pattern)
 {
-    if unlikely(pattern == HitPattern::EMPTY_PATTERN) {
-        return false;
-    }
-
-    return (((pattern >> SubDetectorOffset) & SubDetectorMask) == 1);
+  return pattern > minTrackerWord;
 }
 
 inline bool HitPattern::muonHitFilter(uint16_t pattern)

--- a/DataFormats/TrackReco/interface/HitPattern.h
+++ b/DataFormats/TrackReco/interface/HitPattern.h
@@ -285,6 +285,7 @@ public:
     uint32_t getTrackerLayerCase(HitCategory category, uint16_t substr, uint16_t layer) const;
     uint16_t getTrackerMonoStereo(HitCategory category, uint16_t substr, uint16_t layer) const;
 
+    int trackerLayersWithMeasurementOld() const;        // case 0: tracker
     int trackerLayersWithMeasurement() const;        // case 0: tracker
     int pixelLayersWithMeasurement() const;          // case 0: pixel
     int stripLayersWithMeasurement() const;          // case 0: strip
@@ -903,7 +904,7 @@ inline int HitPattern::numberOfInactiveTrackerHits() const
     return countTypedHits(TRACK_HITS, inactiveHitFilter, trackerHitFilter);
 }
 
-inline int HitPattern::trackerLayersWithMeasurement() const
+inline int HitPattern::trackerLayersWithMeasurementOld() const
 {
     return pixelLayersWithMeasurement() + stripLayersWithMeasurement();
 }

--- a/DataFormats/TrackReco/interface/TrackExtraBase.h
+++ b/DataFormats/TrackReco/interface/TrackExtraBase.h
@@ -30,14 +30,9 @@ public:
         recHits_.push_back(r);
     }
 
-    /// first iterator over RecHits
-    trackingRecHit_iterator recHitsBegin() const {
-        return recHitsProduct().data().begin()+recHits_.begin().key();
-    }
 
-    /// last iterator over RecHits
-    trackingRecHit_iterator recHitsEnd() const {
-        return recHitsBegin()+recHitsSize();
+    unsigned int firstRecHit() const {
+      return recHits_.begin().key();
     }
 
     /// number of RecHits
@@ -45,14 +40,30 @@ public:
         return recHits_.size();
     }
 
+
+    /// first iterator over RecHits
+    trackingRecHit_iterator recHitsBegin() const {
+        return recHitsProduct().data().begin()+firstRecHit();
+    }
+
+    /// last iterator over RecHits
+    trackingRecHit_iterator recHitsEnd() const {
+        return recHitsBegin()+recHitsSize();
+    }
+
+    /// get a ref to i-th recHit
+    TrackingRecHitRef recHitRef(size_t i) const {                                                               
+        return recHits_[i];
+    }
+
     /// get i-th recHit
     TrackingRecHitRef recHit(size_t i) const {
         return recHits_[i];
     }
 
-    TrackingRecHitRefVector const & recHits() const {
-        return recHits_;
-    }
+//    TrackingRecHitRefVector const & recHits() const {
+//        return recHits_;
+//    }
 
     TrackingRecHitCollection const & recHitsProduct() const {
       return *recHits_.product();

--- a/DataFormats/TrackReco/interface/TrackExtraBase.h
+++ b/DataFormats/TrackReco/interface/TrackExtraBase.h
@@ -32,12 +32,12 @@ public:
 
     /// first iterator over RecHits
     trackingRecHit_iterator recHitsBegin() const {
-        return recHits_.begin();
+        return recHitsProduct().data().begin()+recHits_.begin().key();
     }
 
     /// last iterator over RecHits
     trackingRecHit_iterator recHitsEnd() const {
-        return recHits_.end();
+        return recHitsBegin()+recHitsSize();
     }
 
     /// number of RecHits
@@ -50,8 +50,13 @@ public:
         return recHits_[i];
     }
 
-    TrackingRecHitRefVector recHits() const {
+    TrackingRecHitRefVector const & recHits() const {
         return recHits_;
+    }
+
+    TrackingRecHitCollection const & recHitsProduct() const {
+      return *recHits_.product();
+
     }
 
 private:

--- a/DataFormats/TrackReco/interface/TrackExtraBase.h
+++ b/DataFormats/TrackReco/interface/TrackExtraBase.h
@@ -25,6 +25,11 @@ public:
     /// default constructor
     TrackExtraBase() : m_firstHit(-1), m_nHits(0) { }
 
+    void setHits(TrackingRecHitRefProd const & prod, unsigned firstH, unsigned int nH) {
+        m_hitCollection.pushBackItem(prod.refCore(),true);
+        m_firstHit =firstH;  m_nHits=nH;
+    }
+
     /// add a reference to a RecHit
     void add(const TrackingRecHitRef &ref) {
       m_hitCollection.pushBackItem(ref.refCore(), true);
@@ -76,9 +81,6 @@ private:
     edm::RefCore m_hitCollection;
     unsigned int m_firstHit;
     unsigned int m_nHits;
-
-    /// references to the hit assigned to the track.
-    // TrackingRecHitRefVector recHits_;
 
 };
 

--- a/DataFormats/TrackReco/interface/TrackExtraBase.h
+++ b/DataFormats/TrackReco/interface/TrackExtraBase.h
@@ -23,21 +23,26 @@ class TrackExtraBase
 
 public:
     /// default constructor
-    TrackExtraBase() { }
+    TrackExtraBase() : m_firstHit(-1), m_nHits(0) { }
 
     /// add a reference to a RecHit
-    void add(const TrackingRecHitRef &r) {
-        recHits_.push_back(r);
+    void add(const TrackingRecHitRef &ref) {
+      m_hitCollection.pushBackItem(ref.refCore(), true);
+      if (m_nHits==0) {
+        m_firstHit = ref.key();
+      }
+      assert(m_nHits== ref.key()-m_firstHit);
+      ++m_nHits;   
     }
 
 
     unsigned int firstRecHit() const {
-      return recHits_.begin().key();
+      return m_firstHit;
     }
 
     /// number of RecHits
-    size_t recHitsSize() const {
-        return recHits_.size();
+    unsigned int recHitsSize() const {
+        return m_nHits;
     }
 
 
@@ -52,27 +57,28 @@ public:
     }
 
     /// get a ref to i-th recHit
-    TrackingRecHitRef recHitRef(size_t i) const {                                                               
-        return recHits_[i];
+    TrackingRecHitRef recHitRef(unsigned int i) const {                                                               
+        return TrackingRecHitRef(m_hitCollection,m_firstHit+i);
     }
 
     /// get i-th recHit
-    TrackingRecHitRef recHit(size_t i) const {
-        return recHits_[i];
+    TrackingRecHitRef recHit(unsigned int i) const {
+        return recHitRef(i);
     }
 
-//    TrackingRecHitRefVector const & recHits() const {
-//        return recHits_;
-//    }
-
     TrackingRecHitCollection const & recHitsProduct() const {
-      return *recHits_.product();
+      return *edm::getProduct<TrackingRecHitCollection>(m_hitCollection);
 
     }
 
 private:
+
+    edm::RefCore m_hitCollection;
+    unsigned int m_firstHit;
+    unsigned int m_nHits;
+
     /// references to the hit assigned to the track.
-    TrackingRecHitRefVector recHits_;
+    // TrackingRecHitRefVector recHits_;
 
 };
 

--- a/DataFormats/TrackReco/src/HitPattern.cc
+++ b/DataFormats/TrackReco/src/HitPattern.cc
@@ -346,7 +346,22 @@ int HitPattern::numberOfValidStripLayersWithMonoAndStereo(uint16_t stripdet, uin
 
 int HitPattern::numberOfValidStripLayersWithMonoAndStereo() const
 {
-    return numberOfValidStripLayersWithMonoAndStereo(0, 0);
+   auto category = TRACK_HITS;
+   std::bitset<128> side[2];
+   std::pair<uint8_t, uint8_t> range = getCategoryIndexRange(category);
+   for (int i = range.first; i < range.second; ++i) {
+     auto pattern = getHitPatternByAbsoluteIndex(i);
+     if (pattern<minStripWord) continue;
+     uint16_t hitType = (pattern >> HitTypeOffset) & HitTypeMask;
+     if (hitType != HIT_TYPE::VALID) continue;
+     auto apattern = (pattern-minTrackerWord) >> LayerOffset;
+     // assert(apattern<128);
+     side[getSide(pattern)].set(apattern);
+   }
+   // assert(numberOfValidStripLayersWithMonoAndStereo(0, 0)==int((side[0]&side[1]).count()));
+   return (side[0]&side[1]).count();
+
+
 }
 
 int HitPattern::numberOfValidTOBLayersWithMonoAndStereo(uint32_t layer) const
@@ -442,7 +457,7 @@ uint16_t HitPattern::getTrackerMonoStereo(HitCategory category, uint16_t substr,
 
 int HitPattern::trackerLayersWithMeasurement() const {
    auto category = TRACK_HITS;
-   std::bitset<256> layerOk;
+   std::bitset<128> layerOk;
    std::pair<uint8_t, uint8_t> range = getCategoryIndexRange(category);
    for (int i = range.first; i < range.second; ++i) {
      auto pattern = getHitPatternByAbsoluteIndex(i);
@@ -450,7 +465,7 @@ int HitPattern::trackerLayersWithMeasurement() const {
      uint16_t hitType = (pattern >> HitTypeOffset) & HitTypeMask;
      if (hitType != HIT_TYPE::VALID) continue;
      pattern = (pattern-minTrackerWord) >> LayerOffset;
-     // assert(pattern<256);
+     // assert(pattern<128);
      layerOk.set(pattern);
    }
    // assert(trackerLayersWithMeasurementOld()==int(layerOk.count()));
@@ -458,19 +473,19 @@ int HitPattern::trackerLayersWithMeasurement() const {
 }
 
 int HitPattern::trackerLayersWithoutMeasurement(HitCategory category) const {
-   std::bitset<256> layerOk;
-   std::bitset<256> layerMissed;
+   std::bitset<128> layerOk;
+   std::bitset<128> layerMissed;
    std::pair<uint8_t, uint8_t> range = getCategoryIndexRange(category);
    for (int i = range.first; i < range.second; ++i) {
      auto pattern = getHitPatternByAbsoluteIndex(i);
      if unlikely(!trackerHitFilter(pattern)) continue;
      uint16_t hitType = (pattern >> HitTypeOffset) & HitTypeMask;
      pattern = (pattern-minTrackerWord) >> LayerOffset;
-     // assert(pattern<256);
+     // assert(pattern<128);
      if (hitType == HIT_TYPE::VALID) layerOk.set(pattern);
      if (hitType == HIT_TYPE::MISSING) layerMissed.set(pattern);
    }
-   for (int i=0; i<256; ++i) if (layerOk.test(i)) layerMissed.set(i,0);
+   layerMissed &= ~layerOk;
 
    // assert(trackerLayersWithoutMeasurementOld(category)==int(layerMissed.count()));
 

--- a/DataFormats/TrackReco/src/HitPattern.cc
+++ b/DataFormats/TrackReco/src/HitPattern.cc
@@ -455,6 +455,25 @@ uint16_t HitPattern::getTrackerMonoStereo(HitCategory category, uint16_t substr,
 }
 
 
+int HitPattern::pixelLayersWithMeasurement() const {
+   auto category = TRACK_HITS;
+   std::bitset<128> layerOk;
+   std::pair<uint8_t, uint8_t> range = getCategoryIndexRange(category);
+   for (int i = range.first; i < range.second; ++i) {
+     auto pattern = getHitPatternByAbsoluteIndex(i);
+     if unlikely(!trackerHitFilter(pattern)) continue;
+     if (pattern>minStripWord) continue;
+     uint16_t hitType = (pattern >> HitTypeOffset) & HitTypeMask;
+     if (hitType != HIT_TYPE::VALID) continue;
+     pattern = (pattern-minTrackerWord) >> LayerOffset;
+     // assert(pattern<128);
+     layerOk.set(pattern);
+   }
+   // assert(pixelLayersWithMeasurementOld()==int(layerOk.count()));
+   return layerOk.count();
+}
+
+
 int HitPattern::trackerLayersWithMeasurement() const {
    auto category = TRACK_HITS;
    std::bitset<128> layerOk;

--- a/DataFormats/TrackReco/src/HitPattern.cc
+++ b/DataFormats/TrackReco/src/HitPattern.cc
@@ -457,6 +457,29 @@ int HitPattern::trackerLayersWithMeasurement() const {
    return layerOk.count(); 
 }
 
+int HitPattern::trackerLayersWithoutMeasurement(HitCategory category) const {
+   std::bitset<256> layerOk;
+   std::bitset<256> layerMissed;
+   std::pair<uint8_t, uint8_t> range = getCategoryIndexRange(category);
+   for (int i = range.first; i < range.second; ++i) {
+     auto pattern = getHitPatternByAbsoluteIndex(i);
+     if unlikely(!trackerHitFilter(pattern)) continue;
+     uint16_t hitType = (pattern >> HitTypeOffset) & HitTypeMask;
+     pattern = (pattern-minTrackerWord) >> LayerOffset;
+     assert(pattern<256);
+     if (hitType == HIT_TYPE::VALID) layerOk.set(pattern);
+     if (hitType == HIT_TYPE::MISSING) layerMissed.set(pattern);
+   }
+   for (int i=0; i<256; ++i) if (layerOk.test(i)) layerMissed.set(i,0);
+
+   assert(trackerLayersWithoutMeasurementOld(category)==int(layerMissed.count()));
+
+   return layerMissed.count();
+ 
+
+}
+
+
 int HitPattern::pixelBarrelLayersWithMeasurement() const
 {
     int count = 0;

--- a/DataFormats/TrackReco/src/HitPattern.cc
+++ b/DataFormats/TrackReco/src/HitPattern.cc
@@ -450,10 +450,10 @@ int HitPattern::trackerLayersWithMeasurement() const {
      uint16_t hitType = (pattern >> HitTypeOffset) & HitTypeMask;
      if (hitType != HIT_TYPE::VALID) continue;
      pattern = (pattern-minTrackerWord) >> LayerOffset;
-     assert(pattern<256);
+     // assert(pattern<256);
      layerOk.set(pattern);
    }
-   assert(trackerLayersWithMeasurementOld()==int(layerOk.count()));
+   // assert(trackerLayersWithMeasurementOld()==int(layerOk.count()));
    return layerOk.count(); 
 }
 
@@ -466,13 +466,13 @@ int HitPattern::trackerLayersWithoutMeasurement(HitCategory category) const {
      if unlikely(!trackerHitFilter(pattern)) continue;
      uint16_t hitType = (pattern >> HitTypeOffset) & HitTypeMask;
      pattern = (pattern-minTrackerWord) >> LayerOffset;
-     assert(pattern<256);
+     // assert(pattern<256);
      if (hitType == HIT_TYPE::VALID) layerOk.set(pattern);
      if (hitType == HIT_TYPE::MISSING) layerMissed.set(pattern);
    }
    for (int i=0; i<256; ++i) if (layerOk.test(i)) layerMissed.set(i,0);
 
-   assert(trackerLayersWithoutMeasurementOld(category)==int(layerMissed.count()));
+   // assert(trackerLayersWithoutMeasurementOld(category)==int(layerMissed.count()));
 
    return layerMissed.count();
  

--- a/DataFormats/TrackReco/src/HitPattern.cc
+++ b/DataFormats/TrackReco/src/HitPattern.cc
@@ -10,6 +10,8 @@
 #include "DataFormats/MuonDetId/interface/CSCDetId.h"
 #include "DataFormats/MuonDetId/interface/RPCDetId.h"
 
+#include<bitset>
+
 using namespace reco;
 
 HitPattern::HitPattern() :
@@ -435,6 +437,24 @@ uint16_t HitPattern::getTrackerMonoStereo(HitCategory category, uint16_t substr,
         }
     }
     return monoStereo;
+}
+
+
+int HitPattern::trackerLayersWithMeasurement() const {
+   auto category = TRACK_HITS;
+   std::bitset<256> layerOk;
+   std::pair<uint8_t, uint8_t> range = getCategoryIndexRange(category);
+   for (int i = range.first; i < range.second; ++i) {
+     auto pattern = getHitPatternByAbsoluteIndex(i);
+     if unlikely(!trackerHitFilter(pattern)) continue;
+     uint16_t hitType = (pattern >> HitTypeOffset) & HitTypeMask;
+     if (hitType != HIT_TYPE::VALID) continue;
+     pattern = (pattern-minTrackerWord) >> LayerOffset;
+     assert(pattern<256);
+     layerOk.set(pattern);
+   }
+   assert(trackerLayersWithMeasurementOld()==int(layerOk.count()));
+   return layerOk.count(); 
 }
 
 int HitPattern::pixelBarrelLayersWithMeasurement() const

--- a/DataFormats/TrackReco/src/classes_def.xml
+++ b/DataFormats/TrackReco/src/classes_def.xml
@@ -328,10 +328,21 @@
   <class name="reco::TrackResiduals" ClassVersion="10">
    <version ClassVersion="10" checksum="2022291691"/>
   </class>
+
   <class name="reco::TrackExtraBase" ClassVersion="11">
    <version ClassVersion="10" checksum="3548207838"/>
    <version ClassVersion="11" checksum="3450798337"/>
   </class>
+  <ioread sourceClass = "reco::TrackExtraBase" version="[-10]" targetClass="reco::TrackExtraBase" source ="TrackingRecHitRefVector recHits_" target="m_hitCollection">
+    <![CDATA[m_hitCollection=onfile.recHits_.refVector().refCore();]]>
+  </ioread>
+  <ioread sourceClass = "reco::TrackExtraBase" version="[-10]" targetClass="reco::TrackExtraBase" source ="TrackingRecHitRefVector recHits_" target="m_firstHit">
+    <![CDATA[m_firstHit = onfile.recHits_.refVector().keys()[0];]]>
+  </ioread>
+  <ioread sourceClass = "reco::TrackExtraBase" version="[-10]" targetClass="reco::TrackExtraBase" source ="TrackingRecHitRefVector recHits_" target="m_nHits">
+    <![CDATA[m_nHits=onfile.recHits_.size();]]>
+  </ioread>
+
 
   <class name="reco::TrackExtra" ClassVersion="10">
    <version ClassVersion="10" checksum="1613098482"/>

--- a/DataFormats/TrackReco/src/classes_def.xml
+++ b/DataFormats/TrackReco/src/classes_def.xml
@@ -328,8 +328,9 @@
   <class name="reco::TrackResiduals" ClassVersion="10">
    <version ClassVersion="10" checksum="2022291691"/>
   </class>
-  <class name="reco::TrackExtraBase" ClassVersion="10">
+  <class name="reco::TrackExtraBase" ClassVersion="11">
    <version ClassVersion="10" checksum="3548207838"/>
+   <version ClassVersion="11" checksum="3450798337"/>
   </class>
 
   <class name="reco::TrackExtra" ClassVersion="10">

--- a/DataFormats/TrackReco/test/testHitPattern.cpp
+++ b/DataFormats/TrackReco/test/testHitPattern.cpp
@@ -25,7 +25,11 @@ int main()
 				     470045428}; //TEC r7
 
    HitPattern hp;
-   for (auto id : radial_detids) hp.appendHit(id,TrackingRecHit::valid);
+   auto i=0;
+   for (auto id : radial_detids) { hp.appendHit(id,(i++ == 1) ? TrackingRecHit::missing : TrackingRecHit::valid);}
+   hp.appendHit(radial_detids[2],TrackingRecHit::missing);
+   hp.appendHit(radial_detids[8],TrackingRecHit::missing);
+
 
    std::cout << hp.numberOfValidTrackerHits() << ' ' << hp.numberOfValidPixelHits() << ' ' <<	hp.numberOfValidStripHits() << std::endl;
    std::cout << hp.pixelLayersWithMeasurement() << ' ' << hp.stripLayersWithMeasurement() << std::endl;

--- a/DataFormats/TrackReco/test/testHitPattern.cpp
+++ b/DataFormats/TrackReco/test/testHitPattern.cpp
@@ -11,6 +11,31 @@ using namespace reco;
 
 int main()
 {
+
+{
+  const uint32_t radial_detids[] = { 402666125,//TID r1
+				     402668833,//TID r2
+				     402673476,//TID r3
+				     470066725,//TEC r1
+				     470390853,//TEC r2
+				     470114664,//TEC r3
+				     470131344,//TEC r4
+				     470079661,//TEC r5
+				     470049476,//TEC r6
+				     470045428}; //TEC r7
+
+   HitPattern hp;
+   for (auto id : radial_detids) hp.appendHit(id,TrackingRecHit::valid);
+
+   std::cout << hp.numberOfValidTrackerHits() << ' ' << hp.numberOfValidPixelHits() << ' ' <<	hp.numberOfValidStripHits() << std::endl;
+   std::cout << hp.pixelLayersWithMeasurement() << ' ' << hp.stripLayersWithMeasurement() << std::endl;
+   std::cout << hp.numberOfValidStripLayersWithMonoAndStereo() << std::endl;
+   std::cout <<	hp.pixelLayersWithoutMeasurement(HitPattern::TRACK_HITS) << ' ' << hp.stripLayersWithoutMeasurement(HitPattern::TRACK_HITS) << std::endl;
+
+}
+
+
+
     HitPattern hp1;
     HitPattern hp2;
     std::mt19937 eng;

--- a/DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h
+++ b/DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h
@@ -16,6 +16,6 @@ typedef edm::RefProd<TrackingRecHitCollection> TrackingRecHitRefProd;
 /// vector of reference to TrackingRecHit in the same collection
 typedef edm::RefVector<TrackingRecHitCollection> TrackingRecHitRefVector;
 /// iterator over a vector of reference to TrackingRecHit in the same collection
-typedef TrackingRecHitRefVector::iterator trackingRecHit_iterator;
+typedef TrackingRecHitCollection::base::const_iterator trackingRecHit_iterator;
 
 #endif

--- a/FastSimulation/Tracking/plugins/FastTrackMerger.cc
+++ b/FastSimulation/Tracking/plugins/FastTrackMerger.cc
@@ -467,9 +467,9 @@ FastTrackMerger::findId(const reco::Track& aTrack) const {
   trackingRecHit_iterator aHit = aTrack.recHitsBegin();
   trackingRecHit_iterator lastHit = aTrack.recHitsEnd();
   for ( ; aHit!=lastHit; ++aHit ) {
-    if ( !aHit->get()->isValid() ) continue;
+    if ( !(*aHit)->isValid() ) continue;
     //    const SiTrackerGSRecHit2D * rechit = (const SiTrackerGSRecHit2D*) (aHit->get());
-    const SiTrackerGSMatchedRecHit2D * rechit = (const SiTrackerGSMatchedRecHit2D*) (aHit->get());
+    const SiTrackerGSMatchedRecHit2D * rechit = (const SiTrackerGSMatchedRecHit2D*) (*aHit);
     trackId = rechit->simtrackId();
     break;
   }

--- a/FastSimulation/Tracking/plugins/RecoTrackAccumulator.cc
+++ b/FastSimulation/Tracking/plugins/RecoTrackAccumulator.cc
@@ -98,7 +98,7 @@ template<class T> void RecoTrackAccumulator::accumulateEvent(const T& e, edm::Ev
       // rechits:
       auto & newExtra = NewTrackExtraList_->back();
       for( trackingRecHit_iterator hit = extra.recHitsBegin(); hit != extra.recHitsEnd(); ++ hit ) {
-	NewHitList_->push_back( (*hits)[hit->key()] );
+	NewHitList_->push_back( **hit );
 	newExtra.add( TrackingRecHitRef( rHits, NewHitList_->size() - 1) );
       }
     }

--- a/FastSimulation/Tracking/plugins/TrackCandidateProducer.cc
+++ b/FastSimulation/Tracking/plugins/TrackCandidateProducer.cc
@@ -724,9 +724,9 @@ TrackCandidateProducer::findId(const reco::Track& aTrack) const {
   trackingRecHit_iterator aHit = aTrack.recHitsBegin();
   trackingRecHit_iterator lastHit = aTrack.recHitsEnd();
   for ( ; aHit!=lastHit; ++aHit ) {
-    if ( !aHit->get()->isValid() ) continue;
-    //    const SiTrackerGSRecHit2D * rechit = (const SiTrackerGSRecHit2D*) (aHit->get());
-    const SiTrackerGSMatchedRecHit2D * rechit = (const SiTrackerGSMatchedRecHit2D*) (aHit->get());
+    if ( !(*aHit)->isValid() ) continue;
+    //    const SiTrackerGSRecHit2D * rechit = (const SiTrackerGSRecHit2D*) (*aHit);
+    const SiTrackerGSMatchedRecHit2D * rechit = (const SiTrackerGSMatchedRecHit2D*) (*aHit);
     trackId = rechit->simtrackId();
     break;
   }

--- a/FastSimulation/Tracking/test/FastTrackAnalyzer.cc
+++ b/FastSimulation/Tracking/test/FastTrackAnalyzer.cc
@@ -532,7 +532,7 @@ void FastTrackAnalyzer::analyze(const edm::Event& event, const edm::EventSetup& 
 	ri++;
 	if ((*it)->isValid()){
 
-	  if(const SiTrackerGSRecHit2D * rechit = dynamic_cast<const SiTrackerGSRecHit2D *> (it->get()))	  
+	  if(const SiTrackerGSRecHit2D * rechit = dynamic_cast<const SiTrackerGSRecHit2D *> (*it) )	  
 	    {
 	      std::cout<<"---------------------------------------------------------------"<< std::endl;
 	      int currentId = rechit->simtrackId();		      

--- a/Fireworks/Tracks/plugins/FWTrackTrackingRecHitProxyBuilder.cc
+++ b/Fireworks/Tracks/plugins/FWTrackTrackingRecHitProxyBuilder.cc
@@ -36,7 +36,7 @@ FWTrackTrackingRecHitProxyBuilder::build( const reco::Track& iData, unsigned int
       TEvePointSet* pointSet = new TEvePointSet;
       setupAddElement( pointSet, &oItemHolder );
 
-      TrackingRecHitRef rechitRef = *it;
+      auto rechitRef = *it;
       const TrackingRecHit *rechit = &( *rechitRef );
 
       if( rechit->isValid())

--- a/Fireworks/Tracks/src/TrackUtils.cc
+++ b/Fireworks/Tracks/src/TrackUtils.cc
@@ -424,7 +424,7 @@ addSiStripClusters( const FWEventItem* iItem, const reco::Track &t, class TEveEl
       const float* pars = geom->getParameters( rawid );
       
       // -- get phi from SiStripHit
-      TrackingRecHitRef rechitRef = *it;
+      auto rechitRef = *it;
       const TrackingRecHit *rechit = &( *rechitRef );
       const SiStripCluster *cluster = extractClusterFromTrackingRecHit( rechit );
 

--- a/RecoEgamma/EgammaPhotonAlgos/src/ConversionHitChecker.cc
+++ b/RecoEgamma/EgammaPhotonAlgos/src/ConversionHitChecker.cc
@@ -109,10 +109,10 @@ uint8_t ConversionHitChecker::nSharedHits(const reco::Track &trk1, const reco::T
   uint8_t nShared = 0;
 
   for (trackingRecHit_iterator iHit1 = trk1.recHitsBegin();  iHit1 != trk1.recHitsEnd(); ++iHit1) { 
-    const TrackingRecHit *hit1 = iHit1->get();
+    const TrackingRecHit *hit1 = (*iHit1);
     if (hit1->isValid()) {
       for (trackingRecHit_iterator iHit2 = trk2.recHitsBegin();  iHit2 != trk2.recHitsEnd(); ++iHit2) { 
-        const TrackingRecHit *hit2 = iHit2->get();
+        const TrackingRecHit *hit2 = (*iHit2);
         if (hit2->isValid() && hit1->sharesInput(hit2,TrackingRecHit::some)) {
           ++nShared;
         }

--- a/RecoLocalTracker/SiPixelClusterizer/test/TestWithTracks.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/test/TestWithTracks.cc
@@ -834,7 +834,7 @@ void TestWithTracks::analyze(const edm::Event& e,
       //std::vector<SiStripRecHit2D*> output = getRecHitComponents((*recHit).get()); 
       //std::vector<SiPixelRecHit*> TrkComparison::getRecHitComponents(const TrackingRecHit* rechit){
 
-      const SiPixelRecHit* hit = dynamic_cast<const SiPixelRecHit*>((*recHit).get());
+      const SiPixelRecHit* hit = dynamic_cast<const SiPixelRecHit*>((*recHit));
       //edm::Ref<edmNew::DetSetVector<SiStripCluster> ,SiStripCluster> cluster = hit->cluster();
       // get the edm::Ref to the cluster
 

--- a/RecoLocalTracker/SubCollectionProducers/src/TrackClusterSplitter.cc
+++ b/RecoLocalTracker/SubCollectionProducers/src/TrackClusterSplitter.cc
@@ -431,7 +431,7 @@ TrackClusterSplitter::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
                     }
                 }  
 
-	      const TrackingRecHit *hit = it_hit->get();
+	      const TrackingRecHit *hit = *it_hit;
 	      if ( hit == 0 || !hit->isValid() )
 		continue;
 	      
@@ -466,7 +466,7 @@ TrackClusterSplitter::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 	  trackingRecHit_iterator it_hit = track.recHitsBegin(), ed_hit = track.recHitsEnd();
 	  for (; it_hit != ed_hit; ++it_hit) 
 	    {
-	      const TrackingRecHit *hit = it_hit->get();
+	      const TrackingRecHit *hit = *it_hit;
 	      if ( hit == 0 || !hit->isValid() ) 
 		continue;
 	      

--- a/RecoMET/METAlgorithms/src/CSCHaloAlgo.cc
+++ b/RecoMET/METAlgorithms/src/CSCHaloAlgo.cc
@@ -66,9 +66,9 @@ reco::CSCHaloData CSCHaloAlgo::Calculate(const CSCGeometry& TheCSCGeometry,
 	  GlobalPoint InnerMostGlobalPosition(0.,0.,0.);  // smallest abs(z)
 	  GlobalPoint OuterMostGlobalPosition(0.,0.,0.);  // largest abs(z)
 	  int nCSCHits = 0;
-	  for(unsigned int j = 0 ; j < Track->extra()->recHits().size(); j++ )
+	  for(unsigned int j = 0 ; j < Track->extra()->recHitsSize(); j++ )
 	    {
-	      edm::Ref<TrackingRecHitCollection> hit( Track->extra()->recHits(), j );
+	      auto hit = Track->extra()->recHitRef(j);
 	      if( !hit->isValid() ) continue;
 	      DetId TheDetUnitId(hit->geographicalId());
 	      if( TheDetUnitId.det() != DetId::Muon ) continue;

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
@@ -424,14 +424,14 @@ int MuonIdProducer::overlap(const reco::Muon& muon, const reco::Track& track)
 	if ( match->segmentMatches.empty() ) continue;
 	bool foundCommonDetId = false;
 
-	for ( TrackingRecHitRefVector::const_iterator hit = track.extra()->recHitsBegin();
+	for ( auto hit = track.extra()->recHitsBegin();
 	      hit != track.extra()->recHitsEnd(); ++hit )
 	  {
 	     // LogTrace("MuonIdentification") << "hit DetId: " << std::hex << hit->get()->geographicalId().rawId() <<
 	     //  "\t hit chamber DetId: " << getChamberId(hit->get()->geographicalId()) <<
 	     //  "\t segment DetId: " << match->id.rawId() << std::dec;
 
-	     if ( chamberId(hit->get()->geographicalId()) == match->id.rawId() ) {
+	     if ( chamberId((*hit)->geographicalId()) == match->id.rawId() ) {
 		foundCommonDetId = true;
 		break;
 	     }

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
@@ -416,7 +416,7 @@ int MuonIdProducer::overlap(const reco::Muon& muon, const reco::Track& track)
    int numberOfCommonDetIds = 0;
    if ( ! muon.isMatchesValid() ||
 	track.extra().isNull() ||
-	track.extra()->recHits().isNull() ) return numberOfCommonDetIds;
+	track.extra()->recHitsSize()==0 ) return numberOfCommonDetIds;
    const std::vector<reco::MuonChamberMatch>& matches( muon.matches() );
    for ( std::vector<reco::MuonChamberMatch>::const_iterator match = matches.begin();
 	 match != matches.end(); ++match )

--- a/RecoMuon/MuonIdentification/plugins/MuonLinksProducerForHLT.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonLinksProducerForHLT.cc
@@ -53,13 +53,13 @@ void MuonLinksProducerForHLT::produce(edm::Event& iEvent, const edm::EventSetup&
        link != links->end(); ++link){
      bool found = false;
      unsigned int trackIndex = 0;
-     unsigned int muonTrackHits = link->trackerTrack()->extra()->recHits().size();
+     unsigned int muonTrackHits = link->trackerTrack()->extra()->recHitsSize();
      for(reco::TrackCollection::const_iterator track = incTracks->begin();
 	 track != incTracks->end(); ++track, ++trackIndex){      
        if ( track->pt() < ptMin ) continue;
        if ( track->p() < pMin ) continue;
        //std::cout << "pt (muon/track) " << link->trackerTrack()->pt() << " " << track->pt() << std::endl;
-       unsigned trackHits = track->extra()->recHits().size();
+       unsigned trackHits = track->extra()->recHitsSize();
        //std::cout << "hits (muon/track) " << muonTrackHits  << " " << trackHits() << std::endl;
        unsigned int smallestNumberOfHits = trackHits < muonTrackHits ? trackHits : muonTrackHits;
        int numberOfCommonDetIds = 0;

--- a/RecoMuon/MuonIdentification/plugins/MuonLinksProducerForHLT.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonLinksProducerForHLT.cc
@@ -63,12 +63,12 @@ void MuonLinksProducerForHLT::produce(edm::Event& iEvent, const edm::EventSetup&
        //std::cout << "hits (muon/track) " << muonTrackHits  << " " << trackHits() << std::endl;
        unsigned int smallestNumberOfHits = trackHits < muonTrackHits ? trackHits : muonTrackHits;
        int numberOfCommonDetIds = 0;
-       for ( TrackingRecHitRefVector::const_iterator hit = track->extra()->recHitsBegin();
+       for ( auto hit = track->extra()->recHitsBegin();
 	     hit != track->extra()->recHitsEnd(); ++hit ) {
-	 for ( TrackingRecHitRefVector::const_iterator mit = link->trackerTrack()->extra()->recHitsBegin();
+	 for ( auto mit = link->trackerTrack()->extra()->recHitsBegin();
 	     mit != link->trackerTrack()->extra()->recHitsEnd(); ++mit ) {
-	   if ( hit->get()->geographicalId() == mit->get()->geographicalId() && 
-		hit->get()->sharesInput(mit->get(),TrackingRecHit::some) ) { 
+	   if ( (*hit)->geographicalId() == (*mit)->geographicalId() && 
+		(*hit)->sharesInput((*mit),TrackingRecHit::some) ) { 
 	     numberOfCommonDetIds++;
 	     break;
 	   }

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGForRoadSearch.cc
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGForRoadSearch.cc
@@ -431,7 +431,7 @@ void TSGForRoadSearch::pushTrajectorySeed(const reco::Track & muon, std::vector<
 	  LogDebug(theCategory)<<"copying ("<<muon.recHitsSize()<<") muon recHits";
 	  //copy the muon rechit into the seed
 	  for (trackingRecHit_iterator trit = muon.recHitsBegin(); trit!=muon.recHitsEnd();trit++) {
-	    rhContainer.push_back( (*trit).get()->clone() );  }}
+	    rhContainer.push_back( (*trit)->clone() );  }}
 	
 	if ( hit->isValid()) {
 	  TrajectoryStateOnSurface upState(theUpdator->update(predState,*hit));
@@ -477,7 +477,7 @@ void TSGForRoadSearch::pushTrajectorySeed(const reco::Track & muon, std::vector<
       LogDebug(theCategory)<<"copying ("<<muon.recHitsSize()<<") muon recHits";
       //copy the muon rechit into the seed
       for (trackingRecHit_iterator trit = muon.recHitsBegin(); trit!=muon.recHitsEnd();trit++) {
-	rhContainer.push_back( (*trit).get()->clone() );  }}
+	rhContainer.push_back( (*trit)->clone() );  }}
     
     //add this seed to the list and return it
     result.push_back(TrajectorySeed(PTSOD,rhContainer,direction));

--- a/RecoMuon/TrackingTools/src/MuonSegmentMatcher.cc
+++ b/RecoMuon/TrackingTools/src/MuonSegmentMatcher.cc
@@ -70,7 +70,7 @@ vector<const DTRecSegment4D*> MuonSegmentMatcher::matchDT(const reco::Track &muo
   
   vector<const DTRecSegment4D*> pointerTo4DSegments;
 
-  TrackingRecHitRefVector dtHits;
+  std::vector<TrackingRecHit const *> dtHits;
 
   bool segments = false;
 
@@ -97,7 +97,7 @@ vector<const DTRecSegment4D*> MuonSegmentMatcher::matchDT(const reco::Track &muo
 
     if (segments) {
       // Loop over muon recHits
-      for(trackingRecHit_iterator hit = dtHits.begin(); hit != dtHits.end(); ++hit) {
+      for(auto hit = dtHits.begin(); hit != dtHits.end(); ++hit) {
 					
 	// Pick the one in the same DT Chamber as the muon
 	DetId idT = (*hit)->geographicalId();
@@ -127,7 +127,7 @@ vector<const DTRecSegment4D*> MuonSegmentMatcher::matchDT(const reco::Track &muo
       DTChamberId chamberSegIdT((segmZ->geographicalId()).rawId());
 		
       // Loop over muon recHits
-      for(trackingRecHit_iterator hit = dtHits.begin(); hit != dtHits.end(); ++hit) {
+      for(auto hit = dtHits.begin(); hit != dtHits.end(); ++hit) {
 
 	if ( !(*hit)->isValid()) continue; 
 	
@@ -174,7 +174,7 @@ vector<const DTRecSegment4D*> MuonSegmentMatcher::matchDT(const reco::Track &muo
       DTChamberId chamberSegIdT((segmPhi->geographicalId()).rawId());
 		
       // Loop over muon recHits
-      for(trackingRecHit_iterator hit = dtHits.begin(); hit != dtHits.end(); ++hit) {
+      for(auto hit = dtHits.begin(); hit != dtHits.end(); ++hit) {
 
 	if ( !(*hit)->isValid()) continue; 
 

--- a/RecoParticleFlow/PFSimProducer/plugins/ConvBremSeedProducer.cc
+++ b/RecoParticleFlow/PFSimProducer/plugins/ConvBremSeedProducer.cc
@@ -550,8 +550,8 @@ ConvBremSeedProducer::makeTrajectoryState( const DetLayer* layer,
     (GlobalTrajectoryParameters( pos, mom, TrackCharge( pp.charge()), field), *plane);
 }
 bool ConvBremSeedProducer::isGsfTrack(const TrackingRecHitRefVector& tkv, const TrackingRecHit *h ){
-  trackingRecHit_iterator ib=tkv.begin();
-  trackingRecHit_iterator ie=tkv.end();
+  auto ib=tkv.begin();
+  auto ie=tkv.end();
   bool istaken=false;
   //  for (;ib!=ie-2;++ib){
     for (;ib!=ie;++ib){

--- a/RecoParticleFlow/PFSimProducer/plugins/ConvBremSeedProducer.cc
+++ b/RecoParticleFlow/PFSimProducer/plugins/ConvBremSeedProducer.cc
@@ -122,7 +122,7 @@ ConvBremSeedProducer::produce(Event& iEvent, const EventSetup& iSetup)
     unclean.clear();
     tripl.clear();
     vector<int> gc;
-    TrackingRecHitRefVector gsfRecHits=pft->gsfTrackRef()->extra()->recHits();
+    auto const &  gsfRecHits = *pft->gsfTrackRef();
     float pfoutenergy=sqrt((pfmass*pfmass)+pft->gsfTrackRef()->outerMomentum().Mag2());
     XYZTLorentzVector mom =XYZTLorentzVector(pft->gsfTrackRef()->outerMomentum().x(),
 					     pft->gsfTrackRef()->outerMomentum().y(),
@@ -549,9 +549,9 @@ ConvBremSeedProducer::makeTrajectoryState( const DetLayer* layer,
   return TrajectoryStateOnSurface
     (GlobalTrajectoryParameters( pos, mom, TrackCharge( pp.charge()), field), *plane);
 }
-bool ConvBremSeedProducer::isGsfTrack(const TrackingRecHitRefVector& tkv, const TrackingRecHit *h ){
-  auto ib=tkv.begin();
-  auto ie=tkv.end();
+bool ConvBremSeedProducer::isGsfTrack(const reco::Track & tkv, const TrackingRecHit *h ){
+  auto ib=tkv.recHitsBegin();
+  auto ie=tkv.recHitsEnd();
   bool istaken=false;
   //  for (;ib!=ie-2;++ib){
     for (;ib!=ie;++ib){

--- a/RecoParticleFlow/PFSimProducer/plugins/ConvBremSeedProducer.h
+++ b/RecoParticleFlow/PFSimProducer/plugins/ConvBremSeedProducer.h
@@ -16,7 +16,7 @@
 #include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2DCollection.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2DCollection.h"
 #include "DataFormats/ParticleFlowReco/interface/PFClusterFwd.h"
-
+#include "DataFormats/TrackReco/interface/Track.h"
 
 ///ESHANDLE
 #include "RecoTracker/TkDetLayers/interface/GeometricSearchTracker.h"
@@ -62,7 +62,7 @@ class ConvBremSeedProducer : public edm::EDProducer {
 						const MagneticField* field) const;
   const DetLayer* detLayer( const TrackerLayer& layer, float zpos) const;
 
-  bool isGsfTrack(const TrackingRecHitRefVector&, const TrackingRecHit *);
+  bool isGsfTrack(const reco::Track &, const TrackingRecHit *);
 
   int GoodCluster(const BaseParticlePropagator& bpg, const reco::PFClusterCollection& pfc, 
 		  float minep, bool sec=false);

--- a/RecoParticleFlow/PFSimProducer/plugins/PFSimParticleProducer.cc
+++ b/RecoParticleFlow/PFSimProducer/plugins/PFSimParticleProducer.cc
@@ -555,10 +555,10 @@ void PFSimParticleProducer::getSimIDs( const TrackHandle& trackh,
       for (trackingRecHit_iterator it = rhitbeg;  
 	   it != rhitend; it++){
 
-	if( it->get()->isValid() ){
+	if( (*it)->isValid() ){
 
 	  const SiTrackerGSMatchedRecHit2D * rechit 
-	    = (const SiTrackerGSMatchedRecHit2D*) (it->get());
+	    = (const SiTrackerGSMatchedRecHit2D*) (*it);
 	  
 // 	  cout <<  "rechit" 	       
 // 	       << " corresponding simId " 

--- a/RecoParticleFlow/PFTracking/plugins/PFConversionProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFConversionProducer.cc
@@ -102,11 +102,11 @@ PFConversionProducer::produce(Event& iEvent, const EventSetup& iSetup)
 		  int shared=0;
 		  for(trackingRecHit_iterator iHit1=trackRef1->recHitsBegin(); iHit1!=trackRef1->recHitsEnd(); iHit1++) 
 		    {
-		      const TrackingRecHit *h_1=iHit1->get();
+		      const TrackingRecHit *h_1=(*iHit1);
 		      if(h_1->isValid()){		  
 			for(trackingRecHit_iterator iHit2=trackRef2->recHitsBegin(); iHit2!=trackRef2->recHitsEnd(); iHit2++)
 			  {
-			    const TrackingRecHit *h_2=iHit2->get();
+			    const TrackingRecHit *h_2=(*iHit2);
 			    if(h_2->isValid() && h_1->sharesInput(h_2, TrackingRecHit::some))shared++;//count number of shared hits
 			  }
 		      }

--- a/RecoTracker/DebugTools/plugins/TestOutliers.cc
+++ b/RecoTracker/DebugTools/plugins/TestOutliers.cc
@@ -1,4 +1,4 @@
- // -*- C++ -*-
+// -*- C++ -*-
 //
 // Package:    TestOutliers
 // Class:      TestOutliers
@@ -373,8 +373,8 @@ TestOutliers::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
       
       //if ( trackOut->numberOfValidHits() < trackOld->numberOfValidHits() ) {
       if ( trackOut->numberOfValidHits() != trackOld->numberOfValidHits() || 
-	   !trackOut->recHitsBegin()->get()->sharesInput(trackOld->recHitsBegin()->get(),TrackingRecHit::some) ||
-	   !(trackOut->recHitsEnd()-1)->get()->sharesInput((trackOld->recHitsEnd()-1)->get(),TrackingRecHit::some)  ) 
+	   !(*trackOut->recHitsBegin())->sharesInput((*trackOld->recHitsBegin()),TrackingRecHit::some) ||
+	   !(*(trackOut->recHitsEnd()-1))->sharesInput((*(trackOld->recHitsEnd()-1)),TrackingRecHit::some)  ) 
 	{ //there are outliers if the number of valid hits is != or if the first and last hit does not match
 	LogTrace("TestOutliers") << "outliers for track with #hits=" << trackOut->numberOfValidHits();
 	tracks->Fill(1);

--- a/RecoTracker/FinalTrackSelectors/plugins/AnalyticalTrackSelector.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/AnalyticalTrackSelector.cc
@@ -251,6 +251,12 @@ void AnalyticalTrackSelector::run( edm::Event& evt, const edm::EventSetup& es ) 
 
   // Get tracks 
   evt.getByToken( src_, hSrcTrack );
+  // get hits in track..
+  Handle<TrackingRecHitCollection> hSrcHits;
+  evt.getByToken( hSrc_, hSrcHits );
+  const TrackingRecHitCollection & srcHits(*hSrcHits);
+
+
 
   selTracks_ = auto_ptr<TrackCollection>(new TrackCollection());
   rTracks_ = evt.getRefBeforePut<TrackCollection>();      
@@ -276,7 +282,7 @@ void AnalyticalTrackSelector::run( edm::Event& evt, const edm::EventSetup& es ) 
 
     float mvaVal = 0;
     if(useAnyMVA_)mvaVal = mvaVals_[current];
-    bool ok = select(0,vertexBeamSpot, trk, points, vterr, vzerr,mvaVal);
+    bool ok = select(0,vertexBeamSpot, srcHits, trk, points, vterr, vzerr,mvaVal);
     if (!ok) {
 
       LogTrace("TrackSelection") << "track with pt="<< trk.pt() << " NOT selected";

--- a/RecoTracker/FinalTrackSelectors/plugins/AnalyticalTrackSelector.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/AnalyticalTrackSelector.cc
@@ -108,6 +108,7 @@ AnalyticalTrackSelector::AnalyticalTrackSelector( const edm::ParameterSet & cfg 
     forest_ = nullptr;
 
     src_ = consumes<reco::TrackCollection>(cfg.getParameter<edm::InputTag>( "src" ));
+    hSrc_ = consumes<TrackingRecHitCollection>(cfg.getParameter<edm::InputTag>( "src" ));
     beamspot_ = consumes<reco::BeamSpot>(cfg.getParameter<edm::InputTag>( "beamspot" ));
     useVertices_ = cfg.getParameter<bool>( "useVertices" );
     useVtxError_ = cfg.getParameter<bool>( "useVtxError" );

--- a/RecoTracker/FinalTrackSelectors/plugins/BuildFile.xml
+++ b/RecoTracker/FinalTrackSelectors/plugins/BuildFile.xml
@@ -1,3 +1,4 @@
+<flags   CXXFLAGS="-Ofast"/>
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/DetId"/>
 <use   name="DataFormats/Math"/>

--- a/RecoTracker/FinalTrackSelectors/plugins/CosmicTrackSplitter.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/CosmicTrackSplitter.cc
@@ -192,15 +192,15 @@ namespace reco { namespace modules {
 			// check if the trajectories and rechits are in reverse order...
 			trackingRecHit_iterator bIt = trackFromMap->recHitsBegin();
 			trackingRecHit_iterator fIt = trackFromMap->recHitsEnd() - 1;
-			const TrackingRecHit* bHit = bIt->get();
-			const TrackingRecHit* fHit = fIt->get();
+			const TrackingRecHit* bHit = (*bIt);
+			const TrackingRecHit* fHit = (*fIt);
 			// hit type valid = 0, missing = 1, inactive = 2, bad = 3
 			if( bHit->type() != 0 || bHit->isValid() != 1){
 				//loop over hits forwards until first Valid hit is found
 				trackingRecHit_iterator ihit;
 				for( ihit =  trackFromMap->recHitsBegin();
 					ihit != trackFromMap->recHitsEnd(); ++ihit){
-					const TrackingRecHit* iHit = ihit->get();
+					const TrackingRecHit* iHit = (*ihit);
 					if( iHit->type() == 0 && iHit->isValid() == 1){
 						bHit = iHit;
 						break;
@@ -215,7 +215,7 @@ namespace reco { namespace modules {
 				trackingRecHit_iterator ihitf;
 				for( ihitf =  trackFromMap->recHitsEnd()-1;
 					ihitf != trackFromMap->recHitsBegin(); --ihitf){
-					const TrackingRecHit* iHit = ihitf->get();
+					const TrackingRecHit* iHit = (*ihitf);
 					if( iHit->type() == 0 && iHit->isValid() == 1){
 						fHit = iHit;
 						break;
@@ -268,7 +268,7 @@ namespace reco { namespace modules {
 				int hitCtr = 0;
 				for (trackingRecHit_iterator ith = itt->recHitsBegin(), edh = itt->recHitsEnd(); ith != edh; ++ith) {
 					//hitCtr++;
-					const TrackingRecHit * hit = ith->get(); // ith is an iterator on edm::Ref to rechit
+					const TrackingRecHit * hit = (*ith); // ith is an iterator on edm::Ref to rechit
 					LogDebug("CosmicTrackSplitter") << "         hit number " << (ith - itt->recHitsBegin());
 					// let's look at valid hits
 					if (hit->isValid()) {

--- a/RecoTracker/FinalTrackSelectors/plugins/DuplicateListMerger.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/DuplicateListMerger.cc
@@ -437,10 +437,9 @@ void DuplicateListMerger::produce(edm::Event& iEvent, const edm::EventSetup& iSe
 	
 	// fill TrackingRecHits
 	unsigned nh1=track.recHitsSize();
-	for ( unsigned ih=0; ih<nh1; ++ih ) { 
-	  //const TrackingRecHit*hit=&((*(track->recHit(ih))));
-	  outputTrkHits->push_back( track.recHit(ih)->clone() );
-	  tx.add( TrackingRecHitRef( refTrkHits, outputTrkHits->size() - 1) );
+       	tx.setHits(refTrkHits,outputTrkHits->size(),nh1);
+	for (auto hh = track.recHitsBegin(), eh=track.recHitsEnd(); hh!=eh; ++hh ) { 
+	  outputTrkHits->push_back( (*hh)->clone() );
 	}
 	
       }

--- a/RecoTracker/FinalTrackSelectors/plugins/DuplicateListMerger.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/DuplicateListMerger.cc
@@ -492,14 +492,14 @@ int DuplicateListMerger::matchCandidateToTrack(TrackCandidate candidate, edm::Ha
  
 
   for(int i = 0; i < (int)tracks->size() && track < 0;i++){
-    if((tracks->at(i)).seedRef() != candidate.seedRef())continue;
+    if( (*tracks)[i].seedRef() != candidate.seedRef())continue;
     int match = 0;
-    trackingRecHit_iterator trackRecBegin = tracks->at(i).recHitsBegin();
-    trackingRecHit_iterator trackRecEnd = tracks->at(i).recHitsEnd();
+    trackingRecHit_iterator trackRecBegin = (*tracks)[i].recHitsBegin();
+    trackingRecHit_iterator trackRecEnd = (*tracks)[i].recHitsEnd();
     for(;trackRecBegin != trackRecEnd; trackRecBegin++){
-      if(std::find(rawIds.begin(),rawIds.end(),(*(trackRecBegin)).get()->rawId()) != rawIds.end())match++;
+      if(std::find(rawIds.begin(),rawIds.end(),(*(trackRecBegin))->rawId()) != rawIds.end()) match++;
     }
-    if(match != (int)tracks->at(i).recHitsSize())continue;
+    if(match != (int)( (*tracks)[i].recHitsSize() ) ) continue;
     track = i;
   }
 

--- a/RecoTracker/FinalTrackSelectors/plugins/DuplicateTrackMerger.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/DuplicateTrackMerger.cc
@@ -218,8 +218,8 @@ void DuplicateTrackMerger::produce(edm::Event& iEvent, const edm::EventSetup& iS
       if(t1->outerPosition().Rho() > t2->innerPosition().Rho())deltaR3d *= -1.0;
       if(deltaR3d < minDeltaR3d_)continue;
       
-      FreeTrajectoryState fts1 = trajectoryStateTransform::outerFreeState(*t1, &*magfield_);
-      FreeTrajectoryState fts2 = trajectoryStateTransform::innerFreeState(*t2, &*magfield_);
+      FreeTrajectoryState fts1 = trajectoryStateTransform::outerFreeState(*t1, &*magfield_,false);
+      FreeTrajectoryState fts2 = trajectoryStateTransform::innerFreeState(*t2, &*magfield_,false);
       GlobalPoint avgPoint((t1->outerPosition().x()+t2->innerPosition().x())*0.5,(t1->outerPosition().y()+t2->innerPosition().y())*0.5,(t1->outerPosition().z()+t2->innerPosition().z())*0.5);
       TrajectoryStateClosestToPoint TSCP1 = tscpBuilder(fts1, avgPoint);
       TrajectoryStateClosestToPoint TSCP2 = tscpBuilder(fts2, avgPoint);

--- a/RecoTracker/FinalTrackSelectors/plugins/MultiTrackSelector.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/MultiTrackSelector.cc
@@ -37,14 +37,15 @@ namespace {
  T powN(T t, int n) {
   switch(n) {
   case 4: return PowN<4>::op(t); // the only one that matters
+  case 3: return PowN<3>::op(t); // and this
+  case 8: return PowN<8>::op(t); // used in conversion????
   case 2: return PowN<2>::op(t);
-  case 3: return PowN<3>::op(t);
   case 5: return PowN<5>::op(t);
   case 6: return PowN<6>::op(t);
   case 7: return PowN<7>::op(t);
   case 0: return PowN<0>::op(t);
   case 1: return PowN<1>::op(t);
-  default : return powN(t,T(n)); 
+  default : return std::pow(t,T(n)); 
   }
  }
 

--- a/RecoTracker/FinalTrackSelectors/plugins/MultiTrackSelector.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/MultiTrackSelector.cc
@@ -361,12 +361,12 @@ void MultiTrackSelector::run( edm::Event& evt, const edm::EventSetup& es ) const
 
   using namespace std; 
   
-  if(tk.found()>=min_hits_bypass_[tsNum]) return true;
-  if ( tk.ndof() < 1E-5 ) return false;
-
   //cuts on number of valid hits
-  uint32_t nhits = tk.numberOfValidHits();
+  auto nhits = tk.numberOfValidHits();
+  if(nhits>=min_hits_bypass_[tsNum]) return true;
   if(nhits < min_nhits_[tsNum]) return false;
+
+  if ( tk.ndof() < 1E-5 ) return false;
 
 
   //////////////////////////////////////////////////
@@ -378,7 +378,6 @@ void MultiTrackSelector::run( edm::Event& evt, const edm::EventSetup& es ) const
   /////////////////////////////////
   //End of MVA selection section//
   ///////////////////////////////
-
 
 
   // Cuts on numbers of layers with hits/3D hits/lost hits.

--- a/RecoTracker/FinalTrackSelectors/plugins/MultiTrackSelector.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/MultiTrackSelector.cc
@@ -400,10 +400,10 @@ void MultiTrackSelector::run( edm::Event& evt, const edm::EventSetup& es ) const
   // parametrized z0 resolution for the track pt and eta
   float nomdzE = nomd0E*(std::cosh(eta));
 
-  float dzCut = std::min( pow(dz_par1_[tsNum][0]*nlayers,dz_par1_[tsNum][1])*nomdzE, 
-		          pow(dz_par2_[tsNum][0]*nlayers,dz_par2_[tsNum][1])*dzE );
-  float d0Cut = std::min( pow(d0_par1_[tsNum][0]*nlayers,d0_par1_[tsNum][1])*nomd0E, 
-		          pow(d0_par2_[tsNum][0]*nlayers,d0_par2_[tsNum][1])*d0E );
+  float dzCut = std::min( std::pow(dz_par1_[tsNum][0]*nlayers,int(dz_par1_[tsNum][1]+0.5))*nomdzE, 
+		          std::pow(dz_par2_[tsNum][0]*nlayers,int(dz_par2_[tsNum][1]+0.5))*dzE );
+  float d0Cut = std::min( std::pow(d0_par1_[tsNum][0]*nlayers,int(d0_par1_[tsNum][1]+0.5))*nomd0E, 
+		          std::pow(d0_par2_[tsNum][0]*nlayers,int(d0_par2_[tsNum][1]+0.5))*d0E );
 
 
   // ---- PrimaryVertex compatibility cut
@@ -424,8 +424,8 @@ void MultiTrackSelector::run( edm::Event& evt, const edm::EventSetup& es ) const
     float dzPV = tk.dz(*point); //re-evaluate the dz with respect to the vertex position
     float d0PV = tk.dxy(*point); //re-evaluate the dxy with respect to the vertex position
     if(useVtxError_){
-       float dzErrPV = sqrt(dzE*dzE+vzerr[iv]*vzerr[iv]); // include vertex error in z
-       float d0ErrPV = sqrt(d0E*d0E+vterr[iv]*vterr[iv]); // include vertex error in xy
+       float dzErrPV = std::sqrt(dzE*dzE+vzerr[iv]*vzerr[iv]); // include vertex error in z
+       float d0ErrPV = std::sqrt(d0E*d0E+vterr[iv]*vterr[iv]); // include vertex error in xy
        iv++;
        if (abs(dzPV) < dz_par1_[tsNum][0]*pow(nlayers,dz_par1_[tsNum][1])*nomdzE &&
 	   abs(dzPV) < dz_par2_[tsNum][0]*pow(nlayers,dz_par2_[tsNum][1])*dzErrPV &&

--- a/RecoTracker/FinalTrackSelectors/plugins/MultiTrackSelector.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/MultiTrackSelector.cc
@@ -249,12 +249,12 @@ void MultiTrackSelector::run( edm::Event& evt, const edm::EventSetup& es ) const
 
   // Get tracks 
   Handle<TrackCollection> hSrcTrack;
-  evt.getByToken( src_, hSrcTrack );
+  evt.getByToken(src_, hSrcTrack );
   const TrackCollection& srcTracks(*hSrcTrack);
 
   // get hits in track..
   Handle<TrackingRecHitCollection> hSrcHits;
-  evt.getByToken( hSrc_, hSrcHits );
+  evt.getByToken(hSrc_, hSrcHits );
   const TrackingRecHitCollection & srcHits(*hSrcHits);
 
 

--- a/RecoTracker/FinalTrackSelectors/plugins/MultiTrackSelector.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/MultiTrackSelector.cc
@@ -397,11 +397,11 @@ void MultiTrackSelector::run( edm::Event& evt, const edm::EventSetup& es ) const
   float chi2n_no1Dmod = chi2n;
 
   int count1dhits = 0;
-  auto ith = tk.recHitsBegin().key();
-  auto  edh = (--tk.recHitsEnd()).key();
-  assert( tk.recHitsEnd()-tk.recHitsBegin() == edh-ith+1);
-  for (; ith<=edh; ++ith) {
-    const TrackingRecHit & hit = recHits[ith];
+  auto ith = tk.recHitsBegin();
+  auto  edh = ith + tk.recHitsSize();
+  for (; ith<edh; ++ith) {
+//    const TrackingRecHit & hit = recHits[ith];
+    const TrackingRecHit & hit = **ith;
     if (hit.dimension()==1) ++count1dhits;
   }
   if (count1dhits > 0) {
@@ -545,7 +545,7 @@ void MultiTrackSelector::processMVA(edm::Event& evt, const edm::EventSetup& es, 
  // get hits in track..
   Handle<TrackingRecHitCollection> hSrcHits;
   evt.getByToken( hSrc_, hSrcHits );
-  const TrackingRecHitCollection & srcHits(*hSrcHits);
+  // const TrackingRecHitCollection & srcHits(*hSrcHits);
 
 
   auto_ptr<edm::ValueMap<float> >mvaValValueMap = auto_ptr<edm::ValueMap<float> >(new edm::ValueMap<float>);
@@ -573,11 +573,11 @@ void MultiTrackSelector::processMVA(edm::Event& evt, const edm::EventSetup& es, 
     float chi2n_no1Dmod = chi2n;
     
     int count1dhits = 0;
-    auto ith = trk.recHitsBegin().key();
-    auto  edh = (--trk.recHitsEnd()).key();
-    assert( trk.recHitsEnd()-trk.recHitsBegin() == edh-ith+1);
-    for (; ith<=edh; ++ith) {
-      const TrackingRecHit & hit = srcHits[ith];
+    auto ith = trk.recHitsBegin();
+    auto  edh = ith + trk.recHitsSize();
+    for (; ith<edh; ++ith) {
+//    const TrackingRecHit & hit = srcHits[ith];
+      const TrackingRecHit & hit = **ith;
       if (hit.dimension()==1) ++count1dhits;
     }
     if (count1dhits > 0) {

--- a/RecoTracker/FinalTrackSelectors/plugins/MultiTrackSelector.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/MultiTrackSelector.cc
@@ -397,11 +397,10 @@ void MultiTrackSelector::run( edm::Event& evt, const edm::EventSetup& es ) const
   float chi2n_no1Dmod = chi2n;
 
   int count1dhits = 0;
-  auto ith = tk.recHitsBegin();
+  auto ith = tk.extra()->firstRecHit();
   auto  edh = ith + tk.recHitsSize();
   for (; ith<edh; ++ith) {
-//    const TrackingRecHit & hit = recHits[ith];
-    const TrackingRecHit & hit = **ith;
+    const TrackingRecHit & hit = recHits[ith];
     if (hit.dimension()==1) ++count1dhits;
   }
   if (count1dhits > 0) {
@@ -545,7 +544,7 @@ void MultiTrackSelector::processMVA(edm::Event& evt, const edm::EventSetup& es, 
  // get hits in track..
   Handle<TrackingRecHitCollection> hSrcHits;
   evt.getByToken( hSrc_, hSrcHits );
-  // const TrackingRecHitCollection & srcHits(*hSrcHits);
+  const TrackingRecHitCollection & srcHits(*hSrcHits);
 
 
   auto_ptr<edm::ValueMap<float> >mvaValValueMap = auto_ptr<edm::ValueMap<float> >(new edm::ValueMap<float>);
@@ -573,11 +572,10 @@ void MultiTrackSelector::processMVA(edm::Event& evt, const edm::EventSetup& es, 
     float chi2n_no1Dmod = chi2n;
     
     int count1dhits = 0;
-    auto ith = trk.recHitsBegin();
+    auto ith = trk.extra()->firstRecHit();
     auto  edh = ith + trk.recHitsSize();
     for (; ith<edh; ++ith) {
-//    const TrackingRecHit & hit = srcHits[ith];
-      const TrackingRecHit & hit = **ith;
+      const TrackingRecHit & hit = srcHits[ith];
       if (hit.dimension()==1) ++count1dhits;
     }
     if (count1dhits > 0) {

--- a/RecoTracker/FinalTrackSelectors/plugins/MultiTrackSelector.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/MultiTrackSelector.cc
@@ -10,6 +10,48 @@
 #include <TMath.h>
 #include <TFile.h>
 
+namespace {
+ // not a generic solution (wrong for N negative for instance)
+ template<int N> 
+ struct PowN {
+   template<typename T>
+   static T op(T t) { return PowN<N/2>::op(t)*PowN<(N+1)/2>::op(t);}
+ };
+ template<> 
+ struct PowN<0> {
+   template<typename T>
+   static T op(T t) { return T(1);}
+ };
+ template<>
+ struct PowN<1> {
+   template<typename T>
+   static T op(T t) { return t;}
+ };
+ template<>
+ struct PowN<2> {
+   template<typename T>
+   static T op(T t) { return t*t;}
+ };
+
+ template<typename T>
+ T powN(T t, int n) {
+  switch(n) {
+  case 4: return PowN<4>::op(t); // the only one that matters
+  case 2: return PowN<2>::op(t);
+  case 3: return PowN<3>::op(t);
+  case 5: return PowN<5>::op(t);
+  case 6: return PowN<6>::op(t);
+  case 7: return PowN<7>::op(t);
+  case 0: return PowN<0>::op(t);
+  case 1: return PowN<1>::op(t);
+  default : return powN(t,T(n)); 
+  }
+ }
+
+
+}
+
+
 using namespace reco;
 
 MultiTrackSelector::MultiTrackSelector()
@@ -400,10 +442,10 @@ void MultiTrackSelector::run( edm::Event& evt, const edm::EventSetup& es ) const
   // parametrized z0 resolution for the track pt and eta
   float nomdzE = nomd0E*(std::cosh(eta));
 
-  float dzCut = std::min( std::pow(dz_par1_[tsNum][0]*nlayers,int(dz_par1_[tsNum][1]+0.5))*nomdzE, 
-		          std::pow(dz_par2_[tsNum][0]*nlayers,int(dz_par2_[tsNum][1]+0.5))*dzE );
-  float d0Cut = std::min( std::pow(d0_par1_[tsNum][0]*nlayers,int(d0_par1_[tsNum][1]+0.5))*nomd0E, 
-		          std::pow(d0_par2_[tsNum][0]*nlayers,int(d0_par2_[tsNum][1]+0.5))*d0E );
+  float dzCut = std::min( powN(dz_par1_[tsNum][0]*nlayers,int(dz_par1_[tsNum][1]+0.5))*nomdzE, 
+		          powN(dz_par2_[tsNum][0]*nlayers,int(dz_par2_[tsNum][1]+0.5))*dzE );
+  float d0Cut = std::min( powN(d0_par1_[tsNum][0]*nlayers,int(d0_par1_[tsNum][1]+0.5))*nomd0E, 
+		          powN(d0_par2_[tsNum][0]*nlayers,int(d0_par2_[tsNum][1]+0.5))*d0E );
 
 
   // ---- PrimaryVertex compatibility cut

--- a/RecoTracker/FinalTrackSelectors/plugins/MultiTrackSelector.h
+++ b/RecoTracker/FinalTrackSelectors/plugins/MultiTrackSelector.h
@@ -59,7 +59,8 @@
 
             /// return class, or -1 if rejected
             bool select (unsigned tsNum,
-			 const reco::BeamSpot &vertexBeamSpot, 
+			 const reco::BeamSpot &vertexBeamSpot,
+                         const TrackingRecHitCollection & recHits,
 			 const reco::Track &tk, 
 			 const std::vector<Point> &points,
 			 std::vector<float> &vterr,
@@ -75,6 +76,7 @@
 
             /// source collection label
             edm::EDGetTokenT<reco::TrackCollection> src_;
+            edm::EDGetTokenT<TrackingRecHitCollection> hSrc_;
             edm::EDGetTokenT<reco::BeamSpot> beamspot_;
             bool          useVertices_;
             bool          useVtxError_;

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackListMerger.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackListMerger.cc
@@ -430,9 +430,8 @@ namespace {
 
       rh1[i].reserve(validHits) ;
       auto compById = [](IHit const &  h1, IHit const & h2) {return h1.first < h2.first;};
-      // fh1[i] = &(**track->recHitsBegin());
       for (trackingRecHit_iterator it = track->recHitsBegin();  it != track->recHitsEnd(); ++it) {
-	const TrackingRecHit* hit = &(**it);
+	const TrackingRecHit* hit = (*it);
 	unsigned int id = hit->rawId() ;
 	if(hit->geographicalId().subdetId()>2)  id &= (~3); // mask mono/stereo in strips...
 	if likely(hit->isValid()) { rh1[i].emplace_back(id,hit); std::push_heap(rh1[i].begin(),rh1[i].end(),compById); }
@@ -754,11 +753,10 @@ namespace {
 
 	// fill TrackingRecHits
 	unsigned nh1=track->recHitsSize();
-	for ( unsigned ih=0; ih<nh1; ++ih ) {
-	  //const TrackingRecHit*hit=&((*(track->recHit(ih))));
-	  outputTrkHits->push_back( track->recHit(ih)->clone() );
-	  tx.add( TrackingRecHitRef( refTrkHits, outputTrkHits->size() - 1) );
-	}
+        tx.setHits(refTrkHits,outputTrkHits->size(),nh1);
+        for (auto hh = track->recHitsBegin(), eh=track->recHitsEnd(); hh!=eh; ++hh ) {
+          outputTrkHits->push_back( (*hh)->clone() );
+        }
       }
       trackRefs[i] = reco::TrackRef(refTrks, outputTrks->size() - 1);
 

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackerTrackHitFilter.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackerTrackHitFilter.cc
@@ -564,7 +564,7 @@ void TrackerTrackHitFilter::produceFromTrack(const edm::EventSetup &iSetup, cons
         hits.clear(); // extra safety
 
         for (trackingRecHit_iterator ith = itt->recHitsBegin(), edh = itt->recHitsEnd(); ith != edh; ++ith) {
-	  const TrackingRecHit * hit = ith->get(); // ith is an iterator on edm::Ref to rechit
+	  const TrackingRecHit * hit = (*ith); // ith is an iterator on edm::Ref to rechit
 
 	    DetId detid = hit->geographicalId();
 

--- a/RecoTracker/FinalTrackSelectors/python/multiTrackSelector_cfi.py
+++ b/RecoTracker/FinalTrackSelectors/python/multiTrackSelector_cfi.py
@@ -17,6 +17,7 @@ looseMTS = cms.PSet(
     chi2n_par = cms.double(1.6),
     chi2n_no1Dmod_par = cms.double(9999),
     res_par = cms.vdouble(0.003, 0.01),
+#   second param is actually an	int
     d0_par1 = cms.vdouble(0.55, 4.0),
     dz_par1 = cms.vdouble(0.65, 4.0),
     d0_par2 = cms.vdouble(0.55, 4.0),
@@ -54,6 +55,7 @@ looseMTS = cms.PSet(
 
 tightMTS=looseMTS.clone(
     preFilterName='TrkLoose',
+#   second param is actually an int
     d0_par1 = cms.vdouble(0.3, 4.0),
     dz_par1 = cms.vdouble(0.35,4.0),
     d0_par2 = cms.vdouble(0.4, 4.0),

--- a/RecoTracker/TrackProducer/src/KfTrackProducerBase.cc
+++ b/RecoTracker/TrackProducer/src/KfTrackProducerBase.cc
@@ -126,10 +126,10 @@ void KfTrackProducerBase::putInEvt(edm::Event& evt,
     assert(ih==hidx);
     t2t(*theTraj,*selHits,useSplitting);
     auto ie = selHits->size();
+    tx.setHits(rHits,ih,ie-ih);
     for (;ih<ie; ++ih) {
       auto const & hit = (*selHits)[ih];
       track.appendHitPattern(hit);
-      tx.add( TrackingRecHitRef( rHits, hidx ++ ) );
     }
     
     /*

--- a/RecoTracker/TrackProducer/src/KfTrackProducerBase.cc
+++ b/RecoTracker/TrackProducer/src/KfTrackProducerBase.cc
@@ -33,7 +33,6 @@ void KfTrackProducerBase::putInEvt(edm::Event& evt,
   reco::TrackExtraRefProd rTrackExtras = evt.getRefBeforePut<reco::TrackExtraCollection>();
 
   edm::Ref<reco::TrackExtraCollection>::key_type idx = 0;
-  edm::Ref<reco::TrackExtraCollection>::key_type hidx = 0;
   edm::Ref<reco::TrackCollection>::key_type iTkRef = 0;
   edm::Ref< std::vector<Trajectory> >::key_type iTjRef = 0;
   std::map<unsigned int, unsigned int> tjTkMap;
@@ -123,7 +122,6 @@ void KfTrackProducerBase::putInEvt(edm::Event& evt,
     // This is consistent with innermost and outermost labels only for tracks from LHC collisions
     Traj2TrackHits t2t(hitBuilder,false);
     auto ih = selHits->size();
-    assert(ih==hidx);
     t2t(*theTraj,*selHits,useSplitting);
     auto ie = selHits->size();
     tx.setHits(rHits,ih,ie-ih);
@@ -132,33 +130,6 @@ void KfTrackProducerBase::putInEvt(edm::Event& evt,
       track.appendHitPattern(hit);
     }
     
-    /*
-    // ---  NOTA BENE: the convention is to sort hits and measurements "along the momentum".
-    // This is consistent with innermost and outermost labels only for tracks from LHC collisions
-    TrajectoryFitter::RecHitContainer transHits; theTraj->recHitsV(transHits, useSplitting);
-    if (theTraj->direction() == alongMomentum) {
-        for(TrajectoryFitter::RecHitContainer::const_iterator j = transHits.begin();
-                j != transHits.end(); j++) {
-            if ((**j).hit() != 0){
-                TrackingRecHit *hit = (**j).hit()->clone();
-                track.appendHitPattern(*hit);
-                selHits->push_back(hit);
-                tx.add(TrackingRecHitRef(rHits, hidx++));
-            }
-        }
-    }else{
-        for(TrajectoryFitter::RecHitContainer::const_iterator j = transHits.end() - 1;
-                j != transHits.begin() - 1; --j) {
-            if ((**j).hit() != 0){
-                TrackingRecHit * hit = (**j).hit()->clone();
-                track.appendHitPattern(*hit);
-                selHits->push_back(hit);
-                tx.add(TrackingRecHitRef(rHits, hidx++));
-            }
-        }
-    }
-    */
-
     // ----
     tx.setResiduals(trajectoryToResiduals(*theTraj));
 

--- a/SimMuon/MCTruth/src/MuonAssociatorByHits.cc
+++ b/SimMuon/MCTruth/src/MuonAssociatorByHits.cc
@@ -1396,7 +1396,6 @@ void MuonAssociatorByHits::associateMuons(MuonToSimCollection & recToSim, SimToM
     /// PART 1: Fill MuonAssociatorByHits::TrackHitsCollection
     MuonAssociatorByHits::TrackHitsCollection muonHitRefs;
     edm::OwnVector<TrackingRecHit> allTMRecHits;  // this I will fill in only for tracker muon hits from segments
-    TrackingRecHitRefVector hitRefVector;              // same as above, plus used to get null iterators for muons without a track
     switch (trackType) {
         case InnerTk: 
             for (edm::RefToBaseVector<reco::Muon>::const_iterator it = muons.begin(), ed = muons.end(); it != ed; ++it) {
@@ -1404,7 +1403,7 @@ void MuonAssociatorByHits::associateMuons(MuonToSimCollection & recToSim, SimToM
                 if (mur->track().isNonnull()) { 
                     muonHitRefs.push_back(std::make_pair(mur->track()->recHitsBegin(), mur->track()->recHitsEnd()));
                 } else {
-                    muonHitRefs.push_back(std::make_pair(hitRefVector.begin(), hitRefVector.end()));
+                    muonHitRefs.push_back(std::make_pair(allTMRecHits.data().end(), allTMRecHits.data().end()));
                 }
             }
             break;
@@ -1414,7 +1413,7 @@ void MuonAssociatorByHits::associateMuons(MuonToSimCollection & recToSim, SimToM
                 if (mur->outerTrack().isNonnull()) { 
                     muonHitRefs.push_back(std::make_pair(mur->outerTrack()->recHitsBegin(), mur->outerTrack()->recHitsEnd()));
                 } else {
-                    muonHitRefs.push_back(std::make_pair(hitRefVector.begin(), hitRefVector.end()));
+                    muonHitRefs.push_back(std::make_pair(allTMRecHits.data().end(), allTMRecHits.data().end()));
                 }
             }
             break;
@@ -1424,8 +1423,8 @@ void MuonAssociatorByHits::associateMuons(MuonToSimCollection & recToSim, SimToM
                 if (mur->globalTrack().isNonnull()) { 
                     muonHitRefs.push_back(std::make_pair(mur->globalTrack()->recHitsBegin(), mur->globalTrack()->recHitsEnd()));
                 } else {
-                    muonHitRefs.push_back(std::make_pair(hitRefVector.begin(), hitRefVector.end()));
-                }
+                    muonHitRefs.push_back(std::make_pair(allTMRecHits.data().end(), allTMRecHits.data().end()));
+               }
             }
             break;
         case Segments: {
@@ -1445,13 +1444,9 @@ void MuonAssociatorByHits::associateMuons(MuonToSimCollection & recToSim, SimToM
                     }
                     muonHitIndices.push_back(indices);  
                 }
-                // puts hits in the ref-vector
-                for (size_t i = 0, n = allTMRecHits.size(); i < n; ++i) {
-                    hitRefVector.push_back(TrackingRecHitRef(& allTMRecHits, i)); 
-                }
                 // convert indices into pairs of iterators to references
                 typedef std::pair<size_t, size_t> index_pair;
-                trackingRecHit_iterator hitRefBegin = hitRefVector.begin();
+                trackingRecHit_iterator hitRefBegin = allTMRecHits.data().begin();
                 for (std::vector<std::pair<size_t, size_t> >::const_iterator idxs = muonHitIndices.begin(), idxend = muonHitIndices.end(); idxs != idxend; ++idxs) {
                     muonHitRefs.push_back(std::make_pair(hitRefBegin+idxs->first, 
                                                          hitRefBegin+idxs->second));

--- a/TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h
+++ b/TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h
@@ -22,21 +22,21 @@ namespace trajectoryStateTransform {
   /// Construct a FreeTrajectoryState from the reco::Track innermost or outermost state, 
   /// does not require access to tracking geometry
   FreeTrajectoryState initialFreeState( const reco::Track& tk,
-					const MagneticField* field);
+					const MagneticField* field, bool withErr=true);
 
   FreeTrajectoryState innerFreeState( const reco::Track& tk,
-				      const MagneticField* field);
+				      const MagneticField* field, bool withErr=true);
   FreeTrajectoryState outerFreeState( const reco::Track& tk,
-				      const MagneticField* field);
+				      const MagneticField* field, bool withErr=true);
 
   /// Construct a TrajectoryStateOnSurface from the reco::Track innermost or outermost state, 
   /// requires access to tracking geometry
   TrajectoryStateOnSurface innerStateOnSurface( const reco::Track& tk, 
 						const TrackingGeometry& geom,
-						const MagneticField* field);
+						const MagneticField* field, bool withErr=true);
   TrajectoryStateOnSurface outerStateOnSurface( const reco::Track& tk, 
 						const TrackingGeometry& geom,
-						const MagneticField* field);
+						const MagneticField* field, bool withErr=true);
 
 }
 

--- a/TrackingTools/TrajectoryState/src/TrajectoryStateTransform.cc
+++ b/TrackingTools/TrajectoryState/src/TrajectoryStateTransform.cc
@@ -67,38 +67,41 @@ namespace trajectoryStateTransform {
 }
   
   FreeTrajectoryState initialFreeState( const reco::Track& tk,
-					const MagneticField* field) 
+					const MagneticField* field, bool withErr) 
   {
     Basic3DVector<float> pos( tk.vertex());
     GlobalPoint gpos( pos);
     Basic3DVector<float> mom( tk.momentum());
-  GlobalVector gmom( mom);
-  GlobalTrajectoryParameters par( gpos, gmom, tk.charge(), field);
-  CurvilinearTrajectoryError err( tk.covariance());
-  return FreeTrajectoryState( par, err);
+    GlobalVector gmom( mom);
+    GlobalTrajectoryParameters par( gpos, gmom, tk.charge(), field);
+    if (!withErr) return FreeTrajectoryState(par);
+    CurvilinearTrajectoryError err( tk.covariance());
+    return FreeTrajectoryState( par, err);
   }
   
   FreeTrajectoryState innerFreeState( const reco::Track& tk,
-				      const MagneticField* field)
+				      const MagneticField* field, bool withErr)
   {
     Basic3DVector<float> pos( tk.innerPosition());
     GlobalPoint gpos( pos);
     Basic3DVector<float> mom( tk.innerMomentum());
     GlobalVector gmom( mom);
     GlobalTrajectoryParameters par( gpos, gmom, tk.charge(), field);
+    if (!withErr) return FreeTrajectoryState(par);
     CurvilinearTrajectoryError err( tk.extra()->innerStateCovariance());
     return FreeTrajectoryState( par, err);
   }
 
   
   FreeTrajectoryState outerFreeState( const reco::Track& tk,
-				      const MagneticField* field)
+				      const MagneticField* field, bool withErr)
   {
     Basic3DVector<float> pos( tk.outerPosition());
     GlobalPoint gpos( pos);
     Basic3DVector<float> mom( tk.outerMomentum());
     GlobalVector gmom( mom);
     GlobalTrajectoryParameters par( gpos, gmom, tk.charge(), field);
+    if (!withErr) return FreeTrajectoryState(par);
     CurvilinearTrajectoryError err( tk.extra()->outerStateCovariance());
     return FreeTrajectoryState( par, err);
   }
@@ -106,18 +109,18 @@ namespace trajectoryStateTransform {
   
   TrajectoryStateOnSurface innerStateOnSurface( const reco::Track& tk, 
 						const TrackingGeometry& geom,
-						const MagneticField* field)
+						const MagneticField* field, bool withErr)
   {
     const Surface& surface = geom.idToDet( DetId( tk.extra()->innerDetId()))->surface();
-    return TrajectoryStateOnSurface( innerFreeState( tk, field), surface);
+    return TrajectoryStateOnSurface( innerFreeState( tk, field, withErr), surface);
   }
   
   TrajectoryStateOnSurface outerStateOnSurface( const reco::Track& tk, 
 						const TrackingGeometry& geom,
-						const MagneticField* field)
+						const MagneticField* field, bool withErr)
   {
     const Surface& surface = geom.idToDet( DetId( tk.extra()->outerDetId()))->surface();
-    return TrajectoryStateOnSurface( outerFreeState( tk, field), surface);
+    return TrajectoryStateOnSurface( outerFreeState( tk, field, withErr), surface);
   }
   
 }


### PR DESCRIPTION
Modified the storage of referencing the hits in a track to a simple pair of integer (and a RefCore)
fully backward compatible interface, including iorule.
Speedup MultiTrackSelector removing all overheads not due to MVA.
Part of the improvements are In HitPattern (more can be done, volunteers welcome)
