### PR TITLE
Misc errors and warnings cleanup in DQMOffline/Trigger

### DIFF
--- a/DQMOffline/Trigger/interface/EgHLTDebugFuncs.h
+++ b/DQMOffline/Trigger/interface/EgHLTDebugFuncs.h
@@ -1,5 +1,5 @@
 #ifndef DQMOFFLINE_TRIGGER_DEBUGFUNCS
-#define DQMOFFLINE_TRIGGER_DEGUGFUNCS
+#define DQMOFFLINE_TRIGGER_DEBUGFUNCS
 
 //collection of usefull functions adding to debug namespace
 //

--- a/DQMOffline/Trigger/interface/EgHLTEleHLTFilterMon.h
+++ b/DQMOffline/Trigger/interface/EgHLTEleHLTFilterMon.h
@@ -34,8 +34,8 @@ namespace trigger{
 }
 
 namespace egHLT {
-  class BinData;
-  class CutMasks;
+  struct BinData;
+  struct CutMasks;
   class EleHLTFilterMon {
     
   public:

--- a/DQMOffline/Trigger/interface/EgHLTMonElemFuncs.h
+++ b/DQMOffline/Trigger/interface/EgHLTMonElemFuncs.h
@@ -23,7 +23,7 @@
 
 namespace egHLT {
 
-  class CutMasks;
+  struct CutMasks;
 
   namespace MonElemFuncs {
     

--- a/DQMOffline/Trigger/interface/EgHLTPhoHLTFilterMon.h
+++ b/DQMOffline/Trigger/interface/EgHLTPhoHLTFilterMon.h
@@ -33,8 +33,8 @@ namespace trigger{
 }
 
 namespace egHLT {
-  class BinData;
-  class CutMasks;
+  struct BinData;
+  struct CutMasks;
 
   class PhoHLTFilterMon {
     

--- a/DQMOffline/Trigger/interface/HLTInclusiveVBFSource.h
+++ b/DQMOffline/Trigger/interface/HLTInclusiveVBFSource.h
@@ -71,12 +71,9 @@ class HLTInclusiveVBFSource : public edm::EDAnalyzer {
   //virtual double TriggerPosition(std::string trigName);
   
   // ----------member data --------------------------- 
-  int nev_;
   int nCount_;
   DQMStore * dbe;
       
-  MonitorElement* total_;
-
   std::vector<int>  prescUsed_;
   
   std::string dirname_;
@@ -185,13 +182,10 @@ class HLTInclusiveVBFSource : public edm::EDAnalyzer {
   double hlt_deltaphijet;
   double hlt_invmassjet;
   
-  // data across paths
-  MonitorElement* scalersSelect;
   // helper class to store the data path
   
   class PathInfo {
     PathInfo():
-      pathIndex_(-1), 
       prescaleUsed_(-1), 
       pathName_("unset"), 
       filterName_("unset"), 
@@ -293,7 +287,6 @@ class HLTInclusiveVBFSource : public edm::EDAnalyzer {
       }
       
   private:
-      int pathIndex_;
       int prescaleUsed_;
       std::string pathName_;
       std::string filterName_;

--- a/DQMOffline/Trigger/interface/HLTTauDQMPath.h
+++ b/DQMOffline/Trigger/interface/HLTTauDQMPath.h
@@ -17,7 +17,7 @@ namespace trigger {
   class TriggerEvent;
   class TriggerObject;
 }
-class HLTTauDQMOfflineObjects;
+struct HLTTauDQMOfflineObjects;
 
 class HLTTauDQMPath {
 public:

--- a/DQMOffline/Trigger/interface/JetMETHLTOfflineSource.h
+++ b/DQMOffline/Trigger/interface/JetMETHLTOfflineSource.h
@@ -181,7 +181,6 @@ class JetMETHLTOfflineSource : public thread_unsafe::DQMEDAnalyzer {
 
   class PathInfo {
     PathInfo():
-      pathIndex_(-1),
       prescaleUsed_(-1),
       denomPathName_("unset"),
       pathName_("unset"),
@@ -776,7 +775,6 @@ class JetMETHLTOfflineSource : public thread_unsafe::DQMEDAnalyzer {
       }
 
   private:
-      int pathIndex_;
       int prescaleUsed_;
       std::string denomPathName_;
       std::string pathName_;
@@ -811,8 +809,6 @@ class JetMETHLTOfflineSource : public thread_unsafe::DQMEDAnalyzer {
       MonitorElement*  Eta_HLT_;
       MonitorElement*  Phi_HLT_;
       MonitorElement*  EtaPhi_HLT_;
-      MonitorElement*  DeltaR_HLT_;
-      MonitorElement*  DeltaPhi_HLT_;
 
       MonitorElement*  PtResolution_L1HLT_;
       MonitorElement*  EtaResolution_L1HLT_;

--- a/DQMOffline/Trigger/src/HLTInclusiveVBFSource.cc
+++ b/DQMOffline/Trigger/src/HLTInclusiveVBFSource.cc
@@ -123,19 +123,10 @@ HLTInclusiveVBFSource::analyze(const edm::Event& iEvent, const edm::EventSetup& 
       return;
     }
   }
-  //
-  //int npath;
-  if(&triggerResults_) {
-    // Check how many HLT triggers are in triggerResults
-    //npath = triggerResults_->size();
-    triggerNames_ = iEvent.triggerNames(*triggerResults_);
-  } 
-  else {
-    edm::LogInfo("CaloMETHLTOfflineSource") << "TriggerResults::HLT not found, "
-      "automatically select events";
-    return;
-  }
-  //
+
+  // Check how many HLT triggers are in triggerResults
+  triggerNames_ = iEvent.triggerNames(*triggerResults_);
+
   //---------- triggerSummary ----------
   iEvent.getByToken(triggerSummaryToken,triggerObj_);
   if(!triggerObj_.isValid()) {
@@ -763,9 +754,8 @@ bool HLTInclusiveVBFSource::validPathHLT(std::string pathname){
 bool HLTInclusiveVBFSource::isHLTPathAccepted(std::string pathName){
   // triggerResults_, triggerNames_ has to be defined first before calling this method
   bool output=false;
-  if(&triggerResults_) {
+  if(triggerResults_.isValid()) {
     unsigned index = triggerNames_.triggerIndex(pathName);
-    //std::cout<<" -index = "<<index<<endl;
     if(index < triggerNames_.size() && triggerResults_->accept(index)) output = true;
   }
   return output;

--- a/DQMOffline/Trigger/src/HLTMuonCertSummary.cc
+++ b/DQMOffline/Trigger/src/HLTMuonCertSummary.cc
@@ -241,7 +241,7 @@ HLTMuonCertSummary::dqmEndJob(DQMStore::IBooker & iBooker, DQMStore::IGetter & i
         reportSummaryMapTH2->SetBinContent(reportSummaryMapTH2->GetBin(1,1), qtstatus);
         CertificationSummaryMapTH2->SetBinContent(CertificationSummaryMapTH2->GetBin(1,1), qtstatus );
         if ( (qtstatus == 200) && (SummaryBitResult < 300)) SummaryBitResult = 200;
-        if ( (qtstatus == 300) ) SummaryBitResult = 300;
+        if ( qtstatus == 300 ) SummaryBitResult = 300;
 
       }
 

--- a/DQMOffline/Trigger/src/JetMETHLTOfflineSource.cc
+++ b/DQMOffline/Trigger/src/JetMETHLTOfflineSource.cc
@@ -1574,8 +1574,8 @@ JetMETHLTOfflineSource::bookHistograms(DQMStore::IBooker & iBooker, edm::Run con
     if(plotAll_){
       //
       int Nbins_       = 10;
-      int Nmin_        = -0.5;
-      int Nmax_        = 9.5;
+      double Nmin_        = -0.5;
+      double Nmax_        = 9.5;
       //
       int Ptbins_      = 100;
       if(runStandalone_) Ptbins_ = 1000;

--- a/DQMOffline/Trigger/src/JetMETHLTOfflineSource.cc
+++ b/DQMOffline/Trigger/src/JetMETHLTOfflineSource.cc
@@ -124,17 +124,7 @@ JetMETHLTOfflineSource::analyze(const edm::Event& iEvent, const edm::EventSetup&
   }
   
   //---------- triggerResults ----------
-  //int npath;
-  if(&triggerResults_) {  
-    // Check how many HLT triggers are in triggerResults
-    //npath = triggerResults_->size();
-    triggerNames_ = iEvent.triggerNames(*triggerResults_);
-  } 
-  else {
-    edm::LogInfo("JetMETHLTOfflineSource") << "TriggerResults::HLT not found, "
-      "automatically select events";
-    return;
-  } 
+  triggerNames_ = iEvent.triggerNames(*triggerResults_);
   
   //---------- triggerSummary ----------
   iEvent.getByToken(triggerSummaryToken,triggerObj_);
@@ -383,9 +373,7 @@ JetMETHLTOfflineSource::fillMEforMonTriggerSummary(const Event & iEvent, const e
 void 
 JetMETHLTOfflineSource::fillMEforTriggerNTfired()
 {
-  //int npath;
-  if(&triggerResults_) { /*npath = triggerResults_->size();*/ } 
-  else { return; }
+  if(!triggerResults_.isValid()) return;
   
   //
   for(PathInfoCollection::iterator v = hltPathsAll_.begin(); v!= hltPathsAll_.end(); ++v ){
@@ -445,9 +433,7 @@ JetMETHLTOfflineSource::fillMEforTriggerNTfired()
 void 
 JetMETHLTOfflineSource::fillMEforMonAllTrigger(const Event & iEvent, const edm::EventSetup& iSetup)
 {
-  //int npath;
-  if(&triggerResults_) { /*npath = triggerResults_->size();*/ } 
-  else { return; }
+  if(!triggerResults_.isValid()) return;
   
   const trigger::TriggerObjectCollection & toc(triggerObj_->getObjects());
   PathInfoCollection::iterator v = hltPathsAll_.begin();
@@ -736,9 +722,7 @@ JetMETHLTOfflineSource::fillMEforMonAllTrigger(const Event & iEvent, const edm::
 void 
 JetMETHLTOfflineSource::fillMEforEffAllTrigger(const Event & iEvent, const edm::EventSetup& iSetup)
 {
-  //int npath;
-  if(&triggerResults_){ /*npath = triggerResults_->size();*/ } 
-  else return;
+  if (!triggerResults_.isValid()) return;
   
   int  num         = -1;
   int  denom       = -1;
@@ -2964,7 +2948,7 @@ bool JetMETHLTOfflineSource::validPathHLT(std::string pathname){
 bool JetMETHLTOfflineSource::isHLTPathAccepted(std::string pathName){
   // triggerResults_, triggerNames_ has to be defined first before calling this method
   bool output=false;
-  if(&triggerResults_) {
+  if(triggerResults_.isValid()) {
     unsigned index = triggerNames_.triggerIndex(pathName);
     if(index < triggerNames_.size() && triggerResults_->accept(index)) output = true;
   }


### PR DESCRIPTION
The following patchset cleanups all Clang reported errors and majority of reported warnings. Warnings from RooFit were [fixed today](http://root.cern.ch/gitweb?p=root.git;a=commitdiff;h=de35d07d9f9bde5ded6a97ddef4e0763d8e3a78a) for future 5.34.XX patch releases.

This is needed to compile with Clang.

Please, review.
