### PR TITLE
Extend FED id for pixels

### DIFF
--- a/DataFormats/FEDRawData/interface/FEDNumbering.h
+++ b/DataFormats/FEDRawData/interface/FEDNumbering.h
@@ -35,7 +35,7 @@ class FEDNumbering {
      NOT_A_FEDID = -1,
      MAXFEDID = 1350, // must be larger than largest used FED id
      MINSiPixelFEDID = 0,
-     MAXSiPixelFEDID = 39,
+     MAXSiPixelFEDID = 40,  // increase from 39 for the pilot blade fed
      MINSiStripFEDID = 50,
      MAXSiStripFEDID = 489,
      MINPreShowerFEDID = 520,

--- a/DataFormats/SiPixelDetId/interface/PixelBarrelName.h
+++ b/DataFormats/SiPixelDetId/interface/PixelBarrelName.h
@@ -19,14 +19,14 @@ public:
   enum Shell { mO = 1, mI = 2 , pO =3 , pI =4 };
 
   /// ctor from DetId
-  PixelBarrelName(const DetId &);
+  PixelBarrelName(const DetId &, bool phase=false);
 
-  PixelBarrelName(const DetId &, const TrackerTopology* tt);
+  PixelBarrelName(const DetId &, const TrackerTopology* tt, bool phase=false);
 
   /// ctor for defined name with dummy parameters
-  PixelBarrelName(Shell shell=mO, int layer=0, int module=0, int ladder=0)
-    : PixelModuleName(true), 
-      thePart(shell), theLayer(layer), theModule(module), theLadder(ladder) 
+ PixelBarrelName(Shell shell=mO, int layer=0, int module=0, int ladder=0, bool phase=false)
+   : PixelModuleName(true), 
+    thePart(shell), theLayer(layer), theModule(module), theLadder(ladder), phase1(phase) 
   { }
 
   /// ctor from name string
@@ -69,6 +69,7 @@ public:
 private:
   Shell thePart;
   int theLayer, theModule, theLadder;
+  bool phase1;
 };
 
 std::ostream & operator<<( std::ostream& out, const PixelBarrelName::Shell& t);

--- a/DataFormats/SiPixelDetId/interface/PixelBarrelName.h
+++ b/DataFormats/SiPixelDetId/interface/PixelBarrelName.h
@@ -6,8 +6,10 @@
  */
 
 #include "DataFormats/SiPixelDetId/interface/PixelModuleName.h"
-#include <string>
 #include "DataFormats/SiPixelDetId/interface/PXBDetId.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+
+#include <string>
 
 class DetId; 
 
@@ -19,6 +21,8 @@ public:
   /// ctor from DetId
   PixelBarrelName(const DetId &);
 
+  PixelBarrelName(const DetId &, const TrackerTopology* tt);
+
   /// ctor for defined name with dummy parameters
   PixelBarrelName(Shell shell=mO, int layer=0, int module=0, int ladder=0)
     : PixelModuleName(true), 
@@ -29,6 +33,8 @@ public:
   PixelBarrelName(std::string name);
 
   virtual ~PixelBarrelName() { }
+
+  inline int convertLadderNumber(int oldLadder);
 
   /// from base class
   virtual std::string name() const;
@@ -55,6 +61,7 @@ public:
 
   /// return the DetId
   PXBDetId getDetId();
+  DetId getDetId(const TrackerTopology* tt);
 
   /// check equality of modules from datamemebers
   virtual bool operator== (const PixelModuleName &) const;

--- a/DataFormats/SiPixelDetId/interface/PixelEndcapName.h
+++ b/DataFormats/SiPixelDetId/interface/PixelEndcapName.h
@@ -4,12 +4,12 @@
 /** \class PixelEndcapName
  * Endcap Module name (as in PixelDatabase) for endcaps
  */
-
 #include "DataFormats/SiPixelDetId/interface/PixelModuleName.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "DataFormats/SiPixelDetId/interface/PXFDetId.h"
 
 #include <string>
 #include <iostream>
-#include "DataFormats/SiPixelDetId/interface/PXFDetId.h"
 
 class DetId;
 
@@ -20,6 +20,7 @@ public:
 
   /// ctor from DetId
   PixelEndcapName(const DetId &);
+  PixelEndcapName(const DetId &, const TrackerTopology* tt);
   
   /// ctor for defined name
   PixelEndcapName( HalfCylinder part = mO, int disk =0, int blade =0, int pannel=0, int plaq=0) 
@@ -49,11 +50,15 @@ public:
   /// plaquetteId (in pannel)
   int plaquetteName() const { return thePlaquette; }
 
+  /// ring Id
+  int ringName() const { return theRing; }
+
   /// module Type
    virtual PixelModuleName::ModuleType  moduleType() const;
 
   /// return DetId
   PXFDetId getDetId(); 
+  DetId getDetId(const TrackerTopology* tt); 
 
   /// check equality of modules from datamemebers
   virtual bool operator== (const PixelModuleName &) const;
@@ -61,7 +66,7 @@ public:
 
 private:
   HalfCylinder thePart;
-  int theDisk, theBlade, thePannel, thePlaquette;
+  int theDisk, theBlade, thePannel, thePlaquette, theRing;
 };
 
 std::ostream & operator<<( std::ostream& out, const PixelEndcapName::HalfCylinder & t);

--- a/DataFormats/SiPixelDetId/interface/PixelEndcapName.h
+++ b/DataFormats/SiPixelDetId/interface/PixelEndcapName.h
@@ -19,13 +19,15 @@ public:
   enum HalfCylinder { mO = 1, mI = 2 , pO =3 , pI =4 };
 
   /// ctor from DetId
-  PixelEndcapName(const DetId &);
-  PixelEndcapName(const DetId &, const TrackerTopology* tt);
+  PixelEndcapName(const DetId &, bool phase=false);
+  PixelEndcapName(const DetId &, const TrackerTopology* tt, bool phase=false);
   
   /// ctor for defined name
-  PixelEndcapName( HalfCylinder part = mO, int disk =0, int blade =0, int pannel=0, int plaq=0) 
+  PixelEndcapName( HalfCylinder part = mO, int disk =0, int blade =0, int pannel=0, 
+		   int plaq=0, bool phase=false) 
     : PixelModuleName(false), 
