### PR TITLE
testChrono: drop boost timer

### DIFF
--- a/HLTrigger/Timer/test/BuildFile.xml
+++ b/HLTrigger/Timer/test/BuildFile.xml
@@ -11,6 +11,6 @@
   <use   name="boost"/>
   <use   name="tbb"/>
   <use   name="sockets"/>       <!-- imply -lrt on Linux -->
-  <flags CXXFLAGS="-I${CMSSW_BASE}/src/HLTrigger/Timer/test/chrono -I${CMSSW_RELEASE_BASE}/src/HLTrigger/Timer/test/chrono -fopenmp -lboost_timer"/>
+  <flags CXXFLAGS="-I${CMSSW_BASE}/src/HLTrigger/Timer/test/chrono -I${CMSSW_RELEASE_BASE}/src/HLTrigger/Timer/test/chrono -fopenmp -DHAVE_TBB"/>
   <flags NO_TESTRUN="1"/>
 </bin>

--- a/HLTrigger/Timer/test/chrono/interface/boost_timer.h
+++ b/HLTrigger/Timer/test/chrono/interface/boost_timer.h
@@ -1,3 +1,5 @@
+#ifdef HAVE_BOOST_TIMER
+
 #ifndef boost_timer_h
 #define boost_timer_h
 
@@ -49,3 +51,5 @@ struct clock_boost_timer_realtime
 };
 
 #endif // boost_timer_h
+
+#endif // HAVE_BOOST_TIMER

--- a/HLTrigger/Timer/test/chrono/interface/tbb_tick_count.h
+++ b/HLTrigger/Timer/test/chrono/interface/tbb_tick_count.h
@@ -1,3 +1,5 @@
+#ifdef HAVE_TBB
+
 #ifndef tbb_tick_count_h
 #define tbb_tick_count_h
 
@@ -59,3 +61,5 @@ namespace std {
 }
 
 #endif // tbb_tick_count_h
+
+#endif // HAVE_TBB

--- a/HLTrigger/Timer/test/chrono/src/tbb_tick_count.cc
+++ b/HLTrigger/Timer/test/chrono/src/tbb_tick_count.cc
@@ -1,3 +1,7 @@
+#ifdef HAVE_TBB
+
 #include "interface/tbb_tick_count.h"
 
 const tbb::tick_count clock_tbb_tick_count::epoch = tbb::tick_count::now();
+
+#endif // HAVE_TBB

--- a/HLTrigger/Timer/test/chrono/test/chrono.cc
+++ b/HLTrigger/Timer/test/chrono/test/chrono.cc
@@ -170,12 +170,16 @@ void init_timers(std::vector<BenchmarkBase *> & timers)
 
 #endif // defined __x86_64__ or defined __i386__
 
+#ifdef HAVE_BOOST_TIMER
   // boost timer clock
   timers.push_back(new Benchmark<clock_boost_timer_realtime>("boost::timer (wall-clock time)"));
   timers.push_back(new Benchmark<clock_boost_timer_cputime>("boost::timer (cpu time)"));
+#endif // HAVE_BOOST_TIMER
 
+#ifdef HAVE_TBB
   // TBB tick_count (this interface does not expose the underlying type, so it cannot easily be used to build a "native" clock interface)
   timers.push_back(new Benchmark<clock_tbb_tick_count>("tbb::tick_count"));
+#endif // HAVE_TBB
 
 #ifndef __clang__
   // OpenMP timer


### PR DESCRIPTION
- make boost::timer and tbb optional in the source code
- enable only tbb in the BuildFile.xml
- effectively drop the usage of boost::timer
