### PR TITLE
Bug fix for enumerations

### DIFF
--- a/FWCore/Utilities/src/TypeWithDict.cc
+++ b/FWCore/Utilities/src/TypeWithDict.cc
@@ -366,7 +366,7 @@ namespace edm {
 
   bool
   TypeWithDict::isTypedef() const {
-    if (class_ != nullptr || dataType_ != nullptr || *ti_ == typeid(void)) {
+    if (class_ != nullptr || dataType_ != nullptr || enum_ != nullptr || *ti_ == typeid(void)) {
       return false;
     }
     assert(type_ != nullptr);


### PR DESCRIPTION
Fix for a bug in TypeWithDict handling enumerations that causes fatal asserts in many "other" tests and some unit tests.
Please merge this simple fix as soon as convenient.
