### PR TITLE
Additional reference trajectories based on GeneralBrokenLines for tracker alignment with Millepede-II

### DIFF
--- a/Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeAlignmentAlgorithm.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeAlignmentAlgorithm.h
@@ -100,6 +100,12 @@ class MillePedeAlignmentAlgorithm : public AlignmentAlgorithmBase
 			 const ReferenceTrajectoryBase::ReferenceTrajectoryPtr &refTrajPtr,
 			 unsigned int iHit, AlignmentParameters *&params);
 
+  /// Add global data (labels, derivatives) to GBL trajectory
+  /// Returns -1 if any problem (for params cf. globalDerivativesHierarchy)
+  int addGlobalData(const edm::EventSetup &setup, const EventInfo &eventInfo,
+                    const ReferenceTrajectoryBase::ReferenceTrajectoryPtr &refTrajPtr,
+                    unsigned int iHit, GblPoint &gblPoint);
+
   /// Increase hit counting of MillePedeVariables behind each parVec[i]
   /// (and also for parameters higher in hierarchy),
   /// assuming 'parVec' and 'validHitVecY' to be parallel.
@@ -130,13 +136,22 @@ class MillePedeAlignmentAlgorithm : public AlignmentAlgorithmBase
 				  std::vector<int> &globalLabels,
 				  AlignmentParameters *&lowestParams) const;
 
+  /// recursively adding derivatives (double) and labels, false if problems
+  bool globalDerivativesHierarchy(const EventInfo &eventInfo,
+                                  const TrajectoryStateOnSurface &tsos,
+                                  Alignable *ali, const AlignableDetOrUnitPtr &alidet,
+                                  std::vector<double> &globalDerivativesX,
+                                  std::vector<double> &globalDerivativesY,
+                                  std::vector<int> &globalLabels,
+                                  AlignmentParameters *&lowestParams) const;
+
   /// adding derivatives from integrated calibrations
   void globalDerivativesCalibration(const TransientTrackingRecHit::ConstRecHitPointer &recHit,
-				    const TrajectoryStateOnSurface &tsos,
-				    const edm::EventSetup &setup, const EventInfo &eventInfo,
-				    std::vector<float> &globalDerivativesX,
-				    std::vector<float> &globalDerivativesY,
-				    std::vector<int> &globalLabels) const;
+                                    const TrajectoryStateOnSurface &tsos,
+                                    const edm::EventSetup &setup, const EventInfo &eventInfo,
+                                    std::vector<float> &globalDerivativesX,
+                                    std::vector<float> &globalDerivativesY,
+                                    std::vector<int> &globalLabels) const;
 
   /// calls callMille1D or callMille2D
   int callMille(const ReferenceTrajectoryBase::ReferenceTrajectoryPtr &refTrajPtr,
@@ -219,6 +234,9 @@ class MillePedeAlignmentAlgorithm : public AlignmentAlgorithmBase
   std::vector<float>        theFloatBufferY;
   std::vector<int>          theIntBuffer;
   bool                      theDoSurveyPixelBarrel;
+  // CHK for GBL
+  MilleBinary              *theBinary;
+  bool                      theGblDoubleBinary;
 };
 
 #endif

