### PR TITLE
Changes in the CondFormat (Only) necessary for migration to 6x6 APE 

### DIFF
--- a/CondCore/AlignmentPlugins/src/plugin.cc
+++ b/CondCore/AlignmentPlugins/src/plugin.cc
@@ -1,14 +1,15 @@
 /*
- *  plugin.cc
- *  CMSSW
- *
- *  Created by Frederic Ronga on June 7, 2006
- *
- */
+*  plugin.cc
+*  CMSSW
+*
+*  Created by Frederic Ronga on June 7, 2006
+*
+*/
 
 #include "CondCore/ESSources/interface/registration_macros.h"
 #include "CondFormats/Alignment/interface/Alignments.h"
 #include "CondFormats/Alignment/interface/AlignmentErrors.h"
+#include "CondFormats/Alignment/interface/AlignmentErrorsExtended.h"
 #include "CondFormats/Alignment/interface/AlignmentSurfaceDeformations.h"
 #include "CondFormats/Alignment/interface/SurveyErrors.h"
 #include "CondFormats/AlignmentRecord/interface/GlobalPositionRcd.h"
@@ -43,9 +44,20 @@
 #include "CondFormats/AlignmentRecord/interface/ZDCAlignmentRcd.h"
 #include "CondFormats/AlignmentRecord/interface/ZDCAlignmentErrorRcd.h"
 
+#include "CondFormats/AlignmentRecord/interface/TrackerAlignmentErrorExtendedRcd.h"
+#include "CondFormats/AlignmentRecord/interface/DTAlignmentErrorExtendedRcd.h"
+#include "CondFormats/AlignmentRecord/interface/CSCAlignmentErrorExtendedRcd.h"
+#include "CondFormats/AlignmentRecord/interface/EBAlignmentErrorExtendedRcd.h"
+#include "CondFormats/AlignmentRecord/interface/EEAlignmentErrorExtendedRcd.h"
+#include "CondFormats/AlignmentRecord/interface/ESAlignmentErrorExtendedRcd.h"
+#include "CondFormats/AlignmentRecord/interface/HBAlignmentErrorExtendedRcd.h"
+#include "CondFormats/AlignmentRecord/interface/HEAlignmentErrorExtendedRcd.h"
+#include "CondFormats/AlignmentRecord/interface/HOAlignmentErrorExtendedRcd.h"
+#include "CondFormats/AlignmentRecord/interface/HFAlignmentErrorExtendedRcd.h"
+#include "CondFormats/AlignmentRecord/interface/ZDCAlignmentErrorExtendedRcd.h"
+
 REGISTER_PLUGIN(GlobalPositionRcd,Alignments);
 REGISTER_PLUGIN(TrackerAlignmentRcd,Alignments);
-REGISTER_PLUGIN(TrackerAlignmentErrorRcd,AlignmentErrors);
 REGISTER_PLUGIN(TrackerSurfaceDeformationRcd,AlignmentSurfaceDeformations);
 REGISTER_PLUGIN(DTAlignmentRcd,Alignments);
 REGISTER_PLUGIN(DTAlignmentErrorRcd,AlignmentErrors);
@@ -74,3 +86,14 @@ REGISTER_PLUGIN(HFAlignmentRcd,Alignments);
 REGISTER_PLUGIN(HFAlignmentErrorRcd,AlignmentErrors);
 REGISTER_PLUGIN(ZDCAlignmentRcd,Alignments);
 REGISTER_PLUGIN(ZDCAlignmentErrorRcd,AlignmentErrors);
+REGISTER_PLUGIN(TrackerAlignmentErrorExtendedRcd,AlignmentErrorsExtended);
+REGISTER_PLUGIN(DTAlignmentErrorExtendedRcd,AlignmentErrorsExtended);
+REGISTER_PLUGIN(CSCAlignmentErrorExtendedRcd,AlignmentErrorsExtended);
+REGISTER_PLUGIN(EBAlignmentErrorExtendedRcd,AlignmentErrorsExtended);
+REGISTER_PLUGIN(EEAlignmentErrorExtendedRcd,AlignmentErrorsExtended);
+REGISTER_PLUGIN(ESAlignmentErrorExtendedRcd,AlignmentErrorsExtended);
+REGISTER_PLUGIN(HBAlignmentErrorExtendedRcd,AlignmentErrorsExtended);
+REGISTER_PLUGIN(HEAlignmentErrorExtendedRcd,AlignmentErrorsExtended);
+REGISTER_PLUGIN(HOAlignmentErrorExtendedRcd,AlignmentErrorsExtended);
+REGISTER_PLUGIN(HFAlignmentErrorExtendedRcd,AlignmentErrorsExtended);
+REGISTER_PLUGIN(ZDCAlignmentErrorExtendedRcd,AlignmentErrorsExtended);

