### PR TITLE
HGCal Material Budget Validation

### DIFF
--- a/Validation/Geometry/interface/MaterialBudgetHGCal.h
+++ b/Validation/Geometry/interface/MaterialBudgetHGCal.h
@@ -1,0 +1,46 @@
+#ifndef Validation_Geometry_MaterialBudgetHGCal_h
+#define Validation_Geometry_MaterialBudgetHGCal_h
+
+#include "Validation/Geometry/interface/MaterialBudgetHGCalHistos.h"
+
+#include "SimG4Core/Watcher/interface/SimWatcher.h"
+#include "SimG4Core/Notification/interface/Observer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include <CLHEP/Vector/LorentzVector.h>
+
+class BeginOfJob;
+class BeginOfTrack;
+class G4Step;
+class EndOfTrack;
+
+class MaterialBudgetHGCal
+: public SimWatcher, 
+  public Observer<const BeginOfJob*>,
+  public Observer<const BeginOfTrack*>,
+  public Observer<const G4Step*>,
+  public Observer<const EndOfTrack*>
+{
+ public:
+
+  MaterialBudgetHGCal( const edm::ParameterSet& );
+  virtual ~MaterialBudgetHGCal( void );
+  
+ private:
+
+  MaterialBudgetHGCal( const MaterialBudgetHGCal& );
+  const MaterialBudgetHGCal& operator=( const MaterialBudgetHGCal& );
+  
+  void update( const BeginOfJob* );
+  void update( const BeginOfTrack* );
+  void update( const G4Step* );
+  void update( const EndOfTrack* );
+
+  bool stopAfter( const G4Step* );
+  
+  MaterialBudgetHGCalHistos* m_HistoHGCal;
+  double m_rMax;
+  double m_zMax;
+};
+
+#endif

--- a/Validation/Geometry/interface/MaterialBudgetHGCalHistos.h
+++ b/Validation/Geometry/interface/MaterialBudgetHGCalHistos.h
@@ -1,0 +1,58 @@
+#ifndef Validation_Geometry_MaterialBudgetHGCalHistos_h
+#define Validation_Geometry_MaterialBudgetHGCalHistos_h 
+
+#include "DetectorDescription/Core/interface/DDFilteredView.h"
+#include "DetectorDescription/Core/interface/DDsvalues.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "G4Step.hh"
+#include "G4Track.hh"
+
+#include <TH1F.h>
+#include <TH2F.h>
+#include <TProfile.h>
+#include <TProfile2D.h>
+
+#include <string>
+#include <vector>
+
+class MaterialBudgetHGCalHistos
+{
+ public:
+  
+  MaterialBudgetHGCalHistos( const edm::ParameterSet & );
+  virtual ~MaterialBudgetHGCalHistos( void ) {}
+  
+  void fillBeginJob( const DDCompactView & );
+  void fillStartTrack( const G4Track* );
+  void fillPerStep( const G4Step * );
+  void fillEndTrack( void );
+  
+ private:
+  
+  void book( void ); 
+  void fillHisto( int );
+  std::vector<std::string> getNames( DDFilteredView& );
+  bool isItHGC( const std::string & );
+  
+  static const int         maxSet = 5;
+  std::vector<std::string> sensitives, hgcNames, sensitiveHGC;
+  bool                     m_fillHistos;
+  bool                     m_printSum;
+  int                      binEta, binPhi;
+  double                   maxEta, etaLow, etaHigh;
+  std::vector<std::string> matList;
+  std::vector<double>      stepLength, radLength, intLength;
+  TH1F                     *me400[maxSet], *me800[maxSet];
+  TH2F                     *me1200[maxSet];
+  TProfile                 *me100[maxSet], *me200[maxSet], *me300[maxSet];
+  TProfile                 *me500[maxSet], *me600[maxSet], *me700[maxSet];
+  TProfile2D               *me900[maxSet], *me1000[maxSet],*me1100[maxSet];
+  int                      m_id;
+  int layer, steps;
+  double                   radLen, intLen, stepLen;
+  double                   eta, phi;
+};
+
+
+#endif

