### PR TITLE
Provide the ability to do a separate cache-hint for cloning.

### DIFF
--- a/FWCore/Catalog/interface/SiteLocalConfig.h
+++ b/FWCore/Catalog/interface/SiteLocalConfig.h
@@ -32,6 +32,7 @@ namespace edm {
     virtual std::string const* sourceCacheTempDir() const = 0;
     virtual double const* sourceCacheMinFree() const = 0;
     virtual std::string const* sourceCacheHint() const = 0;
+    virtual std::string const* sourceCloneCacheHint() const = 0;
     virtual std::string const* sourceReadHint() const = 0;
     virtual unsigned int const* sourceTTreeCacheSize() const = 0;
     virtual unsigned int const* sourceTimeout() const = 0;

--- a/FWCore/Services/src/SiteLocalConfigService.cc
+++ b/FWCore/Services/src/SiteLocalConfigService.cc
@@ -118,6 +118,8 @@ namespace edm {
           m_cacheMinFreePtr(nullptr),
           m_cacheHint(),
           m_cacheHintPtr(nullptr),
+          m_cloneCacheHint(),
+          m_cloneCacheHintPtr(nullptr),
           m_readHint(),
           m_readHintPtr(nullptr),
           m_ttreeCacheSize(0U),
@@ -145,6 +147,7 @@ namespace edm {
         overrideFromPSet("overrideSourceCacheTempDir", pset, m_cacheTempDir, m_cacheTempDirPtr);
         overrideFromPSet("overrideSourceCacheMinFree", pset, m_cacheMinFree, m_cacheMinFreePtr);
         overrideFromPSet("overrideSourceCacheHintDir", pset, m_cacheHint, m_cacheHintPtr);
+        overrideFromPSet("overrideSourceCloneCacheHintDir", pset, m_cloneCacheHint, m_cloneCacheHintPtr);
         overrideFromPSet("overrideSourceReadHint", pset, m_readHint, m_readHintPtr);
         overrideFromPSet("overrideSourceNativeProtocols", pset, m_nativeProtocols, m_nativeProtocolsPtr);
         overrideFromPSet("overrideSourceTTreeCacheSize", pset, m_ttreeCacheSize, m_ttreeCacheSizePtr);
@@ -285,6 +288,11 @@ namespace edm {
     std::string const*
     SiteLocalConfigService::sourceCacheHint() const {
        return m_cacheHintPtr;
+    }
+
+    std::string const*
+    SiteLocalConfigService::sourceCloneCacheHint() const {
+       return m_cloneCacheHintPtr;
     }
 
     std::string const*
@@ -448,6 +456,14 @@ namespace edm {
                 m_cacheHintPtr = &m_cacheHint;
               }
 
+              DOMNodeList *cloneCacheHintList = sourceConfig->getElementsByTagName(_toDOMS("clone-cache-hint"));
+
+              if (cloneCacheHintList->getLength() > 0) {
+                DOMElement *cloneCacheHint = static_cast<DOMElement *>(cloneCacheHintList->item(0));
+                m_cloneCacheHint = _toString(cloneCacheHint->getAttribute(_toDOMS("value")));
+                m_cloneCacheHintPtr = &m_cloneCacheHint;
+              }
+
               DOMNodeList *readHintList = sourceConfig->getElementsByTagName(_toDOMS("read-hint"));
 
               if (readHintList->getLength() > 0) {
@@ -542,6 +558,8 @@ namespace edm {
       desc.addOptionalUntracked<std::string>("overrideSourceCacheTempDir");
       desc.addOptionalUntracked<double>("overrideSourceCacheMinFree");
       desc.addOptionalUntracked<std::string>("overrideSourceCacheHintDir");
+      desc.addOptionalUntracked<std::string>("overrideSourceCloneCacheHintDir")
+        ->setComment("Provide an alternate cache hint for fast cloning.");
       desc.addOptionalUntracked<std::string>("overrideSourceReadHint");
       desc.addOptionalUntracked<std::vector<std::string> >("overrideSourceNativeProtocols");
       desc.addOptionalUntracked<unsigned int>("overrideSourceTTreeCacheSize");

--- a/FWCore/Services/src/SiteLocalConfigService.h
+++ b/FWCore/Services/src/SiteLocalConfigService.h
@@ -32,6 +32,7 @@ namespace edm {
             std::string const* sourceCacheTempDir() const;
             double const* sourceCacheMinFree() const;
             std::string const* sourceCacheHint() const;
+            std::string const* sourceCloneCacheHint() const override;
             std::string const* sourceReadHint() const;
             unsigned int const* sourceTTreeCacheSize() const;
             unsigned int const* sourceTimeout() const;
@@ -63,6 +64,8 @@ namespace edm {
             double const*       m_cacheMinFreePtr;
             std::string         m_cacheHint;
             std::string const*  m_cacheHintPtr;
+            std::string         m_cloneCacheHint;
+            std::string const*  m_cloneCacheHintPtr;
             std::string         m_readHint;
             std::string const*  m_readHintPtr;
             unsigned int        m_ttreeCacheSize;

--- a/IOPool/Output/src/RootOutputTree.cc
+++ b/IOPool/Output/src/RootOutputTree.cc
@@ -9,6 +9,8 @@
 #include "FWCore/Utilities/interface/Algorithms.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Utilities/interface/RootHandlers.h"
+#include "FWCore/Catalog/interface/SiteLocalConfig.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
 
 #include "TBranch.h"
 #include "TBranchElement.h"
@@ -21,6 +23,66 @@
 #include <limits>
 
 namespace edm {
+
+    /**
+     * Currently, ROOT doesn't use any latency-hiding optimizations for
+     * fast-cloning.  This causes a significant slowdown when doing fast-cloning
+     * over a high-latency network (30ms latency makes this multiple factors slower).
+     *
+     * Accordingly, we allow sites to provide a separate hint on how to treat fast-
+     * cloning.  The DuplicateTreeSentry allows us to implement it - given a tree
+     * we are about to clone, with the appropriate configs, this will re-open the
+     * file with lazy-download and re-open the tree.  The new tree is appropriate
+     * for cloning.  When the object is destroyed, the new file and tree are cleaned up.
+     *
+     */
+    class DuplicateTreeSentry
+    {
+    public:
+        DuplicateTreeSentry(TTree * tree)
+          : tree_(tree)
+        {
+            dup();
+        }
+
+        TTree *tree() const {return mytree_ ? mytree_.get() : tree_;}
+
+    private:
+        DuplicateTreeSentry(DuplicateTreeSentry const&) = delete; // Disallow copying and moving
+        DuplicateTreeSentry& operator=(DuplicateTreeSentry const&) = delete;
+        struct CloseBeforeDelete { void operator()(TFile* iFile) const { if( iFile) { iFile->Close(); } delete iFile; } };
+
+        void dup()
+        {
+            edm::Service<edm::SiteLocalConfig> pSLC;
+            if (!pSLC.isAvailable()) {return;}
+            if (pSLC->sourceCacheHint() && *(pSLC->sourceCacheHint()) == "lazy-download") {return;}
+            if (!pSLC->sourceCloneCacheHint() || *(pSLC->sourceCloneCacheHint()) != "lazy-download") {return;}
+            edm::LogWarning("DuplicateTreeSentry") << "Re-opening file for fast-cloning";
+
+            TFile *file = tree_->GetCurrentFile();
+            const TUrl *url = file->GetEndpointUrl();
+            if (!url)
+            {
+                return;
+            }
+            file_.reset(TFile::Open(url->GetUrl(), "READWRAP")); // May throw an exception.
+            if (!file_)
+            {
+                return;
+            }
+            mytree_.reset(dynamic_cast<TTree*>(file_->Get(tree_->GetName())));
+            if (!mytree_) {return;}
+        }
+
+        /**
+         * Note this relies on the implicit delete ordering - mytree_ (if non-null)
+         * must be deleted before file_.  Do not reorder the class members!
+         */
+        std::unique_ptr<TFile, CloseBeforeDelete> file_;
+        TTree *tree_ = nullptr;
+        std::unique_ptr<TTree> mytree_ = nullptr;
+    };
 
     RootOutputTree::RootOutputTree(
                    std::shared_ptr<TFile> filePtr,
@@ -179,7 +241,8 @@ namespace edm {
         branches->Compress();
       }
 
-      TTreeCloner cloner(in, tree_, option.c_str(), TTreeCloner::kNoWarnings|TTreeCloner::kIgnoreMissingTopLevel);
+      DuplicateTreeSentry dupTree(in);
+      TTreeCloner cloner(dupTree.tree(), tree_, option.c_str(), TTreeCloner::kNoWarnings|TTreeCloner::kIgnoreMissingTopLevel);
 
       if(!cloner.IsValid()) {
         // Let's check why
@@ -194,6 +257,7 @@ namespace edm {
       tree_->SetEntries(tree_->GetEntries() + in->GetEntries());
       Service<RootHandlers> rootHandler;
       rootHandler->ignoreWarningsWhileDoing([&cloner] { cloner.Exec(); });
+
       if(mustRemoveSomeAuxs) {
         for(std::map<Int_t, TBranch *>::const_iterator it = auxIndexes.begin(), itEnd = auxIndexes.end();
              it != itEnd; ++it) {

--- a/IOPool/TFileAdaptor/src/TStorageFactoryFile.cc
+++ b/IOPool/TFileAdaptor/src/TStorageFactoryFile.cc
@@ -147,7 +147,8 @@ TStorageFactoryFile::Initialize(const char *path,
   Bool_t create   = (fOption == "CREATE");
   Bool_t recreate = (fOption == "RECREATE");
   Bool_t update   = (fOption == "UPDATE");
-  Bool_t read     = (fOption == "READ");
+  Bool_t read     = (fOption == "READ") || (fOption == "READWRAP");
+  Bool_t readwrap = (fOption == "READWRAP");
 
   if (!create && !recreate && !update && !read)
   {
@@ -178,6 +179,7 @@ TStorageFactoryFile::Initialize(const char *path,
   if (!read)    openFlags |= IOFlags::OpenWrite;
   if (create)   openFlags |= IOFlags::OpenCreate;
   //if (recreate) openFlags |= IOFlags::OpenCreate | IOFlags::OpenTruncate;
+  if (readwrap) openFlags |= IOFlags::OpenWrap;
 
   // Open storage
   if (! (storage_ = StorageFactory::get()->open(path, openFlags)))

--- a/Utilities/StorageFactory/interface/IOFlags.h
+++ b/Utilities/StorageFactory/interface/IOFlags.h
@@ -29,11 +29,13 @@ namespace IOFlags
 				    file exists.  */
     OpenTruncate	= 128,	/*< If the file exists, truncate it to
 				    zero size.  */
-    OpenNotCTTY		= 256	/*< If the specified file is a
+    OpenNotCTTY		= 256,	/*< If the specified file is a
 				    terminal device, do not make it
 				    the controlling terminal for the
 				    process even if the process does
 				    not have one yet.  */
+    OpenWrap		= 512	/*< Wrap the file if at all possible
+				    with a local file.  */
   };
 } // namespace IOFlags
 

--- a/Utilities/StorageFactory/src/StorageFactory.cc
+++ b/Utilities/StorageFactory/src/StorageFactory.cc
@@ -260,7 +260,7 @@ StorageFactory::wrapNonLocalFile (Storage *s,
 				  int mode)
 {
   StorageFactory::CacheHint hint = cacheHint();
-  if ((hint == StorageFactory::CACHE_HINT_LAZY_DOWNLOAD)
+  if (((hint == StorageFactory::CACHE_HINT_LAZY_DOWNLOAD) || (mode & IOFlags::OpenWrap))
       && ! (mode & IOFlags::OpenWrite)
       && ! m_tempdir.empty()
       && (path.empty() || ! m_lfs.isLocalPath(path)))


### PR DESCRIPTION
Cloning is one of the very problematic places for high-latency IO
as it reads baskets one-at-a-time.  Hence, it makes a lot of sense
to use lazy-download for this case.  _However_, it may not be
desirable to enable lazy-download for all workflows!  Nor may it
be desirable for the workflow layers to enable lazy-download for
all merges (as some sites don't have the disk space).

This patch allows us to selectively turn on lazy-download only for
merge jobs at a given site by editing site-local-config.xml.

This commit is a cherry-pick of the b19f156f954152ff741226a3c2600fade3e95397 in 7_3_X.
