### PR TITLE
New flexyble payloads for DT ttrig, vdrift and uncertainties

### DIFF
--- a/CalibMuon/DTCalibration/plugins/DTCalibrationMap.cc
+++ b/CalibMuon/DTCalibration/plugins/DTCalibrationMap.cc
@@ -191,7 +191,7 @@ void DTCalibrationMap::readConsts(const string& inputFileName) {
 	 istream_iterator<float>(),
 	 back_inserter(wireCalib.second));
     
-    if(wireCalib.second.size() !=  nFields){
+    if(wireCalib.second.size() <  nFields){
       cout << "[DTCalibrationMap]***Warning: the CalibConstFile is not consistent with the number of fields!" << endl;
     }
     

--- a/CalibMuon/DTCalibration/plugins/DTCalibrationMap.h
+++ b/CalibMuon/DTCalibration/plugins/DTCalibrationMap.h
@@ -3,10 +3,23 @@
 
 /** \class DTCalibrationMap
  *  Allow saving and retrieving of calibration constants to/from txt file.
- *  This is mainly provided for backward compatibility with the ORCA MuBarDigiParameters file.
+ *  This was originally provided for backward compatibility with the ORCA MuBarDigiParameters file.
  *  Can be used to save an arbitrary number of constants with the
  *  needed granularity and to retrieve them back using the wireId.
- *  The first 5 fields for each key are allocated to ttri, sigma_ttrig, kfactor, vdrift and sigma_vdrift.
+ *  Current field allocation: fields for each key are allocated to:
+ *  --First block: legacy descriptors-- 
+ *  [0] ttrig 
+ *  [1] sigma_ttrig  (obsolete)
+ *  [2] kfactor      (obsolete)
+ *  [3] vdrift       
+ *  [4] sigma_vdrift (obsolete, was formerly hacked to include reoslution)
+ *  [5] t0
+ *  [6] t0rms
+ *  [7] noisy or dead flag
+ *  [8-9] left for future usage 
+ * --Second block (optional): free fields
+ *  [10] Encoded information of free fields: (1000*version)+(100*type)+(number of fields); type is: ttrig=0, vdrift=1, uncertainties=3
+ *  [11-end] free fields
  *
  *  \author G. Cerminara - INFN Torino
  */

--- a/CalibMuon/DTCalibration/test/DBTools/DumpDBToFile.h
+++ b/CalibMuon/DTCalibration/test/DBTools/DumpDBToFile.h
@@ -22,6 +22,7 @@ class DTDeadFlag;
 class DTCalibrationMap;
 class DTReadOutMapping;
 class DTRecoUncertainties;
+class DTRecoConditions;
 
 class DumpDBToFile : public edm::EDAnalyzer {
 public:
@@ -48,6 +49,7 @@ private:
   const DTDeadFlag *deadMap;
   const DTReadOutMapping *channelsMap;
   const DTRecoUncertainties *uncertMap;
+  const DTRecoConditions *rconds;
 
   DTCalibrationMap *theCalibFile;
 
@@ -55,6 +57,7 @@ private:
 
   std::string dbToDump;
   std::string dbLabel;
+  std::string format;
 
 };
 #endif

--- a/CalibMuon/DTCalibration/test/DBTools/DumpFileToDB.h
+++ b/CalibMuon/DTCalibration/test/DBTools/DumpFileToDB.h
@@ -44,6 +44,8 @@ private:
   std::string mapFileName;
 
   std::string dbToDump;
+  std::string format;
+
   // sum the correction in the txt file (for the mean value) to what is input DB 
   bool diffMode;
   const DTTtrig *tTrigMapOrig;

--- a/CondCore/DTPlugins/src/plugin.cc
+++ b/CondCore/DTPlugins/src/plugin.cc
@@ -40,6 +40,10 @@
 #include "CondCore/CondDB/interface/KeyListProxy.h"
 #include "CondFormats/DTObjects/interface/DTRecoUncertainties.h"
 #include "CondFormats/DataRecord/interface/DTRecoUncertaintiesRcd.h"
+#include "CondFormats/DTObjects/interface/DTRecoConditions.h"
+#include "CondFormats/DataRecord/interface/DTRecoConditionsTtrigRcd.h"
+#include "CondFormats/DataRecord/interface/DTRecoConditionsVdriftRcd.h"
+#include "CondFormats/DataRecord/interface/DTRecoConditionsUncertRcd.h"
 
 //
 #include "CondCore/CondDB/interface/Serialization.h"
@@ -116,6 +120,9 @@ REGISTER_PLUGIN_INIT(DTLVStatusRcd,DTLVStatus,InitDTLVStatus);
 REGISTER_PLUGIN(DTKeyedConfigContainerRcd, cond::BaseKeyed);
 REGISTER_KEYLIST_PLUGIN(DTKeyedConfigListRcd,cond::persistency::KeyList,DTKeyedConfigContainerRcd);
 REGISTER_PLUGIN(DTRecoUncertaintiesRcd, DTRecoUncertainties);
-
+//New flexyble payloads for ttrig, vdrift, uncertainty
+REGISTER_PLUGIN(DTRecoConditionsTtrigRcd, DTRecoConditions);
+REGISTER_PLUGIN(DTRecoConditionsVdriftRcd, DTRecoConditions);
+REGISTER_PLUGIN(DTRecoConditionsUncertRcd, DTRecoConditions);
 
 

--- a/CondFormats/DTObjects/BuildFile.xml
+++ b/CondFormats/DTObjects/BuildFile.xml
@@ -5,6 +5,7 @@
 <use   name="CondCore/DBCommon"/>
 <use   name="boost_serialization"/>
 <use   name="rootrflx"/>
+<use   name="root"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/CondFormats/DTObjects/interface/DTRecoConditions.h
+++ b/CondFormats/DTObjects/interface/DTRecoConditions.h
@@ -1,0 +1,85 @@
+#ifndef CondFormats_DTObjects_DTRecoConditions_H
+#define CondFormats_DTObjects_DTRecoConditions_H
+
+/** \class DTRecoConditions
+ *  DB object for storing per-SL DT reconstruction parameters (ttrig, vdrift, uncertainties), 
+ *  possibly with their dependency from external quantities (like position, angle, etc.) 
+ *
+ *  Dependencies can be specified  with the expression set by setFormula(string), representing:
+ *  -a TFormula,  e.g. "[0]+[1]*x", in the most general case;
+ *  -special cases like "[0]" = fixed constant, that are implemented without calling TFormula.
+ *
+ *  \author N. Amapane, G. Cerminara
+ */
+
+
+#include "CondFormats/Serialization/interface/Serializable.h"
+
+#include <map>
+#include <vector>
+#include <string>
+#include <stdint.h>
+
+class DTWireId;
+class TFormula;
+
+class DTRecoConditions {
+public:
+  typedef std::map<uint32_t, std::vector<double> >::const_iterator const_iterator;
+
+  /// Constructor
+  DTRecoConditions();
+
+  /// Destructor
+  virtual ~DTRecoConditions();
+
+  void setVersion(int version) {
+    theVersion = version;
+  }
+  
+  /// Version numer specifying the structure of the payload. See .cc file for details.
+  int version() const {
+    return theVersion;
+  }
+
+  /// Get the value correspoding to the given WireId, 
+  //// using x[] as parameters of the parametrization when relevant
+  float get(const DTWireId& wireid, double* x=0) const;
+
+  /// Set the expression representing the formula used for parametrization
+  void setFormulaExpr(const std::string& expr) {
+    expression=expr;
+  }
+  
+  std::string getFormulaExpr() const {
+    return expression;
+  }
+
+  /// Fill the payload
+  void set(const DTWireId& wireid, const std::vector<double>& values); 
+
+  /// Access the data
+  const_iterator begin() const;
+  const_iterator end() const;
+
+private:
+
+  // The formula used for parametrization (transient pointer)
+  mutable TFormula* formula COND_TRANSIENT;
+  
+  // Formula evalaution strategy, derived from expression and cached for efficiency reasons
+  mutable int formulaType COND_TRANSIENT;
+
+  // String with the expression representing the formula used for parametrization
+  std::string expression;
+  
+  // Actual data
+  std::map<uint32_t, std::vector<double> > payload;
+  
+  // Versioning
+  int theVersion;
+
+  COND_SERIALIZABLE;
+};
+#endif
+

--- a/CondFormats/DTObjects/src/DTRecoConditions.cc
+++ b/CondFormats/DTObjects/src/DTRecoConditions.cc
@@ -1,0 +1,77 @@
+/*
+ *  See header file for a description of this class.
+ *
+ *  \author N. Amapane, G. Cerminara
+ */
+
+#include "CondFormats/DTObjects/interface/DTRecoConditions.h"
+#include "DataFormats/MuonDetId/interface/DTWireId.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include <iostream>
+#include <algorithm>
+
+#include <TFormula.h>
+
+using std::string;
+using std::map;
+using std::vector;
+using std::cout;
+using std::endl;
+
+
+DTRecoConditions::DTRecoConditions() : 
+  formula(0), 
+  formulaType(0),  
+  expression("[0]")
+{}
+
+DTRecoConditions::~DTRecoConditions(){
+  delete formula;
+}
+
+
+float DTRecoConditions::get(const DTWireId& wireid, double* x) const {
+
+  map<uint32_t, vector<double> >::const_iterator slIt = payload.find(wireid.superlayerId().rawId());
+  if(slIt == payload.end()) {
+    throw cms::Exception("InvalidInput") << "The SLId: " << wireid.superlayerId() << " is not in the paylaod map";
+  }
+  const vector<double>& par = slIt->second;
+
+  // Initialize if this is the first call
+  if (formulaType==0) {
+    if (expression=="[0]") {
+      formulaType = 1;
+    } else if  (expression=="par[step]") {
+      formulaType = 2;
+    } else { 
+      formulaType = 99;
+      formula  = new TFormula("DTExpr",expression.c_str());
+    }
+  }
+  
+  if (formulaType==1 || par.size()==1) {
+    // Return value is simply a constant. Assume this is the case also if only one parameter exists.
+    return par[0];
+  } else if (formulaType==2) {            
+    // Special case: par[i] represents the value for step i
+    return par[unsigned (x[0])];
+  } else {
+    // Use the formula corresponding to expression. 
+    return formula->EvalPar(x,par.data());
+  }
+}
+
+
+void DTRecoConditions::set(const DTWireId& wireid, const std::vector<double>& values) {
+  payload[wireid.superlayerId()] = values;
+}
+
+
+DTRecoConditions::const_iterator DTRecoConditions::begin() const {
+  return payload.begin();
+}
+
+DTRecoConditions::const_iterator DTRecoConditions::end() const {
+  return payload.end();
+}

--- a/CondFormats/DTObjects/src/T_EventSetup_DTRecoConditions.cc
+++ b/CondFormats/DTObjects/src/T_EventSetup_DTRecoConditions.cc
@@ -1,0 +1,5 @@
+// user include files
+#include "CondFormats/DTObjects/interface/DTRecoConditions.h"
+#include "FWCore/Utilities/interface/typelookup.h"
+
+TYPELOOKUP_DATA_REG(DTRecoConditions);

--- a/CondFormats/DTObjects/src/classes.h
+++ b/CondFormats/DTObjects/src/classes.h
@@ -51,6 +51,8 @@ namespace CondFormats_DTObjects {
     
     std::pair<uint32_t, std::vector<float> > p_payload;
     std::map<uint32_t, std::vector<float> > payload;
+    std::pair<uint32_t, std::vector<double> > p_payloadD;
+    std::map<uint32_t, std::vector<double> > payloadD;
 
   };
 }

