### PR TITLE
 Gen relval cmssw 7_3_X_2014-10-07-1400

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -884,8 +884,8 @@ steps['TTbarFS_ID']=identityFS(steps['TTbarFS'])
  
 step1GenDefaults=merge([{'-s':'GEN,VALIDATION:genvalid',
                          '--relval':'250000,20000',
-                         '--eventcontent':'RAWSIM',
-                         '--datatier':'GEN'},
+                         '--eventcontent':'RAWSIM,DQM',
+                         '--datatier':'GEN,DQMIO'},
                         step1Defaults])
 def genvalid(fragment,d,suffix='all',fi='',dataSet=''):
     import copy
@@ -1331,7 +1331,8 @@ steps['HARVESTGEN']={'-s':'HARVESTING:genHarvesting',
                      '--harvesting':'AtJobEnd',
                      '--conditions':'auto:run1_mc',
                      '--mc':'',
-                     '--filein':'file:step1.root'
+                     '--filetype':'DQM',
+                     '--filein':'file:step1_inDQM.root'
                   }
 
 #data


### PR DESCRIPTION
- explicit DQMIO in datatier of GEN relvals
- fixes are intended to properly trigger the harvesting in production and documented also here https://hypernews.cern.ch/HyperNews/CMS/get/dataopsrequests/5638/1/1/2/1/1/1/1/1.html

@bendavid 
@inugent
