### PR TITLE
Remove not needed and deprecated Boost.Signals header

### DIFF
--- a/SimG4Core/Geometry/interface/DDG4Builder.h
+++ b/SimG4Core/Geometry/interface/DDG4Builder.h
@@ -12,8 +12,6 @@
 #include <vector>
 #include <string>
  
-#include "boost/signals.hpp"
-
 struct DDPosData;
 class DDG4SolidConverter;
 class G4LogicalVolume;


### PR DESCRIPTION
`"boost/signals.hpp"` is not used in the package and since Boost 1.56.0 is
considered unmaintained and deprecated.

```
warning: #warning "Boost.Signals is no longer being maintained and
is now deprecated. Please switch to Boost.Signals2. To disable this
warning message, define BOOST_SIGNALS_NO_DEPRECATION_WARNING." [-Wcpp]
```

The patch removes the header.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
