### PR TITLE
Remove `operator[](std::ptrdiff_t) const` from boost::shared_ptr

### DIFF
--- a/PhysicsTools/FWLite/src/classes_def.xml
+++ b/PhysicsTools/FWLite/src/classes_def.xml
@@ -1,20 +1,20 @@
 <lcgdict>
- <class name="reco::parser::ExpressionBase" persistent="false" />
- <class name="reco::parser::SelectorBase" persistent="false" />
- <class name="reco::parser::ExpressionPtr" persistent="false" />
- <class name="reco::parser::SelectorPtr" persistent="false" />
- <class name="reco::parser::ExpressionPtrs" persistent="false" />
- <class name="reco::parser::SelectorPtrs" persistent="false" />
- <class name="helper::Parser" persistent="false" />
- <class name="helper::ScannerBase" persistent="false" />
- <!--
- <class name="fwlite::helper::CandScanner" persistent="false" />
- <class name="CandidateSelector" persistent="false" />
- <class name="CandidateFunction" persistent="false" />
- <class name="std::vector<CandidateFunction>" persistent="false" />
-
- <class name="Selector" persistent="false" />
- <class name="CandidateSelector" persistent="false" />
- <class name="CandidateSelector" persistent="false" />
- -->
+  <selection>
+    <class name="reco::parser::ExpressionBase" persistent="false" />
+    <class name="reco::parser::SelectorBase" persistent="false" />
+    <class name="reco::parser::ExpressionPtr" persistent="false" />
+    <class name="reco::parser::SelectorPtr" persistent="false" />
+    <class name="reco::parser::ExpressionPtrs" persistent="false" />
+    <class name="reco::parser::SelectorPtrs" persistent="false" />
+    <class name="helper::Parser" persistent="false" />
+    <class name="helper::ScannerBase" persistent="false" />
+  </selection>
+  <exclusion>
+    <class name="boost::shared_ptr<reco::parser::ExpressionBase>">
+      <method name="[]" />
+    </class>
+    <class name="boost::shared_ptr<reco::parser::SelectorBase>">
+      <method name="[]" />
+    </class>
+  </exclusion>
 </lcgdict>


### PR DESCRIPTION
Starting Boost 1.53.0 a new feature was introduced into
boost::shared_ptr: a support for a pointer to a dynamically
allocated array.

This is achieved by adding `operator[](std::ptrdiff_t) const` to
all instances on boost::shared_ptr. There are two levels of protection
here:
- Runtime checks that the pointer you hold is an array
- A trait returns `void` return type for non-array types in
  `boost::shared_ptr`

The second point creates compilation errors in Reflex dictionaries.
Reflex needs to generate a call for `operator[]`, but by doing that we
get `operator[]` with return type `void` and with `return` statement.

Think about it as a static assert.

Simply put Reflex does not know, that it should not call `operator[]` on
not array `boost::shared_ptr`.

```
reco::parser::ExpressionPtr : boost::shared_ptr<reco::parser::ExpressionBase>
reco::parser::SelectorPtr   : boost::shared_ptr<reco::parser::SelectorBase>
```

These are not pointers to dynamically allocated arrays.

The patch disables `operator[]` on them (will not be visible in
interpreter).

More details available in: https://github.com/cms-sw/cmsdist/issues/1167

No difference with Boost 1.51.0 (current version)

```
--- xr.orig.cc  2014-11-08 10:32:06.000000001 +0100
+++ xr.new.cc   2014-11-08 10:36:34.000000001 +0100
@@ -1,4 +1,4 @@
-// Generated at Sat Nov  8 10:31:31 2014. Do not modify it
+// Generated at Sat Nov  8 10:36:08 2014. Do not modify it

 /*
 GCC-XML version 0.9.0
```

The difference with Boost 1.57.0 (removes `operator[]`)

