### PR TITLE
Update types of event/run/lumi in Jet/MET (for fastjet)

### DIFF
--- a/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
@@ -307,8 +307,10 @@ void VirtualJetProducer::produce(edm::Event& iEvent,const edm::EventSetup& iSetu
   if ( useDeterministicSeed_ ) {
     fastjet::GhostedAreaSpec gas;
     std::vector<int> seeds(2);
-    seeds[0] = std::max(iEvent.id().run(),minSeed_ + 3) + 3 * iEvent.id().event();
-    seeds[1] = std::max(iEvent.id().run(),minSeed_ + 5) + 5 * iEvent.id().event();
+    unsigned int runNum_uint = static_cast <unsigned int> (iEvent.id().run());
+    unsigned int evNum_uint = static_cast <unsigned int> (iEvent.id().event()); 
+    seeds[0] = std::max(runNum_uint,minSeed_ + 3) + 3 * evNum_uint;
+    seeds[1] = std::max(runNum_uint,minSeed_ + 5) + 5 * evNum_uint;
     gas.set_random_status(seeds);
   }
 


### PR DESCRIPTION
The online is changing to produce data with event numbers that are 64 bits instead of 32 bits. CMSSW software needs to be modified to handle that. Following
https://hypernews.cern.ch/HyperNews/CMS/get/recoDevelopment/1302.html
I am making changes to different packages, here JET/MET for fastjet usage. Changing the types in fastjet would be a longer process so I just explicitly cast to the supported type (the run/event numbers are used as random seeds - there should be no practical problem here).  Updates are generally trivial and there should be no any visible effects of them (except for the rare event numbers with > 32 bits). 
