### PR TITLE
TimeSlew modelling update

### DIFF
--- a/SimCalorimetry/HcalSimAlgos/src/HcalTimeSlewSim.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalTimeSlewSim.cc
@@ -45,19 +45,39 @@ void HcalTimeSlewSim::delay(CaloSamples & samples, CLHEP::HepRandomEngine* engin
       HcalTimeSlew::Slow :
       HcalTimeSlew::Medium;
 
-    double totalCharge = charge(samples);
-    if(totalCharge <= 0.) totalCharge = 1.e-6; // protecion against negaive v.
-    double delay = HcalTimeSlew::delay(totalCharge, biasSetting);
-    // now, the smearing
-    const HcalSimParameters& params=static_cast<const HcalSimParameters&>(theParameterMap->simParameters(detId));
-    if (params.doTimeSmear()) {
-      double rms=params.timeSmearRMS(totalCharge);
-      double smearns=CLHEP::RandGaussQ::shoot(engine)*rms;
+    // double totalCharge = charge(samples);
 
-      LogDebug("HcalTimeSlewSim") << "TimeSmear charge " << totalCharge << " rms " << rms << " delay " << delay << " smearns " << smearns;
-      delay+=smearns;
+    int maxbin =  samples.size();
+    std::vector<double> data(maxbin);    
+    for(int i = 0; i < maxbin-1; ++i) data[i] = samples[i];  
+
+    for(int i = 0; i < samples.size(); ++i) {
+      double totalCharge = data[i]/0.6;   // temporary change from total charge to approximation TS/0.6
+                                          // until we get more precise/reliable QIE8 simulation  
+
+      if(totalCharge <= 0.) totalCharge = 1.e-6; // protecion against negaive v.
+      double delay = HcalTimeSlew::delay(totalCharge, biasSetting);
+      // now, the smearing still remains
+      const HcalSimParameters& params=static_cast<const HcalSimParameters&>(theParameterMap->simParameters(detId));
+      if (params.doTimeSmear()) {
+	double rms=params.timeSmearRMS(totalCharge);
+	double smearns=CLHEP::RandGaussQ::shoot(engine)*rms;
+	
+	LogDebug("HcalTimeSlewSim") << "TimeSmear charge " << totalCharge << " rms " << rms << " delay " << delay << " smearns " << smearns;
+	delay+=smearns;
+      }
+      
+      // samples.offsetTime(delay);  -> replacing it with 1TS move 
+
+      double t = i*25. - delay;
+      int firstbin = floor(t/25.);
+      double f = t/25. - firstbin;
+      int nextbin = firstbin + 1;
+      double v2 = (nextbin < 0  || nextbin  >= maxbin) ? 0. : data[nextbin];
+      data[i] = v2*f;
+      data[i+1] = data[i+1] + (v2 - data[i]); 
     }
+    for(int i = 0; i < maxbin; ++i)  samples[i] = data[i];  
 
-    samples.offsetTime(delay);
   }
 }

--- a/SimCalorimetry/HcalSimAlgos/src/HcalTimeSlewSim.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalTimeSlewSim.cc
@@ -16,7 +16,7 @@ HcalTimeSlewSim::HcalTimeSlewSim(const CaloVSimParameterMap * parameterMap)
 }
 
 
-
+// not quite adequate to 25ns high-PU regime
 double HcalTimeSlewSim::charge(const CaloSamples & samples) const
 {
   double totalCharge = 0.;
@@ -45,13 +45,13 @@ void HcalTimeSlewSim::delay(CaloSamples & samples, CLHEP::HepRandomEngine* engin
       HcalTimeSlew::Slow :
       HcalTimeSlew::Medium;
 
-    // double totalCharge = charge(samples);
+    // double totalCharge = charge(samples); 
 
     int maxbin =  samples.size();
-    std::vector<double> data(maxbin);    
-    for(int i = 0; i < maxbin-1; ++i) data[i] = samples[i];  
+    CaloSamples data(detId, maxbin);   // for a temporary copy 
+    data =  samples;  
 
-    for(int i = 0; i < samples.size(); ++i) {
+    for(int i = 0; i < samples.size()-1; ++i) {
       double totalCharge = data[i]/0.6;   // temporary change from total charge to approximation TS/0.6
                                           // until we get more precise/reliable QIE8 simulation  
 
@@ -77,7 +77,6 @@ void HcalTimeSlewSim::delay(CaloSamples & samples, CLHEP::HepRandomEngine* engin
       data[i] = v2*f;
       data[i+1] = data[i+1] + (v2 - data[i]); 
     }
-    for(int i = 0; i < maxbin; ++i)  samples[i] = data[i];  
-
+    samples = data;
   }
 }


### PR DESCRIPTION
NB: to have it more adequate to 25ns high-PU simulation. Needs to be included in 73X in sync with "Method 2"  
https://github.com/cms-sw/cmssw/pull/5954

(1)
Current TimeSlew modelling has been developed/implemented quite some time ago and it relies on the "standalone" signal properties, evaluating the time delay of the signal based on the total charge collected in 4TS.  It was OK for low-PU sparse BX simulation , but becomes less adequate for high-PU 25ns regime.  
(2)
This update still uses existing "TimeSlew vs full-signal" parametrization, but it makes estimates for "full signal" for each 1TS  and delays each TS accordingly, which corresponds better to the hardware operation mode.
Still keeps previous TimeSlew smearing evaluated in 2010 (to mimic real data timing variation).  
(3)  
More advanced and detailed simulation of the HCAL FE electronics properties is being developed, but out of scope of 730. 
