### PR TITLE
Fixed class version problems caused by merge with standard release

### DIFF
--- a/DataFormats/EgammaCandidates/src/classes_def.xml
+++ b/DataFormats/EgammaCandidates/src/classes_def.xml
@@ -11,7 +11,6 @@
 
   <class name="reco::Photon" ClassVersion="15">
    <version ClassVersion="15" checksum="577991108"/>
-   <version ClassVersion="14" checksum="3272056827"/>
    <version ClassVersion="13" checksum="2963666409"/>
    <version ClassVersion="14" checksum="753726370"/>
   </class>

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -16,9 +16,9 @@
   <class name="pat::Lepton<reco::BaseTau>" />
 
   <!-- PAT Objects, and embedded data  -->
-  <class name="pat::Electron"  ClassVersion="25">
-   <version ClassVersion="25" checksum="3820731538"/>
+  <class name="pat::Electron"  ClassVersion="26">
    <field name="superClusterRelinked_" transient="true"/>
+   <version ClassVersion="26" checksum="3820731538"/>
    <version ClassVersion="25" checksum="1488101799"/>
    <version ClassVersion="24" checksum="2646043873"/>
    <version ClassVersion="23" checksum="434577157"/>
@@ -179,8 +179,9 @@
    <version ClassVersion="11" checksum="1239840459"/>
   </class>
 
-  <class name="pat::PackedCandidate" ClassVersion="15">
-    <version ClassVersion="15" checksum="3261782486"/>
+  <class name="pat::PackedCandidate" ClassVersion="16">
+    <version ClassVersion="16" checksum="3261782486"/>
+    <version ClassVersion="15" checksum="2118306102"/>
     <version ClassVersion="14" checksum="1075333340"/>
     <version ClassVersion="13" checksum="981046949"/>
     <version ClassVersion="12" checksum="981046949"/>

--- a/DataFormats/Provenance/src/classes_def.xml
+++ b/DataFormats/Provenance/src/classes_def.xml
@@ -109,7 +109,7 @@
  </class>
  <class name="edm::FileIndex::Element" ClassVersion="12">
   <version ClassVersion="12" checksum="3292924581"/>
-  <version ClassVersion="11" checksum="436636819"/>
+  <version ClassVersion="11" checksum="1881476699"/>
   <version ClassVersion="10" checksum="1310120368"/>
  </class>
  <class name="std::vector<edm::FileIndex::Element>"/>


### PR DESCRIPTION
After fixing the checksums in _DEVEL_X there were later changes in _X
which use the same class version as those in _DEVEL_X. This change
moves the class versions in _DEVEL_X forward.
