### PR TITLE
DataFormats/Common: edm::WrapperBase class version updated

### DIFF
--- a/DataFormats/Common/src/classes_def.xml
+++ b/DataFormats/Common/src/classes_def.xml
@@ -1,5 +1,6 @@
 <lcgdict>
- <class name="edm::WrapperBase" ClassVersion="3">
+ <class name="edm::WrapperBase" ClassVersion="4">
+  <version ClassVersion="4" checksum="3914746810"/>
   <version ClassVersion="2" checksum="2150796830"/>
   <version ClassVersion="3" checksum="1936948526"/>
  </class>


### PR DESCRIPTION
This should fix the compilation errors in 7_3_DEVEL_X. @Dr15Jones, @ktf 

https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc6_amd64_gcc481/CMSSW_7_3_DEVEL_X_2014-10-13-1400/DataFormats/Common
