### PR TITLE
Backport of #6429: Fix errors from using published datasets

### DIFF
--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/dataset.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/dataset.py
@@ -172,7 +172,10 @@ class Dataset:
     def __getData( self, dasQuery, dasLimit = 0 ):
         dasData = das_client.get_data( 'https://cmsweb.cern.ch',
                                        dasQuery, 0, dasLimit, False )
-        jsondict = json.loads( dasData )
+        if isinstance(dasData, str):
+            jsondict = json.loads( dasData )
+        else:
+            jsondict = dasData
         # Check, if the DAS query fails
         if jsondict["status"] != 'ok':
             msg = "Status not 'ok', but:", jsondict["status"]
@@ -183,7 +186,11 @@ class Dataset:
         dasQuery_type = ( 'dataset dataset=%s | grep dataset.datatype,'
                           'dataset.name'%( self.__name ) )
         data = self.__getData( dasQuery_type )
-        return data[0]["dataset"][0]["datatype"]
+        for a in data[0]["dataset"]:
+            if "datatype" in a:
+                return a["datatype"]
+        msg = ("Cannot find the datatype of the dataset '%s'"%( self.name() ))
+        raise AllInOneError( msg )
 
     def __getFileInfoList( self, dasLimit ):
         if self.__fileInfoList:


### PR DESCRIPTION
This pull request fixes two errors in the All In One Validation Tool's interface to DAS, which currently does not function at all, requiring an extra step in specifying the data files to use.
