### PR TITLE
Correct a typo in Ele32 path names 73X

### DIFF
--- a/DQMOffline/Trigger/python/singletopHLTEventDQM_cfi.py
+++ b/DQMOffline/Trigger/python/singletopHLTEventDQM_cfi.py
@@ -211,7 +211,7 @@ SingleTopSingleElectronHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOffline
     ## will be empty
     triggerExtras = cms.PSet(
       src   = cms.InputTag("TriggerResults","","HLT"),
-      paths = cms.vstring(['HLT_Ele27_eta2p1_WP85_Gsf_v', 'HLT_Ele27_eta2p1_WP85_Gsf_TriCentralPFJet40_v', 'HLT_Ele27_eta2p1_WP85_Gsf_TriCentralPFJet60_50_35_v', 'HLT_Ele27_eta2p1_WP85_Gsf_CentralPFJet30_BTagCSV_v', 'HLT_Ele32_WP85_Gsf_CentralPFJet30_BTagCSV_v', 'HLT_Ele32_WP85_Gsf_TriCentralPFJet40_v', 'HLT_Ele32_WP85_Gsf_TriCentralPFJet60_50_35_v', 'HLT_Ele32_WP85_Gsf_v'])
+      paths = cms.vstring(['HLT_Ele27_eta2p1_WP85_Gsf_v', 'HLT_Ele27_eta2p1_WP85_Gsf_TriCentralPFJet40_v', 'HLT_Ele27_eta2p1_WP85_Gsf_TriCentralPFJet60_50_35_v', 'HLT_Ele27_eta2p1_WP85_Gsf_CentralPFJet30_BTagCSV_v', 'HLT_Ele32_eta2p1_WP85_Gsf_CentralPFJet30_BTagCSV_v', 'HLT_Ele32_eta2p1_WP85_Gsf_TriCentralPFJet40_v', 'HLT_Ele32_eta2p1_WP85_Gsf_TriCentralPFJet60_50_35_v', 'HLT_Ele32_eta2p1_WP85_Gsf_v'])
      )
   ),
   ## ------------------------------------------------------
