### PR TITLE
Protect EOS Portable Archive from GCCXML

### DIFF
--- a/CondFormats/HcalObjects/interface/AbsOOTPileupCorrection.h
+++ b/CondFormats/HcalObjects/interface/AbsOOTPileupCorrection.h
@@ -8,9 +8,11 @@
 
 // Archive headers are needed here for the serialization registration to work.
 // <cassert> is needed for the archive headers to work.
+#if !defined(__GCCXML__)
 #include <cassert>
 #include "CondFormats/Serialization/interface/eos/portable_iarchive.hpp"
 #include "CondFormats/Serialization/interface/eos/portable_oarchive.hpp"
+#endif /* #if !defined(__GCCXML__) */
 
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 


### PR DESCRIPTION
The following breakes on armv7hl.

```
basic_binary_oarchive.hpp:80: error: invalid application of 'sizeof' to
incomplete type 'boost::STATIC_ASSERTION_FAILURE<false>'
```

Static asserts are failing while running inside GCCXML.

The following class from Boost:

```
class class_id_type {
private:
 typedef int_least16_t base_type;
 base_type t;
};
```

The size of it is different between GCC 4.2.1 (GCCXML) and GCC 4.91.

There is no need to have those headers in GCCXML, we disabled them
centrally for Boost Serialization. Disable them also here.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
