### PR TITLE
Convert PileupInformation to stream module

### DIFF
--- a/SimGeneral/PileupInformation/interface/PileupInformation.h
+++ b/SimGeneral/PileupInformation/interface/PileupInformation.h
@@ -5,7 +5,7 @@
 
 #include "DataFormats/Common/interface/Handle.h"
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
@@ -24,7 +24,7 @@
 
 #include "SimGeneral/TrackingAnalysis/interface/EncodedTruthId.h"
 
-class PileupInformation : public edm::EDProducer
+class PileupInformation : public edm::stream::EDProducer<>
 {
 
 public:
@@ -33,7 +33,7 @@ public:
 
 private:
 
-    void produce( edm::Event &, const edm::EventSetup & );
+    void produce( edm::Event &, const edm::EventSetup & ) override;
 
     edm::ParameterSet conf_;
 


### PR DESCRIPTION
The static analyzer believes this module can safely be converted
to a stream module. This was also converted to make the DIGI workflow
more thread efficient.
