### PR TITLE
 Validation code for trigger QuadJet+TripleBTag

### DIFF
--- a/HLTriggerOffline/Higgs/interface/HLTHiggsPlotter.h
+++ b/HLTriggerOffline/Higgs/interface/HLTHiggsPlotter.h
@@ -59,7 +59,7 @@ class HLTHiggsPlotter
         void analyze(const bool & isPassTrigger,const std::string & source,
         const std::vector<MatchStruct> & matches, const unsigned int & minCandidates);
         void analyze(const bool & isPassTrigger, const std::string & source, const std::vector<MatchStruct> & matches, std::map<std::string,bool> & nMinOne,
-                     const float & dEtaqq, const float & mqq, const float & dPhibb, const float & CSV1, const bool & passAllCuts);
+                     const float & dEtaqq, const float & mqq, const float & dPhibb, const float & CSV1, const float & CSV2, const float & CSV3, const bool & passAllCuts);
 
         inline const std::string gethltpath() const { return _hltPath; }
 

--- a/HLTriggerOffline/Higgs/interface/HLTHiggsSubAnalysis.h
+++ b/HLTriggerOffline/Higgs/interface/HLTHiggsSubAnalysis.h
@@ -87,7 +87,7 @@ class HLTHiggsSubAnalysis
         void initAndInsertJets(const edm::Event & iEvent, EVTColContainer * cols, 
                                std::vector<MatchStruct> * matches);
         void passJetCuts(std::vector<MatchStruct> * matches, std::map<std::string,bool> & jetCutResult,
-                         float & dEtaqq, float & mqq, float & dPhibb, float & CSV1); 
+                         float & dEtaqq, float & mqq, float & dPhibb, float & CSV1, float & CSV2, float & CSV3); 
         void passOtherCuts(const std::vector<MatchStruct> & matches, std::map<std::string,bool> & jetCutResult); 
         void insertcandidates(const unsigned int & objtype, const EVTColContainer * col,
                               std::vector<MatchStruct> * matches);

--- a/HLTriggerOffline/Higgs/python/hltHiggsPostProcessors_cff.py
+++ b/HLTriggerOffline/Higgs/python/hltHiggsPostProcessors_cff.py
@@ -62,6 +62,14 @@ def efficiency_string(objtype,plot_type,triggerpath):
         title = "CSV1 Efficiency"
         xAxis = "CSV1 of Generated %s " % (objtype)
         input_type = "gen%sCSV1" % (objtype)
+    elif plot_type == "EffCSV2":
+        title = "CSV2 Efficiency"
+        xAxis = "CSV2 of Generated %s " % (objtype)
+        input_type = "gen%sCSV2" % (objtype)
+    elif plot_type == "EffCSV3":
+        title = "CSV3 Efficiency"
+        xAxis = "CSV3 of Generated %s " % (objtype)
+        input_type = "gen%sCSV3" % (objtype)
     elif plot_type == "EffmaxCSV":
         title = "max CSV Efficiency"
         xAxis = "max CSV of Generated %s " % (objtype)
@@ -100,6 +108,7 @@ for an in _config.analysis:
     vstr = s.__getattribute__("hltPathsToCheck")
     map(lambda x: triggers.add(x.replace("_v","")),vstr)
 triggers = list(triggers)
+
 #------------------------------------------------------------
 
 # Generating the list with all the efficiencies
@@ -152,7 +161,7 @@ hltHiggsPostHtaunu.efficiencyProfile = efficiency_strings
 
 #Specific plots for VBFHbb  
 #dEtaqq, mqq, dPhibb, CVS1, maxCSV_jets, maxCSV_E, MET, pt1, pt2, pt3, pt4
-NminOneCutNames = ("EffdEtaqq", "Effmqq", "EffdPhibb", "EffCSV1", "EffmaxCSV", "", "", "TurnOn1", "TurnOn2", "TurnOn3", "TurnOn4")
+NminOneCutNames = ("EffdEtaqq", "Effmqq", "EffdPhibb", "EffCSV1", "EffCSV2", "EffCSV3",  "EffmaxCSV", "", "", "TurnOn1", "TurnOn2", "TurnOn3", "TurnOn4")
 plot_types = ["EffEta", "EffPhi"]
 NminOneCuts = (_config.__getattribute__("VBFHbb")).__getattribute__("NminOneCuts")
 if NminOneCuts: 
