### PR TITLE
Explicit L1 match in single tkmu trigger

### DIFF
--- a/HLTrigger/Muon/interface/HLTMuonTrkFilter.h
+++ b/HLTrigger/Muon/interface/HLTMuonTrkFilter.h
@@ -4,6 +4,7 @@
 //  based on HLTrigger/Muon/interface/HLTDiMuonGlbTrkFilter.h
 #include "HLTrigger/HLTcore/interface/HLTFilter.h"
 #include "DataFormats/RecoCandidate/interface/RecoChargedCandidateFwd.h"
+#include "DataFormats/MuonReco/interface/MuonFwd.h"
 #include "DataFormats/MuonReco/interface/MuonSelectors.h"
 
 namespace edm {
@@ -24,6 +25,8 @@ class HLTMuonTrkFilter : public HLTFilter {
   edm::EDGetTokenT<reco::MuonCollection>                 m_muonsToken; // input collection of muons
   edm::InputTag                                          m_candsTag;   // input collection of candidates to be referenced
   edm::EDGetTokenT<reco::RecoChargedCandidateCollection> m_candsToken; // input collection of candidates to be referenced
+  edm::InputTag                                          m_previousCandTag;   // input tag identifying product contains muons passing the previous level
+  edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> m_previousCandToken; // token identifying product contains muons passing the previous level
   int m_minTrkHits;
   int m_minMuonHits;
   int m_minMuonStations;

--- a/HLTrigger/Muon/src/HLTMuonTrkFilter.cc
+++ b/HLTrigger/Muon/src/HLTMuonTrkFilter.cc
@@ -96,7 +96,7 @@ HLTMuonTrkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, t
     if (check_l1match) {
       bool matchl1 = false;
       for (std::vector<l1extra::L1MuonParticleRef>::iterator l1cand = vl1cands_begin; l1cand != vl1cands_end; ++l1cand) {
-	if (deltaR(muon,**l1cand) < 0.2) {
+	if (deltaR(muon,**l1cand) < 0.3) {
 	  matchl1 = true;
 	  break;
 	}


### PR DESCRIPTION
Backport of #6137 to 72X.

I forgot to mention in the 73X PR, but this includes a new parameter to be parsed in ConfDB:

previousCandTag, for HLTMuonTrkFilter