--- a/Validation/Geometry/src/MaterialBudgetHGCal.cc
+++ b/Validation/Geometry/src/MaterialBudgetHGCal.cc
@@ -1,0 +1,86 @@
+#include "Validation/Geometry/interface/MaterialBudgetHGCal.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESTransientHandle.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "SimG4Core/Notification/interface/BeginOfJob.h"
+#include "SimG4Core/Notification/interface/BeginOfTrack.h"
+#include "SimG4Core/Notification/interface/EndOfTrack.h"
+
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+#include "DetectorDescription/Core/interface/DDCompactView.h"
+
+#include "G4Step.hh"
+#include "G4Track.hh"
+
+#include <iostream>
+
+MaterialBudgetHGCal::MaterialBudgetHGCal( const edm::ParameterSet& p )
+  : m_HistoHGCal(0)
+{
+  edm::ParameterSet pSet = p.getParameter<edm::ParameterSet>( "MaterialBudgetHGCal" );
+  m_rMax = pSet.getUntrackedParameter<double>( "RMax", 4.5 )*m;
+  m_zMax = pSet.getUntrackedParameter<double>( "ZMax", 13.0 )*m;
+  edm::LogInfo( "MaterialBudget" ) << "MaterialBudgetHGCal initialized with rMax "
+				   << m_rMax << " mm and zMax " << m_zMax << " mm";
+  m_HistoHGCal = new MaterialBudgetHGCalHistos( pSet );
+}
+
+MaterialBudgetHGCal::~MaterialBudgetHGCal( void )
+{
+  if( m_HistoHGCal) delete m_HistoHGCal;
+}
+
+void
+MaterialBudgetHGCal::update( const BeginOfJob* job )
+{
+  edm::ESTransientHandle<DDCompactView> pDD;
+  (*job)()->get<IdealGeometryRecord>().get(pDD);
+  if( m_HistoHGCal ) m_HistoHGCal->fillBeginJob((*pDD));
+}
+
+void
+MaterialBudgetHGCal::update( const BeginOfTrack* trk )
+{
+  const G4Track * aTrack = ( *trk )(); // recover G4 pointer if wanted
+  if( m_HistoHGCal ) m_HistoHGCal->fillStartTrack( aTrack );
+}
+ 
+void
+MaterialBudgetHGCal::update( const G4Step* aStep )
+{
+  if( m_HistoHGCal ) m_HistoHGCal->fillPerStep( aStep );
+
+  if( stopAfter( aStep ))
+  {
+    G4Track* track = aStep->GetTrack();
+    track->SetTrackStatus( fStopAndKill );
+  }
+}
+
+void
+MaterialBudgetHGCal::update( const EndOfTrack* )
+{
+  if( m_HistoHGCal ) m_HistoHGCal->fillEndTrack();
+}
+
+bool
+MaterialBudgetHGCal::stopAfter( const G4Step* aStep )
+{
+  G4ThreeVector hitPoint = aStep->GetPreStepPoint()->GetPosition();
+  double        rr = hitPoint.perp();
+  double        zz = std::abs( hitPoint.z());
+
+  if( rr > m_rMax || zz > m_zMax )
+  {
+    LogDebug("MaterialBudget") << " MaterialBudgetHGCal::StopAfter R = " << rr
+			       << " and Z = " << zz;
+    return true;
+  }
+  else
+  {
+    return false;
+  }
+}

