### PR TITLE
fixing compilation warnings

### DIFF
--- a/Alignment/CommonAlignment/interface/AlignmentUserVariables.h
+++ b/Alignment/CommonAlignment/interface/AlignmentUserVariables.h
@@ -7,7 +7,7 @@ class AlignmentUserVariables
 {
 
 public:
-
+  virtual ~AlignmentUserVariables() {}
   // derived class must implement clone method
   // (should be simply copy constructor)
   virtual AlignmentUserVariables* clone( void ) const = 0;

--- a/CalibCalorimetry/EcalLaserSorting/src/LaserSorter.cc
+++ b/CalibCalorimetry/EcalLaserSorting/src/LaserSorter.cc
@@ -492,7 +492,7 @@ bool LaserSorter::writeEvent(OutStreamRecord& outRcd, const edm::Event& event,
   if(rc){
     //update index table for this file:
     vector<IndexRecord>& indices = *outRcd.indices();
-    IndexRecord indexRcd = {event.orbitNumber(), evtStart};
+    IndexRecord indexRcd = {static_cast<unsigned int>(event.orbitNumber()), evtStart};
     indices.push_back(indexRcd);
   }
   return rc;

--- a/CalibTracker/SiPixelSCurveCalibration/src/SiPixelSCurveCalibrationAnalysis.cc
+++ b/CalibTracker/SiPixelSCurveCalibration/src/SiPixelSCurveCalibrationAnalysis.cc
@@ -66,7 +66,9 @@ void SiPixelSCurveCalibrationAnalysis::makeThresholdSummary(void){
 	  //        const sipixelobjects::PixelFEDLink * link = theFed->link(cabling.link);
 	  //        const sipixelobjects::PixelROC *theRoc = link->roc(cabling.roc);
 	  sipixelobjects::LocalPixel locpixel(loc);
-	  sipixelobjects::CablingPathToDetUnit path = {realfedID, cabling.link, cabling.roc};  
+	  sipixelobjects::CablingPathToDetUnit path = {static_cast<unsigned int>(realfedID),
+                                                       static_cast<unsigned int>(cabling.link),
+                                                       static_cast<unsigned int>(cabling.roc)};
 	  const sipixelobjects::PixelROC *theRoc = theCablingMap_->findItem(path);
 	  // END of FIX
 	  int newrow= locpixel.rocRow();

--- a/CalibTracker/SiStripAPVAnalysis/interface/TkApvMask.h
+++ b/CalibTracker/SiStripAPVAnalysis/interface/TkApvMask.h
@@ -10,6 +10,8 @@ class TkApvMask {
   
  public:
 
+  virtual ~TkApvMask() {}
+
   enum StripMaskType{ok=0,dead=1,noisy=2};
   
   typedef std::vector<StripMaskType> MaskType;

--- a/CalibTracker/SiStripAPVAnalysis/interface/TkCommonModeCalculator.h
+++ b/CalibTracker/SiStripAPVAnalysis/interface/TkCommonModeCalculator.h
@@ -9,6 +9,7 @@
 class TkCommonModeCalculator{
   
  public:  
+  virtual ~TkCommonModeCalculator() {}
   /** Return CM-subtracted data in APV */
   virtual ApvAnalysis::PedestalType doIt(ApvAnalysis::PedestalType) = 0 ;  
   virtual void setCM(TkCommonMode*) = 0;

--- a/CalibTracker/SiStripAPVAnalysis/interface/TkNoiseCalculator.h
+++ b/CalibTracker/SiStripAPVAnalysis/interface/TkNoiseCalculator.h
@@ -9,6 +9,7 @@
  */
 class TkNoiseCalculator {
  public:
+  virtual ~TkNoiseCalculator() {}
   /** Return status flag indicating if noise values are usable */
   TkStateMachine* status() {return &theStatus;}
   

--- a/CalibTracker/SiStripAPVAnalysis/interface/TkPedestalCalculator.h
+++ b/CalibTracker/SiStripAPVAnalysis/interface/TkPedestalCalculator.h
@@ -9,7 +9,7 @@
 class TkPedestalCalculator{
  public:
   
-  
+  virtual ~TkPedestalCalculator() {} 
   /** Return reconstructed pedestals */
   //  virtual ApvAnalysis::PedestalType pedestal() const = 0 ;
   virtual ApvAnalysis::PedestalType pedestal() const =0;

--- a/CondFormats/SiPixelObjects/src/SiPixelFedCablingMap.cc
+++ b/CondFormats/SiPixelObjects/src/SiPixelFedCablingMap.cc
@@ -29,19 +29,19 @@ SiPixelFedCablingMap::SiPixelFedCablingMap(const SiPixelFedCablingTree *cab)
   std::vector<const PixelFEDCabling *> fedList = cab->fedList();
   for (std::vector<const PixelFEDCabling *>::const_iterator ifed=fedList.begin();
    ifed != fedList.end(); ifed++) {
-    int fed = (**ifed).id();
-    int numLink = (**ifed).numberOfLinks();
-    for (int link=1; link <= numLink; link++) {
+    unsigned int fed = (**ifed).id();
+    unsigned int numLink = (**ifed).numberOfLinks();
+    for (unsigned int link=1; link <= numLink; link++) {
       const PixelFEDLink * pLink = (**ifed).link(link); 
       if (pLink==0) continue;
-      int linkId = static_cast<int>(pLink->id());
+      unsigned int linkId = pLink->id();
       if (linkId != 0 && linkId!= link) 
           std::cout << "PROBLEM WITH LINK NUMBER!!!!" << std::endl;
-      int numberROC = pLink->numberOfROCs(); 
-      for (int roc=1; roc <= numberROC; roc++) {
+      unsigned int numberROC = pLink->numberOfROCs(); 
+      for (unsigned int roc=1; roc <= numberROC; roc++) {
         const PixelROC * pROC = pLink->roc(roc);
         if (pROC==0) continue;
-        if (static_cast<int>(pROC->idInLink()) != roc) 
+        if (pROC->idInLink() != roc) 
             std::cout << "PROBLEM WITH ROC NUMBER!!!!" << std::endl;
         Key key = {fed, link, roc}; 
         theMap[key] = (*pROC);

--- a/CondFormats/SiPixelObjects/src/SiPixelFrameConverter.cc
+++ b/CondFormats/SiPixelObjects/src/SiPixelFrameConverter.cc
@@ -29,7 +29,9 @@ bool SiPixelFrameConverter::hasDetUnit(uint32_t rawId) const
 
 int SiPixelFrameConverter::toDetector(const ElectronicIndex & cabling, DetectorIndex & detector) const
 {
-  CablingPathToDetUnit path = {theFedId, cabling.link, cabling.roc }; 
+  CablingPathToDetUnit path = {static_cast<unsigned int>(theFedId),
+                               static_cast<unsigned int>(cabling.link),
+                               static_cast<unsigned int>(cabling.roc)}; 
   const PixelROC * roc = theMap->findItem(path);
   if (!roc){
     stringstream stm;
@@ -71,7 +73,8 @@ int SiPixelFrameConverter::toCabling(
     //<<  local.dcol()<<" pxid="<<  local.pxid()<<" inside: " <<local.valid();
 
     if(!local.valid()) continue;
-    ElectronicIndex cabIdx = {it->link, it->roc, local.dcol(), local.pxid()}; 
+    ElectronicIndex cabIdx = {static_cast<int>(it->link), 
+                              static_cast<int>(it->roc), local.dcol(), local.pxid()}; 
     cabling = cabIdx;
     return 0;
   }  

--- a/CondFormats/SiPixelObjects/src/SiPixelFrameReverter.cc
+++ b/CondFormats/SiPixelObjects/src/SiPixelFrameReverter.cc
@@ -67,7 +67,7 @@ int SiPixelFrameReverter::toCabling(
     GlobalPixel global = {detector.row, detector.col};
     LocalPixel local = roc->toLocal(global);
     if(!local.valid()) continue;
-    ElectronicIndex cabIdx = {it->link, it->roc, local.dcol(), local.pxid()};
+    ElectronicIndex cabIdx = {static_cast<int>(it->link), static_cast<int>(it->roc), local.dcol(), local.pxid()};
     cabling = cabIdx;
 
     return it->fed;


### PR DESCRIPTION
fixed various compilation warninsg for slc6. Identical fixes are already in 7XX releases
- missing virtual destructors
- explicit type conversions
