### PR TITLE
addPlotForFracChargeRelValMonitoring

### DIFF
--- a/DQM/TrackingMonitor/interface/dEdxAnalyzer.h
+++ b/DQM/TrackingMonitor/interface/dEdxAnalyzer.h
@@ -67,13 +67,17 @@ class dEdxAnalyzer : public DQMEDAnalyzer {
     MonitorElement* ME_MipDeDxNSatHits;
     MonitorElement* ME_MipDeDxMass;
     MonitorElement* ME_HipDeDxMass;
-    
+    MonitorElement* ME_MipHighPtDeDx;
+    MonitorElement* ME_MipHighPtDeDxNHits;
+  
     dEdxMEs()
       :ME_MipDeDx(NULL)
       ,ME_MipDeDxNHits(NULL)
       ,ME_MipDeDxNSatHits(NULL)
       ,ME_MipDeDxMass(NULL)
       ,ME_HipDeDxMass(NULL)
+      ,ME_MipHighPtDeDx(NULL)
+      ,ME_MipHighPtDeDxNHits(NULL)
     {}
   };
   

--- a/DQM/TrackingMonitor/interface/dEdxAnalyzer.h
+++ b/DQM/TrackingMonitor/interface/dEdxAnalyzer.h
@@ -81,7 +81,7 @@ class dEdxAnalyzer : public DQMEDAnalyzer {
     {}
   };
   
-  double TrackHitMin, HIPdEdxMin;
+  double TrackHitMin, HIPdEdxMin, HighPtThreshold;
   double dEdxK, dEdxC;
   
   edm::InputTag trackInputTag_;

--- a/DQM/TrackingMonitor/python/dEdxAnalyzer_cfi.py
+++ b/DQM/TrackingMonitor/python/dEdxAnalyzer_cfi.py
@@ -16,6 +16,7 @@ dEdxAnalyzer = cms.EDAnalyzer("dEdxAnalyzer",
        #cuts on number of hits
        TrackHitMin         = cms.double(8),
        HIPdEdxMin          = cms.double(3.5),
+       HighPtThreshold     = cms.double(100.0),
 
        #constants for dEdx mass reco
        dEdxK               = cms.double(2.529),

--- a/DQM/TrackingMonitor/src/dEdxAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/dEdxAnalyzer.cc
@@ -82,6 +82,7 @@ void dEdxAnalyzer::bookHistograms(DQMStore::IBooker & ibooker,
     // get binning from the configuration
     TrackHitMin  = conf_.getParameter<double>("TrackHitMin");
     HIPdEdxMin   = conf_.getParameter<double>("HIPdEdxMin");
+    HighPtThreshold =  conf_.getParameter<double>("HighPtThreshold");
 
     dEdxK      = conf_.getParameter<double>("dEdxK");
     dEdxC      = conf_.getParameter<double>("dEdxC");
@@ -140,12 +141,12 @@ void dEdxAnalyzer::bookHistograms(DQMStore::IBooker & ibooker,
 
          histname = "MIPOfHighPt_dEdxPerTrack_";
          dEdxMEsVector[i].ME_MipHighPtDeDx = ibooker.book1D(histname, histname, dEdxBin, dEdxMin, dEdxMax);
-         dEdxMEsVector[i].ME_MipHighPtDeDx->setAxisTitle("dEdx of each MIP (pT>100GeV) Track (MeV/cm)");
+         dEdxMEsVector[i].ME_MipHighPtDeDx->setAxisTitle("dEdx of each MIP (of High pT) Track (MeV/cm)");
          dEdxMEsVector[i].ME_MipHighPtDeDx->setAxisTitle("Number of Tracks", 2);
 
          histname =  "MIPOfHighPt_NumberOfdEdxHitsPerTrack_";
          dEdxMEsVector[i].ME_MipHighPtDeDxNHits = ibooker.book1D(histname, histname, dEdxNHitBin, dEdxNHitMin, dEdxNHitMax);
-         dEdxMEsVector[i].ME_MipHighPtDeDxNHits->setAxisTitle("Number of dEdxHits of each MIP (pT>100GeV) Track");
+         dEdxMEsVector[i].ME_MipHighPtDeDxNHits->setAxisTitle("Number of dEdxHits of each MIP (of High pT) Track");
          dEdxMEsVector[i].ME_MipHighPtDeDxNHits->setAxisTitle("Number of Tracks", 2);
        }
     }
@@ -197,7 +198,7 @@ void dEdxAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
                  dEdxMEsVector[i].ME_MipDeDxMass    ->Fill(mass(track->p(), dEdxColl[track].dEdx()));
 
 
-                 if(track->pt() >= 100.0){
+                 if(track->pt() >= HighPtThreshold){
                     dEdxMEsVector[i].ME_MipHighPtDeDx        ->Fill(dEdxColl[track].dEdx());
                     dEdxMEsVector[i].ME_MipHighPtDeDxNHits   ->Fill(dEdxColl[track].numberOfMeasurements());
                  }
@@ -232,7 +233,8 @@ dEdxAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   // Please change this to state exactly what you do use, even if it is no parameters
   edm::ParameterSetDescription desc;
   desc.setUnknown();
-  descriptions.addDefault(desc);
+  desc.add<double>("HIPdEdxMin",100.0);
+  descriptions.add("dEdxAnalyzer", desc);
 }
 
 DEFINE_FWK_MODULE(dEdxAnalyzer);

--- a/DQM/TrackingMonitor/src/dEdxAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/dEdxAnalyzer.cc
@@ -233,8 +233,7 @@ dEdxAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   // Please change this to state exactly what you do use, even if it is no parameters
   edm::ParameterSetDescription desc;
   desc.setUnknown();
-  desc.add<double>("HIPdEdxMin",100.0);
-  descriptions.add("dEdxAnalyzer", desc);
+  descriptions.addDefault(desc);
 }
 
 DEFINE_FWK_MODULE(dEdxAnalyzer);