@@ -173,6 +182,7 @@ efficiency_strings = get_reco_strings(efficiency_strings)
 hltHiggsPostVBFHbb = hltHiggsPostProcessor.clone()
 hltHiggsPostVBFHbb.subDirs = ['HLT/Higgs/VBFHbb']
 hltHiggsPostVBFHbb.efficiencyProfile = efficiency_strings
+
 
 #Specific plots for ZnnHbb
 #Jet plots
@@ -206,6 +216,29 @@ hltHiggsPostZnnHbb = hltHiggsPostProcessor.clone()
 hltHiggsPostZnnHbb.subDirs = ['HLT/Higgs/ZnnHbb']
 hltHiggsPostZnnHbb.efficiencyProfile = efficiency_strings
 
+
+#Specific plots for X4b
+#Jet plots
+NminOneCuts = (_config.__getattribute__("X4b")).__getattribute__("NminOneCuts")
+if NminOneCuts: 
+    for iCut in range(0,len(NminOneCuts)):
+        if( NminOneCuts[iCut] and NminOneCutNames[iCut] ):
+            plot_types.append(NminOneCutNames[iCut])
+
+efficiency_strings = []
+for type in plot_types:
+    for obj in ["Jet"]:
+        for trig in triggers:
+            efficiency_strings.append(efficiency_string(obj,type,trig))
+        
+efficiency_strings = get_reco_strings(efficiency_strings)
+
+hltHiggsPostX4b = hltHiggsPostProcessor.clone()
+hltHiggsPostX4b.subDirs = ['HLT/Higgs/X4b']
+hltHiggsPostX4b.efficiencyProfile = efficiency_strings
+
+
+
 hltHiggsPostProcessors = cms.Sequence(
         hltHiggsPostHWW+
         hltHiggsPostHZZ+
@@ -215,7 +248,9 @@ hltHiggsPostProcessors = cms.Sequence(
         hltHiggsPostVBFHbb+
         hltHiggsPostZnnHbb+
         hltHiggsPostDoubleHinTaus+
-        hltHiggsPostHiggsDalitz
+        hltHiggsPostHiggsDalitz+
+        hltHiggsPostX4b
+
 )
 
 

--- a/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
+++ b/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
         
     hltProcessName = cms.string("HLT"),
-    analysis       = cms.vstring("HWW", "HZZ", "Hgg", "Htaunu", "H2tau", "VBFHbb", "ZnnHbb","DoubleHinTaus","HiggsDalitz"),
+    analysis       = cms.vstring("HWW", "HZZ", "Hgg", "Htaunu", "H2tau", "VBFHbb", "ZnnHbb","DoubleHinTaus","HiggsDalitz","X4b"), 
     
     # -- The instance name of the reco::GenParticles collection
     genParticleLabel = cms.string("genParticles"),
@@ -223,7 +223,7 @@ hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
         jetTagLabel  = cms.string("pfCombinedSecondaryVertexBJetTags"),
         # -- Analysis specific cuts
         minCandidates = cms.uint32(4), 
-        NminOneCuts = cms.untracked.vdouble(2.6, 350, 2.6, 0.8, 0, 0, 0, 95, 85, 70, 40), #dEtaqq, mqq, dPhibb, CSV1, maxCSV_jets, maxCSV_E, MET, pt1, pt2, pt3, pt4
+        NminOneCuts = cms.untracked.vdouble(2.6, 350, 2.6, 0.8, 0, 0, 0, 0, 0, 95, 85, 70, 40), #dEtaqq, mqq, dPhibb, CSV1, maxCSV_jets, maxCSV_E, MET, pt1, pt2, pt3, pt4
         ),
     ZnnHbb = cms.PSet( 
         hltPathsToCheck = cms.vstring(
@@ -237,6 +237,19 @@ hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
         recPFMETLabel = cms.string("pfMet"),  
         # -- Analysis specific cuts
         minCandidates = cms.uint32(1), 
-        NminOneCuts = cms.untracked.vdouble(0, 0, 0, 0.9, 8, 30, 100, 70), #dEtaqq, mqq, dPhibb, CSV1, maxCSV_jets, maxCSV_E, MET, pt1
+        NminOneCuts = cms.untracked.vdouble(0, 0, 0, 0.9, 0, 0, 8, 30, 100, 70), #dEtaqq, mqq, dPhibb, CSV1, maxCSV_jets, maxCSV_E, MET, pt1
+        ),
+    X4b  = cms.PSet( 
+        hltPathsToCheck = cms.vstring(
+            "HLT_DoubleJet90_Double30_TripleCSV0p5_v",
+            "HLT_DoubleJet90_Double30_DoubleCSV0p5_v",
+            "HLT_QuadJet45_TripleCSV0p5_v",
+            "HLT_QuadJet45_DoubleCSV0p5_v",
+            ),
+        recJetLabel  = cms.string("ak4PFJetsCHS"),
+        jetTagLabel  = cms.string("pfCombinedSecondaryVertexBJetTags"),
+        # -- Analysis specific cuts
+        minCandidates = cms.uint32(4), 
+        NminOneCuts = cms.untracked.vdouble(0, 0, 0, 0.5, 0.5 , 0.5, 0, 0, 0, 0, 90, 0, 45), #dEtaqq, mqq, dPhibb, CSV1, maxCSV_jets, maxCSV_E, MET, pt1, pt2, pt3, pt4
         ),
 )

