### PR TITLE
Interface changes to go with Pythia 8.200 official release (73x)

### DIFF
--- a/Configuration/Generator/python/Pythia8CommonSettings_cfi.py
+++ b/Configuration/Generator/python/Pythia8CommonSettings_cfi.py
@@ -9,6 +9,5 @@ pythia8CommonSettingsBlock = cms.PSet(
       'ParticleDecays:limitTau0 = on',
       'ParticleDecays:tau0Max = 10',
       'ParticleDecays:allowPhotonRadiation = on',
-      'ParticleDecays:tauIgnoreSpinUpCMSSW = on',
     )
 )

--- a/GeneratorInterface/Pythia8Interface/plugins/LHAupLesHouches.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/LHAupLesHouches.cc
@@ -65,6 +65,8 @@ bool LHAupLesHouches::setEvent(int inProcId, double mRecalculate)
 
   const std::vector<float> &scales = event->scales();
   
+  bool doRecalculate = (mRecalculate > 0.);
+  
   unsigned int iscale = 0;
   for(int i = 0; i < hepeup.NUP; i++) {
     //retrieve scale corresponding to each particle
@@ -81,12 +83,25 @@ bool LHAupLesHouches::setEvent(int inProcId, double mRecalculate)
       scalein = scales[iscale];
       ++iscale;
     }
+    
+    double energy = hepeup.PUP[i][3];
+    double mass = hepeup.PUP[i][4];
+    
+    // Optionally recalculate mass from four-momentum.
+    if (doRecalculate && mass > mRecalculate) {
+      mass = sqrtpos( energy*energy - hepeup.PUP[i][0]*hepeup.PUP[i][0] - hepeup.PUP[i][1]*hepeup.PUP[i][1] - hepeup.PUP[i][2]*hepeup.PUP[i][2]);
+    }
+    // If not, recalculate energy from three-momentum and mass.
+    else {
+      energy = sqrt( hepeup.PUP[i][0]*hepeup.PUP[i][0] + hepeup.PUP[i][1]*hepeup.PUP[i][1] + hepeup.PUP[i][2]*hepeup.PUP[i][2] + mass*mass);
+    }
+    
     addParticle(hepeup.IDUP[i], hepeup.ISTUP[i],
                 hepeup.MOTHUP[i].first, hepeup.MOTHUP[i].second,
                 hepeup.ICOLUP[i].first, hepeup.ICOLUP[i].second,
                 hepeup.PUP[i][0], hepeup.PUP[i][1],
-                hepeup.PUP[i][2], hepeup.PUP[i][3],
-                hepeup.PUP[i][4], hepeup.VTIMUP[i],
+                hepeup.PUP[i][2], energy,
+                mass, hepeup.VTIMUP[i],
                 hepeup.SPINUP[i],scalein);
   }
   

--- a/GeneratorInterface/Pythia8Interface/plugins/LHAupLesHouches.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/LHAupLesHouches.cc
@@ -67,9 +67,6 @@ bool LHAupLesHouches::setEvent(int inProcId, double mRecalculate)
   
   unsigned int iscale = 0;
   for(int i = 0; i < hepeup.NUP; i++) {
-    //override spinup flag if so configured
-    double spinup = (std::abs(hepeup.IDUP[i])==15 && ignoreTauSpinUp_) ? 9. : hepeup.SPINUP[i];
-        
     //retrieve scale corresponding to each particle
     double scalein = -1.;
     
@@ -90,7 +87,7 @@ bool LHAupLesHouches::setEvent(int inProcId, double mRecalculate)
                 hepeup.PUP[i][0], hepeup.PUP[i][1],
                 hepeup.PUP[i][2], hepeup.PUP[i][3],
                 hepeup.PUP[i][4], hepeup.VTIMUP[i],
-                spinup, scalein);
+                hepeup.SPINUP[i],scalein);
   }
   
   infoPtr->eventAttributes->clear();

--- a/GeneratorInterface/Pythia8Interface/plugins/LHAupLesHouches.h
+++ b/GeneratorInterface/Pythia8Interface/plugins/LHAupLesHouches.h
@@ -21,7 +21,7 @@
 
 class LHAupLesHouches : public Pythia8::LHAup {
   public:
-    LHAupLesHouches() : ignoreTauSpinUp_(false) {;}
+    LHAupLesHouches() {;}
 
     //void loadRunInfo(const boost::shared_ptr<lhef::LHERunInfo> &runInfo)
     void loadRunInfo(lhef::LHERunInfo* runInfo)
@@ -30,16 +30,12 @@ class LHAupLesHouches : public Pythia8::LHAup {
     //void loadEvent(const boost::shared_ptr<lhef::LHEEvent> &event)
     void loadEvent(lhef::LHEEvent* event)
       { this->event = event; }
-      
-    void setIgnoreTauSpinUp(bool b) { ignoreTauSpinUp_ = b; }
 
   private:
 
     bool setInit();
     bool setEvent(int idProcIn, double mRecalculate = -1.);
 
-    bool ignoreTauSpinUp_;
-    
     //boost::shared_ptr<lhef::LHERunInfo> runInfo;
     lhef::LHERunInfo* runInfo;
     //boost::shared_ptr<lhef::LHEEvent>	event;

--- a/GeneratorInterface/Pythia8Interface/plugins/Pythia8Hadronizer.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Pythia8Hadronizer.cc
@@ -407,10 +407,7 @@ bool Pythia8Hadronizer::initializeForExternalPartons()
   } else {
 
     lhaUP.reset(new LHAupLesHouches());
-    lhaUP->setIgnoreTauSpinUp(fMasterGen->settings.flag("ParticleDecays:tauIgnoreSpinUpCMSSW"));
     lhaUP->loadRunInfo(lheRunInfo());
-
-    
     
     if ( fJetMatchingHook )
     {

--- a/GeneratorInterface/Pythia8Interface/src/Py8InterfaceBase.cc
+++ b/GeneratorInterface/Pythia8Interface/src/Py8InterfaceBase.cc
@@ -12,8 +12,6 @@ Py8InterfaceBase::Py8InterfaceBase( edm::ParameterSet const& ps )
   fMasterGen.reset(new Pythia);
   fDecayer.reset(new Pythia);
 
-  fMasterGen->settings.addFlag("ParticleDecays:tauIgnoreSpinUpCMSSW",false);
-  
   fMasterGen->readString("Next:numberShowEvent = 0");
   fDecayer->readString("Next:numberShowEvent = 0");
 


### PR DESCRIPTION
Revert a workaround which is no longer needed, and bring the LHE->pythia8 interface in line with the latest changes to pythia8 standalone for what concerns energy-momentum-mass treatment of LHE input.
