### PR TITLE
fixing compilation warnings

### DIFF
--- a/EventFilter/EcalTBRawToDigi/src/MatacqRawEvent.h
+++ b/EventFilter/EcalTBRawToDigi/src/MatacqRawEvent.h
@@ -92,7 +92,7 @@ private:
    */
   struct field32spec_t{
     int offset;
-    int mask;
+    unsigned int mask;
   };
   
   /** DAQ header field specifications.

--- a/RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitRatioMethodAlgo.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitRatioMethodAlgo.h
@@ -5,9 +5,6 @@
  *  Template used to compute amplitude, pedestal, time jitter, chi2 of a pulse
  *  using a ratio method
  *
- *  $Id: EcalUncalibRecHitRatioMethodAlgo.h,v 1.47 2012/05/10 15:42:04 franzoni Exp $
- *  $Date: 2012/05/10 15:42:04 $
- *  $Revision: 1.47 $
  *  \author A. Ledovskoy (Design) - M. Balazs (Implementation)
  */
 
@@ -20,14 +17,14 @@
 template < class C > class EcalUncalibRecHitRatioMethodAlgo {
       public:
 	struct Ratio {
-		int index;
-                int step;
+		unsigned int index;
+                unsigned int step;
 		double value;
 		double error;
 	};
 	struct Tmax {
-		int index;
-                int step;
+		unsigned int index;
+                unsigned int step;
 		double value;
 		double error;
                 double amplitude;

--- a/RecoTracker/DeDx/interface/BaseDeDxEstimator.h
+++ b/RecoTracker/DeDx/interface/BaseDeDxEstimator.h
@@ -5,10 +5,8 @@
 class BaseDeDxEstimator
 {
 public: 
- virtual std::pair<float,float> dedx(const reco::DeDxHitCollection& Hits) = 0;
-
-
-
+  virtual ~BaseDeDxEstimator() {}
+  virtual std::pair<float,float> dedx(const reco::DeDxHitCollection& Hits) = 0;
 };
 
 #endif

--- a/RecoTracker/TkTrackingRegions/interface/HitRZCompatibility.h
+++ b/RecoTracker/TkTrackingRegions/interface/HitRZCompatibility.h
@@ -7,6 +7,8 @@
 class HitRZCompatibility {
 public:
   typedef PixelRecoRange<float> Range;
+
+  virtual ~HitRZCompatibility() {}
   virtual bool operator() (const float & r, const float & z) const = 0;
   virtual Range range(const float & rORz) const = 0; 
   virtual HitRZCompatibility * clone() const = 0;

--- a/RecoTracker/TkTrackingRegions/interface/TrackingRegion.h
+++ b/RecoTracker/TkTrackingRegions/interface/TrackingRegion.h
@@ -25,7 +25,7 @@ namespace edm { class Event; class EventSetup; }
 
 class TrackingRegion{
 public:
-
+  virtual ~TrackingRegion(){}
   typedef PixelRecoRange<float> Range;
   typedef TransientTrackingRecHit::ConstRecHitPointer Hit;
   typedef std::vector<Hit> Hits;

--- a/RecoVertex/PrimaryVertexProducer/interface/TrackFilterForPVFindingBase.h
+++ b/RecoVertex/PrimaryVertexProducer/interface/TrackFilterForPVFindingBase.h
@@ -18,7 +18,7 @@ public:
   TrackFilterForPVFindingBase(){};
   TrackFilterForPVFindingBase(const edm::ParameterSet& conf){};
   virtual std::vector<reco::TransientTrack> select (const std::vector<reco::TransientTrack>& tracks)const=0;
-  //  ~TrackFilterForPVFindingBase(){};
+  virtual ~TrackFilterForPVFindingBase(){};
 };
 
 #endif


### PR DESCRIPTION
fixed various compilation warninsg for slc6. Identical fixes are already in 7XX releases
- missing virtual destructors
- explicit type conversions
