### PR TITLE
Do not declare class in template instantiation; add missing header

### DIFF
--- a/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
+++ b/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
@@ -35,6 +35,7 @@
 
 #include "JetMETCorrections/Type1MET/interface/JetCorrExtractorT.h"
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
+#include "PhysicsTools/PatUtils/interface/PATJetCorrExtractor.h"
 
 #include <TFile.h>
 #include <TFormula.h>
@@ -241,7 +242,7 @@ template <typename T, typename Textractor>
         edm::Handle<reco::JetCorrector> jetCorr;
         evt.getByToken(jetCorrToken_, jetCorr);
 	corrJetP4 =
-	std::is_base_of<class PATJetCorrExtractor, Textractor>::value ?
+	std::is_base_of<PATJetCorrExtractor, Textractor>::value ?
 	  jetCorrExtractor_(jet, jetCorrLabel_.label(), jetCorrEtaMax_, &rawJetP4) :
 	  jetCorrExtractor_(jet, jetCorr.product(), jetCorrEtaMax_, &rawJetP4);
       }


### PR DESCRIPTION
The package contains two files, which cause Clang to abort (assert):
- `PhysicsTools/PatUtils/plugins/SmearedJetProducer.cc`
- `PhysicsTools/PatUtils/plugins/SmearedPATJetProducer.cc`

After long investigation I stopped here:

```
corrJetP4 =
std::is_base_of<class PATJetCorrExtractor, Textractor>::value ?
  jetCorrExtractor_(jet, jetCorrLabel_.label(), jetCorrEtaMax_, &rawJetP4) :
  jetCorrExtractor_(jet, jetCorr.product(), jetCorrEtaMax_, &rawJetP4);
```

`PATJetCorrExtractor` was nowhere to be found in the translation unit.
We have a class declaration in template instantion.

The patch removes such declaration and includes a header (from the same
package), which declares and defines `PATJetCorrExtractor`.

Resolves both Clang aborts.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
