### PR TITLE
Issue warnings when lazy-download is not used.

### DIFF
--- a/Utilities/StorageFactory/interface/LocalFileSystem.h
+++ b/Utilities/StorageFactory/interface/LocalFileSystem.h
@@ -16,6 +16,7 @@ public:
 
   bool		isLocalPath(const std::string &path);
   std::string	findCachePath(const std::vector<std::string> &paths, double minFreeSpace);
+  void          issueWarning();
 
 private:
   int		readFSTypes(void);
@@ -26,6 +27,7 @@ private:
 
   std::vector<FSInfo *> fs_;
   std::vector<std::string> fstypes_;
+  std::string unusable_dir_warnings_;
 
   // undefined, no semantics
   LocalFileSystem(LocalFileSystem &);

--- a/Utilities/StorageFactory/src/StorageFactory.cc
+++ b/Utilities/StorageFactory/src/StorageFactory.cc
@@ -264,14 +264,25 @@ StorageFactory::wrapNonLocalFile (Storage *s,
 				  int mode)
 {
   StorageFactory::CacheHint hint = cacheHint();
-  if (((hint == StorageFactory::CACHE_HINT_LAZY_DOWNLOAD) || (mode & IOFlags::OpenWrap))
-      && ! (mode & IOFlags::OpenWrite)
-      && ! m_tempdir.empty()
-      && (path.empty() || ! m_lfs.isLocalPath(path)))
+  if ((hint == StorageFactory::CACHE_HINT_LAZY_DOWNLOAD) || (mode & IOFlags::OpenWrap))
   {
-    if (accounting())
-      s = new StorageAccountProxy(proto, s);
-    s = new LocalCacheFile(s, m_tempdir);
+      if (mode & IOFlags::OpenWrite)
+      {
+        // For now, issue no warning - otherwise, we'd always warn on output files.
+      }
+      else if (m_tempdir.empty())
+      {
+        m_lfs.issueWarning();
+      }
+      else if (path.empty() || m_lfs.isLocalPath(path))
+      {
+        // For now, issue no warning - otherwise, we'd always warn on local input files.
+      }
+      else
+      {
+        if (accounting()) {s = new StorageAccountProxy(proto, s);}
+        s = new LocalCacheFile(s, m_tempdir);
+      }
   }
 
   return s;


### PR DESCRIPTION
Previously, when lazy-download was not used because:
- The cache directory was not writable,
- The cache filesystem was too small, OR
- The cache filesystem was thought to be on a remote filesystem,
  then lazy-download was turned off without warning.

This made debugging issues difficult - especially as turning off
lazy-download can cause merges to go many times slower.  Whether lazy-download
is used is logged in the FrameworkJobReport - but often it takes an expert to decode
those!

We now issue a reasonably-worded warning when this happens.
