### PR TITLE
Minimal (temporary) solution to automatically switch between 25ns and 50ns configs in ecal local reco

### DIFF
--- a/FastSimulation/PileUpProducer/plugins/PileUpProducer.cc
+++ b/FastSimulation/PileUpProducer/plugins/PileUpProducer.cc
@@ -267,7 +267,7 @@ void PileUpProducer::produce(edm::Event & iEvent, const edm::EventSetup & es)
   std::vector<float> trueInteractionList;
   trueInteractionList.push_back(truePUevts);
   
-  PileupMixing_ = std::auto_ptr< PileupMixingContent >(new PileupMixingContent(bunchCrossingList,numInteractionList,trueInteractionList,25)); // it shouldn't matter what the assumed bunchspacing is if there is no OOT PU. Add argument for compatibility.
+  PileupMixing_ = std::auto_ptr< PileupMixingContent >(new PileupMixingContent(bunchCrossingList,numInteractionList,trueInteractionList,450)); // it shouldn't matter what the assumed bunchspacing is if there is no OOT PU. Add argument for compatibility.
   iEvent.put(PileupMixing_);
 
   // Get N events from random files

--- a/RecoLocalCalo/EcalRecProducers/interface/EcalUncalibRecHitWorkerBaseClass.h
+++ b/RecoLocalCalo/EcalRecProducers/interface/EcalUncalibRecHitWorkerBaseClass.h
@@ -18,6 +18,7 @@ class EcalUncalibRecHitWorkerBaseClass {
                 virtual ~EcalUncalibRecHitWorkerBaseClass(){}
 
                 virtual void set(const edm::EventSetup& es) = 0;
+                virtual void set(const edm::Event& evt) {}
                 virtual bool run(const edm::Event& evt, const EcalDigiCollection::const_iterator & digi, EcalUncalibratedRecHitCollection & result) = 0;
 };
 

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitProducer.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitProducer.cc
@@ -54,6 +54,7 @@ EcalUncalibRecHitProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
 
         // tranparently get things from event setup
         worker_->set(es);
+        worker_->set(evt);
 
         // prepare output
         std::auto_ptr< EBUncalibratedRecHitCollection > ebUncalibRechits( new EBUncalibratedRecHitCollection );

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
@@ -40,7 +40,7 @@ EcalUncalibRecHitWorkerMultiFit::EcalUncalibRecHitWorkerMultiFit(const edm::Para
   useLumiInfoRunHeader_ = ps.getParameter<bool>("useLumiInfoRunHeader");
   
   if (useLumiInfoRunHeader_) {
-    pileupSummaryInfos_ = c.consumes<std::vector<PileupSummaryInfo> >(edm::InputTag("addPileupInfo"));
+    bunchSpacing_ = c.consumes<int>(edm::InputTag("addPileupInfo","bunchSpacing"));
   }
 
   // algorithm to be used for timing
@@ -158,9 +158,9 @@ EcalUncalibRecHitWorkerMultiFit::set(const edm::Event& evt)
       }
     }
     else {
-      edm::Handle<std::vector<PileupSummaryInfo> > pileupSummaryInfosH;
-      evt.getByToken(pileupSummaryInfos_,pileupSummaryInfosH);
-      bunchspacing = pileupSummaryInfosH->front().getBunchSpacing();
+      edm::Handle<int> bunchSpacingH;
+      evt.getByToken(bunchSpacing_,bunchSpacingH);
+      bunchspacing = *bunchSpacingH;
     }
     
     if (bunchspacing == 25) {
@@ -173,7 +173,7 @@ EcalUncalibRecHitWorkerMultiFit::set(const edm::Event& evt)
       activeBX << -4,-2,0,2,4;
     }
   }
