### PR TITLE
Event number from 32 to 64 bits in Core

### DIFF
--- a/DPGAnalysis/SiStripTools/plugins/BigEventsDebugger.cc
+++ b/DPGAnalysis/SiStripTools/plugins/BigEventsDebugger.cc
@@ -175,7 +175,7 @@ BigEventsDebugger<T>::analyze(const edm::Event& iEvent, const edm::EventSetup& i
      m_hist.clear();     m_hprof.clear();     m_hist2d.clear();
 
      char dirname[500];
-     sprintf(dirname,"event_%u_%u",iEvent.run(),iEvent.id().event());
+     sprintf(dirname,"event_%u_%llu",iEvent.run(),iEvent.id().event());
      TFileDirectory subd = tfserv->mkdir(dirname);
 
      //book histos

--- a/DataFormats/FWLite/test/test.cppunit.cpp
+++ b/DataFormats/FWLite/test/test.cppunit.cpp
@@ -431,7 +431,7 @@ void testRefInROOT::testThinning() {
     // It is just checking that we read the values known to be
     // be put in by the relevant producer.
 
-    int offset = 100 + 100 * events.eventAuxiliary().event();
+    int offset = static_cast<int>(100 + 100 * events.eventAuxiliary().event());
 
     // In the D branch this tests accessing a value in
     // thinned collection made from a thinned collection
@@ -567,7 +567,7 @@ void testRefInROOT::testThinning() {
     // It is just checking that we read the values known to be
     // be put in by the relevant producer.
 
-    int offset = 100 + 100 * multiChainEvents.eventAuxiliary().event();
+    int offset = static_cast<int>(100 + 100 * multiChainEvents.eventAuxiliary().event());
 
     // In the D branch this tests accessing a value in
     // thinned collection made from a thinned collection

--- a/DataFormats/Provenance/interface/EventID.h
+++ b/DataFormats/Provenance/interface/EventID.h
@@ -100,8 +100,16 @@ namespace edm {
 
       // ---------- static functions ---------------------------
 
-      static EventNumber_t maxEventNumber() {
+      static RunNumber_t maxRunNumber() {
          return 0xFFFFFFFFU;
+      }
+
+      static LuminosityBlockNumber_t maxLuminosityBlockNumber() {
+         return 0xFFFFFFFFU;
+      }
+
+      static EventNumber_t maxEventNumber() {
+         return 0xFFFFFFFFFFFFFFFFULL;
       }
 
       static EventID firstValidEvent() {

--- a/DataFormats/Provenance/interface/EventRange.h
+++ b/DataFormats/Provenance/interface/EventRange.h
@@ -21,15 +21,12 @@
 #include <iosfwd>
 #include <vector>
 #include "DataFormats/Provenance/interface/EventID.h"
+#include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
 
 // user include files
 
 // forward declarations
 namespace edm {
-
-   typedef unsigned int EventNumber_t;
-   typedef unsigned int LumiNumber_t;
-   typedef unsigned int RunNumber_t;
 
   class EventRange {
 
@@ -37,8 +34,8 @@ namespace edm {
 
       EventRange();
 
-      EventRange(RunNumber_t startRun, LumiNumber_t startLumi, EventNumber_t startEvent,
-                 RunNumber_t endRun, LumiNumber_t endLumi, EventNumber_t endEvent);
+      EventRange(RunNumber_t startRun, LuminosityBlockNumber_t startLumi, EventNumber_t startEvent,
+                 RunNumber_t endRun, LuminosityBlockNumber_t endLumi, EventNumber_t endEvent);
 
       EventRange(EventID const& begin, EventID const& end);
 //      virtual ~EventRange();
@@ -48,8 +45,8 @@ namespace edm {
       EventID       endEventID() const {return   endEventID_; }
       RunNumber_t     startRun() const {return    startEventID_.run(); }
       RunNumber_t       endRun() const {return      endEventID_.run(); }
-      LumiNumber_t   startLumi() const {return startEventID_.luminosityBlock(); }
-      LumiNumber_t     endLumi() const {return   endEventID_.luminosityBlock(); }
+      LuminosityBlockNumber_t   startLumi() const {return startEventID_.luminosityBlock(); }
+      LuminosityBlockNumber_t     endLumi() const {return   endEventID_.luminosityBlock(); }
       EventNumber_t startEvent() const {return  startEventID_.event(); }
       EventNumber_t   endEvent() const {return    endEventID_.event(); }
 
@@ -58,8 +55,8 @@ namespace edm {
       // ---------- member data --------------------------------
       //RunNumber_t   startRun_;
       //RunNumber_t   endRun_;
-      //LumiNumber_t   startLumi_;
-      //LumiNumber_t   endLumi_;
+      //LuminosityBlockNumber_t   startLumi_;
+      //LuminosityBlockNumber_t   endLumi_;
       //EventNumber_t startEvent_;
       //EventNumber_t endEvent_;
       EventID startEventID_;

--- a/DataFormats/Provenance/interface/FileIndex.h
+++ b/DataFormats/Provenance/interface/FileIndex.h
@@ -77,7 +77,7 @@ namespace edm {
 
       bool
       containsItem(RunNumber_t run, LuminosityBlockNumber_t lumi, EventNumber_t event) const {
-        return event ? containsEvent(run, lumi, event) : (lumi ? containsLumi(run, lumi) : containsRun(run));
+        return (event != 0) ? containsEvent(run, lumi, event) : (lumi ? containsLumi(run, lumi) : containsRun(run));
       }
 
       bool

--- a/DataFormats/Provenance/interface/IndexIntoFile.h
+++ b/DataFormats/Provenance/interface/IndexIntoFile.h
@@ -110,9 +110,7 @@ hold the information giving the event numbers and
 event entry numbers.
 
 eventNumbers_ is a std::vector containing EventNumber_t's.
-Each element is a 4 byte int.  eventEntries_ is a
-std::vector containing EventEntry's.  Each EventEntry
-contains a 4 byte event number and an 8 byte entry number.
+eventEntries_ is a std::vector containing EventEntry's.
 If filled, both vectors contain the same number of
 entries with identical event numbers sorted in the
 same order.  The only difference is that one includes
@@ -924,7 +922,7 @@ namespace edm {
       /// pointer to its base class.
       void setEventFinder(std::shared_ptr<EventFinder> ptr) const {transient_.eventFinder_ = ptr;}
 
-      /// Fills a vector of 4 byte event numbers.
+      /// Fills a vector of event numbers.
       /// Not filling it reduces the memory used by IndexIntoFile.
       /// As long as the event finder is still pointing at an open file
       /// this will automatically be called on demand (when the event
@@ -939,8 +937,8 @@ namespace edm {
       /// in the current file without reading them.
       void fillEventNumbers() const;
 
-      /// Fills a vector of objects that contain a 4 byte event number and
-      /// the corresponding TTree entry number (8 bytes) for the event.
+      /// Fills a vector of objects that contain an event number and
+      /// the corresponding TTree entry number for the event.
       /// Not filling it reduces the memory used by IndexIntoFile.
       /// As long as the event finder is still pointing at an open file
       /// this will automatically be called on demand (when the event

--- a/DataFormats/Provenance/interface/RunLumiEventNumber.h
+++ b/DataFormats/Provenance/interface/RunLumiEventNumber.h
@@ -9,7 +9,7 @@
 
 namespace edm {
 
-   typedef unsigned int EventNumber_t;
+   typedef unsigned long long EventNumber_t;
    typedef unsigned int LuminosityBlockNumber_t;
    typedef unsigned int RunNumber_t;
 

--- a/DataFormats/Provenance/src/EventRange.cc
+++ b/DataFormats/Provenance/src/EventRange.cc
@@ -11,8 +11,8 @@ namespace edm {
       endEventID_(0U, 0U, EventID::maxEventNumber()) {
   }
 
-  EventRange::EventRange(RunNumber_t startRun, LumiNumber_t startLumi, EventNumber_t startEvent,
-                         RunNumber_t endRun, LumiNumber_t endLumi, EventNumber_t endEvent) :
+  EventRange::EventRange(RunNumber_t startRun, LuminosityBlockNumber_t startLumi, EventNumber_t startEvent,
+                         RunNumber_t endRun, LuminosityBlockNumber_t endLumi, EventNumber_t endEvent) :
       // Special cases since 0 means maximum
       startEventID_(startRun, startLumi, startEvent != 0 ? startEvent : EventID::maxEventNumber()),
       endEventID_(endRun, endLumi, endEvent != 0 ? endEvent : EventID::maxEventNumber()) {

--- a/DataFormats/Provenance/src/IndexIntoFile.cc
+++ b/DataFormats/Provenance/src/IndexIntoFile.cc
@@ -733,12 +733,12 @@ namespace edm {
 
   bool
   IndexIntoFile::containsItem(RunNumber_t run, LuminosityBlockNumber_t lumi, EventNumber_t event) const {
-        return event ? containsEvent(run, lumi, event) : (lumi ? containsLumi(run, lumi) : containsRun(run));
+    return (event != 0) ? containsEvent(run, lumi, event) : (lumi ? containsLumi(run, lumi) : containsRun(run));
   }
 
   bool
   IndexIntoFile::containsEvent(RunNumber_t run, LuminosityBlockNumber_t lumi, EventNumber_t event) const {
-        return findEventPosition(run, lumi, event).getEntryType() != kEnd;
+    return findEventPosition(run, lumi, event).getEntryType() != kEnd;
   }
 
   bool

--- a/DataFormats/Provenance/src/classes_def.xml
+++ b/DataFormats/Provenance/src/classes_def.xml
@@ -8,7 +8,8 @@
  <class name="edm::BranchID" ClassVersion="10">
   <version ClassVersion="10" checksum="21214741"/>
  </class>
- <class name="edm::EventID" ClassVersion="10">
+ <class name="edm::EventID" ClassVersion="11">
+  <version ClassVersion="11" checksum="341254076"/>
   <version ClassVersion="10" checksum="1903450811"/>
  </class>
  <class name="edm::LuminosityBlockID" ClassVersion="10">
@@ -105,7 +106,8 @@
  <class name="edm::FileFormatVersion" ClassVersion="10">
   <version ClassVersion="10" checksum="2078548510"/>
  </class>
- <class name="edm::FileIndex::Element" ClassVersion="10">
+ <class name="edm::FileIndex::Element" ClassVersion="11">
+  <version ClassVersion="11" checksum="1881476699"/>
   <version ClassVersion="10" checksum="1310120368"/>
  </class>
  <class name="std::vector<edm::FileIndex::Element>"/>

--- a/DataFormats/Provenance/test/eventid_t.cppunit.cc
+++ b/DataFormats/Provenance/test/eventid_t.cppunit.cc
@@ -22,7 +22,7 @@ class testEventID: public CppUnit::TestFixture
    
    CPPUNIT_TEST_SUITE_END();
 public:
-      void setUp(){}
+   void setUp(){}
    void tearDown(){}
    
    void constructTest();
@@ -35,16 +35,25 @@ CPPUNIT_TEST_SUITE_REGISTRATION(testEventID);
 
 
 void testEventID::constructTest()
-{
-   const EventNumber_t et = 1;
-   const LuminosityBlockNumber_t lt = 1;
-   const RunNumber_t rt = 2;
+ {
+   EventID eventID;
+   CPPUNIT_ASSERT(eventID.run() == 0U);
+   CPPUNIT_ASSERT(eventID.luminosityBlock() == 0U);
+   CPPUNIT_ASSERT(eventID.event() == 0U);
+
+   const RunNumber_t rt = 3;
+   const LuminosityBlockNumber_t lt = 2;
+   const EventNumber_t et = 10123456789;
 
    EventID temp(rt, lt, et);
    
    CPPUNIT_ASSERT(temp.run() == rt);
    CPPUNIT_ASSERT(temp.luminosityBlock() == lt);
    CPPUNIT_ASSERT(temp.event() == et);
+
+   CPPUNIT_ASSERT(EventID::maxRunNumber() == 0xFFFFFFFF);
+   CPPUNIT_ASSERT(EventID::maxLuminosityBlockNumber() == 0xFFFFFFFF);
+   CPPUNIT_ASSERT(EventID::maxEventNumber() == 0xFFFFFFFFFFFFFFFF);
 }
 
 void testEventID::comparisonTest()
@@ -53,14 +62,22 @@ void testEventID::comparisonTest()
    const EventID med(2, 3, 2);
    const EventID med2(2, 3, 2);
    const EventID large(3, 1, 3);
+   const EventID larger(3, 2, 1);
    const EventID largest(3, 2, 2);
    
    CPPUNIT_ASSERT(small < med);
+   CPPUNIT_ASSERT(!(med < small));
    CPPUNIT_ASSERT(small <= med);
    CPPUNIT_ASSERT(!(small == med));
    CPPUNIT_ASSERT(small != med);
    CPPUNIT_ASSERT(!(small > med));
    CPPUNIT_ASSERT(!(small >= med));
+
+   CPPUNIT_ASSERT(!(med <= small));
+   CPPUNIT_ASSERT(!(med == small));
+   CPPUNIT_ASSERT(med != small);
+   CPPUNIT_ASSERT(med > small);
+   CPPUNIT_ASSERT(med >= small);
 
    CPPUNIT_ASSERT(med2 == med);
    CPPUNIT_ASSERT(med2 <= med);
@@ -75,15 +92,17 @@ void testEventID::comparisonTest()
    CPPUNIT_ASSERT(med != large);
    CPPUNIT_ASSERT(!(med > large));
    CPPUNIT_ASSERT(!(med >= large));
-   
-   
+
    CPPUNIT_ASSERT(large < largest);
+   CPPUNIT_ASSERT(!(largest < large));
    CPPUNIT_ASSERT(large <= largest);
    CPPUNIT_ASSERT(!(large == largest));
    CPPUNIT_ASSERT(large != largest);
    CPPUNIT_ASSERT(!(large > largest));
    CPPUNIT_ASSERT(!(large >= largest));
-   
+
+   CPPUNIT_ASSERT(larger < largest);
+   CPPUNIT_ASSERT(!(largest < larger));
 }
 
 void testEventID::iterationTest()

--- a/DataFormats/Provenance/test/eventrange_t.cppunit.cc
+++ b/DataFormats/Provenance/test/eventrange_t.cppunit.cc
@@ -23,7 +23,7 @@ class testEventRange: public CppUnit::TestFixture {
 
    CPPUNIT_TEST_SUITE_END();
 public:
-      void setUp(){}
+   void setUp(){}
    void tearDown(){}
 
    void constructTest();
@@ -39,19 +39,18 @@ CPPUNIT_TEST_SUITE_REGISTRATION(testEventRange);
 void testEventRange::constructTest() {
    RunNumber_t const rb = 1;
    RunNumber_t const re = 2;
-   EventNumber_t const lb = 3;
-   EventNumber_t const le = 4;
+   EventNumber_t const lb { 30123456789ull };
+   EventNumber_t const le { 40123456789ull };
 
    EventRange normal(rb, 1, lb, re, 1, le);
    EventRange maxed(rb, 1, 0, re, 1, 0);
-   EventID    dummy;
 
    CPPUNIT_ASSERT(normal.startRun() == rb);
    CPPUNIT_ASSERT(normal.endRun()   == re);
    CPPUNIT_ASSERT(normal.startEvent() == lb);
    CPPUNIT_ASSERT(normal.endEvent()   == le);
-   CPPUNIT_ASSERT(maxed.startEventID().event() == dummy.maxEventNumber());
-   CPPUNIT_ASSERT(maxed.endEventID().event() == dummy.maxEventNumber());
+   CPPUNIT_ASSERT(maxed.startEventID().event() == EventID::maxEventNumber());
+   CPPUNIT_ASSERT(maxed.endEventID().event() == EventID::maxEventNumber());
 }
 
 void testEventRange::comparisonTest() {

--- a/DataFormats/TestObjects/interface/ToyProducts.h
+++ b/DataFormats/TestObjects/interface/ToyProducts.h
@@ -48,6 +48,13 @@ namespace edmtest {
     cms_int32_t value;
   };
 
+  struct UInt64Product {
+    explicit UInt64Product(unsigned long long i = 0) : value(i) {}
+    ~UInt64Product() {}
+
+    unsigned long long value;
+  };
+
   struct TransientIntProduct {
     explicit TransientIntProduct(int i = 0) : value(i) {}
     ~TransientIntProduct() {}

--- a/DataFormats/TestObjects/src/classes.h
+++ b/DataFormats/TestObjects/src/classes.h
@@ -25,6 +25,7 @@ namespace DataFormats_TestObjects {
 struct dictionary {
   edm::Wrapper<edmtest::DummyProduct> dummyw12;
   edm::Wrapper<edmtest::IntProduct> dummyw13;
+  edm::Wrapper<edmtest::UInt64Product> dummyw13ull;
   edm::Wrapper<edmtest::TransientIntProduct> dummyw13t;
   edm::Wrapper<edmtest::DoubleProduct> dummyw14;
   edm::Wrapper<edmtest::StringProduct> dummyw15;

--- a/DataFormats/TestObjects/src/classes_def.xml
+++ b/DataFormats/TestObjects/src/classes_def.xml
@@ -5,6 +5,9 @@
  <class name="edmtest::IntProduct" ClassVersion="10">
   <version ClassVersion="10" checksum="4286676158"/>
  </class>
+ <class name="edmtest::UInt64Product" ClassVersion="10">
+  <version ClassVersion="10" checksum="380152127"/>
+ </class>
  <class name="edmtest::EnumProduct" ClassVersion="10">
   <version ClassVersion="10" checksum="3025325436"/>
  </class>
@@ -62,6 +65,7 @@
  </ioread>
  <class name="edm::Wrapper<edmtest::DummyProduct>"/>
  <class name="edm::Wrapper<edmtest::IntProduct>"/>
+ <class name="edm::Wrapper<edmtest::UInt64Product>"/>
  <class name="edm::Wrapper<edmtest::TransientIntProduct>" persistent="false"/>
  <class name="edm::Wrapper<edmtest::Int16_tProduct>"/>
  <class name="edm::Wrapper<edmtest::DoubleProduct>"/>

--- a/EgammaAnalysis/ElectronTools/plugins/EGammaCutBasedEleIdAnalyzer.cc
+++ b/EgammaAnalysis/ElectronTools/plugins/EGammaCutBasedEleIdAnalyzer.cc
@@ -227,7 +227,7 @@ EGammaCutBasedEleIdAnalyzer::analyze(const edm::Event& iEvent, const edm::EventS
         //
 
         if (printDebug_) {
-            printf("%u %u %u : ",       iEvent.id().run(), iEvent.luminosityBlock(), iEvent.id().event());
+            printf("%u %u %llu : ",       iEvent.id().run(), iEvent.luminosityBlock(), iEvent.id().event());
             printf("veto(%i), ",        veto);
             printf("loose(%i), ",       loose);
             printf("medium(%i), ",      medium);

--- a/FWCore/Framework/test/stubs/RunLumiEventAnalyzer.cc
+++ b/FWCore/Framework/test/stubs/RunLumiEventAnalyzer.cc
@@ -17,8 +17,8 @@
 namespace edmtest {
 
   RunLumiEventAnalyzer::RunLumiEventAnalyzer(edm::ParameterSet const& pset) :
-    expectedRunLumisEvents0_(pset.getUntrackedParameter<std::vector<unsigned int> >("expectedRunLumiEvents", std::vector<unsigned int>())),
-    expectedRunLumisEvents1_(pset.getUntrackedParameter<std::vector<unsigned int> >("expectedRunLumiEvents1", std::vector<unsigned int>())),
+    expectedRunLumisEvents0_(),
+    expectedRunLumisEvents1_(),
     expectedRunLumisEvents_(&expectedRunLumisEvents0_),
     index_(0),
     verbose_(pset.getUntrackedParameter<bool>("verbose", false)),
@@ -26,6 +26,21 @@ namespace edmtest {
     expectedEndingIndex0_(pset.getUntrackedParameter<int>("expectedEndingIndex", -1)),
     expectedEndingIndex1_(pset.getUntrackedParameter<int>("expectedEndingIndex1", -1)),
     expectedEndingIndex_(expectedEndingIndex0_) {
+
+    if(pset.existsAs<std::vector<unsigned int> >("expectedRunLumiEvents", false)) {
+      std::vector<unsigned int> temp = pset.getUntrackedParameter<std::vector<unsigned int> >("expectedRunLumiEvents");
+      expectedRunLumisEvents0_.assign(temp.begin(), temp.end());
+    } else {
+      expectedRunLumisEvents0_ = pset.getUntrackedParameter<std::vector<unsigned long long> >("expectedRunLumiEvents", std::vector<unsigned long long>());
+    }
+
+    if(pset.existsAs<std::vector<unsigned int> >("expectedRunLumiEvents1", false)) {
+      std::vector<unsigned int> temp = pset.getUntrackedParameter<std::vector<unsigned int> >("expectedRunLumiEvents1");
+      expectedRunLumisEvents1_.assign(temp.begin(), temp.end());
+    } else {
+      expectedRunLumisEvents1_ = pset.getUntrackedParameter<std::vector<unsigned long long> >("expectedRunLumiEvents1", std::vector<unsigned long long>());
+    }
+
   }
 
   void RunLumiEventAnalyzer::analyze(edm::Event const& event, edm::EventSetup const&) {

--- a/FWCore/Framework/test/stubs/RunLumiEventAnalyzer.h
+++ b/FWCore/Framework/test/stubs/RunLumiEventAnalyzer.h
@@ -25,9 +25,9 @@ namespace edmtest {
 
   private:
 
-    std::vector<unsigned int> expectedRunLumisEvents0_;
-    std::vector<unsigned int> expectedRunLumisEvents1_;
-    std::vector<unsigned int> *expectedRunLumisEvents_;
+    std::vector<unsigned long long> expectedRunLumisEvents0_;
+    std::vector<unsigned long long> expectedRunLumisEvents1_;
+    std::vector<unsigned long long> *expectedRunLumisEvents_;
     int index_;
     bool verbose_;
     bool dumpTriggerResults_;

--- a/FWCore/Framework/test/stubs/TestFailuresAnalyzer.cc
+++ b/FWCore/Framework/test/stubs/TestFailuresAnalyzer.cc
@@ -56,7 +56,7 @@ enum {
 //
 TestFailuresAnalyzer::TestFailuresAnalyzer(const edm::ParameterSet& iConfig)
   : whichFailure_(iConfig.getParameter<int>("whichFailure")),
-    eventToThrow_(iConfig.getUntrackedParameter<unsigned>("eventToThrow", 2U))
+    eventToThrow_(iConfig.getUntrackedParameter<unsigned long long>("eventToThrow", 2U))
 {
    //now do what ever initialization is needed
    if(whichFailure_ == kConstructor){

--- a/FWCore/Framework/test/stubs/TestFailuresAnalyzer.h
+++ b/FWCore/Framework/test/stubs/TestFailuresAnalyzer.h
@@ -37,7 +37,7 @@ public:
 private:
       // ----------member data ---------------------------
       int whichFailure_;
-      unsigned eventToThrow_;
+      unsigned long long eventToThrow_;
 };
 
 

--- a/FWCore/Framework/test/stubs/ToyIntProducers.cc
+++ b/FWCore/Framework/test/stubs/ToyIntProducers.cc
@@ -102,10 +102,10 @@ namespace edmtest {
   class EventNumberIntProducer : public edm::EDProducer {
   public:
     explicit EventNumberIntProducer(edm::ParameterSet const&) {
-      produces<IntProduct>();
+      produces<UInt64Product>();
     }
     EventNumberIntProducer() {
-      produces<IntProduct>();
+      produces<UInt64Product>();
     }
     virtual ~EventNumberIntProducer() {}
     virtual void produce(edm::Event& e, edm::EventSetup const& c);
@@ -116,7 +116,7 @@ namespace edmtest {
   void
   EventNumberIntProducer::produce(edm::Event& e, edm::EventSetup const&) {
     // EventSetup is not used.
-    std::unique_ptr<IntProduct> p(new IntProduct(e.id().event()));
+    std::unique_ptr<UInt64Product> p(new UInt64Product(e.id().event()));
     e.put(std::move(p));
   }
 

--- a/FWCore/Integration/test/TestPSetAnalyzer.cc
+++ b/FWCore/Integration/test/TestPSetAnalyzer.cc
@@ -31,9 +31,7 @@ class TestPSetAnalyzer : public edm::EDAnalyzer {
 
 
    private:
-      virtual void beginJob() ;
       virtual void analyze(edm::Event const&, edm::EventSetup const&);
-      virtual void endJob() ;
 
       edm::LuminosityBlockID                 testLumi_;
       edm::LuminosityBlockRange              testLRange_;
@@ -42,6 +40,18 @@ class TestPSetAnalyzer : public edm::EDAnalyzer {
       std::vector<edm::LuminosityBlockID>    testVLumi_;
       std::vector<edm::LuminosityBlockRange> testVLRange_;
       std::vector<edm::EventRange>           testVERange_;
+
+      edm::EventID                           testEventID1_;
+      edm::EventID                           testEventID2_;
+      edm::EventID                           testEventID3_;
+      edm::EventID                           testEventID4_;
+      std::vector<edm::EventID>              testVEventID_;
+      edm::EventRange                        testERange1_;
+      edm::EventRange                        testERange2_;
+      edm::EventRange                        testERange3_;
+      edm::EventRange                        testERange4_;
+      edm::EventRange                        testERange5_;
+      std::vector<edm::EventRange>           testVERange2_;
 
       // ----------member data ---------------------------
 };
@@ -66,32 +76,54 @@ TestPSetAnalyzer::TestPSetAnalyzer(edm::ParameterSet const& iConfig) {
     testERange_           = iConfig.getParameter<edm::EventRange>("testERange");
     testVERange_          = iConfig.getParameter<std::vector<edm::EventRange> >("testVERange");
 
+    testEventID1_          = iConfig.getParameter<edm::EventID>("testEventID1");
+    testEventID2_          = iConfig.getParameter<edm::EventID>("testEventID2");
+    testEventID3_          = iConfig.getParameter<edm::EventID>("testEventID3");
+    testEventID4_          = iConfig.getParameter<edm::EventID>("testEventID4");
+    testVEventID_         = iConfig.getParameter<std::vector<edm::EventID> >("testVEventID");
+    testERange1_          = iConfig.getParameter<edm::EventRange>("testERange1");
+    testERange2_          = iConfig.getParameter<edm::EventRange>("testERange2");
+    testERange3_          = iConfig.getParameter<edm::EventRange>("testERange3");
+    testERange4_          = iConfig.getParameter<edm::EventRange>("testERange4");
+    testERange5_          = iConfig.getParameter<edm::EventRange>("testERange5");
+    testVERange2_         = iConfig.getParameter<std::vector<edm::EventRange> >("testVERange2");
+
     std::cout << "Lumi PSet test "   << testLumi_  << std::endl;
     std::cout << "LRange PSet test "  << testLRange_ << std::endl;
     std::cout << "ERange PSet test "  << testERange_ << std::endl;
 
-    for(std::vector<edm::LuminosityBlockID>::const_iterator i = testVLumi_.begin();
-        i !=  testVLumi_.end(); ++i) {
-      std::cout << "VLumi PSet test " << *i << std::endl;
+    for(auto const& i : testVLumi_) {
+      std::cout << "VLumi PSet test " << i << std::endl;
     }
 
-    for(std::vector<edm::LuminosityBlockRange>::const_iterator i = testVLRange_.begin();
-        i !=  testVLRange_.end(); ++i) {
-      std::cout << "VLRange PSet test " << *i << std::endl;
+    for(auto const& i : testVLRange_) {
+      std::cout << "VLRange PSet test " << i << std::endl;
     }
 
-    for(std::vector<edm::EventRange>::const_iterator i = testVERange_.begin();
-        i !=  testVERange_.end(); ++i) {
-      std::cout << "VERange PSet test " << *i << std::endl;
+    for(auto const& i : testVERange_) {
+      std::cout << "VERange PSet test " << i << std::endl;
     }
 
-   //now do what ever initialization is needed
+    std::cout << "EventID1 PSet test "  << testEventID1_ << std::endl;
+    std::cout << "EventID2 PSet test "  << testEventID2_ << std::endl;
+    std::cout << "EventID3 PSet test "  << testEventID3_ << std::endl;
+    std::cout << "EventID4 PSet test "  << testEventID4_ << std::endl;
+    std::cout << "ERange1 PSet test "  << testERange1_ << std::endl;
+    std::cout << "ERange2 PSet test "  << testERange2_ << std::endl;
+    std::cout << "ERange3 PSet test "  << testERange3_ << std::endl;
+    std::cout << "ERange4 PSet test "  << testERange4_ << std::endl;
+    std::cout << "ERange5 PSet test "  << testERange5_ << std::endl;
 
+    for( auto const& i : testVEventID_) {
+      std::cout << "VEventID PSet test " << i << std::endl;
+    }
+
+    for( auto const& i : testVERange2_) {
+      std::cout << "VERange2 PSet test " << i << std::endl;
+    }
 }
 
 TestPSetAnalyzer::~TestPSetAnalyzer() {
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
 }
 
 //
@@ -112,16 +144,6 @@ TestPSetAnalyzer::analyze(edm::Event const&, edm::EventSetup const&) {
    ESHandle<SetupData> pSetup;
    iSetup.get<SetupRecord>().get(pSetup);
 #endif
-}
-
-// ------------ method called once each job just before starting event loop  ------------
-void
-TestPSetAnalyzer::beginJob() {
-}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void
-TestPSetAnalyzer::endJob() {
 }
 
 //define this as a plug-in

--- a/FWCore/Integration/test/ThinningTestAnalyzer.cc
+++ b/FWCore/Integration/test/ThinningTestAnalyzer.cc
@@ -116,7 +116,7 @@ namespace edmtest {
       for(auto const& thing : *parentCollection) {
         // Just some numbers that match the somewhat arbitrary values put in
         // by the ThingProducer.
-        int expected  = expectedParentContent_.at(i) + event.eventAuxiliary().event() * 100 + 100;
+        int expected = static_cast<int>(expectedParentContent_.at(i) + event.eventAuxiliary().event() * 100 + 100);
         if(thing.a != expected) {
           throw cms::Exception("TestFailure") << "parent collection has unexpected content";
         }

--- a/FWCore/Integration/test/testPSetAnalyzer_cfg.py
+++ b/FWCore/Integration/test/testPSetAnalyzer_cfg.py
@@ -17,8 +17,18 @@ process.demo = cms.EDAnalyzer('TestPSetAnalyzer',
     testVRange = cms.VLuminosityBlockRange("1:2-4:MAX","99:99","3:4-5:9"),
     testERange = cms.EventRange("1:2-4:MAX"),
     testVERange = cms.VEventRange("1:2-4:MAX","99:99","3:4-5:9","9:9-11:MIN"),
-    testEvent = cms.LuminosityBlockID("1:2")
+    testEvent = cms.LuminosityBlockID("1:2"),
+    testEventID1 = cms.EventID(1, 1, 1000123456789),
+    testEventID2 = cms.EventID(2, 1000123456790),
+    testEventID3 = cms.EventID('3:3:1000123456791'),
+    testEventID4 = cms.EventID('4:1000123456792'),
+    testVEventID = cms.VEventID('1:1:1000123456789', '2:1000123456790', cms.EventID(3, 3, 1000123456791)),
+    testERange1 = cms.EventRange("1:2:1000123456789-2:3:1000123456790"),
+    testERange2 = cms.EventRange("3:1000123456791-4:1000123456792"),
+    testERange3 = cms.EventRange("5:6:1000123456793"),
+    testERange4 = cms.EventRange(7,8,1000123456794,9,10, 1000123456795),
+    testERange5 = cms.EventRange(11, 1000123456796, 12, 1000123456797),
+    testVERange2 = cms.VEventRange("1:2:1000123456789-2:3:1000123456790", "1:2-4:1000123456789",cms.EventRange("3:1000123456791-4:1000123456792"),cms.EventRange(11, 1000123456796, 12, 1000123456797))
 )
-
 
 process.p = cms.Path(process.demo)

--- a/FWCore/Integration/test/testRunMergeFastCloning_cfg.py
+++ b/FWCore/Integration/test/testRunMergeFastCloning_cfg.py
@@ -37,7 +37,7 @@ process.out = cms.OutputModule("PoolOutputModule",
 
 process.testThrow = cms.EDAnalyzer("TestFailuresAnalyzer",
     whichFailure = cms.int32(5),
-    eventToThrow = cms.untracked.uint32(2)
+    eventToThrow = cms.untracked.uint64(2)
 )
 
 process.p = cms.Path(process.testThrow)

--- a/FWCore/Integration/test/testSkipEvent_cfg.py
+++ b/FWCore/Integration/test/testSkipEvent_cfg.py
@@ -26,7 +26,7 @@ process.source = cms.Source("EmptySource",
 
 process.testThrow = cms.EDAnalyzer("TestFailuresAnalyzer",
     whichFailure = cms.int32(5),
-    eventToThrow = cms.untracked.uint32(2)
+    eventToThrow = cms.untracked.uint64(2)
 )
 
 # In the path before the module throwing an exception all 3 events should run

--- a/FWCore/Integration/test/unit_test_outputs/testPSetAnalyzer.txt
+++ b/FWCore/Integration/test/unit_test_outputs/testPSetAnalyzer.txt
@@ -1,13 +1,29 @@
 Lumi PSet test run: 1 luminosityBlock: 2
 LRange PSet test '1:2-4:4294967295'
-ERange PSet test '1:2-4:4294967295'
+ERange PSet test '1:2-4:18446744073709551615'
 VLumi PSet test run: 1 luminosityBlock: 2
 VLumi PSet test run: 2 luminosityBlock: 2
 VLumi PSet test run: 3 luminosityBlock: 3
 VLRange PSet test '1:2-4:4294967295'
 VLRange PSet test '99:99-99:99'
 VLRange PSet test '3:4-5:9'
-VERange PSet test '1:2-4:4294967295'
+VERange PSet test '1:2-4:18446744073709551615'
 VERange PSet test '99:99-99:99'
 VERange PSet test '3:4-5:9'
 VERange PSet test '9:9-11:1'
+EventID1 PSet test run: 1 lumi: 1 event: 1000123456789
+EventID2 PSet test run: 2 lumi: 0 event: 1000123456790
+EventID3 PSet test run: 3 lumi: 3 event: 1000123456791
+EventID4 PSet test run: 4 lumi: 0 event: 1000123456792
+ERange1 PSet test '1:2:1000123456789-2:3:1000123456790'
+ERange2 PSet test '3:1000123456791-4:1000123456792'
+ERange3 PSet test '5:6:1000123456793-5:6:1000123456793'
+ERange4 PSet test '7:8:1000123456794-9:10:1000123456795'
+ERange5 PSet test '11:1000123456796-12:1000123456797'
+VEventID PSet test run: 1 lumi: 1 event: 1000123456789
+VEventID PSet test run: 2 lumi: 0 event: 1000123456790
+VEventID PSet test run: 3 lumi: 3 event: 1000123456791
+VERange2 PSet test '1:2:1000123456789-2:3:1000123456790'
+VERange2 PSet test '1:2-4:1000123456789'
+VERange2 PSet test '3:1000123456791-4:1000123456792'
+VERange2 PSet test '11:1000123456796-12:1000123456797'

--- a/FWCore/MessageLogger/interface/JobReport.h
+++ b/FWCore/MessageLogger/interface/JobReport.h
@@ -81,6 +81,7 @@ Changes Log 1: 2009/01/14 10:29:00, Natalia Garcia Nebot
         and /proc/meminfo files and Memory statistics
 */
 
+#include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
 #include "FWCore/Utilities/interface/InputType.h"
 
 #include <atomic>
@@ -317,14 +318,14 @@ namespace edm {
       /// the file identified by the given Token.
       // CMS-THREADING Current implementation requires an instance of an
       // OuputModule run on only one thread at a time.
-      void eventWrittenToFile(Token fileToken, unsigned int run, unsigned int event);
+      void eventWrittenToFile(Token fileToken, RunNumber_t run, EventNumber_t event);
 
       /// Report that the output file identified by the given Token has
       /// been closed. An exception will be thrown if the given Token
       /// was not obtained from outputFileOpened.
       void outputFileClosed(Token fileToken);
 
-      void reportSkippedEvent(unsigned int run, unsigned int event);
+      void reportSkippedEvent(RunNumber_t run, EventNumber_t event);
 
       /// API for reporting a Run to the job report.
       /// for output files, call only if Run is written to

--- a/FWCore/MessageLogger/src/JobReport.cc
+++ b/FWCore/MessageLogger/src/JobReport.cc
@@ -504,7 +504,7 @@ namespace edm {
   }
 
   void
-  JobReport::eventWrittenToFile(JobReport::Token fileToken, unsigned int /*run*/, unsigned int) {
+  JobReport::eventWrittenToFile(JobReport::Token fileToken, RunNumber_t /*run*/, EventNumber_t) {
     JobReport::OutputFile& f = impl_->getOutputFileForToken(fileToken);
     ++f.numEventsWritten;
   }
@@ -517,7 +517,7 @@ namespace edm {
   }
 
   void
-  JobReport::reportSkippedEvent(unsigned int run, unsigned int event) {
+  JobReport::reportSkippedEvent(RunNumber_t run, EventNumber_t event) {
     if(impl_->ost_) {
       std::ostream& msg = *(impl_->ost_);
       {

--- a/FWCore/Modules/src/NavigateEventsLooper.cc
+++ b/FWCore/Modules/src/NavigateEventsLooper.cc
@@ -93,7 +93,7 @@ namespace edm {
 
     std::cout << "(3) stop loop\n";
     std::cout << "(4) stop process" << std::endl;
-    int x;
+    long long int x;
 
     bool inputFailed = false;
     do {

--- a/FWCore/ParameterSet/python/Types.py
+++ b/FWCore/ParameterSet/python/Types.py
@@ -397,6 +397,8 @@ class EventRange(_ParameterTypeBase):
             eevent = endParts[1]             
         else:
             raise RuntimeError('EventRange ctor must have 4 or 6 arguments')
+        # note int will return a long if the value is too large to fit in
+        # a smaller type
         return EventRange(int(brun), int(blumi), int(bevent),
                           int(erun), int(elumi), int(eevent))
 

--- a/FWCore/ParameterSet/src/types.cc
+++ b/FWCore/ParameterSet/src/types.cc
@@ -741,7 +741,7 @@ static void
     assert(tokens.size() == 2 || tokens.size() == 3);
     unsigned int run = strtoul(tokens[0].c_str(), 0, 0);
     unsigned int lumi = (tokens.size() == 2 ? 0 : strtoul(tokens[1].c_str(), 0, 0));
-    unsigned int event = strtoul(tokens[tokens.size() - 1].c_str(), 0, 0);
+    unsigned long long event = strtoull(tokens[tokens.size() - 1].c_str(), 0, 0);
     to = edm::EventID(run, lumi, event);
 
     return true;

--- a/FWCore/ParameterSet/test/ps_t.cppunit.cc
+++ b/FWCore/ParameterSet/test/ps_t.cppunit.cc
@@ -234,19 +234,19 @@ void testps::eventIDTest()
   testbody<edm::EventID>(edm::EventID::firstValidEvent());
   testbody<edm::EventID>(edm::EventID(2,3,4));
   testbody<edm::EventID>(edm::EventID(2,3,edm::EventID::maxEventNumber()));
-  testbody<edm::EventID>(edm::EventID(edm::EventID::maxEventNumber(),edm::EventID::maxEventNumber(),edm::EventID::maxEventNumber()));
+  testbody<edm::EventID>(edm::EventID(edm::EventID::maxRunNumber(), edm::EventID::maxLuminosityBlockNumber(), edm::EventID::maxEventNumber()));
 }
 
 void testps::eventRangeTest()
 {
   testbody<edm::EventRange>(edm::EventRange());
   testbody<edm::EventRange>(edm::EventRange(1,1,1,
-                                            edm::EventID::maxEventNumber(),edm::EventID::maxEventNumber(),edm::EventID::maxEventNumber()));
+                                            edm::EventID::maxRunNumber(), edm::EventID::maxLuminosityBlockNumber(), edm::EventID::maxEventNumber()));
   testbody<edm::EventRange>(edm::EventRange(2,3,4,2,3,10));
 
 
   testbody<edm::EventRange>(edm::EventRange(1,0,1,
-                                            edm::EventID::maxEventNumber(),0,edm::EventID::maxEventNumber()));
+                                            edm::EventID::maxRunNumber(),0,edm::EventID::maxEventNumber()));
   testbody<edm::EventRange>(edm::EventRange(2,0,4,2,0,10));
 }
 
@@ -255,13 +255,13 @@ void testps::vEventRangeTest()
   testbody<std::vector<edm::EventRange> >(std::vector<edm::EventRange>());
   testbody<std::vector<edm::EventRange> >(std::vector<edm::EventRange>(1, 
                                                                        edm::EventRange(1,1,1,
-                                                                                       edm::EventID::maxEventNumber(),
-                                                                                       edm::EventID::maxEventNumber(),
+                                                                                       edm::EventID::maxRunNumber(),
+                                                                                       edm::EventID::maxLuminosityBlockNumber(),
                                                                                        edm::EventID::maxEventNumber())));
 
   testbody<std::vector<edm::EventRange> >(std::vector<edm::EventRange>(1, 
                                                                        edm::EventRange(1,0,1,
-                                                                                       edm::EventID::maxEventNumber(),
+                                                                                       edm::EventID::maxRunNumber(),
                                                                                        0,
                                                                                        edm::EventID::maxEventNumber())));
 

--- a/FWCore/PythonParameterSet/interface/PythonParameterSet.h
+++ b/FWCore/PythonParameterSet/interface/PythonParameterSet.h
@@ -11,6 +11,7 @@
 #include "DataFormats/Provenance/interface/LuminosityBlockID.h"
 #include "DataFormats/Provenance/interface/LuminosityBlockRange.h"
 #include "DataFormats/Provenance/interface/EventID.h"
+#include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
 
 #include <string>
 #include <vector>
@@ -95,7 +96,7 @@ public:
       return edm::ESInputTag(module, data);
    }
 
-   edm::EventID newEventID(unsigned int run, unsigned int lumi, unsigned int event) {
+   edm::EventID newEventID(edm::RunNumber_t run, edm::LuminosityBlockNumber_t lumi, edm::EventNumber_t event) {
     return edm::EventID(run, lumi, event);
   }
 
@@ -108,8 +109,8 @@ public:
     return edm::LuminosityBlockRange(start, startSub, end, endSub);
   }
 
-  edm::EventRange newEventRange(unsigned int start, unsigned int startLumi, unsigned int startSub,
-                                unsigned int end,   unsigned int endLumi, unsigned int endSub) {
+  edm::EventRange newEventRange(edm::RunNumber_t start, edm::LuminosityBlockNumber_t startLumi, edm::EventNumber_t startSub,
+                                edm::RunNumber_t end,   edm::LuminosityBlockNumber_t endLumi, edm::EventNumber_t endSub) {
     return edm::EventRange(start, startLumi, startSub, end, endLumi, endSub);
   }
 

--- a/FWCore/PythonParameterSet/src/PythonModule.h
+++ b/FWCore/PythonParameterSet/src/PythonModule.h
@@ -9,6 +9,7 @@
 #include "DataFormats/Provenance/interface/LuminosityBlockID.h"
 #include "DataFormats/Provenance/interface/LuminosityBlockRange.h"
 #include "DataFormats/Provenance/interface/EventID.h"
+#include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
 #include "FWCore/Utilities/interface/ESInputTag.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -48,7 +49,7 @@ BOOST_PYTHON_MODULE(libFWCoreParameterSet)
    .def("data",  &edm::ESInputTag::data, boost::python::return_value_policy<boost::python::copy_const_reference>())
    ;
 
-   boost::python::class_<edm::EventID>("EventID", boost::python::init<unsigned int, unsigned int, unsigned int>())
+   boost::python::class_<edm::EventID>("EventID", boost::python::init<edm::RunNumber_t, edm::LuminosityBlockNumber_t, edm::EventNumber_t>())
       .def("run",   &edm::EventID::run)
       .def("luminosityBlock", &edm::EventID::luminosityBlock)
       .def("event", &edm::EventID::event)
@@ -71,7 +72,7 @@ BOOST_PYTHON_MODULE(libFWCoreParameterSet)
       .def("endSub",   &edm::LuminosityBlockRange::endLumi)
   ;
 
-  boost::python::class_<edm::EventRange>("EventRange", boost::python::init<unsigned int, unsigned int, unsigned int, unsigned int, unsigned int, unsigned int>())
+  boost::python::class_<edm::EventRange>("EventRange", boost::python::init<edm::RunNumber_t, edm::LuminosityBlockNumber_t, edm::EventNumber_t, edm::RunNumber_t, edm::LuminosityBlockNumber_t, edm::EventNumber_t>())
       .def("start",     &edm::EventRange::startRun)
       .def("startLumi", &edm::EventRange::startLumi)
       .def("startSub",  &edm::EventRange::startEvent)

--- a/FWCore/Sources/interface/EventSkipperByID.h
+++ b/FWCore/Sources/interface/EventSkipperByID.h
@@ -5,6 +5,8 @@
 #include "DataFormats/Provenance/interface/EventRange.h"
 #include "DataFormats/Provenance/interface/LuminosityBlockID.h"
 #include "DataFormats/Provenance/interface/LuminosityBlockRange.h"
+#include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
+
 #include <memory>
 #include <vector>
 

--- a/FWCore/Sources/interface/ProducerSourceBase.h
+++ b/FWCore/Sources/interface/ProducerSourceBase.h
@@ -10,6 +10,7 @@
 #include "DataFormats/Provenance/interface/EventID.h"
 #include "DataFormats/Provenance/interface/Timestamp.h"
 #include "DataFormats/Provenance/interface/RunID.h"
+#include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
 
 #include <memory>
 
@@ -67,7 +68,7 @@ namespace edm {
 
     unsigned int numberEventsInThisRun_;
     unsigned int numberEventsInThisLumi_;
-    unsigned int const zerothEvent_;
+    EventNumber_t const zerothEvent_;
     EventID eventID_;
     EventID origEventID_;
     bool isRealData_;

--- a/FWCore/Sources/src/EventSkipperByID.cc
+++ b/FWCore/Sources/src/EventSkipperByID.cc
@@ -12,7 +12,8 @@ namespace edm {
 	// calls can and should be deleted from the code.
         firstRun_(pset.getUntrackedParameter<unsigned int>("firstRun", 1U)),
         firstLumi_(pset.getUntrackedParameter<unsigned int>("firstLuminosityBlock", 0U)),
-        firstEvent_(pset.getUntrackedParameter<unsigned int>("firstEvent", 1U)),
+        firstEvent_(pset.existsAs<unsigned int>("firstEvent", false) ? pset.getUntrackedParameter<unsigned int>("firstEvent") :
+                                                                       pset.getUntrackedParameter<unsigned long long>("firstEvent", 1U)),
         whichLumisToSkip_(pset.getUntrackedParameter<std::vector<LuminosityBlockRange> >("lumisToSkip", std::vector<LuminosityBlockRange>())),
         whichLumisToProcess_(pset.getUntrackedParameter<std::vector<LuminosityBlockRange> >("lumisToProcess", std::vector<LuminosityBlockRange>())),
         whichEventsToSkip_(pset.getUntrackedParameter<std::vector<EventRange> >("eventsToSkip",std::vector<EventRange>())),
@@ -20,6 +21,7 @@ namespace edm {
         skippingLumis_(!(whichLumisToSkip_.empty() && whichLumisToProcess_.empty())),
         skippingEvents_(!(whichEventsToSkip_.empty() && whichEventsToProcess_.empty())),
         somethingToSkip_(skippingLumis_ || skippingEvents_ || !(firstRun_ <= 1U && firstLumi_ <= 1U && firstEvent_ <= 1U)) {
+
     sortAndRemoveOverlaps(whichLumisToSkip_);
     sortAndRemoveOverlaps(whichLumisToProcess_);
     sortAndRemoveOverlaps(whichEventsToSkip_);
@@ -113,8 +115,11 @@ namespace edm {
         ->setComment("Skip any run with run number < 'firstRun'.");
     desc.addUntracked<unsigned int>("firstLuminosityBlock", 0U)
         ->setComment("Skip any lumi in run 'firstRun' with lumi number < 'firstLuminosityBlock'.");
-    desc.addUntracked<unsigned int>("firstEvent", 1U)
-        ->setComment("If 'firstLuminosityBlock' == 0, skip any event in run 'firstRun' with event number < 'firstEvent'.\n"
+
+    desc.addNode( edm::ParameterDescription<unsigned int>("firstEvent", 1U, false) xor
+                  edm::ParameterDescription<unsigned long long>("firstEvent", 1ULL, false))
+        ->setComment("'firstEvent' is an XOR group because it can have type uint32 or uint64, default:1\n"
+                     "If 'firstLuminosityBlock' == 0, skip any event in run 'firstRun' with event number < 'firstEvent'.\n"
                      "If 'firstLuminosityBlock' != 0, skip any event in lumi 'firstRun:firstLuminosityBlock' with event number < 'firstEvent'.");
 
     std::vector<LuminosityBlockRange> defaultLumis;

--- a/FWCore/Sources/src/ProducerSourceBase.cc
+++ b/FWCore/Sources/src/ProducerSourceBase.cc
@@ -27,7 +27,8 @@ namespace edm {
       eventCreationDelay_(pset.getUntrackedParameter<unsigned int>("eventCreationDelay", 0)),
       numberEventsInThisRun_(0),
       numberEventsInThisLumi_(0),
-      zerothEvent_(pset.getUntrackedParameter<unsigned int>("firstEvent", 1) - 1),
+      zerothEvent_(pset.existsAs<unsigned int>("firstEvent", false) ? pset.getUntrackedParameter<unsigned int>("firstEvent", 1) - 1 :
+                                                                      pset.getUntrackedParameter<unsigned long long>("firstEvent", 1) - 1),
       eventID_(pset.getUntrackedParameter<unsigned int>("firstRun", 1), pset.getUntrackedParameter<unsigned int>("firstLuminosityBlock", 1), zerothEvent_),
       origEventID_(eventID_),
       isRealData_(realData),
@@ -232,7 +233,12 @@ namespace edm {
     desc.addUntracked<unsigned long long>("firstTime", 1)->setComment("Time before first event (ns) (for timestamp).");
     desc.addUntracked<unsigned long long>("timeBetweenEvents", kNanoSecPerSec/kAveEventPerSec)->setComment("Time between consecutive events (ns) (for timestamp).");
     desc.addUntracked<unsigned int>("eventCreationDelay", 0)->setComment("Real time delay between generation of consecutive events (ms).");
-    desc.addUntracked<unsigned int>("firstEvent", 1)->setComment("Event number of first event to generate.");
+
+    desc.addNode( edm::ParameterDescription<unsigned int>("firstEvent", 1U, false) xor
+                  edm::ParameterDescription<unsigned long long>("firstEvent", 1ULL, false))
+        ->setComment("'firstEvent' is an XOR group because it can have type uint32 or uint64, default:1\n"
+                     "Event number of first event to generate.");
+
     desc.addUntracked<unsigned int>("firstLuminosityBlock", 1)->setComment("Luminosity block number of first lumi to generate.");
     desc.addUntracked<unsigned int>("firstRun", 1)->setComment("Run number of first run to generate.");
     InputSource::fillDescription(desc);

--- a/IOPool/Input/src/RootFile.h
+++ b/IOPool/Input/src/RootFile.h
@@ -119,7 +119,7 @@ namespace edm {
     bool modifiedIDs() const {return daqProvenanceHelper_.get() != 0;}
     std::unique_ptr<FileBlock> createFileBlock() const;
     bool setEntryAtItem(RunNumber_t run, LuminosityBlockNumber_t lumi, EventNumber_t event) {
-      return event ? setEntryAtEvent(run, lumi, event) : (lumi ? setEntryAtLumi(run, lumi) : setEntryAtRun(run));
+      return (event != 0) ? setEntryAtEvent(run, lumi, event) : (lumi ? setEntryAtLumi(run, lumi) : setEntryAtRun(run));
     }
     bool containsItem(RunNumber_t run, LuminosityBlockNumber_t lumi, EventNumber_t event) const;
     bool setEntryAtEvent(RunNumber_t run, LuminosityBlockNumber_t lumi, EventNumber_t event);

--- a/IOPool/SecondaryInput/test/SecondaryProducer.cc
+++ b/IOPool/SecondaryInput/test/SecondaryProducer.cc
@@ -65,7 +65,7 @@ namespace edm {
 
     produces<edmtest::ThingCollection>();
     produces<edmtest::OtherThingCollection>("testUserTag");
-    consumes<edmtest::IntProduct>(edm::InputTag{"EventNumber"});
+    consumes<edmtest::UInt64Product>(edm::InputTag{"EventNumber"});
   }
 
   void SecondaryProducer::beginJob() {
@@ -123,19 +123,19 @@ namespace edm {
 
     EventNumber_t en = eventPrincipal.id().event();
     // Check that secondary source products are retrieved from the same event as the EventAuxiliary
-    BasicHandle bhandle = eventPrincipal.getByLabel(PRODUCT_TYPE, TypeID(typeid(edmtest::IntProduct)),
+    BasicHandle bhandle = eventPrincipal.getByLabel(PRODUCT_TYPE, TypeID(typeid(edmtest::UInt64Product)),
                                                     "EventNumber",
                                                     "",
                                                     "",
                                                     nullptr,
                                                     nullptr);
     assert(bhandle.isValid());
-    Handle<edmtest::IntProduct> handle;
-    convert_handle<edmtest::IntProduct>(std::move(bhandle), handle);
+    Handle<edmtest::UInt64Product> handle;
+    convert_handle<edmtest::UInt64Product>(std::move(bhandle), handle);
     assert(static_cast<EventNumber_t>(handle->value) == en);
 
     // Check that primary source products are retrieved from the same event as the EventAuxiliary
-    e.getByLabel<edmtest::IntProduct>("EventNumber", handle);
+    e.getByLabel<edmtest::UInt64Product>("EventNumber", handle);
     assert(static_cast<EventNumber_t>(handle->value) == e.id().event());
 
     WrapperBase const* ep = eventPrincipal.getByLabel(PRODUCT_TYPE, TypeID(typeid(TC)),

--- a/IOPool/Streamer/bin/DiagStreamerFile.cpp
+++ b/IOPool/Streamer/bin/DiagStreamerFile.cpp
@@ -81,7 +81,7 @@ void readfile(std::string filename, std::string outfile) {
   uint32 num_goodevents(0);
   uint32 num_duplevents(0);
   std::vector<unsigned char> compress_buffer(7000000);
-  std::map<uint32, uint32> seenEventMap;
+  std::map<uint64, uint32> seenEventMap;
   bool output(false);
   if(outfile != "/dev/null") {
     output = true;

--- a/IOPool/Streamer/interface/EventMessage.h
+++ b/IOPool/Streamer/interface/EventMessage.h
@@ -46,6 +46,8 @@ eventdatalength 4 | eventdata blob {variable}
 
 Protocol Version 10: identical to version 9, but incremented to keep in sync with init msg version 
 
+Protocol Version 11: identical to version 10, except event changed from 4 bytes to 8 bytes
+
 */
 
 #ifndef IOPool_Streamer_EventMessage_h
@@ -61,7 +63,7 @@ struct EventHeader
   Header header_;
   uint8 protocolVersion_;
   char_uint32 run_;
-  char_uint32 event_;
+  char_uint64 event_;
   char_uint32 lumi_;
   char_uint32 origDataSize_;
   char_uint32 outModId_;
@@ -83,7 +85,7 @@ public:
   uint32 headerSize() const {return event_start_-buf_;}
   uint32 protocolVersion() const;
   uint32 run() const;
-  uint32 event() const;
+  uint64 event() const;
   uint32 lumi() const;
   uint32 origDataSize() const;
   uint32 outModId() const;
@@ -115,4 +117,3 @@ private:
 };
 
 #endif
-

--- a/IOPool/Streamer/interface/EventMsgBuilder.h
+++ b/IOPool/Streamer/interface/EventMsgBuilder.h
@@ -9,7 +9,7 @@ class EventMsgBuilder
 {
 public:
   EventMsgBuilder(void* buf, uint32 size,
-                  uint32 run, uint32 event, uint32 lumi, uint32 outModId,
+                  uint32 run, uint64 event, uint32 lumi, uint32 outModId,
                   uint32 droppedEventsCount,
                   std::vector<bool>& l1_bits,
                   uint8* hlt_bits, uint32 hlt_bit_count, 

--- a/IOPool/Streamer/interface/FRDEventMessage.h
+++ b/IOPool/Streamer/interface/FRDEventMessage.h
@@ -13,6 +13,18 @@
  * 08-Aug-2008 - KAB  - Initial Implementation
  * 06-Oct-2008 - KAB  - Added version number and lumi block number (version #2)
  * 14-Nov-2013 - RKM  - Added event size, adler32 and padding size (version #3)
+ * 15-Oct-2014 - WDD  - Event number from 32 bits to 64 bits (version #4)
+ *
+ * Version 4 Format:
+ *   uint32 - format version number
+ *   uint32 - run number
+ *   uint32 - lumi number
+ *   uint32 - event number low 32 bits
+ *   uint32 - event number high 32 bits
+ *   uint32 - event size
+ *   uint32 - padding size needed to fill memory page size (_SC_PAGE_SIZE)
+ *   uint32 - adler32 checksum of FED data (excluding event header)
+ *   variable size - FED data
  *
  * Version 3 Format:
  *   uint32 - format version number
@@ -34,6 +46,18 @@
  */
 
 #include "IOPool/Streamer/interface/MsgTools.h"
+
+struct FRDEventHeader_V4
+{
+  uint32 version_;
+  uint32 run_;
+  uint32 lumi_;
+  uint32 eventLow_;
+  uint32 eventHigh_;
+  uint32 eventSize_;
+  uint32 paddingSize_;
+  uint32 adler32_;
+};
 
 struct FRDEventHeader_V3
 {
@@ -73,7 +97,7 @@ class FRDEventMsgView
   uint32 version() const { return version_; }
   uint32 run() const { return run_; }
   uint32 lumi() const { return lumi_; }
-  uint32 event() const { return event_; }
+  uint64 event() const { return event_; }
   uint32 eventSize() const { return eventSize_; }
   uint32 paddingSize() const { return paddingSize_; }
   uint32 adler32() const { return adler32_; }
@@ -86,7 +110,7 @@ class FRDEventMsgView
   uint32 version_;
   uint32 run_;
   uint32 lumi_;
-  uint32 event_;
+  uint64 event_;
   uint32 eventSize_;
   uint32 paddingSize_;
   uint32 adler32_;

--- a/IOPool/Streamer/interface/InitMessage.h
+++ b/IOPool/Streamer/interface/InitMessage.h
@@ -26,6 +26,8 @@ Protocol Version 9: identical to version 8, but incremented to keep in sync with
 Protocol Version 10: removed hostname
 code 1 | size 4 | protocol version 1 | pset 16 | run 4 | Init Header Size 4| Event Header Size 4| releaseTagLength 1 | ReleaseTag var| processNameLength 1 | processName var| outputModuleLabelLength 1 | outputModuleLabel var | outputModuleId 4 | HLT Trig count 4| HLT Trig Length 4 | HLT Trig names var | HLT Selection count 4| HLT Selection Length 4 | HLT Selection names var | L1 Trig Count 4| L1 TrigName len 4| L1 Trig Names var | adler32 chksum 4| desc legth 4 | description blob var
 
+Protocol Version 11: identical to version 10, but incremented to keep in sync with event msg protocol version
+
 */
 
 #ifndef IOPool_Streamer_InitMessage_h
@@ -36,7 +38,7 @@ code 1 | size 4 | protocol version 1 | pset 16 | run 4 | Init Header Size 4| Eve
 
 struct Version
 {
-  Version(const uint8* pset):protocol_(10)
+  Version(const uint8* pset):protocol_(11)
   { std::copy(pset,pset+sizeof(pset_id_),&pset_id_[0]); }
 
   uint8 protocol_; // version of the protocol
@@ -129,4 +131,3 @@ private:
 };
 
 #endif
-

--- a/IOPool/Streamer/interface/Messages.h
+++ b/IOPool/Streamer/interface/Messages.h
@@ -211,7 +211,7 @@ namespace edm {
 
     edm::EventNumber_t getEventNumber() const 
     {
-      assert(sizeof(edm::EventNumber_t) == sizeof(int) && "event ID streaming only knows how to work with 4 byte event ID numbers right now");
+      // assert(sizeof(edm::EventNumber_t) == sizeof(int) && "event ID streaming only knows how to work with 4 byte event ID numbers right now");
       return decodeInt(head_->event_num_);
     }
 
@@ -223,7 +223,7 @@ namespace edm {
 
     edm::RunNumber_t getRunNumber() const
     {
-      assert(sizeof(edm::EventNumber_t) == sizeof(int) && "event ID streaming only knows how to work with 4 byte event ID numbers right now");
+      // assert(sizeof(edm::EventNumber_t) == sizeof(int) && "event ID streaming only knows how to work with 4 byte event ID numbers right now");
       return decodeInt(head_->run_num_);
     }
 

--- a/IOPool/Streamer/src/EventMessage.cc
+++ b/IOPool/Streamer/src/EventMessage.cc
@@ -15,7 +15,7 @@ EventMsgView::EventMsgView(void* buf):
 
   // 18-Jul-2008, wmtan - payload changed for version 7.
   // So we no longer support previous formats.
-  if (protocolVersion() != 10) {
+  if (protocolVersion() != 11) {
     throw cms::Exception("EventMsgView", "Invalid Message Version:")
       << "Only message version 10 is currently supported \n"
       << "(invalid value = " << protocolVersion() << ").\n"
@@ -76,10 +76,10 @@ uint32 EventMsgView::run() const
   return convert32(h->run_);
 }
 
-uint32 EventMsgView::event() const
+uint64 EventMsgView::event() const
 {
   EventHeader* h = (EventHeader*)buf_;
-  return convert32(h->event_);
+  return convert64(h->event_);
 }
 
 uint32 EventMsgView::lumi() const
@@ -138,5 +138,3 @@ std::string EventMsgView::hostName() const
      return host_name;
    }
 }
-
-

--- a/IOPool/Streamer/src/EventMsgBuilder.cc
+++ b/IOPool/Streamer/src/EventMsgBuilder.cc
@@ -7,7 +7,7 @@
 #define MAX_HOSTNAME_LEN 25
 
 EventMsgBuilder::EventMsgBuilder(void* buf, uint32 size,
-                                 uint32 run, uint32 event, uint32 lumi,
+                                 uint32 run, uint64 event, uint32 lumi,
                                  uint32 outModId, uint32 droppedEventsCount,
                                  std::vector<bool>& l1_bits,
                                  uint8* hlt_bits, uint32 hlt_bit_count, 
@@ -15,7 +15,7 @@ EventMsgBuilder::EventMsgBuilder(void* buf, uint32 size,
   buf_((uint8*)buf),size_(size)
 {
   EventHeader* h = (EventHeader*)buf_;
-  h->protocolVersion_ = 10;
+  h->protocolVersion_ = 11;
   convert(run,h->run_);
   convert(event,h->event_);
   convert(lumi,h->lumi_);

--- a/IOPool/Streamer/src/FRDEventMessage.cc
+++ b/IOPool/Streamer/src/FRDEventMessage.cc
@@ -7,15 +7,6 @@
  * to the HLT, hopefully this class can be used or upgraded to handle those
  * events as well.
  *
- * 08-Aug-2008 - KAB  - Initial Implementation
- * 06-Oct-2008 - KAB  - Added lumi block number
- *
- * Format:
- *   uint32 - run number
- *   uint32 - lumi number
- *   uint32 - event number
- *   1024 * uint32 - size values for all 1024 FED buffers
- *   variable size - FED data
  */
 
 #include "IOPool/Streamer/interface/FRDEventMessage.h"
@@ -65,9 +56,22 @@ FRDEventMsgView::FRDEventMsgView(void* buf)
   }
 
   // event number
-  event_ = *bufPtr;
-  size_ += sizeof(uint32);
-  ++bufPtr;
+  if (version_ >= 4) {
+    uint64 eventLow =  *bufPtr;
+    size_ += sizeof(uint32);
+    ++bufPtr;
+
+    uint64 eventHigh =  *bufPtr;
+    size_ += sizeof(uint32);
+    ++bufPtr;
+
+    event_ = (eventHigh << 32) | eventLow;
+
+  } else {
+    event_ = *bufPtr;
+    size_ += sizeof(uint32);
+    ++bufPtr;
+  }
 
   if (version_ >= 3) {
       // event size

--- a/IOPool/Streamer/src/StreamerInputFile.cc
+++ b/IOPool/Streamer/src/StreamerInputFile.cc
@@ -256,7 +256,7 @@ namespace edm {
       eventRead = true;
       if(eventSkipperByID_) {
         EventHeader *evh = (EventHeader *)(&eventBuf_[0]);
-        if(eventSkipperByID_->skipIt(convert32(evh->run_), convert32(evh->lumi_), convert32(evh->event_))) {
+        if(eventSkipperByID_->skipIt(convert32(evh->run_), convert32(evh->lumi_), convert64(evh->event_))) {
           eventRead = false;
         }
       }

--- a/IOPool/Streamer/test/NewStreamCopy2_cfg.py
+++ b/IOPool/Streamer/test/NewStreamCopy2_cfg.py
@@ -12,11 +12,8 @@ process.maxEvents = cms.untracked.PSet(
 )
 
 process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring('file:myout.root')
-)
-
-process.a1 = cms.EDAnalyzer("StreamThingAnalyzer",
-    product_to_get = cms.string('m1')
+    fileNames = cms.untracked.vstring('file:myout.root'),
+    firstEvent = cms.untracked.uint64(10123456792)
 )
 
 process.test = cms.EDAnalyzer('RunLumiEventAnalyzer',
@@ -24,9 +21,9 @@ process.test = cms.EDAnalyzer('RunLumiEventAnalyzer',
     expectedRunLumiEvents = cms.untracked.vuint64(
       1, 0, 0,
       1, 1, 0,
-      1, 1, 10123456789,
-      1, 1, 10123456790,
-      1, 1, 10123456791,
+      #1, 1, 10123456789,
+      #1, 1, 10123456790,
+      #1, 1, 10123456791,
       1, 1, 10123456792,
       1, 1, 10123456793,
       1, 1, 10123456794,
@@ -77,18 +74,7 @@ process.test = cms.EDAnalyzer('RunLumiEventAnalyzer',
       1, 1, 0,
       1, 0, 0
     ),
-    expectedEndingIndex = cms.untracked.int32(162)
+    expectedEndingIndex = cms.untracked.int32(153)
 )
 
-process.out = cms.OutputModule("EventStreamFileWriter",
-    fileName = cms.untracked.string('teststreamfile_copy.dat'),
-    compression_level = cms.untracked.int32(1),
-    use_compression = cms.untracked.bool(True),
-    max_event_size = cms.untracked.int32(7000000)
-)
-
-process.outp = cms.OutputModule("PoolOutputModule",
-    fileName = cms.untracked.string('myout2.root')
-)
-
-process.e = cms.EndPath(process.test*process.a1*process.out*process.outp)
+process.e = cms.EndPath(process.test)

--- a/IOPool/Streamer/test/NewStreamIn_cfg.py
+++ b/IOPool/Streamer/test/NewStreamIn_cfg.py
@@ -8,7 +8,8 @@ process.options = FWCore.Framework.test.cmsExceptionsFatal_cff.options
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
 
 process.source = cms.Source("NewEventStreamFileReader",
-    fileNames = cms.untracked.vstring('file:teststreamfile.dat'),
+    fileNames = cms.untracked.vstring('file:teststreamfile.dat')
+    #firstEvent = cms.untracked.uint64(10123456835)
 )
 
 process.a1 = cms.EDAnalyzer("StreamThingAnalyzer",

--- a/IOPool/Streamer/test/NewStreamOut_cfg.py
+++ b/IOPool/Streamer/test/NewStreamOut_cfg.py
@@ -11,7 +11,9 @@ process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(50)
 )
 
-process.source = cms.Source("EmptySource")
+process.source = cms.Source("EmptySource",
+    firstEvent = cms.untracked.uint64(10123456789)
+)
 
 process.m1 = cms.EDProducer("StreamThingProducer",
     instance_count = cms.int32(5),

--- a/IOPool/Streamer/test/RunSimple_NewStreamer.sh
+++ b/IOPool/Streamer/test/RunSimple_NewStreamer.sh
@@ -19,6 +19,7 @@ cd ${OUTDIR}
 cmsRun --parameter-set NewStreamOut_cfg.py > out 2>&1 || die "cmsRun NewStreamOut_cfg.py" $?
 cmsRun --parameter-set NewStreamIn_cfg.py  > in  2>&1 || die "cmsRun NewStreamIn_cfg.py" $?
 cmsRun --parameter-set NewStreamCopy_cfg.py  > copy  2>&1 || die "cmsRun NewStreamCopy_cfg.py" $?
+cmsRun --parameter-set NewStreamCopy2_cfg.py  > copy2  2>&1 || die "cmsRun NewStreamCopy2_cfg.py" $?
 
 # echo "CHECKSUM = 1" > out
 # echo "CHECKSUM = 1" > in

--- a/PhysicsTools/FWLite/interface/Scanner.h
+++ b/PhysicsTools/FWLite/interface/Scanner.h
@@ -120,7 +120,7 @@ namespace fwlite {
                         if (!scanner.test(&vals[j])) continue;
                         if (printFullEventId_) {
                             const edm::EventAuxiliary &id = event_->eventAuxiliary();
-                            printf(" : %9d : %4d : %9d : %3lu", id.run(), id.luminosityBlock(), id.event(), (unsigned long)j);
+                            printf(" : %9u : %4u : %9llu : %3lu", id.run(), id.luminosityBlock(), id.event(), (unsigned long)j);
                         } else {
 			    printf(" : %5d : %3lu", iev, (unsigned long)j);
                         }

--- a/RecoLocalMuon/RPCRecHit/test/RPCRecHitReader.cc
+++ b/RecoLocalMuon/RPCRecHit/test/RPCRecHitReader.cc
@@ -263,7 +263,7 @@ void RPCRecHitReader::analyze(const edm::Event & event, const edm::EventSetup& e
   if(_mapTrig.size() == 0) return;
 
   char folder[128];
-  sprintf(folder,"HistoXYFit_%d",event.id().event());
+  sprintf(folder,"HistoXYFit_%llu",event.id().event());
   TH1F* histoXYFit = new TH1F(folder,folder,300,-300,300);
 
   for(unsigned int i = 0; i < globalX.size(); ++i){

--- a/RecoMuon/L2MuonIsolationProducer/test/L2MuonIsolationAnalyzer.cc
+++ b/RecoMuon/L2MuonIsolationProducer/test/L2MuonIsolationAnalyzer.cc
@@ -213,7 +213,7 @@ void L2MuonIsolationAnalyzer::analyze(const Event & event, const EventSetup& eve
       }
     }
   }
-  Puts("L2MuonIsolationAnalyzer>>> Run: %ld, Event %ld, number of muons %d"
+  Puts("L2MuonIsolationAnalyzer>>> Run: %llu, Event %llu, number of muons %d"
        , event.id().run(), event.id().event(), depMap->size());
 }
 

--- a/RecoMuon/L3MuonIsolationProducer/test/L3MuonIsolationAnalyzer.cc
+++ b/RecoMuon/L3MuonIsolationProducer/test/L3MuonIsolationAnalyzer.cc
@@ -211,7 +211,7 @@ void L3MuonIsolationAnalyzer::analyze(const Event & event, const EventSetup& eve
     }
 
   }
-  Puts("L3MuonIsolationAnalyzer>>> Run: %ld, Event %ld, number of muons %d"
+  Puts("L3MuonIsolationAnalyzer>>> Run: %llu, Event %llu, number of muons %d"
                  , event.id().run(), event.id().event(), depMap->size());
 }
 


### PR DESCRIPTION
Change the event number in the EventID from 32 bits to
64 bits. This includes only changes for the Core part
of CMSSW. There are a couple hundred places outside the
Core code where this value is being assigned to types
with less than 64 bits that will also need changes to
work properly with data that has an event number exceeding
32 bits. Includes tests for the changes in the Core code.
