### PR TITLE
Reduce memory usage in ROOT6 by reducing header parsing

### DIFF
--- a/CondFormats/Common/src/classes_def.xml
+++ b/CondFormats/Common/src/classes_def.xml
@@ -14,6 +14,9 @@
   <field name="m_scope" persistency="loose_on_reading" />
  </class>
 
+ <typedef name="ora::QueryableVector<cond::IOVElement>::store_base_type" />
+ <typedef name="ora::PVector<cond::IOVElement>::value_type" />
+ <enum name="cond::IOVSequence::ScopeType" />
 
  <class name="cond::IOVProvenance"/>
  <class name="cond::IOVDescription"/>

--- a/CondFormats/EcalObjects/src/classes_def.xml
+++ b/CondFormats/EcalObjects/src/classes_def.xml
@@ -2,6 +2,8 @@
 
 <!-- base class -->
 <class name="EcalChannelStatusCode"/>
+<enum name="EcalChannelStatusCode::Code"/>
+<enum name="EcalChannelStatusCode::Bits"/>
 <!-- templates for EcalCondObjectContainer having the class as template parameter -->
 <class name="std::vector<EcalChannelStatusCode>"/>
 <class name="EcalContainer<EEDetId,EcalChannelStatusCode>"/>

--- a/DataFormats/CSCDigi/src/classes_def.xml
+++ b/DataFormats/CSCDigi/src/classes_def.xml
@@ -73,6 +73,23 @@
    <class name="std::map<CSCDetId,std::vector<CSCALCTStatusDigi> >"/>
    <class name="std::map<CSCDetId,std::vector<CSCCLCTPreTrigger> >"/>
 
+   <class name="std::pair<CSCDetId,std::vector<CSCWireDigi> >"/>
+   <class name="std::pair<CSCDetId,std::vector<CSCRPCDigi> >"/>
+   <class name="std::pair<CSCDetId,std::vector<CSCStripDigi> >"/>
+   <class name="std::pair<CSCDetId,std::vector<CSCComparatorDigi> >"/>
+   <class name="std::pair<CSCDetId,std::vector<CSCCorrelatedLCTDigi> >"/>
+   <class name="std::pair<CSCDetId,std::vector<CSCCLCTDigi> >"/>
+   <class name="std::pair<CSCDetId,std::vector<CSCALCTDigi> >"/>
+   <class name="std::pair<CSCDetId,std::vector<CSCCFEBStatusDigi> >"/>
+   <class name="std::pair<CSCDetId,std::vector<CSCTMBStatusDigi> >"/>
+   <class name="std::pair<CSCDetId,std::vector<CSCDCCFormatStatusDigi> >"/>
+   <class name="std::pair<CSCDetId,std::vector<CSCDMBStatusDigi> >"/>
+   <class name="std::pair<CSCDetId,std::vector<CSCDDUStatusDigi> >"/>
+   <class name="std::pair<CSCDetId,std::vector<CSCDCCStatusDigi> >"/>
+   <class name="std::pair<CSCDetId,std::vector<CSCALCTStatusDigi> >"/>
+   <class name="std::pair<CSCDetId,std::vector<CSCCLCTPreTrigger> >"/>
+
+
    <class name="MuonDigiCollection<CSCDetId,CSCWireDigi>"/>
    <class name="MuonDigiCollection<CSCDetId,CSCRPCDigi>"/>
    <class name="MuonDigiCollection<CSCDetId,CSCStripDigi>"/>

--- a/DataFormats/CSCRecHit/src/classes_def.xml
+++ b/DataFormats/CSCRecHit/src/classes_def.xml
@@ -10,7 +10,10 @@
   <class name="std::vector<CSCRecHit2D*>"/>
   <class name="std::map<CSCDetId,std::pair<unsigned int,unsigned int> >"/>
   <class name="std::map<CSCDetId,std::pair<unsigned long,unsigned long> >"/>
+  <class name="std::pair<CSCDetId,std::pair<unsigned int,unsigned int> >"/>  <!-- Root6 -->
+  <class name="std::pair<CSCDetId,std::pair<unsigned long,unsigned long> >"/><!-- Root6 -->
   <class name="edm::OwnVector<CSCRecHit2D,edm::ClonePolicy<CSCRecHit2D> >"/>
