### PR TITLE
Flag candidate merged clusters for relaxed CPE errors

### DIFF
--- a/DataFormats/SiStripCluster/interface/SiStripCluster.h
+++ b/DataFormats/SiStripCluster/interface/SiStripCluster.h
@@ -32,7 +32,7 @@ public:
 
   /** The number of the first strip in the cluster
    */
-  uint16_t firstStrip() const {return firstStrip_;}
+  uint16_t firstStrip() const {return firstStrip_ & 0x7FFF;}
 
   /** The amplitudes of the strips forming the cluster.
    *  The amplitudes are on consecutive strips; if a strip is missing
@@ -51,6 +51,9 @@ public:
    *  should not be used as position estimate for tracking.
    */
   float barycenter() const;
+
+  bool isMerged() const {return (firstStrip_ & 0x8000) != 0;}
+  void setMerged(bool mergedState) {mergedState ? firstStrip_ |= 0x8000 : firstStrip_ &= 0x7FFF;}
 
   float getSplitClusterError () const    {  return error_x;  }
   void  setSplitClusterError ( float errx ) { error_x = errx; }

--- a/DataFormats/SiStripCluster/src/SiStripCluster.cc
+++ b/DataFormats/SiStripCluster/src/SiStripCluster.cc
@@ -31,7 +31,7 @@ float SiStripCluster::barycenter() const{
   int suma = 0;
   size_t asize = amplitudes_.size();
   for (size_t i=0;i<asize;++i) {
-    sumx += (firstStrip_+i)*(amplitudes_[i]);
+    sumx += ((firstStrip_ & 0x7FFF) + i)*(amplitudes_[i]);
     suma += amplitudes_[i];
   }
   

--- a/RecoLocalTracker/SiStripClusterizer/BuildFile.xml
+++ b/RecoLocalTracker/SiStripClusterizer/BuildFile.xml
@@ -9,6 +9,7 @@
 <use   name="CalibFormats/SiStripObjects"/>
 <use   name="CalibTracker/Records"/>
 <use   name="EventFilter/SiStripRawToDigi"/>
+<use   name="SimTracker/TrackerHitAssociation"/>
 <export>
   <lib name="1"/>
 </export>

--- a/RecoLocalTracker/SiStripClusterizer/BuildFile.xml
+++ b/RecoLocalTracker/SiStripClusterizer/BuildFile.xml
@@ -9,7 +9,6 @@
 <use   name="CalibFormats/SiStripObjects"/>
 <use   name="CalibTracker/Records"/>
 <use   name="EventFilter/SiStripRawToDigi"/>
-<use   name="SimTracker/TrackerHitAssociation"/>
 <export>
   <lib name="1"/>
 </export>

--- a/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusterizer.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusterizer.cc
@@ -69,7 +69,7 @@ refineCluster(const edm::Handle< edm::DetSetVector<SiStripDigi> >& input,
   if (input->size() == 0) return;
 
   // Flag merge-prone clusters for relaxed CPE errors
-  // Criterion is sensor occupancy exceeding threshold
+  // Criterion is sensor occupancy and cluster width exceeding thresholds
 
   for (edmNew::DetSetVector<SiStripCluster>::const_iterator det=output->begin(); det!=output->end(); det++) {
     uint32_t detId = det->id();

--- a/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusterizer.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusterizer.cc
@@ -4,10 +4,14 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Utilities/interface/transform.h"
 #include "boost/foreach.hpp"
+#include "CalibFormats/SiStripObjects/interface/SiStripQuality.h"
+#include "CalibTracker/Records/interface/SiStripQualityRcd.h"
+#include "CalibTracker/SiStripCommon/interface/SiStripDetInfoFileReader.h"
 
 SiStripClusterizer::
 SiStripClusterizer(const edm::ParameterSet& conf) 
-  : inputTags( conf.getParameter<std::vector<edm::InputTag> >("DigiProducersList") ),
+  : confClusterizer_(conf.getParameter<edm::ParameterSet>("Clusterizer")),
+    inputTags( conf.getParameter<std::vector<edm::InputTag> >("DigiProducersList") ),
     algorithm( StripClusterizerAlgorithmFactory::create(conf.getParameter<edm::ParameterSet>("Clusterizer")) ) {
   produces< edmNew::DetSetVector<SiStripCluster> > ();
   inputTokens = edm::vector_transform( inputTags, [this](edm::InputTag const & tag) { return consumes< edm::DetSetVector<SiStripDigi> >(tag);} );
@@ -24,8 +28,24 @@ produce(edm::Event& event, const edm::EventSetup& es)  {
 
   algorithm->initialize(es);  
 
+  bool doRefineCluster = confClusterizer_.getParameter<bool>("doRefineCluster");
+  float occupancyThreshold = confClusterizer_.getParameter<double>("occupancyThreshold");
+  bool useAssociator = confClusterizer_.getParameter<bool>("useMCtruth");
+
+  edm::ESHandle<SiStripQuality> quality = 0;
+  SiStripDetInfoFileReader* reader = 0;
+  std::shared_ptr<TrackerHitAssociator> associator;
+  if (doRefineCluster) {
+    es.get<SiStripQualityRcd>().get("", quality);
+    reader = edm::Service<SiStripDetInfoFileReader>().operator->();
+    if (useAssociator) associator.reset(new TrackerHitAssociator(event, confClusterizer_));
+  }
+
   BOOST_FOREACH( const edm::EDGetTokenT< edm::DetSetVector<SiStripDigi> >& token, inputTokens) {
-    if(      findInput( token, inputOld, event) ) algorithm->clusterize(*inputOld, *output); 
+    if(      findInput( token, inputOld, event) ) {
+      algorithm->clusterize(*inputOld, *output);
+      if (doRefineCluster) refineCluster(inputOld, output, reader, quality, associator, occupancyThreshold);
+    } 
 //     else if( findInput( tag, inputNew, event) ) algorithm->clusterize(*inputNew, *output);
     else edm::LogError("Input Not Found") << "[SiStripClusterizer::produce] ";// << tag;
   }
@@ -42,4 +62,49 @@ bool SiStripClusterizer::
 findInput(const edm::EDGetTokenT<T>& tag, edm::Handle<T>& handle, const edm::Event& e) {
     e.getByToken( tag, handle);
     return handle.isValid();
+}
+
+void SiStripClusterizer::
+refineCluster(const edm::Handle< edm::DetSetVector<SiStripDigi> >& input,
+	      std::auto_ptr< edmNew::DetSetVector<SiStripCluster> >& output,
+	      SiStripDetInfoFileReader* reader,
+	      edm::ESHandle<SiStripQuality> quality,
+	      std::shared_ptr<TrackerHitAssociator> associator,
+	      const float& occupancyThreshold) {
+  if (input->size() == 0) return;
+
+  // Flag merge-prone clusters for relaxed CPE errors
+  // Criterion is sensor occupancy exceeding threshold
+
+  for (edmNew::DetSetVector<SiStripCluster>::const_iterator det=output->begin(); det!=output->end(); det++) {
+    uint32_t detId = det->id();
+    // Find the number of good strips in this sensor
+    //   (from DPGAnalysis/SiStripTools/OccupancyPlots)
+    int nchannideal = reader->getNumberOfApvsAndStripLength(detId).first*128;
+    int nchannreal = 0;
+    for(int strip = 0; strip < nchannideal; ++strip)
+      if(!quality->IsStripBad(detId,strip)) ++nchannreal;
+
+    edm::DetSetVector<SiStripDigi>::const_iterator digis = input->find(detId);
+    if (digis != input->end()) {
+      int ndigi = digis->size();
+      int nmergedclust = 0;
+      for (edmNew::DetSet<SiStripCluster>::iterator clust = det->begin(); clust != det->end(); clust++) {
+	if (associator != 0) {
+	  std::vector<SimHitIdpr> simtrackid;
+	  associator->associateSimpleRecHitCluster(clust, DetId(detId), simtrackid);
+	  if (simtrackid.size() > 1) {
+	    nmergedclust++;
+	    clust->setSplitClusterError(-1.0);
+	  } else {
+	    clust->setSplitClusterError(-99999.9);
+	  }
+	} else {
+	  if (ndigi > occupancyThreshold*nchannreal) clust->setSplitClusterError(-1.0);
+	  else clust->setSplitClusterError(-99999.9);
+	}
+      }
+      // std::cout << "Sensor:strips_occStrips_clust_merged " << nchannreal << " " << ndigi << " " << det->size() << " " << nmergedclust << std::endl;
+    }
+  }  // traverse sensors
 }

--- a/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusterizer.h
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusterizer.h
@@ -6,6 +6,7 @@
 #include "RecoLocalTracker/SiStripClusterizer/interface/StripClusterizerAlgorithm.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
+#include "SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h"
 
 #include <vector>
 #include <memory>
@@ -19,12 +20,20 @@ public:
 
 private:
 
+  edm::ParameterSet confClusterizer_;
   template<class T> bool findInput(const edm::EDGetTokenT<T>&, edm::Handle<T>&, const edm::Event&);
   const std::vector<edm::InputTag> inputTags;
   std::auto_ptr<StripClusterizerAlgorithm> algorithm;
+  void refineCluster(const edm::Handle< edm::DetSetVector<SiStripDigi> >& input,
+		     std::auto_ptr< edmNew::DetSetVector<SiStripCluster> >& output,
+		     SiStripDetInfoFileReader* reader,
+		     edm::ESHandle<SiStripQuality> quality,
+		     std::shared_ptr<TrackerHitAssociator> associator,
+		     const float& occupancyThreshold);
   typedef edm::EDGetTokenT< edm::DetSetVector<SiStripDigi> > token_t;
   typedef std::vector<token_t> token_v;
   token_v inputTokens;
+  typedef std::vector<std::string> vstring;
 
 };
 

--- a/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusterizer.h
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusterizer.h
@@ -6,7 +6,6 @@
 #include "RecoLocalTracker/SiStripClusterizer/interface/StripClusterizerAlgorithm.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
-#include "SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h"
 
 #include <vector>
 #include <memory>
@@ -24,19 +23,16 @@ private:
   bool doRefineCluster_;
   float occupancyThreshold_;
   unsigned widthThreshold_;
-  bool useAssociator_;
   template<class T> bool findInput(const edm::EDGetTokenT<T>&, edm::Handle<T>&, const edm::Event&);
   const std::vector<edm::InputTag> inputTags;
   std::auto_ptr<StripClusterizerAlgorithm> algorithm;
   void refineCluster(const edm::Handle< edm::DetSetVector<SiStripDigi> >& input,
 		     std::auto_ptr< edmNew::DetSetVector<SiStripCluster> >& output,
 		     SiStripDetInfoFileReader* reader,
-		     edm::ESHandle<SiStripQuality> quality,
-		     std::shared_ptr<TrackerHitAssociator> associator);
+		     edm::ESHandle<SiStripQuality> quality);
   typedef edm::EDGetTokenT< edm::DetSetVector<SiStripDigi> > token_t;
   typedef std::vector<token_t> token_v;
   token_v inputTokens;
-  typedef std::vector<std::string> vstring;
 
 };
 

--- a/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusterizer.h
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusterizer.h
@@ -21,6 +21,10 @@ public:
 private:
 
   edm::ParameterSet confClusterizer_;
+  bool doRefineCluster_;
+  float occupancyThreshold_;
+  unsigned widthThreshold_;
+  bool useAssociator_;
   template<class T> bool findInput(const edm::EDGetTokenT<T>&, edm::Handle<T>&, const edm::Event&);
   const std::vector<edm::InputTag> inputTags;
   std::auto_ptr<StripClusterizerAlgorithm> algorithm;
@@ -28,8 +32,7 @@ private:
 		     std::auto_ptr< edmNew::DetSetVector<SiStripCluster> >& output,
 		     SiStripDetInfoFileReader* reader,
 		     edm::ESHandle<SiStripQuality> quality,
-		     std::shared_ptr<TrackerHitAssociator> associator,
-		     const float& occupancyThreshold);
+		     std::shared_ptr<TrackerHitAssociator> associator);
   typedef edm::EDGetTokenT< edm::DetSetVector<SiStripDigi> > token_t;
   typedef std::vector<token_t> token_v;
   token_v inputTokens;

