### PR TITLE
Revert "Make HcalCholeskyMatrix compatible with new ROOT"

### DIFF
--- a/CondFormats/HcalObjects/interface/HcalCholeskyMatrix.h
+++ b/CondFormats/HcalObjects/interface/HcalCholeskyMatrix.h
@@ -5,10 +5,11 @@
 
 #include <boost/cstdint.hpp>
 #include "CondFormats/HcalObjects/interface/HcalPedestal.h"
+#include <math.h>
 
 class HcalCholeskyMatrix {
    public:
-   explicit HcalCholeskyMatrix(int fId=0);
+   HcalCholeskyMatrix(int fId=0);
  
    float getValue(int capid, int i,int j) const;// {return cmatrix[capid][i][j];}
    void setValue(int capid, int i, int j, float val);// {cmatrix[capid][i][j] = val;}
@@ -16,14 +17,9 @@ class HcalCholeskyMatrix {
    uint32_t rawId () const {return mId;}
 
    private:
-
-   static int findIndex(int i, int j);
-   //Due to a bug in ROOT versions before 5.34.20
-   // only the first 4 elements of the array were 
-   // ever stored. The previous array dimensions were
-   //signed short int cmatrix[4][55];
-   signed short int cmatrix[4];
+   signed short int cmatrix[4][55];
    uint32_t mId;
+//   float cmatrix[4][10][10];
 
  COND_SERIALIZABLE;
 };

--- a/CondFormats/HcalObjects/src/HcalCholeskyMatrix.cc
+++ b/CondFormats/HcalObjects/src/HcalCholeskyMatrix.cc
@@ -1,41 +1,29 @@
 #include "CondFormats/HcalObjects/interface/HcalCholeskyMatrix.h"
 #include <cmath>
 
-//Due to a bug in ROOT versions before 5.34.20  only the first 4 elements of the
-// cmatrix array were ever stored. To reproduce the behavior, we make it appear that
-// the matrix returns 0 for any other index request. Similarly, only the first
-// 4 elements can be set.
-HcalCholeskyMatrix::HcalCholeskyMatrix(int fId) : cmatrix{0,0,0,0},mId (fId)
+HcalCholeskyMatrix::HcalCholeskyMatrix(int fId) : mId (fId)
 {
-}
-
-inline int 
-HcalCholeskyMatrix::findIndex(int i, int j) {
-  int ii = i + 1;
-  int jj = j + 1;
-  return (ii*(ii-1)/2+jj)-1;
+   for(int cap = 0; cap != 4; cap++)
+      for(int i = 0; i != 55; i++)
+         cmatrix[cap][i] = 0;
 }
 
 float
 HcalCholeskyMatrix::getValue(int capid, int i,int j) const
 {
-   if(i < j) return 0.f;
-   if(capid != 0) {return 0.f;}
-   auto index = findIndex(i,j);
-   if(index > 3) {
-     return 0.f;
-   }
-   float blah = static_cast<float>(cmatrix[index]);
-   return blah/1000.;
+   if(i < j) return 0;
+   int ii = i + 1;
+   int jj = j + 1;
+   float blah = (float)(cmatrix[capid][(ii*(ii-1)/2+jj)-1]);
+   return blah/1000;
 }
 
 void
 HcalCholeskyMatrix::setValue(int capid, int i, int j, float val)
 {
    if(i < j) return;
-   auto index = findIndex(i,j);
-   if(capid == 0 and index < 4) {
-     cmatrix[index] = static_cast<signed short int>((floor)(val*10000));
-   }
+   int ii = i + 1;
+   int jj = j + 1;
+   cmatrix[capid][(int)(ii*(ii-1)/2+jj)-1] = (signed short int)(floor)(val*10000);
 }
 


### PR DESCRIPTION
As agreed on in the Core meeting, we rever the change to
HcalCholeskyMatrix since CondDB2 wants to work with the original
schema.
