### PR TITLE
Making dEtaIn seed available for ID purposes

### DIFF
--- a/DataFormats/EgammaCandidates/interface/GsfElectron.h
+++ b/DataFormats/EgammaCandidates/interface/GsfElectron.h
@@ -250,6 +250,9 @@ class GsfElectron : public RecoCandidate
     float deltaPhiSuperClusterTrackAtVtx() const { return trackClusterMatching_.deltaPhiSuperClusterAtVtx ; }
     float deltaPhiSeedClusterTrackAtCalo() const { return trackClusterMatching_.deltaPhiSeedClusterAtCalo ; }
     float deltaPhiEleClusterTrackAtCalo() const { return trackClusterMatching_.deltaPhiEleClusterAtCalo ; }
+    float deltaEtaSeedClusterTrackAtVtx() const { return superCluster().isNonnull() && superCluster()->seed().isNonnull() ? 
+	trackClusterMatching_.deltaEtaSuperClusterAtVtx - superCluster()->eta() + superCluster()->seed()->eta() : std::numeric_limits<float>::max();
+    }
     const TrackClusterMatching & trackClusterMatching() const { return trackClusterMatching_ ; }
 
     // for backward compatibility, usefull ?

--- a/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleDEtaInSeedCut.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleDEtaInSeedCut.cc
@@ -1,0 +1,34 @@
+#include "PhysicsTools/SelectorUtils/interface/CutApplicatorBase.h"
+#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
+
+class GsfEleDEtaInSeedCut : public CutApplicatorBase {
+public:
+  GsfEleDEtaInSeedCut(const edm::ParameterSet& c) :
+    CutApplicatorBase(c),
+    _dEtaInSeedCutValueEB(c.getParameter<double>("dEtaInSeedCutValueEB")),
+    _dEtaInSeedCutValueEE(c.getParameter<double>("dEtaInSeedCutValueEE")),
+    _barrelCutOff(c.getParameter<double>("barrelCutOff")){    
+  }
+  
+  result_type operator()(const reco::GsfElectronPtr&) const override final;
+
+  CandidateType candidateType() const override final { 
+    return ELECTRON; 
+  }
+
+private:
+  const double _dEtaInSeedCutValueEB,_dEtaInSeedCutValueEE,_barrelCutOff;
+};
+
+DEFINE_EDM_PLUGIN(CutApplicatorFactory,
+		  GsfEleDEtaInSeedCut,
+		  "GsfEleDEtaInSeedCut");
+
+CutApplicatorBase::result_type 
+GsfEleDEtaInSeedCut::
+operator()(const reco::GsfElectronPtr& cand) const{  
+  const float dEtaInSeedCutValue = 
+    ( std::abs(cand->superCluster()->position().eta()) < _barrelCutOff ? 
+      _dEtaInSeedCutValueEB : _dEtaInSeedCutValueEE );
+  return std::abs(cand->deltaEtaSeedClusterTrackAtVtx()) < dEtaInSeedCutValue;
+}


### PR DESCRIPTION
This pull request simplifies the calculation of the new ID variable dEtaInSeed presented recently in the e/gamma meeting. As the name suggests, it is dEtaIn but computed using the eta of the seed cluster rather than the supercluster. It is simply dEtaIn-sc eta + seed eta. I have added a function to GsfElectron which makes it, it would be nice if we could have this, it just simplifies things and avoids mistakes but we can live without.

I have also added a class to the ID framework which can cut on this variable. 
