### PR TITLE
Fix clang problems in FWCore

### DIFF
--- a/FWCore/FWLite/test/ref_t.cppunit.cpp
+++ b/FWCore/FWLite/test/ref_t.cppunit.cpp
@@ -388,29 +388,29 @@ void testRefInROOT::testThinning() {
 
     CPPUNIT_ASSERT(trackD.refVector1[0]->a == 10 + offset);
     CPPUNIT_ASSERT(trackD.refVector1[4]->a == 14 + offset);
-    CPPUNIT_ASSERT_THROW(trackD.refVector1[8]->a, cms::Exception);
+    CPPUNIT_ASSERT_THROW(trackD.refVector1[8].operator->(), cms::Exception);
     CPPUNIT_ASSERT(!trackD.refVector1.isAvailable());
     CPPUNIT_ASSERT(trackD.refVector1[0]->a == 10 + offset);
     CPPUNIT_ASSERT(trackD.refVector1[4]->a == 14 + offset);
-    CPPUNIT_ASSERT_THROW(trackD.refVector1[8]->a, cms::Exception);
+    CPPUNIT_ASSERT_THROW(trackD.refVector1[8].operator->(), cms::Exception);
 
     CPPUNIT_ASSERT(trackD.ptrVector1[0]->a == 10 + offset);
     CPPUNIT_ASSERT(trackD.ptrVector1[4]->a == 14 + offset);
-    CPPUNIT_ASSERT_THROW(trackD.ptrVector1[8]->a, cms::Exception);
+    CPPUNIT_ASSERT_THROW(trackD.ptrVector1[8].operator->(), cms::Exception);
     CPPUNIT_ASSERT(trackD.ptrVector1[9]->a == 21 + offset);
     CPPUNIT_ASSERT(!trackD.ptrVector1.isAvailable());
     CPPUNIT_ASSERT(trackD.ptrVector1[0]->a == 10 + offset);
     CPPUNIT_ASSERT(trackD.ptrVector1[4]->a == 14 + offset);
-    CPPUNIT_ASSERT_THROW(trackD.ptrVector1[8]->a, cms::Exception);
+    CPPUNIT_ASSERT_THROW(trackD.ptrVector1[8].operator->(), cms::Exception);
     CPPUNIT_ASSERT(trackD.ptrVector1[9]->a == 21 + offset);
 
     CPPUNIT_ASSERT(trackD.refToBaseVector1[0]->a == 10 + offset);
     CPPUNIT_ASSERT(trackD.refToBaseVector1[4]->a == 14 + offset);
-    CPPUNIT_ASSERT_THROW(trackD.refToBaseVector1[8]->a, cms::Exception);
+    CPPUNIT_ASSERT_THROW(trackD.refToBaseVector1[8].operator->(), cms::Exception);
     CPPUNIT_ASSERT(!trackD.refToBaseVector1.isAvailable());
     CPPUNIT_ASSERT(trackD.refToBaseVector1[0]->a == 10 + offset);
     CPPUNIT_ASSERT(trackD.refToBaseVector1[4]->a == 14 + offset);
-    CPPUNIT_ASSERT_THROW(trackD.refToBaseVector1[8]->a, cms::Exception);
+    CPPUNIT_ASSERT_THROW(trackD.refToBaseVector1[8].operator->(), cms::Exception);
 
     // In the G branch this tests accessing a value in
     // thinned collection made from a master collection.
@@ -462,11 +462,11 @@ void testRefInROOT::testThinning() {
 
     edmtest::TrackOfThings const& trackM0 = vTracks->at(0);
     CPPUNIT_ASSERT(!trackM0.ref1.isAvailable());
-    CPPUNIT_ASSERT_THROW(trackM0.ref1->a, cms::Exception);
+    CPPUNIT_ASSERT_THROW(trackM0.ref1.operator->(), cms::Exception);
     CPPUNIT_ASSERT(!trackM0.ptr1.isAvailable());
-    CPPUNIT_ASSERT_THROW(trackM0.ptr1->a, cms::Exception);
+    CPPUNIT_ASSERT_THROW(trackM0.ptr1.operator->(), cms::Exception);
     CPPUNIT_ASSERT(!trackM0.refToBase1.isAvailable());
-    CPPUNIT_ASSERT_THROW(trackM0.refToBase1->a, cms::Exception);
+    CPPUNIT_ASSERT_THROW(trackM0.refToBase1.operator->(), cms::Exception);
 
     edmtest::TrackOfThings const& trackM1 = vTracks->at(1);
     CPPUNIT_ASSERT(trackM1.ref1.isAvailable());
@@ -477,29 +477,29 @@ void testRefInROOT::testThinning() {
     CPPUNIT_ASSERT(trackM1.refToBase1->a == 44 + offset);
 
     edmtest::TrackOfThings const& trackM = vTracks->at(0);
-    CPPUNIT_ASSERT_THROW(trackM.refVector1[0]->a, cms::Exception);
+    CPPUNIT_ASSERT_THROW(trackM.refVector1[0].operator->(), cms::Exception);
     CPPUNIT_ASSERT(trackM.refVector1[4]->a == 44 + offset);
-    CPPUNIT_ASSERT_THROW(trackM.refVector1[8]->a, cms::Exception);
+    CPPUNIT_ASSERT_THROW(trackM.refVector1[8].operator->(), cms::Exception);
     CPPUNIT_ASSERT(!trackM.refVector1.isAvailable());
-    CPPUNIT_ASSERT_THROW(trackM.refVector1[0]->a, cms::Exception);
+    CPPUNIT_ASSERT_THROW(trackM.refVector1[0].operator->(), cms::Exception);
     CPPUNIT_ASSERT(trackM.refVector1[4]->a == 44 + offset);
-    CPPUNIT_ASSERT_THROW(trackM.refVector1[8]->a, cms::Exception);
+    CPPUNIT_ASSERT_THROW(trackM.refVector1[8].operator->(), cms::Exception);
 
-    CPPUNIT_ASSERT_THROW(trackM.ptrVector1[0]->a, cms::Exception);
+    CPPUNIT_ASSERT_THROW(trackM.ptrVector1[0].operator->(), cms::Exception);
     CPPUNIT_ASSERT(trackM.ptrVector1[4]->a == 44 + offset);
-    CPPUNIT_ASSERT_THROW(trackM.ptrVector1[8]->a, cms::Exception);
+    CPPUNIT_ASSERT_THROW(trackM.ptrVector1[8].operator->(), cms::Exception);
     CPPUNIT_ASSERT(!trackM.ptrVector1.isAvailable());
-    CPPUNIT_ASSERT_THROW(trackM.ptrVector1[0]->a, cms::Exception);
+    CPPUNIT_ASSERT_THROW(trackM.ptrVector1[0].operator->(), cms::Exception);
     CPPUNIT_ASSERT(trackM.ptrVector1[4]->a == 44 + offset);
-    CPPUNIT_ASSERT_THROW(trackM.ptrVector1[8]->a, cms::Exception);
+    CPPUNIT_ASSERT_THROW(trackM.ptrVector1[8].operator->(), cms::Exception);
 
-    CPPUNIT_ASSERT_THROW(trackM.refToBaseVector1[0]->a, cms::Exception);
+    CPPUNIT_ASSERT_THROW(trackM.refToBaseVector1[0].operator->(), cms::Exception);
     CPPUNIT_ASSERT(trackM.refToBaseVector1[4]->a == 44 + offset);
-    CPPUNIT_ASSERT_THROW(trackM.refToBaseVector1[8]->a, cms::Exception);
+    CPPUNIT_ASSERT_THROW(trackM.refToBaseVector1[8].operator->(), cms::Exception);
     CPPUNIT_ASSERT(!trackM.refToBaseVector1.isAvailable());
-    CPPUNIT_ASSERT_THROW(trackM.refToBaseVector1[0]->a, cms::Exception);
+    CPPUNIT_ASSERT_THROW(trackM.refToBaseVector1[0].operator->(), cms::Exception);
     CPPUNIT_ASSERT(trackM.refToBaseVector1[4]->a == 44 + offset);
-    CPPUNIT_ASSERT_THROW(trackM.refToBaseVector1[8]->a, cms::Exception);
+    CPPUNIT_ASSERT_THROW(trackM.refToBaseVector1[8].operator->(), cms::Exception);
   }
 }
 

--- a/FWCore/Framework/src/SystemTimeKeeper.h
+++ b/FWCore/Framework/src/SystemTimeKeeper.h
@@ -36,7 +36,7 @@ namespace edm {
   class PathContext;
   class HLTPathStatus;
   class ModuleCallingContext;
-  class TriggerTimingReport;
+  struct TriggerTimingReport;
   namespace service {
     class TriggersNameService;
   }

--- a/FWCore/Framework/test/BuildFile.xml
+++ b/FWCore/Framework/test/BuildFile.xml
@@ -2,7 +2,7 @@
 <library   file="DummyData.cc,DummyRecord.cc,DepRecord.cc,Dummy2Record.cc,DepOn2Record.cc" name="FWCoreFrameworkTestDummyForEventSetup">
   <use   name="FWCore/Framework"/>
 </library>
-<library   file="MockEventProcessor.cc" name="FWCoreFrameworkTest">
+<library   file="MockEventProcessor.cc,stubs/TestBeginEndJobAnalyzer.cc" name="FWCoreFrameworkTest">
   <use   name="FWCore/Framework"/>
 </library>
 <library   file="stubs/TestOutputModule.cc" name="TestOutputModule">
@@ -131,8 +131,9 @@
   <use   name="FWCore/Framework"/>
   <use   name="cppunit"/>
 </library>
-<library   file="stubs/TestBeginEndJobAnalyzer.cc,stubs/TestBeginEndJobAnalyzerModule.cc" name="FWCoreFrameworkTestBeginEndJobAnalyzer">
+<library   file="stubs/TestBeginEndJobAnalyzerModule.cc" name="FWCoreFrameworkTestBeginEndJobAnalyzer">
   <flags   EDM_PLUGIN="1"/>
+  <lib   name="FWCoreFrameworkTest"/>
   <use   name="FWCore/Framework"/>
 </library>
 <library   file="stubs/TestFailuresAnalyzer.cc" name="FWCoreFrameworkTestFailuresAnalyzer">
@@ -169,6 +170,7 @@
   <use   name="cppunit"/>
 </bin>
 <bin   name="TestFWCoreFrameworkeventprocessor" file="testRunner.cpp,eventprocessor2_t.cppunit.cc,eventprocessor_t.cppunit.cc">
+  <lib   name="FWCoreFrameworkTest"/>
   <use   name="DataFormats/Provenance"/>
   <use   name="DataFormats/WrappedStdDictionaries"/>
   <use   name="FWCore/Framework"/>

--- a/FWCore/Framework/test/iovsyncvalue_t.cppunit.cc
+++ b/FWCore/Framework/test/iovsyncvalue_t.cppunit.cc
@@ -174,10 +174,10 @@ testIOVSyncValue::invalidComparisonTest()
 
   CPPUNIT_ASSERT(! timeBased.comparable(eventBased));
   CPPUNIT_ASSERT(! eventBased.comparable(timeBased));
-  CPPUNIT_ASSERT_THROW( (timeBased < eventBased)  , cms::Exception);
-  CPPUNIT_ASSERT_THROW( (timeBased <= eventBased) , cms::Exception);
+  CPPUNIT_ASSERT_THROW( [&](){return timeBased < eventBased;}()  , cms::Exception);
+  CPPUNIT_ASSERT_THROW( [&](){return timeBased <= eventBased;}() , cms::Exception);
   CPPUNIT_ASSERT( !(timeBased == eventBased));
-  CPPUNIT_ASSERT( (timeBased != eventBased));
-  CPPUNIT_ASSERT_THROW( (timeBased > eventBased)  , cms::Exception);
-  CPPUNIT_ASSERT_THROW( (timeBased >= eventBased) , cms::Exception);
+  CPPUNIT_ASSERT( timeBased != eventBased);
+  CPPUNIT_ASSERT_THROW( [&]() {return timeBased > eventBased;}()  , cms::Exception);
+  CPPUNIT_ASSERT_THROW( [&]() {return timeBased >= eventBased;}() , cms::Exception);
 }

--- a/FWCore/Framework/test/stubs/TestBeginEndJobAnalyzer.cc
+++ b/FWCore/Framework/test/stubs/TestBeginEndJobAnalyzer.cc
@@ -26,6 +26,12 @@ void hello(const char * hi) {
   //std::cout << "IN " << hi << std::endl;
 }
 
+TestBeginEndJobAnalyzer::Control & 
+TestBeginEndJobAnalyzer::control() {
+  static Control l;
+  return l;
+}
+
 TestBeginEndJobAnalyzer::TestBeginEndJobAnalyzer(const edm::ParameterSet& /* iConfig */) {
    hello("constr");
 }

--- a/FWCore/Framework/test/stubs/TestBeginEndJobAnalyzer.h
+++ b/FWCore/Framework/test/stubs/TestBeginEndJobAnalyzer.h
@@ -30,31 +30,28 @@ public:
    ~TestBeginEndJobAnalyzer();
    
    
-   virtual void analyze(const edm::Event&, const edm::EventSetup&);
+   virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
    
-   virtual void beginJob();
-   virtual void endJob();
-   virtual void beginRun(edm::Run const&, edm::EventSetup const&);
-   virtual void endRun(edm::Run const&, edm::EventSetup const&);
-   virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
-   virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
+   virtual void beginJob() override;
+   virtual void endJob() override;
+   virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
+   virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
+   virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+   virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
    
 
-   struct dso_export  Control {
-      bool beginJobCalled;
-      bool endJobCalled;
-      bool beginRunCalled;
-      bool endRunCalled;
-      bool beginLumiCalled;
-      bool endLumiCalled;
-      bool destructorCalled;
+   struct Control {
+      bool beginJobCalled = false;
+      bool endJobCalled = false;
+      bool beginRunCalled = false;
+      bool endRunCalled = false;
+      bool beginLumiCalled = false;
+      bool endLumiCalled = false;
+      bool destructorCalled = false;
    };
 
-   static Control & control() dso_export {
-       static Control l;
-       return l;
-   }
+   static Control & control();
 
 
 private:

--- a/FWCore/Integration/test/ThingAlgorithm.h
+++ b/FWCore/Integration/test/ThingAlgorithm.h
@@ -9,14 +9,13 @@
 namespace edmtest {
   class ThingAlgorithm {
   public:
-  ThingAlgorithm(long iOffsetDelta = 0, int nThings = 20) : theDebugLevel(0), offset(0), offsetDelta(iOffsetDelta),
+  ThingAlgorithm(long iOffsetDelta = 0, int nThings = 20) :  offset(0), offsetDelta(iOffsetDelta),
       nThings_(nThings) {}
 
     /// Runs the algorithm and returns a list of Things
     /// The user declares the vector and calls this method.
     void run(ThingCollection& thingCollection);
   private:
-    int    theDebugLevel;
     long   offset;
     long   offsetDelta;
     int    nThings_;

--- a/FWCore/Integration/test/TrackOfThingsProducer.cc
+++ b/FWCore/Integration/test/TrackOfThingsProducer.cc
@@ -62,7 +62,6 @@ namespace edmtest {
     // and have no meaning other than that we will later check that we can
     // read out what we put in here.
     std::vector<unsigned int>::const_iterator key = keysToReference_.begin();
-    std::vector<unsigned int>::const_iterator keyEnd = keysToReference_.end();
     for(unsigned int i = 0; i < 5; ++i) {
 
 


### PR DESCRIPTION
There were several clang errors and warnings originating from FWCore. These commits fix those problems.
