### PR TITLE
SMP HLT DQM, basic config and single photon paths

### DIFF
--- a/HLTriggerOffline/Common/python/HLTValidationHarvest_cff.py
+++ b/HLTriggerOffline/Common/python/HLTValidationHarvest_cff.py
@@ -9,6 +9,7 @@ from HLTriggerOffline.JetMET.Validation.JetMETPostProcessor_cff import *
 from HLTriggerOffline.SUSYBSM.SUSYBSM_postProcessor_cff import *
 from HLTriggerOffline.Higgs.HLTHiggsPostVal_cff import *
 from HLTriggerOffline.Exotica.hltExoticaPostProcessors_cff import *
+from HLTriggerOffline.SMP.HLTSMPPostVal_cff import *
 from Validation.RecoTrack.HLTpostProcessorTracker_cfi import *
 from Validation.RecoVertex.HLTpostProcessorVertex_cfi import *
 #from HLTriggerOffline.Common.PostProcessorExample_cfi import *
@@ -30,6 +31,7 @@ hltpostvalidation = cms.Sequence(
     +HLTHiggsPostVal
     +hltExoticaPostProcessors
     +b2gHLTriggerValidationHarvest
+    +HLTSMPPostVal
     )
 
 hltpostvalidation_fastsim = cms.Sequence( 
@@ -43,6 +45,7 @@ hltpostvalidation_fastsim = cms.Sequence(
     +SusyExoPostVal_fastsim
     +HLTHiggsPostVal
     +b2gHLTriggerValidationHarvest
+    +HLTSMPPostVal
     )
 
 hltpostvalidation_preprod = cms.Sequence( 

--- a/HLTriggerOffline/Common/python/HLTValidation_cff.py
+++ b/HLTriggerOffline/Common/python/HLTValidation_cff.py
@@ -11,6 +11,7 @@ from HLTriggerOffline.Higgs.HiggsValidation_cff import *
 from HLTriggerOffline.Top.topHLTValidation_cff import *
 from HLTriggerOffline.B2G.b2gHLTValidation_cff import *
 from HLTriggerOffline.Exotica.ExoticaValidation_cff import *
+from HLTriggerOffline.SMP.SMPValidation_cff import *
 
 # offline dqm:
 # from DQMOffline.Trigger.DQMOffline_Trigger_cff.py import *
@@ -41,6 +42,7 @@ hltvalidation = cms.Sequence(
     +HiggsValidationSequence
     +ExoticaValidationSequence
     +b2gHLTriggerValidation
+    +SMPValidationSequence
     )
 
 
@@ -64,6 +66,7 @@ hltvalidation_fastsim = cms.Sequence(
     +HLTSusyExoValSeq_FastSim
     +HiggsValidationSequence
     +b2gHLTriggerValidation
+    +SMPValidationSequence
     )
 
 hltvalidation_preprod = cms.Sequence(

--- a/HLTriggerOffline/Higgs/interface/HLTHiggsSubAnalysis.h
+++ b/HLTriggerOffline/Higgs/interface/HLTHiggsSubAnalysis.h
@@ -105,6 +105,7 @@ class HLTHiggsSubAnalysis
         unsigned int _minCandidates;
 
         std::string _hltProcessName;
+        std::string _histDirectory;
         
         //! the hlt paths with regular expressions
         std::vector<std::string> _hltPathsToCheck;

--- a/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
+++ b/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
@@ -5,6 +5,7 @@ hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
         
     hltProcessName = cms.string("HLT"),
     analysis       = cms.vstring("HWW", "HZZ", "Hgg", "Htaunu", "H2tau", "VBFHbb", "ZnnHbb","DoubleHinTaus","HiggsDalitz"),
+    histDirectory  = cms.string("HLT/Higgs"),
     
     # -- The instance name of the reco::GenParticles collection
     genParticleLabel = cms.string("genParticles"),

--- a/HLTriggerOffline/Higgs/src/HLTHiggsSubAnalysis.cc
+++ b/HLTriggerOffline/Higgs/src/HLTHiggsSubAnalysis.cc
@@ -35,6 +35,7 @@ HLTHiggsSubAnalysis::HLTHiggsSubAnalysis(const edm::ParameterSet & pset,
     _analysisname(analysisname),
     _minCandidates(0),
     _hltProcessName(pset.getParameter<std::string>("hltProcessName")),
+    _histDirectory(pset.getParameter<std::string>("histDirectory")),
     _genParticleLabel(iC.consumes<reco::GenParticleCollection>(pset.getParameter<std::string>("genParticleLabel"))),
     _genJetLabel(iC.consumes<reco::GenJetCollection>(pset.getParameter<std::string>("genJetLabel"))),
     _parametersEta(pset.getParameter<std::vector<double> >("parametersEta")),
@@ -245,7 +246,7 @@ void HLTHiggsSubAnalysis::beginRun(const edm::Run & iRun, const edm::EventSetup 
 
 void HLTHiggsSubAnalysis::bookHistograms(DQMStore::IBooker &ibooker)
 {
-    std::string baseDir = "HLT/Higgs/"+_analysisname+"/";
+    std::string baseDir = _histDirectory+"/"+_analysisname+"/";
     ibooker.setCurrentFolder(baseDir);
     // Book the gen/reco analysis-dependent histograms (denominators)
     std::vector<std::string> sources(2);

--- a/HLTriggerOffline/SMP/python/HLTSMPPostVal_cff.py
+++ b/HLTriggerOffline/SMP/python/HLTSMPPostVal_cff.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+
+from HLTriggerOffline.SMP.hltSMPPostProcessors_cff import *
+
+HLTSMPPostVal = cms.Sequence( 
+		hltSMPPostProcessors
+		)
+

--- a/HLTriggerOffline/SMP/python/SMPValidation_cff.py
+++ b/HLTriggerOffline/SMP/python/SMPValidation_cff.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+
+from HLTriggerOffline.SMP.hltSMPValidator_cfi import *
+
+SMPValidationSequence = cms.Sequence(
+    hltSMPValidator
+    )
+

--- a/HLTriggerOffline/SMP/python/hltSMPPostProcessor_cfi.py
+++ b/HLTriggerOffline/SMP/python/hltSMPPostProcessor_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 hltSMPPostProcessor  = cms.EDAnalyzer("DQMGenericClient",
-    subDirs           = cms.untracked.vstring('HLT/Higgs/*'),
+    subDirs           = cms.untracked.vstring('HLT/SMP/*'),
     verbose           = cms.untracked.uint32(2),
     outputFileName    = cms.untracked.string(''),
     resolution        = cms.vstring(),                                    

--- a/HLTriggerOffline/SMP/python/hltSMPPostProcessor_cfi.py
+++ b/HLTriggerOffline/SMP/python/hltSMPPostProcessor_cfi.py
@@ -1,0 +1,11 @@
+import FWCore.ParameterSet.Config as cms
+
+hltSMPPostProcessor  = cms.EDAnalyzer("DQMGenericClient",
+    subDirs           = cms.untracked.vstring('HLT/Higgs/*'),
+    verbose           = cms.untracked.uint32(2),
+    outputFileName    = cms.untracked.string(''),
+    resolution        = cms.vstring(),                                    
+    efficiency        = cms.vstring(),
+    efficiencyProfile = cms.untracked.vstring(),
+)
+

--- a/HLTriggerOffline/SMP/python/hltSMPPostProcessors_cff.py
+++ b/HLTriggerOffline/SMP/python/hltSMPPostProcessors_cff.py
@@ -92,22 +92,16 @@ add_reco_strings(efficiency_strings)
 
 
 hltSMPPostSingleEle = hltSMPPostProcessor.clone()
-hltSMPPostSingleEle.subDirs = ['HLT/Higgs/SingleEle']
+hltSMPPostSingleEle.subDirs = ['HLT/SMP/SingleEle']
 hltSMPPostSingleEle.efficiencyProfile = efficiency_strings
 
-#print hltSMPPostSingleEle.efficiencyProfile
-
 hltSMPPostSingleMu = hltSMPPostProcessor.clone()
-hltSMPPostSingleMu.subDirs = ['HLT/Higgs/SingleMu']
+hltSMPPostSingleMu.subDirs = ['HLT/SMP/SingleMu']
 hltSMPPostSingleMu.efficiencyProfile = efficiency_strings
 
-print hltSMPPostSingleMu.efficiencyProfile
-
 hltSMPPostSinglePhoton = hltSMPPostProcessor.clone()
-hltSMPPostSinglePhoton.subDirs = ['HLT/Higgs/SinglePhoton']
+hltSMPPostSinglePhoton.subDirs = ['HLT/SMP/SinglePhoton']
 hltSMPPostSinglePhoton.efficiencyProfile = efficiency_strings
-
-#print hltSMPPostSinglePhoton
 
 hltSMPPostProcessors = cms.Sequence(
 		hltSMPPostSingleEle+

--- a/HLTriggerOffline/SMP/python/hltSMPPostProcessors_cff.py
+++ b/HLTriggerOffline/SMP/python/hltSMPPostProcessors_cff.py
@@ -91,21 +91,21 @@ add_reco_strings(efficiency_strings)
 
 
 
-hltSMPPostSingleEle = hltSMPPostProcessor.clone()
-hltSMPPostSingleEle.subDirs = ['HLT/SMP/SingleEle']
-hltSMPPostSingleEle.efficiencyProfile = efficiency_strings
+# hltSMPPostSingleEle = hltSMPPostProcessor.clone()
+# hltSMPPostSingleEle.subDirs = ['HLT/SMP/SingleEle']
+# hltSMPPostSingleEle.efficiencyProfile = efficiency_strings
 
-hltSMPPostSingleMu = hltSMPPostProcessor.clone()
-hltSMPPostSingleMu.subDirs = ['HLT/SMP/SingleMu']
-hltSMPPostSingleMu.efficiencyProfile = efficiency_strings
+# hltSMPPostSingleMu = hltSMPPostProcessor.clone()
+# hltSMPPostSingleMu.subDirs = ['HLT/SMP/SingleMu']
+# hltSMPPostSingleMu.efficiencyProfile = efficiency_strings
 
 hltSMPPostSinglePhoton = hltSMPPostProcessor.clone()
 hltSMPPostSinglePhoton.subDirs = ['HLT/SMP/SinglePhoton']
 hltSMPPostSinglePhoton.efficiencyProfile = efficiency_strings
 
 hltSMPPostProcessors = cms.Sequence(
-		hltSMPPostSingleEle+
-		hltSMPPostSingleMu+
+#		hltSMPPostSingleEle+
+#		hltSMPPostSingleMu+
 		hltSMPPostSinglePhoton
 )
 

--- a/HLTriggerOffline/SMP/python/hltSMPPostProcessors_cff.py
+++ b/HLTriggerOffline/SMP/python/hltSMPPostProcessors_cff.py
@@ -1,0 +1,118 @@
+import FWCore.ParameterSet.Config as cms
+
+from HLTriggerOffline.SMP.hltSMPPostProcessor_cfi import *
+
+# Build the standard strings to the DQM
+def efficiency_string(objtype,plot_type,triggerpath):
+    # --- IMPORTANT: Add here a elif if you are introduce a new collection
+    #                (see EVTColContainer::getTypeString) 
+    if objtype == "Mu" :
+	objtypeLatex="#mu"
+    elif objtype == "Photon": 
+	objtypeLatex="#gamma"
+    elif objtype == "Ele": 
+	objtypeLatex="e"
+    elif objtype == "MET" :
+	objtypeLatex="MET"
+    elif objtype == "PFTau": 
+	objtypeLatex="#tau"
+    else:
+	objtypeLatex=objtype
+
+    numer_description = "# gen %s passed the %s" % (objtypeLatex,triggerpath)
+    denom_description = "# gen %s " % (objtypeLatex)
+
+    if plot_type == "TurnOn1":
+        title = "pT Turn-On"
+        xAxis = "p_{T} of Leading Generated %s (GeV/c)" % (objtype)
+        input_type = "gen%sMaxPt1" % (objtype)
+    if plot_type == "TurnOn2":
+        title = "Next-to-Leading pT Turn-On"
+        xAxis = "p_{T} of Next-to-Leading Generated %s (GeV/c)" % (objtype)
+        input_type = "gen%sMaxPt2" % (objtype)
+    if plot_type == "EffEta":
+        title = "#eta Efficiency"
+        xAxis = "#eta of Generated %s " % (objtype)
+        input_type = "gen%sEta" % (objtype)
+    if plot_type == "EffPhi":
+        title = "#phi Efficiency"
+        xAxis = "#phi of Generated %s " % (objtype)
+        input_type = "gen%sPhi" % (objtype)
+
+    yAxis = "%s / %s" % (numer_description, denom_description)
+    all_titles = "%s for trigger %s; %s; %s" % (title, triggerpath,
+                                        xAxis, yAxis)
+    return "Eff_%s_%s '%s' %s_%s %s" % (input_type,triggerpath,
+		    all_titles,input_type,triggerpath,input_type)
+
+# Adding the reco objects
+def add_reco_strings(strings):
+    reco_strings = []
+    for entry in strings:
+        reco_strings.append(entry
+                            .replace("Generated", "Reconstructed")
+                            .replace("Gen", "Reco")
+                            .replace("gen", "rec"))
+    strings.extend(reco_strings)
+
+
+plot_types = ["TurnOn1", "TurnOn2", "EffEta", "EffPhi"]
+#--- IMPORTANT: Update this collection whenever you introduce a new object
+#               in the code (from EVTColContainer::getTypeString)
+obj_types  = ["Mu","Ele","Photon","MET","PFTau"]
+#--- IMPORTANT: Trigger are extracted from the hltSMPValidator_cfi.py module
+triggers = [ ] 
+efficiency_strings = []
+
+# Extract the triggers used in the hltSMPValidator 
+from HLTriggerOffline.SMP.hltSMPValidator_cfi import hltSMPValidator as _config
+triggers = set([])
+for an in _config.analysis:
+	s = _config.__getattribute__(an)
+	vstr = s.__getattribute__("hltPathsToCheck")
+	map(lambda x: triggers.add(x.replace("_v","")),vstr)
+triggers = list(triggers)
+#------------------------------------------------------------
+
+# Generating the list with all the efficiencies
+for type in plot_types:
+    for obj in obj_types:
+	for trig in triggers:
+	    efficiency_strings.append(efficiency_string(obj,type,trig))
+
+
+#add the summary plots
+for an in _config.analysis:
+    efficiency_strings.append("EffSummaryPaths_"+an+"_gen ' Efficiency of paths used in "+an+" ; trigger path ' SummaryPaths_"+an+"_gen_passingHLT SummaryPaths_"+an+"_gen")
+    for trig in triggers:
+        efficiency_strings.append("Eff_trueVtxDist_"+an+"_gen_"+trig+" ' Efficiency of "+trig+" vs nb of interactions ; nb events passing each path ' trueVtxDist_"+an+"_gen_"+trig+" trueVtxDist_"+an+"_gen")
+
+add_reco_strings(efficiency_strings)
+
+
+
+hltSMPPostSingleEle = hltSMPPostProcessor.clone()
+hltSMPPostSingleEle.subDirs = ['HLT/Higgs/SingleEle']
+hltSMPPostSingleEle.efficiencyProfile = efficiency_strings
+
+#print hltSMPPostSingleEle.efficiencyProfile
+
+hltSMPPostSingleMu = hltSMPPostProcessor.clone()
+hltSMPPostSingleMu.subDirs = ['HLT/Higgs/SingleMu']
+hltSMPPostSingleMu.efficiencyProfile = efficiency_strings
+
+print hltSMPPostSingleMu.efficiencyProfile
+
+hltSMPPostSinglePhoton = hltSMPPostProcessor.clone()
+hltSMPPostSinglePhoton.subDirs = ['HLT/Higgs/SinglePhoton']
+hltSMPPostSinglePhoton.efficiencyProfile = efficiency_strings
+
+#print hltSMPPostSinglePhoton
+
+hltSMPPostProcessors = cms.Sequence(
+		hltSMPPostSingleEle+
+		hltSMPPostSingleMu+
+		hltSMPPostSinglePhoton
+)
+
+

--- a/HLTriggerOffline/SMP/python/hltSMPValidator_cfi.py
+++ b/HLTriggerOffline/SMP/python/hltSMPValidator_cfi.py
@@ -1,0 +1,102 @@
+import FWCore.ParameterSet.Config as cms
+
+# taken from hltHiggsValidator_cfi.py in HLTriggerOffline/Higgs/python
+hltSMPValidator = cms.EDAnalyzer("HLTHiggsValidator",
+		
+    hltProcessName = cms.string("HLT"),
+    analysis       = cms.vstring("SingleEle", "SingleMu", "SinglePhoton"),
+    
+    # -- The instance name of the reco::GenParticles collection
+    genParticleLabel = cms.string("genParticles"),
+
+    # -- The nomber of interactions in the event
+    pileUpInfoLabel  = cms.string("addPileupInfo"),
+
+    # -- The binning of the Pt efficiency plots
+    parametersTurnOn = cms.vdouble(0,
+                                   1, 8, 9, 10,
+                                   11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+                                   22, 24, 26, 28, 30, 32, 34, 36, 38, 40,
+                                   45, 50, 55, 60, 65, 70,
+                                   80, 100, 120, 150, 200
+                                   ),
+
+    # -- (NBins, minVal, maxValue) for the Eta,Phi and nInterations efficiency plots
+    parametersEta      = cms.vdouble(48, -2.400, 2.400),
+    parametersPhi      = cms.vdouble(50, -3.142, 3.142),
+    parametersPu       = cms.vdouble(10, 0, 20),
+
+    # TO BE DEPRECATED --------------------------------------------
+    cutsDr = cms.vdouble(0.4, 0.4, 0.015), # TO BE DEPRECATED
+    # parameters for attempting an L1 match using a propagator
+    maxDeltaPhi = cms.double(0.4),  # TO BE DEPRECATED
+    maxDeltaR   = cms.double(0.4),  # TO BE DEPRECATED
+    # TO BE DEPRECATED --------------------------------------------
+
+    # Definition of generic cuts on generated and reconstructed objects (note that
+    # these cuts can be overloaded inside a particular analysis)
+    # Objects recognized: Mu Ele Photon PFTau MET
+    # Syntax in the strings: valid syntax of the StringCutObjectSelector class
+    # --- Muons
+    Mu_genCut     = cms.string("pt > 10 && abs(eta) < 2.4 && abs(pdgId) == 13 && status == 1"),
+    Mu_recCut     = cms.string("pt > 10 && abs(eta) < 2.4 && isGlobalMuon"),
+    Mu_cutMinPt   = cms.double(10),  # TO BE DEPRECATED
+    Mu_cutMaxEta  = cms.double(2.4), # TO BE DEPRECATED
+    
+    # --- Electrons
+    Ele_genCut      = cms.string("pt > 10 && abs(eta) < 2.5 && abs(pdgId) == 11 && status == 1"),
+    Ele_recCut      = cms.string("pt > 10 && abs(eta) < 2.5 && hadronicOverEm < 0.05 && eSuperClusterOverP > 0.5 && eSuperClusterOverP < 2.5"),
+    Ele_cutMinPt    = cms.double(10),  # TO BE DEPRECATED
+    Ele_cutMaxEta   = cms.double(2.5), # TO BE DEPRECATED
+
+    # --- Photons
+    Photon_genCut     = cms.string("abs(pdgId) == 22 && status == 1"),
+    Photon_recCut     = cms.string("pt > 20 && abs(eta) < 2.4 && hadronicOverEm < 0.1 && ( r9 < 0.85 || ("+\
+		    " ( abs(eta) < 1.479 && sigmaIetaIeta < 0.014  || "+\
+		    "   abs(eta) > 1.479 && sigmaIetaIeta < 0.0035 ) && "+\
+		    " ecalRecHitSumEtConeDR03 < (5.0+0.012*et) && hcalTowerSumEtConeDR03 < (5.0+0.0005*et )  && trkSumPtSolidConeDR03 < (5.0 + 0.0002*et)"+\
+		    " )"+")" ),
+    Photon_cutMinPt   = cms.double(20), # TO BE DEPRECATED
+    Photon_cutMaxEta  = cms.double(2.4),# TO BE DEPRECATED
+
+    # The specific parameters per analysis: the name of the parameter set has to be 
+    # the same as the defined ones in the 'analysis' datamember. Each analysis is a PSet
+    # with the mandatory attributes:
+    #    - hltPathsToCheck (cms.vstring) : a list of all the trigger pats to be checked 
+    #                 in this analysis. Up to the version number _v, but not including 
+    #                 the number in order to avoid this version dependence. Example: HLT_Mu18_v
+    #    - recVarLabel (cms.string): where Var can be Muon, Elec, Photon, CaloMET, PFTau. This 
+    #                 attribute is the name of the INSTANCE LABEL for each RECO collection to 
+    #                 be considered in the analysis. Note that the trigger paths rely on some 
+    #                 objects which need to be defined here, otherwise the code will complain. 
+    #    - minCandidates (cms.uint32): the minimum number of GEN/RECO objects in the event
+    # Besides the mandatory attributes, you can redefine the generation and reconstruction cuts
+    # for any object you want.
+    #    * Var_genCut, Var_recCut (cms.string): where Var=Mu, Ele, Photon, MET, PFTau (see above)
+
+    SingleEle = cms.PSet( 
+	    hltPathsToCheck = cms.vstring(
+		    "HLT_Ele27_WP85_Gsf_v",
+		    ),
+	    recElecLabel  = cms.string("gedGsfElectrons"),
+	    # -- Analysis specific cuts
+	    minCandidates = cms.uint32(1),
+	    ),
+    SingleMu = cms.PSet( 
+	    hltPathsToCheck = cms.vstring(
+		    "HLT_IsoMu24_IterTrk02_v",
+		    "HLT_IsoTkMu24_IterTrk02_v",
+		    ),
+	    recMuonLabel  = cms.string("muons"),
+	    # -- Analysis specific cuts
+	    minCandidates = cms.uint32(1), 
+	    ),
+    SinglePhoton = cms.PSet( 
+	    hltPathsToCheck = cms.vstring(
+		    "HLT_Photon155_v",
+		    ),
+	    recPhotonLabel  = cms.string("photons"),
+	    # -- Analysis specific cuts
+	    minCandidates = cms.uint32(1), 
+	    ),
+)

--- a/HLTriggerOffline/SMP/python/hltSMPValidator_cfi.py
+++ b/HLTriggerOffline/SMP/python/hltSMPValidator_cfi.py
@@ -5,7 +5,8 @@ hltSMPValidator = cms.EDAnalyzer("HLTHiggsValidator",
 		
     hltProcessName = cms.string("HLT"),
     histDirectory  = cms.string("HLT/SMP"),
-    analysis       = cms.vstring("SingleEle", "SingleMu", "SinglePhoton"),
+#    analysis       = cms.vstring("SingleEle", "SingleMu", "SinglePhoton"),
+    analysis       = cms.vstring("SinglePhoton"),
     
     # -- The instance name of the reco::GenParticles collection
     genParticleLabel = cms.string("genParticles"),
@@ -18,8 +19,9 @@ hltSMPValidator = cms.EDAnalyzer("HLTHiggsValidator",
                                    1, 8, 9, 10,
                                    11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
                                    22, 24, 26, 28, 30, 32, 34, 36, 38, 40,
-                                   45, 50, 55, 60, 65, 70,
-                                   80, 100, 120, 150, 200
+                                   45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100, 
+                                   110, 120, 130, 140, 150, 160, 170, 180, 190, 200,
+                                   220, 250, 300
                                    ),
 
     # -- (NBins, minVal, maxValue) for the Eta,Phi and nInterations efficiency plots
@@ -75,23 +77,23 @@ hltSMPValidator = cms.EDAnalyzer("HLTHiggsValidator",
     # for any object you want.
     #    * Var_genCut, Var_recCut (cms.string): where Var=Mu, Ele, Photon, MET, PFTau (see above)
 
-    SingleEle = cms.PSet( 
-	    hltPathsToCheck = cms.vstring(
-		    "HLT_Ele27_WP85_Gsf_v",
-		    ),
-	    recElecLabel  = cms.string("gedGsfElectrons"),
-	    # -- Analysis specific cuts
-	    minCandidates = cms.uint32(1),
-	    ),
-    SingleMu = cms.PSet( 
-	    hltPathsToCheck = cms.vstring(
-		    "HLT_IsoMu24_IterTrk02_v",
-		    "HLT_IsoTkMu24_IterTrk02_v",
-		    ),
-	    recMuonLabel  = cms.string("muons"),
-	    # -- Analysis specific cuts
-	    minCandidates = cms.uint32(1), 
-	    ),
+    # SingleEle = cms.PSet( 
+    #         hltPathsToCheck = cms.vstring(
+    #     	    "HLT_Ele27_WP85_Gsf_v",
+    #     	    ),
+    #         recElecLabel  = cms.string("gedGsfElectrons"),
+    #         # -- Analysis specific cuts
+    #         minCandidates = cms.uint32(1),
+    #         ),
+    # SingleMu = cms.PSet( 
+    #         hltPathsToCheck = cms.vstring(
+    #     	    "HLT_IsoMu24_IterTrk02_v",
+    #     	    "HLT_IsoTkMu24_IterTrk02_v",
+    #     	    ),
+    #         recMuonLabel  = cms.string("muons"),
+    #         # -- Analysis specific cuts
+    #         minCandidates = cms.uint32(1), 
+    #         ),
     SinglePhoton = cms.PSet( 
 	    hltPathsToCheck = cms.vstring(
 		    "HLT_Photon155_v",

--- a/HLTriggerOffline/SMP/python/hltSMPValidator_cfi.py
+++ b/HLTriggerOffline/SMP/python/hltSMPValidator_cfi.py
@@ -5,7 +5,6 @@ hltSMPValidator = cms.EDAnalyzer("HLTHiggsValidator",
 		
     hltProcessName = cms.string("HLT"),
     histDirectory  = cms.string("HLT/SMP"),
-#    analysis       = cms.vstring("SingleEle", "SingleMu", "SinglePhoton"),
     analysis       = cms.vstring("SinglePhoton"),
     
     # -- The instance name of the reco::GenParticles collection
@@ -21,7 +20,7 @@ hltSMPValidator = cms.EDAnalyzer("HLTHiggsValidator",
                                    22, 24, 26, 28, 30, 32, 34, 36, 38, 40,
                                    45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100, 
                                    110, 120, 130, 140, 150, 160, 170, 180, 190, 200,
-                                   220, 250, 300
+                                   220, 250, 300, 400, 500
                                    ),
 
     # -- (NBins, minVal, maxValue) for the Eta,Phi and nInterations efficiency plots
@@ -54,11 +53,10 @@ hltSMPValidator = cms.EDAnalyzer("HLTHiggsValidator",
 
     # --- Photons
     Photon_genCut     = cms.string("abs(pdgId) == 22 && status == 1"),
-    Photon_recCut     = cms.string("pt > 20 && abs(eta) < 2.4 && hadronicOverEm < 0.1 && ( r9 < 0.85 || ("+\
-		    " ( abs(eta) < 1.479 && sigmaIetaIeta < 0.014  || "+\
-		    "   abs(eta) > 1.479 && sigmaIetaIeta < 0.0035 ) && "+\
-		    " ecalRecHitSumEtConeDR03 < (5.0+0.012*et) && hcalTowerSumEtConeDR03 < (5.0+0.0005*et )  && trkSumPtSolidConeDR03 < (5.0 + 0.0002*et)"+\
-		    " )"+")" ),
+    Photon_recCut     = cms.string("pt > 20 && abs(eta) < 2.4 && hadronicOverEm < 0.1 && ("+\
+		    "   abs(eta) < 1.479 && sigmaIetaIeta < 0.010  || "+\
+		    "   abs(eta) > 1.479 && sigmaIetaIeta < 0.027 ) && "+\
+		    " ecalRecHitSumEtConeDR03 < (5.0+0.012*et) && hcalTowerSumEtConeDR03 < (5.0+0.0005*et )  && trkSumPtSolidConeDR03 < (5.0 + 0.0002*et)" ),
     Photon_cutMinPt   = cms.double(20), # TO BE DEPRECATED
     Photon_cutMaxEta  = cms.double(2.4),# TO BE DEPRECATED
 
@@ -77,26 +75,24 @@ hltSMPValidator = cms.EDAnalyzer("HLTHiggsValidator",
     # for any object you want.
     #    * Var_genCut, Var_recCut (cms.string): where Var=Mu, Ele, Photon, MET, PFTau (see above)
 
-    # SingleEle = cms.PSet( 
-    #         hltPathsToCheck = cms.vstring(
-    #     	    "HLT_Ele27_WP85_Gsf_v",
-    #     	    ),
-    #         recElecLabel  = cms.string("gedGsfElectrons"),
-    #         # -- Analysis specific cuts
-    #         minCandidates = cms.uint32(1),
-    #         ),
-    # SingleMu = cms.PSet( 
-    #         hltPathsToCheck = cms.vstring(
-    #     	    "HLT_IsoMu24_IterTrk02_v",
-    #     	    "HLT_IsoTkMu24_IterTrk02_v",
-    #     	    ),
-    #         recMuonLabel  = cms.string("muons"),
-    #         # -- Analysis specific cuts
-    #         minCandidates = cms.uint32(1), 
-    #         ),
     SinglePhoton = cms.PSet( 
 	    hltPathsToCheck = cms.vstring(
+		    "HLT_Photon22_v",
+		    "HLT_Photon30_v",
+		    "HLT_Photon36_v",
+		    "HLT_Photon50_v",
+		    "HLT_Photon75_v",
+		    "HLT_Photon90_v",
+		    "HLT_Photon120_v",
 		    "HLT_Photon155_v",
+		    "HLT_Photon22_R9Id90_HE10_Iso40_v",
+		    "HLT_Photon30_R9Id90_HE10_Iso40_v",
+		    "HLT_Photon36_R9Id90_HE10_Iso40_v",
+		    "HLT_Photon50_R9Id90_HE10_Iso40_v",
+		    "HLT_Photon75_R9Id90_HE10_Iso40_v",
+		    "HLT_Photon90_R9Id90_HE10_Iso40_v",
+		    "HLT_Photon120_R9Id90_HE10_Iso40_v",
+		    "HLT_Photon155_R9Id90_HE10_Iso40_v",
 		    ),
 	    recPhotonLabel  = cms.string("photons"),
 	    # -- Analysis specific cuts

--- a/HLTriggerOffline/SMP/python/hltSMPValidator_cfi.py
+++ b/HLTriggerOffline/SMP/python/hltSMPValidator_cfi.py
@@ -4,6 +4,7 @@ import FWCore.ParameterSet.Config as cms
 hltSMPValidator = cms.EDAnalyzer("HLTHiggsValidator",
 		
     hltProcessName = cms.string("HLT"),
+    histDirectory  = cms.string("HLT/SMP"),
     analysis       = cms.vstring("SingleEle", "SingleMu", "SinglePhoton"),
     
     # -- The instance name of the reco::GenParticles collection

--- a/HLTriggerOffline/SMP/python/hltSMPValidator_cfi.py
+++ b/HLTriggerOffline/SMP/python/hltSMPValidator_cfi.py
@@ -10,6 +10,10 @@ hltSMPValidator = cms.EDAnalyzer("HLTHiggsValidator",
     # -- The instance name of the reco::GenParticles collection
     genParticleLabel = cms.string("genParticles"),
 
+    # -- The instance name of the reco::GenJets collection
+    # (not used but required to be set)
+    genJetLabel = cms.string("ak5GenJets"),
+
     # -- The nomber of interactions in the event
     pileUpInfoLabel  = cms.string("addPileupInfo"),
 

--- a/HLTriggerOffline/SMP/test/hltSMPPostProcessor_cfg.py
+++ b/HLTriggerOffline/SMP/test/hltSMPPostProcessor_cfg.py
@@ -1,0 +1,34 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("EDMtoMEConvert")
+
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger.cerr.FwkReport.reportEvery = 2000
+
+process.load('Configuration.StandardSequences.EDMtoMEAtJobEnd_cff')
+process.load("DQMServices.Components.DQMEnvironment_cfi")
+process.load("HLTriggerOffline.SMP.HLTSMPPostVal_cff")
+#process.load("HLTriggerOffline.SMP.HLTSMPQualityTester_cfi")
+
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(-1)
+)
+
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring('file:hltSMPValidator.root')
+)
+
+process.postprocessor_path = cms.Path(
+		process.HLTSMPPostVal
+    #    process.hltSMPQualityTester
+)
+
+process.edmtome_path = cms.Path(process.EDMtoME)
+process.dqmsave_path = cms.Path(process.DQMSaver)
+
+process.schedule = cms.Schedule(process.edmtome_path,
+                                process.postprocessor_path,
+                                process.dqmsave_path)
+
+process.DQMStore.referenceFileName = ''

--- a/HLTriggerOffline/SMP/test/hltSMPValidator_cfg.py
+++ b/HLTriggerOffline/SMP/test/hltSMPValidator_cfg.py
@@ -1,0 +1,58 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("HLTSMPOfflineAnalysis")
+
+process.load("HLTriggerOffline.SMP.SMPValidation_cff")
+process.load("DQMServices.Components.MEtoEDMConverter_cfi")
+
+hltProcessName = "HLT"
+process.hltSMPValidator.hltProcessName = hltProcessName
+
+process.load("Configuration.StandardSequences.Reconstruction_cff")
+process.load("Configuration.StandardSequences.MagneticField_cff")
+process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+from Configuration.AlCa.autoCond import autoCond
+process.GlobalTag.globaltag = cms.string(autoCond['startup'])
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(-1)
+)
+
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring(
+#	    '/store/relval/CMSSW_7_2_0_pre6/RelValPhotonJets_Pt_10_13/GEN-SIM-RECO/PRE_LS172_V11-v1/00000/4CB3A30E-B53F-E411-A93F-0025905A6084.root',
+	    '/store/relval/CMSSW_7_2_0_pre6/RelValZMM_13/GEN-SIM-RECO/PRE_LS172_V11-v1/00000/7E674AE9-933F-E411-9C63-0026189438B1.root',
+    ),
+    secondaryFileNames = cms.untracked.vstring(
+    )
+)
+
+process.DQMStore = cms.Service("DQMStore")
+
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger.cerr.FwkReport.reportEvery = 2000
+process.MessageLogger.destinations += ['SMPValidationMessages']
+process.MessageLogger.categories   += ['SMPValidation']
+process.MessageLogger.debugModules += ['*']#HLTHiggsValidator','HLTHiggsSubAnalysis','HLTHiggsPlotter']
+process.MessageLogger.SMPValidationMessages = cms.untracked.PSet(
+    threshold       = cms.untracked.string('DEBUG'),
+    default         = cms.untracked.PSet(limit = cms.untracked.int32(0)),
+    SMPValidation = cms.untracked.PSet(limit = cms.untracked.int32(1000))
+    )
+
+process.out = cms.OutputModule("PoolOutputModule",
+    outputCommands = cms.untracked.vstring(
+        'drop *', 
+        'keep *_MEtoEDMConverter_*_HLTSMPOfflineAnalysis'),
+    fileName = cms.untracked.string('hltSMPValidator.root')
+)
+
+
+process.analyzerpath = cms.Path(
+    process.hltSMPValidator *
+    process.MEtoEDMConverter
+)
+
+
+process.outpath = cms.EndPath(process.out)

--- a/HLTriggerOffline/SMP/test/hltSMPValidator_cfg.py
+++ b/HLTriggerOffline/SMP/test/hltSMPValidator_cfg.py
@@ -21,8 +21,8 @@ process.maxEvents = cms.untracked.PSet(
 
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring(
-	    '/store/relval/CMSSW_7_2_0_pre6/RelValH130GGgluonfusion_13/GEN-SIM-RECO/PRE_LS172_V11-v1/00000/0E219073-8E3F-E411-AC64-0026189438F2.root',
-	    '/store/relval/CMSSW_7_2_0_pre6/RelValH130GGgluonfusion_13/GEN-SIM-RECO/PRE_LS172_V11-v1/00000/404B9C6F-8E3F-E411-9894-00261894393D.root',
+        '/store/relval/CMSSW_7_3_0_pre1/RelValH130GGgluonfusion_13/GEN-SIM-RECO/PRE_LS172_V15-v1/00000/A8F284E4-FC59-E411-8934-0025905A48D0.root',
+        '/store/relval/CMSSW_7_3_0_pre1/RelValH130GGgluonfusion_13/GEN-SIM-RECO/PRE_LS172_V15-v1/00000/F2BA47E7-FC59-E411-9031-0025905964B4.root'
     ),
     secondaryFileNames = cms.untracked.vstring(
     )

--- a/HLTriggerOffline/SMP/test/hltSMPValidator_cfg.py
+++ b/HLTriggerOffline/SMP/test/hltSMPValidator_cfg.py
@@ -21,8 +21,8 @@ process.maxEvents = cms.untracked.PSet(
 
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring(
-#	    '/store/relval/CMSSW_7_2_0_pre6/RelValPhotonJets_Pt_10_13/GEN-SIM-RECO/PRE_LS172_V11-v1/00000/4CB3A30E-B53F-E411-A93F-0025905A6084.root',
-	    '/store/relval/CMSSW_7_2_0_pre6/RelValZMM_13/GEN-SIM-RECO/PRE_LS172_V11-v1/00000/7E674AE9-933F-E411-9C63-0026189438B1.root',
+	    '/store/relval/CMSSW_7_2_0_pre6/RelValH130GGgluonfusion_13/GEN-SIM-RECO/PRE_LS172_V11-v1/00000/0E219073-8E3F-E411-AC64-0026189438F2.root',
+	    '/store/relval/CMSSW_7_2_0_pre6/RelValH130GGgluonfusion_13/GEN-SIM-RECO/PRE_LS172_V11-v1/00000/404B9C6F-8E3F-E411-9894-00261894393D.root',
     ),
     secondaryFileNames = cms.untracked.vstring(
     )


### PR DESCRIPTION
Resubmission of #6144 with cherry-picked commits.

First commit of basic SMP HLT DQM. Configuration is based on same C++ code as Higgs DQM and contains only python configuration.

Also modifies Higgs DQM code slightly to allow DQM directory name to be configurable. Change was discussed with Higgs DQM developers, Hugues Brun and Sami Lehti.

Currently contains only single photon paths (proposed by SMP at Oct14 Strasbourg TSG workshop).

An example output file is here, including the new paths:
/afs/cern.ch/user/o/olivito/public/dqm/CMSSW_7_3_0_pre1/src/HLTriggerOffline/SMP/test/DQM_SMP_singlephoton_Hggrelval.root
