### PR TITLE
remove reduced ES hits from Shashlik configuration

### DIFF
--- a/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
@@ -140,6 +140,7 @@ def cust_2023SHCal(process):
 
     if hasattr(process,'reconstruction_step'):
     	process.ecalRecHit.EEuncalibRecHitCollection = cms.InputTag("","")
+        process.reducedEcalRecHitsSequence.remove(process.reducedEcalRecHitsES)
         #remove the old EE pfrechit producer
         del process.particleFlowRecHitECAL.producers[1]
         process.particleFlowClusterEBEKMerger = cms.EDProducer('PFClusterCollectionMerger',


### PR DESCRIPTION
One-line fix in the Shashlik customization to get rid of the warning:

> %MSG-e WrongGeometry:   ReducedESRecHitCollectionProducer:reducedEcalRecHitsES@beginRun  10-Nov-2014 17:34:54 CET Run: 1
> could not cast the subdet geometry to preshower geometry
