### PR TITLE
Adding HtMht producer from CaloTowers

### DIFF
--- a/HLTrigger/JetMET/interface/HLTCaloTowerHtMhtProducer.h
+++ b/HLTrigger/JetMET/interface/HLTCaloTowerHtMhtProducer.h
@@ -1,0 +1,56 @@
+#ifndef HLTCaloTowerHtMhtProducer_h_
+#define HLTCaloTowerHtMhtProducer_h_
+
+/** \class HLTCaloTowerHtMhtProducer
+ *
+ *  \brief  This produces a reco::MET object that stores HT and MHT
+ *  \author Steven Lowette
+ *  \author Michele de Gruttola, Jia Fu Low (Nov 2013)
+ *  \author Thiago Tomei (added the "HT from CaloTower code")
+ *
+ *  HT & MHT are calculated using input CaloTower collection.
+ *  HT is stored as `sumet_`, MHT is stored as `p4_` in the output.
+ *
+ */
+
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/METReco/interface/MET.h"
+#include "DataFormats/METReco/interface/METFwd.h"
+#include "DataFormats/CaloTowers/interface/CaloTower.h" 
+#include "DataFormats/CaloTowers/interface/CaloTowerFwd.h"
+
+namespace edm {
+    class ConfigurationDescriptions;
+}
+
+// Class declaration
+class HLTCaloTowerHtMhtProducer : public edm::EDProducer {
+  public:
+    explicit HLTCaloTowerHtMhtProducer(const edm::ParameterSet & iConfig);
+    ~HLTCaloTowerHtMhtProducer();
+    static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+    virtual void produce(edm::Event & iEvent, const edm::EventSetup & iSetup);
+
+  private:
+    /// Use pt; otherwise, use et.
+    bool usePt_;
+
+    /// Minimum pt requirement for jets
+    double minPtTowerHt_;
+    double minPtTowerMht_;
+
+    /// Maximum (abs) eta requirement for jets
+    double maxEtaTowerHt_;
+    double maxEtaTowerMht_;
+
+    /// Input CaloTower collection
+    edm::InputTag towersLabel_;
+    edm::EDGetTokenT<CaloTowerCollection> m_theTowersToken;
+};
+
+#endif  // HLTCaloTowerHtMhtProducer_h_
+

--- a/HLTrigger/JetMET/src/HLTCaloTowerHtMhtProducer.cc
+++ b/HLTrigger/JetMET/src/HLTCaloTowerHtMhtProducer.cc
@@ -1,0 +1,85 @@
+/** \class HLTCaloTowerHtMhtProducer
+ *
+ * See header file for documentation
+ *
+ *  \author Steven Lowette
+ *  \author Thiago Tomei
+ *
+ */
+
+#include "HLTrigger/JetMET/interface/HLTCaloTowerHtMhtProducer.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "DataFormats/Common/interface/Handle.h"
+
+
+// Constructor
+HLTCaloTowerHtMhtProducer::HLTCaloTowerHtMhtProducer(const edm::ParameterSet & iConfig) :
+  usePt_                  ( iConfig.getParameter<bool>("usePt") ),
+  minPtTowerHt_             ( iConfig.getParameter<double>("minPtTowerHt") ),
+  minPtTowerMht_            ( iConfig.getParameter<double>("minPtTowerMht") ),
+  maxEtaTowerHt_            ( iConfig.getParameter<double>("maxEtaTowerHt") ),
+  maxEtaTowerMht_           ( iConfig.getParameter<double>("maxEtaTowerMht") ),
+  towersLabel_              ( iConfig.getParameter<edm::InputTag>("towersLabel") ) {
+    m_theTowersToken = consumes<CaloTowerCollection>(towersLabel_);
+    
+    // Register the products
+    produces<reco::METCollection>();
+}
+
+// Destructor
+HLTCaloTowerHtMhtProducer::~HLTCaloTowerHtMhtProducer() {}
+
+// Fill descriptions
+void HLTCaloTowerHtMhtProducer::fillDescriptions(edm::ConfigurationDescriptions & descriptions) {
+    // Current default is for hltHtMht
+    edm::ParameterSetDescription desc;
+    desc.add<bool>("usePt", false);
+    desc.add<double>("minPtTowerHt", 1.);
+    desc.add<double>("minPtTowerMht", 1.);
+    desc.add<double>("maxEtaTowerHt", 5.);
+    desc.add<double>("maxEtaTowerMht", 5.);
+    desc.add<edm::InputTag>("towersLabel", edm::InputTag("hltTowerMakerForAll"));
+    descriptions.add("hltCaloTowerHtMhtProducer", desc);
+}
+
+// Produce the products
+void HLTCaloTowerHtMhtProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+
+    // Create a pointer to the products
+    std::auto_ptr<reco::METCollection> result(new reco::METCollection());
+
+    edm::Handle<CaloTowerCollection> towers;
+    iEvent.getByToken(m_theTowersToken, towers);
+
+    double ht = 0., mhx = 0., mhy = 0.;
+
+    if (towers->size() > 0) {
+        for(CaloTowerCollection::const_iterator j = towers->begin(); j != towers->end(); ++j) {
+            double pt = usePt_ ? j->pt() : j->et();
+            double eta = j->eta();
+            double phi = j->phi();
+            double px = usePt_ ? j->px() : j->et() * cos(phi);
+            double py = usePt_ ? j->py() : j->et() * sin(phi);
+
+            if (pt > minPtTowerHt_ && std::abs(eta) < maxEtaTowerHt_) {
+                ht += pt;
+            }
+
+            if (pt > minPtTowerMht_ && std::abs(eta) < maxEtaTowerMht_) {
+                mhx -= px;
+                mhy -= py;
+            }
+        }
+    }
+
+    reco::MET::LorentzVector p4(mhx, mhy, 0, sqrt(mhx*mhx + mhy*mhy));
+    reco::MET::Point vtx(0, 0, 0);
+    reco::MET htmht(ht, p4, vtx);
+    result->push_back(htmht);
+    
+    // Put the products into the Event
+    iEvent.put(result);
+}

--- a/HLTrigger/JetMET/src/SealModule.cc
+++ b/HLTrigger/JetMET/src/SealModule.cc
@@ -24,6 +24,7 @@
 
 //Work with all jet collections without changing the module name
 #include "HLTrigger/JetMET/interface/HLTHtMhtProducer.h"
+#include "HLTrigger/JetMET/interface/HLTCaloTowerHtMhtProducer.h"
 #include "HLTrigger/JetMET/interface/HLTMhtProducer.h"
 #include "HLTrigger/JetMET/interface/HLTTrackMETProducer.h"
 #include "HLTrigger/JetMET/interface/HLTMinDPhiMETFilter.h"
@@ -163,6 +164,7 @@ DEFINE_FWK_MODULE(HLTMETCleanerUsingJetID);
 //Work with all jet collections without changing the module name
 DEFINE_FWK_MODULE(HLTMhtProducer);
 DEFINE_FWK_MODULE(HLTHtMhtProducer);
+DEFINE_FWK_MODULE(HLTCaloTowerHtMhtProducer);
 DEFINE_FWK_MODULE(HLTTrackMETProducer);
 DEFINE_FWK_MODULE(HLTMinDPhiMETFilter);
 


### PR DESCRIPTION
I would like to have a HighLevelTrigger HT / MHT producer which takes as CaloTowers as input, as opposed to the jets. The use case is to allow triggering HT made purely from ECAL or HCAL inputs.
