### PR TITLE
Use correct function argument

### DIFF
--- a/CondCore/ORA/src/STLContainerHandler.cc
+++ b/CondCore/ORA/src/STLContainerHandler.cc
@@ -24,7 +24,7 @@ ora::STLContainerIteratorHandler::STLContainerIteratorHandler( void* address,
   } else {
     m_Iterators = new TVirtualCollectionIterators(&m_collProxy);
   }
-  m_Next = m_collProxy.GetFunctionNext();
+  m_Next = m_collProxy.GetFunctionNext(false);
 
   if (m_collProxy.HasPointers()) {
     m_PtrIterators->CreateIterators(address, &m_collProxy);


### PR DESCRIPTION
Many conditions unit tests are segfaulting because of a bug in the ROOT6 specific Conditions code.  TVirtualCollectionProxy::GetFunctionNext(bool) must be called here with an argument of false rather than the default argument value of true.
This pull request eliminates the segfault, but most of the affected tests will still fail later due to different problems that are revealed by this pull request, but not caused by it.
Please merge this request as soon as convenient.
