### PR TITLE
Add module geometry to tt

### DIFF
--- a/DataFormats/TrackerCommon/interface/TrackerTopology.h
+++ b/DataFormats/TrackerCommon/interface/TrackerTopology.h
@@ -462,6 +462,9 @@ class TrackerTopology {
 
   std::string print(DetId detid) const;
 
+  SiStripDetId::ModuleGeometry moduleGeometry(const DetId &id) const; 
+
+
  private:
 
   PixelBarrelValues pbVals_;

--- a/DataFormats/TrackerCommon/interface/TrackerTopology.h
+++ b/DataFormats/TrackerCommon/interface/TrackerTopology.h
@@ -464,7 +464,6 @@ class TrackerTopology {
 
   SiStripDetId::ModuleGeometry moduleGeometry(const DetId &id) const; 
 
-
  private:
 
   PixelBarrelValues pbVals_;

--- a/DataFormats/TrackerCommon/src/TrackerTopology.cc
+++ b/DataFormats/TrackerCommon/src/TrackerTopology.cc
@@ -163,3 +163,27 @@ std::string TrackerTopology::print(DetId id) const {
   return strstr.str();
 }
 
+
+SiStripDetId::ModuleGeometry TrackerTopology::moduleGeometry(const DetId &id) const {
+  switch(subDetector()) {
+  case StripSubdetector::TIB: return tibLayer(id)<3? SiStripDetId::IB1 : SiStripDetId::IB2;
+  case StripSubdetector::TOB: return tobLayer(id)<5? SiStripDetId::OB2 : SiStripDetId::OB1;
+  case StripSubdetector::TID: switch (tidRing(id)) {
+    case 1: return SiStripDetId::W1A;
+    case 2: return SiStripDetId::W2A;
+    case 3: return SiStripDetId::W3A;
+    }
+  case StripSubdetector::TEC: switch (tecRing(id)) {
+    case 1: return SiStripDetId::W1B;
+    case 2: return SiStripDetId::W2B;
+    case 3: return SiStripDetId::W3B;
+    case 4: return SiStripDetId::W4;
+    case 5: return SiStripDetId::W5;
+    case 6: return SiStripDetId::W6;
+    case 7: return SiStripDetId::W7;
+    }
+  case UNKNOWN: default: return SiStripDetId::UNKNOWNGEOMETRY;
+  }
+  return SiStripDetId::UNKNOWNGEOMETRY;
+}
+

--- a/DataFormats/TrackerCommon/src/TrackerTopology.cc
+++ b/DataFormats/TrackerCommon/src/TrackerTopology.cc
@@ -165,7 +165,7 @@ std::string TrackerTopology::print(DetId id) const {
 
 
 SiStripDetId::ModuleGeometry TrackerTopology::moduleGeometry(const DetId &id) const {
-  switch(subDetector()) {
+  switch(id.subdetId()) {
   case StripSubdetector::TIB: return tibLayer(id)<3? SiStripDetId::IB1 : SiStripDetId::IB2;
   case StripSubdetector::TOB: return tobLayer(id)<5? SiStripDetId::OB2 : SiStripDetId::OB1;
   case StripSubdetector::TID: switch (tidRing(id)) {
@@ -182,7 +182,6 @@ SiStripDetId::ModuleGeometry TrackerTopology::moduleGeometry(const DetId &id) co
     case 6: return SiStripDetId::W6;
     case 7: return SiStripDetId::W7;
     }
-  case UNKNOWN: default: return SiStripDetId::UNKNOWNGEOMETRY;
   }
   return SiStripDetId::UNKNOWNGEOMETRY;
 }


### PR DESCRIPTION
I had forgotten the moduleGeometry(DetId) method a year or so ago in TrackerTopology. Adding it (Thanks to Vincenzo for noticing)
