### PR TITLE
fix (rare) crash in DYT muon reco

### DIFF
--- a/RecoMuon/GlobalTrackingTools/src/DynamicTruncation.cc
+++ b/RecoMuon/GlobalTrackingTools/src/DynamicTruncation.cc
@@ -385,7 +385,7 @@ void DynamicTruncation::preliminaryFit(map<int, vector<DetId> > compatibleIds, m
       prelFitState = updatorHandle->update(tsosCSClayer, *theMuonRecHitBuilder->build(&bestCSCSeg));
     }
   }
-  prelFitMeas.pop_back();
+  if (!prelFitMeas.empty()) prelFitMeas.pop_back();
   for (ConstRecHitContainer::const_iterator imrh = prelFitMeas.end(); imrh != prelFitMeas.begin(); imrh-- ) {
     DetId id = (*imrh)->geographicalId(); 
     TrajectoryStateOnSurface tmp = propagatorPF->propagate(prelFitState, theG->idToDet(id)->surface());


### PR DESCRIPTION
Fixes the crash reported in
https://hypernews.cern.ch/HyperNews/CMS/get/relval/3239.html

no changes expected in regular tests and none are observed (the condition for the crash is fairly rare)

@jhgoh please check the changes with the main developers.
My fix is just technical to avoid the crash, but it would be good to check in more details why
this condition happens.
The issue can be reproduced from http://cms-project-relval.web.cern.ch/cms-project-relval/failures/CMSSW_7_3_0_pre2/12Nov2014_1/JpsiMuMu_Pt-15_Job1.tar.gz
(dump the PSet.py there to see the expanded config details)
