### PR TITLE
Thread safe CaloTPGTranscoder

### DIFF
--- a/CalibCalorimetry/CaloTPG/plugins/CaloTPGTranscoderULUTs.cc
+++ b/CalibCalorimetry/CaloTPG/plugins/CaloTPGTranscoderULUTs.cc
@@ -22,7 +22,7 @@
 
 // user include files
 
-#include "FWCore/Framework/interface/SourceFactory.h"
+#include "FWCore/Framework/interface/ModuleFactory.h"
 #include "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/Framework/interface/EventSetupRecordIntervalFinder.h"
 
@@ -31,13 +31,17 @@
 #include "FWCore/Framework/interface/ValidityInterval.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "CondFormats/HcalObjects/interface/HcalLutMetadata.h"
+#include "Geometry/HcalTowerAlgo/interface/HcalTrigTowerGeometry.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+
 
 //
 // class decleration
 //
 
-class CaloTPGTranscoderULUTs : public edm::ESProducer,
-			 public edm::EventSetupRecordIntervalFinder {
+class CaloTPGTranscoderULUTs : public edm::ESProducer {
 public:
   CaloTPGTranscoderULUTs(const edm::ParameterSet&);
   ~CaloTPGTranscoderULUTs();
@@ -46,9 +50,6 @@ public:
   
   ReturnType produce(const CaloTPGRecord&);
 
-  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey& iKey, const edm::IOVSyncValue& iTime, edm::ValidityInterval& oInterval ) override {
-    oInterval = edm::ValidityInterval (edm::IOVSyncValue::beginOfTime(), edm::IOVSyncValue::endOfTime()); //infinite
-  }
 private:
   // ----------member data ---------------------------
   edm::FileInPath hfilename1_;
@@ -81,7 +82,6 @@ CaloTPGTranscoderULUTs::CaloTPGTranscoderULUTs(const edm::ParameterSet& iConfig)
    //the following line is needed to tell the framework what
    // data is being produced
    setWhatProduced(this);
-   findingRecord<CaloTPGRecord>();
 
    //now do what ever other initialization is needed
    read_Ascii_Compression = false;
@@ -144,9 +144,17 @@ CaloTPGTranscoderULUTs::produce(const CaloTPGRecord& iRecord)
 	 //return pTCoder;
    }
    //std::auto_ptr<CaloTPGTranscoder> pTCoder(new CaloTPGTranscoderULUT(ietal, ietah, ZS, LUTfactor, RCTLSB, nominal_gain, file1, file2));
-   std::auto_ptr<CaloTPGTranscoder> pTCoder(new CaloTPGTranscoderULUT(file1, file2));
-   return pTCoder;
+   
+   edm::ESHandle<HcalLutMetadata> lutMetadata;
+   iRecord.getRecord<HcalLutMetadataRcd>().get(lutMetadata);
+   edm::ESHandle<HcalTrigTowerGeometry> theTrigTowerGeometry;
+   iRecord.getRecord<CaloGeometryRecord>().get(theTrigTowerGeometry);
+
+
+   std::auto_ptr<CaloTPGTranscoderULUT> pTCoder(new CaloTPGTranscoderULUT(file1, file2));
+   pTCoder->setup(*lutMetadata, *theTrigTowerGeometry);
+   return std::auto_ptr<CaloTPGTranscoder>( pTCoder );
 }
 
 //define this as a plug-in
-DEFINE_FWK_EVENTSETUP_SOURCE(CaloTPGTranscoderULUTs);
+DEFINE_FWK_EVENTSETUP_MODULE(CaloTPGTranscoderULUTs);

