### PR TITLE
HE recalibration for radiation damage scenarios

### DIFF
--- a/CalibCalorimetry/HcalPlugins/python/Hcal_Conditions_forGlobalTag_cff.py
+++ b/CalibCalorimetry/HcalPlugins/python/Hcal_Conditions_forGlobalTag_cff.py
@@ -12,7 +12,7 @@ es_hardcode = cms.ESSource("HcalHardcodeCalibrations",
 toGet = cms.untracked.vstring('GainWidths'),
 #--- the following 5 parameters can be omitted in case of regular Geometry 
     iLumi = cms.double(-1.),                 # for Upgrade: fb-1
-    HERecalibration = cms.bool(False),       # True for Upgrade   
+    HERecalibration = cms.uint32(0),     # 1 for Upgrade (default aging scenario)
     HEreCalibCutoff = cms.double(20.),       # if above is True  
     HFRecalibration = cms.bool(False),       # True for Upgrade
     GainWidthsForTrigPrims = cms.bool(False) # True Upgrade    

--- a/CalibCalorimetry/HcalPlugins/src/HERecalibration.cc
+++ b/CalibCalorimetry/HcalPlugins/src/HERecalibration.cc
@@ -7,20 +7,20 @@
 
 #include "HERecalibration.h"
 
-HERecalibration::HERecalibration(double integrated_lumi, double cutoff):
-iLumi(integrated_lumi),cutoff_(cutoff),darkening()
+HERecalibration::HERecalibration(double integrated_lumi, double cutoff, unsigned int scenario):
+iLumi(integrated_lumi),cutoff_(cutoff),darkening(scenario)
 { }
    
 HERecalibration::~HERecalibration() { }
 
-void HERecalibration::setDsegm( std::vector<std::vector<int>> m_segmentation) 
+void HERecalibration::setDsegm( const std::vector<std::vector<int>>& m_segmentation) 
 {
 
   //  std::cout << std::endl << " HERecalibration->setDsegm" << std::endl;
 
-  for (int ieta = 0; ieta < maxEta; ieta++) {
+  for (unsigned int ieta = 0; ieta < HEDarkening::nEtaBins; ieta++) {
     //    std::cout << "["<< ieta << "]  ieta =" << ieta + 16 << "  ";
-    for(int ilay = 0; ilay < maxLay; ilay++) {
+    for(unsigned int ilay = 0; ilay < HEDarkening::nScintLayers; ilay++) {
       dsegm[ieta][ilay] = m_segmentation[ieta+15][ilay]; // 0 not used
       //      std::cout << dsegm [ieta][ilay];
     }
@@ -43,17 +43,17 @@ double HERecalibration::getCorr(int ieta, int idepth) {
 
 void HERecalibration::initialize() {
 
-  double dval[maxEta][maxDepth];  // conversion of lval into depths-averaged values - denominator (including degradation for iLumi) 
-  double nval[maxEta][maxDepth];  // conversion of lval into depths-averaged values - numerator (no degradation)
+  double dval[HEDarkening::nEtaBins][nDepths];  // conversion of lval into depths-averaged values - denominator (including degradation for iLumi) 
+  double nval[HEDarkening::nEtaBins][nDepths];  // conversion of lval into depths-averaged values - numerator (no degradation)
 
-  for (int j = 0; j < maxEta; j++) {
-    for (int k = 0; k < maxDepth; k++) {
+  for (unsigned int j = 0; j < HEDarkening::nEtaBins; j++) {
+    for (unsigned int k = 0; k < nDepths; k++) {
       dval[j][k] = 0.0;
       nval[j][k] = 0.0;
     }
   }
 
-  double lval[maxEta][maxLay]    // raw table of mean energy in each layer for each ieta at 0 lumi
+  double lval[HEDarkening::nEtaBins][HEDarkening::nScintLayers]    // raw table of mean energy in each layer for each ieta at 0 lumi
     = {
       {0.000000,0.000000,0.001078,0.008848,0.014552,0.011611,0.008579,0.003211,0.002964,0.001775,0.001244,0.000194,0.000159,0.000000,0.000000,0.000000,0.000000,0.000000,0.000000}, //tower 16
       {0.107991,0.110127,0.081192,0.050552,0.032968,0.022363,0.012158,0.009392,0.006228,0.003650,0.003512,0.001384,0.002693,0.000171,0.000012,0.000000,0.000000,0.000000,0.000000}, //tower 17
@@ -75,10 +75,10 @@ void HERecalibration::initialize() {
 
   //  std::cout << std::endl << " >>> DVAL evaluation " << std::endl;
 
-  for (int ieta = 0; ieta < maxEta; ieta++) {
+  for (unsigned int ieta = 0; ieta < HEDarkening::nEtaBins; ieta++) {
   
     //fill sum(means(layer,0)) and sum(means(layer,lumi)) for each depth
-    for(int ilay = 0; ilay < maxLay; ilay++) {
+    for(unsigned int ilay = 0; ilay < HEDarkening::nScintLayers; ilay++) {
       int idepth = dsegm[ieta][ilay]; // idepth = 0 - not used!
       nval[ieta][idepth] += lval[ieta][ilay];
       dval[ieta][idepth] += lval[ieta][ilay]*darkening.degradation(iLumi,ieta+16,ilay-1); //be careful of eta and layer numbering
@@ -91,22 +91,22 @@ void HERecalibration::initialize() {
     }
    
     //compute factors, w/ safety checks
-	for(int idepth = 0; idepth < maxDepth; idepth++){
-	  if(dval[ieta][idepth] > 0) corr[ieta][idepth] = nval[ieta][idepth]/dval[ieta][idepth];
-	  else corr[ieta][idepth] = 1.0;
-	  
-	  if(corr[ieta][idepth] < 1.0) corr[ieta][idepth] = 1.0;
-	  /*
-          if (idepth > 0 && idepth <= 3) {
-	        std::cout << "nval[" << ieta << "][" << idepth << "]"
-	  	    << " = " << nval[ieta][idepth] << " - "
+    for(unsigned int idepth = 0; idepth < nDepths; idepth++){
+      if(dval[ieta][idepth] > 0) corr[ieta][idepth] = nval[ieta][idepth]/dval[ieta][idepth];
+      else corr[ieta][idepth] = 1.0;
+      
+      if(corr[ieta][idepth] < 1.0) corr[ieta][idepth] = 1.0;
+      /*
+	if (idepth > 0 && idepth <= 3) {
+	std::cout << "nval[" << ieta << "][" << idepth << "]"
+	<< " = " << nval[ieta][idepth] << " - "
 	  	    << "dval["<< ieta << "][" << idepth << "]"
 	  	    << " = " << dval[ieta][idepth] 
-	  	      << "    corr = " << corr[ieta][idepth] << std::endl;
-          }
-	  */
-	}
-   
+		    << "    corr = " << corr[ieta][idepth] << std::endl;
+		    }
+      */
+    }
+    
   }
 
 

--- a/CalibCalorimetry/HcalPlugins/src/HERecalibration.h
+++ b/CalibCalorimetry/HcalPlugins/src/HERecalibration.h
@@ -16,7 +16,7 @@
 class HERecalibration {
 
 public:
-  HERecalibration(double integrated_lumi, double cutoff, unsigned int scenario = 1);
+  HERecalibration(double integrated_lumi, double cutoff, unsigned int scenario);
   ~HERecalibration();
 
   double getCorr(int ieta, int idepth);

--- a/CalibCalorimetry/HcalPlugins/src/HERecalibration.h
+++ b/CalibCalorimetry/HcalPlugins/src/HERecalibration.h
@@ -13,29 +13,27 @@
 #include <iostream>
 #include "DataFormats/HcalCalibObjects/interface/HEDarkening.h"
 
-#define maxEta    14   // ieta rings for HE 
-#define maxLay    19   // max.number of layers 
-#define maxDepth  7    // with some safety margin (wrt 5)
-
 class HERecalibration {
 
 public:
-  HERecalibration(double integrated_lumi, double cutoff);
+  HERecalibration(double integrated_lumi, double cutoff, unsigned int scenario = 1);
   ~HERecalibration();
 
   double getCorr(int ieta, int idepth);
-  void  setDsegm(std::vector<std::vector<int> > m_segmentation);
+  void  setDsegm(const std::vector<std::vector<int> >& m_segmentation);
 
 private:
-
+  // max number of HE recalibration depths
+  static const unsigned int nDepths = 7; 
+  
   void initialize();
   double iLumi;
   double cutoff_;
   HEDarkening darkening;
 
  // Tabulated mean energy values per layer and per depth
-  double dsegm[maxEta][maxLay];
-  double corr[maxEta][maxDepth];
+  double dsegm[HEDarkening::nEtaBins][HEDarkening::nScintLayers];
+  double  corr[HEDarkening::nEtaBins][nDepths];
 
 };
 

--- a/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
+++ b/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
@@ -123,11 +123,11 @@ HcalHardcodeCalibrations::HcalHardcodeCalibrations ( const edm::ParameterSet& iC
     iLumi=iConfig.getParameter<double>("iLumi");
 
   if( iLumi > 0.0 ) {
-    bool he_recalib = iConfig.getParameter<bool>("HERecalibration");
+    unsigned he_recalib = iConfig.getParameter<bool>("HERecalibration");
     bool hf_recalib = iConfig.getParameter<bool>("HFRecalibration");
     if(he_recalib) {
       double cutoff = iConfig.getParameter<double>("HEreCalibCutoff"); 
-      he_recalibration = new HERecalibration(iLumi,cutoff);
+      he_recalibration = new HERecalibration(iLumi,cutoff,he_recalib);
     }
     if(hf_recalib)  hf_recalibration = new HFRecalibration();
     

--- a/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
+++ b/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
@@ -123,7 +123,7 @@ HcalHardcodeCalibrations::HcalHardcodeCalibrations ( const edm::ParameterSet& iC
     iLumi=iConfig.getParameter<double>("iLumi");
 
   if( iLumi > 0.0 ) {
-    unsigned he_recalib = iConfig.getParameter<bool>("HERecalibration");
+    unsigned he_recalib = iConfig.getParameter<unsigned>("HERecalibration");
     bool hf_recalib = iConfig.getParameter<bool>("HFRecalibration");
     if(he_recalib) {
       double cutoff = iConfig.getParameter<double>("HEreCalibCutoff"); 

--- a/DataFormats/HcalCalibObjects/interface/HEDarkening.h
+++ b/DataFormats/HcalCalibObjects/interface/HEDarkening.h
@@ -17,7 +17,7 @@
 class HEDarkening {
 
 public:
-  HEDarkening(unsigned int scenario = 3);
+  HEDarkening(unsigned int scenario);
   ~HEDarkening();
 
   float degradation(float intlumi, int ieta, int lay) const;

--- a/DataFormats/HcalCalibObjects/src/HEDarkening.cc
+++ b/DataFormats/HcalCalibObjects/src/HEDarkening.cc
@@ -42,8 +42,8 @@ HEDarkening::HEDarkening(unsigned int scenario) {
   for(unsigned int j = 0; j < nEtaBins; j++){
     for(unsigned int i = 0; i < nScintLayers; i++){
       if (scenario == 0 ||
-	  (scenario == 2 && exp(-500./_lumiscale[j][i])<0.2) ||
-	  (scenario == 3 && i<4)) {
+	  (scenario == 2 && exp(-500./(_lumiscale[j][i]/flux_factor))<0.2) ||
+	  (scenario == 3 && i<5)) {
 	lumiscale[j][i] = 0;
       }
       else {

--- a/SLHCUpgradeSimulations/Configuration/python/aging.py
+++ b/SLHCUpgradeSimulations/Configuration/python/aging.py
@@ -84,7 +84,7 @@ def ageHcal(process,lumi):
 
     #recalibration and darkening always together
     if hasattr(process,'es_hardcode'):
-        process.es_hardcode.HERecalibration = cms.bool(True)
+        process.es_hardcode.HERecalibration = cms.uint32(1)
         process.es_hardcode.HFRecalibration = cms.bool(True)
         process.es_hardcode.iLumi = cms.double(float(lumi))
 
@@ -227,10 +227,17 @@ def turn_off_HE_aging(process):
     if hasattr(process,'mix') and hasattr(process.mix,'digitizers') and hasattr(process.mix.digitizers,'hcal'):    
         process.mix.digitizers.hcal.HEDarkening = cms.uint32(0)
     if hasattr(process,'es_hardcode'):
-        process.es_hardcode.HERecalibration = cms.bool(False)		
+        process.es_hardcode.HERecalibration = cms.uint32(0)
     if hasattr(process,'simHcalDigis'):
         process.simHcalDigis.HBlevel=cms.int32(16)
         process.simHcalDigis.HElevel=cms.int32(16)
+    return process
+
+def set_HE_aging_scenario(process,scenario):
+    if hasattr(process,'mix') and hasattr(process.mix,'digitizers') and hasattr(process.mix.digitizers,'hcal'):
+        process.mix.digitizers.hcal.HEDarkening = cms.uint32(scenario)
+    if hasattr(process,'es_hardcode'):
+        process.es_hardcode.HERecalibration = cms.uint32(scenario)
     return process
 
 def turn_off_HF_aging(process):


### PR DESCRIPTION
This pull request:
1) extends the addition of a "scenario" parameter for HEDarkening ([5916](https://github.com/cms-sw/cmssw/pull/5916)) to HERecalibration;
2) picks up some optimizations to HERecalibration which had not yet been backported to 62XSLHC (see [7XX history](https://github.com/cms-sw/cmssw/commits/CMSSW_7_3_X/CalibCalorimetry/HcalPlugins/src/HERecalibration.cc));
3) creates a Python customization function "set_HE_aging_scenario" in aging.py, which can easily be added to the end of config files to ensure agreement between the HEDarkening scenario and the HERecalibration scenario settings;
4) fixes a few bugs in the HE aging scenario definitions.

It has been tested using upgrade configuration 11861 in runTheMatrix, to make sure that the calculation of recalibration factors changes appropriately based on the chosen scenario.
