### PR TITLE
Update cfgs to fix module run order problem when used with hltGetConfigu...

### DIFF
--- a/L1Trigger/L1TCalorimeter/python/L1TCaloStage1_PPFromRaw_cff.py
+++ b/L1Trigger/L1TCalorimeter/python/L1TCaloStage1_PPFromRaw_cff.py
@@ -21,12 +21,6 @@ from L1Trigger.L1TCalorimeter.L1TCaloStage1_cff import *
 rctUpgradeFormatDigis.regionTag = cms.InputTag("simRctDigis")
 rctUpgradeFormatDigis.emTag = cms.InputTag("simRctDigis")
 
-# GT
-from L1Trigger.Configuration.SimL1Emulator_cff import simGtDigis
-simGtDigis.GmtInputTag = 'gtDigis'
-simGtDigis.GctInputTag = 'caloStage1LegacyFormatDigis'
-simGtDigis.TechnicalTriggersInputTags = cms.VInputTag( )
-
 # L1Extra
 import L1Trigger.Configuration.L1Extra_cff
 l1ExtraLayer2 = L1Trigger.Configuration.L1Extra_cff.l1extraParticles.clone()
@@ -51,5 +45,4 @@ L1TCaloStage1_PPFromRaw = cms.Sequence(
     +ecalDigis
     +simRctDigis
     +L1TCaloStage1
-    +simGtDigis
 )

--- a/L1Trigger/L1TCalorimeter/test/SimL1Emulator_Stage1.py
+++ b/L1Trigger/L1TCalorimeter/test/SimL1Emulator_Stage1.py
@@ -46,8 +46,17 @@ process.GlobalTag.globaltag = cms.string('POSTLS162_V2::All')
 
 process.load('L1Trigger.L1TCalorimeter.L1TCaloStage1_PPFromRaw_cff')
 
+# GT
+from L1Trigger.Configuration.SimL1Emulator_cff import simGtDigis
+process.simGtDigis = simGtDigis.clone()
+process.simGtDigis.GmtInputTag = 'simGmtDigis'
+process.simGtDigis.GctInputTag = 'caloStage1LegacyFormatDigis'
+process.simGtDigis.TechnicalTriggersInputTags = cms.VInputTag( )
+
+
 process.p1 = cms.Path(
     process.L1TCaloStage1_PPFromRaw
+    +process.simGtDigis
     +process.l1ExtraLayer2
     )
 


### PR DESCRIPTION
...ration script. The updates introduced in PRs 5745 and 5752 introduced a bug that breaks the muon emulation in the HLT paths (the GT emulator ran before the GMT emulator)
