### PR TITLE
Add ptrs() interface to View which returns std::vector<edm::Ptr<T>>

### DIFF
--- a/DataFormats/Common/interface/View.h
+++ b/DataFormats/Common/interface/View.h
@@ -123,6 +123,7 @@ namespace edm {
     Ptr<value_type> ptrAt(size_type i) const;
     RefToBaseVector<T> const& refVector() const { return refs_; }
     PtrVector<T> const& ptrVector() const { return ptrs_; }
+    std::vector<Ptr<value_type> > const& ptrs() const;
 
     const_reference front() const;
     const_reference back() const;
@@ -144,6 +145,7 @@ namespace edm {
     seq_t items_;
     RefToBaseVector<T> refs_;
     PtrVector<T> ptrs_;
+    mutable std::vector<Ptr<value_type> > vPtrs_;
     ViewBase* doClone() const;
   };
 
@@ -297,6 +299,19 @@ namespace edm {
     RefToBase<T> ref = refAt(i);
     return Ptr<T>(ref.id(), (ref.isAvailable() ? ref.get(): 0), ref.key());
   }
+  
+  template<typename T>
+  inline
+  std::vector<Ptr<T> > const&
+  View<T>::ptrs() const {
+    //vPtrs_.insert(ptrs_.begin(),ptrs_.end());
+    if(vPtrs_.size()!=ptrs_.size()) {
+      vPtrs_.reserve(ptrs_.size());
+      std::copy(ptrs_.begin(),ptrs_.end(),std::back_inserter(vPtrs_));
+    } 
+    return vPtrs_;
+  }
+
 
   template<typename T>
   inline

--- a/FWCore/Framework/test/View_t.cpp
+++ b/FWCore/Framework/test/View_t.cpp
@@ -12,6 +12,7 @@ class testView: public CppUnit::TestFixture
   CPPUNIT_TEST(iterateForward);
   CPPUNIT_TEST(iterateBackward);
   CPPUNIT_TEST(cloning);
+  CPPUNIT_TEST(ptrs);
   CPPUNIT_TEST_SUITE_END();
 
  public:
@@ -26,6 +27,7 @@ class testView: public CppUnit::TestFixture
   void iterateForward();
   void iterateBackward();
   void cloning();
+  void ptrs();
 
  private:
   typedef int  value_type;
@@ -128,3 +130,18 @@ void testView::cloning()
     CPPUNIT_ASSERT(*view == v1);
   }
 }
+
+void testView::ptrs()
+{
+  value_type vals[] = { 1, 2, 3, 4, 5 };
+  size_t sz = sizeof(vals)/sizeof(value_type);
+  
+  View v1;
+  edm::View<int>::fill_from_range(vals, vals+sz, v1);
+  size_t i=0;
+  for(auto ptr : v1.ptrs())
+  {
+    CPPUNIT_ASSERT(*ptr == vals[i++]);
+  }
+}
+


### PR DESCRIPTION
This is the first step in removing refVector and ptrVector interfaces from View in order to support containers with 'refs' which point to multiple containers.
