### PR TITLE
Including DYT algorithm into TuneP and PFMuon

### DIFF
--- a/DataFormats/MuonReco/interface/MuonCocktails.h
+++ b/DataFormats/MuonReco/interface/MuonCocktails.h
@@ -6,7 +6,8 @@
  *  Set of functions that select among the different track refits
  *  based on the fit quality, in order to achieve optimal resolution.
  *
- *  \author Piotr Traczyk
+ *  \author Piotr Traczyk,
+ *   modified by Raffaella Radogna
  */
 
 #include "DataFormats/MuonReco/interface/Muon.h"
@@ -19,6 +20,7 @@ namespace muon {
 					     const reco::TrackRef& trackerTrack,
 					     const reco::TrackRef& tpfmsTrack,
 					     const reco::TrackRef& pickyTrack,
+					     const reco::TrackRef& dytTrack,
 					     const double ptThreshold = 200.,
 					     const double tune1 = 17.,
 					     const double tune2 = 40.,
@@ -35,6 +37,7 @@ namespace muon {
 			muon.innerTrack(),
 			muon.tpfmsTrack(),
 			muon.pickyTrack(),
+			muon.dytTrack(),
 			ptThreshold,
 			tune1,
 			tune2,
@@ -43,42 +46,6 @@ namespace muon {
 
   reco::TrackRef getTevRefitTrack(const reco::TrackRef& combinedTrack,
 				  const reco::TrackToTrackMap& map);
-  
-  // The next two versions of tevOptimized are for backward
-  // compatibility; TrackToTrackMaps are to be removed from the
-  // EventContent, so these versions will go away (along with the
-  // helper getter function) after a deprecation period. Since they
-  // are just for backward compatibility and not for new code, we
-  // don't bother to expose the tune parameters.
-
-  inline reco::Muon::MuonTrackTypePair tevOptimized(const reco::TrackRef& combinedTrack,
-						    const reco::TrackRef& trackerTrack,
-						    const reco::TrackToTrackMap& tevMap1,
-						    const reco::TrackToTrackMap& tevMap2,
-						    const reco::TrackToTrackMap& tevMap3,
-						    const double ptThreshold = 200.,
-						    const double tune1 = 17.,
-						    const double tune2 = 40.,
-						    const double dptcut = 0.25) {
-    return tevOptimized(combinedTrack,
-			trackerTrack,
-			getTevRefitTrack(combinedTrack, tevMap2),
-			getTevRefitTrack(combinedTrack, tevMap3),
-			ptThreshold,
-			tune1,
-			tune2,
-			dptcut);
-  }
-  
-  inline reco::Muon::MuonTrackTypePair tevOptimized(const reco::Muon& muon,
-						    const reco::TrackToTrackMap& tevMap1,
-						    const reco::TrackToTrackMap& tevMap2,
-						    const reco::TrackToTrackMap& tevMap3 ) {
-    return tevOptimized(muon.combinedMuon(),
-			muon.track(),
-			getTevRefitTrack(muon.combinedMuon(), tevMap2),
-			getTevRefitTrack(muon.combinedMuon(), tevMap3));
-  }
   
   // The cocktail used as the soon-to-be-old default momentum
   // assignment for the reco::Muon.

--- a/DataFormats/MuonReco/src/MuonCocktails.cc
+++ b/DataFormats/MuonReco/src/MuonCocktails.cc
@@ -15,9 +15,10 @@ reco::Muon::MuonTrackTypePair  muon::tevOptimized(const reco::TrackRef& combined
 						  const double tune1,
 						  const double tune2,
 						  double dptcut) {
+  const unsigned int nAlgo=5; 
 
   // Array for convenience below.
-  const reco::Muon::MuonTrackTypePair refit[5] = { 
+  const reco::Muon::MuonTrackTypePair refit[nAlgo] = { 
     make_pair(trackerTrack, reco::Muon::InnerTrack), 
     make_pair(combinedTrack,reco::Muon::CombinedTrack),
     make_pair(tpfmsTrack,   reco::Muon::TPFMS),
@@ -30,20 +31,20 @@ reco::Muon::MuonTrackTypePair  muon::tevOptimized(const reco::TrackRef& combined
   // the track being not available, whether the (re)fit failed or it's
   // just not in the event, or if the (re)fit ended up with no valid
   // hits.
-  double prob[5] = {0.,0.,0.,0.,0.};
-  bool valid[5] = {0,0,0,0,0};
+  double prob[nAlgo] = {0.,0.,0.,0.,0.};
+  bool valid[nAlgo] = {0,0,0,0,0};
 
   double dptmin = 1.;
 
   if (dptcut>0) {  
-    for (unsigned int i = 0; i < 5; ++i)
+    for (unsigned int i = 0; i < nAlgo; ++i)
       if (refit[i].first.isNonnull())
         if (refit[i].first->ptError()/refit[i].first->pt()<dptmin) dptmin = refit[i].first->ptError()/refit[i].first->pt();
   
     if (dptmin>dptcut) dptcut = dptmin+0.15;
   }
 
-  for (unsigned int i = 0; i < 5; ++i) 
+  for (unsigned int i = 0; i < nAlgo; ++i) 
     if (refit[i].first.isNonnull()){ 
       valid[i] = true;
       if (refit[i].first->numberOfValidHits() && (refit[i].first->ptError()/refit[i].first->pt()<dptcut || dptcut<0)) 
@@ -77,10 +78,12 @@ reco::Muon::MuonTrackTypePair  muon::tevOptimized(const reco::TrackRef& combined
   // is greater than a tuned value. Then compare the
   // so-picked track to TPFMS in the same manner using another tuned
   // value.
-  if (prob[4] && prob[3])
-  if(refit[4].first->ptError()/refit[4].first->pt()-refit[3].first->ptError()/refit[3].first->pt()<=0) 
-  chosen=4; // dyt
-  
+  if (prob[4] && prob[3]) {
+    if(refit[3].first->pt()>0 && refit[4].first->pt()>0 &&
+       (refit[4].first->ptError()/refit[4].first->pt()-refit[3].first->ptError()/refit[3].first->pt())<=0) 
+      chosen=4; // dyt
+  }
+
   if (prob[0] > 0. && prob[chosen] > 0. && (prob[chosen] - prob[0]) > tune1)
     chosen = 0;
   if (prob[2] > 0. && (prob[chosen] - prob[2]) > tune2)

--- a/DataFormats/MuonReco/src/MuonCocktails.cc
+++ b/DataFormats/MuonReco/src/MuonCocktails.cc
@@ -10,17 +10,19 @@ reco::Muon::MuonTrackTypePair  muon::tevOptimized(const reco::TrackRef& combined
 						  const reco::TrackRef& trackerTrack,
 						  const reco::TrackRef& tpfmsTrack,
 						  const reco::TrackRef& pickyTrack,
+						  const reco::TrackRef& dytTrack,
 						  const double ptThreshold,
 						  const double tune1,
 						  const double tune2,
 						  double dptcut) {
 
   // Array for convenience below.
-  const reco::Muon::MuonTrackTypePair refit[4] = { 
+  const reco::Muon::MuonTrackTypePair refit[5] = { 
     make_pair(trackerTrack, reco::Muon::InnerTrack), 
     make_pair(combinedTrack,reco::Muon::CombinedTrack),
     make_pair(tpfmsTrack,   reco::Muon::TPFMS),
-    make_pair(pickyTrack,   reco::Muon::Picky)
+    make_pair(pickyTrack,   reco::Muon::Picky),
+    make_pair(dytTrack,     reco::Muon::DYT)
   }; 
   
   // Calculate the log(tail probabilities). If there's a problem,
@@ -28,20 +30,20 @@ reco::Muon::MuonTrackTypePair  muon::tevOptimized(const reco::TrackRef& combined
   // the track being not available, whether the (re)fit failed or it's
   // just not in the event, or if the (re)fit ended up with no valid
   // hits.
-  double prob[4] = {0.,0.,0.,0.};
-  bool valid[4] = {0,0,0,0};
+  double prob[5] = {0.,0.,0.,0.,0.};
+  bool valid[5] = {0,0,0,0,0};
 
   double dptmin = 1.;
 
   if (dptcut>0) {  
-    for (unsigned int i = 0; i < 4; ++i)
+    for (unsigned int i = 0; i < 5; ++i)
       if (refit[i].first.isNonnull())
         if (refit[i].first->ptError()/refit[i].first->pt()<dptmin) dptmin = refit[i].first->ptError()/refit[i].first->pt();
   
     if (dptmin>dptcut) dptcut = dptmin+0.15;
   }
 
-  for (unsigned int i = 0; i < 4; ++i) 
+  for (unsigned int i = 0; i < 5; ++i) 
     if (refit[i].first.isNonnull()){ 
       valid[i] = true;
       if (refit[i].first->numberOfValidHits() && (refit[i].first->ptError()/refit[i].first->pt()<dptcut || dptcut<0)) 
@@ -58,7 +60,8 @@ reco::Muon::MuonTrackTypePair  muon::tevOptimized(const reco::TrackRef& combined
 
     // split so that passing dptcut<0 recreates EXACTLY the old tuneP behavior
     if (dptcut>0) {
-      if      (prob[0] > 0.) chosen = 0;
+      if      (prob[4] > 0.) chosen = 4;
+      else if (prob[0] > 0.) chosen = 0;
       else if (prob[2] > 0.) chosen = 2;
       else if (prob[1] > 0.) chosen = 1;
     } else {
@@ -68,17 +71,23 @@ reco::Muon::MuonTrackTypePair  muon::tevOptimized(const reco::TrackRef& combined
     }
   } 
   
-  // Now the algorithm: switch from picky to tracker-only if the
+  // Now the algorithm: switch from picky to dyt if the difference is lower than a tuned value. Then 
+  //  switch from picky to tracker-only if the
   // difference, log(tail prob(picky)) - log(tail prob(tracker-only))
   // is greater than a tuned value. Then compare the
   // so-picked track to TPFMS in the same manner using another tuned
   // value.
-  if (prob[0] > 0. && prob[3] > 0. && (prob[3] - prob[0]) > tune1)
+  if (prob[4] && prob[3])
+  if(refit[4].first->ptError()/refit[4].first->pt()-refit[3].first->ptError()/refit[3].first->pt()<=0) 
+  chosen=4; // dyt
+  
+  if (prob[0] > 0. && prob[chosen] > 0. && (prob[chosen] - prob[0]) > tune1)
     chosen = 0;
   if (prob[2] > 0. && (prob[chosen] - prob[2]) > tune2)
     chosen = 2;
 
   // Sanity checks 
+  if (chosen == 4 && !valid[4] ) chosen = 3;
   if (chosen == 3 && !valid[3] ) chosen = 2;
   if (chosen == 2 && !valid[2] ) chosen = 1;
   if (chosen == 1 && !valid[1] ) chosen = 0; 

--- a/DataFormats/MuonReco/src/MuonCocktails.cc
+++ b/DataFormats/MuonReco/src/MuonCocktails.cc
@@ -78,7 +78,7 @@ reco::Muon::MuonTrackTypePair  muon::tevOptimized(const reco::TrackRef& combined
   // is greater than a tuned value. Then compare the
   // so-picked track to TPFMS in the same manner using another tuned
   // value.
-  if (prob[4] && prob[3]) {
+  if (prob[4]>0. && prob[3]>0.) {
     if(refit[3].first->pt()>0 && refit[4].first->pt()>0 &&
        (refit[4].first->ptError()/refit[4].first->pt()-refit[3].first->ptError()/refit[3].first->pt())<=0) 
       chosen=4; // dyt

--- a/DataFormats/ParticleFlowCandidate/interface/PFCandidate.h
+++ b/DataFormats/ParticleFlowCandidate/interface/PFCandidate.h
@@ -81,7 +81,8 @@ namespace reco {
       kTrkMuonVertex=4,
       kGSFVertex=5,
       kTPFMSMuonVertex=6,
-      kPickyMuonVertex=7
+      kPickyMuonVertex=7,
+      kDYTMuonVertex=8
     };
 
 

--- a/DataFormats/ParticleFlowCandidate/src/PFCandidate.cc
+++ b/DataFormats/ParticleFlowCandidate/src/PFCandidate.cc
@@ -667,6 +667,9 @@ const math::XYZPoint & PFCandidate::vertex() const {
   case kPickyMuonVertex:
     return muonRef()->pickyTrack()->vertex();
     break;
+  case kDYTMuonVertex:
+    return muonRef()->dytTrack()->vertex();
+    break;
 
   case kGSFVertex:
     return gsfTrackRef()->vertex();

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
@@ -317,6 +317,7 @@ reco::Muon MuonIdProducer::makeMuon( const reco::MuonTrackLinks& links )
    reco::Muon::MuonTrackTypePair chosenTrack;
    reco::TrackRef tpfmsRef;
    reco::TrackRef pickyRef;
+   reco::TrackRef dytRef;
    bool useSigmaSwitch = false;
 
    if (tpfmsCollectionHandle_.isValid() && !tpfmsCollectionHandle_.failedToGet() &&
@@ -324,8 +325,9 @@ reco::Muon MuonIdProducer::makeMuon( const reco::MuonTrackLinks& links )
 
      tpfmsRef = muon::getTevRefitTrack(links.globalTrack(), *tpfmsCollectionHandle_);
      pickyRef = muon::getTevRefitTrack(links.globalTrack(), *pickyCollectionHandle_);
+     dytRef = muon::getTevRefitTrack(links.globalTrack(), *dytCollectionHandle_);
 
-     if (tpfmsRef.isNull() && pickyRef.isNull()){
+     if (tpfmsRef.isNull() && pickyRef.isNull() && dytRef.isNull()){
        edm::LogWarning("MakeMuonWithTEV")<<"Failed to get  TEV refits, fall back to sigma switch.";
        useSigmaSwitch = true;
      }
@@ -339,7 +341,7 @@ reco::Muon MuonIdProducer::makeMuon( const reco::MuonTrackLinks& links )
 				      ptThresholdToFillCandidateP4WithGlobalFit_);
    } else {
      chosenTrack = muon::tevOptimized( links.globalTrack(), links.trackerTrack(),
-				       tpfmsRef, pickyRef,
+				       tpfmsRef, pickyRef, dytRef,
 				       ptThresholdToFillCandidateP4WithGlobalFit_);
    }
    aMuon = makeMuon(*chosenTrack.first);

--- a/RecoMuon/MuonIdentification/plugins/MuonsFromRefitTracksProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonsFromRefitTracksProducer.cc
@@ -257,8 +257,9 @@ void MuonsFromRefitTracksProducer::produce(edm::Event& event, const edm::EventSe
 	if (fromTMR)
 	  tevTk = tevOptimizedTMR(*muon, *trackMapFirstHit, TMRcut);
 	else if (fromCocktail)
-	  tevTk = muon::tevOptimized(*muon, *trackMapDefault, *trackMapFirstHit,
-				     *trackMapPicky);
+          tevTk = muon::tevOptimized(*muon);	  
+          //tevTk = muon::tevOptimized(*muon, *trackMapDefault, *trackMapFirstHit,
+	  //			     *trackMapPicky);
 	else if (fromSigmaSwitch)
 	  tevTk = sigmaSwitch(*muon, nSigmaSwitch, ptThreshold);
 	else {

--- a/RecoMuon/MuonIdentification/plugins/MuonsFromRefitTracksProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonsFromRefitTracksProducer.cc
@@ -258,8 +258,6 @@ void MuonsFromRefitTracksProducer::produce(edm::Event& event, const edm::EventSe
 	  tevTk = tevOptimizedTMR(*muon, *trackMapFirstHit, TMRcut);
 	else if (fromCocktail)
           tevTk = muon::tevOptimized(*muon);	  
-          //tevTk = muon::tevOptimized(*muon, *trackMapDefault, *trackMapFirstHit,
-	  //			     *trackMapPicky);
 	else if (fromSigmaSwitch)
 	  tevTk = sigmaSwitch(*muon, nSigmaSwitch, ptThreshold);
 	else {

--- a/RecoParticleFlow/PFProducer/src/PFMuonAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFMuonAlgo.cc
@@ -658,10 +658,21 @@ std::vector<reco::Muon::MuonTrackTypePair> PFMuonAlgo::muonTracks(const reco::Mu
     pickyExists=true;
   }
 
+  bool dytExists=false; 
+  if(muon->dytTrack().isNonnull()) {
+    if(muon->dytTrack()->ptError()/muon->dytTrack()->pt()<dpt) 
+      out.push_back(std::make_pair(muon->dytTrack(),reco::Muon::DYT));
+    dytExists=true;
+  }
+
   //Magic: TPFMS is not a really good track especially under misalignment
   //IT is kind of crap because if mu system is displaced it can make a change
   //So allow TPFMS if there is no picky or the error of tpfms is better than picky
-  if(muon->tpfmsTrack().isNonnull() && ((pickyExists && muon->tpfmsTrack()->ptError()/muon->tpfmsTrack()->pt()<muon->pickyTrack()->ptError()/muon->pickyTrack()->pt())||(!pickyExists)) ) 
+  //AND if there is no DYT or the error of tpfms is better than DYT
+  if(muon->tpfmsTrack().isNonnull() 
+     && ((pickyExists && muon->tpfmsTrack()->ptError()/muon->tpfmsTrack()->pt()<muon->pickyTrack()->ptError()/muon->pickyTrack()->pt())||(!pickyExists)) 
+     && ((dytExists && muon->tpfmsTrack()->ptError()/muon->tpfmsTrack()->pt()<muon->dytTrack()->ptError()/muon->dytTrack()->pt())||(!dytExists)) 
+     ) 
     if(muon->tpfmsTrack()->ptError()/muon->tpfmsTrack()->pt()<dpt)
       out.push_back(std::make_pair(muon->tpfmsTrack(),reco::Muon::TPFMS));
 
@@ -774,6 +785,8 @@ void  PFMuonAlgo::changeTrack(reco::PFCandidate& candidate,const MuonTrackTypePa
       candidate.setVertexSource( PFCandidate::kTPFMSMuonVertex );
     else if(trackType == reco::Muon::Picky)
       candidate.setVertexSource( PFCandidate::kPickyMuonVertex );
+    else if(trackType == reco::Muon::DYT)
+      candidate.setVertexSource( PFCandidate::kDYTMuonVertex );
   }
 
 

--- a/RecoParticleFlow/PFProducer/src/PFMuonAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFMuonAlgo.cc
@@ -643,24 +643,28 @@ std::vector<reco::Muon::MuonTrackTypePair> PFMuonAlgo::muonTracks(const reco::Mu
   std::vector<reco::Muon::MuonTrackTypePair> out;
 
   
-  if(muon->globalTrack().isNonnull()) 
+  if(muon->globalTrack().isNonnull() && muon->globalTrack()->pt()>0) 
     if(muon->globalTrack()->ptError()/muon->globalTrack()->pt()<dpt)
       out.push_back(std::make_pair(muon->globalTrack(),reco::Muon::CombinedTrack));
 
-  if(muon->innerTrack().isNonnull()) 
+  if(muon->innerTrack().isNonnull() && muon->innerTrack()->pt()>0) 
     if(muon->innerTrack()->ptError()/muon->innerTrack()->pt()<dpt)//Here Loose!@
       out.push_back(std::make_pair(muon->innerTrack(),reco::Muon::InnerTrack));
 
   bool pickyExists=false; 
-  if(muon->pickyTrack().isNonnull()) {
-    if(muon->pickyTrack()->ptError()/muon->pickyTrack()->pt()<dpt) 
+  double pickyDpt=99999.; 
+  if(muon->pickyTrack().isNonnull() && muon->pickyTrack()->pt()>0) {
+    pickyDpt = muon->pickyTrack()->ptError()/muon->pickyTrack()->pt(); 
+    if(pickyDpt<dpt) 
       out.push_back(std::make_pair(muon->pickyTrack(),reco::Muon::Picky));
     pickyExists=true;
   }
 
   bool dytExists=false; 
-  if(muon->dytTrack().isNonnull()) {
-    if(muon->dytTrack()->ptError()/muon->dytTrack()->pt()<dpt) 
+  double dytDpt=99999.; 
+  if(muon->dytTrack().isNonnull() && muon->dytTrack()->pt()>0) {
+    dytDpt = muon->dytTrack()->ptError()/muon->dytTrack()->pt(); 
+    if(dytDpt<dpt) 
       out.push_back(std::make_pair(muon->dytTrack(),reco::Muon::DYT));
     dytExists=true;
   }
@@ -669,12 +673,13 @@ std::vector<reco::Muon::MuonTrackTypePair> PFMuonAlgo::muonTracks(const reco::Mu
   //IT is kind of crap because if mu system is displaced it can make a change
   //So allow TPFMS if there is no picky or the error of tpfms is better than picky
   //AND if there is no DYT or the error of tpfms is better than DYT
-  if(muon->tpfmsTrack().isNonnull() 
-     && ((pickyExists && muon->tpfmsTrack()->ptError()/muon->tpfmsTrack()->pt()<muon->pickyTrack()->ptError()/muon->pickyTrack()->pt())||(!pickyExists)) 
-     && ((dytExists && muon->tpfmsTrack()->ptError()/muon->tpfmsTrack()->pt()<muon->dytTrack()->ptError()/muon->dytTrack()->pt())||(!dytExists)) 
-     ) 
-    if(muon->tpfmsTrack()->ptError()/muon->tpfmsTrack()->pt()<dpt)
+  if(muon->tpfmsTrack().isNonnull() && muon->tpfmsTrack()->pt()>0) { 
+    double tpfmsDpt = muon->tpfmsTrack()->ptError()/muon->tpfmsTrack()->pt(); 
+    if( ( (pickyExists && tpfmsDpt<pickyDpt) || (!pickyExists) ) && 
+	( (dytExists   && tpfmsDpt<dytDpt)   || (!dytExists)   ) && 
+	tpfmsDpt<dpt )
       out.push_back(std::make_pair(muon->tpfmsTrack(),reco::Muon::TPFMS));
+  }
 
   if(includeSA && muon->outerTrack().isNonnull())
     if(muon->outerTrack()->ptError()/muon->outerTrack()->pt()<dpt)


### PR DESCRIPTION
Hi, 
this PR is to insert the DYnamic Truncation (DYT) muon refit into the TuneP algorithm, which chooses the best muon track among different refits (originally tracker, global, TPFMS, Picky, now also DYT), according to the track quality. (@rradogna, @ptraczyk)
The output of TuneP (other than being available in reco::Muon as "tunePMuonBestTrack") is passed to the PFMuonAlgo, which can modify the choice by TuneP and select a different track or discard the muon, based on the whole event reconstruction, in particular the effect of the muon on the PF MET. The PFMuonAlgo choice is available in reco::Muon as "muonBestTrack". So also PFMuonAlgo (and PFCandidate) needed some adjustments to handle the new refit type. 
In the attached plot by @rradogna, you can see a comparison between the performance of the original TuneP (blue) and the new TuneP with DYT (red) in reconstructing the pt of muons from a SingleMuPt1000 gun sample. The green distribution shows the selected pt between Picky or DYT, when available. It can be seen that the performances of the old and new TuneP are similar, but the new one has less tails (compare RMS, overflow). Note that both DYT and Picky will be further optimized later. 
More performance plots from a Zprime(2250) sample can be found here: 
http://trocino.web.cern.ch/trocino/Temp/2014-10-27_NewTuneP/
Blue plots are for the old TuneP/PFMuonAlgo, red plots are for the new version. You can see the pt resolution of "tunePMuonBestTrack" (from TuneP) and "muonBestTrack" (from PF) for all muons with a valid inner track ("AllMuons_"), for muons passing the HighPt selection ("HighPtMuons_"), and for muons passing the PFMuon selection ("PFMuons_*"). In all cases, you can see an improvement in the resolution, especially the tails. There's also a PFMET distribution, which looks significantly improved. 
@abbiendi, @battibass, @bachtis, @bellan 
![tunep_performances](https://cloud.githubusercontent.com/assets/5376758/4790113/595fe06e-5dcd-11e4-9858-7491915bf110.png)
