### PR TITLE
Default HCAL reco in 73X -> replaces #5882

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowCaloResolution_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowCaloResolution_cfi.py
@@ -22,13 +22,13 @@ _timeResolutionECALEndcap = cms.PSet(
   )
 
 _timeResolutionHCAL = cms.PSet(
-    noiseTerm = cms.double(15.92),
-    constantTerm = cms.double(2.59),
-    noiseTermLowE = cms.double(3.313),
+    noiseTerm = cms.double(8.64),
+    constantTerm = cms.double(1.92),
+    noiseTermLowE = cms.double(0.0),
     corrTermLowE = cms.double(0.0),
-    constantTermLowE = cms.double(4.088),
-    threshLowE = cms.double(5.0),
-    threshHighE = cms.double(20.0)
+    constantTermLowE = cms.double(6.0),
+    threshLowE = cms.double(2.0),
+    threshHighE = cms.double(8.0)
   )
 
 _timeResolutionHCALMaxSample = cms.PSet(

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHBHETimeSelected_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHBHETimeSelected_cfi.py
@@ -57,146 +57,145 @@ particleFlowClusterHBHETimeSelected = cms.EDProducer(
             minEnergy = cms.double(1.0),
             maxEnergy = cms.double(2.0),
             endcap = cms.bool(False),
-            minTime = cms.double(-5.),
-            maxTime = cms.double(50.)
+            minTime = cms.double(-20.),
+            maxTime = cms.double(15.)
         ),
         cms.PSet(
             depth=cms.double(1.0),
             minEnergy = cms.double(1.0),
             maxEnergy = cms.double(2.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-5.),
-            maxTime = cms.double(50.)
+            minTime = cms.double(-20.),
+            maxTime = cms.double(16.)
         ),
         cms.PSet(
             depth=cms.double(2.0),
             minEnergy = cms.double(1.0),
             maxEnergy = cms.double(2.0),
             endcap = cms.bool(False),
-            minTime = cms.double(-5.),
-            maxTime = cms.double(50.)
+            minTime = cms.double(-20.),
+            maxTime = cms.double(15.)
         ),
         cms.PSet(
             depth=cms.double(2.0),
             minEnergy = cms.double(1.0),
             maxEnergy = cms.double(2.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-5.),
-            maxTime = cms.double(50.)
+            minTime = cms.double(-20.),
+            maxTime = cms.double(15.)
         ),
         cms.PSet(
             depth=cms.double(3.0),
             minEnergy = cms.double(1.0),
             maxEnergy = cms.double(2.0),
             endcap = cms.bool(False),
-            minTime = cms.double(-5.),
-            maxTime = cms.double(5.)
+            minTime = cms.double(-20.),
+            maxTime = cms.double(15.)
         ),
         cms.PSet(
             depth=cms.double(3.0),
             minEnergy = cms.double(1.0),
             maxEnergy = cms.double(2.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-5.),
-            maxTime = cms.double(50.)
+            minTime = cms.double(-20.),
+            maxTime = cms.double(15.)
         ),
         cms.PSet(
             depth=cms.double(1.0),
             minEnergy = cms.double(2.),
             maxEnergy = cms.double(5.0),
             endcap = cms.bool(False),
-            minTime = cms.double(-1.),
-            maxTime = cms.double(40.)
+            minTime = cms.double(-20.),
+            maxTime = cms.double(25.)
         ),
         cms.PSet(
             depth=cms.double(1.0),
             minEnergy = cms.double(2.0),
             maxEnergy = cms.double(5.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-1.),
-            maxTime = cms.double(40.)
+            minTime = cms.double(-20.),
+            maxTime = cms.double(25.)
         ),
         cms.PSet(
             depth=cms.double(2.0),
             minEnergy = cms.double(2.),
             maxEnergy = cms.double(5.0),
             endcap = cms.bool(False),
-            minTime = cms.double(-1.),
-            maxTime = cms.double(40.)
+            minTime = cms.double(-15.),
+            maxTime = cms.double(25.)
         ),
         cms.PSet(
             depth=cms.double(2.0),
             minEnergy = cms.double(2.0),
             maxEnergy = cms.double(5.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-1.),
-            maxTime = cms.double(40.)
+            minTime = cms.double(-15.),
+            maxTime = cms.double(25.)
         ),
         cms.PSet(
             depth=cms.double(3.0),
             minEnergy = cms.double(2.),
             maxEnergy = cms.double(5.0),
             endcap = cms.bool(False),
-            minTime = cms.double(-1.),
-            maxTime = cms.double(40.)
+            minTime = cms.double(-15.),
+            maxTime = cms.double(25.)
         ),
         cms.PSet(
             depth=cms.double(3.0),
             minEnergy = cms.double(2.0),
             maxEnergy = cms.double(5.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-1.),
-            maxTime = cms.double(40.)
+            minTime = cms.double(-15.),
+            maxTime = cms.double(25.)
         ),
 
-
         cms.PSet(
             depth=cms.double(1.0),
             minEnergy = cms.double(5.),
             maxEnergy = cms.double(9999999.0),
             endcap = cms.bool(False),
-            minTime = cms.double(-0.5),
-            maxTime = cms.double(25.)
+            minTime = cms.double(-5),
+            maxTime = cms.double(20.)
         ),
         cms.PSet(
             depth=cms.double(1.0),
             minEnergy = cms.double(5.0),
             maxEnergy = cms.double(9999999.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-0.5),
-            maxTime = cms.double(25.)
+            minTime = cms.double(-5),
+            maxTime = cms.double(20.)
         ),
         cms.PSet(
             depth=cms.double(2.0),
             minEnergy = cms.double(5.),
             maxEnergy = cms.double(9999999.0),
             endcap = cms.bool(False),
-            minTime = cms.double(-0.5),
-            maxTime = cms.double(25.)
+            minTime = cms.double(-5),
+            maxTime = cms.double(20.)
         ),
         cms.PSet(
             depth=cms.double(2.0),
             minEnergy = cms.double(5.0),
             maxEnergy = cms.double(9999999.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-0.5),
-            maxTime = cms.double(25.)
+            minTime = cms.double(-5),
+            maxTime = cms.double(20.)
         ),
         cms.PSet(
             depth=cms.double(3.0),
             minEnergy = cms.double(5.),
             maxEnergy = cms.double(9999999.0),
             endcap = cms.bool(False),
-            minTime = cms.double(-0.5),
-            maxTime = cms.double(25.)
+            minTime = cms.double(-5),
+            maxTime = cms.double(20.)
         ),
         cms.PSet(
             depth=cms.double(3.0),
             minEnergy = cms.double(5.0),
             maxEnergy = cms.double(9999999.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-0.5),
-            maxTime = cms.double(25.)
+            minTime = cms.double(-5),
+            maxTime = cms.double(20.)
         )
     )
 )

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHBHE_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHBHE_cfi.py
@@ -36,7 +36,7 @@ particleFlowClusterHBHE = cms.EDProducer(
     ),
     
     pfClusterBuilder = cms.PSet(
-           algoName = cms.string("PFlow2DClusterizerWithTime"),
+           algoName = cms.string("Basic2DGenericPFlowClusterizer"),
            #pf clustering parameters
            minFractionToKeep = cms.double(1e-7),
            positionCalc = cms.PSet(

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHCAL_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHCAL_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 particleFlowClusterHCAL = cms.EDProducer('PFMultiDepthClusterProducer',
-       clustersSource = cms.InputTag("particleFlowClusterHBHETimeSelected"),
+       clustersSource = cms.InputTag("particleFlowClusterHBHE"),
        pfClusterBuilder =cms.PSet(
            algoName = cms.string("PFMultiDepthClusterizer"),
            nSigmaEta = cms.double(2.),

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHCAL_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHCAL_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 particleFlowClusterHCAL = cms.EDProducer('PFMultiDepthClusterProducer',
-       clustersSource = cms.InputTag("particleFlowClusterHBHE"),
+       clustersSource = cms.InputTag("particleFlowClusterHBHETimeSelected"),
        pfClusterBuilder =cms.PSet(
            algoName = cms.string("PFMultiDepthClusterizer"),
            nSigmaEta = cms.double(2.),

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowCluster_cff.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowCluster_cff.py
@@ -29,7 +29,7 @@ pfClusteringPS = cms.Sequence(particleFlowRecHitPS*particleFlowClusterPS)
 
 
 #pfClusteringHBHEHF = cms.Sequence(towerMakerPF*particleFlowRecHitHCAL*particleFlowClusterHCAL+particleFlowClusterHFHAD+particleFlowClusterHFEM)
-pfClusteringHBHEHF = cms.Sequence(particleFlowRecHitHBHE*particleFlowRecHitHF*particleFlowClusterHBHE*particleFlowClusterHBHETimeSelected*particleFlowClusterHF*particleFlowClusterHCAL)
+pfClusteringHBHEHF = cms.Sequence(particleFlowRecHitHBHE*particleFlowRecHitHF*particleFlowClusterHBHE*particleFlowClusterHF*particleFlowClusterHCAL)
 pfClusteringHO = cms.Sequence(particleFlowRecHitHO*particleFlowClusterHO)
 
 

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowCluster_cff.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowCluster_cff.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 
 #from RecoParticleFlow.PFClusterProducer.towerMakerPF_cfi import *
-from RecoParticleFlow.PFClusterProducer.particleFlowCaloResolution_cfi import _timeResolutionHCALMaxSample
+#from RecoParticleFlow.PFClusterProducer.particleFlowCaloResolution_cfi import _timeResolutionHCALMaxSample
 
 from RecoParticleFlow.PFClusterProducer.particleFlowRecHitECAL_cfi import *
 from RecoParticleFlow.PFClusterProducer.particleFlowRecHitHBHE_cfi import *
@@ -15,7 +15,7 @@ from RecoParticleFlow.PFClusterProducer.particleFlowClusterECAL_cfi import *
 
 
 from RecoParticleFlow.PFClusterProducer.particleFlowClusterHBHE_cfi import *
-from RecoParticleFlow.PFClusterProducer.particleFlowClusterHBHEMaxSampleTimeSelected_cfi import *
+from RecoParticleFlow.PFClusterProducer.particleFlowClusterHBHETimeSelected_cfi import *
 from RecoParticleFlow.PFClusterProducer.particleFlowClusterHF_cfi import *
 from RecoParticleFlow.PFClusterProducer.particleFlowClusterHCAL_cfi import *
 from RecoParticleFlow.PFClusterProducer.particleFlowClusterHO_cfi import *
@@ -29,7 +29,7 @@ pfClusteringPS = cms.Sequence(particleFlowRecHitPS*particleFlowClusterPS)
 
 
 #pfClusteringHBHEHF = cms.Sequence(towerMakerPF*particleFlowRecHitHCAL*particleFlowClusterHCAL+particleFlowClusterHFHAD+particleFlowClusterHFEM)
-pfClusteringHBHEHF = cms.Sequence(particleFlowRecHitHBHE*particleFlowRecHitHF*particleFlowClusterHBHE*particleFlowClusterHF*particleFlowClusterHCAL)
+pfClusteringHBHEHF = cms.Sequence(particleFlowRecHitHBHE*particleFlowRecHitHF*particleFlowClusterHBHE*particleFlowClusterHBHETimeSelected*particleFlowClusterHF*particleFlowClusterHCAL)
 pfClusteringHO = cms.Sequence(particleFlowRecHitHO*particleFlowClusterHO)
 
 

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHBHE_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHBHE_cfi.py
@@ -3,13 +3,13 @@ from RecoParticleFlow.PFClusterProducer.particleFlowCaloResolution_cfi import _t
 
 particleFlowRecHitHBHE = cms.EDProducer("PFRecHitProducer",
     navigator = cms.PSet(
-            name = cms.string("PFRecHitHCALNavigatorWithTime"),
-            sigmaCut = cms.double(4.0),
-            timeResolutionCalc = _timeResolutionHCALMaxSample
+            name = cms.string("PFRecHitHCALNavigator"),
+#            sigmaCut = cms.double(4.0),
+#            timeResolutionCalc = _timeResolutionHCALMaxSample
     ),
     producers = cms.VPSet(
            cms.PSet(
-             name = cms.string("PFHBHERecHitCreatorMaxSample"),
+             name = cms.string("PFHBHERecHitCreator"),
              src  = cms.InputTag("hbhereco",""),
              qualityTests = cms.VPSet(
                   cms.PSet(

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHBHE_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHBHE_cfi.py
@@ -1,5 +1,5 @@
 import FWCore.ParameterSet.Config as cms
-from RecoParticleFlow.PFClusterProducer.particleFlowCaloResolution_cfi import _timeResolutionHCALMaxSample,_timeResolutionHCAL
+from RecoParticleFlow.PFClusterProducer.particleFlowCaloResolution_cfi import _timeResolutionHCAL
 
 particleFlowRecHitHBHE = cms.EDProducer("PFRecHitProducer",
     navigator = cms.PSet(

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHBHE_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHBHE_cfi.py
@@ -1,11 +1,11 @@
 import FWCore.ParameterSet.Config as cms
-from RecoParticleFlow.PFClusterProducer.particleFlowCaloResolution_cfi import _timeResolutionHCALMaxSample
+from RecoParticleFlow.PFClusterProducer.particleFlowCaloResolution_cfi import _timeResolutionHCALMaxSample,_timeResolutionHCAL
 
 particleFlowRecHitHBHE = cms.EDProducer("PFRecHitProducer",
     navigator = cms.PSet(
-            name = cms.string("PFRecHitHCALNavigator"),
-#            sigmaCut = cms.double(4.0),
-#            timeResolutionCalc = _timeResolutionHCALMaxSample
+            name = cms.string("PFRecHitHCALNavigatorWithTime"),
+            sigmaCut = cms.double(4.0),
+            timeResolutionCalc = _timeResolutionHCAL
     ),
     producers = cms.VPSet(
            cms.PSet(

--- a/RecoParticleFlow/PFProducer/python/tools/pfClusteringCustoms.py
+++ b/RecoParticleFlow/PFProducer/python/tools/pfClusteringCustoms.py
@@ -2,78 +2,38 @@
 import FWCore.ParameterSet.Config as cms
 
 
-def customizePFECALClustering(process,scenario):
 
-    if scenario ==1:
-        print '-------------ECAL CLUSTERING-------------'
-        print 'SCENARIO 1: Default ECAL clustering & ECAL time reconstruction'
-        print 'Timing cuts are applied to the PF cluster level'
-        process.load('RecoParticleFlow.PFClusterProducer.particleFlowClusterECALTimeSelected_cfi')
-        process.particleFlowClusterECALTimeSelected.src = cms.InputTag('particleFlowClusterECALUncorrected')
-        process.particleFlowClusterECAL.inputECAL = cms.InputTag('particleFlowClusterECALTimeSelected')
-        i = process.pfClusteringECAL.index(process.particleFlowClusterECALUncorrected)
-        process.pfClusteringECAL.insert(i+1,process.particleFlowClusterECALTimeSelected)
+def usePFWithMethodOne(process):
+    print '-------------PF with method I -------------'
+    print 'Assumes that HCAL reco is tuned to method I '
+    process.particleFlowRecHitHBHE.navigator = cms.PSet(
+        name = cms.string("PFRecHitHCALNavigator")
+    )
+    process.pfClusteringHBHEHF.remove(process.particleFlowClusterHBHETimeSelected)
+    process.particleFlowClusterHCAL.clustersSource = cms.InputTag("particleFlowClusterHBHE")
 
-    elif scenario ==2:
-        print '-------------ECAL CLUSTERING-------------'
-        print 'SCENARIO 2: ECAL clustering with time & default ECAL time reconstruction'
-        print 'Timing cuts are applied to the PF cluster level'
 
-        from RecoParticleFlow.PFClusterProducer.particleFlowCaloResolution_cfi import _timeResolutionECALBarrel,_timeResolutionECALEndcap
+def usePFWithMethodOnePointFive(process):
+    print '-------------PF with method I.5-------------'
+    print 'Independent of which HCAL reco was used since it reads the time samples from the rechit '
 
-        process.load('RecoParticleFlow.PFClusterProducer.particleFlowClusterECALTimeSelected_cfi')
 
-        process.particleFlowRecHitECAL.navigator.name = "PFRecHitECALNavigatorWithTime"
-        process.particleFlowRecHitECAL.navigator.barrel = cms.PSet(
-             sigmaCut = cms.double(5.0),
-             timeResolutionCalc = _timeResolutionECALBarrel 
-        )
-        process.particleFlowRecHitECAL.navigator.endcap = cms.PSet(
-            sigmaCut = cms.double(5.0),
-            timeResolutionCalc = _timeResolutionECALEndcap
-        )
-        
-        for p in process.particleFlowRecHitECAL.producers:
-            for t in p.qualityTests:
-                if t.name == 'PFRecHitQTestECAL':
-                    t.timingCleaning = cms.bool(False) 
+    from RecoParticleFlow.PFClusterProducer.particleFlowClusterHBHEMaxSampleTimeSelected_cfi import particleFlowClusterHBHETimeSelected as timeSelector
+    process.particleFlowClusterHBHETimeSelected.cuts = timeSelector.cuts
 
-        process.particleFlowClusterECALUncorrected.recHitsSource = cms.InputTag("particleFlowRecHitECAL")
-        process.particleFlowClusterECALTimeSelected.src = cms.InputTag('particleFlowClusterECALUncorrected')
-        process.particleFlowClusterECAL.inputECAL = cms.InputTag('particleFlowClusterECALTimeSelected')
+    from RecoParticleFlow.PFClusterProducer.particleFlowCaloResolution_cfi import _timeResolutionHCALMaxSample
+    process.particleFlowRecHitHBHE.navigator = cms.PSet(
+        name = cms.string("PFRecHitHCALNavigatorWithTime"),
+        sigmaCut = cms.double(4.0),
+        timeResolutionCalc = _timeResolutionHCALMaxSample
+    )
 
-        i = process.pfClusteringECAL.index(process.particleFlowClusterECALUncorrected)
-        process.pfClusteringECAL.insert(i+1,process.particleFlowClusterECALTimeSelected)
-        process.particleFlowClusterECALUncorrected.pfClusterBuilder.algoName = cms.string("PFlow2DClusterizerWithTime")
+    for p in process.particleFlowRecHitHBHE.producers:
+        p.name = cms.string("PFHBHERecHitCreatorMaxSample")
+    process.particleFlowClusterHBHE.pfClusterBuilder.algoName = cms.string("PFlow2DClusterizerWithTime")
 
-        process.particleFlowClusterECALUncorrected.pfClusterBuilder.showerSigma = cms.double(1.5)
-        process.particleFlowClusterECALUncorrected.pfClusterBuilder.timeSigmaEB = cms.double(10.)
-        process.particleFlowClusterECALUncorrected.pfClusterBuilder.timeSigmaEE = cms.double(10.)
-        process.particleFlowClusterECALUncorrected.pfClusterBuilder.maxNSigmaTime = cms.double(10.)
-        process.particleFlowClusterECALUncorrected.pfClusterBuilder.minChi2Prob = cms.double(0.)
-        process.particleFlowClusterECALUncorrected.pfClusterBuilder.clusterTimeResFromSeed = cms.bool(False)
-        process.particleFlowClusterECALUncorrected.pfClusterBuilder.timeResolutionCalcBarrel = _timeResolutionECALBarrel
-        process.particleFlowClusterECALUncorrected.pfClusterBuilder.timeResolutionCalcEndcap = _timeResolutionECALEndcap
+    
+
 
         
-        
-
-def customizePFHCALClustering(process,scenario):
-    if scenario ==0:
-        print '-------------HCAL CLUSTERING-------------'
-        print 'Default HCAL reconstruction and no 3D clustering with time in PF'
-        print 'but clustering 3D in space from layers'
-
-        process.pfClusteringHBHEHF.remove(process.particleFlowClusterHBHETimeSelected)
-
-
-        for p in process.particleFlowRecHitHBHE.producers:
-            p.name = cms.string('PFHBHERecHitCreator')
-
-
-        process.particleFlowClusterHCAL.clustersSource = cms.InputTag("particleFlowClusterHBHE")
-        process.particleFlowRecHitHBHE.navigator = cms.PSet(
-            name = cms.string("PFRecHitHCALNavigator")
-        )
-        process.particleFlowClusterHBHE.pfClusterBuilder.algoName = cms.string("Basic2DGenericPFlowClusterizer")
 


### PR DESCRIPTION
This tunes PF assuming method II is the default and it applies timing cuts. One can choose to tune PF for method I or use Method1.5 [regardless of the HCAL reco used] using the customization functions in RecoParticleFLow.PFProducer.tools.pfClusteringCustoms
