### PR TITLE
Cleanup of refVector() and ptrVector() calls to edm::View<T>

### DIFF
--- a/CommonTools/CandAlgos/plugins/CandViewRefMerger.cc
+++ b/CommonTools/CandAlgos/plugins/CandViewRefMerger.cc
@@ -26,9 +26,8 @@ private:
     for(std::vector<edm::EDGetTokenT<reco::CandidateView> >::const_iterator i = srcTokens_.begin(); i != srcTokens_.end(); ++i) {
       edm::Handle<reco::CandidateView> src;
       evt.getByToken(*i, src);
-      reco::CandidateBaseRefVector refs = src->refVector();
-      for(reco::CandidateBaseRefVector::const_iterator j = refs.begin(); j != refs.end(); ++j)
-	out->push_back(*j);
+      for(size_t j = 0; j < src->size(); ++j)
+	out->push_back(src->refAt(j));
     }
     evt.put(out);
   }

--- a/DPGAnalysis/Skims/src/TagProbeMassProducer.cc
+++ b/DPGAnalysis/Skims/src/TagProbeMassProducer.cc
@@ -87,8 +87,14 @@ TagProbeMassProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
    // Loop over Tag and associate with Probes
    if( tags.isValid() && probes.isValid() )
    {
-      const edm::RefToBaseVector<reco::Candidate>& vtags = tags->refVector();
-      const edm::RefToBaseVector<reco::Candidate>& vprobes = probes->refVector();
+      edm::RefToBaseVector<reco::Candidate> vtags;
+      for (size_t i = 0; i < tags->size(); ++i) {
+         vtags.push_back(tags->refAt(i));
+      }
+      edm::RefToBaseVector<reco::Candidate> vprobes;
+      for (size_t i = 0; i < probes->size(); ++i) {
+         vprobes.push_back(probes->refAt(i));
+      }
 
       int itag = 0;
       edm::RefToBaseVector<reco::Candidate>::const_iterator tag = vtags.begin();

--- a/DPGAnalysis/Skims/src/TriggerMatchProducer.icc
+++ b/DPGAnalysis/Skims/src/TriggerMatchProducer.icc
@@ -181,8 +181,12 @@ void TriggerMatchProducer<object>::produce(edm::Event &event, const edm::EventSe
      }
    
    // Loop over the candidate collection
-   const edm::PtrVector<object>& ptrVect = candHandle->ptrVector();
-   const edm::RefToBaseVector<object>& refs = candHandle->refVector();
+   edm::PtrVector<object> ptrVect;
+   edm::RefToBaseVector<object> refs;
+   for (size_t i = 0; i < candHandle->size(); ++i) {
+     ptrVect.push_back(candHandle->ptrAt(i));
+     refs.push_back(candHandle->refAt(i));
+   }
    // find how many objects there are
    unsigned int counter=0;
    for( typename edm::View< object>::const_iterator j = candHandle->begin(); 

--- a/DataFormats/Common/interface/RefToBaseVector.h
+++ b/DataFormats/Common/interface/RefToBaseVector.h
@@ -36,8 +36,6 @@ namespace edm {
     explicit RefToBaseVector(REFV const& );
     template<typename C>
     explicit RefToBaseVector(Handle<C> const& );
-    template<typename T1>
-    explicit RefToBaseVector(Handle<View<T1> > const& );
     RefToBaseVector(std::shared_ptr<reftobase::RefVectorHolderBase> p);
     RefToBaseVector& operator=(RefToBaseVector const& iRHS);
     void swap(RefToBaseVector& other);
@@ -280,7 +278,6 @@ namespace edm {
 
 #include "DataFormats/Common/interface/RefVector.h"
 #include "DataFormats/Common/interface/Handle.h"
-#include "DataFormats/Common/interface/View.h"
 
 namespace edm {
 
@@ -289,12 +286,6 @@ namespace edm {
   RefToBaseVector<T>::RefToBaseVector(const Handle<C> & h ) :
     holder_(new reftobase::VectorHolder<T, RefVector<C, typename refhelper::ValueTrait<C>::value, 
 	    typename refhelper::FindTrait<C, T>::value> >(h.id())) {
-  }
-
-  template<typename T>
-  template<typename T1>
-  RefToBaseVector<T>::RefToBaseVector(const Handle<View<T1> > & h ) :
-    holder_(h->refVector().holder_->cloneEmpty()) {
   }
 
 }

--- a/EgammaAnalysis/ElectronTools/test/ElectronIDValidationAnalyzer.cc
+++ b/EgammaAnalysis/ElectronTools/test/ElectronIDValidationAnalyzer.cc
@@ -192,9 +192,8 @@ ElectronIDValidationAnalyzer::analyze(const edm::Event& iEvent, const edm::Event
    iEvent.getByToken(convToken_, convs);
    iEvent.getByToken(beamToken_, thebs);
 
-   const auto& ele_refs = collection->refVector();
- 
-   for( const auto& el : ele_refs ) {
+   for( size_t i = 0; i < collection->size(); ++i ) {
+     auto el = collection->refAt(i);
      pt_ = el->pt();
      etaSC_ = el->superCluster()->eta();
 

--- a/EgammaAnalysis/ElectronTools/test/MiniAODElectronIDValidationAnalyzer.cc
+++ b/EgammaAnalysis/ElectronTools/test/MiniAODElectronIDValidationAnalyzer.cc
@@ -202,9 +202,8 @@ MiniAODElectronIDValidationAnalyzer::analyze(const edm::Event& iEvent, const edm
   iEvent.getByToken(convToken_, convs);
   iEvent.getByToken(beamToken_, thebs);
   
-  const auto& ele_refs = collection->refVector();
-  
-  for( const auto& el : ele_refs ) {
+  for( size_t i = 0; i < collection->size(); ++i ) {
+    auto el = collection->refAt(i);
     pt_ = el->pt();
     etaSC_ = el->superCluster()->eta();
     

--- a/FWCore/Framework/test/stubs/ToyRefProducers.cc
+++ b/FWCore/Framework/test/stubs/ToyRefProducers.cc
@@ -98,7 +98,11 @@ namespace edmtest {
     e.getByLabel(target_, input);
     assert(input.isValid());
 
-    std::unique_ptr<product_type> prod(new product_type(input->refVector()));
+    edm::RefToBaseVector<int> refVector;
+    for (size_t i = 0; i < input->size(); ++i)
+      refVector.push_back(input->refAt(i));
+
+    std::unique_ptr<product_type> prod(new product_type(refVector));
     e.put(std::move(prod));
   }
 

--- a/MuonAnalysis/MuonAssociators/plugins/MuonMCClassifier.cc
+++ b/MuonAnalysis/MuonAssociators/plugins/MuonMCClassifier.cc
@@ -203,7 +203,10 @@ MuonMCClassifier::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     edm::RefToBaseVector<reco::Muon> selMuons;
     if (!hasMuonCut_) {
         // all muons
-        selMuons = muons->refVector();
+        for (size_t i = 0, n = muons->size(); i < n; ++i) {
+            edm::RefToBase<reco::Muon> rmu = muons->refAt(i);
+            selMuons.push_back(rmu);
+        }
     } else {
         // filter, fill refvectors, associate
         // I pass through pat::Muon so that I can access muon id selectors

--- a/PhysicsTools/IsolationAlgos/plugins/CITKPFIsolationSumProducer.cc
+++ b/PhysicsTools/IsolationAlgos/plugins/CITKPFIsolationSumProducer.cc
@@ -132,7 +132,8 @@ namespace citk {
     }
     reco::PFCandidate helper; // to translate pdg id to type    
     // loop over the candidates we are isolating and fill the values
-    for( const auto& cand_to_isolate : to_isolate->ptrVector() ) {
+    for( size_t c = 0; c < to_isolate->size(); ++c ) {
+      auto cand_to_isolate = to_isolate->ptrAt(c);
       std::array<std::vector<float>,kNPFTypes> cand_values;      
       unsigned k = 0;
       for( const auto& isolators_for_type : _isolation_types ) {
@@ -140,7 +141,8 @@ namespace citk {
 	for( auto& value : cand_values[k] ) value = 0.0;
 	++k;
       }
-      for( const auto& isocand : isolate_with->ptrVector() ) {
+      for( size_t ic = 0; ic < isolate_with->size(); ++ic ) {
+        auto isocand = isolate_with->ptrAt(ic);
 	auto isotype = helper.translatePdgIdToType(isocand->pdgId());	
 	const auto& isolations = _isolation_types[isotype];	
 	for( unsigned i = 0; i < isolations.size(); ++ i  ) {

--- a/PhysicsTools/SelectorUtils/interface/VersionedIdProducer.h
+++ b/PhysicsTools/SelectorUtils/interface/VersionedIdProducer.h
@@ -124,7 +124,8 @@ produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
     std::vector<bool> passfail;
     std::vector<float> passfailf;
     std::vector<unsigned> howfar;
-    for(const auto& po : physicsobjects.ptrVector()) {
+    for(size_t i = 0; i < physicsobjects.size(); ++i) {
+      auto po = physicsobjects.ptrAt(i);
       passfail.push_back((*id)(po,iEvent));
       passfailf.push_back(passfail.back());
       howfar.push_back(id->howFarInCutFlow());

--- a/PhysicsTools/TagAndProbe/plugins/ElectronMatchedCandidateProducer.cc
+++ b/PhysicsTools/TagAndProbe/plugins/ElectronMatchedCandidateProducer.cc
@@ -59,8 +59,6 @@ void ElectronMatchedCandidateProducer::produce(edm::Event &event,
   event.getByToken( scCollectionToken_ , recoCandColl);
 
 
-  const edm::PtrVector<reco::Candidate>& ptrVect = recoCandColl->ptrVector();
-  const edm::RefToBaseVector<reco::Candidate>& refs = recoCandColl->refVector();
   unsigned int counter=0;
 
   // Loop over candidates
@@ -77,8 +75,8 @@ void ElectronMatchedCandidateProducer::produce(edm::Event &event,
 
       if( dRval < delRMatchingCut_ ) {
 	//outCol->push_back( *scIt );
-	outColRef->push_back( refs[counter] );
-	outColPtr->push_back( ptrVect[counter]  );
+	outColRef->push_back( recoCandColl->refAt(counter) );
+	outColPtr->push_back( recoCandColl->ptrAt(counter) );
       } // end if loop
     } // end electron loop
 

--- a/PhysicsTools/TagAndProbe/src/TriggerCandProducer.icc
+++ b/PhysicsTools/TagAndProbe/src/TriggerCandProducer.icc
@@ -259,8 +259,6 @@ void TriggerCandProducer<object>::produce(edm::Event &event, const edm::EventSet
    bool firedHLT = (trgIndex < trgNames.size()) && (pTrgResults->accept(trgIndex));
 
    // Loop over the candidate collection
-   // const edm::PtrVector<object>& ptrVect = candHandle->ptrVector();
-   const edm::RefToBaseVector<object>& refs = candHandle->refVector();
    unsigned int counter=0;
 
    for( typename edm::View< object>::const_iterator j = candHandle->begin();
@@ -279,8 +277,8 @@ void TriggerCandProducer<object>::produce(edm::Event &event, const edm::EventSet
      }
 
      if(hltTrigger && firedHLT) {
-       outColRef->push_back( refs[counter] );
-       //outColPtr->push_back( ptrVect[counter] );
+       outColRef->push_back( candHandle->refAt(counter) );
+       //outColPtr->push_back( candHandle->ptrAt(counter) );
      }
    }
 

--- a/RecoEcal/EgammaClusterAlgos/src/PFECALSuperClusterAlgo.cc
+++ b/RecoEcal/EgammaClusterAlgos/src/PFECALSuperClusterAlgo.cc
@@ -232,9 +232,9 @@ loadAndSortPFClusters(const edm::Event &iEvent) {
   _clustersEE.clear();  
   EEtoPS_ = &psclusters;
 
-  auto clusterPtrs = clusters.ptrVector(); 
   //Select PF clusters available for the clustering
-  for ( auto& cluster : clusterPtrs ){
+  for ( size_t i = 0; i < clusters.size(); ++i ){
+    auto cluster = clusters.ptrAt(i);
     LogDebug("PFClustering") 
       << "Loading PFCluster i="<<cluster.key()
       <<" energy="<<cluster->energy()<<std::endl;

--- a/RecoEgamma/EgammaPhotonProducers/src/ConversionProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/ConversionProducer.cc
@@ -195,7 +195,11 @@ ConversionProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
   //build map of ConversionTracks ordered in eta
   std::multimap<float, edm::Ptr<reco::ConversionTrack> > convTrackMap;
-  for (edm::PtrVector<reco::ConversionTrack>::const_iterator tk_ref = trackCollectionHandle->ptrVector().begin(); tk_ref != trackCollectionHandle->ptrVector().end(); ++tk_ref ){
+  edm::PtrVector<reco::ConversionTrack> trackPtrVector;
+  for (size_t i = 0; i < trackCollectionHandle->size(); ++i)
+    trackPtrVector.push_back(trackCollectionHandle->ptrAt(i));
+
+  for (edm::PtrVector<reco::ConversionTrack>::const_iterator tk_ref = trackPtrVector.begin(); tk_ref != trackPtrVector.end(); ++tk_ref ){
     convTrackMap.insert(std::make_pair((*tk_ref)->track()->eta(),*tk_ref));
   }
 

--- a/RecoEgamma/EgammaPhotonProducers/src/ConversionTrackProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/ConversionTrackProducer.cc
@@ -129,7 +129,7 @@ ConversionTrackProducer::ConversionTrackProducer(edm::ParameterSet const& conf) 
    
  
     // Simple conversion of tracks to conversion tracks, setting appropriate flags from configuration
-    for (edm::RefToBaseVector<reco::Track>::const_iterator it = hTrks->refVector().begin(); it != hTrks->refVector().end(); ++it) {
+    for (size_t i = 0; i < hTrks->size(); ++i) {
  
       //--------------------------------------------------
       //Added by D. Giordano
@@ -137,12 +137,12 @@ ConversionTrackProducer::ConversionTrackProducer(edm::ParameterSet const& conf) 
       // Reduction of the track sample based on geometric hypothesis for conversion tracks
       
       math::XYZVector beamSpot=  math::XYZVector(beamSpotHandle->position());
-
-      if( filterOnConvTrackHyp && ConvTrackPreSelector.isTangentPointDistanceLessThan( minConvRadius, it->get(), beamSpot )  )
+      edm::RefToBase<reco::Track> trackBaseRef = hTrks->refAt(i);
+      if( filterOnConvTrackHyp && ConvTrackPreSelector.isTangentPointDistanceLessThan( minConvRadius, trackBaseRef.get(), beamSpot )  )
 	continue;
       //--------------------------------------------------
 
-      reco::ConversionTrack convTrack(*it);
+      reco::ConversionTrack convTrack(trackBaseRef);
       convTrack.setIsTrackerOnly(setTrackerOnly);
       convTrack.setIsArbitratedEcalSeeded(setArbitratedEcalSeeded);
       convTrack.setIsArbitratedMerged(setArbitratedMerged);
@@ -151,10 +151,10 @@ ConversionTrackProducer::ConversionTrackProducer(edm::ParameterSet const& conf) 
       //fill trajectory association if configured, using correct map depending on track type
       if (useTrajectory) {
         if (gsftracktrajmap.size()) {
-          convTrack.setTrajRef(gsftracktrajmap.find(it->castTo<reco::GsfTrackRef>())->second);
+          convTrack.setTrajRef(gsftracktrajmap.find(trackBaseRef.castTo<reco::GsfTrackRef>())->second);
         }
         else {
-          convTrack.setTrajRef(tracktrajmap.find(it->castTo<reco::TrackRef>())->second);
+          convTrack.setTrajRef(tracktrajmap.find(trackBaseRef.castTo<reco::TrackRef>())->second);
         }
       }
       

--- a/RecoEgamma/ElectronIdentification/plugins/ElectronIDValueMapProducer.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/ElectronIDValueMapProducer.cc
@@ -99,7 +99,7 @@ void ElectronIDValueMapProducer::produce(edm::Event& iEvent, const edm::EventSet
   iEvent.getByToken(src_, src);
   
   if( dataFormat_ == "PAT" && src->size() ) {
-    edm::Ptr<pat::Electron> test(src->ptrVector()[0]);
+    edm::Ptr<pat::Electron> test(src->ptrAt(0));
     if( test.isNull() || !test.isAvailable() ) {
       throw cms::Exception("InvalidConfiguration")
 	<<"DataFormat set to \"PAT\" but cannot cast to pat::Electron!";
@@ -112,8 +112,8 @@ void ElectronIDValueMapProducer::produce(edm::Event& iEvent, const edm::EventSet
   std::vector<float> eleFull5x5E1x5,eleFull5x5E2x5,eleFull5x5E5x5;
   
   // reco::GsfElectron::superCluster() is virtual so we can exploit polymorphism
-  for (const auto& iEle : src->ptrVector()){
-    
+  for (size_t i = 0; i < src->size(); ++i){
+    auto iEle = src->ptrAt(i);
     const auto& theseed = *(iEle->superCluster()->seed());
 
     std::vector<float> vCov = lazyToolnoZS->localCovariances( theseed );

--- a/RecoTauTag/TauTagTools/interface/CastedRefProducer.h
+++ b/RecoTauTag/TauTagTools/interface/CastedRefProducer.h
@@ -43,10 +43,9 @@ class CastedRefProducer : public edm::EDProducer {
       edm::Handle<edm::View<BaseType> > input;
       evt.getByLabel(src_, input);
       // Get references to the base
-      const base_ref_vector &baseRefs = input->refVector();
-      for(size_t i = 0; i < baseRefs.size(); ++i) {
+      for(size_t i = 0; i < input->size(); ++i) {
         // Cast the base class to the derived class
-        base_ref base = baseRefs.at(i);
+        base_ref base = input->refAt(i);
         derived_ref derived = base.template castTo<derived_ref>();
         coll->push_back(derived);
       }

--- a/RecoTauTag/TauTagTools/plugins/CandViewRefRandomSelector.cc
+++ b/RecoTauTag/TauTagTools/plugins/CandViewRefRandomSelector.cc
@@ -51,18 +51,18 @@ bool CandViewRefRandomSelector::filter(edm::Event& evt,
   std::auto_ptr<reco::CandidateBaseRefVector> output(
       new reco::CandidateBaseRefVector(cands));
   // If we don't have enough elements to select, just copy what we have
-  const reco::CandidateBaseRefVector &inputRefs = cands->refVector();
-  if (inputRefs.size() <= choose_) {
-    *output = inputRefs;
+  if (cands->size() <= choose_) {
+    for (size_t i = 0; i < cands->size(); ++i)
+        output->push_back(cands->refAt(i));
   } else {
-    for (size_t i = 0; i < inputRefs.size() && output->size() < choose_; ++i) {
+    for (size_t i = 0; i < cands->size() && output->size() < choose_; ++i) {
       // based on http://stackoverflow.com/questions/48087/
       // select-a-random-n-elements-from-listt-in-c/48089#48089
       double selectionProb =
-          (choose_ - output->size())*1.0/(inputRefs.size() - i);
+          (choose_ - output->size())*1.0/(cands->size() - i);
       // throw a number to see if we select this element
       if (randy_.Rndm() < selectionProb)
-        output->push_back(inputRefs[i]);
+        output->push_back(cands->refAt(i));
     }
   }
   size_t outputSize = output->size();

--- a/RecoTauTag/TauTagTools/plugins/CandViewRefTriggerBiasRemover.cc
+++ b/RecoTauTag/TauTagTools/plugins/CandViewRefTriggerBiasRemover.cc
@@ -48,7 +48,7 @@ void CandViewRefTriggerBiasRemover::produce(edm::Event& evt,
   if (nCands > 1) {
     //output->reserve(nCands);
     for (size_t iCand = 0; iCand < nCands; ++iCand) {
-      output->push_back(cands->refVector().at(iCand));
+      output->push_back(cands->refAt(iCand));
     }
   }
   evt.put(output);

--- a/SimMuon/MCTruth/src/MuonAssociatorByHits.cc
+++ b/SimMuon/MCTruth/src/MuonAssociatorByHits.cc
@@ -1387,7 +1387,11 @@ void MuonAssociatorByHits::associateMuons(MuonToSimCollection & recToSim, SimToM
     for (unsigned int j=0; j<tPCH->size();j++)
       tpc.push_back(edm::Ref<TrackingParticleCollection>(tPCH,j));
     
-    associateMuons(recToSim, simToRec, tCH->refVector(),type,tpc,event,setup);
+    edm::RefToBaseVector<reco::Muon> muonBaseRefVector;
+    for (size_t i = 0; i < tCH->size(); ++i)
+      muonBaseRefVector.push_back(tCH->refAt(i));
+
+    associateMuons(recToSim, simToRec, muonBaseRefVector,type,tpc,event,setup);
 }
 
 void MuonAssociatorByHits::associateMuons(MuonToSimCollection & recToSim, SimToMuonCollection & simToRec,

--- a/SimTracker/TrackAssociation/interface/TrackAssociatorBase.h
+++ b/SimTracker/TrackAssociation/interface/TrackAssociatorBase.h
@@ -43,9 +43,9 @@ class TrackAssociatorBase {
 						       edm::Handle<TrackingParticleCollection>& tPCH, 
 						       const edm::Event * event ,
                                                        const edm::EventSetup * setup ) const {
-    edm::RefToBaseVector<reco::Track> tc(tCH);
+    edm::RefToBaseVector<reco::Track> tc;
     for (unsigned int j=0; j<tCH->size();j++)
-      tc.push_back(edm::RefToBase<reco::Track>(tCH,j));
+      tc.push_back(tCH->refAt(j));
 
     edm::RefVector<TrackingParticleCollection> tpc(tPCH.id());
     for (unsigned int j=0; j<tPCH->size();j++)
@@ -59,9 +59,9 @@ class TrackAssociatorBase {
 						       edm::Handle<TrackingParticleCollection>& tPCH,
 						       const edm::Event * event ,
                                                        const edm::EventSetup * setup ) const {
-    edm::RefToBaseVector<reco::Track> tc(tCH);
+    edm::RefToBaseVector<reco::Track> tc;
     for (unsigned int j=0; j<tCH->size();j++)
-      tc.push_back(edm::RefToBase<reco::Track>(tCH,j));
+      tc.push_back(tCH->refAt(j));
 
     edm::RefVector<TrackingParticleCollection> tpc(tPCH.id());
     for (unsigned int j=0; j<tPCH->size();j++)

--- a/Validation/RecoMuon/src/RecoMuonValidator.cc
+++ b/Validation/RecoMuon/src/RecoMuonValidator.cc
@@ -680,7 +680,9 @@ void RecoMuonValidator::analyze(const Event& event, const EventSetup& eventSetup
   const TrackingParticleCollection::size_type nSim = simColl.size();
 
   edm::RefToBaseVector<reco::Muon> Muons;
-  Muons = muonHandle->refVector();
+  for (size_t i = 0; i < muonHandle->size(); ++i) {
+      Muons.push_back(muonHandle->refAt(i));
+  }
 
   edm::RefVector<TrackingParticleCollection> allTPs;
   for (size_t i = 0; i < nSim; ++i) {


### PR DESCRIPTION
Cleanup of refVector() and ptrVector() calls to edm::View<T>. This is a follow-up to #6245.

@Dr15Jones  @arizzi
