### PR TITLE
fix track algoName for HLT tracking

### DIFF
--- a/DQM/TrackingMonitor/src/TrackAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/TrackAnalyzer.cc
@@ -347,10 +347,11 @@ void TrackAnalyzer::bookHistosForHitProperties(DQMStore::IBooker & ibooker) {
       // See DataFormats/TrackReco/interface/TrackBase.h for track algorithm enum definition
       // http://cmssw.cvs.cern.ch/cgi-bin/cmssw.cgi/CMSSW/DataFormats/TrackReco/interface/TrackBase.h?view=log
       histname = "algorithm_";
-      algorithm = ibooker.book1D(histname+CategoryName, histname+CategoryName, 32, 0., 32.);
+      algorithm = ibooker.book1D(histname+CategoryName, histname+CategoryName, reco::TrackBase::algoSize, 0., double(reco::TrackBase::algoSize));
       algorithm->setAxisTitle("Tracking algorithm",1);
       algorithm->setAxisTitle("Number of Tracks",2);
-      
+      for (size_t ibin=0; ibin<reco::TrackBase::algoSize; ibin++)
+	algorithm->setBinLabel(ibin+1,reco::TrackBase::algoNames[ibin]);
     }
 
 }
@@ -651,6 +652,7 @@ void TrackAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
     }
 
     // algorithm
+    std::cout << "[TrackAnalyzer::analyze] track: " << track.algo() << " --> " << track.algoName() << std::endl;
     algorithm->Fill(static_cast<double>(track.algo()));
   }
 

--- a/DQM/TrackingMonitor/src/TrackAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/TrackAnalyzer.cc
@@ -347,10 +347,10 @@ void TrackAnalyzer::bookHistosForHitProperties(DQMStore::IBooker & ibooker) {
       // See DataFormats/TrackReco/interface/TrackBase.h for track algorithm enum definition
       // http://cmssw.cvs.cern.ch/cgi-bin/cmssw.cgi/CMSSW/DataFormats/TrackReco/interface/TrackBase.h?view=log
       histname = "algorithm_";
-      algorithm = ibooker.book1D(histname+CategoryName, histname+CategoryName, reco::TrackBase::algoSize, 0., double(reco::TrackBase::algoSize));
+      algorithm = ibooker.book1D(histname+CategoryName, histname+CategoryName, reco::TrackBase::algoSize-1, 0., double(reco::TrackBase::algoSize-1));
       algorithm->setAxisTitle("Tracking algorithm",1);
       algorithm->setAxisTitle("Number of Tracks",2);
-      for (size_t ibin=0; ibin<reco::TrackBase::algoSize; ibin++)
+      for (size_t ibin=0; ibin<reco::TrackBase::algoSize-1; ibin++)
 	algorithm->setBinLabel(ibin+1,reco::TrackBase::algoNames[ibin]);
     }
 
@@ -652,7 +652,6 @@ void TrackAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
     }
 
     // algorithm
-    std::cout << "[TrackAnalyzer::analyze] track: " << track.algo() << " --> " << track.algoName() << std::endl;
     algorithm->Fill(static_cast<double>(track.algo()));
   }
 

--- a/DQM/TrackingMonitor/src/TrackAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/TrackAnalyzer.cc
@@ -347,7 +347,7 @@ void TrackAnalyzer::bookHistosForHitProperties(DQMStore::IBooker & ibooker) {
       // See DataFormats/TrackReco/interface/TrackBase.h for track algorithm enum definition
       // http://cmssw.cvs.cern.ch/cgi-bin/cmssw.cgi/CMSSW/DataFormats/TrackReco/interface/TrackBase.h?view=log
       histname = "algorithm_";
-      algorithm = ibooker.book1D(histname+CategoryName, histname+CategoryName, reco::TrackBase::algoSize-1, 0., double(reco::TrackBase::algoSize-1));
+      algorithm = ibooker.book1D(histname+CategoryName, histname+CategoryName, reco::TrackBase::algoSize, 0., double(reco::TrackBase::algoSize));
       algorithm->setAxisTitle("Tracking algorithm",1);
       algorithm->setAxisTitle("Number of Tracks",2);
       for (size_t ibin=0; ibin<reco::TrackBase::algoSize-1; ibin++)

--- a/DataFormats/TrackReco/interface/TrackBase.h
+++ b/DataFormats/TrackReco/interface/TrackBase.h
@@ -121,7 +121,7 @@ public:
 	hltIter2 = 32,
 	hltIter3 = 33,
 	hltIter4 = 34,
-	// steps used global muon isolation
+	// steps used by all other objects @HLT
 	hltIterX = 35,
         algoSize = 36
     };
