### PR TITLE
Avoid unnecessary introspection for MVAComputer

### DIFF
--- a/CondFormats/PhysicsToolsObjects/interface/MVAComputer.h
+++ b/CondFormats/PhysicsToolsObjects/interface/MVAComputer.h
@@ -14,6 +14,7 @@
 
 #include "CondFormats/Serialization/interface/Serializable.h"
 
+#include <memory>
 #include <string>
 #include <vector>
 #include <map>
@@ -54,6 +55,9 @@ class VarProcessor {
 
 	virtual ~VarProcessor() {}
 	virtual std::string getInstanceName() const;
+#ifndef __GCCXML__
+        virtual std::unique_ptr<VarProcessor> clone() const;
+#endif
 
   COND_SERIALIZABLE;
 };
@@ -73,17 +77,27 @@ class Variable {
 
 class ProcOptional : public VarProcessor {
     public:
+#ifndef __GCCXML__
+        virtual std::unique_ptr<VarProcessor> clone() const;
+#endif
 	std::vector<double>		neutralPos;
 
   COND_SERIALIZABLE;
 };
 
 class ProcCount : public VarProcessor {
+    public:
+#ifndef __GCCXML__
+        virtual std::unique_ptr<VarProcessor> clone() const;
+#endif
   COND_SERIALIZABLE;
 };
 
 class ProcClassed : public VarProcessor {
     public:
+#ifndef __GCCXML__
+        virtual std::unique_ptr<VarProcessor> clone() const;
+#endif
 	unsigned int			nClasses;
 
   COND_SERIALIZABLE;
@@ -91,6 +105,9 @@ class ProcClassed : public VarProcessor {
 
 class ProcSplitter : public VarProcessor {
     public:
+#ifndef __GCCXML__
+        virtual std::unique_ptr<VarProcessor> clone() const;
+#endif
 	unsigned int			nFirst;
 
   COND_SERIALIZABLE;
@@ -98,6 +115,9 @@ class ProcSplitter : public VarProcessor {
 
 class ProcForeach : public VarProcessor {
     public:
+#ifndef __GCCXML__
+        virtual std::unique_ptr<VarProcessor> clone() const;
+#endif
 	unsigned int			nProcs;
 
   COND_SERIALIZABLE;
@@ -105,6 +125,9 @@ class ProcForeach : public VarProcessor {
 
 class ProcSort : public VarProcessor {
     public:
+#ifndef __GCCXML__
+        virtual std::unique_ptr<VarProcessor> clone() const;
+#endif
 	unsigned int			sortByIndex;
 	bool				descending;
 
@@ -113,6 +136,9 @@ class ProcSort : public VarProcessor {
 
 class ProcCategory : public VarProcessor {
     public:
+#ifndef __GCCXML__
+        virtual std::unique_ptr<VarProcessor> clone() const;
+#endif
 	typedef std::vector<double> BinLimits;
 
 	std::vector<BinLimits>		variableBinLimits;
@@ -123,6 +149,9 @@ class ProcCategory : public VarProcessor {
 
 class ProcNormalize : public VarProcessor {
     public:
+#ifndef __GCCXML__
+        virtual std::unique_ptr<VarProcessor> clone() const;
+#endif
 	std::vector<HistogramF>		distr;
 	int				categoryIdx;
 
@@ -131,6 +160,9 @@ class ProcNormalize : public VarProcessor {
 
 class ProcLikelihood : public VarProcessor {
     public:
+#ifndef __GCCXML__
+        virtual std::unique_ptr<VarProcessor> clone() const;
+#endif
 	class SigBkg {
 	    public:
 		HistogramF		background;
@@ -153,6 +185,9 @@ class ProcLikelihood : public VarProcessor {
 
 class ProcLinear : public VarProcessor {
     public:
+#ifndef __GCCXML__
+        virtual std::unique_ptr<VarProcessor> clone() const;
+#endif
 	std::vector<double>		coeffs;
 	double				offset;
 
@@ -161,6 +196,9 @@ class ProcLinear : public VarProcessor {
 
 class ProcMultiply : public VarProcessor {
     public:
+#ifndef __GCCXML__
+        virtual std::unique_ptr<VarProcessor> clone() const;
+#endif
 	typedef std::vector<unsigned int>	Config;
 
 	unsigned int			in;
@@ -171,6 +209,9 @@ class ProcMultiply : public VarProcessor {
 
 class ProcMatrix : public VarProcessor {
     public:
+#ifndef __GCCXML__
+        virtual std::unique_ptr<VarProcessor> clone() const;
+#endif
 	Matrix				matrix;
 
   COND_SERIALIZABLE;
@@ -178,6 +219,9 @@ class ProcMatrix : public VarProcessor {
 
 class ProcExternal : public VarProcessor {
     public:
+#ifndef __GCCXML__
+        virtual std::unique_ptr<VarProcessor> clone() const;
+#endif
 	virtual std::string getInstanceName() const;
 
 	std::string			method;
@@ -188,6 +232,9 @@ class ProcExternal : public VarProcessor {
 
 class ProcMLP : public VarProcessor {
     public:
+#ifndef __GCCXML__
+        virtual std::unique_ptr<VarProcessor> clone() const;
+#endif
 	typedef std::pair<double, std::vector<double> >	Neuron;
 	typedef std::pair<std::vector<Neuron>, bool>	Layer;
 

--- a/CondFormats/PhysicsToolsObjects/src/MVAComputer.cc
+++ b/CondFormats/PhysicsToolsObjects/src/MVAComputer.cc
@@ -9,16 +9,10 @@
 //     the discriminator computer calibration object. POOL doesn't support
 //     polymorph pointers, so this is implemented using multiple containers
 //     for each possible sub-class and an index array from which the
-//     array of pointers can be reconstructed. In order to avoid having
-//     to handle each sub-class container by hand here, the generated
-//     reflex dictionary is used to find and read/write the std::vector<...>
-//     containers for the individual classes in the private data members.
-//     So changes can be solely done in the header files and does not leave
-//     a trail elsewhere.
+//     array of pointers can be reconstructed. 
 //
 // Author:      Christophe Saout
 // Created:     Sat Apr 24 15:18 CEST 2007
-// $Id: MVAComputer.cc,v 1.10 2010/01/26 19:40:03 saout Exp $
 //
 #include <functional>
 #include <algorithm>
@@ -51,6 +45,81 @@ std::string VarProcessor::getInstanceName() const
 			<< typeid(*this).name() << "." << std::endl;
 
 	return type.substr(sizeof prefix - 1);
+}
+
+std::unique_ptr<VarProcessor>
+VarProcessor::clone() const {
+   return(std::unique_ptr<VarProcessor>(new VarProcessor(*this)));
+}
+
+std::unique_ptr<VarProcessor>
+ProcOptional::clone() const {
+   return(std::unique_ptr<VarProcessor>(new ProcOptional(*this)));
+}
+
+std::unique_ptr<VarProcessor>
+ProcCount::clone() const {
+   return(std::unique_ptr<VarProcessor>(new ProcCount(*this)));
+}
+
+std::unique_ptr<VarProcessor>
+ProcClassed::clone() const {
+   return(std::unique_ptr<VarProcessor>(new ProcClassed(*this)));
+}
+
+std::unique_ptr<VarProcessor>
+ProcSplitter::clone() const {
+   return(std::unique_ptr<VarProcessor>(new ProcSplitter(*this)));
+}
+
+std::unique_ptr<VarProcessor>
+ProcForeach::clone() const {
+   return(std::unique_ptr<VarProcessor>(new ProcForeach(*this)));
+}
+
+std::unique_ptr<VarProcessor>
+ProcSort::clone() const {
+   return(std::unique_ptr<VarProcessor>(new ProcSort(*this)));
+}
+
+std::unique_ptr<VarProcessor>
+ProcCategory::clone() const {
+   return(std::unique_ptr<VarProcessor>(new ProcCategory(*this)));
+}
+
+std::unique_ptr<VarProcessor>
+ProcNormalize::clone() const {
+   return(std::unique_ptr<VarProcessor>(new ProcNormalize(*this)));
+}
+
+std::unique_ptr<VarProcessor>
+ProcLikelihood::clone() const {
+   return(std::unique_ptr<VarProcessor>(new ProcLikelihood(*this)));
+}
+
+std::unique_ptr<VarProcessor>
+ProcLinear::clone() const {
+   return(std::unique_ptr<VarProcessor>(new ProcLinear(*this)));
+}
+
+std::unique_ptr<VarProcessor>
+ProcMultiply::clone() const {
+   return(std::unique_ptr<VarProcessor>(new ProcMultiply(*this)));
+}
+
+std::unique_ptr<VarProcessor>
+ProcMatrix::clone() const {
+   return(std::unique_ptr<VarProcessor>(new ProcMatrix(*this)));
+}
+
+std::unique_ptr<VarProcessor>
+ProcExternal::clone() const {
+   return(std::unique_ptr<VarProcessor>(new ProcExternal(*this)));
+}
+
+std::unique_ptr<VarProcessor>
+ProcMLP::clone() const {
+   return(std::unique_ptr<VarProcessor>(new ProcMLP(*this)));
 }
 
 std::string ProcExternal::getInstanceName() const
@@ -118,42 +187,7 @@ std::vector<VarProcessor*> MVAComputer::getProcessors() const
 void MVAComputer::addProcessor(const VarProcessor *proc)
 {
 	cacheId = getNextMVAComputerCacheId();
-
-	ROOT::Reflex::Type baseType = ROOT::Reflex::GetType<VarProcessor>();
-	ROOT::Reflex::Type type =
-				ROOT::Reflex::Type::ByTypeInfo(typeid(*proc));
-	ROOT::Reflex::Type refType(type,
-				ROOT::Reflex::CONST & ROOT::Reflex::REFERENCE);
-	if (!type.Name().size())
-		throw cms::Exception("MVAComputerCalibration")
-			<< "Calibration class " << typeid(*proc).name()
-			<< " not registered with ROOT::Reflex."
-			<< std::endl;
-
-	ROOT::Reflex::Object obj =
-		ROOT::Reflex::Object(baseType, const_cast<void*>(
-			static_cast<const void*>(proc))).CastObject(type);
-
-	// find and call copy constructor
-	for(ROOT::Reflex::Member_Iterator iter = type.FunctionMember_Begin();
-	    iter != type.FunctionMember_End(); iter++) {
-		const ROOT::Reflex::Type &ctor = iter->TypeOf();
-		if (!iter->IsConstructor() ||
-		    ctor.FunctionParameterSize() != 1 ||
-		    ctor.FunctionParameterAt(0).Id() != refType.Id())
-			continue;
-
-		ROOT::Reflex::Object copy = type.Construct(ctor,
-			ROOT::Reflex::Tools::MakeVector<void*>(obj.Address()));
-
-		processors.push_back(static_cast<VarProcessor*>(copy.Address()));
-		return;
-	}
-
-	throw cms::Exception("MVAComputerCalibration")
-			<< "Calibration class " << typeid(*proc).name()
-			<< " has no copy ctor registered with ROOT::Reflex."
-			<< std::endl;
+        processors.push_back(proc->clone().release());
 }
 
 static MVAComputerContainer::CacheId getNextMVAComputerContainerCacheId()


### PR DESCRIPTION
NOTE:  Do not merge this pull request into CMSSW_7_3_ROOT6_X, as there will be merge conflicts.
This pull request is for code commonality between CMSSW for ROOT 5 and ROOT 6.
In the ROOT6 IB, unnecessary introspection has been removed from MVAComputer, to save memory and increase performance, as this particular use of introspection causes run-time header parsing.
This pull request makes the equivalent change in the CMSSW ROOT 5 IB, for code commonality.
The introspection was used to invoke the copy constructor of classes derived from VarProcessor.
In less than an hour, I was able to replace this ugly introspection with a virtual clone() function, which can be called directly.
