### PR TITLE
Method Class_Version() must be both 'static' and 'public'

### DIFF
--- a/DataFormats/Candidate/interface/LeafRefCandidateT.h
+++ b/DataFormats/Candidate/interface/LeafRefCandidateT.h
@@ -224,6 +224,8 @@ namespace reco {
     virtual bool isConvertedPhoton() const GCC11_FINAL  { return false; }
     virtual bool isJet() const GCC11_FINAL  { return false; }
 
+    CMS_CLASS_VERSION(11)
+
   protected:
     /// T internally.
     /// NOTE! T must satisfy ref_->pt(), ref_->phi(), etc, like a TrackRef
@@ -261,8 +263,6 @@ namespace reco {
     friend class ::OverlapChecker;
     friend class ShallowCloneCandidate;
     friend class ShallowClonePtrCandidate;
-
-    CMS_CLASS_VERSION(11)
 
   private:
     // const iterator implementation


### PR DESCRIPTION
genreflex is producing at least two errors while compiling CMSSW
with

```
method Class_Version() must be both 'static' and 'public'.
```

for class reco::LeafRefCandidateT.

Move Class_Version() from protected to public to meet Reflex
requirements.

```
--->> genreflex: ERROR: class reco::LeafRefCandidateT<edm::Ref<std::vector<reco::PFCluster>,reco::PFCluster,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCluster>,reco::PFCluster> > >'s method Class_Version() must be both 'static' and 'public'.
--->> genreflex: ERROR: class reco::LeafRefCandidateT<edm::Ref<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> > >'s method Class_Version() must be both 'static' and 'public'.
```

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
