### PR TITLE
RSG to GamGam Fragment for RelVal

### DIFF
--- a/Configuration/Generator/python/RSGravitonToGammaGamma_kMpl01_M_3000_TuneCUETP8M1_13TeV_pythia8_cfi.py
+++ b/Configuration/Generator/python/RSGravitonToGammaGamma_kMpl01_M_3000_TuneCUETP8M1_13TeV_pythia8_cfi.py
@@ -1,0 +1,38 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+        comEnergy = cms.double(13000.0),
+        crossSection = cms.untracked.double(1),
+        filterEfficiency = cms.untracked.double(1),
+        maxEventsToPrint = cms.untracked.int32(0),
+        pythiaHepMCVerbosity = cms.untracked.bool(False),
+        pythiaPylistVerbosity = cms.untracked.int32(1),
+        PythiaParameters = cms.PSet(
+                processParameters = cms.vstring(
+                        'ExtraDimensionsG*:all = on',
+                        'ExtraDimensionsG*:kappaMG = 0.54',
+                        '5100039:m0 = 3000',
+                        '5100039:onMode = off',
+                        '5100039:onIfAny = 22',
+
+                ),
+                parameterSets = cms.vstring('pythia8CommonSettings',
+                                            'pythia8CUEP8M1Settings',
+                                            'processParameters',
+                                            )
+        )
+)
+
+ProductionFilterSequence = cms.Sequence(generator)
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
Added the gen fragment for the RSG to Diphotons for RelVal Production. Exotica needs high pt diphoton samples for online/offline dqm.

RSGravitonToGammaGamma_kMpl01_M_3000_TuneCUETP8M1_13TeV_pythia8_cfi.py

uses pythia8, with the CUETP8M1 tune
