### PR TITLE
DB account for ORA tests moved to prep

### DIFF
--- a/CondCore/ORA/test/TestBase.h
+++ b/CondCore/ORA/test/TestBase.h
@@ -28,7 +28,7 @@ namespace ora {
 
     void run( const std::string& connectionString ){
       const char* authEnv = ::getenv( "CORAL_AUTH_PATH" );
-      std::string defaultPath("/afs/cern.ch/cms/DB/conddb/int9r");
+      std::string defaultPath("/afs/cern.ch/cms/DB/conddb");
       std::string pathEnv(std::string("CORAL_AUTH_PATH=")+defaultPath);
       if( !authEnv ){
 	//setting environment variable: if pathEnv is defined in this scope (as it should be), it does not work!! (??)
@@ -49,7 +49,7 @@ namespace ora {
     }
 
     void run(){
-      std::string connStr("oracle://cms_orcoff_int/CMS_COND_UNIT_TESTS");
+      std::string connStr("oracle://cms_orcoff_prep/CMS_COND_UNIT_TESTS");
       const char* envVar = ::getenv( "ORA_TEST_DB" );
       if( envVar ){
         connStr = std::string(envVar);


### PR DESCRIPTION
Temporary change for running the ORA tests for the ROOT6 based implementation in a separate account, to avoid the impact on the testing for the main 72X and 73X branches. 
