### PR TITLE
csc bad channels handling in rechit building updated for unganged me11a

### DIFF
--- a/CalibMuon/CSCCalibration/interface/CSCConditions.h
+++ b/CalibMuon/CSCCalibration/interface/CSCConditions.h
@@ -85,9 +85,20 @@ public:
   /// anode bx offset in bx given detId of chamber
   float anodeBXoffset( const CSCDetId & detId) const;
 
-  /// bad channel words per CSCLayer - 1 bit per channel
-  const std::bitset<80>& badStripWord( const CSCDetId& id ) const;
-  const std::bitset<112>& badWireWord( const CSCDetId& id ) const;
+  /// bad strip channel word for a CSCLayer - 1 bit per channel
+  const std::bitset<112>& badStripWord() const {
+    return badStripWord_; 
+  }
+
+  /// bad wiregroup channel word for a CSCLayer - 1 bit per channel
+  const std::bitset<112>& badWireWord() const {
+    return badWireWord_;
+  }
+
+  /// the offline CSCDetId of current bad channel words
+  const CSCDetId& idOfBadChannelWords() const{
+    return idOfBadChannelWords_;
+  }
 
   void print() const;
 
@@ -103,9 +114,8 @@ public:
   /// did we request reading timing correction info from db?
   bool useTimingCorrections() const { return useTimingCorrections_; }
 
-  /// fill bad channel words
-  void fillBadStripWords();
-  void fillBadWireWords();
+  /// Fill bad channel words - one for strips, one for wires, for an offline CSCDetId
+  void fillBadChannelWords( const CSCDetId& id );
 
   /// average gain over entire CSC system (logically const although must be cached here).
   float averageGain() const;
@@ -121,6 +131,14 @@ public:
   int rawStripChannel( const CSCDetId& id, int geomChannel) const;
 
 private:
+
+  /// fill bad channel words for offline id
+  void fillBadStripWord( const CSCDetId& id );
+  void fillBadWireWord( const CSCDetId& id );
+  /// Set id for current content of bad channel words - this is offline id i.e. separate for ME11A & ME11B
+  void setIdOfBadChannelWords ( const CSCDetId& id ){
+    idOfBadChannelWords_ = id;
+  }
 
 // handles to conditions data
 
@@ -147,9 +165,10 @@ private:
   bool useTimingCorrections_; // flag whether or not to even attempt reading timing correction info from db
   bool useGasGainCorrections_; // flag whether or not to even attempt reading gas-gain correction info from db
 
-  // cache bad channel words once created
-  std::vector< std::bitset<80> > badStripWords;
-  std::vector< std::bitset<112> > badWireWords;
+  // Cache bad channel content for current CSC layer
+  CSCDetId idOfBadChannelWords_;
+  std::bitset<112> badStripWord_;
+  std::bitset<112> badWireWord_;
 
   mutable float theAverageGain; // average over entire system, subject to some constraints!
 

