### PR TITLE
73X - fix `HadronAndPartonSelector` for unknown generators

### DIFF
--- a/PhysicsTools/JetMCAlgos/plugins/HadronAndPartonSelector.cc
+++ b/PhysicsTools/JetMCAlgos/plugins/HadronAndPartonSelector.cc
@@ -10,27 +10,27 @@
  * to these particles in the event. The following hadrons are selected:
  *
  * - b hadrons that do not have other b hadrons as daughters
- * 
+ *
  * - c hadrons that do not have other c hadrons as daughters
- * 
+ *
  * Older Fortran Monte Carlo generators (Pythia6 and Herwig6) follow the HEPEVT [1] particle status code convention while
  * newer C++ Monte Carlo generators (Pythia8, Herwig++, and Sherpa) follow the HepMC [2] particle status code convention.
  * However, both conventions give considerable freedom in defining the status codes of intermediate particle states. Hence,
  * the parton selection is generator-dependent and is described in each of the parton selectors separately.
- * 
+ *
  * Using the provenance information of the GenEventInfoProduct, the producer attempts to automatically determine what generator
  * was used to hadronize events and based on that information decides what parton selection mode to use. It is also possible
  * to enforce any of the supported parton selection modes.
  *
  * The selected hadrons and partons are finally used by the JetFlavourClustering producer to determine the jet flavour.
- * 
+ *
  * The following leptons are selected:
- * 
+ *
  * - status==1 electrons and muons
- * 
+ *
  * - status==2 taus
- * 
- * 
+ *
+ *
  * [1] http://cepa.fnal.gov/psm/stdhep/
  * [2] http://lcgapp.cern.ch/project/simu/HepMC/
  */
@@ -147,9 +147,10 @@ HadronAndPartonSelector::produce(edm::Event& iEvent, const edm::EventSetup& iSet
      iEvent.getByToken(srcToken_, genEvtInfoProduct);
 
      std::string moduleName = "";
-     const edm::Provenance& prov = iEvent.getProvenance(genEvtInfoProduct.id());
-     if( genEvtInfoProduct.isValid() )
+     if( genEvtInfoProduct.isValid() ) {
+       const edm::Provenance& prov = iEvent.getProvenance(genEvtInfoProduct.id());
        moduleName = edm::moduleName(prov);
+     }
 
      if( moduleName.find("Pythia6")!=std::string::npos )
        partonMode_="Pythia6";


### PR DESCRIPTION
Forward port of #6485 :
A possibly invalid handle in the `HadronAndPartonSelector` is not dereferenced any more, before its validity has been checked.
