### PR TITLE
Allow the XrdFile to close quickly

### DIFF
--- a/Utilities/XrdAdaptor/src/XrdRequestManager.cc
+++ b/Utilities/XrdAdaptor/src/XrdRequestManager.cc
@@ -849,12 +849,13 @@ XrdAdaptor::RequestManager::OpenHandler::~OpenHandler()
 void
 XrdAdaptor::RequestManager::OpenHandler::GiftSelf(std::unique_ptr<OpenHandler> me)
 {
-    m_self = std::move(me);
+    std::shared_ptr<OpenHandler> myself(std::move(me));
+    m_self = myself;
     m_ignore_response.test_and_set();
     // The test and set indicates to the open handler it should throw away the results.  However,
     // if the open handler fired between the time we set m_self and m_ignore_response, we must
     // make sure to delete ourself.
-    if (m_shared_future.valid() && (m_shared_future.wait_for(std::chrono::seconds(0)) == std::future_status::ready))
+    if (!m_shared_future.valid() || (m_shared_future.wait_for(std::chrono::seconds(0)) == std::future_status::ready))
     {
         m_self.reset();
     }

--- a/Utilities/XrdAdaptor/src/XrdRequestManager.cc
+++ b/Utilities/XrdAdaptor/src/XrdRequestManager.cc
@@ -206,7 +206,15 @@ RequestManager::~RequestManager()
 {
   // This will cause the open handler to delete itself once
   // the final open comes through.
-  m_open_handler->GiftSelf(std::move(m_open_handler));
+  if (m_open_handler)
+  {
+    // Note that this is invalid:
+    //   m_open_handler->GiftSelf(std::move(m_open_handler));
+    // in gcc 4.8, the std::move is evaluated first, meaning
+    // m_open_handler->GiftSelf is a null-pointer dereference.
+    OpenHandler *handler = m_open_handler.get();
+    handler->GiftSelf(std::move(m_open_handler));
+  }
 }
 
 void

--- a/Utilities/XrdAdaptor/src/XrdRequestManager.h
+++ b/Utilities/XrdAdaptor/src/XrdRequestManager.h
@@ -224,7 +224,7 @@ private:
         std::recursive_mutex m_mutex;
         std::atomic_flag m_ignore_response;
 
-        std::unique_ptr<OpenHandler> m_self;
+        std::shared_ptr<OpenHandler> m_self;
     };
 
     std::unique_ptr<OpenHandler> m_open_handler;

--- a/Utilities/XrdAdaptor/src/XrdRequestManager.h
+++ b/Utilities/XrdAdaptor/src/XrdRequestManager.h
@@ -47,7 +47,7 @@ public:
 
     RequestManager(const std::string & filename, XrdCl::OpenFlags::Flags flags, XrdCl::Access::Mode perms);
 
-    ~RequestManager() = default;
+    ~RequestManager();
 
     /**
      * Interface for handling a client request.
@@ -204,6 +204,16 @@ private:
          */
         std::string current_source();
 
+        /**
+         * Turn lifetime management of the open handler to itself.
+         * The post conditions are one of the following:
+         *   - The OpenHandler deletes itself, OR
+         *   - The OpenHandler will delete itself when the callback fires.
+         * In the latter case, the OpenHandler will not attempt to call
+         * back to the RequestManager - it is assumed to have already been deleted.
+         */
+        void GiftSelf(std::unique_ptr<OpenHandler> me);
+
     private:
         RequestManager & m_manager;
         std::shared_future<std::shared_ptr<Source> > m_shared_future;
@@ -213,9 +223,11 @@ private:
         std::unique_ptr<XrdCl::File> m_file;
         std::recursive_mutex m_mutex;
         std::atomic_flag m_ignore_response;
+
+        std::unique_ptr<OpenHandler> m_self;
     };
 
-    OpenHandler m_open_handler;
+    std::unique_ptr<OpenHandler> m_open_handler;
 };
 
 }


### PR DESCRIPTION
Previously, the XrdFile close would not finish until the OpenHandler returned.

Accordingly - if there was a random probe for new sources occurring which was taking a long amount of time (timeout is 180 seconds by default), then the XrdFile::close() call would take up to 180 seconds.  This was especially irritating as we would just throw away the results of the OpenHandler.

With this, when XrdRequestManager's destructor fires, we pass ownership of the OpenHandler object to itself.  Then, when the callback fires, the object will delete itself.

Note the use of shared_ptr in XrdRequestManager::OpenHandler::GiftSelf to prevent the deletion of the object while GiftSelf is running (if the callback fires concurrently).

This allows the OpenHandler to be destroyed completely asynchronously from the XrdRequestManager, making shutdown much faster.
