### PR TITLE
Fix compareStringsPlain error for 53X

### DIFF
--- a/Alignment/OfflineValidation/macros/PlotAlignmentValidation.C
+++ b/Alignment/OfflineValidation/macros/PlotAlignmentValidation.C
@@ -461,7 +461,6 @@ void PlotAlignmentValidation::plotSS( const std::string& options, const std::str
 
 	TString myTitle = "Surface Shape, ";
 	myTitle += subDetName;
-	// TODO: move "layer"/"disc" below into the legend, like with DMRs !!!!
 	if (layer!=0) {
 	  // TEC and TID have discs, the rest have layers
 	  if (iSubDet==4 || iSubDet==6)
@@ -489,7 +488,7 @@ void PlotAlignmentValidation::plotSS( const std::string& options, const std::str
 	  hs->Add(defhist);
 	  hs->SetTitle( myTitle );
 	  hs->Draw();
-	} // !!!! default. asd
+	}
 	else {
 	  hs->SetTitle( myTitle );
 	  hs->Draw("nostack PE");
@@ -537,7 +536,7 @@ void PlotAlignmentValidation::plotSS( const std::string& options, const std::str
 	f.Close();
 
 	delete legend;
-	delete hs; // !!!! Delete everything in it, too?
+	delete hs;
       }
     }
   }