@@ -429,82 +429,120 @@ inline std::string TrackBase::algoName() const
     // I'd like to do:
     // return TrackBase::algoName(algorithm_);
     // but I cannot define a const static function. Why???
-
+  std::cout << "[TrackBase::algoName] algorithm_: " << algorithm_ << std::endl;
     switch (algorithm_) {
     case undefAlgorithm:
-        return "undefAlgorithm";
+      return "undefAlgorithm";
+      break;
     case ctf:
-        return "ctf";
+      return "ctf";
+      break;
     case rs:
-        return "rs";
+      return "rs";
+      break;
     case cosmics:
-        return "cosmics";
+      return "cosmics";
+      break;
     case beamhalo:
-        return "beamhalo";
+      return "beamhalo";
+      break;
     case initialStep:
-        return "initialStep";
+      return "initialStep";
+      break;
     case lowPtTripletStep:
-        return "lowPtTripletStep";
+      return "lowPtTripletStep";
+      break;
     case pixelPairStep:
-        return "pixelPairStep";
+      return "pixelPairStep";
+      break;
     case detachedTripletStep:
-        return "detachedTripletStep";
+      return "detachedTripletStep";
+      break;
     case mixedTripletStep:
-        return "mixedTripletStep";
+      return "mixedTripletStep";
+      break;
     case pixelLessStep:
-        return "pixelLessStep";
+      return "pixelLessStep";
+      break;
     case tobTecStep:
-        return "tobTecStep";
+      return "tobTecStep";
+      break;
     case jetCoreRegionalStep:
-        return "jetCoreRegionalStep";
+      return "jetCoreRegionalStep";
+      break;
     case conversionStep:
-        return "conversionStep";
+      return "conversionStep";
+      break;
     case muonSeededStepInOut:
-        return "muonSeededStepInOut";
+      return "muonSeededStepInOut";
+      break;
     case muonSeededStepOutIn:
-        return "muonSeededStepOutIn";
+      return "muonSeededStepOutIn";
+      break;
     case outInEcalSeededConv:
-        return "outInEcalSeededConv";
+      return "outInEcalSeededConv";
+      break;
     case inOutEcalSeededConv:
-        return "inOutEcalSeededConv";
+      return "inOutEcalSeededConv";
+      break;
     case nuclInter:
-        return "nuclInter";
+      return "nuclInter";
+      break;
     case standAloneMuon:
-        return "standAloneMuon";
+      return "standAloneMuon";
+      break;
     case globalMuon:
-        return "globalMuon";
+      return "globalMuon";
+      break;
     case cosmicStandAloneMuon:
-        return "cosmicStandAloneMuon";
+      return "cosmicStandAloneMuon";
+      break;
     case cosmicGlobalMuon:
-        return "cosmicGlobalMuon";
+      return "cosmicGlobalMuon";
+      break;
     case iter1LargeD0:
-        return "iter1LargeD0";
+      return "iter1LargeD0";
+      break;
     case iter2LargeD0:
-        return "iter2LargeD0";
+      return "iter2LargeD0";
+      break;
     case iter3LargeD0:
-        return "iter3LargeD0";
+      return "iter3LargeD0";
+      break;
     case iter4LargeD0:
-        return "iter4LargeD0";
+      return "iter4LargeD0";
+      break;
     case iter5LargeD0:
-        return "iter5LargeD0";
+      return "iter5LargeD0";
+      break;
     case bTagGhostTracks:
-        return "bTagGhostTracks";
+      return "bTagGhostTracks";
+      break;
     case gsf:
-        return "gsf";
+      return "gsf";
+      break;
     case hltIter0 :
       return "hltIter0";
+      break;
     case hltIter1 :
       return "hltIter1";
+      break;
     case hltIter2 :
       return "hltIter2";
+      break;
     case hltIter3 :
       return "hltIter3";
+      break;
     case hltIter4 :
       return "hltIter4";
+      break;
     case hltIterX :
       return "hltIterX";
+      break;
+    default:
+      return "undefAlgorithm";
+      break;
     }
