### PR TITLE
Make HO information available in PFJet interface

### DIFF
--- a/DataFormats/JetReco/interface/PFJet.h
+++ b/DataFormats/JetReco/interface/PFJet.h
@@ -156,10 +156,10 @@ class PFJet : public Jet {
   /// neutralMultiplicity
   int neutralMultiplicity () const {return m_specific.mNeutralMultiplicity;}
 
-  /// HOEnergy 
-  float HOEnergy () const {return m_specific.mHOEnergy;}
-  /// HOEnergyFraction
-  float HOEnergyFraction () const {return HOEnergy () / energy ();}
+  /// hoEnergy 
+  float hoEnergy () const {return m_specific.mHOEnergy;}
+  /// hoEnergyFraction
+  float hoEnergyFraction () const {return hoEnergy () / energy ();}
 
   /// get specific constituent
   virtual reco::PFCandidatePtr getPFConstituent (unsigned fIndex) const;

--- a/DataFormats/JetReco/interface/PFJet.h
+++ b/DataFormats/JetReco/interface/PFJet.h
@@ -48,6 +48,8 @@ class PFJet : public Jet {
        
        mChargedMultiplicity (0),
        mNeutralMultiplicity (0)
+
+       mHOEnergy (0),
     {}
     float mChargedHadronEnergy;
     float mNeutralHadronEnergy;
@@ -72,6 +74,8 @@ class PFJet : public Jet {
     float mNeutralEmEnergy;
     int mChargedMultiplicity;
     int mNeutralMultiplicity;
+
+    float mHOEnergy;
  };
   
   /** Default constructor*/
@@ -152,6 +156,10 @@ class PFJet : public Jet {
   /// neutralMultiplicity
   int neutralMultiplicity () const {return m_specific.mNeutralMultiplicity;}
 
+  /// HOEnergy 
+  float HOEnergy () const {return m_specific.mHOEnergy;}
+  /// HOEnergyFraction
+  float HOEnergyFraction () const {return HOEnergy () / energy ();}
 
   /// get specific constituent
   virtual reco::PFCandidatePtr getPFConstituent (unsigned fIndex) const;

--- a/DataFormats/JetReco/interface/PFJet.h
+++ b/DataFormats/JetReco/interface/PFJet.h
@@ -47,9 +47,9 @@ class PFJet : public Jet {
        mNeutralEmEnergy (0),
        
        mChargedMultiplicity (0),
-       mNeutralMultiplicity (0)
+       mNeutralMultiplicity (0),
 
-       mHOEnergy (0),
+       mHOEnergy (0)
     {}
     float mChargedHadronEnergy;
     float mNeutralHadronEnergy;

--- a/DataFormats/JetReco/src/PFJet.cc
+++ b/DataFormats/JetReco/src/PFJet.cc
@@ -95,7 +95,7 @@ std::string PFJet::print () const {
       << "      charged/neutral em energy: " << chargedEmEnergy () << '/' << neutralEmEnergy () << std::endl
       << "      charged muon energy: " << chargedMuEnergy () << '/' << std::endl
       << "      charged/neutral multiplicity: " << chargedMultiplicity () << '/' << neutralMultiplicity () << std::endl
-      << "      HO energy: " << HOEnergy () << std::endl;
+      << "      HO energy: " << hoEnergy () << std::endl;
   out << "      PFCandidate constituents:" << std::endl;
   std::vector <PFCandidatePtr> constituents = getPFConstituents ();
   for (unsigned i = 0; i < constituents.size (); ++i) {

--- a/DataFormats/JetReco/src/PFJet.cc
+++ b/DataFormats/JetReco/src/PFJet.cc
@@ -94,7 +94,7 @@ std::string PFJet::print () const {
       << "      charged/neutral hadrons energy: " << chargedHadronEnergy () << '/' << neutralHadronEnergy () << std::endl
       << "      charged/neutral em energy: " << chargedEmEnergy () << '/' << neutralEmEnergy () << std::endl
       << "      charged muon energy: " << chargedMuEnergy () << '/' << std::endl
-      << "      charged/neutral multiplicity: " << chargedMultiplicity () << '/' << neutralMultiplicity () << std::endl;
+      << "      charged/neutral multiplicity: " << chargedMultiplicity () << '/' << neutralMultiplicity () << std::endl
       << "      HO energy: " << HOEnergy () << std::endl;
   out << "      PFCandidate constituents:" << std::endl;
   std::vector <PFCandidatePtr> constituents = getPFConstituents ();

--- a/DataFormats/JetReco/src/PFJet.cc
+++ b/DataFormats/JetReco/src/PFJet.cc
@@ -95,6 +95,7 @@ std::string PFJet::print () const {
       << "      charged/neutral em energy: " << chargedEmEnergy () << '/' << neutralEmEnergy () << std::endl
       << "      charged muon energy: " << chargedMuEnergy () << '/' << std::endl
       << "      charged/neutral multiplicity: " << chargedMultiplicity () << '/' << neutralMultiplicity () << std::endl;
+      << "      HO energy: " << HOEnergy () << std::endl;
   out << "      PFCandidate constituents:" << std::endl;
   std::vector <PFCandidatePtr> constituents = getPFConstituents ();
   for (unsigned i = 0; i < constituents.size (); ++i) {

--- a/DataFormats/JetReco/src/classes_def_1.xml
+++ b/DataFormats/JetReco/src/classes_def_1.xml
@@ -9,8 +9,8 @@
   <class name="reco::CaloJet" ClassVersion="10">
    <version ClassVersion="10" checksum="715843310"/>
   </class>
-  <class name="reco::CaloJet::Specific" ClassVersion="10">
-   <version ClassVersion="10" checksum="2617452651"/>
+  <class name="reco::CaloJet::Specific" ClassVersion="11">
+   <version ClassVersion="10" checksum="3865393003"/>
   </class>
   <class name="std::vector<reco::CaloJet>"/>
   <class name="edm::RefProd<std::vector<reco::CaloJet> >"/>

--- a/DataFormats/JetReco/src/classes_def_1.xml
+++ b/DataFormats/JetReco/src/classes_def_1.xml
@@ -59,6 +59,7 @@
   </class>
   <class name="reco::PFJet::Specific" ClassVersion="11">
    <version ClassVersion="11" checksum="3865393003"/>
+   <version ClassVersion="10" checksum="3345092571"/>
   </class>
   <class name="std::vector<reco::PFJet>"/>
   <class name="edm::RefVector<std::vector<reco::PFJet>,reco::PFJet,edm::refhelper::FindUsingAdvance<std::vector<reco::PFJet>,reco::PFJet> >"/>

--- a/DataFormats/JetReco/src/classes_def_1.xml
+++ b/DataFormats/JetReco/src/classes_def_1.xml
@@ -9,8 +9,8 @@
   <class name="reco::CaloJet" ClassVersion="10">
    <version ClassVersion="10" checksum="715843310"/>
   </class>
-  <class name="reco::CaloJet::Specific" ClassVersion="11">
-   <version ClassVersion="10" checksum="3865393003"/>
+  <class name="reco::CaloJet::Specific" ClassVersion="10">
+   <version ClassVersion="10" checksum="2617452651"/>
   </class>
   <class name="std::vector<reco::CaloJet>"/>
   <class name="edm::RefProd<std::vector<reco::CaloJet> >"/>
@@ -57,8 +57,8 @@
   <class name="reco::PFJet" ClassVersion="10">
    <version ClassVersion="10" checksum="3657319332"/>
   </class>
-  <class name="reco::PFJet::Specific" ClassVersion="10">
-   <version ClassVersion="10" checksum="3345092571"/>
+  <class name="reco::PFJet::Specific" ClassVersion="11">
+   <version ClassVersion="11" checksum="3865393003"/>
   </class>
   <class name="std::vector<reco::PFJet>"/>
   <class name="edm::RefVector<std::vector<reco::PFJet>,reco::PFJet,edm::refhelper::FindUsingAdvance<std::vector<reco::PFJet>,reco::PFJet> >"/>

--- a/DataFormats/PatCandidates/interface/Jet.h
+++ b/DataFormats/PatCandidates/interface/Jet.h
@@ -403,10 +403,10 @@ namespace pat {
       /// neutralMultiplicity
       int neutralMultiplicity () const {return pfSpecific().mNeutralMultiplicity;}
 
-      /// HOEnergy
-      float HOEnergy () const {return pfSpecific().mHOEnergy;}
-      /// HOEnergyFraction (relative to corrected jet energy)
-      float HOEnergyFraction () const {return HOEnergy()/((jecSetsAvailable() ? jecFactor(0) : 1.)*energy());}
+      /// hoEnergy
+      float hoEnergy () const {return pfSpecific().mHOEnergy;}
+      /// hoEnergyFraction (relative to corrected jet energy)
+      float hoEnergyFraction () const {return hoEnergy()/((jecSetsAvailable() ? jecFactor(0) : 1.)*energy());}
       /// convert generic constituent to specific type
 
       //  static CaloTowerPtr caloTower (const reco::Candidate* fConstituent);

--- a/DataFormats/PatCandidates/interface/Jet.h
+++ b/DataFormats/PatCandidates/interface/Jet.h
@@ -403,7 +403,12 @@ namespace pat {
       /// neutralMultiplicity
       int neutralMultiplicity () const {return pfSpecific().mNeutralMultiplicity;}
 
+      /// HOEnergy
+      float HOEnergy () const {return pfSpecific().mHOEnergy;}
+      /// HOEnergyFraction (relative to corrected jet energy)
+      float HOEnergyFraction () const {return HOEnergy()/((jecSetsAvailable() ? jecFactor(0) : 1.)*energy());}
       /// convert generic constituent to specific type
+
       //  static CaloTowerPtr caloTower (const reco::Candidate* fConstituent);
       /// get specific constituent of the CaloJet.
       /// if the caloTowers were embedded, this reference is transient only and must not be persisted

--- a/RecoJets/JetProducers/src/JetSpecific.cc
+++ b/RecoJets/JetProducers/src/JetSpecific.cc
@@ -268,6 +268,8 @@ bool reco::makeSpecific(vector<reco::CandidatePtr> const & particles,
   float chargedMuEnergy=0.;
   int   chargedMultiplicity=0;
   int   neutralMultiplicity=0;
+
+  float HOEnergy=0.;
   
   vector<reco::CandidatePtr>::const_iterator itParticle;
   for (itParticle=particles.begin();itParticle!=particles.end();++itParticle){
@@ -277,6 +279,11 @@ bool reco::makeSpecific(vector<reco::CandidatePtr> const & particles,
     }    
     const Candidate* pfCand = itParticle->get();
     if (pfCand) {
+
+      const PFCandidate* pfCandCast = dynamic_cast<const PFCandidate*>(pfCand);
+      if (pfCandCast)
+        HOEnergy += pfCandCast->hoEnergy();
+
       switch (std::abs(pfCand->pdgId())) {
       case 211: //PFCandidate::h:       // charged hadron
 	chargedHadronEnergy += pfCand->energy();
@@ -359,6 +366,8 @@ bool reco::makeSpecific(vector<reco::CandidatePtr> const & particles,
   pfJetSpecific->mNeutralEmEnergy=neutralEmEnergy;
   pfJetSpecific->mChargedMultiplicity=chargedMultiplicity;
   pfJetSpecific->mNeutralMultiplicity=neutralMultiplicity;
+
+  pfJetSpecific->mHOEnergy= HOEnergy;
 
   return true;
 }

--- a/Validation/RecoJets/plugins/JetTester.cc
+++ b/Validation/RecoJets/plugins/JetTester.cc
@@ -617,8 +617,8 @@ void JetTester::analyze(const edm::Event& mEvent, const edm::EventSetup& mSetup)
         chargedMuEnergy ->Fill((*pfJets)[ijet].chargedMuEnergy());
         chargedMuEnergyFraction ->Fill((*pfJets)[ijet].chargedMuEnergyFraction());
         neutralMultiplicity ->Fill((*pfJets)[ijet].neutralMultiplicity()); 
-        HOEnergy ->Fill((*pfJets)[ijet].HOEnergy());
-        HOEnergyFraction ->Fill((*pfJets)[ijet].HOEnergyFraction());
+        HOEnergy ->Fill((*pfJets)[ijet].hoEnergy());
+        HOEnergyFraction ->Fill((*pfJets)[ijet].hoEnergyFraction());
      }
       // ---- JPT Jet specific information ----
      /* if (isJPTJet) {

--- a/Validation/RecoJets/plugins/JetTester.cc
+++ b/Validation/RecoJets/plugins/JetTester.cc
@@ -232,6 +232,10 @@ JetTester::JetTester(const edm::ParameterSet& iConfig) :
   /// neutralMultiplicity
   neutralMultiplicity = 0;
 
+  /// HOEnergy
+  HOEnergy = 0;
+  /// HOEnergyFraction (relative to corrected jet energy)
+  HOEnergyFraction = 0;
 }
 
 void JetTester::bookHistograms(DQMStore::IBooker & ibooker,
@@ -401,6 +405,8 @@ void JetTester::bookHistograms(DQMStore::IBooker & ibooker,
       chargedMuEnergy = ibooker.book1D("chargedMuEnergy", "chargedMuEnergy", 50,0,500);
       chargedMuEnergyFraction = ibooker.book1D("chargedMuEnergyFraction", "chargedMuEnergyFraction", 50,0,1);
       neutralMultiplicity = ibooker.book1D("neutralMultiplicity", "neutralMultiplicity", 50,0,50);
+      HOEnergy = ibooker.book1D("HOEnergy", "HOEnergy", 50,0,500);
+      HOEnergyFraction = ibooker.book1D("HOEnergyFraction", "HOEnergyFraction", 50,0,1);
     }
 
   if (mOutputFile.empty ())
@@ -611,6 +617,8 @@ void JetTester::analyze(const edm::Event& mEvent, const edm::EventSetup& mSetup)
         chargedMuEnergy ->Fill((*pfJets)[ijet].chargedMuEnergy());
         chargedMuEnergyFraction ->Fill((*pfJets)[ijet].chargedMuEnergyFraction());
         neutralMultiplicity ->Fill((*pfJets)[ijet].neutralMultiplicity()); 
+        HOEnergy ->Fill((*pfJets)[ijet].HOEnergy());
+        HOEnergyFraction ->Fill((*pfJets)[ijet].HOEnergyFraction());
      }
       // ---- JPT Jet specific information ----
      /* if (isJPTJet) {

--- a/Validation/RecoJets/plugins/JetTester.h
+++ b/Validation/RecoJets/plugins/JetTester.h
@@ -207,6 +207,8 @@ class JetTester : public thread_unsafe::DQMEDAnalyzer {
   MonitorElement* chargedMuEnergy;
   MonitorElement* chargedMuEnergyFraction;
   MonitorElement* neutralMultiplicity;
+  MonitorElement* HOEnergy;
+  MonitorElement* HOEnergyFraction;
 
   // Parameters
   double          mRecoJetPtThreshold;


### PR DESCRIPTION
Make HO energy+fraction available in the PFJet interface, pat::Jet, JetValidation, such that it becomes available at user level (in MiniAOD) given the importance of its understanding in Run II for high pT jets.
The actual PF algorithm that includes HO information into PF candidate reconstruction is not modified.
This request is mainly for user convenience.

Attached are plots from 10 events of the runTheMatrix workflow 13.0_QCD_Pt_3000_3500+QCD_Pt_3000_3500+DIGI+RECO+HARVEST.

pfclusterho_energy
![pfclusterho_energy](https://cloud.githubusercontent.com/assets/4518137/5043107/eabe0bae-6be1-11e4-859d-9b3f07182f54.png)
pfcandidate_rawhoenergy
![pfcandidate_rawhoenergy](https://cloud.githubusercontent.com/assets/4518137/5043108/ed3c2618-6be1-11e4-858a-4a13e1d1cac4.png)
pfjet_hoenergy
![pfjet_hoenergy](https://cloud.githubusercontent.com/assets/4518137/5043109/f034d0ae-6be1-11e4-81f4-c5b4afc80be4.png)
dqm_hoenergy
![dqm_hoenergy](https://cloud.githubusercontent.com/assets/4518137/5043111/f30ae462-6be1-11e4-91f5-c9b0f53955ab.png)
dqm_hoenergyfraction
![dqm_hoenergyfraction](https://cloud.githubusercontent.com/assets/4518137/5043113/f537b508-6be1-11e4-9d08-74a8a51da9ff.png)
HO energy is visible in these high energy jets, and this is visible in the PFjet, so technically it works.
