### PR TITLE
TrackCountingComputer update for displaced jets

### DIFF
--- a/RecoBTag/ImpactParameter/interface/TrackCountingComputer.h
+++ b/RecoBTag/ImpactParameter/interface/TrackCountingComputer.h
@@ -16,7 +16,7 @@ class TrackCountingComputer : public JetTagComputer
   TrackCountingComputer(const edm::ParameterSet  & parameters )
   {
     m_minIP            = parameters.existsAs<double>("minimumImpactParameter") ? parameters.getParameter<double>("minimumImpactParameter") : -1;
-    m_useSignedIPSig   = parameters.existsAs<double>("useSignedImpactParameterSig") ? parameters.getParameter<double>("useSignedImpactParameterSig") : true;
+    m_useSignedIPSig   = parameters.existsAs<bool>("useSignedImpactParameterSig") ? parameters.getParameter<bool>("useSignedImpactParameterSig") : true;
     m_nthTrack         = parameters.getParameter<int>("nthTrack");
     m_ipType           = parameters.getParameter<int>("impactParameterType");
     m_deltaR           = parameters.getParameter<double>("deltaR");

--- a/RecoBTag/ImpactParameter/interface/TrackCountingComputer.h
+++ b/RecoBTag/ImpactParameter/interface/TrackCountingComputer.h
@@ -15,10 +15,8 @@ class TrackCountingComputer : public JetTagComputer
  public:
   TrackCountingComputer(const edm::ParameterSet  & parameters )
   {
-    
-    m_minIP         = parameters.getParameter<double>("minimumImpactParameter");
-    m_useSignedIPSig = parameters.getParameter<bool>("useSignedImpactParameterSig");
-
+    m_minIP            = parameters.existsAs<double>("minimumImpactParameter") ? parameters.getParameter<double>("minimumImpactParameter") : -1;
+    m_useSignedIPSig   = parameters.existsAs<double>("useSignedImpactParameterSig") ? parameters.getParameter<double>("useSignedImpactParameterSig") : true;
     m_nthTrack         = parameters.getParameter<int>("nthTrack");
     m_ipType           = parameters.getParameter<int>("impactParameterType");
     m_deltaR           = parameters.getParameter<double>("deltaR");

--- a/RecoBTag/ImpactParameter/interface/TrackCountingComputer.h
+++ b/RecoBTag/ImpactParameter/interface/TrackCountingComputer.h
@@ -15,6 +15,7 @@ class TrackCountingComputer : public JetTagComputer
  public:
   TrackCountingComputer(const edm::ParameterSet  & parameters )
   {
+
     m_nthTrack         = parameters.getParameter<int>("nthTrack");
     m_ipType           = parameters.getParameter<int>("impactParameterType");
     m_deltaR           = parameters.getParameter<double>("deltaR");

--- a/RecoBTag/ImpactParameter/interface/TrackCountingComputer.h
+++ b/RecoBTag/ImpactParameter/interface/TrackCountingComputer.h
@@ -15,6 +15,9 @@ class TrackCountingComputer : public JetTagComputer
  public:
   TrackCountingComputer(const edm::ParameterSet  & parameters )
   {
+    
+    m_minIP         = parameters.getParameter<double>("minimumImpactParameter");
+    m_useSignedIPSig = parameters.getParameter<bool>("useSignedImpactParameterSig");
 
     m_nthTrack         = parameters.getParameter<int>("nthTrack");
     m_ipType           = parameters.getParameter<int>("impactParameterType");
@@ -73,14 +76,21 @@ class TrackCountingComputer : public JetTagComputer
     for(std::vector<reco::btag::TrackIPData>::const_iterator it = impactParameters.begin(); it!=impactParameters.end(); ++it, i++)  {
       if( fabs(impactParameters[i].distanceToJetAxis.value()) < m_cutMaxDistToAxis  &&        // distance to JetAxis
 	  (impactParameters[i].closestToJetAxis - pv).mag() < m_cutMaxDecayLen  &&      // max decay len
-	  (m_useAllQualities  == true || (*tracks[i]).quality(m_trackQuality)) // use selected track qualities
+	  (m_useAllQualities  == true || (*tracks[i]).quality(m_trackQuality)) && // use selected track qualities
+	  (fabs(((m_ipType==0) ? it->ip3d:it->ip2d).value()) > m_minIP) // minimum impact parameter
 	  ) {	 
+
+	//calculate the signed or un-signed significance
+	float signed_sig = ((m_ipType == 0) ? it->ip3d : it->ip2d).significance();  
+	float unsigned_sig = fabs(signed_sig);
+	float significance = (m_useSignedIPSig) ? signed_sig : unsigned_sig;
+
 	if (useVariableJTA_) {
-	  if (tkip.variableJTA( varJTApars )[i])  significances.insert( ((m_ipType==0)?it->ip3d:it->ip2d).significance() );
+	  if (tkip.variableJTA( varJTApars )[i])  significances.insert( significance );
 	}
 	else // no using variable JTA, use the default method 
 	  if(m_deltaR <=0  || ROOT::Math::VectorUtil::DeltaR((*tkip.jet()).p4().Vect(), (*tracks[i]).momentum()) < m_deltaR)
-	    significances.insert( ((m_ipType==0)?it->ip3d:it->ip2d).significance() );
+	    significances.insert( significance );
       }
     }	  
     
@@ -90,7 +100,10 @@ class TrackCountingComputer : public JetTagComputer
   
   bool useVariableJTA_;
   reco::btag::variableJTAParameters varJTApars;
-  
+
+  double m_minIP;
+  bool m_useSignedIPSig;
+
   int m_nthTrack;
   int m_ipType;
   double m_deltaR;

--- a/RecoBTag/ImpactParameter/python/promptTrackCountingComputer_cfi.py
+++ b/RecoBTag/ImpactParameter/python/promptTrackCountingComputer_cfi.py
@@ -9,7 +9,8 @@ import FWCore.ParameterSet.Config as cms
 
 promptTrackCounting = cms.ESProducer("PromptTrackCountingESProducer",
     impactParameterType = cms.int32(0), ## 0 = 3D, 1 = 2D
-
+    minimumImpactParameter = cms.double(-1),                                     
+    useSignedImpactParameterSig = cms.bool(True), 
     maximumDistanceToJetAxis = cms.double(999999.0),
     deltaR = cms.double(-1.0), ## maximum deltaR of track to jet. If -ve just use cut from JTA
     deltaRmin = cms.double(0.0), ## minimum deltaR of track to jet.                                     

--- a/RecoBTag/ImpactParameter/python/trackCounting3D1stComputer_cfi.py
+++ b/RecoBTag/ImpactParameter/python/trackCounting3D1stComputer_cfi.py
@@ -5,8 +5,9 @@ from RecoBTag.ImpactParameter.variableJTA_cfi import *
 # trackCounting3D1st btag computer
 trackCounting3D1st = cms.ESProducer("TrackCountingESProducer",
                                     variableJTAPars,
-                                    impactParameterType = cms.int32(0), ## 0 = 3D, 1 = 2D
-                                    
+                                    minimumImpactParameter = cms.double(-1),
+                                    useSignedImpactParameterSig = cms.bool(True),
+                                    impactParameterType = cms.int32(0), ## 0 = 3D, 1 = 2D                                    
                                     maximumDistanceToJetAxis = cms.double(0.07),
                                     deltaR = cms.double(-1.0), ## use cut from JTA
                                     

--- a/RecoBTag/ImpactParameter/python/trackCounting3D2ndComputer_cfi.py
+++ b/RecoBTag/ImpactParameter/python/trackCounting3D2ndComputer_cfi.py
@@ -5,11 +5,11 @@ from RecoBTag.ImpactParameter.variableJTA_cfi import *
 # trackCounting3D2nd btag computer
 trackCounting3D2nd = cms.ESProducer("TrackCountingESProducer",
                                     variableJTAPars,
+                                    minimumImpactParameter = cms.double(-1),
+                                    useSignedImpactParameterSig = cms.bool(True),
                                     impactParameterType = cms.int32(0), ## 0 = 3D, 1 = 2D
-                                    
                                     maximumDistanceToJetAxis = cms.double(0.07),
-                                    deltaR = cms.double(-1.0), ## use cut from JTA
-                                    
+                                    deltaR = cms.double(-1.0), ## use cut from JTA                                    
                                     maximumDecayLength = cms.double(5.0),
                                     nthTrack = cms.int32(2),
                                     trackQualityClass = cms.string("any"),

--- a/RecoBTag/ImpactParameter/python/trackCounting3D3rdComputer_cfi.py
+++ b/RecoBTag/ImpactParameter/python/trackCounting3D3rdComputer_cfi.py
@@ -5,6 +5,8 @@ from RecoBTag.ImpactParameter.variableJTA_cfi import *
 # trackCounting3D3rd btag computer
 trackCounting3D3rd = cms.ESProducer("TrackCountingESProducer",
                                     variableJTAPars,
+                                    minimumImpactParameter = cms.double(-1),
+                                    useSignedImpactParameterSig = cms.bool(True),
                                     impactParameterType = cms.int32(0), ## 0 = 3D, 1 = 2D
                                     
                                     maximumDistanceToJetAxis = cms.double(0.07),


### PR DESCRIPTION
Added functionality for tagging displaced jets using the b-tagging track counting computer at HLT. For use in confDB.

Added a minimum impact parameter cut to remove background events which low displacement but high Impact parameter significance. 

Added an option to sort tracks using unsigned impact parameter significance. When the a long lived particle (X) decays to two jets and the X is not significantly boosted, one of the jets flight path can be opposite that of the (X). This produces high negative values of Impact parameter significance.

Fragments updated and existAs statements added to produce old behavior. 
