### PR TITLE
HCAL NZS customization (for DIGI step) added

### DIFF
--- a/SLHCUpgradeSimulations/Configuration/python/hcalNZS.py
+++ b/SLHCUpgradeSimulations/Configuration/python/hcalNZS.py
@@ -2,10 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 def customise_hcalNZS(process):
     if hasattr(process,'simHcalDigis'):
-        process.simHcalDigis.useConfigZSvalues=cms.int32(1)
-        process.simHcalDigis.HBlevel=cms.int32(-999)
-        process.simHcalDigis.HElevel=cms.int32(-999)
-        process.simHcalDigis.HOlevel=cms.int32(-999)
-        process.simHcalDigis.HFlevel=cms.int32(-999)
+        process.simHcalDigis.markAndPass = cms.bool(True)
 
     return process

--- a/SLHCUpgradeSimulations/Configuration/python/hcalNZS.py
+++ b/SLHCUpgradeSimulations/Configuration/python/hcalNZS.py
@@ -1,0 +1,11 @@
+import FWCore.ParameterSet.Config as cms
+
+def customise_hcalNZS(process):
+    if hasattr(process,'simHcalDigis'):
+        process.simHcalDigis.useConfigZSvalues=cms.int32(1)
+        process.simHcalDigis.HBlevel=cms.int32(-999)
+        process.simHcalDigis.HElevel=cms.int32(-999)
+        process.simHcalDigis.HOlevel=cms.int32(-999)
+        process.simHcalDigis.HFlevel=cms.int32(-999)
+
+    return process


### PR DESCRIPTION
For some special HCAL MC production, we need NZS samples. This small "standalone" customization snippet will then be helpful 
-- customize SLHCUpgradeSimulations/Configuration/hcalNZS.customise_hcalNZS
