### PR TITLE
Removed unused methods from edm::View

### DIFF
--- a/DataFormats/Common/interface/View.h
+++ b/DataFormats/Common/interface/View.h
@@ -121,8 +121,6 @@ namespace edm {
     const_reference operator[](size_type pos) const;
     RefToBase<value_type> refAt(size_type i) const;
     Ptr<value_type> ptrAt(size_type i) const;
-    RefToBaseVector<T> const& refVector() const { return refs_; }
-    PtrVector<T> const& ptrVector() const { return ptrs_; }
     std::vector<Ptr<value_type> > const& ptrs() const;
 
     const_reference front() const;


### PR DESCRIPTION
All the uses of the refPtr and refVector interfaces were removed
from CMSSW. This is in anticipation of a future code change which
can not support those interfaces. Removing them from View now insures
that no new code tries to use them.
