### PR TITLE
Adding dEtaInSeed  and r9_5x5 to HLT

### DIFF
--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTGsfTrackVarProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTGsfTrackVarProducer.cc
@@ -41,6 +41,7 @@ EgammaHLTGsfTrackVarProducer::EgammaHLTGsfTrackVarProducer(const edm::ParameterS
  
   //register your products
   produces < reco::RecoEcalCandidateIsolationMap >( "Deta" ).setBranchAlias( "deta" );
+  produces < reco::RecoEcalCandidateIsolationMap >( "DetaSeed" ).setBranchAlias( "detaSeed" );
   produces < reco::RecoEcalCandidateIsolationMap >( "Dphi" ).setBranchAlias( "dphi" );
   produces < reco::RecoEcalCandidateIsolationMap >( "OneOESuperMinusOneOP" );
   produces < reco::RecoEcalCandidateIsolationMap >( "OneOESeedMinusOneOP" );
@@ -83,6 +84,7 @@ void EgammaHLTGsfTrackVarProducer::produce(edm::Event& iEvent, const edm::EventS
   iSetup.get<IdealMagneticFieldRecord>().get(theMagField);
 
   reco::RecoEcalCandidateIsolationMap dEtaMap;
+  reco::RecoEcalCandidateIsolationMap dEtaSeedMap;
   reco::RecoEcalCandidateIsolationMap dPhiMap;
   reco::RecoEcalCandidateIsolationMap oneOverESuperMinusOneOverPMap;
   reco::RecoEcalCandidateIsolationMap oneOverESeedMinusOneOverPMap;
@@ -92,7 +94,7 @@ void EgammaHLTGsfTrackVarProducer::produce(edm::Event& iEvent, const edm::EventS
     reco::RecoEcalCandidateRef recoEcalCandRef(recoEcalCandHandle,iRecoEcalCand-recoEcalCandHandle->begin());
    
     const reco::SuperClusterRef scRef = recoEcalCandRef->superCluster();
-   
+ 
     //the idea is that we can take the tracks from properly associated electrons or just take all gsf tracks with that sc as a seed
     std::vector<const reco::GsfTrack*> gsfTracks;
     if(electronHandle.isValid()){
@@ -116,18 +118,18 @@ void EgammaHLTGsfTrackVarProducer::produce(edm::Event& iEvent, const edm::EventS
 
     float missingHitsValue = 9999999;
     float dEtaInValue=999999;
+    float dEtaInSeedValue=999999;
     float dPhiInValue=999999;
     float oneOverESuperMinusOneOverPValue=999999;
     float oneOverESeedMinusOneOverPValue=999999;
     
-    if(static_cast<int>(gsfTracks.size())>=upperTrackNrToRemoveCut_){
+    if(static_cast<int>(gsfTracks.size())>=upperTrackNrToRemoveCut_ || static_cast<int>(gsfTracks.size())<=lowerTrackNrToRemoveCut_ ){
       dEtaInValue=0;
+      dEtaInSeedValue=0;
       dPhiInValue=0;
       missingHitsValue = 0;
-    }else if(static_cast<int>(gsfTracks.size())<=lowerTrackNrToRemoveCut_){
-      dEtaInValue=0;
-      dPhiInValue=0;
-      missingHitsValue = 0;
+      oneOverESuperMinusOneOverPValue=0;
+      oneOverESeedMinusOneOverPValue=0;
     }else{
       for(size_t trkNr=0;trkNr<gsfTracks.size();trkNr++){
       
@@ -145,29 +147,37 @@ void EgammaHLTGsfTrackVarProducer::produce(edm::Event& iEvent, const edm::EventS
 	}
 
 	if (gsfTracks[trkNr]->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS) < missingHitsValue){ 
-        missingHitsValue = gsfTracks[trkNr]->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS);
-    }
+	  missingHitsValue = gsfTracks[trkNr]->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS);
+	}
 
-	if (fabs(scAtVtx.dEta())<dEtaInValue) 
-	  dEtaInValue=fabs(scAtVtx.dEta()); //we are allowing them to come from different tracks
-	if (fabs(scAtVtx.dPhi())<dPhiInValue) 
-	  dPhiInValue=fabs(scAtVtx.dPhi());//we are allowing them to come from different tracks
+	if (fabs(scAtVtx.dEta())<dEtaInValue) dEtaInValue=fabs(scAtVtx.dEta()); //we are allowing them to come from different tracks
+	if (fabs(scAtVtx.dPhi())<dPhiInValue) dPhiInValue=fabs(scAtVtx.dPhi());//we are allowing them to come from different tracks
+	//so a SC should *always* have a seed, this is a code configuration error,
+	//so we'll check to be sure but cause the cut to fail if theres not SC so its quickly spotted
+	if(scRef->seed().isNonnull()){
+	  float dEtaInSeedAbs = fabs(scAtVtx.dEta()-scRef->eta()+scRef->seed()->eta());
+	  if(dEtaInSeedAbs<dEtaInSeedValue) dEtaInSeedValue=dEtaInSeedAbs;
+	}
+      
       }	
     }
    
     dEtaMap.insert(recoEcalCandRef, dEtaInValue);
+    dEtaSeedMap.insert(recoEcalCandRef,dEtaInSeedValue);
     dPhiMap.insert(recoEcalCandRef, dPhiInValue);
     oneOverESuperMinusOneOverPMap.insert(recoEcalCandRef,oneOverESuperMinusOneOverPValue);   
     oneOverESeedMinusOneOverPMap.insert(recoEcalCandRef,oneOverESeedMinusOneOverPValue);
     missingHitsMap.insert(recoEcalCandRef, missingHitsValue);
   }
 
-  std::auto_ptr<reco::RecoEcalCandidateIsolationMap> dEtaMapForEvent(new reco::RecoEcalCandidateIsolationMap(dEtaMap));
+  std::auto_ptr<reco::RecoEcalCandidateIsolationMap> dEtaMapForEvent(new reco::RecoEcalCandidateIsolationMap(dEtaMap)); 
+  std::auto_ptr<reco::RecoEcalCandidateIsolationMap> dEtaSeedMapForEvent(new reco::RecoEcalCandidateIsolationMap(dEtaSeedMap));
   std::auto_ptr<reco::RecoEcalCandidateIsolationMap> dPhiMapForEvent(new reco::RecoEcalCandidateIsolationMap(dPhiMap));
   std::auto_ptr<reco::RecoEcalCandidateIsolationMap> oneOverESuperMinusOneOverPMapForEvent(new reco::RecoEcalCandidateIsolationMap(oneOverESuperMinusOneOverPMap));
   std::auto_ptr<reco::RecoEcalCandidateIsolationMap> oneOverESeedMinusOneOverPMapForEvent(new reco::RecoEcalCandidateIsolationMap(oneOverESeedMinusOneOverPMap));
   std::auto_ptr<reco::RecoEcalCandidateIsolationMap> missingHitsForEvent(new reco::RecoEcalCandidateIsolationMap(missingHitsMap));
   iEvent.put(dEtaMapForEvent, "Deta" );
+  iEvent.put(dEtaSeedMapForEvent,"DetaSeed");
   iEvent.put(dPhiMapForEvent, "Dphi" );
   iEvent.put(oneOverESuperMinusOneOverPMapForEvent,"OneOESuperMinusOneOP");
   iEvent.put(oneOverESeedMinusOneOverPMapForEvent,"OneOESeedMinusOneOP");

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTR9IDProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTR9IDProducer.cc
@@ -33,6 +33,7 @@ EgammaHLTR9IDProducer::EgammaHLTR9IDProducer(const edm::ParameterSet& config) : 
 
   //register your products
   produces < reco::RecoEcalCandidateIsolationMap >();
+  produces < reco::RecoEcalCandidateIsolationMap >("r95x5");
 }
 
 EgammaHLTR9IDProducer::~EgammaHLTR9IDProducer(){}