--- a/CondFormats/DTObjects/src/classes_def.xml
+++ b/CondFormats/DTObjects/src/classes_def.xml
@@ -90,6 +90,12 @@
   <class name="DTRecoUncertainties" class_version="10">
     <field name="payload" mapping="blob" />
   </class>
+  <class name="std::map<uint32_t, std::vector<double> >"/> 
+  <class name="DTRecoConditions">
+    <field name="formulaType" transient="true"/>
+    <field name="formula" transient="true"/>
+    <field name="payload" mapping="blob" />
+  </class>
 <!-- comment -->
 </lcgdict>
 

--- a/CondFormats/DTObjects/src/headers.h
+++ b/CondFormats/DTObjects/src/headers.h
@@ -11,6 +11,8 @@
  * DTHVStatus
  * DTCCBConfig
  * DTTPGParameters
+ * DTRecoUncertainties
+ * DTRecoConditions
  */
 
 #include "CondFormats/DTObjects/interface/DTReadOutMapping.h"
@@ -27,3 +29,4 @@
 #include "CondFormats/DTObjects/interface/DTKeyedConfig.h"
 #include "CondFormats/DTObjects/interface/DTTPGParameters.h"
 #include "CondFormats/DTObjects/interface/DTRecoUncertainties.h"
+#include "CondFormats/DTObjects/interface/DTRecoConditions.h"

