### PR TITLE
Bugfix for cosmic track splitting alignment validation

### DIFF
--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/trackSplittingValidationTemplates.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/trackSplittingValidationTemplates.py
@@ -131,7 +131,8 @@ process.load("RecoTracker.TrackProducer.CTFFinalFitWithMaterialP5_cff")
 process.HitFilteredTracks = RecoTracker.TrackProducer.CTFFinalFitWithMaterialP5_cff.ctfWithMaterialTracksCosmics.clone(
      src = 'cosmicTrackSplitter',
      TrajectoryInEvent = True,
-     TTRHBuilder = "WithTrackAngle"
+     TTRHBuilder = "WithTrackAngle",
+     NavigationSchool = ""
 )
 # second refit
 process.TrackRefitter2 = process.TrackRefitter1.clone(
@@ -156,15 +157,7 @@ process.TFileService = cms.Service("TFileService",
     fileName = cms.string('.oO[outputFile]Oo.')
 )
 
-#needed for 7X
-#https://hypernews.cern.ch/HyperNews/CMS/get/tif-alignment/232/1.html
-process.load("RecoTracker.MeasurementDet.MeasurementTrackerEventProducer_cfi")
-process.MeasurementTrackerEvent.pixelClusterProducer = '.oO[TrackCollection]Oo.'
-process.MeasurementTrackerEvent.stripClusterProducer = '.oO[TrackCollection]Oo.'
-process.MeasurementTrackerEvent.inactivePixelDetectorLabels = cms.VInputTag()
-process.MeasurementTrackerEvent.inactiveStripDetectorLabels = cms.VInputTag()
-
-process.p = cms.Path(process.offlineBeamSpot*process.MeasurementTrackerEvent*process.TrackRefitter1*process.AlignmentTrackSelector*process.cosmicTrackSplitter*process.HitFilteredTracks*process.TrackRefitter2*process.cosmicValidation)
+process.p = cms.Path(process.offlineBeamSpot*process.TrackRefitter1*process.AlignmentTrackSelector*process.cosmicTrackSplitter*process.HitFilteredTracks*process.TrackRefitter2*process.cosmicValidation)
 """
 
 

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/trackSplittingValidationTemplates.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/trackSplittingValidationTemplates.py
@@ -156,7 +156,15 @@ process.TFileService = cms.Service("TFileService",
     fileName = cms.string('.oO[outputFile]Oo.')
 )
 
-process.p = cms.Path(process.offlineBeamSpot*process.TrackRefitter1*process.AlignmentTrackSelector*process.cosmicTrackSplitter*process.HitFilteredTracks*process.TrackRefitter2*process.cosmicValidation)
+#needed for 7X
+#https://hypernews.cern.ch/HyperNews/CMS/get/tif-alignment/232/1.html
+process.load("RecoTracker.MeasurementDet.MeasurementTrackerEventProducer_cfi")
+process.MeasurementTrackerEvent.pixelClusterProducer = '.oO[TrackCollection]Oo.'
+process.MeasurementTrackerEvent.stripClusterProducer = '.oO[TrackCollection]Oo.'
+process.MeasurementTrackerEvent.inactivePixelDetectorLabels = cms.VInputTag()
+process.MeasurementTrackerEvent.inactiveStripDetectorLabels = cms.VInputTag()
+
+process.p = cms.Path(process.offlineBeamSpot*process.MeasurementTrackerEvent*process.TrackRefitter1*process.AlignmentTrackSelector*process.cosmicTrackSplitter*process.HitFilteredTracks*process.TrackRefitter2*process.cosmicValidation)
 """
 
 

--- a/Alignment/OfflineValidation/scripts/validateAlignments.py
+++ b/Alignment/OfflineValidation/scripts/validateAlignments.py
@@ -295,9 +295,11 @@ def createMergeScript( path, validations ):
     repMap["CompareAlignments"] = "#run comparisons"
     for validationId in comparisonLists:
         compareStrings = [ val.getCompareStrings(validationId) for val in comparisonLists[validationId] ]
+        compareStringsPlain = [ val.getCompareStrings(validationId, plain=True) for val in comparisonLists[validationId] ]
             
         repMap.update({"validationId": validationId,
-                       "compareStrings": " , ".join(compareStrings) })
+                       "compareStrings": " , ".join(compareStrings),
+                       "compareStringsPlain": " ".join(compareStringsPlain) })
         
         repMap["CompareAlignments"] += \
             replaceByMap(configTemplates.compareAlignmentsExecution, repMap)


### PR DESCRIPTION
These fixes are needed for the validation to run, because of 7X and other recent improvements.

Backport of #6244
