### PR TITLE
Calibration HTR: fix of Unpacker

### DIFF
--- a/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
@@ -101,10 +101,13 @@ namespace HcalUnpacker_impl {
 	ncurr++;
       }
       digi.setSize(ntaken);
+    } else {
+      edm::LogWarning("Bad Data") << "Invalid flavor " << flavor;
+      qie_work=limit;
     }
     return qie_work;
   }
-
+  
   template <class DigiClass>
   void unpack_compact(HcalUHTRData::const_iterator& i, const HcalUHTRData::const_iterator& iend, DigiClass& digi, 
 		      int presamples, const HcalElectronicsId& eid, int startSample, int endSample) {


### PR DESCRIPTION
When previous version of Unpacker has been used (as a private branch in
71X) for current MWGR data in private RAW data unpacking, a problem of the
unpacker hanging and memory blowing has been observed in some (rare)
events. It was traced down to improper handling of the corrupted HTR
calibration data fragments.

This is the fix suggested by Jeremy Mans for 72X soon coming as online
release.
