### PR TITLE
Add missing header <sys/time.h> for gettimeofday

### DIFF
--- a/Utilities/StorageFactory/src/StorageAccount.cc
+++ b/Utilities/StorageFactory/src/StorageAccount.cc
@@ -2,12 +2,13 @@
 #include <mutex>
 #include <sstream>
 #include <unistd.h>
+#include <sys/time.h>
 
 static std::mutex            s_mutex;
 StorageAccount::StorageStats s_stats;
 
 static double timeRealNanoSecs (void) {
-#if _POSIX_TIMERS > 0
+#if defined(_POSIX_TIMERS) && (_POSIX_TIMERS > 0)
   struct timespec tm;
   if (clock_gettime(CLOCK_REALTIME, &tm) == 0)
     return tm.tv_sec * 1e9 + tm.tv_nsec;


### PR DESCRIPTION
The patch adds `<sys/time.h>` header for `clock_gettime()`. Also make
sure `_POSIX_TIMERS` is defined before checking its value.

On Darwin/OSX one could use `mach_absolute_time()` and
`AbsoluteToNanoseconds` provided by CoreServices framework instead.

Details and examples are here: https://developer.apple.com/library/mac/qa/qa1398/_index.html

Signed-off-by: David Abdurachmanov davidlt@cern.ch
