### PR TITLE
Use correct arguments for iterator constructor

### DIFF
--- a/CondCore/ORA/src/STLContainerHandler.cc
+++ b/CondCore/ORA/src/STLContainerHandler.cc
@@ -22,7 +22,7 @@ ora::STLContainerIteratorHandler::STLContainerIteratorHandler( void* address,
   if (m_collProxy.HasPointers()) {
     m_PtrIterators = new TVirtualCollectionPtrIterators(&m_collProxy);
   } else {
-    m_Iterators = new TVirtualCollectionIterators(&m_collProxy);
+    m_Iterators = new TVirtualCollectionIterators(&m_collProxy, false);
   }
   m_Next = m_collProxy.GetFunctionNext(false);
 


### PR DESCRIPTION
This ROOT 6 specific pull request fixes the three failing unit tests in package CondCore/DBCommon.
Please merge as soon as convenient.
