### PR TITLE
Make pointers to error strings const in TinyXML

### DIFF
--- a/FWCore/Utilities/interface/tinyxml.h
+++ b/FWCore/Utilities/interface/tinyxml.h
@@ -372,7 +372,7 @@ protected:
 								bool ignoreCase,
 								TiXmlEncoding encoding );
 
-	static const char* errorString[ TIXML_ERROR_STRING_COUNT ];
+	static const char* const errorString[ TIXML_ERROR_STRING_COUNT ];
 
 	TiXmlCursor location;
 

--- a/FWCore/Utilities/src/tinyxmlerror.cc
+++ b/FWCore/Utilities/src/tinyxmlerror.cc
@@ -35,7 +35,7 @@ distribution.
 // It also cleans up the code a bit.
 //
 
-const char* TiXmlBase::errorString[ TIXML_ERROR_STRING_COUNT ] =
+const char* const TiXmlBase::errorString[ TIXML_ERROR_STRING_COUNT ] =
 {
 	"No error",
 	"Error",


### PR DESCRIPTION
The static analyzer (correctly) pointed to the fact that the array of pointers to the error strings in TinyXML kept one from changing the strings but did not keep one from changing the addresses of the pointers in the array. Making the pointers const solves that problem and guarantees immutability.
