### PR TITLE
Bug fix for NewEventStreamFileReader

### DIFF
--- a/FWCore/Sources/interface/RawInputSource.h
+++ b/FWCore/Sources/interface/RawInputSource.h
@@ -34,8 +34,11 @@ namespace edm {
     virtual void rewind_() override;
     virtual ItemType getNextItemType() override;
     virtual void preForkReleaseResources() override;
+    virtual void closeFile_() override final;
+    virtual void genuineCloseFile() { }
 
     bool inputFileTransitionsEachEvent_;
+    bool fakeInputFileTransition_;
   };
 }
 #endif

--- a/IOPool/Streamer/interface/StreamerInputModule.h
+++ b/IOPool/Streamer/interface/StreamerInputModule.h
@@ -28,7 +28,7 @@ namespace edm
                  InputSourceDescription const& desc);
     virtual ~StreamerInputModule();
   private:
-    virtual void closeFile_() {
+    virtual void genuineCloseFile() override {
       if(pr_.get() != nullptr) pr_->closeFile();
     }
 

--- a/IOPool/Streamer/src/StreamerFileReader.cc
+++ b/IOPool/Streamer/src/StreamerFileReader.cc
@@ -76,7 +76,7 @@ namespace edm {
   }
 
   void
-  StreamerFileReader::closeFile_() {
+  StreamerFileReader::genuineCloseFile() {
     if(streamReader_.get() != nullptr) streamReader_->closeStreamerFile();
   }
 

--- a/IOPool/Streamer/src/StreamerFileReader.h
+++ b/IOPool/Streamer/src/StreamerFileReader.h
@@ -30,7 +30,7 @@ namespace edm {
   private:
     virtual bool checkNextEvent();
     virtual void skip(int toSkip);
-    virtual void closeFile_();
+    virtual void genuineCloseFile() override;
     virtual void reset_();
 
     std::vector<std::string> streamerNames_; // names of Streamer files

--- a/IOPool/Streamer/test/NewStreamIn2_cfg.py
+++ b/IOPool/Streamer/test/NewStreamIn2_cfg.py
@@ -1,0 +1,23 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TRANSFER")
+
+import FWCore.Framework.test.cmsExceptionsFatal_cff
+process.options = FWCore.Framework.test.cmsExceptionsFatal_cff.options
+
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+
+process.source = cms.Source("NewEventStreamFileReader",
+    fileNames = cms.untracked.vstring('file:teststreamfile.dat'),
+    inputFileTransitionsEachEvent = cms.untracked.bool(True)
+)
+
+process.a1 = cms.EDAnalyzer("StreamThingAnalyzer",
+    product_to_get = cms.string('m1')
+)
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('myout11.root')
+)
+
+process.end = cms.EndPath(process.a1*process.out)

--- a/IOPool/Streamer/test/RunSimple_NewStreamer.sh
+++ b/IOPool/Streamer/test/RunSimple_NewStreamer.sh
@@ -18,6 +18,7 @@ cd ${OUTDIR}
 
 cmsRun --parameter-set NewStreamOut_cfg.py > out 2>&1 || die "cmsRun NewStreamOut_cfg.py" $?
 cmsRun --parameter-set NewStreamIn_cfg.py  > in  2>&1 || die "cmsRun NewStreamIn_cfg.py" $?
+cmsRun --parameter-set NewStreamIn2_cfg.py  > in2  2>&1 || die "cmsRun NewStreamIn2_cfg.py" $?
 cmsRun --parameter-set NewStreamCopy_cfg.py  > copy  2>&1 || die "cmsRun NewStreamCopy_cfg.py" $?
 
 # echo "CHECKSUM = 1" > out
@@ -26,6 +27,7 @@ cmsRun --parameter-set NewStreamCopy_cfg.py  > copy  2>&1 || die "cmsRun NewStre
 ANS_OUT_SIZE=`grep -c CHECKSUM out`
 ANS_OUT=`grep CHECKSUM out`
 ANS_IN=`grep CHECKSUM in`
+ANS_IN2=`grep CHECKSUM in2`
 ANS_COPY=`grep CHECKSUM copy`
 
 if [ "${ANS_OUT_SIZE}" == "0" ]
@@ -37,6 +39,12 @@ fi
 if [ "${ANS_OUT}" != "${ANS_IN}" ]
 then
     echo "New Stream Test Failed (out!=in)"
+    RC=1
+fi
+
+if [ "${ANS_OUT}" != "${ANS_IN2}" ]
+then
+    echo "New Stream Test Failed (out!=in2)"
     RC=1
 fi
 


### PR DESCRIPTION
(This fix for 7_2_X is the same fix as PR 6363
for 7_3_X, do not forward this one to 7_3_X as
it will conflict)

Make the inputFileTransitionsEachEvent option work
with NewEventStreamFileReader. This was accidently
broken in 2012, although as far as I know no one
normally uses this option with this source. It was
noticed when someone used the option to debug a
related problem in another source. Added a unit test
so we will notice if this problem recurs.

The bug caused the input file to be prematurely closed
when the fake input file transitions were occurring.
