### PR TITLE
Clean up DQM/HLTEvF based on Clang warnings/errors

### DIFF
--- a/DQM/HLTEvF/interface/FourVectorHLT.h
+++ b/DQM/HLTEvF/interface/FourVectorHLT.h
@@ -68,19 +68,13 @@ class FourVectorHLT : public edm::EDAnalyzer {
       int nev_;
       DQMStore * dbe_;
 
-      MonitorElement* total_;
-
       bool plotAll_;
-      bool resetMe_;
-      int currentRun_;
  
       unsigned int nBins_; 
       double ptMin_ ;
       double ptMax_ ;
       
       std::string dirname_;
-      bool monitorDaemon_;
-      int theHLTOutputType;
       edm::InputTag triggerSummaryLabel_;
       edm::InputTag triggerResultLabel_;
 

--- a/DQM/HLTEvF/interface/FourVectorHLTOnline.h
+++ b/DQM/HLTEvF/interface/FourVectorHLTOnline.h
@@ -148,8 +148,6 @@ class FourVectorHLTOnline : public edm::EDAnalyzer {
       unsigned int Nbx_; 
 
       bool plotAll_;
-      bool resetMe_;
-      int currentRun_;
       
       unsigned int nBins_; 
       unsigned int nBinsOneOverEt_; 
@@ -200,8 +198,6 @@ class FourVectorHLTOnline : public edm::EDAnalyzer {
       std::string dirname_;
       std::string processname_;
       std::string muonRecoCollectionName_;
-      bool monitorDaemon_;
-      int theHLTOutputType;
       edm::InputTag triggerSummaryLabel_;
       edm::InputTag triggerResultsLabel_;
       HLTConfigProvider hltConfig_;

--- a/DQM/HLTEvF/interface/FourVectorHLTOnline.h
+++ b/DQM/HLTEvF/interface/FourVectorHLTOnline.h
@@ -691,7 +691,7 @@ bool objMonData<T>::isL1TriggerType(int t)
   for(std::vector<int>::const_iterator it = l1triggerType_.begin(); it != l1triggerType_.end(); ++it)
   {
 
-   if(fabs(t) == fabs(*it)) { rc = true; break; }
+   if(std::abs(t) == std::abs(*it)) { rc = true; break; }
 
   } // end for
 

--- a/DQM/HLTEvF/interface/HLTAlCaMonPi0.h
+++ b/DQM/HLTEvF/interface/HLTAlCaMonPi0.h
@@ -32,9 +32,6 @@ public:
   }
 };
 
-
-
-
 class DQMStore;
 class MonitorElement;
 
@@ -245,9 +242,6 @@ private:
   edm::InputTag productMonitoredEEpi0_;
   edm::InputTag productMonitoredEEeta_;
 
-      int gammaCandEtaSize_;
-      int gammaCandPhiSize_;
-
       double seleXtalMinEnergy_;
       double seleXtalMinEnergyEndCap_;
 
@@ -304,12 +298,6 @@ private:
       double seleEtaBeltDetaEndCap_;
 
 
-  bool ParameterLogWeighted_;
-  double ParameterX0_;
-  double ParameterT0_barl_;
-  double ParameterT0_endc_;
-  double ParameterT0_endcPresh_;
-  double ParameterW0_;
 
 
 

--- a/DQM/HLTEvF/interface/HLTEventInfoClient.h
+++ b/DQM/HLTEvF/interface/HLTEventInfoClient.h
@@ -70,7 +70,6 @@ private:
   int counterEvt_;     ///counter
   int prescaleLS_;     ///units of lumi sections
   int prescaleEvt_;    ///prescale on number of events
-  int nChannels;
   Float_t reportSummary;
   Float_t summarySum;
   Float_t summaryContent[20];

--- a/DQM/HLTEvF/interface/HLTMon.h
+++ b/DQM/HLTEvF/interface/HLTMon.h
@@ -85,9 +85,7 @@ class HLTMon : public edm::EDAnalyzer {
       unsigned int theNbins ;
       
       std::string dirname_;
-      bool monitorDaemon_;
       std::ofstream logFile_;
-      int theHLTOutputType;
       std::string outputFile_;
 
       std::string histoTitle;

--- a/DQM/HLTEvF/interface/HLTMonElectron.h
+++ b/DQM/HLTEvF/interface/HLTMonElectron.h
@@ -81,9 +81,7 @@ class HLTMonElectron : public edm::EDAnalyzer {
       unsigned int theNbins ;
       
       std::string dirname_;
-      bool monitorDaemon_;
       std::ofstream logFile_;
-      int theHLTOutputType;
       std::string outputFile_;
       
 };

--- a/DQM/HLTEvF/interface/HLTMonElectronConsumer.h
+++ b/DQM/HLTEvF/interface/HLTMonElectronConsumer.h
@@ -80,7 +80,6 @@ class HLTMonElectronConsumer : public edm::EDAnalyzer {
       std::string dirname_;
       std::string pixeldirname_;
       std::string isodirname_;
-      bool monitorDaemon_;
       std::ofstream logFile_;
       std::string outputFile_;
       

--- a/DQM/HLTEvF/interface/HLTMonHcalIsoTrack.h
+++ b/DQM/HLTEvF/interface/HLTMonHcalIsoTrack.h
@@ -28,8 +28,6 @@ public:
 
 private:
 
-  int evtBuf;
-
   DQMStore* dbe_;
 
   virtual void beginJob() ;

--- a/DQM/HLTEvF/interface/HLTMonMuonClient.h
+++ b/DQM/HLTEvF/interface/HLTMonMuonClient.h
@@ -49,8 +49,6 @@ private:
 
   static const int NTRIG = 20;
 
-  int nTriggers_;
-
   DQMStore* dbe_;
   std::string indir_, outdir_;
 

--- a/DQM/HLTEvF/interface/HLTMonPhotonClient.h
+++ b/DQM/HLTEvF/interface/HLTMonPhotonClient.h
@@ -56,7 +56,6 @@ class HLTMonPhotonClient : public edm::EDAnalyzer {
 
       std::string dirname_;
       std::string sourcedirname_;
-      bool monitorDaemon_;
       std::ofstream logFile_;
       std::string outputFile_;
       std::vector<edm::InputTag> theHLTCollectionLabels;

--- a/DQM/HLTEvF/interface/HLTMonPhotonSource.h
+++ b/DQM/HLTEvF/interface/HLTMonPhotonSource.h
@@ -68,9 +68,7 @@ class HLTMonPhotonSource : public edm::EDAnalyzer {
 
       
       std::string dirname_;
-      bool monitorDaemon_;
       std::ofstream logFile_;
-      int theHLTOutputType;
       std::string outputFile_;
       
 };

--- a/DQM/HLTEvF/interface/HLTMonSimpleBTag.h
+++ b/DQM/HLTEvF/interface/HLTMonSimpleBTag.h
@@ -76,19 +76,12 @@ private:
   int refresheff_;
   DQMStore * dbe_;
 
-  MonitorElement* total_;
-
-  bool resetMe_;
-  int currentRun_;
- 
   unsigned int nBins_; 
   double ptMin_ ;
   double ptMax_ ;
   double dRTrigObjMatch_;
       
   std::string dirname_;
-  bool monitorDaemon_;
-  int theHLTOutputType;
   edm::InputTag triggerSummaryLabel_;
   edm::InputTag triggerResultLabel_;
 

--- a/DQM/HLTEvF/interface/PathTimerService.h
+++ b/DQM/HLTEvF/interface/PathTimerService.h
@@ -40,13 +40,7 @@ namespace edm {
             edm::EventID curr_event_;
             double curr_job_;         // seconds
             double curr_event_time_;  // seconds
-            double curr_module_time_; // seconds
       
-            //
-            // Min Max and average event times for summary
-            //  at end of job
-            double max_event_time_;    // seconds
-            double min_event_time_;    // seconds
             int total_event_count_; 
 
             ParameterSet _myPS;

--- a/DQM/HLTEvF/interface/TrigResRateMon.h
+++ b/DQM/HLTEvF/interface/TrigResRateMon.h
@@ -158,7 +158,6 @@ class TrigResRateMon : public edm::EDAnalyzer {
 
   bool jmsDebug;
   bool jmsFakeZBCounts;
-  unsigned int zbIndex;
   bool found_zbIndex;
 
       MonitorElement* ME_HLTAll_LS;
@@ -236,7 +235,6 @@ class TrigResRateMon : public edm::EDAnalyzer {
       bool plotAll_;
       bool doCombineRuns_;
       bool doVBTFMuon_;
-      int currentRun_;
       
       unsigned int nBins_; 
       unsigned int nBins2D_; 
@@ -247,42 +245,6 @@ class TrigResRateMon : public edm::EDAnalyzer {
       double dRMax_ ;
       double dRMaxElectronMuon_ ;
       
-      double electronEtaMax_;
-      double electronEtMin_;
-      double electronDRMatch_;
-      double electronL1DRMatch_;
-      double muonEtaMax_;
-      double muonEtMin_;
-      double muonDRMatch_;
-      double muonL1DRMatch_;
-      double tauEtaMax_;
-      double tauEtMin_;
-      double tauDRMatch_;
-      double tauL1DRMatch_;
-      double jetEtaMax_;
-      double jetEtMin_;
-      double jetDRMatch_;
-      double jetL1DRMatch_;
-      double bjetEtaMax_;
-      double bjetEtMin_;
-      double bjetDRMatch_;
-      double bjetL1DRMatch_;
-      double photonEtaMax_;
-      double photonEtMin_;
-      double photonDRMatch_;
-      double photonL1DRMatch_;
-      double trackEtaMax_;
-      double trackEtMin_;
-      double trackDRMatch_;
-      double trackL1DRMatch_;
-      double metEtaMax_;
-      double metMin_;
-      double metDRMatch_;
-      double metL1DRMatch_;
-      double htEtaMax_;
-      double htMin_;
-      double htDRMatch_;
-      double htL1DRMatch_;
       double sumEtMin_;
 
       // Muon quality cuts
@@ -313,8 +275,6 @@ class TrigResRateMon : public edm::EDAnalyzer {
       std::string dirname_;
       std::string processname_;
       std::string muonRecoCollectionName_;
-      bool monitorDaemon_;
-      int theHLTOutputType;
       edm::InputTag triggerSummaryLabel_;
       edm::InputTag triggerResultsLabel_;
       edm::InputTag recHitsEBTag_, recHitsEETag_;

--- a/DQM/HLTEvF/plugins/FourVectorHLT.cc
+++ b/DQM/HLTEvF/plugins/FourVectorHLT.cc
@@ -14,8 +14,7 @@
 
 using namespace edm;
 
-FourVectorHLT::FourVectorHLT(const edm::ParameterSet& iConfig):
-  resetMe_(true),  currentRun_(-99)
+FourVectorHLT::FourVectorHLT(const edm::ParameterSet& iConfig)
 {
   LogDebug("FourVectorHLT") << "constructor...." ;
 

--- a/DQM/HLTEvF/plugins/FourVectorHLTOnline.cc
+++ b/DQM/HLTEvF/plugins/FourVectorHLTOnline.cc
@@ -11,8 +11,7 @@ using namespace edm;
 using namespace trigger;
 using namespace std;
 
-FourVectorHLTOnline::FourVectorHLTOnline(const edm::ParameterSet& iConfig):
-  resetMe_(true),  currentRun_(-99)
+FourVectorHLTOnline::FourVectorHLTOnline(const edm::ParameterSet& iConfig)
 {
 
   LogDebug("FourVectorHLTOnline") << "constructor...." ;

--- a/DQM/HLTEvF/plugins/HLTMonSimpleBTag.cc
+++ b/DQM/HLTEvF/plugins/HLTMonSimpleBTag.cc
@@ -18,8 +18,7 @@
 
 using namespace edm;
 
-HLTMonSimpleBTag::HLTMonSimpleBTag(const edm::ParameterSet& iConfig):
-  resetMe_(true),  currentRun_(-99)
+HLTMonSimpleBTag::HLTMonSimpleBTag(const edm::ParameterSet& iConfig)
 {
   LogDebug("HLTMonSimpleBTag") << "constructor...." ;
 

--- a/DQM/HLTEvF/plugins/TrigResRateMon.cc
+++ b/DQM/HLTEvF/plugins/TrigResRateMon.cc
@@ -13,7 +13,7 @@ using namespace edm;
 using namespace trigger;
 using namespace std;
 
-TrigResRateMon::TrigResRateMon(const edm::ParameterSet& iConfig): currentRun_(-99)
+TrigResRateMon::TrigResRateMon(const edm::ParameterSet& iConfig)
 {
 
   LogDebug("TrigResRateMon") << "constructor...." ;

--- a/DQM/HLTEvF/plugins/TriggerRatesMonitor.cc
+++ b/DQM/HLTEvF/plugins/TriggerRatesMonitor.cc
@@ -40,9 +40,6 @@
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
 
-// length of a lumisections, corresponding to 2**18 LHC orbits, or 23.31 seconds
-static const double SECS_PER_LUMI = 23.31040958083832;
-
 // helper functions
 template <typename T>
 static


### PR DESCRIPTION
According to Clang this package has 1 error and 84 warnings. The following patchset resolves the error and majority of warnings, only 2 warnings are left which are coming from a different package.

I have a feeling that most of problems are caused by copy & pasting the the code.
