### PR TITLE
Fix HCAL etaRange signature

### DIFF
--- a/Geometry/HcalTowerAlgo/src/HcalTrigTowerGeometry.cc
+++ b/Geometry/HcalTowerAlgo/src/HcalTrigTowerGeometry.cc
@@ -215,8 +215,8 @@ int HcalTrigTowerGeometry::firstHFRingInTower(int ietaTower) const {
 void HcalTrigTowerGeometry::towerEtaBounds(int ieta, double & eta1, double & eta2) const {
   int ietaAbs = abs(ieta);
   std::pair<double,double> etas = 
-    (ietaAbs < firstHFTower()) ? theTopology->etaRange(HcalBarrel,ieta) : 
-    theTopology->etaRange(HcalForward,ieta);
+    (ietaAbs < firstHFTower()) ? theTopology->etaRange(HcalBarrel,ietaAbs) : 
+    theTopology->etaRange(HcalForward,ietaAbs);
   eta1 = etas.first;
   eta2 = etas.second;
   


### PR DESCRIPTION
Current HCAL TP code passes a signed `ieta` to towerEtaBounds, which passes this through to etaRange of the HcalTopology.  If `ieta` is negative, the sign of the result is reversed.  This currently fails for negative `ieta`, as etaRange will use the `ieta` as an array index.

Fix contains two parts:
- pass abs(`ieta`) instead of `ieta` to etaRange
- change the signature to indicate that positive values of `ieta` are desired
