### PR TITLE
take RCT LUTs from db

### DIFF
--- a/L1Trigger/L1TCommon/python/customsPostLS1.py
+++ b/L1Trigger/L1TCommon/python/customsPostLS1.py
@@ -12,7 +12,7 @@ def customiseSimL1EmulatorForPostLS1(process):
     # the following line will break HLT if HLT menu is not updated with the corresponding menu
     process=customiseL1Menu(process)
     #print "INFO:  loading RCT LUTs"
-    process.load("L1Trigger.L1TCalorimeter.caloStage1RCTLuts_cff")
+    #process.load("L1Trigger.L1TCalorimeter.caloStage1RCTLuts_cff")
     if hasattr(process,'L1simulation_step'):
         #print "INFO:  Removing GCT from simulation and adding new Stage 1"
         process.load('L1Trigger.L1TCalorimeter.caloStage1Params_cfi')


### PR DESCRIPTION
As requested by Alca/DB, we should have RCT configs in the GT for 7_3_0.  This PR turns off the customization which takes these from local config file.
