### PR TITLE
Make getting Process ParameterSet thread-safe

### DIFF
--- a/FWCore/Framework/test/stubs/HistoryAnalyzer.cc
+++ b/FWCore/Framework/test/stubs/HistoryAnalyzer.cc
@@ -83,7 +83,8 @@ namespace edmtest {
     }
 
     if (eventCount_ == 0) {
-      edm::ParameterSet const& proc_pset = edm::getProcessParameterSet();
+      edm::ParameterSet proc_pset;
+      event.getProcessParameterSet(event.processHistory().rbegin()->processName(),proc_pset);
 
       edm::pset::Registry* reg = edm::pset::Registry::instance();
 

--- a/FWCore/ParameterSet/interface/Registry.h
+++ b/FWCore/ParameterSet/interface/Registry.h
@@ -97,7 +97,7 @@ namespace edm {
     /// Return the ParameterSetID of the top-level ParameterSet.
     /// Note the the returned ParameterSetID may be invalid;
     /// this will happen if the Registry has not yet been filled.
-    ParameterSetID const& getProcessParameterSetID();
+    ParameterSetID getProcessParameterSetID();
   }  // namespace pset
 
   ParameterSet const& getProcessParameterSet();


### PR DESCRIPTION
The static analyzer was complaining about the access so I made it safe.
The use of a mutex in this context shouldn't be a performance problem since it is used very infrequently and normally before the event loop has begun.

NOTE: We should eventually have a campaign to remove the use of this function since it has no reliable meaning when a job contains a SubProcess.
