### PR TITLE
Fix build error caused by missing link dependency

### DIFF
--- a/CondFormats/CSCObjects/BuildFile.xml
+++ b/CondFormats/CSCObjects/BuildFile.xml
@@ -2,8 +2,8 @@
 <use   name="DataFormats/MuonDetId"/>
 <use   name="FWCore/MessageLogger"/>
 <use   name="FWCore/ParameterSet"/>
+<use   name="CondFormats/Serialization"/>
 <use   name="boost_serialization"/>
-
 <export>
   <lib   name="1"/>
 </export>


### PR DESCRIPTION
Add missing link dependency that is causing many build errors.
Please merge this as soon as feasible.
It would also be nice if the ROOT6 IB could be restarted.
