### PR TITLE
Kt pruning and dynamic filtering radius

### DIFF
--- a/RecoJets/JetProducers/plugins/FastjetJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/FastjetJetProducer.cc
@@ -58,6 +58,7 @@ FastjetJetProducer::FastjetJetProducer(const edm::ParameterSet& iConfig)
     useTrimming_(false),
     usePruning_(false),
     useCMSBoostedTauSeedingAlgorithm_(false),
+    useKtPruning_(false),
     muCut_(-1.0),
     yCut_(-1.0),
     rFilt_(-1.0),
@@ -105,6 +106,7 @@ FastjetJetProducer::FastjetJetProducer(const edm::ParameterSet& iConfig)
     useTrimming_=false;
     usePruning_=false;
     useCMSBoostedTauSeedingAlgorithm_=false;
+    useKtPruning_=false;
     rFilt_=-1.0;
     nFilt_=-1;
     trimPtFracMin_=-1.0;
@@ -145,6 +147,8 @@ FastjetJetProducer::FastjetJetProducer(const edm::ParameterSet& iConfig)
       zCut_ = iConfig.getParameter<double>("zcut");
       RcutFactor_ = iConfig.getParameter<double>("rcut_factor");
       nFilt_ = iConfig.getParameter<int>("nFilt");
