### PR TITLE
MiniAOD for InputGenJetsParticleSelector

### DIFF
--- a/RecoJets/JetProducers/plugins/InputGenJetsParticleSelector.cc
+++ b/RecoJets/JetProducers/plugins/InputGenJetsParticleSelector.cc
@@ -250,7 +250,7 @@ void InputGenJetsParticleSelector::produce (edm::Event &evt, const edm::EventSet
 
     for (edm::View<reco::Candidate>::const_iterator iter=prunedGenParticles->begin();iter!=prunedGenParticles->end();++iter)
     {
-      if(iter->status()!=1)
+      if(iter->status()!=1) // to avoid double-counting, skipping stable particles already contained in the collection of PackedGenParticles
         particles.push_back(&*iter);
     }
   }
@@ -275,7 +275,7 @@ void InputGenJetsParticleSelector::produce (edm::Event &evt, const edm::EventSet
     const reco::Candidate *particle = particles[i];
     if (invalid[i])
       continue;
-    if (particle->status() == 1)
+    if (particle->status() == 1) // selecting stable particles
       selected[i] = true;
     if (partonicFinalState && isParton(particle->pdgId())) {
 	  

--- a/RecoJets/JetProducers/plugins/InputGenJetsParticleSelector.cc
+++ b/RecoJets/JetProducers/plugins/InputGenJetsParticleSelector.cc
@@ -32,6 +32,8 @@
 * 
 *    04.08.2014: Dinko Ferencek
 *                Added support for Pythia8 (status=22 for intermediate resonances)
+*    23.09.2014: Dinko Ferencek
+*                Generalized code to work with miniAOD (except for the partonicFinalState which requires AOD)
 *
 */
 
@@ -46,9 +48,11 @@ using namespace std;
 
 InputGenJetsParticleSelector::InputGenJetsParticleSelector(const edm::ParameterSet &params ):
   inTag(params.getParameter<edm::InputTag>("src")),
+  prunedInTag(params.exists("prunedGenParticles") ? params.getParameter<edm::InputTag>("prunedGenParticles") : edm::InputTag()),
   partonicFinalState(params.getParameter<bool>("partonicFinalState")),
   excludeResonances(params.getParameter<bool>("excludeResonances")),
   tausAsJets(params.getParameter<bool>("tausAsJets")),
+  isMiniAOD(params.exists("prunedGenParticles")),
   ptMin(0.0){
   if (params.exists("ignoreParticleIDs"))
     setIgnoredParticles(params.getParameter<std::vector<unsigned int> >
@@ -56,9 +60,11 @@ InputGenJetsParticleSelector::InputGenJetsParticleSelector(const edm::ParameterS
   setExcludeFromResonancePids(params.getParameter<std::vector<unsigned int> >
 			("excludeFromResonancePids"));
 
-  produces <reco::GenParticleRefVector> ();
+  produces <reco::CandidatePtrVector> ();
 
-  input_genpartcoll_token_ = consumes<reco::GenParticleCollection>(inTag);
+  input_genpartcoll_token_ = consumes<edm::View<reco::Candidate> >(inTag);
+  if(isMiniAOD)
+    input_prunedgenpartcoll_token_ = consumes<edm::View<reco::Candidate> >(prunedInTag);
       
 }
 
@@ -120,7 +126,7 @@ bool InputGenJetsParticleSelector::isExcludedFromResonance(int pdgId) const
 }
 
 static unsigned int partIdx(const InputGenJetsParticleSelector::ParticleVector &p,
-			       const reco::GenParticle *particle)
+			       const reco::Candidate *particle)
 {
   InputGenJetsParticleSelector::ParticleVector::const_iterator pos =
     std::lower_bound(p.begin(), p.end(), particle);
@@ -134,18 +140,18 @@ static unsigned int partIdx(const InputGenJetsParticleSelector::ParticleVector &
     
 static void invalidateTree(InputGenJetsParticleSelector::ParticleBitmap &invalid,
 			   const InputGenJetsParticleSelector::ParticleVector &p,
-			   const reco::GenParticle *particle)
+			   const reco::Candidate *particle)
 {
   unsigned int npart=particle->numberOfDaughters();
   if (!npart) return;
 
   for (unsigned int i=0;i<npart;++i){
-    unsigned int idx=partIdx(p,dynamic_cast<const reco::GenParticle*>(particle->daughter(i)));
+    unsigned int idx=partIdx(p,particle->daughter(i));
     if (invalid[idx])
       continue;
     invalid[idx] = true;
     //cout<<"Invalidated: ["<<setw(4)<<idx<<"] With pt:"<<particle->daughter(i)->pt()<<endl;
-    invalidateTree(invalid, p, dynamic_cast<const reco::GenParticle*>(particle->daughter(i)));
+    invalidateTree(invalid, p, particle->daughter(i));
   }
 }
   
@@ -153,13 +159,13 @@ static void invalidateTree(InputGenJetsParticleSelector::ParticleBitmap &invalid
 int InputGenJetsParticleSelector::testPartonChildren
 (InputGenJetsParticleSelector::ParticleBitmap &invalid,
  const InputGenJetsParticleSelector::ParticleVector &p,
- const reco::GenParticle *particle) const
+ const reco::Candidate *particle) const
 {
   unsigned int npart=particle->numberOfDaughters();
   if (!npart) {return 0;}
 
   for (unsigned int i=0;i<npart;++i){
-    unsigned int idx = partIdx(p,dynamic_cast<const reco::GenParticle*>(particle->daughter(i)));
+    unsigned int idx = partIdx(p,particle->daughter(i));
     if (invalid[idx])
       continue;
     if (isParton((particle->daughter(i)->pdgId()))){
@@ -168,7 +174,7 @@ int InputGenJetsParticleSelector::testPartonChildren
     if (isHadron((particle->daughter(i)->pdgId()))){
       return -1;
     }
-    int result = testPartonChildren(invalid,p,dynamic_cast<const reco::GenParticle*>(particle->daughter(i)));
+    int result = testPartonChildren(invalid,p,particle->daughter(i));
     if (result) return result;
   }
   return 0;
@@ -177,7 +183,7 @@ int InputGenJetsParticleSelector::testPartonChildren
 InputGenJetsParticleSelector::ResonanceState
 InputGenJetsParticleSelector::fromResonance(ParticleBitmap &invalid,
 							   const ParticleVector &p,
-							   const reco::GenParticle *particle) const
+							   const reco::Candidate *particle) const
 {
   unsigned int idx = partIdx(p, particle);
   int id = particle->pdgId();
@@ -200,12 +206,12 @@ InputGenJetsParticleSelector::fromResonance(ParticleBitmap &invalid,
   
 
   for(unsigned int i=0;i<nMo;++i){
-    ResonanceState result = fromResonance(invalid,p,dynamic_cast<const reco::GenParticle*>(particle->mother(i)));
+    ResonanceState result = fromResonance(invalid,p,particle->mother(i));
     switch(result) {
     case kNo:
       break;
     case kDirect:
-      if (dynamic_cast<const reco::GenParticle*>(particle->mother(i))->pdgId()==id || isResonance(id))
+      if (particle->mother(i)->pdgId()==id || isResonance(id))
 	return kDirect;
       if(!isExcludedFromResonance(id))
 	break;
@@ -219,7 +225,7 @@ return kNo;
     
 bool InputGenJetsParticleSelector::hasPartonChildren(ParticleBitmap &invalid,
 						     const ParticleVector &p,
-						     const reco::GenParticle *particle) const {
+						     const reco::Candidate *particle) const {
   return testPartonChildren(invalid, p, particle) > 0;
 }
     
@@ -228,14 +234,25 @@ bool InputGenJetsParticleSelector::hasPartonChildren(ParticleBitmap &invalid,
 void InputGenJetsParticleSelector::produce (edm::Event &evt, const edm::EventSetup &evtSetup){
 
  
-  std::auto_ptr<reco::GenParticleRefVector> selected_ (new reco::GenParticleRefVector);
+  std::auto_ptr<reco::CandidatePtrVector> selected_ (new reco::CandidatePtrVector);
     
-  edm::Handle<reco::GenParticleCollection> genParticles;
-  evt.getByToken(input_genpartcoll_token_, genParticles );
-    
-  std::map<const reco::GenParticle*,size_t> particlePtrIdxMap;
   ParticleVector particles;
-  for (reco::GenParticleCollection::const_iterator iter=genParticles->begin();iter!=genParticles->end();++iter){
+  
+  edm::Handle<edm::View<reco::Candidate> > prunedGenParticles;
+  if(isMiniAOD && !partonicFinalState)
+  {
+    evt.getByToken(input_prunedgenpartcoll_token_, prunedGenParticles );
+
+    for (edm::View<reco::Candidate>::const_iterator iter=prunedGenParticles->begin();iter!=prunedGenParticles->end();++iter)
+      particles.push_back(&*iter);
+  }
+
+  edm::Handle<edm::View<reco::Candidate> > genParticles;
+  evt.getByToken(input_genpartcoll_token_, genParticles );
+
+  std::map<const reco::Candidate*,size_t> particlePtrIdxMap;
+
+  for (edm::View<reco::Candidate>::const_iterator iter=genParticles->begin();iter!=genParticles->end();++iter){
     particles.push_back(&*iter);
     particlePtrIdxMap[&*iter] = (iter - genParticles->begin());
   }
@@ -247,7 +264,7 @@ void InputGenJetsParticleSelector::produce (edm::Event &evt, const edm::EventSet
   ParticleBitmap invalid(size, false);
 
   for(unsigned int i = 0; i < size; i++) {
-    const reco::GenParticle *particle = particles[i];
+    const reco::Candidate *particle = particles[i];
     if (invalid[i])
       continue;
     if (particle->status() == 1)
@@ -269,7 +286,7 @@ void InputGenJetsParticleSelector::produce (edm::Event &evt, const edm::EventSet
   }
 
   for(size_t idx = 0; idx < size; ++idx){ 
-    const reco::GenParticle *particle = particles[idx];
+    const reco::Candidate *particle = particles[idx];
     if (!selected[idx] || invalid[idx]){
       continue;
     }
@@ -287,8 +304,7 @@ void InputGenJetsParticleSelector::produce (edm::Event &evt, const edm::EventSet
 
    
     if (particle->pt() >= ptMin){
-      edm::Ref<reco::GenParticleCollection> particleRef(genParticles,particlePtrIdxMap[particle]);
-      selected_->push_back(particleRef);
+      selected_->push_back(genParticles->ptrAt(particlePtrIdxMap[particle]));
       //cout<<"Finally we have: ["<<setw(4)<<idx<<"] "<<setw(4)<<particle->pdgId()<<" "<<particle->pt()<<endl;
     }
   }

--- a/RecoJets/JetProducers/plugins/InputGenJetsParticleSelector.cc
+++ b/RecoJets/JetProducers/plugins/InputGenJetsParticleSelector.cc
@@ -249,7 +249,10 @@ void InputGenJetsParticleSelector::produce (edm::Event &evt, const edm::EventSet
     evt.getByToken(input_prunedgenpartcoll_token_, prunedGenParticles );
 
     for (edm::View<reco::Candidate>::const_iterator iter=prunedGenParticles->begin();iter!=prunedGenParticles->end();++iter)
-      particles.push_back(&*iter);
+    {
+      if(iter->status()!=1)
+        particles.push_back(&*iter);
+    }
   }
 
   edm::Handle<edm::View<reco::Candidate> > genParticles;

--- a/RecoJets/JetProducers/plugins/InputGenJetsParticleSelector.cc
+++ b/RecoJets/JetProducers/plugins/InputGenJetsParticleSelector.cc
@@ -67,9 +67,9 @@ InputGenJetsParticleSelector::InputGenJetsParticleSelector(const edm::ParameterS
 
   produces <reco::CandidatePtrVector> ();
 
-  input_genpartcoll_token_ = consumes<edm::View<reco::Candidate> >(inTag);
+  input_genpartcoll_token_ = consumes<reco::CandidateView>(inTag);
   if(isMiniAOD)
-    input_prunedgenpartcoll_token_ = consumes<edm::View<reco::Candidate> >(prunedInTag);
+    input_prunedgenpartcoll_token_ = consumes<reco::CandidateView>(prunedInTag);
       
 }
 
@@ -243,7 +243,7 @@ void InputGenJetsParticleSelector::produce (edm::Event &evt, const edm::EventSet
     
   ParticleVector particles;
   
-  edm::Handle<edm::View<reco::Candidate> > prunedGenParticles;
+  edm::Handle<reco::CandidateView> prunedGenParticles;
   if(isMiniAOD)
   {
     evt.getByToken(input_prunedgenpartcoll_token_, prunedGenParticles );
@@ -255,7 +255,7 @@ void InputGenJetsParticleSelector::produce (edm::Event &evt, const edm::EventSet
     }
   }
 
-  edm::Handle<edm::View<reco::Candidate> > genParticles;
+  edm::Handle<reco::CandidateView> genParticles;
   evt.getByToken(input_genpartcoll_token_, genParticles );
 
   std::map<const reco::Candidate*,size_t> particlePtrIdxMap;

--- a/RecoJets/JetProducers/plugins/InputGenJetsParticleSelector.h
+++ b/RecoJets/JetProducers/plugins/InputGenJetsParticleSelector.h
@@ -93,8 +93,8 @@ class InputGenJetsParticleSelector : public edm::EDProducer {
   bool			isMiniAOD;
   double		ptMin;
   
-  edm::EDGetTokenT<edm::View<reco::Candidate> > input_genpartcoll_token_;
-  edm::EDGetTokenT<edm::View<reco::Candidate> > input_prunedgenpartcoll_token_;
+  edm::EDGetTokenT<reco::CandidateView> input_genpartcoll_token_;
+  edm::EDGetTokenT<reco::CandidateView> input_prunedgenpartcoll_token_;
   
 };
 

--- a/RecoJets/JetProducers/plugins/InputGenJetsParticleSelector.h
+++ b/RecoJets/JetProducers/plugins/InputGenJetsParticleSelector.h
@@ -14,8 +14,8 @@
  */
 
 #include "DataFormats/Provenance/interface/Provenance.h"
-#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -29,7 +29,7 @@ class InputGenJetsParticleSelector : public edm::EDProducer {
   // collection type
  public:
   typedef std::vector<bool>     ParticleBitmap;
-  typedef std::vector<const reco::GenParticle*> ParticleVector;
+  typedef std::vector<const reco::Candidate*> ParticleVector;
       
   InputGenJetsParticleSelector(const edm::ParameterSet & ); 
   ~InputGenJetsParticleSelector(); 
@@ -57,7 +57,7 @@ class InputGenJetsParticleSelector : public edm::EDProducer {
   bool isIgnored(int pdgId) const;
   bool hasPartonChildren(ParticleBitmap &invalid,
 			 const ParticleVector &p,
-			 const reco::GenParticle *particle) const;
+			 const reco::Candidate *particle) const;
   
   enum ResonanceState {
     kNo = 0,
@@ -66,7 +66,7 @@ class InputGenJetsParticleSelector : public edm::EDProducer {
   };
   ResonanceState fromResonance(ParticleBitmap &invalid,
 			       const ParticleVector &p,
-			       const reco::GenParticle *particle) const;
+			       const reco::Candidate *particle) const;
   
   
   // iterators over selected objects: collection begin
@@ -76,9 +76,10 @@ class InputGenJetsParticleSelector : public edm::EDProducer {
   InputGenJetsParticleSelector(){} //should not be used!
   
   edm::InputTag inTag;
+  edm::InputTag prunedInTag;
   int testPartonChildren(ParticleBitmap &invalid,
 			 const ParticleVector &p,
-			 const reco::GenParticle *particle) const;
+			 const reco::Candidate *particle) const;
   
   std::vector<unsigned int>	ignoreParticleIDs;
   std::vector<unsigned int> excludeFromResonancePids;
@@ -89,10 +90,11 @@ class InputGenJetsParticleSelector : public edm::EDProducer {
   bool			partonicFinalState;
   bool			excludeResonances;
   bool			tausAsJets;
-  double			ptMin;
+  bool			isMiniAOD;
+  double		ptMin;
   
-  edm::EDGetTokenT<reco::GenParticleCollection> input_genpartcoll_token_;
-  
+  edm::EDGetTokenT<edm::View<reco::Candidate> > input_genpartcoll_token_;
+  edm::EDGetTokenT<edm::View<reco::Candidate> > input_prunedgenpartcoll_token_;
   
 };
 

--- a/Validation/RecoTau/python/dataTypes/ValidateTausOnZEE_cff.py
+++ b/Validation/RecoTau/python/dataTypes/ValidateTausOnZEE_cff.py
@@ -25,7 +25,7 @@ selectStableElectrons = genParticlesForJets.clone(src = cms.InputTag("selectElec
 #objectTypeSelectedTauValDenominatorModule.src = cms.InputTag("selectElectronsForGenJets")
 
 kinematicSelectedTauValDenominatorZEE = cms.EDFilter(
-   "TauValGenPRefSelector", #"GenJetSelector"
+   "CandPtrSelector",
    src = cms.InputTag('selectStableElectrons'),
    cut = kinematicSelectedTauValDenominatorCut,#cms.string('pt > 5. && abs(eta) < 2.5'), #Defined: Validation.RecoTau.RecoTauValidation_cfi 
    filter = cms.bool(False)

--- a/Validation/RecoTau/python/dataTypes/ValidateTausOnZMM_cff.py
+++ b/Validation/RecoTau/python/dataTypes/ValidateTausOnZMM_cff.py
@@ -22,7 +22,7 @@ selectMuons = cms.EDProducer(
 selectStableMuons = genParticlesForJets.clone(src = cms.InputTag("selectMuons"))
 
 kinematicSelectedTauValDenominatorZMM = cms.EDFilter(
-   "TauValGenPRefSelector", #"GenJetSelector"
+   "CandPtrSelector",
    src = cms.InputTag('selectStableMuons'),
    cut = kinematicSelectedTauValDenominatorCut,#cms.string('pt > 5. && abs(eta) < 2.5'), #Defined: Validation.RecoTau.RecoTauValidation_cfi 
    filter = cms.bool(False)


### PR DESCRIPTION
This PR adapts the InputGenJetsParticleSelector so it also works with miniAOD. The main difference between AOD and miniAOD is that in miniAOD a subset of GenParticles is stored in the following two collections:
- `prunedGenParticles`
- `packedGenParticles`

and InputGenJetsParticleSelector needs to access both collections in order to perform the same selection of GenParticles as in AOD where all GenParticles are stored in one collection, `genParticles`. Attached are a few comparison plots. Small differences between AOD and miniAOD are expected due to the loss of precision in the GenParticle (un)packing process.

![genjetscomparison_1](https://cloud.githubusercontent.com/assets/4885289/4550513/562a2bd6-4e67-11e4-8891-3c4f62e97f3c.png)
![genjetscomparison_2](https://cloud.githubusercontent.com/assets/4885289/4550515/562f9b52-4e67-11e4-9c15-ccfbeaadfa75.png)
![genjetscomparison_3](https://cloud.githubusercontent.com/assets/4885289/4550512/5629c13c-4e67-11e4-801f-34b36c14573b.png)
![genjetscomparison_4](https://cloud.githubusercontent.com/assets/4885289/4550514/562cb7c0-4e67-11e4-813a-134129c6ba68.png)
