### PR TITLE
DQM pixel update strings

### DIFF
--- a/DQM/SiPixelCommon/interface/SiPixelFolderOrganizer.h
+++ b/DQM/SiPixelCommon/interface/SiPixelFolderOrganizer.h
@@ -44,7 +44,7 @@ class SiPixelFolderOrganizer {
   
  private:
 
-  std::string TopFolderName;
+  std::string topFolderName;
   DQMStore* dbe_;
 };
 #endif

--- a/DQM/SiPixelCommon/interface/SiPixelFolderOrganizer.h
+++ b/DQM/SiPixelCommon/interface/SiPixelFolderOrganizer.h
@@ -44,7 +44,7 @@ class SiPixelFolderOrganizer {
   
  private:
 
-  std::string rootFolder;
+  std::string TopFolderName;
   DQMStore* dbe_;
 };
 #endif

--- a/DQM/SiPixelCommon/src/SiPixelFolderOrganizer.cc
+++ b/DQM/SiPixelCommon/src/SiPixelFolderOrganizer.cc
@@ -15,7 +15,7 @@
 
 /// Constructor
 SiPixelFolderOrganizer::SiPixelFolderOrganizer(bool getStore) :
-  TopFolderName("Pixel")
+  topFolderName("Pixel")
 {  
   //Not allowed in multithread framework, but can still be called by other modules not from DQM.
   if (getStore) dbe_ = edm::Service<DQMStore>().operator->();
@@ -29,7 +29,7 @@ bool SiPixelFolderOrganizer::setModuleFolder(const uint32_t& rawdetid, int type,
   bool flag = false;
 
    if(rawdetid == 0) {
-     dbe_->setCurrentFolder(TopFolderName);
+     dbe_->setCurrentFolder(topFolderName);
      flag = true;
    }
    ///
@@ -53,7 +53,7 @@ bool SiPixelFolderOrganizer::setModuleFolder(const uint32_t& rawdetid, int type,
      
      std::ostringstream sfolder;
      
-     sfolder << TopFolderName << "/" << subDetectorFolder; 
+     sfolder << topFolderName << "/" << subDetectorFolder; 
      if(type<4){
      sfolder << "/Shell_" <<DBshell
 	     << "/" << slayer;
@@ -86,7 +86,7 @@ bool SiPixelFolderOrganizer::setModuleFolder(const uint32_t& rawdetid, int type,
        
        std::ostringstream sfolder;
        
-       sfolder << TopFolderName << "/" << subDetectorFolder; 
+       sfolder << topFolderName << "/" << subDetectorFolder; 
        if(type<4){
        sfolder << "/Shell_" <<DBshell
                << "/" << slayer;
@@ -129,7 +129,7 @@ bool SiPixelFolderOrganizer::setModuleFolder(const uint32_t& rawdetid, int type,
 
       std::ostringstream sfolder;
 
-      sfolder <<TopFolderName <<"/" << subDetectorFolder << 
+      sfolder <<topFolderName <<"/" << subDetectorFolder << 
 	"/HalfCylinder_" << side << "/" << sdisk; 
       if(type==0 || type ==4){
 	sfolder << "/" << sblade; 
@@ -165,7 +165,7 @@ bool SiPixelFolderOrganizer::setModuleFolder(const uint32_t& rawdetid, int type,
         
         std::ostringstream sfolder;
         
-        sfolder <<TopFolderName <<"/" << subDetectorFolder << 
+        sfolder <<topFolderName <<"/" << subDetectorFolder << 
           "/HalfCylinder_" << side << "/" << sdisk; 
         if(type==0 || type ==4){
           sfolder << "/" << sblade; 
@@ -195,7 +195,7 @@ bool SiPixelFolderOrganizer::setModuleFolder(DQMStore::IBooker& iBooker, const u
   bool flag = false;
 
    if(rawdetid == 0) {
-     iBooker.setCurrentFolder(TopFolderName);
+     iBooker.setCurrentFolder(topFolderName);
      flag = true;
    }
    ///
@@ -219,7 +219,7 @@ bool SiPixelFolderOrganizer::setModuleFolder(DQMStore::IBooker& iBooker, const u
      
      std::ostringstream sfolder;
      
-     sfolder << TopFolderName << "/" << subDetectorFolder; 
+     sfolder << topFolderName << "/" << subDetectorFolder; 
      if(type<4){
      sfolder << "/Shell_" <<DBshell
 	     << "/" << slayer;
@@ -252,7 +252,7 @@ bool SiPixelFolderOrganizer::setModuleFolder(DQMStore::IBooker& iBooker, const u
        
        std::ostringstream sfolder;
        
-       sfolder << TopFolderName << "/" << subDetectorFolder; 
+       sfolder << topFolderName << "/" << subDetectorFolder; 
        if(type<4){
        sfolder << "/Shell_" <<DBshell
                << "/" << slayer;
@@ -295,7 +295,7 @@ bool SiPixelFolderOrganizer::setModuleFolder(DQMStore::IBooker& iBooker, const u
 
       std::ostringstream sfolder;
 
-      sfolder <<TopFolderName <<"/" << subDetectorFolder << 
+      sfolder <<topFolderName <<"/" << subDetectorFolder << 
 	"/HalfCylinder_" << side << "/" << sdisk; 
       if(type==0 || type ==4){
 	sfolder << "/" << sblade; 
@@ -331,7 +331,7 @@ bool SiPixelFolderOrganizer::setModuleFolder(DQMStore::IBooker& iBooker, const u
         
         std::ostringstream sfolder;
         
-        sfolder <<TopFolderName <<"/" << subDetectorFolder << 
+        sfolder <<topFolderName <<"/" << subDetectorFolder << 
           "/HalfCylinder_" << side << "/" << sdisk; 
         if(type==0 || type ==4){
           sfolder << "/" << sblade; 
@@ -362,7 +362,7 @@ bool SiPixelFolderOrganizer::setFedFolder(const uint32_t FedId) {
   char sFed[80];  sprintf(sFed,  "FED_%i",FedId);
   std::ostringstream sfolder;
   
-  sfolder << TopFolderName << "/" << subDetectorFolder << "/" << sFed;
+  sfolder << topFolderName << "/" << subDetectorFolder << "/" << sFed;
   dbe_->setCurrentFolder(sfolder.str().c_str());
   
   return true;
@@ -376,7 +376,7 @@ bool SiPixelFolderOrganizer::setFedFolder(DQMStore::IBooker& iBooker, const uint
   char sFed[80];  sprintf(sFed,  "FED_%i",FedId);
   std::ostringstream sfolder;
   
-  sfolder << TopFolderName << "/" << subDetectorFolder << "/" << sFed;
+  sfolder << topFolderName << "/" << subDetectorFolder << "/" << sFed;
   iBooker.setCurrentFolder(sfolder.str().c_str());
   
   return true;
@@ -387,7 +387,7 @@ void SiPixelFolderOrganizer::getModuleFolder(const uint32_t& rawdetid,
                                              std::string& path,
                                              bool isUpgrade) {
 
-  path = TopFolderName;
+  path = topFolderName;
   if(rawdetid == 0) {
     return;
   }else if( (DetId(rawdetid).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel)) && (!isUpgrade) ) {
@@ -403,7 +403,7 @@ void SiPixelFolderOrganizer::getModuleFolder(const uint32_t& rawdetid,
     char smodule[80]; sprintf(smodule,"Module_%i",  DBmodule);
     
     std::ostringstream sfolder;
-    sfolder << TopFolderName << "/" << subDetectorFolder << "/Shell_" <<DBshell << "/" << slayer << "/" << sladder;
+    sfolder << topFolderName << "/" << subDetectorFolder << "/Shell_" <<DBshell << "/" << slayer << "/" << sladder;
     if ( PixelBarrelName(DetId(rawdetid)).isHalfModule() ) sfolder <<"H"; 
     else sfolder <<"F";
     sfolder << "/" <<smodule;
@@ -428,7 +428,7 @@ void SiPixelFolderOrganizer::getModuleFolder(const uint32_t& rawdetid,
     char smodule[80]; sprintf(smodule,"Module_%i",  DBmodule);
     
     std::ostringstream sfolder;
-    sfolder << TopFolderName << "/" << subDetectorFolder << "/Shell_" <<DBshell << "/" << slayer << "/" << sladder;
+    sfolder << topFolderName << "/" << subDetectorFolder << "/Shell_" <<DBshell << "/" << slayer << "/" << sladder;
     if ( PixelBarrelNameUpgrade(DetId(rawdetid)).isHalfModule() ) sfolder <<"H"; 
     else sfolder <<"F";
     sfolder << "/" <<smodule;
@@ -455,7 +455,7 @@ void SiPixelFolderOrganizer::getModuleFolder(const uint32_t& rawdetid,
     char smodule[80];sprintf(smodule,"Module_%i",module);
 
     std::ostringstream sfolder;
-    sfolder <<TopFolderName <<"/" << subDetectorFolder << "/HalfCylinder_" << side << "/" << sdisk << "/" << sblade << "/" << spanel << "/" << smodule;
+    sfolder <<topFolderName <<"/" << subDetectorFolder << "/HalfCylinder_" << side << "/" << sdisk << "/" << sblade << "/" << spanel << "/" << smodule;
     path = sfolder.str().c_str();
     
     //path = path + "/" + subDetectorFolder + "/" + shc + "/" + sdisk + "/" + sblade + "/" + spanel + "/" + smodule;
@@ -475,7 +475,7 @@ void SiPixelFolderOrganizer::getModuleFolder(const uint32_t& rawdetid,
     char smodule[80];sprintf(smodule,"Module_%i",module);
 
     std::ostringstream sfolder;
-    sfolder <<TopFolderName <<"/" << subDetectorFolder << "/HalfCylinder_" << side << "/" << sdisk << "/" << sblade << "/" << spanel << "/" << smodule;
+    sfolder <<topFolderName <<"/" << subDetectorFolder << "/HalfCylinder_" << side << "/" << sdisk << "/" << sblade << "/" << spanel << "/" << smodule;
     path = sfolder.str().c_str();
     
     //path = path + "/" + subDetectorFolder + "/" + shc + "/" + sdisk + "/" + sblade + "/" + spanel + "/" + smodule;

--- a/DQM/SiPixelCommon/src/SiPixelFolderOrganizer.cc
+++ b/DQM/SiPixelCommon/src/SiPixelFolderOrganizer.cc
@@ -15,7 +15,7 @@
 
 /// Constructor
 SiPixelFolderOrganizer::SiPixelFolderOrganizer(bool getStore) :
-  rootFolder("Pixel")
+  TopFolderName("Pixel")
 {  
   //Not allowed in multithread framework, but can still be called by other modules not from DQM.
   if (getStore) dbe_ = edm::Service<DQMStore>().operator->();
@@ -29,7 +29,7 @@ bool SiPixelFolderOrganizer::setModuleFolder(const uint32_t& rawdetid, int type,
   bool flag = false;
 
    if(rawdetid == 0) {
-     dbe_->setCurrentFolder(rootFolder);
+     dbe_->setCurrentFolder(TopFolderName);
      flag = true;
    }
    ///
@@ -53,7 +53,7 @@ bool SiPixelFolderOrganizer::setModuleFolder(const uint32_t& rawdetid, int type,
      
      std::ostringstream sfolder;
      
-     sfolder << rootFolder << "/" << subDetectorFolder; 
+     sfolder << TopFolderName << "/" << subDetectorFolder; 
      if(type<4){
      sfolder << "/Shell_" <<DBshell
 	     << "/" << slayer;
@@ -86,7 +86,7 @@ bool SiPixelFolderOrganizer::setModuleFolder(const uint32_t& rawdetid, int type,
        
        std::ostringstream sfolder;
        
-       sfolder << rootFolder << "/" << subDetectorFolder; 
+       sfolder << TopFolderName << "/" << subDetectorFolder; 
        if(type<4){
        sfolder << "/Shell_" <<DBshell
                << "/" << slayer;
@@ -129,7 +129,7 @@ bool SiPixelFolderOrganizer::setModuleFolder(const uint32_t& rawdetid, int type,
 
       std::ostringstream sfolder;
 
-      sfolder <<rootFolder <<"/" << subDetectorFolder << 
+      sfolder <<TopFolderName <<"/" << subDetectorFolder << 
 	"/HalfCylinder_" << side << "/" << sdisk; 
       if(type==0 || type ==4){
 	sfolder << "/" << sblade; 
@@ -165,7 +165,7 @@ bool SiPixelFolderOrganizer::setModuleFolder(const uint32_t& rawdetid, int type,
         
         std::ostringstream sfolder;
         
-        sfolder <<rootFolder <<"/" << subDetectorFolder << 
+        sfolder <<TopFolderName <<"/" << subDetectorFolder << 
           "/HalfCylinder_" << side << "/" << sdisk; 
         if(type==0 || type ==4){
           sfolder << "/" << sblade; 
@@ -195,7 +195,7 @@ bool SiPixelFolderOrganizer::setModuleFolder(DQMStore::IBooker& iBooker, const u
   bool flag = false;
 
    if(rawdetid == 0) {
-     iBooker.setCurrentFolder(rootFolder);
+     iBooker.setCurrentFolder(TopFolderName);
      flag = true;
    }
    ///
@@ -219,7 +219,7 @@ bool SiPixelFolderOrganizer::setModuleFolder(DQMStore::IBooker& iBooker, const u
      
      std::ostringstream sfolder;
      
-     sfolder << rootFolder << "/" << subDetectorFolder; 
+     sfolder << TopFolderName << "/" << subDetectorFolder; 
      if(type<4){
      sfolder << "/Shell_" <<DBshell
 	     << "/" << slayer;
@@ -252,7 +252,7 @@ bool SiPixelFolderOrganizer::setModuleFolder(DQMStore::IBooker& iBooker, const u
        
        std::ostringstream sfolder;
        
-       sfolder << rootFolder << "/" << subDetectorFolder; 
+       sfolder << TopFolderName << "/" << subDetectorFolder; 
        if(type<4){
        sfolder << "/Shell_" <<DBshell
                << "/" << slayer;
@@ -295,7 +295,7 @@ bool SiPixelFolderOrganizer::setModuleFolder(DQMStore::IBooker& iBooker, const u
 
       std::ostringstream sfolder;
 
-      sfolder <<rootFolder <<"/" << subDetectorFolder << 
+      sfolder <<TopFolderName <<"/" << subDetectorFolder << 
 	"/HalfCylinder_" << side << "/" << sdisk; 
       if(type==0 || type ==4){
 	sfolder << "/" << sblade; 
@@ -331,7 +331,7 @@ bool SiPixelFolderOrganizer::setModuleFolder(DQMStore::IBooker& iBooker, const u
         
         std::ostringstream sfolder;
         
-        sfolder <<rootFolder <<"/" << subDetectorFolder << 
+        sfolder <<TopFolderName <<"/" << subDetectorFolder << 
           "/HalfCylinder_" << side << "/" << sdisk; 
         if(type==0 || type ==4){
           sfolder << "/" << sblade; 
@@ -362,7 +362,7 @@ bool SiPixelFolderOrganizer::setFedFolder(const uint32_t FedId) {
   char sFed[80];  sprintf(sFed,  "FED_%i",FedId);
   std::ostringstream sfolder;
   
-  sfolder << rootFolder << "/" << subDetectorFolder << "/" << sFed;
+  sfolder << TopFolderName << "/" << subDetectorFolder << "/" << sFed;
   dbe_->setCurrentFolder(sfolder.str().c_str());
   
   return true;
@@ -376,7 +376,7 @@ bool SiPixelFolderOrganizer::setFedFolder(DQMStore::IBooker& iBooker, const uint
   char sFed[80];  sprintf(sFed,  "FED_%i",FedId);
   std::ostringstream sfolder;
   
-  sfolder << rootFolder << "/" << subDetectorFolder << "/" << sFed;
+  sfolder << TopFolderName << "/" << subDetectorFolder << "/" << sFed;
   iBooker.setCurrentFolder(sfolder.str().c_str());
   
   return true;
@@ -387,7 +387,7 @@ void SiPixelFolderOrganizer::getModuleFolder(const uint32_t& rawdetid,
                                              std::string& path,
                                              bool isUpgrade) {
 
-  path = rootFolder;
+  path = TopFolderName;
   if(rawdetid == 0) {
     return;
   }else if( (DetId(rawdetid).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel)) && (!isUpgrade) ) {
@@ -403,7 +403,7 @@ void SiPixelFolderOrganizer::getModuleFolder(const uint32_t& rawdetid,
     char smodule[80]; sprintf(smodule,"Module_%i",  DBmodule);
     
     std::ostringstream sfolder;
-    sfolder << rootFolder << "/" << subDetectorFolder << "/Shell_" <<DBshell << "/" << slayer << "/" << sladder;
+    sfolder << TopFolderName << "/" << subDetectorFolder << "/Shell_" <<DBshell << "/" << slayer << "/" << sladder;
     if ( PixelBarrelName(DetId(rawdetid)).isHalfModule() ) sfolder <<"H"; 
     else sfolder <<"F";
     sfolder << "/" <<smodule;
@@ -428,7 +428,7 @@ void SiPixelFolderOrganizer::getModuleFolder(const uint32_t& rawdetid,
     char smodule[80]; sprintf(smodule,"Module_%i",  DBmodule);
     
     std::ostringstream sfolder;
-    sfolder << rootFolder << "/" << subDetectorFolder << "/Shell_" <<DBshell << "/" << slayer << "/" << sladder;
+    sfolder << TopFolderName << "/" << subDetectorFolder << "/Shell_" <<DBshell << "/" << slayer << "/" << sladder;
     if ( PixelBarrelNameUpgrade(DetId(rawdetid)).isHalfModule() ) sfolder <<"H"; 
     else sfolder <<"F";
     sfolder << "/" <<smodule;
@@ -455,7 +455,7 @@ void SiPixelFolderOrganizer::getModuleFolder(const uint32_t& rawdetid,
     char smodule[80];sprintf(smodule,"Module_%i",module);
 
     std::ostringstream sfolder;
-    sfolder <<rootFolder <<"/" << subDetectorFolder << "/HalfCylinder_" << side << "/" << sdisk << "/" << sblade << "/" << spanel << "/" << smodule;
+    sfolder <<TopFolderName <<"/" << subDetectorFolder << "/HalfCylinder_" << side << "/" << sdisk << "/" << sblade << "/" << spanel << "/" << smodule;
     path = sfolder.str().c_str();
     
     //path = path + "/" + subDetectorFolder + "/" + shc + "/" + sdisk + "/" + sblade + "/" + spanel + "/" + smodule;
@@ -475,7 +475,7 @@ void SiPixelFolderOrganizer::getModuleFolder(const uint32_t& rawdetid,
     char smodule[80];sprintf(smodule,"Module_%i",module);
 
     std::ostringstream sfolder;
-    sfolder <<rootFolder <<"/" << subDetectorFolder << "/HalfCylinder_" << side << "/" << sdisk << "/" << sblade << "/" << spanel << "/" << smodule;
+    sfolder <<TopFolderName <<"/" << subDetectorFolder << "/HalfCylinder_" << side << "/" << sdisk << "/" << sblade << "/" << spanel << "/" << smodule;
     path = sfolder.str().c_str();
     
     //path = path + "/" + subDetectorFolder + "/" + shc + "/" + sdisk + "/" + sblade + "/" + spanel + "/" + smodule;

--- a/DQM/SiPixelMonitorCluster/interface/SiPixelClusterSource.h
+++ b/DQM/SiPixelMonitorCluster/interface/SiPixelClusterSource.h
@@ -71,6 +71,8 @@
        virtual void buildStructure(edm::EventSetup const&);
        virtual void bookMEs(DQMStore::IBooker &);
 
+       std::string topFolderName_;
+
     private:
        edm::ParameterSet conf_;
        edm::InputTag src_;

--- a/DQM/SiPixelMonitorCluster/python/SiPixelMonitorCluster_cfi.py
+++ b/DQM/SiPixelMonitorCluster/python/SiPixelMonitorCluster_cfi.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 SiPixelClusterSource = cms.EDAnalyzer("SiPixelClusterSource",
+    TopFolderName = cms.string('Pixel'),
     src = cms.InputTag("siPixelClusters"),
     outputFile = cms.string('Pixel_DQM_Cluster.root'),
     saveFile = cms.untracked.bool(False),

--- a/DQM/SiPixelMonitorCluster/src/SiPixelClusterSource.cc
+++ b/DQM/SiPixelMonitorCluster/src/SiPixelClusterSource.cc
@@ -67,6 +67,7 @@ SiPixelClusterSource::SiPixelClusterSource(const edm::ParameterSet& iConfig) :
    //set Token(-s)
    srcToken_ = consumes<edmNew::DetSetVector<SiPixelCluster> >(conf_.getParameter<edm::InputTag>("src"));
    firstRun = true;
+   topFolderName_ = conf_.getParameter<std::string>("TopFolderName");
 }
 
 
@@ -109,7 +110,7 @@ void SiPixelClusterSource::dqmBeginRun(const edm::Run& r, const edm::EventSetup&
 void SiPixelClusterSource::bookHistograms(DQMStore::IBooker & iBooker, edm::Run const &, edm::EventSetup const &){
   bookMEs(iBooker);
   // Book occupancy maps in global coordinates for all clusters:
-  iBooker.setCurrentFolder("Pixel/Clusters/OffTrack");
+  iBooker.setCurrentFolder(topFolderName_+"/Clusters/OffTrack");
   //bpix
   meClPosLayer1 = iBooker.book2D("position_siPixelClusters_Layer_1","Clusters Layer1;Global Z (cm);Global #phi",200,-30.,30.,128,-3.2,3.2);
   meClPosLayer2 = iBooker.book2D("position_siPixelClusters_Layer_2","Clusters Layer2;Global Z (cm);Global #phi",200,-30.,30.,128,-3.2,3.2);
@@ -288,7 +289,7 @@ void SiPixelClusterSource::buildStructure(const edm::EventSetup& iSetup){
 void SiPixelClusterSource::bookMEs(DQMStore::IBooker & iBooker){
   
   // Get DQM interface
-  iBooker.setCurrentFolder("Pixel");
+  iBooker.setCurrentFolder(topFolderName_);
   char title[256]; snprintf(title, 256, "Rate of events with >%i FPIX clusters;LumiSection;Rate of large FPIX events per LS [Hz]",bigEventSize);
   bigFpixClusterEventRate = iBooker.book1D("bigFpixClusterEventRate",title,5000,0.,5000.);
 

--- a/DQM/SiPixelMonitorDigi/interface/SiPixelDigiSource.h
+++ b/DQM/SiPixelMonitorDigi/interface/SiPixelDigiSource.h
@@ -59,6 +59,8 @@
        virtual void buildStructure(edm::EventSetup const&);
        virtual void bookMEs(DQMStore::IBooker &);
 
+       std::string topFolderName_;
+
     private:
        edm::ParameterSet conf_;
        edm::InputTag src_;

--- a/DQM/SiPixelMonitorDigi/python/SiPixelMonitorDigi_cfi.py
+++ b/DQM/SiPixelMonitorDigi/python/SiPixelMonitorDigi_cfi.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 SiPixelDigiSource = cms.EDAnalyzer("SiPixelDigiSource",
+    TopFolderName = cms.string('Pixel'),
     src = cms.InputTag("siPixelDigis"),
     outputFile = cms.string('Pixel_DQM_Digi.root'),
     saveFile = cms.untracked.bool(False),

--- a/DQM/SiPixelMonitorDigi/src/SiPixelDigiSource.cc
+++ b/DQM/SiPixelMonitorDigi/src/SiPixelDigiSource.cc
@@ -68,6 +68,8 @@ SiPixelDigiSource::SiPixelDigiSource(const edm::ParameterSet& iConfig) :
    //set Token(-s)
    srcToken_ = consumes<edm::DetSetVector<PixelDigi> >(conf_.getParameter<edm::InputTag>( "src" ));
 
+   topFolderName_ = conf_.getParameter<std::string>("TopFolderName");
+
    firstRun = true;  
    // find a FED# for the current detId:
    ifstream infile(edm::FileInPath("DQM/SiPixelMonitorClient/test/detId.dat").fullPath().c_str(),ios::in);
@@ -652,7 +654,7 @@ void SiPixelDigiSource::buildStructure(const edm::EventSetup& iSetup){
 void SiPixelDigiSource::bookMEs(DQMStore::IBooker & iBooker){
   
   // Get DQM interface
-  iBooker.setCurrentFolder("Pixel");
+  iBooker.setCurrentFolder(topFolderName_);
   char title[80];   sprintf(title, "Rate of events with >%i digis;LumiSection;Rate [Hz]",bigEventSize);
   bigEventRate    = iBooker.book1D("bigEventRate",title,5000,0.,5000.);
   char title1[80];  sprintf(title1, "Pixel events vs. BX;BX;# events");
@@ -734,7 +736,7 @@ void SiPixelDigiSource::bookMEs(DQMStore::IBooker & iBooker){
       }
     }
   }
-  iBooker.cd("Pixel/Barrel");
+  iBooker.cd(topFolderName_+"/Barrel");
   meNDigisCOMBBarrel_ = iBooker.book1D("ALLMODS_ndigisCOMB_Barrel","Number of Digis",200,0.,400.);
   meNDigisCOMBBarrel_->setAxisTitle("Number of digis per module per event",1);
   meNDigisCHANBarrel_ = iBooker.book1D("ALLMODS_ndigisCHAN_Barrel","Number of Digis",100,0.,1000.);
@@ -824,7 +826,7 @@ void SiPixelDigiSource::bookMEs(DQMStore::IBooker & iBooker){
   meNDigisCHANBarrelCh35_->setAxisTitle("Number of digis per FED channel per event",1);
   meNDigisCHANBarrelCh36_ = iBooker.book1D("ALLMODS_ndigisCHAN_BarrelCh36","Number of Digis Ch36",100,0.,1000.);
   meNDigisCHANBarrelCh36_->setAxisTitle("Number of digis per FED channel per event",1);
-  iBooker.cd("Pixel/Endcap");
+  iBooker.cd(topFolderName_+"/Endcap");
   meNDigisCOMBEndcap_ = iBooker.book1D("ALLMODS_ndigisCOMB_Endcap","Number of Digis",200,0.,400.);
   meNDigisCOMBEndcap_->setAxisTitle("Number of digis per module per event",1);
   meNDigisCHANEndcap_ = iBooker.book1D("ALLMODS_ndigisCHAN_Endcap","Number of Digis",100,0.,1000.);
@@ -845,7 +847,8 @@ void SiPixelDigiSource::bookMEs(DQMStore::IBooker & iBooker){
     meNDigisCHANEndcapDm3_ = iBooker.book1D("ALLMODS_ndigisCHAN_EndcapDm3","Number of Digis Disk m3",100,0.,1000.);
     meNDigisCHANEndcapDm3_->setAxisTitle("Number of digis per FED channel per event",1);
   }
-  iBooker.cd("Pixel");
+  iBooker.cd(topFolderName_);
+
 }
 
 //define this as a plug-in

--- a/DQM/SiPixelMonitorRawData/interface/SiPixelHLTSource.h
+++ b/DQM/SiPixelMonitorRawData/interface/SiPixelHLTSource.h
@@ -56,6 +56,8 @@
        virtual void dqmBeginRun(const edm::Run&, edm::EventSetup const&) ;
        virtual void bookMEs(DQMStore::IBooker &);
 
+       std::string topFolderName_;
+
     private:
        edm::ParameterSet conf_;
        edm::EDGetTokenT<FEDRawDataCollection> rawin_;
@@ -63,7 +65,6 @@
        edm::ESHandle<TrackerGeometry> pDD;
        bool saveFile;
        bool slowDown;
-       std::string dirName_;
        int eventNo;
        MonitorElement* meRawWords_;
        MonitorElement* meNCRCs_;

--- a/DQM/SiPixelMonitorRawData/interface/SiPixelRawDataErrorSource.h
+++ b/DQM/SiPixelMonitorRawData/interface/SiPixelRawDataErrorSource.h
@@ -65,6 +65,8 @@
        virtual void buildStructure(edm::EventSetup const&);
        virtual void bookMEs(DQMStore::IBooker &);
 
+       std::string topFolderName_;
+
     private:
        edm::ParameterSet conf_;
        edm::EDGetTokenT<edm::DetSetVector<SiPixelRawDataError> > src_;

--- a/DQM/SiPixelMonitorRawData/python/SiPixelMonitorHLT_cfi.py
+++ b/DQM/SiPixelMonitorRawData/python/SiPixelMonitorHLT_cfi.py
@@ -1,12 +1,12 @@
 import FWCore.ParameterSet.Config as cms
 
 SiPixelHLTSource = cms.EDAnalyzer("SiPixelHLTSource",
+    TopFolderName = cms.string('Pixel'),
     RawInput = cms.InputTag("rawDataCollector"),
     ErrorInput = cms.InputTag("siPixelDigis"),
     outputFile = cms.string('Pixel_DQM_HLT.root'),
     saveFile = cms.untracked.bool(False),
     slowDown = cms.untracked.bool(False),
-    DirName = cms.untracked.string('Pixel/FEDIntegrity/')
 )
 
 

--- a/DQM/SiPixelMonitorRawData/python/SiPixelMonitorRawData_cfi.py
+++ b/DQM/SiPixelMonitorRawData/python/SiPixelMonitorRawData_cfi.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 SiPixelRawDataErrorSource = cms.EDAnalyzer("SiPixelRawDataErrorSource",
+    TopFolderName = cms.string('Pixel'),
     src = cms.InputTag("siPixelDigis"),
     outputFile = cms.string('Pixel_DQM_Error.root'),
     saveFile = cms.untracked.bool(False),

--- a/DQM/SiPixelMonitorRawData/src/SiPixelHLTSource.cc
+++ b/DQM/SiPixelMonitorRawData/src/SiPixelHLTSource.cc
@@ -51,11 +51,11 @@ SiPixelHLTSource::SiPixelHLTSource(const edm::ParameterSet& iConfig) :
   rawin_( consumes<FEDRawDataCollection>( conf_.getParameter<edm::InputTag>( "RawInput" ) ) ),
   errin_( consumes<edm::DetSetVector<SiPixelRawDataError> >( conf_.getParameter<edm::InputTag>( "ErrorInput" ) ) ),
   saveFile( conf_.getUntrackedParameter<bool>("saveFile",false) ),
-  slowDown( conf_.getUntrackedParameter<bool>("slowDown",false) ),
-  dirName_( conf_.getUntrackedParameter<std::string>("DirName","Pixel/FEDIntegrity/") )
+  slowDown( conf_.getUntrackedParameter<bool>("slowDown",false) )
 {
   firstRun = true;
   LogInfo ("PixelDQM") << "SiPixelHLTSource::SiPixelHLTSource: Got DQM BackEnd interface"<<endl;
+  topFolderName_ = conf_.getParameter<std::string>("TopFolderName");
 }
 
 
@@ -153,7 +153,7 @@ void SiPixelHLTSource::analyze(const edm::Event& iEvent, const edm::EventSetup& 
 void SiPixelHLTSource::bookMEs(DQMStore::IBooker & iBooker){
 
   iBooker.cd();
-  iBooker.setCurrentFolder(dirName_);
+  iBooker.setCurrentFolder(topFolderName_+"/FEDIntegrity/");
 
   std::string rawhid;
   std::string errhid;

--- a/DQM/SiPixelMonitorRawData/src/SiPixelRawDataErrorSource.cc
+++ b/DQM/SiPixelMonitorRawData/src/SiPixelRawDataErrorSource.cc
@@ -64,6 +64,7 @@ SiPixelRawDataErrorSource::SiPixelRawDataErrorSource(const edm::ParameterSet& iC
 {
   firstRun = true;
   LogInfo ("PixelDQM") << "SiPixelRawDataErrorSource::SiPixelRawDataErrorSource: Got DQM BackEnd interface"<<endl;
+  topFolderName_ = conf_.getParameter<std::string>("TopFolderName");
 }
 
 
@@ -251,7 +252,7 @@ void SiPixelRawDataErrorSource::buildStructure(const edm::EventSetup& iSetup){
 //------------------------------------------------------------------
 void SiPixelRawDataErrorSource::bookMEs(DQMStore::IBooker & iBooker){
   //cout<<"Entering SiPixelRawDataErrorSource::bookMEs now: "<<endl;
-  iBooker.setCurrentFolder("Pixel/AdditionalPixelErrors");
+  iBooker.setCurrentFolder(topFolderName_+"/AdditionalPixelErrors");
   char title[80]; sprintf(title, "By-LumiSection Error counters");
   byLumiErrors = iBooker.book1D("byLumiErrors",title,2,0.,2.);
   byLumiErrors->setLumiFlag();
@@ -305,7 +306,7 @@ void SiPixelRawDataErrorSource::bookMEs(DQMStore::IBooker & iBooker){
 
   for (uint32_t id = 0; id < 40; id++){
     char temp [50];
-    sprintf( temp, "Pixel/AdditionalPixelErrors/FED_%d",id);
+    sprintf( temp, (topFolderName_+"/AdditionalPixelErrors/FED_%d").c_str(),id);
     iBooker.cd(temp);
     // Types of errors
     hid = theHistogramId->setHistoId("errorType",id);

--- a/DQM/SiPixelMonitorRecHit/interface/SiPixelRecHitSource.h
+++ b/DQM/SiPixelMonitorRecHit/interface/SiPixelRecHitSource.h
@@ -65,6 +65,8 @@ class SiPixelRecHitSource : public thread_unsafe::DQMEDAnalyzer {
        virtual void buildStructure(edm::EventSetup const&);
        virtual void bookMEs(DQMStore::IBooker &);
 
+       std::string topFolderName_;
+
     private:
        edm::ParameterSet conf_;
        edm::EDGetTokenT<SiPixelRecHitCollection> src_;

--- a/DQM/SiPixelMonitorRecHit/python/SiPixelMonitorRecHit_cfi.py
+++ b/DQM/SiPixelMonitorRecHit/python/SiPixelMonitorRecHit_cfi.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 SiPixelRecHitSource = cms.EDAnalyzer("SiPixelRecHitSource",
+    TopFolderName = cms.string('Pixel'),
     src = cms.InputTag("siPixelRecHits"),
     outputFile = cms.string('Pixel_DQM_RecHits.root'),
     saveFile = cms.untracked.bool(False),

--- a/DQM/SiPixelMonitorRecHit/src/SiPixelRecHitSource.cc
+++ b/DQM/SiPixelMonitorRecHit/src/SiPixelRecHitSource.cc
@@ -64,6 +64,7 @@ SiPixelRecHitSource::SiPixelRecHitSource(const edm::ParameterSet& iConfig) :
   diskOn( conf_.getUntrackedParameter<bool>("diskOn",false) ), 
   isUpgrade( conf_.getUntrackedParameter<bool>("isUpgrade",false) )
 {
+  topFolderName_ = conf_.getParameter<std::string>("TopFolderName");
   firstRun = true;
   LogInfo ("PixelDQM") << "SiPixelRecHitSource::SiPixelRecHitSource: Got DQM BackEnd interface"<<endl;
 }

--- a/DQM/SiPixelMonitorTrack/interface/SiPixelTrackResidualSource.h
+++ b/DQM/SiPixelMonitorTrack/interface/SiPixelTrackResidualSource.h
@@ -54,6 +54,7 @@ class SiPixelTrackResidualSource : public thread_unsafe::DQMEDAnalyzer {
     virtual void analyze(const edm::Event&, const edm::EventSetup&);
     void triplets(double x1,double y1,double z1,double x2,double y2,double z2,double x3,double y3,double z3,
                   double ptsig, double & dc,double & dz, double kap); 
+    std::string topFolderName_;
   private: 
     edm::ParameterSet pSet_; 
     edm::InputTag src_; 

--- a/DQM/SiPixelMonitorTrack/python/SiPixelMonitorTrack_Cosmics_cfi.py
+++ b/DQM/SiPixelMonitorTrack/python/SiPixelMonitorTrack_Cosmics_cfi.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 SiPixelTrackResidualSource_Cosmics = cms.EDAnalyzer("SiPixelTrackResidualSource",
+    TopFolderName = cms.string('Pixel'),
     src = cms.InputTag("siPixelTrackResiduals"),
     clustersrc = cms.InputTag("siPixelClusters"),                            
     debug = cms.untracked.bool(False),                          

--- a/DQM/SiPixelMonitorTrack/python/SiPixelMonitorTrack_cfi.py
+++ b/DQM/SiPixelMonitorTrack/python/SiPixelMonitorTrack_cfi.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 SiPixelTrackResidualSource = cms.EDAnalyzer("SiPixelTrackResidualSource",
+    TopFolderName = cms.string('Pixel'),
     src = cms.InputTag("siPixelTrackResiduals"),
     clustersrc = cms.InputTag("siPixelClusters"),                            
     debug = cms.untracked.bool(False),                          

--- a/DQM/SiPixelMonitorTrack/src/SiPixelTrackResidualSource.cc
+++ b/DQM/SiPixelMonitorTrack/src/SiPixelTrackResidualSource.cc
@@ -93,6 +93,8 @@ SiPixelTrackResidualSource::SiPixelTrackResidualSource(const edm::ParameterSet& 
   LogInfo ("PixelDQM") << "Blade/Disk/Ring" << bladeOn << "/" << diskOn << "/" 
             << ringOn << std::endl;
 
+  topFolderName_ = pSet_.getParameter<std::string>("TopFolderName");
+
   firstRun = true;
   NTotal=0;
   NLowProb=0;
@@ -180,7 +182,7 @@ void SiPixelTrackResidualSource::bookHistograms(DQMStore::IBooker & iBooker, edm
 //   edm::InputTag clustersrc = pSet_.getParameter<edm::InputTag>("clustersrc");
 
   //number of tracks
-  iBooker.setCurrentFolder("Pixel/Tracks");
+  iBooker.setCurrentFolder(topFolderName_+"/Tracks");
   meNofTracks_ = iBooker.book1D("ntracks_" + tracksrc_.label(),"Number of Tracks",4,0,4);
   meNofTracks_->setAxisTitle("Number of Tracks",1);
   meNofTracks_->setBinLabel(1,"All");
@@ -189,20 +191,20 @@ void SiPixelTrackResidualSource::bookHistograms(DQMStore::IBooker & iBooker, edm
   meNofTracks_->setBinLabel(4,"FPix");
 
   //number of tracks in pixel fiducial volume
-  iBooker.setCurrentFolder("Pixel/Tracks");
+  iBooker.setCurrentFolder(topFolderName_+"/Tracks");
   meNofTracksInPixVol_ = iBooker.book1D("ntracksInPixVol_" + tracksrc_.label(),"Number of Tracks crossing Pixel fiducial Volume",2,0,2);
   meNofTracksInPixVol_->setAxisTitle("Number of Tracks",1);
   meNofTracksInPixVol_->setBinLabel(1,"With Hits");
   meNofTracksInPixVol_->setBinLabel(2,"Without Hits");
 
   //number of clusters (associated to track / not associated)
-  iBooker.setCurrentFolder("Pixel/Clusters/OnTrack");
+  iBooker.setCurrentFolder(topFolderName_+"/Clusters/OnTrack");
   meNofClustersOnTrack_ = iBooker.book1D("nclusters_" + clustersrc_.label() + "_tot","Number of Clusters (on track)",3,0,3);
   meNofClustersOnTrack_->setAxisTitle("Number of Clusters on Track",1);
   meNofClustersOnTrack_->setBinLabel(1,"All");
   meNofClustersOnTrack_->setBinLabel(2,"BPix");
   meNofClustersOnTrack_->setBinLabel(3,"FPix");
-  iBooker.setCurrentFolder("Pixel/Clusters/OffTrack");
+  iBooker.setCurrentFolder(topFolderName_+"/Clusters/OffTrack");
   meNofClustersNotOnTrack_ = iBooker.book1D("nclusters_" + clustersrc_.label() + "_tot","Number of Clusters (off track)",3,0,3);
   meNofClustersNotOnTrack_->setAxisTitle("Number of Clusters off Track",1);
   meNofClustersNotOnTrack_->setBinLabel(1,"All");
@@ -212,7 +214,7 @@ void SiPixelTrackResidualSource::bookHistograms(DQMStore::IBooker & iBooker, edm
   //cluster charge and size
   //charge
   //on track
-  iBooker.setCurrentFolder("Pixel/Clusters/OnTrack");
+  iBooker.setCurrentFolder(topFolderName_+"/Clusters/OnTrack");
   meClChargeOnTrack_all = iBooker.book1D("charge_" + clustersrc_.label(),"Charge (on track)",500,0.,500.);
   meClChargeOnTrack_all->setAxisTitle("Charge size (in ke)",1);
   meClChargeOnTrack_bpix = iBooker.book1D("charge_" + clustersrc_.label() + "_Barrel","Charge (on track, barrel)",500,0.,500.);
@@ -246,7 +248,7 @@ void SiPixelTrackResidualSource::bookHistograms(DQMStore::IBooker & iBooker, edm
     meClChargeOnTrack_diskm3->setAxisTitle("Charge size (in ke)",1);
   }
   //off track
-  iBooker.setCurrentFolder("Pixel/Clusters/OffTrack");
+  iBooker.setCurrentFolder(topFolderName_+"/Clusters/OffTrack");
   meClChargeNotOnTrack_all = iBooker.book1D("charge_" + clustersrc_.label(),"Charge (off track)",500,0.,500.);
   meClChargeNotOnTrack_all->setAxisTitle("Charge size (in ke)",1);
   meClChargeNotOnTrack_bpix = iBooker.book1D("charge_" + clustersrc_.label() + "_Barrel","Charge (off track, barrel)",500,0.,500.);
@@ -282,7 +284,7 @@ void SiPixelTrackResidualSource::bookHistograms(DQMStore::IBooker & iBooker, edm
 
   //size
   //on track
-  iBooker.setCurrentFolder("Pixel/Clusters/OnTrack");
+  iBooker.setCurrentFolder(topFolderName_+"/Clusters/OnTrack");
   meClSizeOnTrack_all = iBooker.book1D("size_" + clustersrc_.label(),"Size (on track)",100,0.,100.);
   meClSizeOnTrack_all->setAxisTitle("Cluster size (in pixels)",1);
   meClSizeOnTrack_bpix = iBooker.book1D("size_" + clustersrc_.label() + "_Barrel","Size (on track, barrel)",100,0.,100.);
@@ -380,7 +382,7 @@ void SiPixelTrackResidualSource::bookHistograms(DQMStore::IBooker & iBooker, edm
     meClSizeYOnTrack_diskm3->setAxisTitle("Cluster size (in pixels)",1);
   }
   //off track
-  iBooker.setCurrentFolder("Pixel/Clusters/OffTrack");
+  iBooker.setCurrentFolder(topFolderName_+"/Clusters/OffTrack");
   meClSizeNotOnTrack_all = iBooker.book1D("size_" + clustersrc_.label(),"Size (off track)",100,0.,100.);
   meClSizeNotOnTrack_all->setAxisTitle("Cluster size (in pixels)",1); 
   meClSizeNotOnTrack_bpix = iBooker.book1D("size_" + clustersrc_.label() + "_Barrel","Size (off track, barrel)",100,0.,100.);
@@ -480,7 +482,7 @@ void SiPixelTrackResidualSource::bookHistograms(DQMStore::IBooker & iBooker, edm
 
   //cluster global position
   //on track
-  iBooker.setCurrentFolder("Pixel/Clusters/OnTrack");
+  iBooker.setCurrentFolder(topFolderName_+"/Clusters/OnTrack");
   //bpix
   meClPosLayer1OnTrack = iBooker.book2D("position_" + clustersrc_.label() + "_Layer_1","Clusters Layer1 (on track)",200,-30.,30.,128,-3.2,3.2);
   meClPosLayer1OnTrack->setAxisTitle("Global Z (cm)",1);
@@ -553,7 +555,7 @@ void SiPixelTrackResidualSource::bookHistograms(DQMStore::IBooker & iBooker, edm
   }
 
   //not on track
-  iBooker.setCurrentFolder("Pixel/Clusters/OffTrack");
+  iBooker.setCurrentFolder(topFolderName_+"/Clusters/OffTrack");
   //bpix
   meClPosLayer1NotOnTrack = iBooker.book2D("position_" + clustersrc_.label() + "_Layer_1","Clusters Layer1 (off track)",200,-30.,30.,128,-3.2,3.2);
   meClPosLayer1NotOnTrack->setAxisTitle("Global Z (cm)",1);
@@ -627,7 +629,7 @@ void SiPixelTrackResidualSource::bookHistograms(DQMStore::IBooker & iBooker, edm
 
   //HitProbability
   //on track
-  iBooker.setCurrentFolder("Pixel/Clusters/OnTrack");
+  iBooker.setCurrentFolder(topFolderName_+"/Clusters/OnTrack");
   meHitProbability = iBooker.book1D("FractionLowProb","Fraction of hits with low probability;FractionLowProb;#HitsOnTrack",100,0.,1.);
 
   if (debug_) {


### PR DESCRIPTION
Updating the folders of the MonitorElements in Pixel DQM packages. In the future a second layer of DQM process will go on at HLT level, and this would conflict with the original one's folders. In order to avoid that, the base folders of the MonitorElements are set in the python configuration files. The necessary modifications for this can be seen in the PR.
