### PR TITLE
73X - fix Heppy GCC4.9.1 compilation warnings

### DIFF
--- a/PhysicsTools/Heppy/interface/Hemisphere.h
+++ b/PhysicsTools/Heppy/interface/Hemisphere.h
@@ -72,6 +72,8 @@ class Hemisphere {
   // RejectISRDRmax() max DeltaR below which objects can be included
   //   (default = 10.)
 
+  Hemisphere(){};
+  
   Hemisphere(std::vector<float> Px_vector, std::vector<float> Py_vector, std::vector<float> Pz_vector, std::vector<float> E_vector, int seed_method, int hemisphere_association_method);
 
   Hemisphere(std::vector<float> Px_vector, std::vector<float> Py_vector, std::vector<float> Pz_vector, std::vector<float> E_vector);

--- a/PhysicsTools/Heppy/interface/HemisphereViaKt.h
+++ b/PhysicsTools/Heppy/interface/HemisphereViaKt.h
@@ -24,6 +24,7 @@ class HemisphereViaKt {
     
  public:
 
+  HemisphereViaKt(){};
   HemisphereViaKt(std::vector<float> Px_vector, 
 		  std::vector<float> Py_vector, 
 		  std::vector<float> Pz_vector, 

--- a/PhysicsTools/Heppy/src/classes.h
+++ b/PhysicsTools/Heppy/src/classes.h
@@ -9,8 +9,8 @@
 #include "PhysicsTools/Heppy/interface/Davismt2.h"
 #include "PhysicsTools/Heppy/interface/mt2w_bisect.h"
 #include "PhysicsTools/Heppy/interface/Hemisphere.h"
-#include "PhysicsTools/Heppy/interface/AlphaT.h"
 #include "PhysicsTools/Heppy/interface/HemisphereViaKt.h"
+#include "PhysicsTools/Heppy/interface/AlphaT.h"
 #include "EgammaAnalysis/ElectronTools/interface/SimpleElectron.h"
 #include "EgammaAnalysis/ElectronTools/interface/ElectronEPcombinator.h"
 //#include "EgammaAnalysis/ElectronTools/interface/ElectronEnergyCalibrator.h"
@@ -24,8 +24,8 @@ namespace {
     heppy::TriggerBitChecker checker;
     heppy::CMGMuonCleanerBySegmentsAlgo cmgMuonCleanerBySegmentsAlgo;
     heppy::EGammaMvaEleEstimatorFWLite egMVA;
-    heppy::Hemisphere hemisphere(std::vector<float> px, std::vector<float> py, std::vector<float> pz, std::vector<float> E, int hemi_seed, int hemi_association);
-    heppy::HemisphereViaKt hemisphere(std::vector<float> px, std::vector<float> py, std::vector<float> pz, std::vector<float> E, double ktpower);
+    heppy::Hemisphere hemisphere_;
+    heppy::HemisphereViaKt hemisphereViaKt_;
     heppy::Davismt2 mt2;
     heppy::mt2w_bisect::mt2w mt2wlept;
     heppy::AlphaT alphaT;


### PR DESCRIPTION
Add (empty) default constructors to `heppy::Hemisphere` and `heppy::HemisphereViaKt` to be used in Reflex dictionary creation.
