### PR TITLE
Upgrading event number datatype to EventNumber_t (32 to 64bit)

### DIFF
--- a/DQM/CastorMonitor/interface/CastorMonitorModule.h
+++ b/DQM/CastorMonitor/interface/CastorMonitorModule.h
@@ -26,6 +26,7 @@
 
 #include "FWCore/Utilities/interface/CPUTimer.h"
 #include "DataFormats/Provenance/interface/EventID.h"  
+#include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
 
 #include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutSetup.h"
 #include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutRecord.h"
@@ -179,9 +180,11 @@ public:
 
   ////---- define the DQMStore 
   DQMStore* dbe_;  
-  
+
   ////---- define environment variables
-  int irun_,ilumisec_,ievent_,itime_,ibunch_;
+  int ilumisec_, itime_,ibunch_;
+  edm::RunNumber_t irun_;
+  edm::EventNumber_t ievent_;
   bool actonLS_ ;
   std::string rootFolder_;
 

--- a/DQM/HcalMonitorClient/interface/HcalMonitorClient.h
+++ b/DQM/HcalMonitorClient/interface/HcalMonitorClient.h
@@ -17,6 +17,8 @@
 #include "DQM/HcalMonitorClient/interface/HcalBaseDQClient.h"
 #include "DQM/HcalMonitorTasks/interface/HcalEtaPhiHists.h"
 
+#include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
+
 class DQMStore;
 class HcalChannelQuality;
 class HcalSummaryClient;
@@ -80,7 +82,7 @@ private:
   // Event counters
   int ievt_; // all events
   int jevt_; // events in current run
-  int run_;
+  edm::RunNumber_t run_;
   int evt_;
   bool begin_run_;
   bool end_run_;

--- a/DQM/HcalMonitorClient/interface/ZDCMonitorClient.h
+++ b/DQM/HcalMonitorClient/interface/ZDCMonitorClient.h
@@ -12,6 +12,8 @@
 
 #include "FWCore/Utilities/interface/CPUTimer.h"
 
+#include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
+
 class DQMStore;
 class TH2F;
 class TH1F;
@@ -116,7 +118,9 @@ public:
   DQMStore* dbe_;  
   
   // environment variables
-  int irun_,ievent_,itime_;
+  edm::RunNumber_t irun_;
+  edm::EventNumber_t ievent_;
+  int itime_;
   int ilumisec_;
   int maxlumisec_, minlumisec_;
 

--- a/DQM/HcalMonitorClient/src/HcalMonitorClient.cc
+++ b/DQM/HcalMonitorClient/src/HcalMonitorClient.cc
@@ -146,10 +146,9 @@ void HcalMonitorClient::beginJob(void)
   begin_run_ = false;
   end_run_   = false;
 
-  run_=-1;
-  evt_=-1;
-  ievt_=0;
-  jevt_=0;
+  run_ = edm::invalidRunNumber;
+  ievt_ = 0;
+  jevt_ =0;
 
   current_time_ = time(NULL);
   last_time_html_ = 0; 
@@ -179,10 +178,9 @@ void HcalMonitorClient::beginRun(const edm::Run& r, const edm::EventSetup& c)
   begin_run_ = true;
   end_run_   = false;
 
-  run_=r.id().run();
-  evt_=0;
-  jevt_=0;
-  htmlcounter_=0;
+  run_ = r.id().run();
+  jevt_ = 0;
+  htmlcounter_ = 0;
 
   // Store list of bad channels and their values
   std::map <HcalDetId, unsigned int> badchannelmap; 
@@ -326,7 +324,6 @@ void HcalMonitorClient::analyze(const edm::Event & e, const edm::EventSetup & c)
   jevt_++;
 
   run_=e.id().run();
-  evt_=e.id().event();
   if (prescaleFactor_>0 && jevt_%prescaleFactor_==0) {
 
     for (unsigned int i=0;i<clients_.size();++i)
@@ -471,8 +468,11 @@ void HcalMonitorClient::writeHtml()
 
   char tmp[20];
 
-  if(run_!=-1) sprintf(tmp, "DQM_%s_R%09d_%i", prefixME_.substr(0,prefixME_.size()-1).c_str(),run_,htmlcounter_);
-  else sprintf(tmp, "DQM_%s_R%09d_%i", prefixME_.substr(0,prefixME_.size()-1).c_str(),0,htmlcounter_);
+  if (run_ != edm::invalidRunNumber) {
+    sprintf(tmp, "DQM_%s_R%09d_%i", prefixME_.substr(0,prefixME_.size()-1).c_str(),run_,htmlcounter_);
+  } else {
+    sprintf(tmp, "DQM_%s_R%09d_%i", prefixME_.substr(0,prefixME_.size()-1).c_str(),0,htmlcounter_);
+  }
   std::string htmlDir = baseHtmlDir_ + "/" + tmp + "/";
   system(("/bin/mkdir -p " + htmlDir).c_str());
 

--- a/DQM/HcalMonitorModule/interface/HcalMonitorModule.h
+++ b/DQM/HcalMonitorModule/interface/HcalMonitorModule.h
@@ -17,8 +17,8 @@
 #include "DQM/HcalMonitorTasks/interface/HcalEtaPhiHists.h"
 
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
-
 #include "DataFormats/HcalDigi/interface/HcalUnpackerReport.h"
+#include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
 // forward declarations
 
 class MonitorElement;
@@ -68,8 +68,8 @@ public:
  private:
 
   int ievt_;
-  int runNumber_;
-  int evtNumber_;
+  edm::RunNumber_t runNumber_;
+  edm::EventNumber_t evtNumber_;
 
   MonitorElement* meStatus_;
   MonitorElement* meRun_;

--- a/DQM/HcalMonitorModule/interface/ZDCMonitorModule.h
+++ b/DQM/HcalMonitorModule/interface/ZDCMonitorModule.h
@@ -22,6 +22,8 @@
 #include "CalibFormats/HcalObjects/interface/HcalDbRecord.h"
 
 #include "DataFormats/HcalDigi/interface/HcalUnpackerReport.h"
+#include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
+
 #include "DQM/HcalMonitorTasks/interface/HcalZDCMonitor.h"
 
 #include "FWCore/Utilities/interface/CPUTimer.h"
@@ -117,7 +119,9 @@ public:
   } psTime_;    
 
   // environment variables
