### PR TITLE
L1t bugfix algbugfixes cmssw 7 2 x

### DIFF
--- a/L1Trigger/L1TCalorimeter/interface/PUSubtractionMethods.h
+++ b/L1Trigger/L1TCalorimeter/interface/PUSubtractionMethods.h
@@ -25,7 +25,6 @@ namespace l1t {
 			   std::vector<l1t::CaloRegion> *subRegions);
 
   void RegionCorrection(const std::vector<l1t::CaloRegion> & regions,
-			const std::vector<l1t::CaloEmCand> & EMCands,
 			std::vector<l1t::CaloRegion> *subRegions,
 			std::vector<double> regionPUSparams,
 			std::string regionPUSType);

--- a/L1Trigger/L1TCalorimeter/src/PUSubtractionMethods.cc
+++ b/L1Trigger/L1TCalorimeter/src/PUSubtractionMethods.cc
@@ -106,6 +106,7 @@ namespace l1t {
       if (regionET > 0) {puMult++;}
     }
     int pumbin = (int) puMult/22;
+    if(pumbin == 18) pumbin = 17; // if puMult = 396 exactly there is an overflow
 
     for(std::vector<CaloRegion>::const_iterator notCorrectedRegion = regions.begin();
 	notCorrectedRegion != regions.end(); notCorrectedRegion++){

--- a/L1Trigger/L1TCalorimeter/src/PUSubtractionMethods.cc
+++ b/L1Trigger/L1TCalorimeter/src/PUSubtractionMethods.cc
@@ -106,31 +106,28 @@ namespace l1t {
       if (regionET > 0) {puMult++;}
     }
     int pumbin = (int) puMult/22;
-    
+
     for(std::vector<CaloRegion>::const_iterator notCorrectedRegion = regions.begin();
 	notCorrectedRegion != regions.end(); notCorrectedRegion++){
-      
+
       int regionET = notCorrectedRegion->hwPt();
       int regionEta = notCorrectedRegion->hwEta();
       int regionPhi = notCorrectedRegion->hwPhi();
 
-      int regionEtCorr (0);
-
-      double puSub = regionPUSParams[18*regionEta+pumbin]*2;
+      int puSub = ceil(regionPUSParams[18*regionEta+pumbin]*2);
       // The values in regionSubtraction are MULTIPLIED by
       // RegionLSB=.5 (physicalRegionEt), so to get back unmultiplied
       // regionSubtraction we want to multiply the number by 2
       // (aka divide by LSB).
-      
-      regionEtCorr = regionET - puSub;
-      if(regionEtCorr < 0) regionEtCorr = 0;
-      
+
+      int regionEtCorr = std::max(0, regionET - puSub);
+
       ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double> > lorentz(0,0,0,0);
       CaloRegion newSubRegion(*&lorentz, 0, 0, regionEtCorr, regionEta, regionPhi, notCorrectedRegion->hwQual(), notCorrectedRegion->hwEtEm(), notCorrectedRegion->hwEtHad());
       subRegions->push_back(newSubRegion);
     }
   }
-  
+
 }
-  
+
 }