--- a/RecoLocalMuon/CSCRecHitD/src/CSCHitFromStripOnly.cc
+++ b/RecoLocalMuon/CSCRecHitD/src/CSCHitFromStripOnly.cc
@@ -141,8 +141,8 @@ std::vector<CSCStripHit> CSCHitFromStripOnly::runStrip( const CSCDetId& id, cons
     
     //---- Check if a neighbouring strip is a dead strip
     //bool deadStrip = isNearDeadStrip(id, theMaxima.at(imax)); 
-    bool deadStripL = isDeadStrip(id, theMaxima.at(imax)-1);
-    bool deadStripR = isDeadStrip(id, theMaxima.at(imax)+1);
+    bool deadStripL = isDeadStrip(id, theMaxima.at(imax)-1, nstrips_);
+    bool deadStripR = isDeadStrip(id, theMaxima.at(imax)+1, nstrips_);
     short int aDeadStrip = 0;
     if(!deadStripL && !deadStripR){
       aDeadStrip = 0;
@@ -433,7 +433,7 @@ void CSCHitFromStripOnly::findMaxima(const CSCDetId& id) {
     
     bool maximumFound = false;
     // Left edge of chamber
-    if(!isDeadStrip(id, i+1)){ // is it i or i+1 
+    if( !isDeadStrip(id, i+1, nstrips_) ){ // Is it i or i+1 
       if ( i == 0 ) {
 	heightCluster = thePulseHeightMap[i].phmax()+thePulseHeightMap[i+1].phmax();
 	// Have found a strip Hit if...
@@ -557,16 +557,16 @@ float CSCHitFromStripOnly::findHitOnStripPosition( const std::vector<CSCStripHit
   return strippos;
 }
 
-bool CSCHitFromStripOnly::isNearDeadStrip(const CSCDetId& id, int centralStrip){
+bool CSCHitFromStripOnly::isNearDeadStrip(const CSCDetId& id, int centralStrip, int  nstrips){
 
   //@@ Tim says: not sure I understand this properly... but just moved code to CSCRecoConditions
   // where it can handle the conversion from strip to channel etc.
-  return recoConditions_->nearBadStrip( id, centralStrip );
+  return recoConditions_->nearBadStrip( id, centralStrip, nstrips );
 
 } 
 
-bool CSCHitFromStripOnly::isDeadStrip(const CSCDetId& id, int centralStrip){
-  return recoConditions_->badStrip( id, centralStrip );
+bool CSCHitFromStripOnly::isDeadStrip(const CSCDetId& id, int centralStrip, int  nstrips ){
+  return recoConditions_->badStrip( id, centralStrip, nstrips );
 
 } 
 

--- a/RecoLocalMuon/CSCRecHitD/src/CSCHitFromStripOnly.h
+++ b/RecoLocalMuon/CSCRecHitD/src/CSCHitFromStripOnly.h
@@ -68,10 +68,10 @@ class CSCHitFromStripOnly
   CSCStripHitData makeStripData( int centerStrip, int offset );
 
   /// Is either neighbour 'bad'?
-  bool isNearDeadStrip(const CSCDetId& id, int centralStrip); 
+  bool isNearDeadStrip(const CSCDetId& id, int centralStrip, int nstrips); 
 
   /// Is the strip 'bad'?
-  bool isDeadStrip(const CSCDetId& id, int centralStrip); 
+  bool isDeadStrip(const CSCDetId& id, int centralStrip, int nstrips); 
 
   /// Find position of hit in strip cluster in terms of strip #
   float findHitOnStripPosition( const std::vector<CSCStripHitData>& data, const int& centerStrip );

--- a/RecoLocalMuon/CSCRecHitD/src/CSCRecHitDBuilder.cc
+++ b/RecoLocalMuon/CSCRecHitD/src/CSCRecHitDBuilder.cc
@@ -108,7 +108,10 @@ void CSCRecHitDBuilder::build( const CSCStripDigiCollection* stripdc, const CSCW
       rwired = wiredc->get( compId );
     }
  
+    // Fill bad channel bitsets for this layer
+    recoConditions_->fillBadChannelWords( id );
     
+    // Build strip hits for this layer
     std::vector<CSCStripHit> const & cscStripHit = hitsFromStripOnly_->runStrip( id, layer, rstripd);
 
     if (cscStripHit.empty()) continue;
@@ -166,7 +169,8 @@ const CSCLayer* CSCRecHitDBuilder::getLayer( const CSCDetId& detId )  {
 }
 
 
-void CSCRecHitDBuilder::setConditions( const CSCRecoConditions* reco ) {
+void CSCRecHitDBuilder::setConditions( CSCRecoConditions* reco ) {
+  recoConditions_ = reco;
   hitsFromStripOnly_->setConditions( reco );
   hitsFromWireOnly_->setConditions( reco );
   make2DHits_->setConditions( reco );  

--- a/RecoLocalMuon/CSCRecHitD/src/CSCRecHitDBuilder.h
+++ b/RecoLocalMuon/CSCRecHitD/src/CSCRecHitDBuilder.h
@@ -67,7 +67,7 @@ class CSCRecHitDBuilder
   /**
    * Pass conditions downstream
    */
-  void setConditions ( const CSCRecoConditions* reco );
+  void setConditions ( CSCRecoConditions* reco );
 
   const CSCLayer* getLayer( const CSCDetId& detId );
 
@@ -92,6 +92,10 @@ class CSCRecHitDBuilder
    * Cache geometry for current event
    */
   const CSCGeometry* geom_;
+  /* 
+   * Cache conditions data for current event - cannot be const because we need to update bad channels words
+   */
+  CSCRecoConditions* recoConditions_;
 };
 
 #endif

--- a/RecoLocalMuon/CSCRecHitD/src/CSCRecoBadChannelsAnalyzer.cc
+++ b/RecoLocalMuon/CSCRecHitD/src/CSCRecoBadChannelsAnalyzer.cc
@@ -1,0 +1,146 @@
+/// Stand-alone test of bad strip channels testing via CSCRecoConditions
+/// Tim Cox - 03-Oct-2014
+
+#include <string>
+#include <iostream>
+#include <vector>
+
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "CalibMuon/CSCCalibration/interface/CSCIndexerBase.h"
+#include "CalibMuon/CSCCalibration/interface/CSCIndexerRecord.h"
+#include "CalibMuon/CSCCalibration/interface/CSCChannelMapperBase.h"
+#include "CalibMuon/CSCCalibration/interface/CSCChannelMapperRecord.h"
+
+#include <DataFormats/MuonDetId/interface/CSCDetId.h>
+
+#include <Geometry/Records/interface/MuonGeometryRecord.h>
+#include <Geometry/CSCGeometry/interface/CSCGeometry.h>
+#include <Geometry/CSCGeometry/interface/CSCLayer.h>
+
+#include <RecoLocalMuon/CSCRecHitD/src/CSCRecoConditions.h>
+
+
+  class CSCRecoBadChannelsAnalyzer : public edm::EDAnalyzer
+  {
+  public:
+    explicit  CSCRecoBadChannelsAnalyzer(edm::ParameterSet const& ps ) 
+      : dashedLineWidth_( 80 ), 
+        dashedLine_( std::string(dashedLineWidth_, '-') ), 
+	myName_( "CSCRecoBadChannelsAnalyzer" ),
+	readBadChannels_( ps.getParameter<bool>("readBadChannels") ),
+        recoConditions_( new CSCRecoConditions( ps ) ) {
+    }
+
+    virtual ~CSCRecoBadChannelsAnalyzer() { delete recoConditions_; }
+    virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
+
+    /// did we request reading bad channel info from db?
+    bool readBadChannels() const { return readBadChannels_; }
+    const std::string& myName() { return myName_;}
+
+  private:
+
+    const int dashedLineWidth_;
+    const std::string dashedLine_;
+    const std::string myName_;
+
+    bool readBadChannels_; 
+    CSCRecoConditions* recoConditions_;
+  };
+  
+  void CSCRecoBadChannelsAnalyzer::analyze(const edm::Event& ev, const edm::EventSetup& evsetup )
+  {
+    using namespace edm::eventsetup;
+
+    std::cout << myName() << "::analyze running..." << std::endl;
+    std::cout << "start " << dashedLine_ << std::endl;
+
+    std::cout << "RUN# " << ev.id().run() << std::endl;
+    std::cout << "EVENT# " << ev.id().event() << std::endl;
+
+    edm::ESHandle<CSCIndexerBase> theIndexer;
+    evsetup.get<CSCIndexerRecord>().get(theIndexer);
+
+    std::cout << myName() << "::analyze sees indexer " << theIndexer->name()  << " in Event Setup" << std::endl;
+
+    edm::ESHandle<CSCChannelMapperBase> theMapper;
+    evsetup.get<CSCChannelMapperRecord>().get(theMapper);
+
+    std::cout << myName() << "::analyze sees mapper " << theMapper->name()  << " in Event Setup" << std::endl;
+
+    edm::ESHandle<CSCGeometry> theGeometry;
+    evsetup.get<MuonGeometryRecord>().get( theGeometry );     
+
+    std::cout << " Geometry node for CSCGeom is  " << &(*theGeometry) << std::endl;   
+    std::cout << " There are " << theGeometry->dets().size() << " dets" << std::endl;
+    std::cout << " There are " << theGeometry->detTypes().size() << " types" << "\n" << std::endl;
+
+    // INITIALIZE CSCConditions
+    recoConditions_->initializeEvent(evsetup);
+
+    // HERE NEED TO ITERATE OVER ALL CSCDetId
+
+    std::cout << myName() << ": Begin iteration over geometry..." << std::endl;
+
+    const CSCGeometry::LayerContainer& vecOfLayers = theGeometry->layers();
+    std::cout << "There are " << vecOfLayers.size() << " layers" << std::endl;
+
+    std::cout << dashedLine_ << std::endl;
+
+    int ibadchannels = 0; // COUNT OF BAD STRIP CHANNELS
+    int ibadlayers = 0 ; //COUNT OF LAYERS WITH BAD STRIP CHANNELS
+
+    for( auto it = vecOfLayers.begin(); it != vecOfLayers.end(); ++it ){
+
+      const CSCLayer* layer = *it;
+
+      if( layer ){
+        CSCDetId id = layer->id();
+        int nstrips = layer->geometry()->numberOfStrips();
+        std::cout << "Layer " << id << " has " << nstrips << " strips" << std::endl;
+
+	// GET BAD CHANNELS FOR THIS LAYER
+
+        recoConditions_->fillBadChannelWords( id );
+
+	// SEARCH FOR BAD STRIP CHANNELS IN THIS LAYER - GEOMETRIC STRIP INPUT!!
+
+	bool layerhasbadchannels = false;
+	for ( short is = 1; is<=nstrips; ++is ) {
+	  if ( recoConditions_->badStrip( id, is, nstrips ) ) {
+              ++ibadchannels;
+	      layerhasbadchannels = true;
+	      std::cout << id << " strip " << is << " is bad" << std::endl;
+	    }            
+	}
+
+	for ( short is = 1; is<=nstrips; ++is ) {
+	  if ( recoConditions_->nearBadStrip( id, is, nstrips ) ) {
+	    std::cout << id << " strip " << is << " is a neighbor of a bad strip" << std::endl;
+	    }            
+	}
+
+	if (layerhasbadchannels) ++ibadlayers;
+
+      }
+      else {
+	std::cout << "WEIRD ERROR: a null CSCLayer* was seen" << std::endl;
+      }
+    }
+
+    std::cout << "No. of layers with bad strip channels = " << ibadlayers << std::endl;
+    std::cout << "No. of bad strip channels seen = " << ibadchannels << std::endl;
+
+    std::cout << dashedLine_ << " end" << std::endl;
+  }
+
+  DEFINE_FWK_MODULE(CSCRecoBadChannelsAnalyzer);
+
+

--- a/RecoLocalMuon/CSCRecHitD/src/CSCRecoBadChannelsAnalyzer.cc
+++ b/RecoLocalMuon/CSCRecHitD/src/CSCRecoBadChannelsAnalyzer.cc
@@ -1,14 +1,14 @@
 /// Stand-alone test of bad strip channels testing via CSCRecoConditions
-/// Tim Cox - 03-Oct-2014
+/// Tim Cox - 07-Oct-2014 - now using MessageLogger
 
 #include <string>
-#include <iostream>
 #include <vector>
 
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -29,6 +29,7 @@
 
   class CSCRecoBadChannelsAnalyzer : public edm::EDAnalyzer
   {
+
   public:
     explicit  CSCRecoBadChannelsAnalyzer(edm::ParameterSet const& ps ) 
       : dashedLineWidth_( 80 ), 
@@ -59,40 +60,40 @@
   {
     using namespace edm::eventsetup;
 
-    std::cout << myName() << "::analyze running..." << std::endl;
-    std::cout << "start " << dashedLine_ << std::endl;
+    edm::LogVerbatim("CSCBadChannels") << myName() << "::analyze running..." ;
+    edm::LogVerbatim("CSCBadChannels") << "start " << dashedLine_ ;
 
-    std::cout << "RUN# " << ev.id().run() << std::endl;
-    std::cout << "EVENT# " << ev.id().event() << std::endl;
+    edm::LogVerbatim("CSCBadChannels") << "RUN# " << ev.id().run() ;
+    edm::LogVerbatim("CSCBadChannels") << "EVENT# " << ev.id().event() ;
 
     edm::ESHandle<CSCIndexerBase> theIndexer;
     evsetup.get<CSCIndexerRecord>().get(theIndexer);
 
-    std::cout << myName() << "::analyze sees indexer " << theIndexer->name()  << " in Event Setup" << std::endl;
+    edm::LogVerbatim("CSCBadChannels") << myName() << "::analyze sees indexer " << theIndexer->name()  << " in Event Setup" ;
 
     edm::ESHandle<CSCChannelMapperBase> theMapper;
     evsetup.get<CSCChannelMapperRecord>().get(theMapper);
 
-    std::cout << myName() << "::analyze sees mapper " << theMapper->name()  << " in Event Setup" << std::endl;
+    edm::LogVerbatim("CSCBadChannels") << myName() << "::analyze sees mapper " << theMapper->name()  << " in Event Setup" ;
 
     edm::ESHandle<CSCGeometry> theGeometry;
     evsetup.get<MuonGeometryRecord>().get( theGeometry );     
 
-    std::cout << " Geometry node for CSCGeom is  " << &(*theGeometry) << std::endl;   
-    std::cout << " There are " << theGeometry->dets().size() << " dets" << std::endl;
-    std::cout << " There are " << theGeometry->detTypes().size() << " types" << "\n" << std::endl;
+    edm::LogVerbatim("CSCBadChannels") << " Geometry node for CSCGeom is  " << &(*theGeometry) ;   
+    edm::LogVerbatim("CSCBadChannels") << " There are " << theGeometry->dets().size() << " dets" ;
+    edm::LogVerbatim("CSCBadChannels") << " There are " << theGeometry->detTypes().size() << " types" << "\n" ;
 
     // INITIALIZE CSCConditions
     recoConditions_->initializeEvent(evsetup);
 
     // HERE NEED TO ITERATE OVER ALL CSCDetId
 
-    std::cout << myName() << ": Begin iteration over geometry..." << std::endl;
+    edm::LogVerbatim("CSCBadChannels") << myName() << ": Begin iteration over geometry..." ;
 
     const CSCGeometry::LayerContainer& vecOfLayers = theGeometry->layers();
-    std::cout << "There are " << vecOfLayers.size() << " layers" << std::endl;
+    edm::LogVerbatim("CSCBadChannels") << "There are " << vecOfLayers.size() << " layers" ;
 
-    std::cout << dashedLine_ << std::endl;
+    edm::LogVerbatim("CSCBadChannels") << dashedLine_ ;
 
     int ibadchannels = 0; // COUNT OF BAD STRIP CHANNELS
     int ibadlayers = 0 ; //COUNT OF LAYERS WITH BAD STRIP CHANNELS
@@ -104,7 +105,7 @@
       if( layer ){
         CSCDetId id = layer->id();
         int nstrips = layer->geometry()->numberOfStrips();
-        std::cout << "Layer " << id << " has " << nstrips << " strips" << std::endl;
+        edm::LogVerbatim("CSCBadChannels") << "Layer " << id << " has " << nstrips << " strips" ;
 
 	// GET BAD CHANNELS FOR THIS LAYER
 
@@ -117,13 +118,13 @@
 	  if ( recoConditions_->badStrip( id, is, nstrips ) ) {
               ++ibadchannels;
 	      layerhasbadchannels = true;
-	      std::cout << id << " strip " << is << " is bad" << std::endl;
+	      edm::LogVerbatim("CSCBadChannels") << id << " strip " << is << " is bad" ;
 	    }            
 	}
 
 	for ( short is = 1; is<=nstrips; ++is ) {
 	  if ( recoConditions_->nearBadStrip( id, is, nstrips ) ) {
-	    std::cout << id << " strip " << is << " is a neighbor of a bad strip" << std::endl;
+	    edm::LogVerbatim("CSCBadChannels") << id << " strip " << is << " is a neighbor of a bad strip" ;
 	    }            
 	}
 
@@ -131,14 +132,14 @@
 
       }
       else {
-	std::cout << "WEIRD ERROR: a null CSCLayer* was seen" << std::endl;
+	edm::LogVerbatim("CSCBadChannels") << "WEIRD ERROR: a null CSCLayer* was seen" ;
       }
     }
 
-    std::cout << "No. of layers with bad strip channels = " << ibadlayers << std::endl;
-    std::cout << "No. of bad strip channels seen = " << ibadchannels << std::endl;
+    edm::LogVerbatim("CSCBadChannels") << "No. of layers with bad strip channels = " << ibadlayers ;
+    edm::LogVerbatim("CSCBadChannels") << "No. of bad strip channels seen = " << ibadchannels ;
 
-    std::cout << dashedLine_ << " end" << std::endl;
+    edm::LogVerbatim("CSCBadChannels") << dashedLine_ << " end" ;
   }
 
   DEFINE_FWK_MODULE(CSCRecoBadChannelsAnalyzer);

--- a/RecoLocalMuon/CSCRecHitD/src/CSCRecoConditions.h
+++ b/RecoLocalMuon/CSCRecHitD/src/CSCRecoConditions.h
@@ -72,11 +72,14 @@ class CSCRecoConditions
   /// returns gas-gain correction
   float gasGainCorrection( const CSCDetId& id, int strip, int wireGroup ) const;
 
+  /// fill bad strip & bad wiregroup bitsets from conditions data
+  void fillBadChannelWords( const CSCDetId& id );
+
   /// Is a neighbour bad?
-  bool nearBadStrip( const CSCDetId& id, int geomStrip ) const;
+  bool nearBadStrip( const CSCDetId& id, int geomStrip, int nstrips ) const;
 
   /// Is the strip bad?
-  bool badStrip( const CSCDetId& id, int geomStrip ) const;
+  bool badStrip( const CSCDetId& id, int geomStrip, int nstrips ) const;
 
   /// Get bad wiregroup word
   const std::bitset<112>& badWireWord( const CSCDetId& id ) const;

--- a/RecoLocalMuon/CSCRecHitD/test/run_on_raw_72x.py
+++ b/RecoLocalMuon/CSCRecHitD/test/run_on_raw_72x.py
@@ -1,0 +1,54 @@
+## Process  100  events in CSC rechit builder - Tim Cox - 06.10.2014
+## This version runs in 720pre6, 7, 73X IBs  on a real data RelVal RAW sample.
+
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.load("Configuration/StandardSequences/Geometry_cff")
+process.load("Configuration/StandardSequences/MagneticField_cff")
+process.load("Configuration/StandardSequences/FrontierConditions_GlobalTag_cff")
+process.load("Configuration/StandardSequences/RawToDigi_Data_cff")
+process.load("Configuration.StandardSequences.Reconstruction_cff")
+process.load("Configuration.StandardSequences.EndOfProcess_cff")
+
+# --- MATCH GT TO RELEASE AND DATA SAMPLE
+
+# This is OK for 72x real data
+process.GlobalTag.globaltag = "GR_R_71_V1::All"
+
+# --- NUMBER OF EVENTS --- 
+
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(100) )
+
+process.options   = cms.untracked.PSet( SkipEvent = cms.untracked.vstring("ProductNotFound") )
+process.options   = cms.untracked.PSet( wantSummary = cms.untracked.bool(True) )
+process.source    = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring(
+    "/store/relval/CMSSW_7_2_0_pre6/SingleMu/RAW/GR_H_V38A_RelVal_mu2012D-v1/00000/001E161E-6F3F-E411-BD55-0025905A60D0.root" )
+)
+
+# --- ACTIVATE LogTrace IN VARIOUS MODULES - NEED TO COMPILE *EACH MODULE* WITH 
+# scram b -j8 USER_CXXFLAGS="-DEDM_ML_DEBUG"
+# LogTrace output goes to cout; all other output to "junk.log"
+
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger.categories.append("CSCRecHit")
+
+# module label is something like "muonCSCDigis"...
+process.MessageLogger.debugModules = cms.untracked.vstring("*")
+process.MessageLogger.destinations = cms.untracked.vstring("cout","junk")
+process.MessageLogger.cout = cms.untracked.PSet(
+    threshold = cms.untracked.string("DEBUG"),
+    default   = cms.untracked.PSet( limit = cms.untracked.int32(0)  ),
+    FwkReport = cms.untracked.PSet( limit = cms.untracked.int32(-1) ),
+    CSCRecHit = cms.untracked.PSet( limit = cms.untracked.int32(-1) ) 
+)
+
+# Path and EndPath def
+process.unpack = cms.Path(process.muonCSCDigis)
+process.reco = cms.Path(process.csc2DRecHits)
+process.endjob = cms.EndPath(process.endOfProcess)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.unpack, process.reco, process.endjob)

--- a/RecoLocalMuon/CSCRecHitD/test/test_bad_channels.py
+++ b/RecoLocalMuon/CSCRecHitD/test/test_bad_channels.py
@@ -1,0 +1,43 @@
+## Run standalone CSCRecoBadChannelsAnalyzer - test bad strip channels - Tim Cox - 02.10.2014
+## This version runs in 720pre6 on a real data RelVal RAW sample.
+
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.load("Configuration/StandardSequences/Geometry_cff")
+process.load("Configuration/StandardSequences/MagneticField_cff")
+process.load("Configuration/StandardSequences/FrontierConditions_GlobalTag_cff")
+process.load("Configuration/StandardSequences/RawToDigi_Data_cff")
+process.load("Configuration.StandardSequences.Reconstruction_cff")
+process.load("Configuration.StandardSequences.EndOfProcess_cff")
+
+# --- MATCH GT TO RELEASE AND DATA SAMPLE
+
+# This is OK for 72x real data
+process.GlobalTag.globaltag = "GR_R_71_V1::All"
+
+# --- NUMBER OF EVENTS ---  JUST ONE!
+
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32( 1 ) )
+
+# --- MUST HAVE A DUMMY SOURCE
+
+process.source = cms.Source("EmptySource",
+ firstRun = cms.untracked.uint32(100001)
+)
+
+process.options   = cms.untracked.PSet( SkipEvent = cms.untracked.vstring("ProductNotFound") )
+process.options   = cms.untracked.PSet( wantSummary = cms.untracked.bool(True) )
+
+process.analyze = cms.EDAnalyzer("CSCRecoBadChannelsAnalyzer",
+    readBadChannels = cms.bool(True),
+    readBadChambers = cms.bool(False),
+    CSCUseTimingCorrections = cms.bool(False),
+    CSCUseGasGainCorrections = cms.bool(False)
+)
+
+process.printEventNumber = cms.OutputModule("AsciiOutputModule")
+
+process.p = cms.Path(process.analyze)
+process.ep = cms.EndPath(process.printEventNumber)

--- a/RecoLocalMuon/CSCRecHitD/test/test_bad_channels.py
+++ b/RecoLocalMuon/CSCRecHitD/test/test_bad_channels.py
@@ -1,5 +1,9 @@
-## Run standalone CSCRecoBadChannelsAnalyzer - test bad strip channels - Tim Cox - 02.10.2014
+## Run standalone CSCRecoBadChannelsAnalyzer - test bad strip channels - Tim Cox - 07.10.2014
 ## This version runs in 720pre6 on a real data RelVal RAW sample.
+
+## Output via MessageLogger - configured, after much flailing, so that
+## ONLY the LogVerbatim("CSCBadChannels") messages are sent to std:output.
+
 
 import FWCore.ParameterSet.Config as cms
 
@@ -11,6 +15,16 @@ process.load("Configuration/StandardSequences/FrontierConditions_GlobalTag_cff")
 process.load("Configuration/StandardSequences/RawToDigi_Data_cff")
 process.load("Configuration.StandardSequences.Reconstruction_cff")
 process.load("Configuration.StandardSequences.EndOfProcess_cff")
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+
+process.MessageLogger.categories.append("CSCBadChannels")
+process.MessageLogger.destinations = cms.untracked.vstring("cout")
+process.MessageLogger.cout = cms.untracked.PSet(
+    threshold = cms.untracked.string("INFO"),
+    default   = cms.untracked.PSet( limit = cms.untracked.int32(0)  ),
+    FwkReport = cms.untracked.PSet( limit = cms.untracked.int32(-1) ),
+    CSCBadChannels = cms.untracked.PSet( limit = cms.untracked.int32(-1) )
+)
 
 # --- MATCH GT TO RELEASE AND DATA SAMPLE
 


### PR DESCRIPTION
[Directed at  73X]. This updates CSC bad channel handling in local reco to allow extension to unganged ME11A channels. Amazingly tricky to do this because the extra channels are appended to the bad channels conditions data. At the same time I decided it was more sensible to change the way the bad channels data are handled. Until now, each time the conditions data changes, the bad channels information was unpacked and stored in a large vector - one 80-bit bitset for the 80 strip channels of each layer in the CSC system: there are 3240 layers in the system. There is also a 112-bitset for the possible bad wiregroups in each layer. However, with unganged ME11A instead of 80 strip channels, we'd have to increase to 64+48=112 bits for the bad strip channels too. So I've changed the approach so the bitsets for a given layer are filled only when that layer is being reconstructed. This saves on storage at the expense of computing time, which is basically trivial. This change is made in CSCConditions, a class in CalibMuon/CSCCalibration, which is our interface to CSC conditions data. There are NO changes to actual conditions data handling - just how the local reco accesses it once it is available. This is done in RecoLocalMuon/CSCRecHitD, where rechits are built. CSCConditions is also used in SimMuon/CSCDigitizer, but the bad channels part is NOT used there (since we don't know how to simulate bad channels even if we know somewhere in the complex change from detector element to read-out signal something is broken.) So there is NO change to Sim code. I added a new test analyzer for the bad channels handling in CSCRecHitD, called CSCRecoBadChannelsAnalyzer. This has a new config in CSCRecHitD/test. I also updated the sample config file for the rechit builder to 72X/73X level. This is run_on_raw_72X.py also in CSCRecHitD/test. I have run on 2500 events from a real data 2012 SingleMu raw relval sample and dumped all rechits built and find identical output for the new code and the old code. I have also run runTheMatrix.py -s --useInput all and this completes with no errors.
