### PR TITLE
Hcal DQM Migration - II.2

### DIFF
--- a/DQM/HcalMonitorClient/interface/HcalBaseDQClient.h
+++ b/DQM/HcalMonitorClient/interface/HcalBaseDQClient.h
@@ -28,14 +28,13 @@ class HcalBaseDQClient
   virtual ~HcalBaseDQClient(void);
   
   // Overload these functions with client-specific instructions
-  virtual void beginJob(void);
   virtual void beginRun(void)          {}
   virtual void setup(void)             {}
 
-  virtual void analyze(void)           {enoughevents_=true;} // fill new histograms
+  virtual void analyze(DQMStore::IBooker &, DQMStore::IGetter &)           {enoughevents_=true;} // fill new histograms
   virtual void calculateProblems(void) {} // update/fill ProblemCell histograms
   
-  virtual void endRun(void)            {}
+  //virtual void endRun(void)            {}
   virtual void endJob(void)            {}
   virtual void cleanup(void)           {}
   
@@ -44,11 +43,11 @@ class HcalBaseDQClient
   virtual bool hasOther_Temp(void)     {return false;};
   virtual bool test_enabled(void)      {return false;};
 
-  virtual void htmlOutput(std::string htmlDir);
+  virtual void htmlOutput(DQMStore::IBooker &, DQMStore::IGetter &, std::string htmlDir);
   virtual void setStatusMap(std::map<HcalDetId, unsigned int>& map);
   virtual void updateChannelStatus(std::map<HcalDetId, unsigned int>& myqual){};     
   
-  virtual bool validHtmlOutput();
+  virtual bool validHtmlOutput(DQMStore::IBooker &, DQMStore::IGetter &);
 
   void getLogicalMap(const edm::EventSetup& es);
 
@@ -78,7 +77,6 @@ class HcalBaseDQClient
   std::vector<std::string> problemnames_;
 
   std::map<HcalDetId, unsigned int> badstatusmap;
-  DQMStore* dqmStore_;
   bool enoughevents_;
 
   bool needLogicalMap_;

--- a/DQM/HcalMonitorClient/interface/HcalBeamClient.h
+++ b/DQM/HcalMonitorClient/interface/HcalBeamClient.h
@@ -14,13 +14,12 @@ class HcalBeamClient : public HcalBaseDQClient {
   HcalBeamClient(std::string myname);//{ name_=myname;};
   HcalBeamClient(std::string myname, const edm::ParameterSet& ps);
 
-  void analyze(void);
-  void calculateProblems(void); // calculates problem histogram contents
+  void analyze(DQMStore::IBooker &, DQMStore::IGetter &);
+  void calculateProblems(DQMStore::IBooker &, DQMStore::IGetter &); // calculates problem histogram contents
   void updateChannelStatus(std::map<HcalDetId, unsigned int>& myqual);
-  void beginJob(void);
   void endJob(void);
   void beginRun(void);
-  void endRun(void); 
+  //void endRun(void); 
   void setup(void);  
   void cleanup(void);
 
@@ -34,6 +33,14 @@ class HcalBeamClient : public HcalBaseDQClient {
 
  private:
   int nevts_;
+
+  // -- setup the problem cells monitor
+  bool setupProblemCells_;   // defaults to true in constructor
+  
+  // perform the setup of the problem cells monitor elements and EtaPhiHists
+  // This function sets the above setupProblemCells_ to false.
+  void doProblemCellSetup(DQMStore::IBooker &, DQMStore::IGetter &);
+  
 };
 
 #endif

--- a/DQM/HcalMonitorClient/interface/HcalCoarsePedestalClient.h
+++ b/DQM/HcalMonitorClient/interface/HcalCoarsePedestalClient.h
@@ -14,13 +14,12 @@ class HcalCoarsePedestalClient : public HcalBaseDQClient {
   HcalCoarsePedestalClient(std::string myname);//{ name_=myname;};
   HcalCoarsePedestalClient(std::string myname, const edm::ParameterSet& ps);
 
-  void analyze(void);
-  void calculateProblems(void); // calculates problem histogram contents
+  void analyze(DQMStore::IBooker &, DQMStore::IGetter &);
+  void calculateProblems(DQMStore::IBooker &, DQMStore::IGetter &); // calculates problem histogram contents
   void updateChannelStatus(std::map<HcalDetId, unsigned int>& myqual);
-  void beginJob(void);
   void endJob(void);
   void beginRun(void);
-  void endRun(void); 
+  //void endRun(void); 
   void setup(void);  
   void cleanup(void);
 
@@ -39,6 +38,14 @@ class HcalCoarsePedestalClient : public HcalBaseDQClient {
   TH2F* DatabasePedestalsADCByDepth[4];
   EtaPhiHists* CoarsePedestalsByDepth;
   MonitorElement* CoarsePedDiff;
+
+  // -- setup problem cells monitors
+  bool doCoarseSetup_;  // defaults to true in constructor
+
+  // performs the setup of the coarse cell 
+  // sets the doCoarseSetup_ to false  
+  void setupCoarsePedestal(DQMStore::IBooker &, DQMStore::IGetter &);
+
 };
 
 #endif

--- a/DQM/HcalMonitorClient/interface/HcalDeadCellClient.h
+++ b/DQM/HcalMonitorClient/interface/HcalDeadCellClient.h
@@ -14,13 +14,12 @@ class HcalDeadCellClient : public HcalBaseDQClient {
   HcalDeadCellClient(std::string myname);//{ name_=myname;};
   HcalDeadCellClient(std::string myname, const edm::ParameterSet& ps);
 
-  void analyze(void);
-  void calculateProblems(void); // calculates problem histogram contents
+  void analyze(DQMStore::IBooker &, DQMStore::IGetter &);
+  void calculateProblems(DQMStore::IBooker &, DQMStore::IGetter &); // calculates problem histogram contents
   void updateChannelStatus(std::map<HcalDetId, unsigned int>& myqual);
-  void beginJob(void);
   void endJob(void);
   void beginRun(void);
-  void endRun(void); 
+  //void endRun(void); 
   void setup(void);  
   void cleanup(void);
 
@@ -37,6 +36,13 @@ class HcalDeadCellClient : public HcalBaseDQClient {
 
   int HBpresent_, HEpresent_, HOpresent_, HFpresent_;
   bool excludeHOring2_backup_; // this value is used for excludeHOring2 if it can't be read directly from the DQM file
+
+  // -- setup the problem cells monitors
+  bool doProblemCellSetup_; // defaults to true in the constructor
+
+  // setup the problem cell monitors
+  // Sets the doProblemCellSetup_ to false
+  void setupProblemCells(DQMStore::IBooker &, DQMStore::IGetter &);
 
 };
 

--- a/DQM/HcalMonitorClient/interface/HcalDetDiagLEDClient.h
+++ b/DQM/HcalMonitorClient/interface/HcalDetDiagLEDClient.h
@@ -14,13 +14,12 @@ class HcalDetDiagLEDClient : public HcalBaseDQClient {
   HcalDetDiagLEDClient(std::string myname);//{ name_=myname;};
   HcalDetDiagLEDClient(std::string myname, const edm::ParameterSet& ps);
 
-  void analyze(void);
-  void calculateProblems(void); // calculates problem histogram contents
+  void analyze(DQMStore::IBooker &, DQMStore::IGetter &);
+  void calculateProblems(DQMStore::IBooker &, DQMStore::IGetter &); // calculates problem histogram contents
   void updateChannelStatus(std::map<HcalDetId, unsigned int>& myqual);
-  void beginJob(void);
   void endJob(void);
   void beginRun(void);
-  void endRun(void); 
+  //void endRun(void); 
   void setup(void);  
   void cleanup(void);
   bool hasErrors_Temp(void);  
@@ -28,8 +27,8 @@ class HcalDetDiagLEDClient : public HcalBaseDQClient {
   bool hasOther_Temp(void);
   bool test_enabled(void);
   
-  void htmlOutput(std::string);
-  bool validHtmlOutput();
+  void htmlOutput(DQMStore::IBooker &, DQMStore::IGetter &, std::string);
+  bool validHtmlOutput(DQMStore::IBooker &, DQMStore::IGetter &);
  
   /// Destructor
   ~HcalDetDiagLEDClient();
@@ -48,6 +47,13 @@ class HcalDetDiagLEDClient : public HcalBaseDQClient {
   TH2F *ChannelStatusTimeRMS[4];
   double get_channel_status(std::string subdet,int eta,int phi,int depth,int type);
   double get_energy(std::string subdet,int eta,int phi,int depth,int type);
+
+  // -- setup for problem cells
+  bool doProblemCellSetup_; // default to true in the constructor
+
+  // setup the problem cells 
+  // this sets the doProblemCellSetup_ to false
+  void setupProblemCells(DQMStore::IBooker &, DQMStore::IGetter &);
 };
 
 #endif

--- a/DQM/HcalMonitorClient/interface/HcalDetDiagLaserClient.h
+++ b/DQM/HcalMonitorClient/interface/HcalDetDiagLaserClient.h
@@ -14,13 +14,12 @@ class HcalDetDiagLaserClient : public HcalBaseDQClient {
   HcalDetDiagLaserClient(std::string myname);//{ name_=myname;};
   HcalDetDiagLaserClient(std::string myname, const edm::ParameterSet& ps);
 
-  void analyze(void);
-  void calculateProblems(void); // calculates problem histogram contents
+  void analyze(DQMStore::IBooker &, DQMStore::IGetter &);
+  void calculateProblems(DQMStore::IBooker &, DQMStore::IGetter &); // calculates problem histogram contents
   void updateChannelStatus(std::map<HcalDetId, unsigned int>& myqual);
-  void beginJob(void);
   void endJob(void);
   void beginRun(void);
-  void endRun(void); 
+  //void endRun(void); 
   void setup(void);  
   void cleanup(void);
   bool hasErrors_Temp(void);  
@@ -28,14 +27,20 @@ class HcalDetDiagLaserClient : public HcalBaseDQClient {
   bool hasOther_Temp(void);
   bool test_enabled(void);
   
-  void htmlOutput(std::string);
-  bool validHtmlOutput();
+  void htmlOutput(DQMStore::IBooker &, DQMStore::IGetter &, std::string);
+  bool validHtmlOutput(DQMStore::IBooker &, DQMStore::IGetter &);
   /// Destructor
   ~HcalDetDiagLaserClient();
 
  private:
   int nevts_;
   int status;
+
+  // -- problem cell setup flag
+  bool doProblemCellSetup_; // defaults to true in constructor
+  // setup the problem cell monitors and set the doProblemCellSetup_
+  // flag to false
+  void setupProblemCells(DQMStore::IBooker &, DQMStore::IGetter &);
 };
 
 #endif

--- a/DQM/HcalMonitorClient/interface/HcalDetDiagNoiseMonitorClient.h
+++ b/DQM/HcalMonitorClient/interface/HcalDetDiagNoiseMonitorClient.h
@@ -14,11 +14,10 @@ class HcalDetDiagNoiseMonitorClient : public HcalBaseDQClient {
   HcalDetDiagNoiseMonitorClient(std::string myname);//{ name_=myname;};
   HcalDetDiagNoiseMonitorClient(std::string myname, const edm::ParameterSet& ps);
 
-  void analyze(void);
-  void calculateProblems(void); // calculates problem histogram contents
+  void analyze(DQMStore::IBooker &, DQMStore::IGetter &);
+  void calculateProblems(DQMStore::IBooker &, DQMStore::IGetter &); // calculates problem histogram contents
   void updateChannelStatus(std::map<HcalDetId, unsigned int>& myqual);
-  void beginJob(void);
-  void endJob(void);
+  //void endJob(void);
   void beginRun(void);
   void endRun(void); 
   void setup(void);  
@@ -34,6 +33,11 @@ class HcalDetDiagNoiseMonitorClient : public HcalBaseDQClient {
 
  private:
   int nevts_;
+
+  // -- problem cell setup flag
+  bool doProblemCellSetup_;  // defaults to true in the constructor
+  // setup the problem cell monitors and set the doProblemCellSetup_ flag to false
+  void setupProblemCells(DQMStore::IBooker &, DQMStore::IGetter &);
 };
 
 #endif

--- a/DQM/HcalMonitorClient/interface/HcalDetDiagPedestalClient.h
+++ b/DQM/HcalMonitorClient/interface/HcalDetDiagPedestalClient.h
@@ -14,13 +14,12 @@ class HcalDetDiagPedestalClient : public HcalBaseDQClient {
   HcalDetDiagPedestalClient(std::string myname);//{ name_=myname;};
   HcalDetDiagPedestalClient(std::string myname, const edm::ParameterSet& ps);
 
-  void analyze(void);
-  void calculateProblems(void); // calculates problem histogram contents
+  void analyze(DQMStore::IBooker &, DQMStore::IGetter &);
+  void calculateProblems(DQMStore::IBooker & , DQMStore::IGetter &); // calculates problem histogram contents
   void updateChannelStatus(std::map<HcalDetId, unsigned int>& myqual);
-  void beginJob(void);
   void endJob(void);
   void beginRun(void);
-  void endRun(void); 
+  //void endRun(void); 
   void setup(void);  
   void cleanup(void);
   bool hasErrors_Temp(void);  
@@ -29,8 +28,8 @@ class HcalDetDiagPedestalClient : public HcalBaseDQClient {
   bool test_enabled(void);
   
 
-  void htmlOutput(std::string);
-  bool validHtmlOutput();
+  void htmlOutput(DQMStore::IBooker &, DQMStore::IGetter &, std::string);
+  bool validHtmlOutput(DQMStore::IBooker &, DQMStore::IGetter &);
 
   /// Destructor
   ~HcalDetDiagPedestalClient();
@@ -38,6 +37,12 @@ class HcalDetDiagPedestalClient : public HcalBaseDQClient {
  private:
   int nevts_;
   int status;
+
+  // - setup problem cell flags
+  bool doProblemCellSetup_;  // defaults to true in the constructor
+  // setup the problem cell monitor elements
+  // This method sets the doProblemCellSetup_ flag to false
+  void setupProblemCells(DQMStore::IBooker &, DQMStore::IGetter &);
 };
 
 #endif

--- a/DQM/HcalMonitorClient/interface/HcalDetDiagTimingClient.h
+++ b/DQM/HcalMonitorClient/interface/HcalDetDiagTimingClient.h
@@ -14,13 +14,12 @@ class HcalDetDiagTimingClient : public HcalBaseDQClient {
   HcalDetDiagTimingClient(std::string myname);//{ name_=myname;};
   HcalDetDiagTimingClient(std::string myname, const edm::ParameterSet& ps);
 
-  void analyze(void);
-  void calculateProblems(void); // calculates problem histogram contents
+  void analyze(DQMStore::IBooker &, DQMStore::IGetter &);
+  void calculateProblems(DQMStore::IBooker &, DQMStore::IGetter &); // calculates problem histogram contents
   void updateChannelStatus(std::map<HcalDetId, unsigned int>& myqual);
-  void beginJob(void);
   void endJob(void);
   void beginRun(void);
-  void endRun(void); 
+  //void endRun(void); 
   void setup(void);  
   void cleanup(void);
 
@@ -34,6 +33,13 @@ class HcalDetDiagTimingClient : public HcalBaseDQClient {
 
  private:
   int nevts_;
+
+  // - setup problem cell flags
+  bool doProblemCellSetup_;  // defaults to true in the constructor
+  // setup the problem cell monitor elements
+  // This method sets the doProblemCellSetup_ flag to false
+  void setupProblemCells(DQMStore::IBooker &, DQMStore::IGetter &);
+
 };
 
 #endif

--- a/DQM/HcalMonitorClient/interface/HcalDigiClient.h
+++ b/DQM/HcalMonitorClient/interface/HcalDigiClient.h
@@ -14,13 +14,12 @@ class HcalDigiClient : public HcalBaseDQClient {
   HcalDigiClient(std::string myname);//{ name_=myname;};
   HcalDigiClient(std::string myname, const edm::ParameterSet& ps);
 
-  void analyze(void);
-  void calculateProblems(void); // calculates problem histogram contents
+  void analyze(DQMStore::IBooker &, DQMStore::IGetter &);
+  void calculateProblems(DQMStore::IBooker &, DQMStore::IGetter &); // calculates problem histogram contents
   void updateChannelStatus(std::map<HcalDetId, unsigned int>& myqual);
-  void beginJob(void);
   void endJob(void);
   void beginRun(void);
-  void endRun(void); 
+  //void endRun(void); 
   void setup(void);  
   void cleanup(void);
 
@@ -35,6 +34,13 @@ class HcalDigiClient : public HcalBaseDQClient {
  private:
   int nevts_;
   MonitorElement* HFTiming_averageTime;
+
+  // - setup problem cell flags
+  bool doProblemCellSetup_;  // defaults to true in the constructor
+  // setup the problem cell monitor elements
+  // This method sets the doProblemCellSetup_ flag to false
+  void setupProblemCells(DQMStore::IBooker &, DQMStore::IGetter &);
+
 };
 
 #endif

--- a/DQM/HcalMonitorClient/interface/HcalHotCellClient.h
+++ b/DQM/HcalMonitorClient/interface/HcalHotCellClient.h
@@ -14,13 +14,12 @@ class HcalHotCellClient : public HcalBaseDQClient {
   HcalHotCellClient(std::string myname);//{ name_=myname;};
   HcalHotCellClient(std::string myname, const edm::ParameterSet& ps);
 
-  void analyze(void);
-  void calculateProblems(void); // calculates problem histogram contents
+  void analyze(DQMStore::IBooker &, DQMStore::IGetter &);
+  void calculateProblems(DQMStore::IBooker &, DQMStore::IGetter &); // calculates problem histogram contents
   void updateChannelStatus(std::map<HcalDetId, unsigned int>& myqual);
-  void beginJob(void);
   void endJob(void);
   void beginRun(void);
-  void endRun(void); 
+  //void endRun(void); 
   void setup(void);  
   void cleanup(void);
 
@@ -34,6 +33,13 @@ class HcalHotCellClient : public HcalBaseDQClient {
 
  private:
   int nevts_;
+
+  // - setup problem cell flags
+  bool doProblemCellSetup_;  // defaults to true in the constructor
+  // setup the problem cell monitor elements
+  // This method sets the doProblemCellSetup_ flag to false
+  void setupProblemCells(DQMStore::IBooker &, DQMStore::IGetter &);
+
 };
 
 #endif

--- a/DQM/HcalMonitorClient/interface/HcalMonitorClient.h
+++ b/DQM/HcalMonitorClient/interface/HcalMonitorClient.h
@@ -48,8 +48,6 @@ public:
   void endRun(DQMStore::IBooker &, DQMStore::IGetter &);
   void endRun(const edm::Run & r, const edm::EventSetup & c);
   
-  /// BeginLumiBlock
-  // CATCH void beginLuminosityBlock(const edm::LuminosityBlock & l, const edm::EventSetup & c);
   
   /// EndLumiBlock
   void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &, const edm::LuminosityBlock & l, const edm::EventSetup & c);

--- a/DQM/HcalMonitorClient/interface/HcalMonitorClient.h
+++ b/DQM/HcalMonitorClient/interface/HcalMonitorClient.h
@@ -11,7 +11,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMEDHarvester.h"
 #include "CalibFormats/HcalObjects/interface/HcalDbService.h"
 
 #include "DQM/HcalMonitorClient/interface/HcalBaseDQClient.h"
@@ -19,11 +19,10 @@
 
 #include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
 
-class DQMStore;
 class HcalChannelQuality;
 class HcalSummaryClient;
 
-class HcalMonitorClient: public edm::EDAnalyzer
+class HcalMonitorClient: public DQMEDHarvester
 {
 
 public:
@@ -35,28 +34,25 @@ public:
   virtual ~HcalMonitorClient();
 
  /// Analyze
-  void analyze(int LS=-1);
-  void analyze(const edm::Event & e, const edm::EventSetup & c);
-  
-  /// BeginJob
-  void beginJob(void);
+  void analyze(DQMStore::IBooker &ib, DQMStore::IGetter &, int LS=-1);
+  //void analyze(const edm::Event & e, const edm::EventSetup & c);
   
   /// EndJob
-  void endJob(void);
+  void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &);
   
   /// BeginRun
-  void beginRun();
+  //void beginRun();
   void beginRun(const edm::Run & r, const edm::EventSetup & c);
   
   /// EndRun
-  void endRun();
+  void endRun(DQMStore::IBooker &, DQMStore::IGetter &);
   void endRun(const edm::Run & r, const edm::EventSetup & c);
   
   /// BeginLumiBlock
-  void beginLuminosityBlock(const edm::LuminosityBlock & l, const edm::EventSetup & c);
+  // CATCH void beginLuminosityBlock(const edm::LuminosityBlock & l, const edm::EventSetup & c);
   
   /// EndLumiBlock
-  void endLuminosityBlock(const edm::LuminosityBlock & l, const edm::EventSetup & c);
+  void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &, const edm::LuminosityBlock & l, const edm::EventSetup & c);
   
   /// Reset
   void reset(void);
@@ -74,7 +70,7 @@ public:
   void writeChannelStatus();
   
   // Write html output
-  void writeHtml();
+  void writeHtml(DQMStore::IBooker &, DQMStore::IGetter &);
 
   void PlotPedestalValues(const HcalDbService& cond);
 
@@ -118,7 +114,6 @@ private:
 
   std::vector<HcalBaseDQClient*> clients_;  
 
-  DQMStore* dqmStore_;
   const HcalChannelQuality* chanquality_;
 
   HcalSummaryClient* summaryClient_;
@@ -127,6 +122,18 @@ private:
   EtaPhiHists* ADC_WidthFromDBByDepth;
   EtaPhiHists* fC_PedestalFromDBByDepth;
   EtaPhiHists* fC_WidthFromDBByDepth;
+
+  // -- 
+  bool doPedSetup_;
+  // This function creates the EtaPhiHists for pedestal monitoring
+  // The doPedSetup_ flag is set to false during the execution of the function.
+  void setupPedestalMon(DQMStore::IBooker &);
+
+  bool doChanStatSetup_;
+  // The setupChannelStatusMon function creates the EtaPhiHists to record ChannelStatus.
+  // It will be retrieved by the HcalSummaryClient in the analysis(LS) method.
+  // The doChanStatSetup_ flag is set to false during the xectuion of the function.
+  void setupChannelStatusMon(DQMStore::IBooker &);
 
 };
 

--- a/DQM/HcalMonitorClient/interface/HcalNZSClient.h
+++ b/DQM/HcalMonitorClient/interface/HcalNZSClient.h
@@ -14,13 +14,12 @@ class HcalNZSClient : public HcalBaseDQClient {
   HcalNZSClient(std::string myname);//{ name_=myname;};
   HcalNZSClient(std::string myname, const edm::ParameterSet& ps);
 
-  void analyze(void);
-  void calculateProblems(void); // calculates problem histogram contents
+  void analyze(DQMStore::IBooker &, DQMStore::IGetter &);
+  void calculateProblems(DQMStore::IBooker &, DQMStore::IGetter &); // calculates problem histogram contents
   void updateChannelStatus(std::map<HcalDetId, unsigned int>& myqual);
-  void beginJob(void);
   void endJob(void);
   void beginRun(void);
-  void endRun(void); 
+  //void endRun(void); 
   void setup(void);  
   void cleanup(void);
 
@@ -34,6 +33,14 @@ class HcalNZSClient : public HcalBaseDQClient {
 
  private:
   int nevts_;
+
+
+  // - setup problem cell flags
+  bool doProblemCellSetup_;  // defaults to true in the constructor
+  // setup the problem cell monitor elements
+  // This method sets the doProblemCellSetup_ flag to false
+  void setupProblemCells(DQMStore::IBooker &, DQMStore::IGetter &);
+
 };
 
 #endif

--- a/DQM/HcalMonitorClient/interface/HcalRawDataClient.h
+++ b/DQM/HcalMonitorClient/interface/HcalRawDataClient.h
@@ -26,7 +26,6 @@ class HcalRawDataClient : public HcalBaseDQClient {
   //void endRun(void); 
   void setup(void);  
   void cleanup(void);
-  //void endLuminosityBlock(void);  // CATCH - I don't think this is called
   bool hasErrors_Temp(void);  
   bool hasWarnings_Temp(void);
   bool hasOther_Temp(void);

--- a/DQM/HcalMonitorClient/interface/HcalRawDataClient.h
+++ b/DQM/HcalMonitorClient/interface/HcalRawDataClient.h
@@ -18,16 +18,15 @@ class HcalRawDataClient : public HcalBaseDQClient {
   HcalRawDataClient(std::string myname);//{ name_=myname;};
   HcalRawDataClient(std::string myname, const edm::ParameterSet& ps);
 
-  void analyze(void);
-  void calculateProblems(void); // calculates problem histogram contents
+  void analyze(DQMStore::IBooker &, DQMStore::IGetter &);
+  void calculateProblems(DQMStore::IBooker &, DQMStore::IGetter &); // calculates problem histogram contents
   void updateChannelStatus(std::map<HcalDetId, unsigned int>& myqual);
-  void beginJob(void);
   void endJob(void);
   void beginRun(void);
-  void endRun(void); 
+  //void endRun(void); 
   void setup(void);  
   void cleanup(void);
-  void endLuminosityBlock(void);
+  //void endLuminosityBlock(void);  // CATCH - I don't think this is called
   bool hasErrors_Temp(void);  
   bool hasWarnings_Temp(void);
   bool hasOther_Temp(void);
@@ -66,9 +65,9 @@ class HcalRawDataClient : public HcalBaseDQClient {
   // handy array of pointers to pointers...
   TH2F* Chann_DataIntegrityCheck_[NUMDCCS];
 
-  void getHardwareSpaceHistos(void);
+  void getHardwareSpaceHistos(DQMStore::IBooker &, DQMStore::IGetter &);
 
-  void fillProblemCountArray(void);
+  void fillProblemCountArray(DQMStore::IBooker &, DQMStore::IGetter &);
   uint64_t problemcount[85][72][4]; // HFd1,2 at 'depths' 3,4 to avoid collision with HE
   void mapDCCproblem  (int dcc, float n) ;                         // Take maximum problem counters for affected cells
   void mapHTRproblem  (int dcc, int spigot, float n) ;             // Take maximum problem counters for affected cells
@@ -77,6 +76,14 @@ class HcalRawDataClient : public HcalBaseDQClient {
   void normalizeHardwareSpaceHistos(void);
 
   bool excludeHORing2_;
+
+  // - setup problem cell flags
+  bool doProblemCellSetup_;  // defaults to true in the constructor
+  // setup the problem cell monitor elements
+  // This method sets the doProblemCellSetup_ flag to false
+  void setupProblemCells(DQMStore::IBooker &, DQMStore::IGetter &);
+
+
 };
 
 #endif

--- a/DQM/HcalMonitorClient/interface/HcalRecHitClient.h
+++ b/DQM/HcalMonitorClient/interface/HcalRecHitClient.h
@@ -16,13 +16,12 @@ class HcalRecHitClient : public HcalBaseDQClient {
   HcalRecHitClient(std::string myname);//{ name_=myname;};
   HcalRecHitClient(std::string myname, const edm::ParameterSet& ps);
 
-  void analyze(void);
-  void calculateProblems(void); // calculates problem histogram contents
+  void analyze(DQMStore::IBooker &, DQMStore::IGetter &);
+  void calculateProblems(DQMStore::IBooker &, DQMStore::IGetter &); // calculates problem histogram contents
   void updateChannelStatus(std::map<HcalDetId, unsigned int>& myqual);
-  void beginJob(void);
   void endJob(void);
   void beginRun(void);
-  void endRun(void); 
+  //void endRun(void); 
   void setup(void);  
   void cleanup(void);
 
@@ -63,6 +62,13 @@ class HcalRecHitClient : public HcalBaseDQClient {
   MonitorElement* meHEEnergyRMSThresh_1D;
   MonitorElement* meHOEnergyRMSThresh_1D;
   MonitorElement* meHFEnergyRMSThresh_1D;
+
+  // - setup problem cell flags
+  bool doProblemCellSetup_;  // defaults to true in the constructor
+  // setup the problem cell monitor elements
+  // This method sets the doProblemCellSetup_ flag to false
+  void setupProblemCells(DQMStore::IBooker &, DQMStore::IGetter &);
+
 };
 
 #endif

--- a/DQM/HcalMonitorClient/interface/HcalSummaryClient.h
+++ b/DQM/HcalMonitorClient/interface/HcalSummaryClient.h
@@ -50,6 +50,13 @@ class HcalSummaryClient : public HcalBaseDQClient {
   MonitorElement* reportMap_;
   MonitorElement* certificationMap_;
 
+  // minEvents and TaskLists_ were added as private members during the
+  // MT migration.
+  // Originally this functionality was performed by the HcalLSbyLSMonitor
+  // under DQM/HcalMonitorTasks
+  int minEvents_;
+  std::vector<std::string> TaskList_;
+
   double status_global_, status_HB_, status_HE_, status_HO_, status_HF_;
   double status_HO0_, status_HO12_, status_HFlumi_;
   int NLumiBlocks_;

--- a/DQM/HcalMonitorClient/interface/HcalSummaryClient.h
+++ b/DQM/HcalMonitorClient/interface/HcalSummaryClient.h
@@ -18,17 +18,16 @@ class HcalSummaryClient : public HcalBaseDQClient {
   HcalSummaryClient(std::string myname);//{ name_=myname;};
   HcalSummaryClient(std::string myname, const edm::ParameterSet& ps);
 
-  void analyze(int LS=-1);
+  void analyze(DQMStore::IBooker &, DQMStore::IGetter &, int LS=-1);
   void updateChannelStatus(std::map<HcalDetId, unsigned int>& myqual);
-  void beginJob(void);
   void endJob(void);
   void beginRun(void);
-  void endRun(void); 
-  void setup(void);  
+  //void endRun(void); 
+  void setup(DQMStore::IBooker &, DQMStore::IGetter &);  
   void cleanup(void);
   
-  void fillReportSummary(int LS);
-  void fillReportSummaryLSbyLS(int LS);
+  void fillReportSummary(DQMStore::IBooker &, DQMStore::IGetter &, int LS);
+  void fillReportSummaryLSbyLS(DQMStore::IBooker &, DQMStore::IGetter &, int LS);
 
   bool hasErrors_Temp(void);  
   bool hasWarnings_Temp(void);
@@ -59,6 +58,8 @@ class HcalSummaryClient : public HcalBaseDQClient {
   std::vector<HcalBaseDQClient*> clients_;
   std::map<std::string, int> subdetCells_;
   int HBpresent_, HEpresent_, HOpresent_, HFpresent_;
+
+  bool doSetup_; // defaults to true in constructor
 };
 
 #endif

--- a/DQM/HcalMonitorClient/interface/HcalTrigPrimClient.h
+++ b/DQM/HcalMonitorClient/interface/HcalTrigPrimClient.h
@@ -14,13 +14,12 @@ class HcalTrigPrimClient : public HcalBaseDQClient {
   HcalTrigPrimClient(std::string myname);//{ name_=myname;};
   HcalTrigPrimClient(std::string myname, const edm::ParameterSet& ps);
 
-  void analyze(void);
-  void calculateProblems(void); // calculates problem histogram contents
+  void analyze(DQMStore::IBooker &, DQMStore::IGetter &);
+  void calculateProblems(DQMStore::IBooker &, DQMStore::IGetter &); // calculates problem histogram contents
   void updateChannelStatus(std::map<HcalDetId, unsigned int>& myqual);
-  void beginJob(void);
   void endJob(void);
   void beginRun(void);
-  void endRun(void); 
+  //void endRun(void); 
   void setup(void);  
   void cleanup(void);
 
@@ -37,6 +36,13 @@ class HcalTrigPrimClient : public HcalBaseDQClient {
 
   EtaPhiHists* ProblemsByDepthZS_;
   EtaPhiHists* ProblemsByDepthNZS_;
+
+  // - setup problem cell flags
+  bool doProblemCellSetup_;  // defaults to true in the constructor
+  // setup the problem cell monitor elements
+  // This method sets the doProblemCellSetup_ flag to false
+  void setupProblemCells(DQMStore::IBooker &, DQMStore::IGetter &);
+
 };
 
 #endif

--- a/DQM/HcalMonitorClient/python/HcalMonitorClient_cfi.py
+++ b/DQM/HcalMonitorClient/python/HcalMonitorClient_cfi.py
@@ -69,4 +69,12 @@ hcalClient = cms.EDAnalyzer("HcalMonitorClient",
                                                                     "Summary"
                                                                     ]
                                                                    ),
+                                 # List directories of all tasks that contribute to this test
+                                 # Make sure that all listed tasks are filling their ProblemCurrentLB histogram,
+                                 # or they will cause this test to automatically fail!
+                                 TaskDirectories        = cms.untracked.vstring("DeadCellMonitor_Hcal/",
+                                                                                "DigiMonitor_Hcal/",
+                                                                                "HotCellMonitor_Hcal/",
+                                                                                "BeamMonitor_Hcal/"),
+                                 minEvents              = cms.untracked.int32(500),
                             )

--- a/DQM/HcalMonitorClient/src/HcalBaseDQClient.cc
+++ b/DQM/HcalMonitorClient/src/HcalBaseDQClient.cc
@@ -142,9 +142,7 @@ void HcalBaseDQClient::htmlOutput(DQMStore::IBooker &ib, DQMStore::IGetter &ig, 
   htmlFile << "cellpadding=\"10\"> " << std::endl;
   
 
-  // CATCH - how do I replace this functionality
-  //std::vector<MonitorElement*> hists = dqmStore_->getAllContents(subdir_);
-  std::vector<MonitorElement*> hists;
+  std::vector<MonitorElement*> hists = ig.getAllContents(subdir_);
   gStyle->SetPalette(1);
   
   int counter=0;

--- a/DQM/HcalMonitorClient/src/HcalBaseDQClient.cc
+++ b/DQM/HcalMonitorClient/src/HcalBaseDQClient.cc
@@ -41,16 +41,6 @@ HcalBaseDQClient::HcalBaseDQClient(std::string s, const edm::ParameterSet& ps)
 HcalBaseDQClient::~HcalBaseDQClient()
 {}
 
-void HcalBaseDQClient::beginJob()
-{
-  dqmStore_ = edm::Service<DQMStore>().operator->();
-  if (debug_>0) 
-    {
-      std::cout <<"<HcalBaseDQClient::beginJob()>  Displaying dqmStore directory structure:"<<std::endl;
-      dqmStore_->showDirStructure();
-    }
-}
-
 void HcalBaseDQClient::setStatusMap(std::map<HcalDetId, unsigned int>& map)
   {
     /* Get the list of all bad channels in the status map,
@@ -70,18 +60,13 @@ void HcalBaseDQClient::setStatusMap(std::map<HcalDetId, unsigned int>& map)
   } // void HcalBaseDQClient::getStatusMap
 
 
-bool HcalBaseDQClient::validHtmlOutput()
+bool HcalBaseDQClient::validHtmlOutput(DQMStore::IBooker &ib, DQMStore::IGetter &ig)
 {
   return validHtmlOutput_;
 }
 
-void HcalBaseDQClient::htmlOutput(std::string htmlDir)
+void HcalBaseDQClient::htmlOutput(DQMStore::IBooker &ib, DQMStore::IGetter &ig, std::string htmlDir)
 {
-  if (dqmStore_==0) 
-    {
-      if (debug_>0) std::cout <<"<HcalBaseDQClient::htmlOutput> dqmStore object does not exist!"<<std::endl;
-      return;
-    }
 
   if (debug_>2) std::cout <<"\t<HcalBaseDQClient::htmlOutput>  Preparing html for task: "<<name_<<std::endl;
   int pcol_error[105];
@@ -157,7 +142,9 @@ void HcalBaseDQClient::htmlOutput(std::string htmlDir)
   htmlFile << "cellpadding=\"10\"> " << std::endl;
   
 
-  std::vector<MonitorElement*> hists = dqmStore_->getAllContents(subdir_);
+  // CATCH - how do I replace this functionality
+  //std::vector<MonitorElement*> hists = dqmStore_->getAllContents(subdir_);
+  std::vector<MonitorElement*> hists;
   gStyle->SetPalette(1);
   
   int counter=0;
@@ -209,6 +196,7 @@ void HcalBaseDQClient::htmlOutput(std::string htmlDir)
   htmlFile << "</body> " << std::endl;
   htmlFile << "</html> " << std::endl;
   htmlFile.close();
+  
   return;
 }
 void HcalBaseDQClient::getLogicalMap(const edm::EventSetup& c) {

--- a/DQM/HcalMonitorClient/src/HcalBaseDQClient.cc
+++ b/DQM/HcalMonitorClient/src/HcalBaseDQClient.cc
@@ -39,7 +39,9 @@ HcalBaseDQClient::HcalBaseDQClient(std::string s, const edm::ParameterSet& ps)
 }
 
 HcalBaseDQClient::~HcalBaseDQClient()
-{}
+{
+  if ( logicalMap_ ) delete logicalMap_;
+}
 
 void HcalBaseDQClient::setStatusMap(std::map<HcalDetId, unsigned int>& map)
   {

--- a/DQM/HcalMonitorClient/src/HcalBeamClient.cc
+++ b/DQM/HcalMonitorClient/src/HcalBeamClient.cc
@@ -51,19 +51,23 @@ HcalBeamClient::HcalBeamClient(std::string myname, const edm::ParameterSet& ps)
 
   ProblemCells=0;
   ProblemCellsByDepth=0;
+
+  setupProblemCells_=true;
 }
 
-void HcalBeamClient::analyze()
+void HcalBeamClient::analyze(DQMStore::IBooker &ib, DQMStore::IGetter &ig)
 {
   if (debug_>2) std::cout <<"\tHcalBeamClient::analyze()"<<std::endl;
   enoughevents_=false;
-  calculateProblems();
+
+  if ( setupProblemCells_ ) doProblemCellSetup(ib,ig);
+
+  calculateProblems(ib,ig);
 }
 
-void HcalBeamClient::calculateProblems()
+void HcalBeamClient::calculateProblems(DQMStore::IBooker &ib, DQMStore::IGetter &ig)
 {
   if (debug_>2) std::cout <<"\t\tHcalBeamClient::calculateProblems()"<<std::endl;
-  if(!dqmStore_) return;
   double totalLumiBlocks=0;
   // reminder:: lumi histograms work a bit differently, counting total number of lumi blocks, not total number of events
   int etabins=0, phibins=0, zside=0;
@@ -93,11 +97,11 @@ void HcalBeamClient::calculateProblems()
   TH2F* dead = 0;
   TH2F* hot  = 0;
   MonitorElement* me;
-  me=dqmStore_->get(subdir_+"Lumi/HFlumi_total_deadcells");
+  me=ig.get(subdir_+"Lumi/HFlumi_total_deadcells");
   if (me!=0)
     dead=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_,dead,debug_);
   else if (debug_>0) std::cout <<" <HcalBeamClient::calculateProblems> Unable to get dead cell plot 'HFlumi_total_deadcells"<<std::endl;
-  me=dqmStore_->get(subdir_+"Lumi/HFlumi_total_hotcells");
+  me=ig.get(subdir_+"Lumi/HFlumi_total_hotcells");
   if (me!=0)
     hot=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_,dead,debug_);
   else if (debug_>0) std::cout <<" <HcalBeamClient::calculateProblems> Unable to get hot cell plot 'HFlumi_total_hotcells"<<std::endl;
@@ -180,47 +184,42 @@ void HcalBeamClient::calculateProblems()
   return;
 }
 
-void HcalBeamClient::beginJob()
-{
-  dqmStore_ = edm::Service<DQMStore>().operator->();
-  if (debug_>0) 
-    {
-      std::cout <<"<HcalBeamClient::beginJob()>  Displaying dqmStore directory structure:"<<std::endl;
-      dqmStore_->showDirStructure();
-    }
-}
 void HcalBeamClient::endJob(){}
 
-void HcalBeamClient::beginRun(void)
+void HcalBeamClient::doProblemCellSetup(DQMStore::IBooker &ib, DQMStore::IGetter &ig)
 {
-  enoughevents_=false;
-  if (!dqmStore_) 
-    {
-      if (debug_>0) std::cout <<"<HcalBeamClient::beginRun> dqmStore does not exist!"<<std::endl;
-      return;
-    }
-  dqmStore_->setCurrentFolder(subdir_);
+
+  ib.setCurrentFolder(subdir_);
   problemnames_.clear();
 
   // Put the appropriate name of your problem summary here
   if (ProblemCells==0)
-    ProblemCells=dqmStore_->book2D(" Problem BeamMonitor",
+    ProblemCells=ib.book2D(" Problem BeamMonitor",
 				   " Problem Beam Monitor Rate for all HCAL;ieta;iphi",
 				   85,-42.5,42.5,
 				   72,0.5,72.5);
   problemnames_.push_back(ProblemCells->getName());
   if (debug_>1)
     std::cout << "Tried to create ProblemCells Monitor Element in directory "<<subdir_<<"  \t  Failed?  "<<(ProblemCells==0)<<std::endl;
-  dqmStore_->setCurrentFolder(subdir_+"problem_beammonitor");
+  ib.setCurrentFolder(subdir_+"problem_beammonitor");
   nevts_=0;
   if (ProblemCellsByDepth!=0) return; // histograms already set up
   ProblemCellsByDepth = new EtaPhiHists();
-  ProblemCellsByDepth->setup(dqmStore_," Problem BeamMonitor Rate");
+  ProblemCellsByDepth->setup(ib," Problem BeamMonitor Rate");
   for (unsigned int i=0; i<ProblemCellsByDepth->depth.size();++i)
     problemnames_.push_back(ProblemCellsByDepth->depth[i]->getName());
+
+  setupProblemCells_ = false;
+
 }
 
-void HcalBeamClient::endRun(void){analyze();}
+//
+void HcalBeamClient::beginRun(void)
+{
+  enoughevents_=false;
+}
+
+//void HcalBeamClient::endRun(void){analyze();}
 
 void HcalBeamClient::setup(void){}
 void HcalBeamClient::cleanup(void){}

--- a/DQM/HcalMonitorClient/src/HcalBeamClient.cc
+++ b/DQM/HcalMonitorClient/src/HcalBeamClient.cc
@@ -271,4 +271,6 @@ void HcalBeamClient::updateChannelStatus(std::map<HcalDetId, unsigned int>& myqu
 } //void HcalBeamClient::updateChannelStatus
 
 HcalBeamClient::~HcalBeamClient()
-{}
+{
+  if ( ProblemCellsByDepth ) delete ProblemCellsByDepth;
+}

--- a/DQM/HcalMonitorClient/src/HcalCoarsePedestalClient.cc
+++ b/DQM/HcalMonitorClient/src/HcalCoarsePedestalClient.cc
@@ -49,18 +49,19 @@ HcalCoarsePedestalClient::HcalCoarsePedestalClient(std::string myname, const edm
 
   ProblemCellsByDepth=0;
 
+  doCoarseSetup_ = true;
 }
 
-void HcalCoarsePedestalClient::analyze()
+void HcalCoarsePedestalClient::analyze(DQMStore::IBooker &ib, DQMStore::IGetter &ig)
 {
   if (debug_>2) std::cout <<"\tHcalCoarsePedestalClient::analyze()"<<std::endl;
-  calculateProblems();
+  if ( doCoarseSetup_ ) setupCoarsePedestal(ib,ig);
+  calculateProblems(ib,ig);
 } // void HcalCoarsePedestalClient::analyze()
 
-void HcalCoarsePedestalClient::calculateProblems()
+void HcalCoarsePedestalClient::calculateProblems(DQMStore::IBooker &ib, DQMStore::IGetter &ig)
 {
  if (debug_>2) std::cout <<"\t\tHcalCoarsePedestalClient::calculateProblems()"<<std::endl;
-  if(!dqmStore_) return;
   //int totalevents=0; // events checked on a channel-by-channel basis
   int etabins=0, phibins=0, zside=0;
   double problemvalue=0;
@@ -97,7 +98,7 @@ void HcalCoarsePedestalClient::calculateProblems()
   for (int i=0;i<4;++i)
     {
       std::string s=subdir_+"CoarsePedestalSumPlots/"+name[i]+"Coarse Pedestal Summed Map";
-      me=dqmStore_->get(s.c_str());
+      me=ig.get(s.c_str());
       if (me==0) 
 	{
 	  gothistos=false;
@@ -106,7 +107,7 @@ void HcalCoarsePedestalClient::calculateProblems()
       CoarsePedestalsSumByDepth[i]=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, CoarsePedestalsSumByDepth[i], debug_);
 
       s=subdir_+"CoarsePedestalSumPlots/"+name[i]+"Coarse Pedestal Occupancy Map";
-      me=dqmStore_->get(s.c_str());
+      me=ig.get(s.c_str());
       if (me==0) 
 	{
 	  gothistos=false;
@@ -212,43 +213,33 @@ void HcalCoarsePedestalClient::calculateProblems()
 }
 
 
-void HcalCoarsePedestalClient::beginJob()
-{
-  dqmStore_ = edm::Service<DQMStore>().operator->();
-  if (debug_>0) 
-    {
-      std::cout <<"<HcalCoarsePedestalClient::beginJob()>  Displaying dqmStore directory structure:"<<std::endl;
-      dqmStore_->showDirStructure();
-    }
-}
-
 void HcalCoarsePedestalClient::endJob(){}
 
 void HcalCoarsePedestalClient::beginRun(void)
 {
   enoughevents_=false;
-  if (!dqmStore_) 
-    {
-      if (debug_>0) std::cout <<"<HcalCoarsePedestalClient::beginRun> dqmStore does not exist!"<<std::endl;
-      return;
-    }
-  dqmStore_->setCurrentFolder(subdir_);
-  CoarsePedestalsByDepth = new EtaPhiHists();
-  CoarsePedestalsByDepth->setup(dqmStore_," Coarse Pedestal Map");
+} // void HcalCoarsePedestalClient::beginRun()
 
-  CoarsePedDiff=dqmStore_->book1D("PedRefDiff","(Pedestal-Reference)",200,-10,10);
+void HcalCoarsePedestalClient::setupCoarsePedestal(DQMStore::IBooker &ib, DQMStore::IGetter &ig)
+{
+
+  ib.setCurrentFolder(subdir_);
+  CoarsePedestalsByDepth = new EtaPhiHists();
+  CoarsePedestalsByDepth->setup(ib," Coarse Pedestal Map");
+
+  CoarsePedDiff=ib.book1D("PedRefDiff","(Pedestal-Reference)",200,-10,10);
 
   problemnames_.clear();
-  ProblemCells=dqmStore_->book2D(" ProblemCoarsePedestals",
+  ProblemCells=ib.book2D(" ProblemCoarsePedestals",
 				 " Problem Coarse Pedestal Rate for all HCAL;ieta;iphi",
 				 85,-42.5,42.5,
 				 72,0.5,72.5);
   problemnames_.push_back(ProblemCells->getName());
   if (debug_>1)
     std::cout << "Tried to create ProblemCells Monitor Element in directory "<<subdir_<<"  \t  Failed?  "<<(ProblemCells==0)<<std::endl;
-  dqmStore_->setCurrentFolder(subdir_+"problem_coarsepedestals");
+  ib.setCurrentFolder(subdir_+"problem_coarsepedestals");
   ProblemCellsByDepth = new EtaPhiHists();
-  ProblemCellsByDepth->setup(dqmStore_," Problem Coarse Pedestal Rate");
+  ProblemCellsByDepth->setup(ib," Problem Coarse Pedestal Rate");
   for (unsigned int i=0; i<ProblemCellsByDepth->depth.size();++i)
     problemnames_.push_back(ProblemCellsByDepth->depth[i]->getName());
   nevts_=0;
@@ -258,7 +249,7 @@ void HcalCoarsePedestalClient::beginRun(void)
   for (int i=0;i<4;++i)
     {
       std::string s=prefixME_+"HcalInfo/PedestalsFromCondDB/"+name[i]+"ADC Pedestals From Conditions DB";
-      me=dqmStore_->get(s.c_str());
+      me=ig.get(s.c_str());
       if (me==0) 
 	{
 	  if (debug_>0) std::cout <<"<HcalCoarsePedestalClient::beginRun> Could not get histogram with name "<<s<<std::endl;
@@ -266,7 +257,7 @@ void HcalCoarsePedestalClient::beginRun(void)
       DatabasePedestalsADCByDepth[i]=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, DatabasePedestalsADCByDepth[i], debug_);
     }
   std::string s=subdir_+"CoarsePedestal_parameters/ADCdiff_Problem_Threshold";
-  me=dqmStore_->get(s.c_str());
+  me=ig.get(s.c_str());
   if (me==0)
     {
       if (debug_>0) 
@@ -276,7 +267,7 @@ void HcalCoarsePedestalClient::beginRun(void)
     ADCDiffThresh_=me->getFloatValue();
   s=subdir_+"CoarsePedestal_parameters/minEventsNeededForPedestalCalculation";
 
-  me=dqmStore_->get(s.c_str());
+  me=ig.get(s.c_str());
   int temp = 0;
   if (me==0) 
     {
@@ -293,9 +284,12 @@ void HcalCoarsePedestalClient::beginRun(void)
 	std::cout <<"<HcalCoarsePedestalClient::beginRun>  Specified client 'minevents' value of "<<minevents_<<"  is less than minimum task 'minevents' value of "<<temp<<"\n\t  Setting client 'minevents' to "<<temp<<std::endl;
       minevents_=temp;
     }
-} // void HcalCoarsePedestalClient::beginRun()
 
-void HcalCoarsePedestalClient::endRun(void){analyze();}
+  doCoarseSetup_ = false;
+
+}
+
+//void HcalCoarsePedestalClient::endRun(void){analyze();}
 
 void HcalCoarsePedestalClient::setup(void){}
 void HcalCoarsePedestalClient::cleanup(void){}

--- a/DQM/HcalMonitorClient/src/HcalCoarsePedestalClient.cc
+++ b/DQM/HcalMonitorClient/src/HcalCoarsePedestalClient.cc
@@ -47,6 +47,7 @@ HcalCoarsePedestalClient::HcalCoarsePedestalClient(std::string myname, const edm
   minevents_    = ps.getUntrackedParameter<int>("CoarsePedestal_minevents",
 						ps.getUntrackedParameter<int>("minevents",1));
 
+  CoarsePedestalsByDepth=0;
   ProblemCellsByDepth=0;
 
   doCoarseSetup_ = true;
@@ -339,4 +340,9 @@ void HcalCoarsePedestalClient::updateChannelStatus(std::map<HcalDetId, unsigned 
 } //void HcalCoarsePedestalClient::updateChannelStatus
 
 HcalCoarsePedestalClient::~HcalCoarsePedestalClient()
-{}
+{
+
+  if ( CoarsePedestalsByDepth ) delete CoarsePedestalsByDepth;
+  if ( ProblemCellsByDepth ) delete ProblemCellsByDepth;
+
+}

--- a/DQM/HcalMonitorClient/src/HcalDeadCellClient.cc
+++ b/DQM/HcalMonitorClient/src/HcalDeadCellClient.cc
@@ -51,28 +51,26 @@ HcalDeadCellClient::HcalDeadCellClient(std::string myname, const edm::ParameterS
   ProblemCellsByDepth=0;
   ProblemCells=0;
 
+  doProblemCellSetup_ = true;
+
 }
 
-void HcalDeadCellClient::analyze()
+void HcalDeadCellClient::analyze(DQMStore::IBooker &ib, DQMStore::IGetter &ig)
 {
   if (debug_>2) std::cout <<"\tHcalDeadCellClient::analyze()"<<std::endl;
-  calculateProblems();
+  if ( doProblemCellSetup_ ) setupProblemCells(ib,ig);
+  calculateProblems(ib,ig);
 }
 
-void HcalDeadCellClient::calculateProblems()
+void HcalDeadCellClient::calculateProblems(DQMStore::IBooker &ib, DQMStore::IGetter &ig)
 {
 
 
   if (debug_>2) std::cout <<"\t\tHcalDeadCellClient::calculateProblems()"<<std::endl;
-  if(!dqmStore_) 
-    {
-      if (debug_>2) std::cout <<"DQM STORE DOESN'T EXIST"<<std::endl;
-      return;
-    }
 
   MonitorElement* temp_present;
 
-  temp_present=dqmStore_->get(subdir_+"ExcludeHOring2");
+  temp_present=ig.get(subdir_+"ExcludeHOring2");
   int excludeFromHOring2 = 0;
   if (temp_present)
     {
@@ -90,25 +88,25 @@ void HcalDeadCellClient::calculateProblems()
   // Don't fill histograms if nothing from Hcal is present
   if (HBpresent_!=1)
     {
-      temp_present=dqmStore_->get(prefixME_+"HcalInfo/HBpresent");
+      temp_present=ig.get(prefixME_+"HcalInfo/HBpresent");
       if (temp_present!=0)
         HBpresent_=temp_present->getIntValue();
     }
   if (HEpresent_!=1)
     {
-      temp_present=dqmStore_->get(prefixME_+"HcalInfo/HEpresent");
+      temp_present=ig.get(prefixME_+"HcalInfo/HEpresent");
       if (temp_present!=0)
         HEpresent_=temp_present->getIntValue();
     }
   if (HOpresent_!=1)
     {
-      temp_present=dqmStore_->get(prefixME_+"HcalInfo/HOpresent");
+      temp_present=ig.get(prefixME_+"HcalInfo/HOpresent");
       if (temp_present!=0)
         HOpresent_=temp_present->getIntValue();
     }
   if (HFpresent_!=1)
     {
-      temp_present=dqmStore_->get(prefixME_+"HcalInfo/HFpresent");
+      temp_present=ig.get(prefixME_+"HcalInfo/HFpresent");
       if (temp_present!=0)
         HFpresent_=temp_present->getIntValue();
     }
@@ -154,19 +152,19 @@ void HcalDeadCellClient::calculateProblems()
       RecentMissingRecHitsByDepth[i]=0;
       
       std::string s=subdir_+"dead_digi_never_present/"+name[i]+"Digi Present At Least Once";
-      me=dqmStore_->get(s.c_str());
+      me=ig.get(s.c_str());
       if (me!=0) DigiPresentByDepth[i]=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, DigiPresentByDepth[i], debug_);
       
       s=subdir_+"dead_digi_often_missing/"+name[i]+"Dead Cells with No Digis";
-      me=dqmStore_->get(s.c_str());
+      me=ig.get(s.c_str());
       if (me!=0) RecentMissingDigisByDepth[i]=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, RecentMissingDigisByDepth[i], debug_);
      
       s=subdir_+"dead_rechit_never_present/"+name[i]+"RecHit Above Threshold At Least Once";
-      me=dqmStore_->get(s.c_str());
+      me=ig.get(s.c_str());
       if (me!=0) RecHitsPresentByDepth[i]=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, RecHitsPresentByDepth[i], debug_);
 
        s=subdir_+"dead_rechit_often_missing/"+name[i]+"RecHits Failing Energy Threshold Test";
-      me=dqmStore_->get(s.c_str());
+      me=ig.get(s.c_str());
       if (me!=0)RecentMissingRecHitsByDepth[i]=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, RecentMissingRecHitsByDepth[i], debug_);
 
     }
@@ -275,16 +273,29 @@ void HcalDeadCellClient::calculateProblems()
   return;
 }
 
-void HcalDeadCellClient::beginJob()
-{
-  dqmStore_ = edm::Service<DQMStore>().operator->();
-  if (debug_>0) 
-    {
-      std::cout <<"<HcalDeadCellClient::beginJob()>  Displaying dqmStore directory structure:"<<std::endl;
-      dqmStore_->showDirStructure();
-    }
-}
 void HcalDeadCellClient::endJob(){}
+
+void HcalDeadCellClient::setupProblemCells(DQMStore::IBooker &ib, DQMStore::IGetter &ig )
+{
+
+  ib.setCurrentFolder(subdir_);
+  problemnames_.clear();
+  ProblemCells=ib.book2D(" ProblemDeadCells",
+				 " Problem Dead Cell Rate for all HCAL;ieta;iphi",
+				 85,-42.5,42.5,
+				 72,0.5,72.5);
+  problemnames_.push_back(ProblemCells->getName());
+  if (debug_>1)
+    std::cout << "Tried to create ProblemCells Monitor Element in directory "<<subdir_<<"  \t  Failed?  "<<(ProblemCells==0)<<std::endl;
+  ib.setCurrentFolder(subdir_+"problem_deadcells");
+  ProblemCellsByDepth = new EtaPhiHists();
+  ProblemCellsByDepth->setup(ib," Problem Dead Cell Rate");
+  for (unsigned int i=0; i<ProblemCellsByDepth->depth.size();++i)
+    problemnames_.push_back(ProblemCellsByDepth->depth[i]->getName());
+
+  doProblemCellSetup_ = false;
+
+}
 
 void HcalDeadCellClient::beginRun(void)
 {
@@ -293,30 +304,11 @@ void HcalDeadCellClient::beginRun(void)
   HEpresent_=-1;
   HOpresent_=-1;
   HFpresent_=-1;
-  if (!dqmStore_) 
-    {
-      if (debug_>0) std::cout <<"<HcalDeadCellClient::beginRun> dqmStore does not exist!"<<std::endl;
-      return;
-    }
-  dqmStore_->setCurrentFolder(subdir_);
-  problemnames_.clear();
-  ProblemCells=dqmStore_->book2D(" ProblemDeadCells",
-				 " Problem Dead Cell Rate for all HCAL;ieta;iphi",
-				 85,-42.5,42.5,
-				 72,0.5,72.5);
-  problemnames_.push_back(ProblemCells->getName());
-  if (debug_>1)
-    std::cout << "Tried to create ProblemCells Monitor Element in directory "<<subdir_<<"  \t  Failed?  "<<(ProblemCells==0)<<std::endl;
-  dqmStore_->setCurrentFolder(subdir_+"problem_deadcells");
-  ProblemCellsByDepth = new EtaPhiHists();
-  ProblemCellsByDepth->setup(dqmStore_," Problem Dead Cell Rate");
-  for (unsigned int i=0; i<ProblemCellsByDepth->depth.size();++i)
-    problemnames_.push_back(ProblemCellsByDepth->depth[i]->getName());
 
   nevts_=0;
 }
 
-void HcalDeadCellClient::endRun(void){analyze();}
+//void HcalDeadCellClient::endRun(void){analyze();}
 
 void HcalDeadCellClient::setup(void){}
 void HcalDeadCellClient::cleanup(void){}

--- a/DQM/HcalMonitorClient/src/HcalDeadCellClient.cc
+++ b/DQM/HcalMonitorClient/src/HcalDeadCellClient.cc
@@ -434,4 +434,6 @@ void HcalDeadCellClient::updateChannelStatus(std::map<HcalDetId, unsigned int>& 
 } //void HcalDeadCellClient::updateChannelStatus
 
 HcalDeadCellClient::~HcalDeadCellClient()
-{}
+{
+  if ( ProblemCellsByDepth ) delete ProblemCellsByDepth;
+}

--- a/DQM/HcalMonitorClient/src/HcalDetDiagLEDClient.cc
+++ b/DQM/HcalMonitorClient/src/HcalDetDiagLEDClient.cc
@@ -39,14 +39,17 @@ HcalDetDiagLEDClient::HcalDetDiagLEDClient(std::string myname, const edm::Parame
   badChannelStatusMask_   = ps.getUntrackedParameter<int>("DetDiagLED_BadChannelStatusMask",
                             ps.getUntrackedParameter<int>("BadChannelStatusMask",(1<<HcalChannelStatus::HcalCellDead)));
   needLogicalMap_=true;
+
+  doProblemCellSetup_ = true;
 }
 
-void HcalDetDiagLEDClient::analyze(){
+void HcalDetDiagLEDClient::analyze(DQMStore::IBooker &ib, DQMStore::IGetter &ig){
   if (debug_>2) std::cout <<"\tHcalDetDiagLEDClient::analyze()"<<std::endl;
-  calculateProblems();
+  if ( doProblemCellSetup_ ) setupProblemCells(ib,ig);
+  calculateProblems(ib,ig);
 }
 
-void HcalDetDiagLEDClient::calculateProblems(){}
+void HcalDetDiagLEDClient::calculateProblems(DQMStore::IBooker &ib, DQMStore::IGetter &ig){}
 void HcalDetDiagLEDClient::updateChannelStatus(std::map<HcalDetId, unsigned int>& myqual){
   // This gets called by HcalMonitorClient
   // trigger primitives don't yet contribute to channel status (though they could...)
@@ -54,40 +57,37 @@ void HcalDetDiagLEDClient::updateChannelStatus(std::map<HcalDetId, unsigned int>
 
 }
 
-void HcalDetDiagLEDClient::beginJob(){
-  dqmStore_ = edm::Service<DQMStore>().operator->();
-  if (debug_>0){
-    std::cout <<"<HcalDetDiagLEDClient::beginJob()>  Displaying dqmStore directory structure:"<<std::endl;
-    dqmStore_->showDirStructure();
-  }
-}
+
 void HcalDetDiagLEDClient::endJob(){}
 
-void HcalDetDiagLEDClient::beginRun(void){
-  if (!dqmStore_) 
-    {
-      if (debug_>0) std::cout <<"<HcalDetDiagLEDClient::beginRun> dqmStore does not exist!"<<std::endl;
-      return;
-    }
-  dqmStore_->setCurrentFolder(subdir_);
+void HcalDetDiagLEDClient::setupProblemCells(DQMStore::IBooker &ib, DQMStore::IGetter &ig )
+{
+
+  ib.setCurrentFolder(subdir_);
   problemnames_.clear();
 
   // Put the appropriate name of your problem summary here
-  ProblemCells=dqmStore_->book2D(" ProblemDetDiagLED",
+  ProblemCells=ib.book2D(" ProblemDetDiagLED",
 				 " Problem DetDiagLED Rate for all HCAL;ieta;iphi",
 				 85,-42.5,42.5,
 				 72,0.5,72.5);
   problemnames_.push_back(ProblemCells->getName());
   if (debug_>1)
     std::cout << "Tried to create ProblemCells Monitor Element in directory "<<subdir_<<"  \t  Failed?  "<<(ProblemCells==0)<<std::endl;
-  dqmStore_->setCurrentFolder(subdir_+"problem_DetDiagLED");
+  ib.setCurrentFolder(subdir_+"problem_DetDiagLED");
   ProblemCellsByDepth = new EtaPhiHists();
-  ProblemCellsByDepth->setup(dqmStore_," Problem DetDiagLED Rate");
+  ProblemCellsByDepth->setup(ib," Problem DetDiagLED Rate");
   for (unsigned int i=0; i<ProblemCellsByDepth->depth.size();++i)
     problemnames_.push_back(ProblemCellsByDepth->depth[i]->getName());
+
+ doProblemCellSetup_ = false;
+
+}
+
+void HcalDetDiagLEDClient::beginRun(void){
   nevts_=0;
 }
-void HcalDetDiagLEDClient::endRun(void){analyze();}
+//void HcalDetDiagLEDClient::endRun(void){analyze();}
 void HcalDetDiagLEDClient::setup(void){}
 void HcalDetDiagLEDClient::cleanup(void){}
 
@@ -102,9 +102,9 @@ bool HcalDetDiagLEDClient::hasWarnings_Temp(void){
 bool HcalDetDiagLEDClient::hasOther_Temp(void){return false;}
 bool HcalDetDiagLEDClient::test_enabled(void){return true;}
 
-bool HcalDetDiagLEDClient::validHtmlOutput(){
+bool HcalDetDiagLEDClient::validHtmlOutput(DQMStore::IBooker &ib, DQMStore::IGetter &ig){
   std::string s=subdir_+"HcalDetDiagLEDMonitor Event Number";
-  MonitorElement *me = dqmStore_->get(s.c_str());
+  MonitorElement *me = ig.get(s.c_str());
   int n=0;
   if ( me ) {
     s = me->valueString();
@@ -212,7 +212,7 @@ double HcalDetDiagLEDClient::get_energy(std::string subdet,int eta,int phi,int d
    if(type==2) return ChannelsLEDEnergyRef[depth-1]->GetBinContent(ietabin,phi);
    return -1.0;
 }
-void HcalDetDiagLEDClient::htmlOutput(std::string htmlDir){
+void HcalDetDiagLEDClient::htmlOutput(DQMStore::IBooker &ib, DQMStore::IGetter &ig, std::string htmlDir){
 MonitorElement* me;
 int  MissingCnt=0;
 int  UnstableCnt=0;
@@ -228,7 +228,6 @@ int  HO[7] ={0,0,0,0,0,0,0},newHO[7] ={0,0,0,0,0,0,0};
 std::string subdet[4]={"HB","HE","HO","HF"};
 
    if (debug_>0) std::cout << "<HcalDetDiagLEDClient::htmlOutput> Preparing  html output ..." << std::endl;
-   if(!dqmStore_) return;
    HcalElectronicsMap emap=logicalMap_->generateHcalElectronicsMap();
    std::vector<std::string> name = HcalEtaPhiHistNames();
 
@@ -238,31 +237,31 @@ std::string subdet[4]={"HB","HE","HO","HF"};
       ChannelStatusTimeRMS[i]=0;
       std::string s;
       s=subdir_+"channel status/"+name[i]+" Missing Channels";
-      me=dqmStore_->get(s.c_str());
+      me=ig.get(s.c_str());
       if (me!=0) ChannelStatusMissingChannels[i]=HcalUtilsClient::getHisto<TH2F*>(me,cloneME_,ChannelStatusMissingChannels[i],debug_); else return;  
       s=subdir_+"channel status/"+name[i]+" Unstable Channels";
-      me=dqmStore_->get(s.c_str());
+      me=ig.get(s.c_str());
       if (me!=0) ChannelStatusUnstableChannels[i]=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, ChannelStatusUnstableChannels[i], debug_); else return;  
       s=subdir_+"channel status/"+name[i]+" Unstable LED";
-      me=dqmStore_->get(s.c_str());
+      me=ig.get(s.c_str());
       if (me!=0) ChannelStatusUnstableLEDsignal[i]=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, ChannelStatusUnstableLEDsignal[i], debug_); else return;  
       s=subdir_+"channel status/"+name[i]+" LED Mean";
-      me=dqmStore_->get(s.c_str());
+      me=ig.get(s.c_str());
       if (me!=0) ChannelStatusLEDMean[i]=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, ChannelStatusLEDMean[i], debug_); else return;  
       s=subdir_+"channel status/"+name[i]+" LED RMS";
-      me=dqmStore_->get(s.c_str());
+      me=ig.get(s.c_str());
       if (me!=0) ChannelStatusLEDRMS[i]=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, ChannelStatusLEDRMS[i], debug_); else return;  
       s=subdir_+"channel status/"+name[i]+" Time Mean";
-      me=dqmStore_->get(s.c_str());
+      me=ig.get(s.c_str());
       if (me!=0) ChannelStatusTimeMean[i]=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, ChannelStatusTimeMean[i], debug_); else return;  
       s=subdir_+"channel status/"+name[i]+" Time RMS";
-      me=dqmStore_->get(s.c_str());
+      me=ig.get(s.c_str());
       if (me!=0) ChannelStatusTimeRMS[i]=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, ChannelStatusTimeRMS[i], debug_); else return;  
       s=subdir_+"Summary Plots/"+name[i]+" Channel LED Energy";
-      me=dqmStore_->get(s.c_str());
+      me=ig.get(s.c_str());
       if (me!=0) ChannelsLEDEnergy[i]=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, ChannelsLEDEnergy[i], debug_); else return;  
       s=subdir_+"Summary Plots/"+name[i]+" Channel LED Energy Reference";
-      me=dqmStore_->get(s.c_str());
+      me=ig.get(s.c_str());
       if (me!=0) ChannelsLEDEnergyRef[i]=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, ChannelsLEDEnergyRef[i], debug_); else return;
   }
 
@@ -471,19 +470,19 @@ std::string subdet[4]={"HB","HE","HO","HF"};
   int ievt_ = -1,runNo=-1;
   std::string ref_run;
   std::string s=subdir_+"HcalDetDiagLEDMonitor Event Number";
-  me = dqmStore_->get(s.c_str());
+  me = ig.get(s.c_str());
   if ( me ) {
     s = me->valueString();
     sscanf((s.substr(2,s.length()-2)).c_str(), "%d", &ievt_);
   }
   s=subdir_+"HcalDetDiagLEDMonitor Run Number";
-  me = dqmStore_->get(s.c_str());
+  me = ig.get(s.c_str());
   if ( me ) {
     s = me->valueString();
     sscanf((s.substr(2,s.length()-2)).c_str(), "%d", &runNo);
   } 
   s=subdir_+"HcalDetDiagLEDMonitor Reference Run";
-  me = dqmStore_->get(s.c_str());
+  me = ig.get(s.c_str());
   if(me) {
     std::string s=me->valueString();
     char str[200]; 
@@ -494,54 +493,54 @@ std::string subdet[4]={"HB","HE","HO","HF"};
   TH2F *Time2Dhbhehf=0,*Time2Dho=0,*Energy2Dhbhehf=0,*Energy2Dho=0;
   TH2F *HBPphi=0,*HBMphi=0,*HEPphi=0,*HEMphi=0,*HFPphi=0,*HFMphi=0,*HO0phi=0,*HO1Pphi=0,*HO2Pphi=0,*HO1Mphi=0,*HO2Mphi=0;
 
-  s=subdir_+"Summary Plots/HBHEHO LED Energy Distribution"; me=dqmStore_->get(s.c_str());
+  s=subdir_+"Summary Plots/HBHEHO LED Energy Distribution"; me=ig.get(s.c_str());
   if(me!=0) Energy=HcalUtilsClient::getHisto<TH1F*>(me, cloneME_, Energy, debug_); else return;
-  s=subdir_+"Summary Plots/HBHEHO LED Timing Distribution"; me=dqmStore_->get(s.c_str());
+  s=subdir_+"Summary Plots/HBHEHO LED Timing Distribution"; me=ig.get(s.c_str());
   if(me!=0) Timing=HcalUtilsClient::getHisto<TH1F*>(me, cloneME_, Timing, debug_); else return;
-  s=subdir_+"Summary Plots/HBHEHO LED Energy RMS_div_Energy Distribution"; me=dqmStore_->get(s.c_str());
+  s=subdir_+"Summary Plots/HBHEHO LED Energy RMS_div_Energy Distribution"; me=ig.get(s.c_str());
   if(me!=0) EnergyRMS=HcalUtilsClient::getHisto<TH1F*>(me, cloneME_, EnergyRMS, debug_); else return;
-  s=subdir_+"Summary Plots/HBHEHO LED Timing RMS Distribution"; me=dqmStore_->get(s.c_str());
+  s=subdir_+"Summary Plots/HBHEHO LED Timing RMS Distribution"; me=ig.get(s.c_str());
   if(me!=0) TimingRMS=HcalUtilsClient::getHisto<TH1F*>(me, cloneME_, TimingRMS, debug_); else return;
-  s=subdir_+"Summary Plots/HF LED Energy Distribution"; me=dqmStore_->get(s.c_str());
+  s=subdir_+"Summary Plots/HF LED Energy Distribution"; me=ig.get(s.c_str());
   if(me!=0) EnergyHF=HcalUtilsClient::getHisto<TH1F*>(me, cloneME_, EnergyHF, debug_); else return;
-  s=subdir_+"Summary Plots/HF LED Timing Distribution"; me=dqmStore_->get(s.c_str());
+  s=subdir_+"Summary Plots/HF LED Timing Distribution"; me=ig.get(s.c_str());
   if(me!=0) TimingHF=HcalUtilsClient::getHisto<TH1F*>(me, cloneME_, TimingHF, debug_); else return;
-  s=subdir_+"Summary Plots/HF LED Energy RMS_div_Energy Distribution"; me=dqmStore_->get(s.c_str());
+  s=subdir_+"Summary Plots/HF LED Energy RMS_div_Energy Distribution"; me=ig.get(s.c_str());
   if(me!=0) EnergyRMSHF=HcalUtilsClient::getHisto<TH1F*>(me, cloneME_, EnergyRMSHF, debug_); else return;
-  s=subdir_+"Summary Plots/HF LED Timing RMS Distribution"; me=dqmStore_->get(s.c_str());
+  s=subdir_+"Summary Plots/HF LED Timing RMS Distribution"; me=ig.get(s.c_str());
   if(me!=0) TimingRMSHF=HcalUtilsClient::getHisto<TH1F*>(me, cloneME_, TimingRMSHF, debug_); else return;
 
-  s=subdir_+"Summary Plots/LED Timing HBHEHF"; me=dqmStore_->get(s.c_str());
+  s=subdir_+"Summary Plots/LED Timing HBHEHF"; me=ig.get(s.c_str());
   if(me!=0) Time2Dhbhehf=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, Time2Dhbhehf, debug_); else return;
-  s=subdir_+"Summary Plots/LED Timing HO"; me=dqmStore_->get(s.c_str());
+  s=subdir_+"Summary Plots/LED Timing HO"; me=ig.get(s.c_str());
   if(me!=0) Time2Dho=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, Time2Dho, debug_); else return;
-  s=subdir_+"Summary Plots/LED Energy HBHEHF"; me=dqmStore_->get(s.c_str());
+  s=subdir_+"Summary Plots/LED Energy HBHEHF"; me=ig.get(s.c_str());
   if(me!=0) Energy2Dhbhehf=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, Energy2Dhbhehf, debug_); else return;
-  s=subdir_+"Summary Plots/LED Energy HO"; me=dqmStore_->get(s.c_str());
+  s=subdir_+"Summary Plots/LED Energy HO"; me=ig.get(s.c_str());
   if(me!=0) Energy2Dho=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, Energy2Dho, debug_); else return;
 
-  s=subdir_+"Summary Plots/HBP Average over HPD LED Ref"; me=dqmStore_->get(s.c_str());
+  s=subdir_+"Summary Plots/HBP Average over HPD LED Ref"; me=ig.get(s.c_str());
   if(me!=0) HBPphi=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, HBPphi, debug_); else return;
-  s=subdir_+"Summary Plots/HBM Average over HPD LED Ref"; me=dqmStore_->get(s.c_str());
+  s=subdir_+"Summary Plots/HBM Average over HPD LED Ref"; me=ig.get(s.c_str());
   if(me!=0) HBMphi=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, HBMphi, debug_); else return;
-  s=subdir_+"Summary Plots/HEP Average over HPD LED Ref"; me=dqmStore_->get(s.c_str());
+  s=subdir_+"Summary Plots/HEP Average over HPD LED Ref"; me=ig.get(s.c_str());
   if(me!=0) HEPphi=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, HEPphi, debug_); else return;
-  s=subdir_+"Summary Plots/HEM Average over HPD LED Ref"; me=dqmStore_->get(s.c_str());
+  s=subdir_+"Summary Plots/HEM Average over HPD LED Ref"; me=ig.get(s.c_str());
   if(me!=0) HEMphi=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, HEMphi, debug_); else return;
-  s=subdir_+"Summary Plots/HFP Average over RM LED Ref"; me=dqmStore_->get(s.c_str());
+  s=subdir_+"Summary Plots/HFP Average over RM LED Ref"; me=ig.get(s.c_str());
   if(me!=0) HFPphi=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, HFPphi, debug_); else return;
-  s=subdir_+"Summary Plots/HFM Average over RM LED Ref"; me=dqmStore_->get(s.c_str());
+  s=subdir_+"Summary Plots/HFM Average over RM LED Ref"; me=ig.get(s.c_str());
   if(me!=0) HFMphi=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, HFMphi, debug_); else return;
 
-  s=subdir_+"Summary Plots/HO0 Average over HPD LED Ref"; me=dqmStore_->get(s.c_str());
+  s=subdir_+"Summary Plots/HO0 Average over HPD LED Ref"; me=ig.get(s.c_str());
   if(me!=0) HO0phi=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, HO0phi, debug_); else return;
-  s=subdir_+"Summary Plots/HO1P Average over HPD LED Ref"; me=dqmStore_->get(s.c_str());
+  s=subdir_+"Summary Plots/HO1P Average over HPD LED Ref"; me=ig.get(s.c_str());
   if(me!=0) HO1Pphi=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, HO1Pphi, debug_); else return;
-  s=subdir_+"Summary Plots/HO2P Average over HPD LED Ref"; me=dqmStore_->get(s.c_str());
+  s=subdir_+"Summary Plots/HO2P Average over HPD LED Ref"; me=ig.get(s.c_str());
   if(me!=0) HO2Pphi=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, HO2Pphi, debug_); else return;
-  s=subdir_+"Summary Plots/HO1M Average over HPD LED Ref"; me=dqmStore_->get(s.c_str());
+  s=subdir_+"Summary Plots/HO1M Average over HPD LED Ref"; me=ig.get(s.c_str());
   if(me!=0) HO1Mphi=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, HO1Mphi, debug_); else return;
-  s=subdir_+"Summary Plots/HO2M Average over HPD LED Ref"; me=dqmStore_->get(s.c_str());
+  s=subdir_+"Summary Plots/HO2M Average over HPD LED Ref"; me=ig.get(s.c_str());
   if(me!=0) HO2Mphi=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, HO2Mphi, debug_); else return;
 
   gROOT->SetBatch(true);

--- a/DQM/HcalMonitorClient/src/HcalDetDiagLEDClient.cc
+++ b/DQM/HcalMonitorClient/src/HcalDetDiagLEDClient.cc
@@ -41,6 +41,8 @@ HcalDetDiagLEDClient::HcalDetDiagLEDClient(std::string myname, const edm::Parame
   needLogicalMap_=true;
 
   doProblemCellSetup_ = true;
+
+  ProblemCellsByDepth = 0;
 }
 
 void HcalDetDiagLEDClient::analyze(DQMStore::IBooker &ib, DQMStore::IGetter &ig){
@@ -868,7 +870,10 @@ std::string subdet[4]={"HB","HE","HO","HF"};
   htmlFile << "</html> " << std::endl;
   htmlFile.close();
   can->Close();
+  delete can;
 }
 
 HcalDetDiagLEDClient::~HcalDetDiagLEDClient()
-{}
+{
+  if ( ProblemCellsByDepth ) delete ProblemCellsByDepth;
+}

--- a/DQM/HcalMonitorClient/src/HcalDetDiagLaserClient.cc
+++ b/DQM/HcalMonitorClient/src/HcalDetDiagLaserClient.cc
@@ -64,18 +64,20 @@ HcalDetDiagLaserClient::HcalDetDiagLaserClient(std::string myname, const edm::Pa
   ProblemCells=0;
   ProblemCellsByDepth=0;
   needLogicalMap_=true;
+
+  doProblemCellSetup_ = true;
 }
 
-void HcalDetDiagLaserClient::analyze()
+void HcalDetDiagLaserClient::analyze(DQMStore::IBooker &ib, DQMStore::IGetter &ig)
 {
   if (debug_>2) std::cout <<"\tHcalDetDiagLaserClient::analyze()"<<std::endl;
-  calculateProblems();
+  if ( doProblemCellSetup_ ) setupProblemCells(ib,ig);
+  calculateProblems(ib,ig);
 }
 
-void HcalDetDiagLaserClient::calculateProblems()
+void HcalDetDiagLaserClient::calculateProblems(DQMStore::IBooker &ib, DQMStore::IGetter &ig)
 {
  if (debug_>2) std::cout <<"\t\tHcalDetDiagLaserClient::calculateProblems()"<<std::endl;
-  if(!dqmStore_) return;
   double totalevents=0;
   int etabins=0, phibins=0, zside=0;
   double problemvalue=0;
@@ -111,11 +113,11 @@ void HcalDetDiagLaserClient::calculateProblems()
       BadTiming[i]=0;
       BadEnergy[i]=0;
       string s=subdir_+name[i]+" Problem Bad Laser Timing";
-      me=dqmStore_->get(s.c_str());
+      me=ig.get(s.c_str());
       if (me!=0) BadTiming[i]=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, BadTiming[i], debug_);
       else if (debug_>0) std::cout <<"<HcalDetDiagLaserClient::calculateProblems> could not get histogram '"<<s<<"'"<<std::endl;
       s=subdir_+name[i]+" Problem Bad Laser Energy";
-      me=dqmStore_->get(s.c_str());
+      me=ig.get(s.c_str());
       if (me!=0) BadEnergy[i]=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, BadEnergy[i], debug_);
       else if (debug_>0) std::cout <<"<HcalDetDiagLaserClient::calculateProblems> could not get histogram '"<<s<<"'"<<std::endl;
     }      
@@ -198,45 +200,38 @@ void HcalDetDiagLaserClient::calculateProblems()
   return;
 }
 
-void HcalDetDiagLaserClient::beginJob()
-{
-  dqmStore_ = Service<DQMStore>().operator->();
-  if (debug_>0) 
-    {
-      std::cout <<"<HcalDetDiagLaserClient::beginJob()>  Displaying dqmStore directory structure:"<<std::endl;
-      dqmStore_->showDirStructure();
-    }
-}
 void HcalDetDiagLaserClient::endJob(){}
 
-void HcalDetDiagLaserClient::beginRun(void)
+void HcalDetDiagLaserClient::setupProblemCells(DQMStore::IBooker &ib, DQMStore::IGetter &ig)
 {
-  enoughevents_=false;
-  if (!dqmStore_) 
-    {
-      if (debug_>0) std::cout <<"<HcalDetDiagLaserClient::beginRun> dqmStore does not exist!"<<std::endl;
-      return;
-    }
-  dqmStore_->setCurrentFolder(subdir_);
+  ib.setCurrentFolder(subdir_);
   problemnames_.clear();
 
   // Put the appropriate name of your problem summary here
-  ProblemCells=dqmStore_->book2D(" ProblemDetDiagLaser",
+  ProblemCells=ib.book2D(" ProblemDetDiagLaser",
 				 " Problem DetDiagLaser Rate for all HCAL;ieta;iphi",
 				 85,-42.5,42.5,
 				 72,0.5,72.5);
   problemnames_.push_back(ProblemCells->getName());
   if (debug_>1)
     std::cout << "Tried to create ProblemCells Monitor Element in directory "<<subdir_<<"  \t  Failed?  "<<(ProblemCells==0)<<std::endl;
-  dqmStore_->setCurrentFolder(subdir_+"problem_DetDiagLaser");
+  ib.setCurrentFolder(subdir_+"problem_DetDiagLaser");
   ProblemCellsByDepth = new EtaPhiHists();
-  ProblemCellsByDepth->setup(dqmStore_," Problem DetDiagLaser Rate");
+  ProblemCellsByDepth->setup(ib," Problem DetDiagLaser Rate");
   for (unsigned int i=0; i<ProblemCellsByDepth->depth.size();++i)
     problemnames_.push_back(ProblemCellsByDepth->depth[i]->getName());
+
+  doProblemCellSetup_ = false;
+
+}
+
+void HcalDetDiagLaserClient::beginRun(void)
+{
+  enoughevents_=false;
   nevts_=0;
 }
 
-void HcalDetDiagLaserClient::endRun(void){analyze();}
+//void HcalDetDiagLaserClient::endRun(void){analyze();}
 
 void HcalDetDiagLaserClient::setup(void){}
 void HcalDetDiagLaserClient::cleanup(void){}
@@ -363,9 +358,9 @@ static void printTableTail(std::ofstream& file){
      file << "</html>"<< endl;
 }
 
-bool HcalDetDiagLaserClient::validHtmlOutput(){
+bool HcalDetDiagLaserClient::validHtmlOutput(DQMStore::IBooker &ib, DQMStore::IGetter &ig){
   string s=subdir_+"HcalDetDiagLaserMonitor Event Number";
-  MonitorElement *me = dqmStore_->get(s.c_str());
+  MonitorElement *me = ig.get(s.c_str());
   int n=0;
   if ( me ) {
     s = me->valueString();
@@ -374,11 +369,8 @@ bool HcalDetDiagLaserClient::validHtmlOutput(){
   if(n<100) return false;
   return true;
 }
-void HcalDetDiagLaserClient::htmlOutput(string htmlDir){
-  if(dqmStore_==0){
-      if (debug_>0) std::cout <<"<HcalDetDiagLaserClient::htmlOutput> dqmStore object does not exist!"<<std::endl;
-      return;
-  }
+void HcalDetDiagLaserClient::htmlOutput(DQMStore::IBooker &ib, DQMStore::IGetter &ig, string htmlDir){
+
   if(debug_>2) std::cout <<"\t<HcalDetDiagLaserClient::htmlOutput>  Preparing html for task: "<<name_<<std::endl;
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -414,71 +406,71 @@ void HcalDetDiagLaserClient::htmlOutput(string htmlDir){
   int HBpresent_=0,HEpresent_=0,HOpresent_=0,HFpresent_=0;
 
  
-  me=dqmStore_->get(prefixME_+"HcalInfo/HBpresent");
+  me=ig.get(prefixME_+"HcalInfo/HBpresent");
   if(me!=0) HBpresent_=me->getIntValue();
-  me=dqmStore_->get(prefixME_+"HcalInfo/HEpresent");
+  me=ig.get(prefixME_+"HcalInfo/HEpresent");
   if(me!=0) HEpresent_=me->getIntValue();
-  me=dqmStore_->get(prefixME_+"HcalInfo/HOpresent");
+  me=ig.get(prefixME_+"HcalInfo/HOpresent");
   if(me!=0) HOpresent_=me->getIntValue();
-  me=dqmStore_->get(prefixME_+"HcalInfo/HFpresent");
+  me=ig.get(prefixME_+"HcalInfo/HFpresent");
   if(me!=0) HFpresent_=me->getIntValue();
 
-  s=subdir_+"Summary Plots/HBHE Laser Energy Distribution"; me=dqmStore_->get(s.c_str()); 
+  s=subdir_+"Summary Plots/HBHE Laser Energy Distribution"; me=ig.get(s.c_str()); 
   if(me!=0) hbheEnergy=HcalUtilsClient::getHisto<TH1F*>(me, cloneME_, hbheEnergy, debug_);  else return;
-  s=subdir_+"Summary Plots/HBHE Laser Timing Distribution"; me=dqmStore_->get(s.c_str());
+  s=subdir_+"Summary Plots/HBHE Laser Timing Distribution"; me=ig.get(s.c_str());
   if(me!=0) hbheTiming=HcalUtilsClient::getHisto<TH1F*>(me, cloneME_, hbheTiming, debug_); else return;
-  s=subdir_+"Summary Plots/HBHE Laser Energy RMS_div_Energy Distribution"; me=dqmStore_->get(s.c_str());
+  s=subdir_+"Summary Plots/HBHE Laser Energy RMS_div_Energy Distribution"; me=ig.get(s.c_str());
   if(me!=0) hbheEnergyRMS= HcalUtilsClient::getHisto<TH1F*>(me, cloneME_, hbheEnergyRMS, debug_); else return;
-  s=subdir_+"Summary Plots/HBHE Laser Timing RMS Distribution"; me=dqmStore_->get(s.c_str());
+  s=subdir_+"Summary Plots/HBHE Laser Timing RMS Distribution"; me=ig.get(s.c_str());
   if(me!=0) hbheTimingRMS= HcalUtilsClient::getHisto<TH1F*>(me, cloneME_, hbheTimingRMS, debug_); else return;
-  s=subdir_+"Summary Plots/HO Laser Energy Distribution"; me=dqmStore_->get(s.c_str());
+  s=subdir_+"Summary Plots/HO Laser Energy Distribution"; me=ig.get(s.c_str());
   if(me!=0) hoEnergy = HcalUtilsClient::getHisto<TH1F*>(me, cloneME_, hoEnergy, debug_); else return;
-  s=subdir_+"Summary Plots/HO Laser Timing Distribution"; me=dqmStore_->get(s.c_str());
+  s=subdir_+"Summary Plots/HO Laser Timing Distribution"; me=ig.get(s.c_str());
   if(me!=0) hoTiming = HcalUtilsClient::getHisto<TH1F*>(me, cloneME_, hoTiming, debug_); else return;
-  s=subdir_+"Summary Plots/HO Laser Energy RMS_div_Energy Distribution"; me=dqmStore_->get(s.c_str());
+  s=subdir_+"Summary Plots/HO Laser Energy RMS_div_Energy Distribution"; me=ig.get(s.c_str());
   if(me!=0) hoEnergyRMS = HcalUtilsClient::getHisto<TH1F*>(me, cloneME_, hoEnergyRMS, debug_); else return;
-  s=subdir_+"Summary Plots/HO Laser Timing RMS Distribution"; me=dqmStore_->get(s.c_str());
+  s=subdir_+"Summary Plots/HO Laser Timing RMS Distribution"; me=ig.get(s.c_str());
   if(me!=0) hoTimingRMS  = HcalUtilsClient::getHisto<TH1F*>(me, cloneME_, hoTimingRMS, debug_); else return;
-  s=subdir_+"Summary Plots/HF Laser Energy Distribution"; me=dqmStore_->get(s.c_str());
+  s=subdir_+"Summary Plots/HF Laser Energy Distribution"; me=ig.get(s.c_str());
   if(me!=0) hfEnergy  = HcalUtilsClient::getHisto<TH1F*>(me, cloneME_, hfEnergy, debug_); else return;
-  s=subdir_+"Summary Plots/HF Laser Timing Distribution"; me=dqmStore_->get(s.c_str());
+  s=subdir_+"Summary Plots/HF Laser Timing Distribution"; me=ig.get(s.c_str());
   if(me!=0) hfTiming  = HcalUtilsClient::getHisto<TH1F*>(me, cloneME_, hfTiming, debug_); else return;
-  s=subdir_+"Summary Plots/HF Laser Energy RMS_div_Energy Distribution"; me=dqmStore_->get(s.c_str());
+  s=subdir_+"Summary Plots/HF Laser Energy RMS_div_Energy Distribution"; me=ig.get(s.c_str());
   if(me!=0) hfEnergyRMS = HcalUtilsClient::getHisto<TH1F*>(me, cloneME_, hfEnergyRMS, debug_); else return;
-  s=subdir_+"Summary Plots/HF Laser Timing RMS Distribution"; me=dqmStore_->get(s.c_str());
+  s=subdir_+"Summary Plots/HF Laser Timing RMS Distribution"; me=ig.get(s.c_str());
   if(me!=0) hfTimingRMS = HcalUtilsClient::getHisto<TH1F*>(me, cloneME_, hfTimingRMS, debug_); else return;
 
-  s=subdir_+"Summary Plots/HB RBX average Time-Ref"; me=dqmStore_->get(s.c_str());
+  s=subdir_+"Summary Plots/HB RBX average Time-Ref"; me=ig.get(s.c_str());
   if(me!=0) hb     = HcalUtilsClient::getHisto<TH1F*>(me, cloneME_, hb, debug_); else return;
-  s=subdir_+"Summary Plots/HE RBX average Time-Ref"; me=dqmStore_->get(s.c_str());
+  s=subdir_+"Summary Plots/HE RBX average Time-Ref"; me=ig.get(s.c_str());
   if(me!=0) he     = HcalUtilsClient::getHisto<TH1F*>(me, cloneME_, he, debug_); else return;
-  s=subdir_+"Summary Plots/HO RBX average Time-Ref"; me=dqmStore_->get(s.c_str());
+  s=subdir_+"Summary Plots/HO RBX average Time-Ref"; me=ig.get(s.c_str());
   if(me!=0) ho     = HcalUtilsClient::getHisto<TH1F*>(me, cloneME_, ho, debug_); else return;
-  s=subdir_+"Summary Plots/HF RoBox average Time-Ref"; me=dqmStore_->get(s.c_str());
+  s=subdir_+"Summary Plots/HF RoBox average Time-Ref"; me=ig.get(s.c_str());
   if(me!=0) hf     = HcalUtilsClient::getHisto<TH1F*>(me, cloneME_, hf, debug_); else return;
 
-  s=subdir_+"Summary Plots/Laser Timing HBHEHF"; me=dqmStore_->get(s.c_str());
+  s=subdir_+"Summary Plots/Laser Timing HBHEHF"; me=ig.get(s.c_str());
   if(me!=0) Time2Dhbhehf  = HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, Time2Dhbhehf, debug_); else return;
-  s=subdir_+"Summary Plots/Laser Timing HO"; me=dqmStore_->get(s.c_str());
+  s=subdir_+"Summary Plots/Laser Timing HO"; me=ig.get(s.c_str());
   if(me!=0) Time2Dho      = HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, Time2Dho, debug_); else return;
-  s=subdir_+"Summary Plots/Laser Energy HBHEHF"; me=dqmStore_->get(s.c_str());
+  s=subdir_+"Summary Plots/Laser Energy HBHEHF"; me=ig.get(s.c_str());
   if(me!=0) Energy2Dhbhehf= HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, Energy2Dhbhehf, debug_); else return;
-  s=subdir_+"Summary Plots/Laser Energy HO"; me=dqmStore_->get(s.c_str());
+  s=subdir_+"Summary Plots/Laser Energy HO"; me=ig.get(s.c_str());
   if(me!=0) Energy2Dho    = HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, Energy2Dho, debug_); else return;
-  s=subdir_+"Summary Plots/HBHEHF Laser (Timing-Ref)+1"; me=dqmStore_->get(s.c_str());
+  s=subdir_+"Summary Plots/HBHEHF Laser (Timing-Ref)+1"; me=ig.get(s.c_str());
   if(me!=0) refTime2Dhbhehf  = HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, refTime2Dhbhehf, debug_); else return;
-  s=subdir_+"Summary Plots/HO Laser (Timing-Ref)+1"; me=dqmStore_->get(s.c_str());
+  s=subdir_+"Summary Plots/HO Laser (Timing-Ref)+1"; me=ig.get(s.c_str());
   if(me!=0) refTime2Dho      = HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, refTime2Dho, debug_); else return;
-  s=subdir_+"Summary Plots/HBHEHF Laser Energy_div_Ref"; me=dqmStore_->get(s.c_str());
+  s=subdir_+"Summary Plots/HBHEHF Laser Energy_div_Ref"; me=ig.get(s.c_str());
   if(me!=0) refEnergy2Dhbhehf= HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, refEnergy2Dhbhehf, debug_); else return;
-  s=subdir_+"Summary Plots/HO Laser Energy_div_Ref"; me=dqmStore_->get(s.c_str());
+  s=subdir_+"Summary Plots/HO Laser Energy_div_Ref"; me=ig.get(s.c_str());
   if(me!=0) refEnergy2Dho    = HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, refEnergy2Dho, debug_); else return;
 
   TH1F *Raddam[56];
   char str[100];
   for(int i=0;i<56;i++){  
        sprintf(str,"RADDAM (%i %i)",RADDAM_CH[i].eta,RADDAM_CH[i].phi);
-       s=subdir_+"Raddam Plots/"+str; me=dqmStore_->get(s.c_str());
+       s=subdir_+"Raddam Plots/"+str; me=ig.get(s.c_str());
        if(me!=0) Raddam[i] = HcalUtilsClient::getHisto<TH1F*>(me, cloneME_, Raddam[i], debug_);
        Raddam[i]->SetXTitle("TS");
        Raddam[i]->SetTitle(str);
@@ -486,19 +478,19 @@ void HcalDetDiagLaserClient::htmlOutput(string htmlDir){
   
   int ievt_ = -1,runNo=-1;
   s=subdir_+"HcalDetDiagLaserMonitor Event Number";
-  me = dqmStore_->get(s.c_str());
+  me = ig.get(s.c_str());
   if ( me ) {
     s = me->valueString();
     sscanf((s.substr(2,s.length()-2)).c_str(), "%d", &ievt_);
   }
   s=subdir_+"HcalDetDiagLaserMonitor Run Number";
-  me = dqmStore_->get(s.c_str());
+  me = ig.get(s.c_str());
   if ( me ) {
     s = me->valueString();
     sscanf((s.substr(2,s.length()-2)).c_str(), "%d", &runNo);
   }
   s=subdir_+"HcalDetDiagLaserMonitor Reference Run";
-  me = dqmStore_->get(s.c_str());
+  me = ig.get(s.c_str());
   if(me) {
     string s=me->valueString();
     char str[200]; 
@@ -530,10 +522,10 @@ void HcalDetDiagLaserClient::htmlOutput(string htmlDir){
       BadTiming_val[i]=0;
       BadEnergy_val[i]=0;
       string s=subdir_+"Plots for client/"+name[i]+" Laser Timing difference";
-      me=dqmStore_->get(s.c_str());
+      me=ig.get(s.c_str());
       if (me!=0) BadTiming_val[i]=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, BadTiming_val[i], debug_); else return;
       s=subdir_+"Plots for client/"+name[i]+" Laser Energy difference";
-      me=dqmStore_->get(s.c_str());
+      me=ig.get(s.c_str());
       if (me!=0) BadEnergy_val[i]=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, BadEnergy_val[i], debug_); else return;
   }
 

--- a/DQM/HcalMonitorClient/src/HcalDetDiagLaserClient.cc
+++ b/DQM/HcalMonitorClient/src/HcalDetDiagLaserClient.cc
@@ -1103,10 +1103,13 @@ void HcalDetDiagLaserClient::htmlOutput(DQMStore::IBooker &ib, DQMStore::IGetter
   htmlFile << "</body> " << endl;
   htmlFile << "</html> " << endl;
   can->Close();
+  delete can;
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   htmlFile.close();
   return;
 }
 
 HcalDetDiagLaserClient::~HcalDetDiagLaserClient()
-{}
+{
+  if ( ProblemCellsByDepth ) delete ProblemCellsByDepth;
+}

--- a/DQM/HcalMonitorClient/src/HcalDetDiagNoiseMonitorClient.cc
+++ b/DQM/HcalMonitorClient/src/HcalDetDiagNoiseMonitorClient.cc
@@ -44,18 +44,20 @@ HcalDetDiagNoiseMonitorClient::HcalDetDiagNoiseMonitorClient(std::string myname,
 						ps.getUntrackedParameter<int>("minevents",1));
   ProblemCells=0;
   ProblemCellsByDepth=0;
+
+  doProblemCellSetup_ = true;
 }
 
-void HcalDetDiagNoiseMonitorClient::analyze()
+void HcalDetDiagNoiseMonitorClient::analyze(DQMStore::IBooker &ib, DQMStore::IGetter &ig)
 {
   if (debug_>2) std::cout <<"\tHcalDetDiagNoiseMonitorClient::analyze()"<<std::endl;
-  calculateProblems();
+  if ( doProblemCellSetup_ ) setupProblemCells(ib,ig);
+  calculateProblems(ib,ig);
 }
 
-void HcalDetDiagNoiseMonitorClient::calculateProblems()
+void HcalDetDiagNoiseMonitorClient::calculateProblems(DQMStore::IBooker &ib, DQMStore::IGetter &ig)
 {
  if (debug_>2) std::cout <<"\t\tHcalDetDiagNoiseMonitorClient::calculateProblems()"<<std::endl;
-  if(!dqmStore_) return;
   //double totalevents=0;
   int etabins=0, phibins=0, zside=0;
   double problemvalue=0;
@@ -182,45 +184,38 @@ void HcalDetDiagNoiseMonitorClient::calculateProblems()
   return;
 }
 
-void HcalDetDiagNoiseMonitorClient::beginJob()
-{
-  dqmStore_ = edm::Service<DQMStore>().operator->();
-  if (debug_>0) 
-    {
-      std::cout <<"<HcalDetDiagNoiseMonitorClient::beginJob()>  Displaying dqmStore directory structure:"<<std::endl;
-      dqmStore_->showDirStructure();
-    }
-}
-void HcalDetDiagNoiseMonitorClient::endJob(){}
+//void HcalDetDiagNoiseMonitorClient::endJob(){}
 
-void HcalDetDiagNoiseMonitorClient::beginRun(void)
+void HcalDetDiagNoiseMonitorClient::setupProblemCells(DQMStore::IBooker &ib, DQMStore::IGetter &ig)
 {
-  enoughevents_=false;
-  if (!dqmStore_) 
-    {
-      if (debug_>0) std::cout <<"<HcalDetDiagNoiseMonitorClient::beginRun> dqmStore does not exist!"<<std::endl;
-      return;
-    }
-  dqmStore_->setCurrentFolder(subdir_);
+
+  ib.setCurrentFolder(subdir_);
   problemnames_.clear();
 
   // Put the appropriate name of your problem summary here
-  ProblemCells=dqmStore_->book2D(" ProblemDetDiagNoiseMonitor",
+  ProblemCells=ib.book2D(" ProblemDetDiagNoiseMonitor",
 				 " Problem DetDiagNoiseMonitor Rate for all HCAL;ieta;iphi",
 				 85,-42.5,42.5,
 				 72,0.5,72.5);
   problemnames_.push_back(ProblemCells->getName());
   if (debug_>1)
     std::cout << "Tried to create ProblemCells Monitor Element in directory "<<subdir_<<"  \t  Failed?  "<<(ProblemCells==0)<<std::endl;
-  dqmStore_->setCurrentFolder(subdir_+"problem_DetDiagNoiseMonitor");
+  ib.setCurrentFolder(subdir_+"problem_DetDiagNoiseMonitor");
   ProblemCellsByDepth = new EtaPhiHists();
-  ProblemCellsByDepth->setup(dqmStore_," Problem DetDiagNoiseMonitor Rate");
+  ProblemCellsByDepth->setup(ib," Problem DetDiagNoiseMonitor Rate");
   for (unsigned int i=0; i<ProblemCellsByDepth->depth.size();++i)
     problemnames_.push_back(ProblemCellsByDepth->depth[i]->getName());
+
+  doProblemCellSetup_ = false;
+}
+
+void HcalDetDiagNoiseMonitorClient::beginRun(void)
+{
+  enoughevents_=false;
   nevts_=0;
 }
 
-void HcalDetDiagNoiseMonitorClient::endRun(void){analyze();}
+//void HcalDetDiagNoiseMonitorClient::endRun(void){analyze();}
 
 void HcalDetDiagNoiseMonitorClient::setup(void){}
 void HcalDetDiagNoiseMonitorClient::cleanup(void){}

--- a/DQM/HcalMonitorClient/src/HcalDetDiagNoiseMonitorClient.cc
+++ b/DQM/HcalMonitorClient/src/HcalDetDiagNoiseMonitorClient.cc
@@ -267,4 +267,6 @@ void HcalDetDiagNoiseMonitorClient::updateChannelStatus(std::map<HcalDetId, unsi
 } //void HcalDetDiagNoiseMonitorClient::updateChannelStatus
 
 HcalDetDiagNoiseMonitorClient::~HcalDetDiagNoiseMonitorClient()
-{}
+{
+  if ( ProblemCellsByDepth ) delete ProblemCellsByDepth;
+}

--- a/DQM/HcalMonitorClient/src/HcalDetDiagPedestalClient.cc
+++ b/DQM/HcalMonitorClient/src/HcalDetDiagPedestalClient.cc
@@ -51,18 +51,20 @@ HcalDetDiagPedestalClient::HcalDetDiagPedestalClient(std::string myname, const e
   ProblemCells=0;
   ProblemCellsByDepth=0;
   needLogicalMap_=true;
+
+  doProblemCellSetup_ = true;
 }
 
-void HcalDetDiagPedestalClient::analyze()
+void HcalDetDiagPedestalClient::analyze(DQMStore::IBooker &ib, DQMStore::IGetter &ig)
 {
   if (debug_>2) std::cout <<"\tHcalDetDiagPedestalClient::analyze()"<<std::endl;
-  calculateProblems();
+  if ( doProblemCellSetup_ ) setupProblemCells(ib,ig);
+  calculateProblems(ib,ig);
 }
 
-void HcalDetDiagPedestalClient::calculateProblems()
+void HcalDetDiagPedestalClient::calculateProblems(DQMStore::IBooker &ib, DQMStore::IGetter &ig)
 {
  if (debug_>2) std::cout <<"\t\tHcalDetDiagPedestalClient::calculateProblems()"<<std::endl;
-  if(!dqmStore_) return;
   double totalevents=0;
   int etabins=0, phibins=0, zside=0;
   double problemvalue=0;
@@ -103,7 +105,7 @@ void HcalDetDiagPedestalClient::calculateProblems()
       PedestalsBadMean[i]=0;
       PedestalsBadRMS[i]=0;
       std::string s=subdir_+name[i]+" Problem Missing Channels";
-      me=dqmStore_->get(s.c_str());
+      me=ig.get(s.c_str());
       if (me!=0) PedestalsMissing[i]=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, PedestalsMissing[i], debug_);
       else 
 	{
@@ -112,15 +114,15 @@ void HcalDetDiagPedestalClient::calculateProblems()
 	}
 
       s=subdir_+name[i]+" Problem Unstable Channels";
-      me=dqmStore_->get(s.c_str());
+      me=ig.get(s.c_str());
       if (me!=0) PedestalsUnstable[i]=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, PedestalsUnstable[i], debug_);
       else if (debug_>0) std::cout <<"<HcalDetDiagPedestalClient::calculateProblems> could not get histogram '"<<s<<"'"<<std::endl;
       s=subdir_+name[i]+" Problem Bad Pedestal Value";
-      me=dqmStore_->get(s.c_str());
+      me=ig.get(s.c_str());
       if (me!=0) PedestalsBadMean[i]=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, PedestalsBadMean[i], debug_);
       else if (debug_>0) std::cout <<"<HcalDetDiagPedestalClient::calculateProblems> could not get histogram '"<<s<<"'"<<std::endl;
       s=subdir_+name[i]+" Problem Bad Rms Value";
-      me=dqmStore_->get(s.c_str());
+      me=ig.get(s.c_str());
       if (me!=0) PedestalsBadRMS[i]=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, PedestalsBadRMS[i], debug_);
       else if (debug_>0) std::cout <<"<HcalDetDiagPedestalClient::calculateProblems> could not get histogram '"<<s<<"'"<<std::endl;
     }      
@@ -207,45 +209,38 @@ void HcalDetDiagPedestalClient::calculateProblems()
   return;
 }
 
-void HcalDetDiagPedestalClient::beginJob()
-{
-  dqmStore_ = edm::Service<DQMStore>().operator->();
-  if (debug_>0) 
-    {
-      std::cout <<"<HcalDetDiagPedestalClient::beginJob()>  Displaying dqmStore directory structure:"<<std::endl;
-      dqmStore_->showDirStructure();
-    }
-}
 void HcalDetDiagPedestalClient::endJob(){}
 
-void HcalDetDiagPedestalClient::beginRun(void)
+void HcalDetDiagPedestalClient::setupProblemCells(DQMStore::IBooker &ib, DQMStore::IGetter &ig)
 {
-  enoughevents_=false;
-  if (!dqmStore_) 
-    {
-      if (debug_>0) std::cout <<"<HcalDetDiagPedestalClient::beginRun> dqmStore does not exist!"<<std::endl;
-      return;
-    }
-  dqmStore_->setCurrentFolder(subdir_);
+
+  ib.setCurrentFolder(subdir_);
   problemnames_.clear();
 
   // Put the appropriate name of your problem summary here
-  ProblemCells=dqmStore_->book2D(" ProblemDetDiagPedestal",
+  ProblemCells=ib.book2D(" ProblemDetDiagPedestal",
 				 " Problem DetDiagPedestal Rate for all HCAL;ieta;iphi",
 				 85,-42.5,42.5,
 				 72,0.5,72.5);
   problemnames_.push_back(ProblemCells->getName());
   if (debug_>1)
     std::cout << "Tried to create ProblemCells Monitor Element in directory "<<subdir_<<"  \t  Failed?  "<<(ProblemCells==0)<<std::endl;
-  dqmStore_->setCurrentFolder(subdir_+"problem_DetDiagPedestal");
+  ib.setCurrentFolder(subdir_+"problem_DetDiagPedestal");
   ProblemCellsByDepth = new EtaPhiHists();
-  ProblemCellsByDepth->setup(dqmStore_," Problem DetDiagPedestal Rate");
+  ProblemCellsByDepth->setup(ib," Problem DetDiagPedestal Rate");
   for (unsigned int i=0; i<ProblemCellsByDepth->depth.size();++i)
     problemnames_.push_back(ProblemCellsByDepth->depth[i]->getName());
+
+  doProblemCellSetup_ = false;
+}
+
+void HcalDetDiagPedestalClient::beginRun(void)
+{
+  enoughevents_=false;
   nevts_=0;
 }
 
-void HcalDetDiagPedestalClient::endRun(void){analyze();}
+//void HcalDetDiagPedestalClient::endRun(void){analyze();}
 
 void HcalDetDiagPedestalClient::setup(void){}
 void HcalDetDiagPedestalClient::cleanup(void){}
@@ -374,9 +369,9 @@ static void printTableTail(std::ofstream& file){
      file << "</html>"<< std::endl;
 }
 
-bool HcalDetDiagPedestalClient::validHtmlOutput(){
+bool HcalDetDiagPedestalClient::validHtmlOutput(DQMStore::IBooker &ib, DQMStore::IGetter &ig){
   std::string s=subdir_+"HcalDetDiagPedestalMonitor Event Number";
-  MonitorElement *me = dqmStore_->get(s.c_str());
+  MonitorElement *me = ig.get(s.c_str());
   int n=0;
   if ( me ) {
     s = me->valueString();
@@ -386,13 +381,12 @@ bool HcalDetDiagPedestalClient::validHtmlOutput(){
   return true;
 }
 
-void HcalDetDiagPedestalClient::htmlOutput(std::string htmlDir){
+void HcalDetDiagPedestalClient::htmlOutput(DQMStore::IBooker &ib, DQMStore::IGetter &ig, std::string htmlDir){
 int  MissingCnt=0,UnstableCnt=0,BadCnt=0; 
 int  HBP[4]={0,0,0,0},HBM[4]={0,0,0,0},HEP[4]={0,0,0,0},HEM[4]={0,0,0,0},HFP[4]={0,0,0,0},HFM[4]={0,0,0,0},HO[4] ={0,0,0,0}; 
 int  newHBP[4]={0,0,0,0},newHBM[4]={0,0,0,0},newHEP[4]={0,0,0,0},newHEM[4]={0,0,0,0};
 int  newHFP[4]={0,0,0,0},newHFM[4]={0,0,0,0},newHO[4] ={0,0,0,0}; 
  if (debug_>0) std::cout << "<HcalDetDiagPedestalClient::htmlOutput> Preparing  html output ..." << std::endl;
-  if(!dqmStore_) return;
 
   HcalElectronicsMap emap=logicalMap_->generateHcalElectronicsMap();
   TH2F *Missing_val[4],*Unstable_val[4],*BadPed_val[4],*BadRMS_val[4];
@@ -427,57 +421,57 @@ int  newHFP[4]={0,0,0,0},newHFM[4]={0,0,0,0},newHO[4] ={0,0,0,0};
   TH2F *Pedestals2DErrorHBHEHF=0;
   TH2F *Pedestals2DErrorHO=0;
 
-  std::string s=subdir_+"Summary Plots/HB Pedestal Distribution (average over 4 caps)"; me=dqmStore_->get(s.c_str());
+  std::string s=subdir_+"Summary Plots/HB Pedestal Distribution (average over 4 caps)"; me=ig.get(s.c_str());
   if(me!=0) PedestalsAve4HB=HcalUtilsClient::getHisto<TH1F*>(me, cloneME_, PedestalsAve4HB, debug_); else return;
-  s=subdir_+"Summary Plots/HE Pedestal Distribution (average over 4 caps)"; me=dqmStore_->get(s.c_str()); 
+  s=subdir_+"Summary Plots/HE Pedestal Distribution (average over 4 caps)"; me=ig.get(s.c_str()); 
   if(me!=0) PedestalsAve4HE=HcalUtilsClient::getHisto<TH1F*>(me, cloneME_, PedestalsAve4HE, debug_);  else return; 
-  s=subdir_+"Summary Plots/HO Pedestal Distribution (average over 4 caps)"; me=dqmStore_->get(s.c_str()); 
+  s=subdir_+"Summary Plots/HO Pedestal Distribution (average over 4 caps)"; me=ig.get(s.c_str()); 
   if(me!=0) PedestalsAve4HO=HcalUtilsClient::getHisto<TH1F*>(me, cloneME_, PedestalsAve4HO, debug_);  else return; 
-  s=subdir_+"Summary Plots/HF Pedestal Distribution (average over 4 caps)"; me=dqmStore_->get(s.c_str()); 
+  s=subdir_+"Summary Plots/HF Pedestal Distribution (average over 4 caps)"; me=ig.get(s.c_str()); 
   if(me!=0) PedestalsAve4HF=HcalUtilsClient::getHisto<TH1F*>(me, cloneME_, PedestalsAve4HF, debug_);  else return; 
-  s=subdir_+"Summary Plots/SIPM Pedestal Distribution (average over 4 caps)"; me=dqmStore_->get(s.c_str()); 
+  s=subdir_+"Summary Plots/SIPM Pedestal Distribution (average over 4 caps)"; me=ig.get(s.c_str()); 
   if(me!=0) PedestalsAve4Simp=HcalUtilsClient::getHisto<TH1F*>(me, cloneME_, PedestalsAve4Simp, debug_); else return; 
  
-  s=subdir_+"Summary Plots/HB Pedestal-Reference Distribution (average over 4 caps)"; me=dqmStore_->get(s.c_str()); 
+  s=subdir_+"Summary Plots/HB Pedestal-Reference Distribution (average over 4 caps)"; me=ig.get(s.c_str()); 
   if(me!=0) PedestalsAve4HBref=HcalUtilsClient::getHisto<TH1F*>(me, cloneME_, PedestalsAve4HBref, debug_); else return;  
-  s=subdir_+"Summary Plots/HE Pedestal-Reference Distribution (average over 4 caps)"; me=dqmStore_->get(s.c_str()); 
+  s=subdir_+"Summary Plots/HE Pedestal-Reference Distribution (average over 4 caps)"; me=ig.get(s.c_str()); 
   if(me!=0) PedestalsAve4HEref=HcalUtilsClient::getHisto<TH1F*>(me, cloneME_, PedestalsAve4HEref, debug_); else return; 
-  s=subdir_+"Summary Plots/HO Pedestal-Reference Distribution (average over 4 caps)"; me=dqmStore_->get(s.c_str()); 
+  s=subdir_+"Summary Plots/HO Pedestal-Reference Distribution (average over 4 caps)"; me=ig.get(s.c_str()); 
   if(me!=0) PedestalsAve4HOref=HcalUtilsClient::getHisto<TH1F*>(me, cloneME_, PedestalsAve4HOref, debug_); else return;  
-  s=subdir_+"Summary Plots/HF Pedestal-Reference Distribution (average over 4 caps)"; me=dqmStore_->get(s.c_str()); 
+  s=subdir_+"Summary Plots/HF Pedestal-Reference Distribution (average over 4 caps)"; me=ig.get(s.c_str()); 
   if(me!=0) PedestalsAve4HFref=HcalUtilsClient::getHisto<TH1F*>(me, cloneME_, PedestalsAve4HFref, debug_); else return;  
    
-  s=subdir_+"Summary Plots/HB Pedestal RMS Distribution (individual cap)"; me=dqmStore_->get(s.c_str()); 
+  s=subdir_+"Summary Plots/HB Pedestal RMS Distribution (individual cap)"; me=ig.get(s.c_str()); 
   if(me!=0) PedestalsRmsHB=HcalUtilsClient::getHisto<TH1F*>(me, cloneME_, PedestalsRmsHB, debug_);  else return; 
-  s=subdir_+"Summary Plots/HE Pedestal RMS Distribution (individual cap)"; me=dqmStore_->get(s.c_str()); 
+  s=subdir_+"Summary Plots/HE Pedestal RMS Distribution (individual cap)"; me=ig.get(s.c_str()); 
   if(me!=0) PedestalsRmsHE=HcalUtilsClient::getHisto<TH1F*>(me, cloneME_, PedestalsRmsHE, debug_);  else return; 
-  s=subdir_+"Summary Plots/HO Pedestal RMS Distribution (individual cap)"; me=dqmStore_->get(s.c_str()); 
+  s=subdir_+"Summary Plots/HO Pedestal RMS Distribution (individual cap)"; me=ig.get(s.c_str()); 
   if(me!=0) PedestalsRmsHO=HcalUtilsClient::getHisto<TH1F*>(me, cloneME_, PedestalsRmsHO, debug_);  else return; 
-  s=subdir_+"Summary Plots/HF Pedestal RMS Distribution (individual cap)"; me=dqmStore_->get(s.c_str()); 
+  s=subdir_+"Summary Plots/HF Pedestal RMS Distribution (individual cap)"; me=ig.get(s.c_str()); 
   if(me!=0) PedestalsRmsHF=HcalUtilsClient::getHisto<TH1F*>(me, cloneME_, PedestalsRmsHF, debug_);  else return; 
-  s=subdir_+"Summary Plots/SIPM Pedestal RMS Distribution (individual cap)"; me=dqmStore_->get(s.c_str()); 
+  s=subdir_+"Summary Plots/SIPM Pedestal RMS Distribution (individual cap)"; me=ig.get(s.c_str()); 
   if(me!=0) PedestalsRmsSimp=HcalUtilsClient::getHisto<TH1F*>(me, cloneME_, PedestalsRmsSimp, debug_);  else return; 
    
-  s=subdir_+"Summary Plots/HB Pedestal_rms-Reference_rms Distribution"; me=dqmStore_->get(s.c_str()); 
+  s=subdir_+"Summary Plots/HB Pedestal_rms-Reference_rms Distribution"; me=ig.get(s.c_str()); 
   if(me!=0) PedestalsRmsHBref=HcalUtilsClient::getHisto<TH1F*>(me, cloneME_, PedestalsRmsHBref, debug_);  else return; 
-  s=subdir_+"Summary Plots/HE Pedestal_rms-Reference_rms Distribution"; me=dqmStore_->get(s.c_str()); 
+  s=subdir_+"Summary Plots/HE Pedestal_rms-Reference_rms Distribution"; me=ig.get(s.c_str()); 
   if(me!=0) PedestalsRmsHEref=HcalUtilsClient::getHisto<TH1F*>(me, cloneME_, PedestalsRmsHEref, debug_);  else return; 
-  s=subdir_+"Summary Plots/HO Pedestal_rms-Reference_rms Distribution"; me=dqmStore_->get(s.c_str()); 
+  s=subdir_+"Summary Plots/HO Pedestal_rms-Reference_rms Distribution"; me=ig.get(s.c_str()); 
   if(me!=0) PedestalsRmsHOref=HcalUtilsClient::getHisto<TH1F*>(me, cloneME_, PedestalsRmsHOref, debug_);  else return; 
-  s=subdir_+"Summary Plots/HF Pedestal_rms-Reference_rms Distribution"; me=dqmStore_->get(s.c_str()); 
+  s=subdir_+"Summary Plots/HF Pedestal_rms-Reference_rms Distribution"; me=ig.get(s.c_str()); 
   if(me!=0) PedestalsRmsHFref=HcalUtilsClient::getHisto<TH1F*>(me, cloneME_, PedestalsRmsHFref, debug_);  else return; 
      
-  s=subdir_+"Summary Plots/HBHEHF pedestal mean map"; me=dqmStore_->get(s.c_str()); 
+  s=subdir_+"Summary Plots/HBHEHF pedestal mean map"; me=ig.get(s.c_str()); 
   if(me!=0) Pedestals2DHBHEHF=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, Pedestals2DHBHEHF, debug_); else return;  
-  s=subdir_+"Summary Plots/HO pedestal mean map"; me=dqmStore_->get(s.c_str()); 
+  s=subdir_+"Summary Plots/HO pedestal mean map"; me=ig.get(s.c_str()); 
   if(me!=0) Pedestals2DHO=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, Pedestals2DHO, debug_);  else return; 
-  s=subdir_+"Summary Plots/HBHEHF pedestal rms map"; me=dqmStore_->get(s.c_str()); 
+  s=subdir_+"Summary Plots/HBHEHF pedestal rms map"; me=ig.get(s.c_str()); 
   if(me!=0) Pedestals2DRmsHBHEHF=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, Pedestals2DRmsHBHEHF, debug_); else return;  
-  s=subdir_+"Summary Plots/HO pedestal rms map"; me=dqmStore_->get(s.c_str()); 
+  s=subdir_+"Summary Plots/HO pedestal rms map"; me=ig.get(s.c_str()); 
   if(me!=0) Pedestals2DRmsHO=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, Pedestals2DRmsHO, debug_);  else return; 
-  s=subdir_+"Summary Plots/HBHEHF pedestal problems map"; me=dqmStore_->get(s.c_str()); 
+  s=subdir_+"Summary Plots/HBHEHF pedestal problems map"; me=ig.get(s.c_str()); 
   if(me!=0) Pedestals2DErrorHBHEHF=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, Pedestals2DErrorHBHEHF, debug_);  else return; 
-  s=subdir_+"Summary Plots/HO pedestal problems map"; me=dqmStore_->get(s.c_str()); 
+  s=subdir_+"Summary Plots/HO pedestal problems map"; me=ig.get(s.c_str()); 
   if(me!=0) Pedestals2DErrorHO=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, Pedestals2DErrorHO, debug_); else return;  
 
 
@@ -485,16 +479,16 @@ int  newHFP[4]={0,0,0,0},newHFM[4]={0,0,0,0},newHO[4] ={0,0,0,0};
   for(int i=0;i<4;++i){
       Missing_val[i]=Unstable_val[i]=BadPed_val[i]=BadRMS_val[i]=0;
       std::string s=subdir_+"Plots for client/"+name[i]+" Missing channels";
-      me=dqmStore_->get(s.c_str());
+      me=ig.get(s.c_str());
       if (me!=0) Missing_val[i]=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, Missing_val[i], debug_); else return;  
       s=subdir_+"Plots for client/"+name[i]+" Channel instability value";
-      me=dqmStore_->get(s.c_str());
+      me=ig.get(s.c_str());
       if (me!=0) Unstable_val[i]=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, Unstable_val[i], debug_); else return;  
       s=subdir_+"Plots for client/"+name[i]+" Bad Pedestal-Ref Value";
-      me=dqmStore_->get(s.c_str());
+      me=ig.get(s.c_str());
       if (me!=0) BadPed_val[i]=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, BadPed_val[i], debug_); else return;  
       s=subdir_+"Plots for client/"+name[i]+" Bad Rms-ref Value";
-      me=dqmStore_->get(s.c_str());
+      me=ig.get(s.c_str());
       if (me!=0) BadRMS_val[i]=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, BadRMS_val[i], debug_); else return;  
   }
   // Calculate problems 
@@ -889,19 +883,19 @@ int  newHFP[4]={0,0,0,0},newHFM[4]={0,0,0,0},newHO[4] ={0,0,0,0};
   int ievt_ = -1,runNo=-1;
   std::string ref_run;
   s=subdir_+"HcalDetDiagPedestalMonitor Event Number";
-  me = dqmStore_->get(s.c_str());
+  me = ig.get(s.c_str());
   if ( me ) {
     s = me->valueString();
     sscanf((s.substr(2,s.length()-2)).c_str(), "%d", &ievt_);
   }
   s=subdir_+"HcalDetDiagPedestalMonitor Run Number";
-  me = dqmStore_->get(s.c_str());
+  me = ig.get(s.c_str());
   if ( me ) {
     s = me->valueString();
     sscanf((s.substr(2,s.length()-2)).c_str(), "%d", &runNo);
   } 
   s=subdir_+"HcalDetDiagLaserMonitor Reference Run";
-  me = dqmStore_->get(s.c_str());
+  me = ig.get(s.c_str());
   if(me) {
     std::string s=me->valueString();
     char str[200]; 

--- a/DQM/HcalMonitorClient/src/HcalDetDiagTimingClient.cc
+++ b/DQM/HcalMonitorClient/src/HcalDetDiagTimingClient.cc
@@ -46,18 +46,20 @@ HcalDetDiagTimingClient::HcalDetDiagTimingClient(std::string myname, const edm::
 
   ProblemCells=0;
   ProblemCellsByDepth=0;
+
+  doProblemCellSetup_ = true;
 }
 
-void HcalDetDiagTimingClient::analyze()
+void HcalDetDiagTimingClient::analyze(DQMStore::IBooker &ib, DQMStore::IGetter &ig)
 {
   if (debug_>2) std::cout <<"\tHcalDetDiagTimingClient::analyze()"<<std::endl;
-  calculateProblems();
+  if ( doProblemCellSetup_ ) setupProblemCells(ib,ig);
+  calculateProblems(ib,ig);
 }
 
-void HcalDetDiagTimingClient::calculateProblems()
+void HcalDetDiagTimingClient::calculateProblems(DQMStore::IBooker &ib, DQMStore::IGetter &ig)
 {
  if (debug_>2) std::cout <<"\t\tHcalDetDiagTimingClient::calculateProblems()"<<std::endl;
-  if(!dqmStore_) return;
   //double totalevents=0;
   int etabins=0, phibins=0, zside=0;
   double problemvalue=0;
@@ -184,45 +186,39 @@ void HcalDetDiagTimingClient::calculateProblems()
   return;
 }
 
-void HcalDetDiagTimingClient::beginJob()
-{
-  dqmStore_ = edm::Service<DQMStore>().operator->();
-  if (debug_>0) 
-    {
-      std::cout <<"<HcalDetDiagTimingClient::beginJob()>  Displaying dqmStore directory structure:"<<std::endl;
-      dqmStore_->showDirStructure();
-    }
-}
 void HcalDetDiagTimingClient::endJob(){}
 
-void HcalDetDiagTimingClient::beginRun(void)
+void HcalDetDiagTimingClient::setupProblemCells(DQMStore::IBooker &ib, DQMStore::IGetter &ig)
 {
-  enoughevents_=false;
-  if (!dqmStore_) 
-    {
-      if (debug_>0) std::cout <<"<HcalDetDiagTimingClient::beginRun> dqmStore does not exist!"<<std::endl;
-      return;
-    }
-  dqmStore_->setCurrentFolder(subdir_);
+
+  ib.setCurrentFolder(subdir_);
   problemnames_.clear();
 
   // Put the appropriate name of your problem summary here
-  ProblemCells=dqmStore_->book2D(" ProblemDetDiagTiming",
+  ProblemCells=ib.book2D(" ProblemDetDiagTiming",
 				 " Problem DetDiagTiming Rate for all HCAL;ieta;iphi",
 				 85,-42.5,42.5,
 				 72,0.5,72.5);
   problemnames_.push_back(ProblemCells->getName());
   if (debug_>1)
     std::cout << "Tried to create ProblemCells Monitor Element in directory "<<subdir_<<"  \t  Failed?  "<<(ProblemCells==0)<<std::endl;
-  dqmStore_->setCurrentFolder(subdir_+"problem_DetDiagTiming");
+  ib.setCurrentFolder(subdir_+"problem_DetDiagTiming");
   ProblemCellsByDepth = new EtaPhiHists();
-  ProblemCellsByDepth->setup(dqmStore_," Problem DetDiagTiming Rate");
+  ProblemCellsByDepth->setup(ib," Problem DetDiagTiming Rate");
   for (unsigned int i=0; i<ProblemCellsByDepth->depth.size();++i)
     problemnames_.push_back(ProblemCellsByDepth->depth[i]->getName());
+
+  doProblemCellSetup_ = false;
+
+}
+
+void HcalDetDiagTimingClient::beginRun(void)
+{
+  enoughevents_=false;
   nevts_=0;
 }
 
-void HcalDetDiagTimingClient::endRun(void){analyze();}
+//void HcalDetDiagTimingClient::endRun(void){analyze();}
 
 void HcalDetDiagTimingClient::setup(void){}
 void HcalDetDiagTimingClient::cleanup(void){}

--- a/DQM/HcalMonitorClient/src/HcalDetDiagTimingClient.cc
+++ b/DQM/HcalMonitorClient/src/HcalDetDiagTimingClient.cc
@@ -270,4 +270,6 @@ void HcalDetDiagTimingClient::updateChannelStatus(std::map<HcalDetId, unsigned i
 } //void HcalDetDiagTimingClient::updateChannelStatus
 
 HcalDetDiagTimingClient::~HcalDetDiagTimingClient()
-{}
+{
+  if ( ProblemCellsByDepth ) delete ProblemCellsByDepth;
+}

--- a/DQM/HcalMonitorClient/src/HcalDigiClient.cc
+++ b/DQM/HcalMonitorClient/src/HcalDigiClient.cc
@@ -49,24 +49,27 @@ HcalDigiClient::HcalDigiClient(std::string myname, const edm::ParameterSet& ps)
   ProblemCells=0;
 
   HFTiming_averageTime=0;
+
+  doProblemCellSetup_ = true;
 }
 
-void HcalDigiClient::analyze()
+void HcalDigiClient::analyze(DQMStore::IBooker &ib, DQMStore::IGetter &ig)
 {
   if (debug_>2) std::cout <<"\tHcalDigiClient::analyze()"<<std::endl;
-  calculateProblems();
+  if ( doProblemCellSetup_ ) setupProblemCells(ib,ig);
+  calculateProblems(ib,ig);
 
   // Get Pawel's timing plots to form averages
   TH2F* TimingStudyTime=0;
   TH2F* TimingStudyOcc=0;
   std::string s=subdir_+"HFTimingStudy/sumplots/HFTiming_Total_Time";
   
-  MonitorElement* me=dqmStore_->get(s.c_str());
+  MonitorElement* me=ig.get(s.c_str());
   if (me!=0)
     TimingStudyTime=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_,TimingStudyTime, debug_);
 
   s=subdir_+"HFTimingStudy/sumplots/HFTiming_Occupancy";
-  me=dqmStore_->get(s.c_str());
+  me=ig.get(s.c_str());
   if (me!=0)
     TimingStudyOcc=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_,TimingStudyOcc, debug_);
 
@@ -86,10 +89,9 @@ void HcalDigiClient::analyze()
     }
 }
 
-void HcalDigiClient::calculateProblems()
+void HcalDigiClient::calculateProblems(DQMStore::IBooker &ib, DQMStore::IGetter &ig)
 {
  if (debug_>2) std::cout <<"\t\tHcalDigiClient::calculateProblems()"<<std::endl;
-  if(!dqmStore_) return;
   int totalevents=0;
   int etabins=0, phibins=0, zside=0;
   double problemvalue=0;
@@ -123,7 +125,7 @@ void HcalDigiClient::calculateProblems()
   for (int i=0;i<4;++i)
     {
       std::string s=subdir_+"bad_digis/bad_digi_occupancy/"+name[i]+"Bad Digi Map";
-      me=dqmStore_->get(s.c_str());
+      me=ig.get(s.c_str());
       if (me==0) 
 	{
 	  gothistos=false;
@@ -132,7 +134,7 @@ void HcalDigiClient::calculateProblems()
       BadDigisByDepth[i]=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, BadDigisByDepth[i], debug_);
 
       s=subdir_+"good_digis/digi_occupancy/"+name[i]+" Digi Eta-Phi Occupancy Map";
-      me=dqmStore_->get(s.c_str());
+      me=ig.get(s.c_str());
       if (me==0) 
 	{
 	  gothistos=false;
@@ -213,48 +215,40 @@ void HcalDigiClient::calculateProblems()
 }
 
 
-void HcalDigiClient::beginJob()
-{
-  dqmStore_ = edm::Service<DQMStore>().operator->();
-  if (debug_>0) 
-    {
-      std::cout <<"<HcalDigiClient::beginJob()>  Displaying dqmStore directory structure:"<<std::endl;
-      dqmStore_->showDirStructure();
-    }
-}
 
 void HcalDigiClient::endJob(){}
 
-void HcalDigiClient::beginRun(void)
+void HcalDigiClient::setupProblemCells(DQMStore::IBooker &ib, DQMStore::IGetter &ig )
 {
-  enoughevents_=false;
-  if (!dqmStore_) 
-    {
-      if (debug_>0) std::cout <<"<HcalDigiClient::beginRun> dqmStore does not exist!"<<std::endl;
-      return;
-    }
-  dqmStore_->setCurrentFolder(subdir_);
+  ib.setCurrentFolder(subdir_);
   problemnames_.clear();
-  ProblemCells=dqmStore_->book2D(" ProblemDigis",
+  ProblemCells=ib.book2D(" ProblemDigis",
 				 " Problem Digi Rate for all HCAL;ieta;iphi",
 				 85,-42.5,42.5,
 				 72,0.5,72.5);
   problemnames_.push_back(ProblemCells->getName());
   if (debug_>1)
     std::cout << "Tried to create ProblemCells Monitor Element in directory "<<subdir_<<"  \t  Failed?  "<<(ProblemCells==0)<<std::endl;
-  dqmStore_->setCurrentFolder(subdir_+"problem_digis");
+  ib.setCurrentFolder(subdir_+"problem_digis");
   ProblemCellsByDepth = new EtaPhiHists();
-  ProblemCellsByDepth->setup(dqmStore_," Problem Digi Rate");
+  ProblemCellsByDepth->setup(ib," Problem Digi Rate");
   for (unsigned int i=0; i<ProblemCellsByDepth->depth.size();++i)
     problemnames_.push_back(ProblemCellsByDepth->depth[i]->getName());
 
-  nevts_=0;
+  ib.setCurrentFolder(subdir_+"HFTimingStudy");
+  HFTiming_averageTime=ib.book2D("HFTimingStudy_Average_Time","HFTimingStudy Average Time (time sample)",83,-41.5,41.5,72,0.5,72.5);
 
-  dqmStore_->setCurrentFolder(subdir_+"HFTimingStudy");
-  HFTiming_averageTime=dqmStore_->book2D("HFTimingStudy_Average_Time","HFTimingStudy Average Time (time sample)",83,-41.5,41.5,72,0.5,72.5);
+  doProblemCellSetup_ = false;
+
 }
 
-void HcalDigiClient::endRun(void){analyze();}
+void HcalDigiClient::beginRun(void)
+{
+  enoughevents_=false;
+  nevts_=0;
+}
+
+//void HcalDigiClient::endRun(void){analyze();}
 
 void HcalDigiClient::setup(void){}
 void HcalDigiClient::cleanup(void){}

--- a/DQM/HcalMonitorClient/src/HcalDigiClient.cc
+++ b/DQM/HcalMonitorClient/src/HcalDigiClient.cc
@@ -297,4 +297,6 @@ void HcalDigiClient::updateChannelStatus(std::map<HcalDetId, unsigned int>& myqu
 } //void HcalDigiClient::updateChannelStatus
 
 HcalDigiClient::~HcalDigiClient()
-{}
+{
+  if ( ProblemCellsByDepth ) delete ProblemCellsByDepth;
+}

--- a/DQM/HcalMonitorClient/src/HcalHotCellClient.cc
+++ b/DQM/HcalMonitorClient/src/HcalHotCellClient.cc
@@ -48,18 +48,20 @@ HcalHotCellClient::HcalHotCellClient(std::string myname, const edm::ParameterSet
 
   ProblemCellsByDepth=0;
   ProblemCells=0;
+  
+  doProblemCellSetup_ = true;
 }
 
-void HcalHotCellClient::analyze()
+void HcalHotCellClient::analyze(DQMStore::IBooker &ib, DQMStore::IGetter &ig)
 {
   if (debug_>2) std::cout <<"\tHcalHotCellClient::analyze()"<<std::endl;
-  calculateProblems();
+  if ( doProblemCellSetup_ ) setupProblemCells(ib,ig);
+  calculateProblems(ib,ig);
 }
 
-void HcalHotCellClient::calculateProblems()
+void HcalHotCellClient::calculateProblems(DQMStore::IBooker &ib, DQMStore::IGetter &ig)
 {
   if (debug_>2) std::cout <<"\t\tHcalHotCellClient::calculateProblems()"<<std::endl;
-  if(!dqmStore_) return;
   double totalevents=0;
   int etabins=0, phibins=0, zside=0;
   double problemvalue=0;
@@ -103,26 +105,26 @@ void HcalHotCellClient::calculateProblems()
       HotNeighborsByDepth[i]=0;
 
       std::string s=subdir_+"hot_rechit_above_threshold/"+name[i]+"Hot Cells Above ET Threshold";
-      me=dqmStore_->get(s.c_str());
+      me=ig.get(s.c_str());
       if (me!=0)HotAboveETThresholdByDepth[i]=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, HotAboveETThresholdByDepth[i], debug_);
 
       s=subdir_+"hot_rechit_always_above_threshold/"+name[i]+"Hot Cells Persistently Above ET Threshold";
-      me=dqmStore_->get(s.c_str());
+      me=ig.get(s.c_str());
       if (me!=0)HotAlwaysAboveETThresholdByDepth[i]=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, HotAlwaysAboveETThresholdByDepth[i], debug_);
 
       s=subdir_+"hot_rechit_above_threshold/"+name[i]+"Hot Cells Above Energy Threshold";
-      me=dqmStore_->get(s.c_str());
+      me=ig.get(s.c_str());
       if (me!=0)HotAboveThresholdByDepth[i]=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, HotAboveThresholdByDepth[i], debug_);
 
       s=subdir_+"hot_rechit_always_above_threshold/"+name[i]+"Hot Cells Persistently Above Energy Threshold";
-      me=dqmStore_->get(s.c_str());
+      me=ig.get(s.c_str());
       if (me!=0)HotAlwaysAboveThresholdByDepth[i]=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, HotAlwaysAboveThresholdByDepth[i], debug_);
 
       s=subdir_+"hot_neighbortest/"+name[i]+"Hot Cells Failing Neighbor Test";
-      me=dqmStore_->get(s.c_str());
+      me=ig.get(s.c_str());
       if (me!=0)HotNeighborsByDepth[i]=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, HotNeighborsByDepth[i], debug_);
       s=subdir_+"hot_neighbortest/NeighborTestEnabled";
-      me=dqmStore_->get(s.c_str());
+      me=ig.get(s.c_str());
       if (me!=0 && me->getIntValue()==1)
 	neighbortest=true;
     }
@@ -213,45 +215,38 @@ void HcalHotCellClient::calculateProblems()
 }
 
 
-void HcalHotCellClient::beginJob()
-{
-  dqmStore_ = edm::Service<DQMStore>().operator->();
-  if (debug_>0) 
-    {
-      std::cout <<"<HcalHotCellClient::beginJob()>  Displaying dqmStore directory structure:"<<std::endl;
-      dqmStore_->showDirStructure();
-    }
-}
 
 void HcalHotCellClient::endJob(){}
 
-void HcalHotCellClient::beginRun(void)
+void HcalHotCellClient::setupProblemCells(DQMStore::IBooker &ib, DQMStore::IGetter & ig)
 {
-  enoughevents_=false;
-  if (!dqmStore_) 
-    {
-      if (debug_>0) std::cout <<"<HcalHotCellClient::beginRun> dqmStore does not exist!"<<std::endl;
-      return;
-    }
-  dqmStore_->setCurrentFolder(subdir_);
+
+  ib.setCurrentFolder(subdir_);
   problemnames_.clear();
-  ProblemCells=dqmStore_->book2D(" ProblemHotCells",
+  ProblemCells=ib.book2D(" ProblemHotCells",
 				 " Problem Hot Cell Rate for all HCAL;ieta;iphi",
 				 85,-42.5,42.5,
 				 72,0.5,72.5);
   problemnames_.push_back(ProblemCells->getName());
   if (debug_>1)
     std::cout << "Tried to create ProblemCells Monitor Element in directory "<<subdir_<<"  \t  Failed?  "<<(ProblemCells==0)<<std::endl;
-  dqmStore_->setCurrentFolder(subdir_+"problem_hotcells");
+  ib.setCurrentFolder(subdir_+"problem_hotcells");
   ProblemCellsByDepth=new EtaPhiHists();
-  ProblemCellsByDepth->setup(dqmStore_," Problem Hot Cell Rate");
+  ProblemCellsByDepth->setup(ib," Problem Hot Cell Rate");
   for (unsigned int i=0; i<ProblemCellsByDepth->depth.size();++i)
     problemnames_.push_back(ProblemCellsByDepth->depth[i]->getName());
 
+  doProblemCellSetup_ = false;
+
+}
+
+void HcalHotCellClient::beginRun(void)
+{
+  enoughevents_=false;
   nevts_=0;
 }
 
-void HcalHotCellClient::endRun(void){analyze();}
+//void HcalHotCellClient::endRun(void){analyze();}
 
 void HcalHotCellClient::setup(void){}
 void HcalHotCellClient::cleanup(void){}

--- a/DQM/HcalMonitorClient/src/HcalHotCellClient.cc
+++ b/DQM/HcalMonitorClient/src/HcalHotCellClient.cc
@@ -372,4 +372,6 @@ void HcalHotCellClient::updateChannelStatus(std::map<HcalDetId, unsigned int>& m
 } //void HcalHotCellClient::updateChannelStatus
 
 HcalHotCellClient::~HcalHotCellClient()
-{}
+{
+  if ( ProblemCellsByDepth ) delete ProblemCellsByDepth;
+}

--- a/DQM/HcalMonitorClient/src/HcalMonitorClient.cc
+++ b/DQM/HcalMonitorClient/src/HcalMonitorClient.cc
@@ -76,6 +76,10 @@ HcalMonitorClient::HcalMonitorClient(const edm::ParameterSet& ps)
   Online_                = ps.getUntrackedParameter<bool>("online",false);
 
 
+  doPedSetup_ = true;
+  doChanStatSetup_ = true;
+
+
   if (debug_>0)
     {
       std::cout <<"HcalMonitorClient:: The following clients are enabled:"<<std::endl;
@@ -127,22 +131,8 @@ HcalMonitorClient::HcalMonitorClient(const edm::ParameterSet& ps)
 
   if (find(enabledClients_.begin(), enabledClients_.end(),"Summary")!=enabledClients_.end())
     summaryClient_ = new HcalSummaryClient((std::string)"ReportSummaryClient",ps);
-  
-} // HcalMonitorClient constructor
 
-
-HcalMonitorClient::~HcalMonitorClient()
-{
-  if (debug_>0) std::cout <<"<HcalMonitorClient>  Exiting..."<<std::endl;
-  for (unsigned int i=0;i<clients_.size();++i)
-    delete clients_[i];
-  //if (summaryClient_) delete summaryClient_;
-
-}
-
-void HcalMonitorClient::beginJob(void)
-{
-
+  // Contents of the beginJob(void) method (this was moved here during the MT migration
   begin_run_ = false;
   end_run_   = false;
 
@@ -155,21 +145,24 @@ void HcalMonitorClient::beginJob(void)
   last_time_db_ = 0;   
 
   // get hold of back-end interface
-
-  dqmStore_ = edm::Service<DQMStore>().operator->();
-
-  if ( inputFile_.size() != 0 ) 
-    {
-      if ( dqmStore_ )    dqmStore_->open(inputFile_);
-    }
-
-  for ( unsigned int i=0; i<clients_.size();++i ) 
+  // CATCH -- removed beginJob methods from clients
+  /*for ( unsigned int i=0; i<clients_.size();++i ) 
     clients_[i]->beginJob();
 
-  if ( summaryClient_ ) summaryClient_->beginJob();
+  if ( summaryClient_ ) summaryClient_->beginJob();*/
   
+  
+} // HcalMonitorClient constructor
 
-} // void HcalMonitorClient::beginJob(void)
+
+HcalMonitorClient::~HcalMonitorClient()
+{
+  if (debug_>0) std::cout <<"<HcalMonitorClient>  Exiting..."<<std::endl;
+  for (unsigned int i=0;i<clients_.size();++i)
+    delete clients_[i];
+  //if (summaryClient_) delete summaryClient_;
+
+}
 
 
 void HcalMonitorClient::beginRun(const edm::Run& r, const edm::EventSetup& c) 
@@ -194,50 +187,6 @@ void HcalMonitorClient::beginRun(const edm::Run& r, const edm::EventSetup& c)
   c.get<HcalChannelQualityRcd>().get("withTopo",p);
   chanquality_= p.product();
  
-  if (dqmStore_ && ChannelStatus==0)
-    {
-      dqmStore_->setCurrentFolder(prefixME_+"HcalInfo/ChannelStatus");
-      ChannelStatus=new EtaPhiHists;
-      ChannelStatus->setup(dqmStore_,"ChannelStatus");
-      std::stringstream x;
-      for (unsigned int d=0;d<ChannelStatus->depth.size();++d)
-	{
-	  ChannelStatus->depth[d]->Reset();
-	  x<<"1+log2(status) for HCAL depth "<<d+1;
-	  if (ChannelStatus->depth[d]) ChannelStatus->depth[d]->setTitle(x.str().c_str());
-	  x.str("");
-	}
-    }
-
-  edm::ESHandle<HcalDbService> conditions;
-  c.get<HcalDbRecord>().get(conditions);
-  // Now let's setup pedestals
-  if (dqmStore_ )
-    {
-      dqmStore_->setCurrentFolder(prefixME_+"HcalInfo/PedestalsFromCondDB");
-      if (ADC_PedestalFromDBByDepth==0)
-	{
-	  ADC_PedestalFromDBByDepth = new EtaPhiHists;
-	  ADC_PedestalFromDBByDepth->setup(dqmStore_,"ADC Pedestals From Conditions DB");
-	}
-      if (ADC_WidthFromDBByDepth==0)
-	{
-	  ADC_WidthFromDBByDepth = new EtaPhiHists;
-	  ADC_WidthFromDBByDepth->setup(dqmStore_,"ADC Widths From Conditions DB");
-	}
-      if (fC_PedestalFromDBByDepth==0)
-	{
-	  fC_PedestalFromDBByDepth = new EtaPhiHists;
-	  fC_PedestalFromDBByDepth->setup(dqmStore_,"fC Pedestals From Conditions DB");
-	}
-      if (fC_WidthFromDBByDepth==0)
-	{
-	  fC_WidthFromDBByDepth = new EtaPhiHists;
-	  fC_WidthFromDBByDepth->setup(dqmStore_,"fC Widths From Conditions DB");
-	}
-      PlotPedestalValues(*conditions);
-    }
-
   // Find only channels with non-zero quality, and add them to badchannelmap
   std::vector<DetId> mydetids = chanquality_->getAllChannels();
   for (std::vector<DetId>::const_iterator i = mydetids.begin();i!=mydetids.end();++i)
@@ -251,7 +200,6 @@ void HcalMonitorClient::beginRun(const edm::Run& r, const edm::EventSetup& c)
       badchannelmap[id]=status;
 
       // Fill Channel Status histogram
-      if (dqmStore_==0) continue;
       int depth=id.depth();
       if (depth<1 || depth>4) continue;
       int ieta=id.ieta();
@@ -283,7 +231,8 @@ void HcalMonitorClient::beginRun(const edm::Run& r, const edm::EventSetup& c)
 
 } // void HcalMonitorClient::beginRun(const Run& r, const EventSetup& c)
 
-void HcalMonitorClient::beginRun()
+// CATCH  I don't think this is called
+/*void HcalMonitorClient::beginRun()
 {
   // What is the difference between this and beginRun above?
   // When would this be called?
@@ -303,19 +252,23 @@ void HcalMonitorClient::beginRun()
       if (ChannelStatus->depth[d]) ChannelStatus->depth[d]->setTitle(x.str().c_str());
       x.str("");
     }
-} // void HcalMonitorClient::beginRun()
+} */ // void HcalMonitorClient::beginRun()
 
 void HcalMonitorClient::setup(void)
 {
   // no setup required
 }
 
-void HcalMonitorClient::beginLuminosityBlock(const edm::LuminosityBlock &l, const edm::EventSetup &c) 
+// CATCH this can be removed
+/*void HcalMonitorClient::beginLuminosityBlock(const edm::LuminosityBlock &l, const edm::EventSetup &c) 
 {
   if (debug_>0) std::cout <<"<HcalMonitorClient::beginLuminosityBlock>"<<std::endl;
-} // void HcalMonitorClient::beginLuminosityBlock
+}*/ // void HcalMonitorClient::beginLuminosityBlock
 
-void HcalMonitorClient::analyze(const edm::Event & e, const edm::EventSetup & c)
+// CATCH
+// I think this function can be removed since the prescaleFactor is set to -1 by default configuration.
+// ievt and jevt are diisplayed by the monitor, but this should be found by some other means.
+/*void HcalMonitorClient::analyze(const edm::Event & e, const edm::EventSetup & c)
 {
   if (debug_>4) 
     std::cout <<"HcalMonitorClient::analyze(const edm::Event&, const edm::EventSetup&) ievt_ = "<<ievt_<<std::endl;
@@ -331,30 +284,34 @@ void HcalMonitorClient::analyze(const edm::Event & e, const edm::EventSetup & c)
     this->analyze(e.luminosityBlock());
   }
 
-} // void HcalMonitorClient::analyze(const edm::Event & e, const edm::EventSetup & c)
+} */ // void HcalMonitorClient::analyze(const edm::Event & e, const edm::EventSetup & c)
 
-void HcalMonitorClient::analyze(int LS)
+void HcalMonitorClient::analyze(DQMStore::IBooker &ib, DQMStore::IGetter &ig, int LS)
 {
   if (debug_>0)
     std::cout <<"HcalMonitorClient::analyze() "<<std::endl;
   current_time_ = time(NULL);
   // no ievt_, jevt_ counters needed here:  this function gets called at endlumiblock, after default analyze function runs
   for (unsigned int i=0;i<clients_.size();++i)
-    clients_[i]->analyze();
+    clients_[i]->analyze(ib,ig);
   if (summaryClient_!=0)
     {
       // Always call basic analyze to form histograms for each task
-      summaryClient_->analyze(LS);
+      summaryClient_->analyze(ib,ig,LS);
       // Call this if LS-by-LS enabling is set to true
       if (saveByLumiSection_==true)
-	summaryClient_->fillReportSummaryLSbyLS(LS);
+	summaryClient_->fillReportSummaryLSbyLS(ib,ig,LS);
     }
 } // void HcalMonitorClient::analyze()
 
 
-void HcalMonitorClient::endLuminosityBlock(const edm::LuminosityBlock &l, const edm::EventSetup &c) 
+void HcalMonitorClient::dqmEndLuminosityBlock(DQMStore::IBooker &ib, DQMStore::IGetter &ig, const edm::LuminosityBlock &l, const edm::EventSetup &c) 
 {
-  if (debug_>0) std::cout <<"<HcalMonitorClient::endLuminosityBlock>"<<std::endl;
+
+  if ( doChanStatSetup_ ) setupChannelStatusMon(ib);
+  if ( doPedSetup_ ) setupPedestalMon(ib);
+
+  if (debug_>0) std::cout <<"<HcalMonitorClient::dqmEndLuminosityBlock>"<<std::endl;
   current_time_ = time(NULL);
   if (updateTime_>0)
     {
@@ -362,7 +319,7 @@ void HcalMonitorClient::endLuminosityBlock(const edm::LuminosityBlock &l, const 
 	return;
       last_time_update_ = current_time_;
     }
-  this->analyze(l.luminosityBlock());
+  this->analyze(ib,ig,l.luminosityBlock());
 
   if (databaseUpdateTime_>0)
     {
@@ -387,14 +344,15 @@ void HcalMonitorClient::endLuminosityBlock(const edm::LuminosityBlock &l, const 
 	  ||((current_time_-last_time_html_)>=60*htmlUpdateTime_)
 	  ) // htmlUpdateTime_ in minutes
 	{
-	  this->writeHtml();
+	  this->writeHtml(ib,ig);
 	  last_time_html_=current_time_;
 	}
     }
 
+
 } // void HcalMonitorClient::endLuminosityBlock
 
-void HcalMonitorClient::endRun(void)
+void HcalMonitorClient::endRun(DQMStore::IBooker &ib, DQMStore::IGetter &ig)
 {
   begin_run_ = false;
   end_run_   = true;
@@ -402,14 +360,14 @@ void HcalMonitorClient::endRun(void)
   // Always fill summaryClient at end of run (as opposed to the end-lumi fills, which may just contain info for a single LS)
   // At the end of this run, set LS=-1  (LS-based plotting in doesn't work yet anyway)
   if (summaryClient_)
-    summaryClient_->analyze(-1);
+    summaryClient_->analyze(ib,ig,-1);
 
   if (databasedir_.size()>0)
     this->writeChannelStatus();
   // writeHtml takes longer; run it last 
   // Also, don't run it if htmlUpdateTime_>0 -- it should have already been run
   if (baseHtmlDir_.size()>0 && htmlUpdateTime_==0)
-    this->writeHtml();
+    this->writeHtml(ib,ig);
 }
 
 void HcalMonitorClient::endRun(const edm::Run& r, const edm::EventSetup& c) 
@@ -420,11 +378,20 @@ void HcalMonitorClient::endRun(const edm::Run& r, const edm::EventSetup& c)
   begin_run_ = false;
   end_run_   = true;
 
-  this->analyze();
-  this->endRun();
+  // pedestal values
+  if ( !doPedSetup_ ) {
+    edm::ESHandle<HcalDbService> conditions;
+    c.get<HcalDbRecord>().get(conditions);
+    PlotPedestalValues(*conditions);
+  }
+
+  // CATCH -- hopefully this does not break functionality
+  // The clients will need access to IBooker and IGetter in the analyze methods.
+  /*this->analyze();
+  this->endRun();*/
 }
 
-void HcalMonitorClient::endJob(void)
+void HcalMonitorClient::dqmEndJob(DQMStore::IBooker &ib, DQMStore::IGetter &ig)
 {
   // Temporary fix for crash of April 2011 in online DQM
   if (Online_==true)
@@ -432,8 +399,8 @@ void HcalMonitorClient::endJob(void)
 
   if (! end_run_)
     {
-      this->analyze();
-      this->endRun();
+      this->analyze(ib,ig);
+      this->endRun(ib,ig);
     }
   this->cleanup(); // currently does nothing
 
@@ -450,7 +417,7 @@ void HcalMonitorClient::cleanup(void)
 } // void HcalMonitorClient::cleanup(void)
 
 
-void HcalMonitorClient::writeHtml()
+void HcalMonitorClient::writeHtml(DQMStore::IBooker &ib, DQMStore::IGetter &ig)
 {
   if (debug_>0) std::cout << "Preparing HcalMonitorClient html output ..." << std::endl;
   
@@ -500,9 +467,9 @@ void HcalMonitorClient::writeHtml()
 
   for (unsigned int i=0;i<clients_.size();++i)
     {
-      if (clients_[i]->validHtmlOutput()==true)
+      if (clients_[i]->validHtmlOutput(ib,ig)==true)
 	{
-	  clients_[i]->htmlOutput(htmlDir);
+	  clients_[i]->htmlOutput(ib,ig,htmlDir);
 	  // Always print this out?  Or only when validHtmlOutput is true? 
 	  htmlFile << "<table border=0 WIDTH=\"50%\"><tr>" << std::endl;
 	  htmlFile << "<td WIDTH=\"35%\"><a href=\"" << clients_[i]->name_ << ".html"<<"\">"<<clients_[i]->name_<<"</a></td>" << std::endl;
@@ -517,7 +484,7 @@ void HcalMonitorClient::writeHtml()
   // Add call to reportSummary html output
   if (summaryClient_)
     {
-      summaryClient_->htmlOutput(htmlDir);
+      summaryClient_->htmlOutput(ib,ig,htmlDir);
       htmlFile << "<table border=0 WIDTH=\"50%\"><tr>" << std::endl;
       htmlFile << "<td WIDTH=\"35%\"><a href=\"" << summaryClient_->name_ << ".html"<<"\">"<<summaryClient_->name_<<"</a></td>" << std::endl;
       if(summaryClient_->hasErrors_Temp()) htmlFile << "<td bgcolor=red align=center>This monitor task has errors.</td>" << std::endl;
@@ -706,6 +673,64 @@ void HcalMonitorClient::PlotPedestalValues(const HcalDbService& cond)
     if (ADC_WidthFromDBByDepth->depth[i]->getTH2F()->GetMaximum()<2)
       ADC_WidthFromDBByDepth->depth[i]->getTH2F()->SetMaximum(2);
   }
+
+}
+
+
+//
+// setupPedestalMon
+//
+void HcalMonitorClient::setupPedestalMon(DQMStore::IBooker &ib) 
+{
+
+  // Now let's setup pedestals
+      ib.setCurrentFolder(prefixME_+"HcalInfo/PedestalsFromCondDB");
+      if (ADC_PedestalFromDBByDepth==0)
+	{
+	  ADC_PedestalFromDBByDepth = new EtaPhiHists;
+	  ADC_PedestalFromDBByDepth->setup(ib,"ADC Pedestals From Conditions DB");
+	}
+      if (ADC_WidthFromDBByDepth==0)
+	{
+	  ADC_WidthFromDBByDepth = new EtaPhiHists;
+	  ADC_WidthFromDBByDepth->setup(ib,"ADC Widths From Conditions DB");
+	}
+      if (fC_PedestalFromDBByDepth==0)
+	{
+	  fC_PedestalFromDBByDepth = new EtaPhiHists;
+	  fC_PedestalFromDBByDepth->setup(ib,"fC Pedestals From Conditions DB");
+	}
+      if (fC_WidthFromDBByDepth==0)
+	{
+	  fC_WidthFromDBByDepth = new EtaPhiHists;
+	  fC_WidthFromDBByDepth->setup(ib,"fC Widths From Conditions DB");
+	}
+
+    doPedSetup_ = false;
+}
+
+//
+// setupChannelStatus
+//
+void HcalMonitorClient::setupChannelStatusMon(DQMStore::IBooker &ib) 
+{
+
+  if (ChannelStatus==0)
+    {
+      ib.setCurrentFolder(prefixME_+"HcalInfo/ChannelStatus");
+      ChannelStatus=new EtaPhiHists;
+      ChannelStatus->setup(ib,"ChannelStatus");
+      std::stringstream x;
+      for (unsigned int d=0;d<ChannelStatus->depth.size();++d)
+	{
+	  ChannelStatus->depth[d]->Reset();
+	  x<<"1+log2(status) for HCAL depth "<<d+1;
+	  if (ChannelStatus->depth[d]) ChannelStatus->depth[d]->setTitle(x.str().c_str());
+	  x.str("");
+	}
+    }
+
+  doChanStatSetup_ = false;
 
 }
 

--- a/DQM/HcalMonitorClient/src/HcalMonitorClient.cc
+++ b/DQM/HcalMonitorClient/src/HcalMonitorClient.cc
@@ -144,13 +144,6 @@ HcalMonitorClient::HcalMonitorClient(const edm::ParameterSet& ps)
   last_time_html_ = 0; 
   last_time_db_ = 0;   
 
-  // get hold of back-end interface
-  // CATCH -- removed beginJob methods from clients
-  /*for ( unsigned int i=0; i<clients_.size();++i ) 
-    clients_[i]->beginJob();
-
-  if ( summaryClient_ ) summaryClient_->beginJob();*/
-  
   
 } // HcalMonitorClient constructor
 
@@ -213,7 +206,7 @@ void HcalMonitorClient::beginRun(const edm::Run& r, const edm::EventSetup& c)
 	logstatus=-1*(log2(-1.*status)+1);
       else
 	logstatus=log2(1.*status)+1;
-      if (ChannelStatus->depth[depth-1]) ChannelStatus->depth[depth-1]->Fill(ieta,iphi,logstatus);
+      if (ChannelStatus && ChannelStatus->depth[depth-1]) ChannelStatus->depth[depth-1]->Fill(ieta,iphi,logstatus);
     }
     
   for (unsigned int i=0;i<clients_.size();++i)
@@ -231,60 +224,13 @@ void HcalMonitorClient::beginRun(const edm::Run& r, const edm::EventSetup& c)
 
 } // void HcalMonitorClient::beginRun(const Run& r, const EventSetup& c)
 
-// CATCH  I don't think this is called
-/*void HcalMonitorClient::beginRun()
-{
-  // What is the difference between this and beginRun above?
-  // When would this be called?
-  begin_run_ = true;
-  end_run_   = false;
-  jevt_ = 0;
-  htmlcounter_=0;
-
-  if (dqmStore_==0 || ChannelStatus!=0) return;
-  dqmStore_->setCurrentFolder(prefixME_+"HcalInfo");
-  ChannelStatus=new EtaPhiHists;
-  ChannelStatus->setup(dqmStore_,"ChannelStatus");
-  std::stringstream x;
-  for (unsigned int d=0;d<ChannelStatus->depth.size();++d)
-    {
-      x<<"1+log2(status) for HCAL depth "<<d+1;
-      if (ChannelStatus->depth[d]) ChannelStatus->depth[d]->setTitle(x.str().c_str());
-      x.str("");
-    }
-} */ // void HcalMonitorClient::beginRun()
 
 void HcalMonitorClient::setup(void)
 {
   // no setup required
 }
 
-// CATCH this can be removed
-/*void HcalMonitorClient::beginLuminosityBlock(const edm::LuminosityBlock &l, const edm::EventSetup &c) 
-{
-  if (debug_>0) std::cout <<"<HcalMonitorClient::beginLuminosityBlock>"<<std::endl;
-}*/ // void HcalMonitorClient::beginLuminosityBlock
 
-// CATCH
-// I think this function can be removed since the prescaleFactor is set to -1 by default configuration.
-// ievt and jevt are diisplayed by the monitor, but this should be found by some other means.
-/*void HcalMonitorClient::analyze(const edm::Event & e, const edm::EventSetup & c)
-{
-  if (debug_>4) 
-    std::cout <<"HcalMonitorClient::analyze(const edm::Event&, const edm::EventSetup&) ievt_ = "<<ievt_<<std::endl;
-  ievt_++;
-  jevt_++;
-
-  run_=e.id().run();
-  if (prescaleFactor_>0 && jevt_%prescaleFactor_==0) {
-
-    for (unsigned int i=0;i<clients_.size();++i)
-      clients_[i]->getLogicalMap(c); // actually runs just once internally
-
-    this->analyze(e.luminosityBlock());
-  }
-
-} */ // void HcalMonitorClient::analyze(const edm::Event & e, const edm::EventSetup & c)
 
 void HcalMonitorClient::analyze(DQMStore::IBooker &ib, DQMStore::IGetter &ig, int LS)
 {
@@ -385,10 +331,6 @@ void HcalMonitorClient::endRun(const edm::Run& r, const edm::EventSetup& c)
     PlotPedestalValues(*conditions);
   }
 
-  // CATCH -- hopefully this does not break functionality
-  // The clients will need access to IBooker and IGetter in the analyze methods.
-  /*this->analyze();
-  this->endRun();*/
 }
 
 void HcalMonitorClient::dqmEndJob(DQMStore::IBooker &ib, DQMStore::IGetter &ig)

--- a/DQM/HcalMonitorClient/src/HcalNZSClient.cc
+++ b/DQM/HcalMonitorClient/src/HcalNZSClient.cc
@@ -44,18 +44,20 @@ HcalNZSClient::HcalNZSClient(std::string myname, const edm::ParameterSet& ps)
 						ps.getUntrackedParameter<int>("minevents",1));
   ProblemCells=0;
   ProblemCellsByDepth=0;
+
+  doProblemCellSetup_ = true;
 }
 
-void HcalNZSClient::analyze()
+void HcalNZSClient::analyze(DQMStore::IBooker &ib, DQMStore::IGetter &ig)
 {
   if (debug_>2) std::cout <<"\tHcalNZSClient::analyze()"<<std::endl;
-  calculateProblems();
+  if ( doProblemCellSetup_ ) setupProblemCells(ib,ig);
+  calculateProblems(ib,ig);
 }
 
-void HcalNZSClient::calculateProblems()
+void HcalNZSClient::calculateProblems(DQMStore::IBooker &ib, DQMStore::IGetter &ig)
 {
  if (debug_>2) std::cout <<"\t\tHcalNZSClient::calculateProblems()"<<std::endl;
-  if(!dqmStore_) return;
   double totalevents=0;
   int etabins=0, phibins=0, zside=0;
   double problemvalue=0;
@@ -167,45 +169,39 @@ void HcalNZSClient::calculateProblems()
   return;
 }
 
-void HcalNZSClient::beginJob()
-{
-  dqmStore_ = edm::Service<DQMStore>().operator->();
-  if (debug_>0) 
-    {
-      std::cout <<"<HcalNZSClient::beginJob()>  Displaying dqmStore directory structure:"<<std::endl;
-      dqmStore_->showDirStructure();
-    }
-}
 void HcalNZSClient::endJob(){}
 
-void HcalNZSClient::beginRun(void)
+void HcalNZSClient::setupProblemCells(DQMStore::IBooker &ib, DQMStore::IGetter &ig) 
 {
-  enoughevents_=false;
-  if (!dqmStore_) 
-    {
-      if (debug_>0) std::cout <<"<HcalNZSClient::beginRun> dqmStore does not exist!"<<std::endl;
-      return;
-    }
-  dqmStore_->setCurrentFolder(subdir_);
+
+  ib.setCurrentFolder(subdir_);
   problemnames_.clear();
 
   // Put the appropriate name of your problem summary here
-  ProblemCells=dqmStore_->book2D(" ProblemNZS",
+  ProblemCells=ib.book2D(" ProblemNZS",
 				 " Problem NZS Rate for all HCAL;ieta;iphi",
 				 85,-42.5,42.5,
 				 72,0.5,72.5);
   problemnames_.push_back(ProblemCells->getName());
   if (debug_>1)
     std::cout << "Tried to create ProblemCells Monitor Element in directory "<<subdir_<<"  \t  Failed?  "<<(ProblemCells==0)<<std::endl;
-  dqmStore_->setCurrentFolder(subdir_+"problem_NZS");
+  ib.setCurrentFolder(subdir_+"problem_NZS");
   ProblemCellsByDepth = new EtaPhiHists();
-  ProblemCellsByDepth->setup(dqmStore_," Problem NZS Rate");
+  ProblemCellsByDepth->setup(ib," Problem NZS Rate");
   for (unsigned int i=0; i<ProblemCellsByDepth->depth.size();++i)
     problemnames_.push_back(ProblemCellsByDepth->depth[i]->getName());
+
+  doProblemCellSetup_ = false;
+
+}
+
+void HcalNZSClient::beginRun(void)
+{
+  enoughevents_=false;
   nevts_=0;
 }
 
-void HcalNZSClient::endRun(void){analyze();}
+//void HcalNZSClient::endRun(void){analyze();}
 
 void HcalNZSClient::setup(void){}
 void HcalNZSClient::cleanup(void){}

--- a/DQM/HcalMonitorClient/src/HcalNZSClient.cc
+++ b/DQM/HcalMonitorClient/src/HcalNZSClient.cc
@@ -253,4 +253,6 @@ void HcalNZSClient::updateChannelStatus(std::map<HcalDetId, unsigned int>& myqua
 } //void HcalNZSClient::updateChannelStatus
 
 HcalNZSClient::~HcalNZSClient()
-{}
+{
+  if ( ProblemCellsByDepth ) delete ProblemCellsByDepth;
+}

--- a/DQM/HcalMonitorClient/src/HcalRawDataClient.cc
+++ b/DQM/HcalMonitorClient/src/HcalRawDataClient.cc
@@ -53,35 +53,38 @@ HcalRawDataClient::HcalRawDataClient(std::string myname, const edm::ParameterSet
 
   ProblemCells=0;
   ProblemCellsByDepth=0;
+
+  doProblemCellSetup_ = true;
 }
 
-void HcalRawDataClient::endLuminosityBlock() {
+// CATCH
+/*void HcalRawDataClient::endLuminosityBlock() {
 //  if (LBprocessed_==true) return;  // LB already processed
 //  UpdateMEs();
 //  LBprocessed_=true; 
   if (debug_>2) std::cout <<"\tHcalRawDataClient::endLuminosityBlock()"<<std::endl;
   calculateProblems();
   return;
-}
+}*/
 
 
-void HcalRawDataClient::analyze()
+void HcalRawDataClient::analyze(DQMStore::IBooker &ib, DQMStore::IGetter &ig)
 {
   if (debug_>2) std::cout <<"\tHcalRawDataClient::analyze()"<<std::endl;
-  calculateProblems();
+  if ( doProblemCellSetup_ ) setupProblemCells(ib,ig);
+  calculateProblems(ib,ig);
 }
 
-void HcalRawDataClient::calculateProblems()
+void HcalRawDataClient::calculateProblems(DQMStore::IBooker &ib, DQMStore::IGetter &ig)
 {
  if (debug_>2) std::cout <<"\t\tHcalRawDataClient::calculateProblems()"<<std::endl;
-  if(!dqmStore_) return;
   double totalevents=0;
   int etabins=0, phibins=0, zside=0;
   double problemvalue=0;
   
   //Get number of events to normalize by
   MonitorElement* me;
-  me = dqmStore_->get(subdir_+"Events_Processed_Task_Histogram");
+  me = ig.get(subdir_+"Events_Processed_Task_Histogram");
   if (me) totalevents=me->getBinContent(1);
 
   // Clear away old problems
@@ -111,7 +114,7 @@ void HcalRawDataClient::calculateProblems()
 
   // Try to read excludeHOring2 status from file
   
-  MonitorElement* temp_exclude = dqmStore_->get(subdir_+"ExcludeHOring2");
+  MonitorElement* temp_exclude = ig.get(subdir_+"ExcludeHOring2");
 
   // If value can't be read from file, keep the excludeHOring2_backup status
   if (temp_exclude != 0)
@@ -126,7 +129,7 @@ void HcalRawDataClient::calculateProblems()
 
   //Get the plots showing raw data errors,
   //fill problemcount[][][] 
-  fillProblemCountArray();
+  fillProblemCountArray(ib,ig);
 
   std::vector<std::string> name = HcalEtaPhiHistNames();
 
@@ -203,15 +206,6 @@ void HcalRawDataClient::calculateProblems()
   return;
 }
 
-void HcalRawDataClient::beginJob()
-{
-  dqmStore_ = edm::Service<DQMStore>().operator->();
-  if (debug_>0) 
-    {
-      std::cout <<"<HcalRawDataClient::beginJob()>  Displaying dqmStore directory structure:"<<std::endl;
-      dqmStore_->showDirStructure();
-    }
-}
 void HcalRawDataClient::endJob(){}
 
 void HcalRawDataClient::stashHDI(int thehash, HcalDetId thehcaldetid) {
@@ -267,36 +261,38 @@ void HcalRawDataClient::beginRun(void)
   if (debug_>2) std::cout <<"\t<HcalRawDataClient::beginRun> Completed loop."<<std::endl;
 
   enoughevents_=false;
-  if (!dqmStore_) 
-    {
-      if (debug_>0) std::cout <<"<HcalRawDataClient::beginRun> dqmStore does not exist!"<<std::endl;
-      return;
-    }
+  nevts_=0;
+}
 
-  dqmStore_->setCurrentFolder(subdir_);
+void HcalRawDataClient::setupProblemCells(DQMStore::IBooker &ib, DQMStore::IGetter &ig )
+{
+
+
+  ib.setCurrentFolder(subdir_);
   problemnames_.clear();
   // Put the appropriate name of your problem summary here
-  ProblemCells=dqmStore_->book2D(" ProblemRawData",
+  ProblemCells=ib.book2D(" ProblemRawData",
 				 " Problem Raw Data Rate for all HCAL;ieta;iphi",
 				 85,-42.5,42.5,
 				 72,0.5,72.5);
   problemnames_.push_back(ProblemCells->getName());
   if (debug_>1)
     std::cout << "Tried to create ProblemCells Monitor Element in directory "<<subdir_<<"  \t  Failed?  "<<(ProblemCells==0)<<std::endl;
-  dqmStore_->setCurrentFolder(subdir_+"problem_rawdata");
+  ib.setCurrentFolder(subdir_+"problem_rawdata");
   ProblemCellsByDepth = new EtaPhiHists();
 
   ProblemCells->getTH2F()->SetMinimum(0);
   ProblemCells->getTH2F()->SetMaximum(1.05);
 
-  ProblemCellsByDepth->setup(dqmStore_," Problem Raw Data Rate");
+  ProblemCellsByDepth->setup(ib," Problem Raw Data Rate");
   for (unsigned int i=0; i<ProblemCellsByDepth->depth.size();++i)
     problemnames_.push_back(ProblemCellsByDepth->depth[i]->getName());
 
-  nevts_=0;
+  doProblemCellSetup_ = false;
+
 }
 
-void HcalRawDataClient::endRun(void){analyze();}
+//void HcalRawDataClient::endRun(void){analyze();}
 
 void HcalRawDataClient::setup(void){}
 void HcalRawDataClient::cleanup(void){}
@@ -346,47 +342,47 @@ void HcalRawDataClient::updateChannelStatus(std::map<HcalDetId, unsigned int>& m
 } //void HcalRawDataClient::updateChannelStatus
 
 
-void HcalRawDataClient::getHardwareSpaceHistos(void){
+void HcalRawDataClient::getHardwareSpaceHistos(DQMStore::IBooker &ib, DQMStore::IGetter &ig){
   MonitorElement* me;
   std::string s;
   if (debug_>1) std::cout<<"\t<HcalRawDataClient>: getHardwareSpaceHistos()"<<std::endl;
   s=subdir_+"Corruption/01 Common Data Format violations";
-  me=dqmStore_->get(s.c_str());  
+  me=ig.get(s.c_str());  
   meCDFErrorFound_=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, meCDFErrorFound_, debug_);
   if (!meCDFErrorFound_ & (debug_>0)) std::cout <<"<HcalRawDataClient::analyze> "<<s<<" histogram does not exist!"<<std::endl;
 
   s=subdir_+"Corruption/02 DCC Event Format violation";
-  me=dqmStore_->get(s.c_str());  
+  me=ig.get(s.c_str());  
   meDCCEventFormatError_=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, meDCCEventFormatError_, debug_);
   if (!meDCCEventFormatError_ & (debug_>0)) std::cout <<"<HcalRawDataClient::analyze> "<<s<<" histogram does not exist!"<<std::endl;
 
   s=subdir_+"Corruption/03 OrN Inconsistent - HTR vs DCC";
-  me=dqmStore_->get(s.c_str());  
+  me=ig.get(s.c_str());  
   meOrNSynch_=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, meOrNSynch_, debug_);
   if (!meOrNSynch_ & (debug_>0)) std::cout <<"<HcalRawDataClient::analyze> "<<s<<" histogram does not exist!"<<std::endl;
 
   s=subdir_+"Corruption/05 BCN Inconsistent - HTR vs DCC";
-  me=dqmStore_->get(s.c_str());  
+  me=ig.get(s.c_str());  
   meBCNSynch_=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, meBCNSynch_, debug_);
   if (!meBCNSynch_ & (debug_>0)) std::cout <<"<HcalRawDataClient::analyze> "<<s<<" histogram does not exist!"<<std::endl;
 
   s=subdir_+"Corruption/06 EvN Inconsistent - HTR vs DCC";
-  me=dqmStore_->get(s.c_str());  
+  me=ig.get(s.c_str());  
   meEvtNumberSynch_=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, meEvtNumberSynch_, debug_);
   if (!meEvtNumberSynch_ & (debug_>0)) std::cout <<"<HcalRawDataClient::analyze> "<<s<<" histogram does not exist!"<<std::endl;
 
   s=subdir_+"Corruption/07 LRB Data Corruption Indicators";
-  me=dqmStore_->get(s.c_str());  
+  me=ig.get(s.c_str());  
   LRBDataCorruptionIndicators_=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, LRBDataCorruptionIndicators_, debug_);
   if (!LRBDataCorruptionIndicators_ & (debug_>0)) std::cout <<"<HcalRawDataClient::analyze> "<<s<<" histogram does not exist!"<<std::endl;
 
   s=subdir_+"Corruption/08 Half-HTR Data Corruption Indicators";
-  me=dqmStore_->get(s.c_str());  
+  me=ig.get(s.c_str());  
   HalfHTRDataCorruptionIndicators_=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, HalfHTRDataCorruptionIndicators_, debug_);
   if (!HalfHTRDataCorruptionIndicators_ & (debug_>0)) std::cout <<"<HcalRawDataClient::analyze> "<<s<<" histogram does not exist!"<<std::endl;
 
   s=subdir_+"Corruption/09 Channel Integrity Summarized by Spigot";
-  me=dqmStore_->get(s.c_str());  
+  me=ig.get(s.c_str());  
   ChannSumm_DataIntegrityCheck_=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, ChannSumm_DataIntegrityCheck_, debug_);
   if (!ChannSumm_DataIntegrityCheck_ & (debug_>0)) std::cout <<"<HcalRawDataClient::analyze> "<<s<<" histogram does not exist!"<<std::endl;
   if (ChannSumm_DataIntegrityCheck_)
@@ -396,16 +392,16 @@ void HcalRawDataClient::getHardwareSpaceHistos(void){
   for (int i=0; i<NUMDCCS; i++) {
     sprintf(chararray,"Corruption/Channel Data Integrity/FED %03d Channel Integrity", i+700);
     s=subdir_+std::string(chararray);
-    me=dqmStore_->get(s.c_str());  
+    me=ig.get(s.c_str());  
     Chann_DataIntegrityCheck_[i]=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, Chann_DataIntegrityCheck_[i], debug_);
     if (!Chann_DataIntegrityCheck_[i] & (debug_>0)) std::cout <<"<HcalRawDataClient::analyze> "<<s<<" histogram does not exist!"<<std::endl;
     if (Chann_DataIntegrityCheck_[i])
       Chann_DataIntegrityCheck_[i]->SetMinimum(0);
   }
 }
-void HcalRawDataClient::fillProblemCountArray(void){
+void HcalRawDataClient::fillProblemCountArray(DQMStore::IBooker &ib, DQMStore::IGetter &ig){
   if (debug_>1) std::cout <<"\t<HcalRawDataClient>::fillProblemCountArray(): getHardwareSpaceHistos()"<<std::endl;
-  getHardwareSpaceHistos();
+  getHardwareSpaceHistos(ib,ig);
   float n=0.0;
   int dcc_=-999;
 

--- a/DQM/HcalMonitorClient/src/HcalRawDataClient.cc
+++ b/DQM/HcalMonitorClient/src/HcalRawDataClient.cc
@@ -57,16 +57,6 @@ HcalRawDataClient::HcalRawDataClient(std::string myname, const edm::ParameterSet
   doProblemCellSetup_ = true;
 }
 
-// CATCH
-/*void HcalRawDataClient::endLuminosityBlock() {
-//  if (LBprocessed_==true) return;  // LB already processed
-//  UpdateMEs();
-//  LBprocessed_=true; 
-  if (debug_>2) std::cout <<"\tHcalRawDataClient::endLuminosityBlock()"<<std::endl;
-  calculateProblems();
-  return;
-}*/
-
 
 void HcalRawDataClient::analyze(DQMStore::IBooker &ib, DQMStore::IGetter &ig)
 {

--- a/DQM/HcalMonitorClient/src/HcalRawDataClient.cc
+++ b/DQM/HcalMonitorClient/src/HcalRawDataClient.cc
@@ -704,4 +704,6 @@ void HcalRawDataClient::normalizeHardwareSpaceHistos(void){
 }
 
 HcalRawDataClient::~HcalRawDataClient()
-{}
+{
+  if ( ProblemCellsByDepth ) delete ProblemCellsByDepth;
+}

--- a/DQM/HcalMonitorClient/src/HcalRecHitClient.cc
+++ b/DQM/HcalMonitorClient/src/HcalRecHitClient.cc
@@ -48,11 +48,15 @@ HcalRecHitClient::HcalRecHitClient(std::string myname, const edm::ParameterSet& 
 
   ProblemCells=0;
   ProblemCellsByDepth=0;
+
+  doProblemCellSetup_ = true;
 }
 
-void HcalRecHitClient::analyze()
+void HcalRecHitClient::analyze(DQMStore::IBooker &ib, DQMStore::IGetter &ig)
 {
   if (debug_>2) std::cout <<"\tHcalRecHitClient::analyze()"<<std::endl;
+
+  if ( doProblemCellSetup_ ) setupProblemCells(ib,ig);
  
   TH2F* OccupancyByDepth[4];
   TH2F* SumEnergyByDepth[4];
@@ -72,37 +76,37 @@ void HcalRecHitClient::analyze()
   for (int i=0;i<4;++i)
     {
       std::string s=subdir_+"Distributions_AllRecHits/"+name[i]+"RecHit Occupancy";
-      me=dqmStore_->get(s.c_str());
+      me=ig.get(s.c_str());
       if (me==0) {if (debug_>0) std::cout <<"Could not get histogram "<<s<<std::endl; gotHistos=false; break;}
       OccupancyByDepth[i]=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, OccupancyByDepth[i], debug_);
       s=subdir_+"Distributions_AllRecHits/sumplots/"+name[i]+"RecHit Summed Energy GeV";
-      me=dqmStore_->get(s.c_str());
+      me=ig.get(s.c_str());
       if (me==0) {if (debug_>0) std::cout <<"Could not get histogram "<<s<<std::endl; gotHistos=false; break;}
       SumEnergyByDepth[i]=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, SumEnergyByDepth[i], debug_);
       s=subdir_+"Distributions_AllRecHits/sumplots/"+name[i]+"RecHit Summed Time nS";
-      me=dqmStore_->get(s.c_str());
+      me=ig.get(s.c_str());
       if (me==0) {if (debug_>0) std::cout <<"Could not get histogram "<<s<<std::endl; gotHistos=false; break;}
       SumTimeByDepth[i]=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, SumTimeByDepth[i], debug_);
       s=subdir_+"Distributions_AllRecHits/sumplots/"+name[i]+"RecHit Sqrt Summed Energy2 GeV";
-      me=dqmStore_->get(s.c_str());
+      me=ig.get(s.c_str());
       if (me==0) {if (debug_>0) std::cout <<"Could not get histogram "<<s<<std::endl; gotHistos=false; break;}
       SqrtSumEnergy2ByDepth[i]=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, SqrtSumEnergy2ByDepth[i], debug_);
 
       // Threshold histograms
       s=subdir_+"Distributions_PassedMinBias/"+name[i]+"Above Threshold RecHit Occupancy";
-      me=dqmStore_->get(s.c_str());
+      me=ig.get(s.c_str());
       if (me==0) {if (debug_>0) std::cout <<"Could not get histogram "<<s<<std::endl; gotHistos=false; break;}
       OccupancyThreshByDepth[i]=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, OccupancyThreshByDepth[i], debug_);
       s=subdir_+"Distributions_PassedMinBias/sumplots/"+name[i]+"Above Threshold RecHit Summed Energy GeV";
-      me=dqmStore_->get(s.c_str());
+      me=ig.get(s.c_str());
       if (me==0) {if (debug_>0) std::cout <<"Could not get histogram "<<s<<std::endl; gotHistos=false; break;}
       SumEnergyThreshByDepth[i]=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, SumEnergyThreshByDepth[i], debug_);
       s=subdir_+"Distributions_PassedMinBias/sumplots/"+name[i]+"Above Threshold RecHit Summed Time nS";
-      me=dqmStore_->get(s.c_str());
+      me=ig.get(s.c_str());
       if (me==0) {if (debug_>0) std::cout <<"Could not get histogram "<<s<<std::endl; gotHistos=false; break;}
       SumTimeThreshByDepth[i]=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, SumTimeThreshByDepth[i], debug_);
       s=subdir_+"Distributions_PassedMinBias/sumplots/"+name[i]+"Above Threshold RecHit Sqrt Summed Energy2 GeV";
-      me=dqmStore_->get(s.c_str());
+      me=ig.get(s.c_str());
       if (me==0) {if (debug_>0) std::cout <<"Could not get histogram "<<s<<std::endl; gotHistos=false; break;}
       SqrtSumEnergy2ThreshByDepth[i]=HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, SqrtSumEnergy2ThreshByDepth[i], debug_);
     }
@@ -239,13 +243,12 @@ void HcalRecHitClient::analyze()
   FillUnphysicalHEHFBins(*meEnergyThreshByDepth);
   FillUnphysicalHEHFBins(*meTimeThreshByDepth);
 
-  calculateProblems();
+  calculateProblems(ib,ig);
 }
 
-void HcalRecHitClient::calculateProblems()
+void HcalRecHitClient::calculateProblems(DQMStore::IBooker &ib, DQMStore::IGetter &ig)
 {
  if (debug_>2) std::cout <<"\t\tHcalRecHitClient::calculateProblems()"<<std::endl;
-  if(!dqmStore_) return;
   double totalevents=0;
   int etabins=0, phibins=0, zside=0;
   double problemvalue=0;
@@ -350,48 +353,32 @@ void HcalRecHitClient::calculateProblems()
 
 }
 
-void HcalRecHitClient::beginJob()
-{
-  dqmStore_ = edm::Service<DQMStore>().operator->();
-  if (debug_>0) 
-    {
-      std::cout <<"<HcalRecHitClient::beginJob()>  Displaying dqmStore directory structure:"<<std::endl;
-      dqmStore_->showDirStructure();
-    }
-}
 void HcalRecHitClient::endJob(){}
 
-void HcalRecHitClient::beginRun(void)
+void HcalRecHitClient::setupProblemCells(DQMStore::IBooker &ib, DQMStore::IGetter &ig) 
 {
-  if (debug_>1)  std::cout <<"<HcalRecHitClient::endRun>"<<std::endl;
-
-  if (!dqmStore_) 
-    {
-      if (debug_>0) std::cout <<"<HcalRecHitClient::beginRun> dqmStore does not exist!"<<std::endl;
-      return;
-    }
-  dqmStore_->setCurrentFolder(subdir_);
+  ib.setCurrentFolder(subdir_);
   problemnames_.clear();
-  ProblemCells=dqmStore_->book2D(" ProblemRecHits",
+  ProblemCells=ib.book2D(" ProblemRecHits",
 				 "Problem RecHit Rate for all HCAL;ieta;iphi",
 				 85,-42.5,42.5,
 				 72,0.5,72.5);
   problemnames_.push_back(ProblemCells->getName());
   if (debug_>1)
     std::cout << "Tried to create ProblemCells Monitor Element in directory "<<subdir_<<"  \t  Failed?  "<<(ProblemCells==0)<<std::endl;
-  dqmStore_->setCurrentFolder(subdir_+"problem_rechits");
+  ib.setCurrentFolder(subdir_+"problem_rechits");
   ProblemCellsByDepth=new EtaPhiHists();
-  ProblemCellsByDepth->setup(dqmStore_," Problem RecHit Rate");
+  ProblemCellsByDepth->setup(ib," Problem RecHit Rate");
   for (unsigned int i=0; i<ProblemCellsByDepth->depth.size();++i)
     problemnames_.push_back(ProblemCellsByDepth->depth[i]->getName());
 
   nevts_=0;
 
-  dqmStore_->setCurrentFolder(subdir_+"Distributions_AllRecHits");
+  ib.setCurrentFolder(subdir_+"Distributions_AllRecHits");
   meEnergyByDepth = new EtaPhiHists();
-  meEnergyByDepth->setup(dqmStore_,"RecHit Average Energy","GeV");
+  meEnergyByDepth->setup(ib,"RecHit Average Energy","GeV");
   meTimeByDepth = new EtaPhiHists();
-  meTimeByDepth->setup(dqmStore_,"RecHit Average Time","nS");
+  meTimeByDepth->setup(ib,"RecHit Average Time","nS");
   // set all average times to -1000 by default (so that they don't show up on plots
   for (unsigned int i=0;i<meTimeByDepth->depth.size();++i)
     {
@@ -404,11 +391,11 @@ void HcalRecHitClient::beginRun(void)
 	  meTimeByDepth->depth[i]->setBinContent(x,y,-1000);
     }
 
-  dqmStore_->setCurrentFolder(subdir_+"Distributions_PassedMinBias");
+  ib.setCurrentFolder(subdir_+"Distributions_PassedMinBias");
   meEnergyThreshByDepth = new EtaPhiHists();
-  meEnergyThreshByDepth->setup(dqmStore_,"Above Threshold RecHit Average Energy","GeV");
+  meEnergyThreshByDepth->setup(ib,"Above Threshold RecHit Average Energy","GeV");
   meTimeThreshByDepth = new EtaPhiHists();
-  meTimeThreshByDepth->setup(dqmStore_,"Above Threshold RecHit Average Time","nS");
+  meTimeThreshByDepth->setup(ib,"Above Threshold RecHit Average Time","nS");
  // set all average times to -1000 by default (so that they don't show up on plots
   for (unsigned int i=0;i<meTimeThreshByDepth->depth.size();++i)
     {
@@ -421,34 +408,43 @@ void HcalRecHitClient::beginRun(void)
 	  meTimeThreshByDepth->depth[i]->setBinContent(x,y,-1000);
     }
 
-  dqmStore_->setCurrentFolder(subdir_+"Distributions_AllRecHits/rechit_1D_plots/");
-  meHBEnergy_1D=dqmStore_->book1D("HB_energy_1D","HB Average Energy Per RecHit;Energy (GeV)",200,-5,15);
-  meHEEnergy_1D=dqmStore_->book1D("HE_energy_1D","HE Average Energy Per RecHit;Energy (GeV)",200,-5,15);
-  meHOEnergy_1D=dqmStore_->book1D("HO_energy_1D","HO Average Energy Per RecHit;Energy (GeV)",200,-10,20);
-  meHFEnergy_1D=dqmStore_->book1D("HF_energy_1D","HF Average Energy Per RecHit;Energy (GeV)",200,-5,15);
+  ib.setCurrentFolder(subdir_+"Distributions_AllRecHits/rechit_1D_plots/");
+  meHBEnergy_1D=ib.book1D("HB_energy_1D","HB Average Energy Per RecHit;Energy (GeV)",200,-5,15);
+  meHEEnergy_1D=ib.book1D("HE_energy_1D","HE Average Energy Per RecHit;Energy (GeV)",200,-5,15);
+  meHOEnergy_1D=ib.book1D("HO_energy_1D","HO Average Energy Per RecHit;Energy (GeV)",200,-10,20);
+  meHFEnergy_1D=ib.book1D("HF_energy_1D","HF Average Energy Per RecHit;Energy (GeV)",200,-5,15);
 
-  meHBEnergyRMS_1D=dqmStore_->book1D("HB_energy_RMS_1D","HB Energy RMS Per RecHit;Energy (GeV)",250,0,5);
-  meHEEnergyRMS_1D=dqmStore_->book1D("HE_energy_RMS_1D","HE Energy RMS Per RecHit;Energy (GeV)",250,0,5);
-  meHOEnergyRMS_1D=dqmStore_->book1D("HO_energy_RMS_1D","HO Energy RMS Per RecHit;Energy (GeV)",250,0,5);
-  meHFEnergyRMS_1D=dqmStore_->book1D("HF_energy_RMS_1D","HF Energy RMS Per RecHit;Energy (GeV)",250,0,5);
+  meHBEnergyRMS_1D=ib.book1D("HB_energy_RMS_1D","HB Energy RMS Per RecHit;Energy (GeV)",250,0,5);
+  meHEEnergyRMS_1D=ib.book1D("HE_energy_RMS_1D","HE Energy RMS Per RecHit;Energy (GeV)",250,0,5);
+  meHOEnergyRMS_1D=ib.book1D("HO_energy_RMS_1D","HO Energy RMS Per RecHit;Energy (GeV)",250,0,5);
+  meHFEnergyRMS_1D=ib.book1D("HF_energy_RMS_1D","HF Energy RMS Per RecHit;Energy (GeV)",250,0,5);
 
-  dqmStore_->setCurrentFolder(subdir_+"Distributions_PassedMinBias/rechit_1D_plots/");
-  meHBEnergyThresh_1D=dqmStore_->book1D("HB_energyThresh_1D","HB Average Energy Per RecHit Above Threshold;Energy (GeV)",200,-5,35);
-  meHEEnergyThresh_1D=dqmStore_->book1D("HE_energyThresh_1D","HE Average Energy Per RecHit Above Threshold;Energy (GeV)",200,-5,35);
-  meHOEnergyThresh_1D=dqmStore_->book1D("HO_energyThresh_1D","HO Average Energy Per RecHit Above Threshold;Energy (GeV)",300,-10,50);
-  meHFEnergyThresh_1D=dqmStore_->book1D("HF_energyThresh_1D","HF Average Energy Per RecHit Above Threshold;Energy (GeV)",200,-5,95);
+  ib.setCurrentFolder(subdir_+"Distributions_PassedMinBias/rechit_1D_plots/");
+  meHBEnergyThresh_1D=ib.book1D("HB_energyThresh_1D","HB Average Energy Per RecHit Above Threshold;Energy (GeV)",200,-5,35);
+  meHEEnergyThresh_1D=ib.book1D("HE_energyThresh_1D","HE Average Energy Per RecHit Above Threshold;Energy (GeV)",200,-5,35);
+  meHOEnergyThresh_1D=ib.book1D("HO_energyThresh_1D","HO Average Energy Per RecHit Above Threshold;Energy (GeV)",300,-10,50);
+  meHFEnergyThresh_1D=ib.book1D("HF_energyThresh_1D","HF Average Energy Per RecHit Above Threshold;Energy (GeV)",200,-5,95);
 
-  meHBEnergyRMSThresh_1D=dqmStore_->book1D("HB_energy_RMSThresh_1D","HB Energy RMS Per RecHit Above Threshold;Energy (GeV)",200,0,10);
-  meHEEnergyRMSThresh_1D=dqmStore_->book1D("HE_energy_RMSThresh_1D","HE Energy RMS Per RecHit Above Threshold;Energy (GeV)",200,0,10);
-  meHOEnergyRMSThresh_1D=dqmStore_->book1D("HO_energy_RMSThresh_1D","HO Energy RMS Per RecHit Above Threshold;Energy (GeV)",200,0,10);
-  meHFEnergyRMSThresh_1D=dqmStore_->book1D("HF_energy_RMSThresh_1D","HF Energy RMS Per RecHit Above Threshold;Energy (GeV)",200,0,20);
+  meHBEnergyRMSThresh_1D=ib.book1D("HB_energy_RMSThresh_1D","HB Energy RMS Per RecHit Above Threshold;Energy (GeV)",200,0,10);
+  meHEEnergyRMSThresh_1D=ib.book1D("HE_energy_RMSThresh_1D","HE Energy RMS Per RecHit Above Threshold;Energy (GeV)",200,0,10);
+  meHOEnergyRMSThresh_1D=ib.book1D("HO_energy_RMSThresh_1D","HO Energy RMS Per RecHit Above Threshold;Energy (GeV)",200,0,10);
+  meHFEnergyRMSThresh_1D=ib.book1D("HF_energy_RMSThresh_1D","HF Energy RMS Per RecHit Above Threshold;Energy (GeV)",200,0,20);
+
+  doProblemCellSetup_ = false;
+
 }
 
-void HcalRecHitClient::endRun(void)
+void HcalRecHitClient::beginRun(void)
+{
+  if (debug_>1)  std::cout <<"<HcalRecHitClient::endRun>"<<std::endl;
+
+}
+
+/*void HcalRecHitClient::endRun(void)
 {
   if (debug_>1)  std::cout <<"<HcalRecHitClient::endRun>"<<std::endl;
   analyze();
-}
+}*/
 
 void HcalRecHitClient::setup(void){}
 void HcalRecHitClient::cleanup(void){}

--- a/DQM/HcalMonitorClient/src/HcalRecHitClient.cc
+++ b/DQM/HcalMonitorClient/src/HcalRecHitClient.cc
@@ -49,6 +49,13 @@ HcalRecHitClient::HcalRecHitClient(std::string myname, const edm::ParameterSet& 
   ProblemCells=0;
   ProblemCellsByDepth=0;
 
+  meEnergyByDepth=0;
+  meEnergyThreshByDepth=0;
+  meTimeByDepth=0;
+  meTimeThreshByDepth=0;
+  meSqrtSumEnergy2ByDepth=0;
+  meSqrtSumEnergy2ThreshByDepth=0;
+
   doProblemCellSetup_ = true;
 }
 
@@ -496,4 +503,13 @@ void HcalRecHitClient::updateChannelStatus(std::map<HcalDetId, unsigned int>& my
 } //void HcalRecHitClient::updateChannelStatus
 
 HcalRecHitClient::~HcalRecHitClient()
-{}
+{
+  if ( ProblemCellsByDepth ) delete ProblemCellsByDepth;
+  if ( meEnergyByDepth ) delete meEnergyByDepth;
+  if ( meEnergyThreshByDepth ) delete meEnergyThreshByDepth;
+  if ( meTimeByDepth ) delete meTimeByDepth;
+  if ( meTimeThreshByDepth ) delete meTimeThreshByDepth;
+  if ( meSqrtSumEnergy2ByDepth ) delete meSqrtSumEnergy2ByDepth;
+  if ( meSqrtSumEnergy2ThreshByDepth ) delete meSqrtSumEnergy2ThreshByDepth;
+
+}

--- a/DQM/HcalMonitorClient/src/HcalSummaryClient.cc
+++ b/DQM/HcalMonitorClient/src/HcalSummaryClient.cc
@@ -32,6 +32,27 @@ HcalSummaryClient::HcalSummaryClient(std::string myname)
   certificationMap_=0;
   reportMap_=0;
   reportMapShift_=0;
+
+  // set total number of cells in each subdetector
+  subdetCells_.insert(std::make_pair("HB",2592));
+  subdetCells_.insert(std::make_pair("HE",2592));
+  subdetCells_.insert(std::make_pair("HO",2160));
+  subdetCells_.insert(std::make_pair("HF",1728));
+  subdetCells_.insert(std::make_pair("HO0",576));
+  subdetCells_.insert(std::make_pair("HO12",1584));
+  subdetCells_.insert(std::make_pair("HFlumi",288));  // 8 rings, 36 cells/ring
+  // Assume subdetectors are 'unknown'
+  HBpresent_=-1;
+  HEpresent_=-1;
+  HOpresent_=-1;
+  HFpresent_=-1;
+  
+  EnoughEvents_=0;
+  MinEvents_=0;
+  MinErrorRate_=0;
+
+  doSetup_ = true;
+
 }
 
 HcalSummaryClient::HcalSummaryClient(std::string myname, const edm::ParameterSet& ps)
@@ -67,11 +88,34 @@ HcalSummaryClient::HcalSummaryClient(std::string myname, const edm::ParameterSet
   certificationMap_=0;
   reportMap_=0;
   reportMapShift_=0;
+
+  // set total number of cells in each subdetector
+  subdetCells_.insert(std::make_pair("HB",2592));
+  subdetCells_.insert(std::make_pair("HE",2592));
+  subdetCells_.insert(std::make_pair("HO",2160));
+  subdetCells_.insert(std::make_pair("HF",1728));
+  subdetCells_.insert(std::make_pair("HO0",576));
+  subdetCells_.insert(std::make_pair("HO12",1584));
+  subdetCells_.insert(std::make_pair("HFlumi",288));  // 8 rings, 36 cells/ring
+  // Assume subdetectors are 'unknown'
+  HBpresent_=-1;
+  HEpresent_=-1;
+  HOpresent_=-1;
+  HFpresent_=-1;
+  
+  EnoughEvents_=0;
+  MinEvents_=0;
+  MinErrorRate_=0;
+
+  doSetup_ = true;
+
 }
 
-void HcalSummaryClient::analyze(int LS)
+void HcalSummaryClient::analyze(DQMStore::IBooker &ib, DQMStore::IGetter &ig, int LS)
 { 
   if (debug_>2) std::cout <<"\tHcalSummaryClient::analyze()"<<std::endl;
+
+  if ( doSetup_ ) setup(ib,ig);
 
   // 
 
@@ -104,25 +148,25 @@ void HcalSummaryClient::analyze(int LS)
   MonitorElement* temp_present;
   if (HBpresent_!=1)
     {
-      temp_present=dqmStore_->get(prefixME_+"HcalInfo/HBpresent");
+      temp_present=ig.get(prefixME_+"HcalInfo/HBpresent");
       if (temp_present!=0)
 	HBpresent_=temp_present->getIntValue();
     }
   if (HEpresent_!=1)
     {
-      temp_present=dqmStore_->get(prefixME_+"HcalInfo/HEpresent");
+      temp_present=ig.get(prefixME_+"HcalInfo/HEpresent");
       if (temp_present!=0)
 	HEpresent_=temp_present->getIntValue();
     }
   if (HOpresent_!=1)
     {
-      temp_present=dqmStore_->get(prefixME_+"HcalInfo/HOpresent");
+      temp_present=ig.get(prefixME_+"HcalInfo/HOpresent");
       if (temp_present!=0)
 	HOpresent_=temp_present->getIntValue();
     }
   if (HFpresent_!=1)
     {
-      temp_present=dqmStore_->get(prefixME_+"HcalInfo/HFpresent");
+      temp_present=ig.get(prefixME_+"HcalInfo/HFpresent");
       if (temp_present!=0)
 	HFpresent_=temp_present->getIntValue();
     }
@@ -172,7 +216,7 @@ void HcalSummaryClient::analyze(int LS)
 	  std::cout<<"\tHFlumi: "<<status_HFlumi_<<std::endl;
 	}
 
-      fillReportSummary(LS);
+      fillReportSummary(ib,ig,LS);
       return;
     }
   if (EnoughEvents_!=0) EnoughEvents_->setBinContent(clients_.size()+1,1); // summary is good to go!
@@ -213,10 +257,10 @@ void HcalSummaryClient::analyze(int LS)
   
       // Get Channel Status histograms here
       std::vector<MonitorElement*> chStat;
-      chStat.push_back(dqmStore_->get(prefixME_+"HcalInfo/ChannelStatus/HB HE HF Depth 1 ChannelStatus"));
-      chStat.push_back(dqmStore_->get(prefixME_+"HcalInfo/ChannelStatus/HB HE HF Depth 2 ChannelStatus"));
-      chStat.push_back(dqmStore_->get(prefixME_+"HcalInfo/ChannelStatus/HE Depth 3 ChannelStatus"));
-      chStat.push_back(dqmStore_->get(prefixME_+"HcalInfo/ChannelStatus/HO Depth 4 ChannelStatus"));
+      chStat.push_back(ig.get(prefixME_+"HcalInfo/ChannelStatus/HB HE HF Depth 1 ChannelStatus"));
+      chStat.push_back(ig.get(prefixME_+"HcalInfo/ChannelStatus/HB HE HF Depth 2 ChannelStatus"));
+      chStat.push_back(ig.get(prefixME_+"HcalInfo/ChannelStatus/HE Depth 3 ChannelStatus"));
+      chStat.push_back(ig.get(prefixME_+"HcalInfo/ChannelStatus/HO Depth 4 ChannelStatus"));
 
 
       for (int d=0;d<4;++d)
@@ -456,10 +500,10 @@ void HcalSummaryClient::analyze(int LS)
 
   // Fill certification map here
 
-  dqmStore_->setCurrentFolder(prefixME_+"HcalInfo");
-  certificationMap_=dqmStore_->get(prefixME_+"HcalInfo/CertificationMap");
-  if (certificationMap_) dqmStore_->removeElement(certificationMap_->getName());
-  certificationMap_=dqmStore_->book2D("CertificationMap","Certification Map",7,0,7,
+  ig.setCurrentFolder(prefixME_+"HcalInfo");
+  certificationMap_=ig.get(prefixME_+"HcalInfo/CertificationMap");
+  if (certificationMap_) ig.removeElement(certificationMap_->getName());
+  certificationMap_=ib.book2D("CertificationMap","Certification Map",7,0,7,
 				      clients_.size()+1,0,clients_.size()+1);
 
   certificationMap_->getTH2F()->GetYaxis()->SetBinLabel(1,"Summary");
@@ -497,10 +541,10 @@ void HcalSummaryClient::analyze(int LS)
   certificationMap_->setBinContent(5,1,status_HO0_);
   certificationMap_->setBinContent(6,1,status_HO12_);
   certificationMap_->setBinContent(7,1,status_HF_);
-  fillReportSummary(LS);
+  fillReportSummary(ib,ig,LS);
 } // analyze
 
-void HcalSummaryClient::fillReportSummary(int LS)
+void HcalSummaryClient::fillReportSummary(DQMStore::IBooker &ib, DQMStore::IGetter &ig, int LS)
 {
 
   // We've now checked all tasks; now let's calculate summary values
@@ -536,7 +580,7 @@ void HcalSummaryClient::fillReportSummary(int LS)
     }
 
   MonitorElement* me;
-  dqmStore_->setCurrentFolder(subdir_);
+  ig.setCurrentFolder(subdir_);
  
   //me=dqmStore_->get(subdir_+"reportSummaryMap");
   if (reportMap_)
@@ -572,7 +616,7 @@ void HcalSummaryClient::fillReportSummary(int LS)
     }
   else if (debug_>0) std::cout <<"<HcalSummaryClient::fillReportSummary> CANNOT GET REPORT SUMMARY MAP!!!!!"<<std::endl;
 
-  me=dqmStore_->get(subdir_+"reportSummary");
+  me=ig.get(subdir_+"reportSummary");
   // Clear away old versions
   if (me) me->Fill(status_global_);
 
@@ -581,8 +625,8 @@ void HcalSummaryClient::fillReportSummary(int LS)
   for (unsigned int i=0;i<7;++i)
     {
       // Create floats showing subtasks status
-      dqmStore_->setCurrentFolder( subdir_+ "reportSummaryContents" );  
-      me=dqmStore_->get(subdir_+"reportSummaryContents/Hcal_"+subdets[i]);
+      ig.setCurrentFolder( subdir_+ "reportSummaryContents" );  
+      me=ig.get(subdir_+"reportSummaryContents/Hcal_"+subdets[i]);
       if (me==0)
 	{
 	  if (debug_>0) std::cout <<"<HcalSummaryClient::analyze()>  Could not get Monitor Element named 'Hcal_"<<subdets[i]<<"'"<<std::endl;
@@ -600,11 +644,11 @@ void HcalSummaryClient::fillReportSummary(int LS)
 } // fillReportSummary()
 
 
-void HcalSummaryClient::fillReportSummaryLSbyLS(int LS)
+void HcalSummaryClient::fillReportSummaryLSbyLS(DQMStore::IBooker &ib, DQMStore::IGetter &ig, int LS)
 {
 
   MonitorElement* me;
-  dqmStore_->setCurrentFolder(prefixME_+"LSbyLS_Hcal/LSvalues");
+  ig.setCurrentFolder(prefixME_+"LSbyLS_Hcal/LSvalues");
   
   float status_HB=-1;
   float status_HE=-1;
@@ -615,7 +659,7 @@ void HcalSummaryClient::fillReportSummaryLSbyLS(int LS)
   float status_HFlumi=-1;
   float status_global=-1;
 
-  me=dqmStore_->get(prefixME_+"LSbyLS_Hcal/LSvalues/ProblemsThisLS");
+  me=ig.get(prefixME_+"LSbyLS_Hcal/LSvalues/ProblemsThisLS");
   if (me!=0)
     {
       //check to see if enough events were processed to make tests
@@ -673,7 +717,7 @@ void HcalSummaryClient::fillReportSummaryLSbyLS(int LS)
 	} // if (events(>0)
     } // if (me!=0)
 
-  dqmStore_->setCurrentFolder(subdir_);
+  ig.setCurrentFolder(subdir_);
   if (reportMap_)
     {
       reportMap_->setBinContent(1,1,status_HB);
@@ -709,7 +753,7 @@ void HcalSummaryClient::fillReportSummaryLSbyLS(int LS)
     }
   else if (debug_>0) std::cout <<"<HcalSummaryClient::fillReportSummaryLSbyLS> CANNOT GET REPORT SUMMARY MAP!!!!!"<<std::endl;
 
-  me=dqmStore_->get(subdir_+"reportSummary");
+  me=ig.get(subdir_+"reportSummary");
   // Clear away old versions
   if (me) me->Fill(status_global);
 
@@ -718,8 +762,8 @@ void HcalSummaryClient::fillReportSummaryLSbyLS(int LS)
   for (unsigned int i=0;i<7;++i)
     {
       // Create floats showing subtasks status
-      dqmStore_->setCurrentFolder( subdir_+ "reportSummaryContents" );  
-      me=dqmStore_->get(subdir_+"reportSummaryContents/Hcal_"+subdets[i]);
+      ig.setCurrentFolder( subdir_+ "reportSummaryContents" );  
+      me=ig.get(subdir_+"reportSummaryContents/Hcal_"+subdets[i]);
       if (me==0)
 	{
 	  if (debug_>0) std::cout <<"<HcalSummaryClient::LSbyLS>  Could not get Monitor Element named 'Hcal_"<<subdets[i]<<"'"<<std::endl;
@@ -753,47 +797,26 @@ void HcalSummaryClient::fillReportSummaryLSbyLS(int LS)
 
 
 
-void HcalSummaryClient::beginJob()
-{
-  dqmStore_ = edm::Service<DQMStore>().operator->();
-  // set total number of cells in each subdetector
-  subdetCells_.insert(std::make_pair("HB",2592));
-  subdetCells_.insert(std::make_pair("HE",2592));
-  subdetCells_.insert(std::make_pair("HO",2160));
-  subdetCells_.insert(std::make_pair("HF",1728));
-  subdetCells_.insert(std::make_pair("HO0",576));
-  subdetCells_.insert(std::make_pair("HO12",1584));
-  subdetCells_.insert(std::make_pair("HFlumi",288));  // 8 rings, 36 cells/ring
-  // Assume subdetectors are 'unknown'
-  HBpresent_=-1;
-  HEpresent_=-1;
-  HOpresent_=-1;
-  HFpresent_=-1;
-  
-  EnoughEvents_=0;
-  MinEvents_=0;
-  MinErrorRate_=0;
-}
-
 void HcalSummaryClient::endJob(){}
 
 void HcalSummaryClient::beginRun(void)
 {
-  if (!dqmStore_) 
-    {
-      if (debug_>0) std::cout <<"<HcalSummaryClient::beginRun> dqmStore does not exist!"<<std::endl;
-      return;
-    }
+} // void HcalSummaryClient::beginRun(void)
+
+
+//void HcalSummaryClient::endRun(void){}
+
+void HcalSummaryClient::setup(DQMStore::IBooker &ib, DQMStore::IGetter &ig){
   nevts_=0;
 
-  dqmStore_->setCurrentFolder(subdir_);
+  ib.setCurrentFolder(subdir_);
 
   MonitorElement* me;
   // reportSummary holds overall detector status
-  me=dqmStore_->get(subdir_+"reportSummary");
+  me=ig.get(subdir_+"reportSummary");
   // Clear away old versions
-  if (me) dqmStore_->removeElement(me->getName());
-  me = dqmStore_->bookFloat("reportSummary");
+  if (me) ig.removeElement(me->getName());
+  me = ib.bookFloat("reportSummary");
   me->Fill(-1); // set status to unknown at startup
 
   // Create floats for each subdetector status
@@ -801,31 +824,31 @@ void HcalSummaryClient::beginRun(void)
   for (unsigned int i=0;i<7;++i)
     {
       // Create floats showing subtasks status
-      dqmStore_->setCurrentFolder( subdir_+ "reportSummaryContents" );  
-      me=dqmStore_->get(subdir_+"reportSummaryContents/Hcal_"+subdets[i]);
-      if (me) dqmStore_->removeElement(me->getName());
-      me = dqmStore_->bookFloat("Hcal_"+subdets[i]);
+      ig.setCurrentFolder( subdir_+ "reportSummaryContents" );  
+      me=ig.get(subdir_+"reportSummaryContents/Hcal_"+subdets[i]);
+      if (me) ig.removeElement(me->getName());
+      me = ib.bookFloat("Hcal_"+subdets[i]);
       me->Fill(-1);
     } // for (unsigned int i=0;...)
 
-  dqmStore_->setCurrentFolder(prefixME_+"HcalInfo/SummaryClientPlots");
-  me=dqmStore_->get(prefixME_+"HcalInfo/SummaryClientPlots/HB HE HF Depth 1 Problem Summary Map");
-  if (me) dqmStore_->removeElement(me->getName());
-  me=dqmStore_->get(prefixME_+"HcalInfo/SummaryClientPlots/HB HE HF Depth 2 Problem Summary Map");
-  if (me) dqmStore_->removeElement(me->getName());
-  me=dqmStore_->get(prefixME_+"HcalInfo/SummaryClientPlots/HE Depth 3 Problem Summary Map");
-  if (me) dqmStore_->removeElement(me->getName());
-  me=dqmStore_->get(prefixME_+"HcalInfo/SummaryClientPlots/HO Depth 4 Problem Summary Map");
-  if (me) dqmStore_->removeElement(me->getName());
+  ib.setCurrentFolder(prefixME_+"HcalInfo/SummaryClientPlots");
+  me=ig.get(prefixME_+"HcalInfo/SummaryClientPlots/HB HE HF Depth 1 Problem Summary Map");
+  if (me) ig.removeElement(me->getName());
+  me=ig.get(prefixME_+"HcalInfo/SummaryClientPlots/HB HE HF Depth 2 Problem Summary Map");
+  if (me) ig.removeElement(me->getName());
+  me=ig.get(prefixME_+"HcalInfo/SummaryClientPlots/HE Depth 3 Problem Summary Map");
+  if (me) ig.removeElement(me->getName());
+  me=ig.get(prefixME_+"HcalInfo/SummaryClientPlots/HO Depth 4 Problem Summary Map");
+  if (me) ig.removeElement(me->getName());
 
   if (EnoughEvents_==0)
-    EnoughEvents_=dqmStore_->book1D("EnoughEvents","Enough Events Passed From Each Task To Form Summary",1+(int)clients_.size(),0,1+(int)clients_.size());
+    EnoughEvents_=ib.book1D("EnoughEvents","Enough Events Passed From Each Task To Form Summary",1+(int)clients_.size(),0,1+(int)clients_.size());
   for (std::vector<HcalBaseDQClient*>::size_type i=0;i<clients_.size();++i)
     EnoughEvents_->setBinLabel(i+1,clients_[i]->name());
   EnoughEvents_->setBinLabel(1+(int)clients_.size(),"Summary");
 
   if (MinEvents_==0)
-    MinEvents_=dqmStore_->book1D("MinEvents","Minimum Events Required From Each Task To Form Summary",
+    MinEvents_=ib.book1D("MinEvents","Minimum Events Required From Each Task To Form Summary",
 				 1+(int)clients_.size(),0,1+(int)clients_.size());
   int summin=0;
   for (std::vector<HcalBaseDQClient*>::size_type i=0;i<clients_.size();++i)
@@ -835,7 +858,7 @@ void HcalSummaryClient::beginRun(void)
       summin=std::max(summin,clients_[i]->minevents_);
     }
   if (MinErrorRate_==0)
-    MinErrorRate_=dqmStore_->book1D("MinErrorRate",
+    MinErrorRate_=ib.book1D("MinErrorRate",
 				    "Minimum Error Rate Required For Channel To Be Counted As Problem",
 				    (int)clients_.size(),0,(int)clients_.size());
   for (std::vector<HcalBaseDQClient*>::size_type i=0;i<clients_.size();++i)
@@ -855,7 +878,7 @@ void HcalSummaryClient::beginRun(void)
   if (SummaryMapByDepth==0) 
     {
       SummaryMapByDepth=new EtaPhiHists();
-      SummaryMapByDepth->setup(dqmStore_,"Problem Summary Map");
+      SummaryMapByDepth->setup(ib,"Problem Summary Map");
     }
   // Set histogram values to -1
   // Set all bins to "unknown" to start
@@ -873,9 +896,9 @@ void HcalSummaryClient::beginRun(void)
     }
 
   // Make histogram of status vs LS
-  StatusVsLS_ = dqmStore_->get(prefixME_+"HcalInfo/SummaryClientPlots/StatusVsLS");
-  if (StatusVsLS_) dqmStore_->removeElement(StatusVsLS_->getName());
-  StatusVsLS_ = dqmStore_->book2D("StatusVsLS","Status vs. Luminosity Section",
+  StatusVsLS_ = ig.get(prefixME_+"HcalInfo/SummaryClientPlots/StatusVsLS");
+  if (StatusVsLS_) ig.removeElement(StatusVsLS_->getName());
+  StatusVsLS_ = ib.book2D("StatusVsLS","Status vs. Luminosity Section",
 				  NLumiBlocks_,0.5,NLumiBlocks_+0.5,
 				  7,0,7);
   // Set all status values to -1 to begin
@@ -894,12 +917,12 @@ void HcalSummaryClient::beginRun(void)
   (StatusVsLS_->getTH2F())->SetMaximum(1);
 
   // Finally, form report Summary Map
-  dqmStore_->setCurrentFolder(subdir_);
+  ig.setCurrentFolder(subdir_);
 
-  reportMap_=dqmStore_->get(subdir_+"reportSummaryMap");
+  reportMap_=ig.get(subdir_+"reportSummaryMap");
   if (reportMap_)
-    dqmStore_->removeElement(reportMap_->getName());
-  reportMap_ = dqmStore_->book2D("reportSummaryMap","reportSummaryMap",
+    ig.removeElement(reportMap_->getName());
+  reportMap_ = ib.book2D("reportSummaryMap","reportSummaryMap",
 				 7,0,7,1,0,1);
   (reportMap_->getTH2F())->GetXaxis()->SetBinLabel(1,"HB");
   (reportMap_->getTH2F())->GetXaxis()->SetBinLabel(2,"HE");
@@ -916,8 +939,8 @@ void HcalSummaryClient::beginRun(void)
   (reportMap_->getTH2F())->SetMaximum(1);
 
   if (reportMapShift_)
-    dqmStore_->removeElement(reportMapShift_->getName());
-  reportMapShift_ = dqmStore_->book2D("reportSummaryMapShift","reportSummaryMapShift",
+    ig.removeElement(reportMapShift_->getName());
+  reportMapShift_ = ib.book2D("reportSummaryMapShift","reportSummaryMapShift",
 				 6,0,6,1,0,1);
   (reportMapShift_->getTH2F())->GetXaxis()->SetBinLabel(1,"HB");
   (reportMapShift_->getTH2F())->GetXaxis()->SetBinLabel(2,"HE");
@@ -946,12 +969,10 @@ void HcalSummaryClient::beginRun(void)
     reportMap_->setBinContent(i,1,-1);
   for (int i=1;i<=(reportMapShift_->getTH2F())->GetNbinsX();++i)
     reportMapShift_->setBinContent(i,1,-1);
-} // void HcalSummaryClient::beginRun(void)
 
+  doSetup_ = false;
 
-void HcalSummaryClient::endRun(void){}
-
-void HcalSummaryClient::setup(void){}
+}
 void HcalSummaryClient::cleanup(void){}
 
 bool HcalSummaryClient::hasErrors_Temp(void){  return false;}

--- a/DQM/HcalMonitorClient/src/HcalSummaryClient.cc
+++ b/DQM/HcalMonitorClient/src/HcalSummaryClient.cc
@@ -1016,4 +1016,6 @@ void HcalSummaryClient::updateChannelStatus(std::map<HcalDetId, unsigned int>& m
 
 
 HcalSummaryClient::~HcalSummaryClient()
-{}
+{
+  if ( SummaryMapByDepth ) delete SummaryMapByDepth;
+}

--- a/DQM/HcalMonitorClient/src/HcalTrigPrimClient.cc
+++ b/DQM/HcalMonitorClient/src/HcalTrigPrimClient.cc
@@ -46,18 +46,20 @@ HcalTrigPrimClient::HcalTrigPrimClient(std::string myname, const edm::ParameterS
 
   ProblemCells=0;
   ProblemCellsByDepth=0;
+
+  doProblemCellSetup_ = true;
 }
 
-void HcalTrigPrimClient::analyze()
+void HcalTrigPrimClient::analyze(DQMStore::IBooker &ib, DQMStore::IGetter &ig)
 {
   if (debug_>2) std::cout <<"\tHcalTrigPrimClient::analyze()"<<std::endl;
-  calculateProblems();
+  if ( doProblemCellSetup_ ) setupProblemCells(ib,ig);
+  calculateProblems(ib,ig);
 }
 
-void HcalTrigPrimClient::calculateProblems()
+void HcalTrigPrimClient::calculateProblems(DQMStore::IBooker &ib, DQMStore::IGetter &ig)
 {
  if (debug_>2) std::cout <<"\t\tHcalTrigPrimClient::calculateProblems()"<<std::endl;
-  if(!dqmStore_) return;
   double totalevents=0;
   int etabins=0, phibins=0;
   double problemvalue=0;
@@ -114,22 +116,22 @@ void HcalTrigPrimClient::calculateProblems()
   TH2F* goodNZS=0;
   TH2F* badNZS=0;
 
-  me=dqmStore_->get(subdir_+"Good TPs_ZS");
+  me=ig.get(subdir_+"Good TPs_ZS");
   if (!me && debug_>0)
     std::cout <<"<HcalTrigPrimClient::calculateProblems>  Could not get histogram named '"<<subdir_<<"Good TPs_ZS'"<<std::endl;
   else goodZS = HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, goodZS, debug_);
 
-  me=dqmStore_->get(subdir_+"Bad TPs_ZS");
+  me=ig.get(subdir_+"Bad TPs_ZS");
   if (!me && debug_>0)
     std::cout <<"<HcalTrigPrimClient::calculateProblems>  Could not get histogram named '"<<subdir_<<"Bad TPs_ZS'"<<std::endl;
   else badZS = HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, badZS, debug_);
 
-  me=dqmStore_->get(subdir_+"noZS/Good TPs_noZS");
+  me=ig.get(subdir_+"noZS/Good TPs_noZS");
   if (!me && debug_>0)
     std::cout <<"<HcalTrigPrimClient::calculateProblems>  Could not get histogram named '"<<subdir_<<"noZS/Good TPs_noZS'"<<std::endl;
   else goodNZS = HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, goodNZS, debug_);
 
-  me=dqmStore_->get(subdir_+"noZS/Bad TPs_noZS");
+  me=ig.get(subdir_+"noZS/Bad TPs_noZS");
   if (!me && debug_>0)
     std::cout <<"<HcalTrigPrimClient::calculateProblems>  Could not get histogram named '"<<subdir_<<"noZS/Bad TPs_noZS'"<<std::endl;
   else badNZS = HcalUtilsClient::getHisto<TH2F*>(me, cloneME_, badNZS, debug_);
@@ -306,52 +308,45 @@ void HcalTrigPrimClient::calculateProblems()
   return;
 }
 
-void HcalTrigPrimClient::beginJob()
-{
-  dqmStore_ = edm::Service<DQMStore>().operator->();
-  if (debug_>0) 
-    {
-      std::cout <<"<HcalTrigPrimClient::beginJob()>  Displaying dqmStore directory structure:"<<std::endl;
-      dqmStore_->showDirStructure();
-    }
-}
 void HcalTrigPrimClient::endJob(){}
 
-void HcalTrigPrimClient::beginRun(void)
+void HcalTrigPrimClient::setupProblemCells(DQMStore::IBooker &ib, DQMStore::IGetter &ig)
 {
-  enoughevents_=false;
-  if (!dqmStore_) 
-    {
-      if (debug_>0) std::cout <<"<HcalTrigPrimClient::beginRun> dqmStore does not exist!"<<std::endl;
-      return;
-    }
-  dqmStore_->setCurrentFolder(subdir_);
+
+  ib.setCurrentFolder(subdir_);
   problemnames_.clear();
 
   // Put the appropriate name of your problem summary here
-  ProblemCells=dqmStore_->book2D(" ProblemTriggerPrimitives",
+  ProblemCells=ib.book2D(" ProblemTriggerPrimitives",
 				 " Problem Trigger Primitive Rate for all HCAL;ieta;iphi",
 				 85,-42.5,42.5,
 				 72,0.5,72.5);
   problemnames_.push_back(ProblemCells->getName());
   if (debug_>1)
     std::cout << "Tried to create ProblemCells Monitor Element in directory "<<subdir_<<"  \t  Failed?  "<<(ProblemCells==0)<<std::endl;
-  dqmStore_->setCurrentFolder(subdir_+"problem_triggerprimitives");
+  ib.setCurrentFolder(subdir_+"problem_triggerprimitives");
   ProblemCellsByDepth = new EtaPhiHists();
-  ProblemCellsByDepth->setup(dqmStore_," Problem Trigger Primitive Rate");
+  ProblemCellsByDepth->setup(ib," Problem Trigger Primitive Rate");
   for (unsigned int i=0; i<ProblemCellsByDepth->depth.size();++i)
     problemnames_.push_back(ProblemCellsByDepth->depth[i]->getName());
   nevts_=0;
 
-  dqmStore_->setCurrentFolder(subdir_+"problem_ZS");
+  ib.setCurrentFolder(subdir_+"problem_ZS");
   ProblemsByDepthZS_  = new EtaPhiHists();
-  ProblemsByDepthZS_->setup(dqmStore_,"ZS Problem Trigger Primitive Rate");
-  dqmStore_->setCurrentFolder(subdir_+"problem_NZS");
+  ProblemsByDepthZS_->setup(ib,"ZS Problem Trigger Primitive Rate");
+  ib.setCurrentFolder(subdir_+"problem_NZS");
   ProblemsByDepthNZS_ = new EtaPhiHists();
-  ProblemsByDepthNZS_->setup(dqmStore_,"NZS Problem Trigger Primitive Rate");
+  ProblemsByDepthNZS_->setup(ib,"NZS Problem Trigger Primitive Rate");
+
+  doProblemCellSetup_ = false;
 }
 
-void HcalTrigPrimClient::endRun(void){analyze();}
+void HcalTrigPrimClient::beginRun(void)
+{
+  enoughevents_=false;
+}
+
+//void HcalTrigPrimClient::endRun(void){analyze();}
 
 void HcalTrigPrimClient::setup(void){}
 void HcalTrigPrimClient::cleanup(void){}

--- a/DQM/HcalMonitorClient/src/HcalTrigPrimClient.cc
+++ b/DQM/HcalMonitorClient/src/HcalTrigPrimClient.cc
@@ -46,6 +46,8 @@ HcalTrigPrimClient::HcalTrigPrimClient(std::string myname, const edm::ParameterS
 
   ProblemCells=0;
   ProblemCellsByDepth=0;
+  ProblemsByDepthZS_  = 0;
+  ProblemsByDepthNZS_ = 0;
 
   doProblemCellSetup_ = true;
 }
@@ -398,4 +400,8 @@ void HcalTrigPrimClient::updateChannelStatus(std::map<HcalDetId, unsigned int>& 
 } //void HcalTrigPrimClient::updateChannelStatus
 
 HcalTrigPrimClient::~HcalTrigPrimClient()
-{}
+{
+  if ( ProblemCellsByDepth ) delete ProblemCellsByDepth;
+  if ( ProblemsByDepthZS_ ) delete ProblemsByDepthZS_;
+  if ( ProblemsByDepthNZS_ ) delete ProblemsByDepthNZS_;
+}

--- a/DQM/HcalMonitorTasks/interface/HcalBaseDQMonitor.h
+++ b/DQM/HcalMonitorTasks/interface/HcalBaseDQMonitor.h
@@ -6,14 +6,13 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "FWCore/Framework/interface/ESHandle.h" // needed to grab objects
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 
@@ -21,7 +20,7 @@
 
 class HcalLogicalMap;
 
-class HcalBaseDQMonitor : public edm::EDAnalyzer
+class HcalBaseDQMonitor : public DQMEDAnalyzer
 {
 
 public:
@@ -34,6 +33,8 @@ public:
   // Destructor
   virtual ~HcalBaseDQMonitor();
 
+  virtual void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &);
+
 protected:
 
   // Analyze
@@ -45,7 +46,7 @@ protected:
   virtual void beginJob();
 
   // BeginRun
-  virtual void beginRun(const edm::Run& run, const edm::EventSetup& c);
+  //virtual void beginRun(const edm::Run& run, const edm::EventSetup& c);
 
   // Begin LumiBlock
   virtual void beginLuminosityBlock(const edm::LuminosityBlock& lumiSeg,
@@ -68,14 +69,14 @@ protected:
   virtual void cleanup(void);
 
   // setup
-  virtual void setup(void);
+  virtual void setup(DQMStore::IBooker &);
   
   // LumiOutOfOrder
   bool LumiInOrder(int lumisec);
 
-  void SetupEtaPhiHists(EtaPhiHists & hh, std::string Name, std::string Units)
+  void SetupEtaPhiHists(DQMStore::IBooker &ib, EtaPhiHists & hh, std::string Name, std::string Units)
   {
-    hh.setup(dbe_, Name, Units);
+    hh.setup(ib, Name, Units);
     return;
   }
 
@@ -92,7 +93,6 @@ protected:
   std::string subdir_;
 
   int currentLS;
-  DQMStore* dbe_;
   int ievt_;
   int levt_; // number of events in current lumi block
   int tevt_; // number of events overall

--- a/DQM/HcalMonitorTasks/interface/HcalBaseDQMonitor.h
+++ b/DQM/HcalMonitorTasks/interface/HcalBaseDQMonitor.h
@@ -127,6 +127,8 @@ protected:
   bool needLogicalMap_;
 
   int badChannelStatusMask_;
+
+
   private:
   bool setupDone_;
 
@@ -135,7 +137,7 @@ protected:
   void CheckCalibType(const edm::Handle<FEDRawDataCollection>&); 
 
   edm::InputTag FEDRawDataCollection_;
-  edm::EDGetTokenT<FEDRawDataCollection> tok_raw_;
+  edm::EDGetTokenT<FEDRawDataCollection> tok_braw_;
 
   const HcalElectronicsMap * eMap_;
   

--- a/DQM/HcalMonitorTasks/interface/HcalBaseDQMonitor.h
+++ b/DQM/HcalMonitorTasks/interface/HcalBaseDQMonitor.h
@@ -18,7 +18,10 @@
 
 #include "DQM/HcalMonitorTasks/interface/HcalEtaPhiHists.h"
 
+#include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
+
 class HcalLogicalMap;
+class HcalElectronicsMap;
 
 class HcalBaseDQMonitor : public DQMEDAnalyzer
 {
@@ -46,7 +49,7 @@ protected:
   virtual void beginJob();
 
   // BeginRun
-  //virtual void beginRun(const edm::Run& run, const edm::EventSetup& c);
+  virtual void dqmBeginRun(const edm::Run& run, const edm::EventSetup& c);
 
   // Begin LumiBlock
   virtual void beginLuminosityBlock(const edm::LuminosityBlock& lumiSeg,
@@ -126,6 +129,16 @@ protected:
   int badChannelStatusMask_;
   private:
   bool setupDone_;
+
+  // methods to check for sub-detector status
+  void CheckSubdetectorStatus(const edm::Handle<FEDRawDataCollection>&, HcalSubdetector, const HcalElectronicsMap &);
+  void CheckCalibType(const edm::Handle<FEDRawDataCollection>&); 
+
+  edm::InputTag FEDRawDataCollection_;
+  edm::EDGetTokenT<FEDRawDataCollection> tok_raw_;
+
+  const HcalElectronicsMap * eMap_;
+  
 };// class HcalBaseDQMonitor : public edm::EDAnalyzer
 
 

--- a/DQM/HcalMonitorTasks/interface/HcalBaseDQMonitor.h
+++ b/DQM/HcalMonitorTasks/interface/HcalBaseDQMonitor.h
@@ -45,9 +45,6 @@ protected:
 
   void getLogicalMap(const edm::EventSetup& c);
  
- // BeginJob
-  virtual void beginJob();
-
   // BeginRun
   virtual void dqmBeginRun(const edm::Run& run, const edm::EventSetup& c);
 
@@ -58,9 +55,6 @@ protected:
   // End LumiBlock
   virtual void endLuminosityBlock(const edm::LuminosityBlock& lumiSeg,
                           const edm::EventSetup& c);
-
- // EndJob
-  virtual void endJob(void);
 
   // EndRun
   virtual void endRun(const edm::Run& run, const edm::EventSetup& c);

--- a/DQM/HcalMonitorTasks/interface/HcalBeamMonitor.h
+++ b/DQM/HcalMonitorTasks/interface/HcalBeamMonitor.h
@@ -23,8 +23,8 @@ class HcalBeamMonitor:  public HcalBaseDQMonitor {
   HcalBeamMonitor(const edm::ParameterSet& ps);
   ~HcalBeamMonitor();
   
-  void setup();
-  void beginRun(const edm::Run& run, const edm::EventSetup& c);
+  void setup(DQMStore::IBooker &);
+  void bookHistograms(DQMStore::IBooker &ib, const edm::Run& run, const edm::EventSetup& c);
   void beginLuminosityBlock(const edm::LuminosityBlock& lumiSeg,
 			    const edm::EventSetup& c);
   void analyze(const edm::Event& e, const edm::EventSetup& c);
@@ -38,7 +38,6 @@ class HcalBeamMonitor:  public HcalBaseDQMonitor {
   void endLuminosityBlock(const edm::LuminosityBlock& lumiSeg,
 			  const edm::EventSetup& c);
   void reset();
-  void cleanup();
 
  private:
   void SetEtaLabels(MonitorElement* h);

--- a/DQM/HcalMonitorTasks/interface/HcalCoarsePedestalMonitor.h
+++ b/DQM/HcalMonitorTasks/interface/HcalCoarsePedestalMonitor.h
@@ -18,9 +18,8 @@ public:
   HcalCoarsePedestalMonitor(const edm::ParameterSet& ps); 
   ~HcalCoarsePedestalMonitor(); 
 
-  void setup();
-  void beginRun(const edm::Run& run, const edm::EventSetup& c);
-  void cleanup();
+  void setup(DQMStore::IBooker &);
+  void bookHistograms(DQMStore::IBooker &ib, const edm::Run& run, const edm::EventSetup& c);
 
   void analyze(const edm::Event& e, const edm::EventSetup& c);
 

--- a/DQM/HcalMonitorTasks/interface/HcalDataIntegrityTask.h
+++ b/DQM/HcalMonitorTasks/interface/HcalDataIntegrityTask.h
@@ -32,14 +32,13 @@ class HcalDataIntegrityTask: public HcalBaseDQMonitor
   HcalDataIntegrityTask(const edm::ParameterSet& ps);
   ~HcalDataIntegrityTask();
   
-  void setup();
+  void setup(DQMStore::IBooker &);
   void processEvent(const FEDRawDataCollection& rawraw, const
 		    HcalUnpackerReport& report, const HcalElectronicsMap& emap);
   void unpack(const FEDRawData& raw, const HcalElectronicsMap& emap);
-  void cleanup();
   void reset();
 
-  void beginRun(const edm::Run& run, const edm::EventSetup& c);
+  void bookHistograms(DQMStore::IBooker &ib, const edm::Run& run, const edm::EventSetup& c);
   void analyze(const edm::Event&, const edm::EventSetup&);
 
  public: //Electronics map -> geographic channel map

--- a/DQM/HcalMonitorTasks/interface/HcalDeadCellMonitor.h
+++ b/DQM/HcalMonitorTasks/interface/HcalDeadCellMonitor.h
@@ -33,14 +33,13 @@ class HcalDeadCellMonitor: public HcalBaseDQMonitor {
 
   ~HcalDeadCellMonitor();
 
-  void setup();
-  void beginRun(const edm::Run& run, const edm::EventSetup& c);
+  void setup(DQMStore::IBooker &);
+  void bookHistograms(DQMStore::IBooker &ib, const edm::Run& run, const edm::EventSetup& c);
   void analyze(edm::Event const&e, edm::EventSetup const&s);
   void endLuminosityBlock(const edm::LuminosityBlock& lumiSeg,
 			  const edm::EventSetup& c);
   void endRun(const edm::Run& run, const edm::EventSetup& c);
   void endJob();
-  void cleanup(); // overrides base class function
   void reset();
 
   void processEvent(const HBHERecHitCollection& hbHits,

--- a/DQM/HcalMonitorTasks/interface/HcalDetDiagNoiseMonitor.h
+++ b/DQM/HcalMonitorTasks/interface/HcalDetDiagNoiseMonitor.h
@@ -38,14 +38,13 @@ public:
   HcalDetDiagNoiseMonitor(const edm::ParameterSet& ps); 
   ~HcalDetDiagNoiseMonitor(); 
 
-  void setup();
+  void setup(DQMStore::IBooker &);
   void analyze(edm::Event const&e, edm::EventSetup const&s);
   void done();
   void reset();
-  void beginRun(const edm::Run& run, const edm::EventSetup& c);
+  void bookHistograms(DQMStore::IBooker &ib, const edm::Run& run, const edm::EventSetup& c);
   void endLuminosityBlock(const edm::LuminosityBlock& lumiSeg,const edm::EventSetup& c);
 
-  void cleanup(); 
   void UpdateHistos();
   int  GetStatistics(){ return ievt_; }
 private:

--- a/DQM/HcalMonitorTasks/interface/HcalDetDiagTimingMonitor.h
+++ b/DQM/HcalMonitorTasks/interface/HcalDetDiagTimingMonitor.h
@@ -103,12 +103,11 @@ public:
   double occSum;
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////  
-  void setup();
-  void beginRun(const edm::Run& run, const edm::EventSetup& c);
+  void setup(DQMStore::IBooker &);
+  void bookHistograms(DQMStore::IBooker &ib, const edm::Run& run, const edm::EventSetup& c);
   void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup);
   void done();
   void reset();
-  void cleanup(); 
   
 private:
   edm::InputTag inputLabelDigi_;

--- a/DQM/HcalMonitorTasks/interface/HcalDigiMonitor.h
+++ b/DQM/HcalMonitorTasks/interface/HcalDigiMonitor.h
@@ -70,9 +70,8 @@ public:
   HcalDigiMonitor(const edm::ParameterSet& ps); 
   ~HcalDigiMonitor(); 
 
-  void setup();
-  void beginRun(const edm::Run& run, const edm::EventSetup& c);
-  void cleanup();
+  void setup(DQMStore::IBooker &);
+  void bookHistograms(DQMStore::IBooker &ib, const edm::Run& run, const edm::EventSetup& c);
 
   void analyze(const edm::Event& e, const edm::EventSetup& c);
 
@@ -104,7 +103,7 @@ private:  ///Methods, variables accessible only within class code
  
   void fill_Nevents();
   void zeroCounters();
-  void setupSubdetHists(DigiHists& hist,  std::string subdet); // enable this feature at some point
+  void setupSubdetHists(DQMStore::IBooker &ib, DigiHists& hist,  std::string subdet); // enable this feature at some point
 
   template<class T> int process_Digi(T& digi, DigiHists& hist, int& firstcap);
   void UpdateHists(DigiHists& h);

--- a/DQM/HcalMonitorTasks/interface/HcalEtaPhiHists.h
+++ b/DQM/HcalMonitorTasks/interface/HcalEtaPhiHists.h
@@ -20,61 +20,6 @@ class EtaPhiHists{
   EtaPhiHists(){};
   ~EtaPhiHists(){};
 
-  // dummy 
-  void setup(DQMStore *& m_dbe,std::string Name, std::string Units="") 
-    {
-      std::stringstream name;
-      name<<Name;
-
-      std::stringstream unitname;
-      std::stringstream unittitle;
-      std::string s(Units);
-      if (s.empty())
-	{
-	  unitname<<Units;
-	  unittitle<<"No Units";
-	}
-      else
-	{
-	  unitname<<" "<<Units;
-	  unittitle<<Units;
-	}
-      
-      // Push back depth plots
-      depth.push_back(m_dbe->book2D(("HB HE HF Depth 1 "+name.str()+unitname.str()).c_str(),
-				    (name.str()+" Depth 1 -- HB HE HF ("+unittitle.str().c_str()+")"),
-				    85,-42.5,42.5,
-				    72,0.5,72.5));
-      float ybins[73];
-      for (int i=0;i<=72;i++) ybins[i]=(float)(i+0.5);
-      float xbinsd2[]={-42.5,-41.5,-40.5,-39.5,-38.5,-37.5,-36.5,-35.5,-34.5,-33.5,-32.5,-31.5,-30.5,-29.5,
-		       -28.5,-27.5,-26.5,-25.5,-24.5,-23.5,-22.5,-21.5,-20.5,-19.5,-18.5,-17.5,-16.5,
-		       -15.5,-14.5,
-		       14.5, 15.5,
-		       16.5,17.5,18.5,19.5,20.5,21.5,22.5,23.5,24.5,25.5,26.5,27.5,28.5,29.5,30.5,
-		       31.5,32.5,33.5,34.5,35.5,36.5,37.5,38.5,39.5,40.5,41.5,42.5};
-      depth.push_back(m_dbe->book2D(("HB HE HF Depth 2 "+name.str()+unitname.str()).c_str(),
-				    (name.str()+" Depth 2 -- HB HE HF ("+unittitle.str().c_str()+")"),
-				    57, xbinsd2, 72, ybins));
-      
-      // Set up variable-sized bins for HE depth 3 (MonitorElement also requires phi bins to be entered in array format)
-      float xbins[]={-28.5,-27.5,-26.5,-16.5,-15.5,
-		     15.5,16.5,26.5,27.5,28.5};
-      
-      depth.push_back(m_dbe->book2D(("HE Depth 3 "+name.str()+unitname.str()).c_str(),
-				    (name.str()+" Depth 3 -- HE ("+unittitle.str().c_str()+")"),
-				    // Use variable-sized eta bins 
-				    9, xbins, 72, ybins));
-      // HO bins are fixed width, but cover a smaller eta range (-15 -> 15)
-      depth.push_back(m_dbe->book2D(("HO Depth 4 "+name.str()+unitname.str()).c_str(),
-				    (name.str()+" Depth 4 -- HO ("+unittitle.str().c_str()+")"),
-				    31,-15.5,15.5,
-				    72,0.5,72.5));
-      for (unsigned int i=0;i<depth.size();++i)
-	(depth[i]->getTH2F())->SetOption("colz");
-      setBinLabels(); // set axis titles, special bins
-      
-    } // void setup(...)
 
   void setup(DQMStore::IBooker & m_dbe,std::string Name, std::string Units="")
     {

--- a/DQM/HcalMonitorTasks/interface/HcalHotCellMonitor.h
+++ b/DQM/HcalMonitorTasks/interface/HcalHotCellMonitor.h
@@ -32,12 +32,11 @@ class HcalHotCellMonitor: public HcalBaseDQMonitor {
 
   ~HcalHotCellMonitor();
 
-  void setup();
-  void beginRun(const edm::Run& run, const edm::EventSetup& c);
+  void setup(DQMStore::IBooker &);
+  void bookHistograms(DQMStore::IBooker &ib, const edm::Run& run, const edm::EventSetup& c);
   void endRun(const edm::Run& run, const edm::EventSetup& c);
   
   void done();
-  void cleanup(void);
   void reset();
   void endJob();
 

--- a/DQM/HcalMonitorTasks/interface/HcalLSbyLSMonitor.h
+++ b/DQM/HcalMonitorTasks/interface/HcalLSbyLSMonitor.h
@@ -27,12 +27,11 @@ class HcalLSbyLSMonitor: public HcalBaseDQMonitor {
 
   ~HcalLSbyLSMonitor();
 
-  void setup();
-  void beginRun(const edm::Run& run, const edm::EventSetup& c);
+  void setup(DQMStore::IBooker &);
+  void bookHistograms(DQMStore::IBooker &ib, const edm::Run& run, const edm::EventSetup& c);
   void endRun(const edm::Run& run, const edm::EventSetup& c){};
   
   void done();
-  void cleanup(void);
   void reset();
   void endJob();
 

--- a/DQM/HcalMonitorTasks/interface/HcalNZSMonitor.h
+++ b/DQM/HcalMonitorTasks/interface/HcalNZSMonitor.h
@@ -14,15 +14,14 @@ class HcalNZSMonitor: public HcalBaseDQMonitor
   ~HcalNZSMonitor();
 
 
-  void setup();
-  void beginRun(const edm::Run& run, const edm::EventSetup& c);
+  void setup(DQMStore::IBooker &);
+  void bookHistograms(DQMStore::IBooker &ib, const edm::Run& run, const edm::EventSetup& c);
   void analyze(edm::Event const&e, edm::EventSetup const&s);
   void processEvent(const FEDRawDataCollection& rawraw, const edm::TriggerResults&, int bxNum,const edm::TriggerNames & triggerNames);
 
 
 
   void unpack(const FEDRawData& raw, const HcalElectronicsMap& emap);
-  void cleanup();
   void reset();
 
  private: 

--- a/DQM/HcalMonitorTasks/interface/HcalNoiseMonitor.h
+++ b/DQM/HcalMonitorTasks/interface/HcalNoiseMonitor.h
@@ -20,12 +20,11 @@ public:
    ~HcalNoiseMonitor();
 
 
-   void setup();
-   void beginRun(const edm::Run& run, const edm::EventSetup& c);
+   void setup(DQMStore::IBooker &);
+   void bookHistograms(DQMStore::IBooker &ib, const edm::Run& run, const edm::EventSetup& c);
    void analyze(edm::Event const&e, edm::EventSetup const&s);
 
    void unpack(const FEDRawData& raw, const HcalElectronicsMap& emap);
-   void cleanup();
    void reset();
 
 private:

--- a/DQM/HcalMonitorTasks/interface/HcalRawDataMonitor.h
+++ b/DQM/HcalMonitorTasks/interface/HcalRawDataMonitor.h
@@ -37,7 +37,7 @@ class HcalRawDataMonitor: public HcalBaseDQMonitor {
   ~HcalRawDataMonitor();
  protected:
   void analyze(const edm::Event& e, const edm::EventSetup& c);
-  void beginRun(const edm::Run& run, const edm::EventSetup& c);
+  void bookHistograms(DQMStore::IBooker &ib, const edm::Run& run, const edm::EventSetup& c);
   void beginLuminosityBlock(const edm::LuminosityBlock& lumiSeg,
                             const edm::EventSetup& c) ;
   // End LumiBlock 
@@ -51,7 +51,7 @@ class HcalRawDataMonitor: public HcalBaseDQMonitor {
   void unpack(const FEDRawData& raw);
   void endJob(void);
   void endRun(const edm::Run& run, const edm::EventSetup& c);
-  void setup(void);
+  void setup(DQMStore::IBooker &);
   void reset(void);
 
   edm::InputTag FEDRawDataCollection_;

--- a/DQM/HcalMonitorTasks/interface/HcalRecHitMonitor.h
+++ b/DQM/HcalMonitorTasks/interface/HcalRecHitMonitor.h
@@ -19,13 +19,12 @@ class HcalRecHitMonitor: public HcalBaseDQMonitor {
 
   ~HcalRecHitMonitor();
 
-  void setup();
-  void beginRun(const edm::Run& run, const edm::EventSetup& c);
+  void setup(DQMStore::IBooker &);
+  void bookHistograms(DQMStore::IBooker &ib, const edm::Run& run, const edm::EventSetup& c);
   void endRun(const edm::Run& run, const edm::EventSetup& c);
   void endLuminosityBlock(const edm::LuminosityBlock& lumiSeg,
 			  const edm::EventSetup& c);
   void endJob();
-  void cleanup();
   void reset();
   void zeroCounters();
  

--- a/DQM/HcalMonitorTasks/interface/HcalTrigPrimMonitor.h
+++ b/DQM/HcalMonitorTasks/interface/HcalTrigPrimMonitor.h
@@ -15,15 +15,14 @@ class HcalTrigPrimMonitor: public HcalBaseDQMonitor {
       HcalTrigPrimMonitor(const edm::ParameterSet& ps);
       ~HcalTrigPrimMonitor(); 
   
-      void setup();
+      void setup(DQMStore::IBooker &);
       void analyze(const edm::Event& e, const edm::EventSetup& c);
       void processEvent(const edm::Handle<HcalTrigPrimDigiCollection>& data_tp_col,
                         const edm::Handle<HcalTrigPrimDigiCollection>& emul_tp_col);
       void reset();
-      void beginRun(const edm::Run& run, const edm::EventSetup& c);
+      void bookHistograms(DQMStore::IBooker &ib, const edm::Run& run, const edm::EventSetup& c);
       void beginLuminosityBlock(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& c) ;
       void endLuminosityBlock(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& c);
-      void cleanup();
       void endJob();
 
    private:
@@ -36,12 +35,12 @@ class HcalTrigPrimMonitor: public HcalBaseDQMonitor {
       std::vector<int> ZSBadTPThreshold_;
       std::vector<int> ZSAlarmThreshold_;
 
-      MonitorElement* create_summary(const std::string& folder, const std::string& name);
-      MonitorElement* create_errorflag(const std::string& folder, const std::string& name);
-      MonitorElement* create_tp_correlation(const std::string& folder, const std::string& name);
-      MonitorElement* create_fg_correlation(const std::string& folder, const std::string& name);
-      MonitorElement* create_map(const std::string& folder, const std::string& name);
-      MonitorElement* create_et_histogram(const std::string& folder, const std::string& name);
+      MonitorElement* create_summary(DQMStore::IBooker &ib, const std::string& folder, const std::string& name);
+      MonitorElement* create_errorflag(DQMStore::IBooker &ib, const std::string& folder, const std::string& name);
+      MonitorElement* create_tp_correlation(DQMStore::IBooker &ib, const std::string& folder, const std::string& name);
+      MonitorElement* create_fg_correlation(DQMStore::IBooker &ib, const std::string& folder, const std::string& name);
+      MonitorElement* create_map(DQMStore::IBooker &ib, const std::string& folder, const std::string& name);
+      MonitorElement* create_et_histogram(DQMStore::IBooker &ib, const std::string& folder, const std::string& name);
 
       enum ErrorFlag{
          kZeroTP=-1,

--- a/DQM/HcalMonitorTasks/python/HcalBaseDQMonitor_cfi.py
+++ b/DQM/HcalMonitorTasks/python/HcalBaseDQMonitor_cfi.py
@@ -10,4 +10,5 @@ hcalBaseDQMonitor=cms.EDAnalyzer("HcalBaseDQMonitor",
                                  TaskFolder             = cms.untracked.string("Test/"),
                                  skipOutOfOrderLS       = cms.untracked.bool(False),
                                  NLumiBlocks            = cms.untracked.int32(4000),
+                             	 FEDRawDataCollection=cms.untracked.InputTag("rawDataCollector")
                                  )

--- a/DQM/HcalMonitorTasks/python/HcalBeamMonitor_cfi.py
+++ b/DQM/HcalMonitorTasks/python/HcalBeamMonitor_cfi.py
@@ -26,4 +26,5 @@ hcalBeamMonitor=cms.EDAnalyzer("HcalBeamMonitor",
                                hotrate                = cms.untracked.double(0.25),
                                minBadCells            = cms.untracked.int32(10),
                                Overwrite              = cms.untracked.bool(False),
+                               FEDRawDataCollection=cms.untracked.InputTag("rawDataCollector")
                                )

--- a/DQM/HcalMonitorTasks/python/HcalCoarsePedestalMonitor_cfi.py
+++ b/DQM/HcalMonitorTasks/python/HcalCoarsePedestalMonitor_cfi.py
@@ -19,4 +19,5 @@ hcalCoarsePedestalMonitor=cms.EDAnalyzer("HcalCoarsePedestalMonitor",
                                          minEvents              = cms.untracked.int32(25),
                                          # Turn off calculation of Ring2 pedestals
                                          excludeHORing2         = cms.untracked.bool(True),
+                             	 	 FEDRawDataCollection=cms.untracked.InputTag("rawDataCollector")
                                          )

--- a/DQM/HcalMonitorTasks/python/HcalDataIntegrityTask_cfi.py
+++ b/DQM/HcalMonitorTasks/python/HcalDataIntegrityTask_cfi.py
@@ -15,5 +15,6 @@ hcalDataIntegrityMonitor = cms.EDAnalyzer("HcalDataIntegrityTask",
                                           # task-specific stuff
                                    
                                           RawDataLabel           = cms.untracked.InputTag("rawDataCollector"),
-                                          UnpackerReportLabel    = cms.untracked.InputTag("hcalDigis")
+                                          UnpackerReportLabel    = cms.untracked.InputTag("hcalDigis"),
+                             	 	  FEDRawDataCollection=cms.untracked.InputTag("rawDataCollector")
                                           )

--- a/DQM/HcalMonitorTasks/python/HcalDeadCellMonitor_cfi.py
+++ b/DQM/HcalMonitorTasks/python/HcalDeadCellMonitor_cfi.py
@@ -29,6 +29,7 @@ hcalDeadCellMonitor=cms.EDAnalyzer("HcalDeadCellMonitor",
                                    #booleans for dead cell tests
                                    test_digis             = cms.untracked.bool(True), # test for recent missing digis
                                    test_rechits           = cms.untracked.bool(True), # test for missing rechits
-                                   MissingRechitEnergyThreshold = cms.untracked.double(-99.)
+                                   MissingRechitEnergyThreshold = cms.untracked.double(-99.),
+                             	   FEDRawDataCollection=cms.untracked.InputTag("rawDataCollector")
 
                                    )

--- a/DQM/HcalMonitorTasks/python/HcalDetDiagLEDMonitor_cfi.py
+++ b/DQM/HcalMonitorTasks/python/HcalDetDiagLEDMonitor_cfi.py
@@ -22,5 +22,6 @@ hcalDetDiagLEDMonitor=cms.EDAnalyzer("HcalDetDiagLEDMonitor",
                                      digiLabel              = cms.untracked.InputTag("hcalDigis"),
                                      calibDigiLabel         = cms.untracked.InputTag("hcalDigis"),
                                      triggerLabel           = cms.untracked.InputTag("l1GtUnpack"),
-                                     hcalTBTriggerDataTag   = cms.InputTag("tbunpack")
+                                     hcalTBTriggerDataTag   = cms.InputTag("tbunpack"),
+                             	     FEDRawDataCollection=cms.untracked.InputTag("rawDataCollector")
                                    )

--- a/DQM/HcalMonitorTasks/python/HcalDetDiagLaserMonitor_cfi.py
+++ b/DQM/HcalMonitorTasks/python/HcalDetDiagLaserMonitor_cfi.py
@@ -34,5 +34,6 @@ hcalDetDiagLaserMonitor=cms.EDAnalyzer("HcalDetDiagLaserMonitor",
                                    XmlFilePath            = cms.untracked.string(""),
 			           # thresholds
                                    LaserTimingThreshold   = cms.untracked.double(0.2),
-                                   LaserEnergyThreshold   = cms.untracked.double(0.1)
+                                   LaserEnergyThreshold   = cms.untracked.double(0.1),
+                             	   FEDRawDataCollection=cms.untracked.InputTag("rawDataCollector")
                                    )

--- a/DQM/HcalMonitorTasks/python/HcalDetDiagNoiseMonitor_cfi.py
+++ b/DQM/HcalMonitorTasks/python/HcalDetDiagNoiseMonitor_cfi.py
@@ -47,4 +47,5 @@ hcalDetDiagNoiseMonitor=cms.EDAnalyzer("HcalDetDiagNoiseMonitor",
                                        MinJetChargeFraction                = cms.untracked.double(0.05),
                                        MaxJetHadronicEnergyFraction        = cms.untracked.double(0.98),
                                        caloTowerCollName                   = cms.InputTag("towerMaker"),
+                             	       FEDRawDataCollection=cms.untracked.InputTag("rawDataCollector")
                                    )

--- a/DQM/HcalMonitorTasks/python/HcalDetDiagPedestalMonitor_cfi.py
+++ b/DQM/HcalMonitorTasks/python/HcalDetDiagPedestalMonitor_cfi.py
@@ -39,5 +39,6 @@ hcalDetDiagPedestalMonitor=cms.EDAnalyzer("HcalDetDiagPedestalMonitor",
                                           HORmsTreshold          = cms.untracked.double(0.3),
                                           HFMeanTreshold         = cms.untracked.double(0.2),
                                           HFRmsTreshold          = cms.untracked.double(0.3),
-                                          hcalTBTriggerDataTag   = cms.InputTag("tbunpack")
+                                          hcalTBTriggerDataTag   = cms.InputTag("tbunpack"),
+                             	          FEDRawDataCollection=cms.untracked.InputTag("rawDataCollector")
                                    )

--- a/DQM/HcalMonitorTasks/python/HcalDigiMonitor_cfi.py
+++ b/DQM/HcalMonitorTasks/python/HcalDigiMonitor_cfi.py
@@ -57,5 +57,5 @@ hcalDigiMonitor=cms.EDAnalyzer("HcalDigiMonitor",
                                
                                # block orbit test
                                shutOffOrbitTest       = cms.untracked.bool(False),
-                               ExpectedOrbitMessageTime = cms.untracked.int32(3559)
+                               ExpectedOrbitMessageTime = cms.untracked.int32(3559),
                                )

--- a/DQM/HcalMonitorTasks/python/HcalHotCellMonitor_cfi.py
+++ b/DQM/HcalMonitorTasks/python/HcalHotCellMonitor_cfi.py
@@ -43,5 +43,6 @@ hcalHotCellMonitor=cms.EDAnalyzer("HcalHotCellMonitor",
 
                                   persistentETThreshold    = cms.untracked.double(3.),
                                   persistentETThreshold_HF = cms.untracked.double(3.),
+                             	  FEDRawDataCollection=cms.untracked.InputTag("rawDataCollector")
 
                                   )

--- a/DQM/HcalMonitorTasks/python/HcalLSbyLSMonitor_cfi.py
+++ b/DQM/HcalMonitorTasks/python/HcalLSbyLSMonitor_cfi.py
@@ -20,5 +20,6 @@ hcalLSbyLSMonitor=cms.EDAnalyzer("HcalLSbyLSMonitor",
                                                                                 "DigiMonitor_Hcal/",
                                                                                 "HotCellMonitor_Hcal/",
                                                                                 "BeamMonitor_Hcal/"),
-                                 minEvents              = cms.untracked.int32(500)
+                                 minEvents              = cms.untracked.int32(500),
+                             	 FEDRawDataCollection=cms.untracked.InputTag("rawDataCollector")
                                  )

--- a/DQM/HcalMonitorTasks/python/HcalNZSMonitor_cfi.py
+++ b/DQM/HcalMonitorTasks/python/HcalNZSMonitor_cfi.py
@@ -19,4 +19,5 @@ hcalNZSMonitor=cms.EDAnalyzer("HcalNZSMonitor",
                               nzsHLTnames            = cms.untracked.vstring('HLT_HcalPhiSym',
                                                                    'HLT_HcalNZS_8E29'),
                               NZSeventPeriod         = cms.untracked.int32(4096),
+                              FEDRawDataCollection=cms.untracked.InputTag("rawDataCollector")
                               )

--- a/DQM/HcalMonitorTasks/python/HcalNoiseMonitor_cfi.py
+++ b/DQM/HcalMonitorTasks/python/HcalNoiseMonitor_cfi.py
@@ -29,5 +29,6 @@ hcalNoiseMonitor=cms.EDAnalyzer("HcalNoiseMonitor",
                                 MaxHPDHitCount         = cms.untracked.int32(17),
                                 MaxHPDNoOtherHitCount  = cms.untracked.int32(10),
                                 MaxADCZeros            = cms.untracked.int32(10),
-                                TotalZeroMinEnergy     = cms.untracked.double(10)
+                                TotalZeroMinEnergy     = cms.untracked.double(10),
+                                FEDRawDataCollection=cms.untracked.InputTag("rawDataCollector")
                                 )

--- a/DQM/HcalMonitorTasks/python/HcalRawDataMonitor_cfi.py
+++ b/DQM/HcalMonitorTasks/python/HcalRawDataMonitor_cfi.py
@@ -3,9 +3,9 @@ import FWCore.ParameterSet.Config as cms
 hcalRawDataMonitor=cms.EDAnalyzer("HcalRawDataMonitor",
                                  # base class stuff
                                  debug                  = cms.untracked.int32(0),
-                                 online                 = cms.bool(False),
+                                 online                 = cms.untracked.bool(False),
                                  AllowedCalibTypes      = cms.untracked.vint32(0), # by default, don't include calibration events
-                                 mergeRuns              = cms.bool(False),
+                                 mergeRuns              = cms.untracked.bool(False),
                                  enableCleanup          = cms.untracked.bool(False),
                                  subSystemFolder        = cms.untracked.string("Hcal/"),
                                  TaskFolder             = cms.untracked.string("RawDataMonitor_Hcal/"),

--- a/DQM/HcalMonitorTasks/python/HcalRecHitMonitor_cfi.py
+++ b/DQM/HcalMonitorTasks/python/HcalRecHitMonitor_cfi.py
@@ -35,5 +35,6 @@ hcalRecHitMonitor=cms.EDAnalyzer("HcalRecHitMonitor",
                                  HF_energyThreshold           = cms.untracked.double(3.),
                                  HF_ETThreshold               = cms.untracked.double(0.),
                                  HO_energyThreshold           = cms.untracked.double(5.),
-                                 collisiontimediffThresh      = cms.untracked.double(10.) # max time diff between HF+, HF- weighted times for some plot filling
+                                 collisiontimediffThresh      = cms.untracked.double(10.), # max time diff between HF+, HF- weighted times for some plot filling
+                                 FEDRawDataCollection=cms.untracked.InputTag("rawDataCollector")
                                  )

--- a/DQM/HcalMonitorTasks/python/HcalTrigPrimMonitor_cfi.py
+++ b/DQM/HcalMonitorTasks/python/HcalTrigPrimMonitor_cfi.py
@@ -31,5 +31,6 @@ hcalTrigPrimMonitor=cms.EDAnalyzer("HcalTrigPrimMonitor",
                                         10, 10, 10, 10, 40, 50, 10, 30, 30, 30,
                                         20, 15, 15, 15, 15, 15, 10, 10,
                                         5, 5, 5, 5
-                                      )
+                                      ),
+   FEDRawDataCollection=cms.untracked.InputTag("rawDataCollector")
 )

--- a/DQM/HcalMonitorTasks/src/HcalBaseDQMonitor.cc
+++ b/DQM/HcalMonitorTasks/src/HcalBaseDQMonitor.cc
@@ -3,6 +3,12 @@
 #include "CondFormats/HcalObjects/interface/HcalLogicalMap.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "CalibCalorimetry/HcalAlgos/interface/HcalLogicalMapGenerator.h"
+#include "CondFormats/HcalObjects/interface/HcalElectronicsMap.h"
+#include "CalibFormats/HcalObjects/interface/HcalDbService.h"
+#include "CalibFormats/HcalObjects/interface/HcalDbRecord.h"
+#include "DataFormats/FEDRawData/interface/FEDNumbering.h"
+#include "EventFilter/HcalRawToDigi/interface/HcalDCCHeader.h"
+#include "EventFilter/HcalRawToDigi/interface/HcalHTRData.h"
 
 #include <iostream>
 #include <vector>
@@ -36,6 +42,10 @@ HcalBaseDQMonitor::HcalBaseDQMonitor(const edm::ParameterSet& ps)
   skipOutOfOrderLS_      = ps.getUntrackedParameter<bool>("skipOutOfOrderLS",false);
   NLumiBlocks_           = ps.getUntrackedParameter<int>("NLumiBlocks",4000);
   makeDiagnostics_       = ps.getUntrackedParameter<bool>("makeDiagnostics",false);
+
+
+  FEDRawDataCollection_  = ps.getUntrackedParameter<edm::InputTag>("FEDRawDataCollection");
+  tok_raw_ = consumes<FEDRawDataCollection>(FEDRawDataCollection_);
   
   setupDone_ = false;
   logicalMap_= 0;
@@ -50,6 +60,8 @@ HcalBaseDQMonitor::HcalBaseDQMonitor(const edm::ParameterSet& ps)
   ProblemsVsLB_HBHEHF=0;
   ProblemsVsLB_HO=0;
   ProblemsCurrentLB=0;
+
+  eMap_ = 0;
 } //HcalBaseDQMonitor::HcalBaseDQMonitor(const ParameterSet& ps)
 
 
@@ -58,6 +70,23 @@ HcalBaseDQMonitor::HcalBaseDQMonitor(const edm::ParameterSet& ps)
 HcalBaseDQMonitor::~HcalBaseDQMonitor()
 {
   if (logicalMap_) delete logicalMap_;
+}
+
+
+//dqmBeginRun
+void HcalBaseDQMonitor::dqmBeginRun(const edm::Run &run, const edm::EventSetup &es)
+{
+
+  if (eMap_==0) //eMap_ not created yet
+    {
+      if (debug_>1) std::cout <<"\t<HcalBaseDQMonitor::dqmBeginRun> Getting Emap!"<<std::endl;
+      edm::ESHandle<HcalDbService> pSetup;
+      es.get<HcalDbRecord>().get( pSetup );
+      eMap_=pSetup->getHcalMapping(); 
+    }
+  if (mergeRuns_) return;
+  this->reset();
+
 }
 
 void HcalBaseDQMonitor::beginJob(void)
@@ -190,21 +219,13 @@ bool HcalBaseDQMonitor::LumiInOrder(int lumisec)
 
 bool HcalBaseDQMonitor::IsAllowedCalibType()
 {
-  //CATCH ME AND FIX ME
-  return true;
-  /*if (debug_>9) std::cout <<"<HcalBaseDQMonitor::IsAllowedCalibType>"<<std::endl;
+  if (debug_>9) std::cout <<"<HcalBaseDQMonitor::IsAllowedCalibType>"<<std::endl;
   if (AllowedCalibTypes_.size()==0)
     {
       if (debug_>9) std::cout <<"\tNo calib types specified by user; All events allowed"<<std::endl;
       return true;
     }
-  MonitorElement* me = dbe_->get((prefixME_+"HcalInfo/CURRENT_EVENT_TYPE").c_str());
-  if (me) currenttype_=me->getIntValue();
-  else 
-    {
-      if (debug_>9) std::cout <<"\tCalib Type cannot be determined from HcalMonitorModule"<<std::endl;
-      return true; // is current type can't be determined, assume event is allowed
-    }
+
   if (debug_>9) std::cout <<"\tHcalBaseDQMonitor::IsAllowedCalibType  checking if calibration type = "<<currenttype_<<" is allowed...";
   for (std::vector<int>::size_type i=0;i<AllowedCalibTypes_.size();++i)
     {
@@ -216,7 +237,7 @@ bool HcalBaseDQMonitor::IsAllowedCalibType()
     }
   if (debug_>9) std::cout <<"\t Type not allowed!"<<std::endl;
   return false;
-*/
+
 } // bool HcalBaseDQMonitor::IsAllowedCalibType()
 
 void HcalBaseDQMonitor::getLogicalMap(const edm::EventSetup& c) {
@@ -235,6 +256,15 @@ void HcalBaseDQMonitor::analyze(const edm::Event& e, const edm::EventSetup& c)
   if (debug_>5) std::cout <<"\t<HcalBaseDQMonitor::analyze>  event = "<<ievt_<<std::endl;
   eventAllowed_=true; // assume event is allowed
 
+
+  // Try to get raw data
+  edm::Handle<FEDRawDataCollection> rawraw;  
+  if (!(e.getByToken(tok_raw_,rawraw)))
+    {
+      edm::LogWarning("HcalMonitorModule")<<" raw data with label "<<FEDRawDataCollection_ <<" not available";
+      return;
+    }
+
   // fill with total events seen (this differs from ievent, which is total # of good events)
   ++tevt_;
   if (meTevt_) meTevt_->Fill(tevt_);
@@ -245,6 +275,8 @@ void HcalBaseDQMonitor::analyze(const edm::Event& e, const edm::EventSetup& c)
       eventAllowed_=false;
       return;
     }
+
+  this->CheckCalibType(rawraw);
   // skip events of wrong calibration type
   eventAllowed_&=(this->IsAllowedCalibType());
   if (!eventAllowed_) return;
@@ -256,30 +288,158 @@ void HcalBaseDQMonitor::analyze(const edm::Event& e, const edm::EventSetup& c)
   if (meLevt_) meLevt_->Fill(levt_);
 
 
-  // CATCH ME
-  /*MonitorElement* me;
   if (HBpresent_==false)
     {
-      me = dbe_->get((prefixME_+"HcalInfo/HBpresent"));
-      if (me==0 || me->getIntValue()>0) HBpresent_=true;
+      CheckSubdetectorStatus(rawraw,HcalBarrel,*eMap_);
     }
   if (HEpresent_==false)
     {
-      me = dbe_->get((prefixME_+"HcalInfo/HEpresent"));
-      if (me==0 || me->getIntValue()>0) HEpresent_=true;
+      CheckSubdetectorStatus(rawraw,HcalEndcap,*eMap_);
     }
   if (HOpresent_==false)
     {
-      me = dbe_->get((prefixME_+"HcalInfo/HOpresent"));
-      if (me==0 || me->getIntValue()>0) HOpresent_=true;
+      CheckSubdetectorStatus(rawraw,HcalOuter,*eMap_);
     }
   if (HFpresent_==false)
     {
-      me = dbe_->get((prefixME_+"HcalInfo/HOpresent"));
-      if (me ==0 || me->getIntValue()>0) HFpresent_=true;
-    }*/
+      CheckSubdetectorStatus(rawraw,HcalForward,*eMap_);
+    }
 
 
 } // void HcalBaseDQMonitor::analyze(const edm::Event& e, const edm::EventSetup& c)
+
+//
+//  CheckSubdetectorStatus
+void HcalBaseDQMonitor::CheckSubdetectorStatus(const edm::Handle<FEDRawDataCollection>& rawraw, HcalSubdetector subdet, const HcalElectronicsMap &emap)
+{
+
+  std::vector<int> fedUnpackList;
+  for (int i=FEDNumbering::MINHCALFEDID; 
+       i<=FEDNumbering::MAXHCALFEDID; 
+       i++) 
+    fedUnpackList.push_back(i);
+
+  if (debug_>1) std::cout <<"<HcalMonitorModule::CheckSubdetectorStatus>  Checking subdetector "<<subdet<<std::endl;
+  for (std::vector<int>::const_iterator i=fedUnpackList.begin();
+       i!=fedUnpackList.end(); 
+       ++i) 
+    {
+      if (debug_>2) std::cout <<"\t<HcalMonitorModule::CheckSubdetectorStatus>  FED = "<<*i<<std::endl;
+      const FEDRawData& fed =(*rawraw).FEDData(*i);
+      if (fed.size()<12) continue; // Was 16. How do such tiny events even get here?
+      
+      // get the DCC header
+      const HcalDCCHeader* dccHeader=(const HcalDCCHeader*)(fed.data());
+      if (!dccHeader) return;
+      int dccid=dccHeader->getSourceId();
+      // check for HF
+      if (subdet == HcalForward && dccid>717 && dccid<724)
+	{
+	  HFpresent_=true;
+	  return;
+	}
+      else if (subdet==HcalOuter && dccid>723)
+	{
+	  HOpresent_=true;
+	  return;
+	}
+      else if (dccid<718 && (subdet==HcalBarrel || subdet==HcalEndcap))
+	{
+	  HcalHTRData htr;  
+	  for (int spigot=0; spigot<HcalDCCHeader::SPIGOT_COUNT; spigot++) 
+	    {    
+	      if (!dccHeader->getSpigotPresent(spigot)) continue;
+	      
+	      // Load the given decoder with the pointer and length from this spigot.
+	      dccHeader->getSpigotData(spigot,htr, fed.size()); 
+	      
+	      // check min length, correct wordcount, empty event, or total length if histo event.
+	      if (!htr.check()) continue;
+	      if (htr.isHistogramEvent()) continue;
+	      
+	      int firstFED =  FEDNumbering::MINHCALFEDID;
+	      
+	      // Tease out HB and HE, which share HTRs in HBHE
+	      for(int fchan=0; fchan<3; ++fchan) //0,1,2 are valid
+		{
+		  for(int fib=1; fib<9; ++fib) //1...8 are valid
+		    {
+		      HcalElectronicsId eid(fchan,fib,spigot,dccid-firstFED);
+		      eid.setHTR(htr.readoutVMECrateId(),
+				 htr.htrSlot(),htr.htrTopBottom());
+		      
+		      DetId did=emap.lookup(eid);
+		      if (!did.null()) 
+			{
+			  
+			  if ((HcalSubdetector)did.subdetId()==subdet)
+			    {
+			      if (subdet==HcalBarrel)
+				{
+				  HBpresent_=true;
+				  return;
+				}
+			      else if (subdet==HcalEndcap)
+			      {
+				HEpresent_=true;
+				return;
+			      }
+			    } // if ((HcalSubdetector)did.subdetId()==subdet)
+			} // if (!did.null())
+		    } // for (int fib=1;fib<9;...)
+		} // for (int fchan=0; fchan<3;...)
+	    } // for (int spigot=0;spigot<HcalDCCHeader::SPIGOT_COUNT; spigot++) 
+	} //else if (dcc<718 && (subdet...))
+  } // loop over fedUnpackList
+  
+
+} // void CheckSubdetectorStatus
+
+
+// Check Calib type
+void HcalBaseDQMonitor::CheckCalibType(const edm::Handle<FEDRawDataCollection> &rawraw)
+{
+  // Get Event Calibration Type -- copy of Bryan Dahmes' filter
+  int calibType=-1;
+  int numEmptyFEDs = 0 ;
+  std::vector<int> calibTypeCounter(8,0) ;
+  for( int i = FEDNumbering::MINHCALFEDID; i <= FEDNumbering::MAXHCALFEDID; i++) 
+    {
+      const FEDRawData& fedData = rawraw->FEDData(i) ;
+      
+      if ( fedData.size() < 24 ) numEmptyFEDs++ ;
+      if ( fedData.size() < 24 ) continue;
+
+      int value = (int)((const HcalDCCHeader*)(fedData.data()))->getCalibType() ;
+      if(value>7) 
+	{
+	  edm::LogWarning("HcalMonitorModule::CalibTypeFilter") << "Unexpected Calibration type: "<< value << " in FED: "<<i<<" (should be 0-7). I am bailing out...";
+	  return;
+	}
+
+      calibTypeCounter.at(value)++ ; // increment the counter for this calib type
+    } // for (int i = FEDNumbering::MINHCALFEDID; ...)
+
+  int maxCount = 0;
+  int numberOfFEDIds = FEDNumbering::MAXHCALFEDID  - FEDNumbering::MINHCALFEDID + 1 ;
+  for (unsigned int i=0; i<calibTypeCounter.size(); i++) {
+    if ( calibTypeCounter.at(i) > maxCount )
+      { calibType = i ; maxCount = calibTypeCounter.at(i) ; }
+    if ( maxCount == numberOfFEDIds ) break ;
+  }
+  
+  if ( maxCount != (numberOfFEDIds-numEmptyFEDs) )
+    edm::LogWarning("HcalMonitorModule::CalibTypeFilter") << "Conflicting calibration types found.  Assigning type "
+					   << calibType ;
+  LogDebug("HcalMonitorModule::CalibTypeFilter") << "Calibration type is: " << calibType ;
+  // Fill histogram of calibration types, as well as integer to keep track of current value
+  currenttype_ = calibType;
+  //if (meCalibType_) meCalibType_->Fill(calibType);
+  //if (meCurrentCalibType_) meCurrentCalibType_->Fill(calibType);
+  ////if (meCurrentCalibType_) meCurrentCalibType_->Fill(ievt_); // use for debugging check ONLY!
+
+  if (debug_>2) std::cout <<"\t<HcalMonitorModule>  ievt = "<<ievt_<<"  calibration type = "<<calibType<<std::endl;
+
+} // check calib type
 
 DEFINE_FWK_MODULE(HcalBaseDQMonitor);

--- a/DQM/HcalMonitorTasks/src/HcalBaseDQMonitor.cc
+++ b/DQM/HcalMonitorTasks/src/HcalBaseDQMonitor.cc
@@ -45,7 +45,7 @@ HcalBaseDQMonitor::HcalBaseDQMonitor(const edm::ParameterSet& ps)
 
 
   FEDRawDataCollection_  = ps.getUntrackedParameter<edm::InputTag>("FEDRawDataCollection");
-  tok_raw_ = consumes<FEDRawDataCollection>(FEDRawDataCollection_);
+  tok_braw_ = consumes<FEDRawDataCollection>(FEDRawDataCollection_);
   
   setupDone_ = false;
   logicalMap_= 0;
@@ -85,7 +85,7 @@ void HcalBaseDQMonitor::dqmBeginRun(const edm::Run &run, const edm::EventSetup &
       eMap_=pSetup->getHcalMapping(); 
     }
   if (mergeRuns_) return;
-  this->reset();
+  if( setupDone_ ) this->reset();
 
 }
 
@@ -259,7 +259,7 @@ void HcalBaseDQMonitor::analyze(const edm::Event& e, const edm::EventSetup& c)
 
   // Try to get raw data
   edm::Handle<FEDRawDataCollection> rawraw;  
-  if (!(e.getByToken(tok_raw_,rawraw)))
+  if (!(e.getByToken(tok_braw_,rawraw)))
     {
       edm::LogWarning("HcalMonitorModule")<<" raw data with label "<<FEDRawDataCollection_ <<" not available";
       return;

--- a/DQM/HcalMonitorTasks/src/HcalBaseDQMonitor.cc
+++ b/DQM/HcalMonitorTasks/src/HcalBaseDQMonitor.cc
@@ -64,7 +64,6 @@ void HcalBaseDQMonitor::beginJob(void)
 {
 
   if (debug_>0) std::cout <<"HcalBaseDQMonitor::beginJob():  task =  '"<<subdir_<<"'"<<std::endl;
-  dbe_ = edm::Service<DQMStore>().operator->();
 
   ievt_=0;
   levt_=0;
@@ -84,17 +83,17 @@ void HcalBaseDQMonitor::endJob(void)
     cleanup();
 } // endJob()
 
-void HcalBaseDQMonitor::beginRun(const edm::Run& run, const edm::EventSetup& c)
+void HcalBaseDQMonitor::bookHistograms(DQMStore::IBooker &ib, const edm::Run& run, const edm::EventSetup& c)
 {
-  if (debug_>0) std::cout <<"HcalBaseDQMonitor::beginRun():  task =  '"<<subdir_<<"'"<<std::endl;
+  if (debug_>0) std::cout <<"HcalBaseDQMonitor::bookHistograms():  task =  '"<<subdir_<<"'"<<std::endl;
   if (! mergeRuns_)
     {
-      this->setup();
+      this->setup(ib);
       this->reset();
     }
   else if (tevt_ == 0)
     {
-      this->setup();
+      this->setup(ib);
       this->reset();
     }
 } // beginRun(const edm::Run& run, const edm::EventSetup& c)
@@ -128,23 +127,23 @@ void HcalBaseDQMonitor::cleanup(void)
 
 } //cleanup()
 
-void HcalBaseDQMonitor::setup(void)
+void HcalBaseDQMonitor::setup(DQMStore::IBooker &ib)
 {
   if (setupDone_)
     return;
   setupDone_ = true;
   if (debug_>3) std::cout <<"<HcalBaseDQMonitor> setup in progress"<<std::endl;
-  dbe_->setCurrentFolder(subdir_);
-  meIevt_ = dbe_->bookInt("EventsProcessed");
+  ib.setCurrentFolder(subdir_);
+  meIevt_ = ib.bookInt("EventsProcessed");
   if (meIevt_) meIevt_->Fill(-1);
-  meLevt_ = dbe_->bookInt("EventsProcessed_currentLS");
+  meLevt_ = ib.bookInt("EventsProcessed_currentLS");
   if (meLevt_) meLevt_->Fill(-1);
-  meTevt_ = dbe_->bookInt("EventsProcessed_Total");
+  meTevt_ = ib.bookInt("EventsProcessed_Total");
   if (meTevt_) meTevt_->Fill(-1);
-  meTevtHist_=dbe_->book1D("Events_Processed_Task_Histogram","Counter of Events Processed By This Task",1,0.5,1.5);
+  meTevtHist_=ib.book1D("Events_Processed_Task_Histogram","Counter of Events Processed By This Task",1,0.5,1.5);
   if (meTevtHist_) meTevtHist_->Reset();
-  dbe_->setCurrentFolder(subdir_+"LSvalues");
-  ProblemsCurrentLB=dbe_->book2D("ProblemsThisLS","Problem Channels in current Lumi Section",
+  ib.setCurrentFolder(subdir_+"LSvalues");
+  ProblemsCurrentLB=ib.book2D("ProblemsThisLS","Problem Channels in current Lumi Section",
 				 7,0,7,1,0,1);
   if (ProblemsCurrentLB)
     {
@@ -191,7 +190,9 @@ bool HcalBaseDQMonitor::LumiInOrder(int lumisec)
 
 bool HcalBaseDQMonitor::IsAllowedCalibType()
 {
-  if (debug_>9) std::cout <<"<HcalBaseDQMonitor::IsAllowedCalibType>"<<std::endl;
+  //CATCH ME AND FIX ME
+  return true;
+  /*if (debug_>9) std::cout <<"<HcalBaseDQMonitor::IsAllowedCalibType>"<<std::endl;
   if (AllowedCalibTypes_.size()==0)
     {
       if (debug_>9) std::cout <<"\tNo calib types specified by user; All events allowed"<<std::endl;
@@ -215,6 +216,7 @@ bool HcalBaseDQMonitor::IsAllowedCalibType()
     }
   if (debug_>9) std::cout <<"\t Type not allowed!"<<std::endl;
   return false;
+*/
 } // bool HcalBaseDQMonitor::IsAllowedCalibType()
 
 void HcalBaseDQMonitor::getLogicalMap(const edm::EventSetup& c) {
@@ -254,7 +256,8 @@ void HcalBaseDQMonitor::analyze(const edm::Event& e, const edm::EventSetup& c)
   if (meLevt_) meLevt_->Fill(levt_);
 
 
-  MonitorElement* me;
+  // CATCH ME
+  /*MonitorElement* me;
   if (HBpresent_==false)
     {
       me = dbe_->get((prefixME_+"HcalInfo/HBpresent"));
@@ -274,7 +277,7 @@ void HcalBaseDQMonitor::analyze(const edm::Event& e, const edm::EventSetup& c)
     {
       me = dbe_->get((prefixME_+"HcalInfo/HOpresent"));
       if (me ==0 || me->getIntValue()>0) HFpresent_=true;
-    }
+    }*/
 
 
 } // void HcalBaseDQMonitor::analyze(const edm::Event& e, const edm::EventSetup& c)

--- a/DQM/HcalMonitorTasks/src/HcalBaseDQMonitor.cc
+++ b/DQM/HcalMonitorTasks/src/HcalBaseDQMonitor.cc
@@ -62,7 +62,20 @@ HcalBaseDQMonitor::HcalBaseDQMonitor(const edm::ParameterSet& ps)
   ProblemsCurrentLB=0;
 
   eMap_ = 0;
+
+  ievt_=0;
+  levt_=0;
+  tevt_=0;
+  currenttype_=-1;
+  HBpresent_=false;
+  HEpresent_=false;
+  HOpresent_=false;
+  HFpresent_=false;
+
+
 } //HcalBaseDQMonitor::HcalBaseDQMonitor(const ParameterSet& ps)
+
+
 
 
 // destructor
@@ -89,28 +102,7 @@ void HcalBaseDQMonitor::dqmBeginRun(const edm::Run &run, const edm::EventSetup &
 
 }
 
-void HcalBaseDQMonitor::beginJob(void)
-{
 
-  if (debug_>0) std::cout <<"HcalBaseDQMonitor::beginJob():  task =  '"<<subdir_<<"'"<<std::endl;
-
-  ievt_=0;
-  levt_=0;
-  tevt_=0;
-  currenttype_=-1;
-  HBpresent_=false;
-  HEpresent_=false;
-  HOpresent_=false;
-  HFpresent_=false;
-
-
-} // beginJob()
-
-void HcalBaseDQMonitor::endJob(void)
-{
-  if (enableCleanup_)
-    cleanup();
-} // endJob()
 
 void HcalBaseDQMonitor::bookHistograms(DQMStore::IBooker &ib, const edm::Run& run, const edm::EventSetup& c)
 {

--- a/DQM/HcalMonitorTasks/src/HcalBeamMonitor.cc
+++ b/DQM/HcalMonitorTasks/src/HcalBeamMonitor.cc
@@ -27,6 +27,7 @@
 
 // constructor
 HcalBeamMonitor::HcalBeamMonitor(const edm::ParameterSet& ps):
+  HcalBaseDQMonitor(ps),
   ETA_OFFSET_HB(16),
   ETA_OFFSET_HE(29),
   ETA_BOUND_HE(17),

--- a/DQM/HcalMonitorTasks/src/HcalBeamMonitor.cc
+++ b/DQM/HcalMonitorTasks/src/HcalBeamMonitor.cc
@@ -144,41 +144,29 @@ void HcalBeamMonitor::reset()
   HFlumi_Ring2Status_vs_LS->Reset();
 }
 
-void HcalBeamMonitor::cleanup()
-{
-  if (dbe_) 
-    {
-      dbe_->setCurrentFolder(subdir_);
-      dbe_->removeContents();
-      dbe_->setCurrentFolder(subdir_+"LSvalues");
-      dbe_->removeContents();
-    } // if (dbe_)
-} // void HcalBeamMonitor::cleanup()
 
-
-void HcalBeamMonitor::setup()
+void HcalBeamMonitor::setup(DQMStore::IBooker &ib)
 {
   if (setupDone_)
     return;
   setupDone_ = true;
    if (debug_>0) std::cout <<"<HcalBeamMonitor::setup> Setup in progress..."<<std::endl;
-  HcalBaseDQMonitor::setup();
-  if (!dbe_) return;
+  HcalBaseDQMonitor::setup(ib);
 
   //jason's
-  dbe_->setCurrentFolder(subdir_);
-  CenterOfEnergyRadius = dbe_->book1D("CenterOfEnergyRadius",
+  ib.setCurrentFolder(subdir_);
+  CenterOfEnergyRadius = ib.book1D("CenterOfEnergyRadius",
 				       "Center Of Energy radius",
 				       200,0,1);
       
   CenterOfEnergyRadius->setAxisTitle("(normalized) radius",1);
       
-  CenterOfEnergy = dbe_->book2D("CenterOfEnergy",
+  CenterOfEnergy = ib.book2D("CenterOfEnergy",
 				 "Center of Energy;normalized x coordinate;normalize y coordinate",
 				 40,-1,1,
 				 40,-1,1);
 
-  COEradiusVSeta = dbe_->bookProfile("COEradiusVSeta",
+  COEradiusVSeta = ib.bookProfile("COEradiusVSeta",
 				      "Center of Energy radius vs i#eta",
 				      172,-43,43,
 				      20,0,1);
@@ -187,11 +175,11 @@ void HcalBeamMonitor::setup()
       
   std::stringstream histname;
   std::stringstream histtitle;
-  dbe_->setCurrentFolder(subdir_+"HB");
-  HBCenterOfEnergyRadius = dbe_->book1D("HBCenterOfEnergyRadius",
+  ib.setCurrentFolder(subdir_+"HB");
+  HBCenterOfEnergyRadius = ib.book1D("HBCenterOfEnergyRadius",
 					 "HB Center Of Energy radius",
 					 200,0,1);
-  HBCenterOfEnergy = dbe_->book2D("HBCenterOfEnergy",
+  HBCenterOfEnergy = ib.book2D("HBCenterOfEnergy",
 				   "HB Center of Energy",
 				   40,-1,1,
 				   40,-1,1);
@@ -204,16 +192,16 @@ void HcalBeamMonitor::setup()
 	  histtitle.str("");
 	  histname<<"HB_CenterOfEnergyRadius_ieta"<<i;
 	  histtitle<<"HB Center Of Energy ieta = "<<i;
-	  HB_CenterOfEnergyRadius[i+ETA_OFFSET_HB]=dbe_->book1D(histname.str().c_str(),
+	  HB_CenterOfEnergyRadius[i+ETA_OFFSET_HB]=ib.book1D(histname.str().c_str(),
 								 histtitle.str().c_str(),
 								 200,0,1);
 	} // end of HB loop
     }
-  dbe_->setCurrentFolder(subdir_+"HE");
-  HECenterOfEnergyRadius = dbe_->book1D("HECenterOfEnergyRadius",
+  ib.setCurrentFolder(subdir_+"HE");
+  HECenterOfEnergyRadius = ib.book1D("HECenterOfEnergyRadius",
 					 "HE Center Of Energy radius",
 					 200,0,1);
-  HECenterOfEnergy = dbe_->book2D("HECenterOfEnergy",
+  HECenterOfEnergy = ib.book2D("HECenterOfEnergy",
 				   "HE Center of Energy",
 				   40,-1,1,
 				   40,-1,1);
@@ -227,16 +215,16 @@ void HcalBeamMonitor::setup()
 	  histtitle.str("");
 	  histname<<"HE_CenterOfEnergyRadius_ieta"<<i;
 	  histtitle<<"HE Center Of Energy ieta = "<<i;
-	  HE_CenterOfEnergyRadius[i+ETA_OFFSET_HE]=dbe_->book1D(histname.str().c_str(),
+	  HE_CenterOfEnergyRadius[i+ETA_OFFSET_HE]=ib.book1D(histname.str().c_str(),
 								 histtitle.str().c_str(),
 								 200,0,1);
 	} // end of HE loop
     }
-  dbe_->setCurrentFolder(subdir_+"HO");
-  HOCenterOfEnergyRadius = dbe_->book1D("HOCenterOfEnergyRadius",
+  ib.setCurrentFolder(subdir_+"HO");
+  HOCenterOfEnergyRadius = ib.book1D("HOCenterOfEnergyRadius",
 					 "HO Center Of Energy radius",
 					 200,0,1);
-  HOCenterOfEnergy = dbe_->book2D("HOCenterOfEnergy",
+  HOCenterOfEnergy = ib.book2D("HOCenterOfEnergy",
 				   "HO Center of Energy",
 				   40,-1,1,
 				   40,-1,1);
@@ -249,16 +237,16 @@ void HcalBeamMonitor::setup()
 	  histtitle.str("");
 	  histname<<"HO_CenterOfEnergyRadius_ieta"<<i;
 	  histtitle<<"HO Center Of Energy radius ieta = "<<i;
-	  HO_CenterOfEnergyRadius[i+ETA_OFFSET_HO]=dbe_->book1D(histname.str().c_str(),
+	  HO_CenterOfEnergyRadius[i+ETA_OFFSET_HO]=ib.book1D(histname.str().c_str(),
 								 histtitle.str().c_str(),
 								 200,0,1);
 	} // end of HO loop
     }
-  dbe_->setCurrentFolder(subdir_+"HF");
-  HFCenterOfEnergyRadius = dbe_->book1D("HFCenterOfEnergyRadius",
+  ib.setCurrentFolder(subdir_+"HF");
+  HFCenterOfEnergyRadius = ib.book1D("HFCenterOfEnergyRadius",
 					 "HF Center Of Energy radius",
 					 200,0,1);
-  HFCenterOfEnergy = dbe_->book2D("HFCenterOfEnergy",
+  HFCenterOfEnergy = ib.book2D("HFCenterOfEnergy",
 				   "HF Center of Energy",
 				   40,-1,1,
 				   40,-1,1);
@@ -271,13 +259,13 @@ void HcalBeamMonitor::setup()
 	  histtitle.str("");
 	  histname<<"HF_CenterOfEnergyRadius_ieta"<<i;
 	  histtitle<<"HF Center Of Energy radius ieta = "<<i;
-	  HF_CenterOfEnergyRadius[i+ETA_OFFSET_HF]=dbe_->book1D(histname.str().c_str(),
+	  HF_CenterOfEnergyRadius[i+ETA_OFFSET_HF]=ib.book1D(histname.str().c_str(),
 								 histtitle.str().c_str(),
 								 200,0,1);
 	} // end of HF loop
     }
       
-  dbe_->setCurrentFolder(subdir_+"Lumi");
+  ib.setCurrentFolder(subdir_+"Lumi");
   // Wenhan's 
   // reducing bins from ",200,0,2000" to ",40,0,800"
       
@@ -290,55 +278,55 @@ void HcalBeamMonitor::setup()
 		     1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9,
 		     2.0, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 2.9,
 		     3.0, 3.1, 3.2, 3.3, 3.4, 3.5};
-  Etsum_eta_L=dbe_->bookProfile("Et Sum vs Eta Long Fiber","Et Sum per Area vs Eta Long Fiber",27,0,27,100,0,100);
-  Etsum_eta_S=dbe_->bookProfile("Et Sum vs Eta Short Fiber","Et Sum per Area vs Eta Short Fiber",27,0,27,100,0,100);
-  Etsum_phi_L=dbe_->bookProfile("Et Sum vs Phi Long Fiber","Et Sum per Area vs Phi Long Fiber",36,0.5,72.5,100,0,100);
-  Etsum_phi_S=dbe_->bookProfile("Et Sum vs Phi Short Fiber","Et Sum per Area crossing vs Phi Short Fiber",36,0.5,72.5,100,0,100);
+  Etsum_eta_L=ib.bookProfile("Et Sum vs Eta Long Fiber","Et Sum per Area vs Eta Long Fiber",27,0,27,100,0,100);
+  Etsum_eta_S=ib.bookProfile("Et Sum vs Eta Short Fiber","Et Sum per Area vs Eta Short Fiber",27,0,27,100,0,100);
+  Etsum_phi_L=ib.bookProfile("Et Sum vs Phi Long Fiber","Et Sum per Area vs Phi Long Fiber",36,0.5,72.5,100,0,100);
+  Etsum_phi_S=ib.bookProfile("Et Sum vs Phi Short Fiber","Et Sum per Area crossing vs Phi Short Fiber",36,0.5,72.5,100,0,100);
 
-  Etsum_ratio_p=dbe_->book1D("Occ vs PMT events HF+","Energy difference of Long and Short Fiber HF+ in PMT events",105,0.,1.05);
-  Energy_Occ=dbe_->book1D("Occ vs Energy","Occupancy vs Energy",200,0,2000);
-  Etsum_ratio_m=dbe_->book1D("Occ vs PMT events HF-","Energy difference of Long and Short Fiber HF- in PMT events",105,0.,1.05);
-  Etsum_map_L=dbe_->book2D("EtSum 2D phi and eta Long Fiber","Et Sum 2D phi and eta Long Fiber",27,0,27,36,0.5,72.5);
-  Etsum_map_S=dbe_->book2D("EtSum 2D phi and eta Short Fiber","Et Sum 2D phi and eta Short Fiber",27,0,27,36,0.5,72.5);
+  Etsum_ratio_p=ib.book1D("Occ vs PMT events HF+","Energy difference of Long and Short Fiber HF+ in PMT events",105,0.,1.05);
+  Energy_Occ=ib.book1D("Occ vs Energy","Occupancy vs Energy",200,0,2000);
+  Etsum_ratio_m=ib.book1D("Occ vs PMT events HF-","Energy difference of Long and Short Fiber HF- in PMT events",105,0.,1.05);
+  Etsum_map_L=ib.book2D("EtSum 2D phi and eta Long Fiber","Et Sum 2D phi and eta Long Fiber",27,0,27,36,0.5,72.5);
+  Etsum_map_S=ib.book2D("EtSum 2D phi and eta Short Fiber","Et Sum 2D phi and eta Short Fiber",27,0,27,36,0.5,72.5);
 
-  Etsum_rphi_S=dbe_->book2D("EtSum 2D phi and radius Short Fiber","Et Sum 2D phi and radius Short Fiber",12, radiusbins, 70, phibins);
-  Etsum_rphi_L=dbe_->book2D("EtSum 2D phi and radius Long Fiber","Et Sum 2D phi and radius Long Fiber",12, radiusbins, 70, phibins);
+  Etsum_rphi_S=ib.book2D("EtSum 2D phi and radius Short Fiber","Et Sum 2D phi and radius Short Fiber",12, radiusbins, 70, phibins);
+  Etsum_rphi_L=ib.book2D("EtSum 2D phi and radius Long Fiber","Et Sum 2D phi and radius Long Fiber",12, radiusbins, 70, phibins);
 
-  Etsum_ratio_map=dbe_->book2D("Abnormal PMT events","Abnormal PMT events",
+  Etsum_ratio_map=ib.book2D("Abnormal PMT events","Abnormal PMT events",
 				8,0,8,36, 0.5,72.5);
   SetEtaLabels(Etsum_ratio_map);
 
-  HFlumi_occ_LS = dbe_->book2D("HFlumi_occ_LS","HFlumi occupancy for current LS",
+  HFlumi_occ_LS = ib.book2D("HFlumi_occ_LS","HFlumi occupancy for current LS",
 				8,0,8,36, 0.5,72.5);
   SetEtaLabels(HFlumi_occ_LS);
       
-  HFlumi_total_deadcells = dbe_->book2D("HFlumi_total_deadcells","Number of dead lumi channels for LS with at least 10 bad channels",
+  HFlumi_total_deadcells = ib.book2D("HFlumi_total_deadcells","Number of dead lumi channels for LS with at least 10 bad channels",
 					 8,0,8,36,0.5,72.5);
   SetEtaLabels(HFlumi_total_deadcells);
-  HFlumi_total_hotcells = dbe_->book2D("HFlumi_total_hotcells","Number of hot lumi channels for LS with at least 10 bad channels",
+  HFlumi_total_hotcells = ib.book2D("HFlumi_total_hotcells","Number of hot lumi channels for LS with at least 10 bad channels",
 					8,0,8,36,0.5,72.5);
   SetEtaLabels(HFlumi_total_hotcells);
 
-  HFlumi_diag_deadcells = dbe_->book2D("HFlumi_diag_deadcells","Channels that had no hit for at least one LS",
+  HFlumi_diag_deadcells = ib.book2D("HFlumi_diag_deadcells","Channels that had no hit for at least one LS",
 				       8,0,8,36,0.5,72.5);
   SetEtaLabels(HFlumi_diag_deadcells);
-  HFlumi_diag_hotcells = dbe_->book2D("HFlumi_diag_hotcells","Channels that appeared hot for at least one LS",
+  HFlumi_diag_hotcells = ib.book2D("HFlumi_diag_hotcells","Channels that appeared hot for at least one LS",
 				      8,0,8,36,0.5,72.5);
   SetEtaLabels(HFlumi_diag_hotcells);
 
 
 
-  Occ_rphi_S=dbe_->book2D("Occ 2D phi and radius Short Fiber","Occupancy 2D phi and radius Short Fiber",12, radiusbins, 70, phibins);
-  Occ_rphi_L=dbe_->book2D("Occ 2D phi and radius Long Fiber","Occupancy 2D phi and radius Long Fiber",12, radiusbins, 70, phibins);
-  Occ_eta_S=dbe_->bookProfile("Occ vs iEta Short Fiber","Occ per Bunch crossing vs iEta Short Fiber",27,0,27,40,0,800);
-  Occ_eta_L=dbe_->bookProfile("Occ vs iEta Long Fiber","Occ per Bunch crossing vs iEta Long Fiber",27,0,27,40,0,800);
+  Occ_rphi_S=ib.book2D("Occ 2D phi and radius Short Fiber","Occupancy 2D phi and radius Short Fiber",12, radiusbins, 70, phibins);
+  Occ_rphi_L=ib.book2D("Occ 2D phi and radius Long Fiber","Occupancy 2D phi and radius Long Fiber",12, radiusbins, 70, phibins);
+  Occ_eta_S=ib.bookProfile("Occ vs iEta Short Fiber","Occ per Bunch crossing vs iEta Short Fiber",27,0,27,40,0,800);
+  Occ_eta_L=ib.bookProfile("Occ vs iEta Long Fiber","Occ per Bunch crossing vs iEta Long Fiber",27,0,27,40,0,800);
       
-  Occ_phi_L=dbe_->bookProfile("Occ vs iPhi Long Fiber","Occ per Bunch crossing vs iPhi Long Fiber",36,0.5,72.5,40,0,800);
+  Occ_phi_L=ib.bookProfile("Occ vs iPhi Long Fiber","Occ per Bunch crossing vs iPhi Long Fiber",36,0.5,72.5,40,0,800);
       
-  Occ_phi_S=dbe_->bookProfile("Occ vs iPhi Short Fiber","Occ per Bunch crossing vs iPhi Short Fiber",36,0.5,72.5,40,0,800);
+  Occ_phi_S=ib.bookProfile("Occ vs iPhi Short Fiber","Occ per Bunch crossing vs iPhi Short Fiber",36,0.5,72.5,40,0,800);
       
-  Occ_map_L=dbe_->book2D("Occ_map Long Fiber","Occ Map long Fiber (above threshold)",27,0,27,36,0.5,72.5);
-  Occ_map_S=dbe_->book2D("Occ_map Short Fiber","Occ Map Short Fiber (above threshold)",27,0,27,36,0.5,72.5);
+  Occ_map_L=ib.book2D("Occ_map Long Fiber","Occ Map long Fiber (above threshold)",27,0,27,36,0.5,72.5);
+  Occ_map_S=ib.book2D("Occ_map Short Fiber","Occ Map Short Fiber (above threshold)",27,0,27,36,0.5,72.5);
 
   std::stringstream binlabel;
   for (int zz=0;zz<27;++zz)
@@ -361,15 +349,15 @@ void HcalBeamMonitor::setup()
     }
 
   //HFlumi plots
-  HFlumi_ETsum_perwedge =  dbe_->book1D("HF lumi ET-sum per wedge","HF lumi ET-sum per wedge;wedge",36,1,37);
+  HFlumi_ETsum_perwedge =  ib.book1D("HF lumi ET-sum per wedge","HF lumi ET-sum per wedge;wedge",36,1,37);
   HFlumi_ETsum_perwedge->getTH1F()->SetMinimum(0); 
       
-  HFlumi_Occupancy_above_thr_r1 =  dbe_->book1D("HF lumi Occupancy above threshold ring1","HF lumi Occupancy above threshold ring1;wedge",36,1,37);
-  HFlumi_Occupancy_between_thrs_r1 = dbe_->book1D("HF lumi Occupancy between thresholds ring1","HF lumi Occupancy between thresholds ring1;wedge",36,1,37);
-  HFlumi_Occupancy_below_thr_r1 = dbe_->book1D("HF lumi Occupancy below threshold ring1","HF lumi Occupancy below threshold ring1;wedge",36,1,37);
-  HFlumi_Occupancy_above_thr_r2 = dbe_->book1D("HF lumi Occupancy above threshold ring2","HF lumi Occupancy above threshold ring2;wedge",36,1,37);
-  HFlumi_Occupancy_between_thrs_r2 = dbe_->book1D("HF lumi Occupancy between thresholds ring2","HF lumi Occupancy between thresholds ring2;wedge",36,1,37);
-  HFlumi_Occupancy_below_thr_r2 = dbe_->book1D("HF lumi Occupancy below threshold ring2","HF lumi Occupancy below threshold ring2;wedge",36,1,37);
+  HFlumi_Occupancy_above_thr_r1 =  ib.book1D("HF lumi Occupancy above threshold ring1","HF lumi Occupancy above threshold ring1;wedge",36,1,37);
+  HFlumi_Occupancy_between_thrs_r1 = ib.book1D("HF lumi Occupancy between thresholds ring1","HF lumi Occupancy between thresholds ring1;wedge",36,1,37);
+  HFlumi_Occupancy_below_thr_r1 = ib.book1D("HF lumi Occupancy below threshold ring1","HF lumi Occupancy below threshold ring1;wedge",36,1,37);
+  HFlumi_Occupancy_above_thr_r2 = ib.book1D("HF lumi Occupancy above threshold ring2","HF lumi Occupancy above threshold ring2;wedge",36,1,37);
+  HFlumi_Occupancy_between_thrs_r2 = ib.book1D("HF lumi Occupancy between thresholds ring2","HF lumi Occupancy between thresholds ring2;wedge",36,1,37);
+  HFlumi_Occupancy_below_thr_r2 = ib.book1D("HF lumi Occupancy below threshold ring2","HF lumi Occupancy below threshold ring2;wedge",36,1,37);
 
   HFlumi_Occupancy_above_thr_r1->getTH1F()->SetMinimum(0);
   HFlumi_Occupancy_between_thrs_r1->getTH1F()->SetMinimum(0);
@@ -378,35 +366,35 @@ void HcalBeamMonitor::setup()
   HFlumi_Occupancy_between_thrs_r2->getTH1F()->SetMinimum(0);
   HFlumi_Occupancy_below_thr_r2->getTH1F()->SetMinimum(0);
  
-  HFlumi_Occupancy_per_channel_vs_lumiblock_RING1 = dbe_->bookProfile("HFlumiRing1OccupancyPerChannelVsLB",
+  HFlumi_Occupancy_per_channel_vs_lumiblock_RING1 = ib.bookProfile("HFlumiRing1OccupancyPerChannelVsLB",
 								      "HFlumi Occupancy per channel vs lumi-block (RING 1);LS; -ln(empty fraction)",
 								      NLumiBlocks_,0.5,NLumiBlocks_+0.5,100,0,10000);
-  HFlumi_Occupancy_per_channel_vs_lumiblock_RING2 = dbe_->bookProfile("HFlumiRing2OccupancyPerChannelVsLB","HFlumi Occupancy per channel vs lumi-block (RING 2);LS; -ln(empty fraction)",NLumiBlocks_,0.5,NLumiBlocks_+0.5,100,0,10000);
+  HFlumi_Occupancy_per_channel_vs_lumiblock_RING2 = ib.bookProfile("HFlumiRing2OccupancyPerChannelVsLB","HFlumi Occupancy per channel vs lumi-block (RING 2);LS; -ln(empty fraction)",NLumiBlocks_,0.5,NLumiBlocks_+0.5,100,0,10000);
 
-  HFlumi_Occupancy_per_channel_vs_BX_RING1 = dbe_->bookProfile("HFlumi Occupancy per channel vs BX (RING 1)","HFlumi Occupancy per channel vs BX (RING 1);BX; -ln(empty fraction)",4000,0,4000,100,0,10000);
-  HFlumi_Occupancy_per_channel_vs_BX_RING2 = dbe_->bookProfile("HFlumi Occupancy per channel vs BX (RING 2)","HFlumi Occupancy per channel vs BX (RING 2);BX; -ln(empty fraction)",4000,0,4000,100,0,10000);
-  HFlumi_ETsum_vs_BX = dbe_->bookProfile("HFlumi_ETsum_vs_BX","HFlumi ETsum vs BX; BX; ETsum",4000,0,4000,100,0,10000);
+  HFlumi_Occupancy_per_channel_vs_BX_RING1 = ib.bookProfile("HFlumi Occupancy per channel vs BX (RING 1)","HFlumi Occupancy per channel vs BX (RING 1);BX; -ln(empty fraction)",4000,0,4000,100,0,10000);
+  HFlumi_Occupancy_per_channel_vs_BX_RING2 = ib.bookProfile("HFlumi Occupancy per channel vs BX (RING 2)","HFlumi Occupancy per channel vs BX (RING 2);BX; -ln(empty fraction)",4000,0,4000,100,0,10000);
+  HFlumi_ETsum_vs_BX = ib.bookProfile("HFlumi_ETsum_vs_BX","HFlumi ETsum vs BX; BX; ETsum",4000,0,4000,100,0,10000);
 
-  HFlumi_Et_per_channel_vs_lumiblock = dbe_->bookProfile("HFlumi Et per channel vs lumi-block","HFlumi Et per channel vs lumi-block;LS;ET",NLumiBlocks_,0.5,NLumiBlocks_+0.5,100,0,10000);
+  HFlumi_Et_per_channel_vs_lumiblock = ib.bookProfile("HFlumi Et per channel vs lumi-block","HFlumi Et per channel vs lumi-block;LS;ET",NLumiBlocks_,0.5,NLumiBlocks_+0.5,100,0,10000);
 
   HFlumi_Occupancy_per_channel_vs_lumiblock_RING1->getTProfile()->SetMarkerStyle(20);
   HFlumi_Occupancy_per_channel_vs_lumiblock_RING2->getTProfile()->SetMarkerStyle(20);
   HFlumi_Et_per_channel_vs_lumiblock->getTProfile()->SetMarkerStyle(20);
 
-  HFlumi_Ring1Status_vs_LS = dbe_->bookProfile("HFlumi_Ring1Status_vs_LS","Fraction of good Ring 1 channels vs LS;LS; Fraction of Good Channels",NLumiBlocks_,0.5,NLumiBlocks_+0.5,100,0,10000);
-  HFlumi_Ring2Status_vs_LS = dbe_->bookProfile("HFlumi_Ring2Status_vs_LS","Fraction of good Ring 2 channels vs LS;LS; Fraction of Good Channels",NLumiBlocks_,0.5,NLumiBlocks_+0.5,100,0,10000);
+  HFlumi_Ring1Status_vs_LS = ib.bookProfile("HFlumi_Ring1Status_vs_LS","Fraction of good Ring 1 channels vs LS;LS; Fraction of Good Channels",NLumiBlocks_,0.5,NLumiBlocks_+0.5,100,0,10000);
+  HFlumi_Ring2Status_vs_LS = ib.bookProfile("HFlumi_Ring2Status_vs_LS","Fraction of good Ring 2 channels vs LS;LS; Fraction of Good Channels",NLumiBlocks_,0.5,NLumiBlocks_+0.5,100,0,10000);
   HFlumi_Ring1Status_vs_LS->getTProfile()->SetMarkerStyle(20);
   HFlumi_Ring2Status_vs_LS->getTProfile()->SetMarkerStyle(20);
 
   return;
 }
 
-void HcalBeamMonitor::beginRun(const edm::Run& run, const edm::EventSetup& c)
+void HcalBeamMonitor::bookHistograms(DQMStore::IBooker &ib, const edm::Run& run, const edm::EventSetup& c)
 {
-  HcalBaseDQMonitor::beginRun(run,c);  
+  HcalBaseDQMonitor::bookHistograms(ib,run,c);  
 
-  if (debug_>1) std::cout <<"HcalBeamMonitor::beginRun"<<std::endl;
-  HcalBaseDQMonitor::beginRun(run,c);
+  if (debug_>1) std::cout <<"HcalBeamMonitor::bookHistograms"<<std::endl;
+  HcalBaseDQMonitor::bookHistograms(ib,run,c);
 
   lastProcessedLS_=0;
   runNumber_=run.id().run();
@@ -462,12 +450,12 @@ void HcalBeamMonitor::beginRun(const edm::Run& run, const edm::EventSetup& c)
 	} // if ((id.depth()==1) ...
     } // for (unsigned int i=0;...)
     
-  if (tevt_==0) this->setup(); // create all histograms; not necessary if merging runs together
+  if (tevt_==0) this->setup(ib); // create all histograms; not necessary if merging runs together
   if (mergeRuns_==false) this->reset(); // call reset at start of all runs
 
   return;
 
-} // void HcalBeamMonitor::beginRun(const edm::Run& run, const edm::EventSetup& c)
+} // void HcalBeamMonitor::bookHistograms(const edm::Run& run, const edm::EventSetup& c)
 
 
 void HcalBeamMonitor::analyze(const edm::Event& e, const edm::EventSetup& c)
@@ -521,12 +509,6 @@ void HcalBeamMonitor::processEvent(const HBHERecHitCollection& hbheHits,
   
 { 
   //processEvent loop
-  if (!dbe_)
-    {
-      if (debug_>0) std::cout <<"HcalBeamMonitor::processEvent   DQMStore not instantiated!!!"<<std::endl;
-      return;
-    }
-
   HBHERecHitCollection::const_iterator HBHEiter;
   HORecHitCollection::const_iterator HOiter;
   HFRecHitCollection::const_iterator HFiter;

--- a/DQM/HcalMonitorTasks/src/HcalCoarsePedestalMonitor.cc
+++ b/DQM/HcalMonitorTasks/src/HcalCoarsePedestalMonitor.cc
@@ -11,7 +11,7 @@
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 
 // constructor
-HcalCoarsePedestalMonitor::HcalCoarsePedestalMonitor(const edm::ParameterSet& ps) 
+HcalCoarsePedestalMonitor::HcalCoarsePedestalMonitor(const edm::ParameterSet& ps) : HcalBaseDQMonitor(ps)
 {
   Online_                = ps.getUntrackedParameter<bool>("online",false);
   mergeRuns_             = ps.getUntrackedParameter<bool>("mergeRuns",false);

--- a/DQM/HcalMonitorTasks/src/HcalCoarsePedestalMonitor.cc
+++ b/DQM/HcalMonitorTasks/src/HcalCoarsePedestalMonitor.cc
@@ -45,26 +45,6 @@ HcalCoarsePedestalMonitor::HcalCoarsePedestalMonitor(const edm::ParameterSet& ps
 HcalCoarsePedestalMonitor::~HcalCoarsePedestalMonitor() {}
 
 
-
-void HcalCoarsePedestalMonitor::cleanup()
-{
-  // Need to add code to clear out subfolders as well?
-  if (debug_>0) std::cout <<"HcalCoarsePedestalMonitor::cleanup()"<<std::endl;
-  if (!enableCleanup_) return;
-  if (dbe_)
-    {
-      // removeContents doesn't remove subdirectories
-      dbe_->setCurrentFolder(subdir_);
-      dbe_->removeContents();
-      dbe_->setCurrentFolder(subdir_+"CoarsePedestal_parameters");
-      dbe_->removeContents();
-      dbe_->setCurrentFolder(subdir_+"LSvalues");
-      dbe_->removeContents();
-    } // if(dbe_)
-
-} // void HcalCoarsePedestalMonitor::cleanup();
-
-
 void HcalCoarsePedestalMonitor::endRun(const edm::Run& run, const edm::EventSetup& c)
 {
   // Anything to do here?
@@ -77,32 +57,31 @@ void HcalCoarsePedestalMonitor::endJob()
 }
 
 
-void HcalCoarsePedestalMonitor::setup()
+void HcalCoarsePedestalMonitor::setup(DQMStore::IBooker &ib)
 {
   // Call base class setup
-  HcalBaseDQMonitor::setup();
-  if (!dbe_) return;
+  HcalBaseDQMonitor::setup(ib);
 
   /******* Set up all histograms  ********/
   if (debug_>1)
-    std::cout <<"<HcalCoarsePedestalMonitor::beginRun>  Setting up histograms"<<std::endl;
+    std::cout <<"<HcalCoarsePedestalMonitor::setup>  Setting up histograms"<<std::endl;
 
   std::ostringstream name;
-  dbe_->setCurrentFolder(subdir_ +"CoarsePedestalSumPlots");
-  SetupEtaPhiHists(CoarsePedestalsSumByDepth,"Coarse Pedestal Summed Map","");
-  SetupEtaPhiHists(CoarsePedestalsOccByDepth,"Coarse Pedestal Occupancy Map","");
+  ib.setCurrentFolder(subdir_ +"CoarsePedestalSumPlots");
+  SetupEtaPhiHists(ib,CoarsePedestalsSumByDepth,"Coarse Pedestal Summed Map","");
+  SetupEtaPhiHists(ib,CoarsePedestalsOccByDepth,"Coarse Pedestal Occupancy Map","");
   for (unsigned int i=0;i<CoarsePedestalsSumByDepth.depth.size();++i)
     (CoarsePedestalsSumByDepth.depth[i]->getTH2F())->SetOption("colz");
   for (unsigned int i=0;i<CoarsePedestalsOccByDepth.depth.size();++i)
     (CoarsePedestalsOccByDepth.depth[i]->getTH2F())->SetOption("colz");
 
 
-  dbe_->setCurrentFolder(subdir_+"CoarsePedestal_parameters");
-  MonitorElement* ADCDiffThresh = dbe_->bookFloat("ADCdiff_Problem_Threshold");
+  ib.setCurrentFolder(subdir_+"CoarsePedestal_parameters");
+  MonitorElement* ADCDiffThresh = ib.bookFloat("ADCdiff_Problem_Threshold");
   ADCDiffThresh->Fill(ADCDiffThresh_);
-  MonitorElement* minevents = dbe_->bookInt("minEventsNeededForPedestalCalculation");
+  MonitorElement* minevents = ib.bookInt("minEventsNeededForPedestalCalculation");
   minevents->Fill(minEvents_);
-  MonitorElement* excludeHORing2 = dbe_->bookInt("excludeHORing2");
+  MonitorElement* excludeHORing2 = ib.bookInt("excludeHORing2");
   if (excludeHORing2_==true)
     excludeHORing2->Fill(1);
   else
@@ -112,14 +91,14 @@ void HcalCoarsePedestalMonitor::setup()
   return;
 } // void HcalCoarsePedestalMonitor::setup()
 
-void HcalCoarsePedestalMonitor::beginRun(const edm::Run& run, const edm::EventSetup& c)
+void HcalCoarsePedestalMonitor::bookHistograms(DQMStore::IBooker &ib, const edm::Run& run, const edm::EventSetup& c)
 {
-  HcalBaseDQMonitor::beginRun(run,c);
+  HcalBaseDQMonitor::bookHistograms(ib,run,c);
   if (mergeRuns_ && tevt_>0) return; // don't reset counters if merging runs
 
-  if (tevt_==0) this->setup(); // create all histograms; not necessary if merging runs together
+  if (tevt_==0) this->setup(ib); // create all histograms; not necessary if merging runs together
   if (mergeRuns_==false) this->reset(); // call reset at start of all runs
-} // void HcalCoarsePedestalMonitor::beginRun()
+} // void HcalCoarsePedestalMonitor::bookHistograms()
 
 
 void HcalCoarsePedestalMonitor::analyze(edm::Event const&e, edm::EventSetup const&s)
@@ -172,13 +151,6 @@ void HcalCoarsePedestalMonitor::processEvent(const HBHEDigiCollection& hbhe,
 					     const HFDigiCollection& hf,
 					     const HcalUnpackerReport& report)
 { 
-  if(!dbe_) 
-    { 
-      if(debug_) 
-	std::cout <<"HcalCoarsePedestalMonitor::processEvent   DQMStore not instantiated!!!"<<std::endl; 
-      return; 
-    }
-
   // Skip events in which minimal good digis found -- still getting some strange (calib?) events through DQM
   
   unsigned int allgooddigis= hbhe.size()+ho.size()+hf.size();

--- a/DQM/HcalMonitorTasks/src/HcalDataIntegrityTask.cc
+++ b/DQM/HcalMonitorTasks/src/HcalDataIntegrityTask.cc
@@ -5,7 +5,7 @@
 #include "DataFormats/FEDRawData/interface/FEDTrailer.h"
 #include <iostream>
 
-HcalDataIntegrityTask::HcalDataIntegrityTask(const edm::ParameterSet& ps) 
+HcalDataIntegrityTask::HcalDataIntegrityTask(const edm::ParameterSet& ps) :HcalBaseDQMonitor(ps)
 {
 
   Online_                = ps.getUntrackedParameter<bool>("online",false);

--- a/DQM/HcalMonitorTasks/src/HcalDataIntegrityTask.cc
+++ b/DQM/HcalMonitorTasks/src/HcalDataIntegrityTask.cc
@@ -47,23 +47,13 @@ void HcalDataIntegrityTask::reset()
 
 }
 
-void HcalDataIntegrityTask::cleanup()
-{
-  if(dbe_)
-    {
-      dbe_->setCurrentFolder(subdir_);
-      dbe_->removeContents();
-    }
 
-} // void HcalDataIntegrityTask::cleanup()
-
-
-void HcalDataIntegrityTask::beginRun(const edm::Run& run, const edm::EventSetup& c)
+void HcalDataIntegrityTask::bookHistograms(DQMStore::IBooker &ib, const edm::Run& run, const edm::EventSetup& c)
 {
 
-  if (debug_>0) std::cout <<"HcalDataIntegrityTask::beginRun():  task =  '"<<subdir_<<"'"<<std::endl;
+  if (debug_>0) std::cout <<"HcalDataIntegrityTask::bookHistograms():  task =  '"<<subdir_<<"'"<<std::endl;
 
-  HcalBaseDQMonitor::beginRun(run, c);
+  HcalBaseDQMonitor::bookHistograms(ib,run, c);
   if (mergeRuns_ && tevt_>0) return;
 
   if (debug_>1)  std::cout<<"\t<HcalDataIntegrityTask::getting eMap..."<<std::endl;
@@ -72,18 +62,18 @@ void HcalDataIntegrityTask::beginRun(const edm::Run& run, const edm::EventSetup&
   readoutMap_=pSetup->getHcalMapping();
 
   if (tevt_==0) // create histograms, if they haven't been created already
-    this->setup();
+    this->setup(ib);
   // Clear histograms at the start of each run if not merging runs
   if (mergeRuns_==false)
   this->reset();
 
-} // beginRun(const edm::Run& run, const edm::EventSetup& c)
+} // bookHistograms(const edm::Run& run, const edm::EventSetup& c)
 
 
-void HcalDataIntegrityTask::setup()
+void HcalDataIntegrityTask::setup(DQMStore::IBooker &ib)
 {
   // Setup Creates all necessary histograms
-  HcalBaseDQMonitor::setup();
+  HcalBaseDQMonitor::setup(ib);
   
   //Initialize phatmap to a vector of vectors of uint64_t 0
   static size_t iphirange = IPHIMAX - IPHIMIN;
@@ -133,18 +123,14 @@ void HcalDataIntegrityTask::setup()
       fedUnpackList_.push_back(i);
     }
 
-  if ( dbe_ ) 
-    {
-      
       if (debug_>1)
 	std::cout <<"\t<HcalDataIntegrityTask> Setting folder to "<<subdir_<<std::endl;
 
-      dbe_->setCurrentFolder(subdir_);
+      ib.setCurrentFolder(subdir_);
       
-      fedEntries_ = dbe_->book1D("FEDEntries","# entries per HCAL FED",32,700,732);
-      fedFatal_ = dbe_->book1D("FEDFatal","# fatal errors HCAL FED",32,700,732);
-      fedNonFatal_ = dbe_->book1D("FEDNonFatal","# non-fatal errors HCAL FED",32,700,732);
-    } // if (dbe_)
+      fedEntries_ = ib.book1D("FEDEntries","# entries per HCAL FED",32,700,732);
+      fedFatal_ = ib.book1D("FEDFatal","# fatal errors HCAL FED",32,700,732);
+      fedNonFatal_ = ib.book1D("FEDNonFatal","# non-fatal errors HCAL FED",32,700,732);
 
   this->reset(); // clear all histograms at start
   return;
@@ -184,12 +170,6 @@ void HcalDataIntegrityTask::processEvent(const FEDRawDataCollection& rawraw,
 					 const HcalUnpackerReport& report, 
 					 const HcalElectronicsMap& emap){
   
-  if(!dbe_) 
-    { 
-      std::cout<<"HcalDataIntegrityTask::processEvent DQMStore not instantiated!!!"<<std::endl;  
-      return;
-    }
-
   // Loop over all FEDs reporting the event, unpacking if good.
   for (std::vector<int>::const_iterator i=fedUnpackList_.begin();i!=fedUnpackList_.end(); i++) 
     {

--- a/DQM/HcalMonitorTasks/src/HcalDeadCellMonitor.cc
+++ b/DQM/HcalMonitorTasks/src/HcalDeadCellMonitor.cc
@@ -2,7 +2,7 @@
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "CondFormats/HcalObjects/interface/HcalLogicalMap.h"
 
-HcalDeadCellMonitor::HcalDeadCellMonitor(const edm::ParameterSet& ps)
+HcalDeadCellMonitor::HcalDeadCellMonitor(const edm::ParameterSet& ps):HcalBaseDQMonitor(ps)
 {
   Online_                = ps.getUntrackedParameter<bool>("online",false);
   mergeRuns_             = ps.getUntrackedParameter<bool>("mergeRuns",false);

--- a/DQM/HcalMonitorTasks/src/HcalDeadCellMonitor.cc
+++ b/DQM/HcalMonitorTasks/src/HcalDeadCellMonitor.cc
@@ -82,7 +82,7 @@ HcalDeadCellMonitor::~HcalDeadCellMonitor()
 
 /* ------------------------------------ */ 
 
-void HcalDeadCellMonitor::setup()
+void HcalDeadCellMonitor::setup(DQMStore::IBooker &ib)
 {
   if (setupDone_)
   {
@@ -96,42 +96,40 @@ void HcalDeadCellMonitor::setup()
   else
     setupDone_=true;
   
-  HcalBaseDQMonitor::setup();
+  HcalBaseDQMonitor::setup(ib);
   if (debug_>0)
     std::cout <<"<HcalDeadCellMonitor::setup>  Setting up histograms"<<std::endl;
 
-  if (!dbe_) return;
-
-  dbe_->setCurrentFolder(subdir_);
-  MonitorElement* excludeHO2=dbe_->bookInt("ExcludeHOring2");
+  ib.setCurrentFolder(subdir_);
+  MonitorElement* excludeHO2=ib.bookInt("ExcludeHOring2");
   // Fill with 0 if ring is not to be excluded; fill with 1 if it is to be excluded
   if (excludeHO2) excludeHO2->Fill(excludeHORing2_==true ? 1 : 0);
 
-  Nevents = dbe_->book1D("NumberOfDeadCellEvents","Number of Events Seen by DeadCellMonitor",2,0,2);
+  Nevents = ib.book1D("NumberOfDeadCellEvents","Number of Events Seen by DeadCellMonitor",2,0,2);
   Nevents->setBinLabel(1,"allEvents");
   Nevents->setBinLabel(2,"lumiCheck");
  // 1D plots count number of bad cells vs. luminosity block
-  ProblemsVsLB=dbe_->bookProfile("TotalDeadCells_HCAL_vs_LS",
+  ProblemsVsLB=ib.bookProfile("TotalDeadCells_HCAL_vs_LS",
 				  "Total Number of Dead Hcal Cells (excluding known problems) vs LS;Lumi Section;Dead Cells", 
 				  NLumiBlocks_,0.5,NLumiBlocks_+0.5,
 				  100,0,10000);
-  ProblemsVsLB_HB=dbe_->bookProfile("TotalDeadCells_HB_vs_LS",
+  ProblemsVsLB_HB=ib.bookProfile("TotalDeadCells_HB_vs_LS",
 				     "Total Number of Dead HB Cells (excluding known problems) vs LS;Lumi Section;Dead Cells",
 				     NLumiBlocks_,0.5,NLumiBlocks_+0.5,
 				     100,0,10000);
-  ProblemsVsLB_HE=dbe_->bookProfile("TotalDeadCells_HE_vs_LS",
+  ProblemsVsLB_HE=ib.bookProfile("TotalDeadCells_HE_vs_LS",
 				     "Total Number of Dead HE Cells (excluding known problems) vs LS;Lumi Section;Dead Cells",
 				     NLumiBlocks_,0.5,NLumiBlocks_+0.5,100,0,10000);
-  ProblemsVsLB_HO=dbe_->bookProfile("TotalDeadCells_HO_vs_LS",
+  ProblemsVsLB_HO=ib.bookProfile("TotalDeadCells_HO_vs_LS",
 				      "Total Number of Dead HO Cells Ring 0,1 |ieta|<=10 (excluding known problems) vs LS;Lumi Section;Dead Cells",
 				      NLumiBlocks_,0.5,NLumiBlocks_+0.5,100,0,10000);
-  ProblemsVsLB_HO2=dbe_->bookProfile("TotalDeadCells_HO2_vs_LS",
+  ProblemsVsLB_HO2=ib.bookProfile("TotalDeadCells_HO2_vs_LS",
 				     "Total Number of Dead HO Cells Ring 2 |ieta|>10 (excluding known problems) vs LS;Lumi Section;Dead Cells",
 				     NLumiBlocks_,0.5,NLumiBlocks_+0.5,100,0,10000);
-  ProblemsVsLB_HF=dbe_->bookProfile("TotalDeadCells_HF_vs_LS",
+  ProblemsVsLB_HF=ib.bookProfile("TotalDeadCells_HF_vs_LS",
 				     "Total Number of Dead HF Cells (excluding known problems) vs LS;Lumi Section;Dead Cells",
 				     NLumiBlocks_,0.5,NLumiBlocks_+0.5,100,0,10000);
-  ProblemsVsLB_HBHEHF=dbe_->bookProfile("TotalDeadCells_HBHEHF_vs_LS",
+  ProblemsVsLB_HBHEHF=ib.bookProfile("TotalDeadCells_HBHEHF_vs_LS",
 				     "Total Number of Dead HBHEHF Cells (excluding known problems) vs LS;Lumi Section;Dead Cells",
 				     NLumiBlocks_,0.5,NLumiBlocks_+0.5,100,0,10000);
   
@@ -143,39 +141,39 @@ void HcalDeadCellMonitor::setup()
   (ProblemsVsLB_HF->getTProfile())->SetMarkerStyle(20);
   (ProblemsVsLB_HBHEHF->getTProfile())->SetMarkerStyle(20);
 
-  RBX_loss_VS_LB=dbe_->book2D("RBX_loss_VS_LB",
+  RBX_loss_VS_LB=ib.book2D("RBX_loss_VS_LB",
 			      "RBX loss vs LS; Lumi Section; Index of lost RBX", 
 			      NLumiBlocks_,0.5,NLumiBlocks_+0.5,156,0,156);
 
-  ProblemsInLastNLB_HBHEHF_alarm=dbe_->book1D("ProblemsInLastNLB_HBHEHF_alarm",
+  ProblemsInLastNLB_HBHEHF_alarm=ib.book1D("ProblemsInLastNLB_HBHEHF_alarm",
 					      "Total Number of Dead HBHEHF Cells in last 10 LS. Last bin contains OverFlow",
 					      100,0,100);
-  ProblemsInLastNLB_HO01_alarm=dbe_->book1D("ProblemsInLastNLB_HO01_alarm",
+  ProblemsInLastNLB_HO01_alarm=ib.book1D("ProblemsInLastNLB_HO01_alarm",
 					    "Total Number of Dead Cells Ring 0,1 (abs(ieta)<=10) in last 10 LS. Last bin contains OverFlow",
 					    100,0,100);
 
 
-  dbe_->setCurrentFolder(subdir_+"dead_cell_parameters");
-  MonitorElement* me=dbe_->bookInt("Test_NeverPresent_Digis");
+  ib.setCurrentFolder(subdir_+"dead_cell_parameters");
+  MonitorElement* me=ib.bookInt("Test_NeverPresent_Digis");
   me->Fill(1);
-  me=dbe_->bookInt("Test_DigiMissing_Periodic_Lumi_Check");
+  me=ib.bookInt("Test_DigiMissing_Periodic_Lumi_Check");
   if (deadmon_test_digis_)
     me->Fill(1);
   else 
     me->Fill(0);
-  me=dbe_->bookInt("Min_Events_Required_Periodic_Lumi_Check");
+  me=ib.bookInt("Min_Events_Required_Periodic_Lumi_Check");
   me->Fill(minDeadEventCount_);
-  me=dbe_->bookInt("Test_NeverPresent_RecHits");
+  me=ib.bookInt("Test_NeverPresent_RecHits");
   deadmon_test_rechits_>0 ? me->Fill(1) : me->Fill(0);
-  me=dbe_->bookFloat("HBMinimumRecHitEnergy");
+  me=ib.bookFloat("HBMinimumRecHitEnergy");
   me->Fill(HBenergyThreshold_);
-  me=dbe_->bookFloat("HEMinimumRecHitEnergy");
+  me=ib.bookFloat("HEMinimumRecHitEnergy");
   me->Fill(HEenergyThreshold_);
-  me=dbe_->bookFloat("HOMinimumRecHitEnergy");
+  me=ib.bookFloat("HOMinimumRecHitEnergy");
   me->Fill(HOenergyThreshold_);
-  me=dbe_->bookFloat("HFMinimumRecHitEnergy");
+  me=ib.bookFloat("HFMinimumRecHitEnergy");
   me->Fill(HFenergyThreshold_);
-  me=dbe_->bookInt("Test_RecHitsMissing_Periodic_Lumi_Check");
+  me=ib.bookInt("Test_RecHitsMissing_Periodic_Lumi_Check");
   deadmon_test_rechits_>0 ? me->Fill(1) : me->Fill(0);
 
   // ProblemCells plots are in HcalDeadCellClient!
@@ -186,27 +184,27 @@ void HcalDeadCellMonitor::setup()
 
   // Never-present test will always be called, by definition of dead cell
 
-  dbe_->setCurrentFolder(subdir_+"dead_digi_never_present");
-  SetupEtaPhiHists(DigiPresentByDepth,
+  ib.setCurrentFolder(subdir_+"dead_digi_never_present");
+  SetupEtaPhiHists(ib,DigiPresentByDepth,
 		   "Digi Present At Least Once","");
   // 1D plots count number of bad cells
-  NumberOfNeverPresentDigis=dbe_->bookProfile("Problem_NeverPresentDigis_HCAL_vs_LS",
+  NumberOfNeverPresentDigis=ib.bookProfile("Problem_NeverPresentDigis_HCAL_vs_LS",
 					       "Total Number of Never-Present Hcal Cells vs LS;Lumi Section;Dead Cells",
 					       NLumiBlocks_,0.5,NLumiBlocks_+0.5,100,0,10000);
       
-  NumberOfNeverPresentDigisHB=dbe_->bookProfile("Problem_NeverPresentDigis_HB_vs_LS",
+  NumberOfNeverPresentDigisHB=ib.bookProfile("Problem_NeverPresentDigis_HB_vs_LS",
 						 "Total Number of Never-Present HB Cells vs LS;Lumi Section;Dead Cells",
 						 NLumiBlocks_,0.5,NLumiBlocks_+0.5,100,0,10000);
       
-  NumberOfNeverPresentDigisHE=dbe_->bookProfile("Problem_NeverPresentDigis_HE_vs_LS",
+  NumberOfNeverPresentDigisHE=ib.bookProfile("Problem_NeverPresentDigis_HE_vs_LS",
 						 "Total Number of Never-Present HE Cells vs LS;Lumi Section;Dead Cells",
 						 NLumiBlocks_,0.5,NLumiBlocks_+0.5,100,0,10000);
       
-  NumberOfNeverPresentDigisHO=dbe_->bookProfile("Problem_NeverPresentDigis_HO_vs_LS",
+  NumberOfNeverPresentDigisHO=ib.bookProfile("Problem_NeverPresentDigis_HO_vs_LS",
 						 "Total Number of Never-Present HO Cells vs LS;Lumi Section;Dead Cells",
 						 NLumiBlocks_,0.5,NLumiBlocks_+0.5,100,0,10000);
       
-  NumberOfNeverPresentDigisHF=dbe_->bookProfile("Problem_NeverPresentDigis_HF_vs_LS",
+  NumberOfNeverPresentDigisHF=ib.bookProfile("Problem_NeverPresentDigis_HF_vs_LS",
 						 "Total Number of Never-Present HF Cells vs LS;Lumi Section;Dead Cells",
 						 NLumiBlocks_,0.5,NLumiBlocks_+0.5,100,0,10000);
   (NumberOfNeverPresentDigis->getTProfile())->SetMarkerStyle(20);
@@ -219,10 +217,10 @@ void HcalDeadCellMonitor::setup()
 
   if (deadmon_test_digis_)
     {
-      dbe_->setCurrentFolder(subdir_+"dead_digi_often_missing");
+      ib.setCurrentFolder(subdir_+"dead_digi_often_missing");
       //units<<"("<<deadmon_checkNevents_<<" consec. events)";
       name<<"Dead Cells with No Digis";
-      SetupEtaPhiHists(RecentMissingDigisByDepth,
+      SetupEtaPhiHists(ib,RecentMissingDigisByDepth,
 		       name.str(),
 		       "");
       name.str("");
@@ -244,27 +242,27 @@ void HcalDeadCellMonitor::setup()
 
       // 1D plots count number of bad cells
       name<<"Total Number of Hcal Digis Unoccupied for at least 1 Full Luminosity Block"; 
-      NumberOfRecentMissingDigis=dbe_->bookProfile("Problem_RecentMissingDigis_HCAL_vs_LS",
+      NumberOfRecentMissingDigis=ib.bookProfile("Problem_RecentMissingDigis_HCAL_vs_LS",
 						    name.str(),
 						    NLumiBlocks_,0.5,NLumiBlocks_+0.5,100,0,10000);
       name.str("");
       name<<"Total Number of HB Digis Unoccupied for at least 1 Full LS vs LS;Lumi Section; Dead Cells";
-      NumberOfRecentMissingDigisHB=dbe_->bookProfile("Problem_RecentMissingDigis_HB_vs_LS",
+      NumberOfRecentMissingDigisHB=ib.bookProfile("Problem_RecentMissingDigis_HB_vs_LS",
 						      name.str(),
 						      NLumiBlocks_,0.5,NLumiBlocks_+0.5,100,0,10000);
       name.str("");
       name<<"Total Number of HE Digis Unoccupied for at least 1 Full LS vs LS;Lumi Section; Dead Cells";
-      NumberOfRecentMissingDigisHE=dbe_->bookProfile("Problem_RecentMissingDigis_HE_vs_LS",
+      NumberOfRecentMissingDigisHE=ib.bookProfile("Problem_RecentMissingDigis_HE_vs_LS",
 						      name.str(),
 						      NLumiBlocks_,0.5,NLumiBlocks_+0.5,100,0,10000);
       name.str("");
       name<<"Total Number of HO Digis Unoccupied for at least 1 Full LS vs LS;Lumi Section; Dead Cells";
-      NumberOfRecentMissingDigisHO=dbe_->bookProfile("Problem_RecentMissingDigis_HO_vs_LS",
+      NumberOfRecentMissingDigisHO=ib.bookProfile("Problem_RecentMissingDigis_HO_vs_LS",
 						      name.str(),
 						      NLumiBlocks_,0.5,NLumiBlocks_+0.5,100,0,10000);
       name.str("");
       name<<"Total Number of HF Digis Unoccupied for at least 1 Full LS vs LS;Lumi Section; Dead Cells";
-      NumberOfRecentMissingDigisHF=dbe_->bookProfile("Problem_RecentMissingDigis_HF_vs_LS",
+      NumberOfRecentMissingDigisHF=ib.bookProfile("Problem_RecentMissingDigis_HF_vs_LS",
 						      name.str(),
 						      NLumiBlocks_,0.5,NLumiBlocks_+0.5,100,0,10000);
       (NumberOfRecentMissingDigis->getTProfile())->SetMarkerStyle(20);
@@ -278,8 +276,8 @@ void HcalDeadCellMonitor::setup()
   if (deadmon_test_rechits_)
     {
       // test 1:  energy never above threshold
-      dbe_->setCurrentFolder(subdir_+"dead_rechit_neverpresent");
-      SetupEtaPhiHists(RecHitPresentByDepth,"RecHit Above Threshold At Least Once","");
+      ib.setCurrentFolder(subdir_+"dead_rechit_neverpresent");
+      SetupEtaPhiHists(ib,RecHitPresentByDepth,"RecHit Above Threshold At Least Once","");
       // set more descriptive titles for threshold plots
       units.str("");
       units<<"Cells Above Energy Threshold At Least Once: Depth 1 -- HB >="<<HBenergyThreshold_<<" GeV, HE >= "<<HEenergyThreshold_<<", HF >="<<HFenergyThreshold_<<" GeV";
@@ -296,27 +294,27 @@ void HcalDeadCellMonitor::setup()
       units.str("");
 
       // 1D plots count number of bad cells
-      NumberOfNeverPresentRecHits=dbe_->bookProfile("Problem_RecHitsNeverPresent_HCAL_vs_LS",
+      NumberOfNeverPresentRecHits=ib.bookProfile("Problem_RecHitsNeverPresent_HCAL_vs_LS",
 						     "Total Number of Hcal Rechits with Low Energy;Lumi Section;Dead Cells",
 						     NLumiBlocks_,0.5,NLumiBlocks_+0.5,100,0,10000);
       name.str("");
       name<<"Total Number of HB RecHits with Energy Never >= "<<HBenergyThreshold_<<" GeV;Lumi Section;Dead Cells";
-      NumberOfNeverPresentRecHitsHB=dbe_->bookProfile("Problem_RecHitsNeverPresent_HB_vs_LS",
+      NumberOfNeverPresentRecHitsHB=ib.bookProfile("Problem_RecHitsNeverPresent_HB_vs_LS",
 						       name.str(),
 						       NLumiBlocks_,0.5,NLumiBlocks_+0.5,100,0,10000);
       name.str("");
       name<<"Total Number of HE RecHits with Energy Never >= "<<HEenergyThreshold_<<" GeV;Lumi Section;Dead Cells";
-      NumberOfNeverPresentRecHitsHE=dbe_->bookProfile("Problem_RecHitsNeverPresent_HE_vs_LS",
+      NumberOfNeverPresentRecHitsHE=ib.bookProfile("Problem_RecHitsNeverPresent_HE_vs_LS",
 						       name.str(),
 						       NLumiBlocks_,0.5,NLumiBlocks_+0.5,100,0,10000);
       name.str("");
       name<<"Total Number of HO RecHits with Energy Never >= "<<HOenergyThreshold_<<" GeV;Lumi Section;Dead Cells";
-      NumberOfNeverPresentRecHitsHO=dbe_->bookProfile("Problem_RecHitsNeverPresent_HO_vs_LS",
+      NumberOfNeverPresentRecHitsHO=ib.bookProfile("Problem_RecHitsNeverPresent_HO_vs_LS",
 						       name.str(),
 						       NLumiBlocks_,0.5,NLumiBlocks_+0.5,100,0,10000);
       name.str("");
       name<<"Total Number of HF RecHits with Energy Never >= "<<HFenergyThreshold_<<" GeV;Lumi Section;Dead Cells";
-      NumberOfNeverPresentRecHitsHF=dbe_->bookProfile("Problem_RecHitsNeverPresent_HF_vs_LS",
+      NumberOfNeverPresentRecHitsHF=ib.bookProfile("Problem_RecHitsNeverPresent_HF_vs_LS",
 						       name.str(),
 						       NLumiBlocks_,0.5,NLumiBlocks_+0.5,100,0,10000);
       (NumberOfNeverPresentRecHits->getTProfile())->SetMarkerStyle(20);
@@ -325,8 +323,8 @@ void HcalDeadCellMonitor::setup()
       (NumberOfNeverPresentRecHitsHO->getTProfile())->SetMarkerStyle(20);
       (NumberOfNeverPresentRecHitsHF->getTProfile())->SetMarkerStyle(20);
  
-      dbe_->setCurrentFolder(subdir_+"dead_rechit_often_missing");
-      SetupEtaPhiHists(RecentMissingRecHitsByDepth,"RecHits Failing Energy Threshold Test","");
+      ib.setCurrentFolder(subdir_+"dead_rechit_often_missing");
+      SetupEtaPhiHists(ib,RecentMissingRecHitsByDepth,"RecHits Failing Energy Threshold Test","");
       // set more descriptive titles for threshold plots
       units.str("");
       units<<"RecHits with Consistent Low Energy Depth 1 -- HB <"<<HBenergyThreshold_<<" GeV, HE < "<<HEenergyThreshold_<<", HF <"<<HFenergyThreshold_<<" GeV";
@@ -346,27 +344,27 @@ void HcalDeadCellMonitor::setup()
       // 1D plots count number of bad cells
       name.str("");
       name<<"Total Number of Hcal RecHits with Consistent Low Energy;Lumi Section;Dead Cells";
-      NumberOfRecentMissingRecHits=dbe_->bookProfile("Problem_BelowEnergyRecHits_HCAL_vs_LS",
+      NumberOfRecentMissingRecHits=ib.bookProfile("Problem_BelowEnergyRecHits_HCAL_vs_LS",
 						      name.str(),
 						      NLumiBlocks_,0.5,NLumiBlocks_+0.5,100,0,10000);
       name.str("");
       name<<"Total Number of HB RecHits with Consistent Low Energy < "<<HBenergyThreshold_<<" GeV;Lumi Section;Dead Cells";
-      NumberOfRecentMissingRecHitsHB=dbe_->bookProfile("Problem_BelowEnergyRecHits_HB_vs_LS",
+      NumberOfRecentMissingRecHitsHB=ib.bookProfile("Problem_BelowEnergyRecHits_HB_vs_LS",
 							name.str(),
 							NLumiBlocks_,0.5,NLumiBlocks_+0.5,100,0,10000);
       name.str("");
       name<<"Total Number of HE RecHits with Consistent Low Energy < "<<HEenergyThreshold_<<" GeV;Lumi Section;Dead Cells";
-      NumberOfRecentMissingRecHitsHE=dbe_->bookProfile("Problem_BelowEnergyRecHits_HE_vs_LS",
+      NumberOfRecentMissingRecHitsHE=ib.bookProfile("Problem_BelowEnergyRecHits_HE_vs_LS",
 							name.str(),
 							NLumiBlocks_,0.5,NLumiBlocks_+0.5,100,0,10000);
       name.str("");
       name<<"Total Number of HO RecHits with Consistent Low Energy < "<<HOenergyThreshold_<<" GeV;Lumi Section;Dead Cells";
-      NumberOfRecentMissingRecHitsHO=dbe_->bookProfile("Problem_BelowEnergyRecHits_HO_vs_LS",
+      NumberOfRecentMissingRecHitsHO=ib.bookProfile("Problem_BelowEnergyRecHits_HO_vs_LS",
 							name.str(),
 							NLumiBlocks_,0.5,NLumiBlocks_+0.5,100,0,10000);
       name.str("");
       name<<"Total Number of HF RecHits with Consistent Low Energy < "<<HFenergyThreshold_<<" GeV;Lumi Section;Dead Cells";
-      NumberOfRecentMissingRecHitsHF=dbe_->bookProfile("Problem_BelowEnergyRecHits_HF_vs_LS",
+      NumberOfRecentMissingRecHitsHF=ib.bookProfile("Problem_BelowEnergyRecHits_HF_vs_LS",
 							name.str(),
 							NLumiBlocks_,0.5,NLumiBlocks_+0.5,100,0,10000);
       (NumberOfRecentMissingRecHits->getTProfile())->SetMarkerStyle(20);
@@ -380,23 +378,23 @@ void HcalDeadCellMonitor::setup()
 
   if (makeDiagnostics_)
     {
-      dbe_->setCurrentFolder(subdir_+"DiagnosticPlots");
-      HBDeadVsEvent=dbe_->book1D("HBDeadVsEvent","HB Total Dead Cells Vs Event", NLumiBlocks_/10,-0.5,NLumiBlocks_-0.5);
-      HEDeadVsEvent=dbe_->book1D("HEDeadVsEvent","HE Total Dead Cells Vs Event", NLumiBlocks_/10,-0.5,NLumiBlocks_-0.5);
-      HODeadVsEvent=dbe_->book1D("HODeadVsEvent","HO Total Dead Cells Vs Event", NLumiBlocks_/10,-0.5,NLumiBlocks_-0.5);
-      HFDeadVsEvent=dbe_->book1D("HFDeadVsEvent","HF Total Dead Cells Vs Event", NLumiBlocks_/10,-0.5,NLumiBlocks_-0.5);
+      ib.setCurrentFolder(subdir_+"DiagnosticPlots");
+      HBDeadVsEvent=ib.book1D("HBDeadVsEvent","HB Total Dead Cells Vs Event", NLumiBlocks_/10,-0.5,NLumiBlocks_-0.5);
+      HEDeadVsEvent=ib.book1D("HEDeadVsEvent","HE Total Dead Cells Vs Event", NLumiBlocks_/10,-0.5,NLumiBlocks_-0.5);
+      HODeadVsEvent=ib.book1D("HODeadVsEvent","HO Total Dead Cells Vs Event", NLumiBlocks_/10,-0.5,NLumiBlocks_-0.5);
+      HFDeadVsEvent=ib.book1D("HFDeadVsEvent","HF Total Dead Cells Vs Event", NLumiBlocks_/10,-0.5,NLumiBlocks_-0.5);
     }
 
   return;
 
 } // void HcalDeadCellMonitor::setup(...)
 
-void HcalDeadCellMonitor::beginRun(const edm::Run& run, const edm::EventSetup& c)
+void HcalDeadCellMonitor::bookHistograms(DQMStore::IBooker &ib, const edm::Run& run, const edm::EventSetup& c)
 {
-  if (debug_>1) std::cout <<"HcalDeadCellMonitor::beginRun"<<std::endl;
-  HcalBaseDQMonitor::beginRun(run,c);
+  if (debug_>1) std::cout <<"HcalDeadCellMonitor::bookHistograms"<<std::endl;
+  HcalBaseDQMonitor::bookHistograms(ib,run,c);
 
-  if (tevt_==0) this->setup(); // set up histograms if they have not been created before
+  if (tevt_==0) this->setup(ib); // set up histograms if they have not been created before
   if (mergeRuns_==false)
     this->reset();
 
@@ -422,7 +420,7 @@ void HcalDeadCellMonitor::beginRun(const edm::Run& run, const edm::EventSetup& c
 	} 
     } // if (badChannelStatusMask_>0)
   return;
-} //void HcalDeadCellMonitor::beginRun(...)
+} //void HcalDeadCellMonitor::bookHistograms(...)
 
 void HcalDeadCellMonitor::reset()
 {
@@ -501,31 +499,6 @@ void HcalDeadCellMonitor::reset()
 
 /* ------------------------------------------------------------------------- */
 
-
-void HcalDeadCellMonitor::cleanup()
-{
-  if (!enableCleanup_) return;
-  if (dbe_)
-    {
-      dbe_->setCurrentFolder(subdir_);
-      dbe_->removeContents();
-      dbe_->setCurrentFolder(subdir_+"dead_digi_never_present");
-      dbe_->removeContents();
-      dbe_->setCurrentFolder(subdir_+"dead_digi_often_missing");
-      dbe_->removeContents();
-      dbe_->setCurrentFolder(subdir_+"dead_rechit_neverpresent");
-      dbe_->removeContents();
-      dbe_->setCurrentFolder(subdir_+"dead_rechit_often_missing");
-      dbe_->removeContents();
-      dbe_->setCurrentFolder(subdir_+"dead_cell_parameters");
-      dbe_->removeContents();
-      dbe_->setCurrentFolder(subdir_+"LSvalues");
-      dbe_->removeContents();
-    }
-  return;
-} // void HcalDeadCellMonitor::cleanup()
-
-/* ------------------------------------------------------------------------- */
 
 void HcalDeadCellMonitor::endLuminosityBlock(const edm::LuminosityBlock& lumiSeg,
 					     const edm::EventSetup& c)

--- a/DQM/HcalMonitorTasks/src/HcalDetDiagLEDMonitor.cc
+++ b/DQM/HcalMonitorTasks/src/HcalDetDiagLEDMonitor.cc
@@ -238,7 +238,9 @@ static const float adc2fC[128]={-0.5,0.5,1.5,2.5,3.5,4.5,5.5,6.5,7.5,8.5,9.5, 10
 
 
 
-HcalDetDiagLEDMonitor::HcalDetDiagLEDMonitor(const edm::ParameterSet& ps) {
+HcalDetDiagLEDMonitor::HcalDetDiagLEDMonitor(const edm::ParameterSet& ps):
+ HcalBaseDQMonitor(ps)
+ {
 
 
   ievt_=0;

--- a/DQM/HcalMonitorTasks/src/HcalDetDiagLEDMonitor.cc
+++ b/DQM/HcalMonitorTasks/src/HcalDetDiagLEDMonitor.cc
@@ -110,12 +110,11 @@ public:
   HcalDetDiagLEDMonitor(const edm::ParameterSet& ps); 
   ~HcalDetDiagLEDMonitor(); 
 
-  void beginRun(const edm::Run& run, const edm::EventSetup& c) override;
-  void setup() override;
+  void bookHistograms(DQMStore::IBooker &ib, const edm::Run& run, const edm::EventSetup& c) override;
+  void setup(DQMStore::IBooker &ib) override;
   void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;// const HcalDbService& cond)
   void endRun(const edm::Run& run, const edm::EventSetup& c) override;
   void reset() override;
-  void cleanup() override; 
   void fillHistos();
   int  GetStatistics(){ return ievt_; }
 private:
@@ -287,21 +286,14 @@ HcalDetDiagLEDMonitor::HcalDetDiagLEDMonitor(const edm::ParameterSet& ps) {
 
 HcalDetDiagLEDMonitor::~HcalDetDiagLEDMonitor(){}
 
-void HcalDetDiagLEDMonitor::cleanup(){
-  if(dbe_){
-    dbe_->setCurrentFolder(subdir_);
-    dbe_->removeContents();
-    dbe_ = 0;
-  }
-} 
 void HcalDetDiagLEDMonitor::reset(){}
 
-void HcalDetDiagLEDMonitor::beginRun(const edm::Run& run, const edm::EventSetup& c)
+void HcalDetDiagLEDMonitor::bookHistograms(DQMStore::IBooker &ib, const edm::Run& run, const edm::EventSetup& c)
 {
-  if (debug_>1) std::cout <<"HcalDetDiagLEDMonitor::beginRun"<<std::endl;
-  HcalBaseDQMonitor::beginRun(run,c);
+  if (debug_>1) std::cout <<"HcalDetDiagLEDMonitor::bookHistograms"<<std::endl;
+  HcalBaseDQMonitor::bookHistograms(ib,run,c);
 
-  if (tevt_==0) this->setup(); // set up histograms if they have not been created before
+  if (tevt_==0) this->setup(ib); // set up histograms if they have not been created before
   if (mergeRuns_==false) this->reset();
 
   edm::ESHandle<HcalChannelQuality> p;
@@ -320,69 +312,68 @@ void HcalDetDiagLEDMonitor::beginRun(const edm::Run& run, const edm::EventSetup&
   } 
 
   return;
-} // void HcalNDetDiagLEDMonitor::beginRun(...)
+} // void HcalNDetDiagLEDMonitor::bookHistograms(...)
 
-void HcalDetDiagLEDMonitor::setup(){
+void HcalDetDiagLEDMonitor::setup(DQMStore::IBooker &ib){
      // Call base class setup
-     HcalBaseDQMonitor::setup();
-     if (!dbe_) return;
+     HcalBaseDQMonitor::setup(ib);
 
      std::string name;
-     dbe_->setCurrentFolder(subdir_);   
-     meEVT_ = dbe_->bookInt("HcalDetDiagLEDMonitor Event Number");
-     meRUN_ = dbe_->bookInt("HcalDetDiagLEDMonitor Run Number");
+     ib.setCurrentFolder(subdir_);   
+     meEVT_ = ib.bookInt("HcalDetDiagLEDMonitor Event Number");
+     meRUN_ = ib.bookInt("HcalDetDiagLEDMonitor Run Number");
      ReferenceRun="UNKNOWN";
      LoadReference();
-     dbe_->setCurrentFolder(subdir_);
-     RefRun_= dbe_->bookString("HcalDetDiagLEDMonitor Reference Run",ReferenceRun);
-     dbe_->setCurrentFolder(subdir_+"Summary Plots");
+     ib.setCurrentFolder(subdir_);
+     RefRun_= ib.bookString("HcalDetDiagLEDMonitor Reference Run",ReferenceRun);
+     ib.setCurrentFolder(subdir_+"Summary Plots");
      
-     name="HBHEHO LED Energy Distribution";               Energy         = dbe_->book1D(name,name,200,0,3000);
-     name="HBHEHO LED Timing Distribution";               Time           = dbe_->book1D(name,name,200,0,10);
-     name="HBHEHO LED Energy RMS_div_Energy Distribution";EnergyRMS      = dbe_->book1D(name,name,200,0,0.2);
-     name="HBHEHO LED Timing RMS Distribution";           TimeRMS        = dbe_->book1D(name,name,200,0,0.4);
-     name="HF LED Energy Distribution";                   EnergyHF       = dbe_->book1D(name,name,200,0,3000);
-     name="HF LED Timing Distribution";                   TimeHF         = dbe_->book1D(name,name,200,0,10);
-     name="HF LED Energy RMS_div_Energy Distribution";    EnergyRMSHF    = dbe_->book1D(name,name,200,0,0.5);
-     name="HF LED Timing RMS Distribution";               TimeRMSHF      = dbe_->book1D(name,name,200,0,0.4);
-     name="LED Energy Corr(PinDiod) Distribution";        EnergyCorr     = dbe_->book1D(name,name,200,0,10);
-     name="LED Timing HBHEHF";                            Time2Dhbhehf   = dbe_->book2D(name,name,87,-43,43,74,0,73);
-     name="LED Timing HO";                                Time2Dho       = dbe_->book2D(name,name,33,-16,16,74,0,73);
-     name="LED Energy HBHEHF";                            Energy2Dhbhehf = dbe_->book2D(name,name,87,-43,43,74,0,73);
-     name="LED Energy HO";                                Energy2Dho     = dbe_->book2D(name,name,33,-16,16,74,0,73);
+     name="HBHEHO LED Energy Distribution";               Energy         = ib.book1D(name,name,200,0,3000);
+     name="HBHEHO LED Timing Distribution";               Time           = ib.book1D(name,name,200,0,10);
+     name="HBHEHO LED Energy RMS_div_Energy Distribution";EnergyRMS      = ib.book1D(name,name,200,0,0.2);
+     name="HBHEHO LED Timing RMS Distribution";           TimeRMS        = ib.book1D(name,name,200,0,0.4);
+     name="HF LED Energy Distribution";                   EnergyHF       = ib.book1D(name,name,200,0,3000);
+     name="HF LED Timing Distribution";                   TimeHF         = ib.book1D(name,name,200,0,10);
+     name="HF LED Energy RMS_div_Energy Distribution";    EnergyRMSHF    = ib.book1D(name,name,200,0,0.5);
+     name="HF LED Timing RMS Distribution";               TimeRMSHF      = ib.book1D(name,name,200,0,0.4);
+     name="LED Energy Corr(PinDiod) Distribution";        EnergyCorr     = ib.book1D(name,name,200,0,10);
+     name="LED Timing HBHEHF";                            Time2Dhbhehf   = ib.book2D(name,name,87,-43,43,74,0,73);
+     name="LED Timing HO";                                Time2Dho       = ib.book2D(name,name,33,-16,16,74,0,73);
+     name="LED Energy HBHEHF";                            Energy2Dhbhehf = ib.book2D(name,name,87,-43,43,74,0,73);
+     name="LED Energy HO";                                Energy2Dho     = ib.book2D(name,name,33,-16,16,74,0,73);
 
-     name="HBP Average over HPD LED Ref";          HBPphi = dbe_->book2D(name,name,180,1,73,400,0,2);
-     name="HBM Average over HPD LED Ref";          HBMphi = dbe_->book2D(name,name,180,1,73,400,0,2);
-     name="HEP Average over HPD LED Ref";          HEPphi = dbe_->book2D(name,name,180,1,73,400,0,2);
-     name="HEM Average over HPD LED Ref";          HEMphi = dbe_->book2D(name,name,180,1,73,400,0,2);
-     name="HFP Average over RM LED Ref";           HFPphi = dbe_->book2D(name,name,180,1,37,400,0,2);
-     name="HFM Average over RM LED Ref";           HFMphi = dbe_->book2D(name,name,180,1,37,400,0,2);
-     name="HO0 Average over HPD LED Ref";          HO0phi = dbe_->book2D(name,name,180,1,49,400,0,2);
-     name="HO1P Average over HPD LED Ref";         HO1Pphi= dbe_->book2D(name,name,180,1,49,400,0,2);
-     name="HO2P Average over HPD LED Ref";         HO2Pphi= dbe_->book2D(name,name,180,1,49,400,0,2);
-     name="HO1M Average over HPD LED Ref";         HO1Mphi= dbe_->book2D(name,name,180,1,49,400,0,2);
-     name="HO2M Average over HPD LED Ref";         HO2Mphi= dbe_->book2D(name,name,180,1,49,400,0,2);
+     name="HBP Average over HPD LED Ref";          HBPphi = ib.book2D(name,name,180,1,73,400,0,2);
+     name="HBM Average over HPD LED Ref";          HBMphi = ib.book2D(name,name,180,1,73,400,0,2);
+     name="HEP Average over HPD LED Ref";          HEPphi = ib.book2D(name,name,180,1,73,400,0,2);
+     name="HEM Average over HPD LED Ref";          HEMphi = ib.book2D(name,name,180,1,73,400,0,2);
+     name="HFP Average over RM LED Ref";           HFPphi = ib.book2D(name,name,180,1,37,400,0,2);
+     name="HFM Average over RM LED Ref";           HFMphi = ib.book2D(name,name,180,1,37,400,0,2);
+     name="HO0 Average over HPD LED Ref";          HO0phi = ib.book2D(name,name,180,1,49,400,0,2);
+     name="HO1P Average over HPD LED Ref";         HO1Pphi= ib.book2D(name,name,180,1,49,400,0,2);
+     name="HO2P Average over HPD LED Ref";         HO2Pphi= ib.book2D(name,name,180,1,49,400,0,2);
+     name="HO1M Average over HPD LED Ref";         HO1Mphi= ib.book2D(name,name,180,1,49,400,0,2);
+     name="HO2M Average over HPD LED Ref";         HO2Mphi= ib.book2D(name,name,180,1,49,400,0,2);
 
      ChannelsLEDEnergy = new EtaPhiHists();
-     ChannelsLEDEnergy->setup(dbe_," Channel LED Energy");
+     ChannelsLEDEnergy->setup(ib," Channel LED Energy");
      ChannelsLEDEnergyRef = new EtaPhiHists();
-     ChannelsLEDEnergyRef->setup(dbe_," Channel LED Energy Reference");
+     ChannelsLEDEnergyRef->setup(ib," Channel LED Energy Reference");
      
-     dbe_->setCurrentFolder(subdir_+"channel status");
+     ib.setCurrentFolder(subdir_+"channel status");
      ChannelStatusMissingChannels = new EtaPhiHists();
-     ChannelStatusMissingChannels->setup(dbe_," Missing Channels");
+     ChannelStatusMissingChannels->setup(ib," Missing Channels");
      ChannelStatusUnstableChannels = new EtaPhiHists();
-     ChannelStatusUnstableChannels->setup(dbe_," Unstable Channels");
+     ChannelStatusUnstableChannels->setup(ib," Unstable Channels");
      ChannelStatusUnstableLEDsignal = new EtaPhiHists();
-     ChannelStatusUnstableLEDsignal->setup(dbe_," Unstable LED");
+     ChannelStatusUnstableLEDsignal->setup(ib," Unstable LED");
      ChannelStatusLEDMean = new EtaPhiHists();
-     ChannelStatusLEDMean->setup(dbe_," LED Mean");
+     ChannelStatusLEDMean->setup(ib," LED Mean");
      ChannelStatusLEDRMS = new EtaPhiHists();
-     ChannelStatusLEDRMS->setup(dbe_," LED RMS");
+     ChannelStatusLEDRMS->setup(ib," LED RMS");
      ChannelStatusTimeMean = new EtaPhiHists();
-     ChannelStatusTimeMean->setup(dbe_," Time Mean");
+     ChannelStatusTimeMean->setup(ib," Time Mean");
      ChannelStatusTimeRMS = new EtaPhiHists();
-     ChannelStatusTimeRMS->setup(dbe_," Time RMS");
+     ChannelStatusTimeRMS->setup(ib," Time RMS");
 
      
 } 
@@ -394,7 +385,6 @@ int  eta,phi,depth,nTS;
      emap=new HcalElectronicsMap(logicalMap_->generateHcalElectronicsMap());
    }
 
-   if(!dbe_) return; 
    bool LEDEvent=false;
    bool LocalRun=false;
    // for local runs 

--- a/DQM/HcalMonitorTasks/src/HcalDetDiagLEDMonitor.cc
+++ b/DQM/HcalMonitorTasks/src/HcalDetDiagLEDMonitor.cc
@@ -283,10 +283,34 @@ HcalDetDiagLEDMonitor::HcalDetDiagLEDMonitor(const edm::ParameterSet& ps):
   tok_hf_ = consumes<HFDigiCollection>(digiLabel_);
   tok_calib_ = consumes<HcalCalibDigiCollection>(ps.getUntrackedParameter<edm::InputTag>("calibDigiLabel",edm::InputTag("hcalDigis")));
   
+  ChannelsLEDEnergy=0;
+  ChannelsLEDEnergyRef=0;
+  ChannelStatusMissingChannels=0;
+  ChannelStatusUnstableChannels=0;
+  ChannelStatusUnstableLEDsignal=0;
+  ChannelStatusLEDMean=0;
+  ChannelStatusLEDRMS=0;
+  ChannelStatusTimeMean=0;
+  ChannelStatusTimeRMS=0;
 
 }
 
-HcalDetDiagLEDMonitor::~HcalDetDiagLEDMonitor(){}
+HcalDetDiagLEDMonitor::~HcalDetDiagLEDMonitor()
+{
+
+  if ( ChannelsLEDEnergy ) delete ChannelsLEDEnergy;
+  if ( ChannelsLEDEnergyRef ) delete ChannelsLEDEnergyRef;
+  if ( ChannelStatusMissingChannels ) delete ChannelStatusMissingChannels;
+  if ( ChannelStatusUnstableChannels ) delete ChannelStatusUnstableChannels;
+  if ( ChannelStatusUnstableLEDsignal ) delete ChannelStatusUnstableLEDsignal;
+  if ( ChannelStatusLEDMean ) delete ChannelStatusLEDMean;
+  if ( ChannelStatusLEDRMS ) delete ChannelStatusLEDRMS;
+  if ( ChannelStatusTimeMean ) delete ChannelStatusTimeMean;
+  if ( ChannelStatusTimeRMS ) delete ChannelStatusTimeRMS;
+
+  if ( emap ) delete emap;
+  
+}
 
 void HcalDetDiagLEDMonitor::reset(){}
 
@@ -808,7 +832,7 @@ char   Subdet[10],str[500];
        } 
        theFile->Write();
        theFile->Close();
-
+       theFile->Delete();
 
    if(XmlFilePath.size()>0){
       //create XML file
@@ -1051,6 +1075,7 @@ TFile *f;
      if(strcmp(subdet,"CALIB_HF")==0) calib_data[4][Eta+2][Phi-1].set_reference(led,rms);
    }
    f->Close();
+   f->Delete();
    IsReference=true;
 } 
 void HcalDetDiagLEDMonitor::CheckStatus(){

--- a/DQM/HcalMonitorTasks/src/HcalDetDiagLaserMonitor.cc
+++ b/DQM/HcalMonitorTasks/src/HcalDetDiagLaserMonitor.cc
@@ -378,7 +378,9 @@ class HcalDetDiagLaserMonitor : public HcalBaseDQMonitor {
       std::map<unsigned int, int> KnownBadCells_;
 };
 
-HcalDetDiagLaserMonitor::HcalDetDiagLaserMonitor(const edm::ParameterSet& iConfig) {
+HcalDetDiagLaserMonitor::HcalDetDiagLaserMonitor(const edm::ParameterSet& iConfig):
+ HcalBaseDQMonitor(iConfig)
+ {
  
 
   ievt_=-1;

--- a/DQM/HcalMonitorTasks/src/HcalDetDiagLaserMonitor.cc
+++ b/DQM/HcalMonitorTasks/src/HcalDetDiagLaserMonitor.cc
@@ -424,6 +424,12 @@ HcalDetDiagLaserMonitor::HcalDetDiagLaserMonitor(const edm::ParameterSet& iConfi
   tok_ho_  = consumes<HODigiCollection>(inputLabelDigi_);
   tok_hf_ = consumes<HFDigiCollection>(inputLabelDigi_);
 
+
+  ProblemCellsByDepth_timing=0;
+  ProblemCellsByDepth_energy=0;
+  ProblemCellsByDepth_timing_val=0;
+  ProblemCellsByDepth_energy_val=0;
+
 }
 
 
@@ -562,6 +568,11 @@ void HcalDetDiagLaserMonitor::bookHistograms(DQMStore::IBooker &ib, const edm::R
 
 
 HcalDetDiagLaserMonitor::~HcalDetDiagLaserMonitor(){
+
+  if ( ProblemCellsByDepth_timing ) delete ProblemCellsByDepth_timing;
+  if ( ProblemCellsByDepth_energy ) delete ProblemCellsByDepth_energy;
+  if ( ProblemCellsByDepth_timing_val ) delete ProblemCellsByDepth_timing_val;
+  if ( ProblemCellsByDepth_energy_val ) delete ProblemCellsByDepth_energy_val;
 
 }
 
@@ -1543,6 +1554,7 @@ char   Subdet[10],str[500];
        } 
        theFile->Write();
        theFile->Close();
+       theFile->Delete();
    }
    if(XmlFilePath.size()>0){
       char TIME[40];
@@ -1797,6 +1809,7 @@ TFile *f;
          if(strcmp(subdet,"CALIB_HF")==0) calib_data[4][Eta+2][Phi-1].set_reference(amp,rms,time,time_rms);
      }
       f->Close();
+      f->Delete();
       IsReference=true;
 } 
 void HcalDetDiagLaserMonitor::LoadDataset(){
@@ -1875,6 +1888,7 @@ TFile *f;
       TObjString *STR3=(TObjString *)f->Get("Dataset number");
       if(STR3){ int ds; sscanf(STR3->String(),"%i",&ds); dataset_seq_number=ds;}
       f->Close(); 
+      f->Delete();
 } 
 
 void HcalDetDiagLaserMonitor::SaveRaddamData(){
@@ -2021,6 +2035,7 @@ char str[100];
          }
          theFile->Write();
          theFile->Close();
+	 theFile->Delete();
       } 
 }
 

--- a/DQM/HcalMonitorTasks/src/HcalDetDiagLaserMonitor.cc
+++ b/DQM/HcalMonitorTasks/src/HcalDetDiagLaserMonitor.cc
@@ -282,7 +282,7 @@ class HcalDetDiagLaserMonitor : public HcalBaseDQMonitor {
       }
       return &calib_data[SD][ETA+2][PHI-1];
       };   
-      void beginRun(const edm::Run& run, const edm::EventSetup& c) override;  
+      void bookHistograms(DQMStore::IBooker &ib, const edm::Run& run, const edm::EventSetup& c) override;  
       void endRun(const edm::Run& run, const edm::EventSetup& c) override;
       void beginLuminosityBlock(const edm::LuminosityBlock& lumiSeg,const edm::EventSetup& c) override ;
       void endLuminosityBlock(const edm::LuminosityBlock& lumiSeg,const edm::EventSetup& c) override;
@@ -423,7 +423,9 @@ HcalDetDiagLaserMonitor::HcalDetDiagLaserMonitor(const edm::ParameterSet& iConfi
   tok_hf_ = consumes<HFDigiCollection>(inputLabelDigi_);
 
 }
-void HcalDetDiagLaserMonitor::beginRun(const edm::Run& run, const edm::EventSetup& c){
+
+
+void HcalDetDiagLaserMonitor::bookHistograms(DQMStore::IBooker &ib, const edm::Run& run, const edm::EventSetup& c){
   edm::ESHandle<HcalChannelQuality> p;
   c.get<HcalChannelQualityRcd>().get("withTopo",p);
   const HcalChannelQuality* chanquality= p.product();
@@ -443,68 +445,67 @@ void HcalDetDiagLaserMonitor::beginRun(const edm::Run& run, const edm::EventSetu
   c.get<HcalDbRecord>().get(conditions_);
   emap=conditions_->getHcalMapping();
   
-  HcalBaseDQMonitor::setup();
-  if (!dbe_) return;
+  HcalBaseDQMonitor::setup(ib);
   std::string name;
  
-  dbe_->setCurrentFolder(subdir_);   
-  meEVT_ = dbe_->bookInt("HcalDetDiagLaserMonitor Event Number");
-  meRUN_ = dbe_->bookInt("HcalDetDiagLaserMonitor Run Number");
+  ib.setCurrentFolder(subdir_);   
+  meEVT_ = ib.bookInt("HcalDetDiagLaserMonitor Event Number");
+  meRUN_ = ib.bookInt("HcalDetDiagLaserMonitor Run Number");
 
   ReferenceRun="UNKNOWN";
   LoadReference();
   LoadDataset();
   if(DatasetName.size()>0 && createHTMLonly){
      char str[200]; sprintf(str,"%sHcalDetDiagLaserData_run%i_%i/",htmlOutputPath.c_str(),run_number,dataset_seq_number);
-     htmlFolder=dbe_->bookString("HcalDetDiagLaserMonitor HTML folder",str);
+     htmlFolder=ib.bookString("HcalDetDiagLaserMonitor HTML folder",str);
      MonitorElement *me;
-     dbe_->setCurrentFolder(prefixME_+"HcalInfo");
-     me=dbe_->bookInt("HBpresent");
+     ib.setCurrentFolder(prefixME_+"HcalInfo");
+     me=ib.bookInt("HBpresent");
      if(nHB>0) me->Fill(1);
-     me=dbe_->bookInt("HEpresent");
+     me=ib.bookInt("HEpresent");
      if(nHE>0) me->Fill(1);
-     me=dbe_->bookInt("HOpresent");
+     me=ib.bookInt("HOpresent");
      if(nHO>0) me->Fill(1);
-     me=dbe_->bookInt("HFpresent");
+     me=ib.bookInt("HFpresent");
      if(nHF>0) me->Fill(1);
   }
   ProblemCellsByDepth_timing = new EtaPhiHists();
-  ProblemCellsByDepth_timing->setup(dbe_," Problem Bad Laser Timing");
+  ProblemCellsByDepth_timing->setup(ib," Problem Bad Laser Timing");
   for(unsigned int i=0;i<ProblemCellsByDepth_timing->depth.size();i++)
           problemnames_.push_back(ProblemCellsByDepth_timing->depth[i]->getName());
   ProblemCellsByDepth_energy = new EtaPhiHists();
-  ProblemCellsByDepth_energy->setup(dbe_," Problem Bad Laser Energy");
+  ProblemCellsByDepth_energy->setup(ib," Problem Bad Laser Energy");
   for(unsigned int i=0;i<ProblemCellsByDepth_energy->depth.size();i++)
           problemnames_.push_back(ProblemCellsByDepth_energy->depth[i]->getName());
 
-  dbe_->setCurrentFolder(subdir_+"Summary Plots");
+  ib.setCurrentFolder(subdir_+"Summary Plots");
      
-  name="HBHE Laser Energy Distribution";                hbheEnergy        = dbe_->book1D(name,name,200,0,3000);
-  name="HBHE Laser Timing Distribution";                hbheTime          = dbe_->book1D(name,name,200,0,10);
-  name="HBHE Laser Energy RMS_div_Energy Distribution"; hbheEnergyRMS     = dbe_->book1D(name,name,200,0,0.5);
-  name="HBHE Laser Timing RMS Distribution";            hbheTimeRMS       = dbe_->book1D(name,name,200,0,1);
-  name="HO Laser Energy Distribution";                  hoEnergy          = dbe_->book1D(name,name,200,0,3000);
-  name="HO Laser Timing Distribution";                  hoTime            = dbe_->book1D(name,name,200,0,10);
-  name="HO Laser Energy RMS_div_Energy Distribution";   hoEnergyRMS       = dbe_->book1D(name,name,200,0,0.5);
-  name="HO Laser Timing RMS Distribution";              hoTimeRMS         = dbe_->book1D(name,name,200,0,1);
-  name="HF Laser Energy Distribution";                  hfEnergy          = dbe_->book1D(name,name,200,0,3000);
-  name="HF Laser Timing Distribution";                  hfTime            = dbe_->book1D(name,name,200,0,10);
-  name="HF Laser Energy RMS_div_Energy Distribution";   hfEnergyRMS       = dbe_->book1D(name,name,200,0,0.7);
-  name="HF Laser Timing RMS Distribution";              hfTimeRMS         = dbe_->book1D(name,name,200,0,1);
+  name="HBHE Laser Energy Distribution";                hbheEnergy        = ib.book1D(name,name,200,0,3000);
+  name="HBHE Laser Timing Distribution";                hbheTime          = ib.book1D(name,name,200,0,10);
+  name="HBHE Laser Energy RMS_div_Energy Distribution"; hbheEnergyRMS     = ib.book1D(name,name,200,0,0.5);
+  name="HBHE Laser Timing RMS Distribution";            hbheTimeRMS       = ib.book1D(name,name,200,0,1);
+  name="HO Laser Energy Distribution";                  hoEnergy          = ib.book1D(name,name,200,0,3000);
+  name="HO Laser Timing Distribution";                  hoTime            = ib.book1D(name,name,200,0,10);
+  name="HO Laser Energy RMS_div_Energy Distribution";   hoEnergyRMS       = ib.book1D(name,name,200,0,0.5);
+  name="HO Laser Timing RMS Distribution";              hoTimeRMS         = ib.book1D(name,name,200,0,1);
+  name="HF Laser Energy Distribution";                  hfEnergy          = ib.book1D(name,name,200,0,3000);
+  name="HF Laser Timing Distribution";                  hfTime            = ib.book1D(name,name,200,0,10);
+  name="HF Laser Energy RMS_div_Energy Distribution";   hfEnergyRMS       = ib.book1D(name,name,200,0,0.7);
+  name="HF Laser Timing RMS Distribution";              hfTimeRMS         = ib.book1D(name,name,200,0,1);
      
-  name="Laser Timing HBHEHF";                           Time2Dhbhehf      = dbe_->book2D(name,name,87,-43,43,74,0,73);
-  name="Laser Timing HO";                               Time2Dho          = dbe_->book2D(name,name,33,-16,16,74,0,73);
-  name="Laser Energy HBHEHF";                           Energy2Dhbhehf    = dbe_->book2D(name,name,87,-43,43,74,0,73);
-  name="Laser Energy HO";                               Energy2Dho        = dbe_->book2D(name,name,33,-16,16,74,0,73);
-  name="HBHEHF Laser (Timing-Ref)+1";                   refTime2Dhbhehf   = dbe_->book2D(name,name,87,-43,43,74,0,73);
-  name="HO Laser (Timing-Ref)+1";                       refTime2Dho       = dbe_->book2D(name,name,33,-16,16,74,0,73);
-  name="HBHEHF Laser Energy_div_Ref";                   refEnergy2Dhbhehf = dbe_->book2D(name,name,87,-43,43,74,0,73);
-  name="HO Laser Energy_div_Ref";                       refEnergy2Dho     = dbe_->book2D(name,name,33,-16,16,74,0,73);
+  name="Laser Timing HBHEHF";                           Time2Dhbhehf      = ib.book2D(name,name,87,-43,43,74,0,73);
+  name="Laser Timing HO";                               Time2Dho          = ib.book2D(name,name,33,-16,16,74,0,73);
+  name="Laser Energy HBHEHF";                           Energy2Dhbhehf    = ib.book2D(name,name,87,-43,43,74,0,73);
+  name="Laser Energy HO";                               Energy2Dho        = ib.book2D(name,name,33,-16,16,74,0,73);
+  name="HBHEHF Laser (Timing-Ref)+1";                   refTime2Dhbhehf   = ib.book2D(name,name,87,-43,43,74,0,73);
+  name="HO Laser (Timing-Ref)+1";                       refTime2Dho       = ib.book2D(name,name,33,-16,16,74,0,73);
+  name="HBHEHF Laser Energy_div_Ref";                   refEnergy2Dhbhehf = ib.book2D(name,name,87,-43,43,74,0,73);
+  name="HO Laser Energy_div_Ref";                       refEnergy2Dho     = ib.book2D(name,name,33,-16,16,74,0,73);
      
-  name="HB RBX average Time-Ref";                       hb_time_rbx       = dbe_->book1D(name,name,36,0.5,36.5);
-  name="HE RBX average Time-Ref";                       he_time_rbx       = dbe_->book1D(name,name,36,0.5,36.5);
-  name="HO RBX average Time-Ref";                       ho_time_rbx       = dbe_->book1D(name,name,36,0.5,36.5);
-  name="HF RoBox average Time-Ref";                     hf_time_rbx       = dbe_->book1D(name,name,24,0.5,24.5);
+  name="HB RBX average Time-Ref";                       hb_time_rbx       = ib.book1D(name,name,36,0.5,36.5);
+  name="HE RBX average Time-Ref";                       he_time_rbx       = ib.book1D(name,name,36,0.5,36.5);
+  name="HO RBX average Time-Ref";                       ho_time_rbx       = ib.book1D(name,name,36,0.5,36.5);
+  name="HF RoBox average Time-Ref";                     hf_time_rbx       = ib.book1D(name,name,24,0.5,24.5);
   
   char str[200];
   for(int i=1;i<=18;i++){ sprintf(str,"HBM%02i",i);     hb_time_rbx->setBinLabel(i,str);    }
@@ -541,20 +542,20 @@ void HcalDetDiagLaserMonitor::beginRun(const edm::Run& run, const edm::EventSetu
   refEnergy2Dhbhehf->setAxisRange(0.5,1.5,3);
   refEnergy2Dho->setAxisRange(0.5,1.5,3);
 
-  dbe_->setCurrentFolder(subdir_);
-  RefRun_= dbe_->bookString("HcalDetDiagLaserMonitor Reference Run",ReferenceRun);
+  ib.setCurrentFolder(subdir_);
+  RefRun_= ib.bookString("HcalDetDiagLaserMonitor Reference Run",ReferenceRun);
 
-  dbe_->setCurrentFolder(subdir_+"Raddam Plots");
+  ib.setCurrentFolder(subdir_+"Raddam Plots");
   for(int i=0;i<56;i++){
      sprintf(str,"RADDAM (%i %i)",RADDAM_CH[i].eta,RADDAM_CH[i].phi);
-     Raddam[i] = dbe_->book1D(str,str,10,-0.5,9.5); 
+     Raddam[i] = ib.book1D(str,str,10,-0.5,9.5); 
   }
 
-  dbe_->setCurrentFolder(subdir_+"Plots for client");
+  ib.setCurrentFolder(subdir_+"Plots for client");
   ProblemCellsByDepth_timing_val = new EtaPhiHists();
-  ProblemCellsByDepth_timing_val->setup(dbe_," Laser Timing difference");
+  ProblemCellsByDepth_timing_val->setup(ib," Laser Timing difference");
   ProblemCellsByDepth_energy_val = new EtaPhiHists();
-  ProblemCellsByDepth_energy_val->setup(dbe_," Laser Energy difference");
+  ProblemCellsByDepth_energy_val->setup(ib," Laser Energy difference");
 }
 
 
@@ -575,7 +576,6 @@ static int  lastHBHEorbit,lastHOorbit,lastHForbit,nChecksHBHE,nChecksHO,nChecksH
        ievt_hbhe=0,ievt_ho=0,ievt_hf=0;
    }
 
-   if(!dbe_) return; 
    bool LaserEvent=false;
    bool LaserRaddam=false;
    int orbit=iEvent.orbitNumber();

--- a/DQM/HcalMonitorTasks/src/HcalDetDiagNoiseMonitor.cc
+++ b/DQM/HcalMonitorTasks/src/HcalDetDiagNoiseMonitor.cc
@@ -200,22 +200,15 @@ HcalDetDiagNoiseMonitor::HcalDetDiagNoiseMonitor(const edm::ParameterSet& ps) {
   setupDone_ = false;
 }
 
-void HcalDetDiagNoiseMonitor::cleanup(){
-  if(dbe_){
-    dbe_->setCurrentFolder(subdir_);
-    dbe_->removeContents();
-    dbe_ = 0;
-  }
-} 
 void HcalDetDiagNoiseMonitor::reset(){}
 
 
-void HcalDetDiagNoiseMonitor::beginRun(const edm::Run& run, const edm::EventSetup& c)
+void HcalDetDiagNoiseMonitor::bookHistograms(DQMStore::IBooker &ib, const edm::Run& run, const edm::EventSetup& c)
 {
-  if (debug_>1) std::cout <<"HcalDetDiagNoiseMonitor::beginRun"<<std::endl;
-  HcalBaseDQMonitor::beginRun(run,c);
+  if (debug_>1) std::cout <<"HcalDetDiagNoiseMonitor::bookHistograms"<<std::endl;
+  HcalBaseDQMonitor::bookHistograms(ib,run,c);
 
-  if (tevt_==0) this->setup(); // set up histograms if they have not been created before
+  if (tevt_==0) this->setup(ib); // set up histograms if they have not been created before
   if (mergeRuns_==false)
     this->reset();
 
@@ -223,52 +216,50 @@ void HcalDetDiagNoiseMonitor::beginRun(const edm::Run& run, const edm::EventSetu
 
 } 
 
-void HcalDetDiagNoiseMonitor::setup(){
+void HcalDetDiagNoiseMonitor::setup(DQMStore::IBooker &ib){
   if (setupDone_)
     return;
   setupDone_ = true;
   // Call base class setup
-  HcalBaseDQMonitor::setup();
-  if (!dbe_) return;
+  HcalBaseDQMonitor::setup(ib);
   RMSummary = new HcalDetDiagNoiseRMSummary();
 
   std::string name;
-  if(dbe_!=NULL){    
-     dbe_->setCurrentFolder(subdir_);   
-     meEVT_ = dbe_->bookInt("HcalNoiseMonitor Event Number");
-     dbe_->setCurrentFolder(subdir_+"Common Plots");
+     ib.setCurrentFolder(subdir_);   
+     meEVT_ = ib.bookInt("HcalNoiseMonitor Event Number");
+     ib.setCurrentFolder(subdir_+"Common Plots");
      
-     name="RBX Pixel multiplicity";     PixelMult        = dbe_->book1D(name,name,73,0,73);
-     name="HPD energy";                 HPDEnergy        = dbe_->book1D(name,name,200,0,2500);
-     name="RBX energy";                 RBXEnergy        = dbe_->book1D(name,name,200,0,3500);
-     name="Number of zero TS per RBX";  NZeroes          = dbe_->book1D(name,name,100,0,100);
-     name="Trigger BX Tbit11";          TriggerBx11      = dbe_->book1D(name,name,4000,0,4000);
-     name="Trigger BX Tbit12";          TriggerBx12      = dbe_->book1D(name,name,4000,0,4000);
+     name="RBX Pixel multiplicity";     PixelMult        = ib.book1D(name,name,73,0,73);
+     name="HPD energy";                 HPDEnergy        = ib.book1D(name,name,200,0,2500);
+     name="RBX energy";                 RBXEnergy        = ib.book1D(name,name,200,0,3500);
+     name="Number of zero TS per RBX";  NZeroes          = ib.book1D(name,name,100,0,100);
+     name="Trigger BX Tbit11";          TriggerBx11      = ib.book1D(name,name,4000,0,4000);
+     name="Trigger BX Tbit12";          TriggerBx12      = ib.book1D(name,name,4000,0,4000);
 
-     dbe_->setCurrentFolder(subdir_+"HBHE Plots");
-     name="HBP HPD Noise Rate Pixel above 50fC"; HBP_Rate50    = dbe_->book1D(name,name,73,0,73);
-     name="HBM HPD Noise Rate Pixel above 50fC"; HBM_Rate50    = dbe_->book1D(name,name,73,0,73);
-     name="HEP HPD Noise Rate Pixel above 50fC"; HEP_Rate50    = dbe_->book1D(name,name,73,0,73);
-     name="HEM HPD Noise Rate Pixel above 50fC"; HEM_Rate50    = dbe_->book1D(name,name,73,0,73);
-     name="HBP HPD Noise Rate HPD above 300fC";  HBP_Rate300   = dbe_->book1D(name,name,73,0,73);
-     name="HBM HPD Noise Rate HPD above 300fC";  HBM_Rate300   = dbe_->book1D(name,name,73,0,73);
-     name="HEP HPD Noise Rate HPD above 300fC";  HEP_Rate300   = dbe_->book1D(name,name,73,0,73);
-     name="HEM HPD Noise Rate HPD above 300fC";  HEM_Rate300   = dbe_->book1D(name,name,73,0,73);
+     ib.setCurrentFolder(subdir_+"HBHE Plots");
+     name="HBP HPD Noise Rate Pixel above 50fC"; HBP_Rate50    = ib.book1D(name,name,73,0,73);
+     name="HBM HPD Noise Rate Pixel above 50fC"; HBM_Rate50    = ib.book1D(name,name,73,0,73);
+     name="HEP HPD Noise Rate Pixel above 50fC"; HEP_Rate50    = ib.book1D(name,name,73,0,73);
+     name="HEM HPD Noise Rate Pixel above 50fC"; HEM_Rate50    = ib.book1D(name,name,73,0,73);
+     name="HBP HPD Noise Rate HPD above 300fC";  HBP_Rate300   = ib.book1D(name,name,73,0,73);
+     name="HBM HPD Noise Rate HPD above 300fC";  HBM_Rate300   = ib.book1D(name,name,73,0,73);
+     name="HEP HPD Noise Rate HPD above 300fC";  HEP_Rate300   = ib.book1D(name,name,73,0,73);
+     name="HEM HPD Noise Rate HPD above 300fC";  HEM_Rate300   = ib.book1D(name,name,73,0,73);
 
-     dbe_->setCurrentFolder(subdir_+"HO Plots");
-     name="HO0  HPD Noise Rate Pixel above 50fC"; HO0_Rate50   = dbe_->book1D(name,name,49,0,49);
-     name="HO1P HPD Noise Rate Pixel above 50fC"; HO1P_Rate50   = dbe_->book1D(name,name,48,0,48);
-     name="HO1M HPD Noise Rate Pixel above 50fC"; HO1M_Rate50   = dbe_->book1D(name,name,48,0,48);
-     name="HO0 HPD Noise Rate HPD above 300fC";   HO0_Rate300  = dbe_->book1D(name,name,48,0,48);
-     name="HO1P HPD Noise Rate HPD abGetRMindexove 300fC";  HO1P_Rate300 = dbe_->book1D(name,name,48,0,48);
-     name="HO1M HPD Noise Rate HPD above 300fC";  HO1M_Rate300 = dbe_->book1D(name,name,48,0,48);
+     ib.setCurrentFolder(subdir_+"HO Plots");
+     name="HO0  HPD Noise Rate Pixel above 50fC"; HO0_Rate50   = ib.book1D(name,name,49,0,49);
+     name="HO1P HPD Noise Rate Pixel above 50fC"; HO1P_Rate50   = ib.book1D(name,name,48,0,48);
+     name="HO1M HPD Noise Rate Pixel above 50fC"; HO1M_Rate50   = ib.book1D(name,name,48,0,48);
+     name="HO0 HPD Noise Rate HPD above 300fC";   HO0_Rate300  = ib.book1D(name,name,48,0,48);
+     name="HO1P HPD Noise Rate HPD abGetRMindexove 300fC";  HO1P_Rate300 = ib.book1D(name,name,48,0,48);
+     name="HO1M HPD Noise Rate HPD above 300fC";  HO1M_Rate300 = ib.book1D(name,name,48,0,48);
       
 
-     dbe_->setCurrentFolder(subdir_+"Noise Spike Plots");
+     ib.setCurrentFolder(subdir_+"Noise Spike Plots");
 
-     name="HB RM Spike Map";          HB_RBXmapSpikeCnt= dbe_->book2D(name,name,4,0.5,4.5,36,0.5,36.5);
-     name="HE RM Spike Map";          HE_RBXmapSpikeCnt= dbe_->book2D(name,name,4,0.5,4.5,36,0.5,36.5);
-     name="HO RM Spike Map";          HO_RBXmapSpikeCnt= dbe_->book2D(name,name,4,0.5,4.5,36,0.5,36.5);
+     name="HB RM Spike Map";          HB_RBXmapSpikeCnt= ib.book2D(name,name,4,0.5,4.5,36,0.5,36.5);
+     name="HE RM Spike Map";          HE_RBXmapSpikeCnt= ib.book2D(name,name,4,0.5,4.5,36,0.5,36.5);
+     name="HO RM Spike Map";          HO_RBXmapSpikeCnt= ib.book2D(name,name,4,0.5,4.5,36,0.5,36.5);
 
      std::string title="RM";
      HB_RBXmapSpikeCnt->setAxisTitle(title);
@@ -280,7 +271,6 @@ void HcalDetDiagNoiseMonitor::setup(){
         HE_RBXmapSpikeCnt->setBinLabel(i+1,HE_RBX[i],2);
         HO_RBXmapSpikeCnt->setBinLabel(i+1,HO_RBX[i],2);
      }
-  } 
 
 
   return;
@@ -292,7 +282,6 @@ void HcalDetDiagNoiseMonitor::analyze(const edm::Event& iEvent, const edm::Event
   if (LumiInOrder(iEvent.luminosityBlock())==false) return;
   HcalBaseDQMonitor::analyze(iEvent, iSetup);
   bool isNoiseEvent=false;  
-  if(!dbe_) return;
   int orbit=-1111;
   int bx=-1111;
 

--- a/DQM/HcalMonitorTasks/src/HcalDetDiagNoiseMonitor.cc
+++ b/DQM/HcalMonitorTasks/src/HcalDetDiagNoiseMonitor.cc
@@ -152,7 +152,9 @@ public:
   HcalDetDiagNoiseRMData rm[HcalFrontEndId::maxRmIndex];
 };
 
-HcalDetDiagNoiseMonitor::HcalDetDiagNoiseMonitor(const edm::ParameterSet& ps) {
+HcalDetDiagNoiseMonitor::HcalDetDiagNoiseMonitor(const edm::ParameterSet& ps):
+  HcalBaseDQMonitor(ps)
+ {
 
   tok_tb_ = consumes<HcalTBTriggerData>(ps.getParameter<edm::InputTag>("hcalTBTriggerDataTag"));
 

--- a/DQM/HcalMonitorTasks/src/HcalDetDiagNoiseMonitor.cc
+++ b/DQM/HcalMonitorTasks/src/HcalDetDiagNoiseMonitor.cc
@@ -616,6 +616,7 @@ char str[500];
        }
        theFile->Write();
        theFile->Close();
+       theFile->Delete();
        dataset_seq_number++;
 
    }
@@ -624,6 +625,11 @@ char str[500];
 
 void HcalDetDiagNoiseMonitor::done(){}
  
-HcalDetDiagNoiseMonitor::~HcalDetDiagNoiseMonitor(){if(LocalRun) UpdateHistos(); SaveRates(); }
+HcalDetDiagNoiseMonitor::~HcalDetDiagNoiseMonitor()
+{
+  if(LocalRun) UpdateHistos(); SaveRates(); 
+
+  if ( RMSummary ) delete RMSummary;
+}
 
 DEFINE_FWK_MODULE (HcalDetDiagNoiseMonitor);

--- a/DQM/HcalMonitorTasks/src/HcalDetDiagPedestalMonitor.cc
+++ b/DQM/HcalMonitorTasks/src/HcalDetDiagPedestalMonitor.cc
@@ -242,7 +242,7 @@ class HcalDetDiagPedestalMonitor : public HcalBaseDQMonitor {
 
 };
 
-HcalDetDiagPedestalMonitor::HcalDetDiagPedestalMonitor(const edm::ParameterSet& iConfig) {
+HcalDetDiagPedestalMonitor::HcalDetDiagPedestalMonitor(const edm::ParameterSet& iConfig): HcalBaseDQMonitor(iConfig) {
 
   ievt_=-1;
   emap=0;

--- a/DQM/HcalMonitorTasks/src/HcalDetDiagPedestalMonitor.cc
+++ b/DQM/HcalMonitorTasks/src/HcalDetDiagPedestalMonitor.cc
@@ -155,7 +155,7 @@ class HcalDetDiagPedestalMonitor : public HcalBaseDQMonitor {
     edm::EDGetTokenT<FEDRawDataCollection> tok_raw_;
     edm::EDGetTokenT<HcalTBTriggerData> tok_tb_;
 
-      void beginRun(const edm::Run& run, const edm::EventSetup& c) override;  
+      void bookHistograms(DQMStore::IBooker &ib, const edm::Run& run, const edm::EventSetup& c) override;  
       void endRun(const edm::Run& run, const edm::EventSetup& c) override;
       void beginLuminosityBlock(const edm::LuminosityBlock& lumiSeg,const edm::EventSetup& c) override ;
       void endLuminosityBlock(const edm::LuminosityBlock& lumiSeg,const edm::EventSetup& c) override;
@@ -290,7 +290,7 @@ HcalDetDiagPedestalMonitor::HcalDetDiagPedestalMonitor(const edm::ParameterSet& 
 
 HcalDetDiagPedestalMonitor::~HcalDetDiagPedestalMonitor(){}
 
-void HcalDetDiagPedestalMonitor::beginRun(const edm::Run& run, const edm::EventSetup& c){
+void HcalDetDiagPedestalMonitor::bookHistograms(DQMStore::IBooker &ib, const edm::Run& run, const edm::EventSetup& c){
   edm::ESHandle<HcalDbService> conditions_;
   c.get<HcalDbRecord>().get(conditions_);
   emap=conditions_->getHcalMapping();
@@ -311,80 +311,79 @@ void HcalDetDiagPedestalMonitor::beginRun(const edm::Run& run, const edm::EventS
   } 
  
 
-  HcalBaseDQMonitor::setup();
-  if (!dbe_) return;
+  HcalBaseDQMonitor::setup(ib);
   std::string name;
 
-  dbe_->setCurrentFolder(subdir_);   
-  meEVT_ = dbe_->bookInt("HcalDetDiagPedestalMonitor Event Number");
-  meRUN_ = dbe_->bookInt("HcalDetDiagPedestalMonitor Run Number");
+  ib.setCurrentFolder(subdir_);   
+  meEVT_ = ib.bookInt("HcalDetDiagPedestalMonitor Event Number");
+  meRUN_ = ib.bookInt("HcalDetDiagPedestalMonitor Run Number");
 
   ReferenceRun="UNKNOWN";
   LoadReference();
   LoadDataset();
-  dbe_->setCurrentFolder(subdir_);
-  RefRun_= dbe_->bookString("HcalDetDiagPedestalMonitor Reference Run",ReferenceRun);
+  ib.setCurrentFolder(subdir_);
+  RefRun_= ib.bookString("HcalDetDiagPedestalMonitor Reference Run",ReferenceRun);
   if(DatasetName.size()>0 && createHTMLonly){
      char str[200]; sprintf(str,"%sHcalDetDiagPedestalData_run%i_%i/",htmlOutputPath.c_str(),run_number,dataset_seq_number);
-     htmlFolder=dbe_->bookString("HcalDetDiagPedestalMonitor HTML folder",str);
+     htmlFolder=ib.bookString("HcalDetDiagPedestalMonitor HTML folder",str);
      MonitorElement *me;
-     dbe_->setCurrentFolder(prefixME_+"HcalInfo");
-     me=dbe_->bookInt("HBpresent");
+     ib.setCurrentFolder(prefixME_+"HcalInfo");
+     me=ib.bookInt("HBpresent");
      if(nHB>0) me->Fill(1);
-     me=dbe_->bookInt("HEpresent");
+     me=ib.bookInt("HEpresent");
      if(nHE>0) me->Fill(1);
-     me=dbe_->bookInt("HOpresent");
+     me=ib.bookInt("HOpresent");
      if(nHO>0) me->Fill(1);
-     me=dbe_->bookInt("HFpresent");
+     me=ib.bookInt("HFpresent");
      if(nHF>0) me->Fill(1);
   }
 
   ProblemCellsByDepth_missing = new EtaPhiHists();
-  ProblemCellsByDepth_missing->setup(dbe_," Problem Missing Channels");
+  ProblemCellsByDepth_missing->setup(ib," Problem Missing Channels");
   for(unsigned int i=0;i<ProblemCellsByDepth_missing->depth.size();i++)
           problemnames_.push_back(ProblemCellsByDepth_missing->depth[i]->getName());
   ProblemCellsByDepth_unstable = new EtaPhiHists();
-  ProblemCellsByDepth_unstable->setup(dbe_," Problem Unstable Channels");
+  ProblemCellsByDepth_unstable->setup(ib," Problem Unstable Channels");
   for(unsigned int i=0;i<ProblemCellsByDepth_unstable->depth.size();i++)
           problemnames_.push_back(ProblemCellsByDepth_unstable->depth[i]->getName());
   ProblemCellsByDepth_badped = new EtaPhiHists();
-  ProblemCellsByDepth_badped->setup(dbe_," Problem Bad Pedestal Value");
+  ProblemCellsByDepth_badped->setup(ib," Problem Bad Pedestal Value");
   for(unsigned int i=0;i<ProblemCellsByDepth_badped->depth.size();i++)
           problemnames_.push_back(ProblemCellsByDepth_badped->depth[i]->getName());
   ProblemCellsByDepth_badrms = new EtaPhiHists();
-  ProblemCellsByDepth_badrms->setup(dbe_," Problem Bad Rms Value");
+  ProblemCellsByDepth_badrms->setup(ib," Problem Bad Rms Value");
   for(unsigned int i=0;i<ProblemCellsByDepth_badrms->depth.size();i++)
           problemnames_.push_back(ProblemCellsByDepth_badrms->depth[i]->getName());
 
-  dbe_->setCurrentFolder(subdir_+"Summary Plots");
-  name="HB Pedestal Distribution (average over 4 caps)";           PedestalsAve4HB = dbe_->book1D(name,name,200,0,6);
-  name="HE Pedestal Distribution (average over 4 caps)";           PedestalsAve4HE = dbe_->book1D(name,name,200,0,6);
-  name="HO Pedestal Distribution (average over 4 caps)";           PedestalsAve4HO = dbe_->book1D(name,name,200,0,6);
-  name="HF Pedestal Distribution (average over 4 caps)";           PedestalsAve4HF = dbe_->book1D(name,name,200,0,6);
-  name="SIPM Pedestal Distribution (average over 4 caps)";         PedestalsAve4Simp = dbe_->book1D(name,name,200,5,15);
+  ib.setCurrentFolder(subdir_+"Summary Plots");
+  name="HB Pedestal Distribution (average over 4 caps)";           PedestalsAve4HB = ib.book1D(name,name,200,0,6);
+  name="HE Pedestal Distribution (average over 4 caps)";           PedestalsAve4HE = ib.book1D(name,name,200,0,6);
+  name="HO Pedestal Distribution (average over 4 caps)";           PedestalsAve4HO = ib.book1D(name,name,200,0,6);
+  name="HF Pedestal Distribution (average over 4 caps)";           PedestalsAve4HF = ib.book1D(name,name,200,0,6);
+  name="SIPM Pedestal Distribution (average over 4 caps)";         PedestalsAve4Simp = ib.book1D(name,name,200,5,15);
      
-  name="HB Pedestal-Reference Distribution (average over 4 caps)"; PedestalsAve4HBref= dbe_->book1D(name,name,1500,-3,3);
-  name="HE Pedestal-Reference Distribution (average over 4 caps)"; PedestalsAve4HEref= dbe_->book1D(name,name,1500,-3,3);
-  name="HO Pedestal-Reference Distribution (average over 4 caps)"; PedestalsAve4HOref= dbe_->book1D(name,name,1500,-3,3);
-  name="HF Pedestal-Reference Distribution (average over 4 caps)"; PedestalsAve4HFref= dbe_->book1D(name,name,1500,-3,3);
+  name="HB Pedestal-Reference Distribution (average over 4 caps)"; PedestalsAve4HBref= ib.book1D(name,name,1500,-3,3);
+  name="HE Pedestal-Reference Distribution (average over 4 caps)"; PedestalsAve4HEref= ib.book1D(name,name,1500,-3,3);
+  name="HO Pedestal-Reference Distribution (average over 4 caps)"; PedestalsAve4HOref= ib.book1D(name,name,1500,-3,3);
+  name="HF Pedestal-Reference Distribution (average over 4 caps)"; PedestalsAve4HFref= ib.book1D(name,name,1500,-3,3);
     
-  name="HB Pedestal RMS Distribution (individual cap)";            PedestalsRmsHB = dbe_->book1D(name,name,200,0,2);
-  name="HE Pedestal RMS Distribution (individual cap)";            PedestalsRmsHE = dbe_->book1D(name,name,200,0,2);
-  name="HO Pedestal RMS Distribution (individual cap)";            PedestalsRmsHO = dbe_->book1D(name,name,200,0,2);
-  name="HF Pedestal RMS Distribution (individual cap)";            PedestalsRmsHF = dbe_->book1D(name,name,200,0,2);
-  name="SIPM Pedestal RMS Distribution (individual cap)";          PedestalsRmsSimp = dbe_->book1D(name,name,200,0,4);
+  name="HB Pedestal RMS Distribution (individual cap)";            PedestalsRmsHB = ib.book1D(name,name,200,0,2);
+  name="HE Pedestal RMS Distribution (individual cap)";            PedestalsRmsHE = ib.book1D(name,name,200,0,2);
+  name="HO Pedestal RMS Distribution (individual cap)";            PedestalsRmsHO = ib.book1D(name,name,200,0,2);
+  name="HF Pedestal RMS Distribution (individual cap)";            PedestalsRmsHF = ib.book1D(name,name,200,0,2);
+  name="SIPM Pedestal RMS Distribution (individual cap)";          PedestalsRmsSimp = ib.book1D(name,name,200,0,4);
      
-  name="HB Pedestal_rms-Reference_rms Distribution";               PedestalsRmsHBref = dbe_->book1D(name,name,1500,-3,3);
-  name="HE Pedestal_rms-Reference_rms Distribution";               PedestalsRmsHEref = dbe_->book1D(name,name,1500,-3,3);
-  name="HO Pedestal_rms-Reference_rms Distribution";               PedestalsRmsHOref = dbe_->book1D(name,name,1500,-3,3);
-  name="HF Pedestal_rms-Reference_rms Distribution";               PedestalsRmsHFref = dbe_->book1D(name,name,1500,-3,3);
+  name="HB Pedestal_rms-Reference_rms Distribution";               PedestalsRmsHBref = ib.book1D(name,name,1500,-3,3);
+  name="HE Pedestal_rms-Reference_rms Distribution";               PedestalsRmsHEref = ib.book1D(name,name,1500,-3,3);
+  name="HO Pedestal_rms-Reference_rms Distribution";               PedestalsRmsHOref = ib.book1D(name,name,1500,-3,3);
+  name="HF Pedestal_rms-Reference_rms Distribution";               PedestalsRmsHFref = ib.book1D(name,name,1500,-3,3);
      
-  name="HBHEHF pedestal mean map";       Pedestals2DHBHEHF      = dbe_->book2D(name,name,87,-43,43,74,0,73);
-  name="HO pedestal mean map";           Pedestals2DHO          = dbe_->book2D(name,name,33,-16,16,74,0,73);
-  name="HBHEHF pedestal rms map";        Pedestals2DRmsHBHEHF   = dbe_->book2D(name,name,87,-43,43,74,0,73);
-  name="HO pedestal rms map";            Pedestals2DRmsHO       = dbe_->book2D(name,name,33,-16,16,74,0,73);
-  name="HBHEHF pedestal problems map";   Pedestals2DErrorHBHEHF = dbe_->book2D(name,name,87,-43,43,74,0,73);
-  name="HO pedestal problems map";       Pedestals2DErrorHO     = dbe_->book2D(name,name,33,-16,16,74,0,73);
+  name="HBHEHF pedestal mean map";       Pedestals2DHBHEHF      = ib.book2D(name,name,87,-43,43,74,0,73);
+  name="HO pedestal mean map";           Pedestals2DHO          = ib.book2D(name,name,33,-16,16,74,0,73);
+  name="HBHEHF pedestal rms map";        Pedestals2DRmsHBHEHF   = ib.book2D(name,name,87,-43,43,74,0,73);
+  name="HO pedestal rms map";            Pedestals2DRmsHO       = ib.book2D(name,name,33,-16,16,74,0,73);
+  name="HBHEHF pedestal problems map";   Pedestals2DErrorHBHEHF = ib.book2D(name,name,87,-43,43,74,0,73);
+  name="HO pedestal problems map";       Pedestals2DErrorHO     = ib.book2D(name,name,33,-16,16,74,0,73);
 
   Pedestals2DHBHEHF->setAxisRange(1,5,3);
   Pedestals2DHO->setAxisRange(1,5,3);
@@ -422,15 +421,15 @@ void HcalDetDiagPedestalMonitor::beginRun(const edm::Run& run, const edm::EventS
   PedestalsRmsHOref->setAxisTitle("ADC counts",1);
   PedestalsRmsHFref->setAxisTitle("ADC counts",1);
 
-  dbe_->setCurrentFolder(subdir_+"Plots for client");
+  ib.setCurrentFolder(subdir_+"Plots for client");
   ProblemCellsByDepth_missing_val = new EtaPhiHists();
-  ProblemCellsByDepth_missing_val->setup(dbe_," Missing channels");
+  ProblemCellsByDepth_missing_val->setup(ib," Missing channels");
   ProblemCellsByDepth_unstable_val = new EtaPhiHists();
-  ProblemCellsByDepth_unstable_val->setup(dbe_," Channel instability value");
+  ProblemCellsByDepth_unstable_val->setup(ib," Channel instability value");
   ProblemCellsByDepth_badped_val = new EtaPhiHists();
-  ProblemCellsByDepth_badped_val->setup(dbe_," Bad Pedestal-Ref Value");
+  ProblemCellsByDepth_badped_val->setup(ib," Bad Pedestal-Ref Value");
   ProblemCellsByDepth_badrms_val = new EtaPhiHists();
-  ProblemCellsByDepth_badrms_val->setup(dbe_," Bad Rms-ref Value");
+  ProblemCellsByDepth_badrms_val->setup(ib," Bad Rms-ref Value");
 }
 
 

--- a/DQM/HcalMonitorTasks/src/HcalDetDiagPedestalMonitor.cc
+++ b/DQM/HcalMonitorTasks/src/HcalDetDiagPedestalMonitor.cc
@@ -286,9 +286,32 @@ HcalDetDiagPedestalMonitor::HcalDetDiagPedestalMonitor(const edm::ParameterSet& 
   tok_raw_ = consumes<FEDRawDataCollection>(iConfig.getUntrackedParameter<edm::InputTag>("rawDataLabel"));
   tok_tb_ = consumes<HcalTBTriggerData>(iConfig.getParameter<edm::InputTag>("hcalTBTriggerDataTag"));
 
+
+  ProblemCellsByDepth_missing=0;
+  ProblemCellsByDepth_unstable=0;
+  ProblemCellsByDepth_badped=0;
+  ProblemCellsByDepth_badrms=0;
+
+  ProblemCellsByDepth_missing_val=0;
+  ProblemCellsByDepth_unstable_val=0;
+  ProblemCellsByDepth_badped_val=0;
+  ProblemCellsByDepth_badrms_val=0;
+
 }
 
-HcalDetDiagPedestalMonitor::~HcalDetDiagPedestalMonitor(){}
+HcalDetDiagPedestalMonitor::~HcalDetDiagPedestalMonitor()
+{
+
+  if ( ProblemCellsByDepth_missing ) delete ProblemCellsByDepth_missing;
+  if ( ProblemCellsByDepth_unstable ) delete ProblemCellsByDepth_unstable;
+  if ( ProblemCellsByDepth_badped ) delete ProblemCellsByDepth_badped;
+  if ( ProblemCellsByDepth_badrms ) delete ProblemCellsByDepth_badrms;
+  if ( ProblemCellsByDepth_missing_val ) delete ProblemCellsByDepth_missing_val;
+  if ( ProblemCellsByDepth_unstable_val ) delete ProblemCellsByDepth_unstable_val;
+  if ( ProblemCellsByDepth_badped_val ) delete ProblemCellsByDepth_badped_val;
+  if ( ProblemCellsByDepth_badrms_val ) delete ProblemCellsByDepth_badrms_val;
+
+}
 
 void HcalDetDiagPedestalMonitor::bookHistograms(DQMStore::IBooker &ib, const edm::Run& run, const edm::EventSetup& c){
   edm::ESHandle<HcalDbService> conditions_;
@@ -1025,6 +1048,7 @@ char   Subdet[10],str[500];
       }
       theFile->Write();
       theFile->Close();
+      theFile->Delete();
    }
 
    if(XmlFilePath.size()>0){
@@ -1221,6 +1245,7 @@ void HcalDetDiagPedestalMonitor::LoadReference(){
     }
   }
   f->Close();
+  f->Delete();
   IsReference=true;
 } 
 
@@ -1305,6 +1330,7 @@ void HcalDetDiagPedestalMonitor::LoadDataset(){
   if(STR3){ int ds; sscanf(STR3->String(),"%i",&ds); dataset_seq_number=ds;}
 
   f->Close();
+  f->Delete();
 } 
 void HcalDetDiagPedestalMonitor::beginLuminosityBlock(const edm::LuminosityBlock& lumiSeg,const edm::EventSetup& c){}
 void HcalDetDiagPedestalMonitor::endLuminosityBlock(const edm::LuminosityBlock& lumiSeg,const edm::EventSetup& c){}

--- a/DQM/HcalMonitorTasks/src/HcalDetDiagTimingMonitor.cc
+++ b/DQM/HcalMonitorTasks/src/HcalDetDiagTimingMonitor.cc
@@ -35,7 +35,7 @@ static const int TRIG_GCT=4;
 static const int TRIG_CSC=8;
 static const int TRIG_RPCF=16;
 
-HcalDetDiagTimingMonitor::HcalDetDiagTimingMonitor(const edm::ParameterSet& ps) 
+HcalDetDiagTimingMonitor::HcalDetDiagTimingMonitor(const edm::ParameterSet& ps) :HcalBaseDQMonitor(ps)
 {
   Online_                = ps.getUntrackedParameter<bool>("online",false);
   mergeRuns_             = ps.getUntrackedParameter<bool>("mergeRuns",false);

--- a/DQM/HcalMonitorTasks/src/HcalDetDiagTimingMonitor.cc
+++ b/DQM/HcalMonitorTasks/src/HcalDetDiagTimingMonitor.cc
@@ -74,39 +74,31 @@ HcalDetDiagTimingMonitor::HcalDetDiagTimingMonitor(const edm::ParameterSet& ps)
 
 HcalDetDiagTimingMonitor::~HcalDetDiagTimingMonitor(){}
 
-void HcalDetDiagTimingMonitor::cleanup(){
-  if(dbe_){
-    dbe_->setCurrentFolder(subdir_);
-    dbe_->removeContents();
-    dbe_ = 0;
-  }
-} 
 void HcalDetDiagTimingMonitor::reset(){}
 
-void HcalDetDiagTimingMonitor::beginRun(const edm::Run& run, const edm::EventSetup& c)
+void HcalDetDiagTimingMonitor::bookHistograms(DQMStore::IBooker &ib, const edm::Run& run, const edm::EventSetup& c)
 {
-  if (debug_>1) std::cout <<"HcalDetDiagTimingMonitor::beginRun"<<std::endl;
-  HcalBaseDQMonitor::beginRun(run,c);
+  if (debug_>1) std::cout <<"HcalDetDiagTimingMonitor::bookHistograms"<<std::endl;
+  HcalBaseDQMonitor::bookHistograms(ib,run,c);
 
-  if (tevt_==0) this->setup(); // set up histograms if they have not been created before
+  if (tevt_==0) this->setup(ib); // set up histograms if they have not been created before
   if (mergeRuns_==false)
     this->reset();
 
   return;
 
-} // void HcalNDetDiagTimingMonitor::beginRun(...)
+} // void HcalNDetDiagTimingMonitor::bookHistograms(...)
 
 
 
-void HcalDetDiagTimingMonitor::setup()
+void HcalDetDiagTimingMonitor::setup(DQMStore::IBooker &ib)
 {
   
-  HcalBaseDQMonitor::setup();
+  HcalBaseDQMonitor::setup(ib);
 
   std::string str;
-  if(dbe_!=NULL){    
-     dbe_->setCurrentFolder(subdir_);   
-     str="Hcal Timing summary"; Summary = dbe_->book2D(str,str,6,0,6,6,0,6); 
+     ib.setCurrentFolder(subdir_);   
+     str="Hcal Timing summary"; Summary = ib.book2D(str,str,6,0,6,6,0,6); 
      Summary->setBinLabel(1,"DT",1);
      Summary->setBinLabel(2,"RPC",1);
      Summary->setBinLabel(3,"GCT",1);
@@ -121,26 +113,26 @@ void HcalDetDiagTimingMonitor::setup()
      Summary->setBinLabel(6,"HFP",2);
      for(int i=1;i<=6;i++) for(int j=1;j<=6;j++) Summary->setBinContent(i,j,-1);
      
-     dbe_->setCurrentFolder(subdir_+"Timing Plots");
-     str="HB Timing (DT Trigger)";                      HBTimeDT  = dbe_->book1D(str,str,100,0,10); 
-     str="HO Timing (DT Trigger)";                      HOTimeDT  = dbe_->book1D(str,str,100,0,10); 
-     str="HB Timing (RPC Trigger)";                     HBTimeRPC = dbe_->book1D(str,str,100,0,10); 
-     str="HO Timing (RPC Trigger)";                     HOTimeRPC = dbe_->book1D(str,str,100,0,10); 
-     str="HB Timing (HO SelfTrigger tech bit 11)";      HBTimeHO  = dbe_->book1D(str,str,100,0,10); 
-     str="HO Timing (HO SelfTrigger tech bit 11)";      HOTimeHO  = dbe_->book1D(str,str,100,0,10); 
+     ib.setCurrentFolder(subdir_+"Timing Plots");
+     str="HB Timing (DT Trigger)";                      HBTimeDT  = ib.book1D(str,str,100,0,10); 
+     str="HO Timing (DT Trigger)";                      HOTimeDT  = ib.book1D(str,str,100,0,10); 
+     str="HB Timing (RPC Trigger)";                     HBTimeRPC = ib.book1D(str,str,100,0,10); 
+     str="HO Timing (RPC Trigger)";                     HOTimeRPC = ib.book1D(str,str,100,0,10); 
+     str="HB Timing (HO SelfTrigger tech bit 11)";      HBTimeHO  = ib.book1D(str,str,100,0,10); 
+     str="HO Timing (HO SelfTrigger tech bit 11)";      HOTimeHO  = ib.book1D(str,str,100,0,10); 
      
-     str="HB Timing (GCT Trigger alg bit 15 16 17 18)"; HBTimeGCT  =dbe_->book1D(str,str,100,0,10); 
-     str="HO Timing (GCT Trigger alg bit 15 16 17 18)"; HOTimeGCT  =dbe_->book1D(str,str,100,0,10); 
+     str="HB Timing (GCT Trigger alg bit 15 16 17 18)"; HBTimeGCT  =ib.book1D(str,str,100,0,10); 
+     str="HO Timing (GCT Trigger alg bit 15 16 17 18)"; HOTimeGCT  =ib.book1D(str,str,100,0,10); 
      
-     str="HEP Timing (CSC Trigger)";                    HETimeCSCp =dbe_->book1D(str,str,100,0,10); 
-     str="HEM Timing (CSC Trigger)";                    HETimeCSCm =dbe_->book1D(str,str,100,0,10);
-     str="HEP Timing (RPCf Trigger)";                   HETimeRPCp =dbe_->book1D(str,str,100,0,10); 
-     str="HEM Timing (RPCf Trigger)";                   HETimeRPCm =dbe_->book1D(str,str,100,0,10);
-     str="HFP Timing (CSC Trigger)";                    HFTimeCSCp =dbe_->book1D(str,str,100,0,10); 
-     str="HFM Timing (CSC Trigger)";                    HFTimeCSCm =dbe_->book1D(str,str,100,0,10);     
-     str="HBHE Shape";                                  HBHEShape  =dbe_->book1D(str,str,10,-0.5,9.5);
-     str="HO Shape";                                    HOShape    =dbe_->book1D(str,str,10,-0.5,9.5);
-  }   
+     str="HEP Timing (CSC Trigger)";                    HETimeCSCp =ib.book1D(str,str,100,0,10); 
+     str="HEM Timing (CSC Trigger)";                    HETimeCSCm =ib.book1D(str,str,100,0,10);
+     str="HEP Timing (RPCf Trigger)";                   HETimeRPCp =ib.book1D(str,str,100,0,10); 
+     str="HEM Timing (RPCf Trigger)";                   HETimeRPCm =ib.book1D(str,str,100,0,10);
+     str="HFP Timing (CSC Trigger)";                    HFTimeCSCp =ib.book1D(str,str,100,0,10); 
+     str="HFM Timing (CSC Trigger)";                    HFTimeCSCm =ib.book1D(str,str,100,0,10);     
+     str="HBHE Shape";                                  HBHEShape  =ib.book1D(str,str,10,-0.5,9.5);
+     str="HO Shape";                                    HOShape    =ib.book1D(str,str,10,-0.5,9.5);
+
 } 
 
 void HcalDetDiagTimingMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
@@ -151,7 +143,6 @@ void HcalDetDiagTimingMonitor::analyze(const edm::Event& iEvent, const edm::Even
   
   int eta,phi,depth,nTS,BXinEVENT=1,TRIGGER=0;
   
-  if(!dbe_) return;
   // We do not want to look at Abort Gap events
   edm::Handle<FEDRawDataCollection> rawdata;
   iEvent.getByToken(tok_raw_,rawdata);

--- a/DQM/HcalMonitorTasks/src/HcalDigiMonitor.cc
+++ b/DQM/HcalMonitorTasks/src/HcalDigiMonitor.cc
@@ -9,7 +9,7 @@
 #include "CondFormats/HcalObjects/interface/HcalChannelQuality.h"
 
 // constructor
-HcalDigiMonitor::HcalDigiMonitor(const edm::ParameterSet& ps) 
+HcalDigiMonitor::HcalDigiMonitor(const edm::ParameterSet& ps):HcalBaseDQMonitor(ps)
 {
   Online_                = ps.getUntrackedParameter<bool>("online",false);
   mergeRuns_             = ps.getUntrackedParameter<bool>("mergeRuns",false);

--- a/DQM/HcalMonitorTasks/src/HcalDigiMonitor.cc
+++ b/DQM/HcalMonitorTasks/src/HcalDigiMonitor.cc
@@ -111,7 +111,7 @@ static bool bitUpset(int last, int now){
   return true;
 } // static bool bitUpset(...)
 
-void HcalDigiMonitor::cleanup()
+/*void HcalDigiMonitor::cleanup()
 {
   // Need to add code to clear out subfolders as well?
   if (debug_>0) std::cout <<"HcalDigiMonitor::cleanup()"<<std::endl;
@@ -143,7 +143,7 @@ void HcalDigiMonitor::cleanup()
       dbe_->removeContents();
     } // if(dbe_)
 
-} // void HcalDigiMonitor::cleanup();
+}*/ // void HcalDigiMonitor::cleanup();
 
 
 void HcalDigiMonitor::endRun(const edm::Run& run, const edm::EventSetup& c)
@@ -158,59 +158,58 @@ void HcalDigiMonitor::endJob()
 }
 
 
-void HcalDigiMonitor::setup()
+void HcalDigiMonitor::setup(DQMStore::IBooker &ib)
 {
   if (setupDone_)
     return;
   setupDone_=true;
   // Call base class setup
-  HcalBaseDQMonitor::setup();
-  if (!dbe_) return;
+  HcalBaseDQMonitor::setup(ib);
 
   /******* Set up all histograms  ********/
   if (debug_>1)
-    std::cout <<"<HcalDigiMonitor::beginRun>  Setting up histograms"<<std::endl;
+    std::cout <<"<HcalDigiMonitor::setup>  Setting up histograms"<<std::endl;
 
   std::ostringstream name;
-  dbe_->setCurrentFolder(subdir_);
+  ib.setCurrentFolder(subdir_);
   
-  dbe_->setCurrentFolder(subdir_+"digi_parameters");
-  MonitorElement* ExpectedOrbit = dbe_->bookInt("ExpectedOrbitMessageTime");
+  ib.setCurrentFolder(subdir_+"digi_parameters");
+  MonitorElement* ExpectedOrbit = ib.bookInt("ExpectedOrbitMessageTime");
   ExpectedOrbit->Fill(DigiMonitor_ExpectedOrbitMessageTime_);
 
-  MonitorElement* shapeT = dbe_->bookInt("DigiShapeThresh");
+  MonitorElement* shapeT = ib.bookInt("DigiShapeThresh");
   shapeT->Fill(shapeThresh_);
-  MonitorElement* shapeTHB = dbe_->bookInt("DigiShapeThreshHB");
+  MonitorElement* shapeTHB = ib.bookInt("DigiShapeThreshHB");
   shapeTHB->Fill(shapeThreshHB_);
-  MonitorElement* shapeTHE = dbe_->bookInt("DigiShapeThreshHE");
+  MonitorElement* shapeTHE = ib.bookInt("DigiShapeThreshHE");
   shapeTHE->Fill(shapeThreshHE_);
-  MonitorElement* shapeTHO = dbe_->bookInt("DigiShapeThreshHO");
+  MonitorElement* shapeTHO = ib.bookInt("DigiShapeThreshHO");
   shapeTHO->Fill(shapeThreshHO_);
-  MonitorElement* shapeTHF = dbe_->bookInt("DigiShapeThreshHF");
+  MonitorElement* shapeTHF = ib.bookInt("DigiShapeThreshHF");
   shapeTHF->Fill(shapeThreshHF_);
   
-  dbe_->setCurrentFolder(subdir_+"bad_digis/bad_digi_occupancy");
-  SetupEtaPhiHists(DigiErrorsByDepth,"Bad Digi Map","");
-  dbe_->setCurrentFolder(subdir_+"bad_digis/1D_digi_plots");
-  ProblemsVsLB=dbe_->bookProfile("BadDigisVsLB","Number Bad Digis vs Luminosity block;Lumi block;# of Bad digis",
+  ib.setCurrentFolder(subdir_+"bad_digis/bad_digi_occupancy");
+  SetupEtaPhiHists(ib,DigiErrorsByDepth,"Bad Digi Map","");
+  ib.setCurrentFolder(subdir_+"bad_digis/1D_digi_plots");
+  ProblemsVsLB=ib.bookProfile("BadDigisVsLB","Number Bad Digis vs Luminosity block;Lumi block;# of Bad digis",
 				 NLumiBlocks_,0.5,NLumiBlocks_+0.5,100,0,10000);
-  ProblemsVsLB_HB=dbe_->bookProfile("HB Bad Quality Digis vs LB","HB Bad Quality Digis vs Luminosity Block",
+  ProblemsVsLB_HB=ib.bookProfile("HB Bad Quality Digis vs LB","HB Bad Quality Digis vs Luminosity Block",
 				     NLumiBlocks_,0.5,NLumiBlocks_+0.5,
 				     100,0,10000);   
-  ProblemsVsLB_HE=dbe_->bookProfile("HE Bad Quality Digis vs LB","HE Bad Quality Digis vs Luminosity Block",
+  ProblemsVsLB_HE=ib.bookProfile("HE Bad Quality Digis vs LB","HE Bad Quality Digis vs Luminosity Block",
 				     NLumiBlocks_,0.5,NLumiBlocks_+0.5,
 				     100,0,10000);
-  ProblemsVsLB_HO=dbe_->bookProfile("HO Bad Quality Digis vs LB","HO Bad Quality Digis vs Luminosity Block",
+  ProblemsVsLB_HO=ib.bookProfile("HO Bad Quality Digis vs LB","HO Bad Quality Digis vs Luminosity Block",
 				     NLumiBlocks_,0.5,NLumiBlocks_+0.5,
 				     100,0,10000);
-  ProblemsVsLB_HF=dbe_->bookProfile("HF Bad Quality Digis vs LB","HF Bad Quality Digis vs Luminosity Block",
+  ProblemsVsLB_HF=ib.bookProfile("HF Bad Quality Digis vs LB","HF Bad Quality Digis vs Luminosity Block",
 				     NLumiBlocks_,0.5,NLumiBlocks_+0.5,
 				     100,0,10000);
-  ProblemsVsLB_HBHEHF=dbe_->bookProfile("HBHEHF Bad Quality Digis vs LB","HBHEHF Bad Quality Digis vs Luminosity Block",
+  ProblemsVsLB_HBHEHF=ib.bookProfile("HBHEHF Bad Quality Digis vs LB","HBHEHF Bad Quality Digis vs Luminosity Block",
 				     NLumiBlocks_,0.5,NLumiBlocks_+0.5,
 				     100,0,10000);
 
-  ProblemDigisInLastNLB_HBHEHF_alarm=dbe_->book1D("ProblemDigisInLastNLB_HBHEHF_alarm",
+  ProblemDigisInLastNLB_HBHEHF_alarm=ib.book1D("ProblemDigisInLastNLB_HBHEHF_alarm",
 					      "Total Number of ProblemDigis HBHEHF in last 10 LS. Last bin contains OverFlow",
 					      100,0,100);
 
@@ -218,40 +217,40 @@ void HcalDigiMonitor::setup()
   if (makeDiagnostics_) 
     {
       // by default, unpacked digis won't have these errors
-      dbe_->setCurrentFolder(subdir_+"diagnostics/bad_digis/badcapID");
-      SetupEtaPhiHists(DigiErrorsBadCapID," Digis with Bad Cap ID Rotation", "");
-      dbe_->setCurrentFolder(subdir_+"diagnostics/bad_digis/data_invalid_error");
-      SetupEtaPhiHists(DigiErrorsDVErr," Digis with Data Invalid or Error Bit Set", "");
+      ib.setCurrentFolder(subdir_+"diagnostics/bad_digis/badcapID");
+      SetupEtaPhiHists(ib,DigiErrorsBadCapID," Digis with Bad Cap ID Rotation", "");
+      ib.setCurrentFolder(subdir_+"diagnostics/bad_digis/data_invalid_error");
+      SetupEtaPhiHists(ib,DigiErrorsDVErr," Digis with Data Invalid or Error Bit Set", "");
     }
   
   if (Online_)
     {
       // Special histograms for Pawel's timing study
-      dbe_->setCurrentFolder(subdir_+"HFTimingStudy");
-      HFtiming_etaProfile=dbe_->bookProfile("HFTiming_etaProfile","HFTiming Eta Profile;ieta;average time (time slice)",83,-41.5,41.5,200,0,10);
-      HFP_shape=dbe_->book1D("HFP_signal_shape","HFP signal shape",10,-0.5,9.5);
-      HFM_shape=dbe_->book1D("HFM_signal_shape","HFM signal shape",10,-0.5,9.5);
-      dbe_->setCurrentFolder(subdir_+"HFTimingStudy/sumplots");
-      HFtiming_totaltime2D=dbe_->book2D("HFTiming_Total_Time","HFTiming Total Time",83,-41.5,41.5,72,0.5,72.5);
-      HFtiming_occupancy2D=dbe_->book2D("HFTiming_Occupancy","HFTiming Occupancy",83,-41.5,41.5,72,0.5,72.5);
+      ib.setCurrentFolder(subdir_+"HFTimingStudy");
+      HFtiming_etaProfile=ib.bookProfile("HFTiming_etaProfile","HFTiming Eta Profile;ieta;average time (time slice)",83,-41.5,41.5,200,0,10);
+      HFP_shape=ib.book1D("HFP_signal_shape","HFP signal shape",10,-0.5,9.5);
+      HFM_shape=ib.book1D("HFM_signal_shape","HFM signal shape",10,-0.5,9.5);
+      ib.setCurrentFolder(subdir_+"HFTimingStudy/sumplots");
+      HFtiming_totaltime2D=ib.book2D("HFTiming_Total_Time","HFTiming Total Time",83,-41.5,41.5,72,0.5,72.5);
+      HFtiming_occupancy2D=ib.book2D("HFTiming_Occupancy","HFTiming Occupancy",83,-41.5,41.5,72,0.5,72.5);
     }
   
-  dbe_->setCurrentFolder(subdir_+"bad_digis/bad_reportUnpackerErrors");
-  SetupEtaPhiHists(DigiErrorsUnpacker," Bad Unpacker Digis", "");
+  ib.setCurrentFolder(subdir_+"bad_digis/bad_reportUnpackerErrors");
+  SetupEtaPhiHists(ib,DigiErrorsUnpacker," Bad Unpacker Digis", "");
   
-  dbe_->setCurrentFolder(subdir_+"bad_digis/baddigisize");
-  SetupEtaPhiHists(DigiErrorsBadDigiSize," Digis with Bad Size", "");
+  ib.setCurrentFolder(subdir_+"bad_digis/baddigisize");
+  SetupEtaPhiHists(ib,DigiErrorsBadDigiSize," Digis with Bad Size", "");
   
-  dbe_->setCurrentFolder(subdir_+"digi_info");
+  ib.setCurrentFolder(subdir_+"digi_info");
   
-  h_valid_digis=dbe_->book1D("ValidEvents","Events with minimum number of valid digis",2,-0.5,1.5);
+  h_valid_digis=ib.book1D("ValidEvents","Events with minimum number of valid digis",2,-0.5,1.5);
   h_valid_digis->setBinLabel(1,"Valid");
   h_valid_digis->setBinLabel(2,"Invalid");
   
-  h_invalid_orbitnumMod103=dbe_->book1D("InvalidDigiEvents_ORN","Orbit Number (mod 103) for Events with Many Unpacker Errors",103,-0.5,102.5);
-  h_invalid_bcn=dbe_->book1D("InvalidDigiEvents_BCN","Bunch Crossing Number fo Events with Many Unpacker Errors",3464,-0.5,3563.5);
+  h_invalid_orbitnumMod103=ib.book1D("InvalidDigiEvents_ORN","Orbit Number (mod 103) for Events with Many Unpacker Errors",103,-0.5,102.5);
+  h_invalid_bcn=ib.book1D("InvalidDigiEvents_BCN","Bunch Crossing Number fo Events with Many Unpacker Errors",3464,-0.5,3563.5);
 
-  DigiSize = dbe_->book2D("Digi Size", "Digi Size",4,0,4,20,-0.5,19.5);
+  DigiSize = ib.book2D("Digi Size", "Digi Size",4,0,4,20,-0.5,19.5);
   DigiSize->setBinLabel(1,"HB",1);
   DigiSize->setBinLabel(2,"HE",1);
   DigiSize->setBinLabel(3,"HO",1);
@@ -259,93 +258,93 @@ void HcalDigiMonitor::setup()
   DigiSize->setAxisTitle("Subdetector",1);
   DigiSize->setAxisTitle("Digi Size",2);
   
-  DigiExpectedSize = dbe_->book2D("Digi Expected Size", "Digi Expected Size",3,0,3,20,-0.5,19.5);
+  DigiExpectedSize = ib.book2D("Digi Expected Size", "Digi Expected Size",3,0,3,20,-0.5,19.5);
   DigiExpectedSize->setBinLabel(1,"HBHE",1);
   DigiExpectedSize->setBinLabel(2,"HO",1);
   DigiExpectedSize->setBinLabel(3,"HF",1);
   DigiExpectedSize->setAxisTitle("Subdetector",1);
   DigiExpectedSize->setAxisTitle("Digi Expected Size from HTR",2);
   
-  dbe_->setCurrentFolder(subdir_+"bad_digis/badfibBCNoff");
-  SetupEtaPhiHists(DigiErrorsBadFibBCNOff," Digis with non-zero Fiber Orbit Msg Idle BCN Offsets", "");
+  ib.setCurrentFolder(subdir_+"bad_digis/badfibBCNoff");
+  SetupEtaPhiHists(ib,DigiErrorsBadFibBCNOff," Digis with non-zero Fiber Orbit Msg Idle BCN Offsets", "");
   
-  dbe_->setCurrentFolder(subdir_+"good_digis/1D_digi_plots");
-  HBocc_vs_LB=dbe_->bookProfile("HBoccVsLB","HB digi occupancy vs Luminosity Block;Lumi block;# of Good digis",
+  ib.setCurrentFolder(subdir_+"good_digis/1D_digi_plots");
+  HBocc_vs_LB=ib.bookProfile("HBoccVsLB","HB digi occupancy vs Luminosity Block;Lumi block;# of Good digis",
 				 NLumiBlocks_,0.5,NLumiBlocks_+0.5,
 				 0,2600);
-  HEocc_vs_LB=dbe_->bookProfile("HEoccVsLB","HE digi occupancy vs Luminosity Block;Lumi block;# of Good digis",
+  HEocc_vs_LB=ib.bookProfile("HEoccVsLB","HE digi occupancy vs Luminosity Block;Lumi block;# of Good digis",
 				 NLumiBlocks_,0.5,NLumiBlocks_+0.5,
 				 0,2600);
-  HOocc_vs_LB=dbe_->bookProfile("HOoccVsLB","HO digi occupancy vs Luminosity Block;Lumi block;# of Good digis",
+  HOocc_vs_LB=ib.bookProfile("HOoccVsLB","HO digi occupancy vs Luminosity Block;Lumi block;# of Good digis",
 				 NLumiBlocks_,0.5,NLumiBlocks_+0.5,
 				 0,2200);
-  HFocc_vs_LB=dbe_->bookProfile("HFoccVsLB","HF digi occupancy vs Luminosity Block;Lumi block;# of Good digis",
+  HFocc_vs_LB=ib.bookProfile("HFoccVsLB","HF digi occupancy vs Luminosity Block;Lumi block;# of Good digis",
 				 NLumiBlocks_,0.5,NLumiBlocks_+0.5,
 				 0,1800);
   
-  dbe_->setCurrentFolder(subdir_+"good_digis/digi_occupancy");
-  SetupEtaPhiHists(DigiOccupancyByDepth," Digi Eta-Phi Occupancy Map","");
-  DigiOccupancyPhi= dbe_->book1D("Digi Phi Occupancy Map",
+  ib.setCurrentFolder(subdir_+"good_digis/digi_occupancy");
+  SetupEtaPhiHists(ib,DigiOccupancyByDepth," Digi Eta-Phi Occupancy Map","");
+  DigiOccupancyPhi= ib.book1D("Digi Phi Occupancy Map",
 				  "Digi Phi Occupancy Map;i#phi;# of Events",
 				  72,0.5,72.5);
-  DigiOccupancyEta= dbe_->book1D("Digi Eta Occupancy Map",
+  DigiOccupancyEta= ib.book1D("Digi Eta Occupancy Map",
 				  "Digi Eta Occupancy Map;i#eta;# of Events",
 				  83,-41.5,41.5);
-  DigiOccupancyVME = dbe_->book2D("Digi VME Occupancy Map",
+  DigiOccupancyVME = ib.book2D("Digi VME Occupancy Map",
 				   "Digi VME Occupancy Map;HTR Slot;VME Crate Id",
 				   40,-0.25,19.75,18,-0.5,17.5);
   
-  DigiOccupancySpigot = dbe_->book2D("Digi Spigot Occupancy Map",
+  DigiOccupancySpigot = ib.book2D("Digi Spigot Occupancy Map",
 				      "Digi Spigot Occupancy Map;Spigot;DCC Id",
 				      HcalDCCHeader::SPIGOT_COUNT,-0.5,HcalDCCHeader::SPIGOT_COUNT-0.5,
 				      36,-0.5,35.5);
   
-  dbe_->setCurrentFolder(subdir_+"bad_digis/bad_digi_occupancy");
-  DigiErrorVME = dbe_->book2D("Digi VME Error Map",
+  ib.setCurrentFolder(subdir_+"bad_digis/bad_digi_occupancy");
+  DigiErrorVME = ib.book2D("Digi VME Error Map",
 			       "Digi VME Error Map;HTR Slot;VME Crate Id",
 			       40,-0.25,19.75,18,-0.5,17.5);
   
-  DigiErrorSpigot = dbe_->book2D("Digi Spigot Error Map",
+  DigiErrorSpigot = ib.book2D("Digi Spigot Error Map",
 				  "Digi Spigot Error Map;Spigot;DCC Id",
 				  HcalDCCHeader::SPIGOT_COUNT,-0.5,HcalDCCHeader::SPIGOT_COUNT-0.5,
 				  36,-0.5,35.5);
   
-  dbe_->setCurrentFolder(subdir_+"bad_digis");
+  ib.setCurrentFolder(subdir_+"bad_digis");
   int nbins = sizeof(bins_cellcount_new)/sizeof(float)-1;
 
-  DigiBQ = dbe_->book1D("NumBadQualDigis","Number Bad Qual Digis within Digi Collection",nbins, bins_cellcount_new);
+  DigiBQ = ib.book1D("NumBadQualDigis","Number Bad Qual Digis within Digi Collection",nbins, bins_cellcount_new);
 
   nbins=sizeof(bins_fraccount_new)/sizeof(float)-1;
 
-  DigiBQFrac =  dbe_->book1D("Bad Digi Fraction","Bad Digi Fraction;Bad Quality Digi Fraction for digis in collection; # of Events",
+  DigiBQFrac =  ib.book1D("Bad Digi Fraction","Bad Digi Fraction;Bad Quality Digi Fraction for digis in collection; # of Events",
 			     nbins, bins_fraccount_new);
   
   nbins = sizeof(bins_cellcount_new)/sizeof(float)-1;
-  DigiUnpackerErrorCount = dbe_->book1D("Unpacker Error Count", "Number of Bad Digis from Unpacker; Bad Unpacker Digis; # of Events",nbins, bins_cellcount_new);
+  DigiUnpackerErrorCount = ib.book1D("Unpacker Error Count", "Number of Bad Digis from Unpacker; Bad Unpacker Digis; # of Events",nbins, bins_cellcount_new);
   
   nbins=sizeof(bins_fraccount_new)/sizeof(float)-1;
-  DigiUnpackerErrorFrac = dbe_->book1D("Unpacker Bad Digi Fraction", 
+  DigiUnpackerErrorFrac = ib.book1D("Unpacker Bad Digi Fraction", 
 				       "Bad Digis From Unpacker/ (Bad Digis From Unpacker + Good Digis); Bad Unpacker Fraction; # of Events",
 				       nbins,bins_fraccount_new);
   
-  dbe_->setCurrentFolder(subdir_+"good_digis/");
-  DigiNum = dbe_->book1D("NumGoodDigis","Number of Digis;# of Good Digis;# of Events",DIGI_NUM+1,-0.5,DIGI_NUM+1-0.5);
+  ib.setCurrentFolder(subdir_+"good_digis/");
+  DigiNum = ib.book1D("NumGoodDigis","Number of Digis;# of Good Digis;# of Events",DIGI_NUM+1,-0.5,DIGI_NUM+1-0.5);
     
-  setupSubdetHists(hbHists,"HB");
-  setupSubdetHists(heHists,"HE");
-  setupSubdetHists(hoHists,"HO");
-  setupSubdetHists(hfHists,"HF");
+  setupSubdetHists(ib,hbHists,"HB");
+  setupSubdetHists(ib,heHists,"HE");
+  setupSubdetHists(ib,hoHists,"HO");
+  setupSubdetHists(ib,hfHists,"HF");
 
   this->reset();
   return;
 } // void HcalDigiMonitor::setup()
 
-void HcalDigiMonitor::beginRun(const edm::Run& run, const edm::EventSetup& c)
+void HcalDigiMonitor::bookHistograms(DQMStore::IBooker &ib, const edm::Run& run, const edm::EventSetup& c)
 {
-  HcalBaseDQMonitor::beginRun(run,c);
+  HcalBaseDQMonitor::bookHistograms(ib,run,c);
   if (mergeRuns_ && tevt_>0) return; // don't reset counters if merging runs
 
-  if (debug_>1) std::cout <<"\t<HcalDigiMonitor::setup> Getting conditions from DB!"<<std::endl;
+  if (debug_>1) std::cout <<"\t<HcalDigiMonitor::bookHistograms> Getting conditions from DB!"<<std::endl;
   c.get<HcalDbRecord>().get(conditions_);
 
   // Get all pedestals by Cap ID
@@ -375,7 +374,7 @@ void HcalDigiMonitor::beginRun(const edm::Run& run, const edm::EventSetup& c)
       PedestalsByCapId_[*chan]=peds;
     } // loop on DetIds
 
-  if (tevt_==0) this->setup(); // create all histograms; not necessary if merging runs together
+  if (tevt_==0) this->setup(ib); // create all histograms; not necessary if merging runs together
   if (mergeRuns_==false) this->reset(); // call reset at start of all runs
 
   // Get known dead cells for this run
@@ -400,51 +399,50 @@ void HcalDigiMonitor::beginRun(const edm::Run& run, const edm::EventSetup& c)
 	} 
     } // if (badChannelStatusMask_>0)
 
-} // void HcalDigiMonitor::beginRun()
+} // void HcalDigiMonitor::bookHistograms()
 
 
-void HcalDigiMonitor::setupSubdetHists(DigiHists& hist, std::string subdet)
+void HcalDigiMonitor::setupSubdetHists(DQMStore::IBooker &ib, DigiHists& hist, std::string subdet)
 {
-  if (!dbe_) return;
   std::stringstream name;
   int nChan=0;
   if (subdet=="HB" || subdet=="HE") nChan=2592;
   else if (subdet == "HO") nChan=2160;
   else if (subdet == "HF") nChan=1728;
 
-  dbe_->setCurrentFolder(subdir_+"digi_info/"+subdet);
-  hist.shape = dbe_->book1D(subdet+" Digi Shape",subdet+" Digi Shape;Time Slice",10,-0.5,9.5);
-  hist.shapeThresh = dbe_->book1D(subdet+" Digi Shape - over thresh",
+  ib.setCurrentFolder(subdir_+"digi_info/"+subdet);
+  hist.shape = ib.book1D(subdet+" Digi Shape",subdet+" Digi Shape;Time Slice",10,-0.5,9.5);
+  hist.shapeThresh = ib.book1D(subdet+" Digi Shape - over thresh",
 				  subdet+" Digi Shape - over thresh passing trigger and HF HT cuts;Time slice",
 				  10,-0.5,9.5);
-  hist.ThreshCount = dbe_->book1D(subdet+" Total Digis Over Threshold",
+  hist.ThreshCount = ib.book1D(subdet+" Total Digis Over Threshold",
 				  subdet+" Total Digis Over Threshold",
 				  1,-0.5,0.5);
   // Create plots of sums of adjacent time slices
   for (int ts=0;ts<9;++ts)
     {
       name<<subdet<<" Plus Time Slices "<<ts<<" and "<<ts+1;
-      hist.TS_sum_plus.push_back(dbe_->book1D(name.str().c_str(),name.str().c_str(),50, 0., 50.));
+      hist.TS_sum_plus.push_back(ib.book1D(name.str().c_str(),name.str().c_str(),50, 0., 50.));
       name.str("");
       name<<subdet<<" Minus Time Slices "<<ts<<" and "<<ts+1;
-      hist.TS_sum_minus.push_back(dbe_->book1D(name.str().c_str(),name.str().c_str(),50, 0., 50.));
+      hist.TS_sum_minus.push_back(ib.book1D(name.str().c_str(),name.str().c_str(),50, 0., 50.));
       name.str("");
     }
-  hist.presample= dbe_->book1D(subdet+" Digi Presamples",subdet+" Digi Presamples",50,-0.5,49.5);
-  hist.BQ = dbe_->book1D(subdet+" Bad Quality Digis",subdet+" Bad Quality Digis",nChan+1,-0.5,nChan+0.5);
+  hist.presample= ib.book1D(subdet+" Digi Presamples",subdet+" Digi Presamples",50,-0.5,49.5);
+  hist.BQ = ib.book1D(subdet+" Bad Quality Digis",subdet+" Bad Quality Digis",nChan+1,-0.5,nChan+0.5);
   //(hist.BQ->getTH1F())->LabelsOption("v");
-  hist.BQFrac = dbe_->book1D(subdet+" Bad Quality Digi Fraction",subdet+" Bad Quality Digi Fraction",DIGI_BQ_FRAC_NBINS,(0-0.5/(DIGI_BQ_FRAC_NBINS-1)),1+0.5/(DIGI_BQ_FRAC_NBINS-1));
-  hist.DigiFirstCapID = dbe_->book1D(subdet+" Capid 1st Time Slice",subdet+" Capid for 1st Time Slice;CapId (T0)- 1st CapId (T0);# of Events",7,-3.5,3.5);
+  hist.BQFrac = ib.book1D(subdet+" Bad Quality Digi Fraction",subdet+" Bad Quality Digi Fraction",DIGI_BQ_FRAC_NBINS,(0-0.5/(DIGI_BQ_FRAC_NBINS-1)),1+0.5/(DIGI_BQ_FRAC_NBINS-1));
+  hist.DigiFirstCapID = ib.book1D(subdet+" Capid 1st Time Slice",subdet+" Capid for 1st Time Slice;CapId (T0)- 1st CapId (T0);# of Events",7,-3.5,3.5);
 
-  hist.DVerr = dbe_->book1D(subdet+" Data Valid Err Bits",subdet+" QIE Data Valid Err Bits",4,-0.5,3.5);
+  hist.DVerr = ib.book1D(subdet+" Data Valid Err Bits",subdet+" QIE Data Valid Err Bits",4,-0.5,3.5);
   hist.DVerr ->setBinLabel(1,"Err=0, DV=0",1);
   hist.DVerr ->setBinLabel(2,"Err=0, DV=1",1);
   hist.DVerr ->setBinLabel(3,"Err=1, DV=0",1);
   hist.DVerr ->setBinLabel(4,"Err=1, DV=1",1);
-  hist.CapID = dbe_->book1D(subdet+" CapID",subdet+" CapID",4,-0.5,3.5);
-  hist.ADC = dbe_->book1D(subdet+" ADC count per time slice",subdet+" ADC count per time slice",200,-0.5,199.5);
-  hist.ADCsum = dbe_->book1D(subdet+" ADC sum", subdet+" ADC sum",200,-0.5,199.5);
-  hist.fibBCNOff = dbe_->book1D(subdet+" Fiber Orbit Message Idle BCN Offset", subdet+" Fiber Orbit Message Idle BCN Offset;Offset from Expected",
+  hist.CapID = ib.book1D(subdet+" CapID",subdet+" CapID",4,-0.5,3.5);
+  hist.ADC = ib.book1D(subdet+" ADC count per time slice",subdet+" ADC count per time slice",200,-0.5,199.5);
+  hist.ADCsum = ib.book1D(subdet+" ADC sum", subdet+" ADC sum",200,-0.5,199.5);
+  hist.fibBCNOff = ib.book1D(subdet+" Fiber Orbit Message Idle BCN Offset", subdet+" Fiber Orbit Message Idle BCN Offset;Offset from Expected",
 				 15, -7.5, 7.5);
 }
 
@@ -615,12 +613,6 @@ void HcalDigiMonitor::processEvent(const HBHEDigiCollection& hbhe,
 				   const HcalUnpackerReport& report,
 				   int orN, int bcN)
 { 
-  if(!dbe_) 
-    { 
-      if(debug_) 
-	std::cout <<"HcalDigiMonitor::processEvent   DQMStore not instantiated!!!"<<std::endl; 
-      return; 
-    }
 
   // Skip events in which minimal good digis found -- still getting some strange (calib?) events through DQM
 

--- a/DQM/HcalMonitorTasks/src/HcalHotCellMonitor.cc
+++ b/DQM/HcalMonitorTasks/src/HcalHotCellMonitor.cc
@@ -2,7 +2,7 @@
 #include "DQM/HcalMonitorTasks/interface/HcalHotCellMonitor.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 
-HcalHotCellMonitor::HcalHotCellMonitor(const edm::ParameterSet& ps)
+HcalHotCellMonitor::HcalHotCellMonitor(const edm::ParameterSet& ps):HcalBaseDQMonitor(ps)
 {
   // Standard information, inherited from base class
   Online_                = ps.getUntrackedParameter<bool>("online",false);

--- a/DQM/HcalMonitorTasks/src/HcalHotCellMonitor.cc
+++ b/DQM/HcalMonitorTasks/src/HcalHotCellMonitor.cc
@@ -112,42 +112,42 @@ HcalHotCellMonitor::~HcalHotCellMonitor()
 
 /* ------------------------------------ */ 
 
-void HcalHotCellMonitor::setup()
+void HcalHotCellMonitor::setup(DQMStore::IBooker &ib)
 {
   if (setupDone_)
     return;
   setupDone_ = true;
   // Call base class setup
-  HcalBaseDQMonitor::setup();
+  HcalBaseDQMonitor::setup(ib);
 
   if (debug_>1)
     std::cout <<"<HcalHotCellMonitor::setup>  Setting up histograms"<<std::endl;
 
-  dbe_->setCurrentFolder(subdir_);
+  ib.setCurrentFolder(subdir_);
 
   MonitorElement* me;
-  me=dbe_->bookFloat("minErrorFractionPerLumiSection");
+  me=ib.bookFloat("minErrorFractionPerLumiSection");
   me->Fill(minErrorFlag_);
   // Create plots of problems vs LB
 
   // 1D plots count number of bad cells vs. luminosity block
-  ProblemsVsLB=dbe_->bookProfile("TotalHotCells_HCAL_vs_LS",
+  ProblemsVsLB=ib.bookProfile("TotalHotCells_HCAL_vs_LS",
 				 "Total Number of Hot Hcal Cells vs lumi section", 
 				 NLumiBlocks_,0.5,NLumiBlocks_+0.5,100,0,10000);
 
-  ProblemsVsLB_HB=dbe_->bookProfile("TotalHotCells_HB_vs_LS",
+  ProblemsVsLB_HB=ib.bookProfile("TotalHotCells_HB_vs_LS",
 				    "Total Number of Hot HB Cells vs lumi section",
 				    NLumiBlocks_,0.5,NLumiBlocks_+0.5,100,0,3000);
-  ProblemsVsLB_HE=dbe_->bookProfile("TotalHotCells_HE_vs_LS",
+  ProblemsVsLB_HE=ib.bookProfile("TotalHotCells_HE_vs_LS",
 				    "Total Number of Hot HE Cells vs lumi section",
 				    NLumiBlocks_,0.5,NLumiBlocks_+0.5,100,0,3000);
-  ProblemsVsLB_HO=dbe_->bookProfile("TotalHotCells_HO_vs_LS",
+  ProblemsVsLB_HO=ib.bookProfile("TotalHotCells_HO_vs_LS",
 				    "Total Number of Hot HO Cells vs lumi section",
 				    NLumiBlocks_,0.5,NLumiBlocks_+0.5,100,0,3000);
-  ProblemsVsLB_HF=dbe_->bookProfile("TotalHotCells_HF_vs_LS",
+  ProblemsVsLB_HF=ib.bookProfile("TotalHotCells_HF_vs_LS",
 				    "Total Number of Hot HF Cells vs lumi section",
 				    NLumiBlocks_,0.5,NLumiBlocks_+0.5,100,0,2000);
-  ProblemsVsLB_HBHEHF=dbe_->bookProfile("TotalHotCells_HBHEHF_vs_LS",
+  ProblemsVsLB_HBHEHF=ib.bookProfile("TotalHotCells_HBHEHF_vs_LS",
 				    "Total Number of Hot HBHEHF Cells vs lumi section",
 				    NLumiBlocks_,0.5,NLumiBlocks_+0.5,100,0,2000);
  
@@ -161,14 +161,14 @@ void HcalHotCellMonitor::setup()
   // Set up plots for each failure mode of hot cells
   std::stringstream units; // We'll need to set the titles individually, rather than passing units to SetupEtaPhiHists (since this also would affect the name of the histograms)
 
-  dbe_->setCurrentFolder(subdir_+"hot_rechit_above_threshold");
-  me=dbe_->bookInt("HotCellAboveThresholdTestEnabled");
+  ib.setCurrentFolder(subdir_+"hot_rechit_above_threshold");
+  me=ib.bookInt("HotCellAboveThresholdTestEnabled");
   me->Fill(0);
   
   if (test_energy_)
     {
       me->Fill(1);
-      SetupEtaPhiHists(AboveEnergyThresholdCellsByDepth,
+      SetupEtaPhiHists(ib,AboveEnergyThresholdCellsByDepth,
 		       "Hot Cells Above Energy Threshold","");
       //setMinMaxHists2D(AboveEnergyThresholdCellsByDepth,0.,1.);
       
@@ -190,7 +190,7 @@ void HcalHotCellMonitor::setup()
   if (test_et_)
     {
       me->Fill(1);
-      SetupEtaPhiHists(AboveETThresholdCellsByDepth,
+      SetupEtaPhiHists(ib,AboveETThresholdCellsByDepth,
 		       "Hot Cells Above ET Threshold","");
       //setMinMaxHists2D(AboveETThresholdCellsByDepth,0.,1.);
       
@@ -210,17 +210,17 @@ void HcalHotCellMonitor::setup()
       units.str("");
     }
   
-  dbe_->setCurrentFolder(subdir_+"hot_rechit_always_above_threshold");
-  me=dbe_->bookInt("PersistentHotCellTestEnabled");
+  ib.setCurrentFolder(subdir_+"hot_rechit_always_above_threshold");
+  me=ib.bookInt("PersistentHotCellTestEnabled");
   me->Fill(0);
   if (test_persistent_)
     {
       me->Fill(1);
-      me=dbe_->bookInt("minEventsPerLS");
+      me=ib.bookInt("minEventsPerLS");
       me->Fill(minEvents_);
 
       if (test_energy_) {
-	SetupEtaPhiHists(AbovePersistentThresholdCellsByDepth,
+	SetupEtaPhiHists(ib,AbovePersistentThresholdCellsByDepth,
 			 "Hot Cells Persistently Above Energy Threshold","");
 	//setMinMaxHists2D(AbovePersistentThresholdCellsByDepth,0.,1.);
 	
@@ -241,7 +241,7 @@ void HcalHotCellMonitor::setup()
       }
   
       if (test_et_) {
-	SetupEtaPhiHists(AbovePersistentETThresholdCellsByDepth,
+	SetupEtaPhiHists(ib,AbovePersistentETThresholdCellsByDepth,
 			 "Hot Cells Persistently Above ET Threshold","");
 	//setMinMaxHists2D(AbovePersistentThresholdCellsByDepth,0.,1.);
 	
@@ -262,37 +262,37 @@ void HcalHotCellMonitor::setup()
       }
     }
   
-  dbe_->setCurrentFolder(subdir_+"hot_neighbortest");
-  me=dbe_->bookInt("NeighborTestEnabled");
+  ib.setCurrentFolder(subdir_+"hot_neighbortest");
+  me=ib.bookInt("NeighborTestEnabled");
   me->Fill(0);
   if (test_neighbor_)
     me->Fill(1);
   if (test_neighbor_ || makeDiagnostics_)
     {
-      SetupEtaPhiHists(AboveNeighborsHotCellsByDepth,"Hot Cells Failing Neighbor Test","");
+      SetupEtaPhiHists(ib,AboveNeighborsHotCellsByDepth,"Hot Cells Failing Neighbor Test","");
       if (makeDiagnostics_)
 	{
-	  d_HBenergyVsNeighbor=dbe_->book1D("NeighborSumOverEnergyHB","HB Neighbor Sum Energy/Cell Energy;sum(neighbors)/E_cell",500,0,10);
-	  d_HEenergyVsNeighbor=dbe_->book1D("NeighborSumOverEnergyHE","HE Neighbor Sum Energy/Cell Energy;sum(neighbors)/E_cell",500,0,10);
-	  d_HOenergyVsNeighbor=dbe_->book1D("NeighborSumOverEnergyHO","HO Neighbor Sum Energy/Cell Energy;sum(neighbors)/E_cell",500,0,10);
-	  d_HFenergyVsNeighbor=dbe_->book1D("NeighborSumOverEnergyHF","HF Neighbor Sum Energy/Cell Energy;sum(neighbors)/E_cell",500,0,10);
+	  d_HBenergyVsNeighbor=ib.book1D("NeighborSumOverEnergyHB","HB Neighbor Sum Energy/Cell Energy;sum(neighbors)/E_cell",500,0,10);
+	  d_HEenergyVsNeighbor=ib.book1D("NeighborSumOverEnergyHE","HE Neighbor Sum Energy/Cell Energy;sum(neighbors)/E_cell",500,0,10);
+	  d_HOenergyVsNeighbor=ib.book1D("NeighborSumOverEnergyHO","HO Neighbor Sum Energy/Cell Energy;sum(neighbors)/E_cell",500,0,10);
+	  d_HFenergyVsNeighbor=ib.book1D("NeighborSumOverEnergyHF","HF Neighbor Sum Energy/Cell Energy;sum(neighbors)/E_cell",500,0,10);
 	}
     } // if (test_neighbor_ || makeDiagnostics_)
   
   this->reset();
 } // void HcalHotCellMonitor::setup(...)
 
-void HcalHotCellMonitor::beginRun(const edm::Run& run, const edm::EventSetup& c)
+void HcalHotCellMonitor::bookHistograms(DQMStore::IBooker &ib, const edm::Run& run, const edm::EventSetup& c)
 {
-  if (debug_>1) std::cout <<"HcalHotCellMonitor::beginRun"<<std::endl;
-  HcalBaseDQMonitor::beginRun(run,c);
+  if (debug_>1) std::cout <<"HcalHotCellMonitor::bookHistograms"<<std::endl;
+  HcalBaseDQMonitor::bookHistograms(ib,run,c);
 
-  if (tevt_==0) this->setup(); // set up histograms if they have not been created before
+  if (tevt_==0) this->setup(ib); // set up histograms if they have not been created before
   if (mergeRuns_==false)
     this->reset();
 
   return;
-} //void HcalHotCellMonitor::beginRun(...)
+} //void HcalHotCellMonitor::bookHistograms(...)
 
 
 /* --------------------------- */
@@ -1145,7 +1145,7 @@ void HcalHotCellMonitor::endJob()
   if (enableCleanup_) cleanup(); // when do we force cleanup?
 }
 
-void HcalHotCellMonitor::cleanup()
+/*void HcalHotCellMonitor::cleanup()
 {
   if (debug_>0) std::cout <<"HcalHotCellMonitor::cleanup()"<<std::endl;
   if (!enableCleanup_) return;
@@ -1163,7 +1163,7 @@ void HcalHotCellMonitor::cleanup()
       dbe_->setCurrentFolder(subdir_+"LSvalues");
       dbe_->removeContents();
     }
-} // cleanup
+}*/ // cleanup
 
 void HcalHotCellMonitor::periodicReset()
 {

--- a/DQM/HcalMonitorTasks/src/HcalLSbyLSMonitor.cc
+++ b/DQM/HcalMonitorTasks/src/HcalLSbyLSMonitor.cc
@@ -35,31 +35,31 @@ HcalLSbyLSMonitor::~HcalLSbyLSMonitor()
 {
 } //destructor
 
-void HcalLSbyLSMonitor::setup()
+void HcalLSbyLSMonitor::setup(DQMStore::IBooker &ib)
 {
   // Call base class setup
-  HcalBaseDQMonitor::setup();
+  HcalBaseDQMonitor::setup(ib);
 
   if (debug_>1)
     std::cout <<"<HcalLSbyLSMonitor::setup>  Setting up histograms"<<std::endl;
 
-  dbe_->setCurrentFolder(subdir_);
+  ib.setCurrentFolder(subdir_);
   // This will cause this information to be kept for every lumi block
   if (ProblemsCurrentLB)
     ProblemsCurrentLB->setLumiFlag();
   this->reset();
 }
-void HcalLSbyLSMonitor::beginRun(const edm::Run& run, const edm::EventSetup& c)
+void HcalLSbyLSMonitor::bookHistograms(DQMStore::IBooker &ib, const edm::Run& run, const edm::EventSetup& c)
 {
-  if (debug_>1) std::cout <<"HcalLSbyLSMonitor::beginRun"<<std::endl;
-  HcalBaseDQMonitor::beginRun(run,c);
+  if (debug_>1) std::cout <<"HcalLSbyLSMonitor::bookHistograms"<<std::endl;
+  HcalBaseDQMonitor::bookHistograms(ib,run,c);
 
-  if (tevt_==0) this->setup(); // set up histograms if they have not been created before
+  if (tevt_==0) this->setup(ib); // set up histograms if they have not been created before
   if (mergeRuns_==false)
     this->reset();
 
   return;
-} //void HcalLSbyLSMonitor::beginRun(...)
+} //void HcalLSbyLSMonitor::bookHistograms(...)
 
 
 void HcalLSbyLSMonitor::reset()
@@ -80,8 +80,7 @@ void HcalLSbyLSMonitor::beginLuminosityBlock(const edm::LuminosityBlock& lumiSeg
 void HcalLSbyLSMonitor::endLuminosityBlock(const edm::LuminosityBlock& lumiSeg,
 					    const edm::EventSetup& c)
 {
-  // Processing should go here
-  if (!dbe_) return;
+  /*// Processing should go here
   bool enoughEvents=true;
   int Nevents=0;
   int TotalEvents=0;
@@ -136,7 +135,7 @@ void HcalLSbyLSMonitor::endLuminosityBlock(const edm::LuminosityBlock& lumiSeg,
   ProblemsCurrentLB->setBinContent(4,1,badHF);
   ProblemsCurrentLB->setBinContent(5,1,badHO0);
   ProblemsCurrentLB->setBinContent(6,1,badHO12);
-  ProblemsCurrentLB->setBinContent(7,1,badHFLUMI);
+  ProblemsCurrentLB->setBinContent(7,1,badHFLUMI); */
   return;
 }
 
@@ -156,7 +155,7 @@ void HcalLSbyLSMonitor::endJob()
 }
 
 
-void HcalLSbyLSMonitor::cleanup()
+/*void HcalLSbyLSMonitor::cleanup()
 {
   if (!enableCleanup_) return;
   if (dbe_)
@@ -166,6 +165,6 @@ void HcalLSbyLSMonitor::cleanup()
       dbe_->setCurrentFolder(subdir_+"LSvalues");
       dbe_->removeContents();
     }
-}
+}*/
 
 DEFINE_FWK_MODULE(HcalLSbyLSMonitor);

--- a/DQM/HcalMonitorTasks/src/HcalLSbyLSMonitor.cc
+++ b/DQM/HcalMonitorTasks/src/HcalLSbyLSMonitor.cc
@@ -7,7 +7,7 @@
 */
 
 // constructor
-HcalLSbyLSMonitor::HcalLSbyLSMonitor(const edm::ParameterSet& ps) 
+HcalLSbyLSMonitor::HcalLSbyLSMonitor(const edm::ParameterSet& ps):HcalBaseDQMonitor(ps)
 {
   Online_                = ps.getUntrackedParameter<bool>("online",false);
   mergeRuns_             = ps.getUntrackedParameter<bool>("mergeRuns",false);

--- a/DQM/HcalMonitorTasks/src/HcalNZSMonitor.cc
+++ b/DQM/HcalMonitorTasks/src/HcalNZSMonitor.cc
@@ -50,33 +50,24 @@ void HcalNZSMonitor::reset()
   meFullCMSdataSize_->Reset();
 } // void HcalNZSMonitor::reset()
 
-void HcalNZSMonitor::cleanup()
+
+void HcalNZSMonitor::bookHistograms(DQMStore::IBooker &ib, const edm::Run& run, const edm::EventSetup& c)
 {
-  if(dbe_)
-    {
-      dbe_->setCurrentFolder(subdir_);
-      dbe_->removeContents();
-    }
-}//void HcalNZSMonitor::cleanup()
+  if (debug_>1) std::cout <<"HcalNZSMonitor::bookHistograms"<<std::endl;
+  HcalBaseDQMonitor::bookHistograms(ib,run,c);
 
-
-void HcalNZSMonitor::beginRun(const edm::Run& run, const edm::EventSetup& c)
-{
-  if (debug_>1) std::cout <<"HcalNZSMonitor::beginRun"<<std::endl;
-  HcalBaseDQMonitor::beginRun(run,c);
-
-  if (tevt_==0) this->setup(); // set up histograms if they have not been created before
+  if (tevt_==0) this->setup(ib); // set up histograms if they have not been created before
   if (mergeRuns_==false)
     this->reset();
 
   return;
 
-} // void HcalNZSMonitor::beginRun(...)
+} // void HcalNZSMonitor::bookHistograms(...)
 
 
-void HcalNZSMonitor::setup()
+void HcalNZSMonitor::setup(DQMStore::IBooker &ib)
 {
-  HcalBaseDQMonitor::setup();
+  HcalBaseDQMonitor::setup(ib);
   
   if(debug_>1) std::cout << "<HcalNZSMonitor::setup> About to pushback fedUnpackList_" << std::endl;
 
@@ -93,42 +84,39 @@ void HcalNZSMonitor::setup()
   nAcc_Total=0;
   
   if (debug_>1) std::cout <<"<HcalNZSMonitor::setup>  Creating histograms"<<std::endl;
-  if (dbe_)
-    {
-      dbe_->setCurrentFolder(subdir_);
+      ib.setCurrentFolder(subdir_);
       
-      meFEDsizesNZS_=dbe_->bookProfile("FED sizes","FED sizes",32,699.5,731.5,100,-1000.0,12000.0,"");
+      meFEDsizesNZS_=ib.bookProfile("FED sizes","FED sizes",32,699.5,731.5,100,-1000.0,12000.0,"");
       meFEDsizesNZS_->setAxisTitle("FED number",1);
       meFEDsizesNZS_->setAxisTitle("average size (KB)",2);
       meFEDsizesNZS_->getTProfile()->SetMarkerStyle(22);
       
-      meFEDsizeVsLumi_=dbe_->bookProfile("FED_size_Vs_lumi_block_number",
+      meFEDsizeVsLumi_=ib.bookProfile("FED_size_Vs_lumi_block_number",
 					 "FED size Vs lumi block number;lumiblock number;average HCAL FED size (kB)",
 					 NLumiBlocks_,0.5,NLumiBlocks_+0.5,100,0,10000,"");
       meFEDsizeVsLumi_->getTProfile()->SetMarkerStyle(22);
 
-      meL1evtNumber_=dbe_->book1D("Is_L1_event_number_multiple_of_NZS_period",
+      meL1evtNumber_=ib.book1D("Is_L1_event_number_multiple_of_NZS_period",
 				  "Is L1 event number multiple of NZS period",2,0,2);
       meL1evtNumber_->setBinLabel(1, "NO", 1);
       meL1evtNumber_->setBinLabel(2, "YES", 1);
 
-      meIsUS_=dbe_->book1D("IsUnsuppressed_bit","IsUnsuppressed bit",2,0,2);
+      meIsUS_=ib.book1D("IsUnsuppressed_bit","IsUnsuppressed bit",2,0,2);
       meIsUS_->setBinLabel(1,"NO",1);
       meIsUS_->setBinLabel(2,"YES",1);
 
-      meBXtriggered_=dbe_->book1D("Triggered_BX_number","Triggered BX number",3850,0,3850);
+      meBXtriggered_=ib.book1D("Triggered_BX_number","Triggered BX number",3850,0,3850);
       meBXtriggered_->setAxisTitle("BX number",1);
 
-      meTrigFrac_=dbe_->book1D("HLT_accept_fractions","HLT accept fractions",triggers_.size()+1,0,triggers_.size()+1);
+      meTrigFrac_=ib.book1D("HLT_accept_fractions","HLT accept fractions",triggers_.size()+1,0,triggers_.size()+1);
       for (unsigned int k=0; k<triggers_.size(); k++) meTrigFrac_->setBinLabel(k+1,triggers_[k].c_str(),1);
       meTrigFrac_->setBinLabel(triggers_.size()+1,"AND",1);
 
-      meFullCMSdataSize_=dbe_->bookProfile("full_CMS_datasize",
+      meFullCMSdataSize_=ib.bookProfile("full_CMS_datasize",
 					   "full CMS data size;lumiblock number;average FEDRawDataCollection size (kB)",
 					   NLumiBlocks_,0.5,NLumiBlocks_+0.5,100,0,10000,"");
       meFullCMSdataSize_->getTProfile()->SetMarkerStyle(22);
 
-    } // if (dbe_)
   return;
 } // void HcalNZSMonitor::setup()
 
@@ -167,11 +155,6 @@ void HcalNZSMonitor::processEvent(const FEDRawDataCollection& rawraw,
 				  int bxNum, 
 				  const edm::TriggerNames& triggerNames)
 {
-  if(!dbe_) 
-    { 
-      if (debug_>0) std::cout <<"HcalNZSMonitor::processEvent DQMStore not instantiated!!!"<<std::endl;  
-      return;
-    }
 
   const unsigned int nTrig(triggerNames.size());
  

--- a/DQM/HcalMonitorTasks/src/HcalNZSMonitor.cc
+++ b/DQM/HcalMonitorTasks/src/HcalNZSMonitor.cc
@@ -8,7 +8,7 @@
 #include "FWCore/Common/interface/TriggerNames.h"
 #include <math.h>
 
-HcalNZSMonitor::HcalNZSMonitor(const edm::ParameterSet& ps) 
+HcalNZSMonitor::HcalNZSMonitor(const edm::ParameterSet& ps) :HcalBaseDQMonitor(ps)
 {
   Online_                = ps.getUntrackedParameter<bool>("online",false);
   mergeRuns_             = ps.getUntrackedParameter<bool>("mergeRuns",false);

--- a/DQM/HcalMonitorTasks/src/HcalNoiseMonitor.cc
+++ b/DQM/HcalMonitorTasks/src/HcalNoiseMonitor.cc
@@ -22,7 +22,7 @@
 
 #include "FWCore/Common/interface/TriggerNames.h"
 
-HcalNoiseMonitor::HcalNoiseMonitor(const edm::ParameterSet& ps)
+HcalNoiseMonitor::HcalNoiseMonitor(const edm::ParameterSet& ps):HcalBaseDQMonitor(ps)
 {
    Online_                = ps.getUntrackedParameter<bool>("online",false);
    mergeRuns_             = ps.getUntrackedParameter<bool>("mergeRuns",false);

--- a/DQM/HcalMonitorTasks/src/HcalNoiseMonitor.cc
+++ b/DQM/HcalMonitorTasks/src/HcalNoiseMonitor.cc
@@ -67,24 +67,15 @@ void HcalNoiseMonitor::reset()
 {
 }
 
-void HcalNoiseMonitor::cleanup()
-{
-   if(dbe_)
-   {
-      dbe_->setCurrentFolder(subdir_);
-      dbe_->removeContents();
-   }
-}
-
-void HcalNoiseMonitor::beginRun(const edm::Run& run, const edm::EventSetup& c)
+void HcalNoiseMonitor::bookHistograms(DQMStore::IBooker &ib, const edm::Run& run, const edm::EventSetup& c)
 {
    if(debug_ > 1)
-      std::cout <<"HcalNoiseMonitor::beginRun"<< std::endl;
+      std::cout <<"HcalNoiseMonitor::bookHistograms"<< std::endl;
 
-   HcalBaseDQMonitor::beginRun(run,c);
+   HcalBaseDQMonitor::bookHistograms(ib,run,c);
 
    if(tevt_ == 0)
-      setup();
+      setup(ib);
 
    if(mergeRuns_ == false)
       reset();
@@ -92,99 +83,96 @@ void HcalNoiseMonitor::beginRun(const edm::Run& run, const edm::EventSetup& c)
    return;
 }
 
-
-void HcalNoiseMonitor::setup()
+void HcalNoiseMonitor::setup(DQMStore::IBooker &ib)
 {
    if (setupDone_)
      return;
    setupDone_ = true;
-   HcalBaseDQMonitor::setup();
+   HcalBaseDQMonitor::setup(ib);
 
    if(debug_ > 1)
       std::cout << "<HcalNoiseMonitor::setup> Creating histograms" << std::endl;
 
-   if(dbe_)
-   {
-      dbe_->setCurrentFolder(subdir_);
+      ib.setCurrentFolder(subdir_);
 
       // Fit-based
-      dbe_->setCurrentFolder(subdir_ + "DoubleChi2/");
+      ib.setCurrentFolder(subdir_ + "DoubleChi2/");
 
-      hNominalChi2 = dbe_->book1D("Nominal_fit_chi2", "Nominal fit chi2, total charge > 20 fC", 100, 0, 200);
+      hNominalChi2 = ib.book1D("Nominal_fit_chi2", "Nominal fit chi2, total charge > 20 fC", 100, 0, 200);
       hNominalChi2->setAxisTitle("Nominal fit #chi^{2}", 1);
 
-      hLinearChi2 = dbe_->book1D("Linear_fit_chi2", "Linear fit chi2, total charge > 20 fC", 100, 0, 200);
+      hLinearChi2 = ib.book1D("Linear_fit_chi2", "Linear fit chi2, total charge > 20 fC", 100, 0, 200);
       hLinearChi2->setAxisTitle("Linear fit #chi^{2}", 1);
       
-      hLinearTestStatistics = dbe_->book1D("Lambda_linear", "#Lambda_{linear}, total charge > 20 fC", 100, -10, 10);
+      hLinearTestStatistics = ib.book1D("Lambda_linear", "#Lambda_{linear}, total charge > 20 fC", 100, -10, 10);
       hLinearTestStatistics->setAxisTitle("#Lambda_{linear}", 1);
 
-      hRMS8OverMax = dbe_->book1D("RMS8_over_Max", "RMS8/max, total charge > 20 fC", 100, 0, 2);
+      hRMS8OverMax = ib.book1D("RMS8_over_Max", "RMS8/max, total charge > 20 fC", 100, 0, 2);
       hRMS8OverMax->setAxisTitle("RMS8/max", 1);
 
-      hRMS8OverMaxTestStatistics = dbe_->book1D("Lambda_RMS8_over_max", "#Lambda_{RMS8/Max}, total charge > 20 fC",
+      hRMS8OverMaxTestStatistics = ib.book1D("Lambda_RMS8_over_max", "#Lambda_{RMS8/Max}, total charge > 20 fC",
          100, -30, 10);
       hRMS8OverMaxTestStatistics->setAxisTitle("#Lambda_{RMS8/Max}", 1);
 
-      hLambdaLinearVsTotalCharge = dbe_->book2D("Lambda_linear_vs_total_charge", "#Lambda_{Linear}",
+      hLambdaLinearVsTotalCharge = ib.book2D("Lambda_linear_vs_total_charge", "#Lambda_{Linear}",
          50, -5, 5, 25, 0, 500);
       hLambdaLinearVsTotalCharge->setAxisTitle("#Lambda_{linear}", 1);
       hLambdaLinearVsTotalCharge->setAxisTitle("Total charge", 2);
 
-      hLambdaRMS8MaxVsTotalCharge = dbe_->book2D("Lambda_RMS8Max_vs_total_charge", "#Lambda_{RMS8/Max}",
+      hLambdaRMS8MaxVsTotalCharge = ib.book2D("Lambda_RMS8Max_vs_total_charge", "#Lambda_{RMS8/Max}",
          50, -15, 5, 25, 0, 500);
       hLambdaRMS8MaxVsTotalCharge->setAxisTitle("#Lambda_{RMS8/Max}", 1);
       hLambdaRMS8MaxVsTotalCharge->setAxisTitle("Total charge", 2);
 
-      hTriangleLeftSlopeVsTS4 = dbe_->book2D("Triangle_fit_left_slope",
+      hTriangleLeftSlopeVsTS4 = ib.book2D("Triangle_fit_left_slope",
          "Triangle fit left distance vs. TS4", 50, 0, 10, 25, 0, 500);
       hTriangleLeftSlopeVsTS4->setAxisTitle("Left slope", 1);
       hTriangleLeftSlopeVsTS4->setAxisTitle("Peak time slice", 2);
 
-      hTriangleRightSlopeVsTS4 = dbe_->book2D("Triangle_fit_right_slope",
+      hTriangleRightSlopeVsTS4 = ib.book2D("Triangle_fit_right_slope",
          "Triangle fit right distance vs. peak time slice", 50, 0, 10, 25, 0, 500);
       hTriangleRightSlopeVsTS4->setAxisTitle("Left slope", 1);
       hTriangleRightSlopeVsTS4->setAxisTitle("Peak time slice", 2);
 
-      SetupEtaPhiHists(hFailLinearEtaPhi, "Fail_linear_Eta_Phi_Map", "");
-      SetupEtaPhiHists(hFailRMSMaxEtaPhi, "Fail_RMS8Max_Eta_Phi_Map", "");
-      SetupEtaPhiHists(hFailTriangleEtaPhi, "Fail_triangle_Eta_Phi_Map", "");
+      SetupEtaPhiHists(ib,hFailLinearEtaPhi, "Fail_linear_Eta_Phi_Map", "");
+      SetupEtaPhiHists(ib,hFailRMSMaxEtaPhi, "Fail_RMS8Max_Eta_Phi_Map", "");
+      SetupEtaPhiHists(ib,hFailTriangleEtaPhi, "Fail_triangle_Eta_Phi_Map", "");
 
       // High-level isolation filter
-      dbe_->setCurrentFolder(subdir_ + "IsolationVariable/");
+      ib.setCurrentFolder(subdir_ + "IsolationVariable/");
 
-      SetupEtaPhiHists(hFailIsolationEtaPhi, "Fail_isolation_Eta_Phi_Map", "");
+      SetupEtaPhiHists(ib,hFailIsolationEtaPhi, "Fail_isolation_Eta_Phi_Map", "");
       
       // TS4 vs. TS5 variable
-      dbe_->setCurrentFolder(subdir_ + "TS4TS5Variable/");
+      ib.setCurrentFolder(subdir_ + "TS4TS5Variable/");
       
-      hTS4TS5RelativeDifference = dbe_->book1D("TS4_TS5_relative_difference",
+      hTS4TS5RelativeDifference = ib.book1D("TS4_TS5_relative_difference",
          "(TS4-TS5)/(TS4+TS5), total charge > 20 fC", 100, -1, 1);
       hTS4TS5RelativeDifference->setAxisTitle("(TS4 - TS5) / (TS4 + TS5)", 1);
 
-      hTS4TS5RelativeDifferenceVsCharge = dbe_->book2D("TS4_TS5_relative_difference_charge",
+      hTS4TS5RelativeDifferenceVsCharge = ib.book2D("TS4_TS5_relative_difference_charge",
          "(TS4-TS5)/(TS4+TS5) vs. Charge", 25, 0, 400, 75, -1, 1);
       hTS4TS5RelativeDifferenceVsCharge->setAxisTitle("Charge", 1);
       hTS4TS5RelativeDifferenceVsCharge->setAxisTitle("(TS4 - TS5) / (TS4 + TS5)", 2);
 
       // Noise summary object
-      dbe_->setCurrentFolder(subdir_ + "NoiseMonitoring/");
+      ib.setCurrentFolder(subdir_ + "NoiseMonitoring/");
    
-      hMaxZeros = dbe_->book1D("Max_Zeros", "Max zeros", 15, -0.5, 14.5);
+      hMaxZeros = ib.book1D("Max_Zeros", "Max zeros", 15, -0.5, 14.5);
       
-      hTotalZeros = dbe_->book1D("Total_Zeros", "Total zeros", 15, -0.5, 14.5);
+      hTotalZeros = ib.book1D("Total_Zeros", "Total zeros", 15, -0.5, 14.5);
       
-      hE2OverE10Digi = dbe_->book1D("E2OverE10Digi", "E2/E10 of the highest digi in an HPD", 100, 0, 2);
+      hE2OverE10Digi = ib.book1D("E2OverE10Digi", "E2/E10 of the highest digi in an HPD", 100, 0, 2);
       
-      hE2OverE10Digi5 = dbe_->book1D("E2OverE10Digi5", "E2/E10 of the highest 5 digi in an HPD", 100, 0, 2);
+      hE2OverE10Digi5 = ib.book1D("E2OverE10Digi5", "E2/E10 of the highest 5 digi in an HPD", 100, 0, 2);
       
-      hE2OverE10RBX = dbe_->book1D("E2OverE10RBX", "E2/E10 of RBX", 100, 0, 2);
+      hE2OverE10RBX = ib.book1D("E2OverE10RBX", "E2/E10 of RBX", 100, 0, 2);
       
-      hHPDHitCount = dbe_->book1D("HPDHitCount", "HPD hit count (1.5 GeV)", 19, -0.5, 18.5);
+      hHPDHitCount = ib.book1D("HPDHitCount", "HPD hit count (1.5 GeV)", 19, -0.5, 18.5);
       
-      hRBXHitCount = dbe_->book1D("RBXHitCount", "Number of hits in RBX", 74, -0.5, 73.5);
+      hRBXHitCount = ib.book1D("RBXHitCount", "Number of hits in RBX", 74, -0.5, 73.5);
 
-      hHcalNoiseCategory = dbe_->book1D("Hcal_noise_category", "Hcal noise category", 10, 0.5, 10.5);
+      hHcalNoiseCategory = ib.book1D("Hcal_noise_category", "Hcal noise category", 10, 0.5, 10.5);
       hHcalNoiseCategory->setBinLabel(1, "RBX noise", 1);
       hHcalNoiseCategory->setBinLabel(2, "RBX pedestal flatter", 1);
       hHcalNoiseCategory->setBinLabel(3, "RBX pedestal sharper", 1);
@@ -193,11 +181,10 @@ void HcalNoiseMonitor::setup()
       hHcalNoiseCategory->setBinLabel(7, "HPD discharge", 1);
       hHcalNoiseCategory->setBinLabel(8, "HPD ion feedback", 1);
 
-      hBadZeroRBX = dbe_->book1D("BadZeroRBX", "RBX with bad ADC zero counts", 72, 0.5, 72.5);
-      hBadCountHPD = dbe_->book1D("BadCountHPD", "HPD with bad hit counts", 72 * 4, 0.5, 72 * 4 + 0.5);
-      hBadNoOtherCountHPD = dbe_->book1D("BadNoOtherCountHPD", "HPD with bad \"no other\" hit counts", 72 * 4, 0.5, 72 * 4 + 0.5);
-      hBadE2E10RBX = dbe_->book1D("BadE2E10RBX", "RBX with bad E2/E10 value", 72, 0.5, 72.5);
-   }
+      hBadZeroRBX = ib.book1D("BadZeroRBX", "RBX with bad ADC zero counts", 72, 0.5, 72.5);
+      hBadCountHPD = ib.book1D("BadCountHPD", "HPD with bad hit counts", 72 * 4, 0.5, 72 * 4 + 0.5);
+      hBadNoOtherCountHPD = ib.book1D("BadNoOtherCountHPD", "HPD with bad \"no other\" hit counts", 72 * 4, 0.5, 72 * 4 + 0.5);
+      hBadE2E10RBX = ib.book1D("BadE2E10RBX", "RBX with bad E2/E10 value", 72, 0.5, 72.5);
 
    ReadHcalPulse();
 
@@ -221,12 +208,6 @@ void HcalNoiseMonitor::analyze(edm::Event const &iEvent, edm::EventSetup const &
 
    HcalBaseDQMonitor::analyze(iEvent, iSetup);
 
-   if(dbe_ == NULL)
-   {
-      if(debug_ > 0)
-         std::cout << "HcalNoiseMonitor::processEvent DQMStore not instantiated!!!"<< std::endl;
-      return;
-   }
 
    // loop over digis
    for(HBHEDigiCollection::const_iterator iter = hHBHEDigis->begin(); iter != hHBHEDigis->end(); iter++)

--- a/DQM/HcalMonitorTasks/src/HcalRawDataMonitor.cc
+++ b/DQM/HcalMonitorTasks/src/HcalRawDataMonitor.cc
@@ -128,8 +128,8 @@ void HcalRawDataMonitor::reset(void)
 } // HcalRawDataMonitor::HcalRawDataMonitor()
 
 // BeginRun
-void HcalRawDataMonitor::beginRun(const edm::Run& run, const edm::EventSetup& c){
-  HcalBaseDQMonitor::beginRun(run,c);
+void HcalRawDataMonitor::bookHistograms(DQMStore::IBooker &ib, const edm::Run& run, const edm::EventSetup& c){
+  HcalBaseDQMonitor::bookHistograms(ib,run,c);
   edm::ESHandle<HcalDbService> pSetup;
   c.get<HcalDbRecord>().get( pSetup );
 
@@ -178,36 +178,32 @@ void HcalRawDataMonitor::beginLuminosityBlock(const edm::LuminosityBlock& lumiSe
   return;
 }
 // Setup
-void HcalRawDataMonitor::setup(void){
+void HcalRawDataMonitor::setup(DQMStore::IBooker &ib){
   // Call base class setup
-  HcalBaseDQMonitor::setup();
-  if (!dbe_) {
-    if (debug_>1)
-      std::cout <<"<HcalRawDataMonitor::setup>  No DQMStore instance available. Bailing out."<<std::endl;
-    return;}
+  HcalBaseDQMonitor::setup(ib);
 
   /******* Set up all histograms  ********/
   if (debug_>1)
     std::cout <<"<HcalRawDataMonitor::beginRun>  Setting up histograms"<<std::endl;
   
-  dbe_->setCurrentFolder(subdir_);
-  ProblemsVsLB=dbe_->bookProfile("RAW_Problems_HCAL_vs_LS",
+  ib.setCurrentFolder(subdir_);
+  ProblemsVsLB=ib.bookProfile("RAW_Problems_HCAL_vs_LS",
 				 "Total HCAL RAW Problems vs lumi section", 
 				 NLumiBlocks_,0.5,NLumiBlocks_+0.5,100,0,10000);
 
-  ProblemsVsLB_HB=dbe_->bookProfile("Total_RAW_Problems_HB_vs_LS",
+  ProblemsVsLB_HB=ib.bookProfile("Total_RAW_Problems_HB_vs_LS",
 				    "Total HB RAW Problems vs lumi section",
 				    NLumiBlocks_,0.5,NLumiBlocks_+0.5,100,0,3000);
-  ProblemsVsLB_HE=dbe_->bookProfile("Total_RAW_Problems_HE_vs_LS",
+  ProblemsVsLB_HE=ib.bookProfile("Total_RAW_Problems_HE_vs_LS",
 				    "Total HE RAW Problems vs lumi section",
 				    NLumiBlocks_,0.5,NLumiBlocks_+0.5,100,0,3000);
-  ProblemsVsLB_HO=dbe_->bookProfile("Total_RAW_Problems_HO_vs_LS",
+  ProblemsVsLB_HO=ib.bookProfile("Total_RAW_Problems_HO_vs_LS",
 				    "Total HO RAW Problems vs lumi section",
 				    NLumiBlocks_,0.5,NLumiBlocks_+0.5,100,0,3000);
-  ProblemsVsLB_HF=dbe_->bookProfile("Total_RAW_Problems_HF_vs_LS",
+  ProblemsVsLB_HF=ib.bookProfile("Total_RAW_Problems_HF_vs_LS",
 				    "Total HF RAW Problems vs lumi section",
 				    NLumiBlocks_,0.5,NLumiBlocks_+0.5,100,0,2000);
-  ProblemsVsLB_HBHEHF=dbe_->bookProfile("Total_RAW_Problems_HBHEHF_vs_LS",
+  ProblemsVsLB_HBHEHF=ib.bookProfile("Total_RAW_Problems_HBHEHF_vs_LS",
 				    "Total HBHEHF RAW Problems vs lumi section",
 				    NLumiBlocks_,0.5,NLumiBlocks_+0.5,100,0,2000);
  
@@ -217,27 +213,27 @@ void HcalRawDataMonitor::setup(void){
   ProblemsVsLB_HO->getTProfile()->SetMarkerStyle(20);
   ProblemsVsLB_HF->getTProfile()->SetMarkerStyle(20);
   ProblemsVsLB_HBHEHF->getTProfile()->SetMarkerStyle(20);
-  MonitorElement* excludeHO2=dbe_->bookInt("ExcludeHOring2");
+  MonitorElement* excludeHO2=ib.bookInt("ExcludeHOring2");
   // Fill with 0 if ring is not to be excluded; fill with 1 if it is to be excluded
   if (excludeHO2) excludeHO2->Fill(excludeHORing2_==true ? 1 : 0);
 
 
   //  Already done in base class:
-  //dbe_->setCurrentFolder(subdir_);
-  //meIevt_ = dbe_->bookInt("EventsProcessed");
+  //ib.setCurrentFolder(subdir_);
+  //meIevt_ = ib.bookInt("EventsProcessed");
   //if (meIevt_) meIevt_->Fill(-1);
-  //meLevt_ = dbe_->bookInt("EventsProcessed_currentLS");
+  //meLevt_ = ib.bookInt("EventsProcessed_currentLS");
   //if (meLevt_) meLevt_->Fill(-1);
-  //meTevt_ = dbe_->bookInt("EventsProcessed_All");
+  //meTevt_ = ib.bookInt("EventsProcessed_All");
   //if (meTevt_) meTevt_->Fill(-1);
-  //meTevtHist_=dbe_->book1D("EventsProcessed_AllHists","Counter of Events Processed By This Task",1,0.5,1.5);
+  //meTevtHist_=ib.book1D("EventsProcessed_AllHists","Counter of Events Processed By This Task",1,0.5,1.5);
   //if (meTevtHist_) meTevtHist_->Reset();
   
   std::string type;
       
-  dbe_->setCurrentFolder(subdir_ + "Corruption"); /// Below, "Corruption" FOLDER
+  ib.setCurrentFolder(subdir_ + "Corruption"); /// Below, "Corruption" FOLDER
   type = "01 Common Data Format violations";
-  meCDFErrorFound_ = dbe_->book2D(type,type,32,699.5,731.5,9,0.5,9.5);
+  meCDFErrorFound_ = ib.book2D(type,type,32,699.5,731.5,9,0.5,9.5);
   meCDFErrorFound_->setAxisTitle("HCAL FED ID", 1);
   meCDFErrorFound_->setBinLabel(1, "Hdr1BitUnset", 2);
   meCDFErrorFound_->setBinLabel(2, "FmtNumChange", 2);
@@ -250,7 +246,7 @@ void HcalRawDataMonitor::setup(void){
   meCDFErrorFound_->setBinLabel(9, "TrailerBad", 2);
       
   type = "02 DCC Event Format violation";
-  meDCCEventFormatError_ = dbe_->book2D(type,type,32,699.5,731.5,6,0.5,6.5);
+  meDCCEventFormatError_ = ib.book2D(type,type,32,699.5,731.5,6,0.5,6.5);
   meDCCEventFormatError_->setAxisTitle("HCAL FED ID", 1);
   meDCCEventFormatError_->setBinLabel(1, "FmtVers Changed", 2);
   meDCCEventFormatError_->setBinLabel(2, "StrayBits Changed", 2);
@@ -260,34 +256,34 @@ void HcalRawDataMonitor::setup(void){
   meDCCEventFormatError_->setBinLabel(6, "Low 8 HTR Status Bits Miscopy", 2);	       
       
   type = "04 HTR BCN when OrN Diff";
-  meBCNwhenOrNDiff_ = dbe_->book1D(type,type,3564,-0.5,3563.5);
+  meBCNwhenOrNDiff_ = ib.book1D(type,type,3564,-0.5,3563.5);
   meBCNwhenOrNDiff_->setAxisTitle("BCN",1);
   meBCNwhenOrNDiff_->setAxisTitle("# of Entries",2);
       
   type = "03 OrN NonZero Difference HTR - DCC";
-  meOrNCheck_ = dbe_->book1D(type,type,65,-32.5,32.5);
+  meOrNCheck_ = ib.book1D(type,type,65,-32.5,32.5);
   meOrNCheck_->setAxisTitle("htr OrN - dcc OrN",1);
       
   type = "03 OrN Inconsistent - HTR vs DCC";
-  meOrNSynch_= dbe_->book2D(type,type,32,700,732, 15,0,15);
+  meOrNSynch_= ib.book2D(type,type,32,700,732, 15,0,15);
   meOrNSynch_->setAxisTitle("FED #",1);
   meOrNSynch_->setAxisTitle("Spigot #",2);
       
   type = "05 BCN NonZero Difference HTR - DCC";
-  meBCNCheck_ = dbe_->book1D(type,type,501,-250.5,250.5);
+  meBCNCheck_ = ib.book1D(type,type,501,-250.5,250.5);
   meBCNCheck_->setAxisTitle("htr BCN - dcc BCN",1);
       
   type = "05 BCN Inconsistent - HTR vs DCC";
-  meBCNSynch_= dbe_->book2D(type,type,32,700,732, 15,0,15);
+  meBCNSynch_= ib.book2D(type,type,32,700,732, 15,0,15);
   meBCNSynch_->setAxisTitle("FED #",1);
   meBCNSynch_->setAxisTitle("Slot #",2);
       
   type = "06 EvN NonZero Difference HTR - DCC";
-  meEvtNCheck_ = dbe_->book1D(type,type,601,-300.5,300.5);
+  meEvtNCheck_ = ib.book1D(type,type,601,-300.5,300.5);
   meEvtNCheck_->setAxisTitle("htr Evt # - dcc Evt #",1);
       
   type = "06 EvN Inconsistent - HTR vs DCC";
-  meEvtNumberSynch_= dbe_->book2D(type,type,32,700,732, 15,0,15);
+  meEvtNumberSynch_= ib.book2D(type,type,32,700,732, 15,0,15);
   meEvtNumberSynch_->setAxisTitle("FED #",1);
   meEvtNumberSynch_->setAxisTitle("Slot #",2);
       
@@ -297,7 +293,7 @@ void HcalRawDataMonitor::setup(void){
   // | T | CRC | ST | ODD| 					       
   // -------------------- 					       
   type="07 LRB Data Corruption Indicators";  
-  meLRBDataCorruptionIndicators_= dbe_->book2D(type,type,
+  meLRBDataCorruptionIndicators_= ib.book2D(type,type,
 						THREE_FED,0,THREE_FED,
 						THREE_SPG,0,THREE_SPG);
   label_xFEDs   (meLRBDataCorruptionIndicators_, 4); // 3 bins + 1 margin per ch.
@@ -309,7 +305,7 @@ void HcalRawDataMonitor::setup(void){
   //     | TM | CK | IW | (Illegal Wordcount)
   //     ---------------- 
   type="08 Half-HTR Data Corruption Indicators";
-  meHalfHTRDataCorruptionIndicators_= dbe_->book2D(type,type,
+  meHalfHTRDataCorruptionIndicators_= ib.book2D(type,type,
 						    THREE_FED,0,THREE_FED,
 						    THREE_SPG,0,THREE_SPG);
   label_xFEDs   (meHalfHTRDataCorruptionIndicators_, 4); // 3 bins + 1 margin per ch.
@@ -320,46 +316,46 @@ void HcalRawDataMonitor::setup(void){
   //    | NTS | Cap |
   //    ------------
   type = "09 Channel Integrity Summarized by Spigot";
-  meChannSumm_DataIntegrityCheck_= dbe_->book2D(type,type,
+  meChannSumm_DataIntegrityCheck_= ib.book2D(type,type,
 						 TWO___FED,0,TWO___FED,
 						 TWO__SPGT,0,TWO__SPGT);
   label_xFEDs   (meChannSumm_DataIntegrityCheck_, 3); // 2 bins + 1 margin per ch.
   label_ySpigots(meChannSumm_DataIntegrityCheck_, 3); // 2 bins + 1 margin per spgt
       
-  dbe_->setCurrentFolder(subdir_ + "Corruption/Channel Data Integrity");
+  ib.setCurrentFolder(subdir_ + "Corruption/Channel Data Integrity");
   char label[256];
   for (int f=0; f<NUMDCCS; f++){      
     snprintf(label, 256, "FED %03d Channel Integrity", f+700);
-    meChann_DataIntegrityCheck_[f] =  dbe_->book2D(label,label,
+    meChann_DataIntegrityCheck_[f] =  ib.book2D(label,label,
 						    TWO_CHANN,0,TWO_CHANN,
 						    TWO__SPGT,0,TWO__SPGT);
     label_xChanns (meChann_DataIntegrityCheck_[f], 3); // 2 bins + 1 margin per ch.
     label_ySpigots(meChann_DataIntegrityCheck_[f], 3); // 2 bins + 1 margin per spgt
     ;}
       
-  dbe_->setCurrentFolder(subdir_ + "Data Flow"); ////Below, "Data Flow" FOLDER
+  ib.setCurrentFolder(subdir_ + "Data Flow"); ////Below, "Data Flow" FOLDER
   type="DCC Event Counts";
-  mefedEntries_ = dbe_->book1D(type,type,32,699.5,731.5);
+  mefedEntries_ = ib.book1D(type,type,32,699.5,731.5);
       
   type = "BCN from DCCs";
-  medccBCN_ = dbe_->book1D(type,type,3564,-0.5,3563.5);
+  medccBCN_ = ib.book1D(type,type,3564,-0.5,3563.5);
   medccBCN_->setAxisTitle("BCN",1);
   medccBCN_->setAxisTitle("# of Entries",2);
       
   type = "BCN from HTRs";
-  meBCN_ = dbe_->book1D(type,type,3564,-0.5,3563.5);
+  meBCN_ = ib.book1D(type,type,3564,-0.5,3563.5);
   meBCN_->setAxisTitle("BCN",1);
   meBCN_->setAxisTitle("# of Entries",2);
       
   type = "DCC Data Block Size Distribution";
-  meFEDRawDataSizes_=dbe_->book1D(type,type,1200,-0.5,12000.5);
+  meFEDRawDataSizes_=ib.book1D(type,type,1200,-0.5,12000.5);
   meFEDRawDataSizes_->setAxisTitle("# of bytes",1);
   meFEDRawDataSizes_->setAxisTitle("# of Data Blocks",2);
       
   type = "DCC Data Block Size Profile";
-  meEvFragSize_ = dbe_->bookProfile(type,type,32,699.5,731.5,100,-1000.0,12000.0,"");
+  meEvFragSize_ = ib.bookProfile(type,type,32,699.5,731.5,100,-1000.0,12000.0,"");
   type = "DCC Data Block Size Each FED";
-  meEvFragSize2_ =  dbe_->book2D(type,type,64,699.5,731.5, 240,0,12000);
+  meEvFragSize2_ =  ib.book2D(type,type,64,699.5,731.5, 240,0,12000);
       
   //     ------------
   //     | OW | OFW |    "Two Caps HTR; Three Caps FED."
@@ -369,127 +365,127 @@ void HcalRawDataMonitor::setup(void){
   // | CE |            (corrected error, Hamming code)
   // ------
   type = "01 Data Flow Indicators";
-  meDataFlowInd_= dbe_->book2D(type,type,
+  meDataFlowInd_= ib.book2D(type,type,
 				TWO___FED,0,TWO___FED,
 				THREE_SPG,0,THREE_SPG);
   label_xFEDs   (meDataFlowInd_, 3); // 2 bins + 1 margin per ch.
   label_ySpigots(meDataFlowInd_, 4); // 3 bins + 1 margin each spgt
       
-  dbe_->setCurrentFolder(subdir_ + "Diagnostics"); ////Below, "Diagnostics" FOLDER
+  ib.setCurrentFolder(subdir_ + "Diagnostics"); ////Below, "Diagnostics" FOLDER
 
   type = "DCC Firmware Version";
-  meDCCVersion_ = dbe_->bookProfile(type,type, 32, 699.5, 731.5, 256, -0.5, 255.5);
+  meDCCVersion_ = ib.bookProfile(type,type, 32, 699.5, 731.5, 256, -0.5, 255.5);
   meDCCVersion_ ->setAxisTitle("FED ID", 1);
       
   type = "HTR Status Word HBHE";
-  HTR_StatusWd_HBHE =  dbe_->book1D(type,type,16,-0.5,15.5);
+  HTR_StatusWd_HBHE =  ib.book1D(type,type,16,-0.5,15.5);
   labelHTRBits(HTR_StatusWd_HBHE,1);
       
   type = "HTR Status Word HF";
-  HTR_StatusWd_HF =  dbe_->book1D(type,type,16,-0.5,15.5);
+  HTR_StatusWd_HF =  ib.book1D(type,type,16,-0.5,15.5);
   labelHTRBits(HTR_StatusWd_HF,1);
       
   type = "HTR Status Word HO";
-  HTR_StatusWd_HO = dbe_->book1D(type,type,16,-0.5,15.5);
+  HTR_StatusWd_HO = ib.book1D(type,type,16,-0.5,15.5);
   labelHTRBits(HTR_StatusWd_HO,1);
       
   int maxbits = 16;//Look at all 16 bits of the Error Words
   type = "HTR Status Word by Crate";
-  meStatusWdCrate_ = dbe_->book2D(type,type,18,-0.5,17.5,maxbits,-0.5,maxbits-0.5);
+  meStatusWdCrate_ = ib.book2D(type,type,18,-0.5,17.5,maxbits,-0.5,maxbits-0.5);
   meStatusWdCrate_ -> setAxisTitle("Crate #",1);
   labelHTRBits(meStatusWdCrate_,2);
       
   type = "Unpacking - HcalHTRData check failures";
-  meInvHTRData_= dbe_->book2D(type,type,16,-0.5,15.5,32,699.5,731.5);
+  meInvHTRData_= ib.book2D(type,type,16,-0.5,15.5,32,699.5,731.5);
   meInvHTRData_->setAxisTitle("Spigot #",1);
   meInvHTRData_->setAxisTitle("DCC #",2);
       
   type = "HTR Fiber Orbit Message BCN";
-  meFibBCN_ = dbe_->book1D(type,type,3564,-0.5,3563.5);
+  meFibBCN_ = ib.book1D(type,type,3564,-0.5,3563.5);
   meFibBCN_->setAxisTitle("BCN of Fib Orb Msg",1);
       
   type = "HTR Status Word - Crate 0";
-  meCrate0HTRStatus_ = dbe_->book2D(type,type,40,-0.25,19.75,maxbits,-0.5,maxbits-0.5);
+  meCrate0HTRStatus_ = ib.book2D(type,type,40,-0.25,19.75,maxbits,-0.5,maxbits-0.5);
   meCrate0HTRStatus_ ->setAxisTitle("Slot #",1);
   labelHTRBits(meCrate0HTRStatus_,2);
       
   type = "HTR Status Word - Crate 1";
-  meCrate1HTRStatus_ = dbe_->book2D(type,type,40,-0.25,19.75,maxbits,-0.5,maxbits-0.5);
+  meCrate1HTRStatus_ = ib.book2D(type,type,40,-0.25,19.75,maxbits,-0.5,maxbits-0.5);
   meCrate1HTRStatus_ ->setAxisTitle("Slot #",1);
   labelHTRBits(meCrate1HTRStatus_,2);
       
   type = "HTR Status Word - Crate 2";
-  meCrate2HTRStatus_ = dbe_->book2D(type,type,40,-0.25,19.75,maxbits,-0.5,maxbits-0.5);
+  meCrate2HTRStatus_ = ib.book2D(type,type,40,-0.25,19.75,maxbits,-0.5,maxbits-0.5);
   meCrate2HTRStatus_ ->setAxisTitle("Slot #",1);
   labelHTRBits(meCrate2HTRStatus_,2);
       
   type = "HTR Status Word - Crate 3";
-  meCrate3HTRStatus_ = dbe_->book2D(type,type,40,-0.25,19.75,maxbits,-0.5,maxbits-0.5);
+  meCrate3HTRStatus_ = ib.book2D(type,type,40,-0.25,19.75,maxbits,-0.5,maxbits-0.5);
   meCrate3HTRStatus_ ->setAxisTitle("Slot #",1);
   labelHTRBits(meCrate3HTRStatus_,2);
       
   type = "HTR Status Word - Crate 4";
-  meCrate4HTRStatus_ = dbe_->book2D(type,type,40,-0.25,19.75,maxbits,-0.5,maxbits-0.5);
+  meCrate4HTRStatus_ = ib.book2D(type,type,40,-0.25,19.75,maxbits,-0.5,maxbits-0.5);
   meCrate4HTRStatus_ ->setAxisTitle("Slot #",1);
   labelHTRBits(meCrate4HTRStatus_,2);
 
   type = "HTR Status Word - Crate 5";
-  meCrate5HTRStatus_ = dbe_->book2D(type,type,40,-0.25,19.75,maxbits,-0.5,maxbits-0.5);
+  meCrate5HTRStatus_ = ib.book2D(type,type,40,-0.25,19.75,maxbits,-0.5,maxbits-0.5);
   meCrate5HTRStatus_ ->setAxisTitle("Slot #",1);
   labelHTRBits(meCrate5HTRStatus_,2);
 
   type = "HTR Status Word - Crate 6";
-  meCrate6HTRStatus_ = dbe_->book2D(type,type,40,-0.25,19.75,maxbits,-0.5,maxbits-0.5);
+  meCrate6HTRStatus_ = ib.book2D(type,type,40,-0.25,19.75,maxbits,-0.5,maxbits-0.5);
   meCrate6HTRStatus_ ->setAxisTitle("Slot #",1);
   labelHTRBits(meCrate6HTRStatus_,2);
 
   type = "HTR Status Word - Crate 7";
-  meCrate7HTRStatus_ = dbe_->book2D(type,type,40,-0.25,19.75,maxbits,-0.5,maxbits-0.5);
+  meCrate7HTRStatus_ = ib.book2D(type,type,40,-0.25,19.75,maxbits,-0.5,maxbits-0.5);
   meCrate7HTRStatus_ ->setAxisTitle("Slot #",1);
   labelHTRBits(meCrate7HTRStatus_,2);
 
   type = "HTR Status Word - Crate 9";
-  meCrate9HTRStatus_ = dbe_->book2D(type,type,40,-0.25,19.75,maxbits,-0.5,maxbits-0.5);
+  meCrate9HTRStatus_ = ib.book2D(type,type,40,-0.25,19.75,maxbits,-0.5,maxbits-0.5);
   meCrate9HTRStatus_ ->setAxisTitle("Slot #",1);
   labelHTRBits(meCrate9HTRStatus_,2);
 
   type = "HTR Status Word - Crate 10";
-  meCrate10HTRStatus_ = dbe_->book2D(type,type,40,-0.25,19.75,maxbits,-0.5,maxbits-0.5);
+  meCrate10HTRStatus_ = ib.book2D(type,type,40,-0.25,19.75,maxbits,-0.5,maxbits-0.5);
   meCrate10HTRStatus_ ->setAxisTitle("Slot #",1);
   labelHTRBits(meCrate10HTRStatus_,2);
 
   type = "HTR Status Word - Crate 11";
-  meCrate11HTRStatus_ = dbe_->book2D(type,type,40,-0.25,19.75,maxbits,-0.5,maxbits-0.5);
+  meCrate11HTRStatus_ = ib.book2D(type,type,40,-0.25,19.75,maxbits,-0.5,maxbits-0.5);
   meCrate11HTRStatus_ ->setAxisTitle("Slot #",1);
   labelHTRBits(meCrate11HTRStatus_,2);
 
   type = "HTR Status Word - Crate 12";
-  meCrate12HTRStatus_ = dbe_->book2D(type,type,40,-0.25,19.75,maxbits,-0.5,maxbits-0.5);
+  meCrate12HTRStatus_ = ib.book2D(type,type,40,-0.25,19.75,maxbits,-0.5,maxbits-0.5);
   meCrate12HTRStatus_ ->setAxisTitle("Slot #",1);
   labelHTRBits(meCrate12HTRStatus_,2);
 
   type = "HTR Status Word - Crate 13";
-  meCrate13HTRStatus_ = dbe_->book2D(type,type,40,-0.25,19.75,maxbits,-0.5,maxbits-0.5);
+  meCrate13HTRStatus_ = ib.book2D(type,type,40,-0.25,19.75,maxbits,-0.5,maxbits-0.5);
   meCrate13HTRStatus_ ->setAxisTitle("Slot #",1);
   labelHTRBits(meCrate13HTRStatus_,2);
 
   type = "HTR Status Word - Crate 14";
-  meCrate14HTRStatus_ = dbe_->book2D(type,type,40,-0.25,19.75,maxbits,-0.5,maxbits-0.5);
+  meCrate14HTRStatus_ = ib.book2D(type,type,40,-0.25,19.75,maxbits,-0.5,maxbits-0.5);
   meCrate14HTRStatus_ ->setAxisTitle("Slot #",1);
   labelHTRBits(meCrate14HTRStatus_,2);
 
   type = "HTR Status Word - Crate 15";
-  meCrate15HTRStatus_ = dbe_->book2D(type,type,40,-0.25,19.75,maxbits,-0.5,maxbits-0.5);
+  meCrate15HTRStatus_ = ib.book2D(type,type,40,-0.25,19.75,maxbits,-0.5,maxbits-0.5);
   meCrate15HTRStatus_ ->setAxisTitle("Slot #",1);
   labelHTRBits(meCrate15HTRStatus_,2);
 
   type = "HTR Status Word - Crate 17";
-  meCrate17HTRStatus_ = dbe_->book2D(type,type,40,-0.25,19.75,maxbits,-0.5,maxbits-0.5);
+  meCrate17HTRStatus_ = ib.book2D(type,type,40,-0.25,19.75,maxbits,-0.5,maxbits-0.5);
   meCrate17HTRStatus_ ->setAxisTitle("Slot #",1);
   labelHTRBits(meCrate17HTRStatus_,2);
 
   type = "HTR UnSuppressed Event Fractions";
-  meUSFractSpigs_ = dbe_->book1D(type,type,481,0,481);
+  meUSFractSpigs_ = ib.book1D(type,type,481,0,481);
   for(int f=0; f<NUMDCCS; f++) {
     snprintf(label, 256, "FED 7%02d", f);
     meUSFractSpigs_->setBinLabel(1+(HcalDCCHeader::SPIGOT_COUNT*f), label);
@@ -500,27 +496,27 @@ void HcalRawDataMonitor::setup(void){
   // Firmware version
   type = "HTR Firmware Version";
   //  Maybe change to Profile histo eventually
-  //meHTRFWVersion_ = dbe_->bookProfile(type,type,18,-0.5,17.5,245,10.0,255.0,"");
-  meHTRFWVersion_ = dbe_->book2D(type,type ,18,-0.5,17.5,180,75.5,255.5);
+  //meHTRFWVersion_ = ib.bookProfile(type,type,18,-0.5,17.5,245,10.0,255.0,"");
+  meHTRFWVersion_ = ib.book2D(type,type ,18,-0.5,17.5,180,75.5,255.5);
   meHTRFWVersion_->setAxisTitle("Crate #",1);
   meHTRFWVersion_->setAxisTitle("HTR Firmware Version",2);
 
   type = "HTR Fiber 1 Orbit Message BCNs";
-  meFib1OrbMsgBCN_= dbe_->book2D(type,type,40,-0.25,19.75,18,-0.5,17.5);
+  meFib1OrbMsgBCN_= ib.book2D(type,type,40,-0.25,19.75,18,-0.5,17.5);
   type = "HTR Fiber 2 Orbit Message BCNs";
-  meFib2OrbMsgBCN_= dbe_->book2D(type,type,40,-0.25,19.75,18,-0.5,17.5);
+  meFib2OrbMsgBCN_= ib.book2D(type,type,40,-0.25,19.75,18,-0.5,17.5);
   type = "HTR Fiber 3 Orbit Message BCNs";
-  meFib3OrbMsgBCN_= dbe_->book2D(type,type,40,-0.25,19.75,18,-0.5,17.5);
+  meFib3OrbMsgBCN_= ib.book2D(type,type,40,-0.25,19.75,18,-0.5,17.5);
   type = "HTR Fiber 4 Orbit Message BCNs";
-  meFib4OrbMsgBCN_= dbe_->book2D(type,type,40,-0.25,19.75,18,-0.5,17.5);
+  meFib4OrbMsgBCN_= ib.book2D(type,type,40,-0.25,19.75,18,-0.5,17.5);
   type = "HTR Fiber 5 Orbit Message BCNs";
-  meFib5OrbMsgBCN_= dbe_->book2D(type,type,40,-0.25,19.75,18,-0.5,17.5);
+  meFib5OrbMsgBCN_= ib.book2D(type,type,40,-0.25,19.75,18,-0.5,17.5);
   type = "HTR Fiber 6 Orbit Message BCNs";
-  meFib6OrbMsgBCN_= dbe_->book2D(type,type,40,-0.25,19.75,18,-0.5,17.5);
+  meFib6OrbMsgBCN_= ib.book2D(type,type,40,-0.25,19.75,18,-0.5,17.5);
   type = "HTR Fiber 7 Orbit Message BCNs";
-  meFib7OrbMsgBCN_= dbe_->book2D(type,type,40,-0.25,19.75,18,-0.5,17.5);
+  meFib7OrbMsgBCN_= ib.book2D(type,type,40,-0.25,19.75,18,-0.5,17.5);
   type = "HTR Fiber 8 Orbit Message BCNs";
-  meFib8OrbMsgBCN_= dbe_->book2D(type,type,40,-0.25,19.75,18,-0.5,17.5);
+  meFib8OrbMsgBCN_= ib.book2D(type,type,40,-0.25,19.75,18,-0.5,17.5);
 
 }
 
@@ -598,11 +594,6 @@ void HcalRawDataMonitor::analyze(const edm::Event& e, const edm::EventSetup& s){
 
 void HcalRawDataMonitor::processEvent(const FEDRawDataCollection& rawraw, 
 				      const HcalUnpackerReport& report){
-  if(!dbe_) { 
-    if (debug_>1)
-      printf("HcalRawDataMonitor::processEvent DQMStore not instantiated!\n");  
-    return;}
-  
   // Fill event counters (underflow bins of histograms)
   meLRBDataCorruptionIndicators_->update();
   meHalfHTRDataCorruptionIndicators_->update();

--- a/DQM/HcalMonitorTasks/src/HcalRawDataMonitor.cc
+++ b/DQM/HcalMonitorTasks/src/HcalRawDataMonitor.cc
@@ -6,9 +6,9 @@
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 
 
-HcalRawDataMonitor::HcalRawDataMonitor(const edm::ParameterSet& ps) {
-  Online_                = ps.getParameter<bool>("online");
-  mergeRuns_             = ps.getParameter<bool>("mergeRuns");
+HcalRawDataMonitor::HcalRawDataMonitor(const edm::ParameterSet& ps):HcalBaseDQMonitor(ps) {
+  Online_                = ps.getUntrackedParameter<bool>("online");
+  mergeRuns_             = ps.getUntrackedParameter<bool>("mergeRuns");
   enableCleanup_         = ps.getUntrackedParameter<bool>("enableCleanup");
   debug_                 = ps.getUntrackedParameter<int>("debug",0);
   prefixME_              = ps.getUntrackedParameter<std::string>("subSystemFolder", "Hcal/"); // Hcal

--- a/DQM/HcalMonitorTasks/src/HcalRecHitMonitor.cc
+++ b/DQM/HcalMonitorTasks/src/HcalRecHitMonitor.cc
@@ -13,7 +13,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <cmath>
 
-HcalRecHitMonitor::HcalRecHitMonitor(const edm::ParameterSet& ps)
+HcalRecHitMonitor::HcalRecHitMonitor(const edm::ParameterSet& ps):HcalBaseDQMonitor(ps)
 {
   // Common Base Class parameters
   Online_                = ps.getUntrackedParameter<bool>("online",false);

--- a/DQM/HcalMonitorTasks/src/HcalRecHitMonitor.cc
+++ b/DQM/HcalMonitorTasks/src/HcalRecHitMonitor.cc
@@ -74,7 +74,7 @@ HcalRecHitMonitor::~HcalRecHitMonitor()
 /* ------------------------------------ */ 
 
 
-void HcalRecHitMonitor::setup()
+void HcalRecHitMonitor::setup(DQMStore::IBooker &ib)
 {
 
   if (setupDone_)
@@ -90,7 +90,7 @@ void HcalRecHitMonitor::setup()
   else
     setupDone_=true;
 
-  HcalBaseDQMonitor::setup();
+  HcalBaseDQMonitor::setup(ib);
 
 
   if (debug_>0)
@@ -101,238 +101,238 @@ void HcalRecHitMonitor::setup()
   if (debug_>1)
     std::cout <<"<HcalRecHitMonitor::setup>  Creating Histograms"<<std::endl;
 
-  dbe_->setCurrentFolder(subdir_);
-  h_TriggeredEvents=dbe_->book1D("EventTriggers","EventTriggers",3,-0.5,2.5);
+  ib.setCurrentFolder(subdir_);
+  h_TriggeredEvents=ib.book1D("EventTriggers","EventTriggers",3,-0.5,2.5);
   h_TriggeredEvents->setBinLabel(1,"AllEvents");
   h_TriggeredEvents->setBinLabel(2,"HLT_Minbias");
   h_TriggeredEvents->setBinLabel(3,"HLT_Hcal");
 
-  dbe_->setCurrentFolder(subdir_+"rechit_parameters");
+  ib.setCurrentFolder(subdir_+"rechit_parameters");
   MonitorElement* THR;
-  dbe_->setCurrentFolder(subdir_+"rechit_parameters/thresholds");
-  THR=dbe_->bookFloat("HB_Rechit_Energy_Threshold");
+  ib.setCurrentFolder(subdir_+"rechit_parameters/thresholds");
+  THR=ib.bookFloat("HB_Rechit_Energy_Threshold");
   THR->Fill(HBenergyThreshold_);
-  THR=dbe_->bookFloat("HE_Rechit_Energy_Threshold");
+  THR=ib.bookFloat("HE_Rechit_Energy_Threshold");
   THR->Fill(HEenergyThreshold_);
-  THR=dbe_->bookFloat("HO_Rechit_Energy_Threshold");
+  THR=ib.bookFloat("HO_Rechit_Energy_Threshold");
   THR->Fill(HOenergyThreshold_);
-  THR=dbe_->bookFloat("HF_Rechit_Energy_Threshold");
+  THR=ib.bookFloat("HF_Rechit_Energy_Threshold");
   THR->Fill(HFenergyThreshold_);
-  THR=dbe_->bookFloat("HB_Rechit_ET_Threshold");
+  THR=ib.bookFloat("HB_Rechit_ET_Threshold");
   THR->Fill(HBETThreshold_);
-  THR=dbe_->bookFloat("HE_Rechit_ET_Threshold");
+  THR=ib.bookFloat("HE_Rechit_ET_Threshold");
   THR->Fill(HEETThreshold_);
-  THR=dbe_->bookFloat("HO_Rechit_ET_Threshold");
+  THR=ib.bookFloat("HO_Rechit_ET_Threshold");
   THR->Fill(HOETThreshold_);
-  THR=dbe_->bookFloat("HF_Rechit_ET_Threshold");
+  THR=ib.bookFloat("HF_Rechit_ET_Threshold");
   THR->Fill(HFETThreshold_);
-  THR=dbe_->bookFloat("Maximum_HFM_HFP_time_difference_for_luminosityplots");
+  THR=ib.bookFloat("Maximum_HFM_HFP_time_difference_for_luminosityplots");
   THR->Fill(timediffThresh_);
 
   
   // Set up histograms that are filled by all rechits
-  dbe_->setCurrentFolder(subdir_+"Distributions_AllRecHits");
-  SetupEtaPhiHists(OccupancyByDepth,"RecHit Occupancy","");
-  h_rechitieta = dbe_->book1D("HcalRecHitIeta",
+  ib.setCurrentFolder(subdir_+"Distributions_AllRecHits");
+  SetupEtaPhiHists(ib,OccupancyByDepth,"RecHit Occupancy","");
+  h_rechitieta = ib.book1D("HcalRecHitIeta",
 			      "Hcal RecHit ieta",
 			      83,-41.5,41.5);
-  h_rechitiphi = dbe_->book1D("HcalRecHitIphi",
+  h_rechitiphi = ib.book1D("HcalRecHitIphi",
 			      "Hcal RecHit iphi",
 			      72,0.5,72.5);
 
-  h_rechitieta_05 = dbe_->book1D("HcalRecHitIeta05",
+  h_rechitieta_05 = ib.book1D("HcalRecHitIeta05",
 				 "Hcal RecHit ieta E>0.5 GeV",
 				 83,-41.5,41.5);
-  h_rechitiphi_05 = dbe_->book1D("HcalRecHitIphi05",
+  h_rechitiphi_05 = ib.book1D("HcalRecHitIphi05",
 				 "Hcal RecHit iphi E>0.5 GeV",
 				 72,0.5,72.5);
-  h_rechitieta_10 = dbe_->book1D("HcalRecHitIeta10",
+  h_rechitieta_10 = ib.book1D("HcalRecHitIeta10",
 				 "Hcal RecHit ieta E>1.0 GeV",
 				 83,-41.5,41.5);
-  h_rechitiphi_10 = dbe_->book1D("HcalRecHitIphi10",
+  h_rechitiphi_10 = ib.book1D("HcalRecHitIphi10",
 				 "Hcal RecHit iphi E>1.0 GeV",
 				 72,0.5,72.5);
-  h_rechitieta_25 = dbe_->book1D("HcalRecHitIeta25",
+  h_rechitieta_25 = ib.book1D("HcalRecHitIeta25",
 				 "Hcal RecHit ieta E>2.5 GeV",
 				 83,-41.5,41.5);
-  h_rechitiphi_25 = dbe_->book1D("HcalRecHitIphi25",
+  h_rechitiphi_25 = ib.book1D("HcalRecHitIphi25",
 				 "Hcal RecHit iphi E>2.5 GeV",
 				 72,0.5,72.5);
-  h_rechitieta_100 = dbe_->book1D("HcalRecHitIeta100",
+  h_rechitieta_100 = ib.book1D("HcalRecHitIeta100",
 				  "Hcal RecHit ieta E>10.0 GeV",
 				  83,-41.5,41.5);
-  h_rechitiphi_100 = dbe_->book1D("HcalRecHitIphi100",
+  h_rechitiphi_100 = ib.book1D("HcalRecHitIphi100",
 				  "Hcal RecHit iphi E>10.0 GeV",
 				  72,0.5,72.5);
 
 
 
-  h_LumiPlot_LS_allevents = dbe_->book1D("AllEventsPerLS",
+  h_LumiPlot_LS_allevents = ib.book1D("AllEventsPerLS",
 					 "LS # of all events",
 					 NLumiBlocks_,0.5,NLumiBlocks_+0.5);
-  h_LumiPlot_BX_allevents = dbe_->book1D("BX_allevents",
+  h_LumiPlot_BX_allevents = ib.book1D("BX_allevents",
 					 "BX # of all events",
 					 3600,0,3600);
-  h_LumiPlot_MinTime_vs_MinHT = dbe_->book2D("MinTime_vs_MinSumET",
+  h_LumiPlot_MinTime_vs_MinHT = ib.book2D("MinTime_vs_MinSumET",
 					     "Energy-Weighted Time vs Min (HF+,HF-) Scalar Sum ET;min Sum ET(GeV);time(ns)",
 					     100,0,10,80,-40,40);
 
-  h_LumiPlot_timeHT_HFM = dbe_->book2D("HFM_Time_vs_SumET",
+  h_LumiPlot_timeHT_HFM = ib.book2D("HFM_Time_vs_SumET",
 				       "Energy-Weighted Time vs HFMinus Scalar Sum ET;Sum ET(GeV);time(ns)",
 				       100,0,10,80,-40,40);
   
-  h_LumiPlot_timeHT_HFP = dbe_->book2D("HFP_Time_vs_SumET",
+  h_LumiPlot_timeHT_HFP = ib.book2D("HFP_Time_vs_SumET",
 				       "Energy-Weighted Time vs HFPlus Scalar Sum ET;Sum ET(GeV);time(ns)",
 				       100,0,10,80,-40,40);
 
 
-  dbe_->setCurrentFolder(subdir_+"Distributions_AllRecHits/sumplots");
-  SetupEtaPhiHists(SumEnergyByDepth,"RecHit Summed Energy","GeV");
-  SetupEtaPhiHists(SqrtSumEnergy2ByDepth,"RecHit Sqrt Summed Energy2","GeV");
-  SetupEtaPhiHists(SumTimeByDepth,"RecHit Summed Time","nS");
+  ib.setCurrentFolder(subdir_+"Distributions_AllRecHits/sumplots");
+  SetupEtaPhiHists(ib,SumEnergyByDepth,"RecHit Summed Energy","GeV");
+  SetupEtaPhiHists(ib,SqrtSumEnergy2ByDepth,"RecHit Sqrt Summed Energy2","GeV");
+  SetupEtaPhiHists(ib,SumTimeByDepth,"RecHit Summed Time","nS");
 
   // Histograms for events that passed MinBias triggers
-  dbe_->setCurrentFolder(subdir_+"Distributions_PassedMinBias");
+  ib.setCurrentFolder(subdir_+"Distributions_PassedMinBias");
 
-  h_HBP_weightedTime = dbe_->book1D("WeightedTime_HBP","Weighted Time for HBP",
+  h_HBP_weightedTime = ib.book1D("WeightedTime_HBP","Weighted Time for HBP",
 				    300,-150,150);
-  h_HBM_weightedTime = dbe_->book1D("WeightedTime_HBM","Weighted Time for HBM",
+  h_HBM_weightedTime = ib.book1D("WeightedTime_HBM","Weighted Time for HBM",
 				    300,-150,150);
-  h_HEP_weightedTime = dbe_->book1D("WeightedTime_HEP","Weighted Time for HEP",
+  h_HEP_weightedTime = ib.book1D("WeightedTime_HEP","Weighted Time for HEP",
 				    300,-150,150);
-  h_HEM_weightedTime = dbe_->book1D("WeightedTime_HEM","Weighted Time for HEM",
+  h_HEM_weightedTime = ib.book1D("WeightedTime_HEM","Weighted Time for HEM",
 				    300,-150,150);
-  h_HFP_weightedTime = dbe_->book1D("WeightedTime_HFP","Weighted Time for HFP",
+  h_HFP_weightedTime = ib.book1D("WeightedTime_HFP","Weighted Time for HFP",
 				    300,-150,150);
-  h_HFM_weightedTime = dbe_->book1D("WeightedTime_HFM","Weighted Time for HFM",
+  h_HFM_weightedTime = ib.book1D("WeightedTime_HFM","Weighted Time for HFM",
 				    300,-150,150);
 
-  h_HFtimedifference = dbe_->book1D("HFweightedtimeDifference",
+  h_HFtimedifference = ib.book1D("HFweightedtimeDifference",
 				    "Energy-Weighted time difference between HF+ and HF- passing MinBias (no HT cut)",
 				    251,-250.5,250.5);
-  h_HEtimedifference = dbe_->book1D("HEweightedtimeDifference",
+  h_HEtimedifference = ib.book1D("HEweightedtimeDifference",
 				    "Energy-Weighted time difference between HE+ and HE- passing MinBias (no HT cut)",
 				    251,-250.5,250.5);
   
-  HFP_HFM_Energy = dbe_->book2D("HFP_HFM_Energy",
+  HFP_HFM_Energy = ib.book2D("HFP_HFM_Energy",
 				"HFP VS HFM Energy; Total Energy in HFMinus (TeV); Total Energy in HFPlus (TeV)",
 				100,0,100, 100,0,100);
   
   // Would these work better as 2D plots?
-  h_HFenergydifference = dbe_->book1D("HFenergyDifference",
+  h_HFenergydifference = ib.book1D("HFenergyDifference",
 				      "Sum(E_HFPlus - E_HFMinus)/Sum(E_HFPlus + E_HFMinus)",
 				      200,-1,1);
-  h_HEenergydifference = dbe_->book1D("HEenergyDifference",
+  h_HEenergydifference = ib.book1D("HEenergyDifference",
 				      "Sum(E_HEPlus - E_HEMinus)/Sum(E_HEPlus + E_HEMinus)",
 				      200,-1,1);
 
-  h_LumiPlot_LS_MinBiasEvents=dbe_->book1D("MinBiasEventsPerLS",
+  h_LumiPlot_LS_MinBiasEvents=ib.book1D("MinBiasEventsPerLS",
 					   "Number of MinBias Events vs LS (HT cut and HFM-HFP time cut)",
 					   NLumiBlocks_/10,0.5,NLumiBlocks_+0.5); 
-  h_LumiPlot_LS_MinBiasEvents_notimecut=dbe_->book1D("MinBiasEventsPerLS_notimecut",
+  h_LumiPlot_LS_MinBiasEvents_notimecut=ib.book1D("MinBiasEventsPerLS_notimecut",
 						     "Number of Events with MinBias vs LS (HFM,HFP HT>1,no time cut)",
 						     NLumiBlocks_/10,0.5,NLumiBlocks_+0.5); 
 
-  h_LumiPlot_SumHT_HFPlus_vs_HFMinus = dbe_->book2D("SumHT_plus_minus",
+  h_LumiPlot_SumHT_HFPlus_vs_HFMinus = ib.book2D("SumHT_plus_minus",
 						    "HF+ Sum HT vs HF- Sum HT",60,0,30,60,0,30);
-  h_LumiPlot_SumEnergy_HFPlus_vs_HFMinus = dbe_->book2D("SumEnergy_plus_minus",
+  h_LumiPlot_SumEnergy_HFPlus_vs_HFMinus = ib.book2D("SumEnergy_plus_minus",
 							"HF+ Sum Energy  vs HF- Sum Energy",
 							60,0,150,60,0,150);
-  h_LumiPlot_timeHFPlus_vs_timeHFMinus = dbe_->book2D("timeHFplus_vs_timeHFminus",
+  h_LumiPlot_timeHFPlus_vs_timeHFMinus = ib.book2D("timeHFplus_vs_timeHFminus",
 						      "Energy-weighted time average of HF+ vs HF-",
 						      60,-60,60,60,-60,60);
-  h_LumiPlot_BX_MinBiasEvents = dbe_->book1D("BX_MinBias_Events_TimeCut",
+  h_LumiPlot_BX_MinBiasEvents = ib.book1D("BX_MinBias_Events_TimeCut",
 					  "BX # of MinBias events (HFM & HFP HT>1 & HFM-HFP time cut)",
 					  3600,0,3600);
-  h_LumiPlot_BX_MinBiasEvents_notimecut = dbe_->book1D("BX_MinBias_Events_notimecut",
+  h_LumiPlot_BX_MinBiasEvents_notimecut = ib.book1D("BX_MinBias_Events_notimecut",
 						       "BX # of MinBias events (HFM,HFP HT>1, no time cut)",
 						       3600,0,3600);
   // threshold plots must pass MinBias Trigger
-  SetupEtaPhiHists(OccupancyThreshByDepth,"Above Threshold RecHit Occupancy","");
-  h_rechitieta_thresh = dbe_->book1D("HcalRecHitIeta_thresh",
+  SetupEtaPhiHists(ib,OccupancyThreshByDepth,"Above Threshold RecHit Occupancy","");
+  h_rechitieta_thresh = ib.book1D("HcalRecHitIeta_thresh",
 			      "Hcal RecHit ieta above energy and ET threshold",
 			      83,-41.5,41.5);
-  h_rechitiphi_thresh = dbe_->book1D("HcalRecHitIphi_thresh",
+  h_rechitiphi_thresh = ib.book1D("HcalRecHitIphi_thresh",
 			      "Hcal RecHit iphi above energy and ET threshold",
 			      72,0.5,72.5);
 
-  dbe_->setCurrentFolder(subdir_+"Distributions_PassedMinBias/sumplots");
-  SetupEtaPhiHists(SumEnergyThreshByDepth,"Above Threshold RecHit Summed Energy","GeV");
-  SetupEtaPhiHists(SumTimeThreshByDepth,"Above Threshold RecHit Summed Time","nS");
-  SetupEtaPhiHists(SqrtSumEnergy2ThreshByDepth,"Above Threshold RecHit Sqrt Summed Energy2","GeV");
+  ib.setCurrentFolder(subdir_+"Distributions_PassedMinBias/sumplots");
+  SetupEtaPhiHists(ib,SumEnergyThreshByDepth,"Above Threshold RecHit Summed Energy","GeV");
+  SetupEtaPhiHists(ib,SumTimeThreshByDepth,"Above Threshold RecHit Summed Time","nS");
+  SetupEtaPhiHists(ib,SqrtSumEnergy2ThreshByDepth,"Above Threshold RecHit Sqrt Summed Energy2","GeV");
 
-  dbe_->setCurrentFolder(subdir_+"Distributions_PassedMinBias/rechit_1D_plots");
-  h_HBThreshTime=dbe_->book1D("HB_time_thresh", 
+  ib.setCurrentFolder(subdir_+"Distributions_PassedMinBias/rechit_1D_plots");
+  h_HBThreshTime=ib.book1D("HB_time_thresh", 
 			      "HB RecHit Time Above Threshold",
 			      int(RECHITMON_TIME_MAX-RECHITMON_TIME_MIN),RECHITMON_TIME_MIN,RECHITMON_TIME_MAX);
-  h_HBThreshOccupancy=dbe_->book1D("HB_occupancy_thresh",
+  h_HBThreshOccupancy=ib.book1D("HB_occupancy_thresh",
 				   "HB RecHit Occupancy Above Threshold",260,-0.5,2599.5);
-  h_HEThreshTime=dbe_->book1D("HE_time_thresh", 
+  h_HEThreshTime=ib.book1D("HE_time_thresh", 
 			      "HE RecHit Time Above Threshold",
 			      int(RECHITMON_TIME_MAX-RECHITMON_TIME_MIN),RECHITMON_TIME_MIN,RECHITMON_TIME_MAX);
-  h_HEThreshOccupancy=dbe_->book1D("HE_occupancy_thresh",
+  h_HEThreshOccupancy=ib.book1D("HE_occupancy_thresh",
 				   "HE RecHit Occupancy Above Threshold",260,-0.5,2599.5);
-  h_HOThreshTime=dbe_->book1D("HO_time_thresh", 
+  h_HOThreshTime=ib.book1D("HO_time_thresh", 
 			      "HO RecHit Time Above Threshold",
 			      int(RECHITMON_TIME_MAX-RECHITMON_TIME_MIN),RECHITMON_TIME_MIN,RECHITMON_TIME_MAX);
-  h_HOThreshOccupancy=dbe_->book1D("HO_occupancy_thresh",
+  h_HOThreshOccupancy=ib.book1D("HO_occupancy_thresh",
 				   "HO RecHit Occupancy Above Threshold",217,-0.5,2169.5);
-  h_HFThreshTime=dbe_->book1D("HF_time_thresh", 
+  h_HFThreshTime=ib.book1D("HF_time_thresh", 
 			      "HF RecHit Time Above Threshold",
 			      int(RECHITMON_TIME_MAX-RECHITMON_TIME_MIN),RECHITMON_TIME_MIN,RECHITMON_TIME_MAX);
-  h_HFThreshOccupancy=dbe_->book1D("HF_occupancy_thresh",
+  h_HFThreshOccupancy=ib.book1D("HF_occupancy_thresh",
 				   "HF RecHit Occupancy Above Threshold",
 				   173,-0.5,1729.5);
 
   // Histograms for events that did passed Hcal-specfied HLT triggers
-  dbe_->setCurrentFolder(subdir_+"Distributions_PassedHcalHLTriggers");
+  ib.setCurrentFolder(subdir_+"Distributions_PassedHcalHLTriggers");
   
-  h_LumiPlot_BX_HcalHLTEvents = dbe_->book1D("BX_HcalHLT_Events_TimeCut",
+  h_LumiPlot_BX_HcalHLTEvents = ib.book1D("BX_HcalHLT_Events_TimeCut",
 					  "BX # of HcalHLT events (HFM & HFP HT>1 & HFM-HFP time cut)",
 					  3600,0,3600);
-  h_LumiPlot_BX_HcalHLTEvents_notimecut = dbe_->book1D("BX_HcalHLT_Events_notimecut",
+  h_LumiPlot_BX_HcalHLTEvents_notimecut = ib.book1D("BX_HcalHLT_Events_notimecut",
 						       "BX # of HcalHLT events (HFM,HFP HT>1, no time cut)",
 						       3600,0,3600);
-  h_LumiPlot_LS_HcalHLTEvents=dbe_->book1D("HcalHLTEventsPerLS",
+  h_LumiPlot_LS_HcalHLTEvents=ib.book1D("HcalHLTEventsPerLS",
 					   "Number of HcalHLT Events vs LS (HT cut and HFM-HFP time cut)",
 					   NLumiBlocks_/10,0.5,NLumiBlocks_+0.5); 
-  h_LumiPlot_LS_HcalHLTEvents_notimecut=dbe_->book1D("HcalHLTEventsPerLS_notimecut",
+  h_LumiPlot_LS_HcalHLTEvents_notimecut=ib.book1D("HcalHLTEventsPerLS_notimecut",
 						     "Number of Events with HcalHLT vs LS (HFM,HFP HT>1,no time cut)",
 						     NLumiBlocks_/10,0.5,NLumiBlocks_+0.5); 
   
 
-  dbe_->setCurrentFolder(subdir_+"Distributions_PassedHcalHLTriggers/");
-  h_HF_HcalHLT_weightedtimedifference = dbe_->book1D("HF_HcalHLT_weightedtimeDifference",
+  ib.setCurrentFolder(subdir_+"Distributions_PassedHcalHLTriggers/");
+  h_HF_HcalHLT_weightedtimedifference = ib.book1D("HF_HcalHLT_weightedtimeDifference",
 					     "Energy-Weighted time difference between HF+ and HF- Hcal HLT",
 					     251,-250.5,250.5);
-  h_HE_HcalHLT_weightedtimedifference = dbe_->book1D("HE_HcalHLT_weightedtimeDifference",
+  h_HE_HcalHLT_weightedtimedifference = ib.book1D("HE_HcalHLT_weightedtimeDifference",
 					     "Energy-Weighted time difference between HE+ and HE- Hcal HLT",
 					     251,-250.5,250.5);
-  h_HF_HcalHLT_energydifference = dbe_->book1D("HF_HcalHLT_energyDifference",
+  h_HF_HcalHLT_energydifference = ib.book1D("HF_HcalHLT_energyDifference",
 					     "Sum(E_HFPlus - E_HFMinus)/Sum(E_HFPlus + E_HFMinus)",
 					     200,-1,1);
-  h_HE_HcalHLT_energydifference = dbe_->book1D("HE_HcalHLT_energyDifference",
+  h_HE_HcalHLT_energydifference = ib.book1D("HE_HcalHLT_energyDifference",
 					     "Sum(E_HEPlus - E_HEMinus)/Sum(E_HEPlus + E_HEMinus)",
 					     200,-1,1);
 
   // Do we want separate directories for Minbias, other flags at some point?
-  dbe_->setCurrentFolder(subdir_+"AnomalousCellFlags");// HB Flag Histograms
+  ib.setCurrentFolder(subdir_+"AnomalousCellFlags");// HB Flag Histograms
 
 
-  h_HFLongShort_vs_LS=dbe_->book1D("HFLongShort_vs_LS",
+  h_HFLongShort_vs_LS=ib.book1D("HFLongShort_vs_LS",
 				   "HFLongShort Flags vs Lumi Section",
 				   NLumiBlocks_/10,0.5,0.5+NLumiBlocks_);
-  h_HFDigiTime_vs_LS=dbe_->book1D("HFDigiTime_vs_LS",
+  h_HFDigiTime_vs_LS=ib.book1D("HFDigiTime_vs_LS",
 				  "HFDigiTime Flags vs Lumi Section",
 				  NLumiBlocks_/10,0.5,0.5+NLumiBlocks_);
-  h_HBHEHPDMult_vs_LS=dbe_->book1D("HBHEHPDMult_vs_LS",
+  h_HBHEHPDMult_vs_LS=ib.book1D("HBHEHPDMult_vs_LS",
 				   "HBHEHPDMult Flags vs Lumi Section",
 				   NLumiBlocks_/10,0.5,0.5+NLumiBlocks_);
-  h_HBHEPulseShape_vs_LS=dbe_->book1D("HBHEPulseShape_vs_LS",
+  h_HBHEPulseShape_vs_LS=ib.book1D("HBHEPulseShape_vs_LS",
 				      "HBHEPulseShape Flags vs Lumi Section",
 				      NLumiBlocks_/10,0.5,0.5+NLumiBlocks_);
 
-  h_HF_FlagCorr=dbe_->book2D("HF_FlagCorrelation",
+  h_HF_FlagCorr=ib.book2D("HF_FlagCorrelation",
 			     "HF LongShort vs. DigiTime flags; DigiTime; LongShort", 
 			     2,-0.5,1.5,2,-0.5,1.5);
   h_HF_FlagCorr->setBinLabel(1,"OFF",1);
@@ -340,7 +340,7 @@ void HcalRecHitMonitor::setup()
   h_HF_FlagCorr->setBinLabel(1,"OFF",2);
   h_HF_FlagCorr->setBinLabel(2,"ON",2);
 
-  h_HBHE_FlagCorr=dbe_->book2D("HBHE_FlagCorrelation",
+  h_HBHE_FlagCorr=ib.book2D("HBHE_FlagCorrelation",
 			       "HBHE HpdHitMultiplicity vs. PulseShape flags; PulseShape; HpdHitMultiplicity", 
 			       2,-0.5,1.5,2,-0.5,1.5);
   h_HBHE_FlagCorr->setBinLabel(1,"OFF",1);
@@ -348,30 +348,30 @@ void HcalRecHitMonitor::setup()
   h_HBHE_FlagCorr->setBinLabel(1,"OFF",2);
   h_HBHE_FlagCorr->setBinLabel(2,"ON",2);
 
-  h_FlagMap_HPDMULT=dbe_->book2D("FlagMap_HPDMULT",
+  h_FlagMap_HPDMULT=ib.book2D("FlagMap_HPDMULT",
 				 "RBX Map of HBHEHpdHitMultiplicity Flags;RBX;RM",
 				  72,-0.5,71.5,4,0.5,4.5);
-  h_FlagMap_PULSESHAPE=dbe_->book2D("FlagMap_PULSESHAPE",
+  h_FlagMap_PULSESHAPE=ib.book2D("FlagMap_PULSESHAPE",
 				    "RBX Map of HBHEPulseShape Flags;RBX;RM",
 				  72,-0.5,71.5,4,0.5,4.5);
-  h_FlagMap_DIGITIME=dbe_->book2D("FlagMap_DIGITIME",
+  h_FlagMap_DIGITIME=ib.book2D("FlagMap_DIGITIME",
 				  "RBX Map of HFDigiTime Flags;RBX;RM",
 				  24,131.5,155.5,4,0.5,4.5);
-  h_FlagMap_LONGSHORT=dbe_->book2D("FlagMap_LONGSHORT",
+  h_FlagMap_LONGSHORT=ib.book2D("FlagMap_LONGSHORT",
 				   "RBX Map of HFLongShort Flags;RBX;RM",
 				   24,131.5,155.5,4,0.5,4.5);
 
-  h_FlagMap_TIMEADD=dbe_->book2D("FlagMap_TIMEADD",
+  h_FlagMap_TIMEADD=ib.book2D("FlagMap_TIMEADD",
 				 "RBX Map of Timing Added Flags;RBX;RM",
 				   156,-0.5,155.5,4,0.5,4.5);
-  h_FlagMap_TIMESUBTRACT=dbe_->book2D("FlagMap_TIMESUBTRACT",
+  h_FlagMap_TIMESUBTRACT=ib.book2D("FlagMap_TIMESUBTRACT",
 				      "RBX Map of Timing Subtracted Flags;RBX;RM",
 				   156,-0.5,155.5,4,0.5,4.5);
-  h_FlagMap_TIMEERROR=dbe_->book2D("FlagMap_TIMEERROR",
+  h_FlagMap_TIMEERROR=ib.book2D("FlagMap_TIMEERROR",
 				   "RBX Map of Timing Error Flags;RBX;RM",
 				   156,-0.5,155.5,4,0.5,4.5);
 
-  h_HBflagcounter=dbe_->book1D("HBflags","HB flags",32,-0.5,31.5);
+  h_HBflagcounter=ib.book1D("HBflags","HB flags",32,-0.5,31.5);
   h_HBflagcounter->setBinLabel(1+HcalCaloFlagLabels::HBHEHpdHitMultiplicity, "HpdHitMult",1);
   h_HBflagcounter->setBinLabel(1+HcalCaloFlagLabels::HBHEPulseShape, "PulseShape",1);
   h_HBflagcounter->setBinLabel(1+HcalCaloFlagLabels::HSCP_R1R2, "HSCP R1R2",1);
@@ -394,7 +394,7 @@ void HcalRecHitMonitor::setup()
   h_HBflagcounter->setBinLabel(1+HcalCaloFlagLabels::Fraction2TS,"Frac2TS",1);
 
   // HE Flag Histograms
-  h_HEflagcounter=dbe_->book1D("HEflags","HE flags",32,-0.5,31.5);
+  h_HEflagcounter=ib.book1D("HEflags","HE flags",32,-0.5,31.5);
   h_HEflagcounter->setBinLabel(1+HcalCaloFlagLabels::HBHEHpdHitMultiplicity, "HpdHitMult",1);
   h_HEflagcounter->setBinLabel(1+HcalCaloFlagLabels::HBHEPulseShape, "PulseShape",1);
   h_HEflagcounter->setBinLabel(1+HcalCaloFlagLabels::HSCP_R1R2, "HSCP R1R2",1);
@@ -415,7 +415,7 @@ void HcalRecHitMonitor::setup()
   h_HEflagcounter->setBinLabel(1+HcalCaloFlagLabels::Fraction2TS,"Frac2TS",1);
 
   // HO Flag Histograms
-  h_HOflagcounter=dbe_->book1D("HOflags","HO flags",32,-0.5,31.5);
+  h_HOflagcounter=ib.book1D("HOflags","HO flags",32,-0.5,31.5);
   h_HOflagcounter->setBinLabel(1+HcalCaloFlagLabels::TimingSubtractedBit, "Subtracted",1);
   h_HOflagcounter->setBinLabel(1+HcalCaloFlagLabels::TimingAddedBit, "Added",1);
   h_HOflagcounter->setBinLabel(1+HcalCaloFlagLabels::TimingErrorBit, "TimingError",1);
@@ -423,7 +423,7 @@ void HcalRecHitMonitor::setup()
   h_HOflagcounter->setBinLabel(1+HcalCaloFlagLabels::Fraction2TS,"Frac2TS",1);
 
   // HF Flag Histograms
-  h_HFflagcounter=dbe_->book1D("HFflags","HF flags",32,-0.5,31.5);
+  h_HFflagcounter=ib.book1D("HFflags","HF flags",32,-0.5,31.5);
   h_HFflagcounter->setBinLabel(1+HcalCaloFlagLabels::HFLongShort, "LongShort",1);
   h_HFflagcounter->setBinLabel(1+HcalCaloFlagLabels::HFDigiTime, "DigiTime",1);
   h_HFflagcounter->setBinLabel(1+HcalCaloFlagLabels::HFTimingTrustBits,"TimingTrust1",1);
@@ -441,91 +441,91 @@ void HcalRecHitMonitor::setup()
 
   // Diagnostic plots are currently filled for all rechits (no trigger/threshold requirement)
   // hb
-  dbe_->setCurrentFolder(subdir_+"diagnostics/hb");
+  ib.setCurrentFolder(subdir_+"diagnostics/hb");
   
-  h_HBTimeVsEnergy=dbe_->book2D("HBTimeVsEnergy","HB Time Vs Energy (All RecHits);Energy (GeV); time(nS)",100,0,500,40,-100,100);
+  h_HBTimeVsEnergy=ib.book2D("HBTimeVsEnergy","HB Time Vs Energy (All RecHits);Energy (GeV); time(nS)",100,0,500,40,-100,100);
 
-  h_HBsizeVsLS=dbe_->bookProfile("HBRecHitsVsLB","HB RecHits vs Luminosity Block",
+  h_HBsizeVsLS=ib.bookProfile("HBRecHitsVsLB","HB RecHits vs Luminosity Block",
 				 NLumiBlocks_,0.5,NLumiBlocks_+0.5,
 				 100,0,10000);
 
-  h_HBTime=dbe_->book1D("HB_time","HB RecHit Time",
+  h_HBTime=ib.book1D("HB_time","HB RecHit Time",
 			int(RECHITMON_TIME_MAX-RECHITMON_TIME_MIN),RECHITMON_TIME_MIN,RECHITMON_TIME_MAX);
-  h_HBOccupancy=dbe_->book1D("HB_occupancy",
+  h_HBOccupancy=ib.book1D("HB_occupancy",
 			     "HB RecHit Occupancy",260,-0.5,2599.5);
   
   //he
-  dbe_->setCurrentFolder(subdir_+"diagnostics/he");
+  ib.setCurrentFolder(subdir_+"diagnostics/he");
 
-  h_HETimeVsEnergy=dbe_->book2D("HETimeVsEnergy","HE Time Vs Energy (All RecHits);Energy (GeV); time(nS)",100,0,500,40,-100,100);
+  h_HETimeVsEnergy=ib.book2D("HETimeVsEnergy","HE Time Vs Energy (All RecHits);Energy (GeV); time(nS)",100,0,500,40,-100,100);
 
-  h_HEsizeVsLS=dbe_->bookProfile("HERecHitsVsLB","HE RecHits vs Luminosity Block",
+  h_HEsizeVsLS=ib.bookProfile("HERecHitsVsLB","HE RecHits vs Luminosity Block",
 				 NLumiBlocks_,0.5,NLumiBlocks_+0.5,
 				 100,0,10000);
 	
-  h_HETime=dbe_->book1D("HE_time","HE RecHit Time",
+  h_HETime=ib.book1D("HE_time","HE RecHit Time",
 			int(RECHITMON_TIME_MAX-RECHITMON_TIME_MIN),RECHITMON_TIME_MIN,RECHITMON_TIME_MAX);
-  h_HEOccupancy=dbe_->book1D("HE_occupancy","HE RecHit Occupancy",260,-0.5,2599.5);
+  h_HEOccupancy=ib.book1D("HE_occupancy","HE RecHit Occupancy",260,-0.5,2599.5);
    
   // ho
-  dbe_->setCurrentFolder(subdir_+"diagnostics/ho");	
+  ib.setCurrentFolder(subdir_+"diagnostics/ho");	
 
-  h_HOTimeVsEnergy=dbe_->book2D("HOTimeVsEnergy","HO Time Vs Energy (All RecHits);Energy (GeV); time(nS)",100,0,500,40,-100,100);
+  h_HOTimeVsEnergy=ib.book2D("HOTimeVsEnergy","HO Time Vs Energy (All RecHits);Energy (GeV); time(nS)",100,0,500,40,-100,100);
 
-  h_HOsizeVsLS=dbe_->bookProfile("HORecHitsVsLB","HO RecHits vs Luminosity Block",
+  h_HOsizeVsLS=ib.bookProfile("HORecHitsVsLB","HO RecHits vs Luminosity Block",
 				 NLumiBlocks_,0.5,NLumiBlocks_+0.5,
 				 100,0,10000);
-  h_HOTime=dbe_->book1D("HO_time",
+  h_HOTime=ib.book1D("HO_time",
 			"HO RecHit Time",
 			int(RECHITMON_TIME_MAX-RECHITMON_TIME_MIN),RECHITMON_TIME_MIN,RECHITMON_TIME_MAX);
-  h_HOOccupancy=dbe_->book1D("HO_occupancy",
+  h_HOOccupancy=ib.book1D("HO_occupancy",
 			     "HO RecHit Occupancy",217,-0.5,2169.5);
   
   // hf
-  dbe_->setCurrentFolder(subdir_+"diagnostics/hf");
+  ib.setCurrentFolder(subdir_+"diagnostics/hf");
 
-  h_HFTimeVsEnergy=dbe_->book2D("HFTimeVsEnergy","HF Time Vs Energy (All RecHits);Energy (GeV); time(nS)",100,0,500,40,-100,100);
+  h_HFTimeVsEnergy=ib.book2D("HFTimeVsEnergy","HF Time Vs Energy (All RecHits);Energy (GeV); time(nS)",100,0,500,40,-100,100);
 
-  h_HFsizeVsLS=dbe_->bookProfile("HFRecHitsVsLB",
+  h_HFsizeVsLS=ib.bookProfile("HFRecHitsVsLB",
 				 "HF RecHits vs Luminosity Block",
 				 NLumiBlocks_,0.5,NLumiBlocks_+0.5,
 				 100, 0,10000);	
-  h_HFTime=dbe_->book1D("HF_time","HF RecHit Time",
+  h_HFTime=ib.book1D("HF_time","HF RecHit Time",
 			int(RECHITMON_TIME_MAX-RECHITMON_TIME_MIN),RECHITMON_TIME_MIN,RECHITMON_TIME_MAX);
-  h_HFOccupancy=dbe_->book1D("HF_occupancy","HF RecHit Occupancy",173,-0.5,1729.5);
+  h_HFOccupancy=ib.book1D("HF_occupancy","HF RecHit Occupancy",173,-0.5,1729.5);
 
   return;
 } //void HcalRecHitMonitor::setup(...)
 
-void HcalRecHitMonitor::beginRun(const edm::Run& run, const edm::EventSetup& c)
+void HcalRecHitMonitor::bookHistograms(DQMStore::IBooker &ib, const edm::Run& run, const edm::EventSetup& c)
 {
 
-  if (debug_>0) std::cout <<"HcalRecHitMonitor::beginRun():  task =  '"<<subdir_<<"'"<<std::endl;
-  HcalBaseDQMonitor::beginRun(run, c);
+  if (debug_>0) std::cout <<"HcalRecHitMonitor::bookHistograms():  task =  '"<<subdir_<<"'"<<std::endl;
+  HcalBaseDQMonitor::bookHistograms(ib,run, c);
   if (tevt_==0) // create histograms, if they haven't been created already
-    this->setup();
+    this->setup(ib);
   // Clear histograms at the start of each run if not merging runs
   if (mergeRuns_==false)
     this->reset();
 
   if (tevt_!=0) return;
   // create histograms displaying trigger parameters?  Specify names?
-  dbe_->setCurrentFolder(subdir_+"rechit_parameters");
+  ib.setCurrentFolder(subdir_+"rechit_parameters");
   std::string tnames="";
   if (HcalHLTBits_.size()>0)
     tnames=HcalHLTBits_[0];
   for (unsigned int i=1;i<HcalHLTBits_.size();++i)
     tnames=tnames + " OR " + HcalHLTBits_[i];
-  dbe_->bookString("HcalHLTriggerRequirements",tnames);
+  ib.bookString("HcalHLTriggerRequirements",tnames);
   tnames="";
   if (MinBiasHLTBits_.size()>0)
     tnames=MinBiasHLTBits_[0];
   for (unsigned int i=1;i<MinBiasHLTBits_.size();++i)
     tnames=tnames + " OR " + MinBiasHLTBits_[i];
-  dbe_->bookString("MinBiasHLTriggerRequirements",tnames);
+  ib.bookString("MinBiasHLTriggerRequirements",tnames);
   return;
   
-} //void HcalRecHitMonitor::beginRun(...)
+} //void HcalRecHitMonitor::bookHistograms(...)
 
 
 void HcalRecHitMonitor::endRun(const edm::Run& run, const edm::EventSetup& c)
@@ -540,14 +540,123 @@ void HcalRecHitMonitor::endRun(const edm::Run& run, const edm::EventSetup& c)
 
 void HcalRecHitMonitor::reset()
 {
-  std::vector<MonitorElement*> hists = dbe_->getAllContents(subdir_);
+   // REIMPLEMENT FUNCTIONALITY WITHOUT USING GETTER
+  /*std::vector<MonitorElement*> hists = dbe_->getAllContents(subdir_);
   for (unsigned int i=0;i<hists.size();++i)
     {
       if (hists[i]->kind()==MonitorElement::DQM_KIND_TH1F ||
 	  hists[i]->kind()==MonitorElement::DQM_KIND_TH2F ||
 	  hists[i]->kind()==MonitorElement::DQM_KIND_TPROFILE)
 	hists[i]->Reset();
-    }
+    }*/
+
+   h_rechitieta->Reset();
+   h_rechitiphi->Reset();
+
+   h_rechitieta_05->Reset();
+   h_rechitieta_10->Reset();
+   h_rechitieta_25->Reset();
+   h_rechitieta_100->Reset();
+   h_rechitiphi_05->Reset();
+   h_rechitiphi_10->Reset();
+   h_rechitiphi_25->Reset();
+   h_rechitiphi_100->Reset();
+
+   h_rechitieta_thresh->Reset();
+   h_rechitiphi_thresh->Reset();
+
+   h_HBsizeVsLS->Reset();
+   h_HEsizeVsLS->Reset();
+   h_HOsizeVsLS->Reset();
+   h_HFsizeVsLS->Reset();
+
+   h_HBTime->Reset();
+   h_HBThreshTime->Reset();
+   h_HBOccupancy->Reset();
+   h_HBThreshOccupancy->Reset();
+
+   h_HETime->Reset();
+   h_HEThreshTime->Reset();
+   h_HEOccupancy->Reset();
+   h_HEThreshOccupancy->Reset();
+
+   h_HOTime->Reset();
+   h_HOThreshTime->Reset();
+   h_HOOccupancy->Reset();
+   h_HOThreshOccupancy->Reset();
+
+   h_HFTime->Reset();
+   h_HFThreshTime->Reset();
+   h_HFOccupancy->Reset();
+   h_HFThreshOccupancy->Reset();
+
+   h_HBflagcounter->Reset();
+   h_HEflagcounter->Reset();
+   h_HOflagcounter->Reset();
+   h_HFflagcounter->Reset();
+  
+   h_FlagMap_HPDMULT->Reset();
+   h_FlagMap_PULSESHAPE->Reset();
+   h_FlagMap_DIGITIME->Reset();
+   h_FlagMap_LONGSHORT->Reset();
+   h_FlagMap_TIMEADD->Reset();
+   h_FlagMap_TIMESUBTRACT->Reset();
+   h_FlagMap_TIMEERROR->Reset();
+                 
+   h_HFLongShort_vs_LS->Reset();
+   h_HFDigiTime_vs_LS->Reset();
+   h_HBHEHPDMult_vs_LS->Reset();
+   h_HBHEPulseShape_vs_LS->Reset();
+
+   h_HF_FlagCorr->Reset();
+   h_HBHE_FlagCorr->Reset();
+
+   h_HFtimedifference->Reset();
+   h_HFenergydifference->Reset();
+   h_HEtimedifference->Reset();
+   h_HEenergydifference->Reset();
+
+   h_HF_HcalHLT_weightedtimedifference->Reset();
+   h_HF_HcalHLT_energydifference->Reset();
+   h_HE_HcalHLT_weightedtimedifference->Reset();
+   h_HE_HcalHLT_energydifference->Reset();
+
+   h_LumiPlot_LS_allevents->Reset();
+   h_LumiPlot_LS_MinBiasEvents->Reset();
+   h_LumiPlot_LS_MinBiasEvents_notimecut->Reset();
+   h_LumiPlot_LS_HcalHLTEvents->Reset();
+   h_LumiPlot_LS_HcalHLTEvents_notimecut->Reset();
+
+   h_LumiPlot_SumHT_HFPlus_vs_HFMinus->Reset();
+   h_LumiPlot_timeHFPlus_vs_timeHFMinus->Reset();
+
+   h_LumiPlot_SumEnergy_HFPlus_vs_HFMinus->Reset();
+  
+   h_LumiPlot_BX_allevents->Reset();
+   h_LumiPlot_BX_MinBiasEvents->Reset();
+   h_LumiPlot_BX_MinBiasEvents_notimecut->Reset();
+   h_LumiPlot_BX_HcalHLTEvents->Reset();
+   h_LumiPlot_BX_HcalHLTEvents_notimecut->Reset();
+
+   h_LumiPlot_MinTime_vs_MinHT->Reset();
+   h_LumiPlot_timeHT_HFM->Reset();
+   h_LumiPlot_timeHT_HFP->Reset();
+
+   h_TriggeredEvents->Reset();
+   h_HFP_weightedTime->Reset();
+   h_HFM_weightedTime->Reset();
+   h_HEP_weightedTime->Reset();
+   h_HEM_weightedTime->Reset();
+   h_HBP_weightedTime->Reset();
+   h_HBM_weightedTime->Reset();
+
+   h_HBTimeVsEnergy->Reset();
+   h_HETimeVsEnergy->Reset();
+   h_HOTimeVsEnergy->Reset();
+   h_HFTimeVsEnergy->Reset();
+   HFP_HFM_Energy->Reset();
+
+
 }  
 
 void HcalRecHitMonitor::endJob()
@@ -560,7 +669,7 @@ void HcalRecHitMonitor::endJob()
 
 /* --------------------------------- */
 
-void HcalRecHitMonitor::cleanup()
+/*void HcalRecHitMonitor::cleanup()
 {
   //Add code to clean out subdirectories
   if (!enableCleanup_) return;
@@ -583,7 +692,7 @@ void HcalRecHitMonitor::cleanup()
       dbe_->setCurrentFolder(subdir_+"diagnostics/hf"); dbe_->removeContents();
     }
   return;
-} // void HcalRecHitMonitor::cleanup()
+} */ // void HcalRecHitMonitor::cleanup()
 
 /* -------------------------------- */
 

--- a/DQM/HcalMonitorTasks/src/HcalTrigPrimMonitor.cc
+++ b/DQM/HcalMonitorTasks/src/HcalTrigPrimMonitor.cc
@@ -39,18 +39,15 @@ HcalTrigPrimMonitor::reset () {
 
 
 void
-HcalTrigPrimMonitor::setup() {
-   HcalBaseDQMonitor::setup();
+HcalTrigPrimMonitor::setup(DQMStore::IBooker &ib) {
+   HcalBaseDQMonitor::setup(ib);
    
-   if (dbe_ == 0)
-      return;
-
-   dbe_->setCurrentFolder(subdir_ + "TP Occupancy");
-   TPOccupancyEta_ = dbe_->book1D("TPOccupancyVsEta", "TPOccupancyVsEta", 65, -32.5, 32.5);
-   TPOccupancyPhi_ = dbe_->book1D("TPOccupancyVsPhi", "TPOccupancyVsPhi", 72, 0.5, 72.5);
-   TPOccupancyPhiHFP_ = dbe_->book1D("TPOccupancyHFPVsPhi", "TPOccupancyHFPVsPhi", 72, 0.5, 72.5);
-   TPOccupancyPhiHFM_ = dbe_->book1D("TPOccupancyHFMVsPhi", "TPOccupancyHFMVsPhi", 72, 0.5, 72.5);
-   TPOccupancy_ = create_map(subdir_ + "TP Occupancy", "TPOccupancy");
+   ib.setCurrentFolder(subdir_ + "TP Occupancy");
+   TPOccupancyEta_ = ib.book1D("TPOccupancyVsEta", "TPOccupancyVsEta", 65, -32.5, 32.5);
+   TPOccupancyPhi_ = ib.book1D("TPOccupancyVsPhi", "TPOccupancyVsPhi", 72, 0.5, 72.5);
+   TPOccupancyPhiHFP_ = ib.book1D("TPOccupancyHFPVsPhi", "TPOccupancyHFPVsPhi", 72, 0.5, 72.5);
+   TPOccupancyPhiHFM_ = ib.book1D("TPOccupancyHFMVsPhi", "TPOccupancyHFMVsPhi", 72, 0.5, 72.5);
+   TPOccupancy_ = create_map(ib, subdir_ + "TP Occupancy", "TPOccupancy");
 
    for (int isZS = 0; isZS <= 1; ++isZS) {
 
@@ -65,28 +62,28 @@ HcalTrigPrimMonitor::setup() {
       std::string problem_folder(folder);
       problem_folder += "Problem TPs/";
       
-      good_tps[isZS] = create_map(folder, "Good TPs"+zsname);
-      bad_tps[isZS] = create_map(folder, "Bad TPs"+zsname);
+      good_tps[isZS] = create_map(ib,folder, "Good TPs"+zsname);
+      bad_tps[isZS] = create_map(ib,folder, "Bad TPs"+zsname);
 
-      errorflag[isZS] = create_errorflag(folder, "Error Flag"+zsname);
-      problem_map[isZS][kMismatchedEt] = create_map(problem_folder, "Mismatched Et"+zsname);
-      problem_map[isZS][kMismatchedFG] = create_map(problem_folder, "Mismatched FG"+zsname);
-      problem_map[isZS][kMissingData] = create_map(problem_folder, "Missing Data"+zsname);
-      problem_map[isZS][kMissingEmul] = create_map(problem_folder, "Missing Emul"+zsname);
+      errorflag[isZS] = create_errorflag(ib,folder, "Error Flag"+zsname);
+      problem_map[isZS][kMismatchedEt] = create_map(ib,problem_folder, "Mismatched Et"+zsname);
+      problem_map[isZS][kMismatchedFG] = create_map(ib,problem_folder, "Mismatched FG"+zsname);
+      problem_map[isZS][kMissingData] = create_map(ib,problem_folder, "Missing Data"+zsname);
+      problem_map[isZS][kMissingEmul] = create_map(ib,problem_folder, "Missing Emul"+zsname);
 
       for (int isHF = 0; isHF <= 1; ++isHF) {
          std::string subdet = (isHF == 0 ? "HBHE " : "HF ");
-         tp_corr[isZS][isHF] = create_tp_correlation(folder, subdet + "TP Correlation"+zsname);
-         fg_corr[isZS][isHF] = create_fg_correlation(folder, subdet + "FG Correlation"+zsname);
+         tp_corr[isZS][isHF] = create_tp_correlation(ib,folder, subdet + "TP Correlation"+zsname);
+         fg_corr[isZS][isHF] = create_fg_correlation(ib,folder, subdet + "FG Correlation"+zsname);
 
          problem_et[isZS][isHF][kMismatchedFG]
-            = create_et_histogram(problem_folder + "TP Values/", subdet + "Mismatched FG"+zsname);
+            = create_et_histogram(ib,problem_folder + "TP Values/", subdet + "Mismatched FG"+zsname);
 
          problem_et[isZS][isHF][kMissingData]
-            = create_et_histogram(problem_folder + "TP Values/", subdet + "Missing Data"+zsname);
+            = create_et_histogram(ib,problem_folder + "TP Values/", subdet + "Missing Data"+zsname);
 
          problem_et[isZS][isHF][kMissingEmul]
-            = create_et_histogram(problem_folder + "TP Values/", subdet + "Missing Emul"+zsname);
+            = create_et_histogram(ib,problem_folder + "TP Values/", subdet + "Missing Emul"+zsname);
       }//isHF
    }//isZS
 
@@ -104,54 +101,54 @@ HcalTrigPrimMonitor::setup() {
       std::string problem_folder(folder);
       problem_folder += "Problem OOT TPs/";
       
-      good_tps_oot[isZS] = create_map(folder, "Good OOT TPs"+zsname);
-      bad_tps_oot[isZS] = create_map(folder, "Bad OOT TPs"+zsname);
+      good_tps_oot[isZS] = create_map(ib,folder, "Good OOT TPs"+zsname);
+      bad_tps_oot[isZS] = create_map(ib,folder, "Bad OOT TPs"+zsname);
 
-      errorflag_oot[isZS] = create_errorflag(folder, "Error Flag OOT"+zsname);
-      problem_map_oot[isZS][kMismatchedEt] = create_map(problem_folder, "Mismatched OOT Et"+zsname);
-      problem_map_oot[isZS][kMismatchedFG] = create_map(problem_folder, "Mismatched OOT FG"+zsname);
-      problem_map_oot[isZS][kMissingData] = create_map(problem_folder, "Missing OOT Data"+zsname);
-      problem_map_oot[isZS][kMissingEmul] = create_map(problem_folder, "Missing OOT Emul"+zsname);
+      errorflag_oot[isZS] = create_errorflag(ib,folder, "Error Flag OOT"+zsname);
+      problem_map_oot[isZS][kMismatchedEt] = create_map(ib,problem_folder, "Mismatched OOT Et"+zsname);
+      problem_map_oot[isZS][kMismatchedFG] = create_map(ib,problem_folder, "Mismatched OOT FG"+zsname);
+      problem_map_oot[isZS][kMissingData] = create_map(ib,problem_folder, "Missing OOT Data"+zsname);
+      problem_map_oot[isZS][kMissingEmul] = create_map(ib,problem_folder, "Missing OOT Emul"+zsname);
 
       for (int isHF = 0; isHF <= 1; ++isHF) {
          std::string subdet = (isHF == 0 ? "HBHE " : "HF ");
-         tp_corr_oot[isZS][isHF] = create_tp_correlation(folder, subdet + "OOT TP Correlation"+zsname);
-         fg_corr_oot[isZS][isHF] = create_fg_correlation(folder, subdet + "OOT FG Correlation"+zsname);
+         tp_corr_oot[isZS][isHF] = create_tp_correlation(ib,folder, subdet + "OOT TP Correlation"+zsname);
+         fg_corr_oot[isZS][isHF] = create_fg_correlation(ib,folder, subdet + "OOT FG Correlation"+zsname);
 
          problem_et_oot[isZS][isHF][kMismatchedFG]
-            = create_et_histogram(problem_folder + "TP Values/", subdet + "OOT Mismatched FG"+zsname);
+            = create_et_histogram(ib,problem_folder + "TP Values/", subdet + "OOT Mismatched FG"+zsname);
 
          problem_et_oot[isZS][isHF][kMissingData]
-            = create_et_histogram(problem_folder + "TP Values/", subdet + "OOT Missing Data"+zsname);
+            = create_et_histogram(ib,problem_folder + "TP Values/", subdet + "OOT Missing Data"+zsname);
 
          problem_et_oot[isZS][isHF][kMissingEmul]
-            = create_et_histogram(problem_folder + "TP Values/", subdet + "OOT Missing Emul"+zsname);
+            = create_et_histogram(ib,problem_folder + "TP Values/", subdet + "OOT Missing Emul"+zsname);
       }//isHF
    }//isZS
 
    // Number of bad cells vs. luminosity block
-   ProblemsVsLB = dbe_->bookProfile(
+   ProblemsVsLB = ib.bookProfile(
          "TotalBadTPs_HCAL_vs_LS",
          "Total Number of Bad HCAL TPs vs lumi section",
          NLumiBlocks_,0.5,NLumiBlocks_+0.5,100,0,10000);
 
-   ProblemsVsLB_HB = dbe_->bookProfile(
+   ProblemsVsLB_HB = ib.bookProfile(
          "TotalBadTPs_HB_vs_LS",
          "Total Number of Bad HB TPs vs lumi section",
          NLumiBlocks_,0.5,NLumiBlocks_+0.5,100,0,3000);
 
-   ProblemsVsLB_HE = dbe_->bookProfile(
+   ProblemsVsLB_HE = ib.bookProfile(
          "TotalBadTPs_HE_vs_LS",
          "Total Number of Bad HE TPs vs lumi section",
          NLumiBlocks_,0.5,NLumiBlocks_+0.5,100,0,3000);
 
-   ProblemsVsLB_HF = dbe_->bookProfile(
+   ProblemsVsLB_HF = ib.bookProfile(
          "TotalBadTPs_HF_vs_LS",
          "Total Number of Bad HF TPs vs lumi section",
          NLumiBlocks_,0.5,NLumiBlocks_+0.5,100,0,3000);
 
    // No TPs for HO, DO NOT fill this histogram
-   ProblemsVsLB_HO = dbe_->bookProfile(
+   ProblemsVsLB_HO = ib.bookProfile(
          "TotalBadTPs_HO_vs_LS",
          "Total Number of Bad HO TPs vs lumi section",
          NLumiBlocks_,0.5,NLumiBlocks_+0.5,100,0,3000);
@@ -163,13 +160,13 @@ HcalTrigPrimMonitor::setup() {
    ProblemsVsLB_HF->getTProfile()->SetMarkerStyle(20);
 }
 
-void HcalTrigPrimMonitor::beginRun(const edm::Run& run, const edm::EventSetup& c)
+void HcalTrigPrimMonitor::bookHistograms(DQMStore::IBooker &ib, const edm::Run& run, const edm::EventSetup& c)
 {
-  HcalBaseDQMonitor::beginRun(run,c);
+  HcalBaseDQMonitor::bookHistograms(ib,run,c);
   if (mergeRuns_ && tevt_>0) return; // don't reset counters if merging runs
-  if (tevt_==0) this->setup(); // create all histograms; not necessary if merging runs together
+  if (tevt_==0) this->setup(ib); // create all histograms; not necessary if merging runs together
   if (mergeRuns_==false) this->reset(); // call reset at start of all runs
-} // void HcalTrigPrimMonitor::beginRun()
+} // void HcalTrigPrimMonitor::bookHistograms()
 
 void
 HcalTrigPrimMonitor::analyze (edm::Event const &e, edm::EventSetup const &s) {
@@ -197,9 +194,6 @@ void
 HcalTrigPrimMonitor::processEvent (
       const edm::Handle <HcalTrigPrimDigiCollection>& data_tp_col,
       const edm::Handle <HcalTrigPrimDigiCollection>& emul_tp_col) {
-
-   if(dbe_ == 0) 
-      return;
 
    std::vector<int> errorflag_per_event[2][2];
    std::vector<int> errorflag_per_event_oot[2][2];
@@ -537,7 +531,7 @@ HcalTrigPrimMonitor::processEvent (
    }//for isZS
 }
 
-void
+/*void
 HcalTrigPrimMonitor::cleanup() {
    if (!enableCleanup_) return;
    if (dbe_) {
@@ -560,7 +554,7 @@ HcalTrigPrimMonitor::cleanup() {
       dbe_->setCurrentFolder(subdir_ + "Problem OOT TPs");
       dbe_->removeContents();
    }
-}
+}*/
 
 void HcalTrigPrimMonitor::endJob()
 {
@@ -593,19 +587,19 @@ void HcalTrigPrimMonitor::endLuminosityBlock(const edm::LuminosityBlock& lumiSeg
 
 
 MonitorElement*
-HcalTrigPrimMonitor::create_summary(const std::string& folder, const std::string& name) {
+HcalTrigPrimMonitor::create_summary(DQMStore::IBooker &ib, const std::string& folder, const std::string& name) {
    edm::LogInfo("HcalTrigPrimMonitor") << "Creating MonitorElement " << name << " in folder " << folder << "\n";
 
-   dbe_->setCurrentFolder(folder);
-   return dbe_->book2D(name, name, 65, -32.5, 32.5, 72, 0.5, 72.5);
+   ib.setCurrentFolder(folder);
+   return ib.book2D(name, name, 65, -32.5, 32.5, 72, 0.5, 72.5);
 }
 
 MonitorElement*
-HcalTrigPrimMonitor::create_errorflag(const std::string& folder, const std::string& name) {
+HcalTrigPrimMonitor::create_errorflag(DQMStore::IBooker &ib, const std::string& folder, const std::string& name) {
    edm::LogInfo("HcalTrigPrimMonitor") << "Creating MonitorElement " << name << " in folder " << folder << "\n";
 
-   dbe_->setCurrentFolder(folder);
-   MonitorElement* element = dbe_->book2D(name, name, 4, 1, 5, 2, 0, 2);
+   ib.setCurrentFolder(folder);
+   MonitorElement* element = ib.book2D(name, name, 4, 1, 5, 2, 0, 2);
    element->setBinLabel(1, "Mismatched E");
    element->setBinLabel(2, "Mismatched FG");
    element->setBinLabel(3, "Missing Data");
@@ -616,42 +610,42 @@ HcalTrigPrimMonitor::create_errorflag(const std::string& folder, const std::stri
 }
 
 MonitorElement*
-HcalTrigPrimMonitor::create_tp_correlation(const std::string& folder, const std::string& name) {
+HcalTrigPrimMonitor::create_tp_correlation(DQMStore::IBooker &ib, const std::string& folder, const std::string& name) {
    edm::LogInfo("HcalTrigPrimMonitor") << "Creating MonitorElement " << name << " in folder " << folder << "\n";
 
-   dbe_->setCurrentFolder(folder);
-   MonitorElement* element = dbe_->book2D(name, name, 50, 0, 256, 50, 0, 256);
+   ib.setCurrentFolder(folder);
+   MonitorElement* element = ib.book2D(name, name, 50, 0, 256, 50, 0, 256);
    element->setAxisTitle("data TP", 1);
    element->setAxisTitle("emul TP", 2);
    return element;
 }
 
 MonitorElement*
-HcalTrigPrimMonitor::create_fg_correlation(const std::string& folder, const std::string& name) {
+HcalTrigPrimMonitor::create_fg_correlation(DQMStore::IBooker &ib, const std::string& folder, const std::string& name) {
    edm::LogInfo("HcalTrigPrimMonitor") << "Creating MonitorElement " << name << " in folder " << folder << "\n";
 
-   dbe_->setCurrentFolder(folder);
-   MonitorElement* element = dbe_->book2D(name, name, 2, 0, 2, 2, 0, 2);
+   ib.setCurrentFolder(folder);
+   MonitorElement* element = ib.book2D(name, name, 2, 0, 2, 2, 0, 2);
    element->setAxisTitle("data FG", 1);
    element->setAxisTitle("emul FG", 2);
    return element;
 }
 
 MonitorElement*
-HcalTrigPrimMonitor::create_map(const std::string& folder, const std::string& name) {
+HcalTrigPrimMonitor::create_map(DQMStore::IBooker &ib, const std::string& folder, const std::string& name) {
    edm::LogInfo("HcalTrigPrimMonitor") << "Creating MonitorElement " << name << " in folder " << folder << "\n";
 
-   dbe_->setCurrentFolder(folder);
+   ib.setCurrentFolder(folder);
    std::string title = name +";ieta;iphi";
-   return dbe_->book2D(name, title, 65, -32.5, 32.5, 72, 0.5, 72.5);
+   return ib.book2D(name, title, 65, -32.5, 32.5, 72, 0.5, 72.5);
 }
 
 MonitorElement*
-HcalTrigPrimMonitor::create_et_histogram(const std::string& folder, const std::string& name) {
+HcalTrigPrimMonitor::create_et_histogram(DQMStore::IBooker &ib, const std::string& folder, const std::string& name) {
    edm::LogInfo("HcalTrigPrimMonitor") << "Creating MonitorElement " << name << " in folder " << folder << "\n";
 
-   dbe_->setCurrentFolder(folder);
-   return dbe_->book1D(name, name, 256, 0, 256);
+   ib.setCurrentFolder(folder);
+   return ib.book1D(name, name, 256, 0, 256);
 }
 
 DEFINE_FWK_MODULE (HcalTrigPrimMonitor);

--- a/DQM/HcalMonitorTasks/src/HcalTrigPrimMonitor.cc
+++ b/DQM/HcalMonitorTasks/src/HcalTrigPrimMonitor.cc
@@ -2,6 +2,7 @@
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 
 HcalTrigPrimMonitor::HcalTrigPrimMonitor (const edm::ParameterSet& ps) :
+   HcalBaseDQMonitor(ps),
    dataLabel_(ps.getParameter<edm::InputTag>("dataLabel")),
    emulLabel_(ps.getParameter<edm::InputTag>("emulLabel")),
    ZSBadTPThreshold_(ps.getParameter< std::vector<int> >("ZSBadTPThreshold")),


### PR DESCRIPTION
This should complete the HCAL DQM migration to MT framework. This affects DQM/HcalMonitorClient and DQM/HcalMonitorTasks. The use of helper classes inheriting from a common base class made it dificult to trace for every case the functional flow of the monitors and clients. However, with the exception of the removal of endRun(void) methods in HcalBaseDQClient and its derivatives, the functionality is intended to be the same in both frameworks.
