### PR TITLE
Improvement of muon post cleaning [MET tails] at 73X

### DIFF
--- a/RecoParticleFlow/PFProducer/src/PFMuonAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFMuonAlgo.cc
@@ -894,6 +894,15 @@ void PFMuonAlgo::postClean(reco::PFCandidateCollection*  cands) {
   for(unsigned int i=0;i<cands->size();++i) 
     if ( cands->at(i).particleId() == reco::PFCandidate::mu )
       muons.push_back(i);
+    else if ( cands->at(i).particleId() == reco::PFCandidate::h ) {
+    //clean this crazy shit with iter10
+    if (cands->at(i).pt()>100.0 &&  (!cands->at(i).trackRef()->quality(trackQuality_)) && cands->at(i).muonRef()->isGlobalMuon()) {
+      maskedIndices_.push_back(i);
+      pfPunchThroughMuonCleanedCandidates_->push_back(cands->at(i));
+
+    }
+  }
+      
 
   //Then sort the muon indicess by decsending pt
 

--- a/RecoParticleFlow/PFProducer/src/PFMuonAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFMuonAlgo.cc
@@ -896,7 +896,7 @@ void PFMuonAlgo::postClean(reco::PFCandidateCollection*  cands) {
       muons.push_back(i);
     else if ( cands->at(i).particleId() == reco::PFCandidate::h ) {
     //clean this crazy shit with iter10
-    if (cands->at(i).pt()>100.0 &&  (!cands->at(i).trackRef()->quality(trackQuality_)) && cands->at(i).muonRef()->isGlobalMuon()) {
+      if (cands->at(i).pt()>100.0 &&  (!cands->at(i).trackRef()->quality(trackQuality_)) && cands->at(i).muonRef()->isGlobalMuon() && cands.at(i).rawHcalEnergy()/cands.at(i).p()<0.05) {
       maskedIndices_.push_back(i);
       pfPunchThroughMuonCleanedCandidates_->push_back(cands->at(i));
 

--- a/RecoParticleFlow/PFProducer/src/PFMuonAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFMuonAlgo.cc
@@ -759,7 +759,7 @@ void  PFMuonAlgo::changeTrack(reco::PFCandidate& candidate,const MuonTrackTypePa
     double px = bestTrack->px();
     double py = bestTrack->py();
     double pz = bestTrack->pz();
-    double energy = sqrt(bestTrack->p()*bestTrack->p() + 0.13957*0.13957);
+    double energy = sqrt(bestTrack->p()*bestTrack->p() + 0.1057*0.1057);
 
     candidate.setCharge(bestTrack->charge()>0 ? 1 : -1);
     candidate.setP4(math::XYZTLorentzVector(px,py,pz,energy));

--- a/RecoParticleFlow/PFProducer/src/PFMuonAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFMuonAlgo.cc
@@ -789,58 +789,17 @@ PFMuonAlgo::getTrackWithSmallestError(const std::vector<reco::Muon::MuonTrackTyp
 
 void PFMuonAlgo::estimateEventQuantities(const reco::PFCandidateCollection* pfc)
 {
-  //SUM ET from PU
+  //SUM ET 
   sumetPU_ = 0.0;
   METX_=0.;
   METY_=0.;
-  for (unsigned short i=1 ;i<vertices_->size();++i ) {
-    if ( !vertices_->at(i).isValid() || vertices_->at(i).isFake() ) continue; 
-
-    for ( reco::Vertex::trackRef_iterator itr = vertices_->at(i).tracks_begin();
-	  itr <  vertices_->at(i).tracks_end(); ++itr ) { 
-      sumetPU_ += (*itr)->pt();
-    }
-  }
-  sumetPU_ /= 0.65;
-  //SUM ET and MET
   sumet_=0.0;
-  double METXCh=0.0;
-  double METYCh=0.0;
-  double METXNeut=0.0;
-  double METYNeut=0.0;
+  for(reco::PFCandidateCollection::const_iterator i = pfc->begin();i!=pfc->end();++i) {
+    sumet_+=i->pt();
+    METX_+=i->px();
+    METY_+=i->py();
+  }
 
-    if (vertices_->size()>0 && vertices_->at(0).isValid()&& !vertices_->at(0).isFake()) {
-
-      for(reco::PFCandidateCollection::const_iterator i = pfc->begin();i!=pfc->end();++i) {
-	sumet_+=i->pt();
-
-	//If charged and from PV or muon
-	if( (i->charge() !=0 && i->trackRef().isNonnull() && vertices_->size()>0&& i->trackRef()->dz(vertices_->at(0).position())<dzPV_)||(abs(i->pdgId())==13)) {
-	  METXCh+=i->px();
-	  METYCh+=i->py();
-	}
-	//If charged and not from PV(assume there is a neutral balancing it)
-	else if( i->charge() !=0 && i->trackRef().isNonnull() && i->trackRef()->dz(vertices_->at(0).position())>dzPV_) {
-	  METXNeut-=i->px();
-	  METYNeut-=i->py();
-	}
-      //Neutral
-	else if( !(i->charge() !=0 && i->trackRef().isNonnull())) {
-	  METXNeut+=i->px();
-	  METYNeut+=i->py();
-	}
-      } //else if we dont have a vertex make standard PFMET
-    }
-    else {
-      for(reco::PFCandidateCollection::const_iterator i = pfc->begin();i!=pfc->end();++i) {
-	sumet_+=i->pt();
-	METXCh+=i->px();
-	METYCh+=i->py();
-      }
-    }
-
-    METX_ = (METXCh+METXNeut);
-    METY_ = (METYCh+METYNeut);
 }
 
 

--- a/RecoParticleFlow/PFProducer/src/PFMuonAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFMuonAlgo.cc
@@ -854,19 +854,19 @@ void PFMuonAlgo::postClean(reco::PFCandidateCollection*  cands) {
   std::vector<int> muons;
   std::vector<int> cosmics;
   //get the muons
-  for(unsigned int i=0;i<cands->size();++i) 
-    if ( cands->at(i).particleId() == reco::PFCandidate::mu )
+  for(unsigned int i=0;i<cands->size();++i)  {
+    const reco::PFCandidate& cand = (*cands)[i];
+    if ( cand.particleId() == reco::PFCandidate::mu )
       muons.push_back(i);
-    else if ( cands->at(i).particleId() == reco::PFCandidate::h && cands->at(i).muonRef().isNonnull()) {
-    //clean this crazy shit with iter10
-      if (cands->at(i).pt()>100.0 &&  (!cands->at(i).trackRef()->quality(trackQuality_)) && cands->at(i).muonRef()->isGlobalMuon() && cands->at(i).rawHcalEnergy()/cands->at(i).p()<0.05) {
+    else if ( cand.particleId() == reco::PFCandidate::h && cand.muonRef().isNonnull()) {
+    //MET cleaning for muons that are not high purity and became charged hadrons 
+      if (cand.pt()>100.0 &&  (!cand.trackRef()->quality(trackQuality_)) && cand.muonRef()->isGlobalMuon() && cand.rawHcalEnergy()<0.05*cand.p()) {
       maskedIndices_.push_back(i);
-      pfPunchThroughMuonCleanedCandidates_->push_back(cands->at(i));
-
+      pfPunchThroughMuonCleanedCandidates_->push_back(cand);
+      }
     }
-  }
       
-
+  }
   //Then sort the muon indicess by decsending pt
 
   IndexPtComparator comparator(cands);


### PR DESCRIPTION
Hi,
This PR applies the following changes to the muon post cleaning:
1. Fixes an issue observed in CSA14 samples  where a charged hadron is allowed to have a non high purity track that screws the MET. The story here is the following: When we import tracks we require high purity but if the track is the inner track of a muon we dont since the TuneP+PF can allow another refit to be used for the four vector. However the case was observed that the track was failing muID in PF and then a charged  hadron was created > 500 GeV with no HCAL deposit ... Added a fix for those cases

2., In the attempt to improve the MET in PF there was a mistake in calculating it ending up with a MET=PFMET+offset . After studies switched to plain PFMET . Tried also track MET but doesnt help since 
the post cleaning also creates neutral particles some times.

Example result plots follow in two samples:
1.Z prime -> this sample is great to see the effect of mismeasured muons since it has MET=0 and very high pt muons that can be mismeasured. In this sample the arithmetic RMS goes from 150->140 GeV
1. The Flat QCD sample shows smaller(as expected) improvement as well 30.07->30.03 

**red is before, black is after**

Adding also the MUO POG: @trocino @battibass @abbiendi

![qcd](https://cloud.githubusercontent.com/assets/5180887/4526104/310a10de-4d5c-11e4-87d6-b21607e17a1c.png)
![zprime](https://cloud.githubusercontent.com/assets/5180887/4526105/31102410-4d5c-11e4-9c33-6681a2948afa.png)
