### PR TITLE
Add missing entry in selection file

### DIFF
--- a/DataFormats/Candidate/src/classes_def.xml
+++ b/DataFormats/Candidate/src/classes_def.xml
@@ -77,6 +77,7 @@
   <class name="reco::CompositeCandidateRef" />
   <class name="reco::CompositeCandidateRefVector" />
   <class name="reco::VertexCompositeCandidateRefVector" />
+  <class name="reco::VertexCompositePtrCandidate" />
   <class name="reco::VertexCompositePtrCandidateRefVector" />
   <class name="reco::CandidateRefProd" />
 


### PR DESCRIPTION
From Danilo Piparo: Add missing entry in dictionary selection file.  This fixes an error in Relval 5.1.
Please merge this request as soon as convenient.
