### PR TITLE
Thread safe access to HCAL conditions containers

### DIFF
--- a/CalibCalorimetry/CaloTPG/plugins/CaloTPGTranscoderULUTs.cc
+++ b/CalibCalorimetry/CaloTPG/plugins/CaloTPGTranscoderULUTs.cc
@@ -150,6 +150,11 @@ CaloTPGTranscoderULUTs::produce(const CaloTPGRecord& iRecord)
    edm::ESHandle<HcalTrigTowerGeometry> theTrigTowerGeometry;
    iRecord.getRecord<CaloGeometryRecord>().get(theTrigTowerGeometry);
 
+   edm::ESHandle<HcalTopology> htopo;
+   iRecord.getRecord<HcalLutMetadataRcd>().getRecord<IdealGeometryRecord>().get(htopo);
+
+   HcalLutMetadata fullLut{ *lutMetadata };
+   fullLut.setTopo(htopo.product());
 
    std::auto_ptr<CaloTPGTranscoderULUT> pTCoder(new CaloTPGTranscoderULUT(file1, file2));
    pTCoder->setup(*lutMetadata, *theTrigTowerGeometry);

--- a/CalibCalorimetry/CaloTPG/plugins/CaloTPGTranscoderULUTs.cc
+++ b/CalibCalorimetry/CaloTPG/plugins/CaloTPGTranscoderULUTs.cc
@@ -157,7 +157,7 @@ CaloTPGTranscoderULUTs::produce(const CaloTPGRecord& iRecord)
    fullLut.setTopo(htopo.product());
 
    std::auto_ptr<CaloTPGTranscoderULUT> pTCoder(new CaloTPGTranscoderULUT(file1, file2));
-   pTCoder->setup(*lutMetadata, *theTrigTowerGeometry);
+   pTCoder->setup(fullLut, *theTrigTowerGeometry);
    return std::auto_ptr<CaloTPGTranscoder>( pTCoder );
 }
 

--- a/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
+++ b/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
@@ -1,5 +1,6 @@
 #include "CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.h"
 #include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Framework/interface/ESTransientHandle.h"
 #include "Geometry/HcalTowerAlgo/interface/HcalTrigTowerGeometry.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "FWCore/Utilities/interface/Exception.h"

--- a/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.h
+++ b/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.h
@@ -1,6 +1,7 @@
 #ifndef CALOTPGTRANSCODERULUT_H
 #define CALOTPGTRANSCODERULUT_H 1
 
+#include <memory>
 #include <vector>
 #include "CalibFormats/CaloTPG/interface/CaloTPGTranscoder.h"
 

--- a/CalibCalorimetry/HcalAlgos/interface/HcalPulseShapes.h
+++ b/CalibCalorimetry/HcalAlgos/interface/HcalPulseShapes.h
@@ -45,9 +45,9 @@ private:
   Shape hpdShape_v2, hpdShapeMC_v2;
   Shape hpdShape_v3, hpdShapeMC_v3;
   Shape hpdBV30Shape_v2, hpdBV30ShapeMC_v2;
-  const HcalMCParams * theMCParams;
+  HcalMCParams * theMCParams;
   const HcalTopology * theTopology;
-  const HcalRecoParams * theRecoParams;
+  HcalRecoParams * theRecoParams;
   typedef std::map<int, const Shape *> ShapeMap;
   ShapeMap theShapes;
 

--- a/CalibCalorimetry/HcalPlugins/src/HcalDbProducer.h
+++ b/CalibCalorimetry/HcalPlugins/src/HcalDbProducer.h
@@ -29,6 +29,7 @@ class HcalDbService;
 class HcalDbRecord;
 
 #include "CondFormats/DataRecord/interface/HcalAllRcds.h"
