### PR TITLE
Codes required to do multiple hadronization and to print out cross section including HepMCFilter efficiency

### DIFF
--- a/GeneratorInterface/Core/BuildFile.xml
+++ b/GeneratorInterface/Core/BuildFile.xml
@@ -3,6 +3,7 @@
 <use   name="FWCore/Utilities"/>
 <use   name="SimDataFormats/GeneratorProducts"/>
 <use   name="GeneratorInterface/LHEInterface"/>
+<use   name="GeneratorInterface/HepMCFilters"/>
 <use   name="boost"/>
 <use   name="clhep"/>
 <use   name="lhapdf"/>

--- a/GeneratorInterface/Core/interface/GenXSecAnalyzer.h
+++ b/GeneratorInterface/Core/interface/GenXSecAnalyzer.h
@@ -46,16 +46,23 @@ private:
   void compute();
 
   edm::EDGetTokenT<GenFilterInfo> genFilterInfoToken_;
+  edm::EDGetTokenT<GenFilterInfo> hepMCFilterInfoToken_;
   edm::EDGetTokenT<GenLumiInfoProduct> genLumiInfoToken_;
   
   // ----------member data --------------------------
 
   int hepidwtup_;
   unsigned int theProcesses_size;
+  bool           hasHepMCFilterInfo_;
+
   // final cross sections
   GenLumiInfoProduct::XSec xsec_;
   // statistics from additional generator filter
   GenFilterInfo  filterOnlyEffStat_;     
+
+  // statistics from HepMC filter
+  GenFilterInfo  hepMCFilterEffStat_;   
+
   // statistics for event level efficiency, the size is the number of processes + 1 
   std::vector<GenFilterInfo>  eventEffStat_; 
   // statistics from jet matching, the size is the number of processes + 1 

--- a/GeneratorInterface/Core/interface/HadronizerFilter.h
+++ b/GeneratorInterface/Core/interface/HadronizerFilter.h
@@ -360,6 +360,10 @@ namespace edm
             << hadronizer_.classname()
             << "\n";
     }
+    
+    if (filter_) {
+      filter_->resetStatistics();
+    }
 
     if (! hadronizer_.initializeForExternalPartons())
       throw edm::Exception(errors::Configuration) 

--- a/GeneratorInterface/Core/interface/HadronizerFilter.h
+++ b/GeneratorInterface/Core/interface/HadronizerFilter.h
@@ -156,6 +156,8 @@ namespace edm
     produces<GenEventInfoProduct>();
     produces<GenLumiInfoProduct, edm::InLumi>();
     produces<GenRunInfoProduct, edm::InRun>();
+    if(filter_)
+      produces<GenFilterInfo, edm::InLumi>(); 
   }
 
   template <class HAD, class DEC>
@@ -406,6 +408,23 @@ namespace edm
     genLumiInfo->setProcessInfo( GenLumiProcess );
     lumi.put(genLumiInfo);
 
+
+    // produce GenFilterInfo if HepMCFilter is called
+    if (filter_) {
+
+      std::auto_ptr<GenFilterInfo> thisProduct(new GenFilterInfo(
+								 filter_->numEventsPassPos(),
+								 filter_->numEventsPassNeg(),
+								 filter_->numEventsTotalPos(),
+								 filter_->numEventsTotalNeg(),
+								 filter_->sumpass_w(),
+								 filter_->sumpass_w2(),
+								 filter_->sumtotal_w(),
+								 filter_->sumtotal_w2()
+								 ));
+      lumi.put(thisProduct);
+    }
+      
 
   }
 

--- a/GeneratorInterface/Core/interface/HadronizerFilter.h
+++ b/GeneratorInterface/Core/interface/HadronizerFilter.h
@@ -137,10 +137,8 @@ namespace edm
     }
     
     if ( ps.exists("HepMCFilter") ) {
-      printf("Creating HepMCFilter\n");
       ParameterSet psfilter = ps.getParameter<ParameterSet>("HepMCFilter");
       filter_ = new HepMCFilterDriver(psfilter);
-      printf("Created HepMCFilter\n");
     }
     
     //initialize setting for multiple hadronization attempts

--- a/GeneratorInterface/Core/interface/HadronizerFilter.h
+++ b/GeneratorInterface/Core/interface/HadronizerFilter.h
@@ -31,6 +31,8 @@
 
 // #include "GeneratorInterface/ExternalDecays/interface/ExternalDecayDriver.h"
 
+#include "GeneratorInterface/HepMCFilters/interface/HepMCFilterDriver.h"
+
 // LHE Run
 #include "SimDataFormats/GeneratorProducts/interface/LHERunInfoProduct.h"
 #include "GeneratorInterface/LHEInterface/interface/LHERunInfo.h"
@@ -38,6 +40,7 @@
 // LHE Event
 #include "SimDataFormats/GeneratorProducts/interface/LHEEventProduct.h"
 #include "GeneratorInterface/LHEInterface/interface/LHEEvent.h"
+
 
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 #include "SimDataFormats/GeneratorProducts/interface/GenRunInfoProduct.h"
@@ -75,9 +78,11 @@ namespace edm
     Hadronizer hadronizer_;
     // gen::ExternalDecayDriver* decayer_;
     Decayer* decayer_;
