### PR TITLE
Use new function TEnum::GetQualifiedName()

### DIFF
--- a/FWCore/Utilities/src/TypeWithDict.cc
+++ b/FWCore/Utilities/src/TypeWithDict.cc
@@ -426,7 +426,7 @@ namespace edm {
   std::string
   TypeWithDict::name() const {
     if(enum_ != nullptr && *ti_ == typeid(int)) {
-      return std::string(enum_->GetClass()->GetName()) + "::" + enum_->GetName();
+      return enum_->GetQualifiedName();
     }
     return TypeID(*ti_).className();
   }


### PR DESCRIPTION
In order to fix a problem causing a failing unit test (PhysicsTools/PatAlgos), a new ROOT function, TEnum::GetQualifiedName() was needed, as well as some other ROOT changes.
As part of the fix, CMSSW needs to call the new function.  This pull request replaces an obsoleted call with a call to the new function.
Please merge this request for the same IB in which ROOT6 is being updated to the HEAD of the patches branch, as the changes are mutually dependent.
If this request is merged without updating ROOT6, a compilation error will result.