--- a/CondFormats/DTObjects/test/testSerializationDTObjects.cpp
+++ b/CondFormats/DTObjects/test/testSerializationDTObjects.cpp
@@ -30,6 +30,7 @@ int main()
     testSerialization<DTReadOutGeometryLink>();
     testSerialization<DTReadOutMapping>();
     testSerialization<DTRecoUncertainties>();
+    testSerialization<DTRecoConditions>();
     testSerialization<DTStatusFlag>();
     testSerialization<DTStatusFlagData>();
     testSerialization<DTStatusFlagId>();

--- a/CondFormats/DataRecord/interface/DTRecoConditionsTtrigRcd.h
+++ b/CondFormats/DataRecord/interface/DTRecoConditionsTtrigRcd.h
@@ -1,0 +1,6 @@
+#ifndef DTRecoConditionsTtrigRcd_H
+#define DTRecoConditionsTtrigRcd_H
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+class DTRecoConditionsTtrigRcd : public edm::eventsetup::EventSetupRecordImplementation<DTRecoConditionsTtrigRcd> {};
+#endif

--- a/CondFormats/DataRecord/interface/DTRecoConditionsUncertRcd.h
+++ b/CondFormats/DataRecord/interface/DTRecoConditionsUncertRcd.h
@@ -1,0 +1,6 @@
+#ifndef DTRecoConditionsUncertRcd_H
+#define DTRecoConditionsUncertRcd_H
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+class DTRecoConditionsUncertRcd : public edm::eventsetup::EventSetupRecordImplementation<DTRecoConditionsUncertRcd> {};
+#endif

