### PR TITLE
fix beginLuminosityBlock, and add endLuminosityBlock and endRun

### DIFF
--- a/SimGeneral/DataMixingModule/plugins/DataMixingModule.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingModule.cc
@@ -329,6 +329,13 @@ namespace edm
     }
   }
 
+  void DataMixingModule::endRun(edm::Run const& run, const edm::EventSetup& ES) { 
+    //if( addMCDigiNoise_ ) {
+      // HcalDigiWorkerProd_->endRun( run, ES ); // FIXME not implemented
+      // EcalDigiWorkerProd_->endRun( ES );      // FIXME not implemented
+    //}
+    BMixingModule::endRun( run, ES);
+  }
 
   // Virtual destructor needed.
   DataMixingModule::~DataMixingModule() { 
@@ -545,9 +552,14 @@ namespace edm
   }
 
   void DataMixingModule::beginLuminosityBlock(LuminosityBlock const& l1, EventSetup const& c) {
+    BMixingModule::beginLuminosityBlock(l1, c);
     EcalDigiWorkerProd_->beginLuminosityBlock(l1,c);
   }
 
+  void DataMixingModule::endLuminosityBlock(LuminosityBlock const& l1, EventSetup const& c) {
+    // EcalDigiWorkerProd_->endLuminosityBlock(l1,c);  // FIXME Not implemented.
+    BMixingModule::endLuminosityBlock(l1, c);
+  }
 
 
 } //edm

--- a/SimGeneral/DataMixingModule/plugins/DataMixingModule.h
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingModule.h
@@ -70,8 +70,8 @@ namespace edm {
       //virtual void beginJob();
       //virtual void endJob();
       virtual void beginLuminosityBlock(LuminosityBlock const& l1, EventSetup const& c) override;
-      //virtual void endLuminosityBlock(LuminosityBlock const& l1, EventSetup const& c) override;
-      //virtual void endRun(const edm::Run& r, const edm::EventSetup& setup) override;
+      virtual void endLuminosityBlock(LuminosityBlock const& l1, EventSetup const& c) override;
+      virtual void endRun(const edm::Run& r, const edm::EventSetup& setup) override;
 
 
 


### PR DESCRIPTION
This pull request fixes two problems in the DataMixingModule:
1) DataMixingModule::beginLuminosityBlock() did not call BMixingModule::beginLuminosityBlock(),  This causes a segfault if the secondary source fails to open an input file.
2) beginRun and beginLuminosityBlock were implemented, but endRun and endLuminosityBlock were not.  This is an accident waiting to happen.  The implementation of endRun and endLuminosityBlock do not change current functionality, but make the code more maintainable.
