### PR TITLE
Remove usage of HcalCholeskyMatrix in simulation, and propagate this to the new Global Tags for pre2 RelVal.

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,23 +2,23 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   'DESRUN1_72_V0::All',
+    'run1_design'       :   'DESRUN1_73_V0::All',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   'MCRUN1_72_V0::All',
+    'run1_mc'           :   'MCRUN1_73_V0::All',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   'MCHI1_72_V0::All',
+    'run1_mc_hi'        :   'MCHI1_73_V0::All',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   'MCPA1_72_V0::All',
+    'run1_mc_pa'        :   'MCPA1_73_V0::All',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   'DESRUN2_72_V0::All',
+    'run2_design'       :   'DESRUN2_73_V0::All',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   'MCRUN2_72_V0::All',
+    'run2_mc_50ns'      :   'MCRUN2_73_V0::All',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   'MCRUN2_72_V1::All',
+    'run2_mc'           :   'MCRUN2_73_V1::All',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   'GR_R_72_V12A::All',
+    'run1_data'         :   'GR_R_73_V0A::All',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   'GR_R_72_V13A::All',
+    'run2_data'         :   'GR_R_73_V1A::All',
     # GlobalTag for Run1 HLT: it points to the online GT and overrides the connection string and pfnPrefix for use offline
     'run1_hlt'          :   'GR_H_V43A::All,frontier://FrontierProd/CMS_COND_31X_GLOBALTAG,frontier://FrontierProd/',
     # GlobalTag for Run2 HLT: it points to the online GT and overrides the connection string and pfnPrefix for use offline

--- a/Configuration/AlCa/python/autoCond_condDBv2.py
+++ b/Configuration/AlCa/python/autoCond_condDBv2.py
@@ -2,23 +2,23 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   'DESRUN1_72_V0',
+    'run1_design'       :   'DESRUN1_73_V0',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   'MCRUN1_72_V0',
+    'run1_mc'           :   'MCRUN1_73_V0',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   'MCHI1_72_V0',
+    'run1_mc_hi'        :   'MCHI1_73_V0',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   'MCPA1_72_V0',
+    'run1_mc_pa'        :   'MCPA1_73_V0',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   'DESRUN2_72_V0',
+    'run2_design'       :   'DESRUN2_73_V0',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   'MCRUN2_72_V0',
+    'run2_mc_50ns'      :   'MCRUN2_73_V0',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   'MCRUN2_72_V1',
+    'run2_mc'           :   'MCRUN2_73_V1',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   'GR_R_72_V12A',
+    'run1_data'         :   'GR_R_73_V0A',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   'GR_R_72_V13A',
+    'run2_data'         :   'GR_R_73_V1A',
     # GlobalTag for Run1 HLT: it points to the online GT and overrides the connection string and pfnPrefix for use offline
     'run1_hlt'          :   'GR_H_V43A,frontier://FrontierProd/CMS_CONDITIONS,frontier://FrontierProd/',
     # GlobalTag for Run2 HLT: it points to the online GT and overrides the connection string and pfnPrefix for use offline

--- a/SimCalorimetry/HcalSimAlgos/interface/HcalAmplifier.h
+++ b/SimCalorimetry/HcalSimAlgos/interface/HcalAmplifier.h
@@ -62,6 +62,8 @@ private:
   const HcalDbService * theDbService;
   const CaloVSimParameterMap * theParameterMap;
   const CaloVNoiseSignalGenerator * theNoiseSignalGenerator;
+  const HcalCholeskyMatrices * myCholeskys;
+  const HcalPedestals * myADCPeds;
   HPDIonFeedbackSim * theIonFeedbackSim;
   HcalTimeSlewSim * theTimeSlewSim;
   unsigned theStartingCapId;
@@ -77,8 +79,6 @@ private:
   double HE_ff;
   double HF_ff;
   double HO_ff;
-  const HcalCholeskyMatrices * myCholeskys;
-  const HcalPedestals * myADCPeds;
 };
 
 #endif

