### PR TITLE
Avoid segfault if type is not a class

### DIFF
--- a/CondCore/ORA/src/RflxPropList.h
+++ b/CondCore/ORA/src/RflxPropList.h
@@ -12,8 +12,11 @@ namespace Reflex {
     class PropertyList {
     
       public:
-          PropertyList(const edm::TypeWithDict   &dict) { 
-              m_wp = dict.getClass()->GetAttributeMap();
+          PropertyList(const edm::TypeWithDict   &dict) : m_wp(0) {
+              TClass* cl = dict.getClass();
+              if(cl) {
+                m_wp = cl->GetAttributeMap();
+              }
           }
           PropertyList(const edm::MemberWithDict &dict) : m_wp(0) {
               TClass* cl = dict.typeOf().getClass();


### PR DESCRIPTION
This simple fix for a segfault caused by a dereference of a null pointer fixes five failing unit tests, two in CondCore/DBCommon, and three in CondCore/ORA.
Please merge as soon as convenient.