+  <class name="edm::ClonePolicy<CSCRecHit2D>"/> <!-- Root6 -->
   <class name="edm::RangeMap<CSCDetId,edm::OwnVector<CSCRecHit2D,edm::ClonePolicy<CSCRecHit2D> >,edm::ClonePolicy<CSCRecHit2D> >"/>
   <class name="edm::Wrapper<edm::RangeMap<CSCDetId,edm::OwnVector<CSCRecHit2D,edm::ClonePolicy<CSCRecHit2D> >,edm::ClonePolicy<CSCRecHit2D> > >"/>
 
@@ -21,6 +24,7 @@
   </class>
   <class name="edm::OwnVector<CSCSegment,edm::ClonePolicy<CSCSegment> >"/>
   <class name="edm::RangeMap<CSCDetId,edm::OwnVector<CSCSegment,edm::ClonePolicy<CSCSegment> >,edm::ClonePolicy<CSCSegment> >"/>
+  <class name="edm::ClonePolicy<CSCSegment>"/> <!-- Root6 -->
   <class name="edm::Wrapper<edm::RangeMap<CSCDetId,edm::OwnVector<CSCSegment,edm::ClonePolicy<CSCSegment> >,edm::ClonePolicy<CSCSegment> > >"/>
   <class name="CSCSegmentRef"/>
 </selection>

--- a/DataFormats/CaloTowers/src/classes_def.xml
+++ b/DataFormats/CaloTowers/src/classes_def.xml
@@ -10,11 +10,13 @@
   <class name="std::vector<CaloTower>"/>
   <class name="edm::Wrapper<std::vector<CaloTower> >"/>
   <class name="edm::SortedCollection<CaloTower,edm::StrictWeakOrdering<CaloTower> >"/>
+  <class name="edm::StrictWeakOrdering<CaloTower>"/>
   <class name="edm::Ref<edm::SortedCollection<CaloTower, edm::StrictWeakOrdering<CaloTower> >, CaloTower, edm::refhelper::FindUsingAdvance<edm::SortedCollection<CaloTower, edm::StrictWeakOrdering<CaloTower> >, CaloTower > >"/>  
   <class name="edm::RefVector<edm::SortedCollection<CaloTower, edm::StrictWeakOrdering<CaloTower> >, CaloTower, edm::refhelper::FindUsingAdvance<edm::SortedCollection<CaloTower, edm::StrictWeakOrdering<CaloTower> >, CaloTower > >"/> 
   <class name="edm::RefProd<edm::SortedCollection<CaloTower, edm::StrictWeakOrdering<CaloTower> > >"/> 
   <class name="edm::Wrapper<edm::SortedCollection<CaloTower,edm::StrictWeakOrdering<CaloTower> > >"/> 
   <class name="edm::FwdRef<edm::SortedCollection<CaloTower, edm::StrictWeakOrdering<CaloTower> >, CaloTower, edm::refhelper::FindUsingAdvance<edm::SortedCollection<CaloTower, edm::StrictWeakOrdering<CaloTower> >, CaloTower > >"/>
+  <class name="edm::refhelper::FindUsingAdvance<edm::SortedCollection<CaloTower,edm::StrictWeakOrdering<CaloTower> >,CaloTower>" /> <!-- Root6 -->
   <class name="std::vector<edm::FwdRef<edm::SortedCollection<CaloTower, edm::StrictWeakOrdering<CaloTower> >, CaloTower, edm::refhelper::FindUsingAdvance<edm::SortedCollection<CaloTower, edm::StrictWeakOrdering<CaloTower> >, CaloTower > > >"/>
   <class name="edm::Wrapper< std::vector<edm::FwdRef<edm::SortedCollection<CaloTower, edm::StrictWeakOrdering<CaloTower> >, CaloTower, edm::refhelper::FindUsingAdvance<edm::SortedCollection<CaloTower, edm::StrictWeakOrdering<CaloTower> >, CaloTower > > > >"/>
 

--- a/DataFormats/DTDigi/src/classes_def.xml
+++ b/DataFormats/DTDigi/src/classes_def.xml
@@ -4,6 +4,7 @@
 </class>
 <class name="std::vector<DTDigi>"/>
 <class name="std::map<DTLayerId,std::vector<DTDigi> >"/>
