### PR TITLE
Use compiler, not introspection, to find nested typedefs

### DIFF
--- a/DataFormats/Common/interface/PtrVector.h
+++ b/DataFormats/Common/interface/PtrVector.h
@@ -106,6 +106,7 @@ namespace edm {
     typedef PtrVectorItr<T> const_iterator;
     typedef PtrVectorItr<T> iterator; // make boost::sub_range happy (std allows this)
     typedef Ptr<T> value_type;
+    typedef T member_type;
     typedef void collection_type;
 
     friend class PtrVectorItr<T>;

--- a/DataFormats/Common/interface/WrapperBase.h
+++ b/DataFormats/Common/interface/WrapperBase.h
@@ -8,12 +8,13 @@ WrapperBase: The base class of all things that will be inserted into the Event.
 ----------------------------------------------------------------------*/
 
 #include "DataFormats/Common/interface/EDProductfwd.h"
+#include "DataFormats/Provenance/interface/ViewTypeChecker.h"
 
 #include <typeinfo>
 #include <vector>
 
 namespace edm {
-  class WrapperBase {
+  class WrapperBase : public ViewTypeChecker {
   public:
     WrapperBase();
     virtual ~WrapperBase();

--- a/DataFormats/Common/src/WrapperBase.cc
+++ b/DataFormats/Common/src/WrapperBase.cc
@@ -7,7 +7,7 @@
 #include <cassert>
 
 namespace edm {
-  WrapperBase::WrapperBase() {}
+  WrapperBase::WrapperBase() : ViewTypeChecker() {}
 
   WrapperBase::~WrapperBase() {}
 

--- a/DataFormats/Common/src/classes_def.xml
+++ b/DataFormats/Common/src/classes_def.xml
@@ -1,6 +1,7 @@
 <lcgdict>
- <class name="edm::WrapperBase" ClassVersion="2">
+ <class name="edm::WrapperBase" ClassVersion="3">
   <version ClassVersion="2" checksum="2150796830"/>
+  <version ClassVersion="3" checksum="1936948526"/>
  </class>
  <class name="edm::EDProductGetter" ClassVersion="10">
   <version ClassVersion="10" checksum="2702412727"/>

--- a/DataFormats/Common/test/DictionaryTools_t.cpp
+++ b/DataFormats/Common/test/DictionaryTools_t.cpp
@@ -20,11 +20,6 @@ class TestDictionaries: public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(TestDictionaries);
   CPPUNIT_TEST(default_is_invalid);
   CPPUNIT_TEST(no_dictionary_is_invalid);
-  CPPUNIT_TEST(find_nested);
-  CPPUNIT_TEST(burrowing);
-  CPPUNIT_TEST(burrowing_failure);
-  CPPUNIT_TEST(wrapper_type);
-  CPPUNIT_TEST(wrapper_type_failure);
   CPPUNIT_TEST(not_a_template_instance);
   CPPUNIT_TEST(demangling);
   CPPUNIT_TEST_SUITE_END();
@@ -37,11 +32,6 @@ class TestDictionaries: public CppUnit::TestFixture {
 
   void default_is_invalid();
   void no_dictionary_is_invalid();
-  void find_nested();
-  void burrowing();
-  void burrowing_failure();
-  void wrapper_type();
-  void wrapper_type_failure();
   void not_a_template_instance();
   void demangling();
 
@@ -59,66 +49,6 @@ void TestDictionaries::default_is_invalid() {
 void TestDictionaries::no_dictionary_is_invalid() {
   edm::TypeWithDict t(edm::TypeWithDict::byName("ThereIsNoTypeWithThisName"));
   CPPUNIT_ASSERT(!t);
-}
-
-void TestDictionaries::find_nested() {
-  edm::TypeWithDict intvec(edm::TypeWithDict::byName("std::vector<int>"));
-  CPPUNIT_ASSERT(intvec);
-
-  edm::TypeWithDict found_type;
-
-  CPPUNIT_ASSERT(edm::find_nested_type_named("const_iterator",
-                                             intvec,
-                                             found_type));
-
-  CPPUNIT_ASSERT(!edm::find_nested_type_named("WankelRotaryEngine",
-                                              intvec,
-                                              found_type));
-}
-
-void TestDictionaries::burrowing() {
-  edm::TypeWithDict wrapper_type(typeid(edm::Wrapper<int>));
-  CPPUNIT_ASSERT(wrapper_type);
-  edm::TypeWithDict wrapped_type;
-  CPPUNIT_ASSERT(edm::find_nested_type_named("wrapped_type",
-                                             wrapper_type,
-                                             wrapped_type));
-  CPPUNIT_ASSERT(wrapped_type);
-  edm::TypeWithDict wrapped_Dict_type(wrapped_type.typeInfo());
-  CPPUNIT_ASSERT(!wrapped_Dict_type.isTypedef());
-  CPPUNIT_ASSERT(wrapped_Dict_type.isFundamental());
-  CPPUNIT_ASSERT(wrapped_type == edm::TypeWithDict::byName("int"));
-  CPPUNIT_ASSERT(wrapped_type.typeInfo() == typeid(int));
-}
-
-void TestDictionaries::burrowing_failure() {
-  edm::TypeWithDict not_a_wrapper(edm::TypeWithDict::byName("double"));
-  CPPUNIT_ASSERT(not_a_wrapper);
-  edm::TypeWithDict no_such_wrapped_type;
-  CPPUNIT_ASSERT(!no_such_wrapped_type);
-  CPPUNIT_ASSERT(!edm::find_nested_type_named("wrapped_type",
-                                              not_a_wrapper,
-                                              no_such_wrapped_type));
-  CPPUNIT_ASSERT(!no_such_wrapped_type);
-}
-
-void TestDictionaries::wrapper_type() {
-  edm::TypeWithDict wrapper_type(typeid(edm::Wrapper<int>));
-  edm::TypeWithDict wrapped_type;
-  CPPUNIT_ASSERT(edm::wrapper_type_of(wrapper_type, wrapped_type));
-  edm::TypeWithDict wrapped_Dict_type(wrapped_type.typeInfo());
-  CPPUNIT_ASSERT(!wrapped_Dict_type.isTypedef());
-  CPPUNIT_ASSERT(wrapped_type == edm::TypeWithDict::byName("int"));
-}
-
-void TestDictionaries::wrapper_type_failure() {
-  edm::TypeWithDict not_a_wrapper(edm::TypeWithDict::byName("double"));
-  CPPUNIT_ASSERT(not_a_wrapper);
-  edm::TypeWithDict no_such_wrapped_type;
-  CPPUNIT_ASSERT(!no_such_wrapped_type);
-  CPPUNIT_ASSERT(!edm::wrapper_type_of(not_a_wrapper,
-                                       no_such_wrapped_type));
-  CPPUNIT_ASSERT(!no_such_wrapped_type);
 }
 
 void TestDictionaries::not_a_template_instance() {

--- a/DataFormats/Provenance/interface/ProductHolderIndexHelper.h
+++ b/DataFormats/Provenance/interface/ProductHolderIndexHelper.h
@@ -62,7 +62,24 @@ ProductRegistry is frozen.
 #include <vector>
 
 namespace edm {
-  class TypeWithDict;
+
+  namespace productholderindexhelper {
+    // The next function supports views. For the given wrapped type,
+    // which must be Wrapper<T>,
+    // this function returns the type of the contained type of T.
+    // If the type is not a recongnized container, it returns
+    // a TypeID(typeid(void)).
+    TypeID getContainedTypeFromWrapper(TypeID const& wrappedtypeID, std::string const& className);
+
+    // The next function supports views. For the given type T,
+    // this function returns the type of the contained type of T.
+    // If the type is not a recongnized container, it returns
+    // a TypeID(typeid(void)).
+    // This calls getContainedTypefromWrapped internally
+    // If the TypeID for the wrapped type is already available,
+    // it is faster to call getContainedTypeFromWrapper directly.
+    TypeID getContainedType(TypeID const& typeID);
+  }
 
   class ProductHolderIndexHelper {
   public:
@@ -152,10 +169,19 @@ namespace edm {
     // entry with a new ProductHolderIndex for the case
     // which searches for the most recent process.
     ProductHolderIndex
-    insert(TypeWithDict const& typeWithDict,
+    insert(TypeID const& typeID,
            char const* moduleLabel,
            char const* instance,
-           char const* process);
+           char const* process,
+           TypeID const& containedTypeID);
+
+    ProductHolderIndex
+    insert(TypeID const& typeID,
+           char const* moduleLabel,
+           char const* instance,
+           char const* process) {
+      return insert(typeID, moduleLabel, instance, process, productholderindexhelper::getContainedType(typeID));
+    }
 
     // Before the object is frozen the accessors above will
     // fail to find a match. Once frozen, no more new entries

--- a/DataFormats/Provenance/interface/ViewTypeChecker.h
+++ b/DataFormats/Provenance/interface/ViewTypeChecker.h
@@ -1,0 +1,26 @@
+#ifndef DataFormats_Provenance_ViewTypeChecker_h
+#define DataFormats_Provenance_ViewTypeChecker_h
+
+/*----------------------------------------------------------------------
+
+Checks for "value_type" and "member_type" typedefs inside T (of Wrapper<T>).
+
+----------------------------------------------------------------------*/
+
+#include <typeinfo>
+
+namespace edm {
+  class ViewTypeChecker {
+  public:
+    ViewTypeChecker();
+    virtual ~ViewTypeChecker();
+
+    std::type_info const& valueTypeInfo() const {return valueTypeInfo_();}
+    std::type_info const& memberTypeInfo() const {return memberTypeInfo_();}
+
+   private:
+    virtual std::type_info const& valueTypeInfo_() const = 0;
+    virtual std::type_info const& memberTypeInfo_() const = 0;
+  };
+}
+#endif

--- a/DataFormats/Provenance/src/ViewTypeChecker.cc
+++ b/DataFormats/Provenance/src/ViewTypeChecker.cc
@@ -1,0 +1,12 @@
+/*----------------------------------------------------------------------
+
+----------------------------------------------------------------------*/
+
+#include "DataFormats/Provenance/interface/ViewTypeChecker.h"
+#include <cassert>
+
+namespace edm {
+  ViewTypeChecker::ViewTypeChecker() {}
+
+  ViewTypeChecker::~ViewTypeChecker() {}
+}

--- a/DataFormats/Provenance/src/classes.h
+++ b/DataFormats/Provenance/src/classes.h
@@ -32,6 +32,7 @@
 #include "DataFormats/Provenance/interface/ThinnedAssociationsHelper.h"
 #include "DataFormats/Provenance/interface/Timestamp.h"
 #include "DataFormats/Provenance/interface/ESRecordAuxiliary.h"
+#include "DataFormats/Provenance/interface/ViewTypeChecker.h"
 #include "FWCore/Utilities/interface/typedefs.h"
 #include <map>
 #include <set>

--- a/DataFormats/Provenance/src/classes_def.xml
+++ b/DataFormats/Provenance/src/classes_def.xml
@@ -1,4 +1,7 @@
 <lcgdict>
+ <class name="edm::ViewTypeChecker" ClassVersion="2">
+  <version ClassVersion="2" checksum="2398868528"/>
+ </class>
  <class name="edm::ProductID" ClassVersion="10">
   <version ClassVersion="10" checksum="1501211476"/>
  </class>

--- a/DataFormats/Provenance/test/productHolderIndexHelperTest.cc
+++ b/DataFormats/Provenance/test/productHolderIndexHelperTest.cc
@@ -6,7 +6,6 @@
 #include "FWCore/RootAutoLibraryLoader/interface/RootAutoLibraryLoader.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Utilities/interface/ProductKindOfType.h"
-#include "FWCore/Utilities/interface/TypeWithDict.h"
 
 #include "TClass.h"
 
@@ -139,21 +138,16 @@ int main() {
     // most of the total time as well.
     TClass* clss = TClass::GetClass(n.className.c_str());
 
-    TypeWithDict typeWithDict;
-
     if (n.className == "bool") {
       n.typeID = TypeID(typeid(bool));
-      typeWithDict = TypeWithDict(typeid(bool));
     } else if (n.className == "double") {
       n.typeID = TypeID(typeid(double));
-      typeWithDict = TypeWithDict(typeid(double));
     } else {
       n.typeID = TypeID(*clss->GetTypeInfo());
-      typeWithDict = TypeWithDict(*clss->GetTypeInfo());
     }
 
     timer.start();
-    phih.insert(typeWithDict,
+    phih.insert(n.typeID,
                 n.label.c_str(),
                 n.instance.c_str(),
                 n.process.c_str());

--- a/DataFormats/Provenance/test/productHolderIndexHelper_t.cppunit.cc
+++ b/DataFormats/Provenance/test/productHolderIndexHelper_t.cppunit.cc
@@ -13,7 +13,6 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/ProductKindOfType.h"
 #include "FWCore/Utilities/interface/TypeID.h"
-#include "FWCore/Utilities/interface/TypeWithDict.h"
 
 #include <iostream>
 #include <iomanip>
@@ -72,16 +71,16 @@ void TestProductHolderIndexHelper::testCreateEmpty() {
   matches = helper.relatedIndexes(PRODUCT_TYPE, typeID_ProductID);
   CPPUNIT_ASSERT(matches.numberOfMatches() == 0);
 
-  TypeWithDict typeWithDict(typeid(ProductID));
-  CPPUNIT_ASSERT_THROW( helper.insert(typeWithDict, "labelA", "instanceA", "processA") , cms::Exception);
+  TypeID typeID(typeid(ProductID));
+  CPPUNIT_ASSERT_THROW( helper.insert(typeID, "labelA", "instanceA", "processA") , cms::Exception);
 }
 
 void TestProductHolderIndexHelper::testOneEntry() {
 
   edm::ProductHolderIndexHelper helper;
 
-  TypeWithDict typeWithDictProductID(typeid(ProductID));
-  helper.insert(typeWithDictProductID, "labelA", "instanceA", "processA");
+  TypeID typeIDProductID(typeid(ProductID));
+  helper.insert(typeIDProductID, "labelA", "instanceA", "processA");
 
   CPPUNIT_ASSERT(helper.index(PRODUCT_TYPE, typeID_ProductID, "labelA", "instanceA", "processA") == ProductHolderIndexInvalid);
   CPPUNIT_ASSERT(helper.index(ELEMENT_TYPE, typeID_ProductID, "labelA", "instanceA", "processA") == ProductHolderIndexInvalid);
@@ -141,30 +140,30 @@ void TestProductHolderIndexHelper::testManyEntries() {
 
   edm::ProductHolderIndexHelper helper;
 
-  TypeWithDict typeWithDictProductID(typeid(ProductID));
-  TypeWithDict typeWithDictEventID(typeid(EventID));
-  TypeWithDict typeWithDictVectorInt(typeid(std::vector<int>));
-  TypeWithDict typeWithDictSetInt(typeid(std::set<int>));
-  TypeWithDict typeWithDictVSimpleDerived(typeid(std::vector<edmtest::SimpleDerived>));
+  TypeID typeIDProductID(typeid(ProductID));
+  TypeID typeIDEventID(typeid(EventID));
+  TypeID typeIDVectorInt(typeid(std::vector<int>));
+  TypeID typeIDSetInt(typeid(std::set<int>));
+  TypeID typeIDVSimpleDerived(typeid(std::vector<edmtest::SimpleDerived>));
 
-  helper.insert(typeWithDictVectorInt, "labelC", "instanceC", "processC"); // 0, 1, 2
-  helper.insert(typeWithDictVectorInt, "label",  "instance",  "process");  // 3, 4, 5
-  helper.insert(typeWithDictEventID, "labelB", "instanceB", "processB");   // 6, 7
-  helper.insert(typeWithDictEventID, "label",  "instanceB", "processB");   // 8, 9
-  helper.insert(typeWithDictEventID, "labelX", "instanceB", "processB");   // 10, 11
-  helper.insert(typeWithDictEventID, "labelB", "instance",  "processB");   // 12, 13
-  helper.insert(typeWithDictEventID, "labelB", "instanceX", "processB");   // 14, 15
-  helper.insert(typeWithDictEventID, "labelB", "instanceB", "processB1");  // 16, 5
-  helper.insert(typeWithDictEventID, "labelB", "instanceB", "processB3");  // 17, 5
-  helper.insert(typeWithDictEventID, "labelB", "instanceB", "processB2");  // 18, 5
-  helper.insert(typeWithDictProductID, "label",  "instance",  "process");  // 19, 20
-  helper.insert(typeWithDictEventID, "label",  "instance",  "process");    // 21, 22
-  helper.insert(typeWithDictProductID, "labelA", "instanceA", "processA"); // 23, 24
-  CPPUNIT_ASSERT_THROW(helper.insert(typeWithDictProductID, "labelA", "instanceA", "processA"), cms::Exception); // duplicate
+  helper.insert(typeIDVectorInt, "labelC", "instanceC", "processC"); // 0, 1, 2
+  helper.insert(typeIDVectorInt, "label",  "instance",  "process");  // 3, 4, 5
+  helper.insert(typeIDEventID, "labelB", "instanceB", "processB");   // 6, 7
+  helper.insert(typeIDEventID, "label",  "instanceB", "processB");   // 8, 9
+  helper.insert(typeIDEventID, "labelX", "instanceB", "processB");   // 10, 11
+  helper.insert(typeIDEventID, "labelB", "instance",  "processB");   // 12, 13
+  helper.insert(typeIDEventID, "labelB", "instanceX", "processB");   // 14, 15
+  helper.insert(typeIDEventID, "labelB", "instanceB", "processB1");  // 16, 5
+  helper.insert(typeIDEventID, "labelB", "instanceB", "processB3");  // 17, 5
+  helper.insert(typeIDEventID, "labelB", "instanceB", "processB2");  // 18, 5
+  helper.insert(typeIDProductID, "label",  "instance",  "process");  // 19, 20
+  helper.insert(typeIDEventID, "label",  "instance",  "process");    // 21, 22
+  helper.insert(typeIDProductID, "labelA", "instanceA", "processA"); // 23, 24
+  CPPUNIT_ASSERT_THROW(helper.insert(typeIDProductID, "labelA", "instanceA", "processA"), cms::Exception); // duplicate
 
-  helper.insert(typeWithDictSetInt, "labelC", "instanceC", "processC"); // 25, 26
+  helper.insert(typeIDSetInt, "labelC", "instanceC", "processC"); // 25, 26
 
-  helper.insert(typeWithDictVSimpleDerived, "labelC", "instanceC", "processC"); // 27, 28, 29, 30
+  helper.insert(typeIDVSimpleDerived, "labelC", "instanceC", "processC"); // 27, 28, 29, 30
 
   // helper.print(std::cout);
   helper.setFrozen();

--- a/DataFormats/TestObjects/interface/DeleteEarly.h
+++ b/DataFormats/TestObjects/interface/DeleteEarly.h
@@ -34,6 +34,7 @@ namespace edmtest {
     
     // ---------- static member functions --------------------
     static unsigned int nDeletes() {return s_nDeletes;}
+    static void resetDeleteCount() {s_nDeletes = 0;}
     
     // ---------- member functions ---------------------------
     

--- a/DataFormats/TestObjects/src/classes.h
+++ b/DataFormats/TestObjects/src/classes.h
@@ -68,6 +68,7 @@ struct dictionary {
   edm::DetSet<edmtest::Unsortable> x2;
   std::vector<edmtest::Sortable> x3;
   std::vector<edmtest::Unsortable> x4;
+  edm::Wrapper<std::vector<edmtest::SimpleDerived> > dummy99;
 
   edm::Ref<std::vector<edmtest::Thing> > dummyRefThings;
   edm::reftobase::Holder<edmtest::Thing,edm::Ref<std::vector<edmtest::Thing> > > bhThing;

--- a/DataFormats/TestObjects/src/classes_def.xml
+++ b/DataFormats/TestObjects/src/classes_def.xml
@@ -42,6 +42,7 @@
  <class name="std::vector<edmtest::Simple>"/>
  <class name="edm::Wrapper<std::vector<edmtest::Simple> >"/>
  <class name="std::vector<edmtest::SimpleDerived>"/>
+ <class name="edm::Wrapper<std::vector<edmtest::SimpleDerived> >"/>
  <class name="edm::RefProd<std::vector<edmtest::Simple> >"/>
  <class name="edm::DetSet<edmtest::Sortable>"/>
  <class name="std::vector<edm::DetSet<edmtest::Sortable> >"/>

--- a/FWCore/Framework/test/edconsumerbase_t.cppunit.cc
+++ b/FWCore/Framework/test/edconsumerbase_t.cppunit.cc
@@ -133,27 +133,27 @@ TestEDConsumerBase::testRegularType()
   
   edm::ProductHolderIndexHelper helper;
   
-  edm::TypeWithDict typeWithDictProductID(typeid(edm::ProductID));
-  edm::TypeWithDict typeWithDictEventID(typeid(edm::EventID));
-  edm::TypeWithDict typeWithDictVectorInt(typeid(std::vector<int>));
-  edm::TypeWithDict typeWithDictSetInt(typeid(std::set<int>));
-  edm::TypeWithDict typeWithDictVSimpleDerived(typeid(std::vector<edmtest::SimpleDerived>));
+  edm::TypeID typeIDProductID(typeid(edm::ProductID));
+  edm::TypeID typeIDEventID(typeid(edm::EventID));
+  edm::TypeID typeIDVectorInt(typeid(std::vector<int>));
+  edm::TypeID typeIDSetInt(typeid(std::set<int>));
+  edm::TypeID typeIDVSimpleDerived(typeid(std::vector<edmtest::SimpleDerived>));
   
-  helper.insert(typeWithDictVectorInt, "labelC", "instanceC", "processC"); // 0, 1, 2
-  helper.insert(typeWithDictVectorInt, "label",  "instance",  "process");  // 3, 4, 5
-  helper.insert(typeWithDictEventID, "labelB", "instanceB", "processB");   // 6, 7
-  helper.insert(typeWithDictEventID, "label",  "instanceB", "processB");   // 8, 9
-  helper.insert(typeWithDictEventID, "labelX", "instanceB", "processB");   // 10, 11
-  helper.insert(typeWithDictEventID, "labelB", "instance",  "processB");   // 12, 13
-  helper.insert(typeWithDictEventID, "labelB", "instanceX", "processB");   // 14, 15
-  helper.insert(typeWithDictEventID, "labelB", "instanceB", "processB1");  // 16, 5
-  helper.insert(typeWithDictEventID, "labelB", "instanceB", "processB3");  // 17, 5
-  helper.insert(typeWithDictEventID, "labelB", "instanceB", "processB2");  // 18, 5
-  helper.insert(typeWithDictProductID, "label",  "instance",  "process");  // 19, 20
-  helper.insert(typeWithDictEventID, "label",  "instance",  "process");    // 21, 22
-  helper.insert(typeWithDictProductID, "labelA", "instanceA", "processA"); // 23, 24
-  helper.insert(typeWithDictSetInt, "labelC", "instanceC", "processC"); // 25, 26
-  helper.insert(typeWithDictVSimpleDerived, "labelC", "instanceC", "processC"); // 27, 28, 29, 30
+  helper.insert(typeIDVectorInt, "labelC", "instanceC", "processC"); // 0, 1, 2
+  helper.insert(typeIDVectorInt, "label",  "instance",  "process");  // 3, 4, 5
+  helper.insert(typeIDEventID, "labelB", "instanceB", "processB");   // 6, 7
+  helper.insert(typeIDEventID, "label",  "instanceB", "processB");   // 8, 9
+  helper.insert(typeIDEventID, "labelX", "instanceB", "processB");   // 10, 11
+  helper.insert(typeIDEventID, "labelB", "instance",  "processB");   // 12, 13
+  helper.insert(typeIDEventID, "labelB", "instanceX", "processB");   // 14, 15
+  helper.insert(typeIDEventID, "labelB", "instanceB", "processB1");  // 16, 5
+  helper.insert(typeIDEventID, "labelB", "instanceB", "processB3");  // 17, 5
+  helper.insert(typeIDEventID, "labelB", "instanceB", "processB2");  // 18, 5
+  helper.insert(typeIDProductID, "label",  "instance",  "process");  // 19, 20
+  helper.insert(typeIDEventID, "label",  "instance",  "process");    // 21, 22
+  helper.insert(typeIDProductID, "labelA", "instanceA", "processA"); // 23, 24
+  helper.insert(typeIDSetInt, "labelC", "instanceC", "processC"); // 25, 26
+  helper.insert(typeIDVSimpleDerived, "labelC", "instanceC", "processC"); // 27, 28, 29, 30
 
   helper.setFrozen();
 
@@ -315,27 +315,27 @@ TestEDConsumerBase::testViewType()
 {
   edm::ProductHolderIndexHelper helper;
   
-  edm::TypeWithDict typeWithDictProductID(typeid(edm::ProductID));
-  edm::TypeWithDict typeWithDictEventID(typeid(edm::EventID));
-  edm::TypeWithDict typeWithDictVectorInt(typeid(std::vector<int>));
-  edm::TypeWithDict typeWithDictSetInt(typeid(std::set<int>));
-  edm::TypeWithDict typeWithDictVSimpleDerived(typeid(std::vector<edmtest::SimpleDerived>));
+  edm::TypeID typeIDProductID(typeid(edm::ProductID));
+  edm::TypeID typeIDEventID(typeid(edm::EventID));
+  edm::TypeID typeIDVectorInt(typeid(std::vector<int>));
+  edm::TypeID typeIDSetInt(typeid(std::set<int>));
+  edm::TypeID typeIDVSimpleDerived(typeid(std::vector<edmtest::SimpleDerived>));
   
-  helper.insert(typeWithDictVectorInt, "labelC", "instanceC", "processC"); // 0, 1, 2
-  helper.insert(typeWithDictVectorInt, "label",  "instance",  "process");  // 3, 4, 5
-  helper.insert(typeWithDictEventID, "labelB", "instanceB", "processB");   // 6, 7
-  helper.insert(typeWithDictEventID, "label",  "instanceB", "processB");   // 8, 9
-  helper.insert(typeWithDictEventID, "labelX", "instanceB", "processB");   // 10, 11
-  helper.insert(typeWithDictEventID, "labelB", "instance",  "processB");   // 12, 13
-  helper.insert(typeWithDictEventID, "labelB", "instanceX", "processB");   // 14, 15
-  helper.insert(typeWithDictEventID, "labelB", "instanceB", "processB1");  // 16, 5
-  helper.insert(typeWithDictEventID, "labelB", "instanceB", "processB3");  // 17, 5
-  helper.insert(typeWithDictEventID, "labelB", "instanceB", "processB2");  // 18, 5
-  helper.insert(typeWithDictProductID, "label",  "instance",  "process");  // 19, 20
-  helper.insert(typeWithDictEventID, "label",  "instance",  "process");    // 21, 22
-  helper.insert(typeWithDictProductID, "labelA", "instanceA", "processA"); // 23, 24
-  helper.insert(typeWithDictSetInt, "labelC", "instanceC", "processC"); // 25, 26
-  helper.insert(typeWithDictVSimpleDerived, "labelC", "instanceC", "processC"); // 27, 28, 29, 30
+  helper.insert(typeIDVectorInt, "labelC", "instanceC", "processC"); // 0, 1, 2
+  helper.insert(typeIDVectorInt, "label",  "instance",  "process");  // 3, 4, 5
+  helper.insert(typeIDEventID, "labelB", "instanceB", "processB");   // 6, 7
+  helper.insert(typeIDEventID, "label",  "instanceB", "processB");   // 8, 9
+  helper.insert(typeIDEventID, "labelX", "instanceB", "processB");   // 10, 11
+  helper.insert(typeIDEventID, "labelB", "instance",  "processB");   // 12, 13
+  helper.insert(typeIDEventID, "labelB", "instanceX", "processB");   // 14, 15
+  helper.insert(typeIDEventID, "labelB", "instanceB", "processB1");  // 16, 5
+  helper.insert(typeIDEventID, "labelB", "instanceB", "processB3");  // 17, 5
+  helper.insert(typeIDEventID, "labelB", "instanceB", "processB2");  // 18, 5
+  helper.insert(typeIDProductID, "label",  "instance",  "process");  // 19, 20
+  helper.insert(typeIDEventID, "label",  "instance",  "process");    // 21, 22
+  helper.insert(typeIDProductID, "labelA", "instanceA", "processA"); // 23, 24
+  helper.insert(typeIDSetInt, "labelC", "instanceC", "processC"); // 25, 26
+  helper.insert(typeIDVSimpleDerived, "labelC", "instanceC", "processC"); // 27, 28, 29, 30
   
   helper.setFrozen();
   
@@ -436,27 +436,27 @@ TestEDConsumerBase::testMany()
   
   edm::ProductHolderIndexHelper helper;
   
-  edm::TypeWithDict typeWithDictProductID(typeid(edm::ProductID));
-  edm::TypeWithDict typeWithDictEventID(typeid(edm::EventID));
-  edm::TypeWithDict typeWithDictVectorInt(typeid(std::vector<int>));
-  edm::TypeWithDict typeWithDictSetInt(typeid(std::set<int>));
-  edm::TypeWithDict typeWithDictVSimpleDerived(typeid(std::vector<edmtest::SimpleDerived>));
+  edm::TypeID typeIDProductID(typeid(edm::ProductID));
+  edm::TypeID typeIDEventID(typeid(edm::EventID));
+  edm::TypeID typeIDVectorInt(typeid(std::vector<int>));
+  edm::TypeID typeIDSetInt(typeid(std::set<int>));
+  edm::TypeID typeIDVSimpleDerived(typeid(std::vector<edmtest::SimpleDerived>));
   
-  helper.insert(typeWithDictVectorInt, "labelC", "instanceC", "processC"); // 0, 1, 2
-  helper.insert(typeWithDictVectorInt, "label",  "instance",  "process");  // 3, 4, 5
-  helper.insert(typeWithDictEventID, "labelB", "instanceB", "processB");   // 6, 7
-  helper.insert(typeWithDictEventID, "label",  "instanceB", "processB");   // 8, 9
-  helper.insert(typeWithDictEventID, "labelX", "instanceB", "processB");   // 10, 11
-  helper.insert(typeWithDictEventID, "labelB", "instance",  "processB");   // 12, 13
-  helper.insert(typeWithDictEventID, "labelB", "instanceX", "processB");   // 14, 15
-  helper.insert(typeWithDictEventID, "labelB", "instanceB", "processB1");  // 16, 5
-  helper.insert(typeWithDictEventID, "labelB", "instanceB", "processB3");  // 17, 5
-  helper.insert(typeWithDictEventID, "labelB", "instanceB", "processB2");  // 18, 5
-  helper.insert(typeWithDictProductID, "label",  "instance",  "process");  // 19, 20
-  helper.insert(typeWithDictEventID, "label",  "instance",  "process");    // 21, 22
-  helper.insert(typeWithDictProductID, "labelA", "instanceA", "processA"); // 23, 24
-  helper.insert(typeWithDictSetInt, "labelC", "instanceC", "processC"); // 25, 26
-  helper.insert(typeWithDictVSimpleDerived, "labelC", "instanceC", "processC"); // 27, 28, 29, 30
+  helper.insert(typeIDVectorInt, "labelC", "instanceC", "processC"); // 0, 1, 2
+  helper.insert(typeIDVectorInt, "label",  "instance",  "process");  // 3, 4, 5
+  helper.insert(typeIDEventID, "labelB", "instanceB", "processB");   // 6, 7
+  helper.insert(typeIDEventID, "label",  "instanceB", "processB");   // 8, 9
+  helper.insert(typeIDEventID, "labelX", "instanceB", "processB");   // 10, 11
+  helper.insert(typeIDEventID, "labelB", "instance",  "processB");   // 12, 13
+  helper.insert(typeIDEventID, "labelB", "instanceX", "processB");   // 14, 15
+  helper.insert(typeIDEventID, "labelB", "instanceB", "processB1");  // 16, 5
+  helper.insert(typeIDEventID, "labelB", "instanceB", "processB3");  // 17, 5
+  helper.insert(typeIDEventID, "labelB", "instanceB", "processB2");  // 18, 5
+  helper.insert(typeIDProductID, "label",  "instance",  "process");  // 19, 20
+  helper.insert(typeIDEventID, "label",  "instance",  "process");    // 21, 22
+  helper.insert(typeIDProductID, "labelA", "instanceA", "processA"); // 23, 24
+  helper.insert(typeIDSetInt, "labelC", "instanceC", "processC"); // 25, 26
+  helper.insert(typeIDVSimpleDerived, "labelC", "instanceC", "processC"); // 27, 28, 29, 30
   
   helper.setFrozen();
 
@@ -482,27 +482,27 @@ TestEDConsumerBase::testMay()
  
   edm::ProductHolderIndexHelper helper;
   
-  edm::TypeWithDict typeWithDictProductID(typeid(edm::ProductID));
-  edm::TypeWithDict typeWithDictEventID(typeid(edm::EventID));
-  edm::TypeWithDict typeWithDictVectorInt(typeid(std::vector<int>));
-  edm::TypeWithDict typeWithDictSetInt(typeid(std::set<int>));
-  edm::TypeWithDict typeWithDictVSimpleDerived(typeid(std::vector<edmtest::SimpleDerived>));
+  edm::TypeID typeIDProductID(typeid(edm::ProductID));
+  edm::TypeID typeIDEventID(typeid(edm::EventID));
+  edm::TypeID typeIDVectorInt(typeid(std::vector<int>));
+  edm::TypeID typeIDSetInt(typeid(std::set<int>));
+  edm::TypeID typeIDVSimpleDerived(typeid(std::vector<edmtest::SimpleDerived>));
   
-  helper.insert(typeWithDictVectorInt, "labelC", "instanceC", "processC"); // 0, 1, 2
-  helper.insert(typeWithDictVectorInt, "label",  "instance",  "process");  // 3, 4, 5
-  helper.insert(typeWithDictEventID, "labelB", "instanceB", "processB");   // 6, 7
-  helper.insert(typeWithDictEventID, "label",  "instanceB", "processB");   // 8, 9
-  helper.insert(typeWithDictEventID, "labelX", "instanceB", "processB");   // 10, 11
-  helper.insert(typeWithDictEventID, "labelB", "instance",  "processB");   // 12, 13
-  helper.insert(typeWithDictEventID, "labelB", "instanceX", "processB");   // 14, 15
-  helper.insert(typeWithDictEventID, "labelB", "instanceB", "processB1");  // 16, 5
-  helper.insert(typeWithDictEventID, "labelB", "instanceB", "processB3");  // 17, 5
-  helper.insert(typeWithDictEventID, "labelB", "instanceB", "processB2");  // 18, 5
-  helper.insert(typeWithDictProductID, "label",  "instance",  "process");  // 19, 20
-  helper.insert(typeWithDictEventID, "label",  "instance",  "process");    // 21, 22
-  helper.insert(typeWithDictProductID, "labelA", "instanceA", "processA"); // 23, 24
-  helper.insert(typeWithDictSetInt, "labelC", "instanceC", "processC"); // 25, 26
-  helper.insert(typeWithDictVSimpleDerived, "labelC", "instanceC", "processC"); // 27, 28, 29, 30
+  helper.insert(typeIDVectorInt, "labelC", "instanceC", "processC"); // 0, 1, 2
+  helper.insert(typeIDVectorInt, "label",  "instance",  "process");  // 3, 4, 5
+  helper.insert(typeIDEventID, "labelB", "instanceB", "processB");   // 6, 7
+  helper.insert(typeIDEventID, "label",  "instanceB", "processB");   // 8, 9
+  helper.insert(typeIDEventID, "labelX", "instanceB", "processB");   // 10, 11
+  helper.insert(typeIDEventID, "labelB", "instance",  "processB");   // 12, 13
+  helper.insert(typeIDEventID, "labelB", "instanceX", "processB");   // 14, 15
+  helper.insert(typeIDEventID, "labelB", "instanceB", "processB1");  // 16, 5
+  helper.insert(typeIDEventID, "labelB", "instanceB", "processB3");  // 17, 5
+  helper.insert(typeIDEventID, "labelB", "instanceB", "processB2");  // 18, 5
+  helper.insert(typeIDProductID, "label",  "instance",  "process");  // 19, 20
+  helper.insert(typeIDEventID, "label",  "instance",  "process");    // 21, 22
+  helper.insert(typeIDProductID, "labelA", "instanceA", "processA"); // 23, 24
+  helper.insert(typeIDSetInt, "labelC", "instanceC", "processC"); // 25, 26
+  helper.insert(typeIDVSimpleDerived, "labelC", "instanceC", "processC"); // 27, 28, 29, 30
   
   helper.setFrozen();
   edm::TypeID typeID_vint(typeid(std::vector<int>));

--- a/FWCore/Framework/test/stubs/DeleteEarlyModules.cc
+++ b/FWCore/Framework/test/stubs/DeleteEarlyModules.cc
@@ -32,6 +32,11 @@ namespace edmtest {
       produces<DeleteEarly>();
     }
     
+    virtual void beginJob() {
+      // Needed because DeleteEarly objects may be allocated and deleted in initialization
+      edmtest::DeleteEarly::resetDeleteCount();
+    }
+
     virtual void produce(edm::Event& e, edm::EventSetup const& ){
       std::unique_ptr<DeleteEarly> p(new DeleteEarly);
       e.put(std::move(p));

--- a/FWCore/Utilities/interface/DictionaryTools.h
+++ b/FWCore/Utilities/interface/DictionaryTools.h
@@ -17,42 +17,6 @@ namespace edm {
   class TypeWithDict;
   typedef std::set<std::string> StringSet;
 
-  bool
-  find_nested_type_named(std::string const& nested_type,
-			 TypeWithDict const& type_to_search,
-			 TypeWithDict& found_type);
-  bool
-  find_nested_type_named(std::string const& nested_type,
-			 TypeWithDict const& type_to_search,
-			 TypeWithDict& found_type);
-
-  inline
-  bool
-  value_type_of(TypeWithDict const& t, TypeWithDict& found_type) {
-    return find_nested_type_named("value_type", t, found_type);
-  }
-
-
-  inline
-  bool
-  wrapper_type_of(TypeWithDict const& possible_wrapper,
-		  TypeWithDict& found_wrapped_type) {
-    return find_nested_type_named("wrapped_type",
-				  possible_wrapper,
-				  found_wrapped_type);
-  }
-
-  bool
-  is_RefVector(TypeWithDict const& possible_ref_vector,
-	       TypeWithDict& value_type);
-
-  bool
-  is_PtrVector(TypeWithDict const& possible_ref_vector,
-	       TypeWithDict& value_type);
-  bool
-  is_RefToBaseVector(TypeWithDict const& possible_ref_vector,
-		     TypeWithDict& value_type);
-
   void checkDictionaries(std::string const& name, bool noComponents = false);
   void throwMissingDictionariesException();
   void loadMissingDictionaries();

--- a/FWCore/Utilities/interface/getAnyPtr.h
+++ b/FWCore/Utilities/interface/getAnyPtr.h
@@ -1,0 +1,26 @@
+#ifndef FWCore_Utilities_getAnyPtr_h
+#define FWCore_Utilities_getAnyPtr_h
+
+#include <cassert>
+#include <memory>
+
+namespace edm {
+  template <typename T>
+  inline
+  std::unique_ptr<T> getAnyPtr(void* p, int offset) {
+    // A union is used to avoid possible copies during the triple cast that would otherwise be needed. 	 
+    // std::unique_ptr<T> edp(static_cast<T*>(static_cast<void *>(static_cast<unsigned char *>(p) + offset))); 	 
+    union { 	 
+      void* vp; 	 
+      unsigned char* ucp; 	 
+      T* tp; 	 
+    } pointerUnion; 	 
+    assert(p != nullptr);
+    pointerUnion.vp = p; 	 
+    pointerUnion.ucp += offset; 	 
+    std::unique_ptr<T> tp(pointerUnion.tp);
+    return(std::move(tp));
+  }
+}
+
+#endif

--- a/FWCore/Utilities/src/DictionaryTools.cc
+++ b/FWCore/Utilities/src/DictionaryTools.cc
@@ -27,59 +27,6 @@ namespace edm {
   static StringSet foundTypes_;
   static StringSet missingTypes_;
 
-  bool
-  find_nested_type_named(std::string const& nested_type,
-                         TypeWithDict const& typeToSearch,
-                         TypeWithDict& found_type) {
-    // Look for a sub-type named 'nested_type'
-    TypeWithDict foundType = typeToSearch.nestedType(nested_type);
-    if(bool(foundType)) {
-      found_type = foundType;
-      return true;
-    }
-    return false;
-  }
-
-  bool
-  is_RefVector(TypeWithDict const& possibleRefVector,
-               TypeWithDict& value_type) {
-
-    static std::string const template_name("edm::RefVector");
-    static std::string const member_type("member_type");
-    if(template_name == possibleRefVector.templateName()) {
-      return find_nested_type_named(member_type, possibleRefVector, value_type);
-    }
-    return false;
-  }
-
-  bool
-  is_PtrVector(TypeWithDict const& possibleRefVector,
-               TypeWithDict& value_type) {
-
-    static std::string const template_name("edm::PtrVector");
-    static std::string const member_type("member_type");
-    static std::string const val_type("value_type");
-    if(template_name == possibleRefVector.templateName()) {
-      TypeWithDict ptrType;
-      if(find_nested_type_named(val_type, possibleRefVector, ptrType)) {
-        return find_nested_type_named(val_type, ptrType, value_type);
-      }
-    }
-    return false;
-  }
-
-  bool
-  is_RefToBaseVector(TypeWithDict const& possibleRefVector,
-                     TypeWithDict& value_type) {
-
-    static std::string const template_name("edm::RefToBaseVector");
-    static std::string const member_type("member_type");
-    if(template_name == possibleRefVector.templateName()) {
-      return find_nested_type_named(member_type, possibleRefVector, value_type);
-    }
-    return false;
-  }
-
   namespace {
 
     int const oneParamArraySize = 6;

--- a/IOPool/Common/interface/getWrapperBasePtr.h
+++ b/IOPool/Common/interface/getWrapperBasePtr.h
@@ -1,26 +1,13 @@
 #ifndef IOPool_Common_getWrapperBasePtr_h
 #define IOPool_Common_getWrapperBasePtr_h
 
-#include <cassert>
-#include <memory>
-#include "TClass.h"
 #include "DataFormats/Common/interface/WrapperBase.h"
+#include "FWCore/Utilities//interface/getAnyPtr.h"
 
 namespace edm {
   inline
   std::unique_ptr<WrapperBase> getWrapperBasePtr(void* p, int offset) {
-    // A union is used to avoid possible copies during the triple cast that would otherwise be needed. 	 
-    // std::unique_ptr<WrapperBase> edp(static_cast<WrapperBase *>(static_cast<void *>(static_cast<unsigned char *>(p) + branchInfo.offsetToWrapperBase_))); 	 
-    union { 	 
-      void* vp; 	 
-      unsigned char* ucp; 	 
-      WrapperBase* edp; 	 
-    } pointerUnion; 	 
-    assert(p != nullptr);
-    pointerUnion.vp = p; 	 
-    pointerUnion.ucp += offset; 	 
-    std::unique_ptr<WrapperBase> edp(pointerUnion.edp);
-    return(std::move(edp));
+    return(std::move(getAnyPtr<WrapperBase>(p, offset)));
   }
 }
 


### PR DESCRIPTION
Use the compiler, rather than introspection, to find the type corresponding to T::value_type or T::member_type for any Wrapper<T>.
In ROOT 6 this avoids unnecessary header autoparsing, and thereby saves memory.  Since there is nothing specific to ROOT 6 about this change,  for code commonality this change is being made in the main 7_3_X branch.
I ran the full relval matrix, and no new errors occurred.
