### PR TITLE
reorganize HCAL aging functions

### DIFF
--- a/CalibCalorimetry/HcalPlugins/python/Hcal_Conditions_forGlobalTag_cff.py
+++ b/CalibCalorimetry/HcalPlugins/python/Hcal_Conditions_forGlobalTag_cff.py
@@ -17,6 +17,7 @@ toGet = cms.untracked.vstring('GainWidths'),
     HBRecalibration = cms.uint32(0),         # 1 for Upgrade (default aging scenario)
     HBreCalibCutoff = cms.double(20.),       # if above is True
     HFRecalibration = cms.bool(False),       # True for Upgrade
+    SipmAging       = cms.bool(False),       # True for Upgrade
     GainWidthsForTrigPrims = cms.bool(False) # True Upgrade    
 )
 

--- a/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
+++ b/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
@@ -108,7 +108,8 @@ namespace {
 
 }
 
-HcalHardcodeCalibrations::HcalHardcodeCalibrations ( const edm::ParameterSet& iConfig ): he_recalibration(0), hb_recalibration(0), hf_recalibration(0), setHEdsegm(false), setHBdsegm(false)
+HcalHardcodeCalibrations::HcalHardcodeCalibrations ( const edm::ParameterSet& iConfig ): 
+he_recalibration(0), hb_recalibration(0), hf_recalibration(0), setHEdsegm(false), setHBdsegm(false), SipmLumi(0.0)
 {
   edm::LogInfo("HCAL") << "HcalHardcodeCalibrations::HcalHardcodeCalibrations->...";
 
@@ -136,6 +137,10 @@ HcalHardcodeCalibrations::HcalHardcodeCalibrations ( const edm::ParameterSet& iC
     }
     if(hf_recalib)  hf_recalibration = new HFRecalibration();
     
+	SipmLumi = iLumi;
+	bool doSipmAging = iConfig.getParameter<bool>("SipmAging");
+	if(!doSipmAging) SipmLumi = 0.0;
+	
     //     std::cout << " HcalHardcodeCalibrations:  iLumi = " <<  iLumi << std::endl;
   }
 
@@ -263,7 +268,7 @@ std::auto_ptr<HcalPedestals> HcalHardcodeCalibrations::producePedestals (const H
   std::auto_ptr<HcalPedestals> result (new HcalPedestals (topo,false));
   std::vector <HcalGenericDetId> cells = allCells(*topo);
   for (std::vector <HcalGenericDetId>::const_iterator cell = cells.begin (); cell != cells.end (); cell++) {
-    HcalPedestal item = HcalDbHardcode::makePedestal (*cell, false, iLumi);
+    HcalPedestal item = HcalDbHardcode::makePedestal (*cell, false, SipmLumi);
     result->addValues(item);
   }
   return result;
@@ -278,7 +283,7 @@ std::auto_ptr<HcalPedestalWidths> HcalHardcodeCalibrations::producePedestalWidth
   std::auto_ptr<HcalPedestalWidths> result (new HcalPedestalWidths (topo,false));
   std::vector <HcalGenericDetId> cells = allCells(*htopo);
   for (std::vector <HcalGenericDetId>::const_iterator cell = cells.begin (); cell != cells.end (); cell++) {
-    HcalPedestalWidth item = HcalDbHardcode::makePedestalWidth (*cell, iLumi);
+    HcalPedestalWidth item = HcalDbHardcode::makePedestalWidth (*cell, SipmLumi);
     result->addValues(item);
   }
   return result;

--- a/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.h
+++ b/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.h
@@ -95,5 +95,6 @@ private:
   bool switchGainWidthsForTrigPrims; 
   bool setHEdsegm;
   bool setHBdsegm;
+  double SipmLumi;
 };
 

--- a/SLHCUpgradeSimulations/Configuration/python/aging.py
+++ b/SLHCUpgradeSimulations/Configuration/python/aging.py
@@ -66,31 +66,40 @@ def agePixel(process,lumi):
 
     return process    
 
