### PR TITLE
Update of the Higgs DQM list of monitored path

### DIFF
--- a/HLTriggerOffline/Higgs/python/hltHiggsPostProcessors_cff.py
+++ b/HLTriggerOffline/Higgs/python/hltHiggsPostProcessors_cff.py
@@ -133,6 +133,13 @@ hltHiggsPostHgg = hltHiggsPostProcessor.clone()
 hltHiggsPostHgg.subDirs = ['HLT/Higgs/Hgg']
 hltHiggsPostHgg.efficiencyProfile = efficiency_strings
 
+hltHiggsPostDoubleHinTaus = hltHiggsPostProcessor.clone()
+hltHiggsPostDoubleHinTaus.subDirs = ['HLT/Higgs/DoubleHinTaus']
+hltHiggsPostDoubleHinTaus.efficiencyProfile = efficiency_strings
+
+ltHiggsPostHiggsDalitz = hltHiggsPostProcessor.clone()
+ltHiggsPostHiggsDalitz.subDirs = ['HLT/Higgs/HiggsDalitz']
+ltHiggsPostHiggsDalitz.efficiencyProfile = efficiency_strings
 
 hltHiggsPostH2tau = hltHiggsPostProcessor.clone()
 hltHiggsPostH2tau.subDirs = ['HLT/Higgs/H2tau']

--- a/HLTriggerOffline/Higgs/python/hltHiggsPostProcessors_cff.py
+++ b/HLTriggerOffline/Higgs/python/hltHiggsPostProcessors_cff.py
@@ -137,9 +137,9 @@ hltHiggsPostDoubleHinTaus = hltHiggsPostProcessor.clone()
 hltHiggsPostDoubleHinTaus.subDirs = ['HLT/Higgs/DoubleHinTaus']
 hltHiggsPostDoubleHinTaus.efficiencyProfile = efficiency_strings
 
-ltHiggsPostHiggsDalitz = hltHiggsPostProcessor.clone()
-ltHiggsPostHiggsDalitz.subDirs = ['HLT/Higgs/HiggsDalitz']
-ltHiggsPostHiggsDalitz.efficiencyProfile = efficiency_strings
+hltHiggsPostHiggsDalitz = hltHiggsPostProcessor.clone()
+hltHiggsPostHiggsDalitz.subDirs = ['HLT/Higgs/HiggsDalitz']
+hltHiggsPostHiggsDalitz.efficiencyProfile = efficiency_strings
 
 hltHiggsPostH2tau = hltHiggsPostProcessor.clone()
 hltHiggsPostH2tau.subDirs = ['HLT/Higgs/H2tau']
@@ -213,7 +213,9 @@ hltHiggsPostProcessors = cms.Sequence(
         hltHiggsPostHtaunu+
         hltHiggsPostH2tau+
         hltHiggsPostVBFHbb+
-        hltHiggsPostZnnHbb
+        hltHiggsPostZnnHbb+
+        hltHiggsPostDoubleHinTaus+
+        hltHiggsPostHiggsDalitz
 )
 
 

--- a/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
+++ b/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
         
     hltProcessName = cms.string("HLT"),
-    analysis       = cms.vstring("HWW", "HZZ", "Hgg", "Htaunu", "H2tau", "VBFHbb", "ZnnHbb"), 
+    analysis       = cms.vstring("HWW", "HZZ", "Hgg", "Htaunu", "H2tau", "VBFHbb", "ZnnHbb","DoubleHinTaus","HiggsDalitz"),
     
     # -- The instance name of the reco::GenParticles collection
     genParticleLabel = cms.string("genParticles"),
@@ -105,17 +105,19 @@ hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
 
     HWW = cms.PSet( 
         hltPathsToCheck = cms.vstring(
-            "HLT_Mu17_Mu8_v",
-            "HLT_Mu17_TkMu8_v",
-            "HLT_Mu17_Ele8_CaloIdT_CaloIsoVL_TrkIdVL_TrkIsoVL_v",
-            "HLT_Mu8_Ele17_CaloIdT_CaloIsoVL_TrkIdVL_TrkIsoVL_v",
-            "HLT_Ele17_CaloIdT_CaloIsoVL_TrkIdVL_TrkIsoVL_Ele8_CaloIdT_CaloIsoVL_TrkIdVL_TrkIsoVL_v",
-            "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_v",
-                    "HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_v",
-                    "HLT_Mu23_TrkIsoVVL_Ele12_Gsf_CaloId_TrackId_Iso_MediumWP_v",
-                    "HLT_Mu8_TrkIsoVVL_Ele23_Gsf_CaloId_TrackId_Iso_MediumWP_v",
-                    "HLT_Ele23_Ele12_CaloId_TrackId_Iso_v"
-            ),
+          #dileptons for Hww and Hzz
+              "HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v",
+              "HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_v",
+              "HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_v",
+              "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v",
+              "HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ_v",
+              #prescaled control paths
+              "HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_v",
+              "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_v",
+              "HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_v",
+              "HLT_Ele23_CaloIdL_TrackIdL_IsoVL_v",
+              "HLT_Ele12_CaloIdL_TrackIdL_IsoVL_v"
+          ),
         recMuonLabel  = cms.string("muons"),
         recElecLabel  = cms.string("gedGsfElectrons"),
         # -- Analysis specific cuts
