### PR TITLE
RecoMET/METPUSubtraction -- Removed 3 unused functions

### DIFF
--- a/RecoMET/METPUSubtraction/plugins/NoPileUpPFMEtDataProducer.cc
+++ b/RecoMET/METPUSubtraction/plugins/NoPileUpPFMEtDataProducer.cc
@@ -116,19 +116,6 @@ namespace
     }
   }
 
-  std::string getPFCandidateType(const reco::PFCandidate& pfCandidate)
-  {
-    reco::PFCandidate::ParticleType pfCandidateType = pfCandidate.particleId();
-    if      ( pfCandidateType == reco::PFCandidate::X         ) return "undefined";
-    else if ( pfCandidateType == reco::PFCandidate::h         ) return "PFChargedHadron";
-    else if ( pfCandidateType == reco::PFCandidate::e         ) return "PFElectron";
-    else if ( pfCandidateType == reco::PFCandidate::mu        ) return "PFMuon";
-    else if ( pfCandidateType == reco::PFCandidate::gamma     ) return "PFGamma";
-    else if ( pfCandidateType == reco::PFCandidate::h0        ) return "PFNeutralHadron";
-    else if ( pfCandidateType == reco::PFCandidate::h_HF      ) return "HF_had";
-    else if ( pfCandidateType == reco::PFCandidate::egamma_HF ) return "HF_em";
-    else assert(0);
-  }
 }
 
 void NoPileUpPFMEtDataProducer::produce(edm::Event& evt, const edm::EventSetup& es)

--- a/RecoMET/METPUSubtraction/plugins/PFMETProducerMVA.cc
+++ b/RecoMET/METPUSubtraction/plugins/PFMETProducerMVA.cc
@@ -54,25 +54,6 @@ namespace
     return os.str();
   }
 
-  std::string format_vInputTag(const std::vector<edm::InputTag>& vit)
-  {
-    std::vector<std::string> vit_string;
-    for ( std::vector<edm::InputTag>::const_iterator vit_i = vit.begin();
-	  vit_i != vit.end(); ++vit_i ) {
-      vit_string.push_back(vit_i->label());
-    }
-    return format_vT(vit_string);
-  }
-
-  void printJets(std::ostream& stream, const reco::PFJetCollection& jets)
-  {
-    unsigned numJets = jets.size();
-    for ( unsigned iJet = 0; iJet < numJets; ++iJet ) {
-      const reco::Candidate::LorentzVector& jetP4 = jets.at(iJet).p4();
-      stream << " #" << iJet << ": Pt = " << jetP4.pt() << "," 
-	     << " eta = " << jetP4.eta() << ", phi = " << jetP4.phi() << std::endl;
-    }
-  }
 }
 
 PFMETProducerMVA::PFMETProducerMVA(const edm::ParameterSet& cfg) 


### PR DESCRIPTION
This is to clean up the warnings shown here: 
https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc6_amd64_gcc491/CMSSW_7_3_X_2014-10-16-0200/RecoMET/METPUSubtraction
