### PR TITLE
Saving pixel match info in the electron for offline ID purposes

### DIFF
--- a/DataFormats/EgammaCandidates/interface/GsfElectron.h
+++ b/DataFormats/EgammaCandidates/interface/GsfElectron.h
@@ -792,17 +792,17 @@ class GsfElectron : public RecoCandidate
   
   public:
     struct PixelMatchVariables{
-      unsigned char subdetectors ;
       float dPhi1 ;
       float dPhi2 ;
       float dRz1  ;
       float dRz2  ;
+      unsigned char subdetectors ;
       PixelMatchVariables():
-        subdetectors(0),
         dPhi1(-999),
         dPhi2(-999),
         dRz1(-999),
-        dRz2(-999)
+        dRz2(-999),
+        subdetectors(0)
       {}
       ~PixelMatchVariables(){}
     };

--- a/DataFormats/EgammaCandidates/interface/GsfElectron.h
+++ b/DataFormats/EgammaCandidates/interface/GsfElectron.h
@@ -789,7 +789,37 @@ class GsfElectron : public RecoCandidate
 
     // attributes
     Corrections corrections_ ;
-
+  
+  public:
+    struct PixelMatchVariables{
+      unsigned char subdetectors ;
+      float dPhi1 ;
+      float dPhi2 ;
+      float dRz1  ;
+      float dRz2  ;
+      PixelMatchVariables():
+        subdetectors(0),
+        dPhi1(-999),
+        dPhi2(-999),
+        dRz1(-999),
+        dRz2(-999)
+      {}
+      ~PixelMatchVariables(){}
+    };
+  void setPixelMatchSubdetectors(int sd1, int sd2){ pixelMatchVariables_.subdetectors = 10*sd1+sd2 ; }
+  void setPixelMatchDPhi1(float dPhi1){ pixelMatchVariables_.dPhi1 = dPhi1 ; }
+  void setPixelMatchDPhi2(float dPhi2){ pixelMatchVariables_.dPhi2 = dPhi2 ; }
+  void setPixelMatchDRz1 (float dRz1 ){ pixelMatchVariables_.dRz1  = dRz1  ; }
+  void setPixelMatchDRz2 (float dRz2 ){ pixelMatchVariables_.dRz2  = dRz2  ; }
+  
+  int pixelMatchSubdetector1(){ return pixelMatchVariables_.subdetectors/10 ; }
+  int pixelMatchSubdetector2(){ return pixelMatchVariables_.subdetectors%10 ; }
+  float pixelMatchDPhi1(){ return pixelMatchVariables_.dPhi1 ; }
+  float pixelMatchDPhi2(){ return pixelMatchVariables_.dPhi2 ; }
+  float pixelMatchDRz1 (){ return pixelMatchVariables_.dRz1  ; }
+  float pixelMatchDRz2 (){ return pixelMatchVariables_.dRz2  ; }
+  private:
+    PixelMatchVariables pixelMatchVariables_ ;
  } ;
 
  } // namespace reco

--- a/DataFormats/EgammaCandidates/interface/GsfElectron.h
+++ b/DataFormats/EgammaCandidates/interface/GsfElectron.h
@@ -792,10 +792,15 @@ class GsfElectron : public RecoCandidate
   
   public:
     struct PixelMatchVariables{
+      //! Pixel match variable: deltaPhi for innermost hit
       float dPhi1 ;
+      //! Pixel match variable: deltaPhi for second hit
       float dPhi2 ;
+      //! Pixel match variable: deltaRz for innermost hit
       float dRz1  ;
+      //! Pixel match variable: deltaRz for second hit
       float dRz2  ;
+      //! Subdetectors for first and second pixel hit
       unsigned char subdetectors ;
       PixelMatchVariables():
         dPhi1(-999),
@@ -812,12 +817,12 @@ class GsfElectron : public RecoCandidate
   void setPixelMatchDRz1 (float dRz1 ){ pixelMatchVariables_.dRz1  = dRz1  ; }
   void setPixelMatchDRz2 (float dRz2 ){ pixelMatchVariables_.dRz2  = dRz2  ; }
   
-  int pixelMatchSubdetector1(){ return pixelMatchVariables_.subdetectors/10 ; }
-  int pixelMatchSubdetector2(){ return pixelMatchVariables_.subdetectors%10 ; }
-  float pixelMatchDPhi1(){ return pixelMatchVariables_.dPhi1 ; }
-  float pixelMatchDPhi2(){ return pixelMatchVariables_.dPhi2 ; }
-  float pixelMatchDRz1 (){ return pixelMatchVariables_.dRz1  ; }
-  float pixelMatchDRz2 (){ return pixelMatchVariables_.dRz2  ; }
+  int pixelMatchSubdetector1() const { return pixelMatchVariables_.subdetectors/10 ; }
+  int pixelMatchSubdetector2() const { return pixelMatchVariables_.subdetectors%10 ; }
+  float pixelMatchDPhi1() const { return pixelMatchVariables_.dPhi1 ; }
+  float pixelMatchDPhi2() const { return pixelMatchVariables_.dPhi2 ; }
+  float pixelMatchDRz1 () const { return pixelMatchVariables_.dRz1  ; }
+  float pixelMatchDRz2 () const { return pixelMatchVariables_.dRz2  ; }
   private:
     PixelMatchVariables pixelMatchVariables_ ;
  } ;

