### PR TITLE
GeneratorInterface/Core: drop VLA of non-POD type

### DIFF
--- a/GeneratorInterface/Core/plugins/GenXSecAnalyzer.cc
+++ b/GeneratorInterface/Core/plugins/GenXSecAnalyzer.cc
@@ -377,7 +377,7 @@ GenXSecAnalyzer::endJob() {
 
   const int sizeOfInfos= theProcesses_size+1;
   const int last = sizeOfInfos-1;
-  std::string title[sizeOfInfos];
+  std::string * title = new std::string[sizeOfInfos];
 
   for(int i=0; i < sizeOfInfos; i++){
 
@@ -425,6 +425,7 @@ GenXSecAnalyzer::endJob() {
 
 
   }
+  delete [] title;
 
   edm::LogPrint("GenXSecAnalyzer") 
     << "--------------------------------------------------------------------------------------------------------------------------------------------------------------------------";


### PR DESCRIPTION
The patch resolves Clang compile errors regarding usage of VLA with
non-POD types. VLA are not part of C++ standard. It's GNU extension
originating from GCC. Use a standard array on the heap instead as
performance is not a priority in `endJob()`.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
