### PR TITLE
bugfix input seeds for electrons - should be the PF clusters as default

### DIFF
--- a/RecoHI/HiEgammaAlgos/python/HiElectronSequence_cff.py
+++ b/RecoHI/HiEgammaAlgos/python/HiElectronSequence_cff.py
@@ -6,8 +6,6 @@ from TrackingTools.GsfTracking.GsfElectronTracking_cff import *
 ecalDrivenElectronSeeds.SeedConfiguration.initialSeeds = "hiPixelTrackSeeds"
 electronCkfTrackCandidates.src = "ecalDrivenElectronSeeds"
 
-ecalDrivenElectronSeeds.barrelSuperClusters = cms.InputTag("correctedIslandBarrelSuperClusters")
-
 ecalDrivenElectronSeeds.SeedConfiguration.maxHOverEBarrel = cms.double(0.25)
 ecalDrivenElectronSeeds.SeedConfiguration.maxHOverEEndcaps = cms.double(0.25)
 


### PR DESCRIPTION
Besides fixing the PF electrons in HI, this PR is a prerequisite for the upcoming pull-requests on pixel-tracking.
