### PR TITLE
Make static theVerboseLevel const

### DIFF
--- a/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplateReco.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplateReco.cc
@@ -67,7 +67,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #define LOGERROR(x) edm::LogError(x)
 #define LOGDEBUG(x) LogDebug(x)
-static int theVerboseLevel = 2;
+static const int theVerboseLevel = 2;
 #define ENDL " "
 #include "FWCore/Utilities/interface/Exception.h"
 #else


### PR DESCRIPTION
The file static variable theVerboseLevel has no way of being changed
via code therefore it is safe to make it const. This avoids complaints
from the static analyzer.
