### PR TITLE
Resolve unused variable 'vtxItr' compiler error

### DIFF
--- a/Calibration/IsolatedParticles/plugins/IsolatedGenParticles.cc
+++ b/Calibration/IsolatedParticles/plugins/IsolatedGenParticles.cc
@@ -32,9 +32,9 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include <iostream>
 #include <iomanip>
-#include<list>
-#include<vector>
-#include<cmath>
+#include <list>
+#include <vector>
+#include <cmath>
 
 #include "Calibration/IsolatedParticles/interface/CaloPropagateTrack.h"
 #include "Calibration/IsolatedParticles/interface/ChargeIsolation.h"

--- a/Calibration/IsolatedParticles/plugins/IsolatedTracksHcalScale.cc
+++ b/Calibration/IsolatedParticles/plugins/IsolatedTracksHcalScale.cc
@@ -148,7 +148,6 @@ void IsolatedTracksHcalScale::analyze(const edm::Event& iEvent, const edm::Event
   edm::Handle<edm::SimTrackContainer> SimTk;
   edm::SimTrackContainer::const_iterator simTrkItr;
   edm::Handle<edm::SimVertexContainer> SimVtx;
-  edm::SimVertexContainer::const_iterator vtxItr = SimVtx->begin();
 
   //get Handles to PCaloHitContainers of eb/ee/hbhe
   edm::Handle<edm::PCaloHitContainer> pcaloeb;


### PR DESCRIPTION
Clang 3.5.0 complains:

```
Calibration/IsolatedParticles/plugins/IsolatedTracksHcalScale.cc:151:43:
error: unused variable 'vtxItr' [-Werror,-Wunused-variable]
```

The patch removes `vtxItr`.

Also add a space between `#include` and `<`.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
