### PR TITLE
DataFormats/L1Trigger -- updated class version to l1extra::L1MuonParticleExtended::StationData

### DIFF
--- a/DataFormats/L1Trigger/src/classes_def.xml
+++ b/DataFormats/L1Trigger/src/classes_def.xml
@@ -11,8 +11,7 @@
   <class name="l1extra::L1MuonParticleExtended" ClassVersion="10">
    <version ClassVersion="10" checksum="3441232593"/>
   </class>
-  <class name="l1extra::L1MuonParticleExtended::StationData" ClassVersion="11">
-   <version ClassVersion="11" checksum="234715042"/>
+  <class name="l1extra::L1MuonParticleExtended::StationData" ClassVersion="10">
    <version ClassVersion="10" checksum="2917595494"/>
   </class>
   <class name="l1extra::L1EtMissParticle" ClassVersion="10">


### PR DESCRIPTION
This should solve the error found here: 
https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc6_amd64_gcc472/CMSSW_6_2_X_SLHC_2014-10-26-1400/DataFormats/L1Trigger
