### PR TITLE
Changed payload proxy cache as required from Framework

### DIFF
--- a/CondCore/CondDB/interface/PayloadProxy.h
+++ b/CondCore/CondDB/interface/PayloadProxy.h
@@ -97,6 +97,11 @@ namespace cond {
 	  m_session.transaction().commit();
 	}
       }
+
+      virtual void invalidateTransientCache() {
+	m_data.reset();
+        m_currentPayloadId.clear();
+      }
       
       virtual void invalidateCache() {
 	m_data.reset();

--- a/CondCore/ESSources/interface/DataProxy.h
+++ b/CondCore/ESSources/interface/DataProxy.h
@@ -44,7 +44,7 @@ class DataProxy : public edm::eventsetup::DataProxyTemplate<RecordT, DataT >{
     // m_data->invalidateCache();
   }
   virtual void invalidateTransientCache() {
-    m_data->invalidateCache();
+    m_data->invalidateTransientCache();
   }
   private:
   //DataProxy(); // stop default


### PR DESCRIPTION
The caching policy of the PayloadProxy has been changed according to the requirements of the Framework. When a invalidateTransientCache() is requested in the DataProxy, a corresponding new function invalidateTransientCache() is called in the PayloadProxy. This call reset the Payload ( when available) and clears its Payload ID, while the current IOV is kept for further use.  
The former function, invalidateCache(), which is resetting the entire IOV cache ( IOV+Payload), is currently not called by the Framework.