-  int irun_,ievent_,itime_;
+  edm::RunNumber_t irun_;
+  edm::EventNumber_t ievent_;
+  int itime_;
   unsigned int ilumisec;
   bool Online_;
   std::string rootFolder_;

--- a/DQM/Physics/src/TopDiLeptonDQM.cc
+++ b/DQM/Physics/src/TopDiLeptonDQM.cc
@@ -6,6 +6,7 @@
 
 #include "TLorentzVector.h"
 #include "DataFormats/Math/interface/deltaR.h"
+#include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
 #include "DQM/Physics/src/TopDiLeptonDQM.h"
 #include "FWCore/Common/interface/TriggerNames.h"
 
@@ -219,8 +220,8 @@ void TopDiLeptonDQM::analyze(const edm::Event& evt,
   bool Fired_Signal_Trigger[100] = {false};
   bool Fired_Control_Trigger[100] = {false};
 
-  int N_run = (evt.id()).run();
-  int N_event = (evt.id()).event();
+  edm::RunNumber_t N_run = (evt.id()).run();
+  edm::EventNumber_t N_event = (evt.id()).event();
   int N_lumi = evt.luminosityBlock();
 
   int N_leptons = 0;

--- a/DQM/PhysicsHWW/interface/HWW.h
+++ b/DQM/PhysicsHWW/interface/HWW.h
@@ -2,6 +2,7 @@
 #define HWW_H
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
 #include "Math/LorentzVector.h"
 #include "TMath.h"
 #include <vector>
@@ -169,16 +170,16 @@ class HWW{
   std::vector<int>            hyp_type_;
 
   //event variables
-  unsigned int                evt_run_;
-  unsigned int                evt_lumiBlock_;
-  unsigned int                evt_event_;
-  int                         evt_isRealData_;
-  float                       evt_ww_rho_vor_;
-  float                       evt_ww_rho_;
-  float                       evt_rho_;
-  float                       evt_kt6pf_foregiso_rho_;
-  float                       evt_pfmet_;
-  float                       evt_pfmetPhi_;
+  edm::RunNumber_t             evt_run_;
+  edm::LuminosityBlockNumber_t evt_lumiBlock_;
+  edm::EventNumber_t           evt_event_;
+  int                          evt_isRealData_;
+  float                        evt_ww_rho_vor_;
+  float                        evt_ww_rho_;
+  float                        evt_rho_;
+  float                        evt_kt6pf_foregiso_rho_;
+  float                        evt_pfmet_;
+  float                        evt_pfmetPhi_;
 
   std::vector<float>          convs_ndof_;
   std::vector<float>          convs_chi2_;
@@ -593,16 +594,16 @@ public:
   std::vector<int>            &hyp_type();
 
   //event variables
-  unsigned int                &evt_run();
-  unsigned int                &evt_lumiBlock();
-  unsigned int                &evt_event();
-  int                         &evt_isRealData();
-  float                       &evt_ww_rho_vor();
-  float                       &evt_ww_rho();
-  float                       &evt_rho();
-  float                       &evt_kt6pf_foregiso_rho();
-  float                       &evt_pfmet();
-  float                       &evt_pfmetPhi();
+  edm::RunNumber_t             &evt_run();
+  edm::LuminosityBlockNumber_t &evt_lumiBlock();
+  edm::EventNumber_t           &evt_event();
+  int                          &evt_isRealData();
+  float                        &evt_ww_rho_vor();
+  float                        &evt_ww_rho();
+  float                        &evt_rho();
+  float                        &evt_kt6pf_foregiso_rho();
+  float                        &evt_pfmet();
+  float                        &evt_pfmetPhi();
 
   std::vector<float>          &convs_ndof();
   std::vector<float>          &convs_chi2();

--- a/DQM/PhysicsHWW/src/HWW.cc
+++ b/DQM/PhysicsHWW/src/HWW.cc
@@ -604,15 +604,15 @@ std::vector<int>            & HWW::hyp_type(){
 }
 
 //event variables
-unsigned int                & HWW::evt_run(){
+edm::RunNumber_t             & HWW::evt_run(){
   if(!evt_run_isLoaded) edm::LogWarning("VariableNotSet") << "evt_run not loaded!";
   return(evt_run_);
 }
-unsigned int                & HWW::evt_lumiBlock(){
+edm::LuminosityBlockNumber_t & HWW::evt_lumiBlock(){
   if(!evt_lumiBlock_isLoaded) edm::LogWarning("VariableNotSet") << "evt_lumiBlock not loaded!";
   return(evt_lumiBlock_);
 }
-unsigned int                & HWW::evt_event(){
+edm::EventNumber_t           & HWW::evt_event(){
   if(!evt_event_isLoaded) edm::LogWarning("VariableNotSet") << "evt_event not loaded!";
   return(evt_event_);
 }

--- a/DQM/SiStripMonitorHardware/src/SiStripCMMonitor.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripCMMonitor.cc
@@ -115,7 +115,7 @@ class SiStripCMMonitorPlugin : public edm::EDAnalyzer
 
   std::pair<uint16_t,uint16_t> prevMedians_[FEDNumbering::MAXSiStripFEDID+1][sistrip::FEDCH_PER_FED];
 
-  unsigned int evt_;
+  edm::EventNumber_t evt_;
 
 };
 
@@ -345,9 +345,19 @@ SiStripCMMonitorPlugin::analyze(const edm::Event& iEvent,
     }//loop on channels
     
     float lTime = 0;
-    if (fillWithEvtNum_) lTime = iEvent.id().event();
-    else if (fillWithLocalEvtNum_) lTime = evt_;//iEvent.id().event();
-    else lTime = iEvent.orbitNumber()/11223.;
+    if (fillWithEvtNum_) {
+      // casting from unsigned long long to a float here
+      // doing it explicitely
+      lTime = static_cast<float>(iEvent.id().event());
+    } else {
+      if (fillWithLocalEvtNum_) {
+        // casting from unsigned long long to a float here
+        // doing it explicitely
+        lTime = static_cast<float>(evt_);
+      } else {
+        lTime = iEvent.orbitNumber()/11223.;
+      }
+    }
 
     cmHists_.fillHistograms(values,lTime,fedId);
 

--- a/DQM/SiStripMonitorHardware/src/SiStripFEDMonitor.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripFEDMonitor.cc
@@ -384,10 +384,23 @@ SiStripFEDMonitorPlugin::analyze(const edm::Event& iEvent,
   fedErrors_.getFEDErrorsCounters().nTotalBadChannels = lNTotBadChannels;
   fedErrors_.getFEDErrorsCounters().nTotalBadActiveChannels = lNTotBadActiveChannels;
 
-  //fedHists_.fillCountersHistograms(FEDErrors::getFEDErrorsCounters(), nEvt_);
   //time in seconds since beginning of the run or event number
-  if (fillWithEvtNum_) fedHists_.fillCountersHistograms(fedErrors_.getFEDErrorsCounters(),fedErrors_.getChannelErrorsCounters(),maxFedBufferSize_,iEvent.id().event());
-  else fedHists_.fillCountersHistograms(fedErrors_.getFEDErrorsCounters(),fedErrors_.getChannelErrorsCounters(),maxFedBufferSize_,iEvent.orbitNumber()/11223.);
+  if (fillWithEvtNum_) {
+    // explicitely casting the event number unsigned long long to double here
+    double eventNumber = static_cast<double>(iEvent.id().event());
+    fedHists_.fillCountersHistograms(
+        fedErrors_.getFEDErrorsCounters(),
+        fedErrors_.getChannelErrorsCounters(),
+        maxFedBufferSize_,
+        eventNumber);
+  } else {
+    double aTime = iEvent.orbitNumber()/11223.;    
+    fedHists_.fillCountersHistograms(
+        fedErrors_.getFEDErrorsCounters(),
+        fedErrors_.getChannelErrorsCounters(),
+        maxFedBufferSize_,
+        aTime);
+  }
 
   nEvt_++;
 

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyMonitorModule.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyMonitorModule.cc
@@ -99,7 +99,7 @@ class SiStripSpyMonitorModule : public edm::EDAnalyzer
   uint32_t minDigitalHigh_;
   uint32_t maxDigitalHigh_;
 
-  unsigned int evt_;
+  edm::EventNumber_t evt_;
 
   DQMStore* dqm_;
   //folder name for histograms in DQMStore
@@ -520,8 +520,15 @@ SiStripSpyMonitorModule::analyze(const edm::Event& iEvent,
   //else if (fillWithLocalEvtNum_) lTime = evt_;
   //no orbit number for spy data !!
   //else lTime = iEvent.orbitNumber()/11223.;
-  lTime = iEvent.id().event();
-  if (fillWithLocalEvtNum_) lTime = evt_;
+  if (fillWithLocalEvtNum_) {
+    // casting from unsigned long long to a double here
+    // doing it explicitely
+    lTime = static_cast<double>(evt_);
+  } else {
+    // casting from unsigned long long to a double here
+    // doing it explicitely
+    lTime = static_cast<double>(iEvent.id().event());
+  }
   
   histManager_.fillCountersHistograms(lCounters,lTime);
  

--- a/DQM/SiStripMonitorTrack/interface/SiStripMonitorTrack.h
+++ b/DQM/SiStripMonitorTrack/interface/SiStripMonitorTrack.h
@@ -188,7 +188,7 @@ private:
   bool tracksCollection_in_EventTree;
   bool trackAssociatorCollection_in_EventTree;
   bool flag_ring;
-  int runNb, eventNb;
+  edm::EventNumber_t eventNb;
   int firstEvent;
 
   bool   applyClusterQuality_;

--- a/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
+++ b/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
@@ -106,7 +106,6 @@ void SiStripMonitorTrack::analyze(const edm::Event& e, const edm::EventSetup& es
 
   //initialization of global quantities
   LogDebug("SiStripMonitorTrack") << "[SiStripMonitorTrack::analyse]  " << "Run " << e.id().run() << " Event " << e.id().event() << std::endl;
-  runNb   = e.id().run();
   eventNb = e.id().event();
 //  vPSiStripCluster.clear();
   vPSiStripCluster.clear();

--- a/DQMOffline/EGamma/plugins/ElectronAnalyzer.cc
+++ b/DQMOffline/EGamma/plugins/ElectronAnalyzer.cc
@@ -15,7 +15,6 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-//#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 
 #include "CLHEP/Units/GlobalPhysicalConstants.h"
@@ -332,9 +331,9 @@ void ElectronAnalyzer::analyze( const edm::Event& iEvent, const edm::EventSetup 
   iEvent.getByToken(beamSpotTag_,recoBeamSpotHandle) ;
   const BeamSpot bs = *recoBeamSpotHandle ;
 
-  int ievt = iEvent.id().event();
-  int irun = iEvent.id().run();
-  int ils = iEvent.luminosityBlock();
+  edm::EventNumber_t ievt = iEvent.id().event();
+  edm::RunNumber_t irun = iEvent.id().run();
+  edm::LuminosityBlockNumber_t ils = iEvent.luminosityBlock();
 
   edm::LogInfo("ElectronAnalyzer::analyze")
     <<"Treating "<<gsfElectrons.product()->size()<<" electrons"

--- a/DQMOffline/EGamma/plugins/ElectronGeneralAnalyzer.cc
+++ b/DQMOffline/EGamma/plugins/ElectronGeneralAnalyzer.cc
@@ -71,9 +71,9 @@ void ElectronGeneralAnalyzer::analyze( const edm::Event& iEvent, const edm::Even
   iEvent.getByToken(beamSpotTag_,recoBeamSpotHandle) ;
   const BeamSpot bs = *recoBeamSpotHandle ;
 
-  int ievt = iEvent.id().event();
-  int irun = iEvent.id().run();
-  int ils = iEvent.luminosityBlock();
+  edm::EventNumber_t ievt = iEvent.id().event();
+  edm::RunNumber_t irun = iEvent.id().run();
+  edm::LuminosityBlockNumber_t ils = iEvent.luminosityBlock();
 
   edm::LogInfo("ElectronGeneralAnalyzer::analyze")
     <<"Treating "<<gsfElectrons.product()->size()<<" electrons"

--- a/DQMOffline/EGamma/plugins/ElectronTagProbeAnalyzer.cc
+++ b/DQMOffline/EGamma/plugins/ElectronTagProbeAnalyzer.cc
@@ -17,7 +17,6 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-//#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 
 #include "CLHEP/Units/GlobalPhysicalConstants.h"
@@ -265,9 +264,9 @@ void ElectronTagProbeAnalyzer::analyze( const edm::Event& iEvent, const edm::Eve
   iEvent.getByToken(beamSpotTag_,recoBeamSpotHandle) ;
   const BeamSpot bs = *recoBeamSpotHandle ;
 
-  int ievt = iEvent.id().event();
-  int irun = iEvent.id().run();
-  int ils = iEvent.luminosityBlock();
+  edm::EventNumber_t ievt = iEvent.id().event();
+  edm::RunNumber_t irun = iEvent.id().run();
+  edm::LuminosityBlockNumber_t ils = iEvent.luminosityBlock();
 
   edm::LogInfo("ElectronMcSignalValidator::analyze")
     <<"Treating "<<gsfElectrons.product()->size()<<" electrons"

--- a/DQMOffline/JetMET/src/BeamHaloAnalyzer.cc
+++ b/DQMOffline/JetMET/src/BeamHaloAnalyzer.cc
@@ -305,9 +305,9 @@ void BeamHaloAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& 
   EventID TheEvent = iEvent.id();
   int BXN = iEvent.bunchCrossing() ;
   bool Dump = TextFileName.size();
-  int TheEventNumber = TheEvent.event();
-  int Lumi = iEvent.luminosityBlock();
-  int Run  = iEvent.run();
+  edm::EventNumber_t TheEventNumber = TheEvent.event();
+  edm::LuminosityBlockNumber_t Lumi = iEvent.luminosityBlock();
+  edm::RunNumber_t Run  = iEvent.run();
 
   //Get CSC Geometry
   edm::ESHandle<CSCGeometry> TheCSCGeometry;

--- a/DQMOffline/PFTau/plugins/PFDQMEventSelector.cc
+++ b/DQMOffline/PFTau/plugins/PFDQMEventSelector.cc
@@ -44,9 +44,9 @@ bool PFDQMEventSelector::filter( edm::Event & iEvent, edm::EventSetup const& iSe
   nEvents_++;
   if (!fileOpened_) return false;
 
-  unsigned int runNb  = iEvent.id().run();
-  unsigned int evtNb  = iEvent.id().event();
-  unsigned int lumiNb = iEvent.id().luminosityBlock();
+  edm::RunNumber_t runNb  = iEvent.id().run();
+  edm::EventNumber_t evtNb  = iEvent.id().event();
+  edm::LuminosityBlockNumber_t lumiNb = iEvent.id().luminosityBlock();
   std::ostringstream eventid_str;
   eventid_str << runNb << "_"<< evtNb << "_" << lumiNb;
   

--- a/DQMOffline/Trigger/src/TopDiLeptonHLTOfflineDQM.cc
+++ b/DQMOffline/Trigger/src/TopDiLeptonHLTOfflineDQM.cc
@@ -411,9 +411,13 @@ namespace HLTOfflineDQMTopDiLepton {
               if(elecMuLogged_<=hists_.find("elecMuLogger_")->second->getNbinsY()){
                 // log runnumber, lumi block, event number & some
                 // more pysics infomation for interesting events
-                fill("elecMuLogger_", 0.5, elecMuLogged_+0.5, event.eventAuxiliary().run()); 
-                fill("elecMuLogger_", 1.5, elecMuLogged_+0.5, event.eventAuxiliary().luminosityBlock()); 
-                fill("elecMuLogger_", 2.5, elecMuLogged_+0.5, event.eventAuxiliary().event()); 
+                // We're doing a static_cast here to denote the explicity of the cast
+                double runID = static_cast<double>(event.eventAuxiliary().run());
+                double luminosityBlockID = static_cast<double>(event.eventAuxiliary().luminosityBlock());
+                double eventID = static_cast<double>(event.eventAuxiliary().event());
+                fill("elecMuLogger_", 0.5, elecMuLogged_+0.5, runID); 
+                fill("elecMuLogger_", 1.5, elecMuLogged_+0.5, luminosityBlockID); 
+                fill("elecMuLogger_", 2.5, elecMuLogged_+0.5, eventID); 
                 fill("elecMuLogger_", 3.5, elecMuLogged_+0.5, isoMuons[0]->pt()); 
                 fill("elecMuLogger_", 4.5, elecMuLogged_+0.5, isoElecs[0]->pt()); 
                 if(leadingJets.size()>0) fill("elecMuLogger_", 5.5, elecMuLogged_+0.5, leadingJets[0].pt()); 
@@ -438,9 +442,13 @@ namespace HLTOfflineDQMTopDiLepton {
               if(diMuonLogged_<=hists_.find("diMuonLogger_")->second->getNbinsY()){
                 // log runnumber, lumi block, event number & some
                 // more pysics infomation for interesting events
-                fill("diMuonLogger_", 0.5, diMuonLogged_+0.5, event.eventAuxiliary().run()); 
-                fill("diMuonLogger_", 1.5, diMuonLogged_+0.5, event.eventAuxiliary().luminosityBlock()); 
-                fill("diMuonLogger_", 2.5, diMuonLogged_+0.5, event.eventAuxiliary().event()); 
+                // We're doing a static_cast here to denote the explicity of the cast
+                double runID = static_cast<double>(event.eventAuxiliary().run());
+                double luminosityBlockID = static_cast<double>(event.eventAuxiliary().luminosityBlock());
+                double eventID = static_cast<double>(event.eventAuxiliary().event());
+                fill("diMuonLogger_", 0.5, diMuonLogged_+0.5, runID); 
+                fill("diMuonLogger_", 1.5, diMuonLogged_+0.5, luminosityBlockID); 
+                fill("diMuonLogger_", 2.5, diMuonLogged_+0.5, eventID); 
                 fill("diMuonLogger_", 3.5, diMuonLogged_+0.5, isoMuons[0]->pt()); 
                 fill("diMuonLogger_", 4.5, diMuonLogged_+0.5, isoMuons[1]->pt()); 
                 if(leadingJets.size()>0) fill("diMuonLogger_", 5.5, diMuonLogged_+0.5, leadingJets[0].pt()); 
@@ -465,9 +473,13 @@ namespace HLTOfflineDQMTopDiLepton {
               if(diElecLogged_<=hists_.find("diElecLogger_")->second->getNbinsY()){
                 // log runnumber, lumi block, event number & some
                 // more pysics infomation for interesting events
-                fill("diElecLogger_", 0.5, diElecLogged_+0.5, event.eventAuxiliary().run()); 
-                fill("diElecLogger_", 1.5, diElecLogged_+0.5, event.eventAuxiliary().luminosityBlock()); 
-                fill("diElecLogger_", 2.5, diElecLogged_+0.5, event.eventAuxiliary().event()); 
+                // We're doing a static_cast here to denote the explicity of the cast
+                double runID = static_cast<double>(event.eventAuxiliary().run());
+                double luminosityBlockID = static_cast<double>(event.eventAuxiliary().luminosityBlock());
+                double eventID = static_cast<double>(event.eventAuxiliary().event());
+                fill("diElecLogger_", 0.5, diElecLogged_+0.5, runID); 
+                fill("diElecLogger_", 1.5, diElecLogged_+0.5, luminosityBlockID); 
+                fill("diElecLogger_", 2.5, diElecLogged_+0.5, eventID); 
                 fill("diElecLogger_", 3.5, diElecLogged_+0.5, isoElecs[0]->pt()); 
                 fill("diElecLogger_", 4.5, diElecLogged_+0.5, isoElecs[1]->pt()); 
                 if(leadingJets.size()>0) fill("diElecLogger_", 5.5, diElecLogged_+0.5, leadingJets[0].pt()); 

--- a/DQMOffline/Trigger/src/TopSingleLeptonHLTOfflineDQM.cc
+++ b/DQMOffline/Trigger/src/TopSingleLeptonHLTOfflineDQM.cc
@@ -468,9 +468,13 @@ namespace HLTOfflineDQMTopSingleLepton {
         if(logged_<=hists_.find("eventLogger_")->second->getNbinsY()){
           // log runnumber, lumi block, event number & some
           // more pysics infomation for interesting events
-          fill("eventLogger_", 0.5, logged_+0.5, event.eventAuxiliary().run()); 
-          fill("eventLogger_", 1.5, logged_+0.5, event.eventAuxiliary().luminosityBlock()); 
-          fill("eventLogger_", 2.5, logged_+0.5, event.eventAuxiliary().event()); 
+          // We're doing a static_cast here to denote the explicity of the cast
+          double runID = static_cast<double>(event.eventAuxiliary().run());
+          double luminosityBlockID = static_cast<double>(event.eventAuxiliary().luminosityBlock());
+          double eventID = static_cast<double>(event.eventAuxiliary().event());
+          fill("eventLogger_", 0.5, logged_+0.5, runID); 
+          fill("eventLogger_", 1.5, logged_+0.5, luminosityBlockID); 
+          fill("eventLogger_", 2.5, logged_+0.5, eventID); 
           ++logged_;
         }
       }

--- a/DQMServices/Components/src/DQMEventInfo.cc
+++ b/DQMServices/Components/src/DQMEventInfo.cc
@@ -115,7 +115,7 @@ void DQMEventInfo::beginLuminosityBlock(const edm::LuminosityBlock& l, const edm
 
 void DQMEventInfo::analyze(const edm::Event& e, const edm::EventSetup& c){
 
-  eventId_->Fill(int64_t(e.id().event()));
+  eventId_->Fill(e.id().event()); // Handing edm::EventNumber_t to Fill method which will handle further casting
   eventTimeStamp_->Fill(stampToReal(e.time()));
 
   pEvent_++;

--- a/Validation/GlobalDigis/src/GlobalDigisAnalyzer.cc
+++ b/Validation/GlobalDigis/src/GlobalDigisAnalyzer.cc
@@ -483,8 +483,8 @@ void GlobalDigisAnalyzer::analyze(const edm::Event& iEvent,
 
 
   // get event id information
-  int nrun = iEvent.id().run();
-  int nevt = iEvent.id().event();
+  edm::RunNumber_t nrun = iEvent.id().run();
+  edm::EventNumber_t nevt = iEvent.id().event();
   
   if (verbosity > 0) {
     edm::LogInfo(MsgLoggerCat)

--- a/Validation/GlobalDigis/src/GlobalDigisHistogrammer.cc
+++ b/Validation/GlobalDigis/src/GlobalDigisHistogrammer.cc
@@ -361,8 +361,8 @@ void GlobalDigisHistogrammer::analyze(const edm::Event& iEvent,
   ++count;
 
   // get event id information
-  int nrun = iEvent.id().run();
-  int nevt = iEvent.id().event();
+  edm::RunNumber_t nrun = iEvent.id().run();
+  edm::EventNumber_t nevt = iEvent.id().event();
 
   if (verbosity > 0) {
     edm::LogInfo(MsgLoggerCat)

--- a/Validation/GlobalDigis/src/GlobalDigisProducer.cc
+++ b/Validation/GlobalDigis/src/GlobalDigisProducer.cc
@@ -185,8 +185,8 @@ void GlobalDigisProducer::produce(edm::Event& iEvent,
   
 
   // get event id information
-  int nrun = iEvent.id().run();
-  int nevt = iEvent.id().event();
+  edm::RunNumber_t nrun = iEvent.id().run();
+  edm::EventNumber_t nevt = iEvent.id().event();
 
   if (verbosity > 0) {
     edm::LogInfo(MsgLoggerCat)

--- a/Validation/GlobalHits/src/GlobalHitsAnalyzer.cc
+++ b/Validation/GlobalHits/src/GlobalHitsAnalyzer.cc
@@ -716,8 +716,8 @@ void GlobalHitsAnalyzer::analyze(const edm::Event& iEvent,
   ++count;
 
   // get event id information
-  int nrun = iEvent.id().run();
-  int nevt = iEvent.id().event();
+  edm::RunNumber_t nrun = iEvent.id().run();
+  edm::EventNumber_t nevt = iEvent.id().event();
 
   if (verbosity > 0) {
     edm::LogInfo(MsgLoggerCat)

--- a/Validation/GlobalHits/src/GlobalHitsHistogrammer.cc
+++ b/Validation/GlobalHits/src/GlobalHitsHistogrammer.cc
@@ -537,8 +537,8 @@ void GlobalHitsHistogrammer::analyze(const edm::Event& iEvent,
   ++count;
 
   // get event id information
-  int nrun = iEvent.id().run();
-  int nevt = iEvent.id().event();
+  edm::RunNumber_t nrun = iEvent.id().run();
+  edm::EventNumber_t nevt = iEvent.id().event();
 
   if (verbosity > 0) {
     edm::LogInfo(MsgLoggerCat)

--- a/Validation/GlobalHits/src/GlobalHitsProdHist.cc
+++ b/Validation/GlobalHits/src/GlobalHitsProdHist.cc
@@ -637,8 +637,8 @@ void GlobalHitsProdHist::produce(edm::Event& iEvent,
   ++count;
 
   // get event id information
-  int nrun = iEvent.id().run();
-  int nevt = iEvent.id().event();
+  edm::RunNumber_t nrun = iEvent.id().run();
+  edm::EventNumber_t nevt = iEvent.id().event();
 
   if (verbosity > 0) {
     edm::LogInfo(MsgLoggerCat)

--- a/Validation/GlobalHits/src/GlobalHitsProducer.cc
+++ b/Validation/GlobalHits/src/GlobalHitsProducer.cc
@@ -177,8 +177,8 @@ void GlobalHitsProducer::produce(edm::Event& iEvent,
   ++count;
 
   // get event id information
-  int nrun = iEvent.id().run();
-  int nevt = iEvent.id().event();
+  edm::RunNumber_t nrun = iEvent.id().run();
+  edm::EventNumber_t nevt = iEvent.id().event();
 
   if (verbosity > 0) {
     edm::LogInfo(MsgLoggerCat)

--- a/Validation/GlobalRecHits/src/GlobalRecHitsAnalyzer.cc
+++ b/Validation/GlobalRecHits/src/GlobalRecHitsAnalyzer.cc
@@ -326,8 +326,8 @@ void GlobalRecHitsAnalyzer::analyze(const edm::Event& iEvent,
   ++count;
   
   // get event id information
-  int nrun = iEvent.id().run();
-  int nevt = iEvent.id().event();
+  edm::RunNumber_t nrun = iEvent.id().run();
+  edm::EventNumber_t nevt = iEvent.id().event();
   
   if (verbosity > 0) {
     edm::LogInfo(MsgLoggerCat)

--- a/Validation/GlobalRecHits/src/GlobalRecHitsHistogrammer.cc
+++ b/Validation/GlobalRecHits/src/GlobalRecHitsHistogrammer.cc
@@ -287,8 +287,8 @@ void GlobalRecHitsHistogrammer::analyze(const edm::Event& iEvent,
   ++count;
 
   // get event id information
-  int nrun = iEvent.id().run();
-  int nevt = iEvent.id().event();
+  edm::RunNumber_t nrun = iEvent.id().run();
+  edm::EventNumber_t nevt = iEvent.id().event();
 
   if (verbosity > 0) {
     edm::LogInfo(MsgLoggerCat)

--- a/Validation/GlobalRecHits/src/GlobalRecHitsProducer.cc
+++ b/Validation/GlobalRecHits/src/GlobalRecHitsProducer.cc
@@ -146,8 +146,8 @@ void GlobalRecHitsProducer::produce(edm::Event& iEvent,
   ++count;
 
   // get event id information
-  int nrun = iEvent.id().run();
-  int nevt = iEvent.id().event();
+  edm::RunNumber_t nrun = iEvent.id().run();
+  edm::EventNumber_t nevt = iEvent.id().event();
 
   if (verbosity > 0) {
     edm::LogInfo(MsgLoggerCat)

--- a/Validation/MuonHits/src/MuonSimHitsValidAnalyzer.cc
+++ b/Validation/MuonHits/src/MuonSimHitsValidAnalyzer.cc
@@ -822,8 +822,8 @@ void MuonSimHitsValidAnalyzer::analyze(const edm::Event& iEvent,
   ++count;
 
   /// get event id information
-  int nrun = iEvent.id().run();
-  int nevt = iEvent.id().event();
+  edm::RunNumber_t nrun = iEvent.id().run();
+  edm::EventNumber_t nevt = iEvent.id().event();
 
   if (verbosity > 0) {
     edm::LogInfo ("MuonSimHitsValidAnalyzer::analyze")

--- a/Validation/RecoTrack/interface/SiPixelTrackingRecHitsValid.h
+++ b/Validation/RecoTrack/interface/SiPixelTrackingRecHitsValid.h
@@ -508,8 +508,8 @@ class SiPixelTrackingRecHitsValid : public thread_unsafe::DQMEDAnalyzer
   float simhitx; // true x position of hit 
   float simhity; // true y position of hit
 
-  int evt;
-  int run;
+  edm::EventNumber_t evt;
+  edm::RunNumber_t run;
 
   TFile * tfile_;
   TTree * t_;

--- a/Validation/RecoVertex/interface/PrimaryVertexAnalyzer4PU.h
+++ b/Validation/RecoVertex/interface/PrimaryVertexAnalyzer4PU.h
@@ -325,9 +325,9 @@ private:
   int ndump_;
 
   // from the event setup
-  int run_;
-  int luminosityBlock_;
-  int event_;
+  edm::RunNumber_t run_;
+  edm::LuminosityBlockNumber_t luminosityBlock_;
+  edm::EventNumber_t event_;
   int bunchCrossing_;
   int orbitNumber_;
 

--- a/Validation/RecoVertex/src/PrimaryVertexAnalyzer4PU.cc
+++ b/Validation/RecoVertex/src/PrimaryVertexAnalyzer4PU.cc
@@ -2147,7 +2147,7 @@ PrimaryVertexAnalyzer4PU::analyze(const Event& iEvent, const EventSetup& iSetup)
       Fill(hnoBS,"yrecBeamvsdyXBS",recVtxs->begin()->yError(),recVtxs->begin()->y()-vertexBeamSpot_.y0());
 
       if(printXBS_) {
-	cout << Form("XBS %10d %5d %10d  %4d   %lu %5.2f    %8f %8f       %8f %8f      %8f %8f",
+	cout << Form("XBS %10d %5d %14llu  %4d   %lu %5.2f    %8f %8f       %8f %8f      %8f %8f",
 		      run_,luminosityBlock_,event_,bunchCrossing_,
 		      (unsigned long)(recVtxs->begin()->tracksSize()), recVtxs->begin()->ndof(),
 		      recVtxs->begin()->x(), 		   recVtxs->begin()->xError(), 
@@ -3346,7 +3346,7 @@ void PrimaryVertexAnalyzer4PU::analyzeVertexCollection(std::map<std::string, TH1
     Fill(h,"eff0vsntrec",nrectrks,0.);
     Fill(h,"eff0vsntsel",nseltrks,0.);
     if((nseltrks>1)&&(verbose_)){
-      cout << Form("PrimaryVertexAnalyzer4PU: %s may have lost a vertex  %10d  %10d     %4d / %4d ",message.c_str(),run_, event_, nrectrks,nseltrks) << endl;
+      cout << Form("PrimaryVertexAnalyzer4PU: %s may have lost a vertex  %10d  %14llu     %4d / %4d ",message.c_str(),run_, event_, nrectrks,nseltrks) << endl;
       dumpThisEvent_=true;
     }
   }

--- a/Validation/TrackerHits/src/TrackerHitProducer.cc
+++ b/Validation/TrackerHits/src/TrackerHitProducer.cc
@@ -134,8 +134,8 @@ void TrackerHitProducer::produce(edm::Event& iEvent,
   ++count;
 
   // get event id information
-  int nrun = iEvent.id().run();
-  int nevt = iEvent.id().event();
+  edm::RunNumber_t nrun = iEvent.id().run();
+  edm::EventNumber_t nevt = iEvent.id().event();
 
   // get event setup information
   //edm::ESHandle<edm::SetupData> pSetup;

--- a/Validation/TrackerRecHits/src/SiPixelRecHitsValid.cc
+++ b/Validation/TrackerRecHits/src/SiPixelRecHitsValid.cc
@@ -288,7 +288,7 @@ void SiPixelRecHitsValid::analyze(const edm::Event& e, const edm::EventSetup& es
   const TrackerTopology *tTopo=tTopoHand.product();
 
   edm::LogInfo("EventInfo") << " Run = " << e.id().run() << " Event = " << e.id().event();
-  if ( (int) e.id().event() % 1000 == 0 )
+  if (e.id().event() % 1000 == 0)
     std::cout << " Run = " << e.id().run() << " Event = " << e.id().event() << std::endl;
   
   //Get RecHits


### PR DESCRIPTION
Based on list from David Dagenhart that pointed us (DQM) to all the locations in code where the output from the funtions EventID::event(), EventAuxiliary::event() or EventID::maximumEventNumber() was assigned to some datatype different from EventNumber_t (which is currently unsigned long long).
Most of the time this unsigned long long was cast to an int, but in some cases also float or double to fill a histogram.

Most of these assignments were obviously made to internal variables used for output to log (files) or histograms.

For the sake of consistency, we also fixed similar parallel issues with the RunNumber_t and LuminosityBlockNumber_t, even though of course assigning them to int's is never really a problem.