--- a/CondFormats/Alignment/doc/Alignment.doc
+++ b/CondFormats/Alignment/doc/Alignment.doc
@@ -22,7 +22,7 @@
 
 - AlignTransform
 - AlignTransformError
-- AlignmentErrors
+- AlignmentErrorsExtended
 - AlignmentSorter
 - AlignmentSurfaceDeformations
 - Alignments

--- a/CondFormats/Alignment/interface/AlignTransformErrorExtended.h
+++ b/CondFormats/Alignment/interface/AlignTransformErrorExtended.h
@@ -1,0 +1,49 @@
+#ifndef AlignTransformErrorExtended_H
+#define AlignTransformErrorExtended_H
+#include "CondFormats/Serialization/interface/Serializable.h"
+
+#include "CLHEP/Matrix/SymMatrix.h"
+#include "CLHEP/Vector/RotationInterfaces.h"
+
+#include "CondFormats/Alignment/interface/Definitions.h"
+
+/// Class holding error due to an Alignment transformation
+/// It contains the raw detector id and the symmetrical error matrix.
+/// It is optimized for storage (error matrix is stored as C-array)
+class  AlignTransformErrorExtended {
+public:
+  typedef CLHEP::HepSymMatrix SymMatrix;
+
+
+  AlignTransformErrorExtended(){ }
+  AlignTransformErrorExtended( const SymMatrix & symMatrix,
+		       align::ID irawId ) :
+    m_rawId(irawId) 
+  { 
+    for ( unsigned int i=0; i<m_nPars; ++i )
+      for ( unsigned int j=0; j<=i; ++j )
+        m_Parameters[i*(i+1)/2+j] = symMatrix[i][j];
+  }
+  
+  SymMatrix matrix() const { 
+    SymMatrix result(m_nPars);
+    for ( unsigned int i=0; i<m_nPars; ++i )
+      for ( unsigned int j=0; j<=i; ++j )
+        result[i][j] = m_Parameters[i*(i+1)/2+j];
+    return result;
+  }
+
+  align::ID rawId()  const { return m_rawId; }
+
+private:
+
+  //FIXME difference here 
+  static const unsigned int m_nPars = 6;
+  double m_Parameters[m_nPars*(m_nPars+1)/2];
+  align::ID m_rawId;
+
+
+
+  COND_SERIALIZABLE;
+};
+#endif //AlignTransformErrorExtended_H

--- a/CondFormats/Alignment/interface/AlignmentErrorsExtended.h
+++ b/CondFormats/Alignment/interface/AlignmentErrorsExtended.h
@@ -1,0 +1,23 @@
+#ifndef CondFormats_Alignment_AlignmentErrorsExtended_H
+#define CondFormats_Alignment_AlignmentErrorsExtended_H
+
+#include "CondFormats/Serialization/interface/Serializable.h"
+
+#include "CondFormats/Alignment/interface/AlignTransformErrorExtended.h"
+
+#include<vector>
+
+class AlignmentErrorsExtended {
+public:
+  AlignmentErrorsExtended(){}
+  virtual ~AlignmentErrorsExtended(){}
+  /// Test of empty vector without having to look into internals:
+  inline bool empty() const { return m_alignError.empty();}
+  /// Clear vector without having to look into internals:
+  inline void clear() {m_alignError.clear();}
+
+  std::vector<AlignTransformErrorExtended> m_alignError;
+
+  COND_SERIALIZABLE;
+};
+#endif // AlignmentErrorsExtended_H