--- a/SimCalorimetry/HcalSimAlgos/src/HcalAmplifier.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalAmplifier.cc
@@ -18,7 +18,6 @@
 #include "CLHEP/Random/RandGaussQ.h"
 #include "CLHEP/Random/RandFlat.h"
 
-#include<iostream>
 #include <cmath>
 #include <math.h>
 
@@ -135,33 +134,56 @@ void HcalAmplifier::addPedestals(CaloSamples & frame, CLHEP::HepRandomEngine* en
   if(hcalGenDetId.isHcalCastorDetId()) return;
   if(hcalGenDetId.isHcalZDCDetId()) return;
 
-  const HcalCholeskyMatrix * thisChanCholesky = myCholeskys->getValues(hcalGenDetId,false);
-  if ( !thisChanCholesky) {
-    std::cout << "no Cholesky " << hcalSubDet << " " << hcalGenDetId.rawId() << " " << frame.id().subdetId() <<std::endl;
-    return;
-  }
-  const HcalPedestal * thisChanADCPeds = myADCPeds->getValues(hcalGenDetId);
   int theStartingCapId_2 = (int)floor(CLHEP::RandFlat::shoot(engine, 0., 4.));
-
   double noise [32] = {0.}; //big enough
-  if(addNoise_)
-  {
+
+  if( myCholeskys ) {
+    const HcalCholeskyMatrix * thisChanCholesky = myCholeskys->getValues(hcalGenDetId,false);
+    if ( !thisChanCholesky ) {
+      edm::LogWarning("HcalAmplifier") << "no Cholesky " << hcalSubDet << " "
+				       << hcalGenDetId.rawId() << " " 
+				       << frame.id().subdetId();
+      return;
+    }
+
+    if(addNoise_)
+    {
+      double gauss [32]; //big enough
+      for (int i = 0; i < frame.size(); i++) gauss[i] = CLHEP::RandGaussQ::shoot(engine, 0., 1.);
+      makeNoise(*thisChanCholesky, frame.size(), gauss, noise, (int)theStartingCapId_2);
+    }
+  } else if(addNoise_) {
+    /* TODO: Re-add the Cholesky matrix when computing the noise.
+     * The payloads currently stored in Condition DB suffer a bug in ROOT5 streamer.
+     * The workaround here is to fall back to the old noise computation when the matrix is not provided.
+     * When a permanent fix is found, this condition should be removed:
+     * when Cholesky matrix is not set from the digitizer, issue a warning.
+     * -Salvatore Di Guida
+     */
+    const HcalCalibrationWidths & calibWidths = theDbService->getHcalCalibrationWidths(hcalGenDetId);
     double gauss [32]; //big enough
     for (int i = 0; i < frame.size(); i++) gauss[i] = CLHEP::RandGaussQ::shoot(engine, 0., 1.);
-    makeNoise(*thisChanCholesky, frame.size(), gauss, noise, (int)theStartingCapId_2);
+    makeNoiseOld(hcalSubDet, calibWidths, frame.size(), gauss, noise);
+  } else {
+    edm::LogWarning("HcalAmplifier") << "No Cholesky Matrices provided for new HCAL noise simulation.";
   }
+  
+  if( myADCPeds ) {
+    const HcalPedestal* thisChanADCPeds = myADCPeds->getValues(hcalGenDetId);
+    const HcalQIECoder* coder = theDbService->getHcalCoder(hcalGenDetId);
+    const HcalQIEShape* shape = theDbService->getHcalShape(coder);
 
-  const HcalQIECoder* coder = theDbService->getHcalCoder(hcalGenDetId);
-  const HcalQIEShape* shape = theDbService->getHcalShape(coder);
-
-  for (int tbin = 0; tbin < frame.size(); ++tbin) {
-    int capId = (theStartingCapId_2 + tbin)%4;
-    double x = noise[tbin] * fudgefactor + thisChanADCPeds->getValue(capId);//*(values+capId); //*.70 goes here!
-    int x1=(int)std::floor(x);
-    int x2=(int)std::floor(x+1);
-    float y2=coder->charge(*shape,x2,capId);
-    float y1=coder->charge(*shape,x1,capId);
-    frame[tbin] = (y2-y1)*(x-x1)+y1;
+    for (int tbin = 0; tbin < frame.size(); ++tbin) {
+      int capId = (theStartingCapId_2 + tbin)%4;
+      double x = noise[tbin] * fudgefactor + thisChanADCPeds->getValue(capId);//*(values+capId); //*.70 goes here!
+      int x1=(int)std::floor(x);
+      int x2=(int)std::floor(x+1);
+      float y2=coder->charge(*shape,x2,capId);
+      float y1=coder->charge(*shape,x1,capId);
+      frame[tbin] = (y2-y1)*(x-x1)+y1;
+    }
+  } else {
+    edm::LogWarning("HcalAmplifier") << "No ADC pedestals provided for new HCAL simulation.";
   }
 }
 

--- a/SimCalorimetry/HcalSimAlgos/src/HcalAmplifier.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalAmplifier.cc
@@ -23,12 +23,14 @@
 #include <math.h>
 
 HcalAmplifier::HcalAmplifier(const CaloVSimParameterMap * parameters, bool addNoise, bool PreMix1, bool PreMix2) :
-  theDbService(0), 
+  theDbService(nullptr),
   theParameterMap(parameters),
-  theNoiseSignalGenerator(0),
-  theIonFeedbackSim(0),
-  theTimeSlewSim(0),
-  theStartingCapId(0), 
+  theNoiseSignalGenerator(nullptr),
+  myCholeskys(nullptr),
+  myADCPeds(nullptr),
+  theIonFeedbackSim(nullptr),
+  theTimeSlewSim(nullptr),
+  theStartingCapId(0),
   addNoise_(addNoise),
   preMixDigi_(PreMix1),
   preMixAdd_(PreMix2),

--- a/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
+++ b/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
@@ -401,17 +401,17 @@ void HcalDigitizer::initializeEvent(edm::Event const& e, edm::EventSetup const& 
   theParameterMap->setDbService(conditions.product());
 
   edm::ESHandle<HcalCholeskyMatrices> refCholesky;
-  eventSetup.get<HcalCholeskyMatricesRcd>().get(refCholesky);
-  const HcalCholeskyMatrices * myCholesky = refCholesky.product();
-
+  if (eventSetup.find(edm::eventsetup::EventSetupRecordKey::makeKey<HcalCholeskyMatricesRcd>())) {
+    eventSetup.get<HcalCholeskyMatricesRcd>().get(refCholesky);
+    const HcalCholeskyMatrices * myCholesky = refCholesky.product();
+    theHBHEAmplifier->setCholesky(myCholesky);
+    theHFAmplifier->setCholesky(myCholesky);
+    theHOAmplifier->setCholesky(myCholesky);
+  }
   edm::ESHandle<HcalPedestals> pedshandle;
   eventSetup.get<HcalPedestalsRcd>().get(pedshandle);
   const HcalPedestals *  myADCPedestals = pedshandle.product();
 
-  theHBHEAmplifier->setCholesky(myCholesky);
-  theHFAmplifier->setCholesky(myCholesky);
-  theHOAmplifier->setCholesky(myCholesky);
-  
   theHBHEAmplifier->setADCPeds(myADCPedestals);
   theHFAmplifier->setADCPeds(myADCPedestals);
   theHOAmplifier->setADCPeds(myADCPedestals);


### PR DESCRIPTION
`HcalCholeskyMatrix` payloads are touched by a ROOT5 streamer bug in serialisation. As temporary workaround, we remove their usage in simulation, falling back to the old description of the noise, as agreed with @Dr15Jones at the last ORP.

New set of Global Tags in view of second pre-release of 73X release cycle.
- Run1 and Run2 simulations:
  - added `DYTThresholdObject` payloads with dummy values as currently in configuration, in order to consume them properly from the GT. The values are different for Run1 and Run2 as they account for different geometries. No changes expected for Muon POG
  - removed `HcalCholeskyMatrices` payloads.
- Run1 and Run2 data:
  - added `DYTThresholdObject` payloads with dummy values as currently in configuration, in order to consume them properly from the GT. The values are different for Run1 and Run2 as they account for different geometries. No changes expected for Muon POG.
