### PR TITLE
fix compiler warnings

### DIFF
--- a/HiggsAnalysis/CombinedLimit/interface/LimitAlgo.h
+++ b/HiggsAnalysis/CombinedLimit/interface/LimitAlgo.h
@@ -17,6 +17,7 @@ namespace RooStats { class ModelConfig; }
 class LimitAlgo {
 public:
   LimitAlgo() { }
+  virtual ~LimitAlgo() { }
   LimitAlgo(const char * desc) : options_(desc) { }
   virtual void applyOptions(const boost::program_options::variables_map &vm) { }
   virtual void applyDefaultOptions() { }


### PR DESCRIPTION
fixed various compilation warninsg for slc6. Identical fixes are already in 7XX releases
- missing virtual destructors
- explicit type conversions
