### PR TITLE
Update TrunCastChecker to look at ImplicitCastExpr when the child is a 

### DIFF
--- a/Utilities/StaticAnalyzers/src/ThrUnsafeFCallChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/ThrUnsafeFCallChecker.cpp
@@ -51,9 +51,9 @@ void TUFWalker::VisitCXXMemberCallExpr( CXXMemberCallExpr *CE ) {
 		PathDiagnosticLocation CELoc = PathDiagnosticLocation::createBegin(CE, BR.getSourceManager(),AC);
  		BugType * BT = new BugType(Checker, "known thread unsafe function called","ThreadSafety");
 		BugReport * R = new BugReport(*BT,os.str(),CELoc);
+		R->setDeclWithIssue(AC->getDecl());
 		R->addRange(CE->getSourceRange());
 		BR.emitReport(R);
-
 		std::string tname = "function-checker.txt.unsorted";
 		std::string ostring =  "function '"+ pname + "' known thread unsafe function '" + mname + "'.\n";
 		support::writeLog(ostring,tname);

--- a/Utilities/StaticAnalyzers/src/TrunCastChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/TrunCastChecker.cpp
@@ -1,6 +1,7 @@
 #include <clang/AST/Attr.h>
 #include <clang/AST/DeclCXX.h>
 #include <clang/AST/ExprCXX.h>
+#include <clang/AST/Expr.h>
 #include <clang/AST/Decl.h>
 #include <clang/AST/DeclTemplate.h>
 #include <clang/AST/StmtVisitor.h>
@@ -39,30 +40,51 @@ bool VisitImplicitCastExpr( ImplicitCastExpr *CE);
 
 bool ICEVisitor::VisitImplicitCastExpr( ImplicitCastExpr *CE )  
 {
+ 	const char *sfile=BR.getSourceManager().getPresumedLoc(CE->getExprLoc()).getFilename();
+	std::string sname(sfile);
+	if ( ! support::isInterestingLocation(sname) || ! support::isCmsLocalFile(sfile) ) return true;	
 	BR.getContext();
   	llvm::SmallString<100> buf;
   	llvm::raw_svector_ostream os(buf);
-	const Expr * SE = CE->getSubExprAsWritten();	
-	std::string sname = SE->getType().getAsString();
-	if (!(sname=="EventNumber_t")) return true;
+	const Expr * SE = CE->getSubExprAsWritten();
+	std::string sename = SE->getType().getAsString();
+	std::string evn = "EventNumber_t";
+	std::string lname;
+	std::string rname;
 	const clang::Expr *E = CE->getSubExpr();
+	if ( BinaryOperator::classof(SE) ) {
+		const BinaryOperator * BO = dyn_cast<BinaryOperator>(SE);
+		lname = BO->getLHS()->getType().getAsString();
+		rname = BO->getRHS()->getType().getAsString();
+	}
+	if (!(sename==evn || lname==evn || rname==evn )) return true;	
 	clang::QualType OrigTy = BR.getContext().getCanonicalType(E->getType());
 	clang::QualType ToTy = BR.getContext().getCanonicalType(CE->getType());
-	if (!OrigTy->isIntegerType()) return true;
-	if (!(ToTy->isIntegerType()||ToTy->isFloatingType())) return true;
-	uint64_t size_otype = BR.getContext().getTypeSize(OrigTy);
-	uint64_t size_ttype = BR.getContext().getTypeSize(ToTy);
+	if (!(ToTy->isIntegerType()||ToTy->isFloatingType()) ) return true;
+	if ( ToTy->isBooleanType() ) return true;
+	CharUnits size_otype = BR.getContext().getTypeSizeInChars(OrigTy);
+	CharUnits size_ttype = BR.getContext().getTypeSizeInChars(ToTy);
 	std::string oname = OrigTy.getAsString();
 	std::string tname = ToTy.getAsString();
-
-	if ( size_ttype < size_otype || ToTy->isFloatingType() ) {
-		os <<"Size of cast-to type, "<<tname<<", is smaller than cast-from type, "<<oname<<", and may result in truncation"; 
+	if ( ToTy->isFloatingType() ) {
+		os <<"Cast-to type, "<<tname<<". Cast-from type, "<<oname; 
 		clang::ento::PathDiagnosticLocation CELoc = clang::ento::PathDiagnosticLocation::createBegin(CE, BR.getSourceManager(),AC);
- 		BugType * BT = new BugType(CheckName(), "implicit cast size truncates","CMS code rules");
+ 		BugType * BT = new BugType(CheckName(), "implicit cast of int type to float type","CMS code rules");
 		BugReport * R = new BugReport(*BT,os.str(),CELoc);
 		R->addRange(CE->getSourceRange());
 		BR.emitReport(R);
 		return true;
+		} 
+	else {
+		if (  (size_otype > size_ttype) || ( size_otype == size_ttype && ToTy->getTypeClass() != OrigTy->getTypeClass() ) ) {
+			os <<"Cast-to type, "<<tname<<". Cast-from type, "<<oname<<". Cast may result in truncation."; 
+			clang::ento::PathDiagnosticLocation CELoc = clang::ento::PathDiagnosticLocation::createBegin(CE, BR.getSourceManager(),AC);
+ 			BugType * BT = new BugType(CheckName(), "implicit cast of int type to different int type could truncate","CMS code rules");
+			BugReport * R = new BugReport(*BT,os.str(),CELoc);
+			R->addRange(CE->getSourceRange());
+			BR.emitReport(R);
+			return true;
+		} 
 	}
 	return true;
 }

--- a/Utilities/StaticAnalyzers/src/TrunCastChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/TrunCastChecker.cpp
@@ -25,7 +25,7 @@ using namespace llvm;
 namespace clangcms
 {
 
-class ICEVisitor: public clang::RecursiveASTVisitor<ICEVisitor> {
+class ICEVisitor: public clang::StmtVisitor<ICEVisitor> {
 	const clang::ento::CheckerBase *Checker;
 	clang::ento::BugReporter &BR;
 	clang::AnalysisDeclContext* AC;
@@ -34,65 +34,130 @@ class ICEVisitor: public clang::RecursiveASTVisitor<ICEVisitor> {
    ICEVisitor(const clang::ento::CheckerBase *checker, clang::ento::BugReporter &br, clang::AnalysisDeclContext *ac)
        : Checker(checker), BR(br), AC(ac) {}
  
-bool VisitImplicitCastExpr( ImplicitCastExpr *CE);
-
+void VisitImplicitCastExpr( ImplicitCastExpr *CE );
+void VisitBinaryOperator( BinaryOperator *BO );
+void VisitChildren( clang::Stmt *S );
+void VisitStmt( clang::Stmt *S ) { VisitChildren(S); }
 };
 
-bool ICEVisitor::VisitImplicitCastExpr( ImplicitCastExpr *CE )  
+void ICEVisitor::VisitChildren( clang::Stmt *S ) {
+  for ( auto I = S->child_begin(), E = S->child_end(); I!=E; ++I)
+    if (clang::Stmt *child = *I) {
+      Visit(child);
+    }
+}
+
+
+void ICEVisitor::VisitBinaryOperator( BinaryOperator *BO )
 {
- 	const char *sfile=BR.getSourceManager().getPresumedLoc(CE->getExprLoc()).getFilename();
-	std::string sname(sfile);
-	if ( ! support::isInterestingLocation(sname) || ! support::isCmsLocalFile(sfile) ) return true;	
-	BR.getContext();
-  	llvm::SmallString<100> buf;
-  	llvm::raw_svector_ostream os(buf);
-	const Expr * SE = CE->getSubExprAsWritten();
-	std::string sename = SE->getType().getAsString();
-	std::string evn = "EventNumber_t";
-	std::string lname;
-	std::string rname;
-	const clang::Expr *E = CE->getSubExpr();
-	if ( BinaryOperator::classof(SE) ) {
-		const BinaryOperator * BO = dyn_cast<BinaryOperator>(SE);
-		lname = BO->getLHS()->getType().getAsString();
-		rname = BO->getRHS()->getType().getAsString();
+	const NamedDecl * ACD = dyn_cast<NamedDecl>(AC->getDecl());
+	VisitChildren(BO);
+	std::string ename = "EventNumber_t";
+	clang::Expr * LHS = BO->getLHS();
+	clang::Expr * RHS = BO->getRHS();
+	std::string lname = LHS->getType().getAsString();
+	std::string rname = RHS->getType().getAsString();
+	if (IntegerLiteral::classof(LHS->IgnoreCasts()) || IntegerLiteral::classof(RHS->IgnoreCasts())) return;
+	if (!(lname == ename || rname == ename)) return;
+	if (  lname == ename && rname == ename ) return;
+	clang::QualType OTy;
+	clang::QualType TTy;
+	if (lname == ename) {
+		ImplicitCastExpr * ICE = dyn_cast<ImplicitCastExpr>(RHS);
+		TTy = BR.getContext().getCanonicalType(LHS->getType());
+		OTy = BR.getContext().getCanonicalType(ICE->getSubExprAsWritten()->getType());
 	}
-	if (!(sename==evn || lname==evn || rname==evn )) return true;	
-	clang::QualType OrigTy = BR.getContext().getCanonicalType(E->getType());
-	clang::QualType ToTy = BR.getContext().getCanonicalType(CE->getType());
-	if (!(ToTy->isIntegerType()||ToTy->isFloatingType()) ) return true;
-	if ( ToTy->isBooleanType() ) return true;
+	if (rname == ename) {
+		ImplicitCastExpr * ICE = dyn_cast<ImplicitCastExpr>(LHS);
+		TTy = BR.getContext().getCanonicalType(RHS->getType());
+		OTy = BR.getContext().getCanonicalType(ICE->getSubExprAsWritten()->getType());
+	}
+	QualType ToTy = TTy.getUnqualifiedType();
+	QualType OrigTy = OTy.getUnqualifiedType();
+	if (!(ToTy->isIntegerType()||ToTy->isFloatingType()) ) return;
+	if ( ToTy->isBooleanType() ) return;
 	CharUnits size_otype = BR.getContext().getTypeSizeInChars(OrigTy);
 	CharUnits size_ttype = BR.getContext().getTypeSizeInChars(ToTy);
 	std::string oname = OrigTy.getAsString();
 	std::string tname = ToTy.getAsString();
 	if ( ToTy->isFloatingType() ) {
-		os <<"Cast-to type, "<<tname<<". Cast-from type, "<<oname; 
-		clang::ento::PathDiagnosticLocation CELoc = clang::ento::PathDiagnosticLocation::createBegin(CE, BR.getSourceManager(),AC);
- 		BugType * BT = new BugType(CheckName(), "implicit cast of int type to float type","CMS code rules");
-		BugReport * R = new BugReport(*BT,os.str(),CELoc);
-		R->addRange(CE->getSourceRange());
-		BR.emitReport(R);
-		return true;
+  		llvm::SmallString<100> buf;
+  		llvm::raw_svector_ostream os(buf);
+		os <<"Cast-to type, "<<tname<<". Cast-from type, "<<oname<<" . "<<support::getQualifiedName(*(ACD)); 
+		clang::ento::PathDiagnosticLocation CELoc = clang::ento::PathDiagnosticLocation::createBegin(BO, BR.getSourceManager(),AC);
+		BR.EmitBasicReport(ACD,CheckName(),"implicit cast of int type to float type","CMS code rules", os.str(),CELoc, BO->getSourceRange());
 		} 
-	else {
-		if (  (size_otype > size_ttype) || ( size_otype == size_ttype && ToTy->getTypeClass() != OrigTy->getTypeClass() ) ) {
-			os <<"Cast-to type, "<<tname<<". Cast-from type, "<<oname<<". Cast may result in truncation."; 
-			clang::ento::PathDiagnosticLocation CELoc = clang::ento::PathDiagnosticLocation::createBegin(CE, BR.getSourceManager(),AC);
- 			BugType * BT = new BugType(CheckName(), "implicit cast of int type to different int type could truncate","CMS code rules");
-			BugReport * R = new BugReport(*BT,os.str(),CELoc);
-			R->addRange(CE->getSourceRange());
-			BR.emitReport(R);
-			return true;
-		} 
+	if (  (size_otype > size_ttype) ) {
+  		llvm::SmallString<100> buf;
+  		llvm::raw_svector_ostream os(buf);
+		os <<"Cast-to type, "<<tname<<". Cast-from type, "<<oname<<". Cast may result in truncation. "<<support::getQualifiedName(*(ACD)); 
+		clang::ento::PathDiagnosticLocation CELoc = clang::ento::PathDiagnosticLocation::createBegin(BO, BR.getSourceManager(),AC);
+		BR.EmitBasicReport(ACD,CheckName(),"implicit cast of int type to smaller int type could truncate","CMS code rules", os.str(),CELoc, BO->getSourceRange());
+		}
+	if ( ( size_otype == size_ttype ) && (ToTy->hasSignedIntegerRepresentation() &&  OrigTy->hasUnsignedIntegerRepresentation() || 
+		ToTy->hasUnsignedIntegerRepresentation() &&  OrigTy->hasSignedIntegerRepresentation() ) ) {
+  		llvm::SmallString<100> buf;
+  		llvm::raw_svector_ostream os(buf);
+		os <<"Cast-to type, "<<tname<<". Cast-from type, "<<oname<<". Changes int sign type. "<<support::getQualifiedName(*(ACD)); 
+		clang::ento::PathDiagnosticLocation CELoc = clang::ento::PathDiagnosticLocation::createBegin(BO, BR.getSourceManager(),AC);
+		BR.EmitBasicReport(ACD,CheckName(),"implicit cast ins sign type","CMS code rules", os.str(),CELoc, BO->getSourceRange());
 	}
-	return true;
+	return;
+return;
 }
 
-void TrunCastChecker::checkASTDecl(const TranslationUnitDecl *D, AnalysisManager& Mgr,BugReporter &BR) const  {
-   	ICEVisitor icevisitor(this, BR, Mgr.getAnalysisDeclContext(D));
-     	icevisitor.TraverseDecl(const_cast<TranslationUnitDecl *>(D));
+void ICEVisitor::VisitImplicitCastExpr( ImplicitCastExpr *CE )  
+{
+	const NamedDecl * ACD = dyn_cast<NamedDecl>(AC->getDecl());
+	VisitChildren(CE);
+	const Expr * SE = CE->getSubExprAsWritten();
+	std::string sename = SE->getType().getAsString();
+	const clang::Expr *E = CE->getSubExpr();
+	if (!(sename=="EventNumber_t")) return;	
+	QualType OTy = BR.getContext().getCanonicalType(E->getType());
+	QualType TTy = BR.getContext().getCanonicalType(CE->getType());
+	QualType ToTy = TTy.getUnqualifiedType();
+	QualType OrigTy = OTy.getUnqualifiedType();
+	if (!(ToTy->isIntegerType()||ToTy->isFloatingType()) ) return;
+	if ( ToTy->isBooleanType() ) return;
+	CharUnits size_otype = BR.getContext().getTypeSizeInChars(OrigTy);
+	CharUnits size_ttype = BR.getContext().getTypeSizeInChars(ToTy);
+	std::string oname = OrigTy.getAsString();
+	std::string tname = ToTy.getAsString();
+	if ( ToTy->isFloatingType() ) {
+  		llvm::SmallString<100> buf;
+  		llvm::raw_svector_ostream os(buf);
+		os <<"Cast-to type, "<<tname<<". Cast-from type, "<<oname<<" . "<<support::getQualifiedName(*(ACD)); 
+		clang::ento::PathDiagnosticLocation CELoc = clang::ento::PathDiagnosticLocation::createBegin(CE, BR.getSourceManager(),AC);
+		BR.EmitBasicReport(ACD,CheckName(),"implicit cast of int type to float type","CMS code rules", os.str(),CELoc, CE->getSourceRange());
+		} 
+	if (  (size_otype > size_ttype) ) {
+  		llvm::SmallString<100> buf;
+  		llvm::raw_svector_ostream os(buf);
+		os <<"Cast-to type, "<<tname<<". Cast-from type, "<<oname<<". Cast may result in truncation. "<<support::getQualifiedName(*(ACD)); 
+		clang::ento::PathDiagnosticLocation CELoc = clang::ento::PathDiagnosticLocation::createBegin(CE, BR.getSourceManager(),AC);
+		BR.EmitBasicReport(ACD,CheckName(),"implicit cast of int type to smaller int type could truncate","CMS code rules", os.str(),CELoc, CE->getSourceRange());
+		}
+	if ( ToTy->hasSignedIntegerRepresentation() &&  OrigTy->hasUnsignedIntegerRepresentation() || 
+		ToTy->hasUnsignedIntegerRepresentation() &&  OrigTy->hasSignedIntegerRepresentation() ) {	
+  		llvm::SmallString<100> buf;
+ 	 	llvm::raw_svector_ostream os(buf);
+		os <<"Cast-to type, "<<tname<<". Cast-from type, "<<oname<<". Changes int sign type. "<<support::getQualifiedName(*(ACD)); 
+		clang::ento::PathDiagnosticLocation CELoc = clang::ento::PathDiagnosticLocation::createBegin(CE, BR.getSourceManager(),AC);
+		BR.EmitBasicReport(ACD,CheckName(),"implicit cast changes int sign type","CMS code rules", os.str(),CELoc, CE->getSourceRange());
+	}
+	return;
 }
 
+void TrunCastChecker::checkASTDecl(const CXXRecordDecl *D, AnalysisManager& Mgr,BugReporter &BR) const  {
+	for ( auto I = D->method_begin(), E = D->method_end(); I != E; ++I)  {
+		if ( !llvm::isa<clang::CXXMethodDecl>((*I)) ) continue;
+		clang::CXXMethodDecl * MD = llvm::cast<clang::CXXMethodDecl>((*I)->getMostRecentDecl());
+		if ( ! MD->hasBody() ) continue;
+		clang::Stmt *Body = MD->getBody();
+   		ICEVisitor icevisitor(this, BR, Mgr.getAnalysisDeclContext(MD));
+     		icevisitor.Visit(Body);
+	}
+}
 
 }

--- a/Utilities/StaticAnalyzers/src/TrunCastChecker.h
+++ b/Utilities/StaticAnalyzers/src/TrunCastChecker.h
@@ -8,10 +8,10 @@
 
 namespace clangcms {
 
-class TrunCastChecker: public clang::ento::Checker< clang::ento::check::ASTDecl<clang::TranslationUnitDecl> > {
+class TrunCastChecker: public clang::ento::Checker< clang::ento::check::ASTDecl<clang::CXXRecordDecl> > {
 public:
      mutable std::unique_ptr<clang::ento::BugType> BT;
-     void checkASTDecl(const clang::TranslationUnitDecl *D, clang::ento::AnalysisManager& Mgr, clang::ento::BugReporter &BR) const; 
+     void checkASTDecl(const clang::CXXRecordDecl *D, clang::ento::AnalysisManager& Mgr, clang::ento::BugReporter &BR) const; 
 
 private:
   CmsException m_exception;


### PR DESCRIPTION
BinaryOperator with at least one side of type EventNumber_t/