--- a/HLTriggerOffline/Higgs/src/HLTHiggsPlotter.cc
+++ b/HLTriggerOffline/Higgs/src/HLTHiggsPlotter.cc
@@ -88,9 +88,11 @@ void HLTHiggsPlotter::bookHistograms(DQMStore::IBooker &ibooker, const bool & us
                     if( _NminOneCuts[1] ) bookHist(source, objTypeStr, "mqq", ibooker);
                     if( _NminOneCuts[2] ) bookHist(source, objTypeStr, "dPhibb", ibooker);
                     if( _NminOneCuts[3] ) {
-                        if ( _NminOneCuts[4] ) bookHist(source, objTypeStr, "maxCSV", ibooker);
+                        if ( _NminOneCuts[6] ) bookHist(source, objTypeStr, "maxCSV", ibooker);
                         else bookHist(source, objTypeStr, "CSV1", ibooker);
                     }
+                    if( _NminOneCuts[4] ) bookHist(source, objTypeStr, "CSV2", ibooker);
+                    if( _NminOneCuts[5] ) bookHist(source, objTypeStr, "CSV3", ibooker);
                 }
             }
             
@@ -171,7 +173,7 @@ void HLTHiggsPlotter::analyze(const bool & isPassTrigger,
 }
 
 void HLTHiggsPlotter::analyze(const bool & isPassTrigger, const std::string & source, const std::vector<MatchStruct> & matches,
-                std::map<std::string,bool> & nMinOne, const float & dEtaqq, const float & mqq, const float & dPhibb, const float & CSV1, const bool & passAllCuts)
+                std::map<std::string,bool> & nMinOne, const float & dEtaqq, const float & mqq, const float & dPhibb, const float & CSV1, const float & CSV2, const float & CSV3, const bool & passAllCuts)
 {
     if ( !isPassTrigger )
     {
@@ -205,7 +207,7 @@ void HLTHiggsPlotter::analyze(const bool & isPassTrigger, const std::string & so
         float phi = matches[j].phi;
         
         // PFMET N-1 cut
-        if( objType == EVTColContainer::PFMET && _NminOneCuts[6] && ! nMinOne["PFMET"] ) continue;
+        if( objType == EVTColContainer::PFMET && _NminOneCuts[8] && ! nMinOne["PFMET"] ) continue;
         
         TString maxPt;
         if( (unsigned)(countobjects)[objType] < _NptPlots )
@@ -217,9 +219,8 @@ void HLTHiggsPlotter::analyze(const bool & isPassTrigger, const std::string & so
             }
             ++(countobjects[objType]);
             ++counttotal;
-        }
-        else continue;  // if not needed (minCandidates == _NptPlots if _useNminOneCuts 
-        
+        } 
+        else continue; // if not needed (minCandidates == _NptPlots if _useNminOneCuts 
         if( ! objType == EVTColContainer::PFJET || passAllCuts ) {
             this->fillHist(isPassTrigger,source,objTypeStr,"Eta",eta);
             this->fillHist(isPassTrigger,source,objTypeStr,"Phi",phi);
@@ -242,8 +243,14 @@ void HLTHiggsPlotter::analyze(const bool & isPassTrigger, const std::string & so
         }
         if( _NminOneCuts[3] ) {
             std::string nameCSVplot = "CSV1";
-            if ( _NminOneCuts[4] ) nameCSVplot = "maxCSV";
+            if ( _NminOneCuts[6] ) nameCSVplot = "maxCSV";
             if ( nMinOne[nameCSVplot] ) this->fillHist(isPassTrigger,source,EVTColContainer::getTypeString(EVTColContainer::PFJET),nameCSVplot,CSV1);
+        }
+        if( _NminOneCuts[4] && nMinOne["CSV2"] ) {
+            this->fillHist(isPassTrigger,source,EVTColContainer::getTypeString(EVTColContainer::PFJET),"CSV2",CSV2);
+        }
+        if( _NminOneCuts[5] && nMinOne["CSV3"] ) {
+            this->fillHist(isPassTrigger,source,EVTColContainer::getTypeString(EVTColContainer::PFJET),"CSV3",CSV3);
         }
     }
 }
