### PR TITLE
Update types of event/run/lumi in Jet/MET

### DIFF
--- a/RecoJets/FFTJetProducers/plugins/FFTJetTreeDump.cc
+++ b/RecoJets/FFTJetProducers/plugins/FFTJetTreeDump.cc
@@ -40,6 +40,8 @@
 // functions which manipulate storable trees
 #include "RecoJets/FFTJetAlgorithms/interface/clusteringTreeConverters.h"
 
+#include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
+
 using namespace fftjetcms;
 
 //
@@ -179,8 +181,8 @@ void FFTJetTreeDump::processTreeData(const edm::Event& iEvent,
                                      std::ofstream& file)
 {
     // Get the event number
-    const unsigned long runNum = iEvent.id().run();
-    const unsigned long evNum = iEvent.id().event();
+    edm::RunNumber_t const  runNum = iEvent.id().run();
+    edm::EventNumber_t const evNum = iEvent.id().event();
 
     // Get the input
     edm::Handle<StoredTree> input;

--- a/RecoJets/JetAnalyzers/src/FFTJetImageRecorder.cc
+++ b/RecoJets/JetAnalyzers/src/FFTJetImageRecorder.cc
@@ -37,6 +37,8 @@
 
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
 
+#include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
+
 #define init_param(type, varname) varname (ps.getParameter< type >( #varname ))
 
 //
@@ -95,8 +97,8 @@ void FFTJetImageRecorder::beginJob()
 void FFTJetImageRecorder::analyze(const edm::Event& iEvent,
                                   const edm::EventSetup& iSetup)
 {
-    const long runnumber = iEvent.id().run();
-    const long eventnumber = iEvent.id().event();
+    edm::RunNumber_t const runnumber = iEvent.id().run();
+    edm::EventNumber_t const eventnumber = iEvent.id().event();
 
     edm::Handle<TH3F> input;
     iEvent.getByToken(histoToken, input);

--- a/RecoJets/JetAnalyzers/src/FFTJetPileupAnalyzer.cc
+++ b/RecoJets/JetAnalyzers/src/FFTJetPileupAnalyzer.cc
@@ -42,6 +42,8 @@
 
 #include "DataFormats/JetReco/interface/DiscretizedEnergyFlow.h"
 
+#include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
+
 #define init_param(type, varname) varname (ps.getParameter< type >( #varname ))
 
 //
@@ -289,8 +291,8 @@ void FFTJetPileupAnalyzer::analyze(const edm::Event& iEvent,
     totalNpu = -1;
     totalNPV = -1;
 
-    const long runnumber = iEvent.id().run();
-    const long eventnumber = iEvent.id().event();
+    edm::RunNumber_t const runnumber = iEvent.id().run();
+    edm::EventNumber_t const eventnumber = iEvent.id().event();
     ntupleData.push_back(runnumber);
     ntupleData.push_back(eventnumber);
 

--- a/RecoMET/METFilters/plugins/EcalDeadCellDeltaRFilter.cc
+++ b/RecoMET/METFilters/plugins/EcalDeadCellDeltaRFilter.cc
@@ -88,6 +88,8 @@
 #include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 
+#include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
+
 #include "TFile.h"
 #include "TTree.h"
 #include "TH1.h"
@@ -123,7 +125,10 @@ private:
   void loadJets(const edm::Event& iEvent, const edm::EventSetup& iSetup);
   void loadMET(const edm::Event& iEvent, const edm::EventSetup& iSetup);
 
-  unsigned int run, event, ls; bool isdata;
+  edm::RunNumber_t run;
+  edm::EventNumber_t event;
+  edm::LuminosityBlockNumber_t ls;
+  bool isdata;
 
   double calomet, calometPhi, tcmet, tcmetPhi, pfmet, pfmetPhi;
 
@@ -312,7 +317,7 @@ bool EcalDeadCellDeltaRFilter::filter(edm::Event& iEvent, const edm::EventSetup&
   int boundaryStatus = etaToBoundary(closeToMETjetsVec);
 
   if(debug_ ){
-     printf("\nrun : %8d  event : %12d  ls : %8d  dPhiToMETstatus : %d  deadCellStatus : %d  boundaryStatus : %d\n", run, event, ls, dPhiToMETstatus, deadCellStatus, boundaryStatus);
+     printf("\nrun : %8u  event : %12llu  ls : %8u  dPhiToMETstatus : %d  deadCellStatus : %d  boundaryStatus : %d\n", run, event, ls, dPhiToMETstatus, deadCellStatus, boundaryStatus);
      printf("met : %6.2f  metphi : % 6.3f  dPhiToMET : %5.3f  dRtoDeadCell : %5.3f\n", (*met)[0].pt(), (*met)[0].phi(), dPhiToMET, dRtoDeadCell);
   }
 

--- a/RecoMET/METFilters/plugins/EcalDeadCellTriggerPrimitiveFilter.cc
+++ b/RecoMET/METFilters/plugins/EcalDeadCellTriggerPrimitiveFilter.cc
@@ -64,6 +64,8 @@
 #include "Geometry/CaloTopology/interface/CaloTowerConstituentsMap.h"
 #include "DataFormats/CaloTowers/interface/CaloTowerDetId.h"
 
+#include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
+
 #include "TFile.h"
 #include "TTree.h"
 
@@ -145,7 +147,9 @@ private:
   std::vector<std::string> *cutFlowStrTmpPtr;
 
   void loadEventInfo(const edm::Event& iEvent, const edm::EventSetup& iSetup);
-  unsigned int run, event, ls;
+  edm::RunNumber_t run;
+  edm::EventNumber_t event;
+  edm::LuminosityBlockNumber_t ls;
 
   bool getEventInfoForFilterOnce_;
 
@@ -356,7 +360,7 @@ bool EcalDeadCellTriggerPrimitiveFilter::filter(edm::Event& iEvent, const edm::E
 
   if(debug_ && verbose_ >=2){
      int evtstatusABS = abs(evtTagged);
-     printf("\nrun : %8d  event : %10d  lumi : %4d  evtTPstatus  ABS : %d  13 : % 2d\n", run, event, ls, evtstatusABS, evtTagged);
+     printf("\nrun : %8u  event : %10llu  lumi : %4u  evtTPstatus  ABS : %d  13 : % 2d\n", run, event, ls, evtstatusABS, evtTagged);
   }
 
   std::auto_ptr<bool> pOut( new bool(pass) );

--- a/RecoMET/METFilters/plugins/HcalLaserEventFilter.cc
+++ b/RecoMET/METFilters/plugins/HcalLaserEventFilter.cc
@@ -65,7 +65,6 @@ class HcalLaserEventFilter : public edm::EDFilter {
 
   // Filter option 1:  veto events by run, event number
   const bool vetoByRunEventNumber_;
-//  std::vector<std::pair<unsigned int,unsigned int> > RunEventData_;
   std::vector<std::pair<edm::RunNumber_t,edm::EventNumber_t> > RunEventData_;
 
   // Filter option 2:  veto events by HBHE occupancy

--- a/RecoMET/METFilters/plugins/HcalLaserEventFilter.cc
+++ b/RecoMET/METFilters/plugins/HcalLaserEventFilter.cc
@@ -41,6 +41,7 @@ It also allows users to remove events in which the number of HBHE rechits exceed
 
 #include "DataFormats/METReco/interface/HcalNoiseSummary.h"
 
+#include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
 //
 // class declaration
 //
@@ -64,7 +65,8 @@ class HcalLaserEventFilter : public edm::EDFilter {
 
   // Filter option 1:  veto events by run, event number
   const bool vetoByRunEventNumber_;
-  std::vector<std::pair<unsigned int,unsigned int> > RunEventData_;
+//  std::vector<std::pair<unsigned int,unsigned int> > RunEventData_;
+  std::vector<std::pair<edm::RunNumber_t,edm::EventNumber_t> > RunEventData_;
 
   // Filter option 2:  veto events by HBHE occupancy
   const bool vetoByHBHEOccupancy_;
@@ -135,8 +137,8 @@ HcalLaserEventFilter::HcalLaserEventFilter(const edm::ParameterSet& iConfig)
   // Make this a map for better search performance?
   for (unsigned int i=0;i+1<temprunevt.size();i+=2)
     {
-      unsigned int run=temprunevt[i];
-      unsigned int evt=temprunevt[i+1];
+      edm::RunNumber_t run=temprunevt[i];
+      edm::EventNumber_t evt=temprunevt[i+1];
       RunEventData_.push_back(std::make_pair(run,evt));
     }
   errorcount=0;

--- a/RecoMET/METFilters/plugins/MultiEventFilter.cc
+++ b/RecoMET/METFilters/plugins/MultiEventFilter.cc
@@ -7,16 +7,18 @@
 
 #include "FWCore/ParameterSet/interface/FileInPath.h"
 
+#include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
+
 #include <fstream>
 
 class MultiEventFilter : public edm::EDFilter {
 
   class Event {
     public:
-      Event(unsigned int r, unsigned int l, unsigned int e) : run(r), lumi(l), event(e) {}
-      unsigned int run;
-      unsigned int lumi;
-      unsigned int event;
+      Event(edm::RunNumber_t r, edm::LuminosityBlockNumber_t l, edm::EventNumber_t e) : run(r), lumi(l), event(e) {}
+      edm::RunNumber_t run;
+      edm::LuminosityBlockNumber_t lumi;
+      edm::EventNumber_t event;
   };
 
   public:


### PR DESCRIPTION
The online is changing to produce data with event numbers that are 64 bits instead of 32 bits.  CMSSW software needs to be modified to handle that. Following 
https://hypernews.cern.ch/HyperNews/CMS/get/recoDevelopment/1302.html
I am making changes to different packages, here JET/MET. I am using the  events/run/lumi types defined in   DataFormats/Provenance/interface/RunLumiEventNumber.h . There is an issue with fastjet that needs special treatment (not for this PR). Updates are generally trivial and there should be no any visible effects of them (except for the rare event numbers with > 32 bits).  
