### PR TITLE
Remove include of unused deprecated header

### DIFF
--- a/RecoLocalCalo/HcalRecAlgos/interface/PulseShapeFitOOTPileupCorrection.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/PulseShapeFitOOTPileupCorrection.h
@@ -9,7 +9,6 @@
 #include "CalibFormats/HcalObjects/interface/HcalCalibrations.h"
 
 #include <TMinuit.h>
-#include "TFitterMinuit.h"
 
 #include <TH1F.h>
 #include "Minuit2/FCNBase.h"


### PR DESCRIPTION
This request removes the include of an unused deprecated header, which does not even exist in ROOT 6, thereby breaking the build of the ROOT6 IB.
Please merge this request as soon as convenient.  The IB is worthless without this request.
