### PR TITLE
HGC V5 geometry modification to include inner thermal screen and support...

### DIFF
--- a/Geometry/HGCalCommonData/data/v5/hgcal.xml
+++ b/Geometry/HGCalCommonData/data/v5/hgcal.xml
@@ -13,6 +13,7 @@
   <Constant name="rMaxHGCal3" value="([rMaxHGCal2]+(([zHGCal3]-[zHGCal2])*[slope3]))"/>
   <Constant name="rMaxHGCal4" value="2499.5*mm"/>
   <Constant name="zHGCal4"    value="4870.85*mm"/>
+  <Constant name="zHGCal44"    value="4100.00*mm"/>
   <Constant name="zHGCal5"    value="5218.85*mm"/>
   <Constant name="zMinEE"     value="[zHGCal1]"/>
   <Constant name="zMaxEE"     value="3488.85*mm"/>
@@ -22,6 +23,7 @@
   <Constant name="rMinHGCal2" value="[etaMax:slope]*[zHGCal2]"/>    
   <Constant name="rMinHGCal3" value="[etaMax:slope]*[zHGCal3]"/>
   <Constant name="rMinHGCal4" value="[etaMax:slope]*[zHGCal4]"/>
+  <Constant name="rMinHGCal44" value="[etaMax:slope]*[zHGCal44]"/>
   <Constant name="rMinHGCal5" value="[etaMax:slope]*[zHGCal5]"/>
   <Constant name="rMinEEMin"  value="[etaMax:slope]*[zMinEE]"/>
   <Constant name="rMinEEMax"  value="[etaMax:slope]*[zMaxEE]"/>
@@ -44,12 +46,24 @@
 
 <SolidSection label="hgcal.xml">
   <Polycone name="HGCal" startPhi="0*deg" deltaPhi="360*deg">
-    <ZSection z="[zHGCal1]" rMin="[rMinHGCal1]" rMax="[rMaxHGCal1]"/>
-    <ZSection z="[zHGCal2]" rMin="[rMinHGCal2]" rMax="[rMaxHGCal2]"/>
-    <ZSection z="[zHGCal3]" rMin="[rMinHGCal3]" rMax="[rMaxHGCal3]"/>
-    <ZSection z="[zHGCal4]" rMin="[rMinHGCal4]" rMax="[rMaxHGCal3]"/>
-    <ZSection z="[zHGCal4]" rMin="[rMinHGCal4]" rMax="[rMaxHGCal4]"/>
-    <ZSection z="[zHGCal5]" rMin="[rMinHGCal5]" rMax="[rMaxHGCal4]"/>
+    <ZSection z="[zHGCal1]" rMin="[rMinHGCal1]-2.1*cm" rMax="[rMaxHGCal1]"/>
+    <ZSection z="[zHGCal2]" rMin="[rMinHGCal2]-2.1*cm" rMax="[rMaxHGCal2]"/>
+    <ZSection z="[zHGCal3]" rMin="[rMinHGCal3]-2.1*cm" rMax="[rMaxHGCal3]"/>
+    <ZSection z="[zHGCal4]" rMin="[rMinHGCal4]-2.1*cm" rMax="[rMaxHGCal3]"/>
+    <ZSection z="[zHGCal4]" rMin="[rMinHGCal4]-2.1*cm" rMax="[rMaxHGCal4]"/>
+    <ZSection z="[zHGCal5]" rMin="[rMinHGCal5]-2.1*cm" rMax="[rMaxHGCal4]"/>
+  </Polycone>
+  <Polycone name="HGCalBottomScreenCover1" startPhi="0*deg" deltaPhi="360*deg">
+    <ZSection z="[zHGCal1]" rMin="[rMinHGCal1]-0.3*cm" rMax="[rMinHGCal1]-0.1*cm"/>
+    <ZSection z="[zHGCal44]" rMin="[rMinHGCal44]-0.3*cm" rMax="[rMinHGCal44]-0.1*cm"/>
+  </Polycone>
+  <Polycone name="HGCalBottomScreen" startPhi="0*deg" deltaPhi="360*deg">
+    <ZSection z="[zHGCal1]" rMin="[rMinHGCal1]-1.9*cm" rMax="[rMinHGCal1]-0.3*cm"/>
+    <ZSection z="[zHGCal44]" rMin="[rMinHGCal44]-1.9*cm" rMax="[rMinHGCal44]-0.3*cm"/>
+  </Polycone>
+  <Polycone name="HGCalBottomScreenCover2" startPhi="0*deg" deltaPhi="360*deg">
+    <ZSection z="[zHGCal1]" rMin="[rMinHGCal1]-2.1*cm" rMax="[rMinHGCal1]-1.9*cm"/>
+    <ZSection z="[zHGCal44]" rMin="[rMinHGCal44]-2.1*cm" rMax="[rMinHGCal44]-1.9*cm"/>
   </Polycone>
   <Polyhedra name="HGCalEE" numSide="18" startPhi="350*deg" deltaPhi="360*deg">
     <ZSection z="[zMinEE]" rMin="[rMinEEMin]" rMax="[rMapEEMin]"/>