-def ageHcal(process,lumi):
+#scenario = 1 enables default, 0 disables
+def ageHB(process,scenario):
+    if hasattr(process,'mix') and hasattr(process.mix,'digitizers') and hasattr(process.mix.digitizers,'hcal'):
+        process.mix.digitizers.hcal.HBDarkening = cms.uint32(scenario)
+    if hasattr(process,'es_hardcode'):
+        process.es_hardcode.HBRecalibration = cms.uint32(scenario)
+    return process
 
-    instLumi=1.0e34
-    if lumi>=1000:
-        instLumi=5.0e34
-	
-    if hasattr(process,'mix') and hasattr(process.mix,'digitizers') and hasattr(process.mix.digitizers,'hcal'):  
-        process.mix.digitizers.hcal.DelivLuminosity = cms.double(float(lumi))  # integrated lumi in fb-1
-        process.mix.digitizers.hcal.HEDarkening     = cms.uint32(1)
-        process.mix.digitizers.hcal.HFDarkening     = cms.bool(True)
+#scenario = 1 enables default, 0 disables
+def ageHE(process,scenario):
+    if hasattr(process,'mix') and hasattr(process.mix,'digitizers') and hasattr(process.mix.digitizers,'hcal'):
+        process.mix.digitizers.hcal.HEDarkening = cms.uint32(scenario)
+    if hasattr(process,'es_hardcode'):
+        process.es_hardcode.HERecalibration = cms.uint32(scenario)
+    return process
 
-    #these lines need to be further activated by tuning on 'complete' aging for HF 
-    if hasattr(process,'g4SimHits'):  
-        process.g4SimHits.HCalSD.InstLuminosity = cms.double(float(instLumi))
-        process.g4SimHits.HCalSD.DelivLuminosity = cms.double(float(lumi))
+#turnon = True enables default, False disables
+def ageHF(process,turnon):
+    if hasattr(process,'mix') and hasattr(process.mix,'digitizers') and hasattr(process.mix.digitizers,'hcal'):
+        process.mix.digitizers.hcal.HFDarkening = cms.bool(turnon)
+    if hasattr(process,'es_hardcode'):
+        process.es_hardcode.HFRecalibration = cms.bool(turnon)
+    return process
 
+#turnon = True enables default, False disables
+#needs lumi to set proper ZS thresholds
+def ageSipm(process,turnon,lumi):
     #recalibration and darkening always together
     if hasattr(process,'es_hardcode'):
-        process.es_hardcode.HERecalibration = cms.uint32(1)
-        process.es_hardcode.HFRecalibration = cms.bool(True)
-        process.es_hardcode.iLumi = cms.double(float(lumi))
+        process.es_hardcode.SipmAging = cms.bool(turnon)
 
     #change ZS thresholds for SiPMs
     if hasattr(process,'simHcalDigis'):
-        if lumi<499: #values for 0 to 200
+        if lumi<499 or not turnon: #values for 0 to 200
             process.simHcalDigis.HBlevel=cms.int32(16)
             process.simHcalDigis.HElevel=cms.int32(16)
         elif lumi<999: #values for 500
@@ -102,9 +111,69 @@ def ageHcal(process,lumi):
         else: #values for 3000
             process.simHcalDigis.HBlevel=cms.int32(209)
             process.simHcalDigis.HElevel=cms.int32(76) 
+    return process
+
+def ageHcal(process,lumi):
+
+    instLumi=1.0e34
+    if lumi>=1000:
+        instLumi=5.0e34
+
+    if hasattr(process,'mix') and hasattr(process.mix,'digitizers') and hasattr(process.mix.digitizers,'hcal'):  
+        process.mix.digitizers.hcal.DelivLuminosity = cms.double(float(lumi))  # integrated lumi in fb-1
+
+    #these lines need to be further activated by turning on 'complete' aging for HF 
+    if hasattr(process,'g4SimHits'):  
+        process.g4SimHits.HCalSD.InstLuminosity = cms.double(float(instLumi))
+        process.g4SimHits.HCalSD.DelivLuminosity = cms.double(float(lumi))
+
+    #recalibration and darkening always together
+    if hasattr(process,'es_hardcode'):
+        process.es_hardcode.iLumi = cms.double(float(lumi))
+
+    #functions to enable individual subdet aging
+    process = ageHE(process,1)
+    process = ageHF(process,True)
+    process = ageSipm(process,True,lumi)
         
     return process
 