--- a/RecoLocalTracker/SiStripClusterizer/python/DefaultClusterizer_cff.py
+++ b/RecoLocalTracker/SiStripClusterizer/python/DefaultClusterizer_cff.py
@@ -10,30 +10,7 @@ DefaultClusterizer = cms.PSet(
     MaxAdjacentBad = cms.uint32(0),
     QualityLabel = cms.string(""),
     RemoveApvShots     = cms.bool(True),
-    doRefineCluster = cms.bool(False),
+    doRefineCluster = cms.bool(True),
     occupancyThreshold = cms.double(0.05),
     widthThreshold = cms.uint32(4),
-    useMCtruth = cms.bool(False),
-#  For TrackerHitAssociator
-#  If pileup and crossing frames available:
-    # ROUList = cms.vstring('g4SimHitsTrackerHitsTIBLowTof',
-    #                       'g4SimHitsTrackerHitsTIBHighTof',
-    #                       'g4SimHitsTrackerHitsTIDLowTof',
-    #                       'g4SimHitsTrackerHitsTIDHighTof',
-    #                       'g4SimHitsTrackerHitsTOBLowTof',
-    #                       'g4SimHitsTrackerHitsTOBHighTof',
-    #                       'g4SimHitsTrackerHitsTECLowTof',
-    #                       'g4SimHitsTrackerHitsTECHighTof'),
-#  otherwise:
-    ROUList = cms.vstring('TrackerHitsTIBLowTof',
-                          'TrackerHitsTIBHighTof',
-                          'TrackerHitsTIDLowTof',
-                          'TrackerHitsTIDHighTof',
-                          'TrackerHitsTOBLowTof',
-                          'TrackerHitsTOBHighTof',
-                          'TrackerHitsTECLowTof',
-                          'TrackerHitsTECHighTof'),
-    associateRecoTracks = cms.bool(True),
-    associatePixel = cms.bool(False),
-    associateStrip = cms.bool(True)
 )

