### PR TITLE
backport of  #6145: Add RelVals for Exo HLT and Tk POG

### DIFF
--- a/Configuration/Generator/python/HSCPmchamp1_M_600_TuneZ2star_13TeV_pythia6_cff.py
+++ b/Configuration/Generator/python/HSCPmchamp1_M_600_TuneZ2star_13TeV_pythia6_cff.py
@@ -1,0 +1,68 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. 
+MASS_POINT = 600   # GeV
+CHARGE = 1   # electron charge/3
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.PythiaUEZ2starSettings_cfi import *
+
+generator = cms.EDFilter("Pythia6GeneratorFilter",
+    filterEfficiency = cms.untracked.double(1.),
+    comEnergy = cms.double(COM_ENERGY),
+    crossSection = cms.untracked.double(-1),
+    maxEventsToPrint = cms.untracked.int32(0),
+                         
+	PythiaParameters = cms.PSet(
+	    pythiaUESettingsBlock,
+	 	processParameters = cms.vstring(
+ 	      'MSEL=0          ! User defined processes',
+		  'MSUB(1)=1 !',
+		  'MSTP(43)    = 3   ! complete Z0/gamma* interference',
+		  'MSTP(1)=4 !fourth generation',
+		  'CKIN(1)=%f !min sqrt(s hat)' % hipMass,
+		  'CKIN(2)= -1  ! (no) max sqrt(s hat) (GeV)', 
+                  'KCHG(17,1)=%i !charge of tauprime' % CHARGE,
+		  'PMAS(17,1)=%f !tauprime mass' % hipMass,
+		  'MDME(174,1) = 0   !Z decay into d dbar', 
+		  'MDME(175,1) = 0   !Z decay into u ubar', 
+		  'MDME(176,1) = 0   !Z decay into s sbar', 
+		  'MDME(177,1) = 0   !Z decay into c cbar', 
+		  'MDME(178,1) = 0   !Z decay into b bbar', 
+		  'MDME(179,1) = 0   !Z decay into t tbar', 
+		  'MDME(180,1) = 0   !Z decay into bprime bprimebar', 
+		  'MDME(181,1) = 0   !Z decay into tprime tprimebar', 
+		  'MDME(182,1) = 0   !Z decay into e- e+', 
+		  'MDME(183,1) = 0   !Z decay into nu_e nu_ebar', 
+		  'MDME(184,1) = 0   !Z decay into mu- mu+', 
+		  'MDME(185,1) = 0   !Z decay into nu_mu nu_mubar', 
+		  'MDME(186,1) = 0   !Z decay into tau- tau+', 
+		  'MDME(187,1) = 0   !Z decay into nu_tau nu_taubar',
+		  'MDME(188,1) = 1   !Z decay into tauprime tauprimebar',
+		  'MDME(189,1) = 0   !Z decay into nu_tauprime nu_tauprimebar',
+		  'MDCY(17,1)=0    ! set tauprime stable',
+		  'MWID(17)=0      ! set tauprime width 0'
+		  ),
+    parameterSets = cms.vstring(
+
+    'pythiaUESettings', 'processParameters'),
+    
+    )
+ )
+                         
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/Configuration/Generator/python/HSCPstop_M_200_TuneCUETP8M1_13TeV_pythia8_cff.py
+++ b/Configuration/Generator/python/HSCPstop_M_200_TuneCUETP8M1_13TeV_pythia8_cff.py
@@ -1,0 +1,58 @@
+FLAVOR = 'stop'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 200   # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/stophadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/particles_%s_%d_GeV.txt'  % (FLAVOR, MASS_POINT)
+SLHA_FILE ='Configuration/Generator/data/HSCP_%s_%d_SLHA.spc' % (FLAVOR, MASS_POINT)
+PDT_FILE = 'Configuration/Generator/data/hscppythiapdt%s%d.tbl'  % (FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+                         pythiaPylistVerbosity = cms.untracked.int32(0),
+                         filterEfficiency = cms.untracked.double(-1),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(COM_ENERGY),
+                         crossSection = cms.untracked.double(-1),
+                         maxEventsToPrint = cms.untracked.int32(0),
+                         SLHAFileForPythia8 = cms.string('%s' % SLHA_FILE), 
+			 PythiaParameters = cms.PSet(
+    processParameters = cms.vstring(
+			  'SUSY:all = off',
+			  'SUSY:gg2squarkantisquark  = on',
+			  'SUSY:qqbar2squarkantisquark= on',
+			  'RHadrons:allow  = on',
+			  'RHadrons:allowDecay = off',
+			  'RHadrons:setMasses = on',
+			  ),
+    parameterSets = cms.vstring('pythia8CommonSettings',
+                                'pythia8CUEP8M1Settings',
+                                'processParameters'
+                                )
+    
+    )
+                         )
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+dirhadrongenfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(1000612,1000622,1000632,1000642,1000652,1006113,1006211,1006213,1006223,1006311,1006313,1006321,1006323,1006333),
+    ParticleID2 = cms.untracked.vint32(1000612,1000622,1000632,1000642,1000652,1006113,1006211,1006213,1006223,1006311,1006313,1006321,1006323,1006333)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*dirhadrongenfilter)

--- a/Configuration/Generator/python/Hadronizer_TuneCUETP8M1_13TeV_generic_LHE_pythia8_cff.py
+++ b/Configuration/Generator/python/Hadronizer_TuneCUETP8M1_13TeV_generic_LHE_pythia8_cff.py
@@ -1,0 +1,19 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    filterEfficiency = cms.untracked.double(1.0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(13000.),
+    PythiaParameters = cms.PSet(
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CUEP8M1Settings'
+                                    )
+        )
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/Configuration/Generator/python/WprimeToENu_M-2000_TuneCUETP8M1_13TeV-pythia8_cff.py
+++ b/Configuration/Generator/python/WprimeToENu_M-2000_TuneCUETP8M1_13TeV-pythia8_cff.py
@@ -1,0 +1,27 @@
+## Wprime to electron
+
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    filterEfficiency = cms.untracked.double(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(13000.0),
+    crossSection = cms.untracked.double(0.001843),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        processParameters = cms.vstring( 'NewGaugeBoson:ffbar2Wprime = on', 
+                                         '34:m0 = 2000.', 
+                                         '34:onMode = off', 
+                                         '34:onIfAny = 11,12'),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CUEP8M1Settings',
+                                    'processParameters'
+                                    )
+    )
+)
+
+ProductionFilterSequence = cms.Sequence(generator)


### PR DESCRIPTION
Add HSCP stops, fractionally charged particles, and WpE for relvals. For Exotica HLT validation and for Tk POG RECO validation of dE/dx.

Backport needed so that we can perform the HLT validation in 72X as well.
