### PR TITLE
increased #cluster threshold for cosmic seed finder

### DIFF
--- a/DQM/Integration/python/test/sistrip_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/test/sistrip_dqm_sourceclient-live_cfg.py
@@ -241,6 +241,7 @@ if (process.runType.getRunType() == process.runType.cosmic_run):
     # Reco for cosmic data
     process.load('RecoTracker.SpecialSeedGenerators.SimpleCosmicBONSeeder_cfi')
     process.simpleCosmicBONSeeds.ClusterCheckPSet.MaxNumberOfCosmicClusters = 450
+    process.combinatorialcosmicseedfinderP5.MaxNumberOfCosmicClusters = 450
 
     process.RecoForDQM_TrkReco_cosmic = cms.Sequence(process.offlineBeamSpot*process.MeasurementTrackerEvent*process.ctftracksP5)
 


### PR DESCRIPTION
fix to increase the threshold of number of clusters in event, before the cosmic tracking (in online DQM) bails out. This will bring back the missing tracks we currently observe in online for Strips in PEAK mode.
