### PR TITLE
fix bug in weighting for multiple hadronization

### DIFF
--- a/GeneratorInterface/Core/interface/HadronizerFilter.h
+++ b/GeneratorInterface/Core/interface/HadronizerFilter.h
@@ -258,8 +258,8 @@ namespace edm
     
 
     
-    //adjust event weights if necessary (in case input event was accepted multiple times)
-    if (naccept>1) {
+    //adjust event weights if necessary (in case input event was attempted multiple times)
+    if (nAttempts_>1) {
       std::vector<double> genEventInfoWeights = finalGenEventInfo->weights();
       genEventInfoWeights.push_back(double(naccept)/double(nAttempts_));
       finalGenEventInfo->setWeights(genEventInfoWeights);


### PR DESCRIPTION
Event weight was wrong when running with multiple hadronization.  (Standard configurations not affected.)
