### PR TITLE
Remove include of unused deprecated header

### DIFF
--- a/RecoLocalCalo/HcalRecAlgos/interface/PulseShapeFitOOTPileupCorrection.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/PulseShapeFitOOTPileupCorrection.h
@@ -9,7 +9,6 @@
 #include "CalibFormats/HcalObjects/interface/HcalCalibrations.h"
 
 #include <TMinuit.h>
-#include "TFitterMinuit.h"
 
 #include <TH1F.h>
 #include "Minuit2/FCNBase.h"


### PR DESCRIPTION
Remove the include of an unused deprecated header.  This header does not exist at all in ROOT6, and this include breaks the build.
This request is utterly trivial.
