### PR TITLE
fix priority for injection

### DIFF
--- a/Configuration/PyReleaseValidation/python/MatrixInjector.py
+++ b/Configuration/PyReleaseValidation/python/MatrixInjector.py
@@ -81,7 +81,7 @@ class MatrixInjector(object):
         self.defaultChain={
             "RequestType" :    "TaskChain",                    #this is how we handle relvals
             "SubRequestType" : "RelVal",                       #this is how we handle relvals, now that TaskChain is also used for central MC production
-            "RequestPriority": 999999,
+            "RequestPriority": 500000,
             "Requestor": self.user,                           #Person responsible
             "Group": self.group,                              #group for the request
             "CMSSWVersion": os.getenv('CMSSW_VERSION'),       #CMSSW Version (used for all tasks in chain)


### PR DESCRIPTION
set the priority for relvals at 500000 : high enough to be always first (>110000) and allowing flexilibility among the different submissions (<999999)
Uniformity : PR for 73X about to be sumitted  -   already in SLHC releases (#6159) - 
