### PR TITLE
Replace boost::{bind,cref,ref} with std:: version; C++11 compliant

### DIFF
--- a/Mixing/Base/BuildFile.xml
+++ b/Mixing/Base/BuildFile.xml
@@ -7,7 +7,6 @@
 <use   name="FWCore/Sources"/>
 <use   name="FWCore/Utilities"/>
 <use   name="FWCore/Version"/>
-<use   name="boost"/>
 <use   name="clhep"/>
 <use   name="roothistmatrix"/>
 <use   name="CondFormats/RunInfo"/>

--- a/Mixing/Base/interface/BMixingModule.h
+++ b/Mixing/Base/interface/BMixingModule.h
@@ -16,8 +16,7 @@
  ************************************************************/
 
 #include <vector>
-
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 #include "FWCore/Framework/interface/one/EDProducer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
@@ -94,7 +93,7 @@ namespace edm {
       unsigned int eventId_;
 
       // input, cosmics, beamhalo_plus, beamhalo_minus
-      std::vector<boost::shared_ptr<PileUp> > inputSources_;
+      std::vector<std::shared_ptr<PileUp> > inputSources_;
 
       void update(edm::EventSetup const&);
       edm::ESWatcher<MixingRcd> parameterWatcher_;

--- a/Mixing/Base/interface/PileUp.h
+++ b/Mixing/Base/interface/PileUp.h
@@ -4,7 +4,6 @@
 #include <memory>
 #include <string>
 #include <vector>
-//#include <boost/bind.hpp>
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Sources/interface/VectorInputSource.h"
 #include "DataFormats/Provenance/interface/EventID.h"
@@ -195,22 +194,9 @@ namespace edm {
         read = input_->loopRandomWithID(*eventPrincipal_, lumi, pileEventCnt, recorder, randomEngine(streamID));
     } else {
       if (sequential_) {
-        // boost::bind creates a functor from recordEventForPlayback
-        // so that recordEventForPlayback can insert itself before
-        // the original eventOperator.
-
         read = input_->loopSequential(*eventPrincipal_, pileEventCnt, recorder);
-        //boost::bind(&PileUp::recordEventForPlayback<T>,
-        //                    boost::ref(*this), _1, boost::ref(ids),
-        //                             boost::ref(eventOperator))
-        //  );
-          
       } else  {
         read = input_->loopRandom(*eventPrincipal_, pileEventCnt, recorder, randomEngine(streamID));
-        //               boost::bind(&PileUp::recordEventForPlayback<T>,
-        //                             boost::ref(*this), _1, boost::ref(ids),
-        //                             boost::ref(eventOperator))
-        //                 );
       }
     }
     if (read != pileEventCnt)

--- a/Mixing/Base/src/BMixingModule.cc
+++ b/Mixing/Base/src/BMixingModule.cc
@@ -21,10 +21,10 @@ const unsigned int edm::BMixingModule::maxNbSources_ =4;
 
 namespace
 {
-  boost::shared_ptr<edm::PileUp>
+  std::shared_ptr<edm::PileUp>
   maybeMakePileUp(edm::ParameterSet const& ps,std::string sourceName, const int minb, const int maxb, const bool playback)
   { 
-    boost::shared_ptr<edm::PileUp> pileup; // value to be returned
+    std::shared_ptr<edm::PileUp> pileup; // value to be returned
     // Make sure we have a parameter named 'sourceName'
     if (ps.exists(sourceName))
       {

--- a/SimGeneral/DataMixingModule/plugins/DataMixingModule.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingModule.cc
@@ -6,7 +6,9 @@
 
 #include <map>
 #include <iostream>
-#include <boost/bind.hpp>
+#include <memory>
+#include <functional>
+
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Framework/interface/ConstProductRegistry.h"
@@ -463,6 +465,8 @@ namespace edm
   
   void DataMixingModule::doPileUp(edm::Event &e, const edm::EventSetup& ES)
   {
+    using namespace std::placeholders;
+
     std::vector<edm::EventID> recordEventID;
     std::vector<int> PileupList;
     PileupList.clear();
@@ -472,7 +476,7 @@ namespace edm
 
     for (int bunchCrossing=minBunch_;bunchCrossing<=maxBunch_;++bunchCrossing) {
       for (unsigned int isource=0;isource<maxNbSources_;++isource) {
-        boost::shared_ptr<PileUp> source = inputSources_[isource];
+        std::shared_ptr<PileUp> source = inputSources_[isource];
         if (!source || !(source->doPileUp(bunchCrossing))) 
           continue;
 
@@ -490,8 +494,8 @@ namespace edm
         source->readPileUp(
                 e.id(),
                 recordEventID,
-                boost::bind(&DataMixingModule::pileWorker, boost::ref(*this),
-                            _1, bunchCrossing, _2, boost::cref(ES), mcc),
+                std::bind(&DataMixingModule::pileWorker, std::ref(*this),
+                            _1, bunchCrossing, _2, std::cref(ES), mcc),
 		NumPU_Events,
                 e.streamID()
                 );

--- a/SimGeneral/MixingModule/plugins/MixingModule.cc
+++ b/SimGeneral/MixingModule/plugins/MixingModule.cc
@@ -4,11 +4,12 @@
 //
 //--------------------------------------------
 
+#include <functional>
+#include <memory>
+
 #include "MixingModule.h"
 #include "MixingWorker.h"
 #include "Adjuster.h"
-
-#include "boost/bind.hpp"
 
 #include "CondFormats/RunInfo/interface/MixingModuleConfig.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -321,6 +322,8 @@ namespace edm {
   }
 
   void MixingModule::doPileUp(edm::Event &e, const edm::EventSetup& setup) {
+    using namespace std::placeholders;
+
     // Don't allocate because PileUp will do it for us.
     std::vector<edm::EventID> recordEventID;
     edm::Handle<CrossingFramePlaybackInfoExtended>  playbackInfo_H;
@@ -340,7 +343,7 @@ namespace edm {
     PileupList.clear();
     TrueNumInteractions_.clear();
 
-    boost::shared_ptr<PileUp> source0 = inputSources_[0];
+    std::shared_ptr<PileUp> source0 = inputSources_[0];
 
     if((source0 && source0->doPileUp(0) ) && !playback_) {
       //    if((!inputSources_[0] || !inputSources_[0]->doPileUp()) && !playback_ ) 
@@ -366,7 +369,7 @@ namespace edm {
       }
 
       for (size_t readSrcIdx=0; readSrcIdx<maxNbSources_; ++readSrcIdx) {
-        boost::shared_ptr<PileUp> source = inputSources_[readSrcIdx];   // this looks like we create
+        std::shared_ptr<PileUp> source = inputSources_[readSrcIdx];   // this looks like we create
                                                                         // new PileUp objects for each
                                                                         // source for each event?
                                                                         // Why?
@@ -390,8 +393,8 @@ namespace edm {
         ModuleCallingContext const* mcc = e.moduleCallingContext(); 
         if (!playback_) {
           inputSources_[readSrcIdx]->readPileUp(e.id(), recordEventID,
-                                                boost::bind(&MixingModule::pileAllWorkers, boost::ref(*this), _1, mcc, bunchIdx,
-                                                            _2, vertexOffset, boost::ref(setup), boost::cref(e.streamID())), NumPU_Events, e.streamID()
+                                                std::bind(&MixingModule::pileAllWorkers, std::ref(*this), _1, mcc, bunchIdx,
+                                                            _2, vertexOffset, std::ref(setup), e.streamID()), NumPU_Events, e.streamID()
             );
           playbackInfo_->setStartEventId(recordEventID, readSrcIdx, bunchIdx, KeepTrackOfPileup);
           KeepTrackOfPileup+=NumPU_Events;
@@ -404,8 +407,8 @@ namespace edm {
           }
           inputSources_[readSrcIdx]->playPileUp(
             playEventID,
-            boost::bind(&MixingModule::pileAllWorkers, boost::ref(*this), _1, mcc, bunchIdx,
-                        _2, vertexOffset, boost::ref(setup), boost::cref(e.streamID()))
+            std::bind(&MixingModule::pileAllWorkers, std::ref(*this), _1, mcc, bunchIdx,
+                        _2, vertexOffset, std::ref(setup), e.streamID())
             );
         }
       }

--- a/SimGeneral/MixingModule/plugins/SecSourceAnalyzer.cc
+++ b/SimGeneral/MixingModule/plugins/SecSourceAnalyzer.cc
@@ -19,7 +19,7 @@
 
 // system include files
 #include <memory>
-#include <boost/bind.hpp>
+#include <functional>
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
@@ -93,6 +93,7 @@ SecSourceAnalyzer::~SecSourceAnalyzer()
 void
 SecSourceAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
+   using namespace std::placeholders;
    vectorEventIDs_.resize(maxBunch_-minBunch_+1);
 
    int nevt = 0 ;
@@ -102,7 +103,7 @@ SecSourceAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
 	 {
 	   input_->readPileUp( iEvent.id(),
                                vectorEventIDs_[ ibx-minBunch_ ],
-                               boost::bind(&SecSourceAnalyzer::getBranches,
+                               std::bind(&SecSourceAnalyzer::getBranches,
                                            this, _1, iEvent.moduleCallingContext()), ibx,
                                iEvent.streamID());
 	 }
@@ -110,7 +111,7 @@ SecSourceAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
 	 {
 	   input_->readPileUp( iEvent.id(),
                                vectorEventIDs_[ ibx-minBunch_ ],
-                               boost::bind(&SecSourceAnalyzer::dummyFunction,
+                               std::bind(&SecSourceAnalyzer::dummyFunction,
                                            this, _1),
                                ibx,
                                iEvent.streamID());


### PR DESCRIPTION
Boost 1.53.0 modified their `cref/ref` to match C++11 standard. Remove
dependency on boost and use standard library features. According to C++
standard you are not allowed to use `cref/ref` with rvalues. In this
particular case you are not allowed to pass `e.streamID()` as a
reference. I think, `std::reference_wrapper` is not allowed to hold a
reference to a temporary, otherwise it would be undefined behavior.

Details: http://wg21.cmeerw.net/lwg/issue688

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
