### PR TITLE
Make StorageFactory's StorageMaker cache thread safe

### DIFF
--- a/Utilities/StorageFactory/interface/StorageFactory.h
+++ b/Utilities/StorageFactory/interface/StorageFactory.h
@@ -6,7 +6,8 @@
 # include "Utilities/StorageFactory/interface/IOTypes.h"
 # include "Utilities/StorageFactory/interface/IOFlags.h"
 # include <string>
-# include <map>
+#include <memory>
+#include "tbb/concurrent_unordered_map.h"
 
 class Storage;
 class StorageFactory 
@@ -65,8 +66,8 @@ public:
 				  const std::string &path,
 				  int mode);
 
-protected:
-  typedef std::map<std::string, StorageMaker *> MakerTable;
+private:
+  typedef tbb::concurrent_unordered_map<std::string, std::shared_ptr<StorageMaker>> MakerTable;
 
   StorageFactory (void);
   StorageMaker *getMaker (const std::string &proto);


### PR DESCRIPTION
Given the use of SecondarySource, it is possible for multiple modules to ask the StorageFactory to open a file simultaneously. Switching the cache to use a tbb::concurrent_unordered_map avoids race conditions. In addition, having the map hold std::shared_ptr makes lifetime issues easier to deal with. [Can't use a std::unique_ptr since tbb::concurrent_unordered_map can't deal with R-value references.]
