### PR TITLE
Update types of event/run/lumi in Tracking/Vertexing

### DIFF
--- a/RecoLocalTracker/SiPixelClusterizer/test/ReadPixClusters.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/test/ReadPixClusters.cc
@@ -78,6 +78,8 @@
 
 #define HISTOS
 
+#include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
+
 using namespace std;
 
 //=============================================================================
@@ -395,10 +397,10 @@ void ReadPixClusters::analyze(const edm::Event& e,
 
 
   countAllEvents++;
-  int run       = e.id().run();
-  int event     = e.id().event();
+  RunNumber_t const run       = e.id().run();
+  EventNumber_t const event     = e.id().event();
+  LuminosityBlockNumber_t const lumiBlock = e.luminosityBlock();
 
-  int lumiBlock = e.luminosityBlock();
   int bx        = e.bunchCrossing();
   int orbit     = e.orbitNumber();
 

--- a/RecoLocalTracker/SiPixelClusterizer/test/TestClusters.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/test/TestClusters.cc
@@ -93,6 +93,8 @@
 #include "DataFormats/SiPixelDetId/interface/PXFDetId.h" 
 #endif 
 
+#include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
+
 using namespace std;
 
 #define HISTOS
@@ -1915,7 +1917,7 @@ void TestClusters::analyze(const edm::Event& e,
   //const int MAX_CUT = 1000000; unused
   const int selectEvent = -1;
   //bool select = false; unused
-  static int runNumberOld=-1;
+  static RunNumber_t runNumberOld=-1;
   static int countRuns=0;
   //static double pixsum = 0., clussum=0.;
   //static int nsum = 0, lsold=-999, lumiold=0.;
@@ -1927,10 +1929,10 @@ void TestClusters::analyze(const edm::Event& e,
   const TrackerGeometry& theTracker(*geom);
 
   countAllEvents++;
-  int run       = e.id().run();
-  int event     = e.id().event();
+  RunNumber_t const run       = e.id().run();
+  EventNumber_t const event     = e.id().event();
+  LuminosityBlockNumber_t const lumiBlock = e.luminosityBlock();
 
-  int lumiBlock = e.luminosityBlock();
   int bx        = e.bunchCrossing();
   int orbit     = e.orbitNumber();
 

--- a/RecoLocalTracker/SiPixelClusterizer/test/TestWithTracks.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/test/TestWithTracks.cc
@@ -96,6 +96,8 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
 
+#include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
+
 // For ROOT
 #include <TROOT.h>
 #include <TChain.h>
@@ -514,7 +516,7 @@ void TestWithTracks::analyze(const edm::Event& e,
 
   using namespace edm;
   using namespace reco;
-  static int lumiBlockOld = -9999;
+  static LuminosityBlockNumber_t lumiBlockOld = -9999;
 
   const float CLU_SIZE_PT_CUT = 1.;
 
@@ -550,9 +552,10 @@ void TestWithTracks::analyze(const edm::Event& e,
   int numOfClustersPerDisk3=0; 
   int numOfClustersPerDisk4=0; 
 
-  int run       = e.id().run();
-  int event     = e.id().event();
-  int lumiBlock = e.luminosityBlock();
+  RunNumber_t const run       = e.id().run();
+  EventNumber_t const event     = e.id().event();
+  LuminosityBlockNumber_t const lumiBlock = e.luminosityBlock();
+
   int bx        = e.bunchCrossing();
   //int orbit     = e.orbitNumber(); // unused 
 

--- a/RecoLocalTracker/SiStripZeroSuppression/plugins/SiStripBaselineAnalyzer.cc
+++ b/RecoLocalTracker/SiStripZeroSuppression/plugins/SiStripBaselineAnalyzer.cc
@@ -50,6 +50,8 @@
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
 #include "CommonTools/Utils/interface/TFileDirectory.h"
 
+#include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
+
 //ROOT inclusion
 #include "TROOT.h"
 #include "TFile.h"
@@ -254,8 +256,8 @@ SiStripBaselineAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& es)
       
     
       actualModule_++;
-      uint32_t event = e.id().event();
-      uint32_t run = e.id().run();
+      edm::RunNumber_t const run = e.id().run();
+      edm::EventNumber_t const event = e.id().event();
       //std::cout << "processing module N: " << actualModule_<< " detId: " << detId << " event: "<< event << std::endl; 
 	 
 
@@ -288,8 +290,8 @@ SiStripBaselineAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& es)
       }
       
       sprintf(detIds,"%ul", detId);
-      sprintf(evs,"%ul", event);
-      sprintf(runs,"%ul", run);
+      sprintf(evs,"%llu", event);
+      sprintf(runs,"%u", run);
       char* dHistoName = Form("Id:%s_run:%s_ev:%s",detIds, runs, evs);
       h1ProcessedRawDigis_ = sdProcessedRawDigis_.make<TH1F>(dHistoName,dHistoName, bins, minx, maxx); 
       

--- a/RecoPixelVertexing/PixelVertexFinding/interface/SkipBadEvents.h
+++ b/RecoPixelVertexing/PixelVertexFinding/interface/SkipBadEvents.h
@@ -12,6 +12,9 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
+
 #include <map>
 #include <set>
 
@@ -22,6 +25,6 @@ class SkipBadEvents: public edm::EDFilter {
   virtual bool filter(edm::Event& e, const edm::EventSetup& s);
   
  private:
-  std::map<int,std::set<int> > skip_; // Skip these run, event pairs
+  std::map<edm::RunNumber_t,std::set<edm::EventNumber_t> > skip_; // Skip these run, event pairs
 };
 #endif

--- a/RecoPixelVertexing/PixelVertexFinding/src/SkipBadEvents.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/src/SkipBadEvents.cc
@@ -11,8 +11,8 @@ SkipBadEvents::SkipBadEvents(const edm::ParameterSet& config) {
 SkipBadEvents::~SkipBadEvents(){}
 
 bool SkipBadEvents::filter(edm::Event& e, const edm::EventSetup& s) {
-  int run = e.id().run();
-  int evt = e.id().event();
+  edm::RunNumber_t run = e.id().run();
+  edm::EventNumber_t evt = e.id().event();
 
   bool pass = ( skip_[run].find(evt) == skip_[run].end() );
 

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackerTrackHitFilter.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackerTrackHitFilter.cc
@@ -42,6 +42,8 @@
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHit.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHitBuilder.h"
 
+#include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
+
 #include <boost/regex.hpp>
 #include <map>
 //#include <math>
@@ -107,8 +109,8 @@ namespace reco {
 
     edm::InputTag src_;
 
-    int iRun;
-    int iEvt;
+    edm::RunNumber_t iRun;
+    edm::EventNumber_t iEvt;
 
     size_t minimumHits_;
 

--- a/RecoVertex/ConfigurableVertexReco/test/CVRTest.cc
+++ b/RecoVertex/ConfigurableVertexReco/test/CVRTest.cc
@@ -9,6 +9,9 @@
 #include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
 #include "TrackingTools/Records/interface/TransientTrackRecord.h"
 #include "RecoVertex/ConfigurableVertexReco/test/CVRTest.h"
+
+#include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
+
 #include <iostream>
 
 using namespace std;
@@ -93,7 +96,7 @@ void CVRTest::discussPrimary( const edm::Event& iEvent ) const
 void CVRTest::analyze( const edm::Event & iEvent,
                        const edm::EventSetup & iSetup )
 {
-  int evt=iEvent.id().event();
+  edm::EventNumber_t const evt = iEvent.id().event();
   cout << "[CVRTest] next event: " << evt << endl;
   edm::ESHandle<MagneticField> magneticField;
   iSetup.get<IdealMagneticFieldRecord>().get(magneticField);

--- a/TrackPropagation/SteppingHelixPropagator/test/SteppingHelixPropagatorAnalyzer.cc
+++ b/TrackPropagation/SteppingHelixPropagator/test/SteppingHelixPropagatorAnalyzer.cc
@@ -75,8 +75,6 @@
 #include "TrackPropagation/SteppingHelixPropagator/interface/SteppingHelixPropagator.h"
 #include "TrackPropagation/SteppingHelixPropagator/interface/SteppingHelixStateInfo.h"
 
-#include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
-
 #include "TFile.h"
 #include "TTree.h"
 
@@ -142,8 +140,8 @@ private:
   float covFlat_[1000][21];
 
   bool debug_;
-  edm::RunNumber_t run_;
-  edm::EventNumber_t event_;
+  int run_;
+  int event_;
 
   int trkIndOffset_;
 
@@ -190,8 +188,8 @@ SteppingHelixPropagatorAnalyzer::SteppingHelixPropagatorAnalyzer(const edm::Para
   tr_->Branch("p3R", p3R_, "p3R[nPoints][3]/F");
   tr_->Branch("r3R", r3R_, "r3R[nPoints][3]/F");
   tr_->Branch("covFlat", covFlat_, "covFlat[nPoints][21]/F");
-  tr_->Branch("run", &run_, "run/i");
-  tr_->Branch("event_", &event_, "event/l");
+  tr_->Branch("run", &run_, "run/I");
+  tr_->Branch("event_", &event_, "event/I");
 
   trkIndOffset_ = iConfig.getParameter<int>("trkIndOffset");
   debug_ = iConfig.getParameter<bool>("debug");
@@ -268,8 +266,8 @@ SteppingHelixPropagatorAnalyzer::analyze(const edm::Event& iEvent, const edm::Ev
   //     std::cout<<"Got RPCGeometry "<<std::endl;
   //   }
 
-  run_ = iEvent.id().run();
-  event_ = iEvent.id().event();
+  run_ = (int)iEvent.id().run();
+  event_ = (int)iEvent.id().event();
   if (debug_){
     LogTrace(metname)<<"Begin for run:event =="<<run_<<":"<<event_<<std::endl;
   }

--- a/TrackPropagation/SteppingHelixPropagator/test/SteppingHelixPropagatorAnalyzer.cc
+++ b/TrackPropagation/SteppingHelixPropagator/test/SteppingHelixPropagatorAnalyzer.cc
@@ -75,6 +75,8 @@
 #include "TrackPropagation/SteppingHelixPropagator/interface/SteppingHelixPropagator.h"
 #include "TrackPropagation/SteppingHelixPropagator/interface/SteppingHelixStateInfo.h"
 
+#include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
+
 #include "TFile.h"
 #include "TTree.h"
 
@@ -140,8 +142,8 @@ private:
   float covFlat_[1000][21];
 
   bool debug_;
-  int run_;
-  int event_;
+  edm::RunNumber_t run_;
+  edm::EventNumber_t event_;
 
   int trkIndOffset_;
 
@@ -188,8 +190,8 @@ SteppingHelixPropagatorAnalyzer::SteppingHelixPropagatorAnalyzer(const edm::Para
   tr_->Branch("p3R", p3R_, "p3R[nPoints][3]/F");
   tr_->Branch("r3R", r3R_, "r3R[nPoints][3]/F");
   tr_->Branch("covFlat", covFlat_, "covFlat[nPoints][21]/F");
-  tr_->Branch("run", &run_, "run/I");
-  tr_->Branch("event_", &event_, "event/I");
+  tr_->Branch("run", &run_, "run/i");
+  tr_->Branch("event_", &event_, "event/l");
 
   trkIndOffset_ = iConfig.getParameter<int>("trkIndOffset");
   debug_ = iConfig.getParameter<bool>("debug");
@@ -266,8 +268,8 @@ SteppingHelixPropagatorAnalyzer::analyze(const edm::Event& iEvent, const edm::Ev
   //     std::cout<<"Got RPCGeometry "<<std::endl;
   //   }
 
-  run_ = (int)iEvent.id().run();
-  event_ = (int)iEvent.id().event();
+  run_ = iEvent.id().run();
+  event_ = iEvent.id().event();
   if (debug_){
     LogTrace(metname)<<"Begin for run:event =="<<run_<<":"<<event_<<std::endl;
   }


### PR DESCRIPTION
The online is changing to produce data with event numbers that are 64 bits instead of 32 bits. CMSSW software needs to be modified to handle that. Following
https://hypernews.cern.ch/HyperNews/CMS/get/recoDevelopment/1302.html
I am making changes to different packages, here Tracking/Vertexing. I am using the events/run/lumi types defined in DataFormats/Provenance/interface/RunLumiEventNumber.h . Updates are generally trivial and there should be no any visible effects of them (except for the rare event numbers with > 32 bits). 
