### PR TITLE
Add dependency on boost_test instead of boost_unit_test_framework lib

### DIFF
--- a/Fireworks/Core/test/BuildFile.xml
+++ b/Fireworks/Core/test/BuildFile.xml
@@ -4,5 +4,5 @@
  <use name="boost"/>
  <use name="rootcintex"/>
  <use name="rootcore"/>
- <lib name="boost_unit_test_framework"/>
+ <use name="boost_test"/>
 </bin>


### PR DESCRIPTION
`boost_test` toolfile was added to CMSDIST, which incl.
`libboost_unit_test_framework.so`. Add dependency on the toolfile instead of
attempting to link to `libboost_unit_test_framework.so` directly.

https://github.com/cms-sw/cmsdist/pull/1180

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
