### PR TITLE
Make vertex collection configurable in class computing MVA for non-isolated electrons.

### DIFF
--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronBaseProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronBaseProducer.cc
@@ -365,8 +365,9 @@ GsfElectronBaseProducer::GsfElectronBaseProducer( const edm::ParameterSet& cfg )
    }
 
 
-   mva_NIso_Cfg_.vweightsfiles=cfg.getParameter<std::vector<std::string>>("SoftElecMVAFilesString");
-   mva_Iso_Cfg_.vweightsfiles=cfg.getParameter<std::vector<std::string>>("ElecMVAFilesString");
+   mva_NIso_Cfg_.vweightsfiles = cfg.getParameter<std::vector<std::string>>("SoftElecMVAFilesString");
+   mva_NIso_Cfg_.vtxCollection = consumes<reco::VertexCollection>(cfg.getParameter<edm::InputTag>("vtxTag"));
+   mva_Iso_Cfg_.vweightsfiles  = cfg.getParameter<std::vector<std::string>>("ElecMVAFilesString");
   // create algo
   algo_ = new GsfElectronAlgo
    ( inputCfg_, strategyCfg_,

--- a/RecoEgamma/EgammaElectronProducers/python/gedGsfElectrons_cfi.py
+++ b/RecoEgamma/EgammaElectronProducers/python/gedGsfElectrons_cfi.py
@@ -162,7 +162,7 @@ gedGsfElectronsTmp = cms.EDProducer("GEDGsfElectronProducer",
  SoftElecMVAFilesString = cms.vstring(
     "RecoEgamma/ElectronIdentification/data/TMVA_BDTSoftElectrons_7Feb2014.weights.xml"
                                 ),
- SoftElecMVAVtxTag = vtxTag,                                   
+ SoftElecMVAVtxTag = cms.InputTag('offlinePrimaryVertices'),
  ElecMVAFilesString = cms.vstring(
      "RecoEgamma/ElectronIdentification/data/TMVA_BDTSimpleCat_17Feb2011.weights.xml"
                                  ),

--- a/RecoEgamma/EgammaElectronProducers/python/gedGsfElectrons_cfi.py
+++ b/RecoEgamma/EgammaElectronProducers/python/gedGsfElectrons_cfi.py
@@ -162,7 +162,6 @@ gedGsfElectronsTmp = cms.EDProducer("GEDGsfElectronProducer",
  SoftElecMVAFilesString = cms.vstring(
     "RecoEgamma/ElectronIdentification/data/TMVA_BDTSoftElectrons_7Feb2014.weights.xml"
                                 ),
- SoftElecMVAVtxTag = cms.InputTag('offlinePrimaryVertices'),
  ElecMVAFilesString = cms.vstring(
      "RecoEgamma/ElectronIdentification/data/TMVA_BDTSimpleCat_17Feb2011.weights.xml"
                                  ),

--- a/RecoEgamma/EgammaElectronProducers/python/gedGsfElectrons_cfi.py
+++ b/RecoEgamma/EgammaElectronProducers/python/gedGsfElectrons_cfi.py
@@ -162,6 +162,7 @@ gedGsfElectronsTmp = cms.EDProducer("GEDGsfElectronProducer",
  SoftElecMVAFilesString = cms.vstring(
     "RecoEgamma/ElectronIdentification/data/TMVA_BDTSoftElectrons_7Feb2014.weights.xml"
                                 ),
+ SoftElecMVAVtxTag = vtxTag,                                   
  ElecMVAFilesString = cms.vstring(
      "RecoEgamma/ElectronIdentification/data/TMVA_BDTSimpleCat_17Feb2011.weights.xml"
                                  ),

--- a/RecoEgamma/EgammaElectronProducers/python/gsfElectrons_cfi.py
+++ b/RecoEgamma/EgammaElectronProducers/python/gsfElectrons_cfi.py
@@ -159,7 +159,8 @@ ecalDrivenGsfElectrons = cms.EDProducer("GsfElectronEcalDrivenProducer",
    useIsolationValues = cms.bool(False),
   SoftElecMVAFilesString = cms.vstring(
     "RecoEgamma/ElectronIdentification/data/TMVA_BDTSoftElectrons_9Dec2013.weights.xml"
-                                ),
+                                ), 
+  SoftElecMVAVtxTag = cms.InputTag('offlinePrimaryVertices'),
   ElecMVAFilesString = cms.vstring(
      "RecoEgamma/ElectronIdentification/data/TMVA_BDTSimpleCat_17Feb2011.weights.xml"
                                  ),
@@ -334,7 +335,7 @@ gsfElectrons = cms.EDProducer("GsfElectronProducer",
    SoftElecMVAFilesString = cms.vstring(
     "RecoEgamma/ElectronIdentification/data/TMVA_BDTSoftElectrons_7Feb2014.weights.xml"
                                 ),
-   SoftElecMVAVtxTag = vtxTag,
+   SoftElecMVAVtxTag = cms.InputTag('offlinePrimaryVertices'),
    ElecMVAFilesString = cms.vstring(
      "RecoEgamma/ElectronIdentification/data/TMVA_BDTSimpleCat_17Feb2011.weights.xml"
                                  ),

--- a/RecoEgamma/EgammaElectronProducers/python/gsfElectrons_cfi.py
+++ b/RecoEgamma/EgammaElectronProducers/python/gsfElectrons_cfi.py
@@ -160,7 +160,6 @@ ecalDrivenGsfElectrons = cms.EDProducer("GsfElectronEcalDrivenProducer",
   SoftElecMVAFilesString = cms.vstring(
     "RecoEgamma/ElectronIdentification/data/TMVA_BDTSoftElectrons_9Dec2013.weights.xml"
                                 ), 
-  SoftElecMVAVtxTag = cms.InputTag('offlinePrimaryVertices'),
   ElecMVAFilesString = cms.vstring(
      "RecoEgamma/ElectronIdentification/data/TMVA_BDTSimpleCat_17Feb2011.weights.xml"
                                  ),
@@ -335,7 +334,6 @@ gsfElectrons = cms.EDProducer("GsfElectronProducer",
    SoftElecMVAFilesString = cms.vstring(
     "RecoEgamma/ElectronIdentification/data/TMVA_BDTSoftElectrons_7Feb2014.weights.xml"
                                 ),
-   SoftElecMVAVtxTag = cms.InputTag('offlinePrimaryVertices'),
    ElecMVAFilesString = cms.vstring(
      "RecoEgamma/ElectronIdentification/data/TMVA_BDTSimpleCat_17Feb2011.weights.xml"
                                  ),

--- a/RecoEgamma/EgammaElectronProducers/python/gsfElectrons_cfi.py
+++ b/RecoEgamma/EgammaElectronProducers/python/gsfElectrons_cfi.py
@@ -334,6 +334,7 @@ gsfElectrons = cms.EDProducer("GsfElectronProducer",
    SoftElecMVAFilesString = cms.vstring(
     "RecoEgamma/ElectronIdentification/data/TMVA_BDTSoftElectrons_7Feb2014.weights.xml"
                                 ),
+   SoftElecMVAVtxTag = vtxTag,
    ElecMVAFilesString = cms.vstring(
      "RecoEgamma/ElectronIdentification/data/TMVA_BDTSimpleCat_17Feb2011.weights.xml"
                                  ),

--- a/RecoEgamma/ElectronIdentification/interface/SoftElectronMVAEstimator.h
+++ b/RecoEgamma/ElectronIdentification/interface/SoftElectronMVAEstimator.h
@@ -12,7 +12,8 @@
 class SoftElectronMVAEstimator {
  public:
   struct Configuration{
-	std::vector<std::string> vweightsfiles;
+    std::vector<std::string> vweightsfiles;
+    edm::InputTag fullPrimaryVertexTag_;
   };
   SoftElectronMVAEstimator(const Configuration & );
   ~SoftElectronMVAEstimator() ;
@@ -27,7 +28,7 @@ class SoftElectronMVAEstimator {
     std::vector<std::string> mvaWeightFiles_;
     std::vector<TMVA::Reader*> fmvaReader;
     TMVA::Reader*    tmvaReader_;
-
+    
     Float_t                    fbrem;
     Float_t                    EtotOvePin;
     Float_t                    EBremOverDeltaP;

--- a/RecoEgamma/ElectronIdentification/interface/SoftElectronMVAEstimator.h
+++ b/RecoEgamma/ElectronIdentification/interface/SoftElectronMVAEstimator.h
@@ -13,7 +13,7 @@ class SoftElectronMVAEstimator {
  public:
   struct Configuration{
     std::vector<std::string> vweightsfiles;
-    edm::InputTag fullPrimaryVertexTag_;
+    edm::EDGetTokenT<reco::VertexCollection> vtxCollection;
   };
   SoftElectronMVAEstimator(const Configuration & );
   ~SoftElectronMVAEstimator() ;

--- a/RecoEgamma/ElectronIdentification/src/SoftElectronMVAEstimator.cc
+++ b/RecoEgamma/ElectronIdentification/src/SoftElectronMVAEstimator.cc
@@ -114,7 +114,7 @@ UInt_t SoftElectronMVAEstimator::GetMVABin(int pu, double eta, double pt) const 
 double SoftElectronMVAEstimator::mva(const reco::GsfElectron& myElectron,const edm::Event & evt)  {
 
  edm::Handle<reco::VertexCollection> FullprimaryVertexCollection;
- evt.getByLabel(cfg_.fullPrimaryVertexTag_, FullprimaryVertexCollection);
+ evt.getByToken(cfg_.vtxCollection, FullprimaryVertexCollection);
  const reco::VertexCollection pvc = *(FullprimaryVertexCollection.product());
  
   fbrem                 	=myElectron.fbrem();

--- a/RecoEgamma/ElectronIdentification/src/SoftElectronMVAEstimator.cc
+++ b/RecoEgamma/ElectronIdentification/src/SoftElectronMVAEstimator.cc
@@ -71,8 +71,8 @@ SoftElectronMVAEstimator::SoftElectronMVAEstimator(const Configuration & cfg):cf
     tmvaReader_->BookMVA("BDT",weightsfiles[i]);
     fmvaReader.push_back(tmvaReader_);
 //    delete tmvaReader_;
-  }
 
+  }
 }
 
 
@@ -114,7 +114,7 @@ UInt_t SoftElectronMVAEstimator::GetMVABin(int pu, double eta, double pt) const 
 double SoftElectronMVAEstimator::mva(const reco::GsfElectron& myElectron,const edm::Event & evt)  {
 
  edm::Handle<reco::VertexCollection> FullprimaryVertexCollection;
- evt.getByLabel("offlinePrimaryVertices", FullprimaryVertexCollection);
+ evt.getByLabel(cfg_.fullPrimaryVertexTag_, FullprimaryVertexCollection);
  const reco::VertexCollection pvc = *(FullprimaryVertexCollection.product());
  
   fbrem                 	=myElectron.fbrem();


### PR DESCRIPTION
The MVA is now computed with the same vertex collection used in the electron producer (previously the collection name was hardcoded).
Additionally migrated one getByLabel to getByToken in the same class.
The change was esplicitly requested by HI people: 
@yetkinyilmaz
@mandrenguyen
@istaslis