--- a/RecoLocalTracker/SiStripClusterizer/python/DefaultClusterizer_cff.py
+++ b/RecoLocalTracker/SiStripClusterizer/python/DefaultClusterizer_cff.py
@@ -9,5 +9,30 @@ DefaultClusterizer = cms.PSet(
     MaxSequentialBad = cms.uint32(1),
     MaxAdjacentBad = cms.uint32(0),
     QualityLabel = cms.string(""),
-    RemoveApvShots     = cms.bool(True)
-    )
+    RemoveApvShots     = cms.bool(True),
+    doRefineCluster = cms.bool(True),
+    occupancyThreshold = cms.double(0.08),
+    useMCtruth = cms.bool(True),
+#  For TrackerHitAssociator
+#  If pileup and crossing frames available:
+    # ROUList = cms.vstring('g4SimHitsTrackerHitsTIBLowTof',
+    #                       'g4SimHitsTrackerHitsTIBHighTof',
+    #                       'g4SimHitsTrackerHitsTIDLowTof',
+    #                       'g4SimHitsTrackerHitsTIDHighTof',
+    #                       'g4SimHitsTrackerHitsTOBLowTof',
+    #                       'g4SimHitsTrackerHitsTOBHighTof',
+    #                       'g4SimHitsTrackerHitsTECLowTof',
+    #                       'g4SimHitsTrackerHitsTECHighTof'),
+#  otherwise:
+    ROUList = cms.vstring('TrackerHitsTIBLowTof',
+                          'TrackerHitsTIBHighTof',
+                          'TrackerHitsTIDLowTof',
+                          'TrackerHitsTIDHighTof',
+                          'TrackerHitsTOBLowTof',
+                          'TrackerHitsTOBHighTof',
+                          'TrackerHitsTECLowTof',
+                          'TrackerHitsTECHighTof'),
+    associateRecoTracks = cms.bool(True),
+    associatePixel = cms.bool(False),
+    associateStrip = cms.bool(True)
+)

