### PR TITLE
a fix for SUB=TH1F::Sumw2 error in DQM/Physics package

### DIFF
--- a/DQM/Physics/src/QcdPhotonsDQM.cc
+++ b/DQM/Physics/src/QcdPhotonsDQM.cc
@@ -209,10 +209,18 @@ void QcdPhotonsDQM::bookHistograms(DQMStore::IBooker & ibooker,
   h_photon_et_jetfo = ibooker.book1D("photon_et_jetfo",
       "#gamma with highest E_{T} (1.55<#eta(jet)<2.5, "
       "#eta(#gamma)#eta(jet)<0);E_{T}(#gamma) (GeV)", num_bins_et, bins_et);
-  h_photon_et_jetcs->getTH1F()->Sumw2();
-  h_photon_et_jetco->getTH1F()->Sumw2();
-  h_photon_et_jetfs->getTH1F()->Sumw2();
-  h_photon_et_jetfo->getTH1F()->Sumw2();
+
+  auto setSumw2 = [](MonitorElement* me) {
+    if (me->getTH1F()->GetSumw2N() == 0) {
+      me->getTH1F()->Sumw2();
+    }
+  };
+
+  setSumw2(h_photon_et_jetcs);
+  setSumw2(h_photon_et_jetco);
+  setSumw2(h_photon_et_jetfs);
+  setSumw2(h_photon_et_jetfo);
+
   // Ratio of the above Photon Et distributions
   h_photon_et_ratio_co_cs = ibooker.book1D("photon_et_ratio_00_co_cs",
       "D(|#eta(jet)|<1.45, #eta(jet)*#eta(#gamma)<0) / D(|#eta(jet)|<1.45, "
@@ -237,12 +245,12 @@ void QcdPhotonsDQM::bookHistograms(DQMStore::IBooker & ibooker,
       "D(|#eta(jet)|<1.45, #eta(jet)*#eta(#gamma)<0) / D(1.55<|#eta(jet)|<2.6, "
       "#eta(jet)*#eta(#gamma)<0);E_{T}(#gamma) (GeV); ratio",
       num_bins_et, bins_et);
-  h_photon_et_ratio_co_cs->getTH1F()->Sumw2();
-  h_photon_et_ratio_fo_fs->getTH1F()->Sumw2();
-  h_photon_et_ratio_cs_fs->getTH1F()->Sumw2();
-  h_photon_et_ratio_co_fs->getTH1F()->Sumw2();
-  h_photon_et_ratio_cs_fo->getTH1F()->Sumw2();
-  h_photon_et_ratio_co_fo->getTH1F()->Sumw2();
+  setSumw2(h_photon_et_ratio_co_cs);
+  setSumw2(h_photon_et_ratio_fo_fs);
+  setSumw2(h_photon_et_ratio_cs_fs);
+  setSumw2(h_photon_et_ratio_co_fs);
+  setSumw2(h_photon_et_ratio_cs_fo);
+  setSumw2(h_photon_et_ratio_co_fo);
 }
 
 void QcdPhotonsDQM::analyze(const Event& iEvent, const EventSetup& iSetup) {


### PR DESCRIPTION
A fix needed for issue found in here : https://github.com/cms-sw/cmssw/pull/6177
Adds a check if Sumw2 call was done before.
Before when running a workflow (4.6) where multiple runs were processed bookHistograms method was called one than once and it triggered a "Sum of squares of weights structure already created" error.
