### PR TITLE
IsoTrackHB/HE (bsunanda:IsoCalib02)

### DIFF
--- a/Calibration/HcalIsolatedTrackReco/interface/IsolatedEcalPixelTrackCandidateProducer.h
+++ b/Calibration/HcalIsolatedTrackReco/interface/IsolatedEcalPixelTrackCandidateProducer.h
@@ -1,0 +1,40 @@
+#ifndef Calibration_IsolatedEcalPixelTrackCandidateProducer_h
+#define Calibration_IsolatedEcalPixelTrackCandidateProducer_h
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/HcalIsolatedTrack/interface/IsolatedPixelTrackCandidate.h"
+#include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
+#include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
+
+//
+// class decleration
+//
+
+class IsolatedEcalPixelTrackCandidateProducer : public edm::EDProducer {
+
+public:
+  explicit IsolatedEcalPixelTrackCandidateProducer(const edm::ParameterSet&);
+  ~IsolatedEcalPixelTrackCandidateProducer();
+
+private:
+
+  virtual void beginJob() ;
+  virtual void produce(edm::Event&, const edm::EventSetup&);
+  virtual void endJob() ;
+
+  double coneSizeEta0_, coneSizeEta1_;
+  double hitCountEthr_;
+  double hitEthr_;
+  edm::EDGetTokenT<EcalRecHitCollection> tok_ee;
+  edm::EDGetTokenT<EcalRecHitCollection> tok_eb;
+  edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> tok_trigcand;
+};
+
+#endif

--- a/Calibration/HcalIsolatedTrackReco/interface/IsolatedPixelTrackCandidateProducer.h
+++ b/Calibration/HcalIsolatedTrackReco/interface/IsolatedPixelTrackCandidateProducer.h
@@ -16,35 +16,53 @@
 #include "DataFormats/DetId/interface/DetId.h"
 
 //#include "DataFormats/Common/interface/Provenance.h"
-#include "DataFormats/VertexReco/interface/VertexFwd.h"
-#include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutSetupFwd.h"
-#include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
-#include "DataFormats/Common/interface/TriggerResults.h"
-#include "DataFormats/L1Trigger/interface/L1JetParticleFwd.h"
 
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/L1Trigger/interface/L1JetParticle.h"
 #include "DataFormats/HcalIsolatedTrack/interface/IsolatedPixelTrackCandidate.h"
