### PR TITLE
Add placeholder product for fill scheme and use in Ecal Local Reco

### DIFF
--- a/Configuration/StandardSequences/python/ReconstructionHeavyIons_cff.py
+++ b/Configuration/StandardSequences/python/ReconstructionHeavyIons_cff.py
@@ -24,6 +24,7 @@ from RecoLocalCalo.CastorReco.CastorSimpleReconstructor_cfi import *
 from RecoLocalMuon.Configuration.RecoLocalMuon_cff import *
 
 from RecoLuminosity.LumiProducer.lumiProducer_cff import *
+from RecoLuminosity.LumiProducer.fillSchemeInfoProducer_cfi import *
 
 #--------------------------------------------------------------------------
 # HIGH LEVEL RECO
@@ -49,10 +50,10 @@ localReco_HcalNZS = cms.Sequence(offlineBeamSpot*muonReco*caloRecoNZS)
 #--------------------------------------------------------------------------
 # Main Sequence
 
-reconstruct_PbPb = cms.Sequence(localReco*globalRecoPbPb*CastorFullReco)
+reconstruct_PbPb = cms.Sequence(fillSchemeInfo*localReco*globalRecoPbPb*CastorFullReco)
 reconstructionHeavyIons = cms.Sequence(reconstruct_PbPb)
 
-reconstructionHeavyIons_HcalNZS = cms.Sequence(localReco_HcalNZS*globalRecoPbPb)
+reconstructionHeavyIons_HcalNZS = cms.Sequence(fillSchemeInfo*localReco_HcalNZS*globalRecoPbPb)
 
 reconstructionHeavyIons_withRegitMu = cms.Sequence(reconstructionHeavyIons*regionalMuonRecoPbPb)
 #--------------------------------------------------------------------------

--- a/Configuration/StandardSequences/python/Reconstruction_cff.py
+++ b/Configuration/StandardSequences/python/Reconstruction_cff.py
@@ -38,8 +38,8 @@ from RecoVertex.BeamSpotProducer.BeamSpot_cff import *
 
 from RecoLocalCalo.CastorReco.CastorSimpleReconstructor_cfi import *
 
-localreco = cms.Sequence(fillSchemeInfo+trackerlocalreco+muonlocalreco+calolocalreco+castorreco)
-localreco_HcalNZS = cms.Sequence(fillSchemeInfo+trackerlocalreco+muonlocalreco+calolocalrecoNZS+castorreco)
+localreco = cms.Sequence(trackerlocalreco+muonlocalreco+calolocalreco+castorreco)
+localreco_HcalNZS = cms.Sequence(trackerlocalreco+muonlocalreco+calolocalrecoNZS+castorreco)
 
 #
 # temporarily switching off recoGenJets; since this are MC and wil be moved to a proper sequence
