### PR TITLE
label the processString with _gen for generator specific relvals

### DIFF
--- a/Configuration/PyReleaseValidation/python/MatrixInjector.py
+++ b/Configuration/PyReleaseValidation/python/MatrixInjector.py
@@ -191,6 +191,8 @@ class MatrixInjector(object):
                     index=0
                     splitForThisWf=None
                     thisLabel=self.speciallabel
+                    if 'HARVESTGEN' in s[3]:
+                        thisLabel=thisLabel+"_gen"
                     processStrPrefix=''
                     setPrimaryDs=None
                     for step in s[3]:


### PR DESCRIPTION
- back port from 7_3, the same logic as pr #6104
- only relevant for submission to computing; not relevant for performance / IB
- label the processString with _gen for generator specific relvals
- as requested by @anorkus to ease bookeping and relmon-ification of generator relvals
-  the labelling will become effective once the content of the GEN relvals will be back-ported to 71 (@bendavid @inugent: gen fragment missing)
