### PR TITLE
Allow experiment type to be set in 7_2_X

### DIFF
--- a/CalibCalorimetry/EcalLaserSorting/interface/LmfSource.h
+++ b/CalibCalorimetry/EcalLaserSorting/interface/LmfSource.h
@@ -33,7 +33,7 @@ private:
    * (lumi block, run number, event number, timestamp)
    * Called by the framework before produce()
    */
-  virtual bool setRunAndEventInfo(edm::EventID& id, edm::TimeValue_t& time);
+  virtual bool setRunAndEventInfo(edm::EventID& id, edm::TimeValue_t& time, edm::EventAuxiliary::ExperimentType& eType);
 
   bool openFile(int iFile);
   

--- a/CalibCalorimetry/EcalLaserSorting/src/LmfSource.cc
+++ b/CalibCalorimetry/EcalLaserSorting/src/LmfSource.cc
@@ -221,7 +221,7 @@ bool LmfSource::readEvent(bool doSkip){
   return rcRead_;
 }
  
-bool LmfSource::setRunAndEventInfo(EventID& id, TimeValue_t& time){
+bool LmfSource::setRunAndEventInfo(EventID& id, TimeValue_t& time, edm::EventAuxiliary::ExperimentType& eType){
   //empties collection:
   if(fedId_>0){
     fedColl_.FEDData(fedId_).resize(0);

--- a/CondCore/Utilities/plugins/EmptyIOVSource.cc
+++ b/CondCore/Utilities/plugins/EmptyIOVSource.cc
@@ -8,7 +8,7 @@ namespace cond {
     ~EmptyIOVSource();
   private:
     virtual void produce(edm::Event & e) override;
-    virtual bool setRunAndEventInfo(edm::EventID& id, edm::TimeValue_t& time) override;
+    virtual bool setRunAndEventInfo(edm::EventID& id, edm::TimeValue_t& time, edm::EventAuxiliary::ExperimentType& eType) override;
     virtual void initialize(edm::EventID& id, edm::TimeValue_t& time, edm::TimeValue_t& interval) override;
   private:
     TimeType m_timeType;
@@ -40,7 +40,7 @@ namespace cond{
   }
   void EmptyIOVSource::produce( edm::Event & ) {
   }  
-  bool EmptyIOVSource::setRunAndEventInfo(edm::EventID& id, edm::TimeValue_t& time){
+  bool EmptyIOVSource::setRunAndEventInfo(edm::EventID& id, edm::TimeValue_t& time, edm::EventAuxiliary::ExperimentType& eType){
     if(m_current<=m_lastValid){
       if( m_timeType == cond::runnumber ){
 	id = edm::EventID(m_current, id.luminosityBlock(), 1);

--- a/EventFilter/Utilities/plugins/FRDStreamSource.cc
+++ b/EventFilter/Utilities/plugins/FRDStreamSource.cc
@@ -26,7 +26,7 @@ FRDStreamSource::FRDStreamSource(edm::ParameterSet const& pset,
 }
 
 
-bool FRDStreamSource::setRunAndEventInfo(edm::EventID& id, edm::TimeValue_t& theTime)
+bool FRDStreamSource::setRunAndEventInfo(edm::EventID& id, edm::TimeValue_t& theTime, edm::EventAuxiliary::ExperimentType& eType)
 {
   if ( fin_.peek() == EOF ) {
     if ( ++itFileName_==fileNames().end() ) {
@@ -105,6 +105,7 @@ bool FRDStreamSource::setRunAndEventInfo(edm::EventID& id, edm::TimeValue_t& the
       evf::evtn::TCDSRecord record((unsigned char *)(event + eventSize ));
       id = edm::EventID(frdEventMsg->run(),record.getHeader().getData().header.lumiSection,
 			record.getHeader().getData().header.eventNumber);
+      eType = ((edm::EventAuxiliary::ExperimentType)FED_EVTY_EXTRACT(fedHeader->eventid));
       //evf::evtn::evm_board_setformat(fedSize);
       uint64_t gpsh = record.getBST().getBST().gpstimehigh;
       uint32_t gpsl = record.getBST().getBST().gpstimelow;

--- a/EventFilter/Utilities/plugins/FRDStreamSource.h
+++ b/EventFilter/Utilities/plugins/FRDStreamSource.h
@@ -28,7 +28,7 @@ public:
 
 private:
   // member functions
-  virtual bool setRunAndEventInfo(edm::EventID& id, edm::TimeValue_t& theTime);
+  virtual bool setRunAndEventInfo(edm::EventID& id, edm::TimeValue_t& theTime, edm::EventAuxiliary::ExperimentType& eType);
   virtual void produce(edm::Event& e);
 
   void beginRun(edm::Run&) {}

--- a/FWCore/Integration/test/IntSource.cc
+++ b/FWCore/Integration/test/IntSource.cc
@@ -16,7 +16,7 @@ namespace edm {
     ~IntSource();
     static void fillDescriptions(ConfigurationDescriptions& descriptions);
   private:
-    virtual bool setRunAndEventInfo(EventID& id, TimeValue_t& time);
+    virtual bool setRunAndEventInfo(EventID& id, TimeValue_t& time, edm::EventAuxiliary::ExperimentType& eType);
     virtual void produce(Event &);
   };
 
@@ -29,7 +29,7 @@ namespace edm {
   }
 
   bool
-  IntSource::setRunAndEventInfo(EventID&, TimeValue_t&) {
+  IntSource::setRunAndEventInfo(EventID&, TimeValue_t&, edm::EventAuxiliary::ExperimentType&) {
     return true;
   }
 

--- a/FWCore/Integration/test/ThingExtSource.cc
+++ b/FWCore/Integration/test/ThingExtSource.cc
@@ -19,7 +19,7 @@ namespace edmtest {
   ThingExtSource::~ThingExtSource() { }  
 
   // Functions that gets called by framework every event
-  bool ThingExtSource::setRunAndEventInfo(edm::EventID&, edm::TimeValue_t&) {
+  bool ThingExtSource::setRunAndEventInfo(edm::EventID&, edm::TimeValue_t&, edm::EventAuxiliary::ExperimentType&) {
     // Fake running out of data.
     if (event() > 2) return false;
     return true;

--- a/FWCore/Integration/test/ThingExtSource.h
+++ b/FWCore/Integration/test/ThingExtSource.h
@@ -23,7 +23,7 @@ namespace edmtest {
 
     virtual ~ThingExtSource();
 
-    virtual bool setRunAndEventInfo(edm::EventID&, edm::TimeValue_t&);
+    virtual bool setRunAndEventInfo(edm::EventID&, edm::TimeValue_t&, edm::EventAuxiliary::ExperimentType&);
 
     virtual void produce(edm::Event& e);
 

--- a/FWCore/Integration/test/ThingSource.h
+++ b/FWCore/Integration/test/ThingSource.h
@@ -23,7 +23,7 @@ namespace edmtest {
 
     virtual ~ThingSource();
 
-    virtual bool setRunAndEventInfo(edm::EventID&, edm::TimeValue_t&) {return true;}
+    virtual bool setRunAndEventInfo(edm::EventID&, edm::TimeValue_t&, edm::EventAuxiliary::ExperimentType&) {return true;}
 
     virtual void produce(edm::Event& e);
 

--- a/FWCore/Integration/test/ThrowingSource.cc
+++ b/FWCore/Integration/test/ThrowingSource.cc
@@ -41,7 +41,7 @@ namespace edm {
       kCloseFile = 13,
       kDestructor = 14
     };
-    virtual bool setRunAndEventInfo(EventID& id, TimeValue_t& time);
+    virtual bool setRunAndEventInfo(EventID& id, TimeValue_t& time, edm::EventAuxiliary::ExperimentType& eType);
     virtual void produce(Event &);
 
     // To test exception throws from sources
@@ -60,7 +60,7 @@ namespace edm {
   }
 
   bool
-  ThrowingSource::setRunAndEventInfo(EventID&, TimeValue_t&) {
+  ThrowingSource::setRunAndEventInfo(EventID&, TimeValue_t&, edm::EventAuxiliary::ExperimentType&) {
     return true;
   }
 

--- a/FWCore/Modules/src/EmptySource.cc
+++ b/FWCore/Modules/src/EmptySource.cc
@@ -11,7 +11,7 @@ namespace edm {
     ~EmptySource();
     static void fillDescriptions(ConfigurationDescriptions& descriptions);
   private:
-    virtual bool setRunAndEventInfo(EventID& id, TimeValue_t& time) override;
+    virtual bool setRunAndEventInfo(EventID& id, TimeValue_t& time, edm::EventAuxiliary::ExperimentType&) override;
     virtual void produce(Event &) override;
   };
 
@@ -24,7 +24,7 @@ namespace edm {
   }
 
   bool
-  EmptySource::setRunAndEventInfo(EventID&, TimeValue_t&) {
+  EmptySource::setRunAndEventInfo(EventID&, TimeValue_t&, edm::EventAuxiliary::ExperimentType&) {
     return true;
   }
 

--- a/FWCore/Sources/interface/ProducerSourceBase.h
+++ b/FWCore/Sources/interface/ProducerSourceBase.h
@@ -38,9 +38,9 @@ namespace edm {
   protected:
 
   private:
-    virtual ItemType getNextItemType() override;
+    virtual ItemType getNextItemType() override final;
     virtual void initialize(EventID& id, TimeValue_t& time, TimeValue_t& interval);
-    virtual bool setRunAndEventInfo(EventID& id, TimeValue_t& time) = 0;
+    virtual bool setRunAndEventInfo(EventID& id, TimeValue_t& time, EventAuxiliary::ExperimentType& etype) = 0;
     virtual void produce(Event& e) = 0;
     virtual bool noFiles() const;
     virtual size_t fileIndex() const;

--- a/FWCore/Sources/src/ProducerSourceBase.cc
+++ b/FWCore/Sources/src/ProducerSourceBase.cc
@@ -142,7 +142,7 @@ namespace edm {
     advanceToNext(eventID_, presentTime_);
     if (eventCreationDelay_ > 0) {usleep(eventCreationDelay_);}
     size_t index = fileIndex();
-    bool another = setRunAndEventInfo(eventID_, presentTime_);
+    bool another = setRunAndEventInfo(eventID_, presentTime_, eType_);
     if(!another) {
       return IsStop;
     }

--- a/GeneratorInterface/AlpgenInterface/plugins/AlpgenSource.cc
+++ b/GeneratorInterface/AlpgenInterface/plugins/AlpgenSource.cc
@@ -36,7 +36,7 @@ public:
   virtual ~AlpgenSource();
 
 private:
-  virtual bool setRunAndEventInfo(edm::EventID&, edm::TimeValue_t&) override;
+  virtual bool setRunAndEventInfo(edm::EventID&, edm::TimeValue_t&, edm::EventAuxiliary::ExperimentType&) override;
   virtual void produce(edm::Event &event) override;
   virtual void beginRun(edm::Run &run) override;
 
@@ -403,7 +403,7 @@ bool AlpgenSource::readAlpgenEvent(lhef::HEPEUP &hepeup)
   return true;
 }
 
-bool AlpgenSource::setRunAndEventInfo(edm::EventID&, edm::TimeValue_t&)
+bool AlpgenSource::setRunAndEventInfo(edm::EventID&, edm::TimeValue_t&, edm::EventAuxiliary::ExperimentType&)
 {
   // The LHE Event Record
   hepeup_.reset(new lhef::HEPEUP);

--- a/GeneratorInterface/LHEInterface/plugins/LHESource.cc
+++ b/GeneratorInterface/LHEInterface/plugins/LHESource.cc
@@ -161,7 +161,7 @@ void LHESource::endRun(edm::Run&)
 	runPrincipal_ = nullptr;
 }
 
-bool LHESource::setRunAndEventInfo(edm::EventID&, edm::TimeValue_t&)
+bool LHESource::setRunAndEventInfo(edm::EventID&, edm::TimeValue_t&, edm::EventAuxiliary::ExperimentType&)
 {
 	nextEvent();
 	if (!partonLevel) {

--- a/GeneratorInterface/LHEInterface/plugins/LHESource.h
+++ b/GeneratorInterface/LHEInterface/plugins/LHESource.h
@@ -38,7 +38,7 @@ class LHERunInfoProduct;
 	virtual void endJob() override;
 	virtual void beginRun(edm::Run &run) override;
 	virtual void endRun(edm::Run &run) override;
- 	virtual bool setRunAndEventInfo(edm::EventID&, edm::TimeValue_t&) override;
+ 	virtual bool setRunAndEventInfo(edm::EventID&, edm::TimeValue_t&, edm::EventAuxiliary::ExperimentType&) override;
 	virtual void readRun_(edm::RunPrincipal& runPrincipal) override;
 	virtual void readLuminosityBlock_(edm::LuminosityBlockPrincipal& lumiPrincipal) override;
 	virtual void readEvent_(edm::EventPrincipal& eventPrincipal) override;

--- a/GeneratorInterface/MCatNLOInterface/plugins/MCatNLOSource.cc
+++ b/GeneratorInterface/MCatNLOInterface/plugins/MCatNLOSource.cc
@@ -155,7 +155,7 @@ void MCatNLOSource::beginRun(edm::Run &run)
   return;
 }
 
-bool MCatNLOSource::setRunAndEventInfo(edm::EventID&, edm::TimeValue_t&)
+bool MCatNLOSource::setRunAndEventInfo(edm::EventID&, edm::TimeValue_t&, edm::EventAuxiliary::ExperimentType&)
 {
   InstanceWrapper wrapper(this);
 

--- a/GeneratorInterface/MCatNLOInterface/plugins/MCatNLOSource.h
+++ b/GeneratorInterface/MCatNLOInterface/plugins/MCatNLOSource.h
@@ -50,7 +50,7 @@ public:
 private:
   virtual void endJob();
   virtual void beginRun(edm::Run &run);
-  virtual bool setRunAndEventInfo(edm::EventID&, edm::TimeValue_t&);
+  virtual bool setRunAndEventInfo(edm::EventID&, edm::TimeValue_t&, edm::EventAuxiliary::ExperimentType&);
   virtual void produce(edm::Event &event);
   
   void nextEvent();

--- a/IOMC/Input/interface/MCFileSource.h
+++ b/IOMC/Input/interface/MCFileSource.h
@@ -28,7 +28,7 @@ namespace edm {
     virtual ~MCFileSource();
 
   private:
-    virtual bool setRunAndEventInfo(EventID&, TimeValue_t& time);
+    virtual bool setRunAndEventInfo(EventID&, TimeValue_t& time, EventAuxiliary::ExperimentType& eType);
     virtual void produce(Event &e);
     void clear();
     

--- a/IOMC/Input/src/MCFileSource.cc
+++ b/IOMC/Input/src/MCFileSource.cc
@@ -41,7 +41,7 @@ MCFileSource::~MCFileSource(){
 }
 
 //-------------------------------------------------------------------------
-bool MCFileSource::setRunAndEventInfo(EventID&, TimeValue_t&) {
+bool MCFileSource::setRunAndEventInfo(EventID&, TimeValue_t&, EventAuxiliary::ExperimentType&) {
   // Read one HepMC event
   LogInfo("MCFileSource") << "Start Reading";
   evt_ = reader_->fillCurrentEventData(); 

--- a/IORawData/HcalTBInputService/interface/HcalTBSource.h
+++ b/IORawData/HcalTBInputService/interface/HcalTBSource.h
@@ -29,7 +29,7 @@ public:
 explicit HcalTBSource(const edm::ParameterSet & pset, edm::InputSourceDescription const& desc);
 virtual ~HcalTBSource();
 private:
-  virtual bool setRunAndEventInfo(edm::EventID& id, edm::TimeValue_t& time);
+  virtual bool setRunAndEventInfo(edm::EventID& id, edm::TimeValue_t& time, edm::EventAuxiliary::ExperimentType&);
   virtual void produce(edm::Event & e);
   void unpackSetup(const std::vector<std::string>& params);
   void openFile(const std::string& filename);

--- a/IORawData/HcalTBInputService/src/HcalTBSource.cc
+++ b/IORawData/HcalTBInputService/src/HcalTBSource.cc
@@ -106,7 +106,7 @@ void HcalTBSource::openFile(const std::string& filename) {
   m_i=0;
 }
 
-bool HcalTBSource::setRunAndEventInfo(EventID& id, TimeValue_t& time) {
+bool HcalTBSource::setRunAndEventInfo(EventID& id, TimeValue_t& time, edm::EventAuxiliary::ExperimentType&) {
   bool is_new=false;
 
   while (m_tree==0 || m_i==m_tree->GetEntries()) {

--- a/IORawData/SiPixelInputSources/interface/PixelSLinkDataInputSource.h
+++ b/IORawData/SiPixelInputSources/interface/PixelSLinkDataInputSource.h
@@ -46,7 +46,7 @@ public:
 
 private:
 
-  virtual bool setRunAndEventInfo(edm::EventID& id, edm::TimeValue_t& time);
+  virtual bool setRunAndEventInfo(edm::EventID& id, edm::TimeValue_t& time, edm::EventAuxiliary::ExperimentType&);
   virtual void produce(edm::Event& event);
   uint32_t synchronizeEvents();
 

--- a/IORawData/SiPixelInputSources/src/PixelSLinkDataInputSource.cc
+++ b/IORawData/SiPixelInputSources/src/PixelSLinkDataInputSource.cc
@@ -172,7 +172,7 @@ PixelSLinkDataInputSource::~PixelSLinkDataInputSource() {
 
 }
 
-bool PixelSLinkDataInputSource::setRunAndEventInfo(edm::EventID& id, edm::TimeValue_t& time) {
+bool PixelSLinkDataInputSource::setRunAndEventInfo(edm::EventID& id, edm::TimeValue_t& time, edm::EventAuxiliary::ExperimentType&) {
   Storage & m_file = *storage;
 
   // create product (raw data)

--- a/L1Trigger/GlobalMuonTrigger/src/L1MuGMTHWFileReader.cc
+++ b/L1Trigger/GlobalMuonTrigger/src/L1MuGMTHWFileReader.cc
@@ -67,7 +67,7 @@ L1MuGMTHWFileReader::~L1MuGMTHWFileReader() {
 //--------------
 // Operations --
 //--------------
-bool L1MuGMTHWFileReader::setRunAndEventInfo(edm::EventID& id, edm::TimeValue_t& time) {
+bool L1MuGMTHWFileReader::setRunAndEventInfo(edm::EventID& id, edm::TimeValue_t& time, edm::EventAuxiliary::ExperimentType& eType) {
   readNextEvent();
   if(!m_evt.getRunNumber() && !m_evt.getEventNumber()) return false;
   id = edm::EventID(m_evt.getRunNumber(), id.luminosityBlock(), m_evt.getEventNumber());

--- a/L1Trigger/GlobalMuonTrigger/src/L1MuGMTHWFileReader.h
+++ b/L1Trigger/GlobalMuonTrigger/src/L1MuGMTHWFileReader.h
@@ -50,7 +50,7 @@ class L1MuGMTHWFileReader : public edm::ProducerSourceFromFiles {
 
 
  private:
-   virtual bool setRunAndEventInfo(edm::EventID& id, edm::TimeValue_t& time);
+   virtual bool setRunAndEventInfo(edm::EventID& id, edm::TimeValue_t& time, edm::EventAuxiliary::ExperimentType& eType);
    virtual void produce(edm::Event&);
 
    std::ifstream m_in;


### PR DESCRIPTION
Remi Mommsen discovered that there is no way to set the ExperimentType data member in ProducerSourceBase, which is the base class of FRDStreamSource.
This pull request fixes this problem in 7_2_X.
Remi requested the problem be fixed in 7_2_X and 7_3_X.
A separate pull request (#6416) was used for 7_3_X.
The member function setRunAndEventInfo() needed an additional argument.
All classes inheriting from ProducerSourceBase needed this addtional argument added.
At the moment, only FRDStreamSource actually sets the ExperimentType (done in this pull request).