@@ -89,7 +89,7 @@ highlevelreco = cms.Sequence(egammaHighLevelRecoPrePF*
 from FWCore.Modules.logErrorHarvester_cfi import *
 
 # "Export" Section
-reconstruction         = cms.Sequence(localreco*globalreco*highlevelreco*logErrorHarvester)
+reconstruction         = cms.Sequence(fillSchemeInfo*localreco*globalreco*highlevelreco*logErrorHarvester)
 
 #need a fully expanded sequence copy
 modulesToRemove = list() # copy does not work well
@@ -153,17 +153,17 @@ reconstruction_noTracking = reconstruction.copyAndExclude(noTrackingAndDependent
 
 
 #sequences with additional stuff
-reconstruction_withPixellessTk  = cms.Sequence(localreco        *globalreco_plusPL*highlevelreco*logErrorHarvester)
-reconstruction_HcalNZS = cms.Sequence(localreco_HcalNZS*globalreco       *highlevelreco*logErrorHarvester)
+reconstruction_withPixellessTk  = cms.Sequence(fillSchemeInfo*localreco        *globalreco_plusPL*highlevelreco*logErrorHarvester)
+reconstruction_HcalNZS = cms.Sequence(fillSchemeInfo*localreco_HcalNZS*globalreco       *highlevelreco*logErrorHarvester)
 
 #sequences without some stuffs
 #
-reconstruction_woCosmicMuons = cms.Sequence(localreco*globalreco*highlevelreco*logErrorHarvester)
+reconstruction_woCosmicMuons = cms.Sequence(fillSchemeInfo*localreco*globalreco*highlevelreco*logErrorHarvester)
 
 
 # define a standard candle. please note I am picking up individual
 # modules instead of sequences
 #
-reconstruction_standard_candle = cms.Sequence(localreco*globalreco*vertexreco*recoJetAssociations*btagging*electronSequence*photonSequence)
+reconstruction_standard_candle = cms.Sequence(fillSchemeInfo*localreco*globalreco*vertexreco*recoJetAssociations*btagging*electronSequence*photonSequence)
 
 

--- a/Configuration/StandardSequences/python/Reconstruction_cff.py
+++ b/Configuration/StandardSequences/python/Reconstruction_cff.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 from RecoLuminosity.LumiProducer.lumiProducer_cff import *
+from RecoLuminosity.LumiProducer.fillSchemeInfoProducer_cfi import *
 from RecoLocalMuon.Configuration.RecoLocalMuon_cff import *
 from RecoLocalCalo.Configuration.RecoLocalCalo_cff import *
 from RecoTracker.Configuration.RecoTracker_cff import *
@@ -37,8 +38,8 @@ from RecoVertex.BeamSpotProducer.BeamSpot_cff import *
 
 from RecoLocalCalo.CastorReco.CastorSimpleReconstructor_cfi import *
 
-localreco = cms.Sequence(trackerlocalreco+muonlocalreco+calolocalreco+castorreco)
-localreco_HcalNZS = cms.Sequence(trackerlocalreco+muonlocalreco+calolocalrecoNZS+castorreco)
+localreco = cms.Sequence(fillSchemeInfo+trackerlocalreco+muonlocalreco+calolocalreco+castorreco)
+localreco_HcalNZS = cms.Sequence(fillSchemeInfo+trackerlocalreco+muonlocalreco+calolocalrecoNZS+castorreco)
 
 #
 # temporarily switching off recoGenJets; since this are MC and wil be moved to a proper sequence

--- a/DataFormats/Luminosity/interface/FillSchemeInfo.h
+++ b/DataFormats/Luminosity/interface/FillSchemeInfo.h
@@ -1,0 +1,28 @@
+#ifndef DataFormats_Luminosity_FillSchemeInfo_h
+#define DataFormats_Luminosity_FillSchemeInfo_h
+ 
+/** \class FillSchemeInfo
+ *
+ *
+ * FillSchemeInfo holds information about the filling scheme
+ * in the present run
+ *
+ * \author Josh Bendavid
+ *
+ ************************************************************/
+
+class FillSchemeInfo {
+ 
+  public:
+    FillSchemeInfo() {}
+    FillSchemeInfo(int bunchSpacing) : bunchSpacing_(bunchSpacing) {}
+    ~FillSchemeInfo() {}
+    
+    int bunchSpacing() const { return bunchSpacing_; }
+    
+  private:
+    int bunchSpacing_;
+  
+};
+
+#endif

--- a/DataFormats/Luminosity/src/FillSchemeInfo.cc
+++ b/DataFormats/Luminosity/src/FillSchemeInfo.cc
@@ -1,0 +1,1 @@
+#include "DataFormats/Luminosity/interface/FillSchemeInfo.h"

--- a/DataFormats/Luminosity/src/classes.h
+++ b/DataFormats/Luminosity/src/classes.h
@@ -3,11 +3,13 @@
 #include "DataFormats/Luminosity/interface/LumiSummaryRunHeader.h"
 #include "DataFormats/Luminosity/interface/LumiSummary.h"
 #include "DataFormats/Luminosity/interface/LumiDetails.h"
+#include "DataFormats/Luminosity/interface/FillSchemeInfo.h"
 
 namespace DataFormats_Luminosity {
    struct dictionary {
       edm::Wrapper<LumiSummaryRunHeader> lumisummaryrunheaderobj;
       edm::Wrapper<LumiSummary> lumisummaryobj;
       edm::Wrapper<LumiDetails> lumidetailsobj;
+      edm::Wrapper<FillSchemeInfo> fillschemeobj;
    };
 }

--- a/DataFormats/Luminosity/src/classes_def.xml
+++ b/DataFormats/Luminosity/src/classes_def.xml
@@ -20,4 +20,7 @@
   </class>
   <class name="std::vector<LumiSummary::L1>"/>
   <class name="std::vector<LumiSummary::HLT>"/>
+  <class name="FillSchemeInfo" ClassVersion="2">
+   <version ClassVersion="2" checksum="550713909"/>
+  </class>
 </lcgdict>

--- a/FastSimulation/Configuration/python/FamosSequences_cff.py
+++ b/FastSimulation/Configuration/python/FamosSequences_cff.py
@@ -19,6 +19,9 @@ from FastSimulation.TrackingRecHitProducer.SiTrackerGaussianSmearingRecHitConver
 # Rec Hit Tranlator to the Full map with DeTId'
 from FastSimulation.TrackingRecHitProducer.TrackingRecHitTranslator_cfi import *
 
+#FillSchemeInfoProducer
+from RecoLuminosity.LumiProducer.fillSchemeInfoProducer_cfi import *
+
 # CTF and Iterative tracking (contains pixelTracks and pixelVertices)
 
 # 1) Common algorithms and configuration taken from full reconstruction
@@ -423,6 +426,7 @@ if(CaloMode==3):
     if(MixingMode=='GenMixing'):
         reconstructionWithFamos = cms.Sequence(
             digitizationSequence+ # temporary; repetition!
+            fillSchemeInfo+
             trackVertexReco+
             caloTowersSequence+
             particleFlowCluster+
@@ -450,6 +454,7 @@ if(CaloMode==3):
             )
     elif(MixingMode=='DigiRecoMixing'):
         reconstructionWithFamos = cms.Sequence(
+            fillSchemeInfo+
             caloTowersSequence+
             particleFlowCluster+
             ecalClusters+
@@ -478,6 +483,7 @@ if(CaloMode==3):
         print 'unsupported MixingMode label'
 else:
     reconstructionWithFamos = cms.Sequence(
+        fillSchemeInfo+
         trackVertexReco+
         caloTowersSequence+
         particleFlowCluster+
@@ -729,6 +735,7 @@ simulationWithFamos = cms.Sequence(
 
 
 reconstructionWithFamosNoTk = cms.Sequence(
+    fillSchemeInfo+
     vertexreco+
     caloTowersSequence+
     particleFlowCluster+

--- a/RecoLocalCalo/EcalRecProducers/interface/EcalUncalibRecHitWorkerBaseClass.h
+++ b/RecoLocalCalo/EcalRecProducers/interface/EcalUncalibRecHitWorkerBaseClass.h
@@ -18,6 +18,7 @@ class EcalUncalibRecHitWorkerBaseClass {
                 virtual ~EcalUncalibRecHitWorkerBaseClass(){}
 
                 virtual void set(const edm::EventSetup& es) = 0;
+                virtual void set(const edm::Event& evt) {}
                 virtual bool run(const edm::Event& evt, const EcalDigiCollection::const_iterator & digi, EcalUncalibratedRecHitCollection & result) = 0;
 };
 

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitProducer.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitProducer.cc
@@ -54,6 +54,7 @@ EcalUncalibRecHitProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
 
         // tranparently get things from event setup
         worker_->set(es);
+        worker_->set(evt);
 
         // prepare output
         std::auto_ptr< EBUncalibratedRecHitCollection > ebUncalibRechits( new EBUncalibratedRecHitCollection );

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
@@ -36,6 +36,11 @@ EcalUncalibRecHitWorkerMultiFit::EcalUncalibRecHitWorkerMultiFit(const edm::Para
 
   // uncertainty calculation (CPU intensive)
   ampErrorCalculation_ = ps.getParameter<bool>("ampErrorCalculation");
+  useFillSchemeInfo_ = ps.getParameter<bool>("useFillSchemeInfo");
+  
+  if (useFillSchemeInfo_) {
+    fillSchemeInfo_ = c.consumes<FillSchemeInfo>(edm::InputTag("fillSchemeInfo"));
+  }
 
   // algorithm to be used for timing
   timealgo_ = ps.getParameter<std::string>("timealgo");
@@ -125,6 +130,28 @@ EcalUncalibRecHitWorkerMultiFit::set(const edm::EventSetup& es)
 
         // for the time correction methods
         es.get<EcalTimeBiasCorrectionsRcd>().get(timeCorrBias_);
+}
+
+void
+EcalUncalibRecHitWorkerMultiFit::set(const edm::Event& evt)
+{
+
+  if (useFillSchemeInfo_) {
+    edm::Handle<FillSchemeInfo> fillSchemeInfoH;
+    evt.getByToken(fillSchemeInfo_,fillSchemeInfoH);
+    int bunchspacing = fillSchemeInfoH->bunchSpacing();
+    
+    if (bunchspacing == 25) {
+      activeBX.resize(10);
+      activeBX << -5,-4,-3,-2,-1,0,1,2,3,4;
+    }
+    else {
+      //50ns configuration otherwise (also for no pileup)
+      activeBX.resize(5);
+      activeBX << -4,-2,0,2,4;
+    }
+  }
+  
 }
 
 /**

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.h
@@ -26,7 +26,7 @@
 #include "CondFormats/EcalObjects/interface/EcalSampleMask.h"
 #include "CondFormats/EcalObjects/interface/EcalTimeBiasCorrections.h"
 #include "RecoLocalCalo/EcalRecAlgos/interface/EigenMatrixTypes.h"
-
+#include "DataFormats/Luminosity/interface/FillSchemeInfo.h"
 
 namespace edm {
         class Event;
@@ -41,8 +41,9 @@ class EcalUncalibRecHitWorkerMultiFit : public EcalUncalibRecHitWorkerBaseClass 
 				//EcalUncalibRecHitWorkerMultiFit(const edm::ParameterSet&);
                 virtual ~EcalUncalibRecHitWorkerMultiFit() {};
 
-                void set(const edm::EventSetup& es);
-                bool run(const edm::Event& evt, const EcalDigiCollection::const_iterator & digi, EcalUncalibratedRecHitCollection & result);
+                void set(const edm::EventSetup& es) override;
+                void set(const edm::Event& evt) override;
+                bool run(const edm::Event& evt, const EcalDigiCollection::const_iterator & digi, EcalUncalibratedRecHitCollection & result) override;
 
         protected:
 
@@ -73,8 +74,10 @@ class EcalUncalibRecHitWorkerMultiFit : public EcalUncalibRecHitWorkerBaseClass 
                 FullSampleMatrix fullpulsecovEE;
                 BXVector activeBX;
                 bool ampErrorCalculation_;
+                bool useFillSchemeInfo_;
                 EcalUncalibRecHitMultiFitAlgo multiFitMethod_;
                 
+                edm::EDGetTokenT<FillSchemeInfo> fillSchemeInfo_; 
 
                 // determine which of the samples must actually be used by ECAL local reco
                 edm::ESHandle<EcalSampleMask> sampleMaskHand_;                

--- a/RecoLocalCalo/EcalRecProducers/python/ecalLocalCustom.py
+++ b/RecoLocalCalo/EcalRecProducers/python/ecalLocalCustom.py
@@ -1,10 +1,17 @@
 
 import FWCore.ParameterSet.Config as cms
 
+def configureEcalLocal25ns(process):
+    process.ecalMultiFitUncalibRecHit.activeBXs = cms.vint32(-5,-4,-3,-2,-1,0,1,2,3,4),
+    process.ecalMultiFitUncalibRecHit.useFillSchemeInfo = False
+    return process
+
 def configureEcalLocal50ns(process):
     process.ecalMultiFitUncalibRecHit.activeBXs = cms.vint32(-4,-2,0,2,4)
+    process.ecalMultiFitUncalibRecHit.useFillSchemeInfo = False
     return process
   
 def configureEcalLocalNoOOTPU(process):
     process.ecalMultiFitUncalibRecHit.activeBXs = cms.vint32(0)
+    process.ecalMultiFitUncalibRecHit.useFillSchemeInfo = False
     return process

--- a/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cfi.py
+++ b/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cfi.py
@@ -12,6 +12,7 @@ ecalMultiFitUncalibRecHit = cms.EDProducer("EcalUncalibRecHitProducer",
     EcalPulseShapeParameters = cms.PSet( ecal_pulse_shape_parameters ),
     activeBXs = cms.vint32(-5,-4,-3,-2,-1,0,1,2,3,4),
     ampErrorCalculation = cms.bool(True),
+    useFillSchemeInfo = cms.bool(True),
 
     # decide which algorithm to be use to calculate the jitter
     timealgo = cms.string("RatioMethod"),

--- a/RecoLuminosity/LumiProducer/plugins/BuildFile.xml
+++ b/RecoLuminosity/LumiProducer/plugins/BuildFile.xml
@@ -98,3 +98,10 @@
   <use name="FWCore/PluginManager"/>
   <flags   EDM_PLUGIN="1"/>
 </library>
+<library file="FillSchemeInfoProducer.cc" name="FillSchemeInfoProducer">
+  <use name="RecoLuminosity/LumiProducer"/>
+  <use name="FWCore/PluginManager"/>
+  <use name="DataFormats/Provenance"/>
+  <use name="DataFormats/Luminosity"/>
+  <flags EDM_PLUGIN="1"/>
+</library>

--- a/RecoLuminosity/LumiProducer/plugins/FillSchemeInfoProducer.cc
+++ b/RecoLuminosity/LumiProducer/plugins/FillSchemeInfoProducer.cc
@@ -1,0 +1,47 @@
+#include "RecoLuminosity/LumiProducer/plugins/FillSchemeInfoProducer.h"
+#include "DataFormats/Luminosity/interface/FillSchemeInfo.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+FillSchemeInfoProducer::FillSchemeInfoProducer(const edm::ParameterSet& ps) {
+  
+  pileupSummaryInfos_ = consumes<std::vector<PileupSummaryInfo> >(edm::InputTag("addPileupInfo"));
+  produces<FillSchemeInfo>();
+  
+  
+}
+
+void FillSchemeInfoProducer::produce(edm::Event &event, edm::EventSetup const& es) {
+  
+  int bunchspacing = 450;
+  
+  if (event.isRealData()) {
+    edm::RunNumber_t run = event.run();
+    if (run == 178003 ||
+        run == 178004 ||
+        run == 209089 ||
+        run == 209106 ||
+        run == 209109 ||
+        run == 209146 ||
+        run == 209148 ||
+        run == 209151) {
+      bunchspacing = 25;
+    }
+    else {
+      bunchspacing = 50;
+    }
+  }
+  else {
+    edm::Handle<std::vector<PileupSummaryInfo> > pileupSummaryInfosH;
+    event.getByToken(pileupSummaryInfos_,pileupSummaryInfosH);
+    bunchspacing = pileupSummaryInfosH->front().getBunchSpacing();
+  }
+  
+  
+  std::auto_ptr<FillSchemeInfo> fillSchemeInfo(new FillSchemeInfo(bunchspacing));
+  event.put(fillSchemeInfo);
+  
+  
+}
+
+DEFINE_FWK_MODULE(FillSchemeInfoProducer);

--- a/RecoLuminosity/LumiProducer/plugins/FillSchemeInfoProducer.h
+++ b/RecoLuminosity/LumiProducer/plugins/FillSchemeInfoProducer.h
@@ -1,0 +1,28 @@
+#ifndef RecoLuminosity_LumiProducer_FillSchemeInfoProducer_h
+#define RecoLuminosity_LumiProducer_FillSchemeInfoProducer_h
+
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
+#include "FWCore/Framework/interface/Run.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "SimDataFormats/PileupSummaryInfo/interface/PileupSummaryInfo.h"
+#include <vector>
+
+
+class FillSchemeInfoProducer : public edm::one::EDProducer<> {
+  public:
+  
+  FillSchemeInfoProducer(const edm::ParameterSet&);  
+  ~FillSchemeInfoProducer() {}
+    
+  virtual void produce(edm::Event &, edm::EventSetup const&) override;
+    
+  private:
+    edm::EDGetTokenT<std::vector<PileupSummaryInfo> > pileupSummaryInfos_; 
+
+};
+#endif
+
+

--- a/RecoLuminosity/LumiProducer/python/fillSchemeInfoProducer_cfi.py
+++ b/RecoLuminosity/LumiProducer/python/fillSchemeInfoProducer_cfi.py
@@ -1,0 +1,4 @@
+
+import FWCore.ParameterSet.Config as cms
+fillSchemeInfo=cms.EDProducer("FillSchemeInfoProducer",
+                            )

--- a/SimGeneral/MixingModule/python/mixNoPU_cfi.py
+++ b/SimGeneral/MixingModule/python/mixNoPU_cfi.py
@@ -13,7 +13,7 @@ mix = cms.EDProducer("MixingModule",
     maxBunch = cms.int32(3),
     minBunch = cms.int32(-5), ## in terms of 25 ns
 
-    bunchspace = cms.int32(25),
+    bunchspace = cms.int32(450),
     mixProdStep1 = cms.bool(False),
     mixProdStep2 = cms.bool(False),
 

--- a/Validation/Configuration/python/ECALHCAL.py
+++ b/Validation/Configuration/python/ECALHCAL.py
@@ -66,7 +66,7 @@ def customise(process):
             cms.InputTag("interestingEcalDetIdEE"),
             )            
 
-    process.local_digireco = cms.Path(process.mix * process.calDigi * process.ecalPacker * process.esDigiToRaw * process.hcalRawData * process.rawDataCollector * process.ecalDigis * process.ecalPreshowerDigis * process.hcalDigis * process.calolocalreco *(process.ecalClustersNoPFBox+process.caloTowersRec) * process.reducedEcalRecHitsSequenceEcalOnly )
+    process.local_digireco = cms.Path(process.mix * process.addPileupInfo * process.calDigi * process.ecalPacker * process.esDigiToRaw * process.hcalRawData * process.rawDataCollector * process.ecalDigis * process.ecalPreshowerDigis * process.hcalDigis * process.fillSchemeInfo * process.calolocalreco *(process.ecalClustersNoPFBox+process.caloTowersRec) * process.reducedEcalRecHitsSequenceEcalOnly )
 
     process.schedule.append(process.local_digireco)
 


### PR DESCRIPTION
Add placeholder FillSchemeInfo product which contains only the bunch spacing for now, but should contain the full filling scheme in the future.

Dummy producer added which fills bunch spacing from PileupSummaryInfo for MC and from hardcoded run list for data.   (n. b. the bunchSpacing parameter in the default mixing nopileup config was changed to be easily distinguishable from 50ns and 25ns, but this should have no physics effect)

Ecal local reco modified to use the FillSchemeInfo (but only switching between 10pulse config for 25ns and 5pulse config for 50ns for now)

@bachtis @emanueledimarco @argiro @lgray
