### PR TITLE
Add missing link dependency

### DIFF
--- a/CondFormats/DTObjects/BuildFile.xml
+++ b/CondFormats/DTObjects/BuildFile.xml
@@ -5,6 +5,7 @@
 <use   name="FWCore/Utilities"/>
 <use   name="CondCore/DBCommon"/>
 <use   name="boost_serialization"/>
+<use   name="roothistmatrix"/>
 <use   name="rootrflx"/>
 <use   name="root"/>
 <export>


### PR DESCRIPTION
Add a missing link dependency for consistency with the ROOT 6 branch.
This pull request is not strictly necessary in this branch, but aids code commonality between 7_3_X and 7_3_ROOT6_X.
