### PR TITLE
add full5x5 shower variables to reco::Photon

### DIFF
--- a/DataFormats/EgammaCandidates/interface/Photon.h
+++ b/DataFormats/EgammaCandidates/interface/Photon.h
@@ -165,6 +165,8 @@ namespace reco {
       {}
     } ;
     void setShowerShapeVariables ( const ShowerShape& a )     { showerShapeBlock_ = a ;}
+    void full5x5_setShowerShapeVariables ( const ShowerShape& a )     { full5x5_showerShapeBlock_ = a ;}
+    
     /// the total hadronic over electromagnetic fraction
     float hadronicOverEm() const {return   showerShapeBlock_.hcalDepth1OverEcal + showerShapeBlock_.hcalDepth2OverEcal  ;}
     /// the  hadronic release in depth1 over electromagnetic fraction
@@ -191,6 +193,18 @@ namespace reco {
     float r1x5 ()           const {return showerShapeBlock_.e1x5/showerShapeBlock_.e5x5;}
     float r2x5 ()           const {return showerShapeBlock_.e2x5/showerShapeBlock_.e5x5;}
     float r9 ()             const {return showerShapeBlock_.e3x3/this->superCluster()->rawEnergy();}  
+    
+    ///full5x5 Shower shape variables
+    float full5x5_e1x5()            const {return full5x5_showerShapeBlock_.e1x5;}
+    float full5x5_e2x5()            const {return full5x5_showerShapeBlock_.e2x5;}
+    float full5x5_e3x3()            const {return full5x5_showerShapeBlock_.e3x3;}
+    float full5x5_e5x5()            const {return full5x5_showerShapeBlock_.e5x5;}
+    float full5x5_maxEnergyXtal()   const {return full5x5_showerShapeBlock_.maxEnergyXtal;}
+    float full5x5_sigmaEtaEta()     const {return full5x5_showerShapeBlock_.sigmaEtaEta;}
+    float full5x5_sigmaIetaIeta()   const {return full5x5_showerShapeBlock_.sigmaIetaIeta;}
+    float full5x5_r1x5 ()           const {return full5x5_showerShapeBlock_.e1x5/full5x5_showerShapeBlock_.e5x5;}
+    float full5x5_r2x5 ()           const {return full5x5_showerShapeBlock_.e2x5/full5x5_showerShapeBlock_.e5x5;}
+    float full5x5_r9 ()             const {return full5x5_showerShapeBlock_.e3x3/this->superCluster()->rawEnergy();}      
 
     //=======================================================
     // Energy Determinations
@@ -467,6 +481,7 @@ namespace reco {
     IsolationVariables isolationR04_;
     IsolationVariables isolationR03_;
     ShowerShape        showerShapeBlock_;
+    ShowerShape        full5x5_showerShapeBlock_;
     EnergyCorrections eCorrections_; 
     MIPVariables        mipVariableBlock_; 
     PflowIsolationVariables pfIsolation_;

--- a/DataFormats/EgammaCandidates/src/Photon.cc
+++ b/DataFormats/EgammaCandidates/src/Photon.cc
@@ -23,6 +23,7 @@ Photon::Photon( const Photon& rhs ) :
   isolationR04_ ( rhs.isolationR04_),
   isolationR03_ ( rhs.isolationR03_),
   showerShapeBlock_ ( rhs.showerShapeBlock_),
+  full5x5_showerShapeBlock_ ( rhs.full5x5_showerShapeBlock_),
   eCorrections_(rhs.eCorrections_),
   mipVariableBlock_ (rhs.mipVariableBlock_),
   pfIsolation_ ( rhs.pfIsolation_ )

--- a/DataFormats/EgammaCandidates/src/classes_def.xml
+++ b/DataFormats/EgammaCandidates/src/classes_def.xml
@@ -9,8 +9,9 @@
   </ioread>
 
 
-  <class name="reco::Photon" ClassVersion="13">
+  <class name="reco::Photon" ClassVersion="14">
    <version ClassVersion="13" checksum="2963666409"/>
+   <version ClassVersion="14" checksum="753726370"/>
   </class>
   <class name="reco::Conversion" ClassVersion="11">
    <version ClassVersion="10" checksum="2140222741"/>

--- a/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
@@ -498,6 +498,20 @@ void GEDPhotonProducer::fillPhotonCollection(edm::Event& evt,
       
     float sigmaEtaEta = sqrt(cov[0]);
     float sigmaIetaIeta = sqrt(locCov[0]);
+    
+    float full5x5_maxXtal =   noZS::EcalClusterTools::eMax( *(scRef->seed()), &(*hits) );
+    //AA
+    //Change these to consider severity level of hits
+    float full5x5_e1x5    =   noZS::EcalClusterTools::e1x5(  *(scRef->seed()), &(*hits), &(*topology));
+    float full5x5_e2x5    =   noZS::EcalClusterTools::e2x5Max(  *(scRef->seed()), &(*hits), &(*topology));
+    float full5x5_e3x3    =   noZS::EcalClusterTools::e3x3(  *(scRef->seed()), &(*hits), &(*topology));
+    float full5x5_e5x5    =   noZS::EcalClusterTools::e5x5( *(scRef->seed()), &(*hits), &(*topology));
+    std::vector<float> full5x5_cov =  noZS::EcalClusterTools::covariances( *(scRef->seed()), &(*hits), &(*topology), geometry);
+    std::vector<float> full5x5_locCov =  noZS::EcalClusterTools::localCovariances( *(scRef->seed()), &(*hits), &(*topology));
+      
+    float full5x5_sigmaEtaEta = sqrt(full5x5_cov[0]);
+    float full5x5_sigmaIetaIeta = sqrt(full5x5_locCov[0]);    
+    
     // compute position of ECAL shower
     math::XYZPoint caloPosition = scRef->position();
     
@@ -542,6 +556,17 @@ void GEDPhotonProducer::fillPhotonCollection(edm::Event& evt,
     showerShape.hcalTowersBehindClusters =  TowersBehindClus;
     newCandidate.setShowerShapeVariables ( showerShape ); 
 
+    /// fill full5x5 shower shape block
+    reco::Photon::ShowerShape  full5x5_showerShape;
+    full5x5_showerShape.e1x5= full5x5_e1x5;
+    full5x5_showerShape.e2x5= full5x5_e2x5;
+    full5x5_showerShape.e3x3= full5x5_e3x3;
+    full5x5_showerShape.e5x5= full5x5_e5x5;
+    full5x5_showerShape.maxEnergyXtal =  full5x5_maxXtal;
+    full5x5_showerShape.sigmaEtaEta =    full5x5_sigmaEtaEta;
+    full5x5_showerShape.sigmaIetaIeta =  full5x5_sigmaIetaIeta;
+    newCandidate.full5x5_setShowerShapeVariables ( full5x5_showerShape );     
+    
     /// get ecal photon specific corrected energy 
     /// plus values from regressions     and store them in the Photon
     // Photon candidate takes by default (set in photons_cfi.py) 


### PR DESCRIPTION
Correcting an inconsistency which entered in 71x and propagated to 72x.

For history purposes:
In CMSSW_7_0_X the full5x5 shower variables were added to pat::Electron and pat::Photon so they would be easily accessible in the MiniAOD (the need for these variables arose after the reco part of the release was closed and they were added during the miniaod development stage)

In 71X the full5x5 variables were added to the reco::GsfElectron, but due to some oversight/miscommunication never to the reco::Photon.  The changes adding the full5x5 variables to the pat::Electron AND photon classes were nevertheless intentionally kept out of 71x, resulting in these variables being nowhere accessible for photons in 72x MiniAOD.  (Well they could be recomputed from the rechits, but this is a nasty regression compared to 70x from an end user point of view.)

@lgray @arizzi @gpetruc 
