### PR TITLE
HGC V5 Calibration weights

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHGCEE_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHGCEE_cfi.py
@@ -47,25 +47,26 @@ _arborClusterizer_HGCEE = cms.PSet(
     minFractionToKeep = cms.double(1e-7)
 )
 
-#weights for layers from P.Silva (24 June 2014)
-weight_vec = [0.42]
-weight_vec.extend([1.00 for x in range(10)])
-weight_vec.extend([1.61 for x in range(10)])
-weight_vec.extend([2.44 for x in range(10)])
+#weights for layers from P.Silva (24 October 2014)
+## this is for V5!
+weight_vec = [0.080]
+weight_vec.extend([0.62 for x in range(9)])
+weight_vec.extend([0.81 for x in range(9)])
+weight_vec.extend([1.19 for x in range(8)])
 
 # MIP effective to 1.0/GeV (from fit to data of P. Silva)
 #f(x) = a/(1-exp(-bx - c))
 # x = cosh(eta)
-# a = 168.0
-# b = 0.6871
-# c = 0.9038
+# a = 82.8
+# b = 1e6
+# c = 1e6
 
 _HGCEE_ElectronEnergy = cms.PSet(
     algoName = cms.string("HGCEEElectronEnergyCalibrator"),
     weights = cms.vdouble(weight_vec),
-    effMip_to_InverseGeV_a = cms.double(168.0),
-    effMip_to_InverseGeV_b = cms.double(0.6871),
-    effMip_to_InverseGeV_c = cms.double(0.9038),
+    effMip_to_InverseGeV_a = cms.double(82.8),
+    effMip_to_InverseGeV_b = cms.double(1e6),
+    effMip_to_InverseGeV_c = cms.double(1e6),
     MipValueInGeV = cms.double(55.1*1e-6)
 )
 

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHGCHEB_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHGCHEB_cfi.py
@@ -31,14 +31,16 @@ _manqiArborClusterizer_HGCHEB = cms.PSet(
     thresholdsByDetector = cms.VPSet( )
 )
 
-#weights for layers from P.Silva (26 June 2014)
-weight_vec = [0.0902 for x in range(12)]
-weight_vec.extend([0.1051 for x in range(10)])
+#weights for layers from P.Silva (24 October 2014)                                                                 
+# this is for V5!!!!!                                                                                          
+weight_vec = [0.0464]
+weight_vec.extend([0.0474 for x in range(10)])
+weight_vec.extend([0.1215 for x in range(11)])
 
 # MIP effective to 1.0/GeV (from fit to data of P. Silva) for HEF
 #f(x) = a/(1+exp(-bx - c))
 # x = cosh(eta)
-# a = 11.33333 <--- from straight average of Pedro's data
+# a = 1.0 <--- from straight average of Pedro's data
 # b = 1e6 
 # c = 1e6
 

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHGCHEF_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHGCHEF_cfi.py
@@ -31,9 +31,11 @@ _manqiArborClusterizer_HGCHEF = cms.PSet(
     thresholdsByDetector = cms.VPSet( )
 )
 
-#weights for layers from P.Silva (26 June 2014)
-weight_vec = [0.0902 for x in range(12)]
-weight_vec.extend([0.1051 for x in range(10)])
+#weights for layers from P.Silva (24 October 2014)
+# this is for V5!!!!!
+weight_vec = [0.0464]
+weight_vec.extend([0.0474 for x in range(10)])
+weight_vec.extend([0.1215 for x in range(11)])
 
 # MIP effective to 1.0/GeV (from fit to data of P. Silva) for HEF
 #f(x) = a/(1-exp(-bx - c))


### PR DESCRIPTION
Use October 24th weights from @pfs for HGC V5 geometry.

@vandreev11 - this PR deprecates V4.
