### PR TITLE
Replace use of boost::mutex

### DIFF
--- a/CondFormats/PhysicsToolsObjects/src/MVAComputer.cc
+++ b/CondFormats/PhysicsToolsObjects/src/MVAComputer.cc
@@ -21,7 +21,7 @@
 #include <cstring>
 #include <cstddef>
 
-#include <boost/thread.hpp>
+#include <atomic>
 
 #include <Reflex/Reflex.h>
 
@@ -129,10 +129,8 @@ std::string ProcExternal::getInstanceName() const
 
 static MVAComputer::CacheId getNextMVAComputerCacheId()
 {
-	static boost::mutex mutex;
-	static MVAComputer::CacheId nextCacheId = 0;
+	static std::atomic<MVAComputer::CacheId> nextCacheId{0};
 
-	boost::mutex::scoped_lock scoped_lock(mutex);
 	return ++nextCacheId;
 }
 

--- a/PhysicsTools/MVAComputer/src/AtomicId.cc
+++ b/PhysicsTools/MVAComputer/src/AtomicId.cc
@@ -4,7 +4,7 @@
 #include <cstring>
 #include <set>
 
-#include <boost/thread.hpp>
+#include <mutex>
 
 #include "PhysicsTools/MVAComputer/interface/AtomicId.h"
 
@@ -25,7 +25,7 @@ namespace { // anonymous
 
 		IdSet				idSet;
 		static std::allocator<char>	stringAllocator;
-		mutable boost::mutex		mutex;
+		mutable std::mutex		mutex;
 	};
 } // anonymous namespace
 
@@ -41,7 +41,7 @@ IdCache::~IdCache()
 
 const char *IdCache::findOrInsert(const char *string) throw()
 {
-	boost::mutex::scoped_lock scoped_lock(mutex);
+	std::lock_guard<std::mutex> scoped_lock(mutex);
 
 	IdSet::iterator pos = idSet.lower_bound(string);
 	if (pos != idSet.end() && std::strcmp(*pos, string) == 0)
@@ -60,7 +60,7 @@ namespace PhysicsTools {
 
 static IdCache &getAtomicIdCache()
 {
-	static IdCache atomicIdCache;
+	[[cms::thread_safe]] static IdCache atomicIdCache;
 	return atomicIdCache;
 }
 


### PR DESCRIPTION
Since the C++11 standard now has a full array of thread related classes
we no longer need to use the boost equivalent. Switching to the appropriate
std class should allow for easier maintenance.

The static analyzer was complaining about boost::mutex since the analyzer doesn't know it is thread safe. Rather than modify the analyzer I believe it is better to switch to the appropriate C++11 class.
