### PR TITLE
Fix failure during merge when histogram limits are invalid

### DIFF
--- a/DataFormats/Histograms/interface/MEtoEDMFormat.h
+++ b/DataFormats/Histograms/interface/MEtoEDMFormat.h
@@ -113,10 +113,15 @@ class MEtoEDM
            MEtoEdmObject[j].object.GetYaxis()->GetXmax() == newMEtoEDMObject[i].object.GetYaxis()->GetXmax() &&
            MEtoEdmObject[j].object.GetNbinsZ()           == newMEtoEDMObject[i].object.GetNbinsZ()           &&
            MEtoEdmObject[j].object.GetZaxis()->GetXmin() == newMEtoEDMObject[i].object.GetZaxis()->GetXmin() &&
-           MEtoEdmObject[j].object.GetZaxis()->GetXmax() == newMEtoEDMObject[i].object.GetZaxis()->GetXmax()) {
+           MEtoEdmObject[j].object.GetZaxis()->GetXmax() == newMEtoEDMObject[i].object.GetZaxis()->GetXmax() &&
+		   // Also check that the min is less than the max. Root allows this to be booked but then
+		   // crashes when it adds them.
+           (MEtoEdmObject[j].object.GetXaxis()->GetXmin() < MEtoEdmObject[j].object.GetXaxis()->GetXmax())   &&
+           (MEtoEdmObject[j].object.GetYaxis()->GetXmin() < MEtoEdmObject[j].object.GetYaxis()->GetXmax())   &&
+           (MEtoEdmObject[j].object.GetZaxis()->GetXmin() < MEtoEdmObject[j].object.GetZaxis()->GetXmax())) {
          MEtoEdmObject[j].object.Add(&newMEtoEDMObject[i].object);
        } else {
-          std::cout << "ERROR MEtoEDM::mergeProducts(): found histograms with different axis limits, '" << name << "' not merged" <<  std::endl;
+          std::cout << "ERROR MEtoEDM::mergeProducts(): found histograms with different or invalid axis limits, '" << name << "' not merged" <<  std::endl;
 #if debug
           std::cout << MEtoEdmObject[j].name                         << " " << newMEtoEDMObject[i].name                         << std::endl;
           std::cout << MEtoEdmObject[j].object.GetNbinsX()           << " " << newMEtoEDMObject[i].object.GetNbinsX()           << std::endl;

--- a/DataFormats/Histograms/interface/MEtoEDMFormat.h
+++ b/DataFormats/Histograms/interface/MEtoEDMFormat.h
@@ -114,8 +114,8 @@ class MEtoEDM
            MEtoEdmObject[j].object.GetNbinsZ()           == newMEtoEDMObject[i].object.GetNbinsZ()           &&
            MEtoEdmObject[j].object.GetZaxis()->GetXmin() == newMEtoEDMObject[i].object.GetZaxis()->GetXmin() &&
            MEtoEdmObject[j].object.GetZaxis()->GetXmax() == newMEtoEDMObject[i].object.GetZaxis()->GetXmax() &&
-		   // Also check that the min is less than the max. Root allows this to be booked but then
-		   // crashes when it adds them.
+           // Also check that the min is less than the max. Root allows this to be booked but then
+           // crashes when it adds them.
            (MEtoEdmObject[j].object.GetXaxis()->GetXmin() < MEtoEdmObject[j].object.GetXaxis()->GetXmax())   &&
            (MEtoEdmObject[j].object.GetYaxis()->GetXmin() < MEtoEdmObject[j].object.GetYaxis()->GetXmax())   &&
            (MEtoEdmObject[j].object.GetZaxis()->GetXmin() < MEtoEdmObject[j].object.GetZaxis()->GetXmax())) {


### PR DESCRIPTION
This should stop the relval failures for HGCal.  The problem was that validation plots were being booked with equal minimum and maximum limits which causes root to fail when adding them together during merging.  This adds a check during the merging to ignore histograms where the min is not less than the max.  **This does not fix the underlying problem**, it merely stops it failing the whole merge.

The underlying problem is for the following plots:

```
HcalHitsV/SimHitsValidationHcal/HcalHitEtaHE0-z
HcalHitsV/SimHitsValidationHcal/HcalHitEtaHE2+z
HcalHitsV/SimHitsValidationHcal/HcalHitEtaHE2-z
HcalHitsV/SimHitsValidationHcal/HcalHitTimeAEtaHE0-z
HcalHitsV/SimHitsValidationHcal/HcalHitTimeAEtaHE2+z
HcalHitsV/SimHitsValidationHcal/HcalHitTimeAEtaHE2-z
HcalHitsV/SimHitsValidationHcal/HcalHitE100HE0-z
HcalHitsV/SimHitsValidationHcal/HcalHitE100HE2+z
HcalHitsV/SimHitsValidationHcal/HcalHitE100HE2-z
HcalHitsV/SimHitsValidationHcal/HcalHitE250HE0-z
HcalHitsV/SimHitsValidationHcal/HcalHitE250HE2+z
HcalHitsV/SimHitsValidationHcal/HcalHitE250HE2-z
HcalHitsV/SimHitsValidationHcal/HcalHitE25HE0-z
HcalHitsV/SimHitsValidationHcal/HcalHitE25HE2+z
HcalHitsV/SimHitsValidationHcal/HcalHitE25HE2-z
HcalHitsV/SimHitsValidationHcal/HcalHitE50HE0-z
HcalHitsV/SimHitsValidationHcal/HcalHitE50HE2+z
HcalHitsV/SimHitsValidationHcal/HcalHitE50HE2-z
```

It appears that the limits are set dynamically in [SimHitsValidationHcal::getLimits](https://github.com/cms-sw/cmssw/blob/CMSSW_6_2_X_SLHC/Validation/HcalHits/src/SimHitsValidationHcal.cc#L302) and this is failing for HGCal and returning equal numbers.

@vandreev11, @pfs, @boudoul, @davidlange6 (also @lgray since you were on some thread about it).