+def turn_on_HB_aging_1(process):
+    process = ageHB(process,1)
+    return process
+
+def turn_off_HB_aging(process):
+    process = ageHB(process,0)
+    return process
+
+def turn_on_HE_aging_1(process):
+    process = ageHE(process,1)
+    return process
+
+def turn_on_HE_aging_2(process):
+    process = ageHE(process,2)
+    return process
+
+def turn_on_HE_aging_3(process):
+    process = ageHE(process,3)
+    return process
+    
+def turn_off_HE_aging(process):
+    process = ageHE(process,0)
+    return process
+    
+def turn_on_HF_aging(process):
+    process = ageHF(process,True)
+    return process
+    
+def turn_off_HF_aging(process):
+    process = ageHF(process,False)
+    return process
+
+def turn_off_Sipm_aging(process):
+    process = ageSipm(process,False,0)
+    return process
+    
 def ageEcal(process,lumi):
 
     instLumi=1.0e34
@@ -221,43 +290,6 @@ def ecal_complete_aging(process):
         process.g4SimHits.ECalSD.AgeingWithSlopeLY = cms.untracked.bool(True)
     if hasattr(process,'ecal_digi_parameters'):    
         process.ecal_digi_parameters.UseLCcorrection = cms.untracked.bool(False)
-    return process
-
-def turn_off_HE_aging(process):
-    if hasattr(process,'mix') and hasattr(process.mix,'digitizers') and hasattr(process.mix.digitizers,'hcal'):    
-        process.mix.digitizers.hcal.HEDarkening = cms.uint32(0)
-    if hasattr(process,'es_hardcode'):
-        process.es_hardcode.HERecalibration = cms.uint32(0)
-    return process
-
-def set_HE_aging_scenario(process,scenario):
-    if hasattr(process,'mix') and hasattr(process.mix,'digitizers') and hasattr(process.mix.digitizers,'hcal'):
-        process.mix.digitizers.hcal.HEDarkening = cms.uint32(scenario)
-    if hasattr(process,'es_hardcode'):
-        process.es_hardcode.HERecalibration = cms.uint32(scenario)
-    return process
-
-def turn_off_HB_aging(process):
-    if hasattr(process,'mix') and hasattr(process.mix,'digitizers') and hasattr(process.mix.digitizers,'hcal'):    
-        process.mix.digitizers.hcal.HBDarkening = cms.uint32(0)
-    if hasattr(process,'es_hardcode'):
-        process.es_hardcode.HBRecalibration = cms.uint32(0)
-    return process
-
-def set_HB_aging_scenario(process,scenario):
-    if hasattr(process,'mix') and hasattr(process.mix,'digitizers') and hasattr(process.mix.digitizers,'hcal'):
-        process.mix.digitizers.hcal.HBDarkening = cms.uint32(scenario)
-    if hasattr(process,'es_hardcode'):
-        process.es_hardcode.HBRecalibration = cms.uint32(scenario)
-    return process
-
-def turn_off_HF_aging(process):
-    if hasattr(process,'g4SimHits'):
-        process.g4SimHits.HCalSD.HFDarkening = cms.untracked.bool(False)
-    if hasattr(process,'mix') and hasattr(process.mix,'digitizers') and hasattr(process.mix.digitizers,'hcal'):    
-        process.mix.digitizers.hcal.HFDarkening = cms.bool(False)
-    if hasattr(process,'es_hardcode'):
-        process.es_hardcode.HFRecalibration = cms.bool(False)
     return process
 
 def turn_off_Pixel_aging(process):


### PR DESCRIPTION
This commit reorganizes the HCAL aging functions to separate the aging customizations for HB, HE, HF, and SiPMs. Important notes:
- The default behavior of the function ageHcal remains unchanged (HB aging is not enabled by default).
- Several pre-defined function snippets are added to change the HE aging scenarios easily via the cmsDriver --customise command: turn_on_HE_aging_X for scenario X (currently 1, 2, or 3).
- SiPM aging can now be separately disabled.
