### PR TITLE
Corrected portcard positions in standard pixfwd cylinder

### DIFF
--- a/Geometry/TrackerCommonData/data/pixfwdCylinder.xml
+++ b/Geometry/TrackerCommonData/data/pixfwdCylinder.xml
@@ -8,6 +8,7 @@
          @created Dmitry Onoprienko
          @modified Xingtao Huang to implement the fpix service cylinder
          @modified Vesna Cuplov to fix the Electronics boards positions (august 2008).
+         @modified Francesca Ricci-Tam to edit the Portcards positions (October 2014)
          
          
          == COMPONENT DEFINED BY THIS FILE: ==
@@ -48,6 +49,7 @@
         <Constant name="CylindersPortCardsWidth" value="60.0*mm"/>
         <Constant name="CylindersPortCardsLength1" value="223.52*mm"/>
         <Constant name="CylindersPortCardsLength2" value="355.60*mm"/>
+        <Constant name="PortCardsOffset" value="([CylindersPortCardsLength2]-[CylindersPortCardsLength1])/2."/>
         <Constant name="CylindersPortCardsThickness" value="5.40*mm"/>
         <Constant name="CylindersServiceZoff" value="320.0*mm"/>
         <Constant name="CylindersServiceRmin" value="100*mm"/>
@@ -297,16 +299,16 @@
             <Translation x="[PortCardsToBeam]*cos([PortCardsAngle2])" y="[PortCardsToBeam]*sin([PortCardsAngle2])" z="[PortCardsToIP]+[ZOffCylinder]"/>
             <rRotation name="pixfwdCylinder:PortCardsRot1"/>
         </PosPart>
-        <PosPart copyNumber="1">
-            <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
-            <rChild name="pixfwdCylinder:PixelForwardCylindersPortCards2"/>
-            <Translation x="[PortCardsToBeam]*cos([PortCardsAngle1])" y="[PortCardsToBeam]*sin([PortCardsAngle1])" z="[PortCardsToIP]+[ZOffCylinder]"/>
-            <rRotation name="pixfwdCylinder:PortCardsRot2"/>
-        </PosPart>
         <PosPart copyNumber="2">
             <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
             <rChild name="pixfwdCylinder:PixelForwardCylindersPortCards1"/>
-            <Translation x="[PortCardsToBeam]*cos([PortCardsAngle1])" y="-[PortCardsToBeam]*sin([PortCardsAngle1])" z="[PortCardsToIP]+[ZOffCylinder]"/>
+            <Translation x="[PortCardsToBeam]*cos([PortCardsAngle1])" y="[PortCardsToBeam]*sin([PortCardsAngle1])" z="[PortCardsToIP]+[ZOffCylinder]"/>
+            <rRotation name="pixfwdCylinder:PortCardsRot2"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
+            <rChild name="pixfwdCylinder:PixelForwardCylindersPortCards2"/>
+            <Translation x="[PortCardsToBeam]*cos([PortCardsAngle1])" y="-[PortCardsToBeam]*sin([PortCardsAngle1])" z="[PortCardsToIP]+[ZOffCylinder]+[PortCardsOffset]"/>
             <rRotation name="pixfwdCylinder:PortCardsRot3"/>
         </PosPart>
         <PosPart copyNumber="3">
@@ -324,7 +326,7 @@
         <PosPart copyNumber="2">
             <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
             <rChild name="pixfwdCylinder:PixelForwardCylindersPortCards2"/>
-            <Translation x="-[PortCardsToBeam]*cos([PortCardsAngle1])" y="[PortCardsToBeam]*sin([PortCardsAngle1])" z="[PortCardsToIP]+[ZOffCylinder]"/>
+            <Translation x="-[PortCardsToBeam]*cos([PortCardsAngle1])" y="[PortCardsToBeam]*sin([PortCardsAngle1])" z="[PortCardsToIP]+[ZOffCylinder]+[PortCardsOffset]"/>
             <rRotation name="pixfwdCylinder:PortCardsRot6"/>
         </PosPart>
         <PosPart copyNumber="5">


### PR DESCRIPTION
Modifications to Geometry/TrackerCommonData/data/pixfwdCylinder.xml:
- shifted objects of type "PortCards2" so that the IP-facing edges are lined up with the IP-facing edges of the objects of type "PortCards1"
- in BmO, swapped the positions of PortCards1(copyNumber 2) and PortCards2(copyNumber 1) to reflect actual position of BmO CCU in standard geometry
