### PR TITLE
72X - Update RelVal input for b-tagging

### DIFF
--- a/PhysicsTools/PatAlgos/python/patInputFiles_cff.py
+++ b/PhysicsTools/PatAlgos/python/patInputFiles_cff.py
@@ -1,67 +1,67 @@
 import FWCore.ParameterSet.Config as cms
 from PhysicsTools.PatAlgos.tools.cmsswVersionTools import pickRelValInputFiles
 
-# /RelValProdTTbar/CMSSW_7_2_0_pre5-START72_V1-v1/AODSIM
+# /RelValProdTTbar/CMSSW_7_2_0_pre7-PRE_STA72_V4-v1/AODSIM
 filesRelValProdTTbarAODSIM = cms.untracked.vstring(
-    #pickRelValInputFiles( cmsswVersion  = 'CMSSW_7_2_0_pre5'
+    #pickRelValInputFiles( cmsswVersion  = 'CMSSW_7_2_0_pre7'
                         #, relVal        = 'RelValProdTTbar'
-                        #, globalTag     = 'START72_V1'
+                        #, globalTag     = 'STA72_V4'
                         #, dataTier      = 'AODSIM'
                         #, maxVersions   = 1
                         #, numberOfFiles = 1
                         #, useDAS        = True
                         #)
-        '/store/relval/CMSSW_7_2_0_pre5/RelValProdTTbar/AODSIM/START72_V1-v1/00000/84686BF3-AC30-E411-B9A8-00261894391C.root'
+        '/store/relval/CMSSW_7_2_0_pre7/RelValProdTTbar/AODSIM/PRE_STA72_V4-v1/00000/3E58BB46-BD4B-E411-B2EC-002618943856.root'
     )
 
-# /RelValProdTTbar/CMSSW_7_2_0_pre5-START72_V1-v1/GEN-SIM-RECO
+# /RelValProdTTbar/CMSSW_7_2_0_pre7-PRE_STA72_V4-v1/GEN-SIM-RECO
 filesRelValProdTTbarGENSIMRECO = cms.untracked.vstring(
-    #pickRelValInputFiles( cmsswVersion  = 'CMSSW_7_2_0_pre5'
+    #pickRelValInputFiles( cmsswVersion  = 'CMSSW_7_2_0_pre7'
                         #, relVal        = 'RelValProdTTbar'
-                        #, globalTag     = 'START72_V1'
+                        #, globalTag     = 'STA72_V4'
                         #, dataTier      = 'GEN-SIM-RECO'
                         #, maxVersions   = 1
                         #, numberOfFiles = 1
                         #, useDAS        = True
                         #)
-        '/store/relval/CMSSW_7_2_0_pre5/RelValProdTTbar/GEN-SIM-RECO/START72_V1-v1/00000/022350A9-AC30-E411-B225-0025905A6076.root'
+        '/store/relval/CMSSW_7_2_0_pre7/RelValProdTTbar/GEN-SIM-RECO/PRE_STA72_V4-v1/00000/B223AEC2-B94B-E411-884B-00261894395F.root'
     )
 
-# /RelValTTbar/CMSSW_7_2_0_pre5-PU_START72_V1_FastSim-v1/GEN-SIM-DIGI-RECO
+# /RelValTTbar/CMSSW_7_2_0_pre7-PU_PRE_STA72_V4_FastSim-v1/GEN-SIM-DIGI-RECO
 filesRelValTTbarPileUpFastSimGENSIMDIGIRECO = cms.untracked.vstring(
-    #pickRelValInputFiles( cmsswVersion  = 'CMSSW_7_2_0_pre5'
+    #pickRelValInputFiles( cmsswVersion  = 'CMSSW_7_2_0_pre7'
                         #, relVal        = 'RelValTTbar'
-                        #, globalTag     = 'PU_START71_V5_FastSim'
+                        #, globalTag     = 'PU_PRE_STA72_V4_FastSim'
                         #, dataTier      = 'GEN-SIM-DIGI-RECO'
                         #, maxVersions   = 1
                         #, numberOfFiles = 1
                         #, useDAS        = True
                         #)
-        '/store/relval/CMSSW_7_2_0_pre5/RelValTTbar/GEN-SIM-DIGI-RECO/PU_START72_V1_FastSim-v1/00000/0082D343-4B30-E411-93C1-0026189438F6.root'
+        '/store/relval/CMSSW_7_2_0_pre7/RelValTTbar/GEN-SIM-DIGI-RECO/PU_PRE_STA72_V4_FastSim-v1/00000/009B474D-1C4B-E411-8347-0026189438EF.root'
     )
 
