### PR TITLE
Remove unnecessary cout from DQMStore constructor

### DIFF
--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -268,7 +268,6 @@ DQMStore::DQMStore(const edm::ParameterSet &pset, edm::ActivityRegistry& ar)
   if(pset.getUntrackedParameter<bool>("forceResetOnBeginRun",false)) {
     ar.watchPostSourceRun(this,&DQMStore::forceReset);
   }
-  std::cout << __LINE__ << " DQMStore::DQMStore " << std::endl;
 }
 
 DQMStore::DQMStore(const edm::ParameterSet &pset)


### PR DESCRIPTION
Title says it all.  Current jobs always have "271 DQMStore::DQMStore" in the logs, which is unnecessary.