@@ -55,26 +56,35 @@ void EgammaHLTR9IDProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
   iEvent.getByToken(recoEcalCandidateProducer_, recoecalcandHandle);
 
   EcalClusterLazyTools lazyTools( iEvent, iSetup, ecalRechitEBToken_, ecalRechitEEToken_ );
-  
+  noZS::EcalClusterLazyTools lazyTools5x5(iEvent, iSetup, ecalRechitEBToken_, ecalRechitEEToken_ );
   reco::RecoEcalCandidateIsolationMap r9Map;
-   
+  reco::RecoEcalCandidateIsolationMap r95x5Map; 
   for(unsigned  int iRecoEcalCand=0; iRecoEcalCand<recoecalcandHandle->size(); iRecoEcalCand++) {
     
     reco::RecoEcalCandidateRef recoecalcandref(recoecalcandHandle, iRecoEcalCand);//-recoecalcandHandle->begin());
 
     float r9 = -1;
+    float r95x5 = -1;
 
     float e9 = lazyTools.e3x3( *(recoecalcandref->superCluster()->seed()) );
+    float e95x5 = lazyTools5x5.e3x3( *(recoecalcandref->superCluster()->seed()) );
+
     float eraw = recoecalcandref->superCluster()->rawEnergy();
-    if (eraw > 0. ) {r9 = e9/eraw;}
+    if (eraw > 0. ) {
+      r9 = e9/eraw;
+      r95x5 = e95x5/eraw;
+    }
 
     r9Map.insert(recoecalcandref, r9);
+    r95x5Map.insert(recoecalcandref,r95x5);
     
   }
 
   std::auto_ptr<reco::RecoEcalCandidateIsolationMap> R9Map(new reco::RecoEcalCandidateIsolationMap(r9Map));
   iEvent.put(R9Map);
 
+  std::auto_ptr<reco::RecoEcalCandidateIsolationMap> R95x5Map(new reco::RecoEcalCandidateIsolationMap(r95x5Map));
+  iEvent.put(R95x5Map,"r95x5");
 }
 
 //define this as a plug-in


### PR DESCRIPTION
This patch makes dEtaInSeed and r9 5x5 available at the HLT. It is fully backwards compatible with all HLT menus, just adds 2 new value maps into the event for the producers to pick up. 
