### PR TITLE
Use local time to fill timestamp if the GPS information is not available

### DIFF
--- a/EventFilter/Utilities/src/AuxiliaryMakers.cc
+++ b/EventFilter/Utilities/src/AuxiliaryMakers.cc
@@ -1,8 +1,11 @@
+#include <sys/time.h>
+
 #include "EventFilter/Utilities/interface/AuxiliaryMakers.h"
+
 namespace evf{
   namespace evtn{
 
-      edm::EventAuxiliary makeEventAuxiliary(TCDSRecord *record, 
+      edm::EventAuxiliary makeEventAuxiliary(TCDSRecord *record,
 					     unsigned int runNumber,
                                              unsigned int lumiSection,
 					     std::string const &processGUID){
@@ -10,13 +13,19 @@ namespace evf{
 			     //record->getHeader().getData().header.lumiSection,//+1
                              lumiSection,
 			     record->getHeader().getData().header.eventNumber);
-	
+
 	uint64_t gpsh = record->getBST().getBST().gpstimehigh;
 	uint32_t gpsl = record->getBST().getBST().gpstimelow;
-	edm::Timestamp tstamp = edm::Timestamp(static_cast<edm::TimeValue_t> ((gpsh << 32) + gpsl));
+        edm::TimeValue_t time = static_cast<edm::TimeValue_t> ((gpsh << 32) + gpsl);
+        if (time == 0) {
+          timeval stv;
+          gettimeofday(&stv,0);
+          time = stv.tv_sec;
+          time = (time << 32) + stv.tv_usec;
+        }
 	return edm::EventAuxiliary(eventId,
 				   processGUID,
-				   tstamp,
+				   edm::Timestamp(time),
 				   true,
 				   (edm::EventAuxiliary::ExperimentType)record->getHistory().history().hist[0].eventtype,
 				   (int)record->getHeader().getData().header.bcid,
@@ -25,4 +34,3 @@ namespace evf{
       }
   }
 }
-


### PR DESCRIPTION
Assure that any event passing the HLT has a valid timestamp. If the GPS time from TCDS (or GT) is not available, use the local time of the machine running the HLT process. This time is less accurate, but better than nothing /:
