### PR TITLE
Fix for RunInfo PopCon tools

### DIFF
--- a/CondTools/RunInfo/interface/RunInfoHandler.h
+++ b/CondTools/RunInfo/interface/RunInfoHandler.h
@@ -10,7 +10,7 @@
 class RunInfoHandler : public popcon::PopConSourceHandler<RunInfo>{
  public:
   void getNewObjects();
-  std::string id() const { return m_name;}
+  std::string id() const { return m_name; }
   ~RunInfoHandler();
   RunInfoHandler(const edm::ParameterSet& pset); 
   
@@ -18,16 +18,11 @@ class RunInfoHandler : public popcon::PopConSourceHandler<RunInfo>{
   std::string m_name;
   unsigned long long m_since;
   
-  // for reading from omds 
-  
-  std::string  m_connectionString;
-  
+  // for reading from omds
+  std::string m_connectionString;
   std::string m_authpath;
-  std::string m_host;
-  std::string m_sid;
   std::string m_user;
   std::string m_pass;
-  int m_port;
 };
 
 #endif 

--- a/CondTools/RunInfo/src/RunInfoHandler.cc
+++ b/CondTools/RunInfo/src/RunInfoHandler.cc
@@ -18,44 +18,38 @@ RunInfoHandler::~RunInfoHandler() {}
 
 void RunInfoHandler::getNewObjects() {
   //check whats already inside of database
-  edm::LogInfo   ("RunInfoHandler") << "------- " << m_name 
-				    << " - > getNewObjects\n" 
-				    << "got offlineInfo " << tagInfo().name 
-				    << ", size " << tagInfo().size 
-				    << ", last object valid since " 
-				    << tagInfo().lastInterval.first 
-				    << " token " << tagInfo().lastPayloadToken 
-				    << std::endl;
-  unsigned int snc;
-  std::cerr << "Source implementation test ::getNewObjects : enter runnumber as a first since !\n";
-  std::cin >> snc;
-  std::cout <<"runnumber/first since = " << snc << std::endl;
-  RunInfo* r = new RunInfo(); 
+  edm::LogInfo( "RunInfoHandler" ) << "------- " << m_name
+                                   << " - > getNewObjects\n"
+                                   << "got offlineInfo " << tagInfo().name
+                                   << ", size " << tagInfo().size
+                                   << ", last object valid since " << tagInfo().lastInterval.first
+                                   << " token " << tagInfo().lastPayloadToken << std::endl;
+  edm::LogInfo( "RunInfoHandler" ) << "runnumber/first since = " << m_since << std::endl;
+  RunInfo* r = new RunInfo();
   
   //fill with null runinfo if empty run are found beetween the two last valid ones 
   size_t n_empty_run = 0;
-  if(tagInfo().size > 0  && (tagInfo().lastInterval.first+1) < snc) {
-    n_empty_run = snc - tagInfo().lastInterval.first - 1; 
-    edm::LogInfo   ("RunInfoHandler") << "------- " << "entering fake run from " 
-				      << tagInfo().lastInterval.first + 1 
-				      <<  "to " << snc - 1 << "- > getNewObjects" 
-				      << std::endl;
-    n_empty_run = snc - tagInfo().lastInterval.first - 1; 
+  if( tagInfo().size > 0  && (tagInfo().lastInterval.first + 1) < m_since ) {
+    n_empty_run = m_since - tagInfo().lastInterval.first - 1;
+    edm::LogInfo( "RunInfoHandler" ) << "------- " << "entering fake run from "
+                                     << tagInfo().lastInterval.first + 1
+                                     <<  "to " << m_since - 1 << "- > getNewObjects"
+                                     << std::endl;
   } 
   // transfer fake run for 1 to since for the first time
-  if (tagInfo().size == 0 && snc != 1) {
-    m_to_transfer.push_back(std::make_pair((RunInfo*) (r->Fake_RunInfo()),1));
+  if( tagInfo().size == 0 && m_since != 1 ) {
+    m_to_transfer.push_back( std::make_pair( (RunInfo*)(r->Fake_RunInfo()), 1 ) );
   }
-  if (n_empty_run != 0) {
-    m_to_transfer.push_back(std::make_pair((RunInfo*) (r->Fake_RunInfo()),tagInfo().lastInterval.first + 1));
+  if ( n_empty_run != 0 ) {
+    m_to_transfer.push_back(std::make_pair( (RunInfo*)(r->Fake_RunInfo()), tagInfo().lastInterval.first + 1 ) );
   }
   
   //reading from omds
-  RunInfoRead rn(m_connectionString, m_user, m_pass);
-  *r = rn.readData("RUNSESSION_PARAMETER", "STRING_VALUE",(int)snc);
-  m_to_transfer.push_back(std::make_pair((RunInfo*)r,snc));
+  RunInfoRead rn( m_connectionString, m_user, m_pass );
+  *r = rn.readData( "RUNSESSION_PARAMETER", "STRING_VALUE",(int)m_since );
+  m_to_transfer.push_back( std::make_pair( (RunInfo*)r, m_since) );
   std::ostringstream ss;
-  ss << "since =" << snc;
+  ss << "since =" << m_since;
   m_userTextLog = ss.str() + ";";
-  edm::LogInfo   ("RunInfoHandler") << "------- " << m_name << " - > getNewObjects" << std::endl;
+  edm::LogInfo( "RunInfoHandler" ) << "------- " << m_name << " - > getNewObjects" << std::endl;
 }

--- a/CondTools/RunInfo/src/RunInfoHandler.cc
+++ b/CondTools/RunInfo/src/RunInfoHandler.cc
@@ -6,10 +6,12 @@
 #include<vector>
 
 RunInfoHandler::RunInfoHandler(const edm::ParameterSet& pset) :
-  m_name(pset.getUntrackedParameter<std::string>("name","RunInfoHandler"))
-  ,m_user(pset.getUntrackedParameter<std::string>("OnlineDBUser","CMS_RUNINFO_R")) 
-  ,m_pass(pset.getUntrackedParameter<std::string>("OnlineDBPass","PASSWORD")) {
-  m_connectionString= "oracle://cms_omds_adg/CMS_RUNINFO";
+   m_name( pset.getUntrackedParameter<std::string>( "name", "RunInfoHandler") )
+  ,m_since( pset.getParameter<unsigned long long>( "runNumber" ) )
+  ,m_connectionString( pset.getUntrackedParameter<std::string>( "connectionString", "oracle://cms_omds_adg/CMS_RUNINFO") )
+  ,m_authpath( pset.getUntrackedParameter<std::string>( "authenticationPath", "." ) )
+  ,m_user( pset.getUntrackedParameter<std::string>( "OnlineDBUser", "CMS_RUNINFO_R" ) )
+  ,m_pass( pset.getUntrackedParameter<std::string>( "OnlineDBPass", "PASSWORD") ) {
 }
 
 RunInfoHandler::~RunInfoHandler() {}

--- a/CondTools/RunInfo/test/RunInfoPopConAnalyzer.py
+++ b/CondTools/RunInfo/test/RunInfoPopConAnalyzer.py
@@ -1,46 +1,52 @@
 import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
 
-process = cms.Process("ProcessOne")
-process.load("CondCore.DBCommon.CondDBCommon_cfi")
+options = VarParsing.VarParsing()
+options.register( 'runNumber'
+                , 1 #default value
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.int
+                , "Run number to be uploaded."
+                  )
+options.parseArguments()
+
+process = cms.Process( "RunInfoPopulator" )
+process.load( "CondCore.DBCommon.CondDBCommon_cfi" )
 process.CondDBCommon.connect = 'sqlite_file:dbox_upload.db'
 process.CondDBCommon.DBParameters.authenticationPath = '.'
-process.CondDBCommon.DBParameters.messageLevel=cms.untracked.int32(3)
+process.CondDBCommon.DBParameters.messageLevel=cms.untracked.int32( 3 )
 
-process.MessageLogger = cms.Service("MessageLogger",
-    cout = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO')
-    ),
-    destinations = cms.untracked.vstring('cout')
-)
+process.MessageLogger = cms.Service( "MessageLogger"
+                                   , cout = cms.untracked.PSet( threshold = cms.untracked.string( 'INFO' ) )
+                                   , destinations = cms.untracked.vstring( 'cout' )
+                                     )
 
-process.source = cms.Source("EmptyIOVSource",
-    lastValue = cms.uint64(1),
-    timetype = cms.string('runnumber'),
-    firstValue = cms.uint64(1),
-    interval = cms.uint64(1)
-)
+process.source = cms.Source( "EmptyIOVSource"
+                           , lastValue = cms.uint64( 1 )
+                           , timetype = cms.string( 'runnumber' )
+                           , firstValue = cms.uint64( 1 )
+                           , interval = cms.uint64( 1 )
+                             )
 
-process.PoolDBOutputService = cms.Service("PoolDBOutputService",
-    process.CondDBCommon,
-    logconnect = cms.untracked.string('sqlite_file:logruninfo_pop_test.db'),
-    timetype = cms.untracked.string('runnumber'),
-    toPut = cms.VPSet(cms.PSet(
-        record = cms.string('RunInfoRcd'),
-        tag = cms.string('runinfo_31X_hlt')
-    ))
-)
+process.PoolDBOutputService = cms.Service( "PoolDBOutputService"
+                                         , process.CondDBCommon
+                                         , logconnect = cms.untracked.string( 'sqlite_file:logruninfo_pop_test.db' )
+                                         , timetype = cms.untracked.string( 'runnumber' )
+                                         , toPut = cms.VPSet( cms.PSet( record = cms.string( 'RunInfoRcd' )
+                                                                      , tag = cms.string( 'runinfo_31X_hlt' )
+                                                                        )
+                                                              )
+                                          )
 
-process.Test1 = cms.EDAnalyzer("RunInfoPopConAnalyzer",
-    SinceAppendMode = cms.bool(True),
-    record = cms.string('RunInfoRcd'),
-    Source = cms.PSet(
-        OnlineDBPass = cms.untracked.string('MICKEY2MOUSE')),
-    loggingOn = cms.untracked.bool(True),
-    IsDestDbCheckedInQueryLog = cms.untracked.bool(False),
-    targetDBConnectionString = cms.untracked.string('sqlite_file:run_info_popcontest.db')
-)
+process.popConRunInfo = cms.EDAnalyzer( "RunInfoPopConAnalyzer"
+                                      , SinceAppendMode = cms.bool( True )
+                                      , record = cms.string( 'RunInfoRcd' )
+                                      , Source = cms.PSet( runNumber = cms.uint64( options.runNumber )
+                                                         , OnlineDBPass = cms.untracked.string( 'PASSWORD' )
+                                                           )
+                                      , loggingOn = cms.untracked.bool( True )
+                                      , IsDestDbCheckedInQueryLog = cms.untracked.bool( False )
+                                      , targetDBConnectionString = cms.untracked.string( 'sqlite_file:run_info_popcontest.db' )
+                                        )
 
-process.p = cms.Path(process.Test1)
-
-
-
+process.p = cms.Path( process.popConRunInfo )


### PR DESCRIPTION
This Pull Request contains the fixes for allowing the RunInfo PopCon jobs to use the dropbox, and not the direct access to Oracle:
- Cleanup of the source handler
- Pass the run number from configuration, not standard input
- Use two connections, both to the target DB for looking at the last IOV, and to a local file for writing the new payload.
