### PR TITLE
Disable SimWatchers for MT sim in presence of more than one thread + additional fixes

### DIFF
--- a/SimG4CMS/ShowerLibraryProducer/src/CastorShowerLibraryMaker.cc
+++ b/SimG4CMS/ShowerLibraryProducer/src/CastorShowerLibraryMaker.cc
@@ -312,7 +312,7 @@ void CastorShowerLibraryMaker::update(const BeginOfEvent * evt) {
 
 //=================================================================== per STEP
 void CastorShowerLibraryMaker::update(const G4Step * aStep) {
-   static int CurrentPrimary = 0;
+   static thread_local int CurrentPrimary = 0;
    G4Track *trk = aStep->GetTrack();
    if (trk->GetCurrentStepNumber()==1) {
       if (trk->GetParentID()==0) {

--- a/SimG4Core/Application/interface/CustomUIsession.h
+++ b/SimG4Core/Application/interface/CustomUIsession.h
@@ -16,6 +16,9 @@ class CustomUIsession : public G4UIsession
 
   G4int ReceiveG4cout(const G4String& coutString) override;
   G4int ReceiveG4cerr(const G4String& cerrString) override;
+
+protected:
+  std::string trim(const std::string& str);
 };
 
 #endif

--- a/SimG4Core/Application/interface/CustomUIsessionThreadPrefix.h
+++ b/SimG4Core/Application/interface/CustomUIsessionThreadPrefix.h
@@ -1,0 +1,29 @@
+#ifndef SimG4Core_CustomUIsessionThreadPrefix_H
+#define SimG4Core_CustomUIsessionThreadPrefix_H 
+
+#include "SimG4Core/Application/interface/CustomUIsession.h"
+
+
+/**
+ * This class is intended for debugging of multithreaded simulation
+ * when the amount of output is small to moderate. The output of
+ * Geant4 is forwarded to MessageLogger as in CustomUIsession, but a
+ * thread-specific prefix is added before each line of output. This
+ * makes it easier to grab the output of a specific thread.
+ */
+class CustomUIsessionThreadPrefix : public CustomUIsession
+{
+
+ public:
+
+  CustomUIsessionThreadPrefix(const std::string& threadPrefix, int threadId);
+  ~CustomUIsessionThreadPrefix();
+
+  G4int ReceiveG4cout(const G4String& coutString) override;
+  G4int ReceiveG4cerr(const G4String& cerrString) override;
+
+private:
+  const std::string m_threadPrefix;
+};
+
+#endif

--- a/SimG4Core/Application/interface/CustomUIsessionToFile.h
+++ b/SimG4Core/Application/interface/CustomUIsessionToFile.h
@@ -1,0 +1,34 @@
+#ifndef SimG4Core_CustomUIsessionToFile_H
+#define SimG4Core_CustomUIsessionToFile_H 
+
+#include "SimG4Core/Application/interface/CustomUIsession.h"
+
+#include <fstream>
+
+/**
+ * This class is intended for debugging of multithreaded simulation
+ * when the amount of output is moderate to large. Output of Geant4 in
+ * each thread is forwarded to a thread-specific file. Compared to
+ * using MessageLogger, this way the synchronization is avoided.
+ * Thread safety is ensured by
+ * - each thread gets its own file name
+ * - each thread gets its own std::ofstream object (as
+ *   RunManagerMTWorker creates a CustomUIsessionToFile object
+ *   separately for each thread).
+ */
+class CustomUIsessionToFile : public CustomUIsession
+{
+
+ public:
+
+  CustomUIsessionToFile(const std::string& filePrefix, int threadId);
+  ~CustomUIsessionToFile();
+
+  G4int ReceiveG4cout(const G4String& coutString) override;
+  G4int ReceiveG4cerr(const G4String& cerrString) override;
+
+private:
+  std::ofstream m_output;
+};
+
+#endif

--- a/SimG4Core/Application/interface/RunManagerMTWorker.h
+++ b/SimG4Core/Application/interface/RunManagerMTWorker.h
@@ -82,6 +82,7 @@ private:
   edm::ParameterSet m_pStackingAction;
   edm::ParameterSet m_pTrackingAction;
   edm::ParameterSet m_pSteppingAction;
+  edm::ParameterSet m_pCustomUIsession;
   edm::ParameterSet m_p;
 
   struct TLSData;

--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -53,6 +53,11 @@ g4SimHits = cms.EDProducer("OscarProducer",
     Watchers = cms.VPSet(),
     HepMCProductLabel = cms.InputTag("generator"),
     theLHCTlinkTag = cms.InputTag("LHCTransport"),
+    CustomUIsession = cms.untracked.PSet(
+        Type = cms.untracked.string("MessageLogger"), # MessageLoggerThreadPrefix, FilePerThread; the non-default ones are meant only for MT debugging
+        ThreadPrefix = cms.untracked.string("W"), # For MessageLoggerThreadPrefix
+        ThreadFile = cms.untracked.string("sim_output_thread"), # For FilePerThread
+    ),
     MagneticField = cms.PSet(
         UseLocalMagFieldManager = cms.bool(False),
         Verbosity = cms.untracked.bool(False),

--- a/SimG4Core/Application/src/CustomUIsession.cc
+++ b/SimG4Core/Application/src/CustomUIsession.cc
@@ -16,14 +16,6 @@ CustomUIsession::~CustomUIsession()
 
 }
 
-namespace {
-  std::string trim(const std::string& str) {
-    if(!str.empty() && str.back() == '\n')
-      return str.substr(0, str.length()-1);
-    return str;
-  }
-}
-
 G4int CustomUIsession::ReceiveG4cout(const G4String& coutString)
 {
   //std::cout << coutString << std::flush;
@@ -36,4 +28,10 @@ G4int CustomUIsession::ReceiveG4cerr(const G4String& cerrString)
   //std::cerr << cerrString << std::flush;
   edm::LogWarning("G4cerr") << trim(cerrString);
   return 0;
+}
+
+std::string CustomUIsession::trim(const std::string& str) {
+  if(!str.empty() && str.back() == '\n')
+    return str.substr(0, str.length()-1);
+  return str;
 }

--- a/SimG4Core/Application/src/CustomUIsessionThreadPrefix.cc
+++ b/SimG4Core/Application/src/CustomUIsessionThreadPrefix.cc
@@ -1,0 +1,36 @@
+#include "SimG4Core/Application/interface/CustomUIsessionThreadPrefix.h"
+
+CustomUIsessionThreadPrefix::CustomUIsessionThreadPrefix(const std::string& threadPrefix, int threadId):
+  CustomUIsession(),
+  m_threadPrefix(threadPrefix+std::to_string(threadId)+">> ")
+{}
+
+CustomUIsessionThreadPrefix::~CustomUIsessionThreadPrefix() {}
+
+namespace {
+  std::string addThreadPrefix(const std::string& threadPrefix, const std::string str) {
+    // Add thread prefix to each line beginning
+    std::string ret;
+    std::string::size_type beg = 0;
+    std::string::size_type end = str.find('\n');
+    while(end != std::string::npos) {
+      ret += threadPrefix + str.substr(beg, end-beg) + "\n";
+      beg = end+1;
+      end = str.find('\n', beg);
+    }
+    ret += threadPrefix + str.substr(beg, end);
+    return ret;
+  }
+}
+
+G4int CustomUIsessionThreadPrefix::ReceiveG4cout(const G4String& coutString)
+{
+  edm::LogVerbatim("G4cout") << addThreadPrefix(m_threadPrefix, trim(coutString));
+  return 0;
+}
+
+G4int CustomUIsessionThreadPrefix::ReceiveG4cerr(const G4String& cerrString)
+{
+  edm::LogWarning("G4cerr") << addThreadPrefix(m_threadPrefix, trim(cerrString));
+  return 0;
+}

--- a/SimG4Core/Application/src/CustomUIsessionToFile.cc
+++ b/SimG4Core/Application/src/CustomUIsessionToFile.cc
@@ -1,0 +1,20 @@
+#include "SimG4Core/Application/interface/CustomUIsessionToFile.h"
+
+CustomUIsessionToFile::CustomUIsessionToFile(const std::string& filePrefix, int threadId):
+  CustomUIsession(),
+  m_output(filePrefix+"_"+std::to_string(threadId)+".txt")
+{}
+
+CustomUIsessionToFile::~CustomUIsessionToFile() {}
+
+G4int CustomUIsessionToFile::ReceiveG4cout(const G4String& coutString)
+{
+  m_output << coutString;
+  return 0;
+}
+
+G4int CustomUIsessionToFile::ReceiveG4cerr(const G4String& cerrString)
+{
+  m_output << cerrString;
+  return 0;
+}

--- a/SimG4Core/Application/src/RunManagerMTWorker.cc
+++ b/SimG4Core/Application/src/RunManagerMTWorker.cc
@@ -8,6 +8,8 @@
 #include "SimG4Core/Application/interface/TrackingAction.h"
 #include "SimG4Core/Application/interface/SteppingAction.h"
 #include "SimG4Core/Application/interface/CustomUIsession.h"
+#include "SimG4Core/Application/interface/CustomUIsessionThreadPrefix.h"
+#include "SimG4Core/Application/interface/CustomUIsessionToFile.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -137,6 +139,7 @@ RunManagerMTWorker::RunManagerMTWorker(const edm::ParameterSet& iConfig, edm::Co
   m_pStackingAction(iConfig.getParameter<edm::ParameterSet>("StackingAction")),
   m_pTrackingAction(iConfig.getParameter<edm::ParameterSet>("TrackingAction")),
   m_pSteppingAction(iConfig.getParameter<edm::ParameterSet>("SteppingAction")),
+  m_pCustomUIsession(iConfig.getUntrackedParameter<edm::ParameterSet>("CustomUIsession")),
   m_p(iConfig)
 {
   initializeTLS();
@@ -181,7 +184,19 @@ void RunManagerMTWorker::initializeThread(const RunManagerMT& runManagerMaster, 
   // Initialize per-thread output
   G4Threading::G4SetThreadId( thisID );
   G4UImanager::GetUIpointer()->SetUpForAThread( thisID );
-  m_tls->UIsession.reset(new CustomUIsession());
+  const std::string& uitype = m_pCustomUIsession.getUntrackedParameter<std::string>("Type");
+  if(uitype == "MessageLogger") {
+    m_tls->UIsession.reset(new CustomUIsession());
+  }
+  else if(uitype == "MessageLoggerThreadPrefix") {
+    m_tls->UIsession.reset(new CustomUIsessionThreadPrefix(m_pCustomUIsession.getUntrackedParameter<std::string>("ThreadPrefix"), thisID));
+  }
+  else if(uitype == "FilePerThread") {
+    m_tls->UIsession.reset(new CustomUIsessionToFile(m_pCustomUIsession.getUntrackedParameter<std::string>("ThreadFile"), thisID));
+  }
+  else {
+    throw cms::Exception("Configuration") << "Invalid value of CustomUIsession.Type '" << uitype << "', valid are MessageLogger, MessageLoggerThreadPrefix, FilePerThread";
+  }
 
   // Initialize worker part of shared resources (geometry, physics)
   G4WorkerThread::BuildGeometryAndPhysicsVector();

--- a/SimG4Core/Generators/src/Generator.cc
+++ b/SimG4Core/Generators/src/Generator.cc
@@ -124,7 +124,7 @@ void Generator::HepMC2G4(const HepMC::GenEvent * evt_orig, G4Event * g4evt)
                                      (*(evt->vertices_begin()))->position().t());
 
   if(verbose > 0) {
-    evt->print();
+    evt->print(G4cout);
     LogDebug("SimG4CoreGenerator") << "Primary Vertex = (" 
 				   << vtx_->x() << "," 
 				   << vtx_->y() << ","


### PR DESCRIPTION
Most of SimWatchers are thread-unsafe, so for now support for them is explicitly disabled if running OscarMTProducer with more than one thread. Same is done for the connection to external SimActivityRegistry (connection to visualization?). It is assumed now that one thread would be sufficient for both of these activities.

Introduce two optional CustomUIsession classes for MT (no effect for serial OscarProducer nor the default behaviour of OscarMTProducer) for making it easier to interpret debug output from Geant4 in the presence of multiple threads:
- CustomUIsessionThreadPrefix: use MessageLogger, but add a thread-specific prefix for each line
- CustomUIsessionToFile: forward the output to thread-specific files

The first class is for small to moderate size output, and the latter for large outputs (e.g. when the synchronization in MessageLogger makes the MT job essentially serial thus hiding possible MT-specific issues).
