### PR TITLE
 fix crash in CtfSpecialSeedGenerator ocurring at run boundaries (73X version of #6418 )

### DIFF
--- a/RecoTracker/SpecialSeedGenerators/src/CtfSpecialSeedGenerator.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/CtfSpecialSeedGenerator.cc
@@ -1,5 +1,4 @@
 #include "RecoTracker/SpecialSeedGenerators/interface/CtfSpecialSeedGenerator.h"
-//#include "RecoTracker/SpecialSeedGenerators/interface/CosmicLayerTriplets.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "DataFormats/GeometrySurface/interface/RectangularPlaneBounds.h"
@@ -43,11 +42,11 @@ CtfSpecialSeedGenerator::CtfSpecialSeedGenerator(const edm::ParameterSet& conf):
 }
 
 CtfSpecialSeedGenerator::~CtfSpecialSeedGenerator(){
+    if (theRegionProducer) { delete theRegionProducer; theRegionProducer = 0; }
 }
 
 void CtfSpecialSeedGenerator::endRun(edm::Run const&, edm::EventSetup const&){
     if (theSeedBuilder)    { delete theSeedBuilder;    theSeedBuilder = 0; }
-    if (theRegionProducer) { delete theRegionProducer; theRegionProducer = 0; }
 }
 
 void CtfSpecialSeedGenerator::beginRun(edm::Run const&, const edm::EventSetup& iSetup){
@@ -89,27 +88,7 @@ void CtfSpecialSeedGenerator::beginRun(edm::Run const&, const edm::EventSetup& i
 	edm::ESHandle<Propagator>  propagatorOppositeHandle;
         iSetup.get<TrackingComponentsRecord>().get("PropagatorWithMaterialOpposite",propagatorOppositeHandle);
 
-/*  	edm::ParameterSet hitsfactoryOutInPSet = conf_.getParameter<edm::ParameterSet>("OrderedHitsFactoryOutInPSet");
-  	std::string hitsfactoryOutInName = hitsfactoryOutInPSet.getParameter<std::string>("ComponentName");
-  	hitsGeneratorOutIn = OrderedHitsGeneratorFactory::get()->create( hitsfactoryOutInName, hitsfactoryOutInPSet);
-	std::string propagationDirection = hitsfactoryOutInPSet.getUntrackedParameter<std::string>("PropagationDirection", 
-											            "alongMomentum");
-	if (propagationDirection == "alongMomentum") outInPropagationDirection = alongMomentum;
-	else outInPropagationDirection = oppositeToMomentum;
-	edm::LogVerbatim("CtfSpecialSeedGenerator") << "hitsGeneratorOutIn done";
 
-	edm::ParameterSet hitsfactoryInOutPSet = conf_.getParameter<edm::ParameterSet>("OrderedHitsFactoryInOutPSet");
-        std::string hitsfactoryInOutName = hitsfactoryInOutPSet.getParameter<std::string>("ComponentName");
-        hitsGeneratorInOut = OrderedHitsGeneratorFactory::get()->create( hitsfactoryInOutName, hitsfactoryInOutPSet);
-
-	propagationDirection = hitsfactoryInOutPSet.getUntrackedParameter<std::string>("PropagationDirection",
-                                                                                        "alongMomentum");
-	if (propagationDirection == "alongMomentum") inOutPropagationDirection = alongMomentum;
-        else inOutPropagationDirection = oppositeToMomentum;
-	edm::LogVerbatim("CtfSpecialSeedGenerator") << "hitsGeneratorInOut done";
-	if (!hitsGeneratorOutIn || !hitsGeneratorInOut) 
-		throw cms::Exception("CtfSpecialSeedGenerator") << "Only corcrete implementation GenericPairOrTripletGenerator of OrderedHitsGenerator is allowed ";
-*/
 	std::vector<edm::ParameterSet> pSets = conf_.getParameter<std::vector<edm::ParameterSet> >("OrderedHitsFactoryPSets");
 	std::vector<edm::ParameterSet>::const_iterator iPSet;
 	for (iPSet = pSets.begin(); iPSet != pSets.end(); iPSet++){


### PR DESCRIPTION
move theRegionProducer delete to the destructor
fixes problems online
discussed in
https://hypernews.cern.ch/HyperNews/CMS/get/edmFramework/3395/2/1/1/2/1.html

tested in CMSSW_7_2_1_patch1 using the online DQM setup (crash is gone) and then with short matrix to see no differences in output as expected.

same code diff as in #6418
