### PR TITLE
Improve the 'listoftags' script

### DIFF
--- a/CondCore/TagCollection/scripts/listoftags
+++ b/CondCore/TagCollection/scripts/listoftags
@@ -1,15 +1,23 @@
-#!/bin/sh
-if [ "$1" == "" ]; then
-   echo "Usage: $0 <connect> <treename>"
-   exit
+#! /bin/sh
+if [ "$2" == "" ]; then
+  NAME=`basename $0`
+   echo "Usage: $NAME <connect> <treename>"
+   echo
+   echo "Examples"
+   echo
+   echo "Read the PHYS14_25_V1 global tag from Oracle:"
+   echo "    $NAME oracle://cms_orcon_adg/CMS_COND_31X_GLOBALTAG PHYS14_25_V1"
+   echo
+   echo "Read the PHYS14_25_V1 global tag from Frontier:"
+   echo "    $NAME frontier://FrontierProd/CMS_COND_31X_GLOBALTAG PHYS14_25_V1"
+   exit 1
 fi
+
 CONNECT=$1
 TREE=$2
-TMP=`mktemp`
-cp /afs/cern.ch/cms/DB/conddb/authentication.xml .
-cmscond_tagtree_list -c $CONNECT -T $TREE | awk '{print $4,$1,$3}' > ${TMP}
-cp ${TMP} mytmp 
-
-#rm authentication.xml
-awk -F / '{print $NF}' ${TMP} | awk -F "tag:" '{print $1,$2,$3}' | awk -F "leafnode:" '{print $1,$2}' | awk '{printf "%-25s %-35s %s\n",$1,$2,$3}' | sort
-rm ${TMP}
+cmscond_tagtree_list -c $CONNECT -P /afs/cern.ch/cms/DB/conddb/authentication.xml -T $TREE \
+  | grep 'leafnode' \
+  | awk '{print $4,$6,$1,$3}' \
+  | sed -e 's/\<record://' -e's/ *\<label:None//' -e's/ *\<label:/#/' -e's/\<leafnode://' -e's/\<tag://' \
+  | sort \
+  | column -t


### PR DESCRIPTION
Improve the `listoftags` script:
- print labels along with records
- automatically columnate the output
- add examples for reading a global tag from Oracle or Frontier
