### PR TITLE
added configurable parameters maxAssocCaloE and maxAssocCaloEDeltaRSize

### DIFF
--- a/RecoTracker/DeDx/plugins/HLTDeDxFilter.cc
+++ b/RecoTracker/DeDx/plugins/HLTDeDxFilter.cc
@@ -106,15 +106,15 @@ bool
 
   edm::Handle<reco::TrackCollection> trackCollectionHandle;
   iEvent.getByToken(inputTracksToken_,trackCollectionHandle);
-  reco::TrackCollection trackCollection = *trackCollectionHandle.product();
+  const reco::TrackCollection &trackCollection = *trackCollectionHandle.product();
 
   edm::Handle<edm::ValueMap<reco::DeDxData> > dEdxTrackHandle;
   iEvent.getByToken(inputdedxToken_, dEdxTrackHandle);
-  const edm::ValueMap<reco::DeDxData> dEdxTrack = *dEdxTrackHandle.product();
+  const edm::ValueMap<reco::DeDxData> &dEdxTrack = *dEdxTrackHandle.product();
 
   edm::Handle<CaloTowerCollection> caloTowersHandle;
   iEvent.getByToken(caloTowersToken_, caloTowersHandle);
-  const CaloTowerCollection caloTower = *caloTowersHandle.product();
+  const CaloTowerCollection &caloTower = *caloTowersHandle.product();
 
 
   bool accept=false;

--- a/RecoTracker/DeDx/plugins/HLTDeDxFilter.h
+++ b/RecoTracker/DeDx/plugins/HLTDeDxFilter.h
@@ -41,7 +41,9 @@ class HLTDeDxFilter : public HLTFilter {
       double maxAssocCaloE_;
       double maxAssocCaloEDeltaRSize_;
       edm::EDGetToken inputTracksToken_;
+      edm::EDGetToken caloTowersToken_;
       edm::EDGetToken inputdedxToken_;
+      edm::InputTag caloTowersTag_;
       edm::InputTag inputTracksTag_;
       edm::InputTag inputdedxTag_;
       edm::InputTag thisModuleTag_;

--- a/RecoTracker/DeDx/plugins/HLTDeDxFilter.h
+++ b/RecoTracker/DeDx/plugins/HLTDeDxFilter.h
@@ -38,6 +38,8 @@ class HLTDeDxFilter : public HLTFilter {
       double maxNHitMissMid_;
       double maxRelTrkIsoDeltaRp3_;
       double relTrkIsoDeltaRSize_;
+      double maxAssocCaloE_;
+      double maxAssocCaloEDeltaRSize_;
       edm::EDGetToken inputTracksToken_;
       edm::EDGetToken inputdedxToken_;
       edm::InputTag inputTracksTag_;


### PR DESCRIPTION
These configurable parameters calculate the associated calorimeter energy associated with a track (i.e. the sum of all calo tower deposits within a cone around the track)
