### PR TITLE
Made CRC lookup table const and use std::uint32_t

### DIFF
--- a/FWCore/Utilities/interface/CRC32Calculator.h
+++ b/FWCore/Utilities/interface/CRC32Calculator.h
@@ -53,7 +53,7 @@ from the original code follow below to attribute the source.
 /*                                                               */
 /*****************************************************************/
 
-#include "boost/cstdint.hpp"
+#include <cstdint>
 
 #include <string>
 
@@ -65,11 +65,11 @@ namespace cms {
 
     CRC32Calculator(std::string const& message);
 
-    boost::uint32_t checksum() { return checksum_; }
+    std::uint32_t checksum() { return checksum_; }
 
   private:
 
-    boost::uint32_t checksum_;
+    std::uint32_t checksum_;
   };
 }
 #endif

--- a/FWCore/Utilities/src/CRC32Calculator.cc
+++ b/FWCore/Utilities/src/CRC32Calculator.cc
@@ -6,10 +6,10 @@ namespace cms {
 
   namespace {
 
-    const boost::uint32_t CRC32_XINIT = 0xFFFFFFFFL;
-    const boost::uint32_t CRC32_XOROT = 0xFFFFFFFFL;
+    const std::uint32_t CRC32_XINIT = 0xFFFFFFFFL;
+    const std::uint32_t CRC32_XOROT = 0xFFFFFFFFL;
 
-    boost::uint32_t crctable[256] =
+    const std::uint32_t crctable[256] =
     {
       0x00000000L, 0x77073096L, 0xEE0E612CL, 0x990951BAL,
       0x076DC419L, 0x706AF48FL, 0xE963A535L, 0x9E6495A3L,
@@ -84,9 +84,9 @@ namespace cms {
     checksum_ = CRC32_XINIT;
 
     /* process each byte prior to checksum field */
-    int length = message.length();
+    auto length = message.length();
     char const* p = message.data();
-    for (int j = 0; j < length; j++) {
+    for (size_t j = 0; j < length; j++) {
       unsigned char uc = *p++;
       checksum_ = cms::crctable[(checksum_ ^ uc) & 0xFFL] ^ (checksum_ >> 8);
     }


### PR DESCRIPTION
Avoid complaints from the static analyzer about a non-const static. Also reduce dependency on boost by using the C++11 type.
