### PR TITLE
Convert ESZeroSuppressionProducer to stream module

### DIFF
--- a/SimCalorimetry/EcalZeroSuppressionProducers/interface/ESZeroSuppressionProducer.h
+++ b/SimCalorimetry/EcalZeroSuppressionProducers/interface/ESZeroSuppressionProducer.h
@@ -2,7 +2,7 @@
 #define ESZEROSUPPRESSIONPRODUCER_H
 
 #include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -17,7 +17,7 @@
 #include "CondFormats/ESObjects/interface/ESPedestals.h"
 #include "CondFormats/DataRecord/interface/ESPedestalsRcd.h"
 
-class ESZeroSuppressionProducer : public edm::EDProducer
+class ESZeroSuppressionProducer : public edm::stream::EDProducer<>
 {
  public:
     
@@ -25,7 +25,7 @@ class ESZeroSuppressionProducer : public edm::EDProducer
   virtual ~ESZeroSuppressionProducer();
   
   /**Produces the EDM products,*/
-  virtual void produce(edm::Event& event, const edm::EventSetup& eventSetup);
+  virtual void produce(edm::Event& event, const edm::EventSetup& eventSetup) override;
   
   
  private:


### PR DESCRIPTION
The static analyzer believes this module can safely be converted
to a stream module. This was also converted to make the DIGI workflow
more thread efficient.