-    return "undefAlgorithm";
 }
 
 inline bool TrackBase::quality(const TrackBase::TrackQuality q) const

--- a/DataFormats/TrackReco/interface/TrackBase.h
+++ b/DataFormats/TrackReco/interface/TrackBase.h
@@ -115,15 +115,16 @@ public:
         beamhalo = 28,
         gsf = 29,
 	// HLT algo name
+	hltPixel = 30,
 	// steps used by PF
-	hltIter0 = 30,
-	hltIter1 = 31,
-	hltIter2 = 32,
-	hltIter3 = 33,
-	hltIter4 = 34,
+	hltIter0 = 31,
+	hltIter1 = 32,
+	hltIter2 = 33,
+	hltIter3 = 34,
+	hltIter4 = 35,
 	// steps used by all other objects @HLT
-	hltIterX = 35,
-        algoSize = 36
+	hltIterX = 36,
+        algoSize = 37
     };
 
     static const std::string algoNames[];
@@ -519,6 +520,9 @@ inline std::string TrackBase::algoName() const
       break;
     case gsf:
       return "gsf";
+      break;
+    case hltPixel :
+      return "hltPixel";
       break;
     case hltIter0 :
       return "hltIter0";

--- a/DataFormats/TrackReco/interface/TrackBase.h
+++ b/DataFormats/TrackReco/interface/TrackBase.h
@@ -429,7 +429,6 @@ inline std::string TrackBase::algoName() const
     // I'd like to do:
     // return TrackBase::algoName(algorithm_);
     // but I cannot define a const static function. Why???
-  std::cout << "[TrackBase::algoName] algorithm_: " << algorithm_ << std::endl;
     switch (algorithm_) {
     case undefAlgorithm:
       return "undefAlgorithm";

--- a/DataFormats/TrackReco/interface/TrackBase.h
+++ b/DataFormats/TrackReco/interface/TrackBase.h
@@ -114,7 +114,16 @@ public:
         bTagGhostTracks = 27,
         beamhalo = 28,
         gsf = 29,
-        algoSize = 30
+	// HLT algo name
+	// steps used by PF
+	hltIter0 = 30,
+	hltIter1 = 31,
+	hltIter2 = 32,
+	hltIter3 = 33,
+	hltIter4 = 34,
+	// steps used global muon isolation
+	hltIterX = 35,
+        algoSize = 36
     };
 
     static const std::string algoNames[];
@@ -482,6 +491,18 @@ inline std::string TrackBase::algoName() const
         return "bTagGhostTracks";
     case gsf:
         return "gsf";
+    case hltIter0 :
+      return "hltIter0";
+    case hltIter1 :
+      return "hltIter1";
+    case hltIter2 :
+      return "hltIter2";
+    case hltIter3 :
+      return "hltIter3";
+    case hltIter4 :
+      return "hltIter4";
+    case hltIterX :
+      return "hltIterX";
     }
     return "undefAlgorithm";
 }

