### PR TITLE
removing spurious error message from GsfElectron::ecalDriven()

### DIFF
--- a/DataFormats/EgammaCandidates/src/GsfElectron.cc
+++ b/DataFormats/EgammaCandidates/src/GsfElectron.cc
@@ -173,12 +173,6 @@ GsfElectron * GsfElectron::clone
 
 bool GsfElectron::ecalDriven() const
  {
-  if (!passingCutBasedPreselection()&&!passingMvaPreselection())
-   {
-    edm::LogWarning("GsfElectronAlgo|UndefinedPreselectionInfo")
-      <<"All preselection flags are false,"
-      <<" either the data is too old or electrons were not preselected." ;
-   }
   return (ecalDrivenSeed()&&passingCutBasedPreselection()) ;
  }
 


### PR DESCRIPTION
The flags passPflowPreselection_ and passMvaPreslection_ [sic] are not being filled in 7X. This creates a spurious error message in GsfElectron::ecalDriven() which does a sanity check on whether any preselection was passed. As passMvaPreslection_ is always false, this fails when the electron does not pass the cut based preselection and this causes the error message to print out. The message is harmless, the function returns exactly the correct value, it just alerted us to this issue. We will shortly port the same fix to 72X.

In 73X or 74X, we will actually fill the flags although on closer inspection passPflowPreselection_ is fully redundant with mvaOutput.status. In theory passMvaPreslection_ is also redundant as you have the mva variables used to cut on but this cut value could change in time so its probably worth keeping it around to avoid accidents. We will not port this to 72X unless requested as the samples have been produced and therefore this will have no effect.
