### PR TITLE
HCAL tuning and bug fixing for Phys14 exercise

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/interface/PFHBHERecHitCreatorMaxSample.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHBHERecHitCreatorMaxSample.h
@@ -27,6 +27,8 @@
 
 
 #include "RecoCaloTools/Navigation/interface/CaloNavigator.h"
+
+
 class PFHBHERecHitCreatorMaxSample :  public  PFRecHitCreatorBase {
 
  public:  
@@ -35,6 +37,11 @@ class PFHBHERecHitCreatorMaxSample :  public  PFRecHitCreatorBase {
     {
       recHitToken_ = iC.consumes<edm::SortedCollection<HBHERecHit> >(iConfig.getParameter<edm::InputTag>("src"));
     }
+
+
+  ~PFHBHERecHitCreatorMaxSample() {
+  }
+
 
     void importRecHits(std::auto_ptr<reco::PFRecHitCollection>&out,std::auto_ptr<reco::PFRecHitCollection>& cleaned ,const edm::Event& iEvent,const edm::EventSetup& iSetup) {
 
@@ -60,21 +67,17 @@ class PFHBHERecHitCreatorMaxSample :  public  PFRecHitCreatorBase {
 	const HcalDetId& detid = (HcalDetId)erh.detid();
 	HcalSubdetector esd=(HcalSubdetector)detid.subdetId();
 	
-	double energy = erh.energy();
-	double time = erh.time();
-
-
+	
 	//CUSTOM ENERGY AND TIME RECO
+
 	CaloSamples tool;
 	const HcalCalibrations& calibrations = conditions->getHcalCalibrations(detid);
 	const HcalQIECoder* channelCoder = conditions->getHcalCoder(detid);
 	const HcalQIEShape* shape = conditions->getHcalShape(channelCoder);
 	HcalCoderDb coder(*channelCoder, *shape);
-
 	int auxwd1 = erh.auxHBHE();  // TS = 0,1,2,3 info
 	int auxwd2 = erh.aux();      // TS = 4,5,6,7 info 	
 
-	
 	int adc[8];
 	int capid[8];
 
@@ -106,82 +109,57 @@ class PFHBHERecHitCreatorMaxSample :  public  PFRecHitCreatorBase {
 	  HcalQIESample s (adc[ii], capid[ii], 0, 0);
 	  digi.setSample(ii,s);
 	} 
-	
-
-	// Convert/linearize ADC to fC 
 	coder.adc2fC(digi, tool); 
-
-
-	// Get gain (GeV/fC)
-
 	HcalGenericDetId hcalGenDetId(erh.id());
-	//	const HcalPedestal* pedestal = conditions->getPedestal(hcalGenDetId);
-	//	const HcalGain* gain = conditions->getGain(hcalGenDetId);
-
-	// Convert all 8 TS from fC to GeV (also subtractibg pedestal)
-
 	std::array<double,8> samples;
 
-	unsigned int maxSample = -1;
-	double maxGain=-1e+18;
+
+	//store the samples over thresholds
 	for (int ii = 0; ii < 8; ii++) {
 	  double gain = calibrations.respcorrgain(capid[ii]) *
 	    (tool[ii] - calibrations.pedestal(capid[ii]));
-	  samples[ii] = gain;
-	  if (gain>maxGain) {
-	    maxSample=ii;
-	    maxGain=gain;
-	  } 
+	  if (gain>0.6)
+	    samples[ii] = gain;
+	  else
+	    samples[ii] = 0.0;
 
-	  //	  printf("SAMPLE %d ,%f\n",ii,calibrations.respcorrgain(capid[ii]) *
-	  //		 (tool[ii] - calibrations.pedestal(capid[ii])));
-	} 
-
-	/////////////////////////////
-	/////////////////////////////
-
-	//NAIVE ALGO By michalis -> Find the maximum and assign the maximum energy
-
-	energy  = samples[maxSample];
-	time = -100. + maxSample*25.0;
-
-	//if possible add the highest neighbour
-	double e2=0.0;
-	double t2=0.0; 
-	if (maxSample==0) {
-	  if (samples[1]>0) {
-	    e2 = samples[1];
-	    t2 = -75.0;
-	  }
 	}
-	else if (maxSample==samples.size()-1) {
-	  if (samples[samples.size()-2]>0) {
-	    e2 = samples[samples.size()-2];
-	    t2 = -100.+(samples.size()-2)*25.0;
-	  }
-	}
-	else {
-	  double eprev=0.0;
-	  double enext=0.0;
-	  eprev=samples[maxSample-1];
-	  enext=samples[maxSample+1];
-	  if (std::max(eprev,enext)>0.0) {
-	    if (eprev>enext) {
-	      e2=eprev;
-	      t2=-100.+(maxSample-1)*25.;
+
+	
+	//run the algorithm
+	double energy=0.0;
+	double energy2=0.0;
+	double time=0.0;
+
+	std::vector<double> hitEnergies;	  
+	std::vector<double> hitTimes;	  
+	for (int ii = 0; ii < 8; ii++) {
+	  energy=energy+samples[ii];
+	  time = time+(-100. + ii*25.0)*samples[ii]*samples[ii];
+	  energy2=energy2+samples[ii]*samples[ii];
+
+	  if (ii>0 && ii<7) {
+	    if (samples[ii]<=samples[ii-1] && samples[ii]<samples[ii+1] && energy>0) {
+	      hitEnergies.push_back(energy);
+	      hitTimes.push_back(time/energy2);
+	      energy=0.0;
+	      energy2=0.0;
+	      time=0.0;
 	    }
-	    else {
-	      e2=enext;
-	      t2=-100.+(maxSample+1)*25.;
-	    }
+	      
 	  }
-	}
-	if (e2>0) {
-	  time = (energy*energy*time+e2*e2*t2)/(energy*energy+e2*e2);
-	  energy+=e2;
-	}
-	  
+	  else if (ii==7 && energy>0) {
+	      hitEnergies.push_back(energy);
+	      hitTimes.push_back(time/energy2);
+	      energy=0.0;
+	      energy2=0.0;
+	      time=0.0;
+	  }
 
+	}	    
+
+	if (hitEnergies.size()==0)
+	  continue;
 
 	int depth = detid.depth();
 	math::XYZVector position;
@@ -216,13 +194,16 @@ class PFHBHERecHitCreatorMaxSample :  public  PFRecHitCreatorBase {
 	position.SetCoordinates ( point.x(),
 				  point.y(),
 				  point.z() );
-  
+
+
 	reco::PFRecHit rh( detid.rawId(),layer,
 			   energy, 
 			   position.x(), position.y(), position.z(), 
 			   0,0,0);
-	rh.setTime(time); //Mike: This we will use later
+
 	rh.setDepth(depth);
+
+
 	const CaloCellGeometry::CornersVec& corners = thisCell->getCorners();
 	assert( corners.size() == 8 );
 
@@ -231,15 +212,28 @@ class PFHBHERecHitCreatorMaxSample :  public  PFRecHitCreatorBase {
 	rh.setSWCorner( corners[2].x(), corners[2].y(),  corners[2].z());
 	rh.setNWCorner( corners[3].x(), corners[3].y(),  corners[3].z());
 	
+	//	for (unsigned int i=0;i<hitEnergies.size();++i)
+	//	  printf(" %f / %f ,",hitEnergies[i],hitTimes[i]);
+	
+	//now find the best hit	
+	auto best_hit = std::min_element(hitTimes.begin(),hitTimes.end(),
+				      [](const double& a, 
+					 const double& b){
+					   return fabs(a) < fabs(b);
+				      });
 
+
+	rh.setTime(*best_hit);
+	rh.setEnergy(hitEnergies[std::distance(hitTimes.begin(),best_hit)]);
+	//	printf("Best = %f %f\n",rh.energy(),rh.time());
+
+	//Apply Q tests
 	bool rcleaned = false;
 	bool keep=true;
 
-	//Apply Q tests
 	for( const auto& qtest : qualityTests_ ) {
 	  if (!qtest->test(rh,erh,rcleaned)) {
 	    keep = false;
-	    
 	  }
 	}
 	  
@@ -252,11 +246,8 @@ class PFHBHERecHitCreatorMaxSample :  public  PFRecHitCreatorBase {
     }
 
 
-
  protected:
     edm::EDGetTokenT<edm::SortedCollection<HBHERecHit> > recHitToken_;
-
-
 };
 
 

--- a/RecoParticleFlow/PFClusterProducer/interface/PFHBHERecHitCreatorMaxSample.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHBHERecHitCreatorMaxSample.h
@@ -118,7 +118,7 @@ class PFHBHERecHitCreatorMaxSample :  public  PFRecHitCreatorBase {
 	for (int ii = 0; ii < 8; ii++) {
 	  double gain = calibrations.respcorrgain(capid[ii]) *
 	    (tool[ii] - calibrations.pedestal(capid[ii]));
-	  if (gain>0.6)
+	  if (gain>sampleCut_)
 	    samples[ii] = gain;
 	  else
 	    samples[ii] = 0.0;
@@ -130,13 +130,15 @@ class PFHBHERecHitCreatorMaxSample :  public  PFRecHitCreatorBase {
 	double energy=0.0;
 	double energy2=0.0;
 	double time=0.0;
-
+	double s2=0.0;
 	std::vector<double> hitEnergies;	  
 	std::vector<double> hitTimes;	  
+
 	for (int ii = 0; ii < 8; ii++) {
 	  energy=energy+samples[ii];
-	  time = time+(-100. + ii*25.0)*samples[ii]*samples[ii];
-	  energy2=energy2+samples[ii]*samples[ii];
+	  s2=samples[ii]*samples[ii];
+	  time = time+(-100. + ii*25.0)*s2;
+	  energy2=energy2+s2;
 
 	  if (ii>0 && ii<7) {
 	    if (samples[ii]<=samples[ii-1] && samples[ii]<samples[ii+1] && energy>0) {
@@ -248,7 +250,11 @@ class PFHBHERecHitCreatorMaxSample :  public  PFRecHitCreatorBase {
 
  protected:
     edm::EDGetTokenT<edm::SortedCollection<HBHERecHit> > recHitToken_;
+    const double sampleCut_ = 0.6; // minimalistic threshold just to reduce the iterations 
+
 };
+
+
 
 
 

--- a/RecoParticleFlow/PFClusterProducer/interface/PFHBHERecHitCreatorMaxSample.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHBHERecHitCreatorMaxSample.h
@@ -116,10 +116,10 @@ class PFHBHERecHitCreatorMaxSample :  public  PFRecHitCreatorBase {
 
 	//store the samples over thresholds
 	for (int ii = 0; ii < 8; ii++) {
-	  double gain = calibrations.respcorrgain(capid[ii]) *
+	  double sampleE = calibrations.respcorrgain(capid[ii]) *
 	    (tool[ii] - calibrations.pedestal(capid[ii]));
-	  if (gain>sampleCut_)
-	    samples[ii] = gain;
+	  if (sampleE>sampleCut_)
+	    samples[ii] = sampleE;
 	  else
 	    samples[ii] = 0.0;
 

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitCaloNavigatorWithTime.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitCaloNavigatorWithTime.h
@@ -132,7 +132,7 @@ class PFRecHitCaloNavigatorWithTime : public PFRecHitNavigatorBase {
     if (found_hit != hits->end() && found_hit->detId() == id.rawId()) {
       sigma2 = _timeResolutionCalc->timeResolution2(hit.energy()) + _timeResolutionCalc->timeResolution2(found_hit->energy());
       const double deltaTime = hit.time()-found_hit->time();
-      if(deltaTime*deltaTime/sigma2<sigmaCut2_) {
+      if(deltaTime*deltaTime<sigmaCut2_*sigma2) {
 	hit.addNeighbour(eta,phi,0,reco::PFRecHitRef(refProd,std::distance(hits->begin(),found_hit)));
       }
     }

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitCaloNavigatorWithTime.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitCaloNavigatorWithTime.h
@@ -120,21 +120,24 @@ class PFRecHitCaloNavigatorWithTime : public PFRecHitNavigatorBase {
     double sigma2=10000.0;
     
     const reco::PFRecHit temp(id,PFLayer::NONE,0.0,math::XYZPoint(0,0,0),math::XYZVector(0,0,0),std::vector<math::XYZPoint>());
+
     auto found_hit = std::lower_bound(hits->begin(),hits->end(),
 				      temp,
 				      [](const reco::PFRecHit& a, 
 					 const reco::PFRecHit& b){
 					return a.detId() < b.detId();
 				      });
-    if( found_hit != hits->end() && found_hit->detId() == id.rawId() ) {
-        sigma2 = _timeResolutionCalc->timeResolution2(hit.energy()) + _timeResolutionCalc->timeResolution2(found_hit->energy());
-	const double deltaTime = hit.time()-found_hit->time();
-	if(deltaTime*deltaTime/sigma2<sigmaCut2_) {
-	  hit.addNeighbour(eta,phi,0,reco::PFRecHitRef(refProd,std::distance(hits->begin(),found_hit)));
+
+
+    if (found_hit != hits->end() && found_hit->detId() == id.rawId()) {
+      sigma2 = _timeResolutionCalc->timeResolution2(hit.energy()) + _timeResolutionCalc->timeResolution2(found_hit->energy());
+      const double deltaTime = hit.time()-found_hit->time();
+      if(deltaTime*deltaTime/sigma2<sigmaCut2_) {
+	hit.addNeighbour(eta,phi,0,reco::PFRecHitRef(refProd,std::distance(hits->begin(),found_hit)));
       }
     }
-  }
 
+  }
 
 
 

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFClusterProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFClusterProducer.cc
@@ -90,13 +90,20 @@ void PFClusterProducer::produce(edm::Event& e, const edm::EventSetup& es) {
     cleaner->clean(rechits, mask);
   }
 
+
+
   std::vector<bool> seedable(rechits->size(),false);
   _seedFinder->findSeeds(rechits,mask,seedable);
+
+
 
   std::auto_ptr<reco::PFClusterCollection> initialClusters;
   initialClusters.reset(new reco::PFClusterCollection);
   _initialClustering->buildClusters(rechits, mask, seedable, *initialClusters);
   LOGVERB("PFClusterProducer::produce()") << *_initialClustering;
+
+
+
 
   std::auto_ptr<reco::PFClusterCollection> pfClusters;
   pfClusters.reset(new reco::PFClusterCollection);
@@ -107,6 +114,9 @@ void PFClusterProducer::produce(edm::Event& e, const edm::EventSetup& es) {
     pfClusters->insert(pfClusters->end(),
 		       initialClusters->begin(),initialClusters->end());
   }
+
+
+
   
   if( _positionReCalc ) {
     _positionReCalc->calculateAndSetPositions(*pfClusters);

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowCaloResolution_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowCaloResolution_cfi.py
@@ -32,12 +32,12 @@ _timeResolutionHCAL = cms.PSet(
   )
 
 _timeResolutionHCALMaxSample = cms.PSet(
-    noiseTerm = cms.double(39),
-    constantTerm = cms.double(0.),
-    noiseTermLowE = cms.double(8.5),
+    noiseTerm = cms.double(21.86),
+    constantTerm = cms.double(2.82),
+    noiseTermLowE = cms.double(8),
     corrTermLowE = cms.double(0.0),
-    constantTermLowE = cms.double(7.7),
-    threshLowE = cms.double(5.0),
+    constantTermLowE = cms.double(4.24),
+    threshLowE = cms.double(6.0),
     threshHighE = cms.double(15.0)
   )
 

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHBHETimeSelected_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHBHETimeSelected_cfi.py
@@ -57,196 +57,147 @@ particleFlowClusterHBHETimeSelected = cms.EDProducer(
             minEnergy = cms.double(1.0),
             maxEnergy = cms.double(2.0),
             endcap = cms.bool(False),
-            minTime = cms.double(-25.),
-            maxTime = cms.double(30.)
+            minTime = cms.double(-5.),
+            maxTime = cms.double(50.)
         ),
         cms.PSet(
             depth=cms.double(1.0),
             minEnergy = cms.double(1.0),
             maxEnergy = cms.double(2.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-25.),
-            maxTime = cms.double(30.)
+            minTime = cms.double(-5.),
+            maxTime = cms.double(50.)
         ),
         cms.PSet(
             depth=cms.double(2.0),
             minEnergy = cms.double(1.0),
             maxEnergy = cms.double(2.0),
             endcap = cms.bool(False),
-            minTime = cms.double(-25.),
-            maxTime = cms.double(30.)
+            minTime = cms.double(-5.),
+            maxTime = cms.double(50.)
         ),
         cms.PSet(
             depth=cms.double(2.0),
             minEnergy = cms.double(1.0),
             maxEnergy = cms.double(2.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-25.),
-            maxTime = cms.double(30.)
+            minTime = cms.double(-5.),
+            maxTime = cms.double(50.)
         ),
         cms.PSet(
             depth=cms.double(3.0),
             minEnergy = cms.double(1.0),
             maxEnergy = cms.double(2.0),
             endcap = cms.bool(False),
-            minTime = cms.double(-25.),
-            maxTime = cms.double(30.)
+            minTime = cms.double(-5.),
+            maxTime = cms.double(5.)
         ),
         cms.PSet(
             depth=cms.double(3.0),
             minEnergy = cms.double(1.0),
             maxEnergy = cms.double(2.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-25.),
-            maxTime = cms.double(30.)
+            minTime = cms.double(-5.),
+            maxTime = cms.double(50.)
         ),
         cms.PSet(
             depth=cms.double(1.0),
             minEnergy = cms.double(2.),
             maxEnergy = cms.double(5.0),
             endcap = cms.bool(False),
-            minTime = cms.double(-25.),
-            maxTime = cms.double(25.)
+            minTime = cms.double(-1.),
+            maxTime = cms.double(40.)
         ),
         cms.PSet(
             depth=cms.double(1.0),
             minEnergy = cms.double(2.0),
             maxEnergy = cms.double(5.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-25.),
-            maxTime = cms.double(25.)
+            minTime = cms.double(-1.),
+            maxTime = cms.double(40.)
         ),
         cms.PSet(
             depth=cms.double(2.0),
             minEnergy = cms.double(2.),
             maxEnergy = cms.double(5.0),
             endcap = cms.bool(False),
-            minTime = cms.double(-25.),
-            maxTime = cms.double(25.)
+            minTime = cms.double(-1.),
+            maxTime = cms.double(40.)
         ),
         cms.PSet(
             depth=cms.double(2.0),
             minEnergy = cms.double(2.0),
             maxEnergy = cms.double(5.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-25.),
-            maxTime = cms.double(25.)
+            minTime = cms.double(-1.),
+            maxTime = cms.double(40.)
         ),
         cms.PSet(
             depth=cms.double(3.0),
             minEnergy = cms.double(2.),
             maxEnergy = cms.double(5.0),
             endcap = cms.bool(False),
-            minTime = cms.double(-25.),
-            maxTime = cms.double(25.)
+            minTime = cms.double(-1.),
+            maxTime = cms.double(40.)
         ),
         cms.PSet(
             depth=cms.double(3.0),
             minEnergy = cms.double(2.0),
             maxEnergy = cms.double(5.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-25.),
-            maxTime = cms.double(25.)
+            minTime = cms.double(-1.),
+            maxTime = cms.double(40.)
         ),
 
 
         cms.PSet(
             depth=cms.double(1.0),
             minEnergy = cms.double(5.),
-            maxEnergy = cms.double(10.0),
+            maxEnergy = cms.double(9999999.0),
             endcap = cms.bool(False),
-            minTime = cms.double(-22.),
-            maxTime = cms.double(15.)
+            minTime = cms.double(-0.5),
+            maxTime = cms.double(25.)
         ),
         cms.PSet(
             depth=cms.double(1.0),
             minEnergy = cms.double(5.0),
-            maxEnergy = cms.double(10.0),
+            maxEnergy = cms.double(9999999.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-22.),
-            maxTime = cms.double(15.)
+            minTime = cms.double(-0.5),
+            maxTime = cms.double(25.)
         ),
         cms.PSet(
             depth=cms.double(2.0),
             minEnergy = cms.double(5.),
-            maxEnergy = cms.double(10.0),
+            maxEnergy = cms.double(9999999.0),
             endcap = cms.bool(False),
-            minTime = cms.double(-22.),
-            maxTime = cms.double(15.)
+            minTime = cms.double(-0.5),
+            maxTime = cms.double(25.)
         ),
         cms.PSet(
             depth=cms.double(2.0),
             minEnergy = cms.double(5.0),
-            maxEnergy = cms.double(10.0),
+            maxEnergy = cms.double(9999999.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-22.),
-            maxTime = cms.double(15.)
+            minTime = cms.double(-0.5),
+            maxTime = cms.double(25.)
         ),
         cms.PSet(
             depth=cms.double(3.0),
             minEnergy = cms.double(5.),
-            maxEnergy = cms.double(10.0),
+            maxEnergy = cms.double(9999999.0),
             endcap = cms.bool(False),
-            minTime = cms.double(-22.),
-            maxTime = cms.double(15.)
+            minTime = cms.double(-0.5),
+            maxTime = cms.double(25.)
         ),
         cms.PSet(
             depth=cms.double(3.0),
             minEnergy = cms.double(5.0),
-            maxEnergy = cms.double(10.0),
-            endcap = cms.bool(True),
-            minTime = cms.double(-22.),
-            maxTime = cms.double(15.)
-        ),
-        cms.PSet(
-            depth=cms.double(1.0),
-            minEnergy = cms.double(10.),
             maxEnergy = cms.double(9999999.0),
-            endcap = cms.bool(False),
-            minTime = cms.double(-17.),
-            maxTime = cms.double(10.)
-        ),
-        cms.PSet(
-            depth=cms.double(1.0),
-            minEnergy = cms.double(10.0),
-            maxEnergy = cms.double(99999999.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-17.),
-            maxTime = cms.double(10.)
-        ),
-        cms.PSet(
-            depth=cms.double(2.0),
-            minEnergy = cms.double(10.),
-            maxEnergy = cms.double(9999999.0),
-            endcap = cms.bool(False),
-            minTime = cms.double(-17.),
-            maxTime = cms.double(10.)
-        ),
-        cms.PSet(
-            depth=cms.double(2.0),
-            minEnergy = cms.double(10.0),
-            maxEnergy = cms.double(99999999.0),
-            endcap = cms.bool(True),
-            minTime = cms.double(-17.),
-            maxTime = cms.double(10.)
-        ),
-        cms.PSet(
-            depth=cms.double(3.0),
-            minEnergy = cms.double(10.),
-            maxEnergy = cms.double(9999999.0),
-            endcap = cms.bool(False),
-            minTime = cms.double(-17.),
-            maxTime = cms.double(10.)
-        ),
-        cms.PSet(
-            depth=cms.double(3.0),
-            minEnergy = cms.double(10.0),
-            maxEnergy = cms.double(99999999.0),
-            endcap = cms.bool(True),
-            minTime = cms.double(-17.),
-            maxTime = cms.double(10.)
+            minTime = cms.double(-0.5),
+            maxTime = cms.double(25.)
         )
-
     )
 )
 

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHBHE_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHBHE_cfi.py
@@ -10,7 +10,7 @@ particleFlowClusterHBHE = cms.EDProducer(
         algoName = cms.string("LocalMaximumSeedFinder"),
         thresholdsByDetector = cms.VPSet(
               cms.PSet( detector = cms.string("HCAL_BARREL1"),
-                        seedingThreshold = cms.double(0.8),
+                        seedingThreshold = cms.double(1.0),
                         seedingThresholdPt = cms.double(0.0)
                         ),
               cms.PSet( detector = cms.string("HCAL_ENDCAP"),

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHBHE_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHBHE_cfi.py
@@ -4,7 +4,7 @@ from RecoParticleFlow.PFClusterProducer.particleFlowCaloResolution_cfi import _t
 particleFlowRecHitHBHE = cms.EDProducer("PFRecHitProducer",
     navigator = cms.PSet(
             name = cms.string("PFRecHitHCALNavigatorWithTime"),
-            sigmaCut = cms.double(5.0),
+            sigmaCut = cms.double(4.0),
             timeResolutionCalc = _timeResolutionHCALMaxSample
     ),
     producers = cms.VPSet(
@@ -14,7 +14,7 @@ particleFlowRecHitHBHE = cms.EDProducer("PFRecHitProducer",
              qualityTests = cms.VPSet(
                   cms.PSet(
                   name = cms.string("PFRecHitQTestThreshold"),
-                  threshold = cms.double(0.4)
+                  threshold = cms.double(0.8)
                   ),
                   cms.PSet(
                       name = cms.string("PFRecHitQTestHCALChannel"),


### PR DESCRIPTION
Hi,
This is the long waited pull request for HCAL in PF  in 72X. In pre6 we encountered an issue at very high energy jets where the reoslution degrades by a huge amount . This is due to the fact that we were sampling only the two maximum samples which at high pt gives a degradation of the resolution. Small modification of the underlying code was done [essentially one module] to not do thay but find the local minima of a pulse shape and splitiing the pulses in terms of those. This gives very good performance for high pt jets while it maintains the previously achieved PU rejection

The response is a bit lower as expected but this will be absorbed in the3 calibrations

The plots below show (red = HCAL method I) black =new algorithm , purple = pre6 out of the box[only response plot]

So you can see that we have recovered the resolution while we still remove large part of sum ET in the 25ns sample. The reduction on the TT no pu sample is very small as expected and the reason this reduction is not 0  is that the timing cuts kill some low quality clusters mainly at very low energy < 1 GeV.

This method is the nearest we can do to the Method II that is being worked at HCAL DPG and in case we 
cannot manage to run Method II fast this technique could be very useful at the HLT land.

The initial integration plan was to act quickly as soon as pre6 was out but problems in SIM made 
this release useless . So in this little timescale to complete the inital plan [study the algorithms in pre6 ]
I had to rereco those samples in pre5 to test the performance of the algorithm.Hence the delay to this PR .

![qcdcomparison](https://cloud.githubusercontent.com/assets/5180887/4516501/0939edbc-4bfa-11e4-9c67-1cd8f1811b5b.png)
![tt25ns_sumet](https://cloud.githubusercontent.com/assets/5180887/4516499/09363320-4bfa-11e4-9657-7ad6d54d27fb.png)
![tt25ns_sumeth](https://cloud.githubusercontent.com/assets/5180887/4516500/0936d186-4bfa-11e4-9380-1e85f2c91252.png)
![tt_sumet](https://cloud.githubusercontent.com/assets/5180887/4516502/093f3592-4bfa-11e4-9e4f-d9c4b64223b2.png)
