### PR TITLE
Optional printout of random number end of event

### DIFF
--- a/SimG4Core/Application/interface/EventAction.h
+++ b/SimG4Core/Application/interface/EventAction.h
@@ -50,6 +50,7 @@ private:
     SimRunInterface* m_runInterface;
     SimTrackManager* m_trackManager;
     std::string m_stopFile;
+    bool m_printRandom;
     bool m_debug;
 };
 

--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -146,6 +146,7 @@ g4SimHits = cms.EDProducer("OscarProducer",
     EventAction = cms.PSet(
         debug = cms.untracked.bool(False),
         StopFile = cms.string('StopRun'),
+        PrintRandomSeed = cms.bool(False),
         CollapsePrimaryVertices = cms.bool(False)
     ),
     StackingAction = cms.PSet(

--- a/SimG4Core/Application/src/EventAction.cc
+++ b/SimG4Core/Application/src/EventAction.cc
@@ -8,6 +8,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include <fstream>
+#include "Randomize.hh"
 
 //using std::cout;
 //using std::endl;
@@ -18,6 +19,7 @@ EventAction::EventAction(const edm::ParameterSet & p,
     : m_runInterface(rm),
       m_trackManager(iManager),
       m_stopFile(p.getParameter<std::string>("StopFile")),
+      m_printRandom(p.getParameter<bool>("PrintRandomSeed")),
       m_debug(p.getUntrackedParameter<bool>("debug",false))
 {
   m_trackManager->setCollapsePrimaryVertices(p.getParameter<bool>("CollapsePrimaryVertices"));
@@ -45,6 +47,14 @@ void EventAction::BeginOfEventAction(const G4Event * anEvent)
 
 void EventAction::EndOfEventAction(const G4Event * anEvent)
 {
+  if(m_printRandom) 
+    {
+      edm::LogInfo("SimG4CoreApplication") << " Event " << anEvent->GetEventID()
+					   << " Random number: " << G4UniformRand();  
+      //std::cout << " Event " << anEvent->GetEventID()
+      //	<< " Random number: " << G4UniformRand() << std::endl;  
+      //CLHEP::HepRandom::showEngineStatus();
+    }
   if (std::ifstream(m_stopFile.c_str()))
     {
       edm::LogWarning("SimG4CoreApplication")


### PR DESCRIPTION
Added optional feature mainly for MT mode but is also applicable for sequential. Disabled by default.

No effect on production.
