### PR TITLE
Make RPCDigiProducer a stream module

### DIFF
--- a/SimMuon/RPCDigitizer/src/RPCDigiProducer.h
+++ b/SimMuon/RPCDigitizer/src/RPCDigiProducer.h
@@ -1,7 +1,7 @@
 #ifndef RPCDigiProducer_h
 #define RPCDigiProducer_h
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -16,7 +16,7 @@ class RPCGeometry;
 class RPCSimSetUp;
 class RPCSynchronizer;
 
-class RPCDigiProducer : public edm::EDProducer
+class RPCDigiProducer : public edm::stream::EDProducer<>
 {
 public:
 


### PR DESCRIPTION
The static analyzer did not find a thread safety problem with the
RPCDigiProducer so it was changed to a stream module.
