### PR TITLE
fixed data race in decay table definition in MT mode

### DIFF
--- a/SimG4Core/Application/interface/RunManagerMT.h
+++ b/SimG4Core/Application/interface/RunManagerMT.h
@@ -39,7 +39,7 @@ class DDCompactView;
 class DDDWorld;
 class MagneticField;
 
-class G4RunManagerKernel;
+class G4MTRunManagerKernel;
 class G4Run;
 class G4Event;
 class G4Field;
@@ -109,7 +109,7 @@ private:
   void terminateRun();
   void DumpMagneticField( const G4Field*) const;
 
-  G4RunManagerKernel * m_kernel;
+  G4MTRunManagerKernel * m_kernel;
     
   std::unique_ptr<PhysicsList> m_physicsList;
   bool m_managerInitialized;

--- a/SimG4Core/Application/src/RunManagerMT.cc
+++ b/SimG4Core/Application/src/RunManagerMT.cc
@@ -142,6 +142,7 @@ void RunManagerMT::initG4(const DDCompactView *pDD, const MagneticField *pMF, co
   
   m_kernel->SetPhysics(phys);
   m_kernel->InitializePhysics();
+  m_kernel->SetUpDecayChannels();
   // The following line was with the following comment in
   // G4MTRunManager::InitializePhysics() in 10.00.p01; in practice
   // needed to initialize certain singletons during the master thread


### PR DESCRIPTION
Fixed data race in SIM in MT mode due to incomplete initialisation of decay tables which is a responsibility of CMSSW.

No effect on mainstream SIM production.