--- a/CondFormats/DataRecord/interface/DTRecoConditionsVdriftRcd.h
+++ b/CondFormats/DataRecord/interface/DTRecoConditionsVdriftRcd.h
@@ -1,0 +1,6 @@
+#ifndef DTRecoConditionsVdriftRcd_H
+#define DTRecoConditionsVdriftRcd_H
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+class DTRecoConditionsVdriftRcd : public edm::eventsetup::EventSetupRecordImplementation<DTRecoConditionsVdriftRcd> {};
+#endif

--- a/CondFormats/DataRecord/src/DTRecoConditionsTtrigRcd.cc
+++ b/CondFormats/DataRecord/src/DTRecoConditionsTtrigRcd.cc
@@ -1,0 +1,4 @@
+#include "CondFormats/DataRecord/interface/DTRecoConditionsTtrigRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+
+EVENTSETUP_RECORD_REG(DTRecoConditionsTtrigRcd);

--- a/CondFormats/DataRecord/src/DTRecoConditionsUncertRcd.cc
+++ b/CondFormats/DataRecord/src/DTRecoConditionsUncertRcd.cc
@@ -1,0 +1,4 @@
+#include "CondFormats/DataRecord/interface/DTRecoConditionsUncertRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+
+EVENTSETUP_RECORD_REG(DTRecoConditionsUncertRcd);

--- a/CondFormats/DataRecord/src/DTRecoConditionsVdriftRcd.cc
+++ b/CondFormats/DataRecord/src/DTRecoConditionsVdriftRcd.cc
@@ -1,0 +1,4 @@
+#include "CondFormats/DataRecord/interface/DTRecoConditionsVdriftRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+
+EVENTSETUP_RECORD_REG(DTRecoConditionsVdriftRcd);


### PR DESCRIPTION
New payload format for DT ttrig, vdrift and uncertainties, to allow for additional flexibility, e.g. introduce dependencies from track angle, position in the chamber etc. Some of these dependencies are hardcoded corrections in the code at the moment, or cannot be implemented at all.

This PR just includes payload definition, records, and tools to read/write the new format. It includes no change in the existing format, nor any usage of the new format in reconstruction code.

Reference: DT report at the DPG coordination meeting, Oct, 25:
https://indico.cern.ch/event/346292/contribution/4/material/slides/0.pdf
