### PR TITLE
Pass address of pointer, not value, again

### DIFF
--- a/CondCore/ORA/src/OraPtrStreamer.cc
+++ b/CondCore/ORA/src/OraPtrStreamer.cc
@@ -259,10 +259,10 @@ void ora::OraPtrUpdater::update( int oid,
   }
   edm::ObjectWithDict ptrObject( m_objectType, m_dataElement->address( data ) );
   // first load if required
-  ptrObject.typeOf().functionMemberByName("load").invoke(ptrObject,0);
-  void *ptrAddress = 0;
-  edm::ObjectWithDict ptrAddrObj = edm::ObjectWithDict( edm::TypeWithDict(typeid(void*)), ptrAddress );
-  ptrObject.typeOf().functionMemberByName("address").invoke(ptrObject, &ptrAddrObj);
+  m_objectType.functionMemberByName("load").invoke(ptrObject, nullptr);
+  void *ptrAddress = nullptr;
+  edm::ObjectWithDict ptrAddrObj = edm::ObjectWithDict( edm::TypeWithDict(typeid(void*)), &ptrAddress );
+  m_objectType.functionMemberByName("address").invoke(ptrObject, &ptrAddrObj);
   m_updater->update( oid, ptrAddress );
 }
 

--- a/CondCore/ORA/src/QueryableVectorStreamer.cc
+++ b/CondCore/ORA/src/QueryableVectorStreamer.cc
@@ -420,10 +420,10 @@ void ora::QueryableVectorUpdater::update( int oid,
   }
   void* vectorAddress = m_offset->address( data );
   edm::ObjectWithDict vectorObj( m_objectType,const_cast<void*>(vectorAddress));
-  vectorObj.typeOf().functionMemberByName("load").invoke(vectorObj, 0);
-  void* storageAddress = 0;
-  edm::ObjectWithDict storAddObj = edm::ObjectWithDict( edm::TypeWithDict(typeid(void*)), storageAddress );
-  vectorObj.typeOf().functionMemberByName("storageAddress").invoke(vectorObj, &storAddObj);
+  m_objectType.functionMemberByName("load").invoke(vectorObj, nullptr);
+  void* storageAddress = nullptr;
+  edm::ObjectWithDict storAddObj = edm::ObjectWithDict( edm::TypeWithDict(typeid(void*)), &storageAddress );
+  m_objectType.functionMemberByName("storageAddress").invoke(vectorObj, &storAddObj);
   m_updater.update( oid, storageAddress );
 }  
   


### PR DESCRIPTION
In (at least) four places in the ROOT 6 specific conditions code, the address of a pointer to an object needed to be passed to an ObjectWithDict constructor.
Unfortunately, the value of the pointer was passed instead (missing '&').
Two of these four were fixed in pull request #6521.
This pull request fixes the two cases of this that were missed in the prior pull request.
Editorial comment: I hate code that is not type safe.
This request also does some minor optimization by avoiding unnecessary ObjectWithDict::typeOf() calls, since the return value is already known.
Please merge this request as soon as convenient.
