### PR TITLE
bugfix for pixel clustershape filter, and, change HI tracking low-pt seeding from triplet to track

### DIFF
--- a/RecoPixelVertexing/PixelTrackFitting/interface/PixelTrackFilter.h
+++ b/RecoPixelVertexing/PixelTrackFitting/interface/PixelTrackFilter.h
@@ -6,7 +6,7 @@ namespace edm { class Event; class EventSetup; class ConsumesCollector;}
 class TrackingRecHit;
 
 #include <vector>
-
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 
 class PixelTrackFilter {
 public:
@@ -15,5 +15,6 @@ public:
   virtual void update(const edm::Event& ev, const edm::EventSetup& es) = 0;
   virtual bool operator()(const reco::Track*) const {return false;}
   virtual bool operator()(const reco::Track*, const Hits&) const {return false;} 
+  virtual bool operator()(const reco::Track*, const Hits&, const TrackerTopology *tTopo) const {return false;} 
 };
 #endif

--- a/RecoPixelVertexing/PixelTrackFitting/interface/PixelTrackReconstruction.h
+++ b/RecoPixelVertexing/PixelTrackFitting/interface/PixelTrackReconstruction.h
@@ -36,6 +36,7 @@ private:
   std::unique_ptr<OrderedHitsGenerator> theGenerator;
   std::unique_ptr<TrackingRegionProducer> theRegionProducer;
   std::unique_ptr<QuadrupletSeedMerger> theMerger_;
+  bool useClusterShape;
 };
 #endif
 

--- a/RecoPixelVertexing/PixelTrackFitting/src/PixelTrackReconstruction.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/src/PixelTrackReconstruction.cc
@@ -56,6 +56,7 @@ PixelTrackReconstruction::PixelTrackReconstruction(const ParameterSet& cfg,
     if(theConfig.exists("useFilterWithES")) {
       edm::LogInfo("Obsolete") << "useFilterWithES parameter is obsolete and can be removed";
     }
+    useClusterShape = filterPSet.exists("useClusterShape");
   }
 
   ParameterSet orderedPSet =
@@ -129,10 +130,12 @@ void PixelTrackReconstruction::run(TracksWithTTRHs& tracks, edm::Event& ev, cons
       reco::Track* track = theFitter->run( ev, es, hits, region);
       if (!track) continue;
 
-      // decide if track should be skipped according to filter
-      if (theFilter && !(*theFilter)(track, hits) ) {
-        delete track;
-        continue;
+      if (theFilter) {
+	if ((useClusterShape && !(*theFilter)(track, hits, tTopo)) ||
+	    (!useClusterShape && !(*theFilter)(track, hits))) {
+	  delete track;
+	  continue;
+	}
       }
 
       // add tracks


### PR DESCRIPTION
As listed in the commits, first commit is for bugfixing the clustershape filter, removing conflict between two vs three argument version of the operator(). This was a prerequisite for the update of low-pt tracking.

In the second commit, the HI tracking uses tracks instead of triplets in seeding, which is a significant improvement in timing. Details in: https://indico.cern.ch/event/345510/contribution/5/material/slides/0.pdf

This PR requires https://github.com/cms-sw/cmssw/pull/6374 to be merged, in order to run the full HI reco sequence successfully.
