### PR TITLE
Secondary vertex clustering + explicit jet-track association

### DIFF
--- a/PhysicsTools/JetMCAlgos/plugins/JetFlavourClustering.cc
+++ b/PhysicsTools/JetMCAlgos/plugins/JetFlavourClustering.cc
@@ -383,7 +383,7 @@ JetFlavourClustering::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
      else
      {
        // since the "ghosts" are extremely soft, the configuration and ordering of the reclustered and original jets should in principle stay the same
-       if( ( fabs( inclusiveJets.at(reclusteredIndices.at(i)).pt() - jets->at(i).pt() ) / jets->at(i).pt() ) > relPtTolerance_ )
+       if( ( std::abs( inclusiveJets.at(reclusteredIndices.at(i)).pt() - jets->at(i).pt() ) / jets->at(i).pt() ) > relPtTolerance_ )
        {
          if( jets->at(i).pt() < 10. )  // special handling for low-Pt jets (Pt<10 GeV)
            edm::LogWarning("JetPtMismatchAtLowPt") << "The reclustered and original jet " << i << " have different Pt's (" << inclusiveJets.at(reclusteredIndices.at(i)).pt() << " vs " << jets->at(i).pt() << " GeV, respectively).\n"
@@ -647,14 +647,14 @@ JetFlavourClustering::setFlavours(const reco::GenParticleRefVector& clusteredbHa
          hardestLightParton = (*it);
      }
      // c flavour
-     if( flavourParton.isNull() && ( abs( (*it)->pdgId() ) == 4 ) )
+     if( flavourParton.isNull() && ( std::abs( (*it)->pdgId() ) == 4 ) )
        flavourParton = (*it);
      // b flavour gets priority
-     if( abs( (*it)->pdgId() ) == 5 )
+     if( std::abs( (*it)->pdgId() ) == 5 )
      {
        if( flavourParton.isNull() )
          flavourParton = (*it);
-       else if( abs( flavourParton->pdgId() ) != 5 )
+       else if( std::abs( flavourParton->pdgId() ) != 5 )
          flavourParton = (*it);
      }
    }
@@ -675,9 +675,9 @@ JetFlavourClustering::setFlavours(const reco::GenParticleRefVector& clusteredbHa
    // if enabled, check for conflicts between hadron- and parton-based flavours and give priority to the hadron-based flavour
    if( hadronFlavourHasPriority_ )
    {
-     if( hadronFlavour==0 && (abs(partonFlavour)==4 || abs(partonFlavour)==5) )
+     if( hadronFlavour==0 && (std::abs(partonFlavour)==4 || std::abs(partonFlavour)==5) )
        partonFlavour = ( hardestLightParton.isNonnull() ? hardestLightParton->pdgId() : 0 );
-     else if( hadronFlavour!=0 && abs(partonFlavour)!=hadronFlavour )
+     else if( hadronFlavour!=0 && std::abs(partonFlavour)!=hadronFlavour )
        partonFlavour = hadronFlavour;
    }
 }

--- a/PhysicsTools/JetMCAlgos/plugins/JetFlavourClustering.cc
+++ b/PhysicsTools/JetMCAlgos/plugins/JetFlavourClustering.cc
@@ -362,6 +362,24 @@ JetFlavourClustering::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
        // set an empty JetFlavourInfo for this jet
        (*jetFlavourInfos)[jets->refAt(i)] = reco::JetFlavourInfo(clusteredbHadrons, clusteredcHadrons, clusteredPartons, clusteredLeptons, 0, 0);
      }
