### PR TITLE
EXO Val Dev backported to 72X

### DIFF
--- a/HLTriggerOffline/Exotica/interface/HLTExoticaSubAnalysis.h
+++ b/HLTriggerOffline/Exotica/interface/HLTExoticaSubAnalysis.h
@@ -24,6 +24,8 @@
 #include "DataFormats/Candidate/interface/LeafCandidate.h"
 #include "DataFormats/MuonReco/interface/Muon.h"
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
 #include "DataFormats/EgammaCandidates/interface/Photon.h"
@@ -34,6 +36,8 @@
 #include "DataFormats/TauReco/interface/PFTauFwd.h"
 #include "DataFormats/JetReco/interface/PFJet.h"
 #include "DataFormats/JetReco/interface/PFJetCollection.h"
+#include "DataFormats/JetReco/interface/CaloJet.h"
+#include "DataFormats/JetReco/interface/CaloJetCollection.h"
 #include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
 
@@ -138,16 +142,21 @@ private:
     /// gen/rec objects cuts
     std::map<unsigned int, std::string> _genCut;
     std::map<unsigned int, std::string> _recCut;
+    /// gen/rec pt-leading objects cuts
+    std::map<unsigned int, std::string> _genCut_leading;
+    std::map<unsigned int, std::string> _recCut_leading;
 
     /// The concrete String selectors (use the string cuts introduced
     /// via the config python)
     std::map<unsigned int, StringCutObjectSelector<reco::GenParticle> *> _genSelectorMap;
     StringCutObjectSelector<reco::Muon>        * _recMuonSelector;
+    StringCutObjectSelector<reco::Track>        * _recMuonTrkSelector;
     StringCutObjectSelector<reco::GsfElectron> * _recElecSelector;
     StringCutObjectSelector<reco::PFMET>       * _recPFMETSelector;
     StringCutObjectSelector<reco::PFTau>       * _recPFTauSelector;
     StringCutObjectSelector<reco::Photon>      * _recPhotonSelector;
-    StringCutObjectSelector<reco::PFJet>       * _recJetSelector;
+    StringCutObjectSelector<reco::PFJet>       * _recPFJetSelector;
+    StringCutObjectSelector<reco::CaloJet>     * _recCaloJetSelector;
 
     /// The plotters: managers of each hlt path where the plots are done
     std::vector<HLTExoticaPlotter> _plotters;

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaDiPhoton_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaDiPhoton_cff.py
@@ -1,11 +1,11 @@
 import FWCore.ParameterSet.Config as cms
 
-HighPtDielectronPSet = cms.PSet(
+DiPhotonPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
-        "HLT_DoubleEle33_CaloIdL_GsfTrkIdVL_MW_v", # Run2
-        "HLT_DoubleEle33_CaloIdL_GsfTrkIdVL_v"     # Run1 & Run2
+        "HLT_DoublePho85_v",    # Run2 proposal
+        "HLT_DoublePhoton70_v"  # Run1 (frozenHLT)
         ),
-    recElecLabel  = cms.InputTag("gedGsfElectrons"),
+    recPhotonLabel  = cms.InputTag("gedPhotons"),
     # -- Analysis specific cuts
     minCandidates = cms.uint32(2),
     # -- Analysis specific binnings

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaDisplacedDimuon_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaDisplacedDimuon_cff.py
@@ -1,0 +1,16 @@
+import FWCore.ParameterSet.Config as cms
+
+DisplacedDimuonPSet = cms.PSet(
+    hltPathsToCheck = cms.vstring(
+        "HLT_DoubleMu33NoFiltersNoVtx_v", # Run2
+        "HLT_DoubleMu38NoFiltersNoVtx_v"  # Run2
+        ),
+    recMuonLabel  = cms.InputTag("muons"),
+    # -- Analysis specific cuts
+    minCandidates = cms.uint32(2),
+    # -- Analysis specific binnings
+
+    parametersTurnOn = cms.vdouble( 0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50,
+                                    60, 70, 80, 100
+                                   ),
+    )

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaDisplacedEleMu_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaDisplacedEleMu_cff.py
@@ -1,9 +1,11 @@
 import FWCore.ParameterSet.Config as cms
 
-EleMuPSet = cms.PSet(
+DisplacedEleMuPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
-        "HLT_Mu17_Ele8_CaloIdT_CaloIsoVL_TrkIdVL_TrkIsoVL_v",
-        "HLT_Mu8_Ele17_CaloIdT_CaloIsoVL_TrkIdVL_TrkIsoVL_v"
+        "HLT_Mu38NoFiltersNoVtx_Photon38_CaloIdL_v", # Run2 Displaced muons
+        "HLT_Mu42NoFiltersNoVtx_Photon42_CaloIdL_v", # Run2 Displaced muons
+        "HLT_Mu17_Ele8_CaloIdT_CaloIsoVL_TrkIdVL_TrkIsoVL_v", # Run1
+        "HLT_Mu8_Ele17_CaloIdT_CaloIsoVL_TrkIdVL_TrkIsoVL_v"  # Run1
         ),
     recElecLabel  = cms.InputTag("gedGsfElectrons"),
     recMuonLabel  = cms.InputTag("muons"),

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaDisplacedL2Dimuon_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaDisplacedL2Dimuon_cff.py
@@ -1,0 +1,18 @@
+import FWCore.ParameterSet.Config as cms
+
+DisplacedL2DimuonPSet = cms.PSet(
+    hltPathsToCheck = cms.vstring(
+        "HLT_L2DoubleMu28_NoVertex_2Cha_Angle2p5_Mass10_v" # Run2 
+        ),
+    #recMuonLabel  = cms.InputTag("muons"),
+    recMuonTrkLabel  = cms.InputTag("refittedStandAloneMuons"),
+    # -- Analysis specific cuts
+    minCandidates = cms.uint32(2),
+    # -- Analysis specific binnings
+    #parametersTurnOn = cms.vdouble( 0, 50, 100, 150, 200, 250, 300, 400, 500, 600, 700, 800, 900, 1000,
+    #                                1100, 1200, 1500
+    #                               ),
+    parametersTurnOn = cms.vdouble( 0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50,
+                                    60, 70, 80, 100
+                                   ),
+    )

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaHT_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaHT_cff.py
@@ -2,7 +2,10 @@ import FWCore.ParameterSet.Config as cms
 
 HTPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
-        "HLT_PFNoPUHT350_v",
+        "HLT_PFNoPUHT750_4Jet_v", # Run2
+        "HLT_PFHT900_v",          # Run2
+        "HLT_HT900_v",            # Run2
+        "HLT_HT750_v"             # Run1 (frozenHLT)
         ),
     recPFMETLabel  = cms.InputTag("recoExoticaValidationHT"),
     # -- Analysis specific cuts

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaHighPtDimuon_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaHighPtDimuon_cff.py
@@ -2,9 +2,10 @@ import FWCore.ParameterSet.Config as cms
 
 HighPtDimuonPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
+        "HLT_Mu30_TkMu11_v" # Run2
         "HLT_Mu17_Mu8_v",   # Run2 & Run1
-        "HLT_Mu17_TkMu8_v", # Run2 & Run1
-        "HLT_Mu22_TkMu8_v" # Run1
+        "HLT_Mu17_TkMu8_v", # Run1
+        "HLT_Mu22_TkMu8_v"  # Run1
         ),
     recMuonLabel  = cms.InputTag("muons"),
     # -- Analysis specific cuts

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaHighPtElectron_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaHighPtElectron_cff.py
@@ -1,13 +1,13 @@
 import FWCore.ParameterSet.Config as cms
 
-HighPtDielectronPSet = cms.PSet(
+HighPtElectronPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
-        "HLT_DoubleEle33_CaloIdL_GsfTrkIdVL_MW_v", # Run2
-        "HLT_DoubleEle33_CaloIdL_GsfTrkIdVL_v"     # Run1 & Run2
+        "HLT_Ele95_CaloIdVT_GsfTrkIdT_v", # Run2 proposal
+        "HLT_Ele80_CaloIdVT_GsfTrkIdT_v", # Run1
         ),
     recElecLabel  = cms.InputTag("gedGsfElectrons"),
     # -- Analysis specific cuts
