### PR TITLE
Fix writeXMLHeader overloading with multi-inheritance

### DIFF
--- a/CalibFormats/SiPixelObjects/interface/PixelCalibBase.h
+++ b/CalibFormats/SiPixelObjects/interface/PixelCalibBase.h
@@ -28,7 +28,7 @@ namespace pos{
     PixelCalibBase();
     virtual ~PixelCalibBase();
     virtual std::string mode() const {return mode_;}
-    virtual void writeXMLHeader(  pos::PixelConfigKey &key, 
+    virtual void writeXMLHeader(  pos::PixelConfigKey key,
 				  int version, 
 				  std::string path, 
 				  std::ofstream *out,

--- a/CalibFormats/SiPixelObjects/interface/PixelCalibConfiguration.h
+++ b/CalibFormats/SiPixelObjects/interface/PixelCalibConfiguration.h
@@ -174,7 +174,7 @@ namespace pos{
 
     virtual void writeASCII(std::string dir="") const;
     void 	 writeXML(        pos::PixelConfigKey key, int version, std::string path) const {;}
-    virtual void writeXMLHeader(  pos::PixelConfigKey &key,
+    virtual void writeXMLHeader(  pos::PixelConfigKey key,
 				  int version, 
 				  std::string path, 
 				  std::ofstream *out,

--- a/CalibFormats/SiPixelObjects/interface/PixelTrimCommon.h
+++ b/CalibFormats/SiPixelObjects/interface/PixelTrimCommon.h
@@ -44,7 +44,12 @@ namespace pos{
 
     void         writeASCII(std::string filename)                                                           const  ;
     void         writeXML(      pos::PixelConfigKey key, int version, std::string path)                     const {;}
-    virtual void writeXMLHeader(pos::PixelConfigKey key, int version, std::string path, std::ofstream *out) const {;}
+    virtual void writeXMLHeader(pos::PixelConfigKey key,
+                                int version, std::string path,
+                                std::ofstream *out,
+                                std::ofstream *out1 = NULL,
+                                std::ofstream *out2 = NULL
+                                ) const {;}
     virtual void writeXML(                                                              std::ofstream *out) const {;}
     virtual void writeXMLTrailer(                                                       std::ofstream *out) const {;}
 

--- a/CalibFormats/SiPixelObjects/src/PixelCalibConfiguration.cc
+++ b/CalibFormats/SiPixelObjects/src/PixelCalibConfiguration.cc
@@ -1673,7 +1673,7 @@ bool PixelCalibConfiguration::containsScan(std::string name) const
 }
 
 //=============================================================================================
-void PixelCalibConfiguration::writeXMLHeader(pos::PixelConfigKey &key,
+void PixelCalibConfiguration::writeXMLHeader(pos::PixelConfigKey key,
                                     	     int version, 
                                     	     std::string path, 
                                     	     std::ofstream *outstream,


### PR DESCRIPTION
The previous patch only partially resolved the issue. We have
multi-inheritance here and both base classes contain`writeXMLHeader`, yet
both have different signatures.

This patch resolves all warnings related to `writeXMLHeader` and should 
resolve the last diagnostic error on Darwin in Boost Serialization.

Compile tested on GCC and Clang.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
