### PR TITLE
Pass address of pointer, not value of pointer

### DIFF
--- a/CondCore/ORA/src/OraPtrStreamer.cc
+++ b/CondCore/ORA/src/OraPtrStreamer.cc
@@ -196,11 +196,11 @@ void ora::OraPtrWriter::write( int oid,
   
   edm::ObjectWithDict ptrObject( m_objectType, m_dataElement->address( data ) );
   // first load if required
-  ptrObject.typeOf().functionMemberByName("load").invoke(ptrObject,0);
+  m_objectType.functionMemberByName("load").invoke(ptrObject,nullptr);
   // then get the data...
-  void* ptrAddress = 0;
-  edm::ObjectWithDict ptrAddrObj = edm::ObjectWithDict( edm::TypeWithDict(typeid(void*)), ptrAddress );
-  ptrObject.typeOf().functionMemberByName("address").invoke(ptrObject, &ptrAddrObj);
+  void* ptrAddress = nullptr;
+  edm::ObjectWithDict ptrAddrObj = edm::ObjectWithDict( edm::TypeWithDict(typeid(void*)), &ptrAddress );
+  m_objectType.functionMemberByName("address").invoke(ptrObject, &ptrAddrObj);
   m_writer->write( oid, ptrAddress );
 }
 

--- a/CondCore/ORA/src/QueryableVectorStreamer.cc
+++ b/CondCore/ORA/src/QueryableVectorStreamer.cc
@@ -381,10 +381,10 @@ void ora::QueryableVectorWriter::write( int oid,
   }
   void* vectorAddress = m_offset->address( inputData );
   edm::ObjectWithDict vectorObj( m_objectType, const_cast<void*>(vectorAddress) );
-  vectorObj.typeOf().functionMemberByName("load").invoke(vectorObj,0);
-  void* storageAddress = 0;
-  edm::ObjectWithDict storAddObj = edm::ObjectWithDict( edm::TypeWithDict(typeid(void*)), storageAddress );
-  vectorObj.typeOf().functionMemberByName("storageAddress").invoke(vectorObj, &storAddObj);
+  m_objectType.functionMemberByName("load").invoke(vectorObj,nullptr);
+  void* storageAddress = nullptr;
+  edm::ObjectWithDict storAddObj = edm::ObjectWithDict( edm::TypeWithDict(typeid(void*)), &storageAddress );
+  m_objectType.functionMemberByName("storageAddress").invoke(vectorObj, &storAddObj);
   m_writer.write( oid, storageAddress );
 }
 


### PR DESCRIPTION
This request fixes ROOT 6 specific segfaults in four unit tests in CondCore packages, although the tests still fail later due to a different problem.
In two places in the code, the address of a pointer to an object needed to be passed to an ObjectWithDict constructor.
Unfortunately, the value of the pointer was passed instead (missing '&').
Editorial comment:  I hate code that is not type safe.
This request also does some minor optimization by avoiding unnecessary ObjectWithDict::typeOf() calls, since the return value is already known.
Please merge this request as soon as convenient.
