### PR TITLE
Only run compareSources if there are enough entries in the vector.

### DIFF
--- a/Utilities/XrdAdaptor/src/XrdRequestManager.cc
+++ b/Utilities/XrdAdaptor/src/XrdRequestManager.cc
@@ -206,8 +206,10 @@ RequestManager::checkSources(timespec &now, IOSize requestSize)
 
 
 bool
-RequestManager::compareSources(const timespec &now, int a, int b)
+RequestManager::compareSources(const timespec &now, unsigned a, unsigned b)
 {
+  if (m_activeSources.size() < std::max(a, b)+1) {return false;}
+
   bool findNewSource = false;
   if ((m_activeSources[a]->getQuality() > 5130) ||
      ((m_activeSources[a]->getQuality() > 260) && (m_activeSources[b]->getQuality()*4 < m_activeSources[a]->getQuality())))

--- a/Utilities/XrdAdaptor/src/XrdRequestManager.h
+++ b/Utilities/XrdAdaptor/src/XrdRequestManager.h
@@ -135,7 +135,7 @@ private:
      * NOTE: assumes two sources are active and the caller must already hold
      * m_source_mutex
      */
-    bool compareSources(const timespec &now, int a, int b);
+    bool compareSources(const timespec &now, unsigned a, unsigned b);
 
     /**
      * Picks a single source for the next operation.


### PR DESCRIPTION
After recent refactoring, it was possible to run compareSources even when there was only one source.
