### PR TITLE
Pdigitizer dynamic ineff fpix

### DIFF
--- a/SimGeneral/MixingModule/python/pixelDigitizer_cfi.py
+++ b/SimGeneral/MixingModule/python/pixelDigitizer_cfi.py
@@ -53,7 +53,7 @@ pixelDigitizer = cms.PSet(
     killModules = cms.bool(True),
     NumPixelBarrel = cms.int32(3),
     NumPixelEndcap = cms.int32(2),
-    theInstLumiScaleFactor = cms.double(221.95),
+    theInstLumiScaleFactor = cms.double(261.9),
     bunchScale = cms.double(1.0), #for 25ns case
     thePixelColEfficiency_BPix1 = cms.double(1.0), 	# Only used when AddPixelInefficiency = true
     thePixelColEfficiency_BPix2 = cms.double(1.0),
@@ -210,10 +210,10 @@ pixelDigitizer = cms.PSet(
     theOuterEfficiency_FPix1 = cms.double(1.0),
     theOuterEfficiency_FPix2 = cms.double(1.0),
     thePUEfficiency_FPix_Inner = cms.vdouble(
-        1
+        1.0
         ),
     thePUEfficiency_FPix_Outer = cms.vdouble(
-        1
+        1.0
         ),
 DeadModules = cms.VPSet(
  cms.PSet(Dead_detID = cms.int32(302055940), Module = cms.string("tbmB"))

--- a/SimGeneral/MixingModule/python/pixelDigitizer_cfi.py
+++ b/SimGeneral/MixingModule/python/pixelDigitizer_cfi.py
@@ -53,6 +53,8 @@ pixelDigitizer = cms.PSet(
     killModules = cms.bool(True),
     NumPixelBarrel = cms.int32(3),
     NumPixelEndcap = cms.int32(2),
+    theInstLumiScaleFactor = cms.double(221.95),
+    bunchScale = cms.double(1.0), #for 25ns case
     thePixelColEfficiency_BPix1 = cms.double(1.0), 	# Only used when AddPixelInefficiency = true
     thePixelColEfficiency_BPix2 = cms.double(1.0),
     thePixelColEfficiency_BPix3 = cms.double(1.0),
@@ -202,6 +204,16 @@ pixelDigitizer = cms.PSet(
         1.0032,
         -1.96206e-08,
         -1.99009e-10
+        ),
+    theInnerEfficiency_FPix1 = cms.double(1.0),
+    theInnerEfficiency_FPix2 = cms.double(1.0),
+    theOuterEfficiency_FPix1 = cms.double(1.0),
+    theOuterEfficiency_FPix2 = cms.double(1.0),
+    thePUEfficiency_FPix_Inner = cms.vdouble(
+        1
+        ),
+    thePUEfficiency_FPix_Outer = cms.vdouble(
+        1
         ),
 DeadModules = cms.VPSet(
  cms.PSet(Dead_detID = cms.int32(302055940), Module = cms.string("tbmB"))

--- a/SimGeneral/MixingModule/python/pixelDigitizer_cfi.py
+++ b/SimGeneral/MixingModule/python/pixelDigitizer_cfi.py
@@ -54,7 +54,7 @@ pixelDigitizer = cms.PSet(
     NumPixelBarrel = cms.int32(3),
     NumPixelEndcap = cms.int32(2),
     theInstLumiScaleFactor = cms.double(261.9),
-    bunchScale = cms.double(1.0), #for 25ns case
+    bunchScaleAt25 = cms.double(1.0), #for 25ns case
     thePixelColEfficiency_BPix1 = cms.double(1.0), 	# Only used when AddPixelInefficiency = true
     thePixelColEfficiency_BPix2 = cms.double(1.0),
     thePixelColEfficiency_BPix3 = cms.double(1.0),

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
@@ -147,7 +147,7 @@ SiPixelDigitizerAlgorithm::SiPixelDigitizerAlgorithm(const edm::ParameterSet& co
   NumberOfEndcapDisks(conf.exists("NumPixelEndcap")?conf.getParameter<int>("NumPixelEndcap"):2),
 
   theInstLumiScaleFactor(conf.getParameter<double>("theInstLumiScaleFactor")), //For dynamic inefficiency PU scaling
-  bunchScale(conf.getParameter<double>("bunchScale")), //For dynamic inefficiency bunchspace scaling
+  bunchScaleAt25(conf.getParameter<double>("bunchScaleAt25")), //For dynamic inefficiency bunchspace scaling
 
   // ADC calibration 1adc count(135e.
   // Corresponds to 2adc/kev, 270[e/kev]/135[e/adc](2[adc/kev]
@@ -549,8 +549,9 @@ void SiPixelDigitizerAlgorithm::calculateInstlumiFactor(PileupMixingContent* puI
     const std::vector<int> bunchCrossing = puInfo->getMix_bunchCrossing();
     const std::vector<float> TrueInteractionList = puInfo->getMix_TrueInteractions();      
     const int bunchSpacing = puInfo->getMix_bunchSpacing();
+    double bunchScale=1.0;
 
-    if (bunchSpacing==25) bunchScale=1.0;
+    if (bunchSpacing==25) bunchScale=bunchScaleAt25;
 
     int pui = 0, p = 0;
     std::vector<int>::const_iterator pu;

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
@@ -447,7 +447,7 @@ SiPixelDigitizerAlgorithm::PixelEfficiencies::PixelEfficiencies(const edm::Param
     i=FPixIndex;
     thePUEfficiency[i++] = conf.getParameter<std::vector<double> >("thePUEfficiency_FPix_Inner");
     thePUEfficiency[i++] = conf.getParameter<std::vector<double> >("thePUEfficiency_FPix_Outer");
-    if ( ((thePUEfficiency[3].size()==0) || (thePUEfficiency[4].size()==0)) && (NumberOfBarrelLayers==3) )
+    if ( ((thePUEfficiency[3].size()==0) || (thePUEfficiency[4].size()==0)) && (NumberOfEndcapDisks==2) )
     throw cms::Exception("Configuration") << "At least one (FPix) PU efficiency number is needed in efficiency config!";
   }
   // the first "NumberOfBarrelLayers" settings [0],[1], ... , [NumberOfBarrelLayers-1] are for the barrel pixels
@@ -550,7 +550,7 @@ void SiPixelDigitizerAlgorithm::calculateInstlumiFactor(PileupMixingContent* puI
     const std::vector<float> TrueInteractionList = puInfo->getMix_TrueInteractions();      
     const int bunchSpacing = puInfo->getMix_bunchSpacing();
 
-    if (bunchSpacing==50) bunchScale=1.0;
+    if (bunchSpacing==25) bunchScale=1.0;
 
     int pui = 0, p = 0;
     std::vector<int>::const_iterator pu;
@@ -1384,9 +1384,9 @@ void SiPixelDigitizerAlgorithm::pixel_inefficiency(const PixelEfficiencies& eff,
   int numRows = topol->nrows();
 
   // Predefined efficiencies
-  float pixelEfficiency  = 1.0;
-  float columnEfficiency = 1.0;
-  float chipEfficiency   = 1.0;
+  double pixelEfficiency  = 1.0;
+  double columnEfficiency = 1.0;
+  double chipEfficiency   = 1.0;
 
   // setup the chip indices conversion
   unsigned int Subid=DetId(detID).subdetId();

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.h
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.h
@@ -240,14 +240,14 @@ class SiPixelDigitizerAlgorithm  {
    */
    struct PixelEfficiencies {
      PixelEfficiencies(const edm::ParameterSet& conf, bool AddPixelInefficiency, int NumberOfBarrelLayers, int NumberOfEndcapDisks);
-     float thePixelEfficiency[20];     // Single pixel effciency
-     float thePixelColEfficiency[20];  // Column effciency
-     float thePixelChipEfficiency[20]; // ROC efficiency
+     double thePixelEfficiency[20];     // Single pixel effciency
+     double thePixelColEfficiency[20];  // Column effciency
+     double thePixelChipEfficiency[20]; // ROC efficiency
      std::vector<double> theLadderEfficiency_BPix[20]; // Ladder efficiency
      std::vector<double> theModuleEfficiency_BPix[20]; // Module efficiency
      std::vector<double> thePUEfficiency[20]; // Instlumi dependent efficiency
-     float theInnerEfficiency_FPix[20]; // Fpix inner module efficiency
-     float theOuterEfficiency_FPix[20]; // Fpix outer module efficiency
+     double theInnerEfficiency_FPix[20]; // Fpix inner module efficiency
+     double theOuterEfficiency_FPix[20]; // Fpix outer module efficiency
      unsigned int FPixIndex;         // The Efficiency index for FPix Disks
    };
 

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.h
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.h
@@ -307,8 +307,8 @@ class SiPixelDigitizerAlgorithm  {
     const int NumberOfBarrelLayers;     // Default = 3
     const int NumberOfEndcapDisks;      // Default = 2
 
-    const float theInstLumiScaleFactor;
-    float bunchScale;
+    const double theInstLumiScaleFactor;
+    double bunchScale;
 
     //-- make_digis 
     const float theElectronPerADC;     // Gain, number of electrons per adc count.

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.h
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.h
@@ -308,7 +308,7 @@ class SiPixelDigitizerAlgorithm  {
     const int NumberOfEndcapDisks;      // Default = 2
 
     const double theInstLumiScaleFactor;
-    double bunchScale;
+    const double bunchScaleAt25;
 
     //-- make_digis 
     const float theElectronPerADC;     // Gain, number of electrons per adc count.

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.h
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.h
@@ -245,7 +245,9 @@ class SiPixelDigitizerAlgorithm  {
      float thePixelChipEfficiency[20]; // ROC efficiency
      std::vector<double> theLadderEfficiency_BPix[20]; // Ladder efficiency
      std::vector<double> theModuleEfficiency_BPix[20]; // Module efficiency
-     std::vector<double> thePUEfficiency_BPix[20]; // Instlumi dependent efficiency
+     std::vector<double> thePUEfficiency[20]; // Instlumi dependent efficiency
+     float theInnerEfficiency_FPix[20]; // Fpix inner module efficiency
+     float theOuterEfficiency_FPix[20]; // Fpix outer module efficiency
      unsigned int FPixIndex;         // The Efficiency index for FPix Disks
    };
 
@@ -263,7 +265,7 @@ class SiPixelDigitizerAlgorithm  {
 
  private:
    // Needed by dynamic inefficiency 
-   // 0-3 BPix, 4-5 FPix
+   // 0-3 BPix, 4-5 FPix (inner, outer)
    double _pu_scale[20];
 
     // Internal typedefs
@@ -304,6 +306,9 @@ class SiPixelDigitizerAlgorithm  {
     //-- Allow for upgrades
     const int NumberOfBarrelLayers;     // Default = 3
     const int NumberOfEndcapDisks;      // Default = 2
+
+    const float theInstLumiScaleFactor;
+    float bunchScale;
 
     //-- make_digis 
     const float theElectronPerADC;     // Gain, number of electrons per adc count.


### PR DESCRIPTION
This is an extension of pixel digitizer's dynamic inefficiency feature for endcap disks in current detector as part of Run2 preparation.
New configurable variables: theInstlumiScaleFactor, bunchScale (which depends on bunchpace value).
Currently all config variables are under discussion with the tracker experts, the final factors will be in a different PR with config file changes only.