@@ -63,12 +77,29 @@
     <ZSection z="[zHGCal4]" rMin="[rMinHGCal4]" rMax="[rMapHGCal4]"/>
     <ZSection z="[zMaxHE]"  rMin="[rMinHEMax]"  rMax="[rMapHEMax]"/>
   </Polyhedra>
+  <Polycone name="HGCalSupport" startPhi="0*deg" deltaPhi="360*deg">
+    <ZSection z="299*cm" rMin="29.5*cm-0.6*cm" rMax="29.5*cm"/>
+    <ZSection z="[zHGCal1]" rMin="29.5*cm-0.6*cm" rMax="29.5*cm"/>
+    <ZSection z="417.5*cm" rMin="[etaMax:slope]*417.5*cm-2.7*cm" rMax="[etaMax:slope]*417.5*cm-2.1*cm"/>
+  </Polycone>
 </SolidSection>
 
 <LogicalPartSection label="hgcal.xml">
   <LogicalPart name="HGCal" category="unspecified">
     <rSolid name="HGCal"/>
     <rMaterial name="materials:Air"/>
+  </LogicalPart>
+  <LogicalPart name="HGCalBottomScreen" category="unspecified">
+    <rSolid name="HGCalBottomScreen"/>
+    <rMaterial name="materials:Foam"/>
+  </LogicalPart>
+  <LogicalPart name="HGCalBottomScreenCover1" category="unspecified">
+    <rSolid name="HGCalBottomScreenCover1"/>
+    <rMaterial name="materials:Aluminium"/>
+  </LogicalPart>
+  <LogicalPart name="HGCalBottomScreenCover2" category="unspecified">
+    <rSolid name="HGCalBottomScreenCover2"/>
+    <rMaterial name="materials:Aluminium"/>
   </LogicalPart>
   <LogicalPart name="HGCalEE" category="unspecified">
     <rSolid name="HGCalEE"/>
@@ -77,6 +108,10 @@
   <LogicalPart name="HGCalHE" category="unspecified">
     <rSolid name="HGCalHE"/>
     <rMaterial name="materials:Air"/>
+  </LogicalPart>
+  <LogicalPart name="HGCalSupport" category="unspecified">
+    <rSolid name="HGCalSupport"/>
+    <rMaterial name="materials:Aluminium"/>
   </LogicalPart>
 </LogicalPartSection>
 
@@ -93,12 +128,32 @@
   </PosPart>
   <PosPart copyNumber="1">
     <rParent name="HGCal"/>
+    <rChild name="HGCalBottomScreenCover1"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="HGCal"/>
+    <rChild name="HGCalBottomScreen"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="HGCal"/>
+    <rChild name="HGCalBottomScreenCover2"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="HGCal"/>
     <rChild name="HGCalEE"/>
     <rRotation name="rotations:000D"/>
   </PosPart>
   <PosPart copyNumber="1">
     <rParent name="HGCal"/>
     <rChild name="HGCalHE"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="caloBase:CALO"/>
+    <rChild name="HGCalSupport"/>
     <rRotation name="rotations:000D"/>
   </PosPart>
 </PosPartSection>


### PR DESCRIPTION
... structure

@ianna @pfs @lgray @fratnikov @bachtis To include changes to HGCAL geometry from Yana, namely the inner thermal screen and support structure. The corresponding code in PR 5905 can be dropped as this is the part of HGCAL baseline V5 geometry now. 
