### PR TITLE
label the processString with _gen for generator specific relvals

### DIFF
--- a/Configuration/PyReleaseValidation/python/MatrixInjector.py
+++ b/Configuration/PyReleaseValidation/python/MatrixInjector.py
@@ -191,6 +191,8 @@ class MatrixInjector(object):
                     index=0
                     splitForThisWf=None
                     thisLabel=self.speciallabel
+                    if 'HARVESTGEN' in s[3]:
+                        thisLabel=thisLabel+"_gen"
                     processStrPrefix=''
                     setPrimaryDs=None
                     for step in s[3]:


### PR DESCRIPTION
- only relevant for submission to computing; not relevant for performance / IB 
- label the processString with _gen for generator specific relvals
- as requested by @anorkus to ease bookeping and relmon-ification of generator relvals

Hello @bendavid @inugent , this will address the relmon report needs you expressed last week.
Will back port this chance to 7_1 too, in anticipation of when we'll have GEN relvals there too.
