### PR TITLE
Another Tau trigger DQM fixes

### DIFF
--- a/DQMOffline/Trigger/python/HLTTauDQMOffline_cfi.py
+++ b/DQMOffline/Trigger/python/HLTTauDQMOffline_cfi.py
@@ -2,13 +2,14 @@ import FWCore.ParameterSet.Config as cms
 
 hltTauDQMofflineProcess = "HLT"
 
-#Ref Pbjects-------------------------------------------------------------------------------------------------------
+#Ref Objects-------------------------------------------------------------------------------------------------------
 TauRefProducer = cms.EDProducer("HLTTauRefProducer",
 
                     PFTaus = cms.untracked.PSet(
                             PFTauDiscriminators = cms.untracked.VInputTag(
-                            						cms.InputTag("hpsPFTauDiscriminationByDecayModeFinding"),
-                                                    cms.InputTag("hpsPFTauDiscriminationByLooseIsolation")
+                                    cms.InputTag("hpsPFTauDiscriminationByDecayModeFinding"),
+                                    cms.InputTag("hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr3Hits"),
+                                    cms.InputTag("hpsPFTauDiscriminationByLooseMuonRejection2")
                             ),
                             doPFTaus = cms.untracked.bool(True),
                             ptMin = cms.untracked.double(15.0),
@@ -22,37 +23,37 @@ TauRefProducer = cms.EDProducer("HLTTauRefProducer",
                             doElectrons = cms.untracked.bool(True),
                             TrackCollection = cms.untracked.InputTag("generalTracks"),
                             OuterConeDR = cms.untracked.double(0.6),
-                            ptMin = cms.untracked.double(10.0),
+                            ptMin = cms.untracked.double(15.0),
                             doTrackIso = cms.untracked.bool(True),
                             ptMinTrack = cms.untracked.double(1.5),
                             lipMinTrack = cms.untracked.double(0.2),
                             IdCollection = cms.untracked.InputTag("elecIDext")
                             ),
                    Jets = cms.untracked.PSet(
-                            JetCollection = cms.untracked.InputTag("iterativeCone5CaloJets"),
-                            etMin = cms.untracked.double(10.0),
-                            doJets = cms.untracked.bool(True)
+                            JetCollection = cms.untracked.InputTag("ak4PFJetsCHS"),
+                            etMin = cms.untracked.double(15.0),
+                            doJets = cms.untracked.bool(False)
                             ),
                    Towers = cms.untracked.PSet(
                             TowerCollection = cms.untracked.InputTag("towerMaker"),
                             etMin = cms.untracked.double(10.0),
-                            doTowers = cms.untracked.bool(True),
+                            doTowers = cms.untracked.bool(False),
                             towerIsolation = cms.untracked.double(5.0)
                             ),
 
                    Muons = cms.untracked.PSet(
                             doMuons = cms.untracked.bool(True),
                             MuonCollection = cms.untracked.InputTag("muons"),
-                            ptMin = cms.untracked.double(10.0)
+                            ptMin = cms.untracked.double(15.0)
                             ),
 
                    Photons = cms.untracked.PSet(
-                            doPhotons = cms.untracked.bool(True),
+                            doPhotons = cms.untracked.bool(False),
                             PhotonCollection = cms.untracked.InputTag("gedPhotons"),
-                            etMin = cms.untracked.double(10.0),
+                            etMin = cms.untracked.double(15.0),
                             ECALIso = cms.untracked.double(3.0)
                             ),
-                  EtaMax = cms.untracked.double(2.5)
+                  EtaMax = cms.untracked.double(2.3)
                   )
 
 #----------------------------------MONITORS--------------------------------------------------------------------------

--- a/DQMOffline/Trigger/src/HLTTauDQMOfflineSource.cc
+++ b/DQMOffline/Trigger/src/HLTTauDQMOfflineSource.cc
@@ -26,7 +26,7 @@ HLTTauDQMOfflineSource::HLTTauDQMOfflineSource( const edm::ParameterSet& ps ):
   ptMax_(ps.getUntrackedParameter<double>("PtHistoMax",200)),
   highPtMax_(ps.getUntrackedParameter<double>("HighPtHistoMax",1000)),
   l1MatchDr_(ps.getUntrackedParameter<double>("L1MatchDeltaR", 0.5)),
-  hltMatchDr_(ps.getUntrackedParameter<double>("HLTMatchDeltaR", 0.2)),
+  hltMatchDr_(ps.getUntrackedParameter<double>("HLTMatchDeltaR", 0.5)),
   dqmBaseFolder_(ps.getUntrackedParameter<std::string>("DQMBaseFolder")),
   counterEvt_(0),
   prescaleEvt_(ps.getUntrackedParameter<int>("prescaleEvt", -1))

--- a/DQMOffline/Trigger/src/HLTTauDQMPath.cc
+++ b/DQMOffline/Trigger/src/HLTTauDQMPath.cc
@@ -142,14 +142,24 @@ namespace {
     TauLeptonMultiplicity n;
 
     if(moduleType == "HLTLevel1GTSeed") {
-      if(filterName.find("SingleMu") != std::string::npos) {
-        n.muon = 1;
+      if(filterName.find("Single") != std::string::npos) {
+	if(filterName.find("Mu") != std::string::npos) {
+	  n.muon = 1;
+	}
+	else if(filterName.find("EG") != std::string::npos) {
+	  n.electron = 1;
+	}
       }
-      else if(filterName.find("SingleEG") != std::string::npos) {
-        n.electron = 1;
-      }
-      else if(filterName.find("DoubleTau") != std::string::npos) {
+      else if(filterName.find("Double") != std::string::npos && filterName.find("Tau") != std::string::npos) {
         n.tau = 2;
+      }
+      else if(filterName.find("Mu") != std::string::npos && filterName.find("Tau") != std::string::npos) { 
+	n.muon = 1;
+	//n.tau = 1;
+      }
+      else if(filterName.find("EG") != std::string::npos && filterName.find("Tau") != std::string::npos) { 
+	n.electron = 1;
+	//n.tau = 1;
       }
     }
     else if(moduleType == "HLT1CaloJet" || moduleType == "HLT1PFJet") {
@@ -180,7 +190,8 @@ namespace {
       n.electron = getParameterSafe(HLTCP, filterName, "ncandcut");
     }
     else if(moduleType == "HLTMuonIsoFilter" || moduleType == "HLTMuonL3PreFilter") {
-      n.muon = HLTCP.modulePSet(filterName).getParameter<int>("MinN");
+      //n.muon = HLTCP.modulePSet(filterName).getParameter<int>("MinN");
+      n.muon = getParameterSafe(HLTCP, filterName, "MinN");
     }
     else if(moduleType == "HLT2ElectronTau" || moduleType == "HLT2ElectronPFTau" || moduleType == "HLT2PhotonTau" || moduleType == "HLT2PhotonPFTau") {
       //int num = HLTCP.modulePSet(filterName).getParameter<int>("MinN");
@@ -392,7 +403,7 @@ bool HLTTauDQMPath::offlineMatching(size_t i, const std::vector<Object>& trigger
     for(const Object& trgObj: triggerObjects) {
       //std::cout << "trigger object id " << trgObj.id << std::endl;
       if(! ((isL1 && (trgObj.id == trigger::TriggerL1NoIsoEG || trgObj.id == trigger::TriggerL1IsoEG))
-            || trgObj.id == trigger::TriggerElectron) )
+            || trgObj.id == trigger::TriggerElectron || trgObj.id == trigger::TriggerPhoton) )
         continue;
       if(deltaRmatch(trgObj.object, offlineObjects.electrons, dR, offlineMask, matchedOfflineObjects.electrons)) {
         ++matchedObjects;

--- a/DQMOffline/Trigger/src/HLTTauPostProcessor.cc
+++ b/DQMOffline/Trigger/src/HLTTauPostProcessor.cc
@@ -63,7 +63,7 @@ void HLTTauPostProcessor::plotFilterEfficiencies(DQMStore::IBooker& iBooker, DQM
   efficiency->setAxisTitle("Efficiency", 2);
   const TAxis *xaxis = eventsPerFilter->getTH1F()->GetXaxis();
   for(int bin=1; bin < eventsPerFilter->getNbinsX(); ++bin) {
-    efficiency->setBinLabel(bin, xaxis->GetBinLabel(bin));
+    efficiency->setBinLabel(bin, xaxis->GetBinLabel(bin+1));
   }
 
   // Fill efficiency TProfile


### PR DESCRIPTION
This request consist of set small fixes to Tau trigger DQM:
- Refreshed definition of offline reference objects (DQMOffline/Trigger/python/HLTTauDQMOffline_cfi.py)
- Looser default dR value for offline-HLT matching (DQMOffline/Trigger/src/HLTTauDQMOfflineSource.cc)
- Another fix for matching with generic EGamm filters and better handling of lepton+tau L1 cross-seeds (DQMOffline/Trigger/src/HLTTauDQMPath.cc)
