### PR TITLE
Drop genParticles process name to fix empty histograms in FastSim.

### DIFF
--- a/HLTriggerOffline/Egamma/src/EmDQM.cc
+++ b/HLTriggerOffline/Egamma/src/EmDQM.cc
@@ -45,7 +45,7 @@ EmDQM::EmDQM(const edm::ParameterSet& pset_) : pset(pset_)
   histoFillerL1NonIso = new HistoFiller<l1extra::L1EmParticleCollection>(this);
 
   // consumes
-  genParticles_token = consumes<edm::View<reco::Candidate> >(edm::InputTag("genParticles", "", "SIM"));
+  genParticles_token = consumes<edm::View<reco::Candidate> >(edm::InputTag("genParticles"));
   triggerObject_token = consumes<trigger::TriggerEventWithRefs>(triggerObject_);
   hltResults_token = consumes<edm::TriggerResults>(edm::InputTag("TriggerResults", "", triggerObject_.process()));
   if (autoConfMode_) {


### PR DESCRIPTION
Hard coded genParticles process name resulted in empty histograms in FastSim after the consumes migration in 7_0_0_pre10.

This affects all Egamma HLT FastSim Relval starting from 7_0_0_pre10.