--- a/CondFormats/Alignment/interface/AlignmentSorter.h
+++ b/CondFormats/Alignment/interface/AlignmentSorter.h
@@ -2,7 +2,7 @@
 #define __CondFormats_Alignment_AlignmentSorter_h
 
 ///
-/// A struct to sort Alignments and AlignmentErrors by increasing DetId
+/// A struct to sort Alignments and AlignmentErrorsExtended by increasing DetId
 ///
 /// To sort Alignments, do something like: 
 /// std::sort( alignments->m_align.begin(), alignments->m_align.end(), 

--- a/CondFormats/Alignment/src/T_EventSetup_AlignmentErrorExtended.cc
+++ b/CondFormats/Alignment/src/T_EventSetup_AlignmentErrorExtended.cc
@@ -1,0 +1,19 @@
+// -*- C++ -*-
+//
+// Package:     Alignment
+// 
+// Implementation:
+//     create all the 'infrastructure' needed to get into the Context
+//
+// Author:      Frederic Ronga
+// Created:     Wed Jun  7 09:20:28 CEST 2006
+//
+
+// system include files
+
+// user include files
+#include "CondFormats/Alignment/interface/AlignmentErrorsExtended.h"
+#include "FWCore/Utilities/interface/typelookup.h"
+
+//using Alignments;
+TYPELOOKUP_DATA_REG(AlignmentErrorsExtended);

--- a/CondFormats/Alignment/src/classes.h
+++ b/CondFormats/Alignment/src/classes.h
@@ -1,5 +1,6 @@
 #include "CondFormats/Alignment/interface/Alignments.h"
 #include "CondFormats/Alignment/interface/AlignmentErrors.h"
+#include "CondFormats/Alignment/interface/AlignmentErrorsExtended.h"
 #include "CondFormats/Alignment/interface/SurveyErrors.h"
 #include "CondFormats/Alignment/interface/AlignmentSurfaceDeformations.h"
 

--- a/CondFormats/Alignment/src/classes_def.xml
+++ b/CondFormats/Alignment/src/classes_def.xml
@@ -5,8 +5,11 @@
  <class name="uint32_t"/>
 
  <class name="AlignmentErrors"/>
+ <class name="AlignmentErrorsExtended"/>
  <class name="AlignTransformError"/>
  <class name="std::vector<AlignTransformError>"/>
+ <class name="AlignTransformErrorExtended"/>
+ <class name="std::vector<AlignTransformErrorExtended>"/>
 
  <class name="AlignmentSurfaceDeformations">
    <field name="m_items" mapping="blob"/>

--- a/CondFormats/Alignment/src/headers.h
+++ b/CondFormats/Alignment/src/headers.h
@@ -1,5 +1,6 @@
 #include "CondFormats/Alignment/interface/Alignments.h"
 #include "CondFormats/Alignment/interface/AlignmentErrors.h"
+#include "CondFormats/Alignment/interface/AlignmentErrorsExtended.h"
 #include "CondFormats/Alignment/interface/SurveyErrors.h"
 #include "CondFormats/Alignment/interface/AlignmentSurfaceDeformations.h"
 

