### PR TITLE
Propagating run cache and other JSON monitoring changes to 73X

### DIFF
--- a/EventFilter/Utilities/interface/EvFDaqDirector.h
+++ b/EventFilter/Utilities/interface/EvFDaqDirector.h
@@ -104,9 +104,9 @@ namespace evf{
         filesToDeletePtr_ = filesToDelete;
       }
       bool registerStreamProducer(std::string producer) {
-        auto itr = iniFileMap_.find(producer);
-        if (itr==iniFileMap_.end()) {
-            iniFileMap_[producer]=true;
+        auto itr = std::find(streamProducers_.begin(),streamProducers_.end(),producer);
+        if (itr==streamProducers_.end()) {
+            streamProducers_.push_back(producer);
             return false;
         }
         else return true;
@@ -185,7 +185,7 @@ namespace evf{
       bool readEolsDefinition_ = true;
       unsigned int eolsNFilesIndex_ = 1;
 
-      std::map<std::string,bool> iniFileMap_;
+      std::vector<std::string> streamProducers_;
 
   };
 }

--- a/EventFilter/Utilities/interface/EvFDaqDirector.h
+++ b/EventFilter/Utilities/interface/EvFDaqDirector.h
@@ -103,14 +103,7 @@ namespace evf{
         fileDeleteLockPtr_=fileDeleteLock;
         filesToDeletePtr_ = filesToDelete;
       }
-      bool registerStreamProducer(std::string producer) {
-        auto itr = std::find(streamProducers_.begin(),streamProducers_.end(),producer);
-        if (itr==streamProducers_.end()) {
-            streamProducers_.push_back(producer);
-            return false;
-        }
-        else return true;
-      }
+
 
     private:
       //bool bulock();
@@ -184,8 +177,6 @@ namespace evf{
 
       bool readEolsDefinition_ = true;
       unsigned int eolsNFilesIndex_ = 1;
-
-      std::vector<std::string> streamProducers_;
 
   };
 }


### PR DESCRIPTION
This PR collects today's changes to the JSON monitoring code (most notably the addition of a run cache) and reverts yesterday's changes to the DaqDirector which are no longer necessary. After these changes, the 73X branch will be equal to 72X plus #6203 .
