### PR TITLE
Do not flag std::cout and std::cerr as thread unsafe non-const statics

### DIFF
--- a/Utilities/StaticAnalyzers/src/CmsSupport.cpp
+++ b/Utilities/StaticAnalyzers/src/CmsSupport.cpp
@@ -112,7 +112,9 @@ bool support::isSafeClassName(const std::string &cname) {
     "class edm::AtomicPtrCache"
     "std::once_flag",
     "struct std::once_flag",
-    "boost::<anonymous namespace>::extents"
+    "boost::<anonymous namespace>::extents",
+    "cout", "cerr",
+    "std::cout","std::cerr"
   };
   
   for (auto& name: names)


### PR DESCRIPTION
@ktf @Dr15Jones 
