### PR TITLE
Fixing initialization of event setup point of PR 6030

### DIFF
--- a/Alignment/OfflineValidation/plugins/TrackerOfflineValidation.cc
+++ b/Alignment/OfflineValidation/plugins/TrackerOfflineValidation.cc
@@ -382,7 +382,9 @@ TrackerOfflineValidation::~TrackerOfflineValidation()
 void
 TrackerOfflineValidation::checkBookHists(const edm::EventSetup& es)
 {
-  lastSetup_ = &es;
+  if(lastSetup_==nullptr){
+    lastSetup_ = &es;
+  }
   es.get<TrackerDigiGeometryRecord>().get( tkGeom_ );
   const TrackerGeometry *newBareTkGeomPtr = &(*tkGeom_);
   if (newBareTkGeomPtr == bareTkGeomPtr_) return; // already booked hists, nothing changed

--- a/Alignment/OfflineValidation/plugins/TrackerOfflineValidation.cc
+++ b/Alignment/OfflineValidation/plugins/TrackerOfflineValidation.cc
@@ -382,9 +382,6 @@ TrackerOfflineValidation::~TrackerOfflineValidation()
 void
 TrackerOfflineValidation::checkBookHists(const edm::EventSetup& es)
 {
-  if(lastSetup_==nullptr){
-    lastSetup_ = &es;
-  }
   es.get<TrackerDigiGeometryRecord>().get( tkGeom_ );
   const TrackerGeometry *newBareTkGeomPtr = &(*tkGeom_);
   if (newBareTkGeomPtr == bareTkGeomPtr_) return; // already booked hists, nothing changed


### PR DESCRIPTION
Small fix to save memory. Initializing event setup pointer once for all
