### PR TITLE
modify generic gridpack run script to allow using different compression ...

### DIFF
--- a/GeneratorInterface/LHEInterface/data/run_generic_tarball.sh
+++ b/GeneratorInterface/LHEInterface/data/run_generic_tarball.sh
@@ -34,15 +34,15 @@ fi
 mkdir lheevent; cd lheevent
 
 # retrieve the wanted gridpack from the official repository 
-fn-fileget -c `cmsGetFnConnect frontier://smallfiles` ${repo}/${name}_tarball.tar.gz 
+fn-fileget -c `cmsGetFnConnect frontier://smallfiles` ${repo}/${name}
 
 #check the structure of the tarball
-tar xzf ${name}_tarball.tar.gz ; rm -f ${name}_tarball.tar.gz ;
+tar xaf ${name} ; rm -f ${name} ;
 
 #generate events (call for 1 core always for now until hooks to set number of cores are implemented upstream)
 ./runcmsgrid.sh $nevt $rnum 1
 
-mv cmsgrid_final.lhe $LHEWORKDIR/${name}_final.lhe
+mv cmsgrid_final.lhe $LHEWORKDIR/
 
 cd $LHEWORKDIR
 


### PR DESCRIPTION
...types (in particular xz, which is needed to keep larger gridpacks under the 1GB frontier limit)

Note that existing tar.gz gridpacks can still be used, but the gen fragment for ExternalLHEInterface in the wmlhe step would have to be updated for old requests to run in new releases.

Output file name is now "cmsgrid_final.lhe" and the name argument now refers to the full filename including the extension.
(Compression type is inferred automatically from the file extension, and this has been tested at least with tar.gz and tar.xz)