+<class name="std::pair<DTLayerId,std::vector<DTDigi> >"/>
 <class name="MuonDigiCollection<DTLayerId,DTDigi>"/> 
 <class name="edm::Wrapper<MuonDigiCollection<DTLayerId,DTDigi>>" splitLevel="0"/> 
 
@@ -12,6 +13,7 @@
 </class>
 <class name="std::vector<DTLocalTrigger>"/>
 <class name="std::map<DTChamberId,std::vector<DTLocalTrigger> >"/>
+<class name="std::pair<DTChamberId,std::vector<DTLocalTrigger> >"/>
 <class name="MuonDigiCollection<DTChamberId,DTLocalTrigger>"/> 
 <class name="edm::Wrapper<MuonDigiCollection<DTChamberId,DTLocalTrigger>>" splitLevel="0"/> 
 

--- a/DataFormats/DTRecHit/src/classes_def.xml
+++ b/DataFormats/DTRecHit/src/classes_def.xml
@@ -8,8 +8,11 @@
   </class>
   <class name="std::vector<DTRecHit1DPair*>"/>
   <class name="std::map<DTLayerId,std::pair<unsigned int,unsigned int> >"/>
+  <class name="std::pair<DTLayerId,std::pair<unsigned int,unsigned int> >"/>
   <class name="std::map<DTLayerId,std::pair<unsigned long,unsigned long> >"/>
+  <class name="std::pair<DTLayerId,std::pair<unsigned long,unsigned long> >"/>
   <class name="edm::OwnVector<DTRecHit1DPair,edm::ClonePolicy<DTRecHit1DPair> >"/>
+  <class name="edm::ClonePolicy<DTRecHit1DPair>" /> <!-- Root6 -->
   <class name="edm::RangeMap <DTLayerId,edm::OwnVector<DTRecHit1DPair,edm::ClonePolicy<DTRecHit1DPair> >,edm::ClonePolicy<DTRecHit1DPair> >"/> 
   <class name="edm::Wrapper<edm::RangeMap <DTLayerId, edm::OwnVector<DTRecHit1DPair,edm::ClonePolicy<DTRecHit1DPair> >,edm::ClonePolicy<DTRecHit1DPair> > >"/>
   <class name="std::vector<DTRecHit1D>"/>
@@ -41,8 +44,11 @@
   </class>
   <class name="std::vector<DTRecSegment4D*>"/>
   <class name="std::map<DTChamberId,std::pair<unsigned int,unsigned int> >"/>
+  <class name="std::pair<DTChamberId,std::pair<unsigned int,unsigned int> >"/>
   <class name="std::map<DTChamberId,std::pair<unsigned long,unsigned long> >"/>
+  <class name="std::pair<DTChamberId,std::pair<unsigned long,unsigned long> >"/>
   <class name="edm::OwnVector<DTRecSegment4D,edm::ClonePolicy<DTRecSegment4D> >"/>
+  <class name="edm::ClonePolicy<DTRecSegment4D>" /> <!-- Root6 -->
   <class name="edm::RangeMap <DTChamberId, edm::OwnVector<DTRecSegment4D,edm::ClonePolicy<DTRecSegment4D> >,edm::ClonePolicy<DTRecSegment4D> >"/>
   <class name="edm::Wrapper<edm::RangeMap <DTChamberId, edm::OwnVector<DTRecSegment4D,edm::ClonePolicy<DTRecSegment4D> >,edm::ClonePolicy<DTRecSegment4D> > >"/>
   <class name="DTRecSegment4DRef"/>

--- a/DataFormats/EcalDigi/src/classes_def.xml
+++ b/DataFormats/EcalDigi/src/classes_def.xml
@@ -77,10 +77,15 @@
    
    <class name="edm::SortedCollection<ESDataFrame,edm::StrictWeakOrdering<ESDataFrame> >"/>
    <class name="edm::SortedCollection<EcalTriggerPrimitiveDigi,edm::StrictWeakOrdering<EcalTriggerPrimitiveDigi> >"/>
