### PR TITLE
Fix checksums for ROOT 5.32.22

### DIFF
--- a/DataFormats/BTauReco/src/classes_def.xml
+++ b/DataFormats/BTauReco/src/classes_def.xml
@@ -99,10 +99,9 @@
    <version ClassVersion="10" checksum="3825121604"/>
   </class>
 
-  <class name="reco::SoftLeptonTagInfo" ClassVersion="11">
-   <version ClassVersion="11" checksum="610843768"/>
-   <version ClassVersion="10" checksum="1042007752"/>
-  </class>
+  <class name="std::pair<edm::RefToBase<reco::Track>, reco::SoftLeptonProperties>"/>
+  <class name="reco::TemplatedSoftLeptonTagInfo<edm::RefToBase<reco::Track> >::LeptonMap"/>
+  <class name="reco::SoftLeptonTagInfo" />
   <class name="reco::SoftLeptonTagInfoCollection"/>
   <class name="reco::SoftLeptonTagInfoRef"/>
   <class name="reco::SoftLeptonTagInfoFwdRef"/>

--- a/DataFormats/EgammaCandidates/src/classes_def.xml
+++ b/DataFormats/EgammaCandidates/src/classes_def.xml
@@ -214,8 +214,9 @@
   <class name="reco::GsfElectron::PixelMatchVariables" ClassVersion="2">
     <version ClassVersion="2" checksum="3522539867"/>
   </class>
-  <class name="reco::GsfElectron" ClassVersion="16">
-   <version ClassVersion="16" checksum="933254703"/>
+  <class name="reco::GsfElectron" ClassVersion="17">
+   <version ClassVersion="17" checksum="1861965703"/>
+   <version ClassVersion="16" checksum="1022265405"/>
    <version ClassVersion="15" checksum="515498629"/>
    <version ClassVersion="14" checksum="3918953183"/>
    <version ClassVersion="13" checksum="2991498573"/>

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -18,7 +18,7 @@
   <!-- PAT Objects, and embedded data  -->
   <class name="pat::Electron"  ClassVersion="26">
    <field name="superClusterRelinked_" transient="true"/>
-   <version ClassVersion="26" checksum="3903550452"/>
+   <version ClassVersion="26" checksum="2045819644"/>
    <version ClassVersion="25" checksum="1488101799"/>
    <version ClassVersion="24" checksum="2646043873"/>
    <version ClassVersion="23" checksum="434577157"/>
@@ -113,10 +113,9 @@
     <version ClassVersion="10" checksum="1628501942" />
   </class>
   <class name="std::vector<pat::tau::TauPFEssential>" />
-  <class name="pat::Photon"  ClassVersion="17">
-   <version ClassVersion="17" checksum="344001813"/>
+  <class name="pat::Photon"  ClassVersion="16">
    <field name="superClusterRelinked_" transient="true"/>
-   <version ClassVersion="16" checksum="1272212778"/>
+   <version ClassVersion="16" checksum="344001813"/>
    <version ClassVersion="15" checksum="3096238365"/>
    <version ClassVersion="14" checksum="2817723713"/>
    <version ClassVersion="13" checksum="3948496360"/>


### PR DESCRIPTION
The change of reco::SoftLeptonTagInfo from a real class to a typedef to a template wasn't handled by the merging in the correct way. This makes the code conform to CMSSW_7_3_X.
In all cases, the class versions are always just 1 value ahead of their CMSSW_7_3_X counterparts.
