### PR TITLE
72X - `consumes` migration X

### DIFF
--- a/PhysicsTools/JetMCAlgos/plugins/GenHFHadronMatcher.cc
+++ b/PhysicsTools/JetMCAlgos/plugins/GenHFHadronMatcher.cc
@@ -97,6 +97,7 @@ private:
 
 // ----------member data ---------------------------
     edm::InputTag genJets_;
+    edm::EDGetTokenT<reco::GenJetCollection> genJetsToken_;
     int flavour_;
     bool noBBbarResonances_;
     bool onlyJetClusteredHadrons_;
@@ -147,6 +148,7 @@ GenHFHadronMatcher::GenHFHadronMatcher ( const edm::ParameterSet& cfg )
 {
 
     genJets_           = cfg.getParameter<edm::InputTag> ( "genJets" );
+    genJetsToken_      = consumes<reco::GenJetCollection>(genJets_);
     flavour_           = cfg.getParameter<int> ( "flavour" );
     noBBbarResonances_ = cfg.getParameter<bool> ( "noBBbarResonances" );
     onlyJetClusteredHadrons_ = cfg.getParameter<bool> ( "onlyJetClusteredHadrons" );
@@ -219,7 +221,7 @@ void GenHFHadronMatcher::produce ( edm::Event& evt, const edm::EventSetup& setup
     using namespace edm;
 
     edm::Handle<reco::GenJetCollection> genJets;
-    evt.getByLabel ( genJets_, genJets );
+    evt.getByToken ( genJetsToken_, genJets );
 
 
     // Defining adron matching variables

--- a/PhysicsTools/JetMCAlgos/plugins/InputGenJetsParticlePlusHadronSelector.cc
+++ b/PhysicsTools/JetMCAlgos/plugins/InputGenJetsParticlePlusHadronSelector.cc
@@ -41,7 +41,7 @@
 using namespace std;
 
 InputGenJetsParticlePlusHadronSelector::InputGenJetsParticlePlusHadronSelector(const edm::ParameterSet &params ):
-  inTag(params.getParameter<edm::InputTag>("src")),
+  inToken(consumes<reco::GenParticleCollection>(params.getParameter<edm::InputTag>("src"))),
   flavours(params.getParameter<std::vector<int> >("injectHadronFlavours")),
   partonicFinalState(params.getParameter<bool>("partonicFinalState")),
   excludeResonances(params.getParameter<bool>("excludeResonances")),
@@ -228,8 +228,7 @@ void InputGenJetsParticlePlusHadronSelector::produce (edm::Event &evt, const edm
   std::auto_ptr<reco::GenParticleCollection> selected_ (new reco::GenParticleCollection);
 
   edm::Handle<reco::GenParticleCollection> genParticles;
-  //  evt.getByLabel("genParticles", genParticles );
-  evt.getByLabel(inTag, genParticles );
+  evt.getByToken(inToken, genParticles );
 
   ParticleVector particles;
   for (reco::GenParticleCollection::const_iterator iter=genParticles->begin();iter!=genParticles->end();++iter){

--- a/PhysicsTools/JetMCAlgos/plugins/InputGenJetsParticlePlusHadronSelector.h
+++ b/PhysicsTools/JetMCAlgos/plugins/InputGenJetsParticlePlusHadronSelector.h
@@ -76,7 +76,7 @@ class InputGenJetsParticlePlusHadronSelector : public edm::EDProducer {
   //container selected_;  //container required by selector
   InputGenJetsParticlePlusHadronSelector(){} //should not be used!
   
-  edm::InputTag inTag;
+  edm::EDGetTokenT<reco::GenParticleCollection> inToken;
   int testPartonChildren(ParticleBitmap &invalid,
 			 const ParticleVector &p,
 			 const reco::GenParticle *particle) const;

--- a/PhysicsTools/PatUtils/interface/RazorComputer.h
+++ b/PhysicsTools/PatUtils/interface/RazorComputer.h
@@ -1,6 +1,8 @@
 #ifndef PhysicsToolsPatUtils_RazorComputer_H
 #define PhysicsToolsPatUtils_RazorComputer_H
 #include "PhysicsTools/UtilAlgos/interface/CachingVariable.h"
+#include "DataFormats/PatCandidates/interface/Jet.h"
+#include "DataFormats/PatCandidates/interface/MET.h"
 
 
 class RazorBox : public CachingVariable {
@@ -22,6 +24,8 @@ class RazorComputer : public VariableComputer {
  private:
   edm::InputTag jet_;
   edm::InputTag met_;
+  edm::EDGetTokenT<std::vector<pat::Jet>> jetToken_;
+  edm::EDGetTokenT<std::vector<pat::MET>> metToken_;
   float pt_,eta_;
   
 };

--- a/PhysicsTools/PatUtils/src/RazorComputer.cc
+++ b/PhysicsTools/PatUtils/src/RazorComputer.cc
@@ -1,6 +1,4 @@
 #include "PhysicsTools/PatUtils/interface/RazorComputer.h"
-#include "DataFormats/PatCandidates/interface/Jet.h"
-#include "DataFormats/PatCandidates/interface/MET.h"
 #include "TLorentzVector.h"
 
 RazorBox::RazorBox( const CachingVariable::CachingVariableFactoryArg& arg, edm::ConsumesCollector& iC) :
@@ -15,8 +13,8 @@ void RazorBox::compute( const edm::Event & iEvent) const{
 RazorComputer::RazorComputer( const CachingVariable::CachingVariableFactoryArg& arg, edm::ConsumesCollector& iC) : VariableComputer(arg,iC){
   jet_ = edm::Service<InputTagDistributorService>()->retrieve("jet",arg.iConfig);
   met_ = edm::Service<InputTagDistributorService>()->retrieve("met",arg.iConfig);
-  iC.consumes<std::vector<pat::Jet>>(jet_);
-  iC.consumes<std::vector<pat::MET>>(met_);
+  jetToken_ = iC.consumes<std::vector<pat::Jet>>(jet_);
+  metToken_ = iC.consumes<std::vector<pat::MET>>(met_);
   pt_ = 40.;
   eta_=2.4;
 
@@ -57,8 +55,8 @@ void RazorComputer::compute(const edm::Event & iEvent) const{
 
   edm::Handle<std::vector<pat::Jet>> jetH;
   edm::Handle<std::vector<pat::MET>> metH;
-  iEvent.getByLabel( jet_, jetH);
-  iEvent.getByLabel( met_, metH);
+  iEvent.getByToken( jetToken_, jetH);
+  iEvent.getByToken( metToken_, metH);
   
   typedef reco::Candidate::LorentzVector LorentzVector;
 


### PR DESCRIPTION
Fix some accidentally introduced/accepted `getByLabel` usages
(backport from #5870 ).