-# /RelValTTbar_13/CMSSW_7_2_0_pre5-PU50ns_POSTLS172_V4-v1/GEN-SIM-RECO
+# /RelValTTbar_13/CMSSW_7_2_0_pre7-PU50ns_PRE_LS172_V12-v1/GEN-SIM-RECO
 filesRelValTTbarPileUpGENSIMRECO = cms.untracked.vstring(
-    #pickRelValInputFiles( cmsswVersion  = 'CMSSW_7_2_0_pre5'
+    #pickRelValInputFiles( cmsswVersion  = 'CMSSW_7_2_0_pre7'
                         #, relVal        = 'RelValTTbar_13'
-                        #, globalTag     = 'PU50ns_POSTLS172_V4'
+                        #, globalTag     = 'PU50ns_PRE_LS172_V12'
                         #, dataTier      = 'GEN-SIM-RECO'
                         #, maxVersions   = 1
                         #, numberOfFiles = 1
                         #, useDAS        = True
                         #)
-        '/store/relval/CMSSW_7_2_0_pre5/RelValTTbar_13/GEN-SIM-RECO/PU50ns_POSTLS172_V4-v1/00000/303570F4-6030-E411-B7A6-0025905A60A0.root'
+        '/store/relval/CMSSW_7_2_0_pre7/RelValTTbar_13/GEN-SIM-RECO/PU50ns_PRE_LS172_V12-v1/00000/1267B7ED-2F4E-E411-A0B9-0025905964A6.root'
     )
 
-# /SingleMu/CMSSW_7_2_0_pre5-GR_R_72_V2_RelVal_mu2012D-v1/RECO
+# /SingleMu/CMSSW_7_2_0_pre7-PRE_R_72_V6A_RelVal_mu2012D-v1/RECO # not at CERN
 filesSingleMuRECO = cms.untracked.vstring(
-    #pickRelValInputFiles( cmsswVersion  = 'CMSSW_7_2_0_pre5' # not at CERN
+    #pickRelValInputFiles( cmsswVersion  = 'CMSSW_7_2_0_pre7'
                         #, relVal        = 'SingleMu'
                         #, dataTier      = 'RECO'
-                        #, globalTag     = 'GR_R_72_V2_RelVal_mu2012D'
+                        #, globalTag     = 'PRE_R_72_V6A_RelVal_mu2012D'
                         #, maxVersions   = 1
                         #, numberOfFiles = 1
                         #, useDAS        = True
                         #)
-        '/store/relval/CMSSW_7_2_0_pre5/SingleMu/RECO/GR_R_72_V2_RelVal_mu2012D-v1/00000/002CC908-9130-E411-B785-003048FFD732.root'
+        '/store/relval/CMSSW_7_2_0_pre7/SingleMu/RECO/PRE_R_72_V6A_RelVal_mu2012D-v1/00000/00421099-5B4B-E411-923A-0025905A612C.root'
     )

