### PR TITLE
Resolve implicit conversion from nullptr to false

### DIFF
--- a/Geometry/EcalAlgo/src/EcalBarrelGeometry.cc
+++ b/Geometry/EcalAlgo/src/EcalBarrelGeometry.cc
@@ -24,7 +24,7 @@ EcalBarrelGeometry::EcalBarrelGeometry() :
    m_borderMgr    ( nullptr ),
    m_borderPtrVec ( nullptr ) ,
    m_radius       ( -1. ),
-   m_check        ( nullptr ),
+   m_check        ( false ),
    m_cellVec      ( k_NumberOfCellsForCorners )
 {
    const int neba[] = {25,45,65,85} ;

--- a/Geometry/EcalAlgo/src/EcalEndcapGeometry.cc
+++ b/Geometry/EcalAlgo/src/EcalEndcapGeometry.cc
@@ -22,7 +22,7 @@ EcalEndcapGeometry::EcalEndcapGeometry( void )
     m_borderMgr( nullptr ),
     m_borderPtrVec( nullptr ),
     m_avgZ( -1 ),
-    m_check( nullptr ),
+    m_check( false ),
     m_cellVec( k_NumberOfCellsForCorners )
 {
   m_xlo[0] = 999.;


### PR DESCRIPTION
```
Geometry/EcalAlgo/src/EcalBarrelGeometry.cc:27:21: error: implicit
conversion of nullptr constant to 'bool' [-Werror,-Wnull-conversion]
   m_check        ( nullptr ),
   ~~~~~~~          ^~~~~~~
                    false

Geometry/EcalAlgo/src/EcalEndcapGeometry.cc:25:14: error: implicit
conversion of nullptr constant to 'bool' [-Werror,-Wnull-conversion]
    m_check( nullptr ),
    ~~~~~~~  ^~~~~~~
             false
```

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