+#include "DataFormats/Common/interface/TriggerResults.h"
+// L1Extra
+#include "DataFormats/L1Trigger/interface/L1EmParticle.h"
+#include "DataFormats/L1Trigger/interface/L1JetParticleFwd.h"
+///
+//vertices
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
+
+#include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutSetupFwd.h"
+#include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutRecord.h"
+#include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerObjectMapRecord.h"
+//#include "DataFormats/L1GlobalTrigger/interface/L1GtLogicParser.h"
+
+#include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerObjectMapFwd.h"
+#include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerObjectMap.h"
 
 class IsolatedPixelTrackCandidateProducer : public edm::EDProducer {
 
- public:
+public:
 
   IsolatedPixelTrackCandidateProducer (const edm::ParameterSet& ps);
   ~IsolatedPixelTrackCandidateProducer();
+  
 
-
-  virtual void beginRun(const edm::Run&, const edm::EventSetup&) override;
-  virtual void produce(edm::Event& evt, const edm::EventSetup& es) override;
-
+  virtual void beginJob ();
+  virtual void beginRun(const edm::Run&, const edm::EventSetup&);
+  virtual void produce(edm::Event& evt, const edm::EventSetup& es);
+  
   double getDistInCM(double eta1, double phi1, double eta2, double phi2);
-  std::pair<double, double> GetEtaPhiAtEcal(const edm::EventSetup& iSetup, double etaIP, double phiIP, double pT, int charge, double vtxZ);
+  std::pair<double, double> GetEtaPhiAtEcal(double etaIP, double phiIP, double pT, int charge, double vtxZ);
 
- private:
-	
+private:
+  struct seedAtEC {
+    seedAtEC(unsigned int i, bool f, double et, double fi) {index=i; ok=f;
+      eta=et; phi=fi;}
+    unsigned int index;
+    bool         ok;
+    double       eta, phi;
+  };
   std::vector<edm::InputTag> pixelTracksSources_;
   edm::ParameterSet parameters;
-
   edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> tok_hlt_;
   edm::EDGetTokenT<l1extra::L1JetParticleCollection> tok_l1_;
   edm::EDGetTokenT<reco::VertexCollection> tok_vert_;
@@ -63,6 +81,7 @@ class IsolatedPixelTrackCandidateProducer : public edm::EDProducer {
   double rEB_;
   double zEE_;
   double ebEtaBoundary_;
+  double bfVal;
 };
 
 

--- a/Calibration/HcalIsolatedTrackReco/python/isolEcalPixelTrackProd_cfi.py
+++ b/Calibration/HcalIsolatedTrackReco/python/isolEcalPixelTrackProd_cfi.py
@@ -1,0 +1,13 @@
+import FWCore.ParameterSet.Config as cms
+
+isolEcalPixelTrackProd = cms.EDProducer("IsolatedEcalPixelTrackCandidateProducer",
+                                        filterLabel               = cms.InputTag("isolPixelTrackProd"),
+                                        EBRecHitSource            = cms.InputTag("hltEcalRegionalPixelTrackRecHit", "EcalRecHitsEB"),
+                                        EERecHitSource            = cms.InputTag("hltEcalRegionalPixelTrackRecHit", "EcalRecHitsEE"),
+                                        ECHitEnergyThreshold      = cms.double(0.05),
+                                        ECHitCountEnergyThreshold = cms.double(0.5),
+                                        EcalConeSizeEta0          = cms.double(0.09),
+                                        EcalConeSizeEta1          = cms.double(0.14)
+                                        )
+
+

--- a/Calibration/HcalIsolatedTrackReco/src/IsolatedEcalPixelTrackCandidateProducer.cc
+++ b/Calibration/HcalIsolatedTrackReco/src/IsolatedEcalPixelTrackCandidateProducer.cc
@@ -1,0 +1,145 @@
+// -*- C++ -*-
+//
+// Package:    IsolatedEcalPixelTrackCandidateProducer
+// Class:      IsolatedEcalPixelTrackCandidateProducer
+// 
+/**\class IsolatedEcalPixelTrackCandidateProducer IsolatedEcalPixelTrackCandidateProducer.cc Calibration/HcalIsolatedTrackReco/src/IsolatedEcalPixelTrackCandidateProducer.cc
+
+ Description: <one line class summary>
+
+ Implementation:
+     <Notes on implementation>
+*/
+//
+// Original Author:  Ruchi Gupta
+//         Created:  Thu Feb 11 17:21:58 MSD 2014
+// $Id: IsolatedEcalPixelTrackCandidateProducer.cc,v 1.0 2014/02/11 22:25:52 wmtan Exp $
+//
+//
+
+//#define DebugLog
+// system include files
+#include <memory>
+
+// user include files
+
+#include "FWCore/Framework/interface/EventSetup.h"
+
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/Math/interface/deltaR.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+
+#include "Calibration/HcalIsolatedTrackReco/interface/IsolatedEcalPixelTrackCandidateProducer.h"
+
+IsolatedEcalPixelTrackCandidateProducer::IsolatedEcalPixelTrackCandidateProducer(const edm::ParameterSet& conf) {
+
+  coneSizeEta0_    = conf.getParameter<double>("EcalConeSizeEta0");
+  coneSizeEta1_    = conf.getParameter<double>("EcalConeSizeEta1");
+  hitCountEthr_    = conf.getParameter<double>("ECHitCountEnergyThreshold");
+  hitEthr_         = conf.getParameter<double>("ECHitEnergyThreshold");
+  tok_trigcand = consumes<trigger::TriggerFilterObjectWithRefs>(conf.getParameter<edm::InputTag>("filterLabel"));
+  tok_eb = consumes<EcalRecHitCollection>(conf.getParameter<edm::InputTag>("EBRecHitSource"));
+  tok_ee = consumes<EcalRecHitCollection>(conf.getParameter<edm::InputTag>("EERecHitSource"));
+
+   //register your products
+  produces< reco::IsolatedPixelTrackCandidateCollection >();
+}
+
+IsolatedEcalPixelTrackCandidateProducer::~IsolatedEcalPixelTrackCandidateProducer() { }
+
+// ------------ method called to produce the data  ------------
+void IsolatedEcalPixelTrackCandidateProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+#ifdef DebugLog
+  std::cout << "==============Inside IsolatedEcalPixelTrackCandidateProducer" << std::endl;
+#endif
+  edm::ESHandle<CaloGeometry> pG;
+  iSetup.get<CaloGeometryRecord>().get(pG);
+  const CaloGeometry* geo = pG.product();
+
+  edm::Handle<EcalRecHitCollection> ecalEB;
+  iEvent.getByToken(tok_eb,ecalEB);
+
+  edm::Handle<EcalRecHitCollection> ecalEE;
+  iEvent.getByToken(tok_ee,ecalEE);
+#ifdef DebugLog
+  std::cout << "ecal Collections isValid: " << ecalEB.isValid() << "/" << ecalEE.isValid() << std::endl;
+#endif
+
+  edm::Handle<trigger::TriggerFilterObjectWithRefs> trigCand;
+  iEvent.getByToken(tok_trigcand,trigCand);
+
+  std::vector< edm::Ref<reco::IsolatedPixelTrackCandidateCollection> > isoPixTrackRefs;
+  trigCand->getObjects(trigger::TriggerTrack, isoPixTrackRefs);
+  int nCand=isoPixTrackRefs.size();  
+
+  reco::IsolatedPixelTrackCandidateCollection * iptcCollection=new reco::IsolatedPixelTrackCandidateCollection;
+#ifdef DebugLog
+  std::cout << "coneSize_ " << coneSizeEta0_ << "/"<< coneSizeEta1_ << " hitCountEthr_ " << hitCountEthr_ << " hitEthr_ " << hitEthr_ << std::endl;
+#endif
+  for (int p=0; p<nCand; p++) {
+    int    nhitIn(0), nhitOut(0);
+    double inEnergy(0), outEnergy(0);
+    std::pair<double,double> etaPhi(isoPixTrackRefs[p]->track()->eta(), isoPixTrackRefs[p]->track()->phi());
+    if (isoPixTrackRefs[p]->etaPhiEcal()) etaPhi = isoPixTrackRefs[p]->EtaPhiEcal();
+    double etaAbs = std::abs(etaPhi.first);
+    double coneSize_ = (etaAbs > 1.5) ? coneSizeEta1_ : (coneSizeEta0_*(1.5-etaAbs)+coneSizeEta1_*etaAbs)/1.5;
+#ifdef DebugLog
+    std::cout << "Track: eta/phi " << etaPhi.first << "/" << etaPhi.second << " pt:" << isoPixTrackRefs[p]->track()->pt() << " cone " << coneSize_ << std::endl;
+    std::cout << "rechit size EB/EE : " << ecalEB->size() << "/" << ecalEE->size() << " coneSize_: " <<  coneSize_ << std::endl;
+#endif
+    if (etaAbs<1.7) {
+      for (EcalRecHitCollection::const_iterator eItr=ecalEB->begin(); eItr!=ecalEB->end(); eItr++) {
+	GlobalPoint pos = geo->getPosition(eItr->detid());
+	double      R   = reco::deltaR(pos.eta(),pos.phi(),etaPhi.first,etaPhi.second);
+	if (R < coneSize_) {
+	  nhitIn++;
+	  inEnergy += (eItr->energy());
+	  if (eItr->energy() > hitCountEthr_) nhitOut++;
+	  if (eItr->energy() > hitEthr_)      outEnergy += (eItr->energy());
+#ifdef DebugLog
+	  std::cout << "Rechit Close to the track has energy " << eItr->energy()
+		    << " eta/phi: " << pos.eta() << "/" << pos.phi() << " deltaR: " << R << std::endl;
+#endif
+	}
+      }
+    }
+    if (etaAbs>1.25) {
+      for (EcalRecHitCollection::const_iterator eItr=ecalEE->begin(); eItr!=ecalEE->end(); eItr++) {
+	GlobalPoint pos = geo->getPosition(eItr->detid());
+	double      R   = reco::deltaR(pos.eta(),pos.phi(),etaPhi.first,etaPhi.second);
+	if (R < coneSize_) {
+	  nhitIn++;
+	  inEnergy += (eItr->energy());
+	  if (eItr->energy() > hitCountEthr_) nhitOut++;
+	  if (eItr->energy() > hitEthr_)      outEnergy += (eItr->energy());
+#ifdef DebugLog
+	  std::cout << "Rechit Close to the track has energy " << eItr->energy()
+		    << " eta/phi: " << pos.eta() << "/" << pos.phi() << " deltaR: " << R << std::endl;
+#endif
+	}
+      }
+    }
+#ifdef DebugLog
+    std::cout << "nhitIn:" << nhitIn << " inEnergy:" << inEnergy << " nhitOut:" << nhitOut << " outEnergy:" << outEnergy << std::endl;
+#endif
+    reco::IsolatedPixelTrackCandidate newca(*isoPixTrackRefs[p]);
+    newca.SetEnergyIn(inEnergy);
+    newca.SetEnergyOut(outEnergy);
+    newca.SetNHitIn(nhitIn);
+    newca.SetNHitOut(nhitOut);
+    iptcCollection->push_back(newca);	
+  }
+#ifdef DebugLog
+  std::cout << "ncand:" << nCand << " outcollction size:" << iptcCollection->size() << std::endl;
+#endif
+  std::auto_ptr<reco::IsolatedPixelTrackCandidateCollection> outCollection(iptcCollection);
+  iEvent.put(outCollection);
+}
+// ------------ method called once each job just before starting event loop  ------------
+void IsolatedEcalPixelTrackCandidateProducer::beginJob() { }
+
+// ------------ method called once each job just after ending the event loop  ------------
+void IsolatedEcalPixelTrackCandidateProducer::endJob() { }

--- a/Calibration/HcalIsolatedTrackReco/src/IsolatedPixelTrackCandidateProducer.cc
+++ b/Calibration/HcalIsolatedTrackReco/src/IsolatedPixelTrackCandidateProducer.cc
@@ -1,6 +1,7 @@
 #include <vector>
 #include <memory>
 #include <algorithm>
+#include <cmath>
 
 // Class header file
 #include "Calibration/HcalIsolatedTrackReco/interface/IsolatedPixelTrackCandidateProducer.h"
@@ -12,25 +13,12 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/Exception.h"
 //
-// L1Extra
-#include "DataFormats/L1Trigger/interface/L1EmParticle.h"
-///
 
-
-#include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutRecord.h"
-#include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerObjectMapRecord.h"
-//#include "DataFormats/L1GlobalTrigger/interface/L1GtLogicParser.h"
-
-#include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerObjectMapFwd.h"
-#include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerObjectMap.h"
 
 // Math
 #include "Math/GenVector/VectorUtil.h"
 #include "Math/GenVector/PxPyPzE4D.h"
 #include "DataFormats/Math/interface/deltaR.h"
