### PR TITLE
73X - caching jet correctors

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/JetCorrFactorsProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/JetCorrFactorsProducer.h
@@ -123,8 +123,11 @@ namespace pat {
     /// per definition the vectors for all elements in this map should
     /// have the same size
     FlavorCorrLevelMap levels_;
+    /// cache identifier for JetCorrectionsRecord
     unsigned long long cacheId_;
+    /// cache container for jet corrections
     std::map<JetCorrFactors::Flavor, std::shared_ptr<FactorizedJetCorrector> > correctors_;
+    /// cache container for JPTOffset jet corrections
     std::shared_ptr<FactorizedJetCorrector> extraJPTOffsetCorrector_;
   };
 

--- a/PhysicsTools/PatAlgos/plugins/JetCorrFactorsProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/JetCorrFactorsProducer.h
@@ -38,7 +38,7 @@
 
 #include <map>
 #include <string>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include "DataFormats/Common/interface/View.h"
 #include "DataFormats/JetReco/interface/Jet.h"
@@ -83,7 +83,7 @@ namespace pat {
     /// result in an empty string as this correction level is not available
     std::vector<std::string> expand(const std::vector<std::string>& levels, const JetCorrFactors::Flavor& flavor);
     /// evaluate jet correction factor up to a given level
-    float evaluate(edm::View<reco::Jet>::const_iterator& jet, boost::shared_ptr<FactorizedJetCorrector>& corrector, boost::shared_ptr<FactorizedJetCorrector>& extraJPTOffset, int level);
+    float evaluate(edm::View<reco::Jet>::const_iterator& jet, const JetCorrFactors::Flavor& flavor, int level);
     /// determines the number of valid primary vertices for the standard L1Offset correction of JetMET
     int numberOf(const edm::Handle<std::vector<reco::Vertex> >& primaryVertices);
     /// map jet algorithm to payload in DB
@@ -123,6 +123,9 @@ namespace pat {
     /// per definition the vectors for all elements in this map should
     /// have the same size
     FlavorCorrLevelMap levels_;
+    unsigned long long cacheId_;
+    std::map<JetCorrFactors::Flavor, std::shared_ptr<FactorizedJetCorrector> > correctors_;
+    std::shared_ptr<FactorizedJetCorrector> extraJPTOffsetCorrector_;
   };
 
   inline int


### PR DESCRIPTION
Jet correctors used in `pat::JetCorrFactorsProducer` are cached and updated only, if the underlying `JetCorrectionsRecord` changes, instead of re-creating them in every event.
