### PR TITLE
Fix double inversion of MET covariance matrix

### DIFF
--- a/DataFormats/METReco/src/MET.cc
+++ b/DataFormats/METReco/src/MET.cc
@@ -85,7 +85,7 @@ double MET::significance() const {
   double signif = -1;
   double det=0;
   metmat.Det2(det);
-  if(std::fabs(det)>0.000001){
+  if(std::abs(det)>0.000001){
     metmat.Invert();
     signif = ROOT::Math::Dot(metvec, (metmat * metvec) );
   }

--- a/DataFormats/METReco/src/MET.cc
+++ b/DataFormats/METReco/src/MET.cc
@@ -84,7 +84,7 @@ double MET::significance() const {
   metvec(1)=this->py();
   double signif = -1;
   double det=0;
-  metmat.Det(det);
+  metmat.Det2(det);
   if(std::fabs(det)>0.000001){
     metmat.Invert();
     signif = ROOT::Math::Dot(metvec, (metmat * metvec) );


### PR DESCRIPTION
Bug was inserted during https://github.com/cms-sw/cmssw/pull/5417,

MET covariance matrix was inverted twice instead of once, now corrected. Impacts MET significance results only.
