### PR TITLE
fix compiler warnings

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
@@ -1062,7 +1062,7 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::findLCTs(const std::vector<int>
   const int max_lct_num = 2;
   const int adjacent_strips = 2;
   // Distrip, halfstrip pattern threshold.
-  const int ptrn_thrsh[2] = {nplanes_hit_pattern, nplanes_hit_pattern};
+  const unsigned int ptrn_thrsh[2] = {nplanes_hit_pattern, nplanes_hit_pattern};
   int highest_quality = 0;
 
   int keystrip_data[CSCConstants::NUM_HALF_STRIPS][7];
@@ -1108,7 +1108,7 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::findLCTs(const std::vector<int>
       // equal to the (variable) valid pattern threshold ptrn_thrsh.
       int keystrip = final_lcts[j];
       if (keystrip >= 0 &&
-	  keystrip_data[keystrip][CLCT_QUALITY] >= ptrn_thrsh[stripType]) {
+	  keystrip_data[keystrip][CLCT_QUALITY] >= static_cast<int>(ptrn_thrsh[stripType])) {
      	// assign the stripType here. 1 = halfstrip, 0 = distrip.
      	keystrip_data[keystrip][CLCT_STRIP_TYPE] = stripType;
 	// Now make the LCT words for the 2 highest, and store them in a list

--- a/L1Trigger/RPCTrigger/interface/RPCBasicTrigConfig.h
+++ b/L1Trigger/RPCTrigger/interface/RPCBasicTrigConfig.h
@@ -48,6 +48,8 @@ public:
     * to m_tower number 2'complement*/
   virtual int towNum2TowNum2Comp(int towNum);
 
+  virtual ~RPCBasicTrigConfig() {}
+
 private:
   static const int m_TRIGGER_CRATES_CNT;
 


### PR DESCRIPTION
fixed various compilation warninsg for slc6. Identical fixes are already in 7XX releases
- missing virtual destructors
- explicit type conversions