--- a/CalibCalorimetry/CaloTPG/python/CaloTPGTranscoder_cfi.py
+++ b/CalibCalorimetry/CaloTPG/python/CaloTPGTranscoder_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-CaloTPGTranscoder = cms.ESSource("CaloTPGTranscoderULUTs",
+CaloTPGTranscoder = cms.ESProducer("CaloTPGTranscoderULUTs",
     hcalLUT1 = cms.FileInPath('CalibCalorimetry/CaloTPG/data/outputLUTtranscoder_physics.dat'),
     hcalLUT2 = cms.FileInPath('CalibCalorimetry/CaloTPG/data/TPGcalcDecompress2.txt'),
     read_Ascii_Compression_LUTs = cms.bool(False),

--- a/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
+++ b/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
@@ -16,7 +16,7 @@ using namespace std;
 
 CaloTPGTranscoderULUT::CaloTPGTranscoderULUT(const std::string& compressionFile,
                                              const std::string& decompressionFile)
-                                                : isLoaded_(false), nominal_gain_(0.), rctlsb_factor_(0.),
+                                                : nominal_gain_(0.), rctlsb_factor_(0.),
                                                   compressionFile_(compressionFile),
                                                   decompressionFile_(decompressionFile)
 {
@@ -29,7 +29,8 @@ CaloTPGTranscoderULUT::~CaloTPGTranscoderULUT() {
   }
 }
 
-void CaloTPGTranscoderULUT::loadHCALCompress() const{
+void CaloTPGTranscoderULUT::loadHCALCompress(HcalLutMetadata const& lutMetadata,
+                                             HcalTrigTowerGeometry const& theTrigTowerGeometry) {
 // Initialize analytical compression LUT's here
    // TODO cms::Error log
   if (OUTPUT_LUT_SIZE != (unsigned int) 0x400) std::cout << "Error: Analytic compression expects 10-bit LUT; found LUT with " << OUTPUT_LUT_SIZE << " entries instead" << std::endl;
@@ -56,19 +57,19 @@ void CaloTPGTranscoderULUT::loadHCALCompress() const{
         outputLUT_[lutId] = new LUT[OUTPUT_LUT_SIZE];
 
         HcalTrigTowerDetId id(ieta, iphi);
-        const HcalLutMetadatum *meta = lutMetadata_->getValues(id);
+        const HcalLutMetadatum *meta = lutMetadata.getValues(id);
         int threshold = meta->getOutputLutThreshold();
 
         for (int i = 0; i < threshold; ++i)
            outputLUT_[lutId][i] = 0;
 
         for (unsigned int i = threshold; i < OUTPUT_LUT_SIZE; ++i)
-           outputLUT_[lutId][i] = (abs(ieta) < theTrigTowerGeometry->firstHFTower()) ? analyticalLUT[i] : identityLUT[i];
+           outputLUT_[lutId][i] = (abs(ieta) < theTrigTowerGeometry.firstHFTower()) ? analyticalLUT[i] : identityLUT[i];
      } //for iphi
   } //for ieta
 }
 
-void CaloTPGTranscoderULUT::loadHCALCompress(const std::string& filename) const{
+void CaloTPGTranscoderULUT::loadHCALCompress(const std::string& filename, HcalLutMetadata const& lutMetadata, HcalTrigTowerGeometry const& theTrigTowerGeometry) {
   int tool;
   std::ifstream userfile;
   std::vector< std::vector<LUT> > outputluts;
@@ -168,11 +169,12 @@ void CaloTPGTranscoderULUT::loadHCALCompress(const std::string& filename) const{
 	
   } else {
     
-	loadHCALCompress();
+    loadHCALCompress(lutMetadata,theTrigTowerGeometry);
   }
 }
 
-void CaloTPGTranscoderULUT::loadHCALUncompress() const {
+void CaloTPGTranscoderULUT::loadHCALUncompress(HcalLutMetadata const& lutMetadata,
+                                               HcalTrigTowerGeometry const& theTrigTowerGeometry) {
    hcaluncomp_.clear();
    for (int i = 0; i < NOUTLUTS; i++){
       RCTdecompression decompressionTable(TPGMAX,0);
@@ -182,7 +184,7 @@ void CaloTPGTranscoderULUT::loadHCALUncompress() const {
    for (int ieta = -32; ieta <= 32; ++ieta){
 
       double eta_low = 0., eta_high = 0.;
-		theTrigTowerGeometry->towerEtaBounds(ieta,eta_low,eta_high); 
+		theTrigTowerGeometry.towerEtaBounds(ieta,eta_low,eta_high); 
       double cosh_ieta = fabs(cosh((eta_low + eta_high)/2.));
 
 		for (int iphi = 1; iphi <= 72; iphi++) {
@@ -191,11 +193,11 @@ void CaloTPGTranscoderULUT::loadHCALUncompress() const {
 			int lutId = getOutputLUTId(ieta,iphi);
          HcalTrigTowerDetId id(ieta, iphi);
 
-         const HcalLutMetadatum *meta = lutMetadata_->getValues(id);
+         const HcalLutMetadatum *meta = lutMetadata.getValues(id);
          double factor = 0.;
 
          // HF
-         if (abs(ieta) >= theTrigTowerGeometry->firstHFTower())
+         if (abs(ieta) >= theTrigTowerGeometry.firstHFTower())
             factor = rctlsb_factor_;
          // HBHE
          else 
@@ -217,7 +219,7 @@ void CaloTPGTranscoderULUT::loadHCALUncompress() const {
 	} // for ieta
 }
 
-void CaloTPGTranscoderULUT::loadHCALUncompress(const std::string& filename) const {
+void CaloTPGTranscoderULUT::loadHCALUncompress(const std::string& filename, HcalLutMetadata const& lutMetadata, HcalTrigTowerGeometry const& theTrigTowerGeometry)  {
   std::ifstream userfile;
   userfile.open(filename.c_str());
   
@@ -242,7 +244,7 @@ void CaloTPGTranscoderULUT::loadHCALUncompress(const std::string& filename) cons
   }
   else {
 
-	loadHCALUncompress();
+    loadHCALUncompress(lutMetadata,theTrigTowerGeometry);
   }
 }
 
@@ -263,10 +265,6 @@ HcalTriggerPrimitiveSample CaloTPGTranscoderULUT::hcalCompress(const HcalTrigTow
 }
 
 double CaloTPGTranscoderULUT::hcaletValue(const int& ieta, const int& iphi, const int& compET) const {
-  if (hcaluncomp_.empty()) {
-
-	CaloTPGTranscoderULUT::loadHCALUncompress(decompressionFile_);
-  }
   double etvalue = 0.;
   int itower = getOutputLUTId(ieta,iphi);
   if (itower < 0) std::cout << "hcaletValue error: no decompression LUT found for ieta, iphi = " << ieta << ", " << iphi << std::endl;
@@ -278,11 +276,6 @@ double CaloTPGTranscoderULUT::hcaletValue(const int& ieta, const int& iphi, cons
 double CaloTPGTranscoderULUT::hcaletValue(const int& ieta, const int& compET) const {
 // This is now an obsolete method; we return the AVERAGE over all the allowed iphi channels if it's invoked
 // The user is encouraged to use hcaletValue(const int& ieta, const int& iphi, const int& compET) instead
-
-  if (hcaluncomp_.empty()) {
-	std::cout << "Initializing the RCT decompression table from the file: " << decompressionFile_ << std::endl;
-	CaloTPGTranscoderULUT::loadHCALUncompress(decompressionFile_);
-  }
 
   double etvalue = 0.;
   if (compET < 0 || compET > 0xff) std::cout << "hcaletValue error: compressed value out of range: eta, cET = " << ieta << ", " << compET << std::endl;
@@ -302,7 +295,6 @@ double CaloTPGTranscoderULUT::hcaletValue(const int& ieta, const int& compET) co
 }
 
 double CaloTPGTranscoderULUT::hcaletValue(const HcalTrigTowerDetId& hid, const HcalTriggerPrimitiveSample& hc) const {
-  if (hcaluncomp_.empty()) loadHCALUncompress(decompressionFile_);
 
   int ieta = hid.ieta();			// No need to check the validity,
   int iphi = hid.iphi();			// as the values are guaranteed
@@ -364,39 +356,23 @@ std::vector<unsigned char> CaloTPGTranscoderULUT::getCompressionLUT(HcalTrigTowe
    return lut;
 }
 
-void CaloTPGTranscoderULUT::setup(const edm::EventSetup& es, Mode mode=All) const{
-   if (isLoaded_) return;
-   // TODO Try/except
-   es.get<HcalLutMetadataRcd>().get(lutMetadata_);
-   es.get<CaloGeometryRecord>().get(theTrigTowerGeometry);
-   
-   nominal_gain_ = lutMetadata_->getNominalGain();
-   float rctlsb =lutMetadata_->getRctLsb();
+void CaloTPGTranscoderULUT::setup(HcalLutMetadata const& lutMetadata, HcalTrigTowerGeometry const& theTrigTowerGeometry)
+{
+   nominal_gain_ = lutMetadata.getNominalGain();
+   float rctlsb =lutMetadata.getRctLsb();
    if (rctlsb != 0.25 && rctlsb != 0.5)
       throw cms::Exception("RCTLSB") << " value=" << rctlsb << " (should be 0.25 or 0.5)" << std::endl;
    rctlsb_factor_ = rctlsb;
 
    if (compressionFile_.empty() && decompressionFile_.empty()) {
-      loadHCALCompress();
+     loadHCALCompress(lutMetadata,theTrigTowerGeometry);
    }
    else {
       // TODO Message to discourage using txt.
       std::cout << "From Text File:" << std::endl;
-      loadHCALCompress(compressionFile_);
+      loadHCALCompress(compressionFile_, lutMetadata,theTrigTowerGeometry);
    }
-   isLoaded_ = true;
-}
-
-void CaloTPGTranscoderULUT::printDecompression() const{
-   std::cout << "RCT Decompression table" << std::endl;                          
-   for (int i=0; i < 256; i++) {                                                 
-      for (int j=1; j <= theTrigTowerGeometry->nTowers(); j++)
-         std::cout << int(hcaletValue(j,i)*100. + 0.5)/100. << " ";
-      std::cout << std::endl;                                               
-      for (int j=1; j <= theTrigTowerGeometry->nTowers(); j++)               
-         if (hcaletValue(j,i) != hcaletValue(-j,i))                    
-            cout << "Error: decompression table for ieta = +/- " << j << " disagree! " << hcaletValue(-j,i) << ", " << hcaletValue(j,i) << endl;        
-   }
+   loadHCALUncompress(decompressionFile_, lutMetadata,theTrigTowerGeometry);
 }
 
 //int CaloTPGTranscoderULUT::getLutGranularity(const DetId& id) const{

--- a/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.h
+++ b/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.h
@@ -5,7 +5,6 @@
 #include "CalibFormats/CaloTPG/interface/CaloTPGTranscoder.h"
 
 // tmp
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "CondFormats/HcalObjects/interface/HcalLutMetadata.h"
 
 
@@ -35,9 +34,8 @@ public:
   virtual double hcaletValue(const HcalTrigTowerDetId& hid, const HcalTriggerPrimitiveSample& hc) const;
   virtual bool HTvalid(const int ieta, const int iphi) const;
   virtual std::vector<unsigned char> getCompressionLUT(HcalTrigTowerDetId id) const;
-  virtual void setup(const edm::EventSetup& es, Mode) const;
+  virtual void setup(HcalLutMetadata const&, HcalTrigTowerGeometry const&);
   virtual int getOutputLUTId(const int ieta, const int iphi) const;
-  void printDecompression() const;
 
  private:
   // Typedef
@@ -52,17 +50,16 @@ public:
   static const bool newHFphi = true;
 
   // Member functions
-  void loadHCALCompress(void) const; //Analytical compression tables
-  void loadHCALCompress(const std::string& filename) const; //Compression tables from file
-  void loadHCALUncompress(void) const; //Analytical decompression
-  void loadHCALUncompress(const std::string& filename) const; //Decompression tables from file
+  void loadHCALCompress(HcalLutMetadata const&, HcalTrigTowerGeometry const&) ; //Analytical compression tables
+  void loadHCALCompress(const std::string& filename, HcalLutMetadata const&, HcalTrigTowerGeometry const&) ; //Compression tables from file
+  void loadHCALUncompress(HcalLutMetadata const&, HcalTrigTowerGeometry const&) ; //Analytical decompression
+  void loadHCALUncompress(const std::string& filename, HcalLutMetadata const&, HcalTrigTowerGeometry const&) ; //Decompression tables from file
   //int getLutGranularity(const DetId& id) const;
   //int getLutThreshold(const DetId& id) const;
 
   // Member Variables
-  mutable bool isLoaded_;
-  mutable double nominal_gain_;
-  mutable double rctlsb_factor_;
+  double nominal_gain_;
+  double rctlsb_factor_;
   std::string compressionFile_;
   std::string decompressionFile_;
   std::vector<int> ietal;
@@ -70,9 +67,7 @@ public:
   std::vector<int> ZS;
   std::vector<int> LUTfactor;
 
-  mutable LUT *outputLUT_[NOUTLUTS];
-  mutable std::vector<RCTdecompression> hcaluncomp_;
-  mutable edm::ESHandle<HcalLutMetadata> lutMetadata_;
-  mutable edm::ESHandle<HcalTrigTowerGeometry> theTrigTowerGeometry;
+  LUT *outputLUT_[NOUTLUTS];
+  std::vector<RCTdecompression> hcaluncomp_;
 };
 #endif

--- a/CalibCalorimetry/HcalTPGIO/src/HcalLuttoDB.cc
+++ b/CalibCalorimetry/HcalTPGIO/src/HcalLuttoDB.cc
@@ -274,7 +274,6 @@ HcalLuttoDB::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
   iSetup.get<HcalTPGRecord>().get(inputCoder);
   edm::ESHandle<CaloTPGTranscoder> outTranscoder;
   iSetup.get<CaloTPGRecord>().get(outTranscoder);
-  outTranscoder->setup(iSetup,CaloTPGTranscoder::HcalTPG);
 
   std::vector<HcalElectronicsId> allEID = Map_->allElectronicsId();
   std::vector<HcalElectronicsId>::iterator itreid;
@@ -318,7 +317,6 @@ HcalLuttoDB::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
   *oc_ << "</CFGBrick>\n";
   delete oc_;
 
-  outTranscoder->releaseSetup();
 }
 
 

--- a/CalibFormats/CaloTPG/BuildFile.xml
+++ b/CalibFormats/CaloTPG/BuildFile.xml
@@ -4,6 +4,8 @@
 <use   name="DataFormats/EcalDigi"/>
 <use   name="CalibFormats/CaloObjects"/>
 <use   name="FWCore/Framework"/>
+<use   name="Geometry/Records"/>
+<use   name="CondFormats/DataRecord"/>
 <use   name="boost"/>
 <export>
   <lib   name="1"/>

--- a/CalibFormats/CaloTPG/interface/CaloTPGRecord.h
+++ b/CalibFormats/CaloTPG/interface/CaloTPGRecord.h
@@ -19,8 +19,10 @@
 // $Id$
 //
 
-#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+#include "FWCore/Framework/interface/DependentRecordImplementation.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "CondFormats/DataRecord/interface/HcalLutMetadataRcd.h"
 
-class CaloTPGRecord : public edm::eventsetup::EventSetupRecordImplementation<CaloTPGRecord> {};
+class CaloTPGRecord : public edm::eventsetup::DependentRecordImplementation<CaloTPGRecord, boost::mpl::vector<HcalLutMetadataRcd,CaloGeometryRecord> > {};
 
 #endif

--- a/CalibFormats/CaloTPG/interface/CaloTPGTranscoder.h
+++ b/CalibFormats/CaloTPG/interface/CaloTPGTranscoder.h
@@ -27,10 +27,6 @@ public:
   virtual ~CaloTPGTranscoder(); 
 
   enum Mode { All=0, RCT=1, HcalTPG=2, EcalTPG=3 };
-  /// Obtain any needed objects from the EventSetup.  Note that any member variables which are changed must be mutable.
-  virtual void setup(const edm::EventSetup& es, Mode mode=All) const;
-  /// Release any objects obtained from the EventSetup
-  virtual void releaseSetup() const;
   /** \brief Compression from linear samples+fine grain in the HTR */
   virtual HcalTriggerPrimitiveSample hcalCompress(const HcalTrigTowerDetId& id, unsigned int sample, bool fineGrain) const = 0;
   /** \brief Compression from linear samples+fine grain in the ECAL */
@@ -47,11 +43,11 @@ public:
   virtual double hcaletValue(const int& ieta, const int& compET) const = 0;  
   virtual double hcaletValue(const int& ieta, const int& iphi, const int& compressedValue) const = 0;
   virtual double hcaletValue(const HcalTrigTowerDetId& hid, const HcalTriggerPrimitiveSample& hc) const = 0; 
-  boost::shared_ptr<HcalTPGCompressor> getHcalCompressor() const { return hccompress_; }
-  boost::shared_ptr<EcalTPGCompressor> getEcalCompressor() const { return eccompress_; }
+  boost::shared_ptr<const HcalTPGCompressor> getHcalCompressor() const { return hccompress_; }
+  boost::shared_ptr<const EcalTPGCompressor> getEcalCompressor() const { return eccompress_; }
 private:
-  boost::shared_ptr<HcalTPGCompressor> hccompress_;
-  boost::shared_ptr<EcalTPGCompressor> eccompress_;
+  boost::shared_ptr<const HcalTPGCompressor> hccompress_;
+  boost::shared_ptr<const EcalTPGCompressor> eccompress_;
 };
 
 #endif

--- a/CalibFormats/CaloTPG/src/CaloTPGTranscoder.cc
+++ b/CalibFormats/CaloTPG/src/CaloTPGTranscoder.cc
@@ -9,9 +9,3 @@ CaloTPGTranscoder::CaloTPGTranscoder() :
 
 CaloTPGTranscoder::~CaloTPGTranscoder() {
 }
-
-void CaloTPGTranscoder::setup(const edm::EventSetup& es, CaloTPGTranscoder::Mode mode) const {
-}
-
-void CaloTPGTranscoder::releaseSetup() const {
-}

--- a/CaloOnlineTools/HcalOnlineDb/src/HcalLutGenerator.cc
+++ b/CaloOnlineTools/HcalOnlineDb/src/HcalLutGenerator.cc
@@ -42,7 +42,7 @@ void HcalLutGenerator::analyze(const edm::Event& iEvent, const edm::EventSetup& 
   //
   edm::ESHandle<CaloTPGTranscoder> outTranscoder;
   iSetup.get<CaloTPGRecord>().get(outTranscoder);
-  outTranscoder->setup(iSetup,CaloTPGTranscoder::HcalTPG);
+ 
   edm::ESHandle<CaloTPGTranscoderULUT> transcoder;
   transcoder.swap(outTranscoder);
 
@@ -120,7 +120,6 @@ void HcalLutGenerator::analyze(const edm::Event& iEvent, const edm::EventSetup& 
   manager -> createLutXmlFiles_HBEFFromCoder_HOFromAscii_ZDC( _tag, *inputCoder, *transcoder, _lin_file, split_by_crate );
   delete manager;
 
-  transcoder->releaseSetup();
    
 }
 

--- a/SimCalorimetry/HcalTrigPrimProducers/src/HcalTrigPrimDigiProducer.cc
+++ b/SimCalorimetry/HcalTrigPrimProducers/src/HcalTrigPrimDigiProducer.cc
@@ -57,7 +57,6 @@ void HcalTrigPrimDigiProducer::produce(edm::Event& iEvent, const edm::EventSetup
 
   edm::ESHandle<CaloTPGTranscoder> outTranscoder;
   eventSetup.get<CaloTPGRecord>().get(outTranscoder);
-  outTranscoder->setup(eventSetup,CaloTPGTranscoder::HcalTPG);
 
   edm::ESHandle<HcalLutMetadata> lutMetadata;
   eventSetup.get<HcalLutMetadataRcd>().get(lutMetadata);
@@ -88,8 +87,6 @@ void HcalTrigPrimDigiProducer::produce(edm::Event& iEvent, const edm::EventSetup
       // put empty HcalTrigPrimDigiCollection in the event
       iEvent.put(result);
 
-      outTranscoder->releaseSetup();
-
       return;
   }
 
@@ -102,8 +99,6 @@ void HcalTrigPrimDigiProducer::produce(edm::Event& iEvent, const edm::EventSetup
 
       // put empty HcalTrigPrimDigiCollection in the event
       iEvent.put(result);
-
-      outTranscoder->releaseSetup();
 
       return;
   }
@@ -138,8 +133,6 @@ void HcalTrigPrimDigiProducer::produce(edm::Event& iEvent, const edm::EventSetup
 
             iEvent.put(emptyResult);
 
-            outTranscoder->releaseSetup();
-
             return;
         }
 
@@ -151,8 +144,6 @@ void HcalTrigPrimDigiProducer::produce(edm::Event& iEvent, const edm::EventSetup
 
   // Step D: Put outputs into event
   iEvent.put(result);
-
-  outTranscoder->releaseSetup();
 }
 
 


### PR DESCRIPTION
CaloTPGTranscoder is one of the last (if not the last) EventSetup product to be thread-unsafe.
These commits change the way that class is handles so that it gets fully initialized in its ESProducer and therefore later clients do not need to cause it to be updated.