-
-//vertices
-#include "DataFormats/VertexReco/interface/Vertex.h"
 
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "DetectorDescription/Core/interface/DDLogicalPart.h"
@@ -55,11 +43,9 @@ IsolatedPixelTrackCandidateProducer::IsolatedPixelTrackCandidateProducer(const e
   tauAssocCone_               = config.getParameter<double>("tauAssociationCone"); 
   tauUnbiasCone_              = config.getParameter<double>("tauUnbiasCone");
   pixelTracksSources_         = config.getParameter<std::vector<edm::InputTag> >("PixelTracksSources");
-
   const unsigned nLabels = pixelTracksSources_.size();
   for ( unsigned i=0; i != nLabels; i++ ) 
     toks_pix_.push_back(consumes<reco::TrackCollection>(pixelTracksSources_[i]));
-
   prelimCone_                 = config.getParameter<double>("ExtrapolationConeSize");
   pixelIsolationConeSizeAtEC_ = config.getParameter<double>("PixelIsolationConeSizeAtEC");
   tok_hlt_ = consumes<trigger::TriggerFilterObjectWithRefs>(config.getParameter<edm::InputTag>("L1GTSeedLabel"));
@@ -71,7 +57,7 @@ IsolatedPixelTrackCandidateProducer::IsolatedPixelTrackCandidateProducer(const e
   maxPForIsolationValue_      = config.getParameter<double>("maxPTrackForIsolation");
   ebEtaBoundary_              = config.getParameter<double>("EBEtaBoundary");
   rEB_ = zEE_ = -1;
-
+  bfVal = 0;
   // Register the product
   produces< reco::IsolatedPixelTrackCandidateCollection >();
 }
@@ -80,8 +66,9 @@ IsolatedPixelTrackCandidateProducer::~IsolatedPixelTrackCandidateProducer() {
 
 }
 
-void IsolatedPixelTrackCandidateProducer::beginRun(const edm::Run &run, const edm::EventSetup &theEventSetup)
-{
+void IsolatedPixelTrackCandidateProducer::beginJob () {}
+
+void IsolatedPixelTrackCandidateProducer::beginRun(const edm::Run &run, const edm::EventSetup &theEventSetup) {
 
   edm::ESHandle<CaloGeometry> pG;
   theEventSetup.get<CaloGeometryRecord>().get(pG);   
@@ -93,6 +80,11 @@ void IsolatedPixelTrackCandidateProducer::beginRun(const edm::Run &run, const ed
   rEB_=rad;
   zEE_=zz;
 
+  edm::ESHandle<MagneticField> vbfField;
+  theEventSetup.get<IdealMagneticFieldRecord>().get(vbfField);
+  const VolumeBasedMagneticField* vbfCPtr = dynamic_cast<const VolumeBasedMagneticField*>(&(*vbfField));
+  GlobalVector BField=vbfCPtr->inTesla(GlobalPoint(0,0,0));
+  bfVal=BField.mag();
 }
 
 void IsolatedPixelTrackCandidateProducer::produce(edm::Event& theEvent, const edm::EventSetup& theEventSetup) {
@@ -102,15 +94,13 @@ void IsolatedPixelTrackCandidateProducer::produce(edm::Event& theEvent, const ed
   //create vector of refs from input collections
   std::vector<reco::TrackRef> pixelTrackRefs;
 
-  for (unsigned int iPix=0; iPix<toks_pix_.size(); iPix++)
-    {
-      edm::Handle<reco::TrackCollection> iPixCol;
-      theEvent.getByToken(toks_pix_[iPix],iPixCol);
-      for (reco::TrackCollection::const_iterator pit=iPixCol->begin(); pit!=iPixCol->end(); pit++)
-        {
-          pixelTrackRefs.push_back(reco::TrackRef(iPixCol,pit-iPixCol->begin()));
-        }
+  for (unsigned int iPix=0; iPix<pixelTracksSources_.size(); iPix++) {
+    edm::Handle<reco::TrackCollection> iPixCol;
+    theEvent.getByToken(toks_pix_[iPix],iPixCol);
+    for (reco::TrackCollection::const_iterator pit=iPixCol->begin(); pit!=iPixCol->end(); pit++) {
+      pixelTrackRefs.push_back(reco::TrackRef(iPixCol,pit-iPixCol->begin()));
     }
+  }
 
   edm::Handle<l1extra::L1JetParticleCollection> l1eTauJets;
   theEvent.getByToken(tok_l1_,l1eTauJets);
@@ -133,163 +123,141 @@ void IsolatedPixelTrackCandidateProducer::produce(edm::Event& theEvent, const ed
   l1trigobj->getObjects(trigger::TriggerL1CenJet, l1jetobjref);
   l1trigobj->getObjects(trigger::TriggerL1ForJet, l1forjetobjref);
   
-  for (unsigned int p=0; p<l1tauobjref.size(); p++)
-    {
-      if (l1tauobjref[p]->pt()>ptTriggered)
-	{
-	  ptTriggered  = l1tauobjref[p]->pt(); 
-	  phiTriggered = l1tauobjref[p]->phi();
-	  etaTriggered = l1tauobjref[p]->eta();
-	}
+  for (unsigned int p=0; p<l1tauobjref.size(); p++) {
+    if (l1tauobjref[p]->pt()>ptTriggered) {
+      ptTriggered  = l1tauobjref[p]->pt(); 
+      phiTriggered = l1tauobjref[p]->phi();
+      etaTriggered = l1tauobjref[p]->eta();
     }
-  for (unsigned int p=0; p<l1jetobjref.size(); p++)
-    {
-      if (l1jetobjref[p]->pt()>ptTriggered)
-	{
-	  ptTriggered  = l1jetobjref[p]->pt();
-	  phiTriggered = l1jetobjref[p]->phi();
-	  etaTriggered = l1jetobjref[p]->eta();
-	}
+  }
+  for (unsigned int p=0; p<l1jetobjref.size(); p++) {
+    if (l1jetobjref[p]->pt()>ptTriggered) {
+      ptTriggered  = l1jetobjref[p]->pt();
+      phiTriggered = l1jetobjref[p]->phi();
+      etaTriggered = l1jetobjref[p]->eta();
     }
-  for (unsigned int p=0; p<l1forjetobjref.size(); p++)
-    {
-      if (l1forjetobjref[p]->pt()>ptTriggered)
-        {
-          ptTriggered=l1forjetobjref[p]->pt();
-          phiTriggered=l1forjetobjref[p]->phi();
-          etaTriggered=l1forjetobjref[p]->eta();
-        }
+  }
+  for (unsigned int p=0; p<l1forjetobjref.size(); p++) {
+    if (l1forjetobjref[p]->pt()>ptTriggered) {
+      ptTriggered=l1forjetobjref[p]->pt();
+      phiTriggered=l1forjetobjref[p]->phi();
+      etaTriggered=l1forjetobjref[p]->eta();
     }
+  }
 
-  double minPTrack_    = minPTrackValue_;
   double drMaxL1Track_ = tauAssocCone_;
   
   int ntr = 0;
-  
+  std::vector<seedAtEC>  VecSeedsatEC;
   //loop to select isolated tracks
-  for (unsigned iSeed=0; iSeed<pixelTrackRefs.size(); iSeed++)
-    {
-      if(pixelTrackRefs[iSeed]->p()<minPTrack_) continue;
+  for (unsigned iS=0; iS<pixelTrackRefs.size(); iS++) {
+    bool vtxMatch = false;
+    //associate to vertex (in Z) 
+    reco::VertexCollection::const_iterator vitSel;
+    double minDZ = 1000;
+    bool   found(false);
+    for (reco::VertexCollection::const_iterator vit=pVert->begin(); vit!=pVert->end(); vit++) {
+      if (std::abs(pixelTrackRefs[iS]->dz(vit->position()))<minDZ) {
+	minDZ  = std::abs(pixelTrackRefs[iS]->dz(vit->position()));
+	vitSel = vit;
+	found  = true;
+      }
+    }
+    //cut on dYX:
+    if (found) {
+      if(std::abs(pixelTrackRefs[iS]->dxy(vitSel->position()))<vtxCutSeed_) vtxMatch=true;
+    } else {
+      vtxMatch=true;
+    }
 
-      bool good     = false;
-      bool vtxMatch = false;
+    //select tracks not matched to triggered L1 jet
+    double R=reco::deltaR(etaTriggered, phiTriggered, 
+			  pixelTrackRefs[iS]->eta(), pixelTrackRefs[iS]->phi());
+    if (R<tauUnbiasCone_) continue;
 
-      //associate to vertex (in Z) 
-      reco::VertexCollection::const_iterator vitSel;
-      double minDZ = 100;
-      for (reco::VertexCollection::const_iterator vit=pVert->begin(); vit!=pVert->end(); vit++)
-	{
-	  if (fabs(pixelTrackRefs[iSeed]->dz(vit->position()))<minDZ)
-	    {
-	      minDZ  = fabs(pixelTrackRefs[iSeed]->dz(vit->position()));
-	      vitSel = vit;
-	    }
+    //check taujet matching
+    bool tmatch=false;
+    l1extra::L1JetParticleCollection::const_iterator selj;
+    for (l1extra::L1JetParticleCollection::const_iterator tj=l1eTauJets->begin(); tj!=l1eTauJets->end(); tj++) {
+      if (reco::deltaR(pixelTrackRefs[iS]->momentum().eta(), pixelTrackRefs[iS]->momentum().phi(), tj->momentum().eta(), tj->momentum().phi()) > drMaxL1Track_) continue;
+      selj   = tj;
+      tmatch = true;
+    } //loop over L1 tau
+
+    
+    //propagate seed track to ECAL surface:
+    std::pair<double,double> seedCooAtEC;
+    // in case vertex is found:
+    if (found) seedCooAtEC=GetEtaPhiAtEcal(pixelTrackRefs[iS]->eta(), pixelTrackRefs[iS]->phi(), pixelTrackRefs[iS]->pt(), pixelTrackRefs[iS]->charge(), vitSel->z());
+    //in case vertex is not found:
+    else       seedCooAtEC=GetEtaPhiAtEcal(pixelTrackRefs[iS]->eta(), pixelTrackRefs[iS]->phi(), pixelTrackRefs[iS]->pt(), pixelTrackRefs[iS]->charge(), 0);
+    seedAtEC seed(iS,(tmatch||vtxMatch),seedCooAtEC.first,seedCooAtEC.second);
+    VecSeedsatEC.push_back(seed);
+  }
+
+  for (unsigned int i=0; i<VecSeedsatEC.size(); i++) {
+    unsigned int iSeed = VecSeedsatEC[i].index;
+    if (!VecSeedsatEC[i].ok) continue;
+    if(pixelTrackRefs[iSeed]->p()<minPTrackValue_) continue; 
+    l1extra::L1JetParticleCollection::const_iterator selj;
+    for (l1extra::L1JetParticleCollection::const_iterator tj=l1eTauJets->begin(); tj!=l1eTauJets->end(); tj++)  {
+      if (reco::deltaR(pixelTrackRefs[iSeed]->momentum().eta(),pixelTrackRefs[iSeed]->momentum().phi(),tj->momentum().eta(),tj->momentum().phi()) > drMaxL1Track_) continue;
+      selj   = tj;
+    } //loop over L1 tau
+    double maxP = 0;
+    double sumP = 0;
+    for(unsigned int j=0; j<VecSeedsatEC.size(); j++) {
+      if (i==j) continue;
+      unsigned int iSurr = VecSeedsatEC[j].index;
+      //define preliminary cone around seed track impact point from which tracks will be extrapolated:
+      if (reco::deltaR(pixelTrackRefs[iSeed]->eta(), pixelTrackRefs[iSeed]->phi(), pixelTrackRefs[iSurr]->eta(), pixelTrackRefs[iSurr]->phi())>prelimCone_) continue;
+      double minDZ2(1000);
+      bool   found(false);
+      reco::VertexCollection::const_iterator vitSel2;
+      for (reco::VertexCollection::const_iterator vit=pVert->begin(); vit!=pVert->end(); vit++) {
+	if (std::abs(pixelTrackRefs[iSurr]->dz(vit->position()))<minDZ2) {
+	  minDZ2  = std::abs(pixelTrackRefs[iSurr]->dz(vit->position()));
+	  vitSel2 = vit;
+	  found   = true;
 	}
-      //cut on dYX:
-      if (minDZ!=100&&fabs(pixelTrackRefs[iSeed]->dxy(vitSel->position()))<vtxCutSeed_) vtxMatch=true;
-      if (minDZ==100) vtxMatch=true;
-
-      //select tracks not matched to triggered L1 jet
-      double R=deltaR(etaTriggered, phiTriggered, pixelTrackRefs[iSeed]->eta(), pixelTrackRefs[iSeed]->phi());
-      if (R<tauUnbiasCone_) continue;
-      
-      //check taujet matching
-      bool tmatch=false;
-      l1extra::L1JetParticleCollection::const_iterator selj;
-      for (l1extra::L1JetParticleCollection::const_iterator tj=l1eTauJets->begin(); tj!=l1eTauJets->end(); tj++) 
-	{
-	  if(ROOT::Math::VectorUtil::DeltaR(pixelTrackRefs[iSeed]->momentum(),tj->momentum()) > drMaxL1Track_) continue;
-	  selj   = tj;
-	  tmatch = true;
-	} //loop over L1 tau
-      
-      //propagate seed track to ECAL surface:
-      std::pair<double,double> seedCooAtEC;
-      // in case vertex is found:
-      if (minDZ!=100) seedCooAtEC=GetEtaPhiAtEcal(theEventSetup, pixelTrackRefs[iSeed]->eta(), pixelTrackRefs[iSeed]->phi(), pixelTrackRefs[iSeed]->pt(), pixelTrackRefs[iSeed]->charge(), vitSel->z());
-      //in case vertex is not found:
-      else seedCooAtEC=GetEtaPhiAtEcal(theEventSetup, pixelTrackRefs[iSeed]->eta(), pixelTrackRefs[iSeed]->phi(), pixelTrackRefs[iSeed]->pt(), pixelTrackRefs[iSeed]->charge(), 0);
-
-      //calculate isolation
-      double maxP = 0;
-      double sumP = 0;
-      for (unsigned iSurr=0; iSurr<pixelTrackRefs.size(); iSurr++)
-        {
-	  if(iSeed==iSurr) continue;
-	  //define preliminary cone around seed track impact point from which tracks will be extrapolated:
-          if (deltaR(seedCooAtEC.first, seedCooAtEC.second, pixelTrackRefs[iSurr]->eta(), pixelTrackRefs[iSurr]->phi())>prelimCone_) continue;
-	  //associate to vertex (in Z):
-	  double minDZ2=100;
-	  reco::VertexCollection::const_iterator vitSel2;
-	  for (reco::VertexCollection::const_iterator vit=pVert->begin(); vit!=pVert->end(); vit++)
-	    {
-	      if (fabs(pixelTrackRefs[iSurr]->dz(vit->position()))<minDZ2)
-		{
-		  minDZ2  = fabs(pixelTrackRefs[iSurr]->dz(vit->position()));
-		  vitSel2 = vit;
-		}
-	    }
-	  //cut ot dXY:
-	  if (minDZ2!=100&&fabs(pixelTrackRefs[iSurr]->dxy(vitSel2->position()))>vtxCutIsol_) continue;
-	  //propagate to ECAL surface:
-	  std::pair<double,double> cooAtEC;
-	  // in case vertex is found:
-	  if (minDZ2!=100) cooAtEC=GetEtaPhiAtEcal(theEventSetup, pixelTrackRefs[iSurr]->eta(), pixelTrackRefs[iSurr]->phi(), pixelTrackRefs[iSurr]->pt(), pixelTrackRefs[iSurr]->charge(), vitSel2->z());
-	  // in case vertex is not found:
-	  else cooAtEC=GetEtaPhiAtEcal(theEventSetup, pixelTrackRefs[iSurr]->eta(), pixelTrackRefs[iSurr]->phi(), pixelTrackRefs[iSurr]->pt(), pixelTrackRefs[iSurr]->charge(), 0);
-	  
-	  //calculate distance at ECAL surface and update isolation: 
-	  if (getDistInCM(seedCooAtEC.first, seedCooAtEC.second, cooAtEC.first, cooAtEC.second)<pixelIsolationConeSizeAtEC_)
-	    {
-	      sumP+=pixelTrackRefs[iSurr]->p();
-	      if(pixelTrackRefs[iSurr]->p()>maxP) maxP=pixelTrackRefs[iSurr]->p();
-	    }
-	}
-
-      if (tmatch||vtxMatch) good=true;
-
-      if (good&&maxP<maxPForIsolationValue_)
-	{
-	  reco::IsolatedPixelTrackCandidate newCandidate(pixelTrackRefs[iSeed], l1extra::L1JetParticleRef(l1eTauJets,selj-l1eTauJets->begin()), maxP, sumP);
-	  trackCollection->push_back(newCandidate);
-	  ntr++;
-	}
-    }//loop over pixel tracks
-
+      }
+      //cut ot dXY:
+      if (found&&std::abs(pixelTrackRefs[iSurr]->dxy(vitSel2->position()))>vtxCutIsol_) continue;
+      //calculate distance at ECAL surface and update isolation: 
+      if (getDistInCM(VecSeedsatEC[i].eta, VecSeedsatEC[i].phi, VecSeedsatEC[j].eta, VecSeedsatEC[j].phi)<pixelIsolationConeSizeAtEC_) {
+	sumP+=pixelTrackRefs[iSurr]->p();
+	if(pixelTrackRefs[iSurr]->p()>maxP) maxP=pixelTrackRefs[iSurr]->p();
+      }      
+    }
+    if (maxP<maxPForIsolationValue_) {
+      reco::IsolatedPixelTrackCandidate newCandidate(pixelTrackRefs[iSeed], l1extra::L1JetParticleRef(l1eTauJets,selj-l1eTauJets->begin()), maxP, sumP);
+      newCandidate.SetEtaPhiEcal(VecSeedsatEC[i].eta, VecSeedsatEC[i].phi);
+      trackCollection->push_back(newCandidate);
+      ntr++;
+    }    
+  }
   // put the product in the event
   std::auto_ptr< reco::IsolatedPixelTrackCandidateCollection > outCollection(trackCollection);
   theEvent.put(outCollection);
-
 }
 
 
-double IsolatedPixelTrackCandidateProducer::getDistInCM(double eta1, double phi1, double eta2, double phi2)
-{
+double IsolatedPixelTrackCandidateProducer::getDistInCM(double eta1, double phi1, double eta2, double phi2) {
   double Rec;
   double theta1=2*atan(exp(-eta1));
   double theta2=2*atan(exp(-eta2));
-  if (fabs(eta1)<1.479) Rec=129; //radius of ECAL barrel
-  else if (fabs(eta1)>1.479&&fabs(eta1)<7.0) Rec=tan(theta1)*317; //distance from IP to ECAL endcap
+  if (std::abs(eta1)<1.479) Rec=rEB_; //radius of ECAL barrel
+  else if (std::abs(eta1)>1.479&&std::abs(eta1)<7.0) Rec=tan(theta1)*zEE_; //distance from IP to ECAL endcap
   else return 1000;
 
   //|vect| times tg of acos(scalar product)
   double angle=acos((sin(theta1)*sin(theta2)*(sin(phi1)*sin(phi2)+cos(phi1)*cos(phi2))+cos(theta1)*cos(theta2)));
-  if (angle<acos(-1)/2) return fabs((Rec/sin(theta1))*tan(angle));
+  if (angle<M_PI_2) return std::abs((Rec/sin(theta1))*tan(angle));
   else return 1000;
 }
 
 
-std::pair<double,double>
-IsolatedPixelTrackCandidateProducer::GetEtaPhiAtEcal(const edm::EventSetup& iSetup, double etaIP, double phiIP, double pT, int charge, double vtxZ)
-{
-  edm::ESHandle<MagneticField> vbfField;
-  iSetup.get<IdealMagneticFieldRecord>().get(vbfField);
-  const VolumeBasedMagneticField* vbfCPtr = dynamic_cast<const VolumeBasedMagneticField*>(&(*vbfField));
-  GlobalVector BField=vbfCPtr->inTesla(GlobalPoint(0,0,0));
- //test
- //int curvSgn=int(BField.z()/fabs(BField.z())); 
-
-  double bfVal=BField.mag();
+std::pair<double,double> IsolatedPixelTrackCandidateProducer::GetEtaPhiAtEcal(double etaIP, double phiIP, double pT, int charge, double vtxZ) {
 
   double deltaPhi=0;
   double etaEC = 100;
@@ -300,55 +268,47 @@ IsolatedPixelTrackCandidateProducer::GetEtaPhiAtEcal(const edm::EventSetup& iSet
 
   double ecDist = zEE_;  //distance to ECAL andcap from IP (cm), 317 - ecal (not preshower), preshower -300
   double ecRad  = rEB_;  //radius of ECAL barrel (cm)
-  double theta=2*atan(exp(-etaIP));
-  double zNew=0;
-  if (theta>0.5*acos(-1)) theta=acos(-1)-theta;
-  if (fabs(etaIP)<ebEtaBoundary_)
-    {
-      if ((0.5*ecRad/Rcurv)>1)
-	{
-	  etaEC=10000;
-	  deltaPhi=0;
-	}
-      else
-	{
-	  deltaPhi      =-charge*asin(0.5*ecRad/Rcurv);
-	  double alpha1 = 2*asin(0.5*ecRad/Rcurv);
-	  double z      = ecRad/tan(theta);
-	  if (etaIP>0) zNew = z*(Rcurv*alpha1)/ecRad+vtxZ; //new z-coordinate of track
-	  else         zNew =-z*(Rcurv*alpha1)/ecRad+vtxZ; //new z-coordinate of track
-	  double zAbs=fabs(zNew);
-	  if (zAbs<ecDist)
-	    {
-	      etaEC    = -log(tan(0.5*atan(ecRad/zAbs)));
-	      deltaPhi = -charge*asin(0.5*ecRad/Rcurv);
-	    }
-	  if (zAbs>ecDist)
-	    {
-	      zAbs           = (fabs(etaIP)/etaIP)*ecDist;
-	      double Zflight = fabs(zAbs-vtxZ);
-	      double alpha   = (Zflight*ecRad)/(z*Rcurv);
-	      double Rec     = 2*Rcurv*sin(alpha/2);
-	      deltaPhi       =-charge*alpha/2;
-	      etaEC          =-log(tan(0.5*atan(Rec/ecDist)));
-	    }
-	}
+  double theta  = 2*atan(exp(-etaIP));
+  double zNew   = 0;
+  if (theta>M_PI_2) theta=M_PI-theta;
+  if (std::abs(etaIP)<ebEtaBoundary_) {
+    if ((0.5*ecRad/Rcurv)>1) {
+      etaEC         = 10000;
+      deltaPhi      = 0;
+    } else {
+      deltaPhi      =-charge*asin(0.5*ecRad/Rcurv);
+      double alpha1 = 2*asin(0.5*ecRad/Rcurv);
+      double z      = ecRad/tan(theta);
+      if (etaIP>0) zNew = z*(Rcurv*alpha1)/ecRad+vtxZ; //new z-coordinate of track
+      else         zNew =-z*(Rcurv*alpha1)/ecRad+vtxZ; //new z-coordinate of track
+      double zAbs=std::abs(zNew);
+      if (zAbs<ecDist) {
+	etaEC    = -log(tan(0.5*atan(ecRad/zAbs)));
+	deltaPhi = -charge*asin(0.5*ecRad/Rcurv);
+      }
+      if (zAbs>ecDist) {
+	zAbs           = (std::abs(etaIP)/etaIP)*ecDist;
+	double Zflight = std::abs(zAbs-vtxZ);
+	double alpha   = (Zflight*ecRad)/(z*Rcurv);
+	double Rec     = 2*Rcurv*sin(alpha/2);
+	deltaPhi       =-charge*alpha/2;
+	etaEC          =-log(tan(0.5*atan(Rec/ecDist)));
+      }
     }
-  else
-    {
-      zNew           = (fabs(etaIP)/etaIP)*ecDist;
-      double Zflight = fabs(zNew-vtxZ);
-      double Rvirt   = fabs(Zflight*tan(theta));
-      double Rec     = 2*Rcurv*sin(Rvirt/(2*Rcurv));
-      deltaPhi       =-(charge)*(Rvirt/(2*Rcurv));
-      etaEC          =-log(tan(0.5*atan(Rec/ecDist)));
-    }
+  } else {
+    zNew           = (std::abs(etaIP)/etaIP)*ecDist;
+    double Zflight = std::abs(zNew-vtxZ);
+    double Rvirt   = std::abs(Zflight*tan(theta));
+    double Rec     = 2*Rcurv*sin(Rvirt/(2*Rcurv));
+    deltaPhi       =-(charge)*(Rvirt/(2*Rcurv));
+    etaEC          =-log(tan(0.5*atan(Rec/ecDist)));
+  }
 
   if (zNew<0) etaEC=-etaEC;
   phiEC            = phiIP+deltaPhi;
 
-  if (phiEC<-acos(-1)) phiEC = 2*acos(-1)+phiEC;
-  if (phiEC>acos(-1))  phiEC =-2*acos(-1)+phiEC;
+  if (phiEC<-M_PI) phiEC += M_2_PI;
+  if (phiEC>M_PI)  phiEC -= M_2_PI;
 
   std::pair<double,double> retVal(etaEC,phiEC);
   return retVal;

--- a/Calibration/HcalIsolatedTrackReco/src/SealModule.cc
+++ b/Calibration/HcalIsolatedTrackReco/src/SealModule.cc
@@ -1,6 +1,7 @@
 #include "FWCore/PluginManager/interface/ModuleDef.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "Calibration/HcalIsolatedTrackReco/interface/IsolatedPixelTrackCandidateProducer.h"
+#include "Calibration/HcalIsolatedTrackReco/interface/IsolatedEcalPixelTrackCandidateProducer.h"
 #include "Calibration/HcalIsolatedTrackReco/interface/EcalIsolatedParticleCandidateProducer.h"
 #include "RecoTracker/TkTrackingRegions/interface/TrackingRegionProducerFactory.h" 	 
 #include "RecoTracker/TkTrackingRegions/interface/TrackingRegionProducer.h" 	 
@@ -14,6 +15,7 @@
 DEFINE_EDM_PLUGIN(TrackingRegionProducerFactory, HITRegionalPixelSeedGenerator, "HITRegionalPixelSeedGenerator"); 
 //
 DEFINE_FWK_MODULE(IsolatedPixelTrackCandidateProducer);
+DEFINE_FWK_MODULE(IsolatedEcalPixelTrackCandidateProducer);
 DEFINE_FWK_MODULE(EcalIsolatedParticleCandidateProducer);
 DEFINE_FWK_MODULE(SiStripRegFEDSelector);
 DEFINE_FWK_MODULE(ECALRegFEDSelector);

--- a/DataFormats/HcalIsolatedTrack/interface/IsolatedPixelTrackCandidate.h
+++ b/DataFormats/HcalIsolatedTrack/interface/IsolatedPixelTrackCandidate.h
@@ -19,105 +19,131 @@
 namespace reco {
   
   class IsolatedPixelTrackCandidate: public RecoCandidate {
-    
+
   public:
     
-    /// default constructor
-    IsolatedPixelTrackCandidate() : RecoCandidate() { }
-      ///constructor from LorentzVector
-      IsolatedPixelTrackCandidate(const LorentzVector& v): RecoCandidate(0,v)
-	{
-	  enIn_=-1;
-	  enOut_=-1;
-	  nhitIn_=-1;
-	  nhitOut_=-1;
-	  maxPtPxl_=-1;
-	  sumPtPxl_=-1;
-	}
-      /// constructor from a track
-      IsolatedPixelTrackCandidate(const reco::TrackRef & tr, const l1extra::L1JetParticleRef & tauRef, double max, double sum): 
-	RecoCandidate( 0, LorentzVector((tr.get()->px()),(tr.get())->py(),(tr.get())->pz(),(tr.get())->p()) ),
-	track_(tr), l1tauJet_(tauRef), maxPtPxl_(max), sumPtPxl_(sum) 
-	{
-	  enIn_=-1;
-	  enOut_=-1;
-	  nhitIn_=-1;
-	  nhitOut_=-1;
-	}
-	
-	///constructor from tau jet
-	IsolatedPixelTrackCandidate(const l1extra::L1JetParticleRef & tauRef, double enIn, double enOut, int nhitIn, int nhitOut):
-	  RecoCandidate( 0, LorentzVector(tauRef->px(),tauRef->py(),tauRef->pz(),tauRef->p()) ), 
-	  l1tauJet_(tauRef), enIn_(enIn), enOut_(enOut), nhitIn_(nhitIn), nhitOut_(nhitOut) 
-	  {
-	    maxPtPxl_=-1;
-	    sumPtPxl_=-1;
-	  }
-	  
-	  
-	  
-	  
-	  /// destructor
-	  virtual ~IsolatedPixelTrackCandidate();
+    // default constructor
+    IsolatedPixelTrackCandidate() : RecoCandidate() { 
+      enIn_=-1;
+      enOut_=-1;
+      nhitIn_=-1;
+      nhitOut_=-1;
+      maxPtPxl_=-1;
+      sumPtPxl_=-1;
+      etaEcal_=0;
+      phiEcal_=0;
+      etaPhiEcal_=false; 
+    }
+    ///constructor from LorentzVector
+    IsolatedPixelTrackCandidate(const LorentzVector& v): RecoCandidate(0,v) {
+      enIn_=-1;
+      enOut_=-1;
+      nhitIn_=-1;
+      nhitOut_=-1;
+      maxPtPxl_=-1;
+      sumPtPxl_=-1;
+      etaEcal_=0;
+      phiEcal_=0;
+      etaPhiEcal_=false;
+    }
+    /// constructor from a track
+  IsolatedPixelTrackCandidate(const reco::TrackRef & tr, const l1extra::L1JetParticleRef & tauRef, double max, double sum): 
+    RecoCandidate( 0, LorentzVector((tr.get()->px()),(tr.get())->py(),(tr.get())->pz(),(tr.get())->p()) ),
+      track_(tr), l1tauJet_(tauRef), maxPtPxl_(max), sumPtPxl_(sum) {
+      enIn_=-1;
+      enOut_=-1;
+      nhitIn_=-1;
+      nhitOut_=-1;
+      etaEcal_=0;
+      phiEcal_=0;
+      etaPhiEcal_=false;
+    }
+        
+    ///constructor from tau jet
+    IsolatedPixelTrackCandidate(const l1extra::L1JetParticleRef & tauRef, double enIn, double enOut, int nhitIn, int nhitOut):
+    RecoCandidate( 0, LorentzVector(tauRef->px(),tauRef->py(),tauRef->pz(),tauRef->p()) ), 
+      l1tauJet_(tauRef), enIn_(enIn), enOut_(enOut), nhitIn_(nhitIn), nhitOut_(nhitOut) {
+      maxPtPxl_=-1;
+      sumPtPxl_=-1;
+      etaEcal_=0;
+      phiEcal_=0;
+      etaPhiEcal_=false;
+    }
+    /// Copy constructor
+    IsolatedPixelTrackCandidate(const IsolatedPixelTrackCandidate&);
 
-	  /// returns a clone of the candidate
-	  virtual IsolatedPixelTrackCandidate * clone() const;
+    /// destructor
+    virtual ~IsolatedPixelTrackCandidate();
 
-	  /// refrence to a Track
-	  virtual reco::TrackRef track() const;
-          void setTrack( const reco::TrackRef & tr ) { track_ = tr; }
+    /// returns a clone of the candidate
+    virtual IsolatedPixelTrackCandidate * clone() const;
 
-	  /// highest Pt of other pixel tracks in the cone around the candidate
-	  double maxPtPxl() const {return maxPtPxl_;}
-	  void SetMaxPtPxl(double mptpxl) {maxPtPxl_=mptpxl;}
+    /// refrence to a Track
+    virtual reco::TrackRef track() const;
+    void setTrack( const reco::TrackRef & tr ) { track_ = tr; }
 
-	  /// Pt sum of other pixel tracks in the cone around the candidate
-	  double sumPtPxl() const {return sumPtPxl_;}
-	  void SetSumPtPxl(double sumptpxl) {sumPtPxl_=sumptpxl;}
-	  
-	  /// get reference to L1 tau jet
-	  virtual l1extra::L1JetParticleRef l1tau() const;
-          void setL1TauJet( const l1extra::L1JetParticleRef & tauRef ) { l1tauJet_ = tauRef; }
- 	  
-	  /// ECAL energy in the inner cone around tau jet
-	  double energyIn() const {return enIn_; }
-	  void SetEnergyIn(double a) {enIn_=a;}
-	  
-	  /// ECAL energy in the outer cone around tau jet
-	  double energyOut() const {return enOut_;}
-	  void SetEnergyOut(double a) {enOut_=a;}
-	  
-	  /// number of ECAL hits in the inner cone around tau jet
-	  int nHitIn() const {return nhitIn_;}
-	  void SetNHitIn(int a) {nhitIn_=a;}
-	  
-	  /// number of ECAL hits in the outer cone around tau jet
-	  int nHitOut() const {return nhitOut_;}
-	  void SetNHitOut(int a) {nhitOut_=a;}
-	  
-	  ///get index of tower which track is hitting
-	  std::pair<int,int> towerIndex() const;
-	  
+    /// highest Pt of other pixel tracks in the cone around the candidate
+    double maxPtPxl() const {return maxPtPxl_;}
+    void SetMaxPtPxl(double mptpxl) {maxPtPxl_=mptpxl;}
+
+    /// Pt sum of other pixel tracks in the cone around the candidate
+    double sumPtPxl() const {return sumPtPxl_;}
+    void SetSumPtPxl(double sumptpxl) {sumPtPxl_=sumptpxl;}
+          
+    /// get reference to L1 tau jet
+    virtual l1extra::L1JetParticleRef l1tau() const;
+    void setL1TauJet( const l1extra::L1JetParticleRef & tauRef ) { l1tauJet_ = tauRef; }
+          
+    /// ECAL energy in the inner cone around tau jet
+    double energyIn() const {return enIn_; }
+    void SetEnergyIn(double a) {enIn_=a;}
+          
+    /// ECAL energy in the outer cone around tau jet
+    double energyOut() const {return enOut_;}
+    void SetEnergyOut(double a) {enOut_=a;}
+          
+    /// number of ECAL hits in the inner cone around tau jet
+    int nHitIn() const {return nhitIn_;}
+    void SetNHitIn(int a) {nhitIn_=a;}
+          
+    /// number of ECAL hits in the outer cone around tau jet
+    int nHitOut() const {return nhitOut_;}
+    void SetNHitOut(int a) {nhitOut_=a;}
+          
+    ///get index of tower which track is hitting
+    std::pair<int,int> towerIndex() const;
+
+    ///eta, phi at ECAL surface
+    void SetEtaPhiEcal(double eta, double phi) {
+      etaEcal_=eta; phiEcal_=phi; etaPhiEcal_=true;
+    }
+    std::pair<double,double> EtaPhiEcal() const {
+      return ((etaPhiEcal_) ? std::pair<double,double>(etaEcal_,phiEcal_) : std::pair<double,double>(0,0));
+    }
+    bool etaPhiEcal() const {return etaPhiEcal_;}
+
   private:
-	  /// check overlap with another candidate
-	  virtual bool overlap( const Candidate & ) const;
-	  /// reference to a Track
-	  reco::TrackRef track_;
-	  /// reference to a L1 tau jet
-	  l1extra::L1JetParticleRef l1tauJet_;
-	  /// highest Pt of other pixel tracks in the cone around the candidate
-	  double maxPtPxl_;
-	  /// Pt sum of other pixel tracks in the cone around the candidate
-	  double sumPtPxl_;
-	  /// energy in inner cone around L1 tau jet
-	  double enIn_;
-	  /// energy in outer cone around L1 tau jet
-	  double enOut_;
-	  /// number of hits in inner cone
-	  int nhitIn_;
-	  /// number of hits in inner cone
-	  int nhitOut_;
-	  
+    /// check overlap with another candidate
+    virtual bool overlap( const Candidate & ) const;
+    /// reference to a Track
+    reco::TrackRef track_;
+    /// reference to a L1 tau jet
+    l1extra::L1JetParticleRef l1tauJet_;
+    /// highest Pt of other pixel tracks in the cone around the candidate
+    double maxPtPxl_;
+    /// Pt sum of other pixel tracks in the cone around the candidate
+    double sumPtPxl_;
+    /// energy in inner cone around L1 tau jet
+    double enIn_;
+    /// energy in outer cone around L1 tau jet
+    double enOut_;
+    /// number of hits in inner cone
+    int nhitIn_;
+    /// number of hits in inner cone
+    int nhitOut_;
+    /// eta, phi at ECAL
+    bool etaPhiEcal_;
+    double etaEcal_, phiEcal_;
   };
   
   

--- a/DataFormats/HcalIsolatedTrack/src/IsolatedPixelTrackCandidate.cc
+++ b/DataFormats/HcalIsolatedTrack/src/IsolatedPixelTrackCandidate.cc
@@ -2,7 +2,20 @@
 
 using namespace reco;
 
+IsolatedPixelTrackCandidate::IsolatedPixelTrackCandidate(const IsolatedPixelTrackCandidate& right) : RecoCandidate(right), track_(right.track_), l1tauJet_(right.l1tauJet_) {
+  maxPtPxl_  = right.maxPtPxl_;
+  sumPtPxl_  = right.sumPtPxl_;
+  enIn_      = right.enIn_;
+  enOut_     = right.enOut_;
+  nhitIn_    = right.nhitIn_;
+  nhitOut_   = right.nhitOut_;
+  etaPhiEcal_= right.etaPhiEcal_;
+  etaEcal_   = right.etaEcal_; 
+  phiEcal_   = right.phiEcal_;  
+}
+
 IsolatedPixelTrackCandidate::~IsolatedPixelTrackCandidate() { }
+
 
 IsolatedPixelTrackCandidate * IsolatedPixelTrackCandidate::clone() const { 
   return new IsolatedPixelTrackCandidate( * this ); 

--- a/DataFormats/HcalIsolatedTrack/src/classes_def.xml
+++ b/DataFormats/HcalIsolatedTrack/src/classes_def.xml
@@ -2,8 +2,9 @@
 
   <class name="edm::Wrapper<std::map <int,std::pair<double,double> > >"/> 
 
-  <class name="reco::IsolatedPixelTrackCandidate" ClassVersion="10">
+ <class name="reco::IsolatedPixelTrackCandidate" ClassVersion="11">
    <version ClassVersion="10" checksum="3865088611"/>
+   <version ClassVersion="11" checksum="264617237"/>
   </class>
   <class name="reco::IsolatedPixelTrackCandidateCollection"/>
   <class name="reco::IsolatedPixelTrackCandidateRef"/>
@@ -17,10 +18,10 @@
   <class name="reco::EcalIsolatedParticleCandidate" ClassVersion="11">
    <version ClassVersion="10" checksum="4174683084"/>
    <version ClassVersion="11" checksum="928263435"/>
-   <ioread sourceClass="reco::EcalIsolatedParticleCandidate" version="[1-10]" targetClass="reco::LeafParticle" source="double eta_" target="float eta_">
+   <ioread sourceClass="reco::EcalIsolatedParticleCandidate" version="[1-11]" targetClass="reco::LeafParticle" source="double eta_" target="float eta_">
    <![CDATA[eta_ = onfile.eta_;]]>
    </ioread>  
-   <ioread sourceClass="reco::EcalIsolatedParticleCandidate" version="[1-10]" targetClass="reco::LeafParticle" source="double phi_" target="float phi_">
+   <ioread sourceClass="reco::EcalIsolatedParticleCandidate" version="[1-11]" targetClass="reco::LeafParticle" source="double phi_" target="float phi_">
    <![CDATA[phi_ = onfile.phi_;]]>
    </ioread>   
   </class>

--- a/HLTrigger/special/interface/HLTEcalPixelIsolTrackFilter.h
+++ b/HLTrigger/special/interface/HLTEcalPixelIsolTrackFilter.h
@@ -1,0 +1,32 @@
+#ifndef HLTEcalPixelIsolTrackFilter_h
+#define HLTEcalPixelIsolTrackFilter_h
+
+#include "HLTrigger/HLTcore/interface/HLTFilter.h"
+#include "DataFormats/HcalIsolatedTrack/interface/IsolatedPixelTrackCandidate.h"
+/*
+ This filter complements HLTPixelIsolTrackFilter in the trigger path
+ IsoTrackHB(HE) to eliminates non-MIP tracks in ECAL and thus improving
+ efficiency and reducing data rate significantly
+ */
+namespace edm {
+  class ConfigurationDescriptions;
+}
+
+class HLTEcalPixelIsolTrackFilter : public HLTFilter {  
+
+public:
+  explicit HLTEcalPixelIsolTrackFilter(const edm::ParameterSet&);
+  ~HLTEcalPixelIsolTrackFilter();
+  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
+  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+
+private:
+  edm::EDGetTokenT<reco::IsolatedPixelTrackCandidateCollection> candTok;
+  edm::InputTag candTag_; 
+  double maxEnergyIn_;
+  double maxEnergyOut_;
+  int    nMaxTrackCandidates_;
+  bool   dropMultiL2Event_;
+};
+
+#endif 

--- a/HLTrigger/special/src/HLTEcalPixelIsolTrackFilter.cc
+++ b/HLTrigger/special/src/HLTEcalPixelIsolTrackFilter.cc
@@ -1,0 +1,63 @@
+#include "HLTrigger/special/interface/HLTEcalPixelIsolTrackFilter.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Common/interface/RefToBase.h"
+#include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
+#include "DataFormats/HLTReco/interface/TriggerTypeDefs.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+HLTEcalPixelIsolTrackFilter::HLTEcalPixelIsolTrackFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig) {
+  candTag_             = iConfig.getParameter<edm::InputTag> ("candTag");
+  maxEnergyIn_         = iConfig.getParameter<double> ("MaxEnergyIn");
+  maxEnergyOut_        = iConfig.getParameter<double> ("MaxEnergyOut");
+  nMaxTrackCandidates_ = iConfig.getParameter<int>("NMaxTrackCandidates");
+  dropMultiL2Event_    = iConfig.getParameter<bool> ("DropMultiL2Event");
+  candTok = consumes<reco::IsolatedPixelTrackCandidateCollection>(candTag_);
+}
+
+HLTEcalPixelIsolTrackFilter::~HLTEcalPixelIsolTrackFilter(){}
+
+void HLTEcalPixelIsolTrackFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  makeHLTFilterDescription(desc);
+  desc.add<edm::InputTag>("candTag",edm::InputTag("isolEcalPixelTrackProdHB"));
+  desc.add<double>("MaxEnergyIn",1.2);
+  desc.add<double>("MaxEnergyOut",1.2);
+  desc.add<int>("NMaxTrackCandidates",10);
+  desc.add<bool>("DropMultiL2Event",false);
+  descriptions.add("isolEcalPixelTrackFilter",desc);
+}
+
+bool HLTEcalPixelIsolTrackFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const {
+
+  if (saveTags())
+    filterproduct.addCollectionTag(candTag_);
+
+  edm::Handle<reco::IsolatedPixelTrackCandidateCollection> recotrackcands;
+  iEvent.getByToken(candTok,recotrackcands);
+  if (!recotrackcands.isValid()) return false;
+
+  int n=0;
+  for (unsigned int i=0; i<recotrackcands->size(); i++) {
+    edm::Ref<reco::IsolatedPixelTrackCandidateCollection> candref =
+      edm::Ref<reco::IsolatedPixelTrackCandidateCollection>(recotrackcands, i);
+    //    std::cout << "candref.isNull() " << candref.isNull() << std::endl;
+    if(candref.isNull()) continue;
+    //    std::cout << "candref.track().isNull() " << candref->track().isNull() << std::endl;
+    if(candref->track().isNull()) continue;
+    // select on transverse momentum
+    //    std::cout << "energyin/out: " << candref->energyIn() << "/" << candref->energyOut() << std::endl;
+    if (candref->energyIn()<maxEnergyIn_&& candref->energyOut()<maxEnergyOut_) {
+      filterproduct.addObject(trigger::TriggerTrack, candref);
+      n++;
+    }
+    if(!dropMultiL2Event_ && n>=nMaxTrackCandidates_) break; 
+
+  } 
+  bool accept(n>0);
+  if (dropMultiL2Event_ && n>nMaxTrackCandidates_ ) accept=false;  
+  //  std::cout << "accept here" << accept << std::endl;
+  return accept;
+}
+	  

--- a/HLTrigger/special/src/SealModule.cc
+++ b/HLTrigger/special/src/SealModule.cc
@@ -3,6 +3,7 @@
 #include "HLTrigger/special/interface/HLTPixlMBFilt.h"
 #include "HLTrigger/special/interface/HLTPixlMBForAlignmentFilter.h"
 #include "HLTrigger/special/interface/HLTPixelIsolTrackFilter.h"
+#include "HLTrigger/special/interface/HLTEcalPixelIsolTrackFilter.h"
 #include "HLTrigger/special/interface/HLTEcalIsolationFilter.h"
 #include "HLTrigger/special/interface/HLTEcalPhiSymFilter.h"
 #include "HLTrigger/special/interface/HLTHcalPhiSymFilter.h"
@@ -33,6 +34,7 @@
 DEFINE_FWK_MODULE(HLTPixlMBFilt);
 DEFINE_FWK_MODULE(HLTPixlMBForAlignmentFilter);
 DEFINE_FWK_MODULE(HLTPixelIsolTrackFilter);
+DEFINE_FWK_MODULE(HLTEcalPixelIsolTrackFilter);
 DEFINE_FWK_MODULE(HLTEcalIsolationFilter);
 DEFINE_FWK_MODULE(HLTEcalPhiSymFilter);
 DEFINE_FWK_MODULE(HLTHcalPhiSymFilter);


### PR DESCRIPTION
Porting back the code from 7_3_X. This contains code for improving IsoTrackHB(HE) HLT's required for HCAL calibration using isolated charged particles. This porting is needed to create the HLT trigger path using confDB. This is a truncated version from IsoCalib01. The testing part of the code is not present. Only the ones required to make trigger path from ConfDB are kept.
