### PR TITLE
Must enable autoloading

### DIFF
--- a/CondCore/CondDB/test/BuildFile.xml
+++ b/CondCore/CondDB/test/BuildFile.xml
@@ -4,6 +4,7 @@
 <use   name="CondFormats/Common"/>
 <use   name="DataFormats/StdDictionaries"/>
 <use   name="FWCore/PluginManager"/>
+<use   name="FWCore/RootAutoLibraryLoader"/>
 <library   name="testCondDBDict" file="">
 </library>
 <bin   file="testConditionDatabase_0.cpp" name="testConditionDatabase_0">

--- a/CondCore/CondDB/test/testFrontier.cpp
+++ b/CondCore/CondDB/test/testFrontier.cpp
@@ -1,6 +1,7 @@
 #include "FWCore/PluginManager/interface/PluginManager.h"
 #include "FWCore/PluginManager/interface/standard.h"
 #include "FWCore/PluginManager/interface/SharedLibrary.h"
+#include "FWCore/RootAutoLibraryLoader/interface/RootAutoLibraryLoader.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
 //
@@ -30,6 +31,10 @@ int main (int argc, char** argv)
 
   std::string connectionString("frontier://FrontierProd/CMS_COND_31X_RUN_INFO");
   std::cout <<"# Connecting with db in "<<connectionString<<std::endl;
+
+  // Enable Autoloading
+  edm::RootAutoLibraryLoader::enable();
+
   try{
     //*************
     ConnectionPool connPool;


### PR DESCRIPTION
The "testFrontier" unit test is failing due to a missing dictionary.  The problem has been traced to the fact that autoloading of dictionaries is not enabled in the test.
This pull request enables autoloading, and fixes the unit test.
Please merge as soon as convenient.
