### PR TITLE
Add explicit initialization check to pythia8 interface (73x)

### DIFF
--- a/GeneratorInterface/Core/interface/HadronizerFilter.h
+++ b/GeneratorInterface/Core/interface/HadronizerFilter.h
@@ -369,7 +369,7 @@ namespace edm
       throw edm::Exception(errors::Configuration) 
 	<< "Failed to initialize hadronizer "
 	<< hadronizer_.classname()
-	<< " for internal parton generation\n";
+	<< " for external parton generation\n";
   }
 
   template <class HAD, class DEC>

--- a/GeneratorInterface/Pythia8Interface/plugins/Pythia8Hadronizer.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Pythia8Hadronizer.cc
@@ -304,13 +304,16 @@ Pythia8Hadronizer::~Pythia8Hadronizer()
 
 bool Pythia8Hadronizer::initializeForInternalPartons()
 {
+  
+  bool status = true;
+  
   if ( fInitialState == PP ) // default
   {
     //fMasterGen->init(2212, 2212, comEnergy);
     fMasterGen->settings.mode("Beams:idA", 2212);
     fMasterGen->settings.mode("Beams:idB", 2212);
     fMasterGen->settings.parm("Beams:eCM", comEnergy);
-    fMasterGen->init();
+    status &= fMasterGen->init();
   }
   else if ( fInitialState == PPbar )
   {
@@ -318,7 +321,7 @@ bool Pythia8Hadronizer::initializeForInternalPartons()
     fMasterGen->settings.mode("Beams:idA", 2212);
     fMasterGen->settings.mode("Beams:idB", -2212);
     fMasterGen->settings.parm("Beams:eCM", comEnergy);
-    fMasterGen->init();
+    status &= fMasterGen->init();
   }
   else if ( fInitialState == ElectronPositron )
   {
@@ -326,7 +329,7 @@ bool Pythia8Hadronizer::initializeForInternalPartons()
     fMasterGen->settings.mode("Beams:idA", 11);
     fMasterGen->settings.mode("Beams:idB", -11);
     fMasterGen->settings.parm("Beams:eCM", comEnergy);
-    fMasterGen->init();
+    status &= fMasterGen->init();
   }    
   else 
   {
@@ -350,9 +353,9 @@ bool Pythia8Hadronizer::initializeForInternalPartons()
   //fDecayer->readString("ProcessLevel::resonanceDecays=on");
   fDecayer->settings.flag("ProcessLevel:all", false ); // trick
   fDecayer->settings.flag("ProcessLevel:resonanceDecays", true );
-  fDecayer->init();
+  status &= fDecayer->init();
 
-  return true;
+  return status;
 }
 
 
@@ -361,6 +364,8 @@ bool Pythia8Hadronizer::initializeForExternalPartons()
 
   edm::LogInfo("Pythia8Interface") << "Initializing for external partons";
 
+  bool status = true;
+  
   if((fMasterGen->settings.mode("POWHEG:veto") > 0 || fMasterGen->settings.mode("POWHEG:MPIveto") > 0) && !fEmissionVetoHook) {
 
     if(fJetMatchingHook || fEmissionVetoHook1)
@@ -411,7 +416,7 @@ bool Pythia8Hadronizer::initializeForExternalPartons()
     //fMasterGen->init(LHEInputFileName);
     fMasterGen->settings.mode("Beams:frameType", 4);
     fMasterGen->settings.word("Beams:LHEF", LHEInputFileName);
-    fMasterGen->init();
+    status &= fMasterGen->init();
 
   } else {
 
@@ -426,7 +431,7 @@ bool Pythia8Hadronizer::initializeForExternalPartons()
     //fMasterGen->init(lhaUP.get());
     fMasterGen->settings.mode("Beams:frameType", 5);
     fMasterGen->setLHAupPtr(lhaUP.get());
-    fMasterGen->init();
+    status &= fMasterGen->init();
   }
   
   if ( pythiaPylistVerbosity > 10 )
@@ -442,9 +447,9 @@ bool Pythia8Hadronizer::initializeForExternalPartons()
   //fDecayer->readString("ProcessLevel::resonanceDecays=on");
   fDecayer->settings.flag("ProcessLevel:all", false ); // trick
   fDecayer->settings.flag("ProcessLevel:resonanceDecays", true );
-  fDecayer->init();
+  status &= fDecayer->init();
 
-  return true;
+  return status;
 }
 
 


### PR DESCRIPTION
Previously failure in pythia8 initialization caused empty events to be produced and silently filtered out by the generator sequence, making the problem not obvious in central production.  This will now cause the job to crash as it should in this case.
