### PR TITLE
Avoid an infinite loop in InitRootHandlers destructor

### DIFF
--- a/FWCore/Services/src/InitRootHandlers.cc
+++ b/FWCore/Services/src/InitRootHandlers.cc
@@ -294,12 +294,16 @@ namespace edm {
 
     InitRootHandlers::~InitRootHandlers () {
       // close all open ROOT files
-      // We get a new iterator each time,
-      // because closing a file can invalidate the iterator
-      while(gROOT->GetListOfFiles()->GetSize()) {
-        TIter iter(gROOT->GetListOfFiles());
-        TFile* f = dynamic_cast<TFile*>(iter.Next());
-        if(f) f->Close();
+      TIter iter(gROOT->GetListOfFiles());
+      TObject *obj = nullptr;
+      while(nullptr != (obj = iter.Next())) {
+        TFile* f = dynamic_cast<TFile*>(obj);
+        if(f) {
+          // We get a new iterator each time,
+          // because closing a file can invalidate the iterator
+          f->Close();
+          iter = TIter(gROOT->GetListOfFiles());
+        }
       }
     }
     


### PR DESCRIPTION
If there is a problem with the list of open files from ROOT such that casting an element to TFile fails the code no longer gets stuck in an infinite loop.
The problem actually happened in the Tier 0 probably due to a threading problem in ROOT.

This is a backport of #6213 
