### PR TITLE
HLT paths for VBFHbb and ZnnHbb

### DIFF
--- a/HLTriggerOffline/Higgs/python/hltHiggsPostProcessors_cff.py
+++ b/HLTriggerOffline/Higgs/python/hltHiggsPostProcessors_cff.py
@@ -146,26 +146,26 @@ hltHiggsPostHtaunu.efficiencyProfile = efficiency_strings
 #Specific plots for VBFHbb  
 #dEtaqq, mqq, dPhibb, CVS1, maxCSV_jets, maxCSV_E, MET, pt1, pt2, pt3, pt4
 NminOneCutNames = ("EffdEtaqq", "Effmqq", "EffdPhibb", "EffCSV1", "EffmaxCSV", "", "TurnOn1", "TurnOn2", "TurnOn3", "TurnOn4")
-#plot_types = ["EffEta", "EffPhi"]
-#NminOneCuts = (_config.__getattribute__("VBFHbb")).__getattribute__("NminOneCuts")
-#if NminOneCuts: 
-    #for iCut in range(0,len(NminOneCuts)-1):
-        #if( NminOneCuts[iCut] and NminOneCutNames[iCut] ):
-            #if( NminOneCutNames[iCut] == "EffmaxCSV" ):
-                #plot_types.pop()
-            #plot_types.append(NminOneCutNames[iCut])
+plot_types = ["EffEta", "EffPhi"]
+NminOneCuts = (_config.__getattribute__("VBFHbb")).__getattribute__("NminOneCuts")
+if NminOneCuts: 
+    for iCut in range(0,len(NminOneCuts)-1):
+        if( NminOneCuts[iCut] and NminOneCutNames[iCut] ):
+            if( NminOneCutNames[iCut] == "EffmaxCSV" ):
+                plot_types.pop()
+            plot_types.append(NminOneCutNames[iCut])
     
-#efficiency_strings = []
-#for type in plot_types:
-    #for obj in ["Jet"]:
-        #for trig in triggers:
-            #efficiency_strings.append(efficiency_string(obj,type,trig))
+efficiency_strings = []
+for type in plot_types:
+    for obj in ["Jet"]:
+        for trig in triggers:
+            efficiency_strings.append(efficiency_string(obj,type,trig))
         
-#efficiency_strings = get_reco_strings(efficiency_strings)
+efficiency_strings = get_reco_strings(efficiency_strings)
     
-#hltHiggsPostVBFHbb = hltHiggsPostProcessor.clone()
-#hltHiggsPostVBFHbb.subDirs = ['HLT/Higgs/VBFHbb']
-#hltHiggsPostVBFHbb.efficiencyProfile = efficiency_strings
+hltHiggsPostVBFHbb = hltHiggsPostProcessor.clone()
+hltHiggsPostVBFHbb.subDirs = ['HLT/Higgs/VBFHbb']
+hltHiggsPostVBFHbb.efficiencyProfile = efficiency_strings
 
 #Specific plots for ZnnHbb
 #Jet plots
@@ -205,7 +205,7 @@ hltHiggsPostProcessors = cms.Sequence(
         hltHiggsPostHgg+
         hltHiggsPostHtaunu+
         hltHiggsPostH2tau+
-        #hltHiggsPostVBFHbb+
+        hltHiggsPostVBFHbb+
         hltHiggsPostZnnHbb
 )
 

--- a/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
+++ b/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
         
     hltProcessName = cms.string("HLT"),
-    analysis       = cms.vstring("HWW", "HZZ", "Hgg", "Htaunu", "H2tau", "ZnnHbb"), 
+    analysis       = cms.vstring("HWW", "HZZ", "Hgg", "Htaunu", "H2tau", "VBFHbb", "ZnnHbb"), 
     
     # -- The instance name of the reco::GenParticles collection
     genParticleLabel = cms.string("genParticles"),
@@ -81,8 +81,8 @@ hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
     PFMET_cutMaxEta   = cms.double(0),  # TO BE DEPRECATED
     
     # --- Jets: 
-    Jet_genCut      = cms.string("pt > 0."),
-    Jet_recCut      = cms.string("pt > 0."),  
+    Jet_genCut      = cms.string("pt > 10"),
+    Jet_recCut      = cms.string("pt > 10"),  
     Jet_cutMinPt    = cms.double(0), # TO BE DEPRECATED
     Jet_cutMaxEta   = cms.double(0),  # TO BE DEPRECATED
     
@@ -170,29 +170,30 @@ hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
         # -- Analysis specific cuts
         minCandidates = cms.uint32(2), 
         ),
