### PR TITLE
removing spurious error message from GsfElectron::ecalDriven()  72X

### DIFF
--- a/DataFormats/EgammaCandidates/src/GsfElectron.cc
+++ b/DataFormats/EgammaCandidates/src/GsfElectron.cc
@@ -171,12 +171,6 @@ GsfElectron * GsfElectron::clone
 
 bool GsfElectron::ecalDriven() const
  {
-  if (!passingCutBasedPreselection()&&!passingMvaPreselection())
-   {
-    edm::LogWarning("GsfElectronAlgo|UndefinedPreselectionInfo")
-      <<"All preselection flags are false,"
-      <<" either the data is too old or electrons were not preselected." ;
-   }
   return (ecalDrivenSeed()&&passingCutBasedPreselection()) ;
  }
 


### PR DESCRIPTION
This is the 72X edition of https://github.com/cms-sw/cmssw/pull/6479 which removes a spurious error message from GsfElectron::ecalDriven() that no longer makes sense given which flags are currently filled in 7X. It has no other effect on the results of the function.