--- a/PhysicsTools/PatAlgos/python/producersLayer1/jetProducer_cfi.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/jetProducer_cfi.py
@@ -42,7 +42,9 @@ patJets = cms.EDProducer("PATJetProducer",
         cms.InputTag("trackCountingHighEffBJetTags"),
         cms.InputTag("simpleSecondaryVertexHighEffBJetTags"),
         cms.InputTag("simpleSecondaryVertexHighPurBJetTags"),
-        cms.InputTag("combinedSecondaryVertexBJetTags")
+        cms.InputTag("combinedInclusiveSecondaryVertexV2BJetTags"),
+        cms.InputTag("pfCombinedSecondaryVertexBJetTags"),
+        cms.InputTag("combinedMVABJetTags")
     ),
     # clone tag infos ATTENTION: these take lots of space!
     # usually the discriminators from the default algos

--- a/TopQuarkAnalysis/TopEventSelection/test/ttFullHadSignalSelMVAComputer_cfg.py
+++ b/TopQuarkAnalysis/TopEventSelection/test/ttFullHadSignalSelMVAComputer_cfg.py
@@ -8,55 +8,59 @@ process.MessageLogger.cerr.threshold = 'INFO'
 process.MessageLogger.cerr.FwkReport.reportEvery = 1000
 
 ## define input
+from TopQuarkAnalysis.TopEventProducers.tqafInputFiles_cff import relValTTbar
 process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring(
-    #'/store/relval/CMSSW_7_1_0_pre1/RelValProdTTbar/GEN-SIM-RECO/START70_V5-v1/00000/14842A6B-2086-E311-B5CB-02163E00E8DA.root'
-
-    #'/store/user/eschliec/Summer09/7TeV/TTBar/MCatNLO/patTuple_1.root',
-    #'/store/user/eschliec/Summer09/7TeV/TTBar/MCatNLO/patTuple_2.root'
-
-    '/store/user/eschliec/Summer09/7TeV/QCD/pt0015-pythia/patTuple_1.root',
-    '/store/user/eschliec/Summer09/7TeV/QCD/pt0015-pythia/patTuple_4.root',
-    '/store/user/eschliec/Summer09/7TeV/QCD/pt0015-pythia/patTuple_8.root',
-    '/store/user/eschliec/Summer09/7TeV/QCD/pt0015-pythia/patTuple_7.root',
-    '/store/user/eschliec/Summer09/7TeV/QCD/pt0015-pythia/patTuple_3.root',
-    '/store/user/eschliec/Summer09/7TeV/QCD/pt0015-pythia/patTuple_6.root',
-    '/store/user/eschliec/Summer09/7TeV/QCD/pt0015-pythia/patTuple_9.root',
-    '/store/user/eschliec/Summer09/7TeV/QCD/pt0015-pythia/patTuple_2.root',
-    '/store/user/eschliec/Summer09/7TeV/QCD/pt0015-pythia/patTuple_5.root',
-    '/store/user/eschliec/Summer09/7TeV/QCD/pt0015-pythia/patTuple_10.root',
-    '/store/user/eschliec/Summer09/7TeV/QCD/pt0015-pythia/patTuple_14.root',
-    '/store/user/eschliec/Summer09/7TeV/QCD/pt0015-pythia/patTuple_12.root',
-    '/store/user/eschliec/Summer09/7TeV/QCD/pt0015-pythia/patTuple_13.root',
-    '/store/user/eschliec/Summer09/7TeV/QCD/pt0015-pythia/patTuple_11.root'
-
-    #'/store/user/eschliec/Summer09/7TeV/QCD/pt1400-pythia/patTuple_1.root',
-    #'/store/user/eschliec/Summer09/7TeV/QCD/pt1400-pythia/patTuple_4.root',
-    #'/store/user/eschliec/Summer09/7TeV/QCD/pt1400-pythia/patTuple_8.root',
-    #'/store/user/eschliec/Summer09/7TeV/QCD/pt1400-pythia/patTuple_7.root',
-    #'/store/user/eschliec/Summer09/7TeV/QCD/pt1400-pythia/patTuple_3.root',
-    #'/store/user/eschliec/Summer09/7TeV/QCD/pt1400-pythia/patTuple_6.root',
-    #'/store/user/eschliec/Summer09/7TeV/QCD/pt1400-pythia/patTuple_9.root',
-    #'/store/user/eschliec/Summer09/7TeV/QCD/pt1400-pythia/patTuple_2.root',
-    #'/store/user/eschliec/Summer09/7TeV/QCD/pt1400-pythia/patTuple_5.root',
-    #'/store/user/eschliec/Summer09/7TeV/QCD/pt1400-pythia/patTuple_10.root',
-    #'/store/user/eschliec/Summer09/7TeV/QCD/pt1400-pythia/patTuple_14.root',
-    #'/store/user/eschliec/Summer09/7TeV/QCD/pt1400-pythia/patTuple_12.root',
-    #'/store/user/eschliec/Summer09/7TeV/QCD/pt1400-pythia/patTuple_13.root',
-    #'/store/user/eschliec/Summer09/7TeV/QCD/pt1400-pythia/patTuple_11.root',
-    #'/store/user/eschliec/Summer09/7TeV/QCD/pt1400-pythia/patTuple_15.root',
-    #'/store/user/eschliec/Summer09/7TeV/QCD/pt1400-pythia/patTuple_16.root',
-    #'/store/user/eschliec/Summer09/7TeV/QCD/pt1400-pythia/patTuple_17.root',
-    #'/store/user/eschliec/Summer09/7TeV/QCD/pt1400-pythia/patTuple_18.root',
-    #'/store/user/eschliec/Summer09/7TeV/QCD/pt1400-pythia/patTuple_19.root',
-    #'/store/user/eschliec/Summer09/7TeV/QCD/pt1400-pythia/patTuple_20.root',
-    #'/store/user/eschliec/Summer09/7TeV/QCD/pt1400-pythia/patTuple_24.root',
-    #'/store/user/eschliec/Summer09/7TeV/QCD/pt1400-pythia/patTuple_22.root',
-    #'/store/user/eschliec/Summer09/7TeV/QCD/pt1400-pythia/patTuple_23.root',
-    #'/store/user/eschliec/Summer09/7TeV/QCD/pt1400-pythia/patTuple_21.root'
-     ),
-     skipEvents = cms.untracked.uint32(0)
+    fileNames = cms.untracked.vstring(relValTTbar)
 )