+      if ( iConfig.exists("useKtPruning") )
+        useKtPruning_ = iConfig.getParameter<bool>("useKtPruning");
     }
 
     if ( iConfig.exists("useCMSBoostedTauSeedingAlgorithm") ) {
@@ -360,6 +364,8 @@ void FastjetJetProducer::runAlgorithm( edm::Event & iEvent, edm::EventSetup cons
     fastjet::Filter trimmer( fastjet::Filter(fastjet::JetDefinition(fastjet::kt_algorithm, rFilt_), fastjet::SelectorPtFractionMin(trimPtFracMin_)));
     fastjet::Filter filter( fastjet::Filter(fastjet::JetDefinition(fastjet::cambridge_algorithm, rFilt_), fastjet::SelectorNHardest(nFilt_)));
     fastjet::Pruner pruner(fastjet::cambridge_algorithm, zCut_, RcutFactor_);
+    if ( useKtPruning_ )
+      pruner = fastjet::Pruner(fastjet::kt_algorithm, zCut_, RcutFactor_);
 
     std::vector<fastjet::Transformer const *> transformers;
 

--- a/RecoJets/JetProducers/plugins/FastjetJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/FastjetJetProducer.cc
@@ -55,6 +55,7 @@ FastjetJetProducer::FastjetJetProducer(const edm::ParameterSet& iConfig)
   : VirtualJetProducer( iConfig ),
     useMassDropTagger_(false),
     useFiltering_(false),
+    useDynamicFiltering_(false),
     useTrimming_(false),
     usePruning_(false),
     useCMSBoostedTauSeedingAlgorithm_(false),
@@ -62,6 +63,7 @@ FastjetJetProducer::FastjetJetProducer(const edm::ParameterSet& iConfig)
     muCut_(-1.0),
     yCut_(-1.0),
     rFilt_(-1.0),
+    rFiltFactor_(-1.0),
     nFilt_(-1),
     trimPtFracMin_(-1.0),
     zCut_(-1.0),
@@ -103,11 +105,13 @@ FastjetJetProducer::FastjetJetProducer(const edm::ParameterSet& iConfig)
        iConfig.exists("useCMSBoostedTauSeedingAlgorithm") ) {
     useMassDropTagger_=false;
     useFiltering_=false;
+    useDynamicFiltering_=false;
     useTrimming_=false;
     usePruning_=false;
     useCMSBoostedTauSeedingAlgorithm_=false;
     useKtPruning_=false;
     rFilt_=-1.0;
+    rFiltFactor_=-1.0;
     nFilt_=-1;
     trimPtFracMin_=-1.0;
     zCut_=-1.0;
@@ -134,6 +138,12 @@ FastjetJetProducer::FastjetJetProducer(const edm::ParameterSet& iConfig)
       useFiltering_ = iConfig.getParameter<bool>("useFiltering");
       rFilt_ = iConfig.getParameter<double>("rFilt");
       nFilt_ = iConfig.getParameter<int>("nFilt");
+      if ( iConfig.exists("useDynamicFiltering") ) {
+        useDynamicFiltering_ = iConfig.getParameter<bool>("useDynamicFiltering");
+        rFiltFactor_ = iConfig.getParameter<double>("rFiltFactor");
+        if ( useDynamicFiltering_ )
+          rFiltDynamic_ = DynamicRfiltPtr(new DynamicRfilt(rFilt_, rFiltFactor_));
+      }
     }
   
     if ( iConfig.exists("useTrimming") ) {
@@ -363,6 +373,8 @@ void FastjetJetProducer::runAlgorithm( edm::Event & iEvent, edm::EventSetup cons
     fastjet::contrib::CMSBoostedTauSeedingAlgorithm tau_tagger( subjetPtMin_, muMin_, muMax_, yMin_, yMax_, dRMin_, dRMax_, maxDepth_, verbosity_ );
     fastjet::Filter trimmer( fastjet::Filter(fastjet::JetDefinition(fastjet::kt_algorithm, rFilt_), fastjet::SelectorPtFractionMin(trimPtFracMin_)));
     fastjet::Filter filter( fastjet::Filter(fastjet::JetDefinition(fastjet::cambridge_algorithm, rFilt_), fastjet::SelectorNHardest(nFilt_)));
+    if ( useDynamicFiltering_ )
+      filter = fastjet::Filter( fastjet::Filter(&*rFiltDynamic_, fastjet::SelectorNHardest(nFilt_)));
     fastjet::Pruner pruner(fastjet::cambridge_algorithm, zCut_, RcutFactor_);
     if ( useKtPruning_ )
       pruner = fastjet::Pruner(fastjet::kt_algorithm, zCut_, RcutFactor_);
@@ -378,11 +390,11 @@ void FastjetJetProducer::runAlgorithm( edm::Event & iEvent, edm::EventSetup cons
     if ( useTrimming_ ) {
       transformers.push_back(&trimmer);
     } 
-    if ( useFiltering_ ) {
-      transformers.push_back(&filter);
-    } 
     if ( usePruning_ ) {
       transformers.push_back(&pruner);
+    }
+    if ( useFiltering_ ) {
+      transformers.push_back(&filter);
     }
 
     for ( std::vector<fastjet::PseudoJet>::const_iterator ijet = tempJets.begin(),

--- a/RecoJets/JetProducers/plugins/FastjetJetProducer.h
+++ b/RecoJets/JetProducers/plugins/FastjetJetProducer.h
@@ -46,6 +46,7 @@ protected:
   bool useTrimming_;          /// Jet trimming technique
   bool usePruning_;           /// Jet pruning technique
   bool useCMSBoostedTauSeedingAlgorithm_; /// algorithm for seeding reconstruction of boosted Taus (similar to mass-drop tagging)
+  bool useKtPruning_;         /// Use Kt clustering algorithm for pruning (default is Cambridge/Aachen)
   double muCut_;              /// for mass-drop tagging, m0/mjet (m0 = mass of highest mass subjet)
   double yCut_;               /// for mass-drop tagging, symmetry cut: min(pt1^2,pt2^2) * dR(1,2) / mjet > ycut
   double rFilt_;              /// for filtering, trimming: dR scale of sub-clustering

--- a/RecoJets/JetProducers/plugins/FastjetJetProducer.h
+++ b/RecoJets/JetProducers/plugins/FastjetJetProducer.h
@@ -8,6 +8,31 @@
 
 #include "RecoJets/JetProducers/plugins/VirtualJetProducer.h"
 
+// a function returning
+//   min(Rmax, deltaR_factor * deltaR(j1,j2))
+// where j1 and j2 are the 2 subjets of j
+// if the jet does not have exactly 2 pieces, Rmax is used.
+class DynamicRfilt : public fastjet::FunctionOfPseudoJet<double>{
+public:
+  // default ctor
+  DynamicRfilt(double Rmax, double deltaR_factor) : _Rmax(Rmax), _deltaR_factor(deltaR_factor){}
+
+  // action of the function
+  double result(const fastjet::PseudoJet &j) const{
+    if (! j.has_pieces()) return _Rmax;
+
+    std::vector<fastjet::PseudoJet> pieces = j.pieces();
+    if (! pieces.size()==2) return _Rmax;
+
+    double deltaR = pieces[0].delta_R(pieces[1]);
+    return std::min(_Rmax, _deltaR_factor * deltaR);
+  }
+
+private:
+  double _Rmax, _deltaR_factor;
+};
+
+
 class FastjetJetProducer : public VirtualJetProducer
 {
 
@@ -20,7 +45,9 @@ public:
 
   virtual void produce( edm::Event & iEvent, const edm::EventSetup & iSetup );
 
-  
+  // typedefs
+  typedef boost::shared_ptr<DynamicRfilt>  DynamicRfiltPtr;
+
 protected:
 
   //
@@ -43,6 +70,7 @@ protected:
   // jet trimming parameters
   bool useMassDropTagger_;    /// Mass-drop tagging for boosted Higgs
   bool useFiltering_;         /// Jet filtering technique
+  bool useDynamicFiltering_;  /// Use dynamic filtering radius (as in arXiv:0802.2470)
   bool useTrimming_;          /// Jet trimming technique
   bool usePruning_;           /// Jet pruning technique
   bool useCMSBoostedTauSeedingAlgorithm_; /// algorithm for seeding reconstruction of boosted Taus (similar to mass-drop tagging)
@@ -50,6 +78,8 @@ protected:
   double muCut_;              /// for mass-drop tagging, m0/mjet (m0 = mass of highest mass subjet)
   double yCut_;               /// for mass-drop tagging, symmetry cut: min(pt1^2,pt2^2) * dR(1,2) / mjet > ycut
   double rFilt_;              /// for filtering, trimming: dR scale of sub-clustering
+  DynamicRfiltPtr rFiltDynamic_; /// for dynamic filtering radius (as in arXiv:0802.2470)
+  double rFiltFactor_;        /// for dynamic filtering radius (as in arXiv:0802.2470)
   int    nFilt_;              /// for filtering, pruning: number of subjets expected
   double trimPtFracMin_;      /// for trimming: constituent minimum pt fraction of full jet
   double zCut_;               /// for pruning: constituent minimum pt fraction of parent cluster


### PR DESCRIPTION
This PR adds the option of using the Kt instead of the C/A clustering algorithm for jet pruning. It also add the possibility to use dynamic filtering radius as in the original BDRS paper (http://arxiv.org/abs/0802.2470).

No changes expected in the standard reconstruction.
