### PR TITLE
Support autoloading of enumerations

### DIFF
--- a/FWCore/RootAutoLibraryLoader/src/RootAutoLibraryLoader.cc
+++ b/FWCore/RootAutoLibraryLoader/src/RootAutoLibraryLoader.cc
@@ -22,6 +22,7 @@
 
 #include "TClass.h"
 #include "TClassTable.h"
+#include "TEnum.h"
 #include "TInterpreter.h"
 #include "TROOT.h"
 
@@ -36,7 +37,11 @@ static
 bool
 rootTypeSystemLookupClass(const std::string& name)
 {
-  return TClassTable::GetDict(name.c_str());
+  bool found = TClassTable::GetDict(name.c_str()) != nullptr;
+  if (!found) {
+    found = TEnum::GetEnum(name.c_str(), TEnum::kNone) != nullptr;
+  }
+  return found;
 }
 
 /// Use the SEAL Capabilities plugin to load a library which


### PR DESCRIPTION
This pull request enables the autolibrary loader to find enumerations in the root type system.
This is necessary to load a library based on the presence of an enumeration in the ROOT type system.
Please merge this request as soon as convenient.
