### PR TITLE
Add missing std:: qualifiers

### DIFF
--- a/CondFormats/BTauObjects/interface/BTagCalibration.h
+++ b/CondFormats/BTauObjects/interface/BTagCalibration.h
@@ -37,9 +37,9 @@ public:
   void addEntry(const BTagEntry &entry);
   const std::vector<BTagEntry>& getEntries(const BTagEntry::Parameters &par) const;
 
-  void readCSV(istream &s);
+  void readCSV(std::istream &s);
   void readCSV(const std::string &s);
-  void makeCSV(ostream &s) const;
+  void makeCSV(std::ostream &s) const;
   std::string makeCSV() const;
 
 protected:

--- a/CondFormats/BTauObjects/src/BTagCalibration.cc
+++ b/CondFormats/BTauObjects/src/BTagCalibration.cc
@@ -41,7 +41,7 @@ void BTagCalibration::readCSV(const std::string &s)
   readCSV(buff);
 }
 
-void BTagCalibration::readCSV(istream &s)
+void BTagCalibration::readCSV(std::istream &s)
 {
   std::string line;
 
@@ -60,7 +60,7 @@ void BTagCalibration::readCSV(istream &s)
   }
 }
 
-void BTagCalibration::makeCSV(ostream &s) const
+void BTagCalibration::makeCSV(std::ostream &s) const
 {
   s << BTagEntry::makeCSVHeader();
   for (auto i = data_.cbegin(); i != data_.cend(); ++i) {

--- a/RecoBTag/PerformanceDB/test/BTagCalibrationStandalone.cc
+++ b/RecoBTag/PerformanceDB/test/BTagCalibrationStandalone.cc
@@ -221,7 +221,7 @@ void BTagCalibration::readCSV(const std::string &s)
   readCSV(buff);
 }
 
-void BTagCalibration::readCSV(istream &s)
+void BTagCalibration::readCSV(std::istream &s)
 {
   std::string line;
 
@@ -240,7 +240,7 @@ void BTagCalibration::readCSV(istream &s)
   }
 }
 
-void BTagCalibration::makeCSV(ostream &s) const
+void BTagCalibration::makeCSV(std::ostream &s) const
 {
   s << BTagEntry::makeCSVHeader();
   for (auto i = data_.cbegin(); i != data_.cend(); ++i) {

--- a/RecoBTag/PerformanceDB/test/BTagCalibrationStandalone.h
+++ b/RecoBTag/PerformanceDB/test/BTagCalibrationStandalone.h
@@ -118,9 +118,9 @@ public:
   void addEntry(const BTagEntry &entry);
   const std::vector<BTagEntry>& getEntries(const BTagEntry::Parameters &par) const;
 
-  void readCSV(istream &s);
+  void readCSV(std::istream &s);
   void readCSV(const std::string &s);
-  void makeCSV(ostream &s) const;
+  void makeCSV(std::ostream &s) const;
   std::string makeCSV() const;
 
 protected:


### PR DESCRIPTION
Totally trivial.
This pull request ads missing std:: qualifiers.  These missing qualifiers cause massive build errors.
Please merge in time for the next IB, if not sooner.
