### PR TITLE
Add support for noticing and complaining about removed plugins.

### DIFF
--- a/FWCore/PluginManager/interface/standard.h
+++ b/FWCore/PluginManager/interface/standard.h
@@ -33,6 +33,7 @@ namespace edmplugin {
     PluginManager::Config config();
     
     const boost::filesystem::path& cachefileName();
+    const boost::filesystem::path& poisonedCachefileName();
     
     const std::string& pluginPrefix();
   }

--- a/FWCore/PluginManager/src/standard.cc
+++ b/FWCore/PluginManager/src/standard.cc
@@ -48,6 +48,11 @@ namespace edmplugin {
       static const boost::filesystem::path s_path(".edmplugincache");
       return s_path;
     }
+
+    const boost::filesystem::path& poisonedCachefileName() {
+      static const boost::filesystem::path s_path(".poisonededmplugincache");
+      return s_path;
+    }
     
     
     const std::string& pluginPrefix() {


### PR DESCRIPTION
This introduces the concept of a poisoned Plugin Cache File which will
contain dummy (wrong) entries for all plugins which should be built
given a local area. If those plugins are actually there, nothing is
changed since the local cache file has precedence. If the plugin was not
built, e.g. it was removed in the local area, the plugin manager will
complain about not finding the library specified by the dummy entry.

This patch alone will not introduce any change in behavior and will
require scram to generate the poison file in order to turn on the new
functionality.