+   <class name="edm::StrictWeakOrdering<EcalTriggerPrimitiveDigi>" /> <!-- Root6 -->
    <class name="edm::SortedCollection<EcalPseudoStripInputDigi,edm::StrictWeakOrdering<EcalPseudoStripInputDigi> >"/>
+   <class name="edm::StrictWeakOrdering<EcalPseudoStripInputDigi>" /> <!-- Root6 -->
    <class name="edm::SortedCollection<EBSrFlag,edm::StrictWeakOrdering<EBSrFlag> >"/>
+   <class name="edm::StrictWeakOrdering<EBSrFlag>" /> <!-- Root6 -->
    <class name="edm::SortedCollection<EESrFlag,edm::StrictWeakOrdering<EESrFlag> >"/>
+   <class name="edm::StrictWeakOrdering<EESrFlag>" /> <!-- Root6 -->
    <class name="edm::SortedCollection<EcalPnDiodeDigi,edm::StrictWeakOrdering<EcalPnDiodeDigi> >"/>
+   <class name="edm::StrictWeakOrdering<EcalPnDiodeDigi>" /> <!-- Root6 -->
    <class name="edm::SortedCollection<EcalMatacqDigi,edm::StrictWeakOrdering<EcalMatacqDigi> >"/>
    <class name="edm::Wrapper<edm::SortedCollection<ESDataFrame,edm::StrictWeakOrdering<ESDataFrame> > >" splitLevel="0" id="C3D41492-2914-2291-7C22-BBE6D77043F7"/>
    <class name="edm::Wrapper<edm::SortedCollection<EcalTriggerPrimitiveDigi,edm::StrictWeakOrdering<EcalTriggerPrimitiveDigi> > > " splitLevel="0" id="D932A444-CBDD-A27C-4D85-BFED25EFBCF8"/>

--- a/DataFormats/EcalRawData/src/classes_def.xml
+++ b/DataFormats/EcalRawData/src/classes_def.xml
@@ -7,6 +7,7 @@
    </class>
    <class name="std::vector<EcalDCCHeaderBlock>"/>
    <class name="edm::SortedCollection<EcalDCCHeaderBlock,edm::StrictWeakOrdering<EcalDCCHeaderBlock> >"/>
+   <class name="edm::StrictWeakOrdering<EcalDCCHeaderBlock>" /> <!-- Root6 -->
    <class name="edm::Wrapper<edm::SortedCollection<EcalDCCHeaderBlock,edm::StrictWeakOrdering<EcalDCCHeaderBlock> > >" id="679B9EAA-1B71-051A-FFD7-79D324E1AAC3"/>
    <class name="EcalListOfFEDS" ClassVersion="10">
     <version ClassVersion="10" checksum="1070537451"/>
@@ -25,12 +26,14 @@
    </class>
    <class name="std::vector<ESDCCHeaderBlock>"/>
    <class name="edm::SortedCollection<ESDCCHeaderBlock,edm::StrictWeakOrdering<ESDCCHeaderBlock> >"/>
+   <class name="edm::StrictWeakOrdering<ESDCCHeaderBlock>" /> <!-- Root6 -->
    <class name="edm::Wrapper<edm::SortedCollection<ESDCCHeaderBlock,edm::StrictWeakOrdering<ESDCCHeaderBlock> > >" />
    <class name="ESKCHIPBlock" ClassVersion="10">
     <version ClassVersion="10" checksum="3879602689"/>
    </class>
    <class name="std::vector<ESKCHIPBlock>"/>
    <class name="edm::SortedCollection<ESKCHIPBlock,edm::StrictWeakOrdering<ESKCHIPBlock> >"/>
+   <class name="edm::StrictWeakOrdering<ESKCHIPBlock>" /> <!-- Root6 -->
    <class name="edm::Wrapper<edm::SortedCollection<ESKCHIPBlock,edm::StrictWeakOrdering<ESKCHIPBlock> > >" />
 
 </lcgdict>