+#process.source = cms.Source("PoolSource",
+    #fileNames = cms.untracked.vstring(
+    ##'/store/relval/CMSSW_7_1_0_pre1/RelValProdTTbar/GEN-SIM-RECO/START70_V5-v1/00000/14842A6B-2086-E311-B5CB-02163E00E8DA.root'
+
+    ##'/store/user/eschliec/Summer09/7TeV/TTBar/MCatNLO/patTuple_1.root',
+    ##'/store/user/eschliec/Summer09/7TeV/TTBar/MCatNLO/patTuple_2.root'
+
+    #'/store/user/eschliec/Summer09/7TeV/QCD/pt0015-pythia/patTuple_1.root',
+    #'/store/user/eschliec/Summer09/7TeV/QCD/pt0015-pythia/patTuple_4.root',
+    #'/store/user/eschliec/Summer09/7TeV/QCD/pt0015-pythia/patTuple_8.root',
+    #'/store/user/eschliec/Summer09/7TeV/QCD/pt0015-pythia/patTuple_7.root',
+    #'/store/user/eschliec/Summer09/7TeV/QCD/pt0015-pythia/patTuple_3.root',
+    #'/store/user/eschliec/Summer09/7TeV/QCD/pt0015-pythia/patTuple_6.root',
+    #'/store/user/eschliec/Summer09/7TeV/QCD/pt0015-pythia/patTuple_9.root',
+    #'/store/user/eschliec/Summer09/7TeV/QCD/pt0015-pythia/patTuple_2.root',
+    #'/store/user/eschliec/Summer09/7TeV/QCD/pt0015-pythia/patTuple_5.root',
+    #'/store/user/eschliec/Summer09/7TeV/QCD/pt0015-pythia/patTuple_10.root',
+    #'/store/user/eschliec/Summer09/7TeV/QCD/pt0015-pythia/patTuple_14.root',
+    #'/store/user/eschliec/Summer09/7TeV/QCD/pt0015-pythia/patTuple_12.root',
+    #'/store/user/eschliec/Summer09/7TeV/QCD/pt0015-pythia/patTuple_13.root',
+    #'/store/user/eschliec/Summer09/7TeV/QCD/pt0015-pythia/patTuple_11.root'
+
+    ##'/store/user/eschliec/Summer09/7TeV/QCD/pt1400-pythia/patTuple_1.root',
+    ##'/store/user/eschliec/Summer09/7TeV/QCD/pt1400-pythia/patTuple_4.root',
+    ##'/store/user/eschliec/Summer09/7TeV/QCD/pt1400-pythia/patTuple_8.root',
+    ##'/store/user/eschliec/Summer09/7TeV/QCD/pt1400-pythia/patTuple_7.root',
+    ##'/store/user/eschliec/Summer09/7TeV/QCD/pt1400-pythia/patTuple_3.root',
+    ##'/store/user/eschliec/Summer09/7TeV/QCD/pt1400-pythia/patTuple_6.root',
+    ##'/store/user/eschliec/Summer09/7TeV/QCD/pt1400-pythia/patTuple_9.root',
+    ##'/store/user/eschliec/Summer09/7TeV/QCD/pt1400-pythia/patTuple_2.root',
+    ##'/store/user/eschliec/Summer09/7TeV/QCD/pt1400-pythia/patTuple_5.root',
+    ##'/store/user/eschliec/Summer09/7TeV/QCD/pt1400-pythia/patTuple_10.root',
+    ##'/store/user/eschliec/Summer09/7TeV/QCD/pt1400-pythia/patTuple_14.root',
+    ##'/store/user/eschliec/Summer09/7TeV/QCD/pt1400-pythia/patTuple_12.root',
+    ##'/store/user/eschliec/Summer09/7TeV/QCD/pt1400-pythia/patTuple_13.root',
+    ##'/store/user/eschliec/Summer09/7TeV/QCD/pt1400-pythia/patTuple_11.root',
+    ##'/store/user/eschliec/Summer09/7TeV/QCD/pt1400-pythia/patTuple_15.root',
+    ##'/store/user/eschliec/Summer09/7TeV/QCD/pt1400-pythia/patTuple_16.root',
+    ##'/store/user/eschliec/Summer09/7TeV/QCD/pt1400-pythia/patTuple_17.root',
+    ##'/store/user/eschliec/Summer09/7TeV/QCD/pt1400-pythia/patTuple_18.root',
+    ##'/store/user/eschliec/Summer09/7TeV/QCD/pt1400-pythia/patTuple_19.root',
+    ##'/store/user/eschliec/Summer09/7TeV/QCD/pt1400-pythia/patTuple_20.root',
+    ##'/store/user/eschliec/Summer09/7TeV/QCD/pt1400-pythia/patTuple_24.root',
+    ##'/store/user/eschliec/Summer09/7TeV/QCD/pt1400-pythia/patTuple_22.root',
+    ##'/store/user/eschliec/Summer09/7TeV/QCD/pt1400-pythia/patTuple_23.root',
+    ##'/store/user/eschliec/Summer09/7TeV/QCD/pt1400-pythia/patTuple_21.root'
+     #),
+     #skipEvents = cms.untracked.uint32(0)
+#)
 ## define maximal number of events to loop over
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(10000)


### PR DESCRIPTION
After new b-tag discriminators have been added to 720pre7 at RECO level with #5446 , they are also added to the default PAT with the required updated input.
This PR supersedes #5729 .