--- a/Validation/Geometry/src/MaterialBudgetHGCalHistos.cc
+++ b/Validation/Geometry/src/MaterialBudgetHGCalHistos.cc
@@ -1,0 +1,323 @@
+#include "Validation/Geometry/interface/MaterialBudgetHGCalHistos.h"
+
+#include "DetectorDescription/Core/interface/DDFilter.h"
+#include "DetectorDescription/Core/interface/DDLogicalPart.h"
+#include "DetectorDescription/Core/interface/DDSplit.h"
+#include "DetectorDescription/Core/interface/DDValue.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+
+#include "CLHEP/Units/GlobalPhysicalConstants.h"
+#include "CLHEP/Units/GlobalSystemOfUnits.h"
+
+MaterialBudgetHGCalHistos::MaterialBudgetHGCalHistos( const edm::ParameterSet &p )
+{
+  binEta      = p.getUntrackedParameter<int>( "NBinEta", 260 );
+  binPhi      = p.getUntrackedParameter<int>( "NBinPhi", 180 );
+  maxEta      = p.getUntrackedParameter<double>( "MaxEta", 5.2 );
+  etaLow      = p.getUntrackedParameter<double>( "EtaLow", -5.2 );
+  etaHigh     = p.getUntrackedParameter<double>( "EtaHigh", 5.2 );
+  m_fillHistos  = p.getUntrackedParameter<bool>( "FillHisto", true );
+  m_printSum    = p.getUntrackedParameter<bool>( "PrintSummary", false );
+  edm::LogInfo("MaterialBudget") << "MaterialBudgetHGCalHistos: FillHisto : "
+				 << m_fillHistos << " PrintSummary " << m_printSum
+				 << " == Eta plot: NX " << binEta << " Range "
+				 << -maxEta << ":" << maxEta <<" Phi plot: NX "
+				 << binPhi << " Range " << -pi << ":" << pi 
+				 << " (Eta limit " << etaLow << ":" << etaHigh 
+				 <<")";
+  if( m_fillHistos) book();
+}
+
+void
+MaterialBudgetHGCalHistos::fillBeginJob( const DDCompactView & cpv )
+{
+  if( m_fillHistos )
+  {
+    std::string attribute = "ReadOutName";
+    std::string value     = "HGCHits";
+    DDSpecificsFilter filter1;
+    DDValue           ddv1( attribute, value, 0 );
+    filter1.setCriteria( ddv1, DDSpecificsFilter::equals );
+    DDFilteredView fv1( cpv );
+    fv1.addFilter( filter1 );
+    sensitives = getNames( fv1 );
+    edm::LogInfo("MaterialBudget") << "MaterialBudgetHGCalHistos: Names to be "
+				   << "tested for " << attribute << " = " 
+				   << value << " has " << sensitives.size()
+				   << " elements";
+    for( unsigned int i = 0; i < sensitives.size(); i++ ) 
+      edm::LogInfo("MaterialBudget") << "MaterialBudgetHGCalHistos: sensitives["
+				     << i << "] = " << sensitives[i];
+
+    attribute = "Volume";
+    value     = "HGC";
+    DDSpecificsFilter filter2;
+    DDValue           ddv2( attribute, value, 0 );
+    filter2.setCriteria( ddv2, DDSpecificsFilter::equals );
+    DDFilteredView fv2( cpv );
+    fv2.addFilter( filter2 );
+    hgcNames = getNames( fv2 );
+    fv2.firstChild();
+    DDsvalues_type sv( fv2.mergedSpecifics());
+
+    std::string hgcalRO[3] = {"HGCHitsEE", "HGCHitsHEfront", "HGCHitsHEback"};
+    attribute = "ReadOutName";
+    for( int k = 0; k < 3; k++ )
+    {
+      value = hgcalRO[k];
+      DDSpecificsFilter filter3;
+      DDValue           ddv3( attribute, value, 0 );
+      filter3.setCriteria( ddv3, DDSpecificsFilter::equals );
+      DDFilteredView fv3( cpv );
+      fv3.addFilter( filter3 );
+      std::vector<std::string> senstmp = getNames( fv3 );
+      edm::LogInfo("MaterialBudget") << "MaterialBudgetHGCalHistos: Names to be"
+				     << " tested for " << attribute << " = " 
+				     << value << " has " << senstmp.size()
+				     << " elements";
+      for( unsigned int i = 0; i < senstmp.size(); i++ )
+	sensitiveHGC.push_back( senstmp[i] );
+    }
+    for( unsigned int i = 0; i < sensitiveHGC.size(); i++ ) 
+      edm::LogInfo("MaterialBudget") << "MaterialBudgetHGCalHistos:sensitiveHGC["
+				     << i << "] = " << sensitiveHGC[i];
+  }
+}
+
+void
+MaterialBudgetHGCalHistos::fillStartTrack( const G4Track* aTrack )
+{
+  m_id     = layer  = steps   = 0;
+  radLen = intLen = stepLen = 0;
+
+  const G4ThreeVector& dir = aTrack->GetMomentum() ;
+  if (dir.theta() != 0 ) {
+    eta = dir.eta();
+  } else {
+    eta = -99;
+  }
+  phi = dir.phi();
+  double theEnergy = aTrack->GetTotalEnergy();
+  int    theID     = (int)(aTrack->GetDefinition()->GetPDGEncoding());
+
+  if( m_printSum ) {
+    matList.clear();
+    stepLength.clear();
+    radLength.clear();
+    intLength.clear();
+  }
+
+  edm::LogInfo("MaterialBudget") << "MaterialBudgetHGCalHistos: Track " 
+				 << aTrack->GetTrackID() << " Code " << theID
+				 << " Energy " << theEnergy/GeV << " GeV; Eta "
+				 << eta << " Phi " << phi/deg << " PT "
+				 << dir.perp()/GeV << " GeV *****";
+}
+
+void
+MaterialBudgetHGCalHistos::fillPerStep( const G4Step* aStep )
+{
+  G4Material * material = aStep->GetPreStepPoint()->GetMaterial();
+  double step    = aStep->GetStepLength();
+  double radl    = material->GetRadlen();
+  double intl    = material->GetNuclearInterLength();
+  double density = material->GetDensity() / (g/cm3);
+
+  const G4VTouchable* touch = aStep->GetPreStepPoint()->GetTouchable();
+  std::string         name  = touch->GetVolume(0)->GetName();
+  std::string         matName = material->GetName();
+  if( m_printSum )
+  {
+    bool found = false;
+    for( unsigned int ii = 0; ii < matList.size(); ii++ )
+    {
+      if( matList[ii] == matName )
+      {
+	stepLength[ii] += step;
+	radLength[ii]  += (step/radl);
+	intLength[ii]  += (step/intl);
+	found           = true;
+	break;
+      }
+    }
+    if( !found )
+    {
+      matList.push_back( matName );
+      stepLength.push_back( step );
+      radLength.push_back( step / radl );
+      intLength.push_back( step / intl );
+    }
+    edm::LogInfo("MaterialBudget") << name << " " << step << " " << matName 
+				   << " " << stepLen << " " << step/radl << " " 
+				   << radLen << " " <<step/intl << " " <<intLen;
+  }
+  else
+  {
+    edm::LogInfo("MaterialBudget") << "MaterialBudgetHGCalHistos: Step at " 
+				   << name << " Length " << step << " in " 
+				   << matName << " of density " << density 
+				   << " g/cc; Radiation Length " <<radl <<" mm;"
+				   << " Interaction Length " << intl << " mm\n"
+				   << "                          Position " 
+				   << aStep->GetPreStepPoint()->GetPosition()
+				   << " Cylindrical R "
+				   <<aStep->GetPreStepPoint()->GetPosition().perp()
+				   << " Length (so far) " << stepLen << " L/X0 "
+				   << step/radl << "/" << radLen << " L/Lambda "
+				   << step/intl << "/" << intLen;
+  }
+
+  if( m_fillHistos && isItHGC( name ))
+  {
+    m_id = 1;
+    fillHisto(m_id-1);
+  }
+
+  stepLen += step;
+  radLen  += step/radl;
+  intLen  += step/intl;
+}
+
+void
+MaterialBudgetHGCalHistos::fillEndTrack( void )
+{
+  if( m_fillHistos )
+  {
+    fillHisto( maxSet - 1 );
+  }
+  if( m_printSum )
+  {
+    for( unsigned int ii = 0; ii < matList.size(); ii++ )
+    {
+      edm::LogInfo("MaterialBudget") << matList[ii] << "\t" << stepLength[ii]
+				     << "\t" << radLength[ii] << "\t"
+				     << intLength[ii];
+    }
+  }
+}
+
+void
+MaterialBudgetHGCalHistos::book( void )
+{
+  edm::Service<TFileService> tfile;
+  
+  if( !tfile.isAvailable() )
+    throw cms::Exception("BadConfig") << "TFileService unavailable: "
+                                      << "please add it to config file";
+
+  double maxPhi = pi;
+  edm::LogInfo("MaterialBudget") << "MaterialBudgetHGCalHistos: Booking user "
+				 << "histos === with " << binEta << " bins "
+				 << "in eta from " << -maxEta << " to "
+				 << maxEta << " and " << binPhi << " bins "
+				 << "in phi from " << -maxPhi << " to " 
+				 << maxPhi;
+
+  char  name[10], title[40];
+  // total X0
+  for( int i = 0; i < maxSet; i++ )
+  {
+    sprintf(name, "%d", i+100);
+    sprintf(title, "MB(X0) prof Eta in region %d", i);
+    me100[i] =  tfile->make<TProfile>(name, title, binEta, -maxEta, maxEta);
+    sprintf(name, "%d", i+200);
+    sprintf(title, "MB(L0) prof Eta in region %d", i);
+    me200[i] = tfile->make<TProfile>(name, title, binEta, -maxEta, maxEta);
+    sprintf(name, "%d", i+300);
+    sprintf(title, "MB(Step) prof Eta in region %d", i);
+    me300[i] = tfile->make<TProfile>(name, title, binEta, -maxEta, maxEta);
+    sprintf(name, "%d", i+400);
+    sprintf(title, "Eta in region %d", i);
+    me400[i] = tfile->make<TH1F>(name, title, binEta, -maxEta, maxEta);
+    sprintf(name, "%d", i+500);
+    sprintf(title, "MB(X0) prof Ph in region %d", i);
+    me500[i] = tfile->make<TProfile>(name, title, binPhi, -maxPhi, maxPhi);
+    sprintf(name, "%d", i+600);
+    sprintf(title, "MB(L0) prof Ph in region %d", i);
+    me600[i] = tfile->make<TProfile>(name, title, binPhi, -maxPhi, maxPhi);
+    sprintf(name, "%d", i+700);
+    sprintf(title, "MB(Step) prof Ph in region %d", i);
+    me700[i] = tfile->make<TProfile>(name, title, binPhi, -maxPhi, maxPhi);
+    sprintf(name, "%d", i+800);
+    sprintf(title, "Phi in region %d", i);
+    me800[i] = tfile->make<TH1F>(name, title, binPhi, -maxPhi, maxPhi);
+    sprintf(name, "%d", i+900);
+    sprintf(title, "MB(X0) prof Eta Phi in region %d", i);
+    me900[i] = tfile->make<TProfile2D>(name, title, binEta/2, -maxEta, maxEta,
+				       binPhi/2, -maxPhi, maxPhi);
+    sprintf(name, "%d", i+1000);
+    sprintf(title, "MB(L0) prof Eta Phi in region %d", i);
+    me1000[i]= tfile->make<TProfile2D>(name, title, binEta/2, -maxEta, maxEta,
+				       binPhi/2, -maxPhi, maxPhi);
+    sprintf(name, "%d", i+1100);
+    sprintf(title, "MB(Step) prof Eta Phi in region %d", i);
+    me1100[i]= tfile->make<TProfile2D>(name, title, binEta/2, -maxEta, maxEta,
+				       binPhi/2, -maxPhi, maxPhi);
+    sprintf(name, "%d", i+1200);
+    sprintf(title, "Eta vs Phi in region %d", i);
+    me1200[i]= tfile->make<TH2F>(name, title, binEta/2, -maxEta, maxEta, 
+				 binPhi/2, -maxPhi, maxPhi);
+  }
+  edm::LogInfo("MaterialBudget") << "MaterialBudgetHGCalHistos: Booking user "
+				 << "histos done ===";
+}
+
+void
+MaterialBudgetHGCalHistos::fillHisto( int ii )
+{
+  LogDebug("MaterialBudget") << "MaterialBudgetHGCalHistos:FillHisto called "
+			     << "with index " << ii << " integrated  step "
+			     << stepLen << " X0 " << radLen << " Lamda " 
+			     << intLen;
+  
+  if( ii >=0 && ii < maxSet )
+  {
+    me100[ii]->Fill( eta, radLen );
+    me200[ii]->Fill( eta, intLen );
+    me300[ii]->Fill( eta, stepLen );
+    me400[ii]->Fill( eta );
+
+    if( eta >= etaLow && eta <= etaHigh )
+    {
+      me500[ii]->Fill( phi, radLen );
+      me600[ii]->Fill( phi, intLen );
+      me700[ii]->Fill( phi, stepLen );
+      me800[ii]->Fill( phi );
+    }
+
+    me900[ii]->Fill( eta, phi, radLen );
+    me1000[ii]->Fill( eta, phi, intLen );
+    me1100[ii]->Fill( eta, phi, stepLen );
+    me1200[ii]->Fill( eta, phi );
+  }
+}
+
+std::vector<std::string>
+MaterialBudgetHGCalHistos::getNames( DDFilteredView& fv )
+{
+  std::vector<std::string> tmp;
+  bool dodet = fv.firstChild();
+  while (dodet) {
+    const DDLogicalPart & log = fv.logicalPart();
+    std::string namx = log.name().name();
+    bool ok = true;
+    for (unsigned int i=0; i<tmp.size(); i++)
+      if (namx == tmp[i]) ok = false;
+    if (ok) tmp.push_back(namx);
+    dodet = fv.next();
+  }
+  return tmp;
+}
+
+bool
+MaterialBudgetHGCalHistos::isItHGC( const std::string & name )
+{
+  std::vector<std::string>::const_iterator it = sensitiveHGC.begin();
+  std::vector<std::string>::const_iterator itEnd = sensitiveHGC.end();
+  for( ; it != itEnd; ++it )
+    if( name == *it ) return true;
+  return false;
+}