--- a/DQM/TrackingMonitor/src/dEdxAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/dEdxAnalyzer.cc
@@ -138,6 +138,15 @@ void dEdxAnalyzer::bookHistograms(DQMStore::IBooker & ibooker,
          dEdxMEsVector[i].ME_HipDeDxMass->setAxisTitle("dEdx Mass of each HIP Track (GeV/c^{2})");
          dEdxMEsVector[i].ME_HipDeDxMass->setAxisTitle("Number of Tracks", 2);
 
+         histname = "MIPOfHighPt_dEdxPerTrack_";
+         dEdxMEsVector[i].ME_MipHighPtDeDx = ibooker.book1D(histname, histname, dEdxBin, dEdxMin, dEdxMax);
+         dEdxMEsVector[i].ME_MipHighPtDeDx->setAxisTitle("dEdx of each MIP (pT>100GeV) Track (MeV/cm)");
+         dEdxMEsVector[i].ME_MipHighPtDeDx->setAxisTitle("Number of Tracks", 2);
+
+         histname =  "MIPOfHighPt_NumberOfdEdxHitsPerTrack_";
+         dEdxMEsVector[i].ME_MipHighPtDeDxNHits = ibooker.book1D(histname, histname, dEdxNHitBin, dEdxNHitMin, dEdxNHitMax);
+         dEdxMEsVector[i].ME_MipHighPtDeDxNHits->setAxisTitle("Number of dEdxHits of each MIP (pT>100GeV) Track");
+         dEdxMEsVector[i].ME_MipHighPtDeDxNHits->setAxisTitle("Number of Tracks", 2);
        }
     }
 
@@ -186,6 +195,12 @@ void dEdxAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
 		 if (dEdxColl[track].numberOfMeasurements()!=0)
 		   dEdxMEsVector[i].ME_MipDeDxNSatHits->Fill((1.0*dEdxColl[track].numberOfSaturatedMeasurements())/dEdxColl[track].numberOfMeasurements());
                  dEdxMEsVector[i].ME_MipDeDxMass    ->Fill(mass(track->p(), dEdxColl[track].dEdx()));
+
+
+                 if(track->pt() >= 100.0){
+                    dEdxMEsVector[i].ME_MipHighPtDeDx        ->Fill(dEdxColl[track].dEdx());
+                    dEdxMEsVector[i].ME_MipHighPtDeDxNHits   ->Fill(dEdxColl[track].numberOfMeasurements());
+                 }
 
               //HighlyIonizing particles
               }else if(track->pt()<2 && dEdxColl[track].dEdx()>HIPdEdxMin){


### PR DESCRIPTION
Add two plots to the Tk DQM for the monitoring of frac. charged signal in relVals.
This changes were discussed at the PdmV/DQM Joint meeting of the 28th of october: https://indico.cern.ch/event/294179/
