### PR TITLE
Convert HcalRealisticZS to stream module

### DIFF
--- a/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalRealisticZS.cc
+++ b/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalRealisticZS.cc
@@ -62,8 +62,8 @@ HcalRealisticZS::HcalRealisticZS(edm::ParameterSet const& conf):
     //which means that channel-by-channel ZS thresholds from DB will NOT be used
     if ( conf.getParameter<int>("useConfigZSvalues") ) {
 
-      algo_=std::auto_ptr<HcalZSAlgoRealistic>
-	(new HcalZSAlgoRealistic (markAndPass,
+      algo_.reset(
+	 new HcalZSAlgoRealistic (markAndPass,
 				  conf.getParameter<int>("HBlevel"),
 				  conf.getParameter<int>("HElevel"),
 				  conf.getParameter<int>("HOlevel"),
@@ -76,8 +76,8 @@ HcalRealisticZS::HcalRealisticZS(edm::ParameterSet const& conf):
       
     } else {
 
-      algo_=std::auto_ptr<HcalZSAlgoRealistic>
-	(new HcalZSAlgoRealistic(markAndPass,				  
+      algo_.reset(
+	 new HcalZSAlgoRealistic(markAndPass,				  
 				 HBsearchTS,
 				 HEsearchTS,
 				 HOsearchTS,

--- a/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalRealisticZS.h
+++ b/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalRealisticZS.h
@@ -1,7 +1,7 @@
 #ifndef HCALSIMPLEREALISTICZS_H
 #define HCALSIMPLEREALISTICZS_H 1
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
 
@@ -17,13 +17,13 @@
 	
 \author J. Mans - Minnesota
 */
-class HcalRealisticZS : public edm::EDProducer {
+class HcalRealisticZS : public edm::stream::EDProducer<> {
 public:
   explicit HcalRealisticZS(const edm::ParameterSet& ps);
   virtual ~HcalRealisticZS();
-  virtual void produce(edm::Event& e, const edm::EventSetup& c);
+  virtual void produce(edm::Event& e, const edm::EventSetup& c) override;
 private:
-  std::auto_ptr<HcalZSAlgoRealistic> algo_;
+  std::unique_ptr<HcalZSAlgoRealistic> algo_;
   std::string inputLabel_;
   edm::EDGetTokenT<HBHEDigiCollection> tok_hbhe_;
   edm::EDGetTokenT<HODigiCollection> tok_ho_;


### PR DESCRIPTION
The HcalRealisticZS uses the HcalDbService which the static analyzer
has complained about because of that object's use of the HCAL
conditions containers. However, upon further investigation the HcalDbService
is thread safe for this use. In addition, an upcoming change to
the conditions containers will solve the remaining thread unsafe uses
of those containers.
With that in mind, it is safe to convert HcalRealisticZS to a stream module.