--- a/Alignment/MillePedeAlignmentAlgorithm/python/MillePedeAlignmentAlgorithm_cfi.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/python/MillePedeAlignmentAlgorithm_cfi.py
@@ -58,6 +58,7 @@ MillePedeAlignmentAlgorithm = cms.PSet(
         Presigmas = cms.VPSet(),
         minHieraConstrCoeff = cms.double(1.e-7), # min abs value of coeff. in hierarchy constr.
         minHieraParPerConstr = cms.uint32(2), # ignore hierarchy constraints with less params
+        constrPrecision = cms.uint32(0), # use default precision for writing constraints to text file
 
         # specify additional steering files
         additionalSteerFiles = cms.vstring(), # obsolete - can be given as entries in 'options'
@@ -84,6 +85,7 @@ MillePedeAlignmentAlgorithm = cms.PSet(
 	# TwoBodyDecayReferenceTrajectoryFactory, # for this overwrite MaterialEffects for BL
     minNumHits = cms.uint32(7), ## minimum number of hits (with alignable parameters)
     max2Dcorrelation = cms.double(0.05), ## if correlation >5% 2D measurements in TID/TEC get diagonalized
+    doubleBinary = cms.bool(False), ## create binary files with doubles instead of floats (GBL only)
 
 	# Parameters for PXB survey steering
     surveyPixelBarrel = cms.PSet(

--- a/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeAlignmentAlgorithm.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeAlignmentAlgorithm.cc
@@ -89,7 +89,8 @@ MillePedeAlignmentAlgorithm::MillePedeAlignmentAlgorithm(const edm::ParameterSet
   theTrajectoryFactory(0),
   theMinNumHits(cfg.getParameter<unsigned int>("minNumHits")),
   theMaximalCor2D(cfg.getParameter<double>("max2Dcorrelation")),
-  theLastWrittenIov(0)
+  theLastWrittenIov(0),
+  theBinary(0),theGblDoubleBinary(cfg.getParameter<bool>("doubleBinary"))
 {
   if (!theDir.empty() && theDir.find_last_of('/') != theDir.size()-1) theDir += '/';// may need '/'
   edm::LogInfo("Alignment") << "@SUB=MillePedeAlignmentAlgorithm" << "Start in mode '"
@@ -97,6 +98,8 @@ MillePedeAlignmentAlgorithm::MillePedeAlignmentAlgorithm(const edm::ParameterSet
                             << "' with output directory '" << theDir << "'.";
   if (this->isMode(myMilleBit)) {
     theMille = new Mille((theDir + theConfig.getParameter<std::string>("binaryFile")).c_str());// add ', false);' for text output);
+    // use same file for GBL
+    theBinary = new MilleBinary((theDir + theConfig.getParameter<std::string>("binaryFile")).c_str(), theGblDoubleBinary);
   }
 }
 
@@ -350,38 +353,78 @@ MillePedeAlignmentAlgorithm::addReferenceTrajectory(const edm::EventSetup &setup
   std::pair<unsigned int, unsigned int> hitResultXy(0,0);
   if (refTrajPtr->isValid()) {
     
-    // to add hits if all fine:
-    std::vector<AlignmentParameters*> parVec(refTrajPtr->recHits().size());
-    // collect hit statistics, assuming that there are no y-only hits
-    std::vector<bool> validHitVecY(refTrajPtr->recHits().size(), false);
-    // Use recHits from ReferenceTrajectory (since they have the right order!):
-    for (unsigned int iHit = 0; iHit < refTrajPtr->recHits().size(); ++iHit) {
-      const int flagXY = this->addMeasurementData(setup, eventInfo, refTrajPtr, iHit, parVec[iHit]);
 
-      if (flagXY < 0) { // problem
-	hitResultXy.first = 0;
-	break;
-      } else { // hit is fine, increase x/y statistics
-	if (flagXY >= 1) ++hitResultXy.first;
-	validHitVecY[iHit] = (flagXY >= 2);
-      } 
-    } // end loop on hits
-
-    // add virtual measurements
-    for (unsigned int iVirtualMeas = 0; iVirtualMeas < refTrajPtr->numberOfVirtualMeas(); ++iVirtualMeas) {
-      this->addVirtualMeas(refTrajPtr, iVirtualMeas);
-    }
-             
-    // kill or end 'track' for mille, depends on #hits criterion
-    if (hitResultXy.first == 0 || hitResultXy.first < theMinNumHits) {
-      theMille->kill();
-      hitResultXy.first = hitResultXy.second = 0; //reset
+    // GblTrajectory?
+    if (refTrajPtr->gblInput().size() > 0) {
+      // by construction: number of GblPoints == number of recHits or == zero !!!
+      unsigned int iHit = 0;
+      unsigned int numPointsWithMeas = 0;
+      std::vector<GblPoint>::iterator itPoint;
+      std::vector<std::pair<std::vector<GblPoint>, TMatrixD> > theGblInput = refTrajPtr->gblInput();
+      for (unsigned int iTraj = 0; iTraj < refTrajPtr->gblInput().size(); ++iTraj) {
+        for (itPoint = refTrajPtr->gblInput()[iTraj].first.begin(); itPoint < refTrajPtr->gblInput()[iTraj].first.end(); ++itPoint) {
+          if (this->addGlobalData(setup, eventInfo, refTrajPtr, iHit++, *itPoint) < 0) return hitResultXy;
+          if (itPoint->hasMeasurement() >= 1) ++numPointsWithMeas;
+        }
+      }
+      hitResultXy.first = numPointsWithMeas;
+      // check #hits criterion
+      if (hitResultXy.first == 0 || hitResultXy.first < theMinNumHits) return hitResultXy;
+      // construct GBL trajectory
+      if (refTrajPtr->gblInput().size() == 1) {
+        // from single track
+        GblTrajectory aGblTrajectory( refTrajPtr->gblInput()[0].first, refTrajPtr->nominalField() != 0 );
+        // GBL fit trajectory
+        /*double Chi2;
+        int Ndf;
+        double lostWeight;
+        aGblTrajectory.fit(Chi2, Ndf, lostWeight);
+        std::cout << " GblFit: " << Chi2 << ", " << Ndf << ", " << lostWeight << std::endl; */
+        // write to MP binary file
+        if (aGblTrajectory.isValid() && aGblTrajectory.getNumPoints() >= theMinNumHits) aGblTrajectory.milleOut(*theBinary);
+      }
+      if (refTrajPtr->gblInput().size() == 2) {
+        // from TwoBodyDecay
+        GblTrajectory aGblTrajectory( refTrajPtr->gblInput(), refTrajPtr->gblExtDerivatives(), refTrajPtr->gblExtMeasurements(), refTrajPtr->gblExtPrecisions() );
+        // write to MP binary file
+        if (aGblTrajectory.isValid() && aGblTrajectory.getNumPoints() >= theMinNumHits) aGblTrajectory.milleOut(*theBinary);
+      }
     } else {
-      theMille->end();
-      // add x/y hit count to MillePedeVariables of parVec,
-      // returning number of y-hits of the reference trajectory
-      hitResultXy.second = this->addHitCount(parVec, validHitVecY);
+      // to add hits if all fine:
+      std::vector<AlignmentParameters*> parVec(refTrajPtr->recHits().size());
+      // collect hit statistics, assuming that there are no y-only hits
+      std::vector<bool> validHitVecY(refTrajPtr->recHits().size(), false);
+      // Use recHits from ReferenceTrajectory (since they have the right order!):
+      for (unsigned int iHit = 0; iHit < refTrajPtr->recHits().size(); ++iHit) {
+        const int flagXY = this->addMeasurementData(setup, eventInfo, refTrajPtr, iHit, parVec[iHit]);
+
+        if (flagXY < 0) { // problem
+          hitResultXy.first = 0;
+          break;
+        } else { // hit is fine, increase x/y statistics
+          if (flagXY >= 1) ++hitResultXy.first;
+          validHitVecY[iHit] = (flagXY >= 2);
+        }
+      } // end loop on hits
+
+      // add virtual measurements
+      for (unsigned int iVirtualMeas = 0; iVirtualMeas < refTrajPtr->numberOfVirtualMeas(); ++iVirtualMeas) {
+        this->addVirtualMeas(refTrajPtr, iVirtualMeas);
+      }
+
+      // kill or end 'track' for mille, depends on #hits criterion
+      if (hitResultXy.first == 0 || hitResultXy.first < theMinNumHits) {
+        theMille->kill();
+        hitResultXy.first = hitResultXy.second = 0; //reset
+      } else {
+        theMille->end();
+        // add x/y hit count to MillePedeVariables of parVec,
+        // returning number of y-hits of the reference trajectory
+        hitResultXy.second = this->addHitCount(parVec, validHitVecY);
+        //
+      }
     }
+
   } // end if valid trajectory
 
   return hitResultXy;
@@ -465,6 +508,64 @@ int MillePedeAlignmentAlgorithm::addMeasurementData(const edm::EventSetup &setup
 }
 
 //____________________________________________________
+
+int MillePedeAlignmentAlgorithm::addGlobalData(const edm::EventSetup &setup, const EventInfo &eventInfo,
+                                                    const ReferenceTrajectoryBase::ReferenceTrajectoryPtr &refTrajPtr,
+                                                    unsigned int iHit, GblPoint &gblPoint)
+{
+  AlignmentParameters* params = 0;
+  std::vector<double> theDoubleBufferX, theDoubleBufferY;
+  theDoubleBufferX.clear();
+  theDoubleBufferY.clear();
+  theIntBuffer.clear();
+  int iret = 0;
+
+  const TrajectoryStateOnSurface &tsos = refTrajPtr->trajectoryStates()[iHit];
+  const ConstRecHitPointer &recHitPtr = refTrajPtr->recHits()[iHit];
+  // ignore invalid hits
+  if (!recHitPtr->isValid()) return 0;
+
+  // get AlignableDet/Unit for this hit
+  AlignableDetOrUnitPtr alidet(theAlignableNavigator->alignableFromDetId(recHitPtr->geographicalId()));
+
+  if (!this->globalDerivativesHierarchy(eventInfo,
+                                        tsos, alidet, alidet, theDoubleBufferX, // 2x alidet, sic!
+                                        theDoubleBufferY, theIntBuffer, params)) {
+    return -1; // problem
+  }
+  //calibration parameters
+  int globalLabel;
+  std::vector<IntegratedCalibrationBase::ValuesIndexPair> derivs;
+  for (auto iCalib = theCalibrations.begin(); iCalib != theCalibrations.end(); ++iCalib) {
+    // get all derivatives of this calibration // const unsigned int num =
+    (*iCalib)->derivatives(derivs, *recHitPtr, tsos, setup, eventInfo);
+    for (auto iValuesInd = derivs.begin(); iValuesInd != derivs.end(); ++iValuesInd) {
+      // transfer label and x/y derivatives
+      globalLabel = thePedeLabels->calibrationLabel(*iCalib, iValuesInd->second);
+      if (globalLabel > 0 && globalLabel <= 2147483647) {
+        theIntBuffer.push_back(globalLabel);
+        theDoubleBufferX.push_back(iValuesInd->first.first);
+        theDoubleBufferY.push_back(iValuesInd->first.second);
+      } else {
+        std::cerr << "MillePedeAlignmentAlgorithm::addGlobalData: Invalid label " << globalLabel << " <= 0 or > 2147483647" << std::endl;
+      }
+    }
+  }
+  unsigned int numGlobals = theIntBuffer.size();
+  if (numGlobals > 0)
+  {
+    TMatrixD globalDer(2,numGlobals);
+    for (unsigned int i = 0; i < numGlobals; ++i) {
+      globalDer(0,i) = theDoubleBufferX[i];
+      globalDer(1,i) = theDoubleBufferY[i];
+    }
+    gblPoint.addGlobals( theIntBuffer, globalDer );
+    iret = 1;
+  }
+  return iret;
+}
+  
+//____________________________________________________
 bool MillePedeAlignmentAlgorithm
 ::globalDerivativesHierarchy(const EventInfo &eventInfo,
 			     const TrajectoryStateOnSurface &tsos,
@@ -520,7 +621,66 @@ bool MillePedeAlignmentAlgorithm
 					  globalLabels, lowestParams);
 }
 
+//____________________________________________________
+bool MillePedeAlignmentAlgorithm
+::globalDerivativesHierarchy(const EventInfo &eventInfo,
+                             const TrajectoryStateOnSurface &tsos,
+                             Alignable *ali, const AlignableDetOrUnitPtr &alidet,
+                             std::vector<double> &globalDerivativesX,
+                             std::vector<double> &globalDerivativesY,
+                             std::vector<int> &globalLabels,
+                             AlignmentParameters *&lowestParams) const
+{
+  // derivatives and labels are recursively attached
+  if (!ali) return true; // no mother might be OK
 
+  if (false && theMonitor && alidet != ali) theMonitor->fillFrameToFrame(alidet, ali);
+
+  AlignmentParameters *params = ali->alignmentParameters();
+
+  if (params) {
+    if (!lowestParams) lowestParams = params; // set parameters of lowest level
+
+    bool hasSplitParameters = thePedeLabels->hasSplitParameters(ali);
+    const unsigned int alignableLabel = thePedeLabels->alignableLabel(ali);
+
+    if (0 == alignableLabel) { // FIXME: what about regardAllHits in Markus' code?
+      edm::LogWarning("Alignment") << "@SUB=MillePedeAlignmentAlgorithm::globalDerivativesHierarchy"
+                                   << "Label not found, skip Alignable.";
+      return false;
+    }
+
+    const std::vector<bool> &selPars = params->selector();
+    const AlgebraicMatrix derivs(params->derivatives(tsos, alidet));
+    int globalLabel;
+
+    // cols: 2, i.e. x&y, rows: parameters, usually RigidBodyAlignmentParameters::N_PARAM
+    for (unsigned int iSel = 0; iSel < selPars.size(); ++iSel) {
+      if (selPars[iSel]) {
+        if (hasSplitParameters==true) {
+          globalLabel = thePedeLabels->parameterLabel(ali, iSel, eventInfo, tsos);
+        } else {
+          globalLabel = thePedeLabels->parameterLabel(alignableLabel, iSel);
+        }
+        if (globalLabel > 0 && globalLabel <= 2147483647) {
+          globalLabels.push_back(globalLabel);
+          globalDerivativesX.push_back(derivs[iSel][kLocalX] / thePedeSteer->cmsToPedeFactor(iSel));
+          globalDerivativesY.push_back(derivs[iSel][kLocalY] / thePedeSteer->cmsToPedeFactor(iSel));
+        } else {
+          std::cerr << "MillePedeAlignmentAlgorithm::globalDerivativesHierarchy: Invalid label " << globalLabel << " <= 0 or > 2147483647" << std::endl;
+        }
+      }
+    }
+    // Exclude mothers if Alignable selected to be no part of a hierarchy:
+    if (thePedeSteer->isNoHiera(ali)) return true;
+  }
+  // Call recursively for mother, will stop if mother == 0:
+  return this->globalDerivativesHierarchy(eventInfo,
+                                          tsos, ali->mother(), alidet,
+                                          globalDerivativesX, globalDerivativesY,
+                                          globalLabels, lowestParams);
+}
+					  
 //____________________________________________________
 void MillePedeAlignmentAlgorithm::
 globalDerivativesCalibration(const TransientTrackingRecHit::ConstRecHitPointer &recHit,

--- a/Alignment/MillePedeAlignmentAlgorithm/src/PedeSteerer.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/PedeSteerer.cc
@@ -62,6 +62,7 @@ PedeSteerer::PedeSteerer(AlignableTracker *aliTracker, AlignableMuon *aliMuon, A
   myParameterSign(myConfig.getUntrackedParameter<int>("parameterSign")),
   theMinHieraConstrCoeff(myConfig.getParameter<double>("minHieraConstrCoeff")),
   theMinHieraParPerConstr(myConfig.getParameter<unsigned int>("minHieraParPerConstr")),
+  theConstrPrecision(myConfig.getParameter<unsigned int>("constrPrecision")),
   theCoordMaster(0)
 {
   if (myParameterSign != 1 && myParameterSign != -1) {
@@ -512,7 +513,10 @@ void PedeSteerer::hierarchyConstraint(const Alignable *ali,
       const unsigned int aliLabel = myLabels->alignableLabel(aliSubComp);
       const unsigned int paramLabel = myLabels->parameterLabel(aliLabel, compParNum);
       // FIXME: multiply by cmsToPedeFactor(subcomponent)/cmsToPedeFactor(mother) (or vice a versa?)
-      aConstr << paramLabel << "    " << factors[iParam];
+      if (theConstrPrecision > 0)
+        aConstr << paramLabel << "    " << std::setprecision(theConstrPrecision) << factors[iParam];
+      else
+        aConstr << paramLabel << "    " << factors[iParam];
       if (myIsSteerFileDebug) { // debug
 	aConstr << "   ! for param " << compParNum << " of a " 
 		<< AlignableObjectId::idToString(aliSubComp->alignableObjectId()) << " at " 

--- a/Alignment/MillePedeAlignmentAlgorithm/src/PedeSteerer.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/PedeSteerer.h
@@ -122,7 +122,8 @@ class PedeSteerer
   int myParameterSign; /// old pede versions (before May '07) need a sign flip...
   double theMinHieraConstrCoeff; /// min absolute value of coefficients in hierarchy constraints
   unsigned int theMinHieraParPerConstr; /// hierarchy constraints with less params are ignored
-
+  unsigned int theConstrPrecision; /// precision for writing constraints to text file
+  
   std::vector<std::string> mySteeringFiles; /// keeps track of created 'secondary' steering files
 
   std::set<const Alignable*> myNoHieraCollection; /// Alignables deselected for hierarchy constr.

--- a/Alignment/ReferenceTrajectories/interface/BorderedBandMatrix.h
+++ b/Alignment/ReferenceTrajectories/interface/BorderedBandMatrix.h
@@ -1,0 +1,87 @@
+/*
+ * BorderedBandMatrix.h
+ *
+ *  Created on: Aug 14, 2011
+ *      Author: kleinwrt
+ */
+
+#ifndef BORDEREDBANDMATRIX_H_
+#define BORDEREDBANDMATRIX_H_
+
+#include<iostream>
+#include<vector>
+#include<math.h>
+#include<cstdlib>
+#include "TVectorD.h"
+#include "TMatrixD.h"
+#include "TMatrixDSym.h"
+#include "VMatrix.h"
+
+//! Namespace for the general broken lines package
+namespace gbl {
+
+/// (Symmetric) Bordered Band Matrix.
+/**
+ *  Separate storage of border, mixed and band parts (as vector<double>).
+ *
+ *\verbatim
+ *  Example for matrix size=8 with border size and band width of two
+ *
+ *     +-                                 -+
+ *     |  B11 B12 M13 M14 M15 M16 M17 M18  |
+ *     |  B12 B22 M23 M24 M25 M26 M27 M28  |
+ *     |  M13 M23 C33 C34 C35  0.  0.  0.  |
+ *     |  M14 M24 C34 C44 C45 C46  0.  0.  |
+ *     |  M15 M25 C35 C45 C55 C56 C57  0.  |
+ *     |  M16 M26  0. C46 C56 C66 C67 C68  |
+ *     |  M17 M27  0.  0. C57 C67 C77 C78  |
+ *     |  M18 M28  0.  0.  0. C68 C78 C88  |
+ *     +-                                 -+
+ *
+ *  Is stored as::
+ *
+ *     +-         -+     +-                         -+
+ *     |  B11 B12  |     |  M13 M14 M15 M16 M17 M18  |
+ *     |  B12 B22  |     |  M23 M24 M25 M26 M27 M28  |
+ *     +-         -+     +-                         -+
+ *
+ *                       +-                         -+
+ *                       |  C33 C44 C55 C66 C77 C88  |
+ *                       |  C34 C45 C56 C67 C78  0.  |
+ *                       |  C35 C46 C57 C68  0.  0.  |
+ *                       +-                         -+
+ *\endverbatim
+ */
+
+class BorderedBandMatrix {
+public:
+	BorderedBandMatrix();
+	virtual ~BorderedBandMatrix();
+	void resize(unsigned int nSize, unsigned int nBorder = 1,
+			unsigned int nBand = 5);
+	void solveAndInvertBorderedBand(const VVector &aRightHandSide,
+			VVector &aSolution);
+	void addBlockMatrix(double aWeight,
+			const std::vector<unsigned int>* anIndex,
+			const std::vector<double>* aVector);
+	TMatrixDSym getBlockMatrix(const std::vector<unsigned int> anIndex) const;
+	void printMatrix() const;
+
+private:
+	unsigned int numSize; ///< Matrix size
+	unsigned int numBorder; ///< Border size
+	unsigned int numBand; ///< Band width
+	unsigned int numCol; ///< Band matrix size
+	VSymMatrix theBorder; ///< Border part
+	VMatrix theMixed; ///< Mixed part
+	VMatrix theBand; ///< Band part
+
+	void decomposeBand();
+	VVector solveBand(const VVector &aRightHandSide) const;
+	VMatrix solveBand(const VMatrix &aRightHandSide) const;
+	VMatrix invertBand();
+	VMatrix bandOfAVAT(const VMatrix &anArray,
+			const VSymMatrix &aSymArray) const;
+};
+}
+#endif /* BORDEREDBANDMATRIX_H_ */

--- a/Alignment/ReferenceTrajectories/interface/GblData.h
+++ b/Alignment/ReferenceTrajectories/interface/GblData.h
@@ -1,0 +1,75 @@
+/*
+ * GblData.h
+ *
+ *  Created on: Aug 18, 2011
+ *      Author: kleinwrt
+ */
+
+#ifndef GBLDATA_H_
+#define GBLDATA_H_
+
+#include<iostream>
+#include<vector>
+#include<math.h>
+#include "VMatrix.h"
+#include "TVectorD.h"
+#include "TMatrixD.h"
+#include "TMatrixDSym.h"
+
+#include "Math/SMatrix.h"
+#include "Math/SVector.h"
+typedef ROOT::Math::SMatrix<double, 2, 5> SMatrix25;
+typedef ROOT::Math::SMatrix<double, 2, 7> SMatrix27;
+typedef ROOT::Math::SMatrix<double, 5, 5> SMatrix55;
+
+//! Namespace for the general broken lines package
+namespace gbl {
+
+/// Data (block) for independent scalar measurement
+/**
+ * Data (block) containing value, precision and derivatives for measurements and kinks.
+ * Created from attributes of GblPoints, used to construct linear equation system for track fit.
+ */
+class GblData {
+public:
+	GblData(unsigned int aLabel, double aMeas, double aPrec);
+	virtual ~GblData();
+	void addDerivatives(unsigned int iRow,
+			const std::vector<unsigned int> &labDer, const SMatrix55 &matDer,
+			unsigned int iOff, const TMatrixD &derLocal,
+			const std::vector<int> &labGlobal, const TMatrixD &derGlobal,
+			unsigned int nLocal, const TMatrixD &derTrans);
+	void addDerivatives(unsigned int iRow,
+			const std::vector<unsigned int> &labDer, const SMatrix27 &matDer,
+			unsigned int nLocal, const TMatrixD &derTrans);
+	void addDerivatives(const std::vector<unsigned int> &index,
+			const std::vector<double> &derivatives);
+
+	void setPrediction(const VVector &aVector);
+	double setDownWeighting(unsigned int aMethod);
+	double getChi2() const;
+	void printData() const;
+	void getLocalData(double &aValue, double &aWeight,
+			std::vector<unsigned int>* &indLocal,
+			std::vector<double>* &derLocal);
+	void getAllData(double &aValue, double &aErr,
+			std::vector<unsigned int>* &indLocal,
+			std::vector<double>* &derLocal, std::vector<int>* &labGlobal,
+			std::vector<double>* &derGlobal);
+	void getResidual(double &aResidual, double &aVariance, double &aDownWeight,
+			std::vector<unsigned int>* &indLocal,
+			std::vector<double>* &derLocal);
+
+private:
+	unsigned int theLabel; ///< Label (of measurements point)
+	double theValue; ///< Value (residual)
+	double thePrecision; ///< Precision (1/sigma**2)
+	double theDownWeight; ///< Down-weighting factor (0-1)
+	double thePrediction; ///< Prediction from fit
+	std::vector<unsigned int> theParameters; ///< List of fit parameters (with non zero derivatives)
+	std::vector<double> theDerivatives; ///< List of derivatives for fit
+	std::vector<int> globalLabels; ///< Labels for global derivatives
+	std::vector<double> globalDerivatives; ///< Global derivatives
+};
+}
+#endif /* GBLDATA_H_ */

--- a/Alignment/ReferenceTrajectories/interface/GblPoint.h
+++ b/Alignment/ReferenceTrajectories/interface/GblPoint.h
@@ -1,0 +1,110 @@
+/*
+ * GblPoint.h
+ *
+ *  Created on: Aug 18, 2011
+ *      Author: kleinwrt
+ */
+
+#ifndef GBLPOINT_H_
+#define GBLPOINT_H_
+
+#include<iostream>
+#include<vector>
+#include<math.h>
+#include <stdexcept>
+#include "TVectorD.h"
+#include "TMatrixD.h"
+#include "TMatrixDSym.h"
+#include "TMatrixDSymEigen.h"
+
+#include "Math/SMatrix.h"
+#include "Math/SVector.h"
+typedef ROOT::Math::SMatrix<double, 2> SMatrix22;
+typedef ROOT::Math::SMatrix<double, 2, 3> SMatrix23;
+typedef ROOT::Math::SMatrix<double, 2, 5> SMatrix25;
+typedef ROOT::Math::SMatrix<double, 2, 7> SMatrix27;
+typedef ROOT::Math::SMatrix<double, 3, 2> SMatrix32;
+typedef ROOT::Math::SMatrix<double, 3> SMatrix33;
+typedef ROOT::Math::SMatrix<double, 5> SMatrix55;
+typedef ROOT::Math::SVector<double, 2> SVector2;
+typedef ROOT::Math::SVector<double, 5> SVector5;
+
+namespace gbl {
+
+/// Point on trajectory
+/**
+ * User supplied point on (initial) trajectory.
+ *
+ * Must have jacobian for propagation from previous point. May have:
+ *
+ *   -# Measurement (1D - 5D)
+ *   -# Scatterer (thin, 2D kinks)
+ *   -# Additional local parameters (with derivatives). Fitted together with track parameters.
+ *   -# Additional global parameters (with labels and derivatives). Not fitted, only passed
+ *      on to (binary) file for fitting with Millepede-II.
+ */
+class GblPoint {
+public:
+	GblPoint(const TMatrixD &aJacobian);
+	GblPoint(const SMatrix55 &aJacobian);
+	virtual ~GblPoint();
+	void addMeasurement(const TMatrixD &aProjection, const TVectorD &aResiduals,
+			const TVectorD &aPrecision, double minPrecision = 0.);
+	void addMeasurement(const TMatrixD &aProjection, const TVectorD &aResiduals,
+			const TMatrixDSym &aPrecision, double minPrecision = 0.);
+	void addMeasurement(const TVectorD &aResiduals, const TVectorD &aPrecision,
+			double minPrecision = 0.);
+	void addMeasurement(const TVectorD &aResiduals,
+			const TMatrixDSym &aPrecision, double minPrecision = 0.);
+	unsigned int hasMeasurement() const;
+	void getMeasurement(SMatrix55 &aProjection, SVector5 &aResiduals,
+			SVector5 &aPrecision) const;
+	void getMeasTransformation(TMatrixD &aTransformation) const;
+	void addScatterer(const TVectorD &aResiduals, const TVectorD &aPrecision);
+	void addScatterer(const TVectorD &aResiduals,
+			const TMatrixDSym &aPrecision);
+	bool hasScatterer() const;
+	void getScatterer(SMatrix22 &aTransformation, SVector2 &aResiduals,
+			SVector2 &aPrecision) const;
+	void getScatTransformation(TMatrixD &aTransformation) const;
+	void addLocals(const TMatrixD &aDerivatives);
+	unsigned int getNumLocals() const;
+	const TMatrixD& getLocalDerivatives() const;
+	void addGlobals(const std::vector<int> &aLabels,
+			const TMatrixD &aDerivatives);
+	unsigned int getNumGlobals() const;
+	std::vector<int> getGlobalLabels() const;
+	const TMatrixD& getGlobalDerivatives() const;
+	void setLabel(unsigned int aLabel);
+	unsigned int getLabel() const;
+	void setOffset(int anOffset);
+	int getOffset() const;
+	const SMatrix55& getP2pJacobian() const;
+	void addPrevJacobian(const SMatrix55 &aJac);
+	void addNextJacobian(const SMatrix55 &aJac);
+	void getDerivatives(int aDirection, SMatrix22 &matW, SMatrix22 &matWJ,
+			SVector2 &vecWd) const;
+	void printPoint(unsigned int level = 0) const;
+
+private:
+	unsigned int theLabel; ///< Label identifying point
+	int theOffset; ///< Offset number at point if not negative (else interpolation needed)
+	SMatrix55 p2pJacobian; ///< Point-to-point jacobian from previous point
+	SMatrix55 prevJacobian; ///< Jacobian to previous scatterer (or first measurement)
+	SMatrix55 nextJacobian; ///< Jacobian to next scatterer (or last measurement)
+	unsigned int measDim; ///< Dimension of measurement (1-5), 0 indicates absence of measurement
+	SMatrix55 measProjection; ///< Projection from measurement to local system
+	SVector5 measResiduals; ///< Measurement residuals
+	SVector5 measPrecision; ///< Measurement precision (diagonal of inverse covariance matrix)
+	bool transFlag; ///< Transformation exists?
+	TMatrixD measTransformation; ///< Transformation of diagonalization (of meas. precision matrix)
+	bool scatFlag; ///< Scatterer present?
+	SMatrix22 scatTransformation; ///< Transformation of diagonalization (of scat. precision matrix)
+	SVector2 scatResiduals; ///< Scattering residuals (initial kinks if iterating)
+	SVector2 scatPrecision; ///< Scattering precision (diagonal of inverse covariance matrix)
+	TMatrixD localDerivatives; ///< Derivatives of measurement vs additional local (fit) parameters
+	std::vector<int> globalLabels; ///< Labels of global (MP-II) derivatives
+	TMatrixD globalDerivatives; ///< Derivatives of measurement vs additional global (MP-II) parameters
+};
+}
+#endif /* GBLPOINT_H_ */

--- a/Alignment/ReferenceTrajectories/interface/GblTrajectory.h
+++ b/Alignment/ReferenceTrajectories/interface/GblTrajectory.h
@@ -1,0 +1,104 @@
+/*
+ * GblTrajectory.h
+ *
+ *  Created on: Aug 18, 2011
+ *      Author: kleinwrt
+ */
+
+#ifndef GBLTRAJECTORY_H_
+#define GBLTRAJECTORY_H_
+
+#include "GblPoint.h"
+#include "GblData.h"
+#include "GblPoint.h"
+#include "BorderedBandMatrix.h"
+#include "MilleBinary.h"
+#include "TMatrixDSymEigen.h"
+
+//! Namespace for the general broken lines package
+namespace gbl {
+
+/// GBL trajectory.
+/**
+ * List of GblPoints ordered by arc length.
+ * Can be fitted and optionally written to MP-II binary file.
+ */
+class GblTrajectory {
+public:
+	GblTrajectory(const std::vector<GblPoint> &aPointList, bool flagCurv = true,
+			bool flagU1dir = true, bool flagU2dir = true);
+	GblTrajectory(const std::vector<GblPoint> &aPointList, unsigned int aLabel,
+			const TMatrixDSym &aSeed, bool flagCurv = true, bool flagU1dir =
+					true, bool flagU2dir = true);
+	GblTrajectory(
+			const std::vector<std::pair<std::vector<GblPoint>, TMatrixD> > &aPointaAndTransList);
+	GblTrajectory(
+			const std::vector<std::pair<std::vector<GblPoint>, TMatrixD> > &aPointaAndTransList,
+			const TMatrixD &extDerivatives, const TVectorD &extMeasurements,
+			const TVectorD &extPrecisions);
+	virtual ~GblTrajectory();
+	bool isValid() const;
+	unsigned int getNumPoints() const;
+	unsigned int getResults(int aSignedLabel, TVectorD &localPar,
+			TMatrixDSym &localCov) const;
+	unsigned int getMeasResults(unsigned int aLabel, unsigned int &numRes,
+			TVectorD &aResiduals, TVectorD &aMeasErrors, TVectorD &aResErrors,
+			TVectorD &aDownWeights);
+	unsigned int getScatResults(unsigned int aLabel, unsigned int &numRes,
+			TVectorD &aResiduals, TVectorD &aMeasErrors, TVectorD &aResErrors,
+			TVectorD &aDownWeights);
+	void getLabels(std::vector<unsigned int> &aLabelList);
+	void getLabels(std::vector<std::vector< unsigned int> > &aLabelList);
+	unsigned int fit(double &Chi2, int &Ndf, double &lostWeight,
+			std::string optionList = "");
+	void milleOut(MilleBinary &aMille);
+	void printTrajectory(unsigned int level = 0);
+	void printPoints(unsigned int level = 0);
+	void printData();
+
+private:
+	unsigned int numAllPoints; ///< Number of all points on trajectory
+	std::vector<unsigned int> numPoints; ///< Number of points on (sub)trajectory
+	unsigned int numTrajectories; ///< Number of trajectories (in composed trajectory)
+	unsigned int numOffsets; ///< Number of (points with) offsets on trajectory
+	unsigned int numInnerTrans; ///< Number of inner transformations to external parameters
+	unsigned int numCurvature; ///< Number of curvature parameters (0 or 1) or external parameters
+	unsigned int numParameters; ///< Number of fit parameters
+	unsigned int numLocals; ///< Total number of (additional) local parameters
+	unsigned int numMeasurements; ///< Total number of measurements
+	unsigned int externalPoint; ///< Label of external point (or 0)
+	bool constructOK; ///< Trajectory has been successfully constructed (ready for fit/output)
+	bool fitOK; ///< Trajectory has been successfully fitted (results are valid)
+	std::vector<unsigned int> theDimension; ///< List of active dimensions (0=u1, 1=u2) in fit
+	std::vector<std::vector<GblPoint> > thePoints; ///< (list of) List of points on trajectory
+	std::vector<GblData> theData; ///< List of data blocks
+	std::vector<unsigned int> measDataIndex; ///< mapping points to data blocks from measurements
+	std::vector<unsigned int> scatDataIndex; ///< mapping points to data blocks from scatterers
+	TMatrixDSym externalSeed; ///< Precision (inverse covariance matrix) of external seed
+	std::vector<TMatrixD> innerTransformations; ///< Transformations at innermost points of
+	// composed trajectory (from common external parameters)
+	TMatrixD externalDerivatives; // Derivatives for external measurements of composed trajectory
+	TVectorD externalMeasurements; // Residuals for external measurements of composed trajectory
+	TVectorD externalPrecisions; // Precisions for external measurements of composed trajectory
+	VVector theVector; ///< Vector of linear equation system
+	BorderedBandMatrix theMatrix; ///< (Bordered band) matrix of linear equation system
+
+	std::pair<std::vector<unsigned int>, TMatrixD> getJacobian(
+			int aSignedLabel) const;
+	void getFitToLocalJacobian(std::vector<unsigned int> &anIndex,
+			SMatrix55 &aJacobian, const GblPoint &aPoint, unsigned int measDim,
+			unsigned int nJacobian = 1) const;
+	void getFitToKinkJacobian(std::vector<unsigned int> &anIndex,
+			SMatrix27 &aJacobian, const GblPoint &aPoint) const;
+	void construct();
+	void defineOffsets();
+	void calcJacobians();
+	void prepare();
+	void buildLinearEquationSystem();
+	void predict();
+	double downWeight(unsigned int aMethod);
+	void getResAndErr(unsigned int aData, double &aResidual,
+			double &aMeadsError, double &aResError, double &aDownWeight);
+};
+}
+#endif /* GBLTRAJECTORY_H_ */

--- a/Alignment/ReferenceTrajectories/interface/MilleBinary.h
+++ b/Alignment/ReferenceTrajectories/interface/MilleBinary.h
@@ -1,0 +1,66 @@
+/*
+ * MilleBinary.h
+ *
+ *  Created on: Aug 31, 2011
+ *      Author: kleinwrt
+ */
+
+#ifndef MILLEBINARY_H_
+#define MILLEBINARY_H_
+
+#include<fstream>
+#include<vector>
+
+//! Namespace for the general broken lines package
+namespace gbl {
+
+///  Millepede-II (binary) record.
+/**
+ *  Containing information for local (track) and global fit.
+ *
+ *  The data blocks are collected in two arrays, a real array
+ *  (containing float or double values) and integer array, of same length.
+ *  A positive record length indicate _float_ and a negative one _double_ values.
+ *  The content of the record is:
+ *\verbatim
+ *         real array              integer array
+ *     0   0.0                     error count (this record)
+ *     1   RMEAS, measured value   0                            -+
+ *     2   local derivative        index of local derivative     |
+ *     3   local derivative        index of local derivative     |
+ *     4    ...                                                  | block
+ *         SIGMA, error (>0)       0                             |
+ *         global derivative       label of global derivative    |
+ *         global derivative       label of global derivative   -+
+ *         RMEAS, measured value   0
+ *         local derivative        index of local derivative
+ *         local derivative        index of local derivative
+ *         ...
+ *         SIGMA, error            0
+ *         global derivative       label of global derivative
+ *         global derivative       label of global derivative
+ *         ...
+ *         global derivative       label of global derivative
+ *\endverbatim
+ */
+class MilleBinary {
+public:
+	MilleBinary(const std::string fileName = "milleBinaryISN.dat",
+			bool doublePrec = false, unsigned int aSize = 2000);
+	virtual ~MilleBinary();
+	void addData(double aMeas, double aPrec,
+			const std::vector<unsigned int> &indLocal,
+			const std::vector<double> &derLocal,
+			const std::vector<int> &labGlobal,
+			const std::vector<double> &derGlobal);
+	void writeRecord();
+
+private:
+	std::ofstream binaryFile; ///< Binary File
+	std::vector<int> intBuffer; ///< Integer buffer
+	std::vector<float> floatBuffer; ///< Float buffer
+	std::vector<double> doubleBuffer; ///< Double buffer
+	bool doublePrecision; ///< Flag for storage in as *double* values
+};
+}
+#endif /* MILLEBINARY_H_ */

--- a/Alignment/ReferenceTrajectories/interface/ReferenceTrajectory.h
+++ b/Alignment/ReferenceTrajectories/interface/ReferenceTrajectory.h
@@ -39,6 +39,11 @@
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHit.h"
 #include "DataFormats/TrajectorySeed/interface/PropagationDirection.h"
 #include "TrackingTools/TrajectoryState/interface/SurfaceSideDefinition.h"
+#include "Alignment/ReferenceTrajectories/interface/GblTrajectory.h"
+
+#include <TMatrixDSym.h>
+#include <TMatrixD.h>
+#include <TVectorD.h>
 
 class TrajectoryStateOnSurface;
 class MagneticField;
@@ -147,6 +152,21 @@ protected:
 				     const std::vector<double> &allSteps,
 				     const GlobalTrajectoryParameters &gtp,   
 				     const double minStep = 1.0);
+  
+  /** internal methods to add material effects using broken lines (fine version, local system)
+   */
+  virtual bool addMaterialEffectsLocalGbl(const std::vector<AlgebraicMatrix> &allJacobians,
+                                     const std::vector<AlgebraicMatrix> &allProjections,
+                                     const std::vector<AlgebraicSymMatrix> &allCurvatureChanges,
+                                     const std::vector<AlgebraicSymMatrix> &allDeltaParameterCovs);
+
+  /** internal methods to add material effects using broken lines (fine version, curvilinear system)
+   */
+  virtual bool addMaterialEffectsCurvlinGbl(const std::vector<AlgebraicMatrix> &allJacobians,
+                                     const std::vector<AlgebraicMatrix> &allProjections,
+                                     const std::vector<AlgebraicSymMatrix> &allCurvChanges,
+                                     const std::vector<AlgebraicSymMatrix> &allDeltaParaCovs,
+                                     const std::vector<AlgebraicMatrix> &allLocalToCurv);
           
   /// Don't care for propagation direction 'anyDirection' - in that case the material effects
   /// are anyway not updated ...
@@ -167,6 +187,10 @@ protected:
   template <unsigned int N>
     AlgebraicMatrix
     getHitProjectionMatrixT(const TransientTrackingRecHit::ConstRecHitPointer &recHit) const;
+private:
+  void clhep2root(const AlgebraicVector& in, TVectorD& out);
+  void clhep2root(const AlgebraicMatrix& in, TMatrixD& out);
+  void clhep2root(const AlgebraicSymMatrix& in, TMatrixDSym& out);
 };
 
 #endif

--- a/Alignment/ReferenceTrajectories/interface/VMatrix.h
+++ b/Alignment/ReferenceTrajectories/interface/VMatrix.h
@@ -1,0 +1,113 @@
+/*
+ * VMatrix.h
+ *
+ *  Created on: Feb 15, 2012
+ *      Author: kleinwrt
+ */
+
+#ifndef VMATRIX_H_
+#define VMATRIX_H_
+
+#include<iostream>
+#include<iomanip>
+#include<vector>
+#include<cstring>
+#include<math.h>
+
+//! Namespace for the general broken lines package
+namespace gbl {
+
+/// Simple Vector based on std::vector<double>
+class VVector {
+public:
+	VVector(const unsigned int nRows = 0);
+	VVector(const VVector &aVector);
+	virtual ~VVector();
+	void resize(const unsigned int nRows);
+	VVector getVec(unsigned int len, unsigned int start = 0) const;
+	void putVec(const VVector &aVector, unsigned int start = 0);
+	inline double &operator()(unsigned int i);
+	inline double operator()(unsigned int i) const;
+	unsigned int getNumRows() const;
+	void print() const;
+	VVector operator-(const VVector &aVector) const;
+	VVector &operator=(const VVector &aVector);
+private:
+	unsigned int numRows; ///< Number of rows
+	std::vector<double> theVec; ///< Data
+};
+
+/// Simple Matrix based on std::vector<double>
+class VMatrix {
+public:
+	VMatrix(const unsigned int nRows = 0, const unsigned int nCols = 0);
+	VMatrix(const VMatrix &aMatrix);
+	virtual ~VMatrix();
+	void resize(const unsigned int nRows, const unsigned int nCols);
+	VMatrix transpose() const;
+	inline double &operator()(unsigned int i, unsigned int j);
+	inline double operator()(unsigned int i, unsigned int j) const;
+	unsigned int getNumRows() const;
+	unsigned int getNumCols() const;
+	void print() const;
+	VVector operator*(const VVector &aVector) const;
+	VMatrix operator*(const VMatrix &aMatrix) const;
+	VMatrix operator+(const VMatrix &aMatrix) const;
+	VMatrix &operator=(const VMatrix &aMatrix);
+private:
+	unsigned int numRows; ///< Number of rows
+	unsigned int numCols; ///< Number of columns
+	std::vector<double> theVec; ///< Data
+};
+
+/// Simple symmetric Matrix based on std::vector<double>
+class VSymMatrix {
+public:
+	VSymMatrix(const unsigned int nRows = 0);
+	virtual ~VSymMatrix();
+	void resize(const unsigned int nRows);
+	unsigned int invert();
+	inline double &operator()(unsigned int i, unsigned int j);
+	inline double operator()(unsigned int i, unsigned int j) const;
+	unsigned int getNumRows() const;
+	void print() const;
+	VSymMatrix operator-(const VMatrix &aMatrix) const;
+	VVector operator*(const VVector &aVector) const;
+	VMatrix operator*(const VMatrix &aMatrix) const;
+private:
+	unsigned int numRows; ///< Number of rows
+	std::vector<double> theVec; ///< Data (symmetric storage)
+};
+
+/// access element (i,j)
+inline double &VMatrix::operator()(unsigned int iRow, unsigned int iCol) {
+	return theVec[numCols * iRow + iCol];
+}
+
+/// access element (i,j)
+inline double VMatrix::operator()(unsigned int iRow, unsigned int iCol) const {
+	return theVec[numCols * iRow + iCol];
+}
+
+/// access element (i)
+inline double &VVector::operator()(unsigned int iRow) {
+	return theVec[iRow];
+}
+
+/// access element (i)
+inline double VVector::operator()(unsigned int iRow) const {
+	return theVec[iRow];
+}
+
+/// access element (i,j) assuming i>=j
+inline double &VSymMatrix::operator()(unsigned int iRow, unsigned int iCol) {
+	return theVec[(iRow * iRow + iRow) / 2 + iCol]; // assuming iCol <= iRow
+}
+
+/// access element (i,j) assuming i>=j
+inline double VSymMatrix::operator()(unsigned int iRow,
+		unsigned int iCol) const {
+	return theVec[(iRow * iRow + iRow) / 2 + iCol]; // assuming iCol <= iRow
+}
+}
+#endif /* VMATRIX_H_ */

--- a/Alignment/ReferenceTrajectories/src/BorderedBandMatrix.cc
+++ b/Alignment/ReferenceTrajectories/src/BorderedBandMatrix.cc
@@ -1,0 +1,317 @@
+/*
+ * BorderedBandMatrix.cpp
+ *
+ *  Created on: Aug 14, 2011
+ *      Author: kleinwrt
+ */
+
+#include "Alignment/ReferenceTrajectories/interface/BorderedBandMatrix.h"
+
+//! Namespace for the general broken lines package
+namespace gbl {
+
+/// Create bordered band matrix.
+BorderedBandMatrix::BorderedBandMatrix() : numSize(0), numBorder(0), numBand(0), numCol(0) {
+}
+
+BorderedBandMatrix::~BorderedBandMatrix() {
+}
+
+/// Resize bordered band matrix.
+/**
+ * \param nSize [in] Size of matrix
+ * \param nBorder [in] Size of border (=1 for q/p + additional local parameters)
+ * \param nBand [in] Band width (usually = 5, for simplified jacobians = 4)
+ */
+void BorderedBandMatrix::resize(unsigned int nSize, unsigned int nBorder,
+		unsigned int nBand) {
+	numSize = nSize;
+	numBorder = nBorder;
+	numCol = nSize - nBorder;
+	numBand = 0;
+	theBorder.resize(numBorder);
+	theMixed.resize(numBorder, numCol);
+	theBand.resize((nBand + 1), numCol);
+}
+
+/// Add symmetric block matrix.
+/**
+ * Add (extended) block matrix defined by 'aVector * aWeight * aVector.T'
+ * to bordered band matrix:
+ * BBmatrix(anIndex(i),anIndex(j)) += aVector(i) * aWeight * aVector(j).
+ * \param aWeight [in] Weight
+ * \param anIndex [in] List of rows/colums to be used
+ * \param aVector [in] Vector
+ */
+void BorderedBandMatrix::addBlockMatrix(double aWeight,
+		const std::vector<unsigned int>* anIndex,
+		const std::vector<double>* aVector) {
+	int nBorder = numBorder;
+	for (unsigned int i = 0; i < anIndex->size(); ++i) {
+		int iIndex = (*anIndex)[i] - 1; // anIndex has to be sorted
+		for (unsigned int j = 0; j <= i; ++j) {
+			int jIndex = (*anIndex)[j] - 1;
+			if (iIndex < nBorder) {
+				theBorder(iIndex, jIndex) += (*aVector)[i] * aWeight
+						* (*aVector)[j];
+			} else if (jIndex < nBorder) {
+				theMixed(jIndex, iIndex - nBorder) += (*aVector)[i] * aWeight
+						* (*aVector)[j];
+			} else {
+				unsigned int nBand = iIndex - jIndex;
+				theBand(nBand, jIndex - nBorder) += (*aVector)[i] * aWeight
+						* (*aVector)[j];
+				numBand = std::max(numBand, nBand); // update band width
+			}
+		}
+	}
+}
+
+/// Retrieve symmetric block matrix.
+/**
+ * Get (compressed) block from bordered band matrix: aMatrix(i,j) = BBmatrix(anIndex(i),anIndex(j)).
+ * \param anIndex [in] List of rows/colums to be used
+ */
+TMatrixDSym BorderedBandMatrix::getBlockMatrix(
+		const std::vector<unsigned int> anIndex) const {
+
+	TMatrixDSym aMatrix(anIndex.size());
+	int nBorder = numBorder;
+	for (unsigned int i = 0; i < anIndex.size(); ++i) {
+		int iIndex = anIndex[i] - 1; // anIndex has to be sorted
+		for (unsigned int j = 0; j <= i; ++j) {
+			int jIndex = anIndex[j] - 1;
+			if (iIndex < nBorder) {
+				aMatrix(i, j) = theBorder(iIndex, jIndex); // border part of inverse
+			} else if (jIndex < nBorder) {
+				aMatrix(i, j) = -theMixed(jIndex, iIndex - nBorder); // mixed part of inverse
+			} else {
+				unsigned int nBand = iIndex - jIndex;
+				aMatrix(i, j) = theBand(nBand, jIndex - nBorder); // band part of inverse
+			}
+			aMatrix(j, i) = aMatrix(i, j);
+		}
+	}
+	return aMatrix;
+}
+
+/// Solve linear equation system, partially calculate inverse.
+/**
+ * Solve linear equation A*x=b system with bordered band matrix A,
+ * calculate bordered band part of inverse of A. Use decomposition
+ * in border and band part for block matrix algebra:
+ *
+ *     | A  Ct |   | x1 |   | b1 |        , A  is the border part
+ *     |       | * |    | = |    |        , Ct is the mixed part
+ *     | C  D  |   | x2 |   | b2 |        , D  is the band part
+ *
+ * Explicit inversion of D is avoided by using solution X of D*X=C (X=D^-1*C,
+ * obtained from Cholesky decomposition and forward/backward substitution)
+ *
+ *     | x1 |   | E*b1 - E*Xt*b2 |        , E^-1 = A-Ct*D^-1*C = A-Ct*X
+ *     |    | = |                |
+ *     | x2 |   |  x   - X*x1    |        , x is solution of D*x=b2 (x=D^-1*b2)
+ *
+ * Inverse matrix is:
+ *
+ *     |  E   -E*Xt          |
+ *     |                     |            , only band part of (D^-1 + X*E*Xt)
+ *     | -X*E  D^-1 + X*E*Xt |              is calculated
+ *
+ *
+ * \param [in] aRightHandSide Right hand side (vector) 'b' of A*x=b
+ * \param [out] aSolution Solution (vector) x of A*x=b
+ */
+void BorderedBandMatrix::solveAndInvertBorderedBand(
+		const VVector &aRightHandSide, VVector &aSolution) {
+
+	// decompose band
+	decomposeBand();
+	// invert band
+	VMatrix inverseBand = invertBand();
+	if (numBorder > 0) { // need to use block matrix decomposition to solve
+		// solve for mixed part
+		const VMatrix auxMat = solveBand(theMixed); // = Xt
+		const VMatrix auxMatT = auxMat.transpose(); // = X
+		// solve for border part
+		const VVector auxVec = aRightHandSide.getVec(numBorder)
+				- auxMat * aRightHandSide.getVec(numCol, numBorder); // = b1 - Xt*b2
+		VSymMatrix inverseBorder = theBorder - theMixed * auxMatT;
+		inverseBorder.invert(); // = E
+		const VVector borderSolution = inverseBorder * auxVec; // = x1
+		// solve for band part
+		const VVector bandSolution = solveBand(
+				aRightHandSide.getVec(numCol, numBorder)); // = x
+		aSolution.putVec(borderSolution);
+		aSolution.putVec(bandSolution - auxMatT * borderSolution, numBorder); // = x2
+		// parts of inverse
+		theBorder = inverseBorder; // E
+		theMixed = inverseBorder * auxMat; // E*Xt (-mixed part of inverse) !!!
+		theBand = inverseBand + bandOfAVAT(auxMatT, inverseBorder); // band(D^-1 + X*E*Xt)
+	} else {
+		aSolution.putVec(solveBand(aRightHandSide));
+		theBand = inverseBand;
+	}
+}
+
+/// Print bordered band matrix.
+void BorderedBandMatrix::printMatrix() const {
+	std::cout << "Border part " << std::endl;
+	theBorder.print();
+	std::cout << "Mixed  part " << std::endl;
+	theMixed.print();
+	std::cout << "Band   part " << std::endl;
+	theBand.print();
+}
+
+/*============================================================================
+ from Dbandmatrix.F (MillePede-II by V. Blobel, Univ. Hamburg)
+ ============================================================================*/
+/// (root free) Cholesky decomposition of band part: C=LDL^T
+/**
+ * Decompose band matrix into diagonal matrix D and lower triangular band matrix
+ * L (diagonal=1). Overwrite band matrix with D and off-diagonal part of L.
+ *  \exception 2 : matrix is singular.
+ *  \exception 3 : matrix is not positive definite.
+ */
+void BorderedBandMatrix::decomposeBand() {
+
+	int nRow = numBand + 1;
+	int nCol = numCol;
+	VVector auxVec(nCol);
+	for (int i = 0; i < nCol; ++i) {
+		auxVec(i) = theBand(0, i) * 16.0; // save diagonal elements
+	}
+	for (int i = 0; i < nCol; ++i) {
+		if ((theBand(0, i) + auxVec(i)) != theBand(0, i)) {
+			theBand(0, i) = 1.0 / theBand(0, i);
+			if (theBand(0, i) < 0.) {
+				throw 3; // not positive definite
+			}
+		} else {
+			theBand(0, i) = 0.0;
+			throw 2; // singular
+		}
+		for (int j = 1; j < std::min(nRow, nCol - i); ++j) {
+			double rxw = theBand(j, i) * theBand(0, i);
+			for (int k = 0; k < std::min(nRow, nCol - i) - j; ++k) {
+				theBand(k, i + j) -= theBand(k + j, i) * rxw;
+			}
+			theBand(j, i) = rxw;
+		}
+	}
+}
+
+/// Solve for band part.
+/**
+ * Solve C*x=b for band part using decomposition C=LDL^T
+ * and forward (L*z=b) and backward substitution (L^T*x=D^-1*z).
+ * \param [in] aRightHandSide Right hand side (vector) 'b' of C*x=b
+ * \return Solution (vector) 'x' of C*x=b
+ */
+VVector BorderedBandMatrix::solveBand(const VVector &aRightHandSide) const {
+
+	int nRow = theBand.getNumRows();
+	int nCol = theBand.getNumCols();
+	VVector aSolution(aRightHandSide);
+	for (int i = 0; i < nCol; ++i) // forward substitution
+			{
+		for (int j = 1; j < std::min(nRow, nCol - i); ++j) {
+			aSolution(j + i) -= theBand(j, i) * aSolution(i);
+		}
+	}
+	for (int i = nCol - 1; i >= 0; i--) // backward substitution
+			{
+		double rxw = theBand(0, i) * aSolution(i);
+		for (int j = 1; j < std::min(nRow, nCol - i); ++j) {
+			rxw -= theBand(j, i) * aSolution(j + i);
+		}
+		aSolution(i) = rxw;
+	}
+	return aSolution;
+}
+
+/// solve band part for mixed part (border rows).
+/**
+ * Solve C*X=B for mixed part using decomposition C=LDL^T
+ * and forward and backward substitution.
+ * \param [in] aRightHandSide Right hand side (matrix) 'B' of C*X=B
+ * \return Solution (matrix) 'X' of C*X=B
+ */
+VMatrix BorderedBandMatrix::solveBand(const VMatrix &aRightHandSide) const {
+
+	int nRow = theBand.getNumRows();
+	int nCol = theBand.getNumCols();
+	VMatrix aSolution(aRightHandSide);
+	for (unsigned int iBorder = 0; iBorder < numBorder; iBorder++) {
+		for (int i = 0; i < nCol; ++i) // forward substitution
+				{
+			for (int j = 1; j < std::min(nRow, nCol - i); ++j) {
+				aSolution(iBorder, j + i) -= theBand(j, i)
+						* aSolution(iBorder, i);
+			}
+		}
+		for (int i = nCol - 1; i >= 0; i--) // backward substitution
+				{
+			double rxw = theBand(0, i) * aSolution(iBorder, i);
+			for (int j = 1; j < std::min(nRow, nCol - i); ++j) {
+				rxw -= theBand(j, i) * aSolution(iBorder, j + i);
+			}
+			aSolution(iBorder, i) = rxw;
+		}
+	}
+	return aSolution;
+}
+
+/// Invert band part.
+/**
+ * \return Inverted band
+ */
+VMatrix BorderedBandMatrix::invertBand() {
+
+	int nRow = numBand + 1;
+	int nCol = numCol;
+	VMatrix inverseBand(nRow, nCol);
+
+	for (int i = nCol - 1; i >= 0; i--) {
+		double rxw = theBand(0, i);
+		for (int j = i; j >= std::max(0, i - nRow + 1); j--) {
+			for (int k = j + 1; k < std::min(nCol, j + nRow); ++k) {
+				rxw -= inverseBand(abs(i - k), std::min(i, k))
+						* theBand(k - j, j);
+			}
+			inverseBand(i - j, j) = rxw;
+			rxw = 0.;
+		}
+	}
+	return inverseBand;
+}
+
+/// Calculate band part of: 'anArray * aSymArray * anArray.T'.
+/**
+ * \return Band part of product
+ */
+VMatrix BorderedBandMatrix::bandOfAVAT(const VMatrix &anArray,
+		const VSymMatrix &aSymArray) const {
+	int nBand = numBand;
+	int nCol = numCol;
+	int nBorder = numBorder;
+	double sum;
+	VMatrix aBand((nBand + 1), nCol);
+	for (int i = 0; i < nCol; ++i) {
+		for (int j = std::max(0, i - nBand); j <= i; ++j) {
+			sum = 0.;
+			for (int l = 0; l < nBorder; ++l) { // diagonal
+				sum += anArray(i, l) * aSymArray(l, l) * anArray(j, l);
+				for (int k = 0; k < l; ++k) { // off diagonal
+					sum += anArray(i, l) * aSymArray(l, k) * anArray(j, k)
+							+ anArray(i, k) * aSymArray(l, k) * anArray(j, l);
+				}
+			}
+			aBand(i - j, j) = sum;
+		}
+	}
+	return aBand;
+}
+
+}

--- a/Alignment/ReferenceTrajectories/src/GblData.cc
+++ b/Alignment/ReferenceTrajectories/src/GblData.cc
@@ -1,0 +1,248 @@
+/*
+ * GblData.cpp
+ *
+ *  Created on: Aug 18, 2011
+ *      Author: kleinwrt
+ */
+
+#include "Alignment/ReferenceTrajectories/interface/GblData.h"
+
+//! Namespace for the general broken lines package
+namespace gbl {
+
+/// Create data block.
+/**
+ * \param [in] aLabel Label of corresponding point
+ * \param [in] aValue Value of (scalar) measurement
+ * \param [in] aPrec Precision of (scalar) measurement
+ */
+GblData::GblData(unsigned int aLabel, double aValue, double aPrec) :
+		theLabel(aLabel), theValue(aValue), thePrecision(aPrec), theDownWeight(
+				1.), thePrediction(0.), theParameters(), theDerivatives(), globalLabels(), globalDerivatives() {
+
+}
+
+GblData::~GblData() {
+}
+
+/// Add derivatives from measurement.
+/**
+ * Add (non-zero) derivatives to data block. Fill list of labels of used fit parameters.
+ * \param [in] iRow Row index (0-4) in up to 5D measurement
+ * \param [in] labDer Labels for derivatives
+ * \param [in] matDer Derivatives (matrix) 'measurement vs track fit parameters'
+ * \param [in] iOff Offset for row index for additional parameters
+ * \param [in] derLocal Derivatives (matrix) for additional local parameters
+ * \param [in] labGlobal Labels for additional global (MP-II) parameters
+ * \param [in] derGlobal Derivatives (matrix) for additional global (MP-II) parameters
+ * \param [in] extOff Offset for external parameters
+ * \param [in] extDer Derivatives for external Parameters
+ */
+void GblData::addDerivatives(unsigned int iRow,
+		const std::vector<unsigned int> &labDer, const SMatrix55 &matDer,
+		unsigned int iOff, const TMatrixD &derLocal,
+		const std::vector<int> &labGlobal, const TMatrixD &derGlobal,
+		unsigned int extOff, const TMatrixD &extDer) {
+
+	unsigned int nParMax = 5 + derLocal.GetNcols() + extDer.GetNcols();
+	theParameters.reserve(nParMax); // have to be sorted
+	theDerivatives.reserve(nParMax);
+
+	for (int i = 0; i < derLocal.GetNcols(); ++i) // local derivatives
+			{
+		if (derLocal(iRow - iOff, i)) {
+			theParameters.push_back(i + 1);
+			theDerivatives.push_back(derLocal(iRow - iOff, i));
+		}
+	}
+
+	for (int i = 0; i < extDer.GetNcols(); ++i) // external derivatives
+			{
+		if (extDer(iRow - iOff, i)) {
+			theParameters.push_back(extOff + i + 1);
+			theDerivatives.push_back(extDer(iRow - iOff, i));
+		}
+	}
+
+	for (unsigned int i = 0; i < 5; ++i) // curvature, offset derivatives
+			{
+		if (labDer[i] and matDer(iRow, i)) {
+			theParameters.push_back(labDer[i]);
+			theDerivatives.push_back(matDer(iRow, i));
+		}
+	}
+
+	globalLabels = labGlobal;
+	for (int i = 0; i < derGlobal.GetNcols(); ++i) // global derivatives
+		globalDerivatives.push_back(derGlobal(iRow - iOff, i));
+}
+
+/// Add derivatives from kink.
+/**
+ * Add (non-zero) derivatives to data block. Fill list of labels of used fit parameters.
+ * \param [in] iRow Row index (0-1) in 2D kink
+ * \param [in] labDer Labels for derivatives
+ * \param [in] matDer Derivatives (matrix) 'kink vs track fit parameters'
+ * \param [in] extOff Offset for external parameters
+ * \param [in] extDer Derivatives for external Parameters
+ */
+void GblData::addDerivatives(unsigned int iRow,
+		const std::vector<unsigned int> &labDer, const SMatrix27 &matDer,
+		unsigned int extOff, const TMatrixD &extDer) {
+
+	unsigned int nParMax = 7 + extDer.GetNcols();
+	theParameters.reserve(nParMax); // have to be sorted
+	theDerivatives.reserve(nParMax);
+
+	for (int i = 0; i < extDer.GetNcols(); ++i) // external derivatives
+			{
+		if (extDer(iRow, i)) {
+			theParameters.push_back(extOff + i + 1);
+			theDerivatives.push_back(extDer(iRow, i));
+		}
+	}
+
+	for (unsigned int i = 0; i < 7; ++i) // curvature, offset derivatives
+			{
+		if (labDer[i] and matDer(iRow, i)) {
+			theParameters.push_back(labDer[i]);
+			theDerivatives.push_back(matDer(iRow, i));
+		}
+	}
+}
+
+/// Add derivatives from external seed.
+/**
+ * Add (non-zero) derivatives to data block. Fill list of labels of used fit parameters.
+ * \param [in] index Labels for derivatives
+ * \param [in] derivatives Derivatives (vector)
+ */
+void GblData::addDerivatives(const std::vector<unsigned int> &index,
+		const std::vector<double> &derivatives) {
+	for (unsigned int i = 0; i < derivatives.size(); ++i) // any derivatives
+			{
+		if (derivatives[i]) {
+			theParameters.push_back(index[i]);
+			theDerivatives.push_back(derivatives[i]);
+		}
+	}
+}
+
+/// Calculate prediction for data from fit (by GblTrajectory::fit).
+void GblData::setPrediction(const VVector &aVector) {
+
+	thePrediction = 0.;
+	for (unsigned int i = 0; i < theDerivatives.size(); ++i) {
+		thePrediction += theDerivatives[i] * aVector(theParameters[i] - 1);
+	}
+}
+
+/// Outlier down weighting with M-estimators (by GblTrajectory::fit).
+/**
+ * \param [in] aMethod M-estimator (1: Tukey, 2:Huber, 3:Cauchy)
+ */
+double GblData::setDownWeighting(unsigned int aMethod) {
+
+	double aWeight = 1.;
+	double scaledResidual = fabs(theValue - thePrediction) * sqrt(thePrecision);
+	if (aMethod == 1) // Tukey
+			{
+		if (scaledResidual < 4.6851) {
+			aWeight = (1.0 - 0.045558 * scaledResidual * scaledResidual);
+			aWeight *= aWeight;
+		} else {
+			aWeight = 0.;
+		}
+	} else if (aMethod == 2) //Huber
+			{
+		if (scaledResidual >= 1.345) {
+			aWeight = 1.345 / scaledResidual;
+		}
+	} else if (aMethod == 3) //Cauchy
+			{
+		aWeight = 1.0 / (1.0 + (scaledResidual * scaledResidual / 5.6877));
+	}
+	theDownWeight = aWeight;
+	return aWeight;
+}
+
+/// Calculate Chi2 contribution.
+/**
+ * \return (down-weighted) Chi2
+ */
+double GblData::getChi2() const {
+	double aDiff = theValue - thePrediction;
+	return aDiff * aDiff * thePrecision * theDownWeight;
+}
+
+/// Print data block.
+void GblData::printData() const {
+
+	std::cout << " measurement at label " << theLabel << ": " << theValue
+			<< ", " << thePrecision << std::endl;
+	std::cout << "  param " << theParameters.size() << ":";
+	for (unsigned int i = 0; i < theParameters.size(); ++i) {
+		std::cout << " " << theParameters[i];
+	}
+	std::cout << std::endl;
+	std::cout << "  deriv " << theDerivatives.size() << ":";
+	for (unsigned int i = 0; i < theDerivatives.size(); ++i) {
+		std::cout << " " << theDerivatives[i];
+	}
+	std::cout << std::endl;
+}
+
+/// Get Data for local fit.
+/**
+ * \param [out] aValue Value
+ * \param [out] aWeight Weight
+ * \param [out] indLocal List of labels of used (local) fit parameters
+ * \param [out] derLocal List of derivatives for used (local) fit parameters
+ */
+void GblData::getLocalData(double &aValue, double &aWeight,
+		std::vector<unsigned int>* &indLocal, std::vector<double>* &derLocal) {
+
+	aValue = theValue;
+	aWeight = thePrecision * theDownWeight;
+	indLocal = &theParameters;
+	derLocal = &theDerivatives;
+}
+
+/// Get all Data for MP-II binary record.
+/**
+ * \param [out] aValue Value
+ * \param [out] aErr Error
+ * \param [out] indLocal List of labels of local parameters
+ * \param [out] derLocal List of derivatives for local parameters
+ * \param [out] labGlobal List of labels of global parameters
+ * \param [out] derGlobal List of derivatives for global parameters
+ */
+void GblData::getAllData(double &aValue, double &aErr,
+		std::vector<unsigned int>* &indLocal, std::vector<double>* &derLocal,
+		std::vector<int>* &labGlobal, std::vector<double>* &derGlobal) {
+	aValue = theValue;
+	aErr = 1.0 / sqrt(thePrecision);
+	indLocal = &theParameters;
+	derLocal = &theDerivatives;
+	labGlobal = &globalLabels;
+	derGlobal = &globalDerivatives;
+}
+
+/// Get data for residual (and errors).
+/**
+ * \param [out] aResidual Measurement-Prediction
+ * \param [out] aVariance Variance (of measurement)
+ * \param [out] aDownWeight Down-weighting factor
+ * \param [out] indLocal List of labels of used (local) fit parameters
+ * \param [out] derLocal List of derivatives for used (local) fit parameters
+ */
+void GblData::getResidual(double &aResidual, double &aVariance,
+		double &aDownWeight, std::vector<unsigned int>* &indLocal,
+		std::vector<double>* &derLocal) {
+	aResidual = theValue - thePrediction;
+	aVariance = 1.0 / thePrecision;
+	aDownWeight = theDownWeight;
+	indLocal = &theParameters;
+	derLocal = &theDerivatives;
+}
+}

--- a/Alignment/ReferenceTrajectories/src/GblPoint.cc
+++ b/Alignment/ReferenceTrajectories/src/GblPoint.cc
@@ -1,0 +1,489 @@
+/*
+ * GblPoint.cpp
+ *
+ *  Created on: Aug 18, 2011
+ *      Author: kleinwrt
+ */
+
+#include "Alignment/ReferenceTrajectories/interface/GblPoint.h"
+
+//! Namespace for the general broken lines package
+namespace gbl {
+
+/// Create a point.
+/**
+ * Create point on (initial) trajectory. Needs transformation jacobian from previous point.
+ * \param [in] aJacobian Transformation jacobian from previous point
+ */
+GblPoint::GblPoint(const TMatrixD &aJacobian) :
+		theLabel(0), theOffset(0), measDim(0), transFlag(false), measTransformation(), scatFlag(
+				false), localDerivatives(), globalLabels(), globalDerivatives() {
+
+	for (unsigned int i = 0; i < 5; ++i) {
+		for (unsigned int j = 0; j < 5; ++j) {
+			p2pJacobian(i, j) = aJacobian(i, j);
+		}
+	}
+}
+
+GblPoint::GblPoint(const SMatrix55 &aJacobian) :
+		theLabel(0), theOffset(0), p2pJacobian(aJacobian), measDim(0), transFlag(
+				false), measTransformation(), scatFlag(false), localDerivatives(), globalLabels(), globalDerivatives() {
+
+}
+
+GblPoint::~GblPoint() {
+}
+
+/// Add a measurement to a point.
+/**
+ * Add measurement (in meas. system) with diagonal precision (inverse covariance) matrix.
+ * ((up to) 2D: position, 4D: slope+position, 5D: curvature+slope+position)
+ * \param [in] aProjection Projection from local to measurement system
+ * \param [in] aResiduals Measurement residuals
+ * \param [in] aPrecision Measurement precision (diagonal)
+ * \param [in] minPrecision Minimal precision to accept measurement
+ */
+void GblPoint::addMeasurement(const TMatrixD &aProjection,
+		const TVectorD &aResiduals, const TVectorD &aPrecision,
+		double minPrecision) {
+	measDim = aResiduals.GetNrows();
+	unsigned int iOff = 5 - measDim;
+	for (unsigned int i = 0; i < measDim; ++i) {
+		measResiduals(iOff + i) = aResiduals[i];
+		measPrecision(iOff + i) = (
+				aPrecision[i] >= minPrecision ? aPrecision[i] : 0.);
+		for (unsigned int j = 0; j < measDim; ++j) {
+			measProjection(iOff + i, iOff + j) = aProjection(i, j);
+		}
+	}
+}
+
+/// Add a measurement to a point.
+/**
+ * Add measurement (in meas. system) with arbitrary precision (inverse covariance) matrix.
+ * Will be diagonalized.
+ * ((up to) 2D: position, 4D: slope+position, 5D: curvature+slope+position)
+ * \param [in] aProjection Projection from local to measurement system
+ * \param [in] aResiduals Measurement residuals
+ * \param [in] aPrecision Measurement precision (matrix)
+ * \param [in] minPrecision Minimal precision to accept measurement
+ */
+void GblPoint::addMeasurement(const TMatrixD &aProjection,
+		const TVectorD &aResiduals, const TMatrixDSym &aPrecision,
+		double minPrecision) {
+	measDim = aResiduals.GetNrows();
+	TMatrixDSymEigen measEigen(aPrecision);
+	measTransformation.ResizeTo(measDim, measDim);
+	measTransformation = measEigen.GetEigenVectors();
+	measTransformation.T();
+	transFlag = true;
+	TVectorD transResiduals = measTransformation * aResiduals;
+	TVectorD transPrecision = measEigen.GetEigenValues();
+	TMatrixD transProjection = measTransformation * aProjection;
+	unsigned int iOff = 5 - measDim;
+	for (unsigned int i = 0; i < measDim; ++i) {
+		measResiduals(iOff + i) = transResiduals[i];
+		measPrecision(iOff + i) = (
+				transPrecision[i] >= minPrecision ? transPrecision[i] : 0.);
+		for (unsigned int j = 0; j < measDim; ++j) {
+			measProjection(iOff + i, iOff + j) = transProjection(i, j);
+		}
+	}
+}
+
+/// Add a measurement to a point.
+/**
+ * Add measurement in local system with diagonal precision (inverse covariance) matrix.
+ * ((up to) 2D: position, 4D: slope+position, 5D: curvature+slope+position)
+ * \param [in] aResiduals Measurement residuals
+ * \param [in] aPrecision Measurement precision (diagonal)
+ * \param [in] minPrecision Minimal precision to accept measurement
+ */
+void GblPoint::addMeasurement(const TVectorD &aResiduals,
+		const TVectorD &aPrecision, double minPrecision) {
+	measDim = aResiduals.GetNrows();
+	unsigned int iOff = 5 - measDim;
+	for (unsigned int i = 0; i < measDim; ++i) {
+		measResiduals(iOff + i) = aResiduals[i];
+		measPrecision(iOff + i) = (
+				aPrecision[i] >= minPrecision ? aPrecision[i] : 0.);
+	}
+	measProjection = ROOT::Math::SMatrixIdentity();
+}
+
+/// Add a measurement to a point.
+/**
+ * Add measurement in local system with arbitrary precision (inverse covariance) matrix.
+ * Will be diagonalized.
+ * ((up to) 2D: position, 4D: slope+position, 5D: curvature+slope+position)
+ * \param [in] aResiduals Measurement residuals
+ * \param [in] aPrecision Measurement precision (matrix)
+ * \param [in] minPrecision Minimal precision to accept measurement
+ */
+void GblPoint::addMeasurement(const TVectorD &aResiduals,
+		const TMatrixDSym &aPrecision, double minPrecision) {
+	measDim = aResiduals.GetNrows();
+	TMatrixDSymEigen measEigen(aPrecision);
+	measTransformation.ResizeTo(measDim, measDim);
+	measTransformation = measEigen.GetEigenVectors();
+	measTransformation.T();
+	transFlag = true;
+	TVectorD transResiduals = measTransformation * aResiduals;
+	TVectorD transPrecision = measEigen.GetEigenValues();
+	unsigned int iOff = 5 - measDim;
+	for (unsigned int i = 0; i < measDim; ++i) {
+		measResiduals(iOff + i) = transResiduals[i];
+		measPrecision(iOff + i) = (
+				transPrecision[i] >= minPrecision ? transPrecision[i] : 0.);
+		for (unsigned int j = 0; j < measDim; ++j) {
+			measProjection(iOff + i, iOff + j) = measTransformation(i, j);
+		}
+	}
+}
+
+/// Check for measurement at a point.
+/**
+ * Get dimension of measurement (0 = none).
+ * \return measurement dimension
+ */
+unsigned int GblPoint::hasMeasurement() const {
+	return measDim;
+}
+
+/// Retrieve measurement of a point.
+/**
+ * \param [out] aProjection Projection from (diagonalized) measurement to local system
+ * \param [out] aResiduals Measurement residuals
+ * \param [out] aPrecision Measurement precision (diagonal)
+ */
+void GblPoint::getMeasurement(SMatrix55 &aProjection, SVector5 &aResiduals,
+		SVector5 &aPrecision) const {
+	aProjection = measProjection;
+	aResiduals = measResiduals;
+	aPrecision = measPrecision;
+}
+
+/// Get measurement transformation (from diagonalization).
+/**
+ * \param [out] aTransformation Transformation matrix
+ */
+void GblPoint::getMeasTransformation(TMatrixD &aTransformation) const {
+	aTransformation.ResizeTo(measDim, measDim);
+	if (transFlag) {
+		aTransformation = measTransformation;
+	} else {
+		aTransformation.UnitMatrix();
+	}
+}
+
+/// Add a (thin) scatterer to a point.
+/**
+ * Add scatterer with diagonal precision (inverse covariance) matrix.
+ * Changes local track direction.
+ *
+ * \param [in] aResiduals Scatterer residuals
+ * \param [in] aPrecision Scatterer precision (diagonal of inverse covariance matrix)
+ */
+void GblPoint::addScatterer(const TVectorD &aResiduals,
+		const TVectorD &aPrecision) {
+	scatFlag = true;
+	scatResiduals(0) = aResiduals[0];
+	scatResiduals(1) = aResiduals[1];
+	scatPrecision(0) = aPrecision[0];
+	scatPrecision(1) = aPrecision[1];
+	scatTransformation = ROOT::Math::SMatrixIdentity();
+}
+
+/// Add a (thin) scatterer to a point.
+/**
+ * Add scatterer with arbitrary precision (inverse covariance) matrix.
+ * Will be diagonalized. Changes local track direction.
+ *
+ * The precision matrix for the local slopes is defined by the
+ * angular scattering error theta_0 and the scalar products c_1, c_2 of the
+ * offset directions in the local frame with the track direction:
+ *
+ *            (1 - c_1*c_1 - c_2*c_2)   |  1 - c_1*c_1     - c_1*c_2  |
+ *       P =  ----------------------- * |                             |
+ *                theta_0*theta_0       |    - c_1*c_2   1 - c_2*c_2  |
+ *
+ * \param [in] aResiduals Scatterer residuals
+ * \param [in] aPrecision Scatterer precision (matrix)
+ */
+void GblPoint::addScatterer(const TVectorD &aResiduals,
+		const TMatrixDSym &aPrecision) {
+	scatFlag = true;
+	TMatrixDSymEigen scatEigen(aPrecision);
+	TMatrixD aTransformation = scatEigen.GetEigenVectors();
+	aTransformation.T();
+	TVectorD transResiduals = aTransformation * aResiduals;
+	TVectorD transPrecision = scatEigen.GetEigenValues();
+	for (unsigned int i = 0; i < 2; ++i) {
+		scatResiduals(i) = transResiduals[i];
+		scatPrecision(i) = transPrecision[i];
+		for (unsigned int j = 0; j < 2; ++j) {
+			scatTransformation(i, j) = aTransformation(i, j);
+		}
+	}
+}
+
+/// Check for scatterer at a point.
+bool GblPoint::hasScatterer() const {
+	return scatFlag;
+}
+
+/// Retrieve scatterer of a point.
+/**
+ * \param [out] aTransformation Scatterer transformation from diagonalization
+ * \param [out] aResiduals Scatterer residuals
+ * \param [out] aPrecision Scatterer precision (diagonal)
+ */
+void GblPoint::getScatterer(SMatrix22 &aTransformation, SVector2 &aResiduals,
+		SVector2 &aPrecision) const {
+	aTransformation = scatTransformation;
+	aResiduals = scatResiduals;
+	aPrecision = scatPrecision;
+}
+
+/// Get scatterer transformation (from diagonalization).
+/**
+ * \param [out] aTransformation Transformation matrix
+ */
+void GblPoint::getScatTransformation(TMatrixD &aTransformation) const {
+	aTransformation.ResizeTo(2, 2);
+	if (scatFlag) {
+		for (unsigned int i = 0; i < 2; ++i) {
+			for (unsigned int j = 0; j < 2; ++j) {
+				aTransformation(i, j) = scatTransformation(i, j);
+			}
+		}
+	} else {
+		aTransformation.UnitMatrix();
+	}
+}
+
+/// Add local derivatives to a point.
+/**
+ * Point needs to have a measurement.
+ * \param [in] aDerivatives Local derivatives (matrix)
+ */
+void GblPoint::addLocals(const TMatrixD &aDerivatives) {
+	if (measDim) {
+		localDerivatives.ResizeTo(aDerivatives);
+		if (transFlag) {
+			localDerivatives = measTransformation * aDerivatives;
+		} else {
+			localDerivatives = aDerivatives;
+		}
+	}
+}
+
+/// Retrieve number of local derivatives from a point.
+unsigned int GblPoint::getNumLocals() const {
+	return localDerivatives.GetNcols();
+}
+
+/// Retrieve local derivatives from a point.
+const TMatrixD& GblPoint::getLocalDerivatives() const {
+	return localDerivatives;
+}
+
+/// Add global derivatives to a point.
+/**
+ * Point needs to have a measurement.
+ * \param [in] aLabels Global derivatives labels
+ * \param [in] aDerivatives Global derivatives (matrix)
+ */
+void GblPoint::addGlobals(const std::vector<int> &aLabels,
+		const TMatrixD &aDerivatives) {
+	if (measDim) {
+		globalLabels = aLabels;
+		globalDerivatives.ResizeTo(aDerivatives);
+		if (transFlag) {
+			globalDerivatives = measTransformation * aDerivatives;
+		} else {
+			globalDerivatives = aDerivatives;
+		}
+
+	}
+}
+
+/// Retrieve number of global derivatives from a point.
+unsigned int GblPoint::getNumGlobals() const {
+	return globalDerivatives.GetNcols();
+}
+
+/// Retrieve global derivatives labels from a point.
+std::vector<int> GblPoint::getGlobalLabels() const {
+	return globalLabels;
+}
+
+/// Retrieve global derivatives from a point.
+const TMatrixD& GblPoint::getGlobalDerivatives() const {
+	return globalDerivatives;
+}
+
+/// Define label of point (by GBLTrajectory constructor)
+/**
+ * \param [in] aLabel Label identifying point
+ */
+void GblPoint::setLabel(unsigned int aLabel) {
+	theLabel = aLabel;
+}
+
+/// Retrieve label of point
+unsigned int GblPoint::getLabel() const {
+	return theLabel;
+}
+
+/// Define offset for point (by GBLTrajectory constructor)
+/**
+ * \param [in] anOffset Offset number
+ */
+void GblPoint::setOffset(int anOffset) {
+	theOffset = anOffset;
+}
+
+/// Retrieve offset for point
+int GblPoint::getOffset() const {
+	return theOffset;
+}
+
+/// Retrieve point-to-(previous)point jacobian
+const SMatrix55& GblPoint::getP2pJacobian() const {
+	return p2pJacobian;
+}
+
+/// Define jacobian to previous scatterer (by GBLTrajectory constructor)
+/**
+ * \param [in] aJac Jacobian
+ */
+void GblPoint::addPrevJacobian(const SMatrix55 &aJac) {
+	int ifail = 0;
+// to optimize: need only two last rows of inverse
+//	prevJacobian = aJac.InverseFast(ifail);
+//  block matrix algebra
+	SMatrix23 CA = aJac.Sub<SMatrix23>(3, 0)
+			* aJac.Sub<SMatrix33>(0, 0).InverseFast(ifail); // C*A^-1
+	SMatrix22 DCAB = aJac.Sub<SMatrix22>(3, 3) - CA * aJac.Sub<SMatrix32>(0, 3); // D - C*A^-1 *B
+	DCAB.InvertFast();
+	prevJacobian.Place_at(DCAB, 3, 3);
+	prevJacobian.Place_at(-DCAB * CA, 3, 0);
+}
+
+/// Define jacobian to next scatterer (by GBLTrajectory constructor)
+/**
+ * \param [in] aJac Jacobian
+ */
+void GblPoint::addNextJacobian(const SMatrix55 &aJac) {
+	nextJacobian = aJac;
+}
+
+/// Retrieve derivatives of local track model
+/**
+ * Linearized track model: F_u(q/p,u',u) = J*u + S*u' + d*q/p,
+ * W is inverse of S, negated for backward propagation.
+ * \param [in] aDirection Propagation direction (>0 forward, else backward)
+ * \param [out] matW W
+ * \param [out] matWJ W*J
+ * \param [out] vecWd W*d
+ * \exception std::overflow_error : matrix S is singular.
+ */
+void GblPoint::getDerivatives(int aDirection, SMatrix22 &matW, SMatrix22 &matWJ,
+		SVector2 &vecWd) const {
+
+	SMatrix22 matJ;
+	SVector2 vecd;
+	if (aDirection < 1) {
+		matJ = prevJacobian.Sub<SMatrix22>(3, 3);
+		matW = -prevJacobian.Sub<SMatrix22>(3, 1);
+		vecd = prevJacobian.SubCol<SVector2>(0, 3);
+	} else {
+		matJ = nextJacobian.Sub<SMatrix22>(3, 3);
+		matW = nextJacobian.Sub<SMatrix22>(3, 1);
+		vecd = nextJacobian.SubCol<SVector2>(0, 3);
+	}
+
+	if (!matW.InvertFast()) {
+		std::cout << " GblPoint::getDerivatives failed to invert matrix: "
+				<< matW << std::endl;
+		std::cout
+				<< " Possible reason for singular matrix: multiple GblPoints at same arc-length"
+				<< std::endl;
+		throw std::overflow_error("Singular matrix inversion exception");
+	}
+	matWJ = matW * matJ;
+	vecWd = matW * vecd;
+
+}
+
+/// Print GblPoint
+/**
+ * \param [in] level print level (0: minimum, >0: more)
+ */
+void GblPoint::printPoint(unsigned int level) const {
+	std::cout << " GblPoint";
+	if (theLabel) {
+		std::cout << ", label " << theLabel;
+		if (theOffset >= 0) {
+			std::cout << ", offset " << theOffset;
+		}
+	}
+	if (measDim) {
+		std::cout << ", " << measDim << " measurements";
+	}
+	if (scatFlag) {
+		std::cout << ", scatterer";
+	}
+	if (transFlag) {
+		std::cout << ", diagonalized";
+	}
+	if (localDerivatives.GetNcols()) {
+		std::cout << ", " << localDerivatives.GetNcols()
+				<< " local derivatives";
+	}
+	if (globalDerivatives.GetNcols()) {
+		std::cout << ", " << globalDerivatives.GetNcols()
+				<< " global derivatives";
+	}
+	std::cout << std::endl;
+	if (level > 0) {
+		if (measDim) {
+			std::cout << "  Measurement" << std::endl;
+			std::cout << "   Projection: " << std::endl << measProjection
+					<< std::endl;
+			std::cout << "   Residuals: " << measResiduals << std::endl;
+			std::cout << "   Precision: " << measPrecision << std::endl;
+		}
+		if (scatFlag) {
+			std::cout << "  Scatterer" << std::endl;
+			std::cout << "   Residuals: " << scatResiduals << std::endl;
+			std::cout << "   Precision: " << scatPrecision << std::endl;
+		}
+		if (localDerivatives.GetNcols()) {
+			std::cout << "  Local Derivatives:" << std::endl;
+			localDerivatives.Print();
+		}
+		if (globalDerivatives.GetNcols()) {
+			std::cout << "  Global Labels:";
+			for (unsigned int i = 0; i < globalLabels.size(); ++i) {
+				std::cout << " " << globalLabels[i];
+			}
+			std::cout << std::endl;
+			std::cout << "  Global Derivatives:" << std::endl;
+			globalDerivatives.Print();
+		}
+		std::cout << "  Jacobian " << std::endl;
+		std::cout << "   Point-to-point " << std::endl << p2pJacobian
+				<< std::endl;
+		if (theLabel) {
+			std::cout << "   To previous offset " << std::endl << prevJacobian
+					<< std::endl;
+			std::cout << "   To next offset " << std::endl << nextJacobian
+					<< std::endl;
+		}
+	}
+}
+
+}

--- a/Alignment/ReferenceTrajectories/src/GblTrajectory.cc
+++ b/Alignment/ReferenceTrajectories/src/GblTrajectory.cc
@@ -1,0 +1,1116 @@
+/*
+ * GblTrajectory.cpp
+ *
+ *  Created on: Aug 18, 2011
+ *      Author: kleinwrt
+ *    Revision: 113
+ */
+
+/** \file GBL general information
+ *
+ *  \section intro_sec Introduction
+ *
+ *  For a track with an initial trajectory from a prefit of the
+ *  measurements (internal seed) or an external prediction
+ *  (external seed) the description of multiple scattering is
+ *  added by offsets in a local system. Along the initial
+ *  trajectory points are defined with can describe a measurement
+ *  or a (thin) scatterer or both. Measurements are arbitrary
+ *  functions of the local track parameters at a point (e.g. 2D:
+ *  position, 4D: direction+position). The refit provides corrections
+ *  to the local track parameters (in the local system) and the
+ *  corresponding covariance matrix at any of those points.
+ *  Non-diagonal covariance matrices will be diagonalized internally.
+ *  Outliers can be down-weighted by use of M-estimators.
+ *
+ *  The broken lines trajectory is defined by (2D) offsets at the
+ *  first and last point and all points with a scatterer. The
+ *  prediction for a measurement is obtained by interpolation of
+ *  the enclosing offsets and for triplets of adjacent offsets
+ *  kink angles are determined. This requires for all points the
+ *  jacobians for propagation to the previous and next offset.
+ *  These are calculated from the point-to-point jacobians along
+ *  the initial trajectory. The sequence of points has to be
+ *  strictly monotonic in arc-length.
+ *
+ *  Additional local or global parameters can be added and the
+ *  trajectories can be written to special binary files for
+ *  calibration and alignment with Millepede-II.
+ *  (V. Blobel, NIM A, 566 (2006), pp. 5-13).
+ *
+ *  Besides simple trajectories describing the path of a single
+ *  particle composed trajectories are supported. These are
+ *  constructed from the trajectories of multiple particles and
+ *  some external parameters (like those describing a decay)
+ *  and transformations at the first points from the external
+ *  to the local track parameters.
+ *
+ *  The conventions for the coordinate systems follow:
+ *  Derivation of Jacobians for the propagation of covariance
+ *  matrices of track parameters in homogeneous magnetic fields
+ *  A. Strandlie, W. Wittek, NIM A, 566 (2006) 687-698.
+ *
+ *  \section call_sec Calling sequence
+ *
+ *    -# Create list of points on initial trajectory:\n
+ *            <tt>std::vector<GblPoint> list</tt>
+ *    -# For all points on initial trajectory:
+ *        - Create points and add appropriate attributes:\n
+ *           - <tt>point = gbl::GblPoint(..)</tt>
+ *           - <tt>point.addMeasurement(..)</tt>
+ *           - Add additional local or global parameters to measurement:\n
+ *             - <tt>point.addLocals(..)</tt>
+ *             - <tt>point.addGlobals(..)</tt>
+ *           - <tt>point.addScatterer(..)</tt>
+ *        - Add point (ordered by arc length) to list:\n
+ *            <tt>list.push_back(point)</tt>
+ *    -# Create (simple) trajectory from list of points:\n
+ *            <tt>traj = gbl::GblTrajectory (list)</tt>
+ *    -# Optionally with external seed:\n
+ *            <tt>traj = gbl::GblTrajectory (list,seed)</tt>
+ *    -# Optionally check validity of trajectory:\n
+ *            <tt>if (not traj.isValid()) .. //abort</tt>
+ *    -# Fit trajectory, return error code,
+ *       get Chi2, Ndf (and weight lost by M-estimators):\n
+ *            <tt>ierr = traj.fit(..)</tt>
+ *    -# For any point on initial trajectory:
+ *        - Get corrections and covariance matrix for track parameters:\n
+ *            <tt>[..] = traj.getResults(label)</tt>
+ *    -# Optionally write trajectory to MP binary file (doesn't needs to be fitted):\n
+ *            <tt>traj.milleOut(..)</tt>
+ *
+ *  \section loc_sec Local system and local parameters
+ *  At each point on the trajectory a local coordinate system with local track
+ *  parameters has to be defined. The first of the five parameters describes
+ *  the bending, the next two the direction and the last two the position (offsets).
+ *  The curvilinear system (T,U,V) with parameters (q/p, lambda, phi, x_t, y_t)
+ *  is well suited.
+ *
+ *  \section impl_sec Implementation
+ *
+ *  Matrices are implemented with ROOT (root.cern.ch). User input or output is in the
+ *  form of TMatrices. Internally SMatrices are used for fixes sized and simple matrices
+ *  based on std::vector<> for variable sized matrices.
+ *
+ *  \section ref_sec References
+ *    - V. Blobel, C. Kleinwort, F. Meier,
+ *      Fast alignment of a complex tracking detector using advanced track models,
+ *      Computer Phys. Communications (2011), doi:10.1016/j.cpc.2011.03.017
+ *    - C. Kleinwort, General Broken Lines as advanced track fitting method,
+ *      NIM A, 673 (2012), 107-110, doi:10.1016/j.nima.2012.01.024
+ */
+
+#include "Alignment/ReferenceTrajectories/interface/GblTrajectory.h"
+
+//! Namespace for the general broken lines package
+namespace gbl {
+
+/// Create new (simple) trajectory from list of points.
+/**
+ * Curved trajectory in space (default) or without curvature (q/p) or in one
+ * plane (u-direction) only.
+ * \param [in] aPointList List of points
+ * \param [in] flagCurv Use q/p
+ * \param [in] flagU1dir Use in u1 direction
+ * \param [in] flagU2dir Use in u2 direction
+ */
+GblTrajectory::GblTrajectory(const std::vector<GblPoint> &aPointList,
+		bool flagCurv, bool flagU1dir, bool flagU2dir) :
+		numAllPoints(aPointList.size()), numPoints(), numOffsets(0), numInnerTrans(
+				0), numCurvature(flagCurv ? 1 : 0), numParameters(0), numLocals(
+				0), numMeasurements(0), externalPoint(0), theDimension(0), thePoints(), theData(), measDataIndex(), scatDataIndex(), externalSeed(), innerTransformations(), externalDerivatives(), externalMeasurements(), externalPrecisions() {
+
+	if (flagU1dir)
+		theDimension.push_back(0);
+	if (flagU2dir)
+		theDimension.push_back(1);
+	// simple (single) trajectory
+	thePoints.push_back(aPointList);
+	numPoints.push_back(numAllPoints);
+	construct(); // construct trajectory
+}
+
+/// Create new (simple) trajectory from list of points with external seed.
+/**
+ * Curved trajectory in space (default) or without curvature (q/p) or in one
+ * plane (u-direction) only.
+ * \param [in] aPointList List of points
+ * \param [in] aLabel (Signed) label of point for external seed
+ * (<0: in front, >0: after point, slope changes at scatterer!)
+ * \param [in] aSeed Precision matrix of external seed
+ * \param [in] flagCurv Use q/p
+ * \param [in] flagU1dir Use in u1 direction
+ * \param [in] flagU2dir Use in u2 direction
+ */
+GblTrajectory::GblTrajectory(const std::vector<GblPoint> &aPointList,
+		unsigned int aLabel, const TMatrixDSym &aSeed, bool flagCurv,
+		bool flagU1dir, bool flagU2dir) :
+		numAllPoints(aPointList.size()), numPoints(), numOffsets(0), numInnerTrans(
+				0), numCurvature(flagCurv ? 1 : 0), numParameters(0), numLocals(
+				0), numMeasurements(0), externalPoint(aLabel), theDimension(0), thePoints(), theData(), measDataIndex(), scatDataIndex(), externalSeed(
+				aSeed), innerTransformations(), externalDerivatives(), externalMeasurements(), externalPrecisions() {
+
+	if (flagU1dir)
+		theDimension.push_back(0);
+	if (flagU2dir)
+		theDimension.push_back(1);
+	// simple (single) trajectory
+	thePoints.push_back(aPointList);
+	numPoints.push_back(numAllPoints);
+	construct(); // construct trajectory
+}
+
+/// Create new composed trajectory from list of points and transformations.
+/**
+ * Composed of curved trajectory in space.
+ * \param [in] aPointsAndTransList List containing pairs with list of points and transformation (at inner (first) point)
+ */
+GblTrajectory::GblTrajectory(
+		const std::vector<std::pair<std::vector<GblPoint>, TMatrixD> > &aPointsAndTransList) :
+		numAllPoints(), numPoints(), numOffsets(0), numInnerTrans(
+				aPointsAndTransList.size()), numParameters(0), numLocals(0), numMeasurements(
+				0), externalPoint(0), theDimension(0), thePoints(), theData(), measDataIndex(), scatDataIndex(), externalSeed(), innerTransformations(), externalDerivatives(), externalMeasurements(), externalPrecisions() {
+
+	for (unsigned int iTraj = 0; iTraj < aPointsAndTransList.size(); ++iTraj) {
+		thePoints.push_back(aPointsAndTransList[iTraj].first);
+		numPoints.push_back(thePoints.back().size());
+		numAllPoints += numPoints.back();
+		innerTransformations.push_back(aPointsAndTransList[iTraj].second);
+	}
+	theDimension.push_back(0);
+	theDimension.push_back(1);
+	numCurvature = innerTransformations[0].GetNcols();
+	construct(); // construct (composed) trajectory
+}
+
+/// Create new composed trajectory from list of points and transformations with (independent) external measurements.
+/**
+ * Composed of curved trajectory in space.
+ * \param [in] aPointsAndTransList List containing pairs with list of points and transformation (at inner (first) point)
+ * \param [in] extDerivatives Derivatives of external measurements vs external parameters
+ * \param [in] extMeasurements External measurements (residuals)
+ * \param [in] extPrecisions Precision of external measurements
+ */
+GblTrajectory::GblTrajectory(
+		const std::vector<std::pair<std::vector<GblPoint>, TMatrixD> > &aPointsAndTransList,
+		const TMatrixD &extDerivatives, const TVectorD &extMeasurements,
+		const TVectorD &extPrecisions) :
+		numAllPoints(), numPoints(), numOffsets(0), numInnerTrans(
+				aPointsAndTransList.size()), numParameters(0), numLocals(0), numMeasurements(
+				0), externalPoint(0), theDimension(0), thePoints(), theData(), measDataIndex(), scatDataIndex(), externalSeed(), innerTransformations(), externalDerivatives(
+				extDerivatives), externalMeasurements(extMeasurements), externalPrecisions(
+				extPrecisions) {
+
+	for (unsigned int iTraj = 0; iTraj < aPointsAndTransList.size(); ++iTraj) {
+		thePoints.push_back(aPointsAndTransList[iTraj].first);
+		numPoints.push_back(thePoints.back().size());
+		numAllPoints += numPoints.back();
+		innerTransformations.push_back(aPointsAndTransList[iTraj].second);
+	}
+	theDimension.push_back(0);
+	theDimension.push_back(1);
+	numCurvature = innerTransformations[0].GetNcols();
+	construct(); // construct (composed) trajectory
+}
+
+GblTrajectory::~GblTrajectory() {
+}
+
+/// Retrieve validity of trajectory
+bool GblTrajectory::isValid() const {
+	return constructOK;
+}
+
+/// Retrieve number of point from trajectory
+unsigned int GblTrajectory::getNumPoints() const {
+	return numAllPoints;
+}
+
+/// Construct trajectory from list of points.
+/**
+ * Trajectory is prepared for fit or output to binary file, may consists of sub-trajectories.
+ */
+void GblTrajectory::construct() {
+
+	constructOK = false;
+	fitOK = false;
+	unsigned int aLabel = 0;
+	if (numAllPoints < 2) {
+		std::cout << " GblTrajectory construction failed: too few GblPoints "
+				<< std::endl;
+		return;
+	}
+	// loop over trajectories
+	numTrajectories = thePoints.size();
+	//std::cout << " numTrajectories: " << numTrajectories << ", " << innerTransformations.size() << std::endl;
+	for (unsigned int iTraj = 0; iTraj < numTrajectories; ++iTraj) {
+		std::vector<GblPoint>::iterator itPoint;
+		for (itPoint = thePoints[iTraj].begin();
+				itPoint < thePoints[iTraj].end(); ++itPoint) {
+			numLocals = std::max(numLocals, itPoint->getNumLocals());
+			numMeasurements += itPoint->hasMeasurement();
+			itPoint->setLabel(++aLabel);
+		}
+	}
+	defineOffsets();
+	calcJacobians();
+	try {
+		prepare();
+	} catch (std::overflow_error &e) {
+		std::cout << " GblTrajectory construction failed: " << e.what()
+				<< std::endl;
+		return;
+	}
+	constructOK = true;
+	// number of fit parameters
+	numParameters = (numOffsets - 2 * numInnerTrans) * theDimension.size()
+			+ numCurvature + numLocals;
+}
+
+/// Define offsets from list of points.
+/**
+ * Define offsets at points with scatterers and first and last point.
+ * All other points need interpolation from adjacent points with offsets.
+ */
+void GblTrajectory::defineOffsets() {
+
+	// loop over trajectories
+	for (unsigned int iTraj = 0; iTraj < numTrajectories; ++iTraj) {
+		// first point is offset
+		thePoints[iTraj].front().setOffset(numOffsets++);
+		// intermediate scatterers are offsets
+		std::vector<GblPoint>::iterator itPoint;
+		for (itPoint = thePoints[iTraj].begin() + 1;
+				itPoint < thePoints[iTraj].end() - 1; ++itPoint) {
+			if (itPoint->hasScatterer()) {
+				itPoint->setOffset(numOffsets++);
+			} else {
+				itPoint->setOffset(-numOffsets);
+			}
+		}
+		// last point is offset
+		thePoints[iTraj].back().setOffset(numOffsets++);
+	}
+}
+
+/// Calculate Jacobians to previous/next scatterer from point to point ones.
+void GblTrajectory::calcJacobians() {
+
+	SMatrix55 scatJacobian;
+	// loop over trajectories
+	for (unsigned int iTraj = 0; iTraj < numTrajectories; ++iTraj) {
+		// forward propagation (all)
+		GblPoint* previousPoint = &thePoints[iTraj].front();
+		unsigned int numStep = 0;
+		std::vector<GblPoint>::iterator itPoint;
+		for (itPoint = thePoints[iTraj].begin() + 1;
+				itPoint < thePoints[iTraj].end(); ++itPoint) {
+			if (numStep == 0) {
+				scatJacobian = itPoint->getP2pJacobian();
+			} else {
+				scatJacobian = itPoint->getP2pJacobian() * scatJacobian;
+			}
+			numStep++;
+			itPoint->addPrevJacobian(scatJacobian); // iPoint -> previous scatterer
+			if (itPoint->getOffset() >= 0) {
+				previousPoint->addNextJacobian(scatJacobian); // lastPoint -> next scatterer
+				numStep = 0;
+				previousPoint = &(*itPoint);
+			}
+		}
+		// backward propagation (without scatterers)
+		for (itPoint = thePoints[iTraj].end() - 1;
+				itPoint > thePoints[iTraj].begin(); --itPoint) {
+			if (itPoint->getOffset() >= 0) {
+				scatJacobian = itPoint->getP2pJacobian();
+				continue; // skip offsets
+			}
+			itPoint->addNextJacobian(scatJacobian); // iPoint -> next scatterer
+			scatJacobian = scatJacobian * itPoint->getP2pJacobian();
+		}
+	}
+}
+
+/// Get jacobian for transformation from fit to track parameters at point.
+/**
+ * Jacobian broken lines (q/p,..,u_i,u_i+1..) to track (q/p,u',u) parameters
+ * including additional local parameters.
+ * \param [in] aSignedLabel (Signed) label of point for external seed
+ * (<0: in front, >0: after point, slope changes at scatterer!)
+ * \return List of fit parameters with non zero derivatives and
+ * corresponding transformation matrix
+ */
+std::pair<std::vector<unsigned int>, TMatrixD> GblTrajectory::getJacobian(
+		int aSignedLabel) const {
+
+	unsigned int nDim = theDimension.size();
+	unsigned int nCurv = numCurvature;
+	unsigned int nLocals = numLocals;
+	unsigned int nBorder = nCurv + nLocals;
+	unsigned int nParBRL = nBorder + 2 * nDim;
+	unsigned int nParLoc = nLocals + 5;
+	std::vector<unsigned int> anIndex;
+	anIndex.reserve(nParBRL);
+	TMatrixD aJacobian(nParLoc, nParBRL);
+	aJacobian.Zero();
+
+	unsigned int aLabel = abs(aSignedLabel);
+	unsigned int firstLabel = 1;
+	unsigned int lastLabel = 0;
+	unsigned int aTrajectory = 0;
+	// loop over trajectories
+	for (unsigned int iTraj = 0; iTraj < numTrajectories; ++iTraj) {
+		aTrajectory = iTraj;
+		lastLabel += numPoints[iTraj];
+		if (aLabel <= lastLabel)
+			break;
+		if (iTraj < numTrajectories - 1)
+			firstLabel += numPoints[iTraj];
+	}
+	int nJacobian; // 0: prev, 1: next
+	// check consistency of (index, direction)
+	if (aSignedLabel > 0) {
+		nJacobian = 1;
+		if (aLabel >= lastLabel) {
+			aLabel = lastLabel;
+			nJacobian = 0;
+		}
+	} else {
+		nJacobian = 0;
+		if (aLabel <= firstLabel) {
+			aLabel = firstLabel;
+			nJacobian = 1;
+		}
+	}
+	const GblPoint aPoint = thePoints[aTrajectory][aLabel - firstLabel];
+	std::vector<unsigned int> labDer(5);
+	SMatrix55 matDer;
+	getFitToLocalJacobian(labDer, matDer, aPoint, 5, nJacobian);
+
+	// from local parameters
+	for (unsigned int i = 0; i < nLocals; ++i) {
+		aJacobian(i + 5, i) = 1.0;
+		anIndex.push_back(i + 1);
+	}
+	// from trajectory parameters
+	unsigned int iCol = nLocals;
+	for (unsigned int i = 0; i < 5; ++i) {
+		if (labDer[i] > 0) {
+			anIndex.push_back(labDer[i]);
+			for (unsigned int j = 0; j < 5; ++j) {
+				aJacobian(j, iCol) = matDer(j, i);
+			}
+			++iCol;
+		}
+	}
+	return std::make_pair(anIndex, aJacobian);
+}
+
+/// Get (part of) jacobian for transformation from (trajectory) fit to track parameters at point.
+/**
+ * Jacobian broken lines (q/p,..,u_i,u_i+1..) to local (q/p,u',u) parameters.
+ * \param [out] anIndex List of fit parameters with non zero derivatives
+ * \param [out] aJacobian Corresponding transformation matrix
+ * \param [in] aPoint Point to use
+ * \param [in] measDim Dimension of 'measurement'
+ * (<=2: calculate only offset part, >2: complete matrix)
+ * \param [in] nJacobian Direction (0: to previous offset, 1: to next offset)
+ */
+void GblTrajectory::getFitToLocalJacobian(std::vector<unsigned int> &anIndex,
+		SMatrix55 &aJacobian, const GblPoint &aPoint, unsigned int measDim,
+		unsigned int nJacobian) const {
+
+	unsigned int nDim = theDimension.size();
+	unsigned int nCurv = numCurvature;
+	unsigned int nLocals = numLocals;
+
+	int nOffset = aPoint.getOffset();
+
+	if (nOffset < 0) // need interpolation
+			{
+		SMatrix22 prevW, prevWJ, nextW, nextWJ, matN;
+		SVector2 prevWd, nextWd;
+		int ierr;
+		aPoint.getDerivatives(0, prevW, prevWJ, prevWd); // W-, W- * J-, W- * d-
+		aPoint.getDerivatives(1, nextW, nextWJ, nextWd); // W-, W- * J-, W- * d-
+		const SMatrix22 sumWJ(prevWJ + nextWJ);
+		matN = sumWJ.Inverse(ierr); // N = (W- * J- + W+ * J+)^-1
+		// derivatives for u_int
+		const SMatrix22 prevNW(matN * prevW); // N * W-
+		const SMatrix22 nextNW(matN * nextW); // N * W+
+		const SVector2 prevNd(matN * prevWd); // N * W- * d-
+		const SVector2 nextNd(matN * nextWd); // N * W+ * d+
+
+		unsigned int iOff = nDim * (-nOffset - 1) + nLocals + nCurv + 1; // first offset ('i' in u_i)
+
+		// local offset
+		if (nCurv > 0) {
+			aJacobian.Place_in_col(-prevNd - nextNd, 3, 0); // from curvature
+			anIndex[0] = nLocals + 1;
+		}
+		aJacobian.Place_at(prevNW, 3, 1); // from 1st Offset
+		aJacobian.Place_at(nextNW, 3, 3); // from 2nd Offset
+		for (unsigned int i = 0; i < nDim; ++i) {
+			anIndex[1 + theDimension[i]] = iOff + i;
+			anIndex[3 + theDimension[i]] = iOff + nDim + i;
+		}
+
+		// local slope and curvature
+		if (measDim > 2) {
+			// derivatives for u'_int
+			const SMatrix22 prevWPN(nextWJ * prevNW); // W+ * J+ * N * W-
+			const SMatrix22 nextWPN(prevWJ * nextNW); // W- * J- * N * W+
+			const SVector2 prevWNd(nextWJ * prevNd); // W+ * J+ * N * W- * d-
+			const SVector2 nextWNd(prevWJ * nextNd); // W- * J- * N * W+ * d+
+			if (nCurv > 0) {
+				aJacobian(0, 0) = 1.0;
+				aJacobian.Place_in_col(prevWNd - nextWNd, 1, 0); // from curvature
+			}
+			aJacobian.Place_at(-prevWPN, 1, 1); // from 1st Offset
+			aJacobian.Place_at(nextWPN, 1, 3); // from 2nd Offset
+		}
+	} else { // at point
+		// anIndex must be sorted
+		// forward : iOff2 = iOff1 + nDim, index1 = 1, index2 = 3
+		// backward: iOff2 = iOff1 - nDim, index1 = 3, index2 = 1
+		unsigned int iOff1 = nDim * nOffset + nCurv + nLocals + 1; // first offset ('i' in u_i)
+		unsigned int index1 = 3 - 2 * nJacobian; // index of first offset
+		unsigned int iOff2 = iOff1 + nDim * (nJacobian * 2 - 1); // second offset ('i' in u_i)
+		unsigned int index2 = 1 + 2 * nJacobian; // index of second offset
+		// local offset
+		aJacobian(3, index1) = 1.0; // from 1st Offset
+		aJacobian(4, index1 + 1) = 1.0;
+		for (unsigned int i = 0; i < nDim; ++i) {
+			anIndex[index1 + theDimension[i]] = iOff1 + i;
+		}
+
+		// local slope and curvature
+		if (measDim > 2) {
+			SMatrix22 matW, matWJ;
+			SVector2 vecWd;
+			aPoint.getDerivatives(nJacobian, matW, matWJ, vecWd); // W, W * J, W * d
+			double sign = (nJacobian > 0) ? 1. : -1.;
+			if (nCurv > 0) {
+				aJacobian(0, 0) = 1.0;
+				aJacobian.Place_in_col(-sign * vecWd, 1, 0); // from curvature
+				anIndex[0] = nLocals + 1;
+			}
+			aJacobian.Place_at(-sign * matWJ, 1, index1); // from 1st Offset
+			aJacobian.Place_at(sign * matW, 1, index2); // from 2nd Offset
+			for (unsigned int i = 0; i < nDim; ++i) {
+				anIndex[index2 + theDimension[i]] = iOff2 + i;
+			}
+		}
+	}
+}
+
+/// Get jacobian for transformation from (trajectory) fit to kink parameters at point.
+/**
+ * Jacobian broken lines (q/p,..,u_i-1,u_i,u_i+1..) to kink (du') parameters.
+ * \param [out] anIndex List of fit parameters with non zero derivatives
+ * \param [out] aJacobian Corresponding transformation matrix
+ * \param [in] aPoint Point to use
+ */
+void GblTrajectory::getFitToKinkJacobian(std::vector<unsigned int> &anIndex,
+		SMatrix27 &aJacobian, const GblPoint &aPoint) const {
+
+	unsigned int nDim = theDimension.size();
+	unsigned int nCurv = numCurvature;
+	unsigned int nLocals = numLocals;
+
+	int nOffset = aPoint.getOffset();
+
+	SMatrix22 prevW, prevWJ, nextW, nextWJ;
+	SVector2 prevWd, nextWd;
+	aPoint.getDerivatives(0, prevW, prevWJ, prevWd); // W-, W- * J-, W- * d-
+	aPoint.getDerivatives(1, nextW, nextWJ, nextWd); // W-, W- * J-, W- * d-
+	const SMatrix22 sumWJ(prevWJ + nextWJ); // W- * J- + W+ * J+
+	const SVector2 sumWd(prevWd + nextWd); // W+ * d+ + W- * d-
+
+	unsigned int iOff = (nOffset - 1) * nDim + nCurv + nLocals + 1; // first offset ('i' in u_i)
+
+	// local offset
+	if (nCurv > 0) {
+		aJacobian.Place_in_col(-sumWd, 0, 0); // from curvature
+		anIndex[0] = nLocals + 1;
+	}
+	aJacobian.Place_at(prevW, 0, 1); // from 1st Offset
+	aJacobian.Place_at(-sumWJ, 0, 3); // from 2nd Offset
+	aJacobian.Place_at(nextW, 0, 5); // from 1st Offset
+	for (unsigned int i = 0; i < nDim; ++i) {
+		anIndex[1 + theDimension[i]] = iOff + i;
+		anIndex[3 + theDimension[i]] = iOff + nDim + i;
+		anIndex[5 + theDimension[i]] = iOff + nDim * 2 + i;
+	}
+}
+
+/// Get fit results at point.
+/**
+ * Get corrections and covariance matrix for local track and additional parameters
+ * in forward or backward direction.
+ * \param [in] aSignedLabel (Signed) label of point on trajectory
+ * (<0: in front, >0: after point, slope changes at scatterer!)
+ * \param [out] localPar Corrections for local parameters
+ * \param [out] localCov Covariance for local parameters
+ * \return error code (non-zero if trajectory not fitted successfully)
+ */
+unsigned int GblTrajectory::getResults(int aSignedLabel, TVectorD &localPar,
+		TMatrixDSym &localCov) const {
+	if (not fitOK)
+		return 1;
+	std::pair<std::vector<unsigned int>, TMatrixD> indexAndJacobian =
+			getJacobian(aSignedLabel);
+	unsigned int nParBrl = indexAndJacobian.first.size();
+	TVectorD aVec(nParBrl); // compressed vector
+	for (unsigned int i = 0; i < nParBrl; ++i) {
+		aVec[i] = theVector(indexAndJacobian.first[i] - 1);
+	}
+	TMatrixDSym aMat = theMatrix.getBlockMatrix(indexAndJacobian.first); // compressed matrix
+	localPar = indexAndJacobian.second * aVec;
+	localCov = aMat.Similarity(indexAndJacobian.second);
+	return 0;
+}
+
+/// Get residuals at point from measurement.
+/**
+ * Get (diagonalized) residual, error of measurement and residual and down-weighting
+ * factor for measurement at point
+ *
+ * \param [in]  aLabel Label of point on trajectory
+ * \param [out] numData Number of data blocks from measurement at point
+ * \param [out] aResiduals Measurements-Predictions
+ * \param [out] aMeasErrors Errors of Measurements
+ * \param [out] aResErrors Errors of Residuals (including correlations from track fit)
+ * \param [out] aDownWeights Down-Weighting factors
+ * \return error code (non-zero if trajectory not fitted successfully)
+ */
+unsigned int GblTrajectory::getMeasResults(unsigned int aLabel,
+		unsigned int &numData, TVectorD &aResiduals, TVectorD &aMeasErrors,
+		TVectorD &aResErrors, TVectorD &aDownWeights) {
+	numData = 0;
+	if (not fitOK)
+		return 1;
+
+	unsigned int firstData = measDataIndex[aLabel - 1]; // first data block with measurement
+	numData = measDataIndex[aLabel] - firstData; // number of data blocks
+	for (unsigned int i = 0; i < numData; ++i) {
+		getResAndErr(firstData + i, aResiduals[i], aMeasErrors[i],
+				aResErrors[i], aDownWeights[i]);
+	}
+	return 0;
+}
+
+/// Get (kink) residuals at point from scatterer.
+/**
+ * Get (diagonalized) residual, error of measurement and residual and down-weighting
+ * factor for scatterering kinks at point
+ *
+ * \param [in]  aLabel Label of point on trajectory
+ * \param [out] numData Number of data blocks from scatterer at point
+ * \param [out] aResiduals (kink)Measurements-(kink)Predictions
+ * \param [out] aMeasErrors Errors of (kink)Measurements
+ * \param [out] aResErrors Errors of Residuals (including correlations from track fit)
+ * \param [out] aDownWeights Down-Weighting factors
+ * \return error code (non-zero if trajectory not fitted successfully)
+ */
+unsigned int GblTrajectory::getScatResults(unsigned int aLabel,
+		unsigned int &numData, TVectorD &aResiduals, TVectorD &aMeasErrors,
+		TVectorD &aResErrors, TVectorD &aDownWeights) {
+	numData = 0;
+	if (not fitOK)
+		return 1;
+
+	unsigned int firstData = scatDataIndex[aLabel - 1]; // first data block with scatterer
+	numData = scatDataIndex[aLabel] - firstData; // number of data blocks
+	for (unsigned int i = 0; i < numData; ++i) {
+		getResAndErr(firstData + i, aResiduals[i], aMeasErrors[i],
+				aResErrors[i], aDownWeights[i]);
+	}
+	return 0;
+}
+
+/// Get (list of) labels of points on (simple) trajectory
+/**
+ * \param [out] aLabelList List of labels (aLabelList[i] = i+1)
+ */
+void GblTrajectory::getLabels(std::vector<unsigned int> &aLabelList) {
+	unsigned int aLabel = 0;
+	unsigned int nPoint = thePoints[0].size();
+	aLabelList.resize(nPoint);
+	for (unsigned i = 0; i < nPoint; ++i) {
+		aLabelList[i] = ++aLabel;
+	}
+}
+
+/// Get (list of lists of) labels of points on (composed) trajectory
+/**
+ * \param [out] aLabelList List of of lists of labels
+ */
+void GblTrajectory::getLabels(
+		std::vector<std::vector<unsigned int> > &aLabelList) {
+	unsigned int aLabel = 0;
+	aLabelList.resize(numTrajectories);
+	for (unsigned int iTraj = 0; iTraj < numTrajectories; ++iTraj) {
+		unsigned int nPoint = thePoints[iTraj].size();
+		aLabelList[iTraj].resize(nPoint);
+		for (unsigned i = 0; i < nPoint; ++i) {
+			aLabelList[iTraj][i] = ++aLabel;
+		}
+	}
+}
+
+/// Get residual and errors from data block.
+/**
+ * Get residual, error of measurement and residual and down-weighting
+ * factor for (single) data block
+ * \param [in]  aData Label of data block
+ * \param [out] aResidual Measurement-Prediction
+ * \param [out] aMeasError Error of Measurement
+ * \param [out] aResError Error of Residual (including correlations from track fit)
+ * \param [out] aDownWeight Down-Weighting factor
+ */
+void GblTrajectory::getResAndErr(unsigned int aData, double &aResidual,
+		double &aMeasError, double &aResError, double &aDownWeight) {
+
+	double aMeasVar;
+	std::vector<unsigned int>* indLocal;
+	std::vector<double>* derLocal;
+	theData[aData].getResidual(aResidual, aMeasVar, aDownWeight, indLocal,
+			derLocal);
+	unsigned int nParBrl = (*indLocal).size();
+	TVectorD aVec(nParBrl); // compressed vector of derivatives
+	for (unsigned int j = 0; j < nParBrl; ++j) {
+		aVec[j] = (*derLocal)[j];
+	}
+	TMatrixDSym aMat = theMatrix.getBlockMatrix(*indLocal); // compressed (covariance) matrix
+	double aFitVar = aMat.Similarity(aVec); // variance from track fit
+	aMeasError = sqrt(aMeasVar); // error of measurement
+	aResError = (aFitVar < aMeasVar ? sqrt(aMeasVar - aFitVar) : 0.); // error of residual
+}
+
+/// Build linear equation system from data (blocks).
+void GblTrajectory::buildLinearEquationSystem() {
+	unsigned int nBorder = numCurvature + numLocals;
+	theVector.resize(numParameters);
+	theMatrix.resize(numParameters, nBorder);
+	double aValue, aWeight;
+	std::vector<unsigned int>* indLocal;
+	std::vector<double>* derLocal;
+	std::vector<GblData>::iterator itData;
+	for (itData = theData.begin(); itData < theData.end(); ++itData) {
+		itData->getLocalData(aValue, aWeight, indLocal, derLocal);
+		for (unsigned int j = 0; j < indLocal->size(); ++j) {
+			theVector((*indLocal)[j] - 1) += (*derLocal)[j] * aWeight * aValue;
+		}
+		theMatrix.addBlockMatrix(aWeight, indLocal, derLocal);
+	}
+}
+
+/// Prepare fit for simple or composed trajectory
+/**
+ * Generate data (blocks) from measurements, kinks, external seed and measurements.
+ */
+void GblTrajectory::prepare() {
+	unsigned int nDim = theDimension.size();
+	// upper limit
+	unsigned int maxData = numMeasurements + nDim * (numOffsets - 2)
+			+ externalSeed.GetNrows();
+	theData.reserve(maxData);
+	measDataIndex.resize(numAllPoints + 3); // include external seed and measurements
+	scatDataIndex.resize(numAllPoints + 1);
+	unsigned int nData = 0;
+	std::vector<TMatrixD> innerTransDer;
+	std::vector<std::vector<unsigned int> > innerTransLab;
+	// composed trajectory ?
+	if (numInnerTrans > 0) {
+		//std::cout << "composed trajectory" << std::endl;
+		for (unsigned int iTraj = 0; iTraj < numTrajectories; ++iTraj) {
+			// innermost point
+			GblPoint* innerPoint = &thePoints[iTraj].front();
+			// transformation fit to local track parameters
+			std::vector<unsigned int> firstLabels(5);
+			SMatrix55 matFitToLocal, matLocalToFit;
+			getFitToLocalJacobian(firstLabels, matFitToLocal, *innerPoint, 5);
+			// transformation local track to fit parameters
+			int ierr;
+			matLocalToFit = matFitToLocal.Inverse(ierr);
+			TMatrixD localToFit(5, 5);
+			for (unsigned int i = 0; i < 5; ++i) {
+				for (unsigned int j = 0; j < 5; ++j) {
+					localToFit(i, j) = matLocalToFit(i, j);
+				}
+			}
+			// transformation external to fit parameters at inner (first) point
+			innerTransDer.push_back(localToFit * innerTransformations[iTraj]);
+			innerTransLab.push_back(firstLabels);
+		}
+	}
+	// measurements
+	SMatrix55 matP;
+	// loop over trajectories
+	std::vector<GblPoint>::iterator itPoint;
+	for (unsigned int iTraj = 0; iTraj < numTrajectories; ++iTraj) {
+		for (itPoint = thePoints[iTraj].begin();
+				itPoint < thePoints[iTraj].end(); ++itPoint) {
+			SVector5 aMeas, aPrec;
+			unsigned int nLabel = itPoint->getLabel();
+			unsigned int measDim = itPoint->hasMeasurement();
+			if (measDim) {
+				const TMatrixD localDer = itPoint->getLocalDerivatives();
+				const std::vector<int> globalLab = itPoint->getGlobalLabels();
+				const TMatrixD globalDer = itPoint->getGlobalDerivatives();
+				TMatrixD transDer;
+				itPoint->getMeasurement(matP, aMeas, aPrec);
+				unsigned int iOff = 5 - measDim; // first active component
+				std::vector<unsigned int> labDer(5);
+				SMatrix55 matDer, matPDer;
+				unsigned int nJacobian =
+						(itPoint < thePoints[iTraj].end() - 1) ? 1 : 0; // last point needs backward propagation
+				getFitToLocalJacobian(labDer, matDer, *itPoint, measDim,
+						nJacobian);
+				if (measDim > 2) {
+					matPDer = matP * matDer;
+				} else { // 'shortcut' for position measurements
+					matPDer.Place_at(
+							matP.Sub<SMatrix22>(3, 3)
+									* matDer.Sub<SMatrix25>(3, 0), 3, 0);
+				}
+
+				if (numInnerTrans > 0) {
+					// transform for external parameters
+					TMatrixD proDer(measDim, 5);
+					// match parameters
+					unsigned int ifirst = 0;
+					unsigned int ilabel = 0;
+					while (ilabel < 5) {
+						if (labDer[ilabel] > 0) {
+							while (innerTransLab[iTraj][ifirst]
+									!= labDer[ilabel] and ifirst < 5) {
+								++ifirst;
+							}
+							if (ifirst >= 5) {
+								labDer[ilabel] -= 2 * nDim * (iTraj + 1); // adjust label
+							} else {
+								// match
+								labDer[ilabel] = 0; // mark as related to external parameters
+								for (unsigned int k = iOff; k < 5; ++k) {
+									proDer(k - iOff, ifirst) = matPDer(k,
+											ilabel);
+								}
+							}
+						}
+						++ilabel;
+					}
+					transDer.ResizeTo(measDim, numCurvature);
+					transDer = proDer * innerTransDer[iTraj];
+				}
+				for (unsigned int i = iOff; i < 5; ++i) {
+					if (aPrec(i) > 0.) {
+						GblData aData(nLabel, aMeas(i), aPrec(i));
+						aData.addDerivatives(i, labDer, matPDer, iOff, localDer,
+								globalLab, globalDer, numLocals, transDer);
+						theData.push_back(aData);
+						nData++;
+					}
+				}
+
+			}
+			measDataIndex[nLabel] = nData;
+		}
+	}
+
+	// pseudo measurements from kinks
+	SMatrix22 matT;
+	scatDataIndex[0] = nData;
+	scatDataIndex[1] = nData;
+	// loop over trajectories
+	for (unsigned int iTraj = 0; iTraj < numTrajectories; ++iTraj) {
+		for (itPoint = thePoints[iTraj].begin() + 1;
+				itPoint < thePoints[iTraj].end() - 1; ++itPoint) {
+			SVector2 aMeas, aPrec;
+			unsigned int nLabel = itPoint->getLabel();
+			if (itPoint->hasScatterer()) {
+				itPoint->getScatterer(matT, aMeas, aPrec);
+				TMatrixD transDer;
+				std::vector<unsigned int> labDer(7);
+				SMatrix27 matDer, matTDer;
+				getFitToKinkJacobian(labDer, matDer, *itPoint);
+				matTDer = matT * matDer;
+				if (numInnerTrans > 0) {
+					// transform for external parameters
+					TMatrixD proDer(nDim, 5);
+					// match parameters
+					unsigned int ifirst = 0;
+					unsigned int ilabel = 0;
+					while (ilabel < 7) {
+						if (labDer[ilabel] > 0) {
+							while (innerTransLab[iTraj][ifirst]
+									!= labDer[ilabel] and ifirst < 5) {
+								++ifirst;
+							}
+							if (ifirst >= 5) {
+								labDer[ilabel] -= 2 * nDim * (iTraj + 1); // adjust label
+							} else {
+								// match
+								labDer[ilabel] = 0; // mark as related to external parameters
+								for (unsigned int k = 0; k < nDim; ++k) {
+									proDer(k, ifirst) = matTDer(k, ilabel);
+								}
+							}
+						}
+						++ilabel;
+					}
+					transDer.ResizeTo(nDim, numCurvature);
+					transDer = proDer * innerTransDer[iTraj];
+				}
+				for (unsigned int i = 0; i < nDim; ++i) {
+					unsigned int iDim = theDimension[i];
+					if (aPrec(iDim) > 0.) {
+						GblData aData(nLabel, aMeas(iDim), aPrec(iDim));
+						aData.addDerivatives(iDim, labDer, matTDer, numLocals,
+								transDer);
+						theData.push_back(aData);
+						nData++;
+					}
+				}
+			}
+			scatDataIndex[nLabel] = nData;
+		}
+		scatDataIndex[thePoints[iTraj].back().getLabel()] = nData;
+	}
+
+	// external seed
+	if (externalPoint > 0) {
+		std::pair<std::vector<unsigned int>, TMatrixD> indexAndJacobian =
+				getJacobian(externalPoint);
+		std::vector<unsigned int> externalSeedIndex = indexAndJacobian.first;
+		std::vector<double> externalSeedDerivatives(externalSeedIndex.size());
+		const TMatrixDSymEigen externalSeedEigen(externalSeed);
+		const TVectorD valEigen = externalSeedEigen.GetEigenValues();
+		TMatrixD vecEigen = externalSeedEigen.GetEigenVectors();
+		vecEigen = vecEigen.T() * indexAndJacobian.second;
+		for (int i = 0; i < externalSeed.GetNrows(); ++i) {
+			if (valEigen(i) > 0.) {
+				for (int j = 0; j < externalSeed.GetNcols(); ++j) {
+					externalSeedDerivatives[j] = vecEigen(i, j);
+				}
+				GblData aData(externalPoint, 0., valEigen(i));
+				aData.addDerivatives(externalSeedIndex, externalSeedDerivatives);
+				theData.push_back(aData);
+				nData++;
+			}
+		}
+	}
+	measDataIndex[numAllPoints + 1] = nData;
+	// external measurements
+	unsigned int nExt = externalMeasurements.GetNrows();
+	if (nExt > 0) {
+		std::vector<unsigned int> index(numCurvature);
+		std::vector<double> derivatives(numCurvature);
+		for (unsigned int iExt = 0; iExt < nExt; ++iExt) {
+			for (unsigned int iCol = 0; iCol < numCurvature; ++iCol) {
+				index[iCol] = iCol + 1;
+				derivatives[iCol] = externalDerivatives(iExt, iCol);
+			}
+			GblData aData(1U, externalMeasurements(iExt),
+					externalPrecisions(iExt));
+			aData.addDerivatives(index, derivatives);
+			theData.push_back(aData);
+			nData++;
+		}
+	}
+	measDataIndex[numAllPoints + 2] = nData;
+}
+
+/// Calculate predictions for all points.
+void GblTrajectory::predict() {
+	std::vector<GblData>::iterator itData;
+	for (itData = theData.begin(); itData < theData.end(); ++itData) {
+		itData->setPrediction(theVector);
+	}
+}
+
+/// Down-weight all points.
+/**
+ * \param [in] aMethod M-estimator (1: Tukey, 2:Huber, 3:Cauchy)
+ */
+double GblTrajectory::downWeight(unsigned int aMethod) {
+	double aLoss = 0.;
+	std::vector<GblData>::iterator itData;
+	for (itData = theData.begin(); itData < theData.end(); ++itData) {
+		aLoss += (1. - itData->setDownWeighting(aMethod));
+	}
+	return aLoss;
+}
+
+/// Perform fit of trajectory.
+/**
+ * Optionally iterate for outlier down-weighting.
+ * \param [out] Chi2 Chi2 sum (corrected for down-weighting)
+ * \param [out] Ndf  Number of degrees of freedom
+ * \param [out] lostWeight Sum of weights lost due to down-weighting
+ * \param [in] optionList Iterations for down-weighting
+ * (One character per iteration: t,h,c (or T,H,C) for Tukey, Huber or Cauchy function)
+ * \return Error code (non zero value indicates failure of fit)
+ */
+unsigned int GblTrajectory::fit(double &Chi2, int &Ndf, double &lostWeight,
+		std::string optionList) {
+	const double normChi2[4] = { 1.0, 0.8737, 0.9326, 0.8228 };
+	const std::string methodList = "TtHhCc";
+
+	Chi2 = 0.;
+	Ndf = -1;
+	lostWeight = 0.;
+	if (not constructOK)
+		return 10;
+
+	unsigned int aMethod = 0;
+
+	buildLinearEquationSystem();
+	lostWeight = 0.;
+	unsigned int ierr = 0;
+	try {
+
+		theMatrix.solveAndInvertBorderedBand(theVector, theVector);
+		predict();
+
+		for (unsigned int i = 0; i < optionList.size(); ++i) // down weighting iterations
+				{
+			size_t aPosition = methodList.find(optionList[i]);
+			if (aPosition != std::string::npos) {
+				aMethod = aPosition / 2 + 1;
+				lostWeight = downWeight(aMethod);
+				buildLinearEquationSystem();
+				theMatrix.solveAndInvertBorderedBand(theVector, theVector);
+				predict();
+			}
+		}
+		Ndf = theData.size() - numParameters;
+		Chi2 = 0.;
+		for (unsigned int i = 0; i < theData.size(); ++i) {
+			Chi2 += theData[i].getChi2();
+		}
+		Chi2 /= normChi2[aMethod];
+		fitOK = true;
+
+	} catch (int e) {
+		std::cout << " GblTrajectory::fit exception " << e << std::endl;
+		ierr = e;
+	}
+	return ierr;
+}
+
+/// Write valid trajectory to Millepede-II binary file.
+void GblTrajectory::milleOut(MilleBinary &aMille) {
+	double aValue;
+	double aErr;
+	std::vector<unsigned int>* indLocal;
+	std::vector<double>* derLocal;
+	std::vector<int>* labGlobal;
+	std::vector<double>* derGlobal;
+
+	if (not constructOK)
+		return;
+
+//   data: measurements, kinks and external seed
+	std::vector<GblData>::iterator itData;
+	for (itData = theData.begin(); itData != theData.end(); ++itData) {
+		itData->getAllData(aValue, aErr, indLocal, derLocal, labGlobal,
+				derGlobal);
+		aMille.addData(aValue, aErr, *indLocal, *derLocal, *labGlobal,
+				*derGlobal);
+	}
+	aMille.writeRecord();
+}
+
+/// Print GblTrajectory
+/**
+ * \param [in] level print level (0: minimum, >0: more)
+ */
+void GblTrajectory::printTrajectory(unsigned int level) {
+	if (numInnerTrans) {
+		std::cout << "Composed GblTrajectory, " << numInnerTrans
+				<< " subtrajectories" << std::endl;
+	} else {
+		std::cout << "Simple GblTrajectory" << std::endl;
+	}
+	if (theDimension.size() < 2) {
+		std::cout << " 2D-trajectory" << std::endl;
+	}
+	std::cout << " Number of GblPoints          : " << numAllPoints
+			<< std::endl;
+	std::cout << " Number of points with offsets: " << numOffsets << std::endl;
+	std::cout << " Number of fit parameters     : " << numParameters
+			<< std::endl;
+	std::cout << " Number of measurements       : " << numMeasurements
+			<< std::endl;
+	if (externalMeasurements.GetNrows()) {
+		std::cout << " Number of ext. measurements  : "
+				<< externalMeasurements.GetNrows() << std::endl;
+	}
+	if (externalPoint) {
+		std::cout << " Label of point with ext. seed: " << externalPoint
+				<< std::endl;
+	}
+	if (constructOK) {
+		std::cout << " Constructed OK " << std::endl;
+	}
+	if (fitOK) {
+		std::cout << " Fitted OK " << std::endl;
+	}
+	if (level > 0) {
+		if (numInnerTrans) {
+			std::cout << " Inner transformations" << std::endl;
+			for (unsigned int i = 0; i < numInnerTrans; ++i) {
+				innerTransformations[i].Print();
+			}
+		}
+		if (externalMeasurements.GetNrows()) {
+			std::cout << " External measurements" << std::endl;
+			std::cout << "  Measurements:" << std::endl;
+			externalMeasurements.Print();
+			std::cout << "  Precisions:" << std::endl;
+			externalPrecisions.Print();
+			std::cout << "  Derivatives:" << std::endl;
+			externalDerivatives.Print();
+		}
+		if (externalPoint) {
+			std::cout << " External seed:" << std::endl;
+			externalSeed.Print();
+		}
+		if (fitOK) {
+			std::cout << " Fit results" << std::endl;
+			std::cout << "  Parameters:" << std::endl;
+			theVector.print();
+			std::cout << "  Covariance matrix (bordered band part):"
+					<< std::endl;
+			theMatrix.printMatrix();
+		}
+	}
+}
+
+/// Print \link GblPoint GblPoints \endlink on trajectory
+/**
+ * \param [in] level print level (0: minimum, >0: more)
+ */
+void GblTrajectory::printPoints(unsigned int level) {
+	std::cout << "GblPoints " << std::endl;
+	for (unsigned int iTraj = 0; iTraj < numTrajectories; ++iTraj) {
+		std::vector<GblPoint>::iterator itPoint;
+		for (itPoint = thePoints[iTraj].begin();
+				itPoint < thePoints[iTraj].end(); ++itPoint) {
+			itPoint->printPoint(level);
+		}
+	}
+}
+
+/// Print GblData blocks for trajectory
+void GblTrajectory::printData() {
+	std::cout << "GblData blocks " << std::endl;
+	std::vector<GblData>::iterator itData;
+	for (itData = theData.begin(); itData < theData.end(); ++itData) {
+		itData->printData();
+	}
+}
+
+}

--- a/Alignment/ReferenceTrajectories/src/MilleBinary.cc
+++ b/Alignment/ReferenceTrajectories/src/MilleBinary.cc
@@ -1,0 +1,110 @@
+/*
+ * MilleBinary.cpp
+ *
+ *  Created on: Aug 31, 2011
+ *      Author: kleinwrt
+ */
+
+#include "Alignment/ReferenceTrajectories/interface/MilleBinary.h"
+
+//! Namespace for the general broken lines package
+namespace gbl {
+
+/// Create binary file.
+/**
+ * \param [in] fileName File name
+ * \param [in] doublePrec Flag for storage as double values
+ * \param [in] aSize Buffer size
+ */
+MilleBinary::MilleBinary(const std::string fileName, bool doublePrec,
+		unsigned int aSize) :
+		binaryFile(fileName.c_str(), std::ios::binary | std::ios::out), intBuffer(), floatBuffer(), doubleBuffer(), doublePrecision(
+				doublePrec) {
+	intBuffer.reserve(aSize);
+	intBuffer.push_back(0); // first word is error counter
+	if (doublePrecision) {
+		doubleBuffer.reserve(aSize);
+		doubleBuffer.push_back(0.);
+
+	} else {
+		floatBuffer.reserve(aSize);
+		floatBuffer.push_back(0.);
+	}
+}
+
+MilleBinary::~MilleBinary() {
+	binaryFile.close();
+}
+
+/// Add data block to (end of) record.
+/**
+ * \param [in] aMeas Value
+ * \param [in] aErr Error
+ * \param [in] indLocal List of labels of local parameters
+ * \param [in] derLocal List of derivatives for local parameters
+ * \param [in] labGlobal List of labels of global parameters
+ * \param [in] derGlobal List of derivatives for global parameters
+ */
+void MilleBinary::addData(double aMeas, double aErr,
+		const std::vector<unsigned int> &indLocal,
+		const std::vector<double> &derLocal, const std::vector<int> &labGlobal,
+		const std::vector<double> &derGlobal) {
+
+	if (doublePrecision) {
+		// double values
+		intBuffer.push_back(0);
+		doubleBuffer.push_back(aMeas);
+		for (unsigned int i = 0; i < indLocal.size(); ++i) {
+			intBuffer.push_back(indLocal[i]);
+			doubleBuffer.push_back(derLocal[i]);
+		}
+		intBuffer.push_back(0);
+		doubleBuffer.push_back(aErr);
+		for (unsigned int i = 0; i < labGlobal.size(); ++i) {
+			if (derGlobal[i]) {
+				intBuffer.push_back(labGlobal[i]);
+				doubleBuffer.push_back(derGlobal[i]);
+			}
+		}
+	} else {
+		// float values
+		intBuffer.push_back(0);
+		floatBuffer.push_back(aMeas);
+		for (unsigned int i = 0; i < indLocal.size(); ++i) {
+			intBuffer.push_back(indLocal[i]);
+			floatBuffer.push_back(derLocal[i]);
+		}
+		intBuffer.push_back(0);
+		floatBuffer.push_back(aErr);
+		for (unsigned int i = 0; i < labGlobal.size(); ++i) {
+			if (derGlobal[i]) {
+				intBuffer.push_back(labGlobal[i]);
+				floatBuffer.push_back(derGlobal[i]);
+			}
+		}
+	}
+}
+
+/// Write record to file.
+void MilleBinary::writeRecord() {
+
+	const int recordLength =
+			(doublePrecision) ? -intBuffer.size() * 2 : intBuffer.size() * 2;
+	binaryFile.write(reinterpret_cast<const char*>(&recordLength),
+			sizeof(recordLength));
+	if (doublePrecision)
+		binaryFile.write(reinterpret_cast<char*>(&doubleBuffer[0]),
+				doubleBuffer.size() * sizeof(doubleBuffer[0]));
+	else
+		binaryFile.write(reinterpret_cast<char*>(&floatBuffer[0]),
+				floatBuffer.size() * sizeof(floatBuffer[0]));
+	binaryFile.write(reinterpret_cast<char*>(&intBuffer[0]),
+			intBuffer.size() * sizeof(intBuffer[0]));
+// start with new record
+	intBuffer.resize(1);
+	if (doublePrecision)
+		doubleBuffer.resize(1);
+	else
+		floatBuffer.resize(1);
+}
+}

--- a/Alignment/ReferenceTrajectories/src/TrajectoryFactoryBase.cc
+++ b/Alignment/ReferenceTrajectories/src/TrajectoryFactoryBase.cc
@@ -129,7 +129,9 @@ TrajectoryFactoryBase::materialEffects( const std::string & strME ) const
   if ( strME == "BrokenLines" ) return ReferenceTrajectoryBase::brokenLinesCoarse;
   if ( strME == "BrokenLinesCoarse" ) return ReferenceTrajectoryBase::brokenLinesCoarse;
   if ( strME == "BrokenLinesFine" ) return ReferenceTrajectoryBase::brokenLinesFine;
-          
+  if ( strME == "LocalGBL" ) return ReferenceTrajectoryBase::localGBL;
+  if ( strME == "CurvlinGBL" ) return ReferenceTrajectoryBase::curvlinGBL;
+            
   throw cms::Exception("BadConfig")
     << "[TrajectoryFactoryBase::materialEffects] Unknown parameter: " << strME;
 }

--- a/Alignment/ReferenceTrajectories/src/TwoBodyDecayTrajectory.cc
+++ b/Alignment/ReferenceTrajectories/src/TwoBodyDecayTrajectory.cc
@@ -83,16 +83,6 @@ bool TwoBodyDecayTrajectory::construct( const TwoBodyDecayTrajectoryState& state
 
   // check if construction of trajectory was successful
   if ( !trajectory1.isValid() ) return false;
-  
-  int nLocal = deriv.first.num_row();
-  int nTbd   = deriv.first.num_col();
-  unsigned int nHitMeas1     = trajectory1.numberOfHitMeas();
-  unsigned int nVirtualMeas1 = trajectory1.numberOfVirtualMeas(); 
-  unsigned int nPar1         = trajectory1.numberOfPar();
-  unsigned int nVirtualPar1  = trajectory1.numberOfVirtualPar(); 
-     
-  // derivatives of the trajectory w.r.t. to the decay parameters
-  AlgebraicMatrix fullDeriv1 = trajectory1.derivatives().sub(1,nHitMeas1+nVirtualMeas1,1,nLocal) * trajectory1.localToTrajectory() * deriv.first;
 
   //
   // second track
@@ -103,76 +93,119 @@ bool TwoBodyDecayTrajectory::construct( const TwoBodyDecayTrajectoryState& state
 
   if ( !trajectory2.isValid() ) return false;
   
-  unsigned int nHitMeas2     = trajectory2.numberOfHitMeas();
-  unsigned int nVirtualMeas2 = trajectory2.numberOfVirtualMeas();  
-  unsigned int nPar2         = trajectory2.numberOfPar();
-  unsigned int nVirtualPar2  = trajectory2.numberOfVirtualPar();
-
-  AlgebraicMatrix fullDeriv2 = trajectory2.derivatives().sub(1,nHitMeas2+nVirtualMeas2,1,nLocal) * trajectory2.localToTrajectory() * deriv.second;
-
   //
   // combine both tracks
   //
-  
-  theNumberOfRecHits.first = recHits.first.size();
-  theNumberOfRecHits.second = recHits.second.size();
+  unsigned int nLocal = deriv.first.num_row();
+  unsigned int nTbd   = deriv.first.num_col();
 
-  theNumberOfHits = trajectory1.numberOfHits() + trajectory2.numberOfHits(); 
-  theNumberOfPars = nPar1 + nPar2;
-  theNumberOfVirtualPars = nVirtualPar1 + nVirtualPar2;
-  theNumberOfVirtualMeas = nVirtualMeas1 + nVirtualMeas2 + 1; // add virtual mass measurement
+  if (materialEffects >= localGBL) {
+    // GBL trajectory inputs
+    // convert to TMatrix
+    TMatrixD tbdToLocal1(nLocal, nTbd);
+    for (unsigned int row = 0; row < nLocal; ++row) {
+      for (unsigned int col = 0; col < nTbd; ++col) {
+        tbdToLocal1(row,col) = deriv.first[row][col];
+      }
+    }
+    // add first body
+    theGblInput.push_back(std::make_pair(trajectory1.gblInput().front().first, 
+                                         trajectory1.gblInput().front().second*tbdToLocal1));
+    // convert to TMatrix
+    TMatrixD tbdToLocal2(nLocal, nTbd);
+    for (unsigned int row = 0; row < nLocal; ++row) {
+      for (unsigned int col = 0; col < nTbd; ++col) {
+        tbdToLocal2(row,col) = deriv.second[row][col];
+      }
+    }
+    // add second body
+    theGblInput.push_back(std::make_pair(trajectory2.gblInput().front().first, 
+                                         trajectory2.gblInput().front().second*tbdToLocal2));
+    // add virtual mass measurement
+    theGblExtDerivatives.ResizeTo(1,nTbd);
+    theGblExtDerivatives(0,TwoBodyDecayParameters::mass) = 1.0;
+    theGblExtMeasurements.ResizeTo(1);
+    theGblExtMeasurements(0) = state.primaryMass() - state.decayParameters()[TwoBodyDecayParameters::mass];
+    theGblExtPrecisions.ResizeTo(1);
+    theGblExtPrecisions(0) = 1.0 / (state.primaryWidth() * state.primaryWidth());
+    // nominal field
+    theNomField = trajectory1.nominalField();
+  } else {
+    unsigned int nHitMeas1     = trajectory1.numberOfHitMeas();
+    unsigned int nVirtualMeas1 = trajectory1.numberOfVirtualMeas(); 
+    unsigned int nPar1         = trajectory1.numberOfPar();
+    unsigned int nVirtualPar1  = trajectory1.numberOfVirtualPar(); 
+     
+    // derivatives of the trajectory w.r.t. to the decay parameters
+    AlgebraicMatrix fullDeriv1 = trajectory1.derivatives().sub(1,nHitMeas1+nVirtualMeas1,1,nLocal) * trajectory1.localToTrajectory() * deriv.first;
+
+    unsigned int nHitMeas2     = trajectory2.numberOfHitMeas();
+    unsigned int nVirtualMeas2 = trajectory2.numberOfVirtualMeas();  
+    unsigned int nPar2         = trajectory2.numberOfPar();
+    unsigned int nVirtualPar2  = trajectory2.numberOfVirtualPar();
+
+    AlgebraicMatrix fullDeriv2 = trajectory2.derivatives().sub(1,nHitMeas2+nVirtualMeas2,1,nLocal) * trajectory2.localToTrajectory() * deriv.second;
+
+    theNumberOfRecHits.first = recHits.first.size();
+    theNumberOfRecHits.second = recHits.second.size();
+
+    theNumberOfHits = trajectory1.numberOfHits() + trajectory2.numberOfHits(); 
+    theNumberOfPars = nPar1 + nPar2;
+    theNumberOfVirtualPars = nVirtualPar1 + nVirtualPar2;
+    theNumberOfVirtualMeas = nVirtualMeas1 + nVirtualMeas2 + 1; // add virtual mass measurement
   
-  // hit measurements from trajectory 1
-  int rowOffset = 1;
-  int colOffset = 1; 
-  theDerivatives.sub( rowOffset, colOffset,                fullDeriv1.sub(            1, nHitMeas1,                     1, nTbd ) );
-  colOffset += nTbd;
-  theDerivatives.sub( rowOffset, colOffset, trajectory1.derivatives().sub(            1, nHitMeas1,            nLocal + 1, nPar1 + nVirtualPar1 ) );
-  // hit measurements from trajectory 2
-  rowOffset += nHitMeas1;
-  colOffset = 1; 
-  theDerivatives.sub( rowOffset, colOffset,                fullDeriv2.sub(            1, nHitMeas2,                     1, nTbd ) );
-  colOffset += (nPar1 + nVirtualPar1 + nTbd - nLocal);
-  theDerivatives.sub( rowOffset, colOffset, trajectory2.derivatives().sub(            1, nHitMeas2,            nLocal + 1, nPar2 + nVirtualPar2 ) );  
-  // MS measurements from trajectory 1
-  rowOffset += nHitMeas2;  
-  colOffset = 1; 
-  theDerivatives.sub( rowOffset, colOffset,                fullDeriv1.sub(nHitMeas1 + 1, nHitMeas1 + nVirtualMeas1,          1, nTbd ) );  
-  colOffset += nTbd;
-  theDerivatives.sub( rowOffset, colOffset, trajectory1.derivatives().sub(nHitMeas1 + 1, nHitMeas1 + nVirtualMeas1, nLocal + 1, nPar1 + nVirtualPar1 ) ); 
-  // MS measurements from trajectory 2
-  rowOffset += nVirtualMeas1;  
-  colOffset = 1; 
-  theDerivatives.sub( rowOffset, colOffset,                fullDeriv2.sub(nHitMeas2 + 1, nHitMeas2 + nVirtualMeas2,          1, nTbd ) );
-  colOffset += (nPar1 + nVirtualPar1 + nTbd - nLocal);  
-  theDerivatives.sub( rowOffset, colOffset, trajectory2.derivatives().sub(nHitMeas2 + 1, nHitMeas2 + nVirtualMeas2, nLocal + 1, nPar2 + nVirtualPar2 ) ); 
+    // hit measurements from trajectory 1
+    int rowOffset = 1;
+    int colOffset = 1; 
+    theDerivatives.sub( rowOffset, colOffset,                fullDeriv1.sub(            1, nHitMeas1,                     1, nTbd ) );
+    colOffset += nTbd;
+    theDerivatives.sub( rowOffset, colOffset, trajectory1.derivatives().sub(            1, nHitMeas1,            nLocal + 1, nPar1 + nVirtualPar1 ) );
+    // hit measurements from trajectory 2
+    rowOffset += nHitMeas1;
+    colOffset = 1; 
+    theDerivatives.sub( rowOffset, colOffset,                fullDeriv2.sub(            1, nHitMeas2,                     1, nTbd ) );
+    colOffset += (nPar1 + nVirtualPar1 + nTbd - nLocal);
+    theDerivatives.sub( rowOffset, colOffset, trajectory2.derivatives().sub(            1, nHitMeas2,            nLocal + 1, nPar2 + nVirtualPar2 ) );  
+    // MS measurements from trajectory 1
+    rowOffset += nHitMeas2;  
+    colOffset = 1; 
+    theDerivatives.sub( rowOffset, colOffset,                fullDeriv1.sub(nHitMeas1 + 1, nHitMeas1 + nVirtualMeas1,          1, nTbd ) );  
+    colOffset += nTbd;
+    theDerivatives.sub( rowOffset, colOffset, trajectory1.derivatives().sub(nHitMeas1 + 1, nHitMeas1 + nVirtualMeas1, nLocal + 1, nPar1 + nVirtualPar1 ) ); 
+    // MS measurements from trajectory 2
+    rowOffset += nVirtualMeas1;  
+    colOffset = 1; 
+    theDerivatives.sub( rowOffset, colOffset,                fullDeriv2.sub(nHitMeas2 + 1, nHitMeas2 + nVirtualMeas2,          1, nTbd ) );
+    colOffset += (nPar1 + nVirtualPar1 + nTbd - nLocal);  
+    theDerivatives.sub( rowOffset, colOffset, trajectory2.derivatives().sub(nHitMeas2 + 1, nHitMeas2 + nVirtualMeas2, nLocal + 1, nPar2 + nVirtualPar2 ) ); 
         
-  theMeasurements.sub(                                         1, trajectory1.measurements().sub(            1, nHitMeas1 ) );
-  theMeasurements.sub( nHitMeas1                             + 1, trajectory2.measurements().sub(            1, nHitMeas2 ) );
-  theMeasurements.sub( nHitMeas1 + nHitMeas2                 + 1, trajectory1.measurements().sub(nHitMeas1 + 1, nHitMeas1 + nVirtualMeas1 ) );
-  theMeasurements.sub( nHitMeas1 + nHitMeas2 + nVirtualMeas1 + 1, trajectory2.measurements().sub(nHitMeas2 + 1, nHitMeas2 + nVirtualMeas2 ) );
+    theMeasurements.sub(                                         1, trajectory1.measurements().sub(            1, nHitMeas1 ) );
+    theMeasurements.sub( nHitMeas1                             + 1, trajectory2.measurements().sub(            1, nHitMeas2 ) );
+    theMeasurements.sub( nHitMeas1 + nHitMeas2                 + 1, trajectory1.measurements().sub(nHitMeas1 + 1, nHitMeas1 + nVirtualMeas1 ) );
+    theMeasurements.sub( nHitMeas1 + nHitMeas2 + nVirtualMeas1 + 1, trajectory2.measurements().sub(nHitMeas2 + 1, nHitMeas2 + nVirtualMeas2 ) );
 
-  theMeasurementsCov.sub(                                         1, trajectory1.measurementErrors().sub(            1, nHitMeas1 ) );
-  theMeasurementsCov.sub( nHitMeas1                             + 1, trajectory2.measurementErrors().sub(            1, nHitMeas2 ) );
-  theMeasurementsCov.sub( nHitMeas1 + nHitMeas2                 + 1, trajectory1.measurementErrors().sub(nHitMeas1 + 1, nHitMeas1 + nVirtualMeas1 ) );
-  theMeasurementsCov.sub( nHitMeas1 + nHitMeas2 + nVirtualMeas1 + 1, trajectory2.measurementErrors().sub(nHitMeas2 + 1, nHitMeas2 + nVirtualMeas2 ) );
+    theMeasurementsCov.sub(                                         1, trajectory1.measurementErrors().sub(            1, nHitMeas1 ) );
+    theMeasurementsCov.sub( nHitMeas1                             + 1, trajectory2.measurementErrors().sub(            1, nHitMeas2 ) );
+    theMeasurementsCov.sub( nHitMeas1 + nHitMeas2                 + 1, trajectory1.measurementErrors().sub(nHitMeas1 + 1, nHitMeas1 + nVirtualMeas1 ) );
+    theMeasurementsCov.sub( nHitMeas1 + nHitMeas2 + nVirtualMeas1 + 1, trajectory2.measurementErrors().sub(nHitMeas2 + 1, nHitMeas2 + nVirtualMeas2 ) );
 
-  theTrajectoryPositions.sub(             1, trajectory1.trajectoryPositions() );
-  theTrajectoryPositions.sub( nHitMeas1 + 1, trajectory2.trajectoryPositions() );
+    theTrajectoryPositions.sub(             1, trajectory1.trajectoryPositions() );
+    theTrajectoryPositions.sub( nHitMeas1 + 1, trajectory2.trajectoryPositions() );
 
-  theTrajectoryPositionCov = state.decayParameters().covariance().similarity( theDerivatives.sub(1, nHitMeas1 + nHitMeas2, 1, 9) );
+    theTrajectoryPositionCov = state.decayParameters().covariance().similarity( theDerivatives.sub(1, nHitMeas1 + nHitMeas2, 1, 9) );
 
-  theParameters = state.decayParameters().parameters();
+    theParameters = state.decayParameters().parameters();
+
+    // add virtual mass measurement
+    rowOffset += nVirtualMeas2;
+    int indMass = rowOffset-1;
+    theMeasurements[indMass] = state.primaryMass() - state.decayParameters()[TwoBodyDecayParameters::mass];
+    theMeasurementsCov[indMass][indMass] = state.primaryWidth() * state.primaryWidth();
+    theDerivatives[indMass][TwoBodyDecayParameters::mass] = 1.0;
+  }
 
   theRecHits.insert( theRecHits.end(), recHits.first.begin(), recHits.first.end() );
   theRecHits.insert( theRecHits.end(), recHits.second.begin(), recHits.second.end() );
-
-  // add virtual mass measurement
-  rowOffset += nVirtualMeas2;
-  int indMass = rowOffset-1;
-  theMeasurements[indMass] = state.primaryMass() - state.decayParameters()[TwoBodyDecayParameters::mass];
-  theMeasurementsCov[indMass][indMass] = state.primaryWidth() * state.primaryWidth();
-  theDerivatives[indMass][TwoBodyDecayParameters::mass] = 1.0;
 
   if ( constructTsosWithErrors )
   {

--- a/Alignment/ReferenceTrajectories/src/VMatrix.cc
+++ b/Alignment/ReferenceTrajectories/src/VMatrix.cc
@@ -1,0 +1,430 @@
+/*
+ * VMatrix.cpp
+ *
+ *  Created on: Feb 15, 2012
+ *      Author: kleinwrt
+ */
+
+#include "Alignment/ReferenceTrajectories/interface/VMatrix.h"
+
+//! Namespace for the general broken lines package
+namespace gbl {
+
+/*********** simple Matrix based on std::vector<double> **********/
+
+VMatrix::VMatrix(const unsigned int nRows, const unsigned int nCols) :
+		numRows(nRows), numCols(nCols), theVec(nRows * nCols) {
+}
+
+VMatrix::VMatrix(const VMatrix &aMatrix) :
+		numRows(aMatrix.numRows), numCols(aMatrix.numCols), theVec(
+				aMatrix.theVec) {
+
+}
+
+VMatrix::~VMatrix() {
+}
+
+/// Resize Matrix.
+/**
+ * \param [in] nRows Number of rows.
+ * \param [in] nCols Number of columns.
+ */
+void VMatrix::resize(const unsigned int nRows, const unsigned int nCols) {
+	numRows = nRows;
+	numCols = nCols;
+	theVec.resize(nRows * nCols);
+}
+
+/// Get transposed matrix.
+/**
+ * \return Transposed matrix.
+ */
+VMatrix VMatrix::transpose() const {
+	VMatrix aResult(numCols, numRows);
+	for (unsigned int i = 0; i < numRows; ++i) {
+		for (unsigned int j = 0; j < numCols; ++j) {
+			aResult(j, i) = theVec[numCols * i + j];
+		}
+	}
+	return aResult;
+}
+
+/// Get number of rows.
+/**
+ * \return Number of rows.
+ */
+unsigned int VMatrix::getNumRows() const {
+	return numRows;
+}
+
+/// Get number of columns.
+/**
+ * \return Number of columns.
+ */
+unsigned int VMatrix::getNumCols() const {
+	return numCols;
+}
+
+/// Print matrix.
+void VMatrix::print() const {
+	std::cout << " VMatrix: " << numRows << "*" << numCols << std::endl;
+	for (unsigned int i = 0; i < numRows; ++i) {
+		for (unsigned int j = 0; j < numCols; ++j) {
+			if (j % 5 == 0) {
+				std::cout << std::endl << std::setw(4) << i << ","
+						<< std::setw(4) << j << "-" << std::setw(4)
+						<< std::min(j + 4, numCols) << ":";
+			}
+			std::cout << std::setw(13) << theVec[numCols * i + j];
+		}
+	}
+	std::cout << std::endl << std::endl;
+}
+
+/// Multiplication Matrix*Vector.
+VVector VMatrix::operator*(const VVector &aVector) const {
+	VVector aResult(numRows);
+	for (unsigned int i = 0; i < this->numRows; ++i) {
+		double sum = 0.0;
+		for (unsigned int j = 0; j < this->numCols; ++j) {
+			sum += theVec[numCols * i + j] * aVector(j);
+		}
+		aResult(i) = sum;
+	}
+	return aResult;
+}
+
+/// Multiplication Matrix*Matrix.
+VMatrix VMatrix::operator*(const VMatrix &aMatrix) const {
+
+	VMatrix aResult(numRows, aMatrix.numCols);
+	for (unsigned int i = 0; i < numRows; ++i) {
+		for (unsigned int j = 0; j < aMatrix.numCols; ++j) {
+			double sum = 0.0;
+			for (unsigned int k = 0; k < numCols; ++k) {
+				sum += theVec[numCols * i + k] * aMatrix(k, j);
+			}
+			aResult(i, j) = sum;
+		}
+	}
+	return aResult;
+}
+
+/// Addition Matrix+Matrix.
+VMatrix VMatrix::operator+(const VMatrix &aMatrix) const {
+	VMatrix aResult(numRows, numCols);
+	for (unsigned int i = 0; i < numRows; ++i) {
+		for (unsigned int j = 0; j < numCols; ++j) {
+			aResult(i, j) = theVec[numCols * i + j] + aMatrix(i, j);
+		}
+	}
+	return aResult;
+}
+
+/// Assignment Matrix=Matrix.
+VMatrix &VMatrix::operator=(const VMatrix &aMatrix) {
+	if (this != &aMatrix) {   // Gracefully handle self assignment
+		numRows = aMatrix.getNumRows();
+		numCols = aMatrix.getNumCols();
+		theVec.resize(numRows * numCols);
+		for (unsigned int i = 0; i < numRows; ++i) {
+			for (unsigned int j = 0; j < numCols; ++j) {
+				theVec[numCols * i + j] = aMatrix(i, j);
+			}
+		}
+	}
+	return *this;
+}
+
+/*********** simple symmetric Matrix based on std::vector<double> **********/
+
+VSymMatrix::VSymMatrix(const unsigned int nRows) :
+		numRows(nRows), theVec((nRows * nRows + nRows) / 2) {
+}
+
+VSymMatrix::~VSymMatrix() {
+}
+
+/// Resize symmetric matrix.
+/**
+ * \param [in] nRows Number of rows.
+ */
+void VSymMatrix::resize(const unsigned int nRows) {
+	numRows = nRows;
+	theVec.resize((nRows * nRows + nRows) / 2);
+}
+
+/// Get number of rows (= number of colums).
+/**
+ * \return Number of rows.
+ */
+unsigned int VSymMatrix::getNumRows() const {
+	return numRows;
+}
+
+/// Print matrix.
+void VSymMatrix::print() const {
+	std::cout << " VSymMatrix: " << numRows << "*" << numRows << std::endl;
+	for (unsigned int i = 0; i < numRows; ++i) {
+		for (unsigned int j = 0; j <= i; ++j) {
+			if (j % 5 == 0) {
+				std::cout << std::endl << std::setw(4) << i << ","
+						<< std::setw(4) << j << "-" << std::setw(4)
+						<< std::min(j + 4, i) << ":";
+			}
+			std::cout << std::setw(13) << theVec[(i * i + i) / 2 + j];
+		}
+	}
+	std::cout << std::endl << std::endl;
+}
+
+/// Subtraction SymMatrix-(sym)Matrix.
+VSymMatrix VSymMatrix::operator-(const VMatrix &aMatrix) const {
+	VSymMatrix aResult(numRows);
+	for (unsigned int i = 0; i < numRows; ++i) {
+		for (unsigned int j = 0; j <= i; ++j) {
+			aResult(i, j) = theVec[(i * i + i) / 2 + j] - aMatrix(i, j);
+		}
+	}
+	return aResult;
+}
+
+/// Multiplication SymMatrix*Vector.
+VVector VSymMatrix::operator*(const VVector &aVector) const {
+	VVector aResult(numRows);
+	for (unsigned int i = 0; i < numRows; ++i) {
+		aResult(i) = theVec[(i * i + i) / 2 + i] * aVector(i);
+		for (unsigned int j = 0; j < i; ++j) {
+			aResult(j) += theVec[(i * i + i) / 2 + j] * aVector(i);
+			aResult(i) += theVec[(i * i + i) / 2 + j] * aVector(j);
+		}
+	}
+	return aResult;
+}
+
+/// Multiplication SymMatrix*Matrix.
+VMatrix VSymMatrix::operator*(const VMatrix &aMatrix) const {
+	unsigned int nCol = aMatrix.getNumCols();
+	VMatrix aResult(numRows, nCol);
+	for (unsigned int l = 0; l < nCol; ++l) {
+		for (unsigned int i = 0; i < numRows; ++i) {
+			aResult(i, l) = theVec[(i * i + i) / 2 + i] * aMatrix(i, l);
+			for (unsigned int j = 0; j < i; ++j) {
+				aResult(j, l) += theVec[(i * i + i) / 2 + j] * aMatrix(i, l);
+				aResult(i, l) += theVec[(i * i + i) / 2 + j] * aMatrix(j, l);
+			}
+		}
+	}
+	return aResult;
+}
+
+/*********** simple Vector based on std::vector<double> **********/
+
+VVector::VVector(const unsigned int nRows) :
+		numRows(nRows), theVec(nRows) {
+}
+
+VVector::VVector(const VVector &aVector) :
+		numRows(aVector.numRows), theVec(aVector.theVec) {
+
+}
+
+VVector::~VVector() {
+}
+
+/// Resize vector.
+/**
+ * \param [in] nRows Number of rows.
+ */
+void VVector::resize(const unsigned int nRows) {
+	numRows = nRows;
+	theVec.resize(nRows);
+}
+
+/// Get part of vector.
+/**
+ * \param [in] len Length of part.
+ * \param [in] start Offset of part.
+ * \return Part of vector.
+ */
+VVector VVector::getVec(unsigned int len, unsigned int start) const {
+	VVector aResult(len);
+	std::memcpy(&aResult.theVec[0], &theVec[start], sizeof(double) * len);
+	return aResult;
+}
+
+/// Put part of vector.
+/**
+ * \param [in] aVector Vector with part.
+ * \param [in] start Offset of part.
+ */
+void VVector::putVec(const VVector &aVector, unsigned int start) {
+	std::memcpy(&theVec[start], &aVector.theVec[0],
+			sizeof(double) * aVector.numRows);
+}
+
+/// Get number of rows.
+/**
+ * \return Number of rows.
+ */
+unsigned int VVector::getNumRows() const {
+	return numRows;
+}
+
+/// Print vector.
+void VVector::print() const {
+	std::cout << " VVector: " << numRows << std::endl;
+	for (unsigned int i = 0; i < numRows; ++i) {
+
+		if (i % 5 == 0) {
+			std::cout << std::endl << std::setw(4) << i << "-" << std::setw(4)
+					<< std::min(i + 4, numRows) << ":";
+		}
+		std::cout << std::setw(13) << theVec[i];
+	}
+	std::cout << std::endl << std::endl;
+}
+
+/// Subtraction Vector-Vector.
+VVector VVector::operator-(const VVector &aVector) const {
+	VVector aResult(numRows);
+	for (unsigned int i = 0; i < numRows; ++i) {
+		aResult(i) = theVec[i] - aVector(i);
+	}
+	return aResult;
+}
+
+/// Assignment Vector=Vector.
+VVector &VVector::operator=(const VVector &aVector) {
+	if (this != &aVector) {   // Gracefully handle self assignment
+		numRows = aVector.getNumRows();
+		theVec.resize(numRows);
+		for (unsigned int i = 0; i < numRows; ++i) {
+			theVec[i] = aVector(i);
+		}
+	}
+	return *this;
+}
+
+/*============================================================================
+ from mpnum.F (MillePede-II by V. Blobel, Univ. Hamburg)
+ ============================================================================*/
+/// Matrix inversion.
+/**
+ *     Invert symmetric N-by-N matrix V in symmetric storage mode
+ *               V(1) = V11, V(2) = V12, V(3) = V22, V(4) = V13, . . .
+ *               replaced by inverse matrix
+ *
+ *     Method of solution is by elimination selecting the  pivot  on  the
+ *     diagonal each stage. The rank of the matrix is returned in  NRANK.
+ *     For NRANK ne N, all remaining  rows  and  cols  of  the  resulting
+ *     matrix V are  set  to  zero.
+ *  \exception 1 : matrix is singular.
+ *  \return Rank of matrix.
+ */
+unsigned int VSymMatrix::invert() {
+
+	const double eps = 1.0E-10;
+	unsigned int aSize = numRows;
+	std::vector<int> next(aSize);
+	std::vector<double> diag(aSize);
+	int nSize = aSize;
+
+	int first = 1;
+	for (int i = 1; i <= nSize; ++i) {
+		next[i - 1] = i + 1; // set "next" pointer
+		diag[i - 1] = fabs(theVec[(i * i + i) / 2 - 1]); // save abs of diagonal elements
+	}
+	next[aSize - 1] = -1; // end flag
+
+	unsigned int nrank = 0;
+	for (int i = 1; i <= nSize; ++i) { // start of loop
+		int k = 0;
+		double vkk = 0.0;
+
+		int j = first;
+		int previous = 0;
+		int last = previous;
+		// look for pivot
+		while (j > 0) {
+			int jj = (j * j + j) / 2 - 1;
+			if (fabs(theVec[jj]) > std::max(fabs(vkk), eps * diag[j - 1])) {
+				vkk = theVec[jj];
+				k = j;
+				last = previous;
+			}
+			previous = j;
+			j = next[j - 1];
+		}
+		// pivot found
+		if (k > 0) {
+			int kk = (k * k + k) / 2 - 1;
+			if (last <= 0) {
+				first = next[k - 1];
+			} else {
+				next[last - 1] = next[k - 1];
+			}
+			next[k - 1] = 0; // index is used, reset
+			nrank++; // increase rank and ...
+
+			vkk = 1.0 / vkk;
+			theVec[kk] = -vkk;
+			int jk = kk - k;
+			int jl = -1;
+			for (int j = 1; j <= nSize; ++j) { // elimination
+				if (j == k) {
+					jk = kk;
+					jl += j;
+				} else {
+					if (j < k) {
+						++jk;
+					} else {
+						jk += j - 1;
+					}
+
+					double vjk = theVec[jk];
+					theVec[jk] = vkk * vjk;
+					int lk = kk - k;
+					if (j >= k) {
+						for (int l = 1; l <= k - 1; ++l) {
+							++jl;
+							++lk;
+							theVec[jl] -= theVec[lk] * vjk;
+						}
+						++jl;
+						lk = kk;
+						for (int l = k + 1; l <= j; ++l) {
+							++jl;
+							lk += l - 1;
+							theVec[jl] -= theVec[lk] * vjk;
+						}
+					} else {
+						for (int l = 1; l <= j; ++l) {
+							++jl;
+							++lk;
+							theVec[jl] -= theVec[lk] * vjk;
+						}
+					}
+				}
+			}
+		} else {
+			for (int k = 1; k <= nSize; ++k) {
+				if (next[k - 1] >= 0) {
+					int kk = (k * k - k) / 2 - 1;
+					for (int j = 1; j <= nSize; ++j) {
+						if (next[j - 1] >= 0) {
+							theVec[kk + j] = 0.0; // clear matrix row/col
+						}
+					}
+				}
+			}
+			throw 1; // singular
+		}
+	}
+	for (int ij = 0; ij < (nSize * nSize + nSize) / 2; ++ij) {
+		theVec[ij] = -theVec[ij]; // finally reverse sign of all matrix elements
+	}
+	return nrank;
+}
+}


### PR DESCRIPTION
For the tracker alignment with Millepede-II in the recent years as reference trajectory with proper description of multiple scattering a custom implementation of ‘broken lines’ had been used. Meanwhile this has been developed further to the so called ‘general broken lines’ (GBL) mathematically equivalent to a Kalman filter (NIM A, 673 (2012), 107-110). Experiment independent implementations (C++, Python, Fortran) are maintained by the Helmholtz Terascale Alliance at DESY.
The current custom implementation allows only the construction of the (reference) trajectory (fitted later by Millepede-II). GBL implements a rich set of features like fitting the trajectory (allows to iterate the reference trajectory) or direct output to a Millepede-II binary file or 4D measurements (position and direction). The implementation of the reference trajectories in CMSSW with GBL is much simpler compared to the custom ones. This would very much ease a possible extension to the muon system for a combined alignment.
Further information:
- https://indico.cern.ch/event/243958/session/1/contribution/6/material/slides/0.pdf
- https://www.wiki.terascale.de/index.php/GeneralBrokenLines
- https://www.desy.de/~kleinwrt/GBL/doc/cpp/html/index.html