-    
+ 
 }
 
 /**

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.h
@@ -26,7 +26,7 @@
 #include "CondFormats/EcalObjects/interface/EcalSampleMask.h"
 #include "CondFormats/EcalObjects/interface/EcalTimeBiasCorrections.h"
 #include "RecoLocalCalo/EcalRecAlgos/interface/EigenMatrixTypes.h"
-
+#include "SimDataFormats/PileupSummaryInfo/interface/PileupSummaryInfo.h"
 
 namespace edm {
         class Event;
@@ -41,8 +41,9 @@ class EcalUncalibRecHitWorkerMultiFit : public EcalUncalibRecHitWorkerBaseClass 
 				//EcalUncalibRecHitWorkerMultiFit(const edm::ParameterSet&);
                 virtual ~EcalUncalibRecHitWorkerMultiFit() {};
 
-                void set(const edm::EventSetup& es);
-                bool run(const edm::Event& evt, const EcalDigiCollection::const_iterator & digi, EcalUncalibratedRecHitCollection & result);
+                void set(const edm::EventSetup& es) override;
+                void set(const edm::Event& evt) override;
+                bool run(const edm::Event& evt, const EcalDigiCollection::const_iterator & digi, EcalUncalibratedRecHitCollection & result) override;
 
         protected:
 
@@ -73,8 +74,10 @@ class EcalUncalibRecHitWorkerMultiFit : public EcalUncalibRecHitWorkerBaseClass 
                 FullSampleMatrix fullpulsecovEE;
                 BXVector activeBX;
                 bool ampErrorCalculation_;
+                bool useLumiInfoRunHeader_;
                 EcalUncalibRecHitMultiFitAlgo multiFitMethod_;
                 
+                edm::EDGetTokenT<std::vector<PileupSummaryInfo> > pileupSummaryInfos_; 
 
                 // determine which of the samples must actually be used by ECAL local reco
                 edm::ESHandle<EcalSampleMask> sampleMaskHand_;                

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.h
@@ -26,7 +26,6 @@
 #include "CondFormats/EcalObjects/interface/EcalSampleMask.h"
 #include "CondFormats/EcalObjects/interface/EcalTimeBiasCorrections.h"
 #include "RecoLocalCalo/EcalRecAlgos/interface/EigenMatrixTypes.h"
-#include "SimDataFormats/PileupSummaryInfo/interface/PileupSummaryInfo.h"
 
 namespace edm {
         class Event;
@@ -77,7 +76,7 @@ class EcalUncalibRecHitWorkerMultiFit : public EcalUncalibRecHitWorkerBaseClass 
                 bool useLumiInfoRunHeader_;
                 EcalUncalibRecHitMultiFitAlgo multiFitMethod_;
                 
-                edm::EDGetTokenT<std::vector<PileupSummaryInfo> > pileupSummaryInfos_; 
+                edm::EDGetTokenT<int> bunchSpacing_; 
 
                 // determine which of the samples must actually be used by ECAL local reco
                 edm::ESHandle<EcalSampleMask> sampleMaskHand_;                

--- a/RecoLocalCalo/EcalRecProducers/python/ecalLocalCustom.py
+++ b/RecoLocalCalo/EcalRecProducers/python/ecalLocalCustom.py
@@ -1,10 +1,17 @@
 
 import FWCore.ParameterSet.Config as cms
 
+def configureEcalLocal25ns(process):
+    process.ecalMultiFitUncalibRecHit.activeBXs = cms.vint32(-5,-4,-3,-2,-1,0,1,2,3,4),
+    process.ecalMultiFitUncalibRecHit.useLumiInfoRunHeader = False
+    return process
+
 def configureEcalLocal50ns(process):
     process.ecalMultiFitUncalibRecHit.activeBXs = cms.vint32(-4,-2,0,2,4)
+    process.ecalMultiFitUncalibRecHit.useLumiInfoRunHeader = False
     return process
   
 def configureEcalLocalNoOOTPU(process):
     process.ecalMultiFitUncalibRecHit.activeBXs = cms.vint32(0)
+    process.ecalMultiFitUncalibRecHit.useLumiInfoRunHeader = False
     return process

--- a/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cfi.py
+++ b/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cfi.py
@@ -12,6 +12,7 @@ ecalMultiFitUncalibRecHit = cms.EDProducer("EcalUncalibRecHitProducer",
     EcalPulseShapeParameters = cms.PSet( ecal_pulse_shape_parameters ),
     activeBXs = cms.vint32(-5,-4,-3,-2,-1,0,1,2,3,4),
     ampErrorCalculation = cms.bool(True),
+    useLumiInfoRunHeader = cms.bool(True),
 
     # decide which algorithm to be use to calculate the jitter
     timealgo = cms.string("RatioMethod"),

--- a/SimGeneral/Configuration/python/SimGeneral_EventContent_cff.py
+++ b/SimGeneral/Configuration/python/SimGeneral_EventContent_cff.py
@@ -10,14 +10,17 @@ SimGeneralFEVTDEBUG = cms.PSet(
 #RAW content
 SimGeneralRAW = cms.PSet(
     outputCommands = cms.untracked.vstring('keep CrossingFramePlaybackInfoExtended_*_*_*',
-                                           'keep PileupSummaryInfos_*_*_*')
+                                           'keep PileupSummaryInfos_*_*_*',
+                                           'keep int_addPileupInfo_bunchSpacing_*')
 )
 #RECO content
 SimGeneralRECO = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep PileupSummaryInfos_*_*_*')
+    outputCommands = cms.untracked.vstring('keep PileupSummaryInfos_*_*_*',
+                                           'keep int_addPileupInfo_bunchSpacing_*')
 )
 #AOD content
 SimGeneralAOD = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep PileupSummaryInfos_*_*_*')
+    outputCommands = cms.untracked.vstring('keep PileupSummaryInfos_*_*_*',
+                                           'keep int_addPileupInfo_bunchSpacing_*')
 )
 

--- a/SimGeneral/MixingModule/python/mixNoPU_cfi.py
+++ b/SimGeneral/MixingModule/python/mixNoPU_cfi.py
@@ -13,7 +13,7 @@ mix = cms.EDProducer("MixingModule",
     maxBunch = cms.int32(3),
     minBunch = cms.int32(-5), ## in terms of 25 ns
 
-    bunchspace = cms.int32(25),
+    bunchspace = cms.int32(450),
     mixProdStep1 = cms.bool(False),
     mixProdStep2 = cms.bool(False),
 

--- a/SimGeneral/PileupInformation/plugins/PileupInformation.cc
+++ b/SimGeneral/PileupInformation/plugins/PileupInformation.cc
@@ -48,6 +48,7 @@ PileupInformation::PileupInformation(const edm::ParameterSet & config)
 
 
     produces< std::vector<PileupSummaryInfo> >();
+    produces<int>("bunchSpacing");
     //produces<PileupSummaryInfo>();
 }
 
@@ -337,6 +338,9 @@ void PileupInformation::produce(edm::Event &event, const edm::EventSetup & setup
 
   event.put(PSIVector);
 
+  //add bunch spacing to the event as a seperate integer for use by downstream modules
+  std::auto_ptr<int> bunchSpacingP(new int(bunchSpacing));
+  event.put(bunchSpacingP,"bunchSpacing");
 
 }
 

--- a/Validation/Configuration/python/ECALHCAL.py
+++ b/Validation/Configuration/python/ECALHCAL.py
@@ -66,7 +66,7 @@ def customise(process):
             cms.InputTag("interestingEcalDetIdEE"),
             )            
 
-    process.local_digireco = cms.Path(process.mix * process.calDigi * process.ecalPacker * process.esDigiToRaw * process.hcalRawData * process.rawDataCollector * process.ecalDigis * process.ecalPreshowerDigis * process.hcalDigis * process.calolocalreco *(process.ecalClustersNoPFBox+process.caloTowersRec) * process.reducedEcalRecHitsSequenceEcalOnly )
+    process.local_digireco = cms.Path(process.mix * process.addPileupInfo * process.calDigi * process.ecalPacker * process.esDigiToRaw * process.hcalRawData * process.rawDataCollector * process.ecalDigis * process.ecalPreshowerDigis * process.hcalDigis * process.calolocalreco *(process.ecalClustersNoPFBox+process.caloTowersRec) * process.reducedEcalRecHitsSequenceEcalOnly )
 
     process.schedule.append(process.local_digireco)
 


### PR DESCRIPTION
Minimal, but temporary solution which puts the isRealData call directly in the ecal local reco (and reads the pileupSummaryInfo in the mc case)

Default bunchspacing for no OOT pileup needed to be changed for both fullsim and fastsim (should have no physics effect, but changes what gets written in the pileupSummaryInfo)

Any cleaner solution should go in the direction of the desired long term solution (ie fixing properly https://github.com/cms-sw/cmssw/pull/6281 )
