### PR TITLE
New Global Tags for pre3 RelVal

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -10,11 +10,11 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
     'run1_mc_pa'        :   'MCPA1_73_V0::All',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   'DESRUN2_73_V0::All',
+    'run2_design'       :   'DESRUN2_73_V1::All',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   'MCRUN2_73_V0::All',
+    'run2_mc_50ns'      :   'MCRUN2_73_V2::All',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   'MCRUN2_73_V1::All',
+    'run2_mc'           :   'MCRUN2_73_V3::All',
     # GlobalTag for Run1 data reprocessing
     'run1_data'         :   'GR_R_73_V0A::All',
     # GlobalTag for Run2 data reprocessing

--- a/Configuration/AlCa/python/autoCond_condDBv2.py
+++ b/Configuration/AlCa/python/autoCond_condDBv2.py
@@ -10,11 +10,11 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
     'run1_mc_pa'        :   'MCPA1_73_V0',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   'DESRUN2_73_V0',
+    'run2_design'       :   'DESRUN2_73_V1',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   'MCRUN2_73_V0',
+    'run2_mc_50ns'      :   'MCRUN2_73_V2',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   'MCRUN2_73_V1',
+    'run2_mc'           :   'MCRUN2_73_V3',
     # GlobalTag for Run1 data reprocessing
     'run1_data'         :   'GR_R_73_V0A',
     # GlobalTag for Run2 data reprocessing


### PR DESCRIPTION
New Run2 (ideal, startup, asymptotic) simulation GlobalTags with updated L1T conditions for CSC (Pt LUT and TF) and RCT.