--- a/DataFormats/EcalRecHit/src/classes_def.xml
+++ b/DataFormats/EcalRecHit/src/classes_def.xml
@@ -9,14 +9,20 @@
   <class name="edm::Ref<edm::SortedCollection<EcalUncalibratedRecHit,edm::StrictWeakOrdering<EcalUncalibratedRecHit> >,EcalUncalibratedRecHit,edm::refhelper::FindUsingAdvance<edm::SortedCollection<EcalUncalibratedRecHit,edm::StrictWeakOrdering<EcalUncalibratedRecHit> >,EcalUncalibratedRecHit> >"/>
   <class name="edm::RefVector<edm::SortedCollection<EcalUncalibratedRecHit,edm::StrictWeakOrdering<EcalUncalibratedRecHit> >,EcalUncalibratedRecHit,edm::refhelper::FindUsingAdvance<edm::SortedCollection<EcalUncalibratedRecHit,edm::StrictWeakOrdering<EcalUncalibratedRecHit> >,EcalUncalibratedRecHit> >"/>
   <class name="edm::RefProd<edm::SortedCollection<EcalUncalibratedRecHit,edm::StrictWeakOrdering<EcalUncalibratedRecHit> > >"/>
+  <class name="edm::StrictWeakOrdering<EcalUncalibratedRecHit>"/> <!-- Root6 -->
 
   <class name="EcalRecHit" ClassVersion="12">
    <version ClassVersion="10" checksum="283504841"/>
    <version ClassVersion="11" checksum="3356791847"/>
    <version ClassVersion="12" checksum="3356791847"/>
   </class>
+  <enum name="EcalRecHit::Flags"/>
+  <enum name="EcalRecHit::ESFlags"/>
+  <enum name="EcalSeverityLevel::SeverityLevel"/>
+
   <class name="std::vector<EcalRecHit>"/>
   <class name="edm::SortedCollection<EcalRecHit,edm::StrictWeakOrdering<EcalRecHit> >"/>
+  <class name="edm::StrictWeakOrdering<EcalRecHit>" /> <!-- Root6 -->
   <class name="edm::Wrapper<edm::SortedCollection<EcalRecHit,edm::StrictWeakOrdering<EcalRecHit> > >" />
   <class name="edm::Ref<edm::SortedCollection<EcalRecHit,edm::StrictWeakOrdering<EcalRecHit> >,EcalRecHit,edm::refhelper::FindUsingAdvance<edm::SortedCollection<EcalRecHit,edm::StrictWeakOrdering<EcalRecHit> >,EcalRecHit> >"/>
   <class name="edm::RefVector<edm::SortedCollection<EcalRecHit,edm::StrictWeakOrdering<EcalRecHit> >,EcalRecHit,edm::refhelper::FindUsingAdvance<edm::SortedCollection<EcalRecHit,edm::StrictWeakOrdering<EcalRecHit> >,EcalRecHit> >"/>
@@ -45,5 +51,4 @@
   <class name="edm::Wrapper<edm::RefGetter<EcalRecHit> >"/>
  
   <class name="edm::Ref< edm::LazyGetter<EcalRecHit>, EcalRecHit, edm::FindValue<EcalRecHit> >"/>
-  <enum name="EcalSeverityLevel::SeverityLevel"/> 
 </lcgdict>

--- a/DataFormats/HcalDigi/src/classes_def.xml
+++ b/DataFormats/HcalDigi/src/classes_def.xml
@@ -74,6 +74,19 @@
    <class name="edm::SortedCollection<HcalTTPDigi,edm::StrictWeakOrdering<HcalTTPDigi> >"/>
    <class name="edm::SortedCollection<HcalUpgradeDataFrame,edm::StrictWeakOrdering<HcalUpgradeDataFrame> >"/>
 
+   <class name="edm::StrictWeakOrdering<HBHEDataFrame>"/>
+   <class name="edm::StrictWeakOrdering<HODataFrame>"/>
+   <class name="edm::StrictWeakOrdering<HFDataFrame>"/>
+   <class name="edm::StrictWeakOrdering<HcalCalibDataFrame>"/>
+   <class name="edm::StrictWeakOrdering<HcalTriggerPrimitiveDigi>"/>
+   <class name="edm::StrictWeakOrdering<HOTriggerPrimitiveDigi>"/>
+   <class name="edm::StrictWeakOrdering<HcalHistogramDigi>"/>
+   <class name="edm::StrictWeakOrdering<ZDCDataFrame>"/>
+   <class name="edm::StrictWeakOrdering<CastorDataFrame>"/>
+   <class name="edm::StrictWeakOrdering<CastorTriggerPrimitiveDigi>"/>
+   <class name="edm::StrictWeakOrdering<HcalTTPDigi>"/>
+   <class name="edm::StrictWeakOrdering<HcalUpgradeDataFrame>"/>
+
    <class name="edm::Wrapper<edm::SortedCollection<HBHEDataFrame,edm::StrictWeakOrdering<HBHEDataFrame> > >" splitLevel="0" />
    <class name="edm::Wrapper<edm::SortedCollection<HODataFrame,edm::StrictWeakOrdering<HODataFrame> > >" splitLevel="0" />
    <class name="edm::Wrapper<edm::SortedCollection<HFDataFrame,edm::StrictWeakOrdering<HFDataFrame> > >" splitLevel="0" />

