### PR TITLE
If test fails, return a non-zero exit code

### DIFF
--- a/CondCore/DBCommon/test/testCondObjCopy.cc
+++ b/CondCore/DBCommon/test/testCondObjCopy.cc
@@ -51,9 +51,13 @@ int main(){
     std::cout<<"committed"<<std::endl;
   }catch(cond::Exception& er){
     std::cout<<er.what()<<std::endl;
+    return -1;
   }catch(std::exception& er){
     std::cout<<er.what()<<std::endl;
+    return -1;
   }catch(...){
     std::cout<<"Funny error"<<std::endl;
+    return -1;
   }
+  return 0;
 }

--- a/CondCore/DBCommon/test/testDbSession.cc
+++ b/CondCore/DBCommon/test/testDbSession.cc
@@ -58,6 +58,7 @@ int main(){
     std::cout << "Session is correctly open."<<std::endl;
   } catch ( const cond::Exception& exc ){
     std::cout << "ERROR: "<<exc.what()<<std::endl;
+    return -1;
   }
     std::cout << "######### test 6"<<std::endl;
   s.close();
@@ -73,6 +74,7 @@ int main(){
     s2.transaction().commit();    
   } catch ( const cond::Exception& exc ){
     std::cout << "ERROR: "<<exc.what()<<std::endl;
+    return -1;
   }
     std::cout << "######### test 8"<<std::endl;
   // closing connection...
@@ -89,5 +91,6 @@ int main(){
   } catch ( const ora::Exception& exc ){
     std::cout << "Expected error: "<<exc.what()<<std::endl;
   }
+  return 0;
   
 }

--- a/CondCore/DBCommon/test/testDbSessionIO.cc
+++ b/CondCore/DBCommon/test/testDbSessionIO.cc
@@ -91,5 +91,7 @@ int main(){
     s0.transaction().commit();    
   } catch ( const cond::Exception& exc ){
     std::cout << "ERROR: "<<exc.what()<<std::endl;
+    return -1;
   } 
+  return 0;
 }

--- a/CondCore/DBCommon/test/testTechnologyPlugin.cc
+++ b/CondCore/DBCommon/test/testTechnologyPlugin.cc
@@ -47,6 +47,7 @@ int main(){
     }
   } catch ( const std::exception & er) {
     std::cout << "Error: " << er.what()<<std::endl;
+    return -1;
   } 
   return 0;
 }

--- a/CondCore/IOVService/test/testIOVCopy.cc
+++ b/CondCore/IOVService/test/testIOVCopy.cc
@@ -59,7 +59,10 @@ int main(){
     std::cout<<"editor deleted"<<std::endl;
   }catch(const cond::Exception& er){
     std::cout<<"error "<<er.what()<<std::endl;
+    return -1;
   }catch(const std::exception& er){
     std::cout<<"std error "<<er.what()<<std::endl;
+    return -1;
   }
+  return 0;
 }

--- a/CondCore/IOVService/test/testIOVDelete.cc
+++ b/CondCore/IOVService/test/testIOVDelete.cc
@@ -42,7 +42,10 @@ int main(){
     pooldb.transaction().commit();
   }catch(const cond::Exception& er){
     std::cout<<"error "<<er.what()<<std::endl;
+    return -1;
   }catch(const std::exception& er){
     std::cout<<"std error "<<er.what()<<std::endl;
+    return -1;
   }
+  return 0;
 }

--- a/CondCore/IOVService/test/testIOVEditor.cc
+++ b/CondCore/IOVService/test/testIOVEditor.cc
@@ -196,7 +196,10 @@ int main(){
 
   }catch(const cond::Exception& er){
     std::cout<<"error "<<er.what()<<std::endl;
+    return -1;
   }catch(const std::exception& er){
     std::cout<<"std error "<<er.what()<<std::endl;
+    return -1;
   }
+  return 0;
 }

--- a/CondCore/IOVService/test/testIOVIterator.cc
+++ b/CondCore/IOVService/test/testIOVIterator.cc
@@ -202,7 +202,10 @@ int main(){
     }
   }catch(const cond::Exception& er){
     std::cout<<"error "<<er.what()<<std::endl;
+    return -1;
   }catch(const std::exception& er){
     std::cout<<"std error "<<er.what()<<std::endl;
+    return -1;
   }
+  return 0;
 }

--- a/CondCore/IOVService/test/testIOVReplaceInterval.cc
+++ b/CondCore/IOVService/test/testIOVReplaceInterval.cc
@@ -88,7 +88,10 @@ int main(){
     delete session;
   }catch(const cond::Exception& er){
     std::cout<<"error "<<er.what()<<std::endl;
+    return -1;
   }catch(const std::exception& er){
     std::cout<<"std error "<<er.what()<<std::endl;
+    return -1;
   }
+  return 0;
 }

--- a/CondCore/IOVService/test/testqueryPContainer.cc
+++ b/CondCore/IOVService/test/testqueryPContainer.cc
@@ -40,7 +40,10 @@ int main(){
     }
   }catch(const cond::Exception& er){
     std::cout<<"error "<<er.what()<<std::endl;
+    return -1;
   }catch(const std::exception& er){
     std::cout<<"std error "<<er.what()<<std::endl;
+    return -1;
   }
+  return 0;
 }

--- a/CondCore/ORA/test/TestBase.h
+++ b/CondCore/ORA/test/TestBase.h
@@ -44,6 +44,7 @@ namespace ora {
 	serializer.release();
       }catch ( const std::exception& exc ){
 	std::cout << "### TEST "<<m_testName<<" ERROR: "<<exc.what()<<std::endl;      
+        exit(-1);
       }
     }
 


### PR DESCRIPTION
This pull request affects unit tests only.
Many unit tests in CondCore/\* packages return a zero return value even if the test fails. This causes failures to not be reported as failures in the IB.
In the ROOT 6 IB, there were approximately 15 test failures that were not noticed until now because of this.
NOTE:  Since these code changes are not ROOT 6 specific, they are also being pull requested in the main 7_3_X branch for code commonality.
Please merge this request in the ROOT6 branch as soon as convenient.
