### PR TITLE
add capability to mix OOT muons with different bunch pattern from minbias

### DIFF
--- a/Mixing/Base/interface/PileUp.h
+++ b/Mixing/Base/interface/PileUp.h
@@ -30,7 +30,7 @@ namespace edm {
 
   class PileUp {
   public:
-    explicit PileUp(ParameterSet const& pset, double averageNumber, TH1F* const histo, const bool playback);
+    explicit PileUp(ParameterSet const& pset, std::string sourcename, double averageNumber, TH1F* const histo, const bool playback);
     ~PileUp();
 
     template<typename T>
@@ -41,7 +41,14 @@ namespace edm {
 
     double averageNumber() const {return averageNumber_;}
     bool poisson() const {return poisson_;}
-    bool doPileUp() {return none_ ? false :  averageNumber_>0.;}
+    bool doPileUp( int BX ) {
+      if(Source_type_ != "cosmics") {
+	return none_ ? false :  averageNumber_>0.;
+      }
+      else {
+	return ( BX >= minBunch_cosmics_ && BX <= maxBunch_cosmics_);
+      }
+    }
     void dropUnwantedBranches(std::vector<std::string> const& wantedBranches) {
       input_->dropUnwantedBranches(wantedBranches);
     }
@@ -75,6 +82,7 @@ namespace edm {
 
     unsigned int  inputType_;
     std::string type_;
+    std::string Source_type_;
     double averageNumber_;
     int const intAverage_;
     TH1F* histo_;
@@ -90,8 +98,12 @@ namespace edm {
     bool PU_Study_;
     std::string Study_type_;
 
+
     int  intFixed_OOT_;
     int  intFixed_ITPU_;
+
+    int minBunch_cosmics_;
+    int maxBunch_cosmics_;
 
     std::shared_ptr<ProductRegistry> productRegistry_;
     std::unique_ptr<VectorInputSource> const input_;

--- a/Mixing/Base/src/BMixingModule.cc
+++ b/Mixing/Base/src/BMixingModule.cc
@@ -43,7 +43,7 @@ namespace
 	if (ps.exists("readDB") && ps.getParameter<bool>("readDB")){
 	  //in case of DB access, do not try to load anything from the PSet, but wait for beginRun.
  	  edm::LogError("BMixingModule")<<"Will read from DB: reset to a dummy PileUp object.";
-	  pileup.reset(new edm::PileUp(psin,0,0,playback));
+	  pileup.reset(new edm::PileUp(psin,sourceName,0,0,playback));
 	  return pileup;
 	}
 	if (type_!="none"){
@@ -52,7 +52,7 @@ namespace
 	    if (psin_average.exists("averageNumber"))
 	      {
 		averageNumber=psin_average.getParameter<double>("averageNumber");
-		pileup.reset(new edm::PileUp(psin,averageNumber,h,playback));
+		pileup.reset(new edm::PileUp(psin,sourceName,averageNumber,h,playback));
 		edm::LogInfo("MixingModule") <<" Created source "<<sourceName<<" with averageNumber "<<averageNumber;
 	      }
 	    else if (psin_average.exists("fileName") && psin_average.exists("histoName")) {
@@ -77,7 +77,7 @@ namespace
 		// Get the averageNumber from the histo 
 		averageNumber = h->GetMean();
 		
-		pileup.reset(new edm::PileUp(psin,averageNumber,h,playback));
+		pileup.reset(new edm::PileUp(psin,sourceName,averageNumber,h,playback));
 		edm::LogInfo("MixingModule") <<" Created source "<<sourceName<<" with averageNumber "<<averageNumber;
 	      
 	      }
@@ -141,7 +141,7 @@ namespace
 		outfile->Close();
 		outfile->Delete();		
 		
-		pileup.reset(new edm::PileUp(psin,averageNumber,hprob,playback));
+		pileup.reset(new edm::PileUp(psin,sourceName,averageNumber,hprob,playback));
 		edm::LogInfo("MixingModule") <<" Created source "<<sourceName<<" with averageNumber "<<averageNumber;
 		
 	      } 
@@ -149,7 +149,7 @@ namespace
 	    else if (sourceName=="input" && psin_average.exists("Lumi") && psin_average.exists("sigmaInel")) {
 	      averageNumber=psin_average.getParameter<double>("Lumi")*psin_average.getParameter<double>("sigmaInel")*ps.getParameter<int>("bunchspace")/1000*3564./2808.;  //FIXME
 	      pileup.reset(new
- 	      edm::PileUp(psin,averageNumber,h,playback));
+			   edm::PileUp(psin,sourceName,averageNumber,h,playback));
 	      edm::LogInfo("MixingModule") <<" Created source "<<sourceName<<" with minBunch,maxBunch "<<minb<<" "<<maxb;
 	      edm::LogInfo("MixingModule")<<" Luminosity configuration, average number used is "<<averageNumber;
 	    }

--- a/Mixing/Base/src/PileUp.cc
+++ b/Mixing/Base/src/PileUp.cc
@@ -29,8 +29,9 @@
 #include <memory>
 
 namespace edm {
-  PileUp::PileUp(ParameterSet const& pset, double averageNumber, TH1F * const histo, const bool playback) :
+  PileUp::PileUp(ParameterSet const& pset, std::string sourcename, double averageNumber, TH1F * const histo, const bool playback) :
     type_(pset.getParameter<std::string>("type")),
+    Source_type_(sourcename),
     averageNumber_(averageNumber),
     intAverage_(static_cast<int>(averageNumber)),
     histo_(histo),
@@ -160,7 +161,19 @@ namespace edm {
     }
     }
     
-  }
+    if(Source_type_ == "cosmics") {  // allow for some extra flexibility for mixing
+      minBunch_cosmics_ = pset.getUntrackedParameter<int>("minBunch_cosmics", -1000);
+      maxBunch_cosmics_ = pset.getUntrackedParameter<int>("maxBunch_cosmics", 1000);
+    }
+
+
+
+  } // end of constructor
+
+
+
+
+
   void PileUp::beginJob () {
     input_->doBeginJob();
     if (provider_.get() != nullptr) {

--- a/SimGeneral/DataMixingModule/plugins/DataMixingModule.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingModule.cc
@@ -473,7 +473,7 @@ namespace edm
     for (int bunchCrossing=minBunch_;bunchCrossing<=maxBunch_;++bunchCrossing) {
       for (unsigned int isource=0;isource<maxNbSources_;++isource) {
         boost::shared_ptr<PileUp> source = inputSources_[isource];
-        if (not source or not source->doPileUp()) 
+        if (!source || !(source->doPileUp(bunchCrossing))) 
           continue;
 
 	if (isource==0) 

--- a/SimGeneral/MixingModule/plugins/MixingModule.cc
+++ b/SimGeneral/MixingModule/plugins/MixingModule.cc
@@ -342,7 +342,7 @@ namespace edm {
 
     boost::shared_ptr<PileUp> source0 = inputSources_[0];
 
-    if((source0 && source0->doPileUp() ) && !playback_) {
+    if((source0 && source0->doPileUp(0) ) && !playback_) {
       //    if((!inputSources_[0] || !inputSources_[0]->doPileUp()) && !playback_ ) 
 
       // Pre-calculate all pileup distributions before we go fishing for events
@@ -374,7 +374,7 @@ namespace edm {
           workers_[setSrcIdx]->setSourceOffset(readSrcIdx);
         }
 
-        if (!source || !source->doPileUp()) continue;
+        if (!source || !source->doPileUp(bunchIdx)) continue;
 
         int NumPU_Events = 0;
 
@@ -426,7 +426,7 @@ namespace edm {
     //Makin' a list: Basically, we don't care about the "other" sources at this point.
     for (int bunchCrossing=minBunch_;bunchCrossing<=maxBunch_;++bunchCrossing) {
       bunchCrossingList.push_back(bunchCrossing);
-      if(!inputSources_[0] || !inputSources_[0]->doPileUp()) {
+      if(!inputSources_[0] || !inputSources_[0]->doPileUp(0)) {
         numInteractionList.push_back(0);
         TrueInteractionList.push_back(0);
       }

--- a/SimGeneral/MixingModule/plugins/SecSourceAnalyzer.cc
+++ b/SimGeneral/MixingModule/plugins/SecSourceAnalyzer.cc
@@ -64,7 +64,7 @@ SecSourceAnalyzer::SecSourceAnalyzer(const edm::ParameterSet& iConfig)
    TH1F * histoName = new TH1F("h","",10,0,10); 
    bool playback = false;
    
-   input_.reset(new edm::PileUp(iConfig.getParameter<edm::ParameterSet>("input"),
+   input_.reset(new edm::PileUp(iConfig.getParameter<edm::ParameterSet>("input"),"input",
                                 averageNumber,histoName,playback));
       
    dataStep2_ = iConfig.getParameter<bool>("dataStep2");

--- a/SimGeneral/MixingModule/python/mix_OOT_Muons_and_minbias_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_OOT_Muons_and_minbias_cfi.py
@@ -1,0 +1,52 @@
+import FWCore.ParameterSet.Config as cms
+
+# configuration to model pileup for initial physics phase
+from SimGeneral.MixingModule.mixObjects_cfi import theMixObjects
+from SimGeneral.MixingModule.mixPoolSource_cfi import *
+from SimGeneral.MixingModule.digitizers_cfi import *
+
+mix = cms.EDProducer("MixingModule",
+    digitizers = cms.PSet(theDigitizers),
+    LabelPlayback = cms.string(''),
+    maxBunch = cms.int32(4),
+    minBunch = cms.int32(-4), ## in terms of 25 nsec
+
+    bunchspace = cms.int32(25), ##ns
+    mixProdStep1 = cms.bool(False),
+    mixProdStep2 = cms.bool(False),
+
+    playback = cms.untracked.bool(False),
+    useCurrentProcessOnly = cms.bool(False),
+
+    input = cms.SecSource("PoolSource",
+        type = cms.string('fixed'),
+        nbPileupEvents = cms.PSet(
+            averageNumber = cms.double(40.0)
+        ),
+
+	sequential = cms.untracked.bool(False),
+        manage_OOT = cms.untracked.bool(True),  ## manage out-of-time pileup
+        ## setting this to True means that the out-of-time pileup
+        ## will have a different distribution than in-time, given
+        ## by what is described on the next line:
+        #OOT_type = cms.untracked.string('Poisson'),  ## generate OOT with a Poisson matching the number chosen for in-time
+        OOT_type = cms.untracked.string('fixed'),  ## generate OOT with a fixed distribution
+        intFixed_OOT = cms.untracked.int32(0), ## we only want in-time pileup, but muons
+                                               ## need out of time bunch crossings
+        fileNames = FileNames
+    ),
+    cosmics = cms.SecSource("PoolSource",
+        nbPileupEvents = cms.PSet(
+            averageNumber = cms.double(1.)
+        ),
+        type = cms.string('fixed'),
+        sequential = cms.untracked.bool(False),
+        maxBunch_cosmics = cms.untracked.int32(4),
+        minBunch_cosmics = cms.untracked.int32(4),
+        fileNames = cms.untracked.vstring('file:SingleMuPt2_50_cfi_GEN_SIM.root')
+    ),
+    mixObjects = cms.PSet(theMixObjects)
+)
+
+
+


### PR DESCRIPTION
Two input streams are enabled, with the one used for "cosmics" allowed to occupy different bunch ranges than that specified by the minbias stream.  Useful for looking at the effects of accidental coincidences of in-time pileup (=tracks) with out-of-time muon hits.
