### PR TITLE
SUSYBSMAnalysis/HSCP: fix Clang reported errors

### DIFF
--- a/SUSYBSMAnalysis/HSCP/plugins/HSCPTreeBuilder.cc
+++ b/SUSYBSMAnalysis/HSCP/plugins/HSCPTreeBuilder.cc
@@ -502,7 +502,7 @@ HSCPTreeBuilder::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
        Hscp_hasCalo         [NHSCPs] = hscp.hasCaloInfo();
        Hscp_type            [NHSCPs] = hscp.type();
 
-      if(track.isNonnull() && Hscp_hasTrack){
+      if(track.isNonnull() && Hscp_hasTrack[NHSCPs]){
          Track_p            [NHSCPs] = track->p();
          Track_pt           [NHSCPs] = track->pt();
          Track_pt_err       [NHSCPs] = track->ptError();
@@ -538,7 +538,7 @@ HSCPTreeBuilder::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
 */
       }
 
-      if(muon.isNonnull() && Hscp_hasMuon){
+      if(muon.isNonnull() && Hscp_hasMuon[NHSCPs]){
          Muon_p             [NHSCPs] = muon->p();
          Muon_pt            [NHSCPs] = muon->pt();
          Muon_eta           [NHSCPs] = muon->eta();
@@ -592,7 +592,7 @@ HSCPTreeBuilder::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
 */
       }
 
-      if(Hscp_hasRpc){
+      if(Hscp_hasRpc[NHSCPs]){
          Rpc_beta           [NHSCPs] = hscp.rpc().beta;
       }
 


### PR DESCRIPTION
`Hscp_hasTrack`, `Hscp_hasMuon` and `Hscp_hasRpc` are bool arrays (not
dynamically alloced). Bool conversion on the address of the array
will always return true.

I believe, the intention was to do, e.g., `Hscp_hasTrack[NHSCPs]`

**This is a guess based on the code, verify that the changes are correct before approving**

This is definitely a bug in the code.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