--- a/DataFormats/TrackReco/src/TrackBase.cc
+++ b/DataFormats/TrackReco/src/TrackBase.cc
@@ -36,7 +36,13 @@ std::string const TrackBase::algoNames[] = {
     "iter5LargeD0",
     "bTagGhostTracks",
     "beamhalo" ,
-    "gsf"
+    "gsf",
+    "hltIter0",
+    "hltIter1",
+    "hltIter2",
+    "hltIter3",
+    "hltIter4",
+    "hltIterX"
 };
 
 std::string const TrackBase::qualityNames[] = {

--- a/DataFormats/TrackReco/src/TrackBase.cc
+++ b/DataFormats/TrackReco/src/TrackBase.cc
@@ -37,6 +37,7 @@ std::string const TrackBase::algoNames[] = {
     "bTagGhostTracks",
     "beamhalo" ,
     "gsf",
+    "hltPixel",
     "hltIter0",
     "hltIter1",
     "hltIter2",

--- a/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporter.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporter.cc
@@ -176,19 +176,15 @@ goodPtResolution( const reco::TrackRef& trackref) const {
   case reco::TrackBase::hltIter0:
   case reco::TrackBase::hltIter1:
   case reco::TrackBase::hltIter2:
-    std::cout << "[GeneralTracksImporter::goodPtResolution] trackref->algo(): " << trackref->algo() << " 0,1 or 2" << std::endl;
     Algo = _useIterTracking ? 0 : 0;
     break;
   case reco::TrackBase::hltIter3:
-    std::cout << "[GeneralTracksImporter::goodPtResolution] trackref->algo(): " << trackref->algo() << " 3" << std::endl;
     Algo = _useIterTracking ? 1 : 0;
     break;
   case reco::TrackBase::hltIter4:
-    std::cout << "[GeneralTracksImporter::goodPtResolution] trackref->algo(): " << trackref->algo() << " 4" << std::endl;
     Algo = _useIterTracking ? 2 : 0;
     break;
   case reco::TrackBase::hltIterX:
-    std::cout << "[GeneralTracksImporter::goodPtResolution] trackref->algo(): " << trackref->algo() << " X" << std::endl;
     Algo = _useIterTracking ? 0 : 0;
     break;
   default:

--- a/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporter.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporter.cc
@@ -173,6 +173,24 @@ goodPtResolution( const reco::TrackRef& trackref) const {
   case reco::TrackBase::tobTecStep:
     Algo = 4;
     break;
+  case reco::TrackBase::hltIter0:
+  case reco::TrackBase::hltIter1:
+  case reco::TrackBase::hltIter2:
+    std::cout << "[GeneralTracksImporter::goodPtResolution] trackref->algo(): " << trackref->algo() << " 0,1 or 2" << std::endl;
+    Algo = _useIterTracking ? 0 : 0;
+    break;
+  case reco::TrackBase::hltIter3:
+    std::cout << "[GeneralTracksImporter::goodPtResolution] trackref->algo(): " << trackref->algo() << " 3" << std::endl;
+    Algo = _useIterTracking ? 1 : 0;
+    break;
+  case reco::TrackBase::hltIter4:
+    std::cout << "[GeneralTracksImporter::goodPtResolution] trackref->algo(): " << trackref->algo() << " 4" << std::endl;
+    Algo = _useIterTracking ? 2 : 0;
+    break;
+  case reco::TrackBase::hltIterX:
+    std::cout << "[GeneralTracksImporter::goodPtResolution] trackref->algo(): " << trackref->algo() << " X" << std::endl;
+    Algo = _useIterTracking ? 0 : 0;
+    break;
   default:
     Algo = _useIterTracking ? 5 : 0;
     break;

--- a/RecoParticleFlow/PFProducer/src/PFAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFAlgo.cc
@@ -1956,15 +1956,12 @@ void PFAlgo::processBlock( const reco::PFBlockRef& blockref,
       case reco::TrackBase::hltIter1:
       case reco::TrackBase::hltIter2:
       case reco::TrackBase::hltIter3:
-	std::cout << "[PFAlgo::processBlock] trackRef->algo(): " << trackRef->algo() << " 0,1,2 or 3" << std::endl;
 	blowError = 1.;
 	break;
       case reco::TrackBase::hltIter4:
-	std::cout << "[PFAlgo::processBlock] trackRef->algo(): " << trackRef->algo() << " 4" << std::endl;
 	blowError = factors45_[0];
 	break;
       case reco::TrackBase::hltIterX:
-	std::cout << "[PFAlgo::processBlock] trackRef->algo(): " << trackRef->algo() << " X" << std::endl;
 	blowError = 1.;
 	break;
       default:

--- a/RecoParticleFlow/PFProducer/src/PFAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFAlgo.cc
@@ -798,7 +798,7 @@ void PFAlgo::processBlock( const reco::PFBlockRef& blockref,
 	PFBlockElement::Type type = elements[iEle].type();
 	if(type==PFBlockElement::TRACK)
 	  {
-	    if(elements[iEle].trackRef()->algo() == 12)
+	    if(elements[iEle].trackRef()->algo() == 12) // should not be reco::TrackBase::conversionStep ?
 	      active[iEle]=false;	
 	    if(elements[iEle].trackRef()->quality(reco::TrackBase::highPurity))continue;
 	    const reco::PFBlockElementTrack * trackRef = dynamic_cast<const reco::PFBlockElementTrack*>((&elements[iEle]));
@@ -1952,6 +1952,21 @@ void PFAlgo::processBlock( const reco::PFBlockRef& blockref,
       case TrackBase::tobTecStep:
 	blowError = factors45_[1];
 	break;
+      case reco::TrackBase::hltIter0:
+      case reco::TrackBase::hltIter1:
+      case reco::TrackBase::hltIter2:
+      case reco::TrackBase::hltIter3:
+	std::cout << "[PFAlgo::processBlock] trackRef->algo(): " << trackRef->algo() << " 0,1,2 or 3" << std::endl;
+	blowError = 1.;
+	break;
+      case reco::TrackBase::hltIter4:
+	std::cout << "[PFAlgo::processBlock] trackRef->algo(): " << trackRef->algo() << " 4" << std::endl;
+	blowError = factors45_[0];
+	break;
+      case reco::TrackBase::hltIterX:
+	std::cout << "[PFAlgo::processBlock] trackRef->algo(): " << trackRef->algo() << " X" << std::endl;
+	blowError = 1.;
+	break;
       default:
 	blowError = 1E9;
 	break;
@@ -2420,6 +2435,13 @@ void PFAlgo::processBlock( const reco::PFBlockRef& blockref,
 		      << " rejected (Dpt = " << -it->first 
 		      << " GeV/c, algo = " << trackref->algo() << ")" << std::endl;
 	  break;
+	case reco::TrackBase::hltIter0:
+	case reco::TrackBase::hltIter1:
+	case reco::TrackBase::hltIter2:
+	case reco::TrackBase::hltIter3:
+	case reco::TrackBase::hltIter4:
+	case reco::TrackBase::hltIterX:
+	  break;	  
 	default:
 	  break;
 	}

--- a/Validation/RecoTrack/src/MTVHistoProducerAlgoForTracker.cc
+++ b/Validation/RecoTrack/src/MTVHistoProducerAlgoForTracker.cc
@@ -189,7 +189,9 @@ void MTVHistoProducerAlgoForTracker::bookRecoHistos(DQMStore::IBooker& ibook){
   h_nmisslayers_inner.push_back( ibook.book1D("missing_inner_layers", "number of missing inner layers", nintLayers,minLayers,maxLayers ) );
   h_nmisslayers_outer.push_back( ibook.book1D("missing_outer_layers", "number of missing outer layers", nintLayers,minLayers,maxLayers ) );
 
-  h_algo.push_back( ibook.book1D("h_algo","Tracks by algo",15,0.0,15.0) );
+  h_algo.push_back( ibook.book1D("h_algo","Tracks by algo",reco::TrackBase::algoSize-1, 0., double(reco::TrackBase::algoSize-1) ) );
+  //  for (size_t ibin=0; ibin<reco::TrackBase::algoSize-1; ibin++)
+  //    h_algo.setBinLabel(ibin+1,reco::TrackBase::algoNames[ibin]);
 
   /// these are needed to calculate efficiency during the harvesting for the automated validation
   h_recoeta.push_back( ibook.book1D("num_reco_eta","N of reco track vs eta",nintEta,minEta,maxEta) );
@@ -635,7 +637,8 @@ void MTVHistoProducerAlgoForTracker::fill_generic_recoTrack_histos(int count,
 								   double dR){
 
   //Fill track algo histogram
-  if (track.algo()>=4 && track.algo()<=14) fillPlotNoFlow(h_algo[count],track.algo()-4);
+  //  if (track.algo()>=4 && track.algo()<=14) fillPlotNoFlow(h_algo[count],track.algo()-4);
+  fillPlotNoFlow(h_algo[count],track.algo());
   int sharedHits = sharedFraction *  track.numberOfValidHits();
 
   //Compute fake rate vs eta

--- a/Validation/RecoTrack/src/MTVHistoProducerAlgoForTracker.cc
+++ b/Validation/RecoTrack/src/MTVHistoProducerAlgoForTracker.cc
@@ -189,8 +189,9 @@ void MTVHistoProducerAlgoForTracker::bookRecoHistos(DQMStore::IBooker& ibook){
   h_nmisslayers_inner.push_back( ibook.book1D("missing_inner_layers", "number of missing inner layers", nintLayers,minLayers,maxLayers ) );
   h_nmisslayers_outer.push_back( ibook.book1D("missing_outer_layers", "number of missing outer layers", nintLayers,minLayers,maxLayers ) );
 
-  h_algo.push_back( ibook.book1D("h_algo","Tracks by algo",reco::TrackBase::algoSize-1, 0., double(reco::TrackBase::algoSize-1) ) );
-  //  for (size_t ibin=0; ibin<reco::TrackBase::algoSize-1; ibin++)
+  h_algo.push_back( ibook.book1D("h_algo","Tracks by algo",reco::TrackBase::algoSize, 0., double(reco::TrackBase::algoSize) ) );
+  for (size_t ibin=0; ibin<reco::TrackBase::algoSize-1; ibin++)
+    h_algo.back()->setBinLabel(ibin+1,reco::TrackBase::algoNames[ibin]);
   //    h_algo.setBinLabel(ibin+1,reco::TrackBase::algoNames[ibin]);
 
   /// these are needed to calculate efficiency during the harvesting for the automated validation


### PR DESCRIPTION
as already pointed out in 
https://github.com/cms-sw/cmssw/pull/5807

some updates were needed both on the TrackBase side and on the DQM one
in order to properly deal w/ the tracking algoName @mdhildreth 

new enums have been defined in the TrackBase
for handling the steps used by PFJet, PFMET and PFTau @HLT
for the other flavours of the tracking (used by leptons isolation, b-tagging, PFTau regional and displaced jets)
for the timebeing a single enum has been defined "hltIterX"
those tracks are indeed not used by the PF algorithm @HLT

we need also an update on the HLT menu configuration side
in order to synchronize the algorithName parameter in each TrackProducer module
defined w/in the HLT menu

as soon as both this PR will be integrated and the update of the HLT menu will be available in the standard workflow,
plots spotted by stoyan will be --finally-- properly filled 
as they are in attachment (as result of my test)

hltIter0HP
![hltiter0hp_algo](https://cloud.githubusercontent.com/assets/4946419/4991948/8aecdee2-699a-11e4-88ea-5d65f7f865ea.png)

hltIter2Merged
![hltiter2merged_algo](https://cloud.githubusercontent.com/assets/4946419/4991952/99cd9550-699a-11e4-9d17-9da8d2693be3.png)

the above plots come from runTheMatrix 25.0
w/o any kind of error
(after of course, updating the input HLT config locally)
