### PR TITLE
71x: Fix crash on remote X connection using XQuartz version  2.7.7

### DIFF
--- a/Fireworks/Core/src/CmsShowMain.cc
+++ b/Fireworks/Core/src/CmsShowMain.cc
@@ -284,7 +284,7 @@ CmsShowMain::CmsShowMain(int argc, char *argv[])
    // open any graphics or build dictionaries
    AutoLibraryLoader::enable();
 
-   TEveManager::Create(kFALSE, "FIV");
+   TEveManager::Create(kFALSE, eveMode ? "FIV" : "FI");
 
    setup(m_navigator.get(), m_context.get(), m_metadataManager.get());
 

--- a/Fireworks/FWInterface/src/FWFFHelper.cc
+++ b/Fireworks/FWInterface/src/FWFFHelper.cc
@@ -76,5 +76,5 @@ FWFFHelper::FWFFHelper(const edm::ParameterSet &ps, const edm::ActivityRegistry 
    }
 #endif
 
-    TEveManager::Create(kFALSE, "FIV");
+    TEveManager::Create(kFALSE, "FI");
 }


### PR DESCRIPTION
The change is a workaround for remote X connection using XQuartz 2.7.7. 

The crashe is in the creation of a default GL viewer whcic is not needed in standard version of cmShow. This  creation can be skipped by removing 'V' option from TEveManager::Create().
