### PR TITLE
Make DTObjects thread safe

### DIFF
--- a/CondFormats/DTObjects/src/DTPerformance.cc
+++ b/CondFormats/DTObjects/src/DTPerformance.cc
@@ -110,7 +110,9 @@ int DTPerformance::get( int   wheelId,
   chanKey.push_back(  sectorId );
   chanKey.push_back(      slId );
   int ientry;
-  int searchStatus = dBuf->find( chanKey.begin(), chanKey.end(), ientry );
+  //Guarantee const correctness for thread-safety
+  const DTBufferTree<int,int>* constDBuf = dBuf;
+  int searchStatus = constDBuf->find( chanKey.begin(), chanKey.end(), ientry );
   if ( !searchStatus ) {
     const DTPerformanceData& data( dataList[ientry].second );
     meanT0         = data.meanT0;

--- a/CondFormats/DTObjects/src/DTRangeT0.cc
+++ b/CondFormats/DTObjects/src/DTRangeT0.cc
@@ -92,7 +92,9 @@ int DTRangeT0::get( int   wheelId,
   chanKey.push_back(  sectorId );
   chanKey.push_back(      slId );
   int ientry;
-  int searchStatus = dBuf->find( chanKey.begin(), chanKey.end(), ientry );
+  //Guarantee const correctness for thread-safety
+  const DTBufferTree<int,int>* constDBuf = dBuf;
+  int searchStatus = constDBuf->find( chanKey.begin(), chanKey.end(), ientry );
   if ( !searchStatus ) {
     const DTRangeT0Data& data( dataList[ientry].second );
     t0min = data.t0min;


### PR DESCRIPTION
The static analyzer found that the objects were calling the non-const
version of 'find' for a pointer member variable. By assigning the same
address to a pointer to const we now make sure the const 'find' is called.