--- a/RecoLocalTracker/SiStripClusterizer/python/DefaultClusterizer_cff.py
+++ b/RecoLocalTracker/SiStripClusterizer/python/DefaultClusterizer_cff.py
@@ -10,7 +10,7 @@ DefaultClusterizer = cms.PSet(
     MaxAdjacentBad = cms.uint32(0),
     QualityLabel = cms.string(""),
     RemoveApvShots     = cms.bool(True),
-    doRefineCluster = cms.bool(True),
+    doRefineCluster = cms.bool(False),
     occupancyThreshold = cms.double(0.05),
-    widthThreshold = cms.uint32(4),
+    widthThreshold = cms.uint32(4)
 )

--- a/RecoLocalTracker/SiStripClusterizer/python/DefaultClusterizer_cff.py
+++ b/RecoLocalTracker/SiStripClusterizer/python/DefaultClusterizer_cff.py
@@ -10,9 +10,10 @@ DefaultClusterizer = cms.PSet(
     MaxAdjacentBad = cms.uint32(0),
     QualityLabel = cms.string(""),
     RemoveApvShots     = cms.bool(True),
-    doRefineCluster = cms.bool(True),
-    occupancyThreshold = cms.double(0.08),
-    useMCtruth = cms.bool(True),
+    doRefineCluster = cms.bool(False),
+    occupancyThreshold = cms.double(0.05),
+    widthThreshold = cms.uint32(4),
+    useMCtruth = cms.bool(False),
 #  For TrackerHitAssociator
 #  If pileup and crossing frames available:
     # ROUList = cms.vstring('g4SimHitsTrackerHitsTIBLowTof',

--- a/RecoLocalTracker/SiStripRecHitConverter/src/StripCPEfromTrackAngle.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/src/StripCPEfromTrackAngle.cc
@@ -38,7 +38,10 @@ localParameters( const SiStripCluster& cluster, const GeomDetUnit& det, const Lo
 
   const unsigned N = cluster.amplitudes().size();
   const float fullProjection = p.coveredStrips( track+p.drift, ltp.position());
-  const float uerr2 = useLegacyError ? legacyStripErrorSquared(N,std::abs(fullProjection)) : stripErrorSquared( N, std::abs(fullProjection),ssdid.subDetector() );
+  // std::cout << cluster.getSplitClusterError() << ", legacyErr = " << legacyStripErrorSquared(N,std::abs(fullProjection))
+  // << ", newErr = " << stripErrorSquared( N, std::abs(fullProjection),ssdid.subDetector() ) << std::endl;
+  const float uerr2 = useLegacyError || cluster.getSplitClusterError() == -1.0 ? legacyStripErrorSquared(N,std::abs(fullProjection)) : stripErrorSquared( N, std::abs(fullProjection),ssdid.subDetector() );
+  // std::cout << " uerr2 = " << uerr2 << std::endl;
   const float strip = cluster.barycenter() -  0.5f*(1.f-p.backplanecorrection) * fullProjection
     + 0.5f*p.coveredStrips(track, ltp.position());
 

--- a/RecoLocalTracker/SiStripRecHitConverter/src/StripCPEfromTrackAngle.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/src/StripCPEfromTrackAngle.cc
@@ -38,7 +38,7 @@ localParameters( const SiStripCluster& cluster, const GeomDetUnit& det, const Lo
 
   const unsigned N = cluster.amplitudes().size();
   const float fullProjection = p.coveredStrips( track+p.drift, ltp.position());
-  // std::cout << cluster.getSplitClusterError() << ", legacyErr = " << legacyStripErrorSquared(N,std::abs(fullProjection))
+  // std::cout << cluster.firstStrip() << ", "<< cluster.isMerged() << ", legacyErr = " << legacyStripErrorSquared(N,std::abs(fullProjection))
   // << ", newErr = " << stripErrorSquared( N, std::abs(fullProjection),ssdid.subDetector() ) << std::endl;
   const float uerr2 = useLegacyError || cluster.isMerged() ? legacyStripErrorSquared(N,std::abs(fullProjection)) : stripErrorSquared( N, std::abs(fullProjection),ssdid.subDetector() );
   // std::cout << " uerr2 = " << uerr2 << std::endl;

--- a/RecoLocalTracker/SiStripRecHitConverter/src/StripCPEfromTrackAngle.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/src/StripCPEfromTrackAngle.cc
@@ -40,7 +40,7 @@ localParameters( const SiStripCluster& cluster, const GeomDetUnit& det, const Lo
   const float fullProjection = p.coveredStrips( track+p.drift, ltp.position());
   // std::cout << cluster.getSplitClusterError() << ", legacyErr = " << legacyStripErrorSquared(N,std::abs(fullProjection))
   // << ", newErr = " << stripErrorSquared( N, std::abs(fullProjection),ssdid.subDetector() ) << std::endl;
-  const float uerr2 = useLegacyError || cluster.getSplitClusterError() == -1.0 ? legacyStripErrorSquared(N,std::abs(fullProjection)) : stripErrorSquared( N, std::abs(fullProjection),ssdid.subDetector() );
+  const float uerr2 = useLegacyError || cluster.isMerged() ? legacyStripErrorSquared(N,std::abs(fullProjection)) : stripErrorSquared( N, std::abs(fullProjection),ssdid.subDetector() );
   // std::cout << " uerr2 = " << uerr2 << std::endl;
   const float strip = cluster.barycenter() -  0.5f*(1.f-p.backplanecorrection) * fullProjection
     + 0.5f*p.coveredStrips(track, ltp.position());


### PR DESCRIPTION
Add a function "refineCluster" in SiStripClusterizer to mark SiStrip clusters as merged.  Use this information StripCPEfromTrackAngle to fall back to the larger "legacy" CPE errors for these clusters.  The flag lives on the high bit of the firstStrip_ private data member of the SiStripCluster.  Configurable thresholds in the sensor occupancy and strip width are used to discriminate between un- and merged candidates.  The cluster refiner is turned off as configured for this PR. 
