### PR TITLE
Fix 100xx (2017) workflows

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHF_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHF_cfi.py
@@ -13,7 +13,7 @@ particleFlowRecHitHF = cms.EDProducer("PFRecHitProducer",
     producers = cms.VPSet(
            cms.PSet(
              name = cms.string("PFHFRecHitCreator"),
-             src  = cms.InputTag("hfUpgradeReco",""),
+             src  = cms.InputTag("hfreco",""),
              EMDepthCorrection = cms.double(22.),
              HADDepthCorrection = cms.double(25.),
              thresh_HF = cms.double(0.4),


### PR DESCRIPTION
The 2017 workflows (numbers 100xx) have been broken since #5923 was merged yesterday.  This pull request fixes them.

Phase1 and Phase2 customisation functions change this parameter to the correct upgrade value (hfUpgradeReco), so the default should be the non-upgrade value (hfreco).
