### PR TITLE
Remove  unnecessary use of boost::cref() in framework

### DIFF
--- a/FWCore/ParameterSet/src/AllowedLabelsDescriptionBase.cc
+++ b/FWCore/ParameterSet/src/AllowedLabelsDescriptionBase.cc
@@ -5,8 +5,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/ParameterSet/interface/DocFormatHelper.h"
 
-#include "boost/ref.hpp"
-
 #include <iomanip>
 #include <ostream>
 
@@ -54,7 +52,7 @@ namespace edm {
         allowedLabels = pset.getUntrackedParameter<std::vector<std::string> >(parameterHoldingLabels_.label());
       }
       for_all(allowedLabels, std::bind(&AllowedLabelsDescriptionBase::validateAllowedLabel_,
-                                         boost::cref(this),
+                                         this,
                                          std::placeholders::_1,
                                          std::ref(pset),
                                          std::ref(validatedLabels)));

--- a/FWCore/ParameterSet/src/ParameterWildcard.cc
+++ b/FWCore/ParameterSet/src/ParameterWildcard.cc
@@ -5,8 +5,6 @@
 #include "FWCore/ParameterSet/interface/VParameterSetEntry.h"
 #include "FWCore/Utilities/interface/Algorithms.h"
 
-#include "boost/ref.hpp"
-
 #include <cassert>
 #include <iomanip>
 #include <ostream>
@@ -64,7 +62,7 @@ namespace edm {
     if(psetDesc_) {
       for_all(parameterNames,
               std::bind(&ParameterWildcard<ParameterSetDescription>::validateDescription,
-                          boost::cref(this),
+                          this,
                           std::placeholders::_1,
                           std::ref(pset)));
     }
@@ -181,7 +179,7 @@ namespace edm {
     if(psetDesc_) {
       for_all(parameterNames,
               std::bind(&ParameterWildcard<std::vector<ParameterSet> >::validatePSetVector,
-                          boost::cref(this),
+                          this,
                           std::placeholders::_1,
                           std::ref(pset)));
     }


### PR DESCRIPTION
boost::cref(this) will no longer compile with boost 1.57.0, and std::cref(this) will not compile either, because these functions do not take an rvalue reference as an argument.
Also, all the use of boost::cref did in this case is _possibly_ saving the copying of a pointer, at the overhead of a function call, so it was not a good idea in the first place.
This pull request replaces "boost::cref(this)" with simply "this".
Note that "std::cref(*this)" would (likely) also work, but there is no point to adding the overhead of a function call for the _possible_ saving of a pointer copy, especially if it complicates the code.
