### PR TITLE
Remove unneeded function

### DIFF
--- a/DataFormats/PatCandidates/src/UserData.cc
+++ b/DataFormats/PatCandidates/src/UserData.cc
@@ -4,8 +4,7 @@
 #include "FWCore/Utilities/interface/EDMException.h"
 
 void pat::UserData::checkDictionaries(const std::type_info &type) {
-    edm::TypeWithDict edmType(type);
-    if (!edmType.hasDictionary()) {
+    if (!edm::hasDictionary(type)) {
         int status = 0;
         char * demangled = abi::__cxa_demangle(type.name(),  0, 0, &status);
         std::string typeName(status == 0 ? demangled : type.name());

--- a/FWCore/Services/src/InitRootHandlers.cc
+++ b/FWCore/Services/src/InitRootHandlers.cc
@@ -272,7 +272,7 @@ namespace edm {
       setRefCoreStreamer();
 
       // Load the library containing dictionaries for std:: classes, if not already loaded.
-      if (!TypeWithDict(typeid(std::vector<std::vector<unsigned int> >)).hasDictionary()) {
+      if (!hasDictionary(typeid(std::vector<std::vector<unsigned int> >))) {
          edmplugin::PluginCapabilities::get()->load(dictionaryPlugInPrefix() + "std::vector<std::vector<unsigned int> >");
       }
 

--- a/FWCore/Utilities/interface/TypeWithDict.h
+++ b/FWCore/Utilities/interface/TypeWithDict.h
@@ -60,9 +60,7 @@ public:
   explicit TypeWithDict(TEnum* type, std::string const& name, long property = 0L);
   explicit TypeWithDict(TMethodArg* arg, long property = 0L);
   explicit TypeWithDict(TType* type, long property = 0L);
-  //template<typename T> TypeWithDict() : TypeWithDict(typeid(T)) {}
   explicit operator bool() const;
-  bool hasDictionary() const;
   std::type_info const& typeInfo() const;
   std::type_info const& id() const;
   TClass* getClass() const;

--- a/FWCore/Utilities/src/TypeWithDict.cc
+++ b/FWCore/Utilities/src/TypeWithDict.cc
@@ -266,18 +266,6 @@ namespace edm {
     return gInterpreter->Type_Bool(type_);
   }
 
-  bool
-  TypeWithDict::hasDictionary() const {
-    if (*ti_ == typeid(void)) {
-      return true;
-    }
-    if (ti_->name()[1] == '\0') {
-      // returns true for built in types (single character mangled names)
-      return true; 
-    }
-    return (TClassTable::GetDict(*ti_) != nullptr);
-  }
-
   std::type_info const&
   TypeWithDict::typeInfo() const {
     return *ti_;


### PR DESCRIPTION
The function TypeWithDict::hasDictionary() can be removed.   In ROOT6, it will not work correctly for enums, pointers, or C style arrays, because TypeWithDict does not necessarily have a correct type_info for these types.  The use of this function is replaced by use of the existing hasDictionary() free function, which takes the type_info as its input argument.
Please merge this as soon as convenient.