-    minCandidates = cms.uint32(2),
+    minCandidates = cms.uint32(1),
     # -- Analysis specific binnings
     parametersTurnOn = cms.vdouble( 0, 50, 100, 150, 200, 250, 300, 400, 500, 600, 700, 800, 900, 1000,
                                     1100, 1200, 1500

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaHighPtPhoton_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaHighPtPhoton_cff.py
@@ -1,13 +1,13 @@
 import FWCore.ParameterSet.Config as cms
 
-HighPtDielectronPSet = cms.PSet(
+HighPtPhotonPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
-        "HLT_DoubleEle33_CaloIdL_GsfTrkIdVL_MW_v", # Run2
-        "HLT_DoubleEle33_CaloIdL_GsfTrkIdVL_v"     # Run1 & Run2
+        "HLT_Photon155_v",  # Run2 proposal
+        "HLT_Photon135_v"  # Run1 (frozenHLT)
         ),
-    recElecLabel  = cms.InputTag("gedGsfElectrons"),
+    recPhotonLabel  = cms.InputTag("gedPhotons"),
     # -- Analysis specific cuts
-    minCandidates = cms.uint32(2),
+    minCandidates = cms.uint32(1),
     # -- Analysis specific binnings
     parametersTurnOn = cms.vdouble( 0, 50, 100, 150, 200, 250, 300, 400, 500, 600, 700, 800, 900, 1000,
                                     1100, 1200, 1500

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaJetNoBptx_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaJetNoBptx_cff.py
@@ -1,14 +1,14 @@
 import FWCore.ParameterSet.Config as cms
 
-MonojetPSet = cms.PSet(
+JetNoBptxPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
-        "HLT_PFJet260_v", # Run2
-        "HLT_MonoCentralPFJet80_PFMETnoMu105_NHEF0p95_v" # Run1
+        "HLT_JetE50_NoBPTX3BX_NoHalo_v" # Run2 proposal AND Run1 (frozenHLT)
         ),
-    recJetLabel    = cms.InputTag("ak5PFJetsCHS"),
-    recPFMETLabel  = cms.InputTag("pfMet"),
+    recCaloJetLabel    = cms.InputTag("ak5CaloJets"),
+
     # -- Analysis specific cuts
-    minCandidates = cms.uint32(2),
+    minCandidates = cms.uint32(1),
+
     # -- Analysis specific binnings
     parametersTurnOn = cms.vdouble( 0, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150,
                                     160, 170, 180, 190, 200,

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaLowPtDielectron_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaLowPtDielectron_cff.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-HighPtDielectronPSet = cms.PSet(
+LowPtDielectronPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
         "HLT_DoubleEle33_CaloIdL_GsfTrkIdVL_MW_v", # Run2
         "HLT_DoubleEle33_CaloIdL_GsfTrkIdVL_v"     # Run1 & Run2
@@ -9,7 +9,8 @@ HighPtDielectronPSet = cms.PSet(
     # -- Analysis specific cuts
     minCandidates = cms.uint32(2),
     # -- Analysis specific binnings
-    parametersTurnOn = cms.vdouble( 0, 50, 100, 150, 200, 250, 300, 400, 500, 600, 700, 800, 900, 1000,
-                                    1100, 1200, 1500
+
+    parametersTurnOn = cms.vdouble( 0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50,
+                                    60, 70, 80, 100
                                    ),
     )

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaLowPtDimuon_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaLowPtDimuon_cff.py
@@ -2,9 +2,10 @@ import FWCore.ParameterSet.Config as cms
 
 LowPtDimuonPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
+        "HLT_Mu30_TkMu11_v" # Run2
         "HLT_Mu17_Mu8_v",   # Run2 & Run1
-        "HLT_Mu17_TkMu8_v", # Run2 & Run1
-        "HLT_Mu22_TkMu8_v" # Run1
+        "HLT_Mu17_TkMu8_v", # Run1
+        "HLT_Mu22_TkMu8_v"  # Run1
         ),
     recMuonLabel  = cms.InputTag("muons"),
     # -- Analysis specific cuts

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaLowPtDimuon_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaLowPtDimuon_cff.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-HighPtDimuonPSet = cms.PSet(
+LowPtDimuonPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
         "HLT_Mu17_Mu8_v",   # Run2 & Run1
         "HLT_Mu17_TkMu8_v", # Run2 & Run1
@@ -10,7 +10,8 @@ HighPtDimuonPSet = cms.PSet(
     # -- Analysis specific cuts
     minCandidates = cms.uint32(2),
     # -- Analysis specific binnings
-    parametersTurnOn = cms.vdouble( 0, 50, 100, 150, 200, 250, 300, 400, 500, 600, 700, 800, 900, 1000,
-                                    1100, 1200, 1500
+
+    parametersTurnOn = cms.vdouble( 0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50,
+                                    60, 70, 80, 100
                                    ),
     )

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaLowPtElectron_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaLowPtElectron_cff.py
@@ -1,0 +1,17 @@
+import FWCore.ParameterSet.Config as cms
+
+LowPtElectronPSet = cms.PSet(
+    hltPathsToCheck = cms.vstring(
+        "HLT_Ele27_WP85_Gsf_v", # Run2 proposal
+        "HLT_Ele27_WP80_v"    # Run1 
+        ),
+    recElecLabel  = cms.InputTag("gedGsfElectrons"),
+    # -- Analysis specific cuts
+    minCandidates = cms.uint32(1),
+    # -- Analysis specific binnings
+    #parametersTurnOn = cms.vdouble( 0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50,
+    #                                60, 70, 80, 100, 120, 140, 160, 180, 200
+    parametersTurnOn = cms.vdouble( 0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50,
+                                    60, 70, 80, 100
+                                   ),
+    )

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaMuonNoBptx_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaMuonNoBptx_cff.py
@@ -1,0 +1,19 @@
+import FWCore.ParameterSet.Config as cms
+
+MuonNoBptxPSet = cms.PSet(
+    hltPathsToCheck = cms.vstring(
+        "HLT_L2Mu20_NoVertex_3Sta_NoBPTX3BX_NoHalo_v", # Run2 proposal
+        "HLT_L2Mu20_NoVertex_2Cha_NoBPTX3BX_NoHalo_v"  # Run1 frozenHLT
+        ),
+    #recMuonLabel  = cms.InputTag("muons"),
+    recMuonTrkLabel  = cms.InputTag("refittedStandAloneMuons"),
+    # -- Analysis specific cuts
+    minCandidates = cms.uint32(1),
+    # -- Analysis specific binnings
+    #parametersTurnOn = cms.vdouble( 0, 50, 100, 150, 200, 250, 300, 400, 500, 600, 700, 800, 900, 1000,
+    #                                1100, 1200, 1500
+    #                               ),
+    parametersTurnOn = cms.vdouble( 0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50,
+                                    60, 70, 80, 100
+                                   ),
+    )

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaPureMET_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaPureMET_cff.py
@@ -2,7 +2,8 @@ import FWCore.ParameterSet.Config as cms
 
 PureMETPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
-        "HLT_MET120_HBHENoiseCleaned_v",
+        "HLT_PFMET180_NoiseCleaned_v",    # Run2
+        "HLT_MET120_HBHENoiseCleaned_v" # Run1
         ),
     recPFMETLabel  = cms.InputTag("pfMet"),
     # -- Analysis specific cuts

--- a/HLTriggerOffline/Exotica/python/hltExoticaPostProcessors_cff.py
+++ b/HLTriggerOffline/Exotica/python/hltExoticaPostProcessors_cff.py
@@ -8,6 +8,8 @@ def efficiency_string(objtype,plot_type,triggerpath):
     #                (see EVTColContainer::getTypeString) 
     if objtype == "Mu" :
 	objtypeLatex="#mu"
+    elif objtype == "refittedStandAloneMuons": 
+	objtypeLatex="refittedStandAlone #mu"
     elif objtype == "Ele": 
 	objtypeLatex="e"
     elif objtype == "Photon": 
@@ -18,6 +20,10 @@ def efficiency_string(objtype,plot_type,triggerpath):
 	objtypeLatex="PFJet"
     elif objtype == "MET" :
 	objtypeLatex="MET"
+    elif objtype == "PFMET" :
+	objtypeLatex="PFMET"
+    elif objtype == "CaloJet" :
+	objtypeLatex="CaloJet"
     else:
 	objtypeLatex=objtype
 
@@ -65,7 +71,7 @@ def add_reco_strings(strings):
 plot_types = ["TurnOn1", "TurnOn2", "TurnOn3", "EffEta", "EffPhi"]
 #--- IMPORTANT: Update this collection whenever you introduce a new object
 #               in the code (from EVTColContainer::getTypeString)
-obj_types  = ["Mu","Ele","Photon","PFTau","PFJet","MET"]
+obj_types  = ["Mu","refittedStandAloneMuons","Ele","Photon","PFTau","PFJet","MET","PFMET","CaloJet"]
 #--- IMPORTANT: Trigger are extracted from the hltExoticaValidator_cfi.py module
 triggers = [ ] 
 efficiency_strings = []
@@ -83,9 +89,9 @@ print triggers
 
 # Generating the list with all the efficiencies
 for type in plot_types:
-    for obj in obj_types:
-	for trig in triggers:
-	    efficiency_strings.append(efficiency_string(obj,type,trig))
+	for obj in obj_types:
+		for trig in triggers:
+			efficiency_strings.append(efficiency_string(obj,type,trig))
 #for item in efficiency_strings:
 #    print item
 
@@ -100,10 +106,55 @@ hltExoticaPostHighPtDielectron = hltExoticaPostProcessor.clone()
 hltExoticaPostHighPtDielectron.subDirs = ['HLT/Exotica/HighPtDielectron']
 hltExoticaPostHighPtDielectron.efficiencyProfile = efficiency_strings
 
-hltExoticaPostEleMu = hltExoticaPostProcessor.clone()
-hltExoticaPostEleMu.subDirs = ['HLT/Exotica/EleMu']
-hltExoticaPostEleMu.efficiencyProfile = efficiency_strings
+hltExoticaPostHighPtElectron = hltExoticaPostProcessor.clone()
+hltExoticaPostHighPtElectron.subDirs = ['HLT/Exotica/HighPtElectron']
+hltExoticaPostHighPtElectron.efficiencyProfile = efficiency_strings
 
+hltExoticaPostLowPtElectron = hltExoticaPostProcessor.clone()
+hltExoticaPostLowPtElectron.subDirs = ['HLT/Exotica/LowPtElectron']
+hltExoticaPostLowPtElectron.efficiencyProfile = efficiency_strings
+
+hltExoticaPostLowPtDimuon = hltExoticaPostProcessor.clone()
+hltExoticaPostLowPtDimuon.subDirs = ['HLT/Exotica/LowPtDimuon']
+hltExoticaPostLowPtDimuon.efficiencyProfile = efficiency_strings
+
+hltExoticaPostLowPtDielectron = hltExoticaPostProcessor.clone()
+hltExoticaPostLowPtDielectron.subDirs = ['HLT/Exotica/LowPtDielectron']
+hltExoticaPostLowPtDielectron.efficiencyProfile = efficiency_strings
+
+hltExoticaPostHighPtPhoton = hltExoticaPostProcessor.clone()
+hltExoticaPostHighPtPhoton.subDirs = ['HLT/Exotica/HighPtPhoton']
+hltExoticaPostHighPtPhoton.efficiencyProfile = efficiency_strings
+
+hltExoticaPostDiPhoton = hltExoticaPostProcessor.clone()
+hltExoticaPostDiPhoton.subDirs = ['HLT/Exotica/DiPhoton']
+hltExoticaPostDiPhoton.efficiencyProfile = efficiency_strings
+
+hltExoticaPostHT = hltExoticaPostProcessor.clone()
+hltExoticaPostHT.subDirs = ['HLT/Exotica/HT']
+hltExoticaPostHT.efficiencyProfile = efficiency_strings
+
+hltExoticaPostJetNoBptx = hltExoticaPostProcessor.clone()
+hltExoticaPostJetNoBptx.subDirs = ['HLT/Exotica/JetNoBptx']
+hltExoticaPostJetNoBptx.efficiencyProfile = efficiency_strings
+
+hltExoticaPostMuonNoBptx = hltExoticaPostProcessor.clone()
+hltExoticaPostMuonNoBptx.subDirs = ['HLT/Exotica/MuonNoBptx']
+hltExoticaPostMuonNoBptx.efficiencyProfile = efficiency_strings
+
+hltExoticaPostDisplacedEleMu = hltExoticaPostProcessor.clone()
+hltExoticaPostDisplacedEleMu.subDirs = ['HLT/Exotica/DisplacedEleMu']
+hltExoticaPostDisplacedEleMu.efficiencyProfile = efficiency_strings
+
+hltExoticaPostDisplacedDimuon = hltExoticaPostProcessor.clone()
+hltExoticaPostDisplacedDimuon.subDirs = ['HLT/Exotica/DisplacedDimuon']
+hltExoticaPostDisplacedDimuon.efficiencyProfile = efficiency_strings
+
+hltExoticaPostDisplacedL2Dimuon = hltExoticaPostProcessor.clone()
+hltExoticaPostDisplacedL2Dimuon.subDirs = ['HLT/Exotica/DisplacedL2Dimuon']
+hltExoticaPostDisplacedL2Dimuon.efficiencyProfile = efficiency_strings
+
+# Not integrated yet
 hltExoticaPostMonojet = hltExoticaPostProcessor.clone()
 hltExoticaPostMonojet.subDirs = ['HLT/Exotica/Monojet']
 hltExoticaPostMonojet.efficiencyProfile = efficiency_strings
@@ -112,15 +163,28 @@ hltExoticaPostPureMET = hltExoticaPostProcessor.clone()
 hltExoticaPostPureMET.subDirs = ['HLT/Exotica/PureMET']
 hltExoticaPostPureMET.efficiencyProfile = efficiency_strings
 
-hltExoticaPostHT = hltExoticaPostProcessor.clone()
-hltExoticaPostHT.subDirs = ['HLT/Exotica/HT']
-hltExoticaPostHT.efficiencyProfile = efficiency_strings
-
 hltExoticaPostProcessors = cms.Sequence(
-		hltExoticaPostHighPtDimuon +
-		hltExoticaPostHighPtDielectron +
-		hltExoticaPostEleMu +
-		hltExoticaPostMonojet +
-		hltExoticaPostPureMET +
-		hltExoticaPostHT
-)
+    # Di-lepton paths
+    hltExoticaPostHighPtDimuon +
+    hltExoticaPostHighPtDielectron +
+    hltExoticaPostLowPtDimuon +
+    hltExoticaPostLowPtDielectron +
+    # Single Lepton paths
+    hltExoticaPostHighPtElectron +
+    hltExoticaPostLowPtElectron +
+    # Photon paths
+    hltExoticaPostHighPtPhoton +
+    hltExoticaPostDiPhoton +
+    # HT path
+    hltExoticaPostHT +
+    # NoBptx paths
+    hltExoticaPostJetNoBptx +
+    hltExoticaPostMuonNoBptx +
+    # Displaced paths
+    hltExoticaPostDisplacedEleMu +
+    hltExoticaPostDisplacedDimuon +
+    hltExoticaPostDisplacedL2Dimuon +
+    # Others (to be properly integrated)
+    hltExoticaPostMonojet +
+    hltExoticaPostPureMET
+    )

--- a/HLTriggerOffline/Exotica/python/hltExoticaValidator_cfi.py
+++ b/HLTriggerOffline/Exotica/python/hltExoticaValidator_cfi.py
@@ -13,27 +13,50 @@
 
 import FWCore.ParameterSet.Config as cms
 
-# The specific analyses to be loaded
-from HLTriggerOffline.Exotica.analyses.hltExoticaHighPtDimuon_cff import HighPtDimuonPSet
-from HLTriggerOffline.Exotica.analyses.hltExoticaHighPtDielectron_cff import HighPtDielectronPSet
-from HLTriggerOffline.Exotica.analyses.hltExoticaEleMu_cff import EleMuPSet
-from HLTriggerOffline.Exotica.analyses.hltExoticaPureMET_cff import PureMETPSet
-from HLTriggerOffline.Exotica.analyses.hltExoticaMonojet_cff import MonojetPSet
-from HLTriggerOffline.Exotica.analyses.hltExoticaHT_cff import HTPSet
+# Validation categories (sub-analyses)
+from HLTriggerOffline.Exotica.analyses.hltExoticaHighPtDimuon_cff      import HighPtDimuonPSet
+from HLTriggerOffline.Exotica.analyses.hltExoticaHighPtDielectron_cff  import HighPtDielectronPSet
+from HLTriggerOffline.Exotica.analyses.hltExoticaLowPtDimuon_cff       import LowPtDimuonPSet
+#from HLTriggerOffline.Exotica.analyses.hltExoticaLowPtDielectron_cff   import LowPtDielectronPSet
+from HLTriggerOffline.Exotica.analyses.hltExoticaHighPtElectron_cff    import HighPtElectronPSet
+from HLTriggerOffline.Exotica.analyses.hltExoticaLowPtElectron_cff     import LowPtElectronPSet
+from HLTriggerOffline.Exotica.analyses.hltExoticaHighPtPhoton_cff      import HighPtPhotonPSet
+from HLTriggerOffline.Exotica.analyses.hltExoticaDiPhoton_cff          import DiPhotonPSet
+from HLTriggerOffline.Exotica.analyses.hltExoticaHT_cff                import HTPSet
+from HLTriggerOffline.Exotica.analyses.hltExoticaJetNoBptx_cff         import JetNoBptxPSet
+from HLTriggerOffline.Exotica.analyses.hltExoticaMuonNoBptx_cff        import MuonNoBptxPSet
+from HLTriggerOffline.Exotica.analyses.hltExoticaDisplacedEleMu_cff    import DisplacedEleMuPSet
+from HLTriggerOffline.Exotica.analyses.hltExoticaDisplacedDimuon_cff   import DisplacedDimuonPSet
+from HLTriggerOffline.Exotica.analyses.hltExoticaDisplacedL2Dimuon_cff import DisplacedL2DimuonPSet
+from HLTriggerOffline.Exotica.analyses.hltExoticaPureMET_cff           import PureMETPSet
+from HLTriggerOffline.Exotica.analyses.hltExoticaMonojet_cff           import MonojetPSet
 
+hltExoticaValidator = cms.EDAnalyzer(
 
-hltExoticaValidator = cms.EDAnalyzer("HLTExoticaValidator",
+    "HLTExoticaValidator",
 		
     hltProcessName = cms.string("HLT"),
     
     # -- The name of the analysis. This is the name that
     # appears in Run summary/Exotica/ANALYSIS_NAME
+
     analysis       = cms.vstring("HighPtDimuon",
-                                 "HighPtDielectron"),
-#                                 "EleMu",
-#                                 "PureMET",
-#                                 "Monojet",
-#                                 "HT"),
+                                 "HighPtDielectron",
+                                 "LowPtDimuon",
+                                 #"LowPtDielectron",
+                                 "HighPtElectron",
+                                 "LowPtElectron",
+                                 "HighPtPhoton",
+                                 "DiPhoton",
+                                 "JetNoBptx",
+                                 "MuonNoBptx",
+                                 "HT",
+                                 "DisplacedEleMu",
+                                 "DisplacedDimuon",
+                                 "DisplacedL2Dimuon",
+                                 "PureMET",
+                                 "Monojet"
+                                 ),
     
     # -- The instance name of the reco::GenParticles collection
     genParticleLabel = cms.string("genParticles"),
@@ -54,38 +77,57 @@ hltExoticaValidator = cms.EDAnalyzer("HLTExoticaValidator",
 
     # Definition of generic cuts on generated and reconstructed objects (note that
     # these cuts can be overloaded inside a particular analysis)
-    # Objects recognized: Mu Ele Photon PFTau Jet MET
+    # Objects recognized: Mu Ele Photon PFTau Jet MET => recognized by the method EVTColContainer::getTypeString
     # Syntax in the strings: valid syntax of the StringCutObjectSelector class
+
     # --- Muons
     Mu_genCut     = cms.string("pt > 10 && abs(eta) < 2.4 && abs(pdgId) == 13 && status == 1"),
     Mu_recCut     = cms.string("pt > 10 && abs(eta) < 2.4 && isPFMuon && (isTrackerMuon || isGlobalMuon)"), # Loose Muon
     
+    # --- MuonTracks
+    #refittedStandAloneMuons_genCut  = cms.string("pt > 10 && abs(eta) < 2.4 && abs(pdgId) == 13 && status == 1"),
+    refittedStandAloneMuons_genCut  = cms.string("pt > 10 && abs(eta) < 2.4"),
+    #refittedStandAloneMuons_recCut  = cms.string("pt > 10 && abs(eta) < 2.4 && isPFMuon && (isTrackerMuon || isGlobalMuon)"), # Loose Muon
+    refittedStandAloneMuons_recCut  = cms.string("pt > 10 && abs(eta) < 2.4"), 
+
     # --- Electrons
-    Ele_genCut      = cms.string("pt > 10 && abs(eta) < 2.5 && abs(pdgId) == 11 && status == 1"),
-    Ele_recCut      = cms.string("pt > 10 && abs(eta) < 2.5 && hadronicOverEm < 0.05 &&"+\
-                                     "eSuperClusterOverP > 0.5 && eSuperClusterOverP < 2.5"), # Loose-like electron
+    Ele_genCut      = cms.string("pt > 10 && (abs(eta)<1.444 || abs(eta)>1.566) && abs(eta)<2.5 && abs(pdgId) == 11 && status==3 "),
+    Ele_recCut      = cms.string(
+        "pt > 10 && (abs(eta)<1.444 || abs(eta)>1.566) && abs(eta)< 2.5 "+
+        " && hadronicOverEm < 0.05 "+ #&& eSuperClusterOverP > 0.5 && eSuperClusterOverP < 1.5 "+
+        " && abs(deltaEtaSuperClusterTrackAtVtx)<0.007 &&  abs(deltaPhiSuperClusterTrackAtVtx)<0.06 "+
+        " && sigmaIetaIeta<0.03 "+
+        " && (pfIsolationVariables.sumChargedParticlePt + pfIsolationVariables.sumNeutralHadronEtHighThreshold + pfIsolationVariables.sumPhotonEtHighThreshold )/pt < 0.10 "+
+        " && abs(1/energy - 1/p)<0.05"),
+        #" && abs(trackPositionAtVtx.z-vertexPosition.z)<"),
+    #" && "), # Loose-like electron
 
     # --- Photons
     Photon_genCut     = cms.string("pt > 20 && abs(eta) < 2.4 && abs(pdgId) == 22 && status == 1"),
     Photon_recCut     = cms.string("pt > 20 && abs(eta) < 2.4"), # STILL MISSING THIS INFO
+    Photon_genCut_leading  = cms.string("pt > 150 "),
+    Photon_recCut_leading  = cms.string("pt > 150 "),
    
     # --- Taus: 
     PFTau_genCut      = cms.string("pt > 20 && abs(eta) < 2.4 && abs(pdgId) == 15 && status == 3"),
     PFTau_recCut      = cms.string("pt > 20 && abs(eta) < 2.4"),  # STILL MISSING THIS INFO
    
     # --- Jets: 
-    Jet_genCut      = cms.string("pt > 30 && abs(eta) < 2.4"),
-    Jet_recCut      = cms.string("pt > 30 && abs(eta) < 2.4 &&"+\
-                                     "(neutralHadronEnergy + HFHadronEnergy)/energy < 0.99 &&"+\
-                                     "neutralEmEnergyFraction < 0.99 &&"+\
-                                     "numberOfDaughters > 1 &&"+\
-                                     "chargedHadronEnergyFraction > 0 &&"+\
-                                     "chargedMultiplicity > 0 && "+\
+    PFJet_genCut      = cms.string("pt > 30 && abs(eta) < 2.4"),
+    PFJet_recCut      = cms.string("pt > 30 && abs(eta) < 2.4 &&"+
+                                     "(neutralHadronEnergy + HFHadronEnergy)/energy < 0.99 &&"+
+                                     "neutralEmEnergyFraction < 0.99 &&"+
+                                     "numberOfDaughters > 1 &&"+
+                                     "chargedHadronEnergyFraction > 0 &&"+
+                                     "chargedMultiplicity > 0 && "+
                                      "chargedEmEnergyFraction < 0.99"),  # Loose PFJet
+
+    CaloJet_genCut      = cms.string("pt > 30 && abs(eta) < 2.4"),
+    CaloJet_recCut      = cms.string("pt > 30 && abs(eta) < 2.4"), # find realistic cuts
    
     # --- MET (PF)    
-    MET_genCut      = cms.string("pt > 75"),
-    MET_recCut      = cms.string("pt > 75"),  
+    PFMET_genCut      = cms.string("pt > 75"),
+    PFMET_recCut      = cms.string("pt > 75"),  
    
     # The specific parameters per analysis: the name of the parameter set has to be 
     # the same as the defined ones in the 'analysis' datamember. Each analysis is a PSet
@@ -101,9 +143,20 @@ hltExoticaValidator = cms.EDAnalyzer("HLTExoticaValidator",
     # Besides the mandatory attributes, you can redefine the generation and reconstruction cuts
     # for any object you want.
     #    * Var_genCut, Var_recCut (cms.string): where Var=Mu, Ele, Photon, Jet, PFTau, MET (see above)
+
     HighPtDimuon     = HighPtDimuonPSet,
     HighPtDielectron = HighPtDielectronPSet,
-    EleMu            = EleMuPSet,
+    LowPtDimuon      = LowPtDimuonPSet,
+    #LowPtDielectron  = LowPtDielectronPSet,
+    HighPtElectron   = HighPtElectronPSet,
+    LowPtElectron    = LowPtElectronPSet,
+    HighPtPhoton     = HighPtPhotonPSet,                                 
+    DiPhoton         = DiPhotonPSet,                                 
+    JetNoBptx        = JetNoBptxPSet,
+    MuonNoBptx       = MuonNoBptxPSet,
+    DisplacedEleMu   = DisplacedEleMuPSet,
+    DisplacedDimuon  = DisplacedDimuonPSet,
+    DisplacedL2Dimuon = DisplacedL2DimuonPSet,
     PureMET          = PureMETPSet,                                 
     Monojet          = MonojetPSet,
     HT               = HTPSet

--- a/HLTriggerOffline/Exotica/src/EVTColContainer.cc
+++ b/HLTriggerOffline/Exotica/src/EVTColContainer.cc
@@ -21,6 +21,8 @@
 #include "DataFormats/METReco/interface/PFMETFwd.h"
 #include "DataFormats/JetReco/interface/PFJet.h"
 #include "DataFormats/JetReco/interface/PFJetCollection.h"
+#include "DataFormats/JetReco/interface/CaloJet.h"
+#include "DataFormats/JetReco/interface/CaloJetCollection.h"
 #include "DataFormats/TauReco/interface/PFTau.h"
 #include "DataFormats/TauReco/interface/PFTauFwd.h"
 #include "DataFormats/HepMCCandidate/interface/GenParticle.h"
@@ -35,10 +37,12 @@ struct EVTColContainer {
     enum {
         ELEC = 11,
         MUON = 13,
+        MUONTRACK = 130000, //RY
         PFTAU = 15,
         PHOTON = 22,
         PFMET = 39,
-        JET = 211,
+        PFJET = 211,
+        CALOJET = 111, //ND
         _nMAX
     };
 
@@ -46,22 +50,26 @@ struct EVTColContainer {
     int nInitialized;
     const reco::GenParticleCollection * genParticles;
     const std::vector<reco::Muon> * muons;
+    const std::vector<reco::Track> * muonTracks;
     const std::vector<reco::GsfElectron> * electrons;
     const std::vector<reco::Photon> * photons;
-    const std::vector<reco::PFMET> * pfMETs;
-    const std::vector<reco::PFTau> * pfTaus;
-    const std::vector<reco::PFJet> * jets;
+    const std::vector<reco::PFMET>  * pfMETs;
+    const std::vector<reco::PFTau>  * pfTaus;
+    const std::vector<reco::PFJet>  * pfJets;
+    const std::vector<reco::CaloJet>* caloJets;
     const edm::TriggerResults   * triggerResults ;
     EVTColContainer():
         nOfCollections(6),
         nInitialized(0),
         genParticles(0),
         muons(0),
+        muonTracks(0),
         electrons(0),
         photons(0),
         pfMETs(0),
         pfTaus(0),
-        jets(0),
+        pfJets(0),
+        caloJets(0),
         triggerResults(0)
     {
     }
@@ -82,11 +90,13 @@ struct EVTColContainer {
         nInitialized = 0;
         genParticles = 0;
         muons = 0;
+        muonTracks = 0;
         electrons = 0;
         photons = 0;
         pfMETs = 0;
         pfTaus = 0;
-        jets = 0;
+        pfJets = 0;
+        caloJets = 0;
         triggerResults = 0;
     }
 
@@ -94,6 +104,11 @@ struct EVTColContainer {
     void set(const reco::MuonCollection * v)
     {
 	muons = v;
+        ++nInitialized;
+    }
+    void set(const reco::TrackCollection * v)
+    {
+	muonTracks = v;
         ++nInitialized;
     }
     void set(const reco::GsfElectronCollection * v)
@@ -118,7 +133,12 @@ struct EVTColContainer {
     }
     void set(const reco::PFJetCollection * v)
     {
-        jets = v;
+        pfJets = v;
+        ++nInitialized;
+    }
+    void set(const reco::CaloJetCollection * v)
+    {
+        caloJets = v;
         ++nInitialized;
     }
 
@@ -128,6 +148,8 @@ struct EVTColContainer {
         unsigned int size = 0;
         if (objtype == EVTColContainer::MUON && muons != 0) {
             size = muons->size();
+        } else if (objtype == EVTColContainer::MUONTRACK && muonTracks != 0) {
+            size = muonTracks->size();
         } else if (objtype == EVTColContainer::ELEC && electrons != 0) {
             size = electrons->size();
         } else if (objtype == EVTColContainer::PHOTON && photons != 0) {
@@ -136,8 +158,10 @@ struct EVTColContainer {
             size = pfMETs->size();
         } else if (objtype == EVTColContainer::PFTAU && pfTaus != 0) {
             size = pfTaus->size();
-        } else if (objtype == EVTColContainer::JET && jets != 0) {
-            size = jets->size();
+        } else if (objtype == EVTColContainer::PFJET && pfJets != 0) {
+            size = pfJets->size();
+        } else if (objtype == EVTColContainer::CALOJET && caloJets != 0) {
+            size = caloJets->size();
         }
 
         return size;
@@ -150,16 +174,20 @@ struct EVTColContainer {
 
         if (objtype == EVTColContainer::MUON) {
             objTypestr = "Mu";
+        } else if (objtype == EVTColContainer::MUONTRACK) {
+            objTypestr = "refittedStandAloneMuons";
         } else if (objtype == EVTColContainer::ELEC) {
             objTypestr = "Ele";
         } else if (objtype == EVTColContainer::PHOTON) {
             objTypestr = "Photon";
         } else if (objtype == EVTColContainer::PFMET) {
-            objTypestr = "MET";
+            objTypestr = "PFMET";
         } else if (objtype == EVTColContainer::PFTAU) {
             objTypestr = "PFTau";
-        } else if (objtype == EVTColContainer::JET) {
-            objTypestr = "Jet";
+        } else if (objtype == EVTColContainer::PFJET) {
+            objTypestr = "PFJet";
+        } else if (objtype == EVTColContainer::CALOJET) {
+            objTypestr = "CaloJet";
         } else {
             edm::LogError("ExoticaValidations") << "EVTColContainer::getTypeString, "
                                                 << "NOT Implemented error (object type id='" << objtype << "')" << std::endl;;

--- a/HLTriggerOffline/Exotica/src/HLTExoticaSubAnalysis.cc
+++ b/HLTriggerOffline/Exotica/src/HLTExoticaSubAnalysis.cc
@@ -423,14 +423,14 @@ void HLTExoticaSubAnalysis::analyze(const edm::Event & iEvent, const edm::EventS
 	// |  0   |  1  | --> 1 muon used
 	// |  1   |  2  | --> 2 electrons used  
 	// Initializing the count of the used objects.
-	std::map<unsigned int, int> * countobjects = new std::map<unsigned int, int>;
+	std::map<unsigned int, int> countobjects;
 	for (std::map<unsigned int, edm::InputTag>::iterator co = _recLabels.begin();
 	     co != _recLabels.end(); ++co) {
-	    countobjects->insert(std::pair<unsigned int, int>(co->first, 0));
+	    countobjects.insert(std::pair<unsigned int, int>(co->first, 0));
 	}
     
 	int counttotal = 0;
-	int totalobjectssize2 = 2 * countobjects->size();
+	int totalobjectssize2 = 2 * countobjects.size();
     
 	for (size_t j = 0; j != matchesGen.size(); ++j) {
 	    const unsigned int objType = matchesGen[j].pdgId();
@@ -439,7 +439,7 @@ void HLTExoticaSubAnalysis::analyze(const edm::Event & iEvent, const edm::EventS
 	
 	    float pt  = matchesGen[j].pt();
 
-	    if ((*countobjects)[objType] == 0) {
+	    if (countobjects[objType] == 0) {
 
                 // Cut for the pt-leading object 
                 StringCutObjectSelector<reco::LeafCandidate> select( _genCut_leading[objType] );
@@ -447,12 +447,12 @@ void HLTExoticaSubAnalysis::analyze(const edm::Event & iEvent, const edm::EventS
 
 		this->fillHist("gen", objTypeStr, "MaxPt1", pt);
 		// Filled the high pt ...
-		++((*countobjects)[objType]);
+		++countobjects[objType];
 		++counttotal;
-	    } else if ((*countobjects)[objType] == 1) {
+	    } else if (countobjects[objType] == 1) {
 		this->fillHist("gen", objTypeStr, "MaxPt2", pt);
 		// Filled the second high pt ...
-		++((*countobjects)[objType]);
+		++countobjects[objType];
 		++counttotal;
 	    } else {
 		// Already the minimum two objects has been filled, get out...
@@ -470,9 +470,6 @@ void HLTExoticaSubAnalysis::analyze(const edm::Event & iEvent, const edm::EventS
 	    this->fillHist("gen", objTypeStr, "SumEt", sumEt);
 
 	} // Closes loop in gen
-
-	LogDebug("ExoticaValidation") << "                        deleting countobjects";
-	//delete countobjects;
 
 	// Calling to the plotters analysis (where the evaluation of the different trigger paths are done)
 	//const std::string source = "gen";
@@ -502,14 +499,14 @@ void HLTExoticaSubAnalysis::analyze(const edm::Event & iEvent, const edm::EventS
 	// |  0   |  1  | --> 1 muon used
 	// |  1   |  2  | --> 2 electrons used  
 	// Initializing the count of the used objects.
-	std::map<unsigned int, int> * countobjects = new std::map<unsigned int, int>;
+	std::map<unsigned int, int> countobjects;
 	for (std::map<unsigned int, edm::InputTag>::iterator co = _recLabels.begin();
 	     co != _recLabels.end(); ++co) {
-	    countobjects->insert(std::pair<unsigned int, int>(co->first, 0));
+	    countobjects.insert(std::pair<unsigned int, int>(co->first, 0));
 	}
     
 	int counttotal = 0;
-	int totalobjectssize2 = 2 * countobjects->size();
+	int totalobjectssize2 = 2 * countobjects.size();
     
 	/// Debugging.
 	//std::cout << "Our RECO vector has matchesReco.size() = " << matchesReco.size() << std::endl;
@@ -521,7 +518,7 @@ void HLTExoticaSubAnalysis::analyze(const edm::Event & iEvent, const edm::EventS
 	    
 	    float pt  = matchesReco[j].pt();
 
-	    if ((*countobjects)[objType] == 0) {
+	    if (countobjects[objType] == 0) {
 
                 // Cut for the pt-leading object 
                 StringCutObjectSelector<reco::LeafCandidate> select( _recCut_leading[objType] );
@@ -529,12 +526,12 @@ void HLTExoticaSubAnalysis::analyze(const edm::Event & iEvent, const edm::EventS
 
 		this->fillHist("rec", objTypeStr, "MaxPt1", pt);
 		// Filled the high pt ...
-		++((*countobjects)[objType]);
+		++countobjects[objType];
 		++counttotal;
-	    } else if ((*countobjects)[objType] == 1) {
+	    } else if (countobjects[objType] == 1) {
 		this->fillHist("rec", objTypeStr, "MaxPt2", pt);
 		// Filled the second high pt ...
-		++((*countobjects)[objType]);
+		++countobjects[objType];
 		++counttotal;
 	    } else {
 		// Already the minimum two objects has been filled, get out...
@@ -552,9 +549,6 @@ void HLTExoticaSubAnalysis::analyze(const edm::Event & iEvent, const edm::EventS
 	    this->fillHist("rec", objTypeStr, "SumEt", sumEt);
 	} // Closes loop in reco
 
-	LogDebug("ExoticaValidation") << "                        deleting countobjects";
-	//delete countobjects;
-	
 	// Calling to the plotters analysis (where the evaluation of the different trigger paths are done)
 	//const std::string source = "reco";
 	for (std::vector<HLTExoticaPlotter>::iterator an = _plotters.begin(); an != _plotters.end(); ++an) {

--- a/HLTriggerOffline/Exotica/src/HLTExoticaSubAnalysis.cc
+++ b/HLTriggerOffline/Exotica/src/HLTExoticaSubAnalysis.cc
@@ -22,6 +22,8 @@
 #include <set>
 #include <algorithm>
 
+int verbose=0;
+
 /// Constructor
 HLTExoticaSubAnalysis::HLTExoticaSubAnalysis(const edm::ParameterSet & pset,
                                              const std::string & analysisname,
@@ -36,11 +38,13 @@ HLTExoticaSubAnalysis::HLTExoticaSubAnalysis(const edm::ParameterSet & pset,
     _parametersPhi(pset.getParameter<std::vector<double> >("parametersPhi")),
     _parametersTurnOn(pset.getParameter<std::vector<double> >("parametersTurnOn")),
     _recMuonSelector(0),
+    _recMuonTrkSelector(0),
     _recElecSelector(0),
     _recPFMETSelector(0),
     _recPFTauSelector(0),
     _recPhotonSelector(0),
-    _recJetSelector(0)
+    _recPFJetSelector(0),
+    _recCaloJetSelector(0)
 {
 
     LogDebug("ExoticaValidation") << "In HLTExoticaSubAnalysis::constructor()";
@@ -79,6 +83,12 @@ HLTExoticaSubAnalysis::HLTExoticaSubAnalysis(const edm::ParameterSet & pset,
 	const std::string objStr = EVTColContainer::getTypeString(it->first);
         _genCut[it->first] = pset.getParameter<std::string>(std::string(objStr + "_genCut").c_str());
         _recCut[it->first] = pset.getParameter<std::string>(std::string(objStr + "_recCut").c_str());
+        if (pset.exists(std::string(objStr + "_genCut_leading"))) {
+          _genCut_leading[it->first] = pset.getParameter<std::string>(std::string(objStr + "_genCut_leading").c_str());
+        }
+        if (pset.exists(std::string(objStr + "_recCut_leading"))) {
+          _recCut_leading[it->first] = pset.getParameter<std::string>(std::string(objStr + "_recCut_leading").c_str());
+        }
     }
 
     //--- Updating parameters if has to be modified for this particular specific analysis
@@ -112,6 +122,8 @@ HLTExoticaSubAnalysis::~HLTExoticaSubAnalysis()
     }
     delete _recMuonSelector;
     _recMuonSelector = 0;
+    delete _recMuonTrkSelector;
+    _recMuonTrkSelector = 0;
     delete _recElecSelector;
     _recElecSelector = 0;
     delete _recPhotonSelector;
@@ -120,8 +132,10 @@ HLTExoticaSubAnalysis::~HLTExoticaSubAnalysis()
     _recPFMETSelector = 0;
     delete _recPFTauSelector;
     _recPFTauSelector = 0;
-    delete _recJetSelector;
-    _recJetSelector = 0;
+    delete _recPFJetSelector;
+    _recPFJetSelector = 0;
+    delete _recCaloJetSelector;
+    _recCaloJetSelector = 0;
 }
 
 
@@ -202,10 +216,12 @@ void HLTExoticaSubAnalysis::beginRun(const edm::Run & iRun, const edm::EventSetu
                 _hltPaths.insert(thetriggername);
                 found = true;
             }
+	    if(verbose>2 && i==0) 
+	      std::cout << "--- TRIGGER PATH : " << thetriggername << std::endl;
         }
 	
 	// Oh dear, the path we wanted seems to not be available
-        if (! found) {
+        if (! found && verbose>2) {
             edm::LogWarning("ExoticaValidation") << "HLTExoticaSubAnalysis::constructor(): In "
                                                  << _analysisname << " subfolder NOT found the path: '"
                                                  << _hltPathsToCheck[i] << "*'" ;
@@ -375,6 +391,7 @@ void HLTExoticaSubAnalysis::analyze(const edm::Event & iEvent, const edm::EventS
 	      matchesReco.end(), 
 	      comparator);
 
+
     // --- All the objects are in place
     //std::cout << "DEBUG(0)" << std::endl;
 
@@ -396,7 +413,6 @@ void HLTExoticaSubAnalysis::analyze(const edm::Event & iEvent, const edm::EventS
     //////////////// 
     {
 	if(matchesGen.size() < _minCandidates) return; // FIXME: A bug is potentially here: what about the mixed channels?
-
 	// Okay, there are enough candidates. Move on!
     
 	// Filling the gen/reco objects (eff-denominators):
@@ -422,15 +438,13 @@ void HLTExoticaSubAnalysis::analyze(const edm::Event & iEvent, const edm::EventS
 	    const std::string objTypeStr = EVTColContainer::getTypeString(objType);
 	
 	    float pt  = matchesGen[j].pt();
-	    float eta = matchesGen[j].eta();
-	    float phi = matchesGen[j].phi();
-	    float sumEt = 0;//matchesGen[j].sumEt;
-	
-	    this->fillHist("gen", objTypeStr, "Eta", eta);
-	    this->fillHist("gen", objTypeStr, "Phi", phi);
-	    this->fillHist("gen", objTypeStr, "SumEt", sumEt);
 
 	    if ((*countobjects)[objType] == 0) {
+
+                // Cut for the pt-leading object 
+                StringCutObjectSelector<reco::LeafCandidate> select( _genCut_leading[objType] );
+                if ( !select( matchesGen[j] ) ) break;
+
 		this->fillHist("gen", objTypeStr, "MaxPt1", pt);
 		// Filled the high pt ...
 		++((*countobjects)[objType]);
@@ -446,6 +460,15 @@ void HLTExoticaSubAnalysis::analyze(const edm::Event & iEvent, const edm::EventS
 		    break;
 		}
 	    }
+
+	    float eta = matchesGen[j].eta();
+	    float phi = matchesGen[j].phi();
+	    float sumEt = 0;//matchesGen[j].sumEt;
+	
+	    this->fillHist("gen", objTypeStr, "Eta", eta);
+	    this->fillHist("gen", objTypeStr, "Phi", phi);
+	    this->fillHist("gen", objTypeStr, "SumEt", sumEt);
+
 	} // Closes loop in gen
 
 	LogDebug("ExoticaValidation") << "                        deleting countobjects";
@@ -497,15 +520,13 @@ void HLTExoticaSubAnalysis::analyze(const edm::Event & iEvent, const edm::EventS
 	    const std::string objTypeStr = EVTColContainer::getTypeString(objType);
 	    
 	    float pt  = matchesReco[j].pt();
-	    float eta = matchesReco[j].eta();
-	    float phi = matchesReco[j].phi();
-	    float sumEt = 0;//matchesReco[j].sumEt;
-	
-	    this->fillHist("rec", objTypeStr, "Eta", eta);
-	    this->fillHist("rec", objTypeStr, "Phi", phi);
-	    this->fillHist("rec", objTypeStr, "SumEt", sumEt);
 
 	    if ((*countobjects)[objType] == 0) {
+
+                // Cut for the pt-leading object 
+                StringCutObjectSelector<reco::LeafCandidate> select( _recCut_leading[objType] );
+                if ( !select( matchesReco[j] ) ) break;
+
 		this->fillHist("rec", objTypeStr, "MaxPt1", pt);
 		// Filled the high pt ...
 		++((*countobjects)[objType]);
@@ -521,6 +542,14 @@ void HLTExoticaSubAnalysis::analyze(const edm::Event & iEvent, const edm::EventS
 		    break;
 		}
 	    }
+
+	    float eta = matchesReco[j].eta();
+	    float phi = matchesReco[j].phi();
+	    float sumEt = 0;//matchesReco[j].sumEt;
+	
+	    this->fillHist("rec", objTypeStr, "Eta", eta);
+	    this->fillHist("rec", objTypeStr, "Phi", phi);
+	    this->fillHist("rec", objTypeStr, "SumEt", sumEt);
 	} // Closes loop in reco
 
 	LogDebug("ExoticaValidation") << "                        deleting countobjects";
@@ -545,14 +574,16 @@ const std::vector<unsigned int> HLTExoticaSubAnalysis::getObjectsType(const std:
 {
     LogDebug("ExoticaValidation") << "In HLTExoticaSubAnalysis::getObjectsType()";
 
-    static const unsigned int objSize = 6;
+    static const unsigned int objSize = 7;
     static const unsigned int objtriggernames[] = {
         EVTColContainer::MUON,
+        EVTColContainer::MUONTRACK,
         EVTColContainer::ELEC,
         EVTColContainer::PHOTON,
         EVTColContainer::PFMET,
         EVTColContainer::PFTAU,
-        EVTColContainer::JET
+        EVTColContainer::PFJET,
+        EVTColContainer::CALOJET
     };
 
     std::set<unsigned int> objsType;
@@ -580,6 +611,10 @@ void HLTExoticaSubAnalysis::getNamesOfObjects(const edm::ParameterSet & anpset)
         _recLabels[EVTColContainer::MUON] = anpset.getParameter<edm::InputTag>("recMuonLabel");
         _genSelectorMap[EVTColContainer::MUON] = 0 ;
     }
+    if (anpset.exists("recMuonTrkLabel")) {
+        _recLabels[EVTColContainer::MUONTRACK] = anpset.getParameter<edm::InputTag>("recMuonTrkLabel");
+        _genSelectorMap[EVTColContainer::MUONTRACK] = 0 ;
+    }
     if (anpset.exists("recElecLabel")) {
         _recLabels[EVTColContainer::ELEC] = anpset.getParameter<edm::InputTag>("recElecLabel");
         _genSelectorMap[EVTColContainer::ELEC] = 0 ;
@@ -596,9 +631,13 @@ void HLTExoticaSubAnalysis::getNamesOfObjects(const edm::ParameterSet & anpset)
         _recLabels[EVTColContainer::PFTAU] = anpset.getParameter<edm::InputTag>("recPFTauLabel");
         _genSelectorMap[EVTColContainer::PFTAU] = 0 ;
     }
-    if (anpset.exists("recJetLabel")) {
-        _recLabels[EVTColContainer::JET] = anpset.getParameter<edm::InputTag>("recJetLabel");
-        _genSelectorMap[EVTColContainer::JET] = 0 ;
+    if (anpset.exists("recPFJetLabel")) {
+        _recLabels[EVTColContainer::PFJET] = anpset.getParameter<edm::InputTag>("recPFJetLabel");
+        _genSelectorMap[EVTColContainer::PFJET] = 0 ;
+    }
+    if (anpset.exists("recCaloJetLabel")) {
+        _recLabels[EVTColContainer::CALOJET] = anpset.getParameter<edm::InputTag>("recCaloJetLabel");
+        _genSelectorMap[EVTColContainer::CALOJET] = 0 ;
     }
 
     if (_recLabels.size() < 1) {
@@ -630,6 +669,11 @@ void HLTExoticaSubAnalysis::registerConsumes(edm::ConsumesCollector & iC)
 	    edm::EDGetToken token(particularToken);
 	    _tokens[it->first] = token;
 	} 
+	else if (it->first == EVTColContainer::MUONTRACK) {
+	    edm::EDGetTokenT<reco::TrackCollection> particularToken = iC.consumes<reco::TrackCollection>(it->second);
+	    edm::EDGetToken token(particularToken);
+	    _tokens[it->first] = token;
+        }
 	else if (it->first == EVTColContainer::ELEC) {
             edm::EDGetTokenT<reco::GsfElectronCollection> particularToken = iC.consumes<reco::GsfElectronCollection>(it->second);
 	    edm::EDGetToken token(particularToken);
@@ -650,8 +694,13 @@ void HLTExoticaSubAnalysis::registerConsumes(edm::ConsumesCollector & iC)
 	    edm::EDGetToken token(particularToken);
 	    _tokens[it->first] = token;
 	} 
-	else if (it->first == EVTColContainer::JET) {
+	else if (it->first == EVTColContainer::PFJET) {
             edm::EDGetTokenT<reco::PFJetCollection> particularToken = iC.consumes<reco::PFJetCollection>(it->second);
+	    edm::EDGetToken token(particularToken);
+	    _tokens[it->first] = token;
+	} 
+	else if (it->first == EVTColContainer::CALOJET) {
+            edm::EDGetTokenT<reco::CaloJetCollection> particularToken = iC.consumes<reco::CaloJetCollection>(it->second);
 	    edm::EDGetToken token(particularToken);
 	    _tokens[it->first] = token;
 	} 
@@ -695,6 +744,11 @@ void HLTExoticaSubAnalysis::getHandlesToObjects(const edm::Event & iEvent, EVTCo
             iEvent.getByToken(it->second, theHandle);
             col->set(theHandle.product());
         } 
+	else if (it->first == EVTColContainer::MUONTRACK) {
+            edm::Handle<reco::TrackCollection> theHandle;
+            iEvent.getByToken(it->second, theHandle);
+            col->set(theHandle.product());
+        }
 	else if (it->first == EVTColContainer::ELEC) {
             edm::Handle<reco::GsfElectronCollection> theHandle;
             iEvent.getByToken(it->second, theHandle);
@@ -715,8 +769,13 @@ void HLTExoticaSubAnalysis::getHandlesToObjects(const edm::Event & iEvent, EVTCo
             iEvent.getByToken(it->second, theHandle);
             col->set(theHandle.product());
         } 
-	else if (it->first == EVTColContainer::JET) {
+	else if (it->first == EVTColContainer::PFJET) {
             edm::Handle<reco::PFJetCollection> theHandle;
+            iEvent.getByToken(it->second, theHandle);
+            col->set(theHandle.product());
+        }
+	else if (it->first == EVTColContainer::CALOJET) {
+            edm::Handle<reco::CaloJetCollection> theHandle;
             iEvent.getByToken(it->second, theHandle);
             col->set(theHandle.product());
         }
@@ -800,6 +859,8 @@ void HLTExoticaSubAnalysis::initSelector(const unsigned int & objtype)
 
     if (objtype == EVTColContainer::MUON && _recMuonSelector == 0) {
         _recMuonSelector = new StringCutObjectSelector<reco::Muon>(_recCut[objtype]);
+    } else if (objtype == EVTColContainer::MUONTRACK && _recMuonTrkSelector == 0) {
+        _recMuonTrkSelector = new StringCutObjectSelector<reco::Track>(_recCut[objtype]);
     } else if (objtype == EVTColContainer::ELEC && _recElecSelector == 0) {
         _recElecSelector = new StringCutObjectSelector<reco::GsfElectron>(_recCut[objtype]);
     } else if (objtype == EVTColContainer::PHOTON && _recPhotonSelector == 0) {
@@ -808,8 +869,10 @@ void HLTExoticaSubAnalysis::initSelector(const unsigned int & objtype)
         _recPFMETSelector = new StringCutObjectSelector<reco::PFMET>(_recCut[objtype]);
     } else if (objtype == EVTColContainer::PFTAU && _recPFTauSelector == 0) {
         _recPFTauSelector = new StringCutObjectSelector<reco::PFTau>(_recCut[objtype]);
-    } else if (objtype == EVTColContainer::JET && _recJetSelector == 0) {
-        _recJetSelector = new StringCutObjectSelector<reco::PFJet>(_recCut[objtype]);
+    } else if (objtype == EVTColContainer::PFJET && _recPFJetSelector == 0) {
+        _recPFJetSelector = new StringCutObjectSelector<reco::PFJet>(_recCut[objtype]);
+    } else if (objtype == EVTColContainer::CALOJET && _recCaloJetSelector == 0) {
+        _recCaloJetSelector = new StringCutObjectSelector<reco::CaloJet>(_recCut[objtype]);
     }
     /* else
     {
@@ -830,6 +893,17 @@ void HLTExoticaSubAnalysis::insertCandidates(const unsigned int & objType, const
 		reco::LeafCandidate m(0, cols->muons->at(i).p4(), cols->muons->at(i).vertex(), objType, 0, true);
 		matches->push_back(m);
 	    }
+        }
+    } else if (objType == EVTColContainer::MUONTRACK) {
+        for (size_t i = 0; i < cols->muonTracks->size(); i++) {
+	    LogDebug("ExoticaValidation") << "Inserting muonTrack " << i ;
+	    if (_recMuonTrkSelector->operator()(cols->muonTracks->at(i))) {
+		ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double>> mom4;
+                ROOT::Math::XYZVector mom3 = cols->muonTracks->at(i).innerMomentum();
+                mom4.SetXYZT(mom3.x(),mom3.y(),mom3.z(),mom3.r());
+		reco::LeafCandidate m(0, mom4, cols->muons->at(i).vertex(), objType, 0, true);
+		matches->push_back(m);
+            }
         }
     } else if (objType == EVTColContainer::ELEC) {
         for (size_t i = 0; i < cols->electrons->size(); i++) {
@@ -866,11 +940,19 @@ void HLTExoticaSubAnalysis::insertCandidates(const unsigned int & objType, const
 		matches->push_back(m);
 	    }
         }
-    } else if (objType == EVTColContainer::JET) {
-        for (size_t i = 0; i < cols->jets->size(); i++) {
+    } else if (objType == EVTColContainer::PFJET) {
+        for (size_t i = 0; i < cols->pfJets->size(); i++) {
 	    LogDebug("ExoticaValidation") << "Inserting jet " << i ;
-            if (_recJetSelector->operator()(cols->jets->at(i))) {
-		reco::LeafCandidate m(0, cols->jets->at(i).p4(), cols->jets->at(i).vertex(), objType, 0, true);
+            if (_recPFJetSelector->operator()(cols->pfJets->at(i))) {
+		reco::LeafCandidate m(0, cols->pfJets->at(i).p4(), cols->pfJets->at(i).vertex(), objType, 0, true);
+		matches->push_back(m);
+            }
+        }
+    } else if (objType == EVTColContainer::CALOJET) {
+        for (size_t i = 0; i < cols->caloJets->size(); i++) {
+	    LogDebug("ExoticaValidation") << "Inserting jet " << i ;
+            if (_recCaloJetSelector->operator()(cols->caloJets->at(i))) {
+		reco::LeafCandidate m(0, cols->caloJets->at(i).p4(), cols->caloJets->at(i).vertex(), objType, 0, true);
 		matches->push_back(m);
             }
         }

--- a/HLTriggerOffline/Exotica/src/HLTExoticaSubAnalysis.cc
+++ b/HLTriggerOffline/Exotica/src/HLTExoticaSubAnalysis.cc
@@ -901,7 +901,7 @@ void HLTExoticaSubAnalysis::insertCandidates(const unsigned int & objType, const
 		ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double>> mom4;
                 ROOT::Math::XYZVector mom3 = cols->muonTracks->at(i).innerMomentum();
                 mom4.SetXYZT(mom3.x(),mom3.y(),mom3.z(),mom3.r());
-		reco::LeafCandidate m(0, mom4, cols->muons->at(i).vertex(), objType, 0, true);
+		reco::LeafCandidate m(0, mom4, cols->muonTracks->at(i).vertex(), objType, 0, true);
 		matches->push_back(m);
             }
         }

--- a/HLTriggerOffline/Exotica/test/hltExoticaPostProcessor_cfg.py
+++ b/HLTriggerOffline/Exotica/test/hltExoticaPostProcessor_cfg.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+import os,sys
 
 process = cms.Process("EDMtoMEConvert")
 
@@ -10,13 +11,24 @@ process.load("DQMServices.Components.DQMEnvironment_cfi")
 process.load("HLTriggerOffline.Exotica.HLTExoticaPostVal_cff")
 #process.load("HLTriggerOffline.Exotica.HLTExoticaQualityTester_cfi")
 
+# Decide input data
+myinput   = ""
+
+for i in range(0,len(sys.argv)):
+    if str(sys.argv[i])=="_input" and len(sys.argv)>i+1:
+        myinput = str(sys.argv[i+1])
+
+myfileNames = cms.untracked.vstring('file:hltExoticaValidator'+myinput+'.root')
+
+print "Using inputs : "
+print myfileNames
 
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(-1)
 )
 
 process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring('file:hltExoticaValidator.root')
+    fileNames = myfileNames
 )
 
 process.postprocessor_path = cms.Path(

--- a/HLTriggerOffline/Exotica/test/hltExoticaValidator_cfg.py
+++ b/HLTriggerOffline/Exotica/test/hltExoticaValidator_cfg.py
@@ -1,9 +1,176 @@
+import os, sys
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("HLTExoticaOfflineAnalysis")
 
 process.load("HLTriggerOffline.Exotica.ExoticaValidation_cff")
 process.load("DQMServices.Components.MEtoEDMConverter_cfi")
+
+# Decide input data
+myinput   = ""
+myfileNames = cms.untracked.vstring(
+    #'/store/relval/CMSSW_7_2_0_pre1/RelValZEE_13/GEN-SIM-RECO/POSTLS172_V1-v1/00000/0A69FE2A-DAFD-E311-9FA2-00261894391C.root',
+    #'/store/relval/CMSSW_7_2_0_pre1/RelValZEE_13/GEN-SIM-RECO/POSTLS172_V1-v1/00000/4ACF05B1-ABFD-E311-BC8C-0026189438BC.root'
+    'file:/results_exo_nobptx.root'
+    )
+
+for i in range(0,len(sys.argv)):
+    if str(sys.argv[i])=="_input" and len(sys.argv)>i+1:
+        myinput = str(sys.argv[i+1])
+        
+print "Using myinput="+myinput
+
+if   myinput=="ZEE" :
+    myfileNames = cms.untracked.vstring(
+        '/store/relval/CMSSW_7_2_0_pre1/RelValZEE_13/GEN-SIM-RECO/POSTLS172_V1-v1/00000/0A69FE2A-DAFD-E311-9FA2-00261894391C.root',
+        '/store/relval/CMSSW_7_2_0_pre1/RelValZEE_13/GEN-SIM-RECO/POSTLS172_V1-v1/00000/4ACF05B1-ABFD-E311-BC8C-0026189438BC.root')
+
+elif myinput=="ZMM" :
+    myfileNames = cms.untracked.vstring(
+        '/store/relval/CMSSW_7_2_0_pre1/RelValZMM_13/GEN-SIM-RECO/POSTLS172_V1-v1/00000/12E10345-F9FD-E311-9694-0026189438AE.root',
+        '/store/relval/CMSSW_7_2_0_pre1/RelValZMM_13/GEN-SIM-RECO/POSTLS172_V1-v1/00000/B25222BF-F9FD-E311-A217-003048FFCBA4.root')
+
+elif myinput=="ZpEE" :
+    myfileNames = cms.untracked.vstring(
+        '/store/relval/CMSSW_7_2_0_pre1/RelValZpEE_2250_13TeV_Tauola/GEN-SIM-RECO/POSTLS172_V1-v1/00000/343EDE59-F9FD-E311-898D-0025905A612A.root',
+        '/store/relval/CMSSW_7_2_0_pre1/RelValZpEE_2250_13TeV_Tauola/GEN-SIM-RECO/POSTLS172_V1-v1/00000/E2A8B37B-FDFD-E311-8018-002618943849.root')
+
+elif myinput=="ZpMM" :
+    myfileNames = cms.untracked.vstring(
+        '/store/relval/CMSSW_7_2_0_pre1/RelValZpMM_13/GEN-SIM-RECO/POSTLS172_V1-v1/00000/80CB6E2E-0BFE-E311-B644-0025905A4964.root',
+        '/store/relval/CMSSW_7_2_0_pre1/RelValZpMM_13/GEN-SIM-RECO/POSTLS172_V1-v1/00000/E0547611-00FE-E311-88AB-0025905A48F0.root')
+
+elif myinput=="PhotonJets" :
+    myfileNames = cms.untracked.vstring(
+        '/store/relval/CMSSW_7_2_0_pre1/RelValPhotonJets_Pt_10_13/GEN-SIM-RECO/POSTLS172_V1-v1/00000/6AD79C3F-F9FD-E311-AD0C-0025905A610A.root',
+        '/store/relval/CMSSW_7_2_0_pre1/RelValPhotonJets_Pt_10_13/GEN-SIM-RECO/POSTLS172_V1-v1/00000/F8CBE44F-F6FD-E311-8F8C-0025905964BC.root')
+
+elif myinput=="QCD":
+    myfileNames = cms.untracked.vstring(
+        '/store/relval/CMSSW_7_2_0_pre1/RelValQCD_FlatPt_15_3000HS_13/GEN-SIM-RECO/POSTLS172_V1-v1/00000/1EB9CDDA-C8FE-E311-9082-0025905A6066.root',
+       '/store/relval/CMSSW_7_2_0_pre1/RelValQCD_FlatPt_15_3000HS_13/GEN-SIM-RECO/POSTLS172_V1-v1/00000/40620B64-C8FE-E311-86CB-002354EF3BDE.root',
+       '/store/relval/CMSSW_7_2_0_pre1/RelValQCD_FlatPt_15_3000HS_13/GEN-SIM-RECO/POSTLS172_V1-v1/00000/6065EBCA-C2FE-E311-9CD4-003048FFCB8C.root',
+       '/store/relval/CMSSW_7_2_0_pre1/RelValQCD_FlatPt_15_3000HS_13/GEN-SIM-RECO/POSTLS172_V1-v1/00000/68B120F8-CAFE-E311-AAA0-0025905A60FE.root',
+       '/store/relval/CMSSW_7_2_0_pre1/RelValQCD_FlatPt_15_3000HS_13/GEN-SIM-RECO/POSTLS172_V1-v1/00000/72A73941-C8FE-E311-8093-0025905A612C.root',
+       '/store/relval/CMSSW_7_2_0_pre1/RelValQCD_FlatPt_15_3000HS_13/GEN-SIM-RECO/POSTLS172_V1-v1/00000/7E99AB18-CCFE-E311-9ECD-0025905A607E.root',
+       '/store/relval/CMSSW_7_2_0_pre1/RelValQCD_FlatPt_15_3000HS_13/GEN-SIM-RECO/POSTLS172_V1-v1/00000/A0A799B8-C7FE-E311-A820-0025905A6122.root',
+       '/store/relval/CMSSW_7_2_0_pre1/RelValQCD_FlatPt_15_3000HS_13/GEN-SIM-RECO/POSTLS172_V1-v1/00000/AA107A6D-C9FE-E311-B3E4-003048FFCBA4.root',
+       '/store/relval/CMSSW_7_2_0_pre1/RelValQCD_FlatPt_15_3000HS_13/GEN-SIM-RECO/POSTLS172_V1-v1/00000/B4A2DA31-C7FE-E311-B197-0025905A60A8.root',
+       '/store/relval/CMSSW_7_2_0_pre1/RelValQCD_FlatPt_15_3000HS_13/GEN-SIM-RECO/POSTLS172_V1-v1/00000/B67E922A-CAFE-E311-86F9-002618943918.root',
+       '/store/relval/CMSSW_7_2_0_pre1/RelValQCD_FlatPt_15_3000HS_13/GEN-SIM-RECO/POSTLS172_V1-v1/00000/E695A31A-C3FE-E311-B86B-002618943865.root')
+    
+elif myinput=="ZEE_f" :
+    myfileNames = cms.untracked.vstring(
+        '/store/relval/CMSSW_7_2_0_pre1/RelValZEE_13/GEN-SIM-RECO/POSTLS172_V1_frozenHLT-v1/00000/0C68F3E2-D300-E411-A2E1-003048FFCC0A.root',
+        '/store/relval/CMSSW_7_2_0_pre1/RelValZEE_13/GEN-SIM-RECO/POSTLS172_V1_frozenHLT-v1/00000/6A11D18F-D800-E411-A121-0026189438C4.root')
+
+elif myinput=="ZMM_f" :
+    myfileNames = cms.untracked.vstring(
+        '/store/relval/CMSSW_7_2_0_pre1/RelValZMM_13/GEN-SIM-RECO/POSTLS172_V1_frozenHLT-v1/00000/2200CE0D-C600-E411-BF5B-0025905A60B4.root',
+        '/store/relval/CMSSW_7_2_0_pre1/RelValZMM_13/GEN-SIM-RECO/POSTLS172_V1_frozenHLT-v1/00000/8860B293-DB00-E411-A736-0025905A60D6.root')
+
+elif myinput=="ZpEE_f" :
+    myfileNames = cms.untracked.vstring()
+
+elif myinput=="ZpMM_f" :
+    myfileNames = cms.untracked.vstring(
+        '/store/relval/CMSSW_7_2_0_pre1/RelValZpMM_13/GEN-SIM-RECO/POSTLS172_V1_frozenHLT-v1/00000/88067900-C600-E411-B0D4-003048FFD76E.root',
+        '/store/relval/CMSSW_7_2_0_pre1/RelValZpMM_13/GEN-SIM-RECO/POSTLS172_V1_frozenHLT-v1/00000/BA282D59-C900-E411-B969-0025905A6064.root')
+
+elif myinput=="PhotonJets_f" :
+    myfileNames = cms.untracked.vstring(
+        '/store/relval/CMSSW_7_2_0_pre1/RelValPhotonJets_Pt_10_13/GEN-SIM-RECO/POSTLS172_V1_frozenHLT-v1/00000/90422F57-D900-E411-944B-002590593872.root',
+        '/store/relval/CMSSW_7_2_0_pre1/RelValPhotonJets_Pt_10_13/GEN-SIM-RECO/POSTLS172_V1_frozenHLT-v1/00000/E0DD9115-BE00-E411-8C70-00261894382D.root')
+
+elif myinput=="QCD_f":
+    myfileNames = cms.untracked.vstring(
+        '/store/relval/CMSSW_7_2_0_pre1/RelValQCD_FlatPt_15_3000HS_13/GEN-SIM-RECO/POSTLS172_V1_frozenHLT-v1/00000/0AE4F4AE-BE00-E411-8E38-00259059649C.root',
+       '/store/relval/CMSSW_7_2_0_pre1/RelValQCD_FlatPt_15_3000HS_13/GEN-SIM-RECO/POSTLS172_V1_frozenHLT-v1/00000/0CCB8433-C600-E411-AFA1-0025905B85B2.root',
+       '/store/relval/CMSSW_7_2_0_pre1/RelValQCD_FlatPt_15_3000HS_13/GEN-SIM-RECO/POSTLS172_V1_frozenHLT-v1/00000/24043AB8-BD00-E411-B4A6-003048FFD730.root',
+       '/store/relval/CMSSW_7_2_0_pre1/RelValQCD_FlatPt_15_3000HS_13/GEN-SIM-RECO/POSTLS172_V1_frozenHLT-v1/00000/28514BA6-BD00-E411-9B9A-002618943860.root',
+       '/store/relval/CMSSW_7_2_0_pre1/RelValQCD_FlatPt_15_3000HS_13/GEN-SIM-RECO/POSTLS172_V1_frozenHLT-v1/00000/4C0435CC-BD00-E411-8766-002354EF3BD2.root',
+       '/store/relval/CMSSW_7_2_0_pre1/RelValQCD_FlatPt_15_3000HS_13/GEN-SIM-RECO/POSTLS172_V1_frozenHLT-v1/00000/52BBEE04-DC00-E411-9BDC-003048FFD7D4.root',
+       '/store/relval/CMSSW_7_2_0_pre1/RelValQCD_FlatPt_15_3000HS_13/GEN-SIM-RECO/POSTLS172_V1_frozenHLT-v1/00000/5E349B87-BE00-E411-B2CA-0025905A609E.root',
+       '/store/relval/CMSSW_7_2_0_pre1/RelValQCD_FlatPt_15_3000HS_13/GEN-SIM-RECO/POSTLS172_V1_frozenHLT-v1/00000/74B1258C-BF00-E411-91AC-0025905AA9F0.root',
+       '/store/relval/CMSSW_7_2_0_pre1/RelValQCD_FlatPt_15_3000HS_13/GEN-SIM-RECO/POSTLS172_V1_frozenHLT-v1/00000/8668C7C0-DE00-E411-863D-003048FFD752.root',
+       '/store/relval/CMSSW_7_2_0_pre1/RelValQCD_FlatPt_15_3000HS_13/GEN-SIM-RECO/POSTLS172_V1_frozenHLT-v1/00000/9A6C429F-BD00-E411-86FE-002618943857.root',
+       '/store/relval/CMSSW_7_2_0_pre1/RelValQCD_FlatPt_15_3000HS_13/GEN-SIM-RECO/POSTLS172_V1_frozenHLT-v1/00000/ACA31613-BE00-E411-B352-002590596484.root',
+       '/store/relval/CMSSW_7_2_0_pre1/RelValQCD_FlatPt_15_3000HS_13/GEN-SIM-RECO/POSTLS172_V1_frozenHLT-v1/00000/C65023E5-BD00-E411-963E-0025905A60E4.root',
+       '/store/relval/CMSSW_7_2_0_pre1/RelValQCD_FlatPt_15_3000HS_13/GEN-SIM-RECO/POSTLS172_V1_frozenHLT-v1/00000/E8DB8D9A-BE00-E411-BA12-003048FFD7C2.root')
+
+# PU40 25ns
+elif   myinput=="ZEE_PU25ns" :
+    myfileNames = cms.untracked.vstring(
+        '/store/relval/CMSSW_7_2_0_pre1/RelValZEE_13/GEN-SIM-RECO/PU25ns_POSTLS172_V1-v1/00000/00E2C10F-E6FD-E311-ACE3-0025905A60DA.root',
+        '/store/relval/CMSSW_7_2_0_pre1/RelValZEE_13/GEN-SIM-RECO/PU25ns_POSTLS172_V1-v1/00000/62F42186-91FD-E311-92E8-0025905A60EE.root',
+        '/store/relval/CMSSW_7_2_0_pre1/RelValZEE_13/GEN-SIM-RECO/PU25ns_POSTLS172_V1-v1/00000/78D08417-8DFD-E311-B022-0026189438D9.root',
+        '/store/relval/CMSSW_7_2_0_pre1/RelValZEE_13/GEN-SIM-RECO/PU25ns_POSTLS172_V1-v1/00000/CE1B9922-8BFD-E311-82F5-00259059642E.root',
+        '/store/relval/CMSSW_7_2_0_pre1/RelValZEE_13/GEN-SIM-RECO/PU25ns_POSTLS172_V1-v1/00000/E468EFE3-E7FD-E311-A9FF-0025905A6088.root')
+
+elif myinput=="ZMM_PU25ns" :
+    myfileNames = cms.untracked.vstring()
+
+elif myinput=="ZpEE_PU25ns" :
+    myfileNames = cms.untracked.vstring()
+
+elif myinput=="ZpMM_PU25ns" :
+    myfileNames = cms.untracked.vstring()
+
+elif myinput=="ZEE_f_PU25ns" :
+    myfileNames = cms.untracked.vstring(
+        '/store/relval/CMSSW_7_2_0_pre1/RelValZEE_13/GEN-SIM-RECO/PU25ns_POSTLS172_V1_frozenHLT-v1/00000/0C0AFEDA-B600-E411-B890-0025905A6094.root',
+        '/store/relval/CMSSW_7_2_0_pre1/RelValZEE_13/GEN-SIM-RECO/PU25ns_POSTLS172_V1_frozenHLT-v1/00000/684B8352-CC00-E411-B019-0026189438B3.root',
+        '/store/relval/CMSSW_7_2_0_pre1/RelValZEE_13/GEN-SIM-RECO/PU25ns_POSTLS172_V1_frozenHLT-v1/00000/A872BF63-B800-E411-AC92-003048FFCBA8.root',
+        '/store/relval/CMSSW_7_2_0_pre1/RelValZEE_13/GEN-SIM-RECO/PU25ns_POSTLS172_V1_frozenHLT-v1/00000/EC7D73CF-D500-E411-926D-002618943886.root',
+        '/store/relval/CMSSW_7_2_0_pre1/RelValZEE_13/GEN-SIM-RECO/PU25ns_POSTLS172_V1_frozenHLT-v1/00000/F2B7DB47-B500-E411-88B3-0025905A613C.root')
+    
+elif myinput=="ZMM_f_PU25ns" :
+    myfileNames = cms.untracked.vstring()
+
+elif myinput=="ZpEE_f_PU25ns" :
+    myfileNames = cms.untracked.vstring()
+
+elif myinput=="ZpMM_f_PU25ns" :
+    myfileNames = cms.untracked.vstring()
+
+## PU40 50ns
+elif myinput=="ZEE_PU50ns" :
+    myfileNames = cms.untracked.vstring(
+        '/store/relval/CMSSW_7_2_0_pre1/RelValZEE_13/GEN-SIM-RECO/PU50ns_POSTLS172_V2-v1/00000/0213DA84-8AFD-E311-A2FB-0026189438FF.root',
+        '/store/relval/CMSSW_7_2_0_pre1/RelValZEE_13/GEN-SIM-RECO/PU50ns_POSTLS172_V2-v1/00000/10BE77F0-86FD-E311-A7F6-0026189438DF.root',
+        '/store/relval/CMSSW_7_2_0_pre1/RelValZEE_13/GEN-SIM-RECO/PU50ns_POSTLS172_V2-v1/00000/3410BEEC-E6FD-E311-9D13-0025905A60F4.root',
+        '/store/relval/CMSSW_7_2_0_pre1/RelValZEE_13/GEN-SIM-RECO/PU50ns_POSTLS172_V2-v1/00000/5471FED0-8CFD-E311-8064-003048FFCB74.root',
+        '/store/relval/CMSSW_7_2_0_pre1/RelValZEE_13/GEN-SIM-RECO/PU50ns_POSTLS172_V2-v1/00000/C2BECB0F-89FD-E311-83DE-0025905B8610.root')
+
+elif myinput=="ZMM_PU50ns" :
+    myfileNames = cms.untracked.vstring()
+
+elif myinput=="ZpEE_PU50ns" :
+    myfileNames = cms.untracked.vstring()
+
+elif myinput=="ZpMM_PU50ns" :
+    myfileNames = cms.untracked.vstring()
+
+elif myinput=="ZEE_f_PU50ns" :
+    myfileNames = cms.untracked.vstring(
+        '/store/relval/CMSSW_7_2_0_pre1/RelValZEE_13/GEN-SIM-RECO/PU50ns_POSTLS172_V2_frozenHLT-v1/00000/02D5E5C6-BD00-E411-B421-00259059391E.root',
+        '/store/relval/CMSSW_7_2_0_pre1/RelValZEE_13/GEN-SIM-RECO/PU50ns_POSTLS172_V2_frozenHLT-v1/00000/2817C10B-D600-E411-B17C-002618943939.root',
+        '/store/relval/CMSSW_7_2_0_pre1/RelValZEE_13/GEN-SIM-RECO/PU50ns_POSTLS172_V2_frozenHLT-v1/00000/547D27A4-C700-E411-8686-0025905A60EE.root',
+        '/store/relval/CMSSW_7_2_0_pre1/RelValZEE_13/GEN-SIM-RECO/PU50ns_POSTLS172_V2_frozenHLT-v1/00000/58E959E1-BA00-E411-89F8-0025905938A4.root',
+        '/store/relval/CMSSW_7_2_0_pre1/RelValZEE_13/GEN-SIM-RECO/PU50ns_POSTLS172_V2_frozenHLT-v1/00000/D0F38943-D800-E411-8517-002590593920.root',
+        '/store/relval/CMSSW_7_2_0_pre1/RelValZEE_13/GEN-SIM-RECO/PU50ns_POSTLS172_V2_frozenHLT-v1/00000/FABFF406-C300-E411-AE96-002618943800.root')
+
+elif myinput=="ZMM_f_PU50ns" :
+    myfileNames = cms.untracked.vstring()
+
+elif myinput=="ZpEE_f_PU50ns" :
+    myfileNames = cms.untracked.vstring()
+
+elif myinput=="ZpMM_f_PU50ns" :
+    myfileNames = cms.untracked.vstring()
+
+print "### Files : "
+print myfileNames
 
 
 ##############################################################################
@@ -27,16 +194,7 @@ process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(-1)
 )
 
-process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring(
-        #'/store/relval/CMSSW_7_1_0_pre1/RelValZMM_13/GEN-SIM-RECO/POSTLS170_V1-v1/00000/98CCC248-5B86-E311-B20C-02163E00EB5A.root'
-        #'/store/relval/CMSSW_7_1_0_pre1/RelValADDMonoJet_d3MD3_13/GEN-SIM-RECO/POSTLS170_V1-v1/00000/2C2E143F-2386-E311-9DD8-02163E00E5B2.root'
-        #'/store/relval/CMSSW_7_1_0_pre1/RelValQCD_Pt_600_800_13/GEN-SIM-RECO/POSTLS170_V1-v1/00000/E6B796C9-3686-E311-B7CF-02163E00EB6E.root'
-        #'/store/relval/CMSSW_7_1_0_pre1/RelValZpTT_1500_13TeV_Tauola/GEN-SIM-RECO/POSTLS170_V1-v1/00000/0C7325DD-4986-E311-A342-02163E008F41.root'
-        '/store/relval/CMSSW_7_1_0_pre1/RelValTTbarLepton_13/GEN-SIM-RECO/POSTLS170_V1-v1/00000/6E99FADF-4386-E311-8AB5-02163E008CCC.root',
-        '/store/relval/CMSSW_7_1_0_pre1/RelValTTbarLepton_13/GEN-SIM-RECO/POSTLS170_V1-v1/00000/82E02E9D-3886-E311-A699-003048D2C0F2.root',
-        '/store/relval/CMSSW_7_1_0_pre1/RelValTTbarLepton_13/GEN-SIM-RECO/POSTLS170_V1-v1/00000/5CB7C5E7-4B86-E311-9394-02163E00EB64.root')
-)
+process.source = cms.Source("PoolSource", fileNames=myfileNames)
 
 process.DQMStore = cms.Service("DQMStore")
 
@@ -67,11 +225,12 @@ process.out = cms.OutputModule("PoolOutputModule",
     outputCommands = cms.untracked.vstring(
         'drop *', 
         'keep *_MEtoEDMConverter_*_HLTExoticaOfflineAnalysis'),
-    fileName = cms.untracked.string('hltExoticaValidator.root')
+    fileName = cms.untracked.string('hltExoticaValidator'+myinput+'.root')
 )
 
 
 process.analyzerpath = cms.Path(
+    process.ExoticaValidationProdSeq +
     process.ExoticaValidationSequence +
     process.MEtoEDMConverter
 )


### PR DESCRIPTION
The idea is to backport #5320 (originally from @ndaci, and merged in 73X since two weeks already) in 72X.
This PR would allow monitoring also in 72X a set of paths from Exotica included in the Run2 HLT menu.
Of course, I let @deguio and the release managers to decide about it. But I think it  would be a pity not being able of monitoring those HLT paths in 72X, when the PR exists in 73X and it is now ready also for 72X.