--- a/L1Trigger/L1TCalorimeter/src/PUSubtractionMethods.cc
+++ b/L1Trigger/L1TCalorimeter/src/PUSubtractionMethods.cc
@@ -77,7 +77,6 @@ namespace l1t {
   /// --------- New region correction (PUsub, no response correction at the moment) -----------
 
  void RegionCorrection(const std::vector<l1t::CaloRegion> & regions,
-		       const std::vector<l1t::CaloEmCand> & EMCands,
 		       std::vector<l1t::CaloRegion> *subRegions,
 		       std::vector<double> regionPUSParams,
 		       std::string regionPUSType)
@@ -106,6 +105,7 @@ namespace l1t {
       // cout << "regionET: " << regionET <<endl;
       if (regionET > 0) {puMult++;}
     }
+    int pumbin = (int) puMult/22;
     
     for(std::vector<CaloRegion>::const_iterator notCorrectedRegion = regions.begin();
 	notCorrectedRegion != regions.end(); notCorrectedRegion++){
@@ -115,53 +115,15 @@ namespace l1t {
       int regionPhi = notCorrectedRegion->hwPhi();
 
       int regionEtCorr (0);
-      // Only non-empty regions are corrected
-      if (regionET !=0) {
-	int energyECAL2x1=0;
-	// Find associated 2x1 ECAL energy (EG are calibrated,
-	// we should not scale them up, it affects the isolation routines)
-	// 2x1 regions have the MAX tower contained in the 4x4 region that its position points to.
-	// This is to not break isolation.
-	for(CaloEmCandBxCollection::const_iterator egCand = EMCands.begin();
-	    egCand != EMCands.end(); egCand++) {
-	  int et = egCand->hwPt();
-	  if(egCand->hwPhi() == regionPhi && egCand->hwEta() == regionEta) {
-	    energyECAL2x1=et;
-	    break; // I do not really like "breaks"
-	   }
-	}
-	
-	//comment out region corrections (below) at the moment, since they're broken
-	
-	//double alpha = regionSF[2*regionEta + 0]; //Region Scale factor (See regionSF_cfi)
-	//double gamma = 2*((regionSF[2*regionEta + 1])/9); //Region Offset.
-	// It needs to be divided by nine from the jet derived value in the lookup table.
-	// Multiplied by 2 because gamma is given in regionPhysicalET (=regionEt*regionLSB),
-	// while we want regionEt= physicalEt/LSB and LSB=.5.
-	
-	
-	//if(!ResponseCorr || regionET<20) {alpha=1;  gamma=0;}
-	double alpha=1;  double gamma=0;
-	
-	
-	int pumbin = (int) puMult/22; //396 Regions. Bins are 22 wide. Dividing by 22 gives which bin# of the 18 bins.
-	
-	double puSub = regionPUSParams[18*regionEta+pumbin]*2;
-	// The values in regionSubtraction are MULTIPLIED by
-	// RegionLSB=.5 (physicalRegionEt), so to get back unmultiplied
-	// regionSubtraction we want to multiply the number by 2
-	// (aka divide by LSB).
-	
-	int corrpum0pt (0);
-	if(regionET - puSub>0) {
-	  int pum0pt = (regionET - puSub-energyECAL2x1); //subtract ECAl energy
-	  
-	  corrpum0pt = pum0pt*alpha+gamma+energyECAL2x1;
-	  //add back in ECAL energy, calibrate regions(not including the ECAL2x1).
-	  if (corrpum0pt <0 || pum0pt<0) {corrpum0pt=0;} //zero floor
-	}
-	regionEtCorr = corrpum0pt;
-      }
+
+      double puSub = regionPUSParams[18*regionEta+pumbin]*2;
+      // The values in regionSubtraction are MULTIPLIED by
+      // RegionLSB=.5 (physicalRegionEt), so to get back unmultiplied
+      // regionSubtraction we want to multiply the number by 2
+      // (aka divide by LSB).
+      
+      regionEtCorr = regionET - puSub;
+      if(regionEtCorr < 0) regionEtCorr = 0;
       
       ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double> > lorentz(0,0,0,0);
       CaloRegion newSubRegion(*&lorentz, 0, 0, regionEtCorr, regionEta, regionPhi, notCorrectedRegion->hwQual(), notCorrectedRegion->hwEtEm(), notCorrectedRegion->hwEtHad());

--- a/L1Trigger/L1TCalorimeter/src/firmware/Stage1Layer2EGammaAlgorithmImpPP.cc
+++ b/L1Trigger/L1TCalorimeter/src/firmware/Stage1Layer2EGammaAlgorithmImpPP.cc
@@ -44,7 +44,7 @@ void l1t::Stage1Layer2EGammaAlgorithmImpPP::processEvent(const std::vector<l1t::
 
   //Region Correction will return uncorrected subregions if
   //regionPUSType is set to None in the config
-  RegionCorrection(regions, EMCands, subRegions, regionPUSParams, regionPUSType);
+  RegionCorrection(regions, subRegions, regionPUSParams, regionPUSType);
 
   // ----- need to cluster jets in order to compute jet isolation ----
   std::vector<l1t::Jet> *unCorrJets = new std::vector<l1t::Jet>();

--- a/L1Trigger/L1TCalorimeter/src/firmware/Stage1Layer2EtSumAlgorithmImpPP.cc
+++ b/L1Trigger/L1TCalorimeter/src/firmware/Stage1Layer2EtSumAlgorithmImpPP.cc
@@ -28,7 +28,7 @@ l1t::Stage1Layer2EtSumAlgorithmImpPP::~Stage1Layer2EtSumAlgorithmImpPP() {
 }
 
 double l1t::Stage1Layer2EtSumAlgorithmImpPP::regionPhysicalEt(const l1t::CaloRegion& cand) const {
- 
+
   return jetLsb*cand.hwPt();
 }
 
@@ -61,7 +61,7 @@ void l1t::Stage1Layer2EtSumAlgorithmImpPP::processEvent(const std::vector<l1t::C
 
   std::string regionPUSType = params_->regionPUSType();
   std::vector<double> regionPUSParams = params_->regionPUSParams();
-  RegionCorrection(regions, EMCands, subRegions, regionPUSParams, regionPUSType);
+  RegionCorrection(regions, subRegions, regionPUSParams, regionPUSType);
 
   for(std::vector<CaloRegion>::const_iterator region = subRegions->begin(); region != subRegions->end(); region++) {
     if (region->hwEta() < etSumEtaMinEt || region->hwEta() > etSumEtaMaxEt) {

--- a/L1Trigger/L1TCalorimeter/src/firmware/Stage1Layer2JetAlgorithmImpPP.cc
+++ b/L1Trigger/L1TCalorimeter/src/firmware/Stage1Layer2JetAlgorithmImpPP.cc
@@ -39,7 +39,7 @@ void Stage1Layer2JetAlgorithmImpPP::processEvent(const std::vector<l1t::CaloRegi
 
   //Region Correction will return uncorrected subregions
   //if regionPUSType is set to None in the config
-  RegionCorrection(regions, EMCands, subRegions, regionPUSParams, regionPUSType);
+  RegionCorrection(regions, subRegions, regionPUSParams, regionPUSType);
 
 
   slidingWindowJetFinder(jetSeedThreshold, subRegions, uncalibjets);

--- a/L1Trigger/L1TCalorimeter/src/firmware/Stage1Layer2TauAlgorithmImpPP.cc
+++ b/L1Trigger/L1TCalorimeter/src/firmware/Stage1Layer2TauAlgorithmImpPP.cc
@@ -53,7 +53,7 @@ void l1t::Stage1Layer2TauAlgorithmImpPP::processEvent(const std::vector<l1t::Cal
 
   //Region Correction will return uncorrected subregions if
   //regionPUSType is set to None in the config
-  RegionCorrection(regions, EMCands, subRegions, regionPUSParams, regionPUSType);
+  RegionCorrection(regions, subRegions, regionPUSParams, regionPUSType);
 
 
 
@@ -88,20 +88,20 @@ void l1t::Stage1Layer2TauAlgorithmImpPP::processEvent(const std::vector<l1t::Cal
     int highestNeighborTauVeto=999;
 
     // if (regionEt>0) std::cout << "CCLA Prod: TauVeto: " << region->hwQual() << "\tET: " << regionEt << "\tETA: " << regionEta  << "\tPhi: " << regionPhi  << std::endl;
-	  
+
     //Find neighbor with highest Et
     for(CaloRegionBxCollection::const_iterator neighbor = subRegions->begin();
 	neighbor != subRegions->end(); neighbor++) {
-      
+
       int neighborPhi = neighbor->hwPhi();
       int neighborEta = neighbor->hwEta();
       int deltaPhi = regionPhi - neighborPhi;
       if (std::abs(deltaPhi) == L1CaloRegionDetId::N_PHI-1)
 	deltaPhi = -deltaPhi/std::abs(deltaPhi); //18 regions in phi
-      
+
       deltaPhi = std::abs(deltaPhi);
       int deltaEta = std::abs(regionEta - neighborEta);
-      
+
       if (deltaPhi + deltaEta > 0 && deltaPhi + deltaEta < 2) {  //nondiagonal neighbors
 	if (neighbor->hwPt() > highestNeighborEt) {
 	  highestNeighborEt = neighbor->hwPt();
@@ -117,11 +117,11 @@ void l1t::Stage1Layer2TauAlgorithmImpPP::processEvent(const std::vector<l1t::Cal
     string NESW = findNESW(regionEta, regionPhi, highestNeighborEta, highestNeighborPhi);
 
     //std::cout << "tau et, neighbor et " << tauEt << " " << highestNeighborEt << std::endl;
-    if((tauEt > highestNeighborEt && (NESW=="isEast" || NESW=="isNorth")) 
+    if((tauEt > highestNeighborEt && (NESW=="isEast" || NESW=="isNorth"))
        || (tauEt >= highestNeighborEt && (NESW=="isSouth" || NESW=="isWest"))) {
 
       if (highestNeighborEt >= tauNeighbourThreshold) tauEt += highestNeighborEt;
-      
+
       int regionTauVeto = region->hwQual() & 0x1;  // tauVeto should be the first bit of quality integer
       //std::cout<< "regiontauveto, neighbor " << regionTauVeto << " " << highestNeighborTauVeto << std::endl;
 
@@ -132,9 +132,9 @@ void l1t::Stage1Layer2TauAlgorithmImpPP::processEvent(const std::vector<l1t::Cal
 	      || (std::abs(jetIsolation - 999.) < 0.1) ) isoFlag=1;
 	}
 	ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double> > tauLorentz(0,0,0,0);
-	
+
 	l1t::Tau theTau(*&tauLorentz, tauEt, region->hwEta(), region->hwPhi(), quality, isoFlag);
-	
+
 	preGtTaus->push_back(theTau);
     }
   }
@@ -183,9 +183,9 @@ string l1t::Stage1Layer2TauAlgorithmImpPP::findNESW(int ieta, int iphi, int neta
   int deltaPhi = iphi - nphi;
   if (std::abs(deltaPhi) == L1CaloRegionDetId::N_PHI-1)
     deltaPhi = -deltaPhi/std::abs(deltaPhi); //18 regions in phi
-  
+
   int deltaEta = ieta - neta;
-  
+
   if ((std::abs(deltaPhi) +  std::abs(deltaEta)) < 2) {
     if (deltaEta==-1) {
       return "isEast";
@@ -196,7 +196,7 @@ string l1t::Stage1Layer2TauAlgorithmImpPP::findNESW(int ieta, int iphi, int neta
       }
       if (deltaPhi==1) {
 	return "isSouth";
-      }     
+      }
     }
     else {
       return "isWest";

--- a/L1Trigger/L1TCalorimeter/src/legacyGtHelper.cc
+++ b/L1Trigger/L1TCalorimeter/src/legacyGtHelper.cc
@@ -16,7 +16,9 @@ namespace l1t {
     for(std::vector<l1t::Jet>::const_iterator itJet = input->begin();
 	itJet != input->end(); ++itJet){
       const unsigned newEta = gtEta(itJet->hwEta());
-      const uint16_t rankPt = params->jetScale().rank((uint16_t)itJet->hwPt());
+      uint16_t linPt = (uint16_t)itJet->hwPt();
+      if(linPt > params->jetScale().linScaleMax() ) linPt = params->jetScale().linScaleMax();
+      const uint16_t rankPt = params->jetScale().rank(linPt);
 
       ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double> > ldummy(0,0,0,0);
 
@@ -32,7 +34,7 @@ namespace l1t {
     for(std::vector<l1t::EGamma>::const_iterator itEGamma = input->begin();
 	itEGamma != input->end(); ++itEGamma){
       const unsigned newEta = gtEta(itEGamma->hwEta());
-      const uint16_t rankPt = (uint16_t)itEGamma->hwPt();
+      const uint16_t rankPt = (uint16_t)itEGamma->hwPt(); //max value?
 
       ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double> > ldummy(0,0,0,0);
 
@@ -48,7 +50,9 @@ namespace l1t {
     for(std::vector<l1t::Tau>::const_iterator itTau = input->begin();
 	itTau != input->end(); ++itTau){
       const unsigned newEta = gtEta(itTau->hwEta());
-      const uint16_t rankPt = params->jetScale().rank((uint16_t)itTau->hwPt());
+      uint16_t linPt = (uint16_t)itTau->hwPt();
+      if(linPt > params->jetScale().linScaleMax() ) linPt = params->jetScale().linScaleMax();
+      const uint16_t rankPt = params->jetScale().rank(linPt);
 
       ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double> > ldummy(0,0,0,0);
 
@@ -68,7 +72,10 @@ namespace l1t {
       //rankPt = params->jetScale().rank((uint16_t)itEtSum->hwPt());
       rankPt = (uint16_t)itEtSum->hwPt();
       if (EtSum::EtSumType::kMissingHt == itEtSum->getType())
-	rankPt = params->HtMissScale().rank(itEtSum->hwPt()*params->emScale().linearLsb());
+      {
+	if(rankPt > params->HtMissScale().linScaleMax()) rankPt = params->HtMissScale().linScaleMax();
+	rankPt = params->HtMissScale().rank(rankPt*params->emScale().linearLsb());
+      }
 
       ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double> > ldummy(0,0,0,0);
 

--- a/L1Trigger/L1TCalorimeter/src/legacyGtHelper.cc
+++ b/L1Trigger/L1TCalorimeter/src/legacyGtHelper.cc
@@ -73,7 +73,9 @@ namespace l1t {
       rankPt = (uint16_t)itEtSum->hwPt();
       if (EtSum::EtSumType::kMissingHt == itEtSum->getType())
       {
-	if(rankPt > params->HtMissScale().linScaleMax()) rankPt = params->HtMissScale().linScaleMax();
+	// if(rankPt > params->HtMissScale().linScaleMax()) rankPt = params->HtMissScale().linScaleMax();
+	// params->HtMissScale().linScaleMax() always returns zero.  Hardcode 512 for now
+	if(rankPt > 512) rankPt = 512;
 	rankPt = params->HtMissScale().rank(rankPt*params->emScale().linearLsb());
       }
 

--- a/L1Trigger/L1TCommon/python/customsPostLS1.py
+++ b/L1Trigger/L1TCommon/python/customsPostLS1.py
@@ -21,7 +21,7 @@ def customiseSimL1EmulatorForPostLS1(process):
         process.rctUpgradeFormatDigis.regionTag = cms.InputTag("simRctDigis")
         process.rctUpgradeFormatDigis.emTag = cms.InputTag("simRctDigis")
         #print "New L1 simulation step is:", process.L1simulation_step
-        process.simGtDigis.GmtInputTag = 'gtDigis'
+        process.simGtDigis.GmtInputTag = 'simGmtDigis'
         process.simGtDigis.GctInputTag = 'caloStage1LegacyFormatDigis'
         process.simGtDigis.TechnicalTriggersInputTags = cms.VInputTag( )
         process.gctDigiToRaw.gctInputLabel = 'caloStage1LegacyFormatDigis'


### PR DESCRIPTION
This PR fixes a major bug in the postLS1 configuration that causes GT to loose all muon inputs in emulation.  There are included smaller emulator algorithm bug fixes involving the treatment of scale limits, array-out-of-bounds, and pile-up calculation.
