### PR TITLE
fix the electronIDs for the miniAOD step

### DIFF
--- a/PhysicsTools/SelectorUtils/python/tools/vid_id_tools.py
+++ b/PhysicsTools/SelectorUtils/python/tools/vid_id_tools.py
@@ -30,7 +30,7 @@ def addVIDSelectionToPATProducer(patProducer,idProducer,idName):
 
 def setupAllVIDIdsInModule(process,id_module_name,setupFunction,patProducer=None):
 #    idmod = importlib.import_module(id_module_name)
-    idmod= __import__(id_module_name)
+    idmod= __import__(id_module_name,globals(), locals(), ['idName','cutFlow'])
     for name in dir(idmod):
         item = getattr(idmod,name)
         if hasattr(item,'idName') and hasattr(item,'cutFlow'):


### PR DESCRIPTION
The problem of the electronIDs in the miniAOD step was raised here:

https://hypernews.cern.ch/HyperNews/CMS/get/physTools/3253.html