@@ -323,6 +330,20 @@ void HLTHiggsPlotter::bookHist(const std::string & source,
         }
         else if ( variable == "CSV1" ){
             std::string title  = "CSV1 of " + sourceUpper + " " + objType;
+            int    nBins = 20;
+            double min   = 0;
+            double max   = 1;
+            h = new TH1F(name.c_str(), title.c_str(), nBins, min, max);
+        } 
+        else if ( variable == "CSV2" ){
+            std::string title  = "CSV2 of " + sourceUpper + " " + objType;
+            int    nBins = 20;
+            double min   = 0;
+            double max   = 1;
+            h = new TH1F(name.c_str(), title.c_str(), nBins, min, max);
+        } 
+        else if ( variable == "CSV3" ){
+            std::string title  = "CSV3 of " + sourceUpper + " " + objType;
             int    nBins = 20;
             double min   = 0;
             double max   = 1;

--- a/HLTriggerOffline/Higgs/test/hltHiggsValidator_cfg.py
+++ b/HLTriggerOffline/Higgs/test/hltHiggsValidator_cfg.py
@@ -37,12 +37,12 @@ process.maxEvents = cms.untracked.PSet(
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring(
         #'file:/afs/cern.ch/user/d/duarte/scratch0/step2_RAW2DIGI_RECO.root',
-        'file:/afs/cern.ch/work/j/jlauwers/hlt/CMSSW_7_2_0_pre1/src/RECO/0090828A-AC71-E311-A488-7845C4FC36D7.root'
+        'file:/afs/cern.ch/user/s/sdonato/AFSwork/public/TTbar-GEN-SIM-RECO-new.root'
         #'file:/afs/cern.ch/user/s/sdonato/AFSwork/public/forJasper/ZnnHbb_GEN_SIM_RECO_trigger.root'
     ),
     secondaryFileNames = cms.untracked.vstring(
         #'file:/afs/cern.ch/user/d/duarte/scratch0/H130GGgluonfusion_cfi_py_GEN_SIM_DIGI_L1_DIGI2RAW_HLT.root',
-        'file:/afs/cern.ch/work/j/jlauwers/hlt/CMSSW_7_2_0_pre1/src/GEN-SIM-RAW/0090828A-AC71-E311-A488-7845C4FC36D7.root'
+        #'file:/afs/cern.ch/work/j/jlauwers/hlt/CMSSW_7_2_0_pre1/src/GEN-SIM-RAW/0090828A-AC71-E311-A488-7845C4FC36D7.root'
     )
 )
 
@@ -75,6 +75,5 @@ process.analyzerpath = cms.Path(
     process.hltHiggsValidator *
     process.MEtoEDMConverter
 )
-
 
 process.outpath = cms.EndPath(process.out)


### PR DESCRIPTION
Validation code for the trigger paths:

HLT_QuadJet45_TripleCSV0p5
HLT_DoubleJet90_Double30_TripleCSV0p5
and the prescaled:
HLT_QuadJet45_DoubleCSV0p5
HLT_DoubleJet90_Double30_DoubleCSV0p5

added with the JIRA ticket:
https://its.cern.ch/jira/browse/CMSHLT-128

An output file is in:
/afs/cern.ch/user/s/sdonato/AFSwork/public/DQM_4b.root

Aligned with CMSSW_7_3_X_2014-11-06-0200
(it includes HiggsDalitz and DoubleHinTaus plots)

cc: @arizzi @cvernier @jasperlauwers @hunge @HuguesBrun
