### PR TITLE
Fix tracked nEvents parameter in ExternalLHEProducer (73x)

### DIFF
--- a/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
+++ b/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
@@ -127,7 +127,7 @@ ExternalLHEProducer::ExternalLHEProducer(const edm::ParameterSet& iConfig) :
   outputFile_(iConfig.getParameter<std::string>("outputFile")),
   args_(iConfig.getParameter<std::vector<std::string> >("args")),
   npars_(iConfig.getParameter<uint32_t>("numberOfParameters")),
-  nEvents_(iConfig.getParameter<uint32_t>("nEvents"))
+  nEvents_(iConfig.getUntrackedParameter<uint32_t>("nEvents"))
 {
   if (npars_ != args_.size())
     throw cms::Exception("ExternalLHEProducer") << "Problem with configuration: " << args_.size() << " script arguments given, expected " << npars_;
@@ -453,7 +453,7 @@ ExternalLHEProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptio
   desc.add<std::string>("outputFile", "myoutput");
   desc.add<std::vector<std::string> >("args");
   desc.add<uint32_t>("numberOfParameters");
-  desc.add<uint32_t>("nEvents");
+  desc.addUntracked<uint32_t>("nEvents");
 
   descriptions.addDefault(desc);
 }

--- a/GeneratorInterface/LHEInterface/python/ExternalLHEProducer_cfi.py
+++ b/GeneratorInterface/LHEInterface/python/ExternalLHEProducer_cfi.py
@@ -5,6 +5,6 @@ externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
     outputFile = cms.string("W1Jet_7TeV_madgraph_final.lhe"),
     numberOfParameters = cms.uint32(10),
     args = cms.vstring('slc5_ia32_gcc434/madgraph/V5_1.3.27/test','W1Jet_7TeV_madgraph','false','true','wjets','5','20','false','0','99'),
-    nEvents = cms.uint32(100)                                    
+    nEvents = cms.untracked.uint32(100)                                    
 )
 


### PR DESCRIPTION
This is the proper solution for the issue discussed in 
https://hypernews.cern.ch/HyperNews/CMS/get/dataopsrequests/5669.html

By making the nEvents paramter untracked, the spurious run transitions should be avoided.
