### PR TITLE
Use std:: not boost:: thread handling classes

### DIFF
--- a/FWCore/MessageLogger/interface/ConfigurationHandshake.h
+++ b/FWCore/MessageLogger/interface/ConfigurationHandshake.h
@@ -3,8 +3,8 @@
 
 #include "FWCore/Utilities/interface/EDMException.h"
 
-#include "boost/thread/condition.hpp"
-#include "boost/thread/mutex.hpp"
+#include <condition_variable>
+#include <mutex>
 
 namespace edm {
   class ParameterSet;
@@ -14,8 +14,8 @@ namespace edm {
 
   struct ConfigurationHandshake {
     void* p;
-    boost::mutex m;
-    boost::condition c;
+    std::mutex m;
+    std::condition_variable c;
     edm::Place_for_passing_exception_ptr epp;
     explicit ConfigurationHandshake 
       (void* p_in, Place_for_passing_exception_ptr epp_in) : 

--- a/FWCore/MessageService/src/MainThreadMLscribe.cc
+++ b/FWCore/MessageService/src/MainThreadMLscribe.cc
@@ -30,7 +30,7 @@ runCommand(MessageLoggerQ::OpCode  opcode, void * operand)
     void * v(static_cast<void *>(&h));
     Pointer_to_new_exception_on_heap ep;
     {
-      boost::mutex::scoped_lock sl(h.m);       // get lock
+      std::unique_lock<std::mutex> sl(h.m);       // get lock
       m_queue->produce (opcode, v);
       // wait for result to appear (in epp)
       h.c.wait(sl); // c.wait(sl) unlocks the scoped lock and sleeps till notified

--- a/FWCore/MessageService/src/MessageLoggerScribe.cc
+++ b/FWCore/MessageService/src/MessageLoggerScribe.cc
@@ -309,7 +309,7 @@ void
 	ConfigurationHandshake * h_p = 
 		static_cast<ConfigurationHandshake *>(operand);
 	job_pset_p.reset(static_cast<ParameterSet *>(h_p->p));
-	boost::mutex::scoped_lock sl(h_p->m);   // get lock
+  std::lock_guard<std::mutex> sl(h_p->m);   // get lock
 	try {
 	  configure_errorlog();
 	}
@@ -398,7 +398,7 @@ void
       ConfigurationHandshake * h_p = 
 	      static_cast<ConfigurationHandshake *>(operand);
       job_pset_p.reset(static_cast<ParameterSet *>(h_p->p));
-      boost::mutex::scoped_lock sl(h_p->m);   // get lock
+      std::lock_guard<std::mutex> sl(h_p->m);   // get lock
       h_p->c.notify_all();  // Signal to MessageLoggerQ that we are done
       // finally, release the scoped lock by letting it go out of scope 
       break;
@@ -419,7 +419,7 @@ void
       } else {
 	ConfigurationHandshake * h_p = 
 		static_cast<ConfigurationHandshake *>(operand);
-	boost::mutex::scoped_lock sl(h_p->m);   // get lock
+    std::lock_guard<std::mutex> sl(h_p->m);   // get lock
 	std::map<std::string, double> * smp = 
 		static_cast<std::map<std::string, double> *>(h_p->p);
 	triggerFJRmessageSummary(*smp);

--- a/FWCore/Utilities/interface/SingleConsumerQ.h
+++ b/FWCore/Utilities/interface/SingleConsumerQ.h
@@ -35,8 +35,8 @@
 */
 
 #include <vector>
-#include "boost/thread/mutex.hpp"
-#include "boost/thread/condition.hpp"
+#include <mutex>
+#include <condition_variable>
 
 namespace edm {
 
@@ -126,11 +126,11 @@ namespace edm {
     Queue queue_;
     unsigned int fpos_, bpos_; // positions for queue - front and back
 
-    boost::mutex pool_lock_;
-    boost::mutex queue_lock_;
-    boost::condition pool_cond_;
-    boost::condition pop_cond_;
-    boost::condition push_cond_;
+    std::mutex pool_lock_;
+    std::mutex queue_lock_;
+    std::condition_variable pool_cond_;
+    std::condition_variable pop_cond_;
+    std::condition_variable push_cond_;
 
   };
 

--- a/FWCore/Utilities/src/SingleConsumerQ.cc
+++ b/FWCore/Utilities/src/SingleConsumerQ.cc
@@ -28,7 +28,7 @@ namespace edm
   SingleConsumerQ::Buffer SingleConsumerQ::getProducerBuffer()
   {
     // get lock
-    boost::mutex::scoped_lock sl(pool_lock_);
+    std::unique_lock<std::mutex> sl(pool_lock_);
     // wait for buffer to appear
     while(pos_ < 0)
       {
@@ -42,7 +42,7 @@ namespace edm
   void SingleConsumerQ::releaseProducerBuffer(void* v)
   {
     // get lock
-    boost::mutex::scoped_lock sl(pool_lock_);
+    std::lock_guard<std::mutex> sl(pool_lock_);
     ++pos_;
     buffer_pool_[pos_] = v;
     pool_cond_.notify_all();
@@ -51,7 +51,7 @@ namespace edm
   void SingleConsumerQ::commitProducerBuffer(void* v, int len)
   {
     // get lock
-    boost::mutex::scoped_lock sl(queue_lock_);
+    std::unique_lock<std::mutex> sl(queue_lock_);
     // if full, wait for item to be removed
     while((bpos_+max_queue_depth_)==fpos_)
       {
@@ -68,7 +68,7 @@ namespace edm
   SingleConsumerQ::Buffer SingleConsumerQ::getConsumerBuffer()
   {
     // get lock
-    boost::mutex::scoped_lock sl(queue_lock_);
+    std::unique_lock<std::mutex> sl(queue_lock_);
     // if empty, wait for item to appear
     while(bpos_==fpos_)
       {

--- a/Utilities/StorageFactory/src/StorageAccount.cc
+++ b/Utilities/StorageFactory/src/StorageAccount.cc
@@ -1,9 +1,9 @@
 #include "Utilities/StorageFactory/interface/StorageAccount.h"
-#include <boost/thread/mutex.hpp>
+#include <mutex>
 #include <sstream>
 #include <unistd.h>
 
-boost::mutex                 s_mutex;
+static std::mutex            s_mutex;
 StorageAccount::StorageStats s_stats;
 
 static double timeRealNanoSecs (void) {
@@ -94,7 +94,7 @@ StorageAccount::summary (void)
 
 StorageAccount::Counter&
 StorageAccount::counter (const std::string &storageClass, const std::string &operation) {
-  boost::mutex::scoped_lock lock (s_mutex);
+  std::lock_guard<std::mutex> lock (s_mutex);
   boost::shared_ptr<OperationStats> &opstats = s_stats [storageClass];
   if (!opstats) opstats.reset(new OperationStats);
 
@@ -111,14 +111,14 @@ StorageAccount::Stamp::Stamp (Counter &counter)
   : m_counter (counter),
     m_start (timeRealNanoSecs ())
 {
-  boost::mutex::scoped_lock lock (s_mutex);
+  std::lock_guard<std::mutex> lock (s_mutex);
   m_counter.attempts++;
 }
 
 void
 StorageAccount::Stamp::tick (double amount, int64_t count) const
 {
-  boost::mutex::scoped_lock lock (s_mutex);
+  std::lock_guard<std::mutex> lock (s_mutex);
   double elapsed = timeRealNanoSecs () - m_start;
   m_counter.successes++;
 


### PR DESCRIPTION
Given that C++11 now has a full set of thread safety and thread classes it is more portable to use those then to use the boost equivalent.

The static analyzer knows about std::mutex but not boost::mutex. Instead of changing the static analyzer I figured it was better to 'modernize' the code.
