### PR TITLE
Fix for UE tune fragment and improvement to LHE run script (72x)

### DIFF
--- a/Configuration/Generator/python/Pythia8CUEP8M1Settings_cfi.py
+++ b/Configuration/Generator/python/Pythia8CUEP8M1Settings_cfi.py
@@ -5,7 +5,7 @@ pythia8CUEP8M1SettingsBlock = cms.PSet(
         'Tune:pp 14',
         'Tune:ee 7',
         'MultipartonInteractions:pT0Ref=2.4024',
-        'MultipartonInteractions:ecmPow=2.5208',
+        'MultipartonInteractions:ecmPow=0.25208',
         'MultipartonInteractions:expPow=1.6',
     )
 )

--- a/GeneratorInterface/LHEInterface/data/run_generic_tarball.sh
+++ b/GeneratorInterface/LHEInterface/data/run_generic_tarball.sh
@@ -34,15 +34,15 @@ fi
 mkdir lheevent; cd lheevent
 
 # retrieve the wanted gridpack from the official repository 
-fn-fileget -c `cmsGetFnConnect frontier://smallfiles` ${repo}/${name}_tarball.tar.gz 
+fn-fileget -c `cmsGetFnConnect frontier://smallfiles` ${repo}/${name}
 
 #check the structure of the tarball
-tar xzf ${name}_tarball.tar.gz ; rm -f ${name}_tarball.tar.gz ;
+tar xaf ${name} ; rm -f ${name} ;
 
 #generate events (call for 1 core always for now until hooks to set number of cores are implemented upstream)
 ./runcmsgrid.sh $nevt $rnum 1
 
-mv cmsgrid_final.lhe $LHEWORKDIR/${name}_final.lhe
+mv cmsgrid_final.lhe $LHEWORKDIR/
 
 cd $LHEWORKDIR
 


### PR DESCRIPTION
Fixes a trivial, but critical mistake in the new UE tune fragment and adds support for tar.xz to gridpack executions script. (Desired in 72x to avoid user confusion/mistakes with the UE tune fragments.)
