### PR TITLE
Add missing link dependency

### DIFF
--- a/CondFormats/DTObjects/BuildFile.xml
+++ b/CondFormats/DTObjects/BuildFile.xml
@@ -5,6 +5,7 @@
 <use   name="FWCore/Utilities"/>
 <use   name="CondCore/DBCommon"/>
 <use   name="boost_serialization"/>
+<use   name="roothistmatrix"/>
 
 <export>
   <lib   name="1"/>


### PR DESCRIPTION
Add missing link dependency.  This fixes numerous link errors in the ROOT6 IB.
Please merge as soon as convenient.
