### PR TITLE
Fixes for enumerations

### DIFF
--- a/FWCore/Utilities/interface/TypeWithDict.h
+++ b/FWCore/Utilities/interface/TypeWithDict.h
@@ -46,7 +46,6 @@ private:
   TClass* class_;
   TEnum* enum_;
   TDataType* dataType_;
-  std::string enumName_; 
   long property_;
 public:
   static TypeWithDict byName(std::string const& name, long property = 0L);
@@ -123,7 +122,7 @@ public:
 bool hasDictionary(std::type_info const&);
 
 inline bool operator<(TypeWithDict const& a, TypeWithDict const& b) {
-  return a.typeInfo().before(b.typeInfo());
+  return a.name() < b.name();
 }
 
 bool operator==(TypeWithDict const& a, TypeWithDict const& b);

--- a/FWCore/Utilities/src/TypeWithDict.cc
+++ b/FWCore/Utilities/src/TypeWithDict.cc
@@ -189,7 +189,6 @@ namespace edm {
 
     enum_ = TEnum::GetEnum(ti, TEnum::kAutoload);
     if(enum_ != nullptr) {
-      enumName_ = TypeID(ti).className();
       property_ |= (long)kIsEnum;
       return;
     }
@@ -215,7 +214,6 @@ namespace edm {
     class_(nullptr),
     enum_(enm),
     dataType_(nullptr),
-    enumName_(name),
     property_((long) kIsEnum | property) {
   }
 
@@ -414,7 +412,7 @@ namespace edm {
   std::string
   TypeWithDict::name() const {
     if(enum_ != nullptr) {
-      return enumName_;
+      return std::string(enum_->GetClass()->GetName()) + "::" + enum_->GetName();
     }
     return TypeID(*ti_).className();
   }
@@ -431,7 +429,7 @@ namespace edm {
   TypeWithDict::userClassName() const {
     //FIXME: What about const and reference?
     if(enum_ != nullptr) {
-      return enumName_;
+      return name();
     }
     return TypeID(*ti_).userClassName();
   }
@@ -775,7 +773,7 @@ namespace edm {
 
   bool
   operator==(TypeWithDict const& a, TypeWithDict const& b) {
-    return a.typeInfo() == b.typeInfo();
+    return a.name() == b.name();
   }
 
   std::ostream&


### PR DESCRIPTION
Two ROOT 6 specific minor improvements/fixes for enumerations.
1) Get the name of an enum directly from the TEnum, rather than storing the name.
2) Since for enumerations, (and in the future, for pointers and C-style arrays), TypeWithDict is no longer guaranteed to have a correct std::type_info available, we order TypeWithDict's by comparing the fully scoped names, rather than comparing the type_info's.
Please merge this as soon as convenient.