+    HepMCFilterDriver *filter_;
     bool fromSource_;
     InputTag runInfoProductTag_;
     unsigned int counterRunInfoProducts_;
+    unsigned int nAttempts_;
   };
 
   //------------------------------------------------------------------------
@@ -89,9 +94,11 @@ namespace edm
     EDFilter(),
     hadronizer_(ps),
     decayer_(0),
+    filter_(0),
     fromSource_(true),
     runInfoProductTag_(),
-    counterRunInfoProducts_(0)
+    counterRunInfoProducts_(0),
+    nAttempts_(1)
   {
     callWhenNewProductsRegistered([this]( BranchDescription const& iBD) {
       //this is called each time a module registers that it will produce a LHERunInfoProduct
@@ -128,6 +135,19 @@ namespace edm
          usesResource(resource);
        }
     }
+    
+    if ( ps.exists("HepMCFilter") ) {
+      printf("Creating HepMCFilter\n");
+      ParameterSet psfilter = ps.getParameter<ParameterSet>("HepMCFilter");
+      filter_ = new HepMCFilterDriver(psfilter);
+      printf("Created HepMCFilter\n");
+    }
+    
+    //initialize setting for multiple hadronization attempts
+    if (ps.exists("nAttempts")) {
+      nAttempts_ = ps.getParameter<unsigned int>("nAttempts");
+    }
+    
     // This handles the case where there are no shared resources, because you
     // have to declare something when the SharedResources template parameter was used.
     if(sharedResources.empty() && (!decayer_ || decayer_->sharedResources().empty())) {
@@ -142,7 +162,10 @@ namespace edm
 
   template <class HAD, class DEC>
   HadronizerFilter<HAD,DEC>::~HadronizerFilter()
-  { if (decayer_) delete decayer_; }
+  {
+    if (decayer_) delete decayer_;
+    if (filter_) delete filter_;
+  }
 
   template <class HAD, class DEC>
   bool
@@ -160,59 +183,93 @@ namespace edm
       ev.getByLabel("source", product);
     else
       ev.getByLabel("externalLHEProducer", product);
-
-
-    lhef::LHEEvent *lheEvent =
-		new lhef::LHEEvent(hadronizer_.getLHERunInfo(), *product);
-    hadronizer_.setLHEEvent( lheEvent );
     
-    // hadronizer_.generatePartons();
-    if ( !hadronizer_.hadronize() ) return false ;
-
-    //  this is "fake" stuff
-    // in principle, decays are done as part of full event generation,
-    // except for particles that are marked as to be kept stable
-    // but we currently keep in it the design, because we might want
-    // to use such feature for other applications
-    //
-    if ( !hadronizer_.decay() ) return false;
+    std::auto_ptr<HepMC::GenEvent> finalEvent;
+    std::auto_ptr<GenEventInfoProduct> finalGenEventInfo;
     
-    std::auto_ptr<HepMC::GenEvent> event (hadronizer_.getGenEvent());
-    if( !event.get() ) return false; 
+    //sum of weights for events passing hadronization
+    double waccept = 0;
+    //number of accepted events
+    unsigned int naccept = 0;
+    
+    for (unsigned int itry = 0; itry<nAttempts_; ++itry) {
 
-    // The external decay driver is being added to the system,
-    // it should be called here
-    //
-    if ( decayer_ ) 
-    {
-      event.reset( decayer_->decay( event.get(),lheEvent ) );
+      lhef::LHEEvent *lheEvent =
+		  new lhef::LHEEvent(hadronizer_.getLHERunInfo(), *product);
+      hadronizer_.setLHEEvent( lheEvent );
+      
+      // hadronizer_.generatePartons();
+      if ( !hadronizer_.hadronize() ) continue ;
+
+      //  this is "fake" stuff
+      // in principle, decays are done as part of full event generation,
+      // except for particles that are marked as to be kept stable
+      // but we currently keep in it the design, because we might want
+      // to use such feature for other applications
+      //
+      if ( !hadronizer_.decay() ) continue;
+      
+      std::auto_ptr<HepMC::GenEvent> event (hadronizer_.getGenEvent());
+      if( !event.get() ) continue; 
+
+      // The external decay driver is being added to the system,
+      // it should be called here
+      //
+      if ( decayer_ ) 
+      {
+        event.reset( decayer_->decay( event.get(),lheEvent ) );
+      }
+
+      if ( !event.get() ) continue;
+
+      // check and perform if there're any unstable particles after 
+      // running external decay packges
+      //
+      hadronizer_.resetEvent( event.release() );
+      if ( !hadronizer_.residualDecay() ) continue;
+
+      hadronizer_.finalizeEvent();
+
+      event.reset( hadronizer_.getGenEvent() );
+      if ( !event.get() ) continue;
+      
+      event->set_event_number( ev.id().event() );
+      
+      std::auto_ptr<GenEventInfoProduct> genEventInfo(hadronizer_.getGenEventInfo());      
+      if (!genEventInfo.get())
+      { 
+        // create GenEventInfoProduct from HepMC event in case hadronizer didn't provide one
+        genEventInfo.reset(new GenEventInfoProduct(event.get()));
+      }
+      
+      //if HepMCFilter was specified, test event
+      if (filter_ && !filter_->filter(event.get(), genEventInfo->weight())) continue;      
+      
+      waccept += genEventInfo->weight();
+      ++naccept;
+      
+      //keep the LAST accepted event (which is equivalent to choosing randomly from the accepted events)
+      finalEvent.reset(event.release());
+      finalGenEventInfo.reset(genEventInfo.release());
+      
     }
+    
+    if (!naccept) return false;
+    
 
-    if ( !event.get() ) return false;
-
-    // check and perform if there're any unstable particles after 
-    // running external decay packges
-    //
-    hadronizer_.resetEvent( event.release() );
-    if ( !hadronizer_.residualDecay() ) return false;
-
-    hadronizer_.finalizeEvent();
-
-    event.reset( hadronizer_.getGenEvent() );
-    if ( !event.get() ) return false;
-
-    event->set_event_number( ev.id().event() );
-
-    std::auto_ptr<GenEventInfoProduct> genEventInfo(hadronizer_.getGenEventInfo());
-    if (!genEventInfo.get())
-    { 
-      // create GenEventInfoProduct from HepMC event in case hadronizer didn't provide one
-      genEventInfo.reset(new GenEventInfoProduct(event.get()));
+    
+    //adjust event weights if necessary (in case input event was accepted multiple times)
+    if (naccept>1) {
+      std::vector<double> genEventInfoWeights = finalGenEventInfo->weights();
+      genEventInfoWeights.push_back(waccept/finalGenEventInfo->weight());
+      finalGenEventInfo->setWeights(genEventInfoWeights);
     }
-    ev.put(genEventInfo);
+    
+    
+    ev.put(finalGenEventInfo);
 
     std::auto_ptr<HepMCProduct> bare_product(new HepMCProduct());
-    bare_product->addHepMCData( event.release() );
+    bare_product->addHepMCData( finalEvent.release() );
     ev.put(bare_product);
 
     return true;
@@ -267,6 +324,7 @@ namespace edm
 
     hadronizer_.statistics();
     if ( decayer_ ) decayer_->statistics();
+    if ( filter_ ) filter_->statistics();
     lheRunInfo->statistics();
 
     std::auto_ptr<GenRunInfoProduct> griproduct( new GenRunInfoProduct(genRunInfo) );

--- a/GeneratorInterface/Core/interface/HadronizerFilter.h
+++ b/GeneratorInterface/Core/interface/HadronizerFilter.h
@@ -261,7 +261,7 @@ namespace edm
     //adjust event weights if necessary (in case input event was accepted multiple times)
     if (naccept>1) {
       std::vector<double> genEventInfoWeights = finalGenEventInfo->weights();
-      genEventInfoWeights.push_back(waccept/finalGenEventInfo->weight());
+      genEventInfoWeights.push_back(double(naccept)/double(nAttempts_));
       finalGenEventInfo->setWeights(genEventInfoWeights);
     }
     

--- a/GeneratorInterface/Core/plugins/GenXSecAnalyzer.cc
+++ b/GeneratorInterface/Core/plugins/GenXSecAnalyzer.cc
@@ -6,8 +6,10 @@
 GenXSecAnalyzer::GenXSecAnalyzer(const edm::ParameterSet& iConfig):
   hepidwtup_(-1),
   theProcesses_size(0),
+  hasHepMCFilterInfo_(false),
   xsec_(0,0),
-  filterOnlyEffStat_(0,0,0,0,0.,0.,0.,0.)
+  filterOnlyEffStat_(0,0,0,0,0.,0.,0.,0.),
+  hepMCFilterEffStat_(0,0,0,0,0.,0.,0.,0.)
 {
   eventEffStat_.clear();
   jetMatchEffStat_.clear();
@@ -15,6 +17,7 @@ GenXSecAnalyzer::GenXSecAnalyzer(const edm::ParameterSet& iConfig):
   xsecAfterMatching_.clear();
   products_.clear();
   genFilterInfoToken_ = consumes<GenFilterInfo,edm::InLumi>(edm::InputTag("genFilterEfficiencyProducer",""));
+  hepMCFilterInfoToken_ = consumes<GenFilterInfo,edm::InLumi>(edm::InputTag("generator",""));
   genLumiInfoToken_ = consumes<GenLumiInfoProduct,edm::InLumi>(edm::InputTag("generator",""));
 }
 
@@ -48,6 +51,14 @@ GenXSecAnalyzer::endLuminosityBlock(edm::LuminosityBlock const& iLumi, edm::Even
   iLumi.getByToken(genFilterInfoToken_,genFilter);
   if(genFilter.isValid())
     filterOnlyEffStat_.mergeProduct(*genFilter);
+
+
+  edm::Handle<GenFilterInfo> hepMCFilter;
+  iLumi.getByToken(hepMCFilterInfoToken_,hepMCFilter);
+  hasHepMCFilterInfo_ = hepMCFilter.isValid();
+  if(hasHepMCFilterInfo_)
+    hepMCFilterEffStat_.mergeProduct(*hepMCFilter);
+
 
   edm::Handle<GenLumiInfoProduct> genLumiInfo;
   iLumi.getByToken(genLumiInfoToken_,genLumiInfo);
@@ -442,6 +453,39 @@ GenXSecAnalyzer::endJob() {
     << std::scientific << std::setprecision(3)  
     << xsec_match << " +- " << error_match <<  " pb";
 
+
+  // hepMC filter efficiency
+  double hepMCFilter_eff = 1.0;
+  double hepMCFilter_err = 0.0;
+  if( hasHepMCFilterInfo_){
+    hepMCFilter_eff = hepMCFilterEffStat_.filterEfficiency(hepidwtup_);
+    hepMCFilter_err = hepMCFilterEffStat_.filterEfficiencyError(hepidwtup_);
+
+    edm::LogPrint("GenXSecAnalyzer") 
+      << "HepMC filter efficiency (taking into account weights)= "
+      << "(" << hepMCFilterEffStat_.sumPassWeights() << ")"
+      << " / "
+      << "(" << hepMCFilterEffStat_.sumWeights() << ")"
+      << " = " 
+      <<  std::scientific << std::setprecision(3) 
+      << hepMCFilter_eff << " +- " << hepMCFilter_err;
+
+    double hepMCFilter_event_total = hepMCFilterEffStat_.numTotalPositiveEvents() + hepMCFilterEffStat_.numTotalNegativeEvents();
+    double hepMCFilter_event_pass  = hepMCFilterEffStat_.numPassPositiveEvents() +  hepMCFilterEffStat_.numPassNegativeEvents();
+    double hepMCFilter_event_eff   =  hepMCFilter_event_total > 0 ? hepMCFilter_event_pass/ hepMCFilter_event_total : 0;
+    double hepMCFilter_event_err   = hepMCFilter_event_total > 0 ? 
+      sqrt((1-hepMCFilter_event_eff)*hepMCFilter_event_eff/hepMCFilter_event_total): -1;
+    edm::LogPrint("GenXSecAnalyzer") 
+      << "HepMC filter efficiency (event-level)= " 
+      << "(" << hepMCFilter_event_pass << ")"
+      << " / "
+      << "(" << hepMCFilter_event_total << ")"
+      << " = " 
+      <<  std::scientific << std::setprecision(3) 
+      << hepMCFilter_event_eff << " +- " <<  hepMCFilter_event_err;
+  }
+
+  // gen-particle filter efficiency
   double filterOnly_eff = filterOnlyEffStat_.filterEfficiency(hepidwtup_);
   double filterOnly_err = filterOnlyEffStat_.filterEfficiencyError(hepidwtup_);
 
@@ -455,18 +499,25 @@ GenXSecAnalyzer::endJob() {
     << filterOnly_eff << " +- " << filterOnly_err;
 
   double filterOnly_event_total = filterOnlyEffStat_.numTotalPositiveEvents() + filterOnlyEffStat_.numTotalNegativeEvents();
-  double filterOnly_event_eff = filterOnly_event_total > 0 ? 
-    (filterOnlyEffStat_.numPassPositiveEvents() + filterOnlyEffStat_.numPassNegativeEvents())/filterOnly_event_total : 0;
-  double filterOnly_event_err = sqrt((1-filterOnly_event_eff)*filterOnly_event_eff/filterOnly_event_total);
+  double filterOnly_event_pass  = filterOnlyEffStat_.numPassPositiveEvents() + filterOnlyEffStat_.numPassNegativeEvents();
+  double filterOnly_event_eff   = filterOnly_event_total > 0 ? filterOnly_event_pass/filterOnly_event_total : 0;
+  double filterOnly_event_err   = filterOnly_event_total > 0 ?  
+    sqrt((1-filterOnly_event_eff)*filterOnly_event_eff/filterOnly_event_total): -1;
   edm::LogPrint("GenXSecAnalyzer") 
     << "Filter efficiency (event-level)= " 
+    << "(" << filterOnly_event_pass << ")"
+    << " / "
+    << "(" << filterOnly_event_total << ")"
+    << " = " 
     <<  std::scientific << std::setprecision(3) 
     << filterOnly_event_eff << " +- " << filterOnly_event_err;
 
 
-  double xsec_final  = xsec_match*filterOnly_eff ;
+  double xsec_final  = xsec_match*filterOnly_eff*hepMCFilter_eff;
   double error_final = xsec_final*sqrt(error_match*error_match/xsec_match/xsec_match+
-				       filterOnly_err*filterOnly_err/filterOnly_eff/filterOnly_eff);
+				       filterOnly_err*filterOnly_err/filterOnly_eff/filterOnly_eff + 
+				       hepMCFilter_err*hepMCFilter_err/hepMCFilter_eff/hepMCFilter_eff
+				       );
 
   edm::LogPrint("GenXSecAnalyzer") 
     << "After filter: final cross section = " 

--- a/GeneratorInterface/Core/test/calcnattempts.C
+++ b/GeneratorInterface/Core/test/calcnattempts.C
@@ -1,0 +1,72 @@
+#include "TGraph.h"
+#include "TCanvas.h"
+#include "TMath.h"
+
+//J.Bendavid
+//Script to optimize the number of hadronization steps for a given matching*filter efficiency
+//Optimization is exact under the assumption that every input event has the same underlying matching*filter efficiency
+//In practice this is not true for jet matching when mixing multiplicities, so the optimization becomes approximate.
+//This assumption is also not strictly true in case gen filters include pt/acceptance cuts which correlate the filter
+//efficiency with the parton kinematics from the hard event.
+
+void calcnattempts() {
+  
+  const double eff=0.273*0.00122; // (54924/201000)*(67/54924)
+  const unsigned int ntmax=1000;
+  
+  const double tlhe = 2.8;  //cpu time to generate an lhe event
+  const double tps = 19.5e-3;  //cpu time to shower/hadronize an event
+  const double ts = 70.6;   //cpu time to simulate an event
+  
+  double tmin = (1./eff)*(tlhe+tps) + ts;
+  int ntmin = 1;
+  double ninmin = 0.;
+  double noutmin = 0.;
+  
+  printf("initial tmin = %5f\n",tmin);
+  
+  TGraph *htime = new TGraph;
+  for (int nt=1; nt<=ntmax; ++nt) {
+    double pk0 = pow(1.-eff,nt);
+    //double pk0 = TMath::Binomial(nt,0)*pow(eff,0)*pow(1.-eff,nt-0);
+    double r1 = 0.;
+    double r2 = 0.;
+    bool trippednan = false;
+    for (int k=0; k<=nt; ++k) {
+      double pk = 0;
+      if (!trippednan) {
+	pk = TMath::Binomial(nt,k)*pow(eff,k)*pow(1.-eff,nt-k);
+	if (std::isnan(pk)) trippednan = true;
+	//assert(!trippednan);
+      }
+      if (trippednan) {
+	//printf("binomialcoeff = %5f\n", TMath::Binomial(nt,k));
+	double lambda = (double)nt*eff;
+	pk = TMath::PoissonI(k,lambda);
+      }
+      r1 += pk*k*k;
+      r2 += pk*k;
+    }
+    double r = r1/(r2*r2);
+    double nin = r;
+    double nout = r*(1.-pk0);
+    double tcpu = r*(tlhe + nt*tps + (1.-pk0)*ts);
+    //double tcpu = r*(tlhe + nt*tps + ts);
+    if (tcpu<tmin) {
+      tmin = tcpu;
+      ntmin = nt;
+      ninmin = nin;
+      noutmin = nout;
+    }
+    printf("pk0 = %5f, r = %5f, r1 = %5f, r2 = %5f\n",pk0, r,r1,r2);
+    printf("nt = %i, NE = 1, Nin = %5f, Nout = %5f, tcpu = %5f\n",nt,nin,nout,tcpu);
+    htime->SetPoint(nt-1,double(nt),tcpu);
+  }
+  htime->Draw();
+  
+  printf("Optimal nAttempts = %i, cpu time per unweighted event equivalent = %5f\n",ntmin, tmin);
+  printf("NE = 1, Nin = %5f, Nout = %5f\n",ninmin,noutmin);
+  printf("Nout/Nin = %5f\n",noutmin/ninmin);
+  printf("NE/Nin (equivalent unweighted events per input event) = %5f\n",1./ninmin);
+  
+}

--- a/GeneratorInterface/HepMCFilters/BuildFile.xml
+++ b/GeneratorInterface/HepMCFilters/BuildFile.xml
@@ -1,0 +1,7 @@
+<use   name="FWCore/Framework"/>
+<use   name="SimDataFormats/GeneratorProducts"/>
+<use   name="clhep"/>
+<use   name="pythia6"/>
+<export>
+  <lib   name="1"/>
+</export>

--- a/GeneratorInterface/HepMCFilters/interface/BaseHepMCFilter.h
+++ b/GeneratorInterface/HepMCFilters/interface/BaseHepMCFilter.h
@@ -1,0 +1,26 @@
+#ifndef BaseHepMCFilter_H
+#define BaseHepMCFilter_H
+
+// J.Bendavid
+
+// base class for simple filter to run inside of HadronizerFilter for
+// multiple hadronization attempts on lhe events
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
+
+//
+// class declaration
+//
+
+class BaseHepMCFilter  {
+public:
+  BaseHepMCFilter();
+  virtual ~BaseHepMCFilter();
+  
+
+  virtual bool filter(const HepMC::GenEvent* evt)  = 0;
+  
+};
+
+#endif

--- a/GeneratorInterface/HepMCFilters/interface/GenericDauHepMCFilter.h
+++ b/GeneratorInterface/HepMCFilters/interface/GenericDauHepMCFilter.h
@@ -1,0 +1,60 @@
+#ifndef GENERICDAUHEPMCFILTER_h
+#define GENERICDAUHEPMCFILTER_h
+// -*- C++ -*-
+//
+// Package:    GenericDauHepMCFilter
+// Class:      GenericDauHepMCFilter
+//
+/**\class GenericDauHepMCFilter GenericDauHepMCFilter.cc
+
+Description: Filter events using MotherId and ChildrenIds infos
+
+Implementation:
+<Notes on implementation>
+*/
+//
+// Original Author:  Daniele Pedrini
+//         Created:  Apr 29 2008
+// $Id: GenericDauHepMCFilter.h,v 1.2 2010/07/21 04:23:24 wmtan Exp $
+//
+//
+
+
+// system include files
+#include <memory>
+
+// user include files
+#include "GeneratorInterface/HepMCFilters/interface/BaseHepMCFilter.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+
+//
+// class decleration
+//
+
+class GenericDauHepMCFilter : public BaseHepMCFilter {
+  public:
+     GenericDauHepMCFilter(const edm::ParameterSet&);
+    ~GenericDauHepMCFilter();
+
+    virtual bool filter(const HepMC::GenEvent* evt);
+    
+  private:
+    // ----------memeber function----------------------
+
+    // ----------member data ---------------------------
+
+    int particleID;
+    bool chargeconju;
+    int ndaughters;
+    std::vector<int> dauIDs;    
+    double minptcut;
+    double maxptcut;
+    double minetacut;
+    double maxetacut;
+    };
+  #define PYCOMP pycomp_
+  extern "C" {
+  int PYCOMP(int& ip);
+}
+#endif

--- a/GeneratorInterface/HepMCFilters/interface/HepMCFilterDriver.h
+++ b/GeneratorInterface/HepMCFilters/interface/HepMCFilterDriver.h
@@ -1,0 +1,34 @@
+#ifndef gen_HEPMCFILTERDRIVER_H
+#define gen_HEPMCFILTERDRIVER_H
+
+// J.Bendavid
+//class to select a HepMCFilter to run with multiple hadronization attempts
+//inside HadronizerFilter
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
+
+//
+// class declaration
+//
+
+class BaseHepMCFilter;
+
+class HepMCFilterDriver {
+  public:
+    HepMCFilterDriver(const edm::ParameterSet&);
+    ~HepMCFilterDriver();
+
+    bool filter(const HepMC::GenEvent* evt, double weight=1.);
+    void statistics() const;
+    void resetStatistics();
+    
+  private:
+    BaseHepMCFilter *filter_;
+    unsigned int ntried_;
+    unsigned int naccepted_;
+    double weighttried_;
+    double weightaccepted_;
+  
+};
+#endif

--- a/GeneratorInterface/HepMCFilters/interface/HepMCFilterDriver.h
+++ b/GeneratorInterface/HepMCFilters/interface/HepMCFilterDriver.h
@@ -7,6 +7,7 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenFilterInfo.h"
 
 //
 // class declaration
@@ -22,13 +23,26 @@ class HepMCFilterDriver {
     bool filter(const HepMC::GenEvent* evt, double weight=1.);
     void statistics() const;
     void resetStatistics();
+
+    unsigned int numEventsPassPos() const {return numEventsPassPos_;}
+    unsigned int numEventsPassNeg() const {return numEventsPassNeg_;}
+    unsigned int numEventsTotalPos() const {return numEventsTotalPos_;}
+    unsigned int numEventsTotalNeg() const {return numEventsTotalNeg_;}
+    double sumpass_w() const {return sumpass_w_;}
+    double sumpass_w2() const {return sumpass_w2_;}
+    double sumtotal_w() const {return sumtotal_w_;}
+    double sumtotal_w2() const {return sumtotal_w2_;}
     
   private:
     BaseHepMCFilter *filter_;
-    unsigned int ntried_;
-    unsigned int naccepted_;
-    double weighttried_;
-    double weightaccepted_;
+    unsigned int numEventsPassPos_;
+    unsigned int numEventsPassNeg_;
+    unsigned int numEventsTotalPos_;
+    unsigned int numEventsTotalNeg_;
+    double sumpass_w_;
+    double sumpass_w2_;
+    double sumtotal_w_;
+    double sumtotal_w2_;
   
 };
 #endif

--- a/GeneratorInterface/HepMCFilters/src/BaseHepMCFilter.cc
+++ b/GeneratorInterface/HepMCFilters/src/BaseHepMCFilter.cc
@@ -1,0 +1,9 @@
+#include "GeneratorInterface/HepMCFilters/interface/BaseHepMCFilter.h"
+
+BaseHepMCFilter::BaseHepMCFilter() {
+
+}
+
+BaseHepMCFilter::~BaseHepMCFilter() {
+
+}

--- a/GeneratorInterface/HepMCFilters/src/GenericDauHepMCFilter.cc
+++ b/GeneratorInterface/HepMCFilters/src/GenericDauHepMCFilter.cc
@@ -1,0 +1,142 @@
+
+#include "GeneratorInterface/HepMCFilters/interface/GenericDauHepMCFilter.h"
+
+
+#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
+#include "HepMC/PythiaWrapper6_4.h"
+#include <iostream>
+
+using namespace edm;
+using namespace std;
+
+
+// GenericDauHepMCFilter::GenericDauHepMCFilter(const edm::ParameterSet& iConfig) :
+//         particleID(iConfig.getUntrackedParameter("ParticleID", 0)),
+//         chargeconju(iConfig.getUntrackedParameter("ChargeConjugation", true)),
+//         ndaughters(iConfig.getUntrackedParameter("NumberDaughters", 0)),
+//         minptcut(iConfig.getUntrackedParameter("MinPt", 0.)),
+//         maxptcut(iConfig.getUntrackedParameter("MaxPt", 14000.)),
+//         minetacut(iConfig.getUntrackedParameter("MinEta", -10.)),
+//         maxetacut(iConfig.getUntrackedParameter("MaxEta", 10.))
+// {
+//         //now do what ever initialization is needed
+//         vector<int> defdauID;
+//         defdauID.push_back(0);
+//         dauIDs = iConfig.getUntrackedParameter< vector<int> >("DaughterIDs",defdauID);
+// 
+// }
+
+GenericDauHepMCFilter::GenericDauHepMCFilter(const edm::ParameterSet& iConfig) :
+        particleID(iConfig.getParameter<int>("ParticleID")),
+        chargeconju(iConfig.getParameter<bool>("ChargeConjugation")),
+        ndaughters(iConfig.getParameter<int>("NumberDaughters")),
+        dauIDs(iConfig.getParameter<std::vector<int> >("DaughterIDs")),
+        minptcut(iConfig.getParameter<double>("MinPt")),
+        maxptcut(iConfig.getParameter<double>("MaxPt")),
+        minetacut(iConfig.getParameter<double>("MinEta")),
+        maxetacut(iConfig.getParameter<double>("MaxEta"))
+{
+
+}
+
+
+GenericDauHepMCFilter::~GenericDauHepMCFilter()
+{
+
+}
+
+
+//
+// member functions
+//
+
+// ------------ method called to produce the data  ------------
+bool GenericDauHepMCFilter::filter(const HepMC::GenEvent* evt)
+{
+  
+  for ( HepMC::GenEvent::particle_const_iterator p = evt->particles_begin();
+                  p != evt->particles_end(); ++p ) {
+
+          if( (*p)->pdg_id() != particleID ) continue ;
+
+          //     cout << "=> found a particle with : " << particleID << endl;
+          //
+          //     if ( (*p)->production_vertex() ) {
+          //       for ( HepMC::GenVertex::particle_iterator 
+          //             mother = (*p)->production_vertex()->particles_begin(HepMC::parents);
+          //                          mother != (*p)->production_vertex()->particles_end(HepMC::parents); 
+          //                          ++mother ) {
+          //                        std::cout << "\t";
+          //                        (*mother)->print();
+          //       }
+          // }
+
+          int ndauac = 0;
+          int ndau = 0;     
+          if ( (*p)->end_vertex() ) {     
+                  for ( HepMC::GenVertex::particle_iterator 
+                                  des=(*p)->end_vertex()->particles_begin(HepMC::children);
+                                  des != (*p)->end_vertex()->particles_end(HepMC::children);
+                                  ++des ) {
+                          ++ndau;       
+                          //       cout << "   -> Daughter = " << (*des)->pdg_id() << endl;
+                          for( unsigned int i=0; i<dauIDs.size(); ++i) {
+                                  if( (*des)->pdg_id() != dauIDs[i] ) continue ;
+                                  if(   (*des)->momentum().perp() >  minptcut  &&
+                                                  (*des)->momentum().perp() <  maxptcut  &&
+                                                  (*des)->momentum().eta()  >  minetacut && 
+                                                  (*des)->momentum().eta()  <  maxetacut ) {
+                                          ++ndauac;
+                                          //           cout << "     -> pT = " << (*des)->momentum().perp() << endl;
+                                          break;
+                                  } 
+                          }                            
+                  }
+          }  
+          if( ndau ==  ndaughters && ndauac == ndaughters ) {
+                  return true;
+          }    
+
+  }
+
+
+  if (chargeconju) {
+
+          for ( HepMC::GenEvent::particle_const_iterator p = evt->particles_begin();
+                          p != evt->particles_end(); ++p ) {
+
+                  if( (*p)->pdg_id() != -particleID ) continue ;
+                  int ndauac = 0;
+                  int ndau = 0;     
+                  if ( (*p)->end_vertex() ) {
+                          for ( HepMC::GenVertex::particle_iterator 
+                                          des=(*p)->end_vertex()->particles_begin(HepMC::children);
+                                          des != (*p)->end_vertex()->particles_end(HepMC::children);
+                                          ++des ) {
+                                  ++ndau;
+                                  for( unsigned int i=0; i<dauIDs.size(); ++i) {
+                                          int IDanti = -dauIDs[i];
+                                          int pythiaCode = PYCOMP(dauIDs[i]);
+                                          int has_antipart = pydat2.kchg[3-1][pythiaCode-1];
+                                          if( has_antipart == 0 ) IDanti = dauIDs[i];
+                                          if( (*des)->pdg_id() != IDanti ) continue ;
+                                          if(   (*des)->momentum().perp() >  minptcut  &&
+                                                          (*des)->momentum().perp() <  maxptcut  &&
+                                                          (*des)->momentum().eta()  >  minetacut && 
+                                                          (*des)->momentum().eta()  <  maxetacut ) {
+                                                  ++ndauac;
+                                                  break;
+                                          } 
+                                  }                            
+                          }
+                  }
+                  if( ndau ==  ndaughters && ndauac == ndaughters ) {
+                          return true;
+                  }    
+          }
+
+  }    
+
+  return false;
+
+}

--- a/GeneratorInterface/HepMCFilters/src/HepMCFilterDriver.cc
+++ b/GeneratorInterface/HepMCFilters/src/HepMCFilterDriver.cc
@@ -1,0 +1,62 @@
+#include "GeneratorInterface/HepMCFilters/interface/HepMCFilterDriver.h"
+#include "GeneratorInterface/HepMCFilters/interface/GenericDauHepMCFilter.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+HepMCFilterDriver::HepMCFilterDriver(const edm::ParameterSet& pset) :
+  filter_(0),
+  ntried_(0),
+  naccepted_(0),
+  weighttried_(0.),
+  weightaccepted_(0.)
+{
+    
+  std::string filterName = pset.getParameter<std::string>("filterName");
+  edm::ParameterSet filterParameters = pset.getParameter<edm::ParameterSet>("filterParameters");
+  
+  if (filterName=="GenericDauHepMCFilter") {
+    filter_ = new GenericDauHepMCFilter(filterParameters);
+  }
+  else {
+    edm::LogError("HepMCFilterDriver")<< "Invalid HepMCFilter name:" << filterName;
+  }
+  
+}
+
+HepMCFilterDriver::~HepMCFilterDriver()
+{
+  if (filter_) delete filter_;
+  
+}
+
+bool HepMCFilterDriver::filter(const HepMC::GenEvent* evt, double weight)
+{ 
+  ++ntried_;
+  weighttried_ += weight;
+  
+  bool accepted = filter_->filter(evt);
+  
+  if (accepted) {
+    ++naccepted_;
+    weightaccepted_ += weight;
+  }
+  
+  return accepted;
+}
+
+void HepMCFilterDriver::statistics() const
+{ 
+
+  printf("ntried = %i, naccepted = %i, efficiency = %5f\n",ntried_,naccepted_,(double)naccepted_/(double)ntried_);
+  printf("weighttried = %5f, weightaccepted = %5f, efficiency = %5f\n",weighttried_,weightaccepted_,weightaccepted_/weighttried_);
+  
+}
+
+void HepMCFilterDriver::resetStatistics() {
+ 
+  ntried_ = 0;
+  naccepted_ = 0;
+  weighttried_ = 0.;
+  weightaccepted_ = 0.;
+  
+}

--- a/GeneratorInterface/HepMCFilters/src/HepMCFilterDriver.cc
+++ b/GeneratorInterface/HepMCFilters/src/HepMCFilterDriver.cc
@@ -5,10 +5,14 @@
 
 HepMCFilterDriver::HepMCFilterDriver(const edm::ParameterSet& pset) :
   filter_(0),
-  ntried_(0),
-  naccepted_(0),
-  weighttried_(0.),
-  weightaccepted_(0.)
+  numEventsPassPos_(0),
+  numEventsPassNeg_(0),
+  numEventsTotalPos_(0),
+  numEventsTotalNeg_(0),
+  sumpass_w_(0.),
+  sumpass_w2_(0.),
+  sumtotal_w_(0.),
+  sumtotal_w2_(0.)
 {
     
   std::string filterName = pset.getParameter<std::string>("filterName");
@@ -31,14 +35,26 @@ HepMCFilterDriver::~HepMCFilterDriver()
 
 bool HepMCFilterDriver::filter(const HepMC::GenEvent* evt, double weight)
 { 
-  ++ntried_;
-  weighttried_ += weight;
+  if(weight>0)
+    numEventsTotalPos_++;
+  else
+    numEventsTotalNeg_++;
+
+  sumtotal_w_ += weight;
+  sumtotal_w2_ += weight*weight;
+
   
   bool accepted = filter_->filter(evt);
   
   if (accepted) {
-    ++naccepted_;
-    weightaccepted_ += weight;
+
+    if(weight>0)
+      numEventsPassPos_++;
+    else
+      numEventsPassNeg_++;
+    sumpass_w_   += weight;
+    sumpass_w2_ += weight*weight;
+
   }
   
   return accepted;
@@ -47,16 +63,23 @@ bool HepMCFilterDriver::filter(const HepMC::GenEvent* evt, double weight)
 void HepMCFilterDriver::statistics() const
 { 
 
+  unsigned int ntried_    = numEventsTotalPos_ + numEventsTotalNeg_;
+  unsigned int naccepted_ = numEventsPassPos_ + numEventsPassNeg_;
   printf("ntried = %i, naccepted = %i, efficiency = %5f\n",ntried_,naccepted_,(double)naccepted_/(double)ntried_);
-  printf("weighttried = %5f, weightaccepted = %5f, efficiency = %5f\n",weighttried_,weightaccepted_,weightaccepted_/weighttried_);
+  printf("weighttried = %5f, weightaccepted = %5f, efficiency = %5f\n",sumtotal_w_,sumpass_w_,sumpass_w_/sumtotal_w_);
   
 }
 
+
 void HepMCFilterDriver::resetStatistics() {
  
-  ntried_ = 0;
-  naccepted_ = 0;
-  weighttried_ = 0.;
-  weightaccepted_ = 0.;
+  numEventsPassPos_  = 0;
+  numEventsPassNeg_  = 0;
+  numEventsTotalPos_ = 0;
+  numEventsTotalNeg_ = 0;
+  sumpass_w_         = 0;
+  sumpass_w2_        = 0;
+  sumtotal_w_        = 0;
+  sumtotal_w2_       = 0;
   
 }


### PR DESCRIPTION
The code change includes 

1) Josh's update which allows input lhe files to be hadronized multiple times in 
order to boost the matching/filter efficiency.

2) Eiko's update in GenXSectionAnalyzer, HadronizerFilter, and HepMCFilterDriver:
Additional GenFilterInfo with process name = "generator" is saved so to retrieve the filter efficiency of HepMCFilter and to compute cross section correctly.
