### PR TITLE
New SoftMuon ID selector

### DIFF
--- a/DataFormats/MuonReco/src/MuonSelectors.cc
+++ b/DataFormats/MuonReco/src/MuonSelectors.cc
@@ -777,7 +777,6 @@ bool muon::isSoftMuon(const reco::Muon& muon, const reco::Vertex& vtx){
   
   bool ip = fabs(muon.innerTrack()->dxy(vtx.position())) < 0.3 && fabs(muon.innerTrack()->dz(vtx.position())) < 20.;
   
-  //return muID && layers && ip && ishighq;
   return layers && ip && ishighq;
 }
 

--- a/DataFormats/MuonReco/src/MuonSelectors.cc
+++ b/DataFormats/MuonReco/src/MuonSelectors.cc
@@ -771,13 +771,14 @@ bool muon::isSoftMuon(const reco::Muon& muon, const reco::Vertex& vtx){
   if(!muID) return false;
   
   bool layers = muon.innerTrack()->hitPattern().trackerLayersWithMeasurement() > 5 &&
-    muon.innerTrack()->hitPattern().pixelLayersWithMeasurement() > 1;
+    muon.innerTrack()->hitPattern().pixelLayersWithMeasurement() > 0;
 
-  bool chi2 = muon.innerTrack()->normalizedChi2() < 1.8;  
+  bool ishighq = muon.innerTrack()->quality(reco::Track::highPurity); 
   
-  bool ip = fabs(muon.innerTrack()->dxy(vtx.position())) < 3. && fabs(muon.innerTrack()->dz(vtx.position())) < 30.;
+  bool ip = fabs(muon.innerTrack()->dxy(vtx.position())) < 0.3 && fabs(muon.innerTrack()->dz(vtx.position())) < 20.;
   
-  return muID && layers && ip && chi2 ;
+  //return muID && layers && ip && ishighq;
+  return layers && ip && ishighq;
 }
 
 


### PR DESCRIPTION
Hi, 
this is an update of the SoftMuon ID selector in
DataFormats/MuonReco/src/MuonSelectors.cc 
as described in the Muon POG Twiki: 
https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideMuonId#New_Version_recommended. 
The optimization of the new working point was carried out by I. Krätschmer, as well as the performance studies: 
https://indico.cern.ch/event/277448/material/slides/0?contribId=3
https://indico.cern.ch/event/316122/contribution/3/material/slides/0.pdf. 
In few words, the cut on the number of pixel layers is loosened from >1 to >0, the transverse and longitudinal impact parameter cuts are tightened from 3cm to 0.3cm and from 30cm to 20cm, respectively, and the cut on the track chi^2 is replaced by a requirement for the track to be high-purity. 
The change does not have any effect at reconstruction level. 