@@ -123,10 +125,13 @@ hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
         ),
     HZZ = cms.PSet( 
         hltPathsToCheck = cms.vstring(
-            "HLT_Mu17_TkMu8_v",
-            "HLT_Ele17_CaloIdT_CaloIsoVL_TrkIdVL_TrkIsoVL_Ele8_CaloIdT_CaloIsoVL_TrkIdVL_TrkIsoVL_v",
-            "HLT_Ele17_Ele12_Ele10_CaloId_TrackId_v"
-            ),
+        #tri-leptons for Hzz
+            "HLT_Ele16_Ele12_Ele8_CaloIdL_TrackIdL_v",
+            "HLT_Mu8_DiEle12_CaloIdL_TrackIdL_v",
+            "HLT_DiMu9_Ele9_CaloIdL_TrackIdL_v",
+            "HLT_TripleMu_12_10_5_1PairDZ_v",
+            "HLT_TripleMu_12_10_5_v"
+        ),
         recMuonLabel  = cms.string("muons"),
         recElecLabel  = cms.string("gedGsfElectrons"),
         #recTrackLabel = cms.string("globalMuons"),
@@ -135,17 +140,38 @@ hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
         ),
     Hgg = cms.PSet( 
         hltPathsToCheck = cms.vstring(
-            "HLT_Photon26_R9Id85_OR_CaloId10_Iso50_Photon18_R9Id85_OR_CaloId10_Iso50_Mass70_v",
-            "HLT_Photon36_R9Id85_OR_CaloId10_Iso50_Photon22_R9Id85_OR_CaloId10_Iso50_v",
-            "HLT_Photon36_R9Id85_OR_CaloId10_Iso50_Photon10_R9Id85_OR_CaloId10_Iso50_Mass80_v",
             "HLT_Photon36_R9Id85_OR_CaloId24b40e_Iso50T80L_Photon18_AND_HE10_R9Id65_Mass95_v",
-            "HLT_Photon42_R9Id85_OR_CaloId24b40e_Iso50T80L_Photon22_AND_HE10_R9Id65_v"
-            ),
+            "HLT_Photon42_R9Id85_OR_CaloId24b40e_Iso50T80L_Photon22_AND_HE10_R9Id65_v",
+            "HLT_Photon28_R9Id85_OR_CaloId24b40e_Iso50T80L_Photon14_AND_HE10_R9Id65_Mass50_Eta1p5_v",
+            "HLT_Photon36_R9Id85_AND_CaloId24b40e_Iso50T80L_Photon18_AND_HE10_R9Id65_Mass30_v",
+            "HLT_Photon36_R9Id85_AND_CaloId24b40e_Iso50T80L_Photon18_AND_HE10_R9Id65_v",
+            "HLT_Photon36_R9Id85_OR_CaloId24b40e_Iso50T80L_Photon18_AND_HE10_R9Id65_Mass70_v"
+        ),
         recPhotonLabel  = cms.string("photons"),
         # -- Analysis specific cuts
         minCandidates = cms.uint32(2), 
         ),
-    Htaunu = cms.PSet( 
+     DoubleHinTaus = cms.PSet(
+        hltPathsToCheck = cms.vstring(
+            "HLT_Mu17_Mu8_SameSign_v",
+            "HLT_Mu17_Mu8_SameSign_DPhi_v"
+        ),
+        recMuonLabel  = cms.string("muons"),
+        # -- Analysis specific cuts
+        minCandidates = cms.uint32(2),
+        ),
+     HiggsDalitz = cms.PSet(
+        hltPathsToCheck = cms.vstring(
+            "HLT_Mu12_Photon25_CaloIdL_v",
+            "HLT_Mu12_Photon25_CaloIdL_L1ISO_v",
+            "HLT_Mu12_Photon25_CaloIdL_L1OR_v"
+        ),
+        recMuonLabel  = cms.string("muons"),
+        recPhotonLabel  = cms.string("photons"),
+        # -- Analysis specific cuts
+        minCandidates = cms.uint32(2),
+        ),
+     Htaunu = cms.PSet(
         hltPathsToCheck = cms.vstring(
             "HLT_LooseIsoPFTau35_Trk20_Prong1_MET70_v",
             "HLT_LooseIsoPFTau35_Trk20_Prong1_MET75_v",


### PR DESCRIPTION
Update of the Higgs DQM to include the paths recently integrated (or updated) in the HLT menu. The include the paths for the following JIRA tickets:
- [CMSHLT-132](https://its.cern.ch/jira/browse/CMSHLT-132?jql=project%20%3D%20CMSHLT) HLT for low mass Higgs
- [CMSHLT-147](https://its.cern.ch/jira/browse/CMSHLT-147) update of multi lepton paths
- [CMSHLT-163](https://its.cern.ch/jira/browse/CMSHLT-163) same sign double muon trigger
- [CMSHLT-134](https://its.cern.ch/jira/browse/CMSHLT-134) trigger for Higgs Dalitz decay in 2 muons and a photon

The DQM files corresponding to these paths are available here: 
`~hbrun/public/dqmFiles/`
