### PR TITLE
Update types of event/run/lumi in Muon/Tau/HI

### DIFF
--- a/RecoHI/HiTracking/test/HIPixelClusterVtxAnalyzer.cc
+++ b/RecoHI/HiTracking/test/HIPixelClusterVtxAnalyzer.cc
@@ -19,6 +19,8 @@
 
 #include "SimDataFormats/Vertex/interface/SimVertexContainer.h"
 
+#include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
+
 #include <fstream>
 #include <iostream>
 #include <vector>
@@ -54,8 +56,8 @@ void HIPixelClusterVtxAnalyzer::analyze(const edm::Event& ev, const edm::EventSe
   std::cout << "counter = " << counter << std::endl;
   counter++;
 
-  int evtnum = ev.id().event();
-  TH1D *hClusterVtx = fs->make<TH1D>(Form("hClusterVtx_%d",evtnum),"compatibility of pixel cluster length with vertex hypothesis; z [cm]",(int)((maxZ_-minZ_)/zStep_),minZ_,maxZ_);
+  edm::EventNumber_t evtnum  = ev.id().event();
+  TH1D *hClusterVtx = fs->make<TH1D>(Form("hClusterVtx_%llu",evtnum),"compatibility of pixel cluster length with vertex hypothesis; z [cm]",(int)((maxZ_-minZ_)/zStep_),minZ_,maxZ_);
 
   // new vertex collection
   std::auto_ptr<reco::VertexCollection> vertices(new reco::VertexCollection);

--- a/RecoLocalMuon/CSCEfficiency/src/CSCEfficiency.cc
+++ b/RecoLocalMuon/CSCEfficiency/src/CSCEfficiency.cc
@@ -14,6 +14,9 @@
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
 #include "DataFormats/MuonReco/interface/MuonSelectors.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
+
+#include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
+
 using namespace std;
 
 bool CSCEfficiency::filter(edm::Event & event, const edm::EventSetup& eventSetup){
@@ -25,11 +28,11 @@ bool CSCEfficiency::filter(edm::Event & event, const edm::EventSetup& eventSetup
   nEventsAnalyzed++;
   // printalot debug output
   printalot = (nEventsAnalyzed < int(printout_NEvents)); // 
-  int iRun   = event.id().run();
-  int iEvent = event.id().event();
+  edm::RunNumber_t const iRun = event.id().run();
+  edm::EventNumber_t const iEvent = event.id().event();
   if(0==fmod(double (nEventsAnalyzed) ,double(1000) )){
     if(printalot){
-      printf("\n==enter==CSCEfficiency===== run %i\tevent %i\tn Analyzed %i\n",iRun,iEvent,nEventsAnalyzed);
+      printf("\n==enter==CSCEfficiency===== run %u\tevent %llu\tn Analyzed %i\n",iRun,iEvent,nEventsAnalyzed);
     }
   }
   theService->update(eventSetup);  
@@ -527,7 +530,7 @@ bool CSCEfficiency::filter(edm::Event & event, const edm::EventSetup& eventSetup
     }
   }
   //---- End
-  if (printalot) printf("==exit===CSCEfficiency===== run %i\tevent %i\n\n",iRun,iEvent);
+  if (printalot) printf("==exit===CSCEfficiency===== run %u\tevent %llu\n\n",iRun,iEvent);
   return passTheEvent;
 }
 

--- a/RecoMuon/MuonIdentification/test/RPCMuonAnalyzer.cc
+++ b/RecoMuon/MuonIdentification/test/RPCMuonAnalyzer.cc
@@ -16,6 +16,8 @@
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
 #include "DataFormats/MuonReco/interface/MuonSelectors.h"
 
+#include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
+
 #include "TTree.h"
 #include "TH1F.h"
 #include "TH2F.h"
@@ -43,7 +45,9 @@ private:
   double minPtTrk_;
   double maxEtaTrk_;
 
-  Int_t runNumber, eventNumber, nMuon;
+  edm::RunNumber_t runNumber;
+  edm::EventNumber_t eventNumber;
+  Int_t nMuon;
   Int_t nGlbMuon, nStaMuon, nTrkMuon;
   Int_t nRPCMuon, nRPCMuTight;
   Int_t nTrkMuTight, nTrkMuTight2;

--- a/RecoTauTag/RecoTau/interface/RecoTauVertexAssociator.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauVertexAssociator.h
@@ -29,6 +29,8 @@
 
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
 
+#include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
+
 #include <map>
 
 // Forward declarations
@@ -80,7 +82,7 @@ class RecoTauVertexAssociator {
     edm::EDGetTokenT<reco::VertexCollection> vxToken_;
     // containers for holding vertices associated to jets
     std::map<const reco::PFJet*, reco::VertexRef>* jetToVertexAssociation_;
-    int lastEvent_;    
+    edm::EventNumber_t lastEvent_;    
     int verbosity_;
 };
 

--- a/RecoTauTag/RecoTau/src/RecoTauVertexAssociator.cc
+++ b/RecoTauTag/RecoTau/src/RecoTauVertexAssociator.cc
@@ -130,7 +130,7 @@ RecoTauVertexAssociator::RecoTauVertexAssociator(const edm::ParameterSet& pset, 
   : vertexSelector_(0),
     qcuts_(0),
     jetToVertexAssociation_(0),
-    lastEvent_(-1)
+    lastEvent_(0)
 {
   //std::cout << "<RecoTauVertexAssociator::RecoTauVertexAssociator>:" << std::endl;
 
@@ -227,7 +227,7 @@ void RecoTauVertexAssociator::setEvent(const edm::Event& evt)
   if ( selectedVertices_.size() > 0 ) {
     qcuts_->setPV(selectedVertices_[0]);
   }
-  int currentEvent = evt.id().event();
+  edm::EventNumber_t currentEvent = evt.id().event();
   if ( currentEvent != lastEvent_ || !jetToVertexAssociation_ ) {
     if ( !jetToVertexAssociation_ ) jetToVertexAssociation_ = new std::map<const reco::PFJet*, reco::VertexRef>;
     else jetToVertexAssociation_->clear();


### PR DESCRIPTION
The online is changing to produce data with event numbers that are 64 bits instead of 32 bits. CMSSW software needs to be modified to handle that. Following
https://hypernews.cern.ch/HyperNews/CMS/get/recoDevelopment/1302.html
I am making changes to different packages, here Muon/Tau/HI. Updates are generally trivial and there should be no any visible effects of them (except for the rare event numbers with > 32 bits). 
