### PR TITLE
Message locker is now thread-safe; remove mutex.

### DIFF
--- a/Utilities/XrdAdaptor/src/QualityMetric.cc
+++ b/Utilities/XrdAdaptor/src/QualityMetric.cc
@@ -26,9 +26,6 @@
 
 using namespace XrdAdaptor;
 
-// Right now, MessageLogger requires a global mutex.
-std::mutex XrdAdaptor::g_ml_mutex;
-
 QualityMetricWatch::QualityMetricWatch(QualityMetric *parent1, QualityMetric *parent2)
     : m_parent1(parent1), m_parent2(parent2)
 {
@@ -44,9 +41,7 @@ QualityMetricWatch::~QualityMetricWatch()
         GET_CLOCK_MONOTONIC(stop);
 
         int ms = 1000*(stop.tv_sec - m_start.tv_sec) + (stop.tv_nsec - m_start.tv_nsec)/1e6;
-        {std::unique_lock<std::mutex> sentry(g_ml_mutex);
         edm::LogVerbatim("XrdAdaptorInternal") << "Finished timer after " << ms << std::endl;
-        }
         m_parent1->finishWatch(stop, ms);
         m_parent2->finishWatch(stop, ms);
     }

--- a/Utilities/XrdAdaptor/src/QualityMetric.h
+++ b/Utilities/XrdAdaptor/src/QualityMetric.h
@@ -11,8 +11,6 @@
 
 namespace XrdAdaptor {
 
-extern std::mutex g_ml_mutex;
-
 class QualityMetric;
 class QualityMetricSource;
 class QualityMetricUniqueSource;

--- a/Utilities/XrdAdaptor/src/XrdRequest.cc
+++ b/Utilities/XrdAdaptor/src/XrdRequest.cc
@@ -46,13 +46,11 @@ XrdAdaptor::ClientRequest::HandleResponse(XrdCl::XRootDStatus *stat, XrdCl::AnyO
     else
     {
         Source *source = m_source.get();
-        {std::unique_lock<std::mutex> sentry(g_ml_mutex);
         edm::LogWarning("XrdAdaptorInternal") << "XrdRequestManager::handle(name='"
           << m_manager.getFilename() << ") failure when reading from "
           << (source ? source->ID() : "(unknown source)")
           << "; failed with error '" << status->ToStr() << "' (errno="
           << status->errNo << ", code=" << status->code << ").";
-        }
         m_failure_count++;
         try
         {
@@ -78,9 +76,7 @@ XrdAdaptor::ClientRequest::HandleResponse(XrdCl::XRootDStatus *stat, XrdCl::AnyO
               << status->errNo << ", code=" << status->code << ", source=" << (source ? source->ID() : "(unknown source)") << ").";
             ex.addAdditionalInfo(ss.str());
             m_promise.set_exception(std::current_exception());
-            {std::unique_lock<std::mutex> sentry(g_ml_mutex);
             edm::LogWarning("XrdAdaptorInternal") << "Caught a CMSSW exception when running connection recovery.";
-            }
         }
         catch (...)
         {
@@ -94,9 +90,7 @@ XrdAdaptor::ClientRequest::HandleResponse(XrdCl::XRootDStatus *stat, XrdCl::AnyO
             m_manager.addConnections(ex);
             ex.addAdditionalInfo("Original source of error is " + (source ? source->ID() : "(unknown source)"));
             m_promise.set_exception(std::make_exception_ptr(ex));
-            {std::unique_lock<std::mutex> sentry(g_ml_mutex);
             edm::LogWarning("XrdAdaptorInternal") << "Caught a new exception when running connection recovery.";
-            }
         }
     }
     m_self_reference = nullptr;

--- a/Utilities/XrdAdaptor/src/XrdSource.cc
+++ b/Utilities/XrdAdaptor/src/XrdSource.cc
@@ -56,7 +56,6 @@ Source::~Source()
   XrdCl::XRootDStatus status;
   if (! (status = m_fh->Close()).IsOK())
   {
-    std::unique_lock<std::mutex> sentry(g_ml_mutex);
     edm::LogWarning("XrdFileWarning")
       << "Source::~Source() failed with error '" << status.ToStr()
       << "' (errno=" << status.errNo << ", code=" << status.code << ")";
@@ -88,9 +87,7 @@ validateList(const XrdCl::ChunkList& cl)
 void
 Source::handle(std::shared_ptr<ClientRequest> c)
 {
-    {std::unique_lock<std::mutex> sentry(g_ml_mutex);
     edm::LogVerbatim("XrdAdaptorInternal") << "Reading from " << ID() << ", quality " << m_qm->get() << std::endl;
-    }
     c->m_source = shared_from_this();
     c->m_self_reference = c;
     m_qm->startWatch(c->m_qmw);


### PR DESCRIPTION
It wasn't true when the multisource branch was written, but @Dr15Jones assures me that the MessageLocker is now thread-safe.

Onward and upward!
