### PR TITLE
HLT Validation VBFHbb ZnnHbb bug fix

### DIFF
--- a/HLTriggerOffline/Higgs/python/hltHiggsPostProcessors_cff.py
+++ b/HLTriggerOffline/Higgs/python/hltHiggsPostProcessors_cff.py
@@ -145,11 +145,11 @@ hltHiggsPostHtaunu.efficiencyProfile = efficiency_strings
 
 #Specific plots for VBFHbb  
 #dEtaqq, mqq, dPhibb, CVS1, maxCSV_jets, maxCSV_E, MET, pt1, pt2, pt3, pt4
-NminOneCutNames = ("EffdEtaqq", "Effmqq", "EffdPhibb", "EffCSV1", "EffmaxCSV", "", "TurnOn1", "TurnOn2", "TurnOn3", "TurnOn4")
+NminOneCutNames = ("EffdEtaqq", "Effmqq", "EffdPhibb", "EffCSV1", "EffmaxCSV", "", "", "TurnOn1", "TurnOn2", "TurnOn3", "TurnOn4")
 plot_types = ["EffEta", "EffPhi"]
 NminOneCuts = (_config.__getattribute__("VBFHbb")).__getattribute__("NminOneCuts")
 if NminOneCuts: 
-    for iCut in range(0,len(NminOneCuts)-1):
+    for iCut in range(0,len(NminOneCuts)):
         if( NminOneCuts[iCut] and NminOneCutNames[iCut] ):
             if( NminOneCutNames[iCut] == "EffmaxCSV" ):
                 plot_types.pop()
@@ -172,7 +172,7 @@ hltHiggsPostVBFHbb.efficiencyProfile = efficiency_strings
 plot_types = ["EffEta", "EffPhi"]
 NminOneCuts = (_config.__getattribute__("ZnnHbb")).__getattribute__("NminOneCuts")
 if NminOneCuts: 
-    for iCut in range(0,len(NminOneCuts)-1):
+    for iCut in range(0,len(NminOneCuts)):
         if( NminOneCuts[iCut] and NminOneCutNames[iCut] ):
             plot_types.append(NminOneCutNames[iCut])
     

--- a/HLTriggerOffline/Higgs/src/HLTHiggsPlotter.cc
+++ b/HLTriggerOffline/Higgs/src/HLTHiggsPlotter.cc
@@ -217,7 +217,8 @@ void HLTHiggsPlotter::analyze(const bool & isPassTrigger, const std::string & so
             }
             ++(countobjects[objType]);
             ++counttotal;
-        }  // else not needed (minCandidates == _NptPlots if _useNminOneCuts 
+        }
+        else continue;  // if not needed (minCandidates == _NptPlots if _useNminOneCuts 
         
         if( ! objType == EVTColContainer::PFJET || passAllCuts ) {
             this->fillHist(isPassTrigger,source,objTypeStr,"Eta",eta);

--- a/HLTriggerOffline/Higgs/test/hltHiggsValidator_cfg.py
+++ b/HLTriggerOffline/Higgs/test/hltHiggsValidator_cfg.py
@@ -3,7 +3,6 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("HLTHiggsOfflineAnalysis")
 
 #process.load("DQMOffline.RecoB.dqmAnalyzer_cff")
-process.load("HLTriggerOffline.Higgs.dqmAnalyzer_cff")
 process.load("HLTriggerOffline.Higgs.HiggsValidation_cff")
 process.load("DQMServices.Components.MEtoEDMConverter_cfi")
 


### PR DESCRIPTION
After checking the plots with more events, two fixes made:
- The VBFHbb jet pt1 efficiency plot wasn't made before, which is now fixed.
- A small bug fix for the ZnnHbb eta and phi trigger dependent histograms.

The differences can be seen here:
-- Fixed version:  /afs/cern.ch/user/j/jlauwers/public/DQM/DQM_ZnnHbb_VBFHbb_fixed.root
-- Old version: /afs/cern.ch/user/j/jlauwers/public/DQM/DQM_ZnnHbb_VBFHbb.root

The second commit removes the no longer used pre b-tagging sequence from the test code.

cc: @HuguesBrun, @slehti, @silviodonato
