### PR TITLE
Look for built in types first

### DIFF
--- a/FWCore/Utilities/src/TypeWithDict.cc
+++ b/FWCore/Utilities/src/TypeWithDict.cc
@@ -80,10 +80,6 @@ namespace edm {
     if (it != typeMap.end()) {
       return TypeWithDict(it->second, property);
     }
-    TClass* theClass = TClass::GetClass(name.c_str());
-    if (theClass != nullptr && theClass->GetTypeInfo() != nullptr) {
-      return TypeWithDict(theClass, property);
-    }
     TDataType* theDataType = gROOT->GetType(name.c_str()); 
     if(theDataType) {
       switch(theDataType->GetType()) {
@@ -128,6 +124,10 @@ namespace edm {
       return TypeWithDict(typeid(void), property);
     }
 
+    TClass* theClass = TClass::GetClass(name.c_str());
+    if (theClass != nullptr && theClass->GetTypeInfo() != nullptr) {
+      return TypeWithDict(theClass, property);
+    }
     TEnum* theEnum = TEnum::GetEnum(name.c_str(), TEnum::kAutoload);
     if(theEnum) {
       return TypeWithDict(theEnum, name, property);


### PR DESCRIPTION
A performance improvement.  When creating a TypeWithDict from a type name, check for built in types before checking for classes.
This is because it is _much_ cheaper to check for a built in type than for a class.
Please merge this request as soon as convenient.
