### PR TITLE
Run action cleanup

### DIFF
--- a/SimG4CMS/EcalTestBeam/src/FakeTBEventHeaderProducer.cc
+++ b/SimG4CMS/EcalTestBeam/src/FakeTBEventHeaderProducer.cc
@@ -40,7 +40,9 @@ FakeTBEventHeaderProducer::~FakeTBEventHeaderProducer()
   if (!theEcalTBInfo)
     return;
   
-  product->setEventNumber(event.id().event());
+  // 64 bits event ID in CMSSW converted to EcalTBEventHeader ID
+  int evtid = (int)event.id().event();
+  product->setEventNumber(evtid);
   product->setRunNumber(event.id().run());
   product->setBurstNumber(1);
   product->setTriggerMask(0x1);

--- a/SimG4Core/Application/interface/RunAction.h
+++ b/SimG4Core/Application/interface/RunAction.h
@@ -21,6 +21,7 @@ public:
     
     SimActivityRegistry::BeginOfRunSignal m_beginOfRunSignal;
     SimActivityRegistry::EndOfRunSignal m_endOfRunSignal; 
+
 private:
     SimRunInterface* m_runInterface;
     std::string m_stopFile;

--- a/SimG4Core/Application/interface/RunAction.h
+++ b/SimG4Core/Application/interface/RunAction.h
@@ -11,6 +11,7 @@
 class SimRunInterface;
 class BeginOfRun;
 class EndOfRun;
+class G4Timer;
 
 class RunAction: public G4UserRunAction
 {
@@ -25,6 +26,7 @@ public:
 private:
     SimRunInterface* m_runInterface;
     std::string m_stopFile;
+    G4Timer* m_timer;
 };
 
 #endif

--- a/SimG4Core/Application/interface/RunManagerMT.h
+++ b/SimG4Core/Application/interface/RunManagerMT.h
@@ -14,7 +14,6 @@
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 
 #include <memory>
