### PR TITLE
Update the default input for rho in the jet energy corrections in PAT in 5_3_X

### DIFF
--- a/PhysicsTools/PatAlgos/python/recoLayer0/jetCorrFactors_cfi.py
+++ b/PhysicsTools/PatAlgos/python/recoLayer0/jetCorrFactors_cfi.py
@@ -30,5 +30,5 @@ patJetCorrFactors = cms.EDProducer("JetCorrFactorsProducer",
     ## the corresponding jet collection (this variable is
     ## typically taken from kt6PFJets).
     useRho = cms.bool(True),
-    rho = cms.InputTag('kt6PFJets', 'rho'),
+    rho = cms.InputTag('kt6CaloJets', 'rho'),
 )

--- a/PhysicsTools/PatAlgos/python/tools/jetTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/jetTools.py
@@ -821,7 +821,7 @@ class AddJetCollection(ConfigToolBase):
                 ## create jet correctors for MET corrections
                 from JetMETCorrections.Configuration.JetCorrectionServicesAllAlgos_cff import ak5PFL1Fastjet, ak5PFL1Offset, ak5PFL2Relative, ak5PFL3Absolute, ak5PFResidual
                 setattr(process, jetCorrLabel[0]+'L1FastJet'   , ak5PFL1Fastjet.clone ( algorithm=jetCorrLabel[0]
-                                                                                      , srcRho=cms.InputTag(newLabel('kt6PFJets'),'rho') ) )
+                                                                                      , srcRho=cms.InputTag(newLabel('kt6' + jetCollType + 'Jets'),'rho') ) )
                 setattr(process, jetCorrLabel[0]+'L1Offset'    , ak5PFL1Offset.clone  ( algorithm=jetCorrLabel[0] ) )
                 setattr(process, jetCorrLabel[0]+'L2Relative'  , ak5PFL2Relative.clone( algorithm=jetCorrLabel[0] ) )
                 setattr(process, jetCorrLabel[0]+'L3Absolute'  , ak5PFL3Absolute.clone( algorithm=jetCorrLabel[0] ) )
@@ -1216,7 +1216,7 @@ class SwitchJetCollection(ConfigToolBase):
                 ## create jet correctors for MET corrections
                 from JetMETCorrections.Configuration.JetCorrectionServicesAllAlgos_cff import ak5PFL1Fastjet, ak5PFL1Offset, ak5PFL2Relative, ak5PFL3Absolute, ak5PFResidual
                 setattr(process, jetCorrLabel[0]+'L1FastJet'   , ak5PFL1Fastjet.clone ( algorithm=jetCorrLabel[0]
-                                                                                      , srcRho=cms.InputTag('kt6PFJets','rho') ) )
+                                                                                      , srcRho=cms.InputTag('kt6' + jetCollType + 'Jets','rho') ) )
                 setattr(process, jetCorrLabel[0]+'L1Offset'    , ak5PFL1Offset.clone  ( algorithm=jetCorrLabel[0] ) )
                 setattr(process, jetCorrLabel[0]+'L2Relative'  , ak5PFL2Relative.clone( algorithm=jetCorrLabel[0] ) )
                 setattr(process, jetCorrLabel[0]+'L3Absolute'  , ak5PFL3Absolute.clone( algorithm=jetCorrLabel[0] ) )
@@ -1498,7 +1498,7 @@ class SwitchJetCorrLevels(ConfigToolBase):
                             raise TypeError, "L1FastJet corrections are currently only supported for PF and Calo jets in PAT"
                         ## configure module
                         jetCorrFactorsModule.useRho = True
-                        jetCorrFactorsModule.rho = cms.InputTag('kt6PFJets', 'rho')
+                        jetCorrFactorsModule.rho = cms.InputTag('kt6' + jetType + 'Jets', 'rho')
                         ## we set this to True now as a L1 correction type should appear only once
                         ## otherwise levels is miss configured
                         error = True


### PR DESCRIPTION
This PR addresses the issue https://github.com/cms-sw/cmssw/issues/6530.
