### PR TITLE
Fix when unschedule mode and customise_command are used together

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -838,8 +838,8 @@ class ConfigBuilder(object):
 	if len(custMap)!=0:
 		final_snippet += '\n# End of customisation functions\n'
 
-	### now for a usuful command
-	if unsch==0 and not self._options.runUnscheduled:
+	### now for a useful command
+	if unsch==1 or not self._options.runUnscheduled:
 		if self._options.customise_commands:
 			import string
 			final_snippet +='\n# Customisation from command line'
@@ -847,15 +847,7 @@ class ConfigBuilder(object):
 				com=string.lstrip(com)
 				self.executeAndRemember(com)
 				final_snippet +='\n'+com
-	if unsch==1:
-		if self._options.customise_commands:
-                        import string
-                        final_snippet +='\n# Customisation from command line'
-                        for com in self._options.customise_commands.split('\\n'):
-                                com=string.lstrip(com)
-                                self.executeAndRemember(com)
-                                final_snippet +='\n'+com
-
+	
         return final_snippet
 
     #----------------------------------------------------------------------------

--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -839,13 +839,22 @@ class ConfigBuilder(object):
 		final_snippet += '\n# End of customisation functions\n'
 
 	### now for a usuful command
-	if self._options.customise_commands:
-		import string
-		final_snippet +='\n# Customisation from command line'
-		for com in self._options.customise_commands.split('\\n'):
-			com=string.lstrip(com)
-			self.executeAndRemember(com)
-			final_snippet +='\n'+com
+	if unsch==0 and not self._options.runUnscheduled:
+		if self._options.customise_commands:
+			import string
+			final_snippet +='\n# Customisation from command line'
+			for com in self._options.customise_commands.split('\\n'):
+				com=string.lstrip(com)
+				self.executeAndRemember(com)
+				final_snippet +='\n'+com
+	if unsch==1:
+		if self._options.customise_commands:
+                        import string
+                        final_snippet +='\n# Customisation from command line'
+                        for com in self._options.customise_commands.split('\\n'):
+                                com=string.lstrip(com)
+                                self.executeAndRemember(com)
+                                final_snippet +='\n'+com
 
         return final_snippet
 


### PR DESCRIPTION
customise_commands will fail in unschedule mode because it's called before the module is load.

https://github.com/cms-sw/cmssw/blob/CMSSW_7_2_X/Configuration/Applications/python/ConfigBuilder.py#L2211-L2226

For example,
cmsDriver.py step3 --filein file:MUO-Phys14DR-00003_step2.root --fileout file:MUO-Phys14DR-00003.root --mc --eventcontent MINIAODSIM --runUnscheduled --datatier MINIAODSIM --conditions PHYS14_25_V1 --customise_commands 'process.patJetPartons.partonMode = cms.string("Pythia6")' --step PAT --python_filename MUO-Phys14DR-00003_3_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 20