```
--- xr.orig.cc  2014-11-08 10:42:07.557000304 +0100
+++ xr.new.cc   2014-11-08 10:44:41.610120525 +0100
@@ -1,4 +1,4 @@
-// Generated at Sat Nov  8 10:41:56 2014. Do not modify it
+// Generated at Sat Nov  8 10:44:29 2014. Do not modify it

/*
GCC-XML version 0.9.0
@@ -118,7 +118,6 @@ namespace {
  ::Reflex::Type type_5985c = ::Reflex::ConstBuilder(type_5985);
  ::Reflex::Type type_6786 = ::Reflex::ReferenceBuilder(type_5985c);
  ::Reflex::Type type_6784 = ::Reflex::ReferenceBuilder(type_5985);
-  ::Reflex::Type type_1928 = ::Reflex::TypedefTypeBuilder(Reflex::Literal("std::ptrdiff_t"), type_121);
  ::Reflex::Type type_1627 = ::Reflex::PointerBuilder(type_69);
  ::Reflex::Type type_13803 = ::Reflex::TypedefTypeBuilder(Reflex::Literal("boost::core::typeinfo"), type_636);
  ::Reflex::Type type_13837 = ::Reflex::TypedefTypeBuilder(Reflex::Literal("boost::detail::sp_typeinfo"), type_13803);
@@ -127,6 +126,7 @@ namespace {
  ::Reflex::Type type_6780 = ::Reflex::PointerBuilder(type_5985);
  ::Reflex::Type type_6782 = ::Reflex::PointerBuilder(type_5985c);
  ::Reflex::Type type_2063 = ::Reflex::TypedefTypeBuilder(Reflex::Literal("std::size_t"), type_103);
+  ::Reflex::Type type_1928 = ::Reflex::TypedefTypeBuilder(Reflex::Literal("std::ptrdiff_t"), type_121);
  ::Reflex::Type type_2083c = ::Reflex::ConstBuilder(type_2083);
  ::Reflex::Type type_14096 = ::Reflex::ReferenceBuilder(type_2083c);
  ::Reflex::Type type_1848c = ::Reflex::ConstBuilder(type_1848);
@@ -624,11 +624,6 @@ static  void operator_13929( void* retad
  else   (((const ::boost::shared_ptr<reco::parser::SelectorBase>*)o)->operator->)();
}

-static  void operator_13930( void*, void* o, const std::vector<void*>& arg, void*)
-{
-  (((const ::boost::shared_ptr<reco::parser::SelectorBase>*)o)->operator[])(*(::std::ptrdiff_t*)arg[0]);
-}
-
static  void method_13931( void* retaddr, void* o, const std::vector<void*>&, void*)
{
  if (retaddr) *(void**)retaddr = Reflex::FuncToVoidPtr((((const ::boost::shared_ptr<reco::parser::SelectorBase>*)o)->get)());
@@ -724,7 +719,6 @@ void __boost__shared_ptr_reco__parser__S
  .AddFunctionMember(::Reflex::FunctionTypeBuilder(type_69), Reflex::Literal("reset"), method_13927, 0, 0, ::Reflex::PUBLIC)
  .AddFunctionMember(::Reflex::FunctionTypeBuilder(type_15339), Reflex::Literal("operator*"), operator_13928, 0, 0, ::Reflex::PUBLIC | ::Reflex::OPERATOR | ::Reflex::CONST)
  .AddFunctionMember(::Reflex::FunctionTypeBuilder(type_15414), Reflex::Literal("operator->"), operator_13929, 0, 0, ::Reflex::PUBLIC | ::Reflex::OPERATOR | ::Reflex::CONST)
-  .AddFunctionMember(::Reflex::FunctionTypeBuilder(type_69, type_1928), Reflex::Literal("operator[]"), operator_13930, 0, "i", ::Reflex::PUBLIC | ::Reflex::OPERATOR | ::Reflex::CONST)
  .AddFunctionMember(::Reflex::FunctionTypeBuilder(type_15414), Reflex::Literal("get"), method_13931, 0, 0, ::Reflex::PUBLIC | ::Reflex::CONST)
  .AddFunctionMember(::Reflex::FunctionTypeBuilder(type_15579), Reflex::Literal("operator reco::parser::SelectorBase* boost::shared_ptr<reco::parser::SelectorBase>::*"), converter_13932, 0, 0, ::Reflex::PUBLIC | ::Reflex::CONVERTER | ::Reflex::CONST)
  .AddFunctionMember(::Reflex::FunctionTypeBuilder(type_405), Reflex::Literal("operator!"), operator_13933, 0, 0, ::Reflex::PUBLIC | ::Reflex::OPERATOR | ::Reflex::CONST)
@@ -1098,11 +1092,6 @@ static  void operator_13908( void* retad
  else   (((const ::boost::shared_ptr<reco::parser::ExpressionBase>*)o)->operator->)();
}

-static  void operator_13909( void*, void* o, const std::vector<void*>& arg, void*)
-{
-  (((const ::boost::shared_ptr<reco::parser::ExpressionBase>*)o)->operator[])(*(::std::ptrdiff_t*)arg[0]);
-}
-
static  void method_13910( void* retaddr, void* o, const std::vector<void*>&, void*)
{
  if (retaddr) *(void**)retaddr = Reflex::FuncToVoidPtr((((const ::boost::shared_ptr<reco::parser::ExpressionBase>*)o)->get)());
@@ -1198,7 +1187,6 @@ void __boost__shared_ptr_reco__parser__E
  .AddFunctionMember(::Reflex::FunctionTypeBuilder(type_69), Reflex::Literal("reset"), method_13906, 0, 0, ::Reflex::PUBLIC)
  .AddFunctionMember(::Reflex::FunctionTypeBuilder(type_15333), Reflex::Literal("operator*"), operator_13907, 0, 0, ::Reflex::PUBLIC | ::Reflex::OPERATOR | ::Reflex::CONST)
  .AddFunctionMember(::Reflex::FunctionTypeBuilder(type_15408), Reflex::Literal("operator->"), operator_13908, 0, 0, ::Reflex::PUBLIC | ::Reflex::OPERATOR | ::Reflex::CONST)
-  .AddFunctionMember(::Reflex::FunctionTypeBuilder(type_69, type_1928), Reflex::Literal("operator[]"), operator_13909, 0, "i", ::Reflex::PUBLIC | ::Reflex::OPERATOR | ::Reflex::CONST)
  .AddFunctionMember(::Reflex::FunctionTypeBuilder(type_15408), Reflex::Literal("get"), method_13910, 0, 0, ::Reflex::PUBLIC | ::Reflex::CONST)
  .AddFunctionMember(::Reflex::FunctionTypeBuilder(type_15577), Reflex::Literal("operator reco::parser::ExpressionBase* boost::shared_ptr<reco::parser::ExpressionBase>::*"), converter_13911, 0, 0, ::Reflex::PUBLIC | ::Reflex::CONVERTER | ::Reflex::CONST)
  .AddFunctionMember(::Reflex::FunctionTypeBuilder(type_405), Reflex::Literal("operator!"), operator_13912, 0, 0, ::Reflex::PUBLIC | ::Reflex::OPERATOR | ::Reflex::CONST)
```

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
