### PR TITLE
70X mods to fix SiStrip Tracker PreMixing

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1437,6 +1437,7 @@ class ConfigBuilder(object):
 	    self.scheduleSequence(sequence.split('.')[-1],'digi2raw_step')
 	    if "DIGIPREMIX" in self.stepMap.keys():
 		    self.executeAndRemember("process.esDigiToRaw.Label = cms.string('mix')")  ##terrible hack - bypass zero suppression
+		    self.executeAndRemember("process.SiStripDigiToRaw.FedReadoutMode = cms.string('PREMIX_RAW')")  ##special readout mode for StripTracker
 
             return
 

--- a/DataFormats/SiStripCommon/interface/ConstantsForHardwareSystems.h
+++ b/DataFormats/SiStripCommon/interface/ConstantsForHardwareSystems.h
@@ -107,7 +107,7 @@ namespace sistrip {
   static const char fedProcRaw_[]       = "FedProcessedRaw";
   static const char fedZeroSuppr_[]     = "FedZeroSuppressed";
   static const char fedZeroSupprLite_[] = "FedZeroSupprressedLite";
-  static const char fedPreMixRaw_[] = "FedPreMixRaw";
+  static const char fedPreMixRaw_[]     = "FedPreMixRaw";
   
   // -------------------- Enumerators --------------------
   

--- a/DataFormats/SiStripCommon/interface/ConstantsForHardwareSystems.h
+++ b/DataFormats/SiStripCommon/interface/ConstantsForHardwareSystems.h
@@ -107,6 +107,7 @@ namespace sistrip {
   static const char fedProcRaw_[]       = "FedProcessedRaw";
   static const char fedZeroSuppr_[]     = "FedZeroSuppressed";
   static const char fedZeroSupprLite_[] = "FedZeroSupprressedLite";
+  static const char fedPreMixRaw_[] = "FedPreMixRaw";
   
   // -------------------- Enumerators --------------------
   
@@ -123,7 +124,8 @@ namespace sistrip {
 			FED_VIRGIN_RAW = 2, 
 			FED_PROC_RAW = 6, 
 			FED_ZERO_SUPPR = 10,
-			FED_ZERO_SUPPR_LITE = 12
+			FED_ZERO_SUPPR_LITE = 12,
+			FED_PREMIX_RAW = 15
   };
 
   enum FedReadoutPath { UNKNOWN_FED_READOUT_PATH = sistrip::unknown_,

--- a/EventFilter/SiStripRawToDigi/interface/SiStripFEDBuffer.h
+++ b/EventFilter/SiStripRawToDigi/interface/SiStripFEDBuffer.h
@@ -248,7 +248,7 @@ namespace sistrip {
       //CAMM - to modify more ?
       uint16_t length = channel.length();
       if (length & 0xF000) throwBadChannelLength(length);
-      FEDZSChannelUnpacker result(channel.data(),channel.offset()+2,length-2,2);
+      FEDZSChannelUnpacker result(channel.data(),channel.offset()+7,length-7,2);
       return result;
     }
   

--- a/EventFilter/SiStripRawToDigi/interface/SiStripFEDBuffer.h
+++ b/EventFilter/SiStripRawToDigi/interface/SiStripFEDBuffer.h
@@ -85,21 +85,24 @@ namespace sistrip {
     public:
       static FEDZSChannelUnpacker zeroSuppressedModeUnpacker(const FEDChannel& channel);
       static FEDZSChannelUnpacker zeroSuppressedLiteModeUnpacker(const FEDChannel& channel);
+      static FEDZSChannelUnpacker preMixRawModeUnpacker(const FEDChannel& channel);
       FEDZSChannelUnpacker();
       uint8_t sampleNumber() const;
       uint8_t adc() const;
+      uint16_t adcPreMix() const;
       bool hasData() const;
       FEDZSChannelUnpacker& operator ++ ();
       FEDZSChannelUnpacker& operator ++ (int);
     private:
-      //pointer to begining of FED or FE data, offset of start of channel payload in data and length of channel payload
-      FEDZSChannelUnpacker(const uint8_t* payload, const size_t channelPayloadOffset, const int16_t channelPayloadLength);
+      //pointer to beginning of FED or FE data, offset of start of channel payload in data and length of channel payload
+      FEDZSChannelUnpacker(const uint8_t* payload, const size_t channelPayloadOffset, const int16_t channelPayloadLength, const size_t offsetIncrement=1);
       void readNewClusterInfo();
       static void throwBadChannelLength(const uint16_t length);
       void throwBadClusterLength();
       static void throwUnorderedData(const uint8_t currentStrip, const uint8_t firstStripOfNewCluster);
       const uint8_t* data_;
       size_t currentOffset_;
+      size_t offsetIncrement_;
       uint8_t currentStrip_;
       uint8_t valuesLeftInCluster_;
       uint16_t channelPayloadOffset_;
@@ -206,14 +209,16 @@ namespace sistrip {
   
   inline FEDZSChannelUnpacker::FEDZSChannelUnpacker()
     : data_(NULL),
+      offsetIncrement_(1),
       valuesLeftInCluster_(0),
       channelPayloadOffset_(0),
       channelPayloadLength_(0)
     { }
 
-  inline FEDZSChannelUnpacker::FEDZSChannelUnpacker(const uint8_t* payload, const size_t channelPayloadOffset, const int16_t channelPayloadLength)
+  inline FEDZSChannelUnpacker::FEDZSChannelUnpacker(const uint8_t* payload, const size_t channelPayloadOffset, const int16_t channelPayloadLength, const size_t offsetIncrement)
     : data_(payload),
       currentOffset_(channelPayloadOffset),
+      offsetIncrement_(offsetIncrement),
       currentStrip_(0),
       valuesLeftInCluster_(0),
       channelPayloadOffset_(channelPayloadOffset),
@@ -238,6 +243,15 @@ namespace sistrip {
       return result;
     }
   
+  inline FEDZSChannelUnpacker FEDZSChannelUnpacker::preMixRawModeUnpacker(const FEDChannel& channel)
+    {
+      //CAMM - to modify more ?
+      uint16_t length = channel.length();
+      if (length & 0xF000) throwBadChannelLength(length);
+      FEDZSChannelUnpacker result(channel.data(),channel.offset()+2,length-2,2);
+      return result;
+    }
+  
   inline uint8_t FEDZSChannelUnpacker::sampleNumber() const
     {
       return currentStrip_;
@@ -246,6 +260,11 @@ namespace sistrip {
   inline uint8_t FEDZSChannelUnpacker::adc() const
     {
       return data_[currentOffset_^7];
+    }
+  
+  inline uint16_t FEDZSChannelUnpacker::adcPreMix() const
+    {
+      return ( data_[currentOffset_^7] + ((data_[(currentOffset_+1)^7]&0x03)<<8) );
     }
   
   inline bool FEDZSChannelUnpacker::hasData() const
@@ -257,10 +276,10 @@ namespace sistrip {
     {
       if (valuesLeftInCluster_) {
 	currentStrip_++;
-	currentOffset_++;
+	currentOffset_ += offsetIncrement_;
         valuesLeftInCluster_--;
       } else {
-	currentOffset_++;
+	currentOffset_ += offsetIncrement_;
 	if (hasData()) {
           const uint8_t oldStrip = currentStrip_;
           readNewClusterInfo();

--- a/EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferComponents.h
+++ b/EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferComponents.h
@@ -44,7 +44,7 @@ namespace sistrip {
                         READOUT_MODE_ZERO_SUPPRESSED=0xA,
                         READOUT_MODE_ZERO_SUPPRESSED_LITE=0xC,
                         READOUT_MODE_SPY=0xE,
-			READOUT_MODE_PREMIX_RAW=0xF//0x8?
+			READOUT_MODE_PREMIX_RAW=0xF //0x8?
                       };
 
   static const uint8_t PACKET_CODE_SCOPE = 0xE5;

--- a/EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferComponents.h
+++ b/EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferComponents.h
@@ -43,7 +43,8 @@ namespace sistrip {
                         READOUT_MODE_PROC_RAW=0x6,
                         READOUT_MODE_ZERO_SUPPRESSED=0xA,
                         READOUT_MODE_ZERO_SUPPRESSED_LITE=0xC,
-                        READOUT_MODE_SPY=0xE
+                        READOUT_MODE_SPY=0xE,
+			READOUT_MODE_PREMIX_RAW=0xF//0x8?
                       };
 
   static const uint8_t PACKET_CODE_SCOPE = 0xE5;

--- a/EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferGenerator.h
+++ b/EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferGenerator.h
@@ -33,6 +33,7 @@ namespace sistrip {
         uint16_t getSample(const uint16_t sampleNumber) const;
         //get the 8 bit value to be used for ZS modes, converting it as the FED does if specified in constructor
         uint8_t get8BitSample(const uint16_t sampleNumber) const;
+        uint16_t get10BitSample(const uint16_t sampleNumber) const;
         void setSample(const uint16_t sampleNumber, const uint16_t adcValue);
         //setting value directly is equivalent to get and set Sample but without length check
         uint16_t& operator [] (const size_t sampleNumber);
@@ -241,6 +242,18 @@ namespace sistrip {
       if (sample < 0xFE) return sample;
       else if (sample == 0x3FF) return 0xFF;
       else return 0xFE;
+    }
+  }
+   
+  inline uint16_t FEDStripData::ChannelData::get10BitSample(const uint16_t sampleNumber) const
+  {
+    if (dataIs8Bit_) {
+      return (0xFF & getSample(sampleNumber));
+    }
+    else {
+      const uint16_t sample = getSample(sampleNumber);
+      if (sample < 0x3FF) return sample;
+      else return 0x3FF;
     }
   }
   

--- a/EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferGenerator.h
+++ b/EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferGenerator.h
@@ -93,8 +93,10 @@ namespace sistrip {
       //fill the vector with channel data for zero suppressed modes
       void fillZeroSuppressedChannelBuffer(std::vector<uint8_t>* channelBuffer, const FEDStripData::ChannelData& data, const bool channelEnabled) const;
       void fillZeroSuppressedLiteChannelBuffer(std::vector<uint8_t>* channelBuffer, const FEDStripData::ChannelData& data, const bool channelEnabled) const;
-      //add the ZS cluster data for the channel to the end of the vector
+       void fillPreMixRawChannelBuffer(std::vector<uint8_t>* channelBuffer, const FEDStripData::ChannelData& data, const bool channelEnabled) const;
+     //add the ZS cluster data for the channel to the end of the vector
       void fillClusterData(std::vector<uint8_t>* channelBuffer, const FEDStripData::ChannelData& data) const;
+      void fillClusterDataPreMixMode(std::vector<uint8_t>* channelBuffer, const FEDStripData::ChannelData& data) const;
       std::vector<bool> feUnitsEnabled_;
       std::vector<bool> channelsEnabled_;
     };

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRaw.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRaw.cc
@@ -80,6 +80,9 @@ namespace sistrip {
         
         auto conns = cabling->fedConnections(*ifed);
         
+	//for special mode premix raw, data is zero-suppressed but not converted to 8 bit
+	//zeroSuppressed here means converted to 8 bit...
+	if (mode_ == READOUT_MODE_PREMIX_RAW) zeroSuppressed=false;
         FEDStripData fedData(zeroSuppressed);
         
 	for (auto iconn = conns.begin() ; iconn != conns.end(); iconn++ ) {

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRawModule.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRawModule.cc
@@ -34,6 +34,7 @@ namespace sistrip {
 	<< "[sistrip::DigiToRawModule::DigiToRawModule]"
 	<< " Constructing object...";
     }  
+
     
     switch(mode_) {
     case READOUT_MODE_ZERO_SUPPRESSED_LITE: rawdigi_ = false; break;

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRawModule.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRawModule.cc
@@ -38,6 +38,7 @@ namespace sistrip {
     switch(mode_) {
     case READOUT_MODE_ZERO_SUPPRESSED_LITE: rawdigi_ = false; break;
     case READOUT_MODE_ZERO_SUPPRESSED:      rawdigi_ = false; break;
+    case READOUT_MODE_PREMIX_RAW:      rawdigi_ = false; break; 
     case READOUT_MODE_VIRGIN_RAW:      rawdigi_ = true; break;
     case READOUT_MODE_PROC_RAW:        rawdigi_ = true; break;
     case READOUT_MODE_SCOPE:           rawdigi_ = true; break;

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiUnpacker.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiUnpacker.cc
@@ -272,7 +272,7 @@ namespace sistrip {
 	    
 	    /// unpack -> add check to make sure strip < nstrips && strip > last strip......
             
-	    while (unpacker.hasData()) {zs_work_digis_.push_back(SiStripDigi(unpacker.sampleNumber()+ipair*256,unpacker.adc()));unpacker++;}
+	    while (unpacker.hasData()) {zs_work_digis_.push_back(SiStripDigi(unpacker.sampleNumber()+ipair*256,unpacker.adc())); unpacker++;}
           } catch (const cms::Exception& e) {
             if ( edm::isDebugEnabled() ) {
               edm::LogWarning(sistrip::mlRawToDigi_)
@@ -348,6 +348,7 @@ namespace sistrip {
 	  Registry regItem(key, 0, zs_work_digis_.size(), 0);
 	
 	  try {
+
             /// create unpacker
 	    sistrip::FEDZSChannelUnpacker unpacker = sistrip::FEDZSChannelUnpacker::preMixRawModeUnpacker(buffer->channel(iconn->fedCh()));
 	    

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiUnpacker.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiUnpacker.cc
@@ -343,6 +343,37 @@ namespace sistrip {
 
 	} 
      
+	else if (mode == sistrip::READOUT_MODE_PREMIX_RAW ) { 
+
+	  Registry regItem(key, 0, zs_work_digis_.size(), 0);
+	
+	  try {
+            /// create unpacker
+	    sistrip::FEDZSChannelUnpacker unpacker = sistrip::FEDZSChannelUnpacker::preMixRawModeUnpacker(buffer->channel(iconn->fedCh()));
+	    
+	    /// unpack -> add check to make sure strip < nstrips && strip > last strip......
+	    while (unpacker.hasData()) {zs_work_digis_.push_back(SiStripDigi(unpacker.sampleNumber()+ipair*256,unpacker.adcPreMix()));unpacker++;}
+	  } catch (const cms::Exception& e) {
+            if ( edm::isDebugEnabled() ) {
+              edm::LogWarning(sistrip::mlRawToDigi_)
+                << "[sistrip::RawToDigiUnpacker::" << __func__ << "]"
+                << " Clusters are not ordered for FED "
+                << *ifed << " channel " << iconn->fedCh()
+                << ": " << e.what();
+            }
+            detids.push_back(iconn->detId()); //@@ Possible multiple entries (ok for Giovanni)
+            continue;
+          }  
+
+	  regItem.length = zs_work_digis_.size() - regItem.index;
+	  if (regItem.length > 0) {
+	    regItem.first = zs_work_digis_[regItem.index].strip();
+	    zs_work_registry_.push_back(regItem);
+	  }
+          
+
+	} 
+     
 	else if ( mode == sistrip::READOUT_MODE_VIRGIN_RAW ) {
 
 	  std::vector<uint16_t> samples; 

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiUnpacker.h
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiUnpacker.h
@@ -172,7 +172,7 @@ sistrip::FedReadoutMode sistrip::RawToDigiUnpacker::fedReadoutMode( const uint16
   else if ( ((register_value>>1)&0x7) == 0x3 ) { return sistrip::FED_PROC_RAW; }
   else if ( ((register_value>>1)&0x7) == 0x5 ) { return sistrip::FED_ZERO_SUPPR; }
   else if ( ((register_value>>1)&0x7) == 0x6 ) { return sistrip::FED_ZERO_SUPPR_LITE; }
-  else if ( ((register_value>>1)&0x7) == 0x7 ) { return sistrip::FED_PREMIX_RAW; }
+  else if ( ((register_value>>1)&0x7) == 0x7 ) { return sistrip::FED_PREMIX_RAW; } //new mode
   else { return sistrip::UNKNOWN_FED_READOUT_MODE; }
 }
 

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiUnpacker.h
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiUnpacker.h
@@ -172,6 +172,7 @@ sistrip::FedReadoutMode sistrip::RawToDigiUnpacker::fedReadoutMode( const uint16
   else if ( ((register_value>>1)&0x7) == 0x3 ) { return sistrip::FED_PROC_RAW; }
   else if ( ((register_value>>1)&0x7) == 0x5 ) { return sistrip::FED_ZERO_SUPPR; }
   else if ( ((register_value>>1)&0x7) == 0x6 ) { return sistrip::FED_ZERO_SUPPR_LITE; }
+  else if ( ((register_value>>1)&0x7) == 0x7 ) { return sistrip::FED_PREMIX_RAW; }
   else { return sistrip::UNKNOWN_FED_READOUT_MODE; }
 }
 

--- a/EventFilter/SiStripRawToDigi/src/SiStripFEDBuffer.cc
+++ b/EventFilter/SiStripRawToDigi/src/SiStripFEDBuffer.cc
@@ -73,15 +73,16 @@ namespace sistrip {
     //set min length to 2 for ZSLite, 7 for ZS and 3 for raw
     uint16_t minLength;
     switch (readoutMode()) {
-      case READOUT_MODE_ZERO_SUPPRESSED:
-        minLength = 7;
-        break;
-      case READOUT_MODE_ZERO_SUPPRESSED_LITE:
-        minLength = 2;
-        break;
-      default:
-        minLength = 3;
-        break;
+    case READOUT_MODE_ZERO_SUPPRESSED:
+      minLength = 7;
+      break;
+    case READOUT_MODE_ZERO_SUPPRESSED_LITE:
+    case READOUT_MODE_PREMIX_RAW:
+      minLength = 2;
+      break;
+    default:
+      minLength = 3;
+      break;
     }
     size_t offsetBeginningOfChannel = 0;
     for (size_t i = 0; i < FEDCH_PER_FED; i++) {
@@ -394,6 +395,7 @@ namespace sistrip {
       return PACKET_CODE_ZERO_SUPPRESSED;
       break;
     case READOUT_MODE_ZERO_SUPPRESSED_LITE:
+    case READOUT_MODE_PREMIX_RAW:
     case READOUT_MODE_SPY:
     case READOUT_MODE_INVALID:
     default:

--- a/EventFilter/SiStripRawToDigi/src/SiStripFEDBufferComponents.cc
+++ b/EventFilter/SiStripRawToDigi/src/SiStripFEDBufferComponents.cc
@@ -151,6 +151,9 @@ namespace sistrip {
     case READOUT_MODE_SPY:
       os << "Spy channel";
       break;
+    case READOUT_MODE_PREMIX_RAW:
+      os << "PreMix raw";
+      break;
     case READOUT_MODE_INVALID:
       os << "Invalid";
       break;
@@ -363,6 +366,11 @@ namespace sistrip {
          (readoutModeString == "ZERO_SUPPRESSED_LITE") ||
          (readoutModeString == "Zero suppressed lite") ) {
       return READOUT_MODE_ZERO_SUPPRESSED_LITE;
+    }
+    if ( (readoutModeString == "READOUT_MODE_PREMIX_RAW") ||
+         (readoutModeString == "PREMIX_RAW") ||
+         (readoutModeString == "PreMix Raw") ) {
+      return READOUT_MODE_PREMIX_RAW;
     }
     if ( (readoutModeString == "READOUT_MODE_SPY") ||
          (readoutModeString == "SPY") ||
@@ -650,6 +658,8 @@ namespace sistrip {
     const uint8_t eventTypeNibble = trackerEventTypeNibble();
     //if it is scope mode then return as is (it cannot be fake data)
     if (eventTypeNibble == READOUT_MODE_SCOPE) return FEDReadoutMode(eventTypeNibble);
+    //if it is premix then return as is: stripping last bit would make it spy data !
+    if (eventTypeNibble == READOUT_MODE_PREMIX_RAW) return FEDReadoutMode(eventTypeNibble);
     //if not then ignore the last bit which indicates if it is real or fake
     else {
       const uint8_t mode = (eventTypeNibble & 0xE);
@@ -734,6 +744,11 @@ namespace sistrip {
     case READOUT_MODE_ZERO_SUPPRESSED_LITE:
     case READOUT_MODE_SPY:
       setReadoutModeBits(readoutMode);
+      break;
+    case READOUT_MODE_PREMIX_RAW:
+      //special mode for simulation
+      setReadoutModeBits(readoutMode);
+      setDataTypeBit(true);
       break;
     default:
       std::ostringstream ss;

--- a/RecoLocalTracker/SiStripZeroSuppression/src/SiStripFedZeroSuppression.cc
+++ b/RecoLocalTracker/SiStripZeroSuppression/src/SiStripFedZeroSuppression.cc
@@ -443,6 +443,10 @@ bool SiStripFedZeroSuppression::IsAValidDigi()
 	       )
 	      );
     break;
+  case 5:
+    accept = adc > 0;
+    break;
+
   }
   return accept;
 }

--- a/SimGeneral/DataMixingModule/plugins/DataMixingSiStripMCDigiWorker.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingSiStripMCDigiWorker.cc
@@ -37,7 +37,7 @@ namespace edm
     theFedAlgo(ps.getParameter<int>("FedAlgorithm")),
     geometryType(ps.getParameter<std::string>("GeometryType")),
     theSiZeroSuppress(new SiStripFedZeroSuppression(theFedAlgo)),
-    theSiDigitalConverter(new SiTrivialDigitalConverter(theElectronPerADC))
+    theSiDigitalConverter(new SiTrivialDigitalConverter(theElectronPerADC, false)) // no premixing
 
   {                                                         
 

--- a/SimGeneral/MixingModule/python/SiStripSimParameters_cfi.py
+++ b/SimGeneral/MixingModule/python/SiStripSimParameters_cfi.py
@@ -63,6 +63,7 @@ SiStripSimBlock = cms.PSet(
     LorentzAngle               = cms.string(''),
     Gain                       = cms.string(''),
     #-----SiStripDigitizerAlgorithm
+    PreMixingMode              = cms.bool(False),
     NoiseSigmaThreshold        = cms.double(2.0),
     electronPerAdcDec          = cms.double(247.0), #tuned on collisions at 7 TeV
     electronPerAdcPeak         = cms.double(262.0), #tuned on craft08

--- a/SimGeneral/MixingModule/python/digi_noNoise_cfi.py
+++ b/SimGeneral/MixingModule/python/digi_noNoise_cfi.py
@@ -38,6 +38,8 @@ theDigitizersNoNoise.ecal.doENoise = cms.bool(False)
 theDigitizersNoNoise.pixel.AddNoise = cms.bool(True)
 theDigitizersNoNoise.pixel.addNoisyPixels = cms.bool(False)
 theDigitizersNoNoise.strip.Noise = cms.bool(False)
+theDigitizersNoNoise.strip.PreMixingMode = cms.bool(True)
+theDigitizersNoNoise.strip.FedAlgorithm = cms.int32(5) # special ZS mode: accept adc>0
 theDigitizersNoNoise.ecal.EcalPreMixStage1 = cms.bool(True)
 theDigitizersNoNoise.hcal.HcalPreMixStage1 = cms.bool(True)
 #Need Hcal statement - change variable

--- a/SimTracker/SiStripDigitizer/interface/SiTrivialDigitalConverter.h
+++ b/SimTracker/SiStripDigitizer/interface/SiTrivialDigitalConverter.h
@@ -8,7 +8,7 @@
 class SiTrivialDigitalConverter: public SiDigitalConverter{
  public:
 
-  SiTrivialDigitalConverter(float in);
+  SiTrivialDigitalConverter(float in, bool PreMix);
   
   DigitalVecType    convert(const std::vector<float>&,  edm::ESHandle<SiStripGain>& ,unsigned int detid);
   DigitalRawVecType convertRaw(const std::vector<float>&,  edm::ESHandle<SiStripGain>& ,unsigned int detid);  
@@ -23,6 +23,7 @@ class SiTrivialDigitalConverter: public SiDigitalConverter{
   const float electronperADC;
   SiDigitalConverter::DigitalVecType _temp;
   SiDigitalConverter::DigitalRawVecType _tempRaw;
+  bool PreMixing_;
 
 };
  

--- a/SimTracker/SiStripDigitizer/plugins/DigiSimLinkAlgorithm.cc
+++ b/SimTracker/SiStripDigitizer/plugins/DigiSimLinkAlgorithm.cc
@@ -39,6 +39,7 @@ DigiSimLinkAlgorithm::DigiSimLinkAlgorithm(const edm::ParameterSet& conf, CLHEP:
   cmnRMStid                 = conf_.getParameter<double>("cmnRMStid");
   cmnRMStec                 = conf_.getParameter<double>("cmnRMStec");
   pedOffset                 = (unsigned int)conf_.getParameter<double>("PedestalsOffset");
+  PreMixing_                = conf_.getParameter<bool>("PreMixingMode");
   if (peakMode) {
     tofCut=theTOFCutForPeak;
     LogDebug("StripDigiInfo")<<"APVs running in peak mode (poor time resolution)";
@@ -50,7 +51,7 @@ DigiSimLinkAlgorithm::DigiSimLinkAlgorithm(const edm::ParameterSet& conf, CLHEP:
   theSiHitDigitizer = new SiHitDigitizer(conf_,rndEngine);
   theDigiSimLinkPileUpSignals = new DigiSimLinkPileUpSignals();
   theSiNoiseAdder = new SiGaussianTailNoiseAdder(theThreshold,rndEngine);
-  theSiDigitalConverter = new SiTrivialDigitalConverter(theElectronPerADC);
+  theSiDigitalConverter = new SiTrivialDigitalConverter(theElectronPerADC, PreMixing_);
   theSiZeroSuppress = new SiStripFedZeroSuppression(theFedAlgo);
   theFlatDistribution = new CLHEP::RandFlat(rndEngine, 0., 1.);    
 

--- a/SimTracker/SiStripDigitizer/plugins/DigiSimLinkAlgorithm.h
+++ b/SimTracker/SiStripDigitizer/plugins/DigiSimLinkAlgorithm.h
@@ -99,6 +99,8 @@ class DigiSimLinkAlgorithm {
   double cosmicShift;
   double inefficiency;
   double pedOffset;
+  bool PreMixing_;
+
 
   size_t firstChannelWithSignal;
   size_t lastChannelWithSignal;

--- a/SimTracker/SiStripDigitizer/plugins/SiStripDigitizerAlgorithm.cc
+++ b/SimTracker/SiStripDigitizer/plugins/SiStripDigitizerAlgorithm.cc
@@ -51,10 +51,11 @@ SiStripDigitizerAlgorithm::SiStripDigitizerAlgorithm(const edm::ParameterSet& co
   cosmicShift(conf.getUntrackedParameter<double>("CosmicDelayShift")),
   inefficiency(conf.getParameter<double>("Inefficiency")),
   pedOffset((unsigned int)conf.getParameter<double>("PedestalsOffset")),
+  PreMixing_(conf.getParameter<bool>("PreMixingMode")),
   theSiHitDigitizer(new SiHitDigitizer(conf, eng)),
   theSiPileUpSignals(new SiPileUpSignals()),
   theSiNoiseAdder(new SiGaussianTailNoiseAdder(theThreshold, eng)),
-  theSiDigitalConverter(new SiTrivialDigitalConverter(theElectronPerADC)),
+  theSiDigitalConverter(new SiTrivialDigitalConverter(theElectronPerADC, PreMixing_)),
   theSiZeroSuppress(new SiStripFedZeroSuppression(theFedAlgo)),
   theFlatDistribution(new CLHEP::RandFlat(eng, 0., 1.)) {
 

--- a/SimTracker/SiStripDigitizer/plugins/SiStripDigitizerAlgorithm.h
+++ b/SimTracker/SiStripDigitizer/plugins/SiStripDigitizerAlgorithm.h
@@ -114,6 +114,7 @@ class SiStripDigitizerAlgorithm {
   const double cosmicShift;
   const double inefficiency;
   const double pedOffset;
+  const bool PreMixing_;
 
   const ParticleDataTable * pdt;
   const ParticleData * particle;

--- a/SimTracker/SiStripDigitizer/src/SiTrivialDigitalConverter.cc
+++ b/SimTracker/SiStripDigitizer/src/SiTrivialDigitalConverter.cc
@@ -2,8 +2,8 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-SiTrivialDigitalConverter::SiTrivialDigitalConverter(float in) :
-  electronperADC(in) {
+SiTrivialDigitalConverter::SiTrivialDigitalConverter(float in, bool PreMix) :
+  electronperADC(in), PreMixing_(PreMix) {
   _temp.reserve(800);
   _tempRaw.reserve(800);
 }
@@ -63,8 +63,14 @@ int SiTrivialDigitalConverter::truncate(float in_adc) const {
     254 ADC: 254  <= raw charge < 1023
     255 ADC: raw charge >= 1023
   */
-  if (adc > 1022 ) return 255;
-  if (adc > 253) return 254;
+  if(PreMixing_) {
+    if (adc > 2047 ) return 1023;
+    if (adc > 1022 ) return 1022;
+  }
+  else {
+    if (adc > 1022 ) return 255;
+    if (adc > 253) return 254;
+  }
   //Protection
   if (adc < 0) return 0;
   return adc;


### PR DESCRIPTION
Add special 10-bit FED Readout Mode in simulation to preserve high pulse height hits in Tracker through the Digi to Raw step.  Both Packer and Unpacker were modified to allow this (A.-M. Magnan).  Added a new ZeroSuppression mode that merely passes any adc > 0 so that low-level hits are not lost.  Because of all of this, the SiStrip Digitizer now needs to know that it is working in PreMixing mode, so as to not truncate all hits at ADC=256, so this switch was added. One customization added to ConfigBuilder so that the new PreMixing readout mode is enabled in the PreMixing DigiToRaw step.
