### PR TITLE
HLTEgammaGenericFilter added to recognized modules

### DIFF
--- a/DQMOffline/Trigger/src/HLTTauDQMPath.cc
+++ b/DQMOffline/Trigger/src/HLTTauDQMPath.cc
@@ -175,7 +175,7 @@ namespace {
     else if(moduleType == "HLTPFTauPairDzMatchFilter") {
       n.tau = 2;
     }
-    else if(moduleType == "HLTElectronGenericFilter") {
+    else if(moduleType == "HLTElectronGenericFilter" || moduleType == "HLTEgammaGenericFilter") {
       //n.electron = HLTCP.modulePSet(filterName).getParameter<int>("ncandcut");
       n.electron = getParameterSafe(HLTCP, filterName, "ncandcut");
     }


### PR DESCRIPTION
Another fix for electrons in tau DQM (on top of https://github.com/cms-sw/cmssw/pull/6174): HLTEgammaGenericFilter added to recognized modules.
