### PR TITLE
Making CMVA in standard Reco IVF-based

### DIFF
--- a/PhysicsTools/PatAlgos/python/recoLayer0/bTagging_cff.py
+++ b/PhysicsTools/PatAlgos/python/recoLayer0/bTagging_cff.py
@@ -81,7 +81,7 @@ supportedBtagDiscr = {
   , 'negativeSoftPFElectronByPtBJetTags'                    : ['softPFElectronsTagInfos']
   , 'negativeSoftPFElectronByIP3dBJetTags'                  : ['softPFElectronsTagInfos']
   , 'negativeSoftPFElectronByIP2dBJetTags'                  : ['softPFElectronsTagInfos']
-  , 'combinedMVABJetTags'                                   : ['impactParameterTagInfos', 'secondaryVertexTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
-  , 'positiveCombinedMVABJetTags'                           : ['impactParameterTagInfos', 'secondaryVertexTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
-  , 'negativeCombinedMVABJetTags'                           : ['impactParameterTagInfos', 'secondaryVertexNegativeTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
+  , 'combinedMVABJetTags'                                   : ['impactParameterTagInfos', 'inclusiveSecondaryVertexFinderTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
+  , 'positiveCombinedMVABJetTags'                           : ['impactParameterTagInfos', 'inclusiveSecondaryVertexFinderTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
+  , 'negativeCombinedMVABJetTags'                           : ['impactParameterTagInfos', 'inclusiveSecondaryVertexFinderNegativeTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
   }

--- a/RecoBTau/JetTagComputer/python/combinedMVABJetTags_cfi.py
+++ b/RecoBTau/JetTagComputer/python/combinedMVABJetTags_cfi.py
@@ -4,7 +4,7 @@ combinedMVABJetTags = cms.EDProducer("JetTagProducer",
 	jetTagComputer = cms.string('combinedMVAComputer'),
 	tagInfos = cms.VInputTag(
 		cms.InputTag("impactParameterTagInfos"),
-		cms.InputTag("secondaryVertexTagInfos"),
+		cms.InputTag("inclusiveSecondaryVertexFinderTagInfos"),
 		cms.InputTag("softPFMuonsTagInfos"),
 		cms.InputTag("softPFElectronsTagInfos")
 	)

--- a/RecoBTau/JetTagComputer/python/negativeCombinedMVABJetTags_cfi.py
+++ b/RecoBTau/JetTagComputer/python/negativeCombinedMVABJetTags_cfi.py
@@ -4,7 +4,7 @@ negativeCombinedMVABJetTags = cms.EDProducer("JetTagProducer",
 	jetTagComputer = cms.string('negativeCombinedMVAComputer'),
 	tagInfos = cms.VInputTag(
 		cms.InputTag("impactParameterTagInfos"),
-		cms.InputTag("secondaryVertexNegativeTagInfos"),
+		cms.InputTag("inclusiveSecondaryVertexFinderNegativeTagInfos"),
 		cms.InputTag("softPFMuonsTagInfos"),
 		cms.InputTag("softPFElectronsTagInfos")
 	)

--- a/RecoBTau/JetTagComputer/python/positiveCombinedMVABJetTags_cfi.py
+++ b/RecoBTau/JetTagComputer/python/positiveCombinedMVABJetTags_cfi.py
@@ -4,7 +4,7 @@ positiveCombinedMVABJetTags = cms.EDProducer("JetTagProducer",
 	jetTagComputer = cms.string('positiveCombinedMVAComputer'),
 	tagInfos = cms.VInputTag(
 		cms.InputTag("impactParameterTagInfos"),
-		cms.InputTag("secondaryVertexTagInfos"),
+		cms.InputTag("inclusiveSecondaryVertexFinderTagInfos"),
 		cms.InputTag("softPFMuonsTagInfos"),
 		cms.InputTag("softPFElectronsTagInfos")
 	)


### PR DESCRIPTION
In 7_2_X CMVA in PAT was IVF-based but the Reco version wasn't. This PR synchronizes the two versions and makes them both IVF-based.
