### PR TITLE
get njettiness to be consistent with cc implementation

### DIFF
--- a/RecoJets/JetProducers/python/nJettinessAdder_cfi.py
+++ b/RecoJets/JetProducers/python/nJettinessAdder_cfi.py
@@ -1,7 +1,15 @@
 import FWCore.ParameterSet.Config as cms
 
 Njettiness = cms.EDProducer("NjettinessAdder",
-                            src=cms.InputTag("ca8PFJetsCHS"),
-                            cone=cms.double(0.8),
-                            Njets=cms.vuint32(1,2,3)
+                            src=cms.InputTag("ak8PFJetsCHS"),
+                            Njets=cms.vuint32(1,2,3),            # compute 1-, 2-, 3- subjettiness
+                            # variables for measure definition : 
+                            measureDefinition = cms.uint32( 1 ), # default is unnormalized measure
+                            beta = cms.double(-999.0),           # not used by default
+                            R0 = cms.double( -999.0 ),           # not used by default
+                            Rcutoff = cms.double( -999.0),       # not used by default
+                            # variables for axes definition :
+                            axesDefinition = cms.uint32( 6 ),    # default is 1-pass KT axes
+                            nPass = cms.int32(-999),             # not used by default
+                            akAxesR0 = cms.double(-999.0)        # not used by default
                             )

--- a/RecoJets/JetProducers/python/nJettinessAdder_cfi.py
+++ b/RecoJets/JetProducers/python/nJettinessAdder_cfi.py
@@ -11,5 +11,5 @@ Njettiness = cms.EDProducer("NjettinessAdder",
                             # variables for axes definition :
                             axesDefinition = cms.uint32( 6 ),    # default is 1-pass KT axes
                             nPass = cms.int32(-999),             # not used by default
-                            akAxesR0 = cms.double(-999.0)        # not used by default
+                            axAxesR0 = cms.int32(-999)        # not used by default
                             )


### PR DESCRIPTION
More fixes from fastjet-contrib problems. (including a typo fix from the jet/met PR from Sal)