-    #VBFHbb  = cms.PSet( 
-        #hltPathsToCheck = cms.vstring(
-            #"HLT_QuadJet75_55_35_20_BTagIP_VBF_v",
-            #"HLT_QuadJet75_55_38_20_BTagIP_VBF_v"
-            #),
-        ##recJetLabel  = cms.string("ak5PFJets"),
-        #recJetLabel  = cms.string("higgsDqmPFJetsFilter"),
-        #jetTagLabel  = cms.string("hltHiggsDqmPfCombinedSecondaryVertexBJetTags"),
-        ## -- Analysis specific cuts
-        #minCandidates = cms.uint32(4), 
-        #NminOneCuts = cms.untracked.vdouble(2.4, 300, 2, 0, 0, 0, 0, 85, 70, 60, 40), #dEtaqq, mqq, dPhibb, CSV1, maxCSV_jets, maxCSV_E, MET, pt1, pt2, pt3, pt4
-        #),
+    VBFHbb  = cms.PSet( 
+        hltPathsToCheck = cms.vstring(
+            "HLT_QuadPFJet_BTagCSV_VBF_v",
+            "HLT_QuadPFJet_VBF_v",
+            "HLT_L1_TripleJet_VBF_v"
+            ),
+        recJetLabel  = cms.string("ak4PFJetsCHS"),
+        jetTagLabel  = cms.string("pfCombinedSecondaryVertexBJetTags"),
+        # -- Analysis specific cuts
+        minCandidates = cms.uint32(4), 
+        NminOneCuts = cms.untracked.vdouble(2.6, 350, 2.6, 0.8, 0, 0, 0, 95, 85, 70, 40), #dEtaqq, mqq, dPhibb, CSV1, maxCSV_jets, maxCSV_E, MET, pt1, pt2, pt3, pt4
+        ),
     ZnnHbb = cms.PSet( 
         hltPathsToCheck = cms.vstring(
-            "HLT_PFMHT100_SingleCentralJet60_BTagCSV0p6_v"
-            #"HLT_DiCentralPFJet30_PFMET80_BTagCSV07_v"
+            "HLT_CaloMHTNoPU90_PFMET90_PFMHT90_IDLoose_BTagCSV0p7_v",
+            "HLT_PFMET110_PFMHT110_IDLoose_v",
+            "HLT_CaloMHTNoPU90_PFMET90_PFMHT90_IDLoose_v"
             ),
-        Jet_recCut   = cms.string("abs(eta) < 2.6"),
+        Jet_recCut   = cms.string("pt > 10 && abs(eta) < 2.6"),
         recJetLabel  = cms.string("ak4PFJetsCHS"),
         jetTagLabel  = cms.string("pfCombinedSecondaryVertexBJetTags"),
         recPFMETLabel = cms.string("pfMet"),  
         # -- Analysis specific cuts
         minCandidates = cms.uint32(1), 
-        NminOneCuts = cms.untracked.vdouble(0, 0, 0, 0.9, 4, 20, 80, 60), #dEtaqq, mqq, dPhibb, CSV1, maxCSV_jets, maxCSV_E, MET, pt1
+        NminOneCuts = cms.untracked.vdouble(0, 0, 0, 0.9, 8, 30, 100, 70), #dEtaqq, mqq, dPhibb, CSV1, maxCSV_jets, maxCSV_E, MET, pt1
         ),
 )

--- a/HLTriggerOffline/Higgs/src/HLTHiggsPlotter.cc
+++ b/HLTriggerOffline/Higgs/src/HLTHiggsPlotter.cc
@@ -229,7 +229,7 @@ void HLTHiggsPlotter::analyze(const bool & isPassTrigger, const std::string & so
             break;
         }
     }
-    if( source == "rec") {
+    if( source == "rec" && _objectsType.find(EVTColContainer::PFJET) != _objectsType.end()) {
         if( _NminOneCuts[0] && nMinOne["dEtaqq"] ) {
             this->fillHist(isPassTrigger,source,EVTColContainer::getTypeString(EVTColContainer::PFJET),"dEtaqq",dEtaqq);
         }
@@ -275,7 +275,7 @@ void HLTHiggsPlotter::bookHist(const std::string & source,
         
         std::string jetObj = EVTColContainer::getTypeString(EVTColContainer::PFJET);
         if( objType == jetObj ) {
-            const size_t nBinsJets = 20;
+            const size_t nBinsJets = 25;
             nBins = nBinsJets;
             delete [] edges;
             edges = new float[nBinsJets+1];

--- a/HLTriggerOffline/Higgs/src/HLTHiggsSubAnalysis.cc
+++ b/HLTriggerOffline/Higgs/src/HLTHiggsSubAnalysis.cc
@@ -656,8 +656,10 @@ const std::vector<unsigned int> HLTHiggsSubAnalysis::getObjectsType(const std::s
         // Check if it is needed this object for this trigger
         if( ! TString(hltPath).Contains(objTypeStr) )
         {
-            if( !( objtriggernames[i] == EVTColContainer::PFMET && TString(hltPath).Contains("MHT") ) ) // fix for ZnnHbb
-                continue;
+            if( (objtriggernames[i] == EVTColContainer::PFJET && TString(hltPath).Contains("BTagCSV")) ||   // fix for ZnnHbb PFJET            
+                (objtriggernames[i] == EVTColContainer::PFMET && TString(hltPath).Contains("MHT")) )        // fix for ZnnHbb PFMET
+                objsType.insert(objtriggernames[i]);
+           continue;
         }
         if( objtriggernames[i] == EVTColContainer::CALOMET && (TString(hltPath).Contains("PFMET") || TString(hltPath).Contains("MHT") ) ) continue; // fix for PFMET
 
@@ -842,7 +844,7 @@ void HLTHiggsSubAnalysis::bookHist(const std::string & source,
         
         std::string jetObj = EVTColContainer::getTypeString(EVTColContainer::PFJET);
         if( objType == jetObj ) {
-            const size_t nBinsJets = 20;
+            const size_t nBinsJets = 25;
             nBins = nBinsJets;
             delete [] edges;
             edges = new float[nBinsJets+1];


### PR DESCRIPTION
The changes:
- The VBFHbb part in the config file has been uncommented.
- The paths are updated for VBFHbb and ZnnHbb.
- Two lines in the code had to be changed in order to handle the new path names properly.

The increase in size:

| subsystem/folder | histograms | bins | Empty bins | Empty/Total | bins per histogram | MB | kB per histogram |
| --- | --- | --- | --- | --- | --- | --- | --- |
| Higgs before commit | 348 | 16450 | 12264 | 0.746 | 47.3 | 0.0628 | 0.185 |
| Higgs after commit | 426 | 18578 | 14348 | 0.772 | 43.6 | 0.0709 | 0.17 |

cc: @HuguesBrun, @slehti, @silviodonato
