### PR TITLE
Fix another missing link dependency

### DIFF
--- a/CondFormats/CastorObjects/BuildFile.xml
+++ b/CondFormats/CastorObjects/BuildFile.xml
@@ -2,6 +2,7 @@
 <use   name="DataFormats/DetId"/>
 <use   name="DataFormats/HcalDetId"/>
 <use   name="FWCore/Utilities"/>
+<use   name="CondFormats/Serialization"/>
 <use   name="boost_serialization"/>
 
 <export>


### PR DESCRIPTION
Found another missing link dependency causing fatal build errors.

Please merge as soon as feasible.

If this is not merged in time for the Oct 17 0200 build, can that build be restarted, or a new build started.
If this is not avaliable tomorrow, I will miss a whole day of productive ROOT6 work.