@@ -625,10 +624,10 @@ void PlotAlignmentValidation::plotDMR(const std::string& variable, Int_t minHits
   if (variable == "meanX") {          plotinfo.nbins = 50;  plotinfo.min = -0.001; plotinfo.max = 0.001; }
   else if (variable == "meanY") {     plotinfo.nbins = 50;  plotinfo.min = -0.005; plotinfo.max = 0.005; }
   else if (variable == "medianX")
-    if (plotSplits) {                 plotinfo.nbins = 50;  plotinfo.min = -0.0005; plotinfo.max = 0.0005;} // !!!!
+    if (plotSplits) {                 plotinfo.nbins = 50;  plotinfo.min = -0.0005; plotinfo.max = 0.0005;}
     else {                            plotinfo.nbins = 100;  plotinfo.min = -0.001; plotinfo.max = 0.001; }
   else if (variable == "medianY")
-    if (plotSplits) {                 plotinfo.nbins = 50;  plotinfo.min = -0.0005; plotinfo.max = 0.0005;} // !!!!
+    if (plotSplits) {                 plotinfo.nbins = 50;  plotinfo.min = -0.0005; plotinfo.max = 0.0005;}
     else {                            plotinfo.nbins = 100;  plotinfo.min = -0.001; plotinfo.max = 0.001; }
   else if (variable == "meanNormX") { plotinfo.nbins = 100; plotinfo.min = -2.0;   plotinfo.max = 2.0; }
   else if (variable == "meanNormY") { plotinfo.nbins = 100; plotinfo.min = -2.0;   plotinfo.max = 2.0; }
@@ -739,17 +738,17 @@ void PlotAlignmentValidation::plotDMR(const std::string& variable, Int_t minHits
 
     }
 
-    if (plotinfo.h != 0 || plotinfo.h1 != 0 || plotinfo.h2 != 0) { // !!!!
+    if (plotinfo.h != 0 || plotinfo.h1 != 0 || plotinfo.h2 != 0) {
 
       hstack.Draw("nostack");
-      hstack.SetMaximum(plotinfo.maxY*1.3); // !!!! Surf. shapeihinkin?
+      hstack.SetMaximum(plotinfo.maxY*1.3);
       setTitleStyle(hstack, variable.c_str(), "#modules", plotinfo.subDetId);
       setHistStyle(*hstack.GetHistogram(), variable.c_str(), "#modules", 1);
 
       plotinfo.legend->Draw(); 
     }
     else {
-      // Draw an empty default histogram !!!! asd
+      // Draw an empty default histogram
       plotinfo.h = new TH1F("defhist", "Empty default histogram", plotinfo.nbins, plotinfo.min, plotinfo.max);
       if (plotinfo.variable.find("Norm") == std::string::npos)
         scaleXaxis(plotinfo.h, 10000);
@@ -808,7 +807,7 @@ void PlotAlignmentValidation::plotDMR(const std::string& variable, Int_t minHits
     c.Write();
     f.Close();
     
-    // !!!! ?? Free allocated memory.
+    // Free allocated memory.
     delete plotinfo.h;
     delete plotinfo.h1;
     delete plotinfo.h2;
@@ -866,6 +865,22 @@ void PlotAlignmentValidation::plotChi2(const char *inputFile)
   if (l != 0) {
     l->SetX1NDC(0.25);
     l->SetY1NDC(0.86);
+  }
+
+  // Move stat boxes slightly right so that the border lines fit in
+  int i = 1;
+  for (TH1F* h = (TH1F*)findObjectFromCanvas(normchi, "TH1F", i); h != 0;
+       h = (TH1F*)findObjectFromCanvas(normchi, "TH1F", ++i)) {
+        TPaveStats *s = (TPaveStats*)h->GetListOfFunctions()->FindObject("stats");
+        if (s != 0)
+          s->SetX2NDC(0.995);
+  }
+  i = 1;
+  for (TH1F* h = (TH1F*)findObjectFromCanvas(chiprob, "TH1F", i); h != 0;
+       h = (TH1F*)findObjectFromCanvas(chiprob, "TH1F", ++i)) {
+        TPaveStats *s = (TPaveStats*)h->GetListOfFunctions()->FindObject("stats");
+        if (s != 0)
+          s->SetX2NDC(0.995);
   }
 
   chiprob->Draw();
@@ -1117,7 +1132,7 @@ void  PlotAlignmentValidation::setNiceStyle() {
     zoff = MyStyle->GetLabelOffset("Z");
 
   MyStyle->SetCanvasBorderMode ( 0 );
-  MyStyle->SetFrameBorderMode ( 0 ); // !!!! to get rid of the red lines around the borders
+  MyStyle->SetFrameBorderMode ( 0 );
   MyStyle->SetPadBorderMode    ( 0 );
   MyStyle->SetPadColor         ( 0 );
   MyStyle->SetCanvasColor      ( 0 );
@@ -1447,6 +1462,6 @@ void PlotAlignmentValidation::modifySSHistAndLegend(THStack* hs, TLegend* legend
     index++;
   }
 
-  // Make some room for the legend !!!!
+  // Make some room for the legend
   hs->SetMaximum(hs->GetMaximum("nostack PE")*1.3);
 }

--- a/Alignment/OfflineValidation/macros/PlotAlignmentValidation.C
+++ b/Alignment/OfflineValidation/macros/PlotAlignmentValidation.C
@@ -688,6 +688,7 @@ void PlotAlignmentValidation::plotDMR(const std::string& variable, Int_t minHits
       int maxlayer = plotLayers ? plotinfo.nLayers : plotLayerN;
 
       plotinfo.vars = *it;
+      plotinfo.h1 = plotinfo.h2 = plotinfo.h = 0;
 
       for (int layer = minlayer; layer <= maxlayer; layer++) {
 
@@ -738,8 +739,7 @@ void PlotAlignmentValidation::plotDMR(const std::string& variable, Int_t minHits
 
     }
 
-    if (plotinfo.h != 0 || plotinfo.h1 != 0 || plotinfo.h2 != 0) {
-
+    if (hstack.GetHists()!=0 && hstack.GetHists()->GetSize()!=0) {
       hstack.Draw("nostack");
       hstack.SetMaximum(plotinfo.maxY*1.3);
       setTitleStyle(hstack, variable.c_str(), "#modules", plotinfo.subDetId);
@@ -750,6 +750,7 @@ void PlotAlignmentValidation::plotDMR(const std::string& variable, Int_t minHits
     else {
       // Draw an empty default histogram
       plotinfo.h = new TH1F("defhist", "Empty default histogram", plotinfo.nbins, plotinfo.min, plotinfo.max);
+      plotinfo.h->SetMaximum(10);
       if (plotinfo.variable.find("Norm") == std::string::npos)
         scaleXaxis(plotinfo.h, 10000);
       setTitleStyle(*plotinfo.h, variable.c_str(), "#modules", plotinfo.subDetId);

--- a/Alignment/OfflineValidation/macros/PlotAlignmentValidation.h
+++ b/Alignment/OfflineValidation/macros/PlotAlignmentValidation.h
@@ -105,6 +105,7 @@ private :
   void setNiceStyle();
   void setCanvasStyle( TCanvas& canv );
   void setLegendStyle( TLegend& leg );
+  void scaleXaxis(TH1* hist, Int_t scale);
   TObject* findObjectFromCanvas(TCanvas* canv, const char* className, Int_t n=1);
 
   TString outputFile;

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/alternateValidationTemplates.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/alternateValidationTemplates.py
@@ -312,18 +312,6 @@ process.load("Configuration.StandardSequences.GeometryDB_cff")
 ##
 process.load("Configuration/StandardSequences/MagneticField_38T_cff")
 
-import CalibTracker.Configuration.Common.PoolDBESSource_cfi
-
-process.conditionsInTrackerAlignmentRcd = CalibTracker.Configuration.Common.PoolDBESSource_cfi.poolDBESSource.clone(connect = cms.string('sqlite_file:/afs/cern.ch/cms/CAF/CMSALCA/ALCA_TRACKERALIGN/MP/MPproduction/mp1193/jobData/jobm/alignments_MP.db'),
-          toGet = cms.VPSet(cms.PSet(record = cms.string('TrackerAlignmentRcd'),
-          tag = cms.string('Alignments')
-          )
-          )
-          )
-
-process.prefer_conditionsInTrackerAlignmentRcd = cms.ESPrefer("PoolDBESSource", "conditionsInTrackerAlignmentRcd")
-
-          
 .oO[LorentzAngleTemplate]Oo.
   
  ##
@@ -511,6 +499,307 @@ process.p = cms.Path(process.offlineBeamSpot*process.AliMomConstraint1*process.T
 
 """
 
+
+######################################################################
+######################################################################
+CosmicsAt0TParallelOfflineValidation="""
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("OfflineValidator") 
+   
+process.load("Alignment.OfflineValidation..oO[dataset]Oo._cff")
+
+process.options = cms.untracked.PSet(
+   wantSummary = cms.untracked.bool(False),
+   Rethrow = cms.untracked.vstring("ProductNotFound"), # make this exception fatal
+   fileMode  =  cms.untracked.string('NOMERGE') # no ordering needed, but calls endRun/beginRun etc. at file boundaries
+)
+
+ ##
+ ## Maximum number of Events
+ ## and number of events to be skipped
+ ## in case of parallel job nIndex
+ ## .oO[nIndex]Oo * .oO[nEvents]Oo/.oO[nJobs]Oo
+ ## 
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(.oO[nEvents]Oo./.oO[nJobs]Oo.)
+ )
+process.source.skipEvents=cms.untracked.uint32(.oO[nIndex]Oo.*.oO[nEvents]Oo./.oO[nJobs]Oo.)
+
+ ##   
+ ## Messages & Convenience
+ ##
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger.cerr = cms.untracked.PSet(placeholder = cms.untracked.bool(True))
+process.MessageLogger.cout = cms.untracked.PSet(INFO = cms.untracked.PSet(
+reportEvery = cms.untracked.int32(1000) # every 1000th only
+#    limit = cms.untracked.int32(10)       # or limit to 10 printouts...
+))
+process.MessageLogger.statistics.append('cout')
+
+#-- Track hit filter
+# TrackerTrackHitFilter takes as input the tracks/trajectories coming out from TrackRefitter1
+process.load("RecoTracker.FinalTrackSelectors.TrackerTrackHitFilter_cff")
+process.TrackerTrackHitFilter.src = 'TrackRefitter1'
+
+#-- Alignment Track Selection
+process.load("Alignment.CommonAlignmentProducer.AlignmentTrackSelector_cfi")
+process.AlignmentTrackSelector.src = 'HitFilteredTracks'
+process.AlignmentTrackSelector.filter = True
+
+.oO[TrackSelectionTemplate]Oo.
+# Override the pmin setting since not meaningful with B=0T
+process.AlignmentTrackSelector.pMin = 4.
+
+#### momentum constraint for 0T
+# First momentum constraint
+process.load("RecoTracker.TrackProducer.MomentumConstraintProducer_cff")
+import RecoTracker.TrackProducer.MomentumConstraintProducer_cff
+process.AliMomConstraint1 = RecoTracker.TrackProducer.MomentumConstraintProducer_cff.MyMomConstraint.clone()
+process.AliMomConstraint1.src = '.oO[TrackCollection]Oo.'
+process.AliMomConstraint1.fixedMomentum = 5.0
+process.AliMomConstraint1.fixedMomentumError = 0.005
+
+# Second momentum constraint
+#process.load("RecoTracker.TrackProducer.MomentumConstraintProducer_cff")
+#import RecoTracker.TrackProducer.MomentumConstraintProducer_cff
+#process.AliMomConstraint2 = RecoTracker.TrackProducer.MomentumConstraintProducer_cff.MyMomConstraint.clone()
+#process.AliMomConstraint2.src = 'AlignmentTrackSelector'
+#process.AliMomConstraint2.fixedMomentum = 5.0
+#process.AliMomConstraint2.fixedMomentumError = 0.005
+
+#now we give the TrackCandidate coming out of the TrackerTrackHitFilter to the track producer
+import RecoTracker.TrackProducer.CTFFinalFitWithMaterialP5_cff
+process.HitFilteredTracks = RecoTracker.TrackProducer.CTFFinalFitWithMaterialP5_cff.ctfWithMaterialTracksCosmics.clone(
+src = 'TrackerTrackHitFilter',
+NavigationSchool = cms.string(''),
+TTRHBuilder = "WithAngleAndTemplate"
+### ,
+### TrajectoryInEvent = True,
+### TTRHBuilder = "WithAngleAndTemplate"
+)
+
+##
+## Load and Configure TrackRefitter1
+##
+process.load("RecoTracker.TrackProducer.TrackRefitters_cff")
+
+#############
+# parameters for TrackRefitter
+#process.load("RecoTracker.TrackProducer.RefitterWithMaterial_cff")
+import RecoTracker.TrackProducer.TrackRefitters_cff
+process.TrackRefitter1 = process.TrackRefitterP5.clone(
+src = '.oO[TrackCollection]Oo.', #'AliMomConstraint1',
+TrajectoryInEvent = True,
+TTRHBuilder = "WithAngleAndTemplate",
+NavigationSchool = "",
+constraint = 'momentum', ### SPECIFIC FOR CRUZET
+srcConstr='AliMomConstraint1' ### SPECIFIC FOR CRUZET$works only with tag V02-10-02 TrackingTools/PatternTools / or CMSSW >=31X
+)
+
+process.TrackRefitter2 = process.TrackRefitter1.clone(
+src = 'AlignmentTrackSelector',
+srcConstr='AliMomConstraint1',
+constraint = 'momentum' ### SPECIFIC FOR CRUZET
+)
+
+
+##
+## Get the BeamSpot
+##
+process.load("RecoVertex.BeamSpotProducer.BeamSpot_cff")
+
+##
+## GlobalTag Conditions (if needed)
+##
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+process.GlobalTag.globaltag = ".oO[GlobalTag]Oo."
+# process.GlobalTag.connect="frontier://FrontierProd/CMS_COND_31X_GLOBALTAG"
+.oO[LorentzAngleTemplate]Oo.
+
+##
+## Geometry
+##
+process.load("Configuration.StandardSequences.Geometry_cff")
+
+##
+## Magnetic Field
+##
+#process.load("Configuration/StandardSequences/MagneticField_38T_cff")
+process.load("Configuration.StandardSequences.MagneticField_0T_cff") # 0T runs
+.oO[condLoad]Oo.
+
+
+##
+## Load and Configure OfflineValidation
+##
+process.load("Alignment.OfflineValidation.TrackerOfflineValidation_.oO[offlineValidationMode]Oo._cff")
+process.TrackerOfflineValidation.oO[offlineValidationMode]Oo..Tracks = 'TrackRefitter2'
+process.TrackerOfflineValidation.oO[offlineValidationMode]Oo..trajectoryInput = 'TrackRefitter2'
+process.TrackerOfflineValidation.oO[offlineValidationMode]Oo..moduleLevelHistsTransient = cms.bool(.oO[offlineModuleLevelHistsTransient]Oo.)
+process.TFileService.fileName = '.oO[outputFile]Oo.'
+
+##
+## PATH
+##
+process.p = cms.Path(process.offlineBeamSpot*process.AliMomConstraint1*process.TrackRefitter1*process.TrackerTrackHitFilter*process.HitFilteredTracks
+*process.AlignmentTrackSelector*process.TrackRefitter2*process.seqTrackerOfflineValidation.oO[offlineValidationMode]Oo.)
+"""
+
+
+######################################################################
+######################################################################
+CosmicsParallelOfflineValidation="""
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("OfflineValidator") 
+   
+process.load("Alignment.OfflineValidation..oO[dataset]Oo._cff")
+
+process.options = cms.untracked.PSet(
+   wantSummary = cms.untracked.bool(False),
+   Rethrow = cms.untracked.vstring("ProductNotFound"), # make this exception fatal
+   fileMode  =  cms.untracked.string('NOMERGE') # no ordering needed, but calls endRun/beginRun etc. at file boundaries
+)
+
+ ##
+ ## Maximum number of Events
+ ## and number of events to be skipped
+ ## in case of parallel job nIndex
+ ## .oO[nIndex]Oo * .oO[nEvents]Oo/.oO[nJobs]Oo
+ ## 
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(.oO[nEvents]Oo./.oO[nJobs]Oo.)
+ )
+process.source.skipEvents=cms.untracked.uint32(.oO[nIndex]Oo.*.oO[nEvents]Oo./.oO[nJobs]Oo.)
+
+ ##   
+ ## Messages & Convenience
+ ##
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger.cerr = cms.untracked.PSet(placeholder = cms.untracked.bool(True))
+process.MessageLogger.cout = cms.untracked.PSet(INFO = cms.untracked.PSet(
+reportEvery = cms.untracked.int32(1000) # every 1000th only
+#    limit = cms.untracked.int32(10)       # or limit to 10 printouts...
+))
+process.MessageLogger.statistics.append('cout')
+
+ ##
+ ## Get the BeamSpot
+ ##
+process.load("RecoVertex.BeamSpotProducer.BeamSpot_cff")
+
+ #-- Refitting
+process.load("RecoTracker.TrackProducer.TrackRefitters_cff")
+
+##-- Track hit filter
+## TrackerTrackHitFilter takes as input the tracks/trajectories coming out from TrackRefitter1
+#process.load("RecoTracker.FinalTrackSelectors.TrackerTrackHitFilter_cff")
+#process.TrackerTrackHitFilter.src = 'TrackRefitter1'
+
+#-- 1st refit from file
+process.TrackRefitter1 = process.TrackRefitterP5.clone(
+        src ='ALCARECOTkAlCosmicsCTF0T',
+        NavigationSchool = cms.string(''),
+        TrajectoryInEvent = True,
+        TTRHBuilder = "WithAngleAndTemplate" #default
+        )
+
+#-- 2nd fit for AlignmentProducer
+process.TrackRefitter2 = process.TrackRefitter1.clone(
+       src = 'AlignmentTrackSelector'
+       )
+                            
+#-- Filter bad hits
+process.load("RecoTracker.FinalTrackSelectors.TrackerTrackHitFilter_cff")
+process.TrackerTrackHitFilter.src = 'TrackRefitter1'
+process.TrackerTrackHitFilter.useTrajectories= True  # this is needed only if you require some selections; but it will work even if you don't ask for them
+process.TrackerTrackHitFilter.minimumHits = 8
+process.TrackerTrackHitFilter.commands = cms.vstring("keep PXB","keep PXE","keep TIB","keep TID","keep TOB","keep TEC")
+process.TrackerTrackHitFilter.detsToIgnore = []
+process.TrackerTrackHitFilter.replaceWithInactiveHits = True
+process.TrackerTrackHitFilter.stripAllInvalidHits = False
+process.TrackerTrackHitFilter.rejectBadStoNHits = True
+process.TrackerTrackHitFilter.StoNcommands = cms.vstring("ALL 18.0")
+process.TrackerTrackHitFilter.rejectLowAngleHits = True
+process.TrackerTrackHitFilter.TrackAngleCut = 0.35# in rads, starting from the module surface
+process.TrackerTrackHitFilter.usePixelQualityFlag = True #False
+
+#-- TrackProducer
+## now we give the TrackCandidate coming out of the TrackerTrackHitFilter to the track producer
+import RecoTracker.TrackProducer.CTFFinalFitWithMaterialP5_cff
+process.TrackCandidateFitter = RecoTracker.TrackProducer.CTFFinalFitWithMaterialP5_cff.ctfWithMaterialTracksCosmics.clone(
+src = 'TrackerTrackHitFilter',
+     NavigationSchool = cms.string(''),
+     TTRHBuilder = "WithAngleAndTemplate"
+     )
+#-- Filter tracks for alignment
+process.load("Alignment.CommonAlignmentProducer.AlignmentTrackSelector_cfi")
+process.AlignmentTrackSelector.src = 'TrackCandidateFitter'
+process.AlignmentTrackSelector.applyBasicCuts = True
+process.AlignmentTrackSelector.pMin = 4
+process.AlignmentTrackSelector.pMax = 9999.
+process.AlignmentTrackSelector.ptMin = 0
+process.AlignmentTrackSelector.etaMin = -999.
+process.AlignmentTrackSelector.etaMax = 999.
+process.AlignmentTrackSelector.nHitMin = 8
+process.AlignmentTrackSelector.nHitMin2D = 2
+process.AlignmentTrackSelector.chi2nMax = 99.
+process.AlignmentTrackSelector.applyMultiplicityFilter = True# False
+process.AlignmentTrackSelector.maxMultiplicity = 1
+
+## GlobalTag Conditions (if needed)
+##
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+process.GlobalTag.globaltag = ".oO[GlobalTag]Oo."
+
+
+##
+## Geometry
+##
+process.load("Configuration.StandardSequences.GeometryDB_cff")
+
+##
+## Magnetic Field
+##
+process.load("Configuration/StandardSequences/MagneticField_38T_cff")
+
+         
+.oO[LorentzAngleTemplate]Oo.
+  
+ ##
+ ## Geometry
+ ##
+#process.load("Configuration.StandardSequences.Geometry_cff")
+ 
+.oO[condLoad]Oo.
+
+ ##
+ ## Load and Configure OfflineValidation
+ ##
+
+process.load("Alignment.OfflineValidation.TrackerOfflineValidation_.oO[offlineValidationMode]Oo._cff")
+process.TrackerOfflineValidation.oO[offlineValidationMode]Oo..Tracks = 'TrackRefitter2'
+process.TrackerOfflineValidation.oO[offlineValidationMode]Oo..trajectoryInput = 'TrackRefitter2'
+process.TrackerOfflineValidation.oO[offlineValidationMode]Oo..moduleLevelHistsTransient = cms.bool(.oO[offlineModuleLevelHistsTransient]Oo.)
+process.TrackerOfflineValidation.oO[offlineValidationMode]Oo..moduleLevelProfiles = cms.bool(.oO[offlineModuleLevelProfiles]Oo.)
+process.TFileService.fileName = '.oO[outputFile]Oo.'
+
+ ##
+ ## PATH
+ ##
+
+process.p = cms.Path( process.offlineBeamSpot
+     *process.TrackRefitter1
+     *process.TrackerTrackHitFilter
+     *process.TrackCandidateFitter
+     *process.AlignmentTrackSelector
+     *process.TrackRefitter2
+     *process.seqTrackerOfflineValidationStandalone
+)
+
+
+"""
 
 ######################################################################
 ######################################################################

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/configTemplates.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/configTemplates.py
@@ -204,11 +204,6 @@ done
 .oO[RunExtendedOfflineValidation]Oo.
 .oO[RunTrackSplitPlot]Oo.
 
-for file in $(ls -d --color=never *_result.root)
-do
-    cmsStage -f ${file} /store/caf/user/$USER/.oO[eosdir]Oo.
-done
-
 # clean-up
 # ls -l *.root
 rm -f *.root
@@ -223,10 +218,22 @@ find . -name "*.stdout" -exec gzip -f {} \;
 ######################################################################
 ######################################################################
 compareAlignmentsExecution="""
-#merge for .oO[validationId]Oo.
-cp .oO[CMSSW_BASE]Oo./src/Alignment/OfflineValidation/scripts/compareAlignments.cc .
-root -q -b 'compareAlignments.cc++(\".oO[compareStrings]Oo.\")'
-mv result.root .oO[validationId]Oo._result.root
+#merge for .oO[validationId]Oo. if it does not exist or is not up-to-date
+echo -e "\n\nComparing validations"
+cp .oO[CMSSW_BASE]Oo./src/Alignment/OfflineValidation/scripts/compareFileAges.C .
+root -x -q -b -l "compareFileAges.C(\\\"root://eoscms.cern.ch//eos/cms/store/caf/user/$USER/.oO[eosdir]Oo./.oO[validationId]Oo._result.root\\\", \\\".oO[compareStringsPlain]Oo.\\\")"
+comparisonNeeded=${?}
+
+if [[ ${comparisonNeeded} -eq 1 ]]
+then
+    cp .oO[CMSSW_BASE]Oo./src/Alignment/OfflineValidation/scripts/compareAlignments.cc .
+    root -x -q -b -l 'compareAlignments.cc++(\".oO[compareStrings]Oo.\")'
+    mv result.root .oO[validationId]Oo._result.root
+    cmsStage -f .oO[validationId]Oo._result.root /store/caf/user/$USER/.oO[eosdir]Oo.
+else
+    echo ".oO[validationId]Oo._result.root is up-to-date, no need to compare again."
+    cmsStage -f /store/caf/user/$USER/.oO[eosdir]Oo./.oO[validationId]Oo._result.root .
+fi
 """
 
 
@@ -234,6 +241,7 @@ mv result.root .oO[validationId]Oo._result.root
 ######################################################################
 extendedValidationExecution="""
 #run extended offline validation scripts
+echo -e "\n\nRunning extended offline validation"
 if [[ $HOSTNAME = lxplus[0-9]*\.cern\.ch ]] # check for interactive mode
 then
     rfmkdir -p .oO[workdir]Oo./ExtendedOfflineValidation_Images
@@ -243,17 +251,19 @@ fi
 
 rfcp .oO[extendeValScriptPath]Oo. .
 rfcp .oO[CMSSW_BASE]Oo./src/Alignment/OfflineValidation/macros/PlotAlignmentValidation.C .
-root -x -b -q TkAlExtendedOfflineValidation.C
+root -x -b -q -l TkAlExtendedOfflineValidation.C
 rfmkdir -p .oO[datadir]Oo./ExtendedOfflineValidation_Images
 
 if [[ $HOSTNAME = lxplus[0-9]*\.cern\.ch ]] # check for interactive mode
 then
     image_files=$(ls --color=never | find .oO[workdir]Oo./ExtendedOfflineValidation_Images/ -name \*ps -o -name \*root)
-    echo ${image_files}
+    echo -e "\n\nProduced plot files:"
+    #echo ${image_files}
     ls .oO[workdir]Oo./ExtendedOfflineValidation_Images
 else
     image_files=$(ls --color=never | find ExtendedOfflineValidation_Images/ -name \*ps -o -name \*root)
-    echo ${image_files}
+    echo -e "\n\nProduced plot files:"
+    #echo ${image_files}
     ls ExtendedOfflineValidation_Images
 fi
 

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/configTemplates.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/configTemplates.py
@@ -173,6 +173,10 @@ cd .oO[CMSSW_BASE]Oo./src
 export SCRAM_ARCH=.oO[SCRAM_ARCH]Oo.
 eval `scramv1 ru -sh`
 
+#create results-directory and copy used configuration there
+rfmkdir -p .oO[datadir]Oo.
+rfcp .oO[logdir]Oo./usedConfiguration.ini .oO[datadir]Oo.
+
 if [[ $HOSTNAME = lxplus[0-9]*\.cern\.ch ]] # check for interactive mode
 then
     mkdir -p .oO[workdir]Oo.

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/dataset.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/dataset.py
@@ -172,7 +172,10 @@ class Dataset:
     def __getData( self, dasQuery, dasLimit = 0 ):
         dasData = das_client.get_data( 'https://cmsweb.cern.ch',
                                        dasQuery, 0, dasLimit, False )
-        jsondict = json.loads( dasData )
+        if isinstance(dasData, str):
+            jsondict = json.loads( dasData )
+        else:
+            jsondict = dasData
         # Check, if the DAS query fails
         if jsondict["status"] != 'ok':
             msg = "Status not 'ok', but:", jsondict["status"]
@@ -183,7 +186,11 @@ class Dataset:
         dasQuery_type = ( 'dataset dataset=%s | grep dataset.datatype,'
                           'dataset.name'%( self.__name ) )
         data = self.__getData( dasQuery_type )
-        return data[0]["dataset"][0]["datatype"]
+        for a in data[0]["dataset"]:
+            if "datatype" in a:
+                return a["datatype"]
+        msg = ("Cannot find the datatype of the dataset '%s'"%( self.name() ))
+        raise AllInOneError( msg )
 
     def __getFileInfoList( self, dasLimit ):
         if self.__fileInfoList:

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/genericValidation.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/genericValidation.py
@@ -39,7 +39,7 @@ class GenericValidation:
                 })
         return result
 
-    def getCompareStrings( self, requestId = None ):
+    def getCompareStrings( self, requestId = None, plain = False ):
         result = {}
         repMap = self.alignmentToValidate.getRepMap()
         for validationId in self.filesToCompare:
@@ -48,7 +48,10 @@ class GenericValidation:
                 repMap["file"] = "rfio:%(file)s"%repMap
             elif repMap["file"].startswith( "/store/" ):
                 repMap["file"] = "root://eoscms.cern.ch//eos/cms%(file)s"%repMap
-            result[validationId]= "%(file)s=%(name)s|%(color)s|%(style)s"%repMap
+            if plain:
+                result[validationId]=repMap["file"]
+            else:
+                result[validationId]= "%(file)s=%(name)s|%(color)s|%(style)s"%repMap
         if requestId == None:
             return result
         else:

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/offlineValidation.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/offlineValidation.py
@@ -219,7 +219,7 @@ class OfflineValidationParallel(OfflineValidation):
                 
         mergedoutputfile = ("AlignmentValidation_" + self.name + "_"
                             + '%(name)s'%repMap + ".root")
-        validationsSoFar += ('root -x -b -q "TkAlOfflineJobsMerge.C(\\\"'
+        validationsSoFar += ('root -x -b -q -l "TkAlOfflineJobsMerge.C(\\\"'
                              +parameters+'\\\",\\\"'+mergedoutputfile+'\\\")"'
                              +"\n")
         return validationsSoFar

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/offlineValidationTemplates.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/offlineValidationTemplates.py
@@ -405,7 +405,7 @@ mergeOfflineParallelResults="""
 # if merged file already exists it will be moved to a backup file (~)
 
 # run TkAlOfflinejobs.C
-echo "Merging results from parallel jobs with TkAlOfflineJobsMerge.C"
+echo -e "\n\nMerging results from parallel jobs with TkAlOfflineJobsMerge.C"
 #set directory to which TkAlOfflineJobsMerge.C saves the merged file
 # export OUTPUTDIR=.oO[datadir]Oo.
 export OUTPUTDIR=.
@@ -424,7 +424,7 @@ ls -al AlignmentValidation*.root > .oO[datadir]Oo./log_rootfilelist.txt
 ######################################################################
 ######################################################################
 mergeOfflineParJobsTemplate="""
-void TkAlOfflineJobsMerge(TString pars, TString outFile)
+int TkAlOfflineJobsMerge(TString pars, TString outFile)
 {
 // load framework lite just to find the CMSSW libs...
 gSystem->Load("libFWCoreFWLite");
@@ -432,7 +432,7 @@ AutoLibraryLoader::enable();
 //compile the macro
 gROOT->ProcessLine(".L merge_TrackerOfflineValidation.C++");
 
-hadd(pars, outFile);
+return hadd(pars, outFile);
 }
 """
 

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/presentationTemplates.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/presentationTemplates.py
@@ -1,0 +1,87 @@
+# Templates for the production of a LaTeX presentation.
+
+texTemplate=r"""%Offline Alignment Validation presentation.
+%Time of creation: [time]
+%Created with produceOfflineValidationTex.py
+\documentclass{beamer}
+\usepackage[latin1]{inputenc}
+\usepackage{color}
+%\usepackage{siunitx}
+%\usepackage{epstopdf}
+\usetheme{default}
+\title[Offline Validation]{Title here}
+\author{Author(s) here}
+\institute{Institute here}
+\date{Date here}
+
+
+
+\begin{document}
+
+\begin{frame}
+\titlepage
+\end{frame}
+
+\section{Introduction}
+%---------------------------------------------
+\begin{frame}{Introduction}
+{
+\begin{itemize}
+ \item Introduction here
+\end{itemize}
+}
+\end{frame}
+
+
+\section{Plots}
+%---------------------------------------------
+
+
+[frames]
+
+
+\section{Conclusions}
+%---------------------------------------------
+\begin{frame}{Conclusions}
+{
+\begin{itemize}
+\item Conclusions here
+\end{itemize}
+}
+\end{frame} 
+
+
+
+\end{document}
+
+"""
+
+frameTemplate=r"""
+\begin{frame}{[title]}
+  \begin{figure}
+    \centering
+[plots]
+    %\\Comments here
+  \end{figure}
+\end{frame}
+"""
+
+plotTemplate=r"""    \includegraphics[width=[width]\textwidth, height=[height]\textheight, keepaspectratio=true]{[path]}"""
+
+subsectionTemplate=r"""
+
+\subsection{[title]}
+%---------------------------------------------
+"""
+
+toPdf="""
+#To produce a pdf presentation 
+#a. fill in your information, comments etc. in presentation.tex
+#b. run this script: ./ToPdf.sh
+latex presentation.tex
+latex presentation.tex #(twice to produce the bookmarks)
+dvipdf presentation.dvi
+#(pdflatex doesn't like .eps-images; this way we can
+#use just latex and the convert the result into pdf.)
+
+"""

--- a/Alignment/OfflineValidation/scripts/compareFileAges.C
+++ b/Alignment/OfflineValidation/scripts/compareFileAges.C
@@ -1,0 +1,41 @@
+/*
+
+This root macro takes a file name and a space separated list of other file names
+and compares their modification times. If the first file is the most recently
+modified, 0 is returned; otherwise, 1 is returned. If the first file is not
+found, 1 is returned.
+
+*/
+
+#include "TROOT.h"
+#include "TString.h"
+#include "TObjString.h"
+
+int compareFileAges(const char* newestCandidate, const char* filesToCompare) {
+
+  Long_t dummy = 0;
+  Long_t candidateTime = 0;
+  Long_t comparisonTime = 0;
+  int found = !gSystem->GetPathInfo(newestCandidate, &dummy, &dummy, &dummy,
+                                   &candidateTime);
+  //cout << newestCandidate << ": " << candidateTime << endl;
+  // If the first file is not found, return 1
+  if(!found)
+    return 1;
+
+  // Separate files in the list into an array
+  TObjArray* compareList = TString(filesToCompare).Tokenize(" ");
+
+  // Go through the array
+  for (Int_t iFile = 0; iFile < compareList->GetEntriesFast(); ++iFile) {
+    found = !gSystem->GetPathInfo(compareList->At(iFile)->GetName(), &dummy,
+                                 &dummy, &dummy, &comparisonTime);
+    //cout << compareList->At(iFile)->GetName() << ": " << comparisonTime << endl;
+    // If the first file doesn't have the biggest modification time, return 1
+    if(found && candidateTime <= comparisonTime)
+      return 1;
+  }
+
+  // The first file had the biggest modification time: return 0
+  return 0;
+}

--- a/Alignment/OfflineValidation/scripts/merge_TrackerOfflineValidation.C
+++ b/Alignment/OfflineValidation/scripts/merge_TrackerOfflineValidation.C
@@ -60,7 +60,7 @@ float getMedian(const TH1 *histo);
 //////////////////////////////////////////////////////////////////////////
 // master method
 //////////////////////////////////////////////////////////////////////////
-void hadd(const char *filesSeparatedByKommaOrEmpty = "", const char * outputFile = "") {
+int hadd(const char *filesSeparatedByKommaOrEmpty = "", const char * outputFile = "") {
 //void merge_TrackerOfflineValidation(const char *filesSeparatedByKommaOrEmpty = "") {
 
   TString fileNames(filesSeparatedByKommaOrEmpty);
@@ -109,7 +109,7 @@ void hadd(const char *filesSeparatedByKommaOrEmpty = "", const char * outputFile
     } else {
       cout << "File " << names->At(iFile)->GetName() << " does not exist!" << endl;
       delete names; names = 0;
-      return;
+      return 1;
     }
   }
   delete names;
@@ -162,10 +162,12 @@ void hadd(const char *filesSeparatedByKommaOrEmpty = "", const char * outputFile
   // The abort() command is ugly, but much quicker than the clean return()
   // Use of return() can take 90 minutes, while abort() takes 10 minutes
   // (merging 20 jobs with 1M events in total)
-  abort();
+  // BUT abort creates an error signal and incorrect functioning
+  // at higher level
+  // abort();
 
   std::cout << "Now returning from merge_TrackerOfflineValidation.C" << std::endl;
-  return;
+  return 0;
 } 
 
 /////////////////////////////////////////////////////////////////////////

--- a/Alignment/OfflineValidation/scripts/produceOfflineValidationTex.py
+++ b/Alignment/OfflineValidation/scripts/produceOfflineValidationTex.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python
+# This script creates a .tex-file for displaying the results
+# of an offline alignment validation of the CMS tracker.
+#
+# HOW TO USE:
+# -Pass the paths of the directories containing the plots as arguments
+#  (these would be the ExtendedValidationImages-directories of the
+#  relevant validations). E.g.
+#    produceOfflineValidationTex.py plotdir1 plotdir2
+# -To change the general properties of the presentation to be produced,
+#  modify the templates found in presentationTemplates.py.
+# -To produce different plots, use the writePageReg-function to select
+#  the types of files you want on a page.
+#
+#
+# Originally by Eemeli Tomberg, 2014
+
+
+
+import sys
+import re
+import os
+import stat
+import math
+import time
+from Alignment.OfflineValidation.TkAlAllInOneTool.presentationTemplates import *
+
+subdetectors = ["BPIX", "FPIX", "TIB", "TOB", "TID", "TEC"]
+
+
+# Plots related to a single validation:
+class ValidationPlots:
+    def __init__(self, path):
+        if not os.path.isdir(path):
+            print "Error: Directory "+path+" not found!"
+            exit(1)
+        if not path.endswith('/'):
+            path += '/'
+        path = path.replace('\\', '/') # Beacause LaTeX has issues with '\'.
+        self.path = path
+        # List of plot files in given directory:
+        self.plots = [file for file in os.listdir(path)
+                      if file.endswith('.eps')]
+
+
+# Layout of plots on a page:
+class PageLayout:
+    def __init__(self, pattern=[], width=1, height=1):
+        self.pattern = [] # List of rows; row contains the order numbers
+                          # of its plots; e.g. [[1,2,3], [4,5,6]]
+        self.width = width # Maximum width of one plot,
+                           # with respect to textwidth.
+        self.height = height # Maximum height of one plot,
+                             # with respect to textheight.
+
+    # Sets variables for the given plots and returns the plots
+    # in an appropriate order:
+    def fit(self, plots):
+        rowlengths = []
+        # First, try to place plots in a square.
+        nplots = sum(len(p) for p in plots)
+        length = int(math.ceil(math.sqrt(nplots)))
+        # Then, fill the square from the bottom and remove extra rows.
+        fullRows = int(nplots/length)
+        residual = nplots - length*fullRows
+        nrows = fullRows
+        if residual != 0:
+            rowlengths.append(residual)
+            nrows += 1
+        for _ in xrange(fullRows):
+            rowlengths.append(length)
+
+        # Now, fill the pattern.
+        self.pattern = []
+        if residual == 0 and len(plots[0])%length != 0 and\
+           len(plots[0])%nrows == 0:
+            # It's better to arrange plots in columns, not rows.
+            self.pattern.extend(range(i, i+nrows*(length-1)+1, nrows)
+                                for i in range(1, nrows+1))
+        else:
+            if residual != 0:
+                self.pattern.append(range(1, 1+residual))
+            self.pattern.extend(range(i, i+length) for i in
+                                range(residual+1, nplots-length+2, length))
+
+        self.width = 1.0/length
+        self.height = 0.8/nrows
+
+
+# Write a set of pages, one for each subdetector.
+# Arguments: identifier: regular expression to get the wanted plots,
+#                        used together with subdetector name
+#            title: title of the plot type
+#            validations: list of relevant ValidationPlots objects.
+# Returns the parsed script.
+def writeSubsection(identifier, title, validations):
+    script = ''
+    for subdetector in subdetectors:
+        script += writePageReg('(?=.*%s)%s'%(subdetector, identifier),
+                               title+': ' +subdetector, validations)
+    if script != '':
+        script = subsectionTemplate.replace('[title]', title)+script
+    return script
+
+
+# Write a page containing plots of given type.
+# Arguments: identifier: regular expression to get the wanted plots
+#            title: title of the plot type
+#            validations: list of relevant ValidationPlots objects
+#            layout: given page layout.
+# Returns the parsed script.
+def writePageReg(identifier, title, validations, layout=0):
+    plots = []
+    for validation in validations:
+        valiplots = [validation.path+plot for plot in validation.plots
+                     if re.search(identifier, plot)]
+        valiplots.sort(key=plotSortKey)
+        plots.append(valiplots)
+    if sum(len(p) for p in plots) == 0:
+        print 'Warning: no plots matching ' + identifier
+        return ''
+
+    # Create layout, if not given.
+    if layout == 0:
+        layout = PageLayout()
+        layout.fit(plots)
+
+    return writePage([p for vali in plots for p in vali], title, layout)
+
+
+# Write the given plots on a page.
+# Arguments: plots: paths of plots to be drawn on the page
+#            title: title of the plot type
+#            layout: a PageLayout object definig the layout.
+# Returns the parsed script.
+def writePage(plots, title, layout):
+    plotrows = []
+    for row in layout.pattern:
+        plotrow = []
+        for i in xrange(len(row)):
+            plotrow.append(plotTemplate.replace('[width]', str(layout.width)).\
+                           replace('[height]', str(layout.height)).\
+                           replace('[path]', plots[row[i]-1]))
+        plotrows.append('\n'.join(plotrow))
+    script = ' \\\\\n'.join(plotrows)
+
+    return frameTemplate.replace('[plots]', script).replace('[title]', title)
+
+
+# Sort key to rearrange a plot list.
+# Arguments: plot: to be sorted.
+def plotSortKey(plot):
+    # Move normchi2 before chi2Prob
+    if plot.find('normchi2') != -1:
+        return 'chi2a'
+    if plot.find('chi2Prob') != -1:
+        return 'chi2b'
+    return plot
+
+
+
+
+
+
+# Script execution.
+def main():
+    print 'Producing a .tex file from plots...'
+
+    # Get plots from given paths
+    if len(sys.argv) < 2:
+        print 'Error: Need path of plots as an argument!'
+        sys.exit(1)
+
+    validations = []
+    for plotpath in sys.argv[1:]:
+        validations.append(ValidationPlots(plotpath))
+
+    # Compose .tex frames
+    frames = ''
+    # chi2
+    frames += subsectionTemplate.replace('[title]', 'Chi^2 plots')
+    frames += writePageReg('chi2', r'$\chi^2$ plots', validations)
+    # DMRs
+    frames += writeSubsection('DmedianY*R.*plain.eps$', 'DMR', validations)
+    # Split DMRs
+    frames += writeSubsection('DmedianY*R.*split.eps$','Split DMR',validations)
+    # DRnRs:
+    frames += writeSubsection('DrmsNY*R.*plain.eps$', 'DRnR', validations)
+    # Surface Shapes
+    frames += writeSubsection('SurfaceShape', 'Surface Shape', validations)
+    # Additional plots
+    #frames += writePageReg('YourRegExp', 'PageTitle', validations)
+
+    # Write final .tex file
+    file = open('presentation.tex', 'w')
+    file.write(texTemplate.replace('[frames]', frames).\
+               replace('[time]', time.ctime()))
+    file.close()
+
+    # A script to get from .tex to .pdf
+    pdfScript = open('toPdf.sh', 'w')
+    pdfScript.write(toPdf)
+    pdfScript.close()
+    os.chmod("toPdf.sh", stat.S_IRWXU | stat.S_IRGRP | stat.S_IROTH)
+
+
+
+if __name__ == '__main__':
+    main()

--- a/Alignment/OfflineValidation/scripts/validateAlignments.py
+++ b/Alignment/OfflineValidation/scripts/validateAlignments.py
@@ -295,9 +295,11 @@ def createMergeScript( path, validations ):
     repMap["CompareAlignments"] = "#run comparisons"
     for validationId in comparisonLists:
         compareStrings = [ val.getCompareStrings(validationId) for val in comparisonLists[validationId] ]
+        compareStringsPlain = [ val.getCompareStrings(validationId, plain=True) for val in comparisonLists[validationId] ]
             
         repMap.update({"validationId": validationId,
-                       "compareStrings": " , ".join(compareStrings) })
+                       "compareStrings": " , ".join(compareStrings),
+                       "compareStringsPlain": " ".join(compareStringsPlain) })
         
         repMap["CompareAlignments"] += \
             replaceByMap(configTemplates.compareAlignmentsExecution, repMap)

--- a/Alignment/OfflineValidation/scripts/validateAlignments.py
+++ b/Alignment/OfflineValidation/scripts/validateAlignments.py
@@ -302,7 +302,8 @@ def createParallelMergeScript( path, validations ):
     repMap.update({
             "DownloadData":"",
             "CompareAlignments":"",
-            "RunExtendedOfflineValidation":""
+            "RunExtendedOfflineValidation":"",
+            "RunTrackSplitPlot":""
             })
 
     comparisonLists = {} # directory of lists containing the validations that are comparable


### PR DESCRIPTION
Partial backport of #6244 to fix cosmic track splitting and other validations.  The NavigationSchool parameter is only needed for the 7X releases, but the compareStringsPlain fix is necessary in every release where the All In One Tool is used.
