### PR TITLE
Take the EE FEDs out of the HGCal raw-to-digi step

### DIFF
--- a/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
@@ -256,6 +256,24 @@ def cust_2023HGCal(process):
         process.mix.mixObjects.mixCH.subdets.append( process.hgceeDigitizer.hitCollection.value() )
         process.mix.mixObjects.mixCH.subdets.append( process.hgchebackDigitizer.hitCollection.value() )
         process.mix.mixObjects.mixCH.subdets.append( process.hgchefrontDigitizer.hitCollection.value() )
+    if hasattr(process,'raw2digi_step'):
+        process.ecalDigis.FEDs = cms.vint32(
+            # EE-:
+            #601, 602, 603, 604, 605,
+            #606, 607, 608, 609,
+            # EB-:
+            610, 611, 612, 613, 614, 615,
+            616, 617, 618, 619, 620, 621,
+            622, 623, 624, 625, 626, 627,
+            # EB+:
+            628, 629, 630, 631, 632, 633,
+            634, 635, 636, 637, 638, 639,
+            640, 641, 642, 643, 644, 645,
+            # EE+:
+            #646, 647, 648, 649, 650,
+            #651, 652, 653, 654
+            )
+        print "RAW2DIGI only for EB FEDs"
     if hasattr(process,'reconstruction_step'):
         process.particleFlowCluster += process.particleFlowRecHitHGC
         process.particleFlowCluster += process.particleFlowClusterHGC
@@ -319,6 +337,24 @@ def cust_2023HGCalMuon(process):
         process.mix.mixObjects.mixCH.subdets.append( process.hgceeDigitizer.hitCollection.value() )
         process.mix.mixObjects.mixCH.subdets.append( process.hgchebackDigitizer.hitCollection.value() )
         process.mix.mixObjects.mixCH.subdets.append( process.hgchefrontDigitizer.hitCollection.value() )
+    if hasattr(process,'raw2digi_step'):
+        process.ecalDigis.FEDs = cms.vint32(
+            # EE-:
+            #601, 602, 603, 604, 605,
+            #606, 607, 608, 609,
+            # EB-:
+            610, 611, 612, 613, 614, 615,
+            616, 617, 618, 619, 620, 621,
+            622, 623, 624, 625, 626, 627,
+            # EB+:
+            628, 629, 630, 631, 632, 633,
+            634, 635, 636, 637, 638, 639,
+            640, 641, 642, 643, 644, 645,
+            # EE+:
+            #646, 647, 648, 649, 650,
+            #651, 652, 653, 654
+            )
+        print "RAW2DIGI only for EB FEDs"
     if hasattr(process,'reconstruction_step'):
         process.particleFlowCluster += process.particleFlowRecHitHGC
         process.particleFlowCluster += process.particleFlowClusterHGC


### PR DESCRIPTION
Copied the customisation change from the Shashlik customisation.  This should fix the high RelVal failure rate seen recently for HGCal.  I'm surprised any of them worked.

@vandreev11, @pfs, @boudoul