-#include "boost/shared_ptr.hpp"
 
 namespace CLHEP {
   class HepJamesRandom;
@@ -46,7 +45,6 @@ class G4Field;
 class RunAction;
 
 class SimRunInterface;
-//class ExceptionHandler;
 
 namespace HepPDT {
   class ParticleDataTable;
@@ -70,7 +68,7 @@ public:
 
   void stopG4();
 
-  void             Connect(RunAction*);
+  void Connect(RunAction*);
 
   // Keep this to keep ExceptionHandler to compile, probably removed
   // later (or functionality moved to RunManagerMTWorker)
@@ -115,7 +113,8 @@ private:
   bool m_managerInitialized;
   bool m_runTerminated;
   const bool m_pUseMagneticField;
-  std::unique_ptr<RunAction> m_userRunAction;
+  RunAction* m_userRunAction;
+  G4Run* m_currentRun;
   std::unique_ptr<SimRunInterface> m_runInterface;
 
   const std::string m_PhysicsTablesDir;
@@ -126,7 +125,6 @@ private:
   edm::ParameterSet m_pPhysics; 
   edm::ParameterSet m_pRunAction;      
   std::vector<std::string> m_G4Commands;
-  //ExceptionHandler* m_CustomExceptionHandler ;
 
   std::unique_ptr<DDDWorld> m_world;
   SimActivityRegistry m_registry;

--- a/SimG4Core/Application/src/RunAction.cc
+++ b/SimG4Core/Application/src/RunAction.cc
@@ -4,8 +4,7 @@
 #include "SimG4Core/Notification/interface/BeginOfRun.h"
 #include "SimG4Core/Notification/interface/EndOfRun.h"
 
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
- 
+#include "FWCore/MessageLogger/interface/MessageLogger.h" 
 #include <iostream>
 #include <fstream>
  

--- a/SimG4Core/Application/src/RunAction.cc
+++ b/SimG4Core/Application/src/RunAction.cc
@@ -4,32 +4,55 @@
 #include "SimG4Core/Notification/interface/BeginOfRun.h"
 #include "SimG4Core/Notification/interface/EndOfRun.h"
 
-#include "FWCore/MessageLogger/interface/MessageLogger.h" 
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "G4Timer.hh" 
 #include <iostream>
 #include <fstream>
+
+//using std::cout;
+//using std::endl;
  
 RunAction::RunAction(const edm::ParameterSet& p, SimRunInterface* rm) 
    : m_runInterface(rm), 
-     m_stopFile(p.getParameter<std::string>("StopFile")) {}
+     m_stopFile(p.getParameter<std::string>("StopFile")), m_timer(0) 
+{}
 
 void RunAction::BeginOfRunAction(const G4Run * aRun)
 {
   if (std::ifstream(m_stopFile.c_str()))
     {
       edm::LogWarning("SimG4CoreApplication")
-        << "BeginOfRunAction: termination signal received";
+        << "RunAction::BeginOfRunAction: termination signal received";
       m_runInterface->abortRun(true);
     }
-    BeginOfRun r(aRun);
-    m_beginOfRunSignal(&r);
+  BeginOfRun r(aRun);
+  m_beginOfRunSignal(&r);
+  /*
+  if (isMaster) {
+    m_timer = new G4Timer();
+    m_timer->Start();
+  }
+  */
 }
 
 void RunAction::EndOfRunAction(const G4Run * aRun)
 {
+  if (isMaster) {
+    edm::LogInfo("SimG4CoreApplication") 
+      << "RunAction: total number of events "  << aRun->GetNumberOfEvent();
+    if(m_timer) {
+      m_timer->Stop();
+      edm::LogInfo("SimG4CoreApplication") 
+	<< "RunAction: Master thread time  "  << *m_timer;
+      // std::cout << "\n" << "Master thread time:  "  << *m_timer << std::endl;
+      delete m_timer;
+    }
+  }
   if (std::ifstream(m_stopFile.c_str()))
     {
       edm::LogWarning("SimG4CoreApplication")
-        << "EndOfRunAction: termination signal received";
+        << "RunAction::EndOfRunAction: termination signal received";
       m_runInterface->abortRun(true);
     }
   EndOfRun r(aRun);

--- a/SimG4Core/Application/src/RunManager.cc
+++ b/SimG4Core/Application/src/RunManager.cc
@@ -357,7 +357,10 @@ G4Event * RunManager::generateEvent(edm::Event & inpevt)
   m_currentEvent = 0;
   if (m_simEvent!=0) { delete m_simEvent; }
   m_simEvent = 0;
-  G4Event * evt = new G4Event(inpevt.id().event());
+
+  // 64 bits event ID in CMSSW converted into Geant4 event ID
+  G4int evtid = (G4int)inpevt.id().event();
+  G4Event * evt = new G4Event(evtid);
   
   edm::Handle<edm::HepMCProduct> HepMCEvt;
   

--- a/SimG4Core/Application/src/RunManagerMT.cc
+++ b/SimG4Core/Application/src/RunManagerMT.cc
@@ -56,8 +56,6 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-//#include "SimG4Core/Application/interface/ExceptionHandler.h"
-
 RunManagerMT::RunManagerMT(edm::ParameterSet const & p):
       m_managerInitialized(false), 
       m_runTerminated(false),
@@ -91,7 +89,8 @@ RunManagerMT::~RunManagerMT()
   G4GeometryManager::GetInstance()->OpenGeometry();
 }
 
-void RunManagerMT::initG4(const DDCompactView *pDD, const MagneticField *pMF, const HepPDT::ParticleDataTable *fPDGTable)
+void RunManagerMT::initG4(const DDCompactView *pDD, const MagneticField *pMF, 
+			  const HepPDT::ParticleDataTable *fPDGTable)
 {
   if (m_managerInitialized) return;
   

--- a/SimG4Core/Application/src/RunManagerMT.cc
+++ b/SimG4Core/Application/src/RunManagerMT.cc
@@ -69,6 +69,7 @@ RunManagerMT::RunManagerMT(edm::ParameterSet const & p):
       m_G4Commands(p.getParameter<std::vector<std::string> >("G4Commands")),
       m_fieldBuilder(nullptr)
 {    
+  m_currentRun = 0;
   G4RunManagerKernel *kernel = G4MTRunManagerKernel::GetRunManagerKernel();
   if(!kernel) m_kernel = new G4MTRunManagerKernel();
   else {
@@ -183,13 +184,16 @@ void RunManagerMT::initG4(const DDCompactView *pDD, const MagneticField *pMF,
   //
   //  G4cout << "Output of G4ParticleTable DumpTable:" << G4endl;
   //  G4ParticleTable::GetParticleTable()->DumpTable("ALL");
+  G4StateManager::GetStateManager()->SetNewState(G4State_GeomClosed);
+  m_currentRun = new G4Run(); 
+  m_userRunAction->BeginOfRunAction(m_currentRun); 
 }
 
 void RunManagerMT::initializeUserActions() {
   m_runInterface.reset(new SimRunInterface(this, true));
 
-  m_userRunAction.reset(new RunAction(m_pRunAction, m_runInterface.get()));
-  Connect(m_userRunAction.get());
+  m_userRunAction = new RunAction(m_pRunAction, m_runInterface.get());
+  Connect(m_userRunAction);
 }
 
 void  RunManagerMT::Connect(RunAction* runAction)
@@ -205,7 +209,11 @@ void RunManagerMT::stopG4()
 }
 
 void RunManagerMT::terminateRun() {
-  m_userRunAction.reset();
+  m_userRunAction->EndOfRunAction(m_currentRun);
+  delete m_userRunAction;
+  m_userRunAction = 0;
+  // delete m_currentRun;
+  //m_currentRun = 0;
   if(m_kernel && !m_runTerminated) {
     m_kernel->RunTermination();
     m_runTerminated = true;

--- a/SimG4Core/Application/src/RunManagerMTWorker.cc
+++ b/SimG4Core/Application/src/RunManagerMTWorker.cc
@@ -478,7 +478,10 @@ G4Event * RunManagerMTWorker::generateEvent(const edm::Event& inpevt) {
   m_currentEvent.reset();
   m_simEvent.reset();
 
-  G4Event * evt = new G4Event(inpevt.id().event());
+  // 64 bits event ID in CMSSW converted into Geant4 event ID
+  G4int evtid = (G4int)inpevt.id().event();
+  G4Event * evt = new G4Event(evtid);
+
   edm::Handle<edm::HepMCProduct> HepMCEvt;
 
   inpevt.getByToken(m_InToken, HepMCEvt);


### PR DESCRIPTION
For MT mode restore definition of RunAction for the master thread.
Make more accurate conversion of 64 bit CMSSW event ID into Geant4 event ID.
Should not affect production.
