### PR TITLE
Fix checksum for old version of SendJobHeader

### DIFF
--- a/DataFormats/Streamer/src/classes_def.xml
+++ b/DataFormats/Streamer/src/classes_def.xml
@@ -10,6 +10,7 @@
  </class>
  <class name="edm::SendJobHeader" ClassVersion="11">
   <version ClassVersion="11" checksum="79372782"/>
+  <version ClassVersion="10" checksum="1238072397"/>
  </class>
  <class name="std::vector<edm::BranchDescription>"/>
 </lcgdict>


### PR DESCRIPTION
Add back the old checksum which was mistakenly deleted recently
when a new checksum was added and the version changed for the
SendJobHeader class used in the streamer format. Note that no one
reported this problem and probably never would have noticed it because
streamers are normally written and read with the same release.