+     else if( jets->at(i).pt() == 0 )
+     {
+       edm::LogWarning("NullTransverseMomentum") << "The original jet " << i << " has Pt=0. This is not expected so the jet will be skipped.";
+
+       // set an empty JetFlavourInfo for this jet
+       (*jetFlavourInfos)[jets->refAt(i)] = reco::JetFlavourInfo(clusteredbHadrons, clusteredcHadrons, clusteredPartons, clusteredLeptons, 0, 0);
+
+       // if subjets are used
+       if( useSubjets_ && subjetIndices.at(i).size()>0 )
+       {
+         // loop over subjets
+         for(size_t sj=0; sj<subjetIndices.at(i).size(); ++sj)
+         {
+           // set an empty JetFlavourInfo for this subjet
+           (*subjetFlavourInfos)[subjets->refAt(subjetIndices.at(i).at(sj))] = reco::JetFlavourInfo(reco::GenParticleRefVector(), reco::GenParticleRefVector(), reco::GenParticleRefVector(), reco::GenParticleRefVector(), 0, 0);
+         }
+       }
+     }
      else
      {
        // since the "ghosts" are extremely soft, the configuration and ordering of the reclustered and original jets should in principle stay the same

--- a/PhysicsTools/PatAlgos/python/tools/jetTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/jetTools.py
@@ -14,6 +14,16 @@ supportedJetAlgos = {
 }
 
 
+def setupSVClustering(btagInfo, algo, rParam, fatJets=cms.InputTag(''), groomedFatJets=cms.InputTag('')):
+    btagInfo.useSVClustering = cms.bool(True)
+    btagInfo.jetAlgorithm    = cms.string(algo)
+    btagInfo.rParam          = cms.double(rParam)
+    ## if the jets is actually a subjet
+    if fatJets != cms.InputTag('') and groomedFatJets != cms.InputTag(''):
+        btagInfo.fatJets        = fatJets
+        btagInfo.groomedFatJets = groomedFatJets
+
+
 class AddJetCollection(ConfigToolBase):
     """
     Tool to add a new jet collection to your PAT Tuple or to modify an existing one.
@@ -376,14 +386,7 @@ class AddJetCollection(ConfigToolBase):
                     if btagInfo == 'pfInclusiveSecondaryVertexFinderTagInfos':
                         setattr(process, btagInfo+_labelName+postfix, btag.pfInclusiveSecondaryVertexFinderTagInfos.clone(trackIPTagInfos = cms.InputTag('pfImpactParameterTagInfos'+_labelName+postfix)))
                         if svClustering:
-                            _btagInfo = getattr(process, btagInfo+_labelName+postfix)
-                            _btagInfo.useSVClustering = cms.bool(svClustering)
-                            _btagInfo.jetAlgorithm    = cms.string(_algo)
-                            _btagInfo.rParam          = cms.double(rParam)
-                            ## if the jets is actually a subjet
-                            if fatJets != cms.InputTag('') and groomedFatJets != cms.InputTag(''):
-                                _btagInfo.fatJets        = fatJets
-                                _btagInfo.groomedFatJets = groomedFatJets
+                            setupSVClustering(getattr(process, btagInfo+_labelName+postfix), _algo, rParam, fatJets, groomedFatJets)
                     if btagInfo == 'impactParameterTagInfos':
                         setattr(process, btagInfo+_labelName+postfix, btag.impactParameterTagInfos.clone(jetTracks = cms.InputTag('jetTracksAssociatorAtVertex'+_labelName+postfix), primaryVertex=pvSource))
                     if btagInfo == 'secondaryVertexTagInfos':
@@ -391,25 +394,11 @@ class AddJetCollection(ConfigToolBase):
                     if btagInfo == 'inclusiveSecondaryVertexFinderTagInfos':
                         setattr(process, btagInfo+_labelName+postfix, btag.inclusiveSecondaryVertexFinderTagInfos.clone(trackIPTagInfos = cms.InputTag('impactParameterTagInfos'+_labelName+postfix), extSVCollection=svSource))
                         if svClustering:
-                            _btagInfo = getattr(process, btagInfo+_labelName+postfix)
-                            _btagInfo.useSVClustering = cms.bool(svClustering)
-                            _btagInfo.jetAlgorithm    = cms.string(_algo)
-                            _btagInfo.rParam          = cms.double(rParam)
-                            ## if the jets is actually a subjet
-                            if fatJets != cms.InputTag('') and groomedFatJets != cms.InputTag(''):
-                                _btagInfo.fatJets        = fatJets
-                                _btagInfo.groomedFatJets = groomedFatJets
+                            setupSVClustering(getattr(process, btagInfo+_labelName+postfix), _algo, rParam, fatJets, groomedFatJets)
                     if btagInfo == 'inclusiveSecondaryVertexFinderFilteredTagInfos':
                         setattr(process, btagInfo+_labelName+postfix, btag.inclusiveSecondaryVertexFinderFilteredTagInfos.clone(trackIPTagInfos = cms.InputTag('impactParameterTagInfos'+_labelName+postfix)))
                         if svClustering:
-                            _btagInfo = getattr(process, btagInfo+_labelName+postfix)
-                            _btagInfo.useSVClustering = cms.bool(svClustering)
-                            _btagInfo.jetAlgorithm    = cms.string(_algo)
-                            _btagInfo.rParam          = cms.double(rParam)
-                            ## if the jets is actually a subjet
-                            if fatJets != cms.InputTag('') and groomedFatJets != cms.InputTag(''):
-                                _btagInfo.fatJets        = fatJets
-                                _btagInfo.groomedFatJets = groomedFatJets
+                            setupSVClustering(getattr(process, btagInfo+_labelName+postfix), _algo, rParam, fatJets, groomedFatJets)
                     if btagInfo == 'secondaryVertexNegativeTagInfos':
                         setattr(process, btagInfo+_labelName+postfix, btag.secondaryVertexNegativeTagInfos.clone(trackIPTagInfos = cms.InputTag('impactParameterTagInfos'+_labelName+postfix)))
                     if btagInfo == 'inclusiveSecondaryVertexFinderNegativeTagInfos':

--- a/PhysicsTools/PatAlgos/python/tools/jetTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/jetTools.py
@@ -33,12 +33,16 @@ class AddJetCollection(ConfigToolBase):
         self.addParameter(self._defaultParameters,'jetSource','', "Label of the input collection from which the new patJet collection should be created", cms.InputTag)
         self.addParameter(self._defaultParameters,'pfCandidates',cms.InputTag('particleFlow'), "Label of the input collection for candidatecandidatese used in b-tagging", cms.InputTag)
         self.addParameter(self._defaultParameters,'trackSource',cms.InputTag('generalTracks'), "Label of the input collection for tracks to be used in b-tagging", cms.InputTag)
+        self.addParameter(self._defaultParameters,'explicitJTA', False, "Use explicit jet-track association")
         self.addParameter(self._defaultParameters,'pvSource',cms.InputTag('offlinePrimaryVertices'), "Label of the input collection for primary vertices used in b-tagging", cms.InputTag)
         self.addParameter(self._defaultParameters,'svSource',cms.InputTag('inclusiveSecondaryVertices'), "Label of the input collection for IVF vertices used in b-tagging", cms.InputTag)
+        self.addParameter(self._defaultParameters,'svClustering', False, "Secondary vertices ghost-associated to jets using jet clustering (mostly intended for subjets)")
+        self.addParameter(self._defaultParameters,'fatJets', cms.InputTag(''), "Fat jet collection used for secondary vertex clustering", cms.InputTag)
+        self.addParameter(self._defaultParameters,'groomedFatJets', cms.InputTag(''), "Groomed fat jet collection used for secondary vertex clustering", cms.InputTag)
         self.addParameter(self._defaultParameters,'algo', 'AK4', "Jet algorithm of the input collection from which the new patJet collection should be created")
         self.addParameter(self._defaultParameters,'rParam', 0.4, "Jet size (distance parameter R used in jet clustering)")
         self.addParameter(self._defaultParameters,'getJetMCFlavour', True, "Get jet MC truth flavour")
-        self.addParameter(self._defaultParameters,'genJetCollection', cms.InputTag("ak4GenJets"), "GenJet collection to match to")
+        self.addParameter(self._defaultParameters,'genJetCollection', cms.InputTag("ak4GenJets"), "GenJet collection to match to", cms.InputTag)
         self.addParameter(self._defaultParameters,'jetCorrections',None, "Add all relevant information about jet energy corrections that you want to be added to your new patJet \
         collection. The format has to be given in a python tuple of type: (\'AK4Calo\',[\'L2Relative\', \'L3Absolute\'], patMet). Here the first argument corresponds to the payload \
         in the CMS Conditions database for the given jet collection; the second argument corresponds to the jet energy correction levels that you want to be embedded into your \
@@ -74,7 +78,7 @@ class AddJetCollection(ConfigToolBase):
         """
         return self._defaultParameters
 
-    def __call__(self,process,labelName=None,postfix=None,jetSource=None,trackSource=None,pfCandidates=None,pvSource=None,svSource=None,algo=None,rParam=None,getJetMCFlavour=None,genJetCollection=None,jetCorrections=None,btagDiscriminators=None,btagInfos=None,jetTrackAssociation=None,outputModules=None):
+    def __call__(self,process,labelName=None,postfix=None,jetSource=None,pfCandidates=None,trackSource=None,explicitJTA=None,pvSource=None,svSource=None,svClustering=None,fatJets=None,groomedFatJets=None,algo=None,rParam=None,getJetMCFlavour=None,genJetCollection=None,jetCorrections=None,btagDiscriminators=None,btagInfos=None,jetTrackAssociation=None,outputModules=None):
         """
         Function call wrapper. This will check the parameters and call the actual implementation that
         can be found in toolCode via the base class function apply.
@@ -88,21 +92,30 @@ class AddJetCollection(ConfigToolBase):
         if jetSource is None:
             jetSource=self._defaultParameters['jetSource'].value
         self.setParameter('jetSource', jetSource)
-        if svSource is None:
-            svSource=self._defaultParameters['svSource'].value
-        self.setParameter('svSource', svSource)
         if pfCandidates is None:
             pfCandidates=self._defaultParameters['pfCandidates'].value
         self.setParameter('pfCandidates', pfCandidates)
         if trackSource is None:
             trackSource=self._defaultParameters['trackSource'].value
         self.setParameter('trackSource', trackSource)
+        if explicitJTA is None:
+            explicitJTA=self._defaultParameters['explicitJTA'].value
+        self.setParameter('explicitJTA', explicitJTA)
         if pvSource is None:
             pvSource=self._defaultParameters['pvSource'].value
         self.setParameter('pvSource', pvSource)
         if svSource is None:
             svSource=self._defaultParameters['svSource'].value
         self.setParameter('svSource', svSource)
+        if svClustering is None:
+            svClustering=self._defaultParameters['svClustering'].value
+        self.setParameter('svClustering', svClustering)
+        if fatJets is None:
+            fatJets=self._defaultParameters['fatJets'].value
+        self.setParameter('fatJets', fatJets)
+        if groomedFatJets is None:
+            groomedFatJets=self._defaultParameters['groomedFatJets'].value
+        self.setParameter('groomedFatJets', groomedFatJets)
         if algo is None:
             algo=self._defaultParameters['algo'].value
         self.setParameter('algo', algo)
@@ -140,10 +153,14 @@ class AddJetCollection(ConfigToolBase):
         labelName=self._parameters['labelName'].value
         postfix=self._parameters['postfix'].value
         jetSource=self._parameters['jetSource'].value
-        trackSource=self._parameters['trackSource'].value
         pfCandidates=self._parameters['pfCandidates'].value
+        trackSource=self._parameters['trackSource'].value
+        explicitJTA=self._parameters['explicitJTA'].value
         pvSource=self._parameters['pvSource'].value
         svSource=self._parameters['svSource'].value
+        svClustering=self._parameters['svClustering'].value
+        fatJets=self._parameters['fatJets'].value
+        groomedFatJets=self._parameters['groomedFatJets'].value
         algo=self._parameters['algo'].value
         rParam=self._parameters['rParam'].value
         getJetMCFlavour=self._parameters['getJetMCFlavour'].value
@@ -276,20 +293,30 @@ class AddJetCollection(ConfigToolBase):
                 knownModules.append('patJetFlavourAssociation'+_labelName+postfix)
             ## modify new patJets collection accordingly
             _newPatJets.JetFlavourInfoSource.setModuleLabel('patJetFlavourAssociation'+_labelName+postfix)
+            ## if the jets is actually a subjet
+            if fatJets != cms.InputTag('') and groomedFatJets != cms.InputTag(''):
+                _newPatJetFlavourAssociation=getattr(process, 'patJetFlavourAssociation'+_labelName+postfix)
+                _newPatJetFlavourAssociation.jets=fatJets
+                _newPatJetFlavourAssociation.groomedJets=groomedFatJets
+                _newPatJetFlavourAssociation.subjets=jetSource
+                _newPatJets.JetFlavourInfoSource=cms.InputTag('patJetFlavourAssociation'+_labelName+postfix,'SubJets')
         else:
             _newPatJets.getJetMCFlavour = False
 
         ## add jetTrackAssociation for btagging (or jetTracksAssociation only) if required by user
         if (jetTrackAssociation or bTagging):
             ## add new jetTracksAssociationAtVertex to process
-            from RecoJets.JetAssociationProducers.ak4JTA_cff import ak4JetTracksAssociatorAtVertex
+            from RecoJets.JetAssociationProducers.ak4JTA_cff import ak4JetTracksAssociatorAtVertex, ak4JetTracksAssociatorExplicit
             if 'jetTracksAssociationAtVertex'+_labelName+postfix in knownModules :
                 _newJetTracksAssociationAtVertex=getattr(process, 'jetTracksAssociatorAtVertex'+_labelName+postfix)
                 _newJetTracksAssociationAtVertex.jets=jetSource
                 _newJetTracksAssociationAtVertex.tracks=trackSource
                 _newJetTracksAssociationAtVertex.pvSrc=pvSource
             else:
-                setattr(process, 'jetTracksAssociatorAtVertex'+_labelName+postfix, ak4JetTracksAssociatorAtVertex.clone(jets=jetSource,tracks=trackSource,pvSrc=pvSource))
+                jetTracksAssociator=ak4JetTracksAssociatorAtVertex
+                if explicitJTA:
+                    jetTracksAssociator=ak4JetTracksAssociatorExplicit
+                setattr(process, 'jetTracksAssociatorAtVertex'+_labelName+postfix, jetTracksAssociator.clone(jets=jetSource,tracks=trackSource,pvSrc=pvSource))
                 knownModules.append('jetTracksAssociationAtVertex'+_labelName+postfix)
             ## add new patJetCharge to process
             from PhysicsTools.PatAlgos.recoLayer0.jetTracksCharge_cff import patJetCharge
@@ -341,18 +368,48 @@ class AddJetCollection(ConfigToolBase):
                 if hasattr(btag,btagInfo):
                     if btagInfo == 'pfImpactParameterTagInfos':
                         setattr(process, btagInfo+_labelName+postfix, btag.pfImpactParameterTagInfos.clone(jets = jetSource,primaryVertex=pvSource,candidates=pfCandidates))
+                        if explicitJTA:
+                            _btagInfo = getattr(process, btagInfo+_labelName+postfix)
+                            _btagInfo.explicitJTA = cms.bool(explicitJTA)
                     if btagInfo == 'pfSecondaryVertexTagInfos':
                         setattr(process, btagInfo+_labelName+postfix, btag.pfSecondaryVertexTagInfos.clone(trackIPTagInfos = cms.InputTag('pfImpactParameterTagInfos'+_labelName+postfix)))
                     if btagInfo == 'pfInclusiveSecondaryVertexFinderTagInfos':
                         setattr(process, btagInfo+_labelName+postfix, btag.pfInclusiveSecondaryVertexFinderTagInfos.clone(trackIPTagInfos = cms.InputTag('pfImpactParameterTagInfos'+_labelName+postfix)))
+                        if svClustering:
+                            _btagInfo = getattr(process, btagInfo+_labelName+postfix)
+                            _btagInfo.useSVClustering = cms.bool(svClustering)
+                            _btagInfo.jetAlgorithm    = cms.string(_algo)
+                            _btagInfo.rParam          = cms.double(rParam)
+                            ## if the jets is actually a subjet
+                            if fatJets != cms.InputTag('') and groomedFatJets != cms.InputTag(''):
+                                _btagInfo.fatJets        = fatJets
+                                _btagInfo.groomedFatJets = groomedFatJets
                     if btagInfo == 'impactParameterTagInfos':
                         setattr(process, btagInfo+_labelName+postfix, btag.impactParameterTagInfos.clone(jetTracks = cms.InputTag('jetTracksAssociatorAtVertex'+_labelName+postfix), primaryVertex=pvSource))
                     if btagInfo == 'secondaryVertexTagInfos':
                         setattr(process, btagInfo+_labelName+postfix, btag.secondaryVertexTagInfos.clone(trackIPTagInfos = cms.InputTag('impactParameterTagInfos'+_labelName+postfix)))
                     if btagInfo == 'inclusiveSecondaryVertexFinderTagInfos':
                         setattr(process, btagInfo+_labelName+postfix, btag.inclusiveSecondaryVertexFinderTagInfos.clone(trackIPTagInfos = cms.InputTag('impactParameterTagInfos'+_labelName+postfix), extSVCollection=svSource))
+                        if svClustering:
+                            _btagInfo = getattr(process, btagInfo+_labelName+postfix)
+                            _btagInfo.useSVClustering = cms.bool(svClustering)
+                            _btagInfo.jetAlgorithm    = cms.string(_algo)
+                            _btagInfo.rParam          = cms.double(rParam)
+                            ## if the jets is actually a subjet
+                            if fatJets != cms.InputTag('') and groomedFatJets != cms.InputTag(''):
+                                _btagInfo.fatJets        = fatJets
+                                _btagInfo.groomedFatJets = groomedFatJets
                     if btagInfo == 'inclusiveSecondaryVertexFinderFilteredTagInfos':
                         setattr(process, btagInfo+_labelName+postfix, btag.inclusiveSecondaryVertexFinderFilteredTagInfos.clone(trackIPTagInfos = cms.InputTag('impactParameterTagInfos'+_labelName+postfix)))
+                        if svClustering:
+                            _btagInfo = getattr(process, btagInfo+_labelName+postfix)
+                            _btagInfo.useSVClustering = cms.bool(svClustering)
+                            _btagInfo.jetAlgorithm    = cms.string(_algo)
+                            _btagInfo.rParam          = cms.double(rParam)
+                            ## if the jets is actually a subjet
+                            if fatJets != cms.InputTag('') and groomedFatJets != cms.InputTag(''):
+                                _btagInfo.fatJets        = fatJets
+                                _btagInfo.groomedFatJets = groomedFatJets
                     if btagInfo == 'secondaryVertexNegativeTagInfos':
                         setattr(process, btagInfo+_labelName+postfix, btag.secondaryVertexNegativeTagInfos.clone(trackIPTagInfos = cms.InputTag('impactParameterTagInfos'+_labelName+postfix)))
                     if btagInfo == 'inclusiveSecondaryVertexFinderNegativeTagInfos':
@@ -574,8 +631,12 @@ class SwitchJetCollection(ConfigToolBase):
         self.addParameter(self._defaultParameters,'jetSource','', "Label of the input collection from which the new patJet collection should be created", cms.InputTag)
         self.addParameter(self._defaultParameters,'pfCandidates',cms.InputTag('particleFlow'), "Label of the input collection for candidatecandidatese used in b-tagging", cms.InputTag)
         self.addParameter(self._defaultParameters,'trackSource',cms.InputTag('generalTracks'), "Label of the input collection for tracks to be used in b-tagging", cms.InputTag)
+        self.addParameter(self._defaultParameters,'explicitJTA', False, "Use explicit jet-track association")
         self.addParameter(self._defaultParameters,'pvSource',cms.InputTag('offlinePrimaryVertices'), "Label of the input collection for primary vertices used in b-tagging", cms.InputTag)
         self.addParameter(self._defaultParameters,'svSource',cms.InputTag('inclusiveSecondaryVertices'), "Label of the input collection for IVF vertices used in b-tagging", cms.InputTag)
+        self.addParameter(self._defaultParameters,'svClustering', False, "Secondary vertices ghost-associated to jets using jet clustering (mostly intended for subjets)")
+        self.addParameter(self._defaultParameters,'fatJets', cms.InputTag(''), "Fat jet collection used for secondary vertex clustering", cms.InputTag)
+        self.addParameter(self._defaultParameters,'groomedFatJets', cms.InputTag(''), "Groomed fat jet collection used for secondary vertex clustering", cms.InputTag)
         self.addParameter(self._defaultParameters,'algo', 'AK4', "Jet algorithm of the input collection from which the new patJet collection should be created")
         self.addParameter(self._defaultParameters,'rParam', 0.4, "Jet size (distance parameter R used in jet clustering)")
         self.addParameter(self._defaultParameters,'getJetMCFlavour', True, "Get jet MC truth flavour")
@@ -612,7 +673,7 @@ class SwitchJetCollection(ConfigToolBase):
         """
         return self._defaultParameters
 
-    def __call__(self,process,postfix=None,jetSource=None,trackSource=None,pfCandidates=None,pvSource=None,svSource=None,algo=None,rParam=None,getJetMCFlavour=None,genJetCollection=None,jetCorrections=None,btagDiscriminators=None,btagInfos=None,jetTrackAssociation=None,outputModules=None):
+    def __call__(self,process,postfix=None,jetSource=None,pfCandidates=None,trackSource=None,explicitJTA=None,pvSource=None,svSource=None,svClustering=None,fatJets=None,groomedFatJets=None,algo=None,rParam=None,getJetMCFlavour=None,genJetCollection=None,jetCorrections=None,btagDiscriminators=None,btagInfos=None,jetTrackAssociation=None,outputModules=None):
         """
         Function call wrapper. This will check the parameters and call the actual implementation that
         can be found in toolCode via the base class function apply.
@@ -629,12 +690,24 @@ class SwitchJetCollection(ConfigToolBase):
         if trackSource is None:
             trackSource=self._defaultParameters['trackSource'].value
         self.setParameter('trackSource', trackSource)
+        if explicitJTA is None:
+            explicitJTA=self._defaultParameters['explicitJTA'].value
+        self.setParameter('explicitJTA', explicitJTA)
         if pvSource is None:
             pvSource=self._defaultParameters['pvSource'].value
         self.setParameter('pvSource', pvSource)
         if svSource is None:
             svSource=self._defaultParameters['svSource'].value
         self.setParameter('svSource', svSource)
+        if svClustering is None:
+            svClustering=self._defaultParameters['svClustering'].value
+        self.setParameter('svClustering', svClustering)
+        if fatJets is None:
+            fatJets=self._defaultParameters['fatJets'].value
+        self.setParameter('fatJets', fatJets)
+        if groomedFatJets is None:
+            groomedFatJets=self._defaultParameters['groomedFatJets'].value
+        self.setParameter('groomedFatJets', groomedFatJets)
         if algo is None:
             algo=self._defaultParameters['algo'].value
         self.setParameter('algo', algo)
@@ -673,8 +746,12 @@ class SwitchJetCollection(ConfigToolBase):
         jetSource=self._parameters['jetSource'].value
         pfCandidates=self._parameters['pfCandidates'].value
         trackSource=self._parameters['trackSource'].value
+        explicitJTA=self._parameters['explicitJTA'].value
         pvSource=self._parameters['pvSource'].value
         svSource=self._parameters['svSource'].value
+        svClustering=self._parameters['svClustering'].value
+        fatJets=self._parameters['fatJets'].value
+        groomedFatJets=self._parameters['groomedFatJets'].value
         algo=self._parameters['algo'].value
         rParam=self._parameters['rParam'].value
         getJetMCFlavour=self._parameters['getJetMCFlavour'].value
@@ -691,10 +768,14 @@ class SwitchJetCollection(ConfigToolBase):
             labelName='',
             postfix=postfix,
             jetSource=jetSource,
-            trackSource=trackSource,
             pfCandidates=pfCandidates,
+            trackSource=trackSource,
+            explicitJTA=explicitJTA,
             pvSource=pvSource,
             svSource=svSource,
+            svClustering=svClustering,
+            fatJets=fatJets,
+            groomedFatJets=groomedFatJets,
             algo=algo,
             rParam=rParam,
             getJetMCFlavour=getJetMCFlavour,

--- a/RecoBTag/ImpactParameter/plugins/IPProducer.h
+++ b/RecoBTag/ImpactParameter/plugins/IPProducer.h
@@ -84,7 +84,8 @@ namespace IPProducerHelpers {
       class FromJetAndCands{
               public:
 		      FromJetAndCands(const edm::ParameterSet& iConfig,  edm::ConsumesCollector && iC): token_jets(iC.consumes<edm::View<reco::Jet> >(iConfig.getParameter<edm::InputTag>("jets"))),          
-		      token_cands(iC.consumes<edm::View<reco::Candidate> >(iConfig.getParameter<edm::InputTag>("candidates"))), maxDeltaR(iConfig.getParameter<double>("maxDeltaR")){}
+		      token_cands(iC.consumes<edm::View<reco::Candidate> >(iConfig.getParameter<edm::InputTag>("candidates"))), maxDeltaR(iConfig.getParameter<double>("maxDeltaR")),
+		      explicitJTA(iConfig.existsAs<bool>("explicitJTA") ? iConfig.getParameter<bool>("explicitJTA") : false) {}
 
                       std::vector<reco::CandidatePtr> tracks(edm::Event&,const reco::JetTagInfo & it)
                       {
@@ -103,12 +104,22 @@ namespace IPProducerHelpers {
                               for(edm::View<reco::Jet>::const_iterator it = jets->begin();
                                               it != jets->end(); it++, i++) {
                                       edm::RefToBase<reco::Jet> jRef(jets, i);
-                                      bases.push_back(jRef);
-				      //FIXME: add deltaR or any other requirement here
-				      for(size_t j=0;j<cands->size();j++) {
-					      if((*cands)[j].bestTrack()!=0 &&  ROOT::Math::VectorUtil::DeltaR((*cands)[j].p4(),(*jets)[i].p4()) < maxDeltaR && (*cands)[j].charge() !=0 ){
-						      m_map[i].push_back(cands->ptrAt(j));	
-					      }
+                                      bases.push_back(reco::JetTagInfo(jRef));
+				      if( explicitJTA )
+				      {
+					  for(size_t j=0;j<it->numberOfDaughters();++j) {
+						  if( it->daughterPtr(j)->bestTrack()!=0 && it->daughterPtr(j)->charge() !=0 ){
+							  m_map[i].push_back(it->daughterPtr(j));
+						  }
+					  }
+				      }
+				      else
+				      {
+					  for(size_t j=0;j<cands->size();++j) {
+						  if( (*cands)[j].bestTrack()!=0 &&  ROOT::Math::VectorUtil::DeltaR((*cands)[j].p4(),(*jets)[i].p4()) < maxDeltaR && (*cands)[j].charge() !=0 ){
+							  m_map[i].push_back(cands->ptrAt(j));
+						  }
+					  }
 				      }
                               }
                               return bases;
@@ -116,7 +127,8 @@ namespace IPProducerHelpers {
 		      std::vector<std::vector<reco::CandidatePtr> > m_map;	
                       edm::EDGetTokenT<edm::View<reco::Jet> > token_jets;
                       edm::EDGetTokenT<edm::View<reco::Candidate> >token_cands;
-		      double maxDeltaR;	
+		      double maxDeltaR;
+		      bool   explicitJTA;
       };
 }
 template <class Container, class Base, class Helper> 

--- a/RecoBTag/ImpactParameter/plugins/IPProducer.h
+++ b/RecoBTag/ImpactParameter/plugins/IPProducer.h
@@ -116,7 +116,7 @@ namespace IPProducerHelpers {
 				      else
 				      {
 					  for(size_t j=0;j<cands->size();++j) {
-						  if( (*cands)[j].bestTrack()!=0 &&  ROOT::Math::VectorUtil::DeltaR((*cands)[j].p4(),(*jets)[i].p4()) < maxDeltaR && (*cands)[j].charge() !=0 ){
+						  if( (*cands)[j].bestTrack()!=0 && Geom::deltaR2((*cands)[j].p4(),(*jets)[i].p4()) < maxDeltaR*maxDeltaR && (*cands)[j].charge() !=0 ){
 							  m_map[i].push_back(cands->ptrAt(j));
 						  }
 					  }

--- a/RecoBTag/ImpactParameter/plugins/IPProducer.h
+++ b/RecoBTag/ImpactParameter/plugins/IPProducer.h
@@ -99,7 +99,8 @@ namespace IPProducerHelpers {
                               edm::Handle<edm::View<reco::Candidate> > cands;
                               iEvent.getByToken(token_cands, cands);
 			      m_map.clear();
-			      m_map.resize(jets->size());	
+			      m_map.resize(jets->size());
+			      double maxDeltaR2 = maxDeltaR*maxDeltaR;
                               size_t i = 0;
                               for(edm::View<reco::Jet>::const_iterator it = jets->begin();
                                               it != jets->end(); it++, i++) {
@@ -116,7 +117,7 @@ namespace IPProducerHelpers {
 				      else
 				      {
 					  for(size_t j=0;j<cands->size();++j) {
-						  if( (*cands)[j].bestTrack()!=0 && Geom::deltaR2((*cands)[j].p4(),(*jets)[i].p4()) < maxDeltaR*maxDeltaR && (*cands)[j].charge() !=0 ){
+						  if( (*cands)[j].bestTrack()!=0 && Geom::deltaR2((*cands)[j].p4(),(*jets)[i].p4()) < maxDeltaR2 && (*cands)[j].charge() !=0 ){
 							  m_map[i].push_back(cands->ptrAt(j));
 						  }
 					  }

--- a/RecoBTag/SecondaryVertex/plugins/BuildFile.xml
+++ b/RecoBTag/SecondaryVertex/plugins/BuildFile.xml
@@ -14,6 +14,7 @@
    <use name="TrackingTools/TransientTrack"/>
    <use name="RecoVertex/ConfigurableVertexReco"/>
    <use name="RecoVertex/GhostTrackFitter"/>
+   <use name="fastjet"/>
    <flags EDM_PLUGIN="1"/>
 </library>
 

--- a/RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc
+++ b/RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc
@@ -452,6 +452,10 @@ void TemplatedSecondaryVertexProducer<IPTI,VTX>::produce(edm::Event &event,
 	    // collect clustered SVs
 	    for(size_t i=0; i<fatJetsHandle->size(); ++i)
 	    {
+	      if( reclusteredIndices.at(i) < 0 ) continue; // continue if matching reclustered to original jets failed
+	
+	      if( subjetIndices.at(i).size()==0 ) continue; // continue if the original jet does not have subjets assigned
+		
 	      // since the "ghosts" are extremely soft, the configuration and ordering of the reclustered and original fat jets should in principle stay the same
 	      if( ( fabs( inclusiveJets.at(reclusteredIndices.at(i)).pt() - fatJetsHandle->at(i).pt() ) / fatJetsHandle->at(i).pt() ) > relPtTolerance )
 	      {
@@ -477,8 +481,6 @@ void TemplatedSecondaryVertexProducer<IPTI,VTX>::produce(edm::Event &event,
 		 
 		 svIndices.push_back( it->user_info<VertexInfo>().vertexIndex() );
 	      }
-
-	      if( subjetIndices.at(i).size()==0 ) continue; // continue if the original jet does not have subjets assigned
 	
 	      // loop over clustered SVs and assign them to different subjets based on smallest dR
 	      for(size_t sv=0; sv<svIndices.size(); ++sv)
@@ -515,6 +517,8 @@ void TemplatedSecondaryVertexProducer<IPTI,VTX>::produce(edm::Event &event,
 	    // collect clustered SVs
 	    for(size_t i=0; i<trackIPTagInfos->size(); ++i)
 	    {
+	      if( reclusteredIndices.at(i) < 0 ) continue; // continue if matching reclustered to original jets failed
+	
 	      // since the "ghosts" are extremely soft, the configuration and ordering of the reclustered and original jets should in principle stay the same
 	      if( ( fabs( inclusiveJets.at(reclusteredIndices.at(i)).pt() - trackIPTagInfos->at(i).jet()->pt() ) / trackIPTagInfos->at(i).jet()->pt() ) > 1e-3 ) // 0.1% difference in Pt should be sufficient to detect possible misconfigurations
 	      {
@@ -1015,7 +1019,7 @@ void TemplatedSecondaryVertexProducer<IPTI,VTX>::matchGroomedJets(const edm::Han
      double matchedDR2 = 1e9;
      int matchedIdx = -1;
 
-     if( groomedJets->at(gj).pt()>0. ) // skips pathological cases of groomed jets with Pt=0
+     if( groomedJets->at(gj).pt()>0. ) // skip pathological cases of groomed jets with Pt=0
      {
        for(size_t j=0; j<jets->size(); ++j)
        {

--- a/RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc
+++ b/RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc
@@ -454,6 +454,12 @@ void TemplatedSecondaryVertexProducer<IPTI,VTX>::produce(edm::Event &event,
 	    {
 	      if( reclusteredIndices.at(i) < 0 ) continue; // continue if matching reclustered to original jets failed
 	
+	      if( fatJetsHandle->at(i).pt() == 0 ) // continue if the original jet has Pt=0
+	      {
+	        edm::LogWarning("NullTransverseMomentum") << "The original fat jet " << i << " has Pt=0. This is not expected so the jet will be skipped.";
+	        continue;
+	      }
+	
 	      if( subjetIndices.at(i).size()==0 ) continue; // continue if the original jet does not have subjets assigned
 		
 	      // since the "ghosts" are extremely soft, the configuration and ordering of the reclustered and original fat jets should in principle stay the same
@@ -518,6 +524,12 @@ void TemplatedSecondaryVertexProducer<IPTI,VTX>::produce(edm::Event &event,
 	    for(size_t i=0; i<trackIPTagInfos->size(); ++i)
 	    {
 	      if( reclusteredIndices.at(i) < 0 ) continue; // continue if matching reclustered to original jets failed
+	
+	      if( trackIPTagInfos->at(i).jet()->pt() == 0 ) // continue if the original jet has Pt=0
+	      {
+	        edm::LogWarning("NullTransverseMomentum") << "The original jet " << i << " has Pt=0. This is not expected so the jet will be skipped.";
+	        continue;
+	      }
 	
 	      // since the "ghosts" are extremely soft, the configuration and ordering of the reclustered and original jets should in principle stay the same
 	      if( ( fabs( inclusiveJets.at(reclusteredIndices.at(i)).pt() - trackIPTagInfos->at(i).jet()->pt() ) / trackIPTagInfos->at(i).jet()->pt() ) > 1e-3 ) // 0.1% difference in Pt should be sufficient to detect possible misconfigurations

--- a/RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc
+++ b/RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc
@@ -532,7 +532,7 @@ void TemplatedSecondaryVertexProducer<IPTI,VTX>::produce(edm::Event &event,
 	      }
 	
 	      // since the "ghosts" are extremely soft, the configuration and ordering of the reclustered and original jets should in principle stay the same
-	      if( ( fabs( inclusiveJets.at(reclusteredIndices.at(i)).pt() - trackIPTagInfos->at(i).jet()->pt() ) / trackIPTagInfos->at(i).jet()->pt() ) > 1e-3 ) // 0.1% difference in Pt should be sufficient to detect possible misconfigurations
+	      if( ( fabs( inclusiveJets.at(reclusteredIndices.at(i)).pt() - trackIPTagInfos->at(i).jet()->pt() ) / trackIPTagInfos->at(i).jet()->pt() ) > relPtTolerance )
 	      {
 		 if( trackIPTagInfos->at(i).jet()->pt() < 10. )  // special handling for low-Pt jets (Pt<10 GeV)
 		   edm::LogWarning("JetPtMismatchAtLowPt") << "The reclustered and original jet " << i << " have different Pt's (" << inclusiveJets.at(reclusteredIndices.at(i)).pt() << " vs " << trackIPTagInfos->at(i).jet()->pt() << " GeV, respectively).\n"

--- a/RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc
+++ b/RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc
@@ -465,7 +465,7 @@ void TemplatedSecondaryVertexProducer<IPTI,VTX>::produce(edm::Event &event,
 	      if( subjetIndices.at(i).size()==0 ) continue; // continue if the original jet does not have subjets assigned
 		
 	      // since the "ghosts" are extremely soft, the configuration and ordering of the reclustered and original fat jets should in principle stay the same
-	      if( ( fabs( inclusiveJets.at(reclusteredIndices.at(i)).pt() - fatJetsHandle->at(i).pt() ) / fatJetsHandle->at(i).pt() ) > relPtTolerance )
+	      if( ( std::abs( inclusiveJets.at(reclusteredIndices.at(i)).pt() - fatJetsHandle->at(i).pt() ) / fatJetsHandle->at(i).pt() ) > relPtTolerance )
 	      {
 		 if( fatJetsHandle->at(i).pt() < 10. )  // special handling for low-Pt jets (Pt<10 GeV)
 		   edm::LogWarning("JetPtMismatchAtLowPt") << "The reclustered and original fat jet " << i << " have different Pt's (" << inclusiveJets.at(reclusteredIndices.at(i)).pt() << " vs " << fatJetsHandle->at(i).pt() << " GeV, respectively).\n"
@@ -534,7 +534,7 @@ void TemplatedSecondaryVertexProducer<IPTI,VTX>::produce(edm::Event &event,
 	      }
 	
 	      // since the "ghosts" are extremely soft, the configuration and ordering of the reclustered and original jets should in principle stay the same
-	      if( ( fabs( inclusiveJets.at(reclusteredIndices.at(i)).pt() - trackIPTagInfos->at(i).jet()->pt() ) / trackIPTagInfos->at(i).jet()->pt() ) > relPtTolerance )
+	      if( ( std::abs( inclusiveJets.at(reclusteredIndices.at(i)).pt() - trackIPTagInfos->at(i).jet()->pt() ) / trackIPTagInfos->at(i).jet()->pt() ) > relPtTolerance )
 	      {
 		 if( trackIPTagInfos->at(i).jet()->pt() < 10. )  // special handling for low-Pt jets (Pt<10 GeV)
 		   edm::LogWarning("JetPtMismatchAtLowPt") << "The reclustered and original jet " << i << " have different Pt's (" << inclusiveJets.at(reclusteredIndices.at(i)).pt() << " vs " << trackIPTagInfos->at(i).jet()->pt() << " GeV, respectively).\n"

--- a/RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc
+++ b/RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc
@@ -48,9 +48,31 @@
 
 #include "DataFormats/GeometryVector/interface/VectorUtil.h"
 
+#include "fastjet/JetDefinition.hh"
+#include "fastjet/ClusterSequence.hh"
+#include "fastjet/PseudoJet.hh"
+
+//
+// constants, enums and typedefs
+//
+typedef boost::shared_ptr<fastjet::ClusterSequence>  ClusterSequencePtr;
+typedef boost::shared_ptr<fastjet::JetDefinition>    JetDefPtr;
+
+
 using namespace reco;
 
 namespace {
+	class VertexInfo : public fastjet::PseudoJet::UserInfoBase{
+	  public:
+	    VertexInfo(const int vertexIndex) :
+	      m_vertexIndex(vertexIndex) { }
+
+	    inline const int vertexIndex() const { return m_vertexIndex; }
+
+	  protected:
+	    int m_vertexIndex;
+	};
+	
 	template<typename T>
 	struct RefToBaseLess : public std::binary_function<edm::RefToBase<T>,
 							   edm::RefToBase<T>,
@@ -89,6 +111,20 @@ class TemplatedSecondaryVertexProducer : public edm::stream::EDProducer<> {
 	virtual void produce(edm::Event &event, const edm::EventSetup &es) override;
 
     private:
+	void matchReclusteredJets(const edm::Handle<std::vector<IPTI> >& jets,
+				  const std::vector<fastjet::PseudoJet>& matchedJets,
+				  std::vector<int>& matchedIndices);
+	void matchReclusteredFatJets(const edm::Handle<edm::View<reco::Jet> >& jets,
+				     const std::vector<fastjet::PseudoJet>& matchedJets,
+				     std::vector<int>& matchedIndices);
+	void matchGroomedJets(const edm::Handle<edm::View<reco::Jet> >& jets,
+			      const edm::Handle<edm::View<reco::Jet> >& matchedJets,
+			      std::vector<int>& matchedIndices);
+	void matchSubjets(const std::vector<int>& groomedIndices,
+			  const edm::Handle<edm::View<reco::Jet> >& groomedJets,
+			  const edm::Handle<std::vector<IPTI> >& subjets,
+			  std::vector<std::vector<int> >& matchedIndices);
+
 	enum ConstraintType {
 		CONSTRAINT_NONE	= 0,
 		CONSTRAINT_BEAMSPOT,
@@ -114,6 +150,19 @@ class TemplatedSecondaryVertexProducer : public edm::stream::EDProducer<> {
         bool                            useExternalSV;  
         double                          extSVDeltaRToJet;      
         edm::EDGetTokenT<edm::View<VTX> > token_extSVCollection;
+	bool				useSVClustering;
+	bool				useSVMomentum;
+	std::string			jetAlgorithm;
+	double				rParam;
+	double				jetPtMin;
+	double				ghostRescaling;
+	double				relPtTolerance;
+	bool				useFatJets;
+	edm::EDGetTokenT<edm::View<reco::Jet> > token_fatJets;
+	edm::EDGetTokenT<edm::View<reco::Jet> > token_groomedFatJets;
+	
+	ClusterSequencePtr		fjClusterSeq;
+	JetDefPtr			fjJetDefinition;
 
 	void markUsedTracks(TrackDataVector & trackData, const input_container & trackRefs, const SecondaryVertex & sv,size_t idx);
 
@@ -224,6 +273,33 @@ TemplatedSecondaryVertexProducer<IPTI,VTX>::TemplatedSecondaryVertexProducer(
 	   token_extSVCollection =  consumes<edm::View<VTX> >(params.getParameter<edm::InputTag>("extSVCollection"));
        	   extSVDeltaRToJet = params.getParameter<double>("extSVDeltaRToJet");
         }
+        useSVClustering = ( params.existsAs<bool>("useSVClustering") ? params.getParameter<bool>("useSVClustering") : false );
+	useSVMomentum = ( params.existsAs<bool>("useSVMomentum") ? params.getParameter<bool>("useSVMomentum") : false );
+        useFatJets = ( useExternalSV && useSVClustering && params.exists("fatJets") && params.exists("groomedFatJets") );
+	if( useSVClustering )
+	{
+	  jetAlgorithm = params.getParameter<std::string>("jetAlgorithm");
+	  rParam = params.getParameter<double>("rParam");
+	  jetPtMin = 0.; // hardcoded to 0. since we simply want to recluster all input jets which already had some PtMin applied
+	  ghostRescaling = ( params.existsAs<double>("ghostRescaling") ? params.getParameter<double>("ghostRescaling") : 1e-18 );
+	  relPtTolerance = ( params.existsAs<double>("relPtTolerance") ? params.getParameter<double>("relPtTolerance") : 1e-03); // 0.1% relative difference in Pt should be sufficient to detect possible misconfigurations
+
+	  // set jet algorithm
+	  if (jetAlgorithm=="Kt")
+	    fjJetDefinition = JetDefPtr( new fastjet::JetDefinition(fastjet::kt_algorithm, rParam) );
+	  else if (jetAlgorithm=="CambridgeAachen")
+	    fjJetDefinition = JetDefPtr( new fastjet::JetDefinition(fastjet::cambridge_algorithm, rParam) );
+	  else if (jetAlgorithm=="AntiKt")
+	    fjJetDefinition = JetDefPtr( new fastjet::JetDefinition(fastjet::antikt_algorithm, rParam) );
+	  else
+	    throw cms::Exception("InvalidJetAlgorithm") << "Jet clustering algorithm is invalid: " << jetAlgorithm << ", use CambridgeAachen | Kt | AntiKt" << std::endl;
+	}
+	if( useFatJets )
+	{
+	  token_fatJets = consumes<edm::View<reco::Jet> >(params.getParameter<edm::InputTag>("fatJets"));
+	  token_groomedFatJets = consumes<edm::View<reco::Jet> >(params.getParameter<edm::InputTag>("groomedFatJets"));
+	}
+	
 	produces<Product>();
 }
 template <class IPTI,class VTX>
@@ -251,7 +327,17 @@ void TemplatedSecondaryVertexProducer<IPTI,VTX>::produce(edm::Event &event,
         // External Sec Vertex collection (e.g. for IVF usage)
         edm::Handle<edm::View<VTX> > extSecVertex;          
         if(useExternalSV) event.getByToken(token_extSVCollection,extSecVertex);
-                                                             
+
+	edm::Handle<edm::View<reco::Jet> > fatJetsHandle;
+	edm::Handle<edm::View<reco::Jet> > groomedFatJetsHandle;
+	if( useFatJets )
+	{
+	  event.getByToken(token_fatJets, fatJetsHandle);
+	  event.getByToken(token_groomedFatJets, groomedFatJetsHandle);
+	
+	  if( groomedFatJetsHandle->size() > fatJetsHandle->size() )
+            edm::LogError("TooManyGroomedJets") << "There are more groomed (" << groomedFatJetsHandle->size() << ") than original fat jets (" << fatJetsHandle->size() << "). Please check that the two jet collections belong to each other.";
+	}
 
 	edm::Handle<BeamSpot> beamSpot;
 	unsigned int bsCovSrc[7] = { 0, };
@@ -283,6 +369,180 @@ void TemplatedSecondaryVertexProducer<IPTI,VTX>::produce(edm::Event &event,
 	    default:
 		/* nothing */;
 	}
+
+	// ------------------------------------ SV clustering START --------------------------------------------
+	std::vector<std::vector<int> > clusteredSVs(trackIPTagInfos->size(),std::vector<int>());
+	if( useExternalSV && useSVClustering && trackIPTagInfos->size()>0 )
+	{
+	  // vector of constituents for reclustering jets and "ghost" SVs
+	  std::vector<fastjet::PseudoJet> fjInputs;
+	  // loop over all input jets and collect all their constituents
+	  if( useFatJets )
+	  {
+	    for(edm::View<reco::Jet>::const_iterator it = fatJetsHandle->begin(); it != fatJetsHandle->end(); ++it)
+	    {
+	      std::vector<edm::Ptr<reco::Candidate> > constituents = it->getJetConstituents();
+	      std::vector<edm::Ptr<reco::Candidate> >::const_iterator m;
+	      for( m = constituents.begin(); m != constituents.end(); ++m )
+	      {
+		 reco::CandidatePtr constit = *m;
+		 if(constit->pt() == 0)
+		 {
+		   edm::LogWarning("NullTransverseMomentum") << "dropping input candidate with pt=0";
+		   continue;
+		 }
+		 fjInputs.push_back(fastjet::PseudoJet(constit->px(),constit->py(),constit->pz(),constit->energy()));
+	      }
+	    }
+	  }
+	  else
+	  {
+	    for(typename std::vector<IPTI>::const_iterator it = trackIPTagInfos->begin(); it != trackIPTagInfos->end(); ++it)
+	    {
+	      std::vector<edm::Ptr<reco::Candidate> > constituents = it->jet()->getJetConstituents();
+	      std::vector<edm::Ptr<reco::Candidate> >::const_iterator m;
+	      for( m = constituents.begin(); m != constituents.end(); ++m )
+	      {
+		 reco::CandidatePtr constit = *m;
+		 if(constit->pt() == 0)
+		 {
+		   edm::LogWarning("NullTransverseMomentum") << "dropping input candidate with pt=0";
+		   continue;
+		 }
+		 fjInputs.push_back(fastjet::PseudoJet(constit->px(),constit->py(),constit->pz(),constit->energy()));
+	      }
+	    }
+	  }
+	  // insert "ghost" SVs in the vector of constituents
+	  for(typename edm::View<VTX>::const_iterator it = extSecVertex->begin(); it != extSecVertex->end(); ++it)
+	  {
+	    const reco::Vertex &pv = *(trackIPTagInfos->front().primaryVertex());
+	    GlobalVector dir = flightDirection(pv, *it);
+	    dir = dir.unit();
+	    fastjet::PseudoJet p(dir.x(),dir.y(),dir.z(),dir.mag()); // using SV flight direction so treating SV as massless
+	    if( useSVMomentum )
+	      p = fastjet::PseudoJet(it->p4().px(),it->p4().py(),it->p4().pz(),it->p4().energy());
+	    p*=ghostRescaling; // rescale SV direction/momentum
+	    p.set_user_info(new VertexInfo( it - extSecVertex->begin() ));
+	    fjInputs.push_back(p);
+	  }
+	  
+	  // define jet clustering sequence
+	  fjClusterSeq = ClusterSequencePtr( new fastjet::ClusterSequence( fjInputs, *fjJetDefinition ) );
+	  // recluster jet constituents and inserted "ghosts"
+	  std::vector<fastjet::PseudoJet> inclusiveJets = fastjet::sorted_by_pt( fjClusterSeq->inclusive_jets(jetPtMin) );
+	  
+	  if( useFatJets )
+	  {
+	    if( inclusiveJets.size() < fatJetsHandle->size() )
+             edm::LogError("TooFewReclusteredJets") << "There are fewer reclustered (" << inclusiveJets.size() << ") than original fat jets (" << fatJetsHandle->size() << "). Please check that the jet algorithm and jet size match those used for the original jet collection.";
+
+	    // match reclustered and original fat jets
+	    std::vector<int> reclusteredIndices;
+	    matchReclusteredFatJets(fatJetsHandle,inclusiveJets,reclusteredIndices);
+
+	    // match groomed and original fat jets
+	    std::vector<int> groomedIndices;
+	    matchGroomedJets(fatJetsHandle,groomedFatJetsHandle,groomedIndices);
+
+	    // match subjets and original fat jets
+	    std::vector<std::vector<int> > subjetIndices;
+	    matchSubjets(groomedIndices,groomedFatJetsHandle,trackIPTagInfos,subjetIndices);
+	
+	    // collect clustered SVs
+	    for(size_t i=0; i<fatJetsHandle->size(); ++i)
+	    {
+	      // since the "ghosts" are extremely soft, the configuration and ordering of the reclustered and original fat jets should in principle stay the same
+	      if( ( fabs( inclusiveJets.at(reclusteredIndices.at(i)).pt() - fatJetsHandle->at(i).pt() ) / fatJetsHandle->at(i).pt() ) > relPtTolerance )
+	      {
+		 if( fatJetsHandle->at(i).pt() < 10. )  // special handling for low-Pt jets (Pt<10 GeV)
+		   edm::LogWarning("JetPtMismatchAtLowPt") << "The reclustered and original fat jet " << i << " have different Pt's (" << inclusiveJets.at(reclusteredIndices.at(i)).pt() << " vs " << fatJetsHandle->at(i).pt() << " GeV, respectively).\n"
+							   << "Please check that the jet algorithm and jet size match those used for the original fat jet collection and also make sure the original fat jets are uncorrected. In addition, make sure you are not using CaloJets which are presently not supported.\n"
+							   << "Since the mismatch is at low Pt, it is ignored and only a warning is issued.\n"
+							   << "\nIn extremely rare instances the mismatch could be caused by a difference in the machine precision in which case make sure the original jet collection is produced and reclustering is performed in the same job.";
+		 else
+		   edm::LogError("JetPtMismatch") << "The reclustered and original fat jet " << i << " have different Pt's (" << inclusiveJets.at(reclusteredIndices.at(i)).pt() << " vs " << fatJetsHandle->at(i).pt() << " GeV, respectively).\n"
+						  << "Please check that the jet algorithm and jet size match those used for the original fat jet collection and also make sure the original fat jets are uncorrected. In addition, make sure you are not using CaloJets which are presently not supported.\n"
+						  << "\nIn extremely rare instances the mismatch could be caused by a difference in the machine precision in which case make sure the original jet collection is produced and reclustering is performed in the same job.";
+	      }
+	
+	      // get jet constituents
+	      std::vector<fastjet::PseudoJet> constituents = inclusiveJets.at(reclusteredIndices.at(i)).constituents();
+
+	      std::vector<int> svIndices;
+	      // loop over jet constituents and try to find "ghosts"
+	      for(std::vector<fastjet::PseudoJet>::const_iterator it = constituents.begin(); it != constituents.end(); ++it)
+	      {
+		 if( !it->has_user_info() ) continue; // skip if not a "ghost"
+		 
+		 svIndices.push_back( it->user_info<VertexInfo>().vertexIndex() );
+	      }
+
+	      if( subjetIndices.at(i).size()==0 ) continue; // continue if the original jet does not have subjets assigned
+	
+	      // loop over clustered SVs and assign them to different subjets based on smallest dR
+	      for(size_t sv=0; sv<svIndices.size(); ++sv)
+	      {
+		const reco::Vertex &pv = *(trackIPTagInfos->front().primaryVertex());
+		const VTX &extSV = (*extSecVertex)[ svIndices.at(sv) ];
+		GlobalVector dir = flightDirection(pv, extSV);
+		dir = dir.unit();
+		fastjet::PseudoJet p(dir.x(),dir.y(),dir.z(),dir.mag()); // using SV flight direction so treating SV as massless
+		if( useSVMomentum )
+		  p = fastjet::PseudoJet(extSV.p4().px(),extSV.p4().py(),extSV.p4().pz(),extSV.p4().energy());
+		
+		std::vector<double> dR2toSubjets;
+		
+		for(size_t sj=0; sj<subjetIndices.at(i).size(); ++sj)
+		  dR2toSubjets.push_back( reco::deltaR2( p.rapidity(), p.phi_std(), trackIPTagInfos->at(subjetIndices.at(i).at(sj)).jet()->rapidity(), trackIPTagInfos->at(subjetIndices.at(i).at(sj)).jet()->phi() ) );
+
+		// find the closest subjet
+		int closestSubjetIdx = std::distance( dR2toSubjets.begin(), std::min_element(dR2toSubjets.begin(), dR2toSubjets.end()) );
+
+		clusteredSVs.at(subjetIndices.at(i).at(closestSubjetIdx)).push_back( svIndices.at(sv) );
+	      }
+	    }
+	  }
+	  else
+	  {
+	    if( inclusiveJets.size() < trackIPTagInfos->size() )
+	      edm::LogError("TooFewReclusteredJets") << "There are fewer reclustered (" << inclusiveJets.size() << ") than original jets (" << trackIPTagInfos->size() << "). Please check that the jet algorithm and jet size match those used for the original jet collection.";
+	
+	    // match reclustered and original jets
+	    std::vector<int> reclusteredIndices;
+	    matchReclusteredJets(trackIPTagInfos,inclusiveJets,reclusteredIndices);
+	
+	    // collect clustered SVs
+	    for(size_t i=0; i<trackIPTagInfos->size(); ++i)
+	    {
+	      // since the "ghosts" are extremely soft, the configuration and ordering of the reclustered and original jets should in principle stay the same
+	      if( ( fabs( inclusiveJets.at(reclusteredIndices.at(i)).pt() - trackIPTagInfos->at(i).jet()->pt() ) / trackIPTagInfos->at(i).jet()->pt() ) > 1e-3 ) // 0.1% difference in Pt should be sufficient to detect possible misconfigurations
+	      {
+		 if( trackIPTagInfos->at(i).jet()->pt() < 10. )  // special handling for low-Pt jets (Pt<10 GeV)
+		   edm::LogWarning("JetPtMismatchAtLowPt") << "The reclustered and original jet " << i << " have different Pt's (" << inclusiveJets.at(reclusteredIndices.at(i)).pt() << " vs " << trackIPTagInfos->at(i).jet()->pt() << " GeV, respectively).\n"
+							   << "Please check that the jet algorithm and jet size match those used for the original jet collection and also make sure the original jets are uncorrected. In addition, make sure you are not using CaloJets which are presently not supported.\n"
+							   << "Since the mismatch is at low Pt, it is ignored and only a warning is issued.\n"
+							   << "\nIn extremely rare instances the mismatch could be caused by a difference in the machine precision in which case make sure the original jet collection is produced and reclustering is performed in the same job.";
+		 else
+		   edm::LogError("JetPtMismatch") << "The reclustered and original jet " << i << " have different Pt's (" << inclusiveJets.at(reclusteredIndices.at(i)).pt() << " vs " << trackIPTagInfos->at(i).jet()->pt() << " GeV, respectively).\n"
+						  << "Please check that the jet algorithm and jet size match those used for the original jet collection and also make sure the original jets are uncorrected. In addition, make sure you are not using CaloJets which are presently not supported.\n"
+						  << "\nIn extremely rare instances the mismatch could be caused by a difference in the machine precision in which case make sure the original jet collection is produced and reclustering is performed in the same job.";
+	      }
+	
+	      // get jet constituents
+	      std::vector<fastjet::PseudoJet> constituents = inclusiveJets.at(reclusteredIndices.at(i)).constituents();
+
+	      // loop over jet constituents and try to find "ghosts"
+	      for(std::vector<fastjet::PseudoJet>::const_iterator it = constituents.begin(); it != constituents.end(); ++it)
+	      {
+		 if( !it->has_user_info() ) continue; // skip if not a "ghost"
+		 // push back clustered SV indices
+		 clusteredSVs.at(i).push_back( it->user_info<VertexInfo>().vertexIndex() );
+	      }
+	    }
+	  }
+	}
+	// ------------------------------------ SV clustering END ----------------------------------------------
 
 	std::auto_ptr<ConfigurableVertexReconstructor> vertexReco;
 	std::auto_ptr<GhostTrackVertexFinder> vertexRecoGT;
@@ -480,39 +740,49 @@ void TemplatedSecondaryVertexProducer<IPTI,VTX>::produce(edm::Event &event,
 						primaries_, fitTracks,
 						*beamSpot);
 		    }	break;
-		}
+		  }
+		  // build combined SV information and filter
+		  SVBuilder svBuilder(pv, jetDir, withPVError, minTrackWeight);
+		  std::remove_copy_if(boost::make_transform_iterator(
+					  fittedSVs.begin(), svBuilder),
+				      boost::make_transform_iterator(
+					  fittedSVs.end(), svBuilder),
+				      std::back_inserter(SVs),
+				      SVFilter(vertexFilter, pv, jetDir));
 
-		// build combined SV information and filter
+		}else{
+		  if( !useSVClustering ) {
+		      for(size_t iExtSv = 0; iExtSv < extSecVertex->size(); iExtSv++){
+			 const VTX & extVertex = (*extSecVertex)[iExtSv];
+// 			 GlobalVector vtxDir = GlobalVector(extVertex.p4().X(),extVertex.p4().Y(),extVertex.p4().Z());
+// 			 if(Geom::deltaR(extVertex.position() - pv.position(), vtxDir)>0.2) continue; //pointing angle
+// 			 std::cout << " dR " << iExtSv << " " << Geom::deltaR( ( extVertex.position() - pv.position() ), jetDir ) << "eta: " << ( extVertex.position() - pv.position()).eta() << " vs " << jetDir.eta() << " phi: "  << ( extVertex.position() - pv.position()).phi() << " vs  " << jetDir.phi() <<  std::endl; 
+			 if( Geom::deltaR( ( position(extVertex) - pv.position() ), jetDir ) >  extSVDeltaRToJet || extVertex.p4().M() < 0.3 )
+			   continue;
+// 			 std::cout << " SV added " << iExtSv << std::endl; 
+			 extAssoCollection.push_back( extVertex );
+		      }
 
-		SVBuilder svBuilder(pv, jetDir, withPVError, minTrackWeight);
-		std::remove_copy_if(boost::make_transform_iterator(
-		                    	fittedSVs.begin(), svBuilder),
-		                    boost::make_transform_iterator(
-		                    	fittedSVs.end(), svBuilder),
-		                    std::back_inserter(SVs),
-		                    SVFilter(vertexFilter, pv, jetDir));
-
+		  }
+		  else {
+		      size_t jetIdx = ( iterJets - trackIPTagInfos->begin() );
+		
+		      for(size_t iExtSv = 0; iExtSv < clusteredSVs.at(jetIdx).size(); iExtSv++){
+			 const VTX & extVertex = (*extSecVertex)[ clusteredSVs.at(jetIdx).at(iExtSv) ];
+			 if( extVertex.p4().M() < 0.3 )
+			   continue;
+			 extAssoCollection.push_back( extVertex );
+		      }
+		  }
+		  // build combined SV information and filter
+		  SVBuilder svBuilder(pv, jetDir, withPVError, minTrackWeight);
+		  std::remove_copy_if(boost::make_transform_iterator( extAssoCollection.begin(), svBuilder),
+				    boost::make_transform_iterator(extAssoCollection.end(), svBuilder),
+				    std::back_inserter(SVs),
+				    SVFilter(vertexFilter, pv, jetDir));
+                }
+//		std::cout << "size: " << SVs.size() << std::endl;
 		// clean up now unneeded collections
-             }else{
-                  for(size_t iExtSv = 0; iExtSv < extSecVertex->size(); iExtSv++){
-		      const VTX & extVertex = (*extSecVertex)[iExtSv];
-//    	              GlobalVector vtxDir = GlobalVector(extVertex.p4().X(),extVertex.p4().Y(),extVertex.p4().Z());
-//                     if(Geom::deltaR(extVertex.position() - pv.position(), vtxDir)>0.2) continue; //pointing angle
-//		      std::cout << " dR " << iExtSv << " " << Geom::deltaR( ( extVertex.position() - pv.position() ), jetDir ) << "eta: " << ( extVertex.position() - pv.position()).eta() << " vs " << jetDir.eta() << " phi: "  << ( extVertex.position() - pv.position()).phi() << " vs  " << jetDir.phi() <<  std::endl; 
-	              if( Geom::deltaR( ( position(extVertex) - pv.position() ), jetDir ) >  extSVDeltaRToJet || extVertex.p4().M() < 0.3)
-                	continue;
-//		      std::cout << " SV added " << iExtSv << std::endl; 
- 		      extAssoCollection.push_back( extVertex );
-                   }
-                   SVBuilder svBuilder(pv, jetDir, withPVError, minTrackWeight);
-	           std::remove_copy_if(boost::make_transform_iterator( extAssoCollection.begin(), svBuilder),
-                                boost::make_transform_iterator(extAssoCollection.end(), svBuilder),
-                                std::back_inserter(SVs),
-                                SVFilter(vertexFilter, pv, jetDir));
-
-
-                 }
-//		std::cout << "size: " << SVs.size() << std::endl; 
 		gtPred.reset();
 		ghostTrack.reset();
 		gtStates.clear();
@@ -652,7 +922,178 @@ TemplatedSecondaryVertexProducer<CandIPTagInfo,reco::VertexCompositePtrCandidate
 	}
 }
 
+// ------------ method that matches reclustered and original jets based on minimum dR ------------
+template<class IPTI,class VTX>
+void TemplatedSecondaryVertexProducer<IPTI,VTX>::matchReclusteredJets(const edm::Handle<std::vector<IPTI> >& jets,
+                                                                      const std::vector<fastjet::PseudoJet>& reclusteredJets,
+                                                                      std::vector<int>& matchedIndices)
+{
+   std::vector<bool> matchedLocks(reclusteredJets.size(),false);
 
+   for(size_t j=0; j<jets->size(); ++j)
+   {
+     double matchedDR2 = 1e9;
+     int matchedIdx = -1;
+
+     for(size_t rj=0; rj<reclusteredJets.size(); ++rj)
+     {
+       if( matchedLocks.at(rj) ) continue; // skip jets that have already been matched
+
+       double tempDR2 = Geom::deltaR2( jets->at(j).jet()->rapidity(), jets->at(j).jet()->phi(), reclusteredJets.at(rj).rapidity(), reclusteredJets.at(rj).phi_std() );
+       if( tempDR2 < matchedDR2 )
+       {
+         matchedDR2 = tempDR2;
+         matchedIdx = rj;
+       }
+     }
+
+     if( matchedIdx>=0 )
+     {
+       if ( matchedDR2 > rParam*rParam )
+       {
+         edm::LogError("JetMatchingFailed") << "Matched reclustered jet " << matchedIdx << " and original jet " << j <<" are separated by dR=" << sqrt(matchedDR2) << " which is greater than the jet size R=" << rParam << ".\n"
+                                            << "This is not expected so please check that the jet algorithm and jet size match those used for the original jet collection.";
+       }
+       else
+         matchedLocks.at(matchedIdx) = true;
+     }
+     else
+       edm::LogError("JetMatchingFailed") << "Matching reclustered to original jets failed. Please check that the jet algorithm and jet size match those used for the original jet collection.";
+
+     matchedIndices.push_back(matchedIdx);
+   }
+}
+
+// ------------ method that matches reclustered and original fat jets based on minimum dR ------------
+template<class IPTI,class VTX>
+void TemplatedSecondaryVertexProducer<IPTI,VTX>::matchReclusteredFatJets(const edm::Handle<edm::View<reco::Jet> >& jets,
+                                                                         const std::vector<fastjet::PseudoJet>& reclusteredJets,
+                                                                         std::vector<int>& matchedIndices)
+{
+   std::vector<bool> matchedLocks(reclusteredJets.size(),false);
+
+   for(size_t j=0; j<jets->size(); ++j)
+   {
+     double matchedDR2 = 1e9;
+     int matchedIdx = -1;
+
+     for(size_t rj=0; rj<reclusteredJets.size(); ++rj)
+     {
+       if( matchedLocks.at(rj) ) continue; // skip jets that have already been matched
+
+       double tempDR2 = Geom::deltaR2( jets->at(j).rapidity(), jets->at(j).phi(), reclusteredJets.at(rj).rapidity(), reclusteredJets.at(rj).phi_std() );
+       if( tempDR2 < matchedDR2 )
+       {
+         matchedDR2 = tempDR2;
+         matchedIdx = rj;
+       }
+     }
+
+     if( matchedIdx>=0 )
+     {
+       if ( matchedDR2 > rParam*rParam )
+       {
+         edm::LogError("JetMatchingFailed") << "Matched reclustered jet " << matchedIdx << " and original jet " << j <<" are separated by dR=" << sqrt(matchedDR2) << " which is greater than the jet size R=" << rParam << ".\n"
+                                            << "This is not expected so please check that the jet algorithm and jet size match those used for the original jet collection.";
+       }
+       else
+         matchedLocks.at(matchedIdx) = true;
+     }
+     else
+       edm::LogError("JetMatchingFailed") << "Matching reclustered to original fat jets failed. Please check that the jet algorithm and jet size match those used for the original fat jet collection.";
+
+     matchedIndices.push_back(matchedIdx);
+   }
+}
+
+// ------------ method that matches groomed and original jets based on minimum dR ------------
+template<class IPTI,class VTX>
+void TemplatedSecondaryVertexProducer<IPTI,VTX>::matchGroomedJets(const edm::Handle<edm::View<reco::Jet> >& jets,
+                                                                  const edm::Handle<edm::View<reco::Jet> >& groomedJets,
+                                                                  std::vector<int>& matchedIndices)
+{
+   std::vector<bool> jetLocks(jets->size(),false);
+   std::vector<int>  jetIndices;
+
+   for(size_t gj=0; gj<groomedJets->size(); ++gj)
+   {
+     double matchedDR2 = 1e9;
+     int matchedIdx = -1;
+
+     if( groomedJets->at(gj).pt()>0. ) // skips pathological cases of groomed jets with Pt=0
+     {
+       for(size_t j=0; j<jets->size(); ++j)
+       {
+         if( jetLocks.at(j) ) continue; // skip jets that have already been matched
+
+         double tempDR2 = Geom::deltaR2( jets->at(j).rapidity(), jets->at(j).phi(), groomedJets->at(gj).rapidity(), groomedJets->at(gj).phi() );
+         if( tempDR2 < matchedDR2 )
+         {
+           matchedDR2 = tempDR2;
+           matchedIdx = j;
+         }
+       }
+     }
+
+     if( matchedIdx>=0 )
+     {
+       if ( matchedDR2 > rParam*rParam )
+       {
+         edm::LogWarning("MatchedJetsFarApart") << "Matched groomed jet " << gj << " and original jet " << matchedIdx <<" are separated by dR=" << sqrt(matchedDR2) << " which is greater than the jet size R=" << rParam << ".\n"
+                                                << "This is not expected so the matching of these two jets has been discarded. Please check that the two jet collections belong to each other.";
+         matchedIdx = -1;
+       }
+       else
+         jetLocks.at(matchedIdx) = true;
+     }
+     jetIndices.push_back(matchedIdx);
+   }
+
+   for(size_t j=0; j<jets->size(); ++j)
+   {
+     std::vector<int>::iterator matchedIndex = std::find( jetIndices.begin(), jetIndices.end(), j );
+
+     matchedIndices.push_back( matchedIndex != jetIndices.end() ? std::distance(jetIndices.begin(),matchedIndex) : -1 );
+   }
+}
+
+// ------------ method that matches subjets and original fat jets ------------
+template<class IPTI,class VTX>
+void TemplatedSecondaryVertexProducer<IPTI,VTX>::matchSubjets(const std::vector<int>& groomedIndices,
+                                                              const edm::Handle<edm::View<reco::Jet> >& groomedJets,
+                                                              const edm::Handle<std::vector<IPTI> >& subjets,
+                                                              std::vector<std::vector<int> >& matchedIndices)
+{
+   for(size_t g=0; g<groomedIndices.size(); ++g)
+   {
+     std::vector<int> subjetIndices;
+
+     if( groomedIndices.at(g)>=0 )
+     {
+       for(size_t s=0; s<groomedJets->at(groomedIndices.at(g)).numberOfDaughters(); ++s)
+       {
+         const edm::Ptr<reco::Candidate> & subjet = groomedJets->at(groomedIndices.at(g)).daughterPtr(s);
+
+         for(size_t sj=0; sj<subjets->size(); ++sj)
+         {
+           const edm::RefToBase<reco::Jet> &subjetRef = subjets->at(sj).jet();
+           if( subjet == edm::Ptr<reco::Candidate>( subjetRef.id(), subjetRef.get(), subjetRef.key() ) )
+           {
+             subjetIndices.push_back(sj);
+             break;
+           }
+         }
+       }
+
+       if( subjetIndices.size() == 0 )
+         edm::LogError("SubjetMatchingFailed") << "Matching subjets to original fat jets failed. Please check that the groomed fat jet and subjet collections belong to each other.";
+
+       matchedIndices.push_back(subjetIndices);
+     }
+     else
+       matchedIndices.push_back(subjetIndices);
+   }
+}
 
 //define this as a plug-in
 typedef TemplatedSecondaryVertexProducer<TrackIPTagInfo,reco::Vertex> SecondaryVertexProducer;

--- a/RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc
+++ b/RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc
@@ -494,7 +494,7 @@ void TemplatedSecondaryVertexProducer<IPTI,VTX>::produce(edm::Event &event,
 		std::vector<double> dR2toSubjets;
 		
 		for(size_t sj=0; sj<subjetIndices.at(i).size(); ++sj)
-		  dR2toSubjets.push_back( reco::deltaR2( p.rapidity(), p.phi_std(), trackIPTagInfos->at(subjetIndices.at(i).at(sj)).jet()->rapidity(), trackIPTagInfos->at(subjetIndices.at(i).at(sj)).jet()->phi() ) );
+		  dR2toSubjets.push_back( Geom::deltaR2( p.rapidity(), p.phi_std(), trackIPTagInfos->at(subjetIndices.at(i).at(sj)).jet()->rapidity(), trackIPTagInfos->at(subjetIndices.at(i).at(sj)).jet()->phi() ) );
 
 		// find the closest subjet
 		int closestSubjetIdx = std::distance( dR2toSubjets.begin(), std::min_element(dR2toSubjets.begin(), dR2toSubjets.end()) );
@@ -754,12 +754,8 @@ void TemplatedSecondaryVertexProducer<IPTI,VTX>::produce(edm::Event &event,
 		  if( !useSVClustering ) {
 		      for(size_t iExtSv = 0; iExtSv < extSecVertex->size(); iExtSv++){
 			 const VTX & extVertex = (*extSecVertex)[iExtSv];
-// 			 GlobalVector vtxDir = GlobalVector(extVertex.p4().X(),extVertex.p4().Y(),extVertex.p4().Z());
-// 			 if(Geom::deltaR(extVertex.position() - pv.position(), vtxDir)>0.2) continue; //pointing angle
-// 			 std::cout << " dR " << iExtSv << " " << Geom::deltaR( ( extVertex.position() - pv.position() ), jetDir ) << "eta: " << ( extVertex.position() - pv.position()).eta() << " vs " << jetDir.eta() << " phi: "  << ( extVertex.position() - pv.position()).phi() << " vs  " << jetDir.phi() <<  std::endl; 
-			 if( Geom::deltaR( ( position(extVertex) - pv.position() ), jetDir ) >  extSVDeltaRToJet || extVertex.p4().M() < 0.3 )
+			 if( Geom::deltaR2( ( position(extVertex) - pv.position() ), jetDir ) > extSVDeltaRToJet*extSVDeltaRToJet || extVertex.p4().M() < 0.3 )
 			   continue;
-// 			 std::cout << " SV added " << iExtSv << std::endl; 
 			 extAssoCollection.push_back( extVertex );
 		      }
 
@@ -781,7 +777,6 @@ void TemplatedSecondaryVertexProducer<IPTI,VTX>::produce(edm::Event &event,
 				    std::back_inserter(SVs),
 				    SVFilter(vertexFilter, pv, jetDir));
                 }
-//		std::cout << "size: " << SVs.size() << std::endl;
 		// clean up now unneeded collections
 		gtPred.reset();
 		ghostTrack.reset();


### PR DESCRIPTION
This PR adds the SV clustering capability to the SVTagInfo producer and adds the explicit jet-track association to the candidate-based IPTagInfo producer.

All changes completely transparent to the standard reconstruction.

**Update:** Rebased to CMSSW_7_3_X_2014-11-15-0200 and added support for SV clustering, jet flavor for subjets, and explicit jet-track association in PAT