--- a/DataFormats/HcalRecHit/src/classes_def.xml
+++ b/DataFormats/HcalRecHit/src/classes_def.xml
@@ -36,6 +36,14 @@
    <class name="edm::SortedCollection<ZDCRecHit,edm::StrictWeakOrdering<ZDCRecHit> >"/>
    <class name="edm::SortedCollection<CastorRecHit,edm::StrictWeakOrdering<CastorRecHit> >"/>
    <class name="edm::SortedCollection<HcalCalibRecHit,edm::StrictWeakOrdering<HcalCalibRecHit> >" splitLevel="0"/>
+
+   <class name="edm::StrictWeakOrdering<HBHERecHit>"/>
+   <class name="edm::StrictWeakOrdering<HORecHit>"/>
+   <class name="edm::StrictWeakOrdering<HFRecHit>"/>
+   <class name="edm::StrictWeakOrdering<ZDCRecHit>"/>
+   <class name="edm::StrictWeakOrdering<CastorRecHit>"/>
+   <class name="edm::StrictWeakOrdering<HcalCalibRecHit>" splitLevel="0"/>
+
    <class name="edm::Wrapper<edm::SortedCollection<HBHERecHit,edm::StrictWeakOrdering<HBHERecHit> > >" />
    <class name="edm::Wrapper<edm::SortedCollection<HORecHit,edm::StrictWeakOrdering<HORecHit> > >" />
    <class name="edm::Wrapper<edm::SortedCollection<HFRecHit,edm::StrictWeakOrdering<HFRecHit> > >" />

--- a/DataFormats/MuonReco/src/classes_def.xml
+++ b/DataFormats/MuonReco/src/classes_def.xml
@@ -65,6 +65,7 @@
   </class>
 
   <class name="reco::Muon::MuonTrackRefMap"/>
+  <class name="std::pair<MuonTrackType, reco::TrackRef> >" />
 
   <class name="reco::CaloMuon" ClassVersion="10">
    <version ClassVersion="10" checksum="3458815810"/>

--- a/DataFormats/RPCDigi/src/classes_def.xml
+++ b/DataFormats/RPCDigi/src/classes_def.xml
@@ -4,6 +4,7 @@
 </class>
 <class name="std::vector<RPCDigi>"/>
 <class name="std::map<RPCDetId,std::vector<RPCDigi> >"/>
+<class name="std::pair<RPCDetId,std::vector<RPCDigi> >"/>
 <class name="MuonDigiCollection<RPCDetId,RPCDigi>"/> 
 <class name="edm::Wrapper<MuonDigiCollection<RPCDetId,RPCDigi>>" splitLevel="0"/> 
 

--- a/DataFormats/RPCRecHit/src/classes_def.xml
+++ b/DataFormats/RPCRecHit/src/classes_def.xml
@@ -7,7 +7,10 @@
   <class name="std::vector<RPCRecHit*>" splitLevel="0"/>
   <class name="std::map<RPCDetId, std::pair<unsigned int, unsigned int> >" splitLevel="0"/>
   <class name="std::map<RPCDetId, std::pair<unsigned long, unsigned long> >" splitLevel="0"/>
+  <class name="std::pair<RPCDetId, std::pair<unsigned int, unsigned int> >" splitLevel="0"/>
+  <class name="std::pair<RPCDetId, std::pair<unsigned long, unsigned long> >" splitLevel="0"/>
   <class name="edm::OwnVector<RPCRecHit, edm::ClonePolicy<RPCRecHit> >" splitLevel="0"/>
