### PR TITLE
Important BUG FIX in parameter assignment of millepede-based tracker ali...

### DIFF
--- a/Alignment/CommonAlignmentProducer/plugins/AlignmentProducer.cc
+++ b/Alignment/CommonAlignmentProducer/plugins/AlignmentProducer.cc
@@ -467,7 +467,8 @@ AlignmentProducer::duringLoop( const edm::Event& event,
       clusterValueMapPtr = &(*clusterValueMap);
     }
 
-    const AlignmentAlgorithmBase::EventInfo eventInfo(event.id(), trajTracks, *beamSpot,
+    const edm::EventID evtid = event.id();
+    const AlignmentAlgorithmBase::EventInfo eventInfo(evtid, trajTracks, *beamSpot,
 						      clusterValueMapPtr);
     theAlignmentAlgo->run(setup, eventInfo);
 


### PR DESCRIPTION
...gnment

The bug corrupts the IOV-dependent alignment in releases compiled with
slc6_amd64_gcc472 and later. It is caused by using a dangling reference to
an edm::EventID object to determine the run number. At least with the gcc
versions in SLC6, this results in an incorrect determination of the current
IOV. Details are given in this presentation at the tracker-alignment meeting:

https://indico.cern.ch/event/342234/session/0/contribution/8/0/material/slides/0.pdf

The commit is a quick fix to ensure a working alingment fit. There might be
a more involved follow-up to avoid similar bugs in the future.
