### PR TITLE
Updated default btag discriminators for PAT jet

### DIFF
--- a/PhysicsTools/PatAlgos/python/producersLayer1/jetProducer_cfi.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/jetProducer_cfi.py
@@ -42,7 +42,9 @@ patJets = cms.EDProducer("PATJetProducer",
         cms.InputTag("trackCountingHighEffBJetTags"),
         cms.InputTag("simpleSecondaryVertexHighEffBJetTags"),
         cms.InputTag("simpleSecondaryVertexHighPurBJetTags"),
-        cms.InputTag("combinedSecondaryVertexBJetTags")
+        cms.InputTag("combinedInclusiveSecondaryVertexV2BJetTags"),
+        cms.InputTag("pfCombinedSecondaryVertexBJetTags"),
+        cms.InputTag("combinedMVABJetTags")
     ),
     # clone tag infos ATTENTION: these take lots of space!
     # usually the discriminators from the default algos


### PR DESCRIPTION
This is a follow-up to PR #5446 which adds new btag discriminators to the default PAT jet configuration.

Note that this PR requires 720pre7 RelVal samples for PAT tests not to fail.
