### PR TITLE
Use typedef names

### DIFF
--- a/CondCore/ORA/src/RelationalMapping.cc
+++ b/CondCore/ORA/src/RelationalMapping.cc
@@ -436,15 +436,17 @@ void ora::ArrayMapping::process( MappingElement& parentElement,
   }
   RelationalMappingFactory mappingFactory( m_tableRegister );
   if ( keyType ) {
-    std::string keyTypeName = keyType.name();
     std::string keyTypeNameForSchema = MappingRules::variableNameForContainerKey();
     std::auto_ptr<IRelationalMapping> keyProcessor( mappingFactory.newProcessor( keyType ) );
-    keyProcessor->process( me, keyTypeName, keyTypeNameForSchema, arrayScopeNameForSchema  );
+    keyProcessor->process( me, "key_type", keyTypeNameForSchema, arrayScopeNameForSchema  );
   }
-  std::string contentTypeName = contentType.name();
   std::string contentTypeNameForSchema = MappingRules::variableNameForContainerValue();
   std::auto_ptr<IRelationalMapping> contentProcessor( mappingFactory.newProcessor( contentType ) );
-  contentProcessor->process( me, contentTypeName, contentTypeNameForSchema, arrayScopeNameForSchema );
+  if ( keyType ) {
+    contentProcessor->process( me, "mapped_type", contentTypeNameForSchema, arrayScopeNameForSchema );
+  } else {
+    contentProcessor->process( me, "value_type", contentTypeNameForSchema, arrayScopeNameForSchema );
+  }
 }
 
 ora::CArrayMapping::CArrayMapping( const edm::TypeWithDict& attributeType, TableRegister& tableRegister ):


### PR DESCRIPTION
Many unit tests in the conditions packages (CondCore/*) fail because of a problem with names of typedefs.  The conditions code uses the typedefs Container::value_type, Container::key_type,
and Container::mapped_type for a container "Container".  The conditions code expects to use the strings "key_type", "value_type" and "mapped_type" in its internal structures.  The code uses introspection to get the strings from the type.  There are two problems here.  One is that the strings will always have the same value, so it is wasteful to use introspection to obtain a string that is known in advance.  Second, is that in ROOT6, if the underlying type of the typedef is a built-in (e.g. int), the typedef name is removed in the introspection, so, for vector<int>, for example, the introspection returns "int" instead of "value_type".  The obvious solution is to hard code the names, which are always the same.  It would be possible to modify our TypeWithDict class so that the typedefs of built-ins would not be resolved to the underlying type, but this complicates the code for no good reason.
Please merge this as soon as convenient.
Note: Many of the affected conditions unit tests now fail later for a different reason, but this failure was revealed by this pull request, not caused by it.
