### PR TITLE
Remove shared_ptr support from EOS Portable Archive

### DIFF
--- a/CondFormats/Serialization/interface/eos/portable_iarchive.hpp
+++ b/CondFormats/Serialization/interface/eos/portable_iarchive.hpp
@@ -89,7 +89,7 @@
 #include <boost/archive/basic_binary_iprimitive.hpp>
 #include <boost/archive/basic_binary_iarchive.hpp>
 
-#if BOOST_VERSION >= 103500
+#if BOOST_VERSION >= 103500 && BOOST_VERSION <= 105500
 #include <boost/archive/shared_ptr_helper.hpp>
 #endif
 
@@ -188,7 +188,7 @@ namespace eos {
 		// load_override functions so we chose to stay one level higher
 		, public boost::archive::basic_binary_iarchive<portable_iarchive>
 
-	#if BOOST_VERSION >= 103500
+	#if BOOST_VERSION >= 103500 && BOOST_VERSION <= 105500
 		// mix-in helper class for serializing shared_ptr
 		, public boost::archive::detail::shared_ptr_helper
 	#endif

--- a/CondFormats/Serialization/interface/eos/portable_oarchive.hpp
+++ b/CondFormats/Serialization/interface/eos/portable_oarchive.hpp
@@ -92,7 +92,7 @@
 #include <boost/archive/basic_binary_oprimitive.hpp>
 #include <boost/archive/basic_binary_oarchive.hpp>
 
-#if BOOST_VERSION >= 103500
+#if BOOST_VERSION >= 103500 && BOOST_VERSION <= 105500
 #include <boost/archive/shared_ptr_helper.hpp>
 #endif
 
@@ -194,7 +194,7 @@ namespace eos {
 		// save_override functions so we chose to stay one level higher
 		, public boost::archive::basic_binary_oarchive<portable_oarchive>
 
-	#if BOOST_VERSION >= 103500
+	#if BOOST_VERSION >= 103500 && BOOST_VERSION <= 105500
 		// mix-in helper class for serializing shared_ptr
 		, public boost::archive::detail::shared_ptr_helper
 	#endif


### PR DESCRIPTION
`boost::archive::detail::shared_ptr_helper` has been replaced by
`boost::serialization::shared_ptr_helper`. Thus `shared_ptr_helper`
ctor/dtor symbols are missing from Boost Serialization library.

```
undefined reference to `boost::archive::detail::shared_ptr_helper
::shared_ptr_helper()'
undefined reference to `boost::archive::detail::shared_ptr_helper
::~shared_ptr_helper()'
```

The new `shared_ptr_helper` implementation is in
`shared_ptr_helper.cpp`, but the file is not listes in `SOURCES` in
`libs/serialization/build/Jamfile.v2`.

Adding it would break Boost Serialization.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
