### PR TITLE
Added pixel match variables to reco::GsfElectron

### DIFF
--- a/DataFormats/EgammaCandidates/interface/GsfElectron.h
+++ b/DataFormats/EgammaCandidates/interface/GsfElectron.h
@@ -789,7 +789,33 @@ class GsfElectron : public RecoCandidate
 
     // attributes
     Corrections corrections_ ;
-
+  
+  public:
+    struct PixelMatchVariables{
+      int subdetector1 ;
+      int subdetector2 ;
+      float dPhi1 ;
+      float dPhi2 ;
+      float dRz1  ;
+      float dRz2  ;
+      PixelMatchVariables():
+        subdetector1(-1),
+        subdetector2(-1),
+        dPhi1(-999),
+        dPhi2(-999),
+        dRz1(-999),
+        dRz2(-999)
+      {}
+      ~PixelMatchVariables(){}
+    };
+  void setPixelMatchSubdetector1(int sd1){ pixelMatchVariables_.subdetector1 = sd1 ; }
+  void setPixelMatchSubdetector2(int sd2){ pixelMatchVariables_.subdetector2 = sd2 ; }
+  void setPixelMatchDPhi1(float dPhi1){ pixelMatchVariables_.dPhi1 = dPhi1 ; }
+  void setPixelMatchDPhi2(float dPhi2){ pixelMatchVariables_.dPhi2 = dPhi2 ; }
+  void setPixelMatchDRz1 (float dRz1 ){ pixelMatchVariables_.dRz1  = dRz1  ; }
+  void setPixelMatchDRz2 (float dRz2 ){ pixelMatchVariables_.dRz2  = dRz2  ; }
+  private:
+    PixelMatchVariables pixelMatchVariables_ ;
  } ;
 
  } // namespace reco

--- a/DataFormats/EgammaCandidates/src/GsfElectron.cc
+++ b/DataFormats/EgammaCandidates/src/GsfElectron.cc
@@ -94,7 +94,8 @@ GsfElectron::GsfElectron
    ambiguousGsfTracks_(electron.ambiguousGsfTracks_),
    classVariables_(electron.classVariables_),
    class_(electron.class_),
-   corrections_(electron.corrections_)
+   corrections_(electron.corrections_),
+   pixelMatchVariables_(electron.pixelMatchVariables_)
  {
   assert(electron.core()->ctfTrack()==core->ctfTrack()) ;
   assert(electron.core()->ctfGsfOverlap()==core->ctfGsfOverlap()) ;
@@ -130,7 +131,8 @@ GsfElectron::GsfElectron
    //mva_(electron.mva_),
    classVariables_(electron.classVariables_),
    class_(electron.class_),
-   corrections_(electron.corrections_)
+   corrections_(electron.corrections_),
+   pixelMatchVariables_(electron.pixelMatchVariables_)
  {
   trackClusterMatching_.electronCluster = electronCluster ;
   //closestCtfTrack_.ctfTrack = closestCtfTrack ;

--- a/DataFormats/EgammaCandidates/src/classes_def.xml
+++ b/DataFormats/EgammaCandidates/src/classes_def.xml
@@ -207,7 +207,11 @@
   <class name="reco::GsfElectron::ClassificationVariables" ClassVersion="11">
    <version ClassVersion="11" checksum="2094185381"/>
   </class>
-  <class name="reco::GsfElectron" ClassVersion="14">
+  <class name="reco::GsfElectron::PixelMatchVariables">
+  </class>
+  <class name="reco::GsfElectron" ClassVersion="16">
+   <version ClassVersion="15" checksum="1613212064"/>
+   <version ClassVersion="16" checksum="515498629"/>
    <version ClassVersion="14" checksum="3918953183"/>
    <version ClassVersion="13" checksum="2991498573"/>
    <version ClassVersion="12" checksum="2835360780"/>

--- a/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h
@@ -253,6 +253,9 @@ class GsfElectronAlgo {
 
     // associations
     const reco::SuperClusterRef getTrSuperCluster( const reco::GsfTrackRef & trackRef ) ;
+    
+    // Pixel match variables
+    void setPixelMatchInfomation(reco::GsfElectron*) ;
  } ;
 
 #endif // GsfElectronAlgo_H

--- a/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
@@ -1525,6 +1525,11 @@ void GsfElectronAlgo::createElectron()
   //====================================================
 
   setCutBasedPreselectionFlag(ele,*eventData_->beamspot) ;
+  
+  //====================================================
+  // Pixel match variables
+  //====================================================
+  setPixelMatchInfomation(ele) ;
 
   LogTrace("GsfElectronAlgo")<<"Constructed new electron with energy  "<< ele->p4().e() ;
 
@@ -1676,3 +1681,31 @@ void GsfElectronAlgo::removeAmbiguousElectrons()
  }
 
 
+// Pixel match variables
+void GsfElectronAlgo::setPixelMatchInfomation(reco::GsfElectron* ele){
+  edm::RefToBase<TrajectorySeed> seed = ele->gsfTrack()->extra()->seedRef();
+  ElectronSeedRef elseed = seed.castTo<ElectronSeedRef>();
+  if(seed.isNull()){
+    edm::LogError("GsfElectronAlgo")<<"The GsfTrack has no seed, so cannot set pixel match variable" ;
+  }
+  else{
+    if(elseed.isNull()){
+      edm::LogError("GsfElectronAlgo")<<"The GsfTrack seed is not an ElectronSeed, so cannot set pixel match variable" ;
+    }
+    else{
+      int sd1     = elseed->subDet1() ;
+      int sd2     = elseed->subDet2() ;
+      float dPhi1 = elseed->dPhi1() ;
+      float dPhi2 = elseed->dPhi2() ;
+      float dRz1  = elseed->dRz1 () ;
+      float dRz2  = elseed->dRz2 () ;
+      
+      ele->setPixelMatchSubdetector1(sd1) ;
+      ele->setPixelMatchSubdetector2(sd2) ;
+      ele->setPixelMatchDPhi1(dPhi1) ;
+      ele->setPixelMatchDPhi2(dPhi2) ;
+      ele->setPixelMatchDRz1 (dRz1 ) ;
+      ele->setPixelMatchDRz2 (dRz2 ) ;
+    }
+  }
+}


### PR DESCRIPTION
Added new struct reco::GsfElectron::PixelMatchVariables to hold
variables.
Added setter and getter functions to GsfElectron.
Updated constructors of GsfElectron to copy pixel match variables when
another GsfElectron is passed as an argument.
Updated checksum of GsfElectron in class_def.xml, and added
PixelMatchVariables struct to class_def.xml.
Added method to GsfElectronAlgo to add pixel match information to
GsfElectron.
