### PR TITLE
add back ak5 to list of genjets to be dropped in REGEN workflow

### DIFF
--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -718,6 +718,7 @@ REGENEventContent = cms.PSet(
       'drop *_kt6GenJets_*_*',
       'drop *_iterativeCone5GenJets_*_*',
       'drop *_ak4GenJets_*_*',
+      'drop *_ak5GenJets_*_*',
       'drop *_ak7GenJets_*_*',
       'drop *_genCandidatesForMET_*_*',
       'drop *_genParticlesForMETAllVisible_*_*',


### PR DESCRIPTION
Needed for reprocessing of 62X gen-sim in 72x for PHYS14.