--- a/CondFormats/Alignment/test/testSerializationAlignment.cpp
+++ b/CondFormats/Alignment/test/testSerializationAlignment.cpp
@@ -6,7 +6,9 @@ int main()
 {
     testSerialization<AlignTransform>();
     testSerialization<AlignTransformError>();
+    testSerialization<AlignTransformErrorExtended>();
     testSerialization<AlignmentErrors>();
+    testSerialization<AlignmentErrorsExtended>();
     testSerialization<AlignmentSurfaceDeformations>();
     testSerialization<AlignmentSurfaceDeformations::Item>();
     testSerialization<Alignments>();
@@ -14,6 +16,7 @@ int main()
     testSerialization<SurveyErrors>();
     testSerialization<std::vector<AlignTransform>>();
     testSerialization<std::vector<AlignTransformError>>();
+    testSerialization<std::vector<AlignTransformErrorExtended>>();
     testSerialization<std::vector<AlignmentSurfaceDeformations::Item>>();
     testSerialization<std::vector<SurveyError>>();
     testSerialization<uint32_t>();

--- a/CondFormats/AlignmentRecord/interface/CSCAlignmentErrorExtendedRcd.h
+++ b/CondFormats/AlignmentRecord/interface/CSCAlignmentErrorExtendedRcd.h
@@ -1,0 +1,8 @@
+#ifndef CSCALIGNMENTERROREXTENDEDRCD_H
+#define CSCALIGNMENTERROREXTENDEDRCD_H
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+
+class CSCAlignmentErrorExtendedRcd : public edm::eventsetup::EventSetupRecordImplementation<CSCAlignmentErrorExtendedRcd> {};
+
+#endif

--- a/CondFormats/AlignmentRecord/interface/CSCSurveyErrorExtendedRcd.h
+++ b/CondFormats/AlignmentRecord/interface/CSCSurveyErrorExtendedRcd.h
@@ -1,0 +1,20 @@
+#ifndef CondFormats_AlignmentRecord_CSCSurveyErrorExtendedRcd_H
+#define CondFormats_AlignmentRecord_CSCSurveyErrorExtendedRcd_H
+
+/** \class CSCSurveyErrorExtendedRcd
+ *
+ *  DB record to hold errors of alignment parameters from survey.
+ *
+ *  $Date: 2007/07/06 16:01:02 $
+ *  $Revision: 1.1 $
+ *  \author Jim Pivarski
+ */
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+
+class CSCSurveyErrorExtendedRcd:
+  public edm::eventsetup::EventSetupRecordImplementation<CSCSurveyErrorExtendedRcd>
+{
+};
+
+#endif

--- a/CondFormats/AlignmentRecord/interface/CaloTowerAlignmentErrorExtendedRcd.h
+++ b/CondFormats/AlignmentRecord/interface/CaloTowerAlignmentErrorExtendedRcd.h
@@ -1,0 +1,8 @@
+#ifndef CALOTOWERALIGNMENTERROREXTENDEDRCD_H
+#define CALOTOWERALIGNMENTERROREXTENDEDRCD_H
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+
+class CaloTowerAlignmentErrorExtendedRcd : public edm::eventsetup::EventSetupRecordImplementation<CaloTowerAlignmentErrorExtendedRcd> {};
+
+#endif

--- a/CondFormats/AlignmentRecord/interface/CastorAlignmentErrorExtendedRcd.h
+++ b/CondFormats/AlignmentRecord/interface/CastorAlignmentErrorExtendedRcd.h
@@ -1,0 +1,8 @@
+#ifndef CASTORALIGNMENTERROREXTENDEDRCD_H
+#define CASTORALIGNMENTERROREXTENDEDRCD_H
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+
+class CastorAlignmentErrorExtendedRcd : public edm::eventsetup::EventSetupRecordImplementation<CastorAlignmentErrorExtendedRcd> {};
+
+#endif

--- a/CondFormats/AlignmentRecord/interface/DTAlignmentErrorExtendedRcd.h
+++ b/CondFormats/AlignmentRecord/interface/DTAlignmentErrorExtendedRcd.h
@@ -1,0 +1,8 @@
+#ifndef DTALIGNMENTERROREXTENDEDRCD_H
+#define DTALIGNMENTERROREXTENDEDRCD_H
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+
+class DTAlignmentErrorExtendedRcd : public edm::eventsetup::EventSetupRecordImplementation<DTAlignmentErrorExtendedRcd> {};
+
+#endif

--- a/CondFormats/AlignmentRecord/interface/DTSurveyErrorExtendedRcd.h
+++ b/CondFormats/AlignmentRecord/interface/DTSurveyErrorExtendedRcd.h
@@ -1,0 +1,20 @@
+#ifndef CondFormats_AlignmentRecord_DTSurveyErrorExtendedRcd_H
+#define CondFormats_AlignmentRecord_DTSurveyErrorExtendedRcd_H
+
+/** \class DTSurveyErrorExtendedRcd
+ *
+ *  DB record to hold errors of alignment parameters from survey.
+ *
+ *  $Date: 2007/07/06 16:01:02 $
+ *  $Revision: 1.1 $
+ *  \author Jim Pivarski
+ */
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+
+class DTSurveyErrorExtendedRcd:
+  public edm::eventsetup::EventSetupRecordImplementation<DTSurveyErrorExtendedRcd>
+{
+};
+
+#endif

--- a/CondFormats/AlignmentRecord/interface/EBAlignmentErrorExtendedRcd.h
+++ b/CondFormats/AlignmentRecord/interface/EBAlignmentErrorExtendedRcd.h
@@ -1,0 +1,8 @@
+#ifndef EBALIGNMENTERROREXTENDEDRCD_H
+#define EBALIGNMENTERROREXTENDEDRCD_H
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+
+class EBAlignmentErrorExtendedRcd : public edm::eventsetup::EventSetupRecordImplementation<EBAlignmentErrorExtendedRcd> {};
+
+#endif

--- a/CondFormats/AlignmentRecord/interface/EEAlignmentErrorExtendedRcd.h
+++ b/CondFormats/AlignmentRecord/interface/EEAlignmentErrorExtendedRcd.h
@@ -1,0 +1,8 @@
+#ifndef EEALIGNMENTERROREXTENDEDRCD_H
+#define EEALIGNMENTERROREXTENDEDRCD_H
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+
+class EEAlignmentErrorExtendedRcd : public edm::eventsetup::EventSetupRecordImplementation<EEAlignmentErrorExtendedRcd> {};
+
+#endif

--- a/CondFormats/AlignmentRecord/interface/ESAlignmentErrorExtendedRcd.h
+++ b/CondFormats/AlignmentRecord/interface/ESAlignmentErrorExtendedRcd.h
@@ -1,0 +1,8 @@
+#ifndef ESALIGNMENTERROREXTENDEDRCD_H
+#define ESALIGNMENTERROREXTENDEDRCD_H
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+
+class ESAlignmentErrorExtendedRcd : public edm::eventsetup::EventSetupRecordImplementation<ESAlignmentErrorExtendedRcd> {};
+
+#endif

--- a/CondFormats/AlignmentRecord/interface/EcalAlignmentErrorExtendedRcd.h
+++ b/CondFormats/AlignmentRecord/interface/EcalAlignmentErrorExtendedRcd.h
@@ -1,0 +1,8 @@
+#ifndef ECALALIGNMENTERROREXTENDEDRCD_H
+#define ECALALIGNMENTERROREXTENDEDRCD_H
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+
+class EcalAlignmentErrorExtendedRcd : public edm::eventsetup::EventSetupRecordImplementation<EcalAlignmentErrorExtendedRcd> {};
+
+#endif

--- a/CondFormats/AlignmentRecord/interface/HBAlignmentErrorExtendedRcd.h
+++ b/CondFormats/AlignmentRecord/interface/HBAlignmentErrorExtendedRcd.h
@@ -1,0 +1,8 @@
+#ifndef HBALIGNMENTERROREXTENDEDRCD_H
+#define HBALIGNMENTERROREXTENDEDRCD_H
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+
+class HBAlignmentErrorExtendedRcd : public edm::eventsetup::EventSetupRecordImplementation<HBAlignmentErrorExtendedRcd> {};
+
+#endif

--- a/CondFormats/AlignmentRecord/interface/HEAlignmentErrorExtendedRcd.h
+++ b/CondFormats/AlignmentRecord/interface/HEAlignmentErrorExtendedRcd.h
@@ -1,0 +1,8 @@
+#ifndef HEALIGNMENTERROREXTENDEDRCD_H
+#define HEALIGNMENTERROREXTENDEDRCD_H
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+
+class HEAlignmentErrorExtendedRcd : public edm::eventsetup::EventSetupRecordImplementation<HEAlignmentErrorExtendedRcd> {};
+
+#endif

--- a/CondFormats/AlignmentRecord/interface/HFAlignmentErrorExtendedRcd.h
+++ b/CondFormats/AlignmentRecord/interface/HFAlignmentErrorExtendedRcd.h
@@ -1,0 +1,8 @@
+#ifndef HFALIGNMENTERROREXTENDEDRCD_H
+#define HFALIGNMENTERROREXTENDEDRCD_H
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+
+class HFAlignmentErrorExtendedRcd : public edm::eventsetup::EventSetupRecordImplementation<HFAlignmentErrorExtendedRcd> {};
+
+#endif

--- a/CondFormats/AlignmentRecord/interface/HOAlignmentErrorExtendedRcd.h
+++ b/CondFormats/AlignmentRecord/interface/HOAlignmentErrorExtendedRcd.h
@@ -1,0 +1,8 @@
+#ifndef HOALIGNMENTERROREXTENDEDRCD_H
+#define HOALIGNMENTERROREXTENDEDRCD_H
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+
+class HOAlignmentErrorExtendedRcd : public edm::eventsetup::EventSetupRecordImplementation<HOAlignmentErrorExtendedRcd> {};
+
+#endif

--- a/CondFormats/AlignmentRecord/interface/HcalAlignmentErrorExtendedRcd.h
+++ b/CondFormats/AlignmentRecord/interface/HcalAlignmentErrorExtendedRcd.h
@@ -1,0 +1,8 @@
+#ifndef HCALALIGNMENTERROREXTENDEDRCD_H
+#define HCALALIGNMENTERROREXTENDEDRCD_H
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+
+class HcalAlignmentErrorExtendedRcd : public edm::eventsetup::EventSetupRecordImplementation<HcalAlignmentErrorExtendedRcd> {};
+
+#endif

--- a/CondFormats/AlignmentRecord/interface/TrackerAlignmentErrorExtendedRcd.h
+++ b/CondFormats/AlignmentRecord/interface/TrackerAlignmentErrorExtendedRcd.h
@@ -1,0 +1,8 @@
+#ifndef TRACKERALIGNMENTERROREXTENDEDRCD_H
+#define TRACKERALIGNMENTERROREXTENDEDRCD_H
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+
+class TrackerAlignmentErrorExtendedRcd : public edm::eventsetup::EventSetupRecordImplementation<TrackerAlignmentErrorExtendedRcd> {};
+
+#endif

--- a/CondFormats/AlignmentRecord/interface/TrackerSurveyErrorExtendedRcd.h
+++ b/CondFormats/AlignmentRecord/interface/TrackerSurveyErrorExtendedRcd.h
@@ -1,0 +1,20 @@
+#ifndef CondFormats_AlignmentRecord_TrackerSurveyErrorExtendedRcd_H
+#define CondFormats_AlignmentRecord_TrackerSurveyErrorExtendedRcd_H
+
+/** \class TrackerSurveyErrorExtendedRcd
+ *
+ *  DB record to hold errors of alignment parameters from survey.
+ *
+ *  $Date: 2007/04/03 15:24:56 $
+ *  $Revision: 1.1 $
+ *  \author Chung Khim Lae
+ */
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+
+class TrackerSurveyErrorExtendedRcd:
+  public edm::eventsetup::EventSetupRecordImplementation<TrackerSurveyErrorExtendedRcd>
+{
+};
+
+#endif

--- a/CondFormats/AlignmentRecord/interface/ZDCAlignmentErrorExtendedRcd.h
+++ b/CondFormats/AlignmentRecord/interface/ZDCAlignmentErrorExtendedRcd.h
@@ -1,0 +1,8 @@
+#ifndef ZDCALIGNMENTERROREXTENDEDRCD_H
+#define ZDCALIGNMENTERROREXTENDEDRCD_H
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+
+class ZDCAlignmentErrorExtendedRcd : public edm::eventsetup::EventSetupRecordImplementation<ZDCAlignmentErrorExtendedRcd> {};
+
+#endif

--- a/CondFormats/AlignmentRecord/src/CSCAlignmentErrorExtendedRcd.cc
+++ b/CondFormats/AlignmentRecord/src/CSCAlignmentErrorExtendedRcd.cc
@@ -1,0 +1,3 @@
+#include "CondFormats/AlignmentRecord/interface/CSCAlignmentErrorExtendedRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+EVENTSETUP_RECORD_REG(CSCAlignmentErrorExtendedRcd);

--- a/CondFormats/AlignmentRecord/src/CSCSurveyErrorExtendedRcd.cc
+++ b/CondFormats/AlignmentRecord/src/CSCSurveyErrorExtendedRcd.cc
@@ -1,0 +1,4 @@
+#include "CondFormats/AlignmentRecord/interface/CSCSurveyErrorExtendedRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+
+EVENTSETUP_RECORD_REG(CSCSurveyErrorExtendedRcd);

--- a/CondFormats/AlignmentRecord/src/CaloTowerAlignmentErrorExtendedRcd.cc
+++ b/CondFormats/AlignmentRecord/src/CaloTowerAlignmentErrorExtendedRcd.cc
@@ -1,0 +1,3 @@
+#include "CondFormats/AlignmentRecord/interface/CaloTowerAlignmentErrorExtendedRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+EVENTSETUP_RECORD_REG(CaloTowerAlignmentErrorExtendedRcd);

--- a/CondFormats/AlignmentRecord/src/CastorAlignmentErrorExtendedRcd.cc
+++ b/CondFormats/AlignmentRecord/src/CastorAlignmentErrorExtendedRcd.cc
@@ -1,0 +1,3 @@
+#include "CondFormats/AlignmentRecord/interface/CastorAlignmentErrorExtendedRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+EVENTSETUP_RECORD_REG(CastorAlignmentErrorExtendedRcd);

--- a/CondFormats/AlignmentRecord/src/DTAlignmentErrorExtendedRcd.cc
+++ b/CondFormats/AlignmentRecord/src/DTAlignmentErrorExtendedRcd.cc
@@ -1,0 +1,3 @@
+#include "CondFormats/AlignmentRecord/interface/DTAlignmentErrorExtendedRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+EVENTSETUP_RECORD_REG(DTAlignmentErrorExtendedRcd);

--- a/CondFormats/AlignmentRecord/src/DTSurveyErrorExtendedRcd.cc
+++ b/CondFormats/AlignmentRecord/src/DTSurveyErrorExtendedRcd.cc
@@ -1,0 +1,4 @@
+#include "CondFormats/AlignmentRecord/interface/DTSurveyErrorExtendedRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+
+EVENTSETUP_RECORD_REG(DTSurveyErrorExtendedRcd);

--- a/CondFormats/AlignmentRecord/src/EBAlignmentErrorExtendedRcd.cc
+++ b/CondFormats/AlignmentRecord/src/EBAlignmentErrorExtendedRcd.cc
@@ -1,0 +1,3 @@
+#include "CondFormats/AlignmentRecord/interface/EBAlignmentErrorExtendedRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+EVENTSETUP_RECORD_REG(EBAlignmentErrorExtendedRcd);

--- a/CondFormats/AlignmentRecord/src/EEAlignmentErrorExtendedRcd.cc
+++ b/CondFormats/AlignmentRecord/src/EEAlignmentErrorExtendedRcd.cc
@@ -1,0 +1,3 @@
+#include "CondFormats/AlignmentRecord/interface/EEAlignmentErrorExtendedRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+EVENTSETUP_RECORD_REG(EEAlignmentErrorExtendedRcd);

--- a/CondFormats/AlignmentRecord/src/ESAlignmentErrorExtendedRcd.cc
+++ b/CondFormats/AlignmentRecord/src/ESAlignmentErrorExtendedRcd.cc
@@ -1,0 +1,3 @@
+#include "CondFormats/AlignmentRecord/interface/ESAlignmentErrorExtendedRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+EVENTSETUP_RECORD_REG(ESAlignmentErrorExtendedRcd);

--- a/CondFormats/AlignmentRecord/src/EcalAlignmentErrorExtendedRcd.cc
+++ b/CondFormats/AlignmentRecord/src/EcalAlignmentErrorExtendedRcd.cc
@@ -1,0 +1,3 @@
+#include "CondFormats/AlignmentRecord/interface/EcalAlignmentErrorExtendedRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+EVENTSETUP_RECORD_REG(EcalAlignmentErrorExtendedRcd);

--- a/CondFormats/AlignmentRecord/src/HBAlignmentErrorExtendedRcd.cc
+++ b/CondFormats/AlignmentRecord/src/HBAlignmentErrorExtendedRcd.cc
@@ -1,0 +1,3 @@
+#include "CondFormats/AlignmentRecord/interface/HBAlignmentErrorExtendedRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+EVENTSETUP_RECORD_REG(HBAlignmentErrorExtendedRcd);

--- a/CondFormats/AlignmentRecord/src/HEAlignmentErrorExtendedRcd.cc
+++ b/CondFormats/AlignmentRecord/src/HEAlignmentErrorExtendedRcd.cc
@@ -1,0 +1,3 @@
+#include "CondFormats/AlignmentRecord/interface/HEAlignmentErrorExtendedRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+EVENTSETUP_RECORD_REG(HEAlignmentErrorExtendedRcd);

--- a/CondFormats/AlignmentRecord/src/HFAlignmentErrorExtendedRcd.cc
+++ b/CondFormats/AlignmentRecord/src/HFAlignmentErrorExtendedRcd.cc
@@ -1,0 +1,3 @@
+#include "CondFormats/AlignmentRecord/interface/HFAlignmentErrorExtendedRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+EVENTSETUP_RECORD_REG(HFAlignmentErrorExtendedRcd);

--- a/CondFormats/AlignmentRecord/src/HOAlignmentErrorExtendedRcd.cc
+++ b/CondFormats/AlignmentRecord/src/HOAlignmentErrorExtendedRcd.cc
@@ -1,0 +1,3 @@
+#include "CondFormats/AlignmentRecord/interface/HOAlignmentErrorExtendedRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+EVENTSETUP_RECORD_REG(HOAlignmentErrorExtendedRcd);

--- a/CondFormats/AlignmentRecord/src/HcalAlignmentErrorExtendedRcd.cc
+++ b/CondFormats/AlignmentRecord/src/HcalAlignmentErrorExtendedRcd.cc
@@ -1,0 +1,3 @@
+#include "CondFormats/AlignmentRecord/interface/HcalAlignmentErrorExtendedRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+EVENTSETUP_RECORD_REG(HcalAlignmentErrorExtendedRcd);

--- a/CondFormats/AlignmentRecord/src/TrackerAlignmentErrorExtendedRcd.cc
+++ b/CondFormats/AlignmentRecord/src/TrackerAlignmentErrorExtendedRcd.cc
@@ -1,0 +1,3 @@
+#include "CondFormats/AlignmentRecord/interface/TrackerAlignmentErrorExtendedRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+EVENTSETUP_RECORD_REG(TrackerAlignmentErrorExtendedRcd);

--- a/CondFormats/AlignmentRecord/src/TrackerSurveyErrorExtendedRcd.cc
+++ b/CondFormats/AlignmentRecord/src/TrackerSurveyErrorExtendedRcd.cc
@@ -1,0 +1,4 @@
+#include "CondFormats/AlignmentRecord/interface/TrackerSurveyErrorExtendedRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+
+EVENTSETUP_RECORD_REG(TrackerSurveyErrorExtendedRcd);

--- a/CondFormats/AlignmentRecord/src/ZDCAlignmentErrorExtendedRcd.cc
+++ b/CondFormats/AlignmentRecord/src/ZDCAlignmentErrorExtendedRcd.cc
@@ -1,0 +1,3 @@
+#include "CondFormats/AlignmentRecord/interface/ZDCAlignmentErrorExtendedRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+EVENTSETUP_RECORD_REG(ZDCAlignmentErrorExtendedRcd);


### PR DESCRIPTION
Pull request contains the changes i the CondFormat (only) necessary for migration to 6x6 APEs. The pull request is a subset of the earlier PR, containing these files only:
https://github.com/cms-sw/cmssw/pull/6420/files#diff-124
https://github.com/cms-sw/cmssw/pull/6420/files#diff-169

An extra change (bug fix) in the record mapping is done (CondCore/AlignmentPlugins/src/plugins.cc):

REGISTER_PLUGIN(TrackerAlignmentErrorRcd,AlignmentErrors);
L61
REGISTER_PLUGIN(DTAlignmentErrorRcd,AlignmentErrors);
L64
REGISTER_PLUGIN(CSCAlignmentErrorRcd,AlignmentErrors);
L66

Tested locally under CMSSW_7_3_X_2014-11-18-0200 with runTheMatrix, here is the output: 1 1 1 1 tests passed, 0 0 0 0 failed