--- a/DataFormats/EgammaCandidates/src/GsfElectron.cc
+++ b/DataFormats/EgammaCandidates/src/GsfElectron.cc
@@ -94,7 +94,8 @@ GsfElectron::GsfElectron
    ambiguousGsfTracks_(electron.ambiguousGsfTracks_),
    classVariables_(electron.classVariables_),
    class_(electron.class_),
-   corrections_(electron.corrections_)
+   corrections_(electron.corrections_),
+   pixelMatchVariables_(electron.pixelMatchVariables_)
  {
   assert(electron.core()->ctfTrack()==core->ctfTrack()) ;
   assert(electron.core()->ctfGsfOverlap()==core->ctfGsfOverlap()) ;
@@ -130,7 +131,8 @@ GsfElectron::GsfElectron
    //mva_(electron.mva_),
    classVariables_(electron.classVariables_),
    class_(electron.class_),
-   corrections_(electron.corrections_)
+   corrections_(electron.corrections_),
+   pixelMatchVariables_(electron.pixelMatchVariables_)
  {
   trackClusterMatching_.electronCluster = electronCluster ;
   //closestCtfTrack_.ctfTrack = closestCtfTrack ;

--- a/DataFormats/EgammaCandidates/src/classes.h
+++ b/DataFormats/EgammaCandidates/src/classes.h
@@ -143,6 +143,7 @@ namespace DataFormats_EgammaCandidates {
     edm::Ref<reco::GsfElectronCollection> r4;
     edm::RefProd<reco::GsfElectronCollection> rp4;
     edm::Wrapper<edm::RefVector<reco::GsfElectronCollection> > rv4;
+    reco::GsfElectron::PixelMatchVariables gepmv ;
 
     reco::SiStripElectronCollection v5;
     edm::Wrapper<reco::SiStripElectronCollection> w5;

--- a/DataFormats/EgammaCandidates/src/classes.h
+++ b/DataFormats/EgammaCandidates/src/classes.h
@@ -130,7 +130,7 @@ namespace DataFormats_EgammaCandidates {
     reco::GsfElectron::MvaInput gemi ;
     reco::GsfElectron::MvaOutput gemo ;
     reco::GsfElectron::ClassificationVariables gecv ;
-
+    reco::GsfElectron::PixelMatchVariables gepmv ;
 
     edm::RefToBase<reco::GsfElectron> rtbg;
     edm::reftobase::IndirectHolder<reco::GsfElectron> ihg;
@@ -143,7 +143,7 @@ namespace DataFormats_EgammaCandidates {
     edm::Ref<reco::GsfElectronCollection> r4;
     edm::RefProd<reco::GsfElectronCollection> rp4;
     edm::Wrapper<edm::RefVector<reco::GsfElectronCollection> > rv4;
-    reco::GsfElectron::PixelMatchVariables gepmv ;
+    
 
     reco::SiStripElectronCollection v5;
     edm::Wrapper<reco::SiStripElectronCollection> w5;

--- a/DataFormats/EgammaCandidates/src/classes_def.xml
+++ b/DataFormats/EgammaCandidates/src/classes_def.xml
@@ -207,7 +207,10 @@
   <class name="reco::GsfElectron::ClassificationVariables" ClassVersion="11">
    <version ClassVersion="11" checksum="2094185381"/>
   </class>
-  <class name="reco::GsfElectron" ClassVersion="14">
+  <class name="reco::GsfElectron::PixelMatchVariables">
+  </class>
+  <class name="reco::GsfElectron" ClassVersion="15">
+   <version ClassVersion="15" checksum="515498629"/>
    <version ClassVersion="14" checksum="3918953183"/>
    <version ClassVersion="13" checksum="2991498573"/>
    <version ClassVersion="12" checksum="2835360780"/>

--- a/DataFormats/EgammaCandidates/src/classes_def.xml
+++ b/DataFormats/EgammaCandidates/src/classes_def.xml
@@ -207,7 +207,8 @@
   <class name="reco::GsfElectron::ClassificationVariables" ClassVersion="11">
    <version ClassVersion="11" checksum="2094185381"/>
   </class>
-  <class name="reco::GsfElectron::PixelMatchVariables">
+  <class name="reco::GsfElectron::PixelMatchVariables" ClassVersion="2">
+    <version ClassVersion="2" checksum="3522539867"/>
   </class>
   <class name="reco::GsfElectron" ClassVersion="15">
    <version ClassVersion="15" checksum="515498629"/>

--- a/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h
@@ -253,6 +253,9 @@ class GsfElectronAlgo {
 
     // associations
     const reco::SuperClusterRef getTrSuperCluster( const reco::GsfTrackRef & trackRef ) ;
+    
+    // Pixel match variables
+    void setPixelMatchInfomation(reco::GsfElectron*) ;
  } ;
 
 #endif // GsfElectronAlgo_H

--- a/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h
@@ -256,8 +256,6 @@ class GsfElectronAlgo {
     
     // Pixel match variables
     void setPixelMatchInfomation(reco::GsfElectron*) ;
-    unsigned int nPixelMatchErrorNoSeed_ ;
-    unsigned int nPixelMatchErrorNotElectronSeed_ ;
     
  } ;
 

--- a/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h
@@ -256,6 +256,9 @@ class GsfElectronAlgo {
     
     // Pixel match variables
     void setPixelMatchInfomation(reco::GsfElectron*) ;
+    unsigned int nPixelMatchErrorNoSeed_ ;
+    unsigned int nPixelMatchErrorNotElectronSeed_ ;
+    
  } ;
 
 #endif // GsfElectronAlgo_H

--- a/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
@@ -1691,14 +1691,9 @@ void GsfElectronAlgo::setPixelMatchInfomation(reco::GsfElectron* ele){
   float dRz2  = 0 ;
   edm::RefToBase<TrajectorySeed> seed = ele->gsfTrack()->extra()->seedRef();
   ElectronSeedRef elseed = seed.castTo<ElectronSeedRef>();
-  if(seed.isNull()){
-    nPixelMatchErrorNoSeed_++ ;
-  }
+  if(seed.isNull()){}
   else{
-    if(elseed.isNull()){
-      nPixelMatchErrorNotElectronSeed_++ ;
-      
-    }
+    if(elseed.isNull()){}
     else{
       sd1     = elseed->subDet1() ;
       sd2     = elseed->subDet2() ;

--- a/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
@@ -666,7 +666,8 @@ GsfElectronAlgo::GsfElectronAlgo
  )
    : generalData_(new GeneralData(inputCfg,strategyCfg,cutsCfg,cutsCfgPflow,hcalCfg,hcalCfgPflow,isoCfg,recHitsCfg,superClusterErrorFunction,crackCorrectionFunction,mva_NIso_Cfg,mva_Iso_Cfg,regCfg)),
    eventSetupData_(new EventSetupData),
-   eventData_(0), electronData_(0)
+   eventData_(0), electronData_(0),
+   nPixelMatchErrorNoSeed_(0), nPixelMatchErrorNotElectronSeed_(0)
  {}
 
 GsfElectronAlgo::~GsfElectronAlgo()
@@ -1683,28 +1684,34 @@ void GsfElectronAlgo::removeAmbiguousElectrons()
 
 // Pixel match variables
 void GsfElectronAlgo::setPixelMatchInfomation(reco::GsfElectron* ele){
+  int sd1     = 0 ;
+  int sd2     = 0 ;
+  float dPhi1 = 0 ;
+  float dPhi2 = 0 ;
+  float dRz1  = 0 ;
+  float dRz2  = 0 ;
   edm::RefToBase<TrajectorySeed> seed = ele->gsfTrack()->extra()->seedRef();
   ElectronSeedRef elseed = seed.castTo<ElectronSeedRef>();
   if(seed.isNull()){
-    edm::LogError("GsfElectronAlgo")<<"The GsfTrack has no seed, so cannot set pixel match variable" ;
+    nPixelMatchErrorNoSeed_++ ;
   }
   else{
     if(elseed.isNull()){
-      edm::LogError("GsfElectronAlgo")<<"The GsfTrack seed is not an ElectronSeed, so cannot set pixel match variable" ;
+      nPixelMatchErrorNotElectronSeed_++ ;
+      
     }
     else{
-      int sd1     = elseed->subDet1() ;
-      int sd2     = elseed->subDet2() ;
-      float dPhi1 = elseed->dPhi1() ;
-      float dPhi2 = elseed->dPhi2() ;
-      float dRz1  = elseed->dRz1 () ;
-      float dRz2  = elseed->dRz2 () ;
-      
-      ele->setPixelMatchSubdetectors(sd1,sd2) ;
-      ele->setPixelMatchDPhi1(dPhi1) ;
-      ele->setPixelMatchDPhi2(dPhi2) ;
-      ele->setPixelMatchDRz1 (dRz1 ) ;
-      ele->setPixelMatchDRz2 (dRz2 ) ;
+      sd1     = elseed->subDet1() ;
+      sd2     = elseed->subDet2() ;
+      dPhi1 = elseed->dPhi1() ;
+      dPhi2 = elseed->dPhi2() ;
+      dRz1  = elseed->dRz1 () ;
+      dRz2  = elseed->dRz2 () ;
     }
   }
+  ele->setPixelMatchSubdetectors(sd1,sd2) ;
+  ele->setPixelMatchDPhi1(dPhi1) ;
+  ele->setPixelMatchDPhi2(dPhi2) ;
+  ele->setPixelMatchDRz1 (dRz1 ) ;
+  ele->setPixelMatchDRz2 (dRz2 ) ;
 }

--- a/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
@@ -1525,6 +1525,11 @@ void GsfElectronAlgo::createElectron()
   //====================================================
 
   setCutBasedPreselectionFlag(ele,*eventData_->beamspot) ;
+  
+  //====================================================
+  // Pixel match variables
+  //====================================================
+  setPixelMatchInfomation(ele) ;
 
   LogTrace("GsfElectronAlgo")<<"Constructed new electron with energy  "<< ele->p4().e() ;
 
@@ -1676,3 +1681,30 @@ void GsfElectronAlgo::removeAmbiguousElectrons()
  }
 
 
+// Pixel match variables
+void GsfElectronAlgo::setPixelMatchInfomation(reco::GsfElectron* ele){
+  edm::RefToBase<TrajectorySeed> seed = ele->gsfTrack()->extra()->seedRef();
+  ElectronSeedRef elseed = seed.castTo<ElectronSeedRef>();
+  if(seed.isNull()){
+    edm::LogError("GsfElectronAlgo")<<"The GsfTrack has no seed, so cannot set pixel match variable" ;
+  }
+  else{
+    if(elseed.isNull()){
+      edm::LogError("GsfElectronAlgo")<<"The GsfTrack seed is not an ElectronSeed, so cannot set pixel match variable" ;
+    }
+    else{
+      int sd1     = elseed->subDet1() ;
+      int sd2     = elseed->subDet2() ;
+      float dPhi1 = elseed->dPhi1() ;
+      float dPhi2 = elseed->dPhi2() ;
+      float dRz1  = elseed->dRz1 () ;
+      float dRz2  = elseed->dRz2 () ;
+      
+      ele->setPixelMatchSubdetectors(sd1,sd2) ;
+      ele->setPixelMatchDPhi1(dPhi1) ;
+      ele->setPixelMatchDPhi2(dPhi2) ;
+      ele->setPixelMatchDRz1 (dRz1 ) ;
+      ele->setPixelMatchDRz2 (dRz2 ) ;
+    }
+  }
+}

--- a/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
@@ -666,8 +666,7 @@ GsfElectronAlgo::GsfElectronAlgo
  )
    : generalData_(new GeneralData(inputCfg,strategyCfg,cutsCfg,cutsCfgPflow,hcalCfg,hcalCfgPflow,isoCfg,recHitsCfg,superClusterErrorFunction,crackCorrectionFunction,mva_NIso_Cfg,mva_Iso_Cfg,regCfg)),
    eventSetupData_(new EventSetupData),
-   eventData_(0), electronData_(0),
-   nPixelMatchErrorNoSeed_(0), nPixelMatchErrorNotElectronSeed_(0)
+   eventData_(0), electronData_(0)
  {}
 
 GsfElectronAlgo::~GsfElectronAlgo()


### PR DESCRIPTION
This pull request adds the pixel seed into to the GsfElectron object to enable better electron - photon disambiguation and miss matched tracks at the identification level. This change has been agreed by E/gamma (Lindsey, Matteo,Sam) and it would be nice if we could include it into 73X
