### PR TITLE
V0branch - modifications to V0Fitter (V0Producer) for PU

### DIFF
--- a/RecoVertex/V0Producer/python/generalV0Candidates_cfi.py
+++ b/RecoVertex/V0Producer/python/generalV0Candidates_cfi.py
@@ -9,14 +9,16 @@ generalV0Candidates = cms.EDProducer("V0Producer",
    doKShorts = cms.bool(True),
    doLambdas = cms.bool(True),
 
-   # which vertex fitting algorithm to use (we recommend using the KalmanVertexFitter)
-   vertexFitter = cms.InputTag('KalmanVertexFitter'),
+   # which vertex fitting algorithm to use
+   # True -> KalmanVertexFitter (recommended)
+   # False -> AdaptiveVertexFitter (not recommended)
+   vertexFitter = cms.bool(True),
 
-   # if set to True, uses tracks refit by the KVF for V0Candidate kinematics
-   # this is automatically set to FALSE if using the AdaptiveVertexFitter (which is not recommended)
-   useSmoothing = cms.bool(True),
+   # use the refitted tracks returned from the KVF for V0Candidate kinematics
+   # this is automatically set to False if using the AdaptiveVertexFitter
+   useRefTracks = cms.bool(True),
 
-   # -- cuts on initial track collection
+   # -- cuts on initial track collection --
    # Track normalized Chi2 <
    tkChi2Cut = cms.double(10.0),
    # Number of valid hits on track >=
@@ -35,11 +37,15 @@ generalV0Candidates = cms.EDProducer("V0Producer",
    # -- miscellaneous cuts --
    # POCA distance between tracks <
    tkDCACut = cms.double(2.0),
+   # invariant mass of track pair - assuming both tracks are charged pions <
+   mPiPiCut = cms.double(0.6),
    # check if either track has a hit radially inside the vertex position minus this number times the sigma of the vertex fit
    # note: Set this to -1 to disable this cut, which MUST be done if you want to run V0Producer on the AOD track collection!
    innerHitPosCut = cms.double(4.0),
    # cos(angle) between x and p of V0 candidate >
    v0CosThetaCut = cms.double(0.9998),
+
+   # -- cuts on the V0 candidate mass --
    # V0 mass window +- pdg value
    kShortMassCut = cms.double(0.07),
    lambdaMassCut = cms.double(0.05)

--- a/RecoVertex/V0Producer/python/generalV0Candidates_cfi.py
+++ b/RecoVertex/V0Producer/python/generalV0Candidates_cfi.py
@@ -2,61 +2,57 @@ import FWCore.ParameterSet.Config as cms
 
 generalV0Candidates = cms.EDProducer("V0Producer",
                                      
-    # InputTag that tells which TrackCollection to use for vertexing
-    trackRecoAlgorithm = cms.InputTag('generalTracks'),
+   # which TrackCollection to use for vertexing
+   trackRecoAlgorithm = cms.InputTag('generalTracks'),
 
-    # These bools decide whether or not to reconstruct
-    #  specific V0 particles
-    selectKshorts = cms.bool(True),
-    selectLambdas = cms.bool(True),
+   # which V0s to reconstruct
+   doKShorts = cms.bool(True),
+   doLambdas = cms.bool(True),
 
-    # Recommend leaving this one as is.
-    vertexFitter = cms.InputTag('KalmanVertexFitter'),
+   # which vertex fitting algorithm to use (we recommend using the KalmanVertexFitter)
+   vertexFitter = cms.InputTag('KalmanVertexFitter'),
 
-    # set to true, uses tracks refit by the KVF for V0Candidate kinematics
-    #  NOTE: useSmoothing is automatically set to FALSE
-    #  if using the AdaptiveVertexFitter (which is NOT recommended)
-    useSmoothing = cms.bool(True),
-                                     
-    # Select tracks using TrackBase::TrackQuality.
-    # Select ALL tracks by leaving this vstring empty, which
-    #   is equivalent to using 'loose'
-    #trackQualities = cms.vstring('highPurity', 'goodIterative'),
-    trackQualities = cms.vstring('loose'),
-                                     
-    # The next parameters are cut values.
-    # All distances are in cm, all energies in GeV, as usual.
+   # if set to True, uses tracks refit by the KVF for V0Candidate kinematics
+   # this is automatically set to FALSE if using the AdaptiveVertexFitter (which is not recommended)
+   useSmoothing = cms.bool(True),
 
-    # --Track quality/compatibility cuts--
-    #   Normalized track Chi2 <
-    tkChi2Cut = cms.double(5.0),
-    #   Number of valid hits on track >=
-    tkNhitsCut = cms.int32(6),
-    #   Track impact parameter significance >
-    impactParameterSigCut = cms.double(2.),
-    # We calculate the PCA of the tracks quickly in RPhi, extrapolating
-    # the z position as well, before vertexing.  Used in the following 2 cuts:
-    #   m_pipi calculated at PCA of tracks <
-    #mPiPiCut = cms.double(0.6),
-    #   PCA distance between tracks <
-    tkDCACut = cms.double(1.),
+   # The next parameters are cut selections (distances are in cm / energies are in GeV)
 
-    # --V0 Vertex cuts--
-    #   Vertex chi2 < 
-    vtxChi2Cut = cms.double(7.0),
-    #   Vertex radius cut >
-    rVtxCut = cms.double(0.0),
-    #   Radial vertex significance >
-    vtxSignificance2DCut = cms.double(15.0),
-    #   V0 mass window, Candidate mass must be within these values of
-    #     the PDG mass to be stored in the collection
-    kShortMassCut = cms.double(0.07),
-    lambdaMassCut = cms.double(0.05),
-    # We check if either track has a hit inside (radially) the vertex position
-    #  minus this number times the sigma of the vertex fit
-    #  NOTE: Set this to -1 to disable this cut, which MUST be done
-    #  if you want to run V0Producer on the AOD track collection!
-    innerHitPosCut = cms.double(4.)
+   # -- cuts on the input track collection --
+   # select tracks using TrackBase::TrackQuality.
+   # select ALL tracks by leaving this vstring empty, which is equivalent to using 'loose'
+   # trackQualities = cms.vstring('highPurity', 'goodIterative'),
+   trackQualities = cms.vstring('loose'),
+   # Normalized track Chi2 <
+   tkChi2Cut = cms.double(1000.0),
+   # Pt of track >
+   tkPtCut = cms.double(0.35),
+   # Number of valid hits on track >=
+   tkNhitsCut = cms.int32(7),
+   # Track impact parameter significance >
+   tkIPSigCut = cms.double(2.0),
+
+   # -- cuts on the V0 vertex --
+   #   Vertex chi2 <
+   vtxChi2Cut = cms.double(15.0),
+   #  Vertex radius cut >
+   vtxRCut = cms.double(0.0),
+   #  Radial vertex significance >
+   vtxRSigCut = cms.double(10.0),
+
+   # -- miscellaneous cuts after vertexing --
+   # m_pipi calculated at PCA of tracks <
+   #mPiPiCut = cms.double(0.6),
+   # PCA distance between tracks <
+   tkDCACut = cms.double(2.0),
+   #  V0 mass window +- pdg value
+   KShortMassCut = cms.double(0.07),
+   LambdaMassCut = cms.double(0.05),
+   # check if either track has a hit radially inside the vertex position minus this number times the sigma of the vertex fit
+   # note: Set this to -1 to disable this cut, which MUST be done if you want to run V0Producer on the AOD track collection!
+   innerHitPosCut = cms.double(4.0),
+   # cos(angle) between x and p of V0 candidate >
+   V0costhetaCut = cms.double(0.9998)
+
 )
-
 

--- a/RecoVertex/V0Producer/python/generalV0Candidates_cfi.py
+++ b/RecoVertex/V0Producer/python/generalV0Candidates_cfi.py
@@ -44,28 +44,14 @@ generalV0Candidates = cms.EDProducer("V0Producer",
     # --V0 Vertex cuts--
     #   Vertex chi2 < 
     vtxChi2Cut = cms.double(7.0),
-    #   Lambda collinearity cut
-    #   (UNUSED)
-    collinearityCut = cms.double(0.02),
     #   Vertex radius cut >
-    #   (UNUSED)
     rVtxCut = cms.double(0.0),
-    #   V0 decay length from primary cut >
-    #   (UNUSED)
-    lVtxCut = cms.double(0.0),
     #   Radial vertex significance >
     vtxSignificance2DCut = cms.double(15.0),
-    #   3D vertex significance using primary vertex
-    #   (UNUSED)
-    vtxSignificance3DCut = cms.double(0.0),
     #   V0 mass window, Candidate mass must be within these values of
     #     the PDG mass to be stored in the collection
     kShortMassCut = cms.double(0.07),
     lambdaMassCut = cms.double(0.05),
-    #   Mass window cut using normalized mass (mass / massError)
-    #   (UNUSED)
-    kShortNormalizedMassCut = cms.double(0.0),
-    lambdaNormalizedMassCut = cms.double(0.0),
     # We check if either track has a hit inside (radially) the vertex position
     #  minus this number times the sigma of the vertex fit
     #  NOTE: Set this to -1 to disable this cut, which MUST be done

--- a/RecoVertex/V0Producer/python/generalV0Candidates_cfi.py
+++ b/RecoVertex/V0Producer/python/generalV0Candidates_cfi.py
@@ -37,7 +37,7 @@ generalV0Candidates = cms.EDProducer("V0Producer",
     # We calculate the PCA of the tracks quickly in RPhi, extrapolating
     # the z position as well, before vertexing.  Used in the following 2 cuts:
     #   m_pipi calculated at PCA of tracks <
-    mPiPiCut = cms.double(0.6),
+    #mPiPiCut = cms.double(0.6),
     #   PCA distance between tracks <
     tkDCACut = cms.double(1.),
 

--- a/RecoVertex/V0Producer/python/generalV0Candidates_cfi.py
+++ b/RecoVertex/V0Producer/python/generalV0Candidates_cfi.py
@@ -16,41 +16,33 @@ generalV0Candidates = cms.EDProducer("V0Producer",
    # this is automatically set to FALSE if using the AdaptiveVertexFitter (which is not recommended)
    useSmoothing = cms.bool(True),
 
-   # The next parameters are cut selections (distances are in cm / energies are in GeV)
-
-   # -- cuts on the input track collection --
-   # select tracks using TrackBase::TrackQuality.
-   # select ALL tracks by leaving this vstring empty, which is equivalent to using 'loose'
-   # trackQualities = cms.vstring('highPurity', 'goodIterative'),
-   trackQualities = cms.vstring('loose'),
-   # Normalized track Chi2 <
-   tkChi2Cut = cms.double(1000.0),
-   # Pt of track >
-   tkPtCut = cms.double(0.35),
+   # -- cuts on initial track collection
+   # Track normalized Chi2 <
+   tkChi2Cut = cms.double(10.0),
    # Number of valid hits on track >=
    tkNHitsCut = cms.int32(7),
+   # Pt of track >
+   tkPtCut = cms.double(0.35),
    # Track impact parameter significance >
    tkIPSigCut = cms.double(2.0),
 
-   # -- cuts on the V0 vertex --
-   #   Vertex chi2 <
+   # -- cuts on the vertex --
+   # Vertex chi2 <
    vtxChi2Cut = cms.double(15.0),
-   #  Vertex radius cut >
-   vtxRCut = cms.double(0.0),
-   #  Radial vertex significance >
-   vtxRSigCut = cms.double(10.0),
+   # Radial vertex significance >
+   vtxDecayRSigCut = cms.double(10.0),
 
-   # -- miscellaneous cuts after vertexing --
-   # PCA distance between tracks <
+   # -- miscellaneous cuts --
+   # POCA distance between tracks <
    tkDCACut = cms.double(2.0),
-   #  V0 mass window +- pdg value
-   kshortMassCut = cms.double(0.07),
-   lambdaMassCut = cms.double(0.05),
    # check if either track has a hit radially inside the vertex position minus this number times the sigma of the vertex fit
    # note: Set this to -1 to disable this cut, which MUST be done if you want to run V0Producer on the AOD track collection!
    innerHitPosCut = cms.double(4.0),
    # cos(angle) between x and p of V0 candidate >
-   v0CosThetaCut = cms.double(0.9998)
+   v0CosThetaCut = cms.double(0.9998),
+   # V0 mass window +- pdg value
+   kShortMassCut = cms.double(0.07),
+   lambdaMassCut = cms.double(0.05)
 
 )
 

--- a/RecoVertex/V0Producer/python/generalV0Candidates_cfi.py
+++ b/RecoVertex/V0Producer/python/generalV0Candidates_cfi.py
@@ -28,7 +28,7 @@ generalV0Candidates = cms.EDProducer("V0Producer",
    # Pt of track >
    tkPtCut = cms.double(0.35),
    # Number of valid hits on track >=
-   tkNhitsCut = cms.int32(7),
+   tkNHitsCut = cms.int32(7),
    # Track impact parameter significance >
    tkIPSigCut = cms.double(2.0),
 
@@ -41,18 +41,16 @@ generalV0Candidates = cms.EDProducer("V0Producer",
    vtxRSigCut = cms.double(10.0),
 
    # -- miscellaneous cuts after vertexing --
-   # m_pipi calculated at PCA of tracks <
-   #mPiPiCut = cms.double(0.6),
    # PCA distance between tracks <
    tkDCACut = cms.double(2.0),
    #  V0 mass window +- pdg value
-   KShortMassCut = cms.double(0.07),
-   LambdaMassCut = cms.double(0.05),
+   kshortMassCut = cms.double(0.07),
+   lambdaMassCut = cms.double(0.05),
    # check if either track has a hit radially inside the vertex position minus this number times the sigma of the vertex fit
    # note: Set this to -1 to disable this cut, which MUST be done if you want to run V0Producer on the AOD track collection!
    innerHitPosCut = cms.double(4.0),
    # cos(angle) between x and p of V0 candidate >
-   V0costhetaCut = cms.double(0.9998)
+   v0CosThetaCut = cms.double(0.9998)
 
 )
 

--- a/RecoVertex/V0Producer/src/V0Fitter.cc
+++ b/RecoVertex/V0Producer/src/V0Fitter.cc
@@ -75,7 +75,7 @@ V0Fitter::V0Fitter(const edm::ParameterSet& theParameters,
   kShortMassCut = theParameters.getParameter<double>(string("kShortMassCut"));
   lambdaMassCut = theParameters.getParameter<double>(string("lambdaMassCut"));
   impactParameterSigCut = theParameters.getParameter<double>(string("impactParameterSigCut"));
-  mPiPiCut = theParameters.getParameter<double>(string("mPiPiCut"));
+  //mPiPiCut = theParameters.getParameter<double>(string("mPiPiCut"));
   tkDCACut = theParameters.getParameter<double>(string("tkDCACut"));
   vtxFitter = theParameters.getParameter<edm::InputTag>("vertexFitter");
   innerHitPosCut = theParameters.getParameter<double>(string("innerHitPosCut"));
@@ -229,7 +229,7 @@ void V0Fitter::fitAll(const edm::Event& iEvent, const edm::EventSetup& iSetup,
       if (dca < 0. || dca > tkDCACut) continue;
       if (sqrt( cxPt.x()*cxPt.x() + cxPt.y()*cxPt.y() ) > 120. 
           || std::abs(cxPt.z()) > 300.) continue;
-
+/*
       // Get trajectory states for the tracks at POCA for later cuts
       TrajectoryStateClosestToPoint const & posTSCP = 
 	posTransTkPtr->trajectoryStateClosestToPoint( cxPt );
@@ -239,11 +239,11 @@ void V0Fitter::fitAll(const edm::Event& iEvent, const edm::EventSetup& iSetup,
       if( !posTSCP.isValid() || !negTSCP.isValid() ) continue;
 
 
-      /*double posESq = posTSCP.momentum().mag2() + piMassSquared;
+      double posESq = posTSCP.momentum().mag2() + piMassSquared;
       double negESq = negTSCP.momentum().mag2() + piMassSquared;
       double posE = sqrt(posESq);
       double negE = sqrt(negESq);
-      double totalE = posE + negE;*/
+      double totalE = posE + negE;
       double totalE = sqrt( posTSCP.momentum().mag2() + piMassSquared ) +
 	              sqrt( negTSCP.momentum().mag2() + piMassSquared );
       double totalESq = totalE*totalE;
@@ -254,7 +254,7 @@ void V0Fitter::fitAll(const edm::Event& iEvent, const edm::EventSetup& iSetup,
       //mPiPiMassOut << mass << std::endl;
 
       if( mass > mPiPiCut ) continue;
-
+*/
       // Create the vertex fitter object and vertex the tracks
       TransientVertex theRecoVertex;
       if(vtxFitter == std::string("KalmanVertexFitter")) {

--- a/RecoVertex/V0Producer/src/V0Fitter.cc
+++ b/RecoVertex/V0Producer/src/V0Fitter.cc
@@ -71,7 +71,6 @@ V0Fitter::V0Fitter(const edm::ParameterSet& theParameters,
   tkNhitsCut = theParameters.getParameter<int>(string("tkNhitsCut"));
   rVtxCut = theParameters.getParameter<double>(string("rVtxCut"));
   vtxSigCut = theParameters.getParameter<double>(string("vtxSignificance2DCut"));
-  collinCut = theParameters.getParameter<double>(string("collinearityCut"));
   kShortMassCut = theParameters.getParameter<double>(string("kShortMassCut"));
   lambdaMassCut = theParameters.getParameter<double>(string("lambdaMassCut"));
   impactParameterSigCut = theParameters.getParameter<double>(string("impactParameterSigCut"));

--- a/RecoVertex/V0Producer/src/V0Fitter.cc
+++ b/RecoVertex/V0Producer/src/V0Fitter.cc
@@ -2,7 +2,7 @@
 //
 // Package:    V0Producer
 // Class:      V0Fitter
-// 
+//
 /**\class V0Fitter V0Fitter.cc RecoVertex/V0Producer/src/V0Fitter.cc
 
  Description: <one line class summary>
@@ -39,204 +39,171 @@ namespace {
    const double piMassSquared = piMass*piMass;
    const double protonMass = 0.938272046;
    const double protonMassSquared = protonMass*protonMass;
-   const double kshortMass = 0.497614;
+   const double kShortMass = 0.497614;
    const double lambdaMass = 1.115683;
 }
 
-// constructor
+typedef ROOT::Math::SMatrix<double, 3, 3, ROOT::Math::MatRepSym<double, 3> > SMatrixSym3D;
+typedef ROOT::Math::SVector<double, 3> SVector3;
+
 V0Fitter::V0Fitter(const edm::ParameterSet& theParameters, edm::ConsumesCollector && iC)
 {
    using std::string;
 
-   // token to request the tracks (with a parameter to decide which track collection)
+   token_beamSpot = iC.consumes<reco::BeamSpot>(edm::InputTag("offlineBeamSpot"));
    token_tracks = iC.consumes<reco::TrackCollection>(theParameters.getParameter<edm::InputTag>("trackRecoAlgorithm"));
 
-   // token to request the beamspot
-   token_beamspot = iC.consumes<reco::BeamSpot>(edm::InputTag("offlineBeamSpot"));
+   useRefTrax = theParameters.getParameter<bool>(string("useSmoothing"));
+   vertexFitter_ = theParameters.getParameter<edm::InputTag>("vertexFitter");
 
-   // whether to reconstruct K0s
+   // whether to reconstruct KShorts
    doKShorts_ = theParameters.getParameter<bool>(string("doKShorts"));
    // whether to reconstruct Lambdas
    doLambdas_ = theParameters.getParameter<bool>(string("doLambdas"));
 
-   // which vertex fitting algorithm to use
-   vtxFitter = theParameters.getParameter<edm::InputTag>("vertexFitter");
-
-   // whether to use the refit tracks for V0 kinematics
-   useRefTrax = theParameters.getParameter<bool>(string("useSmoothing"));
-
-   // cuts on the input track collection
-   std::vector<std::string> qual = theParameters.getParameter<std::vector<std::string> >("trackQualities");
-   for (unsigned int ndx = 0; ndx < qual.size(); ndx++) {
-      qualities.push_back(reco::TrackBase::qualityByName(qual[ndx]));
-   }
+   // cuts on initial track selection
    tkChi2Cut_ = theParameters.getParameter<double>(string("tkChi2Cut"));
-   tkPtCut_ = theParameters.getParameter<double>(string("tkPtCut"));  
    tkNHitsCut_ = theParameters.getParameter<int>(string("tkNHitsCut"));
+   tkPtCut_ = theParameters.getParameter<double>(string("tkPtCut"));
    tkIPSigCut_ = theParameters.getParameter<double>(string("tkIPSigCut"));
-   // cuts on the V0 vertex
+   // cuts on vertex
    vtxChi2Cut_ = theParameters.getParameter<double>(string("vtxChi2Cut"));
-   vtxRCut_ = theParameters.getParameter<double>(string("vtxRCut"));
-   vtxRSigCut_ = theParameters.getParameter<double>(string("vtxRSigCut"));
-   // miscellaneous cuts after vertexing
+   vtxDecayRSigCut_ = theParameters.getParameter<double>(string("vtxDecayRSigCut"));
+   // cuts post-vertexing
    tkDCACut_ = theParameters.getParameter<double>(string("tkDCACut"));
-   kshortMassCut_ = theParameters.getParameter<double>(string("kshortMassCut"));
-   lambdaMassCut_ = theParameters.getParameter<double>(string("lambdaMassCut"));
    innerHitPosCut_ = theParameters.getParameter<double>(string("innerHitPosCut"));
    v0CosThetaCut_ = theParameters.getParameter<double>(string("v0CosThetaCut"));
-
+   kShortMassCut_ = theParameters.getParameter<double>(string("kShortMassCut"));
+   lambdaMassCut_ = theParameters.getParameter<double>(string("lambdaMassCut"));
 }
 
 // method containing the algorithm for vertex reconstruction
 void V0Fitter::fitAll(const edm::Event& iEvent, const edm::EventSetup& iSetup,
-   reco::VertexCompositeCandidateCollection & theKShorts, reco::VertexCompositeCandidateCollection & theLambdas)
+   reco::VertexCompositeCandidateCollection & theKshorts, reco::VertexCompositeCandidateCollection & theLambdas)
 {
    using std::vector;
    using namespace reco;
    using namespace edm;
 
-   edm::Handle<reco::TrackCollection> trackHandle;
-   iEvent.getByToken(token_tracks, trackHandle);
-   if (!trackHandle->size()) return;
-   const reco::TrackCollection* trackColl = trackHandle.product();
-  
-   edm::Handle<reco::BeamSpot> beamspotHandle;
-   iEvent.getByToken(token_beamspot, beamspotHandle);
-   const GlobalPoint beamspotPos(beamspotHandle->position().x(), beamspotHandle->position().y(), beamspotHandle->position().z());
+   Handle<reco::TrackCollection> theTrackHandle;
+   iEvent.getByToken(token_tracks, theTrackHandle);
+   if (!theTrackHandle->size()) return;
+   const reco::TrackCollection* theTrackCollection = theTrackHandle.product();   
 
-   ESHandle<MagneticField> bFieldHandle;
-   iSetup.get<IdealMagneticFieldRecord>().get(bFieldHandle);
-   const MagneticField* magField = bFieldHandle.product();
+   Handle<reco::BeamSpot> theBeamSpotHandle;
+   iEvent.getByToken(token_beamSpot, theBeamSpotHandle);
+   const reco::BeamSpot* theBeamSpot = theBeamSpotHandle.product();
+   const GlobalPoint beamSpotPos(theBeamSpot->position().x(), theBeamSpot->position().y(), theBeamSpot->position().z());
 
-   ESHandle<GlobalTrackingGeometry> globTkGeomHandle;
-   iSetup.get<GlobalTrackingGeometryRecord>().get(globTkGeomHandle);
+   ESHandle<MagneticField> theMagneticFieldHandle;
+   iSetup.get<IdealMagneticFieldRecord>().get(theMagneticFieldHandle);
+   const MagneticField* theMagneticField = theMagneticFieldHandle.product();
 
-   // fill theGoodTracks with track index if it passes preselection
-   std::vector<size_t> theGoodTracks;
-   for (TrackCollection::const_iterator iTrack = trackColl->begin(); iTrack != trackColl->end(); ++iTrack) {
-      bool quality_ok = true;
-      if (qualities.size() != 0) {
-         quality_ok = false;
-         for (unsigned int ndx_ = 0; ndx_ < qualities.size(); ++ndx_) {
-            if ((*iTrack).quality(qualities[ndx_])) {
-               quality_ok = true;
-               break;
-            }
-         }
-      }
-      if (quality_ok) {
-         if ((*iTrack).normalizedChi2() < tkChi2Cut_ && (*iTrack).pt() > tkPtCut_ && (*iTrack).numberOfValidHits() >= tkNHitsCut_) {
-            FreeTrajectoryState initialFTS = trajectoryStateTransform::initialFreeState((*iTrack), magField);
-            TSCBLBuilderNoMaterial blsBuilder;
-            TrajectoryStateClosestToBeamLine tscb(blsBuilder(initialFTS, *beamspotHandle));
-            if (tscb.isValid()) {
-               if (tscb.transverseImpactParameter().significance() > tkIPSigCut_) {
-                  theGoodTracks.push_back(std::move(std::distance(trackColl->begin(), iTrack)));
-               }
-            }
-         }
+   std::vector<TrackRef> theTrackRefs;
+   std::vector<TransientTrack> theTransTracks;
+
+   // fill vectors of TransientTracks and TrackRefs after applying preselection cuts
+   for (reco::TrackCollection::const_iterator iTk = theTrackCollection->begin(); iTk != theTrackCollection->end(); ++iTk) {
+      const reco::Track* tmpTrack = &(*iTk);
+      double ipsig = fabs(tmpTrack->dxy(*theBeamSpot)/tmpTrack->dxyError());
+      if (tmpTrack->normalizedChi2() < tkChi2Cut_ && tmpTrack->numberOfValidHits() >= tkNHitsCut_ &&
+          tmpTrack->pt() > tkPtCut_ && ipsig > tkIPSigCut_) {
+         TrackRef tmpRef(theTrackHandle, std::distance(theTrackCollection->begin(), iTk));
+         theTrackRefs.push_back(std::move(tmpRef));
+         TransientTrack tmpTransient(*tmpRef, theMagneticField);
+         theTransTracks.push_back(std::move(tmpTransient));
       }
    }
    // good tracks have now been selected for vertexing
 
-   // loop over the tracks and vertex good charged track pairs
-   for (unsigned int trdx1 = 0; trdx1 < theGoodTracks.size(); ++trdx1) {
-   for (unsigned int trdx2 = trdx1 + 1; trdx2 < theGoodTracks.size(); ++trdx2) {
+   // loop over tracks and vertex good charged track pairs
+   for (unsigned int trdx1 = 0; trdx1 < theTrackRefs.size(); ++trdx1) {
+   for (unsigned int trdx2 = trdx1 + 1; trdx2 < theTrackRefs.size(); ++trdx2) {
 
-      TrackRef negativeTrackRef;
       TrackRef positiveTrackRef;
-      TrackRef temp1(trackHandle, theGoodTracks[trdx1]);
-      TrackRef temp2(trackHandle, theGoodTracks[trdx2]);
-       
-      // if the tracks are oppositely charged load them into the appropriate containers
-      if (temp1->charge() < 0. && temp2->charge() > 0.) {
-         negativeTrackRef = temp1;
-         positiveTrackRef = temp2;
-      } else if (temp1->charge() > 0. && temp2->charge() < 0.) {
-         negativeTrackRef = temp2;
-         positiveTrackRef = temp1;
+      TrackRef negativeTrackRef;
+      TransientTrack* posTransTkPtr = nullptr;
+      TransientTrack* negTransTkPtr = nullptr;
+
+      if (theTrackRefs[trdx1]->charge() < 0. && theTrackRefs[trdx2]->charge() > 0.) {
+         negativeTrackRef = theTrackRefs[trdx1];
+         positiveTrackRef = theTrackRefs[trdx2];
+         negTransTkPtr = &theTransTracks[trdx1];
+         posTransTkPtr = &theTransTracks[trdx2];
+      } else if (theTrackRefs[trdx1]->charge() > 0. && theTrackRefs[trdx2]->charge() < 0.) {
+         negativeTrackRef = theTrackRefs[trdx2];
+         positiveTrackRef = theTrackRefs[trdx1];
+         negTransTkPtr = &theTransTracks[trdx2];
+         posTransTkPtr = &theTransTracks[trdx1];
       } else {
-         continue; // try the next pair
+         continue;
       }
 
-      TransientTrack negTransTk(*negativeTrackRef, &(*bFieldHandle), globTkGeomHandle);
-      TransientTrack posTransTk(*positiveTrackRef, &(*bFieldHandle), globTkGeomHandle);
-     
-      // calculate the DCA and POCA for the track pair
-      if (!negTransTk.impactPointTSCP().isValid() || !posTransTk.impactPointTSCP().isValid()) continue;
-      FreeTrajectoryState const & negState = negTransTk.impactPointTSCP().theState();
-      FreeTrajectoryState const & posState = posTransTk.impactPointTSCP().theState();
+      // measure distance between tracks at their closest approach
+      if (!posTransTkPtr->impactPointTSCP().isValid() || !negTransTkPtr->impactPointTSCP().isValid()) continue;
+      FreeTrajectoryState const & posState = posTransTkPtr->impactPointTSCP().theState();
+      FreeTrajectoryState const & negState = negTransTkPtr->impactPointTSCP().theState();
       ClosestApproachInRPhi cApp;
       cApp.calculate(posState, negState);
       if (!cApp.status()) continue;
-      float dca = fabs(cApp.distance());
+      double dca = fabs(cApp.distance());
       if (dca > tkDCACut_) continue;
+      // the POCA should at least be in the sensitive volume
       GlobalPoint cxPt = cApp.crossingPoint();
-      if (sqrt(cxPt.x()*cxPt.x() + cxPt.y()*cxPt.y()) > 120. || std::abs(cxPt.z()) > 300.) continue;
+      if (sqrt(cxPt.x()*cxPt.x() + cxPt.y()*cxPt.y()) > 120. || fabs(cxPt.z()) > 300.) continue;
+      // the tracks should at least point in the same quadrant
+      std::pair<GlobalTrajectoryParameters, GlobalTrajectoryParameters> gtp = cApp.trajectoryParameters();
+      if ((gtp.first.momentum()).dot(gtp.second.momentum()) < 0) continue;
 
-      // fill the vector of TransientTracks to give to the vertexers
+      // Fill the vector of TransientTracks to send to KVF
       std::vector<TransientTrack> transTracks;
       transTracks.reserve(2);
-      transTracks.push_back(negTransTk);
-      transTracks.push_back(posTransTk);
+      transTracks.push_back(*posTransTkPtr);
+      transTracks.push_back(*negTransTkPtr);
 
-      // create the vertex fitter object and vertex the tracks
+      // Create the vertex fitter object and vertex the tracks
       TransientVertex theRecoVertex;
-      if (vtxFitter == std::string("KalmanVertexFitter")) {
+      if (vertexFitter_ == std::string("KalmanVertexFitter")) {
          KalmanVertexFitter theKalmanFitter(useRefTrax == 0 ? false : true);
          theRecoVertex = theKalmanFitter.vertex(transTracks);
-      } else if (vtxFitter == std::string("AdaptiveVertexFitter")) {
+      } else if (vertexFitter_ == std::string("AdaptiveVertexFitter")) {
          useRefTrax = false;
          AdaptiveVertexFitter theAdaptiveFitter;
          theRecoVertex = theAdaptiveFitter.vertex(transTracks);
       }
       if (!theRecoVertex.isValid()) continue;
-
-      // create reco::Vertex object for use in creating the Candidate
+     
       reco::Vertex theVtx = theRecoVertex;
       if (theVtx.normalizedChi2() > vtxChi2Cut_) continue;
 
-      // calculate radial displacement of V0 vertex from beamspot (z uncertainty is large)
-      typedef ROOT::Math::SMatrix<double, 3, 3, ROOT::Math::MatRepSym<double, 3> > SMatrixSym3D;
-      typedef ROOT::Math::SVector<double, 3> SVector3;
-      SMatrixSym3D totalCov = beamspotHandle->rotatedCovariance3D() + theVtx.covariance();
-      SVector3 distanceVector(theVtx.x()-beamspotPos.x(), theVtx.y()-beamspotPos.y(), 0.);
+      GlobalPoint vtxPos(theVtx.x(), theVtx.y(), theVtx.z());
+      SMatrixSym3D totalCov = theBeamSpot->rotatedCovariance3D() + theVtx.covariance();
+      SVector3 distanceVector(vtxPos.x() - beamSpotPos.x(), vtxPos.y() - beamSpotPos.y(), 0.);
       double rVtxMag = ROOT::Math::Mag(distanceVector);
-      if (rVtxMag < vtxRCut_) continue;
       double sigmaRvtxMag = sqrt(ROOT::Math::Similarity(totalCov, distanceVector)) / rVtxMag;
-      if (rVtxMag / sigmaRvtxMag < vtxRSigCut_) continue;
+      if (rVtxMag/sigmaRvtxMag < vtxDecayRSigCut_) continue;
 
-      // see if either daughter track has hits "inside" the vertex
-      // (the methods innerOk() and innerPosition() require TrackExtra which is only available in the RECO data tier - 
-      //  setting innerHitPosCut to -1 avoids this problem and allows to run on AOD)
       if (innerHitPosCut_ > 0. && positiveTrackRef->innerOk()) {
          reco::Vertex::Point posTkHitPos = positiveTrackRef->innerPosition();
-         double posTkHitPosD2 =
-            (posTkHitPos.x()-beamspotPos.x())*(posTkHitPos.x()-beamspotPos.x()) +
-            (posTkHitPos.y()-beamspotPos.y())*(posTkHitPos.y()-beamspotPos.y());
+         double posTkHitPosD2 =  (posTkHitPos.x()-beamSpotPos.x())*(posTkHitPos.x()-beamSpotPos.x()) +
+            (posTkHitPos.y()-beamSpotPos.y())*(posTkHitPos.y()-beamSpotPos.y());
          if (sqrt(posTkHitPosD2) < (rVtxMag - sigmaRvtxMag*innerHitPosCut_)) continue;
       }
       if (innerHitPosCut_ > 0. && negativeTrackRef->innerOk()) {
          reco::Vertex::Point negTkHitPos = negativeTrackRef->innerPosition();
-         double negTkHitPosD2 =
-            (negTkHitPos.x()-beamspotPos.x())*(negTkHitPos.x()-beamspotPos.x()) +
-            (negTkHitPos.y()-beamspotPos.y())*(negTkHitPos.y()-beamspotPos.y());
+         double negTkHitPosD2 = (negTkHitPos.x()-beamSpotPos.x())*(negTkHitPos.x()-beamSpotPos.x()) +
+            (negTkHitPos.y()-beamSpotPos.y())*(negTkHitPos.y()-beamSpotPos.y());
          if (sqrt(negTkHitPosD2) < (rVtxMag - sigmaRvtxMag*innerHitPosCut_)) continue;
       }
-
-      // create and fill vector of refitted TransientTracks (iff they've been created by the KVF)
+      
+      std::auto_ptr<TrajectoryStateClosestToPoint> trajPlus;
+      std::auto_ptr<TrajectoryStateClosestToPoint> trajMins;
       std::vector<TransientTrack> refittedTrax;
       if (theRecoVertex.hasRefittedTracks()) {
          refittedTrax = theRecoVertex.refittedTracks();
       }
 
-      // make TrajectoryStates to extract momentum of daughter tracks at vertex
-      std::auto_ptr<TrajectoryStateClosestToPoint> trajPlus;
-      std::auto_ptr<TrajectoryStateClosestToPoint> trajMins;
-      const GlobalPoint vtxPos(theVtx.x(), theVtx.y(), theVtx.z());
-
       if (useRefTrax && refittedTrax.size() > 1) {
-         // TransientTrack objects to hold the positive and negative refitted tracks
          TransientTrack* thePositiveRefTrack = 0;
          TransientTrack* theNegativeRefTrack = 0;
          for (std::vector<TransientTrack>::iterator iTrack = refittedTrax.begin(); iTrack != refittedTrax.end(); ++iTrack) {
@@ -246,13 +213,14 @@ void V0Fitter::fitAll(const edm::Event& iEvent, const edm::EventSetup& iSetup,
                theNegativeRefTrack = &*iTrack;
             }
          }
-        if (thePositiveRefTrack == 0 || theNegativeRefTrack == 0) continue;
-        trajPlus.reset(new TrajectoryStateClosestToPoint(thePositiveRefTrack->trajectoryStateClosestToPoint(vtxPos)));
-        trajMins.reset(new TrajectoryStateClosestToPoint(theNegativeRefTrack->trajectoryStateClosestToPoint(vtxPos)));
+         if (thePositiveRefTrack == 0 || theNegativeRefTrack == 0) continue;
+         trajPlus.reset(new TrajectoryStateClosestToPoint(thePositiveRefTrack->trajectoryStateClosestToPoint(vtxPos)));
+         trajMins.reset(new TrajectoryStateClosestToPoint(theNegativeRefTrack->trajectoryStateClosestToPoint(vtxPos)));
       } else {
-         trajPlus.reset(new TrajectoryStateClosestToPoint(posTransTk.trajectoryStateClosestToPoint(vtxPos)));
-         trajMins.reset(new TrajectoryStateClosestToPoint(negTransTk.trajectoryStateClosestToPoint(vtxPos)));
+         trajPlus.reset(new TrajectoryStateClosestToPoint(posTransTkPtr->trajectoryStateClosestToPoint(vtxPos)));
+         trajMins.reset(new TrajectoryStateClosestToPoint(negTransTkPtr->trajectoryStateClosestToPoint(vtxPos)));
       }
+
       if (trajPlus.get() == 0 || trajMins.get() == 0 || !trajPlus->isValid() || !trajMins->isValid()) continue;
 
       GlobalVector positiveP(trajPlus->momentum());
@@ -260,24 +228,24 @@ void V0Fitter::fitAll(const edm::Event& iEvent, const edm::EventSetup& iSetup,
       GlobalVector totalP(positiveP + negativeP);
 
       // calculate the pointing angle
-      double posx = theVtx.x() - beamspotHandle->position().x();
-      double posy = theVtx.y() - beamspotHandle->position().y();
+      double posx = theVtx.x() - beamSpotPos.x();
+      double posy = theVtx.y() - beamSpotPos.y();
       double momx = totalP.x();
       double momy = totalP.y();
       double pointangle = (posx*momx+posy*momy)/(sqrt(posx*posx+posy*posy)*sqrt(momx*momx+momy*momy));
       if (pointangle < v0CosThetaCut_) continue;
 
-      // calculate total energy of V0 3 ways: assume a KShort, Lambda, or LambdaBar
+      // calculate total energy of V0 3 ways: assume it's a kShort, a Lambda, or a LambdaBar.
       double piPlusE = sqrt(positiveP.mag2() + piMassSquared);
       double piMinusE = sqrt(negativeP.mag2() + piMassSquared);
       double protonE = sqrt(positiveP.mag2() + protonMassSquared);
       double antiProtonE = sqrt(negativeP.mag2() + protonMassSquared);
-      double kshortETot = piPlusE + piMinusE;
+      double kShortETot = piPlusE + piMinusE;
       double lambdaEtot = protonE + piMinusE;
       double lambdaBarEtot = antiProtonE + piPlusE;
 
-      // create momentum 4-vectors for the 3 candidate types
-      const Particle::LorentzVector kshortP4(totalP.x(), totalP.y(), totalP.z(), kshortETot);
+      // Create momentum 4-vectors for the 3 candidate types
+      const Particle::LorentzVector kShortP4(totalP.x(), totalP.y(), totalP.z(), kShortETot);
       const Particle::LorentzVector lambdaP4(totalP.x(), totalP.y(), totalP.z(), lambdaEtot);
       const Particle::LorentzVector lambdaBarP4(totalP.x(), totalP.y(), totalP.z(), lambdaBarEtot);
 
@@ -286,13 +254,13 @@ void V0Fitter::fitAll(const edm::Event& iEvent, const edm::EventSetup& iSetup,
       double vtxChi2(theVtx.chi2());
       double vtxNdof(theVtx.ndof());
 
-      // create the VertexCompositeCandidate object that will be stored in the Event
-      VertexCompositeCandidate* theKShort = nullptr;
+      // Create the VertexCompositeCandidate object that will be stored in the Event
+      VertexCompositeCandidate* theKshort = nullptr;
       VertexCompositeCandidate* theLambda = nullptr;
       VertexCompositeCandidate* theLambdaBar = nullptr;
 
       if (doKShorts_) {
-         theKShort = new VertexCompositeCandidate(0, kshortP4, vtx, vtxCov, vtxChi2, vtxNdof);
+         theKshort = new VertexCompositeCandidate(0, kShortP4, vtx, vtxCov, vtxChi2, vtxNdof);
       }
       if (doLambdas_) {
          if (positiveP.mag2() > negativeP.mag2()) {
@@ -302,7 +270,7 @@ void V0Fitter::fitAll(const edm::Event& iEvent, const edm::EventSetup& iSetup,
          }
       }
 
-      // create daughter candidates for the VertexCompositeCandidates
+      // Create daughter candidates for the VertexCompositeCandidates
       RecoChargedCandidate thePiPlusCand(
          1, Particle::LorentzVector(positiveP.x(), positiveP.y(), positiveP.z(), piPlusE), vtx);
       thePiPlusCand.setTrack(positiveTrackRef);
@@ -320,22 +288,22 @@ void V0Fitter::fitAll(const edm::Event& iEvent, const edm::EventSetup& iSetup,
       theAntiProtonCand.setTrack(negativeTrackRef);
 
       AddFourMomenta addp4;
-      // store the daughter Candidates in the VertexCompositeCandidates if they pass mass cuts
+      // Store the daughter Candidates in the VertexCompositeCandidates if they pass mass cuts
       if (doKShorts_) {
-         theKShort->addDaughter(thePiPlusCand);
-         theKShort->addDaughter(thePiMinusCand);
-         theKShort->setPdgId(310);
-         addp4.set(*theKShort);
-         if (theKShort->mass() < kshortMass+kshortMassCut_ && theKShort->mass() > kshortMass-kshortMassCut_) {
-            theKShorts.push_back(std::move(*theKShort));
+         theKshort->addDaughter(thePiPlusCand);
+         theKshort->addDaughter(thePiMinusCand);
+         theKshort->setPdgId(310);
+         addp4.set(*theKshort);
+         if (theKshort->mass() < kShortMass + kShortMassCut_ && theKshort->mass() > kShortMass - kShortMassCut_) {
+            theKshorts.push_back(std::move(*theKshort));
          }
-      }      
+      }
       if (doLambdas_ && theLambda) {
          theLambda->addDaughter(theProtonCand);
          theLambda->addDaughter(thePiMinusCand);
          theLambda->setPdgId(3122);
-         addp4.set(*theLambda);
-         if (theLambda->mass() < lambdaMass+lambdaMassCut_ && theLambda->mass() > lambdaMass-lambdaMassCut_) {
+         addp4.set( *theLambda );
+         if (theLambda->mass() < lambdaMass + lambdaMassCut_ && theLambda->mass() > lambdaMass - lambdaMassCut_) {
             theLambdas.push_back(std::move(*theLambda));
          }
       } else if (doLambdas_ && theLambdaBar) {
@@ -343,18 +311,17 @@ void V0Fitter::fitAll(const edm::Event& iEvent, const edm::EventSetup& iSetup,
          theLambdaBar->addDaughter(thePiPlusCand);
          theLambdaBar->setPdgId(-3122);
          addp4.set(*theLambdaBar);
-         if (theLambdaBar->mass() < lambdaMass+lambdaMassCut_ && theLambdaBar->mass() > lambdaMass-lambdaMassCut_) {
+         if (theLambdaBar->mass() < lambdaMass + lambdaMassCut_ && theLambdaBar->mass() > lambdaMass - lambdaMassCut_) {
             theLambdas.push_back(std::move(*theLambdaBar));
          }
       }
 
-      delete theKShort;
+      delete theKshort;
       delete theLambda;
       delete theLambdaBar;
-      theKShort = theLambda = theLambdaBar = nullptr;
+      theKshort = theLambda = theLambdaBar = nullptr;
 
-   }
-   }
-
+    }
+  }
 }
 

--- a/RecoVertex/V0Producer/src/V0Fitter.cc
+++ b/RecoVertex/V0Producer/src/V0Fitter.cc
@@ -69,7 +69,7 @@ V0Fitter::V0Fitter(const edm::ParameterSet& theParameters, edm::ConsumesCollecto
    // cuts on vertex
    vtxChi2Cut_ = theParameters.getParameter<double>(string("vtxChi2Cut"));
    vtxDecayRSigCut_ = theParameters.getParameter<double>(string("vtxDecayRSigCut"));
-   // cuts post-vertexing
+   // miscellaneous cuts
    tkDCACut_ = theParameters.getParameter<double>(string("tkDCACut"));
    innerHitPosCut_ = theParameters.getParameter<double>(string("innerHitPosCut"));
    v0CosThetaCut_ = theParameters.getParameter<double>(string("v0CosThetaCut"));
@@ -105,7 +105,7 @@ void V0Fitter::fitAll(const edm::Event& iEvent, const edm::EventSetup& iSetup,
    // fill vectors of TransientTracks and TrackRefs after applying preselection cuts
    for (reco::TrackCollection::const_iterator iTk = theTrackCollection->begin(); iTk != theTrackCollection->end(); ++iTk) {
       const reco::Track* tmpTrack = &(*iTk);
-      double ipsig = fabs(tmpTrack->dxy(*theBeamSpot)/tmpTrack->dxyError());
+      double ipsig = std::abs(tmpTrack->dxy(*theBeamSpot)/tmpTrack->dxyError());
       if (tmpTrack->normalizedChi2() < tkChi2Cut_ && tmpTrack->numberOfValidHits() >= tkNHitsCut_ &&
           tmpTrack->pt() > tkPtCut_ && ipsig > tkIPSigCut_) {
          TrackRef tmpRef(theTrackHandle, std::distance(theTrackCollection->begin(), iTk));
@@ -146,11 +146,11 @@ void V0Fitter::fitAll(const edm::Event& iEvent, const edm::EventSetup& iSetup,
       ClosestApproachInRPhi cApp;
       cApp.calculate(posState, negState);
       if (!cApp.status()) continue;
-      double dca = fabs(cApp.distance());
+      float dca = std::abs(cApp.distance());
       if (dca > tkDCACut_) continue;
       // the POCA should at least be in the sensitive volume
       GlobalPoint cxPt = cApp.crossingPoint();
-      if (sqrt(cxPt.x()*cxPt.x() + cxPt.y()*cxPt.y()) > 120. || fabs(cxPt.z()) > 300.) continue;
+      if (sqrt(cxPt.x()*cxPt.x() + cxPt.y()*cxPt.y()) > 120. || std::abs(cxPt.z()) > 300.) continue;
       // the tracks should at least point in the same quadrant
       std::pair<GlobalTrajectoryParameters, GlobalTrajectoryParameters> gtp = cApp.trajectoryParameters();
       if ((gtp.first.momentum()).dot(gtp.second.momentum()) < 0) continue;

--- a/RecoVertex/V0Producer/src/V0Fitter.h
+++ b/RecoVertex/V0Producer/src/V0Fitter.h
@@ -59,11 +59,13 @@ class dso_hidden V0Fitter {
    public:
       V0Fitter(const edm::ParameterSet& theParams, edm::ConsumesCollector && iC);
       // Switching to L. Lista's reco::Candidate infrastructure for V0 storage
-      void fitAll(const edm::Event& iEvent, const edm::EventSetup& iSetup, reco::VertexCompositeCandidateCollection & k, reco::VertexCompositeCandidateCollection & l);
+      void fitAll(const edm::Event& iEvent, const edm::EventSetup& iSetup,
+         reco::VertexCompositeCandidateCollection & k, reco::VertexCompositeCandidateCollection & l);
 
    private:
 
-      bool useRefTrax;
+      bool vertexFitter_;
+      bool useRefTracks_;
       bool doKShorts_;
       bool doLambdas_;
 
@@ -75,17 +77,17 @@ class dso_hidden V0Fitter {
       // cuts on the vertex
       double vtxChi2Cut_;
       double vtxDecayRSigCut_;
-      // cuts post-vertexing
+      // miscellaneous cuts
       double tkDCACut_;
+      double mPiPiCut_;
       double innerHitPosCut_;
       double v0CosThetaCut_;
+      // cuts on the V0 candidate mass
       double kShortMassCut_;
       double lambdaMassCut_;
 
       edm::EDGetTokenT<reco::TrackCollection> token_tracks;
       edm::EDGetTokenT<reco::BeamSpot> token_beamSpot;
-      edm::InputTag vertexFitter_;
-
 };
 
 #endif

--- a/RecoVertex/V0Producer/src/V0Fitter.h
+++ b/RecoVertex/V0Producer/src/V0Fitter.h
@@ -19,102 +19,93 @@
 #ifndef RECOVERTEX__V0_FITTER_H
 #define RECOVERTEX__V0_FITTER_H
 
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Utilities/interface/InputTag.h"
 
-#include "DataFormats/Common/interface/Ref.h"
+#include "FWCore/Framework/interface/Event.h" 
+#include "FWCore/Framework/interface/ESHandle.h" 
+#include "FWCore/Utilities/interface/InputTag.h" 
+ 
+#include "DataFormats/Common/interface/Ref.h" 
+ 
+#include "DataFormats/VertexReco/interface/Vertex.h" 
+#include "DataFormats/TrackReco/interface/Track.h" 
+#include "RecoVertex/VertexPrimitives/interface/TransientVertex.h" 
+#include "TrackingTools/TransientTrack/interface/TransientTrack.h" 
+#include "RecoVertex/KalmanVertexFit/interface/KalmanVertexFitter.h" 
+#include "RecoVertex/AdaptiveVertexFit/interface/AdaptiveVertexFitter.h" 
+ 
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h" 
+#include "MagneticField/VolumeBasedEngine/interface/VolumeBasedMagneticField.h" 
+ 
+#include "DataFormats/Candidate/interface/VertexCompositeCandidate.h" 
+#include "DataFormats/RecoCandidate/interface/RecoChargedCandidate.h" 
+ 
+#include "FWCore/ParameterSet/interface/ParameterSet.h" 
+ 
+#include "Geometry/CommonDetUnit/interface/TrackingGeometry.h" 
+#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h" 
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h" 
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h" 
+#include "Geometry/CommonDetUnit/interface/GeomDet.h" 
+#include "Geometry/TrackerGeometryBuilder/interface/GluedGeomDet.h" 
+#include "FWCore/Framework/interface/ConsumesCollector.h" 
+ 
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h" 
+#include "DataFormats/BeamSpot/interface/BeamSpot.h" 
 
-#include "DataFormats/VertexReco/interface/Vertex.h"
-#include "DataFormats/TrackReco/interface/Track.h"
-#include "RecoVertex/VertexPrimitives/interface/TransientVertex.h"
-#include "TrackingTools/TransientTrack/interface/TransientTrack.h"
-#include "RecoVertex/KalmanVertexFit/interface/KalmanVertexFitter.h"
-#include "RecoVertex/AdaptiveVertexFit/interface/AdaptiveVertexFitter.h"
-
-#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
-#include "MagneticField/VolumeBasedEngine/interface/VolumeBasedMagneticField.h"
-
-#include "DataFormats/Candidate/interface/VertexCompositeCandidate.h"
-#include "DataFormats/RecoCandidate/interface/RecoChargedCandidate.h"
-
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-
-#include "Geometry/CommonDetUnit/interface/TrackingGeometry.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-#include "Geometry/CommonDetUnit/interface/GeomDet.h"
-#include "Geometry/TrackerGeometryBuilder/interface/GluedGeomDet.h"
-#include "FWCore/Framework/interface/ConsumesCollector.h"
-
-#include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
-#include "DataFormats/BeamSpot/interface/BeamSpot.h"
-
-#include <string>
-#include <fstream>
+#include <string> 
+#include <fstream> 
 
 
 class dso_hidden V0Fitter {
- public:
-  V0Fitter(const edm::ParameterSet& theParams,
-	   edm::ConsumesCollector && iC);
-  ~V0Fitter();
 
-  // Switching to L. Lista's reco::Candidate infrastructure for V0 storage
-  void fitAll(const edm::Event& iEvent, const edm::EventSetup& iSetup, 
-              reco::VertexCompositeCandidateCollection & k, 
-              reco::VertexCompositeCandidateCollection & l);
+   public:
 
- private:
+      V0Fitter(const edm::ParameterSet& theParams, edm::ConsumesCollector && iC);
+      // Switching to L. Lista's reco::Candidate infrastructure for V0 storage
+      void fitAll(const edm::Event& iEvent, const edm::EventSetup& iSetup,
+         reco::VertexCompositeCandidateCollection & k, reco::VertexCompositeCandidateCollection & l);
 
-  // Tracker geometry for discerning hit positions
-  const TrackerGeometry* trackerGeom;
+   private:
 
-  const MagneticField* magField;
+      bool useRefTrax;
+      bool doKShorts_;
+      bool doLambdas_;
 
-  bool useRefTrax;
-  //  bool storeRefTrax;
-  bool doKshorts;
-  bool doLambdas;
+      // cuts on the input track collection
+      std::vector<reco::TrackBase::TrackQuality> qualities;
+      double tkChi2Cut_;
+      double tkPtCut_;
+      int tkNhitsCut_;
+      double tkIPSigCut_;
+      // cuts on the V0 vertex
+      double vtxChi2Cut_;
+      double vtxRCut_;
+      double vtxRSigCut_;
+      // miscellaneous cuts after vertexing
+      //double mPiPiCut_;
+      double tkDCACut_;
+      double KShortMassCut_;
+      double LambdaMassCut_;
+      double innerHitPosCut_;
+      double V0costhetaCut_;
 
-  /*bool doPostFitCuts;
-    bool doTkQualCuts;*/
+      edm::EDGetTokenT<reco::TrackCollection> token_tracks;
+      edm::InputTag vtxFitter;
 
-  // Cuts
-  double chi2Cut;
-  double tkChi2Cut;
-  int tkNhitsCut;
-  double rVtxCut;
-  double vtxSigCut;
-  double kShortMassCut;
-  double lambdaMassCut;
-  double impactParameterSigCut;
-  //double mPiPiCut;
-  double tkDCACut;
-  double innerHitPosCut;
+      // Helper method that does the actual fitting using the KalmanVertexFitter
+      //double findV0MassError(const GlobalPoint &vtxPos, const std::vector<reco::TransientTrack> &dauTracks);
+      /*
+      // Stuff for debug file output. 
+      std::ofstream mPiPiMassOut; 
+      inline void initFileOutput() { 
+         mPiPiMassOut.open("mPiPi.txt", std::ios::app); 
+      } 
+      inline void cleanupFileOutput() { 
+         mPiPiMassOut.close(); 
+      } 
+      */
 
-  std::vector<reco::TrackBase::TrackQuality> qualities;
-
-  edm::EDGetTokenT<reco::TrackCollection>	 token_tracks; 
-  edm::EDGetTokenT<reco::BeamSpot> 	 token_beamSpot; 
-  edm::InputTag vtxFitter;
-
-  // Helper method that does the actual fitting using the KalmanVertexFitter
-  double findV0MassError(const GlobalPoint &vtxPos, const std::vector<reco::TransientTrack> &dauTracks);
-
-  // Applies cuts to the VertexCompositeCandidates after they are fitted/created.
-  //void applyPostFitCuts();
-
-  // Stuff for debug file output.
-  std::ofstream mPiPiMassOut;
-
-  inline void initFileOutput() {
-    mPiPiMassOut.open("mPiPi.txt", std::ios::app);
-  }
-  inline void cleanupFileOutput() {
-    mPiPiMassOut.close();
-  }
 };
 
 #endif
+

--- a/RecoVertex/V0Producer/src/V0Fitter.h
+++ b/RecoVertex/V0Producer/src/V0Fitter.h
@@ -92,7 +92,7 @@ class dso_hidden V0Fitter {
   double kShortMassCut;
   double lambdaMassCut;
   double impactParameterSigCut;
-  double mPiPiCut;
+  //double mPiPiCut;
   double tkDCACut;
   double innerHitPosCut;
 

--- a/RecoVertex/V0Producer/src/V0Fitter.h
+++ b/RecoVertex/V0Producer/src/V0Fitter.h
@@ -87,8 +87,6 @@ class dso_hidden V0Fitter {
   int tkNhitsCut;
   double rVtxCut;
   double vtxSigCut;
-  //  double vtxSigCut3D;
-  double collinCut;
   double kShortMassCut;
   double lambdaMassCut;
   double impactParameterSigCut;

--- a/RecoVertex/V0Producer/src/V0Fitter.h
+++ b/RecoVertex/V0Producer/src/V0Fitter.h
@@ -75,35 +75,22 @@ class dso_hidden V0Fitter {
       std::vector<reco::TrackBase::TrackQuality> qualities;
       double tkChi2Cut_;
       double tkPtCut_;
-      int tkNhitsCut_;
+      int tkNHitsCut_;
       double tkIPSigCut_;
       // cuts on the V0 vertex
       double vtxChi2Cut_;
       double vtxRCut_;
       double vtxRSigCut_;
       // miscellaneous cuts after vertexing
-      //double mPiPiCut_;
       double tkDCACut_;
-      double KShortMassCut_;
-      double LambdaMassCut_;
+      double kshortMassCut_;
+      double lambdaMassCut_;
       double innerHitPosCut_;
-      double V0costhetaCut_;
+      double v0CosThetaCut_;
 
       edm::EDGetTokenT<reco::TrackCollection> token_tracks;
+      edm::EDGetTokenT<reco::BeamSpot> token_beamspot;
       edm::InputTag vtxFitter;
-
-      // Helper method that does the actual fitting using the KalmanVertexFitter
-      //double findV0MassError(const GlobalPoint &vtxPos, const std::vector<reco::TransientTrack> &dauTracks);
-      /*
-      // Stuff for debug file output. 
-      std::ofstream mPiPiMassOut; 
-      inline void initFileOutput() { 
-         mPiPiMassOut.open("mPiPi.txt", std::ios::app); 
-      } 
-      inline void cleanupFileOutput() { 
-         mPiPiMassOut.close(); 
-      } 
-      */
 
 };
 

--- a/RecoVertex/V0Producer/src/V0Fitter.h
+++ b/RecoVertex/V0Producer/src/V0Fitter.h
@@ -19,51 +19,47 @@
 #ifndef RECOVERTEX__V0_FITTER_H
 #define RECOVERTEX__V0_FITTER_H
 
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Utilities/interface/InputTag.h"
 
-#include "FWCore/Framework/interface/Event.h" 
-#include "FWCore/Framework/interface/ESHandle.h" 
-#include "FWCore/Utilities/interface/InputTag.h" 
- 
-#include "DataFormats/Common/interface/Ref.h" 
- 
-#include "DataFormats/VertexReco/interface/Vertex.h" 
-#include "DataFormats/TrackReco/interface/Track.h" 
-#include "RecoVertex/VertexPrimitives/interface/TransientVertex.h" 
-#include "TrackingTools/TransientTrack/interface/TransientTrack.h" 
-#include "RecoVertex/KalmanVertexFit/interface/KalmanVertexFitter.h" 
-#include "RecoVertex/AdaptiveVertexFit/interface/AdaptiveVertexFitter.h" 
- 
-#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h" 
-#include "MagneticField/VolumeBasedEngine/interface/VolumeBasedMagneticField.h" 
- 
-#include "DataFormats/Candidate/interface/VertexCompositeCandidate.h" 
-#include "DataFormats/RecoCandidate/interface/RecoChargedCandidate.h" 
- 
-#include "FWCore/ParameterSet/interface/ParameterSet.h" 
- 
-#include "Geometry/CommonDetUnit/interface/TrackingGeometry.h" 
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h" 
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h" 
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h" 
-#include "Geometry/CommonDetUnit/interface/GeomDet.h" 
-#include "Geometry/TrackerGeometryBuilder/interface/GluedGeomDet.h" 
-#include "FWCore/Framework/interface/ConsumesCollector.h" 
- 
-#include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h" 
-#include "DataFormats/BeamSpot/interface/BeamSpot.h" 
+#include "DataFormats/Common/interface/Ref.h"
 
-#include <string> 
-#include <fstream> 
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "RecoVertex/VertexPrimitives/interface/TransientVertex.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrack.h"
+#include "RecoVertex/KalmanVertexFit/interface/KalmanVertexFitter.h"
+#include "RecoVertex/AdaptiveVertexFit/interface/AdaptiveVertexFitter.h"
 
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "MagneticField/VolumeBasedEngine/interface/VolumeBasedMagneticField.h"
+
+#include "DataFormats/Candidate/interface/VertexCompositeCandidate.h"
+#include "DataFormats/RecoCandidate/interface/RecoChargedCandidate.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "Geometry/CommonDetUnit/interface/TrackingGeometry.h"
+#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
+#include "Geometry/TrackerGeometryBuilder/interface/GluedGeomDet.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
+
+#include <string>
+#include <fstream>
 
 class dso_hidden V0Fitter {
 
    public:
-
       V0Fitter(const edm::ParameterSet& theParams, edm::ConsumesCollector && iC);
       // Switching to L. Lista's reco::Candidate infrastructure for V0 storage
-      void fitAll(const edm::Event& iEvent, const edm::EventSetup& iSetup,
-         reco::VertexCompositeCandidateCollection & k, reco::VertexCompositeCandidateCollection & l);
+      void fitAll(const edm::Event& iEvent, const edm::EventSetup& iSetup, reco::VertexCompositeCandidateCollection & k, reco::VertexCompositeCandidateCollection & l);
 
    private:
 
@@ -71,26 +67,24 @@ class dso_hidden V0Fitter {
       bool doKShorts_;
       bool doLambdas_;
 
-      // cuts on the input track collection
-      std::vector<reco::TrackBase::TrackQuality> qualities;
+      // cuts on initial track selection
       double tkChi2Cut_;
-      double tkPtCut_;
       int tkNHitsCut_;
+      double tkPtCut_;
       double tkIPSigCut_;
-      // cuts on the V0 vertex
+      // cuts on the vertex
       double vtxChi2Cut_;
-      double vtxRCut_;
-      double vtxRSigCut_;
-      // miscellaneous cuts after vertexing
+      double vtxDecayRSigCut_;
+      // cuts post-vertexing
       double tkDCACut_;
-      double kshortMassCut_;
-      double lambdaMassCut_;
       double innerHitPosCut_;
       double v0CosThetaCut_;
+      double kShortMassCut_;
+      double lambdaMassCut_;
 
       edm::EDGetTokenT<reco::TrackCollection> token_tracks;
-      edm::EDGetTokenT<reco::BeamSpot> token_beamspot;
-      edm::InputTag vtxFitter;
+      edm::EDGetTokenT<reco::BeamSpot> token_beamSpot;
+      edm::InputTag vertexFitter_;
 
 };
 


### PR DESCRIPTION
1) added new cuts and modified old  default values to purify the V0 collection in presence of PU (optimized for PU25). for slides from a tracking POG meeting see:
https://indico.cern.ch/event/337839/
https://indico.cern.ch/event/337839/contribution/3/material/slides/0.pdf
2) deleted code that was no longer relevant to the module
3) rearranged code to apply selection cuts sooner to help speed the execution of the module