--- a/Validation/Geometry/src/module.cc
+++ b/Validation/Geometry/src/module.cc
@@ -2,11 +2,13 @@
 #include "Validation/Geometry/interface/MaterialBudget.h"
 #include "Validation/Geometry/interface/MaterialBudgetAction.h"
 #include "Validation/Geometry/interface/MaterialBudgetHcal.h"
+#include "Validation/Geometry/interface/MaterialBudgetHGCal.h"
 #include "Validation/Geometry/interface/MaterialBudgetForward.h"
 #include "FWCore/PluginManager/interface/ModuleDef.h"
 
 DEFINE_SIMWATCHER (MaterialBudget);
 DEFINE_SIMWATCHER (MaterialBudgetAction);
 DEFINE_SIMWATCHER (MaterialBudgetHcal);
+DEFINE_SIMWATCHER (MaterialBudgetHGCal);
 DEFINE_SIMWATCHER (MaterialBudgetForward);
 

--- a/Validation/Geometry/test/runP_HGCAL_cfg.py
+++ b/Validation/Geometry/test/runP_HGCAL_cfg.py
@@ -1,0 +1,79 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("PROD")
+
+process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
+
+#Geometry
+#
+process.load('Configuration.Geometry.GeometryExtended2023HGCalMuonReco_cff')
+process.load('Configuration.Geometry.GeometryExtended2023HGCalMuon_cff')
+
+#Magnetic Field
+#
+process.load("Configuration.StandardSequences.MagneticField_cff")
+
+process.load("Configuration.EventContent.EventContent_cff")
+
+# Detector simulation (Geant4-based)
+#
+process.load("SimG4Core.Application.g4SimHits_cfi")
+
+process.load("IOMC.RandomEngine.IOMC_cff")
+process.RandomNumberGeneratorService.g4SimHits.initialSeed = 9876
+
+process.MessageLogger = cms.Service("MessageLogger",
+    destinations = cms.untracked.vstring('cout'),
+    categories = cms.untracked.vstring('MaterialBudget'),
+#    debugModules = cms.untracked.vstring('*'),
+    cout = cms.untracked.PSet(
+#        threshold = cms.untracked.string('DEBUG'),
+        default = cms.untracked.PSet(
+            limit = cms.untracked.int32(0)
+        ),
+        MaterialBudget = cms.untracked.PSet(
+            limit = cms.untracked.int32(0)
+        )
+    )
+)
+
+process.source = cms.Source("PoolSource",
+    noEventSort = cms.untracked.bool(True),
+    duplicateCheckMode = cms.untracked.string("noDuplicateCheck"),
+    fileNames = cms.untracked.vstring('file:single_neutrino_random.root')
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(-1)
+)
+
+process.TFileService = cms.Service("TFileService",
+    fileName = cms.string('matbdg_HGCAL.root')
+)
+
+process.p1 = cms.Path(process.g4SimHits)
+process.g4SimHits.UseMagneticField = False
+process.g4SimHits.Physics.type = 'SimG4Core/Physics/DummyPhysics'
+process.g4SimHits.Physics.DummyEMPhysics = True
+process.g4SimHits.Physics.CutsPerRegion = False
+process.g4SimHits.Watchers = cms.VPSet(cms.PSet(
+    MaterialBudgetHGCal = cms.PSet(
+        FillHisto    = cms.untracked.bool(True),
+        PrintSummary = cms.untracked.bool(False),
+        NBinPhi      = cms.untracked.int32(360),
+        NBinEta      = cms.untracked.int32(260),
+        MaxEta       = cms.untracked.double(5.2),
+        EtaLow       = cms.untracked.double(-5.2),
+        EtaHigh      = cms.untracked.double(5.2),
+        RMax         = cms.untracked.double(5.0),
+        ZMax         = cms.untracked.double(14.0)
+    ),
+    type = cms.string('MaterialBudgetHGCal')
+))
+
+
+# Automatic addition of the customisation function from SLHCUpgradeSimulations.Configuration.combinedCustoms
+from SLHCUpgradeSimulations.Configuration.combinedCustoms import cust_2023HGCalMuon 
+
+#call to customisation function cust_2023HGCalMuon imported from SLHCUpgradeSimulations.Configuration.combinedCustoms
+process = cust_2023HGCalMuon(process)


### PR DESCRIPTION
- Add a new SimWatcher plugin for HGCal and a configuration to run the validation

After merging this branch, simply run:

```
cmsRun Validation/Geometry/python/single_neutrino_cfg.py
cmsRun Validation/Geometry/test/runP_HGCAL_cfg.py
```

The histograms are produced in matbdg_HGCAL.root file
