### PR TITLE
DataFormats/TrackReco: reco::TrackExtra class version updated

### DIFF
--- a/DataFormats/TrackReco/src/classes_def.xml
+++ b/DataFormats/TrackReco/src/classes_def.xml
@@ -344,7 +344,8 @@
   </ioread>
 
 
-  <class name="reco::TrackExtra" ClassVersion="11">
+  <class name="reco::TrackExtra" ClassVersion="12">
+   <version ClassVersion="12" checksum="106004853"/>
    <version ClassVersion="11" checksum="2586227274"/>
    <version ClassVersion="10" checksum="1613098482"/>
     <field name="outerPosition_" iotype="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag>" /> 


### PR DESCRIPTION
Fixes the error shown here:
https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc6_amd64_gcc481/CMSSW_7_3_DEVEL_X_2014-10-15-0200/DataFormats/TrackReco