-      thePart(part), theDisk(disk), theBlade(blade), thePannel(pannel), thePlaquette(plaq)
+      thePart(part), theDisk(disk), theBlade(blade), thePannel(pannel), 
+    thePlaquette(plaq), phase1(phase)
   { }
 
   /// ctor from name string
@@ -51,7 +53,7 @@ public:
   int plaquetteName() const { return thePlaquette; }
 
   /// ring Id
-  int ringName() const { return theRing; }
+  int ringName() const { return thePannel; }
 
   /// module Type
    virtual PixelModuleName::ModuleType  moduleType() const;
@@ -66,7 +68,8 @@ public:
 
 private:
   HalfCylinder thePart;
-  int theDisk, theBlade, thePannel, thePlaquette, theRing;
+  int theDisk, theBlade, thePannel, thePlaquette;
+  bool phase1;
 };
 
 std::ostream & operator<<( std::ostream& out, const PixelEndcapName::HalfCylinder & t);

--- a/DataFormats/SiPixelDetId/interface/PixelPannelType.h
+++ b/DataFormats/SiPixelDetId/interface/PixelPannelType.h
@@ -5,7 +5,7 @@
 
 class PixelPannelType {
 public:
-  enum PannelType { p3L, p3R, p4L, p4R, 2x8 };
+  enum PannelType { p3L, p3R, p4L, p4R, p2x8 };
 
   static PannelType pannelType( const PixelEndcapName & name) {
     PannelType type = (name.pannelName()==1) ? p4L : p3L;

--- a/DataFormats/SiPixelDetId/interface/PixelPannelType.h
+++ b/DataFormats/SiPixelDetId/interface/PixelPannelType.h
@@ -5,7 +5,7 @@
 
 class PixelPannelType {
 public:
-  enum PannelType { p3L, p3R, p4L, p4R };
+  enum PannelType { p3L, p3R, p4L, p4R, 2x8 };
 
   static PannelType pannelType( const PixelEndcapName & name) {
     PannelType type = (name.pannelName()==1) ? p4L : p3L;

--- a/DataFormats/SiPixelDetId/src/PixelBarrelName.cc
+++ b/DataFormats/SiPixelDetId/src/PixelBarrelName.cc
@@ -16,13 +16,12 @@ namespace {
   const int lL[2][12] ={{5,15,26, 8,24,41,11,33,56, 0, 0, 0},
 			{3, 9,16, 7,21,36,11,33,56,16,48,81}};
   // for phase 1
-  //const int lL[12] ={ 3, 9,16, 7,21,36,11,33,56,16,48,81};
-  
-  const bool phase1 = false; // this has to come from the trackerTopology class 
+  //const int lL[12] ={ 3, 9,16, 7,21,36,11,33,56,16,48,81};  
+  //const bool phase1 = false; // this has to come from the trackerTopology class 
 }
 
-PixelBarrelName::PixelBarrelName(const DetId & id, const TrackerTopology* tt) 
-  : PixelModuleName(true)
+PixelBarrelName::PixelBarrelName(const DetId & id, const TrackerTopology* tt, bool phase) 
+  : PixelModuleName(true), phase1(phase)
 {
 
   theLayer = tt->pxbLayer(id);
@@ -54,8 +53,8 @@ PixelBarrelName::PixelBarrelName(const DetId & id, const TrackerTopology* tt)
 
 }
 
-PixelBarrelName::PixelBarrelName(const DetId & id) 
-  : PixelModuleName(true)
+PixelBarrelName::PixelBarrelName(const DetId & id, bool phase) 
+  : PixelModuleName(true), phase1(phase)
 {
  
 //  uint32_t rawId = id.rawId(); 

--- a/DataFormats/SiPixelDetId/src/PixelBarrelName.cc
+++ b/DataFormats/SiPixelDetId/src/PixelBarrelName.cc
@@ -1,13 +1,58 @@
 #include "DataFormats/SiPixelDetId/interface/PixelBarrelName.h"
 
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+//#include "DataFormats/SiPixelDetId/interface/PXBDetId.h"
+//#include "DataFormats/TarckerCommon/interface/TarckerTopology.h"
+
 #include <sstream>
 #include <iostream>
 
-#include "DataFormats/SiPixelDetId/interface/PXBDetId.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-
 using namespace std;
+ 
+namespace {
+  // ladder limits
+  // for phase 0
+  const int lL[2][12] ={{5,15,26, 8,24,41,11,33,56, 0, 0, 0},
+			{3, 9,16, 7,21,36,11,33,56,16,48,81}};
+  // for phase 1
+  //const int lL[12] ={ 3, 9,16, 7,21,36,11,33,56,16,48,81};
+  
+  const bool phase1 = false; // this has to come from the trackerTopology class 
+}
 
+PixelBarrelName::PixelBarrelName(const DetId & id, const TrackerTopology* tt) 
+  : PixelModuleName(true)
+{
+
+  theLayer = tt->pxbLayer(id);
+  int oldModule = tt->pxbModule(id) -4; if (oldModule<=0) oldModule--;
+  int oldLadder = tt->pxbLadder(id);
+
+  //cout<<oldLadder<<" "<<oldModule<<endl;
+
+  int ladder = convertLadderNumber(oldLadder);
+
+  //
+  // part
+  //
+  if      (oldModule < 0 && ladder < 0) thePart = mO; 
+  else if (oldModule > 0 && ladder < 0) thePart = pO;
+  else if (oldModule < 0 && ladder > 0) thePart = mI;
+  else if (oldModule > 0 && ladder > 0) thePart = pI;
+  
+
+  //
+  // ladder
+  //
+  theLadder = abs(ladder);
+
+  //
+  // module
+  //
+  theModule = abs(oldModule);
+
+}
 
 PixelBarrelName::PixelBarrelName(const DetId & id) 
   : PixelModuleName(true)
@@ -16,28 +61,54 @@ PixelBarrelName::PixelBarrelName(const DetId & id)
 //  uint32_t rawId = id.rawId(); 
   PXBDetId cmssw_numbering(id);
 
-
   theLayer = cmssw_numbering.layer();
 
   int oldModule = cmssw_numbering.module() -4; if (oldModule<=0) oldModule--;
 
   int oldLadder = cmssw_numbering.ladder();
-  if (theLayer == 1) {
-    if (oldLadder <= 5) oldLadder = 6-oldLadder;
-    else if (oldLadder >= 6 && oldLadder <= 15 ) oldLadder = 5-oldLadder;
-    else if (oldLadder >= 16) oldLadder = 26-oldLadder;
-  } 
-  else if (theLayer == 2) {
-    if (oldLadder <= 8) oldLadder = 9-oldLadder;
-    else if (oldLadder >= 9 && oldLadder <= 24) oldLadder = 8-oldLadder;
-    else if (oldLadder >= 25) oldLadder = 41-oldLadder; 
-  } 
-  else if (theLayer == 3) {
-    if (oldLadder <= 11) oldLadder = 12-oldLadder;
-    else if (oldLadder >= 12 && oldLadder <= 33) oldLadder = 11-oldLadder;
-    else if (oldLadder >= 34) oldLadder = 56-oldLadder;
-  } 
 
+  if(phase1) { // phase 1
+
+    if (theLayer == 1) {
+      if (oldLadder <= 3) oldLadder = 4-oldLadder;                                // +1, ..., +3
+      else if (oldLadder >= 4 && oldLadder <= 9 ) oldLadder = 3-oldLadder;        // -1, ..., -6
+      else if (oldLadder >= 10) oldLadder = 16-oldLadder;                         // +6, ..., +4
+    } 
+    else if (theLayer == 2) {
+      if (oldLadder <= 7) oldLadder = 8-oldLadder;
+      else if (oldLadder >= 8 && oldLadder <= 21) oldLadder = 7-oldLadder;
+      else if (oldLadder >= 22) oldLadder = 36-oldLadder; 
+    } 
+    else if (theLayer == 3) {
+      if (oldLadder <= 11) oldLadder = 12-oldLadder;
+      else if (oldLadder >= 12 && oldLadder <= 33) oldLadder = 11-oldLadder;
+      else if (oldLadder >= 34) oldLadder = 56-oldLadder;
+    } 
+    else if (theLayer == 4) {
+      if (oldLadder <= 16) oldLadder = 17-oldLadder;
+      else if (oldLadder >= 17 && oldLadder <= 48) oldLadder = 16-oldLadder;
+      else if (oldLadder >= 49) oldLadder = 81-oldLadder;
+    } 
+    
+  } else { // phase 0
+
+    if (theLayer == 1) {
+      if (oldLadder <= 5) oldLadder = 6-oldLadder;
+      else if (oldLadder >= 6 && oldLadder <= 15 ) oldLadder = 5-oldLadder;
+      else if (oldLadder >= 16) oldLadder = 26-oldLadder;
+    } 
+    else if (theLayer == 2) {
+      if (oldLadder <= 8) oldLadder = 9-oldLadder;
+      else if (oldLadder >= 9 && oldLadder <= 24) oldLadder = 8-oldLadder;
+      else if (oldLadder >= 25) oldLadder = 41-oldLadder; 
+    } 
+    else if (theLayer == 3) {
+      if (oldLadder <= 11) oldLadder = 12-oldLadder;
+      else if (oldLadder >= 12 && oldLadder <= 33) oldLadder = 11-oldLadder;
+      else if (oldLadder >= 34) oldLadder = 56-oldLadder;
+    } 
+  } // end phase 0/1
+ 
   //
   // part
   //
@@ -56,7 +127,54 @@ PixelBarrelName::PixelBarrelName(const DetId & id)
   // module
   //
   theModule = abs(oldModule);
- 
+
+}
+
+
+// convert ladder number 
+int PixelBarrelName::convertLadderNumber(int oldLadder) {
+  int ladder=-1;
+  int ind=0;
+  if(phase1) ind=1;
+
+  if (theLayer == 1) {
+    if       (oldLadder <= lL[ind][0] )                         
+      ladder =(lL[ind][0]+1)-oldLadder;
+    else if (oldLadder >= (lL[ind][0]+1) && oldLadder <= lL[ind][1]) 
+      ladder = lL[ind][0]-oldLadder;
+    else if (oldLadder >= (lL[ind][1]+1) )                      
+      ladder = lL[ind][2]-oldLadder;
+
+  } else if (theLayer == 2) {
+
+    if      (oldLadder <=  lL[ind][3])                          
+      ladder =(lL[ind][3]+1)-oldLadder;
+    else if (oldLadder >= (lL[ind][3]+1) && oldLadder <= lL[ind][4]) 
+      ladder = lL[ind][3]-oldLadder;
+    else if (oldLadder >= (lL[ind][4]+1))                       
+      ladder = lL[ind][5]-oldLadder; 
+
+  } else if (theLayer == 3) {
+
+    if      (oldLadder <=  lL[ind][6])                          
+      ladder = (lL[ind][6]+1)-oldLadder;
+    else if (oldLadder >= (lL[ind][6]+1) && oldLadder <= lL[ind][7]) 
+      ladder = lL[ind][6]-oldLadder;
+    else if (oldLadder >= (lL[ind][7]+1))                       
+      ladder = lL[ind][8]-oldLadder;
+
+  } else if (theLayer == 4) {
+
+    if      (oldLadder <=  lL[ind][9])                           
+      ladder =(lL[ind][9]+1)-oldLadder;
+    else if (oldLadder >= (lL[ind][9]+1) && oldLadder <= lL[ind][10]) 
+      ladder = lL[ind][9]-oldLadder;
+    else if (oldLadder >= (lL[ind][10]+1))                       
+      ladder = lL[ind][11]-oldLadder;
+
+  } 
+  
+  return ladder;
 }
 
 // constructor from name string
@@ -99,6 +217,7 @@ PixelBarrelName::PixelBarrelName(std::string name)
   if (layerString == "1") theLayer = 1;
   else if (layerString == "2") theLayer = 2;
   else if (layerString == "3") theLayer = 3;
+  else if (phase1 && layerString == "4") theLayer = 4;
   else {
     edm::LogError ("BadNameString|SiPixel")
       << "Unable to determine layer in PixelBarrelName::PixelBarrelName(std::string): "
@@ -107,26 +226,51 @@ PixelBarrelName::PixelBarrelName(std::string name)
 
   // find the ladder
   string ladderString = name.substr(name.find("_LDR")+4, name.find("_MOD")-name.find("_LDR")-4);
-  if (ladderString == "1H") theLadder = 1;
-  else if (ladderString == "10H" && theLayer == 1) theLadder = 10;
-  else if (ladderString == "16H" && theLayer == 2) theLadder = 16;
-  else if (ladderString == "22H" && theLayer == 3) theLadder = 22;
-  else if (ladderString.substr(ladderString.size()-1, 1) == "F") {
-    int ladderNum = atoi(ladderString.substr(0, ladderString.size() -1).c_str());
-    if (theLayer == 1 && ladderNum > 1 && ladderNum < 10) theLadder = ladderNum;
-    else if (theLayer == 2 && ladderNum > 1 && ladderNum < 16) theLadder = ladderNum;
-    else if (theLayer == 3 && ladderNum > 1 && ladderNum < 22) theLadder = ladderNum;
+
+  if(phase1) { // phase 1 ladders
+    // do we want to kee the "F" for phase1?
+    if (ladderString.substr(ladderString.size()-1, 1) == "F") {
+      int ladderNum = atoi(ladderString.substr(0, ladderString.size() -1).c_str());
+      if (theLayer == 1 && ladderNum >= 1 && ladderNum <= 6) theLadder = ladderNum;
+      else if (theLayer == 2 && ladderNum >= 1 && ladderNum <= 14) theLadder = ladderNum;
+      else if (theLayer == 3 && ladderNum >= 1 && ladderNum <= 22) theLadder = ladderNum;
+      else if (theLayer == 4 && ladderNum >= 1 && ladderNum <= 32) theLadder = ladderNum;
+      else {
+	edm::LogError ("BadNameString|SiPixel")
+	  << "Unable to determine ladder in PixelBarrelNameUpgrade::PixelBarrelName(std::string): "
+	  << name;
+      }
+    } // full ladders
+    else {
+      edm::LogError ("BadNameString|SiPixel")
+	<< "Unable to determine ladder in PixelBarrelNameUpgrade::PixelBarrelName(std::string): "
+	<< name;
+    }
+
+
+  } else { // phase 0 ladders
+
+    if (ladderString == "1H") theLadder = 1;
+    else if (ladderString == "10H" && theLayer == 1) theLadder = 10;
+    else if (ladderString == "16H" && theLayer == 2) theLadder = 16;
+    else if (ladderString == "22H" && theLayer == 3) theLadder = 22;
+    else if (ladderString.substr(ladderString.size()-1, 1) == "F") {
+      int ladderNum = atoi(ladderString.substr(0, ladderString.size() -1).c_str());
+      if (theLayer == 1 && ladderNum > 1 && ladderNum < 10) theLadder = ladderNum;
+      else if (theLayer == 2 && ladderNum > 1 && ladderNum < 16) theLadder = ladderNum;
+      else if (theLayer == 3 && ladderNum > 1 && ladderNum < 22) theLadder = ladderNum;
+      else {
+	edm::LogError ("BadNameString|SiPixel")
+	  << "Unable to determine ladder in PixelBarrelName::PixelBarrelName(std::string): "
+	  << name;
+      }
+    } // full ladders
     else {
       edm::LogError ("BadNameString|SiPixel")
 	<< "Unable to determine ladder in PixelBarrelName::PixelBarrelName(std::string): "
 	<< name;
     }
-  } // full ladders
-  else {
-    edm::LogError ("BadNameString|SiPixel")
-      << "Unable to determine ladder in PixelBarrelName::PixelBarrelName(std::string): "
-      << name;
-  }
+  } // phase0/1
 
   // find the module
   string moduleString = name.substr(name.find("_MOD")+4, name.size()-name.find("_MOD")-4);
@@ -145,43 +289,110 @@ PixelBarrelName::PixelBarrelName(std::string name)
 int PixelBarrelName::sectorName() const
 {
   int sector = 0;
+
   if (theLayer==1) {
-    switch (theLadder) {
-    case 1 : case 2: {sector = 1; break;}
-    case 3 :         {sector = 2; break;}
-    case 4 :         {sector = 3; break;}
-    case 5 :         {sector = 4; break;}
-    case 6 :         {sector = 5; break;}
-    case 7 :         {sector = 6; break;}
-    case 8 :         {sector = 7; break;}
-    case 9 : case 10:{sector = 8; break;}
-    default: ;
-    };
+
+    if(phase1) { // phase 1
+      switch (theLadder) {
+      case 1 :  {sector = 1; break;}
+      case 2 :  {sector = 2; break;}
+      case 3 :  {sector = 3; break;}
+      case 4 :  {sector = 6; break;}
+      case 5 :  {sector = 7; break;}
+      case 6 :  {sector = 8; break;}
+      default: ;
+      };
+
+    } else { // phase 0
+      switch (theLadder) {
+      case 1 : case 2: {sector = 1; break;}
+      case 3 :         {sector = 2; break;}
+      case 4 :         {sector = 3; break;}
+      case 5 :         {sector = 4; break;}
+      case 6 :         {sector = 5; break;}
+      case 7 :         {sector = 6; break;}
+      case 8 :         {sector = 7; break;}
+      case 9 : case 10:{sector = 8; break;}
+      default: ;
+      };
+    } // phase0/1
+
   } else if (theLayer==2) {
-    switch (theLadder) {
-    case  1 : case  2: {sector = 1; break;}
-    case  3 : case  4: {sector = 2; break;}
-    case  5 : case  6: {sector = 3; break;}
-    case  7 : case  8: {sector = 4; break;}
-    case  9 : case 10: {sector = 5; break;}
-    case 11 : case 12: {sector = 6; break;}
-    case 13 : case 14: {sector = 7; break;}
-    case 15 : case 16: {sector = 8; break;}
-    default: ;
-    };
+
+    if(phase1) { // phase 1
+      switch (theLadder) {
+      case  1 : case  2: {sector = 1; break;}
+      case  3 : case  4: {sector = 2; break;}
+      case  5 : case  6: {sector = 3; break;}
+      case  7 :          {sector = 4; break;}
+      case  8 :          {sector = 5; break;}
+      case  9 : case 10: {sector = 6; break;}
+      case 11 : case 12: {sector = 7; break;}
+      case 13 : case 14: {sector = 8; break;}    
+      default: ;
+      };
+
+    } else { // phase 0
+      switch (theLadder) {
+      case  1 : case  2: {sector = 1; break;}
+      case  3 : case  4: {sector = 2; break;}
+      case  5 : case  6: {sector = 3; break;}
+      case  7 : case  8: {sector = 4; break;}
+      case  9 : case 10: {sector = 5; break;}
+      case 11 : case 12: {sector = 6; break;}
+      case 13 : case 14: {sector = 7; break;}
+      case 15 : case 16: {sector = 8; break;}
+      default: ;
+      };
+    } // enad phase0/1
+
   } else if (theLayer==3) {
-    switch (theLadder) {
-    case  1 : case  2: case  3: {sector = 1; break;}
-    case  4 : case  5: case  6: {sector = 2; break;}
-    case  7 : case  8: case  9: {sector = 3; break;}
-    case 10 : case 11:          {sector = 4; break;}
-    case 12 : case 13:          {sector = 5; break;}
-    case 14 : case 15: case 16: {sector = 6; break;}
-    case 17 : case 18: case 19: {sector = 7; break;}
-    case 20 : case 21: case 22: {sector = 8; break;}
-    default: ;
-    };
-  }
+
+    if(phase1) { // phase 1
+      switch (theLadder) {
+      case  1 : case  2: case  3: {sector = 1; break;}
+      case  4 : case  5: case  6: {sector = 2; break;}
+      case  7 : case  8: case  9: {sector = 3; break;}
+      case 10 : case 11:          {sector = 4; break;}
+      case 12 : case 13:          {sector = 5; break;}
+      case 14 : case 15: case 16: {sector = 6; break;}
+      case 17 : case 18: case 19: {sector = 7; break;}
+      case 20 : case 21: case 22: {sector = 8; break;}
+      default: ;
+      };
+
+    } else { // phase 0
+      switch (theLadder) {
+      case  1 : case  2: case  3: {sector = 1; break;}
+      case  4 : case  5: case  6: {sector = 2; break;}
+      case  7 : case  8: case  9: {sector = 3; break;}
+      case 10 : case 11:          {sector = 4; break;}
+      case 12 : case 13:          {sector = 5; break;}
+      case 14 : case 15: case 16: {sector = 6; break;}
+      case 17 : case 18: case 19: {sector = 7; break;}
+      case 20 : case 21: case 22: {sector = 8; break;}
+      default: ;
+      };
+    } // end phase 0/1
+
+  } else if (theLayer==4) {
+ 
+    if(phase1) { // phase 1
+      switch (theLadder) {
+      case  1 : case  2: case  3:  case  4: {sector = 1; break;}
+      case  5 : case  6: case  7:  case  8: {sector = 2; break;}
+      case  9 : case 10: case 11:  case 12: {sector = 3; break;}
+      case 13 : case 14: case 15:  case 16: {sector = 4; break;}
+      case 17 : case 18: case 19:  case 20: {sector = 5; break;}
+      case 21 : case 22: case 23:  case 24: {sector = 6; break;}
+      case 25 : case 26: case 27:  case 28: {sector = 7; break;}
+      case 29 : case 30: case 31:  case 32: {sector = 8; break;}
+      default: ;
+      };
+    } // end phase1
+
+  } // layer
+
   return sector;
 
 }
@@ -189,10 +400,13 @@ int PixelBarrelName::sectorName() const
 bool PixelBarrelName::isHalfModule() const 
 {
   bool halfModule = false;
-  if (theLadder == 1) halfModule = true;
-  if (theLayer == 1 && theLadder == 10) halfModule = true;
-  if (theLayer == 2 && theLadder == 16) halfModule = true;
-  if (theLayer == 3 && theLadder == 22) halfModule = true;
+
+  if(!phase1) {
+    if (theLadder == 1) halfModule = true;
+    if (theLayer == 1 && theLadder == 10) halfModule = true;
+    if (theLayer == 2 && theLadder == 16) halfModule = true;
+    if (theLayer == 3 && theLadder == 22) halfModule = true;
+  }
   return halfModule;
 }
 
@@ -224,7 +438,60 @@ string PixelBarrelName::name() const
    return stm.str();
 }
 
-// return the DetId
+// return the DetId, uses the new topology class
+DetId PixelBarrelName::getDetId(const TrackerTopology* tt) {
+  uint32_t layer = 0;
+  uint32_t ladder = 0;
+  uint32_t module = 0;
+
+  layer = layerName();
+  int tmpLadder = ladderName();
+  uint32_t tmpModule = moduleName();
+
+  // translate the ladder number from the naming convention to the cmssw convention
+  bool outer = false;
+  Shell shell = thePart;
+  int ind=0;
+  if(phase1) ind=1;
+  outer = (shell == mO) || (shell == pO);
+  if (outer) {
+    if (layer == 1)
+      ladder = tmpLadder + lL[ind][0];
+    else if (layer == 2)
+      ladder = tmpLadder + lL[ind][3];
+    else if (layer == 3)
+      ladder = tmpLadder + lL[ind][6];
+    else if (layer == 4)
+      ladder = tmpLadder + lL[ind][9];
+  } // outer
+  else { // inner
+    if (layer == 1) {
+      if (tmpLadder <= lL[ind][0]) ladder = (lL[ind][0]+1) - tmpLadder;
+      else                         ladder =  lL[ind][2]    - tmpLadder;
+    } else if (layer == 2) {
+      if (tmpLadder <= lL[ind][3]) ladder = (lL[ind][3]+1) - tmpLadder;
+      else                         ladder =  lL[ind][5]    - tmpLadder;
+    } else if (layer == 3) {
+      if (tmpLadder <= lL[ind][6]) ladder = (lL[ind][6]+1) - tmpLadder;
+      else                         ladder =  lL[ind][8]    - tmpLadder;
+    } else if (layer == 4) {
+      if (tmpLadder <= lL[ind][9]) ladder = (lL[ind][9]+1) - tmpLadder;
+      else                         ladder =  lL[ind][11]   - tmpLadder;
+    } // layer 
+  } // inner
+
+  // translate the module number from naming convention to cmssw convention
+  // numbering starts at positive z
+  if (shell == pO || shell == pI)
+    module = tmpModule + 4;
+  else // negative z side
+    module = 5 - tmpModule;
+
+  DetId id = tt->pxbDetId(layer, ladder, module);
+  return id;
+}  
+
+// return the pixel DetId, obsolete, uses the old index class
 PXBDetId PixelBarrelName::getDetId() {
   
   uint32_t layer = 0;
@@ -239,28 +506,57 @@ PXBDetId PixelBarrelName::getDetId() {
   bool outer = false;
   Shell shell = thePart;
   outer = (shell == mO) || (shell == pO);
-  if (outer) {
-    if (layer == 1)
-      ladder = tmpLadder + 5;
-    else if (layer == 2)
-      ladder = tmpLadder + 8;
-    else if (layer == 3)
-      ladder = tmpLadder + 11;
-  } // outer
-  else { // inner
-    if (layer == 1) {
-      if (tmpLadder <= 5) ladder = 6 - tmpLadder;
-      else if (tmpLadder <= 10) ladder = 26 - tmpLadder;
-    } // layer 1
-    else if (layer == 2) {
-      if (tmpLadder <= 8) ladder = 9 - tmpLadder;
-      else if (tmpLadder <= 16) ladder = 41 - tmpLadder;
-    } // layer 2
-    else if (layer == 3) {
+
+  if(phase1) { // phase 1
+
+    if (outer) {  // outer
+      if (layer == 1)
+	ladder = tmpLadder + 3;
+      else if (layer == 2)
+	ladder = tmpLadder + 7;
+      else if (layer == 3)
+	ladder = tmpLadder + 11;
+      else if (layer == 4)
+	ladder = tmpLadder + 16;
+    } else { // inner
+      if (layer == 1) {
+	if (tmpLadder <= 3) ladder = 4 - tmpLadder;
+	else if (tmpLadder <= 6) ladder = 16 - tmpLadder;
+      } else if (layer == 2) {
+	if (tmpLadder <= 7) ladder = 8 - tmpLadder;
+	else if (tmpLadder <= 14) ladder = 36 - tmpLadder;
+      } else if (layer == 3) {
       if (tmpLadder <= 11) ladder = 12 - tmpLadder;
       else if (tmpLadder <= 22) ladder = 56 - tmpLadder;
-    } // layer 3
-  } // inner
+      } else if (layer == 4) {
+	if (tmpLadder <= 16) ladder = 17 - tmpLadder;
+	else if (tmpLadder <= 32) ladder = 81 - tmpLadder;
+      } // layer 
+    } // inner
+
+  } else { // phase 0
+    if (outer) { // outer 
+      if (layer == 1)
+	ladder = tmpLadder + 5;
+      else if (layer == 2)
+	ladder = tmpLadder + 8;
+      else if (layer == 3)
+	ladder = tmpLadder + 11;
+    } else { // inner
+      if (layer == 1) {  // layer 1
+	if (tmpLadder <= 5) ladder = 6 - tmpLadder;
+	else if (tmpLadder <= 10) ladder = 26 - tmpLadder;
+      } else if (layer == 2) { // layer 2
+	if (tmpLadder <= 8) ladder = 9 - tmpLadder;
+	else if (tmpLadder <= 16) ladder = 41 - tmpLadder;
+      } else if (layer == 3) { // layer 3
+	if (tmpLadder <= 11) ladder = 12 - tmpLadder;
+	else if (tmpLadder <= 22) ladder = 56 - tmpLadder;
+      } // end layer 
+    } // inner
+
+  } // phase
+
 
   // translate the module number from naming convention to cmssw convention
   // numbering starts at positive z
@@ -270,8 +566,7 @@ PXBDetId PixelBarrelName::getDetId() {
     module = 5 - tmpModule;
 
   return PXBDetId(layer, ladder, module);
-
-} // PXBDetId PixelBarrelName::getDetId()
+} 
 
 std::ostream & operator<<( std::ostream& out, const PixelBarrelName::Shell& t)
 {

--- a/DataFormats/SiPixelDetId/src/PixelEndcapName.cc
+++ b/DataFormats/SiPixelDetId/src/PixelEndcapName.cc
@@ -1,12 +1,63 @@
 #include "DataFormats/SiPixelDetId/interface/PixelEndcapName.h"
 
 #include <sstream>
-
-#include "DataFormats/SiPixelDetId/interface/PXFDetId.h"
-
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 using namespace std;
+
+namespace {
+  const bool phase1 = false;
+}
+
+PixelEndcapName::PixelEndcapName(const DetId & id, const TrackerTopology* tt)
+  : PixelModuleName(false)
+{
+
+  //PXFDetId cmssw_numbering(id);
+  int side     = tt->pxfSide(id);
+  int tmpBlade = tt->pxfBlade(id);
+  theDisk      = tt->pxfDisk(id);
+  thePannel    = tt->pxfPanel(id);
+
+  bool outer = false;
+  if(phase1) {  // phase 1
+    // this still has to be modified so blades start from 1 on the top
+    if (tmpBlade>=7 && tmpBlade<=17) {
+      outer = true;
+      theBlade = tmpBlade-6;                      //7...17-->1...11
+    } else if (tmpBlade>=32 && tmpBlade<=48) {
+      outer = true;
+      theBlade = 60-tmpBlade;                     //32...48-->28...12
+    } else if( tmpBlade<=6 ) {
+      theBlade = 7-tmpBlade;                      //1...6-->6...1
+    } else if( tmpBlade>=18 && tmpBlade<=31 ) {
+      theBlade = 38-tmpBlade;                     //18...31-->20...7
+    } else if( tmpBlade>=49 && tmpBlade<=56 ) {
+      theBlade = 77-tmpBlade;                     //49...56-->28...21
+    } //  iasonas2-end
+
+    theRing = tt->pxfModule(id);
+
+  } else { // phase0
+    if (tmpBlade >= 7 && tmpBlade <= 18) {
+      outer = true;
+      theBlade = tmpBlade-6;
+    } else if( tmpBlade <=6 ) { 
+      theBlade = 7-tmpBlade; 
+    } else if( tmpBlade >= 19) { 
+      theBlade = 31-tmpBlade; 
+    } 
+    
+    thePlaquette = tt->pxfModule(id);
+  } // end phase1
+
+
+       if( side == 1 &&  outer ) thePart = mO;
+  else if( side == 1 && !outer ) thePart = mI;
+  else if( side == 2 &&  outer ) thePart = pO;
+  else if( side == 2 && !outer ) thePart = pI;
+
+}
 
 PixelEndcapName::PixelEndcapName(const DetId & id)
   : PixelModuleName(false)
@@ -16,14 +67,41 @@ PixelEndcapName::PixelEndcapName(const DetId & id)
 
   int tmpBlade = cmssw_numbering.blade();
   bool outer = false;
-  if (tmpBlade >= 7 && tmpBlade <= 18) {
-    outer = true;
-    theBlade = tmpBlade-6;
-  } else if( tmpBlade <=6 ) { 
-    theBlade = 7-tmpBlade; 
-  } else if( tmpBlade >= 19) { 
-    theBlade = 31-tmpBlade; 
-  } 
+
+  if(phase1) { // phase1
+  } else { // phase 0
+  } // end phase1
+
+  if(phase1) { // phase1
+    // this still has to be modified so blades start from 1 on the top
+    if (tmpBlade>=7 && tmpBlade<=17) {
+      outer = true;
+      theBlade = tmpBlade-6;                      //7...17-->1...11
+    } else if (tmpBlade>=32 && tmpBlade<=48) {
+      outer = true;
+      theBlade = 60-tmpBlade;                     //32...48-->28...12
+    } else if( tmpBlade<=6 ) {
+      theBlade = 7-tmpBlade;                      //1...6-->6...1
+    } else if( tmpBlade>=18 && tmpBlade<=31 ) {
+      theBlade = 38-tmpBlade;                     //18...31-->20...7
+    } else if( tmpBlade>=49 && tmpBlade<=56 ) {
+      theBlade = 77-tmpBlade;                     //49...56-->28...21
+    } //  iasonas2-end
+    
+    //thePlaquette = cmssw_numbering.module();
+
+  } else { // phase 0
+    if (tmpBlade >= 7 && tmpBlade <= 18) {
+      outer = true;
+      theBlade = tmpBlade-6;
+    } else if( tmpBlade <=6 ) { 
+      theBlade = 7-tmpBlade; 
+    } else if( tmpBlade >= 19) { 
+      theBlade = 31-tmpBlade; 
+    }
+    thePlaquette = cmssw_numbering.module();
+ 
+  } // end phase1
 
 
        if( side == 1 &&  outer ) thePart = mO;
@@ -34,13 +112,12 @@ PixelEndcapName::PixelEndcapName(const DetId & id)
 
   theDisk = cmssw_numbering.disk();
   thePannel = cmssw_numbering.panel();
-  thePlaquette = cmssw_numbering.module();
 }
 
 // constructor from name string
 PixelEndcapName::PixelEndcapName(std::string name)
   : PixelModuleName(false), thePart(mO), theDisk(0), 
-    theBlade(0), thePannel(0), thePlaquette(0) {
+    theBlade(0), thePannel(0), thePlaquette(0), theRing(0) {
 
   // parse the name string
   // first, check to make sure this is an FPix name, should start with "FPix_"
@@ -50,7 +127,8 @@ PixelEndcapName::PixelEndcapName(std::string name)
        (name.find("_D") == string::npos) ||
        (name.find("_BLD") == string::npos) || 
        (name.find("_PNL") == string::npos) ||
-       (name.find("_PLQ") == string::npos) ) {
+       ( (phase1  && name.find("_RNG") == string::npos) ) ||
+       ( (!phase1 && name.find("_PLQ") == string::npos) ) ) {
     edm::LogError ("BadNameString|SiPixel") 
       << "Bad name string in PixelEndcapName::PixelEndcapName(std::string): "
       << name;
@@ -99,6 +177,11 @@ PixelEndcapName::PixelEndcapName(std::string name)
   else if (bladeString == "10") theBlade = 10;
   else if (bladeString == "11") theBlade = 11;
   else if (bladeString == "12") theBlade = 12;
+  else if (bladeString == "13") theBlade = 13;
+  else if (bladeString == "14") theBlade = 14;
+  else if (bladeString == "15") theBlade = 15;
+  else if (bladeString == "16") theBlade = 16;
+  else if (bladeString == "17") theBlade = 17;
   else {
     edm::LogError ("BadNameString|SiPixel") 
       << "Unable to determine blade number in PixelEndcapName::PixelEndcapName(std::string): "
@@ -115,34 +198,57 @@ PixelEndcapName::PixelEndcapName(std::string name)
       << name;
   }
 
-  // find the plaquette
-  string plaquetteString = name.substr(name.find("_PLQ")+4, name.size()-name.find("_PLQ")-4);
-  if (plaquetteString == "1") thePlaquette = 1;
-  else if (plaquetteString == "2") thePlaquette = 2;
-  else if (plaquetteString == "3") thePlaquette = 3;
-  else if (plaquetteString == "4") thePlaquette = 4;
-  else {
-    edm::LogError ("BadNameString|SiPixel") 
-      << "Unable to determine plaquette number in PixelEndcapName::PixelEndcapName(std::string): "
-      << name;
-  }
+  if(phase1) { // phase1
+    string ringString = name.substr(name.find("_RNG")+4, name.size()-name.find("_RNG")-4);
+    if (ringString == "1")      theRing = 1;
+    else if (ringString == "2") theRing = 2;
+    else {
+      edm::LogError ("BadNameString|SiPixel") 
+	<< "Unable to determine ring number in PixelEndcapName::PixelEndcapName(std::string): "
+	<< name;
+    }
+
+  } else { // phase 0
+
+    // find the plaquette
+    string plaquetteString = name.substr(name.find("_PLQ")+4, name.size()-name.find("_PLQ")-4);
+    if (plaquetteString == "1") thePlaquette = 1;
+    else if (plaquetteString == "2") thePlaquette = 2;
+    else if (plaquetteString == "3") thePlaquette = 3;
+    else if (plaquetteString == "4") thePlaquette = 4;
+    else {
+      edm::LogError ("BadNameString|SiPixel") 
+	<< "Unable to determine plaquette number in PixelEndcapName::PixelEndcapName(std::string): "
+	<< name;
+    }
+  } // end phase1
+
 
 } // PixelEndcapName::PixelEndcapName(std::string name)
 
 PixelModuleName::ModuleType  PixelEndcapName::moduleType() const
 {
   ModuleType type = v1x2;
-  if (pannelName() == 1) {
-    if (plaquetteName() == 1)      { type = v1x2; }
-    else if (plaquetteName() == 2) { type = v2x3; }
-    else if (plaquetteName() == 3) { type = v2x4; }
-    else if (plaquetteName() == 4) { type = v1x5; }
-  }
-  else {
-    if (plaquetteName() == 1)      { type = v2x3; }
-    else if (plaquetteName() == 2) { type = v2x4; }
-    else if (plaquetteName() == 3) { type = v2x5; }
-  }
+
+  if(phase1) { // phase1
+
+    type = v2x8;
+
+  } else { // phase 0
+
+    if (pannelName() == 1) {
+      if (plaquetteName() == 1)      { type = v1x2; }
+      else if (plaquetteName() == 2) { type = v2x3; }
+      else if (plaquetteName() == 3) { type = v2x4; }
+      else if (plaquetteName() == 4) { type = v1x5; }
+    } else {
+      if (plaquetteName() == 1)      { type = v2x3; }
+      else if (plaquetteName() == 2) { type = v2x4; }
+      else if (plaquetteName() == 3) { type = v2x5; }
+    }
+
+  } // end phase1
+
   return type;
 }
 
@@ -155,6 +261,7 @@ bool PixelEndcapName::operator== (const PixelModuleName & o) const
              && theDisk      == other->theDisk
              && theBlade     == other->theBlade
              && thePannel    == other->thePannel
+             && theRing      == other->theRing
              && thePlaquette == other->thePlaquette ); 
   } else return false;
 }
@@ -163,7 +270,13 @@ bool PixelEndcapName::operator== (const PixelModuleName & o) const
 string PixelEndcapName::name() const 
 {
   std::ostringstream stm;
+
+  if(phase1) { // phase1
+  } else { // phase 0
+  } // end phase1
+
   stm <<"FPix_B"<<thePart<<"_D"<<theDisk<<"_BLD"<<theBlade<<"_PNL"<<thePannel<<"_PLQ"<<thePlaquette;
+
   return stm.str();
 }
 
@@ -178,6 +291,63 @@ std::ostream & operator<<( std::ostream& out, const PixelEndcapName::HalfCylinde
   };
   return out;
 }
+
+// return the DetId
+DetId PixelEndcapName::getDetId(const TrackerTopology* tt) {
+  
+  uint32_t side = 0;
+  uint32_t disk = 0;
+  uint32_t blade = 0;
+  uint32_t panel = 0;
+  uint32_t module = 0;
+
+  // figure out the side
+  HalfCylinder hc = halfCylinder();
+  if (hc == mO || hc == mI) side = 1;
+  else if (hc == pO || hc == pI) side = 2;
+  
+  // get disk/blade/panel/module numbers from PixelEndcapName object
+  disk = static_cast<uint32_t>(diskName());
+  uint32_t tmpBlade = static_cast<uint32_t>(bladeName());
+  panel = static_cast<uint32_t>(pannelName());
+
+  // convert blade numbering to cmssw convention
+  bool outer = false;
+  outer = (hc == mO) || (hc == pO);
+
+  if(phase1) { // phase1
+
+    // this still has to be modified so blades start from 1 on the top
+    if (outer) {
+      if          (tmpBlade>=7 && tmpBlade<=17)    theBlade = tmpBlade+6;
+      else if     (tmpBlade>=32 && tmpBlade<=48)   theBlade = 60-tmpBlade;
+    } else { //inner
+      if          (tmpBlade<=6 )                   theBlade = 7-tmpBlade;
+      else if     (tmpBlade>=18 && tmpBlade<=31)   theBlade = 38-tmpBlade;
+      else if     (tmpBlade>=49 && tmpBlade<=56)   theBlade = 77-tmpBlade;
+    }
+
+    module = static_cast<uint32_t>(ringName());
+  
+  } else { // phase 0
+    if (outer) {
+      blade = tmpBlade + 6;
+    } else { // inner
+      if (tmpBlade <= 6) blade = 7 - tmpBlade;
+      else if (tmpBlade <= 12) blade = 31 - tmpBlade;
+    }
+
+    module = static_cast<uint32_t>(plaquetteName());
+  } // end phase1
+
+
+  // create and return the DetId
+  DetId id = tt->pxfDetId(side, disk, blade, panel, module);
+
+  return id;
+
+} // PXFDetId PixelEndcapName::getDetId()
+
 
 // return the DetId
 PXFDetId PixelEndcapName::getDetId() {
@@ -197,18 +367,35 @@ PXFDetId PixelEndcapName::getDetId() {
   disk = static_cast<uint32_t>(diskName());
   uint32_t tmpBlade = static_cast<uint32_t>(bladeName());
   panel = static_cast<uint32_t>(pannelName());
-  module = static_cast<uint32_t>(plaquetteName());
 
   // convert blade numbering to cmssw convention
   bool outer = false;
   outer = (hc == mO) || (hc == pO);
-  if (outer) {
-    blade = tmpBlade + 6;
-  }
-  else { // inner
-    if (tmpBlade <= 6) blade = 7 - tmpBlade;
-    else if (tmpBlade <= 12) blade = 31 - tmpBlade;
-  }
+
+  if(phase1) { // phase1
+
+    // this still has to be modified so blades start from 1 on the top
+    if (outer) {
+      if          (tmpBlade>=7 && tmpBlade<=17)    theBlade = tmpBlade+6;
+      else if     (tmpBlade>=32 && tmpBlade<=48)   theBlade = 60-tmpBlade;
+    } else { //inner
+      if          (tmpBlade<=6 )                   theBlade = 7-tmpBlade;
+      else if     (tmpBlade>=18 && tmpBlade<=31)   theBlade = 38-tmpBlade;
+      else if     (tmpBlade>=49 && tmpBlade<=56)   theBlade = 77-tmpBlade;
+    }
+
+    module = static_cast<uint32_t>(ringName());
+  
+  } else { // phase 0
+    if (outer) {
+      blade = tmpBlade + 6;
+    } else { // inner
+      if (tmpBlade <= 6) blade = 7 - tmpBlade;
+      else if (tmpBlade <= 12) blade = 31 - tmpBlade;
+    }
+
+    module = static_cast<uint32_t>(plaquetteName());
+  } // end phase1
 
   // create and return the DetId
   return PXFDetId(side, disk, blade, panel, module);


### PR DESCRIPTION
This pull request has two components:
1)  Extend the maximum FED id for raw data for pixels  from 29 to 40 to accommodate the pilot blade fed.
2) Extend the PixelNames functionality to cover the new pilot blade and the phase 1 pixels.
