### PR TITLE
Hlt integration fix for Photon120 paths

### DIFF
--- a/HLTrigger/Configuration/python/HLT_FULL_Famos_cff.py
+++ b/HLTrigger/Configuration/python/HLT_FULL_Famos_cff.py
@@ -1,11 +1,11 @@
-# /dev/CMSSW_7_2_1/HLT/V114 (CMSSW_7_2_1_patch2)
+# /dev/CMSSW_7_2_1/HLT/V116 (CMSSW_7_2_1_patch2)
 
 import FWCore.ParameterSet.Config as cms
 from FastSimulation.HighLevelTrigger.HLTSetup_cff import *
 
 
 HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_7_2_1/HLT/V114')
+  tableName = cms.string('/dev/CMSSW_7_2_1/HLT/V116')
 )
 
 HLTIter4PSetTrajectoryFilterIT = cms.PSet( 
@@ -22268,7 +22268,7 @@ hltEG120R9Id90HE10Iso40EBOnlyEtFilter = cms.EDFilter( "HLTEgammaEtFilter",
     relaxed = cms.untracked.bool( False ),
     L1IsoCand = cms.InputTag( "hltEgammaCandidates" ),
     inputTag = cms.InputTag( "hltEGL1SingleEG35erFilter" ),
-    etcutEB = cms.double( 90.0 ),
+    etcutEB = cms.double( 120.0 ),
     etcutEE = cms.double( 999999.0 ),
     ncandcut = cms.int32( 1 )
 )

--- a/HLTrigger/Configuration/python/HLT_FULL_cff.py
+++ b/HLTrigger/Configuration/python/HLT_FULL_cff.py
@@ -1,10 +1,10 @@
-# /dev/CMSSW_7_2_1/HLT/V114 (CMSSW_7_2_1_patch2)
+# /dev/CMSSW_7_2_1/HLT/V116 (CMSSW_7_2_1_patch2)
 
 import FWCore.ParameterSet.Config as cms
 
 
 HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_7_2_1/HLT/V114')
+  tableName = cms.string('/dev/CMSSW_7_2_1/HLT/V116')
 )
 
 HLTIter4PSetTrajectoryFilterIT = cms.PSet( 
@@ -33370,7 +33370,7 @@ hltEG120R9Id90HE10Iso40EBOnlyEtFilter = cms.EDFilter( "HLTEgammaEtFilter",
     relaxed = cms.untracked.bool( False ),
     L1IsoCand = cms.InputTag( "hltEgammaCandidates" ),
     inputTag = cms.InputTag( "hltEGL1SingleEG35erFilter" ),
-    etcutEB = cms.double( 90.0 ),
+    etcutEB = cms.double( 120.0 ),
     etcutEE = cms.double( 999999.0 ),
     ncandcut = cms.int32( 1 )
 )

--- a/HLTrigger/Configuration/python/HLT_GRun_Famos_cff.py
+++ b/HLTrigger/Configuration/python/HLT_GRun_Famos_cff.py
@@ -1,11 +1,11 @@
-# /dev/CMSSW_7_2_1/GRun/V62 (CMSSW_7_2_1_patch2)
+# /dev/CMSSW_7_2_1/GRun/V63 (CMSSW_7_2_1_patch2)
 
 import FWCore.ParameterSet.Config as cms
 from FastSimulation.HighLevelTrigger.HLTSetup_cff import *
 
 
 HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_7_2_1/GRun/V62')
+  tableName = cms.string('/dev/CMSSW_7_2_1/GRun/V63')
 )
 
 HLTIter4PSetTrajectoryFilterIT = cms.PSet( 
@@ -19553,7 +19553,7 @@ hltEG120R9Id90HE10Iso40EBOnlyEtFilter = cms.EDFilter( "HLTEgammaEtFilter",
     relaxed = cms.untracked.bool( False ),
     L1IsoCand = cms.InputTag( "hltEgammaCandidates" ),
     inputTag = cms.InputTag( "hltEGL1SingleEG35erFilter" ),
-    etcutEB = cms.double( 90.0 ),
+    etcutEB = cms.double( 120.0 ),
     etcutEE = cms.double( 999999.0 ),
     ncandcut = cms.int32( 1 )
 )

--- a/HLTrigger/Configuration/python/HLT_GRun_cff.py
+++ b/HLTrigger/Configuration/python/HLT_GRun_cff.py
@@ -1,10 +1,10 @@
-# /dev/CMSSW_7_2_1/GRun/V62 (CMSSW_7_2_1_patch2)
+# /dev/CMSSW_7_2_1/GRun/V63 (CMSSW_7_2_1_patch2)
 
 import FWCore.ParameterSet.Config as cms
 
 
 HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_7_2_1/GRun/V62')
+  tableName = cms.string('/dev/CMSSW_7_2_1/GRun/V63')
 )
 
 HLTIter4PSetTrajectoryFilterIT = cms.PSet( 
@@ -29763,7 +29763,7 @@ hltEG120R9Id90HE10Iso40EBOnlyEtFilter = cms.EDFilter( "HLTEgammaEtFilter",
     relaxed = cms.untracked.bool( False ),
     L1IsoCand = cms.InputTag( "hltEgammaCandidates" ),
     inputTag = cms.InputTag( "hltEGL1SingleEG35erFilter" ),
-    etcutEB = cms.double( 90.0 ),
+    etcutEB = cms.double( 120.0 ),
     etcutEE = cms.double( 999999.0 ),
     ncandcut = cms.int32( 1 )
 )

--- a/HLTrigger/Configuration/python/HLT_HIon_cff.py
+++ b/HLTrigger/Configuration/python/HLT_HIon_cff.py
@@ -1,10 +1,10 @@
-# /dev/CMSSW_7_2_1/HIon/V62 (CMSSW_7_2_1_patch2)
+# /dev/CMSSW_7_2_1/HIon/V63 (CMSSW_7_2_1_patch2)
 
 import FWCore.ParameterSet.Config as cms
 
 
 HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_7_2_1/HIon/V62')
+  tableName = cms.string('/dev/CMSSW_7_2_1/HIon/V63')
 )
 
 HLTIter4PSetTrajectoryFilterIT = cms.PSet( 

--- a/HLTrigger/Configuration/python/HLT_PIon_cff.py
+++ b/HLTrigger/Configuration/python/HLT_PIon_cff.py
@@ -1,10 +1,10 @@
-# /dev/CMSSW_7_2_1/PIon/V62 (CMSSW_7_2_1_patch2)
+# /dev/CMSSW_7_2_1/PIon/V63 (CMSSW_7_2_1_patch2)
 
 import FWCore.ParameterSet.Config as cms
 
 
 HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_7_2_1/PIon/V62')
+  tableName = cms.string('/dev/CMSSW_7_2_1/PIon/V63')
 )
 
 HLTIter4PSetTrajectoryFilterIT = cms.PSet( 

--- a/HLTrigger/Configuration/test/OnData_HLT_FULL.py
+++ b/HLTrigger/Configuration/test/OnData_HLT_FULL.py
@@ -1,11 +1,11 @@
-# /dev/CMSSW_7_2_1/HLT/V114 (CMSSW_7_2_1_patch2)
+# /dev/CMSSW_7_2_1/HLT/V116 (CMSSW_7_2_1_patch2)
 
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process( "HLTFULL" )
 
 process.HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_7_2_1/HLT/V114')
+  tableName = cms.string('/dev/CMSSW_7_2_1/HLT/V116')
 )
 
 process.HLTIter4PSetTrajectoryFilterIT = cms.PSet( 
@@ -33867,7 +33867,7 @@ process.hltEG120R9Id90HE10Iso40EBOnlyEtFilter = cms.EDFilter( "HLTEgammaEtFilter
     relaxed = cms.untracked.bool( False ),
     L1IsoCand = cms.InputTag( "hltEgammaCandidates" ),
     inputTag = cms.InputTag( "hltEGL1SingleEG35erFilter" ),
-    etcutEB = cms.double( 90.0 ),
+    etcutEB = cms.double( 120.0 ),
     etcutEE = cms.double( 999999.0 ),
     ncandcut = cms.int32( 1 )
 )

--- a/HLTrigger/Configuration/test/OnData_HLT_GRun.py
+++ b/HLTrigger/Configuration/test/OnData_HLT_GRun.py
@@ -1,11 +1,11 @@
-# /dev/CMSSW_7_2_1/GRun/V62 (CMSSW_7_2_1_patch2)
+# /dev/CMSSW_7_2_1/GRun/V63 (CMSSW_7_2_1_patch2)
 
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process( "HLTGRun" )
 
 process.HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_7_2_1/GRun/V62')
+  tableName = cms.string('/dev/CMSSW_7_2_1/GRun/V63')
 )
 
 process.HLTIter4PSetTrajectoryFilterIT = cms.PSet( 
@@ -30260,7 +30260,7 @@ process.hltEG120R9Id90HE10Iso40EBOnlyEtFilter = cms.EDFilter( "HLTEgammaEtFilter
     relaxed = cms.untracked.bool( False ),
     L1IsoCand = cms.InputTag( "hltEgammaCandidates" ),
     inputTag = cms.InputTag( "hltEGL1SingleEG35erFilter" ),
-    etcutEB = cms.double( 90.0 ),
+    etcutEB = cms.double( 120.0 ),
     etcutEE = cms.double( 999999.0 ),
     ncandcut = cms.int32( 1 )
 )

--- a/HLTrigger/Configuration/test/OnData_HLT_HIon.py
+++ b/HLTrigger/Configuration/test/OnData_HLT_HIon.py
@@ -1,11 +1,11 @@
-# /dev/CMSSW_7_2_1/HIon/V62 (CMSSW_7_2_1_patch2)
+# /dev/CMSSW_7_2_1/HIon/V63 (CMSSW_7_2_1_patch2)
 
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process( "HLTHIon" )
 
 process.HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_7_2_1/HIon/V62')
+  tableName = cms.string('/dev/CMSSW_7_2_1/HIon/V63')
 )
 
 process.HLTIter4PSetTrajectoryFilterIT = cms.PSet( 

--- a/HLTrigger/Configuration/test/OnData_HLT_PIon.py
+++ b/HLTrigger/Configuration/test/OnData_HLT_PIon.py
@@ -1,11 +1,11 @@
-# /dev/CMSSW_7_2_1/PIon/V62 (CMSSW_7_2_1_patch2)
+# /dev/CMSSW_7_2_1/PIon/V63 (CMSSW_7_2_1_patch2)
 
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process( "HLTPIon" )
 
 process.HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_7_2_1/PIon/V62')
+  tableName = cms.string('/dev/CMSSW_7_2_1/PIon/V63')
 )
 
 process.HLTIter4PSetTrajectoryFilterIT = cms.PSet( 

--- a/HLTrigger/Configuration/test/OnMc_HLT_FULL.py
+++ b/HLTrigger/Configuration/test/OnMc_HLT_FULL.py
@@ -1,11 +1,11 @@
-# /dev/CMSSW_7_2_1/HLT/V114 (CMSSW_7_2_1_patch2)
+# /dev/CMSSW_7_2_1/HLT/V116 (CMSSW_7_2_1_patch2)
 
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process( "HLTFULL" )
 
 process.HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_7_2_1/HLT/V114')
+  tableName = cms.string('/dev/CMSSW_7_2_1/HLT/V116')
 )
 
 process.HLTIter4PSetTrajectoryFilterIT = cms.PSet( 
@@ -33867,7 +33867,7 @@ process.hltEG120R9Id90HE10Iso40EBOnlyEtFilter = cms.EDFilter( "HLTEgammaEtFilter
     relaxed = cms.untracked.bool( False ),
     L1IsoCand = cms.InputTag( "hltEgammaCandidates" ),
     inputTag = cms.InputTag( "hltEGL1SingleEG35erFilter" ),
-    etcutEB = cms.double( 90.0 ),
+    etcutEB = cms.double( 120.0 ),
     etcutEE = cms.double( 999999.0 ),
     ncandcut = cms.int32( 1 )
 )

--- a/HLTrigger/Configuration/test/OnMc_HLT_GRun.py
+++ b/HLTrigger/Configuration/test/OnMc_HLT_GRun.py
@@ -1,11 +1,11 @@
-# /dev/CMSSW_7_2_1/GRun/V62 (CMSSW_7_2_1_patch2)
+# /dev/CMSSW_7_2_1/GRun/V63 (CMSSW_7_2_1_patch2)
 
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process( "HLTGRun" )
 
 process.HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_7_2_1/GRun/V62')
+  tableName = cms.string('/dev/CMSSW_7_2_1/GRun/V63')
 )
 
 process.HLTIter4PSetTrajectoryFilterIT = cms.PSet( 
@@ -30260,7 +30260,7 @@ process.hltEG120R9Id90HE10Iso40EBOnlyEtFilter = cms.EDFilter( "HLTEgammaEtFilter
     relaxed = cms.untracked.bool( False ),
     L1IsoCand = cms.InputTag( "hltEgammaCandidates" ),
     inputTag = cms.InputTag( "hltEGL1SingleEG35erFilter" ),
-    etcutEB = cms.double( 90.0 ),
+    etcutEB = cms.double( 120.0 ),
     etcutEE = cms.double( 999999.0 ),
     ncandcut = cms.int32( 1 )
 )

--- a/HLTrigger/Configuration/test/OnMc_HLT_HIon.py
+++ b/HLTrigger/Configuration/test/OnMc_HLT_HIon.py
@@ -1,11 +1,11 @@
-# /dev/CMSSW_7_2_1/HIon/V62 (CMSSW_7_2_1_patch2)
+# /dev/CMSSW_7_2_1/HIon/V63 (CMSSW_7_2_1_patch2)
 
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process( "HLTHIon" )
 
 process.HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_7_2_1/HIon/V62')
+  tableName = cms.string('/dev/CMSSW_7_2_1/HIon/V63')
 )
 
 process.HLTIter4PSetTrajectoryFilterIT = cms.PSet( 

--- a/HLTrigger/Configuration/test/OnMc_HLT_PIon.py
+++ b/HLTrigger/Configuration/test/OnMc_HLT_PIon.py
@@ -1,11 +1,11 @@
-# /dev/CMSSW_7_2_1/PIon/V62 (CMSSW_7_2_1_patch2)
+# /dev/CMSSW_7_2_1/PIon/V63 (CMSSW_7_2_1_patch2)
 
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process( "HLTPIon" )
 
 process.HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_7_2_1/PIon/V62')
+  tableName = cms.string('/dev/CMSSW_7_2_1/PIon/V63')
 )
 
 process.HLTIter4PSetTrajectoryFilterIT = cms.PSet( 


### PR DESCRIPTION
Fix the Photon120 paths to have an Et threshold of 120 GeV (mistakenly set to 90 GeV previously). CMSHLT-138.