+  <class name="edm::ClonePolicy<RPCRecHit>" /> <!-- Root6 -->
   <class name="edm::RangeMap<RPCDetId, edm::OwnVector<RPCRecHit, edm::ClonePolicy<RPCRecHit> >, edm::ClonePolicy<RPCRecHit> >" splitLevel="0"/>
   <class name="edm::Wrapper<edm::RangeMap<RPCDetId, edm::OwnVector<RPCRecHit, edm::ClonePolicy<RPCRecHit> >, edm::ClonePolicy<RPCRecHit> > >" splitLevel="0"/>
 </selection>

--- a/DataFormats/RecoCandidate/src/classes_def.xml
+++ b/DataFormats/RecoCandidate/src/classes_def.xml
@@ -126,6 +126,7 @@
    <version ClassVersion="10" checksum="4098085496"/>
   </class>
   <class name="std::multimap<reco::isodeposit::Direction::Distance,float>"/>
+  <class name="std::pair<reco::isodeposit::Direction::Distance,float>"/>
 
   <class name="reco::IsoDepositMap"/>
   <class name="edm::ValueMap<reco::IsoDeposit>::const_iterator">

--- a/DataFormats/StdDictionaries/src/classes_def_map.xml
+++ b/DataFormats/StdDictionaries/src/classes_def_map.xml
@@ -31,6 +31,7 @@
  <class name="std::map<unsigned int,std::vector<std::pair<unsigned int,int> > >"/>
  <class name="std::map<unsigned int,std::vector<unsigned int> >"/>
  <class name="std::map<unsigned int,unsigned int>"/>
+ <class name="std::pair<unsigned int,unsigned int>"/>
  <class name="std::map<unsigned long long,std::basic_string<char> >"/>
  <class name="std::map<unsigned long,std::vector<unsigned long> >"/>
  <class name="std::map<unsigned long,unsigned long>"/>

--- a/DataFormats/StdDictionaries/src/classes_def_vector.xml
+++ b/DataFormats/StdDictionaries/src/classes_def_vector.xml
@@ -4,12 +4,12 @@
  <class name="std::vector<char*>"/>
  <class name="std::vector<double>"/>
  <class name="std::vector<float>"/>
- <class name="std::vector<int>"/>
+// <class name="std::vector<int>"/>
  <class name="std::vector<long>"/>
  <class name="std::vector<long double>"/>
  <class name="std::vector<long long>"/>
  <class name="std::vector<short>"/>
- <class name="std::vector<std::basic_string<char> >"/>
+// <class name="std::vector<std::basic_string<char> >"/>
  <class name="std::vector<std::map<short,short> >"/>
  <class name="std::vector<std::pair<double,double> >"/>
  <class name="std::vector<std::pair<double,std::vector<double> > >"/>

--- a/DataFormats/TrackingRecHit/src/classes_def.xml
+++ b/DataFormats/TrackingRecHit/src/classes_def.xml
@@ -23,6 +23,7 @@
   </class>
   <class name="std::vector<TrackingRecHit*>"/>
   <class name="edm::OwnVector<TrackingRecHit, edm::ClonePolicy<TrackingRecHit> >"/>
+  <class name="edm::ClonePolicy<TrackingRecHit>"/> <!-- Root6 -->
   <class name="edm::Ref<edm::OwnVector<TrackingRecHit,edm::ClonePolicy<TrackingRecHit> >,TrackingRecHit,edm::refhelper::FindUsingAdvance<edm::OwnVector<TrackingRecHit,edm::ClonePolicy<TrackingRecHit> >,TrackingRecHit> >"/>
   <class name="edm::RefVectorIterator<edm::OwnVector<TrackingRecHit,edm::ClonePolicy<TrackingRecHit> >,TrackingRecHit,edm::refhelper::FindUsingAdvance<edm::OwnVector<TrackingRecHit,edm::ClonePolicy<TrackingRecHit> >,TrackingRecHit> >"/>
   <class pattern="std::iterator<*edm::Ref*>"/>


### PR DESCRIPTION
From Danilo Piparo:
Additional class, enum, and typedef entries in XML selection files to reduce the need for header parsing in ROOT6, and thereby reduce memory consumption.
Please merge as soon as convenient.
