### PR TITLE
fix for test concurrency

### DIFF
--- a/CondCore/IOVService/test/testIOVDelete.cc
+++ b/CondCore/IOVService/test/testIOVDelete.cc
@@ -16,7 +16,7 @@ int main(){
     connection.configuration().setPoolAutomaticCleanUp( false );
     connection.configure();
     cond::DbSession pooldb = connection.createSession();
-    pooldb.open("sqlite_file:mytest.db"); 
+    pooldb.open("sqlite_file:testIOVDelete.db"); 
     cond::IOVEditor editor( pooldb );
     pooldb.transaction().start(false);
     editor.createIOVContainerIfNecessary();

--- a/CondCore/IOVService/test/testIOVEditor.cc
+++ b/CondCore/IOVService/test/testIOVEditor.cc
@@ -20,7 +20,7 @@ int main(){
     connection.configuration().setPoolAutomaticCleanUp( false );
     connection.configure();
     cond::DbSession pooldb = connection.createSession();
-    pooldb.open("sqlite_file:test.db");
+    pooldb.open("sqlite_file:testIOVEditor.db");
     std::string token;
     {
       cond::IOVEditor editor(pooldb);

--- a/CondCore/IOVService/test/testIOVIterator.cc
+++ b/CondCore/IOVService/test/testIOVIterator.cc
@@ -85,7 +85,7 @@ int main(){
     connection.configuration().setPoolAutomaticCleanUp( false );
     connection.configure();
     cond::DbSession pooldb = connection.createSession();
-    pooldb.open("sqlite_file:mytest.db");
+    pooldb.open("sqlite_file:testIOVIterator.db");
     pooldb.transaction().start(false);
     cond::IOVEditor editor( pooldb );
     editor.create(cond::timestamp,60);
@@ -169,7 +169,7 @@ int main(){
       std::cout << " size " << data.iov().size() << std::endl;
       {
         cond::DbSession pooldb2 = connection.createSession();
-        pooldb2.open("sqlite_file:mytest.db");
+        pooldb2.open("sqlite_file:testIOVIterator.db");
         pooldb2.transaction().start(false);
 	cond::IOVEditor editor(pooldb2,iovtok);
         Add add(pooldb2, editor);

--- a/CondCore/IOVService/test/testIOVReplaceInterval.cc
+++ b/CondCore/IOVService/test/testIOVReplaceInterval.cc
@@ -11,7 +11,7 @@ int main(){
   try{
     cond::DBSession* session=new cond::DBSession;
     session->open();
-    cond::Connection myconnection("sqlite_file:test.db",0);  
+    cond::Connection myconnection("sqlite_file:testIOVReplaceInterval.db",0);  
     myconnection.connect(session);
     cond::PoolTransaction& pooldb=myconnection.poolTransaction();
     cond::IOVService iovmanager(pooldb);  

--- a/CondCore/IOVService/test/testqueryPContainer.cc
+++ b/CondCore/IOVService/test/testqueryPContainer.cc
@@ -16,7 +16,7 @@ int main(){
     std::cout<<"#0 "<<std::endl;
     connection.configure();
     cond::DbSession pooldb = connection.createSession();
-    pooldb.open("sqlite_file:mytest.db"); 
+    pooldb.open("sqlite_file:testqueryPContainer.db"); 
     testPayloadObj* myobj=new testPayloadObj;
     myobj->data.push_back(1);
     myobj->data.push_back(10);


### PR DESCRIPTION
Enabling concurrent execution by creating different sqlite files
