### PR TITLE
fix compiler warnings

### DIFF
--- a/Geometry/CommonTopologies/interface/SurfaceDeformation.h
+++ b/Geometry/CommonTopologies/interface/SurfaceDeformation.h
@@ -24,6 +24,8 @@ class SurfaceDeformation
   typedef Topology::Vector2D             Vector2D;
   typedef Topology::MathVector2D         MathVector2D;
 
+  virtual ~SurfaceDeformation() {}
+
   virtual SurfaceDeformation* clone() const = 0;
 
   /// specific type, i.e. SurfaceDeformationFactory::Type


### PR DESCRIPTION
fixed various compilation warninsg for slc6. Identical fixes are already in 7XX releases
- missing virtual destructors
- explicit type conversions