@@ -224,7 +224,7 @@ SingleTopSingleElectronHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOffline
   preselection = cms.PSet(
     trigger = cms.PSet(
       src    = cms.InputTag("TriggerResults","","HLT"),
-      select = cms.vstring(['HLT_Ele27_eta2p1_WP85_Gsf_v', 'HLT_Ele27_eta2p1_WP85_Gsf_TriCentralPFJet40_v', 'HLT_Ele27_eta2p1_WP85_Gsf_TriCentralPFJet60_50_35_v', 'HLT_Ele27_eta2p1_WP85_Gsf_CentralPFJet30_BTagCSV_v', 'HLT_Ele32_WP85_Gsf_CentralPFJet30_BTagCSV_v', 'HLT_Ele32_WP85_Gsf_TriCentralPFJet40_v', 'HLT_Ele32_WP85_Gsf_TriCentralPFJet60_50_35_v', 'HLT_Ele32_WP85_Gsf_v'])
+      select = cms.vstring(['HLT_Ele27_eta2p1_WP85_Gsf_v', 'HLT_Ele27_eta2p1_WP85_Gsf_TriCentralPFJet40_v', 'HLT_Ele27_eta2p1_WP85_Gsf_TriCentralPFJet60_50_35_v', 'HLT_Ele27_eta2p1_WP85_Gsf_CentralPFJet30_BTagCSV_v', 'HLT_Ele32_eta2p1_WP85_Gsf_CentralPFJet30_BTagCSV_v', 'HLT_Ele32_eta2p1_WP85_Gsf_TriCentralPFJet40_v', 'HLT_Ele32_eta2p1_WP85_Gsf_TriCentralPFJet60_50_35_v', 'HLT_Ele32_eta2p1_WP85_Gsf_v'])
      ),
     ## [optional] : when omitted no preselection is applied
     vertex = cms.PSet(

--- a/DQMOffline/Trigger/python/topSingleLeptonHLTEventDQM_cfi.py
+++ b/DQMOffline/Trigger/python/topSingleLeptonHLTEventDQM_cfi.py
@@ -86,7 +86,7 @@ topSingleLeptonHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM",
   preselection = cms.PSet(
    trigger = cms.PSet(
       src    = cms.InputTag("TriggerResults","","HLT"),
-      select = cms.vstring(['HLT_Ele27_eta2p1_WP85_Gsf_v', 'HLT_Ele27_eta2p1_WP85_Gsf_TriCentralPFJet40_v', 'HLT_Ele27_eta2p1_WP85_Gsf_TriCentralPFJet60_50_35_v', 'HLT_Ele27_eta2p1_WP85_Gsf_CentralPFJet30_BTagCSV_v', 'HLT_Ele32_WP85_Gsf_CentralPFJet30_BTagCSV_v', 'HLT_Ele32_WP85_Gsf_TriCentralPFJet40_v', 'HLT_Ele32_WP85_Gsf_TriCentralPFJet60_50_35_v', 'HLT_Ele32_WP85_Gsf_v','HLT_IsoMu24_IterTrk02_v', 'HLT_IsoMu24_IterTrk02_TriCentralPFJet60_50_35_v', 'HLT_IsoMu24_IterTrk02_TriCentralPFJet40_v', 'HLT_IsoMu24_IterTrk02_CentralPFJet30_BTagCSV_v' , 'HLT_IsoMu20_eta2p1_IterTrk02_CentralPFJet30_BTagCSV_v', 'HLT_IsoMu20_eta2p1_IterTrk02_TriCentralPFJet40_v', 'HLT_IsoMu20_eta2p1_IterTrk02_TriCentralPFJet60_50_35_v', 'HLT_IsoMu20_eta2p1_IterTrk02_v', 'HLT_IsoTkMu20_eta2p1_IterTrk02_v', 'HLT_IsoMu24_eta2p1_IterTrk02_CentralPFJet30_BTagCSV_v', 'HLT_IsoMu24_eta2p1_IterTrk02_TriCentralPFJet40_v', 'HLT_IsoMu24_eta2p1_IterTrk02_TriCentralPFJet60_50_35_v', 'HLT_IsoMu24_eta2p1_IterTrk02_v', 'HLT_IsoTkMu24_eta2p1_IterTrk02_v'])
+      select = cms.vstring(['HLT_Ele27_eta2p1_WP85_Gsf_v', 'HLT_Ele27_eta2p1_WP85_Gsf_TriCentralPFJet40_v', 'HLT_Ele27_eta2p1_WP85_Gsf_TriCentralPFJet60_50_35_v', 'HLT_Ele27_eta2p1_WP85_Gsf_CentralPFJet30_BTagCSV_v', 'HLT_Ele32_eta2p1_WP85_Gsf_CentralPFJet30_BTagCSV_v', 'HLT_Ele32_eta2p1_WP85_Gsf_TriCentralPFJet40_v', 'HLT_Ele32_eta2p1_WP85_Gsf_TriCentralPFJet60_50_35_v', 'HLT_Ele32_eta2p1_WP85_Gsf_v','HLT_IsoMu24_IterTrk02_v', 'HLT_IsoMu24_IterTrk02_TriCentralPFJet60_50_35_v', 'HLT_IsoMu24_IterTrk02_TriCentralPFJet40_v', 'HLT_IsoMu24_IterTrk02_CentralPFJet30_BTagCSV_v' , 'HLT_IsoMu20_eta2p1_IterTrk02_CentralPFJet30_BTagCSV_v', 'HLT_IsoMu20_eta2p1_IterTrk02_TriCentralPFJet40_v', 'HLT_IsoMu20_eta2p1_IterTrk02_TriCentralPFJet60_50_35_v', 'HLT_IsoMu20_eta2p1_IterTrk02_v', 'HLT_IsoTkMu20_eta2p1_IterTrk02_v', 'HLT_IsoMu24_eta2p1_IterTrk02_CentralPFJet30_BTagCSV_v', 'HLT_IsoMu24_eta2p1_IterTrk02_TriCentralPFJet40_v', 'HLT_IsoMu24_eta2p1_IterTrk02_TriCentralPFJet60_50_35_v', 'HLT_IsoMu24_eta2p1_IterTrk02_v', 'HLT_IsoTkMu24_eta2p1_IterTrk02_v'])
     ),
     ## [optional] : when omitted no preselection is applied
     vertex = cms.PSet(
@@ -346,7 +346,7 @@ topSingleElectronHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM",
     ## will be empty
     triggerExtras = cms.PSet(
       src   = cms.InputTag("TriggerResults","","HLT"),
-      paths = cms.vstring(['HLT_Ele27_eta2p1_WP85_Gsf_v', 'HLT_Ele27_eta2p1_WP85_Gsf_TriCentralPFJet40_v', 'HLT_Ele27_eta2p1_WP85_Gsf_TriCentralPFJet60_50_35_v', 'HLT_Ele27_eta2p1_WP85_Gsf_CentralPFJet30_BTagCSV_v', 'HLT_Ele32_WP85_Gsf_CentralPFJet30_BTagCSV_v', 'HLT_Ele32_WP85_Gsf_TriCentralPFJet40_v', 'HLT_Ele32_WP85_Gsf_TriCentralPFJet60_50_35_v', 'HLT_Ele32_WP85_Gsf_v'])
+      paths = cms.vstring(['HLT_Ele27_eta2p1_WP85_Gsf_v', 'HLT_Ele27_eta2p1_WP85_Gsf_TriCentralPFJet40_v', 'HLT_Ele27_eta2p1_WP85_Gsf_TriCentralPFJet60_50_35_v', 'HLT_Ele27_eta2p1_WP85_Gsf_CentralPFJet30_BTagCSV_v', 'HLT_Ele32_eta2p1_WP85_Gsf_CentralPFJet30_BTagCSV_v', 'HLT_Ele32_eta2p1_WP85_Gsf_TriCentralPFJet40_v', 'HLT_Ele32_eta2p1_WP85_Gsf_TriCentralPFJet60_50_35_v', 'HLT_Ele32_eta2p1_WP85_Gsf_v'])
     )
   ),
   ## ------------------------------------------------------
@@ -359,7 +359,7 @@ topSingleElectronHLTOfflineDQM = cms.EDAnalyzer("TopSingleLeptonHLTOfflineDQM",
   preselection = cms.PSet(
    trigger = cms.PSet(
       src    = cms.InputTag("TriggerResults","","HLT"),
-      select = cms.vstring(['HLT_Ele27_eta2p1_WP85_Gsf_v', 'HLT_Ele27_eta2p1_WP85_Gsf_TriCentralPFJet40_v', 'HLT_Ele27_eta2p1_WP85_Gsf_TriCentralPFJet60_50_35_v', 'HLT_Ele27_eta2p1_WP85_Gsf_CentralPFJet30_BTagCSV_v', 'HLT_Ele32_WP85_Gsf_CentralPFJet30_BTagCSV_v', 'HLT_Ele32_WP85_Gsf_TriCentralPFJet40_v', 'HLT_Ele32_WP85_Gsf_TriCentralPFJet60_50_35_v', 'HLT_Ele32_WP85_Gsf_v'])
+      select = cms.vstring(['HLT_Ele27_eta2p1_WP85_Gsf_v', 'HLT_Ele27_eta2p1_WP85_Gsf_TriCentralPFJet40_v', 'HLT_Ele27_eta2p1_WP85_Gsf_TriCentralPFJet60_50_35_v', 'HLT_Ele27_eta2p1_WP85_Gsf_CentralPFJet30_BTagCSV_v', 'HLT_Ele32_eta2p1_WP85_Gsf_CentralPFJet30_BTagCSV_v', 'HLT_Ele32_eta2p1_WP85_Gsf_TriCentralPFJet40_v', 'HLT_Ele32_eta2p1_WP85_Gsf_TriCentralPFJet60_50_35_v', 'HLT_Ele32_eta2p1_WP85_Gsf_v'])
     ),
     ## [optional] : when omitted no preselection is applied
     vertex = cms.PSet(

--- a/HLTriggerOffline/Top/python/singletopHLTEventValidation_cfi.py
+++ b/HLTriggerOffline/Top/python/singletopHLTEventValidation_cfi.py
@@ -49,5 +49,5 @@ SingleTopSingleElectronHLTValidation = cms.EDAnalyzer('TopSingleLeptonHLTValidat
         minJets      = cms.untracked.uint32(2),
         # Trigger
         iTrigger     = cms.untracked.InputTag("TriggerResults","","HLT"),
-        vsPaths      = cms.untracked.vstring(['HLT_Ele27_eta2p1_WP85_Gsf_v', 'HLT_Ele27_eta2p1_WP85_Gsf_TriCentralPFJet40_v', 'HLT_Ele27_eta2p1_WP85_Gsf_TriCentralPFJet60_50_35_v', 'HLT_Ele27_eta2p1_WP85_Gsf_CentralPFJet30_BTagCSV_v', 'HLT_Ele32_WP85_Gsf_CentralPFJet30_BTagCSV_v', 'HLT_Ele32_WP85_Gsf_TriCentralPFJet40_v', 'HLT_Ele32_WP85_Gsf_TriCentralPFJet60_50_35_v', 'HLT_Ele32_WP85_Gsf_v']),
+        vsPaths      = cms.untracked.vstring(['HLT_Ele27_eta2p1_WP85_Gsf_v', 'HLT_Ele27_eta2p1_WP85_Gsf_TriCentralPFJet40_v', 'HLT_Ele27_eta2p1_WP85_Gsf_TriCentralPFJet60_50_35_v', 'HLT_Ele27_eta2p1_WP85_Gsf_CentralPFJet30_BTagCSV_v', 'HLT_Ele32_eta2p1_WP85_Gsf_CentralPFJet30_BTagCSV_v', 'HLT_Ele32_eta2p1_WP85_Gsf_TriCentralPFJet40_v', 'HLT_Ele32_eta2p1_WP85_Gsf_TriCentralPFJet60_50_35_v', 'HLT_Ele32_eta2p1_WP85_Gsf_v']),
 )

--- a/HLTriggerOffline/Top/python/topSingleLeptonHLTEventValidation_cfi.py
+++ b/HLTriggerOffline/Top/python/topSingleLeptonHLTEventValidation_cfi.py
@@ -49,5 +49,5 @@ topSingleElectronHLTValidation = cms.EDAnalyzer('TopSingleLeptonHLTValidation',
         minJets      = cms.untracked.uint32(4),
         # Trigger
         iTrigger     = cms.untracked.InputTag("TriggerResults","","HLT"),
-        vsPaths      = cms.untracked.vstring(['HLT_Ele27_eta2p1_WP85_Gsf_v', 'HLT_Ele27_eta2p1_WP85_Gsf_TriCentralPFJet40_v', 'HLT_Ele27_eta2p1_WP85_Gsf_TriCentralPFJet60_50_35_v', 'HLT_Ele27_eta2p1_WP85_Gsf_CentralPFJet30_BTagCSV_v', 'HLT_Ele32_WP85_Gsf_CentralPFJet30_BTagCSV_v', 'HLT_Ele32_WP85_Gsf_TriCentralPFJet40_v', 'HLT_Ele32_WP85_Gsf_TriCentralPFJet60_50_35_v', 'HLT_Ele32_WP85_Gsf_v']),
+        vsPaths      = cms.untracked.vstring(['HLT_Ele27_eta2p1_WP85_Gsf_v', 'HLT_Ele27_eta2p1_WP85_Gsf_TriCentralPFJet40_v', 'HLT_Ele27_eta2p1_WP85_Gsf_TriCentralPFJet60_50_35_v', 'HLT_Ele27_eta2p1_WP85_Gsf_CentralPFJet30_BTagCSV_v', 'HLT_Ele32_eta2p1_WP85_Gsf_CentralPFJet30_BTagCSV_v', 'HLT_Ele32_eta2p1_WP85_Gsf_TriCentralPFJet40_v', 'HLT_Ele32_eta2p1_WP85_Gsf_TriCentralPFJet60_50_35_v', 'HLT_Ele32_eta2p1_WP85_Gsf_v']),
 )


### PR DESCRIPTION
This PR aims to correct a typo in Ele32\* path names in the Top PAG validation codes. See #6068.
