### PR TITLE
fix compiler warnings

### DIFF
--- a/DataFormats/GeometrySurface/src/BlockWipedAllocator.cc
+++ b/DataFormats/GeometrySurface/src/BlockWipedAllocator.cc
@@ -75,7 +75,7 @@ BlockWipedAllocator & BlockWipedAllocator::me() const {
 BlockWipedAllocator::Stat BlockWipedAllocator::stat() const {
   Stat s = { m_typeSize, m_blockSize, (*m_current).m_allocated,
 	     (&*(*m_current).m_data.end()-m_next)/m_typeSize,
-	     std::distance(const_iterator(m_current),m_blocks.end()),
+	     static_cast<size_t>(std::distance(const_iterator(m_current),m_blocks.end())),
 	     m_blocks.size(), m_alive};
   return s;
 }


### PR DESCRIPTION
fixed various compilation warninsg for slc6. Identical fixes are already in 7XX releases
- explicit type conversions