+#include "CalibFormats/HcalObjects/interface/HcalDbService.h"
 
 
 class HcalDbProducer : public edm::ESProducer {
@@ -37,6 +38,8 @@ class HcalDbProducer : public edm::ESProducer {
   ~HcalDbProducer();
   
   boost::shared_ptr<HcalDbService> produce( const HcalDbRecord& );
+
+  boost::shared_ptr<HcalChannelQuality> produceChannelQualityWithTopo( const HcalChannelQualityRcd&);
 
   // callbacks
   void pedestalsCallback (const HcalPedestalsRcd& fRecord);
@@ -59,4 +62,18 @@ class HcalDbProducer : public edm::ESProducer {
   boost::shared_ptr<HcalDbService> mService;
   std::vector<std::string> mDumpRequest;
   std::ostream* mDumpStream;
+
+  std::unique_ptr<HcalPedestals> mPedestals;
+  std::unique_ptr<HcalPedestalWidths> mPedestalWidths;
+  std::unique_ptr<HcalGains> mGains;
+  std::unique_ptr<HcalGainWidths> mGainWidths;
+  std::unique_ptr<HcalQIEData> mQIEData;
+  std::unique_ptr<HcalRespCorrs> mRespCorrs;
+  std::unique_ptr<HcalLUTCorrs> mLUTCorrs;
+  std::unique_ptr<HcalPFCorrs> mPFCorrs;
+  std::unique_ptr<HcalTimeCorrs> mTimeCorrs;
+  std::unique_ptr<HcalZSThresholds> mZSThresholds;
+  std::unique_ptr<HcalL1TriggerObjects> mL1TriggerObjects;
+  std::unique_ptr<HcalLutMetadata> mLutMetadata;
+
 };

--- a/CaloOnlineTools/HcalOnlineDb/src/HcalLutGenerator.cc
+++ b/CaloOnlineTools/HcalOnlineDb/src/HcalLutGenerator.cc
@@ -58,7 +58,7 @@ void HcalLutGenerator::analyze(const edm::Event& iEvent, const edm::EventSetup& 
   //_____ get Channel Quality conditions from Event Setup (example)______
   //
   edm::ESHandle<HcalChannelQuality> hCQ;
-  iSetup.get<HcalChannelQualityRcd>().get(hCQ);
+  iSetup.get<HcalChannelQualityRcd>().get("withTopo",hCQ);
   const HcalChannelQuality * _cq = &(*hCQ);
   //
   /*

--- a/CondFormats/HcalObjects/interface/HcalCondObjectContainer.h
+++ b/CondFormats/HcalObjects/interface/HcalCondObjectContainer.h
@@ -9,9 +9,6 @@
 #include "DataFormats/HcalDetId/interface/HcalCastorDetId.h"
 #include "DataFormats/HcalDetId/interface/HcalZDCDetId.h"
 #include "FWCore/Utilities/interface/Exception.h"
-#ifndef __GCCXML__
-#include<atomic>
-#endif
 
 class HcalTopology;
 
@@ -21,7 +18,7 @@ class HcalCondObjectContainerBase {
 public:
   const HcalTopology* topo() const { return topo_; }
   int getCreatorPackedIndexVersion() const { return packedIndexVersion_; }
-  void setTopo(const HcalTopology* topo) const;
+  void setTopo(const HcalTopology* topo) ;
 protected:
   HcalCondObjectContainerBase(HcalCondObjectContainerBase const & o) : packedIndexVersion_(o.packedIndexVersion_), topo_(o.topo()) {}
   HcalCondObjectContainerBase & operator = (HcalCondObjectContainerBase const & o) {  topo_=o.topo();	packedIndexVersion_=o.packedIndexVersion_; return *this;}
@@ -37,11 +34,7 @@ protected:
   inline HcalOtherSubdetector extractOther(const DetId& id) const { return HcalOtherSubdetector((id.rawId()>>20)&0x1F); }
   std::string textForId(const DetId& id) const;
 private:
-#ifndef __GCCXML__
-  mutable std::atomic<const HcalTopology*> topo_ COND_TRANSIENT;
-#else
-  mutable const HcalTopology* topo_ COND_TRANSIENT;
-#endif
+  const HcalTopology* topo_ COND_TRANSIENT;
 
   COND_SERIALIZABLE;
 };

--- a/CondFormats/HcalObjects/src/HcalCondObjectContainerBase.cc
+++ b/CondFormats/HcalObjects/src/HcalCondObjectContainerBase.cc
@@ -12,7 +12,7 @@ HcalCondObjectContainerBase::HcalCondObjectContainerBase(const HcalTopology* top
   if (topo) packedIndexVersion_=topo->topoVersion();
 }
 
-void HcalCondObjectContainerBase::setTopo(const HcalTopology* topo) const {
+void HcalCondObjectContainerBase::setTopo(const HcalTopology* topo) {
   if (topo && !topo->denseIdConsistent(packedIndexVersion_)) {
     edm::LogError("HCAL") << std::string("Inconsistent dense packing between current topology (") << topo->topoVersion() << ") and calibration object (" << packedIndexVersion_ << ")";
   }

--- a/CondTools/Hcal/plugins/HcalChannelQualityPopConAnalyzer.cc
+++ b/CondTools/Hcal/plugins/HcalChannelQualityPopConAnalyzer.cc
@@ -26,7 +26,7 @@ private:
     //Using ES to get the data:
 
     edm::ESHandle<HcalChannelQuality> objecthandle;
-    esetup.get<HcalChannelQualityRcd>().get(objecthandle);
+    esetup.get<HcalChannelQualityRcd>().get("withTopo",objecthandle);
     myDBObject = new HcalChannelQuality(*objecthandle.product() );
   }
 

--- a/DQM/HcalMonitorClient/interface/HcalMonitorClient.h
+++ b/DQM/HcalMonitorClient/interface/HcalMonitorClient.h
@@ -117,7 +117,7 @@ private:
   std::vector<HcalBaseDQClient*> clients_;  
 
   DQMStore* dqmStore_;
-  HcalChannelQuality* chanquality_;
+  const HcalChannelQuality* chanquality_;
 
   HcalSummaryClient* summaryClient_;
   EtaPhiHists* ChannelStatus;

--- a/DQM/HcalMonitorClient/src/HcalMonitorClient.cc
+++ b/DQM/HcalMonitorClient/src/HcalMonitorClient.cc
@@ -193,9 +193,8 @@ void HcalMonitorClient::beginRun(const edm::Run& r, const edm::EventSetup& c)
   c.get<IdealGeometryRecord>().get(topo);
 
   edm::ESHandle<HcalChannelQuality> p;
-  c.get<HcalChannelQualityRcd>().get(p);
-  chanquality_= new HcalChannelQuality(*p.product());
-  if (!chanquality_->topo()) chanquality_->setTopo(topo.product());
+  c.get<HcalChannelQualityRcd>().get("withTopo",p);
+  chanquality_= p.product();
  
   if (dqmStore_ && ChannelStatus==0)
     {

--- a/DQM/HcalMonitorTasks/src/HcalBeamMonitor.cc
+++ b/DQM/HcalMonitorTasks/src/HcalBeamMonitor.cc
@@ -432,8 +432,8 @@ void HcalBeamMonitor::beginRun(const edm::Run& run, const edm::EventSetup& c)
   // Get Channel quality info for the run
   // Exclude bad channels from overall calculation
   edm::ESHandle<HcalChannelQuality> p;
-  c.get<HcalChannelQualityRcd>().get(p);
-  HcalChannelQuality* chanquality = new HcalChannelQuality(*p.product());
+  c.get<HcalChannelQualityRcd>().get("withTopo",p);
+  const HcalChannelQuality* chanquality = p.product();
   std::vector<DetId> mydetids = chanquality->getAllChannels();
   
   for (unsigned int i=0;i<mydetids.size();++i)
@@ -446,20 +446,19 @@ void HcalBeamMonitor::beginRun(const edm::Run& run, const edm::EventSetup& c)
 	  (id.depth()==2 && (abs(id.ieta())==35 || abs(id.ieta())==36)))
 	{
 	  const HcalChannelStatus* origstatus=chanquality->getValues(id);
-	  HcalChannelStatus* mystatus=new HcalChannelStatus(origstatus->rawId(),origstatus->getValue());
-	  if (mystatus->isBitSet(HcalChannelStatus::HcalCellHot)) 
+	  HcalChannelStatus mystatus(origstatus->rawId(),origstatus->getValue());
+	  if (mystatus.isBitSet(HcalChannelStatus::HcalCellHot)) 
 	    BadCells_[id]=HcalChannelStatus::HcalCellHot;
 	  
-	  else if (mystatus->isBitSet(HcalChannelStatus::HcalCellDead))
+	  else if (mystatus.isBitSet(HcalChannelStatus::HcalCellDead))
 	    BadCells_[id]=HcalChannelStatus::HcalCellDead;
 	  
-	  if (mystatus->isBitSet(HcalChannelStatus::HcalCellHot) || 
-	      mystatus->isBitSet(HcalChannelStatus::HcalCellDead))
+	  if (mystatus.isBitSet(HcalChannelStatus::HcalCellHot) || 
+	      mystatus.isBitSet(HcalChannelStatus::HcalCellDead))
 	    {
 	      if (id.depth()==1) --ring1totalchannels_;
 	      else if (id.depth()==2) --ring2totalchannels_;
 	    }
-	  delete mystatus;
 	} // if ((id.depth()==1) ...
     } // for (unsigned int i=0;...)
     

--- a/DQM/HcalMonitorTasks/src/HcalDeadCellMonitor.cc
+++ b/DQM/HcalMonitorTasks/src/HcalDeadCellMonitor.cc
@@ -407,8 +407,8 @@ void HcalDeadCellMonitor::beginRun(const edm::Run& run, const edm::EventSetup& c
   if (badChannelStatusMask_>0)
     {
       edm::ESHandle<HcalChannelQuality> p;
-      c.get<HcalChannelQualityRcd>().get(p);
-      HcalChannelQuality* chanquality= new HcalChannelQuality(*p.product());
+      c.get<HcalChannelQualityRcd>().get("withTopo",p);
+      const HcalChannelQuality* chanquality= p.product();
       std::vector<DetId> mydetids = chanquality->getAllChannels();
       for (std::vector<DetId>::const_iterator i = mydetids.begin();
 	   i!=mydetids.end();
@@ -420,7 +420,6 @@ void HcalDeadCellMonitor::beginRun(const edm::Run& run, const edm::EventSetup& c
 	  if ((status & badChannelStatusMask_))
 	    KnownBadCells_[id.rawId()]=status;
 	} 
-      delete chanquality;
     } // if (badChannelStatusMask_>0)
   return;
 } //void HcalDeadCellMonitor::beginRun(...)

--- a/DQM/HcalMonitorTasks/src/HcalDetDiagLEDMonitor.cc
+++ b/DQM/HcalMonitorTasks/src/HcalDetDiagLEDMonitor.cc
@@ -305,8 +305,8 @@ void HcalDetDiagLEDMonitor::beginRun(const edm::Run& run, const edm::EventSetup&
   if (mergeRuns_==false) this->reset();
 
   edm::ESHandle<HcalChannelQuality> p;
-  c.get<HcalChannelQualityRcd>().get(p);
-  HcalChannelQuality* chanquality= new HcalChannelQuality(*p.product());
+  c.get<HcalChannelQualityRcd>().get("withTopo",p);
+  const HcalChannelQuality* chanquality= p.product();
   std::vector<DetId> mydetids = chanquality->getAllChannels();
   KnownBadCells_.clear();
 

--- a/DQM/HcalMonitorTasks/src/HcalDetDiagLaserMonitor.cc
+++ b/DQM/HcalMonitorTasks/src/HcalDetDiagLaserMonitor.cc
@@ -425,8 +425,8 @@ HcalDetDiagLaserMonitor::HcalDetDiagLaserMonitor(const edm::ParameterSet& iConfi
 }
 void HcalDetDiagLaserMonitor::beginRun(const edm::Run& run, const edm::EventSetup& c){
   edm::ESHandle<HcalChannelQuality> p;
-  c.get<HcalChannelQualityRcd>().get(p);
-  HcalChannelQuality* chanquality= new HcalChannelQuality(*p.product());
+  c.get<HcalChannelQualityRcd>().get("withTopo",p);
+  const HcalChannelQuality* chanquality= p.product();
   std::vector<DetId> mydetids = chanquality->getAllChannels();
   KnownBadCells_.clear();
 

--- a/DQM/HcalMonitorTasks/src/HcalDetDiagPedestalMonitor.cc
+++ b/DQM/HcalMonitorTasks/src/HcalDetDiagPedestalMonitor.cc
@@ -296,8 +296,8 @@ void HcalDetDiagPedestalMonitor::beginRun(const edm::Run& run, const edm::EventS
   emap=conditions_->getHcalMapping();
   
   edm::ESHandle<HcalChannelQuality> p;
-  c.get<HcalChannelQualityRcd>().get(p);
-  HcalChannelQuality* chanquality= new HcalChannelQuality(*p.product());
+  c.get<HcalChannelQualityRcd>().get("withTopo",p);
+  const HcalChannelQuality* chanquality= p.product();
   std::vector<DetId> mydetids = chanquality->getAllChannels();
   KnownBadCells_.clear();
 

--- a/DQM/HcalMonitorTasks/src/HcalDigiMonitor.cc
+++ b/DQM/HcalMonitorTasks/src/HcalDigiMonitor.cc
@@ -350,8 +350,8 @@ void HcalDigiMonitor::beginRun(const edm::Run& run, const edm::EventSetup& c)
 
   // Get all pedestals by Cap ID
   edm::ESHandle<HcalChannelQuality> p;
-  c.get<HcalChannelQualityRcd>().get(p);
-  HcalChannelQuality *chanquality= new HcalChannelQuality(*p.product());
+  c.get<HcalChannelQualityRcd>().get("withTopo",p);
+  const HcalChannelQuality *chanquality= p.product();
   std::vector<DetId> mydetids = chanquality->getAllChannels();
   PedestalsByCapId_.clear();
 
@@ -377,15 +377,14 @@ void HcalDigiMonitor::beginRun(const edm::Run& run, const edm::EventSetup& c)
 
   if (tevt_==0) this->setup(); // create all histograms; not necessary if merging runs together
   if (mergeRuns_==false) this->reset(); // call reset at start of all runs
-  delete chanquality;
 
   // Get known dead cells for this run
   KnownBadCells_.clear();
   if (badChannelStatusMask_>0)
     {
       edm::ESHandle<HcalChannelQuality> p;
-      c.get<HcalChannelQualityRcd>().get(p);
-      HcalChannelQuality* chanquality= new HcalChannelQuality(*p.product());
+      c.get<HcalChannelQualityRcd>().get("withTopo",p);
+      const HcalChannelQuality* chanquality= p.product();
       std::vector<DetId> mydetids = chanquality->getAllChannels();
       for (std::vector<DetId>::const_iterator i = mydetids.begin();
 	   i!=mydetids.end();
@@ -399,7 +398,6 @@ void HcalDigiMonitor::beginRun(const edm::Run& run, const edm::EventSetup& c)
 	      KnownBadCells_[id.rawId()]=status;
 	    }
 	} 
-        delete chanquality;
     } // if (badChannelStatusMask_>0)
 
 } // void HcalDigiMonitor::beginRun()

--- a/DQMOffline/Hcal/src/HcalRecHitsAnalyzer.cc
+++ b/DQMOffline/Hcal/src/HcalRecHitsAnalyzer.cc
@@ -659,11 +659,8 @@ void HcalRecHitsAnalyzer::analyze(edm::Event const& ev, edm::EventSetup const& c
 
   // HCAL channel status map ****************************************
   edm::ESHandle<HcalChannelQuality> hcalChStatus;
-  c.get<HcalChannelQualityRcd>().get( hcalChStatus );
+  c.get<HcalChannelQualityRcd>().get( "withTopo", hcalChStatus );
   theHcalChStatus = hcalChStatus.product();
-  edm::ESHandle<HcalTopology> topo;
-  c.get<IdealGeometryRecord>().get(topo);
-  if (!theHcalChStatus->topo()) theHcalChStatus->setTopo(topo.product());
 
   // Assignment of severity levels **********************************
   edm::ESHandle<HcalSeverityLevelComputer> hcalSevLvlComputerHndl;

--- a/RecoEgamma/EgammaHLTProducers/interface/EgammaHLTHcalIsolationProducersRegional.h
+++ b/RecoEgamma/EgammaHLTProducers/interface/EgammaHLTHcalIsolationProducersRegional.h
@@ -20,7 +20,7 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
- #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTHcalIsolationProducersRegional.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTHcalIsolationProducersRegional.cc
@@ -14,8 +14,9 @@
 
 #include "RecoLocalCalo/HcalRecAlgos/interface/HcalSeverityLevelComputer.h"
 #include "RecoLocalCalo/HcalRecAlgos/interface/HcalSeverityLevelComputerRcd.h"
-#include "CondFormats/HcalObjects/interface/HcalChannelQuality.h"
 #include "CondFormats/DataRecord/interface/HcalChannelQualityRcd.h"
+#include "CondFormats/HcalObjects/interface/HcalChannelQuality.h"
+
 
 #include "Geometry/CaloGeometry/interface/CaloCellGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
@@ -88,9 +89,10 @@ void EgammaHLTHcalIsolationProducersRegional::produce(edm::Event& iEvent, const 
   iEvent.getByToken(hbheRecHitProducer_, hbheRecHitHandle);
   const HBHERecHitCollection* hbheRecHitCollection = hbheRecHitHandle.product();
   
-  edm::ESHandle<HcalChannelQuality> hcalChStatus;
-  iSetup.get<HcalChannelQualityRcd>().get(hcalChStatus);
-  
+  edm::ESHandle<HcalChannelQuality> hcalChStatusHandle;    
+  iSetup.get<HcalChannelQualityRcd>().get( "withTopo", hcalChStatusHandle );
+  const HcalChannelQuality* hcalChStatus = hcalChStatusHandle.product();
+
   edm::ESHandle<HcalSeverityLevelComputer> hcalSevLvlComp;
   iSetup.get<HcalSeverityLevelComputerRcd>().get(hcalSevLvlComp);
 
@@ -121,7 +123,7 @@ void EgammaHLTHcalIsolationProducersRegional::produce(edm::Event& iEvent, const 
     if(doEtSum_) {
       isol = isolAlgo_->getEtSum(recoEcalCandRef->superCluster()->eta(),
 				 recoEcalCandRef->superCluster()->phi(),hbheRecHitCollection,caloGeom,
-				 hcalSevLvlComp.product(),hcalChStatus.product());      
+				 hcalSevLvlComp.product(),hcalChStatus);      
      
       if (doRhoCorrection_) {
 	if (fabs(recoEcalCandRef->superCluster()->eta()) < 1.442) 
@@ -132,7 +134,7 @@ void EgammaHLTHcalIsolationProducersRegional::produce(edm::Event& iEvent, const 
     } else {
       isol = isolAlgo_->getESum(recoEcalCandRef->superCluster()->eta(),recoEcalCandRef->superCluster()->phi(),
 				hbheRecHitCollection,caloGeom,
-				hcalSevLvlComp.product(),hcalChStatus.product());      
+				hcalSevLvlComp.product(),hcalChStatus);      
     }
 
     isoMap.insert(recoEcalCandRef, isol);   

--- a/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreator.cc
+++ b/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreator.cc
@@ -144,11 +144,10 @@ void CaloTowersCreator::produce(edm::Event& e, const edm::EventSetup& c) {
  
   // HCAL channel status map ****************************************
   edm::ESHandle<HcalChannelQuality> hcalChStatus;    
-  c.get<HcalChannelQualityRcd>().get( hcalChStatus );
+  c.get<HcalChannelQualityRcd>().get( "withTopo", hcalChStatus );
+    
   const HcalChannelQuality* dbHcalChStatus = hcalChStatus.product();
-
-  if (!dbHcalChStatus->topo()) dbHcalChStatus->setTopo(htopo.product());
-
+    
   // Assignment of severity levels **********************************
   edm::ESHandle<HcalSeverityLevelComputer> hcalSevLvlComputerHndl;
   c.get<HcalSeverityLevelComputerRcd>().get(hcalSevLvlComputerHndl);

--- a/RecoLocalCalo/HcalRecAlgos/test/HcalRecHitReflagger.cc
+++ b/RecoLocalCalo/HcalRecAlgos/test/HcalRecHitReflagger.cc
@@ -168,7 +168,7 @@ HcalRecHitReflagger::~HcalRecHitReflagger()
 void HcalRecHitReflagger::beginRun(const Run& r, const EventSetup& c)
 {
   edm::ESHandle<HcalChannelQuality> p;
-  c.get<HcalChannelQualityRcd>().get(p);
+  c.get<HcalChannelQualityRcd>().get("withTopo",p);
   const HcalChannelQuality& chanquality_(*p.product());
 
   std::vector<DetId> mydetids = chanquality_.getAllChannels();

--- a/RecoLocalCalo/HcalRecProducers/src/HBHEIsolatedNoiseReflagger.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HBHEIsolatedNoiseReflagger.cc
@@ -12,13 +12,14 @@ Original Author: John Paul Chou (Brown University)
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "DataFormats/JetReco/interface/TrackExtrapolation.h"
 #include "CondFormats/DataRecord/interface/EcalChannelStatusRcd.h"
-#include "CondFormats/DataRecord/interface/HcalChannelQualityRcd.h"
 #include "RecoLocalCalo/HcalRecAlgos/interface/HcalSeverityLevelComputerRcd.h"
 #include "RecoLocalCalo/HcalRecAlgos/interface/HcalCaloFlagLabels.h"
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgoRcd.h"
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgo.h"
 
 #include "RecoMET/METAlgorithms/interface/HcalHPDRBXMap.h"
+#include "CondFormats/HcalObjects/interface/HcalChannelQuality.h"
+#include "CondFormats/DataRecord/interface/HcalChannelQualityRcd.h"
 
 HBHEIsolatedNoiseReflagger::HBHEIsolatedNoiseReflagger(const edm::ParameterSet& iConfig) :
   
@@ -78,8 +79,9 @@ HBHEIsolatedNoiseReflagger::produce(edm::Event& iEvent, const edm::EventSetup& e
   const EcalChannelStatus* dbEcalChStatus = ecalChStatus.product();
 
   // get the HCAL channel status map
+
   edm::ESHandle<HcalChannelQuality> hcalChStatus;    
-  evSetup.get<HcalChannelQualityRcd>().get( hcalChStatus );
+  evSetup.get<HcalChannelQualityRcd>().get( "withTopo", hcalChStatus );
   const HcalChannelQuality* dbHcalChStatus = hcalChStatus.product();
 
   // get the severity level computers

--- a/RecoLocalCalo/HcalRecProducers/src/HBHEIsolatedNoiseReflagger.h
+++ b/RecoLocalCalo/HcalRecProducers/src/HBHEIsolatedNoiseReflagger.h
@@ -7,6 +7,7 @@ Description: "Reflags" HB/HE hits based on their ECAL, HCAL, and tracking isolat
 Original Author: John Paul Chou (Brown University)
                  Thursday, September 2, 2010
 */
+#include <memory>
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDProducer.h"
@@ -22,7 +23,7 @@ class HBHEIsolatedNoiseReflagger : public edm::EDProducer {
   
   
  private:
-  virtual void produce(edm::Event&, const edm::EventSetup&);
+  virtual void produce(edm::Event&, const edm::EventSetup&) override;
 
   void DumpHBHEHitMap(std::vector<HBHEHitMap>& i) const;
 

--- a/RecoLocalCalo/HcalRecProducers/src/HcalHitReconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HcalHitReconstructor.cc
@@ -5,7 +5,6 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "CalibFormats/HcalObjects/interface/HcalCoderDb.h"
-#include "CalibFormats/HcalObjects/interface/HcalDbService.h"
 #include "CalibFormats/HcalObjects/interface/HcalDbRecord.h"
 #include "RecoLocalCalo/HcalRecAlgos/interface/HcalSeverityLevelComputer.h"
 #include "RecoLocalCalo/HcalRecAlgos/interface/HcalSeverityLevelComputerRcd.h"
@@ -46,8 +45,7 @@ HcalHitReconstructor::HcalHitReconstructor(edm::ParameterSet const& conf):
   mcOOTCorrectionCategory_("MC"),
   setPileupCorrection_(0),
   setPileupCorrectionForNegative_(0),
-  paramTS(0),
-  theTopology(0)
+  paramTS(0)
 {
   // register for data access
   tok_hbhe_ = consumes<HBHEDigiCollection>(inputLabel_);
@@ -260,22 +258,21 @@ HcalHitReconstructor::~HcalHitReconstructor() {
   delete hbhePulseShapeFlagSetter_;
   delete hfS9S1_;
   delete hfPET_;
-  delete theTopology;
   delete paramTS;
 }
 
 void HcalHitReconstructor::beginRun(edm::Run const&r, edm::EventSetup const & es){
+
+  edm::ESHandle<HcalTopology> htopo;
+  es.get<IdealGeometryRecord>().get(htopo);
 
   if ( tsFromDB_== true || recoParamsFromDB_ == true )
     {
       edm::ESHandle<HcalRecoParams> p;
       es.get<HcalRecoParamsRcd>().get(p);
       paramTS = new HcalRecoParams(*p.product());
+      paramTS->setTopo(htopo.product());
 
-      edm::ESHandle<HcalTopology> htopo;
-      es.get<IdealGeometryRecord>().get(htopo);
-      theTopology=new HcalTopology(*htopo);
-      paramTS->setTopo(theTopology);
       
 
 
@@ -288,16 +285,14 @@ void HcalHitReconstructor::beginRun(edm::Run const&r, edm::EventSetup const & es
     {
       edm::ESHandle<HcalFlagHFDigiTimeParams> p;
       es.get<HcalFlagHFDigiTimeParamsRcd>().get(p);
-      HFDigiTimeParams = p.product();
+      HFDigiTimeParams.reset( new HcalFlagHFDigiTimeParams( *p ) );
 
-      if (theTopology==0) {
-	edm::ESHandle<HcalTopology> htopo;
-	es.get<IdealGeometryRecord>().get(htopo);
-	theTopology=new HcalTopology(*htopo);
-      }
-      HFDigiTimeParams->setTopo(theTopology);
+      edm::ESHandle<HcalTopology> htopo;
+      es.get<IdealGeometryRecord>().get(htopo);
+      HFDigiTimeParams->setTopo(htopo.product());
 
     }
+
   reco_.beginRun(es);
 }
 
@@ -329,11 +324,8 @@ void HcalHitReconstructor::produce(edm::Event& e, const edm::EventSetup& eventSe
   if (useLeakCorrection_) reco_.setLeakCorrection();
 
   edm::ESHandle<HcalChannelQuality> p;
-  eventSetup.get<HcalChannelQualityRcd>().get(p);
-  //DLHcalChannelQuality* myqual = new HcalChannelQuality(*p.product());
+  eventSetup.get<HcalChannelQualityRcd>().get("withTopo",p);
   const HcalChannelQuality* myqual = p.product();
-  if (!myqual->topo()) myqual->setTopo(topo.product());
-
 
   edm::ESHandle<HcalSeverityLevelComputer> mycomputer;
   eventSetup.get<HcalSeverityLevelComputerRcd>().get(mycomputer);

--- a/RecoLocalCalo/HcalRecProducers/src/HcalHitReconstructor.h
+++ b/RecoLocalCalo/HcalRecProducers/src/HcalHitReconstructor.h
@@ -1,6 +1,8 @@
 #ifndef HCALHITRECONSTRUCTOR_H 
 #define HCALHITRECONSTRUCTOR_H 1
 
+#include <memory>
+
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
@@ -31,6 +33,7 @@
 #include "RecoLocalCalo/HcalRecAlgos/interface/HcalHF_PETalgorithm.h"
 #include "DataFormats/HcalDigi/interface/HcalDigiCollections.h"
 #include "CalibFormats/HcalObjects/interface/HcalCalibrations.h"
+#include "CalibFormats/HcalObjects/interface/HcalDbService.h"
 
     /** \class HcalHitReconstructor
 	
@@ -47,7 +50,7 @@ class HcalTopology;
 
       virtual void beginRun(edm::Run const&r, edm::EventSetup const & es) override final;
       virtual void endRun(edm::Run const&r, edm::EventSetup const & es) override final;
-      virtual void produce(edm::Event& e, const edm::EventSetup& c);
+      virtual void produce(edm::Event& e, const edm::EventSetup& c) override;
 
     private:      
       typedef void (HcalSimpleRecAlgo::*SetCorrectionFcn)(boost::shared_ptr<AbsOOTPileupCorrection>);
@@ -106,9 +109,7 @@ class HcalTopology;
       SetCorrectionFcnForNegative setPileupCorrectionForNegative_;
 
       HcalRecoParams* paramTS;  // firstSample & sampleToAdd from DB  
-      const HcalFlagHFDigiTimeParams* HFDigiTimeParams; // HF DigiTime parameters
-
-      HcalTopology *theTopology;
+      std::unique_ptr<HcalFlagHFDigiTimeParams> HFDigiTimeParams; // HF DigiTime parameters
     };
 
 #endif

--- a/RecoLocalCalo/HcalRecProducers/src/HcalHitSelection.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HcalHitSelection.cc
@@ -148,7 +148,7 @@ HcalHitSelection::~HcalHitSelection()
 void
 HcalHitSelection::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
-  iSetup.get<HcalChannelQualityRcd>().get(theHcalChStatus);
+  iSetup.get<HcalChannelQualityRcd>().get("withTopo", theHcalChStatus);
   iSetup.get<HcalSeverityLevelComputerRcd>().get(theHcalSevLvlComputer);
 
   edm::Handle<HBHERecHitCollection> hbhe;

--- a/RecoLocalCalo/HcalRecProducers/src/ZdcHitReconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/ZdcHitReconstructor.cc
@@ -84,8 +84,8 @@ void ZdcHitReconstructor::produce(edm::Event& e, const edm::EventSetup& eventSet
   eventSetup.get<HcalDbRecord>().get(conditions);
   
   edm::ESHandle<HcalChannelQuality> p;
-  eventSetup.get<HcalChannelQualityRcd>().get(p);
-  HcalChannelQuality* myqual = new HcalChannelQuality(*p.product());
+  eventSetup.get<HcalChannelQualityRcd>().get("withTopo", p);
+  const HcalChannelQuality* myqual = p.product();
 
   edm::ESHandle<HcalSeverityLevelComputer> mycomputer;
   eventSetup.get<HcalSeverityLevelComputerRcd>().get(mycomputer);
@@ -146,5 +146,4 @@ void ZdcHitReconstructor::produce(edm::Event& e, const edm::EventSetup& eventSet
      e.put(rec);     
    } // else if (det_==DetId::Calo...)
 
-   delete myqual;
 } // void HcalHitReconstructor::produce(...)

--- a/RecoMET/METFilters/plugins/EcalDeadCellDeltaRFilter.cc
+++ b/RecoMET/METFilters/plugins/EcalDeadCellDeltaRFilter.cc
@@ -268,7 +268,7 @@ void EcalDeadCellDeltaRFilter::envSet(const edm::EventSetup& iSetup) {
   iSetup.get<IdealGeometryRecord>().get(ttMap_);
 
   iSetup.get<EcalChannelStatusRcd> ().get(ecalStatus);
-  iSetup.get<HcalChannelQualityRcd>().get(hcalStatus);
+  iSetup.get<HcalChannelQualityRcd>().get("withTopo",hcalStatus);
   iSetup.get<CaloGeometryRecord>   ().get(geometry);
 
   if( !ecalStatus.isValid() )  throw "Failed to get ECAL channel status!";

--- a/RecoMET/METProducers/src/HcalNoiseInfoProducer.cc
+++ b/RecoMET/METProducers/src/HcalNoiseInfoProducer.cc
@@ -324,7 +324,7 @@ HcalNoiseInfoProducer::filldigis(edm::Event& iEvent, const edm::EventSetup& iSet
   edm::ESHandle<HcalDbService> conditions;
   iSetup.get<HcalDbRecord>().get(conditions);
   edm::ESHandle<HcalChannelQuality> qualhandle;
-  iSetup.get<HcalChannelQualityRcd>().get(qualhandle);
+  iSetup.get<HcalChannelQualityRcd>().get("withTopo",qualhandle);
   const HcalChannelQuality* myqual = qualhandle.product();
   edm::ESHandle<HcalSeverityLevelComputer> mycomputer;
   iSetup.get<HcalSeverityLevelComputerRcd>().get(mycomputer);
@@ -501,7 +501,7 @@ HcalNoiseInfoProducer::fillrechits(edm::Event& iEvent, const edm::EventSetup& iS
 {
   // get the HCAL channel status map
   edm::ESHandle<HcalChannelQuality> hcalChStatus;
-  iSetup.get<HcalChannelQualityRcd>().get( hcalChStatus );
+  iSetup.get<HcalChannelQualityRcd>().get( "withTopo", hcalChStatus );
   const HcalChannelQuality* dbHcalChStatus = hcalChStatus.product();
 
   // get the severity level computer

--- a/RecoMuon/MuonIdentification/src/MuonHOAcceptance.cc
+++ b/RecoMuon/MuonIdentification/src/MuonHOAcceptance.cc
@@ -166,8 +166,8 @@ void MuonHOAcceptance::initIds(edm::EventSetup const& eSetup) {
   deadIds.clear();
 
   edm::ESHandle<HcalChannelQuality> p;
-  eSetup.get<HcalChannelQualityRcd>().get(p);
-  HcalChannelQuality *myqual = new HcalChannelQuality(*p.product());
+  eSetup.get<HcalChannelQualityRcd>().get("withTopo",p);
+  const HcalChannelQuality *myqual = p.product();
 
   edm::ESHandle<HcalSeverityLevelComputer> mycomputer;
   eSetup.get<HcalSeverityLevelComputerRcd>().get(mycomputer);
@@ -212,7 +212,6 @@ void MuonHOAcceptance::initIds(edm::EventSetup const& eSetup) {
   buildDeadAreas();
   buildSiPMAreas();
   inited = true;
-  delete myqual;
 }
 
 void MuonHOAcceptance::buildDeadAreas() {

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
@@ -1,6 +1,7 @@
 #ifndef RecoParticleFlow_PFClusterProducer_PFEcalRecHitQTests_h
 #define RecoParticleFlow_PFClusterProducer_PFEcalRecHitQTests_h
 
+#include <memory>
 #include "RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTestBase.h"
 
 
@@ -111,9 +112,8 @@ class PFRecHitQTestHCALChannel : public PFRecHitQTestBase {
       edm::ESHandle<HcalTopology> topo;
       iSetup.get<IdealGeometryRecord>().get(topo);
       edm::ESHandle<HcalChannelQuality> hcalChStatus;    
-      iSetup.get<HcalChannelQualityRcd>().get( hcalChStatus );
+      iSetup.get<HcalChannelQualityRcd>().get( "withTopo", hcalChStatus );
       theHcalChStatus_ = hcalChStatus.product();
-      if (!theHcalChStatus_->topo()) theHcalChStatus_->setTopo(topo.product());
       edm::ESHandle<HcalSeverityLevelComputer> hcalSevLvlComputerHndl;
       iSetup.get<HcalSeverityLevelComputerRcd>().get(hcalSevLvlComputerHndl);
       hcalSevLvlComputer_  =  hcalSevLvlComputerHndl.product();

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFCTRecHitProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFCTRecHitProducer.cc
@@ -829,7 +829,7 @@ PFCTRecHitProducer::beginLuminosityBlock(const edm::LuminosityBlock& lumi,
   // Get cleaned channels in the HCAL and HF 
   // HCAL channel status map ****************************************
   edm::ESHandle<HcalChannelQuality> hcalChStatus;    
-  es.get<HcalChannelQualityRcd>().get( hcalChStatus );
+  es.get<HcalChannelQualityRcd>().get( "withTopo", hcalChStatus );
   theHcalChStatus = hcalChStatus.product();
 
   // Retrieve the good/bad ECAL channels from the DB

--- a/SimCalorimetry/HcalSimAlgos/interface/HcalShapes.h
+++ b/SimCalorimetry/HcalSimAlgos/interface/HcalShapes.h
@@ -32,7 +32,7 @@ public:
 private:
   // hardcoded, if we can't figure it out form the DB
   const CaloVShape * defaultShape(const DetId & detId) const;
-  const HcalMCParams * theMCParams;
+  HcalMCParams * theMCParams;
   const HcalTopology * theTopology;
   typedef std::map<int, const CaloVShape *> ShapeMap;
   ShapeMap theShapes;

--- a/Validation/HcalRecHits/src/HcalRecHitsValidation.cc
+++ b/Validation/HcalRecHits/src/HcalRecHitsValidation.cc
@@ -784,14 +784,9 @@ void HcalRecHitsValidation::analyze(edm::Event const& ev, edm::EventSetup const&
 
   // HCAL channel status map ****************************************
   edm::ESHandle<HcalChannelQuality> hcalChStatus;
-  c.get<HcalChannelQualityRcd>().get( hcalChStatus );
-
-  edm::ESHandle<HcalTopology> topo;
-  c.get<IdealGeometryRecord>().get(topo);
+  c.get<HcalChannelQualityRcd>().get( "withTopo", hcalChStatus );
 
   theHcalChStatus = hcalChStatus.product();
-
-  if( !theHcalChStatus->topo() ) theHcalChStatus->setTopo(topo.product());
 
   // Assignment of severity levels **********************************
   edm::ESHandle<HcalSeverityLevelComputer> hcalSevLvlComputerHndl;


### PR DESCRIPTION
Modified how HCAL conditions containers are used in order to be thread safe. The `setTopo` method of the containers is now non-const. Therefore to fully initialize a container read from the database, the container is copied and the copy gets the `setTopo` call. This copy is either done via an ESProducer or, for less used containers, by the module which requested the original container.
