### PR TITLE
Convert HcalTTPDigiProducer to stream module

### DIFF
--- a/SimCalorimetry/HcalTrigPrimProducers/src/HcalTTPDigiProducer.cc
+++ b/SimCalorimetry/HcalTrigPrimProducers/src/HcalTTPDigiProducer.cc
@@ -79,10 +79,6 @@ HcalTTPDigiProducer::HcalTTPDigiProducer(const edm::ParameterSet& ps)
     produces<HcalTTPDigiCollection>();
 }
 
-
-HcalTTPDigiProducer::~HcalTTPDigiProducer() {
-}
-
 bool HcalTTPDigiProducer::isMasked(HcalDetId id) {
 
     for ( unsigned int i=0; i<maskedChannels_.size(); i++ ) 

--- a/SimCalorimetry/HcalTrigPrimProducers/src/HcalTTPDigiProducer.h
+++ b/SimCalorimetry/HcalTrigPrimProducers/src/HcalTTPDigiProducer.h
@@ -1,21 +1,21 @@
 #ifndef HcalTrigPrimProducers_HcalTTPDigiProducer_h
 #define HcalTrigPrimProducers_HcalTTPDigiProducer_h
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "DataFormats/HcalDigi/interface/HcalDigiCollections.h"
 
-class HcalTTPDigiProducer : public edm::EDProducer
+class HcalTTPDigiProducer : public edm::stream::EDProducer<>
 {
 public:
 
   explicit HcalTTPDigiProducer(const edm::ParameterSet& ps);
-  virtual ~HcalTTPDigiProducer();
+  ~HcalTTPDigiProducer() = default;
 
-  virtual void produce(edm::Event& e, const edm::EventSetup& c);
+  virtual void produce(edm::Event& e, const edm::EventSetup& c) override;
 
 private:
 


### PR DESCRIPTION
The static analyzer believes this module can safely be converted
to a stream module. This was also converted to make the DIGI workflow
more thread efficient.
