### PR TITLE
Fixing electron selection pre-selection flags

### DIFF
--- a/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
@@ -1065,11 +1065,10 @@ void GsfElectronAlgo::addPflowInfo()
 
 bool GsfElectronAlgo::isPreselected( GsfElectron * ele )
  {
-	float mvaValue=generalData_->sElectronMVAEstimator->mva( *(ele),*(eventData_->event));
 	bool passCutBased=ele->passingCutBasedPreselection();
-	bool passPF=ele->passingPflowPreselection();
+	bool passPF=ele->passingPflowPreselection(); //it is worth nothing for gedGsfElectrons, this does nothing as its not set till GedGsfElectron finaliser, this is always false
 	if(generalData_->strategyCfg.gedElectronMode){
-		bool passmva=mvaValue>generalData_->strategyCfg.PreSelectMVA;
+         	bool passmva=ele->passingMvaPreselection();
 		if(!ele->ecalDrivenSeed()){
 		  if(ele->pt() > generalData_->strategyCfg.MaxElePtForOnlyMVA) 
 		    return passmva && passCutBased;
@@ -1525,7 +1524,13 @@ void GsfElectronAlgo::createElectron()
   //====================================================
 
   setCutBasedPreselectionFlag(ele,*eventData_->beamspot) ;
-  
+  //setting mva flag, currently GedGsfElectron and GsfElectron pre-selection flags have desynced
+  //this is for GedGsfElectrons, GsfElectrons (ie old pre 7X std reco) resets this later on
+  //in the function "addPfInfo"
+  //yes this is awful, we'll fix it once we work out how to...
+  float mvaValue=generalData_->sElectronMVAEstimator->mva( *(ele),*(eventData_->event));
+  ele->setPassMvaPreselection(mvaValue>generalData_->strategyCfg.PreSelectMVA);
+
   //====================================================
   // Pixel match variables
   //====================================================

--- a/RecoEgamma/EgammaElectronProducers/plugins/GEDGsfElectronFinalizer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GEDGsfElectronFinalizer.cc
@@ -96,10 +96,12 @@ void GEDGsfElectronFinalizer::produce( edm::Event & event, const edm::EventSetup
        if(itcheck!=gsfPFMap.end()) {
 	 // it means that there is a PFCandidate with the same GsfTrack
 	 myMvaOutput.status = 3; //as defined in PFCandidateEGammaExtra.h
+	 newElectron.setPassPflowPreselection(true); //this is currently fully redundant with mvaOutput.stats so candidate for removal
        }
-       else
+       else{
 	 myMvaOutput.status = 4 ; //
-       
+	 newElectron.setPassPflowPreselection(false);//this is currently fully redundant with mvaOutput.stats so candidate for removal	 
+       }
        newElectron.setMvaOutput(myMvaOutput);
      }
      outputElectrons_p->push_back(newElectron);


### PR DESCRIPTION
This is a small change which fills the electron pre-selection flags, passMvaPreslection_ and passPflowPreselection_ which were currently not being filled. 

If this is a problem for 73X, it can go for 74X, its just the flags wont be filled. The information is slightly redundant but as they are there, it is our view we might as well fill them. 

It is related to https://github.com/cms-sw/cmssw/pull/6479.  I decided not to add back in the error message is its still possible that this error condition can happen if we changed the python config and its not technically an error.
