### PR TITLE
Fix typo in selections file

### DIFF
--- a/TrackingTools/PatternTools/src/classes_def.xml
+++ b/TrackingTools/PatternTools/src/classes_def.xml
@@ -56,7 +56,7 @@
        <field name="transientMap_" transient="true" />
   </class>
 
-  <class name="edm::helpers::KeyVal<edm::Ref<vector<Trajectory>,Trajectory,edm::refhelper::FindUsingAdvance<vector<Trajectory>,Trajectory> >,edm::Ref<vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<vector<reco::Track>,reco::Track>"/>
+  <class name="edm::helpers::KeyVal<edm::Ref<vector<Trajectory>,Trajectory,edm::refhelper::FindUsingAdvance<vector<Trajectory>,Trajectory> >,edm::Ref<vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<vector<reco::Track>,reco::Track> > >"/>
 
   <class name="TrajAnnealing"/>
   <class name="std::vector<TrajAnnealing>" persistent="false"/>


### PR DESCRIPTION
A typo in an xml selection file caused angle brackets to be unbalanced.
This trivial fix corrects the typo.
Please merge as soon as convenient.
