### PR TITLE
remove jet corrections from endpath that is already on the dqm path 

### DIFF
--- a/Configuration/StandardSequences/python/Validation_cff.py
+++ b/Configuration/StandardSequences/python/Validation_cff.py
@@ -25,7 +25,7 @@ from Validation.MuonIdentification.muonIdVal_cff import *
 from Validation.RecoMuon.muonValidationHLT_cff import *
 from Validation.EventGenerator.BasicGenValidation_cff import *
 
-prevalidation = cms.Sequence( globalPrevalidation * hltassociation )
+prevalidation = cms.Sequence( globalPrevalidation * hltassociation * metPreValidSeq )
 prevalidationLiteTracking = cms.Sequence( prevalidation )
 prevalidationLiteTracking.replace(globalPrevalidation,globalPrevalidationLiteTracking)
 

--- a/FastSimulation/Configuration/python/Validation_cff.py
+++ b/FastSimulation/Configuration/python/Validation_cff.py
@@ -3,8 +3,9 @@ from Validation.EventGenerator.BasicGenValidation_cff import *
 from FastSimulation.Validation.globalValidation_cff import *
 from HLTriggerOffline.Common.HLTValidation_cff import *
 from DQM.Physics.DQMPhysics_cff import *
+from Validation.RecoMET.METRelValForDQM_cff import metPreValidSeq
 
-prevalidation = cms.Sequence(globalAssociation+hltassociation_fastsim)
+prevalidation = cms.Sequence(globalAssociation+hltassociation_fastsim+metPreValidSeq)
 prevalidation_preprod = cms.Sequence(globalAssociation)
 prevalidation_prod = cms.Sequence(globalAssociation)
 validation = cms.Sequence(basicGenTest_seq+globalValidation+hltvalidation_fastsim+dqmPhysics) 

--- a/Validation/RecoMET/python/METRelValForDQM_cff.py
+++ b/Validation/RecoMET/python/METRelValForDQM_cff.py
@@ -21,6 +21,10 @@ newAK4PFL1FastL2L3CorrectorChain = cms.Sequence(
     #ak4PFL1FastjetCorrector * ak4PFL2RelativeCorrector * ak4PFL3AbsoluteCorrector * 
     newAK4PFL1FastL2L3Corrector
 )
+
+metPreValidSeq=cms.Sequence(ak4PFL1FastjetCorrector * ak4PFL2RelativeCorrector * ak4PFL3AbsoluteCorrector)
+
+
 corrPfMetType1.jetCorrLabel = cms.InputTag('newAK4PFL1FastL2L3Corrector')
 
 METRelValSequence = cms.Sequence(

--- a/Validation/RecoMET/python/METRelValForDQM_cff.py
+++ b/Validation/RecoMET/python/METRelValForDQM_cff.py
@@ -18,7 +18,8 @@ from JetMETCorrections.Type1MET.correctionTermsPfMetType1Type2_cff import corrPf
 from JetMETCorrections.Configuration.JetCorrectors_cff import ak4PFL1FastL2L3Corrector,ak4PFL1FastjetCorrector,ak4PFL2RelativeCorrector,ak4PFL3AbsoluteCorrector
 newAK4PFL1FastL2L3Corrector = ak4PFL1FastL2L3Corrector.clone()
 newAK4PFL1FastL2L3CorrectorChain = cms.Sequence(
-    ak4PFL1FastjetCorrector * ak4PFL2RelativeCorrector * ak4PFL3AbsoluteCorrector * newAK4PFL1FastL2L3Corrector
+    #ak4PFL1FastjetCorrector * ak4PFL2RelativeCorrector * ak4PFL3AbsoluteCorrector * 
+    newAK4PFL1FastL2L3Corrector
 )
 corrPfMetType1.jetCorrLabel = cms.InputTag('newAK4PFL1FastL2L3Corrector')
 


### PR DESCRIPTION
to make unscheduled mode happier

Note that I'm not clear as to why newAK4PFL1FastL2L3Corrector is needed it all. Perhaps we could gain some tiny CPU gain by just using the already running module ak4PFL1FastL2L3Corrector here?
