### PR TITLE
Add customisations for ecal local reco optimized for 50ns or no oot pileup scenarios

### DIFF
--- a/RecoLocalCalo/EcalRecProducers/python/ecalLocalCustom.py
+++ b/RecoLocalCalo/EcalRecProducers/python/ecalLocalCustom.py
@@ -1,0 +1,10 @@
+
+import FWCore.ParameterSet.Config as cms
+
+def configureEcalLocal50ns(process):
+    process.ecalMultiFitUncalibRecHit.activeBXs = cms.vint32(-4,-2,0,2,4)
+    return process
+  
+def configureEcalLocalNoOOTPU(process):
+    process.ecalMultiFitUncalibRecHit.activeBXs = cms.vint32(0)
+    return process


### PR DESCRIPTION
Adds customize sequence to be used for 50ns or no oot pileup scenarios for optimal performance.  (Intended to handle at least the 25ns vs 50ns switch automatically in the future based on the fill scheme from a forthcoming Lumi run product)
