### PR TITLE
Add missing dictionaries

### DIFF
--- a/DataFormats/L1Trigger/src/classes_def.xml
+++ b/DataFormats/L1Trigger/src/classes_def.xml
@@ -89,5 +89,11 @@
   <class name="std::vector<L1TriggerError>"/>
   <class name="edm::Wrapper<std::vector<L1TriggerError> >"/>
 
+  <class name="BXVector<l1t::CaloSpare>"/>
+  <class name="BXVector<l1t::EGamma>"/>
+  <class name="BXVector<l1t::EtSum>"/>
+  <class name="BXVector<l1t::Jet>"/>
+  <class name="BXVector<l1t::Muon>"/>
+  <class name="BXVector<l1t::Tau>"/>
 
 </lcgdict>


### PR DESCRIPTION
Many relvals are failing in the ROOT6 IB due to missing dictionaries.  This pull request adds the selections for the missing dictionaries.
Please merge this request as soon as convenient.
