### PR TITLE
Changing fastjet seed type.

### DIFF
--- a/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
@@ -309,8 +309,8 @@ void VirtualJetProducer::produce(edm::Event& iEvent,const edm::EventSetup& iSetu
   if ( useDeterministicSeed_ ) {
     fastjet::GhostedAreaSpec gas;
     std::vector<int> seeds(2);
-    seeds[0] = std::max(iEvent.id().run(),minSeed_ + 3) + 3 * iEvent.id().event();
-    seeds[1] = std::max(iEvent.id().run(),minSeed_ + 5) + 5 * iEvent.id().event();
+    seeds[0] = static_cast<int>( std::max(iEvent.id().run(),minSeed_ + 3) + 3 * iEvent.id().event() );
+    seeds[1] = static_cast<int>( std::max(iEvent.id().run(),minSeed_ + 5) + 5 * iEvent.id().event() );
     gas.set_random_status(seeds);
   }
 


### PR DESCRIPTION
Explicitly casting seeds to int to facilitate transition of run and event numbers
